### PR TITLE
soc: adi: max32: max32657: Preserve CPU registers across S2RAM

### DIFF
--- a/soc/adi/max32/max32657/pm_max32657_s2ram.c
+++ b/soc/adi/max32/max32657/pm_max32657_s2ram.c
@@ -1,12 +1,47 @@
 /*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  * Copyright (c) 2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/arch/arm/cortex_m/fpu.h>
+#include <zephyr/arch/arm/cortex_m/scb.h>
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
+#include <zephyr/arch/common/pm_s2ram.h>
 #include <mxc_device.h>
 #include <mcr_regs.h>
+#include <wrap_max32_lp.h>
+
+#define NVIC_MEMBER_SIZE(member) ARRAY_SIZE(((NVIC_Type *)0)->member)
+
+/* Coprocessor Power Control Register Definitions */
+#define SCnSCB_CPPWR_SU11_Pos 22U                            /*!< CPPWR: SU11 Position */
+#define SCnSCB_CPPWR_SU11_Msk (1UL << SCnSCB_CPPWR_SU11_Pos) /*!< CPPWR: SU11 Mask */
+
+#define SCnSCB_CPPWR_SU10_Pos 20U                            /*!< CPPWR: SU10 Position */
+#define SCnSCB_CPPWR_SU10_Msk (1UL << SCnSCB_CPPWR_SU10_Pos) /*!< CPPWR: SU10 Mask */
+
+typedef struct {
+	/* NVIC components stored into RAM. */
+	uint32_t ISER[NVIC_MEMBER_SIZE(ISER)];
+	uint32_t ISPR[NVIC_MEMBER_SIZE(ISPR)];
+	uint8_t IPR[NVIC_MEMBER_SIZE(IPR)];
+} _nvic_context_t;
+
+struct backup {
+	_nvic_context_t nvic_context;
+#if defined(CONFIG_ARM_MPU)
+	struct z_mpu_context_retained mpu_context;
+#endif
+	struct scb_context scb_context;
+#if defined(CONFIG_FPU) && !defined(CONFIG_FPU_SHARING)
+	struct fpu_ctx_full fpu_context;
+#endif
+};
+
+static __noinit struct backup backup_data;
 
 /* Construct retention mask from SRAM devicetree definition */
 #define RET_MASK                                                                                   \
@@ -16,9 +51,74 @@
 	 (DT_PROP(DT_NODELABEL(sram1), adi_ram_bank_retained) << 1) |                              \
 	 DT_PROP(DT_NODELABEL(sram0), adi_ram_bank_retained))
 
-uint8_t pm_get_s2ram_retention_mask(void)
+
+static void nvic_save(_nvic_context_t *backup)
 {
-	return RET_MASK;
+	memcpy(backup->ISER, (uint32_t *)NVIC->ISER, sizeof(NVIC->ISER));
+	memcpy(backup->ISPR, (uint32_t *)NVIC->ISPR, sizeof(NVIC->ISPR));
+	memcpy(backup->IPR, (uint32_t *)NVIC->IPR, sizeof(NVIC->IPR));
+}
+
+static void nvic_restore(_nvic_context_t *backup)
+{
+	memcpy((uint32_t *)NVIC->ISER, backup->ISER, sizeof(NVIC->ISER));
+	memcpy((uint32_t *)NVIC->ISPR, backup->ISPR, sizeof(NVIC->ISPR));
+	memcpy((uint32_t *)NVIC->IPR, backup->IPR, sizeof(NVIC->IPR));
+}
+
+#if defined(CONFIG_FPU)
+static void fpu_power_down(void)
+{
+	SCB->CPACR &= (~(CPACR_CP10_Msk | CPACR_CP11_Msk));
+	SCnSCB->CPPWR |= (SCnSCB_CPPWR_SU11_Msk | SCnSCB_CPPWR_SU10_Msk);
+	__DSB();
+	__ISB();
+}
+
+static void fpu_power_up(void)
+{
+	SCnSCB->CPPWR &= (~(SCnSCB_CPPWR_SU11_Msk | SCnSCB_CPPWR_SU10_Msk));
+	SCB->CPACR |= (CPACR_CP10_Msk | CPACR_CP11_Msk);
+	__DSB();
+	__ISB();
+}
+#endif /* defined(CONFIG_FPU) */
+
+void pm_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
+{
+	Wrap_MXC_LP_EnableRetentionReg();
+	Wrap_MXC_LP_EnableSramRetention(RET_MASK);
+
+	/* Save FPU, SCB and MPU states */
+	z_arm_save_scb_context(&backup_data.scb_context);
+#if defined(CONFIG_FPU)
+#if !defined(CONFIG_FPU_SHARING)
+	z_arm_save_fp_context(&backup_data.fpu_context);
+#endif
+	fpu_power_down();
+#endif
+	nvic_save(&backup_data.nvic_context);
+#if defined(CONFIG_ARM_MPU)
+	z_arm_save_mpu_context(&backup_data.mpu_context);
+#endif
+	/* Save context and enter Standby mode */
+	arch_pm_s2ram_suspend(system_off);
+
+	/* Restore MPU, SCB and FPU states */
+#if defined(CONFIG_FPU)
+	fpu_power_up();
+#if !defined(CONFIG_FPU_SHARING)
+	z_arm_restore_fp_context(&backup_data.fpu_context);
+#endif
+#endif
+
+#if defined(CONFIG_ARM_MPU)
+	z_arm_restore_mpu_context(&backup_data.mpu_context);
+#endif
+	nvic_restore(&backup_data.nvic_context);
+	z_arm_restore_scb_context(&backup_data.scb_context);
+
+	Wrap_MXC_LP_DisableSramRetention();
 }
 
 void __attribute__((naked)) pm_s2ram_mark_set(void)

