### PR TITLE
lib: cbprintf: Set appropriate source macro and do not define prototype

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* for strnlen() */
+
 #include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -17,11 +20,6 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/cbprintf.h>
-
-/* newlib doesn't declare this function unless __POSIX_VISIBLE >= 200809.  No
- * idea how to make that happen, so lets put it right here.
- */
-size_t strnlen(const char *s, size_t maxlen);
 
 /* Provide typedefs used for signed and unsigned integral types
  * capable of holding all convertible integral values.


### PR DESCRIPTION
User code should not re-define prototypes defined in C library headers, but, for prototypes of extensions (like strnlen()) should request them by setting the appropriate [feature test macro](https://man7.org/linux/man-pages/man7/feature_test_macros.7.html).

So, instead of defining the strnlen() prototype in the user code, let's set the appropriate SOURCE macro and get the prototype from its header (string.h).

(Note __POSIX_VISIBLE is an internal C library macro which newlib/pico set when the user sets _POSIX_C_SOURCE )

References:
https://man7.org/linux/man-pages/man7/feature_test_macros.7.html
https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.5/html_node/Feature-Test-Macros.html