### PR TITLE
drivers: virtio: fix virtio_mmio_reset() wait loop

### DIFF
--- a/drivers/virtio/virtio_mmio.c
+++ b/drivers/virtio/virtio_mmio.c
@@ -174,7 +174,7 @@ static void virtio_mmio_reset(const struct device *dev)
 {
 	virtio_mmio_write32(dev, VIRTIO_MMIO_STATUS, 0);
 
-	while (virtio_mmio_read_status_bit(dev, VIRTIO_MMIO_STATUS) != 0) {
+	while (virtio_mmio_read32(dev, VIRTIO_MMIO_STATUS) != 0) {
 	}
 }
 


### PR DESCRIPTION
virtio_mmio_reset() passes VIRTIO_MMIO_STATUS to
virtio_mmio_read_status_bit(), but that macro is the register offset (0x70 = 112), not a bit number. The loop condition therefore evaluates read32(STATUS) & BIT(112), which is always 0, so the driver never actually waits for the device to complete the reset (and BIT(112) is shift-count-overflow UB on 32-bit platforms).

Poll the status register value instead, as required by the virtio specification (4.2.2: after writing 0 to Status, the driver must wait until it reads back 0).

Fixes #115149