### PR TITLE
soc: mimxrt685s/hifi4, mimxrt798s/hifi4: Abandon L3 IRQ usage

### DIFF
--- a/dts/xtensa/nxp/nxp_imxrt700_hifi4.dtsi
+++ b/dts/xtensa/nxp/nxp_imxrt700_hifi4.dtsi
@@ -249,8 +249,8 @@
 		dma-channels = <8>;
 		dma-requests = <105>;
 
-		interrupts = <20 0 0>, <21 0 0>, <22 0 0>, <23 0 0>,
-			     <24 0 0>, <25 0 0>, <26 0 0>, <27 0 0>;
+		interrupts = <19 0 0>, <18 0 0>, <17 0 0>, <16 0 0>,
+			     <15 0 0>, <14 0 0>, <13 0 0>, <12 0 0>;
 		no-error-irq;
 
 		compatible = "nxp,mcux-edma";
@@ -266,7 +266,7 @@
 
 		clocks = <&clkctl0 MCUX_SAI0_CLK>;
 		pinmuxes = <&syscon0 0x240 0x1>;
-		interrupts = <29 0 0>;
+		interrupts = <21 0 0>;
 		dmas = <&edma1 0 81>, <&edma1 1 82>;
 		dma-names = "rx", "tx";
 
@@ -287,7 +287,7 @@
 
 		clocks = <&clkctl0 MCUX_SAI1_CLK>;
 		pinmuxes = <&syscon0 0x240 0x1>;
-		interrupts = <30 0 0>;
+		interrupts = <22 0 0>;
 		dmas = <&edma1 0 83>, <&edma1 0 84>;
 		dma-names = "rx", "tx";
 
@@ -308,7 +308,7 @@
 
 		clocks = <&clkctl0 MCUX_SAI2_CLK>;
 		pinmuxes = <&syscon0 0x240 0x1>;
-		interrupts = <31 0 0>;
+		interrupts = <23 0 0>;
 		dmas = <&edma1 0 85>, <&edma1 0 86>;
 		dma-names = "rx", "tx";
 
@@ -326,7 +326,7 @@
 
 		reg = <0x188000 0x1000>;
 
-		interrupts = <19 0 0>;
+		interrupts = <11 0 0>;
 
 		rx-channels = <4>;
 

--- a/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
+++ b/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
@@ -145,7 +145,7 @@
 				#interrupt-cells = <1>;
 				#address-cells = <0>;
 				interrupts = <7 0 0>, <8 0 0>, <9 0 0>, <10 0 0>,
-					     <11 0 0>, <12 0 0>, <13 0 0>, <14 0 0>;
+					     <11 0 0>, <12 0 0>;
 				num-lines = <8>;
 				num-inputs = <64>;
 			};
