### PR TITLE
include: zephyr: drivers: gic: Enhance drivers API documentation 

### DIFF
--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -126,7 +126,7 @@
  */
 #define GICD_ISACTIVERnE (GIC_DIST_BASE + 0x1A00)
 
-#if CONFIG_GIC_VER >= 2
+#if (CONFIG_GIC_VER >= 2) || defined(__DOXYGEN__)
 /*
  * 0x380  Interrupt Clear-Active Registers
  * v2/v3	GICD_ICACTIVERn
@@ -138,7 +138,7 @@
  * v3.1		GICD_ICACTIVERnE
  */
 #define GICD_ICACTIVERnE (GIC_DIST_BASE + 0x1C00)
-#endif
+#endif /* CONFIG_GIC_VER >= 2 */
 
 /*
  * 0x400  Interrupt Priority Registers
@@ -184,7 +184,7 @@
  * GIC CPU Interface
  */
 
-#if CONFIG_GIC_VER <= 2
+#if (CONFIG_GIC_VER <= 2) || defined(__DOXYGEN__)
 
 /*
  * 0x0000  CPU Interface Control Register
@@ -401,7 +401,7 @@ unsigned int arm_gic_get_active(void);
  */
 void arm_gic_eoi(unsigned int irq);
 
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) || defined(__DOXYGEN__)
 /**
  * @brief Initialize GIC of secondary cores
  */

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -27,158 +27,188 @@
  * GIC Distributor Interface
  */
 
-/*
- * 0x000  Distributor Control Register
+/**
+ * @brief GIC Distributor Control Register
+ *
  * v1		ICDDCR
  * v2/v3	GICD_CTLR
  */
 #define GICD_CTLR (GIC_DIST_BASE + 0x0)
 
-/*
- * 0x004  Interrupt Controller Type Register
+/**
+ * @brief GIC Distributor Interrupt Controller Type Register
+ *
  * v1		ICDICTR
  * v2/v3	GICD_TYPER
  */
 #define GICD_TYPER (GIC_DIST_BASE + 0x4)
 
-/*
- * 0x008  Distributor Implementer Identification Register
+/**
+ * @brief GIC Distributor Implementer Identification Register
+ *
  * v1		ICDIIDR
  * v2/v3	GICD_IIDR
  */
 #define GICD_IIDR (GIC_DIST_BASE + 0x8)
 
-/*
- * 0x080  Interrupt Group Registers
+/**
+ * @brief GIC Distributor Interrupt Group Registers
+ *
  * v1		ICDISRn
  * v2/v3	GICD_IGROUPRn
  */
 #define GICD_IGROUPRn (GIC_DIST_BASE + 0x80)
 
-/*
- * 0x1000  Interrupt Group Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Group Registers for Extended SPI Range
+ *
  * v3.1		GICD_IGROUPRnE
  */
 #define GICD_IGROUPRnE (GIC_DIST_BASE + 0x1000)
 
-/*
- * 0x100  Interrupt Set-Enable Registers
+/**
+ * @brief GIC Distributor Interrupt Set-Enable Registers
+ *
  * v1		ICDISERn
  * v2/v3	GICD_ISENABLERn
  */
 #define GICD_ISENABLERn (GIC_DIST_BASE + 0x100)
 
-/*
- * 0x1200  Interrupt Set-Enable Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Set-Enable Registers for Extended SPI Range
+ *
  * v3.1		GICD_ISENABLERnE
  */
 #define GICD_ISENABLERnE (GIC_DIST_BASE + 0x1200)
 
-/*
- * 0x180  Interrupt Clear-Enable Registers
+/**
+ * @brief GIC Distributor Interrupt Clear-Enable Registers
+ *
  * v1		ICDICERn
  * v2/v3	GICD_ICENABLERn
  */
 #define GICD_ICENABLERn (GIC_DIST_BASE + 0x180)
 
-/*
- * 0x1400  Interrupt Clear-Enable Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Clear-Enable Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICENABLERnE
  */
 #define GICD_ICENABLERnE (GIC_DIST_BASE + 0x1400)
 
-/*
- * 0x200  Interrupt Set-Pending Registers
+/**
+ * @brief GIC Distributor Interrupt Set-Pending Registers
+ *
  * v1		ICDISPRn
  * v2/v3	GICD_ISPENDRn
  */
 #define GICD_ISPENDRn (GIC_DIST_BASE + 0x200)
 
-/*
- * 1600  Interrupt Set-Pending Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Set-Pending Registers for Extended SPI Range
+ *
  * v3.1		GICD_ISPENDRnE
  */
 #define GICD_ISPENDRnE (GIC_DIST_BASE + 0x1600)
 
