### PR TITLE
kernel: avoid 64 bit division in k_sleep() and k_usleep()

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -60,6 +60,25 @@ Kernel
   keeping ``SCHED_SIMPLE`` for affinity purposes can now use their preferred
   backend directly.
 
+* :c:func:`k_sleep` and :c:func:`k_usleep` are no longer system calls of their
+  own.  They are now inline wrappers around the new :c:func:`k_sleep_ticks`
+  system call, so that the compiler can fold or discard their unit conversions.
+  Their prototypes, semantics and return values are unchanged, and they have
+  moved from :file:`include/zephyr/kernel.h` to a new
+  :file:`include/zephyr/sleep.h` which :file:`kernel.h` includes.  Code calling
+  them needs no change.  Out of tree code taking their address, or relying on
+  ``K_SYSCALL_K_SLEEP`` or ``K_SYSCALL_K_USLEEP``, must be updated to use
+  :c:func:`k_sleep_ticks` instead.  Note that it reports an early wakeup from
+  ``K_FOREVER`` as ``K_TICKS_FOREVER``, where :c:func:`k_sleep` returns ``-1``.
+
+* Because the sleep tracing hooks now sit in the single out of line
+  implementation rather than in each flavour, ``sys_port_trace_k_thread_sleep_exit()``
+  reports the time left to sleep in ticks instead of milliseconds, and
+  ``sys_port_trace_k_thread_usleep_enter()`` and
+  ``sys_port_trace_k_thread_usleep_exit()`` are no longer emitted.  Tracing
+  backends that presented the sleep remainder as milliseconds should convert
+  from ticks, for instance with :c:func:`k_ticks_to_ms_ceil64`.
+
 Boards
 ******
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -50,6 +50,24 @@ Kernel
   keeping ``SCHED_SIMPLE`` for affinity purposes can now use their preferred
   backend directly.
 
+* :c:func:`k_sleep` and :c:func:`k_usleep` are no longer system calls of their
+  own.  They are now inline wrappers around the new :c:func:`k_sleep_ticks`
+  system call, so that the compiler can fold or discard their unit conversions.
+  Their prototypes, semantics and return values are unchanged, and they have
+  moved from :file:`include/zephyr/kernel.h` to a new
+  :file:`include/zephyr/sleep.h` which :file:`kernel.h` includes.  Code calling
+  them needs no change.  Out of tree code taking their address, or relying on
+  ``K_SYSCALL_K_SLEEP`` or ``K_SYSCALL_K_USLEEP``, must be updated to use
+  :c:func:`k_sleep_ticks` instead.
+
+* Because the sleep tracing hooks now sit in the single out of line
+  implementation rather than in each flavour, ``sys_port_trace_k_thread_sleep_exit()``
+  reports the time left to sleep in ticks instead of milliseconds, and
+  ``sys_port_trace_k_thread_usleep_enter()`` and
+  ``sys_port_trace_k_thread_usleep_exit()`` are no longer emitted.  Tracing
+  backends that presented the sleep remainder as milliseconds should convert
+  from ticks, for instance with :c:func:`k_ticks_to_ms_ceil64`.
+
 Boards
 ******
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -264,6 +264,7 @@ New APIs and options
   * :c:macro:`K_MSGQ_DEFINE_STATIC`
   * :c:macro:`K_MSGQ_DEFINE_TYPE`
   * :c:macro:`K_MSGQ_DEFINE_STATIC_TYPE`
+  * :c:func:`k_sleep_ticks`
 
 * LoRa
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -249,6 +249,7 @@ New APIs and options
 
   * :c:func:`k_thread_runtime_stats_is_enabled`
   * :c:func:`atomic_test_and_set_bit_to`
+  * :c:func:`k_sleep_ticks`
 
 * LoRa
 

