### PR TITLE
shell: rpmsg: Prevent output loss when TX buffers are full

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -430,6 +430,11 @@ config SHELL_BACKEND_RPMSG
 
 if SHELL_BACKEND_RPMSG
 
+config SHELL_BACKEND_RPMSG_FORCE_TX_BLOCKING_MODE
+	bool "Force blocking mode for TX"
+	help
+	  Force the RPMsg shell backend to wait for an available TX buffer.
+
 config SHELL_PROMPT_RPMSG
 	string "Displayed prompt name"
 	default "ipc:~$ "

--- a/subsys/shell/backends/shell_rpmsg.c
+++ b/subsys/shell/backends/shell_rpmsg.c
@@ -93,7 +93,8 @@ static int enable(const struct shell_transport *transport, bool blocking)
 		return -ENODEV;
 	}
 
-	sh_rpmsg->blocking = blocking;
+	sh_rpmsg->blocking =
+		blocking || IS_ENABLED(CONFIG_SHELL_BACKEND_RPMSG_FORCE_TX_BLOCKING_MODE);
 
 	return 0;
 }


### PR DESCRIPTION
## Description

  Prevent the RPMsg shell backend from silently losing output when no TX buffer is immediately available.

  During normal non-blocking shell operation, the backend uses `rpmsg_trysend()`. If all RPMsg TX buffers are in use, it returns  `RPMSG_ERR_NO_BUFF`.

  The shell core does not retry the failed transport write, and the RPMsg backend has no TX completion callback that could reliably notify the shell when a buffer becomes available. 
As a result, parts of the shell output are silently dropped, which is particularly visible with multi-line command output.

Always use `rpmsg_send()` so the write waits until a TX buffer is returned.
The now-unused backend `blocking` state is also removed.

  ## Observed behavior

  Before this change, commands producing multi-line output could be truncated
  or mixed together:

  ```text
  ipc:~$ kernel
  kernel - Kernel commands
  Subcommands:
    cycles   : Kernel cycles.
    thread   : ith the -p or --pretty options
    version  :
```

With this change, repeated commands produce complete output:

```text
ipc:~$ kernel
kernel - Kernel commands
Subcommands:
  cycles   : Kernel cycles.
  reboot   : Reboot.
  sleep    : ms
  thread   : Kernel threads.
  uptime   : Kernel uptime. Can be called with the -p or --pretty options
  version  : Kernel version.
```