### PR TITLE
drivers: hwinfo: add a WCH ESIG hardware ID driver

### DIFF
--- a/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.dts
+++ b/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.dts
@@ -81,3 +81,7 @@
 	pinctrl-0 = <&usart3_default>;
 	pinctrl-names = "default";
 };
+
+&esig {
+	status = "okay";
+};

--- a/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.yaml
+++ b/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.yaml
@@ -9,6 +9,8 @@ ram: 20
 flash: 224
 supported:
   - gpio
+  - hwinfo
   - i2c
   - pwm
   - uart
+vendor: weact

--- a/boards/weact/ch32v00x_core/ch32v00x_core.dts
+++ b/boards/weact/ch32v00x_core/ch32v00x_core.dts
@@ -100,3 +100,7 @@
 &tim1 {
 	status = "okay";
 };
+
+&esig {
+	status = "okay";
+};

--- a/boards/weact/ch32v00x_core/ch32v00x_core.yaml
+++ b/boards/weact/ch32v00x_core/ch32v00x_core.yaml
@@ -11,6 +11,7 @@ supported:
   - button
   - dma
   - gpio
+  - hwinfo
   - pwm
   - uart
   - watchdog

--- a/drivers/clock_control/clock_control_wch_rcc.c
+++ b/drivers/clock_control/clock_control_wch_rcc.c
@@ -13,6 +13,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/sys/util_macro.h>
 
 #include <hal_ch32fun.h>
@@ -327,6 +328,58 @@ static int clock_control_wch_rcc_init(const struct device *dev)
 
 	return 0;
 }
+
+#if defined(CONFIG_HWINFO)
+
+int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
+{
+	uint32_t status = RCC->RSTSCKR;
+
+	*cause = 0;
+	if ((status & (RCC_IWDGRSTF | RCC_WWDGRSTF)) != 0) {
+		*cause |= RESET_WATCHDOG;
+	}
+
+	if ((status & RCC_PINRSTF) != 0) {
+		*cause |= RESET_PIN;
+	}
+
+	if ((status & RCC_PORRSTF) != 0) {
+		*cause |= RESET_POR;
+	}
+
+	if ((status & RCC_SFTRSTF) != 0) {
+		*cause |= RESET_SOFTWARE;
+	}
+
+#if defined(RCC_LPWRRSTF)
+	if ((status & RCC_LPWRRSTF) != 0) {
+		*cause |= RESET_BROWNOUT;
+	}
+#endif
+
+	return 0;
+}
+
+int z_impl_hwinfo_clear_reset_cause(void)
+{
+	RCC->RSTSCKR |= RCC_RMVF;
+
+	return 0;
+}
+
+int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
+{
+	*supported = RESET_WATCHDOG | RESET_PIN | RESET_POR | RESET_SOFTWARE
+#if defined(RCC_LPWRRSTF)
+		     | RESET_BROWNOUT
+#endif
+		;
+
+	return 0;
+}
+
+#endif
 
 #define CLOCK_CONTROL_WCH_RCC_INIT(idx)                                                            \
 	static const struct clock_control_wch_rcc_config clock_control_wch_rcc_##idx##_config = {  \

--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -57,4 +57,5 @@ zephyr_library_sources_ifdef(CONFIG_HWINFO_SAM_RSTC hwinfo_sam_rstc.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SILABS_S2 hwinfo_silabs_series2.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SMARTBOND hwinfo_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_STM32 hwinfo_stm32.c)
+zephyr_library_sources_ifdef(CONFIG_HWINFO_WCH hwinfo_wch.c)
 # zephyr-keep-sorted-stop

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -54,6 +54,7 @@ rsource "Kconfig.sam_rstc"
 rsource "Kconfig.silabs_series2"
 rsource "Kconfig.smartbond"
 rsource "Kconfig.stm32"
+rsource "Kconfig.wch"
 # zephyr-keep-sorted-stop
 
 endif

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -65,6 +65,7 @@ rsource "Kconfig.sam_rstc"
 rsource "Kconfig.silabs_series2"
 rsource "Kconfig.smartbond"
 rsource "Kconfig.stm32"
+rsource "Kconfig.wch"
 # zephyr-keep-sorted-stop
 
 endif

--- a/drivers/hwinfo/Kconfig.wch
+++ b/drivers/hwinfo/Kconfig.wch
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright Michael Hope <michaelh@juju.nz>
+# SPDX-License-Identifier: Apache-2.0
+
+config HWINFO_WCH
+	bool "WCH CH32V Electronic Signature (ESIG)"
+	default y
+	depends on DT_HAS_WCH_ESIG_ENABLED
+	select HWINFO_HAS_DRIVER
+	help
+	  Enable the WCH CH32V series Electronic Signature (ESIG) driver.

