### PR TITLE
 tests: drivers: flash: add nrf7120dk NAND support to interface_test

### DIFF
--- a/tests/drivers/flash/interface_test/boards/nrf7120dk_nrf7120_cpuapp_w25n01gv.overlay
+++ b/tests/drivers/flash/interface_test/boards/nrf7120dk_nrf7120_cpuapp_w25n01gv.overlay
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &slot1_partition;
+
+&pinctrl {
+	spi22_default: spi22_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 15)>;
+		};
+
+		nordic,drive-mode = <NRF_DRIVE_H0H1>;
+	};
+
+	spi22_sleep: spi22_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 15)>;
+		};
+
+		low-power-enable;
+	};
+};
+
+spi_flash: &spi22 {
+	status = "okay";
+	pinctrl-0 = <&spi22_default>;
+	pinctrl-1 = <&spi22_sleep>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+	overrun-character = <0x00>;
+
+	w25n01gv: spi-nand@0 {
+		compatible = "jedec,spi-nand";
+		reg = <0>;
+		status = "okay";
+		spi-max-frequency = <2000000>;
+
+		/* w25n01gv parameters */
+		jedec-id = [ef aa 21];
+		size-bytes = <DT_SIZE_M(128)>;
+		plane-bytes = <DT_SIZE_M(128)>;
+		erase-block-size = <DT_SIZE_K(128)>;
+		write-block-size = <DT_SIZE_K(2)>;
+		block-erase-duration-max = <10000>;
+		page-program-duration-max = <700>;
+		page-read-duration-max = <200>;
+		reset-duration-max = <500>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@0 {
+				label = "image-1";
+				reg = <0x0 DT_SIZE_M(2)>;
+			};
+		};
+	};
+};

--- a/tests/drivers/flash/interface_test/tests.yaml
+++ b/tests/drivers/flash/interface_test/tests.yaml
@@ -25,10 +25,10 @@ tests:
     extra_configs:
       - CONFIG_TEST_SEQUENTIAL_READ_PATTERN_AMOUNT=50000
       - CONFIG_TEST_SEQUENTIAL_ALTERNATING_READ_PATTERN_AMOUNT=25000
-      - CONFIG_FLASH_EX_OP_ENABLED=y
     extra_args:
       - FILE_SUFFIX="w25n01gv"
       - EXTRA_CONF_FILE="boards/w25n01gv.conf"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     timeout: 900


### PR DESCRIPTION
This PR adds support for interface_test through the Mikroe Flash 5 Click to the nrf7120dk

Note that it depends on #112975 for NAND support in interface_test in general