### PR TITLE
tests: kernel: sched: keep the slice-reset thread array off the stack

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -31,6 +31,7 @@ K_SEM_DEFINE(sema, 0, NUM_THREAD);
 /* Reference timestamp (in ticks) for each measurement */
 static uint64_t elapsed_slice;
 static int thread_idx;
+static struct k_thread t[NUM_THREAD];
 
 static void thread_time_slice(void *p1, void *p2, void *p3)
 {
@@ -92,7 +93,6 @@ ZTEST(threads_scheduling, test_slice_reset)
 #ifdef CONFIG_TIMESLICING
 	uint32_t t32;
 	k_tid_t tid[NUM_THREAD];
-	struct k_thread t[NUM_THREAD];
 	int old_prio = k_thread_priority_get(k_current_get());
 
 	thread_idx = 0;


### PR DESCRIPTION
`test_slice_reset()` in `tests/kernel/sched/schedule_api` keeps three `struct k_thread` control blocks on the ztest thread's stack, which defaults to 1024 bytes (2048 on x86, which is why only the smaller targets are affected). That leaves the test with almost no margin, so a kernel change that grows a frame anywhere on the scheduler path overflows the stack here and surfaces as a USAGE FAULT rather than as a test failure, pointing suspicion at the kernel change rather than the test.

Measured on mps3/corstone300/an547 at current main: the test passes with `CONFIG_ZTEST_STACK_SIZE` at its 1024 byte default and overflows at 960, so it has under 64 bytes of margin. With the array moved off the stack it passes with the ztest stack cut to 512, so the margin becomes larger than 512 bytes.

Two unrelated kernel PRs are currently failing `kernel.scheduler.slice_perthread` for this reason, #113440 and #110059, and cannot pick the fix up while it lives inside one of them. @msalvee diagnosed it and wrote the fix in #113440; this pulls it out so both can use it and so the test stops mis-attributing future kernel changes.
