### PR TITLE
arch: arm: delay msp interrupt stack setup until thread switch

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -553,6 +553,8 @@ int arch_coprocessors_disable(struct k_thread *thread)
  */
 static void z_arm_prepare_switch_to_main(void)
 {
+	z_arm_interrupt_stack_setup();
+
 #if defined(CONFIG_FPU)
 	/* Initialize the Floating Point Status and Control Register when in
 	 * Unshared FP Registers mode (In Shared FP Registers mode, FPSCR is

--- a/arch/arm/include/cortex_m/kernel_arch_func.h
+++ b/arch/arm/include/cortex_m/kernel_arch_func.h
@@ -43,7 +43,6 @@ extern int z_arm_mmu_init(void);
 
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-	z_arm_interrupt_stack_setup();
 	z_arm_exc_setup();
 	z_arm_fault_init();
 	z_arm_cpu_idle_init();


### PR DESCRIPTION
Fixes a critical architectural bug (Issue #88929) where the Main Stack Pointer (MSP) was being prematurely set to `z_interrupt_stacks` in `arch_kernel_init()`.

During early Zephyr initialization, `z_prep_c` sets the Process Stack Pointer (PSP) to point to `z_interrupt_stacks`. If `arch_kernel_init()` subsequently sets MSP to `z_interrupt_stacks` before switching to the main thread, any interrupts firing during early init (`PRE_KERNEL_1`/`PRE_KERNEL_2`) will corrupt the boot thread's PSP stack, causing memory corruption and hardware exceptions.

By moving `z_arm_interrupt_stack_setup()` to `z_arm_prepare_switch_to_main()`, we ensure that MSP safely remains on `z_main_stack` during early boot, and is only configured to use `z_interrupt_stacks` right before PSP is switched to the main thread stack.

Fixes #88929