### PR TITLE
drivers: pcie: endpoint: add zephyr,pcie-ep-emul endpoint emulator

### DIFF
--- a/drivers/dma/Kconfig.emul
+++ b/drivers/dma/Kconfig.emul
@@ -7,3 +7,15 @@ config DMA_EMUL
 	select EXPERIMENTAL
 	help
 	  Emulated DMA Driver
+
+if DMA_EMUL
+
+# Transfer addresses are native pointers; on 64-bit targets the
+# dma_block_config address fields must be 64 bits wide. The driver
+# hard-asserts this at build time, so the default is safe to override:
+# forcing it off fails the build instead of truncating addresses.
+config DMA_64BIT
+	default y
+	depends on 64BIT
+
+endif # DMA_EMUL

--- a/drivers/dma/Kconfig.emul
+++ b/drivers/dma/Kconfig.emul
@@ -4,6 +4,11 @@
 config DMA_EMUL
 	bool "Emulated DMA driver [EXPERIMENTAL]"
 	depends on DT_HAS_ZEPHYR_DMA_EMUL_ENABLED
+	# Transfer addresses are native pointers; on 64-bit targets the
+	# dma_block_config address fields must be 64 bits wide. Imply rather
+	# than select so an explicit CONFIG_DMA_64BIT=n override is honored
+	# and caught by the BUILD_ASSERT in dma_emul.c.
+	imply DMA_64BIT if 64BIT
 	select EXPERIMENTAL
 	help
 	  Emulated DMA Driver

--- a/drivers/dma/dma_emul.c
+++ b/drivers/dma/dma_emul.c
@@ -23,6 +23,16 @@ typedef uint64_t dma_addr_t;
 typedef uint32_t dma_addr_t;
 #endif
 
