### PR TITLE
shell: fix state race between shell_stop() and state_collect()

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1247,7 +1247,10 @@ int shell_start(const struct shell *sh);
  *
  * @param sh Pointer to shell instance.
  *
- * @return Standard error code.
+ * @retval 0 On success.
+ * @retval -ENOTSUP If the shell is already stopped or not yet started.
+ * @retval -EBUSY If the shell thread is currently processing received data
+ *  (e.g. executing a command). Retry once processing completes.
  */
 int shell_stop(const struct shell *sh);
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1979,11 +1979,26 @@ int shell_stop(const struct shell *sh)
 		return -ENOTSUP;
 	}
 
+	/*
+	 * This is the same lock shell_thread() holds for as long as it's
+	 * busy in shell_process()/state_collect(). If we don't grab it here
+	 * too, we can race with a command that's still running on the shell
+	 * thread: it ends with an unconditional state_set(ACTIVE), which
+	 * stomps on the SHELL_STATE_INITIALIZED we're setting below and the
+	 * log backend is left disabled for good (shell_start() won't touch
+	 * it since the state looks wrong).
+	 */
+	if (!z_shell_trylock(sh, SHELL_TX_MTX_TIMEOUT)) {
+		return -EBUSY;
+	}
+
 	state_set(sh, SHELL_STATE_INITIALIZED);
 
 	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 		z_shell_log_backend_disable(sh->log_backend);
 	}
+
+	z_shell_unlock(sh);
 
 	return 0;
 }


### PR DESCRIPTION
`shell_stop()` read/wrote `sh->ctx->state` without taking the shell lock. If a command was still running on the shell thread, `state_collect()` would finish with an unconditional `state_set(ACTIVE)`, clobbering the `SHELL_STATE_INITIALIZED` `shell_stop()` had just set. The log backend was left disabled and `shell_start()` would then fail with -ENOTSUP.

Fix by having shell_stop() take the same lock shell_thread() already holds during `shell_process()`/`state_collect()`, like `shell_start()` already does. Returns `-EBUSY` if the lock is busy.

Fixes #115019