### PR TITLE
drivers: disk: drop redundant cmake if guard

### DIFF
--- a/drivers/disk/CMakeLists.txt
+++ b/drivers/disk/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_DISK_DRIVERS)
-
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_SDMMC_SUBSYS sdmmc_subsys.c)
@@ -16,5 +14,3 @@ zephyr_library_sources_ifdef(CONFIG_DISK_DRIVER_LOOPBACK loopback_disk.c)
 zephyr_library_sources_ifdef(CONFIG_DISK_DRIVER_RAM ramdisk.c)
 zephyr_library_sources_ifdef(CONFIG_SDMMC_STM32 sdmmc_stm32.c)
 # zephyr-keep-sorted-stop
-
-endif()


### PR DESCRIPTION
if() guard in disk CMakeLists file was redundant since the file will only be included by the parent CMakeLists if CONFIG_DISK_DRIVERS is already set. Drop it.