### PR TITLE
soc: xlnx: versal: Add SC-OBC Module V1 RPU OpenAMP support

### DIFF
--- a/dts/vendor/amd/versal.dtsi
+++ b/dts/vendor/amd/versal.dtsi
@@ -13,6 +13,116 @@
 			status = "disabled";
 		};
 
+		ipi_psm: mailbox@ff310000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff310000 0x10000>, <0xff3f0000 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <0>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi_pmc: mailbox@ff320000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 27 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff320000 0x10000>, <0xff3f0200 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi0: mailbox@ff330000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff330000 0x10000>, <0xff3f0400 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <2>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi1: mailbox@ff340000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 31 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff340000 0x10000>, <0xff3f0600 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <3>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi2: mailbox@ff350000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 32 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff350000 0x10000>, <0xff3f0800 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <4>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi3: mailbox@ff360000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 33 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff360000 0x10000>, <0xff3f0a00 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <5>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi4: mailbox@ff370000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff370000 0x10000>, <0xff3f0c00 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <6>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi5: mailbox@ff380000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff380000 0x10000>, <0xff3f0e00 0x200>;
+			reg-names = "ctrl", "msg";
+			xlnx,ipi-id = <7>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi_pmc_nobuf: mailbox@ff390000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 28 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff390000 0x1000>;
+			reg-names = "ctrl";
+			xlnx,ipi-id = <8>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		ipi6: mailbox@ff3a0000 {
+			compatible = "xlnx,mbox-versal-ipi-mailbox";
+			status = "disabled";
+			interrupts = <GIC_SPI 36 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			reg = <0xff3a0000 0x1000>;
+			reg-names = "ctrl";
+			xlnx,ipi-id = <9>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
 		uart0: uart@ff000000 {
 			compatible = "arm,sbsa-uart";
 			reg = <0xff000000 DT_SIZE_K(64)>;

--- a/samples/subsys/ipc/openamp_rsc_table/boards/scobc_v1_versal_rpu.conf
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/scobc_v1_versal_rpu.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Space Cubics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_VERSAL_RPU_REMOTEPROC=y
+CONFIG_SOC_VERSAL_RPU_REMOTEPROC_DATA_LMA=y

--- a/samples/subsys/ipc/openamp_rsc_table/boards/scobc_v1_versal_rpu.overlay
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/scobc_v1_versal_rpu.overlay
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
+/ {
+	chosen {
+		zephyr,ipc = &mbox_consumer;
+		zephyr,ipc_shm = &rpu0vdev0buffer;
+	};
+
+	/*
+	 * One naturally aligned MPU region covers the firmware carveout, both
+	 * vrings, and the shared buffer. APU and the RPU access this memory
+	 * concurrently, so keep it non-cacheable.
+	 */
+	rproc0_shm: shared-memory@9800000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x09800000 0x200000>;
+		zephyr,memory-region = "RPROC_SHM";
+		zephyr,memory-attr = <DT_MEM_ARM_MPU_RAM_NOCACHE>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x09800000 0x200000>;
+
+		/*
+		 * RPROC stores the load image for OCM data and the ELF resource
+		 * table; it is deliberately separate from zephyr,sram, which
+		 * remains in OCM. Limit the linker region to the firmware
+		 * carveout so that an oversized image fails to link instead of
+		 * overwriting vring0 at 0x09860000.
+		 */
+		rproc0_reserved: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 0x60000>;
+			zephyr,memory-region = "RPROC";
+			zephyr,memory-region-flags = "rwx";
+		};
+	};
+
+	rpu0vdev0vring0: memory@9860000 {
+		compatible = "mmio-sram";
+		reg = <0x09860000 0x4000>;
+	};
+
+	rpu0vdev0vring1: memory@9864000 {
+		compatible = "mmio-sram";
+		reg = <0x09864000 0x4000>;
+	};
+
+	rpu0vdev0buffer: memory@9868000 {
+		compatible = "mmio-sram";
+		reg = <0x09868000 0x100000>;
+	};
+
+	mbox_consumer: mbox-consumer {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&rpu0_apu_mailbox 0>, <&rpu0_apu_mailbox 1>;
+		mbox-names = "tx", "rx";
+	};
+};
+
+&ipi1 {
+	status = "okay";
+
+	rpu0_apu_mailbox: mailbox@ff360000 {
+		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
+		reg = <0xff360000 0x10000>, <0xff3f0a00 0x200>;
+		reg-names = "ctrl", "msg";
+		xlnx,ipi-id = <5>;
+		#mbox-cells = <1>;
+		status = "okay";
+	};
+};

--- a/samples/subsys/ipc/openamp_rsc_table/tests.yaml
+++ b/samples/subsys/ipc/openamp_rsc_table/tests.yaml
@@ -8,9 +8,11 @@ tests:
     platform_allow:
       - stm32mp157c_dk2
       - imx8mp_evk/mimx8ml8/adsp
+      - scobc_v1/versal_rpu
     integration_platforms:
       - stm32mp157c_dk2
       - imx8mp_evk/mimx8ml8/adsp
+      - scobc_v1/versal_rpu
     tags:
       - ipm
       - openamp

--- a/soc/xlnx/versal/CMakeLists.txt
+++ b/soc/xlnx/versal/CMakeLists.txt
@@ -30,6 +30,15 @@ if(CONFIG_SOC_VERSAL_RPU_OCM_BOOT)
   )
 endif()
 
