### PR TITLE
kernel: print the exception location via printk()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -7098,11 +7098,11 @@ static inline void k_cpu_atomic_idle(unsigned int key)
 #define z_except_reason(reason)	ARCH_EXCEPT(reason)
 #else
 
-#if !defined(CONFIG_ASSERT_NO_FILE_INFO)
-#define __EXCEPT_LOC() __ASSERT_PRINT("@ %s:%d\n", __FILE__, __LINE__)
+#if defined(CONFIG_PRINTK) && !defined(CONFIG_ASSERT_NO_FILE_INFO)
+#define __EXCEPT_LOC() printk("@ %s:%d\n", __FILE__, __LINE__)
 #else
 #define __EXCEPT_LOC()
-#endif
+#endif /* CONFIG_PRINTK */
 
 /* NOTE: This is the implementation for arches that do not implement
  * ARCH_EXCEPT() to generate a real CPU exception.


### PR DESCRIPTION
Instead of using __ASSERT_PRINT() to emit the "@ file:line" location before entering the fatal error handler we should use printk() directly.

That macro is part of the assert surface and only emits when CONFIG_ASSERT is enabled with a verbose assert level, so on default builds the fault location was silently dropped, even though it is the only diagnostic available for these architectures.

Call printk() directly and gate it on CONFIG_PRINTK instead, which reflects when the location can actually be printed.