### PR TITLE
drivers: mipi_dbi: dcnano_lcdif: fix Type A (6800) format lookup

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -68,8 +68,22 @@ const struct mcux_dcnano_lcdif_dbi_foramt_map_t format_map[] = {
 static int mcux_dcnano_lcdif_dbi_get_format(uint8_t bus_type, uint8_t color_coding,
 	lcdif_dbi_out_format_t *format)
 {
+	/*
+	 * format_map[] is keyed by the Type A (6800) bus-width constants
+	 * (0x3/0x4/0x5). Normalize Type B (8080) bus-width values
+	 * (0x6/0x7/0x8) down to the matching Type A keys before the lookup
+	 * so both bus types resolve correctly. The subtraction step relies
+	 * on the fact that 8080_BUS_x_BIT == 6800_BUS_x_BIT +
+	 * MIPI_DBI_MODE_6800_BUS_16_BIT for every supported width.
+	 */
+	uint8_t normalized_bus_type = bus_type;
+
+	if (bus_type >= MIPI_DBI_MODE_8080_BUS_16_BIT) {
+		normalized_bus_type -= MIPI_DBI_MODE_6800_BUS_16_BIT;
+	}
+
 	for (uint8_t i = 0; i < ARRAY_SIZE(format_map); i++) {
-		if ((format_map[i].bus_type == (bus_type - MIPI_DBI_MODE_6800_BUS_16_BIT)) &&
+		if ((format_map[i].bus_type == normalized_bus_type) &&
 			(format_map[i].color_coding == color_coding)) {
 			*format = format_map[i].format;
 			return 0;
@@ -138,7 +152,7 @@ static int mcux_dcnano_lcdif_dbi_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	/* Get the color cosing */
+	/* Get the output format. */
 	status = mcux_dcnano_lcdif_dbi_get_format(bus_type, color_coding,
 		&lcdif_dbi_config.format);
 


### PR DESCRIPTION
format_map[] is keyed by the Type A (6800) bus-width constants (MIPI_DBI_MODE_6800_BUS_{8,9,16}_BIT = 0x5/0x4/0x3), but mcux_dcnano_lcdif_dbi_get_format() compared each entry's key against `bus_type - MIPI_DBI_MODE_6800_BUS_16_BIT`. That subtraction correctly normalizes the Type B (8080) values 0x6/0x7/0x8 down to 0x3/0x4/0x5, but it also shifts the Type A values 0x3/0x4/0x5 down to 0x0/0x1/0x2 which do not exist in the map. As a result every 6800 mode returned -EINVAL from configure(), even though the switch above accepts the same three modes and selects
kLCDIF_DbiTypeA_FixedE, and mipi-dbi-device.yaml lists all three as valid mipi-mode values.

Only normalize the Type B values before the lookup so both bus types resolve correctly. The 8080 path is byte-for-byte identical to what it does today.

Fixes #114739