@@ -168,7 +168,7 @@
 			dma1: dma-controller@105000 {
 				compatible = "nxp,lpc-dma";
 				reg = <0x105000 0x1000>;
-				interrupts = <29 0 0>;
+				interrupts = <21 0 0>;
 				dma-channels = <33>;
 				status = "disabled";
 				#dma-cells = <1>;
@@ -198,7 +198,7 @@
 			flexcomm1: flexcomm@107000 {
 				compatible = "nxp,lpc-flexcomm";
 				reg = <0x107000 0x1000>;
-				interrupts = <31 0 0>;
+				interrupts = <23 0 0>;
 				clocks = <&clkctl1 MCUX_FLEXCOMM1_CLK>;
 				status = "disabled";
 			};
@@ -206,7 +206,7 @@
 			flexcomm3: flexcomm@109000 {
 				compatible = "nxp,lpc-flexcomm";
 				reg = <0x109000 0x1000>;
-				interrupts = <30 0 0>;
+				interrupts = <22 0 0>;
 				clocks = <&clkctl1 MCUX_FLEXCOMM3_CLK>;
 				status = "disabled";
 			};
@@ -217,7 +217,7 @@
 				compatible = "nxp,mbox-imx-mu";
 				reg = <0x111000 0x1000>;
 
-				interrupts = <27 0 0>;
+				interrupts = <19 0 0>;
 				rx-channels = <4>;
 
 				status = "disabled";

--- a/soc/nxp/imxrt/imxrt6xx/hifi4/soc.c
+++ b/soc/nxp/imxrt/imxrt6xx/hifi4/soc.c
@@ -28,29 +28,23 @@ __weak void mimxrt685s_hifi4_irq_init(void)
 	 * - IRQ 10 (SEL 5):  GPIO_INT0_IRQ3
 	 * - IRQ 11 (SEL 6):  GPIO_INT0_IRQ4
 	 * - IRQ 12 (SEL 7):  GPIO_INT0_IRQ5
-	 * - IRQ 13 (SEL 8):  GPIO_INT0_IRQ6
-	 * - IRQ 14 (SEL 9):  GPIO_INT0_IRQ7
-	 * - IRQ 15 (SEL 10): HSGPIO_INT0
+	 * - IRQ 13 (SEL 8):  MRT0
+	 * - IRQ 14 (SEL 9):  WDT1
+	 * - IRQ 15 (SEL 10): RTC
 	 *
 	 * L2:
-	 * - IRQ 16 (SEL 11): MRT0
-	 * - IRQ 17 (SEL 12): WDT1
-	 * - IRQ 18 (SEL 13): RTC
-	 * - IRQ 19 (SEL 14): CT32BIT0
-	 * - IRQ 20 (SEL 15): CT32BIT1
-	 * - IRQ 21 (SEL 16): CT32BIT2
-	 * - IRQ 22 (SEL 17): CT32BIT3
-	 * - IRQ 23 (SEL 18): CT32BIT4
+	 * - IRQ 16 (SEL 11): UTICK0
+	 * - IRQ 17 (SEL 12): HWVAD0
+	 * - IRQ 18 (SEL 13): Flexcomm 5 (SPI)
+	 * - IRQ 19 (SEL 14): MU
+	 * - IRQ 20 (SEL 15): DMIC
+	 * - IRQ 21 (SEL 16): DMA1
+	 * - IRQ 22 (SEL 17): Flexcomm 3 (I2S TX)
+	 * - IRQ 23 (SEL 18): Flexcomm 1 (I2S RX)
 	 *
 	 * L3: (highest priority)
-	 * - IRQ 24 (SEL 19): UTICK0
-	 * - IRQ 25 (SEL 20): HWVAD0
-	 * - IRQ 26 (SEL 21): Flexcomm 5 (SPI)
-	 * - IRQ 27 (SEL 22): MU
-	 * - IRQ 28 (SEL 23): DMIC
-	 * - IRQ 29 (SEL 24): DMA1
-	 * - IRQ 30 (SEL 25): Flexcomm 3 (I2S TX)
-	 * - IRQ 31 (SEL 26): Flexcomm 1 (I2S RX)
+	 * - IRQ 24 - 31 (SEL 19 - 26): Unmapped.
+	 *   Don't use - these IRQs are above XCHAL_EXCM_LEVEL. (issue #41039)
 	 */
 
 	INPUTMUX_Init(INPUTMUX);
@@ -63,27 +57,18 @@ __weak void mimxrt685s_hifi4_irq_init(void)
 	INPUTMUX_AttachSignal(INPUTMUX, 5, kINPUTMUX_GpioInt3ToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX, 6, kINPUTMUX_GpioInt4ToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX, 7, kINPUTMUX_GpioInt5ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 8, kINPUTMUX_GpioInt6ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 9, kINPUTMUX_GpioInt7ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 10, kINPUTMUX_NsHsGpioInt0ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 8, kINPUTMUX_Mrt0ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 9, kINPUTMUX_Wdt1ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 10, kINPUTMUX_RtcToDspInterrupt);
 
-	INPUTMUX_AttachSignal(INPUTMUX, 11, kINPUTMUX_Mrt0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 12, kINPUTMUX_Wdt1ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 13, kINPUTMUX_RtcToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 14, kINPUTMUX_Ctimer0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 15, kINPUTMUX_Ctimer1ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 16, kINPUTMUX_Ctimer2ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 17, kINPUTMUX_Ctimer3ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 18, kINPUTMUX_Ctimer4ToDspInterrupt);
-
-	INPUTMUX_AttachSignal(INPUTMUX, 19, kINPUTMUX_Utick0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 20, kINPUTMUX_Hwvad0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 21, kINPUTMUX_Flexcomm5ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 22, kINPUTMUX_MuBToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 23, kINPUTMUX_Dmic0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 24, kINPUTMUX_Dmac1ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 25, kINPUTMUX_Flexcomm3ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX, 26, kINPUTMUX_Flexcomm1ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 11, kINPUTMUX_Utick0ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 12, kINPUTMUX_Hwvad0ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 13, kINPUTMUX_Flexcomm5ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 14, kINPUTMUX_MuBToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 15, kINPUTMUX_Dmic0ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 16, kINPUTMUX_Dmac1ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 17, kINPUTMUX_Flexcomm3ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX, 18, kINPUTMUX_Flexcomm1ToDspInterrupt);
 
 	INPUTMUX_Deinit(INPUTMUX);
 }

