### PR TITLE
include: zephyr: drivers: cache: Enhance drivers API documentation

### DIFF
--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -28,12 +28,12 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_DCACHE)
-
 /**
  * @brief Enable the d-cache
  *
  * Enable the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  */
 void cache_data_enable(void);
 
@@ -41,6 +41,8 @@ void cache_data_enable(void);
  * @brief Disable the d-cache
  *
  * Disable the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  */
 void cache_data_disable(void);
 
@@ -48,6 +50,8 @@ void cache_data_disable(void);
  * @brief Flush the d-cache
  *
  * Flush the whole data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
@@ -59,6 +63,8 @@ int cache_data_flush_all(void);
  *
  * Invalidate the whole data cache.
  *
+ * @kconfig_dep{CONFIG_DCACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -69,6 +75,8 @@ int cache_data_invd_all(void);
  *
  * Flush and Invalidate the whole data cache.
  *
+ * @kconfig_dep{CONFIG_DCACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -78,6 +86,8 @@ int cache_data_flush_and_invd_all(void);
  * @brief Flush an address range in the d-cache
  *
  * Flush the specified address range of the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
@@ -98,6 +108,8 @@ int cache_data_flush_range(void *addr, size_t size);
  * @brief Invalidate an address range in the d-cache
  *
  * Invalidate the specified address range of the data cache.
+ *
+ * @kconfig_dep{CONFIG_DCACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being invalidated, all the portions of the
@@ -120,6 +132,8 @@ int cache_data_invd_range(void *addr, size_t size);
  *
  * Flush and Invalidate the specified address range of the data cache.
  *
+ * @kconfig_dep{CONFIG_DCACHE}
+ *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
  *       data structures sharing the same line will be flushed before being
@@ -136,7 +150,6 @@ int cache_data_invd_range(void *addr, size_t size);
  */
 int cache_data_flush_and_invd_range(void *addr, size_t size);
 
-#if defined(CONFIG_DCACHE_LINE_SIZE_DETECT)
 /**
  *
  * @brief Get the d-cache line size.
@@ -147,19 +160,17 @@ int cache_data_flush_and_invd_range(void *addr, size_t size);
  * The function must be implemented only when CONFIG_DCACHE_LINE_SIZE_DETECT is
  * defined.
  *
+ * @kconfig_dep{CONFIG_DCACHE_LINE_SIZE_DETECT}
+ *
  * @retval size Size of the d-cache line.
  * @retval 0 The d-cache is not enabled.
  */
 size_t cache_data_line_size_get(void);
 
-#endif /* CONFIG_DCACHE_LINE_SIZE_DETECT */
-
-#endif /* CONFIG_DCACHE */
-
-#if defined(CONFIG_ICACHE)
-
 /**
  * @brief Enable the i-cache
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * Enable the instruction cache.
  */
@@ -167,6 +178,8 @@ void cache_instr_enable(void);
 
 /**
  * @brief Disable the i-cache
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * Disable the instruction cache.
  */
@@ -176,6 +189,8 @@ void cache_instr_disable(void);
  * @brief Flush the i-cache
  *
  * Flush the whole instruction cache.
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
@@ -187,6 +202,8 @@ int cache_instr_flush_all(void);
  *
  * Invalidate the whole instruction cache.
  *
+ * @kconfig_dep{CONFIG_ICACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -197,6 +214,8 @@ int cache_instr_invd_all(void);
  *
  * Flush and Invalidate the whole instruction cache.
  *
+ * @kconfig_dep{CONFIG_ICACHE}
+ *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP Not supported.
  */
@@ -206,6 +225,8 @@ int cache_instr_flush_and_invd_all(void);
  * @brief Flush an address range in the i-cache
  *
  * Flush the specified address range of the instruction cache.
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
@@ -226,6 +247,8 @@ int cache_instr_flush_range(void *addr, size_t size);
  * @brief Invalidate an address range in the i-cache
  *
  * Invalidate the specified address range of the instruction cache.
+ *
+ * @kconfig_dep{CONFIG_ICACHE}
  *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being invalidated, all the portions of the
@@ -248,6 +271,8 @@ int cache_instr_invd_range(void *addr, size_t size);
  *
  * Flush and Invalidate the specified address range of the instruction cache.
  *
+ * @kconfig_dep{CONFIG_ICACHE}
+ *
  * @note the cache operations act on cache line. When multiple data structures
  *       share the same cache line being flushed, all the portions of the
  *       data structures sharing the same line will be flushed before being
@@ -264,7 +289,6 @@ int cache_instr_invd_range(void *addr, size_t size);
  */
 int cache_instr_flush_and_invd_range(void *addr, size_t size);
 
-#ifdef CONFIG_ICACHE_LINE_SIZE_DETECT
 /**
  *
  * @brief Get the i-cache line size.
@@ -272,17 +296,15 @@ int cache_instr_flush_and_invd_range(void *addr, size_t size);
  * The API is provided to dynamically detect the instruction cache line size at
  * run time.
  *
- * The function must be implemented only when CONFIG_ICACHE_LINE_SIZE_DETECT is
+ * The function must be implemented only when @kconfig{CONFIG_ICACHE_LINE_SIZE_DETECT} is
  * defined.
+ *
+ * @kconfig_dep{CONFIG_ICACHE_LINE_SIZE_DETECT}
  *
  * @retval size Size of the i-cache line.
  * @retval 0 The i-cache is not enabled.
  */
 size_t cache_instr_line_size_get(void);
-
-#endif /* CONFIG_ICACHE_LINE_SIZE_DETECT */
-
-#endif /* CONFIG_ICACHE */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Some Zephyr driver exported header files conditioned functions declaration and macros/structures definition with #ifdef CONFIG_xxx (or like) directives preventing the APIs/ABIs documentation to be considered during the Doxygen based Zepĥyr documentation generation process.

Enhance documentation in these header files by adding @kconfig_dep{CONFIG_xxx} command where applicable and removing the #ifdef CONFIG_xxx directive (or like) (as per [1]).

Link: https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-1-conditional-compilation [1]