### PR TITLE
samples: drivers: spi: Introduce RTIO sample

### DIFF
--- a/samples/drivers/spi/index.rst
+++ b/samples/drivers/spi/index.rst
@@ -1,0 +1,5 @@
+.. zephyr:code-sample-category:: spi
+   :name: SPI
+   :show-listing:
+
+   These samples demonstrate how to use the :ref:`spi_api` driver API.

--- a/samples/drivers/spi/rtio_loopback/CMakeLists.txt
+++ b/samples/drivers/spi/rtio_loopback/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(spi_rtio_loopback)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/spi/rtio_loopback/Kconfig
+++ b/samples/drivers/spi/rtio_loopback/Kconfig
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "SPI RTIO Loopback Test"
+
+config SAMPLE_DATA_WRITE_SIZE
+	int "Write size from perspective of controller in bytes"
+	default 4
+
+config SAMPLE_DATA_READ_SIZE
+	int "Read size from perspective of controller in bytes"
+	default 32
+
+choice SAMPLE_SPI_MODE
+	prompt "SPI mode used by controller and device"
+	default SAMPLE_SPI_MODE_0
+
+config SAMPLE_SPI_MODE_0
+	bool "Use SPI mode 0 for controller and device"
+
+config SAMPLE_SPI_MODE_1
+	bool "Use SPI mode 1 for controller and device"
+
+config SAMPLE_SPI_MODE_2
+	bool "Use SPI mode 2 for controller and device"
+
+config SAMPLE_SPI_MODE_3
+	bool "Use SPI mode 3 for controller and device"
+
+endchoice # SAMPLE_SPI_MODE
+
+choice SAMPLE_SPI_BIT_ORDER
+	prompt "SPI bit order used by controller and device"
+	default SAMPLE_SPI_BIT_ORDER_MSB
+
+config SAMPLE_SPI_BIT_ORDER_MSB
+	bool "Use MSB SPI bit order for controller and device"
+
+config SAMPLE_SPI_BIT_ORDER_LSB
+	bool "Use LSB SPI bit order for controller and device"
+
+endchoice # SAMPLE_SPI_BIT_ORDER
+
+source "Kconfig.zephyr"

--- a/samples/drivers/spi/rtio_loopback/README.rst
+++ b/samples/drivers/spi/rtio_loopback/README.rst
@@ -1,0 +1,75 @@
+.. zephyr:code-sample:: spi-rtio-loopback
+   :name: SPI RTIO loopback
+   :relevant-api: rtio spi_interface
+
+   Perform SPI transfers between SPI controller and SPI target using RTIO.
+
+Overview
+********
+
+This sample demonstrates how to perform SPI transfers using RTIO. It uses two SPI controllers,
+acting as SPI controller and peripheral/target respectively.
+
+Requirements
+************
+
+This sample requires two SPI controllers, one supporting the SPI controller role, one supporting
+the SPI peripheral/target role, connected to the same SPI bus.
+
+.. note::
+
+   Remember to connect the relevant SPI controllers to the bus physically.
+
+Board support
+*************
+
+Any board which meets the requirements must use an overlay to specify which SPI controller will act
+as the controller, and which as the peripheral/target. This is done using the devicetree by adding
+SPI device nodes to the relevant SPI controllers, adding the nodelabel ``spi_controller`` to the
+SPI device SPI controller acting as controller, and ``spi_target`` to the SPI device SPI controller
+acting as peripheral/target. These two SPI device nodes describe the same SPI device, from the
+perspective of the SPI controller and SPI peripheral/target respectively.
+
+.. code-block:: devicetree
+
+   &spi22 {
+           status = "okay";
+           cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+
+           spi_controller: spi-device@0 {
+                      compatible = "vnd,spi-device";
+                      reg = <0>;
+                      spi-max-frequency = <DT_FREQ_M(8)>;
+           };
+   };
+
+   &spi21 {
+           status = "okay";
+
+           spi_target: spi-device@0 {
+                      compatible = "vnd,spi-device";
+                      reg = <0>;
+                      spi-max-frequency = <DT_FREQ_M(8)>;
+           };
+   };
+
+If necessary, add any board specific configs to the board specific conf fragment:
+
+.. code-block:: cfg
+
+   CONFIG_SPI_STM32_INTERRUPT=y
+
+Transferred data sizes
+**********************
+
+One can tune the number of data bytes exchanged during the tests using the sample specific
+configuration options:
+
+* :kconfig:option:`CONFIG_SAMPLE_DATA_WRITE_SIZE`
+* :kconfig:option:`CONFIG_SAMPLE_DATA_READ_SIZE`
+* :kconfig:option:`CONFIG_SAMPLE_SPI_MODE_0`
+* :kconfig:option:`CONFIG_SAMPLE_SPI_MODE_1`
+* :kconfig:option:`CONFIG_SAMPLE_SPI_MODE_2`
+* :kconfig:option:`CONFIG_SAMPLE_SPI_MODE_3`
+* :kconfig:option:`CONFIG_SAMPLE_SPI_BIT_ORDER_MSB`
+* :kconfig:option:`CONFIG_SAMPLE_SPI_BIT_ORDER_LSB`

