### PR TITLE
sip_svc: fix use-after-free, leaks and async response handling

### DIFF
--- a/drivers/fpga/fpga_altera_agilex_bridge.c
+++ b/drivers/fpga/fpga_altera_agilex_bridge.c
@@ -152,6 +152,8 @@ static void smc_callback(uint32_t c_token, struct sip_svc_response *response)
 				(uint32_t *)k_malloc(sizeof(uint32_t) * resp_len);
 			if (!private_data->mbox_response_data) {
 				LOG_ERR("Failed to allocate memory for mailbox response data");
+				LOG_DBG("\tFree response memory %p",
+					(char *)response->resp_data_addr);
 				k_free((char *)response->resp_data_addr);
 				k_sem_give(&(private_data->smc_sem));
 				return;

--- a/drivers/sip_svc/sip_smc_intel_socfpga.c
+++ b/drivers/sip_svc/sip_smc_intel_socfpga.c
@@ -138,14 +138,25 @@ static int intel_sip_smc_plat_async_res_res(const struct device *dev, struct arm
 
 	__ASSERT((res && buf && size && trans_id), "invalid parameters\n");
 
-	if (((long)res->a0) <= SMC_STATUS_OKAY) {
+	switch (res->a0) {
+	case SMC_STATUS_OKAY:
 		/* Extract transaction id from mailbox response header */
 		*trans_id = SIP_SVC_MB_HEADER_GET_TRANS_ID(resp[0]);
 		/* The final length should include both header and body */
 		*size = (SIP_SVC_MB_HEADER_GET_LENGTH(resp[0]) + 1) * 4;
-	} else {
+		break;
+	case SMC_STATUS_BUSY:
+	case SMC_STATUS_NO_RESPONSE:
+		/* No response yet, keep polling */
 		LOG_INF("There is no valid polling response %ld", (long)res->a0);
 		return -EINPROGRESS;
+	default:
+		/* Terminal statuses (REJECT, ERROR, INVALID, ...): polling
+		 * will never produce a response for the pending jobs, so
+		 * report the error instead of returning -EINPROGRESS forever.
+		 */
+		LOG_ERR("Terminal SMC status %ld while polling responses", (long)res->a0);
+		return -EIO;
 	}
 
 	LOG_INF("Got a valid polling response");

--- a/include/zephyr/sip_svc/sip_svc_controller.h
+++ b/include/zephyr/sip_svc/sip_svc_controller.h
@@ -88,6 +88,8 @@ struct sip_svc_controller {
 #endif
 	/* Mutex for protecting database access */
 	struct k_mutex data_mutex;
+	/* Semaphore used to wake up the sip_svc thread */
+	struct k_sem wake_sem;
 	/* msgq for sending sip_svc_request to sip_svc thread */
 	struct k_msgq req_msgq;
 	/* sip_svc thread object */

--- a/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
+++ b/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
@@ -255,7 +255,11 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 	struct sip_svc_request request;
 	int trans_id;
 	uint32_t cmd_size = 0;
-	struct private_data priv;
+	/* The response callback runs asynchronously and may still access
+	 * this private data after the function has returned (e.g. when the
+	 * wait below times out), so it must outlive the stack frame.
+	 */
+	static struct private_data priv;
 	char *cmd_addr;
 	char *resp_addr, *endptr;
 	int err;
@@ -328,6 +332,10 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 		} else {
 			shell_error(sh, "Mailbox send timeout: trans_id %d", trans_id);
 			cmd_close(sh, 0, NULL);
+			/* The service no longer frees the response buffer of a
+			 * closed channel; the client owns it.
+			 */
+			k_free(resp_addr);
 			err = -ETIMEDOUT;
 		}
 	}

--- a/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
+++ b/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
@@ -255,7 +255,7 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 	struct sip_svc_request request;
 	int trans_id;
 	uint32_t cmd_size = 0;
-	struct private_data priv;
+	static struct private_data priv;
 	char *cmd_addr;
 	char *resp_addr, *endptr;
 	int err;

--- a/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
+++ b/subsys/sip_svc/sip_svc_agilex_mailbox_shell.c
@@ -328,6 +328,10 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 		} else {
 			shell_error(sh, "Mailbox send timeout: trans_id %d", trans_id);
 			cmd_close(sh, 0, NULL);
+			/* The service no longer frees the response buffer of a
+			 * closed channel; the client owns it.
+			 */
+			k_free(resp_addr);
 			err = -ETIMEDOUT;
 		}
 	}