+/*
+ * Transfer addresses are native pointers; on 64-bit targets they only
+ * survive the dma_block_config fields when those are 64 bits wide.
+ * Kconfig only implies DMA_64BIT on 64-bit targets, so an explicit
+ * CONFIG_DMA_64BIT=n override is honored; assert the width here so
+ * such a truncated build fails loudly instead of silently.
+ */
+BUILD_ASSERT(!IS_ENABLED(CONFIG_64BIT) || IS_ENABLED(CONFIG_DMA_64BIT),
+	     "dma_emul requires CONFIG_DMA_64BIT=y on 64-bit targets");
+
 enum dma_emul_channel_state {
 	DMA_EMUL_CHANNEL_UNUSED,
 	DMA_EMUL_CHANNEL_LOADED,
@@ -56,6 +66,8 @@ struct dma_emul_config {
 	struct dma_emul_xfer_desc *xfer;
 	/* points to an array of size num_channels * num_requests */
 	struct dma_block_config *block;
+	/* points to an array of size num_channels */
+	struct dma_emul_work *work;
 };
 
 struct dma_emul_data {
@@ -63,7 +75,15 @@ struct dma_emul_data {
 	atomic_t *channels_atomic;
 	struct k_spinlock lock;
 	struct k_work_q work_q;
-	struct dma_emul_work work;
+	/*
+	 * Bitmask of channels with a transfer in flight: set by
+	 * dma_emul_start() for every channel of the chain and cleared by the
+	 * work handler only once it has finished (or acknowledged the
+	 * cancellation of) that channel. The channel state alone cannot
+	 * express this: dma_emul_stop() sets STOPPED immediately while the
+	 * work handler may still be walking the channel's chain.
+	 */
+	uint32_t busy_channels;
 };
 
 static void dma_emul_work_handler(struct k_work *work);
@@ -113,6 +133,19 @@ static void dma_emul_set_channel_state(const struct device *dev, uint32_t channe
 	__ASSERT_NO_MSG(state >= DMA_EMUL_CHANNEL_UNUSED && state <= DMA_EMUL_CHANNEL_STOPPED);
 
 	config->xfer[channel].config._reserved = state;
+}
+
+/*
+ * Note: must be called with data->lock locked!
+ */
+static bool dma_emul_channel_busy(const struct device *dev, uint32_t channel)
+{
+	const struct dma_emul_config *config = dev->config;
+	struct dma_emul_data *data = dev->data;
+
+	__ASSERT_NO_MSG(channel < config->num_channels);
+
+	return (data->busy_channels & BIT(channel)) != 0U;
 }
 
 static const char *dma_emul_xfer_config_to_string(const struct dma_config *cfg)
@@ -193,6 +226,8 @@ static void dma_emul_work_handler(struct k_work *work)
 	size_t i;
 	size_t bytes;
 	uint32_t channel;
+	uint32_t next;
+	uint32_t visited;
 	k_spinlock_key_t key;
 	struct dma_block_config block;
 	struct dma_config xfer_config;
@@ -243,6 +278,37 @@ static void dma_emul_work_handler(struct k_work *work)
 
 				if (state == DMA_EMUL_CHANNEL_STOPPED) {
 					LOG_DBG("asynchronously canceled");
+					key = k_spin_lock(&data->lock);
+					/*
+					 * Acknowledge the cancellation: this channel
+					 * is no longer busy, and neither is the rest
+					 * of the chain, which will never run now.
+					 * Reset the downstream links to STOPPED too,
+					 * so the whole chain is restartable once the
+					 * handler returns. The chain topology cannot
+					 * change while any of its channels is busy,
+					 * so walking it here is safe.
+					 */
+					data->busy_channels &= ~BIT(channel);
+					next = channel;
+					visited = BIT(channel);
+					while (config->xfer[next].config.source_chaining_en ||
+					       config->xfer[next].config.dest_chaining_en) {
+						next = config->xfer[next].config.linked_channel;
+						/*
+						 * The chain was validated cycle-free at start
+						 * time and its topology is frozen while busy;
+						 * assert anyway so a corrupt chain cannot
+						 * loop forever with interrupts off.
+						 */
+						__ASSERT_NO_MSG(next < config->num_channels &&
+								(visited & BIT(next)) == 0U);
+						visited |= BIT(next);
+						dma_emul_set_channel_state(
+							dev, next, DMA_EMUL_CHANNEL_STOPPED);
+						data->busy_channels &= ~BIT(next);
+					}
+					k_spin_unlock(&data->lock, key);
 					if (!xfer_config.error_callback_dis) {
 						xfer_config.dma_callback(dev, xfer_config.user_data,
 									 channel, -ECANCELED);
@@ -266,6 +332,7 @@ static void dma_emul_work_handler(struct k_work *work)
 
 		key = k_spin_lock(&data->lock);
 		dma_emul_set_channel_state(dev, channel, DMA_EMUL_CHANNEL_STOPPED);
+		data->busy_channels &= ~BIT(channel);
 		k_spin_unlock(&data->lock, key);
 
 		/* FIXME: tests/drivers/dma/chan_blen_transfer/ does not set complete_callback_en */
@@ -305,6 +372,14 @@ static bool dma_emul_config_valid(const struct device *dev, uint32_t channel,
 
 	if (channel >= config->num_channels) {
 		LOG_ERR("invalid DMA channel %u", channel);
+		return false;
+	}
+
+	if ((xfer_config->source_chaining_en || xfer_config->dest_chaining_en) &&
+	    (xfer_config->linked_channel >= config->num_channels ||
+	     xfer_config->linked_channel == channel)) {
+		LOG_ERR("invalid linked_channel %u for channel %u", xfer_config->linked_channel,
+			channel);
 		return false;
 	}
 
@@ -370,6 +445,19 @@ static int dma_emul_configure(const struct device *dev, uint32_t channel,
 	switch (state) {
 	case DMA_EMUL_CHANNEL_UNUSED:
 	case DMA_EMUL_CHANNEL_STOPPED:
+		if (dma_emul_channel_busy(dev, channel)) {
+			/*
+			 * A stop was requested but the work handler has not
+			 * acknowledged the cancellation yet: reconfiguring
+			 * now would make the in-flight handler invoke the
+			 * new configuration's callback for a transfer that
+			 * was never started.
+			 */
+			LOG_ERR("attempt to configure DMA channel %u while cancel in flight",
+				channel);
+			ret = -EBUSY;
+			break;
+		}
 		/* copy the configuration into the driver */
 		memcpy(&xfer->config, xfer_config, sizeof(xfer->config));
 
@@ -406,6 +494,8 @@ static int dma_emul_start(const struct device *dev, uint32_t channel)
 {
 	int ret = 0;
 	k_spinlock_key_t key;
+	uint32_t first_channel = channel;
+	uint32_t visited;
 	enum dma_emul_channel_state state;
 	struct dma_emul_xfer_desc *xfer;
 	struct dma_config *xfer_config;
@@ -427,9 +517,68 @@ static int dma_emul_start(const struct device *dev, uint32_t channel)
 		break;
 	case DMA_EMUL_CHANNEL_LOADED:
 	case DMA_EMUL_CHANNEL_STOPPED:
-		data->work.channel = channel;
+		if (dma_emul_channel_busy(dev, channel)) {
+			/*
+			 * dma_emul_stop() was requested but the work handler
+			 * has not acknowledged the cancellation yet.
+			 */
+			LOG_ERR("channel %u cancel still in flight", channel);
+			ret = -EBUSY;
+			break;
+		}
+		/*
+		 * Walk the linked-channel chain once without changing any
+		 * state: dma_emul_config_valid() bounds-checks each single
+		 * link, but a cycle spanning several channels would loop
+		 * forever here with interrupts off. A revisited channel
+		 * proves a cycle (num_channels <= 32, so the mask can hold
+		 * every channel). Each link target must also be configured
+		 * and idle: the work handler asserts on STARTED while it
+		 * walks the chain, so a target that is still running its
+		 * own work would trip that assertion, and an unconfigured
+		 * target would be processed with an empty configuration.
+		 * STOPPED alone does not prove idle: dma_emul_stop() sets it
+		 * immediately while the work handler acknowledges the cancel
+		 * asynchronously, so a target whose transfer is still in
+		 * flight (busy) is rejected as well.
+		 */
+		visited = BIT(channel);
+		while (true) {
+			xfer_config = &config->xfer[channel].config;
+			if (!(xfer_config->source_chaining_en || xfer_config->dest_chaining_en)) {
+				break;
+			}
+			if (xfer_config->linked_channel >= config->num_channels ||
+			    (visited & BIT(xfer_config->linked_channel)) != 0U) {
+				LOG_ERR("invalid linked channel chain at channel %u", channel);
+				ret = -EINVAL;
+				break;
+			}
+			state = dma_emul_get_channel_state(dev, xfer_config->linked_channel);
+			if (state != DMA_EMUL_CHANNEL_LOADED && state != DMA_EMUL_CHANNEL_STOPPED) {
+				LOG_ERR("linked channel %u is not configured and idle (state %d)",
+					xfer_config->linked_channel, state);
+				ret = -EINVAL;
+				break;
+			}
+			if (dma_emul_channel_busy(dev, xfer_config->linked_channel)) {
+				LOG_ERR("linked channel %u cancel still in flight",
+					xfer_config->linked_channel);
+				ret = -EBUSY;
+				break;
+			}
+			visited |= BIT(xfer_config->linked_channel);
+			channel = xfer_config->linked_channel;
+		}
+
+		if (ret != 0) {
+			break;
+		}
+
+		channel = first_channel;
 		while (true) {
 			dma_emul_set_channel_state(dev, channel, DMA_EMUL_CHANNEL_STARTED);
+			data->busy_channels |= BIT(channel);
 
 			xfer_config = &config->xfer[channel].config;
 			if (xfer_config->source_chaining_en || xfer_config->dest_chaining_en) {
@@ -440,7 +589,7 @@ static int dma_emul_start(const struct device *dev, uint32_t channel)
 				break;
 			}
 		}
-		ret = k_work_submit_to_queue(&data->work_q, &data->work.work);
+		ret = k_work_submit_to_queue(&data->work_q, &config->work[first_channel].work);
 		ret = (ret < 0) ? ret : 0;
 		break;
 	default:
@@ -459,7 +608,17 @@ static int dma_emul_stop(const struct device *dev, uint32_t channel)
 	struct dma_emul_data *data = dev->data;
 
 	key = k_spin_lock(&data->lock);
-	dma_emul_set_channel_state(dev, channel, DMA_EMUL_CHANNEL_STOPPED);
+	/*
+	 * Stopping a channel that was never configured is a successful
+	 * no-op, like stopping an already stopped channel. Do not mark it
+	 * STOPPED though: the chain validation in dma_emul_start() accepts
+	 * STOPPED targets, so a stopped-but-never-configured channel would
+	 * be processed with the zero-initialized configuration and its
+	 * NULL dma_callback.
+	 */
+	if (dma_emul_get_channel_state(dev, channel) != DMA_EMUL_CHANNEL_UNUSED) {
+		dma_emul_set_channel_state(dev, channel, DMA_EMUL_CHANNEL_STOPPED);
+	}
 	k_spin_unlock(&data->lock, key);
 
 	return 0;
@@ -500,6 +659,16 @@ static bool dma_emul_chan_filter(const struct device *dev, int channel, void *fi
 	k_spinlock_key_t key;
 	struct dma_emul_data *data = dev->data;
 
+	/*
+	 * A non-NULL filter_param requests one exact channel: it points to
+	 * a uint32_t holding the channel number, the same convention used
+	 * by other DMA drivers with exact-channel filters. NULL keeps the
+	 * any-free-channel behavior.
+	 */
+	if (filter_param != NULL && channel != (int)*(uint32_t *)filter_param) {
+		return false;
+	}
+
 	key = k_spin_lock(&data->lock);
 	/* lets assume the struct dma_context handles races properly */
 	success = dma_emul_get_channel_state(dev, channel) == DMA_EMUL_CHANNEL_UNUSED;
@@ -532,16 +701,20 @@ static int dma_emul_pm_device_pm_action(const struct device *dev, enum pm_device
 
 static int dma_emul_init(const struct device *dev)
 {
+	size_t i;
 	struct dma_emul_data *data = dev->data;
 	const struct dma_emul_config *config = dev->config;
 
-	data->work.dev = dev;
 	data->dma_ctx.magic = DMA_MAGIC;
 	data->dma_ctx.dma_channels = config->num_channels;
 	data->dma_ctx.atomic = data->channels_atomic;
 
 	k_work_queue_init(&data->work_q);
-	k_work_init(&data->work.work, dma_emul_work_handler);
+	for (i = 0; i < config->num_channels; ++i) {
+		config->work[i].dev = dev;
+		config->work[i].channel = i;
+		k_work_init(&config->work[i].work, dma_emul_work_handler);
+	}
 	k_work_queue_start(&data->work_q, config->work_q_stack, config->work_q_stack_size,
 			   config->work_q_priority, NULL);
 
@@ -582,6 +755,8 @@ static int dma_emul_init(const struct device *dev)
 		dma_emul_block_config_##_inst[DMA_EMUL_INST_NUM_CHANNELS(_inst) *                  \
 					      DMA_EMUL_INST_NUM_REQUESTS(_inst)];                  \
                                                                                                    \
+	static struct dma_emul_work dma_emul_work_##_inst[DMA_EMUL_INST_NUM_CHANNELS(_inst)];      \
+                                                                                                   \
 	static const struct dma_emul_config dma_emul_config_##_inst = {                            \
 		.channel_mask = DMA_EMUL_INST_CHANNEL_MASK(_inst),                                 \
 		.num_channels = DMA_EMUL_INST_NUM_CHANNELS(_inst),                                 \
@@ -594,6 +769,7 @@ static int dma_emul_init(const struct device *dev)
 		.work_q_priority = DT_INST_PROP_OR(_inst, priority, 0),                            \
 		.xfer = dma_emul_xfer_desc_##_inst,                                                \
 		.block = dma_emul_block_config_##_inst,                                            \
+		.work = dma_emul_work_##_inst,                                                     \
 	};                                                                                         \
                                                                                                    \
 	static ATOMIC_DEFINE(dma_emul_channels_atomic_##_inst,                                     \

--- a/drivers/dma/dma_emul.c
+++ b/drivers/dma/dma_emul.c
@@ -23,6 +23,15 @@ typedef uint64_t dma_addr_t;
 typedef uint32_t dma_addr_t;
 #endif
 
+/*
+ * Transfer addresses are native pointers; on 64-bit targets they only
+ * survive the dma_block_config fields when those are 64 bits wide.
+ * Kconfig makes DMA_64BIT the default there; overriding it off must
+ * fail the build rather than truncate addresses at runtime.
+ */
+BUILD_ASSERT(!IS_ENABLED(CONFIG_64BIT) || IS_ENABLED(CONFIG_DMA_64BIT),
+	     "dma_emul requires CONFIG_DMA_64BIT=y on 64-bit targets");
+
 enum dma_emul_channel_state {
 	DMA_EMUL_CHANNEL_UNUSED,
 	DMA_EMUL_CHANNEL_LOADED,
@@ -56,6 +65,8 @@ struct dma_emul_config {
 	struct dma_emul_xfer_desc *xfer;
 	/* points to an array of size num_channels * num_requests */
 	struct dma_block_config *block;
+	/* points to an array of size num_channels */
+	struct dma_emul_work *work;
 };
 
 struct dma_emul_data {
@@ -63,7 +74,6 @@ struct dma_emul_data {
 	atomic_t *channels_atomic;
 	struct k_spinlock lock;
 	struct k_work_q work_q;
-	struct dma_emul_work work;
 };
 
 static void dma_emul_work_handler(struct k_work *work);
@@ -406,6 +416,7 @@ static int dma_emul_start(const struct device *dev, uint32_t channel)
 {
 	int ret = 0;
 	k_spinlock_key_t key;
+	uint32_t first_channel = channel;
 	enum dma_emul_channel_state state;
 	struct dma_emul_xfer_desc *xfer;
 	struct dma_config *xfer_config;
@@ -427,7 +438,6 @@ static int dma_emul_start(const struct device *dev, uint32_t channel)
 		break;
 	case DMA_EMUL_CHANNEL_LOADED:
 	case DMA_EMUL_CHANNEL_STOPPED:
-		data->work.channel = channel;
 		while (true) {
 			dma_emul_set_channel_state(dev, channel, DMA_EMUL_CHANNEL_STARTED);
 
@@ -440,7 +450,7 @@ static int dma_emul_start(const struct device *dev, uint32_t channel)
 				break;
 			}
 		}
-		ret = k_work_submit_to_queue(&data->work_q, &data->work.work);
+		ret = k_work_submit_to_queue(&data->work_q, &config->work[first_channel].work);
 		ret = (ret < 0) ? ret : 0;
 		break;
 	default:
@@ -500,6 +510,16 @@ static bool dma_emul_chan_filter(const struct device *dev, int channel, void *fi
 	k_spinlock_key_t key;
 	struct dma_emul_data *data = dev->data;
 
+	/*
+	 * A non-NULL filter_param requests one exact channel: it points to
+	 * a uint32_t holding the channel number, the same convention used
+	 * by other DMA drivers with exact-channel filters. NULL keeps the
+	 * any-free-channel behavior.
+	 */
+	if (filter_param != NULL && channel != (int)*(uint32_t *)filter_param) {
+		return false;
+	}
+
 	key = k_spin_lock(&data->lock);
 	/* lets assume the struct dma_context handles races properly */
 	success = dma_emul_get_channel_state(dev, channel) == DMA_EMUL_CHANNEL_UNUSED;
@@ -532,16 +552,20 @@ static int dma_emul_pm_device_pm_action(const struct device *dev, enum pm_device
 
 static int dma_emul_init(const struct device *dev)
 {
+	size_t i;
 	struct dma_emul_data *data = dev->data;
 	const struct dma_emul_config *config = dev->config;
 
-	data->work.dev = dev;
 	data->dma_ctx.magic = DMA_MAGIC;
 	data->dma_ctx.dma_channels = config->num_channels;
 	data->dma_ctx.atomic = data->channels_atomic;
 
 	k_work_queue_init(&data->work_q);
-	k_work_init(&data->work.work, dma_emul_work_handler);
+	for (i = 0; i < config->num_channels; ++i) {
+		config->work[i].dev = dev;
+		config->work[i].channel = i;
+		k_work_init(&config->work[i].work, dma_emul_work_handler);
+	}
 	k_work_queue_start(&data->work_q, config->work_q_stack, config->work_q_stack_size,
 			   config->work_q_priority, NULL);
 
@@ -582,6 +606,8 @@ static int dma_emul_init(const struct device *dev)
 		dma_emul_block_config_##_inst[DMA_EMUL_INST_NUM_CHANNELS(_inst) *                  \
 					      DMA_EMUL_INST_NUM_REQUESTS(_inst)];                  \
                                                                                                    \
+	static struct dma_emul_work dma_emul_work_##_inst[DMA_EMUL_INST_NUM_CHANNELS(_inst)];      \
+                                                                                                   \
 	static const struct dma_emul_config dma_emul_config_##_inst = {                            \
 		.channel_mask = DMA_EMUL_INST_CHANNEL_MASK(_inst),                                 \
 		.num_channels = DMA_EMUL_INST_NUM_CHANNELS(_inst),                                 \
@@ -594,6 +620,7 @@ static int dma_emul_init(const struct device *dev)
 		.work_q_priority = DT_INST_PROP_OR(_inst, priority, 0),                            \
 		.xfer = dma_emul_xfer_desc_##_inst,                                                \
 		.block = dma_emul_block_config_##_inst,                                            \
+		.work = dma_emul_work_##_inst,                                                     \
 	};                                                                                         \
                                                                                                    \
 	static ATOMIC_DEFINE(dma_emul_channels_atomic_##_inst,                                     \

--- a/drivers/pcie/endpoint/CMakeLists.txt
+++ b/drivers/pcie/endpoint/CMakeLists.txt
@@ -9,3 +9,5 @@ zephyr_library_sources_ifdef(
   pcie_ep_iproc.c
   pcie_ep_iproc_msi.c
   )
+
+zephyr_library_sources_ifdef(CONFIG_PCIE_EP_EMUL pcie_ep_emul.c)

--- a/drivers/pcie/endpoint/Kconfig
+++ b/drivers/pcie/endpoint/Kconfig
@@ -17,5 +17,6 @@ source "subsys/logging/Kconfig.template.log_config"
 comment "PCIe Endpoint Drivers"
 
 source "drivers/pcie/endpoint/Kconfig.iproc"
+source "drivers/pcie/endpoint/Kconfig.emul"
 
 endif # PCIE_ENDPOINT

--- a/drivers/pcie/endpoint/Kconfig.emul
+++ b/drivers/pcie/endpoint/Kconfig.emul
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Emulated PCIe EP configuration options
+
+menuconfig PCIE_EP_EMUL
+	bool "Emulated PCIe EP driver [EXPERIMENTAL]"
+	depends on PCIE_ENDPOINT
+	depends on ARCH_POSIX
+	depends on IRQ_OFFLOAD
+	depends on DT_HAS_ZEPHYR_PCIE_EP_EMUL_ENABLED
+	select EXPERIMENTAL
+	help
+	  This option enables a process-local PCIe Endpoint emulator driver
+	  implementing the PCIe EP driver API purely in software. The
+	  emulated endpoint is not externally PCIe-enumerable. It is usable
+	  on POSIX/native targets such as native_sim.
+
+	  Reset callbacks are delivered in interrupt context through
+	  irq_offload(), so this driver requires IRQ_OFFLOAD (enabled, for
+	  example, by setting CONFIG_TEST and CONFIG_IRQ_OFFLOAD in a test
+	  application).
+
+if PCIE_EP_EMUL
+
+config PCIE_EP_EMUL_MAX_APERTURES
+	int "Maximum registered host apertures per emulated endpoint"
+	range 1 32
+	default 4
+	help
+	  Bounds the per-instance aperture table. Host apertures are
+	  registered explicitly by the test host to model host memory; a
+	  small fixed table keeps per-instance RAM use bounded and
+	  deterministic.
+
+config PCIE_EP_EMUL_MAX_MAPS
+	int "Maximum concurrent outbound mappings per emulated endpoint"
+	range 1 64
+	default 8
+	help
+	  Bounds the per-instance mapping table. Each pcie_ep_map_addr()
+	  call occupies one entry until pcie_ep_unmap_addr() releases it;
+	  a small fixed table keeps per-instance RAM use bounded and
+	  deterministic.
+
+config PCIE_EP_EMUL_MAX_IRQ_EVENTS
+	int "Maximum queued interrupt events per emulated endpoint"
+	range 1 64
+	default 8
+	help
+	  Bounds the per-instance interrupt event queue. Each successful
+	  pcie_ep_raise_irq() call occupies one entry until the test host
+	  consumes it; a small fixed queue keeps per-instance RAM use
+	  bounded and surfaces unbounded producer/consumer drift in tests
+	  as -ENOSPC instead of unbounded memory growth.
+
+endif # PCIE_EP_EMUL

--- a/drivers/pcie/endpoint/pcie_ep_emul.c
+++ b/drivers/pcie/endpoint/pcie_ep_emul.c
@@ -1,0 +1,1164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_pcie_ep_emul
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree/dma.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep_emul.h>
+#include <zephyr/irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(pcie_ep_emul, LOG_LEVEL_ERR);
+
+#define PCIE_EP_EMUL_CFG_SIZE     4096U
+#define PCIE_EP_EMUL_BAR_COUNT    6U
+#define PCIE_EP_EMUL_BAR_MIN_SIZE 4096U
+
+/*
+ * Configuration image layout and write policy.
+ *
+ * Each instance owns a 4 KiB configuration image modelling a conventional
+ * PCIe (Type 0) configuration header. All layout and writability rules
+ * live in this section so that an alternate transport backend can reuse
+ * them unchanged:
+ *
+ *  0x00        vendor/device ID     read-only (from devicetree)
+ *  0x04        command/status       command bits 0..2 writable (I/O space,
+ *                                   memory space, bus master enables),
+ *                                   status (upper 16 bits) read-only;
+ *                                   status bit 4 (capabilities list) is
+ *                                   set when MSI and/or MSI-X is configured
+ *  0x08        class code/revision  read-only (from devicetree)
+ *  0x10-0x27   BAR0..BAR5           writable as base assignment only:
+ *                                   bits below the BAR size mask are
+ *                                   ignored on writes, like hardware;
+ *                                   disabled BARs read as zero
+ *  0x34        capability pointer   read-only: offset of the first
+ *                                   capability, or zero when neither MSI
+ *                                   nor MSI-X is configured
+ *  0x40        MSI capability       present when msi-vectors > 0 (ID 0x05,
+ *                                   32-bit message address, no per-vector
+ *                                   masking): the multiple-message-capable
+ *                                   field encodes the devicetree vector
+ *                                   count; the MSI enable bit and the
+ *                                   multiple-message-enable field (bits
+ *                                   22:20, the host-programmed vector
+ *                                   allocation) are writable, with written
+ *                                   values above MMC clamped to MMC (the
+ *                                   spec leaves that case undefined;
+ *                                   clamping keeps the model
+ *                                   deterministic); message address/data
+ *                                   read as zero and ignore writes
+ *  next        MSI-X capability     present when msix-vectors > 0 (ID 0x11),
+ *                                   placed directly after the MSI
+ *                                   capability when both exist: the table
+ *                                   size field encodes vectors - 1; the
+ *                                   MSI-X enable bit and the function mask
+ *                                   bit are writable; table and
+ *                                   PBA BIR/offset are read-only and point
+ *                                   into the first enabled BAR
+ *  everything else                  read-only, reads as zero
+ *
+ * Writes to registers without writable bits leave the image unchanged and
+ * are reported as -EPERM by the returning interfaces; the void
+ * pcie_ep_conf_write() device API drops the result, so endpoint-side
+ * writes stay silently ignored as on hardware.
+ *
+ * raise_irq() consults the same state like hardware would: MSI raises
+ * fail with -ENOTSUP while the MSI enable bit is clear and with -EINVAL
+ * when the vector lies outside the host-programmed allocation of
+ * 2^MME vectors (MME defaults to zero, one vector); MSI-X raises fail
+ * with -ENOTSUP while the MSI-X enable bit is clear or the function
+ * mask bit is set; legacy interrupts have no enable concept.
+ */
+#define PCIE_EP_EMUL_CFG_VENDOR_DEVICE_ID 0x00U
+#define PCIE_EP_EMUL_CFG_COMMAND_STATUS   0x04U
+#define PCIE_EP_EMUL_CFG_CLASS_REVISION   0x08U
+#define PCIE_EP_EMUL_CFG_BAR_BASE         0x10U
+#define PCIE_EP_EMUL_CFG_CAPABILITY_PTR   0x34U
+#define PCIE_EP_EMUL_CFG_FIRST_CAP        0x40U
+
+/* Command register bits an endpoint application may toggle. */
+#define PCIE_EP_EMUL_CMD_WRITABLE_MASK 0x0007U
+
+/* Status register (upper command/status half) capabilities-list bit. */
+#define PCIE_EP_EMUL_STATUS_CAP_LIST BIT(20)
+
+/* Capability IDs and layout constants. */
+#define PCIE_EP_EMUL_MSI_CAP_ID            0x05U
+#define PCIE_EP_EMUL_MSIX_CAP_ID           0x11U
+/* Config space stride reserved for the MSI capability. */
+#define PCIE_EP_EMUL_MSI_CAP_SIZE          0x10U
+/* In the first capability dword, message control is the upper half. */
+#define PCIE_EP_EMUL_MSI_MMC_SHIFT         17U
+#define PCIE_EP_EMUL_MSI_CTRL_ENABLE       BIT(16)
+#define PCIE_EP_EMUL_MSI_MME_SHIFT         20U
+#define PCIE_EP_EMUL_MSI_MME_MASK          (0x7U << PCIE_EP_EMUL_MSI_MME_SHIFT)
+#define PCIE_EP_EMUL_MSIX_TABLE_SIZE_SHIFT 16U
+#define PCIE_EP_EMUL_MSIX_CTRL_ENABLE      BIT(31)
+#define PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK   BIT(30)
+
+struct pcie_ep_emul_config {
+	uint32_t vendor_id;
+	uint32_t device_id;
+	uint32_t class_code;
+	uint32_t revision_id;
+	uint32_t bar_sizes[PCIE_EP_EMUL_BAR_COUNT];
+	uint32_t msi_vectors;
+	uint32_t msix_vectors;
+	bool legacy_irq;
+	/*
+	 * Optional dedicated DMA channels, indexed by enum xfer_direction
+	 * (HOST_TO_DEVICE first, DEVICE_TO_HOST second, as ordered by
+	 * dma-names in devicetree). dma_devs[] is NULL for both directions
+	 * when the instance has no dmas property.
+	 */
+	const struct device *dma_devs[2];
+	uint32_t dma_channels[2];
+};
+
+struct pcie_ep_emul_aperture {
+	uint64_t pcie_base;
+	uint8_t *local;
+	uint32_t len;
+	bool active;
+};
+
+struct pcie_ep_emul_map {
+	uint64_t mapped_addr;
+	uint32_t size;
+	int aperture_idx;
+	bool active;
+	/*
+	 * Number of DMA transfers currently pinned to this record. A record
+	 * unmapped while pinned is draining: it stays reserved (unusable by
+	 * map_addr and blocking aperture unregistration) until the last
+	 * in-flight transfer referencing it completes.
+	 */
+	unsigned int dma_inflight;
+};
+
+/*
+ * Per-direction DMA channel state. The mutex serializes the whole
+ * configure/start/completion cycle so concurrent users of the same
+ * channel cannot interleave; the semaphore is given by the channel
+ * completion callback, which runs on the controller workqueue thread.
+ */
+struct pcie_ep_emul_dma_chan {
+	struct k_mutex lock;
+	struct k_sem done;
+	int status;
+};
+
+struct pcie_ep_emul_data {
+	struct k_spinlock lock;
+	uint8_t cfg[PCIE_EP_EMUL_CFG_SIZE];
+	uint8_t *bar_backing[PCIE_EP_EMUL_BAR_COUNT];
+	struct pcie_ep_emul_aperture apertures[CONFIG_PCIE_EP_EMUL_MAX_APERTURES];
+	struct pcie_ep_emul_map maps[CONFIG_PCIE_EP_EMUL_MAX_MAPS];
+	struct pcie_ep_emul_dma_chan dma[2];
+	/*
+	 * Bounded interrupt event queue: one entry per successful
+	 * raise_irq, consumed FIFO by the test host. The semaphore is
+	 * given once per recorded event, after the lock is dropped, so a
+	 * successful take always pairs with a queue entry.
+	 */
+	struct k_sem irq_sem;
+	struct pcie_ep_emul_irq_event irq_events[CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS];
+	uint32_t irq_events_head;
+	uint32_t irq_events_tail;
+	pcie_ep_reset_callback_t reset_cbs[PCIE_RESET_MAX];
+	void *reset_cb_args[PCIE_RESET_MAX];
+};
+
+static bool pcie_ep_emul_cfg_access_valid(uint32_t offset)
+{
+	return (offset % sizeof(uint32_t) == 0) &&
+	       (offset <= PCIE_EP_EMUL_CFG_SIZE - sizeof(uint32_t));
+}
+
+static int pcie_ep_emul_cfg_bar_index(uint32_t offset)
+{
+	if (offset < PCIE_EP_EMUL_CFG_BAR_BASE ||
+	    offset >= PCIE_EP_EMUL_CFG_BAR_BASE + PCIE_EP_EMUL_BAR_COUNT * sizeof(uint32_t)) {
+		return -ENOENT;
+	}
+
+	return (offset - PCIE_EP_EMUL_CFG_BAR_BASE) / sizeof(uint32_t);
+}
+
+/* Offset of the MSI-X capability, right after the MSI one when present. */
+static uint32_t pcie_ep_emul_cfg_msix_offset(const struct pcie_ep_emul_config *cfg)
+{
+	return PCIE_EP_EMUL_CFG_FIRST_CAP + (cfg->msi_vectors > 0 ? PCIE_EP_EMUL_MSI_CAP_SIZE : 0);
+}
+
+static void pcie_ep_emul_cfg_init(const struct device *dev)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	uint32_t cap = PCIE_EP_EMUL_CFG_FIRST_CAP;
+
+	sys_put_le32(cfg->vendor_id | (cfg->device_id << 16),
+		     &data->cfg[PCIE_EP_EMUL_CFG_VENDOR_DEVICE_ID]);
+	sys_put_le32(cfg->revision_id | (cfg->class_code << 8),
+		     &data->cfg[PCIE_EP_EMUL_CFG_CLASS_REVISION]);
+	/* BARs start unassigned (zero); the host assigns bases via writes. */
+
+	if (cfg->msi_vectors == 0 && cfg->msix_vectors == 0) {
+		return;
+	}
+
+	sys_put_le32(PCIE_EP_EMUL_STATUS_CAP_LIST, &data->cfg[PCIE_EP_EMUL_CFG_COMMAND_STATUS]);
+	sys_put_le32(cap, &data->cfg[PCIE_EP_EMUL_CFG_CAPABILITY_PTR]);
+
+	if (cfg->msi_vectors > 0) {
+		uint32_t next = cfg->msix_vectors > 0 ? cap + PCIE_EP_EMUL_MSI_CAP_SIZE : 0;
+
+		/* Multiple Message Capable encodes log2 of the vector count. */
+		sys_put_le32(PCIE_EP_EMUL_MSI_CAP_ID | (next << 8) |
+				     (LOG2(cfg->msi_vectors) << PCIE_EP_EMUL_MSI_MMC_SHIFT),
+			     &data->cfg[cap]);
+		cap += PCIE_EP_EMUL_MSI_CAP_SIZE;
+	}
+
+	if (cfg->msix_vectors > 0) {
+		uint32_t bar = 0;
+
+		/* A build-time assert guarantees one BAR is enabled here. */
+		while (cfg->bar_sizes[bar] == 0) {
+			bar++;
+		}
+
+		sys_put_le32(PCIE_EP_EMUL_MSIX_CAP_ID | ((cfg->msix_vectors - 1)
+							 << PCIE_EP_EMUL_MSIX_TABLE_SIZE_SHIFT),
+			     &data->cfg[cap]);
+		/* Table at offset 0 of the first enabled BAR, PBA after it. */
+		sys_put_le32(bar, &data->cfg[cap + 4]);
+		sys_put_le32(bar | (cfg->msix_vectors * 16U), &data->cfg[cap + 8]);
+	}
+}
+
+static int pcie_ep_emul_conf_read(const struct device *dev, uint32_t offset, uint32_t *out)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	if (!pcie_ep_emul_cfg_access_valid(offset)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+	*out = sys_get_le32(&data->cfg[offset]);
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+static int pcie_ep_emul_conf_write_op(const struct device *dev, uint32_t offset, uint32_t value)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+	uint32_t cur;
+	int ret = 0;
+	int bar;
+
+	if (!pcie_ep_emul_cfg_access_valid(offset)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+
+	switch (offset) {
+	case PCIE_EP_EMUL_CFG_COMMAND_STATUS:
+		cur = sys_get_le32(&data->cfg[offset]);
+		cur &= ~PCIE_EP_EMUL_CMD_WRITABLE_MASK;
+		cur |= value & PCIE_EP_EMUL_CMD_WRITABLE_MASK;
+		sys_put_le32(cur, &data->cfg[offset]);
+		break;
+	default:
+		bar = pcie_ep_emul_cfg_bar_index(offset);
+		if (bar >= 0 && cfg->bar_sizes[bar] != 0) {
+			sys_put_le32(value & ~(cfg->bar_sizes[bar] - 1U), &data->cfg[offset]);
+		} else if (cfg->msi_vectors > 0 && offset == PCIE_EP_EMUL_CFG_FIRST_CAP) {
+			uint32_t mme =
+				(value & PCIE_EP_EMUL_MSI_MME_MASK) >> PCIE_EP_EMUL_MSI_MME_SHIFT;
+
+			/*
+			 * The enable bit and the multiple-message-enable
+			 * field are writable. A written MME above MMC is
+			 * clamped to MMC: the spec leaves that case
+			 * undefined, and clamping keeps the model
+			 * deterministic.
+			 */
+			mme = MIN(mme, LOG2(cfg->msi_vectors));
+			cur = sys_get_le32(&data->cfg[offset]);
+			cur &= ~(PCIE_EP_EMUL_MSI_CTRL_ENABLE | PCIE_EP_EMUL_MSI_MME_MASK);
+			cur |= (value & PCIE_EP_EMUL_MSI_CTRL_ENABLE) |
+			       (mme << PCIE_EP_EMUL_MSI_MME_SHIFT);
+			sys_put_le32(cur, &data->cfg[offset]);
+		} else if (cfg->msix_vectors > 0 && offset == pcie_ep_emul_cfg_msix_offset(cfg)) {
+			/* Only the MSI-X enable and function mask bits are writable. */
+			cur = sys_get_le32(&data->cfg[offset]);
+			cur &= ~(PCIE_EP_EMUL_MSIX_CTRL_ENABLE | PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK);
+			cur |= value &
+			       (PCIE_EP_EMUL_MSIX_CTRL_ENABLE | PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK);
+			sys_put_le32(cur, &data->cfg[offset]);
+		} else {
+			ret = -EPERM;
+		}
+		break;
+	}
+
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static void pcie_ep_emul_conf_write(const struct device *dev, uint32_t offset, uint32_t value)
+{
+	/* The void device API silently ignores invalid writes. */
+	(void)pcie_ep_emul_conf_write_op(dev, offset, value);
+}
+
+int pcie_ep_emul_host_conf_read(const struct device *dev, uint32_t offset, uint32_t *value)
+{
+	return pcie_ep_emul_conf_read(dev, offset, value);
+}
+
+int pcie_ep_emul_host_conf_write(const struct device *dev, uint32_t offset, uint32_t value)
+{
+	return pcie_ep_emul_conf_write_op(dev, offset, value);
+}
+
+static int pcie_ep_emul_host_bar_access(const struct device *dev, uint32_t bar, uint32_t offset,
+					void *dst, const void *src, uint32_t len, bool host_write)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	/* A host write copies from src, a host read into dst; the other is NULL. */
+	if (bar >= PCIE_EP_EMUL_BAR_COUNT || len == 0 || (host_write ? src : dst) == NULL) {
+		return -EINVAL;
+	}
+
+	if (len > cfg->bar_sizes[bar] || offset > cfg->bar_sizes[bar] - len) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+	if (host_write) {
+		memcpy(&data->bar_backing[bar][offset], src, len);
+	} else {
+		memcpy(dst, &data->bar_backing[bar][offset], len);
+	}
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+int pcie_ep_emul_host_bar_read(const struct device *dev, uint32_t bar, uint32_t offset, void *buf,
+			       uint32_t len)
+{
+	return pcie_ep_emul_host_bar_access(dev, bar, offset, buf, NULL, len, false);
+}
+
+int pcie_ep_emul_host_bar_write(const struct device *dev, uint32_t bar, uint32_t offset,
+				const void *buf, uint32_t len)
+{
+	return pcie_ep_emul_host_bar_access(dev, bar, offset, NULL, buf, len, true);
+}
+
+static bool pcie_ep_emul_range_overflows(uint64_t base, uint64_t len)
+{
+	return len > UINT64_MAX - base;
+}
+
+int pcie_ep_emul_register_aperture(const struct device *dev, uint64_t pcie_base, void *local_buf,
+				   uint32_t len)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_aperture *free_slot = NULL;
+	k_spinlock_key_t key;
+	int ret = -ENOMEM;
+
+	if (local_buf == NULL || len == 0 || pcie_ep_emul_range_overflows(pcie_base, len)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+
+	for (int i = 0; i < ARRAY_SIZE(data->apertures); i++) {
+		struct pcie_ep_emul_aperture *ap = &data->apertures[i];
+
+		if (!ap->active) {
+			if (free_slot == NULL) {
+				free_slot = ap;
+			}
+			continue;
+		}
+
+		if (pcie_base < ap->pcie_base + ap->len && ap->pcie_base < pcie_base + len) {
+			ret = -EALREADY;
+			goto out;
+		}
+	}
+
+	if (free_slot != NULL) {
+		free_slot->pcie_base = pcie_base;
+		free_slot->local = local_buf;
+		free_slot->len = len;
+		free_slot->active = true;
+		ret = 0;
+	}
+out:
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+int pcie_ep_emul_unregister_aperture(const struct device *dev, uint64_t pcie_base)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+	int ret = -ENOENT;
+
+	key = k_spin_lock(&data->lock);
+
+	for (int i = 0; i < ARRAY_SIZE(data->apertures); i++) {
+		struct pcie_ep_emul_aperture *ap = &data->apertures[i];
+
+		if (!ap->active || ap->pcie_base != pcie_base) {
+			continue;
+		}
+
+		for (int j = 0; j < ARRAY_SIZE(data->maps); j++) {
+			/*
+			 * A record pins the aperture while it is active or
+			 * while an in-flight DMA transfer references it.
+			 */
+			if (data->maps[j].aperture_idx == i &&
+			    (data->maps[j].active || data->maps[j].dma_inflight != 0U)) {
+				ret = -EBUSY;
+				goto out;
+			}
+		}
+
+		ap->active = false;
+		ret = 0;
+		goto out;
+	}
+out:
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static struct pcie_ep_emul_aperture *pcie_ep_emul_find_aperture(struct pcie_ep_emul_data *data,
+								uint64_t pcie_addr, uint32_t size,
+								int *idx)
+{
+	for (int i = 0; i < ARRAY_SIZE(data->apertures); i++) {
+		struct pcie_ep_emul_aperture *ap = &data->apertures[i];
+		uint64_t offset;
+
+		if (!ap->active || pcie_addr < ap->pcie_base) {
+			continue;
+		}
+
+		offset = pcie_addr - ap->pcie_base;
+		if (offset <= ap->len && size <= ap->len - offset) {
+			*idx = i;
+			return ap;
+		}
+	}
+
+	return NULL;
+}
+
+static int pcie_ep_emul_map_addr(const struct device *dev, uint64_t pcie_addr,
+				 uint64_t *mapped_addr, uint32_t size,
+				 enum pcie_ob_mem_type ob_mem_type)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_aperture *ap;
+	k_spinlock_key_t key;
+	uint64_t candidate;
+	int aperture_idx;
+	int ret = -ENOMEM;
+
+	ARG_UNUSED(ob_mem_type);
+
+	/*
+	 * The mapping size is returned as int on success, so sizes that do
+	 * not fit an int are rejected before any record is allocated rather
+	 * than truncating the return value.
+	 */
+	if (size == 0 || size > (uint32_t)INT_MAX ||
+	    pcie_ep_emul_range_overflows(pcie_addr, size)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+
+	ap = pcie_ep_emul_find_aperture(data, pcie_addr, size, &aperture_idx);
+	if (ap == NULL) {
+		ret = -ENOTSUP;
+		goto out;
+	}
+
+	candidate = (uint64_t)(uintptr_t)ap->local + (pcie_addr - ap->pcie_base);
+
+	/*
+	 * Each live host address has exactly one owning record, so two
+	 * callers cannot hold mappings to the same address at once; records
+	 * still pinned by an in-flight DMA transfer count as live. Note
+	 * the inherent limit of the void unmap_addr(dev, addr) API: a
+	 * re-issued mapping of the same range returns the same bare
+	 * address, so unmapping a stale (already released) handle of
+	 * identical value is a caller error the API cannot detect, the
+	 * same class as a double free.
+	 */
+	for (size_t i = 0; i < ARRAY_SIZE(data->maps); i++) {
+		struct pcie_ep_emul_map *map = &data->maps[i];
+
+		if ((map->active || map->dma_inflight != 0U) && map->mapped_addr == candidate) {
+			ret = -EALREADY;
+			goto out;
+		}
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(data->maps); i++) {
+		struct pcie_ep_emul_map *map = &data->maps[i];
+
+		/*
+		 * A draining record (unmapped but still pinned by an
+		 * in-flight DMA transfer) is not reusable until the
+		 * transfer completes.
+		 */
+		if (map->active || map->dma_inflight != 0U) {
+			continue;
+		}
+
+		map->mapped_addr = candidate;
+		map->size = size;
+		map->aperture_idx = aperture_idx;
+		map->active = true;
+		*mapped_addr = map->mapped_addr;
+		ret = (int)size;
+		goto out;
+	}
+out:
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static void pcie_ep_emul_unmap_addr(const struct device *dev, uint64_t mapped_addr)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->lock);
+
+	for (int i = 0; i < ARRAY_SIZE(data->maps); i++) {
+		if (data->maps[i].active && data->maps[i].mapped_addr == mapped_addr) {
+			/*
+			 * Deactivate only: an in-flight DMA transfer may still
+			 * pin the record (dma_inflight), in which case the slot
+			 * stays reserved and keeps blocking aperture
+			 * unregistration until the transfer completes.
+			 */
+			data->maps[i].active = false;
+			break;
+		}
+	}
+
+	k_spin_unlock(&data->lock, key);
+}
+
+static int pcie_ep_emul_raise_irq(const struct device *dev, enum pci_ep_irq_type irq_type,
+				  uint32_t irq_num)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_irq_event *event;
+	k_spinlock_key_t key;
+	uint32_t ctrl;
+	int ret = 0;
+
+	switch (irq_type) {
+	case PCIE_EP_IRQ_LEGACY:
+		if (!cfg->legacy_irq) {
+			return -ENOTSUP;
+		}
+		break;
+	case PCIE_EP_IRQ_MSI:
+		if (cfg->msi_vectors == 0) {
+			return -ENOTSUP;
+		}
+		if (irq_num >= cfg->msi_vectors) {
+			return -EINVAL;
+		}
+		break;
+	case PCIE_EP_IRQ_MSIX:
+		if (cfg->msix_vectors == 0) {
+			return -ENOTSUP;
+		}
+		if (irq_num >= cfg->msix_vectors) {
+			return -EINVAL;
+		}
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+
+	/*
+	 * Like hardware, raises are honored only while the host has the
+	 * capability enabled: MSI additionally bounds vectors by the
+	 * host-programmed allocation (2^MME, one vector by default), and
+	 * MSI-X raises are suppressed while the function mask is set.
+	 * All checks run before any event is recorded.
+	 */
+	switch (irq_type) {
+	case PCIE_EP_IRQ_MSI:
+		ctrl = sys_get_le32(&data->cfg[PCIE_EP_EMUL_CFG_FIRST_CAP]);
+		if ((ctrl & PCIE_EP_EMUL_MSI_CTRL_ENABLE) == 0) {
+			ret = -ENOTSUP;
+		} else if (irq_num >=
+			   BIT((ctrl & PCIE_EP_EMUL_MSI_MME_MASK) >> PCIE_EP_EMUL_MSI_MME_SHIFT)) {
+			ret = -EINVAL;
+		}
+		break;
+	case PCIE_EP_IRQ_MSIX:
+		ctrl = sys_get_le32(&data->cfg[pcie_ep_emul_cfg_msix_offset(cfg)]);
+		if ((ctrl & PCIE_EP_EMUL_MSIX_CTRL_ENABLE) == 0 ||
+		    (ctrl & PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK) != 0) {
+			ret = -ENOTSUP;
+		}
+		break;
+	default:
+		break;
+	}
+	if (ret != 0) {
+		goto out;
+	}
+
+	if (data->irq_events_head - data->irq_events_tail >= ARRAY_SIZE(data->irq_events)) {
+		ret = -ENOSPC;
+		goto out;
+	}
+
+	event = &data->irq_events[data->irq_events_head % ARRAY_SIZE(data->irq_events)];
+	event->type = irq_type;
+	event->vector = irq_type == PCIE_EP_IRQ_LEGACY ? 0 : irq_num;
+	data->irq_events_head++;
+
+out:
+	k_spin_unlock(&data->lock, key);
+
+	if (ret == 0) {
+		/* Notify waiting test hosts only after the event is visible. */
+		k_sem_give(&data->irq_sem);
+	}
+
+	return ret;
+}
+
+int pcie_ep_emul_wait_irq_event(const struct device *dev, struct pcie_ep_emul_irq_event *event,
+				k_timeout_t timeout)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	if (event == NULL) {
+		return -EINVAL;
+	}
+
+	if (k_sem_take(&data->irq_sem, timeout) != 0) {
+		return -EAGAIN;
+	}
+
+	key = k_spin_lock(&data->lock);
+	*event = data->irq_events[data->irq_events_tail % ARRAY_SIZE(data->irq_events)];
+	data->irq_events_tail++;
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+static int pcie_ep_emul_register_reset_cb(const struct device *dev, enum pcie_reset reset,
+					  pcie_ep_reset_callback_t cb, void *arg)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	if ((uint32_t)reset >= PCIE_RESET_MAX || cb == NULL) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+	data->reset_cbs[reset] = cb;
+	data->reset_cb_args[reset] = arg;
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+struct pcie_ep_emul_reset_inject {
+	const struct device *dev;
+	enum pcie_reset reset;
+};
+
+static void pcie_ep_emul_reset_isr(const void *param)
+{
+	const struct pcie_ep_emul_reset_inject *inject = param;
+	struct pcie_ep_emul_data *data = inject->dev->data;
+	pcie_ep_reset_callback_t cb;
+	k_spinlock_key_t key;
+	void *arg;
+
+	key = k_spin_lock(&data->lock);
+	cb = data->reset_cbs[inject->reset];
+	arg = data->reset_cb_args[inject->reset];
+	k_spin_unlock(&data->lock, key);
+
+	if (cb != NULL) {
+		cb(arg);
+	}
+}
+
+int pcie_ep_emul_inject_reset(const struct device *dev, enum pcie_reset reset)
+{
+	struct pcie_ep_emul_reset_inject inject = {
+		.dev = dev,
+		.reset = reset,
+	};
+
+	if ((uint32_t)reset >= PCIE_RESET_MAX) {
+		return -EINVAL;
+	}
+
+	/* Deliver synchronously in interrupt context, like real hardware. */
+	irq_offload(pcie_ep_emul_reset_isr, &inject);
+
+	return 0;
+}
+
+static void pcie_ep_emul_dma_callback(const struct device *dma_dev, void *user_data,
+				      uint32_t channel, int status)
+{
+	struct pcie_ep_emul_dma_chan *chan = user_data;
+
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(channel);
+
+	/* Record the status before releasing the waiter. */
+	chan->status = status;
+	k_sem_give(&chan->done);
+}
+
+/*
+ * The host side of a DMA transfer must be wholly covered by an active
+ * map record produced by map_addr; containment in a registered aperture
+ * alone is not sufficient, so raw or already unmapped addresses are
+ * rejected. The caller pins the returned record (dma_inflight) for the
+ * whole transfer, so unmapping the record or unregistering its aperture
+ * mid-transfer cannot release the host buffer underneath the copy: the
+ * record stays reserved until the transfer completes, and the aperture
+ * cannot be unregistered while any record referencing it is active or
+ * pinned. Caller must hold data->lock.
+ */
+static struct pcie_ep_emul_map *pcie_ep_emul_mapped_covered(struct pcie_ep_emul_data *data,
+							    uint64_t mapped_addr, uint32_t size)
+{
+	for (int i = 0; i < ARRAY_SIZE(data->maps); i++) {
+		struct pcie_ep_emul_map *map = &data->maps[i];
+		uint64_t offset;
+
+		if (!map->active || mapped_addr < map->mapped_addr) {
+			continue;
+		}
+
+		offset = mapped_addr - map->mapped_addr;
+		if (offset <= map->size && size <= map->size - offset) {
+			return map;
+		}
+	}
+
+	return NULL;
+}
+
+static int pcie_ep_emul_dma_xfer(const struct device *dev, uint64_t mapped_addr,
+				 uintptr_t local_addr, uint32_t size, enum xfer_direction dir)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_dma_chan *chan;
+	struct dma_block_config block_cfg;
+	const struct device *dma_dev;
+	struct pcie_ep_emul_map *pin;
+	struct dma_config dma_cfg;
+	k_spinlock_key_t key;
+	int ret;
+
+	if (dir != HOST_TO_DEVICE && dir != DEVICE_TO_HOST) {
+		return -EINVAL;
+	}
+
+	if (local_addr == 0 || size == 0 || pcie_ep_emul_range_overflows(mapped_addr, size)) {
+		return -EINVAL;
+	}
+
+	dma_dev = cfg->dma_devs[dir];
+	if (dma_dev == NULL) {
+		/* The instance has no dmas property: DMA is not available. */
+		return -ENODEV;
+	}
+	if (!device_is_ready(dma_dev)) {
+		return -ENODEV;
+	}
+
+	/*
+	 * Pin the covering map record for the whole transfer so that a
+	 * concurrent unmap_addr() cannot hand its slot out again and a
+	 * concurrent aperture unregistration is blocked (-EBUSY) until the
+	 * copy below has completed.
+	 */
+	key = k_spin_lock(&data->lock);
+	pin = pcie_ep_emul_mapped_covered(data, mapped_addr, size);
+	if (pin != NULL) {
+		pin->dma_inflight++;
+	}
+	k_spin_unlock(&data->lock, key);
+	if (pin == NULL) {
+		return -ENOTSUP;
+	}
+
+	chan = &data->dma[dir];
+
+	/*
+	 * Hold the channel for the whole configure..completion cycle so
+	 * concurrent users of the same direction cannot interleave. A
+	 * K_FOREVER wait cannot fail; assert the return value rather than
+	 * discarding it.
+	 */
+	/* clang-format off */
+	__ASSERT_EVAL((void)k_mutex_lock(&chan->lock, K_FOREVER),
+		int lock_ret = k_mutex_lock(&chan->lock, K_FOREVER),
+		lock_ret == 0, "k_mutex_lock failed");
+	/* clang-format on */
+
+	chan->status = -EIO;
+
+	block_cfg = (struct dma_block_config){
+		.source_address = dir == DEVICE_TO_HOST ? (uint64_t)local_addr : mapped_addr,
+		.dest_address = dir == DEVICE_TO_HOST ? mapped_addr : (uint64_t)local_addr,
+		.block_size = size,
+	};
+	dma_cfg = (struct dma_config){
+		.dma_slot = 0,
+		.channel_direction = MEMORY_TO_MEMORY,
+		.complete_callback_en = 1,
+		.source_data_size = 1,
+		.dest_data_size = 1,
+		.source_burst_length = 1,
+		.dest_burst_length = 1,
+		.block_count = 1,
+		.head_block = &block_cfg,
+		.user_data = chan,
+		.dma_callback = pcie_ep_emul_dma_callback,
+	};
+
+	/*
+	 * Configure-time -EBUSY flags a channel grabbed by another user
+	 * directly on the controller; cross-instance sharing is already
+	 * excluded by the exclusive channel claims made at init.
+	 */
+	ret = dma_config(dma_dev, cfg->dma_channels[dir], &dma_cfg);
+	if (ret == 0) {
+		ret = dma_start(dma_dev, cfg->dma_channels[dir]);
+		if (ret != 0) {
+			/* Undo our LOADED state so the channel stays usable. */
+			(void)dma_stop(dma_dev, cfg->dma_channels[dir]);
+		}
+	}
+	if (ret == 0) {
+		/*
+		 * Once dma_start() accepted the transfer, the callback
+		 * always fires from the controller workqueue, with
+		 * DMA_STATUS_COMPLETE on success or a negative status on
+		 * cancellation; the waiter therefore cannot sleep forever
+		 * and the pinned mapping stays reserved through the copy.
+		 */
+		/* clang-format off */
+		__ASSERT_EVAL((void)k_sem_take(&chan->done, K_FOREVER),
+			int take_ret = k_sem_take(&chan->done, K_FOREVER),
+			take_ret == 0, "k_sem_take failed");
+		/* clang-format on */
+		if (chan->status == DMA_STATUS_COMPLETE) {
+			ret = 0;
+		} else {
+			ret = chan->status < 0 ? chan->status : -EIO;
+		}
+	}
+
+	/* Unlocking a mutex this thread holds cannot fail either. */
+	/* clang-format off */
+	__ASSERT_EVAL((void)k_mutex_unlock(&chan->lock),
+		int unlock_ret = k_mutex_unlock(&chan->lock),
+		unlock_ret == 0, "k_mutex_unlock failed");
+	/* clang-format on */
+
+	/* The copy is over: release the pin taken before the transfer. */
+	key = k_spin_lock(&data->lock);
+	pin->dma_inflight--;
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static DEVICE_API(pcie_ep, pcie_ep_emul_api) = {
+	.conf_read = pcie_ep_emul_conf_read,
+	.conf_write = pcie_ep_emul_conf_write,
+	.map_addr = pcie_ep_emul_map_addr,
+	.unmap_addr = pcie_ep_emul_unmap_addr,
+	.raise_irq = pcie_ep_emul_raise_irq,
+	.register_reset_cb = pcie_ep_emul_register_reset_cb,
+	.dma_xfer = pcie_ep_emul_dma_xfer,
+};
+
+/*
+ * Claim each named channel from its controller so that two endpoint
+ * instances cannot drive the same channel. dma_request_channel()
+ * allocates through the controller's dma_context atomic bitmask, so
+ * claims are race-free across instances; the claim is held for the
+ * whole device lifetime and never released. The channel number named in
+ * devicetree is passed to the controller's channel filter by address, so
+ * claims do not depend on device init order: receiving any other channel,
+ * or no channel at all, means the named channel was taken by another
+ * user. On any failure all channels already claimed by this init are
+ * released again, so a device that never becomes ready leaks no claims.
+ * filter_param is not standardized by the DMA API, so the by-address
+ * uint32_t channel-number encoding is only valid for controllers
+ * implementing the dma_emul filter convention; the dmas controllers are
+ * restricted to zephyr,dma-emul by build-time assertion.
+ */
+static int pcie_ep_emul_claim_dma_channels(const struct device *dev)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	int ret = 0;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(cfg->dma_devs); i++) {
+		const struct device *dma_dev = cfg->dma_devs[i];
+		uint32_t channel = cfg->dma_channels[i];
+		int claimed;
+
+		if (dma_dev == NULL) {
+			continue;
+		}
+
+		if (!device_is_ready(dma_dev)) {
+			LOG_ERR("%s: DMA controller %s is not ready", dev->name, dma_dev->name);
+			ret = -ENODEV;
+			break;
+		}
+
+		claimed = dma_request_channel(dma_dev, &channel);
+		if (claimed >= 0 && (uint32_t)claimed != cfg->dma_channels[i]) {
+			dma_release_channel(dma_dev, (uint32_t)claimed);
+			claimed = -EBUSY;
+		}
+		if (claimed < 0) {
+			LOG_ERR("%s: cannot claim channel %u of %s", dev->name,
+				cfg->dma_channels[i], dma_dev->name);
+			ret = -EBUSY;
+			break;
+		}
+	}
+
+	if (ret != 0) {
+		/* Roll back every channel this init already claimed. */
+		for (int j = 0; j < i; j++) {
+			if (cfg->dma_devs[j] != NULL) {
+				dma_release_channel(cfg->dma_devs[j], cfg->dma_channels[j]);
+			}
+		}
+	}
+
+	return ret;
+}
+
+static int pcie_ep_emul_init(const struct device *dev)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+
+	/* The two directions of one instance must use distinct channels. */
+	if (cfg->dma_devs[0] != NULL && cfg->dma_devs[0] == cfg->dma_devs[1] &&
+	    cfg->dma_channels[0] == cfg->dma_channels[1]) {
+		return -ENODEV;
+	}
+
+	if (pcie_ep_emul_claim_dma_channels(dev) != 0) {
+		return -ENODEV;
+	}
+
+	k_sem_init(&data->irq_sem, 0, CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS);
+	for (int i = 0; i < ARRAY_SIZE(data->dma); i++) {
+		k_mutex_init(&data->dma[i].lock);
+		k_sem_init(&data->dma[i].done, 0, 1);
+	}
+	pcie_ep_emul_cfg_init(dev);
+
+	return 0;
+}
+
+#define PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, idx)                                                    \
+	BUILD_ASSERT(                                                                              \
+		DT_INST_PROP_BY_IDX(inst, bar_sizes, idx) == 0 ||                                  \
+			(IS_POWER_OF_TWO(DT_INST_PROP_BY_IDX(inst, bar_sizes, idx)) &&             \
+			 DT_INST_PROP_BY_IDX(inst, bar_sizes, idx) >= PCIE_EP_EMUL_BAR_MIN_SIZE),  \
+		"bar-sizes entries must be zero or a power of two >= 4096")
+
+#define PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, idx)                                                 \
+	static uint8_t pcie_ep_emul_bar_backing_##inst##_##idx[MAX(                                \
+		DT_INST_PROP_BY_IDX(inst, bar_sizes, idx), 1)]
+
+#define PCIE_EP_EMUL_BAR_BACKING_PTR(inst, idx)                                                    \
+	DT_INST_PROP_BY_IDX(inst, bar_sizes, idx) != 0 ? pcie_ep_emul_bar_backing_##inst##_##idx   \
+						       : NULL
+
+#define PCIE_EP_EMUL_DMA_DEV(inst, name)                                                           \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                          \
+		    (DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(inst, name))), (NULL))
+
+#define PCIE_EP_EMUL_DMA_CHANNEL(inst, name)                                                       \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                          \
+		    (DT_INST_DMAS_CELL_BY_NAME(inst, name, channel)), (0))
+
+/*
+ * Exact-channel claiming passes the devicetree channel number to the
+ * controller's channel filter as a pointer to uint32_t. The DMA API does
+ * not standardize filter_param; that encoding is the dma_emul
+ * convention, so restrict dmas controllers to zephyr,dma-emul at build
+ * time rather than assuming any controller honors it.
+ */
+#define PCIE_EP_EMUL_DMA_CTRL_ASSERT(node_id, prop, idx)                                           \
+	BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_PHANDLE_BY_IDX(node_id, prop, idx), zephyr_dma_emul),   \
+		     "zephyr,pcie-ep-emul dmas controllers must be zephyr,dma-emul: "              \
+		     "exact-channel claiming relies on the dma_emul channel-filter encoding");
+
+#define PCIE_EP_EMUL_DMA_CTRLS_ASSERT(inst)                                                        \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                          \
+		    (DT_INST_FOREACH_PROP_ELEM(inst, dmas, PCIE_EP_EMUL_DMA_CTRL_ASSERT)), ())
+
+/* Size of the first enabled BAR, or zero when all BARs are disabled. */
+#define PCIE_EP_EMUL_FIRST_BAR_SIZE(inst)                                                          \
+	(DT_INST_PROP_BY_IDX(inst, bar_sizes, 0) != 0   ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 0)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 1) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 1)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 2) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 2)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 3) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 3)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 4) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 4)  \
+							: DT_INST_PROP_BY_IDX(inst, bar_sizes, 5))
+
+/* PBA storage for a vector count: one bit per vector, in 8-byte multiples. */
+#define PCIE_EP_EMUL_MSIX_PBA_SIZE(vectors) ROUND_UP(DIV_ROUND_UP(vectors, 8), 8)
+
+#define PCIE_EP_EMUL_MSIX_FITS_ASSERT(inst)                                                        \
+	BUILD_ASSERT(DT_INST_PROP(inst, msix_vectors) == 0 ||                                      \
+			     DT_INST_PROP(inst, msix_vectors) * 16U +                              \
+					     PCIE_EP_EMUL_MSIX_PBA_SIZE(                           \
+						     DT_INST_PROP(inst, msix_vectors)) <=          \
+				     PCIE_EP_EMUL_FIRST_BAR_SIZE(inst),                            \
+		     "msix-vectors table and PBA must fit in the first enabled BAR")
+
+#define PCIE_EP_EMUL_DEFINE(inst)                                                                  \
+	BUILD_ASSERT(DT_INST_PROP_LEN(inst, bar_sizes) == PCIE_EP_EMUL_BAR_COUNT,                  \
+		     "bar-sizes must have exactly 6 entries");                                     \
+	BUILD_ASSERT(DT_INST_PROP(inst, vendor_id) <= 0xFFFFU,                                     \
+		     "vendor-id must fit the 16-bit configuration space field");                   \
+	BUILD_ASSERT(DT_INST_PROP(inst, device_id) <= 0xFFFFU,                                     \
+		     "device-id must fit the 16-bit configuration space field");                   \
+	BUILD_ASSERT(DT_INST_PROP(inst, class_code) <= 0xFFFFFFU,                                  \
+		     "class-code must fit the 24-bit configuration space field");                  \
+	BUILD_ASSERT(DT_INST_PROP(inst, revision_id) <= 0xFFU,                                     \
+		     "revision-id must fit the 8-bit configuration space field");                  \
+	BUILD_ASSERT(!DT_INST_NODE_HAS_PROP(inst, dmas) ||                                         \
+			     (DT_INST_PROP_LEN_OR(inst, dmas, 0) == 2 &&                           \
+			      DT_INST_PROP_LEN_OR(inst, dma_names, 0) == 2),                       \
+		     "dmas and dma-names must have exactly two entries when present");             \
+	PCIE_EP_EMUL_DMA_CTRLS_ASSERT(inst);                                                       \
+	BUILD_ASSERT(DT_INST_PROP(inst, msi_vectors) == 0 ||                                       \
+			     (IS_POWER_OF_TWO(DT_INST_PROP(inst, msi_vectors)) &&                  \
+			      DT_INST_PROP(inst, msi_vectors) <= 32U),                             \
+		     "msi-vectors must be zero or a power of two up to 32");                       \
+	BUILD_ASSERT(DT_INST_PROP(inst, msix_vectors) <= 2048U,                                    \
+		     "msix-vectors must fit the 11-bit table size field");                         \
+	BUILD_ASSERT(DT_INST_PROP(inst, msix_vectors) == 0 ||                                      \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 0) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 1) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 2) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 3) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 4) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 5) != 0,                         \
+		     "msix-vectors requires at least one enabled BAR");                            \
+	PCIE_EP_EMUL_MSIX_FITS_ASSERT(inst);                                                       \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 0);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 1);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 2);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 3);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 4);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 5);                                                     \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 0);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 1);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 2);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 3);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 4);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 5);                                                  \
+	static const struct pcie_ep_emul_config pcie_ep_emul_config_##inst = {                     \
+		.vendor_id = DT_INST_PROP(inst, vendor_id),                                        \
+		.device_id = DT_INST_PROP(inst, device_id),                                        \
+		.class_code = DT_INST_PROP(inst, class_code),                                      \
+		.revision_id = DT_INST_PROP(inst, revision_id),                                    \
+		.bar_sizes = DT_INST_PROP(inst, bar_sizes),                                        \
+		.msi_vectors = DT_INST_PROP(inst, msi_vectors),                                    \
+		.msix_vectors = DT_INST_PROP(inst, msix_vectors),                                  \
+		.legacy_irq = DT_INST_PROP(inst, legacy_irq),                                      \
+		.dma_devs = {PCIE_EP_EMUL_DMA_DEV(inst, host_to_device),                           \
+			     PCIE_EP_EMUL_DMA_DEV(inst, device_to_host)},                          \
+		.dma_channels = {PCIE_EP_EMUL_DMA_CHANNEL(inst, host_to_device),                   \
+				 PCIE_EP_EMUL_DMA_CHANNEL(inst, device_to_host)},                  \
+	};                                                                                         \
+	static struct pcie_ep_emul_data pcie_ep_emul_data_##inst = {                               \
+		.bar_backing = {PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 0),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 1),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 2),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 3),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 4),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 5)},                            \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, &pcie_ep_emul_init, NULL, &pcie_ep_emul_data_##inst,           \
+			      &pcie_ep_emul_config_##inst, POST_KERNEL,                            \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pcie_ep_emul_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PCIE_EP_EMUL_DEFINE)

