### PR TITLE
usb: device_next: Correct trace message specifier

### DIFF
--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -220,7 +220,7 @@ static struct net_buf *lb_control_to_host(struct usbd_class_data *c_data,
 
 		net_buf_add_mem(buf, lb_buf, len);
 
-		LOG_WRN("Device-to-Host, wLength %u | %zu", setup->wLength, len);
+		LOG_WRN("Device-to-Host, wLength %u | %u", setup->wLength, len);
 
 		return buf;
 	}


### PR DESCRIPTION
Correct the trace message %zu specifier added by commit e5bc5c7a6d57 that that should rather be %u since argument is not of size_t or like type.