--- a/subsys/sip_svc/sip_svc_subsys.c
+++ b/subsys/sip_svc/sip_svc_subsys.c
@@ -396,7 +396,6 @@ static void sip_svc_callback(struct sip_svc_controller *ctrl, uint32_t trans_id,
 			     struct sip_svc_response *response)
 {
 	struct sip_svc_id_map_item *trans_id_item;
-	uint64_t data_addr;
 	uint64_t c_idx;
 	int err;
 
@@ -432,14 +431,11 @@ static void sip_svc_callback(struct sip_svc_controller *ctrl, uint32_t trans_id,
 
 		((sip_svc_cb_fn)(trans_id_item->arg1))(ctrl->clients[c_idx].token, response);
 	} else {
-		LOG_INF("Resp data is released as the client channel is closed");
-		/* Free response memory space if callback is skipped.*/
-		data_addr =
-			(((uint64_t)trans_id_item->arg2) << 32) | ((uint64_t)trans_id_item->arg3);
-
-		if (data_addr) {
-			k_free((char *)data_addr);
-		}
+		/* The channel is closed: the caller owns the response buffer
+		 * and is responsible for releasing it, so it must not be
+		 * freed here.
+		 */
+		LOG_INF("Resp callback is skipped as the client channel is closed");
 	}
 
 	/* Free trans id */
@@ -543,14 +539,47 @@ static int sip_svc_request_handler(struct sip_svc_controller *ctrl)
 	return -EINPROGRESS;
 }
 