--- a/drivers/pcie/endpoint/pcie_ep_emul.c
+++ b/drivers/pcie/endpoint/pcie_ep_emul.c
@@ -1,0 +1,1179 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_pcie_ep_emul
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree/dma.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep_emul.h>
+#include <zephyr/irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(pcie_ep_emul, CONFIG_PCIE_EP_LOG_LEVEL);
+
+#define PCIE_EP_EMUL_CFG_SIZE     4096U
+#define PCIE_EP_EMUL_BAR_COUNT    6U
+#define PCIE_EP_EMUL_BAR_MIN_SIZE 4096U
+
+/*
+ * Configuration image layout and write policy.
+ *
+ * Each instance owns a 4 KiB configuration image modelling a conventional
+ * PCIe (Type 0) configuration header. All layout and writability rules
+ * live in this section:
+ *
+ *  0x00        vendor/device ID     read-only (from devicetree)
+ *  0x04        command/status       command bits 0..2 writable (I/O space,
+ *                                   memory space, bus master enables),
+ *                                   status (upper 16 bits) read-only;
+ *                                   status bit 4 (capabilities list) is
+ *                                   set when MSI and/or MSI-X is configured
+ *  0x08        class code/revision  read-only (from devicetree)
+ *  0x10-0x27   BAR0..BAR5           writable as base assignment only:
+ *                                   bits below the BAR size mask are
+ *                                   ignored on writes, like hardware;
+ *                                   disabled BARs read as zero
+ *  0x34        capability pointer   read-only: offset of the first
+ *                                   capability, or zero when neither MSI
+ *                                   nor MSI-X is configured
+ *  0x40        MSI capability       present when msi-vectors > 0 (ID 0x05,
+ *                                   32-bit message address, no per-vector
+ *                                   masking): the multiple-message-capable
+ *                                   field encodes the devicetree vector
+ *                                   count; the MSI enable bit and the
+ *                                   multiple-message-enable field (bits
+ *                                   22:20, the host-programmed vector
+ *                                   allocation) are writable, with written
+ *                                   values above MMC clamped to MMC (the
+ *                                   spec leaves that case undefined;
+ *                                   clamping keeps the model
+ *                                   deterministic); message address/data
+ *                                   read as zero and ignore writes
+ *  next        MSI-X capability     present when msix-vectors > 0 (ID 0x11),
+ *                                   placed directly after the MSI
+ *                                   capability when both exist: the table
+ *                                   size field encodes vectors - 1; the
+ *                                   MSI-X enable bit and the function mask
+ *                                   bit are writable; table and
+ *                                   PBA BIR/offset are read-only and point
+ *                                   into the first enabled BAR
+ *  everything else                  read-only, reads as zero
+ *
+ * Writes to registers without writable bits leave the image unchanged and
+ * are reported as -EPERM by the returning interfaces; the void
+ * pcie_ep_conf_write() device API drops the result, so endpoint-side
+ * writes stay silently ignored as on hardware.
+ *
+ * raise_irq() consults the same state like hardware would: MSI raises
+ * fail with -ENOTSUP while the MSI enable bit is clear and with -EINVAL
+ * when the vector lies outside the host-programmed allocation of
+ * 2^MME vectors (MME defaults to zero, one vector); MSI-X raises fail
+ * with -ENOTSUP while the MSI-X enable bit is clear or the function
+ * mask bit is set; legacy interrupts have no enable concept.
+ */
+#define PCIE_EP_EMUL_CFG_VENDOR_DEVICE_ID 0x00U
+#define PCIE_EP_EMUL_CFG_COMMAND_STATUS   0x04U
+#define PCIE_EP_EMUL_CFG_CLASS_REVISION   0x08U
+#define PCIE_EP_EMUL_CFG_BAR_BASE         0x10U
+#define PCIE_EP_EMUL_CFG_CAPABILITY_PTR   0x34U
+#define PCIE_EP_EMUL_CFG_FIRST_CAP        0x40U
+
+/* Command register bits an endpoint application may toggle. */
+#define PCIE_EP_EMUL_CMD_WRITABLE_MASK 0x0007U
+
+/* Status register (upper command/status half) capabilities-list bit. */
+#define PCIE_EP_EMUL_STATUS_CAP_LIST BIT(20)
+
+/* Capability IDs and layout constants. */
+#define PCIE_EP_EMUL_MSI_CAP_ID            0x05U
+#define PCIE_EP_EMUL_MSIX_CAP_ID           0x11U
+/* Config space stride reserved for the MSI capability. */
+#define PCIE_EP_EMUL_MSI_CAP_SIZE          0x10U
+/* In the first capability dword, message control is the upper half. */
+#define PCIE_EP_EMUL_MSI_MMC_SHIFT         17U
+#define PCIE_EP_EMUL_MSI_CTRL_ENABLE       BIT(16)
+#define PCIE_EP_EMUL_MSI_MME_SHIFT         20U
+#define PCIE_EP_EMUL_MSI_MME_MASK          (0x7U << PCIE_EP_EMUL_MSI_MME_SHIFT)
+#define PCIE_EP_EMUL_MSIX_TABLE_SIZE_SHIFT 16U
+#define PCIE_EP_EMUL_MSIX_CTRL_ENABLE      BIT(31)
+#define PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK   BIT(30)
+
+struct pcie_ep_emul_config {
+	uint32_t vendor_id;
+	uint32_t device_id;
+	uint32_t class_code;
+	uint32_t revision_id;
+	uint32_t bar_sizes[PCIE_EP_EMUL_BAR_COUNT];
+	uint32_t msi_vectors;
+	uint32_t msix_vectors;
+	bool legacy_irq;
+	/*
+	 * Optional dedicated DMA channels, indexed by enum xfer_direction
+	 * (HOST_TO_DEVICE first, DEVICE_TO_HOST second, as ordered by
+	 * dma-names in devicetree). dma_devs[] is NULL for both directions
+	 * when the instance has no dmas property.
+	 */
+	const struct device *dma_devs[2];
+	uint32_t dma_channels[2];
+};
+
+struct pcie_ep_emul_aperture {
+	uint64_t pcie_base;
+	uint8_t *local;
+	uint32_t len;
+	bool active;
+};
+
+struct pcie_ep_emul_map {
+	uint64_t mapped_addr;
+	uint32_t size;
+	int aperture_idx;
+	bool active;
+	/*
+	 * Number of DMA transfers currently pinned to this record. A record
+	 * unmapped while pinned is draining: it stays reserved (unusable by
+	 * map_addr and blocking aperture unregistration) until the last
+	 * in-flight transfer referencing it completes.
+	 */
+	unsigned int dma_inflight;
+};
+
+/*
+ * Per-direction DMA channel state. The mutex serializes the whole
+ * configure/start/completion cycle so concurrent users of the same
+ * channel cannot interleave; the semaphore is given by the channel
+ * completion callback, which runs on the controller workqueue thread.
+ */
+struct pcie_ep_emul_dma_chan {
+	struct k_mutex lock;
+	struct k_sem done;
+	int status;
+};
+
+struct pcie_ep_emul_data {
+	struct k_spinlock lock;
+	uint8_t cfg[PCIE_EP_EMUL_CFG_SIZE];
+	uint8_t *bar_backing[PCIE_EP_EMUL_BAR_COUNT];
+	struct pcie_ep_emul_aperture apertures[CONFIG_PCIE_EP_EMUL_MAX_APERTURES];
+	struct pcie_ep_emul_map maps[CONFIG_PCIE_EP_EMUL_MAX_MAPS];
+	struct pcie_ep_emul_dma_chan dma[2];
+	/*
+	 * Bounded interrupt event queue: one entry per successful
+	 * raise_irq, consumed FIFO by the test host. The semaphore is
+	 * given once per recorded event, after the lock is dropped, so a
+	 * successful take always pairs with a queue entry.
+	 */
+	struct k_sem irq_sem;
+	struct pcie_ep_emul_irq_event irq_events[CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS];
+	uint32_t irq_events_head;
+	uint32_t irq_events_tail;
+	pcie_ep_reset_callback_t reset_cbs[PCIE_RESET_MAX];
+	void *reset_cb_args[PCIE_RESET_MAX];
+};
+
+static bool pcie_ep_emul_cfg_access_valid(uint32_t offset)
+{
+	return (offset % sizeof(uint32_t) == 0) &&
+	       (offset <= PCIE_EP_EMUL_CFG_SIZE - sizeof(uint32_t));
+}
+
+static int pcie_ep_emul_cfg_bar_index(uint32_t offset)
+{
+	if (offset < PCIE_EP_EMUL_CFG_BAR_BASE ||
+	    offset >= PCIE_EP_EMUL_CFG_BAR_BASE + PCIE_EP_EMUL_BAR_COUNT * sizeof(uint32_t)) {
+		return -ENOENT;
+	}
+
+	return (offset - PCIE_EP_EMUL_CFG_BAR_BASE) / sizeof(uint32_t);
+}
+
+/* Offset of the MSI-X capability, right after the MSI one when present. */
+static uint32_t pcie_ep_emul_cfg_msix_offset(const struct pcie_ep_emul_config *cfg)
+{
+	return PCIE_EP_EMUL_CFG_FIRST_CAP + (cfg->msi_vectors > 0 ? PCIE_EP_EMUL_MSI_CAP_SIZE : 0);
+}
+
+static void pcie_ep_emul_cfg_init(const struct device *dev)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	uint32_t cap = PCIE_EP_EMUL_CFG_FIRST_CAP;
+
+	sys_put_le32(cfg->vendor_id | (cfg->device_id << 16),
+		     &data->cfg[PCIE_EP_EMUL_CFG_VENDOR_DEVICE_ID]);
+	sys_put_le32(cfg->revision_id | (cfg->class_code << 8),
+		     &data->cfg[PCIE_EP_EMUL_CFG_CLASS_REVISION]);
+	/* BARs start unassigned (zero); the host assigns bases via writes. */
+
+	if (cfg->msi_vectors == 0 && cfg->msix_vectors == 0) {
+		return;
+	}
+
+	sys_put_le32(PCIE_EP_EMUL_STATUS_CAP_LIST, &data->cfg[PCIE_EP_EMUL_CFG_COMMAND_STATUS]);
+	sys_put_le32(cap, &data->cfg[PCIE_EP_EMUL_CFG_CAPABILITY_PTR]);
+
+	if (cfg->msi_vectors > 0) {
+		uint32_t next = cfg->msix_vectors > 0 ? cap + PCIE_EP_EMUL_MSI_CAP_SIZE : 0;
+
+		/* Multiple Message Capable encodes log2 of the vector count. */
+		sys_put_le32(PCIE_EP_EMUL_MSI_CAP_ID | (next << 8) |
+				     (LOG2(cfg->msi_vectors) << PCIE_EP_EMUL_MSI_MMC_SHIFT),
+			     &data->cfg[cap]);
+		cap += PCIE_EP_EMUL_MSI_CAP_SIZE;
+	}
+
+	if (cfg->msix_vectors > 0) {
+		uint32_t bar = 0;
+
+		/* A build-time assert guarantees one BAR is enabled here. */
+		while (cfg->bar_sizes[bar] == 0) {
+			bar++;
+		}
+
+		sys_put_le32(PCIE_EP_EMUL_MSIX_CAP_ID | ((cfg->msix_vectors - 1)
+							 << PCIE_EP_EMUL_MSIX_TABLE_SIZE_SHIFT),
+			     &data->cfg[cap]);
+		/* Table at offset 0 of the first enabled BAR, PBA after it. */
+		sys_put_le32(bar, &data->cfg[cap + 4]);
+		sys_put_le32(bar | (cfg->msix_vectors * 16U), &data->cfg[cap + 8]);
+	}
+}
+
+static int pcie_ep_emul_conf_read(const struct device *dev, uint32_t offset, uint32_t *out)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	if (!pcie_ep_emul_cfg_access_valid(offset)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+	*out = sys_get_le32(&data->cfg[offset]);
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+static int pcie_ep_emul_conf_write_op(const struct device *dev, uint32_t offset, uint32_t value)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+	uint32_t cur;
+	int ret = 0;
+	int bar;
+
+	if (!pcie_ep_emul_cfg_access_valid(offset)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+
+	if (offset == PCIE_EP_EMUL_CFG_COMMAND_STATUS) {
+		cur = sys_get_le32(&data->cfg[offset]);
+		cur &= ~PCIE_EP_EMUL_CMD_WRITABLE_MASK;
+		cur |= value & PCIE_EP_EMUL_CMD_WRITABLE_MASK;
+		sys_put_le32(cur, &data->cfg[offset]);
+	} else {
+		bar = pcie_ep_emul_cfg_bar_index(offset);
+		if (bar >= 0 && cfg->bar_sizes[bar] != 0) {
+			sys_put_le32(value & ~(cfg->bar_sizes[bar] - 1U), &data->cfg[offset]);
+		} else if (cfg->msi_vectors > 0 && offset == PCIE_EP_EMUL_CFG_FIRST_CAP) {
+			uint32_t mme =
+				(value & PCIE_EP_EMUL_MSI_MME_MASK) >> PCIE_EP_EMUL_MSI_MME_SHIFT;
+
+			/*
+			 * The enable bit and the multiple-message-enable
+			 * field are writable. A written MME above MMC is
+			 * clamped to MMC: the spec leaves that case
+			 * undefined, and clamping keeps the model
+			 * deterministic.
+			 */
+			mme = MIN(mme, LOG2(cfg->msi_vectors));
+			cur = sys_get_le32(&data->cfg[offset]);
+			cur &= ~(PCIE_EP_EMUL_MSI_CTRL_ENABLE | PCIE_EP_EMUL_MSI_MME_MASK);
+			cur |= (value & PCIE_EP_EMUL_MSI_CTRL_ENABLE) |
+			       (mme << PCIE_EP_EMUL_MSI_MME_SHIFT);
+			sys_put_le32(cur, &data->cfg[offset]);
+		} else if (cfg->msix_vectors > 0 && offset == pcie_ep_emul_cfg_msix_offset(cfg)) {
+			/* Only the MSI-X enable and function mask bits are writable. */
+			cur = sys_get_le32(&data->cfg[offset]);
+			cur &= ~(PCIE_EP_EMUL_MSIX_CTRL_ENABLE | PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK);
+			cur |= value &
+			       (PCIE_EP_EMUL_MSIX_CTRL_ENABLE | PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK);
+			sys_put_le32(cur, &data->cfg[offset]);
+		} else {
+			ret = -EPERM;
+		}
+	}
+
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static void pcie_ep_emul_conf_write(const struct device *dev, uint32_t offset, uint32_t value)
+{
+	/* The void device API silently ignores invalid writes. */
+	(void)pcie_ep_emul_conf_write_op(dev, offset, value);
+}
+
+int pcie_ep_emul_host_conf_read(const struct device *dev, uint32_t offset, uint32_t *value)
+{
+	return pcie_ep_emul_conf_read(dev, offset, value);
+}
+
+int pcie_ep_emul_host_conf_write(const struct device *dev, uint32_t offset, uint32_t value)
+{
+	return pcie_ep_emul_conf_write_op(dev, offset, value);
+}
+
+static int pcie_ep_emul_host_bar_access(const struct device *dev, uint32_t bar, uint32_t offset,
+					void *dst, const void *src, uint32_t len, bool host_write)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	/* A host write copies from src, a host read into dst; the other is NULL. */
+	if (bar >= PCIE_EP_EMUL_BAR_COUNT || len == 0 || (host_write ? src : dst) == NULL) {
+		return -EINVAL;
+	}
+
+	if (len > cfg->bar_sizes[bar] || offset > cfg->bar_sizes[bar] - len) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+	if (host_write) {
+		memcpy(&data->bar_backing[bar][offset], src, len);
+	} else {
+		memcpy(dst, &data->bar_backing[bar][offset], len);
+	}
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+int pcie_ep_emul_host_bar_read(const struct device *dev, uint32_t bar, uint32_t offset, void *buf,
+			       uint32_t len)
+{
+	return pcie_ep_emul_host_bar_access(dev, bar, offset, buf, NULL, len, false);
+}
+
+int pcie_ep_emul_host_bar_write(const struct device *dev, uint32_t bar, uint32_t offset,
+				const void *buf, uint32_t len)
+{
+	return pcie_ep_emul_host_bar_access(dev, bar, offset, NULL, buf, len, true);
+}
+
+static bool pcie_ep_emul_range_overflows(uint64_t base, uint64_t len)
+{
+	return len > UINT64_MAX - base;
+}
+
+/*
+ * Half-open range relations on [start, start + size). Callers validate
+ * every range with pcie_ep_emul_range_overflows() at registration/map
+ * time, so the end additions in pcie_ep_emul_range_overlaps() cannot
+ * wrap.
+ */
+static bool pcie_ep_emul_range_within(uint64_t start, uint64_t size, uint64_t base, uint64_t len)
+{
+	uint64_t offset;
+
+	if (start < base) {
+		return false;
+	}
+	offset = start - base;
+	return offset <= len && size <= len - offset;
+}
+
+static bool pcie_ep_emul_range_overlaps(uint64_t start_a, uint64_t size_a, uint64_t start_b,
+					uint64_t size_b)
+{
+	return (start_a < start_b + size_b) && (start_b < start_a + size_a);
+}
+
+int pcie_ep_emul_register_aperture(const struct device *dev, uint64_t pcie_base, void *local_buf,
+				   uint32_t len)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_aperture *free_slot = NULL;
+	k_spinlock_key_t key;
+	int ret = -ENOMEM;
+
+	if (local_buf == NULL || len == 0 || pcie_ep_emul_range_overflows(pcie_base, len)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+
+	for (int i = 0; i < ARRAY_SIZE(data->apertures); i++) {
+		struct pcie_ep_emul_aperture *ap = &data->apertures[i];
+
+		if (!ap->active) {
+			if (free_slot == NULL) {
+				free_slot = ap;
+			}
+			continue;
+		}
+
+		if (pcie_ep_emul_range_overlaps(pcie_base, len, ap->pcie_base, ap->len)) {
+			ret = -EALREADY;
+			goto out;
+		}
+	}
+
+	if (free_slot != NULL) {
+		free_slot->pcie_base = pcie_base;
+		free_slot->local = local_buf;
+		free_slot->len = len;
+		free_slot->active = true;
+		ret = 0;
+	}
+out:
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+int pcie_ep_emul_unregister_aperture(const struct device *dev, uint64_t pcie_base)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+	int ret = -ENOENT;
+
+	key = k_spin_lock(&data->lock);
+
+	for (int i = 0; i < ARRAY_SIZE(data->apertures); i++) {
+		struct pcie_ep_emul_aperture *ap = &data->apertures[i];
+
+		if (!ap->active || ap->pcie_base != pcie_base) {
+			continue;
+		}
+
+		for (int j = 0; j < ARRAY_SIZE(data->maps); j++) {
+			/*
+			 * A record pins the aperture while it is active or
+			 * while an in-flight DMA transfer references it.
+			 */
+			if (data->maps[j].aperture_idx == i &&
+			    (data->maps[j].active || data->maps[j].dma_inflight != 0U)) {
+				ret = -EBUSY;
+				goto out;
+			}
+		}
+
+		ap->active = false;
+		ret = 0;
+		goto out;
+	}
+out:
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static struct pcie_ep_emul_aperture *pcie_ep_emul_find_aperture(struct pcie_ep_emul_data *data,
+								uint64_t pcie_addr, uint32_t size,
+								int *idx)
+{
+	for (int i = 0; i < ARRAY_SIZE(data->apertures); i++) {
+		struct pcie_ep_emul_aperture *ap = &data->apertures[i];
+
+		if (ap->active &&
+		    pcie_ep_emul_range_within(pcie_addr, size, ap->pcie_base, ap->len)) {
+			*idx = i;
+			return ap;
+		}
+	}
+
+	return NULL;
+}
+
+static int pcie_ep_emul_map_addr(const struct device *dev, uint64_t pcie_addr,
+				 uint64_t *mapped_addr, uint32_t size,
+				 enum pcie_ob_mem_type ob_mem_type)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_map *free_slot = NULL;
+	struct pcie_ep_emul_aperture *ap;
+	k_spinlock_key_t key;
+	uint64_t candidate;
+	int aperture_idx;
+	int ret = -ENOMEM;
+
+	ARG_UNUSED(ob_mem_type);
+
+	/*
+	 * The mapping size is returned as int on success, so sizes that do
+	 * not fit an int are rejected before any record is allocated rather
+	 * than truncating the return value.
+	 */
+	if (size == 0 || size > (uint32_t)INT_MAX ||
+	    pcie_ep_emul_range_overflows(pcie_addr, size)) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+
+	ap = pcie_ep_emul_find_aperture(data, pcie_addr, size, &aperture_idx);
+	if (ap == NULL) {
+		ret = -ENOTSUP;
+		goto out;
+	}
+
+	candidate = (uint64_t)(uintptr_t)ap->local + (pcie_addr - ap->pcie_base);
+
+	/*
+	 * Each live host range has exactly one owning record, so two
+	 * callers cannot hold mappings that overlap at once; records
+	 * still pinned by an in-flight DMA transfer count as live. Note
+	 * the inherent limit of the void unmap_addr(dev, addr) API: a
+	 * re-issued mapping of the same range returns the same bare
+	 * address, so unmapping a stale (already released) handle of
+	 * identical value is a caller error the API cannot detect, the
+	 * same class as a double free. Range ends cannot overflow here:
+	 * both were validated against their aperture at registration/map
+	 * time.
+	 */
+	for (size_t i = 0; i < ARRAY_SIZE(data->maps); i++) {
+		struct pcie_ep_emul_map *map = &data->maps[i];
+
+		/*
+		 * A draining record (unmapped but still pinned by an
+		 * in-flight DMA transfer) is not reusable until the
+		 * transfer completes.
+		 */
+		if (!map->active && map->dma_inflight == 0U) {
+			if (free_slot == NULL) {
+				free_slot = map;
+			}
+			continue;
+		}
+
+		if (pcie_ep_emul_range_overlaps(candidate, size, map->mapped_addr, map->size)) {
+			ret = -EALREADY;
+			goto out;
+		}
+	}
+
+	if (free_slot != NULL) {
+		free_slot->mapped_addr = candidate;
+		free_slot->size = size;
+		free_slot->aperture_idx = aperture_idx;
+		free_slot->active = true;
+		*mapped_addr = free_slot->mapped_addr;
+		ret = (int)size;
+	}
+out:
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static void pcie_ep_emul_unmap_addr(const struct device *dev, uint64_t mapped_addr)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->lock);
+
+	for (int i = 0; i < ARRAY_SIZE(data->maps); i++) {
+		if (data->maps[i].active && data->maps[i].mapped_addr == mapped_addr) {
+			/*
+			 * Deactivate only: an in-flight DMA transfer may still
+			 * pin the record (dma_inflight), in which case the slot
+			 * stays reserved and keeps blocking aperture
+			 * unregistration until the transfer completes.
+			 */
+			data->maps[i].active = false;
+			break;
+		}
+	}
+
+	k_spin_unlock(&data->lock, key);
+}
+
+static int pcie_ep_emul_raise_irq(const struct device *dev, enum pci_ep_irq_type irq_type,
+				  uint32_t irq_num)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_irq_event *event;
+	k_spinlock_key_t key;
+	uint32_t ctrl;
+	int ret = 0;
+
+	key = k_spin_lock(&data->lock);
+
+	/*
+	 * Devicetree capability and vector bounds are checked first, then
+	 * the host-programmed enable state: like hardware, raises are
+	 * honored only while the host has the capability enabled, MSI
+	 * additionally bounds vectors by the host-programmed allocation
+	 * (2^MME, one vector by default), and MSI-X raises are suppressed
+	 * while the function mask is set. All checks run before any event
+	 * is recorded.
+	 */
+	switch (irq_type) {
+	case PCIE_EP_IRQ_LEGACY:
+		if (!cfg->legacy_irq) {
+			ret = -ENOTSUP;
+		}
+		break;
+	case PCIE_EP_IRQ_MSI:
+		if (cfg->msi_vectors == 0) {
+			ret = -ENOTSUP;
+		} else if (irq_num >= cfg->msi_vectors) {
+			ret = -EINVAL;
+		} else {
+			ctrl = sys_get_le32(&data->cfg[PCIE_EP_EMUL_CFG_FIRST_CAP]);
+			if ((ctrl & PCIE_EP_EMUL_MSI_CTRL_ENABLE) == 0) {
+				ret = -ENOTSUP;
+			} else {
+				if (irq_num >= BIT((ctrl & PCIE_EP_EMUL_MSI_MME_MASK) >>
+						   PCIE_EP_EMUL_MSI_MME_SHIFT)) {
+					ret = -EINVAL;
+				}
+			}
+		}
+		break;
+	case PCIE_EP_IRQ_MSIX:
+		if (cfg->msix_vectors == 0) {
+			ret = -ENOTSUP;
+		} else if (irq_num >= cfg->msix_vectors) {
+			ret = -EINVAL;
+		} else {
+			ctrl = sys_get_le32(&data->cfg[pcie_ep_emul_cfg_msix_offset(cfg)]);
+			if ((ctrl & PCIE_EP_EMUL_MSIX_CTRL_ENABLE) == 0 ||
+			    (ctrl & PCIE_EP_EMUL_MSIX_CTRL_FUNC_MASK) != 0) {
+				ret = -ENOTSUP;
+			}
+		}
+		break;
+	default:
+		ret = -EINVAL;
+	}
+	if (ret != 0) {
+		goto out;
+	}
+
+	if (data->irq_events_head - data->irq_events_tail >= ARRAY_SIZE(data->irq_events)) {
+		ret = -ENOSPC;
+		goto out;
+	}
+
+	event = &data->irq_events[data->irq_events_head % ARRAY_SIZE(data->irq_events)];
+	event->type = irq_type;
+	event->vector = irq_type == PCIE_EP_IRQ_LEGACY ? 0 : irq_num;
+	data->irq_events_head++;
+
+out:
+	k_spin_unlock(&data->lock, key);
+
+	if (ret == 0) {
+		/* Notify waiting test hosts only after the event is visible. */
+		k_sem_give(&data->irq_sem);
+	}
+
+	return ret;
+}
+
+int pcie_ep_emul_wait_irq_event(const struct device *dev, struct pcie_ep_emul_irq_event *event,
+				k_timeout_t timeout)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	if (event == NULL) {
+		return -EINVAL;
+	}
+
+	if (k_sem_take(&data->irq_sem, timeout) != 0) {
+		return -EAGAIN;
+	}
+
+	key = k_spin_lock(&data->lock);
+	*event = data->irq_events[data->irq_events_tail % ARRAY_SIZE(data->irq_events)];
+	data->irq_events_tail++;
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+static int pcie_ep_emul_register_reset_cb(const struct device *dev, enum pcie_reset reset,
+					  pcie_ep_reset_callback_t cb, void *arg)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	if ((uint32_t)reset >= PCIE_RESET_MAX || cb == NULL) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&data->lock);
+	data->reset_cbs[reset] = cb;
+	data->reset_cb_args[reset] = arg;
+	k_spin_unlock(&data->lock, key);
+
+	return 0;
+}
+
+struct pcie_ep_emul_reset_inject {
+	const struct device *dev;
+	enum pcie_reset reset;
+};
+
+static void pcie_ep_emul_reset_isr(const void *param)
+{
+	const struct pcie_ep_emul_reset_inject *inject = param;
+	struct pcie_ep_emul_data *data = inject->dev->data;
+	pcie_ep_reset_callback_t cb;
+	k_spinlock_key_t key;
+	void *arg;
+
+	key = k_spin_lock(&data->lock);
+	cb = data->reset_cbs[inject->reset];
+	arg = data->reset_cb_args[inject->reset];
+	k_spin_unlock(&data->lock, key);
+
+	if (cb != NULL) {
+		cb(arg);
+	}
+}
+
+int pcie_ep_emul_inject_reset(const struct device *dev, enum pcie_reset reset)
+{
+	struct pcie_ep_emul_reset_inject inject = {
+		.dev = dev,
+		.reset = reset,
+	};
+
+	if ((uint32_t)reset >= PCIE_RESET_MAX) {
+		return -EINVAL;
+	}
+
+	/* Deliver synchronously in interrupt context, like real hardware. */
+	irq_offload(pcie_ep_emul_reset_isr, &inject);
+
+	return 0;
+}
+
+static void pcie_ep_emul_dma_callback(const struct device *dma_dev, void *user_data,
+				      uint32_t channel, int status)
+{
+	struct pcie_ep_emul_dma_chan *chan = user_data;
+
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(channel);
+
+	/* Record the status before releasing the waiter. */
+	chan->status = status;
+	k_sem_give(&chan->done);
+}
+
+/*
+ * The host side of a DMA transfer must be wholly covered by an active
+ * map record produced by map_addr; containment in a registered aperture
+ * alone is not sufficient, so raw or already unmapped addresses are
+ * rejected. The caller pins the returned record (dma_inflight) for the
+ * whole transfer, so unmapping the record or unregistering its aperture
+ * mid-transfer cannot release the host buffer underneath the copy: the
+ * record stays reserved until the transfer completes, and the aperture
+ * cannot be unregistered while any record referencing it is active or
+ * pinned. Caller must hold data->lock.
+ */
+static struct pcie_ep_emul_map *pcie_ep_emul_mapped_covered(struct pcie_ep_emul_data *data,
+							    uint64_t mapped_addr, uint32_t size)
+{
+	for (int i = 0; i < ARRAY_SIZE(data->maps); i++) {
+		struct pcie_ep_emul_map *map = &data->maps[i];
+
+		if (map->active &&
+		    pcie_ep_emul_range_within(mapped_addr, size, map->mapped_addr, map->size)) {
+			return map;
+		}
+	}
+
+	return NULL;
+}
+
+static int pcie_ep_emul_dma_xfer(const struct device *dev, uint64_t mapped_addr,
+				 uintptr_t local_addr, uint32_t size, enum xfer_direction dir)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	struct pcie_ep_emul_data *data = dev->data;
+	struct pcie_ep_emul_dma_chan *chan;
+	struct dma_block_config block_cfg;
+	const struct device *dma_dev;
+	struct pcie_ep_emul_map *pin;
+	struct dma_config dma_cfg;
+	k_spinlock_key_t key;
+	int ret;
+
+	if (dir != HOST_TO_DEVICE && dir != DEVICE_TO_HOST) {
+		return -EINVAL;
+	}
+
+	/*
+	 * The mutex/semaphore waits below only work from thread context.
+	 * Note that calling from the DMA controller's own workqueue thread
+	 * (for example chaining a transfer from a dma_emul completion
+	 * callback) deadlocks: the completion callback this function waits
+	 * for could never run. Only k_is_in_isr() can be checked here.
+	 */
+	if (k_is_in_isr()) {
+		return -EINVAL;
+	}
+
+	if (local_addr == 0 || size == 0 || pcie_ep_emul_range_overflows(mapped_addr, size)) {
+		return -EINVAL;
+	}
+
+	dma_dev = cfg->dma_devs[dir];
+	if (dma_dev == NULL) {
+		/* The instance has no dmas property: DMA is not available. */
+		return -ENODEV;
+	}
+	if (!device_is_ready(dma_dev)) {
+		return -ENODEV;
+	}
+
+	/*
+	 * Pin the covering map record for the whole transfer so that a
+	 * concurrent unmap_addr() cannot hand its slot out again and a
+	 * concurrent aperture unregistration is blocked (-EBUSY) until the
+	 * copy below has completed.
+	 */
+	key = k_spin_lock(&data->lock);
+	pin = pcie_ep_emul_mapped_covered(data, mapped_addr, size);
+	if (pin != NULL) {
+		pin->dma_inflight++;
+	}
+	k_spin_unlock(&data->lock, key);
+	if (pin == NULL) {
+		return -ENOTSUP;
+	}
+
+	chan = &data->dma[dir];
+
+	/*
+	 * Hold the channel for the whole configure..completion cycle so
+	 * concurrent users of the same direction cannot interleave. A
+	 * K_FOREVER wait cannot fail; assert the return value rather than
+	 * discarding it.
+	 */
+	/* clang-format off */
+	__ASSERT_EVAL((void)k_mutex_lock(&chan->lock, K_FOREVER),
+		int lock_ret = k_mutex_lock(&chan->lock, K_FOREVER),
+		lock_ret == 0, "k_mutex_lock failed");
+	/* clang-format on */
+
+	block_cfg = (struct dma_block_config){
+		.source_address = dir == DEVICE_TO_HOST ? (uint64_t)local_addr : mapped_addr,
+		.dest_address = dir == DEVICE_TO_HOST ? mapped_addr : (uint64_t)local_addr,
+		.block_size = size,
+	};
+	dma_cfg = (struct dma_config){
+		.dma_slot = 0,
+		.channel_direction = MEMORY_TO_MEMORY,
+		.complete_callback_en = 1,
+		.source_data_size = 1,
+		.dest_data_size = 1,
+		.source_burst_length = 1,
+		.dest_burst_length = 1,
+		.block_count = 1,
+		.head_block = &block_cfg,
+		.user_data = chan,
+		.dma_callback = pcie_ep_emul_dma_callback,
+	};
+
+	/*
+	 * Configure-time -EBUSY flags a channel grabbed by another user
+	 * directly on the controller; cross-instance sharing is already
+	 * excluded by the exclusive channel claims made at init.
+	 */
+	ret = dma_config(dma_dev, cfg->dma_channels[dir], &dma_cfg);
+	if (ret == 0) {
+		ret = dma_start(dma_dev, cfg->dma_channels[dir]);
+		if (ret != 0) {
+			/* Undo our LOADED state so the channel stays usable. */
+			(void)dma_stop(dma_dev, cfg->dma_channels[dir]);
+		}
+	}
+	if (ret == 0) {
+		/*
+		 * Once dma_start() accepted the transfer, the callback
+		 * always fires from the controller workqueue, with
+		 * DMA_STATUS_COMPLETE on success or a negative status on
+		 * cancellation; the waiter therefore cannot sleep forever
+		 * and the pinned mapping stays reserved through the copy.
+		 * This only holds because the caller is a foreign thread:
+		 * from the controller workqueue itself the callback could
+		 * never run, which the context check at function entry
+		 * documents but cannot detect.
+		 */
+		/* clang-format off */
+		__ASSERT_EVAL((void)k_sem_take(&chan->done, K_FOREVER),
+			int take_ret = k_sem_take(&chan->done, K_FOREVER),
+			take_ret == 0, "k_sem_take failed");
+		/* clang-format on */
+		if (chan->status == DMA_STATUS_COMPLETE) {
+			ret = 0;
+		} else {
+			ret = chan->status < 0 ? chan->status : -EIO;
+		}
+	}
+
+	/* Unlocking a mutex this thread holds cannot fail either. */
+	/* clang-format off */
+	__ASSERT_EVAL((void)k_mutex_unlock(&chan->lock),
+		int unlock_ret = k_mutex_unlock(&chan->lock),
+		unlock_ret == 0, "k_mutex_unlock failed");
+	/* clang-format on */
+
+	/* The copy is over: release the pin taken before the transfer. */
+	key = k_spin_lock(&data->lock);
+	pin->dma_inflight--;
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static DEVICE_API(pcie_ep, pcie_ep_emul_api) = {
+	.conf_read = pcie_ep_emul_conf_read,
+	.conf_write = pcie_ep_emul_conf_write,
+	.map_addr = pcie_ep_emul_map_addr,
+	.unmap_addr = pcie_ep_emul_unmap_addr,
+	.raise_irq = pcie_ep_emul_raise_irq,
+	.register_reset_cb = pcie_ep_emul_register_reset_cb,
+	.dma_xfer = pcie_ep_emul_dma_xfer,
+};
+
+/*
+ * Claim each named channel from its controller so that two endpoint
+ * instances cannot drive the same channel. dma_request_channel()
+ * allocates through the controller's dma_context atomic bitmask, so
+ * claims are race-free across instances; the claim is held for the
+ * whole device lifetime and never released. The channel number named in
+ * devicetree is passed to the controller's channel filter by address, so
+ * claims do not depend on device init order: receiving any other channel,
+ * or no channel at all, means the named channel was taken by another
+ * user. On any failure all channels already claimed by this init are
+ * released again, so a device that never becomes ready leaks no claims.
+ * filter_param is not standardized by the DMA API, so the by-address
+ * uint32_t channel-number encoding is only valid for controllers
+ * implementing the dma_emul filter convention; the dmas controllers are
+ * restricted to zephyr,dma-emul by build-time assertion.
+ */
+static int pcie_ep_emul_claim_dma_channels(const struct device *dev)
+{
+	const struct pcie_ep_emul_config *cfg = dev->config;
+	int ret = 0;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(cfg->dma_devs); i++) {
+		const struct device *dma_dev = cfg->dma_devs[i];
+		uint32_t channel = cfg->dma_channels[i];
+		int claimed;
+
+		if (dma_dev == NULL) {
+			continue;
+		}
+
+		if (!device_is_ready(dma_dev)) {
+			LOG_ERR("%s: DMA controller %s is not ready", dev->name, dma_dev->name);
+			ret = -ENODEV;
+			break;
+		}
+
+		claimed = dma_request_channel(dma_dev, &channel);
+		if (claimed >= 0 && (uint32_t)claimed != cfg->dma_channels[i]) {
+			dma_release_channel(dma_dev, (uint32_t)claimed);
+			claimed = -EBUSY;
+		}
+		if (claimed < 0) {
+			LOG_ERR("%s: cannot claim channel %u of %s", dev->name,
+				cfg->dma_channels[i], dma_dev->name);
+			ret = -EBUSY;
+			break;
+		}
+	}
+
+	if (ret != 0) {
+		/* Roll back every channel this init already claimed. */
+		for (int j = 0; j < i; j++) {
+			if (cfg->dma_devs[j] != NULL) {
+				dma_release_channel(cfg->dma_devs[j], cfg->dma_channels[j]);
+			}
+		}
+	}
+
+	return ret;
+}
+
+static int pcie_ep_emul_init(const struct device *dev)
+{
+	struct pcie_ep_emul_data *data = dev->data;
+
+	if (pcie_ep_emul_claim_dma_channels(dev) != 0) {
+		return -ENODEV;
+	}
+
+	k_sem_init(&data->irq_sem, 0, CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS);
+	for (int i = 0; i < ARRAY_SIZE(data->dma); i++) {
+		k_mutex_init(&data->dma[i].lock);
+		k_sem_init(&data->dma[i].done, 0, 1);
+	}
+	pcie_ep_emul_cfg_init(dev);
+
+	return 0;
+}
+
+#define PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, idx)                                                    \
+	BUILD_ASSERT(                                                                              \
+		DT_INST_PROP_BY_IDX(inst, bar_sizes, idx) == 0 ||                                  \
+			(IS_POWER_OF_TWO(DT_INST_PROP_BY_IDX(inst, bar_sizes, idx)) &&             \
+			 DT_INST_PROP_BY_IDX(inst, bar_sizes, idx) >= PCIE_EP_EMUL_BAR_MIN_SIZE),  \
+		"bar-sizes entries must be zero or a power of two >= 4096")
+
+#define PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, idx)                                                 \
+	static uint8_t pcie_ep_emul_bar_backing_##inst##_##idx[MAX(                                \
+		DT_INST_PROP_BY_IDX(inst, bar_sizes, idx), 1)]
+
+#define PCIE_EP_EMUL_BAR_BACKING_PTR(inst, idx)                                                    \
+	DT_INST_PROP_BY_IDX(inst, bar_sizes, idx) != 0 ? pcie_ep_emul_bar_backing_##inst##_##idx   \
+						       : NULL
+
+#define PCIE_EP_EMUL_DMA_DEV(inst, name)                                                           \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                          \
+		    (DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(inst, name))), (NULL))
+
+#define PCIE_EP_EMUL_DMA_CHANNEL(inst, name)                                                       \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                          \
+		    (DT_INST_DMAS_CELL_BY_NAME(inst, name, channel)), (0))
+
+/*
+ * Exact-channel claiming passes the devicetree channel number to the
+ * controller's channel filter as a pointer to uint32_t. The DMA API does
+ * not standardize filter_param; that encoding is the dma_emul
+ * convention, so restrict dmas controllers to zephyr,dma-emul at build
+ * time rather than assuming any controller honors it.
+ */
+#define PCIE_EP_EMUL_DMA_CTRL_ASSERT(node_id, prop, idx)                                           \
+	BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_PHANDLE_BY_IDX(node_id, prop, idx), zephyr_dma_emul),   \
+		     "zephyr,pcie-ep-emul dmas controllers must be zephyr,dma-emul: "              \
+		     "exact-channel claiming relies on the dma_emul channel-filter encoding");
+
+#define PCIE_EP_EMUL_DMA_CTRLS_ASSERT(inst)                                                        \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                          \
+		    (DT_INST_FOREACH_PROP_ELEM(inst, dmas, PCIE_EP_EMUL_DMA_CTRL_ASSERT)), ())
+
+/* Size of the first enabled BAR, or zero when all BARs are disabled. */
+#define PCIE_EP_EMUL_FIRST_BAR_SIZE(inst)                                                          \
+	(DT_INST_PROP_BY_IDX(inst, bar_sizes, 0) != 0   ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 0)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 1) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 1)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 2) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 2)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 3) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 3)  \
+	 : DT_INST_PROP_BY_IDX(inst, bar_sizes, 4) != 0 ? DT_INST_PROP_BY_IDX(inst, bar_sizes, 4)  \
+							: DT_INST_PROP_BY_IDX(inst, bar_sizes, 5))
+
+/* PBA storage for a vector count: one bit per vector, in 8-byte multiples. */
+#define PCIE_EP_EMUL_MSIX_PBA_SIZE(vectors) ROUND_UP(DIV_ROUND_UP(vectors, 8), 8)
+
+#define PCIE_EP_EMUL_MSIX_FITS_ASSERT(inst)                                                        \
+	BUILD_ASSERT(DT_INST_PROP(inst, msix_vectors) == 0 ||                                      \
+			     DT_INST_PROP(inst, msix_vectors) * 16U +                              \
+					     PCIE_EP_EMUL_MSIX_PBA_SIZE(                           \
+						     DT_INST_PROP(inst, msix_vectors)) <=          \
+				     PCIE_EP_EMUL_FIRST_BAR_SIZE(inst),                            \
+		     "msix-vectors table and PBA must fit in the first enabled BAR")
+
+#define PCIE_EP_EMUL_DEFINE(inst)                                                                  \
+	BUILD_ASSERT(DT_INST_PROP_LEN(inst, bar_sizes) == PCIE_EP_EMUL_BAR_COUNT,                  \
+		     "bar-sizes must have exactly 6 entries");                                     \
+	BUILD_ASSERT(DT_INST_PROP(inst, vendor_id) <= 0xFFFFU,                                     \
+		     "vendor-id must fit the 16-bit configuration space field");                   \
+	BUILD_ASSERT(DT_INST_PROP(inst, device_id) <= 0xFFFFU,                                     \
+		     "device-id must fit the 16-bit configuration space field");                   \
+	BUILD_ASSERT(DT_INST_PROP(inst, class_code) <= 0xFFFFFFU,                                  \
+		     "class-code must fit the 24-bit configuration space field");                  \
+	BUILD_ASSERT(DT_INST_PROP(inst, revision_id) <= 0xFFU,                                     \
+		     "revision-id must fit the 8-bit configuration space field");                  \
+	BUILD_ASSERT(DT_INST_NODE_HAS_PROP(inst, dmas) == DT_INST_NODE_HAS_PROP(inst, dma_names),  \
+		     "dmas and dma-names must be either both absent or both present");             \
+	BUILD_ASSERT(!DT_INST_NODE_HAS_PROP(inst, dmas) ||                                         \
+			     (DT_INST_PROP_LEN_OR(inst, dmas, 0) == 2 &&                           \
+			      DT_INST_PROP_LEN_OR(inst, dma_names, 0) == 2),                       \
+		     "dmas and dma-names must have exactly two entries when present");             \
+	PCIE_EP_EMUL_DMA_CTRLS_ASSERT(inst);                                                       \
+	BUILD_ASSERT(DT_INST_PROP(inst, msi_vectors) == 0 ||                                       \
+			     (IS_POWER_OF_TWO(DT_INST_PROP(inst, msi_vectors)) &&                  \
+			      DT_INST_PROP(inst, msi_vectors) <= 32U),                             \
+		     "msi-vectors must be zero or a power of two up to 32");                       \
+	BUILD_ASSERT(DT_INST_PROP(inst, msix_vectors) <= 2048U,                                    \
+		     "msix-vectors must fit the 11-bit table size field");                         \
+	BUILD_ASSERT(DT_INST_PROP(inst, msix_vectors) == 0 ||                                      \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 0) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 1) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 2) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 3) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 4) != 0 ||                       \
+			     DT_INST_PROP_BY_IDX(inst, bar_sizes, 5) != 0,                         \
+		     "msix-vectors requires at least one enabled BAR");                            \
+	PCIE_EP_EMUL_MSIX_FITS_ASSERT(inst);                                                       \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 0);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 1);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 2);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 3);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 4);                                                     \
+	PCIE_EP_EMUL_BAR_SIZE_ASSERT(inst, 5);                                                     \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 0);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 1);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 2);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 3);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 4);                                                  \
+	PCIE_EP_EMUL_BAR_BACKING_DEFINE(inst, 5);                                                  \
+	static const struct pcie_ep_emul_config pcie_ep_emul_config_##inst = {                     \
+		.vendor_id = DT_INST_PROP(inst, vendor_id),                                        \
+		.device_id = DT_INST_PROP(inst, device_id),                                        \
+		.class_code = DT_INST_PROP(inst, class_code),                                      \
+		.revision_id = DT_INST_PROP(inst, revision_id),                                    \
+		.bar_sizes = DT_INST_PROP(inst, bar_sizes),                                        \
+		.msi_vectors = DT_INST_PROP(inst, msi_vectors),                                    \
+		.msix_vectors = DT_INST_PROP(inst, msix_vectors),                                  \
+		.legacy_irq = DT_INST_PROP(inst, legacy_irq),                                      \
+		.dma_devs = {PCIE_EP_EMUL_DMA_DEV(inst, host_to_device),                           \
+			     PCIE_EP_EMUL_DMA_DEV(inst, device_to_host)},                          \
+		.dma_channels = {PCIE_EP_EMUL_DMA_CHANNEL(inst, host_to_device),                   \
+				 PCIE_EP_EMUL_DMA_CHANNEL(inst, device_to_host)},                  \
+	};                                                                                         \
+	static struct pcie_ep_emul_data pcie_ep_emul_data_##inst = {                               \
+		.bar_backing = {PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 0),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 1),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 2),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 3),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 4),                             \
+				PCIE_EP_EMUL_BAR_BACKING_PTR(inst, 5)},                            \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, &pcie_ep_emul_init, NULL, &pcie_ep_emul_data_##inst,           \
+			      &pcie_ep_emul_config_##inst, POST_KERNEL,                            \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pcie_ep_emul_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PCIE_EP_EMUL_DEFINE)

