### PR TITLE
tests: kernel: fix -Wpointer-sign warnings

### DIFF
--- a/tests/kernel/obj_core/obj_core/src/main.c
+++ b/tests/kernel/obj_core/obj_core/src/main.c
@@ -235,7 +235,7 @@ ZTEST(obj_core, test_obj_core_lifo)
 
 ZTEST(obj_core, test_obj_core_pipe)
 {
-	k_pipe_init(&pipe2, pipe2_buffer, sizeof(pipe2_buffer));
+	k_pipe_init(&pipe2, (uint8_t *)pipe2_buffer, sizeof(pipe2_buffer));
 	common_obj_core_test(K_OBJ_TYPE_PIPE_ID, "pipe",
 			     K_OBJ_CORE(&pipe1), K_OBJ_CORE(&pipe2));
 }

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -83,7 +83,7 @@ ZTEST_USER(poll_api_1cpu, test_poll_no_wait)
 
 	k_msgq_alloc_init(mq, MSGQ_MSG_SIZE, MSGQ_MAX_MSGS);
 
-	k_pipe_write(&no_wait_pipe, PIPE_DATA, sizeof(PIPE_DATA), K_NO_WAIT);
+	k_pipe_write(&no_wait_pipe, (const uint8_t *)PIPE_DATA, sizeof(PIPE_DATA), K_NO_WAIT);
 
 	struct k_poll_event events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SEM_AVAILABLE,
@@ -170,7 +170,8 @@ ZTEST_USER(poll_api_1cpu, test_poll_no_wait)
 	zassert_false(memcmp(msgq_msg, msgq_recv_buf, MSGQ_MSG_SIZE), "");
 
 	zassert_equal(events[5].state, K_POLL_STATE_PIPE_DATA_AVAILABLE);
-	result = k_pipe_read(&no_wait_pipe, pipe_recv_buf, sizeof(pipe_recv_buf), K_NO_WAIT);
+	result = k_pipe_read(&no_wait_pipe, (uint8_t *)pipe_recv_buf,
+			     sizeof(pipe_recv_buf), K_NO_WAIT);
 	zassert_equal(result, sizeof(PIPE_DATA));
 	zassert_str_equal(pipe_recv_buf, PIPE_DATA);
 
@@ -264,7 +265,7 @@ static void poll_wait_helper(void *use_queuelike, void *msgq, void *p3)
 	}
 
 	if (flags & USE_PIPE) {
-		k_pipe_write(&wait_pipe, PIPE_DATA, sizeof(PIPE_DATA), K_NO_WAIT);
+		k_pipe_write(&wait_pipe, (const uint8_t *)PIPE_DATA, sizeof(PIPE_DATA), K_NO_WAIT);
 	}
 }
 
@@ -349,7 +350,7 @@ void check_results(struct k_poll_event *events, uint32_t event_type,
 	case K_POLL_TYPE_PIPE_DATA_AVAILABLE:
 		if (is_available) {
 			zassert_equal(events->state, K_POLL_STATE_PIPE_DATA_AVAILABLE);
-			result = k_pipe_read(&wait_pipe, pipe_recv_buf,
+			result = k_pipe_read(&wait_pipe, (uint8_t *)pipe_recv_buf,
 					     sizeof(pipe_recv_buf), K_NO_WAIT);
 			zassert_equal(result, sizeof(PIPE_DATA));
 			zassert_str_equal(pipe_recv_buf, PIPE_DATA);

--- a/tests/kernel/poll/src/test_poll_fail.c
+++ b/tests/kernel/poll/src/test_poll_fail.c
@@ -184,7 +184,7 @@ ZTEST_USER(poll_api, test_poll_signal_check_obj)
  */
 ZTEST_USER(poll_api, test_poll_signal_check_signal)
 {
-	unsigned int result;
+	int result;
 
 	k_poll_signal_init(&signal_err);
 
@@ -208,7 +208,7 @@ ZTEST_USER(poll_api, test_poll_signal_check_signal)
  */
 ZTEST_USER(poll_api, test_poll_signal_check_result)
 {
-	int signaled;
+	unsigned int signaled;
 
 	k_poll_signal_init(&signal_err);
 

--- a/tests/kernel/threads/thread_stack/src/main.c
+++ b/tests/kernel/threads/thread_stack/src/main.c
@@ -99,7 +99,7 @@ void stack_buffer_scenarios(void)
 	uint8_t val = 0;
 	char *stack_start, *stack_ptr, *stack_end, *obj_start, *obj_end;
 	char *stack_buf;
-	volatile char *pos;
+	volatile uint8_t *pos;
 	int ret, expected;
 	uintptr_t base;
 	bool is_usermode;
@@ -175,8 +175,10 @@ void stack_buffer_scenarios(void)
 	 * stack pointer up to the highest addresses in the buffer
 	 * Starting from &val which is close enough to stack pointer
 	 */
-	stack_ptr = &val;
-	for (pos = stack_ptr; pos < stack_end; pos++) {
+	stack_ptr = (char *)&val;
+	for (pos = (volatile uint8_t *)stack_ptr;
+	     pos < (volatile uint8_t *)stack_end;
+	     pos++) {
 		/* pos is volatile so this doesn't get optimized out */
 		val = *pos;
 		*pos = val;
@@ -187,7 +189,9 @@ void stack_buffer_scenarios(void)
 		/* If we're in user mode, check every byte in the stack buffer
 		 * to ensure that the thread has permissions on it.
 		 */
-		for (pos = stack_start; pos < stack_end; pos++) {
+		for (pos = (volatile uint8_t *)stack_start;
+		     pos < (volatile uint8_t *)stack_end;
+		     pos++) {
 			zassert_false(check_perms((void *)pos, 1, 1),
 				      "bad MPU/MMU permission on stack buffer at address %p",
 				      pos);


### PR DESCRIPTION
Fixes -Wpointer-sign warnings in the kernel tests by explicitly casting pointers when passing signed/unsigned byte pointers to pipe APIs and thread stack APIs.

This is part of a larger effort to fix pointer-sign warnings across the codebase in preparation for dropping -Wno-pointer-sign globally.

Fixes #8921