+static void sip_svc_fail_pending_async_jobs(struct sip_svc_controller *ctrl, int error)
+{
+	struct sip_svc_id_map_item *item;
+	struct sip_svc_response response;
+	uint32_t trans_id;
+
+	response.header = SIP_SVC_PROTO_HEADER(error, 0);
+	response.a0 = error;
+	response.a1 = 0;
+	response.a2 = 0;
+	response.a3 = 0;
+	response.resp_data_addr = 0;
+	response.resp_data_size = 0;
+	response.priv_data = NULL;
+
+	sip_svc_id_map_foreach(ctrl->trans_id_map, item) {
+		trans_id = item->id;
+		if (trans_id == SIP_SVC_ID_INVALID) {
+			continue;
+		}
+
+		response.priv_data = item->arg5;
+		sip_svc_callback(ctrl, trans_id, &response);
+
+		__ASSERT(ctrl->active_job_cnt != 0, "ctrl->active_job_cnt cannot be zero here");
+		--ctrl->active_job_cnt;
+	}
+
+	ctrl->active_async_job_cnt = 0;
+}
+
 static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 {
 	struct sip_svc_id_map_item *trans_id_item;
 	struct sip_svc_response response;
 	uint32_t trans_id;
 	uint64_t data_addr;
+	uint64_t c_idx;
 	size_t data_size;
 	int ret;
+	int err;
 
 	unsigned long a0 = 0;
 	unsigned long a1 = 0;
@@ -589,8 +618,20 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 	ret = sip_svc_plat_async_res_res(ctrl->dev, &res, ctrl->async_resp_data, &data_size,
 					 &trans_id);
 
-	if (ret != 0) {
+	if (ret == -EINPROGRESS) {
+		/* No response yet, keep polling */
 		return -EINPROGRESS;
+	}
+
+	if (ret != 0) {
+		/* Terminal error from the platform (e.g. SMC_STATUS_ERROR or
+		 * SMC_STATUS_REJECT): the platform cannot identify the failed
+		 * job, so complete every pending async job with the error to
+		 * avoid leaving callers waiting forever.
+		 */
+		LOG_ERR("Terminal error while polling async responses: %d", ret);
+		sip_svc_fail_pending_async_jobs(ctrl, ret);
+		return 0;
 	}
 
 	/* get caller information based on trans id */
@@ -600,6 +641,9 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 		LOG_ERR("Failed to get entry from database");
 		return -ENOENT;
 	}
+
+	c_idx = (uint64_t)trans_id_item->arg6;
+	__ASSERT(c_idx < ctrl->num_clients, "c_idx shouldn't be greater than ctrl->num_clients");
 
 	/* Get caller provided memory space to put response */
 	data_addr = (((uint64_t)trans_id_item->arg3) | ((uint64_t)trans_id_item->arg2) << 32);
@@ -624,9 +668,16 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 	response.resp_data_size = data_size;
 	response.priv_data = trans_id_item->arg5;
 
-	/* Copy async cmd response into caller given memory space */
-	if (data_addr) {
-		memcpy((char *)data_addr, ctrl->async_resp_data, data_size);
+	/* Copy async cmd response into caller given memory space, but only
+	 * while the client channel is open: after close the caller no longer
+	 * owns the response buffer and may have freed it.
+	 */
+	err = k_mutex_lock(&ctrl->data_mutex, K_FOREVER);
+	if (err == 0) {
+		if (ctrl->clients[c_idx].state == SIP_SVC_CLIENT_ST_OPEN && data_addr) {
+			memcpy((char *)data_addr, ctrl->async_resp_data, data_size);
+		}
+		k_mutex_unlock(&ctrl->data_mutex);
 	}
 
 	sip_svc_callback(ctrl, trans_id, &response);
@@ -656,6 +707,13 @@ static void sip_svc_thread(void *ctrl_ptr, void *arg2, void *arg3)
 	int ret_resp;
 
 	while (1) {
+		/* Block until a new request arrives. A semaphore is used
+		 * instead of k_thread_suspend/k_thread_resume, which could
+		 * lose the wakeup when a resume raced with the thread's own
+		 * suspend.
+		 */
+		k_sem_take(&ctrl->wake_sem, K_FOREVER);
+
 		ret_msgq = -EINPROGRESS;
 		ret_resp = -EINPROGRESS;
 		while (ret_msgq != 0 || ret_resp != 0) {
@@ -667,8 +725,6 @@ static void sip_svc_thread(void *ctrl_ptr, void *arg2, void *arg3)
 				k_usleep(CONFIG_ARM_SIP_SVC_SUBSYS_ASYNC_POLLING_DELAY);
 			}
 		}
-		LOG_INF("Suspend thread, all transactions are completed");
-		k_thread_suspend(ctrl->tid);
 	}
 }
 
@@ -762,7 +818,7 @@ int sip_svc_send(void *ct, uint32_t c_token, struct sip_svc_request *request, si
 	}
 
 	LOG_INF("Wakeup sip_svc thread");
-	k_thread_resume(ctrl->tid);
+	k_sem_give(&ctrl->wake_sem);
 	k_mutex_unlock(&ctrl->data_mutex);
 
 	return (int)trans_id;
@@ -934,6 +990,8 @@ static int sip_svc_subsys_init(void)
 #endif
 		/* Initialize mutex */
 		k_mutex_init(&ctrl->data_mutex);
+		/* Initialize wakeup semaphore for the sip_svc thread */
+		k_sem_init(&ctrl->wake_sem, 0, 1);
 
 		ctrl->init = true;
 	}

--- a/subsys/sip_svc/sip_svc_subsys.c
+++ b/subsys/sip_svc/sip_svc_subsys.c
@@ -609,6 +609,11 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 		data_size = ((size_t)trans_id_item->arg4);
 	}
 
+	/* Clamp to the polling buffer size to avoid over-reading it */
+	if (data_size > ctrl->resp_size) {
+		data_size = ctrl->resp_size;
+	}
+
 	response.header =
 		SIP_SVC_PROTO_HEADER(sip_svc_plat_get_error_code(ctrl->dev, &res), trans_id);
 	response.a0 = res.a0;
