### PR TITLE
drivers: virtio: accumulate MMIO driver feature bits in a shadow

### DIFF
--- a/drivers/virtio/virtio_mmio.c
+++ b/drivers/virtio/virtio_mmio.c
@@ -22,6 +22,9 @@ LOG_MODULE_REGISTER(virtio_mmio, CONFIG_VIRTIO_LOG_LEVEL);
 #define VIRTIO_MMIO_SUPPORTED_VERSION 2
 #define VIRTIO_MMIO_INVALID_DEVICE_ID 0
 
+/* number of 32-bit words needed to hold all negotiable feature bits */
+#define VIRTIO_MMIO_FEATURE_WORDS (DEV_TYPE_FEAT_RANGE_1_END / 32 + 1)
+
 #define DEV_CFG(dev)  ((const struct virtio_mmio_config *)(dev)->config)
 #define DEV_DATA(dev) ((struct virtio_mmio_data *)(dev)->data)
 
@@ -30,6 +33,9 @@ struct virtio_mmio_data {
 
 	struct virtq *virtqueues;
 	uint16_t virtqueue_count;
+
+	/* shadow of the write-only DRIVER_FEATURES register */
+	uint32_t driver_features[VIRTIO_MMIO_FEATURE_WORDS];
 
 	struct k_spinlock isr_lock;
 	struct k_spinlock notify_lock;
@@ -119,17 +125,24 @@ static bool virtio_mmio_read_device_feature_bit(const struct device *dev, int bi
 
 static void virtio_mmio_write_driver_feature_bit(const struct device *dev, int bit, bool value)
 {
-	const uint32_t mask = sys_cpu_to_le32(BIT(bit % 32));
+	struct virtio_mmio_data *data = dev->data;
+	const uint32_t word_n = bit / 32;
+	const uint32_t mask = BIT(bit % 32);
 
-	virtio_mmio_write32(dev, VIRTIO_MMIO_DRIVER_FEATURES_SEL, bit / 32);
-
-	const uint32_t regval = virtio_mmio_read32(dev, VIRTIO_MMIO_DRIVER_FEATURES);
-
+	/*
+	 * DRIVER_FEATURES is a write-only register (see spec 4.2.2.2), so the
+	 * feature bits have to be accumulated in a driver-side shadow and
+	 * written as complete words; a read-modify-write of the register
+	 * would erase every bit previously written to the same word.
+	 */
 	if (value) {
-		virtio_mmio_write32(dev, VIRTIO_MMIO_DRIVER_FEATURES, regval | mask);
+		data->driver_features[word_n] |= mask;
 	} else {
-		virtio_mmio_write32(dev, VIRTIO_MMIO_DRIVER_FEATURES, regval & ~mask);
+		data->driver_features[word_n] &= ~mask;
 	}
+
+	virtio_mmio_write32(dev, VIRTIO_MMIO_DRIVER_FEATURES_SEL, word_n);
+	virtio_mmio_write32(dev, VIRTIO_MMIO_DRIVER_FEATURES, data->driver_features[word_n]);
 }
 
 static bool virtio_mmio_read_status_bit(const struct device *dev, int bit)


### PR DESCRIPTION
DRIVER_FEATURES is a write-only register per the virtio specification (4.2.2.2), but virtio_mmio_write_driver_feature_bit() did a read-modify-write on it. Reads return 0, so every call only ever wrote the single current mask bit and erased all feature bits previously written to the same 32-bit word -- e.g. a device driver negotiating a feature bit in word 1 (bits 33..63) silently dropped VIRTIO_F_VERSION_1 set during transport init.

Accumulate the feature bits in a per-device shadow and write complete words instead. This also drops the sys_cpu_to_le32() applied to the mask, which was wrong because virtio_mmio_write32() already performs the conversion (a no-op on little-endian hosts, corruption on big-endian ones).

Fixes #115150