--- a/dts/bindings/dma/zephyr,dma-emul.yaml
+++ b/dts/bindings/dma/zephyr,dma-emul.yaml
@@ -18,3 +18,6 @@ properties:
     type: int
     description: >
       Priority for the instance-specific work_q thread.
+
+dma-cells:
+  - channel

--- a/dts/bindings/pcie/endpoint/zephyr,pcie-ep-emul.yaml
+++ b/dts/bindings/pcie/endpoint/zephyr,pcie-ep-emul.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+title: Emulated PCIe Endpoint device
+
+description: |
+  This binding describes a process-local PCIe endpoint emulator. It
+  implements the Zephyr PCIe EP driver API purely in software, within the
+  same process as the emulation host (for example native_sim). The
+  emulated endpoint is NOT externally PCIe-enumerable: it does not appear
+  on any physical or virtual PCIe bus and cannot be discovered by an
+  external host. It is intended for testing PCIe endpoint applications on
+  POSIX/native targets.
+
+compatible: "zephyr,pcie-ep-emul"
+
+include: base.yaml
+
+properties:
+  vendor-id:
+    type: int
+    required: true
+    description: |
+      16-bit PCI vendor ID exposed in the emulated configuration space.
+      The range is enforced by a build-time assertion in the driver.
+
+  device-id:
+    type: int
+    required: true
+    description: |
+      16-bit PCI device ID exposed in the emulated configuration space.
+      The range is enforced by a build-time assertion in the driver.
+
+  class-code:
+    type: int
+    required: true
+    description: |
+      24-bit PCI class code (base class, sub-class and programming
+      interface) exposed in the emulated configuration space. The range
+      is enforced by a build-time assertion in the driver.
+
+  revision-id:
+    type: int
+    required: true
+    description: |
+      8-bit PCI revision ID exposed in the emulated configuration space.
+      The range is enforced by a build-time assertion in the driver.
+
+  bar-sizes:
+    type: array
+    required: true
+    description: |
+      Size in bytes of each of the 6 emulated Base Address Registers.
+      Exactly 6 cells are required, one per BAR. A zero entry disables the
+      corresponding BAR. Non-zero entries must be a power of two and at
+      least 4096 (the minimum PCIe BAR alignment); this is validated at
+      build time by the driver.
+
+  msi-vectors:
+    type: int
+    required: true
+    description: |
+      Number of MSI vectors the emulated endpoint supports. Must be zero
+      or a power of two up to 32 (validated at build time by the driver).
+      A non-zero value models an MSI capability in the emulated
+      configuration space; zero means no MSI capability is present and
+      MSI interrupts are rejected by pcie_ep_raise_irq().
+
+  msix-vectors:
+    type: int
+    required: true
+    description: |
+      Number of MSI-X vectors the emulated endpoint supports. Must be at
+      most 2048 (validated at build time by the driver). A non-zero value
+      models an MSI-X capability in the emulated configuration space and
+      requires at least one enabled BAR large enough to hold the MSI-X
+      table and PBA (validated at build time by the driver); zero means no MSI-X capability
+      is present and MSI-X interrupts are rejected by pcie_ep_raise_irq().
+
+  legacy-irq:
+    type: boolean
+    description: |
+      Present if the emulated endpoint supports legacy (INTx) interrupts.
+      When absent, legacy interrupts are rejected by pcie_ep_raise_irq().
+
+  dmas:
+    description: |
+      Optional pair of DMA channel specifiers used for host-memory data
+      transfers. If present, exactly two entries are required, ordered
+      host-to-device first and device-to-host second, with matching
+      dma-names. Channels must be dedicated: each direction of each
+      endpoint instance requires its own exclusive channel; channels must
+      not be shared between directions or between endpoint instances.
+      Each channel is claimed from its controller by its exact devicetree
+      channel number at driver init and held for the device lifetime, so
+      claims do not depend on device init order; if a named channel is
+      already claimed by another user, the offending endpoint releases
+      any channels it already claimed and fails to initialize.
+      The DMA API does not standardize the channel-filter parameter used
+      for exact claims, so the referenced controllers must implement the
+      zephyr,dma-emul filter convention (uint32_t channel number passed
+      by address); this is enforced by a build-time assertion in the
+      driver.
+
+  dma-names:
+    description: |
+      Names for the optional DMA channels. If dmas is present, exactly
+      two entries are required:
+        dma-names = "host-to-device", "device-to-host";
+      As for dmas, the named channels must be dedicated per direction per
+      endpoint instance and must not be shared.
+    enum:
+      - "host-to-device"
+      - "device-to-host"

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep_emul.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep_emul.h
@@ -1,0 +1,220 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Process-local test-host interface for the emulated PCIe EP.
+ *
+ * The functions declared here exist only for the zephyr,pcie-ep-emul
+ * driver. They model host-side resources (memory apertures, interrupt
+ * event consumption, reset injection, host configuration/BAR access)
+ * inside the same process as the emulated endpoint and are intended for
+ * tests on POSIX/native targets. They are not part of the generic PCIe
+ * EP driver API and have no meaning for real endpoint hardware.
+ *
+ * Note on the driver's pcie_ep_driver_api dma_xfer implementation: it
+ * blocks the caller until the DMA completion callback runs on the
+ * controller's workqueue, so it may only be called from thread context,
+ * and never from a DMA completion callback or the dma_emul workqueue
+ * thread itself — there the callback it waits for could never run and
+ * the call would deadlock.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_ENDPOINT_PCIE_EP_EMUL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PCIE_ENDPOINT_PCIE_EP_EMUL_H_
+
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep.h>
+#include <zephyr/kernel.h>
+
+/**
+ * @brief PCIe EP Emulator Test-Host Interface
+ * @defgroup pcie_ep_emul_interface PCIe EP Emulator Test-Host Interface
+ * @ingroup io_emulators
+ * @ingroup pcie_interface
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Interrupt event recorded by an emulated endpoint
+ *
+ * One event is recorded per successful pcie_ep_raise_irq() call and
+ * consumed by the test host through pcie_ep_emul_wait_irq_event().
+ * All fields are process-local test-host state, not wire data.
+ */
+struct pcie_ep_emul_irq_event {
+	/** Interrupt type passed to pcie_ep_raise_irq(). */
+	enum pci_ep_irq_type type;
+	/** MSI/MSI-X vector passed to pcie_ep_raise_irq(), zero for legacy. */
+	uint32_t vector;
+};
+
+/**
+ * @brief Register a host memory aperture for an emulated endpoint
+ *
+ * Models a chunk of host memory: the PCIe address range
+ * [pcie_base, pcie_base + len) becomes backed by the process-local buffer
+ * @a local_buf. pcie_ep_map_addr() only succeeds for ranges wholly inside
+ * a registered aperture. The caller retains ownership of @a local_buf,
+ * which must stay valid until the aperture is unregistered.
+ *
+ * @param dev       Emulated endpoint device
+ * @param pcie_base PCIe (host) base address of the aperture
+ * @param local_buf Process-local backing buffer
+ * @param len       Aperture length in bytes
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on NULL buffer, zero length or address overflow
+ * @retval -EALREADY if the range overlaps a registered aperture
+ * @retval -ENOMEM if the per-instance aperture table is full
+ */
+int pcie_ep_emul_register_aperture(const struct device *dev, uint64_t pcie_base, void *local_buf,
+				   uint32_t len);
+
+/**
+ * @brief Unregister a host memory aperture
+ *
+ * Removes the aperture starting at @a pcie_base. Apertures with mappings
+ * still in use (pcie_ep_map_addr() without matching pcie_ep_unmap_addr())
+ * cannot be unregistered.
+ *
+ * @param dev       Emulated endpoint device
+ * @param pcie_base PCIe (host) base address given at registration
+ *
+ * @retval 0 on success
+ * @retval -ENOENT if no registered aperture starts at pcie_base
+ * @retval -EBUSY if mappings inside the aperture are still active
+ */
+int pcie_ep_emul_unregister_aperture(const struct device *dev, uint64_t pcie_base);
+
+/**
+ * @brief Consume the oldest queued interrupt event (test-host API)
+ *
+ * Waits up to @a timeout for an interrupt event recorded by a successful
+ * pcie_ep_raise_irq() on @a dev, then removes and returns it. Events are
+ * consumed in raise order. Pass K_NO_WAIT for a non-blocking poll.
+ *
+ * @param dev     Emulated endpoint device
+ * @param event   Event destination
+ * @param timeout Maximum time to wait for an event
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on NULL @a event
+ * @retval -EAGAIN if no event arrived within @a timeout
+ */
+int pcie_ep_emul_wait_irq_event(const struct device *dev, struct pcie_ep_emul_irq_event *event,
+				k_timeout_t timeout);
+
+/**
+ * @brief Inject a PCIe reset into an emulated endpoint (test-host API)
+ *
+ * Models the host asserting a reset: the callback registered through
+ * pcie_ep_register_reset_cb() for @a reset is invoked with its
+ * registration argument in interrupt context (via irq_offload()), as
+ * the PCIe EP driver API contract requires. Injecting a reset with no
+ * registered callback succeeds without any callback running.
+ *
+ * @param dev   Emulated endpoint device
+ * @param reset Reset type to inject
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on an invalid reset type
+ */
+int pcie_ep_emul_inject_reset(const struct device *dev, enum pcie_reset reset);
+
+/**
+ * @brief Read endpoint configuration space as the host (test-host API)
+ *
+ * Models a host configuration read: same layout and access rules as
+ * pcie_ep_conf_read().
+ *
+ * @param dev    Emulated endpoint device
+ * @param offset Offset within configuration space
+ * @param value  Value destination
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on a misaligned or out-of-range offset
+ */
+int pcie_ep_emul_host_conf_read(const struct device *dev, uint32_t offset, uint32_t *value);
+
+/**
+ * @brief Write endpoint configuration space as the host (test-host API)
+ *
+ * Models a host configuration write: same writability rules as
+ * pcie_ep_conf_write() (only the low command bits, enabled BARs as
+ * size-masked base assignment, and the MSI/MSI-X control bits described
+ * for the device are writable). Writes to registers without writable
+ * bits fail with -EPERM and leave the image unchanged.
+ *
+ * @param dev    Emulated endpoint device
+ * @param offset Offset within configuration space
+ * @param value  Value to write
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on a misaligned or out-of-range offset
+ * @retval -EPERM on a write to a register without writable bits
+ *         (identity, class/revision, capability pointer, disabled BARs,
+ *         unimplemented space)
+ */
+int pcie_ep_emul_host_conf_write(const struct device *dev, uint32_t offset, uint32_t value);
+
+/**
+ * @brief Read BAR memory as the host (test-host API)
+ *
+ * Models host reads of the memory window behind BAR @a bar: copies
+ * @a len bytes from the BAR backing storage at @a offset into @a buf.
+ * The assigned base is not consulted; the test host is expected to
+ * access only BARs it has assigned through configuration writes.
+ *
+ * @param dev    Emulated endpoint device
+ * @param bar    BAR index (0..5)
+ * @param offset Byte offset within the BAR window
+ * @param buf    Destination buffer
+ * @param len    Number of bytes to read
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on an invalid BAR index, NULL buffer, zero length,
+ *         an access exceeding the BAR size, or a disabled BAR
+ */
+int pcie_ep_emul_host_bar_read(const struct device *dev, uint32_t bar, uint32_t offset, void *buf,
+			       uint32_t len);
+
+/**
+ * @brief Write BAR memory as the host (test-host API)
+ *
+ * Models host writes of the memory window behind BAR @a bar: copies
+ * @a len bytes from @a buf into the BAR backing storage at @a offset.
+ * See pcie_ep_emul_host_bar_read() for the access semantics.
+ *
+ * @param dev    Emulated endpoint device
+ * @param bar    BAR index (0..5)
+ * @param offset Byte offset within the BAR window
+ * @param buf    Source buffer
+ * @param len    Number of bytes to write
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on an invalid BAR index, NULL buffer, zero length,
+ *         an access exceeding the BAR size, or a disabled BAR
+ */
+int pcie_ep_emul_host_bar_write(const struct device *dev, uint32_t bar, uint32_t offset,
+				const void *buf, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PCIE_ENDPOINT_PCIE_EP_EMUL_H_ */

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep_emul.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep_emul.h
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Process-local test-host interface for the emulated PCIe EP.
+ *
+ * The functions declared here exist only for the zephyr,pcie-ep-emul
+ * driver. They model host-side resources (memory apertures, interrupt
+ * event consumption, reset injection, host configuration/BAR access)
+ * inside the same process as the emulated endpoint and are intended for
+ * tests on POSIX/native targets. They are not part of the generic PCIe
+ * EP driver API and have no meaning for real endpoint hardware.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_ENDPOINT_PCIE_EP_EMUL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PCIE_ENDPOINT_PCIE_EP_EMUL_H_
+
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep.h>
+#include <zephyr/kernel.h>
+
+/**
+ * @brief PCIe EP Emulator Test-Host Interface
+ * @defgroup pcie_ep_emul_interface PCIe EP Emulator Test-Host Interface
+ * @ingroup io_emulators
+ * @ingroup pcie_interface
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Interrupt event recorded by an emulated endpoint
+ *
+ * One event is recorded per successful pcie_ep_raise_irq() call and
+ * consumed by the test host through pcie_ep_emul_wait_irq_event().
+ * All fields are process-local test-host state, not wire data.
+ */
+struct pcie_ep_emul_irq_event {
+	/** Interrupt type passed to pcie_ep_raise_irq(). */
+	enum pci_ep_irq_type type;
+	/** MSI/MSI-X vector passed to pcie_ep_raise_irq(), zero for legacy. */
+	uint32_t vector;
+};
+
+/**
+ * @brief Register a host memory aperture for an emulated endpoint
+ *
+ * Models a chunk of host memory: the PCIe address range
+ * [pcie_base, pcie_base + len) becomes backed by the process-local buffer
+ * @a local_buf. pcie_ep_map_addr() only succeeds for ranges wholly inside
+ * a registered aperture. The caller retains ownership of @a local_buf,
+ * which must stay valid until the aperture is unregistered.
+ *
+ * @param dev       Emulated endpoint device
+ * @param pcie_base PCIe (host) base address of the aperture
+ * @param local_buf Process-local backing buffer
+ * @param len       Aperture length in bytes
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on NULL buffer, zero length or address overflow
+ * @retval -EALREADY if the range overlaps a registered aperture
+ * @retval -ENOMEM if the per-instance aperture table is full
+ */
+int pcie_ep_emul_register_aperture(const struct device *dev, uint64_t pcie_base, void *local_buf,
+				   uint32_t len);
+
+/**
+ * @brief Unregister a host memory aperture
+ *
+ * Removes the aperture starting at @a pcie_base. Apertures with mappings
+ * still in use (pcie_ep_map_addr() without matching pcie_ep_unmap_addr())
+ * cannot be unregistered.
+ *
+ * @param dev       Emulated endpoint device
+ * @param pcie_base PCIe (host) base address given at registration
+ *
+ * @retval 0 on success
+ * @retval -ENOENT if no registered aperture starts at pcie_base
+ * @retval -EBUSY if mappings inside the aperture are still active
+ */
+int pcie_ep_emul_unregister_aperture(const struct device *dev, uint64_t pcie_base);
+
+/**
+ * @brief Consume the oldest queued interrupt event (test-host API)
+ *
+ * Waits up to @a timeout for an interrupt event recorded by a successful
+ * pcie_ep_raise_irq() on @a dev, then removes and returns it. Events are
+ * consumed in raise order. Pass K_NO_WAIT for a non-blocking poll.
+ *
+ * @param dev     Emulated endpoint device
+ * @param event   Event destination
+ * @param timeout Maximum time to wait for an event
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on NULL @a event
+ * @retval -EAGAIN if no event arrived within @a timeout
+ */
+int pcie_ep_emul_wait_irq_event(const struct device *dev, struct pcie_ep_emul_irq_event *event,
+				k_timeout_t timeout);
+
+/**
+ * @brief Inject a PCIe reset into an emulated endpoint (test-host API)
+ *
+ * Models the host asserting a reset: the callback registered through
+ * pcie_ep_register_reset_cb() for @a reset is invoked with its
+ * registration argument in interrupt context (via irq_offload()), as
+ * the PCIe EP driver API contract requires. Injecting a reset with no
+ * registered callback succeeds without any callback running.
+ *
+ * @param dev   Emulated endpoint device
+ * @param reset Reset type to inject
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on an invalid reset type
+ */
+int pcie_ep_emul_inject_reset(const struct device *dev, enum pcie_reset reset);
+
+/**
+ * @brief Read endpoint configuration space as the host (test-host API)
+ *
+ * Models a host configuration read: same layout and access rules as
+ * pcie_ep_conf_read().
+ *
+ * @param dev    Emulated endpoint device
+ * @param offset Offset within configuration space
+ * @param value  Value destination
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on a misaligned or out-of-range offset
+ */
+int pcie_ep_emul_host_conf_read(const struct device *dev, uint32_t offset, uint32_t *value);
+
+/**
+ * @brief Write endpoint configuration space as the host (test-host API)
+ *
+ * Models a host configuration write: same writability rules as
+ * pcie_ep_conf_write() (only the low command bits, enabled BARs as
+ * size-masked base assignment, and the MSI/MSI-X control bits described
+ * for the device are writable). Writes to registers without writable
+ * bits fail with -EPERM and leave the image unchanged.
+ *
+ * @param dev    Emulated endpoint device
+ * @param offset Offset within configuration space
+ * @param value  Value to write
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on a misaligned or out-of-range offset
+ * @retval -EPERM on a write to a register without writable bits
+ *         (identity, class/revision, capability pointer, disabled BARs,
+ *         unimplemented space)
+ */
+int pcie_ep_emul_host_conf_write(const struct device *dev, uint32_t offset, uint32_t value);
+
+/**
+ * @brief Read BAR memory as the host (test-host API)
+ *
+ * Models host reads of the memory window behind BAR @a bar: copies
+ * @a len bytes from the BAR backing storage at @a offset into @a buf.
+ * The assigned base is not consulted; the test host is expected to
+ * access only BARs it has assigned through configuration writes.
+ *
+ * @param dev    Emulated endpoint device
+ * @param bar    BAR index (0..5)
+ * @param offset Byte offset within the BAR window
+ * @param buf    Destination buffer
+ * @param len    Number of bytes to read
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on an invalid BAR index, NULL buffer, zero length,
+ *         an access exceeding the BAR size, or a disabled BAR
+ */
+int pcie_ep_emul_host_bar_read(const struct device *dev, uint32_t bar, uint32_t offset, void *buf,
+			       uint32_t len);
+
+/**
+ * @brief Write BAR memory as the host (test-host API)
+ *
+ * Models host writes of the memory window behind BAR @a bar: copies
+ * @a len bytes from @a buf into the BAR backing storage at @a offset.
+ * See pcie_ep_emul_host_bar_read() for the access semantics.
+ *
+ * @param dev    Emulated endpoint device
+ * @param bar    BAR index (0..5)
+ * @param offset Byte offset within the BAR window
+ * @param buf    Source buffer
+ * @param len    Number of bytes to write
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on an invalid BAR index, NULL buffer, zero length,
+ *         an access exceeding the BAR size, or a disabled BAR
+ */
+int pcie_ep_emul_host_bar_write(const struct device *dev, uint32_t bar, uint32_t offset,
+				const void *buf, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PCIE_ENDPOINT_PCIE_EP_EMUL_H_ */

--- a/tests/drivers/dma/emul_concurrent/CMakeLists.txt
+++ b/tests/drivers/dma/emul_concurrent/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(dma_emul_concurrent)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/dma/emul_concurrent/boards/native_sim.overlay
+++ b/tests/drivers/dma/emul_concurrent/boards/native_sim.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma {
+	dma-channels = <2>;
+	status = "okay";
+};
+
+tst_dma0: &dma {};

--- a/tests/drivers/dma/emul_concurrent/boards/native_sim_native_64.overlay
+++ b/tests/drivers/dma/emul_concurrent/boards/native_sim_native_64.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma {
+	dma-channels = <2>;
+	status = "okay";
+};
+
+tst_dma0: &dma {};

--- a/tests/drivers/dma/emul_concurrent/prj.conf
+++ b/tests/drivers/dma/emul_concurrent/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_DMA=y
+CONFIG_DMA_EMUL=y

--- a/tests/drivers/dma/emul_concurrent/src/main.c
+++ b/tests/drivers/dma/emul_concurrent/src/main.c
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Verify concurrent transfers on separate channels of a dma_emul
+ *        controller complete independently.
+ * @details
+ * - Test Steps
+ *   -# Configure two channels with distinct buffers, callbacks and user data
+ *   -# Start both channels without waiting for the first to complete
+ * - Expected Results
+ *   -# Both transfers complete with data intact
+ *   -# Each callback fires exactly once, with its own channel and user data
+ */
+
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#define NUM_CHANNELS 2
+#define XFER_SIZE    64
+#define TIMEOUT      K_MSEC(1000)
+
+struct chan_ctx {
+	struct k_sem sem;
+	void *seen_user_data;
+	uint32_t channel;
+	int status;
+	int calls;
+	uint8_t tx[XFER_SIZE];
+	uint8_t rx[XFER_SIZE];
+};
+
+static const struct device *const dma_dev = DEVICE_DT_GET(DT_NODELABEL(tst_dma0));
+static struct chan_ctx chan_ctxs[NUM_CHANNELS];
+
+static void dma_emul_test_callback(const struct device *dev, void *user_data, uint32_t channel,
+				   int status)
+{
+	struct chan_ctx *ctx = (struct chan_ctx *)user_data;
+
+	ARG_UNUSED(dev);
+
+	ctx->seen_user_data = user_data;
+	ctx->channel = channel;
+	ctx->status = status;
+	ctx->calls++;
+	k_sem_give(&ctx->sem);
+}
+
+ZTEST(dma_emul_concurrent, test_chan_filter_exact_request)
+{
+	uint32_t wanted;
+	int ch;
+
+	zassert_true(device_is_ready(dma_dev), "dma controller device is not ready");
+
+	/* A NULL filter param keeps the any-free-channel behavior. */
+	ch = dma_request_channel(dma_dev, NULL);
+	zassert_equal(ch, 0, "NULL filter param did not return the lowest free channel");
+	dma_release_channel(dma_dev, (uint32_t)ch);
+
+	/* A filter param pointing to a channel number requests exactly that channel. */
+	wanted = 1;
+	ch = dma_request_channel(dma_dev, &wanted);
+	zassert_equal(ch, 1, "exact request for channel 1 returned %d", ch);
+
+	/* The exact channel is taken now: requesting it again fails. */
+	ch = dma_request_channel(dma_dev, &wanted);
+	zassert_equal(ch, -EINVAL, "re-requesting taken channel 1 returned %d", ch);
+
+	/* Channel zero is a valid exact request, distinct from a NULL param. */
+	wanted = 0;
+	ch = dma_request_channel(dma_dev, &wanted);
+	zassert_equal(ch, 0, "exact request for channel 0 returned %d", ch);
+
+	/* Both channels are taken: no request can succeed anymore. */
+	zassert_equal(dma_request_channel(dma_dev, NULL), -EINVAL);
+	wanted = 1;
+	zassert_equal(dma_request_channel(dma_dev, &wanted), -EINVAL);
+
+	/* An out-of-range exact request matches no channel at all. */
+	wanted = NUM_CHANNELS;
+	zassert_equal(dma_request_channel(dma_dev, &wanted), -EINVAL);
+
+	dma_release_channel(dma_dev, 0);
+	dma_release_channel(dma_dev, 1);
+}
+
+ZTEST(dma_emul_concurrent, test_concurrent_channels)
+{
+	static struct dma_config dma_cfg[NUM_CHANNELS];
+	static struct dma_block_config block_cfg[NUM_CHANNELS];
+
+	zassert_true(device_is_ready(dma_dev), "dma controller device is not ready");
+
+	for (int i = 0; i < NUM_CHANNELS; i++) {
+		struct chan_ctx *ctx = &chan_ctxs[i];
+
+		memset(ctx, 0, sizeof(*ctx));
+		k_sem_init(&ctx->sem, 0, 1);
+		for (int j = 0; j < XFER_SIZE; j++) {
+			ctx->tx[j] = (uint8_t)(j + 0x40 * i);
+		}
+
+		block_cfg[i].block_size = XFER_SIZE;
+#ifdef CONFIG_DMA_64BIT
+		block_cfg[i].source_address = (uint64_t)(uintptr_t)ctx->tx;
+		block_cfg[i].dest_address = (uint64_t)(uintptr_t)ctx->rx;
+#else
+		block_cfg[i].source_address = (uint32_t)(uintptr_t)ctx->tx;
+		block_cfg[i].dest_address = (uint32_t)(uintptr_t)ctx->rx;
+#endif
+
+		dma_cfg[i].channel_direction = MEMORY_TO_MEMORY;
+		dma_cfg[i].source_data_size = 1U;
+		dma_cfg[i].dest_data_size = 1U;
+		dma_cfg[i].source_burst_length = 1U;
+		dma_cfg[i].dest_burst_length = 1U;
+		dma_cfg[i].complete_callback_en = 1U;
+		dma_cfg[i].user_data = ctx;
+		dma_cfg[i].dma_callback = dma_emul_test_callback;
+		dma_cfg[i].block_count = 1U;
+		dma_cfg[i].head_block = &block_cfg[i];
+
+		zassert_ok(dma_config(dma_dev, i, &dma_cfg[i]), "failed to configure channel %d",
+			   i);
+	}
+
+	/* start both channels back to back, without yielding between them */
+	zassert_ok(dma_start(dma_dev, 0), "failed to start channel 0");
+	zassert_ok(dma_start(dma_dev, 1), "failed to start channel 1");
+
+	zassert_ok(k_sem_take(&chan_ctxs[0].sem, TIMEOUT), "channel 0 transfer did not complete");
+	zassert_ok(k_sem_take(&chan_ctxs[1].sem, TIMEOUT), "channel 1 transfer did not complete");
+
+	for (int i = 0; i < NUM_CHANNELS; i++) {
+		zassert_equal(chan_ctxs[i].calls, 1, "channel %d callback fired %d times", i,
+			      chan_ctxs[i].calls);
+		zassert_equal(chan_ctxs[i].channel, i, "channel %d callback got channel %u", i,
+			      chan_ctxs[i].channel);
+		zassert_equal(chan_ctxs[i].status, DMA_STATUS_COMPLETE,
+			      "channel %d callback status %d", i, chan_ctxs[i].status);
+		zassert_equal(chan_ctxs[i].seen_user_data, &chan_ctxs[i],
+			      "channel %d callback got wrong user data", i);
+		zassert_mem_equal(chan_ctxs[i].rx, chan_ctxs[i].tx, XFER_SIZE,
+				  "channel %d data corrupted", i);
+	}
+}
+
+ZTEST_SUITE(dma_emul_concurrent, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/dma/emul_concurrent/src/main.c
+++ b/tests/drivers/dma/emul_concurrent/src/main.c
@@ -1,0 +1,401 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Verify concurrent transfers on separate channels of a dma_emul
+ *        controller complete independently.
+ * @details
+ * - Test Steps
+ *   -# Configure two channels with distinct buffers, callbacks and user data
+ *   -# Start both channels without waiting for the first to complete
+ * - Expected Results
+ *   -# Both transfers complete with data intact
+ *   -# Each callback fires exactly once, with its own channel and user data
+ */
+
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#define NUM_CHANNELS 2
+#define XFER_SIZE    64
+#define TIMEOUT      K_MSEC(1000)
+
+struct chan_ctx {
+	struct k_sem sem;
+	void *seen_user_data;
+	uint32_t channel;
+	int status;
+	int calls;
+	uint8_t tx[XFER_SIZE];
+	uint8_t rx[XFER_SIZE];
+};
+
+static const struct device *const dma_dev = DEVICE_DT_GET(DT_NODELABEL(tst_dma0));
+static struct chan_ctx chan_ctxs[NUM_CHANNELS];
+
+static void dma_emul_test_callback(const struct device *dev, void *user_data, uint32_t channel,
+				   int status)
+{
+	struct chan_ctx *ctx = (struct chan_ctx *)user_data;
+
+	ARG_UNUSED(dev);
+
+	ctx->seen_user_data = user_data;
+	ctx->channel = channel;
+	ctx->status = status;
+	ctx->calls++;
+	k_sem_give(&ctx->sem);
+}
+
+static void init_xfer(struct chan_ctx *ctx, struct dma_config *dma_cfg,
+		      struct dma_block_config *block_cfg, uint8_t fill_seed)
+{
+	memset(ctx, 0, sizeof(*ctx));
+	k_sem_init(&ctx->sem, 0, 1);
+	for (int j = 0; j < XFER_SIZE; j++) {
+		ctx->tx[j] = (uint8_t)(j + fill_seed);
+	}
+
+	memset(dma_cfg, 0, sizeof(*dma_cfg));
+	memset(block_cfg, 0, sizeof(*block_cfg));
+	block_cfg->block_size = XFER_SIZE;
+#ifdef CONFIG_DMA_64BIT
+	block_cfg->source_address = (uint64_t)(uintptr_t)ctx->tx;
+	block_cfg->dest_address = (uint64_t)(uintptr_t)ctx->rx;
+#else
+	block_cfg->source_address = (uint32_t)(uintptr_t)ctx->tx;
+	block_cfg->dest_address = (uint32_t)(uintptr_t)ctx->rx;
+#endif
+	dma_cfg->channel_direction = MEMORY_TO_MEMORY;
+	dma_cfg->source_data_size = 1U;
+	dma_cfg->dest_data_size = 1U;
+	dma_cfg->source_burst_length = 1U;
+	dma_cfg->dest_burst_length = 1U;
+	dma_cfg->complete_callback_en = 1U;
+	dma_cfg->user_data = ctx;
+	dma_cfg->dma_callback = dma_emul_test_callback;
+	dma_cfg->block_count = 1U;
+	dma_cfg->head_block = block_cfg;
+}
+
+ZTEST(dma_emul_concurrent, test_chan_filter_exact_request)
+{
+	uint32_t wanted;
+	int ch;
+
+	zassert_true(device_is_ready(dma_dev), "dma controller device is not ready");
+
+	/* A NULL filter param keeps the any-free-channel behavior. */
+	ch = dma_request_channel(dma_dev, NULL);
+	zassert_equal(ch, 0, "NULL filter param did not return the lowest free channel");
+	dma_release_channel(dma_dev, (uint32_t)ch);
+
+	/* A filter param pointing to a channel number requests exactly that channel. */
+	wanted = 1;
+	ch = dma_request_channel(dma_dev, &wanted);
+	zassert_equal(ch, 1, "exact request for channel 1 returned %d", ch);
+
+	/* The exact channel is taken now: requesting it again fails. */
+	ch = dma_request_channel(dma_dev, &wanted);
+	zassert_equal(ch, -EINVAL, "re-requesting taken channel 1 returned %d", ch);
+
+	/* Channel zero is a valid exact request, distinct from a NULL param. */
+	wanted = 0;
+	ch = dma_request_channel(dma_dev, &wanted);
+	zassert_equal(ch, 0, "exact request for channel 0 returned %d", ch);
+
+	/* Both channels are taken: no request can succeed anymore. */
+	zassert_equal(dma_request_channel(dma_dev, NULL), -EINVAL);
+	wanted = 1;
+	zassert_equal(dma_request_channel(dma_dev, &wanted), -EINVAL);
+
+	/* An out-of-range exact request matches no channel at all. */
+	wanted = NUM_CHANNELS;
+	zassert_equal(dma_request_channel(dma_dev, &wanted), -EINVAL);
+
+	dma_release_channel(dma_dev, 0);
+	dma_release_channel(dma_dev, 1);
+}
+
+/*
+ * ztest runs a suite's tests in name order. This test needs both
+ * channels in the UNUSED state they have at boot, and its name sorts
+ * between test_chan_filter_exact_request (which only requests and
+ * releases channels, leaving the state untouched) and
+ * test_concurrent_channels (the first test that configures them).
+ * It leaves channel 1 STOPPED, which every later test tolerates.
+ */
+ZTEST(dma_emul_concurrent, test_channel_chain_unconfigured_target)
+{
+	static struct dma_config dma_cfg;
+	static struct dma_block_config block_cfg;
+	struct chan_ctx *ctx = &chan_ctxs[1];
+
+	memset(ctx, 0, sizeof(*ctx));
+	k_sem_init(&ctx->sem, 0, 1);
+
+	block_cfg.block_size = XFER_SIZE;
+#ifdef CONFIG_DMA_64BIT
+	block_cfg.source_address = (uint64_t)(uintptr_t)ctx->tx;
+	block_cfg.dest_address = (uint64_t)(uintptr_t)ctx->rx;
+#else
+	block_cfg.source_address = (uint32_t)(uintptr_t)ctx->tx;
+	block_cfg.dest_address = (uint32_t)(uintptr_t)ctx->rx;
+#endif
+	dma_cfg.channel_direction = MEMORY_TO_MEMORY;
+	dma_cfg.source_data_size = 1U;
+	dma_cfg.dest_data_size = 1U;
+	dma_cfg.source_burst_length = 1U;
+	dma_cfg.dest_burst_length = 1U;
+	dma_cfg.complete_callback_en = 1U;
+	dma_cfg.user_data = ctx;
+	dma_cfg.dma_callback = dma_emul_test_callback;
+	dma_cfg.block_count = 1U;
+	dma_cfg.head_block = &block_cfg;
+	dma_cfg.source_chaining_en = 1U;
+	dma_cfg.linked_channel = 0U;
+
+	zassert_ok(dma_config(dma_dev, 1, &dma_cfg), "failed to configure channel 1");
+
+	/*
+	 * Channel 0 was never configured. Starting the chain must be
+	 * rejected before any state changes; otherwise the start would
+	 * mark the zero-initialized channel STARTED and the work handler
+	 * would call its NULL dma_callback.
+	 */
+	zassert_equal(dma_start(dma_dev, 1), -EINVAL,
+		      "chain to an unconfigured channel was not rejected");
+
+	/* Channel 0 is still UNUSED: starting it directly is invalid. */
+	zassert_equal(dma_start(dma_dev, 0), -EIO, "channel 0 is not UNUSED anymore");
+
+	/* No work was submitted, so no callback fired. */
+	zassert_equal(ctx->calls, 0, "callback fired for a rejected start");
+
+	/* Leave channel 1 reconfigurable for the following tests. */
+	zassert_ok(dma_stop(dma_dev, 1));
+}
+
+/*
+ * This test needs channel 0 in the UNUSED state: its name sorts between
+ * test_channel_chain_unconfigured_target (which leaves channel 0 UNUSED)
+ * and test_concurrent_channels (the first test that configures it).
+ */
+ZTEST(dma_emul_concurrent, test_channel_stop_unused_noop)
+{
+	/*
+	 * Stopping a channel that was never configured is a successful
+	 * no-op, like stopping an already stopped channel. It must not
+	 * mark the channel STOPPED: dma_emul_start() accepts STOPPED
+	 * channels as linked-chain targets, so a stopped-but-never-
+	 * configured channel would run with the zero-initialized
+	 * configuration and call its NULL dma_callback.
+	 */
+	zassert_ok(dma_stop(dma_dev, 0), "stop on a never-configured channel failed");
+
+	/* The no-op stop changed no state: channel 0 is still UNUSED. */
+	zassert_equal(dma_start(dma_dev, 0), -EIO, "channel 0 is not UNUSED anymore");
+}
+
+ZTEST(dma_emul_concurrent, test_concurrent_channels)
+{
+	static struct dma_config dma_cfg[NUM_CHANNELS];
+	static struct dma_block_config block_cfg[NUM_CHANNELS];
+
+	zassert_true(device_is_ready(dma_dev), "dma controller device is not ready");
+
+	for (int i = 0; i < NUM_CHANNELS; i++) {
+		init_xfer(&chan_ctxs[i], &dma_cfg[i], &block_cfg[i], 0x40 * i);
+
+		zassert_ok(dma_config(dma_dev, i, &dma_cfg[i]), "failed to configure channel %d",
+			   i);
+	}
+
+	/* start both channels back to back, without yielding between them */
+	zassert_ok(dma_start(dma_dev, 0), "failed to start channel 0");
+	zassert_ok(dma_start(dma_dev, 1), "failed to start channel 1");
+
+	zassert_ok(k_sem_take(&chan_ctxs[0].sem, TIMEOUT), "channel 0 transfer did not complete");
+	zassert_ok(k_sem_take(&chan_ctxs[1].sem, TIMEOUT), "channel 1 transfer did not complete");
+
+	for (int i = 0; i < NUM_CHANNELS; i++) {
+		zassert_equal(chan_ctxs[i].calls, 1, "channel %d callback fired %d times", i,
+			      chan_ctxs[i].calls);
+		zassert_equal(chan_ctxs[i].channel, i, "channel %d callback got channel %u", i,
+			      chan_ctxs[i].channel);
+		zassert_equal(chan_ctxs[i].status, DMA_STATUS_COMPLETE,
+			      "channel %d callback status %d", i, chan_ctxs[i].status);
+		zassert_equal(chan_ctxs[i].seen_user_data, &chan_ctxs[i],
+			      "channel %d callback got wrong user data", i);
+		zassert_mem_equal(chan_ctxs[i].rx, chan_ctxs[i].tx, XFER_SIZE,
+				  "channel %d data corrupted", i);
+	}
+}
+
+ZTEST(dma_emul_concurrent, test_linked_channel_validation)
+{
+	static struct dma_config dma_cfg[NUM_CHANNELS];
+	static struct dma_block_config block_cfg[NUM_CHANNELS];
+	static uint8_t buf[NUM_CHANNELS][XFER_SIZE];
+
+	for (int i = 0; i < NUM_CHANNELS; i++) {
+		memset(&dma_cfg[i], 0, sizeof(dma_cfg[i]));
+		memset(&block_cfg[i], 0, sizeof(block_cfg[i]));
+
+		block_cfg[i].block_size = XFER_SIZE;
+#ifdef CONFIG_DMA_64BIT
+		block_cfg[i].source_address = (uint64_t)(uintptr_t)buf[i];
+		block_cfg[i].dest_address = (uint64_t)(uintptr_t)buf[i];
+#else
+		block_cfg[i].source_address = (uint32_t)(uintptr_t)buf[i];
+		block_cfg[i].dest_address = (uint32_t)(uintptr_t)buf[i];
+#endif
+		dma_cfg[i].channel_direction = MEMORY_TO_MEMORY;
+		dma_cfg[i].source_data_size = 1U;
+		dma_cfg[i].dest_data_size = 1U;
+		dma_cfg[i].source_burst_length = 1U;
+		dma_cfg[i].dest_burst_length = 1U;
+		dma_cfg[i].block_count = 1U;
+		dma_cfg[i].head_block = &block_cfg[i];
+		dma_cfg[i].source_chaining_en = 1U;
+	}
+
+	/* An out-of-range link target is rejected at configure time. */
+	dma_cfg[0].linked_channel = NUM_CHANNELS;
+	zassert_equal(dma_config(dma_dev, 0, &dma_cfg[0]), -EINVAL);
+
+	/* A link pointing at the channel itself is rejected too. */
+	dma_cfg[0].linked_channel = 0U;
+	zassert_equal(dma_config(dma_dev, 0, &dma_cfg[0]), -EINVAL);
+
+	/*
+	 * A cycle spanning two channels passes per-link validation but
+	 * must fail at start time instead of spinning with interrupts off.
+	 */
+	dma_cfg[0].linked_channel = 1U;
+	dma_cfg[1].linked_channel = 0U;
+	zassert_ok(dma_config(dma_dev, 0, &dma_cfg[0]));
+	zassert_ok(dma_config(dma_dev, 1, &dma_cfg[1]));
+	zassert_equal(dma_start(dma_dev, 0), -EINVAL);
+
+	/* The rejected start changed no state: both channels stop cleanly. */
+	zassert_ok(dma_stop(dma_dev, 0));
+	zassert_ok(dma_stop(dma_dev, 1));
+}
+
+ZTEST(dma_emul_concurrent, test_start_chain_rejects_active_downstream)
+{
+	static struct dma_config dma_cfg[NUM_CHANNELS];
+	static struct dma_block_config block_cfg[NUM_CHANNELS];
+	static struct chan_ctx ctx[NUM_CHANNELS];
+
+	for (int i = 0; i < NUM_CHANNELS; i++) {
+		init_xfer(&ctx[i], &dma_cfg[i], &block_cfg[i], 0x40 * i);
+	}
+
+	/* ch0 chains to ch1; ch1 is a standalone transfer. */
+	dma_cfg[0].source_chaining_en = 1U;
+	dma_cfg[0].linked_channel = 1U;
+
+	zassert_ok(dma_config(dma_dev, 0, &dma_cfg[0]), "failed to configure channel 0");
+	zassert_ok(dma_config(dma_dev, 1, &dma_cfg[1]), "failed to configure channel 1");
+
+	/*
+	 * Starting the downstream channel first and then a chain into it
+	 * must be rejected: ch1's descriptor is already queued and would
+	 * otherwise run a second time from the chained tail.
+	 */
+	zassert_ok(dma_start(dma_dev, 1), "failed to start channel 1");
+	zassert_equal(dma_start(dma_dev, 0), -EINVAL,
+		      "chain start into active downstream channel was not rejected");
+
+	/* ch1 still completes exactly once; ch0 was not started. */
+	zassert_ok(k_sem_take(&ctx[1].sem, TIMEOUT), "channel 1 transfer did not complete");
+	zassert_equal(ctx[1].calls, 1, "channel 1 callback fired %d times", ctx[1].calls);
+	zassert_equal(ctx[1].status, DMA_STATUS_COMPLETE, "channel 1 callback status %d",
+		      ctx[1].status);
+	zassert_equal(ctx[0].calls, 0, "channel 0 callback fired despite rejected start");
+
+	/* Once the downstream channel is idle, starting the chain succeeds. */
+	zassert_ok(dma_start(dma_dev, 0), "chain start after downstream completion failed");
+	zassert_ok(k_sem_take(&ctx[0].sem, TIMEOUT), "channel 0 transfer did not complete");
+	zassert_ok(k_sem_take(&ctx[1].sem, TIMEOUT), "chained channel 1 transfer did not complete");
+
+	zassert_equal(ctx[0].calls, 1, "channel 0 callback fired %d times", ctx[0].calls);
+	zassert_equal(ctx[0].status, DMA_STATUS_COMPLETE, "channel 0 callback status %d",
+		      ctx[0].status);
+	zassert_equal(ctx[1].calls, 2, "channel 1 callback fired %d times", ctx[1].calls);
+	zassert_equal(ctx[1].status, DMA_STATUS_COMPLETE, "channel 1 callback status %d",
+		      ctx[1].status);
+	zassert_mem_equal(ctx[1].rx, ctx[1].tx, XFER_SIZE, "channel 1 data corrupted");
+}
+
+ZTEST(dma_emul_concurrent, test_stop_chain_head_restart)
+{
+	static struct dma_config dma_cfg[NUM_CHANNELS];
+	static struct dma_block_config block_cfg[NUM_CHANNELS];
+	static struct chan_ctx ctx[NUM_CHANNELS];
+
+	for (int i = 0; i < NUM_CHANNELS; i++) {
+		init_xfer(&ctx[i], &dma_cfg[i], &block_cfg[i], 0x40 * i);
+	}
+
+	/* ch0 chains to ch1. */
+	dma_cfg[0].source_chaining_en = 1U;
+	dma_cfg[0].linked_channel = 1U;
+
+	zassert_ok(dma_config(dma_dev, 0, &dma_cfg[0]), "failed to configure channel 0");
+	zassert_ok(dma_config(dma_dev, 1, &dma_cfg[1]), "failed to configure channel 1");
+
+	/*
+	 * Stop the chain head before the work queue gets a chance to run:
+	 * the ztest thread runs at a cooperative priority
+	 * (CONFIG_ZTEST_THREAD_PRIORITY defaults to -1), so it cannot be
+	 * preempted by the work queue thread, and start plus stop are
+	 * atomic with respect to the work handler.
+	 */
+	zassert_ok(dma_start(dma_dev, 0), "failed to start channel 0");
+	zassert_ok(dma_stop(dma_dev, 0), "failed to stop channel 0");
+
+	/*
+	 * The cancel is still in flight: STOPPED only means the stop was
+	 * requested, not that the work handler has acknowledged it. An
+	 * immediate restart must be rejected instead of marking the chain
+	 * channels STARTED behind the back of the still-running handler.
+	 */
+	zassert_equal(dma_start(dma_dev, 0), -EBUSY,
+		      "restart while the cancel was in flight was not rejected");
+
+	/* Let the handler observe the stop and acknowledge the cancel. */
+	zassert_ok(k_sem_take(&ctx[0].sem, TIMEOUT), "channel 0 cancel callback did not fire");
+	zassert_equal(ctx[0].status, -ECANCELED, "channel 0 callback status %d", ctx[0].status);
+	zassert_equal(ctx[0].calls, 1, "channel 0 callback fired %d times", ctx[0].calls);
+	zassert_equal(ctx[1].calls, 0, "downstream channel ran despite the canceled chain head");
+
+	/*
+	 * Once the cancel completed, the whole chain must be restartable:
+	 * the handler must have reset the downstream channel it never ran.
+	 */
+	zassert_ok(dma_start(dma_dev, 0), "chain restart after cancel failed");
+	zassert_ok(k_sem_take(&ctx[0].sem, TIMEOUT), "channel 0 transfer did not complete");
+	zassert_ok(k_sem_take(&ctx[1].sem, TIMEOUT), "chained channel 1 transfer did not complete");
+
+	zassert_equal(ctx[0].calls, 2, "channel 0 callback fired %d times", ctx[0].calls);
+	zassert_equal(ctx[0].status, DMA_STATUS_COMPLETE, "channel 0 callback status %d",
+		      ctx[0].status);
+	zassert_equal(ctx[1].calls, 1, "channel 1 callback fired %d times", ctx[1].calls);
+	zassert_equal(ctx[1].status, DMA_STATUS_COMPLETE, "channel 1 callback status %d",
+		      ctx[1].status);
+	zassert_mem_equal(ctx[0].rx, ctx[0].tx, XFER_SIZE, "channel 0 data corrupted");
+	zassert_mem_equal(ctx[1].rx, ctx[1].tx, XFER_SIZE, "channel 1 data corrupted");
+}
+
+ZTEST_SUITE(dma_emul_concurrent, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/dma/emul_concurrent/tests.yaml
+++ b/tests/drivers/dma/emul_concurrent/tests.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.dma.emul_concurrent:
+    min_ram: 16
+    depends_on: dma
+    tags:
+      - drivers
+      - dma
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+    filter: dt_nodelabel_enabled("tst_dma0")

--- a/tests/drivers/pcie/endpoint_emul/CMakeLists.txt
+++ b/tests/drivers/pcie/endpoint_emul/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(pcie_ep_emul)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/pcie/endpoint_emul/boards/native_sim_native_64.overlay
+++ b/tests/drivers/pcie/endpoint_emul/boards/native_sim_native_64.overlay
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	tst_ep0: pcie-ep-emul-0 {
+		compatible = "zephyr,pcie-ep-emul";
+		vendor-id = <0x1234>;
+		device-id = <0x0001>;
+		class-code = <0x060400>;
+		revision-id = <0x01>;
+		bar-sizes = <0x10000 0x1000 0 0 0 0>;
+		msi-vectors = <4>;
+		msix-vectors = <8>;
+		legacy-irq;
+		dmas = <&dma 0>, <&dma 1>;
+		dma-names = "host-to-device", "device-to-host";
+		status = "okay";
+	};
+
+	tst_ep1: pcie-ep-emul-1 {
+		compatible = "zephyr,pcie-ep-emul";
+		vendor-id = <0x5678>;
+		device-id = <0x0002>;
+		class-code = <0xff0000>;
+		revision-id = <0x02>;
+		bar-sizes = <0x1000 0x2000 0x4000 0 0 0>;
+		msi-vectors = <1>;
+		msix-vectors = <0>;
+		dmas = <&dma 2>, <&dma 3>;
+		dma-names = "host-to-device", "device-to-host";
+		status = "okay";
+	};
+
+	/* No dmas property: DMA transfers must report -ENODEV at runtime. */
+	tst_ep2: pcie-ep-emul-2 {
+		compatible = "zephyr,pcie-ep-emul";
+		vendor-id = <0x9abc>;
+		device-id = <0x0003>;
+		class-code = <0x058000>;
+		revision-id = <0x01>;
+		bar-sizes = <0x1000 0 0 0 0 0>;
+		msi-vectors = <0>;
+		msix-vectors = <2>;
+		status = "okay";
+	};
+};
+
+/* Two endpoints x two directions: four distinct dedicated channels. */
+&dma {
+	dma-channels = <4>;
+	status = "okay";
+};

--- a/tests/drivers/pcie/endpoint_emul/prj.conf
+++ b/tests/drivers/pcie/endpoint_emul/prj.conf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_PCIE_ENDPOINT=y
+CONFIG_PCIE_EP_EMUL=y
+CONFIG_IRQ_OFFLOAD=y
+CONFIG_DMA=y
+CONFIG_DMA_EMUL=y

--- a/tests/drivers/pcie/endpoint_emul/src/main.c
+++ b/tests/drivers/pcie/endpoint_emul/src/main.c
@@ -1,0 +1,1183 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep_emul.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <limits.h>
+#include <string.h>
+
+#define CFG_VENDOR_DEVICE_ID 0x00U
+#define CFG_COMMAND_STATUS   0x04U
+#define CFG_CLASS_REVISION   0x08U
+#define CFG_BAR0             0x10U
+#define CFG_BAR1             0x14U
+#define CFG_BAR2             0x18U
+#define CFG_BAR3             0x1cU
+#define CFG_BAR5             0x24U
+#define CFG_CAPABILITY_PTR   0x34U
+#define CFG_MSI_CAP          0x40U
+#define CFG_MSIX_CAP         0x50U
+#define CFG_SIZE             4096U
+
+/* Status register (upper command/status half) capabilities-list bit. */
+#define STATUS_CAPABILITIES_LIST 0x00100000U
+
+/* MSI/MSI-X message control fields (upper half of the first cap dword). */
+#define MSI_CTRL_ENABLE     0x00010000U
+#define MSI_MME_SHIFT       20U
+#define MSIX_CTRL_ENABLE    0x80000000U
+#define MSIX_CTRL_FUNC_MASK 0x40000000U
+
+#define EP0_VENDOR_DEVICE_ID 0x00011234U
+#define EP0_CLASS_REVISION   0x06040001U
+#define EP1_VENDOR_DEVICE_ID 0x00025678U
+#define EP1_CLASS_REVISION   0xff000002U
+
+#define APERTURE0_PCIE_BASE 0x80000000ULL
+#define APERTURE1_PCIE_BASE 0x90000000ULL
+#define APERTURE_LEN        0x2000U
+
+static const struct device *const ep0 = DEVICE_DT_GET(DT_NODELABEL(tst_ep0));
+static const struct device *const ep1 = DEVICE_DT_GET(DT_NODELABEL(tst_ep1));
+/* Third endpoint without a dmas property. */
+static const struct device *const ep2 = DEVICE_DT_GET(DT_NODELABEL(tst_ep2));
+static const struct device *const dma_dev = DEVICE_DT_GET(DT_NODELABEL(dma));
+
+static uint8_t host_mem0[APERTURE_LEN];
+static uint8_t host_mem1[APERTURE_LEN];
+
+ZTEST(pcie_ep_emul, test_devices_ready)
+{
+	zassert_true(device_is_ready(ep0), "first emulated endpoint is not ready");
+	zassert_true(device_is_ready(ep1), "second emulated endpoint is not ready");
+	zassert_true(device_is_ready(ep2), "third emulated endpoint is not ready");
+}
+
+ZTEST(pcie_ep_emul, test_identity_per_instance)
+{
+	uint32_t value;
+
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_CLASS_REVISION, &value));
+	zassert_equal(value, EP0_CLASS_REVISION);
+
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP1_VENDOR_DEVICE_ID);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_CLASS_REVISION, &value));
+	zassert_equal(value, EP1_CLASS_REVISION);
+}
+
+ZTEST(pcie_ep_emul, test_conf_read_invalid_access)
+{
+	uint32_t value;
+
+	zassert_equal(pcie_ep_conf_read(ep0, 1, &value), -EINVAL);
+	zassert_equal(pcie_ep_conf_read(ep0, CFG_SIZE - 2, &value), -EINVAL);
+	zassert_equal(pcie_ep_conf_read(ep0, CFG_SIZE, &value), -EINVAL);
+	zassert_equal(pcie_ep_conf_read(ep0, UINT32_MAX - 2, &value), -EINVAL);
+}
+
+ZTEST(pcie_ep_emul, test_conf_write_readonly_identity)
+{
+	uint32_t value;
+
+	pcie_ep_conf_write(ep0, CFG_VENDOR_DEVICE_ID, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+
+	pcie_ep_conf_write(ep0, CFG_CLASS_REVISION, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_CLASS_REVISION, &value));
+	zassert_equal(value, EP0_CLASS_REVISION);
+
+	/* Invalid writes are a no-op and must not corrupt the image. */
+	pcie_ep_conf_write(ep0, 1, 0xdeadbeefU);
+	pcie_ep_conf_write(ep0, CFG_SIZE, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+}
+
+ZTEST(pcie_ep_emul, test_conf_write_command_bits)
+{
+	uint32_t value;
+
+	/*
+	 * Writable command bits 0..2; status stays read-only and keeps
+	 * the capabilities-list bit set at init (ep0 advertises MSI/MSI-X).
+	 */
+	pcie_ep_conf_write(ep0, CFG_COMMAND_STATUS, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_COMMAND_STATUS, &value));
+	zassert_equal(value, STATUS_CAPABILITIES_LIST | 0x7U);
+
+	pcie_ep_conf_write(ep0, CFG_COMMAND_STATUS, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_COMMAND_STATUS, &value));
+	zassert_equal(value, STATUS_CAPABILITIES_LIST);
+}
+
+ZTEST(pcie_ep_emul, test_bar_assignment_and_mask)
+{
+	uint32_t value;
+
+	/* BAR0 of ep0 is 64 KiB: the low 16 bits are size-masked. */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x0U);
+
+	pcie_ep_conf_write(ep0, CFG_BAR0, 0x1234abcdU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x12340000U);
+
+	/* BAR1 of ep0 is 4 KiB: the low 12 bits are size-masked. */
+	pcie_ep_conf_write(ep0, CFG_BAR1, 0x80000fffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR1, &value));
+	zassert_equal(value, 0x80000000U);
+
+	/* BAR2..BAR5 of ep0 are disabled: reads stay zero, writes ignored. */
+	pcie_ep_conf_write(ep0, CFG_BAR2, 0x12345000U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR2, &value));
+	zassert_equal(value, 0x0U);
+	pcie_ep_conf_write(ep0, CFG_BAR5, 0x12345000U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR5, &value));
+	zassert_equal(value, 0x0U);
+}
+
+ZTEST(pcie_ep_emul, test_instance_isolation)
+{
+	uint32_t value;
+
+	pcie_ep_conf_write(ep0, CFG_BAR0, 0x11110000U);
+	pcie_ep_conf_write(ep0, CFG_COMMAND_STATUS, 0x7U);
+
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_BAR0, &value));
+	zassert_equal(value, 0x0U);
+	/* ep1's status keeps its read-only capabilities-list bit (MSI). */
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_COMMAND_STATUS, &value));
+	zassert_equal(value, STATUS_CAPABILITIES_LIST);
+
+	/* ep1 BAR0 is 4 KiB: same write as above keeps the low 12 bits. */
+	pcie_ep_conf_write(ep1, CFG_BAR0, 0x22222fffU);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_BAR0, &value));
+	zassert_equal(value, 0x22222000U);
+
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x11110000U);
+}
+
+ZTEST(pcie_ep_emul, test_msi_msix_capabilities)
+{
+	uint32_t value;
+
+	/* ep0 advertises both capabilities; make sure both start disabled. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0x0U);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0x0U);
+
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_COMMAND_STATUS, &value));
+	zassert_true((value & STATUS_CAPABILITIES_LIST) != 0);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_CAPABILITY_PTR, &value));
+	zassert_equal(value, CFG_MSI_CAP);
+
+	/* MSI: ID 0x05, next 0x50, Multiple Message Capable = 2 (4 vectors). */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00045005U);
+
+	/* MSI-X: ID 0x11, last capability, table size 7 (8 vectors). */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0x00070011U);
+
+	/* Table at offset 0 of BAR0; PBA right after the 8-entry table. */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP + 4, &value));
+	zassert_equal(value, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP + 8, &value));
+	zassert_equal(value, 0x80U);
+
+	/*
+	 * The MSI enable bit and MME (clamped to MMC = 2) are writable, as is
+	 * the MSI-X function mask bit; the rest of both dwords is read-only.
+	 */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00255005U);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0xc0070011U);
+
+	/* Message address/data read as zero and ignore writes. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP + 4, 0xdeadbeefU);
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP + 8, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP + 4, &value));
+	zassert_equal(value, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP + 8, &value));
+	zassert_equal(value, 0x0U);
+
+	/* The host-side accessors follow the same writability rules. */
+	zassert_ok(pcie_ep_emul_host_conf_write(ep0, CFG_MSI_CAP, 0x0U));
+	zassert_ok(pcie_ep_emul_host_conf_write(ep0, CFG_MSIX_CAP, 0x0U));
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00045005U);
+
+	/* ep1 advertises MSI with 1 vector and no MSI-X. */
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_COMMAND_STATUS, &value));
+	zassert_true((value & STATUS_CAPABILITIES_LIST) != 0);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_CAPABILITY_PTR, &value));
+	zassert_equal(value, CFG_MSI_CAP);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00000005U);
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x00010000U);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00010005U);
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x0U);
+
+	/* Where ep0 has its MSI-X capability, ep1 reads zero and ignores writes. */
+	pcie_ep_conf_write(ep1, CFG_MSIX_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0x0U);
+
+	/*
+	 * ep2 has no MSI but a 2-vector MSI-X capability: without an MSI
+	 * capability the MSI-X one heads the list at 0x40.
+	 */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_COMMAND_STATUS, &value));
+	zassert_true((value & STATUS_CAPABILITIES_LIST) != 0);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_CAPABILITY_PTR, &value));
+	zassert_equal(value, CFG_MSI_CAP);
+
+	/*
+	 * ID 0x11 (MSI-X, not MSI), next pointer 0 terminates the list,
+	 * table size 1 (2 vectors).
+	 */
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00010011U);
+
+	/* Table at offset 0 of BAR0; PBA right after the 2-entry table. */
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP + 4, &value));
+	zassert_equal(value, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP + 8, &value));
+	zassert_equal(value, 0x20U);
+
+	/* The MSI-X enable and function mask bits are writable; the rest is not. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0xc0010011U);
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+
+	/* Where ep0 has its MSI-X capability, ep2 reads zero (its own is at 0x40). */
+	pcie_ep_conf_write(ep2, CFG_MSIX_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0x0U);
+}
+
+ZTEST(pcie_ep_emul, test_dma_channels_claimed_exclusively)
+{
+	/*
+	 * ep0 and ep1 claimed all four channels of the controller at init
+	 * and hold them for their lifetime, so a late channel request on
+	 * the same controller finds nothing free.
+	 */
+	zassert_equal(dma_request_channel(dma_dev, NULL), -EINVAL);
+
+	/* Requesting any of the claimed channels by exact number fails, too. */
+	for (uint32_t ch = 0; ch < 4U; ch++) {
+		zassert_equal(dma_request_channel(dma_dev, &ch), -EINVAL,
+			      "exact request for claimed channel %u succeeded", ch);
+	}
+}
+
+ZTEST(pcie_ep_emul, test_aperture_registration)
+{
+	/* Overlap with the fixture aperture is rejected. */
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE + 0x1000, host_mem0,
+						     APERTURE_LEN),
+		      -EALREADY);
+
+	/* Zero length and overflowing ranges are rejected. */
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, 0xa0000000ULL, host_mem0, 0), -EINVAL);
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, UINT64_MAX - 0x10ULL, host_mem0, 0x20U),
+		      -EINVAL);
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, 0xa0000000ULL, NULL, 0x1000U), -EINVAL);
+
+	/* Unregistering an unknown aperture fails; the registered one is
+	 * removed by the fixture teardown.
+	 */
+	zassert_equal(pcie_ep_emul_unregister_aperture(ep0, 0xa0000000ULL), -ENOENT);
+}
+
+ZTEST(pcie_ep_emul, test_map_addr_negative_paths)
+{
+	uint64_t mapped;
+
+	/* Not covered by any registered aperture. */
+	zassert_equal(pcie_ep_map_addr(ep0, 0x1000ULL, &mapped, 0x100U, PCIE_OB_ANYMEM), -ENOTSUP);
+
+	/* Crossing the aperture end is rejected. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + APERTURE_LEN - 0x100U, &mapped,
+				       0x200U, PCIE_OB_ANYMEM),
+		      -ENOTSUP);
+
+	/* Zero-length and overflowing requests are rejected. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, 0, PCIE_OB_ANYMEM),
+		      -EINVAL);
+	zassert_equal(pcie_ep_map_addr(ep0, UINT64_MAX - 0x10ULL, &mapped, 0x20U, PCIE_OB_ANYMEM),
+		      -EINVAL);
+
+	/* Apertures are per instance: ep0's aperture is invisible to ep1. */
+	zassert_equal(pcie_ep_map_addr(ep1, APERTURE0_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      -ENOTSUP);
+}
+
+ZTEST(pcie_ep_emul, test_map_unmap_lifecycle)
+{
+	uint64_t mapped[CONFIG_PCIE_EP_EMUL_MAX_MAPS];
+	uint64_t extra;
+	int ret;
+
+	/* Fill the per-instance mapping table. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS; i++) {
+		ret = pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + i * 0x100U, &mapped[i], 0x100U,
+				       PCIE_OB_ANYMEM);
+		zassert_equal(ret, 0x100);
+		zassert_equal(mapped[i], (uint64_t)(uintptr_t)&host_mem0[i * 0x100U]);
+	}
+
+	/* The table is bounded: one more mapping of a new address fails. */
+	zassert_equal(pcie_ep_map_addr(ep0,
+				       APERTURE0_PCIE_BASE + CONFIG_PCIE_EP_EMUL_MAX_MAPS * 0x100U,
+				       &extra, 0x100U, PCIE_OB_ANYMEM),
+		      -ENOMEM);
+
+	/* Unknown and duplicate unmaps are ignored and disturb nothing. */
+	pcie_ep_unmap_addr(ep0, (uint64_t)(uintptr_t)&host_mem1[0]);
+	pcie_ep_unmap_addr(ep0, mapped[0]);
+	pcie_ep_unmap_addr(ep0, mapped[0]);
+
+	/* A freed slot is reusable, the remaining records stay valid. */
+	ret = pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped[0], 0x100U, PCIE_OB_ANYMEM);
+	zassert_equal(ret, 0x100);
+
+	/* Unregistering an aperture with active mappings is rejected. */
+	zassert_equal(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE), -EBUSY);
+
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS; i++) {
+		pcie_ep_unmap_addr(ep0, mapped[i]);
+	}
+
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+}
+
+ZTEST(pcie_ep_emul, test_map_addr_duplicate_and_oversize)
+{
+	uint64_t mapped;
+	uint64_t dup;
+
+	/* Sizes that do not fit the int return value are rejected up front. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, (uint32_t)INT_MAX + 1U,
+				       PCIE_OB_ANYMEM),
+		      -EINVAL);
+
+	/* A second mapping of a live address is rejected instead of aliased. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      0x100);
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &dup, 0x100U, PCIE_OB_ANYMEM),
+		      -EALREADY);
+
+	/* Overlapping sub/superranges of a live mapping are rejected too. */
+	zassert_equal(
+		pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + 0x40U, &dup, 0x40U, PCIE_OB_ANYMEM),
+		-EALREADY);
+	zassert_equal(
+		pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + 0x80U, &dup, 0x100U, PCIE_OB_ANYMEM),
+		-EALREADY);
+	pcie_ep_unmap_addr(ep0, mapped);
+
+	/* A repeat unmap frees nothing; the record is owned once and reusable. */
+	pcie_ep_unmap_addr(ep0, mapped);
+	pcie_ep_unmap_addr(ep0, mapped);
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      0x100);
+	pcie_ep_unmap_addr(ep0, mapped);
+}
+
+ZTEST(pcie_ep_emul, test_xfer_data_memcpy_both_directions)
+{
+	uint8_t local_buf[0x100];
+	uint8_t expected[0x100];
+	uint8_t zeros[sizeof(local_buf)] = {0};
+
+	for (int i = 0; i < sizeof(expected); i++) {
+		host_mem0[i] = (uint8_t)(i ^ 0x5a);
+		expected[i] = (uint8_t)(i + 1);
+	}
+
+	/* Host to device: host aperture contents land in local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, host_mem0, sizeof(local_buf));
+
+	/* Device to host: local contents land in the host aperture. */
+	memcpy(local_buf, expected, sizeof(local_buf));
+	memset(host_mem0, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST));
+	zassert_mem_equal(host_mem0, expected, sizeof(expected));
+
+	/* Unregistered host addresses fail without touching local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_equal(pcie_ep_xfer_data_memcpy(ep0, 0x1000ULL, (uintptr_t *)local_buf,
+					       sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/*
+	 * Device to host to an unregistered address fails, too, and the
+	 * registered aperture backing is left unchanged.
+	 */
+	zassert_equal(pcie_ep_xfer_data_memcpy(ep0, 0x1000ULL, (uintptr_t *)local_buf,
+					       sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST),
+		      -ENOTSUP);
+	zassert_mem_equal(host_mem0, expected, sizeof(expected));
+
+	/* The mapping used by the helper is released again. */
+	zassert_equal(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE), 0);
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+}
+
+ZTEST(pcie_ep_emul, test_ep1_aperture_backing_and_isolation)
+{
+	uint8_t local_buf[0x100];
+	uint8_t expected[sizeof(local_buf)];
+	uint8_t zeros[sizeof(local_buf)] = {0};
+	uint64_t mapped;
+
+	for (int i = 0; i < sizeof(expected); i++) {
+		expected[i] = (uint8_t)(i ^ 0x3c);
+	}
+
+	/* ep1's fixture aperture maps into ep1's own backing buffer. */
+	zassert_equal(pcie_ep_map_addr(ep1, APERTURE1_PCIE_BASE, &mapped, sizeof(local_buf),
+				       PCIE_OB_ANYMEM),
+		      sizeof(local_buf));
+	zassert_equal(mapped, (uint64_t)(uintptr_t)host_mem1);
+	pcie_ep_unmap_addr(ep1, mapped);
+
+	/* Host to device: data lands from ep1's backing buffer. */
+	memcpy(host_mem1, expected, sizeof(expected));
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep1, APERTURE1_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, expected, sizeof(local_buf));
+
+	/*
+	 * Device to host: ep1's backing buffer receives the data while
+	 * ep0's backing buffer (zeroed by the fixture) stays untouched.
+	 */
+	memset(host_mem1, 0, sizeof(local_buf));
+	memcpy(local_buf, expected, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep1, APERTURE1_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST));
+	zassert_mem_equal(host_mem1, expected, sizeof(expected));
+	zassert_mem_equal(host_mem0, zeros, sizeof(local_buf));
+
+	/* The mapping used by the helper is released again. */
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep1, APERTURE1_PCIE_BASE));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep1, APERTURE1_PCIE_BASE, host_mem1, APERTURE_LEN));
+}
+
+/* Backing buffers used only to fill the aperture table. */
+static uint8_t aperture_fill_mem[CONFIG_PCIE_EP_EMUL_MAX_APERTURES - 1][0x100];
+
+ZTEST(pcie_ep_emul, test_aperture_table_full)
+{
+	/* The fixture aperture occupies one slot; fill the remaining ones. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_APERTURES - 1; i++) {
+		zassert_ok(pcie_ep_emul_register_aperture(ep0, 0xa0000000ULL + i * 0x1000ULL,
+							  aperture_fill_mem[i],
+							  sizeof(aperture_fill_mem[i])));
+	}
+
+	/* The per-instance table is bounded: one more aperture fails. */
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, 0xb0000000ULL, host_mem0, 0x100U),
+		      -ENOMEM);
+
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_APERTURES - 1; i++) {
+		zassert_ok(pcie_ep_emul_unregister_aperture(ep0, 0xa0000000ULL + i * 0x1000ULL));
+	}
+}
+
+/* ep0: legacy IRQ, 4 MSI vectors, 8 MSI-X vectors. */
+/* ep1: no legacy IRQ, 1 MSI vector, no MSI-X vectors. */
+
+ZTEST(pcie_ep_emul, test_raise_irq_events)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* Enable the capabilities like a real host: MSI with all 4 vectors
+	 * allocated (MME = log2(4) = 2), MSI-X unmasked.
+	 */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (2U << MSI_MME_SHIFT));
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, MSIX_CTRL_ENABLE);
+
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_LEGACY, 0));
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 2));
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 7));
+
+	/* Events are consumed in raise order with type and vector intact. */
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_LEGACY);
+	zassert_equal(event.vector, 0);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSI);
+	zassert_equal(event.vector, 2);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSIX);
+	zassert_equal(event.vector, 7);
+
+	/* The queue is empty: neither polling nor waiting yields an event. */
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT), -EAGAIN);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_MSEC(10)), -EAGAIN);
+
+	/* NULL destination is rejected. */
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, NULL, K_NO_WAIT), -EINVAL);
+}
+
+ZTEST(pcie_ep_emul, test_raise_irq_negative)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* IRQ types disabled in devicetree are rejected. */
+	zassert_equal(pcie_ep_raise_irq(ep1, PCIE_EP_IRQ_LEGACY, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_raise_irq(ep1, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+
+	/* Capabilities the host has not enabled reject raises. */
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+
+	/* Out-of-range vectors are rejected regardless of enable state. */
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 4), -EINVAL);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 8), -EINVAL);
+	zassert_equal(pcie_ep_raise_irq(ep1, PCIE_EP_IRQ_MSI, 1), -EINVAL);
+
+	/*
+	 * The host allocated fewer vectors than advertised: with MME = 0
+	 * (one vector, the default) only vector 0 could be raised.
+	 */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 1), -EINVAL);
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (1U << MSI_MME_SHIFT));
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 2), -EINVAL);
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0x0U);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 0), -ENOTSUP);
+
+	/* A function-masked MSI-X capability suppresses raises. */
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, MSIX_CTRL_ENABLE | MSIX_CTRL_FUNC_MASK);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0x0U);
+
+	/* An invalid interrupt type is rejected. */
+	zassert_equal(pcie_ep_raise_irq(ep0, (enum pci_ep_irq_type)3, 0), -EINVAL);
+
+	/* Failed raises must not record events on either instance. */
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT), -EAGAIN);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep1, &event, K_NO_WAIT), -EAGAIN);
+}
+
+ZTEST(pcie_ep_emul, test_raise_irq_msix_enable_state_ep2)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* ep2's MSI-X capability heads its list at 0x40; it starts disabled. */
+	zassert_equal(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+
+	/* Enabled and unmasked, both vectors raise and record events. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, MSIX_CTRL_ENABLE);
+	zassert_ok(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0));
+	zassert_ok(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 1));
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSIX);
+	zassert_equal(event.vector, 0);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSIX);
+	zassert_equal(event.vector, 1);
+
+	/* Function-masked: raises are suppressed and record nothing. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, MSIX_CTRL_ENABLE | MSIX_CTRL_FUNC_MASK);
+	zassert_equal(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT), -EAGAIN);
+
+	/* Disabled again: raises fail and record nothing. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+	zassert_equal(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT), -EAGAIN);
+}
+
+ZTEST(pcie_ep_emul, test_irq_event_queue_bounded)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* Enable MSI like a real host, with all 4 vectors allocated. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (2U << MSI_MME_SHIFT));
+
+	/* The per-instance queue holds exactly MAX_IRQ_EVENTS events. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS; i++) {
+		/* ep0 has 4 MSI vectors; cycle through the valid range. */
+		zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, (uint32_t)(i % 4)));
+	}
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 0), -ENOSPC);
+
+	/* Draining frees capacity; all events arrive in order. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS; i++) {
+		zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+		zassert_equal(event.type, PCIE_EP_IRQ_MSI);
+		zassert_equal(event.vector, (uint32_t)(i % 4));
+	}
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT), -EAGAIN);
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_LEGACY, 0));
+}
+
+struct reset_cb_record {
+	int calls;
+	bool in_isr;
+	void *arg;
+};
+
+static struct reset_cb_record ep0_reset_records[PCIE_RESET_MAX];
+static struct reset_cb_record ep1_reset_records[PCIE_RESET_MAX];
+
+static void reset_cb(void *arg)
+{
+	struct reset_cb_record *record = arg;
+
+	record->calls++;
+	record->in_isr = k_is_in_isr();
+	record->arg = arg;
+}
+
+ZTEST(pcie_ep_emul, test_reset_callbacks)
+{
+	/* Register one callback per reset type, each with its own record. */
+	for (int i = 0; i < PCIE_RESET_MAX; i++) {
+		zassert_ok(pcie_ep_register_reset_cb(ep0, (enum pcie_reset)i, reset_cb,
+						     &ep0_reset_records[i]));
+	}
+
+	/* Injection runs the callback in interrupt context with its arg. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST));
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST_INB));
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_FLR));
+
+	for (int i = 0; i < PCIE_RESET_MAX; i++) {
+		zassert_equal(ep0_reset_records[i].calls, 1, "reset %d callback did not run", i);
+		zassert_true(ep0_reset_records[i].in_isr,
+			     "reset %d callback did not run in interrupt context", i);
+		zassert_equal(ep0_reset_records[i].arg, &ep0_reset_records[i]);
+	}
+
+	/* A second PERST injection reaches the same callback again. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST));
+	zassert_equal(ep0_reset_records[PCIE_PERST].calls, 2);
+}
+
+ZTEST(pcie_ep_emul, test_reset_negative)
+{
+	/* Invalid reset types and NULL callbacks are rejected. */
+	zassert_equal(
+		pcie_ep_register_reset_cb(ep0, PCIE_RESET_MAX, reset_cb, &ep0_reset_records[0]),
+		-EINVAL);
+	zassert_equal(pcie_ep_register_reset_cb(ep0, (enum pcie_reset)(-1), reset_cb,
+						&ep0_reset_records[0]),
+		      -EINVAL);
+	zassert_equal(pcie_ep_register_reset_cb(ep0, PCIE_PERST, NULL, NULL), -EINVAL);
+	zassert_equal(pcie_ep_emul_inject_reset(ep0, PCIE_RESET_MAX), -EINVAL);
+
+	/* Injecting a reset with no registered callback is a no-op. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep1, PCIE_FLR));
+	zassert_equal(ep1_reset_records[PCIE_FLR].calls, 0);
+}
+
+ZTEST(pcie_ep_emul, test_irq_reset_instance_isolation)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	zassert_ok(pcie_ep_register_reset_cb(ep0, PCIE_PERST, reset_cb,
+					     &ep0_reset_records[PCIE_PERST]));
+	zassert_ok(pcie_ep_register_reset_cb(ep1, PCIE_PERST, reset_cb,
+					     &ep1_reset_records[PCIE_PERST]));
+
+	/* Events raised on ep0 are only consumable on ep0. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (2U << MSI_MME_SHIFT));
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 1));
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep1, &event, K_NO_WAIT), -EAGAIN);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSI);
+	zassert_equal(event.vector, 1);
+
+	/* A reset injected on ep1 never fires the callback of ep0. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep1, PCIE_PERST));
+	zassert_equal(ep0_reset_records[PCIE_PERST].calls, 0);
+	zassert_equal(ep1_reset_records[PCIE_PERST].calls, 1);
+
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST));
+	zassert_equal(ep0_reset_records[PCIE_PERST].calls, 1);
+	zassert_equal(ep1_reset_records[PCIE_PERST].calls, 1);
+}
+
+ZTEST(pcie_ep_emul, test_host_conf_access)
+{
+	uint32_t value;
+
+	/* Host reads see the same image as the endpoint API. */
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+
+	/* Host writes follow the same writability rules. */
+	zassert_ok(pcie_ep_emul_host_conf_write(ep0, CFG_BAR0, 0x4567abcdU));
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x45670000U);
+	/* Writes to read-only registers are reported and change nothing. */
+	zassert_equal(pcie_ep_emul_host_conf_write(ep0, CFG_VENDOR_DEVICE_ID, 0xdeadbeefU), -EPERM);
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+	zassert_equal(pcie_ep_emul_host_conf_write(ep0, CFG_BAR2, 0xdeadbeefU), -EPERM);
+
+	/* Invalid host accesses fail instead of being silently ignored. */
+	zassert_equal(pcie_ep_emul_host_conf_read(ep0, 1, &value), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_conf_read(ep0, CFG_SIZE, &value), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_conf_write(ep0, CFG_SIZE, 0), -EINVAL);
+}
+
+ZTEST(pcie_ep_emul, test_host_bar_access)
+{
+	uint8_t written[0x40];
+	uint8_t read_back[sizeof(written)];
+	uint8_t other[sizeof(written)];
+	uint8_t zeros[sizeof(written)] = {0};
+
+	for (int i = 0; i < sizeof(written); i++) {
+		written[i] = (uint8_t)(i * 3 + 1);
+	}
+
+	/* Data written by the host reads back through the same BAR. */
+	zassert_ok(pcie_ep_emul_host_bar_write(ep0, 0, 0x100, written, sizeof(written)));
+	memset(read_back, 0, sizeof(read_back));
+	zassert_ok(pcie_ep_emul_host_bar_read(ep0, 0, 0x100, read_back, sizeof(read_back)));
+	zassert_mem_equal(read_back, written, sizeof(written));
+
+	/* BAR backing is per instance: ep1's BAR0 is unaffected. */
+	zassert_ok(pcie_ep_emul_host_bar_read(ep1, 0, 0x100, other, sizeof(other)));
+	zassert_mem_equal(other, zeros, sizeof(other));
+
+	/* Out-of-window, disabled-BAR, and malformed accesses fail. */
+	zassert_equal(pcie_ep_emul_host_bar_write(ep0, 6, 0, written, sizeof(written)), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_write(ep0, 2, 0, written, sizeof(written)), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_write(ep0, 0, 0x10000 - 0x10, written, 0x20), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_read(ep0, 0, 0, NULL, 0x10), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_read(ep0, 0, 0, read_back, 0), -EINVAL);
+	/* ep1 BAR0 is 4 KiB: a larger read is out of window. */
+	zassert_equal(pcie_ep_emul_host_bar_read(ep1, 0, 0, other, 0x2000), -EINVAL);
+}
+
+static void fill_pattern(uint8_t *buf, size_t len, uint8_t seed)
+{
+	for (size_t i = 0; i < len; i++) {
+		buf[i] = (uint8_t)(seed + i * 7U);
+	}
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_both_directions)
+{
+	uint8_t local_buf[0x100];
+	uint8_t expected[sizeof(local_buf)];
+	uint8_t zeros[sizeof(local_buf)] = {0};
+
+	fill_pattern(host_mem0, sizeof(local_buf), 0x11);
+	fill_pattern(expected, sizeof(expected), 0x42);
+
+	/* Host to device: host aperture contents land in local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_dma(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					 sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, host_mem0, sizeof(local_buf));
+
+	/* Device to host: local contents land in the host aperture. */
+	memcpy(local_buf, expected, sizeof(local_buf));
+	memset(host_mem0, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_dma(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					 sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST));
+	zassert_mem_equal(host_mem0, expected, sizeof(expected));
+
+	/* Unregistered host addresses fail without touching local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_equal(pcie_ep_xfer_data_dma(ep0, 0x1000ULL, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/* The mapping used by the helper is released after completion. */
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_negative)
+{
+	uint8_t local_buf[0x40];
+	uint64_t host_base = (uint64_t)(uintptr_t)host_mem0;
+	struct dma_block_config steal_block = {
+		.source_address = host_base,
+		.dest_address = host_base + 0x100,
+		.block_size = 0x10,
+	};
+	struct dma_config steal_cfg = {
+		.dma_slot = 0,
+		.channel_direction = MEMORY_TO_MEMORY,
+		.source_data_size = 1,
+		.dest_data_size = 1,
+		.source_burst_length = 1,
+		.dest_burst_length = 1,
+		.block_count = 1,
+		.head_block = &steal_block,
+	};
+	uint8_t zeros[sizeof(local_buf)] = {0};
+	uint64_t mapped;
+
+	memset(local_buf, 0, sizeof(local_buf));
+
+	/* An invalid direction is rejected before anything else. */
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       (enum xfer_direction)2),
+		      -EINVAL);
+
+	/* Zero size and a NULL local pointer are rejected. */
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, (uintptr_t)local_buf, 0, HOST_TO_DEVICE),
+		      -EINVAL);
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, 0, sizeof(local_buf), HOST_TO_DEVICE),
+		      -EINVAL);
+
+	/*
+	 * A raw address inside the aperture without an active mapping
+	 * fails, as does an address outside any aperture; neither touches
+	 * local memory.
+	 */
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base - 0x1000, (uintptr_t)local_buf,
+				       sizeof(local_buf), HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/* The helper rejects transfers crossing the aperture end, too. */
+	zassert_equal(pcie_ep_xfer_data_dma(ep0, APERTURE0_PCIE_BASE + APERTURE_LEN - 0x20,
+					    (uintptr_t *)local_buf, sizeof(local_buf),
+					    PCIE_OB_ANYMEM, HOST_TO_DEVICE),
+		      -ENOTSUP);
+
+	/*
+	 * Once unmapped, the stale address fails even though the aperture
+	 * is still registered; a range crossing the mapping end fails, too.
+	 */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, sizeof(local_buf),
+				       PCIE_OB_ANYMEM),
+		      sizeof(local_buf));
+	zassert_equal(pcie_ep_dma_xfer(ep0, mapped + 0x20, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENOTSUP);
+	pcie_ep_unmap_addr(ep0, mapped);
+	zassert_equal(pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/*
+	 * A channel grabbed by another user is reported busy: occupy the
+	 * host-to-device channel of ep0, leaving it configured, while a
+	 * mapping is active.
+	 */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, sizeof(local_buf),
+				       PCIE_OB_ANYMEM),
+		      sizeof(local_buf));
+	zassert_ok(dma_config(dma_dev, 0, &steal_cfg));
+	zassert_equal(pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -EBUSY);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/* Release the channel; the mapped transfer succeeds afterwards. */
+	zassert_ok(dma_stop(dma_dev, 0));
+	fill_pattern(host_mem0, sizeof(local_buf), 0x77);
+	zassert_ok(pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf, sizeof(local_buf),
+				    HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, host_mem0, sizeof(local_buf));
+	pcie_ep_unmap_addr(ep0, mapped);
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_no_dmas_instance)
+{
+	uint8_t local_buf[0x40] = {0};
+	uint8_t zeros[sizeof(local_buf)] = {0};
+	uint64_t host_base = (uint64_t)(uintptr_t)host_mem0;
+
+	/* An invalid direction is rejected with -EINVAL even without dmas. */
+	zassert_equal(pcie_ep_dma_xfer(ep2, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       (enum xfer_direction)2),
+		      -EINVAL);
+
+	/*
+	 * ep2 has no dmas property: valid transfers in both directions
+	 * report -ENODEV and leave local memory untouched.
+	 */
+	zassert_equal(pcie_ep_dma_xfer(ep2, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENODEV);
+	zassert_equal(pcie_ep_dma_xfer(ep2, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       DEVICE_TO_HOST),
+		      -ENODEV);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+}
+
+#define DMA_CONCURRENT_ITERS 32U
+
+struct dma_xfer_worker {
+	const struct device *ep;
+	uint64_t pcie_base;
+	uint8_t *host_mem;
+	uint8_t seed;
+	int failures;
+};
+
+static void dma_xfer_worker_body(void *p0, void *p1, void *p2)
+{
+	struct dma_xfer_worker *worker = p0;
+	uint8_t local_buf[0x1c0];
+	uint8_t expected[sizeof(local_buf)];
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+
+	for (int i = 0; i < DMA_CONCURRENT_ITERS; i++) {
+		uint32_t off = (uint32_t)(i * 0x40U) % 0x800U;
+		uint32_t len = 0x100U + (uint32_t)(i % 4U) * 0x40U;
+
+		/* Host to device through the worker's own endpoint. */
+		fill_pattern(&worker->host_mem[off], len, (uint8_t)(worker->seed + i));
+		fill_pattern(expected, len, (uint8_t)(worker->seed + i));
+		memset(local_buf, 0, len);
+		if (pcie_ep_xfer_data_dma(worker->ep, worker->pcie_base + off,
+					  (uintptr_t *)local_buf, len, PCIE_OB_ANYMEM,
+					  HOST_TO_DEVICE) != 0 ||
+		    memcmp(local_buf, expected, len) != 0) {
+			worker->failures++;
+			continue;
+		}
+
+		/* Device to host into a disjoint host region. */
+		fill_pattern(local_buf, len, (uint8_t)(worker->seed ^ 0x5aU ^ i));
+		memset(&worker->host_mem[off + 0x1000U], 0, len);
+		if (pcie_ep_xfer_data_dma(worker->ep, worker->pcie_base + off + 0x1000U,
+					  (uintptr_t *)local_buf, len, PCIE_OB_ANYMEM,
+					  DEVICE_TO_HOST) != 0 ||
+		    memcmp(&worker->host_mem[off + 0x1000U], local_buf, len) != 0) {
+			worker->failures++;
+		}
+	}
+}
+
+static K_THREAD_STACK_DEFINE(dma_xfer_worker_stack, 4096);
+
+ZTEST(pcie_ep_emul, test_dma_xfer_concurrent_two_endpoints)
+{
+	struct dma_xfer_worker worker0 = {
+		.ep = ep0,
+		.pcie_base = APERTURE0_PCIE_BASE,
+		.host_mem = host_mem0,
+		.seed = 0x21,
+	};
+	struct dma_xfer_worker worker1 = {
+		.ep = ep1,
+		.pcie_base = APERTURE1_PCIE_BASE,
+		.host_mem = host_mem1,
+		.seed = 0xa7,
+	};
+	struct k_thread thread;
+
+	/*
+	 * ep0 (channels 0/1) transfers from a worker thread while the test
+	 * thread drives ep1 (channels 2/3). Every transfer blocks on its
+	 * own completion callback, so both directions of both endpoints
+	 * interleave on the controller workqueue. Distinct apertures and
+	 * per-iteration patterns surface any cross-instance data or
+	 * callback delivery as a corruption failure.
+	 */
+	k_thread_create(&thread, dma_xfer_worker_stack,
+			K_THREAD_STACK_SIZEOF(dma_xfer_worker_stack), dma_xfer_worker_body,
+			&worker0, NULL, NULL, K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
+
+	dma_xfer_worker_body(&worker1, NULL, NULL);
+
+	zassert_ok(k_thread_join(&thread, K_FOREVER));
+	zassert_equal(worker0.failures, 0, "concurrent ep0 transfers corrupted");
+	zassert_equal(worker1.failures, 0, "concurrent ep1 transfers corrupted");
+}
+
+#define PIN_TEST_PCIE_BASE 0xa0000000ULL
+#define PIN_TEST_XFER_LEN  0x400U
+
+static uint8_t pin_test_mem[0x1000];
+
+static struct {
+	uint64_t mapped;
+	int xfer_ret;
+	bool data_ok;
+} pin_xfer;
+
+static K_THREAD_STACK_DEFINE(pin_xfer_stack, 4096);
+
+static void pin_xfer_body(void *p0, void *p1, void *p2)
+{
+	uint8_t local_buf[PIN_TEST_XFER_LEN];
+	uint8_t expected[sizeof(local_buf)];
+	uint64_t mapped = 0;
+
+	ARG_UNUSED(p0);
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+
+	fill_pattern(pin_test_mem, sizeof(local_buf), 0x33);
+	fill_pattern(expected, sizeof(expected), 0x33);
+	memset(local_buf, 0, sizeof(local_buf));
+
+	pin_xfer.xfer_ret = pcie_ep_map_addr(ep0, PIN_TEST_PCIE_BASE, &mapped, sizeof(local_buf),
+					     PCIE_OB_ANYMEM);
+	if (pin_xfer.xfer_ret > 0) {
+		pin_xfer.mapped = mapped;
+		pin_xfer.xfer_ret = pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf,
+						     sizeof(local_buf), HOST_TO_DEVICE);
+		pin_xfer.data_ok = pin_xfer.xfer_ret == 0 &&
+				   memcmp(local_buf, expected, sizeof(local_buf)) == 0;
+	}
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_pins_mapping)
+{
+	uint64_t filler[CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1];
+	uint64_t free_addr;
+	uint64_t mapped;
+	struct k_thread xfer_thread;
+	int unregister_active;
+	int unregister_draining;
+	int map_full;
+
+	zassert_ok(pcie_ep_emul_register_aperture(ep0, PIN_TEST_PCIE_BASE, pin_test_mem,
+						  sizeof(pin_test_mem)));
+
+	/* Fill all map slots but the one the in-flight transfer will use. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1; i++) {
+		zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + i * 0x100U, &filler[i],
+					       0x100U, PCIE_OB_ANYMEM),
+			      0x100);
+	}
+
+	memset(&pin_xfer, 0, sizeof(pin_xfer));
+
+	/*
+	 * Both this test thread and the worker are cooperative, so the
+	 * preemptible controller workqueue cannot run the transfer to
+	 * completion while either of them is current. The worker starts
+	 * when this thread yields and runs until it blocks inside the
+	 * transfer on its completion semaphore, with the map pin held.
+	 * The probes below then run while the transfer is deterministically
+	 * in flight, and joining the worker blocks this thread again, which
+	 * lets the workqueue complete the transfer.
+	 */
+	k_thread_create(&xfer_thread, pin_xfer_stack, K_THREAD_STACK_SIZEOF(pin_xfer_stack),
+			pin_xfer_body, NULL, NULL, NULL, K_PRIO_COOP(1), 0, K_NO_WAIT);
+	k_yield();
+
+	/* The worker's mapping is active: unregistration is rejected. */
+	unregister_active = pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE);
+
+	/* Unmap mid-transfer: the record drains but stays pinned. */
+	pcie_ep_unmap_addr(ep0, pin_xfer.mapped);
+	unregister_draining = pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE);
+
+	/* All other slots are filled; the draining slot must not be reused. */
+	free_addr = APERTURE0_PCIE_BASE + (CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1) * 0x100U;
+	map_full = pcie_ep_map_addr(ep0, free_addr, &mapped, 0x100U, PCIE_OB_ANYMEM);
+
+	/* Blocking on the join lets the workqueue complete the transfer. */
+	zassert_ok(k_thread_join(&xfer_thread, K_FOREVER));
+
+	/* Active and draining pins both block aperture unregistration. */
+	zassert_equal(unregister_active, -EBUSY);
+	zassert_equal(unregister_draining, -EBUSY);
+	/* The draining slot is reserved: it is not handed out by map_addr. */
+	zassert_equal(map_full, -ENOMEM);
+
+	/* The transfer itself completed with its data intact throughout. */
+	zassert_equal(pin_xfer.xfer_ret, 0);
+	zassert_true(pin_xfer.data_ok, "in-flight transfer data corrupted");
+
+	/* Once the transfer completed, unregistration succeeds. */
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE));
+
+	/* The drained record is reusable after the transfer completed. */
+	zassert_ok(pcie_ep_emul_register_aperture(ep0, PIN_TEST_PCIE_BASE, pin_test_mem,
+						  sizeof(pin_test_mem)));
+	zassert_equal(pcie_ep_map_addr(ep0, PIN_TEST_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      0x100);
+	pcie_ep_unmap_addr(ep0, mapped);
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE));
+
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1; i++) {
+		pcie_ep_unmap_addr(ep0, filler[i]);
+	}
+}
+
+static void *pcie_ep_emul_setup(void)
+{
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep1, APERTURE1_PCIE_BASE, host_mem1, APERTURE_LEN));
+	return NULL;
+}
+
+static void pcie_ep_emul_before(void *fixture)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	ARG_UNUSED(fixture);
+
+	memset(host_mem0, 0, sizeof(host_mem0));
+	memset(host_mem1, 0, sizeof(host_mem1));
+
+	/* Disable interrupt capabilities configured by earlier tests. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0x0U);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0x0U);
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x0U);
+
+	/* Drop queued interrupt events and reset bookkeeping from earlier tests. */
+	while (pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT) == 0) {
+	}
+	while (pcie_ep_emul_wait_irq_event(ep1, &event, K_NO_WAIT) == 0) {
+	}
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+	while (pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT) == 0) {
+	}
+	memset(ep0_reset_records, 0, sizeof(ep0_reset_records));
+	memset(ep1_reset_records, 0, sizeof(ep1_reset_records));
+}
+
+ZTEST_SUITE(pcie_ep_emul, NULL, pcie_ep_emul_setup, pcie_ep_emul_before, NULL, NULL);

