### PR TITLE
net: sockets: tls: Advance a pending record during poll prepare

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -4018,18 +4018,13 @@ static int ztls_poll_prepare_pollin(struct tls_context *ctx)
 		return -EALREADY;
 	}
 
-#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-	if (ctx->type == NET_SOCK_DGRAM) {
-		return 0;
-	}
-#endif
-
 	if (!ctx->is_initialized) {
 		return 0;
 	}
 
 	/* Mbed TLS can hold a message that it already read from the underlying
-	 * socket but did not process yet. The socket has no readiness left to
+	 * socket but did not process yet, for example a further record of a
+	 * datagram that carried several. The socket has no readiness left to
 	 * report in that case, so waiting on it alone can sleep while data is
 	 * available. Advance such a message here instead.
 	 */

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3998,19 +3998,53 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
 #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
 }
 
+static int tls_data_check(struct tls_context *ctx);
+
 static int ztls_poll_prepare_pollin(struct tls_context *ctx)
 {
+	int ret;
+
+	if (ctx->is_listening) {
+		return 0;
+	}
+
 	/* If there already is Mbed TLS data to read, there is no
 	 * need to set the k_poll_event object. Return EALREADY
 	 * so we won't block in the k_poll.
 	 */
-	if (!ctx->is_listening) {
-		if (mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl) > 0) {
-			return -EALREADY;
-		}
+	if (mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl) > 0) {
+		return -EALREADY;
 	}
 
-	return 0;
+	if (!ctx->is_initialized) {
+		return 0;
+	}
+
+	/* Mbed TLS can hold a message that it already read from the underlying
+	 * socket but did not process yet, for example a further record of a
+	 * datagram that carried several. The socket has no readiness left to
+	 * report in that case, so waiting on it alone can sleep while data is
+	 * available. Advance such a message here instead.
+	 */
+	if (mbedtls_ssl_check_pending(&ctx->active_session->ssl) == 0) {
+		return 0;
+	}
+
+	ret = tls_data_check(ctx);
+	if (ret == 0) {
+		return 0;
+	}
+
+	/* Either plaintext is now exposed, or the session was closed or
+	 * failed. All three have to wake the poll. Latch the failure so that
+	 * the update path can turn it into POLLHUP or POLLERR, as the
+	 * underlying socket will never report it.
+	 */
+	if (ret < 0 && ret != -ENOTCONN) {
+		ctx->error = -ret;
+	}
+
+	return -EALREADY;
 }
 
 static int ztls_poll_prepare_ctx(struct tls_context *ctx,
@@ -4134,7 +4168,18 @@ static int tls_update_pollin(int fd, struct tls_context *ctx,
 	}
 
 	if ((pfd->revents & ZSOCK_POLLIN) == 0) {
-		/* No new data on a socket. */
+		/* No new data on a socket. A poll prepare probe may still have
+		 * left a closed session or a fatal error behind, which the
+		 * underlying socket will never report.
+		 */
+		if (!ctx->is_listening) {
+			if (ctx->active_session->session_closed) {
+				pfd->revents |= ZSOCK_POLLHUP;
+			} else if (ctx->error != 0) {
+				pfd->revents |= ZSOCK_POLLERR;
+			}
+		}
+
 		goto next;
 	}
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -4000,19 +4000,58 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
 #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
 }
 
+static int tls_data_check(struct tls_context *ctx);
+
 static int ztls_poll_prepare_pollin(struct tls_context *ctx)
 {
+	int ret;
+
+	if (ctx->is_listening) {
+		return 0;
+	}
+
 	/* If there already is Mbed TLS data to read, there is no
 	 * need to set the k_poll_event object. Return EALREADY
 	 * so we won't block in the k_poll.
 	 */
-	if (!ctx->is_listening) {
-		if (mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl) > 0) {
-			return -EALREADY;
-		}
+	if (mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl) > 0) {
+		return -EALREADY;
 	}
 
