### PR TITLE
include: zephyr: sys: Add missing parentheses in ring_buffer macros

### DIFF
--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -95,8 +95,8 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, ring_buf_idx_t 
 
 #define RING_BUF_INIT(buf, size8)	\
 {					\
-	.buffer = buf,			\
-	.size = size8,			\
+	.buffer = (buf),		\
+	.size = (size8),		\
 }
 
 /**
@@ -114,10 +114,10 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, ring_buf_idx_t 
  * @param size8 Size of ring buffer (in bytes).
  */
 #define RING_BUF_DECLARE(name, size8) \
-	BUILD_ASSERT(size8 <= RING_BUFFER_MAX_SIZE,\
+	BUILD_ASSERT((size8) <= RING_BUFFER_MAX_SIZE,\
 		RING_BUFFER_SIZE_ASSERT_MSG); \
 	static uint8_t __noinit _ring_buffer_data_##name[size8]; \
-	struct ring_buf name = RING_BUF_INIT(_ring_buffer_data_##name, size8)
+	struct ring_buf name = RING_BUF_INIT(_ring_buffer_data_##name, (size8))
 
 /**
  * @brief Define and initialize an "item based" ring buffer.
@@ -153,7 +153,7 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, ring_buf_idx_t 
  * @param size32 Size of ring buffer (in 32-bit words).
  */
 #define RING_BUF_ITEM_DECLARE_SIZE(name, size32) \
-	RING_BUF_ITEM_DECLARE(name, size32)
+	RING_BUF_ITEM_DECLARE(name, (size32))
 
 /**
  * @brief Define and initialize a power-of-2 sized "item based" ring buffer.

--- a/include/zephyr/sys/ringq.h
+++ b/include/zephyr/sys/ringq.h
@@ -40,8 +40,8 @@ struct sys_ringq {
 
 #define SYS_RINGQ_INIT(buf, item_sz, item_capacity)			\
 {									\
-	.rb = RING_BUF_INIT(buf, item_sz * item_capacity),		\
-	.item_size = item_sz,						\
+	.rb = RING_BUF_INIT((buf), (item_sz) * (item_capacity)),	\
+	.item_size = (item_sz),						\
 }
 
 /** @endcond */
@@ -56,8 +56,9 @@ struct sys_ringq {
  * @param item_capacity capacity (in number of elements).
  */
 #define SYS_RINGQ_DEFINE(name, item_size, item_capacity)					\
-	static uint8_t __noinit CONCAT(_ringq_data_, name)[item_size * item_capacity];		\
-	struct sys_ringq name = SYS_RINGQ_INIT(CONCAT(_ringq_data_, name), item_size, item_capacity)
+	static uint8_t __noinit CONCAT(_ringq_data_, name)[(item_size) * (item_capacity)];	\
+	struct sys_ringq name = SYS_RINGQ_INIT(CONCAT(_ringq_data_, name), (item_size),		\
+					       (item_capacity))
 
 /**
  * @brief Initialize a ringq queue.


### PR DESCRIPTION
Add missing parentheses around argument where used in ring_buffer.h and ringq.h macros definitions.