--- a/samples/drivers/spi/rtio_loopback/boards/b_u585i_iot02a.conf
+++ b/samples/drivers/spi/rtio_loopback/boards/b_u585i_iot02a.conf
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_STM32_INTERRUPT=y
+CONFIG_SPI_STM32_DMA=y

--- a/samples/drivers/spi/rtio_loopback/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/spi/rtio_loopback/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* SPI bus pins of SPI1 and SPI3 are exposed on the STMod+ CN2 and CN3 connectors
+ *
+ *  Bus     MISO           MOSI           SCK            NSS
+ *          Pin   Hdr      Pin   Hdr      Pin   Hdr      Pin   Hdr
+ *  spi1    PE14  CN3:3    PE15  CN3:2    PE13  CN3:4    PA4   CN3:1
+ *  spi3    PG10  CN2:3    PD6   CN2:2    PG9   CN2:4    PG12  CN2:1
+ *
+ * Short CN2:1 to CN3:1, CN2:2 to CN3:2, CN2:3 to CN3:3 and CN2:4 to CN3:4 for the
+ * test to pass.
+ */
+
+&gpioh {
+	status = "okay";
+
+	stmod-cn3-spi-select {
+		gpio-hog;
+		gpios = <13 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+
+	stmod-cn2-spi-select {
+		gpio-hog;
+		gpios = <15 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&spi1_miso_pe14 &spi1_mosi_pe15 &spi1_sck_pe13 &spi1_nss_pa4>;
+	pinctrl-names = "default";
+	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
+
+	spi_controller: spi-device@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};
+
+&spi3 {
+	status = "okay";
+	pinctrl-0 = <&spi3_miso_pg10 &spi3_mosi_pd6 &spi3_sck_pg9 &spi3_nss_pg12>;
+	pinctrl-names = "default";
+	dmas = <&gpdma1 2 11 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 3 10 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
+
+	spi_target: spi-device@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};

--- a/samples/drivers/spi/rtio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/spi/rtio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SCK = P1.12 and P1.13
+ * MISO = P1.10 and P1.11
+ * MOSI = P1.08 and P1.09
+ * CSN = P1.14 and P2.10
+ */
+
+&pinctrl {
+	spi22_default: spi22_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 11)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+		};
+	};
+
+	spi22_sleep: spi22_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 11)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+			low-power-enable;
+		};
+	};
+
+	spi21_default: spi21_default {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
+				<NRF_PSEL(SPIS_MISO, 1, 10)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+		};
+	};
+
+	spi21_sleep: spi21_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
+				<NRF_PSEL(SPIS_MISO, 1, 10)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi22 {
+	status = "okay";
+	pinctrl-0 = <&spi22_default>;
+	pinctrl-1 = <&spi22_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+
+	spi_controller: spi-device@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};
+
+&spi21 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi21_default>;
+	pinctrl-1 = <&spi21_sleep>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/ rx-delay-supported;
+	/delete-property/ rx-delay;
+
+	spi_target: spi-device@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};