--- a/tests/drivers/pcie/endpoint_emul/src/main.c
+++ b/tests/drivers/pcie/endpoint_emul/src/main.c
@@ -1,0 +1,1174 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep.h>
+#include <zephyr/drivers/pcie/endpoint/pcie_ep_emul.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <limits.h>
+#include <string.h>
+
+#define CFG_VENDOR_DEVICE_ID 0x00U
+#define CFG_COMMAND_STATUS   0x04U
+#define CFG_CLASS_REVISION   0x08U
+#define CFG_BAR0             0x10U
+#define CFG_BAR1             0x14U
+#define CFG_BAR2             0x18U
+#define CFG_BAR3             0x1cU
+#define CFG_BAR5             0x24U
+#define CFG_CAPABILITY_PTR   0x34U
+#define CFG_MSI_CAP          0x40U
+#define CFG_MSIX_CAP         0x50U
+#define CFG_SIZE             4096U
+
+/* Status register (upper command/status half) capabilities-list bit. */
+#define STATUS_CAPABILITIES_LIST 0x00100000U
+
+/* MSI/MSI-X message control fields (upper half of the first cap dword). */
+#define MSI_CTRL_ENABLE     0x00010000U
+#define MSI_MME_SHIFT       20U
+#define MSIX_CTRL_ENABLE    0x80000000U
+#define MSIX_CTRL_FUNC_MASK 0x40000000U
+
+#define EP0_VENDOR_DEVICE_ID 0x00011234U
+#define EP0_CLASS_REVISION   0x06040001U
+#define EP1_VENDOR_DEVICE_ID 0x00025678U
+#define EP1_CLASS_REVISION   0xff000002U
+
+#define APERTURE0_PCIE_BASE 0x80000000ULL
+#define APERTURE1_PCIE_BASE 0x90000000ULL
+#define APERTURE_LEN        0x2000U
+
+static const struct device *const ep0 = DEVICE_DT_GET(DT_NODELABEL(tst_ep0));
+static const struct device *const ep1 = DEVICE_DT_GET(DT_NODELABEL(tst_ep1));
+/* Third endpoint without a dmas property. */
+static const struct device *const ep2 = DEVICE_DT_GET(DT_NODELABEL(tst_ep2));
+static const struct device *const dma_dev = DEVICE_DT_GET(DT_NODELABEL(dma));
+
+static uint8_t host_mem0[APERTURE_LEN];
+static uint8_t host_mem1[APERTURE_LEN];
+
+ZTEST(pcie_ep_emul, test_devices_ready)
+{
+	zassert_true(device_is_ready(ep0), "first emulated endpoint is not ready");
+	zassert_true(device_is_ready(ep1), "second emulated endpoint is not ready");
+	zassert_true(device_is_ready(ep2), "third emulated endpoint is not ready");
+}
+
+ZTEST(pcie_ep_emul, test_identity_per_instance)
+{
+	uint32_t value;
+
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_CLASS_REVISION, &value));
+	zassert_equal(value, EP0_CLASS_REVISION);
+
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP1_VENDOR_DEVICE_ID);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_CLASS_REVISION, &value));
+	zassert_equal(value, EP1_CLASS_REVISION);
+}
+
+ZTEST(pcie_ep_emul, test_conf_read_invalid_access)
+{
+	uint32_t value;
+
+	zassert_equal(pcie_ep_conf_read(ep0, 1, &value), -EINVAL);
+	zassert_equal(pcie_ep_conf_read(ep0, CFG_SIZE - 2, &value), -EINVAL);
+	zassert_equal(pcie_ep_conf_read(ep0, CFG_SIZE, &value), -EINVAL);
+	zassert_equal(pcie_ep_conf_read(ep0, UINT32_MAX - 2, &value), -EINVAL);
+}
+
+ZTEST(pcie_ep_emul, test_conf_write_readonly_identity)
+{
+	uint32_t value;
+
+	pcie_ep_conf_write(ep0, CFG_VENDOR_DEVICE_ID, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+
+	pcie_ep_conf_write(ep0, CFG_CLASS_REVISION, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_CLASS_REVISION, &value));
+	zassert_equal(value, EP0_CLASS_REVISION);
+
+	/* Invalid writes are a no-op and must not corrupt the image. */
+	pcie_ep_conf_write(ep0, 1, 0xdeadbeefU);
+	pcie_ep_conf_write(ep0, CFG_SIZE, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+}
+
+ZTEST(pcie_ep_emul, test_conf_write_command_bits)
+{
+	uint32_t value;
+
+	/*
+	 * Writable command bits 0..2; status stays read-only and keeps
+	 * the capabilities-list bit set at init (ep0 advertises MSI/MSI-X).
+	 */
+	pcie_ep_conf_write(ep0, CFG_COMMAND_STATUS, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_COMMAND_STATUS, &value));
+	zassert_equal(value, STATUS_CAPABILITIES_LIST | 0x7U);
+
+	pcie_ep_conf_write(ep0, CFG_COMMAND_STATUS, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_COMMAND_STATUS, &value));
+	zassert_equal(value, STATUS_CAPABILITIES_LIST);
+}
+
+ZTEST(pcie_ep_emul, test_bar_assignment_and_mask)
+{
+	uint32_t value;
+
+	/* BAR0 of ep0 is 64 KiB: the low 16 bits are size-masked. */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x0U);
+
+	pcie_ep_conf_write(ep0, CFG_BAR0, 0x1234abcdU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x12340000U);
+
+	/* BAR1 of ep0 is 4 KiB: the low 12 bits are size-masked. */
+	pcie_ep_conf_write(ep0, CFG_BAR1, 0x80000fffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR1, &value));
+	zassert_equal(value, 0x80000000U);
+
+	/* BAR2..BAR5 of ep0 are disabled: reads stay zero, writes ignored. */
+	pcie_ep_conf_write(ep0, CFG_BAR2, 0x12345000U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR2, &value));
+	zassert_equal(value, 0x0U);
+	pcie_ep_conf_write(ep0, CFG_BAR5, 0x12345000U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR5, &value));
+	zassert_equal(value, 0x0U);
+}
+
+ZTEST(pcie_ep_emul, test_instance_isolation)
+{
+	uint32_t value;
+
+	pcie_ep_conf_write(ep0, CFG_BAR0, 0x11110000U);
+	pcie_ep_conf_write(ep0, CFG_COMMAND_STATUS, 0x7U);
+
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_BAR0, &value));
+	zassert_equal(value, 0x0U);
+	/* ep1's status keeps its read-only capabilities-list bit (MSI). */
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_COMMAND_STATUS, &value));
+	zassert_equal(value, STATUS_CAPABILITIES_LIST);
+
+	/* ep1 BAR0 is 4 KiB: same write as above keeps the low 12 bits. */
+	pcie_ep_conf_write(ep1, CFG_BAR0, 0x22222fffU);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_BAR0, &value));
+	zassert_equal(value, 0x22222000U);
+
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x11110000U);
+}
+
+ZTEST(pcie_ep_emul, test_msi_msix_capabilities)
+{
+	uint32_t value;
+
+	/* ep0 advertises both capabilities; make sure both start disabled. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0x0U);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0x0U);
+
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_COMMAND_STATUS, &value));
+	zassert_true((value & STATUS_CAPABILITIES_LIST) != 0);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_CAPABILITY_PTR, &value));
+	zassert_equal(value, CFG_MSI_CAP);
+
+	/* MSI: ID 0x05, next 0x50, Multiple Message Capable = 2 (4 vectors). */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00045005U);
+
+	/* MSI-X: ID 0x11, last capability, table size 7 (8 vectors). */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0x00070011U);
+
+	/* Table at offset 0 of BAR0; PBA right after the 8-entry table. */
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP + 4, &value));
+	zassert_equal(value, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP + 8, &value));
+	zassert_equal(value, 0x80U);
+
+	/*
+	 * The MSI enable bit and MME (clamped to MMC = 2) are writable, as is
+	 * the MSI-X function mask bit; the rest of both dwords is read-only.
+	 */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00255005U);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0xc0070011U);
+
+	/* Message address/data read as zero and ignore writes. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP + 4, 0xdeadbeefU);
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP + 8, 0xdeadbeefU);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP + 4, &value));
+	zassert_equal(value, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep0, CFG_MSI_CAP + 8, &value));
+	zassert_equal(value, 0x0U);
+
+	/* The host-side accessors follow the same writability rules. */
+	zassert_ok(pcie_ep_emul_host_conf_write(ep0, CFG_MSI_CAP, 0x0U));
+	zassert_ok(pcie_ep_emul_host_conf_write(ep0, CFG_MSIX_CAP, 0x0U));
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00045005U);
+
+	/* ep1 advertises MSI with 1 vector and no MSI-X. */
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_COMMAND_STATUS, &value));
+	zassert_true((value & STATUS_CAPABILITIES_LIST) != 0);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_CAPABILITY_PTR, &value));
+	zassert_equal(value, CFG_MSI_CAP);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00000005U);
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x00010000U);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00010005U);
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x0U);
+
+	/* Where ep0 has its MSI-X capability, ep1 reads zero and ignores writes. */
+	pcie_ep_conf_write(ep1, CFG_MSIX_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep1, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0x0U);
+
+	/*
+	 * ep2 has no MSI but a 2-vector MSI-X capability: without an MSI
+	 * capability the MSI-X one heads the list at 0x40.
+	 */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_COMMAND_STATUS, &value));
+	zassert_true((value & STATUS_CAPABILITIES_LIST) != 0);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_CAPABILITY_PTR, &value));
+	zassert_equal(value, CFG_MSI_CAP);
+
+	/*
+	 * ID 0x11 (MSI-X, not MSI), next pointer 0 terminates the list,
+	 * table size 1 (2 vectors).
+	 */
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0x00010011U);
+
+	/* Table at offset 0 of BAR0; PBA right after the 2-entry table. */
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP + 4, &value));
+	zassert_equal(value, 0x0U);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP + 8, &value));
+	zassert_equal(value, 0x20U);
+
+	/* The MSI-X enable and function mask bits are writable; the rest is not. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSI_CAP, &value));
+	zassert_equal(value, 0xc0010011U);
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+
+	/* Where ep0 has its MSI-X capability, ep2 reads zero (its own is at 0x40). */
+	pcie_ep_conf_write(ep2, CFG_MSIX_CAP, 0xffffffffU);
+	zassert_ok(pcie_ep_conf_read(ep2, CFG_MSIX_CAP, &value));
+	zassert_equal(value, 0x0U);
+}
+
+ZTEST(pcie_ep_emul, test_dma_channels_claimed_exclusively)
+{
+	/*
+	 * ep0 and ep1 claimed all four channels of the controller at init
+	 * and hold them for their lifetime, so a late channel request on
+	 * the same controller finds nothing free.
+	 */
+	zassert_equal(dma_request_channel(dma_dev, NULL), -EINVAL);
+
+	/* Requesting any of the claimed channels by exact number fails, too. */
+	for (uint32_t ch = 0; ch < 4U; ch++) {
+		zassert_equal(dma_request_channel(dma_dev, &ch), -EINVAL,
+			      "exact request for claimed channel %u succeeded", ch);
+	}
+}
+
+ZTEST(pcie_ep_emul, test_aperture_registration)
+{
+	/* Overlap with the fixture aperture is rejected. */
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE + 0x1000, host_mem0,
+						     APERTURE_LEN),
+		      -EALREADY);
+
+	/* Zero length and overflowing ranges are rejected. */
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, 0xa0000000ULL, host_mem0, 0), -EINVAL);
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, UINT64_MAX - 0x10ULL, host_mem0, 0x20U),
+		      -EINVAL);
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, 0xa0000000ULL, NULL, 0x1000U), -EINVAL);
+
+	/* Unregistering an unknown aperture fails; the registered one is
+	 * removed by the fixture teardown.
+	 */
+	zassert_equal(pcie_ep_emul_unregister_aperture(ep0, 0xa0000000ULL), -ENOENT);
+}
+
+ZTEST(pcie_ep_emul, test_map_addr_negative_paths)
+{
+	uint64_t mapped;
+
+	/* Not covered by any registered aperture. */
+	zassert_equal(pcie_ep_map_addr(ep0, 0x1000ULL, &mapped, 0x100U, PCIE_OB_ANYMEM), -ENOTSUP);
+
+	/* Crossing the aperture end is rejected. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + APERTURE_LEN - 0x100U, &mapped,
+				       0x200U, PCIE_OB_ANYMEM),
+		      -ENOTSUP);
+
+	/* Zero-length and overflowing requests are rejected. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, 0, PCIE_OB_ANYMEM),
+		      -EINVAL);
+	zassert_equal(pcie_ep_map_addr(ep0, UINT64_MAX - 0x10ULL, &mapped, 0x20U, PCIE_OB_ANYMEM),
+		      -EINVAL);
+
+	/* Apertures are per instance: ep0's aperture is invisible to ep1. */
+	zassert_equal(pcie_ep_map_addr(ep1, APERTURE0_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      -ENOTSUP);
+}
+
+ZTEST(pcie_ep_emul, test_map_unmap_lifecycle)
+{
+	uint64_t mapped[CONFIG_PCIE_EP_EMUL_MAX_MAPS];
+	uint64_t extra;
+	int ret;
+
+	/* Fill the per-instance mapping table. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS; i++) {
+		ret = pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + i * 0x100U, &mapped[i], 0x100U,
+				       PCIE_OB_ANYMEM);
+		zassert_equal(ret, 0x100);
+		zassert_equal(mapped[i], (uint64_t)(uintptr_t)&host_mem0[i * 0x100U]);
+	}
+
+	/* The table is bounded: one more mapping of a new address fails. */
+	zassert_equal(pcie_ep_map_addr(ep0,
+				       APERTURE0_PCIE_BASE + CONFIG_PCIE_EP_EMUL_MAX_MAPS * 0x100U,
+				       &extra, 0x100U, PCIE_OB_ANYMEM),
+		      -ENOMEM);
+
+	/* Unknown and duplicate unmaps are ignored and disturb nothing. */
+	pcie_ep_unmap_addr(ep0, (uint64_t)(uintptr_t)&host_mem1[0]);
+	pcie_ep_unmap_addr(ep0, mapped[0]);
+	pcie_ep_unmap_addr(ep0, mapped[0]);
+
+	/* A freed slot is reusable, the remaining records stay valid. */
+	ret = pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped[0], 0x100U, PCIE_OB_ANYMEM);
+	zassert_equal(ret, 0x100);
+
+	/* Unregistering an aperture with active mappings is rejected. */
+	zassert_equal(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE), -EBUSY);
+
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS; i++) {
+		pcie_ep_unmap_addr(ep0, mapped[i]);
+	}
+
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+}
+
+ZTEST(pcie_ep_emul, test_map_addr_duplicate_and_oversize)
+{
+	uint64_t mapped;
+	uint64_t dup;
+
+	/* Sizes that do not fit the int return value are rejected up front. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, (uint32_t)INT_MAX + 1U,
+				       PCIE_OB_ANYMEM),
+		      -EINVAL);
+
+	/* A second mapping of a live address is rejected instead of aliased. */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      0x100);
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &dup, 0x100U, PCIE_OB_ANYMEM),
+		      -EALREADY);
+
+	/* A repeat unmap frees nothing; the record is owned once and reusable. */
+	pcie_ep_unmap_addr(ep0, mapped);
+	pcie_ep_unmap_addr(ep0, mapped);
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      0x100);
+	pcie_ep_unmap_addr(ep0, mapped);
+}
+
+ZTEST(pcie_ep_emul, test_xfer_data_memcpy_both_directions)
+{
+	uint8_t local_buf[0x100];
+	uint8_t expected[0x100];
+	uint8_t zeros[sizeof(local_buf)] = {0};
+
+	for (int i = 0; i < sizeof(expected); i++) {
+		host_mem0[i] = (uint8_t)(i ^ 0x5a);
+		expected[i] = (uint8_t)(i + 1);
+	}
+
+	/* Host to device: host aperture contents land in local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, host_mem0, sizeof(local_buf));
+
+	/* Device to host: local contents land in the host aperture. */
+	memcpy(local_buf, expected, sizeof(local_buf));
+	memset(host_mem0, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST));
+	zassert_mem_equal(host_mem0, expected, sizeof(expected));
+
+	/* Unregistered host addresses fail without touching local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_equal(pcie_ep_xfer_data_memcpy(ep0, 0x1000ULL, (uintptr_t *)local_buf,
+					       sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/*
+	 * Device to host to an unregistered address fails, too, and the
+	 * registered aperture backing is left unchanged.
+	 */
+	zassert_equal(pcie_ep_xfer_data_memcpy(ep0, 0x1000ULL, (uintptr_t *)local_buf,
+					       sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST),
+		      -ENOTSUP);
+	zassert_mem_equal(host_mem0, expected, sizeof(expected));
+
+	/* The mapping used by the helper is released again. */
+	zassert_equal(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE), 0);
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+}
+
+ZTEST(pcie_ep_emul, test_ep1_aperture_backing_and_isolation)
+{
+	uint8_t local_buf[0x100];
+	uint8_t expected[sizeof(local_buf)];
+	uint8_t zeros[sizeof(local_buf)] = {0};
+	uint64_t mapped;
+
+	for (int i = 0; i < sizeof(expected); i++) {
+		expected[i] = (uint8_t)(i ^ 0x3c);
+	}
+
+	/* ep1's fixture aperture maps into ep1's own backing buffer. */
+	zassert_equal(pcie_ep_map_addr(ep1, APERTURE1_PCIE_BASE, &mapped, sizeof(local_buf),
+				       PCIE_OB_ANYMEM),
+		      sizeof(local_buf));
+	zassert_equal(mapped, (uint64_t)(uintptr_t)host_mem1);
+	pcie_ep_unmap_addr(ep1, mapped);
+
+	/* Host to device: data lands from ep1's backing buffer. */
+	memcpy(host_mem1, expected, sizeof(expected));
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep1, APERTURE1_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, expected, sizeof(local_buf));
+
+	/*
+	 * Device to host: ep1's backing buffer receives the data while
+	 * ep0's backing buffer (zeroed by the fixture) stays untouched.
+	 */
+	memset(host_mem1, 0, sizeof(local_buf));
+	memcpy(local_buf, expected, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_memcpy(ep1, APERTURE1_PCIE_BASE, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST));
+	zassert_mem_equal(host_mem1, expected, sizeof(expected));
+	zassert_mem_equal(host_mem0, zeros, sizeof(local_buf));
+
+	/* The mapping used by the helper is released again. */
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep1, APERTURE1_PCIE_BASE));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep1, APERTURE1_PCIE_BASE, host_mem1, APERTURE_LEN));
+}
+
+/* Backing buffers used only to fill the aperture table. */
+static uint8_t aperture_fill_mem[CONFIG_PCIE_EP_EMUL_MAX_APERTURES - 1][0x100];
+
+ZTEST(pcie_ep_emul, test_aperture_table_full)
+{
+	/* The fixture aperture occupies one slot; fill the remaining ones. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_APERTURES - 1; i++) {
+		zassert_ok(pcie_ep_emul_register_aperture(ep0, 0xa0000000ULL + i * 0x1000ULL,
+							  aperture_fill_mem[i],
+							  sizeof(aperture_fill_mem[i])));
+	}
+
+	/* The per-instance table is bounded: one more aperture fails. */
+	zassert_equal(pcie_ep_emul_register_aperture(ep0, 0xb0000000ULL, host_mem0, 0x100U),
+		      -ENOMEM);
+
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_APERTURES - 1; i++) {
+		zassert_ok(pcie_ep_emul_unregister_aperture(ep0, 0xa0000000ULL + i * 0x1000ULL));
+	}
+}
+
+/* ep0: legacy IRQ, 4 MSI vectors, 8 MSI-X vectors. */
+/* ep1: no legacy IRQ, 1 MSI vector, no MSI-X vectors. */
+
+ZTEST(pcie_ep_emul, test_raise_irq_events)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* Enable the capabilities like a real host: MSI with all 4 vectors
+	 * allocated (MME = log2(4) = 2), MSI-X unmasked.
+	 */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (2U << MSI_MME_SHIFT));
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, MSIX_CTRL_ENABLE);
+
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_LEGACY, 0));
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 2));
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 7));
+
+	/* Events are consumed in raise order with type and vector intact. */
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_LEGACY);
+	zassert_equal(event.vector, 0);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSI);
+	zassert_equal(event.vector, 2);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSIX);
+	zassert_equal(event.vector, 7);
+
+	/* The queue is empty: neither polling nor waiting yields an event. */
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT), -EAGAIN);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_MSEC(10)), -EAGAIN);
+
+	/* NULL destination is rejected. */
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, NULL, K_NO_WAIT), -EINVAL);
+}
+
+ZTEST(pcie_ep_emul, test_raise_irq_negative)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* IRQ types disabled in devicetree are rejected. */
+	zassert_equal(pcie_ep_raise_irq(ep1, PCIE_EP_IRQ_LEGACY, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_raise_irq(ep1, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+
+	/* Capabilities the host has not enabled reject raises. */
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+
+	/* Out-of-range vectors are rejected regardless of enable state. */
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 4), -EINVAL);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 8), -EINVAL);
+	zassert_equal(pcie_ep_raise_irq(ep1, PCIE_EP_IRQ_MSI, 1), -EINVAL);
+
+	/*
+	 * The host allocated fewer vectors than advertised: with MME = 0
+	 * (one vector, the default) only vector 0 could be raised.
+	 */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 1), -EINVAL);
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (1U << MSI_MME_SHIFT));
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 2), -EINVAL);
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0x0U);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 0), -ENOTSUP);
+
+	/* A function-masked MSI-X capability suppresses raises. */
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, MSIX_CTRL_ENABLE | MSIX_CTRL_FUNC_MASK);
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0x0U);
+
+	/* An invalid interrupt type is rejected. */
+	zassert_equal(pcie_ep_raise_irq(ep0, (enum pci_ep_irq_type)3, 0), -EINVAL);
+
+	/* Failed raises must not record events on either instance. */
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT), -EAGAIN);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep1, &event, K_NO_WAIT), -EAGAIN);
+}
+
+ZTEST(pcie_ep_emul, test_raise_irq_msix_enable_state_ep2)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* ep2's MSI-X capability heads its list at 0x40; it starts disabled. */
+	zassert_equal(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+
+	/* Enabled and unmasked, both vectors raise and record events. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, MSIX_CTRL_ENABLE);
+	zassert_ok(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0));
+	zassert_ok(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 1));
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSIX);
+	zassert_equal(event.vector, 0);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSIX);
+	zassert_equal(event.vector, 1);
+
+	/* Function-masked: raises are suppressed and record nothing. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, MSIX_CTRL_ENABLE | MSIX_CTRL_FUNC_MASK);
+	zassert_equal(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT), -EAGAIN);
+
+	/* Disabled again: raises fail and record nothing. */
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+	zassert_equal(pcie_ep_raise_irq(ep2, PCIE_EP_IRQ_MSIX, 0), -ENOTSUP);
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT), -EAGAIN);
+}
+
+ZTEST(pcie_ep_emul, test_irq_event_queue_bounded)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	/* Enable MSI like a real host, with all 4 vectors allocated. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (2U << MSI_MME_SHIFT));
+
+	/* The per-instance queue holds exactly MAX_IRQ_EVENTS events. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS; i++) {
+		/* ep0 has 4 MSI vectors; cycle through the valid range. */
+		zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, (uint32_t)(i % 4)));
+	}
+	zassert_equal(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 0), -ENOSPC);
+
+	/* Draining frees capacity; all events arrive in order. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_IRQ_EVENTS; i++) {
+		zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+		zassert_equal(event.type, PCIE_EP_IRQ_MSI);
+		zassert_equal(event.vector, (uint32_t)(i % 4));
+	}
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT), -EAGAIN);
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_LEGACY, 0));
+}
+
+struct reset_cb_record {
+	int calls;
+	bool in_isr;
+	void *arg;
+};
+
+static struct reset_cb_record ep0_reset_records[PCIE_RESET_MAX];
+static struct reset_cb_record ep1_reset_records[PCIE_RESET_MAX];
+
+static void reset_cb(void *arg)
+{
+	struct reset_cb_record *record = arg;
+
+	record->calls++;
+	record->in_isr = k_is_in_isr();
+	record->arg = arg;
+}
+
+ZTEST(pcie_ep_emul, test_reset_callbacks)
+{
+	/* Register one callback per reset type, each with its own record. */
+	for (int i = 0; i < PCIE_RESET_MAX; i++) {
+		zassert_ok(pcie_ep_register_reset_cb(ep0, (enum pcie_reset)i, reset_cb,
+						     &ep0_reset_records[i]));
+	}
+
+	/* Injection runs the callback in interrupt context with its arg. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST));
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST_INB));
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_FLR));
+
+	for (int i = 0; i < PCIE_RESET_MAX; i++) {
+		zassert_equal(ep0_reset_records[i].calls, 1, "reset %d callback did not run", i);
+		zassert_true(ep0_reset_records[i].in_isr,
+			     "reset %d callback did not run in interrupt context", i);
+		zassert_equal(ep0_reset_records[i].arg, &ep0_reset_records[i]);
+	}
+
+	/* A second PERST injection reaches the same callback again. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST));
+	zassert_equal(ep0_reset_records[PCIE_PERST].calls, 2);
+}
+
+ZTEST(pcie_ep_emul, test_reset_negative)
+{
+	/* Invalid reset types and NULL callbacks are rejected. */
+	zassert_equal(
+		pcie_ep_register_reset_cb(ep0, PCIE_RESET_MAX, reset_cb, &ep0_reset_records[0]),
+		-EINVAL);
+	zassert_equal(pcie_ep_register_reset_cb(ep0, (enum pcie_reset)(-1), reset_cb,
+						&ep0_reset_records[0]),
+		      -EINVAL);
+	zassert_equal(pcie_ep_register_reset_cb(ep0, PCIE_PERST, NULL, NULL), -EINVAL);
+	zassert_equal(pcie_ep_emul_inject_reset(ep0, PCIE_RESET_MAX), -EINVAL);
+
+	/* Injecting a reset with no registered callback is a no-op. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep1, PCIE_FLR));
+	zassert_equal(ep1_reset_records[PCIE_FLR].calls, 0);
+}
+
+ZTEST(pcie_ep_emul, test_irq_reset_instance_isolation)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	zassert_ok(pcie_ep_register_reset_cb(ep0, PCIE_PERST, reset_cb,
+					     &ep0_reset_records[PCIE_PERST]));
+	zassert_ok(pcie_ep_register_reset_cb(ep1, PCIE_PERST, reset_cb,
+					     &ep1_reset_records[PCIE_PERST]));
+
+	/* Events raised on ep0 are only consumable on ep0. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, MSI_CTRL_ENABLE | (2U << MSI_MME_SHIFT));
+	zassert_ok(pcie_ep_raise_irq(ep0, PCIE_EP_IRQ_MSI, 1));
+	zassert_equal(pcie_ep_emul_wait_irq_event(ep1, &event, K_NO_WAIT), -EAGAIN);
+	zassert_ok(pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT));
+	zassert_equal(event.type, PCIE_EP_IRQ_MSI);
+	zassert_equal(event.vector, 1);
+
+	/* A reset injected on ep1 never fires the callback of ep0. */
+	zassert_ok(pcie_ep_emul_inject_reset(ep1, PCIE_PERST));
+	zassert_equal(ep0_reset_records[PCIE_PERST].calls, 0);
+	zassert_equal(ep1_reset_records[PCIE_PERST].calls, 1);
+
+	zassert_ok(pcie_ep_emul_inject_reset(ep0, PCIE_PERST));
+	zassert_equal(ep0_reset_records[PCIE_PERST].calls, 1);
+	zassert_equal(ep1_reset_records[PCIE_PERST].calls, 1);
+}
+
+ZTEST(pcie_ep_emul, test_host_conf_access)
+{
+	uint32_t value;
+
+	/* Host reads see the same image as the endpoint API. */
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+
+	/* Host writes follow the same writability rules. */
+	zassert_ok(pcie_ep_emul_host_conf_write(ep0, CFG_BAR0, 0x4567abcdU));
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_BAR0, &value));
+	zassert_equal(value, 0x45670000U);
+	/* Writes to read-only registers are reported and change nothing. */
+	zassert_equal(pcie_ep_emul_host_conf_write(ep0, CFG_VENDOR_DEVICE_ID, 0xdeadbeefU), -EPERM);
+	zassert_ok(pcie_ep_emul_host_conf_read(ep0, CFG_VENDOR_DEVICE_ID, &value));
+	zassert_equal(value, EP0_VENDOR_DEVICE_ID);
+	zassert_equal(pcie_ep_emul_host_conf_write(ep0, CFG_BAR2, 0xdeadbeefU), -EPERM);
+
+	/* Invalid host accesses fail instead of being silently ignored. */
+	zassert_equal(pcie_ep_emul_host_conf_read(ep0, 1, &value), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_conf_read(ep0, CFG_SIZE, &value), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_conf_write(ep0, CFG_SIZE, 0), -EINVAL);
+}
+
+ZTEST(pcie_ep_emul, test_host_bar_access)
+{
+	uint8_t written[0x40];
+	uint8_t read_back[sizeof(written)];
+	uint8_t other[sizeof(written)];
+	uint8_t zeros[sizeof(written)] = {0};
+
+	for (int i = 0; i < sizeof(written); i++) {
+		written[i] = (uint8_t)(i * 3 + 1);
+	}
+
+	/* Data written by the host reads back through the same BAR. */
+	zassert_ok(pcie_ep_emul_host_bar_write(ep0, 0, 0x100, written, sizeof(written)));
+	memset(read_back, 0, sizeof(read_back));
+	zassert_ok(pcie_ep_emul_host_bar_read(ep0, 0, 0x100, read_back, sizeof(read_back)));
+	zassert_mem_equal(read_back, written, sizeof(written));
+
+	/* BAR backing is per instance: ep1's BAR0 is unaffected. */
+	zassert_ok(pcie_ep_emul_host_bar_read(ep1, 0, 0x100, other, sizeof(other)));
+	zassert_mem_equal(other, zeros, sizeof(other));
+
+	/* Out-of-window, disabled-BAR, and malformed accesses fail. */
+	zassert_equal(pcie_ep_emul_host_bar_write(ep0, 6, 0, written, sizeof(written)), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_write(ep0, 2, 0, written, sizeof(written)), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_write(ep0, 0, 0x10000 - 0x10, written, 0x20), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_read(ep0, 0, 0, NULL, 0x10), -EINVAL);
+	zassert_equal(pcie_ep_emul_host_bar_read(ep0, 0, 0, read_back, 0), -EINVAL);
+	/* ep1 BAR0 is 4 KiB: a larger read is out of window. */
+	zassert_equal(pcie_ep_emul_host_bar_read(ep1, 0, 0, other, 0x2000), -EINVAL);
+}
+
+static void fill_pattern(uint8_t *buf, size_t len, uint8_t seed)
+{
+	for (size_t i = 0; i < len; i++) {
+		buf[i] = (uint8_t)(seed + i * 7U);
+	}
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_both_directions)
+{
+	uint8_t local_buf[0x100];
+	uint8_t expected[sizeof(local_buf)];
+	uint8_t zeros[sizeof(local_buf)] = {0};
+
+	fill_pattern(host_mem0, sizeof(local_buf), 0x11);
+	fill_pattern(expected, sizeof(expected), 0x42);
+
+	/* Host to device: host aperture contents land in local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_dma(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					 sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, host_mem0, sizeof(local_buf));
+
+	/* Device to host: local contents land in the host aperture. */
+	memcpy(local_buf, expected, sizeof(local_buf));
+	memset(host_mem0, 0, sizeof(local_buf));
+	zassert_ok(pcie_ep_xfer_data_dma(ep0, APERTURE0_PCIE_BASE, (uintptr_t *)local_buf,
+					 sizeof(local_buf), PCIE_OB_ANYMEM, DEVICE_TO_HOST));
+	zassert_mem_equal(host_mem0, expected, sizeof(expected));
+
+	/* Unregistered host addresses fail without touching local memory. */
+	memset(local_buf, 0, sizeof(local_buf));
+	zassert_equal(pcie_ep_xfer_data_dma(ep0, 0x1000ULL, (uintptr_t *)local_buf,
+					    sizeof(local_buf), PCIE_OB_ANYMEM, HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/* The mapping used by the helper is released after completion. */
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, APERTURE0_PCIE_BASE));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_negative)
+{
+	uint8_t local_buf[0x40];
+	uint64_t host_base = (uint64_t)(uintptr_t)host_mem0;
+	struct dma_block_config steal_block = {
+		.source_address = host_base,
+		.dest_address = host_base + 0x100,
+		.block_size = 0x10,
+	};
+	struct dma_config steal_cfg = {
+		.dma_slot = 0,
+		.channel_direction = MEMORY_TO_MEMORY,
+		.source_data_size = 1,
+		.dest_data_size = 1,
+		.source_burst_length = 1,
+		.dest_burst_length = 1,
+		.block_count = 1,
+		.head_block = &steal_block,
+	};
+	uint8_t zeros[sizeof(local_buf)] = {0};
+	uint64_t mapped;
+
+	memset(local_buf, 0, sizeof(local_buf));
+
+	/* An invalid direction is rejected before anything else. */
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       (enum xfer_direction)2),
+		      -EINVAL);
+
+	/* Zero size and a NULL local pointer are rejected. */
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, (uintptr_t)local_buf, 0, HOST_TO_DEVICE),
+		      -EINVAL);
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, 0, sizeof(local_buf), HOST_TO_DEVICE),
+		      -EINVAL);
+
+	/*
+	 * A raw address inside the aperture without an active mapping
+	 * fails, as does an address outside any aperture; neither touches
+	 * local memory.
+	 */
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_equal(pcie_ep_dma_xfer(ep0, host_base - 0x1000, (uintptr_t)local_buf,
+				       sizeof(local_buf), HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/* The helper rejects transfers crossing the aperture end, too. */
+	zassert_equal(pcie_ep_xfer_data_dma(ep0, APERTURE0_PCIE_BASE + APERTURE_LEN - 0x20,
+					    (uintptr_t *)local_buf, sizeof(local_buf),
+					    PCIE_OB_ANYMEM, HOST_TO_DEVICE),
+		      -ENOTSUP);
+
+	/*
+	 * Once unmapped, the stale address fails even though the aperture
+	 * is still registered; a range crossing the mapping end fails, too.
+	 */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, sizeof(local_buf),
+				       PCIE_OB_ANYMEM),
+		      sizeof(local_buf));
+	zassert_equal(pcie_ep_dma_xfer(ep0, mapped + 0x20, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENOTSUP);
+	pcie_ep_unmap_addr(ep0, mapped);
+	zassert_equal(pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENOTSUP);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/*
+	 * A channel grabbed by another user is reported busy: occupy the
+	 * host-to-device channel of ep0, leaving it configured, while a
+	 * mapping is active.
+	 */
+	zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE, &mapped, sizeof(local_buf),
+				       PCIE_OB_ANYMEM),
+		      sizeof(local_buf));
+	zassert_ok(dma_config(dma_dev, 0, &steal_cfg));
+	zassert_equal(pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -EBUSY);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+
+	/* Release the channel; the mapped transfer succeeds afterwards. */
+	zassert_ok(dma_stop(dma_dev, 0));
+	fill_pattern(host_mem0, sizeof(local_buf), 0x77);
+	zassert_ok(pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf, sizeof(local_buf),
+				    HOST_TO_DEVICE));
+	zassert_mem_equal(local_buf, host_mem0, sizeof(local_buf));
+	pcie_ep_unmap_addr(ep0, mapped);
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_no_dmas_instance)
+{
+	uint8_t local_buf[0x40] = {0};
+	uint8_t zeros[sizeof(local_buf)] = {0};
+	uint64_t host_base = (uint64_t)(uintptr_t)host_mem0;
+
+	/* An invalid direction is rejected with -EINVAL even without dmas. */
+	zassert_equal(pcie_ep_dma_xfer(ep2, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       (enum xfer_direction)2),
+		      -EINVAL);
+
+	/*
+	 * ep2 has no dmas property: valid transfers in both directions
+	 * report -ENODEV and leave local memory untouched.
+	 */
+	zassert_equal(pcie_ep_dma_xfer(ep2, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       HOST_TO_DEVICE),
+		      -ENODEV);
+	zassert_equal(pcie_ep_dma_xfer(ep2, host_base, (uintptr_t)local_buf, sizeof(local_buf),
+				       DEVICE_TO_HOST),
+		      -ENODEV);
+	zassert_mem_equal(local_buf, zeros, sizeof(local_buf));
+}
+
+#define DMA_CONCURRENT_ITERS 32U
+
+struct dma_xfer_worker {
+	const struct device *ep;
+	uint64_t pcie_base;
+	uint8_t *host_mem;
+	uint8_t seed;
+	int failures;
+};
+
+static void dma_xfer_worker_body(void *p0, void *p1, void *p2)
+{
+	struct dma_xfer_worker *worker = p0;
+	uint8_t local_buf[0x1c0];
+	uint8_t expected[sizeof(local_buf)];
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+
+	for (int i = 0; i < DMA_CONCURRENT_ITERS; i++) {
+		uint32_t off = (uint32_t)(i * 0x40U) % 0x800U;
+		uint32_t len = 0x100U + (uint32_t)(i % 4U) * 0x40U;
+
+		/* Host to device through the worker's own endpoint. */
+		fill_pattern(&worker->host_mem[off], len, (uint8_t)(worker->seed + i));
+		fill_pattern(expected, len, (uint8_t)(worker->seed + i));
+		memset(local_buf, 0, len);
+		if (pcie_ep_xfer_data_dma(worker->ep, worker->pcie_base + off,
+					  (uintptr_t *)local_buf, len, PCIE_OB_ANYMEM,
+					  HOST_TO_DEVICE) != 0 ||
+		    memcmp(local_buf, expected, len) != 0) {
+			worker->failures++;
+			continue;
+		}
+
+		/* Device to host into a disjoint host region. */
+		fill_pattern(local_buf, len, (uint8_t)(worker->seed ^ 0x5aU ^ i));
+		memset(&worker->host_mem[off + 0x1000U], 0, len);
+		if (pcie_ep_xfer_data_dma(worker->ep, worker->pcie_base + off + 0x1000U,
+					  (uintptr_t *)local_buf, len, PCIE_OB_ANYMEM,
+					  DEVICE_TO_HOST) != 0 ||
+		    memcmp(&worker->host_mem[off + 0x1000U], local_buf, len) != 0) {
+			worker->failures++;
+		}
+	}
+}
+
+static K_THREAD_STACK_DEFINE(dma_xfer_worker_stack, 4096);
+
+ZTEST(pcie_ep_emul, test_dma_xfer_concurrent_two_endpoints)
+{
+	struct dma_xfer_worker worker0 = {
+		.ep = ep0,
+		.pcie_base = APERTURE0_PCIE_BASE,
+		.host_mem = host_mem0,
+		.seed = 0x21,
+	};
+	struct dma_xfer_worker worker1 = {
+		.ep = ep1,
+		.pcie_base = APERTURE1_PCIE_BASE,
+		.host_mem = host_mem1,
+		.seed = 0xa7,
+	};
+	struct k_thread thread;
+
+	/*
+	 * ep0 (channels 0/1) transfers from a worker thread while the test
+	 * thread drives ep1 (channels 2/3). Every transfer blocks on its
+	 * own completion callback, so both directions of both endpoints
+	 * interleave on the controller workqueue. Distinct apertures and
+	 * per-iteration patterns surface any cross-instance data or
+	 * callback delivery as a corruption failure.
+	 */
+	k_thread_create(&thread, dma_xfer_worker_stack,
+			K_THREAD_STACK_SIZEOF(dma_xfer_worker_stack), dma_xfer_worker_body,
+			&worker0, NULL, NULL, K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
+
+	dma_xfer_worker_body(&worker1, NULL, NULL);
+
+	zassert_ok(k_thread_join(&thread, K_FOREVER));
+	zassert_equal(worker0.failures, 0, "concurrent ep0 transfers corrupted");
+	zassert_equal(worker1.failures, 0, "concurrent ep1 transfers corrupted");
+}
+
+#define PIN_TEST_PCIE_BASE 0xa0000000ULL
+#define PIN_TEST_XFER_LEN  0x400U
+
+static uint8_t pin_test_mem[0x1000];
+
+static struct {
+	uint64_t mapped;
+	int xfer_ret;
+	bool data_ok;
+} pin_xfer;
+
+static K_THREAD_STACK_DEFINE(pin_xfer_stack, 4096);
+
+static void pin_xfer_body(void *p0, void *p1, void *p2)
+{
+	uint8_t local_buf[PIN_TEST_XFER_LEN];
+	uint8_t expected[sizeof(local_buf)];
+	uint64_t mapped = 0;
+
+	ARG_UNUSED(p0);
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+
+	fill_pattern(pin_test_mem, sizeof(local_buf), 0x33);
+	fill_pattern(expected, sizeof(expected), 0x33);
+	memset(local_buf, 0, sizeof(local_buf));
+
+	pin_xfer.xfer_ret = pcie_ep_map_addr(ep0, PIN_TEST_PCIE_BASE, &mapped, sizeof(local_buf),
+					     PCIE_OB_ANYMEM);
+	if (pin_xfer.xfer_ret > 0) {
+		pin_xfer.mapped = mapped;
+		pin_xfer.xfer_ret = pcie_ep_dma_xfer(ep0, mapped, (uintptr_t)local_buf,
+						     sizeof(local_buf), HOST_TO_DEVICE);
+		pin_xfer.data_ok = pin_xfer.xfer_ret == 0 &&
+				   memcmp(local_buf, expected, sizeof(local_buf)) == 0;
+	}
+}
+
+ZTEST(pcie_ep_emul, test_dma_xfer_pins_mapping)
+{
+	uint64_t filler[CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1];
+	uint64_t free_addr;
+	uint64_t mapped;
+	struct k_thread xfer_thread;
+	int unregister_active;
+	int unregister_draining;
+	int map_full;
+
+	zassert_ok(pcie_ep_emul_register_aperture(ep0, PIN_TEST_PCIE_BASE, pin_test_mem,
+						  sizeof(pin_test_mem)));
+
+	/* Fill all map slots but the one the in-flight transfer will use. */
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1; i++) {
+		zassert_equal(pcie_ep_map_addr(ep0, APERTURE0_PCIE_BASE + i * 0x100U, &filler[i],
+					       0x100U, PCIE_OB_ANYMEM),
+			      0x100);
+	}
+
+	memset(&pin_xfer, 0, sizeof(pin_xfer));
+
+	/*
+	 * Both this test thread and the worker are cooperative, so the
+	 * preemptible controller workqueue cannot run the transfer to
+	 * completion while either of them is current. The worker starts
+	 * when this thread yields and runs until it blocks inside the
+	 * transfer on its completion semaphore, with the map pin held.
+	 * The probes below then run while the transfer is deterministically
+	 * in flight, and joining the worker blocks this thread again, which
+	 * lets the workqueue complete the transfer.
+	 */
+	k_thread_create(&xfer_thread, pin_xfer_stack, K_THREAD_STACK_SIZEOF(pin_xfer_stack),
+			pin_xfer_body, NULL, NULL, NULL, K_PRIO_COOP(1), 0, K_NO_WAIT);
+	k_yield();
+
+	/* The worker's mapping is active: unregistration is rejected. */
+	unregister_active = pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE);
+
+	/* Unmap mid-transfer: the record drains but stays pinned. */
+	pcie_ep_unmap_addr(ep0, pin_xfer.mapped);
+	unregister_draining = pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE);
+
+	/* All other slots are filled; the draining slot must not be reused. */
+	free_addr = APERTURE0_PCIE_BASE + (CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1) * 0x100U;
+	map_full = pcie_ep_map_addr(ep0, free_addr, &mapped, 0x100U, PCIE_OB_ANYMEM);
+
+	/* Blocking on the join lets the workqueue complete the transfer. */
+	zassert_ok(k_thread_join(&xfer_thread, K_FOREVER));
+
+	/* Active and draining pins both block aperture unregistration. */
+	zassert_equal(unregister_active, -EBUSY);
+	zassert_equal(unregister_draining, -EBUSY);
+	/* The draining slot is reserved: it is not handed out by map_addr. */
+	zassert_equal(map_full, -ENOMEM);
+
+	/* The transfer itself completed with its data intact throughout. */
+	zassert_equal(pin_xfer.xfer_ret, 0);
+	zassert_true(pin_xfer.data_ok, "in-flight transfer data corrupted");
+
+	/* Once the transfer completed, unregistration succeeds. */
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE));
+
+	/* The drained record is reusable after the transfer completed. */
+	zassert_ok(pcie_ep_emul_register_aperture(ep0, PIN_TEST_PCIE_BASE, pin_test_mem,
+						  sizeof(pin_test_mem)));
+	zassert_equal(pcie_ep_map_addr(ep0, PIN_TEST_PCIE_BASE, &mapped, 0x100U, PCIE_OB_ANYMEM),
+		      0x100);
+	pcie_ep_unmap_addr(ep0, mapped);
+	zassert_ok(pcie_ep_emul_unregister_aperture(ep0, PIN_TEST_PCIE_BASE));
+
+	for (int i = 0; i < CONFIG_PCIE_EP_EMUL_MAX_MAPS - 1; i++) {
+		pcie_ep_unmap_addr(ep0, filler[i]);
+	}
+}
+
+static void *pcie_ep_emul_setup(void)
+{
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep0, APERTURE0_PCIE_BASE, host_mem0, APERTURE_LEN));
+	zassert_ok(
+		pcie_ep_emul_register_aperture(ep1, APERTURE1_PCIE_BASE, host_mem1, APERTURE_LEN));
+	return NULL;
+}
+
+static void pcie_ep_emul_before(void *fixture)
+{
+	struct pcie_ep_emul_irq_event event;
+
+	ARG_UNUSED(fixture);
+
+	memset(host_mem0, 0, sizeof(host_mem0));
+	memset(host_mem1, 0, sizeof(host_mem1));
+
+	/* Disable interrupt capabilities configured by earlier tests. */
+	pcie_ep_conf_write(ep0, CFG_MSI_CAP, 0x0U);
+	pcie_ep_conf_write(ep0, CFG_MSIX_CAP, 0x0U);
+	pcie_ep_conf_write(ep1, CFG_MSI_CAP, 0x0U);
+
+	/* Drop queued interrupt events and reset bookkeeping from earlier tests. */
+	while (pcie_ep_emul_wait_irq_event(ep0, &event, K_NO_WAIT) == 0) {
+	}
+	while (pcie_ep_emul_wait_irq_event(ep1, &event, K_NO_WAIT) == 0) {
+	}
+	pcie_ep_conf_write(ep2, CFG_MSI_CAP, 0x0U);
+	while (pcie_ep_emul_wait_irq_event(ep2, &event, K_NO_WAIT) == 0) {
+	}
+	memset(ep0_reset_records, 0, sizeof(ep0_reset_records));
+	memset(ep1_reset_records, 0, sizeof(ep1_reset_records));
+}
+
+ZTEST_SUITE(pcie_ep_emul, NULL, pcie_ep_emul_setup, pcie_ep_emul_before, NULL, NULL);

