### PR TITLE
Realtek Bee I2C: bus recovery, async callback, get_config and RTIO submit

### DIFF
--- a/drivers/i2c/Kconfig.bee
+++ b/drivers/i2c/Kconfig.bee
@@ -7,6 +7,7 @@ config I2C_BEE
 	depends on DT_HAS_REALTEK_BEE_I2C_ENABLED
 	select HAL_REALTEK_BEE_I2C
 	select PINCTRL
+	select I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
 	  This option enables the I2C driver for Realtek Bee SoCs.
 

--- a/drivers/i2c/Kconfig.bee
+++ b/drivers/i2c/Kconfig.bee
@@ -9,3 +9,13 @@ config I2C_BEE
 	select PINCTRL
 	help
 	  This option enables the I2C driver for Realtek Bee SoCs.
+
+config I2C_BEE_BUS_RECOVERY
+	bool "Bus recovery support"
+	depends on I2C_BEE
+	default y if I2C_BUS_RECOVERY
+	select I2C_BITBANG
+	help
+	  Enable I2C bus recovery on Realtek Bee SoCs by bit-banging the SCL/SDA
+	  lines through GPIO. Requires GPIO to be enabled and the scl-gpios and
+	  sda-gpios properties on the I2C node.

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -348,6 +348,9 @@ static int i2c_bee_init(const struct device *dev)
 static DEVICE_API(i2c, i2c_bee_driver_api) = {
 	.configure = i2c_bee_configure,
 	.transfer = i2c_bee_transfer,
+#ifdef CONFIG_I2C_RTIO
+	.iodev_submit = i2c_iodev_submit_fallback,
+#endif
 };
 
 #define I2C_IRQ_FUNC_DEFINE(index)                                                                 \

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -57,6 +57,7 @@ struct i2c_bee_data {
 	struct k_mutex bus_mutex;
 	struct k_sem sync_sem;
 	struct i2c_bee_context ctx;
+	uint32_t dev_config;
 	uint8_t errs;
 };
 
@@ -234,20 +235,17 @@ static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 	return ret;
 }
 
-static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
+static int i2c_bee_do_configure(const struct device *dev, uint32_t dev_config)
 {
 	struct i2c_bee_data *data = dev->data;
 	const struct i2c_bee_config *cfg = dev->config;
 	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
 	I2C_InitTypeDef i2c_init_struct;
-	int err = 0;
 
 	/* Only support Controller mode for now, since Target API is not implemented */
 	if ((dev_config & I2C_MODE_CONTROLLER) == 0) {
 		return -ENOTSUP;
 	}
-
-	k_mutex_lock(&data->bus_mutex, K_FOREVER);
 
 	I2C_Cmd(i2c, DISABLE);
 
@@ -272,18 +270,37 @@ static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
 		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST_PLUS;
 		break;
 	default:
-		err = -EINVAL;
-		goto error;
+		return -EINVAL;
 	}
 
 	I2C_Init(i2c, &i2c_init_struct);
 
 	I2C_Cmd(i2c, ENABLE);
 
-error:
+	data->dev_config = dev_config;
+
+	return 0;
+}
+
+static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
+{
+	struct i2c_bee_data *data = dev->data;
+	int err;
+
+	k_mutex_lock(&data->bus_mutex, K_FOREVER);
+	err = i2c_bee_do_configure(dev, dev_config);
 	k_mutex_unlock(&data->bus_mutex);
 
 	return err;
+}
+
+static int i2c_bee_get_config(const struct device *dev, uint32_t *dev_config)
+{
+	struct i2c_bee_data *data = dev->data;
+
+	*dev_config = data->dev_config;
+
+	return 0;
 }
 
 static void i2c_bee_isr(const struct device *dev)
@@ -347,6 +364,7 @@ static int i2c_bee_init(const struct device *dev)
 
 static DEVICE_API(i2c, i2c_bee_driver_api) = {
 	.configure = i2c_bee_configure,
+	.get_config = i2c_bee_get_config,
 	.transfer = i2c_bee_transfer,
 #ifdef CONFIG_I2C_RTIO
 	.iodev_submit = i2c_iodev_submit_fallback,

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -73,6 +73,12 @@ struct i2c_bee_data {
 	void *userdata;
 	struct k_timer timeout_timer;
 #endif
+#ifdef CONFIG_I2C_TARGET
+	struct i2c_target_config *target_cfg;
+	bool target_attached;
+	bool target_in_write;
+	bool target_in_read;
+#endif
 };
 
 static inline bool i2c_bee_next_msg_available(struct i2c_bee_context *ctx)
@@ -271,6 +277,14 @@ static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 
 	k_sem_take(&data->lock, K_FOREVER);
 
+#ifdef CONFIG_I2C_TARGET
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		LOG_ERR("cannot transfer while registered as a target");
+		return -EBUSY;
+	}
+#endif
+
 #ifdef CONFIG_I2C_CALLBACK
 	data->cb = NULL;
 #endif
@@ -320,6 +334,14 @@ static int i2c_bee_transfer_cb(const struct device *dev, struct i2c_msg *msgs, u
 		return -EWOULDBLOCK;
 	}
 
+#ifdef CONFIG_I2C_TARGET
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		LOG_ERR("cannot transfer while registered as a target");
+		return -EBUSY;
+	}
+#endif
+
 	data->cb = cb;
 	data->userdata = userdata;
 
@@ -340,7 +362,9 @@ static int i2c_bee_do_configure(const struct device *dev, uint32_t dev_config)
 	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
 	I2C_InitTypeDef i2c_init_struct;
 
-	/* Only support Controller mode for now, since Target API is not implemented */
+	/* configure() only sets up controller mode; target mode is entered
+	 * through the target_register() API instead.
+	 */
 	if ((dev_config & I2C_MODE_CONTROLLER) == 0) {
 		return -ENOTSUP;
 	}
