### PR TITLE
net: if: preserve mcast groups on iface down

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1141,6 +1141,12 @@ Networking
   * :c:member:`mqtt_sn_transport.poll`
   * :c:member:`mqtt_sn_transport.sendto`
 
+* On :c:func:`net_if_down`, the multicast addresses are no longer cleared from the interface.
+  A leave message is still sent, but the addresses are retained in the interface's multicast list
+  and will be rejoined when the interface is brought back up.
+  This allows applications to bring the interface down and up without losing the multicast
+  addresses. (:github:`115307`)
+
 Ethernet
 ========
 

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -777,6 +777,30 @@ out:
 	return ret;
 }
 
+void net_ipv4_igmp_send_leave(struct net_if *iface, const struct net_if_mcast_addr *addr)
+{
+	if (net_if_is_offloaded(iface)) {
+		goto out;
+	}
+
+#if defined(CONFIG_NET_IPV4_IGMPV3)
+	struct net_if_mcast_addr removed_addr = *addr;
+
+	removed_addr.record_type = IGMPV3_CHANGE_TO_INCLUDE_MODE;
+	removed_addr.sources_len = 0;
+
+	igmpv3_send_generic(iface, &removed_addr);
+#else
+	igmp_send_generic(iface, &addr->address.in_addr, false);
+#endif
+out:
+	net_if_mcast_monitor(iface, &addr->address, false);
+
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_MCAST_LEAVE, iface,
+					&addr->address.in_addr,
+					sizeof(struct net_in_addr));
+}
+
 void net_ipv4_igmp_init(struct net_if *iface)
 {
 	struct net_if_mcast_addr *maddr;

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -605,38 +605,32 @@ drop:
 }
 #endif
 
-int net_ipv4_igmp_rejoin(struct net_if *iface, const struct net_in_addr *addr)
+int net_ipv4_igmp_rejoin(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
-	struct net_if_mcast_addr *maddr;
-	int ret = 0;
-
-	maddr = net_if_ipv4_maddr_lookup(addr, &iface);
-	if (maddr == NULL) {
-		return -ENOENT;
-	}
+	int ret;
 
 	if (net_if_is_offloaded(iface)) {
 		goto out;
 	}
 
 #if defined(CONFIG_NET_IPV4_IGMPV3)
-	ret = igmpv3_send_generic(iface, maddr);
+	ret = igmpv3_send_generic(iface, addr);
 #else
-	ret = igmp_send_generic(iface, addr, true);
+	ret = igmp_send_generic(iface, &addr->address.in_addr, true);
 #endif
 	if (ret < 0) {
 		return ret;
 	}
 
 out:
-	net_if_ipv4_maddr_join(iface, maddr);
+	net_if_ipv4_maddr_join(iface, addr);
 
-	net_if_mcast_monitor(iface, &maddr->address, true);
+	net_if_mcast_monitor(iface, &addr->address, true);
 
-	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_MCAST_JOIN, iface, &maddr->address.in_addr,
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_MCAST_JOIN, iface, &addr->address.in_addr,
 					sizeof(struct net_in_addr));
 
-	return ret;
+	return 0;
 }
 
 int net_ipv4_igmp_join(struct net_if *iface, const struct net_in_addr *addr,

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -213,15 +213,9 @@ drop:
 	return ret;
 }
 
-int net_ipv6_mld_rejoin(struct net_if *iface, const struct net_in6_addr *addr)
+int net_ipv6_mld_rejoin(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
-	struct net_if_mcast_addr *maddr;
-	int ret = 0;
-
-	maddr = net_if_ipv6_maddr_lookup(addr, &iface);
-	if (maddr == NULL) {
-		return -ENOENT;
-	}
+	int ret;
 
 	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
 		return 0;
@@ -231,21 +225,22 @@ int net_ipv6_mld_rejoin(struct net_if *iface, const struct net_in6_addr *addr)
 		goto out;
 	}
 
-	ret = net_ipv6_mld_send_single(iface, addr, NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE);
+	ret = net_ipv6_mld_send_single(iface, &addr->address.in6_addr,
+				       NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE);
 	if (ret < 0) {
 		return ret;
 	}
 
 out:
-	net_if_ipv6_maddr_join(iface, maddr);
+	net_if_ipv6_maddr_join(iface, addr);
 
-	net_if_mcast_monitor(iface, &maddr->address, true);
+	net_if_mcast_monitor(iface, &addr->address, true);
 
 	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_MCAST_JOIN, iface,
