### PR TITLE
bluetooth: classic: bip: make static vars testable

### DIFF
--- a/subsys/bluetooth/host/classic/shell/bip.c
+++ b/subsys/bluetooth/host/classic/shell/bip.c
@@ -44,10 +44,10 @@ struct bt_bip_app {
 	uint32_t conn_id;
 };
 
-static struct bt_bip_app bip_app;
+ZTESTABLE_STATIC struct bt_bip_app bip_app;
 
-static struct bt_bip_rfcomm_server rfcomm_server;
-static struct bt_bip_l2cap_server l2cap_server;
+ZTESTABLE_STATIC struct bt_bip_rfcomm_server rfcomm_server;
+ZTESTABLE_STATIC struct bt_bip_l2cap_server l2cap_server;
 
 #define TLV_COUNT       6
 #define TLV_BUFFER_SIZE 64


### PR DESCRIPTION
Mark static variables bip_app, rfcomm_server, and l2cap_server with ZTESTABLE_STATIC to allow them to be accessed from unit tests while maintaining static linkage in production builds.