### PR TITLE
logging: fix -Wpointer-sign warnings

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -229,7 +229,7 @@ static const char *link_source_name_get(uint8_t domain_id, uint32_t source_id)
 		__ASSERT_NO_MSG(link != NULL);
 
 		err = log_link_get_source_name(link, rel_domain_id, source_id,
-					       cached, &cache_size);
+					       (char *)cached, &cache_size);
 		if (err < 0) {
 			return NULL;
 		}
@@ -276,7 +276,7 @@ static const char *link_domain_name_get(uint8_t domain_id)
 
 		__ASSERT_NO_MSG(link != NULL);
 
-		err = log_link_get_domain_name(link, rel_domain_id, cached, &cache_size);
+		err = log_link_get_domain_name(link, rel_domain_id, (char *)cached, &cache_size);
 		if (err < 0) {
 			log_cache_release(&dname_cache, cached);
 			return invalid_domain;

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -745,7 +745,7 @@ void log_output_dropped_process(const struct log_output *output, uint32_t cnt)
 	len = snprintk(buf, sizeof(buf), "%d", cnt);
 
 	log_output_write(outf, (uint8_t *)prefix, sizeof(prefix) - 1, output->control_block->ctx);
-	log_output_write(outf, buf, len, output->control_block->ctx);
+	log_output_write(outf, (uint8_t *)buf, len, output->control_block->ctx);
 	log_output_write(outf, (uint8_t *)postfix, sizeof(postfix) - 1, output->control_block->ctx);
 }
 


### PR DESCRIPTION
This commit resolves -Wpointer-sign warnings in the logging subsystem by adding explicit (char *) and (uint8_t *) casts at the text API boundaries.

This aligns with @loulanyue and @marc-hb 's feedback for the logging API where text strings should remain char * but binary buffers remain uint8_t *.

This is part of a larger effort to fix pointer-sign warnings across the codebase in preparation for dropping -Wno-pointer-sign globally.

Related to #8921