### PR TITLE
ci: set_assignee: fine-tune assignments and labels per PR

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -121,6 +121,25 @@
 #         are the ones used in test case definitions, and in test suite definitions in
 #         testcase.yaml.
 #
+#     meta:
+#         Boolean (default false). Set to true for areas that cut across the
+#         whole tree (documentation, samples, tests, benchmarks, the release
+#         process, ...) rather than owning one subsystem, and whose file
+#         patterns therefore match large parts of it.
+#
+#         Tooling treats such areas differently:
+#
+#         * scripts/ci/set_assignees.py does not weight them when picking a
+#           pull request assignee, so a meta-area maintainer is only assigned
+#           when the meta-area is the sole area a pull request touches.
+#
+#         * scripts/ci/sync_maintainer_tests.py does not auto-generate 'tests'
+#           entries for them, as the identifiers derived from their broad file
+#           patterns would be too generic to be useful.
+#
+#         This is the single place where meta-areas are declared; add the key
+#         to an area to classify it as one.
+#
 #
 # All areas must have a 'files' and/or 'files-regex' key. The other keys are
 # optional.
@@ -543,6 +562,7 @@ BeagleBoard Platforms:
 
 Benchmarks:
   status: maintained
+  meta: true
   maintainers:
     - peter-mitsis
   collaborators:
@@ -1432,6 +1452,7 @@ Display drivers:
 
 Documentation:
   status: maintained
+  meta: true
   maintainers:
     - kartben
   collaborators:
@@ -5353,6 +5374,7 @@ Realtek Fingerprint Platforms:
 
 Release:
   status: maintained
+  meta: true
   maintainers:
     - henrikbrixandersen
     - teburd
@@ -5642,6 +5664,7 @@ Safety:
 
 Samples:
   status: maintained
+  meta: true
   maintainers:
     - kartben
   collaborators:
@@ -6157,6 +6180,7 @@ Testing with Renode:
 
 Tests:
   status: maintained
+  meta: true
   maintainers:
     - nashif
   files:

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -188,6 +188,33 @@ If the ranking process yielded nothing (e.g. all areas had the author as sole
 maintainer), the maintainer with the highest cumulative file-weight score is
 used as a last resort.
 
+Reset mode
+----------
+With --reset, the PR is staffed from scratch instead of being topped up.  The
+new staffing is worked out first, and every decision an earlier run made is then
+undone, just before the new one is applied:
+
+  - review requests are withdrawn, except from people who reviewed or commented
+    on the PR (they are involved by their own action) and people this run is
+    about to request again (withdrawing only to re-send would notify them
+    twice).  Team review requests are left alone: the script only ever requests
+    individuals, so a team was requested by hand;
+  - all assignees are removed;
+  - all area labels defined in MAINTAINERS.yml are removed.  Size labels are
+    left to update_size_labels, which recomputes them on every run, and labels
+    the script does not own (``bug``, backport labels, ...) are never touched.
+
+Labels, reviewers and the assignee are chosen exactly as they would be for a
+newly opened PR -- including the rule that people who removed themselves from
+the review request are never re-added, which --reset cannot route around.
+
+A PR the run skips (draft, closed, more than MAX_FILES changed files) is not
+reset either: the skip is decided before the reset runs, so such a PR keeps the
+staffing it has rather than being stripped and left bare.
+
+Use it after MAINTAINERS.yml changed, or when a previous run staffed a PR
+badly.
+
 Deferred file-groups
 --------------------
 A file-group in MAINTAINERS.yml may carry ``defer-to-other-areas: true``.
@@ -419,6 +446,19 @@ def parse_args():
         action="count",
         default=0,
         help="Verbose output. Use -v for INFO, -vv for DEBUG.",
