### PR TITLE
debug: gdbstub: fix off-by-one in bin2hex buffer size check

### DIFF
--- a/subsys/debug/gdbstub/gdbstub.c
+++ b/subsys/debug/gdbstub/gdbstub.c
@@ -140,7 +140,12 @@ bool gdb_mem_can_write(const uintptr_t addr, const size_t len, uint8_t *align)
 
 size_t gdb_bin2hex(const uint8_t *buf, size_t buflen, char *hex, size_t hexlen)
 {
-	if ((hexlen + 1) < buflen * 2) {
+	/* The loop below writes exactly 2 * buflen characters (indices
+	 * 0 .. 2*buflen-1). The previous `(hexlen + 1) < buflen * 2` check was
+	 * off by one and admitted hexlen == 2*buflen-1, writing one past the
+	 * destination.
+	 */
+	if (hexlen < buflen * 2) {
 		return 0;
 	}
 


### PR DESCRIPTION
gdb_bin2hex() rejected hexlen when (hexlen + 1) < buflen * 2, which
admitted hexlen == 2*buflen - 1. The loop writes indices 0..2*buflen-1,
so a one-byte write past the destination occurred for odd-length inputs.

Tighten the check to hexlen < buflen * 2.

Assisted-by: Claude:claude-sonnet-4-6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
