### PR TITLE
posix: isolate non-portable pthread APIs under CONFIG_PTHREAD_NP

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -429,8 +429,10 @@ int pthread_attr_setinheritsched(pthread_attr_t *attr, int inheritsched);
 int pthread_once(pthread_once_t *once, void (*initFunc)(void));
 #endif
 FUNC_NORETURN void pthread_exit(void *retval);
+#if defined(CONFIG_PTHREAD_NP) || defined(__DOXYGEN__)
 int pthread_timedjoin_np(pthread_t thread, void **status, const struct timespec *abstime);
 int pthread_tryjoin_np(pthread_t thread, void **status);
+#endif /* CONFIG_PTHREAD_NP */
 int pthread_join(pthread_t thread, void **status);
 int pthread_cancel(pthread_t pthread);
 int pthread_detach(pthread_t thread);
@@ -477,10 +479,13 @@ void __z_pthread_cleanup_pop(int execute);
 		__z_pthread_cleanup_pop(_ex);                                                      \
 	} /* enforce '}'-like behaviour */ while (0)
 
+#if defined(CONFIG_PTHREAD_NP) || defined(__DOXYGEN__)
 /* Glibc / Oracle Extension Functions */
 
 /**
  * @brief Set name of POSIX thread.
+ *
+ * @kconfig_dep{CONFIG_PTHREAD_NP}
  *
  * Non-portable, extension function that conforms with most
  * other definitions of this function.
@@ -499,6 +504,8 @@ int pthread_setname_np(pthread_t thread, const char *name);
  * @brief Get name of POSIX thread and store in name buffer
  *  	  that is of size len.
  *
+ * @kconfig_dep{CONFIG_PTHREAD_NP}
+ *
  * Non-portable, extension function that conforms with most
  * other definitions of this function.
  *
@@ -511,6 +518,7 @@ int pthread_setname_np(pthread_t thread, const char *name);
  * @retval <0 negative value if kernel function error
  */
 int pthread_getname_np(pthread_t thread, char *name, size_t len);
+#endif /* CONFIG_PTHREAD_NP */
 
 #ifdef CONFIG_POSIX_THREADS
 

--- a/samples/subsys/portability/posix/philosophers/prj.conf
+++ b/samples/subsys/portability/posix/philosophers/prj.conf
@@ -11,3 +11,4 @@ CONFIG_MAX_PTHREAD_MUTEX_COUNT=6
 
 #Enable thread awareness for debugging tools supporting it
 CONFIG_DEBUG_THREAD_INFO=y
+CONFIG_PTHREAD_NP=y

--- a/subsys/portability/posix/options/Kconfig.pthread
+++ b/subsys/portability/posix/options/Kconfig.pthread
@@ -185,6 +185,14 @@ config POSIX_THREAD_SAFE_FUNCTIONS
 	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xsh_chap02.html#tag_22_02_09_07
 
+config PTHREAD_NP
+	bool "Non-portable POSIX threads extensions"
+	default n
+	help
+	  Select 'y' here to enable non-portable POSIX threads extensions
+	  such as pthread_setname_np(), pthread_getname_np(),
+	  pthread_timedjoin_np(), and pthread_tryjoin_np().
+
 module = PTHREAD
 module-str = POSIX thread
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -1142,8 +1142,11 @@ static int pthread_timedjoin_internal(pthread_t pthread, void **status, k_timeou
 	return 0;
 }
 
+#if defined(CONFIG_PTHREAD_NP) || defined(__DOXYGEN__)
 /**
  * @brief Await a thread termination with timeout.
+ *
+ * @kconfig_dep{CONFIG_PTHREAD_NP}
  *
  * Non-portable GNU extension of IEEE 1003.1
  */
