### PR TITLE
dts: add devicetree support for the `dma-ranges` property

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -180,6 +180,14 @@ properties:
     description: |
       Optional names given to the DMA channel specifiers in the "dmas" property.
 
+  dma-ranges:
+    type: compound
+    description: |
+      The dma-ranges provides a means of defining a mapping or translation between the
+      physical address space of the bus and the physical address space of the parent of the bus.
+
+      For details, see "2.3.9 dma-ranges" in Devicetree Specification v0.4.
+
   io-channels:
     type: phandle-array
     description: |

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2309,6 +2309,303 @@
 	DT_CAT(node_id, _FOREACH_RANGE)(fn)
 
 /**
+ * @brief Is @p idx a valid dma-range block index?
+ *
+ * If this returns 1, then DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),
+ * DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx) or
+ * DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx) are valid.
+ * If it returns 0, it is an error to use those macros with index @p idx.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 0) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 1) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 2) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 3) // 0
+ *
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(other), 0) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(other), 1) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(other), 2) // 0
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the dma-ranges array
+ * @return 1 if @p idx is a valid dma-ranges block index,
+ *         0 otherwise.
+ */
+#define DT_DMA_RANGES_HAS_IDX(node_id, idx) \
+	IS_ENABLED(DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _EXISTS))
+
+/**
+ * @brief Get the dma-ranges property child bus address at index
+ *
+ * When the node is a PCIe bus, the Child Bus Address has an extra cell used to store
+ * some flags, thus this cell is removed from the Child Bus Address.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x0
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 1) // 0x0
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 0) // 0x0
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 1) // 0x10000000
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the dma-ranges array
+ * @returns dma-range child bus address field at idx
+ */
+#define DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _VAL_CHILD_BUS_ADDRESS)
+
+/**
+ * @brief Get the dma-ranges property parent bus address at index
+ *
+ * Similarly to DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(), this properly accounts
+ * for child bus flags cells when the node is a PCIe bus.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x3eff0000
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 1) // 0x10000000
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 0) // 0x3eff0000
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 1) // 0x10000000
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the dma-ranges array
+ * @returns dma-range parent bus address field at idx
+ */
+#define DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _VAL_PARENT_BUS_ADDRESS)
+
+/**
+ * @brief Get the dma-ranges property length at index
+ *
+ * Similarly to DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(), this properly accounts
+ * for child bus flags cells when the node is a PCIe bus.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x10000
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 1) // 0x2eff0000
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(other), 0) // 0x10000
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(other), 1) // 0x2eff0000
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the dma-ranges array
+ * @returns dma-range length field at idx
+ */
+#define DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _VAL_LENGTH)
+
+/**
+ * @brief Get the number of dma-range blocks in the dma-ranges property
+ *
+ * Use this instead of DT_PROP_LEN(node_id, dma_ranges).
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_NUM_DMA_RANGES(DT_NODELABEL(pcie0)) // 3
+ *     DT_NUM_DMA_RANGES(DT_NODELABEL(other)) // 2
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @return Number of dma-range blocks in the dma-ranges property
+ */
+#define DT_NUM_DMA_RANGES(node_id) DT_CAT(node_id, _NUM_DMA_RANGES)
+
+/**
+ * @brief Invokes @p fn for each entry of @p node_id dma-ranges property
+ *
+ * The macro @p fn must take two parameters, @p node_id which will be the node
+ * identifier of the node with the dma-ranges property and @p idx the index of
+ * the dma-ranges block.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     #define DMA_RANGE_LENGTH(node_id, idx) DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx),
+ *
+ *     const uint64_t *dma_ranges_length[] = {
+ *             DT_FOREACH_DMA_RANGE(DT_NODELABEL(pcie0), DMA_RANGE_LENGTH)
+ *     };
+ * @endcode
+ *
+ * @param node_id node identifier with a dma-ranges property
+ * @param fn macro to invoke
+ */
+#define DT_FOREACH_DMA_RANGE(node_id, fn) \
+	DT_CAT(node_id, _FOREACH_DMA_RANGE)(fn)
+
+/**
  * @}
  */
 

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2309,6 +2309,298 @@
 	DT_CAT(node_id, _FOREACH_RANGE)(fn)
 
 /**
+ * @brief Is @p idx a valid dma-range block index?
+ *
+ * If this returns 1, then DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),
+ * DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx) or
+ * DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx) are valid.
+ * If it returns 0, it is an error to use those macros with index @p idx.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 0) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 2) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 3) // 0
+ *
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(other), 0) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(other), 1) // 1
+ *     DT_DMA_RANGES_HAS_IDX(DT_NODELABEL(other), 2) // 0
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx index to check
+ * @return 1 if @p idx is a valid dma-range block index, 0 otherwise.
+ */
+#define DT_DMA_RANGES_HAS_IDX(node_id, idx) \
+	IS_ENABLED(DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _EXISTS))
+
+/**
+ * @brief Get the dma-ranges property child bus address at index
+ *
+ * When the node is a PCIe bus, the Child Bus Address has an extra cell used to store
+ * some flags, thus this cell is removed from the Child Bus Address.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x0
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 0) // 0x0
+ *     DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 1) // 0x10000000
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the dma-ranges array
+ * @returns dma-range child bus address field at idx
+ */
+#define DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _VAL_CHILD_BUS_ADDRESS)
+
+/**
+ * @brief Get the dma-ranges property parent bus address at index
+ *
+ * Similarly to DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(), this properly accounts
+ * for child bus flags cells when the node is a PCIe bus.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x3eff0000
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 0) // 0x3eff0000
+ *     DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 1) // 0x10000000
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the dma-ranges array
+ * @returns dma-range parent bus address field at idx
+ */
+#define DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _VAL_PARENT_BUS_ADDRESS)
+
+/**
+ * @brief Get the dma-ranges property length at index
+ *
+ * Similarly to DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(), this properly accounts
+ * for child bus flags cells when the node is a PCIe bus.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x10000
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(other), 0) // 0x10000
+ *     DT_DMA_RANGES_LENGTH_BY_IDX(DT_NODELABEL(other), 1) // 0x2eff0000
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the dma-ranges array
+ * @returns dma-range length field at idx
+ */
+#define DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _DMA_RANGES_IDX_, idx, _VAL_LENGTH)
+
+/**
+ * @brief Get the number of dma-range blocks in the dma-ranges property
+ *
+ * Use this instead of DT_PROP_LEN(node_id, dma_ranges).
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_NUM_DMA_RANGES(DT_NODELABEL(pcie0)) // 3
+ *     DT_NUM_DMA_RANGES(DT_NODELABEL(other)) // 2
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @return Number of dma-range blocks in the dma-ranges property
+ */
+#define DT_NUM_DMA_RANGES(node_id) DT_CAT(node_id, _NUM_DMA_RANGES)
+
+/**
+ * @brief Invokes @p fn for each entry of @p node_id dma-ranges property
+ *
+ * The macro @p fn must take two parameters, @p node_id which will be the node
+ * identifier of the node with the dma-ranges property and @p idx the index of
+ * the dma-ranges block.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "pcie-controller";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                                  <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                                  <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                                  <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     #define DMA_RANGE_LENGTH(node_id, idx) DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx),
+ *
+ *     const uint64_t *dma_ranges_length[] = {
+ *             DT_FOREACH_DMA_RANGE(DT_NODELABEL(pcie0), DMA_RANGE_LENGTH)
+ *     };
+ * @endcode
+ *
+ * @param node_id node identifier with a dma-ranges property
+ * @param fn macro to invoke
+ */
+#define DT_FOREACH_DMA_RANGE(node_id, fn) \
+	DT_CAT(node_id, _FOREACH_DMA_RANGE)(fn)
+
+/**
  * @}
  */
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -313,6 +313,7 @@ def write_special_props(node: edtlib.Node) -> None:
     out_comment("Macros for properties that are special in the specification:")
     write_regs(node)
     write_ranges(node)
