### PR TITLE
cmake: modules: soc: Deprecate SOC_NAME, SOC_SERIES and SOC_FAMILY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2364,7 +2364,7 @@ endif()
 
 if(CONFIG_SOC_DEPRECATED_RELEASE)
   message(WARNING "
-      WARNING:  The SoC '${SOC_NAME}' is deprecated and will be
+      WARNING:  The SoC '${CONFIG_SOC}' is deprecated and will be
       removed in version ${CONFIG_SOC_DEPRECATED_RELEASE}"
   )
 endif()

--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -37,6 +37,21 @@ if("${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(WARNING "find_package(Deprecated) missing required COMPONENTS keyword")
 endif()
 
+if("soc_vars" IN_LIST Deprecated_FIND_COMPONENTS)
+  # This code has been deprecated after Zephyr 4.4
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS soc_vars)
+  set(SOC_NAME   ${CONFIG_SOC})
+  set(SOC_SERIES ${CONFIG_SOC_SERIES})
+  set(SOC_FAMILY ${CONFIG_SOC_FAMILY})
+  set(SOC_V2_DIR ${SOC_FULL_DIR})
+
+  # Adds a watch for these deprecated variables to emit a warning
+  variable_watch(SOC_NAME deprecated_soc_var)
+  variable_watch(SOC_SERIES deprecated_soc_var)
+  variable_watch(SOC_FAMILY deprecated_soc_var)
+  variable_watch(SOC_V2_DIR deprecated_soc_var)
+endif()
+
 if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(STATUS "The following deprecated component(s) could not be found: "
     "${Deprecated_FIND_COMPONENTS}")

--- a/cmake/modules/soc.cmake
+++ b/cmake/modules/soc.cmake
@@ -10,9 +10,9 @@
 # Outcome:
 # The following variables will be defined when this CMake module completes:
 #
-# - SOC_NAME:   Name of the SoC in use, identical to CONFIG_SOC
-# - SOC_SERIES: Name of the SoC series in use, identical to CONFIG_SOC_SERIES
-# - SOC_FAMILY: Name of the SoC family, identical to CONFIG_SOC_FAMILY
+# - SOC_FULL_DIR: Full directory of where the SoC files are located
+# - SOC_DIRECTORIES: List of directories where SoC files which include this SoC are located
+# - SOC_TOOLCHAIN_NAME: Optional toolchain name of the SoC
 #
 # Variables set by this module and not mentioned above are considered internal
 # use only and may be removed, renamed, or re-purposed without prior notice.
@@ -21,15 +21,20 @@ include_guard(GLOBAL)
 
 include(kconfig)
 
-set(SOC_NAME   ${CONFIG_SOC})
-set(SOC_SERIES ${CONFIG_SOC_SERIES})
+function(deprecated_soc_var variable access value current_list_file stack)
+  message(DEPRECATION "Variable ${variable} is deprecated, please check the Zephyr 4.5 migration "
+    "guide and update usage of this variable."
+  )
+endfunction()
+
 set(SOC_TOOLCHAIN_NAME ${CONFIG_SOC_TOOLCHAIN_NAME})
-set(SOC_FAMILY ${CONFIG_SOC_FAMILY})
-set(SOC_V2_DIR ${SOC_${SOC_NAME}_DIR})
-set(SOC_FULL_DIR ${SOC_V2_DIR} CACHE PATH "Path to the SoC directory." FORCE)
-set(SOC_DIRECTORIES ${SOC_${SOC_NAME}_DIRECTORIES} CACHE INTERNAL
-    "List of SoC directories for SoC (${SOC_NAME})" FORCE
+set(SOC_FULL_DIR ${SOC_${CONFIG_SOC}_DIR} CACHE PATH "Path to the SoC directory." FORCE)
+set(SOC_DIRECTORIES ${SOC_${CONFIG_SOC}_DIRECTORIES} CACHE INTERNAL
+    "List of SoC directories for SoC (${CONFIG_SOC})" FORCE
 )
+
+find_package(Deprecated COMPONENTS soc_vars)
+
 foreach(dir ${SOC_DIRECTORIES})
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${dir}/soc.yml)
 endforeach()

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -37,6 +37,11 @@ Build System
 * :kconfig:option:`CONFIG_LEGACY_GENERATED_INCLUDE_PATH` has been deprecated, and disabled by
   default, includes must now be prefixed with ``zephyr/`` for zephyr files.
 
