### PR TITLE
soc: st: stm32h7: fix M4 ART accelerator address configuration

### DIFF
--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m4.dts
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m4.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m4.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m4.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m4.dts
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m4.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &uart8;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &uart8;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m4.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m4.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m4.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m4.dts
@@ -19,6 +19,7 @@
 		/* zephyr,shell-uart = &usart1; */
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m4.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m4.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/dts/arm/st/h7/stm32h745Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m4.dtsi
@@ -21,6 +21,17 @@
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
 				bank2-flash-size = <1024>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					slot0_partition: partition@0 {
+						label = "image-0";
+						reg = <0x00000000 DT_SIZE_K(1024)>;
+					};
+				};
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h747Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m4.dtsi
@@ -21,6 +21,17 @@
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
 				bank2-flash-size = <1024>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					slot0_partition: partition@0 {
+						label = "image-0";
+						reg = <0x00000000 DT_SIZE_K(1024)>;
+					};
+				};
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h755Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h755Xi_m4.dtsi
@@ -21,6 +21,17 @@
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
 				bank2-flash-size = <1024>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					slot0_partition: partition@0 {
+						label = "image-0";
+						reg = <0x00000000 DT_SIZE_K(1024)>;
+					};
+				};
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h757Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h757Xi_m4.dtsi
@@ -21,6 +21,17 @@
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
 				bank2-flash-size = <1024>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					slot0_partition: partition@0 {
+						label = "image-0";
+						reg = <0x00000000 DT_SIZE_K(1024)>;
+					};
+				};
 			};
 		};
 

--- a/soc/st/stm32/stm32h7x/soc_m4.c
+++ b/soc/st/stm32/stm32h7x/soc_m4.c
@@ -31,7 +31,7 @@ void soc_early_init_hook(void)
 {
 	/* Enable ART Flash cache accelerator */
 	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_ART);
-	LL_ART_SetBaseAddress(DT_REG_ADDR(DT_CHOSEN(zephyr_flash)));
+	LL_ART_SetBaseAddress(DT_REG_ADDR(DT_CHOSEN(zephyr_code_partition)));
 	LL_ART_Enable();
 
 	/* Enable hardware semaphore clock */


### PR DESCRIPTION
The ART (Adaptive Real-Time) flash cache accelerator base address is
configured using only DT_REG_ADDR(DT_CHOSEN(zephyr_flash)) without
accounting for CONFIG_FLASH_LOAD_OFFSET. When the M4 flash layout uses
zephyr,flash = &flash0 with a non-zero CONFIG_FLASH_LOAD_OFFSET,
the ART caches the wrong flash region.

The fix is to use the zephyr,code-partition to retrieve the flash
address for code and use it instead.