### PR TITLE
boards: infineon: kit_psc3m5_evk: add MikroBUS connector support

### DIFF
--- a/boards/infineon/kit_psc3m5_evk/doc/index.rst
+++ b/boards/infineon/kit_psc3m5_evk/doc/index.rst
@@ -103,6 +103,44 @@ Default Zephyr Peripheral Mapping
 +-----------+-----------------+----------------------------+
 | P2.0      | GPIO            | Button SW2                 |
 +-----------+-----------------+----------------------------+
+| P9.0      | SCB0 I2C SCL    | MikroBUS I2C               |
++-----------+-----------------+----------------------------+
+| P9.2      | SCB0 I2C SDA    | MikroBUS I2C               |
++-----------+-----------------+----------------------------+
+| P7.0      | SCB2 SPI CLK    | MikroBUS SPI               |
++-----------+-----------------+----------------------------+
+| P7.1      | SCB2 SPI MOSI   | MikroBUS SPI               |
++-----------+-----------------+----------------------------+
+| P7.2      | SCB2 SPI MISO   | MikroBUS SPI               |
++-----------+-----------------+----------------------------+
+| P9.5      | GPIO            | MikroBUS SPI CS            |
++-----------+-----------------+----------------------------+
+| P3.3      | SCB4 UART TX    | MikroBUS UART              |
++-----------+-----------------+----------------------------+
+| P3.2      | SCB4 UART RX    | MikroBUS UART              |
++-----------+-----------------+----------------------------+
+
+MikroBUS Connector
+------------------
+
+The board exposes one MikroBUS slot (``mikrobus_header``) with the following
+aliases pre-configured:
+
+- ``mikrobus_i2c`` — SCB0 I2C, P9.0 (SCL) / P9.2 (SDA), 100 kHz
+- ``mikrobus_spi`` — SCB2 SPI, P7.0 (CLK) / P7.1 (MOSI) / P7.2 (MISO),
+  GPIO CS on P9.5; SCB oversampling >= 4 caps the maximum rate at
+  CLK_HF2 / 4 = 20 MHz
+- ``mikrobus_serial`` — SCB4 UART, P3.3 (TX) / P3.2 (RX), 115200 8N1
+- ``mikrobus_adc`` — AN pin mapped to ``adc0`` channel 4
+  (PASS[0].SAR[0].CH[4])
+
+Connector pin limitations:
+
+- **AN (slot 0):** Wired to PASS[0].SAR[0].CH[4]; ADC input only, no GPIO.
+- **RST (slot 1):** Wired to XRES_L_MCU (device reset); not usable as a
+  software-controlled GPIO.
+- **PWM (slot 6, P5.1):** Routed to P5.1 but no TCPWM channel is assigned
+  in the board configuration; available as GPIO only.
 
 System Clock
 ============

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-common.dtsi
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-common.dtsi
@@ -9,6 +9,7 @@
  * Common devicetree content for the kit_psc3m5_evk secure board variants.
  */
 
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -52,6 +53,29 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = /* AN = PASS[0].SAR[0].CH[4], ADC only, no GPIO */
+			   /* RST is XRES_L_MCU, not usable as GPIO */
+			   <2 0 &gpio_prt9 5 0>,   /* CS,  P9.5  */
+			   <3 0 &gpio_prt7 0 0>,   /* SCK, P7.0  */
+			   <4 0 &gpio_prt7 2 0>,   /* MISO, P7.2 */
+			   <5 0 &gpio_prt7 1 0>,   /* MOSI, P7.1 */
+			   <6 0 &gpio_prt5 1 0>,   /* PWM, P5.1  */
+			   <7 0 &gpio_prt7 7 0>,   /* INT, P7.7  */
+			   <8 0 &gpio_prt3 2 0>,   /* RX,  P3.2  */
+			   <9 0 &gpio_prt3 3 0>,   /* TX,  P3.3  */
+			   <10 0 &gpio_prt9 0 0>,  /* SCL, P9.0  */
+			   <11 0 &gpio_prt9 2 0>;  /* SDA, P9.2  */
+	};
+
+	mikrobus_adc: zephyr,user {
+		io-channels = <&adc0 4>;
+	};
 };
 
 &gpio_prt0 {
@@ -78,9 +102,44 @@
 	status = "okay";
 };
 