--- a/drivers/wifi/nxp/CMakeLists.txt
+++ b/drivers/wifi/nxp/CMakeLists.txt
@@ -316,7 +316,7 @@ zephyr_code_relocate(FILES ${ZEPHYR_BASE}/kernel/thread.c
                      LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
 
 zephyr_code_relocate(FILES ${ZEPHYR_BASE}/kernel/sleep.c
-                     FILTER ".*\\.z_impl_k_sleep|.*\\.z_tick_sleep"
+                     FILTER ".*\\.z_impl_k_sleep_ticks"
                      LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
 
 string(JOIN "" NXP_CONDVAR_FILTER

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/tracing/tracing_macros.h>
+#include <zephyr/sleep.h>
 #include <zephyr/sys/mem_stats.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/ring_buffer.h>
@@ -743,57 +744,6 @@ void k_thread_system_pool_assign(struct k_thread *thread);
  *                  is the caller
  */
 __syscall int k_thread_join(struct k_thread *thread, k_timeout_t timeout);
-
-/**
- * @brief Put the current thread to sleep.
- *
- * This routine puts the current thread to sleep for @a duration,
- * specified as a k_timeout_t object.
- *
- * @param timeout Desired duration of sleep.
- *
- * @return Zero if the requested time has elapsed or the time left to
- * sleep rounded up to the nearest millisecond (e.g. if the thread was
- * awoken by the \ref k_wakeup call).  Will be clamped to INT_MAX in
- * the case where the remaining time is unrepresentable in an int32_t.
- * If @a timeout is K_FOREVER and the thread is woken early via
- * k_wakeup(), -1 is returned.
- */
-__syscall int32_t k_sleep(k_timeout_t timeout);
-
-/**
- * @brief Put the current thread to sleep.
- *
- * This routine puts the current thread to sleep for @a duration milliseconds.
- *
- * @param ms Number of milliseconds to sleep.
- *
- * @return Zero if the requested time has elapsed or if the thread was woken up
- * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
- * millisecond.
- */
-static inline int32_t k_msleep(int32_t ms)
-{
-	return k_sleep(Z_TIMEOUT_MS(ms));
-}
-
-/**
- * @brief Put the current thread to sleep with microsecond resolution.
- *
- * This function is unlikely to work as expected without kernel tuning.
- * In particular, because the lower bound on the duration of a sleep is
- * the duration of a tick, @kconfig{CONFIG_SYS_CLOCK_TICKS_PER_SEC} must be
- * adjusted to achieve the resolution desired. The implications of doing
- * this must be understood before attempting to use k_usleep(). Use with
- * caution.
- *
- * @param us Number of microseconds to sleep.
- *
- * @return Zero if the requested time has elapsed or if the thread was woken up
- * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
- * microsecond.
- */
-__syscall int32_t k_usleep(int32_t us);
 
 /**
  * @brief Cause the current thread to busy wait.

--- a/include/zephyr/sleep.h
+++ b/include/zephyr/sleep.h
@@ -29,6 +29,33 @@ extern "C" {
  */
 
 /**
+ * @brief Put the current thread to sleep, with tick resolution.
+ *
+ * This routine puts the current thread to sleep for @a duration,
+ * specified as a k_timeout_t object.
+ *
+ * This is the primitive that k_sleep(), k_msleep() and k_usleep() are built
+ * upon.  It reports the time left to sleep in ticks, the unit the kernel
+ * works in, so it needs no unit conversion and is the cheapest of the four.
+ *
+ * @param timeout Desired duration of sleep.
+ *
+ * @return Zero if the requested time has elapsed, or the time left to sleep
+ * in ticks (e.g. if the thread was awoken by the \ref k_wakeup call).  If
+ * @a timeout is K_FOREVER and the thread is woken early via k_wakeup(),
+ * K_TICKS_FOREVER is returned.
+ */
+__syscall k_ticks_t k_sleep_ticks(k_timeout_t timeout);
+
+/*
+ * k_sleep() and k_usleep() below are inlined on top of k_sleep_ticks()
+ * rather than being separate out of line entry points.  That way the compiler
+ * sees both whether the requested duration is constant and whether the caller
+ * actually cares about the returned value, and it can fold or discard the
+ * unit conversions accordingly.
+ */
+
+/**
  * @brief Put the current thread to sleep.
  *
  * This routine puts the current thread to sleep for @a duration,
@@ -43,7 +70,17 @@ extern "C" {
  * If @a timeout is K_FOREVER and the thread is woken early via
  * k_wakeup(), -1 is returned.
  */
-__syscall int32_t k_sleep(k_timeout_t timeout);
+static inline int32_t k_sleep(k_timeout_t timeout)
+{
+	k_ticks_t ticks = k_sleep_ticks(timeout);
+
+	/* k_sleep() still returns 32 bit milliseconds for compatibility */
+	if (K_TIMEOUT_EQ(timeout, Z_FOREVER)) {
+		return (int32_t)K_TICKS_FOREVER;
+	}
+
+	return (int32_t)MIN(k_ticks_to_ms_ceil64(ticks), (uint64_t)INT32_MAX);
+}
 
 /**
  * @brief Put the current thread to sleep.
@@ -77,7 +114,12 @@ static inline int32_t k_msleep(int32_t ms)
  * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
  * microsecond.
  */
-__syscall int32_t k_usleep(int32_t us);
+static inline int32_t k_usleep(int32_t us)
+{
+	k_ticks_t ticks = k_sleep_ticks(Z_TIMEOUT_TICKS(k_us_to_ticks_ceil64(MAX(us, 0))));
+
+	return (int32_t)MIN(k_ticks_to_us_ceil64(ticks), (uint64_t)INT32_MAX);
+}
 
 /** @} */
 

--- a/include/zephyr/sleep.h
+++ b/include/zephyr/sleep.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SLEEP_H_
+#define ZEPHYR_INCLUDE_SLEEP_H_
+
+/**
+ * @file
+ * @brief Thread sleep APIs
+ */
+
+#include <stdint.h>
+
+#include <zephyr/sys/clock.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup thread_apis
+ * @{
+ */
+
+/**
+ * @brief Put the current thread to sleep.
+ *
+ * This routine puts the current thread to sleep for @a duration,
+ * specified as a k_timeout_t object.
+ *
+ * @param timeout Desired duration of sleep.
+ *
+ * @return Zero if the requested time has elapsed or the time left to
+ * sleep rounded up to the nearest millisecond (e.g. if the thread was
+ * awoken by the \ref k_wakeup call).  Will be clamped to INT_MAX in
+ * the case where the remaining time is unrepresentable in an int32_t.
+ * If @a timeout is K_FOREVER and the thread is woken early via
+ * k_wakeup(), -1 is returned.
+ */
+__syscall int32_t k_sleep(k_timeout_t timeout);
+
+/**
+ * @brief Put the current thread to sleep.
+ *
+ * This routine puts the current thread to sleep for @a duration milliseconds.
+ *
+ * @param ms Number of milliseconds to sleep.
+ *
+ * @return Zero if the requested time has elapsed or if the thread was woken up
+ * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
+ * millisecond.
+ */
+static inline int32_t k_msleep(int32_t ms)
+{
+	return k_sleep(Z_TIMEOUT_MS(ms));
+}
+
+/**
+ * @brief Put the current thread to sleep with microsecond resolution.
+ *
+ * This function is unlikely to work as expected without kernel tuning.
+ * In particular, because the lower bound on the duration of a sleep is
+ * the duration of a tick, @kconfig{CONFIG_SYS_CLOCK_TICKS_PER_SEC} must be
+ * adjusted to achieve the resolution desired. The implications of doing
+ * this must be understood before attempting to use k_usleep(). Use with
+ * caution.
+ *
+ * @param us Number of microseconds to sleep.
+ *
+ * @return Zero if the requested time has elapsed or if the thread was woken up
+ * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
+ * microsecond.
+ */
+__syscall int32_t k_usleep(int32_t us);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <zephyr/syscalls/sleep.h>
+
+#endif /* ZEPHYR_INCLUDE_SLEEP_H_ */

--- a/include/zephyr/sleep.h
+++ b/include/zephyr/sleep.h
@@ -47,13 +47,144 @@ extern "C" {
  */
 __syscall k_ticks_t k_sleep_ticks(k_timeout_t timeout);
 
+/** @cond INTERNAL_HIDDEN */
+
 /*
  * k_sleep() and k_usleep() below are inlined on top of k_sleep_ticks()
  * rather than being separate out of line entry points.  That way the compiler
  * sees both whether the requested duration is constant and whether the caller
  * actually cares about the returned value, and it can fold or discard the
- * unit conversions accordingly.
+ * unit conversions accordingly.  Those conversions are the sole reason many
+ * small builds pull in the 64 bit division helper.
+ *
+ * For the callers that do use the returned value, the two converters below
+ * keep the arithmetic 32 bit wide.  They first clamp in the tick domain,
+ * against a bound computed at compile time, which is what makes the narrower
+ * arithmetic safe.  It pays off because a compiler strength reduces a 32 bit
+ * division by a constant into a multiply, yet calls the 64 bit division
+ * helper for that same constant divisor in 64 bit.
+ *
+ * Where the tick rate makes the conversion a single division or a single
+ * multiplication, that holds on any target.  The split forms are different:
+ * they trade one division for two or three, which only wins where the one
+ * they replace would have been a call to a helper.  A 64 bit target divides
+ * in hardware, so it keeps the plain converter for those.
+ *
+ * The tick count handed to these converters always lies in the
+ * [0, INT32_MAX] range, since k_sleep_ticks() derives it from a 32 bit
+ * subtraction, so narrowing k_ticks_t to a uint32_t loses nothing.
  */
+
+#define Z_SLEEP_TICK_HZ ((uint32_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
+/* True when the conversion reduces to a single division or multiplication,
+ * needing none of the splits.
+ */
+#define Z_SLEEP_IS_SIMPLE(to_hz) \
+	(Z_SLEEP_TICK_HZ % (to_hz) == 0 || (to_hz) % Z_SLEEP_TICK_HZ == 0)
+
+/* Largest tick count whose value in to_hz units still fits in an int32_t. */
+#define Z_SLEEP_MAX_TICKS(to_hz) ((uint64_t)INT32_MAX * Z_SLEEP_TICK_HZ / (to_hz))
+
+/* True when (rem * to_hz + Z_SLEEP_TICK_HZ - 1) cannot overflow 32 bits,
+ * knowing that rem is a remainder modulo Z_SLEEP_TICK_HZ.
+ */
+#define Z_SLEEP_NO_OVERFLOW(to_hz) \
+	((uint64_t)Z_SLEEP_TICK_HZ * ((to_hz) + 1U) <= UINT32_MAX)
+
+/* Past the clamp, ceil(t * to_hz / hz) without exceeding 32 bits: split the
+ * division so the whole seconds are scaled separately from the remainder.
+ */
+#define Z_SLEEP_SPLIT(t, to_hz)                                             \
+	(((t) / Z_SLEEP_TICK_HZ) * (to_hz) +                                \
+	 DIV_ROUND_UP(((t) % Z_SLEEP_TICK_HZ) * (to_hz), Z_SLEEP_TICK_HZ))
+
+static inline int32_t z_sleep_ticks_to_int32_ms(k_ticks_t ticks)
+{
+	uint32_t t = (uint32_t)ticks;
+
+	/* a split is not worth narrowing for where 64 bit division is cheap */
+	if (IS_ENABLED(CONFIG_64BIT) && !Z_SLEEP_IS_SIMPLE(MSEC_PER_SEC)) {
+		return (int32_t)MIN(k_ticks_to_ms_ceil64(t), (uint64_t)INT32_MAX);
+	}
+
+	if (Z_SLEEP_MAX_TICKS(MSEC_PER_SEC) < (uint64_t)INT32_MAX &&
+	    t > (uint32_t)Z_SLEEP_MAX_TICKS(MSEC_PER_SEC)) {
+		return INT32_MAX;
+	}
+
+	/* a whole number of ticks per millisecond, 1:1 included */
+	if (Z_SLEEP_TICK_HZ % MSEC_PER_SEC == 0) {
+		return (int32_t)DIV_ROUND_UP(t, z_tmcvt_divisor(Z_SLEEP_TICK_HZ, MSEC_PER_SEC));
+	}
+
+	/* a whole number of milliseconds per tick */
+	if (MSEC_PER_SEC % Z_SLEEP_TICK_HZ == 0) {
+		return (int32_t)(t * z_tmcvt_divisor(MSEC_PER_SEC, Z_SLEEP_TICK_HZ));
+	}
+
+	if (Z_SLEEP_NO_OVERFLOW(MSEC_PER_SEC)) {
+		return (int32_t)Z_SLEEP_SPLIT(t, MSEC_PER_SEC);
+	}
+
+	/* tick rate too high to be scaled in 32 bits at all */
+	return (int32_t)MIN(k_ticks_to_ms_ceil64(t), (uint64_t)INT32_MAX);
+}
+
+/* Microseconds need one step more than milliseconds: a remainder times
+ * USEC_PER_SEC overflows 32 bits for any tick rate above 4294 Hz, so scale
+ * the remainder by USEC_PER_MSEC twice, carrying the first quotient over.
+ * With A = rem * 1000 = q * hz + r, ceil(A * 1000 / hz) is exactly
+ * q * 1000 + ceil(r * 1000 / hz), and r < hz keeps the second step in range.
+ */
+static inline int32_t z_sleep_ticks_to_int32_us_split(uint32_t t)
+{
+	uint32_t sec = t / Z_SLEEP_TICK_HZ;
+	uint32_t rem = (t % Z_SLEEP_TICK_HZ) * USEC_PER_MSEC;
+	uint32_t q = rem / Z_SLEEP_TICK_HZ;
+	uint32_t r = rem % Z_SLEEP_TICK_HZ;
+
+	return (int32_t)(sec * USEC_PER_SEC + q * USEC_PER_MSEC +
+			 DIV_ROUND_UP(r * USEC_PER_MSEC, Z_SLEEP_TICK_HZ));
+}
+
+static inline int32_t z_sleep_ticks_to_int32_us(k_ticks_t ticks)
+{
+	uint32_t t = (uint32_t)ticks;
+
+	/* a split is not worth narrowing for where 64 bit division is cheap */
+	if (IS_ENABLED(CONFIG_64BIT) && !Z_SLEEP_IS_SIMPLE(USEC_PER_SEC)) {
+		return (int32_t)MIN(k_ticks_to_us_ceil64(t), (uint64_t)INT32_MAX);
+	}
+
+	if (Z_SLEEP_MAX_TICKS(USEC_PER_SEC) < (uint64_t)INT32_MAX &&
+	    t > (uint32_t)Z_SLEEP_MAX_TICKS(USEC_PER_SEC)) {
+		return INT32_MAX;
+	}
+
+	/* a whole number of ticks per microsecond, 1:1 included */
+	if (Z_SLEEP_TICK_HZ % USEC_PER_SEC == 0) {
+		return (int32_t)DIV_ROUND_UP(t, z_tmcvt_divisor(Z_SLEEP_TICK_HZ, USEC_PER_SEC));
+	}
+
+	/* a whole number of microseconds per tick */
+	if (USEC_PER_SEC % Z_SLEEP_TICK_HZ == 0) {
+		return (int32_t)(t * z_tmcvt_divisor(USEC_PER_SEC, Z_SLEEP_TICK_HZ));
+	}
+
+	if (Z_SLEEP_NO_OVERFLOW(USEC_PER_SEC)) {
+		return (int32_t)Z_SLEEP_SPLIT(t, USEC_PER_SEC);
+	}
+
+	if (Z_SLEEP_NO_OVERFLOW(USEC_PER_MSEC)) {
+		return z_sleep_ticks_to_int32_us_split(t);
+	}
+
+	/* tick rate too high to be scaled in 32 bits at all */
+	return (int32_t)MIN(k_ticks_to_us_ceil64(t), (uint64_t)INT32_MAX);
+}
+
+/** @endcond */
 
 /**
  * @brief Put the current thread to sleep.
@@ -79,7 +210,7 @@ static inline int32_t k_sleep(k_timeout_t timeout)
 		return (int32_t)K_TICKS_FOREVER;
 	}
 
-	return (int32_t)MIN(k_ticks_to_ms_ceil64(ticks), (uint64_t)INT32_MAX);
+	return z_sleep_ticks_to_int32_ms(ticks);
 }
 
 /**
@@ -118,7 +249,7 @@ static inline int32_t k_usleep(int32_t us)
 {
 	k_ticks_t ticks = k_sleep_ticks(Z_TIMEOUT_TICKS(k_us_to_ticks_ceil64(MAX(us, 0))));
 
-	return (int32_t)MIN(k_ticks_to_us_ceil64(ticks), (uint64_t)INT32_MAX);
+	return z_sleep_ticks_to_int32_us(ticks);
 }
 
 /** @} */

--- a/include/zephyr/sleep.h
+++ b/include/zephyr/sleep.h
@@ -47,13 +47,144 @@ extern "C" {
  */
 __syscall k_ticks_t k_sleep_ticks(k_timeout_t timeout);
 
+/** @cond INTERNAL_HIDDEN */
+
 /*
  * k_sleep() and k_usleep() below are inlined on top of k_sleep_ticks()
  * rather than being separate out of line entry points.  That way the compiler
  * sees both whether the requested duration is constant and whether the caller
  * actually cares about the returned value, and it can fold or discard the
- * unit conversions accordingly.
+ * unit conversions accordingly.  Those conversions are the sole reason many
+ * small builds pull in the 64 bit division helper.
+ *
+ * For the callers that do use the returned value, the two converters below
+ * keep the arithmetic 32 bit wide.  They first clamp in the tick domain,
+ * against a bound computed at compile time, which is what makes the narrower
+ * arithmetic safe.  It pays off because a compiler strength reduces a 32 bit
+ * division by a constant into a multiply, yet calls the 64 bit division
+ * helper for that same constant divisor in 64 bit.
+ *
+ * Where the tick rate makes the conversion a single division or a single
+ * multiplication, that holds on any target.  The split forms are different:
+ * they trade one division for two or three, which only wins where the one
+ * they replace would have been a call to a helper.  A 64 bit target divides
+ * in hardware, so it keeps the plain converter for those.
+ *
+ * The tick count handed to these converters always lies in the
+ * [0, INT32_MAX] range, since k_sleep_ticks() derives it from a 32 bit
+ * subtraction, so narrowing k_ticks_t to a uint32_t loses nothing.
  */
+
+#define Z_SLEEP_TICK_HZ ((uint32_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
+/* True when the conversion reduces to a single division or multiplication,
+ * needing none of the splits.
+ */
+#define Z_SLEEP_IS_SIMPLE(to_hz) \
+	(Z_SLEEP_TICK_HZ % (to_hz) == 0 || (to_hz) % Z_SLEEP_TICK_HZ == 0)
+
+/* Largest tick count whose value in to_hz units still fits in an int32_t. */
+#define Z_SLEEP_MAX_TICKS(to_hz) ((uint64_t)INT32_MAX * Z_SLEEP_TICK_HZ / (to_hz))
+
+/* True when (rem * to_hz + Z_SLEEP_TICK_HZ - 1) cannot overflow 32 bits,
+ * knowing that rem is a remainder modulo Z_SLEEP_TICK_HZ.
+ */
+#define Z_SLEEP_NO_OVERFLOW(to_hz) \
+	((uint64_t)Z_SLEEP_TICK_HZ * ((to_hz) + 1U) <= UINT32_MAX)
+
+/* Past the clamp, ceil(t * to_hz / hz) without exceeding 32 bits: split the
+ * division so the whole seconds are scaled separately from the remainder.
+ */
+#define Z_SLEEP_SPLIT(t, to_hz)                                             \
+	(((t) / Z_SLEEP_TICK_HZ) * (to_hz) +                                \
+	 DIV_ROUND_UP(((t) % Z_SLEEP_TICK_HZ) * (to_hz), Z_SLEEP_TICK_HZ))
+
+static inline int32_t z_sleep_ticks_to_int32_ms(k_ticks_t ticks)
+{
+	uint32_t t = (uint32_t)ticks;
+
+	/* a split is not worth narrowing for where 64 bit division is cheap */
+	if (IS_ENABLED(CONFIG_64BIT) && !Z_SLEEP_IS_SIMPLE(MSEC_PER_SEC)) {
+		return (int32_t)MIN(k_ticks_to_ms_ceil64(t), (uint64_t)INT32_MAX);
+	}
+
+	if (Z_SLEEP_MAX_TICKS(MSEC_PER_SEC) < (uint64_t)INT32_MAX &&
+	    t > (uint32_t)Z_SLEEP_MAX_TICKS(MSEC_PER_SEC)) {
+		return INT32_MAX;
+	}
+
+	/* a whole number of ticks per millisecond, 1:1 included */
+	if (Z_SLEEP_TICK_HZ % MSEC_PER_SEC == 0) {
+		return (int32_t)DIV_ROUND_UP(t, z_tmcvt_divisor(Z_SLEEP_TICK_HZ, MSEC_PER_SEC));
+	}
+
+	/* a whole number of milliseconds per tick */
+	if (MSEC_PER_SEC % Z_SLEEP_TICK_HZ == 0) {
+		return (int32_t)(t * z_tmcvt_divisor(MSEC_PER_SEC, Z_SLEEP_TICK_HZ));
+	}
+
+	if (Z_SLEEP_NO_OVERFLOW(MSEC_PER_SEC)) {
+		return (int32_t)Z_SLEEP_SPLIT(t, MSEC_PER_SEC);
+	}
+
+	/* tick rate too high to be scaled in 32 bits at all */
+	return (int32_t)MIN(k_ticks_to_ms_ceil64(t), (uint64_t)INT32_MAX);
+}
+
+/* Microseconds need one step more than milliseconds: a remainder times
+ * USEC_PER_SEC overflows 32 bits for any tick rate above 4294 Hz, so scale
+ * the remainder by USEC_PER_MSEC twice, carrying the first quotient over.
+ * With A = rem * 1000 = q * hz + r, ceil(A * 1000 / hz) is exactly
+ * q * 1000 + ceil(r * 1000 / hz), and r < hz keeps the second step in range.
+ */
+static inline int32_t z_sleep_ticks_to_int32_us_split(uint32_t t)
+{
+	uint32_t sec = t / Z_SLEEP_TICK_HZ;
+	uint32_t rem = (t % Z_SLEEP_TICK_HZ) * USEC_PER_MSEC;
+	uint32_t q = rem / Z_SLEEP_TICK_HZ;
+	uint32_t r = rem % Z_SLEEP_TICK_HZ;
+
+	return (int32_t)(sec * USEC_PER_SEC + q * USEC_PER_MSEC +
+			 DIV_ROUND_UP(r * USEC_PER_MSEC, Z_SLEEP_TICK_HZ));
+}
+
+static inline int32_t z_sleep_ticks_to_int32_us(k_ticks_t ticks)
+{
+	uint32_t t = (uint32_t)ticks;
+
+	/* a split is not worth narrowing for where 64 bit division is cheap */
+	if (IS_ENABLED(CONFIG_64BIT) && !Z_SLEEP_IS_SIMPLE(USEC_PER_SEC)) {
+		return (int32_t)MIN(k_ticks_to_us_ceil64(t), (uint64_t)INT32_MAX);
+	}
+
+	if (Z_SLEEP_MAX_TICKS(USEC_PER_SEC) < (uint64_t)INT32_MAX &&
+	    t > (uint32_t)Z_SLEEP_MAX_TICKS(USEC_PER_SEC)) {
+		return INT32_MAX;
+	}
+
+	/* a whole number of ticks per microsecond, 1:1 included */
+	if (Z_SLEEP_TICK_HZ % USEC_PER_SEC == 0) {
+		return (int32_t)DIV_ROUND_UP(t, z_tmcvt_divisor(Z_SLEEP_TICK_HZ, USEC_PER_SEC));
+	}
+
+	/* a whole number of microseconds per tick */
+	if (USEC_PER_SEC % Z_SLEEP_TICK_HZ == 0) {
+		return (int32_t)(t * z_tmcvt_divisor(USEC_PER_SEC, Z_SLEEP_TICK_HZ));
+	}
+
+	if (Z_SLEEP_NO_OVERFLOW(USEC_PER_SEC)) {
+		return (int32_t)Z_SLEEP_SPLIT(t, USEC_PER_SEC);
+	}
+
+	if (Z_SLEEP_NO_OVERFLOW(USEC_PER_MSEC)) {
+		return z_sleep_ticks_to_int32_us_split(t);
+	}
+
+	/* tick rate too high to be scaled in 32 bits at all */
+	return (int32_t)MIN(k_ticks_to_us_ceil64(t), (uint64_t)INT32_MAX);
+}
+
+/** @endcond */
 
 /**
  * @brief Put the current thread to sleep.
@@ -79,7 +210,7 @@ static inline int32_t k_sleep(k_timeout_t timeout)
 		return (int32_t)K_TICKS_FOREVER;
 	}
 
-	return (int32_t)MIN(k_ticks_to_ms_ceil64(ticks), (uint64_t)INT32_MAX);
+	return z_sleep_ticks_to_int32_ms(ticks);
 }
 
 /**
@@ -118,7 +249,7 @@ static inline int32_t k_usleep(int32_t us)
 {
 	k_ticks_t ticks = k_sleep_ticks(Z_TIMEOUT_TICKS(k_us_to_ticks_ceil64(us)));
 
-	return (int32_t)MIN(k_ticks_to_us_ceil64(ticks), (uint64_t)INT32_MAX);
+	return z_sleep_ticks_to_int32_us(ticks);
 }
 
 /** @} */

--- a/include/zephyr/sleep.h
+++ b/include/zephyr/sleep.h
@@ -29,6 +29,33 @@ extern "C" {
  */
 
 /**
+ * @brief Put the current thread to sleep, with tick resolution.
+ *
+ * This routine puts the current thread to sleep for @a duration,
+ * specified as a k_timeout_t object.
+ *
+ * This is the primitive that k_sleep(), k_msleep() and k_usleep() are built
+ * upon.  It reports the time left to sleep in ticks, the unit the kernel
+ * works in, so it needs no unit conversion and is the cheapest of the four.
+ *
+ * @param timeout Desired duration of sleep.
+ *
+ * @return Zero if the requested time has elapsed, or the time left to sleep
+ * in ticks (e.g. if the thread was awoken by the \ref k_wakeup call).  If
+ * @a timeout is K_FOREVER and the thread is woken early via k_wakeup(),
+ * K_TICKS_FOREVER is returned.
+ */
+__syscall k_ticks_t k_sleep_ticks(k_timeout_t timeout);
+
+/*
+ * k_sleep() and k_usleep() below are inlined on top of k_sleep_ticks()
+ * rather than being separate out of line entry points.  That way the compiler
+ * sees both whether the requested duration is constant and whether the caller
+ * actually cares about the returned value, and it can fold or discard the
+ * unit conversions accordingly.
+ */
+
+/**
  * @brief Put the current thread to sleep.
  *
  * This routine puts the current thread to sleep for @a duration,
@@ -43,7 +70,17 @@ extern "C" {
  * If @a timeout is K_FOREVER and the thread is woken early via
  * k_wakeup(), -1 is returned.
  */
-__syscall int32_t k_sleep(k_timeout_t timeout);
+static inline int32_t k_sleep(k_timeout_t timeout)
+{
+	k_ticks_t ticks = k_sleep_ticks(timeout);
+
+	/* k_sleep() still returns 32 bit milliseconds for compatibility */
+	if (K_TIMEOUT_EQ(timeout, Z_FOREVER)) {
+		return (int32_t)K_TICKS_FOREVER;
+	}
+
+	return (int32_t)MIN(k_ticks_to_ms_ceil64(ticks), (uint64_t)INT32_MAX);
+}
 
 /**
  * @brief Put the current thread to sleep.
@@ -77,7 +114,12 @@ static inline int32_t k_msleep(int32_t ms)
  * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
  * microsecond.
  */
-__syscall int32_t k_usleep(int32_t us);
+static inline int32_t k_usleep(int32_t us)
+{
+	k_ticks_t ticks = k_sleep_ticks(Z_TIMEOUT_TICKS(k_us_to_ticks_ceil64(us)));
+
+	return (int32_t)MIN(k_ticks_to_us_ceil64(ticks), (uint64_t)INT32_MAX);
+}
 
 /** @} */
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -6,6 +6,7 @@
 zephyr_syscall_header(
   ${ZEPHYR_BASE}/include/zephyr/device.h
   ${ZEPHYR_BASE}/include/zephyr/kernel.h
+  ${ZEPHYR_BASE}/include/zephyr/sleep.h
   ${ZEPHYR_BASE}/include/zephyr/sys/kobject.h
   ${ZEPHYR_BASE}/include/zephyr/sys/time_units.h
 )

--- a/kernel/nothread.c
+++ b/kernel/nothread.c
@@ -18,10 +18,10 @@ bool k_is_in_isr(void)
 static K_TIMER_DEFINE(sleep_timer, NULL, NULL);
 #endif
 
-/* This is a fallback implementation of k_sleep() for when multi-threading is
- * disabled. The main implementation is in sched.c.
+/* This is a fallback implementation of k_sleep_ticks() for when
+ * multi-threading is disabled. The main implementation is in sleep.c.
  */
-int32_t z_impl_k_sleep(k_timeout_t timeout)
+k_ticks_t z_impl_k_sleep_ticks(k_timeout_t timeout)
 {
 	__ASSERT(!arch_is_in_isr(), "");
 
@@ -31,9 +31,9 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
 		/* In Single Thread, just wait for an interrupt saving power */
 		k_cpu_idle();
-		SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, (int32_t) K_TICKS_FOREVER);
+		SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, K_TICKS_FOREVER);
 
-		return (int32_t) K_TICKS_FOREVER;
+		return K_TICKS_FOREVER;
 	}
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
@@ -74,10 +74,8 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 	/* busy wait to be time coherent since subsystems may depend on it */
 	z_impl_k_busy_wait(k_ticks_to_us_ceil32(ticks_to_wait));
 
-	int32_t ret = k_ticks_to_ms_ceil64(0);
+	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, 0);
 
-	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, ret);
-
-	return ret;
+	return 0;
 #endif
 }

--- a/kernel/sleep.c
+++ b/kernel/sleep.c
@@ -8,10 +8,11 @@
  * @file
  * @brief Thread sleep/wake APIs
  *
- * Implements k_sleep(), k_usleep(), and the internal z_tick_sleep() helper.
- * These APIs suspend the calling thread for a specified duration and rely on
- * the scheduler (via z_sched_unready_locked()) and the timeout subsystem
- * (via z_add_thread_timeout()) to do the heavy lifting.
+ * Implements k_sleep_ticks(), the primitive that k_sleep(), k_msleep() and
+ * k_usleep() are built upon.  It suspends the calling thread for a specified
+ * duration and relies on the scheduler (via z_sched_unready_locked()) and the
+ * timeout subsystem (via z_add_thread_timeout()) to do the heavy lifting.  The
+ * millisecond and microsecond flavours are inlined in sleep.h on top of it.
  */
 
 #include <zephyr/kernel.h>
@@ -43,17 +44,21 @@ extern struct k_thread *pending_current;
  * wakeup.
  *
  * @param timeout Sleep duration.
- * @return Ticks remaining when woken early, or 0 on normal expiry.
+ * @return Ticks remaining when woken early, 0 on normal expiry, or
+ *         K_TICKS_FOREVER if @a timeout was K_FOREVER.
  */
-static int32_t z_tick_sleep(k_timeout_t timeout)
+k_ticks_t z_impl_k_sleep_ticks(k_timeout_t timeout)
 {
 	uint32_t expected_wakeup_ticks;
 
 	__ASSERT(!arch_is_in_isr(), "");
 
+	SYS_PORT_TRACING_FUNC_ENTER(k_thread, sleep, timeout);
+
 	/* K_NO_WAIT is treated as a 'yield' */
 	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		k_yield();
+		SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, 0);
 		return 0;
 	}
 
@@ -68,6 +73,14 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 
 	(void)z_swap(&_sched_spinlock, key);
 
+	/* There is no meaningful remainder to report for K_FOREVER: reaching
+	 * this point at all means a k_wakeup() cut the sleep short.
+	 */
+	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+		SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, K_TICKS_FOREVER);
+		return K_TICKS_FOREVER;
+	}
+
 	/* We require a 32 bit unsigned subtraction to handle a wraparound.
 	 * A normal timeout-driven wakeup leaves zero (or a slightly negative)
 	 * remainder; only an early k_wakeup() yields a positive value.
@@ -81,59 +94,18 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 	 */
 	int32_t signed_left = (int32_t)left_ticks;
 
