### PR TITLE
[Backport v3.7-branch] net: route: Decrement packet lifetime for cross-interface on-link forwarding

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -1131,6 +1131,15 @@ int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
 
 	net_pkt_set_forwarding(pkt, forwarding);
 
+	if (forwarding) {
+		if (NET_IPV6_HDR(pkt)->hop_limit <= 1U) {
+			return -ETIMEDOUT;
+		}
+
+		NET_IPV6_HDR(pkt)->hop_limit--;
+		net_pkt_set_ipv6_hop_limit(pkt, NET_IPV6_HDR(pkt)->hop_limit);
+	}
+
 	net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_if(pkt)->addr;
 	net_pkt_lladdr_src(pkt)->type = net_pkt_lladdr_if(pkt)->type;
 	net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_if(pkt)->len;


### PR DESCRIPTION
Backport of the fix from #111497 to `v3.7-branch`.

Fixes: #113299