### PR TITLE
Bluetooth: Fix uses of BT_HCI_ERR_REMOTE_USER_TERM_CONN

### DIFF
--- a/samples/bluetooth/audio/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/audio/bap_broadcast_assistant/src/main.c
@@ -604,7 +604,7 @@ static void reset(void)
 	printk("\n\nResetting...\n\n");
 
 	if (broadcast_sink_conn != NULL) {
-		err = bt_conn_disconnect(broadcast_sink_conn, BT_HCI_ERR_LOCALHOST_TERM_CONN);
+		err = bt_conn_disconnect(broadcast_sink_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 		if (err != 0) {
 			printk("bt_conn_disconnect failed with %d\n", err);

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -794,7 +794,7 @@ static void hfp_ag_close_sco(struct bt_hfp_ag *ag)
 
 	if (sco != NULL) {
 		LOG_DBG("Disconnect sco %p", sco);
-		bt_conn_disconnect(sco, BT_HCI_ERR_LOCALHOST_TERM_CONN);
+		bt_conn_disconnect(sco, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }
 

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 #include <errno.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -288,7 +289,7 @@ static void test_main(void)
 			gatt_read(long_chrc_handle);
 		}
 
-		err = bt_conn_disconnect(g_conn, 0x13);
+		err = bt_conn_disconnect(g_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		if (err != 0) {
 			TEST_FAIL("Disconnect failed (err %d)", err);
 			return;

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <errno.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -183,7 +184,7 @@ static void test_central_main(void)
 
 	WAIT_FOR_FLAG(flag_is_connected);
 
-	err = bt_conn_disconnect(g_conn, 0x13);
+	err = bt_conn_disconnect(g_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	if (err != 0) {
 		TEST_FAIL("Disconnect failed (err %d)", err);


### PR DESCRIPTION
Some minor changes to use BT_HCI_ERR_REMOTE_USER_TERM_CONN instead of BT_HCI_ERR_LOCALHOST_TERM_CONN or hardcoded values. 