@@ -386,6 +410,18 @@ static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
 	int err;
 
 	k_sem_take(&data->lock, K_FOREVER);
+
+#ifdef CONFIG_I2C_TARGET
+	/* Reconfiguring would switch the peripheral back to controller mode and
+	 * clobber the active target; the target must be unregistered first.
+	 */
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		LOG_ERR("cannot reconfigure while registered as a target");
+		return -EBUSY;
+	}
+#endif
+
 	err = i2c_bee_do_configure(dev, dev_config);
 	k_sem_give(&data->lock);
 
@@ -400,6 +436,159 @@ static int i2c_bee_get_config(const struct device *dev, uint32_t *dev_config)
 
 	return 0;
 }
+
+#ifdef CONFIG_I2C_TARGET
+static void i2c_bee_target_isr(const struct device *dev)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->reg;
+	struct i2c_target_config *target = data->target_cfg;
+	const struct i2c_target_callbacks *cb = target->callbacks;
+	uint8_t val = 0xFFU;
+
+	if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
+		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
+	}
+
+	/* Master is writing to us: drain the RX FIFO into the write callback. */
+	if (I2C_GetINTStatus(i2c, I2C_INT_RX_FULL)) {
+		if (!data->target_in_write) {
+			data->target_in_write = true;
+			if (cb->write_requested != NULL) {
+				cb->write_requested(target);
+			}
+		}
+
+		while (i2c->IC_STATUS & I2C_FLAG_RFNE) {
+			val = (uint8_t)i2c->IC_DATA_CMD;
+			if (cb->write_received != NULL) {
+				cb->write_received(target, val);
+			}
+		}
+
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+	}
+
+	/* Master is reading from us: feed one byte per read request. */
+	if (I2C_GetINTStatus(i2c, I2C_INT_RD_REQ)) {
+		if (!data->target_in_read) {
+			data->target_in_read = true;
+			if (cb->read_requested != NULL) {
+				cb->read_requested(target, &val);
+			}
+		} else {
+			if (cb->read_processed != NULL) {
+				cb->read_processed(target, &val);
+			}
+		}
+
+		i2c->IC_DATA_CMD = val;
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RD_REQ);
+	}
+
+	/* Master NACKed the last byte of a slave-transmit: the read is done. */
+	if (I2C_GetINTStatus(i2c, I2C_INT_RX_DONE)) {
+		data->target_in_read = false;
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RX_DONE);
+	}
+
+	if (I2C_GetINTStatus(i2c, I2C_INT_STOP_DET)) {
+		if (cb->stop != NULL) {
+			cb->stop(target);
+		}
+		data->target_in_write = false;
+		data->target_in_read = false;
+		I2C_ClearINTPendingBit(i2c, I2C_INT_STOP_DET);
+	}
+}
+
+static int i2c_bee_target_register(const struct device *dev, struct i2c_target_config *target_cfg)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->reg;
+	I2C_InitTypeDef i2c_init_struct;
+
+	if (target_cfg == NULL) {
+		return -EINVAL;
+	}
+
+	/* Only 7-bit target addressing is supported for now. */
+	if (target_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		return -ENOTSUP;
+	}
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		return -EBUSY;
+	}
+
+	I2C_Cmd(i2c, DISABLE);
+
+	I2C_StructInit(&i2c_init_struct);
+	i2c_init_struct.I2C_DeviveMode = I2C_DeviveMode_Slave;
+	i2c_init_struct.I2C_AddressMode = I2C_AddressMode_7BIT;
+	i2c_init_struct.I2C_SlaveAddress = target_cfg->address;
+
+	switch (I2C_SPEED_GET(data->dev_config)) {
+	case I2C_SPEED_FAST:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST;
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST_PLUS;
+		break;
+	default:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_STANDARD;
+		break;
+	}
+
+	I2C_Init(i2c, &i2c_init_struct);
+	I2C_Cmd(i2c, ENABLE);
+
+	data->target_cfg = target_cfg;
+	data->target_in_write = false;
+	data->target_in_read = false;
+	data->target_attached = true;
+
+	I2C_INTConfig(i2c, I2C_INT_RX_FULL | I2C_INT_RD_REQ | I2C_INT_RX_DONE |
+					    I2C_INT_TX_ABRT | I2C_INT_STOP_DET, ENABLE);
+
+	k_sem_give(&data->lock);
+
+	return 0;
+}
+
+static int i2c_bee_target_unregister(const struct device *dev, struct i2c_target_config *target_cfg)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->reg;
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	if (!data->target_attached || data->target_cfg != target_cfg) {
+		k_sem_give(&data->lock);
+		return -EINVAL;
+	}
+
+	I2C_INTConfig(i2c, I2C_INT_RX_FULL | I2C_INT_RD_REQ | I2C_INT_RX_DONE |
+					    I2C_INT_TX_ABRT | I2C_INT_STOP_DET, DISABLE);
+	I2C_Cmd(i2c, DISABLE);
+
+	data->target_attached = false;
+	data->target_cfg = NULL;
+
+	/* Restore controller mode with the previously configured settings. */
+	(void)i2c_bee_do_configure(dev, data->dev_config);
+
+	k_sem_give(&data->lock);
+
+	return 0;
+}
+#endif /* CONFIG_I2C_TARGET */
 
 #ifdef CONFIG_I2C_BEE_BUS_RECOVERY
 #if defined(CONFIG_SOC_SERIES_RTL8752H)
@@ -520,6 +709,13 @@ static void i2c_bee_isr(const struct device *dev)
 	const struct i2c_bee_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->reg;
 