--- a/soc/nxp/imxrt/imxrt7xx/hifi4/soc.c
+++ b/soc/nxp/imxrt/imxrt7xx/hifi4/soc.c
@@ -49,56 +49,49 @@ __weak void mimxrt798s_hifi4_irq_init(void)
 	 * - IRQ 6  (SEL 1):  FLEXCOMM0
 	 * - IRQ 7  (SEL 2):  FLEXCOMM2
 	 * - IRQ 8  (SEL 3):  WWDT1
-	 * - IRQ 9  (SEL 4):  Unmapped
-	 * - IRQ 10 (SEL 5):  Unmapped
-	 * - IRQ 11 (SEL 6):  Unmapped
-	 * - IRQ 12 (SEL 7):  Unmapped
-	 * - IRQ 13 (SEL 8):  Unmapped
-	 * - IRQ 14 (SEL 9):  Unmapped
-	 * - IRQ 15 (SEL 10): Unmapped
+	 * - IRQ 9  (SEL 4):  LPSPI14
+	 * - IRQ 10 (SEL 5):  MU2
+	 * - IRQ 11 (SEL 6):  MU4
+	 * - IRQ 12 (SEL 7):  EDMA1-7
+	 * - IRQ 13 (SEL 8):  EDMA1-6
+	 * - IRQ 14 (SEL 9):  EDMA1-5
+	 * - IRQ 15 (SEL 10): EDMA1-4
 	 *
 	 * L2:
-	 * - IRQ 16 (SEL 11): Unmapped
-	 * - IRQ 17 (SEL 12): LPSPI14
-	 * - IRQ 18 (SEL 13): MU2
-	 * - IRQ 19 (SEL 14): MU4
-	 * - IRQ 20 (SEL 15): EDMA1-0
-	 * - IRQ 21 (SEL 16): EDMA1-1
-	 * - IRQ 22 (SEL 17): EDMA1-2
-	 * - IRQ 23 (SEL 18): EDMA1-3
+	 * - IRQ 16 (SEL 11): EDMA1-3
+	 * - IRQ 17 (SEL 12): EDMA1-2
+	 * - IRQ 18 (SEL 13): EDMA1-1
+	 * - IRQ 19 (SEL 14): EDMA1-0
+	 * - IRQ 20 (SEL 15): MICFIL
+	 * - IRQ 21 (SEL 16): SAI0
+	 * - IRQ 22 (SEL 17): SAI1
+	 * - IRQ 23 (SEL 18): SAI2
 	 *
 	 * L3: (highest priority)
