### PR TITLE
ci: doxygen-checks: build the base coverage with the PR doc build system

### DIFF
--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -87,13 +87,14 @@ jobs:
         run: |
           git worktree add --detach ../base-branch origin/${BASE_REF}
           echo "BASE_ROOT=$(readlink -f ../base-branch)" >> $GITHUB_ENV
-          cd ../base-branch
-          west update
-          # Use the PR branch's doc build configuration to ensure consistent
-          # coverage generation between branches (plus, the target may not exist in base)
-          cp ${GITHUB_WORKSPACE}/doc/CMakeLists.txt ${GITHUB_WORKSPACE}/doc/Makefile doc/
-          make -C doc doxygen-coverage-json
-          cp doc/_build/doc-coverage.json ${GITHUB_WORKSPACE}/base-coverage.json
+          # Build the base tree's API documentation with the PR branch's doc build
+          # system, by pointing ZEPHYR_BASE at the base worktree and running the build
+          # from the PR checkout. Everything the Doxygen configuration refers to is
+          # ZEPHYR_BASE-relative, so both coverage reports are produced by an identical
+          # configuration, while the scanned sources come from the base branch.
+          ZEPHYR_BASE=$(readlink -f ../base-branch) \
+            make -C doc doxygen-coverage-json BUILDDIR=_build-base
+          mv doc/_build-base/doc-coverage.json base-coverage.json
 
       - name: Check for undocumented new API
         run: |


### PR DESCRIPTION
The base branch coverage report was generated by copying doc/CMakeLists.txt
and doc/Makefile from the PR branch into the base worktree and building
there. That is a partial cherry-pick of the doc build system onto an old
tree: as soon as a PR changes the build logic to reference something that
does not exist on the base branch, the base build fails and the check
blocks the PR.

Point ZEPHYR_BASE at the base worktree and run the build from the PR
checkout into a separate build directory instead. Everything the Doxygen
configuration refers to is ZEPHYR_BASE-relative, so the sources being
scanned come from the base branch while the entire build system, Doxygen
configuration and scripts included, comes from the PR branch. Both coverage
reports are therefore produced by an identical configuration, and no file
is copied across branches.

Nothing is built in the base worktree anymore, so its west update goes away
as well; it was updating the module checkouts shared with the PR workspace
to the base branch revisions.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