+&gpio_prt7 {
+	status = "okay";
+};
+
 &gpio_prt8 {
 	status = "okay";
 };
+
+&gpio_prt9 {
+	status = "okay";
+};
+
+&scb0 {
+	compatible = "infineon,i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&p9_0_scb0_i2c_scl &p9_2_scb0_i2c_sda>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	clocks = <&peri0_group4_16_5bit_2>;
+	status = "okay";
+};
+
+mikrobus_i2c: &scb0 {};
+
+&scb2 {
+	compatible = "infineon,spi";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&p7_0_scb2_spi_m_clk &p7_1_scb2_spi_m_mosi
+		     &p7_2_scb2_spi_m_miso>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio_prt9 5 GPIO_ACTIVE_LOW>;
+	clocks = <&peri0_group4_16_5bit_1>;
+	status = "okay";
+};
+
+mikrobus_spi: &scb2 {};
 
 uart3: &scb3 {
 	compatible = "infineon,uart";
@@ -93,12 +152,40 @@ uart3: &scb3 {
 	pinctrl-names = "default";
 };
 
+&scb4 {
+	compatible = "infineon,uart";
+	pinctrl-0 = <&p3_3_scb4_uart_tx &p3_2_scb4_uart_rx>;
+	pinctrl-names = "default";
+	clocks = <&peri0_group4_8bit_1>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
+mikrobus_serial: &scb4 {};
+
 &peri0_group4_8bit_0 {
 	status = "okay";
 	clock-div = <86>;
 };
 
+&peri0_group4_8bit_1 {
+	status = "okay";
+	clock-div = <1>;
+};
+
 &peri0_group4_16_5bit_0 {
+	status = "okay";
+	clock-div = <1>;
+};
+
+/* clock source for SCB2 MikroBUS SPI; oversample >= 4 caps rate at 20 MHz */
+&peri0_group4_16_5bit_1 {
+	status = "okay";
+	clock-div = <1>;
+};
+
+/* clock source for SCB0 MikroBUS I2C */
+&peri0_group4_16_5bit_2 {
 	status = "okay";
 	clock-div = <1>;
 };
@@ -233,6 +320,10 @@ uart3: &scb3 {
  * (TRM 002-39348 §27.2.4.4).  Do not modify.
  */
 &hppass_analog0 {
+	status = "okay";
+};
+
+&adc0 {
 	status = "okay";
 };
 

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-common.dtsi
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-common.dtsi
@@ -8,7 +8,7 @@
 /*
  * Common devicetree content for the kit_psc3m5_evk secure board variants.
  */
-
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -52,6 +52,25 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = /* AN has no GPIO connection */
+			   /* RST is XRES_L_MCU, not usable as GPIO */
+			   <2 0 &gpio_prt9 5 0>,   /* CS,  P9.5  */
+			   <3 0 &gpio_prt7 0 0>,   /* SCK, P7.0  */
+			   <4 0 &gpio_prt7 2 0>,   /* MISO, P7.2 */
+			   <5 0 &gpio_prt7 1 0>,   /* MOSI, P7.1 */
+			   <6 0 &gpio_prt5 1 0>,   /* PWM, P5.1  */
+			   <7 0 &gpio_prt7 7 0>,   /* INT, P7.7  */
+			   <8 0 &gpio_prt3 2 0>,   /* RX,  P3.2  */
+			   <9 0 &gpio_prt3 3 0>,   /* TX,  P3.3  */
+			   <10 0 &gpio_prt9 0 0>,  /* SCL, P9.0  */
+			   <11 0 &gpio_prt9 2 0>;  /* SDA, P9.2  */
+	};
 };
 
 &gpio_prt0 {
@@ -78,9 +97,44 @@
 	status = "okay";
 };
 
+&gpio_prt7 {
+	status = "okay";
+};
+
 &gpio_prt8 {
 	status = "okay";
 };
+
+&gpio_prt9 {
+	status = "okay";
+};
+
+&scb0 {
+	compatible = "infineon,i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&p9_0_scb0_i2c_scl &p9_2_scb0_i2c_sda>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	clocks = <&peri0_group4_16_5bit_2>;
+	status = "disabled";
+};
+
+mikrobus_i2c: &scb0 {};
+
+&scb2 {
+	compatible = "infineon,spi";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&p7_0_scb2_spi_m_clk &p7_1_scb2_spi_m_mosi
+		     &p7_2_scb2_spi_m_miso>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio_prt9 5 GPIO_ACTIVE_LOW>;
+	clocks = <&peri0_group4_16_5bit_1>;
+	status = "disabled";
+};
+
+mikrobus_spi: &scb2 {};
 
 uart3: &scb3 {
 	compatible = "infineon,uart";
@@ -93,12 +147,26 @@ uart3: &scb3 {
 	pinctrl-names = "default";
 };
 
+&scb4 {
+	compatible = "infineon,uart";
+	pinctrl-0 = <&p3_3_scb4_uart_tx &p3_2_scb4_uart_rx>;
+	pinctrl-names = "default";
+	clocks = <&peri0_group4_8bit_1>;
+	status = "disabled";
+};
+
 &peri0_group4_8bit_0 {
 	status = "okay";
 	clock-div = <86>;
 };
 
 &peri0_group4_16_5bit_0 {
+	status = "okay";
+	clock-div = <1>;
+};
+
+/* clock source for SCB2 MikroBUS SPI */
+&peri0_group4_16_5bit_1 {
 	status = "okay";
 	clock-div = <1>;
 };

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-pinctrl.dtsi
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-pinctrl.dtsi
@@ -28,3 +28,38 @@
 &p5_3_can1_tx {
 	drive-push-pull;
 };
+
+/* Configure pin drive mode for SCB2 SPI pins (MikroBUS) */
+&p7_0_scb2_spi_m_clk {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p7_1_scb2_spi_m_mosi {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p7_2_scb2_spi_m_miso {
+	input-enable;
+};
+
+/* Configure pin drive mode for SCB0 I2C pins (MikroBUS) */
+&p9_0_scb0_i2c_scl {
+	drive-open-drain;
+	input-enable;
+};
+
+&p9_2_scb0_i2c_sda {
+	drive-open-drain;
+	input-enable;
+};
+
+/* Configure pin drive mode for SCB4 UART pins (MikroBUS) */
+&p3_3_scb4_uart_tx {
+	drive-push-pull;
+};
+
+&p3_2_scb4_uart_rx {
+	input-enable;
+};

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
@@ -13,12 +13,14 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - can
+  - comparator
+  - dma
   - gpio
+  - i2c
+  - rtc
   - spi
   - timer
   - uart
-  - dma
-  - comparator
-  - rtc
 vendor: infineon

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk_psc3m5fds2afq1_norflash.yaml
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk_psc3m5fds2afq1_norflash.yaml
@@ -14,10 +14,12 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - can
   - dma
   - flash
   - gpio
+  - i2c
   - spi
   - timer
   - uart


### PR DESCRIPTION
Add the full MikroBUS connector description to the board common DTSI:

- Complete mikrobus_header GPIO map for routable signals.
- mikrobus_spi alias backed by SCB2 (P7.0/P7.1/P7.2, GPIO CS P9.5);
  SCB oversampling >= 4 caps the rate at CLK_HF2 / 4 = 20 MHz.
- mikrobus_i2c alias backed by SCB0 (P9.0/P9.2)
- mikrobus_serial alias backed by SCB4 (P3.2/P3.3), 115200 8N1
- mikrobus_adc alias for the AN pin (HPPASS SAR adc0 channel 4)
- SCB0, SCB2, SCB4 enabled by default; all three peripheral clocks
  pre-configured (peri0_group4_16_5bit_1/2, peri0_group4_8bit_1).
- Matching pin drive-mode entries in the pinctrl file.

Enable gpio_prt7 and gpio_prt9, which carry the connector pins.
Add i2c and adc to the board supported lists; update doc/index.rst
with the MikroBUS peripheral mapping and connector pin notes.

Tested with the MikroElektronika ETH 3 Click shield (Microchip LAN9250)
on KIT_PSC3M5_EVK at 10 MHz SPI (20 MHz max): DHCP acquires an address
and ICMP ping succeeds.

Add i2c and adc to the supported: lists in both board YAML files so
Twister automatically includes I2C and ADC tests for this board now
that SCB0 and adc0 are enabled by the preceding commit.