-					&maddr->address.in6_addr,
+					&addr->address.in6_addr,
 					sizeof(struct net_in6_addr));
 
-	return ret;
+	return 0;
 }
 
 int net_ipv6_mld_join(struct net_if *iface, const struct net_in6_addr *addr)

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -336,6 +336,27 @@ out:
 	return ret;
 }
 
+void net_ipv6_mld_send_leave(struct net_if *iface, const struct net_if_mcast_addr *addr)
+{
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
+		return;
+	}
+
+	if (net_if_is_offloaded(iface)) {
+		goto out;
+	}
+
+	net_ipv6_mld_send_single(iface, &addr->address.in6_addr,
+				 NET_IPV6_MLDv2_CHANGE_TO_INCLUDE_MODE);
+
+out:
+	net_if_mcast_monitor(iface, &addr->address, false);
+
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_MCAST_LEAVE, iface,
+					&addr->address.in6_addr,
+					sizeof(struct net_in6_addr));
+}
+
 static int send_mld_report(struct net_if *iface)
 {
 	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1266,7 +1266,7 @@ static void leave_mcast_all(struct net_if *iface)
 			continue;
 		}
 
-		net_ipv6_mld_leave(iface, &ipv6->mcast[i].address.in6_addr);
+		net_ipv6_mld_send_leave(iface, &ipv6->mcast[i]);
 	}
 }
 
