### PR TITLE
tests: Bluetooth: Host: ID: Remove add_compile_options

### DIFF
--- a/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_br_oob_get_local)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_add)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_adv_random_addr_check)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_create)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_del)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_delete)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_get)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_init)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_read_public_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_reset)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_scan_random_addr_check)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_set_adv_own_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_set_adv_private_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_set_adv_random_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_set_create_conn_own_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_set_private_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_id_set_scan_own_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_le_ext_adv_oob_get_local)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_le_oob_get_local)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_le_oob_get_sc_data)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_le_oob_set_legacy_tk)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_le_oob_set_sc_data)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_lookup_id_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_setup_public_id_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include_directories(BEFORE

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.28.0)
 
 project(bt_setup_random_id_addr)
 
-# Suppress the format-zero-length error if GNUC is used
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
-endif()
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)


### PR DESCRIPTION
All the ID tests had additional compile options added, which did not serve any purpose, so they were removed.