### PR TITLE
posix: net: zero-initialise the if_nameindex array

### DIFF
--- a/subsys/portability/posix/options/net.c
+++ b/subsys/portability/posix/options/net.c
@@ -138,7 +138,11 @@ struct if_nameindex *if_nameindex(void)
 
 	/* FIXME: would be nice to use this without malloc */
 	NET_IFACE_COUNT(&n);
-	ni = malloc((n + 1) * sizeof(*ni));
+	/* Zero-initialised: on an allocation failure part way through the loop
+	 * below, if_freenameindex() walks every entry and frees if_name, so the
+	 * entries not yet populated must hold NULL rather than heap garbage.
+	 */
+	ni = calloc(n + 1, sizeof(*ni));
 	if (ni == NULL) {
 		goto return_err;
 	}


### PR DESCRIPTION
if_nameindex() allocated the array with malloc() and, on an allocation
failure part way through the loop, called if_freenameindex(), which walks
every entry and frees if_name - including entries still holding
uninitialised heap data.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
