### PR TITLE
net: zperf: fix use of uninitialized periodic result

### DIFF
--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -225,7 +225,7 @@ static void tcp_upload_async_work(struct k_work *work)
 		uint32_t rounds = (duration + report_interval - 1) / report_interval;
 		uint32_t last_round_duration = duration - ((rounds - 1) * report_interval);
 
-		struct zperf_results periodic_result;
+		struct zperf_results periodic_result = { 0 };
 
 		for (; rounds > 0; rounds--) {
 			uint32_t round_duration;


### PR DESCRIPTION
When a TCP upload is started with a report interval but a zero total
duration, "rounds" evaluates to 0, the upload loop never executes and
"periodic_result" is left uninitialized. Its packet_size member is then
copied into the final result.

Reported by the GCC static analyzer
(-Wanalyzer-use-of-uninitialized-value).

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
Assisted-by: Claude:claude-opus-5
