### PR TITLE
posix: mqueue: take the queue reference under the list lock

### DIFF
--- a/subsys/portability/posix/options/mqueue.c
+++ b/subsys/portability/posix/options/mqueue.c
@@ -168,7 +168,15 @@ mqd_t mq_open(const char *name, int oflags, ...)
 		k_sem_give(&mq_sem);
 
 	} else {
+		k_sem_take(&mq_sem, K_FOREVER);
+		if (find_in_list(name) != msg_queue) {
+			k_sem_give(&mq_sem);
+			errno = ENOENT;
+			goto free_mq_desc;
+		}
+
 		atomic_inc(&msg_queue->ref_count);
+		k_sem_give(&mq_sem);
 	}
 
 	msg_queue_desc->mqueue = msg_queue;


### PR DESCRIPTION
mq_open() looked the queue up under mq_sem, released it, and only then
incremented ref_count, so a concurrent mq_close()/mq_unlink() could remove
and free the object in that window - a use-after-free on the increment.

Re-confirm the queue is still linked and take the reference without
dropping the lock.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