@@ -1746,11 +1746,9 @@ out:
  */
 static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 {
-	struct net_in6_addr solicit_addrs[NET_IF_MAX_IPV6_ADDR];
 	struct net_if_mcast_addr *ifaddr, *next;
 	struct net_if_ipv6 *ipv6;
 	sys_slist_t rejoin_needed;
-	int solicit_count = 0;
 
 	sys_slist_init(&rejoin_needed);
 
@@ -1762,24 +1760,6 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 
 	if (net_if_config_ipv6_get(iface, &ipv6) < 0) {
 		goto out;
-	}
-
-	/* Collect the addresses whose solicited node multicast groups need to
-	 * be (re)joined if the interface has ND enabled. The join itself is
-	 * done below without the iface lock held: join_mcast_nodes() transmits
-	 * MLD reports, whose TX path locks other interfaces, so doing it under
-	 * net_if_lock() could deadlock (ABBA) when two interfaces are brought
-	 * up concurrently.
-	 */
-	if (!net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
-		ARRAY_FOR_EACH(ipv6->unicast, i) {
-			if (!ipv6->unicast[i].is_used) {
-				continue;
-			}
-
-			solicit_addrs[solicit_count++] =
-				ipv6->unicast[i].address.in6_addr;
-		}
 	}
 
 	/* If MLD is disabled on the interface, skip rejoining. */
@@ -1799,13 +1779,6 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 
 out:
 	net_if_unlock(iface);
-
-	/* Join the solicited node multicast groups without holding the iface
-	 * lock, see the comment above.
-	 */
-	for (int i = 0; i < solicit_count; i++) {
-		join_mcast_nodes(iface, &solicit_addrs[i]);
-	}
 
 	/* Rejoin multicast groups without holding the iface lock to avoid any
 	 * possible mutex deadlock issues.
@@ -5493,7 +5466,7 @@ static void leave_ipv4_mcast_all(struct net_if *iface)
 			continue;
 		}
 
-		net_ipv4_igmp_leave(iface, &ipv4->mcast[i].address.in_addr);
+		net_ipv4_igmp_send_leave(iface, &ipv4->mcast[i]);
 	}
 }
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1787,7 +1787,7 @@ out:
 					  ifaddr, next, rejoin_node) {
 		int ret;
 
-		ret = net_ipv6_mld_rejoin(iface, &ifaddr->address.in6_addr);
+		ret = net_ipv6_mld_rejoin(iface, ifaddr);
 		if (ret < 0) {
 			NET_ERR("Cannot join mcast address %s for %d (%d)",
 				net_sprint_ipv6_addr(&ifaddr->address.in6_addr),
@@ -5517,7 +5517,7 @@ static void rejoin_ipv4_mcast_groups(struct net_if *iface)
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&rejoin_needed, ifaddr, next, rejoin_node) {
 		int ret;
 
-		ret = net_ipv4_igmp_rejoin(iface, &ifaddr->address.in_addr);
+		ret = net_ipv4_igmp_rejoin(iface, ifaddr);
 		if (ret < 0) {
 			NET_ERR("Cannot join mcast address %s for %d (%d)",
 				net_sprint_ipv4_addr(&ifaddr->address.in_addr),

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -465,3 +465,21 @@ int net_ipv6_mld_rejoin(struct net_if *iface, const struct net_in6_addr *addr);
 #else
 #define net_ipv6_mld_rejoin(...) -ENOSYS
 #endif
+
+#if defined(CONFIG_NET_IPV4_IGMP)
+void net_ipv4_igmp_send_leave(struct net_if *iface, const struct net_if_mcast_addr *addr);
+#else
+static inline void net_ipv4_igmp_send_leave(struct net_if *iface __unused,
+					    const struct net_if_mcast_addr *addr __unused)
+{
+}
+#endif
+
+#if defined(CONFIG_NET_IPV6_MLD)
+void net_ipv6_mld_send_leave(struct net_if *iface, const struct net_if_mcast_addr *addr);
+#else
+static inline void net_ipv6_mld_send_leave(struct net_if *iface __unused,
+					   const struct net_if_mcast_addr *addr __unused)
+{
+}
+#endif /* CONFIG_NET_IPV6_MLD */

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -454,14 +454,14 @@ void net_pkt_tx_init(struct net_pkt *pkt);
 
 /** Rejoin IGMP mcast group w/o registering address, for internal use only. */
 #if defined(CONFIG_NET_IPV4_IGMP)
-int net_ipv4_igmp_rejoin(struct net_if *iface, const struct net_in_addr *addr);
+int net_ipv4_igmp_rejoin(struct net_if *iface, struct net_if_mcast_addr *addr);
 #else
 #define net_ipv4_igmp_rejoin(...) -ENOSYS
 #endif
 
 /** Rejoin MLD mcast group w/o registering address, for internal use only. */
 #if defined(CONFIG_NET_IPV6_MLD)
-int net_ipv6_mld_rejoin(struct net_if *iface, const struct net_in6_addr *addr);
+int net_ipv6_mld_rejoin(struct net_if *iface, struct net_if_mcast_addr *addr);
 #else
 #define net_ipv6_mld_rejoin(...) -ENOSYS
 #endif

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -21,15 +21,12 @@ config DNS_RESOLVER_AUTO_INIT
 
 config MDNS_RESOLVER
 	bool "MDNS support"
-	select NET_MGMT
-	select NET_MGMT_EVENT
 	help
 	  This option enables multicast DNS client side support.
 	  See RFC 6762 for details.
 
 	  When the mDNS responder is not enabled, the resolver joins the mDNS
-	  multicast groups itself and needs the network management events to
-	  rejoin them if an interface goes down and comes back up.
+	  multicast groups itself.
 
 config LLMNR_RESOLVER
 	bool "LLMNR support [DEPRECATED]"
@@ -237,8 +234,6 @@ config MDNS_RESPONDER
 	bool "mDNS responder"
 	select NET_IPV4_IGMP if NET_IPV4
 	select NET_IPV6_MLD if NET_IPV6
-	select NET_MGMT
-	select NET_MGMT_EVENT
 	select NET_SOCKETS
 	select NET_SOCKETS_SERVICE
 	depends on NET_HOSTNAME_ENABLE
@@ -327,6 +322,8 @@ config MDNS_RESPONDER_PROBE
 	select NET_CONNECTION_MANAGER
 	select MDNS_RESOLVER
 	select DNS_RESOLVER
+	select NET_MGMT
+	select NET_MGMT_EVENT
 	select EXPERIMENTAL
 	help
 	  Note that for probing to work, the mDNS and DNS resolver need to
@@ -394,8 +391,6 @@ config LLMNR_RESPONDER
 	select DEPRECATED
 	select NET_IPV4_IGMP if NET_IPV4
 	select NET_IPV6_MLD if NET_IPV6
-	select NET_MGMT
-	select NET_MGMT_EVENT
 	select NET_SOCKETS
 	select NET_SOCKETS_SERVICE
 	depends on NET_HOSTNAME_ENABLE

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -49,8 +49,6 @@ static struct net_sockaddr_in local_addr4;
 static int ipv6;
 #endif
 
-static struct net_mgmt_event_callback mgmt_cb;
-
 #define BUF_ALLOC_TIMEOUT K_MSEC(100)
 
 /* This value is recommended by RFC 1035 */
@@ -115,58 +113,6 @@ static void create_ipv4_dst_addr(struct net_sockaddr_in *src_addr,
 			       (uint8_t *)&src_addr->sin_addr);
 }
 #endif
