### PR TITLE
manifest: hal_nxp: upgrade wifi_nxp to v1.3.r54.z_up.p3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2e21c1747cb79933f6e28298cfcc397cdd785e85
+      revision: 53946adb08b54449391c1c0c73cdd094d92a3b6e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp revision to include wifi_nxp upgrade to v1.3.r54.z_up.p3 with multiple bug fixes, improvements, and aarch64 compile warning fixes.

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/783