+if(CONFIG_SOC_VERSAL_RPU_REMOTEPROC)
+  zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0metadata rpu_remoteproc_metadata.ld)
+  zephyr_linker_sources(SECTIONS rpu_remoteproc_resource_table.ld)
+endif()
+
+if(CONFIG_SOC_VERSAL_RPU_REMOTEPROC_DATA_LMA)
+  zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x1data_lma rpu_remoteproc_data_lma.ld)
+endif()
+
 if(CONFIG_SOC_VERSAL_APU)
   # Use generic ARM64 linker script
   set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/xlnx/versal/Kconfig
+++ b/soc/xlnx/versal/Kconfig
@@ -23,6 +23,24 @@ config SOC_VERSAL_RPU_OCM_BOOT
 		($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM)) >= 0xFF000000)
 	select ARM_MPU_SKIP_ARCH_INIT
 
+config SOC_VERSAL_RPU_REMOTEPROC
+	bool "Support host-side remoteproc loading and attachment"
+	depends on SOC_VERSAL_RPU
+	depends on OPENAMP_RSC_TABLE
+	help
+	  Place the resource table in a linker memory region named RPROC. Also
+	  place the metadata used by the AMD-Xilinx R5 remoteproc driver to
+	  attach to an already running RPU at the beginning of that region.
+
+config SOC_VERSAL_RPU_REMOTEPROC_DATA_LMA
+	bool "Store initialized data load image in the RPROC region"
+	depends on SOC_VERSAL_RPU_REMOTEPROC
+	depends on XIP
+	help
+	  Use RPROC as the load region for initialized runtime data. Enable
+	  this when the ROM region containing the RPU code cannot also hold
+	  the data load image, such as a split TCM-code and OCM-data layout.
+
 if SOC_VERSAL_RPU_OCM_BOOT
 
 config KERNEL_ENTRY

--- a/soc/xlnx/versal/rpu_remoteproc_data_lma.ld
+++ b/soc/xlnx/versal/rpu_remoteproc_data_lma.ld
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The Cortex-R XIP linker script uses ROMABLE_REGION as the load region for
+ * initialized RAM sections. Keep runtime data in the board-selected RAM region
+ * while making its load image visible to remoteproc in RPROC.
+ */
+#undef ROMABLE_REGION
+#define ROMABLE_REGION RPROC

--- a/soc/xlnx/versal/rpu_remoteproc_metadata.ld
+++ b/soc/xlnx/versal/rpu_remoteproc_metadata.ld
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The AMD-Xilinx R5 remoteproc driver checks the first memory-region for
+ * this packed metadata before attaching to an already running RPU.
+ * uintptr_t is 64 bits in the APU's arm64 kernel, so use QUAD for the
+ * resource table address even though the RPU firmware is 32-bit.
+ */
+SECTION_PROLOGUE(.rproc_metadata ORIGIN(RPROC),,)
+{
+	__rproc_metadata_start = .;
+	LONG(1); /* metadata version */
+	LONG(0x78616d70); /* "xamp" magic */
+	LONG(0x879e928f); /* complement of the magic */
+	LONG(__resource_table_end - __resource_table_start);
+	QUAD(__resource_table_start);
+	__rproc_metadata_end = .;
+} GROUP_LINK_IN(RPROC)
+
+ASSERT(__rproc_metadata_start == ORIGIN(RPROC),
+       "remoteproc metadata must start at the RPROC origin")
+ASSERT((__rproc_metadata_end - __rproc_metadata_start) == 24,
+       "unexpected remoteproc metadata size")

--- a/soc/xlnx/versal/rpu_remoteproc_resource_table.ld
+++ b/soc/xlnx/versal/rpu_remoteproc_resource_table.ld
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Keep the resource table in memory visible to host-side remoteproc. Its address
+ * and size are also published in the metadata at the beginning of RPROC.
+ */
+SECTION_PROLOGUE(.resource_table,,)
+{
+	__resource_table_start = .;
+	KEEP(*(.resource_table*))
+	__resource_table_end = .;
+} GROUP_LINK_IN(RPROC)


### PR DESCRIPTION
## Summary

  Add OpenAMP resource table support for the Space Cubics SC-OBC Module V1
  Versal RPU target.

  This PR consists of two commits:

  1. Add optional Versal RPU remoteproc linker support.
  2. Add the SC-OBC V1 board configuration and devicetree overlay for the
     `openamp_rsc_table` sample.

  ## Motivation

  The SC-OBC Module V1 boots Zephyr on the Versal RPU in lockstep mode. Linux running
  on the APU then attaches to the already-running RPU through the remoteproc
  framework and communicates with Zephyr over RPMsg.

  The existing Versal RPU linker configuration did not provide a way to place
  the remoteproc resource table and its loadable data in the memory regions
  described by the board's devicetree.

  ## Implementation

  The first commit adds opt-in Versal RPU linker support for:

  - placing the remoteproc resource table in a dedicated devicetree memory region;
  - giving remoteproc-managed data a suitable load address when required by the
    target memory layout.

  The second commit adds the SC-OBC V1-specific OpenAMP configuration:

  - resource table and shared-memory regions;
  - two vrings and the RPMsg buffer pool;
  - Versal IPI mailbox channels used for notifications;
  - the board configuration required by the `openamp_rsc_table` sample.