+* CMake variables ``SOC_NAME``, ``SOC_SERIES``, ``SOC_FAMILY`` and ``SOC_V2_DIR`` have been
+  deprecated as they duplicate variables already, the replacement variables are as follows:
+  :kconfig:option:`CONFIG_SOC`, :kconfig:option:`CONFIG_SOC_SERIES`,
+  :kconfig:option:`CONFIG_SOC_FAMILY` and ``SOC_FULL_DIR``.
+
 Kernel
 ******
 

--- a/drivers/wifi/bflb/CMakeLists.txt
+++ b/drivers/wifi/bflb/CMakeLists.txt
@@ -5,9 +5,9 @@
 set(BFLB_HAL ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR})
 
 zephyr_include_directories(
-  ${BFLB_HAL}/include/bouffalolab/${SOC_SERIES}
-  ${BFLB_HAL}/include/bouffalolab/${SOC_SERIES}/wifi
-  ${BFLB_HAL}/include/bouffalolab/${SOC_SERIES}/rfparam
+  ${BFLB_HAL}/include/bouffalolab/${CONFIG_SOC_SERIES}
+  ${BFLB_HAL}/include/bouffalolab/${CONFIG_SOC_SERIES}/wifi
+  ${BFLB_HAL}/include/bouffalolab/${CONFIG_SOC_SERIES}/rfparam
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/modules/hal_bouffalolab/CMakeLists.txt
+++ b/modules/hal_bouffalolab/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 if(CONFIG_SOC_FAMILY_BFLB)
   zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include)
-  zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES})
+  zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES})
 
   if(CONFIG_BFLB_FREERTOS_SHIM OR CONFIG_BFLB_BTBLE_PORT_OS_SHIM OR CONFIG_WIFI_BFLB)
     add_subdirectory(shim)

--- a/modules/hal_bouffalolab/src/bl60x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl60x/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 if(CONFIG_BT_BFLB_BL60X)
   zephyr_include_directories(
-    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/ble)
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES}/ble)
 
   if(CONFIG_BFLB_BL60X_BLE_M1S1)
     set(BLE_VARIANT_LIB libblecontroller_bl602_m1s1.a)
@@ -13,7 +13,7 @@ if(CONFIG_BT_BFLB_BL60X)
   endif()
 
   message(STATUS "BL60x BLE controller: ${BLE_VARIANT_LIB}")
-  set(BLE_BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES})
+  set(BLE_BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES})
 
   set(PHYRF_LIB libbl602_phyrf.a)
 

--- a/modules/hal_bouffalolab/src/bl61x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl61x/CMakeLists.txt
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES})
+set(BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES})
 
 if(CONFIG_BT_BFLB_BL61X)
   zephyr_include_directories(
-    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/ble)
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES}/ble)
 
   # Select controller variant
   if(CONFIG_BFLB_BL61X_BLE_1M0S1)

--- a/modules/hal_bouffalolab/src/bl70x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl70x/CMakeLists.txt
@@ -3,9 +3,9 @@
 
 if(CONFIG_BT_BFLB_BL70X)
   zephyr_include_directories(
-    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/ble)
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES}/ble)
   zephyr_include_directories(
-    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/rf)
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES}/rf)
 
   # Select controller library based on Kconfig variant
   if(CONFIG_BFLB_BL70X_BLE_M0S1P)
@@ -26,7 +26,7 @@ if(CONFIG_BT_BFLB_BL70X)
 
   message(STATUS "BL70x BLE controller variant: ${BLE_VARIANT_LIB}")
 
-  set(BLE_BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES})
+  set(BLE_BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES})
 
   if(NOT CONFIG_BUILD_ONLY_NO_BLOBS)
     zephyr_link_libraries(

--- a/modules/hal_bouffalolab/src/bl70xl/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl70xl/CMakeLists.txt
@@ -3,9 +3,9 @@
 
 if(CONFIG_BT_BFLB_BL70XL)
   zephyr_include_directories(
-    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/ble)
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES}/ble)
   zephyr_include_directories(
-    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/rf)
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES}/rf)
 
   # Select controller library and per-variant parameters
   if(CONFIG_BFLB_BL70XL_BLE_M0S1P)