+#ifdef CONFIG_I2C_TARGET
+	if (data->target_attached) {
+		i2c_bee_target_isr(dev);
+		return;
+	}
+#endif
+
 	if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
 		data->errs = I2C_CheckAbortStatus(i2c);
 		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
@@ -584,6 +780,10 @@ static DEVICE_API(i2c, i2c_bee_driver_api) = {
 #endif
 #ifdef CONFIG_I2C_BEE_BUS_RECOVERY
 	.recover_bus = i2c_bee_recover_bus,
+#endif
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_bee_target_register,
+	.target_unregister = i2c_bee_target_unregister,
 #endif
 #ifdef CONFIG_I2C_RTIO
 	.iodev_submit = i2c_iodev_submit_fallback,

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
 
 #include <zephyr/logging/log.h>
@@ -22,6 +23,9 @@
 LOG_MODULE_REGISTER(i2c_bee, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
+#ifdef CONFIG_I2C_BEE_BUS_RECOVERY
+#include "i2c_bitbang.h"
+#endif
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #include <rtl_i2c.h>
@@ -51,6 +55,10 @@ struct i2c_bee_config {
 	uint16_t clkid;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_cfg_func)(void);
+#ifdef CONFIG_I2C_BEE_BUS_RECOVERY
+	struct gpio_dt_spec scl_gpio;
+	struct gpio_dt_spec sda_gpio;
+#endif
 };
 
 struct i2c_bee_data {
@@ -303,6 +311,119 @@ static int i2c_bee_get_config(const struct device *dev, uint32_t *dev_config)
 	return 0;
 }
 
+#ifdef CONFIG_I2C_BEE_BUS_RECOVERY
+#if defined(CONFIG_SOC_SERIES_RTL8752H)
+/*
+ * RTL8752H has no hardware open-drain output mode, so open-drain is emulated by
+ * switching the pin direction on every edge: released == input with pull-up,
+ * driven low == output low.
+ */
+static void i2c_bee_bitbang_set_line(const struct gpio_dt_spec *gpio, int state)
+{
+	(void)gpio_pin_configure_dt(gpio, state ? (GPIO_INPUT | GPIO_PULL_UP) : GPIO_OUTPUT_LOW);
+}
+
+static void i2c_bee_bitbang_set_scl(void *io_context, int state)
+{
+	const struct i2c_bee_config *cfg = io_context;
+
+	i2c_bee_bitbang_set_line(&cfg->scl_gpio, state);
+}
+
+static void i2c_bee_bitbang_set_sda(void *io_context, int state)
+{
+	const struct i2c_bee_config *cfg = io_context;
+
+	i2c_bee_bitbang_set_line(&cfg->sda_gpio, state);
+}
+#else
+/*
+ * Other Bee SoCs support a hardware open-drain output mode, so the lines are
+ * configured once (see i2c_bee_recover_bus) and each edge only writes the data
+ * register - fast enough to meet the SCL timing and free of the transient that
+ * re-running the full pad configuration on every edge would cause.
+ */
+static void i2c_bee_bitbang_set_scl(void *io_context, int state)
+{
+	const struct i2c_bee_config *cfg = io_context;
+
+	gpio_pin_set_dt(&cfg->scl_gpio, state);
+}
+
+static void i2c_bee_bitbang_set_sda(void *io_context, int state)
+{
+	const struct i2c_bee_config *cfg = io_context;
+
+	gpio_pin_set_dt(&cfg->sda_gpio, state);
+}
+#endif
+
+static int i2c_bee_bitbang_get_sda(void *io_context)
+{
+	const struct i2c_bee_config *cfg = io_context;
+
+	return gpio_pin_get_dt(&cfg->sda_gpio) != 0 ? 1 : 0;
+}
+
+static int i2c_bee_recover_bus(const struct device *dev)
+{
+	const struct i2c_bee_config *cfg = dev->config;
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bitbang_io bitbang_io = {
+		.set_scl = i2c_bee_bitbang_set_scl,
+		.set_sda = i2c_bee_bitbang_set_sda,
+		.get_sda = i2c_bee_bitbang_get_sda,
+	};
+	struct i2c_bitbang bitbang;
+	uint32_t dev_config;
+	int ret;
+
+	if (!gpio_is_ready_dt(&cfg->scl_gpio) || !gpio_is_ready_dt(&cfg->sda_gpio)) {
+		LOG_ERR("SCL/SDA recovery GPIO not available");
+		return -ENOSYS;
+	}
+
+	k_mutex_lock(&data->bus_mutex, K_FOREVER);
+
+	ret = 0;
+#if !defined(CONFIG_SOC_SERIES_RTL8752H)
+	/*
+	 * Configure both lines once as open-drain outputs. The bit-bang helper
+	 * then only writes the data register on each edge (a single register
+	 * access), which is fast enough to meet the SCL timing and never
+	 * re-runs the full pad configuration, so the line does not glitch while
+	 * toggling between the driven-low and released states.
+	 */
+	ret = gpio_pin_configure_dt(&cfg->scl_gpio,
+				    GPIO_OUTPUT_HIGH | GPIO_OPEN_DRAIN | GPIO_PULL_UP);
+	if (ret == 0) {
+		ret = gpio_pin_configure_dt(&cfg->sda_gpio,
+					    GPIO_OUTPUT_HIGH | GPIO_OPEN_DRAIN | GPIO_PULL_UP);
+	}
+#endif
+
+	if (ret == 0) {
+		i2c_bitbang_init(&bitbang, &bitbang_io, (void *)cfg);
+
+		ret = i2c_bitbang_recover_bus(&bitbang);
+		if (ret < 0) {
+			LOG_ERR("failed to recover bus (%d)", ret);
+		}
+	} else {
+		LOG_ERR("failed to configure recovery GPIO (%d)", ret);
+	}
+
+	(void)i2c_bee_get_config(dev, &dev_config);
+	(void)pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	(void)clock_control_on(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&cfg->clkid);
+	(void)i2c_bee_do_configure(dev, dev_config);
+
+	k_mutex_unlock(&data->bus_mutex);
+
+	return ret;
+}
+#endif /* CONFIG_I2C_BEE_BUS_RECOVERY */
+
 static void i2c_bee_isr(const struct device *dev)
 {
 	struct i2c_bee_data *data = dev->data;
@@ -366,6 +487,9 @@ static DEVICE_API(i2c, i2c_bee_driver_api) = {
 	.configure = i2c_bee_configure,
 	.get_config = i2c_bee_get_config,
 	.transfer = i2c_bee_transfer,
+#ifdef CONFIG_I2C_BEE_BUS_RECOVERY
+	.recover_bus = i2c_bee_recover_bus,
+#endif
 #ifdef CONFIG_I2C_RTIO
 	.iodev_submit = i2c_iodev_submit_fallback,
 #endif
@@ -379,6 +503,14 @@ static DEVICE_API(i2c, i2c_bee_driver_api) = {
 		irq_enable(DT_INST_IRQN(index));                                                   \
 	}
 
+#ifdef CONFIG_I2C_BEE_BUS_RECOVERY
+#define I2C_BEE_RECOVERY_INIT(index)                                                               \
+	.scl_gpio = GPIO_DT_SPEC_INST_GET_OR(index, scl_gpios, {0}),                               \
+	.sda_gpio = GPIO_DT_SPEC_INST_GET_OR(index, sda_gpios, {0}),
+#else
+#define I2C_BEE_RECOVERY_INIT(index)
+#endif
+
 #define I2C_BEE_INIT(index)                                                                        \
 	PINCTRL_DT_INST_DEFINE(index);                                                             \
 	I2C_IRQ_FUNC_DEFINE(index);                                                                \
@@ -389,6 +521,7 @@ static DEVICE_API(i2c, i2c_bee_driver_api) = {
 		.clkid = DT_INST_CLOCKS_CELL(index, id),                                           \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
 		.irq_cfg_func = i2c_bee_irq_cfg_func_##index,                                      \
+		I2C_BEE_RECOVERY_INIT(index)                                                       \
 	};                                                                                         \
 	I2C_DEVICE_DT_INST_DEFINE(index, i2c_bee_init, NULL, &i2c_bee_data_##index,                \
 				  &i2c_bee_cfg_##index, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,     \

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -55,6 +55,7 @@ struct i2c_bee_config {
 	uint16_t clkid;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_cfg_func)(void);
+	k_timeout_t transfer_timeout;
 #ifdef CONFIG_I2C_BEE_BUS_RECOVERY
 	struct gpio_dt_spec scl_gpio;
 	struct gpio_dt_spec sda_gpio;
@@ -62,11 +63,16 @@ struct i2c_bee_config {
 };
 
 struct i2c_bee_data {
-	struct k_mutex bus_mutex;
+	struct k_sem lock;
 	struct k_sem sync_sem;
 	struct i2c_bee_context ctx;
 	uint32_t dev_config;
 	uint8_t errs;
+#ifdef CONFIG_I2C_CALLBACK
+	i2c_callback_t cb;
+	void *userdata;
+	struct k_timer timeout_timer;
+#endif
 };
 
 static inline bool i2c_bee_next_msg_available(struct i2c_bee_context *ctx)
@@ -203,6 +209,58 @@ static void i2c_bee_log_err(struct i2c_bee_data *data)
 	}
 }
 
+static void i2c_bee_start(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			  uint16_t addr)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
+
+	data->ctx.msgs = msgs;
+	data->ctx.num_msgs = num_msgs;
+	data->ctx.msg_idx = 0U;
+	data->ctx.tx_idx = 0U;
+	data->ctx.rx_idx = 0U;
+	data->errs = I2C_Success;
+
+	I2C_Cmd(i2c, ENABLE);
+	I2C_SetSlaveAddress(i2c, addr);
+
+	I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, ENABLE);
+
+	i2c_bee_do_tx(dev);
+}
+
+static void i2c_bee_complete(const struct device *dev, int result)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
+
+	I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, DISABLE);
+	I2C_Cmd(i2c, DISABLE);
+
+#ifdef CONFIG_I2C_CALLBACK
+	/* Cancel the async watchdog; harmless no-op when it is the one that fired. */
+	k_timer_stop(&data->timeout_timer);
+
+	if (data->cb != NULL) {
+		i2c_callback_t cb = data->cb;
+		void *userdata = data->userdata;
+
+		data->cb = NULL;
+		data->userdata = NULL;
+
+		k_sem_give(&data->lock);
+		cb(dev, result, userdata);
+		return;
+	}
+#endif /* CONFIG_I2C_CALLBACK */
+
+	ARG_UNUSED(result);
+	k_sem_give(&data->sync_sem);
+}
+
 static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
 			    uint16_t addr)
 {
@@ -211,30 +269,26 @@ static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
 	int ret = 0;
 
-	k_mutex_lock(&data->bus_mutex, K_FOREVER);
+	k_sem_take(&data->lock, K_FOREVER);
 
-	data->ctx.msgs = msgs;
-	data->ctx.num_msgs = num_msgs;
-	data->ctx.msg_idx = 0U;
-	data->ctx.tx_idx = 0U;
-	data->ctx.rx_idx = 0U;
-	data->errs = I2C_Success;
+#ifdef CONFIG_I2C_CALLBACK
+	data->cb = NULL;
+#endif
 	k_sem_reset(&data->sync_sem);
 
-	I2C_Cmd(i2c, ENABLE);
-	I2C_SetSlaveAddress(i2c, addr);
+	i2c_bee_start(dev, msgs, num_msgs, addr);
 
-	I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, ENABLE);
-
-	i2c_bee_do_tx(dev);
-
-	k_sem_take(&data->sync_sem, K_FOREVER);
+	if (k_sem_take(&data->sync_sem, cfg->transfer_timeout) != 0) {
+		I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, DISABLE);
+		I2C_Cmd(i2c, DISABLE);
+		k_sem_give(&data->lock);
+		LOG_ERR("transfer timed out");
+		return -ETIMEDOUT;
+	}
 
 	ret = (data->errs == I2C_Success) ? 0 : -EIO;
 
