### PR TITLE
net: wifi: improve Doxygen coverage of the Wi-Fi headers

### DIFF
--- a/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
+++ b/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief ESP32 Wi-Fi mesh public API.
+ * @ingroup esp_wifi_mesh
  *
  * Zephyr-native interface to the ESP Wi-Fi mesh stack: mesh bring-up, the
  * application event callback, the raw send/receive path, and status and

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -8,6 +8,7 @@
 /**
  * @file
  * @brief IEEE 802.11 protocol and general Wi-Fi definitions.
+ * @ingroup wifi_mgmt
  */
 
 /**

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -176,6 +176,7 @@ enum wifi_wpa3_enterprise_type {
 	/** @endcond */
 };
 
+/** @brief EAP TLS cipher types. */
 enum wifi_eap_tls_cipher_type {
 	/** EAP TLS with NONE */
 	WIFI_EAP_TLS_NONE,
@@ -211,6 +212,7 @@ enum wifi_group_mgmt_cipher_type {
 	WPA_CAPA_ENC_BIP_GMAC_256,
 };
 
+/** @brief Cipher capability and name description. */
 struct wifi_cipher_desc {
 	/** Cipher capability. */
 	unsigned int capa;
@@ -218,6 +220,7 @@ struct wifi_cipher_desc {
 	char *name;
 };
 
+/** @brief EAP cipher configuration. */
 struct wifi_eap_cipher_config {
 	/** Key management type string. */
 	char *key_mgmt;
@@ -233,6 +236,7 @@ struct wifi_eap_cipher_config {
 	char *tls_flags;
 };
 
+/** @brief EAP method configuration. */
 struct wifi_eap_config {
 	/**  Security type. */
 	enum wifi_security_type type;
@@ -315,6 +319,7 @@ enum wifi_frequency_bandwidths {
 	WIFI_FREQ_BANDWIDTH_UNKNOWN
 };
 
+/** Helper function to get user-friendly frequency bandwidth name. */
 const char *wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth);
 
 /** Max SSID length */

--- a/include/zephyr/net/wifi_certs.h
+++ b/include/zephyr/net/wifi_certs.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Wi-Fi Enterprise mode credentials setup APIs.
+ * @ingroup wifi_mgmt
+ */
+
 #ifndef ZEPHYR_INCLUDE_NET_WIFI_CERTS_H_
 #define ZEPHYR_INCLUDE_NET_WIFI_CERTS_H_
 

--- a/include/zephyr/net/wifi_credentials.h
+++ b/include/zephyr/net/wifi_credentials.h
@@ -31,26 +31,26 @@ extern "C" {
  */
 
 
-/* this entry contains a BSSID */
+/** This entry contains a BSSID */
 #define WIFI_CREDENTIALS_FLAG_BSSID        BIT(0)
-/* this entry is to be preferred over others */
+/** This entry is to be preferred over others */
 #define WIFI_CREDENTIALS_FLAG_FAVORITE     BIT(1)
-/* this entry can use the 2.4 GHz band */
+/** This entry can use the 2.4 GHz band */
 #define WIFI_CREDENTIALS_FLAG_2_4GHz       BIT(2)
-/* this entry can use the 5 GHz band */
+/** This entry can use the 5 GHz band */
 #define WIFI_CREDENTIALS_FLAG_5GHz         BIT(3)
-/* this entry can use the 6 GHz band */
+/** This entry can use the 6 GHz band */
 #define WIFI_CREDENTIALS_FLAG_6GHz         BIT(4)
-/* this entry requires management frame protection */
+/** This entry requires management frame protection */
 #define WIFI_CREDENTIALS_FLAG_MFP_REQUIRED BIT(5)
-/* this entry disables management frame protection */
+/** This entry disables management frame protection */
 #define WIFI_CREDENTIALS_FLAG_MFP_DISABLED BIT(6)
-/* this entry has anonymous identity configured */
+/** This entry has anonymous identity configured */
 #define WIFI_CREDENTIALS_FLAG_ANONYMOUS_IDENTITY  BIT(7)
-/* this entry has key password configured */
+/** This entry has key password configured */
 #define WIFI_CREDENTIALS_FLAG_KEY_PASSWORD  BIT(8)
 
-/* Maximum length of the password */
+/** Maximum length of the password */
 #define WIFI_CREDENTIALS_MAX_PASSWORD_LEN                                                          \
 	MAX(WIFI_PSK_MAX_LEN, CONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH)
 

--- a/include/zephyr/net/wifi_credentials.h
+++ b/include/zephyr/net/wifi_credentials.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Library for storing and loading Wi-Fi credentials.
+ * @ingroup wifi_credentials
+ */
+
 #ifndef ZEPHYR_INCLUDE_NET_WIFI_CREDENTIALS_H_
 #define ZEPHYR_INCLUDE_NET_WIFI_CREDENTIALS_H_
 

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -9,6 +9,7 @@
 /**
  * @file
  * @brief WiFi L2 stack public header
+ * @ingroup wifi_mgmt
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_WIFI_MGMT_H_

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -197,11 +197,13 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_RTS_THRESHOLD);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS);
 
+/** Request a Wi-Fi 11k configuration */
 #define NET_REQUEST_WIFI_11K_CONFIG				\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_11K_CONFIG)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_11K_CONFIG);
 
+/** Request a Wi-Fi 11k neighbor request */
 #define NET_REQUEST_WIFI_11K_NEIGHBOR_REQUEST			\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_11K_NEIGHBOR_REQUEST)
 
@@ -219,6 +221,7 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_TWT);
 
+/** Request a Wi-Fi broadcast TWT flow setup */
 #define NET_REQUEST_WIFI_BTWT			\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_BTWT)
 
@@ -329,6 +332,7 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_ENTERPRISE_CREDS);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RTS_THRESHOLD_CONFIG);
 
+/** Request a Wi-Fi WPS configuration */
 #define NET_REQUEST_WIFI_WPS_CONFIG (NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_WPS_CONFIG)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_WPS_CONFIG);
@@ -338,26 +342,31 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_WPS_CONFIG);
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT_STORED);
 #endif
 
