### PR TITLE
net: lwm2m: check find_msg() result in notify reply callback

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -3021,6 +3021,10 @@ static int notify_message_reply_cb(const struct coap_packet *response, struct co
 		sprint_token(reply->token, reply->tkl));
 
 	msg = find_msg(NULL, reply);
+	if (msg == NULL) {
+		LOG_ERR("Orphaned reply %p.", reply);
+		return 0;
+	}
 
 	/* remove observer on COAP_TYPE_RESET */
 	if (type == COAP_TYPE_RESET) {


### PR DESCRIPTION
find_msg() returns NULL when no message matches the given reply, but
notify_message_reply_cb() dereferenced it unconditionally. Bail out
instead, like the other find_msg() call sites in this file already do.

Reported by the GCC static analyzer (-Wanalyzer-null-dereference).

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
Assisted-by: Claude:claude-opus-5