-	I2C_Cmd(i2c, DISABLE);
-
-	k_mutex_unlock(&data->bus_mutex);
+	k_sem_give(&data->lock);
 
 	if (ret < 0) {
 		i2c_bee_log_err(data);
@@ -242,6 +296,42 @@ static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 
 	return ret;
 }
+
+#ifdef CONFIG_I2C_CALLBACK
+static void i2c_bee_timeout(struct k_timer *timer)
+{
+	const struct device *dev = k_timer_user_data_get(timer);
+
+	i2c_bee_complete(dev, -ETIMEDOUT);
+}
+
+static int i2c_bee_transfer_cb(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			       uint16_t addr, i2c_callback_t cb, void *userdata)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+
+	/* The bus lock is released from the ISR when the transfer completes. */
+	if (k_sem_take(&data->lock, K_NO_WAIT) != 0) {
+		return -EWOULDBLOCK;
+	}
+
+	data->cb = cb;
+	data->userdata = userdata;
+
+	if (!K_TIMEOUT_EQ(cfg->transfer_timeout, K_FOREVER)) {
+		k_timer_start(&data->timeout_timer, cfg->transfer_timeout, K_NO_WAIT);
+	}
+
+	i2c_bee_start(dev, msgs, num_msgs, addr);
+
+	return 0;
+}
+#endif /* CONFIG_I2C_CALLBACK */
 
 static int i2c_bee_do_configure(const struct device *dev, uint32_t dev_config)
 {
@@ -295,9 +385,9 @@ static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
 	struct i2c_bee_data *data = dev->data;
 	int err;
 
-	k_mutex_lock(&data->bus_mutex, K_FOREVER);
+	k_sem_take(&data->lock, K_FOREVER);
 	err = i2c_bee_do_configure(dev, dev_config);
-	k_mutex_unlock(&data->bus_mutex);
+	k_sem_give(&data->lock);
 
 	return err;
 }
