### PR TITLE
MAINTAINERS: defer add'l vendor-owned sensor drivers from generic area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2782,6 +2782,14 @@ Documentation Infrastructure:
     - name: Vendor-owned sensor drivers
       defer-to-other-areas: true
       files:
+        - drivers/sensor/adi/
+        - drivers/sensor/espressif/
+        - drivers/sensor/infineon/
+        - drivers/sensor/ite/
+        - drivers/sensor/microchip/
+        - drivers/sensor/nordic/
+        - drivers/sensor/nxp/
+        - drivers/sensor/silabs/
         - drivers/sensor/st/
         - drivers/sensor/tdk/
         - drivers/sensor/wsen/


### PR DESCRIPTION
Follow up to commit e556cce95113946538d8d2f289d31a745ec9cd45, deferring additional sensor drivers - adi, espressif, infineon, ite, microchip, nordic, nxp, and silabs - to their respective vendor areas.