-
-static void llmnr_iface_event_handler(struct net_mgmt_event_callback *cb,
-				      uint64_t mgmt_event, struct net_if *iface)
-{
-	if (mgmt_event == NET_EVENT_IF_UP) {
-		/* When the interface comes back up (e.g. Ethernet cable was
-		 * reattached) the stack has left the LLMNR multicast groups if
-		 * the interface was fully brought down. Rejoin both the IPv4
-		 * and IPv6 groups so that the responder keeps receiving
-		 * queries.
-		 */
-#if defined(CONFIG_NET_IPV4)
-		if (net_if_flag_is_set(iface, NET_IF_IPV4)) {
-			int ret;
-
-			/* Rejoin so that a fresh IGMP membership report is always
-			 * emitted, even when the group is still locally marked as
-			 * joined. Fall back to a join if the group was removed
-			 * while the interface was down.
-			 */
-			ret = net_ipv4_igmp_rejoin(iface, &local_addr4.sin_addr);
-			if (ret == -ENOENT) {
-				ret = net_ipv4_igmp_join(iface, &local_addr4.sin_addr, NULL);
-			}
-
-			if (ret < 0) {
-				NET_DBG("Cannot add IPv4 multicast address to iface %p",
-					iface);
-			}
-		}
-#endif /* defined(CONFIG_NET_IPV4) */
-
-#if defined(CONFIG_NET_IPV6)
-		if (net_if_flag_is_set(iface, NET_IF_IPV6)) {
-			struct net_sockaddr_in6 addr6;
-			int ret;
-
-			create_ipv6_addr(&addr6);
-
-			ret = net_ipv6_mld_rejoin(iface, &addr6.sin6_addr);
-			if (ret == -ENOENT) {
-				ret = net_ipv6_mld_join(iface, &addr6.sin6_addr);
-			}
-
-			if (ret < 0) {
-				NET_DBG("Cannot add IPv6 multicast address to iface %p",
-					iface);
-			}
-		}
-#endif /* defined(CONFIG_NET_IPV6) */
-	}
-}
 
 static int get_socket(net_sa_family_t family)
 {
@@ -765,11 +711,6 @@ ipv4_out:
 
 static int llmnr_responder_init(void)
 {
-	net_mgmt_init_event_callback(&mgmt_cb, llmnr_iface_event_handler,
-				     NET_EVENT_IF_UP);
-
-	net_mgmt_add_event_callback(&mgmt_cb);
-
 	return init_listener();
 }
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -235,9 +235,8 @@ NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v6_svc, dns_dispatcher_svc_handler,
 				      MDNS_V6_SVC_POLL_COUNT);
 #endif
 
-static struct net_mgmt_event_callback mgmt_iface_cb;
-
 #if defined(CONFIG_MDNS_RESPONDER_PROBE)
+static struct net_mgmt_event_callback mgmt_iface_cb;
 static void cancel_probes(struct mdns_responder_context *ctx);
 static struct net_mgmt_event_callback mgmt_conn_cb;
 #if defined(CONFIG_NET_IPV4)
@@ -329,6 +328,7 @@ static void mark_needs_announce(struct net_if *iface, bool needs_announce)
 }
 #endif /* CONFIG_MDNS_RESPONDER_PROBE */
 
+#if defined(CONFIG_MDNS_RESPONDER_PROBE)
 static void mdns_iface_event_handler(struct net_mgmt_event_callback *cb,
 				     uint64_t mgmt_event, struct net_if *iface)
 
@@ -337,73 +337,14 @@ static void mdns_iface_event_handler(struct net_mgmt_event_callback *cb,
 		return;
 	}
 
