### PR TITLE
tests: drivers: flash: common: add nrf7120 SPI NAND support

### DIFF
--- a/tests/drivers/flash/common/boards/nrf7120dk_nrf7120_cpuapp_w25n01gv.overlay
+++ b/tests/drivers/flash/common/boards/nrf7120dk_nrf7120_cpuapp_w25n01gv.overlay
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The test picks its area via the `storage_partition` node label, so the
+ * on-MRAM one has to go before it can be re-pointed at the NAND below.
+ */
+/delete-node/ &storage_partition;
+
+&pinctrl {
+	spi22_default: spi22_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 15)>;
+		};
+	};
+
+	spi22_sleep: spi22_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 15)>;
+		};
+
+		low-power-enable;
+	};
+};
+
+spi_flash: &spi22 {
+	status = "okay";
+	pinctrl-0 = <&spi22_default>;
+	pinctrl-1 = <&spi22_sleep>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+	overrun-character = <0x00>;
+
+	w25n01gv: spi-nand@0 {
+		compatible = "jedec,spi-nand";
+		reg = <0>;
+		status = "okay";
+		spi-max-frequency = <104000000>;
+
+		/* w25n01gv parameters */
+		jedec-id = [ef aa 21];
+		size-bytes = <DT_SIZE_M(128)>;
+		plane-bytes = <DT_SIZE_M(128)>;
+		erase-block-size = <DT_SIZE_K(128)>;
+		write-block-size = <DT_SIZE_K(2)>;
+		block-erase-duration-max = <10000>;
+		page-program-duration-max = <700>;
+		page-read-duration-max = <200>;
+		reset-duration-max = <500>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				label = "storage";
+				reg = <0x0 DT_SIZE_M(2)>;
+			};
+		};
+	};
+};

--- a/tests/drivers/flash/common/tests.yaml
+++ b/tests/drivers/flash/common/tests.yaml
@@ -334,3 +334,11 @@ tests:
       - CONFIG_TEST_DRIVER_FLASH_SIZE=-1
     integration_platforms:
       - kit_pse84_eval/pse846gps2dbzc4a/m33
+  drivers.flash.common.spi_nand.w25n01gv:
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp
+    harness_config:
+      fixture: w25n01gv
+    extra_args:
+      - FILE_SUFFIX="w25n01gv"
+      - EXTRA_CONF_FILE="./boards/mikroe_flash_5_click.conf"


### PR DESCRIPTION
This commit adds support for the nrf7120dk + Mikroe Flash 5 Click to flash common, driven externally over SPI.