### PR TITLE
drivers: timer: renesas_rx_cmt: never program CMCOR to zero

### DIFF
--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -38,6 +38,18 @@
 
 #define CYCLES_CYCLE_TIMER (COUNTER_MAX + 1)
 
+/*
+ * Shortest period ever programmed into CMT0. A compare match clears CMCNT, so
+ * CMCOR is the interrupt *period* rather than a one-shot deadline: too small a
+ * value re-triggers the tick interrupt before its own ISR can return, and the
+ * CPU never runs anything else again. Nothing recovers from that once the
+ * kernel timeout queue is empty, because sys_clock_set_timeout() is then
+ * called with SYS_CLOCK_MAX_WAIT and returns without reprogramming. A quarter
+ * tick bounds the interrupt rate at four times the tick rate, which the driver
+ * services with room to spare.
+ */
+#define MIN_PERIOD_CYCLES ((uint16_t)MAX(CYCLES_PER_TICK / 4, 1))
+
 static const struct clock_control_rx_subsys_cfg cmt_clk_cfg = {
 	.mstp = DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(0), 0, mstp),
 	.stop_bit = DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(0), 0, stop_bit),
@@ -248,6 +260,10 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	uint16_t current = *tick_timer_cfg.cmcnt;
 	uint16_t new_cmcor = (uint16_t)(current + delay - 1U);
+
+	if (new_cmcor < MIN_PERIOD_CYCLES) {
+		new_cmcor = MIN_PERIOD_CYCLES;
+	}
 
 	*tick_timer_cfg.cmcor = new_cmcor;
 


### PR DESCRIPTION
sys_clock_set_timeout() computes the compare value as
"current + delay - 1", where delay can legitimately be zero.

On this SoC MAX_TICKS is 0 (CYCLES_PER_TICK is 60000 and the CMT
counter is 16-bit), so the requested tick count is always clamped
to 0 and delay collapses to
"roundup(elapsed, CYCLES_PER_TICK) - elapsed", which is zero
whenever the call lands exactly on a tick boundary. If CMCNT reads
1 at that moment, CMCOR ends up programmed to 0.

That value is fatal: the compare match clears CMCNT to 0, so a
CMCOR of 0 matches again on the very next cycle and the CPU never
leaves the tick ISR. It does not self-heal either, because with no
pending kernel timeout sys_clock_set_timeout() returns early on
SYS_CLOCK_MAX_WAIT and never reprograms the register.

The window is one cycle wide, so any unrelated change in code size
or instruction timing can expose it. It was hit on
qemu_rx/r5f562n8 by the secure_storage.psa.its scenario
secure_storage.custom.store, which hung with its test thread
frozen on its very first instruction and both CMCOR and CMCNT
reading 0.

Push such a deadline out by a single cycle instead. The worst-case
error is one cycle of jitter.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
