### PR TITLE
arch: arm64: fix DAIF restore on arch_buffer_validate() wrap path

### DIFF
--- a/arch/arm64/core/userspace.S
+++ b/arch/arm64/core/userspace.S
@@ -57,9 +57,9 @@ strlen_done:
 GTEXT(arch_buffer_validate)
 SECTION_FUNC(TEXT, arch_buffer_validate)
 
+	mrs	x3, DAIF
 	adds	x1, x1, x0
 	b.cs	abv_fail
-	mrs	x3, DAIF
 	msr	DAIFSET, #DAIFSET_IRQ_BIT
 
 abv_loop:


### PR DESCRIPTION
Commit 0b2a2850ff59 ("arch: arm64: fix arch_buffer_validate() wrap bypass") added an addr+size overflow guard that branches to the shared abv_fail epilogue before x3 is loaded with the current DAIF value. On that path abv_fail executes "msr DAIF, x3" with an uninitialized register, so a wrapping buffer validation returns -1 with arbitrary DAIF bits (IRQ/FIQ/SError/Debug masks) set or cleared from whatever the caller happened to leave in x3.

Save DAIF into x3 before the overflow check so that every exit from abv_fail restores the value the function was entered with.

Fixes #115141