### PR TITLE
arch: x86: fix overflow converting TSC cycles to nanoseconds

### DIFF
--- a/arch/x86/timing.c
+++ b/arch/x86/timing.c
@@ -77,7 +77,15 @@ uint64_t arch_timing_freq_get(void)
 
 uint64_t arch_timing_cycles_to_ns(uint64_t cycles)
 {
-	return ((cycles) * NSEC_PER_SEC / tsc_freq);
+	/*
+	 * Multiplying first would overflow: cycles * NSEC_PER_SEC leaves the
+	 * 64-bit range at 1.8e10 cycles, which on a 3.2 GHz TSC is under six
+	 * seconds of uptime, after which the result wraps back towards zero.
+	 * Splitting the division out keeps the result exact and cannot
+	 * overflow for any counter frequency below about 18 GHz, since the
+	 * remainder is always smaller than tsc_freq.
+	 */
+	return (cycles / tsc_freq) * NSEC_PER_SEC + ((cycles % tsc_freq) * NSEC_PER_SEC) / tsc_freq;
 }
 
 uint64_t arch_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count)


### PR DESCRIPTION
arch_timing_cycles_to_ns() multiplied before it divided, so the
intermediate cycles * NSEC_PER_SEC left the 64-bit range at 1.8e10
cycles. On a 3.2 GHz TSC that is under six seconds of uptime, after
which the returned time wraps back towards zero.

Anything sampling this clock for longer than that sees time jump
backwards. It shows up plainly in CTF tracing, where a capture longer
than a few seconds is rejected outright by babeltrace2: a stream whose
timestamps are not monotonic cannot be read, and per-CPU streams
cannot be merged.

Divide first and fold the remainder back in. The result is exact and
cannot overflow for any counter frequency below roughly 18 GHz, since
the remainder is by construction smaller than the frequency.

