### PR TITLE
include: zephyr: drivers: pcie: Enhance drivers API documentation

### DIFF
--- a/include/zephyr/drivers/pcie/controller.h
+++ b/include/zephyr/drivers/pcie/controller.h
@@ -128,10 +128,14 @@ typedef bool (*pcie_ctrl_region_translate_t)(const struct device *dev, pcie_bdf_
 					     bool mem, bool mem64, uintptr_t bar_bus_addr,
 					     uintptr_t *bar_addr);
 
-#ifdef CONFIG_PCIE_MSI
+/**
+ * @brief Function called to configure the given PCI endpoint to generate MSIs.
+ * See pcie_ctrl_msi_device_setup() for description.
+ *
+ * @kconfig_dep{CONFIG_PCIE_MSI}
+ */
 typedef uint8_t (*pcie_ctrl_msi_device_setup_t)(const struct device *dev, unsigned int priority,
 						msi_vector_t *vectors, uint8_t n_vector);
-#endif
 
 /**
  * @brief Read a 32-bit word from a Memory-Mapped endpoint's configuration space.

--- a/include/zephyr/drivers/pcie/msi.h
+++ b/include/zephyr/drivers/pcie/msi.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+/**  @cond INTERNAL_HIDDEN */
+
 #ifdef CONFIG_PCIE_CONTROLLER
 struct msi_vector_generic {
 	unsigned int irq;
@@ -57,12 +59,16 @@ struct msi_vector {
 #endif /* CONFIG_PCIE_MSI_X */
 };
 
+/** @endcond */
+
+/** Type for MSI interrupt vector */
 typedef struct msi_vector msi_vector_t;
 
-#ifdef CONFIG_PCIE_MSI_MULTI_VECTOR
 
 /**
  * @brief Allocate vector(s) for the endpoint MSI message(s)
+ *
+ * @kconfig_dep{CONFIG_PCIE_MSI_MULTI_VECTOR}
  *
  * @param bdf the target PCI endpoint
  * @param priority the MSI vectors base interrupt priority
@@ -79,6 +85,8 @@ extern uint8_t pcie_msi_vectors_allocate(pcie_bdf_t bdf,
 /**
  * @brief Connect the MSI vector to the handler
  *
+ * @kconfig_dep{CONFIG_PCIE_MSI_MULTI_VECTOR}
+ *
  * @param bdf the target PCI endpoint
  * @param vector the MSI vector to connect
  * @param routine Interrupt service routine
@@ -92,8 +100,6 @@ extern bool pcie_msi_vector_connect(pcie_bdf_t bdf,
 				    void (*routine)(const void *parameter),
 				    const void *parameter,
 				    uint32_t flags);
-
-#endif /* CONFIG_PCIE_MSI_MULTI_VECTOR */
 
 /**
  * @brief Compute the target address for an MSI posted write.
@@ -142,6 +148,8 @@ extern bool pcie_msi_enable(pcie_bdf_t bdf,
  * @return true if the endpoint support MSI/MSI-X
  */
 extern bool pcie_is_msi(pcie_bdf_t bdf);
+
+/**  @cond INTERNAL_HIDDEN */
 
 /*
  * The first word of the MSI capability is shared with the
@@ -192,6 +200,8 @@ extern bool pcie_is_msi(pcie_bdf_t bdf);
 #define PCIE_VTBL_MUA			4U /* Msg Upper Address offset */
 #define PCIE_VTBL_MD			8U /* Msg Data offset */
 #define PCIE_VTBL_VCTRL			12U /* Vector control offset */
+
+/** @endcond */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Some Zephyr driver exported header files conditioned functions declaration and macros/structures definition with #ifdef CONFIG_xxx (or like) directives preventing the APIs/ABIs documentation to be considered during the Doxygen based Zepĥyr documentation generation process.

Enhance documentation in these header files by adding @kconfig_dep{CONFIG_xxx} command where applicable and either adding defined(__DOXYGEN__) directives or removing the #ifdef CONFIG_xxx directive (or like) (as per [1]).

Link: https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-1-conditional-compilation [1]