### PR TITLE
include: zephyr: drivers: pinctrl: Enhance drivers API documentation

### DIFF
--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -369,6 +369,8 @@ static inline int pinctrl_apply_state(const struct pinctrl_dev_config *config,
  * The name of the defined state pins variable is the same used by @p prop. This
  * macro is expected to be used in conjunction with #PINCTRL_DT_STATE_INIT.
  *
+ * @kconfig_dep{CONFIG_PINCTRL_DYNAMIC}
+ *
  * @param node_id Node identifier containing @p prop.
  * @param prop Property within @p node_id containing state configuration.
  *
@@ -384,6 +386,8 @@ static inline int pinctrl_apply_state(const struct pinctrl_dev_config *config,
  * This macro should be used in conjunction with #PINCTRL_DT_STATE_PINS_DEFINE
  * when using dynamic pin control to define an alternative state configuration
  * stored in Devicetree.
+ *
+ * @kconfig_dep{CONFIG_PINCTRL_DYNAMIC}
  *
  * Example:
  *
@@ -427,6 +431,8 @@ static inline int pinctrl_apply_state(const struct pinctrl_dev_config *config,
  * have to be provided. For example, if @c default and @c sleep are in the
  * current list of states, it is expected that the new array of states also
  * contains both.
+ *
+ * @kconfig_dep{CONFIG_PINCTRL_DYNAMIC}
  *
  * @param config Pin control configuration.
  * @param states New states to be set.


### PR DESCRIPTION
Some Zephyr driver exported header files conditioned functions declaration and macros/structures definition with #ifdef CONFIG_xxx (or like) directives preventing the APIs/ABIs documentation to be considered during the Doxygen based Zepĥyr documentation generation process.

Enhance documentation in these header files by adding @kconfig_dep{CONFIG_xxx} command where applicable and either adding defined(__DOXYGEN__) directives or removing the #ifdef CONFIG_xxx directive (or like) (as per [1]).

Link: https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-1-conditional-compilation [1]