### PR TITLE
AMD: ZynqMP / Versal RPU: find timer TTC node via compatible

### DIFF
--- a/dts/bindings/test/vnd,gpio.yaml
+++ b/dts/bindings/test/vnd,gpio.yaml
@@ -11,6 +11,9 @@ properties:
   reg:
     required: true
 
+  clock-frequency:
+    type: int
+
   "#gpio-cells":
     const: 2
 

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -835,6 +835,25 @@ def dt_compat_enabled_num(kconf, _, compat):
 
     return str(len(edt.compat2okay[compat]))
 
+def dt_compat_int_prop(kconf, name, compat, prop, unit=None):
+    """
+    Return an integer property from the first enabled node matching 'compat'
+    as either a decimal or hexadecimal string. If no enabled matching node has
+    the property, return zero in the requested format.
+    """
+    if doc_mode or edt is None:
+        value = 0
+    else:
+        value = 0
+        for node in edt.compat2okay.get(compat, []):
+            if prop in node.props:
+                value = _node_int_prop(node, prop, unit)
+                break
+
+    if name == "dt_compat_int_prop_int":
+        return str(value)
+    if name == "dt_compat_int_prop_hex":
+        return hex(value)
 
 def dt_compat_on_bus(kconf, _, compat, bus):
     """
@@ -1276,6 +1295,8 @@ functions = {
         "dt_has_compat": (dt_has_compat, 1, 1),
         "dt_compat_enabled": (dt_compat_enabled, 1, 1),
         "dt_compat_enabled_num": (dt_compat_enabled_num, 1, 1),
+        "dt_compat_int_prop_int": (dt_compat_int_prop, 2, 3),
+        "dt_compat_int_prop_hex": (dt_compat_int_prop, 2, 3),
         "dt_compat_on_bus": (dt_compat_on_bus, 2, 2),
         "dt_compat_all_has_prop": (dt_compat_all_has_prop, 2, 3),
         "dt_compat_any_has_prop": (dt_compat_any_has_prop, 2, 3),

--- a/soc/xlnx/versal/Kconfig.defconfig
+++ b/soc/xlnx/versal/Kconfig.defconfig
@@ -8,6 +8,8 @@ if SOC_AMD_VERSAL
 
 if SOC_VERSAL_RPU
 
+DT_COMPAT_XLNX_TTCPS := xlnx,ttcps
+
 config CACHE_MANAGEMENT
 	default y
 
@@ -17,7 +19,7 @@ config NUM_IRQS
 	default 256
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_nodelabel_int_prop,ttc0,clock-frequency)
+	default $(dt_compat_int_prop_int,$(DT_COMPAT_XLNX_TTCPS),clock-frequency)
 
 endif # SOC_VERSAL_RPU
 

--- a/soc/xlnx/zynqmp/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp/Kconfig.defconfig
@@ -6,13 +6,15 @@ if SOC_XILINX_ZYNQMP
 
 if SOC_XILINX_ZYNQMP_RPU
 
+DT_COMPAT_XLNX_TTCPS := xlnx,ttcps
+
 config NUM_IRQS
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts
 	default 220
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_nodelabel_int_prop,ttc0,clock-frequency)
+	default $(dt_compat_int_prop_int,$(DT_COMPAT_XLNX_TTCPS),clock-frequency)
 
 endif # SOC_XILINX_ZYNQMP_RPU
 

--- a/tests/kconfig/functions/Kconfig
+++ b/tests/kconfig/functions/Kconfig
@@ -123,6 +123,28 @@ config KCONFIG_VND_GPIO_ENABLED_NUM_4
 	int
 	default $(dt_compat_enabled_num,$(DT_COMPAT_VND_GPIO))
 
+config KCONFIG_VND_GPIO_CLOCK_FREQUENCY_INT
+	int
+	default $(dt_compat_int_prop_int,$(DT_COMPAT_VND_GPIO),clock-frequency)
+
+config KCONFIG_VND_GPIO_CLOCK_FREQUENCY_HEX
+	hex
+	default $(dt_compat_int_prop_hex,$(DT_COMPAT_VND_GPIO),clock-frequency)
+
+config KCONFIG_VND_GPIO_CLOCK_FREQUENCY_KIB
+	int
+	default $(dt_compat_int_prop_int,$(DT_COMPAT_VND_GPIO),clock-frequency,k)
+
+DT_COMPAT_VND_MISSING := vnd,missing
+
+config KCONFIG_MISSING_COMPAT_INT_PROP
+	int
+	default $(dt_compat_int_prop_int,$(DT_COMPAT_VND_MISSING),clock-frequency)
+
+config KCONFIG_MISSING_COMPAT_HEX_PROP
+	hex
+	default $(dt_compat_int_prop_hex,$(DT_COMPAT_VND_MISSING),clock-frequency)
+
 DT_COMPAT_VND_CAN_CONTROLLER := vnd,can-controller
 
 config KCONFIG_VND_CAN_CONTROLLER_ENABLED_NUM_2

--- a/tests/kconfig/functions/app.overlay
+++ b/tests/kconfig/functions/app.overlay
@@ -12,6 +12,7 @@
 		test_gpio_0: gpio@1000 {
 			compatible = "vnd,gpio";
 			reg = <0x1000 0x1000>;
+			clock-frequency = <1048576>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			status = "okay";

--- a/tests/kconfig/functions/src/main.c
+++ b/tests/kconfig/functions/src/main.c
@@ -59,6 +59,15 @@ ZTEST(test_kconfig_functions, test_dt_num_compat_enabled)
 	zassert_equal(CONFIG_KCONFIG_VND_PWM_ENABLED_NUM_0, 0);
 }
 
+ZTEST(test_kconfig_functions, test_dt_compat_int_prop)
+{
+	zassert_equal(CONFIG_KCONFIG_VND_GPIO_CLOCK_FREQUENCY_INT, 1048576);
+	zassert_equal(CONFIG_KCONFIG_VND_GPIO_CLOCK_FREQUENCY_HEX, 0x100000);
+	zassert_equal(CONFIG_KCONFIG_VND_GPIO_CLOCK_FREQUENCY_KIB, 1024);
+	zassert_equal(CONFIG_KCONFIG_MISSING_COMPAT_INT_PROP, 0);
+	zassert_equal(CONFIG_KCONFIG_MISSING_COMPAT_HEX_PROP, 0x0);
+}
+
 ZTEST(test_kconfig_functions, test_dt_partition_mtd)
 {
 	zassert_str_equal(CONFIG_KCONFIG_DT_MTD_DUMMY_0, CONFIG_KCONFIG_DT_DUMMY_FLASH_PATH);


### PR DESCRIPTION
presently TTC is used for timer for zynqmp and versal timer.

it looks for ttc0 name.

instead search via compatible string.