--- a/soc/adi/max32/power.c
+++ b/soc/adi/max32/power.c
@@ -20,7 +20,9 @@
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
 
-extern uint8_t pm_get_s2ram_retention_mask(void);
+#ifdef CONFIG_PM_S2RAM
+extern int pm_s2ram_suspend(pm_s2ram_system_off_fn_t system_off);
+#endif /* CONFIG_PM_S2RAM */
 
 #if defined(CONFIG_PM_S2RAM) && defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER)
 static const struct device *idle_timer =
@@ -69,12 +71,8 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		}
 #endif /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER */
 
-		/* SRAM retention configurable via Kconfig */
-		Wrap_MXC_LP_EnableRetentionReg();
-		Wrap_MXC_LP_EnableSramRetention(pm_get_s2ram_retention_mask());
-
 		/* Suspend to RAM */
-		arch_pm_s2ram_suspend(Wrap_MXC_LP_EnterBackupMode);
+		pm_s2ram_suspend(Wrap_MXC_LP_EnterBackupMode);
 #else
 		LOG_WRN("PM_STATE_SUSPEND_TO_RAM must be enabled by Kconfig option!");
 #endif /* CONFIG_PM_S2RAM */
@@ -106,7 +104,6 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	case PM_STATE_SUSPEND_TO_RAM:
 #ifdef CONFIG_PM_S2RAM
 		max32xx_system_init();
-		Wrap_MXC_LP_DisableSramRetention();
 		Wrap_MXC_LP_ExitBackupMode();
 
 #ifdef CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER

--- a/soc/adi/max32/power.c
+++ b/soc/adi/max32/power.c
@@ -8,7 +8,6 @@
 #include <zephyr/init.h>
 #include <zephyr/platform/hooks.h>
 #include <zephyr/pm/pm.h>
-#include <zephyr/pm/device_runtime.h>
 #include <zephyr/cache.h>
 #include <zephyr/arch/common/pm_s2ram.h>
 
@@ -24,10 +23,7 @@ LOG_MODULE_REGISTER(soc);
 extern int pm_s2ram_suspend(pm_s2ram_system_off_fn_t system_off);
 #endif /* CONFIG_PM_S2RAM */
 
-#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER)
-static const struct device *idle_timer =
-	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_system_timer_companion));
-#endif /* defined(CONFIG_PM_S2RAM) && defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER) */
+#define SYS_TIMER_COMPANION DT_CHOSEN(zephyr_system_timer_companion)
 
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
@@ -60,16 +56,6 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	case PM_STATE_SUSPEND_TO_RAM:
 #ifdef CONFIG_PM_S2RAM
 		LOG_DBG("entering PM state suspend to ram");
-
-#ifdef CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER
-		if (idle_timer) {
-			/* This does not actually suspend the idle-mode timer; it just decrements
-			 * the pm usage counter so that device can be resumed once the system
-			 * wakes up.
-			 */
-			pm_device_runtime_put(idle_timer);
-		}
-#endif /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER */
 
 		/* Suspend to RAM */
 		pm_s2ram_suspend(Wrap_MXC_LP_EnterBackupMode);
@@ -105,21 +91,16 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 #ifdef CONFIG_PM_S2RAM
 		max32xx_system_init();
 		Wrap_MXC_LP_ExitBackupMode();
-
-#ifdef CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER
-		if (idle_timer) {
-			/* Resume the idle-mode timer */
-			pm_device_runtime_get(idle_timer);
-		}
-#endif /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER */
-
+#if DT_NODE_HAS_COMPAT(SYS_TIMER_COMPANION, adi_max32_wut)
+		MXC_LP_EnableWUTAlarmWakeup();
+#endif
 		LOG_DBG("exited PM state suspend to ram");
 #else
 		LOG_WRN("PM_STATE_SUSPEND_TO_RAM must be enabled by Kconfig option!");
 #endif /* CONFIG_PM_S2RAM */
 		break;
 	case PM_STATE_STANDBY:
-#if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_system_timer_companion), adi_max32_rtc_counter)
+#if DT_NODE_HAS_COMPAT(SYS_TIMER_COMPANION, adi_max32_rtc_counter)
 		/* For this state wait a little until RTC register being ready
 		 * otherwise seems previous RTC value being read
 		 */

--- a/soc/adi/max32/soc.c
+++ b/soc/adi/max32/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,8 +30,9 @@ BUILD_ASSERT(DT_HAS_CHOSEN(zephyr_code_rv32_partition),
 struct k_timer max32_soc_timer;
 void max32_soc_timer_callback(struct k_timer *timer_id)
 {
-	/* Allow the system to enter standby */
+	/* Allow the system to enter standby and backup mode */
 	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 }
 #endif /* defined(MAX32_STANDBY_DELAY) && (MAX32_STANDBY_DELAY > 0) */
 
@@ -96,8 +97,9 @@ void soc_early_init_hook(void)
 
 	/* Temporarily prevent  the system from entering standby to prevent debug lockout */
 #if defined(CONFIG_MAX32_STANDBY_DELAY) && (CONFIG_MAX32_STANDBY_DELAY > 0)
-	/* Prevent the system from entering standby mode */
+	/* Prevent the system from entering standby and backup mode */
 	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 
 	/* Start a one-shot timer to put the pm lock */
 	k_timer_init(&max32_soc_timer, max32_soc_timer_callback, NULL);


### PR DESCRIPTION
Save and restore SCB, NVIC, MPU and FPU registers across suspend-to-ram.