### PR TITLE
Bluetooth: CAP: Handle disconnects during procedures

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -39,8 +39,6 @@ LOG_MODULE_REGISTER(bt_cap_commander, CONFIG_BT_CAP_COMMANDER_LOG_LEVEL);
 
 #include "common/bt_str.h"
 
-static void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc);
-
 static const struct bt_cap_commander_cb *cap_cb;
 
 int bt_cap_commander_register_cb(const struct bt_cap_commander_cb *cb)
@@ -1502,7 +1500,7 @@ void cap_commander_register_broadcast_assistant_callbacks(void)
  *
  * This will also unlock the provided @p active_proc
  */
-static void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc)
+void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc)
 {
 	enum bt_cap_common_proc_type proc_type;
 	struct bt_conn *failed_conn;

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -264,22 +264,65 @@ bool bt_cap_common_stream_in_active_proc(const struct bt_cap_stream *cap_stream)
 	return false;
 }
 
-void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
+static void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	struct bt_cap_common_proc *active_proc_ptr = bt_cap_common_get_active_proc();
 	struct bt_cap_common_client *client = bt_cap_common_get_client_by_acl(conn);
 
 	ARG_UNUSED(reason);
 
 	LOG_DBG("conn %p disconnected", conn);
 
-	if (client->conn != NULL) {
-		bt_conn_unref(client->conn);
-	}
+	bt_conn_drop(&client->conn);
 	(void)memset(client, 0, sizeof(*client));
 
 	if (bt_cap_common_conn_in_active_proc(conn)) {
 		bt_cap_common_abort_proc(conn, -ECONNRESET);
+
+#if defined(CONFIG_BT_CAP_INITIATOR_UNICAST)
+		if (active_proc_is_initiator()) {
+			/* For Initiator procedures, we may have multiple procedures per connection,
+			 * so loop through and count the ones that we consider "done"
+			 */
+			for (size_t i = 0U; i < active_proc_ptr->proc_initiated_cnt; i++) {
+				struct bt_cap_initiator_proc_param *proc_param =
+					&active_proc_ptr->proc_param.initiator[i];
+
+				if (proc_param->in_progress &&
+				    proc_param->stream->bap_stream.conn == conn) {
+					proc_param->in_progress = false;
+					active_proc_ptr->proc_done_cnt++;
+					/* bap_stream.conn will be cleared by BAP */
+				}
+			}
+
+			if (bt_cap_common_proc_all_handled()) {
+				cap_initiator_unicast_audio_proc_complete(active_proc_ptr);
+				return;
+			}
+		}
+#endif /* CONFIG_BT_CAP_INITIATOR_UNICAST */
+#if defined(CONFIG_BT_CAP_COMMANDER)
+		if (active_proc_is_commander()) {
+			/* For Commander procedures there is a 1:1 between number of procedures and
+			 * connections, so we always just increment by 1
+			 */
+			for (size_t i = 0U; i < active_proc_ptr->proc_initiated_cnt; i++) {
+				if (active_proc.proc_param.commander[i].conn == conn) {
+					active_proc.proc_param.commander[i].conn = NULL;
+					active_proc_ptr->proc_done_cnt++;
+				}
+			}
+
+			if (bt_cap_common_proc_all_handled()) {
+				cap_commander_proc_complete(active_proc_ptr);
+				return;
+			}
+		}
+#endif /* CONFIG_BT_CAP_INITIATOR_UNICAST */
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1358,7 +1358,7 @@ bool bt_cap_initiator_valid_unicast_audio_start_param(
 	return true;
 }
 
-static void cap_initiator_unicast_audio_proc_complete(struct bt_cap_common_proc *active_proc)
+void cap_initiator_unicast_audio_proc_complete(struct bt_cap_common_proc *active_proc)
 {
 	enum bt_cap_common_proc_type proc_type;
 	struct bt_conn *failed_conn;

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -322,7 +322,6 @@ bool bt_cap_common_proc_is_done(void);
 void bt_cap_common_abort_proc(struct bt_conn *conn, int err);
 bool bt_cap_common_conn_in_active_proc(const struct bt_conn *conn);
 bool bt_cap_common_stream_in_active_proc(const struct bt_cap_stream *cap_stream);
-void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason);
 struct bt_cap_common_client *bt_cap_common_get_client_by_acl(const struct bt_conn *acl);
 struct bt_cap_common_client *
 bt_cap_common_get_client_by_csis(const struct bt_csip_set_coordinator_csis_inst *csis_inst);
@@ -342,6 +341,7 @@ int cap_initiator_unicast_audio_start(struct bt_cap_common_proc *active_proc,
 int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 				     const struct bt_cap_unicast_audio_stop_param *param);
 enum bt_bap_ep_state bt_cap_initiator_stream_get_state(const struct bt_bap_stream *bap_stream);
+void cap_initiator_unicast_audio_proc_complete(struct bt_cap_common_proc *active_proc);
 
 int cap_commander_broadcast_reception_start(
 	struct bt_cap_common_proc *active_proc,
@@ -352,6 +352,7 @@ int cap_commander_broadcast_reception_stop(
 bool bt_cap_commander_valid_broadcast_reception_stop_param(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param);
 void cap_commander_register_broadcast_assistant_callbacks(void);
+void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc);
 
 /** Completes the handover procedure. This also unlocks the active_proc_mutex. */
 void bt_cap_handover_complete(struct bt_cap_common_proc *active_proc);

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -26,7 +26,9 @@
 #include <zephyr/bluetooth/audio/vcp.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/byteorder.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
@@ -61,6 +63,8 @@ CREATE_FLAG(flag_pa_request);
 CREATE_FLAG(flag_bis_sync_requested);
 CREATE_FLAG(flag_base_metadata_updated);
 CREATE_FLAG(flag_unicast_stream_configured);
+
+CREATE_FLAG(flag_disconnect_in_procedure);
 
 static const struct bt_bap_scan_delegator_recv_state *g_recv_state;
 static struct bt_bap_broadcast_sink *g_broadcast_sink;
@@ -646,7 +650,10 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 			   const struct bt_bap_scan_delegator_recv_state *recv_state,
 			   const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS])
 {
-	ARG_UNUSED(conn);
+	if (conn != default_conn) {
+		FAIL("Unexpected connection %p != %p", conn, default_conn);
+		return -EINVAL;
+	}
 
 	if (recv_state != g_recv_state) {
 		FAIL("Unexpected receive state: %p != %p", recv_state, g_recv_state);
@@ -668,7 +675,15 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 		UNSET_FLAG(flag_bis_sync_requested);
 	}
 
-	update_sink_state();
+	if (TEST_FLAG(flag_disconnect_in_procedure)) {
+		const int err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
+		if (err != 0) {
+			FAIL("Failed to disconnect: %d", err);
+		}
+	} else {
+		update_sink_state();
+	}
 
 	return 0;
 }