-/*
- * 0x280  Interrupt Clear-Pending Registers
+/**
+ * @brief GIC Distributor Interrupt Clear-Pending Registers
+ *
  * v1		ICDICPRn
  * v2/v3	GICD_ICPENDRn
  */
 #define GICD_ICPENDRn (GIC_DIST_BASE + 0x280)
 
-/*
- * 0x1800  Interrupt Clear-Pending Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Clear-Pending Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICPENDRnE
  */
 #define GICD_ICPENDRnE (GIC_DIST_BASE + 0x1800)
 
-/*
- * 0x300  Interrupt Set-Active Registers
+/**
+ * @brief GIC Distributor Interrupt Set-Active Registers
+ *
  * v1		ICDABRn
  * v2/v3	GICD_ISACTIVERn
  */
 #define GICD_ISACTIVERn (GIC_DIST_BASE + 0x300)
 
-/*
- * 0x1A00  Interrupt Set-Active Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Set-Active Registers for Extended SPI Range
+ *
  * v3.1		GICD_ISACTIVERnE
  */
 #define GICD_ISACTIVERnE (GIC_DIST_BASE + 0x1A00)
 
 #if (CONFIG_GIC_VER >= 2) || defined(__DOXYGEN__)
-/*
- * 0x380  Interrupt Clear-Active Registers
+/**
+ * @brief GIC Distributor Interrupt Clear-Active Registers
+ *
  * v2/v3	GICD_ICACTIVERn
  */
 #define GICD_ICACTIVERn (GIC_DIST_BASE + 0x380)
 
-/*
- * 0x1C00  Interrupt Clear-Active Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Clear-Active Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICACTIVERnE
  */
 #define GICD_ICACTIVERnE (GIC_DIST_BASE + 0x1C00)
 #endif /* CONFIG_GIC_VER >= 2 */
 
-/*
- * 0x400  Interrupt Priority Registers
+/**
+ * @brief GIC Distributor Interrupt Priority Registers
+ *
  * v1		ICDIPRn
  * v2/v3	GICD_IPRIORITYRn
  */
 #define GICD_IPRIORITYRn (GIC_DIST_BASE + 0x400)
 
-/*
- * 0x2000  Interrupt Priority Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Priority Registers for Extended SPI Range
+ *
  * v3.1		GICD_IPRIORITYRnE
  */
 #define GICD_IPRIORITYRnE (GIC_DIST_BASE + 0x2000)
 
-/*
- * 0x800  Interrupt Processor Targets Registers
+/**
+ * @brief GIC Distributor Interrupt Processor Targets Registers
+ *
  * v1		ICDIPTRn
  * v2/v3	GICD_ITARGETSRn
  */
 #define GICD_ITARGETSRn (GIC_DIST_BASE + 0x800)
 
-/*
- * 0xC00  Interrupt Configuration Registers
+/**
+ * @brief GIC Distributor Interrupt Configuration Registers
+ *
  * v1		ICDICRn
  * v2/v3	GICD_ICFGRn
  */
 #define GICD_ICFGRn (GIC_DIST_BASE + 0xc00)
 
-/*
- * 0x3000  Interrupt Configuration Registers for Extended SPI Range
+/**
+ * @brief GIC Distributor Interrupt Configuration Registers for Extended SPI Range
+ *
  * v3.1		GICD_ICFGRnE
  */
 #define GICD_ICFGRnE (GIC_DIST_BASE + 0x3000)
 
-/*
- * 0xF00  Software Generated Interrupt Register
+/**
+ * @brief GIC Distributor Software Generated Interrupt Register
+ *
  * v1		ICDSGIR
  * v2/v3	GICD_SGIR
  */
 #define GICD_SGIR (GIC_DIST_BASE + 0xf00)
+
+/**
+ * @brief Disable Security (DS) bit in @ref GICD_CTLR
+ *
+ * v3/v3.1	See ARM GIC architecture spec, GICD_CTLR
+ */
+#define GICD_CTLR_DS BIT(6)
 
 /*
  * GIC CPU Interface
@@ -186,44 +216,51 @@
 
 #if (CONFIG_GIC_VER <= 2) || defined(__DOXYGEN__)
 
-/*
- * 0x0000  CPU Interface Control Register
+/**
+ * @brief GIC CPU Interface Control Register
+ *
  * v1		ICCICR
- * v2/v3	GICC_CTLR
+ * v2		GICC_CTLR
  */
 #define GICC_CTLR (GIC_CPU_BASE + 0x0)
 
