### PR TITLE
drivers: ethernet: stm32: restore PTP RX priority

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -54,6 +54,9 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 			/* semaphore taken and receive packets */
 			while ((pkt = eth_stm32_rx(dev)) != NULL) {
 				iface = net_pkt_iface(pkt);
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+				(void)eth_stm32_is_ptp_pkt(pkt);
+#endif
 				res = net_recv_data(iface, pkt);
 				if (res < 0) {
 					eth_stats_update_errors_rx(net_pkt_iface(pkt));

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -187,6 +187,7 @@ void eth_stm32_mcast_filter(const struct device *dev,
 
 #ifdef CONFIG_PTP_CLOCK_STM32_HAL
 const struct device *eth_stm32_get_ptp_clock(const struct device *dev, struct net_if *iface);
+bool eth_stm32_is_ptp_pkt(struct net_pkt *pkt);
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_STM32_HAL_PRIV_H_ */

--- a/drivers/ethernet/eth_stm32_hal_ptp.c
+++ b/drivers/ethernet/eth_stm32_hal_ptp.c
@@ -29,6 +29,39 @@ LOG_MODULE_REGISTER(eth_stm32_hal_ptp, CONFIG_ETHERNET_LOG_LEVEL);
 #define ETH_STM32_PTP_NOT_CONFIGURED HAL_ETH_PTP_NOT_CONFIGURED
 #endif /* stm32F7x or sm32F4x */
 
+bool eth_stm32_is_ptp_pkt(struct net_pkt *pkt)
+{
+	const struct net_buf *buf = pkt->frags;
+	const struct net_eth_hdr *hdr;
+	uint16_t type;
+
+	if (buf == NULL || buf->len < sizeof(struct net_eth_hdr)) {
+		return false;
+	}
+
+	hdr = (const struct net_eth_hdr *)buf->data;
+	type = net_ntohs(hdr->type);
+
+	if (type == NET_ETH_PTYPE_VLAN) {
+		const struct net_eth_vlan_hdr *vlan_hdr;
+
+		if (buf->len < sizeof(struct net_eth_vlan_hdr)) {
+			return false;
+		}
+
+		vlan_hdr = (const struct net_eth_vlan_hdr *)buf->data;
+		type = net_ntohs(vlan_hdr->type);
+	}
+
+	if (type != NET_ETH_PTYPE_PTP) {
+		return false;
+	}
+
+	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
+
+	return true;
+}
+
 void HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp)
 {
 	struct eth_stm32_tx_context *ctx = (struct eth_stm32_tx_context *)buff;


### PR DESCRIPTION
Commit 50cfe12f90aa removed the receive-side priority classification for IEEE 1588 packets while adding RX/TX timestamping support.
Consequently, PTP packets retained the default priority when `net_recv_data()` selected their receive traffic class.

Restore the classification before passing packets to the network stack. Both untagged and single-VLAN PTP frames are safely recognized and assigned `NET_PRIORITY_CA`.

The helper is receive-only, leaving transmit timestamp selection unchanged.