-	if (mgmt_event == NET_EVENT_IF_UP) {
-		/* When the interface comes back up (e.g. Ethernet cable was
-		 * reattached), the stack has left the mDNS multicast groups if
-		 * the interface was fully brought down. Rejoin them here so
-		 * that the responder keeps receiving queries. The well-known
-		 * group addresses are constant, so construct them directly
-		 * instead of relying on any interface-index bookkeeping.
-		 */
-#if defined(CONFIG_NET_IPV4)
-		if (net_if_flag_is_set(iface, NET_IF_IPV4)) {
-			struct net_sockaddr_in addr4;
-			int ret;
-
-			create_ipv4_addr(&addr4);
-
-			/* Rejoin so that a fresh IGMP membership report is always
-			 * emitted, even when the group is still locally marked as
-			 * joined (net_ipv4_igmp_join() would return early without
-			 * sending a report in that case). This matters for e.g. an
-			 * IGMP-snooping switch that dropped its state while the link
-			 * was down. If the group was fully removed while the
-			 * interface was down, rejoin returns -ENOENT, so fall back
-			 * to a join which re-adds it.
-			 */
-			ret = net_ipv4_igmp_rejoin(iface, &addr4.sin_addr);
-			if (ret == -ENOENT) {
-				ret = net_ipv4_igmp_join(iface, &addr4.sin_addr, NULL);
-			}
-
-			if (ret < 0) {
-				NET_DBG("Cannot add IPv4 multicast address %s to iface %d (%d)",
-					net_sprint_ipv4_addr(&addr4.sin_addr),
-					net_if_get_by_iface(iface), ret);
-			}
-		}
-#endif /* defined(CONFIG_NET_IPV4) */
-
-#if defined(CONFIG_NET_IPV6)
-		if (net_if_flag_is_set(iface, NET_IF_IPV6)) {
-			struct net_sockaddr_in6 addr6;
-			int ret;
-
-			create_ipv6_addr(&addr6);
-
-			ret = net_ipv6_mld_rejoin(iface, &addr6.sin6_addr);
-			if (ret == -ENOENT) {
-				ret = net_ipv6_mld_join(iface, &addr6.sin6_addr);
-			}
-
-			if (ret < 0) {
-				NET_DBG("Cannot add IPv6 multicast address %s to iface %d (%d)",
-					net_sprint_ipv6_addr(&addr6.sin6_addr),
-					net_if_get_by_iface(iface), ret);
-			}
-		}
-#endif /* defined(CONFIG_NET_IPV6) */
-	}
-
-#if defined(CONFIG_MDNS_RESPONDER_PROBE)
 	if (mgmt_event == NET_EVENT_IF_UP && init_listener_done) {
 		do_announce = true;
 		announce_count = 0;
 
 		mark_needs_announce(iface, true);
 	}
-#endif /* CONFIG_MDNS_RESPONDER_PROBE */
 }