@@ -35,9 +35,9 @@ if(CONFIG_BT_BFLB_BL70XL)
       set(BL70XL_ROM_LIB libbl702l_rom_a0.a)
     endif()
     zephyr_link_libraries(
-      ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES}/${BLE_VARIANT_LIB}
-      ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES}/libbl702l_rf.a
-      ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES}/${BL70XL_ROM_LIB}
+      ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES}/${BLE_VARIANT_LIB}
+      ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES}/libbl702l_rf.a
+      ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES}/${BL70XL_ROM_LIB}
     )
   endif()
 endif()

--- a/modules/hal_nxp/s32/CMakeLists.txt
+++ b/modules/hal_nxp/s32/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Set the SoC specific drivers and configuration to build
 set(SOC_BASE ${CONFIG_SOC})
 
-add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/s32/drivers/${SOC_SERIES} hal_nxp/s32/drivers)
+add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/s32/drivers/${CONFIG_SOC_SERIES} hal_nxp/s32/drivers)
 add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/s32/soc/${SOC_BASE} hal_nxp/s32/soc)
 
 if(CONFIG_HAS_MCUX)

--- a/soc/CMakeLists.txt
+++ b/soc/CMakeLists.txt
@@ -12,19 +12,19 @@ unset(_SOC_IS_IN_TREE)
 add_subdirectory(common)
 
 # Below is inclusion of HWMv2 SoC CMake lists.
-string(TOUPPER SOC_FAMILY_${SOC_FAMILY}_DIR family_setting_dir)
-string(TOUPPER SOC_SERIES_${SOC_SERIES}_DIR series_setting_dir)
-string(TOUPPER SOC_${SOC_NAME}_DIR soc_setting_dir)
+string(TOUPPER SOC_FAMILY_${CONFIG_SOC_FAMILY}_DIR family_setting_dir)
+string(TOUPPER SOC_SERIES_${CONFIG_SOC_SERIES}_DIR series_setting_dir)
+string(TOUPPER SOC_${CONFIG_SOC}_DIR soc_setting_dir)
 
 if(DEFINED ${soc_setting_dir})
-  add_subdirectory(${${soc_setting_dir}} soc/${SOC_NAME})
+  add_subdirectory(${${soc_setting_dir}} soc/${CONFIG_SOC})
 elseif(DEFINED ${series_setting_dir})
-  add_subdirectory(${${series_setting_dir}} soc/${SOC_SERIES})
+  add_subdirectory(${${series_setting_dir}} soc/${CONFIG_SOC_SERIES})
 elseif(DEFINED ${family_setting_dir})
-  add_subdirectory(${${family_setting_dir}} soc/${SOC_FAMILY})
+  add_subdirectory(${${family_setting_dir}} soc/${CONFIG_SOC_FAMILY})
 else()
-  message(FATAL_ERROR "No CMakeLists.txt file found for SoC: ${SOC_NAME}, "
-                      "series: ${SOC_SERIES}, family: ${SOC_FAMILY}")
+  message(FATAL_ERROR "No CMakeLists.txt file found for SoC: ${CONFIG_SOC}, "
+                      "series: ${CONFIG_SOC_SERIES}, family: ${CONFIG_SOC_FAMILY}")
 endif()
 
 # Include all SoC roots except Zephyr, as we are already in the Zephyr SoC root.

--- a/soc/aesc/CMakeLists.txt
+++ b/soc/aesc/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 zephyr_include_directories(.)
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 add_subdirectory(common)

--- a/soc/aesc/nitrogen/CMakeLists.txt
+++ b/soc/aesc/nitrogen/CMakeLists.txt
@@ -1,5 +1,5 @@
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld
-    CACHE INTERNAL "SoC Linker script ${SOC_NAME}"
+    CACHE INTERNAL "SoC Linker script"
 )

--- a/soc/alif/balletto/CMakeLists.txt
+++ b/soc/alif/balletto/CMakeLists.txt
@@ -4,4 +4,4 @@
 zephyr_include_directories(.)
 zephyr_include_directories(../common)
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/alif/ensemble/CMakeLists.txt
+++ b/soc/alif/ensemble/CMakeLists.txt
@@ -14,4 +14,4 @@ if(CONFIG_SOC_FAMILY_ENSEMBLE_APSS)
   add_subdirectory(apss)
 endif()
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/ambiq/CMakeLists.txt
+++ b/soc/ambiq/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_include_directories(.)
 

