### PR TITLE
Enable MCPWM support for ESP32-C5-DevKitC-1

### DIFF
--- a/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore-pinctrl.dtsi
+++ b/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore-pinctrl.dtsi
@@ -73,4 +73,11 @@
 			pinmux = <RMT_IN0_GPIO12>;
 		};
 	};
+
+	mcpwm0_default: mcpwm0_default {
+		group1 {
+			pinmux = <MCPWM0_OUT0A_GPIO26>;
+			output-enable;
+		};
+	};
 };

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -123,7 +123,8 @@ static void mcpwm_esp32_duty_set(const struct device *dev,
 		duty_mode = channel->inverted ? DUTY_MODE_ACTIVE_LOW : DUTY_MODE_ACTIVE_HIGH;
 	}
 
-	uint32_t timer_clk_hz = data->mcpwm_clk_hz / config->prescale / channel->prescale;
+	uint32_t timer_clk_hz =
+		data->mcpwm_clk_hz / (config->prescale + 1) / (channel->prescale + 1);
 
 	set_duty = (timer_clk_hz / channel->freq) * channel->duty / 100;
 	mcpwm_ll_operator_connect_timer(data->hal.dev, channel->operator_id, channel->timer_id);
@@ -183,11 +184,16 @@ static int mcpwm_esp32_timer_set(const struct device *dev,
 
 	__ASSERT_NO_MSG(channel->freq > 0);
 
-	mcpwm_ll_timer_set_clock_prescale(data->hal.dev, channel->timer_id, channel->prescale);
+	mcpwm_ll_timer_set_clock_prescale(data->hal.dev, channel->timer_id, channel->prescale + 1);
 	mcpwm_ll_timer_set_count_mode(data->hal.dev, channel->timer_id, MCPWM_TIMER_COUNT_MODE_UP);
 	mcpwm_ll_timer_update_period_at_once(data->hal.dev, channel->timer_id);
 
-	uint32_t timer_clk_hz = data->mcpwm_clk_hz / config->prescale / channel->prescale;
+	uint32_t timer_clk_hz =
+		data->mcpwm_clk_hz / (config->prescale + 1) / (channel->prescale + 1);
+	if ((timer_clk_hz / channel->freq) > 65536U) {
+		LOG_ERR("Period too large for timer %d", channel->timer_id);
+		return -ENOTSUP;
+	}
 
 	mcpwm_ll_timer_set_peak(data->hal.dev, channel->timer_id, timer_clk_hz / channel->freq,
 				false);
@@ -241,6 +247,9 @@ static int mcpwm_esp32_set_cycles(const struct device *dev, uint32_t channel_idx
 
 	/* Update PWM frequency according to period_cycles */
 	mcpwm_esp32_get_cycles_per_sec(dev, channel_idx, &clk_freq);
+	if (period_cycles == 0U) {
+		return -EINVAL;
+	}
 
 	channel->freq = (uint32_t)(clk_freq / period_cycles);
 	if (!channel->freq) {
@@ -360,7 +369,7 @@ static int mcpwm_esp32_enable_capture(const struct device *dev, uint32_t channel
 		return -EBUSY;
 	}
 
-	mcpwm_ll_group_set_clock_prescale(config->index, config->prescale);
+	mcpwm_ll_group_set_clock_prescale(config->index, config->prescale + 1);
 	mcpwm_ll_group_enable_shadow_mode(data->hal.dev);
 	mcpwm_ll_group_flush_shadow(data->hal.dev);
 
@@ -520,7 +529,7 @@ int mcpwm_esp32_init(const struct device *dev)
 
 	channel_init(dev);
 
-	mcpwm_ll_group_set_clock_prescale(config->index, config->prescale);
+	mcpwm_ll_group_set_clock_prescale(config->index, config->prescale + 1);
 	mcpwm_ll_group_enable_shadow_mode(data->hal.dev);
 	mcpwm_ll_group_flush_shadow(data->hal.dev);
 

--- a/samples/basic/servo_motor/boards/esp32c5_devkitc_hpcore.overlay
+++ b/samples/basic/servo_motor/boards/esp32c5_devkitc_hpcore.overlay
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2026 Hayashi Takuma */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	servo: servo {
+		compatible = "pwm-servo";
+		pwms = <&mcpwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		min-pulse = <PWM_USEC(1450)>;
+		max-pulse = <PWM_USEC(2400)>;
+	};
+};
+
+&mcpwm0 {
+	pinctrl-0 = <&mcpwm0_default>;
+	pinctrl-names = "default";
+	prescale = <0>;
+	prescale-timer0 = <255>;
+	status = "okay";
+};


### PR DESCRIPTION
1. drivers: pwm: esp32: fix MCPWM prescaler values

The ESP32-C5 MCPWM prescaler registers store the programmed prescaler value minus one.

Increment the group and timer prescaler values before passing them to the ESP HAL low-level functions. Without this adjustment, the generated PWM frequency differs from the requested frequency.

Tested on ESP32-C5-DevKitC-1 using the servo_motor sample. The measured output on GPIO26 was 50 Hz with a period of 20 ms.

2. boards: espressif: esp32c5_devkitc: enable MCPWM

Add the MCPWM0 output pin configuration for the ESP32-C5-DevKitC-1 and route MCPWM0 operator 0 output A to GPIO26.

Add a board overlay for the servo_motor sample so that MCPWM0 and its pin configuration are enabled when building the sample.

The sample was built and flashed on the hpcore target. An oscilloscope connected to GPIO26 measured a 50 Hz PWM waveform with a period of 20 ms.