### PR TITLE
boards: mediatek: doc: Fix legacy board name in xcc/xt-clang example

### DIFF
--- a/boards/mediatek/index.rst
+++ b/boards/mediatek/index.rst
@@ -116,4 +116,4 @@ core identities and paths via the environment, for example:
    export TOOLCHAIN_VER=RI-2021.6-linux
    export ZEPHYR_TOOLCHAIN_VARIANT=xt-clang
    export XTENSA_TOOLCHAIN_PATH=$XTENSA_TOOLS_ROOT/install/tools
-   west build -b mt8186_adsp samples/hello_world
+   west build -b mt8186/mt8186/adsp samples/hello_world


### PR DESCRIPTION
mt8186_adsp no longer exists, therefore use mt8186/mt8186/adsp instead, matching mt8186_mt8186_adsp.yaml and the other build commands on this page.

**Build Log**
Log: https://gist.github.com/SenWang125/2ac4e2bca9b55a514901ac45acf30ed6

Please see the gist build log on the latest zephyr showing mt8186_adsp failing to build whereas mt8186/mt8186/adsp builds.