--- a/soc/andestech/CMakeLists.txt
+++ b/soc/andestech/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2024 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/arm/CMakeLists.txt
+++ b/soc/arm/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED SOC_SERIES)
-  add_subdirectory(${SOC_SERIES})
+if(DEFINED CONFIG_SOC_SERIES)
+  add_subdirectory(${CONFIG_SOC_SERIES})
 else()
-  add_subdirectory(${SOC_NAME})
+  add_subdirectory(${CONFIG_SOC})
 endif()

--- a/soc/aspeed/CMakeLists.txt
+++ b/soc/aspeed/CMakeLists.txt
@@ -2,6 +2,6 @@
 #
 # Copyright (c) 2021 ASPEED Technology Inc.
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_include_directories(.)

--- a/soc/aspeed/ast10x0/CMakeLists.txt
+++ b/soc/aspeed/ast10x0/CMakeLists.txt
@@ -8,9 +8,9 @@ zephyr_include_directories(.)
 zephyr_linker_sources(ROM_START SORT_KEY 0x1sboot sboot.ld)
 zephyr_linker_sources(RAM_SECTIONS nocache.ld)
 
-string(TOUPPER "${SOC_NAME}" soc_name_upper)
+string(TOUPPER "${CONFIG_SOC}" soc_name_upper)
 set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-  COMMAND ${PYTHON_EXECUTABLE} ${SOC_${soc_name_upper}_DIR}/${SOC_SERIES}/tools/gen_uart_booting_image.py
+  COMMAND ${PYTHON_EXECUTABLE} ${SOC_${soc_name_upper}_DIR}/${CONFIG_SOC_SERIES}/tools/gen_uart_booting_image.py
   ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
   ${PROJECT_BINARY_DIR}/uart_${CONFIG_KERNEL_BIN_NAME}.bin
 )

--- a/soc/atmel/sam/CMakeLists.txt
+++ b/soc/atmel/sam/CMakeLists.txt
@@ -6,4 +6,4 @@
 #
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/atmel/sam0/CMakeLists.txt
+++ b/soc/atmel/sam0/CMakeLists.txt
@@ -7,4 +7,4 @@
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/bflb/CMakeLists.txt
+++ b/soc/bflb/CMakeLists.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/bflb/bl61x/CMakeLists.txt
+++ b/soc/bflb/bl61x/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 if(CONFIG_WIFI_BFLB)
   zephyr_include_directories(
-    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/wifi
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${CONFIG_SOC_SERIES}/wifi
   )
   zephyr_sources(
     wifi/bflb_wifi_platform.c

--- a/soc/brcm/bcmvk/CMakeLists.txt
+++ b/soc/brcm/bcmvk/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/egis/CMakeLists.txt
+++ b/soc/egis/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2025 Egis Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_NAME})
+add_subdirectory(${CONFIG_SOC})

--- a/soc/ene/kb106x/CMakeLists.txt
+++ b/soc/ene/kb106x/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/espressif/CMakeLists.txt
+++ b/soc/espressif/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/gd/gd32/CMakeLists.txt
+++ b/soc/gd/gd32/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/infineon/cat1b/CMakeLists.txt
+++ b/soc/infineon/cat1b/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/infineon/cat1c/CMakeLists.txt
+++ b/soc/infineon/cat1c/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/infineon/cat3/CMakeLists.txt
+++ b/soc/infineon/cat3/CMakeLists.txt
@@ -3,6 +3,6 @@
 # Copyright (c) 2020 Linumiz
 # Author: Parthiban Nallathambi <parthiban@linumiz.com>
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_compile_definitions($<UPPER_CASE:${CONFIG_SOC}>_${CONFIG_SOC_PART_NUMBER})

--- a/soc/infineon/psoc4/CMakeLists.txt
+++ b/soc/infineon/psoc4/CMakeLists.txt
@@ -3,5 +3,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/common)

