### PR TITLE
net: lwm2m: Add context close event

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -173,6 +173,8 @@ enum lwm2m_rd_client_event {
 	LWM2M_RD_CLIENT_EVENT_DEREGISTER,
 	/** Server disabled */
 	LWM2M_RD_CLIENT_EVENT_SERVER_DISABLED,
+	/** Context closed */
+	LWM2M_RD_CLIENT_EVENT_CONTEXT_CLOSED,
 };
 
 

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -313,6 +313,9 @@ static void rd_client_event(struct lwm2m_ctx *client,
 	case LWM2M_RD_CLIENT_EVENT_DEREGISTER:
 		LOG_DBG("Client De-register");
 		break;
+	case LWM2M_RD_CLIENT_EVENT_CONTEXT_CLOSED:
+		LOG_DBG("Client context closed");
+		break;
 	}
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1033,11 +1033,19 @@ cleanup:
 	return ret;
 }
 
+static void rd_client_context_close(void)
+{
+	lwm2m_engine_context_close(client.ctx);
+	if (client.ctx->event_cb != 0) {
+		client.ctx->event_cb(client.ctx, LWM2M_RD_CLIENT_EVENT_CONTEXT_CLOSED);
+	}
+}
+
 static void sm_handle_registration_update_failure(void)
 {
 	k_mutex_lock(&client.mutex, K_FOREVER);
 	LOG_WRN("Registration Update fail -> trigger full registration");
-	lwm2m_engine_context_close(client.ctx);
+	rd_client_context_close();
 	set_sm_state(ENGINE_SEND_REGISTRATION);
 	k_mutex_unlock(&client.mutex);
 }