+    write_dma_ranges(node)
     write_interrupts(node)
     write_compatibles(node)
     write_status(node)
@@ -366,6 +367,49 @@ def write_ranges(node: edtlib.Node) -> None:
     out_dt_define(
         f"{path_id}_FOREACH_RANGE(fn)",
         " ".join(f"fn(DT_{path_id}, {i})" for i, range in enumerate(node.ranges)),
+    )
+
+
+def write_dma_ranges(node: edtlib.Node) -> None:
+    # dma-ranges property: same packing logic as ranges, but for
+    # DMA (bus <-> parent physical) address translation
+
+    idx_vals = []
+    path_id = node.z_path_id
+
+    if node.dma_ranges is not None:
+        idx_vals.append((f"{path_id}_NUM_DMA_RANGES", len(node.dma_ranges)))
+
+    for i, range in enumerate(node.dma_ranges):
+        idx_vals.append((f"{path_id}_DMA_RANGES_IDX_{i}_EXISTS", 1))
+
+        if "pcie" in node.buses:
+            idx_vals.append((f"{path_id}_DMA_RANGES_IDX_{i}_VAL_CHILD_BUS_FLAGS_EXISTS", 1))
+            idx_macro = f"{path_id}_DMA_RANGES_IDX_{i}_VAL_CHILD_BUS_FLAGS"
+            idx_value = range.child_bus_addr >> ((range.child_bus_cells - 1) * 32)
+            idx_vals.append((idx_macro, f"{idx_value} /* {hex(idx_value)} */"))
+        if range.child_bus_addr is not None:
+            idx_macro = f"{path_id}_DMA_RANGES_IDX_{i}_VAL_CHILD_BUS_ADDRESS"
+            if "pcie" in node.buses:
+                idx_value = range.child_bus_addr & ((1 << (range.child_bus_cells - 1) * 32) - 1)
+            else:
+                idx_value = range.child_bus_addr
+            idx_vals.append((idx_macro, f"{idx_value} /* {hex(idx_value)} */"))
+        if range.parent_bus_addr is not None:
+            idx_macro = f"{path_id}_DMA_RANGES_IDX_{i}_VAL_PARENT_BUS_ADDRESS"
+            idx_vals.append(
+                (idx_macro, f"{range.parent_bus_addr} /* {hex(range.parent_bus_addr)} */")
+            )
+        if range.length is not None:
+            idx_macro = f"{path_id}_DMA_RANGES_IDX_{i}_VAL_LENGTH"
+            idx_vals.append((idx_macro, f"{range.length} /* {hex(range.length)} */"))
+
+    for macro, val in idx_vals:
+        out_dt_define(macro, val)
+
+    out_dt_define(
+        f"{path_id}_FOREACH_DMA_RANGE(fn)",
+        " ".join(f"fn(DT_{path_id}, {i})" for i, range in enumerate(node.dma_ranges)),
     )
 
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1230,6 +1230,7 @@ class Node:
         self.dep_ordinal: int = -1
         self.compats: list[str] = compats
         self.ranges: list[Range] = []