--- a/drivers/hwinfo/hwinfo_wch.c
+++ b/drivers/hwinfo/hwinfo_wch.c
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Michael Hope <michaelh@juju.nz>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/hwinfo.h>
+#include <string.h>
+
+#include <hal_ch32fun.h>
+
+#define DT_DRV_COMPAT wch_esig
+
+/* Define locally as ch32fun uses different names for ESIG and the ESIG registers on each variant */
+#define HWINFO_WCH_UID_OFFSET 0x08
+#define HWINFO_WCH_UID_SIZE   12
+
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	const uint8_t *uid = (const uint8_t *)DT_INST_REG_ADDR(0) + HWINFO_WCH_UID_OFFSET;
+
+	length = MIN(length, HWINFO_WCH_UID_SIZE);
+	memcpy(buffer, uid, length);
+
+	return length;
+}
+
+int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
+{
+	RCC_TypeDef *regs = (RCC_TypeDef *)DT_REG_ADDR(DT_INST(0, wch_rcc));
+	uint32_t status = regs->RSTSCKR;
+
+	*cause = 0;
+	if ((status & (RCC_IWDGRSTF | RCC_WWDGRSTF)) != 0) {
+		*cause |= RESET_WATCHDOG;
+	}
+
+	if ((status & RCC_PINRSTF) != 0) {
+		*cause |= RESET_PIN;
+	}
+
+	if ((status & RCC_PORRSTF) != 0) {
+		*cause |= RESET_POR;
+	}
+
+	if ((status & RCC_SFTRSTF) != 0) {
+		*cause |= RESET_SOFTWARE;
+	}
+
+#if defined(RCC_LPWRRSTF)
+	if ((status & RCC_LPWRRSTF) != 0) {
+		*cause |= RESET_BROWNOUT;
+	}
+#endif
+
+	return 0;
+}
+
+int z_impl_hwinfo_clear_reset_cause(void)
+{
+	RCC_TypeDef *regs = (RCC_TypeDef *)DT_REG_ADDR(DT_INST(0, wch_rcc));
+
+	regs->RSTSCKR |= RCC_RMVF;
+
+	return 0;
+}
+
+int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
+{
+	*supported = RESET_WATCHDOG | RESET_PIN | RESET_POR | RESET_SOFTWARE
+#if defined(RCC_LPWRRSTF)
+		     | RESET_BROWNOUT
+#endif
+		;
+
+	return 0;
+}

--- a/drivers/hwinfo/hwinfo_wch.c
+++ b/drivers/hwinfo/hwinfo_wch.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Michael Hope <michaelh@juju.nz>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/hwinfo.h>
+#include <string.h>
+
+#include <hal_ch32fun.h>
+
+#define DT_DRV_COMPAT wch_esig
+
+/*
+ * ch32fun uses different names for the typedefs and UID registers across variants.
+ */
+#define HWINFO_WCH_UID_OFFSET 0x08
+
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	const uint8_t *uid = (const uint8_t *)DT_INST_REG_ADDR(0) + HWINFO_WCH_UID_OFFSET;
+
+	length = MIN(length, 12);
+	memcpy(buffer, uid, length);
+
+	return length;
+}

--- a/dts/bindings/hwinfo/wch,esig.yaml
+++ b/dts/bindings/hwinfo/wch,esig.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright Michael Hope <michaelh@juju.nz>
+# SPDX-License-Identifier: Apache-2.0
+
+description: WCH CH32V Electronic Signature (ESIG)
+
+compatible: "wch,esig"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -216,6 +216,11 @@
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};
+
+		esig: esig@1ffff7e0 {
+			compatible = "wch,esig";
+			reg = <0x1ffff7e0 0x20>;
+		};
 	};
 };
 

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -216,6 +216,12 @@
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};
+
+		esig: esig@1ffff7e0 {
+			compatible = "wch,esig";
+			reg = <0x1ffff7e0 0x20>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -224,6 +224,11 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
+
+		esig: esig@1ffff7e0 {
+			compatible = "wch,esig";
+			reg = <0x1ffff7e0 0x20>;
+		};
 	};
 };
 

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -224,6 +224,12 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
+
+		esig: esig@1ffff7e0 {
+			compatible = "wch,esig";
+			reg = <0x1ffff7e0 0x20>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
+++ b/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
@@ -279,5 +279,11 @@
 				status = "disabled";
 			};
 		};
+
+		esig: esig@1ffff7e0 {
+			compatible = "wch,esig";
+			reg = <0x1ffff7e0 0x20>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
+++ b/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
@@ -279,5 +279,10 @@
 				status = "disabled";
 			};
 		};
+
+		esig: esig@1ffff7e0 {
+			compatible = "wch,esig";
+			reg = <0x1ffff7e0 0x20>;
+		};
 	};
 };


### PR DESCRIPTION
The WCH ESIG unit holds a 96 bit unique ID. Expose via the hwinfo driver.

The WCH RCC unit accumulates the recent reset causes. Expose via the hwinfo APIs.

Tested on the `bluepillplus_ch32v203` by running
`tests/drivers/hwinfo/api` and verifying the ID matches minichlink, and that pressing the reset button makes the cause change.