### PR TITLE
boards: microchip: sam: sama7d65_curiosity: add hwinfo support

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
@@ -14,6 +14,7 @@ supported:
   - crypto
   - eeprom
   - gpio
+  - hwinfo
   - i2c
   - led
   - pinctrl

--- a/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
@@ -587,6 +587,21 @@
 			};
 		};
 
+		otpc: efuse@e8c00000 {
+			compatible = "microchip,sama7g5-otpc";
+			reg = <0xe8c00000 0x100>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		hwinfo: device_id@e8c00060 {
+			compatible = "microchip,hwinfo-g1";
+			reg = <0xe8c00060 0x4>,
+			      <0xe8c00064 0x4>,
+			      <0xe8c00068 0x4>,
+			      <0xe8c0006c 0x4>;
+		};
+
 		gic: interrupt-controller@e8c11000 {
 			compatible = "arm,gic-v2", "arm,gic";
 			reg = <0xe8c11000 0x1000>, <0xe8c12000 0x100>;

--- a/soc/microchip/sam/sama7/sama7d6/soc.c
+++ b/soc/microchip/sam/sama7/sama7d6/soc.c
@@ -43,6 +43,9 @@ static const struct arm_mmu_region mmu_regions[] = {
 
 	FOR_EACH_IDX(MMU_REGION_MCAN_DEFN, (), 0, 1, 2, 3, 4)
 
+	MMU_REGION_FLAT_ENTRY("otpc", OTPC_BASE_ADDRESS, 0x1000,
+			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+
 	MMU_REGION_FLAT_ENTRY("pioa", PIO_BASE_ADDRESS, 0x4000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
 


### PR DESCRIPTION
Add hwinfo/chipid feature support for sama7d65_curiosity board.