### PR TITLE
arch: arm64: mmu: fix arch_virt_region_align() for large regions

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1258,8 +1258,8 @@ size_t arch_virt_region_align(uintptr_t phys, size_t size)
 	size_t level_size;
 	int level;
 
-	for (level = XLAT_LAST_LEVEL; level >= BASE_XLAT_LEVEL; level--) {
-		level_size = 1 << LEVEL_TO_VA_SIZE_SHIFT(level);
+	for (level = XLAT_LAST_LEVEL; level >= (int)BASE_XLAT_LEVEL; level--) {
+		level_size = 1ULL << LEVEL_TO_VA_SIZE_SHIFT(level);
 
 		if (size < level_size) {
 			break;


### PR DESCRIPTION
The alignment loop computes level_size with a 32-bit "1 <<" shift, which is undefined behavior once the shift count reaches 32 (level 0 with 4KB granule, level 1 with 16KB/64KB granule). It also compares int level against the unsigned BASE_XLAT_LEVEL, so with base level 0 the loop never terminates at level 0 and runs into negative levels, leaving garbage in the returned alignment. Use 1ULL and cast the bound to int.

The garbage alignment feeds virt_region_alloc(), which can under-reserve the VA bitmap for large mappings.

Fixes #115139