### PR TITLE
dts: arm: st: stm32g0: Add support for vrefbuf

### DIFF
--- a/dts/arm/st/g0/stm32g031.dtsi
+++ b/dts/arm/st/g0/stm32g031.dtsi
@@ -54,5 +54,15 @@
 				status = "disabled";
 			};
 		};
+
+		/* NOTE: only available on packages with 48+ pins */
+		vrefbuf: vrefbuf@40010030 {
+			compatible = "st,stm32-vrefbuf";
+			reg = <0x40010030 0x40>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
+			resets = <&rctl STM32_RESET(APB1H, 0)>;
+			ref-voltages = <2048000>, <2500000>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
Add a node for the VREFBUF peripheral on STM32G0.

VREFBUF exists only on stm32g0X1 variants, and only on 48+ pin packages — smaller packages of the same die don't have it. We don't currently model per-package peripheral differences, so I've added VREFBUF to stm32g031 to inherit down the family, knowing this will make it appear present on smaller packages that don't actually have it.

Not fully correct, but seems like the least-bad option given current infra. Flagging in case there's a preferred approach — this likely isn't the only peripheral affected by this gap.

Refs:
- [[RM0444 Rev 6](https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)](https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), Table 6 p.65: lists VREFBUF for the family without distinguishing package.
- [[DS12992 Rev 4](https://www.st.com/resource/en/datasheet/stm32g031g8.pdf)](https://www.st.com/resource/en/datasheet/stm32g031g8.pdf) (stm32g031g8), Table 2 p.11: shows VREFBUF absent on smaller packages.