### PR TITLE
sys: sflist: guarantee node alignment for flag bits

### DIFF
--- a/include/zephyr/sys/sflist.h
+++ b/include/zephyr/sys/sflist.h
@@ -38,9 +38,14 @@ extern "C" {
 #endif
 
 /** @cond INTERNAL_HIDDEN */
+/*
+ * Flag bits are stored in the low bits of the node address, so a node must be
+ * aligned to at least 4 bytes. Not every ABI gives uintptr_t that alignment
+ * naturally, so require it explicitly. See SYS_SFLIST_FLAGS_MASK below.
+ */
 struct _sfnode {
 	uintptr_t next_and_flags;
-};
+} __aligned(sizeof(void *));
 /** @endcond */
 
 /** Flagged single-linked list node structure. */


### PR DESCRIPTION
`struct _sfnode` is the node type used by Zephyr's singly linked list with per-node flags. A conventional representation would store the next-node pointer and the flags in separate fields. In contrast, `struct _sfnode` combines the next-node pointer and the flags in one pointer-sized word. It stores the flags in low pointer bits made available by node alignment. Two available flag bits therefore require node alignment of at least four bytes.

#71629 made the flag mask follow the node's actual alignment. During review, it also gained a `BUILD_ASSERT` requiring at least two available bits. The `BUILD_ASSERT` enforced the rule; the definition of `struct _sfnode`, however, did not guarantee that the rule would hold. Indeed, the node still inherited whatever natural alignment the ABI gave to `uintptr_t`.

The ABIs used by all currently supported targets provide enough natural alignment, so the rule holds incidentally on those targets. The definition of `struct _sfnode` does not guarantee it.

The m68k port discussed in #114672 exposed this limitation. Its pointers are four bytes wide, but their natural alignment is only two bytes. The mask therefore offers one flag bit. The `BUILD_ASSERT` demands two. The build stops.

Align the node to `sizeof(void *)`. The rule now lives in the type that needs it.

`sizeof(void *)` is deliberate. The spare bits come from the alignment of a node address; `uintptr_t` is the pointer-holding unsigned integer type, not a pointer type itself. Therefore, using `sizeof(void *)` ties the alignment directly to the pointers whose low bits are reused, thereby expressing the intent more precisely than `sizeof(uintptr_t)`.

This preserves the existing 32-bit and 64-bit flag behavior and leaves platforms that already provide pointer-size alignment unchanged.
