### PR TITLE
drivers: sdhc: set SDHC_INIT_PRIORITY to KERNEL_INIT_PRIORITY_DEVICE

### DIFF
--- a/drivers/sdhc/Kconfig
+++ b/drivers/sdhc/Kconfig
@@ -34,7 +34,7 @@ source "drivers/sdhc/Kconfig.xlnx"
 
 config SDHC_INIT_PRIORITY
 	int "SDHC driver init priority"
-	default 85
+	default KERNEL_INIT_PRIORITY_DEVICE
 	help
 	  SDHC driver system init priority
 


### PR DESCRIPTION
set the default of SDHC_INIT_PRIORITY to
KERNEL_INIT_PRIORITY_DEVICE, just like at the other driver priorities.