### PR TITLE
drivers: rtc: ds3231: make isw-gpios optional

### DIFF
--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -22,6 +22,17 @@ LOG_MODULE_REGISTER(RTC_DS3231, CONFIG_RTC_LOG_LEVEL);
 
 #define DT_DRV_COMPAT maxim_ds3231_rtc
 
+/* Evaluates to 1 if any maxim,ds3231-rtc node wires up isw-gpios. Used below
+ * to let the ISW interrupt handling, and the alarm/update callback
+ * registration built on top of it, be optimized out entirely when no
+ * instance can ever use them.
+ */
+#define DS3231_ALARM_CB_REQUIRED \
+	(IS_ENABLED(CONFIG_RTC_ALARM) && DT_ANY_INST_HAS_PROP_STATUS_OKAY(isw_gpios))
+#define DS3231_UPDATE_CB_REQUIRED \
+	(IS_ENABLED(CONFIG_RTC_UPDATE) && DT_ANY_INST_HAS_PROP_STATUS_OKAY(isw_gpios))
+#define DS3231_ISW_ISR_REQUIRED (DS3231_ALARM_CB_REQUIRED || DS3231_UPDATE_CB_REQUIRED)
+
 #ifdef CONFIG_RTC_ALARM
 #define ALARM_COUNT 2
 struct rtc_ds3231_alarm {
@@ -38,16 +49,18 @@ struct rtc_ds3231_update {
 #endif
 
 struct rtc_ds3231_data {
-#ifdef CONFIG_RTC_ALARM
+#if DS3231_ALARM_CB_REQUIRED
 	struct rtc_ds3231_alarm alarms[ALARM_COUNT];
 #endif
-#ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	struct rtc_ds3231_update update;
 #endif
 	struct k_sem lock;
+#if DS3231_ISW_ISR_REQUIRED
 	struct gpio_callback isw_cb_data;
 	struct k_work work;
 	const struct device *dev;
+#endif
 };
 
 struct rtc_ds3231_conf {
@@ -591,6 +604,7 @@ static int rtc_ds3231_alarm_is_pending(const struct device *dev, uint16_t id)
 	return state;
 }
 
+#if DS3231_ALARM_CB_REQUIRED
 static int rtc_ds3231_get_alarm_states(const struct device *dev, bool *states)
 {
 	int err = 0;
@@ -608,6 +622,13 @@ static int rtc_ds3231_get_alarm_states(const struct device *dev, bool *states)
 static int rtc_ds3231_alarm_set_callback(const struct device *dev, uint16_t id,
 					 rtc_alarm_callback cb, void *user_data)
 {
+	const struct rtc_ds3231_conf *config = dev->config;
+
+	if (config->isw_gpios.port == NULL) {
+		LOG_ERR("isw-gpios not configured, alarm callbacks are not supported.");
+		return -ENOTSUP;
+	}
+
 	if (id >= ALARM_COUNT) {
 		return -EINVAL;
 	}
@@ -641,9 +662,11 @@ static int rtc_ds3231_init_alarms(struct rtc_ds3231_data *data)
 	data->alarms[1] = (struct rtc_ds3231_alarm){NULL, NULL};
 	return 0;
 }
+#endif /* DS3231_ALARM_CB_REQUIRED */
 #endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 static int rtc_ds3231_init_update(struct rtc_ds3231_data *data)
 {
 	data->update = (struct rtc_ds3231_update){NULL, NULL};
@@ -652,6 +675,13 @@ static int rtc_ds3231_init_update(struct rtc_ds3231_data *data)
 static int rtc_ds3231_update_set_callback(const struct device *dev, rtc_update_callback cb,
 					  void *user_data)
 {
+	const struct rtc_ds3231_conf *config = dev->config;
+
+	if (config->isw_gpios.port == NULL) {
+		LOG_ERR("isw-gpios not configured, update callbacks are not supported.");
+		return -ENOTSUP;
+	}
+
 	struct rtc_ds3231_data *data = dev->data;
 
 	data->update = (struct rtc_ds3231_update){cb, user_data};
@@ -665,21 +695,22 @@ static void rtc_ds3231_update_callback(const struct device *dev)
 		data->update.cb(dev, data->update.user_data);
 	}
 }
+#endif /* DS3231_UPDATE_CB_REQUIRED */
 #endif /* CONFIG_RTC_UPDATE */
 
-#if defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM)
+#if DS3231_ISW_ISR_REQUIRED
 static void rtc_ds3231_isw_h(struct k_work *work)
 {
 	struct rtc_ds3231_data *data = CONTAINER_OF(work, struct rtc_ds3231_data, work);
 	const struct device *dev = data->dev;
 
-#ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	rtc_ds3231_update_callback(dev);
-#endif /* CONFIG_RTC_UPDATE */
+#endif /* DS3231_UPDATE_CB_REQUIRED */
 
-#ifdef CONFIG_RTC_ALARM
+#if DS3231_ALARM_CB_REQUIRED
 	rtc_ds3231_check_alarms(dev);
-#endif /* CONFIG_RTC_ALARM */
+#endif /* DS3231_ALARM_CB_REQUIRED */
 }
 static void rtc_ds3231_isw_isr(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
@@ -689,6 +720,11 @@ static void rtc_ds3231_isw_isr(const struct device *port, struct gpio_callback *
 }
 static int rtc_ds3231_init_isw(const struct rtc_ds3231_conf *config, struct rtc_ds3231_data *data)
 {
+	if (config->isw_gpios.port == NULL) {
+		LOG_WRN("isw-gpios not configured, alarm/update callbacks will not fire.");
+		return 0;
+	}
+
 	if (!gpio_is_ready_dt(&config->isw_gpios)) {
 		LOG_ERR("ISW GPIO pin is not ready.");
 		return -ENODEV;
@@ -717,7 +753,7 @@ static int rtc_ds3231_init_isw(const struct rtc_ds3231_conf *config, struct rtc_
 
 	return 0;
 }
-#endif /* defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM) */
+#endif /* DS3231_ISW_ISR_REQUIRED */
 
 static DEVICE_API(rtc, driver_api) = {
 	.set_time = rtc_ds3231_set_time,
@@ -728,11 +764,15 @@ static DEVICE_API(rtc, driver_api) = {
 	.alarm_set_time = rtc_ds3231_alarm_set_time,
 	.alarm_get_time = rtc_ds3231_alarm_get_time,
 	.alarm_is_pending = rtc_ds3231_alarm_is_pending,
+#if DS3231_ALARM_CB_REQUIRED
 	.alarm_set_callback = rtc_ds3231_alarm_set_callback,
+#endif /* DS3231_ALARM_CB_REQUIRED */
 #endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	.update_set_callback = rtc_ds3231_update_set_callback,
+#endif /* DS3231_UPDATE_CB_REQUIRED */
 #endif /* CONFIG_RTC_UPDATE */
 
 #ifdef CONFIG_RTC_CALIBRATION
@@ -811,7 +851,7 @@ static int rtc_ds3231_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-#ifdef CONFIG_RTC_ALARM
+#if DS3231_ALARM_CB_REQUIRED
 	err = rtc_ds3231_init_alarms(data);
 	if (err != 0) {
 		LOG_ERR("Failed to init alarms.");
@@ -819,7 +859,7 @@ static int rtc_ds3231_init(const struct device *dev)
 	}
 #endif
 
-#ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	err = rtc_ds3231_init_update(data);
 	if (err != 0) {
 		LOG_ERR("Failed to init update callback.");
@@ -833,14 +873,14 @@ static int rtc_ds3231_init(const struct device *dev)
 		return err;
 	}
 
-#if defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM)
+#if DS3231_ISW_ISR_REQUIRED
 	data->dev = dev;
 	err = rtc_ds3231_init_isw(config, data);
 	if (err != 0) {
 		LOG_ERR("Initing ISW interrupt failed!");
 		return err;
 	}
-#endif /* defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM) */
+#endif /* DS3231_ISW_ISR_REQUIRED */
 
 	return 0;
 }
@@ -849,7 +889,7 @@ static int rtc_ds3231_init(const struct device *dev)
 	static struct rtc_ds3231_data rtc_ds3231_data_##inst;                                      \
 	static const struct rtc_ds3231_conf rtc_ds3231_conf_##inst = {                             \
 		.mfd = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                        \
-		.isw_gpios = GPIO_DT_SPEC_INST_GET(inst, isw_gpios),                               \
+		.isw_gpios = GPIO_DT_SPEC_INST_GET_OR(inst, isw_gpios, {NULL}),                    \
 		.freq_32k_gpios = GPIO_DT_SPEC_INST_GET_OR(inst, freq_32khz_gpios, {NULL})};       \
 	PM_DEVICE_DT_INST_DEFINE(inst, rtc_ds3231_pm_action);                                      \
 	DEVICE_DT_INST_DEFINE(inst, &rtc_ds3231_init, PM_DEVICE_DT_INST_GET(inst),                 \

--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -22,32 +22,52 @@ LOG_MODULE_REGISTER(RTC_DS3231, CONFIG_RTC_LOG_LEVEL);
 
 #define DT_DRV_COMPAT maxim_ds3231_rtc
 
+/* Expands to 1 if the node wires up the `isw-gpios` property */
+#define DS3231_ISW_GPIOS_PRESENT(n) DT_INST_NODE_HAS_PROP(n, isw_gpios) |
+
+/* Evaluates to 1 if any maxim,ds3231-rtc node wires up isw-gpios. Used below
+ * to let the ISW interrupt handling, and the alarm/update callback
+ * registration built on top of it, be optimized out entirely when no
+ * instance can ever use them.
+ */
+#define DS3231_ISW_GPIOS_REQUIRED (DT_INST_FOREACH_STATUS_OKAY(DS3231_ISW_GPIOS_PRESENT) 0)
+
+#define DS3231_ALARM_CB_REQUIRED (IS_ENABLED(CONFIG_RTC_ALARM) && DS3231_ISW_GPIOS_REQUIRED)
+#define DS3231_UPDATE_CB_REQUIRED (IS_ENABLED(CONFIG_RTC_UPDATE) && DS3231_ISW_GPIOS_REQUIRED)
+#define DS3231_ISW_REQUIRED (DS3231_ALARM_CB_REQUIRED || DS3231_UPDATE_CB_REQUIRED)
+
 #ifdef CONFIG_RTC_ALARM
 #define ALARM_COUNT 2
+#if DS3231_ALARM_CB_REQUIRED
 struct rtc_ds3231_alarm {
 	rtc_alarm_callback cb;
 	void *user_data;
 };
+#endif /* DS3231_ALARM_CB_REQUIRED */
 #endif
 
 #ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 struct rtc_ds3231_update {
 	rtc_update_callback cb;
 	void *user_data;
 };
+#endif /* DS3231_UPDATE_CB_REQUIRED */
 #endif
 
 struct rtc_ds3231_data {
-#ifdef CONFIG_RTC_ALARM
+#if DS3231_ALARM_CB_REQUIRED
 	struct rtc_ds3231_alarm alarms[ALARM_COUNT];
 #endif
-#ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	struct rtc_ds3231_update update;
 #endif
 	struct k_sem lock;
+#if DS3231_ISW_REQUIRED
 	struct gpio_callback isw_cb_data;
 	struct k_work work;
 	const struct device *dev;
+#endif
 };
 
 struct rtc_ds3231_conf {
@@ -591,6 +611,7 @@ static int rtc_ds3231_alarm_is_pending(const struct device *dev, uint16_t id)
 	return state;
 }
 
+#if DS3231_ALARM_CB_REQUIRED
 static int rtc_ds3231_get_alarm_states(const struct device *dev, bool *states)
 {
 	int err = 0;
@@ -648,9 +669,11 @@ static int rtc_ds3231_init_alarms(struct rtc_ds3231_data *data)
 	data->alarms[1] = (struct rtc_ds3231_alarm){NULL, NULL};
 	return 0;
 }
+#endif /* DS3231_ALARM_CB_REQUIRED */
 #endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 static int rtc_ds3231_init_update(struct rtc_ds3231_data *data)
 {
 	data->update = (struct rtc_ds3231_update){NULL, NULL};
@@ -679,21 +702,22 @@ static void rtc_ds3231_update_callback(const struct device *dev)
 		data->update.cb(dev, data->update.user_data);
 	}
 }
+#endif /* DS3231_UPDATE_CB_REQUIRED */
 #endif /* CONFIG_RTC_UPDATE */
 
-#if defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM)
+#if DS3231_ISW_REQUIRED
 static void rtc_ds3231_isw_h(struct k_work *work)
 {
 	struct rtc_ds3231_data *data = CONTAINER_OF(work, struct rtc_ds3231_data, work);
 	const struct device *dev = data->dev;
 
-#ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	rtc_ds3231_update_callback(dev);
-#endif /* CONFIG_RTC_UPDATE */
+#endif /* DS3231_UPDATE_CB_REQUIRED */
 
-#ifdef CONFIG_RTC_ALARM
+#if DS3231_ALARM_CB_REQUIRED
 	rtc_ds3231_check_alarms(dev);
-#endif /* CONFIG_RTC_ALARM */
+#endif /* DS3231_ALARM_CB_REQUIRED */
 }
 static void rtc_ds3231_isw_isr(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
@@ -736,7 +760,7 @@ static int rtc_ds3231_init_isw(const struct rtc_ds3231_conf *config, struct rtc_
 
 	return 0;
 }
-#endif /* defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM) */
+#endif /* DS3231_ISW_REQUIRED */
 
 static DEVICE_API(rtc, driver_api) = {
 	.set_time = rtc_ds3231_set_time,
@@ -747,11 +771,15 @@ static DEVICE_API(rtc, driver_api) = {
 	.alarm_set_time = rtc_ds3231_alarm_set_time,
 	.alarm_get_time = rtc_ds3231_alarm_get_time,
 	.alarm_is_pending = rtc_ds3231_alarm_is_pending,
+#if DS3231_ALARM_CB_REQUIRED
 	.alarm_set_callback = rtc_ds3231_alarm_set_callback,
+#endif /* DS3231_ALARM_CB_REQUIRED */
 #endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	.update_set_callback = rtc_ds3231_update_set_callback,
+#endif /* DS3231_UPDATE_CB_REQUIRED */
 #endif /* CONFIG_RTC_UPDATE */
 
 #ifdef CONFIG_RTC_CALIBRATION
@@ -830,7 +858,7 @@ static int rtc_ds3231_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-#ifdef CONFIG_RTC_ALARM
+#if DS3231_ALARM_CB_REQUIRED
 	err = rtc_ds3231_init_alarms(data);
 	if (err != 0) {
 		LOG_ERR("Failed to init alarms.");
@@ -838,7 +866,7 @@ static int rtc_ds3231_init(const struct device *dev)
 	}
 #endif
 
-#ifdef CONFIG_RTC_UPDATE
+#if DS3231_UPDATE_CB_REQUIRED
 	err = rtc_ds3231_init_update(data);
 	if (err != 0) {
 		LOG_ERR("Failed to init update callback.");
@@ -852,14 +880,14 @@ static int rtc_ds3231_init(const struct device *dev)
 		return err;
 	}
 
-#if defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM)
+#if DS3231_ISW_REQUIRED
 	data->dev = dev;
 	err = rtc_ds3231_init_isw(config, data);
 	if (err != 0) {
 		LOG_ERR("Initing ISW interrupt failed!");
 		return err;
 	}
-#endif /* defined(CONFIG_RTC_UPDATE) || defined(CONFIG_RTC_ALARM) */
+#endif /* DS3231_ISW_REQUIRED */
 
 	return 0;
 }

--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -608,6 +608,13 @@ static int rtc_ds3231_get_alarm_states(const struct device *dev, bool *states)
 static int rtc_ds3231_alarm_set_callback(const struct device *dev, uint16_t id,
 					 rtc_alarm_callback cb, void *user_data)
 {
+	const struct rtc_ds3231_conf *config = dev->config;
+
+	if (config->isw_gpios.port == NULL) {
+		LOG_ERR("isw-gpios not configured, alarm callbacks are not supported.");
+		return -ENOTSUP;
+	}
+
 	if (id >= ALARM_COUNT) {
 		return -EINVAL;
 	}
@@ -652,6 +659,13 @@ static int rtc_ds3231_init_update(struct rtc_ds3231_data *data)
 static int rtc_ds3231_update_set_callback(const struct device *dev, rtc_update_callback cb,
 					  void *user_data)
 {
+	const struct rtc_ds3231_conf *config = dev->config;
+
+	if (config->isw_gpios.port == NULL) {
+		LOG_ERR("isw-gpios not configured, update callbacks are not supported.");
+		return -ENOTSUP;
+	}
+
 	struct rtc_ds3231_data *data = dev->data;
 
 	data->update = (struct rtc_ds3231_update){cb, user_data};
@@ -689,6 +703,11 @@ static void rtc_ds3231_isw_isr(const struct device *port, struct gpio_callback *
 }
 static int rtc_ds3231_init_isw(const struct rtc_ds3231_conf *config, struct rtc_ds3231_data *data)
 {
+	if (config->isw_gpios.port == NULL) {
+		LOG_WRN("isw-gpios not configured, alarm/update callbacks will not fire.");
+		return 0;
+	}
+
 	if (!gpio_is_ready_dt(&config->isw_gpios)) {
 		LOG_ERR("ISW GPIO pin is not ready.");
 		return -ENODEV;
@@ -849,7 +868,7 @@ static int rtc_ds3231_init(const struct device *dev)
 	static struct rtc_ds3231_data rtc_ds3231_data_##inst;                                      \
 	static const struct rtc_ds3231_conf rtc_ds3231_conf_##inst = {                             \
 		.mfd = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                        \
-		.isw_gpios = GPIO_DT_SPEC_INST_GET(inst, isw_gpios),                               \
+		.isw_gpios = GPIO_DT_SPEC_INST_GET_OR(inst, isw_gpios, {NULL}),                    \
 		.freq_32k_gpios = GPIO_DT_SPEC_INST_GET_OR(inst, freq_32khz_gpios, {NULL})};       \
 	PM_DEVICE_DT_INST_DEFINE(inst, rtc_ds3231_pm_action);                                      \
 	DEVICE_DT_INST_DEFINE(inst, &rtc_ds3231_init, PM_DEVICE_DT_INST_GET(inst),                 \

--- a/dts/bindings/rtc/maxim,ds3231-rtc.yaml
+++ b/dts/bindings/rtc/maxim,ds3231-rtc.yaml
@@ -31,5 +31,7 @@ properties:
       and also to produce a square wave aligned to the countdown chain.
       Both capabilities are used within the driver.
 
-      This signal must be present to support time set
-      and read operations that preserve sub-second accuracy.
+      This signal is optional. It is only required to use the alarm and
+      update callback APIs. Basic time get/set operations do not require
+      this signal, and the driver will still build and operate without
+      it, e.g. when the INT/SQW pin is left unconnected on the board.

--- a/dts/bindings/rtc/maxim,ds3231-rtc.yaml
+++ b/dts/bindings/rtc/maxim,ds3231-rtc.yaml
@@ -31,8 +31,7 @@ properties:
       and also to produce a square wave aligned to the countdown chain.
       Both capabilities are used within the driver.
 
-      This signal is optional. It is only required to use the alarm
-      (CONFIG_RTC_ALARM) and update (CONFIG_RTC_UPDATE) callback APIs.
-      Basic time get/set operations do not require this signal, and the
-      driver will still build and operate without it, e.g. when the
-      INT/SQW pin is left unconnected on the board.
+      This signal is optional. It is only required to use the alarm and
+      update callback APIs. Basic time get/set operations do not require
+      this signal, and the driver will still build and operate without
+      it, e.g. when the INT/SQW pin is left unconnected on the board.

--- a/dts/bindings/rtc/maxim,ds3231-rtc.yaml
+++ b/dts/bindings/rtc/maxim,ds3231-rtc.yaml
@@ -31,5 +31,8 @@ properties:
       and also to produce a square wave aligned to the countdown chain.
       Both capabilities are used within the driver.
 
-      This signal must be present to support time set
-      and read operations that preserve sub-second accuracy.
+      This signal is optional. It is only required to use the alarm
+      (CONFIG_RTC_ALARM) and update (CONFIG_RTC_UPDATE) callback APIs.
+      Basic time get/set operations do not require this signal, and the
+      driver will still build and operate without it, e.g. when the
+      INT/SQW pin is left unconnected on the board.

--- a/tests/drivers/build_all/rtc/ds3231_no_isw.overlay
+++ b/tests/drivers/build_all/rtc/ds3231_no_isw.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Sachin Pathave
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Regression test for the DS3231 driver building without isw-gpios,
+ * e.g. when the INT/SQW pin is intentionally left unconnected on the
+ * board and only basic time get/set is needed.
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_i2c_no_isw: i2c@22221111 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,i2c";
+			reg = <0x22221111 0x1000>;
+			clock-frequency = <100000>;
+
+			test_ds3231_no_isw: ds3231@a {
+				compatible = "maxim,ds3231-mfd";
+				reg = <0xa>;
+
+				test_ds3231_rtc_no_isw: ds3231_rtc {
+					compatible = "maxim,ds3231-rtc";
+				};
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/rtc/ds3231_no_isw.overlay
+++ b/tests/drivers/build_all/rtc/ds3231_no_isw.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Sachin Pathave
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Regression test for the DS3231 driver building without isw-gpios,
+ * e.g. when the INT/SQW pin is intentionally left unconnected on the
+ * board and only basic time get/set is needed.
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio_no_isw: gpio@beefdead {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xbeefdead 0x1000>;
+			#gpio-cells = <0x2>;
+		};
+
+		test_i2c_no_isw: i2c@22221111 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,i2c";
+			reg = <0x22221111 0x1000>;
+			clock-frequency = <100000>;
+
+			test_ds3231_no_isw: ds3231@a {
+				compatible = "maxim,ds3231-mfd";
+				reg = <0xa>;
+
+				test_ds3231_rtc_no_isw: ds3231_rtc {
+					compatible = "maxim,ds3231-rtc";
+				};
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/rtc/ds3231_no_isw.overlay
+++ b/tests/drivers/build_all/rtc/ds3231_no_isw.overlay
@@ -14,13 +14,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		test_gpio_no_isw: gpio@beefdead {
-			compatible = "vnd,gpio";
-			gpio-controller;
-			reg = <0xbeefdead 0x1000>;
-			#gpio-cells = <0x2>;
-		};
-
 		test_i2c_no_isw: i2c@22221111 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/tests/drivers/build_all/rtc/tests.yaml
+++ b/tests/drivers/build_all/rtc/tests.yaml
@@ -21,3 +21,10 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+  drivers.rtc.build.ds3231_no_isw:
+    extra_args: DTC_OVERLAY_FILE="ds3231_no_isw.overlay"
+    extra_configs:
+      - CONFIG_I2C=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
## Summary
  
   - Make `isw-gpios` truly optional in the DS3231 RTC driver, matching what the devicetree binding already documents. `GPIO_DT_SPEC_INST_GET()` is replaced with `GPIO_DT_SPEC_INST_GET_OR(inst, isw_gpios, {NULL})`, so boards that leave
   the INT/SQW pin unconnected can still build and use basic time get/set.
   - `rtc_ds3231_init_isw()` skips GPIO/interrupt setup (with a `LOG_WRN`) when the pin isn't present, instead of failing at build time.
   - `alarm_set_callback()` / `update_set_callback()` return `-ENOTSUP` when `isw-gpios` isn't configured, since those callbacks would otherwise silently never fire.
   - Updated the `isw-gpios` binding description to reflect that it's optional and only required for alarm/update callback support.
   - Added `tests/drivers/build_all/rtc/ds3231_no_isw.overlay` + a `native_sim` test case that builds a DS3231 node with no `isw-gpios`, to cover this regression going forward.

   Fixes #114886