### PR TITLE
bluetooth: mesh: fix -Wpointer-sign warnings

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -107,7 +107,7 @@ static struct mod_relation mod_rel_list[MOD_REL_LIST_SIZE];
 #define RELATION_TYPE_EXT 0xFF
 
 static const struct {
-	uint8_t *path;
+	const char *path;
 	uint8_t page;
 } comp_data_pages[] = {
 	{ "bt/mesh/cmp/0", 0, },
@@ -458,7 +458,7 @@ int bt_mesh_comp_data_get_page_0(struct net_buf_simple *buf, size_t offset)
 }
 
 static uint8_t count_mod_ext(const struct bt_mesh_model *mod,
-			     uint8_t *max_offset, uint8_t sig_offset)
+			     int8_t *max_offset, uint8_t sig_offset)
 {
 	int i;
 	uint8_t extensions = 0;

--- a/subsys/bluetooth/mesh/crypto.c
+++ b/subsys/bluetooth/mesh/crypto.c
@@ -47,14 +47,14 @@ static int bt_mesh_sha256_hmac_one_raw_key(const uint8_t key[32], const void *m,
 	return bt_mesh_sha256_hmac_raw_key(key, &sg, 1, mac);
 }
 
-int bt_mesh_s1(const char *m, size_t m_len, uint8_t salt[16])
+int bt_mesh_s1(const void *m, size_t m_len, uint8_t salt[16])
 {
 	const uint8_t zero[16] = { 0 };
 
 	return bt_mesh_aes_cmac_one_raw_key(zero, m, m_len, salt);
 }
 
-int bt_mesh_s2(const char *m, size_t m_len, uint8_t salt[32])
+int bt_mesh_s2(const void *m, size_t m_len, uint8_t salt[32])
 {
 	const uint8_t zero[32] = { 0 };
 
@@ -200,7 +200,7 @@ int bt_mesh_k4(const uint8_t n[16], uint8_t out[1])
 }
 
 int bt_mesh_k5(const uint8_t *n, size_t n_len, const uint8_t salt[32],
-		uint8_t *p, uint8_t out[32])
+		const char *p, uint8_t out[32])
 {
 	uint8_t t[32];
 	int err;

--- a/subsys/bluetooth/mesh/crypto.h
+++ b/subsys/bluetooth/mesh/crypto.h
@@ -40,14 +40,14 @@ int bt_mesh_aes_cmac_raw_key(const uint8_t key[16], struct bt_mesh_sg *sg, size_
 int bt_mesh_sha256_hmac_raw_key(const uint8_t key[32], struct bt_mesh_sg *sg, size_t sg_len,
 			uint8_t mac[32]);
 
-int bt_mesh_s1(const char *m, size_t m_len, uint8_t salt[16]);
+int bt_mesh_s1(const void *m, size_t m_len, uint8_t salt[16]);
 
 static inline int bt_mesh_s1_str(const char *m, uint8_t salt[16])
 {
 	return bt_mesh_s1(m, strlen(m), salt);
 }
 
-int bt_mesh_s2(const char *m, size_t m_len, uint8_t salt[32]);
+int bt_mesh_s2(const void *m, size_t m_len, uint8_t salt[32]);
 
 int bt_mesh_k1(const uint8_t *ikm, size_t ikm_len, const uint8_t salt[16], const char *info,
 	       uint8_t okm[16]);
@@ -59,7 +59,8 @@ int bt_mesh_k3(const uint8_t n[16], uint8_t out[8]);
 
 int bt_mesh_k4(const uint8_t n[16], uint8_t out[1]);
 
-int bt_mesh_k5(const uint8_t *n, size_t n_len, const uint8_t salt[32], uint8_t *p, uint8_t out[32]);
+int bt_mesh_k5(const uint8_t *n, size_t n_len, const uint8_t salt[32], const char *p,
+	       uint8_t out[32]);
 
 int bt_mesh_id128(const uint8_t n[16], const char *s, enum bt_mesh_key_type type,
 		  struct bt_mesh_key *out);


### PR DESCRIPTION
This PR resolves `-Wpointer-sign` warnings in the Bluetooth Mesh subsystem.
Instead of relying on C-style pointer casts to suppress the warnings, this PR fixes the underlying types. It updates `comp_data_pages[]` to store a `const char *path` and updates `bt_mesh_k5` to natively accept `const char *p`.
This is a follow-up to my previous PR and is part of a larger effort to fix pointer-sign warnings across the codebase in preparation for dropping `-Wno-pointer-sign` globally.
Fixes #8921