--- a/soc/intel/intel_ish/CMakeLists.txt
+++ b/soc/intel/intel_ish/CMakeLists.txt
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/intel/intel_niosv/CMakeLists.txt
+++ b/soc/intel/intel_niosv/CMakeLists.txt
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/intel/intel_socfpga/CMakeLists.txt
+++ b/soc/intel/intel_socfpga/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 add_subdirectory(common)
 
 zephyr_include_directories(common)

--- a/soc/intel/intel_socfpga_std/CMakeLists.txt
+++ b/soc/intel/intel_socfpga_std/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/ite/ec/CMakeLists.txt
+++ b/soc/ite/ec/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/ite/ec/it51xxx/CMakeLists.txt
+++ b/soc/ite/ec/it51xxx/CMakeLists.txt
@@ -4,5 +4,5 @@ zephyr_include_directories(.)
 zephyr_sources_ifdef(CONFIG_SOC_IT51XXX_USE_ILM ../it8xxx2/ilm.c ilm_wrapper.c)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld
-    CACHE INTERNAL "SoC Linker script ${SOC_NAME}"
+    CACHE INTERNAL "SoC Linker script"
 )

--- a/soc/ite/ec/it8xxx2/CMakeLists.txt
+++ b/soc/ite/ec/it8xxx2/CMakeLists.txt
@@ -5,5 +5,5 @@ zephyr_library_sources_ifndef(CONFIG_RISCV_ISA_EXT_M __arithmetic.S)
 zephyr_sources_ifdef(CONFIG_SOC_IT8XXX2_USE_ILM ilm.c)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld
-    CACHE INTERNAL "SoC Linker script ${SOC_NAME}"
+    CACHE INTERNAL "SoC Linker script"
 )

--- a/soc/litex/CMakeLists.txt
+++ b/soc/litex/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/microchip/mec/CMakeLists.txt
+++ b/soc/microchip/mec/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 add_subdirectory(common)

--- a/soc/microchip/miv/CMakeLists.txt
+++ b/soc/microchip/miv/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2024 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/microchip/pic32c/pic32ck_sg_gc/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32ck_sg_gc/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})

--- a/soc/microchip/pic32c/pic32cm_jh/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32cm_jh/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})

--- a/soc/microchip/pic32c/pic32cm_pl/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32cm_pl/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})

--- a/soc/microchip/pic32c/pic32cm_sg_gc/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32cm_sg_gc/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})

--- a/soc/microchip/pic32c/pic32cx_sg/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32cx_sg/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})

--- a/soc/microchip/pic32c/pic32cz_ca/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32cz_ca/CMakeLists.txt
@@ -3,4 +3,4 @@
 
 add_subdirectory(common)
 
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})

--- a/soc/microchip/pic64/CMakeLists.txt
+++ b/soc/microchip/pic64/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2025 Microchip Technology Inc
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/microchip/sam/sam_d5x_e5x/CMakeLists.txt
+++ b/soc/microchip/sam/sam_d5x_e5x/CMakeLists.txt
@@ -4,4 +4,4 @@
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
 
 zephyr_include_directories(common)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})

--- a/soc/microchip/sam/sama7/CMakeLists.txt
+++ b/soc/microchip/sam/sama7/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 add_subdirectory(../common ${CMAKE_BINARY_DIR}/common)
 

--- a/soc/nordic/CMakeLists.txt
+++ b/soc/nordic/CMakeLists.txt
@@ -52,6 +52,6 @@ if(CONFIG_BUILD_WITH_TFM)
   )
 endif()
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 add_subdirectory(common)

--- a/soc/nuvoton/npcm/CMakeLists.txt
+++ b/soc/nuvoton/npcm/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/nuvoton/npcm/common/CMakeLists.txt
+++ b/soc/nuvoton/npcm/common/CMakeLists.txt
@@ -6,7 +6,7 @@
 zephyr_include_directories(.)
 
 set(NPCM_BIN_NAME ${CONFIG_KERNEL_BIN_NAME}.npcm.bin)
-string(TOUPPER "${SOC_NAME}" soc_name_upper)
+string(TOUPPER "${CONFIG_SOC}" soc_name_upper)
 
 set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
   COMMAND ${PYTHON_EXECUTABLE} ${SOC_${soc_name_upper}_DIR}/common/esiost/esiost.py

