### PR TITLE
manifest: Bring TF-M with nRF91ns fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: f2f7a8edd109825de35b0c239c8fbb77b06f24a2
+      revision: 79823893d870345e944f9acb59f08b5e3a3c55a8
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Brings an update which allows the nRF91 series
devices to access the FICR information from the non secure application using the TF-M memory read service.

The FICR contains non-sensitive information about
the chip, and it is required by some applications
so allow reading it.