@@ -1161,12 +1164,15 @@ int pthread_timedjoin_np(pthread_t pthread, void **status, const struct timespec
 /**
  * @brief Check a thread for termination.
  *
+ * @kconfig_dep{CONFIG_PTHREAD_NP}
+ *
  * Non-portable GNU extension of IEEE 1003.1
  */
 int pthread_tryjoin_np(pthread_t pthread, void **status)
 {
 	return pthread_timedjoin_internal(pthread, status, K_NO_WAIT);
 }
+#endif /* CONFIG_PTHREAD_NP */
 
 /**
  * @brief Await a thread termination.
@@ -1435,6 +1441,7 @@ int pthread_attr_destroy(pthread_attr_t *_attr)
 	return 0;
 }
 
+#if defined(CONFIG_PTHREAD_NP) || defined(__DOXYGEN__)
 int pthread_setname_np(pthread_t thread, const char *name)
 {
 #ifdef CONFIG_THREAD_NAME
@@ -1483,6 +1490,7 @@ int pthread_getname_np(pthread_t thread, char *name, size_t len)
 	return 0;
 #endif
 }
+#endif /* CONFIG_PTHREAD_NP */
 
 int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void))
 {

--- a/tests/posix/pthread_np/CMakeLists.txt
+++ b/tests/posix/pthread_np/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(posix_pthread_np)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/posix/pthread_np/prj.conf
+++ b/tests/posix/pthread_np/prj.conf
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+CONFIG_POSIX_API=y
+CONFIG_PTHREAD_NP=y
+CONFIG_THREAD_NAME=y

--- a/tests/posix/pthread_np/src/main.c
+++ b/tests/posix/pthread_np/src/main.c
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#define SLEEP_DURATION_MS 200
+
+static void *timedjoin_thread(void *p1)
+{
+	int sleep_duration_ms = POINTER_TO_INT(p1);
+
+	usleep(USEC_PER_MSEC * sleep_duration_ms);
+	return NULL;
+}
+
+ZTEST(pthread_np, test_pthread_tryjoin_np)
+{
+	pthread_t th = {0};
+	void *retval;
+
+	/* Creating a thread that exits after 200ms*/
+	zassert_ok(pthread_create(&th, NULL, timedjoin_thread, INT_TO_POINTER(SLEEP_DURATION_MS)));
+
+	/* Attempting to join, when thread is still running, should fail */
+	usleep(USEC_PER_MSEC * SLEEP_DURATION_MS / 2);
+	zassert_equal(pthread_tryjoin_np(th, &retval), EBUSY);
+
+	/* Sleep so thread will exit */
+	usleep(USEC_PER_MSEC * SLEEP_DURATION_MS);
+
+	/* Attempting to join without blocking should succeed now */
+	zassert_ok(pthread_tryjoin_np(th, &retval));
+}
+
+ZTEST(pthread_np, test_pthread_timedjoin_np)
+{
+	pthread_t th = {0};
+	void *ret;
+	struct timespec not_done;
+	struct timespec done;
+	struct timespec invalid[] = {
+		{.tv_nsec = -1},
+		{.tv_nsec = NSEC_PER_SEC},
+	};
+
+	/* setup timespecs when the thread is still running and when it is done */
+	clock_gettime(CLOCK_REALTIME, &not_done);
+	clock_gettime(CLOCK_REALTIME, &done);
+	not_done.tv_nsec += SLEEP_DURATION_MS / 2 * NSEC_PER_MSEC;
+	done.tv_nsec += SLEEP_DURATION_MS * 1.5 * NSEC_PER_MSEC;
+	while (not_done.tv_nsec >= NSEC_PER_SEC) {
+		not_done.tv_sec++;
+		not_done.tv_nsec -= NSEC_PER_SEC;
+	}
+	while (done.tv_nsec >= NSEC_PER_SEC) {
+		done.tv_sec++;
+		done.tv_nsec -= NSEC_PER_SEC;
+	}
+
+	/* Creating a thread that exits after 200ms*/
+	zassert_ok(pthread_create(&th, NULL, timedjoin_thread, INT_TO_POINTER(SLEEP_DURATION_MS)));
+
+	/* pthread_timedjoin-np must return EINVAL for invalid struct timespecs */
+	zassert_equal(pthread_timedjoin_np(th, &ret, NULL), EINVAL);
+	for (size_t i = 0; i < ARRAY_SIZE(invalid); ++i) {
+		zassert_equal(pthread_timedjoin_np(th, &ret, &invalid[i]), EINVAL);
+	}
+
+	/* Attempting to join with a timeout, when the thread is still running should fail */
+	zassert_equal(pthread_timedjoin_np(th, &ret, &not_done), ETIMEDOUT);
+
+	/* Attempting to join with a timeout, when the thread is done, should succeed */
+	zassert_ok(pthread_timedjoin_np(th, &ret, &done));
+}
+
+ZTEST(pthread_np, test_pthread_get_set_name_np)
+{
+	pthread_t th = {0};
+	char thr_name_buf[CONFIG_THREAD_MAX_NAME_LEN];
+	const char *thr_name = "test_thread";
+	int ret;
+
+	/* TESTPOINT: Try getting name of NULL thread (aka uninitialized
+	 * thread var).
+	 */
+	ret = pthread_getname_np(PTHREAD_INVALID, thr_name_buf, sizeof(thr_name_buf));
+	zassert_equal(ret, ESRCH, "uninitialized getname!");
+
+	/* TESTPOINT: Try setting name of NULL thread (aka uninitialized
+	 * thread var).
+	 */
+	ret = pthread_setname_np(PTHREAD_INVALID, thr_name);
+	zassert_equal(ret, ESRCH, "uninitialized setname!");
+
+	zassert_ok(pthread_create(&th, NULL, timedjoin_thread, INT_TO_POINTER(SLEEP_DURATION_MS)));
+
+	/* TESTPOINT: Try getting thread name with no buffer */
+	ret = pthread_getname_np(th, NULL, sizeof(thr_name_buf));
+	zassert_equal(ret, EINVAL, "uninitialized getname!");
+
+	/* TESTPOINT: Try setting thread name with no buffer */
+	ret = pthread_setname_np(th, NULL);
+	zassert_equal(ret, EINVAL, "uninitialized setname!");
+
+	/* TESTPOINT: Try setting thread name */
+	ret = pthread_setname_np(th, thr_name);
+	zassert_false(ret, "Set thread name failed!");
+
+	/* TESTPOINT: Try getting thread name */
+	ret = pthread_getname_np(th, thr_name_buf, sizeof(thr_name_buf));
+	zassert_false(ret, "Get thread name failed!");
+
+	/* TESTPOINT: Thread names match */
+	ret = strncmp(thr_name, thr_name_buf, MIN(strlen(thr_name), strlen(thr_name_buf)));
+	zassert_false(ret, "Thread names don't match!");
+
+	/* Join to clean up */
+	zassert_ok(pthread_join(th, NULL));
+}
+
+ZTEST_SUITE(pthread_np, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/pthread_np/testcase.yaml
+++ b/tests/posix/pthread_np/testcase.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  portability.posix.pthread_np:
+    tags: posix
+    depends_on: posix

--- a/tests/subsys/portability/posix/threads_base/src/pthread.c
+++ b/tests/subsys/portability/posix/threads_base/src/pthread.c
@@ -144,13 +144,6 @@ static void *thread_top_exec(void *p1)
 	return NULL;
 }
 
-static void *timedjoin_thread(void *p1)
-{
-	int sleep_duration_ms = POINTER_TO_INT(p1);
-
-	usleep(USEC_PER_MSEC * sleep_duration_ms);
-	return NULL;
-}
 
 static int bounce_test_done(void)
 {
@@ -274,41 +267,9 @@ ZTEST(pthread, test_pthread_execution)
 
 	sem_init(&main_sem, 0, 1);
 
-	/* TESTPOINT: Try getting name of NULL thread (aka uninitialized
-	 * thread var).
-	 */
-	ret = pthread_getname_np(PTHREAD_INVALID, thr_name_buf, sizeof(thr_name_buf));
-	zassert_equal(ret, ESRCH, "uninitialized getname!");
-
 	for (i = 0; i < N_THR_E; i++) {
 		ret = pthread_create(&newthread[i], NULL, thread_top_exec, INT_TO_POINTER(i));
 	}
-
-	/* TESTPOINT: Try setting name of NULL thread (aka uninitialized
-	 * thread var).
-	 */
-	ret = pthread_setname_np(PTHREAD_INVALID, thr_name);
-	zassert_equal(ret, ESRCH, "uninitialized setname!");
-
-	/* TESTPOINT: Try getting thread name with no buffer */
-	ret = pthread_getname_np(newthread[0], NULL, sizeof(thr_name_buf));
-	zassert_equal(ret, EINVAL, "uninitialized getname!");
-
-	/* TESTPOINT: Try setting thread name with no buffer */
-	ret = pthread_setname_np(newthread[0], NULL);
-	zassert_equal(ret, EINVAL, "uninitialized setname!");
-
-	/* TESTPOINT: Try setting thread name */
-	ret = pthread_setname_np(newthread[0], thr_name);
-	zassert_false(ret, "Set thread name failed!");
-
-	/* TESTPOINT: Try getting thread name */
-	ret = pthread_getname_np(newthread[0], thr_name_buf, sizeof(thr_name_buf));
-	zassert_false(ret, "Get thread name failed!");
-
-	/* TESTPOINT: Thread names match */
-	ret = strncmp(thr_name, thr_name_buf, MIN(strlen(thr_name), strlen(thr_name_buf)));
-	zassert_false(ret, "Thread names don't match!");
 
 	while (!bounce_test_done()) {
 		sem_wait(&main_sem);
@@ -375,68 +336,6 @@ ZTEST(pthread, test_pthread_termination)
 	/* TESTPOINT: Try canceling a terminated thread */
 	ret = pthread_cancel(newthread[0]);
 	zassert_equal(ret, ESRCH, "cancelled a terminated thread!");
-}
-
-ZTEST(pthread, test_pthread_tryjoin)
-{
-	pthread_t th = {0};
-	int sleep_duration_ms = 200;
-	void *retval;
-
-	/* Creating a thread that exits after 200ms*/
-	zassert_ok(pthread_create(&th, NULL, timedjoin_thread, INT_TO_POINTER(sleep_duration_ms)));
-
-	/* Attempting to join, when thread is still running, should fail */
-	usleep(USEC_PER_MSEC * sleep_duration_ms / 2);
-	zassert_equal(pthread_tryjoin_np(th, &retval), EBUSY);
-
-	/* Sleep so thread will exit */
-	usleep(USEC_PER_MSEC * sleep_duration_ms);
-
-	/* Attempting to join without blocking should succeed now */
-	zassert_ok(pthread_tryjoin_np(th, &retval));
-}
-
-ZTEST(pthread, test_pthread_timedjoin)
-{
-	pthread_t th = {0};
-	int sleep_duration_ms = 200;
-	void *ret;
-	struct timespec not_done;
-	struct timespec done;
-	struct timespec invalid[] = {
-		{.tv_nsec = -1},
-		{.tv_nsec = NSEC_PER_SEC},
-	};
-
-	/* setup timespecs when the thread is still running and when it is done */
-	clock_gettime(CLOCK_REALTIME, &not_done);
-	clock_gettime(CLOCK_REALTIME, &done);
-	not_done.tv_nsec += sleep_duration_ms / 2 * NSEC_PER_MSEC;
-	done.tv_nsec += sleep_duration_ms * 1.5 * NSEC_PER_MSEC;
-	while (not_done.tv_nsec >= NSEC_PER_SEC) {
-		not_done.tv_sec++;
-		not_done.tv_nsec -= NSEC_PER_SEC;
-	}
-	while (done.tv_nsec >= NSEC_PER_SEC) {
-		done.tv_sec++;
-		done.tv_nsec -= NSEC_PER_SEC;
-	}
-
-	/* Creating a thread that exits after 200ms*/
-	zassert_ok(pthread_create(&th, NULL, timedjoin_thread, INT_TO_POINTER(sleep_duration_ms)));
-
-	/* pthread_timedjoin-np must return EINVAL for invalid struct timespecs */
-	zassert_equal(pthread_timedjoin_np(th, &ret, NULL), EINVAL);
-	for (size_t i = 0; i < ARRAY_SIZE(invalid); ++i) {
-		zassert_equal(pthread_timedjoin_np(th, &ret, &invalid[i]), EINVAL);
-	}
-
-	/* Attempting to join with a timeout, when the thread is still running should fail */
-	zassert_equal(pthread_timedjoin_np(th, &ret, &not_done), ETIMEDOUT);
-
-	/* Attempting to join with a timeout, when the thread is done, should succeed */
-	zassert_ok(pthread_timedjoin_np(th, &ret, &done));
 }
 
 static void *create_thread1(void *p1)


### PR DESCRIPTION
Fixes #98536.

**Description**
This PR isolates Zephyr's non-portable pthread extensions (e.g., `pthread_setname_np`, `pthread_getname_np`) behind a new Kconfig option, `CONFIG_PTHREAD_NP`. This aligns with the Zephyr project goal of improving strict POSIX compliance by ensuring that non-portable functions are not exposed when standard POSIX APIs are requested.

**Changes:**
1. Introduced `CONFIG_PTHREAD_NP` in `subsys/portability/posix/options/Kconfig.pthread`.
2. Wrapped non-portable APIs in `include/zephyr/posix/pthread.h` and `subsys/portability/posix/options/pthread.c` with `#ifdef CONFIG_PTHREAD_NP`.
3. Created a new dedicated test suite `tests/posix/pthread_np` to independently verify the functionality of the isolated APIs.

Verified locally using twister against the new test suite.
