### PR TITLE
bluetooth: classic: avdtp: fix typo in `UNSUPPORTED_CONFIGURATION`

### DIFF
--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -60,7 +60,7 @@ enum bt_avdtp_err_code {
 	/** The format of Multiplexing Service Capability is not correct */
 	BT_AVDTP_BAD_MULTIPLEXING_FORMAT = 0x28,
 	/** Configuration not supported */
-	BT_AVDTP_UNSUPPORTED_CONFIGURAION = 0x29,
+	BT_AVDTP_UNSUPPORTED_CONFIGURATION = 0x29,
 	/** Indicates that the ACP state machine is in an invalid state in order to process the
 	 * signal. This also includes the situation when an INT receives a request for the
 	 * same command that it is currently expecting a response

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -331,7 +331,7 @@ static int a2dp_process_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep
 	if (codec_info_element_len > CONFIG_BT_A2DP_CODEC_MAX_IE_LEN) {
 		LOG_WRN("Received IE exceeds the max supported length (%u > %u)",
 			codec_info_element_len, CONFIG_BT_A2DP_CODEC_MAX_IE_LEN);
-		*errcode = BT_AVDTP_UNSUPPORTED_CONFIGURAION;
+		*errcode = BT_AVDTP_UNSUPPORTED_CONFIGURATION;
 		return -EINVAL;
 	}
 
@@ -1112,7 +1112,7 @@ static int bt_a2dp_get_config_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 	if (err == 0 && codec_info_element_len > CONFIG_BT_A2DP_CODEC_MAX_IE_LEN) {
 		LOG_WRN("Received IE exceeds the max supported length (%u > %u)",
 			codec_info_element_len, CONFIG_BT_A2DP_CODEC_MAX_IE_LEN);
-		status = BT_AVDTP_UNSUPPORTED_CONFIGURAION;
+		status = BT_AVDTP_UNSUPPORTED_CONFIGURATION;
 	}
 
 	if (status != BT_AVDTP_SUCCESS) {


### PR DESCRIPTION
Fix typo in `BT_AVDTP_UNSUPPORTED_CONFIGURATION` constant name. The constant was misspelled as `BT_AVDTP_UNSUPPORTED_CONFIGURAION`.

Update the enum definition in `avdtp.h` and all references in `a2dp.c` to use the correct spelling.