-	if (signed_left > 0) {
-		return (k_ticks_t)signed_left;
+	if (signed_left < 0) {
+		signed_left = 0;
 	}
 
-	return 0;
-}
-
-int32_t z_impl_k_sleep(k_timeout_t timeout)
-{
-	k_ticks_t ticks;
-
-	__ASSERT(!arch_is_in_isr(), "");
-
-	SYS_PORT_TRACING_FUNC_ENTER(k_thread, sleep, timeout);
-
-	ticks = z_tick_sleep(timeout);
-
-	/* k_sleep() still returns 32 bit milliseconds for compatibility */
-	int64_t ms = K_TIMEOUT_EQ(timeout, K_FOREVER) ? K_TICKS_FOREVER :
-		clamp(k_ticks_to_ms_ceil64(ticks), 0, INT_MAX);
-
-	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, ms);
-	return (int32_t) ms;
+	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, signed_left);
+	return (k_ticks_t)signed_left;
 }
 
 #ifdef CONFIG_USERSPACE
-static inline int32_t z_vrfy_k_sleep(k_timeout_t timeout)
+static inline k_ticks_t z_vrfy_k_sleep_ticks(k_timeout_t timeout)
 {
-	return z_impl_k_sleep(timeout);
+	return z_impl_k_sleep_ticks(timeout);
 }
