### PR TITLE
drivers: emul: improve Doxygen coverage of the emulation framework

### DIFF
--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Public APIs for the device emulation framework.
+ * @ingroup io_emulators
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_EMUL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_EMUL_H_
 

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -41,19 +41,19 @@ struct emul;
  * The types of supported buses.
  */
 enum emul_bus_type {
-	EMUL_BUS_TYPE_I2C,
-	EMUL_BUS_TYPE_ESPI,
-	EMUL_BUS_TYPE_SPI,
-	EMUL_BUS_TYPE_MSPI,
-	EMUL_BUS_TYPE_UART,
-	EMUL_BUS_TYPE_NONE,
+	EMUL_BUS_TYPE_I2C,  /**< I2C bus */
+	EMUL_BUS_TYPE_ESPI, /**< eSPI bus */
+	EMUL_BUS_TYPE_SPI,  /**< SPI bus */
+	EMUL_BUS_TYPE_MSPI, /**< MSPI bus */
+	EMUL_BUS_TYPE_UART, /**< UART bus */
+	EMUL_BUS_TYPE_NONE, /**< Emulator is not attached to a bus */
 };
 
 /**
  * Structure uniquely identifying a device to be emulated
  */
 struct emul_link_for_bus {
-	const struct device *dev;
+	const struct device *dev; /**< Device to be emulated */
 };
 
 /** List of emulators attached to a bus */
@@ -77,8 +77,8 @@ typedef int (*emul_init_t)(const struct emul *emul, const struct device *parent)
  * Emulator API stub when an emulator is not actually placed on a bus.
  */
 struct no_bus_emul {
-	void *api;
-	uint16_t addr;
+	void *api;     /**< Emulator-specific bus API */
+	uint16_t addr; /**< Emulated device address, from the devicetree reg property */
 };
 
 /** An emulator instance - represents the *target* emulated device/peripheral that is
@@ -98,13 +98,13 @@ struct emul {
 	enum emul_bus_type bus_type;
 	/** Pointer to the emulated bus node */
 	union bus {
-		struct i2c_emul *i2c;
-		struct espi_emul *espi;
-		struct spi_emul *spi;
-		struct mspi_emul *mspi;
-		struct uart_emul *uart;
-		struct no_bus_emul *none;
-	} bus;
+		struct i2c_emul *i2c;     /**< I2C emulated bus node */
+		struct espi_emul *espi;   /**< eSPI emulated bus node */
+		struct spi_emul *spi;     /**< SPI emulated bus node */
+		struct mspi_emul *mspi;   /**< MSPI emulated bus node */
+		struct uart_emul *uart;   /**< UART emulated bus node */
+		struct no_bus_emul *none; /**< Stub used when the emulator is not on a bus */
+	} bus; /**< Emulated bus node */
 	/** Address of the API structure exposed by the emulator instance */
 	const void *backend_api;
 };
@@ -230,9 +230,13 @@ const struct emul *emul_get_binding(const char *name);
  * @}
  */
 
+/** @cond INTERNAL_HIDDEN */
+
 #define Z_MAYBE_EMUL_DECLARE_INTERNAL(node_id) extern const struct emul EMUL_DT_NAME_GET(node_id);
 
 DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_EMUL_DECLARE_INTERNAL);
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/emul_bbram.h
+++ b/include/zephyr/drivers/emul_bbram.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Backend APIs for the BBRAM emulators.
+ * @ingroup bbram_emulator_backend
+ */
+
 #ifndef INCLUDE_ZEPHYR_DRIVERS_EMUL_BBRAM_H_
 #define INCLUDE_ZEPHYR_DRIVERS_EMUL_BBRAM_H_
 

--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Backend APIs for the fuel gauge emulators.
+ * @ingroup fuel_gauge_emulator_backend
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_EMUL_FUEL_GAUGE_H_

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Backend APIs for the sensor emulators.
+ * @ingroup sensor_emulator_backend
+ */
+
 #include <zephyr/drivers/emul.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/sensor_attribute_types.h>

--- a/include/zephyr/drivers/emul_stub_device.h
+++ b/include/zephyr/drivers/emul_stub_device.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Stub device support for emulators without a corresponding driver.
+ * @ingroup io_emulators
+ */
+
 #ifndef ZEPHYR_INCLUDE_EMUL_STUB_DEVICE_H_
 #define ZEPHYR_INCLUDE_EMUL_STUB_DEVICE_H_
 

--- a/include/zephyr/drivers/emul_stub_device.h
+++ b/include/zephyr/drivers/emul_stub_device.h
@@ -20,6 +20,7 @@
  * Needed for emulators without corresponding DEVICE_DT_DEFINE drivers
  */
 
+/** @cond INTERNAL_HIDDEN */
 struct emul_stub_dev_data {
 	/* Stub */
 };
