### PR TITLE
drivers: i2c: nrfx: Thread context for bus recovery in RTIO drivers

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -20,20 +20,16 @@ LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 #define DT_DRV_COMPAT nordic_nrf_twi
 
 struct i2c_nrfx_twi_data {
-	nrfx_twi_t twi;
-	uint32_t dev_config;
+	struct i2c_nrfx_twi_common_data common;
 	struct k_sem transfer_sync;
 	struct k_sem completion_sync;
 	volatile int res;
 };
 
-/* Enforce dev_config matches the same offset as the common structure,
+/* Enforce twi and dev_config matches the same offset as the common structure,
  * otherwise common API won't be compatible with i2c_nrfx_twi.
  */
-BUILD_ASSERT(
-	offsetof(struct i2c_nrfx_twi_data, dev_config) ==
-	offsetof(struct i2c_nrfx_twi_common_data, dev_config)
-);
+BUILD_ASSERT(offsetof(struct i2c_nrfx_twi_data, common) == 0);
 
 static int i2c_nrfx_twi_transfer(const struct device *dev,
 				 struct i2c_msg *msgs,
@@ -47,7 +43,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 	/* Dummy take on completion_sync sem to be sure that it is empty */
 	k_sem_take(&data->completion_sync, K_NO_WAIT);
 
-	nrfx_twi_enable(&data->twi);
+	nrfx_twi_enable(&data->common.twi);
 
 	for (size_t i = 0; i < num_msgs; i++) {
 		bool more_msgs = ((i < (num_msgs - 1)) &&
@@ -79,7 +75,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			 * to make sure everything has been done to restore the
 			 * bus from this error.
 			 */
-			nrfx_twi_disable(&data->twi);
+			nrfx_twi_disable(&data->common.twi);
 			(void)i2c_nrfx_twi_recover_bus(dev);
 			ret = -ETIMEDOUT;
 			break;
@@ -91,7 +87,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 		}
 	}
 
-	nrfx_twi_disable(&data->twi);
+	nrfx_twi_disable(&data->common.twi);
 	k_sem_give(&data->transfer_sync);
 
 	return ret;
@@ -131,14 +127,14 @@ static DEVICE_API(i2c, i2c_nrfx_twi_driver_api) = {
 	BUILD_ASSERT(I2C_FREQUENCY(DT_DRV_INST(idx)) != I2C_NRFX_TWI_INVALID_FREQUENCY,           \
 			"Wrong I2C " #idx " frequency setting in dts");                           \
 	static struct i2c_nrfx_twi_data twi_##idx##_data = {                                      \
-		.twi = NRFX_TWI_INSTANCE(DT_INST_REG_ADDR(idx)),                                  \
+		.common.twi = NRFX_TWI_INSTANCE(DT_INST_REG_ADDR(idx)),                           \
 		.transfer_sync = Z_SEM_INITIALIZER(twi_##idx##_data.transfer_sync, 1, 1),         \
 		.completion_sync = Z_SEM_INITIALIZER(twi_##idx##_data.completion_sync, 0, 1)      \
 	};                                                                                        \
 	static int twi_##idx##_init(const struct device *dev)                                     \
 	{                                                                                         \
 		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority), nrfx_twi_irq_handler,  \
-				&twi_##idx##_data.twi, 0);                                        \
+				&twi_##idx##_data.common.twi, 0);                                 \
 		const struct i2c_nrfx_twi_config *config = dev->config;                           \
 		int err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);               \
 		if (err < 0) {                                                                    \

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -189,16 +189,20 @@ static DEVICE_API(i2c, i2c_nrfx_twi_rtio_driver_api) = {
 
 #define I2C_NRFX_TWI_RTIO_DEVICE(idx)                                                             \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(DT_DRV_INST(idx));                                    \
+												  \
 	BUILD_ASSERT(I2C_FREQUENCY(DT_DRV_INST(idx)) !=                                           \
 			I2C_NRFX_TWI_INVALID_FREQUENCY,                                           \
 			"Wrong I2C " #idx " frequency setting in dts");                           \
+												  \
 	I2C_RTIO_DEFINE(_i2c##idx##_twi_rtio,                                                     \
 			DT_INST_PROP_OR(idx, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),                   \
 			DT_INST_PROP_OR(idx, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));                  \
+												  \
 	static struct i2c_nrfx_twi_rtio_data twi_##idx##_data = {                                 \
 		.twi = NRFX_TWI_INSTANCE(DT_INST_REG_ADDR(idx)),	                          \
 		.ctx = &_i2c##idx##_twi_rtio,                                                     \
 	};                                                                                        \
+												  \
 	static int twi_##idx##_init(const struct device *dev)                                     \
 	{                                                                                         \
 		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority),                        \
@@ -213,7 +217,9 @@ static DEVICE_API(i2c, i2c_nrfx_twi_rtio_driver_api) = {
 		i2c_rtio_init(dev_data->ctx, dev);                                                \
 		return i2c_nrfx_twi_init(dev);                                                    \
 	}                                                                                         \
+												  \
 	PINCTRL_DT_INST_DEFINE(idx);                                                              \
+												  \
 	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {                           \
 		.config = {                                                                       \
 			.skip_gpio_cfg = true,                                                    \
@@ -223,7 +229,9 @@ static DEVICE_API(i2c, i2c_nrfx_twi_rtio_driver_api) = {
 		.event_handler = event_handler,                                                   \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                      \
 	};                                                                                        \
+												  \
 	PM_DEVICE_DT_INST_DEFINE(idx, twi_nrfx_pm_action);                                        \
+												  \
 	I2C_DEVICE_DT_INST_DEFINE(idx,                                                            \
 			twi_##idx##_init,                                                         \
 			PM_DEVICE_DT_INST_GET(idx),                                               \

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -25,6 +25,7 @@ struct i2c_nrfx_twi_rtio_data {
 	uint32_t dev_config;
 	bool twi_enabled;
 	struct i2c_rtio *ctx;
+	struct k_work recovery_work;
 };
 
 /* Enforce dev_config matches the same offset as the common structure,
@@ -97,8 +98,11 @@ static bool i2c_nrfx_twi_rtio_start(const struct device *dev, int *status)
 		*status = i2c_nrfx_twi_configure(dev, sqe->i2c_config);
 		return false;
 	case RTIO_OP_I2C_RECOVER:
-		*status = i2c_nrfx_twi_recover_bus(dev);
-		return false;
+		error = k_work_submit(&dev_data->recovery_work);
+		if (error < 0) {
+			break;
+		}
+		return true;
 	case RTIO_OP_AWAIT:
 		iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
 		rtio_iodev_sqe_await_signal(iodev_sqe, i2c_nrfx_twi_rtio_sqe_signaled,
@@ -158,6 +162,15 @@ static int i2c_nrfx_twi_rtio_recover_bus(const struct device *dev)
 	return i2c_rtio_recover(ctx);
 }
 
+static void i2c_nrfx_twi_rtio_recovery_work_fn(struct k_work *work)
+{
+	struct i2c_nrfx_twi_rtio_data *data = CONTAINER_OF(work, struct i2c_nrfx_twi_rtio_data,
+							   recovery_work);
+	const struct device *dev = data->ctx->dt_spec.bus;
+
+	i2c_nrfx_twi_rtio_complete(dev, i2c_nrfx_twi_rtio_recover_bus(dev));
+}
+
 static void event_handler(nrfx_twi_event_t const *p_event, void *p_context)
 {
 	const struct device *dev = p_context;
@@ -208,13 +221,14 @@ static DEVICE_API(i2c, i2c_nrfx_twi_rtio_driver_api) = {
 		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority),                        \
 				nrfx_twi_irq_handler, &twi_##idx##_data.twi, 0);                  \
 		const struct i2c_nrfx_twi_config *config = dev->config;                           \
-		const struct i2c_nrfx_twi_rtio_data *dev_data = dev->data;                        \
+		struct i2c_nrfx_twi_rtio_data *dev_data = dev->data;                              \
 		int err = pinctrl_apply_state(config->pcfg,                                       \
 						PINCTRL_STATE_DEFAULT);                           \
 		if (err < 0) {                                                                    \
 			return err;                                                               \
 		}                                                                                 \
 		i2c_rtio_init(dev_data->ctx, dev);                                                \
+		k_work_init(&dev_data->recovery_work, i2c_nrfx_twi_rtio_recovery_work_fn);        \
 		return i2c_nrfx_twi_init(dev);                                                    \
 	}                                                                                         \
 												  \

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -21,43 +21,38 @@ LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 #define DT_DRV_COMPAT nordic_nrf_twi
 
 struct i2c_nrfx_twi_rtio_data {
-	nrfx_twi_t twi;
-	uint32_t dev_config;
+	struct i2c_nrfx_twi_common_data common;
 	bool twi_enabled;
 	struct i2c_rtio *ctx;
 	struct k_work recovery_work;
 };
 
-/* Enforce dev_config matches the same offset as the common structure,
+/* Enforce twi and dev_config matches the same offset as the common structure,
  * otherwise common API won't be compatible with i2c_nrfx_twi_rtio.
  */
-BUILD_ASSERT(
-	offsetof(struct i2c_nrfx_twi_rtio_data, dev_config) ==
-	offsetof(struct i2c_nrfx_twi_common_data, dev_config)
-);
+BUILD_ASSERT(offsetof(struct i2c_nrfx_twi_rtio_data, common) == 0);
 
 static void i2c_nrfx_twi_rtio_complete(const struct device *dev, int status);
 
 static int i2c_nrfx_twi_rtio_msg_start(const struct device *dev, uint8_t flags, uint8_t *buf,
 				       size_t buf_len, uint16_t i2c_addr)
 {
-	struct i2c_nrfx_twi_common_data *data = dev->data;
-	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
-	struct i2c_rtio *ctx = dev_data->ctx;
+	struct i2c_nrfx_twi_rtio_data *data = dev->data;
+	struct i2c_rtio *ctx = data->ctx;
 	int ret = 0;
 	bool more_msgs = (rtio_txn_next(ctx->txn_curr) != NULL) &&
 			 ((ctx->txn_curr->next->sqe.iodev_flags & RTIO_IODEV_I2C_RESTART) == 0);
 
 	/** Enabling while already enabled ends up in a failed assertion: skip it. */
-	if (!dev_data->twi_enabled) {
-		nrfx_twi_enable(&data->twi);
-		dev_data->twi_enabled = true;
+	if (!data->twi_enabled) {
+		nrfx_twi_enable(&data->common.twi);
+		data->twi_enabled = true;
 	}
 
 	ret = i2c_nrfx_twi_msg_transfer(dev, flags, buf, buf_len, i2c_addr, more_msgs);
 	if (ret != 0) {
-		nrfx_twi_disable(&data->twi);
-		dev_data->twi_enabled = false;
+		nrfx_twi_disable(&data->common.twi);
+		data->twi_enabled = false;
 	}
 
 	return ret;
@@ -72,8 +67,8 @@ static void i2c_nrfx_twi_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, voi
 
 static bool i2c_nrfx_twi_rtio_start(const struct device *dev, int *status)
 {
-	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
-	struct i2c_rtio *ctx = dev_data->ctx;
+	struct i2c_nrfx_twi_rtio_data *data = dev->data;
+	struct i2c_rtio *ctx = data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
 	struct rtio_iodev_sqe *iodev_sqe;
@@ -98,7 +93,7 @@ static bool i2c_nrfx_twi_rtio_start(const struct device *dev, int *status)
 		*status = i2c_nrfx_twi_configure(dev, sqe->i2c_config);
 		return false;
 	case RTIO_OP_I2C_RECOVER:
-		error = k_work_submit(&dev_data->recovery_work);
+		error = k_work_submit(&data->recovery_work);
 		if (error < 0) {
 			break;
 		}
@@ -132,7 +127,7 @@ static void i2c_nrfx_twi_rtio_complete(const struct device *dev, int status)
 	if (i2c_rtio_complete(ctx, status)) {
 		(void)i2c_rtio_run_sync_start_async(dev, ctx, i2c_nrfx_twi_rtio_start);
 	} else {
-		nrfx_twi_disable(&data->twi);
+		nrfx_twi_disable(&data->common.twi);
 		data->twi_enabled = false;
 	}
 }
@@ -212,14 +207,14 @@ static DEVICE_API(i2c, i2c_nrfx_twi_rtio_driver_api) = {
 			DT_INST_PROP_OR(idx, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));                  \
 												  \
 	static struct i2c_nrfx_twi_rtio_data twi_##idx##_data = {                                 \
-		.twi = NRFX_TWI_INSTANCE(DT_INST_REG_ADDR(idx)),	                          \
+		.common.twi = NRFX_TWI_INSTANCE(DT_INST_REG_ADDR(idx)),	                          \
 		.ctx = &_i2c##idx##_twi_rtio,                                                     \
 	};                                                                                        \
 												  \
 	static int twi_##idx##_init(const struct device *dev)                                     \
 	{                                                                                         \
 		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority),                        \
-				nrfx_twi_irq_handler, &twi_##idx##_data.twi, 0);                  \
+				nrfx_twi_irq_handler, &twi_##idx##_data.common.twi, 0);           \
 		const struct i2c_nrfx_twi_config *config = dev->config;                           \
 		struct i2c_nrfx_twi_rtio_data *dev_data = dev->data;                              \
 		int err = pinctrl_apply_state(config->pcfg,                                       \

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -258,17 +258,20 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(DT_DRV_INST(inst));			\
 	BUILD_ASSERT(I2C_FREQUENCY(inst) != I2C_NRFX_TWIM_INVALID_FREQUENCY,			\
 		     "Wrong I2C " #inst " frequency setting in dts");				\
+												\
 	static struct i2c_nrfx_twim_rtio_data twim_##inst##z_data = {				\
 		.twim =										\
 			{									\
 				.p_twim = (NRF_TWIM_Type *)DT_INST_REG_ADDR(inst),		\
 			},									\
 	};											\
+												\
 	NRF_DT_INST_IRQ_DIRECT_DEFINE(								\
 		inst,										\
 		nrfx_twim_irq_handler,								\
 		&CONCAT(twim_, inst, z_data.twim)						\
 	)											\
+												\
 	static void pre_init##inst(void)							\
 	{											\
 		twim_##inst##z_data.twim.p_twim = (NRF_TWIM_Type *)DT_INST_REG_ADDR(inst);	\
@@ -278,11 +281,15 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 			&CONCAT(twim_, inst, z_data.twim)					\
 		)										\
 	}											\
+												\
 	IF_ENABLED(USES_MSG_BUF(inst), (MSG_BUF_DEFINE(inst);))					\
+												\
 	I2C_RTIO_DEFINE(_i2c##inst##_twim_rtio,							\
 			DT_INST_PROP_OR(inst, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),		\
 			DT_INST_PROP_OR(inst, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));		\
+												\
 	PINCTRL_DT_INST_DEFINE(inst);								\
+												\
 	static const struct i2c_nrfx_twim_rtio_config twim_##inst##z_config = {			\
 		.common =									\
 			{									\
@@ -302,7 +309,9 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 			},									\
 		.ctx = &_i2c##inst##_twim_rtio,							\
 	};											\
+												\
 	PM_DEVICE_DT_INST_DEFINE(inst, twim_nrfx_pm_action, I2C_PM_ISR_SAFE(inst));		\
+												\
 	I2C_DEVICE_DT_INST_DEINIT_DEFINE(inst, i2c_nrfx_twim_rtio_init,				\
 					 i2c_nrfx_twim_rtio_deinit,				\
 					 PM_DEVICE_DT_INST_GET(inst), &twim_##inst##z_data,	\

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -32,6 +32,7 @@ struct i2c_nrfx_twim_rtio_data {
 	uint8_t *user_rx_buf;
 	uint16_t user_rx_buf_size;
 	struct i2c_rtio *ctx;
+	struct k_work recovery_work;
 };
 
 static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status);
@@ -107,8 +108,11 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 		*status = i2c_nrfx_twim_configure(dev, sqe->i2c_config);
 		return false;
 	case RTIO_OP_I2C_RECOVER:
-		*status = i2c_nrfx_twim_recover_bus(dev);
-		return false;
+		error = k_work_submit(&data->recovery_work);
+		if (error < 0) {
+			break;
+		}
+		return true;
 	case RTIO_OP_AWAIT:
 		iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
 		rtio_iodev_sqe_await_signal(iodev_sqe, i2c_nrfx_twim_rtio_sqe_signaled,
@@ -170,6 +174,15 @@ static int i2c_nrfx_twim_rtio_recover_bus(const struct device *dev)
 	return i2c_rtio_recover(data->ctx);
 }
 
+static void i2c_nrfx_twim_rtio_recovery_work_fn(struct k_work *work)
+{
+	struct i2c_nrfx_twim_rtio_data *data = CONTAINER_OF(work, struct i2c_nrfx_twim_rtio_data,
+							   recovery_work);
+	const struct device *dev = data->ctx->dt_spec.bus;
+
+	i2c_nrfx_twim_rtio_complete(dev, i2c_nrfx_twim_rtio_recover_bus(dev));
+}
+
 static void i2c_nrfx_twim_rtio_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_seq)
 {
 	struct i2c_nrfx_twim_rtio_data *data = dev->data;
@@ -219,6 +232,7 @@ static int i2c_nrfx_twim_rtio_init(const struct device *dev)
 	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 
 	i2c_rtio_init(data->ctx, dev);
+	k_work_init(&data->recovery_work, i2c_nrfx_twim_rtio_recovery_work_fn);
 	return i2c_nrfx_twim_common_init(dev);
 }
 

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -25,13 +25,13 @@ LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
 struct i2c_nrfx_twim_rtio_config {
 	struct i2c_nrfx_twim_common_config common;
-	struct i2c_rtio *ctx;
 };
 
 struct i2c_nrfx_twim_rtio_data {
 	nrfx_twim_t twim;
 	uint8_t *user_rx_buf;
 	uint16_t user_rx_buf_size;
+	struct i2c_rtio *ctx;
 };
 
 static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status);
@@ -47,7 +47,7 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 {
 	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
 	struct i2c_nrfx_twim_rtio_data *data = dev->data;
-	struct i2c_rtio *ctx = config->ctx;
+	struct i2c_rtio *ctx = data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
 	struct rtio_iodev_sqe *iodev_sqe;
@@ -134,11 +134,11 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status)
 {
 	/** Finalize if there are no more pending xfers */
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
+	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 	bool async_started = false;
 
-	if (i2c_rtio_complete(config->ctx, status)) {
-		async_started = i2c_rtio_run_sync_start_async(dev, config->ctx,
+	if (i2c_rtio_complete(data->ctx, status)) {
+		async_started = i2c_rtio_run_sync_start_async(dev, data->ctx,
 							      i2c_nrfx_twim_rtio_start);
 	}
 
@@ -150,33 +150,30 @@ static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status)
 
 static int i2c_nrfx_twim_rtio_configure(const struct device *dev, uint32_t i2c_config)
 {
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
-	struct i2c_rtio *ctx = config->ctx;
+	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 
-	return i2c_rtio_configure(ctx, i2c_config);
+	return i2c_rtio_configure(data->ctx, i2c_config);
 }
 
 static int i2c_nrfx_twim_rtio_transfer(const struct device *dev, struct i2c_msg *msgs,
 				       uint8_t num_msgs, uint16_t addr)
 {
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
-	struct i2c_rtio *ctx = config->ctx;
+	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 
-	return i2c_rtio_transfer(ctx, msgs, num_msgs, addr);
+	return i2c_rtio_transfer(data->ctx, msgs, num_msgs, addr);
 }
 
 static int i2c_nrfx_twim_rtio_recover_bus(const struct device *dev)
 {
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
-	struct i2c_rtio *ctx = config->ctx;
+	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 
-	return i2c_rtio_recover(ctx);
+	return i2c_rtio_recover(data->ctx);
 }
 
 static void i2c_nrfx_twim_rtio_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_seq)
 {
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
-	struct i2c_rtio *ctx = config->ctx;
+	struct i2c_nrfx_twim_rtio_data *data = dev->data;
+	struct i2c_rtio *ctx = data->ctx;
 	int ret;
 
 	if (!i2c_rtio_submit(ctx, iodev_seq)) {
@@ -219,9 +216,9 @@ static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 
 static int i2c_nrfx_twim_rtio_init(const struct device *dev)
 {
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
+	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 
-	i2c_rtio_init(config->ctx, dev);
+	i2c_rtio_init(data->ctx, dev);
 	return i2c_nrfx_twim_common_init(dev);
 }
 
@@ -259,11 +256,16 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 	BUILD_ASSERT(I2C_FREQUENCY(inst) != I2C_NRFX_TWIM_INVALID_FREQUENCY,			\
 		     "Wrong I2C " #inst " frequency setting in dts");				\
 												\
+	I2C_RTIO_DEFINE(_i2c##inst##_twim_rtio,							\
+			DT_INST_PROP_OR(inst, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),		\
+			DT_INST_PROP_OR(inst, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));		\
+												\
 	static struct i2c_nrfx_twim_rtio_data twim_##inst##z_data = {				\
 		.twim =										\
 			{									\
 				.p_twim = (NRF_TWIM_Type *)DT_INST_REG_ADDR(inst),		\
 			},									\
+		.ctx = &_i2c##inst##_twim_rtio,							\
 	};											\
 												\
 	NRF_DT_INST_IRQ_DIRECT_DEFINE(								\
@@ -284,10 +286,6 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 												\
 	IF_ENABLED(USES_MSG_BUF(inst), (MSG_BUF_DEFINE(inst);))					\
 												\
-	I2C_RTIO_DEFINE(_i2c##inst##_twim_rtio,							\
-			DT_INST_PROP_OR(inst, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),		\
-			DT_INST_PROP_OR(inst, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));		\
-												\
 	PINCTRL_DT_INST_DEFINE(inst);								\
 												\
 	static const struct i2c_nrfx_twim_rtio_config twim_##inst##z_config = {			\
@@ -307,7 +305,6 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 				.max_transfer_size = MAX_TRANSFER_SIZE(inst),			\
 				.twim = &twim_##inst##z_data.twim,				\
 			},									\
-		.ctx = &_i2c##inst##_twim_rtio,							\
 	};											\
 												\
 	PM_DEVICE_DT_INST_DEFINE(inst, twim_nrfx_pm_action, I2C_PM_ISR_SAFE(inst));		\

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -23,10 +23,6 @@ LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_twim
 
-struct i2c_nrfx_twim_rtio_config {
-	struct i2c_nrfx_twim_common_config common;
-};
-
 struct i2c_nrfx_twim_rtio_data {
 	nrfx_twim_t twim;
 	uint8_t *user_rx_buf;
@@ -46,7 +42,7 @@ static void i2c_nrfx_twim_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, vo
 
 static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 {
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
+	const struct i2c_nrfx_twim_common_config *config = dev->config;
 	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 	struct i2c_rtio *ctx = data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
@@ -56,8 +52,8 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
-		if (!nrf_dma_accessible_check(&config->common.twim, sqe->rx.buf)) {
-			if (sqe->rx.buf_len > config->common.msg_buf_size) {
+		if (!nrf_dma_accessible_check(&config->twim, sqe->rx.buf)) {
+			if (sqe->rx.buf_len > config->msg_buf_size) {
 				error = -ENOSPC;
 				break;
 			}
@@ -65,8 +61,7 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 			data->user_rx_buf = sqe->rx.buf;
 			data->user_rx_buf_size = sqe->rx.buf_len;
 			error = i2c_nrfx_twim_msg_transfer(dev, I2C_MSG_READ | sqe->iodev_flags,
-							   config->common.msg_buf,
-							   data->user_rx_buf_size,
+							   config->msg_buf, data->user_rx_buf_size,
 							   dt_spec->addr);
 		} else {
 			data->user_rx_buf = NULL;
@@ -82,9 +77,9 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 		break;
 	case RTIO_OP_TX:
 		/* If buffer is not accessible by DMA, copy it into the internal driver buffer */
-		if (!nrf_dma_accessible_check(&config->common.twim, sqe->tx.buf)) {
+		if (!nrf_dma_accessible_check(&config->twim, sqe->tx.buf)) {
 			/* Validate buffer will fit */
-			if (sqe->tx.buf_len > config->common.msg_buf_size) {
+			if (sqe->tx.buf_len > config->msg_buf_size) {
 				LOG_ERR("Need to use the internal driver "
 					"buffer but its size is insufficient "
 					"(%u > %u). "
@@ -92,13 +87,13 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev, int *status)
 					"zephyr,flash-buf-max-size property "
 					"(the one with greater value) in the "
 					"\"%s\"' node.",
-					sqe->tx.buf_len, config->common.msg_buf_size, dev->name);
+					sqe->tx.buf_len, config->msg_buf_size, dev->name);
 				error = -ENOSPC;
 				break;
 			}
 
-			memcpy(config->common.msg_buf, sqe->tx.buf, sqe->tx.buf_len);
-			sqe->tx.buf = config->common.msg_buf;
+			memcpy(config->msg_buf, sqe->tx.buf, sqe->tx.buf_len);
+			sqe->tx.buf = config->msg_buf;
 		}
 		error = i2c_nrfx_twim_msg_transfer(dev, I2C_MSG_WRITE | sqe->iodev_flags,
 						   (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
@@ -209,12 +204,12 @@ static void i2c_nrfx_twim_rtio_submit(const struct device *dev, struct rtio_iode
 static void event_handler(nrfx_twim_event_t const *p_event, void *p_context)
 {
 	const struct device *dev = p_context;
-	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
+	const struct i2c_nrfx_twim_common_config *config = dev->config;
 	struct i2c_nrfx_twim_rtio_data *data = dev->data;
 	int status = p_event->type == NRFX_TWIM_EVT_DONE ? 0 : -EIO;
 
 	if (data->user_rx_buf) {
-		memcpy(data->user_rx_buf, config->common.msg_buf, data->user_rx_buf_size);
+		memcpy(data->user_rx_buf, config->msg_buf, data->user_rx_buf_size);
 	}
 
 	i2c_nrfx_twim_rtio_complete(dev, status);
@@ -302,23 +297,19 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 												\
 	PINCTRL_DT_INST_DEFINE(inst);								\
 												\
-	static const struct i2c_nrfx_twim_rtio_config twim_##inst##z_config = {			\
-		.common =									\
-			{									\
-				.twim_config =							\
-					{							\
-						.skip_gpio_cfg = true,				\
-						.skip_psel_cfg = true,				\
-						.frequency = I2C_FREQUENCY(inst),		\
-					},							\
-				.event_handler = event_handler,					\
-				.msg_buf_size = MSG_BUF_SIZE(inst),				\
-				.pre_init = pre_init##inst,					\
-				.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),			\
-				IF_ENABLED(USES_MSG_BUF(inst), (.msg_buf = MSG_BUF_SYM(inst),))	\
-				.max_transfer_size = MAX_TRANSFER_SIZE(inst),			\
-				.twim = &twim_##inst##z_data.twim,				\
-			},									\
+	static const struct i2c_nrfx_twim_common_config twim_##inst##z_config = {		\
+		.twim_config = {								\
+			.skip_gpio_cfg = true,							\
+			.skip_psel_cfg = true,							\
+			.frequency = I2C_FREQUENCY(inst),					\
+		},										\
+		.event_handler = event_handler,							\
+		.msg_buf_size = MSG_BUF_SIZE(inst),						\
+		.pre_init = pre_init##inst,							\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),					\
+		IF_ENABLED(USES_MSG_BUF(inst), (.msg_buf = MSG_BUF_SYM(inst),))			\
+		.max_transfer_size = MAX_TRANSFER_SIZE(inst),					\
+		.twim = &twim_##inst##z_data.twim,						\
 	};											\
 												\
 	PM_DEVICE_DT_INST_DEFINE(inst, twim_nrfx_pm_action, I2C_PM_ISR_SAFE(inst));		\


### PR DESCRIPTION
Change I2C bus recovery integration in **nrfx_twi** and **nrfx_twim** RTIO drivers to be executed in a thread context (through a work queue) instead of executing in an interrupt context.

For consistency on impacts of theses changes, remove `struct i2c_nrfx_twim_rtio_config` that is no more needed and improve a bit **nrfx_twi** I2C drivers data structs regarding constraint on common fields offsets.

This change is a followup from https://github.com/zephyrproject-rtos/zephyr/pull/111070#discussion_r3520852562.
