### PR TITLE
include: zephyr: drivers: misc: nexp_flexram: Enhance drivers API docs

### DIFF
--- a/include/zephyr/drivers/misc/flexram/nxp_flexram.h
+++ b/include/zephyr/drivers/misc/flexram/nxp_flexram.h
@@ -10,6 +10,8 @@
 #include <zephyr/devicetree.h>
 #include <soc.h>
 
+/**  @cond INTERNAL_HIDDEN */
+
 #define FLEXRAM_DT_NODE    DT_INST(0, nxp_flexram)
 #define IOMUXC_GPR_DT_NODE DT_NODELABEL(iomuxcgpr)
 
@@ -68,11 +70,14 @@ static inline void flexram_dt_partition(void)
 }
 #endif /* FLEXRAM_RUNTIME_BANKS_USED */
 
-#ifdef CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API
+/** @endcond */
+
 /** @brief Sets magic address for OCRAM
  *
  * Magic address allows core interrupt from FlexRAM when address
  * is accessed.
+ *
+ * @kconfig_dep{CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API}
  *
  * @param ocram_addr: An address in OCRAM to set magic function on.
  * @retval 0 on success
@@ -86,6 +91,8 @@ int flexram_set_ocram_magic_addr(uint32_t ocram_addr);
  * Magic address allows core interrupt from FlexRAM when address
  * is accessed.
  *
+ * @kconfig_dep{CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API}
+ *
  * @param itcm_addr: An address in ITCM to set magic function on.
  * @retval 0 on success
  * @retval -EINVAL if itcm_addr is not in ITCM
@@ -98,13 +105,13 @@ int flexram_set_itcm_magic_addr(uint32_t itcm_addr);
  * Magic address allows core interrupt from FlexRAM when address
  * is accessed.
  *
+ * @kconfig_dep{CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API}
+ *
  * @param dtcm_addr: An address in DTCM to set magic function on.
  * @retval 0 on success
  * @retval -EINVAL if dtcm_addr is not in DTCM
  * @retval -ENODEV if there is no DTCM allocation in flexram
  */
 int flexram_set_dtcm_magic_addr(uint32_t dtcm_addr);
-
-#endif /* CONFIG_NXP_FLEXRAM_MAGIC_ADDR_API */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MISC_FLEXRAM_NXP_FLEXRAM_H_ */


### PR DESCRIPTION
Some Zephyr driver exported header files conditioned functions declaration and macros/structures definition with #ifdef CONFIG_xxx (or like) directives preventing the APIs/ABIs documentation to be considered during the Doxygen based Zepĥyr documentation generation process.

Enhance documentation in these header files by adding @kconfig_dep{CONFIG_xxx} command where applicable and either removing the #ifdef CONFIG_xxx directive (or like) (as per [1]).

For consistency, add a few Doxygen inline description comments and a few "@cond INTERNAL_HIDDEN"/"@endcond" commands where documentation was missing to prevent documentation generation failures.

Link: https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-1-conditional-compilation [1]