### PR TITLE
drivers: mipi_dbi: check the chip select GPIO per device index

### DIFF
--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -45,6 +45,10 @@ extern "C" {
 #define MIPI_DBI_DT_SPI_DEV(node_id)					\
 	DT_PHANDLE(DT_PARENT(node_id), spi_dev)
 
+#define MIPI_DBI_SPI_HAS_CS_GPIOS(node_id)				\
+	DT_PROP_HAS_IDX(MIPI_DBI_DT_SPI_DEV(node_id), cs_gpios,		\
+			DT_REG_ADDR_RAW(node_id))
+
 #define MIPI_DBI_SPI_CS_GPIOS_DT_SPEC_GET(node_id)			\
 	GPIO_DT_SPEC_GET_BY_IDX_OR(MIPI_DBI_DT_SPI_DEV(node_id),	\
 		cs_gpios, DT_REG_ADDR_RAW(node_id), {})
@@ -75,10 +79,10 @@ extern "C" {
 			COND_CODE_1(DT_PROP(node_id, mipi_hold_cs), SPI_HOLD_ON_CS, (0)),	\
 		.slave = DT_REG_ADDR(node_id),				\
 		.cs = {									\
-			COND_CODE_1(DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),	\
+			COND_CODE_1(MIPI_DBI_SPI_HAS_CS_GPIOS(node_id),			\
 			(MIPI_DBI_SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)),		\
 			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))				\
-			.cs_is_gpio = DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),\
+			.cs_is_gpio = MIPI_DBI_SPI_HAS_CS_GPIOS(node_id),		\
 		},									\
 	}
 

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -45,6 +45,14 @@ extern "C" {
 #define MIPI_DBI_DT_SPI_DEV(node_id)					\
 	DT_PHANDLE(DT_PARENT(node_id), spi_dev)
 
+/*
+ * DT_SPI_DEV_HAS_CS_GPIOS() for a MIPI DBI child: same per-device question, but the
+ * controller is reached through the parent's spi-dev phandle rather than DT_BUS().
+ */
+#define MIPI_DBI_SPI_DEV_HAS_CS_GPIOS(node_id)				\
+	DT_PROP_HAS_IDX(MIPI_DBI_DT_SPI_DEV(node_id), cs_gpios,		\
+			DT_REG_ADDR_RAW(node_id))
+
 #define MIPI_DBI_SPI_CS_GPIOS_DT_SPEC_GET(node_id)			\
 	GPIO_DT_SPEC_GET_BY_IDX_OR(MIPI_DBI_DT_SPI_DEV(node_id),	\
 		cs_gpios, DT_REG_ADDR_RAW(node_id), {})
@@ -75,10 +83,10 @@ extern "C" {
 			COND_CODE_1(DT_PROP(node_id, mipi_hold_cs), SPI_HOLD_ON_CS, (0)),	\
 		.slave = DT_REG_ADDR(node_id),				\
 		.cs = {									\
-			COND_CODE_1(DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),	\
+			COND_CODE_1(MIPI_DBI_SPI_DEV_HAS_CS_GPIOS(node_id),			\
 			(MIPI_DBI_SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)),		\
 			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))				\
-			.cs_is_gpio = DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),\
+			.cs_is_gpio = MIPI_DBI_SPI_DEV_HAS_CS_GPIOS(node_id),		\
 		},									\
 	}
 

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -693,8 +693,9 @@
 			status = "okay";
 			clock-frequency = <2000000>;
 
-			/* one entry for every device. Note that this must
-			 * include MIPI DBI devices as well.
+			/* Chip select GPIOs for reg 0 through 9. Children at
+			 * higher reg values, including MIPI DBI ones, take
+			 * the controller's native chip select instead.
 			 */
 			cs-gpios = <&test_gpio 0 0 &test_gpio 0 1 &test_gpio 0 2
 				    &test_gpio 0 3 &test_gpio 0 4 &test_gpio 0 5

