### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 253d42e4c124aecd7b51afa4782140270e890a7d
+      revision: 581cc8c8d922b062101ab2cc252c4b4699b0dae9
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 21184a8f89f101538ad54c3b64a1d9c4da23bdb8


### PR DESCRIPTION
Update the HW models module to:
581cc8c8d922b062101ab2cc252c4b4699b0dae9

Including the following:
581cc8c CMakeLists: Differentiate macros used for building HAL and HW 
09d87d0 nrf_bsim_redef.5340.h: Correct NRF_TIMER* macros 
06f8c68 NHW_misc.5340.c: don't include hal redefinitions header 
37e1c93 nrf_bsim_redef: Include nrf5340 header also for general 5340 macro 
d48c70e OSCILLATORS: Add registers stub for 53 and 54 devices 
b0d807a docs: Mention nRF54LS05 & LM20 in text where relevant
