### PR TITLE
logging: do not pass an uninitialized spinlock key

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -721,7 +721,8 @@ static void msg_commit(struct mpsc_pbuf_buffer *buffer, struct log_msg *msg)
 	bool lock_acquired;
 
 	if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
-		k_spinlock_key_t key;
+		k_spinlock_key_t key = {0};
+
 		lock_acquired = process_lock_acquire_if_needed(&key);
 
 		msg_process(m);


### PR DESCRIPTION
process_lock_acquire_if_needed() returns early without writing *key when
CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT is disabled or the lock is not needed.
msg_commit() then passes that indeterminate value by value to
process_lock_release_if_needed(), which is undefined behaviour even
though the callee does not use it in that case.

Reported by the GCC static analyzer
(-Wanalyzer-use-of-uninitialized-value).

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
Assisted-by: Claude:claude-opus-5