--- a/tests/drivers/pcie/endpoint_emul/tests.yaml
+++ b/tests/drivers/pcie/endpoint_emul/tests.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.pcie.endpoint_emul:
+    tags:
+      - drivers
+      - pcie
+    platform_allow:
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim/native/64
+    filter: dt_compat_enabled("zephyr,pcie-ep-emul")

--- a/tests/drivers/pcie/endpoint_emul_gate/CMakeLists.txt
+++ b/tests/drivers/pcie/endpoint_emul_gate/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(pcie_ep_emul_gate)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/pcie/endpoint_emul_gate/prj.conf
+++ b/tests/drivers/pcie/endpoint_emul_gate/prj.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Request the driver without providing any zephyr,pcie-ep-emul node.
+CONFIG_TEST=y
+CONFIG_PCIE_ENDPOINT=y
+CONFIG_PCIE_EP_EMUL=y
+CONFIG_IRQ_OFFLOAD=y

--- a/tests/drivers/pcie/endpoint_emul_gate/src/main.c
+++ b/tests/drivers/pcie/endpoint_emul_gate/src/main.c
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/util.h>
+
+/*
+ * prj.conf requests CONFIG_PCIE_EP_EMUL=y, but this application has no
+ * zephyr,pcie-ep-emul devicetree node. The driver's
+ * DT_HAS_ZEPHYR_PCIE_EP_EMUL_ENABLED dependency must keep the symbol
+ * off so the driver is not compiled with zero instances. If the gate
+ * is dropped, the symbol turns on and this assert fails the build.
+ */
+BUILD_ASSERT(!IS_ENABLED(CONFIG_PCIE_EP_EMUL),
+	     "PCIE_EP_EMUL must stay gated off without a zephyr,pcie-ep-emul node");
+
+int main(void)
+{
+	return 0;
+}

