### PR TITLE
net: dns: handle unsupported getsockname() for ephemeral ports

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -317,18 +317,21 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 	}
 
 	/* If port 0 was requested, bind() selected an ephemeral local port.
-	 * Store the actual socket name so later dispatcher registrations do
-	 * not treat distinct resolver sockets as duplicate port-0 sockets.
+	 * Record it so that this dispatcher can be told apart from other
+	 * registrations.
 	 */
 	if (net_sin(net_sad(&ctx->local_addr_storage))->sin_port == 0) {
 		net_socklen_t socklen = addrlen;
 
-		ret = zsock_getsockname(ctx->sock, net_sad(&ctx->local_addr_storage), &socklen);
-		if (ret < 0) {
-			ret = -errno;
-			NET_DBG("Cannot get DNS socket %d name (%d)", ctx->sock,
-				ret);
-			goto out;
+		/* The local port is only used to match dispatcher
+		 * registrations, so continue with an unknown port if the
+		 * socket implementation cannot report it.
+		 */
+		if (zsock_getsockname(ctx->sock, net_sad(&ctx->local_addr_storage),
+				      &socklen) < 0) {
+			NET_DBG("Cannot get DNS socket %d name (%d), local port unknown",
+				ctx->sock, -errno);
+			net_sin(net_sad(&ctx->local_addr_storage))->sin_port = 0;
 		}
 	}
 

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -34,6 +34,19 @@ static struct socket_dispatch_table {
 	struct dns_socket_dispatcher *ctx;
 } dispatch_table[ZVFS_OPEN_SIZE];
 
+static uint16_t dns_dispatcher_addr_port(const struct net_sockaddr_storage *addr)
+{
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr->ss_family == NET_AF_INET6) {
+		return net_sin6(net_sad(addr))->sin6_port;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && addr->ss_family == NET_AF_INET) {
+		return net_sin(net_sad(addr))->sin_port;
+	}
+
+	return 0;
+}
+
 static int dns_dispatch(struct dns_socket_dispatcher *dispatcher,
 			int sock, struct net_sockaddr *addr, size_t addrlen,
 			struct net_buf *dns_data, size_t buf_len)
@@ -228,8 +241,8 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 	(void)k_mutex_init(&ctx->lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&sockets, entry, next, node) {
-		uint16_t entry_port = net_sin(net_sad(&entry->local_addr_storage))->sin_port;
-		uint16_t ctx_port = net_sin(net_sad(&ctx->local_addr_storage))->sin_port;
+		uint16_t entry_port = dns_dispatcher_addr_port(&entry->local_addr_storage);
+		uint16_t ctx_port = dns_dispatcher_addr_port(&ctx->local_addr_storage);
 		bool ports_match = ctx_port != 0 && ctx_port == entry_port;
 
 		/* Refuse to register context if we have identical context
@@ -320,18 +333,21 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 	 * Record it so that this dispatcher can be told apart from other
 	 * registrations.
 	 */
-	if (net_sin(net_sad(&ctx->local_addr_storage))->sin_port == 0) {
+	if (dns_dispatcher_addr_port(&ctx->local_addr_storage) == 0) {
+		struct net_sockaddr_storage local_addr = ctx->local_addr_storage;
 		net_socklen_t socklen = addrlen;
 
 		/* The local port is only used to match dispatcher
 		 * registrations, so continue with an unknown port if the
-		 * socket implementation cannot report it.
+		 * socket implementation cannot report it. Restore the address
+		 * we bound with, as a failing call may still have written to
+		 * the buffer.
 		 */
 		if (zsock_getsockname(ctx->sock, net_sad(&ctx->local_addr_storage),
 				      &socklen) < 0) {
 			NET_DBG("Cannot get DNS socket %d name (%d), local port unknown",
 				ctx->sock, -errno);
-			net_sin(net_sad(&ctx->local_addr_storage))->sin_port = 0;
+			ctx->local_addr_storage = local_addr;
 		}
 	}
 

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -228,14 +228,18 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 	(void)k_mutex_init(&ctx->lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&sockets, entry, next, node) {
+		uint16_t entry_port = net_sin(net_sad(&entry->local_addr_storage))->sin_port;
+		uint16_t ctx_port = net_sin(net_sad(&ctx->local_addr_storage))->sin_port;
+		bool ports_match = ctx_port != 0 && ctx_port == entry_port;
+
 		/* Refuse to register context if we have identical context
-		 * already registered.
+		 * already registered. Port 0 means the local port is not
+		 * known, so it cannot be used to tell two contexts apart.
 		 */
 		if (ctx->type == entry->type &&
 		    ctx->local_addr_storage.ss_family == entry->local_addr_storage.ss_family &&
 		    ctx->ifindex == entry->ifindex) {
-			if (net_sin(net_sad(&entry->local_addr_storage))->sin_port ==
-			    net_sin(net_sad(&ctx->local_addr_storage))->sin_port) {
+			if (ports_match) {
 				dup = true;
 				continue;
 			}
@@ -249,8 +253,7 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 		 */
 		if (found == NULL && ctx->type != entry->type &&
 		    ctx->local_addr_storage.ss_family == entry->local_addr_storage.ss_family) {
-			if (net_sin(net_sad(&entry->local_addr_storage))->sin_port ==
-			    net_sin(net_sad(&ctx->local_addr_storage))->sin_port) {
+			if (ports_match) {
 				found = entry;
 				continue;
 			}


### PR DESCRIPTION
Commit 9cc8b3a37188 ("net: lib: dns: dispatcher: fix ephemeral port usage") introduced a call to `getsockname()` after `bind(0)` so the DNS dispatcher can store the actual ephemeral port assigned by the socket implementation.

This assumes that any socket implementation supporting `bind(0)` can also return the assigned port via `getsockname()`.

Some modem-offloaded UDP socket implementations do not support this operation and return `-ENOTSUP` or `-EOPNOTSUPP`, because the modem assigns the ephemeral port internally and does not provide a way to query it.

As a result, DNS dispatcher registration now fails even though the socket itself was successfully created and bound.
