### PR TITLE
scripts: ci: doxygen_coverage_diff: append warn-paths

### DIFF
--- a/scripts/ci/doxygen_coverage_diff.py
+++ b/scripts/ci/doxygen_coverage_diff.py
@@ -241,7 +241,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--warn-paths",
-        nargs="*",
+        action="append",
         default=[],
         help="Path prefixes where undocumented symbols are treated as warnings",
     )


### PR DESCRIPTION
Previously, the last `--warn-paths` argument would replace any previous one that was specified on the command line. Use `action="append"` to ensure that all of the arguments are collected.

Fixes #115072

Testing Done:

This
```shell
python3 -c 'import argparse; p=argparse.ArgumentParser(); p.add_argument("--warn-paths", action="append", default=[]); print(p.parse_args(["--warn-paths", "include/zephyr/dt-bindings", "--warn-paths", "include/zephyr/posix"]))'
```
produces this
```
Namespace(warn_paths=['include/zephyr/dt-bindings', 'include/zephyr/posix'])
```