--- a/tests/drivers/build_all/display/src/main.c
+++ b/tests/drivers/build_all/display/src/main.c
@@ -4,6 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/drivers/mipi_dbi.h>
+#include <zephyr/sys/util.h>
+
+/*
+ * ssd1322@9 is the last MIPI DBI child inside the ten cs-gpios entries this fixture's SPI
+ * controller declares, and st75256@a is the first one past them. Other boards build this
+ * suite with a display fixture of their own, so this is scoped to the nodes it is about.
+ */
+#if DT_NODE_EXISTS(DT_NODELABEL(test_mipi_dbi_ssd1322)) && \
+	DT_NODE_EXISTS(DT_NODELABEL(test_mipi_dbi_st75256))
+BUILD_ASSERT(MIPI_DBI_SPI_DEV_HAS_CS_GPIOS(DT_NODELABEL(test_mipi_dbi_ssd1322)),
+	     "the last child inside cs-gpios must resolve to a GPIO chip select");
+BUILD_ASSERT(!MIPI_DBI_SPI_DEV_HAS_CS_GPIOS(DT_NODELABEL(test_mipi_dbi_st75256)),
+	     "a child past the end of cs-gpios must not resolve to a GPIO chip select");
+#endif
+
 int main(void)
 {
 	return 0;


### PR DESCRIPTION
`MIPI_DBI_SPI_CONFIG_DT()` decides whether the chip select is a GPIO with a controller-wide test, while the GPIO spec beside it is looked up by the device's own `reg`. A device whose `reg` is past the end of its controller's `cs-gpios` therefore gets `cs_is_gpio` set together with an empty GPIO spec.

## How the two halves drifted apart

011a357db replaced a hardcoded `.cs_is_gpio = true` with `DT_SPI_DEV_HAS_CS_GPIOS()`. That macro has `DT_BUS()` baked into it, and a MIPI DBI device's `DT_BUS()` is the MIPI DBI node rather than the SPI controller, so it was looking at the wrong node. 0a878179f fixed that by reaching for the predicate that lets the controller be passed explicitly:

```diff
-			COND_CODE_1(DT_SPI_DEV_HAS_CS_GPIOS(node_id),
-			.cs_is_gpio = DT_SPI_DEV_HAS_CS_GPIOS(node_id),
+			COND_CODE_1(DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),
+			.cs_is_gpio = DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),
```

At that point the two predicates were the same thing. `DT_SPI_DEV_HAS_CS_GPIOS()` was still defined as `DT_SPI_HAS_CS_GPIOS(DT_BUS(spi_dev))`, so this changed which node was consulted and nothing else. No wider behaviour was chosen here.

Two weeks later #98830 reported that testing for the property rather than the index was wrong, and b38054bbaea7 tightened `DT_SPI_DEV_HAS_CS_GPIOS()`:

```diff
-#define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev) DT_SPI_HAS_CS_GPIOS(DT_BUS(spi_dev))
+#define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev)                                                           \
+	DT_PROP_HAS_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
```

MIPI DBI had already moved off that macro for the unrelated node reason, so it kept the older behaviour while the GPIO spec next to it stayed per index. The documented split is still the one to follow: `DT_SPI_HAS_CS_GPIOS()` takes "a SPI bus controller node identifier" and answers whether the property exists, while `DT_SPI_DEV_HAS_CS_GPIOS()` takes "a SPI device node identifier" and answers whether there is "a chip select pin at index DT_REG_ADDR(spi_dev)".

## Verification

I built a native_sim probe that instantiates the whole initializer and asserts the predicate, for the shapes that matter: property absent, device inside the range, device past the end:

| controller `cs-gpios` | device `reg` | predicate | chip select |
|---|---|---|---|
| absent | 0 | 0 | native, unchanged |
| one entry | 0 | 1 | GPIO, unchanged |
| one entry | 1 | 0 | native, previously GPIO with an empty spec |
| two entries | 1 | 1 | GPIO, unchanged |

Only the third row moves, and it is the one that had no GPIO to drive in the first place. The absent-property row matters because `DT_PROP_HAS_IDX()` has to stay quiet there rather than fail to expand, and it does.

`tests/drivers/build_all/display` is the one in-tree fixture where the shape shows up: its SPI controller declares ten CS entries while 20 of the 29 MIPI DBI children on `test_mipi_dbi` sit at higher reg values, so those were the devices getting the inconsistent initializer. It now carries the boundary as two compile-time assertions: `ssd1322@9`, the last child inside the range, must resolve to a GPIO chip select, and `st75256@a` past the end must not. Reverting the predicate to the controller-wide form makes the second one fail the build. Both are guarded on the two fixture nodes existing, because the same suite builds for boards that bring a display fixture of their own that does not define these labels; without a guard it broke `sf32lb52_devkit_lcd` and `ai_m62_12f_kit`. Asserting the in-range child as well means a predicate that regressed to always-false cannot quietly skip the negative case. Verified both ways with twister across all three scenarios it builds.

The comment above that `cs-gpios` array said there was one entry for every device, which stopped being true as children were added past the tenth. It now describes the boundary the array actually draws, so the fixture no longer reads as if the missing entries were an oversight.

The assertions live in the build_all fixture rather than in `tests/drivers/mipi_dbi/api`; #110156 was rewriting that suite when this was written and has since merged. A runtime check on the resulting `spi_config` in that suite would be stronger and is a reasonable follow-up; the predicate itself is a devicetree expression that a `BUILD_ASSERT` settles.

How much stronger is measurable. I broke the header five ways, one at a time, and rebuilt `drivers.display.build.default`:

| change | build_all assertions |
|---|---|
| helper back to the controller-wide test | fails the build |
| helper always false | fails the build |
| only `.cs_is_gpio` back to controller-wide | still builds |
| only the `COND_CODE_1()` union selection back to controller-wide | still builds |
| GPIO spec getter pinned to index 0 | still builds |

The first two are what these assertions exist for, and they hold. The last three change a use site and leave the predicate alone, so a compile-time check on the predicate cannot see them; catching those means inspecting the resulting `spi_config`, which is the follow-up above. That is the bar I would hold such a test to. Built on `native_sim/native/64` because this machine has no 32-bit SDL2 headers. The predicate and the branch it selects are settled by the devicetree macros, so the word size does not change them; the run adds no 32-bit ABI or hardware coverage.

The macro is also named `MIPI_DBI_SPI_DEV_HAS_CS_GPIOS()` now rather than `MIPI_DBI_SPI_HAS_CS_GPIOS()`. In the generic SPI naming, `DT_SPI_HAS_CS_GPIOS()` is the controller-wide predicate and `DT_SPI_DEV_HAS_CS_GPIOS()` is the per-device one, and conflating exactly those two is the bug being fixed here, so the shorter name pointed at the wrong half.

Fixes #115251





