### PR TITLE
net: coap: implement server OSCORE replay-window resync

### DIFF
--- a/doc/services/connectivity/networking/api/coap_oscore.rst
+++ b/doc/services/connectivity/networking/api/coap_oscore.rst
@@ -160,14 +160,7 @@ Known Limitations
    contexts within a service. Each service can use only one OSCORE context at a time,
    so all clients share that context. This is sufficient for many use cases, but it
    does not allow separate contexts per client.
-2. **Reboot Replay Recovery (Echo)**: The Echo-based freshness exchange for restored
-   contexts (:rfc:`8613` Appendix B.1.2, :rfc:`9175`) is not implemented. When uoscore reports
-   the first request after a reboot, the server rejects it with 4.01 Unauthorized instead
-   of answering with an Echo challenge, so a client cannot automatically re-synchronize.
-   This is fail-closed meaning no unprotected or replayed request is accepted but a
-   reused or restored context cannot recover after a reboot without re-establishing the
-   context out of band.
-3. **Mixed-Service Expired-Exchange Plaintext**: On a mixed service (one that serves
+2. **Mixed-Service Expired-Exchange Plaintext**: On a mixed service (one that serves
    both OSCORE and non-OSCORE clients), a response whose exchange cache entry has
    expired can no longer be matched to its OSCORE state and is sent as plaintext. This
    affects both synchronous and deferred (separate) responses (see

--- a/doc/services/connectivity/networking/api/coap_oscore.rst
+++ b/doc/services/connectivity/networking/api/coap_oscore.rst
@@ -1,7 +1,7 @@
 .. _coap_oscore_interface:
 
-OSCORE Support (RFC 8613)
-#########################
+OSCORE Support (:rfc:`8613`)
+############################
 
 .. contents::
     :local:
@@ -112,11 +112,11 @@ service.
 When a service is OSCORE-enabled (its context provider returns a context):
 
 1. **Incoming requests**: The server automatically verifies and decrypts OSCORE-protected
-   requests (RFC 8613 Section 8.2). Resource handlers receive decrypted CoAP messages
+   requests (:rfc:`8613` Section 8.2). Resource handlers receive decrypted CoAP messages
    with Inner options visible.
 
 2. **Outgoing responses**: The server automatically OSCORE-protects responses and
-   notifications that originate from an OSCORE exchange (RFC 8613 Section 8.3).
+   notifications that originate from an OSCORE exchange (:rfc:`8613` Section 8.3).
    Whether a given outgoing message must be protected is decided as follows:
 
    - **Synchronous responses**, produced while the request is being handled, are matched
@@ -134,7 +134,7 @@ When a service is OSCORE-enabled (its context provider returns a context):
       cache entry has expired will result in a plaintext response.
 
 3. **Error handling**: OSCORE verification errors are sent as simple CoAP responses
-    **without** OSCORE processing (RFC 8613 Section 8.2):
+    **without** OSCORE processing (:rfc:`8613` Section 8.2):
     - COSE decode failure → 4.02 Bad Option
     - Security context not found → 4.01 Unauthorized
     - Decryption failure → 4.00 Bad Request
@@ -160,19 +160,14 @@ Known Limitations
    contexts within a service. Each service can use only one OSCORE context at a time,
    so all clients share that context. This is sufficient for many use cases, but it
    does not allow separate contexts per client.
-2. **Context Reuse Across Reboots**: Only freshly derived security contexts are
-   supported, i.e. contexts created with ``fresh_master_secret_salt = true`` where the
-   Master Secret / Master Salt combination is unique at every boot (for example, derived
-   via EDHOC). Applications that cannot guarantee a fresh context at every boot
-   must not enable OSCORE for the time being.
-3. **Reboot Replay Recovery (Echo)**: The Echo-based freshness exchange for restored
-   contexts (RFC 8613 Appendix B.1.2, RFC 9175) is not implemented. When uoscore reports
+2. **Reboot Replay Recovery (Echo)**: The Echo-based freshness exchange for restored
+   contexts (:rfc:`8613` Appendix B.1.2, :rfc:`9175`) is not implemented. When uoscore reports
    the first request after a reboot, the server rejects it with 4.01 Unauthorized instead
    of answering with an Echo challenge, so a client cannot automatically re-synchronize.
    This is fail-closed meaning no unprotected or replayed request is accepted but a
    reused or restored context cannot recover after a reboot without re-establishing the
    context out of band.
-4. **Mixed-Service Expired-Exchange Plaintext**: On a mixed service (one that serves
+3. **Mixed-Service Expired-Exchange Plaintext**: On a mixed service (one that serves
    both OSCORE and non-OSCORE clients), a response whose exchange cache entry has
    expired can no longer be matched to its OSCORE state and is sent as plaintext. This
    affects both synchronous and deferred (separate) responses (see
@@ -185,7 +180,7 @@ Known Limitations
 Security Context Derivation
 ============================
 
-OSCORE security contexts are derived from a small set of parameters (RFC 8613 Section 3):
+OSCORE security contexts are derived from a small set of parameters (:rfc:`8613` Section 3):
 
 **Required parameters**:
 
@@ -214,21 +209,19 @@ Security Considerations
 2. **Master secret protection**: Master secrets must be stored securely (e.g., in
    secure storage or derived from EDHOC).
 
-3. **Replay window**: The uoscore library maintains a replay window to detect and reject
-   replayed requests. This does not protect against replays across reboots, so the SSN
-   must be persisted to non-volatile memory if the same master secret is reused after a
-   reboot.
-
-4. **Fresh master secrets**: If master secrets are not re-derived after reboot (e.g.,
-   using EDHOC), the sender sequence number must be persisted to non-volatile memory
-   to prevent reuse.
+3. **Persistence across reboots**: If the same master secret is reused after a reboot
+   (i.e., master secrets are not re-derived, e.g., via EDHOC), the sender sequence
+   number must be persisted to non-volatile memory to prevent nonce reuse, which would
+   break confidentiality and integrity. The receiver's replay window does not need to
+   be persisted: it is kept in memory and, after a reboot, is re-synchronized using the
+   Echo option as described in :rfc:`8613` Appendix B.1.2.
 
 Handling OSCORE When Not Supported
 -----------------------------------
 
 When OSCORE support is not enabled (:kconfig:option:`CONFIG_COAP_OSCORE` is not set),
 the Zephyr CoAP stack implements fail-closed behavior for the OSCORE option per
-RFC 7252 Section 5.4.1:
+:rfc:`7252` Section 5.4.1:
 
 **Server behavior** (when ``CONFIG_COAP_OSCORE=n``):
 

--- a/modules/uoscore-uedhoc/CMakeLists.txt
+++ b/modules/uoscore-uedhoc/CMakeLists.txt
@@ -45,6 +45,10 @@ if(CONFIG_UOSCORE OR CONFIG_UEDHOC)
       zephyr_library_compile_definitions(DEBUG_PRINT)
     endif()
 
+    if(CONFIG_UOSCORE_NVM_SUPPORT)
+      zephyr_library_compile_definitions(OSCORE_NVM_SUPPORT)
+    endif()
+
     zephyr_library_sources(
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/aad.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/coap2oscore.c
@@ -61,6 +65,10 @@ if(CONFIG_UOSCORE OR CONFIG_UEDHOC)
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/oscore_aad_array.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/oscore_enc_structure.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/oscore_info.c
+    )
+
+    zephyr_library_sources_ifdef(CONFIG_UOSCORE_NVM_SUPPORT
+      ${CMAKE_CURRENT_LIST_DIR}/uoscore_nvm.c
     )
 
     zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedtls_iface)

--- a/modules/uoscore-uedhoc/Kconfig
+++ b/modules/uoscore-uedhoc/Kconfig
@@ -12,6 +12,10 @@ menuconfig UOSCORE
 
 if UOSCORE
 
+config UOSCORE_NVM_SUPPORT
+	bool "Non-volatile storage support for OSCORE SSN persistence"
+	depends on SETTINGS
+
 config UOSCORE_DEBUG
 	bool "Debug logs in the uoscore library"
 

--- a/modules/uoscore-uedhoc/uoscore_nvm.c
+++ b/modules/uoscore-uedhoc/uoscore_nvm.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/sys/util.h>
+
+#include "common/byte_array.h"
+#include "common/oscore_edhoc_error.h"
+#include "oscore/nvm.h"
+#include "oscore/oscore_coap_defines.h"
+
+LOG_MODULE_REGISTER(uoscore_nvm, CONFIG_LOG_DEFAULT_LEVEL);
+
+#define OSCORE_SSN_KEY_PREFIX     "oscore_ssn/"
+#define OSCORE_SSN_KEY_PREFIX_LEN (sizeof(OSCORE_SSN_KEY_PREFIX) - 1U)
+
+/*
+ * Worst-case key length (excluding NUL) for maximum-size identifiers: prefix +
+ * two length-prefixed IDs + trailing ID context, all hex encoded. The literal
+ * 11 is strlen(OSCORE_SSN_KEY_PREFIX). Warn at build time if the settings name
+ * limit cannot hold it, in which case such contexts fail with buffer_to_small.
+ */
+#define OSCORE_SSN_KEY_WORST_LEN                                                                   \
+	(11U + (2U + (2U * MAX_KID_LEN)) + (2U + (2U * MAX_KID_LEN)) + (2U * MAX_KID_CONTEXT_LEN))
+
+#if SETTINGS_MAX_NAME_LEN < OSCORE_SSN_KEY_WORST_LEN
+#warning "SETTINGS_MAX_NAME_LEN too small for OSCORE SSN keys with maximum-size (8/8/8) \
+context identifiers; nvm_read_ssn()/nvm_write_ssn() fail with buffer_to_small"
+#endif
+
+/* Keep the literal 11 above in sync with the actual prefix length. */
+BUILD_ASSERT(OSCORE_SSN_KEY_PREFIX_LEN == 11U);
+
+/*
+ * The settings key is the hex encoded concatenation of the public context
+ * identifiers: sender ID, recipient ID and ID context. The two leading IDs are
+ * preceded by a one-byte length prefix so their boundary is explicit; the ID
+ * context is trailing and consumes the remainder, so it needs no prefix.
+ */
+static enum err key_append_field(char *key, size_t key_size, size_t *offset,
+				 const struct byte_array *field)
+{
+	uint8_t len_byte;
+
+	if (field->len > UINT8_MAX) {
+		return wrong_parameter;
+	}
+
+	/* Length prefix (2 hex chars) + field content (2 hex chars each) + NUL. */
+	if ((*offset + 2U + ((size_t)field->len * 2U) + 1U) > key_size) {
+		return buffer_to_small;
+	}
+
+	len_byte = (uint8_t)field->len;
+	*offset += bin2hex(&len_byte, sizeof(len_byte), key + *offset, key_size - *offset);
+
+	if (field->len > 0U) {
+		*offset += bin2hex(field->ptr, field->len, key + *offset, key_size - *offset);
+	}
+
+	return ok;
+}
+
+static enum err oscore_ssn_key(const struct nvm_key_t *nvm_key, char *key, size_t key_size)
+{
+	size_t offset = OSCORE_SSN_KEY_PREFIX_LEN;
+	enum err r;
+
+	if ((OSCORE_SSN_KEY_PREFIX_LEN + 1U) > key_size) {
+		return buffer_to_small;
+	}
+
+	memcpy(key, OSCORE_SSN_KEY_PREFIX, OSCORE_SSN_KEY_PREFIX_LEN);
+
+	r = key_append_field(key, key_size, &offset, &nvm_key->sender_id);
+	if (r != ok) {
+		return r;
+	}
+
+	r = key_append_field(key, key_size, &offset, &nvm_key->recipient_id);
+	if (r != ok) {
+		return r;
+	}
+
+	/* Trailing ID context: no length prefix needed, just the hex content. */
+	if ((offset + ((size_t)nvm_key->id_context.len * 2U) + 1U) > key_size) {
+		return buffer_to_small;
+	}
+
+	if (nvm_key->id_context.len > 0U) {
+		(void)bin2hex(nvm_key->id_context.ptr, nvm_key->id_context.len, key + offset,
+			      key_size - offset);
+	}
+
+	return ok;
+}
+
+struct ssn_load_ctx {
+	uint64_t *ssn;
+	bool found;
+};
+
+static int ssn_direct_load(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg,
+			   void *param)
+{
+	struct ssn_load_ctx *ctx = param;
+	const char *next;
+	ssize_t rc;
+
+	/* Only the exact leaf (no trailing key components) is of interest. */
+	if (settings_name_next(name, &next) != 0) {
+		return 0;
+	}
+
+	if (len != sizeof(*ctx->ssn)) {
+		return -EINVAL;
+	}
+
+	rc = read_cb(cb_arg, ctx->ssn, sizeof(*ctx->ssn));
+	if (rc < 0) {
+		return (int)rc;
+	}
+
+	ctx->found = true;
+	return 0;
+}
+
+enum err nvm_write_ssn(const struct nvm_key_t *nvm_key, uint64_t ssn)
+{
+	char key[SETTINGS_MAX_NAME_LEN + 1];
+	enum err r;
+	int ret;
+
+	if (nvm_key == NULL) {
+		return wrong_parameter;
+	}
+
+	r = oscore_ssn_key(nvm_key, key, sizeof(key));
+	if (r != ok) {
+		return r;
+	}
+
+	ret = settings_save_one(key, &ssn, sizeof(ssn));
+	if (ret != 0) {
+		LOG_ERR("Failed to write SSN to NVM: %d", ret);
+		return unexpected_result_from_ext_lib;
+	}
+
+	return ok;
+}
+
+enum err nvm_read_ssn(const struct nvm_key_t *nvm_key, uint64_t *ssn)
+{
+	char key[SETTINGS_MAX_NAME_LEN + 1];
+	struct ssn_load_ctx ctx;
+	enum err r;
+	int ret;
+
+	if ((nvm_key == NULL) || (ssn == NULL)) {
+		return wrong_parameter;
+	}
+
+	r = oscore_ssn_key(nvm_key, key, sizeof(key));
+	if (r != ok) {
+		return r;
+	}
+
+	ctx.ssn = ssn;
+	ctx.found = false;
+
+	ret = settings_load_subtree_direct(key, ssn_direct_load, &ctx);
+	if (ret != 0) {
+		LOG_ERR("Failed to read SSN from NVM: %d", ret);
+		return unexpected_result_from_ext_lib;
+	}
+
+	if (!ctx.found) {
+		LOG_ERR("No stored SSN found for the given context");
+		return unexpected_result_from_ext_lib;
+	}
+
+	return ok;
+}
+
+static int oscore_nvm_init(void)
+{
+	int ret = settings_subsys_init();
+
+	if (ret != 0) {
+		LOG_ERR("settings_subsys_init failed: %d", ret);
+	}
+
+	return ret;
+}
+
+SYS_INIT(oscore_nvm_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -338,20 +338,6 @@ config COAP_SERVER_SHELL
 
 endif
 
-config COAP_OSCORE
-	bool "OSCORE support for CoAP (RFC 8613)"
-	depends on UOSCORE
-	help
-	  Enable Object Security for Constrained RESTful Environments (OSCORE)
-	  support for CoAP server. OSCORE provides end-to-end protection of
-	  CoAP messages using COSE (CBOR Object Signing and Encryption).
-
-	  This option requires the uoscore-uedhoc module and PSA Crypto support.
-	  When enabled, CoAP messages can be protected with OSCORE by using a
-	  OSCORE enabled service.
-
-	  See RFC 8613 for details.
-
 rsource "Kconfig.oscore"
 
 module = COAP

--- a/subsys/net/lib/coap/Kconfig.oscore
+++ b/subsys/net/lib/coap/Kconfig.oscore
@@ -65,4 +65,22 @@ config COAP_OSCORE_EXCHANGE_LIFETIME_MS
 	  The default of 247 seconds matches the CoAP EXCHANGE_LIFETIME
 	  (RFC 7252 Section 4.8.2).
 
+config COAP_OSCORE_CONTEXT_REUSE
+	bool "OSCORE support for context reuse across reboots"
+	select UOSCORE_NVM_SUPPORT
+	help
+	  Enable support for reusing OSCORE security contexts across device
+	  reboots. When a context is reused, the sender sequence number (SSN)
+	  must be persisted to non-volatile memory to prevent AEAD nonce reuse,
+	  which is cryptographically catastrophic.
+
+	  The SSN is persisted automatically through the Zephyr settings
+	  subsystem (selected via UOSCORE_NVM_SUPPORT), so the application
+	  needs a working settings backend, e.g. a storage partition and its
+	  matching backend such as CONFIG_SETTINGS_NVS.
+
+	  Applications that cannot guarantee a fresh context at every boot
+	  (e.g., via EDHOC key derivation) require this option. All other
+	  deployments should leave this disabled.
+
 endif # COAP_OSCORE

--- a/subsys/net/lib/coap/Kconfig.oscore
+++ b/subsys/net/lib/coap/Kconfig.oscore
@@ -6,6 +6,7 @@
 config COAP_OSCORE
 	bool "OSCORE support for CoAP (RFC 8613)"
 	depends on UOSCORE
+	depends on PSA_CRYPTO
 	help
 	  Enable Object Security for Constrained RESTful Environments (OSCORE)
 	  support for CoAP server. OSCORE provides end-to-end protection of

--- a/subsys/net/lib/coap/coap_oscore.c
+++ b/subsys/net/lib/coap/coap_oscore.c
@@ -108,6 +108,21 @@ static uint8_t oscore_err_to_coap_code(enum err oscore_err)
 	}
 }
 
+/* RFC 8613 Appendix B.1.2: the recipient replay window is lost on reboot when the
+ * context is reused. These errors mean the server must answer with an Echo challenge
+ * to re-synchronize the replay window rather than a plain error response.
+ */
+static bool oscore_err_needs_echo_challenge(enum err oscore_err)
+{
+	switch (oscore_err) {
+	case first_request_after_reboot:
+	case echo_validation_failed:
+		return true;
+	default:
+		return false;
+	}
+}
+
 int coap_oscore_protect(uint8_t *coap_msg, uint32_t coap_msg_len, uint8_t *oscore_msg,
 			uint32_t *oscore_msg_len, struct coap_oscore_context *ctx)
 {
@@ -129,9 +144,14 @@ int coap_oscore_protect(uint8_t *coap_msg, uint32_t coap_msg_len, uint8_t *oscor
 }
 
 int coap_oscore_verify(uint8_t *oscore_msg, uint32_t oscore_msg_len, uint8_t *coap_msg,
-		       uint32_t *coap_msg_len, struct coap_oscore_context *ctx, uint8_t *error_code)
+		       uint32_t *coap_msg_len, struct coap_oscore_context *ctx, uint8_t *error_code,
+		       bool *needs_echo_challenge)
 {
 	enum err result;
+
+	if (needs_echo_challenge != NULL) {
+		*needs_echo_challenge = false;
+	}
 
 	if (oscore_msg == NULL || coap_msg == NULL || coap_msg_len == NULL || ctx == NULL) {
 		if (error_code != NULL) {
@@ -146,6 +166,9 @@ int coap_oscore_verify(uint8_t *oscore_msg, uint32_t oscore_msg_len, uint8_t *co
 		LOG_ERR("OSCORE verification failed: %d", result);
 		if (error_code != NULL) {
 			*error_code = oscore_err_to_coap_code(result);
+		}
+		if (needs_echo_challenge != NULL) {
+			*needs_echo_challenge = oscore_err_needs_echo_challenge(result);
 		}
 		return -EACCES;
 	}

--- a/subsys/net/lib/coap/coap_oscore.c
+++ b/subsys/net/lib/coap/coap_oscore.c
@@ -185,11 +185,14 @@ int coap_oscore_context_init(struct coap_oscore_init_params *params,
 		return -EINVAL;
 	}
 
-	/* Currently session reuse is not supported */
+#if !defined(CONFIG_COAP_OSCORE_CONTEXT_REUSE)
+	/* If context reuse is not enabled, the master secret and salt must be unique at every boot.
+	 */
 	if (!params->fresh_master_secret_salt) {
-		LOG_ERR("Session reuse is not supported; fresh_master_secret_salt must be true");
+		LOG_ERR("Session reuse is not activated. fresh_master_secret_salt must be true");
 		return -ENOTSUP;
 	}
+#endif
 
 	/* Map the Zephyr parameters onto the uoscore initialization parameters.
 	 * uoscore keeps pointers to master_secret, master_salt, id_context and

--- a/subsys/net/lib/coap/coap_oscore_internal.h
+++ b/subsys/net/lib/coap/coap_oscore_internal.h
@@ -59,11 +59,13 @@ int coap_oscore_protect(uint8_t *coap_msg, uint32_t coap_msg_len, uint8_t *oscor
  * @param coap_msg_len On input: size of output buffer; on output: length of decrypted message
  * @param ctx OSCORE security context
  * @param error_code If verification fails, this is set to the appropriate CoAP error code
+ * @param needs_echo_challenge Optional; if non-NULL, set to true when the failure requires
+ *        an Echo challenge response for replay window synchronization (RFC 8613 Appendix B.1.2)
  * @return 0 on success, negative errno on error
  */
 int coap_oscore_verify(uint8_t *oscore_msg, uint32_t oscore_msg_len, uint8_t *coap_msg,
 		       uint32_t *coap_msg_len, struct coap_oscore_context *ctx,
-		       uint8_t *error_code);
+		       uint8_t *error_code, bool *needs_echo_challenge);
 
 /**
  * @brief Find OSCORE exchange entry

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -21,11 +21,17 @@ LOG_MODULE_DECLARE(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <zephyr/zvfs/eventfd.h>
 
 #if defined(CONFIG_COAP_OSCORE)
+#include <psa/crypto.h>
 #include "coap_oscore_internal.h"
 
 /* Approximate OSCORE buffer overhead */
 #define OSCORE_BUFFER_OVERHEAD        40
 #define COAP_SERVER_WIRE_MESSAGE_SIZE (CONFIG_COAP_SERVER_MESSAGE_SIZE + OSCORE_BUFFER_OVERHEAD)
+
+/* Length of the Echo option challenge value used for replay window
+ * synchronization (RFC 9175 Appendix A.2).
+ */
+#define OSCORE_ECHO_CHALLENGE_LEN 12U
 
 K_MEM_SLAB_DEFINE_STATIC(coap_oscore_send_buffer, ROUND_UP(COAP_SERVER_WIRE_MESSAGE_SIZE, 4), 1, 4);
 #else
@@ -117,35 +123,99 @@ static inline void coap_server_free(void *ptr)
 #endif
 }
 
+/* OSCORE protection mode for coap_service_send_internal */
+enum coap_oscore_protect_mode {
+	OSCORE_PROTECT_CACHE, /* Normal operation: cache exchange and protect if applicable */
+	OSCORE_PROTECT_SKIP,  /* Skip OSCORE protection entirely */
+	OSCORE_PROTECT_FORCE, /* Force OSCORE protection regardless of exchange state */
+};
+
 static int coap_service_send_internal(const struct coap_service *service,
 				      const struct coap_packet *cpkt,
 				      const struct net_sockaddr *addr, net_socklen_t addr_len,
 				      const struct coap_transmission_parameters *params,
-				      bool skip_oscore);
+				      enum coap_oscore_protect_mode oscore_protect_mode);
 
 #if defined(CONFIG_COAP_OSCORE)
-static int send_error_response(const struct coap_service *service,
-			       const struct coap_packet *request, uint8_t code,
-			       const struct net_sockaddr *client_addr,
-			       net_socklen_t client_addr_len)
+static int init_error_response_packet(struct coap_packet *response,
+				      const struct coap_packet *request, uint8_t code, uint8_t *buf,
+				      size_t buf_len)
 {
-	static uint8_t buf[CONFIG_COAP_SERVER_MESSAGE_SIZE]; /* under coap server lock */
-	struct coap_packet response;
 	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t tkl = coap_header_get_token(request, token);
 	uint16_t id = coap_header_get_id(request);
 	uint8_t type = (coap_header_get_type(request) == COAP_TYPE_CON) ? COAP_TYPE_ACK
 									: COAP_TYPE_NON_CON;
+
+	return coap_packet_init(response, buf, buf_len, COAP_VERSION_1, type, tkl, token, code, id);
+}
+
+static int send_error_response(const struct coap_service *service,
+			       const struct coap_packet *request, uint8_t code,
+			       const struct net_sockaddr *client_addr,
+			       net_socklen_t client_addr_len, uint8_t *buf, size_t buf_len)
+{
+	struct coap_packet response;
 	int ret;
 
-	ret = coap_packet_init(&response, buf, sizeof(buf), COAP_VERSION_1, type, tkl, token, code,
-			       id);
+	ret = init_error_response_packet(&response, request, code, buf, buf_len);
 	if (ret < 0) {
 		return ret;
 	}
 
 	return coap_service_send_internal(service, &response, client_addr, client_addr_len, NULL,
-					  true);
+					  OSCORE_PROTECT_SKIP);
+}
+
+/* RFC 8613 Appendix B.1.2: after a reboot with a reused context the recipient replay
+ * window is lost. Answer the offending request with a 4.01 Unauthorized carrying a fresh
+ * Echo option and protect it with OSCORE so the client can prove freshness by echoing the
+ * value back, allowing the replay window to be re-synchronized.
+ */
+static int send_oscore_echo_challenge(const struct coap_service *service,
+				      const struct coap_packet *request,
+				      const struct net_sockaddr *client_addr,
+				      net_socklen_t client_addr_len, uint8_t *buf, size_t buf_len)
+{
+	uint8_t echo_val[OSCORE_ECHO_CHALLENGE_LEN];
+	struct coap_packet response;
+	psa_status_t status;
+	int ret;
+
+	/* RFC 9175: the Echo value must be unpredictable, hence the PSA CSPRNG (already
+	 * pulled in by OSCORE's PSA Crypto dependency).
+	 */
+	status = psa_generate_random(echo_val, sizeof(echo_val));
+	if (status != PSA_SUCCESS) {
+		LOG_ERR("Failed to generate OSCORE Echo challenge (%d)", status);
+		return -EIO;
+	}
+
+	ret = init_error_response_packet(&response, request, COAP_RESPONSE_CODE_UNAUTHORIZED, buf,
+					 buf_len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* The Echo option is class E (inner); uoscore caches its value while in the
+	 * ECHO_VERIFY state so the next request can be validated for freshness.
+	 */
+	ret = coap_packet_append_option(&response, COAP_OPTION_ECHO, echo_val, sizeof(echo_val));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Use coap_service_send_internal with FORCE mode to bypass exchange cache logic
+	 * and ensure OSCORE protection is applied regardless of exchange state.
+	 */
+	ret = coap_service_send_internal(service, &response, client_addr, client_addr_len, NULL,
+					 OSCORE_PROTECT_FORCE);
+
+	if (ret == 0) {
+		LOG_DBG("Sent OSCORE Echo challenge for replay window synchronization");
+	}
+
+	return ret;
 }
 #endif /* CONFIG_COAP_OSCORE */
 
@@ -379,17 +449,29 @@ static int coap_server_process(int sock_fd)
 		static uint8_t decrypted_buf[CONFIG_COAP_SERVER_MESSAGE_SIZE];
 		uint32_t decrypted_len = sizeof(decrypted_buf);
 		uint8_t error_code = COAP_RESPONSE_CODE_BAD_REQUEST;
+		bool needs_echo_challenge = false;
 
 		ret = coap_oscore_verify(buf, received, decrypted_buf, &decrypted_len, oscore_ctx,
-					 &error_code);
+					 &error_code, &needs_echo_challenge);
 		if (ret < 0) {
-			/* RFC 8613 Section 8.2: OSCORE errors are sent as simple CoAP
-			 * responses without OSCORE processing
-			 */
-			LOG_ERR("OSCORE verification failed (%d), sending error %d", ret,
-				error_code);
-			(void)send_error_response(service, &request, error_code,
-						  net_sad(&client_addr), client_addr_len);
+			if (needs_echo_challenge) {
+				/* RFC 8613 Appendix B.1.2: re-synchronize the recipient replay
+				 * window by challenging the client with a protected Echo option.
+				 */
+				LOG_DBG("OSCORE replay window desync, sending Echo challenge");
+				(void)send_oscore_echo_challenge(service, &request,
+								 net_sad(&client_addr),
+								 client_addr_len, buf, sizeof(buf));
+			} else {
+				/* RFC 8613 Section 8.2: OSCORE errors are sent as simple CoAP
+				 * responses without OSCORE processing
+				 */
+				LOG_ERR("OSCORE verification failed (%d), sending error %d", ret,
+					error_code);
+				(void)send_error_response(service, &request, error_code,
+							  net_sad(&client_addr), client_addr_len,
+							  buf, sizeof(buf));
+			}
 			ret = -EACCES;
 			goto unlock;
 		}
@@ -423,7 +505,8 @@ static int coap_server_process(int sock_fd)
 					(void)send_error_response(
 						service, &request,
 						COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE,
-						net_sad(&client_addr), client_addr_len);
+						net_sad(&client_addr), client_addr_len, buf,
+						sizeof(buf));
 					ret = -ENOMEM;
 					goto unlock;
 				}
