### PR TITLE
boards: wch: increase the test coverage for ch32v00{3,6}evt and more

### DIFF
--- a/boards/wch/ch32v003evt/ch32v003evt.yaml
+++ b/boards/wch/ch32v003evt/ch32v003evt.yaml
@@ -8,9 +8,13 @@ toolchain:
 ram: 2
 flash: 16
 supported:
+  - adc
   - dma
   - gpio
   - i2c
+  - pinctrl
   - pwm
+  - spi
   - uart
   - watchdog
+vendor: wch

--- a/boards/wch/ch32v006evt/ch32v006evt.yaml
+++ b/boards/wch/ch32v006evt/ch32v006evt.yaml
@@ -8,10 +8,13 @@ toolchain:
 ram: 8
 flash: 62
 supported:
+  - adc
   - dma
   - gpio
   - i2c
+  - pinctrl
   - pwm
+  - spi
   - uart
   - watchdog
 vendor: wch

--- a/boards/wch/linkw/linkw.yaml
+++ b/boards/wch/linkw/linkw.yaml
@@ -8,9 +8,13 @@ toolchain:
 ram: 64
 flash: 128
 supported:
+  - adc
   - dma
   - gpio
   - i2c
+  - pinctrl
   - pwm
+  - spi
   - uart
   - watchdog
+vendor: wch

--- a/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.yaml
+++ b/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.yaml
@@ -8,7 +8,12 @@ toolchain:
 ram: 20
 flash: 224
 supported:
+  - dma
   - gpio
   - i2c
+  - pinctrl
   - pwm
+  - spi
   - uart
+  - watchdog
+vendor: weact

--- a/boards/weact/ch32v00x_core/ch32v00x_core.yaml
+++ b/boards/weact/ch32v00x_core/ch32v00x_core.yaml
@@ -8,10 +8,13 @@ toolchain:
 ram: 8
 flash: 62
 supported:
+  - adc
   - button
   - dma
   - gpio
+  - i2c
   - pwm
+  - spi
   - uart
   - watchdog
 vendor: weact

--- a/samples/basic/blinky/tests.yaml
+++ b/samples/basic/blinky/tests.yaml
@@ -1,5 +1,8 @@
 sample:
   name: Blinky Sample
+common:
+  min_ram: 2
+  min_flash: 16
 tests:
   sample.basic.blinky:
     tags:

--- a/samples/basic/blinky_pwm/tests.yaml
+++ b/samples/basic/blinky_pwm/tests.yaml
@@ -1,5 +1,8 @@
 sample:
   name: Blink LED (PWM based)
+common:
+  min_ram: 2
+  min_flash: 16
 tests:
   sample.basic.blink_led:
     filter: dt_alias_exists("pwm-led0") and dt_compat_enabled("pwm-leds")

--- a/samples/basic/minimal/tests.yaml
+++ b/samples/basic/minimal/tests.yaml
@@ -2,6 +2,8 @@ sample:
   description: minimal sample, the smallest possible Zephyr application
   name: minimal
 common:
+  min_ram: 2
+  min_flash: 16
   tags: footprint
   harness: console
   harness_config:

--- a/samples/drivers/adc/adc_dt/tests.yaml
+++ b/samples/drivers/adc/adc_dt/tests.yaml
@@ -4,7 +4,8 @@ common:
   tags:
     - adc
   filter: dt_node_has_prop("/zephyr,user","io-channels")
-
+  min_ram: 2
+  min_flash: 16
 tests:
   sample.drivers.adc.adc_dt:
     depends_on:
@@ -61,6 +62,8 @@ tests:
       - mck_ra4t1
       - fpb_ra8e1
       - raytac_an54lv_db_15/nrf54l15/cpuapp
+      - ch32v003evt
+      - ch32v006evt
     integration_platforms:
       - nucleo_l073rz
       - nrf52840dk/nrf52840

--- a/samples/drivers/led/pwm/tests.yaml
+++ b/samples/drivers/led/pwm/tests.yaml
@@ -1,6 +1,9 @@
 sample:
   description: Demonstration of the PWM LED driver
   name: PWM LED sample
+common:
+  min_ram: 2
+  min_flash: 16
 tests:
   sample.drivers.led.led_pwm:
     filter: dt_compat_enabled("pwm-leds")

--- a/samples/drivers/watchdog/tests.yaml
+++ b/samples/drivers/watchdog/tests.yaml
@@ -14,6 +14,8 @@ common:
       - "Waiting for reset..."
       - "Watchdog sample application"
   depends_on: watchdog
+  min_ram: 2
+  min_flash: 16
 tests:
   sample.drivers.watchdog:
     filter: dt_alias_exists("watchdog0") and


### PR DESCRIPTION
Update the board definitions to include the recently added drivers.
This increases the test coverage from to 595 to 619 for the
ch32v006evt and to 708 to 736 for linkw.

Reduce the minimum RAM and Flash requirements for some of the basic
samples so they fit within the ch32v003evt's 16 KiB of flash and 2 KiB
of RAM.

With this the coverage goes from ~1 to 6 which gives much better
driver build test coverage.
