### PR TITLE
ec_host_cmd: shi_ite: Fix race condition in request header processing

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
@@ -286,24 +286,27 @@ static int shi_ite_host_request_expected_size(const struct ec_host_cmd_request_h
 static void shi_ite_parse_header(const struct device *dev)
 {
 	struct shi_it8xxx2_data *data = dev->data;
-	struct ec_host_cmd_request_header *r = (struct ec_host_cmd_request_header *)data->in_msg;
+	struct ec_host_cmd_request_header r;
 
-	/* Store request data from Rx FIFO to in_msg buffer (rx_ctx->buf) */
-	shi_ite_host_request_data(data->in_msg, sizeof(*r));
+	/* Store request header from Rx FIFO to local buffer */
+	shi_ite_host_request_data((uint8_t *)&r, sizeof(r));
 
 	/* Protocol version 3 */
-	if (r->prtcl_ver == EC_HOST_REQUEST_VERSION) {
+	if (r.prtcl_ver == EC_HOST_REQUEST_VERSION) {
 		/* Check how big the packet should be */
-		data->rx_ctx->len = shi_ite_host_request_expected_size(r);
+		data->rx_ctx->len = shi_ite_host_request_expected_size(&r);
 
 		if (data->rx_ctx->len == 0 || data->rx_ctx->len > sizeof(data->in_msg)) {
 			shi_ite_bad_received_data(dev, data->rx_ctx->len);
 			return;
 		}
 
+		/* Copy verified header to in_msg buffer */
+		memcpy(data->in_msg, &r, sizeof(r));
+
 		/* Store request data from Rx FIFO to in_msg buffer */
-		shi_ite_host_request_data(data->rx_ctx->buf + sizeof(*r),
-					  data->rx_ctx->len - sizeof(*r));
+		shi_ite_host_request_data(data->rx_ctx->buf + sizeof(r),
+					  data->rx_ctx->len - sizeof(r));
 
 		ec_host_cmd_rx_notify();
 	} else {
@@ -344,6 +347,11 @@ static void shi_ite_int_handler(const struct device *dev)
 	if (IT83XX_SPI_RX_VLISR & IT83XX_SPI_RVLI) {
 		/* write clear slave status */
 		IT83XX_SPI_RX_VLISR = IT83XX_SPI_RVLI;
+		if (data->shi_state != SHI_STATE_READY_TO_RECV &&
+		    data->shi_state != SHI_STATE_RECEIVING) {
+			LOG_ERR("Received SPI RVLI in invalid state %d", data->shi_state);
+			return;
+		}
 		/* Move to processing state */
 		shi_ite_set_state(data, SHI_STATE_PROCESSING);
 		/* Parse header for version of spi-protocol */
@@ -355,15 +363,15 @@ void shi_ite_cs_callback(const struct device *port, struct gpio_callback *cb, gp
 {
 	struct shi_it8xxx2_data *data = CONTAINER_OF(cb, struct shi_it8xxx2_data, cs_cb);
 
-	if (data->shi_state == SHI_STATE_DISABLED) {
+	if (data->shi_state != SHI_STATE_READY_TO_RECV) {
 		return;
 	}
 
 	/* Prevent the MCU from sleeping during the transmission */
 	shi_ite_pm_policy_state_lock_get(data, SHI_ITE_PM_POLICY_FLAG);
 
-	/* Move to processing state */
-	shi_ite_set_state(data, SHI_STATE_PROCESSING);
+	/* Move to receiving state */
+	shi_ite_set_state(data, SHI_STATE_RECEIVING);
 }
 
 static int shi_ite_init_registers(const struct device *dev)


### PR DESCRIPTION
Prevent race condition where a secondary SPI request header could overwrite in_msg while host command processing is active.

1. Add state check to ignore CS callbacks and RVLI interrupts when not in SHI_STATE_READY_TO_RECV / SHI_STATE_RECEIVING.
2. Read header into a local buffer for length and version validation before copying into in_msg.

Fixes: #116413