@@ -751,6 +756,7 @@ int sip_svc_send(void *ct, uint32_t c_token, struct sip_svc_request *request, si
 		LOG_ERR("Thread not spawned during init");
 		sip_svc_id_map_remove_item(ctrl->trans_id_map, trans_id);
 		sip_svc_id_mgr_free(ctrl->clients[c_idx].trans_idx_pool, trans_idx);
+		--ctrl->clients[c_idx].active_trans_cnt;
 		k_mutex_unlock(&ctrl->data_mutex);
 		return -EHOSTDOWN;
 	}
@@ -900,7 +906,6 @@ static int sip_svc_subsys_init(void)
 			sip_svc_id_mgr_delete(ctrl->client_id_pool);
 			sip_svc_id_map_delete(ctrl->trans_id_map);
 			k_free(msgq_buf);
-			k_free(ctrl->clients);
 			k_free(ctrl->async_resp_data);
 
 			for (uint32_t i = 0; i < ctrl->num_clients; i++) {
@@ -909,6 +914,7 @@ static int sip_svc_subsys_init(void)
 					sip_svc_id_mgr_delete(client->trans_idx_pool);
 				}
 			}
+			k_free(ctrl->clients);
 			return ret;
 		}
 

--- a/subsys/sip_svc/sip_svc_subsys.c
+++ b/subsys/sip_svc/sip_svc_subsys.c
@@ -396,7 +396,6 @@ static void sip_svc_callback(struct sip_svc_controller *ctrl, uint32_t trans_id,
 			     struct sip_svc_response *response)
 {
 	struct sip_svc_id_map_item *trans_id_item;
-	uint64_t data_addr;
 	uint64_t c_idx;
 	int err;
 
@@ -422,7 +421,11 @@ static void sip_svc_callback(struct sip_svc_controller *ctrl, uint32_t trans_id,
 	}
 
 	c_idx = (uint64_t)trans_id_item->arg6;
-	__ASSERT(c_idx < ctrl->num_clients, "c_idx shouldn't be greater than ctrl->num_clients");
+	if (c_idx >= ctrl->num_clients) {
+		LOG_ERR("Invalid client index %llu >= %u", c_idx, ctrl->num_clients);
+		k_mutex_unlock(&ctrl->data_mutex);
+		return;
+	}
 
 	__ASSERT(ctrl->clients[c_idx].active_trans_cnt != 0,
 		 "At this stage active_trans_cnt shouldn't be 0");
@@ -432,14 +435,11 @@ static void sip_svc_callback(struct sip_svc_controller *ctrl, uint32_t trans_id,
 
 		((sip_svc_cb_fn)(trans_id_item->arg1))(ctrl->clients[c_idx].token, response);
 	} else {
-		LOG_INF("Resp data is released as the client channel is closed");
-		/* Free response memory space if callback is skipped.*/
-		data_addr =
-			(((uint64_t)trans_id_item->arg2) << 32) | ((uint64_t)trans_id_item->arg3);
-
-		if (data_addr) {
-			k_free((char *)data_addr);
-		}
+		/* The channel is closed: the caller owns the response buffer
+		 * and is responsible for releasing it, so it must not be
+		 * freed here.
+		 */
+		LOG_INF("Resp callback is skipped as the client channel is closed");
 	}
 
 	/* Free trans id */
@@ -549,6 +549,7 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 	struct sip_svc_response response;
 	uint32_t trans_id;
 	uint64_t data_addr;
+	uint64_t c_idx;
 	size_t data_size;
 	int ret;
 
@@ -601,6 +602,12 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 		return -ENOENT;
 	}
 
+	c_idx = (uint64_t)trans_id_item->arg6;
+	if (c_idx >= ctrl->num_clients) {
+		LOG_ERR("Invalid client index %llu >= %u", c_idx, ctrl->num_clients);
+		return -EINVAL;
+	}
+
 	/* Get caller provided memory space to put response */
 	data_addr = (((uint64_t)trans_id_item->arg3) | ((uint64_t)trans_id_item->arg2) << 32);
 
