### PR TITLE
drivers: mfd: npm10xx: use _SAFE slist walk macro in events_handler

### DIFF
--- a/drivers/mfd/mfd_npm10xx.c
+++ b/drivers/mfd/mfd_npm10xx.c
@@ -168,7 +168,7 @@ static void events_handler(struct k_work *work)
 	const struct mfd_npm10xx_config *config = data->mfd->config;
 	uint8_t buf[EVENTS_REG_NUM];
 	int ret;
-	struct mfd_npm10xx_event_callback *cb;
+	struct mfd_npm10xx_event_callback *cb, *tmp;
 	uint64_t events = 0U;
 	uint64_t handled = 0U;
 
@@ -182,7 +182,7 @@ static void events_handler(struct k_work *work)
 		events |= (uint64_t)buf[idx] << (idx * 8);
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&data->user_callbacks, cb, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&data->user_callbacks, cb, tmp, node) {
 		if (cb->event_mask & events) {
 			cb->handler(data->mfd, cb, cb->event_mask & events);
 			handled |= cb->event_mask & events;


### PR DESCRIPTION
Using the unsafe walk might result in some handlers being silently dropped when one of the callbacks removes itself from the list breaking the loop. Use the safe walk instead to avoid this.