+/** Request a Wi-Fi roaming start */
 #define NET_REQUEST_WIFI_START_ROAMING				\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_START_ROAMING)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_START_ROAMING);
 
+/** Notify that processing of a Wi-Fi neighbor report is complete */
 #define NET_REQUEST_WIFI_NEIGHBOR_REP_COMPLETE			\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_NEIGHBOR_REP_COMPLETE)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_NEIGHBOR_REP_COMPLETE);
 
+/** Request a Wi-Fi BSS maximum idle period configuration */
 #define NET_REQUEST_WIFI_BSS_MAX_IDLE_PERIOD				\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_BSS_MAX_IDLE_PERIOD)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_BSS_MAX_IDLE_PERIOD);
 
+/** Request a Wi-Fi background scan configuration */
 #define NET_REQUEST_WIFI_BGSCAN					\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_BGSCAN)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_BGSCAN);
 
+/** Request a Wi-Fi Direct (P2P) operation */
 #define NET_REQUEST_WIFI_P2P_OPER						\
 	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_P2P_OPER)
 
@@ -909,6 +918,7 @@ enum wifi_ap_status {
 
 /** @brief Generic Wi-Fi status for commands and events */
 struct wifi_status {
+	/** Command or event specific status */
 	union {
 		/** Status value */
 		int status;
@@ -986,6 +996,7 @@ struct wifi_ps_params {
 	enum wifi_ps_exit_strategy exit_strategy;
 };
 
+/** Maximum number of broadcast TWT agreement sets */
 #define WIFI_BTWT_AGREEMENT_MAX 5
 
 /** @brief Wi-Fi broadcast TWT parameters */
@@ -1016,6 +1027,7 @@ struct wifi_twt_params {
 	uint8_t dialog_token;
 	/** Flow ID, used to map setup with teardown */
 	uint8_t flow_id;
+	/** Operation specific parameters */
 	union {
 		/** Setup specific parameters */
 		struct {
@@ -1141,9 +1153,9 @@ struct wifi_enterprise_creds_params {
 	uint8_t *server_key;
 	/** Server key length */
 	uint32_t server_key_len;
-	/** Diffie–Hellman parameter */
+	/** Diffie-Hellman parameter */
 	uint8_t *dh_param;
-	/** Diffie–Hellman parameter length */
+	/** Diffie-Hellman parameter length */
 	uint32_t dh_param_len;
 };
 
@@ -1704,6 +1716,7 @@ struct wifi_nan_params {
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN */
 
 
+/** Maximum length of a WPS PIN */
 #define WIFI_WPS_PIN_MAX_LEN 8
 
 /** Operation for WPS */
@@ -1878,13 +1891,21 @@ struct wifi_p2p_params {
 /** Wi-Fi AP status
  */
 enum wifi_sap_iface_state {
+	/** Interface is uninitialized */
 	WIFI_SAP_IFACE_UNINITIALIZED,
+	/** Interface is disabled */
 	WIFI_SAP_IFACE_DISABLED,
+	/** Country code update in progress */
 	WIFI_SAP_IFACE_COUNTRY_UPDATE,
+	/** Automatic channel selection in progress */
 	WIFI_SAP_IFACE_ACS,
+	/** HT scan in progress */
 	WIFI_SAP_IFACE_HT_SCAN,
+	/** Dynamic frequency selection in progress */
 	WIFI_SAP_IFACE_DFS,
+	/** Selected channel does not allow initiating radiation */
 	WIFI_SAP_IFACE_NO_IR,
+	/** Interface is enabled */
 	WIFI_SAP_IFACE_ENABLED
 };
 
@@ -1914,12 +1935,17 @@ struct wifi_bgscan_params {
 };
 #endif
 
-/* Extended Capabilities */
+/** IEEE 802.11 Extended Capabilities bit positions */
 enum wifi_ext_capab {
+	/** 20/40 BSS coexistence management support */
 	WIFI_EXT_CAPAB_20_40_COEX = 0,
+	/** General link (GLK) support */
 	WIFI_EXT_CAPAB_GLK = 1,
+	/** Extended channel switching support */
 	WIFI_EXT_CAPAB_EXT_CHAN_SWITCH = 2,
+	/** TIM broadcast support */
 	WIFI_EXT_CAPAB_TIM_BROADCAST = 18,
+	/** BSS transition management support */
 	WIFI_EXT_CAPAB_BSS_TRANSITION = 19,
 };
 

--- a/include/zephyr/net/wifi_nm.h
+++ b/include/zephyr/net/wifi_nm.h
@@ -1,5 +1,6 @@
 /** @file
  * @brief Wi-Fi Network manager API
+ * @ingroup wifi_nm
  *
  * This file contains the Wi-Fi network manager API. These APIs are used by the
  * any network management application to register as a Wi-Fi network manager.

--- a/include/zephyr/net/wifi_utils.h
+++ b/include/zephyr/net/wifi_utils.h
@@ -7,6 +7,7 @@
 /** @file
  *
  * @brief Utility functions to be used by the Wi-Fi subsystem.
+ * @ingroup wifi_mgmt
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_WIFI_UTILS_H_


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` blocks, each attached to its Doxygen group,
  across `net/wifi*.h` and the ESP32 Wi-Fi mesh driver header.
- Documents the remaining `wifi_mgmt` and `wifi_credentials` symbols.
- Documents the EAP configuration structures (`wifi_eap_config`,
  `wifi_eap_cipher_config`, `wifi_cipher_desc`) and
  `wifi_bandwidth_txt()`.

Documentation only, no functional change.