### PR TITLE
drivers: ethernet: phy: nxp_t1s_phy: optional plca_node_count

### DIFF
--- a/drivers/ethernet/phy/phy_nxp_t1s.c
+++ b/drivers/ethernet/phy/phy_nxp_t1s.c
@@ -204,7 +204,11 @@ static DEVICE_API(ethphy, nxp_t1s_phy_api) = {
 	static const struct nxp_t1s_config nxp_t1s_##n##_config = {     \
 		.plca_config = {                                            \
 			.nodeId = DT_INST_PROP(n, plca_node_id),                \
-			.nodeCount = DT_INST_PROP(n, plca_node_count),          \
+			.nodeCount = COND_CODE_0( \
+				DT_INST_PROP(n, plca_node_id), \
+				(DT_INST_PROP(n, plca_node_count)), \
+				(DT_INST_PROP_OR(n, plca_node_count, 0)) \
+			), \
 			.toTimer = DT_INST_PROP(n, plca_to_timer),              \
 			.burstTimer = DT_INST_PROP(n, plca_burst_timer),        \
 			.maxBurstCount = DT_INST_PROP(n, plca_burst_count),     \


### PR DESCRIPTION
Plca nodes with node_id not 0 do not manage transmit windows and should therefore not be required to provide plca_node_count. This change makes plca_node_count optional for (node_id != 0) and if omitted sets the default value to 0.
The behaviour for node with id 0 stays the same.

This follows the same design as in [phy_microchip_t1s.c](https://github.com/zephyrproject-rtos/zephyr/pull/105211/changes/88781ef4ad8a51fbf381d583abdc8e1416312c8a#diff-9888d476c94f83d8c84e91b1d9d3eab16b1fad980c9bdc48425272b354adba2b) 