+        self.dma_ranges: list[Range] = []
         self.regs: list[Register] = []
         self.props: dict[str, Property] = {}
         self.interrupts: list[ControllerAndData] = []
@@ -1240,6 +1241,7 @@ class Node:
         self._init_binding()
         self._init_regs()
         self._init_ranges()
+        self._init_dma_ranges()
 
     @property
     def name(self) -> str:
@@ -2075,6 +2077,67 @@ class Node:
                     raw_range[(4*child_address_cells + 4*parent_address_cells):])
 
             self.ranges.append(Range(self, child_bus_cells, child_bus_addr,
+                                     parent_bus_cells, parent_bus_addr,
+                                     length_cells, length))
+
+    def _init_dma_ranges(self) -> None:
+        # Initializes self.dma_ranges
+        node = self._node
+
+        self.dma_ranges = []
+
+        if "dma-ranges" not in node.props:
+            return
+
+        raw_child_address_cells = node.props.get("#address-cells")
+        parent_address_cells = _address_cells(node)
+        if raw_child_address_cells is None:
+            child_address_cells = 2  # Default value per DT spec.
+        else:
+            child_address_cells = raw_child_address_cells.to_num()
+        raw_child_size_cells = node.props.get("#size-cells")
+        if raw_child_size_cells is None:
+            child_size_cells = 1  # Default value per DT spec.
+        else:
+            child_size_cells = raw_child_size_cells.to_num()
+
+        entry_cells = child_address_cells + parent_address_cells + child_size_cells
+
+        if entry_cells == 0:
+            if len(node.props["dma-ranges"].value) == 0:
+                return
+            else:
+                _err(f"'dma-ranges' should be empty in {self._node.path} since "
+                     f"<#address-cells> = {child_address_cells}, "
+                     f"<#address-cells for parent> = {parent_address_cells} and "
+                     f"<#size-cells> = {child_size_cells}")
+
+        for raw_range in _slice(node, "dma-ranges", 4*entry_cells,
+                                f"4*(<#address-cells> (= {child_address_cells}) + "
+                                "<#address-cells for parent> "
+                                f"(= {parent_address_cells}) + "
+                                f"<#size-cells> (= {child_size_cells}))"):
+
+            child_bus_cells = child_address_cells
+            if child_address_cells == 0:
+                child_bus_addr = None
+            else:
+                child_bus_addr = to_num(raw_range[:4*child_address_cells])
+            parent_bus_cells = parent_address_cells
+            if parent_address_cells == 0:
+                parent_bus_addr = None
+            else:
+                parent_bus_addr = to_num(
+                    raw_range[(4*child_address_cells):
+                              (4*child_address_cells + 4*parent_address_cells)])
+            length_cells = child_size_cells
+            if child_size_cells == 0:
+                length = None
+            else:
+                length = to_num(
+                    raw_range[(4*child_address_cells + 4*parent_address_cells):])
+
+            self.dma_ranges.append(Range(self, child_bus_cells, child_bus_addr,
                                      parent_bus_cells, parent_bus_addr,
                                      length_cells, length))
 

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -877,6 +877,31 @@
 			};
 		};
 
