### PR TITLE
sip_svc: fix Agilex5 SiP mailbox communication with TF-A

### DIFF
--- a/drivers/sip_svc/sip_smc_intel_socfpga.c
+++ b/drivers/sip_svc/sip_smc_intel_socfpga.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/sip_svc/sip_svc_agilex_smc.h>
 #include <zephyr/drivers/sip_svc/sip_svc_driver.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/cache.h>
 
 #include <zephyr/logging/log.h>
 
@@ -97,6 +98,7 @@ static void intel_sip_smc_plat_update_trans_id(const struct device *dev,
 	if ((void *)request->a2 != NULL) {
 		data = (uint32_t *)request->a2;
 		SIP_SVC_MB_HEADER_SET_TRANS_ID(data[0], trans_id);
+		sys_cache_data_flush_range(data, request->a3);
 	}
 }
 
@@ -121,6 +123,8 @@ static int intel_sip_smc_plat_async_res_req(const struct device *dev, unsigned l
 {
 	ARG_UNUSED(dev);
 
+	sys_cache_data_flush_range(buf, size);
+
 	/* Fill in SMC parameter to read mailbox response */
 	*a0 = SMC_FUNC_ID_MAILBOX_POLL_RESPONSE;
 	*a1 = 0;
@@ -135,10 +139,22 @@ static int intel_sip_smc_plat_async_res_res(const struct device *dev, struct arm
 {
 	ARG_UNUSED(dev);
 	uint32_t *resp = (uint32_t *)buf;
+	size_t inv_len;
 
 	__ASSERT((res && buf && size && trans_id), "invalid parameters\n");
 
 	if (((long)res->a0) <= SMC_STATUS_OKAY) {
+		/*
+		 * TF-A returned OK with a3==0 for header-only
+		 * mailbox responses (e.g. CANCEL). Invalidate at least the
+		 * header word so EL1 does not reuse a stale cached header.
+		 */
+		inv_len = res->a3;
+		if (inv_len < sizeof(uint32_t)) {
+			inv_len = sizeof(uint32_t);
+		}
+		sys_cache_data_invd_range(resp, inv_len);
+
 		/* Extract transaction id from mailbox response header */
 		*trans_id = SIP_SVC_MB_HEADER_GET_TRANS_ID(resp[0]);
 		/* The final length should include both header and body */

--- a/drivers/sip_svc/sip_smc_intel_socfpga.c
+++ b/drivers/sip_svc/sip_smc_intel_socfpga.c
@@ -14,6 +14,10 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/cache.h>
 
+#if defined(CONFIG_SOC_AGILEX5)
+#include <zephyr/drivers/sip_svc/sip_svc_agilex_mbox_ddr.h>
+#endif
+
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(intel_socfpga_agilex_sip_smc, CONFIG_ARM_SIP_SVC_DRIVER_LOG_LEVEL);
@@ -67,9 +71,14 @@ static uint32_t intel_sip_smc_plat_format_trans_id(const struct device *dev, uin
 						   uint32_t trans_idx)
 {
 	ARG_UNUSED(dev);
+	ARG_UNUSED(client_idx);
 
-	/* Combine the transaction id and client id to get the job id*/
-	return (((client_idx & 0xF) << 4) | (trans_idx & 0xF));
+	/*
+	 * Encode TF-A mailbox client/job in the SMC a1 byte and mailbox
+	 * header byte at offset 24. TF-A SIP SVC V3 async poll matches
+	 * responses on MBOX_ATF_CLIENT_ID, not the sip_svc client index.
+	 */
+	return (((SIP_SVC_MBOX_ATF_CLIENT_ID & 0xF) << 4) | (trans_idx & 0xF));
 }
 
 static uint32_t intel_sip_smc_plat_get_trans_idx(const struct device *dev, uint32_t trans_id)
@@ -112,7 +121,13 @@ static void intel_sip_smc_plat_free_async_memory(const struct device *dev,
 	 * process the async request.
 	 */
 	if (request->a2) {
+#if defined(CONFIG_SOC_AGILEX5)
+		if (!sip_svc_is_mbox_ddr_buffer((void *)request->a2)) {
+			k_free((void *)request->a2);
+		}
+#else
 		k_free((void *)request->a2);
+#endif
 	}
 }
 

--- a/dts/arm64/intel/intel_socfpga_agilex5.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex5.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/reset/intel_socfpga_reset.h>
 #include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm64.h>
 #include <mem.h>
 
 / {
@@ -97,6 +98,14 @@
 	mem0: memory@80100000 {
 		device_type = "memory";
 		reg = <0x80100000 DT_SIZE_M(8)>;
+	};
+
+	/* SiP mailbox buffers for TF-A (must be >= BL31_LIMIT) */
+	mbox_ddr: memory@82000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x82000000 0x10000>;
+		zephyr,memory-region = "MBOX_DDR";
+		zephyr,memory-attr = <DT_MEM_ARM64_MMU_NORMAL>;
 	};
 
 	fpga0: bridges {

--- a/include/zephyr/drivers/sip_svc/sip_svc_agilex_mailbox.h
+++ b/include/zephyr/drivers/sip_svc/sip_svc_agilex_mailbox.h
@@ -21,6 +21,27 @@
 #define SIP_SVP_MB_HEADER_LENGTH_OFFSET		12
 #define SIP_SVP_MB_HEADER_LENGTH_MASK		0x7FF
 
+/** @brief Bit offset of the SDM mailbox header job ID field */
+#define SIP_SVP_MB_HEADER_JOB_ID_OFFSET		24
+
+/** @brief Bit mask of the SDM mailbox header job ID field */
+#define SIP_SVP_MB_HEADER_JOB_ID_MASK		0xF
+
+/** @brief Bit offset of the SDM mailbox header client ID field */
+#define SIP_SVP_MB_HEADER_CLIENT_ID_OFFSET	28
+
+/** @brief Bit mask of the SDM mailbox header client ID field */
+#define SIP_SVP_MB_HEADER_CLIENT_ID_MASK	0xF
+
+/**
+ * @brief TF-A mailbox client ID used for SiP V2 async poll matching
+ *
+ * TF-A routes async mailbox responses for the SiP V2 path through the V3
+ * service using MBOX_ATF_CLIENT_ID. The mailbox header client/job fields
+ * (and matching SMC a1 byte) must use this value, not the sip_svc client index.
+ */
+#define SIP_SVC_MBOX_ATF_CLIENT_ID		0x1U
+
 #define SIP_SVC_MB_HEADER_GET_CLIENT_ID(header) \
 	((header) >> SIP_SVP_MB_HEADER_CLIENT_ID_OFFSET & \
 		SIP_SVP_MB_HEADER_CLIENT_ID_MASK)

--- a/include/zephyr/drivers/sip_svc/sip_svc_agilex_mbox_ddr.h
+++ b/include/zephyr/drivers/sip_svc/sip_svc_agilex_mbox_ddr.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SIP_SVC_AGILEX_MBOX_DDR_H_
+#define ZEPHYR_INCLUDE_SIP_SVC_AGILEX_MBOX_DDR_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/devicetree.h>
+
+/**
+ * @file
+ * @brief DDR mailbox buffer region for Agilex5 SiP SMC.
+ *
+ * External TF-A validates mailbox command buffers with is_address_in_ddr_range(),
+ * which requires addresses >= BL31_LIMIT (0x82000000) on Agilex5. Zephyr SRAM
+ * (mem0 @ 0x80100000) is below that limit, so mailbox buffers must be placed
+ * in the MBOX_DDR linker region defined in devicetree.
+ */
+
+#if DT_NODE_EXISTS(DT_NODELABEL(mbox_ddr))
+/** @brief Base address of the Agilex5 MBOX_DDR mailbox buffer region */
+#define SOCFPGA_MBOX_DDR_BASE	DT_REG_ADDR(DT_NODELABEL(mbox_ddr))
+/** @brief Size in bytes of the Agilex5 MBOX_DDR mailbox buffer region */
+#define SOCFPGA_MBOX_DDR_SIZE	DT_REG_SIZE(DT_NODELABEL(mbox_ddr))
+#else
+/** @brief Base address of the Agilex5 MBOX_DDR mailbox buffer region */
+#define SOCFPGA_MBOX_DDR_BASE	0x82000000UL
+/** @brief Size in bytes of the Agilex5 MBOX_DDR mailbox buffer region */
+#define SOCFPGA_MBOX_DDR_SIZE	0x00010000UL
+#endif
+
+/** @brief Place an object in the MBOX_DDR linker section */
+#define SOCFPGA_MBOX_DDR __attribute__((section("MBOX_DDR")))
+
+/**
+ * @brief Check whether a pointer lies in the MBOX_DDR mailbox region
+ *
+ * @param ptr Buffer address to test
+ *
+ * @retval true if @p ptr is within [SOCFPGA_MBOX_DDR_BASE, BASE+SIZE)
+ * @retval false otherwise
+ */
+static inline bool sip_svc_is_mbox_ddr_buffer(const void *ptr)
+{
+	uintptr_t addr = (uintptr_t)ptr;
+
+	return addr >= SOCFPGA_MBOX_DDR_BASE &&
+	       addr < (SOCFPGA_MBOX_DDR_BASE + SOCFPGA_MBOX_DDR_SIZE);
+}
+
+#endif /* ZEPHYR_INCLUDE_SIP_SVC_AGILEX_MBOX_DDR_H_ */

--- a/include/zephyr/sip_svc/sip_svc.h
+++ b/include/zephyr/sip_svc/sip_svc.h
@@ -121,7 +121,10 @@ int sip_svc_open(void *ctrl, uint32_t c_token, k_timeout_t k_timeout);
 /**
  * @brief Client requests to close the channel on ARM SiP services.
  *
- * Client must close the channel immediately once complete.
+ * Client must close the channel immediately once complete. If a pre-close
+ * request is provided or pending transactions exist, this function waits for
+ * all associated transactions to complete and the client to reach IDLE state
+ * before returning success.
  *
  * @param ctrl Pointer to controller instance which provides ARM SiP services.
  * @param c_token Client's token
@@ -131,6 +134,7 @@ int sip_svc_open(void *ctrl, uint32_t c_token, k_timeout_t k_timeout);
  * @retval -EINVAL invalid arguments.
  * @retval -ENOTSUP error on sending pre_close_request.
  * @retval -EPROTO client is not in OPEN state.
+ * @retval -ETIMEDOUT timed out waiting for pending transactions to complete.
  */
 int sip_svc_close(void *ctrl, uint32_t c_token, struct sip_svc_request *pre_close_req);
 

--- a/include/zephyr/sip_svc/sip_svc_controller.h
+++ b/include/zephyr/sip_svc/sip_svc_controller.h
@@ -81,6 +81,8 @@ struct sip_svc_controller {
 	uint8_t *async_resp_data;
 	/* Thread id of sip_svc thread */
 	k_tid_t tid;
+	/*Blocks the internal thread until a new transaction is enqueued*/
+	struct k_sem thread_sem;
 
 #if CONFIG_ARM_SIP_SVC_SUBSYS_SINGLY_OPEN
 	/* Atomic variable to restrict one client access */
@@ -107,12 +109,14 @@ struct sip_svc_controller {
 		((sip_num_clients <= CONFIG_ARM_SIP_SVC_SUBSYS_MAX_CLIENT_COUNT) &&                \
 		 (sip_num_clients > 0)),                                                           \
 		"Number of client should be within 1 and ARM_SIP_SVC_SUBSYS_MAX_CLIENT_COUNT");    \
+	static uint8_t async_resp_buf##inst[sip_resp_size] __aligned(64);                          \
 	static STRUCT_SECTION_ITERABLE(sip_svc_controller, sip_svc_##inst) = {                     \
 		.method = conduit_name,                                                            \
 		.dev = sip_dev,                                                                    \
 		.num_clients = sip_num_clients,                                                    \
 		.max_transactions = sip_max_transactions,                                          \
 		.resp_size = sip_resp_size,                                                        \
+		.async_resp_data = async_resp_buf##inst,                                           \
 	}
 
 #else

--- a/include/zephyr/sip_svc/sip_svc_controller.h
+++ b/include/zephyr/sip_svc/sip_svc_controller.h
@@ -103,13 +103,20 @@ struct sip_svc_controller {
  * Each sip_svc driver will use this API to instantiate a controller for sip_svc
  * subsystem to consume, for more details check @ref ITERABLE_SECTION_RAM()
  */
+#if defined(CONFIG_SOC_AGILEX5)
+#define SIP_SVC_ASYNC_RESP_BUF_SEC __attribute__((section("MBOX_DDR")))
+#else
+#define SIP_SVC_ASYNC_RESP_BUF_SEC
+#endif
+
 #define SIP_SVC_CONTROLLER_DEFINE(inst, conduit_name, sip_dev, sip_num_clients,                    \
 				  sip_max_transactions, sip_resp_size)                             \
 	BUILD_ASSERT(                                                                              \
 		((sip_num_clients <= CONFIG_ARM_SIP_SVC_SUBSYS_MAX_CLIENT_COUNT) &&                \
 		 (sip_num_clients > 0)),                                                           \
 		"Number of client should be within 1 and ARM_SIP_SVC_SUBSYS_MAX_CLIENT_COUNT");    \
-	static uint8_t async_resp_buf##inst[sip_resp_size] __aligned(64);                          \
+	static SIP_SVC_ASYNC_RESP_BUF_SEC uint8_t async_resp_buf##inst[sip_resp_size]              \
+		__aligned(64);                                                                     \
 	static STRUCT_SECTION_ITERABLE(sip_svc_controller, sip_svc_##inst) = {                     \
 		.method = conduit_name,                                                            \
 		.dev = sip_dev,                                                                    \

--- a/samples/subsys/sip_svc/src/main.c
+++ b/samples/subsys/sip_svc/src/main.c
@@ -14,6 +14,10 @@
 #include <zephyr/drivers/sip_svc/sip_svc_agilex_smc.h>
 #include <zephyr/sys/__assert.h>
 
+#if defined(CONFIG_SOC_AGILEX5)
+#include <zephyr/drivers/sip_svc/sip_svc_agilex_mbox_ddr.h>
+#endif
+
 #define SVC_METHOD	       "smc"
 #define GET_VOLTAGE_CMD	       (0x18U)
 #define SET_VOLTAGE_CHANNEL(x) ((1 << (x)) & 0xffff)
@@ -23,6 +27,11 @@ struct private_data {
 	struct k_sem semaphore;
 	uint32_t voltage_channel0;
 };
+
+#if defined(CONFIG_SOC_AGILEX5)
+static SOCFPGA_MBOX_DDR uint32_t mbox_cmd_buf[2] __aligned(64);
+static SOCFPGA_MBOX_DDR uint32_t mbox_resp_buf[2] __aligned(64);
+#endif
 
 void get_voltage_callback(uint32_t c_token, struct sip_svc_response *response)
 {
@@ -55,8 +64,12 @@ int main(void)
 	float voltage;
 	int err, trans_id;
 
+#if defined(CONFIG_SOC_AGILEX5)
+	resp_addr = mbox_resp_buf;
+#else
 	resp_addr = (uint32_t *)k_malloc(resp_size);
 	__ASSERT(resp_addr != NULL, "Failed to get memory");
+#endif
 
 	mb_smc_ctrl = sip_svc_get_controller(SVC_METHOD);
 	__ASSERT(mb_smc_ctrl != NULL, "Failed to get the controller from sip_svc");
@@ -76,8 +89,12 @@ int main(void)
 		err = sip_svc_open(mb_smc_ctrl, mb_c_token, K_FOREVER);
 		__ASSERT(err != SIP_SVC_ID_INVALID, "Failed to open with sip_svc");
 
+#if defined(CONFIG_SOC_AGILEX5)
+		cmd_addr = mbox_cmd_buf;
+#else
 		cmd_addr = (uint32_t *)k_malloc(cmd_size);
 		__ASSERT(cmd_addr != NULL, "Failed to get memory");
+#endif
 
 		/**
 		 * Populate the SDM mailbox command ,where first word will be the header,

--- a/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
+++ b/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
@@ -15,6 +15,10 @@
 #include <string.h>
 #include <errno.h>
 
+#if defined(CONFIG_SOC_AGILEX5)
+#include <zephyr/drivers/sip_svc/sip_svc_agilex_mbox_ddr.h>
+#endif
+
 #define MAX_TIMEOUT_MSECS (1 * 1000UL)
 
 struct private_data {
@@ -24,6 +28,12 @@ struct private_data {
 
 static void *mb_smc_ctrl;
 static uint32_t mb_c_token = SIP_SVC_ID_INVALID;
+
+#if defined(CONFIG_SOC_AGILEX5)
+static SOCFPGA_MBOX_DDR uint32_t mbox_cmd_buf[SIP_SVP_MB_MAX_WORD_SIZE] __aligned(64);
+static SOCFPGA_MBOX_DDR uint32_t mbox_resp_buf[SIP_SVP_MB_MAX_WORD_SIZE] __aligned(64);
+static SOCFPGA_MBOX_DDR uint32_t mbox_cancel_cmd __aligned(4);
+#endif
 
 static int cmd_reg(const struct shell *sh, size_t argc, char **argv)
 {
@@ -124,6 +134,9 @@ static int cmd_close(const struct shell *sh, size_t argc, char **argv)
 		return 0;
 	}
 
+#if defined(CONFIG_SOC_AGILEX5)
+	mbox_cancel_cmd = MAILBOX_CANCEL_COMMAND;
+#else
 	uint32_t *cmd_addr = k_malloc(cmd_size);
 
 	if (!cmd_addr) {
@@ -131,11 +144,16 @@ static int cmd_close(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	*cmd_addr = MAILBOX_CANCEL_COMMAND;
+#endif
 
 	request.header = SIP_SVC_PROTO_HEADER(SIP_SVC_PROTO_CMD_ASYNC, 0);
 	request.a0 = SMC_FUNC_ID_MAILBOX_SEND_COMMAND;
 	request.a1 = 0;
+#if defined(CONFIG_SOC_AGILEX5)
+	request.a2 = (uint64_t)&mbox_cancel_cmd;
+#else
 	request.a2 = (uint64_t)cmd_addr;
+#endif
 	request.a3 = (uint64_t)cmd_size;
 	request.a4 = 0;
 	request.a5 = 0;
@@ -147,7 +165,9 @@ static int cmd_close(const struct shell *sh, size_t argc, char **argv)
 
 	err = sip_svc_close(mb_smc_ctrl, mb_c_token, &request);
 	if (err) {
+#if !defined(CONFIG_SOC_AGILEX5)
 		k_free(cmd_addr);
+#endif
 		shell_error(sh, "Mailbox client close fail (%d)", err);
 	} else {
 		shell_print(sh, "Mailbox client close success");
@@ -192,7 +212,9 @@ static void cmd_send_callback(uint32_t c_token, struct sip_svc_response *respons
 	 */
 	if (resp_data) {
 		shell_print(sh, "response data %p is freed\n", resp_data);
+#if !defined(CONFIG_SOC_AGILEX5)
 		k_free((char *)resp_data);
+#endif
 	}
 
 	k_sem_give(&(priv->semaphore));
@@ -212,18 +234,24 @@ static int parse_mb_data(const struct shell *sh, char *hex_list, char **cmd_addr
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_SOC_AGILEX5)
+	*cmd_addr = (char *)mbox_cmd_buf;
+#else
 	*cmd_addr = k_malloc(SIP_SVP_MB_MAX_WORD_SIZE * 4);
 	if (!*cmd_addr) {
 		shell_error(sh, "Fail to allocate command memory");
 		return -ENOMEM;
 	}
+#endif
 
 	buffer = (uint32_t *)*cmd_addr;
 	hex_str = strtok_r(hex_str, " ", &state);
 
 	while (hex_str) {
 		if (i >= SIP_SVP_MB_MAX_WORD_SIZE) {
+#if !defined(CONFIG_SOC_AGILEX5)
 			k_free(*cmd_addr);
+#endif
 			shell_error(sh, "Mailbox length too long");
 			return -EOVERFLOW;
 		}
@@ -231,10 +259,14 @@ static int parse_mb_data(const struct shell *sh, char *hex_list, char **cmd_addr
 		hex_val = strtoul(hex_str, &endptr, 16);
 		if (errno == ERANGE) {
 			shell_error(sh, " Value is out of range value");
+#if !defined(CONFIG_SOC_AGILEX5)
 			k_free(*cmd_addr);
+#endif
 			return -ERANGE;
 		} else if (errno || endptr == hex_str || *endptr) {
+#if !defined(CONFIG_SOC_AGILEX5)
 			k_free(*cmd_addr);
+#endif
 			shell_error(sh, " Invalid argument");
 			return -EINVAL;
 		}
@@ -289,12 +321,16 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 		}
 	}
 
+#if defined(CONFIG_SOC_AGILEX5)
+	resp_addr = (char *)mbox_resp_buf;
+#else
 	resp_addr = k_malloc(SIP_SVP_MB_MAX_WORD_SIZE * 4);
 	if (!resp_addr) {
 		k_free(cmd_addr);
 		shell_error(sh, "Fail to allocate response memory");
 		return -ENOMEM;
 	}
+#endif
 	shell_print(sh, "\tResponse memory %p\n", (char *)resp_addr);
 
 	k_sem_init(&(priv.semaphore), 0, 1);
@@ -317,8 +353,10 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 
 	if (trans_id < 0) {
 		shell_error(sh, "Mailbox send fail (no open or no free trans_id)");
+#if !defined(CONFIG_SOC_AGILEX5)
 		k_free(cmd_addr);
 		k_free(resp_addr);
+#endif
 		err = -EBUSY;
 	} else {
 		/*wait for callback*/

--- a/subsys/sip_svc/sip_svc_subsys.c
+++ b/subsys/sip_svc/sip_svc_subsys.c
@@ -117,6 +117,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sip_svc_subsys, CONFIG_ARM_SIP_SVC_SUBSYS_LOG_LEVEL);
 
+#define SIP_SVC_CLOSE_DRAIN_TIMEOUT K_MSEC(1000)
+
 static uint32_t sip_svc_generate_c_token(void)
 {
 	uint32_t c_token = k_cycle_get_32();
@@ -339,10 +341,49 @@ int sip_svc_open(void *ct, uint32_t c_token, k_timeout_t k_timeout)
 	return -ETIMEDOUT;
 }
 
+static int sip_svc_wait_client_idle(struct sip_svc_controller *ctrl, uint32_t c_token,
+				    k_timeout_t k_timeout)
+{
+	uint32_t c_idx;
+	int ret;
+	struct k_timer timer;
+
+	k_timer_init(&timer, NULL, NULL);
+
+	for (bool first_iteration = false; get_timer_status(&first_iteration, &timer, k_timeout);
+	     k_usleep(CONFIG_ARM_SIP_SVC_SUBSYS_ASYNC_POLLING_DELAY)) {
+		ret = k_mutex_lock(&ctrl->data_mutex, K_NO_WAIT);
+		if (ret != 0) {
+			continue;
+		}
+
+		c_idx = sip_svc_get_c_idx(ctrl, c_token);
+		if (c_idx == SIP_SVC_ID_INVALID) {
+			k_mutex_unlock(&ctrl->data_mutex);
+			k_timer_stop(&timer);
+			return -EINVAL;
+		}
+
+		if (ctrl->clients[c_idx].active_trans_cnt == 0 &&
+		    ctrl->clients[c_idx].state == SIP_SVC_CLIENT_ST_IDLE) {
+			k_mutex_unlock(&ctrl->data_mutex);
+			k_timer_stop(&timer);
+			return 0;
+		}
+
+		k_mutex_unlock(&ctrl->data_mutex);
+	}
+
+	k_timer_stop(&timer);
+	LOG_ERR("Timed out waiting for client 0x%x to become idle", c_token);
+	return -ETIMEDOUT;
+}
+
 int sip_svc_close(void *ct, uint32_t c_token, struct sip_svc_request *pre_close_req)
 {
 	uint32_t c_idx;
 	int err;
+	bool need_drain = false;
 
 	if (ct == NULL || !is_sip_svc_controller(ct)) {
 		return -EINVAL;
@@ -379,6 +420,7 @@ int sip_svc_close(void *ct, uint32_t c_token, struct sip_svc_request *pre_close_
 
 	if (ctrl->clients[c_idx].active_trans_cnt != 0) {
 		ctrl->clients[c_idx].state = SIP_SVC_CLIENT_ST_ABORT;
+		need_drain = true;
 	} else {
 		ctrl->clients[c_idx].state = SIP_SVC_CLIENT_ST_IDLE;
 	}
@@ -388,7 +430,14 @@ int sip_svc_close(void *ct, uint32_t c_token, struct sip_svc_request *pre_close_
 #endif
 	k_mutex_unlock(&ctrl->data_mutex);
 
-	LOG_INF("Close the client channel 0x%x", ctrl->clients[c_idx].token);
+	if (need_drain) {
+		err = sip_svc_wait_client_idle(ctrl, c_token, SIP_SVC_CLOSE_DRAIN_TIMEOUT);
+		if (err != 0) {
+			return err;
+		}
+	}
+
+	LOG_INF("Close the client channel 0x%x", c_token);
 	return 0;
 }
 

--- a/subsys/sip_svc/sip_svc_subsys.c
+++ b/subsys/sip_svc/sip_svc_subsys.c
@@ -663,7 +663,7 @@ static void sip_svc_thread(void *ctrl_ptr, void *arg2, void *arg3)
 			}
 		}
 		LOG_INF("Suspend thread, all transactions are completed");
-		k_thread_suspend(ctrl->tid);
+		k_sem_take(&ctrl->thread_sem, K_FOREVER);
 	}
 }
 
@@ -756,7 +756,7 @@ int sip_svc_send(void *ct, uint32_t c_token, struct sip_svc_request *request, si
 	}
 
 	LOG_INF("Wakeup sip_svc thread");
-	k_thread_resume(ctrl->tid);
+	k_sem_give(&ctrl->thread_sem);
 	k_mutex_unlock(&ctrl->data_mutex);
 
 	return (int)trans_id;
@@ -837,21 +837,14 @@ static int sip_svc_subsys_init(void)
 
 		LOG_INF("Got registered conduit %.*s", (int)sizeof(ctrl->method), ctrl->method);
 
-		ctrl->async_resp_data = k_malloc(ctrl->resp_size);
-		if (ctrl->async_resp_data == NULL) {
-			return -ENOMEM;
-		}
-
 		ctrl->client_id_pool = sip_svc_id_mgr_create(ctrl->num_clients);
 		if (!ctrl->client_id_pool) {
-			k_free(ctrl->async_resp_data);
 			return -ENOMEM;
 		}
 
 		ctrl->trans_id_map = sip_svc_id_map_create(ctrl->max_transactions);
 		if (!ctrl->trans_id_map) {
 			sip_svc_id_mgr_delete(ctrl->client_id_pool);
-			k_free(ctrl->async_resp_data);
 			return -ENOMEM;
 		}
 
@@ -861,7 +854,6 @@ static int sip_svc_subsys_init(void)
 		if (!msgq_buf) {
 			sip_svc_id_mgr_delete(ctrl->client_id_pool);
 			sip_svc_id_map_delete(ctrl->trans_id_map);
-			k_free(ctrl->async_resp_data);
 			return -ENOMEM;
 		}
 
@@ -870,7 +862,6 @@ static int sip_svc_subsys_init(void)
 			sip_svc_id_mgr_delete(ctrl->client_id_pool);
 			sip_svc_id_map_delete(ctrl->trans_id_map);
 			k_free(msgq_buf);
-			k_free(ctrl->async_resp_data);
 			return -ENOMEM;
 		}
 
@@ -901,7 +892,6 @@ static int sip_svc_subsys_init(void)
 			sip_svc_id_map_delete(ctrl->trans_id_map);
 			k_free(msgq_buf);
 			k_free(ctrl->clients);
-			k_free(ctrl->async_resp_data);
 
 			for (uint32_t i = 0; i < ctrl->num_clients; i++) {
 				client = &ctrl->clients[i];
@@ -918,6 +908,7 @@ static int sip_svc_subsys_init(void)
 			sip_svc_thread, ctrl, NULL, NULL, CONFIG_ARM_SIP_SVC_SUBSYS_THREAD_PRIORITY,
 			K_ESSENTIAL, K_NO_WAIT);
 		k_thread_name_set(ctrl->tid, "sip_svc");
+		k_sem_init(&ctrl->thread_sem, 0, 1);
 
 		ctrl->active_job_cnt = 0;
 		ctrl->active_async_job_cnt = 0;


### PR DESCRIPTION
## Summary

Fixes SiP mailbox communication between Zephyr and TF-A on Intel Agilex5
(SDM mailbox via `sip_svc` / `sip_smc`).

- Flush/invalidate shared DDR mailbox buffers across the EL1/EL3 boundary,
  and always invalidate at least the response header word when TF-A returns
  `a3 == 0` for header-only SDM responses
- Use a static async response buffer and semaphore-based sip_svc thread sync
- Encode TF-A `MBOX_ATF_CLIENT_ID` in mailbox transaction IDs, drain pending
  transactions on `sip_svc_close()`, and place mailbox buffers in a dedicated
  `MBOX_DDR` region at/above `BL31_LIMIT` 
- Update the sip_svc sample to allocate command/response buffers in `MBOX_DDR`

## Test plan

- [ ] Build `samples/subsys/sip_svc` for `intel_socfpga_agilex5_socdk`
- [ ] Verify mailbox shell / SDM commands get matching responses (no stale
      header / wrong `trans_id`)
- [ ] Confirm buffers land in `MBOX_DDR` (`>= 0x82000000`) and TF-A accepts them
- [ ] Exercise `sip_svc_close()` with in-flight transactions (drain / timeout)