### PR TITLE
drivers: pm_cpu_ops: improve Doxygen coverage of the PSCI headers

### DIFF
--- a/include/zephyr/drivers/pm_cpu_ops.h
+++ b/include/zephyr/drivers/pm_cpu_ops.h
@@ -10,6 +10,7 @@
 /**
  * @file
  * @brief Public API for CPU Power Management
+ * @ingroup power_management_cpu_api
  */
 
 #include <zephyr/types.h>

--- a/include/zephyr/drivers/pm_cpu_ops.h
+++ b/include/zephyr/drivers/pm_cpu_ops.h
@@ -21,8 +21,10 @@
 extern "C" {
 #endif
 
-/* System reset types. */
+/** Warm system reset, used as argument to pm_system_reset(). */
 #define SYS_WARM_RESET 0
+
+/** Cold system reset, used as argument to pm_system_reset(). */
 #define SYS_COLD_RESET 1
 /**
  * @defgroup power_management_cpu_api CPU Power Management

--- a/include/zephyr/drivers/pm_cpu_ops/psci.h
+++ b/include/zephyr/drivers/pm_cpu_ops/psci.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ARM PSCI specific APIs for CPU power management.
+ * @ingroup power_management_cpu_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PM_CPU_OPS_PSCI_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PM_CPU_OPS_PSCI_H_
 

--- a/include/zephyr/drivers/pm_cpu_ops/psci.h
+++ b/include/zephyr/drivers/pm_cpu_ops/psci.h
@@ -23,16 +23,38 @@ extern "C" {
 #endif
 
 /* PSCI version decoding (independent of PSCI version) */
+
+/** @cond INTERNAL_HIDDEN */
 #define PSCI_VERSION_MAJOR_SHIFT		16
 #define PSCI_VERSION_MINOR_MASK			\
 		((1U << PSCI_VERSION_MAJOR_SHIFT) - 1)
 #define PSCI_VERSION_MAJOR_MASK			~PSCI_VERSION_MINOR_MASK
+/** @endcond */
 
+/**
+ * @brief Extract the major version field from a PSCI version value
+ *
+ * @param ver PSCI version value
+ */
 #define PSCI_VERSION_MAJOR(ver)			\
 		(((ver) & PSCI_VERSION_MAJOR_MASK) >> PSCI_VERSION_MAJOR_SHIFT)
+/**
+ * @brief Extract the minor version field from a PSCI version value
+ *
+ * @param ver PSCI version value
+ */
 #define PSCI_VERSION_MINOR(ver)			\
 		((ver) & PSCI_VERSION_MINOR_MASK)
 
+/**
+ * @brief Get the PSCI firmware version
+ *
+ * Returns the version of the detected PSCI firmware, with the major version
+ * in the upper 16 bits and the minor version in the lower 16 bits. Use
+ * PSCI_VERSION_MAJOR() and PSCI_VERSION_MINOR() to decode the fields.
+ *
+ * @return PSCI firmware version
+ */
 uint32_t psci_version(void);
 
 /**


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` block to `pm_cpu_ops/psci.h` and attaches
  both headers to the `power_management_cpu_api` group.
- Documents the `SYS_WARM_RESET` and `SYS_COLD_RESET` arguments to
  `pm_system_reset()`.
- Documents `PSCI_VERSION_MAJOR()`, `PSCI_VERSION_MINOR()` and
  `psci_version()`, including how the major and minor fields are packed.
  The shift and mask macros they are built from are not used outside
  this header, so they are excluded from the generated documentation
  rather than documented as API.

Documentation only, no functional change.