### PR TITLE
MAINTAINERS: rm inactive collaborator pin-zephyr

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -591,7 +591,6 @@ Bluetooth Audio:
     - asbjornsabo
     - fredrikdanebjer
     - larsgk
-    - pin-zephyr
     - niym-ot
     - jthm-ot
     - alexsven


### PR DESCRIPTION
pin-zephyr is inactive as a collaborator for LE Audio.