### PR TITLE
boards: seeed: xiao_nrf54lm20a: commit RRAM write-buffer after flash load

### DIFF
--- a/boards/seeed/xiao_nrf54lm20a/support/openocd.cfg
+++ b/boards/seeed/xiao_nrf54lm20a/support/openocd.cfg
@@ -66,6 +66,12 @@ if {![using_hla]} {
 proc nrf54lm20a-load {file} {
     mww 0x5004e500 0x101
 	load_image $file
+	# Flush the RRAM controller's internal write-buffer. load_image leaves the
+	# final (partial) 128-bit write line uncommitted, so without this the last
+	# ~16 bytes of the image are not programmed -- which silently corrupts
+	# whatever data lands at the tail of the image (e.g. net_buf pool pointers).
+	# RRAMC.TASKS_COMMITWRITEBUF @ 0x5004e008.
+	mww 0x5004e008 1
 }
 
 # Define CTRL_AP_NUM explicitly to avoid variable errors


### PR DESCRIPTION
The `nrf54lm20a-load` OpenOCD proc (`boards/seeed/xiao_nrf54lm20a/support/openocd.cfg`) flashes with `load_image` but never commits the RRAM controller's internal write-buffer. The final (partial) 128-bit write line is left uncommitted, so **the last ~16 bytes of the flashed image are never programmed**.

Whatever data lands at the tail of the image is silently corrupted. In one observed case (a Zephyr HCI controller build), the tail held `net_buf` pool structs at the end of the initialized-data region, so `hci_rx_pool`'s `alloc`/`__bufs` pointers were left NULL. The controller then took a MemManage fault (data access near address `0x0`) when allocating an event buffer to answer the first received HCI command -- presenting as a controller that is simply "silent," with no obvious cause. It's layout-sensitive, so unrelated config changes (e.g. enabling `CONFIG_LOG`) can appear to "fix" or "break" it by shifting what lands in the dropped tail.

## Fix

Trigger `RRAMC.TASKS_COMMITWRITEBUF` (`0x5004e008`) after `load_image` to flush the write-buffer so the final line is programmed. Register offsets per the nRF54LM20A MDK (`RRAMC` base `0x5004e000`, `TASKS_COMMITWRITEBUF` @ `0x008`).

This is the same fix as Seeed's own out-of-tree copy of this board (Seeed-Studio/platform-seeedboards#59) -- porting it here since this in-tree board file still has the bug.

## Testing

Verified locally against this board (real hardware, XIAO nRF54LM20A):
- Forced the image tail to a known-wrong value and reproduced the drop: `load_image` without the commit left the tail unchanged.
- With this change, `west flash` programs the tail to exactly match the built hex, byte for byte.
- Firmware covering several peripherals (I2C sensor, GPIO, logging/console) runs correctly across resets with this fix applied.

Note: I separately have an open, *unresolved* issue with BLE advertising never being detected by a scanner on this same board, with and without this fix applied (Seeed-Studio/platform-seeedboards#65) -- unrelated as far as I can tell (this fix only affects the fixed tail bytes of whatever image is flashed, and the BLE symptom is present independent of what's at the tail), but flagging it here in case it turns out to matter.