-	 * - IRQ 24 (SEL 19): EDMA1-4
-	 * - IRQ 25 (SEL 20): EDMA1-5
-	 * - IRQ 26 (SEL 21): EDMA1-6
-	 * - IRQ 27 (SEL 22): EDMA1-7
-	 * - IRQ 28 (SEL 23): MICFIL
-	 * - IRQ 29 (SEL 24): SAI0
-	 * - IRQ 30 (SEL 25): SAI1
-	 * - IRQ 31 (SEL 26): SAI2
+	 * - IRQ 24 - 31 (SEL 19 - 26): Unmapped.
+	 *   Don't use - these IRQs are above XCHAL_EXCM_LEVEL. (issue #41039)
 	 */
 	INPUTMUX_Init(INPUTMUX0);
 
 	INPUTMUX_AttachSignal(INPUTMUX0, 1, kINPUTMUX_Flexcomm0ToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX0, 2, kINPUTMUX_Flexcomm2ToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX0, 3, kINPUTMUX_Wdt1ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 4, kINPUTMUX_Spi14ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 5, kINPUTMUX_Mu2AToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 6, kINPUTMUX_Mu4BToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 7, kINPUTMUX_Dma1Irq7ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 8, kINPUTMUX_Dma1Irq6ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 9, kINPUTMUX_Dma1Irq5ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 10, kINPUTMUX_Dma1Irq4ToDspInterrupt);
 
-	INPUTMUX_AttachSignal(INPUTMUX0, 12, kINPUTMUX_Spi14ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 13, kINPUTMUX_Mu2AToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 14, kINPUTMUX_Mu4BToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 15, kINPUTMUX_Dma1Irq0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 16, kINPUTMUX_Dma1Irq1ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 17, kINPUTMUX_Dma1Irq2ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 18, kINPUTMUX_Dma1Irq3ToDspInterrupt);
-
-	INPUTMUX_AttachSignal(INPUTMUX0, 19, kINPUTMUX_Dma1Irq4ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 20, kINPUTMUX_Dma1Irq5ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 21, kINPUTMUX_Dma1Irq6ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 22, kINPUTMUX_Dma1Irq7ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 23, kINPUTMUX_MicfilToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 24, kINPUTMUX_Sai0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 25, kINPUTMUX_Sai1ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 26, kINPUTMUX_Sai2ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 11, kINPUTMUX_Dma1Irq3ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 12, kINPUTMUX_Dma1Irq2ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 13, kINPUTMUX_Dma1Irq1ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 14, kINPUTMUX_Dma1Irq0ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 15, kINPUTMUX_MicfilToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 16, kINPUTMUX_Sai0ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 17, kINPUTMUX_Sai1ToDspInterrupt);
+	INPUTMUX_AttachSignal(INPUTMUX0, 18, kINPUTMUX_Sai2ToDspInterrupt);
 
 	INPUTMUX_Deinit(INPUTMUX0);
 }


### PR DESCRIPTION
Remap IRQs for `mimxrt685s/hifi4` and `mimxrt798s/hifi4` so that no L3 IRQs are used. Modify DT fragments and `soc.c` on the platform.

From my understanding, the use of L3 IRQs as regular IRQs on Zephyr is dangerous, as the hardware is set up to assign L2 to exception handlers and current Xtensa arch layer in Zephyr doesn't mask interrupt priorities beyond `XCHAL_EXCM_LEVEL` (`=2` for both platforms) for critical sections. As such, preemption of interrupt and exception handlers can happen even in critical sections of the register window and interrupt handling machinery, corrupting contexts and leaving the system with poisoned registers, eventually leading to a crash.

What was observed specifically in high quantities is that the system crashed with a totally invalid SP (usually close to `0xffffffff`), which was then traced to the window underflow exception being preempted and not fully running to completion once an L3 IRQ arrives.

This looks like an instance of https://github.com/zephyrproject-rtos/zephyr/issues/41039.

Manually tested on `mimxrt685_evk/mimxrt685s/hifi4` and `mimxrt700_evk/mimxrt798s/hifi4`, with the RT700 being observed as unaffected (but that doesn't mean that it can't explode later).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/115231.