--- a/soc/nuvoton/npcx/CMakeLists.txt
+++ b/soc/nuvoton/npcx/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/nuvoton/npcx/common/CMakeLists.txt
+++ b/soc/nuvoton/npcx/common/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 if(DEFINED CONFIG_NPCX_IMAGE_OUTPUT_BIN)
   set(NPCX_BIN_NAME ${CONFIG_KERNEL_BIN_NAME}.npcx.bin)
-  string(TOUPPER "${SOC_NAME}" soc_name_upper)
+  string(TOUPPER "${CONFIG_SOC}" soc_name_upper)
   set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${SOC_${soc_name_upper}_DIR}/common/ecst/ecst.py
     -i ${KERNEL_BIN_NAME}

--- a/soc/nuvoton/numaker/CMakeLists.txt
+++ b/soc/nuvoton/numaker/CMakeLists.txt
@@ -5,4 +5,4 @@
 # This is for access to pinctrl macros
 zephyr_include_directories(common)
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/nuvoton/numicro/CMakeLists.txt
+++ b/soc/nuvoton/numicro/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2020 Linumiz
 # Author: Saravanan Sekar <saravanan@linumiz.com>
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 # This is for access to pinctrl macros
 zephyr_include_directories(common)

--- a/soc/nxp/imx/CMakeLists.txt
+++ b/soc/nxp/imx/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_include_directories(.)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})
 
-zephyr_include_directories(${SOC_SERIES}/include)
+zephyr_include_directories(${CONFIG_SOC_SERIES}/include)
 
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
 

--- a/soc/nxp/imxrt/CMakeLists.txt
+++ b/soc/nxp/imxrt/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_include_directories(.)
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
-zephyr_include_directories(${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_SERIES})
 
 zephyr_linker_sources_ifdef(CONFIG_NXP_IMXRT_BOOT_HEADER
   ROM_START SORT_KEY 0 boot_header.ld)

--- a/soc/nxp/kinetis/CMakeLists.txt
+++ b/soc/nxp/kinetis/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 zephyr_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG	flash_configuration.c)
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 # This is for access to pinctrl macros
 zephyr_include_directories(common)

--- a/soc/nxp/layerscape/CMakeLists.txt
+++ b/soc/nxp/layerscape/CMakeLists.txt
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)

--- a/soc/nxp/lpc/CMakeLists.txt
+++ b/soc/nxp/lpc/CMakeLists.txt
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)

--- a/soc/nxp/mcx/CMakeLists.txt
+++ b/soc/nxp/mcx/CMakeLists.txt
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory(${SOC_FAMILY})
+add_subdirectory(${CONFIG_SOC_FAMILY})
 
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)

--- a/soc/nxp/mcx/mcxe/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxe/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/nxp/mcx/mcxw/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxw/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../common/CMakeLists.txt)
 

--- a/soc/nxp/s32/CMakeLists.txt
+++ b/soc/nxp/s32/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 add_subdirectory(common)
 
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)

--- a/soc/openhwgroup/cva6/CMakeLists.txt
+++ b/soc/openhwgroup/cva6/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 CISPA Helmholtz Center for Information Security gGmbH
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 zephyr_library_sources_ifdef(CONFIG_CACHE_MANAGEMENT soc_cache_management.c)
 

--- a/soc/raspberrypi/rpi_pico/CMakeLists.txt
+++ b/soc/raspberrypi/rpi_pico/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/realtek/bee/CMakeLists.txt
+++ b/soc/realtek/bee/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/realtek/ec/CMakeLists.txt
+++ b/soc/realtek/ec/CMakeLists.txt
@@ -3,5 +3,5 @@
 # Copyright (c) 2024 Realtek Semiconductor Corporation, SIBG-SD7
 #
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 add_subdirectory(common)

--- a/soc/realtek/fingerprint/common/CMakeLists.txt
+++ b/soc/realtek/fingerprint/common/CMakeLists.txt
@@ -4,7 +4,7 @@
 zephyr_include_directories(.)
 
 set(RTS_BIN_NAME ${CONFIG_KERNEL_BIN_NAME}.rts5817.bin)
-string(TOUPPER "${SOC_NAME}" soc_name_upper)
+string(TOUPPER "${CONFIG_SOC}" soc_name_upper)
 
 if(APPVERSION)
   set(version ${APPVERSION})

