### PR TITLE
drivers: clock_control: use syscon for Agilex5 sysmgr register access

### DIFF
--- a/drivers/clock_control/clock_control_agilex5.c
+++ b/drivers/clock_control/clock_control_agilex5.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(clock_control_agilex5, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
 struct clock_control_config {
 	DEVICE_MMIO_ROM;
+	const struct device *sysmgr;
 };
 
 struct clock_control_data {
@@ -27,6 +28,12 @@ static int clock_init(const struct device *dev)
 {
 
 	LOG_DBG("Intel Agilex5 clock driver initialized!");
+	const struct clock_control_config *cfg = dev->config;
+
+	if (!device_is_ready(cfg->sysmgr)) {
+		LOG_ERR("Sysmgr not ready");
+		return -ENODEV;
+	}
 
 	return 0;
 }
@@ -34,39 +41,39 @@ static int clock_init(const struct device *dev)
 static int clock_get_rate(const struct device *dev, clock_control_subsys_t sub_system,
 			  uint32_t *rate)
 {
-	ARG_UNUSED(dev);
+	const struct clock_control_config *config = dev->config;
 
 	switch ((intptr_t)sub_system) {
 	case INTEL_SOCFPGA_CLOCK_MPU:
-		*rate = get_mpu_clk();
+		*rate = get_mpu_clk(config->sysmgr);
 		break;
 
 	case INTEL_SOCFPGA_CLOCK_WDT:
-		*rate = get_wdt_clk();
+		*rate = get_wdt_clk(config->sysmgr);
 		break;
 
 	case INTEL_SOCFPGA_CLOCK_UART:
-		*rate = get_uart_clk();
+		*rate = get_uart_clk(config->sysmgr);
 		break;
 
 	case INTEL_SOCFPGA_CLOCK_MMC:
-		*rate = get_sdmmc_clk();
+		*rate = get_sdmmc_clk(config->sysmgr);
 		break;
 
 	case INTEL_SOCFPGA_CLOCK_TIMER:
-		*rate = get_timer_clk();
+		*rate = get_timer_clk(config->sysmgr);
 		break;
 
 	case INTEL_SOCFPGA_CLOCK_QSPI:
-		*rate = get_qspi_clk();
+		*rate = get_qspi_clk(config->sysmgr);
 		break;
 
 	case INTEL_SOCFPGA_CLOCK_I2C:
-		*rate = get_i2c_clk();
+		*rate = get_i2c_clk(config->sysmgr);
 		break;
 
 	case INTEL_SOCFPGA_CLOCK_I3C:
-		*rate = get_i3c_clk();
+		*rate = get_i3c_clk(config->sysmgr);
 		break;
 
 	default:
@@ -87,6 +94,7 @@ static DEVICE_API(clock_control, clock_api) = {
                                                                                                    \
 	static const struct clock_control_config clock_control_config_##_inst = {                  \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(_inst)),                                          \
+		.sysmgr = DEVICE_DT_GET(DT_INST_PHANDLE(_inst, sysmgr)), \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(_inst, clock_init, NULL, &clock_control_data_##_inst,                \

--- a/drivers/clock_control/clock_control_agilex5_ll.c
+++ b/drivers/clock_control/clock_control_agilex5_ll.c
@@ -15,7 +15,7 @@
 LOG_MODULE_REGISTER(clock_control_agilex5_ll, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
 /* Extract reference clock from platform clock source */
-static uint32_t get_ref_clk(mm_reg_t pllglob_reg, mm_reg_t pllm_reg)
+static uint32_t get_ref_clk(mm_reg_t pllglob_reg, mm_reg_t pllm_reg, const struct device *sysmgr)
 {
 	uint32_t arefclkdiv = 0U;
 	uint32_t ref_clk = 0U;
@@ -32,9 +32,10 @@ static uint32_t get_ref_clk(mm_reg_t pllglob_reg, mm_reg_t pllm_reg)
 	 * scratch registers. These values are filled by boot loader based on
 	 * hand-off data.
 	 */
+
 	switch (CLKCTRL_PSRC(pllglob_val)) {
 	case CLKCTRL_PLLGLOB_PSRC_EOSC1:
-		ref_clk = sys_read32(SOCFPGA_SYSMGR(BOOT_SCRATCH_COLD_1));
+		syscon_read_reg(sysmgr, SOCFPGA_SYSMGR_BOOT_SCRATCH_COLD_1, &ref_clk);
 		break;
 
 	case CLKCTRL_PLLGLOB_PSRC_INTOSC:
@@ -42,7 +43,7 @@ static uint32_t get_ref_clk(mm_reg_t pllglob_reg, mm_reg_t pllm_reg)
 		break;
 
 	case CLKCTRL_PLLGLOB_PSRC_F2S:
-		ref_clk = sys_read32(SOCFPGA_SYSMGR(BOOT_SCRATCH_COLD_2));
+		syscon_read_reg(sysmgr, SOCFPGA_SYSMGR_BOOT_SCRATCH_COLD_2, &ref_clk);
 		break;
 
 	default:
@@ -67,7 +68,7 @@ static uint32_t get_ref_clk(mm_reg_t pllglob_reg, mm_reg_t pllm_reg)
 
 /* Calculate clock frequency based on parameter */
 static uint32_t get_clk_freq(mm_reg_t psrc_reg, mm_reg_t mainpllc_reg,
-			     mm_reg_t perpllc_reg)
+			     mm_reg_t perpllc_reg, const struct device *sysmgr)
 {
 	uint32_t clock_val = 0U;
 	uint32_t clk_psrc = 0U;
@@ -78,23 +79,24 @@ static uint32_t get_clk_freq(mm_reg_t psrc_reg, mm_reg_t mainpllc_reg,
 	 * is not bypassed
 	 */
 	clk_psrc = sys_read32(psrc_reg);
+
 	switch (GET_CLKCTRL_CLKSRC(clk_psrc)) {
 	case CLKCTRL_CLKSRC_MAIN:
-		clock_val = get_ref_clk(CLKCTRL_MAINPLL(PLLGLOB), CLKCTRL_MAINPLL(PLLM));
+		clock_val = get_ref_clk(CLKCTRL_MAINPLL(PLLGLOB), CLKCTRL_MAINPLL(PLLM), sysmgr);
 		pllcx_div = (sys_read32(mainpllc_reg) & CLKCTRL_PLLCX_DIV_MSK);
 		__ASSERT(pllcx_div != 0, "Main PLLC clock divider is zero");
 		clock_val /= pllcx_div;
 		break;
 
 	case CLKCTRL_CLKSRC_PER:
-		clock_val = get_ref_clk(CLKCTRL_PERPLL(PLLGLOB), CLKCTRL_PERPLL(PLLM));
+		clock_val = get_ref_clk(CLKCTRL_PERPLL(PLLGLOB), CLKCTRL_PERPLL(PLLM), sysmgr);
 		pllcx_div = (sys_read32(perpllc_reg) & CLKCTRL_PLLCX_DIV_MSK);
 		__ASSERT(pllcx_div != 0, "Peripheral PLLC clock divider is zero");
 		clock_val /= pllcx_div;
 		break;
 
 	case CLKCTRL_CLKSRC_OSC1:
-		clock_val = sys_read32(SOCFPGA_SYSMGR(BOOT_SCRATCH_COLD_1));
+		syscon_read_reg(sysmgr, SOCFPGA_SYSMGR_BOOT_SCRATCH_COLD_1, &clock_val);
 		break;
 
 	case CLKCTRL_CLKSRC_INTOSC:
@@ -102,7 +104,7 @@ static uint32_t get_clk_freq(mm_reg_t psrc_reg, mm_reg_t mainpllc_reg,
 		break;
 
 	case CLKCTRL_CLKSRC_FPGA:
-		clock_val = sys_read32(SOCFPGA_SYSMGR(BOOT_SCRATCH_COLD_2));
+		syscon_read_reg(sysmgr, SOCFPGA_SYSMGR_BOOT_SCRATCH_COLD_2, &clock_val);
 		break;
 
 	default:
@@ -117,17 +119,17 @@ static uint32_t get_clk_freq(mm_reg_t psrc_reg, mm_reg_t mainpllc_reg,
 }
 
 /* Get L3 free clock */
-static uint32_t get_l3_main_free_clk(void)
+static uint32_t get_l3_main_free_clk(const struct device *sysmgr)
 {
 	return get_clk_freq(CLKCTRL_MAINPLL(NOCCLK),
 			    CLKCTRL_MAINPLL(PLLC3),
-			    CLKCTRL_PERPLL(PLLC1));
+			    CLKCTRL_PERPLL(PLLC1), sysmgr);
 }
 
 /* Get L4 mp clock */
-static uint32_t get_l4_mp_clk(void)
+static uint32_t get_l4_mp_clk(const struct device *sysmgr)
 {
-	uint32_t l3_main_free_clk = get_l3_main_free_clk();
+	uint32_t l3_main_free_clk = get_l3_main_free_clk(sysmgr);
 	uint32_t mainpll_nocdiv_l4mp = BIT(GET_CLKCTRL_MAINPLL_NOCDIV_L4MP(
 					sys_read32(CLKCTRL_MAINPLL(NOCDIV))));
 
@@ -141,19 +143,18 @@ static uint32_t get_l4_mp_clk(void)
  * "l4_sp_clk" (100MHz) will be used for slow peripherals like UART, I2C,
  * Timers ...etc.
  */
-static uint32_t get_l4_sp_clk(void)
+static uint32_t get_l4_sp_clk(const struct device *sysmgr)
 {
-	uint32_t l3_main_free_clk = get_l3_main_free_clk();
+	uint32_t l3_main_free_clk = get_l3_main_free_clk(sysmgr);
 	uint32_t mainpll_nocdiv_l4sp = BIT(GET_CLKCTRL_MAINPLL_NOCDIV_L4SP(
 					sys_read32(CLKCTRL_MAINPLL(NOCDIV))));
-
 	uint32_t l4_sp_clk = (l3_main_free_clk / mainpll_nocdiv_l4sp);
 
 	return l4_sp_clk;
 }
 
 /* Get MPU clock */
-uint32_t get_mpu_clk(void)
+uint32_t get_mpu_clk(const struct device *sysmgr)
 {
 	uint8_t cpu_id = arch_curr_cpu()->id;
 	uint32_t ctr_reg = 0U;
@@ -162,11 +163,11 @@ uint32_t get_mpu_clk(void)
 	if (cpu_id > CLKCTRL_CPU_ID_CORE1) {
 		clock_val = get_clk_freq(CLKCTRL_CTLGRP(CORE23CTR),
 				     CLKCTRL_MAINPLL(PLLC0),
-				     CLKCTRL_PERPLL(PLLC0));
+				     CLKCTRL_PERPLL(PLLC0), sysmgr);
 	} else {
 		clock_val = get_clk_freq(CLKCTRL_CTLGRP(CORE01CTR),
 				     CLKCTRL_MAINPLL(PLLC1),
-				     CLKCTRL_PERPLL(PLLC0));
+				     CLKCTRL_PERPLL(PLLC0), sysmgr);
 	}
 
 	switch (cpu_id) {
@@ -194,9 +195,9 @@ uint32_t get_mpu_clk(void)
 }
 
 /* Calculate clock frequency to be used for watchdog timer */
-uint32_t get_wdt_clk(void)
+uint32_t get_wdt_clk(const struct device *sysmgr)
 {
-	uint32_t l3_main_free_clk = get_l3_main_free_clk();
+	uint32_t l3_main_free_clk = get_l3_main_free_clk(sysmgr);
 	uint32_t mainpll_nocdiv_l4sysfreeclk = BIT(GET_CLKCTRL_MAINPLL_NOCDIV_L4SYSFREE(
 						sys_read32(CLKCTRL_MAINPLL(NOCDIV))));
 	uint32_t l4_sys_free_clk = (l3_main_free_clk / mainpll_nocdiv_l4sysfreeclk);
@@ -205,15 +206,15 @@ uint32_t get_wdt_clk(void)
 }
 
 /* Get clock frequency to be used for UART driver */
-uint32_t get_uart_clk(void)
+uint32_t get_uart_clk(const struct device *sysmgr)
 {
-	return get_l4_sp_clk();
+	return get_l4_sp_clk(sysmgr);
 }
 
 /* Calculate clock frequency to be used for SDMMC driver */
-uint32_t get_sdmmc_clk(void)
+uint32_t get_sdmmc_clk(const struct device *sysmgr)
 {
-	uint32_t l4_mp_clk = get_l4_mp_clk();
+	uint32_t l4_mp_clk = get_l4_mp_clk(sysmgr);
 	uint32_t mainpll_nocdiv = sys_read32(CLKCTRL_MAINPLL(NOCDIV));
 	uint32_t sdmmc_clk = l4_mp_clk / BIT(GET_CLKCTRL_MAINPLL_NOCDIV_SPHY(mainpll_nocdiv));
 
@@ -221,18 +222,17 @@ uint32_t get_sdmmc_clk(void)
 }
 
 /* Calculate clock frequency to be used for Timer driver */
-uint32_t get_timer_clk(void)
+uint32_t get_timer_clk(const struct device *sysmgr)
 {
-	return get_l4_sp_clk();
+	return get_l4_sp_clk(sysmgr);
 }
 
 /* Calculate clock frequency to be used for QSPI driver */
-uint32_t get_qspi_clk(void)
+uint32_t get_qspi_clk(const struct device *sysmgr)
 {
-	uint32_t scr_reg, ref_clk;
+	uint32_t ref_clk;
 
-	scr_reg = SOCFPGA_SYSMGR(BOOT_SCRATCH_COLD_0);
-	ref_clk = sys_read32(scr_reg);
+	syscon_read_reg(sysmgr, SOCFPGA_SYSMGR_BOOT_SCRATCH_COLD_0, &ref_clk);
 
 	/*
 	 * In ATF, the qspi clock is divided by 1000 and loaded in scratch cold register 0
@@ -242,13 +242,13 @@ uint32_t get_qspi_clk(void)
 }
 
 /* Calculate clock frequency to be used for I2C driver */
-uint32_t get_i2c_clk(void)
+uint32_t get_i2c_clk(const struct device *sysmgr)
 {
-	return get_l4_sp_clk();
+	return get_l4_sp_clk(sysmgr);
 }
 
 /* Calculate clock frequency to be used for I3C driver */
-uint32_t get_i3c_clk(void)
+uint32_t get_i3c_clk(const struct device *sysmgr)
 {
-	return get_l4_mp_clk();
+	return get_l4_mp_clk(sysmgr);
 }

--- a/drivers/clock_control/clock_control_agilex5_ll.h
+++ b/drivers/clock_control/clock_control_agilex5_ll.h
@@ -11,6 +11,7 @@
 #include <assert.h>
 
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/drivers/syscon.h>
 
 /* Clock control MMIO register base address */
 #define CLKCTRL_BASE_ADDR			DT_REG_ADDR(DT_NODELABEL(clock))
@@ -186,7 +187,7 @@
  *
  *  @return returns MPU clock value
  */
-uint32_t get_mpu_clk(void);
+uint32_t get_mpu_clk(const struct device *sysmgr);
 
 /**
  *  @brief  Get Watchdog peripheral clock value
@@ -195,7 +196,7 @@ uint32_t get_mpu_clk(void);
  *
  *  @return returns Watchdog clock value
  */
-uint32_t get_wdt_clk(void);
+uint32_t get_wdt_clk(const struct device *sysmgr);
 
 /**
  *  @brief  Get UART peripheral clock value
@@ -204,7 +205,7 @@ uint32_t get_wdt_clk(void);
  *
  *  @return returns UART clock value
  */
-uint32_t get_uart_clk(void);
+uint32_t get_uart_clk(const struct device *sysmgr);
 
 /**
  *  @brief  Get MMC peripheral clock value
@@ -213,7 +214,7 @@ uint32_t get_uart_clk(void);
  *
  *  @return returns MMC clock value
  */
-uint32_t get_sdmmc_clk(void);
+uint32_t get_sdmmc_clk(const struct device *sysmgr);
 
 /**
  *  @brief  Get Timer peripheral clock value
@@ -222,7 +223,7 @@ uint32_t get_sdmmc_clk(void);
  *
  *  @return returns Timer clock value
  */
-uint32_t get_timer_clk(void);
+uint32_t get_timer_clk(const struct device *sysmgr);
 
 /**
  *  @brief  Get QSPI peripheral clock value
@@ -231,7 +232,7 @@ uint32_t get_timer_clk(void);
  *
  *  @return returns QSPI clock value
  */
-uint32_t get_qspi_clk(void);
+uint32_t get_qspi_clk(const struct device *sysmgr);
 
 /**
  *  @brief  Get I2C peripheral clock value
@@ -240,7 +241,7 @@ uint32_t get_qspi_clk(void);
  *
  *  @return returns I2C clock value
  */
-uint32_t get_i2c_clk(void);
+uint32_t get_i2c_clk(const struct device *sysmgr);
 
 /**
  *  @brief  Get I3C peripheral clock value
@@ -249,6 +250,6 @@ uint32_t get_i2c_clk(void);
  *
  *  @return returns I3C clock value
  */
-uint32_t get_i3c_clk(void);
+uint32_t get_i3c_clk(const struct device *sysmgr);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_AGILEX5_LL_H_ */

--- a/drivers/syscon/Kconfig
+++ b/drivers/syscon/Kconfig
@@ -31,7 +31,7 @@ config SYSCON_GENERIC
 
 config SYSCON_INIT_PRIORITY
 	int "SYSCON (System Controller) driver init priority"
-	default 50
+	default 20
 	help
 	  This option controls the priority of the syscon device
 	  initialization. Higher priority ensures that the device is

--- a/dts/arm64/intel/intel_socfpga_agilex5.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex5.dtsi
@@ -75,11 +75,13 @@
 	sysmgr: sysmgr@10d12000 {
 		compatible = "syscon";
 		reg = <0x10d12000 0x1000>;
+		status = "okay";
 	};
 
 	clock: clock@10d10000 {
 		compatible = "intel,agilex5-clock";
 		reg = <0x10d10000 0x1000>;
+		sysmgr = <&sysmgr>;
 		#clock-cells = <1>;
 	};
 

--- a/dts/bindings/clock/intel,agilex5-clock.yaml
+++ b/dts/bindings/clock/intel,agilex5-clock.yaml
@@ -11,6 +11,11 @@ properties:
   reg:
     required: true
 
+  sysmgr:
+    type: phandle
+    required: true
+    description: phandle to the syscon node backing sysmgr registers
+
   "#clock-cells":
     const: 1
 


### PR DESCRIPTION
## Summary

The Agilex5 clock driver was reading System Manager boot-scratch registers via
hard-coded MMIO (`SOCFPGA_SYSMGR()` + `sys_read32()`). This change routes those
accesses through the syscon driver instead.

- Add a required `sysmgr` phandle on `intel,agilex5-clock` and wire it in DT
- Pass the sysmgr device into the LL clock helpers and use `syscon_read_reg()`
- Lower default `SYSCON_INIT_PRIORITY` so syscon is ready before the clock driver

### Test plan
- Build for `intel_socfpga_agilex5_socdk`
- Confirm clock driver init succeeds with sysmgr ready
- Verify QSPI (and other) reported clock rates look correct on hardware