@@ -815,6 +830,14 @@ static int unicast_server_enable(struct bt_bap_stream *stream, const uint8_t met
 				 size_t meta_len, struct bt_bap_ascs_rsp *rsp)
 {
 	LOG_INF("Enable: stream %p meta_len %zu", stream, meta_len);
+
+	if (TEST_FLAG(flag_disconnect_in_procedure)) {
+		const int err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
+		if (err != 0) {
+			FAIL("Failed to disconnect: %d", err);
+		}
+	}
 
 	return bt_audio_data_parse(meta, meta_len, ascs_data_func_cb, rsp);
 }
@@ -1209,7 +1232,21 @@ static void test_cap_acceptor_unicast_timeout(void)
 
 	WAIT_FOR_FLAG(flag_connected);
 
-	PASS("CAP acceptor unicast passed\n");
+	PASS("CAP acceptor unicast timeout passed\n");
+}
+
+static void test_cap_acceptor_unicast_disconnect(void)
+{
+	init();
+
+	test_start_adv();
+
+	SET_FLAG(flag_disconnect_in_procedure); /* Disconnect during CAP Unicast Audio Start */
+
+	WAIT_FOR_FLAG(flag_connected);
+	WAIT_FOR_UNSET_FLAG(flag_connected);
+
+	PASS("CAP acceptor unicast disconnect passed\n");
 }
 
 static void pa_sync_to_broadcaster(void)
@@ -1343,6 +1380,27 @@ static void test_cap_acceptor_broadcast_reception_reject_first(void)
 	test_cap_acceptor_broadcast_reception();
 }
 