@@ -383,7 +473,7 @@ static int i2c_bee_recover_bus(const struct device *dev)
 		return -ENOSYS;
 	}
 
-	k_mutex_lock(&data->bus_mutex, K_FOREVER);
+	k_sem_take(&data->lock, K_FOREVER);
 
 	ret = 0;
 #if !defined(CONFIG_SOC_SERIES_RTL8752H)
@@ -418,7 +508,7 @@ static int i2c_bee_recover_bus(const struct device *dev)
 	(void)clock_control_on(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&cfg->clkid);
 	(void)i2c_bee_do_configure(dev, dev_config);
 
-	k_mutex_unlock(&data->bus_mutex);
+	k_sem_give(&data->lock);
 
 	return ret;
 }
@@ -432,11 +522,11 @@ static void i2c_bee_isr(const struct device *dev)
 
 	if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
 		data->errs = I2C_CheckAbortStatus(i2c);
-		I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, DISABLE);
 		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
 		I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
 		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
-		k_sem_give(&data->sync_sem);
+		i2c_bee_complete(dev, -EIO);
+		return;
 	}
 
 	if (I2C_GetINTStatus(i2c, I2C_INT_RX_FULL)) {
@@ -450,10 +540,7 @@ static void i2c_bee_isr(const struct device *dev)
 	}
 
 	if (!i2c_bee_next_msg_available(&data->ctx) && !I2C_GetFlagState(i2c, I2C_FLAG_ACTIVITY)) {
-		I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, DISABLE);
-		I2C_Cmd(i2c, DISABLE);
-
-		k_sem_give(&data->sync_sem);
+		i2c_bee_complete(dev, 0);
 	}
 }
 
@@ -471,9 +558,14 @@ static int i2c_bee_init(const struct device *dev)
 
 	(void)clock_control_on(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&cfg->clkid);
 
-	k_mutex_init(&data->bus_mutex);
+	k_sem_init(&data->lock, 1, 1);
 
 	k_sem_init(&data->sync_sem, 0, K_SEM_MAX_LIMIT);
+
+#ifdef CONFIG_I2C_CALLBACK
+	k_timer_init(&data->timeout_timer, i2c_bee_timeout, NULL);
+	k_timer_user_data_set(&data->timeout_timer, (void *)dev);
+#endif
 
 	cfg->irq_cfg_func();
 