-#include <zephyr/syscalls/k_sleep_mrsh.c>
-#endif /* CONFIG_USERSPACE */
-
-int32_t z_impl_k_usleep(int32_t us)
-{
-	int32_t ticks;
-
-	SYS_PORT_TRACING_FUNC_ENTER(k_thread, usleep, us);
-
-	ticks = k_us_to_ticks_ceil64(us);
-	ticks = z_tick_sleep(Z_TIMEOUT_TICKS(ticks));
-
-	int32_t ret = k_ticks_to_us_ceil64(ticks);
-
-	SYS_PORT_TRACING_FUNC_EXIT(k_thread, usleep, us, ret);
-
-	return ret;
-}
-
-#ifdef CONFIG_USERSPACE
-static inline int32_t z_vrfy_k_usleep(int32_t us)
-{
-	return z_impl_k_usleep(us);
-}
-#include <zephyr/syscalls/k_usleep_mrsh.c>
+#include <zephyr/syscalls/k_sleep_ticks_mrsh.c>
 #endif /* CONFIG_USERSPACE */

--- a/lib/libc/armstdc/src/threading_weak.c
+++ b/lib/libc/armstdc/src/threading_weak.c
@@ -54,7 +54,7 @@ k_tid_t __weak z_impl_k_sched_current_thread_query(void)
 	return 0;
 }
 
