### PR TITLE
snippets: xen-dom0: add rpi_5/bcm2712 board overlay

### DIFF
--- a/snippets/xen-dom0/boards/rpi_5.overlay
+++ b/snippets/xen-dom0/boards/rpi_5.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart10 {
+	/* Xen consoleio will be used */
+	status = "disabled";
+};

--- a/snippets/xen-dom0/snippet.yml
+++ b/snippets/xen-dom0/snippet.yml
@@ -21,3 +21,6 @@ boards:
   rcar_spider_s4/r8a779f0/a55:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/rcar_spider_s4_r8a779f0_a55.overlay
+  rpi_5/bcm2712:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/rpi_5.overlay


### PR DESCRIPTION
`rpi_5` board docs describe using it as a Xen Dom0 via the xen-dom0 snippet, but no overlay existed for this board. Add one to disable `uart10`, since Xen consoleio takes over the console.