+#endif /* CONFIG_MDNS_RESPONDER_PROBE */
 
 static int set_ttl_hop_limit(int sock, int level, int option, int new_limit)
 {
@@ -2395,15 +2336,14 @@ static void do_init_listener(struct k_work *work)
 
 static int mdns_responder_init(void)
 {
-	uint64_t flags = NET_EVENT_IF_UP;
 	external_records = NULL;
 	external_records_count = 0;
 
-	net_mgmt_init_event_callback(&mgmt_iface_cb, mdns_iface_event_handler, flags);
-	net_mgmt_add_event_callback(&mgmt_iface_cb);
-
 #if defined(CONFIG_MDNS_RESPONDER_PROBE)
 	int ret;
+
+	net_mgmt_init_event_callback(&mgmt_iface_cb, mdns_iface_event_handler, NET_EVENT_IF_UP);
+	net_mgmt_add_event_callback(&mgmt_iface_cb);
 
 	net_mgmt_init_event_callback(&mgmt_conn_cb, mdns_conn_event_handler,
 				     NET_EVENT_L4_DISCONNECTED);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -1869,6 +1869,7 @@ static int init_listener(void)
 
 #if defined(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL)
 static K_MUTEX_DEFINE(reconfigure_lock);
+static void mdns_leave_groups_cb(struct net_if *iface, void *user_data);
 
 /* Tear down every listener socket and its dispatcher registration. The sockets
  * are recreated for the interfaces that remain enabled by init_listener().
@@ -1955,6 +1956,7 @@ int mdns_test_reinit_with_stale_slot(unsigned int slot)
 {
 	/* Start from a clean state (every slot marked closed). */
 	mdns_close_listeners();
+	net_if_foreach(mdns_leave_groups_cb, NULL);
 
 #if defined(CONFIG_NET_IPV6)
 	if (slot < ARRAY_SIZE(v6_ctx)) {

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -414,87 +414,6 @@ static void join_ipv6_mcast_group(struct net_if *iface, void *user_data)
 	}
 }
 
-#if defined(CONFIG_MDNS_RESOLVER) && !defined(CONFIG_MDNS_RESPONDER)
-/* When the mDNS responder is not enabled, the resolver is the one that joined
- * the mDNS multicast groups. If an interface goes fully down and comes back up
- * (for example the connection manager reacting to an Ethernet cable being
- * reattached), the stack leaves those groups and does not rejoin them (they
- * are removed, not just marked unjoined). Rejoin them here so that multicast
- * mDNS responses keep being delivered.
- */
-static struct net_mgmt_event_callback mdns_mcast_cb;
-
-static void mdns_rejoin_groups(struct net_if *iface)
-{
-	ARG_UNUSED(iface);
-
-	/* Rejoin so that a fresh membership report is always emitted, even when
-	 * the group is still locally marked as joined (a plain join would then
-	 * return early without sending a report). Fall back to a join if the
-	 * group was removed while the interface was down.
-	 */
-#if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_IPV4_IGMP)
-	if (net_if_flag_is_set(iface, NET_IF_IPV4)) {
-		struct net_in_addr addr4 = { { { 224, 0, 0, 251 } } };
-		int ret;
-
-		ret = net_ipv4_igmp_rejoin(iface, &addr4);
-		if (ret == -ENOENT) {
-			ret = net_ipv4_igmp_join(iface, &addr4, NULL);
-		}
-
-		if (ret < 0) {
-			NET_DBG("Cannot rejoin %s mDNS group (%d)", "IPv4", ret);
-		}
-	}
-#endif
-
-#if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV6_MLD)
-	if (net_if_flag_is_set(iface, NET_IF_IPV6)) {
-		struct net_in6_addr addr6 = { { { 0xff, 0x02, 0, 0, 0, 0, 0, 0,
-						  0, 0, 0, 0, 0, 0, 0, 0xfb } } };
-		int ret;
-
-		ret = net_ipv6_mld_rejoin(iface, &addr6);
-		if (ret == -ENOENT) {
-			ret = net_ipv6_mld_join(iface, &addr6);
-		}
-
-		if (ret < 0) {
-			NET_DBG("Cannot rejoin %s mDNS group (%d)", "IPv6", ret);
-		}
-	}
-#endif
-}
-
-static void mdns_iface_event_handler(struct net_mgmt_event_callback *cb,
-				     uint64_t mgmt_event, struct net_if *iface)
-{
-	ARG_UNUSED(cb);
-
-	if (mgmt_event == NET_EVENT_IF_UP) {
-		mdns_rejoin_groups(iface);
-	}
-}
-
-static void mdns_monitor_register(void)
-{
-	static bool registered;
-
-	if (registered) {
-		return;
-	}
-
-	net_mgmt_init_event_callback(&mdns_mcast_cb, mdns_iface_event_handler,
-				     NET_EVENT_IF_UP);
-	net_mgmt_add_event_callback(&mdns_mcast_cb);
-
-	registered = true;
-}
-#else
-#define mdns_monitor_register(...)
-#endif /* CONFIG_MDNS_RESOLVER && !CONFIG_MDNS_RESPONDER */
-
 static void dns_postprocess_server(struct dns_resolve_context *ctx, int idx)
 {
 	struct net_sockaddr *addr = &ctx->servers[idx].dns_server;
@@ -3081,11 +3000,6 @@ struct dns_resolve_context *dns_resolve_get_default(void)
 int dns_resolve_init_default(struct dns_resolve_context *ctx)
 {
 	int ret = 0;
-
-	/* Make sure the mDNS multicast groups are rejoined if an interface
-	 * goes down and comes back up (no-op when the responder is enabled).
-	 */
-	mdns_monitor_register();
 
 #if defined(CONFIG_DNS_SERVER_IP_ADDRESSES)
 	static const char *dns_servers[SERVER_COUNT + 1];

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -632,6 +632,7 @@ static void nbr_lookup_ok(void)
 static void *ipv6_setup(void)
 {
 	struct net_if_addr *ifaddr = NULL, *ifaddr2;
+	struct net_in6_addr solicited_node_mcast;
 	struct net_if *iface = TEST_NET_IF;
 	struct net_if *iface2 = NULL;
 	struct net_if_ipv6 *ipv6;
@@ -666,6 +667,14 @@ static void *ipv6_setup(void)
 
 	ifaddr2 = net_if_ipv6_addr_lookup(&my_addr, &iface2);
 	zassert_true(ifaddr2 == ifaddr, "Invalid ifaddr (%p vs %p)\n", ifaddr, ifaddr2);
+
+	/* As the address was added by hand above, the solicited-node multicast
+	 * group that net_if_ipv6_addr_add() would have joined (RFC 4291 ch 2.8)
+	 * needs to be joined manually too.
+	 */
+	net_ipv6_addr_create_solicited_node(&my_addr, &solicited_node_mcast);
+	zassert_ok(net_ipv6_mld_join(iface, &solicited_node_mcast),
+		   "Cannot join solicited node multicast group");
 
 	/* The semaphore is there to wait the data to be received. */
 	k_sem_init(&wait_data, 0, UINT_MAX);

--- a/tests/net/lib/mdns_responder/src/main.c
+++ b/tests/net/lib/mdns_responder/src/main.c
@@ -986,30 +986,6 @@ ZTEST(test_mdns_responder, test_ipv6_group_ref_not_leaked_on_cycles)
 		      "(%ld -> %ld)", ref_before, ref_after);
 }
 
-/* Reproduces the state the connection-manager reporter observed: the mDNS
- * IPv4 group is still marked "joined" when NET_EVENT_IF_UP is delivered (the
- * link bounce did not clear it). A plain net_ipv4_igmp_join() is then a no-op
- * (igmp.c returns early when the address is already joined), so no membership
- * report reaches an IGMP-snooping switch and the responder stops receiving
- * queries even though the local state looks fine. Recovery must force a fresh
- * report in this case.
- */
-ZTEST(test_mdns_responder, test_ipv4_igmp_report_when_already_joined_on_if_up)
-{
-	zassert_true(ipv4_group_joined(iface1),
-		     "IPv4 mDNS group should be joined at start");
-
-	/* Group stays joined; only an IF_UP event is delivered (no down). */
-	igmp_report_count = 0;
-
-	net_mgmt_event_notify(NET_EVENT_IF_UP, iface1);
-	k_sleep(K_MSEC(200));
-
-	zassert_true(igmp_report_count > 0,
-		     "No IGMP report was re-emitted when the group was already joined "
-		     "on interface up");
-}
-
 /* Same, but for a carrier loss (Ethernet cable unplugged/replugged) without an
  * administrative down.
  */

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -89,6 +89,7 @@ static struct mld_report_handler *report_handler;
 K_SEM_DEFINE(wait_data, 0, UINT_MAX);
 K_SEM_DEFINE(wait_joined, 0, UINT_MAX);
 K_SEM_DEFINE(wait_left, 0, UINT_MAX);
+K_SEM_DEFINE(wait_report, 0, UINT_MAX);
 
 #define WAIT_TIME 500
 #define WAIT_TIME_LONG MSEC_PER_SEC
@@ -680,6 +681,8 @@ static void expect_exclude_mcast_report(struct net_pkt *pkt, void *user_data)
 	    net_ipv6_addr_cmp_raw((const uint8_t *)exp_mcast_group,
 				  (const uint8_t *)&record.mcast_addr)) {
 		*report_sent = true;
+
+		k_sem_give(&wait_report);
 	}
 }
 
