### PR TITLE
manifest: hal_nxp: upgrade wifi_nxp to v1.3.r54.z_up.p3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 85d250e97c9319df6c8311f17d6d7eec9e6578e5
+      revision: pull/783/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp revision to include wifi_nxp upgrade to v1.3.r54.z_up.p3 with multiple bug fixes and aarch64 compile warning fixes.

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/783

---
_Generated by WChat AI Agent_