### PR TITLE
doc: use 'west twister' instead of './scripts/twister'

### DIFF
--- a/doc/develop/manifest/external/zscilib.rst
+++ b/doc/develop/manifest/external/zscilib.rst
@@ -64,7 +64,7 @@ To run the unit tests for this library, run the following command:
 
 .. code-block:: console
 
-    $ twister --inline-logs -p mps2/an521/cpu0 -T tests
+    $ west twister --inline-logs -p mps2/an521/cpu0 -T tests
     See the tests folder for further details.
 
 

--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -999,7 +999,7 @@ when executing twister, for example:
 
   ./scripts/zephyr_module.py --twister-out module_tests.args
   if [ -s module_tests.args ]; then
-      ./scripts/twister +module_tests.args --outdir module_tests ...
+      west twister +module_tests.args --outdir module_tests ...
   fi
 
 

--- a/doc/develop/test/coverage.rst
+++ b/doc/develop/test/coverage.rst
@@ -140,13 +140,13 @@ For example, you may invoke:
 
 .. code-block:: console
 
-    $ twister --coverage -p qemu_x86 -T tests/kernel
+    $ west twister --coverage -p qemu_x86 -T tests/kernel
 
 or:
 
 .. code-block:: console
 
-    $ twister --coverage -p native_sim -T tests/bluetooth
+    $ west twister --coverage -p native_sim -T tests/bluetooth
 
 which will produce ``twister-out/coverage/index.html`` report as well as
 the coverage data collected by ``gcovr`` tool in ``twister-out/coverage.json``.
@@ -161,7 +161,7 @@ command line option, for example:
 
 .. code-block:: console
 
-   $ $ZEPHYR_BASE/scripts/twister --coverage -p native_sim --coverage-basedir $ZEPHYR_BASE -T your_project_dir
+   $ west twister --coverage -p native_sim --coverage-basedir $ZEPHYR_BASE -T your_project_dir
 
 .. note::
 
@@ -177,7 +177,7 @@ toolchain and require a different board:
 
 .. code-block:: console
 
-   $ twister --coverage -p unit_testing -T tests/unit
+   $ west twister --coverage -p unit_testing -T tests/unit
 
 which produces a report in the same location as non-unit testing.
 
@@ -190,7 +190,7 @@ answer "which tests exercised line X of ``foo.c``" -- pass ``--coverage-per-test
 
 .. code-block:: console
 
-   $ twister -p mps2/an385 -T tests/kernel --coverage --coverage-tool lcov \
+   $ west twister -p mps2/an385 -T tests/kernel --coverage --coverage-tool lcov \
        --coverage-per-test
 
 This enables :kconfig:option:`CONFIG_ZTEST_COVERAGE_PER_TEST`, which resets the

--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -28,13 +28,13 @@ use the :ref:`Twister <twister_script>` tool, for example:
 
 .. code-block:: console
 
-    ./scripts/twister -T tests/foo/bar/
+    west twister -T tests/foo/bar/
 
 To select just one of the test scenarios, run Twister with ``--scenario`` command:
 
 .. code-block:: console
 
-   ./scripts/twister --scenario tests/foo/bar/your.test.scenario.name
+   west twister --scenario tests/foo/bar/your.test.scenario.name
 
 In the command line above ``tests/foo/bar`` is the path to your test application and
 ``your.test.scenario.name`` references a test scenario defined in :file:`tests.yaml`
@@ -102,7 +102,7 @@ can list all kernel test cases, for example, by running:
 
 .. code-block:: console
 
-   ./scripts/twister --list-tests -T tests/kernel
+   west twister --list-tests -T tests/kernel
 
 Skipping Tests
 ==============

--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -45,10 +45,9 @@ To run Twister in the local tree, follow the steps below:
    operating systems. The following invocations are equivalent:
 
    * ``west twister ...`` (recommended).
-   * ``./scripts/twister ...`` (Linux/macOS) or ``python .\scripts\twister ...``
-     (Windows): invoking the script directly. This requires the Zephyr
-     environment to be set up first (``source zephyr-env.sh`` or
-     ``zephyr-env.cmd``).
+   * ``python .\scripts\twister ...`` (Windows): invoking the script
+     directly. This requires the Zephyr environment to be set up first (``source
+     zephyr-env.sh`` or ``zephyr-env.cmd``).
 
    All forms accept the same command line options.
 

--- a/doc/develop/twister/pytest.rst
+++ b/doc/develop/twister/pytest.rst
@@ -93,7 +93,7 @@ There are two ways for passing extra arguments to the called pytest subprocess:
 
    .. code-block:: console
 
-      $ ./scripts/twister --platform native_sim -T samples/subsys/testsuite/pytest/shell \
+      $ west twister --platform native_sim -T samples/subsys/testsuite/pytest/shell \
       -s samples/subsys/testsuite/pytest/shell/sample.pytest.shell \
       --pytest-args='-k test_shell_print_version'
 
@@ -338,7 +338,7 @@ How to run only one particular test from a python file?
 
    .. code-block:: console
 
-      $ ./scripts/twister ... --pytest-args='-k test_shell_print_help'
+      $ west twister ... --pytest-args='-k test_shell_print_help'
 
 How to get information about used device type in test?
 ======================================================

--- a/doc/services/debugging/gdbstub.rst
+++ b/doc/services/debugging/gdbstub.rst
@@ -96,7 +96,7 @@ Run the test with the following command from your :envvar:`ZEPHYR_BASE` director
 
    .. code-block:: console
 
-      ./scripts/twister -p qemu_x86 -T tests/subsys/debug/gdbstub
+      west twister -p qemu_x86 -T tests/subsys/debug/gdbstub
 
 The test should run successfully, and now let's do something similar step-by-step
 to demonstrate how the Zephyr GDB stub works from the GDB user's perspective.


### PR DESCRIPTION
Be consistent in instructions about how to invoke twister and use 'west
twister', which can be invoked from any path in the tree.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
