### PR TITLE
drivers/haptics/cs40l26: Add missing doxygen end bracket

### DIFF
--- a/include/zephyr/drivers/haptics/cs40l26.h
+++ b/include/zephyr/drivers/haptics/cs40l26.h
@@ -49,6 +49,10 @@ enum cs40l26_source {
 int cs40l26_configure_buzz(const struct device *const dev, const uint32_t frequency,
 			   const uint8_t level, const uint32_t duration);
 
+/**
+ * @}
+ */
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
Just that.

Seen failing in CI 
https://github.com/zephyrproject-rtos/zephyr/actions/runs/30902466040/job/91969934719?pr=115282#step:11:79