@@ -436,13 +519,13 @@ static int coap_server_process(int sock_fd)
 	} else if (oscore_ctx == NULL && request_has_oscore) {
 		LOG_WRN("OSCORE message received but no context configured");
 		(void)send_error_response(service, &request, COAP_RESPONSE_CODE_UNAUTHORIZED,
-					  net_sad(&client_addr), client_addr_len);
+					  net_sad(&client_addr), client_addr_len, buf, sizeof(buf));
 		ret = -ENOTSUP;
 		goto unlock;
 	} else if (service->oscore_required && !request_has_oscore) {
 		LOG_WRN("Service requires OSCORE but request is not protected");
 		(void)send_error_response(service, &request, COAP_RESPONSE_CODE_UNAUTHORIZED,
-					  net_sad(&client_addr), client_addr_len);
+					  net_sad(&client_addr), client_addr_len, buf, sizeof(buf));
 		ret = -EACCES;
 		goto unlock;
 	}
@@ -834,7 +917,7 @@ static int coap_service_send_internal(const struct coap_service *service,
 				      const struct coap_packet *cpkt,
 				      const struct net_sockaddr *addr, net_socklen_t addr_len,
 				      const struct coap_transmission_parameters *params,
-				      bool skip_oscore)
+				      enum coap_oscore_protect_mode oscore_protect_mode)
 {
 	int ret;
 
@@ -867,7 +950,7 @@ static int coap_service_send_internal(const struct coap_service *service,
 	/* RFC 8613 Section 8.3: Protect responses for OSCORE exchanges */
 	struct coap_oscore_context *oscore_ctx = coap_service_oscore_ctx(service);
 
-	if (oscore_ctx != NULL && !skip_oscore) {
+	if (oscore_ctx != NULL && oscore_protect_mode != OSCORE_PROTECT_SKIP) {
 		uint8_t token[COAP_TOKEN_MAX_LEN];
 		uint8_t tkl = coap_header_get_token(cpkt, token);
 		bool protect = false;
@@ -875,7 +958,10 @@ static int coap_service_send_internal(const struct coap_service *service,
 		is_notify = coap_get_option_int(cpkt, COAP_OPTION_OBSERVE) >= 0;
 		is_empty = coap_header_get_code(cpkt) == COAP_CODE_EMPTY;
 
-		if (is_notify) {
+		if (oscore_protect_mode == OSCORE_PROTECT_FORCE) {
+			/* Force protection regardless of exchange or observer state */
+			protect = true;
+		} else if (is_notify) {
 			/* For Observe notifications, find the observer to determine if the response
 			 * needs OSCORE protection
 			 */
@@ -978,8 +1064,8 @@ static int coap_service_send_internal(const struct coap_service *service,
 		 * so release the exchange slot now rather than leaving it stale for the full
 		 * retransmit window if the initial send fails.
 		 */
-		if (oscore_ctx != NULL && !skip_oscore && !is_notify && !is_empty &&
-		    exchange != NULL) {
+		if (oscore_ctx != NULL && oscore_protect_mode != OSCORE_PROTECT_SKIP &&
+		    !is_notify && !is_empty && exchange != NULL) {
 			coap_oscore_finish_exchange(service->data->oscore_exchange_cache, cpkt,
 						    addr, addr_len);
 			exchange_removed = true;
@@ -1006,8 +1092,8 @@ send:
 	/* For NON responses and CON when the pending cache was full, remove the exchange
 	 * entry only after a successful send so the application can retry on failure.
 	 */
-	if (!exchange_removed && oscore_ctx != NULL && !skip_oscore && !is_notify && !is_empty &&
-	    exchange != NULL) {
+	if (!exchange_removed && oscore_ctx != NULL && oscore_protect_mode != OSCORE_PROTECT_SKIP &&
+	    !is_notify && !is_empty && exchange != NULL) {
 
 		(void)k_mutex_lock(&lock, K_FOREVER);
 		coap_oscore_finish_exchange(service->data->oscore_exchange_cache, cpkt, addr,
@@ -1022,7 +1108,8 @@ int coap_service_send(const struct coap_service *service, const struct coap_pack
 		      const struct net_sockaddr *addr, net_socklen_t addr_len,
 		      const struct coap_transmission_parameters *params)
 {
-	return coap_service_send_internal(service, cpkt, addr, addr_len, params, false);
+	return coap_service_send_internal(service, cpkt, addr, addr_len, params,
+					  OSCORE_PROTECT_CACHE);
 }
 
 int coap_resource_send(const struct coap_resource *resource, const struct coap_packet *cpkt,

--- a/tests/net/lib/coap_oscore/src/main.c
+++ b/tests/net/lib/coap_oscore/src/main.c
@@ -33,6 +33,9 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_DBG);
 #define COAP_OSCORE_OPTION 9
 
 #if defined(CONFIG_COAP_OSCORE)
+
+#include "oscore/nvm.h"
+
 /*
  * Shared OSCORE test infrastructure.
  *
@@ -57,9 +60,9 @@ static const uint8_t oscore_deferred_payload[] = "deferred-response";
 static const uint8_t oscore_mixed_payload[] = "mixed-response";
 static const uint8_t oscore_secure_payload[] = "encrypted-response";
 
-static int oscore_make_ctx(const uint8_t *sender_id, size_t sender_id_len,
-			   const uint8_t *recipient_id, size_t recipient_id_len,
-			   struct coap_oscore_context **ctx)
+static int oscore_make_ctx_detailed(const uint8_t *sender_id, size_t sender_id_len,
+				    const uint8_t *recipient_id, size_t recipient_id_len,
+				    bool fresh, struct coap_oscore_context **ctx)
 {
 	struct coap_oscore_init_params params = {
 		.master_secret = oscore_master_secret,
@@ -72,10 +75,18 @@ static int oscore_make_ctx(const uint8_t *sender_id, size_t sender_id_len,
 		.master_salt_len = sizeof(oscore_master_salt),
 		.aead_alg = COAP_OSCORE_AEAD_AES_CCM_16_64_128,
 		.hkdf = COAP_OSCORE_HKDF_SHA_256,
-		.fresh_master_secret_salt = true,
+		.fresh_master_secret_salt = fresh,
 	};
 
 	return coap_oscore_context_init(&params, ctx);
+}
+
+static int oscore_make_ctx(const uint8_t *sender_id, size_t sender_id_len,
+			   const uint8_t *recipient_id, size_t recipient_id_len,
+			   struct coap_oscore_context **ctx)
+{
+	return oscore_make_ctx_detailed(sender_id, sender_id_len, recipient_id, recipient_id_len,
+					true, ctx);
 }
 
 static net_socklen_t oscore_addr_len(const struct net_sockaddr *addr)
@@ -506,6 +517,14 @@ COAP_RESOURCE_DEFINE(oscore_separate_mixed_resource, oscore_mixed_service,
 			}
 );
 /* clang-format on */
+
+/*
+ * nvm_read_ssn()/nvm_write_ssn() are declared in oscore/nvm.h behind
+ * OSCORE_NVM_SUPPORT, which is only defined when building the uoscore library.
+ * Re-declare them here so the test can seed and inspect the persisted SSN.
+ */
+enum err nvm_write_ssn(const struct nvm_key_t *nvm_key, uint64_t ssn);
+enum err nvm_read_ssn(const struct nvm_key_t *nvm_key, uint64_t *ssn);
 
 /* Test OSCORE option number is correctly defined */
 ZTEST(coap_oscore, test_oscore_option_number)
@@ -1328,6 +1347,100 @@ ZTEST(coap_oscore, test_oscore_empty_ack_does_not_clear_exchange)
 					  sizeof(token));
 	zassert_not_null(entry, "tkl=0 removal must not clear the real (tkl>0) entry");
 }
+
+/*
+ * SSN is persisted to NVM so nvm state is updated.
+ */
+ZTEST(coap_oscore, test_oscore_ssn_persisted_to_nvm)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len;
+	uint8_t token[] = {0xC1, 0xC2, 0xC3, 0xC4};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct coap_oscore_context *client_ctx;
+	struct coap_packet req;
+	struct coap_packet inner;
+	int sock;
+	int ret;
+	struct nvm_key_t nvm_key = {
+		.sender_id = {.len = sizeof(oscore_client_id), .ptr = (uint8_t *)oscore_client_id},
+		.recipient_id = {.len = sizeof(oscore_server_id),
+				 .ptr = (uint8_t *)oscore_server_id},
+		.id_context = {.len = 0, .ptr = NULL},
+	};
+	uint64_t stored_ssn = 0;
+
+	/* Seed a prior SSN so the reused (non-fresh) context can initialize from NVM
+	 * and to make the stored value deterministic across runs.
+	 */
+	zassert_equal(nvm_write_ssn(&nvm_key, 0), ok, "Failed to seed SSN in NVM");
+
+	ret = oscore_make_ctx_detailed(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				       sizeof(oscore_server_id), false, &client_ctx);
+	zassert_ok(ret, "Client context init failed (%d)", ret);
+	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+			      sizeof(oscore_client_id), &oscore_secure_service_ctx);
+	zassert_ok(ret, "Server context init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock = oscore_client_socket();
+	zassert_true(sock >= 0, "Failed to create socket (%d)", -errno);
+
+	/* Register the observation. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token, sizeof(token), 0x4001, "observe", 0);
+	zassert_ok(ret, "Failed to build observe request (%d)", ret);
+	ret = oscore_send_protected(sock, client_ctx, &dst, &req);
+	zassert_ok(ret, "Failed to send observe request (%d)", ret);
+
+	/* Initial notification must be OSCORE-protected. */
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client_ctx, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Initial notification verify/parse failed (%d)", ret);
+	zassert_true(coap_get_option_int(&inner, COAP_OPTION_OBSERVE) >= 0,
+		     "Initial notification must carry the Observe option");
+
+	/* Asynchronous notification must be OSCORE-protected. */
+	ret = coap_resource_notify(&oscore_observe_resource);
+	zassert_ok(ret, "coap_resource_notify failed (%d)", ret);
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client_ctx, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Async notification verify/parse failed (%d)", ret);
+	zassert_true(coap_get_option_int(&inner, COAP_OPTION_OBSERVE) >= 0,
+		     "Async notification must carry the Observe option");
+
+	/* Deregister and drain the final response. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token, sizeof(token), 0x4002, "observe", 1);
+	zassert_ok(ret, "Failed to build deregister request (%d)", ret);
+	ret = oscore_send_protected(sock, client_ctx, &dst, &req);
+	zassert_ok(ret, "Failed to send deregister request (%d)", ret);
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client_ctx, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Deregister response verify/parse failed (%d)", ret);
+
+	/* No further notifications once the observation is gone. */
+	ret = coap_resource_notify(&oscore_observe_resource);
+	zassert_ok(ret, "coap_resource_notify after deregister failed (%d)", ret);
+	ret = oscore_recv(sock, SHORT_TIMEOUT, innerbuf, sizeof(innerbuf));
+	zassert_equal(ret, -ETIMEDOUT, "No notification expected after deregister (%d)", ret);
+
+	zassert_ok(zsock_close(sock), "Failed to close socket");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	coap_oscore_context_free(client_ctx);
+	coap_oscore_context_free(oscore_secure_service_ctx);
+	oscore_secure_service_ctx = NULL;
+
+	zassert_equal(nvm_read_ssn(&nvm_key, &stored_ssn), ok, "Failed to read SSN from NVM");
+	LOG_INF("SSN after request: %" PRIu64, stored_ssn);
+	zassert_true(stored_ssn > 0, "Client SSN should be persisted and incremented");
+}
+
 #else
 static uint16_t coap_service_port = 56839;
 static const uint8_t plain_payload[] = "encrypted-response";

--- a/tests/net/lib/coap_oscore/src/main.c
+++ b/tests/net/lib/coap_oscore/src/main.c
@@ -205,7 +205,8 @@ static int oscore_recv_verify(int sock, int timeout_ms, struct coap_oscore_conte
 		return -ENOMSG;
 	}
 
-	ret = coap_oscore_verify(recv_buf, outer.offset, inner_buf, inner_len, ctx, &oscore_error);
+	ret = coap_oscore_verify(recv_buf, outer.offset, inner_buf, inner_len, ctx, &oscore_error,
+				 NULL);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1439,6 +1440,111 @@ ZTEST(coap_oscore, test_oscore_ssn_persisted_to_nvm)
 	zassert_equal(nvm_read_ssn(&nvm_key, &stored_ssn), ok, "Failed to read SSN from NVM");
 	LOG_INF("SSN after request: %" PRIu64, stored_ssn);
 	zassert_true(stored_ssn > 0, "Client SSN should be persisted and incremented");
+}
+
+/* RFC 8613 Appendix B.1.2: after a reboot with a reused context the server has lost its
+ * recipient replay window and must re-synchronize it with an Echo challenge before
+ * accepting requests again.
+ */
+ZTEST(coap_oscore, test_oscore_replay_window_echo_resync)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len;
+	uint8_t token1[] = {0xD1, 0xD2, 0xD3, 0xD4};
+	uint8_t token2[] = {0xE1, 0xE2, 0xE3, 0xE4};
+	uint8_t echo_val[16];
+	uint16_t echo_len;
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct coap_oscore_context *client_ctx;
+	struct coap_packet req;
+	struct coap_packet inner;
+	struct coap_option echo_opt;
+	const uint8_t *payload;
+	uint16_t payload_len;
+	int sock;
+	int ret;
+	/* The non-fresh context here is the server, so seed under its key
+	 * (sender = server ID, recipient = client ID).
+	 */
+	struct nvm_key_t nvm_key = {
+		.sender_id = {.len = sizeof(oscore_server_id), .ptr = (uint8_t *)oscore_server_id},
+		.recipient_id = {.len = sizeof(oscore_client_id),
+				 .ptr = (uint8_t *)oscore_client_id},
+		.id_context = {.len = 0, .ptr = NULL},
+	};
+	uint64_t stored_ssn = 0;
+
+	/* Seed a prior SSN so the reused (non-fresh) context can initialize from NVM
+	 * and to make the stored value deterministic across runs.
+	 */
+	zassert_equal(nvm_write_ssn(&nvm_key, stored_ssn), ok, "Failed to seed SSN in NVM");
+
+	/* Fresh client, but a server whose reused context lost its replay window
+	 * (fresh_master_secret_salt = false => starts in the ECHO_REBOOT state).
+	 */
+	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+			      sizeof(oscore_server_id), &client_ctx);
+	zassert_ok(ret, "Client context init failed (%d)", ret);
+	ret = oscore_make_ctx_detailed(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				       sizeof(oscore_client_id), false, &oscore_secure_service_ctx);
+	zassert_ok(ret, "Server context init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock = oscore_client_socket();
+	zassert_true(sock >= 0, "Failed to create socket (%d)", -errno);
+
+	/* First request after reboot: the server answers with a protected 4.01 carrying an
+	 * Echo option instead of the resource response.
+	 */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token1, sizeof(token1), 0x5001, "e2e", -1);
+	zassert_ok(ret, "Failed to build first request (%d)", ret);
+	ret = oscore_send_protected(sock, client_ctx, &dst, &req);
+	zassert_ok(ret, "Failed to send first request (%d)", ret);
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client_ctx, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Echo challenge verify/parse failed (%d)", ret);
+	zassert_equal(coap_header_get_code(&inner), COAP_RESPONSE_CODE_UNAUTHORIZED,
+		      "Echo challenge must be 4.01 Unauthorized, got %u",
+		      coap_header_get_code(&inner));
+
+	ret = coap_find_options(&inner, COAP_OPTION_ECHO, &echo_opt, 1);
+	zassert_equal(ret, 1, "Echo challenge must carry an Echo option (%d)", ret);
+	zassert_true(echo_opt.len > 0 && echo_opt.len <= sizeof(echo_val),
+		     "Unexpected Echo option length %u", echo_opt.len);
+	echo_len = echo_opt.len;
+	memcpy(echo_val, echo_opt.value, echo_len);
+
+	/* Resend the request echoing the challenge value back to prove freshness. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token2, sizeof(token2), 0x5002, "e2e", -1);
+	zassert_ok(ret, "Failed to build echo request (%d)", ret);
+	ret = coap_packet_append_option(&req, COAP_OPTION_ECHO, echo_val, echo_len);
+	zassert_ok(ret, "Failed to append Echo option (%d)", ret);
+	ret = oscore_send_protected(sock, client_ctx, &dst, &req);
+	zassert_ok(ret, "Failed to send echo request (%d)", ret);
+
+	/* Replay window re-synchronized: the resource response is now delivered. */
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client_ctx, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Resynchronized response verify/parse failed (%d)", ret);
+	zassert_equal(coap_header_get_code(&inner), COAP_RESPONSE_CODE_CONTENT,
+		      "Expected 2.05 Content after resync, got %u", coap_header_get_code(&inner));
+
+	payload = coap_packet_get_payload(&inner, &payload_len);
+	zassert_not_null(payload, "Missing decrypted payload");
+	zassert_equal(payload_len, sizeof(oscore_secure_payload) - 1, "Unexpected payload length");
+	zassert_mem_equal(payload, oscore_secure_payload, payload_len, "Unexpected payload");
+
+	zassert_ok(zsock_close(sock), "Failed to close socket");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	coap_oscore_context_free(client_ctx);
+	coap_oscore_context_free(oscore_secure_service_ctx);
+	oscore_secure_service_ctx = NULL;
 }
 
 #else

--- a/tests/net/lib/coap_oscore/tests.yaml
+++ b/tests/net/lib/coap_oscore/tests.yaml
@@ -4,10 +4,18 @@ tests:
     min_flash: 192
     tags: net
     depends_on: netif
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")
     extra_configs:
       - CONFIG_COAP_OSCORE_MAX_CONTEXTS=2
       - CONFIG_COAP_OSCORE_EXCHANGE_CACHE_SIZE=4
       - CONFIG_COAP_OSCORE_EXCHANGE_LIFETIME_MS=60000
+      - CONFIG_COAP_OSCORE_CONTEXT_REUSE=y
+      - CONFIG_FLASH=y
+      - CONFIG_FLASH_MAP=y
+      - CONFIG_NVS=y
+      - CONFIG_SETTINGS=y
+      - CONFIG_SETTINGS_NVS=y
 
   net.coap.oscore_no_oscore:
     min_ram: 48


### PR DESCRIPTION
This change adds RFC 8613 Appendix B.1.2 replay-window re-synchronization for OSCORE context reuse after reboot.

When a server reuses an OSCORE context, it may lose recipient replay-window state in RAM. In that state, incoming protected requests cannot be safely accepted yet. The server now responds with a protected 4.01 Unauthorized that carries an Echo option challenge. When the client retries with that Echo value, the server verifies freshness and reinitializes replay-window tracking from the request PIV/SSN, then resumes normal request processing.

Implemented:

- SSN persistence by exposing existing uoscore NVM read/write mechanism
- RFC 8613 Appendix B.1.2 replay-window resync

Not implemented (planned in follow-up PRs):

- EDHOC-based context establishment

