### PR TITLE
testsuite: ztest: do not use a mock parameter after a failed lookup

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -206,6 +206,8 @@ void z_ztest_check_expected_value(const char *fn, const char *name, uintptr_t va
 	if (!param) {
 		PRINT_DATA("Failed to find parameter %s for %s\n", name, fn);
 		ztest_test_fail();
+		/* ztest_test_fail() may return, depending on the test phase. */
+		return;
 	}
 
 	expected = param->value;
@@ -300,6 +302,8 @@ uintptr_t z_ztest_get_return_value(const char *fn)
 	if (!param) {
 		PRINT_DATA("Failed to find return value for function %s\n", fn);
 		ztest_test_fail();
+		/* ztest_test_fail() may return, depending on the test phase. */
+		return 0;
 	}
 
 	value = param->value;


### PR DESCRIPTION
ztest_test_fail() does not necessarily terminate the caller: the
multithreading implementation just records the result and returns for
some test phases. Both z_ztest_check_expected_value() and
z_ztest_get_return_value() then dereferenced the NULL parameter they had
just failed to find. Return early, as z_ztest_check_expected_data()
already does.

Reported by the GCC static analyzer (-Wanalyzer-null-dereference).

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
Assisted-by: Claude:claude-opus-5
