### PR TITLE
drivers: i2c: stm32: k_work_submit() may fail

### DIFF
--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -116,7 +116,10 @@ static bool i2c_stm32_start(const struct device *dev, int *status)
 		return false;
 #if CONFIG_I2C_STM32_BUS_RECOVERY
 	case RTIO_OP_I2C_RECOVER:
-		k_work_submit(&data->recovery_work);
+		error = k_work_submit(&data->recovery_work);
+		if (error < 0) {
+			break;
+		}
 		return true;
 #endif
 	default:


### PR DESCRIPTION
Consider `k_work_submit()` return value in STM32 I2C RTIO driver. If failing the bus recovery sequence is not started in which case the error must but reported to the caller and the RTIO queue should not stall.

Addresses Copilot review comment https://github.com/zephyrproject-rtos/zephyr/pull/115167#discussion_r3699031543 that applies to the STM32 I2C RTIO driver.