+static void test_cap_acceptor_broadcast_reception_disconnect(void)
+{
+	SET_FLAG(flag_disconnect_in_procedure);
+
+	init();
+
+	test_start_adv();
+
+	LOG_INF("Waiting for PA sync request");
+	WAIT_FOR_FLAG(flag_pa_request);
+
+	LOG_INF("Waiting for BIS sync request");
+	WAIT_FOR_FLAG(flag_bis_sync_requested); /* We disconnect after this */
+
+	backchannel_sync_send_all(); /* let others know we have received what we wanted */
+
+	WAIT_FOR_UNSET_FLAG(flag_connected);
+
+	PASS("CAP acceptor broadcast reception disconnect passed\n");
+}
+
 static void test_cap_acceptor_capture_and_render(void)
 {
 	init();
@@ -1351,7 +1409,7 @@ static void test_cap_acceptor_capture_and_render(void)
 
 	WAIT_FOR_FLAG(flag_connected);
 
-	PASS("CAP acceptor unicast passed\n");
+	PASS("CAP acceptor capture and render passed\n");
 }
 
 static const struct bst_test_instance test_cap_acceptor[] = {
@@ -1366,6 +1424,12 @@ static const struct bst_test_instance test_cap_acceptor[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_cap_acceptor_unicast_timeout,
+	},
+	{
+		.test_id = "cap_acceptor_unicast_disconnect",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_cap_acceptor_unicast_disconnect,
 	},
 	{
 		.test_id = "cap_acceptor_broadcast",
@@ -1390,6 +1454,12 @@ static const struct bst_test_instance test_cap_acceptor[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_cap_acceptor_broadcast_reception_reject_first,
+	},
+	{
+		.test_id = "cap_acceptor_broadcast_reception_disconnect",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_cap_acceptor_broadcast_reception_disconnect,
 	},
 	{
 		.test_id = "cap_acceptor_capture_and_render",

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -1421,6 +1421,48 @@ static void test_main_cap_commander_cancel(void)
 	PASS("Broadcast reception passed\n");
 }
 
+static void test_main_cap_commander_disconnect(void)
+{
+	size_t acceptor_count;
+
+	/* The test consists of N devices
+	 * 1 device is the broadcast source
+	 * 1 device is the CAP commander
+	 * This leaves N - 2 devices for the acceptor
+	 */
+	if (get_dev_cnt() < 3U) {
+		FAIL("Test needs at least 3 devices");
+		return;
+	}
+
+	acceptor_count = get_dev_cnt() - 2U;
+	LOG_DBG("Acceptor count: %zu", acceptor_count);
+
+	init(acceptor_count);
+
+	for (size_t i = 0U; i < acceptor_count; i++) {
+		scan_and_connect();
+
+		WAIT_FOR_FLAG(flag_mtu_exchanged);
+	}
+
+	/* TODO: We should use CSIP to find set members */
+	discover_cas(acceptor_count);
+	discover_bass(acceptor_count);
+
+	pa_sync_to_broadcaster();
+
+	LOG_INF("Attempting reception start on %zu connections", connected_conn_cnt);
+	test_broadcast_reception_start(connected_conns, connected_conn_cnt);
+	WAIT_FOR_FLAG(flag_broadcast_reception_start_failed);
+
+	backchannel_sync_send_all(); /* let others know we have received what we wanted */
+
+	deinit();
+
+	PASS("CAP Commander disconnect passed\n");
+}
+
 static const struct bst_test_instance test_cap_commander[] = {
 	{
 		.test_id = "cap_commander_capture_and_render",
@@ -1445,6 +1487,12 @@ static const struct bst_test_instance test_cap_commander[] = {
 		.test_post_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_main_cap_commander_cancel,
+	},
+	{
+		.test_id = "cap_commander_disconnect",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_main_cap_commander_disconnect,
 	},
 	BSTEST_END_MARKER,
 };

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -1142,6 +1142,34 @@ static void test_cap_initiator_unicast_ase_error(void)
 	PASS("CAP initiator unicast ASE error passed\n");
 }
 
+static void test_cap_initiator_unicast_disconnect(void)
+{
+	struct bt_cap_unicast_group *unicast_group;
+
+	init();
+
+	scan_and_connect();
+
+	WAIT_FOR_FLAG(flag_mtu_exchanged);
+
+	update_security(default_conn);
+
+	discover_cas(default_conn);
+	discover_sink(default_conn);
+	discover_source(default_conn);
+
+	unicast_group_create(&unicast_group);
+
+	unicast_audio_start(unicast_group, false);
+	WAIT_FOR_UNSET_FLAG(flag_connected);
+	WAIT_FOR_FLAG(flag_start_failed);
+
+	unicast_group_delete(unicast_group);
+	unicast_group = NULL;
+
+	PASS("CAP initiator unicast disconnect passed\n");
+}
+
 static const struct named_lc3_preset *cap_get_named_preset(const char *preset_arg)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(lc3_unicast_presets); i++) {
@@ -1856,6 +1884,12 @@ static const struct bst_test_instance test_cap_initiator_unicast[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_cap_initiator_unicast_ase_error,
+	},
+	{
+		.test_id = "cap_initiator_unicast_disconnect",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_cap_initiator_unicast_disconnect,
 	},
 	{
 		.test_id = "cap_initiator_unicast_inval",

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_commander_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_commander_disconnect.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_commander_disconnect"
+VERBOSITY_LEVEL=2
+NR_OF_DEVICES=3
+EXECUTE_TIMEOUT=180
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running CAP commander disconnect test =========\n\n"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_commander_disconnect \
+  -RealEncryption=1 -rs=46 -D=${NR_OF_DEVICES}
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_initiator_broadcast \
+  -RealEncryption=1 -rs=23 -D=${NR_OF_DEVICES}
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 \
+  -testid=cap_acceptor_broadcast_reception_disconnect \
+  -RealEncryption=1 -rs=23 -D=${NR_OF_DEVICES}
+
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=${NR_OF_DEVICES} -sim_length=60e6 $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_disconnect.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_unicast_disconnect"
+VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running CAP unicast disconnect test =========\n\n"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_disconnect \
+  -RealEncryption=1 -rs=46 -D=2
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast_disconnect \
+  -RealEncryption=1 -rs=23 -D=2
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Add support for handling disconnects during CAP procedures. We treat a disconnect the same way as a write reject / error, and stop the procedure when it happens.

This explicit handling is needed since many of the subprocedures in CAP are notification based, and thus we won't get an error from GATT when there's a disconnect.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/113788