### PR TITLE
dts: binding: Add intel,x86_64 yaml

### DIFF
--- a/dts/bindings/cpu/intel,x86_64.yaml
+++ b/dts/bindings/cpu/intel,x86_64.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Generic x86_64 qemu CPU
+
+compatible: "intel,x86_64"
+
+include: cpu.yaml


### PR DESCRIPTION
Several dts files use "intel,x86_64" as a compatibility string (e.g. qemu_x86_64.dts, apollo_lake.dtsi), but no CPU binding exists in tree. Add a generic CPU binding.

Similar to what was done in https://github.com/zephyrproject-rtos/zephyr/issues/114110 and https://github.com/zephyrproject-rtos/zephyr/pull/114145. In this case there was no regression [that I'm aware of] in-tree, this was identified while working on a different task.