### PR TITLE
usb_c: improve Doxygen coverage of the USB-C headers

### DIFF
--- a/include/zephyr/drivers/usb_c/tcpci_priv.h
+++ b/include/zephyr/drivers/usb_c/tcpci_priv.h
@@ -6,6 +6,7 @@
 /**
  * @file
  * @brief Helper functions to use by the TCPCI-compliant drivers
+ * @ingroup usb_type_c_port_controller_api
  *
  * This file contains generic TCPCI functions that may be used by the drivers to TCPCI-compliant
  * devices that want to implement vendor-specific functionality without the need to reimplement the

--- a/include/zephyr/drivers/usb_c/usbc_pd.h
+++ b/include/zephyr/drivers/usb_c/usbc_pd.h
@@ -6,6 +6,7 @@
 /**
  * @file
  * @brief USB-C Power Delivery API used for USB-C drivers
+ * @ingroup usb_power_delivery
  *
  * The information in this file was taken from the USB PD
  * Specification Revision 3.0, Version 2.0

--- a/include/zephyr/drivers/usb_c/usbc_pd.h
+++ b/include/zephyr/drivers/usb_c/usbc_pd.h
@@ -319,6 +319,7 @@ extern "C" {
  *	  See Table 6-1 Message Header
  */
 union pd_header {
+	/** PD Header fields */
 	struct {
 		/** Type of message */
 		uint16_t message_type : 5;
@@ -335,6 +336,7 @@ union pd_header {
 		/** Extended Message */
 		uint16_t extended : 1;
 	};
+	/** Raw PD Header value */
 	uint16_t raw_value;
 };
 
@@ -350,6 +352,7 @@ union pd_header {
  *	  See Table 6-3 Extended Message Header
  */
 union pd_ext_header {
+	/** Extended Message Header fields */
 	struct {
 		/** Number of total bytes in data block */
 		uint16_t data_size : 9;
@@ -426,6 +429,7 @@ enum pdo_type {
  *	  See Table 6-9 Fixed Supply PDO - Source
  */
 union pd_fixed_supply_pdo_source {
+	/** Fixed Supply PDO Source fields */
 	struct {
 		/** Maximum Current in 10mA units */
 		uint32_t max_current : 10;
@@ -473,6 +477,7 @@ enum pd_frs_type {
  *	  See Table 6-14 Fixed Supply PDO - Sink
  */
 union pd_fixed_supply_pdo_sink {
+	/** Fixed Supply PDO Sink fields */
 	struct {
 		/** Operational Current in 10mA units */
 		uint32_t operational_current : 10;
@@ -532,6 +537,7 @@ union pd_fixed_supply_pdo_sink {
  *	  See Table 6-11 Variable Supply (non-Battery) PDO - Source
  */
 union pd_variable_supply_pdo_source {
+	/** Variable Supply PDO Source fields */
 	struct {
 		/** Maximum Current in 10mA units */
 		uint32_t max_current : 10;
@@ -551,6 +557,7 @@ union pd_variable_supply_pdo_source {
  *	  See Table 6-15 Variable Supply (non-Battery) PDO - Sink
  */
 union pd_variable_supply_pdo_sink {
+	/** Variable Supply PDO Sink fields */
 	struct {
 		/** operational Current in 10mA units */
 		uint32_t operational_current : 10;
@@ -598,6 +605,7 @@ union pd_variable_supply_pdo_sink {
  *	  See Table 6-12 Battery Supply PDO - Source
  */
 union pd_battery_supply_pdo_source {
+	/** Battery Supply PDO Source fields */
 	struct {
 		/** Maximum Allowable Power in 250mW units */
 		uint32_t max_power : 10;
@@ -617,6 +625,7 @@ union pd_battery_supply_pdo_source {
  *	  See Table 6-16 Battery Supply PDO - Sink
  */
 union pd_battery_supply_pdo_sink {
+	/** Battery Supply PDO Sink fields */
 	struct {
 		/** Operational Power in 250mW units */
 		uint32_t operational_power : 10;
@@ -664,6 +673,7 @@ union pd_battery_supply_pdo_sink {
  *	  See Table 6-13 Programmable Power Supply APDO - Source
  */
 union pd_augmented_supply_pdo_source {
+	/** Augmented Supply PDO Source fields */
 	struct {
 		/** Maximum Current in 50mA increments */
 		uint32_t max_current : 7;
@@ -697,6 +707,7 @@ union pd_augmented_supply_pdo_source {
  *	  See Table 6-17 Programmable Power Supply APDO - Sink
  */
 union pd_augmented_supply_pdo_sink {
+	/** Augmented Supply PDO Sink fields */
 	struct {
 		/** Maximum Current in 50mA increments */
 		uint32_t max_current : 7;

--- a/include/zephyr/drivers/usb_c/usbc_ppc.h
+++ b/include/zephyr/drivers/usb_c/usbc_ppc.h
@@ -55,6 +55,15 @@ enum usbc_ppc_event {
 	USBC_PPC_EVENT_SNK_OVERVOLTAGE,
 };
 
+/**
+ * @brief Callback used to notify about PPC events
+ *
+ * Registered with ppc_set_event_handler().
+ *
+ * @param dev PPC device structure
+ * @param data User data passed to ppc_set_event_handler()
+ * @param ev Event being notified
+ */
 typedef void (*usbc_ppc_event_cb_t)(const struct device *dev, void *data, enum usbc_ppc_event ev);
 
 /**

--- a/include/zephyr/drivers/usb_c/usbc_ppc.h
+++ b/include/zephyr/drivers/usb_c/usbc_ppc.h
@@ -6,6 +6,7 @@
 /**
  * @file
  * @brief USB Type-C Power Path Controller device API
+ * @ingroup usb_type_c_power_path_controller
  *
  */
 

--- a/include/zephyr/drivers/usb_c/usbc_tc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tc.h
@@ -8,6 +8,7 @@
 /**
  * @file
  * @brief USB Type-C Cable and Connector API used for USB-C drivers
+ * @ingroup usb_type_c
  *
  * The information in this file was taken from the USB Type-C
  * Cable and Connector Specification Release 2.1

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -6,6 +6,7 @@
 /**
  * @file
  * @brief USBC Type-C Port Controller device APIs
+ * @ingroup usb_type_c_port_controller_api
  *
  * This file contains the USB Type-C Port Controller device APIs.
  * All Type-C Port Controller device drivers should implement the

--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -6,6 +6,7 @@
 /**
  * @file
  * @brief USB-C VBUS device APIs
+ * @ingroup usbc_vbus_api
  *
  * This file contains the USB-C VBUS device APIs.
  * All USB-C VBUS measurement and control device drivers should

--- a/include/zephyr/usb_c/tcpci.h
+++ b/include/zephyr/usb_c/tcpci.h
@@ -214,6 +214,7 @@
 	((((drp) << 6) & TCPC_REG_ROLE_CTRL_DRP_MASK) |                                            \
 	 (((rp) << 4) & TCPC_REG_ROLE_CTRL_RP_MASK) |                                              \
 	 (((cc2) << 2) & TCPC_REG_ROLE_CTRL_CC2_MASK) | ((cc1) & TCPC_REG_ROLE_CTRL_CC1_MASK))
+/** Macro to extract the dual-role port bit from register value */
 #define TCPC_REG_ROLE_CTRL_DRP(reg) (((reg) & TCPC_REG_ROLE_CTRL_DRP_MASK) >> 6)
 /** Macro to extract the enum tc_rp_value from register value */
 #define TCPC_REG_ROLE_CTRL_RP(reg)  (((reg) & TCPC_REG_ROLE_CTRL_RP_MASK) >> 4)
@@ -407,6 +408,7 @@
 #define TCPC_REG_DEV_CAP_1_SRC_RESISTOR_RP_3P0_1P5_DEF     2
 /** Mask for power roles supported */
 #define TCPC_REG_DEV_CAP_1_POWER_ROLE_MASK                 GENMASK(7, 5)
+/** Macro to extract the supported power roles from register value */
 #define TCPC_REG_DEV_CAP_1_POWER_ROLE(reg)                 \
 	(((reg) & TCPC_REG_DEV_CAP_1_POWER_ROLE_MASK) >> 5)
 /** Value for support both source and sink only (no DRP) */

--- a/include/zephyr/usb_c/tcpci.h
+++ b/include/zephyr/usb_c/tcpci.h
@@ -9,6 +9,7 @@
 /**
  * @file
  * @brief Registers and fields definitions for TypeC Port Controller Interface
+ * @ingroup usb_type_c_port_controller_api
  *
  * This file contains register addresses, fields and masks used to retrieve specific data from
  * registry values. They may be used by all TCPC drivers compliant to the TCPCI specification.

--- a/include/zephyr/usb_c/usbc.h
+++ b/include/zephyr/usb_c/usbc.h
@@ -6,6 +6,7 @@
 /**
  * @file
  * @brief USB-C Device APIs
+ * @ingroup _usbc_device_api
  *
  * This file contains the USB-C Device APIs.
  */

--- a/include/zephyr/usb_c/usbc.h
+++ b/include/zephyr/usb_c/usbc.h
@@ -357,6 +357,8 @@ int usbc_suspend(const struct device *dev);
  */
 int usbc_request(const struct device *dev, const enum usbc_policy_request_t req);
 
+/** @cond INTERNAL_HIDDEN */
+
 /**
  * @internal
  * @brief Bypass the next USB-C stack sleep and execute one more iteration of the state machines.
@@ -365,6 +367,8 @@ int usbc_request(const struct device *dev, const enum usbc_policy_request_t req)
  * @param dev Runtime device structure
  */
 void usbc_bypass_next_sleep(const struct device *dev);
+
+/** @endcond */
 
 /**
  * @brief Set pointer to Device Policy Manager (DPM) data


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` blocks, each attached to its Doxygen group,
  across `drivers/usb_c/` and `usb_c/`.
- Documents the PD header and PDO field structures, and the PPC event
  callback.
- Documents the two TCPCI register accessor macros.
- Hides `usbc_bypass_next_sleep()`, which is internal to the USB-C
  stack, from the generated documentation.

Documentation only, no functional change.