--- a/samples/drivers/spi/rtio_loopback/prj.conf
+++ b/samples/drivers/spi/rtio_loopback/prj.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI=y
+CONFIG_RTIO=y
+CONFIG_SPI_RTIO=y

--- a/samples/drivers/spi/rtio_loopback/src/main.c
+++ b/samples/drivers/spi/rtio_loopback/src/main.c
@@ -1,0 +1,279 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/rtio/rtio.h>
+
+#include <string.h>
+
+#define SAMPLE_SPI_CONTROLLER_NODE DT_NODELABEL(spi_controller)
+#define SAMPLE_SPI_CONTROLLER_BUS DEVICE_DT_GET(DT_BUS(SAMPLE_SPI_CONTROLLER_NODE))
+#define SAMPLE_SPI_TARGET_NODE DT_NODELABEL(spi_target)
+#define SAMPLE_SPI_TARGET_BUS DEVICE_DT_GET(DT_BUS(SAMPLE_SPI_TARGET_NODE))
+
+#if CONFIG_SAMPLE_SPI_MODE_0
+#define SAMPLE_CONFIG_MODE (0)
+#elif CONFIG_SAMPLE_SPI_MODE_1
+#define SAMPLE_CONFIG_MODE (SPI_MODE_CPHA)
+#elif CONFIG_SAMPLE_SPI_MODE_2
+#define SAMPLE_CONFIG_MODE (SPI_MODE_CPOL)
+#elif CONFIG_SAMPLE_SPI_MODE_3
+#define SAMPLE_CONFIG_MODE (SPI_MODE_CPOL | SPI_MODE_CPHA)
+#endif
+
+#if CONFIG_SAMPLE_SPI_BIT_ORDER_MSB
+#define SAMPLE_CONFIG_BIT_ORDER (SPI_TRANSFER_MSB)
+#elif CONFIG_SAMPLE_SPI_BIT_ORDER_LSB
+#define SAMPLE_CONFIG_BIT_ORDER (SPI_TRANSFER_LSB)
+#endif
+
+#define SAMPLE_SPI_CONTROLLER_CONFIG \
+	(SPI_WORD_SET(8) | SAMPLE_CONFIG_MODE | SAMPLE_CONFIG_BIT_ORDER | SPI_OP_MODE_MASTER)
+
+#define SAMPLE_SPI_TARGET_CONFIG \
+	(SPI_WORD_SET(8) | SAMPLE_CONFIG_MODE | SAMPLE_CONFIG_BIT_ORDER | SPI_OP_MODE_SLAVE)
+
+#define SAMPLE_TIMEOUT K_SECONDS(1)
+
+#define SAMPLE_WRITE_SIZE CONFIG_SAMPLE_DATA_WRITE_SIZE
+#define SAMPLE_READ_SIZE CONFIG_SAMPLE_DATA_READ_SIZE
+#define SAMPLE_BUFFER_SIZE (SAMPLE_WRITE_SIZE + SAMPLE_READ_SIZE)
+
+/*
+ * The user defines RTIO contexts for which actions like writes and reads will be
+ * submitted, and the results of said actions will be retrieved. They are device
+ * agnostic.
+ *
+ * We have one SPI controller device, and one SPI target device. One RTIO context
+ * is defined for each of them. This allows us to easily manage their separate
+ * transactions as each is tied to a specific RTIO context.
+ *
+ *
+ * We will be using 1 submission queue event (SQEs) for SPI transceive
+ * and 1 completion queue event (CQE) for the transaction result.
+ */
+RTIO_DEFINE(sample_controller_rtio, 1, 1);
+RTIO_DEFINE(sample_target_rtio, 1, 1);
+
+/*
+ * The user defines RTIO IODEVs which bind the RTIO contexts to the specific
+ * underlying devices, in this case SPI devices. The helper macro
+ * SPI_DT_IODEV_DEFINE defines an RTIO IODEV specific to a SPI device defined
+ * in the devicetree.
+ */
+SPI_DT_IODEV_DEFINE(sample_controller_rtio_iodev,
+		    SAMPLE_SPI_CONTROLLER_NODE,
+		    SAMPLE_SPI_CONTROLLER_CONFIG);
+SPI_DT_IODEV_DEFINE(sample_target_rtio_iodev,
+		    SAMPLE_SPI_TARGET_NODE,
+		    SAMPLE_SPI_TARGET_CONFIG);
+
+/* Source of truth transaction data */
+static uint8_t sample_write_data[SAMPLE_BUFFER_SIZE];
+static uint8_t sample_read_data[SAMPLE_BUFFER_SIZE];
+
+/*
+ * The controller will write data from sample_controller_write_data then read
+ * data into sample_controller_read_buf.
+ */
+static uint8_t sample_controller_write_data[SAMPLE_BUFFER_SIZE];
+static uint8_t sample_controller_read_buf[SAMPLE_BUFFER_SIZE];
+
+/*
+ * The target will read data into sample_target_read_buf, then write data from
+ * sample_target_write_data.
+ */
+static uint8_t sample_target_read_buf[SAMPLE_BUFFER_SIZE];
+static uint8_t sample_target_write_data[SAMPLE_BUFFER_SIZE];
+
+static void sample_init_data(void)
+{
+	memset(sample_write_data, 0xFF, SAMPLE_BUFFER_SIZE);
+	for (size_t i = 0; i < SAMPLE_WRITE_SIZE; i++) {
+		sample_write_data[i] = (uint8_t)i;
+	}
+
+	memset(sample_read_data, 0xFF, SAMPLE_BUFFER_SIZE);
+	for (size_t i = 0; i < SAMPLE_READ_SIZE; i++) {
+		sample_read_data[i + SAMPLE_WRITE_SIZE] = 255 - (uint8_t)i;
+	}
+
+	memcpy(sample_controller_write_data, sample_write_data, SAMPLE_BUFFER_SIZE);
+	memset(sample_controller_read_buf, 0x80, SAMPLE_BUFFER_SIZE);
+	memset(sample_target_read_buf, 0x80, SAMPLE_BUFFER_SIZE);
+	memcpy(sample_target_write_data, sample_read_data, SAMPLE_BUFFER_SIZE);
+}
+
+static int sample_validate_transaction(void)
+{
+	int ret;
+
+	ret = memcmp(sample_read_data, sample_controller_read_buf, SAMPLE_BUFFER_SIZE);
+	if (ret) {
+		return ret;
+	}
+
+	ret = memcmp(sample_write_data, sample_target_read_buf, SAMPLE_BUFFER_SIZE);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int sample_submit_target_read_write(void)
+{
+	struct rtio_sqe *sqe;
+	int ret;
+
+	sqe = rtio_sqe_acquire(&sample_target_rtio);
+	rtio_sqe_prep_transceive(sqe,
+				 &sample_target_rtio_iodev,
+				 RTIO_PRIO_NORM,
+				 sample_target_write_data,
+				 sample_target_read_buf,
+				 SAMPLE_BUFFER_SIZE,
+				 NULL);
+
+	/*
+	 * We will now submit the transaction, allowing the RTIO context to start
+	 * performing the SQEs. The RTIO context will start the read SQE, which
+	 * will be waiting until we start the write from the SPI controller device.
+	 */
+	ret = rtio_submit(&sample_target_rtio, 0);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int sample_submit_controller_write_read(void)
+{
+	struct rtio_sqe *sqe;
+	int ret;
+
+	sqe = rtio_sqe_acquire(&sample_controller_rtio);
+	rtio_sqe_prep_transceive(sqe,
+				 &sample_controller_rtio_iodev,
+				 RTIO_PRIO_NORM,
+				 sample_controller_write_data,
+				 sample_controller_read_buf,
+				 SAMPLE_BUFFER_SIZE,
+				 NULL);
+
+	/*
+	 * The RTIO context will start the write SQE, which the waiting target
+	 * device will receive, allowing both transactions to complete in the
+	 * background.
+	 */
+	ret = rtio_submit(&sample_controller_rtio, 0);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int sample_await_target_read_write(void)
+{
+	struct rtio_cqe *cqe;
+	int ret;
+
+	/* Wait for the CQE generated by the target device transaction completing */
+	cqe = rtio_cqe_consume_block(&sample_target_rtio);
+
+	/*
+	 * Copy the result of the transaction. If any SQE of the transaction fails,
+	 * CQEs will still be generated for successive SQEs if RTIO_SQE_NO_RESPONSE
+	 * is not set for them.
+	 */
+	ret = cqe->result;
+
+	/* Remember to release the CQE once done */
+	rtio_cqe_release(&sample_target_rtio, cqe);
+
+	return ret;
+}
+
+static int sample_await_controller_write_read(void)
+{
+	struct rtio_cqe *cqe;
+	int ret;
+
+	cqe = rtio_cqe_consume_block(&sample_controller_rtio);
+
+	ret = cqe->result;
+
+	rtio_cqe_release(&sample_controller_rtio, cqe);
+
+	return ret;
+}
+
+int main(void)
+{
+	int ret;
+
+	if (!spi_is_ready_iodev(&sample_controller_rtio_iodev)) {
+		printk("%s iodev not ready\n", "controller");
+		return 0;
+	}
+
+	if (!spi_is_ready_iodev(&sample_controller_rtio_iodev)) {
+		printk("%s iodev not ready\n", "target");
+		return 0;
+	}
+
+	sample_init_data();
+
+	printk("%s %s\n", "submit_target_read_write", "running");
+	ret = sample_submit_target_read_write();
+	if (ret) {
+		printk("%s %s (%d)\n", "submit_target_read_write", "failed", ret);
+		return 0;
+	}
+
+	/*
+	 * Since RTIO, and the hardware itself, is asynchronous, we can't know exactly when
+	 * the SPI target device is ready to transceive. We wait "a while" post submitting
+	 * the transceive SQE to increase the odds the SPI target is ready and waiting for
+	 * the SPI controller to start the transaction.
+	 */
+	printk("waiting for target ready\n");
+	k_sleep(SAMPLE_TIMEOUT);
+
+	printk("%s %s\n", "submit_controller_write_read", "running");
+	ret = sample_submit_controller_write_read();
+	if (ret) {
+		printk("%s %s (%d)\n", "submit_controller_write_read", "failed", ret);
+		return 0;
+	}
+
+	printk("%s %s\n", "await_target_read_write", "running");
+	ret = sample_await_target_read_write();
+	if (ret < 0) {
+		printk("%s %s (%d)\n", "await_target_read_write", "failed", ret);
+		return 0;
+	}
+
+	printk("%s %s\n", "await_controller_write_read", "running");
+	ret = sample_await_controller_write_read();
+	if (ret) {
+		printk("%s %s (%d)\n", "await_controller_write_read", "failed", ret);
+		return 0;
+	}
+
+	printk("%s %s\n", "sample_validate_transaction", "running");
+	ret = sample_validate_transaction();
+	if (ret) {
+		printk("%s %s (%d)\n", "sample_validate_transaction", "failed", ret);
+		return 0;
+	}
+
+	printk("sample complete\n");
+	return 0;
+}

--- a/samples/drivers/spi/rtio_loopback/tests.yaml
+++ b/samples/drivers/spi/rtio_loopback/tests.yaml
@@ -1,0 +1,16 @@
+sample:
+  name: SPI RTIO loopback sample
+tests:
+  sample.drivers.spi.rtio_loopback:
+    tags:
+      - rtio
+      - spi
+    harness: console
+    harness_config:
+      fixture: spi_loopback
+      type: one_line
+      regex:
+        - "sample complete"
+    platform_allow:
+      - b_u585i_iot02a
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Introduce SPI RTIO sample, which shows how to use RTIO to set up and perform SPI transactions between two SPI devices, one acting as controller, the other as device. It mimics the [i2c rtio loopback sample](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/drivers/i2c/rtio_loopback) though its a bit simpler to avoid demoing RTIO features like callback SQEs in a sample which really just needs to show how to do SPI transfers between SPI controllers in both controller and peripheral roles.