+    )
+
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        default=False,
+        help=(
+            "Re-staff the pull request from scratch: drop the review requests of "
+            "everyone who has not reviewed or commented, remove the assignees and "
+            "the MAINTAINERS.yml area labels, then apply labels, reviewers and an "
+            "assignee as if the pull request had just been opened. Reviewers who "
+            "removed themselves are not re-added."
+        ),
     )
 
     parser.add_argument(
@@ -1106,6 +1146,99 @@ def _select_labels(pr, labels: set, area_counter: dict, area_files: dict) -> set
     return kept | (labels & _SIZE_LABELS)
 
 
+def _interacted_logins(pr) -> set:
+    """Return the logins of everyone who has engaged with *pr*.
+
+    That is anyone who submitted a review, or commented on the PR itself or on
+    one of its review threads.  Such people are involved in the change by their
+    own action, so a reset must not drop them.
+    """
+    logins = set()
+
+    def _add(user):
+        login = getattr(user, 'login', None)
+        if login:
+            logins.add(login)
+
+    for review in pr.get_reviews():
+        _add(review.user)
+    for comment in pr.get_issue_comments():
+        _add(comment.user)
+    for comment in pr.get_review_comments():
+        _add(comment.user)
+
+    return logins
+
+
+def _reset_pr(pr, args, maintainer_file, keep=()) -> set:
+    """Undo this script's earlier decisions on *pr* so it can be staffed afresh.
+
+    Removes the review request from everyone who has not engaged with the PR,
+    drops every assignee, and strips the area labels that MAINTAINERS.yml
+    defines.  The caller then applies the staffing it has just computed, so the
+    PR ends up as if it had been opened now.
+
+    Called late in process_pr, once that staffing is known, for two reasons:
+    every early return (draft, closed, MAX_FILES) has already had its say, so a
+    reset cannot strip a PR and then bail out without restaffing it; and *keep*
+    can hold the logins about to be requested again.  Their request is left in
+    place, since withdrawing it only to re-send it would notify them twice.
+
+    Four things are deliberately left alone:
+
+      - Reviewers who reviewed or commented (see _interacted_logins).  They are
+        already part of the conversation, and dropping their request would
+        either lose that or notify them again for nothing.
+      - Team review requests.  This script only ever requests individuals, so a
+        team request was added by hand and a reset has no basis to withdraw it.
+      - Size labels: update_size_labels recomputes them on every run and
+        removes the stale ones itself.
+      - Labels the script does not own (``bug``, ``RFC``, backport labels, ...).
+        They are not derived from MAINTAINERS.yml, so a reset has no basis for
+        second-guessing whoever added them.
+
+    People who removed themselves from the review request are not handled here:
+    _add_reviewers already refuses to re-request them, so the reset cannot
+    route around that opt-out.
+
+    Returns the names of the labels removed, since pr.labels is a snapshot
+    taken before the reset.
+    """
+    protected = _interacted_logins(pr) | set(keep)
+
+    review_users, _review_teams = pr.get_review_requests()
+    requested = {user.login for user in review_users}
+
+    kept = sorted(requested & protected)
+    if kept:
+        logger.info(
+            "Reset: keeping review request(s) for users who engaged or are still responsible: %s",
+            kept,
+        )
+
+    stale = sorted(requested - protected)
+    if stale:
+        logger.info("Reset: removing %d review request(s): %s", len(stale), stale)
+        if not args.dry_run:
+            pr.delete_review_request(reviewers=stale)
+
+    assignees = sorted({assignee.login for assignee in pr.assignees})
+    if assignees:
+        logger.info("Reset: removing assignee(s): %s", assignees)
+        if not args.dry_run:
+            pr.remove_from_assignees(*assignees)
+
+    area_labels = {label for area in maintainer_file.areas.values() for label in area.labels}
+    removed_labels = {label.name for label in pr.labels} & area_labels
+    if removed_labels:
+        logger.info("Reset: removing label(s): %s", sorted(removed_labels))
+        for name in sorted(removed_labels):
+            if not args.dry_run:
+                pr.remove_from_labels(name)
+
+    return removed_labels
+
+
 def process_pr(gh, args, maintainer_file, number: int):
     gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
     pr = gh_repo.get_pull(number)
@@ -1331,11 +1464,20 @@ def process_pr(gh, args, maintainer_file, number: int):
 
     assignees = _pick_assignees(pr, area_counter, all_maintainers, num_files)
 
+    # With --reset, wipe what an earlier run decided before applying the above,
+    # so the PR ends up staffed as if it were new.  This happens here, not
+    # earlier: every skip condition above has had its say, so a reset cannot
+    # strip a PR the run then declines to restaff, and the reviewers about to be
+    # requested again keep the request they already have.  What the reset
+    # removed is tracked because pr.labels and pr.assignee still describe the
+    # PR as it was before.
+    removed_labels = _reset_pr(pr, args, maintainer_file, keep=collab) if args.reset else set()
+
     # Apply labels — skip any that are already present, then add the rest in
     # a single API call to avoid per-label timeline noise.
     if labels:
         labels = _select_labels(pr, labels, area_counter, area_files)
-        current_label_names = {lbl.name for lbl in pr.labels}
+        current_label_names = {lbl.name for lbl in pr.labels} - removed_labels
         new_labels = sorted(labels - current_label_names)
         if new_labels:
             logger.info("Adding labels: %s", new_labels)
@@ -1351,10 +1493,12 @@ def process_pr(gh, args, maintainer_file, number: int):
         _add_reviewers(gh, gh_repo, pr, args, collab)
 
     # Set assignees (only when none are set yet, unless doing a dry run).
-    if assignees and (not pr.assignee or args.dry_run):
+    # --reset just cleared them, so pr.assignee describes a state that is gone.
+    has_assignee = pr.assignee and not args.reset
+    if assignees and (not has_assignee or args.dry_run):
         _assign_maintainers(gh, pr, args, assignees)
     else:
-        reason = "already has assignee" if pr.assignee else "no assignees found"
+        reason = "already has assignee" if has_assignee else "no assignees found"
         logger.info("Not setting assignee for PR #%d: %s", pr.number, reason)
 
     time.sleep(API_SLEEP_SECONDS)

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -98,6 +98,11 @@ the maintainers of every other touched area:
          these would otherwise get no reviewer whatsoever, since every tier
          above is derived from matched areas.
 
+     This tier is skipped entirely once the tiers above have already produced
+     MIN_TOTAL_REVIEWERS (3) candidates other than the author: the PR then has
+     reviewers who own it by declaration, and lower-confidence names added on
+     top would only dilute the request (and cost API calls).
+
      Two heuristics are tried in order, and the result is appended after the
      tiers above (the author and anyone already listed are excluded).  These
      are lower-confidence picks, so they fill only leftover review slots.
@@ -109,7 +114,9 @@ the maintainers of every other touched area:
      b. When GitHub suggests nobody, the recent contributors to the unstaffed
         files, read from the commit history.  Unlike (a) this is scoped to the
         files that are actually short of reviewers, rather than to the PR as a
-        whole.  Bounded by HISTORY_COMMITS_PER_FILE, MAX_HISTORY_FILES, and
+        whole.  Only the last HISTORY_MAX_AGE_DAYS (365) days are looked at, so
+        that people who stopped working on the file long ago are not asked.
+        Further bounded by HISTORY_COMMITS_PER_FILE, MAX_HISTORY_FILES, and
         MAX_HISTORY_REVIEWERS.
 
 Candidates are then filtered:
@@ -286,10 +293,21 @@ THIN_AREA_COLLABORATORS = 2
 # Bounds on the Git-history heuristic, to keep its GitHub API cost predictable:
 #   - sample at most this many recent commits per changed file,
 #   - inspect at most this many under-covered files in total,
-#   - add at most this many heuristic reviewers to the candidate list.
+#   - add at most this many heuristic reviewers to the candidate list,
+#   - ignore commits older than this, so that people who last touched the file
+#     years ago and have long since moved on are not asked to review it.
 HISTORY_COMMITS_PER_FILE = 20
 MAX_HISTORY_FILES = 40
 MAX_HISTORY_REVIEWERS = 3
+HISTORY_MAX_AGE_DAYS = 365
+
+# The heuristic reviewer tiers (GitHub suggestions, Git history) exist to keep a
+# PR from going unreviewed when MAINTAINERS.yml cannot staff it.  They are not
+# consulted once all the touched areas together have yielded this many
+# candidates: at that point the PR has reviewers responsible for it by
+# declaration, and adding lower-confidence names on top only dilutes the
+# request.
+MIN_TOTAL_REVIEWERS = 3
 
 # GitHub's own reviewer suggestions ("based on commit history and past review
 # comments") are exposed only through the GraphQL API, as a plain unpaginated
@@ -686,10 +704,17 @@ def _history_reviewers(gh_repo, filenames, exclude: set) -> list:
     (commit-author emails cannot be mapped to logins reliably) and does not
     depend on the CI checkout having the full history.
 
+    Only commits from the last HISTORY_MAX_AGE_DAYS days are considered: a
+    contributor who has not touched the file within a year is unlikely to still
+    be the right person to ask, and on old files the unbounded history would
+    otherwise fill every heuristic slot with people who have moved on.
+
     *exclude* holds logins already covered (PR author, existing candidates) so
     they are not re-proposed.  Sampling is bounded by HISTORY_COMMITS_PER_FILE,
     MAX_HISTORY_FILES, and MAX_HISTORY_REVIEWERS.
     """
+    since = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=HISTORY_MAX_AGE_DAYS)
+
     sampled_files = sorted(filenames)
     if len(sampled_files) > MAX_HISTORY_FILES:
         logger.info(
@@ -703,7 +728,7 @@ def _history_reviewers(gh_repo, filenames, exclude: set) -> list:
     counts = defaultdict(int)
     for filename in sampled_files:
         try:
-            commits = gh_repo.get_commits(path=filename)
+            commits = gh_repo.get_commits(path=filename, since=since)
         except GithubException as exc:
             logger.debug("No commit history for '%s': %s", filename, exc)
             continue
@@ -1178,7 +1203,19 @@ def process_pr(gh, args, maintainer_file, number: int):
     for name in thin:
         uncovered_files.update(area_files.get(name, ()))
 
-    if uncovered_files:
+    # The heuristics below are a stopgap for PRs the areas cannot staff, so they
+    # only run while the area tiers are short of reviewers.  The author does not
+    # count: they cannot review their own PR.
+    total_reviewers = set(collab) - {pr.user.login}
+
+    if uncovered_files and len(total_reviewers) >= MIN_TOTAL_REVIEWERS:
+        logger.info(
+            "Skipping heuristic reviewers: %d reviewer(s) already found from the "
+            "touched areas (threshold %d)",
+            len(total_reviewers),
+            MIN_TOTAL_REVIEWERS,
+        )
+    elif uncovered_files:
         if orphan_files:
             logger.info(
                 "%d changed file(s) match no area: %s",

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -25,8 +25,16 @@ Labeling strategy
 For every file changed in the PR, MAINTAINERS.yml is consulted to find the
 matching areas.  The union of all area labels across all matched areas is
 collected and applied to the PR, subject to a cap of MAX_LABELS (10).  If more
-than MAX_LABELS distinct labels would be applied, the entire label step is
-skipped to avoid polluting PRs that touch very broad cross-cutting areas.
+than MAX_LABELS distinct labels would be applied, they are ranked by how much of
+the PR the areas carrying them cover (their file weight, falling back to their
+plain file count for areas weighted 0 -- see Area weighting below) and only the
+MAX_LABELS highest-ranked ones are applied.  That keeps a PR touching very
+broad cross-cutting areas from being papered with labels, while still labelling
+it by whatever it predominantly changes.  Size labels are managed separately:
+they neither count towards the cap nor get dropped by it.
+
+The cap governs what a run applies; labels already on the PR are never removed,
+so it cannot pull an over-labelled PR back under the cap (use --reset for that).
 
 A special lightweight "size: XS" label is managed by default:
   - Added when: the PR has exactly one commit AND at most one line added AND
@@ -281,7 +289,9 @@ REVIEWER_RETRY_BATCH = 15
 # previous comment instead of posting a duplicate.
 MENTION_MARKER = "<!-- set_assignees: reviewer-mention -->"
 
-# Maximum number of labels to apply; more than this is likely noise from over-broad matches.
+# Maximum number of labels to apply; beyond this the labels are noise from
+# over-broad matches, so only the ones contributed by the heaviest areas are
+# kept and the PR is still labelled by what it mostly changes.
 MAX_LABELS = 10
 
 # An area is considered under-covered when it names no maintainers, or names at
@@ -1033,6 +1043,69 @@ def update_size_labels(pr, args, changed_files: list, labels: set):
     )
 
 
+def _rank_labels(labels: set, area_counter: dict, area_files: dict) -> list:
+    """Return *labels* ordered by how much of the PR the areas carrying them cover.
+
+    A label's rank is the sum of the file weights of every touched area that
+    carries it, so a label backed by the bulk of the changed files outranks one
+    coming from a single incidentally matched area.  Ties break by label name to
+    keep the choice deterministic.
+
+    Areas weighing 0 fall back to the number of files they matched.  Those
+    weights are zeroed for assignee selection -- meta-areas, files that only
+    matched CMakeLists.txt, repeated matches of one Platform area -- but the
+    areas still describe what the PR changes, and a label is about exactly that.
+    Without the fallback a documentation-only PR would rank "area: Documentation"
+    last and drop it first.  Labels with no contributing area at all (labels of
+    deferred file-groups) still score 0 and sort last.
+    """
+    weights = defaultdict(int)
+    for area, weight in area_counter.items():
+        weight = weight or len(area_files.get(area.name, ()))
+        for label in area.labels:
+            if label in labels:
+                weights[label] += weight
+
+    return sorted(labels, key=lambda label: (-weights[label], label))
+
+
+def _select_labels(pr, labels: set, area_counter: dict, area_files: dict) -> set:
+    """Return the labels to apply to *pr*, truncated to MAX_LABELS if needed.
+
+    Up to MAX_LABELS area labels everything is applied.  Beyond that the PR
+    touches so many areas that labelling it with all of them says nothing, so
+    only the MAX_LABELS highest-ranked ones are applied (see _rank_labels).
+
+    Only the area labels count towards the limit, and only they can be dropped.
+    Size labels are computed for this PR alone and update_size_labels has
+    already removed the stale ones, so dropping the new one would leave the PR
+    with no size label at all -- and counting it would make MAX_LABELS area
+    labels plus a size label look like an overflow.
+
+    This caps what the run *applies*; it never takes a label off the PR.  A
+    label already there stays, whether a human added it or an earlier run did
+    (--reset is the way to clear those).
+    """
+    area_labels = labels - _SIZE_LABELS
+    if len(area_labels) <= MAX_LABELS:
+        return labels
+
+    ranked = _rank_labels(area_labels, area_counter, area_files)
+    kept = set(ranked[:MAX_LABELS])
+
+    logger.warning(
+        "PR #%d matched %d area labels (limit %d); applying only the %d highest-weight: "
+        "%s (not applying: %s)",
+        pr.number,
+        len(area_labels),
+        MAX_LABELS,
+        len(kept),
+        sorted(kept),
+        sorted(area_labels - kept),
+    )
+    return kept | (labels & _SIZE_LABELS)
+
+
 def process_pr(gh, args, maintainer_file, number: int):
     gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
     pr = gh_repo.get_pull(number)
@@ -1261,21 +1334,15 @@ def process_pr(gh, args, maintainer_file, number: int):
     # Apply labels — skip any that are already present, then add the rest in
     # a single API call to avoid per-label timeline noise.
     if labels:
-        if len(labels) <= MAX_LABELS:
-            current_label_names = {lbl.name for lbl in pr.labels}
-            new_labels = sorted(labels - current_label_names)
-            if new_labels:
-                logger.info("Adding labels: %s", new_labels)
-                if not args.dry_run:
-                    pr.add_to_labels(*new_labels)
-            else:
-                logger.info("All labels already present on PR #%d; skipping", pr.number)
+        labels = _select_labels(pr, labels, area_counter, area_files)
+        current_label_names = {lbl.name for lbl in pr.labels}
+        new_labels = sorted(labels - current_label_names)
+        if new_labels:
+            logger.info("Adding labels: %s", new_labels)
+            if not args.dry_run:
+                pr.add_to_labels(*new_labels)
         else:
-            logger.warning(
-                "Too many labels (%d) for PR #%d; skipping label assignment",
-                len(labels),
-                pr.number,
-            )
+            logger.info("All labels already present on PR #%d; skipping", pr.number)
 
     # Request reviews.
     # additional_reviews is already folded into collab by

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -56,9 +56,10 @@ two exceptions that contribute 0:
 
   - CMakeLists.txt files: build-system boilerplate present in nearly every
     directory, not a reliable signal for area ownership.
-  - Meta-areas (Documentation, Samples, Tests, Release Notes, Release): used
-    only for assignee selection when they are the *sole* area touched (see
-    below); not weighted for mixed PRs.
+  - Meta-areas, i.e. areas carrying ``meta: true`` in MAINTAINERS.yml
+    (Documentation, Samples, Tests, ...): used only for assignee selection
+    when they are the *sole* area touched (see below); not weighted for
+    mixed PRs.
 
 Platform (driver/board) areas receive a weight of 1 for the first file that
 maps to them.  Subsequent files that also map to the *same* Platform area
@@ -163,8 +164,7 @@ weight) using the following priority rules:
      of the ranked list, and the search stops.
   4. Platform areas (drivers, boards) are appended as lower-priority
      fallbacks.
-  5. Meta-areas (Documentation, Samples, Tests, Release Notes, Release)
-     are skipped in mixed PRs.
+  5. Meta-areas (``meta: true`` in MAINTAINERS.yml) are skipped in mixed PRs.
 
 After iterating all areas, the first entry in the ranked list is chosen.
 If the ranking process yielded nothing (e.g. all areas had the author as sole
@@ -310,9 +310,6 @@ query($owner: String!, $name: String!, $number: Int!) {
 
 # Courtesy sleep between consecutive GitHub API calls to avoid secondary rate limits.
 API_SLEEP_SECONDS = 1
-
-# Areas where assignee selection only fires when they are the sole area affected.
-META_AREAS = frozenset(['Release Notes', 'Documentation', 'Samples', 'Tests', 'Release'])
 
 
 def parse_args():
@@ -577,7 +574,7 @@ def _pick_assignees(pr, area_counter: dict, all_maintainers: dict, num_files: in
                 assignees,
             )
             ranked_assignees.append(assignees)
-        elif area.name not in META_AREAS:
+        elif not area.meta:
             logger.debug(
                 "Non-platform area '%s' with maintainers %s takes priority for assignment",
                 area.name,
@@ -1128,7 +1125,7 @@ def process_pr(gh, args, maintainer_file, number: int):
         for area in sorted_areas:
             # CMakeLists.txt changes and meta-area files do not count toward
             # the area weight used for assignee selection.
-            if 'CMakeLists.txt' in filename or area.name in META_AREAS:
+            if 'CMakeLists.txt' in filename or area.meta:
                 count = 0
             else:
                 # Once an instance (Platform) area has been seen, subsequent

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -91,7 +91,9 @@ the maintainers of every other touched area:
 
        - files in an under-covered area, i.e. one that names no maintainers or
          at most THIN_AREA_COLLABORATORS (2) collaborators, and so cannot
-         supply enough reviewers on its own, and
+         supply enough reviewers on its own.  Meta-areas are excluded: they
+         cover large parts of the tree by design, and the people they name are
+         the right reviewers for them, and
        - orphaned files, which match no area at all.  A PR consisting only of
          these would otherwise get no reviewer whatsoever, since every tier
          above is derived from matched areas.
@@ -605,10 +607,18 @@ def _thin_areas(maintainer_file, area_counter: dict) -> set:
     or names at most THIN_AREA_COLLABORATORS collaborators.  These areas cannot
     supply enough reviewers on their own, so the caller supplements them with
     recent Git contributors (see _history_reviewers).
+
+    Meta-areas (``meta: true`` in MAINTAINERS.yml) are never reported as
+    under-covered.  Their file patterns span large parts of the tree, so the
+    small number of people they name is deliberate rather than a gap, and
+    walking the history of every documentation or sample file they match would
+    add reviewers on top of the maintainers who already own the area.
     """
     thin = set()
     for area in area_counter:
         entry = maintainer_file.areas[area.name]
+        if entry.meta:
+            continue
         if not entry.maintainers or len(entry.collaborators) <= THIN_AREA_COLLABORATORS:
             thin.add(area.name)
     return thin

--- a/scripts/ci/sync_maintainer_tests.py
+++ b/scripts/ci/sync_maintainer_tests.py
@@ -64,17 +64,6 @@ _DEEP_GROUP_PREFIXES: frozenset[str] = frozenset(
     }
 )
 