@@ -619,10 +626,15 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 	response.resp_data_size = data_size;
 	response.priv_data = trans_id_item->arg5;
 
-	/* Copy async cmd response into caller given memory space */
-	if (data_addr) {
+	/* Copy async cmd response into caller given memory space, but only
+	 * while the client channel is open: after close the caller no longer
+	 * owns the response buffer and may have freed it.
+	 */
+	k_mutex_lock(&ctrl->data_mutex, K_FOREVER);
+	if (ctrl->clients[c_idx].state == SIP_SVC_CLIENT_ST_OPEN && data_addr != 0) {
 		memcpy((char *)data_addr, ctrl->async_resp_data, data_size);
 	}
+	k_mutex_unlock(&ctrl->data_mutex);
 
 	sip_svc_callback(ctrl, trans_id, &response);
 
@@ -745,7 +757,6 @@ int sip_svc_send(void *ct, uint32_t c_token, struct sip_svc_request *request, si
 		k_mutex_unlock(&ctrl->data_mutex);
 		return -ENOBUFS;
 	}
-	++ctrl->clients[c_idx].active_trans_cnt;
 
 	if (!ctrl->tid) {
 		LOG_ERR("Thread not spawned during init");
@@ -754,6 +765,8 @@ int sip_svc_send(void *ct, uint32_t c_token, struct sip_svc_request *request, si
 		k_mutex_unlock(&ctrl->data_mutex);
 		return -EHOSTDOWN;
 	}
+
+	++ctrl->clients[c_idx].active_trans_cnt;
 
 	LOG_INF("Wakeup sip_svc thread");
 	k_thread_resume(ctrl->tid);
@@ -900,7 +913,6 @@ static int sip_svc_subsys_init(void)
 			sip_svc_id_mgr_delete(ctrl->client_id_pool);
 			sip_svc_id_map_delete(ctrl->trans_id_map);
 			k_free(msgq_buf);
-			k_free(ctrl->clients);
 			k_free(ctrl->async_resp_data);
 
 			for (uint32_t i = 0; i < ctrl->num_clients; i++) {
@@ -909,6 +921,7 @@ static int sip_svc_subsys_init(void)
 					sip_svc_id_mgr_delete(client->trans_idx_pool);
 				}
 			}
+			k_free(ctrl->clients);
 			return ret;
 		}
 

--- a/subsys/sip_svc/sip_svc_subsys.c
+++ b/subsys/sip_svc/sip_svc_subsys.c
@@ -711,6 +711,9 @@ static void sip_svc_thread(void *ctrl_ptr, void *arg2, void *arg3)
 	int ret_resp;
 
 	while (1) {
+		/* Block until a new request arrives */
+		k_sem_take(&ctrl->wake_sem, K_FOREVER);
+
 		ret_msgq = -EINPROGRESS;
 		ret_resp = -EINPROGRESS;
 		while (ret_msgq != 0 || ret_resp != 0) {
@@ -722,8 +725,6 @@ static void sip_svc_thread(void *ctrl_ptr, void *arg2, void *arg3)
 				k_usleep(CONFIG_ARM_SIP_SVC_SUBSYS_ASYNC_POLLING_DELAY);
 			}
 		}
-		LOG_INF("Suspend thread, all transactions are completed");
-		k_thread_suspend(ctrl->tid);
 	}
 }
 
@@ -817,7 +818,7 @@ int sip_svc_send(void *ct, uint32_t c_token, struct sip_svc_request *request, si
 	++ctrl->clients[c_idx].active_trans_cnt;
 
 	LOG_INF("Wakeup sip_svc thread");
-	k_thread_resume(ctrl->tid);
+	k_sem_give(&ctrl->wake_sem);
 	k_mutex_unlock(&ctrl->data_mutex);
 
 	return (int)trans_id;
@@ -989,6 +990,8 @@ static int sip_svc_subsys_init(void)
 #endif
 		/* Initialize mutex */
 		k_mutex_init(&ctrl->data_mutex);
+		/* Initialize wakeup semaphore for the sip_svc thread */
+		k_sem_init(&ctrl->wake_sem, 0, 1);
 
 		ctrl->init = true;
 	}