-	return 0;
+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+	if (ctx->type == NET_SOCK_DGRAM) {
+		return 0;
+	}
+#endif
+
+	if (!ctx->is_initialized) {
+		return 0;
+	}
+
+	/* Mbed TLS can hold a message that it already read from the underlying
+	 * socket but did not process yet. The socket has no readiness left to
+	 * report in that case, so waiting on it alone can sleep while data is
+	 * available. Advance such a message here instead.
+	 */
+	if (mbedtls_ssl_check_pending(&ctx->active_session->ssl) == 0) {
+		return 0;
+	}
+
+	ret = tls_data_check(ctx);
+	if (ret == 0) {
+		return 0;
+	}
+
+	/* Either plaintext is now exposed, or the session was closed or
+	 * failed. All three have to wake the poll. Latch the failure so that
+	 * the update path can turn it into POLLHUP or POLLERR, as the
+	 * underlying socket will never report it.
+	 */
+	if (ret < 0 && ret != -ENOTCONN) {
+		ctx->error = -ret;
+	}
+
+	return -EALREADY;
 }
 
 static int ztls_poll_prepare_ctx(struct tls_context *ctx,
@@ -4136,7 +4175,18 @@ static int tls_update_pollin(int fd, struct tls_context *ctx,
 	}
 
 	if ((pfd->revents & ZSOCK_POLLIN) == 0) {
-		/* No new data on a socket. */
+		/* No new data on a socket. A poll prepare probe may still have
+		 * left a closed session or a fatal error behind, which the
+		 * underlying socket will never report.
+		 */
+		if (!ctx->is_listening) {
+			if (ctx->active_session->session_closed) {
+				pfd->revents |= ZSOCK_POLLHUP;
+			} else if (ctx->error != 0) {
+				pfd->revents |= ZSOCK_POLLERR;
+			}
+		}
+
 		goto next;
 	}
 

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -11,6 +11,14 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/net/loopback.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
+
+/* The BIO callbacks of a socket are needed to build a datagram that carries
+ * two DTLS records.
+ */
+#if !defined(MBEDTLS_ALLOW_PRIVATE_ACCESS)
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+#endif
+
 #include <mbedtls/ssl.h>
 
 #include "../../socket_helpers.h"
@@ -1791,6 +1799,95 @@ ZTEST(net_socket_tls, test_poll_dtls_pollin)
 	ret = zsock_recv(s_sock, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
 	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
+
+	test_sockets_close();
+
+	/* Small delay for the final alert exchange */
+	k_msleep(10);
+}
+
+static uint8_t coalesce_buf[512];
+static size_t coalesce_len;
+
+/* Collect the ciphertext of a record instead of sending it. */
+static int coalesce_send(void *ctx, const unsigned char *buf, size_t len)
+{
+	ARG_UNUSED(ctx);
+
+	if (len > sizeof(coalesce_buf) - coalesce_len) {
+		return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+	}
+
+	memcpy(coalesce_buf + coalesce_len, buf, len);
+	coalesce_len += len;
+
+	return (int)len;
+}
+
+/* A datagram can carry more than one DTLS record. Mbed TLS reads the whole
+ * datagram in and processes one record at a time, so once the application
+ * has consumed the first record, the socket has no readiness left to report
+ * while Mbed TLS still holds the second one. poll() has to report that
+ * record instead of waiting for a datagram which never comes.
+ */
+ZTEST(net_socket_tls, test_poll_dtls_second_record_in_datagram)
+{
+	static const uint8_t rec_a = 'A';
+	static const uint8_t rec_b = 'B';
+	mbedtls_ssl_context *ssl;
+	mbedtls_ssl_send_t *orig_send;
+	mbedtls_ssl_recv_t *orig_recv;
+	struct zsock_pollfd fds[1];
+	void *p_bio;
+	uint8_t byte;
+	int ret;
+
+	test_prepare_dtls_connection(NET_AF_INET6);
+
+	ssl = ztls_get_mbedtls_ssl_context(s_sock);
+	zassert_not_null(ssl, "No Mbed TLS context for the server socket");
+
+	orig_send = ssl->MBEDTLS_PRIVATE(f_send);
+	orig_recv = ssl->MBEDTLS_PRIVATE(f_recv);
+	p_bio = ssl->MBEDTLS_PRIVATE(p_bio);
+
+	/* Hold both records back, so that they can be handed over in one
+	 * datagram below.
+	 */
+	coalesce_len = 0;
+	mbedtls_ssl_set_bio(ssl, p_bio, coalesce_send, orig_recv, NULL);
+
+	ret = zsock_send(s_sock, &rec_a, sizeof(rec_a), 0);
+	zassert_equal(ret, sizeof(rec_a), "Cannot write the first record");
+
+	ret = zsock_send(s_sock, &rec_b, sizeof(rec_b), 0);
+	zassert_equal(ret, sizeof(rec_b), "Cannot write the second record");
+
+	mbedtls_ssl_set_bio(ssl, p_bio, orig_send, orig_recv, NULL);
+
+	ret = orig_send(p_bio, coalesce_buf, coalesce_len);
+	zassert_equal(ret, coalesce_len, "Cannot send the records");
+
+	fds[0].fd = c_sock;
+	fds[0].events = ZSOCK_POLLIN;
+
+	ret = zsock_poll(fds, 1, 500);
+	zassert_equal(ret, 1, "poll() did not report the datagram");
+
+	ret = zsock_recv(c_sock, &byte, 1, 0);
+	zassert_equal(ret, 1, "Cannot read the first record");
+	zassert_equal(byte, rec_a, "Wrong first record");
+
+	/* The datagram is gone from the socket at this point, the second
+	 * record only exists inside Mbed TLS.
+	 */
+	ret = zsock_poll(fds, 1, 500);
+	zassert_equal(ret, 1, "poll() did not report the second record");
+	zassert_true(fds[0].revents & ZSOCK_POLLIN, "No POLLIN event");
+
+	ret = zsock_recv(c_sock, &byte, 1, 0);
+	zassert_equal(ret, 1, "Cannot read the second record");
+	zassert_equal(byte, rec_b, "Wrong second record");
 
 	test_sockets_close();
 


### PR DESCRIPTION
Mbed TLS can own a record that it read from the underlying socket but did not process yet. In that state mbedtls_ssl_get_bytes_avail() is zero, the underlying socket has no readiness left to report, and the only code able to advance the record, tls_data_check(), runs from poll update after the underlying socket reports POLLIN. A poll can therefore sleep while a complete record is available.

Query mbedtls_ssl_check_pending() during poll prepare for TLS stream sockets and, only when it reports unprocessed data, advance the record with one nonblocking data check. The check runs before the underlying socket lock is taken, because the Mbed TLS BIO re-enters that socket.

A data check can also report a peer close or a fatal error. Neither is visible to the underlying socket, so latch the error and report the latched state as POLLHUP or POLLERR from poll update instead of discarding it.

Fixes #115247
