### PR TITLE
drivers: serial: mcux_lpuart: bound the TC wait in configure

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1429,8 +1429,24 @@ static int mcux_lpuart_config_get(const struct device *dev, struct uart_config *
 static int mcux_lpuart_configure(const struct device *dev,
 				 const struct uart_config *cfg)
 {
-	/* Wait for Transmission Complete Flag */
-	while (!(get_base(dev)->STAT & LPUART_STAT_TC_MASK)) {
+	/* Wait for Transmission Complete Flag -- bounded. Under continuous
+	 * TX this flag may never set, and an unbounded wait parks the
+	 * calling thread for the full duration of the traffic (observed:
+	 * a 15 s stall per boot). On timeout, leave the peripheral
+	 * untouched and report busy so the caller can quiesce and retry;
+	 * proceeding would disable the receiver mid-frame and destroy the
+	 * byte being received.
+	 *
+	 * 300 ms covers this driver's worst-case 12-bit frame (start + 8
+	 * data + parity + 2 stop, 240 ms) at 50 baud, the slowest standard
+	 * rate, so a transmitter finishing its last frame never times out.
+	 * Slower rates are still configurable; for those the bound is an
+	 * intentional policy limit: fail fast with a retryable -EBUSY
+	 * rather than wait an arbitrary multiple of the frame time.
+	 */
+	if (!WAIT_FOR((get_base(dev)->STAT & LPUART_STAT_TC_MASK) != 0U,
+		      300U * USEC_PER_MSEC, k_busy_wait(100U))) {
+		return -EBUSY;
 	}
 
 	/* Disable Transmitter and Receiver */


### PR DESCRIPTION
## Summary

While validating the USB CDC-ACM to UART bridge on our probe firmware (NXP MCXA153), we saw the first transfer after every boot stall for over 15 seconds and arrive with its last byte corrupted. The root cause turned out to be in this driver: `mcux_lpuart_configure()` busy-waits **unbounded** on the Transmission Complete (TC) flag before reconfiguring the peripheral. TC only sets while the transmitter is enabled *and idle*, so calling `uart_configure()` while traffic is flowing parks the calling thread for as long as the traffic lasts — and when the loop finally exits, the driver disables TE/RE and reinitializes mid-frame, destroying the byte being received.

Our approach: bound the wait (300 ms) and, on timeout, return `-EBUSY` **with the peripheral left completely untouched**. This turns "hang for the duration of the traffic, then corrupt it" into a clean, retryable busy indication: the caller can quiesce its traffic and call again. Callers that configure an idle UART are unaffected — TC is already set and the wait returns on its first evaluation.

## How we hit it

At USB enumeration the host leaves the CDC line coding at its 9600 default; the application's real 115200 setting only arrives when the port is opened, milliseconds before the first write. Our bridge then called `uart_configure()` against live traffic:

- The configuring thread spun on TC for **15.36 s** — the time the whole transfer took to drain at the old baud rate. We confirmed the stall location by sampling the BAUD register over SWD while the thread was parked.
- When the transfer drained and TC finally set, the driver tore down TE/RE and reinitialized while a byte was mid-frame on the RX line — a deterministic last-byte loss on loopback, and garbage in both directions against a fixed-baud target.

The application-level fix (quiesce TX, wait out the in-flight frame, then reconfigure) belongs to the application and is not part of this PR. But the driver should not offer an unbounded spin followed by mid-frame teardown to any caller that arrives while the UART is busy — this change is the driver-side guard.

## Technical details

- The wait uses `WAIT_FOR(..., 300 * USEC_PER_MSEC, k_busy_wait(100))`: 300 ms total, polled every 100 µs, preserving the original busy-wait semantics (the function is not guaranteed a sleepable context) while adding a bound.
- **Timeout choice**: 300 ms covers this driver's worst-case frame — 12 bits (start + 8 data + parity + 2 stop), 240 ms at 50 baud, the slowest standard rate — so a transmitter that is merely finishing its current frame always completes within the window. Only genuinely continuous traffic times out — exactly the case where proceeding would corrupt data. The hardware can still be configured to arbitrarily slower rates; below 50 baud the bound is an intentional policy limit (see review discussion), and the worst case there is one spurious, retryable `-EBUSY`. (The first revision used 100 ms; raised during review to cover low baud rates.)
- **Why `-EBUSY` with no side effects**: the alternative (proceed after timeout) disables the receiver mid-frame and destroys the byte in flight. Leaving the peripheral untouched makes the call safely retryable: quiesce and retry converges, and the error is distinguishable from `-ENOTSUP` (unsupported coding) which callers should *not* retry.
- No behavior change for the common case: reconfiguring an idle UART finds TC already set and proceeds immediately, as before.

## Testing

Verified on MCXA153 hardware with a CDC-ACM to UART bridge running loopback transfers across line-coding changes: with the application quiescing its traffic, the TC wait exits immediately and reconfiguration is byte-exact (16384/16384 on an unprimed first-after-boot transfer, previously 16383/16384 with a 15.36 s stall); with a caller that does not quiesce, the call returns `-EBUSY` when the bound expires instead of hanging for the duration of the traffic. The `-EBUSY` path was exercised with the initial 100 ms bound; the raise to 300 ms changes only the timeout constant, not the code path.