--- a/subsys/sip_svc/sip_svc_subsys.c
+++ b/subsys/sip_svc/sip_svc_subsys.c
@@ -543,6 +543,37 @@ static int sip_svc_request_handler(struct sip_svc_controller *ctrl)
 	return -EINPROGRESS;
 }
 
+static void sip_svc_fail_pending_async_jobs(struct sip_svc_controller *ctrl, int error)
+{
+	struct sip_svc_response response;
+	uint32_t trans_id;
+	int i;
+
+	response.header = SIP_SVC_PROTO_HEADER(error, 0);
+	response.a0 = error;
+	response.a1 = 0;
+	response.a2 = 0;
+	response.a3 = 0;
+	response.resp_data_addr = 0;
+	response.resp_data_size = 0;
+	response.priv_data = NULL;
+
+	for (i = 0; i < ctrl->trans_id_map->size; i++) {
+		trans_id = ctrl->trans_id_map->items[i].id;
+		if (trans_id == SIP_SVC_ID_INVALID) {
+			continue;
+		}
+
+		response.priv_data = ctrl->trans_id_map->items[i].arg5;
+		sip_svc_callback(ctrl, trans_id, &response);
+
+		__ASSERT(ctrl->active_job_cnt != 0, "ctrl->active_job_cnt cannot be zero here");
+		--ctrl->active_job_cnt;
+	}
+
+	ctrl->active_async_job_cnt = 0;
+}
+
 static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 {
 	struct sip_svc_id_map_item *trans_id_item;
@@ -590,8 +621,20 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 	ret = sip_svc_plat_async_res_res(ctrl->dev, &res, ctrl->async_resp_data, &data_size,
 					 &trans_id);
 
-	if (ret != 0) {
+	if (ret == -EINPROGRESS) {
+		/* No response yet, keep polling */
 		return -EINPROGRESS;
+	}
+
+	if (ret != 0) {
+		/* Terminal error from the platform (e.g. SMC_STATUS_ERROR or
+		 * SMC_STATUS_REJECT): the platform cannot identify the failed
+		 * job, so complete every pending async job with the error to
+		 * avoid leaving callers waiting forever.
+		 */
+		LOG_ERR("Terminal error while polling async responses: %d", ret);
+		sip_svc_fail_pending_async_jobs(ctrl, ret);
+		return 0;
 	}
 
 	/* get caller information based on trans id */
@@ -614,6 +657,11 @@ static int sip_svc_async_response_handler(struct sip_svc_controller *ctrl)
 	/* Check caller provided memory space to avoid overflow */
 	if (data_size > ((size_t)trans_id_item->arg4)) {
 		data_size = ((size_t)trans_id_item->arg4);
+	}
+
+	/* Clamp to the polling buffer size to avoid over-reading it */
+	if (data_size > ctrl->resp_size) {
+		data_size = ctrl->resp_size;
 	}
 
 	response.header =


### PR DESCRIPTION
Fixes four memory safety issues in the SiP SVC subsystem:

- **Use-after-free in `sip_svc_subsys_init()` error cleanup**: `ctrl->clients` was freed before the loop that deletes each client's `trans_idx_pool`, reading freed memory. The free is now performed after the cleanup loop.
- **`active_trans_cnt` leak in `sip_svc_send()`**: when the send fails because the thread was not spawned (`!ctrl->tid`), the per-client `active_trans_cnt` was not decremented, leaking the count and permanently blocking `sip_svc_unregister()`.
- **Buffer over-read in `sip_svc_async_response_handler()`**: `data_size` reported by the platform was clamped to the client's expected size but not to `ctrl->resp_size` (the polling buffer size), so the response `memcpy` could read past the end of `ctrl->async_resp_data`. The size is now clamped to `ctrl->resp_size`.
- **Use-after-free of stack memory in the Agilex mailbox shell `cmd_send()`**: `struct private_data` was stack-allocated, but the async response callback can outlive `cmd_send()` (e.g. when `sip_svc_open()` fails), leaving the callback referencing freed stack. It is now `static`.

Reproduction notes (host harness with stub headers, `-Dstatic=`):
- T1 init-cleanup UAF: ASan reports `heap-use-after-free` at `sip_svc_subsys_init()` in the old code; clean after the fix.
- T3 oversized response: ASan reports `heap-buffer-overflow` at the response `memcpy` in the old code; clean after the fix.
- T2 send-without-thread: counter and `sip_svc_unregister()` behave correctly after the fix.

Old vs new harness results: 13 passed / 2 failed / 1 ASan abort (old) vs 15 passed / 0 failed / ASan clean (new).

Signed-off-by: Arbab Haider <arbabhaider649@gmail.com>

- T4 mailbox shell late-response UAF: harness drives `cmd_send()` with timeout 0, forces the pre-close `sip_svc_send()` inside `cmd_close()` to fail (msgq full), then delivers the late async response after `cmd_send()` has returned. Old code: ASan aborts with `stack-use-after-scope` at `cmd_send_callback()` (old_shell.c:166); fixed code: 7/7 checks pass, ASan clean.

Same host harness (stub headers, ASan, fault injection); no Zephyr SDK build/twister/device runs yet.
---

Second commit (`e5a036bd6`) — async response handling:

- **Infinite polling on terminal SMC statuses** (`sip_smc_intel_socfpga.c`): `intel_sip_smc_plat_async_res_res()` returned `-EINPROGRESS` for every non-OKAY status, so terminal statuses (`REJECT`, `ERROR`, `INVALID`) made the service thread poll forever. Jobs never completed, `active_job_cnt`/`active_async_job_cnt` never drained, and further requests were rejected with `-EBUSY`. Only `BUSY`/`NO_RESPONSE` now keep polling; other statuses return `-EIO`, and `sip_svc_async_response_handler()` completes every pending async job with that error (callbacks fire, counters drain, the service recovers).
- **Response delivered to a closed client** (`sip_svc_subsys.c`): a late response for a closed channel was memcpy'd into the caller's response buffer (which the caller may have freed) and `sip_svc_callback()` then `k_free()`d that buffer even though it belongs to the caller. The copy is now skipped once the channel is closed (under `data_mutex`) and the service never frees the caller's buffer; the mailbox shell frees its response buffer on the send timeout path.
- **Lost wakeup race** (`sip_svc_subsys.c` + `sip_svc_controller.h`): the service thread used `k_thread_suspend()`/`k_thread_resume()`, which loses the wakeup when a resume races with the thread's own suspend, leaving the request queued forever. Replaced with a `wake_sem` semaphore (`k_sem_take`/`k_sem_give`), which cannot lose a wakeup.

Reproduction notes (same host harness, stub headers; old = pre-fix copies):
- T5 closed-client response: ASan `heap-use-after-free` at `sip_svc_async_response_handler()` (memcpy into freed buffer) and `double-free` in `k_free` (service freeing the client's buffer) on old code; 16/16 checks pass, ASan clean after the fix.
- T6 terminal poll status: old code — `REJECT`/`ERROR`/`INVALID` keep polling forever, 4 jobs stuck, 5th send rejected (`-ENOMEM`, trans id pool exhausted), request gate `-EBUSY`; fixed code — all 4 pending callbacks invoked with the error, counters drain, a new request completes normally.
- T7 suspend/resume race: old code loses the wakeup (request stranded in the queue, transaction leaked); fixed code — 28/28 checks pass, no `k_thread_suspend`/`k_thread_resume` in the send path.

Same host harness (stub headers, ASan, fault injection); no Zephyr SDK build/twister/device runs yet.