--- a/tests/drivers/pcie/endpoint_emul_gate/tests.yaml
+++ b/tests/drivers/pcie/endpoint_emul_gate/tests.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.pcie.endpoint_emul_gate:
+    tags:
+      - drivers
+      - pcie
+    build_only: true
+    platform_allow:
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim/native/64


### PR DESCRIPTION
## Summary

Implements the Enhancement in https://github.com/zephyrproject-rtos/zephyr/issues/38212: an experimental, multi-instance emulated PCIe endpoint (`zephyr,pcie-ep-emul`) implementing the existing `pcie_ep` driver API purely in software, so endpoint application code can be exercised by API-level automated tests on `native_sim/native/64` without real PCIe hardware.

The emulated endpoint is process-local and not externally PCIe-enumerable; it is gated on `ARCH_POSIX`, `IRQ_OFFLOAD`, `EXPERIMENTAL`, and `DT_HAS_ZEPHYR_PCIE_EP_EMUL_ENABLED`.

Per devicetree node the driver provides:
- a 4 KiB Type-0 configuration image (identity fields, six BARs backed by instance-local RAM, MSI/MSI-X capabilities whose writable bits — MSI enable/MME, MSI-X enable/function mask — gate `raise_irq()` like hardware; writes to read-only registers are silently ignored by the void device API and reported as `-EPERM` by the test-host interface);
- bounded host-memory apertures with single-owner outbound mappings (duplicate live address rejected with `-EALREADY`, oversize with `-EINVAL`);
- legacy/MSI/MSI-X interrupt event queues and PERST/FLR reset injection delivered in interrupt context via `irq_offload()`;
- an emulator-specific test-host interface  (`include/zephyr/drivers/pcie/endpoint/pcie_ep_emul.h`) for aperture
  lifecycle, host config/BAR access, IRQ event consumption, and reset injection;
