### PR TITLE
usb: device_next: fix compile warning

### DIFF
--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -220,7 +220,7 @@ static struct net_buf *lb_control_to_host(struct usbd_class_data *c_data,
 
 		net_buf_add_mem(buf, lb_buf, len);
 
-		LOG_WRN("Device-to-Host, wLength %u | %zu", setup->wLength, len);
+		LOG_WRN("Device-to-Host, wLength %u | %u", setup->wLength, len);
 
 		return buf;
 	}


### PR DESCRIPTION
Fixes:

loopback.c:223:25: error: format '%zu' expects argument of type 'size_t', but argument 3 has type 'int' [-Werror=format=]

tested with:

west build -p -b frdm_imx93/mimx9352/a55 samples/subsys/usb/shell -T sample.usbd.shell