@@ -800,6 +803,100 @@ ZTEST(net_mld_test_suite, test_solicit_node_after_carrier_toggle)
 ZTEST(net_mld_test_suite, test_join_leave)
 {
 	test_join_group();
+	test_leave_group();
+}
+
+/* Store the record type the expected multicast group was reported with. */
+static void record_mcast_report(struct net_pkt *pkt, void *user_data)
+{
+	struct mld_report_mcast_record record;
+	uint8_t *record_type = user_data;
+	uint16_t records_count;
+	uint16_t res_bytes;
+
+	zassert_not_null(exp_mcast_group, "Expected mcast group not sent");
+
+	net_pkt_set_overwrite(pkt, true);
+	net_pkt_skip(pkt, sizeof(struct net_icmp_hdr));
+
+	zassert_ok(net_pkt_read_be16(pkt, &res_bytes), "Failed to read reserved bytes");
+	zassert_equal(0, res_bytes, "Reserved bytes must be zeroed");
+
+	zassert_ok(net_pkt_read_be16(pkt, &records_count), "Failed to read addr count");
+	zexpect_equal(records_count, 1, "Incorrect record count");
+
+	zassert_ok(net_pkt_read(pkt, &record, sizeof(struct mld_report_mcast_record)),
+		   "Failed to read mcast record");
+
+	if (net_ipv6_addr_cmp_raw((const uint8_t *)exp_mcast_group,
+				  (const uint8_t *)&record.mcast_addr)) {
+		*record_type = record.record_type;
+
+		k_sem_give(&wait_report);
+	}
+}
+
+/* Verify that a group joined by the application is kept on the interface while
+ * the interface is down. The membership is given up on the wire, but the
+ * address stays registered so that it is rejoined - without the application
+ * having to join it again - once the interface comes back up.
+ */
+ZTEST(net_mld_test_suite, test_group_preserved_over_iface_down_up)
+{
+	struct net_if_mcast_addr *ifmaddr;
+	struct net_if *iface = NULL;
+	uint8_t record_type = 0;
+	struct mld_report_handler handler = {
+		.fn = record_mcast_report,
+		.user_data = &record_type
+	};
+
+	test_join_group();
+
+	ifmaddr = net_if_ipv6_maddr_lookup(&mcast_addr, &iface);
+	zassert_not_null(ifmaddr, "Interface does not contain the multicast address");
+	zassert_true(net_if_ipv6_maddr_is_joined(ifmaddr),
+		     "Multicast address is not marked as joined");
+
+	exp_mcast_group_storage = mcast_addr;
+	exp_mcast_group = &exp_mcast_group_storage;
+	report_handler = &handler;
+
+	/* Interface down - the group is left on the wire only. */
+	k_sem_reset(&wait_report);
+
+	zassert_ok(net_if_down(net_iface), "Failed to bring iface down");
+
+	zassert_ok(k_sem_take(&wait_report, K_MSEC(WAIT_TIME)),
+		   "Timeout while waiting for the MLD leave report");
+	zassert_equal(record_type, NET_IPV6_MLDv2_CHANGE_TO_INCLUDE_MODE,
+		      "Interface down did not report leaving the group");
+
+	iface = NULL;
+	ifmaddr = net_if_ipv6_maddr_lookup(&mcast_addr, &iface);
+	zassert_not_null(ifmaddr, "Multicast address was removed on iface down");
+	zassert_false(net_if_ipv6_maddr_is_joined(ifmaddr),
+		      "Multicast address is still marked as joined while down");
+
+	/* Interface up - the preserved group is rejoined. */
+	k_sem_reset(&wait_report);
+	record_type = 0;
+
+	zassert_ok(net_if_up(net_iface), "Failed to bring iface up");
+
+	zassert_ok(k_sem_take(&wait_report, K_MSEC(WAIT_TIME)),
+		   "Timeout while waiting for the MLD report");
+	zassert_equal(record_type, NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE,
+		      "Interface up did not rejoin the group");
+
+	iface = NULL;
+	ifmaddr = net_if_ipv6_maddr_lookup(&mcast_addr, &iface);
+	zassert_not_null(ifmaddr, "Interface does not contain the multicast address");
+	zassert_true(net_if_ipv6_maddr_is_joined(ifmaddr),
+		     "Multicast address was not rejoined");
+
+	report_handler = NULL;
+
 	test_leave_group();
 }
 