- optional dedicated `dma_emul`-backed transfer channels (`host-to-device`/`device-to-host`), claimed exclusively by exact devicetree channel number and held for the device lifetime, with the mapping pinned for the whole transfer so unmap/unregister lifetime races are reported instead of corrupting memory.

As a prerequisite, `dma_emul` gains per-channel work items (previously one driver-global work item corrupted overlapping multi-channel transfers), an exact-channel filter honoring `filter_param` as a `uint32_t *` channel number (the in-tree dereference convention), and a 64-bit address guard (`CONFIG_DMA_64BIT` weak default on 64-bit targets plus a `BUILD_ASSERT`, so an explicit override fails the build instead of truncating native pointers at runtime).

Devicetree payloads are validated at build time: identity field bit widths, BAR count/size rules, MSI/MSI-X vector limits and table fit, dmas/dma-names pairing, and `zephyr,dma-emul`-only dmas controllers all carry `BUILD_ASSERT`s.

## Verification

- `west twister -p native_sim/native/64 -T tests/drivers/pcie/endpoint_emul -T tests/drivers/dma/emul_concurrent`: 2/2 configurations, 32/32 cases (30 endpoint + 2 dma_emul) pass.
- New `tests/drivers/pcie/endpoint_emul` suite: three instances (two fully featured, one without dmas) covering identity/isolation, config space and BAR behavior, aperture map/unmap bounds and duplicate/oversize rejection, read-only write reporting, memcpy both directions, legacy/MSI/MSI-X injection and enable-state gating, reset callbacks, concurrent bidirectional DMA, mapping pinning against unmap lifetime races, exclusive channel claiming, and negative paths.
- New `tests/drivers/dma/emul_concurrent` suite: overlapping multi-channel transfers complete independently; exact-channel requests claim the requested channel (including channel 0) or fail.
- Negative build checks: invalid bar-sizes, out-of-range vendor-id, negative msix-vectors, non-`zephyr,dma-emul` dmas controller, and forced `CONFIG_DMA_64BIT=n` on a 64-bit target all fail the build with the expected static assertions.
- `./scripts/checkpatch.pl`: 0 errors / 0 warnings on every commit; `clang-format --dry-run --Werror` clean; DCO sign-off on all commits.

## Known limitations (by design)

- Process-local only: no external PCIe enumeration; VM-topology transports are a follow-up. POSIX/native targets only.
- `dmas` controllers are restricted to `zephyr,dma-emul` at build time: the DMA API does not standardize `filter_param`, and exact-channel claiming relies on the dma_emul `uint32_t *` filter convention.
- MSI message address/data read as zero (simplest 32-bit, no per-vector-masking MSI model).
- `unmap_addr()` keys on the bare address per the fixed `pcie_ep` API; unmapping a stale, already released handle of identical value is a caller error of the double-free class that no implementation behind this signature can detect (same behavior as the in-tree `pcie_ep_iproc` driver).
- PCI spec chapter attributions in the driver comments are cross-validated against a pinned `linux/pci_regs.h`, not the spec originals.