### PR TITLE
Update the display sample to support full frame buffers and vsync callback.

### DIFF
--- a/samples/drivers/display/Kconfig
+++ b/samples/drivers/display/Kconfig
@@ -19,7 +19,48 @@ config SAMPLE_PITCH_ALIGN
 
 config HEAP_MEM_POOL_ADD_SIZE_SAMPLE
 	int "Sample maximum heap allocated buffer size"
+	default 20971520 if SAMPLE_DISPLAY_DOUBLE_BUFFER
+	default 10485760 if SAMPLE_DISPLAY_FULL_FRAME
 	default 196608 if QEMU_RAMFB_DISPLAY
 	default 65536
 	help
-	  Maximum size of the buffer for rendering rectangles
+	  Maximum size of the buffer for rendering rectangles.
+	  When SAMPLE_DISPLAY_FULL_FRAME is enabled this must be at least
+	  width x height x bytes-per-pixel (e.g. 4 MB for 1280x800 ARGB8888).
+	  When SAMPLE_DISPLAY_DOUBLE_BUFFER is enabled it must cover two frames.
+
+config SAMPLE_DISPLAY_FULL_FRAME
+	bool "Render and submit a complete frame on each update"
+	default n
+	depends on DISPLAY
+	help
+	  When enabled the sample renders all visible elements into a single
+	  full-screen buffer and submits it as one display_write() call per
+	  frame.  This is required for hardware-scanout drivers such as TI DSS
+	  (display_tidss) that treat the write buffer as a framebuffer base
+	  address and ignore partial x/y/width/height parameters.
+	  The full-frame buffer is allocated from the heap; ensure
+	  CONFIG_HEAP_MEM_POOL_ADD_SIZE_SAMPLE is large enough.
+
+config SAMPLE_DISPLAY_DOUBLE_BUFFER
+	bool "Use two full-frame buffers with VSYNC-driven swap"
+	default n
+	depends on SAMPLE_DISPLAY_FULL_FRAME
+	help
+	  Allocates two full-screen buffers.  The animation loop renders into
+	  the back buffer and submits it; on each VSYNC callback the indices are
+	  swapped so the next frame is rendered into the buffer that is no longer
+	  being scanned out.  This eliminates any risk of writing to a buffer
+	  while the display hardware is reading it.
+
+config SAMPLE_DISPLAY_VSYNC_CALLBACK
+	bool "Use VSYNC callback for tear-free frame pacing"
+	default n
+	depends on DISPLAY
+	help
+	  When enabled the sample registers a VSYNC event callback via
+	  display_register_event_cb() and waits on a semaphore posted from
+	  the callback instead of calling k_msleep() between frames.
+	  This synchronises frame submission to the display refresh rate and
+	  avoids tearing on drivers that support DISPLAY_EVENT_VSYNC
+	  callbacks (e.g. the TI DSS driver).

--- a/samples/drivers/display/Kconfig
+++ b/samples/drivers/display/Kconfig
@@ -19,7 +19,22 @@ config SAMPLE_PITCH_ALIGN
 
 config HEAP_MEM_POOL_ADD_SIZE_SAMPLE
 	int "Sample maximum heap allocated buffer size"
+	default 20971520 if SAMPLE_DISPLAY_DOUBLE_BUFFER
+	default 10485760 if SAMPLE_DISPLAY_FULL_FRAME
 	default 196608 if QEMU_RAMFB_DISPLAY
 	default 65536
 	help
-	  Maximum size of the buffer for rendering rectangles
+	  Maximum size of the buffer for rendering rectangles.
+
+config SAMPLE_DISPLAY_FULL_FRAME
+	bool "Render and submit a complete frame on each update"
+	depends on DISPLAY
+	help
+	  When enabled the sample renders all visible elements into a single
+	  full-screen buffer.
+
+config SAMPLE_DISPLAY_DOUBLE_BUFFER
+	bool "Use two full-frame buffers with VSYNC-driven swap"
+	depends on SAMPLE_DISPLAY_FULL_FRAME
+	help
+	  Allocates two full-screen buffers.

