### PR TITLE
tests: usb: exclude stm32h7s78_dk from legacy USB test coverage

### DIFF
--- a/boards/st/stm32h7s78_dk/twister.yaml
+++ b/boards/st/stm32h7s78_dk/twister.yaml
@@ -14,7 +14,6 @@ supported:
   - octospi
   - rtc
   - uart
-  - usb_device
   - usbd
   - watchdog
 vendor: st


### PR DESCRIPTION
This PR fixes build failure encountered in the `legacy USB` tests and samples  after commit https://github.com/zephyrproject-rtos/zephyr/commit/0c9ff4c1c663e996d8d58bd9a4e06b686b4641e3  where USB_OTG_HS and USB_OTG_FS are now enabled at the same time on STM32H7RS DK  


To reproduce :   

`west build -p -b stm32h7s78_dk/stm32h7s7xx tests/subsys/usb/device -T usb.device` 

  

``` 

zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:36:2: error: #error "Only one interface should be enabled at a time, OTG FS or OTG HS" 

   36 | #error "Only one interface should be enabled at a time, OTG FS or OTG HS" 

      |  ^~~~~ 

zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'usb_dc_stm32_clock_enable': 

zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:561:9: error: implicit declaration of function 'LL_AHB1_GRP1_DisableClockLowPower'; did you mean 'LL_AHB1_GRP1_DisableClockSleep'? [-Wimplicit-function-declaration] 

  561 |         LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI); 

      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

      |         LL_AHB1_GRP1_DisableClockSleep 

zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:561:43: error: 'LL_AHB1_GRP1_PERIPH_OTGHSULPI' undeclared (first use in this function); did you mean 'LL_AHB1_GRP1_PERIPH_USBOTGHS'? 

  561 |         LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI); 

      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

      |                                           LL_AHB1_GRP1_PERIPH_USBOTGHS 

zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:561:43: note: each undeclared identifier is reported only once for each function it appears in 

zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:566:34: error: 'LL_APB2_GRP1_PERIPH_OTGPHYC' undeclared (first use in this function); did you mean 'LL_AHB1_GRP1_PERIPH_USBPHYC'? 

  566 |         LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC); 

      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~ 

      |                                  LL_AHB1_GRP1_PERIPH_USBPHYC 

``` 