+		test-dma-ranges {
+			#address-cells = <2>;
+			#size-cells = <1>;
+
+			test_dma_ranges_pcie: pcie@0 {
+				compatible = "vnd,pcie";
+				reg = <0 0 1>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+
+				dma-ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+					     <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+					     <0x3000000 0x80 0 0x80 0 0x80 0>;
+			};
+
+			test_dma_ranges_other: other@1 {
+				reg = <0 1 1>;
+				#address-cells = <2>;
+				#size-cells = <1>;
+
+				dma-ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+					     <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+			};
+		};
+
 		test-regs {
 			#address-cells = <2>;
 			#size-cells = <1>;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -107,6 +107,9 @@
 #define TEST_RANGES_OTHER DT_NODELABEL(test_ranges_other)
 #define TEST_RANGES_EMPTY DT_NODELABEL(test_ranges_empty)
 
+#define TEST_DMA_RANGES_PCIE  DT_NODELABEL(test_dma_ranges_pcie)
+#define TEST_DMA_RANGES_OTHER DT_NODELABEL(test_dma_ranges_other)
+
 #define TEST_REGS_TEST_NODE   DT_NODELABEL(test_regs_test_node)
 #define TEST_REGS_OTHER       DT_NODELABEL(test_regs_other)
 #define TEST_REGS_EMPTY       DT_NODELABEL(test_regs_empty)
@@ -3129,6 +3132,93 @@ ZTEST(devicetree_api, test_ranges_empty)
 	DT_FOREACH_RANGE(TEST_RANGES_EMPTY, FAIL);
 
 #undef FAIL
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_test_dma_ranges_pcie
+ZTEST(devicetree_api, test_dma_ranges_pcie)
+{
+#define CHILD_BUS_ADDR(node_id, idx)				\
+	DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define PARENT_BUS_ADDR(node_id, idx)				\
+	DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define LENGTH(node_id, idx) DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx),
+
+	unsigned int count = DT_NUM_DMA_RANGES(TEST_DMA_RANGES_PCIE);
+
+	const uint64_t dma_ranges_child_bus_addr[] = {
+		DT_FOREACH_DMA_RANGE(TEST_DMA_RANGES_PCIE, CHILD_BUS_ADDR)
+	};
+
+	const uint64_t dma_ranges_parent_bus_addr[] = {
+		DT_FOREACH_DMA_RANGE(TEST_DMA_RANGES_PCIE, PARENT_BUS_ADDR)
+	};
+
+	const uint64_t dma_ranges_length[] = {
+		DT_FOREACH_DMA_RANGE(TEST_DMA_RANGES_PCIE, LENGTH)
+	};
+
+	zassert_equal(count, 3, "");
+
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_PCIE, 0), 1, "");
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_PCIE, 1), 1, "");
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_PCIE, 2), 1, "");
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_PCIE, 3), 0, "");
+
+	zassert_equal(dma_ranges_child_bus_addr[0], 0, "");
+	zassert_equal(dma_ranges_child_bus_addr[1], 0x10000000, "");
+	zassert_equal(dma_ranges_child_bus_addr[2], 0x8000000000, "");
+	zassert_equal(dma_ranges_parent_bus_addr[0], 0x3eff0000, "");
+	zassert_equal(dma_ranges_parent_bus_addr[1], 0x10000000, "");
+	zassert_equal(dma_ranges_parent_bus_addr[2], 0x8000000000, "");
+	zassert_equal(dma_ranges_length[0], 0x10000, "");
+	zassert_equal(dma_ranges_length[1], 0x2eff0000, "");
+	zassert_equal(dma_ranges_length[2], 0x8000000000, "");
+
+#undef CHILD_BUS_ADDR
+#undef PARENT_BUS_ADDR
+#undef LENGTH
+}
+
+ZTEST(devicetree_api, test_dma_ranges_other)
+{
+#define CHILD_BUS_ADDR(node_id, idx) \
+	DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define PARENT_BUS_ADDR(node_id, idx) \
+	DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define LENGTH(node_id, idx) DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx),
+
+	unsigned int count = DT_NUM_DMA_RANGES(TEST_DMA_RANGES_OTHER);
+
+	const uint32_t dma_ranges_child_bus_addr[] = {
+		DT_FOREACH_DMA_RANGE(TEST_DMA_RANGES_OTHER, CHILD_BUS_ADDR)
+	};
+
+	const uint32_t dma_ranges_parent_bus_addr[] = {
+		DT_FOREACH_DMA_RANGE(TEST_DMA_RANGES_OTHER, PARENT_BUS_ADDR)
+	};
+
+	const uint32_t dma_ranges_length[] = {
+		DT_FOREACH_DMA_RANGE(TEST_DMA_RANGES_OTHER, LENGTH)
+	};
+
+	zassert_equal(count, 2, "");
+
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_OTHER, 0), 1, "");
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_OTHER, 1), 1, "");
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_OTHER, 2), 0, "");
+	zassert_equal(DT_DMA_RANGES_HAS_IDX(TEST_DMA_RANGES_OTHER, 3), 0, "");
+
+	zassert_equal(dma_ranges_child_bus_addr[0], 0, "");
+	zassert_equal(dma_ranges_child_bus_addr[1], 0x10000000, "");
+	zassert_equal(dma_ranges_parent_bus_addr[0], 0x3eff0000, "");
+	zassert_equal(dma_ranges_parent_bus_addr[1], 0x10000000, "");
+	zassert_equal(dma_ranges_length[0], 0x10000, "");
+	zassert_equal(dma_ranges_length[1], 0x2eff0000, "");
+
+#undef CHILD_BUS_ADDR
+#undef PARENT_BUS_ADDR
+#undef LENGTH
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
Zephyr's devicetree tooling parses and generates macros for the `ranges` property but has no equivalent support for `dma-ranges`, even though both are defined the same way by the `Devicetree Specification (§2.3.9)` and `edtlib.py` already has the machinery to parse address-translation triplets.

