### PR TITLE
Bluetooth Host: Defer disconnect on TX failure

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -520,6 +520,12 @@ void ull_periph_latency_cancel(struct ll_conn *conn, uint16_t handle)
 				      0, 0, 0, 0, 1, 0,
 				      ticker_update_latency_cancel_op_cb,
 				      (void *)conn);
+		if ((ticker_status == TICKER_STATUS_FAILURE) &&
+		    (conn->lll.handle == LLL_HANDLE_INVALID)) {
+			conn->periph.latency_cancel = 0U;
+			return;
+		}
+
 		LL_ASSERT_ERR((ticker_status == TICKER_STATUS_SUCCESS) ||
 			      (ticker_status == TICKER_STATUS_BUSY));
 	}
@@ -680,7 +686,9 @@ static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
 {
 	struct ll_conn *conn = param;
 
-	LL_ASSERT_ERR(ticker_status == TICKER_STATUS_SUCCESS);
+	LL_ASSERT_ERR((ticker_status == TICKER_STATUS_SUCCESS) ||
+		      ((ticker_status == TICKER_STATUS_FAILURE) &&
+		       (conn->lll.handle == LLL_HANDLE_INVALID)));
 
 	conn->periph.latency_cancel = 0U;
 }

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -336,6 +336,8 @@ static void tx_notify_process(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_CONN_TX */
 
+
+
 void bt_conn_tx_notify(struct bt_conn *conn, bool wait_for_completion)
 {
 #if defined(CONFIG_BT_CONN_TX)
@@ -1068,9 +1070,27 @@ void bt_conn_tx_processor(void)
 	int err = send_buf(conn, buf, buf_len, cb, ud);
 
 	if (err) {
+		int submit_err;
+
 		LOG_ERR("Fatal error (%d). Disconnecting %p", err, conn);
-		bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-		goto exit;
+		bt_conn_set_state(conn, BT_CONN_DISCONNECTING);
+		atomic_set_bit(conn->flags, BT_CONN_TX_DISCONNECT_PENDING);
+		bt_conn_ref(conn);
+		submit_err = k_work_submit(&conn->tx_complete_work);
+		__ASSERT(submit_err >= 0, "Failed to submit disconnect work (err %d)",
+			 submit_err);
+		if (submit_err < 0) {
+			LOG_ERR("Failed to submit disconnect work for %p (err %d)", conn,
+				submit_err);
+			atomic_clear_bit(conn->flags, BT_CONN_TX_DISCONNECT_PENDING);
+			bt_conn_set_state(conn, BT_CONN_CONNECTED);
+			bt_conn_unref(conn);
+		} else if (submit_err == 0) {
+			bt_conn_unref(conn);
+		} else {
+			/* Work successfully submitted, handler will drop the reference */
+		}
+		goto raise_and_exit;
 	}
 
 raise_and_exit:
@@ -1637,7 +1657,21 @@ static void tx_complete_work(struct k_work *work)
 {
 	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn, tx_complete_work);
 
-	tx_notify_process(conn);
+	if (atomic_test_and_clear_bit(conn->flags, BT_CONN_TX_DISCONNECT_PENDING)) {
+		/* Handle deferred disconnect from TX processor */
+		int err;
+
+		err = bt_hci_disconnect(conn->handle, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+		if (err) {
+			LOG_ERR("Failed to disconnect %p (err %d)", conn, err);
+			bt_conn_set_state(conn, BT_CONN_CONNECTED);
+		}
+
+		bt_conn_drop(&conn);
+	} else {
+		/* Normal TX completion processing */
+		tx_notify_process(conn);
+	}
 }
 #endif /* CONFIG_BT_CONN_TX */
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -98,6 +98,8 @@ enum {
 	BT_CONN_CTE_REQ_ENABLED,              /* CTE request procedure is enabled */
 	BT_CONN_CTE_RSP_ENABLED,              /* CTE response procedure is enabled */
 
+	BT_CONN_TX_DISCONNECT_PENDING,        /* TX work should disconnect instead of notify */
+
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,
 };


### PR DESCRIPTION
Defer disconnection when `send_buf()` fails in the dedicated Bluetooth TX processor.

Calling `bt_conn_disconnect()` directly from `bt_conn_tx_processor()` can deadlock when `CONFIG_BT_TX_PROCESSOR_THREAD=y`. Synchronous HCI Disconnect command is queued for processing by the same workqueue that is currently waiting for its completion.

This change schedules the disconnect on the system workqueue instead. It holds a connection reference until the deferred work completes to prevent the connection object from being released prematurely.
Stress test before:
<img width="1027" height="587" alt="image" src="https://github.com/user-attachments/assets/8d63348d-5de8-4506-914b-cafae12397aa" />

Stress test after:
<img width="901" height="604" alt="image" src="https://github.com/user-attachments/assets/e27e8bf8-6ece-4d65-be91-271479414a76" />