-# Meta-areas that intentionally cover large swaths of tests/ or samples/.
-# Adding auto-generated identifiers to these would be too broad and unhelpful.
-_META_AREAS: frozenset[str] = frozenset(
-    {
-        "Benchmarks",
-        "Boards",
-        "Samples",
-        "Tests",
-    }
-)
-
 
 def _is_plain_dir_path(path: str) -> bool:
     """Return True when *path* is a plain (non-glob) directory path."""
@@ -459,7 +448,12 @@ def main() -> int:
         total_areas += 1
         logging.info("Processing: %s", area_name)
 
-        if area_name in _META_AREAS:
+        # Meta-areas (meta: true in MAINTAINERS.yml) intentionally cover large
+        # swaths of tests/ or samples/; identifiers derived from their file
+        # patterns would be too broad to be useful.  This reads the raw YAML,
+        # which get_maintainer.py's boolean check has not vetted, so compare
+        # against True rather than trusting truthiness.
+        if area_dict.get("meta") is True:
             logging.debug("  [%s] skipping meta-area", area_name)
             continue
 

--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -217,6 +217,7 @@ class Maintainers:
             area.tests = area_dict.get("tests", [])
             area.tags = area_dict.get("tags", [])
             area.description = area_dict.get("description")
+            area.meta = bool(area_dict.get("meta", False))
 
             # Initialize file groups if present
             area.file_groups = []