--- a/soc/renesas/ra/CMakeLists.txt
+++ b/soc/renesas/ra/CMakeLists.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/renesas/rcar/CMakeLists.txt
+++ b/soc/renesas/rcar/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/renesas/rx/CMakeLists.txt
+++ b/soc/renesas/rx/CMakeLists.txt
@@ -5,4 +5,4 @@ zephyr_include_directories(include)
 zephyr_include_directories(common)
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/renesas/rz/CMakeLists.txt
+++ b/soc/renesas/rz/CMakeLists.txt
@@ -3,4 +3,4 @@
 
 zephyr_include_directories_ifdef(CONFIG_HAS_RENESAS_RZ_FSP common)
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/renesas/smartbond/CMakeLists.txt
+++ b/soc/renesas/smartbond/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/rockchip/CMakeLists.txt
+++ b/soc/rockchip/CMakeLists.txt
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/sensry/CMakeLists.txt
+++ b/soc/sensry/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 sensry.io
 
-zephyr_include_directories(${SOC_FAMILY}/${SOC_SERIES}/common)
+zephyr_include_directories(${CONFIG_SOC_FAMILY}/${CONFIG_SOC_SERIES}/common)
 
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_SY1XX ganymed/sy1xx)

--- a/soc/sifive/sifive_freedom/CMakeLists.txt
+++ b/soc/sifive/sifive_freedom/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/sifli/sf32/CMakeLists.txt
+++ b/soc/sifli/sf32/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2025 Core Devices LLC
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/silabs/CMakeLists.txt
+++ b/soc/silabs/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2017 Christian Taedcke
 
-zephyr_include_directories(${SOC_FAMILY})
-zephyr_include_directories(${SOC_FAMILY}/${SOC_SERIES})
+zephyr_include_directories(${CONFIG_SOC_FAMILY})
+zephyr_include_directories(${CONFIG_SOC_FAMILY}/${CONFIG_SOC_SERIES})
 
 add_subdirectory(common)
 

--- a/soc/snps/nsim/arc_classic/CMakeLists.txt
+++ b/soc/snps/nsim/arc_classic/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-string(REPLACE "nsim_" "" NSIM_ARC_CLASSIC_SER "${SOC_SERIES}")
+string(REPLACE "nsim_" "" NSIM_ARC_CLASSIC_SER "${CONFIG_SOC_SERIES}")
 add_subdirectory(${NSIM_ARC_CLASSIC_SER})
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/snps/nsim/arc_v/CMakeLists.txt
+++ b/soc/snps/nsim/arc_v/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/st/stm32/CMakeLists.txt
+++ b/soc/st/stm32/CMakeLists.txt
@@ -13,4 +13,4 @@ if(CONFIG_BUILD_WITH_TFM)
 endif()
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/telink/tlsr/CMakeLists.txt
+++ b/soc/telink/tlsr/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2024 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/ti/am13/CMakeLists.txt
+++ b/soc/ti/am13/CMakeLists.txt
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/ti/simplelink/CMakeLists.txt
+++ b/soc/ti/simplelink/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2017 Zephyr Contributors
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/wch/ch32v/CMakeLists.txt
+++ b/soc/wch/ch32v/CMakeLists.txt
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")

--- a/west.yml
+++ b/west.yml
@@ -288,7 +288,7 @@ manifest:
       groups:
         - hal
     - name: hal_xtensa
-      revision: 614d7dd1cdb4dd61b8fda5a504d63297497b05ac
+      revision: 60224c27bed1466287f0246ac04c902b92331c29
       path: modules/hal/xtensa
       groups:
         - hal


### PR DESCRIPTION
    doc: releases: migration_guide: 4.5: Add note on deprecated SoC vars

    Adds a note on some duplicate SoC variables being deprecated


    cmake: modules: soc: Deprecate SOC_NAME, SOC_SERIES, SOC_FAMILY...

    These variables are duplicates of Kconfig values and they do not
    need to exist, therefore deprecated them, including SOC_V2_DIR


    cmake: modules: soc: Remove SOC_NAME, SOC_SERIES and SOC_FAMILY

    These variables are duplicates of Kconfig values and they do not
    need to exist, therefore remove them


Fixes #41534
Included a fix to hal_xtensa for said variable usage