@@ -29,8 +30,16 @@ struct emul_stub_dev_config {
 struct emul_stub_dev_api {
 	/* Stub */
 };
+/** @endcond */
 
-/* For every instance of a @c DT_DRV_COMPAT stub out a device for that instance */
+/**
+ * @brief Stub out a device for an emulator instance.
+ *
+ * For every instance of a @c DT_DRV_COMPAT, define a stub device so that
+ * the emulator's devicetree node has a corresponding device.
+ *
+ * @param n @c DT_DRV_COMPAT instance number
+ */
 #define EMUL_STUB_DEVICE(n)                                                                        \
 	__maybe_unused static int emul_init_stub_##n(const struct device *dev)                     \
 	{                                                                                          \

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -2,6 +2,7 @@
  * @file
  *
  * @brief Public APIs for the I2C emulation drivers.
+ * @ingroup i2c_emul_interface
  */
 
 /*

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -37,12 +37,13 @@ struct i2c_emul_api;
 
 /** Node in a linked list of emulators for I2C devices */
 struct i2c_emul {
+	/** Node in the controller's linked list of emulators */
 	sys_snode_t node;
 
 	/** Target emulator - REQUIRED for all emulated bus nodes of any type */
 	const struct emul *target;
 
-	/* API provided for this device */
+	/** API provided for this device */
 	const struct i2c_emul_api *api;
 
 	/**
@@ -51,7 +52,7 @@ struct i2c_emul {
 	 */
 	struct i2c_emul_api *mock_api;
 
-	/* I2C address of the emulated device */
+	/** I2C address of the emulated device */
 	uint16_t addr;
 };
 
@@ -82,6 +83,7 @@ int i2c_emul_register(const struct device *dev, struct i2c_emul *emul);
 
 /** Definition of the emulator API */
 struct i2c_emul_api {
+	/** Passes I2C messages to the emulator */
 	i2c_emul_transfer_t transfer;
 };
 

--- a/include/zephyr/drivers/mspi_emul.h
+++ b/include/zephyr/drivers/mspi_emul.h
@@ -82,11 +82,13 @@ typedef int (*emul_mspi_dev_api_transceive)(const struct emul *target,
 
 /** Definition of the MSPI device emulator API */
 struct emul_mspi_device_api {
+	/** Passes MSPI transceive requests to the device emulator */
 	emul_mspi_dev_api_transceive transceive;
 };
 
 /** Node in a linked list of emulators for MSPI devices */
 struct mspi_emul {
+	/** Node in the controller's linked list of emulators */
 	sys_snode_t                  node;
 	/** Target emulator - REQUIRED for all emulated bus nodes of any type */
 	const struct emul            *target;
@@ -98,12 +100,14 @@ struct mspi_emul {
 
 /** Definition of the MSPI controller emulator API */
 __subsystem struct emul_mspi_driver_api {
-	/* The struct mspi_driver_api has to be first in
+	/**
+	 * The struct mspi_driver_api has to be first in
 	 * struct emul_mspi_driver_api to make pointer casting working
 	 */
 	struct mspi_driver_api       mspi_api;
-	/* The rest, emulator specific functions */
+	/** Emulator specific: triggers an event on the emulated MSPI controller */
 	mspi_emul_trigger_event      trigger_event;
+	/** Emulator specific: finds an emulator present on the MSPI bus */
 	mspi_emul_find_emul          find_emul;
 };
 

--- a/include/zephyr/drivers/mspi_emul.h
+++ b/include/zephyr/drivers/mspi_emul.h
@@ -17,6 +17,7 @@
  * @file
  *
  * @brief Public APIs for the MSPI emulation drivers.
+ * @ingroup mspi_emul_interface
  */
 
 /**

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -17,6 +17,7 @@
  * @file
  *
  * @brief Public APIs for the SPI emulation drivers.
+ * @ingroup spi_emul_interface
  */
 
 /**

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -37,12 +37,13 @@ struct spi_emul_api;
 
 /** Node in a linked list of emulators for SPI devices */
 struct spi_emul {
+	/** Node in the controller's linked list of emulators */
 	sys_snode_t node;
 
 	/** Target emulator - REQUIRED for all bus emulators */
 	const struct emul *target;
 
-	/* API provided for this device */
+	/** API provided for this device */
 	const struct spi_emul_api *api;
 
 	/**
@@ -51,7 +52,7 @@ struct spi_emul {
 	 */
 	struct spi_emul_api *mock_api;
 
-	/* SPI chip-select of the emulated device */
+	/** SPI chip-select of the emulated device */
 	uint16_t chipsel;
 };
 
@@ -85,6 +86,7 @@ int spi_emul_register(const struct device *dev, struct spi_emul *emul);
 
 /** Definition of the emulator API */
 struct spi_emul_api {
+	/** Passes SPI messages to the emulator */
 	spi_emul_io_t io;
 };
 

--- a/include/zephyr/drivers/uart_emul.h
+++ b/include/zephyr/drivers/uart_emul.h
@@ -46,6 +46,7 @@ typedef void (*uart_emul_device_tx_data_ready_t)(const struct device *dev, size_
 
 /** Node in a linked list of emulators for UART devices */
 struct uart_emul {
+	/** Node in the controller's linked list of emulators */
 	sys_snode_t node;
 	/** Target emulator - REQUIRED for all emulated bus nodes of any type */
 	const struct emul *target;
@@ -55,6 +56,7 @@ struct uart_emul {
 
 /** Definition of the emulator API */
 struct uart_emul_device_api {
+	/** Called when there is new data in the TX buffer */
 	uart_emul_device_tx_data_ready_t tx_data_ready;
 };
 

--- a/include/zephyr/drivers/uart_emul.h
+++ b/include/zephyr/drivers/uart_emul.h
@@ -17,6 +17,7 @@
  * @file
  *
  * @brief Public APIs for the UART device emulation drivers.
+ * @ingroup uart_emul_interface
  */
 
 /**


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` blocks, each attached to its Doxygen group,
  across the `emul*.h` headers.
- Documents the emulator structures and the bus type enumeration
  (`emul`, `emul_link_for_bus`, `no_bus_emul`, `emul_bus_type`), and the
  per-bus emulator struct members for I2C, SPI, MSPI and UART.
- Hides `Z_MAYBE_EMUL_DECLARE_INTERNAL` and the `emul_stub_dev_*`
  structs, which are implementation details of the registration macros.

Documentation only, no functional change.