### PR TITLE
mgmt: updatehub: reject metadata without a sha256sum

### DIFF
--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -880,6 +880,12 @@ enum updatehub_response z_impl_updatehub_probe(void)
 			goto cleanup;
 		}
 
+		if (metadata_any_boards.objects[1].objects[0].objects.sha256sum == NULL) {
+			LOG_ERR("SHA256 is missing from the metadata");
+			ctx.code_status = UPDATEHUB_METADATA_ERROR;
+			goto cleanup;
+		}
+
 		sha256size = strlen(
 			metadata_any_boards.objects[1].objects[0].objects.sha256sum) + 1;
 
@@ -924,6 +930,12 @@ enum updatehub_response z_impl_updatehub_probe(void)
 			LOG_ERR("Incompatible hardware");
 			ctx.code_status =
 				UPDATEHUB_INCOMPATIBLE_HARDWARE;
+			goto cleanup;
+		}
+
+		if (metadata_some_boards.objects[1].objects[0].objects.sha256sum == NULL) {
+			LOG_ERR("SHA256 is missing from the metadata");
+			ctx.code_status = UPDATEHUB_METADATA_ERROR;
 			goto cleanup;
 		}
 


### PR DESCRIPTION
sha256sum is an optional JSON string field on a zero-initialised struct, so
a server response omitting it left the pointer NULL and strlen()
dereferenced it before the length check. Both metadata branches.

Fixes: #116895