-int32_t __weak z_impl_k_usleep(int us)
+k_ticks_t __weak z_impl_k_sleep_ticks(k_timeout_t timeout)
 {
 	return 0;
 }

--- a/tests/kernel/sleep_convert/CMakeLists.txt
+++ b/tests/kernel/sleep_convert/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sleep_convert)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/sleep_convert/prj.conf
+++ b/tests/kernel/sleep_convert/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/sleep_convert/src/main.c
+++ b/tests/kernel/sleep_convert/src/main.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Exercise the tick to millisecond and tick to microsecond converters that
+ * k_sleep() and k_usleep() use on their return value.
+ *
+ * Those converters pick one of several forms at compile time from
+ * CONFIG_SYS_CLOCK_TICKS_PER_SEC, and the narrow ones are only safe because
+ * of a clamp applied beforehand in the tick domain.  So the interesting
+ * coverage is a whole build per tick rate, which tests.yaml provides:
+ *
+ *   100      ms: whole milliseconds per tick   us: whole microseconds per tick
+ *   1000     ms: 1:1                           us: whole microseconds per tick
+ *   10000    ms: whole ticks per millisecond   us: whole microseconds per tick
+ *   32768    ms: split                         us: two stage split
+ *   12345    ms: split                         us: two stage split
+ *   1000000  ms: whole ticks per millisecond   us: 1:1
+ *
+ * The reference is the generic 64 bit converter plus an explicit saturation,
+ * which is the contract these helpers must meet.  On a 64 bit target the
+ * helpers are defined to be exactly that, so there the checks below only
+ * really police the saturation, which is the point they still earn.
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+
+#define TICK_HZ ((uint32_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
+/* Highest tick count k_sleep_ticks() can report, being the result of a
+ * 32 bit subtraction narrowed to a positive int32_t.
+ */
+#define MAX_SLEEP_TICKS ((uint32_t)INT32_MAX)
+
+static int32_t ref_ms(uint32_t ticks)
+{
+	uint64_t ms = k_ticks_to_ms_ceil64((uint64_t)ticks);
+
+	return ms > (uint64_t)INT32_MAX ? INT32_MAX : (int32_t)ms;
+}
+
+static int32_t ref_us(uint32_t ticks)
+{
+	uint64_t us = k_ticks_to_us_ceil64((uint64_t)ticks);
+
+	return us > (uint64_t)INT32_MAX ? INT32_MAX : (int32_t)us;
+}
+
+static void check(uint32_t ticks)
+{
+	zassert_equal(z_sleep_ticks_to_int32_ms(ticks), ref_ms(ticks),
+		      "ms conversion of %u ticks: got %d, expected %d", ticks,
+		      z_sleep_ticks_to_int32_ms(ticks), ref_ms(ticks));
+
+	zassert_equal(z_sleep_ticks_to_int32_us(ticks), ref_us(ticks),
+		      "us conversion of %u ticks: got %d, expected %d", ticks,
+		      z_sleep_ticks_to_int32_us(ticks), ref_us(ticks));
+}
+
+/* Every tick count from zero up, where the quotient and the remainder of the
+ * split forms both change on every step.
+ */
+ZTEST(sleep_convert, test_small_values)
+{
+	for (uint32_t t = 0; t <= 10000U; t++) {
+		check(t);
+	}
+}
+
+/* A stride that is coprime with the usual tick rates, so it lands on a varied
+ * set of remainders all the way up to the top of the range.  Kept sparse on
+ * purpose: this is here for reach, while the cases that actually distinguish
+ * the conversion forms are covered densely above and exactly below.
+ */
+ZTEST(sleep_convert, test_whole_range)
+{
+	for (uint64_t t = 0; t <= (uint64_t)MAX_SLEEP_TICKS; t += 1048573U) {
+		check((uint32_t)t);
+	}
+}
+
+/* Where the converters change behaviour: around the tick rate itself, which
+ * is where the quotient and remainder split, and around the clamp bounds.
+ */
+ZTEST(sleep_convert, test_boundaries)
+{
+	uint64_t clamp_ms = (uint64_t)INT32_MAX * TICK_HZ / MSEC_PER_SEC;
+	uint64_t clamp_us = (uint64_t)INT32_MAX * TICK_HZ / USEC_PER_SEC;
+	uint64_t probes[] = {
+		0, 1, 2,
+		TICK_HZ - 1, TICK_HZ, TICK_HZ + 1,
+		(uint64_t)TICK_HZ * 2, (uint64_t)TICK_HZ * 2 + 1,
+		clamp_ms - 1, clamp_ms, clamp_ms + 1,
+		clamp_us - 1, clamp_us, clamp_us + 1,
+		MAX_SLEEP_TICKS - 1, MAX_SLEEP_TICKS,
+	};
+
+	for (unsigned int i = 0; i < ARRAY_SIZE(probes); i++) {
+		if (probes[i] > (uint64_t)MAX_SLEEP_TICKS) {
+			continue;
+		}
+		check((uint32_t)probes[i]);
+	}
+}
+
+/* Past the clamp bound the result must saturate rather than wrap, which is
+ * the property that lets the conversion itself stay narrow.
+ */
+ZTEST(sleep_convert, test_saturation)
+{
+	uint64_t clamp_ms = (uint64_t)INT32_MAX * TICK_HZ / MSEC_PER_SEC;
+	uint64_t clamp_us = (uint64_t)INT32_MAX * TICK_HZ / USEC_PER_SEC;
+
+	if (clamp_ms < (uint64_t)MAX_SLEEP_TICKS) {
+		zassert_equal(z_sleep_ticks_to_int32_ms(MAX_SLEEP_TICKS), INT32_MAX,
+			      "ms conversion failed to saturate");
+		zassert_equal(z_sleep_ticks_to_int32_ms((uint32_t)clamp_ms + 1), INT32_MAX,
+			      "ms conversion failed to saturate just past the bound");
+	} else {
+		/* every reachable tick count is representable in milliseconds */
+		zassert_true(z_sleep_ticks_to_int32_ms(MAX_SLEEP_TICKS) <= INT32_MAX);
+	}
+
+	if (clamp_us < (uint64_t)MAX_SLEEP_TICKS) {
+		zassert_equal(z_sleep_ticks_to_int32_us(MAX_SLEEP_TICKS), INT32_MAX,
+			      "us conversion failed to saturate");
+		zassert_equal(z_sleep_ticks_to_int32_us((uint32_t)clamp_us + 1), INT32_MAX,
+			      "us conversion failed to saturate just past the bound");
+	} else {
+		zassert_true(z_sleep_ticks_to_int32_us(MAX_SLEEP_TICKS) <= INT32_MAX);
+	}
+}
+
+/* The conversion must never round down: sleeping for the reported remainder
+ * has to cover the time that was actually left.
+ */
+ZTEST(sleep_convert, test_rounds_up)
+{
+	for (uint32_t t = 1; t <= 2000U; t++) {
+		int32_t ms = z_sleep_ticks_to_int32_ms(t);
+		int32_t us = z_sleep_ticks_to_int32_us(t);
+
+		zassert_true((uint64_t)k_ms_to_ticks_floor64(ms) >= t || ms == INT32_MAX,
+			     "%d ms is short of %u ticks", ms, t);
+		zassert_true((uint64_t)k_us_to_ticks_floor64(us) >= t || us == INT32_MAX,
+			     "%d us is short of %u ticks", us, t);
+	}
+}
+
+ZTEST_SUITE(sleep_convert, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/sleep_convert/tests.yaml
+++ b/tests/kernel/sleep_convert/tests.yaml
@@ -1,0 +1,34 @@
+common:
+  tags:
+    - kernel
+    - sleep
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
+    - qemu_cortex_m3
+    - qemu_riscv32
+    - qemu_riscv64
+  integration_platforms:
+    - native_sim
+tests:
+  # One entry per shape the compile time case selection can take, for both
+  # the millisecond and the microsecond converter.  See the comment in
+  # src/main.c for what each tick rate exercises.
+  kernel.sleep.convert.ticks_100:
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=100
+  kernel.sleep.convert.ticks_1000:
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+  kernel.sleep.convert.ticks_10000:
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
+  kernel.sleep.convert.ticks_32768:
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=32768
+  kernel.sleep.convert.ticks_12345:
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=12345
+  kernel.sleep.convert.ticks_1000000:
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000000


### PR DESCRIPTION
`k_sleep()` reports the time left to sleep in milliseconds, so it has to
convert from ticks, and that conversion is what pulls the 64 bit division
helper into an image. `CONFIG_SYS_CLOCK_TICKS_PER_SEC` defaults to 10000 on
tickless platforms, which makes the conversion a 64 bit division by ten,
something GCC will not strength reduce on a 32 bit target. On a stock
`nucleo_f030r8` build, `z_impl_k_sleep()` and `z_impl_k_usleep()` are the only
two callers of `__aeabi_uldivmod` in the whole image.

The cost is paid whether or not anyone wants the returned value, and almost
nobody does: of the 4036 sleep call sites in the tree, exactly six use it, and
only three of those are outside of tests.

So the conversions are moved to where the compiler can see whether they are
needed. `k_sleep()` and `k_usleep()` become inlines over a new
`k_sleep_ticks()` system call that reports the remainder in ticks, which is
also the ticks returning API suggested in the issue. A caller that ignores the
result gets no conversion at all, and a constant duration folds at compile
time: `k_usleep(250)` now passes the literal 3 ticks the compiler worked out
itself. For the callers that do use the result, the conversion is kept 32 bit
wide by clamping first in the tick domain against a compile time bound, so a
constant divisor becomes a multiply instead of a helper call.

FLASH for a loop calling `k_msleep(100)`, `k_sleep(K_SECONDS(1))` and
`k_usleep(250)`:

| | results ignored | results used |
|---|---|---|
| nucleo_f030r8, Cortex-M0, 10000 ticks/s | 11028 to 10600 | 11060 to 10668 |
| nrf52840dk, Cortex-M4, 32768 ticks/s | 17776 to 16944 | 17812 to 17828 |

The one that grows is a caller that both uses the result and passes a non
constant duration, at a tick rate where the conversion needs the split form.
That costs a few bytes per call site, since each site now carries its own copy
rather than calling a shared one. A synthetic case with 32 such sites, five
times as many as exist in the whole tree, comes to 80 bytes, so there is no out
of line fallback keyed on `__builtin_constant_p()`.

Fixes #114781
