### PR TITLE
fs: improve Doxygen coverage of file system and flash API headers

### DIFF
--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -32,9 +32,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Describes a sequence of flash pages of the same size.
+ */
 struct flash_pages_layout {
-	size_t pages_count; /* count of pages sequence of the same size */
-	size_t pages_size;
+	size_t pages_count; /**< Number of pages of the same size in the sequence */
+	size_t pages_size;  /**< Size of each page in the sequence, in bytes */
 };
 
 /**
@@ -89,8 +92,11 @@ struct flash_parameters {
  */
 #define FLASH_ERASE_CAPS_UNSET		(int)-1
 /* The values below are now reserved but not used */
+/** Reserved, not used */
 #define FLASH_ERASE_C_SUPPORTED		0x02
+/** Reserved, not used */
 #define FLASH_ERASE_C_VAL_BIT		0x04
+/** Reserved, not used */
 #define FLASH_ERASE_UNIFORM_PAGE	0x08
 
 /**
@@ -244,9 +250,21 @@ typedef void (*flash_api_pages_layout)(const struct device *dev,
 				       const struct flash_pages_layout **layout,
 				       size_t *layout_size);
 
+/**
+ * @brief Read data from Serial Flash Discoverable Parameters.
+ * See flash_sfdp_read() for argument descriptions.
+ */
 typedef int (*flash_api_sfdp_read)(const struct device *dev, off_t offset,
 				   void *data, size_t len);
+/**
+ * @brief Read the JEDEC ID of the device.
+ * See flash_read_jedec_id() for argument descriptions.
+ */
 typedef int (*flash_api_read_jedec_id)(const struct device *dev, uint8_t *id);
+/**
+ * @brief Perform an extended operation.
+ * See flash_ex_op() for argument descriptions.
+ */
 typedef int (*flash_api_ex_op)(const struct device *dev, uint16_t code,
 			       const uintptr_t in, void *out);
 