@@ -545,6 +546,11 @@ class Area:
         Text from 'description' key, or None if the area has no 'description'
         key
 
+    meta:
+        True if the area is a meta-area, i.e. one that cuts across the tree
+        (documentation, samples, tests, ...) instead of owning a subsystem.
+        False if the area has no 'meta' key. See MAINTAINERS.yml.
+
     file_groups:
         List of FileGroup instances for any file-groups defined in the area.
         Empty if the area has no 'file-groups' key.
@@ -623,6 +629,7 @@ def _print_areas(areas):
 \tlabels: {}
 \ttests: {}
 \ttags: {}
+\tmeta: {}
 \tdescription: {}""".format(area.name,
                             area.status,
                             ", ".join(area.maintainers),
@@ -631,6 +638,7 @@ def _print_areas(areas):
                             ", ".join(area.labels),
                             ", ".join(area.tests),
                             ", ".join(area.tags),
+                            area.meta,
                             area.description or ""))
 
         # Print file groups if any exist
@@ -712,7 +720,8 @@ def _check_maintainers(maints_path, yaml):
 
     ok_keys = {"status", "maintainers", "collaborators", "inform", "files",
                "files-exclude", "files-regex", "files-regex-exclude",
-               "labels", "description", "tests", "tags", "file-groups"}
+               "labels", "description", "tests", "tags", "file-groups",
+               "meta"}
 
     ok_status = {"maintained", "odd fixes", "unmaintained", "obsolete"}
     ok_status_s = ", ".join('"' + s + '"' for s in ok_status)  # For messages
@@ -847,6 +856,10 @@ def _check_maintainers(maints_path, yaml):
            not isinstance(area_dict["description"], str):
             ferr("malformed 'description' value for area '{}' -- should be a "
                  "string".format(area_name))
+
+        if "meta" in area_dict and not isinstance(area_dict["meta"], bool):
+            ferr("malformed 'meta' value for area '{}' -- should be a "
+                 "boolean".format(area_name))
 
 
 def _git(*args):

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -9,6 +9,7 @@ out at module level so the test suite runs without a full Zephyr environment
 or a live GitHub token.
 """
 
+import datetime
 import logging
 import sys
 from types import SimpleNamespace
@@ -814,9 +815,9 @@ def _commit(login):
 
 
 def _repo_with_history(history):
-    """gh_repo stub whose get_commits(path=...) returns history[path] (or [])."""
+    """gh_repo stub whose get_commits(path=..., since=...) returns history[path] (or [])."""
     repo = MagicMock()