@@ -487,6 +579,9 @@ static DEVICE_API(i2c, i2c_bee_driver_api) = {
 	.configure = i2c_bee_configure,
 	.get_config = i2c_bee_get_config,
 	.transfer = i2c_bee_transfer,
+#ifdef CONFIG_I2C_CALLBACK
+	.transfer_cb = i2c_bee_transfer_cb,
+#endif
 #ifdef CONFIG_I2C_BEE_BUS_RECOVERY
 	.recover_bus = i2c_bee_recover_bus,
 #endif
@@ -521,6 +616,7 @@ static DEVICE_API(i2c, i2c_bee_driver_api) = {
 		.clkid = DT_INST_CLOCKS_CELL(index, id),                                           \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
 		.irq_cfg_func = i2c_bee_irq_cfg_func_##index,                                      \
+		.transfer_timeout = I2C_DT_INST_TRANSFER_TIMEOUT(index),                           \
 		I2C_BEE_RECOVERY_INIT(index)                                                       \
 	};                                                                                         \
 	I2C_DEVICE_DT_INST_DEFINE(index, i2c_bee_init, NULL, &i2c_bee_data_##index,                \

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -73,6 +73,12 @@ struct i2c_bee_data {
 	void *userdata;
 	struct k_timer timeout_timer;
 #endif
+#ifdef CONFIG_I2C_TARGET
+	struct i2c_target_config *target_cfg;
+	bool target_attached;
+	bool target_in_write;
+	bool target_in_read;
+#endif
 };
 
 static inline bool i2c_bee_next_msg_available(struct i2c_bee_context *ctx)
@@ -271,6 +277,14 @@ static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 
 	k_sem_take(&data->lock, K_FOREVER);
 
+#ifdef CONFIG_I2C_TARGET
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		LOG_ERR("cannot transfer while registered as a target");
+		return -EBUSY;
+	}
+#endif
+
 #ifdef CONFIG_I2C_CALLBACK
 	data->cb = NULL;
 #endif
@@ -320,6 +334,14 @@ static int i2c_bee_transfer_cb(const struct device *dev, struct i2c_msg *msgs, u
 		return -EWOULDBLOCK;
 	}
 
+#ifdef CONFIG_I2C_TARGET
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		LOG_ERR("cannot transfer while registered as a target");
+		return -EBUSY;
+	}
+#endif
+
 	data->cb = cb;
 	data->userdata = userdata;
 
@@ -340,7 +362,9 @@ static int i2c_bee_do_configure(const struct device *dev, uint32_t dev_config)
 	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
 	I2C_InitTypeDef i2c_init_struct;
 
-	/* Only support Controller mode for now, since Target API is not implemented */
+	/* configure() only sets up controller mode; target mode is entered
+	 * through the target_register() API instead.
+	 */
 	if ((dev_config & I2C_MODE_CONTROLLER) == 0) {
 		return -ENOTSUP;
 	}
@@ -386,6 +410,18 @@ static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
 	int err;
 
 	k_sem_take(&data->lock, K_FOREVER);
+
+#ifdef CONFIG_I2C_TARGET
+	/* Reconfiguring would switch the peripheral back to controller mode and
+	 * clobber the active target; the target must be unregistered first.
+	 */
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		LOG_ERR("cannot reconfigure while registered as a target");
+		return -EBUSY;
+	}
+#endif
+
 	err = i2c_bee_do_configure(dev, dev_config);
 	k_sem_give(&data->lock);
 
@@ -400,6 +436,158 @@ static int i2c_bee_get_config(const struct device *dev, uint32_t *dev_config)
 
 	return 0;
 }
+
+#ifdef CONFIG_I2C_TARGET
+static void i2c_bee_target_isr(const struct device *dev)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->reg;
+	struct i2c_target_config *target = data->target_cfg;
+	const struct i2c_target_callbacks *cb = target->callbacks;
+	uint8_t val = 0xFFU;
+
+	if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
+		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
+	}
+
+	/* Master is writing to us: drain the RX FIFO into the write callback. */
+	if (I2C_GetINTStatus(i2c, I2C_INT_RX_FULL)) {
+		if (!data->target_in_write) {
+			data->target_in_write = true;
+			if (cb->write_requested != NULL) {
+				cb->write_requested(target);
+			}
+		}
+
+		while (i2c->IC_STATUS & I2C_FLAG_RFNE) {
+			val = (uint8_t)i2c->IC_DATA_CMD;
+			if (cb->write_received != NULL) {
+				cb->write_received(target, val);
+			}
+		}
+
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+	}
+
+	/* Master is reading from us: feed one byte per read request. */
+	if (I2C_GetINTStatus(i2c, I2C_INT_RD_REQ)) {
+		if (!data->target_in_read) {
+			data->target_in_read = true;
+			if (cb->read_requested != NULL) {
+				cb->read_requested(target, &val);
+			}
+		} else {
+			if (cb->read_processed != NULL) {
+				cb->read_processed(target, &val);
+			}
+		}
+
+		i2c->IC_DATA_CMD = val;
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RD_REQ);
+	}
+
+	/* Master NACKed the last byte of a slave-transmit: the read is done. */
+	if (I2C_GetINTStatus(i2c, I2C_INT_RX_DONE)) {
+		data->target_in_read = false;
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RX_DONE);
+	}
+
+	if (I2C_GetINTStatus(i2c, I2C_INT_STOP_DET)) {
+		if (cb->stop != NULL) {
+			cb->stop(target);
+		}
+		data->target_in_write = false;
+		data->target_in_read = false;
+		I2C_ClearINTPendingBit(i2c, I2C_INT_STOP_DET);
+	}
+}
+
+static int i2c_bee_target_register(const struct device *dev, struct i2c_target_config *target_cfg)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->reg;
+	I2C_InitTypeDef i2c_init_struct;
+
+	if (target_cfg == NULL) {
+		return -EINVAL;
+	}
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	if (data->target_attached) {
+		k_sem_give(&data->lock);
+		return -EBUSY;
+	}
+
+	I2C_Cmd(i2c, DISABLE);
+
+	I2C_StructInit(&i2c_init_struct);
+	i2c_init_struct.I2C_DeviveMode = I2C_DeviveMode_Slave;
+	if (target_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		i2c_init_struct.I2C_AddressMode = I2C_AddressMode_10BIT;
+	} else {
+		i2c_init_struct.I2C_AddressMode = I2C_AddressMode_7BIT;
+	}
+	i2c_init_struct.I2C_SlaveAddress = target_cfg->address;
+
+	switch (I2C_SPEED_GET(data->dev_config)) {
+	case I2C_SPEED_FAST:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST;
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST_PLUS;
+		break;
+	default:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_STANDARD;
+		break;
+	}
+
+	I2C_Init(i2c, &i2c_init_struct);
+	I2C_Cmd(i2c, ENABLE);
+
+	data->target_cfg = target_cfg;
+	data->target_in_write = false;
+	data->target_in_read = false;
+	data->target_attached = true;
+
+	I2C_INTConfig(i2c, I2C_INT_RX_FULL | I2C_INT_RD_REQ | I2C_INT_RX_DONE |
+					    I2C_INT_TX_ABRT | I2C_INT_STOP_DET, ENABLE);
+
+	k_sem_give(&data->lock);
+
+	return 0;
+}
+
+static int i2c_bee_target_unregister(const struct device *dev, struct i2c_target_config *target_cfg)
+{
+	struct i2c_bee_data *data = dev->data;
+	const struct i2c_bee_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->reg;
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	if (!data->target_attached || data->target_cfg != target_cfg) {
+		k_sem_give(&data->lock);
+		return -EINVAL;
+	}
+
+	I2C_INTConfig(i2c, I2C_INT_RX_FULL | I2C_INT_RD_REQ | I2C_INT_RX_DONE |
+					    I2C_INT_TX_ABRT | I2C_INT_STOP_DET, DISABLE);
+	I2C_Cmd(i2c, DISABLE);
+
+	data->target_attached = false;
+	data->target_cfg = NULL;
+
+	/* Restore controller mode with the previously configured settings. */
+	(void)i2c_bee_do_configure(dev, data->dev_config);
+
+	k_sem_give(&data->lock);
+
+	return 0;
+}
+#endif /* CONFIG_I2C_TARGET */
 
 #ifdef CONFIG_I2C_BEE_BUS_RECOVERY
 #if defined(CONFIG_SOC_SERIES_RTL8752H)
