### PR TITLE
cmake: ccache: fetch USE_CCACHE via zephyr_get for sysbuild

### DIFF
--- a/cmake/modules/FindCcache.cmake
+++ b/cmake/modules/FindCcache.cmake
@@ -16,6 +16,7 @@
 # 'CCACHE_VERSION_STRING'
 # The version of ccache.
 
+zephyr_get(USE_CCACHE)
 if(USE_CCACHE STREQUAL "0")
   # ccache explicitly disabled by the user.
   set(CCACHE CCACHE-NOTFOUND CACHE FILEPATH "Path to a program" FORCE)


### PR DESCRIPTION
Add a `zephyr_get(USE_CCACHE)` call before the `USE_CCACHE` check so that the variable is properly propagated from the sysbuild context, allowing ccache to be enabled or disabled consistently across all images in a sysbuild configuration.