### PR TITLE
tests: posix: fix gcc analyzer reported issues

### DIFF
--- a/tests/subsys/portability/posix/fs/src/test_fs_dir.c
+++ b/tests/subsys/portability/posix/fs/src/test_fs_dir.c
@@ -161,6 +161,8 @@ ZTEST(posix_fs_dir_test, test_fs_readdir_threadsafe)
 ZTEST(posix_fs_dir_test, test_fs_rmdir)
 {
 #define IRWXG	0070
+	int fd;
+
 	/* Create and remove empty directory */
 	zassert_ok(mkdir(TEST_DIR, IRWXG), "Error creating dir: %d", errno);
 	zassert_ok(rmdir(TEST_DIR), "Error removing dir: %d\n", errno);
@@ -170,8 +172,9 @@ ZTEST(posix_fs_dir_test, test_fs_rmdir)
 	 * fail in removal of non empty directory
 	 */
 	zassert_ok(mkdir(TEST_DIR, IRWXG), "Error creating dir: %d", errno);
-	zassert_not_equal(open(TEST_DIR_FILE, O_CREAT | O_RDWR), -1,
-			  "Error creating file: %d", errno);
+	fd = open(TEST_DIR_FILE, O_CREAT | O_RDWR);
+	zassert_not_equal(fd, -1, "Error creating file: %d", errno);
+	zassert_ok(close(fd), "Error closing file: %d", errno);
 	zassert_not_ok(rmdir(TEST_DIR), "Error Non empty dir removed");
 	zassert_not_ok(rmdir(""), "Error Invalid path removed");
 	zassert_not_ok(rmdir(NULL), "Error Invalid path removed");

--- a/tests/subsys/portability/posix/xsi_single_process/src/putenv.c
+++ b/tests/subsys/portability/posix/xsi_single_process/src/putenv.c
@@ -13,7 +13,8 @@ int putenv(char *s);
 
 ZTEST(xsi_single_process, test_putenv)
 {
-	char buf[64];
+	/* putenv() does not copy the string, so the buffer must outlive this test */
+	static char buf[64];
 
 	{
 		/* degenerate cases */


### PR DESCRIPTION
- **tests: posix: fs: close the file opened by the rmdir test**
- **tests: posix: putenv: do not putenv() an automatic buffer**