--- a/samples/drivers/display/Kconfig
+++ b/samples/drivers/display/Kconfig
@@ -38,3 +38,10 @@ config SAMPLE_DISPLAY_DOUBLE_BUFFER
 	depends on SAMPLE_DISPLAY_FULL_FRAME
 	help
 	  Allocates two full-screen buffers.
+
+config SAMPLE_DISPLAY_VSYNC_CALLBACK
+	bool "Use VSYNC callback for tear-free frame pacing"
+	depends on DISPLAY
+	help
+	  When enabled the sample registers a VSYNC event callback and waits
+	  on a semaphore posted from the callback.

--- a/samples/drivers/display/boards/am62l_evm_am62l3_a53.conf
+++ b/samples/drivers/display/boards/am62l_evm_am62l3_a53.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Texas Instruments Incorporated
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_SAMPLE_DISPLAY_FULL_FRAME=y
+CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER=y
+CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK=y

--- a/samples/drivers/display/src/display.c
+++ b/samples/drivers/display/src/display.c
@@ -6,6 +6,8 @@
  *
  * Copyright (c) 2026 NXP
  *
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,6 +25,39 @@ LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 #endif
 
 #include "display.h"
+
+/*
+ * Display render context
+ */
+struct render_ctx {
+	const struct device *display_dev;
+	uint8_t *buf;
+	size_t buf_size;
+	uint16_t rect_w;
+	uint16_t rect_h;
+	uint8_t full_bpp;
+	uint16_t frame_w;
+	uint8_t **full_buf;
+	size_t num_full_buffers;
+	size_t full_frame_size;
+	struct display_buffer_descriptor *buf_desc;
+	struct display_buffer_descriptor *full_desc;
+};
+
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+static void blit_rect(uint8_t *frame, uint16_t frame_w,
+		      uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+		      const uint8_t *src, uint8_t bpp_bytes)
+{
+	size_t row_bytes = (size_t)w * bpp_bytes;
+
+	for (uint16_t row = 0; row < h; row++) {
+		memcpy(frame + ((size_t)(y + row) * frame_w + x) * bpp_bytes,
+		       src + (size_t)row * row_bytes,
+		       row_bytes);
+	}
+}
+#endif /* CONFIG_SAMPLE_DISPLAY_FULL_FRAME */
 
 enum corner {
 	TOP_LEFT,
@@ -277,6 +312,63 @@ static inline void fill_buffer_mono10(enum corner corner, uint8_t grey,
 	fill_buffer_mono(corner, grey, 0xFFu, 0x00u, buf, buf_size);
 }
 
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+static int alloc_full_framebuffers(uint8_t *full_buf[], size_t count,
+				    size_t frame_size, uint8_t bg_color)
+{
+	for (size_t i = 0; i < count; i++) {
+		full_buf[i] = k_aligned_alloc(CONFIG_SAMPLE_BUFFER_ADDR_ALIGN, frame_size);
+		if (full_buf[i] == NULL) {
+			LOG_ERR("Could not allocate frame buffer %zu (%zu B). "
+				"Increase CONFIG_HEAP_MEM_POOL_ADD_SIZE_SAMPLE.",
+				i, frame_size);
+			return -ENOMEM;
+		}
+		(void)memset(full_buf[i], bg_color, frame_size);
+	}
+	return 0;
+}
+#endif /* CONFIG_SAMPLE_DISPLAY_FULL_FRAME */
+
+/*
+ * Renders one static corner rectangle, either into every full-frame buffer
+ * (so all buffers carry the same background before the animation starts) or
+ * directly to the display when full-frame mode is off.
+ */
+static int render_static_corner(const struct render_ctx *ctx, fill_buffer fnc,
+				 enum corner corner, enum display_pixel_format fmt,
+				 uint16_t x, uint16_t y)
+{
+	fnc(corner, 0, ctx->buf, ctx->buf_size, fmt);
+
+	if (IS_ENABLED(CONFIG_SAMPLE_DISPLAY_FULL_FRAME)) {
+		for (size_t i = 0; i < ctx->num_full_buffers; i++) {
+			blit_rect(ctx->full_buf[i], ctx->frame_w, x, y,
+				  ctx->rect_w, ctx->rect_h, ctx->buf, ctx->full_bpp);
+		}
+		return 0;
+	}
+
+	return display_write(ctx->display_dev, x, y, ctx->buf_desc, ctx->buf);
+}
+
+/*
+ * Renders the animated bottom-left rectangle for one frame: blits into the
+ * buffer selected by render_idx and submits it, or writes the small buffer
+ * directly when full-frame mode is off.
+ */
+static int render_frame(const struct render_ctx *ctx, uint16_t x, uint16_t y, size_t render_idx)
+{
+	if (IS_ENABLED(CONFIG_SAMPLE_DISPLAY_FULL_FRAME)) {
+		blit_rect(ctx->full_buf[render_idx], ctx->frame_w, x, y,
+			  ctx->rect_w, ctx->rect_h, ctx->buf, ctx->full_bpp);
+		return display_write(ctx->display_dev, 0, 0, ctx->full_desc,
+				      ctx->full_buf[render_idx]);
+	}
+
+	return display_write(ctx->display_dev, x, y, ctx->buf_desc, ctx->buf);
+}
+
 int sample_display_draw(void)
 {
 	uint16_t x;
@@ -295,6 +387,11 @@ int sample_display_draw(void)
 	size_t buf_size = 0;
 	fill_buffer fill_buffer_fnc = NULL;
 	int ret = 0;
+	uint8_t full_bpp = 0;
+	size_t full_frame_size = 0;
+	size_t render_idx = 0;
+	struct display_buffer_descriptor full_desc = {0};
+	uint8_t *full_buf[SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS] = {NULL};
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -418,6 +515,27 @@ int sample_display_draw(void)
 
 	(void)memset(buf, bg_color, buf_size);
 
+	if (IS_ENABLED(CONFIG_SAMPLE_DISPLAY_FULL_FRAME)) {
+		full_bpp = DIV_ROUND_UP(
+			DISPLAY_BITS_PER_PIXEL(capabilities.current_pixel_format),
+			NUM_BITS(uint8_t));
+		full_frame_size = (size_t)capabilities.x_resolution *
+				  capabilities.y_resolution * full_bpp;
+
+		ret = alloc_full_framebuffers(full_buf, SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS,
+					       full_frame_size, bg_color);
+		if (ret < 0) {
+			goto end;
+		}
+
+		full_desc.buf_size        = full_frame_size;
+		full_desc.pitch           = ROUND_UP(capabilities.x_resolution,
+						     CONFIG_SAMPLE_PITCH_ALIGN);
+		full_desc.width           = capabilities.x_resolution;
+		full_desc.height          = capabilities.y_resolution;
+		full_desc.frame_incomplete = false;
+	}
+
 	buf_desc.buf_size = buf_size;
 	buf_desc.pitch = ROUND_UP(capabilities.x_resolution, CONFIG_SAMPLE_PITCH_ALIGN);
 	buf_desc.width = capabilities.x_resolution;
@@ -431,19 +549,21 @@ int sample_display_draw(void)
 	 */
 	buf_desc.frame_incomplete = true;
 
-	for (uint16_t idx = 0; idx < capabilities.y_resolution; idx += h_step) {
-		/*
-		 * Tweaking the height value not to draw outside of the display.
-		 * It is required when using a monochrome display whose vertical
-		 * resolution can not be divided by 8.
-		 */
-		if ((capabilities.y_resolution - idx) < h_step) {
-			buf_desc.height = (capabilities.y_resolution - idx);
-		}
-		ret = display_write(display_dev, 0, idx, &buf_desc, buf);
-		if (ret < 0) {
-			LOG_ERR("Failed to write to display (error %d)", ret);
-			goto end;
+	if (!IS_ENABLED(CONFIG_SAMPLE_DISPLAY_FULL_FRAME)) {
+		for (uint16_t idx = 0; idx < capabilities.y_resolution; idx += h_step) {
+			/*
+			 * Tweaking the height value not to draw outside of the display.
+			 * It is required when using a monochrome display whose vertical
+			 * resolution can not be divided by 8.
+			 */
+			if ((capabilities.y_resolution - idx) < h_step) {
+				buf_desc.height = (capabilities.y_resolution - idx);
+			}
+			ret = display_write(display_dev, 0, idx, &buf_desc, buf);
+			if (ret < 0) {
+				LOG_ERR("Failed to write to display (error %d)", ret);
+				goto end;
+			}
 		}
 	}
 
@@ -451,19 +571,34 @@ int sample_display_draw(void)
 	buf_desc.width = rect_w;
 	buf_desc.height = rect_h;
 
-	fill_buffer_fnc(TOP_LEFT, 0, buf, buf_size, capabilities.current_pixel_format);
+	struct render_ctx ctx = {
+		.display_dev = display_dev,
+		.buf = buf,
+		.buf_size = buf_size,
+		.rect_w = rect_w,
+		.rect_h = rect_h,
+		.full_bpp = full_bpp,
+		.frame_w = capabilities.x_resolution,
+		.full_buf = full_buf,
+		.num_full_buffers = SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS,
+		.full_frame_size = full_frame_size,
+		.buf_desc = &buf_desc,
+		.full_desc = &full_desc,
+	};
+
 	x = 0;
 	y = 0;
-	ret = display_write(display_dev, x, y, &buf_desc, buf);
+	ret = render_static_corner(&ctx, fill_buffer_fnc, TOP_LEFT,
+				    capabilities.current_pixel_format, x, y);
 	if (ret < 0) {
 		LOG_ERR("Failed to write to display (error %d)", ret);
 		goto end;
 	}
 
-	fill_buffer_fnc(TOP_RIGHT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = capabilities.x_resolution - rect_w;
 	y = 0;
-	ret = display_write(display_dev, x, y, &buf_desc, buf);
+	ret = render_static_corner(&ctx, fill_buffer_fnc, TOP_RIGHT,
+				    capabilities.current_pixel_format, x, y);
 	if (ret < 0) {
 		LOG_ERR("Failed to write to display (error %d)", ret);
 		goto end;
@@ -476,10 +611,10 @@ int sample_display_draw(void)
 	 */
 	buf_desc.frame_incomplete = false;
 
-	fill_buffer_fnc(BOTTOM_RIGHT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = capabilities.x_resolution - rect_w;
 	y = capabilities.y_resolution - rect_h;
-	ret = display_write(display_dev, x, y, &buf_desc, buf);
+	ret = render_static_corner(&ctx, fill_buffer_fnc, BOTTOM_RIGHT,
+				    capabilities.current_pixel_format, x, y);
 	if (ret < 0) {
 		LOG_ERR("Failed to write to display (error %d)", ret);
 		goto end;
@@ -499,7 +634,8 @@ int sample_display_draw(void)
 	while (1) {
 		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size,
 			capabilities.current_pixel_format);
-		ret = display_write(display_dev, x, y, &buf_desc, buf);
+
+		ret = render_frame(&ctx, x, y, render_idx);
 		if (ret < 0) {
 			LOG_ERR("Failed to write to display (error %d)", ret);
 			goto end;
@@ -507,6 +643,8 @@ int sample_display_draw(void)
 
 		++grey_count;
 		k_msleep(grey_scale_sleep);
+		render_idx = (render_idx + 1) % SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS;
+
 #if CONFIG_TEST
 		if (grey_count >= 30) {
 			LOG_INF("Display sample test mode done %s", display_dev->name);
@@ -516,6 +654,12 @@ int sample_display_draw(void)
 	}
 
 end:
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	for (size_t i = 0; i < SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS; i++) {
+		k_free(full_buf[i]);
+	}
+#endif /* CONFIG_SAMPLE_DISPLAY_FULL_FRAME */
+
 #if CONFIG_TEST
 	if (ret == 0) {
 		LOG_INF("PROJECT EXECUTION SUCCESSFUL");

--- a/samples/drivers/display/src/display.c
+++ b/samples/drivers/display/src/display.c
@@ -17,12 +17,56 @@ LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 #include <zephyr/drivers/display.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/cache.h>
 
 #ifdef CONFIG_ARCH_POSIX
 #include "posix_board_if.h"
 #endif
 
 #include "display.h"
+
+static inline void flush_buf(void *addr, size_t size)
+{
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	sys_cache_data_flush_range(addr, size);
+#else
+	ARG_UNUSED(addr);
+	ARG_UNUSED(size);
+#endif
+}
+
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+static void blit_rect(uint8_t *frame, uint16_t frame_w,
+		      uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+		      const uint8_t *src, uint8_t bpp_bytes)
+{
+	size_t row_bytes = (size_t)w * bpp_bytes;
+
+	for (uint16_t row = 0; row < h; row++) {
+		memcpy(frame + ((size_t)(y + row) * frame_w + x) * bpp_bytes,
+		       src + (size_t)row * row_bytes,
+		       row_bytes);
+	}
+}
+#endif /* CONFIG_SAMPLE_DISPLAY_FULL_FRAME */
+
+#ifdef CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK
+static K_SEM_DEFINE(vsync_sem, 0, 1);
+
+static enum display_event_result on_vsync(const struct device *dev,
+					  uint32_t evt,
+					  const struct display_event_data *data,
+					  void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(evt);
+	ARG_UNUSED(data);
+	ARG_UNUSED(user_data);
+
+	k_sem_give(&vsync_sem);
+	return DISPLAY_EVENT_RESULT_CONTINUE;
+}
+#endif /* CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK */
 
 enum corner {
 	TOP_LEFT,
@@ -295,6 +339,20 @@ int sample_display_draw(void)
 	size_t buf_size = 0;
 	fill_buffer fill_buffer_fnc = NULL;
 	int ret = 0;
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	uint8_t full_bpp;
+	size_t full_frame_size;
+	struct display_buffer_descriptor full_desc;
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+	uint8_t *full_buf[2] = {NULL, NULL};
+	int render_idx = 0;
+#else
+	uint8_t *full_buf = NULL;
+#endif
+#endif
+#ifdef CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK
+	uint32_t vsync_handle = 0;
+#endif
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -418,6 +476,42 @@ int sample_display_draw(void)
 
 	(void)memset(buf, bg_color, buf_size);
 
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	full_bpp = DIV_ROUND_UP(
+		DISPLAY_BITS_PER_PIXEL(capabilities.current_pixel_format),
+		NUM_BITS(uint8_t));
+	full_frame_size = (size_t)capabilities.x_resolution *
+			  capabilities.y_resolution * full_bpp;
+	full_buf[0] = k_aligned_alloc(64, full_frame_size);
+	if (full_buf[0] == NULL) {
+		LOG_ERR("Could not allocate full frame buffer (%zu B). "
+			"Increase CONFIG_HEAP_MEM_POOL_ADD_SIZE_SAMPLE.",
+			full_frame_size);
+		ret = -ENOMEM;
+		goto end;
+	}
+	(void)memset(full_buf[0], bg_color, full_frame_size);
+
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+	full_buf[1] = k_aligned_alloc(64, full_frame_size);
+	if (full_buf[1] == NULL) {
+		LOG_ERR("Could not allocate second frame buffer (%zu B). "
+			"Increase CONFIG_HEAP_MEM_POOL_ADD_SIZE_SAMPLE.",
+			full_frame_size);
+		ret = -ENOMEM;
+		goto end;
+	}
+	(void)memset(full_buf[1], bg_color, full_frame_size);
+#endif /* CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER */
+
+	full_desc.buf_size        = full_frame_size;
+	full_desc.pitch           = ROUND_UP(capabilities.x_resolution,
+					     CONFIG_SAMPLE_PITCH_ALIGN);
+	full_desc.width           = capabilities.x_resolution;
+	full_desc.height          = capabilities.y_resolution;
+	full_desc.frame_incomplete = false;
+#endif /* CONFIG_SAMPLE_DISPLAY_FULL_FRAME */
+
 	buf_desc.buf_size = buf_size;
 	buf_desc.pitch = ROUND_UP(capabilities.x_resolution, CONFIG_SAMPLE_PITCH_ALIGN);
 	buf_desc.width = capabilities.x_resolution;
@@ -431,6 +525,8 @@ int sample_display_draw(void)
 	 */
 	buf_desc.frame_incomplete = true;
 
+#ifndef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	flush_buf(buf, buf_size);
 	for (uint16_t idx = 0; idx < capabilities.y_resolution; idx += h_step) {
 		/*
 		 * Tweaking the height value not to draw outside of the display.
@@ -446,6 +542,7 @@ int sample_display_draw(void)
 			goto end;
 		}
 	}
+#endif /* !CONFIG_SAMPLE_DISPLAY_FULL_FRAME */
 
 	buf_desc.pitch = ROUND_UP(rect_w, CONFIG_SAMPLE_PITCH_ALIGN);
 	buf_desc.width = rect_w;
@@ -454,20 +551,40 @@ int sample_display_draw(void)
 	fill_buffer_fnc(TOP_LEFT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = 0;
 	y = 0;
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	blit_rect(full_buf[0], capabilities.x_resolution, x, y,
+		  rect_w, rect_h, buf, full_bpp);
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+	blit_rect(full_buf[1], capabilities.x_resolution, x, y,
+		  rect_w, rect_h, buf, full_bpp);
+#endif
+#else
+	flush_buf(buf, buf_size);
 	ret = display_write(display_dev, x, y, &buf_desc, buf);
 	if (ret < 0) {
 		LOG_ERR("Failed to write to display (error %d)", ret);
 		goto end;
 	}
+#endif
 
 	fill_buffer_fnc(TOP_RIGHT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = capabilities.x_resolution - rect_w;
 	y = 0;
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	blit_rect(full_buf[0], capabilities.x_resolution, x, y,
+		  rect_w, rect_h, buf, full_bpp);
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+	blit_rect(full_buf[1], capabilities.x_resolution, x, y,
+		  rect_w, rect_h, buf, full_bpp);
+#endif
+#else
+	flush_buf(buf, buf_size);
 	ret = display_write(display_dev, x, y, &buf_desc, buf);
 	if (ret < 0) {
 		LOG_ERR("Failed to write to display (error %d)", ret);
 		goto end;
 	}
+#endif
 
 	/*
 	 * This is the last write of the frame, so turn this off.
@@ -479,17 +596,38 @@ int sample_display_draw(void)
 	fill_buffer_fnc(BOTTOM_RIGHT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = capabilities.x_resolution - rect_w;
 	y = capabilities.y_resolution - rect_h;
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	blit_rect(full_buf[0], capabilities.x_resolution, x, y,
+		  rect_w, rect_h, buf, full_bpp);
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+	blit_rect(full_buf[1], capabilities.x_resolution, x, y,
+		  rect_w, rect_h, buf, full_bpp);
+#endif
+#else
+	flush_buf(buf, buf_size);
 	ret = display_write(display_dev, x, y, &buf_desc, buf);
 	if (ret < 0) {
 		LOG_ERR("Failed to write to display (error %d)", ret);
 		goto end;
 	}
+#endif
 
 	ret = display_blanking_off(display_dev);
 	if (ret < 0 && ret != -ENOSYS) {
 		LOG_ERR("Failed to turn blanking off (error %d)", ret);
 		goto end;
 	}
+
+#ifdef CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK
+	ret = display_register_event_cb(display_dev, on_vsync, NULL,
+					DISPLAY_EVENT_VSYNC, true, &vsync_handle);
+	if (ret < 0) {
+		LOG_WRN("VSYNC callback not supported (%d), falling back to polling", ret);
+		vsync_handle = 0;
+	} else {
+		LOG_INF("VSYNC callback registered (handle %u)", vsync_handle);
+	}
+#endif
 
 	grey_count = 0;
 	x = 0;
@@ -499,14 +637,40 @@ int sample_display_draw(void)
 	while (1) {
 		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size,
 			capabilities.current_pixel_format);
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+		blit_rect(full_buf[render_idx], capabilities.x_resolution, x, y,
+			  rect_w, rect_h, buf, full_bpp);
+		flush_buf(full_buf[render_idx], full_frame_size);
+		ret = display_write(display_dev, 0, 0, &full_desc, full_buf[render_idx]);
+#else
+		blit_rect(full_buf[0], capabilities.x_resolution, x, y,
+			  rect_w, rect_h, buf, full_bpp);
+		flush_buf(full_buf[0], full_frame_size);
+		ret = display_write(display_dev, 0, 0, &full_desc, full_buf[0]);
+#endif
+#else
+		flush_buf(buf, buf_size);
 		ret = display_write(display_dev, x, y, &buf_desc, buf);
+#endif
 		if (ret < 0) {
 			LOG_ERR("Failed to write to display (error %d)", ret);
 			goto end;
 		}
 
 		++grey_count;
+#ifdef CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK
+		if (vsync_handle != 0) {
+			k_sem_take(&vsync_sem, K_FOREVER);
+		} else {
+			k_msleep(grey_scale_sleep);
+		}
+#else
 		k_msleep(grey_scale_sleep);
+#endif
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+			render_idx ^= 1;
+#endif
 #if CONFIG_TEST
 		if (grey_count >= 30) {
 			LOG_INF("Display sample test mode done %s", display_dev->name);
@@ -516,6 +680,17 @@ int sample_display_draw(void)
 	}
 
 end:
+#ifdef CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK
+	if (vsync_handle != 0) {
+		(void)display_unregister_event_cb(display_dev, vsync_handle);
+	}
+#endif
+#ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
+	k_free(full_buf[0]);
+#ifdef CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER
+	k_free(full_buf[1]);
+#endif
+#endif
 #if CONFIG_TEST
 	if (ret == 0) {
 		LOG_INF("PROJECT EXECUTION SUCCESSFUL");

--- a/samples/drivers/display/src/display.c
+++ b/samples/drivers/display/src/display.c
@@ -59,6 +59,24 @@ static void blit_rect(uint8_t *frame, uint16_t frame_w,
 }
 #endif /* CONFIG_SAMPLE_DISPLAY_FULL_FRAME */
 
+#ifdef CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK
+static K_SEM_DEFINE(vsync_sem, 0, 1);
+
+static enum display_event_result on_vsync(const struct device *dev,
+					  uint32_t evt,
+					  const struct display_event_data *data,
+					  void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(evt);
+	ARG_UNUSED(data);
+	ARG_UNUSED(user_data);
+
+	k_sem_give(&vsync_sem);
+	return DISPLAY_EVENT_RESULT_CONTINUE;
+}
+#endif /* CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK */
+
 enum corner {
 	TOP_LEFT,
 	TOP_RIGHT,
@@ -392,6 +410,7 @@ int sample_display_draw(void)
 	size_t render_idx = 0;
 	struct display_buffer_descriptor full_desc = {0};
 	uint8_t *full_buf[SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS] = {NULL};
+	uint32_t vsync_handle = 0;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -541,6 +560,18 @@ int sample_display_draw(void)
 	buf_desc.width = capabilities.x_resolution;
 	buf_desc.height = h_step;
 
+	if (IS_ENABLED(CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK)) {
+		ret = display_register_event_cb(display_dev, on_vsync, NULL,
+						DISPLAY_EVENT_VSYNC, true, &vsync_handle);
+		if (ret < 0) {
+			LOG_WRN("VSYNC callback not supported (%d), falling back to polling",
+				ret);
+			vsync_handle = 0;
+		} else {
+			LOG_INF("VSYNC callback registered (handle %u)", vsync_handle);
+		}
+	}
+
 	/*
 	 * The following writes will only render parts of the image,
 	 * so turn this option on.
@@ -642,7 +673,12 @@ int sample_display_draw(void)
 		}
 
 		++grey_count;
-		k_msleep(grey_scale_sleep);
+
+		if (IS_ENABLED(CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK) && vsync_handle != 0) {
+			k_sem_take(&vsync_sem, K_FOREVER);
+		} else {
+			k_msleep(grey_scale_sleep);
+		}
 		render_idx = (render_idx + 1) % SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS;
 
 #if CONFIG_TEST
@@ -654,6 +690,10 @@ int sample_display_draw(void)
 	}
 
 end:
+	if (IS_ENABLED(CONFIG_SAMPLE_DISPLAY_VSYNC_CALLBACK) && vsync_handle != 0) {
+		(void)display_unregister_event_cb(display_dev, vsync_handle);
+	}
+
 #ifdef CONFIG_SAMPLE_DISPLAY_FULL_FRAME
 	for (size_t i = 0; i < SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS; i++) {
 		k_free(full_buf[i]);

--- a/samples/drivers/display/src/display.h
+++ b/samples/drivers/display/src/display.h
@@ -4,11 +4,16 @@
  * Based on ST7789V sample:
  * Copyright (c) 2019 Marc Reilly
  *
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef __SAMPLE_DISPLAY_H__
 #define __SAMPLE_DISPLAY_H__
+
+#define SAMPLE_DISPLAY_NUM_FULL_FRAMEBUFFERS \
+	(IS_ENABLED(CONFIG_SAMPLE_DISPLAY_DOUBLE_BUFFER) ? 2 : 1)
 
 int sample_display_draw(void);
 


### PR DESCRIPTION
This PR updates the display application sample to support full frame buffers and vsync callback registration. Certain drivers may not support partial frame buffer updates and require full frame buffers to be used.
It has been tested with the display driver as per PR #110013 and the display bridge as per PR #110061 on TI's AM62L EVM.

Logs:
```
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 1 on domain 54
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 3 on domain 26
--- 49 messages dropped ---
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 1 on domain 26
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 3 on domain 28
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 1 on domain 28
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 3 on domain 22
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 1 on domain 22
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 3 on domain 23
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 1 on domain 23
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 3 on domain 24
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 1 on domain 24
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 3 on domain 59
[00:00:07.976,000] <inf> scmi_power_domain: attempting PM action 1 on domain 59
[00:00:00.010,000] <inf> display_tidss: TIDSS ready: 1920x1080 @ 148500000 Hz (24-bit bus) [double-buffer VSYNC]
[00:00:00.012,000] <inf> sii9022a: SII9022A: device_id=0xb0 prod_rev=0x02 tpi_rev=0x03 hdcp_rev=0x00
[00:00:00.020,000] <inf> sii9022a: SII9022A mode set: 1920x1080 @ 60 Hz (pix_clk=148500 kHz)
[00:00:00.021,000] <inf> sii9022a: SII9022A ready (1920x1080 @ 148500000 Hz, bus i2c@20010000 addr 0x3b, falling edge, fmt 0)
*** Booting Zephyr OS build v4.4.0-3714-g62f3933eabe8 ***
Secondary CPU core 1 (MPID:0x1) is up
[00:00:00.081,000] <inf> sample: Display sample for dss@30200000
[00:00:00.163,000] <inf> sample: VSYNC callback registered (handle 1)
[00:00:00.163,000] <inf> sample: Display starts
```
Attached the video of this sample running:
https://github.com/user-attachments/assets/60283f0e-ea62-4e88-b67a-4cd2eb247e38
