### PR TITLE
include: zephyr: drivers: adc: Enhance drivers API docs

### DIFF
--- a/include/zephyr/drivers/adc/adc_npcx_threshold.h
+++ b/include/zephyr/drivers/adc/adc_npcx_threshold.h
@@ -15,22 +15,22 @@ enum adc_npcx_threshold_param_l_h {
 };
 
 enum adc_npcx_threshold_param_type {
-	/* Selects ADC channel to be used for measurement */
+	/** Selects ADC channel to be used for measurement */
 	ADC_NPCX_THRESHOLD_PARAM_CHNSEL,
-	/* Sets relation between measured value and assetion threshold value.*/
+	/** Sets relation between measured value and assertion threshold value */
 	ADC_NPCX_THRESHOLD_PARAM_L_H,
-	/* Sets the threshold value to which measured data is compared. */
+	/** Sets the threshold value to which measured data is compared */
 	ADC_NPCX_THRESHOLD_PARAM_THVAL,
-	/* Sets worker queue thread to be notified */
+	/** Sets worker queue thread to be notified */
 	ADC_NPCX_THRESHOLD_PARAM_WORK,
-
+	/** Enum value bound */
 	ADC_NPCX_THRESHOLD_PARAM_MAX,
 };
 
 struct adc_npcx_threshold_param {
-	/* Threshold ocntrol parameter */
+	/** Threshold control parameter */
 	enum adc_npcx_threshold_param_type type;
-	/* Parameter value */
+	/** Parameter value */
 	uint32_t val;
 };
 

--- a/include/zephyr/drivers/adc/adc_npcx_threshold.h
+++ b/include/zephyr/drivers/adc/adc_npcx_threshold.h
@@ -15,22 +15,23 @@ enum adc_npcx_threshold_param_l_h {
 };
 
 enum adc_npcx_threshold_param_type {
-	/* Selects ADC channel to be used for measurement */
+	/** Selects ADC channel to be used for measurement */
 	ADC_NPCX_THRESHOLD_PARAM_CHNSEL,
-	/* Sets relation between measured value and assetion threshold value.*/
+	/** Sets relation between measured value and assertion threshold value */
 	ADC_NPCX_THRESHOLD_PARAM_L_H,
-	/* Sets the threshold value to which measured data is compared. */
+	/** Sets the threshold value to which measured data is compared */
 	ADC_NPCX_THRESHOLD_PARAM_THVAL,
-	/* Sets worker queue thread to be notified */
+	/** Sets worker queue thread to be notified */
 	ADC_NPCX_THRESHOLD_PARAM_WORK,
-
+	/** @cond INTERNAL_HIDDEN */
 	ADC_NPCX_THRESHOLD_PARAM_MAX,
+	/** @endcond */
 };
 
 struct adc_npcx_threshold_param {
-	/* Threshold ocntrol parameter */
+	/** Threshold control parameter */
 	enum adc_npcx_threshold_param_type type;
-	/* Parameter value */
+	/** Parameter value */
 	uint32_t val;
 };
 

--- a/include/zephyr/drivers/adc/adc_npcx_v2t.h
+++ b/include/zephyr/drivers/adc/adc_npcx_v2t.h
@@ -9,11 +9,10 @@
 
 #include <zephyr/device.h>
 
-#ifdef CONFIG_ADC_V2T_NPCX
-
 /**
  * @brief Set ADC V2T channels
  *
+ * @kconfig_dep{CONFIG_ADC_V2T_NPCX}
  *
  * @param dev       Pointer to the ADC device instance.
  * @param channels  Bit-mask indicating the channels to be configured as V2T
@@ -25,6 +24,7 @@ int adc_npcx_v2t_set_channels(const struct device *dev, uint32_t channels);
 /**
  * @brief Get ADC V2T configured channels
  *
+ * @kconfig_dep{CONFIG_ADC_V2T_NPCX}
  *
  * @param dev  Pointer to the ADC device instance.
  *
@@ -33,5 +33,4 @@ int adc_npcx_v2t_set_channels(const struct device *dev, uint32_t channels);
  */
 uint32_t adc_npcx_v2t_get_channels(const struct device *dev);
 
-#endif /* CONFIG_ADC_V2T_NPCX */
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_ADC_NPCX_V2T_H_ */


### PR DESCRIPTION
Some Zephyr driver exported header files conditioned functions declaration and macros/structures definition with #ifdef CONFIG_xxx (or like) directives preventing the APIs/ABIs documentation to be considered during the Doxygen based Zepĥyr documentation generation process.

Enhance documentation in these header files by adding @kconfig_dep{CONFIG_xxx} command where applicable and either adding defined(__DOXYGEN__) directives or removing the #ifdef CONFIG_xxx directive (or like) (as per [1]). Note some #ifdef CONFIG_xxx directives are preserved where inline functions are defined.

Set Doxygen entry tag '/**' for enum adc_npcx_threshold_param_type values and struct adc_npcx_threshold_param fields description so that they are shown in the generated Zephyr documentation.

Link: https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-1-conditional-compilation [1]