### PR TITLE
drivers: ieee802154: harden drivers

### DIFF
--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -400,8 +400,11 @@ static inline uint8_t get_packet_length(const struct device *dev)
 static inline bool verify_rxfifo_validity(const struct device *dev,
 					  uint8_t pkt_len)
 {
-	/* packet should be at least 3 bytes as a ACK */
-	if (pkt_len < 3 ||
+	/* packet should be at least 3 bytes as a ACK and must not exceed
+	 * the IEEE 802.15.4 maximum PHY packet size; otherwise pkt_len
+	 * (radio-supplied, up to 255) would drive an oversized net_buf alloc.
+	 */
+	if (!IN_RANGE(pkt_len, 3, IEEE802154_MAX_PHY_PACKET_SIZE) ||
 	    read_reg_num_rxbytes(dev) > (pkt_len + CC1200_FCS_LEN)) {
 		return false;
 	}

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -439,7 +439,9 @@ static void ieee802154_cc13xx_cc26xx_rx_done(
 			 */
 			len = drv_data->rx_data[i][0];
 			if (len < 4U) {
-				goto next_entry;
+				LOG_WRN("Frame too short");
+				drv_data->rx_entry[i].status = DATA_ENTRY_PENDING;
+				continue;
 			}
 			sdu = drv_data->rx_data[i] + 1;
 			seq = drv_data->rx_data[i][3];
@@ -469,7 +471,6 @@ static void ieee802154_cc13xx_cc26xx_rx_done(
 				continue;
 			}
 
-next_entry:
 			drv_data->rx_entry[i].status = DATA_ENTRY_PENDING;
 
 			net_pkt_set_ieee802154_lqi(pkt, lqi);

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -433,8 +433,14 @@ static void ieee802154_cc13xx_cc26xx_rx_done(
 
 	for (int i = 0; i < CC13XX_CC26XX_NUM_RX_BUF; i++) {
 		if (drv_data->rx_entry[i].status == DATA_ENTRY_FINISHED) {
-			/* rx_data contains length, psdu, fcs, rssi, corr */
+			/* rx_data contains length, psdu, fcs, rssi, corr.
+			 * The two trailing len-- post-decrements and optional
+			 * len -= 2 underflow uint8_t when len < 4; reject early.
+			 */
 			len = drv_data->rx_data[i][0];
+			if (len < 4U) {
+				goto next_entry;
+			}
 			sdu = drv_data->rx_data[i] + 1;
 			seq = drv_data->rx_data[i][3];
 			corr = drv_data->rx_data[i][len--] & 0x3F;
@@ -463,6 +469,7 @@ static void ieee802154_cc13xx_cc26xx_rx_done(
 				continue;
 			}
 
+next_entry:
 			drv_data->rx_entry[i].status = DATA_ENTRY_PENDING;
 
 			net_pkt_set_ieee802154_lqi(pkt, lqi);

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -335,7 +335,19 @@ static void drv_rx_done(struct ieee802154_cc13xx_cc26xx_subg_data *drv_data)
 
 	for (int i = 0; i < CC13XX_CC26XX_NUM_RX_BUF; i++) {
 		if (drv_data->rx_entry[i].status == DATA_ENTRY_FINISHED) {
+			/* The length byte covers the PSDU plus the status and
+			 * RSSI bytes the RF core appends. It comes from the
+			 * air, so reject values that would underflow the two
+			 * post-decrements below, or that would let the optional
+			 * CRC append write past the receive buffer.
+			 */
 			len = drv_data->rx_data[i][0];
+			if (len < 2U || len >= CC13XX_CC26XX_RX_BUF_SIZE) {
+				LOG_WRN("Invalid frame length");
+				drv_data->rx_entry[i].status = DATA_ENTRY_PENDING;
+				continue;
+			}
+
 			sdu = drv_data->rx_data[i] + 1;
 			status = drv_data->rx_data[i][len--];
 			rssi = drv_data->rx_data[i][len--];

--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -79,6 +79,14 @@ static void ieee802154_esp32_rx_deliver(const struct ieee802154_esp32_rx_msg *rx
 	 * the end of a valid frame is replaced with RSSI and LQI values.
 	 * Zephyr L2 expects only valid frames, so checksum is not needed for a re-check.
 	 */
+	/* raw[0] is the PHR; reject a length that cannot hold the FCS before
+	 * subtracting it.
+	 */
+	if (raw[0] < IEEE802154_FCS_LENGTH) {
+		LOG_ERR("Invalid frame length %u", raw[0]);
+		return;
+	}
+
 	if (IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 		len = raw[0];
 	} else {
@@ -86,7 +94,10 @@ static void ieee802154_esp32_rx_deliver(const struct ieee802154_esp32_rx_msg *rx
 	}
 
 #ifdef CONFIG_NET_BUF_DATA_SIZE
-	__ASSERT_NO_MSG(len <= CONFIG_NET_BUF_DATA_SIZE);
+	if (len > CONFIG_NET_BUF_DATA_SIZE) {
+		LOG_ERR("Frame too long: %u", len);
+		return;
+	}
 #endif
 
 	payload = raw + 1;

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -503,6 +503,15 @@ static inline void kw41z_rx(struct kw41z_context *kw41z, uint8_t len)
 
 	LOG_DBG("ENTRY: len: %d", len);
 
+	/* The length comes from the radio's IRQSTS frame-length field. Only a
+	 * non-zero check is done at the call site, so a length below the FCS
+	 * size underflows the subtraction below.
+	 */
+	if (len < KW41Z_FCS_LENGTH) {
+		LOG_ERR("Invalid frame length %u", len);
+		return;
+	}
+
 #if defined(CONFIG_NET_L2_OPENTHREAD)
 	/*
 	 * OpenThread stack expects a receive frame to include the FCS
@@ -520,6 +529,12 @@ static inline void kw41z_rx(struct kw41z_context *kw41z, uint8_t len)
 	}
 
 	buf = pkt->buffer;
+
+	/* The copy loops below write into the first fragment only. */
+	if (net_buf_tailroom(buf) < pkt_len) {
+		LOG_ERR("Frame too long for RX buffer: %u", pkt_len);
+		goto out;
+	}
 
 #if CONFIG_SOC_MKW41Z4
 	/* PKT_BUFFER_RX needs to be accessed aligned to 16 bits */

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -563,12 +563,28 @@ static inline void mcr20a_rx(const struct device *dev, uint8_t len)
 	uint16_t rssi;
 	uint8_t lqi;
 
+	/* The frame length register carries the PHR, so mask off the reserved
+	 * bits and reject a length that cannot hold the FCS: the subtraction
+	 * below would otherwise wrap and drive an oversized FIFO read.
+	 */
+	len &= MCR20A_RX_FRM_LENGTH_MASK;
+	if (len < MCR20A_FCS_LENGTH) {
+		LOG_ERR("Invalid frame length %u", len);
+		goto out;
+	}
+
 	pkt_len = len - MCR20A_FCS_LENGTH;
 
 	pkt = net_pkt_rx_alloc_with_buffer(mcr20a->iface, pkt_len,
 					   NET_AF_UNSPEC, 0, K_NO_WAIT);
 	if (!pkt) {
 		LOG_ERR("No buf available");
+		goto out;
+	}
+
+	/* read_rxfifo_content() reads into the first fragment only. */
+	if (net_buf_tailroom(pkt->buffer) < pkt_len) {
+		LOG_ERR("Frame too long for RX buffer: %u", pkt_len);
 		goto out;
 	}
 

--- a/drivers/ieee802154/ieee802154_mcxw.c
+++ b/drivers/ieee802154/ieee802154_mcxw.c
@@ -1349,13 +1349,24 @@ phyStatus_t pd_mac_sap_handler(void *msg, instanceId_t instance)
 		set_rx_state();
 
 		mcxw_ctx.rx_ack_frame.channel = mcxw_ctx.channel;
-		mcxw_ctx.rx_ack_frame.length = data_msg->msgData.dataCnf.ackLength;
 		mcxw_ctx.rx_ack_frame.lqi = data_msg->msgData.dataCnf.ppduLinkQuality;
 		mcxw_ctx.rx_ack_frame.rssi = data_msg->msgData.dataCnf.ppduRssi;
 		mcxw_ctx.rx_ack_frame.timestamp =
 			rf_adjust_tstamp_from_phy(data_msg->msgData.dataCnf.timeStamp);
-		memcpy(mcxw_ctx.rx_ack_frame.psdu, data_msg->msgData.dataCnf.ackData,
-		       mcxw_ctx.rx_ack_frame.length);
+
+		/* ackLength is supplied by the NBU radio firmware and indexes a
+		 * fixed rx_ack_data[IEEE802154_MAX_PHY_PACKET_SIZE] buffer, so
+		 * drop an ACK that does not fit rather than copying past its
+		 * end. A zero length tells mcxw_tx() that no ACK was received.
+		 */
+		if (data_msg->msgData.dataCnf.ackLength > IEEE802154_MAX_PHY_PACKET_SIZE) {
+			LOG_ERR("Invalid ACK length %u", data_msg->msgData.dataCnf.ackLength);
+			mcxw_ctx.rx_ack_frame.length = 0;
+		} else {
+			mcxw_ctx.rx_ack_frame.length = data_msg->msgData.dataCnf.ackLength;
+			memcpy(mcxw_ctx.rx_ack_frame.psdu, data_msg->msgData.dataCnf.ackData,
+			       mcxw_ctx.rx_ack_frame.length);
+		}
 
 		waiting_ack_until_us = 0;
 		k_sem_give(&mcxw_ctx.tx_wait);

--- a/drivers/ieee802154/ieee802154_stm32wba.c
+++ b/drivers/ieee802154/ieee802154_stm32wba.c
@@ -120,6 +120,15 @@ static void stm32wba_802154_rx_thread(void *arg1, void *arg2, void *arg3)
 
 		__ASSERT_NO_MSG(rx_frame->psdu != NULL);
 
+		/* The length is supplied by the radio firmware; reject one that
+		 * cannot hold the FCS before subtracting it.
+		 */
+		if (rx_frame->length < IEEE802154_FCS_LENGTH) {
+			LOG_ERR("Invalid frame length %u", rx_frame->length);
+			rx_frame->psdu = NULL;
+			continue;
+		}
+
 		/* Depending on the net L2 layer, the FCS may be included in length or not */
 		if (IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 			pkt_len = rx_frame->length;
@@ -128,7 +137,11 @@ static void stm32wba_802154_rx_thread(void *arg1, void *arg2, void *arg3)
 		}
 
 #if defined(CONFIG_NET_BUF_DATA_SIZE)
-		__ASSERT_NO_MSG(pkt_len <= CONFIG_NET_BUF_DATA_SIZE);
+		if (pkt_len > CONFIG_NET_BUF_DATA_SIZE) {
+			LOG_ERR("Frame too long: %u", pkt_len);
+			rx_frame->psdu = NULL;
+			continue;
+		}
 #endif
 
 		LOG_DBG("Frame received - sequence nb: %u, length: %u", rx_frame->psdu[2],


### PR DESCRIPTION
- **drivers: ieee802154: kw41z: reject a frame shorter than the FCS**
- **drivers: ieee802154: mcr20a: mask and bound the received frame length**
- **drivers: ieee802154: mcxw: clamp the ACK length before copying**
- **drivers: ieee802154: stm32wba: bound the RX length at runtime**
- **drivers: ieee802154: esp32: bound the RX length at runtime**
- ...

Fixes: #116864