### PR TITLE
drivers: modem: quectel_bc66x: fix default priority init

### DIFF
--- a/drivers/modem/vendor_standalone/quectel/bc66x/Kconfig.quectel-bc66x
+++ b/drivers/modem/vendor_standalone/quectel/bc66x/Kconfig.quectel-bc66x
@@ -59,14 +59,14 @@ config MODEM_QUECTEL_BC66X_WORKQ_PRIORITY
 
 config MODEM_QUECTEL_BC66X_INIT_PRIORITY
 	int "Quectel BC66x modem driver initialization priority"
-	default 91
+	default 75
 	range 0 99
 	help
 	  This priority must be < MODEM_QUECTEL_BC66X_NET_INIT_PRIORITY
 
 config MODEM_QUECTEL_BC66X_NET_INIT_PRIORITY
 	int "Net device init priority"
-	default 92
+	default 80
 	range 0 99
 	help
 	  This priority must be > MODEM_QUECTEL_BC66X_INIT_PRIORITY


### PR DESCRIPTION
Fix BC66x initialization priorities, to run before the readiness check in `offloaded_if_api`.

A "recent" add in the `subsys/net/ip/net_if.c` made the default init priorities invalid.  The added checking must run after device initialization, otherwise it causes the interface init to be skipped ([source](https://github.com/zephyrproject-rtos/zephyr/blame/d820dddaab31c7c1752f4f2ecb61dc1c59063b34/subsys/net/ip/net_if.c#L452)):
```c
	if (!device_is_ready(dev)) {
		NET_ERR("Iface %p device not ready", iface);
		return;
	}
```

A lower `CONFIG_MODEM_QUECTEL_BC66X_NET_INIT_PRIORITY` default allow the net device to be ready before the checking runs (with priority `CONFIG_NET_INIT_PRIO`).
