### PR TITLE
drivers: display: st7735r: fix strided writes

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -198,7 +198,7 @@ static int st7735r_write(const struct device *dev,
 		write_h = 1U;
 		nbr_of_writes = desc->height;
 		mipi_desc.height = 1;
-		mipi_desc.buf_size = desc->pitch * ST7735R_PIXEL_SIZE;
+		mipi_desc.buf_size = desc->width * ST7735R_PIXEL_SIZE;
 	} else {
 		write_h = desc->height;
 		nbr_of_writes = 1U;

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -184,8 +184,9 @@ static int st7735r_write(const struct device *dev,
 	struct display_buffer_descriptor mipi_desc;
 
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
-	__ASSERT((desc->pitch * ST7735R_PIXEL_SIZE * desc->height)
-		 <= desc->buf_size, "Input buffer too small");
+	__ASSERT(((((size_t)desc->height - 1U) * desc->pitch + desc->width) *
+		  ST7735R_PIXEL_SIZE) <= desc->buf_size,
+		 "Input buffer too small");
 
 	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)",
 		desc->width, desc->height, x, y);


### PR DESCRIPTION
## Summary

Fix ST7735R writes when a display buffer descriptor has a pitch larger
than its width.

- Transfer only the requested width from each strided row.
- Validate the buffer through the last accessed pixel instead of requiring
  a complete pitch after the final row.

## Problem

When `desc->pitch > desc->width`, the driver sends each row separately.
The first row uses `desc->width`, but subsequent MIPI DBI transfers use
`desc->pitch` as their buffer size. This sends pixels outside the requested
row and corrupts the display contents.

The existing buffer check also requires `pitch * height` pixels. Padding
after the final row is not accessed, so this rejects valid strided views
into a larger framebuffer.

The required buffer size is:

```text
((height - 1) * pitch + width) * pixel_size
```

## Testing

- Tested on a custom STM32F407 board with two 160x80 ST7735S panels using
  the `sitronix,st7735r` driver.
- Reproduced with a 160-pixel-wide view using a 320-pixel pitch and multiple
  rows; the unmodified driver mixed pixels from the adjacent view into the
  first panel.
- Verified on hardware that both panels render correctly after these fixes.
- Built the application for `arcap_stm32/stm32f407xx`.
- `scripts/checkpatch.pl`: 0 errors, 0 warnings.
