### PR TITLE
Bluetooth Controller: Handle latency cancel during teardown

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -520,6 +520,12 @@ void ull_periph_latency_cancel(struct ll_conn *conn, uint16_t handle)
 				      0, 0, 0, 0, 1, 0,
 				      ticker_update_latency_cancel_op_cb,
 				      (void *)conn);
+		if ((ticker_status == TICKER_STATUS_FAILURE) &&
+		    (conn->lll.handle == LLL_HANDLE_INVALID)) {
+			conn->periph.latency_cancel = 0U;
+			return;
+		}
+
 		LL_ASSERT_ERR((ticker_status == TICKER_STATUS_SUCCESS) ||
 			      (ticker_status == TICKER_STATUS_BUSY));
 	}
@@ -680,7 +686,9 @@ static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
 {
 	struct ll_conn *conn = param;
 
-	LL_ASSERT_ERR(ticker_status == TICKER_STATUS_SUCCESS);
+	LL_ASSERT_ERR((ticker_status == TICKER_STATUS_SUCCESS) ||
+		      ((ticker_status == TICKER_STATUS_FAILURE) &&
+		       (conn->lll.handle == LLL_HANDLE_INVALID)));
 
 	conn->periph.latency_cancel = 0U;
 }


### PR DESCRIPTION
Added handling connection teardown races while cancelling peripheral latency. `ull_periph_latency_cancel()` may race with disconnection after an ACL packet is submitted. The connection ticker can already be stopped and the connection handle invalidated when `ticker_update()` is processed. This produces `TICKER_STATUS_FAILURE` in two cases:
- returned directly by `ticker_update()`;
- delivered later through `ticker_update_latency_cancel_op_cb()`.

Both paths previously triggered `LL_ASSERT_ERR`, causing a UsageFault and stopping the controller.
`TICKER_STATUS_FAILURE` is being accepted only when the connection handle is already `LLL_HANDLE_INVALID`. The pending `latency_cancel` flag is then cleared. Failures for active connections remain assertions and are not hidden.

Tested on an nRF52840 using repeated BLE connections, active NUS notifications, and disconnects.
Two post-morter debug captures reproduced both race variants. In each case, the connection was already being terminated, with:
- `lll.handle == LLL_HANDLE_INVALID`;
- termination reason `0x13`;
- `latency_cancel == 1`.

Before the change, the device eventually stopped advertising due to the controller assertion. After applying both paths of this fix, more than 1000 disconnect cycles completed without reproducing the fault.

Before:
<img width="704" height="380" alt="image" src="https://github.com/user-attachments/assets/0a891bed-a229-4508-a536-51a8c73fc0c3" />
After:
<img width="727" height="804" alt="image" src="https://github.com/user-attachments/assets/8dd647fd-4763-4192-bc83-d27e29888af0" />

There are some smaller issues but i have confirmed they are related to Windows not the application and are not causing the board to crash:
<img width="720" height="63" alt="image" src="https://github.com/user-attachments/assets/852e6410-79bc-4a1b-8d49-4a1d23a9fdbb" />
<img width="916" height="67" alt="image" src="https://github.com/user-attachments/assets/a0e18502-0f12-4fe3-86a3-48b65f1e8d2d" />
<img width="875" height="85" alt="image" src="https://github.com/user-attachments/assets/838acd1f-7e60-401c-9015-7ce6d1d7793e" />

Test results:
[ble_disconnect_stress.csv](https://github.com/user-attachments/files/30654293/ble_disconnect_stress.csv)