@@ -481,10 +499,13 @@ __syscall int flash_fill(const struct device *dev, uint8_t val, off_t offset, si
  */
 __syscall int flash_flatten(const struct device *dev, off_t offset, size_t size);
 
+/**
+ * @brief Information about a flash page.
+ */
 struct flash_pages_info {
-	off_t start_offset; /* offset from the base of flash address */
-	size_t size;
-	uint32_t index;
+	off_t start_offset; /**< Offset of the page from the base of the flash address space */
+	size_t size;        /**< Size of the page in bytes */
+	uint32_t index;     /**< Index of the page, counted from 0 */
 };
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT) || defined(__DOXYGEN__)
@@ -732,14 +753,21 @@ __syscall int flash_copy(const struct device *src_dev, off_t src_offset,
  *  the same functionality. In this case, vendor operation could provide more
  *  specific access when abstraction in Zephyr counterpart is insufficient.
  */
+/** Base of the range of vendor-specific extended operation codes */
 #define FLASH_EX_OP_VENDOR_BASE 0x8000
+/**
+ * @brief Check if an extended operation code is vendor-specific
+ *
+ * @param c Extended operation code
+ * @return Non-zero if the code is in the vendor-specific range, 0 otherwise
+ */
 #define FLASH_EX_OP_IS_VENDOR(c) ((c) & FLASH_EX_OP_VENDOR_BASE)
 
 /**
  *  @brief Enumeration for extra flash operations
  */
 enum flash_ex_op_types {
-	/*
+	/**
 	 * Reset flash device.
 	 */
 	FLASH_EX_OP_RESET = 0,

--- a/include/zephyr/fs/ext2.h
+++ b/include/zephyr/fs/ext2.h
@@ -44,6 +44,10 @@ struct ext2_cfg {
 	bool set_uuid;
 };
 
+/** @brief Declare an ext2 format configuration with default values.
+ *
+ * @param name Name of the declared @ref ext2_cfg object.
+ */
 #define FS_EXT2_DECLARE_DEFAULT_CONFIG(name)			\
 	static struct ext2_cfg name = {				\
 		.block_size = 1024,				\

--- a/include/zephyr/fs/ext2.h
+++ b/include/zephyr/fs/ext2.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Ext2 file system configuration structures.
+ * @ingroup file_system_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_FS_EXT2_H_
 #define ZEPHYR_INCLUDE_FS_EXT2_H_
 

--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -4,6 +4,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Flash Circular Buffer (FCB) API.
+ * @ingroup fcb
+ */
+
 #ifndef ZEPHYR_INCLUDE_FS_FCB_H_
 #define ZEPHYR_INCLUDE_FS_FCB_H_
 

--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Public API for the file system subsystem.
+ * @ingroup file_system_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_FS_FS_H_
 #define ZEPHYR_INCLUDE_FS_FS_H_
 

--- a/include/zephyr/fs/fs_interface.h
+++ b/include/zephyr/fs/fs_interface.h
@@ -65,14 +65,19 @@ extern "C" {
 #endif
 
 #if !defined(MAX_FILE_NAME) /* filesystem selection */
-/* Use standard 8.3 when no filesystem is explicitly selected */
+/**
+ * @brief Maximum length of a file name, without the terminating null character.
+ *
+ * The value depends on the enabled file systems. The standard 8.3 length is
+ * used when no file system is explicitly selected.
+ */
 #define MAX_FILE_NAME 12
 #endif /* filesystem selection */
 
 #endif /* CONFIG_FILE_SYSTEM_MAX_FILE_NAME */
 
 
-/* Type for fs_open flags */
+/** Type for fs_open() flags */
 typedef uint8_t fs_mode_t;
 
 struct fs_mount_t;

--- a/include/zephyr/fs/fs_interface.h
+++ b/include/zephyr/fs/fs_interface.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief File system core structures and file name length limits.
+ * @ingroup file_system_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_FS_FS_INTERFACE_H_
 #define ZEPHYR_INCLUDE_FS_FS_INTERFACE_H_
 

--- a/include/zephyr/fs/fs_sys.h
+++ b/include/zephyr/fs/fs_sys.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief File system driver interface for file system implementations.
+ * @ingroup file_system_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_FS_FS_SYS_H_
 #define ZEPHYR_INCLUDE_FS_FS_SYS_H_
 

--- a/include/zephyr/fs/littlefs.h
+++ b/include/zephyr/fs/littlefs.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief LittleFS file system mount structures and configuration macros.
+ * @ingroup file_system_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_FS_LITTLEFS_H_
 #define ZEPHYR_INCLUDE_FS_LITTLEFS_H_
 

--- a/include/zephyr/fs/littlefs.h
+++ b/include/zephyr/fs/littlefs.h
@@ -41,23 +41,25 @@ extern "C" {
 
 /** @brief Filesystem info structure for LittleFS mount */
 struct fs_littlefs {
-	/* Defaulted in driver, customizable before mount. */
+	/** littlefs configuration, defaulted in driver, customizable before mount. */
 	struct lfs_config cfg;
 
-	/* Must be cfg.cache_size */
+	/** Read cache buffer, must be cfg.cache_size */
 	uint8_t *read_buffer;
 
-	/* Must be cfg.cache_size */
+	/** Program cache buffer, must be cfg.cache_size */
 	uint8_t *prog_buffer;
 
-	/* Must be cfg.lookahead_size/4 elements, and
+	/** Lookahead buffer, must be cfg.lookahead_size/4 elements, and
 	 * cfg.lookahead_size must be a multiple of 8.
 	 */
 	uint32_t *lookahead_buffer[CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE / sizeof(uint32_t)];
 
-	/* These structures are filled automatically at mount. */
+	/** littlefs state, filled automatically at mount. */
 	struct lfs lfs;
+	/** Storage backend, filled automatically at mount. */
 	void *backend;
+	/** Mutex protecting the instance, filled automatically at mount. */
 	struct k_mutex mutex;
 };
 

--- a/include/zephyr/fs/rpmsgfs.h
+++ b/include/zephyr/fs/rpmsgfs.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief RPMsgFS initialize function declaration
+ * @ingroup file_system_api
  */
 
 #ifndef ZEPHYR_INCLUDE_FS_RPMSGFS_H_

--- a/include/zephyr/fs/virtiofs.h
+++ b/include/zephyr/fs/virtiofs.h
@@ -18,7 +18,9 @@
 extern "C" {
 #endif
 
+/** @brief File system data for a VirtioFS mount */
 struct virtiofs_fs_data {
+	/** Maximum size of a single write request, in bytes */
 	uint32_t max_write;
 };
 

--- a/include/zephyr/fs/virtiofs.h
+++ b/include/zephyr/fs/virtiofs.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief VirtioFS file system data structures.
+ * @ingroup file_system_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_FS_VIRTIOFS_H_
 #define ZEPHYR_INCLUDE_FS_VIRTIOFS_H_
 #include <stdint.h>


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` blocks, each attached to its Doxygen group,
  across the `fs/` public headers.
- Documents the file system configuration structures and macros
  (`ext2`, `littlefs`, `virtiofs`, `fs_interface`).
- Documents `flash_pages_layout` / `flash_pages_info`, the reserved
  erase capability defines, and the `sfdp_read`, `read_jedec_id` and
  `ex_op` driver API typedefs.

Documentation only, no functional change.