@@ -1066,7 +1074,7 @@ static void sm_do_registration(void)
 
 	if (client.ctx->connection_suspended) {
 		if (lwm2m_engine_connection_resume(client.ctx)) {
-			lwm2m_engine_context_close(client.ctx);
+			rd_client_context_close();
 			/* perform full registration */
 			set_sm_state(ENGINE_DO_REGISTRATION);
 			return;
@@ -1086,7 +1094,7 @@ static void sm_do_registration(void)
 				client.close_socket = false;
 				lwm2m_engine_stop(client.ctx);
 			} else {
-				lwm2m_engine_context_close(client.ctx);
+				rd_client_context_close();
 				/* Keep current connection, retry registration with same server */
 				select_srv = false;
 			}
@@ -1251,7 +1259,7 @@ static int sm_do_deregister(void)
 	int ret;
 
 	if (lwm2m_engine_connection_resume(client.ctx)) {
-		lwm2m_engine_context_close(client.ctx);
+		rd_client_context_close();
 		/* Connection failed, enter directly to deregistered state */
 		set_sm_state(ENGINE_DEREGISTERED);
 		return 0;
@@ -1401,7 +1409,7 @@ static void sm_do_network_error(void)
 	/* Retry bootstrap */
 	if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)) {
 		if (client.ctx->bootstrap_mode) {
-			lwm2m_engine_context_close(client.ctx);
+			rd_client_context_close();
 			/* If we don't have fallback BS server, retry with current one */
 			if (sm_next_bootstrap_inst(&client.ctx->sec_obj_inst) < 0) {
 				client.ctx->sec_obj_inst = -1;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -618,8 +618,11 @@ static void do_update_timeout_cb(struct lwm2m_message *msg)
 	if (client.ctx->sock_fd > -1) {
 		client.close_socket = true;
 	}
-	/* Re-do registration */
-	sm_handle_timeout_state(ENGINE_DO_REGISTRATION);
+	/* If we have retries left, try to update again,
+	 * otherwise fallback to bootstrap if enabled
+	 * or restart registration.
+	 */
+	sm_handle_timeout_state(ENGINE_NETWORK_ERROR);
 }
 
 static int do_deregister_reply_cb(const struct coap_packet *response,
@@ -1033,11 +1036,19 @@ cleanup:
 	return ret;
 }
 
+static void rd_client_context_close(void)
+{
+	lwm2m_engine_context_close(client.ctx);
+	if (client.ctx->event_cb != 0) {
+		client.ctx->event_cb(client.ctx, LWM2M_RD_CLIENT_EVENT_CONTEXT_CLOSED);
+	}
+}
+
 static void sm_handle_registration_update_failure(void)
 {
 	k_mutex_lock(&client.mutex, K_FOREVER);
 	LOG_WRN("Registration Update fail -> trigger full registration");
-	lwm2m_engine_context_close(client.ctx);
+	rd_client_context_close();
 	set_sm_state(ENGINE_SEND_REGISTRATION);
 	k_mutex_unlock(&client.mutex);
 }
@@ -1066,7 +1077,7 @@ static void sm_do_registration(void)
 
 	if (client.ctx->connection_suspended) {
 		if (lwm2m_engine_connection_resume(client.ctx)) {
-			lwm2m_engine_context_close(client.ctx);
+			rd_client_context_close();
 			/* perform full registration */
 			set_sm_state(ENGINE_DO_REGISTRATION);
 			return;
@@ -1086,7 +1097,7 @@ static void sm_do_registration(void)
 				client.close_socket = false;
 				lwm2m_engine_stop(client.ctx);
 			} else {
-				lwm2m_engine_context_close(client.ctx);
+				rd_client_context_close();
 				/* Keep current connection, retry registration with same server */
 				select_srv = false;
 			}
@@ -1251,7 +1262,7 @@ static int sm_do_deregister(void)
 	int ret;
 
 	if (lwm2m_engine_connection_resume(client.ctx)) {
-		lwm2m_engine_context_close(client.ctx);
+		rd_client_context_close();
 		/* Connection failed, enter directly to deregistered state */
 		set_sm_state(ENGINE_DEREGISTERED);
 		return 0;
@@ -1401,7 +1412,7 @@ static void sm_do_network_error(void)
 	/* Retry bootstrap */
 	if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)) {
 		if (client.ctx->bootstrap_mode) {
-			lwm2m_engine_context_close(client.ctx);
+			rd_client_context_close();
 			/* If we don't have fallback BS server, retry with current one */
 			if (sm_next_bootstrap_inst(&client.ctx->sec_obj_inst) < 0) {
 				client.ctx->sec_obj_inst = -1;

--- a/tests/net/lib/lwm2m/interop/src/lwm2m-client.c
+++ b/tests/net/lib/lwm2m/interop/src/lwm2m-client.c
@@ -201,6 +201,9 @@ static void rd_client_event(struct lwm2m_ctx *client,
 	case LWM2M_RD_CLIENT_EVENT_DEREGISTER:
 		LOG_DBG("Deregistration client");
 		break;
+	case LWM2M_RD_CLIENT_EVENT_CONTEXT_CLOSED:
+		LOG_DBG("Client context closed");
+		break;
 	}
 }
 

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/main.c
@@ -113,6 +113,9 @@ static void lwm2m_event_cb(struct lwm2m_ctx *client, enum lwm2m_rd_client_event 
 	case LWM2M_RD_CLIENT_EVENT_DEREGISTER:
 		LOG_INF("*** LWM2M_RD_CLIENT_EVENT_DEREGISTER");
 		break;
+	case LWM2M_RD_CLIENT_EVENT_CONTEXT_CLOSED:
+		LOG_INF("*** LWM2M_RD_CLIENT_EVENT_CONTEXT_CLOSED");
+		break;
 	}
 
 	show_lwm2m_event(client_event);


### PR DESCRIPTION
Added event to the LwM2M client to notify when the context is closed.
I am doing some developments on the engine regarding observation and registration persistence across device reboots. I found it useful to have an event that notifies the application when the LWM2M context is closed.
An example of the usefulness would be:
- Device does registration update
- Registration update timeout
- Max retries -> fallback to bootstrap
- Application session persistence is no longer valid due to bootstrap
I was left with two choices, either add a new event for the 'bootstrap beginning' or add an event for the 'context close', I believe the latter is more useful since it is triggered on other circumstances when the LwM2M client session is no longer valid, e.g. new registration, reg update failure...