### PR TITLE
drivers: xen: add memory reservation wrappers

### DIFF
--- a/drivers/xen/memory.c
+++ b/drivers/xen/memory.c
@@ -52,9 +52,11 @@ int xendom_remove_from_physmap(int domid, xen_pfn_t gpfn)
 	return HYPERVISOR_memory_op(XENMEM_remove_from_physmap, &xrfp);
 }
 
-int xendom_populate_physmap(int domid, unsigned int extent_order,
-			    unsigned int nr_extents, unsigned int mem_flags,
-			    xen_pfn_t *extent_start)
+static int xendom_memory_reservation_op(unsigned int cmd, int domid,
+					unsigned int extent_order,
+					unsigned int nr_extents,
+					unsigned int mem_flags,
+					xen_pfn_t *extent_start)
 {
 	struct xen_memory_reservation reservation = {
 		.domid = domid,
@@ -65,7 +67,34 @@ int xendom_populate_physmap(int domid, unsigned int extent_order,
 
 	set_xen_guest_handle(reservation.extent_start, extent_start);
 
-	return HYPERVISOR_memory_op(XENMEM_populate_physmap, &reservation);
+	return HYPERVISOR_memory_op(cmd, &reservation);
+}
+
+int xendom_increase_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start)
+{
+	return xendom_memory_reservation_op(XENMEM_increase_reservation, domid,
+					    extent_order, nr_extents, mem_flags,
+					    extent_start);
+}
+
+int xendom_decrease_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start)
+{
+	return xendom_memory_reservation_op(XENMEM_decrease_reservation, domid,
+					    extent_order, nr_extents, mem_flags,
+					    extent_start);
+}
+
+int xendom_populate_physmap(int domid, unsigned int extent_order,
+			    unsigned int nr_extents, unsigned int mem_flags,
+			    xen_pfn_t *extent_start)
+{
+	return xendom_memory_reservation_op(XENMEM_populate_physmap, domid,
+					    extent_order, nr_extents, mem_flags,
+					    extent_start);
 }
 
 int xendom_acquire_resource(domid_t domid, uint16_t type, uint32_t id, uint64_t frame,

--- a/include/zephyr/xen/memory.h
+++ b/include/zephyr/xen/memory.h
@@ -71,6 +71,47 @@ int xendom_add_to_physmap_batch(int domid, int foreign_domid,
 int xendom_remove_from_physmap(int domid, xen_pfn_t gpfn);
 
 /**
+ * @brief Increase a domain memory reservation.
+ *
+ * This asks Xen to allocate extents for a domain. On success, Xen writes the
+ * allocated machine frame bases into @p extent_start.
+ *
+ * @param domid Domain whose reservation is increased. Unprivileged callers must
+ *              use ``DOMID_SELF``.
+ * @param extent_order Extent order used by Xen, where each extent covers
+ *                     ``2^extent_order`` pages.
+ * @param nr_extents Number of extents requested.
+ * @param mem_flags Xen memory flags, for example the ``XENMEMF_*`` constants.
+ * @param[out] extent_start Array that receives the allocated machine frame
+ *                          bases.
+ *
+ * @return Number of allocated extents on success, negative errno value on
+ *         failure.
+ */
+int xendom_increase_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start);
+
+/**
+ * @brief Decrease a domain memory reservation.
+ *
+ * This asks Xen to free guest frame extents from a domain reservation.
+ *
+ * @param domid Domain whose reservation is decreased. Unprivileged callers must
+ *              use ``DOMID_SELF``.
+ * @param extent_order Extent order used by Xen, where each extent covers
+ *                     ``2^extent_order`` pages.
+ * @param nr_extents Number of extents to free.
+ * @param mem_flags Xen memory flags, for example the ``XENMEMF_*`` constants.
+ * @param extent_start Array of guest frame bases to free.
+ *
+ * @return Number of freed extents on success, negative errno value on failure.
+ */
+int xendom_decrease_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start);
+
+/**
  * @brief Populate guest frames with memory.
  *
  * @param domid Domain whose physmap is populated. Unprivileged callers must use


### PR DESCRIPTION
Add typed wrappers for XENMEM_increase_reservation and XENMEM_decrease_reservation using the existing Xen memory-op helper style. Both operations use struct xen_memory_reservation, so share the reservation setup with the existing populate-physmap wrapper.

These calls are useful for Zephyr when it runs as a Xen hardware/control domain, not as ordinary Zephyr heap management. The Xen support already exposes domain creation, maximum-memory, memory-mapping, grant-table, and event-channel control APIs. A Zephyr control-domain service or validation app needs the reservation operations to exercise the same guest memory lifecycle: ask Xen to adjust a domain reservation, receive any extent bases returned by Xen, and later return guest frames to Xen when the domain is torn down or resized.

Keep this as a typed Xen wrapper instead of adding a Zephyr memory subsystem driver. A real balloon or memory-hotplug driver would need a policy for which frames can be removed, coordination with Zephyr's allocator, and ownership of runtime memory pressure. This patch only exposes the stable Xen ABI primitive needed by that future policy and by control-domain test code.