### PR TITLE
toolchain: zephyr_stdint: only redefine 64-bit types when long is 32-bit

### DIFF
--- a/include/zephyr/toolchain/zephyr_stdint.h
+++ b/include/zephyr/toolchain/zephyr_stdint.h
@@ -53,12 +53,6 @@
 #undef __UINT_FAST32_TYPE__
 #undef __INT_LEAST32_TYPE__
 #undef __UINT_LEAST32_TYPE__
-#undef __INT64_TYPE__
-#undef __UINT64_TYPE__
-#undef __INT_FAST64_TYPE__
-#undef __UINT_FAST64_TYPE__
-#undef __INT_LEAST64_TYPE__
-#undef __UINT_LEAST64_TYPE__
 
 #define __INT32_TYPE__ int
 #define __UINT32_TYPE__ unsigned int
@@ -66,12 +60,30 @@
 #define __UINT_FAST32_TYPE__ __UINT32_TYPE__
 #define __INT_LEAST32_TYPE__ __INT32_TYPE__
 #define __UINT_LEAST32_TYPE__ __UINT32_TYPE__
+
+/*
+ * On LP64 targets (e.g. aarch64) where sizeof(long) == 8, the compiler-native
+ * __UINT64_TYPE__ is already 'long unsigned int', which matches the parameter
+ * types used by intrinsics shipped in the toolchain's own headers (e.g.
+ * arm_acle.h). Overriding it to 'unsigned long long int' desynchronises those
+ * built-ins from 'uint64_t', which GCC 14 flags as an incompatible-pointer-
+ * types error. Only redefine the 64-bit types when sizeof(long) == 4.
+ */
+#if __SIZEOF_LONG__ == 4
+#undef __INT64_TYPE__
+#undef __UINT64_TYPE__
+#undef __INT_FAST64_TYPE__
+#undef __UINT_FAST64_TYPE__
+#undef __INT_LEAST64_TYPE__
+#undef __UINT_LEAST64_TYPE__
+
 #define __INT64_TYPE__ long long int
 #define __UINT64_TYPE__ unsigned long long int
 #define __INT_FAST64_TYPE__ __INT64_TYPE__
 #define __UINT_FAST64_TYPE__ __UINT64_TYPE__
 #define __INT_LEAST64_TYPE__ __INT64_TYPE__
 #define __UINT_LEAST64_TYPE__ __UINT64_TYPE__
+#endif
 
 /*
  * The confusion also exists with __INTPTR_TYPE__ which is either an int


### PR DESCRIPTION
## Summary

Fixes #115244.

`include/zephyr/toolchain/zephyr_stdint.h` unconditionally redefines `__INT64_TYPE__` / `__UINT64_TYPE__` (and the `FAST` / `LEAST` variants) to `long long int` / `unsigned long long int`. On LP64 targets (aarch64) the Zephyr SDK GCC's native `__UINT64_TYPE__` is `long unsigned int`, and headers shipped with GCC (e.g. `arm_acle.h`) call built-ins whose parameter types were resolved against the compiler-native `uint64_t`. The Zephyr override desynchronises those two views, and with GCC 14 promoting `-Wincompatible-pointer-types` to an error by default, any TU that transitively includes `<arm_acle.h>` fails to build:

```
arm_acle.h:276:34: error: passing argument 1 of '__builtin_aarch64_rndr'
  from incompatible pointer type [-Wincompatible-pointer-types]
note: expected 'long unsigned int *' but argument is of type
      'uint64_t *' {aka 'long long unsigned int *'}
```

## Fix

Gate the 64-bit `__INT64_TYPE__` / `__UINT64_TYPE__` overrides (and their `FAST` / `LEAST` variants) on `__SIZEOF_LONG__ == 4`. The 32-bit override introduced in 51b30a5694e is still needed on targets where the SDK GCC declares `__INT32_TYPE__` as `long int`; the 64-bit override is only necessary when `sizeof(long) == 4`. On LP64 the compiler-native types already meet Zephyr's expectations.

## Verification

* `samples/bluetooth/audio/tmap_peripheral` built cleanly on `nitrogen93_smarc/mimx9352/a55/nx611` (aarch64 LP64, Zephyr SDK 1.0.1 GCC 14.3.0) with `CONFIG_LIBLC3=y` — the failing case from the issue.
* Same sample built on `nrf5340_audio_dk/nrf5340/cpuapp` (Cortex-M33, 32-bit) with byte-identical FLASH/RAM footprint versus pre-fix (`FLASH: 174580 B`, `RAM: 55925 B`) — confirms no behavioral change on 32-bit targets.

Assisted-by: Assisted-by: Claude:claude-opus-4.7