This adds the same pipeline that already exists for `ranges`. `edtlib.py` now parses `dma-ranges` into Node.  `dma_ranges` using the same cell-based translation logic as Node via a new` _init_dma_ranges()` method.

`gen_defines.py` emits `DT_N_..._DMA_RANGES_*` macros for each node with a `dma-ranges` property through a new `write_dma_ranges()` function.

`devicetree.h` gains the `DT_DMA_RANGES_*` public API, including `HAS_IDX`, `CHILD_BUS_ADDRESS_BY_IDX`, `PARENT_BUS_ADDRESS_BY_IDX`, `LENGTH_BY_IDX`, `NUM`, and `FOREACH_DMA_RANGE`. `base.yaml` documents the `dma-ranges` property per `DT spec §2.3.9`.

Reference: https://devicetree-specification.readthedocs.io/en/latest/chapter2-devicetree-basics.html#dma-ranges

This PR solves this issue https://github.com/zephyrproject-rtos/zephyr/pull/110701#discussion_r3698519681

# Testing
`app.overlay`
```
/ {
        parent {
                #address-cells = <2>;
                #size-cells = <1>;

                pcie0: pcie@0 {
                        compatible = "pcie-controller";
                        reg = <0 0 1>;
                        #address-cells = <3>;
                        #size-cells = <2>;

                        dma-ranges = <0x1000000 0    0          0    0x3eff0000 0    0x10000>,
                                     <0x2000000 0    0x10000000 0    0x10000000 0    0x2eff0000>,
                                     <0x3000000 0x80 0          0x80 0          0x80 0>;
                };

                other: other@1 {
                        reg = <0 1 1>;

                        dma-ranges = <0x0 0x0        0x0 0x3eff0000 0x10000>,
                                     <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
                };
        };
};
```