@@ -520,6 +708,13 @@ static void i2c_bee_isr(const struct device *dev)
 	const struct i2c_bee_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->reg;
 
+#ifdef CONFIG_I2C_TARGET
+	if (data->target_attached) {
+		i2c_bee_target_isr(dev);
+		return;
+	}
+#endif
+
 	if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
 		data->errs = I2C_CheckAbortStatus(i2c);
 		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
@@ -584,6 +779,10 @@ static DEVICE_API(i2c, i2c_bee_driver_api) = {
 #endif
 #ifdef CONFIG_I2C_BEE_BUS_RECOVERY
 	.recover_bus = i2c_bee_recover_bus,
+#endif
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_bee_target_register,
+	.target_unregister = i2c_bee_target_unregister,
 #endif
 #ifdef CONFIG_I2C_RTIO
 	.iodev_submit = i2c_iodev_submit_fallback,

--- a/dts/bindings/i2c/realtek,bee-i2c.yaml
+++ b/dts/bindings/i2c/realtek,bee-i2c.yaml
@@ -23,3 +23,17 @@ properties:
 
   pinctrl-names:
     required: true
+
+  scl-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SCL line is connected. Used only for bus recovery
+      (CONFIG_I2C_BEE_BUS_RECOVERY): the pin is temporarily muxed to GPIO to
+      bit-bang the recovery clocks, then handed back to the I2C controller.
+
+  sda-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SDA line is connected. Used only for bus recovery
+      (CONFIG_I2C_BEE_BUS_RECOVERY): the pin is temporarily muxed to GPIO to
+      bit-bang the recovery clocks, then handed back to the I2C controller.

--- a/tests/drivers/i2c/i2c_target_api/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The Bee I2C controller cannot act as controller and target at the same
+ * time, so this test runs in single-role mode: i2c0 and i2c1 are two
+ * independent buses that must be wired together on the board
+ * (SCL0-SCL1 and SDA0-SDA1 shorted, the "i2c_bus_short" fixture).
+ *
+ * i2c0: SCL = P0_2, SDA = P0_4
+ * i2c1: SCL = P0_6, SDA = P0_7
+ */
+
+&i2c0 {
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&pinctrl {
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <BEE_PSEL(I2C0_CLK, P0_2)>,
+				<BEE_PSEL(I2C0_DAT, P0_4)>;
+			output-enable;
+			output-high;
+			bias-pull-up;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			psels = <BEE_PSEL(I2C1_CLK, P0_0)>,
+				<BEE_PSEL(I2C1_DAT, P0_1)>;
+			output-enable;
+			output-high;
+			bias-pull-up;
+		};
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The Bee I2C controller cannot act as controller and target at the same
+ * time, so this test runs in single-role mode: i2c0 and i2c1 are two
+ * independent buses that must be wired together on the board
+ * (SCL0-SCL1 and SDA0-SDA1 shorted, the "i2c_bus_short" fixture).
+ *
+ * i2c0: SCL = P2_2, SDA = P2_3
+ * i2c1: SCL = P2_4, SDA = P2_5
+ */
+
+&i2c0 {
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&pinctrl {
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <BEE_PSEL(I2C0_CLK, P2_2)>,
+				<BEE_PSEL(I2C0_DAT, P2_3)>;
+			output-enable;
+			output-high;
+			bias-pull-up;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			psels = <BEE_PSEL(I2C1_CLK, P2_4)>,
+				<BEE_PSEL(I2C1_DAT, P2_5)>;
+			output-enable;
+			output-high;
+			bias-pull-up;
+		};
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -87,6 +87,8 @@ tests:
       - sam_e54_xpro
       - pic32cx_sg41_cult
       - pic32cm_jh01_cpro
+      - rtl8752h_evb/rtl8752hjl
+      - rtl87x2g_evb_a/rtl8762gku
     integration_platforms:
       - max32690evkit/max32690/m4
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -88,6 +88,8 @@ tests:
       - pic32cm_jh01_cpro
       - pic32cx_sg41_cult
       - pic32cz_ca80_cult
+      - rtl8752h_evb/rtl8752hjl
+      - rtl87x2g_evb_a/rtl8762gku
       - sam_e54_xpro
       - s32k5xxcvb/s32k566/m7
       - s32k5xxcvb/s32k566/r52


### PR DESCRIPTION
  **Description**

  This PR extends the Realtek Bee I2C driver with the optional pieces of the Zephyr I2C API and adds test coverage. It applies to both series:
  - **RTL87x2G**
  - **RTL8752H**

  **Key features implemented:**
  - RTIO submit support (RTIO fallback handler on top of the blocking transfer path)
  - get_config (cache and expose the active controller configuration)
  - Bus recovery (`CONFIG_I2C_BEE_BUS_RECOVERY`, via the shared i2c_bitbang helper)
  - Async transfer with timeout (`CONFIG_I2C_CALLBACK`, ISR-completed, watchdog backstop)
  - Target/slave mode (`CONFIG_I2C_TARGET`): target_register/unregister, 7-bit byte-mode callbacks. The Bee peripheral has a single device-mode field, so it is a controller *or* a target at any one time; controller transfers and reconfiguration return -EBUSY while a target is registered.

  **Testing**

  I have verified the driver functionality using the standard Zephyr I2C target-mode API test suite (`tests/drivers/i2c/i2c_target_api`) in single-role mode, with the i2c0/i2c1 SCL and SDA lines shorted together (the `i2c_bus_short` fixture), on the following hardware platforms:

  1.  **Board:** `rtl87x2g_evb_a_rtl8762gku`
      - SoC: RTL87X2G
      - Test: `tests/drivers/i2c/i2c_target_api`
      - Result: **PASSED**

  2.  **Board:** `rtl8752h_evb_rtl8752hjl`
      - SoC: RTL8752H
      - Test: `tests/drivers/i2c/i2c_target_api`
      - Result: **PASSED**

  **Logs**

  ```console

*** Booting Zephyr OS build v4.4.0-10360-ge8f1c94ff62b ***
Running TESTSUITE i2c_eeprom_target
===================================================================
START - test_deinit
  bus gpios not specified in zephyr,path
 SKIP - test_deinit in 0.00=========================================
START - test_eeprom_target
Found EEPROM 0 on I2C bus device i2c@40015000 at addr 54
Found EEPROM 1 on I2C bus device i2c@40015400 at addr 56
Testing single-role
Testing full read: Master: i2c@40015400, address: 0x54
Testing partial read. Master: i2c@40015400, address: 0x54, off=0
Testing partial read. Master: i2c@40015400, address: 0x54, off=1
Testing partial read. Master: i2c@40015400, address: 0x54, off=2
Testing partial read. Master: i2c@40015400, address: 0x54, off=3
Testing partial read. Master: i2c@40015400, address: 0x54, off=4
Testing partial read. Master: i2c@40015400, address: 0x54, off=5
Testing partial read. Master: i2c@40015400, address: 0x54, off=6
Testing partial read. Master: i2c@40015400, address: 0x54, off=7
Testing partial read. Master: i2c@40015400, address: 0x54, off=8
Testing partial read. Master: i2c@40015400, address: 0x54, off=9
Testing partial read. Master: i2c@40015400, address: 0x54, off=10
Testing partial read. Master: i2c@40015400, address: 0x54, off=11
Testing partial read. Master: i2c@40015400, address: 0x54, off=12
Testing partial read. Master: i2c@40015400, address: 0x54, off=13
Testing partial read. Master: i2c@40015400, address: 0x54, off=14
Testing partial read. Master: i2c@40015400, address: 0x54, off=15
Testing partial read. Master: i2c@40015400, address: 0x54, off=16
Testing partial read. Master: i2c@40015400, address: 0x54, off=17
Testing partial read. Master: i2c@40015400, address: 0x54, off=18
Testing program. Master: i2c@40015400, address: 0x54, off=0
Testing program. Master: i2c@40015400, address: 0x54, off=1
Testing program. Master: i2c@40015400, address: 0x54, off=2
Testing program. Master: i2c@40015400, address: 0x54, off=3
Testing program. Master: i2c@40015400, address: 0x54, off=4
Testing program. Master: i2c@40015400, address: 0x54, off=5
Testing program. Master: i2c@40015400, address: 0x54, off=6
Testing program. Master: i2c@40015400, address: 0x54, off=7
Testing program. Master: i2c@40015400, address: 0x54, off=8
Testing program. Master: i2c@40015400, address: 0x54, off=9
Testing program. Master: i2c@40015400, address: 0x54, off=10
Testing program. Master: i2c@40015400, address: 0x54, off=11
Testing program. Master: i2c@40015400, address: 0x54, off=12
Testing program. Master: i2c@40015400, address: 0x54, off=13
Testing program. Master: i2c@40015400, address: 0x54, off=14
Testing program. Master: i2c@40015400, address: 0x54, off=15
Testing program. Master: i2c@40015400, address: 0x54, off=16
Testing program. Master: i2c@40015400, address: 0x54, off=17
Testing program. Master: i2c@40015400, address: 0x54, off=18
 PASS - test_eeprom_target in 0.277 seconds
===================================================================
TESTSUITE i2c_eeprom_target succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [i2c_eeprom_target]: pass = 1, fail = 0, skip = 1, total = 2 duration = 0.282 seconds
 - SKIP - [i2c_eeprom_target.test_deinit] duration = 0.005 seconds
 - PASS - [i2c_eeprom_target.test_eeprom_target] duration = 0.277 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
