### PR TITLE
boards: ti: mspm0: switch to zephyr,mapped-partition

### DIFF
--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
@@ -73,21 +73,24 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x8000>;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00008000 0xc000>;
 		};
 
 		slot1_partition: partition@14000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00014000 0xc000>;
 		};

--- a/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
+++ b/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
@@ -48,21 +48,24 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x8000>;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00008000 0x1c000>;
 		};
 
 		slot1_partition: partition@24000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00024000 0x1c000>;
 		};

--- a/dts/arm/ti/mspm0/g/mspm0g1105.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1105.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(32)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(32)>;
+	ranges = <0x0 0x0 DT_SIZE_K(32)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1105.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1105.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(32)>;
+			ranges = <0x0 0x0 DT_SIZE_K(32)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1105.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1105.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g110x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1106.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1106.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+	ranges = <0x0 0x0 DT_SIZE_K(64)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1106.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1106.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(64)>;
+			ranges = <0x0 0x0 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1106.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1106.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g110x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1107.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1107.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1107.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1107.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1107.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1107.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g110x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1505.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1505.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(32)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(32)>;
+	ranges = <0x0 0x0 DT_SIZE_K(32)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1505.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1505.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(32)>;
+			ranges = <0x0 0x0 DT_SIZE_K(32)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1505.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1505.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g150x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1506.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1506.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+	ranges = <0x0 0x0 DT_SIZE_K(64)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1506.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1506.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(64)>;
+			ranges = <0x0 0x0 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1506.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1506.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g150x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1507.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1507.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1507.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1507.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1507.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1507.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g150x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
@@ -17,16 +17,25 @@
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash1: serial-flash@40000 {
+		flash1: flash@40000 {
 			reg = <0x40000 DT_SIZE_K(128)>;
+			ranges = <0x0 0x40000 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash2: serial-flash@41e00000 {
+		flash2: flash@41e00000 {
 			reg = <0x41e00000 DT_SIZE_K(16)>;
+			ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
@@ -16,17 +16,32 @@
 		sram1: memory@20210000 {
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
+	};
+};
 
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
+};
 
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(128)>;
-		};
+&flashctl {
+	flash1: flash@40000 {
+		compatible = "soc-nv-flash";
+		reg = <0x40000 DT_SIZE_K(128)>;
+		ranges = <0x0 0x40000 DT_SIZE_K(128)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
+	};
 
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
+	flash2: flash@41e00000 {
+		compatible = "soc-nv-flash";
+		reg = <0x41e00000 DT_SIZE_K(16)>;
+		ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
@@ -17,16 +17,25 @@
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(256)>;
+			ranges = <0x0 0x0 DT_SIZE_K(256)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash1: serial-flash@40000 {
+		flash1: flash@40000 {
 			reg = <0x40000 DT_SIZE_K(256)>;
+			ranges = <0x0 0x40000 DT_SIZE_K(256)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash2: serial-flash@41e00000 {
+		flash2: flash@41e00000 {
 			reg = <0x41e00000 DT_SIZE_K(16)>;
+			ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
@@ -16,17 +16,32 @@
 		sram1: memory@20210000 {
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
+	};
+};
 
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(256)>;
-		};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(256)>;
+	ranges = <0x0 0x0 DT_SIZE_K(256)>;
+};
 
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(256)>;
-		};
+&flashctl {
+	flash1: flash@40000 {
+		compatible = "soc-nv-flash";
+		reg = <0x40000 DT_SIZE_K(256)>;
+		ranges = <0x0 0x40000 DT_SIZE_K(256)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
+	};
 
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
+	flash2: flash@41e00000 {
+		compatible = "soc-nv-flash";
+		reg = <0x41e00000 DT_SIZE_K(16)>;
+		ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3105.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3105.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(32)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(32)>;
+	ranges = <0x0 0x0 DT_SIZE_K(32)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3105.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3105.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(32)>;
+			ranges = <0x0 0x0 DT_SIZE_K(32)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3105.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3105.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g310x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3106.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3106.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+	ranges = <0x0 0x0 DT_SIZE_K(64)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3106.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3106.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(64)>;
+			ranges = <0x0 0x0 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3106.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3106.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g310x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3107.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3107.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3107.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3107.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3107.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3107.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g310x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3505.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3505.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(32)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(32)>;
+	ranges = <0x0 0x0 DT_SIZE_K(32)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3505.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3505.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(16)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(32)>;
+			ranges = <0x0 0x0 DT_SIZE_K(32)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3505.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3505.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g350x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3506.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3506.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+	ranges = <0x0 0x0 DT_SIZE_K(64)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3506.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3506.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(64)>;
+			ranges = <0x0 0x0 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3506.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3506.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g350x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3507.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3507.dtsi
@@ -8,9 +8,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3507.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3507.dtsi
@@ -9,8 +9,11 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3507.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3507.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0g350x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
@@ -17,16 +17,25 @@
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash1: serial-flash@40000 {
+		flash1: flash@40000 {
 			reg = <0x40000 DT_SIZE_K(128)>;
+			ranges = <0x0 0x40000 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash2: serial-flash@41e00000 {
+		flash2: flash@41e00000 {
 			reg = <0x41e00000 DT_SIZE_K(16)>;
+			ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
@@ -16,17 +16,32 @@
 		sram1: memory@20210000 {
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
+	};
+};
 
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
+};
 
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(128)>;
-		};
+&flashctl {
+	flash1: flash@40000 {
+		compatible = "soc-nv-flash";
+		reg = <0x40000 DT_SIZE_K(128)>;
+		ranges = <0x0 0x40000 DT_SIZE_K(128)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
+	};
 
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
+	flash2: flash@41e00000 {
+		compatible = "soc-nv-flash";
+		reg = <0x41e00000 DT_SIZE_K(16)>;
+		ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
@@ -17,16 +17,25 @@
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(256)>;
+			ranges = <0x0 0x0 DT_SIZE_K(256)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash1: serial-flash@40000 {
+		flash1: flash@40000 {
 			reg = <0x40000 DT_SIZE_K(256)>;
+			ranges = <0x0 0x40000 DT_SIZE_K(256)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
-		flash2: serial-flash@41e00000 {
+		flash2: flash@41e00000 {
 			reg = <0x41e00000 DT_SIZE_K(16)>;
+			ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments Incorporated
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
@@ -16,17 +16,32 @@
 		sram1: memory@20210000 {
 			reg = <0x20210000 DT_SIZE_K(64)>;
 		};
+	};
+};
 
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(256)>;
-		};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(256)>;
+	ranges = <0x0 0x0 DT_SIZE_K(256)>;
+};
 
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(256)>;
-		};
+&flashctl {
+	flash1: flash@40000 {
+		compatible = "soc-nv-flash";
+		reg = <0x40000 DT_SIZE_K(256)>;
+		ranges = <0x0 0x40000 DT_SIZE_K(256)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
+	};
 
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
+	flash2: flash@41e00000 {
+		compatible = "soc-nv-flash";
+		reg = <0x41e00000 DT_SIZE_K(16)>;
+		ranges = <0x0 0x41e00000 DT_SIZE_K(16)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <1024>;
+		write-block-size = <8>;
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1105.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1105.dtsi
@@ -8,10 +8,7 @@
 #include <mem.h>
 #include <ti/mspm0/l/mspm0l110x.dtsi>
 
-/ {
-	soc {
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(32)>;
-		};
-	};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(32)>;
+	ranges = <0x0 0x0 DT_SIZE_K(32)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1105.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1105.dtsi
@@ -10,8 +10,11 @@
 
 / {
 	soc {
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(32)>;
+			ranges = <0x0 0x0 DT_SIZE_K(32)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1106.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1106.dtsi
@@ -8,10 +8,7 @@
 #include <mem.h>
 #include <ti/mspm0/l/mspm0l110x.dtsi>
 
-/ {
-	soc {
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-	};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+	ranges = <0x0 0x0 DT_SIZE_K(64)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1106.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1106.dtsi
@@ -10,8 +10,11 @@
 
 / {
 	soc {
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(64)>;
+			ranges = <0x0 0x0 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1117.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1117.dtsi
@@ -8,10 +8,7 @@
 #include <mem.h>
 #include <ti/mspm0/l/mspm0l111x.dtsi>
 
-/ {
-	soc {
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
-	};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1117.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1117.dtsi
@@ -10,8 +10,11 @@
 
 / {
 	soc {
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1227.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1227.dtsi
@@ -8,10 +8,7 @@
 #include <mem.h>
 #include <ti/mspm0/l/mspm0lx22x.dtsi>
 
-/ {
-	soc {
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
-	};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1227.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1227.dtsi
@@ -10,8 +10,11 @@
 
 / {
 	soc {
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1228.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1228.dtsi
@@ -8,10 +8,7 @@
 #include <mem.h>
 #include <ti/mspm0/l/mspm0lx22x.dtsi>
 
-/ {
-	soc {
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(256)>;
-		};
-	};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(256)>;
+	ranges = <0x0 0x0 DT_SIZE_K(256)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l1228.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l1228.dtsi
@@ -10,8 +10,11 @@
 
 / {
 	soc {
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(256)>;
+			ranges = <0x0 0x0 DT_SIZE_K(256)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x3.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x3.dtsi
@@ -13,9 +13,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(2)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(8)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(8)>;
+	ranges = <0x0 0x0 DT_SIZE_K(8)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x3.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x3.dtsi
@@ -14,8 +14,11 @@
 			reg = <0x20000000 DT_SIZE_K(2)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(8)>;
+			ranges = <0x0 0x0 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x4.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x4.dtsi
@@ -13,9 +13,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(2)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(16)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(16)>;
+	ranges = <0x0 0x0 DT_SIZE_K(16)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x4.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x4.dtsi
@@ -14,8 +14,11 @@
 			reg = <0x20000000 DT_SIZE_K(2)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(16)>;
+			ranges = <0x0 0x0 DT_SIZE_K(16)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x5.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x5.dtsi
@@ -13,9 +13,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(4)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(32)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(32)>;
+	ranges = <0x0 0x0 DT_SIZE_K(32)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x5.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x5.dtsi
@@ -14,8 +14,11 @@
 			reg = <0x20000000 DT_SIZE_K(4)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(32)>;
+			ranges = <0x0 0x0 DT_SIZE_K(32)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x6.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x6.dtsi
@@ -13,9 +13,10 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(4)>;
 		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+	ranges = <0x0 0x0 DT_SIZE_K(64)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l13x6.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l13x6.dtsi
@@ -14,8 +14,11 @@
 			reg = <0x20000000 DT_SIZE_K(4)>;
 		};
 
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(64)>;
+			ranges = <0x0 0x0 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l2227.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l2227.dtsi
@@ -8,10 +8,7 @@
 #include <mem.h>
 #include <ti/mspm0/l/mspm0lx22x.dtsi>
 
-/ {
-	soc {
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
-	};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(128)>;
+	ranges = <0x0 0x0 DT_SIZE_K(128)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l2227.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l2227.dtsi
@@ -10,8 +10,11 @@
 
 / {
 	soc {
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(128)>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/l/mspm0l2228.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l2228.dtsi
@@ -8,10 +8,7 @@
 #include <mem.h>
 #include <ti/mspm0/l/mspm0lx22x.dtsi>
 
-/ {
-	soc {
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(256)>;
-		};
-	};
+&flash0 {
+	reg = <0x0 DT_SIZE_K(256)>;
+	ranges = <0x0 0x0 DT_SIZE_K(256)>;
 };

--- a/dts/arm/ti/mspm0/l/mspm0l2228.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l2228.dtsi
@@ -10,8 +10,11 @@
 
 / {
 	soc {
-		flash0: serial-flash@0 {
+		flash0: flash@0 {
 			reg = <0x0 DT_SIZE_K(256)>;
+			ranges = <0x0 0x0 DT_SIZE_K(256)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 	};
 };

--- a/dts/arm/ti/mspm0/mspm0.dtsi
+++ b/dts/arm/ti/mspm0/mspm0.dtsi
@@ -156,8 +156,8 @@
 			compatible = "mmio-sram";
 		};
 
-		flash0: serial-flash@0 {
-			compatible = "serial-flash";
+		flash0: flash@0 {
+			compatible = "soc-nv-flash";
 		};
 
 		wdt0: wdt0@40080000 {

--- a/dts/arm/ti/mspm0/mspm0.dtsi
+++ b/dts/arm/ti/mspm0/mspm0.dtsi
@@ -156,8 +156,20 @@
 			compatible = "mmio-sram";
 		};
 
-		flash0: serial-flash@0 {
-			compatible = "serial-flash";
+		flashctl: flash-controller@400cd000 {
+			compatible = "ti,mspm0-flash-controller";
+			reg = <0x400cd000 0x2000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				erase-block-size = <1024>;
+				write-block-size = <8>;
+			};
 		};
 
 		wdt0: wdt0@40080000 {

--- a/dts/bindings/flash_controller/ti,mspm0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/ti,mspm0-flash-controller.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Texas Instruments Incorporated
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI MSPM0 internal flash controller
+
+compatible: "ti,mspm0-flash-controller"
+
+include: flash-controller.yaml


### PR DESCRIPTION
- MSPM0 internal flash is memory-mapped. Switch lp_mspm0l2228 and lp_mspm0g3507 from _fixed-partitions_ to _zephyr,mapped-partition_ per the 4.4 migration guide.

- fixes a long-standing incorrect compatible on all MSPM0 SoC DTSIs. 
MSPM0 internal flash is directly memory-mapped in the ARM address space — "serial-flash" implied a non-memory-mapped serial interface and has no Zephyr binding. 
Replaced with "soc-nv-flash" and node name corrected to flash throughout all 28 affected DTSIs.

Closes #107737