### PR TITLE
Deffered energy density scan

### DIFF
--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -458,41 +458,54 @@ static int esp32_stop(const struct device *dev)
 	return 0;
 }
 
-/* override weak function in components/ieee802154/esp_ieee802154.c of ESP-IDF */
+static void esp32_ed_scan_work_handler(struct k_work *work)
+{
+	energy_scan_done_cb_t callback = esp32_data.energy_scan_done;
+	int8_t power;
+
+	ARG_UNUSED(work);
+
+	if (callback == NULL) {
+		LOG_WRN("No callback available");
+		return;
+	}
+
+	power = esp32_data.ed_scan_power;
+	esp32_data.energy_scan_done = NULL;
+	callback(net_if_get_device(esp32_data.iface), power);
+}
+
+/* Override weak function in components/ieee802154/esp_ieee802154.c of ESP-IDF */
 void IRAM_ATTR esp_ieee802154_energy_detect_done(int8_t power)
 {
-	energy_scan_done_cb_t callback;
-	const struct device *dev;
-
 	if (esp32_data.energy_scan_done == NULL) {
 		return;
 	}
 
-	callback = esp32_data.energy_scan_done;
-	esp32_data.energy_scan_done = NULL;
-	dev = net_if_get_device(esp32_data.iface);
-	callback(dev, power);
+	/* Defer the user callback so the caller stays responsive. */
+	esp32_data.ed_scan_power = power;
+	k_work_submit(&esp32_data.ed_scan_work);
 }
 
 static int esp32_ed_scan(const struct device *dev, uint16_t duration, energy_scan_done_cb_t done_cb)
 {
 	ARG_UNUSED(dev);
 
-	int err = 0;
-
-	if (esp32_data.energy_scan_done == NULL) {
-		esp32_data.energy_scan_done = done_cb;
-
-		/* The duration of energy detection, in symbol unit (16 us) */
-		if (esp_ieee802154_energy_detect(duration * USEC_PER_MSEC / US_PER_SYMBOL) != 0) {
-			esp32_data.energy_scan_done = NULL;
-			err = -EBUSY;
-		}
-	} else {
-		err = -EALREADY;
+	if (esp32_data.energy_scan_done) {
+		return -EALREADY;
 	}
 
-	return err;
+	esp32_data.energy_scan_done = done_cb;
+
+	/* Duration in symbol units (16 us); the channel noise floor is reported
+	 * asynchronously via esp_ieee802154_energy_detect_done().
+	 */
+	if (esp_ieee802154_energy_detect(duration * USEC_PER_MSEC / US_PER_SYMBOL) != 0) {
+		esp32_data.energy_scan_done = NULL;
+		return -EBUSY;
+	}
+
+	return 0;
 }
 
 static int esp32_configure(const struct device *dev, enum ieee802154_config_type type,
@@ -536,6 +549,7 @@ static int esp32_init(const struct device *dev)
 
 	k_sem_init(&data->cca_wait, 0, 1);
 	k_sem_init(&data->tx_wait, 0, 1);
+	k_work_init(&data->ed_scan_work, esp32_ed_scan_work_handler);
 
 	if (esp_ieee802154_enable() != 0) {
 		LOG_ERR("IEEE 802154 enabling failed!");

--- a/drivers/ieee802154/ieee802154_esp32.h
+++ b/drivers/ieee802154/ieee802154_esp32.h
@@ -56,6 +56,14 @@ struct ieee802154_esp32_data {
 	 * It shall be NULL if energy scan is not in progress.
 	 */
 	energy_scan_done_cb_t energy_scan_done;
+
+	/* Energy scan (ED) work item: dispatches energy_scan_done from thread
+	 * context after the HW energy detection completes.
+	 */
+	struct k_work ed_scan_work;
+
+	/* Maximum energy (dBm) reported by the last HW energy detection. */
+	int8_t ed_scan_power;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_ESP32_H_ */


### PR DESCRIPTION
Use k_work to defer the energy density scan calls.