-    repo.get_commits.side_effect = lambda path: list(history.get(path, []))
+    repo.get_commits.side_effect = lambda path, since=None: list(history.get(path, []))
     return repo
 
 
@@ -858,7 +859,7 @@ class TestHistoryReviewers:
         assert result == ["early"]
 
     def test_github_exception_on_a_file_is_skipped(self):
-        def _raise_or_return(path):
+        def _raise_or_return(path, since=None):
             if path == "bad.c":
                 raise sut.GithubException("no history")
             return [_commit("alice")]
@@ -876,6 +877,18 @@ class TestHistoryReviewers:
         repo = _repo_with_history(history)
         result = sut._history_reviewers(repo, {"a.c", "b.c"}, exclude=set())
         assert result == ["alice", "bob"]
+
+    def test_history_is_limited_to_one_year(self):
+        repo = _repo_with_history({"f.c": [_commit("alice")]})
+        sut._history_reviewers(repo, {"f.c"}, exclude=set())
+
+        since = repo.get_commits.call_args.kwargs["since"]
+        age = datetime.datetime.now(datetime.UTC) - since
+        assert sut.HISTORY_MAX_AGE_DAYS == 365
+        # Allow a minute of slack for the time spent between the two calls.
+        assert abs(age - datetime.timedelta(days=sut.HISTORY_MAX_AGE_DAYS)) < datetime.timedelta(
+            minutes=1
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -955,7 +968,7 @@ class TestHistoryReviewersIntegration:
         areas = {"subsys/orphan/foo.c": [area]}
 
         gh, args, mf, pr = _make_process_pr_harness(areas)
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: [
             SimpleNamespace(author=SimpleNamespace(login="frequent_contributor"))
         ]
         sut.process_pr(gh, args, mf, 99)
@@ -967,7 +980,7 @@ class TestHistoryReviewersIntegration:
         areas = {"subsys/orphan/foo.c": [area]}
 
         gh, args, mf, pr = _make_process_pr_harness(areas, pr_user="self")
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: [
             SimpleNamespace(author=SimpleNamespace(login="self"))
         ]
         sut.process_pr(gh, args, mf, 99)
@@ -1004,7 +1017,7 @@ class TestHistoryReviewersIntegration:
             {},
             _suggested_payload([("suggested_by_github", True)]),
         )
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: [
             SimpleNamespace(author=SimpleNamespace(login="from_history"))
         ]
         sut.process_pr(gh, args, mf, 99)
@@ -1021,7 +1034,7 @@ class TestHistoryReviewersIntegration:
 
         gh, args, mf, pr = _make_process_pr_harness(areas)
         gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: [
             SimpleNamespace(author=SimpleNamespace(login="from_history"))
         ]
         sut.process_pr(gh, args, mf, 99)
@@ -1074,7 +1087,7 @@ class TestUnmatchedFiles:
     def test_pr_with_no_matching_area_falls_back_to_history(self):
         gh, args, mf, pr = _make_process_pr_harness({"doc/orphaned.rst": []})
         gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: [
             SimpleNamespace(author=SimpleNamespace(login="baruser"))
         ]
         sut.process_pr(gh, args, mf, 99)
@@ -1088,10 +1101,13 @@ class TestUnmatchedFiles:
 
         gh, args, mf, _ = _make_process_pr_harness(areas)
         gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: [
             SimpleNamespace(author=SimpleNamespace(login="doc_author"))
         ]
-        sut.process_pr(gh, args, mf, 99)
+        # The covered area alone would satisfy MIN_TOTAL_REVIEWERS; disable that
+        # gate so this test covers only which files get walked.
+        with patch.object(sut, "MIN_TOTAL_REVIEWERS", 99):
+            sut.process_pr(gh, args, mf, 99)
 
         walked = [
             call.kwargs.get("path") for call in gh.get_repo.return_value.get_commits.call_args_list
@@ -1108,7 +1124,8 @@ class TestUnmatchedFiles:
             {},
             _suggested_payload([("heuristic_r", True)]),
         )
-        sut.process_pr(gh, args, mf, 99)
+        with patch.object(sut, "MIN_TOTAL_REVIEWERS", 99):
+            sut.process_pr(gh, args, mf, 99)
 
         requested = _reviewers_requested(pr)
         assert requested.index("real_m") < requested.index("heuristic_r")
@@ -1125,10 +1142,66 @@ class TestUnmatchedFiles:
         """Orphaned file with no suggestions and no history: nothing requested."""
         gh, args, mf, pr = _make_process_pr_harness({"doc/orphaned.rst": []})
         gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: []
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: []
         sut.process_pr(gh, args, mf, 99)
 
         assert _reviewers_requested(pr) == []
