### PR TITLE
modbus: allow RX processing on a dedicated workqueue

### DIFF
--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -14,6 +14,22 @@ config MODBUS_BUFFER_SIZE
 	help
 	  Modbus buffer size.
 
+config MODBUS_WORKQUEUE
+	bool "Use dedicated workqueue in Modbus"
+	help
+	  Use the dedicated queue to process received ADUs if the system work
+	  queue cannot be used due to performance issues or other conflicts.
+	  For example, a client transaction can time out when the system work
+	  queue is busy or is itself the caller's context, because response
+	  handling shares that single queue.
+
+config MODBUS_STACK_SIZE
+	int "Modbus workqueue stack size"
+	depends on MODBUS_WORKQUEUE
+	default 1024
+	help
+	  Modbus workqueue stack size.
+
 choice
 	prompt "Supported node roles"
 	default MODBUS_ROLE_CLIENT_SERVER

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -13,6 +13,33 @@ LOG_MODULE_REGISTER(modbus, CONFIG_MODBUS_LOG_LEVEL);
 #include <zephyr/sys/byteorder.h>
 #include <modbus_internal.h>
 
+#if CONFIG_MODBUS_WORKQUEUE
+static struct k_work_q modbus_work_q;
+static K_KERNEL_STACK_DEFINE(modbus_stack, CONFIG_MODBUS_STACK_SIZE);
+
+static int modbus_init_wq(void)
+{
+	k_work_queue_init(&modbus_work_q);
+	k_work_queue_start(&modbus_work_q, modbus_stack, K_KERNEL_STACK_SIZEOF(modbus_stack),
+			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, NULL);
+	k_thread_name_set(modbus_work_q.thread_id, "modbus_work_q");
+
+	return 0;
+}
+
+SYS_INIT(modbus_init_wq, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+int modbus_work_submit(struct k_work *work)
+{
+	return k_work_submit_to_queue(&modbus_work_q, work);
+}
+#else
+int modbus_work_submit(struct k_work *work)
+{
+	return k_work_submit(work);
+}
+#endif /* CONFIG_MODBUS_WORKQUEUE */
+
 #define DT_DRV_COMPAT zephyr_modbus_serial
 
 #define MB_RTU_DEFINE_GPIO_CFG(inst, prop)				\

--- a/subsys/modbus/modbus_internal.h
+++ b/subsys/modbus/modbus_internal.h
@@ -165,6 +165,18 @@ int modbus_iface_get_by_ctx(const struct modbus_context *ctx);
 void modbus_tx_adu(struct modbus_context *ctx);
 
 /**
+ * @brief Submit received ADU processing to the Modbus work queue.
+ *
+ * Uses the dedicated work queue if CONFIG_MODBUS_WORKQUEUE is enabled,
+ * the system work queue otherwise.
+ *
+ * @param work       Work item to submit
+ *
+ * @retval           Value as returned by k_work_submit_to_queue().
+ */
+int modbus_work_submit(struct k_work *work);
+
+/**
  * @brief Send ADU and wait certain time for response.
  *
  * @param ctx        Modbus interface context

--- a/subsys/modbus/modbus_raw.c
+++ b/subsys/modbus/modbus_raw.c
@@ -71,7 +71,7 @@ int modbus_raw_submit_rx(const int iface, const struct modbus_adu *adu)
 	ctx->rx_adu.fc = adu->fc;
 	memcpy(ctx->rx_adu.data, adu->data,
 	       MIN(adu->length, sizeof(ctx->rx_adu.data)));
-	k_work_submit(&ctx->server_work);
+	modbus_work_submit(&ctx->server_work);
 
 	return 0;
 }

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -379,7 +379,7 @@ static void cb_handler_rx(struct modbus_context *ctx)
 		}
 
 		if (c == MODBUS_ASCII_END_FRAME_CHAR2) {
-			k_work_submit(&ctx->server_work);
+			modbus_work_submit(&ctx->server_work);
 		}
 
 	} else {
@@ -470,7 +470,7 @@ static void uart_cb_async_handler(const struct device *dev, struct uart_event *e
 		break;
 	case UART_RX_RDY:
 		cfg->uart_buf_ctr = evt->data.rx.len;
-		k_work_submit(&ctx->server_work);
+		modbus_work_submit(&ctx->server_work);
 		break;
 	case UART_TX_ABORTED:
 		__fallthrough;
@@ -500,7 +500,7 @@ static void rtu_tmr_handler(struct k_timer *t_id)
 		return;
 	}
 
-	k_work_submit(&ctx->server_work);
+	modbus_work_submit(&ctx->server_work);
 }
 
 static int configure_gpio(struct modbus_context *ctx)

--- a/tests/subsys/modbus/tests.yaml
+++ b/tests/subsys/modbus/tests.yaml
@@ -9,6 +9,15 @@ tests:
       # UART3(PTC16)-RX <-> UART2(PTD3)-TX
       # UART3(PTC17)-TX <-> UART2(PTD2)-RX
       fixture: uart_loopback
+  modbus.rtu.dedicated_workqueue:
+    tags: modbus
+    extra_args:
+      - DCONFIG_MODBUS_WORKQUEUE=y
+    platform_allow:
+      - frdm_k64f
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    harness_config:
+      fixture: uart_loopback
   modbus.rtu.build_only:
     build_only: true
     tags: modbus


### PR DESCRIPTION
Received-ADU processing (server_work running modbus_rx_handler) is submitted to the system workqueue. On a client that handler releases the transaction waiting on client_wait_sem, so when the system workqueue is busy (for example an active networking stack) or is the caller's own context, response handling is delayed past the client timeout and reads fail with -EIO even though the reply arrived on time.

Add `MODBUS_WORKQUEUE`, following the USB CDC ACM implementation. When enabled, received ADUs are processed on a workqueue owned by the Modbus subsystem (stack size via `MODBUS_STACK_SIZE`, priority `CONFIG_SYSTEM_WORKQUEUE_PRIORITY`) instead of the system workqueue. The serial and raw RX submit sites are routed through `modbus_work_submit()` so the queue selection lives in one place.

A `modbus.rtu.dedicated_workqueue` twister scenario covers the new option.

More context available in https://github.com/zephyrproject-rtos/zephyr/issues/114494
