### PR TITLE
samples: Bluetooth: Classic: Fix duplicated tests

### DIFF
--- a/samples/bluetooth/classic/a2dp_source/tests.yaml
+++ b/samples/bluetooth/classic/a2dp_source/tests.yaml
@@ -19,7 +19,7 @@ tests:
     extra_args:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
     build_only: true
-  sample.bluetooth.a2dp.sink.nxp_m2_2el_wifi_bt.no_blobs:
+  sample.bluetooth.a2dp.source.nxp_m2_2el_wifi_bt.no_blobs:
     platform_allow:
       - mimxrt1060_evk@C/mimxrt1062/qspi
     tags:

--- a/samples/bluetooth/classic/handsfree/tests.yaml
+++ b/samples/bluetooth/classic/handsfree/tests.yaml
@@ -19,7 +19,7 @@ tests:
     extra_args:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
     build_only: true
-  sample.bluetooth.a2dp.sink.nxp_m2_2el_wifi_bt.no_blobs:
+  sample.bluetooth.handsfree.nxp_m2_2el_wifi_bt.no_blobs:
     platform_allow:
       - mimxrt1060_evk@C/mimxrt1062/qspi
     tags:


### PR DESCRIPTION
Some tests had the same name which is clearly wrong, and this causes CI issues. Changed the test names to be correct.