### PR DESCRIPTION
When I set the socket option
ZSOCK_IPV6_ADD_MEMBERSHIP or ZSOCK_IP_ADD_MEMBERSHIP I expect that that setting is valid for at least the time that the socket is open. As a udp does not close
when the iface that it is attached to, goes down,
it should not be removed from the iface on down.

Just with the socket api I have no way to detect that the multicast membership no longer exists and then also no way to recover.

If the summary I got from Codex about how it is in Linux, can be believed, in Linux they also don't remove the multicast groups on down:

> On a normal `NETDEV_DOWN` / `NETDEV_UP` cycle, Linux usually remembers multicast memberships and re-joins them when the device comes back. The interface-level join is withdrawn on down, then reinstalled on up: IPv4 does that in net/ipv4/igmp.c, and IPv6 does the same in net/ipv6/mcast.c. So for a simple down/up, user space normally does not need to call `IP_ADD_MEMBERSHIP` or `IPV6_ADD_MEMBERSHIP` again.

> The socket itself is not closed or automatically unbound by that event. The membership is stored on the socket and only torn down on explicit leave or socket close, not on interface down: see IPv4 join/close in net/ipv4/igmp.c and net/ipv4/igmp.c, and the IPv6 equivalents in net/ipv6/mcast.c and net/ipv6/mcast.c. While the interface is down, those sockets just stop receiving multicast from that interface; when it comes back and the memberships are reinstated, receive resumes.

> The important caveat is that `down/up` is different from `unregister/destroy`. If the device is actually removed, Linux destroys the device multicast list instead of carrying it across, so a recreated interface may need fresh joins, especially if it comes back with a new `ifindex` (net/ipv4/igmp.c, net/ipv6/addrconf.c). Also, `bind()` to a multicast address alone is not the same thing as joining the group; the real receive membership comes from the multicast join socket options.