+
+
+class TestHeuristicThreshold:
+    """The heuristics only top up PRs that the areas left short of reviewers."""
+
+    def test_enough_area_reviewers_skips_heuristics(self):
+        """An orphaned file does not trigger a walk when the areas staffed the PR."""
+        covered = _make_area("Full", maintainers=["m"], collaborators=["c1", "c2", "c3"])
+        areas = {"doc/orphaned.rst": [], "subsys/full/foo.c": [covered]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        gh.requester.graphql_query.assert_not_called()
+        gh.get_repo.return_value.get_commits.assert_not_called()
+        assert _reviewers_requested(pr) == ["m", "c1", "c2", "c3"]
+
+    def test_too_few_area_reviewers_runs_heuristics(self):
+        thin = _make_area("Thin", maintainers=["m"], collaborators=[])
+        areas = {"subsys/thin/foo.c": [thin]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        gh.requester.graphql_query.return_value = (
+            {},
+            _suggested_payload([("heuristic_r", True)]),
+        )
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "heuristic_r" in _reviewers_requested(pr)
+
+    def test_author_does_not_count_towards_the_threshold(self):
+        """The author cannot review their own PR, so they leave the PR short."""
+        thin = _make_area("Thin", maintainers=["self"], collaborators=["c1", "c2"])
+        areas = {"subsys/thin/foo.c": [thin]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas, pr_user="self")
+        gh.requester.graphql_query.return_value = (
+            {},
+            _suggested_payload([("heuristic_r", True)]),
+        )
+        sut.process_pr(gh, args, mf, 99)
+
+        # Only c1 and c2 can review: one short of MIN_TOTAL_REVIEWERS.
+        assert "heuristic_r" in _reviewers_requested(pr)
+
+    def test_threshold_counts_reviewers_across_areas(self):
+        """Two thin areas can jointly staff a PR that neither could alone."""
+        thin_a = _make_area("ThinA", maintainers=["ma"], collaborators=["ca"])
+        thin_b = _make_area("ThinB", maintainers=["mb"], collaborators=["cb"])
+        areas = {"subsys/a/foo.c": [thin_a], "subsys/b/bar.c": [thin_b]}
+
+        gh, args, mf, _ = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        gh.requester.graphql_query.assert_not_called()
+        gh.get_repo.return_value.get_commits.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1397,7 +1470,7 @@ class TestMentionCommentIsIdempotent:
         area = _make_area("Net", maintainers=["outside_m"], collaborators=["inside_c"])
         gh, args, mf, pr = _make_process_pr_harness({"subsys/net/foo.c": [area]})
         gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
-        gh.get_repo.return_value.get_commits.side_effect = lambda path: []
+        gh.get_repo.return_value.get_commits.side_effect = lambda path, since=None: []
         gh.get_repo.return_value.has_in_collaborators.side_effect = (
             lambda user: user.login != "outside_m"
         )

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -788,6 +788,19 @@ class TestThinAreas:
         mf = self._mf(thin, full)
         assert sut._thin_areas(mf, {thin: 2, full: 1}) == {"Thin"}
 
+    def test_meta_area_is_never_thin(self):
+        # Meta-areas name few people on purpose; they must not pull in
+        # heuristic reviewers on top of their own maintainers.
+        area = _make_area("Documentation", maintainers=["m"], collaborators=[], meta=True)
+        mf = self._mf(area)
+        assert sut._thin_areas(mf, {area: 1}) == set()
+
+    def test_meta_area_excluded_but_thin_area_still_reported(self):
+        meta = _make_area("Documentation", maintainers=[], collaborators=[], meta=True)
+        thin = _make_area("Thin", maintainers=[], collaborators=[])
+        mf = self._mf(meta, thin)
+        assert sut._thin_areas(mf, {meta: 2, thin: 1}) == {"Thin"}
+
 
 # ---------------------------------------------------------------------------
 # _history_reviewers

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -1318,6 +1318,132 @@ class TestReviewRequestRetry:
 
 
 # ---------------------------------------------------------------------------
+# Label selection  (_rank_labels / _select_labels)
+# ---------------------------------------------------------------------------
+
+
+def _labels_added(pr):
+    """Label names passed to add_to_labels() on *pr*."""
+    return [name for call in pr.add_to_labels.call_args_list for name in call.args]
+
+
+class TestRankLabels:
+    def test_orders_by_area_weight(self):
+        heavy = _make_area("Heavy", labels=["area: heavy"])
+        light = _make_area("Light", labels=["area: light"])
+        ranked = sut._rank_labels({"area: heavy", "area: light"}, {heavy: 9, light: 1}, {})
+        assert ranked == ["area: heavy", "area: light"]
+
+    def test_weights_of_areas_sharing_a_label_add_up(self):
+        a = _make_area("A", labels=["shared"])
+        b = _make_area("B", labels=["shared"])
+        solo = _make_area("Solo", labels=["solo"])
+        ranked = sut._rank_labels({"shared", "solo"}, {solo: 3, a: 2, b: 2}, {})
+        assert ranked == ["shared", "solo"]
+
+    def test_labels_from_no_contributing_area_sort_last(self):
+        area = _make_area("A", labels=["area: a"])
+        ranked = sut._rank_labels({"area: a", "deferred"}, {area: 1}, {})
+        assert ranked == ["area: a", "deferred"]
+
+    def test_ties_break_by_name(self):
+        a = _make_area("A", labels=["area: b"])
+        b = _make_area("B", labels=["area: a"])
+        assert sut._rank_labels({"area: a", "area: b"}, {a: 2, b: 2}, {}) == ["area: a", "area: b"]
+
+    def test_unweighted_area_falls_back_to_its_file_count(self):
+        """A meta-area weighs 0 for assignment but still describes the PR."""
+        meta = _make_area("Documentation", labels=["area: Documentation"], meta=True)
+        other = _make_area("Kernel", labels=["area: Kernel"])
+        area_files = {"Documentation": {f"doc/{i}.rst" for i in range(9)}, "Kernel": {"k.c"}}
+
+        ranked = sut._rank_labels(
+            {"area: Documentation", "area: Kernel"}, {meta: 0, other: 1}, area_files
+        )
+        assert ranked == ["area: Documentation", "area: Kernel"]
+
+
+class TestSelectLabels:
+    @staticmethod
+    def _areas(count, weight_of=lambda i: i):
+        """count areas, each with one label, area i weighing weight_of(i)."""
+        return {_make_area(f"A{i}", labels=[f"area: {i:02d}"]): weight_of(i) for i in range(count)}
+
+    def test_under_the_limit_keeps_everything(self):
+        area_counter = self._areas(sut.MAX_LABELS)
+        labels = {next(iter(a.labels)) for a in area_counter}
+        assert sut._select_labels(_make_pr(), labels, area_counter, {}) == labels
+
+    def test_over_the_limit_keeps_the_heaviest(self):
+        area_counter = self._areas(sut.MAX_LABELS + 1)
+        labels = {next(iter(a.labels)) for a in area_counter}
+        kept = sut._select_labels(_make_pr(), labels, area_counter, {})
+        # Weights are 0..MAX_LABELS, so the highest-numbered labels win.
+        assert kept == {f"area: {i:02d}" for i in range(1, sut.MAX_LABELS + 1)}
+
+    def test_size_label_survives_truncation(self):
+        area_counter = self._areas(sut.MAX_LABELS + 1)
+        labels = {next(iter(a.labels)) for a in area_counter} | {"size: L"}
+        kept = sut._select_labels(_make_pr(), labels, area_counter, {})
+        assert "size: L" in kept
+        # The size label is exempt rather than taking one of the MAX_LABELS slots.
+        assert len(kept) == sut.MAX_LABELS + 1
+
+    def test_size_label_does_not_count_towards_the_limit(self, caplog):
+        """MAX_LABELS area labels plus a size label is not an overflow."""
+        area_counter = self._areas(sut.MAX_LABELS)
+        labels = {next(iter(a.labels)) for a in area_counter} | {"size: L"}
+
+        with caplog.at_level(logging.WARNING, logger=sut.logger.name):
+            kept = sut._select_labels(_make_pr(), labels, area_counter, {})
+
+        assert kept == labels
+        assert caplog.records == []
+
+
+class TestLabelApplication:
+    def test_labels_are_applied(self):
+        area = _make_area("Kernel", maintainers=["m"], labels=["area: Kernel"])
+        gh, args, mf, pr = _make_process_pr_harness({"kernel/sched.c": [area]})
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "area: Kernel" in _labels_added(pr)
+
+    def test_broad_pr_keeps_top_labels_instead_of_none(self):
+        """Exceeding MAX_LABELS used to drop every label; now the heaviest stay."""
+        areas_per_file = {}
+        for i in range(sut.MAX_LABELS + 1):
+            area = _make_area(f"A{i}", maintainers=[f"m{i}"], labels=[f"area: {i:02d}"])
+            # Area i matches i + 1 files, so later areas weigh more.
+            for f in range(i + 1):
+                areas_per_file.setdefault(f"subsys/a{i}/f{f}.c", []).append(area)
+
+        gh, args, mf, pr = _make_process_pr_harness(areas_per_file)
+        sut.process_pr(gh, args, mf, 99)
+
+        added = [label for label in _labels_added(pr) if label.startswith("area: ")]
+        # The lightest area (a single file) is the one dropped.
+        assert added == [f"area: {i:02d}" for i in range(1, sut.MAX_LABELS + 1)]
+
+    def test_truncation_does_not_remove_labels_already_on_the_pr(self):
+        """The cap governs what a run applies, not what the PR already carries."""
+        areas_per_file = {}
+        for i in range(sut.MAX_LABELS + 1):
+            area = _make_area(f"A{i}", maintainers=[f"m{i}"], labels=[f"area: {i:02d}"])
+            for f in range(i + 1):
+                areas_per_file.setdefault(f"subsys/a{i}/f{f}.c", []).append(area)
+
+        gh, args, mf, pr = _make_process_pr_harness(areas_per_file)
+        # The label the truncation drops is already on the PR.
+        pr.labels = [SimpleNamespace(name="area: 00")]
+
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "area: 00" not in _labels_added(pr)
+        pr.remove_from_labels.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Mention fallback
 # ---------------------------------------------------------------------------
 

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -15,6 +15,8 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # Stub heavy third-party and project-local modules before the SUT is imported.
 # ---------------------------------------------------------------------------
@@ -541,11 +543,13 @@ def _make_process_pr_harness(areas_per_file, pr_user="someone"):
     pr.labels = []
     pr.user = SimpleNamespace(login=pr_user)
     pr.assignee = None
+    pr.assignees = []
     pr.get_files.return_value = [SimpleNamespace(filename=fn) for fn in areas_per_file]
     pr.get_reviews.return_value = []
     pr.get_review_requests.return_value = ([], [])
     pr.get_issue_events.return_value = []
     pr.get_issue_comments.return_value = []
+    pr.get_review_comments.return_value = []
 
     mf = MagicMock()
     mf.path2areas.side_effect = lambda p: areas_per_file.get(p, [])
@@ -584,6 +588,7 @@ def _make_process_pr_harness(areas_per_file, pr_user="someone"):
         updated_manifest=None,
         updated_maintainer_file=None,
         size_labels=False,
+        reset=False,
     )
     return gh, args, mf, pr
 
@@ -1315,6 +1320,224 @@ class TestReviewRequestRetry:
         sut._add_reviewers(gh, gh_repo, pr, args, [f"u{i}" for i in range(25)])
 
         assert pr.create_review_request.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Reset mode  (--reset / _reset_pr)
+# ---------------------------------------------------------------------------
+
+
+def _user(login):
+    return SimpleNamespace(login=login)
+
+
+def _label(name):
+    return SimpleNamespace(name=name)
+
+
+def _requests_deleted(pr):
+    """Logins passed to delete_review_request() across all calls."""
+    return [
+        login
+        for call in pr.delete_review_request.call_args_list
+        for login in call.kwargs.get("reviewers", call.args[0] if call.args else [])
+    ]
+
+
+def _labels_removed(pr):
+    """Label names passed to remove_from_labels() across all calls."""
+    return [name for call in pr.remove_from_labels.call_args_list for name in call.args]
+
+
+class TestResetPr:
+    @staticmethod
+    def _mf(*areas):
+        mf = MagicMock()
+        mf.areas = {area.name: area for area in areas}
+        return mf
+
+    def _pr(self, requested=(), reviewed=(), commented=(), assignees=(), labels=()):
+        pr = MagicMock()
+        pr.number = 99
+        pr.labels = [_label(name) for name in labels]
+        pr.assignees = [_user(login) for login in assignees]
+        pr.get_review_requests.return_value = ([_user(u) for u in requested], [])
+        pr.get_reviews.return_value = [SimpleNamespace(user=_user(u)) for u in reviewed]
+        pr.get_issue_comments.return_value = [SimpleNamespace(user=_user(u)) for u in commented]
+        pr.get_review_comments.return_value = []
+        return pr
+
+    def test_uninvolved_reviewers_are_removed(self):
+        pr = self._pr(requested=["idle_a", "idle_b"])
+        sut._reset_pr(pr, _make_args(), self._mf())
+        assert sorted(_requests_deleted(pr)) == ["idle_a", "idle_b"]
+
+    def test_reviewer_who_reviewed_is_kept(self):
+        pr = self._pr(requested=["reviewer", "idle"], reviewed=["reviewer"])
+        sut._reset_pr(pr, _make_args(), self._mf())
+        assert _requests_deleted(pr) == ["idle"]
+
+    @pytest.mark.parametrize("state", ["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"])
+    def test_submitted_review_is_never_removed(self, state):
+        """Whatever the verdict, having reviewed protects the review request.
+
+        GitHub normally clears the pending request when a review is submitted,
+        so such a reviewer is not in get_review_requests() at all; this covers
+        the case where someone re-requested a review afterwards.
+        """
+        pr = self._pr(requested=["reviewer", "idle"])
+        pr.get_reviews.return_value = [SimpleNamespace(user=_user("reviewer"), state=state)]
+
+        sut._reset_pr(pr, _make_args(), self._mf())
+
+        assert "reviewer" not in _requests_deleted(pr)
+        assert _requests_deleted(pr) == ["idle"]
+
+    def test_reviewer_who_commented_is_kept(self):
+        pr = self._pr(requested=["talker", "idle"], commented=["talker"])
+        sut._reset_pr(pr, _make_args(), self._mf())
+        assert _requests_deleted(pr) == ["idle"]
+
+    def test_review_thread_comment_counts_as_interaction(self):
+        pr = self._pr(requested=["nitpicker", "idle"])
+        pr.get_review_comments.return_value = [SimpleNamespace(user=_user("nitpicker"))]
+        sut._reset_pr(pr, _make_args(), self._mf())
+        assert _requests_deleted(pr) == ["idle"]
+
+    def test_reviewer_about_to_be_requested_again_is_kept(self):
+        """Withdrawing a request the run is about to re-send would notify twice."""
+        pr = self._pr(requested=["still_owns_it", "idle"])
+        sut._reset_pr(pr, _make_args(), self._mf(), keep=["still_owns_it"])
+        assert _requests_deleted(pr) == ["idle"]
+
+    def test_team_review_requests_are_left_alone(self):
+        pr = self._pr(requested=["idle"])
+        pr.get_review_requests.return_value = ([_user("idle")], [SimpleNamespace(slug="a-team")])
+
+        sut._reset_pr(pr, _make_args(), self._mf())
+
+        assert _requests_deleted(pr) == ["idle"]
+        assert pr.delete_review_request.call_args.kwargs.get("team_reviewers") is None
+
+    def test_assignees_are_removed(self):
+        pr = self._pr(assignees=["assignee_a", "assignee_b"])
+        sut._reset_pr(pr, _make_args(), self._mf())
+        pr.remove_from_assignees.assert_called_once_with("assignee_a", "assignee_b")
+
+    def test_only_maintainer_file_labels_are_removed(self):
+        area = _make_area("Kernel", labels=["area: Kernel"])
+        pr = self._pr(labels=["area: Kernel", "bug", "size: M"])
+        removed = sut._reset_pr(pr, _make_args(), self._mf(area))
+        assert _labels_removed(pr) == ["area: Kernel"]
+        assert removed == {"area: Kernel"}
+
+    def test_dry_run_changes_nothing(self):
+        area = _make_area("Kernel", labels=["area: Kernel"])
+        pr = self._pr(requested=["idle"], assignees=["a"], labels=["area: Kernel"])
+        removed = sut._reset_pr(pr, _make_args(dry_run=True), self._mf(area))
+
+        pr.delete_review_request.assert_not_called()
+        pr.remove_from_assignees.assert_not_called()
+        pr.remove_from_labels.assert_not_called()
+        # Still reported, so the caller can log what a real run would do.
+        assert removed == {"area: Kernel"}
+
+
+class TestProcessPrReset:
+    @staticmethod
+    def _harness(areas_per_file, **kwargs):
+        gh, args, mf, pr = _make_process_pr_harness(areas_per_file, **kwargs)
+        args.reset = True
+        return gh, args, mf, pr
+
+    def test_labels_are_reapplied_after_removal(self):
+        area = _make_area("Kernel", maintainers=["m"], labels=["area: Kernel"])
+        gh, args, mf, pr = self._harness({"kernel/sched.c": [area]})
+        pr.labels = [_label("area: Kernel")]
+
+        sut.process_pr(gh, args, mf, 99)
+
+        # Removed by the reset, then re-added by the normal flow rather than
+        # being considered already present.
+        assert _labels_removed(pr) == ["area: Kernel"]
+        assert "area: Kernel" in _labels_added(pr)
+
+    def test_assignee_is_set_again_after_removal(self):
+        area = _make_area("Kernel", maintainers=["m"], labels=["area: Kernel"])
+        gh, args, mf, pr = self._harness({"kernel/sched.c": [area]})
+        pr.assignee = _user("old_assignee")
+        pr.assignees = [_user("old_assignee")]
+
+        sut.process_pr(gh, args, mf, 99)
+
+        pr.remove_from_assignees.assert_called_once_with("old_assignee")
+        assert [call.args[0].login for call in pr.add_to_assignees.call_args_list] == ["m"]
+
+    def test_self_removed_reviewer_is_not_re_added(self):
+        area = _make_area("Kernel", maintainers=["m"], collaborators=["quitter"])
+        gh, args, mf, pr = self._harness({"kernel/sched.c": [area]})
+        quitter = gh.get_user("quitter")
+        pr.get_issue_events.return_value = [
+            SimpleNamespace(
+                event="review_request_removed", actor=quitter, requested_reviewer=quitter
+            )
+        ]
+
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "quitter" not in _reviewers_requested(pr)
+        assert "m" in _reviewers_requested(pr)
+
+    def test_reviewers_are_requested_as_for_a_new_pr(self):
+        area = _make_area("Kernel", maintainers=["m"], collaborators=["c1"])
+        gh, args, mf, pr = self._harness({"kernel/sched.c": [area]})
+        # An earlier run left a request for someone the areas no longer name.
+        pr.get_review_requests.return_value = ([gh.get_user("stale_reviewer")], [])
+
+        sut.process_pr(gh, args, mf, 99)
+
+        assert _requests_deleted(pr) == ["stale_reviewer"]
+        assert sorted(_reviewers_requested(pr)) == ["c1", "m"]
+
+    def test_still_valid_reviewer_is_not_withdrawn_and_re_requested(self):
+        """Churning the request would notify a maintainer who never left."""
+        area = _make_area("Kernel", maintainers=["m"], collaborators=["c1"])
+        gh, args, mf, pr = self._harness({"kernel/sched.c": [area]})
+        pr.get_review_requests.return_value = ([gh.get_user("m")], [])
+
+        sut.process_pr(gh, args, mf, 99)
+
+        assert _requests_deleted(pr) == []
+        # Already requested, so _add_reviewers leaves them be and asks the rest.
+        assert _reviewers_requested(pr) == ["c1"]
+
+    def test_skipped_pr_is_not_stripped(self):
+        """A PR the run declines to staff must not be left bare (MAX_FILES)."""
+        area = _make_area("Kernel", maintainers=["m"], labels=["area: Kernel"])
+        areas_per_file = {f"kernel/f{i}.c": [area] for i in range(sut.MAX_FILES + 1)}
+        gh, args, mf, pr = self._harness(areas_per_file)
+        pr.labels = [_label("area: Kernel")]
+        pr.assignees = [_user("old_assignee")]
+        pr.get_review_requests.return_value = ([gh.get_user("stale_reviewer")], [])
+
+        sut.process_pr(gh, args, mf, 99)
+
+        pr.delete_review_request.assert_not_called()
+        pr.remove_from_assignees.assert_not_called()
+        pr.remove_from_labels.assert_not_called()
+
+    def test_without_reset_nothing_is_removed(self):
+        area = _make_area("Kernel", maintainers=["m"], labels=["area: Kernel"])
+        gh, args, mf, pr = _make_process_pr_harness({"kernel/sched.c": [area]})
+        pr.labels = [_label("area: Kernel")]
+        pr.assignees = [_user("old_assignee")]
+        pr.get_review_requests.return_value = ([gh.get_user("stale_reviewer")], [])
+
+        sut.process_pr(gh, args, mf, 99)
+
+        pr.delete_review_request.assert_not_called()
+        pr.remove_from_assignees.assert_not_called()
+        assert _labels_removed(pr) == []
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -56,11 +56,12 @@ import set_assignees as sut  # noqa: E402, I001  (import after sys.modules manip
 class _Area:
     """Lightweight hashable area stub accepted by _pick_assignees and process_pr."""
 
-    def __init__(self, name, maintainers=None, labels=None, collaborators=None):
+    def __init__(self, name, maintainers=None, labels=None, collaborators=None, meta=False):
         self.name = name
         self.maintainers = list(maintainers or [])
         self.labels = list(labels or [])
         self.collaborators = list(collaborators or [])
+        self.meta = meta
 
     def is_deferred_for_path(self, path):
         return False
@@ -76,8 +77,10 @@ class _DeferredArea(_Area):
         return True
 
 
-def _make_area(name, maintainers=None, labels=None, collaborators=None):
-    return _Area(name, maintainers=maintainers, labels=labels, collaborators=collaborators)
+def _make_area(name, maintainers=None, labels=None, collaborators=None, meta=False):
+    return _Area(
+        name, maintainers=maintainers, labels=labels, collaborators=collaborators, meta=meta
+    )
 
 
 def _make_pr(commits=1, additions=0, deletions=0, labels=None, user_login="contributor"):
@@ -426,12 +429,12 @@ class TestPickAssignees:
         assert result == ["dave"]
 
     def test_meta_area_only_assigns_meta_maintainer(self):
-        area = _make_area("Documentation", maintainers=["eve"])
+        area = _make_area("Documentation", maintainers=["eve"], meta=True)
         result = sut._pick_assignees(self._pr(), {area: 2}, {"eve": 2}, num_files=2)
         assert result == ["eve"]
 
     def test_meta_area_not_sole_area_skips_meta_logic(self):
-        meta = _make_area("Documentation", maintainers=["eve"])
+        meta = _make_area("Documentation", maintainers=["eve"], meta=True)
         other = _make_area("Kernel", maintainers=["frank"])
         # area_counter is always sorted descending by count before _pick_assignees
         # is called; put the higher-count non-meta area first so it is visited first.


### PR DESCRIPTION
- **maintainers: declare meta-areas in MAINTAINERS.yml**
- **ci: set_assignees: never treat meta-areas as under-covered**
- **ci: set_assignees: narrow the heuristic reviewer tiers**
- **ci: set_assignees: keep the top labels instead of dropping them all**
- **ci: set_assignees: add --reset to re-staff a pull request**