-/*
- * 0x0004  Interrupt Priority Mask Register
+/**
+ * @brief GIC CPU Interface Interrupt Priority Mask Register
+ *
  * v1		ICCPMR
- * v2/v3	GICC_PMR
+ * v2		GICC_PMR
  */
 #define GICC_PMR (GIC_CPU_BASE + 0x4)
 
-/*
- * 0x0008  Binary Point Register
+/**
+ * @brief GIC CPU Interface Binary Point Register
+ *
  * v1		ICCBPR
- * v2/v3	GICC_BPR
+ * v2		GICC_BPR
  */
 #define GICC_BPR (GIC_CPU_BASE + 0x8)
 
-/*
- * 0x000C  Interrupt Acknowledge Register
+/**
+ * @brief GIC CPU Interface Interrupt Acknowledge Register
+ *
  * v1		ICCIAR
- * v2/v3	GICC_IAR
+ * v2		GICC_IAR
  */
 #define GICC_IAR (GIC_CPU_BASE + 0xc)
 
-/*
- * 0x0010  End of Interrupt Register
+/**
+ * @brief GIC CPU Interface End of Interrupt Register
+ *
  * v1		ICCEOIR
- * v2/v3	GICC_EOIR
+ * v2		GICC_EOIR
  */
 #define GICC_EOIR (GIC_CPU_BASE + 0x10)
 
 /*
  * Helper Constants
  */
+
+/** @cond INTERNAL_HIDDEN */
 
 /* GICC_CTLR */
 #define GICC_CTLR_ENABLEGRP0 BIT(0)
@@ -258,13 +295,11 @@
 
 #define GICD_SGIR_SGIINTID(x) (x)
 
+/** @endcond  */
+
 #endif /* CONFIG_GIC_VER <= 2 */
 
-/**
- * 0x000  GICD_CTLR — DS (Disable Security), bit 6
- * v3/v3.1	See ARM GIC architecture spec, GICD_CTLR
- */
-#define GICD_CTLR_DS BIT(6)
+/** @cond INTERNAL_HIDDEN */
 
 /* GICD_ICFGR */
 #define GICD_ICFGR_MASK BIT_MASK(2)
@@ -279,17 +314,27 @@
 /* GICD_TYPER.IDbits */
 #define GICD_TYPER_IDBITS(typer) ((((typer) >> 19) & 0x1f) + 1)
 
+/** @endcond  */
+
 /*
  * Common Helper Constants
  */
+
+/** Base ID of SGI interrupts */
 #define GIC_SGI_INT_BASE 0
+
+/** Base ID of PPI interrupts */
 #define GIC_PPI_INT_BASE 16
 
 #define GIC_IS_SGI(intid) (((intid) >= GIC_SGI_INT_BASE) && ((intid) < GIC_PPI_INT_BASE))
 
+/** Base ID of SPI interrupts */
 #define GIC_SPI_INT_BASE 32
 
+/** Max ID of SPI interrupts */
 #define GIC_SPI_MAX_INTID 1019
+
+/** @cond INTERNAL_HIDDEN */
 
 #define GIC_IS_SPI(intid) (((intid) >= GIC_SPI_INT_BASE) && ((intid) <= GIC_SPI_MAX_INTID))
 
@@ -299,13 +344,17 @@
 
 #define GIC_NUM_PRI_PER_REG 4
 
-/* GIC idle priority : value '0xff' will allow all interrupts */
+/** @endcond  */
+
+/** GIC idle priority : value '0xff' will allow all interrupts */
 #define GIC_IDLE_PRIO 0xff
 
-/* Priority levels 0:255 */
+/** Priority levels 0:255 */
 #define GIC_PRI_MASK 0xff
 
-/*
+/**
+ * @brief Default priority initializer helper macro
+ *
  * '0xa0'is used to initialize each interrupt default priority.
  * This is an arbitrary value in current context.
  * Any value '0x80' to '0xff' will work for both NS and S state.
@@ -314,7 +363,7 @@
  */
 #define GIC_INT_DEF_PRI_X4 0xa0a0a0a0
 
-/* GIC special interrupt id */
+/** GIC special interrupt id */
 #define GIC_INTID_SPURIOUS 1023
 
 /**


### PR DESCRIPTION
Add `defined(__DOXYGEN__)` directives in GIC Zephyr driver header file where there is Doxygen format information that was not considered when building Zephyr documentation.

Change Doxygen formatting of inline description comments to enhance rendering in the generated documentation and fix of few misleading information.