`mani.c`
```
#include <zephyr/kernel.h>
#include <zephyr/devicetree.h>
 
#define PRINT_DMA_RANGE(node_id, idx)                                                              \
        do {                                                                                       \
                printk("DMA range %d\n", idx);                                                     \
                printk("  Child : 0x%016llx\n",                                                    \
                       (unsigned long long)DT_DMA_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx));  \
                printk("  Parent: 0x%016llx\n",                                                    \
                       (unsigned long long)DT_DMA_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx)); \
                printk("  Length: 0x%016llx\n",                                                    \
                       (unsigned long long)DT_DMA_RANGES_LENGTH_BY_IDX(node_id, idx));             \
        } while (0);
 
int main(void)
{
        printk("=== PCIe ===\n");
        printk("Number of ranges: %d\n", DT_NUM_DMA_RANGES(DT_NODELABEL(pcie0)));
 
        DT_FOREACH_DMA_RANGE(DT_NODELABEL(pcie0), PRINT_DMA_RANGE);
 
        printk("\n=== Other ===\n");
        printk("Number of ranges: %d\n", DT_NUM_DMA_RANGES(DT_NODELABEL(other)));
 
        DT_FOREACH_DMA_RANGE(DT_NODELABEL(other), PRINT_DMA_RANGE);
 
        return 0;
}
```
## Output
```
*** Booting Zephyr OS build v4.4.0-10193-g15ac312df720 ***
=== PCIe ===
Number of ranges: 3
DMA range 0
  Child : 0x0000000000000000
  Parent: 0x000000003eff0000
  Length: 0x0000000000010000
DMA range 1
  Child : 0x0000000010000000
  Parent: 0x0000000010000000
  Length: 0x000000002eff0000
DMA range 2
  Child : 0x0000008000000000
  Parent: 0x0000008000000000
  Length: 0x0000008000000000

=== Other ===
Number of ranges: 2
DMA range 0
  Child : 0x0000000000000000
  Parent: 0x000000003eff0000
  Length: 0x0000000000010000
DMA range 1
  Child : 0x0000000010000000
  Parent: 0x0000000010000000
  Length: 0x000000002eff0000
```
