### PR TITLE
Fix some avoid_unnecessary_addr_size warnings coming from the dts compiler

### DIFF
--- a/dts/arm/microchip/mec/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec/mec1501hsz.dtsi
@@ -486,8 +486,6 @@
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
 		};
 
 		peci0: peci@40006400 {

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -730,8 +730,6 @@ kbd0: kbd@40009c00 {
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 	pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 	status = "disabled";
-	#address-cells = <1>;
-	#size-cells = <0>;
 };
 
 peci0: peci@40006400 {

--- a/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
@@ -39,8 +39,6 @@
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
 		};
 
 		uart2: uart@400f2c00 {

--- a/dts/arm/microchip/mec/mec5_mec1743qlj.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1743qlj.dtsi
@@ -42,8 +42,6 @@
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/arm/microchip/mec/mec5_mec1743qsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1743qsz.dtsi
@@ -41,8 +41,6 @@
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/arm/microchip/mec/mec5_mec1753qlj.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1753qlj.dtsi
@@ -43,8 +43,6 @@
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/arm/microchip/mec/mec5_mec1753qsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1753qsz.dtsi
@@ -42,8 +42,6 @@
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
 			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/bindings/input/microchip,xec-kbd.yaml
+++ b/dts/bindings/input/microchip,xec-kbd.yaml
@@ -12,14 +12,6 @@ include:
   - name: microchip,dmec-ecia-girq.yaml
 
 properties:
-  "#address-cells":
-    required: true
-    const: 1
-
-  "#size-cells":
-    type: int
-    const: 0
-
   reg:
     required: true
 

--- a/dts/bindings/mtd/andestech,qspi-nor.yaml
+++ b/dts/bindings/mtd/andestech,qspi-nor.yaml
@@ -10,7 +10,9 @@ description:
   Properties supporting Zephyr qspi-nor flash driver control of
   flash memories using the standard M25P80-based command set.
 
-include: "jedec,spi-nor-common.yaml"
+include:
+  - "jedec,spi-nor-common.yaml"
+  - "spi-device.yaml"
 
 properties:
   wp-gpios:

--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -564,8 +564,6 @@
 
 		pinctrl: pin-controller {
 			compatible = "ite,it8xxx2-pinctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			status = "okay";
 		};
 

--- a/dts/riscv/ite/it81xx2.dtsi
+++ b/dts/riscv/ite/it81xx2.dtsi
@@ -54,8 +54,6 @@
 
 		pinctrl: pin-controller {
 			compatible = "ite,it8xxx2-pinctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			status = "okay";
 		};
 

--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -440,8 +440,6 @@
 
 		pinctrl: pin-controller {
 			compatible = "ite,it8xxx2-pinctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			status = "okay";
 		};
 

--- a/soc/microchip/mec/mec15xx/soc.h
+++ b/soc/microchip/mec/mec15xx/soc.h
@@ -19,6 +19,13 @@
 #include <reg/mec_pcr_vbr.h>
 #include <reg/mec_uart.h>
 
+/* Keyboard scan register offsets for mec15xx (legacy compatibility with new driver) */
+#define XEC_KBD_KSO_SEL_OFS 0x04u
+#define XEC_KBD_KSI_IN_OFS 0x08u
+#define XEC_KBD_KSI_STS_OFS 0x0cu
+#define XEC_KBD_KSI_IEN_OFS 0x10u
+#define XEC_KBD_EXT_CTRL_OFS 0x14u
+
 /* common SoC API */
 #include <soc_dt.h>
 #include <soc_ecia.h>


### PR DESCRIPTION
Fix all the avoid_unnecessary_addr_size warnings being emited by the DTS compiler when building ChromeOS EC binaries.

Assisted-by: Antigravity:gemini-1.5-pro