### PR TITLE
net: dsa: Conditionally enable promiscuous mode on DSA conduit

### DIFF
--- a/drivers/ethernet/dsa/Kconfig
+++ b/drivers/ethernet/dsa/Kconfig
@@ -13,6 +13,16 @@ menuconfig DSA_DRIVERS
 
 if DSA_DRIVERS
 
+config DSA_PROMISC_ON_CONDUIT
+	bool "Run DSA conduit in promiscuous mode"
+	default y
+	select NET_PROMISCUOUS_MODE
+	help
+	  Some conduits leverage ingress filters to discard packets whose DMAC field does not match
+	  that programmed into the conduit's MAC before said packets are ever made available to the
+	  software. Such conduits typically need to run in promiscuous mode to ensure packets
+	  received on DSA ports being processed.
+
 config DSA_NXP_IMX_NETC
 	bool "Support for NXP i.MX NETC"
 	default y

--- a/subsys/net/l2/ethernet/dsa/Kconfig
+++ b/subsys/net/l2/ethernet/dsa/Kconfig
@@ -24,6 +24,17 @@ config DSA_TAG_SIZE
 	help
 	  Set the DSA tag length in bytes.
 
+config DSA_CONDUIT_PROMISC_ON
+	bool "Run DSA conduit in promiscuous mode"
+	default y
+	select NET_PROMISCUOUS_MODE
+	help
+	  Some conduits leverage ingress filters to discard packets whose DMAC field does not match
+	  that programmed into the conduit's MAC before said packets are ever made available to the
+	  software. Such conduits typically need to run in promiscuous mode to ensure packets
+	  received on DSA ports being processed.
+
+
 module = NET_DSA
 module-dep = NET_LOG
 module-str = Log level for DSA

--- a/subsys/net/l2/ethernet/dsa/dsa_core.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_core.c
@@ -9,6 +9,8 @@ LOG_MODULE_REGISTER(net_dsa_core, CONFIG_NET_DSA_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dsa_core.h>
 #include <zephyr/net/dsa_tag.h>
+#include <zephyr/net/net_log.h>
+#include <zephyr/net/promiscuous.h>
 
 struct net_if *dsa_recv(struct net_if *iface, struct net_pkt *pkt)
 {
@@ -67,6 +69,7 @@ int dsa_xmit(const struct device *dev, struct net_pkt *pkt)
 
 int dsa_eth_init(struct net_if *iface)
 {
+	int ret = 0;
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 
 	if (eth_ctx->dsa_port == DSA_CONDUIT_PORT) {
@@ -74,5 +77,11 @@ int dsa_eth_init(struct net_if *iface)
 		net_if_flag_clear(iface, NET_IF_IPV6);
 	}
 
-	return 0;
+	if (IS_ENABLED(CONFIG_DSA_PROMISC_ON_CONDUIT) && eth_ctx->dsa_port == DSA_CONDUIT_PORT) {
+		NET_DBG("Enabling promiscuous mode on iface %d (%p)", net_if_get_by_iface(iface),
+			(void *)iface);
+		ret = net_promisc_mode_on(iface);
+	}
+
+	return ret;
 }

--- a/subsys/net/l2/ethernet/dsa/dsa_core.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_core.c
@@ -9,6 +9,8 @@ LOG_MODULE_REGISTER(net_dsa_core, CONFIG_NET_DSA_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dsa_core.h>
 #include <zephyr/net/dsa_tag.h>
+#include <zephyr/net/net_log.h>
+#include <zephyr/net/promiscuous.h>
 
 struct net_if *dsa_recv(struct net_if *iface, struct net_pkt *pkt)
 {
@@ -67,12 +69,21 @@ int dsa_xmit(const struct device *dev, struct net_pkt *pkt)
 
 int dsa_eth_init(struct net_if *iface)
 {
+	int ret = 0;
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 
-	if (eth_ctx->dsa_port == DSA_CONDUIT_PORT) {
-		net_if_flag_clear(iface, NET_IF_IPV4);
-		net_if_flag_clear(iface, NET_IF_IPV6);
+	if (eth_ctx->dsa_port != DSA_CONDUIT_PORT) {
+		return 0;
 	}
 
-	return 0;
+	net_if_flag_clear(iface, NET_IF_IPV4);
+	net_if_flag_clear(iface, NET_IF_IPV6);
+
+	if (IS_ENABLED(CONFIG_DSA_CONDUIT_PROMISC_ON)) {
+		NET_DBG("Enabling promiscuous mode on iface %d (%p)", net_if_get_by_iface(iface),
+			(void *)iface);
+		ret = net_promisc_mode_on(iface);
+	}
+
+	return ret;
 }

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1042,11 +1042,6 @@ void ethernet_init(struct net_if *iface)
 	NET_DBG("Initializing Ethernet L2 %p for iface %d (%p)", ctx,
 		net_if_get_by_iface(iface), iface);
 
-#if defined(CONFIG_NET_DSA)
-	/* DSA port may need to handle flags */
-	dsa_eth_init(iface);
-#endif
-
 	if (IS_ENABLED(CONFIG_ETH_NET_IF_NO_AUTO_START)) {
 		/* Do not start Ethernet interface automatically */
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
@@ -1061,6 +1056,11 @@ void ethernet_init(struct net_if *iface)
 	if ((caps & ETHERNET_PROMISC_MODE) != 0) {
 		ctx->ethernet_l2_flags |= NET_L2_PROMISC_MODE;
 	}
+
+#if defined(CONFIG_NET_DSA)
+	/* DSA port may need to handle flags */
+	dsa_eth_init(iface);
+#endif
 
 #if defined(CONFIG_NET_NATIVE_IP) && !defined(CONFIG_NET_RAW_MODE)
 	if ((caps & ETHERNET_HW_FILTERING) != 0) {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1356,11 +1356,6 @@ void ethernet_init(struct net_if *iface)
 	NET_DBG("Initializing Ethernet L2 %p for iface %d (%p)", ctx,
 		net_if_get_by_iface(iface), iface);
 
-#if defined(CONFIG_NET_DSA)
-	/* DSA port may need to handle flags */
-	dsa_eth_init(iface);
-#endif
-
 	if (IS_ENABLED(CONFIG_ETH_NET_IF_NO_AUTO_START)) {
 		/* Do not start Ethernet interface automatically */
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
@@ -1375,6 +1370,11 @@ void ethernet_init(struct net_if *iface)
 	if ((caps & ETHERNET_PROMISC_MODE) != 0) {
 		ctx->ethernet_l2_flags |= NET_L2_PROMISC_MODE;
 	}
+
+#if defined(CONFIG_NET_DSA)
+	/* DSA port may need to handle flags */
+	dsa_eth_init(iface);
+#endif
 
 #if defined(NET_ETH_MCAST_FILTER_SUPPORTED) && defined(CONFIG_NET_NATIVE_IP)
 	if ((caps & ETHERNET_HW_FILTERING) != 0) {


### PR DESCRIPTION
Some MACs, notably those used in STM32s, feature ingress filters that cause packets received on DSA user ports to be discarded due to their DMAC fields not matching the address programmed into the MAC itself. This PR introduces a new config option called `DSA_PROMISC_ON_CONDUIT` and selects it for all STM32 SoCs. When said option is enabled, the Ethernet subsystem enables promiscuous mode on the DSA conduit as part of its initialization, allowing packets received on DSA user ports to be forwarded to the software.

Thanks to @maass-hamburg for pointing out that promiscuous mode was the appropriate way to solve the issue.