### PR TITLE
net: ppp: negotiate PFC/ACFC and accept compressed frames on receive

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -537,39 +537,22 @@ static int ppp_input_byte(struct ppp_driver_context *ppp, uint8_t byte)
 		break;
 
 	case STATE_HDLC_FRAME_ADDRESS:
-		if (byte != 0xff) {
-			/* Check if we need to sync again */
-			if (byte == 0x7e) {
-				/* Just skip to the start of the pkt byte */
-				ppp->next_escaped = false;
-				return -EAGAIN;
-			}
-
-			LOG_DBG("Invalid (0x%02x) byte, expecting Address",
-				byte);
-
-			/* If address is != 0xff, then ignore this
-			 * frame. RFC 1662 ch 3.1
-			 */
-			ppp_change_state(ppp, STATE_HDLC_FRAME_START);
-		} else {
-			LOG_DBG("Address byte (0x%02x) start", byte);
-
-			ppp_change_state(ppp, STATE_HDLC_FRAME_DATA);
-
-			/* Save the address field so that we can calculate
-			 * the FCS. The address field will not be passed
-			 * to upper stack.
-			 */
-			ret = ppp_save_byte(ppp, byte);
-			if (ret < 0) {
-				ppp_change_state(ppp, STATE_HDLC_FRAME_START);
-			}
-
-			ret = -EAGAIN;
+		/* Check if we need to sync again */
+		if (byte == 0x7e) {
+			/* Just skip to the start of the pkt byte */
+			ppp->next_escaped = false;
+			return -EAGAIN;
 		}
 
-		break;
+		LOG_DBG("Frame start byte (0x%02x)", byte);
+
+		/* The first octet is the Address field, or the Protocol field
+		 * if the peer compressed the Address and Control fields away
+		 * (RFC 1662 ch. 3.2). Handle both as frame data;
+		 * ppp_process_msg() tells them apart.
+		 */
+		ppp_change_state(ppp, STATE_HDLC_FRAME_DATA);
+		__fallthrough;
 
 	case STATE_HDLC_FRAME_DATA:
 		/* If the next frame starts, then send this one
@@ -686,34 +669,29 @@ static void ppp_process_msg(struct ppp_driver_context *ppp)
 					 NET_ETH_PTYPE_HDLC);
 		}
 
-		/* Remove the Address (0xff), Control (0x03) and
-		 * FCS fields (16-bit) as the PPP L2 layer does not need
-		 * those bytes.
+		/* Remove the Address (0xff), Control (0x03) and FCS fields
+		 * (16-bit) as the PPP L2 layer does not need those bytes. The
+		 * peer may have compressed the Address and Control fields away
+		 * (RFC 1662 ch. 3.2); 0xff 0x03 cannot be mistaken for a
+		 * Protocol field, whose first octet is always even.
 		 */
-		uint16_t addr_and_ctrl = net_buf_pull_be16(ppp->pkt->buffer);
+		struct net_buf *buf = ppp->pkt->buffer;
 
-		/* Currently we do not support compressed Address and Control
-		 * fields so they must always be present.
+		if (buf->len >= 2 && buf->data[0] == 0xff && buf->data[1] == 0x03) {
+			(void)net_buf_pull_be16(buf);
+		}
+
+		/* Remove FCS bytes (2) */
+		net_pkt_remove_tail(ppp->pkt, 2);
+
+		/* Make sure we now start reading from PPP header in
+		 * PPP L2 recv()
 		 */
-		if (addr_and_ctrl != (0xff << 8 | 0x03)) {
-#if defined(CONFIG_NET_STATISTICS_PPP)
-			ppp->stats.drop++;
-			ppp->stats.pkts.rx++;
-#endif
+		net_pkt_cursor_init(ppp->pkt);
+		net_pkt_set_overwrite(ppp->pkt, true);
+
+		if (net_recv_data(ppp->iface, ppp->pkt) < 0) {
 			net_pkt_unref(ppp->pkt);
-		} else {
-			/* Remove FCS bytes (2) */
-			net_pkt_remove_tail(ppp->pkt, 2);
-
-			/* Make sure we now start reading from PPP header in
-			 * PPP L2 recv()
-			 */
-			net_pkt_cursor_init(ppp->pkt);
-			net_pkt_set_overwrite(ppp->pkt, true);
-
-			if (net_recv_data(ppp->iface, ppp->pkt) < 0) {
-				net_pkt_unref(ppp->pkt);
-			}
 		}
 	}
 

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -526,6 +526,7 @@ static int ppp_input_byte(struct ppp_driver_context *ppp, uint8_t byte)
 		if (byte == 0x7e) {
 			/* Note that we do not save the sync flag */
 			LOG_DBG("Sync byte (0x%02x) start", byte);
+			ppp->next_escaped = false;
 			ppp_change_state(ppp, STATE_HDLC_FRAME_ADDRESS);
 #if defined(CONFIG_PPP_CLIENT_CLIENTSERVER)
 		} else {
@@ -540,6 +541,7 @@ static int ppp_input_byte(struct ppp_driver_context *ppp, uint8_t byte)
 			/* Check if we need to sync again */
 			if (byte == 0x7e) {
 				/* Just skip to the start of the pkt byte */
+				ppp->next_escaped = false;
 				return -EAGAIN;
 			}
 
@@ -575,6 +577,11 @@ static int ppp_input_byte(struct ppp_driver_context *ppp, uint8_t byte)
 		 */
 		if (byte == 0x7e) {
 			LOG_DBG("End of pkt (0x%02x)", byte);
+			/* An escape at the very end of a frame (0x7d 0x7e) is
+			 * an aborted frame, RFC 1662 ch. 4.2. Do not let the
+			 * pending escape leak into the next frame.
+			 */
+			ppp->next_escaped = false;
 			ppp_change_state(ppp, STATE_HDLC_FRAME_ADDRESS);
 			ret = 0;
 		} else {

--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -379,13 +379,18 @@ struct lcp_options {
 
 	/** Which authentication protocol was negotiated (0 means none) */
 	uint16_t auth_proto;
+
+	/** Protocol-Field-Compression negotiated */
+	bool pfc;
+
+	/** Address-and-Control-Field-Compression negotiated */
+	bool acfc;
 };
 
-#if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
-#define LCP_NUM_MY_OPTIONS	2
-#else
-#define LCP_NUM_MY_OPTIONS	1
-#endif
+#define LCP_NUM_MY_OPTIONS	(1						\
+	+ IS_ENABLED(CONFIG_NET_L2_PPP_OPTION_MRU)			\
+	+ IS_ENABLED(CONFIG_NET_L2_PPP_OPTION_PFC)			\
+	+ IS_ENABLED(CONFIG_NET_L2_PPP_OPTION_ACFC))
 
 /** IPv4 control protocol options */
 struct ipcp_options {

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -60,6 +60,33 @@ config NET_L2_PPP_OPTION_MRU
 	help
 	  Enable support for LCP MRU option.
 
+config NET_L2_PPP_OPTION_PFC
+	bool "LCP Protocol-Field-Compression (PFC) option support"
+	help
+	  Enable LCP negotiation of Protocol-Field-Compression (RFC 1661,
+	  option 7). This advertises to the peer that a Protocol field
+	  compressed to a single octet, which is possible for protocol numbers
+	  below 0x0100, is acceptable, and records a matching request from the
+	  peer in the PPP context.
+
+	  This option only controls the LCP exchange. Reception does not depend
+	  on it, the receiver always accepts both the compressed and the
+	  uncompressed form. Compressing the Protocol field on transmit is not
+	  implemented.
+
+config NET_L2_PPP_OPTION_ACFC
+	bool "LCP Address-and-Control-Field-Compression (ACFC) option support"
+	help
+	  Enable LCP negotiation of Address-and-Control-Field-Compression
+	  (RFC 1661, option 8). This advertises to the peer that frames without
+	  the Address (0xFF) and Control (0x03) fields are acceptable, and
+	  records a matching request from the peer in the PPP context.
+
+	  This option only controls the LCP exchange. Reception does not depend
+	  on it, the receiver decompresses the fields as described in RFC 1662
+	  ch. 3.2 and accepts both forms. Omitting the fields on transmit is
+	  not implemented.
+
 config NET_L2_PPP_OPTION_SERVE_IP
 	bool "Serve IP address to peer"
 	help

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -258,10 +258,18 @@ static void lcp_lower_up(struct ppp_context *ctx)
 	ppp_fsm_lower_up(&ctx->lcp.fsm);
 }
 
+static void lcp_reset_peer_compression(struct ppp_context *ctx)
+{
+	ctx->lcp.peer_options.pfc = false;
+	ctx->lcp.peer_options.acfc = false;
+}
+
 static void lcp_open(struct ppp_context *ctx)
 {
 	/* Reset peer async control character map */
 	ctx->lcp.peer_options.async_map = 0xffffffff;
+
+	lcp_reset_peer_compression(ctx);
 
 	ppp_fsm_open(&ctx->lcp.fsm);
 }
@@ -287,6 +295,9 @@ static void lcp_down(struct ppp_fsm *fsm)
 
 	memset(&ctx->lcp.peer_options.auth_proto, 0,
 	       sizeof(ctx->lcp.peer_options.auth_proto));
+
+	/* The peer has to ask for compression again after renegotiation */
+	lcp_reset_peer_compression(ctx);
 
 	k_sem_give(&ctx->wait_ppp_link_down);
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -63,6 +63,8 @@ struct lcp_option_data {
 	uint32_t async_ctrl_char_map;
 	uint16_t auth_proto;
 	uint16_t mru;
+	bool pfc;
+	bool acfc;
 };
 
 static const enum ppp_protocol_type lcp_supported_auth_protos[] = {
@@ -155,6 +157,32 @@ static int lcp_peer_mru_nack(struct ppp_fsm *fsm, struct net_pkt *ret_pkt,
 }
 #endif
 
+#if defined(CONFIG_NET_L2_PPP_OPTION_PFC)
+static int lcp_peer_pfc_parse(struct ppp_fsm *fsm, struct net_pkt *pkt,
+			      void *user_data)
+{
+	struct lcp_option_data *data = user_data;
+
+	data->pfc = true;
+	NET_DBG("[LCP] Peer requested Protocol-Field-Compression");
+
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_NET_L2_PPP_OPTION_ACFC)
+static int lcp_peer_acfc_parse(struct ppp_fsm *fsm, struct net_pkt *pkt,
+			       void *user_data)
+{
+	struct lcp_option_data *data = user_data;
+
+	data->acfc = true;
+	NET_DBG("[LCP] Peer requested Address-and-Control-Field-Compression");
+
+	return 0;
+}
+#endif
+
 static const struct ppp_peer_option_info lcp_peer_options[] = {
 	PPP_PEER_OPTION(LCP_OPTION_AUTH_PROTO, lcp_auth_proto_parse,
 			lcp_auth_proto_nack),
@@ -162,6 +190,12 @@ static const struct ppp_peer_option_info lcp_peer_options[] = {
 			NULL),
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
 	PPP_PEER_OPTION(LCP_OPTION_MRU, lcp_peer_mru_parse, lcp_peer_mru_nack),
+#endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_PFC)
+	PPP_PEER_OPTION(LCP_OPTION_PROTO_COMPRESS, lcp_peer_pfc_parse, NULL),
+#endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_ACFC)
+	PPP_PEER_OPTION(LCP_OPTION_ADDR_CTRL_COMPRESS, lcp_peer_acfc_parse, NULL),
 #endif
 };
 
@@ -191,6 +225,12 @@ static int lcp_config_info_req(struct ppp_fsm *fsm,
 	ctx->lcp.peer_options.async_map = data.async_ctrl_char_map;
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
 	ctx->lcp.peer_options.mru = data.mru;
+#endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_PFC)
+	ctx->lcp.peer_options.pfc = data.pfc;
+#endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_ACFC)
+	ctx->lcp.peer_options.acfc = data.acfc;
 #endif
 	NET_DBG("Asynchronous Control Character Map: %08X",  data.async_ctrl_char_map);
 
@@ -428,10 +468,38 @@ static int lcp_nak_async_map(struct ppp_context *ctx, struct net_pkt *pkt,
 	return 0;
 }
 
+#if defined(CONFIG_NET_L2_PPP_OPTION_PFC) || defined(CONFIG_NET_L2_PPP_OPTION_ACFC)
+#define COMPRESS_OPTION_LEN 2
+
+static int lcp_add_compress(struct ppp_context *ctx, struct net_pkt *pkt)
+{
+	return net_pkt_write_u8(pkt, COMPRESS_OPTION_LEN);
+}
+
+static int lcp_ack_compress(struct ppp_context *ctx, struct net_pkt *pkt,
+			    uint8_t oplen)
+{
+	return (oplen == 0) ? 0 : -EINVAL;
+}
+
+static int lcp_nak_compress(struct ppp_context *ctx, struct net_pkt *pkt,
+			    uint8_t oplen)
+{
+	return 0;
+}
+#endif
 
 static const struct ppp_my_option_info lcp_my_options[] = {
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
 	PPP_MY_OPTION(LCP_OPTION_MRU, lcp_add_mru, lcp_ack_mru, lcp_nak_mru),
+#endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_PFC)
+	PPP_MY_OPTION(LCP_OPTION_PROTO_COMPRESS, lcp_add_compress,
+		      lcp_ack_compress, lcp_nak_compress),
+#endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_ACFC)
+	PPP_MY_OPTION(LCP_OPTION_ADDR_CTRL_COMPRESS, lcp_add_compress,
+		      lcp_ack_compress, lcp_nak_compress),
 #endif
 	PPP_MY_OPTION(LCP_OPTION_ASYNC_CTRL_CHAR_MAP, lcp_add_async_map,
 			lcp_ack_async_map, lcp_nak_async_map),
@@ -440,11 +508,19 @@ BUILD_ASSERT(ARRAY_SIZE(lcp_my_options) == LCP_NUM_MY_OPTIONS);
 
 static struct net_pkt *lcp_config_info_add(struct ppp_fsm *fsm)
 {
+	size_t len = ASYNC_MAP_OPTION_LEN;
+
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
-	return ppp_my_options_add(fsm, MRU_OPTION_LEN + ASYNC_MAP_OPTION_LEN);
-#else
-	return ppp_my_options_add(fsm, ASYNC_MAP_OPTION_LEN);
+	len += MRU_OPTION_LEN;
 #endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_PFC)
+	len += COMPRESS_OPTION_LEN;
+#endif
+#if defined(CONFIG_NET_L2_PPP_OPTION_ACFC)
+	len += COMPRESS_OPTION_LEN;
+#endif
+
+	return ppp_my_options_add(fsm, len);
 }
 
 static int lcp_config_info_nack(struct ppp_fsm *fsm, struct net_pkt *pkt,

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -125,18 +125,25 @@ static enum net_verdict process_ppp_msg(struct net_if *iface,
 		return proto->handler(ctx, iface, pkt);
 	}
 
-	switch (protocol) {
-	case PPP_IP:
-	case PPP_IPV6:
-	case PPP_ECP:
-	case PPP_CCP:
-	case PPP_LCP:
-	case PPP_IPCP:
-	case PPP_IPV6CP:
-		ppp_send_proto_rej(iface, pkt, protocol);
-		break;
-	default:
-		break;
+	/* The Rejected-Protocol field of a Protocol-Reject is copied verbatim
+	 * from the received frame, but RFC 1661 ch. 5.7 requires it to be two
+	 * octets. There is no headroom to expand a compressed Protocol field
+	 * in place, so stay silent rather than send a malformed reject.
+	 */
+	if (!pfc) {
+		switch (protocol) {
+		case PPP_IP:
+		case PPP_IPV6:
+		case PPP_ECP:
+		case PPP_CCP:
+		case PPP_LCP:
+		case PPP_IPCP:
+		case PPP_IPV6CP:
+			ppp_send_proto_rej(iface, pkt, protocol);
+			break;
+		default:
+			break;
+		}
 	}
 
 	NET_DBG("%s protocol %s%s(0x%02x)",

--- a/tests/net/ppp/driver/src/main.c
+++ b/tests/net/ppp/driver/src/main.c
@@ -342,8 +342,8 @@ static void ppp_verify_fcs(uint8_t *buf, int len)
 
 	net_pkt_read_be16(pkt, &addr_and_ctrl);
 
-	/* Currently we do not support compressed Address and Control
-	 * fields so they must always be present.
+	/* The test vectors handled here are uncompressed frames, so the
+	 * Address and Control fields must be present.
 	 */
 	if (addr_and_ctrl != (0xff << 8 | 0x03)) {
 		zassert_true(false, "Invalid address / control bytes");
@@ -413,8 +413,8 @@ static void ppp_calc_fcs(uint8_t *buf, int len)
 
 	net_pkt_read_be16(pkt, &addr_and_ctrl);
 
-	/* Currently we do not support compressed Address and Control
-	 * fields so they must always be present.
+	/* The test vectors handled here are uncompressed frames, so the
+	 * Address and Control fields must be present.
 	 */
 	if (addr_and_ctrl != (0xff << 8 | 0x03)) {
 		zassert_true(false, "Invalid address / control bytes");
@@ -620,6 +620,147 @@ static void pfc_iface_setup(void)
 	 */
 	ppp_l2_register_pkt_cb(NULL);
 	net_if_up(net_iface);
+}
+
+/* Longest test frame body used by the ACFC tests: Protocol field plus payload */
+#define ACFC_MAX_FRAME 16
+
+/* Payload including octets that need HDLC escaping */
+static const uint8_t acfc_payload[] = {0x7e, 0x7d, 0x11, 0x00, 0x23, 0x45, 0xff, 0x03};
+
+/* Append an HDLC-wrapped frame to a wire buffer. Frames after the first share
+ * the flag octet that closes the previous one, which is what a peer sending a
+ * burst of frames does.
+ */
+static size_t hdlc_append(uint8_t *out, size_t off, const uint8_t *frame, size_t len)
+{
+	uint8_t tmp[2 * (ACFC_MAX_FRAME + 2) + 2];
+	size_t n;
+
+	zassert_true(len <= ACFC_MAX_FRAME, "Test frame too long");
+
+	n = hdlc_wrap(tmp, frame, len);
+
+	if (off == 0) {
+		memcpy(out, tmp, n);
+		return n;
+	}
+
+	memcpy(&out[off], &tmp[1], n - 1);
+
+	return off + n - 1;
+}
+
+static void expect_acfc_payload(const char *what)
+{
+	zassert_ok(k_sem_take(&proto_handler_sem, WAIT_TIME_LONG),
+		   "Timeout, %s frame not received", what);
+	zassert_equal(proto_handler_data_len, sizeof(acfc_payload),
+		      "%s payload length incorrect", what);
+	zassert_mem_equal(proto_handler_data, acfc_payload, sizeof(acfc_payload),
+			  "%s payload incorrect", what);
+}
+
+ZTEST(net_ppp_test_suite, test_acfc_frame_receive)
+{
+	/* 23 | payload: no Address and Control fields, and the Protocol field
+	 * compressed to a single octet.
+	 */
+	uint8_t frame[1 + sizeof(acfc_payload)] = {0x23};
+	uint8_t wire[2 * (sizeof(frame) + 2) + 2];
+	size_t wire_len;
+
+	memcpy(&frame[1], acfc_payload, sizeof(acfc_payload));
+
+	pfc_iface_setup();
+	k_sem_init(&proto_handler_sem, 0, 1);
+
+	wire_len = hdlc_wrap(wire, frame, sizeof(frame));
+	ppp_driver_feed_data(wire, wire_len);
+
+	expect_acfc_payload("ACFC");
+}
+
+ZTEST(net_ppp_test_suite, test_acfc_uncompressed_protocol_receive)
+{
+	/* 00 23 | payload: no Address and Control fields, but a full two octet
+	 * Protocol field. The 0x00 goes on the wire escaped, so this only
+	 * decodes if the first octet of a frame is unescaped like any other.
+	 */
+	uint8_t frame[2 + sizeof(acfc_payload)] = {0x00, 0x23};
+	uint8_t wire[2 * (sizeof(frame) + 2) + 2];
+	size_t wire_len;
+
+	memcpy(&frame[2], acfc_payload, sizeof(acfc_payload));
+
+	pfc_iface_setup();
+	k_sem_init(&proto_handler_sem, 0, 1);
+
+	wire_len = hdlc_wrap(wire, frame, sizeof(frame));
+	zassert_equal(wire[1], 0x7d, "Expected the first frame octet to be escaped");
+
+	ppp_driver_feed_data(wire, wire_len);
+
+	expect_acfc_payload("ACFC with uncompressed protocol");
+}
+
+ZTEST(net_ppp_test_suite, test_acfc_interleaved_with_full_header)
+{
+	uint8_t compressed[1 + sizeof(acfc_payload)] = {0x23};
+	uint8_t full[4 + sizeof(acfc_payload)] = {0xff, 0x03, 0x00, 0x23};
+	uint8_t wire[3 * (2 * (ACFC_MAX_FRAME + 2) + 2)];
+	size_t wire_len;
+
+	memcpy(&compressed[1], acfc_payload, sizeof(acfc_payload));
+	memcpy(&full[4], acfc_payload, sizeof(acfc_payload));
+
+	pfc_iface_setup();
+	k_sem_init(&proto_handler_sem, 0, 3);
+
+	/* Both forms must be decoded when they arrive back to back, sharing
+	 * the flag octet between them.
+	 */
+	wire_len = hdlc_append(wire, 0, full, sizeof(full));
+	wire_len = hdlc_append(wire, wire_len, compressed, sizeof(compressed));
+	wire_len = hdlc_append(wire, wire_len, full, sizeof(full));
+
+	ppp_driver_feed_data(wire, wire_len);
+
+	expect_acfc_payload("first uncompressed");
+	expect_acfc_payload("ACFC");
+	expect_acfc_payload("second uncompressed");
+}
+
+ZTEST(net_ppp_test_suite, test_acfc_frame_after_aborted_frame)
+{
+	uint8_t full[4 + sizeof(acfc_payload)] = {0xff, 0x03, 0x00, 0x23};
+	uint8_t compressed[1 + sizeof(acfc_payload)] = {0x23};
+	uint8_t wire[2 * (2 * (ACFC_MAX_FRAME + 2) + 2)];
+	size_t wire_len;
+
+	memcpy(&full[4], acfc_payload, sizeof(acfc_payload));
+	memcpy(&compressed[1], acfc_payload, sizeof(acfc_payload));
+
+	pfc_iface_setup();
+	k_sem_init(&proto_handler_sem, 0, 2);
+
+	wire_len = hdlc_append(wire, 0, full, sizeof(full));
+
+	/* Turn the closing flag into a dangling escape followed by the flag.
+	 * RFC 1662 ch. 4.2 calls that an aborted frame; this receiver does not
+	 * discard it and still delivers the octets it collected, which is what
+	 * the first check below expects. What matters here is that the pending
+	 * escape must not be carried over into the next frame.
+	 */
+	wire[wire_len - 1] = 0x7d;
+	wire[wire_len++] = 0x7e;
+
+	wire_len = hdlc_append(wire, wire_len, compressed, sizeof(compressed));
+
+	ppp_driver_feed_data(wire, wire_len);
+
+	expect_acfc_payload("uncompressed");
+	expect_acfc_payload("ACFC after a dangling escape");
 }
 
 ZTEST(net_ppp_test_suite, test_pfc_protocol_receive)

--- a/tests/net/ppp/driver/src/main.c
+++ b/tests/net/ppp/driver/src/main.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_log.h>
+#include <zephyr/net/ppp.h>
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
@@ -698,6 +699,49 @@ ZTEST(net_ppp_test_suite, test_pfc_ip_frame_receive)
 		      "PFC IP frame did not reach IPv4 processing");
 }
 #endif /* CONFIG_NET_STATISTICS && CONFIG_NET_STATISTICS_IPV4 */
+
+#if defined(CONFIG_NET_L2_PPP_OPTION_PFC) && defined(CONFIG_NET_L2_PPP_OPTION_ACFC)
+ZTEST(net_ppp_test_suite, test_lcp_peer_pfc_acfc_options)
+{
+	/* LCP Configure-Request carrying only the PFC (07 02) and ACFC (08 02)
+	 * options, so the whole request is acceptable and acknowledged:
+	 * FF 03 | C0 21 | code=01 id=01 len=0008 | 07 02 | 08 02
+	 */
+	static const uint8_t req[] = {
+		0xff, 0x03, 0xc0, 0x21, 0x01, 0x01, 0x00, 0x08, 0x07, 0x02, 0x08, 0x02,
+	};
+	uint8_t wire[2 * (sizeof(req) + 2) + 2];
+	struct ppp_context *ctx;
+	size_t wire_len;
+
+	pfc_iface_setup();
+
+	ctx = net_if_l2_data(net_iface);
+
+	/* LCP is opened from a net_mgmt event handler, so wait for the FSM to
+	 * reach a state that processes a Configure-Request. With no peer to
+	 * answer our own request it settles in PPP_REQUEST_SENT.
+	 */
+	zassert_true(WAIT_FOR(ctx->lcp.fsm.state == PPP_REQUEST_SENT,
+			      WAIT_TIME * USEC_PER_MSEC, k_msleep(1)),
+		     "LCP did not reach PPP_REQUEST_SENT");
+
+	ctx->lcp.peer_options.pfc = false;
+	ctx->lcp.peer_options.acfc = false;
+
+	wire_len = hdlc_wrap(wire, req, sizeof(req));
+	ppp_driver_feed_data(wire, wire_len);
+
+	/* Let the net RX thread run the frame through the LCP FSM */
+	(void)WAIT_FOR(ctx->lcp.peer_options.pfc && ctx->lcp.peer_options.acfc,
+		       WAIT_TIME * USEC_PER_MSEC, k_msleep(1));
+
+	zassert_true(ctx->lcp.peer_options.pfc,
+		     "Peer Protocol-Field-Compression request not recorded");
+	zassert_true(ctx->lcp.peer_options.acfc,
+		     "Peer Address-and-Control-Field-Compression request not recorded");
+}
+#endif /* CONFIG_NET_L2_PPP_OPTION_PFC && CONFIG_NET_L2_PPP_OPTION_ACFC */
 
 ZTEST(net_ppp_test_suite, test_net_ppp)
 {

--- a/tests/net/ppp/driver/tests.yaml
+++ b/tests/net/ppp/driver/tests.yaml
@@ -11,3 +11,7 @@ tests:
       - CONFIG_NET_STATISTICS=y
       - CONFIG_NET_STATISTICS_PPP=y
       - CONFIG_NET_STATISTICS_USER_API=y
+  net.ppp.option_compress:
+    extra_args:
+      - CONFIG_NET_L2_PPP_OPTION_PFC=y
+      - CONFIG_NET_L2_PPP_OPTION_ACFC=y


### PR DESCRIPTION
LCP had no support for Protocol-Field-Compression (RFC 1661 option 7) and
Address-and-Control-Field-Compression (option 8), and the HDLC receiver in
drivers/net/ppp.c dropped any frame that did not start with ff 03. Peers request
both routinely - Linux pppd does unless told otherwise - and Zephyr had to
Configure-Reject them: it could not have parsed the result.

This series adds the LCP exchange for both options and makes the receiver
accept either form of frame. Decompression on receive is unconditional: it
does not depend on the Kconfig symbols or on the negotiation result, matching
what subsys/modem/modem_ppp.c already does. Frames are self-checking via the FCS.

Transmit-side compression is not implemented and is out of scope for this
series; the new Kconfig symbols only control what is offered over LCP.

Testing

twister: 20 of 20 test cases in tests/net/ppp/driver pass on qemu_x86, across
all three scenarios. With drivers/net/ppp.c reverted, 12 of them fail.

The changes were also integration-tested against Linux pppd 2.5.2 over a real
UART (nucleo_g474re, 115200 8N1), covering negotiation, the compressed data
path, raw-wire injection of malformed and compressed frames, and repeated
renegotiation. 32 of 32 tests passed. On the branch point 6 of the 8 raw-wire
tests fail, so the suite discriminates.