### PR TITLE
net: zperf: fix UDP trailing packet loss accounting

### DIFF
--- a/subsys/net/lib/zperf/zperf_session.c
+++ b/subsys/net/lib/zperf/zperf_session.c
@@ -163,6 +163,7 @@ void zperf_reset_session_stats(struct session *session)
 	session->length = 0U;
 	session->outorder = 0U;
 	session->error = 0U;
+	session->missing_id_bitmap = 0U;
 	session->jitter = 0;
 	session->last_transit_time = 0;
 }

--- a/subsys/net/lib/zperf/zperf_session.h
+++ b/subsys/net/lib/zperf/zperf_session.h
@@ -42,6 +42,7 @@ struct session {
 	uint32_t next_id;
 	uint32_t outorder;
 	uint32_t error;
+	uint64_t missing_id_bitmap;
 	uint64_t length;
 	int64_t start_time;
 	uint32_t last_time;

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -34,10 +34,11 @@ static struct net_sockaddr_in *in4_addr_my;
 
 #define SOCK_ID_IPV4 0
 #define SOCK_ID_IPV6 1
-#define SOCK_ID_MAX 2
+#define SOCK_ID_MAX  2
 
-#define UDP_RECEIVER_BUF_SIZE 1500
-#define POLL_TIMEOUT_MS 100
+#define UDP_RECEIVER_BUF_SIZE   1500
+#define POLL_TIMEOUT_MS         100
+#define UDP_REORDER_WINDOW_SIZE 64U
 
 static zperf_callback udp_session_cb;
 static void *udp_user_data;
@@ -49,12 +50,43 @@ struct zsock_pollfd fds[SOCK_ID_MAX] = { 0 };
 
 static void udp_svc_handler(struct net_socket_service_event *pev);
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_udp, udp_svc_handler,
-				      SOCK_ID_MAX);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_udp, udp_svc_handler, SOCK_ID_MAX);
 static char udp_server_iface_name[NET_IFNAMSIZ];
 
-static inline void build_reply(struct zperf_udp_datagram *hdr,
-			       struct zperf_server_hdr *stat,
+static void udp_update_sequence(struct session *ses, uint32_t packet_id)
+{
+	uint32_t advance;
+
+	if (packet_id < ses->next_id) {
+		uint32_t distance = ses->next_id - packet_id - 1U;
+
+		ses->outorder++;
+		if (distance < UDP_REORDER_WINDOW_SIZE &&
+		    (ses->missing_id_bitmap & BIT64(distance)) != 0U) {
+			ses->missing_id_bitmap &= ~BIT64(distance);
+			if (ses->error > 0U) {
+				ses->error--;
+			}
+		}
+
+		return;
+	}
+
+	advance = packet_id - ses->next_id;
+	ses->error += advance;
+
+	if (advance >= UDP_REORDER_WINDOW_SIZE - 1U) {
+		/* Track the most recent missing IDs and account for older ones as lost. */
+		ses->missing_id_bitmap = ~BIT64(0);
+	} else {
+		ses->missing_id_bitmap <<= advance + 1U;
+		ses->missing_id_bitmap |= BIT64_MASK(advance) << 1U;
+	}
+
+	ses->next_id = packet_id + 1U;
+}
+
+static inline void build_reply(struct zperf_udp_datagram *hdr, struct zperf_server_hdr *stat,
 			       uint8_t *buf)
 {
 	int pos = 0;
@@ -109,6 +141,8 @@ static void udp_received(int sock, const struct net_sockaddr *addr, uint8_t *dat
 	int32_t transit_time;
 	int64_t time;
 	int32_t id;
+	uint32_t packet_id;
+	bool is_final;
 
 	if (datalen < sizeof(struct zperf_udp_datagram)) {
 		NET_WARN("Short iperf packet!");
@@ -125,11 +159,13 @@ static void udp_received(int sock, const struct net_sockaddr *addr, uint8_t *dat
 	}
 
 	id = net_ntohl(hdr->id);
+	is_final = id < 0;
+	packet_id = is_final ? (uint32_t)(-(int64_t)id) : (uint32_t)id;
 
 	switch (session->state) {
 	case STATE_COMPLETED:
 	case STATE_NULL:
-		if (id < 0) {
+		if (is_final) {
 			/* Session is already completed: Resend the stat packet
 			 * and continue
 			 */
@@ -177,23 +213,13 @@ static void udp_received(int sock, const struct net_sockaddr *addr, uint8_t *dat
 		session->last_transit_time = transit_time;
 
 		/* Check header id */
-		if (abs(id) != session->next_id) {
-			if (id < session->next_id) {
-				session->outorder++;
-			} else {
-				session->error += id - session->next_id;
-				session->next_id = id + 1;
-			}
-		} else {
-			session->next_id++;
-		}
+		udp_update_sequence(session, packet_id);
 
-		if (id < 0) { /* Negative id means session end. */
-			struct zperf_results results = { 0 };
+		if (is_final) { /* Negative id means session end. */
+			struct zperf_results results = {0};
 			uint64_t duration;
 
-			duration = k_ticks_to_us_ceil64(time -
-							session->start_time);
+			duration = k_ticks_to_us_ceil64(time - session->start_time);
 
 			/* Update state machine */
 			session->state = STATE_COMPLETED;
@@ -207,7 +233,8 @@ static void udp_received(int sock, const struct net_sockaddr *addr, uint8_t *dat
 			session->stat.stop_usec = duration % USEC_PER_SEC;
 			session->stat.error_cnt = session->error;
 			session->stat.outorder_cnt = session->outorder;
-			session->stat.datagrams = session->counter;
+			/* iPerf encodes the total sequence count, including loss. */
+			session->stat.datagrams = packet_id;
 			session->stat.jitter1 = 0;
 			session->stat.jitter2 = session->jitter;
 

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -24,15 +24,14 @@ static uint8_t sample_packet[sizeof(struct zperf_udp_datagram) +
 static struct zperf_async_upload_context udp_async_upload_ctx;
 #endif /* CONFIG_ZPERF_SESSION_PER_THREAD */
 
-static inline void zperf_upload_decode_stat(const uint8_t *data,
-					    size_t datalen,
+static inline void zperf_upload_decode_stat(const uint8_t *data, size_t datalen,
 					    struct zperf_results *results)
 {
 	struct zperf_server_hdr *stat;
+	uint32_t total_datagrams;
 	uint32_t flags;
 
-	if (datalen < sizeof(struct zperf_udp_datagram) +
-		      sizeof(struct zperf_server_hdr)) {
+	if (datalen < sizeof(struct zperf_udp_datagram) + sizeof(struct zperf_server_hdr)) {
 		NET_WARN("Network packet too short");
 	}
 
@@ -43,27 +42,26 @@ static inline void zperf_upload_decode_stat(const uint8_t *data,
 		NET_WARN("Unexpected response flags");
 	}
 
-	results->nb_packets_rcvd = net_ntohl(UNALIGNED_GET(&stat->datagrams));
 	results->nb_packets_lost = net_ntohl(UNALIGNED_GET(&stat->error_cnt));
-	results->nb_packets_outorder =
-		net_ntohl(UNALIGNED_GET(&stat->outorder_cnt));
+	total_datagrams = net_ntohl(UNALIGNED_GET(&stat->datagrams));
+	/* Keep the public result as the number of datagrams actually received. */
+	results->nb_packets_rcvd = total_datagrams >= results->nb_packets_lost
+					   ? total_datagrams - results->nb_packets_lost
+					   : 0U;
+	results->nb_packets_outorder = net_ntohl(UNALIGNED_GET(&stat->outorder_cnt));
 	results->total_len = (((uint64_t)net_ntohl(UNALIGNED_GET(&stat->total_len1))) << 32) +
-		net_ntohl(UNALIGNED_GET(&stat->total_len2));
+			     net_ntohl(UNALIGNED_GET(&stat->total_len2));
 	results->time_in_us = net_ntohl(UNALIGNED_GET(&stat->stop_usec)) +
-		net_ntohl(UNALIGNED_GET(&stat->stop_sec)) * USEC_PER_SEC;
+			      net_ntohl(UNALIGNED_GET(&stat->stop_sec)) * USEC_PER_SEC;
 	results->jitter_in_us = net_ntohl(UNALIGNED_GET(&stat->jitter2)) +
-		net_ntohl(UNALIGNED_GET(&stat->jitter1)) * USEC_PER_SEC;
+				net_ntohl(UNALIGNED_GET(&stat->jitter1)) * USEC_PER_SEC;
 }
 
-static inline int zperf_upload_fin(int sock,
-				   uint32_t nb_packets,
-				   uint64_t end_time_us,
-				   uint32_t packet_size,
-				   struct zperf_results *results,
+static inline int zperf_upload_fin(int sock, uint32_t nb_packets, uint64_t end_time_us,
+				   uint32_t packet_size, struct zperf_results *results,
 				   bool is_mcast_pkt)
 {
-	uint8_t stats[sizeof(struct zperf_udp_datagram) +
-		      sizeof(struct zperf_server_hdr)] = { 0 };
+	uint8_t stats[sizeof(struct zperf_udp_datagram) + sizeof(struct zperf_server_hdr)] = {0};
 	struct zperf_udp_datagram *datagram;
 	struct zperf_client_hdr_v1 *hdr;
 	uint32_t secs = end_time_us / USEC_PER_SEC;

--- a/tests/net/lib/zperf/CMakeLists.txt
+++ b/tests/net/lib/zperf/CMakeLists.txt
@@ -8,3 +8,7 @@ project(zperf_api)
 target_sources(app PRIVATE
   src/main.c
   )
+
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/subsys/net/lib/zperf
+  )

--- a/tests/net/lib/zperf/src/main.c
+++ b/tests/net/lib/zperf/src/main.c
@@ -13,7 +13,10 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
 #include <zephyr/net/zperf.h>
+
+#include "zperf_internal.h"
 
 #define LOOPBACK_IPV4_ADDR "127.0.0.1"
 #define TEST_PORT          5001
@@ -41,8 +44,12 @@ static enum zperf_status server_last_status = ZPERF_SESSION_ERROR;
 static struct zperf_results client_async_results;
 static enum zperf_status client_last_status = ZPERF_SESSION_ERROR;
 
-static void server_session_cb(enum zperf_status status,
-			      struct zperf_results *result,
+struct test_udp_stat {
+	struct zperf_udp_datagram datagram;
+	struct zperf_server_hdr server;
+} __packed;
+
+static void server_session_cb(enum zperf_status status, struct zperf_results *result,
 			      void *user_data)
 {
 	ARG_UNUSED(user_data);
@@ -165,33 +172,121 @@ ZTEST(zperf_api, test_udp_upload_download)
 	zassert_ok(ret, "UDP upload failed (%d)", ret);
 
 	/* Client side: we sent packets and collected the server statistics. */
-	zassert_true(client_results.nb_packets_sent > 0,
-		     "Client did not send any UDP packets");
+	zassert_true(client_results.nb_packets_sent > 0, "Client did not send any UDP packets");
 	zassert_equal(client_results.packet_size, TEST_PACKET_SIZE,
-		      "Unexpected client packet size %u",
-		      client_results.packet_size);
-	zassert_true(client_results.client_time_in_us > 0,
-		     "Client transfer time not reported");
+		      "Unexpected client packet size %u", client_results.packet_size);
+	zassert_true(client_results.client_time_in_us > 0, "Client transfer time not reported");
 	zassert_true(client_results.nb_packets_rcvd > 0,
 		     "Server did not report any received packets to client");
-	zassert_true(client_results.nb_packets_rcvd <=
-			     client_results.nb_packets_sent,
+	zassert_true(client_results.nb_packets_rcvd <= client_results.nb_packets_sent,
 		     "Server received more packets (%u) than were sent (%u)",
-		     client_results.nb_packets_rcvd,
-		     client_results.nb_packets_sent);
+		     client_results.nb_packets_rcvd, client_results.nb_packets_sent);
+	zassert_equal(client_results.nb_packets_rcvd + client_results.nb_packets_lost,
+		      client_results.nb_packets_sent,
+		      "Server packet accounting does not match the sent total");
 
 	/* Server side: wait for the FINISHED callback and verify its stats. */
 	ret = k_sem_take(&session_finished, TEST_TIMEOUT);
 	zassert_ok(ret, "Timed out waiting for UDP server session to finish");
 	zassert_equal(server_last_status, ZPERF_SESSION_FINISHED,
-		      "UDP server session did not finish cleanly (status %d)",
-		      server_last_status);
-	zassert_true(server_results.nb_packets_rcvd > 0,
-		     "UDP server did not receive any packets");
-	zassert_true(server_results.total_len > 0,
-		     "UDP server did not report any received data");
-	zassert_true(server_results.time_in_us > 0,
-		     "UDP server did not report a transfer time");
+		      "UDP server session did not finish cleanly (status %d)", server_last_status);
+	zassert_true(server_results.nb_packets_rcvd > 0, "UDP server did not receive any packets");
+	zassert_true(server_results.total_len > 0, "UDP server did not report any received data");
+	zassert_true(server_results.time_in_us > 0, "UDP server did not report a transfer time");
+}
+
+static void verify_udp_packet_sequence(const int32_t *packet_ids, size_t packet_count,
+				       uint32_t expected_lost, uint32_t expected_outorder,
+				       uint32_t expected_total)
+{
+	struct zperf_download_params download_param = {
+		.port = TEST_PORT,
+	};
+	struct net_sockaddr_in peer = {
+		.sin_family = NET_AF_INET,
+		.sin_port = net_htons(TEST_PORT),
+	};
+	struct timeval timeout = {
+		.tv_sec = 2,
+	};
+	struct test_udp_stat stat = {0};
+	struct zperf_udp_datagram packet = {0};
+	int sock;
+	int ret;
+
+	ret = zperf_udp_download(&download_param, server_session_cb, NULL);
+	zassert_ok(ret, "Failed to start UDP server (%d)", ret);
+	zassert_equal(net_addr_pton(NET_AF_INET, LOOPBACK_IPV4_ADDR, &peer.sin_addr), 0,
+		      "Failed to parse loopback address");
+
+	sock = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(sock >= 0, "Failed to create UDP socket (%d)", errno);
+	ret = zsock_setsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVTIMEO, &timeout,
+			       sizeof(timeout));
+	zassert_ok(ret, "Failed to set UDP receive timeout (%d)", errno);
+
+	for (size_t i = 0; i < packet_count; i++) {
+		packet.id = net_htonl((uint32_t)packet_ids[i]);
+		ret = zsock_sendto(sock, &packet, sizeof(packet), 0, (struct net_sockaddr *)&peer,
+				   sizeof(peer));
+		zassert_equal(ret, sizeof(packet), "Failed to send packet ID %d (%d)",
+			      packet_ids[i], errno);
+	}
+
+	ret = zsock_recv(sock, &stat, sizeof(stat), 0);
+	zassert_equal(ret, sizeof(stat), "Failed to receive UDP statistics (%d)", errno);
+	zsock_close(sock);
+
+	ret = k_sem_take(&session_finished, TEST_TIMEOUT);
+	zassert_ok(ret, "Timed out waiting for UDP server session to finish");
+	zassert_equal(server_last_status, ZPERF_SESSION_FINISHED,
+		      "UDP server session did not finish cleanly (status %d)", server_last_status);
+	zassert_equal(server_results.nb_packets_rcvd, packet_count,
+		      "Expected %zu received packets, got %u", packet_count,
+		      server_results.nb_packets_rcvd);
+	zassert_equal(server_results.nb_packets_lost, expected_lost,
+		      "Expected %u lost packets, got %u", expected_lost,
+		      server_results.nb_packets_lost);
+	zassert_equal(server_results.nb_packets_outorder, expected_outorder,
+		      "Expected %u out-of-order packets, got %u", expected_outorder,
+		      server_results.nb_packets_outorder);
+	zassert_equal(net_ntohl(stat.server.error_cnt), expected_lost,
+		      "UDP ACK reported %u lost packets instead of %u",
+		      net_ntohl(stat.server.error_cnt), expected_lost);
+	zassert_equal(net_ntohl(stat.server.outorder_cnt), expected_outorder,
+		      "UDP ACK reported %u out-of-order packets instead of %u",
+		      net_ntohl(stat.server.outorder_cnt), expected_outorder);
+	zassert_equal(net_ntohl(stat.server.datagrams), expected_total,
+		      "UDP ACK reported a total of %u datagrams instead of %u",
+		      net_ntohl(stat.server.datagrams), expected_total);
+}
+
+ZTEST(zperf_api, test_udp_fin_accounts_for_trailing_loss)
+{
+	const int32_t packet_ids[] = {1, 2, -5};
+
+	verify_udp_packet_sequence(packet_ids, ARRAY_SIZE(packet_ids), 2, 0, 5);
+}
+
+ZTEST(zperf_api, test_udp_fin_reconciles_out_of_order_gap)
+{
+	const int32_t packet_ids[] = {1, 3, 2, -4};
+
+	verify_udp_packet_sequence(packet_ids, ARRAY_SIZE(packet_ids), 0, 1, 4);
+}
+
+ZTEST(zperf_api, test_udp_fin_does_not_reconcile_duplicate)
+{
+	const int32_t packet_ids[] = {1, 3, 3, -5};
+
+	verify_udp_packet_sequence(packet_ids, ARRAY_SIZE(packet_ids), 2, 1, 5);
+}
+
+ZTEST(zperf_api, test_udp_fin_does_not_reconcile_recovered_duplicate)
+{
+	const int32_t packet_ids[] = {1, 4, 2, 2, -5};
+
+	verify_udp_packet_sequence(packet_ids, ARRAY_SIZE(packet_ids), 1, 2, 5);
 }
 
 ZTEST(zperf_api, test_tcp_upload_download)


### PR DESCRIPTION
The zperf UDP uploader encodes the terminal sequence ID as `-(number_of_packets + 1)`. The receiver mixed this signed terminal ID with unsigned sequence counters, causing trailing packet loss to be reported incorrectly.

The UDP ACK also used the number of received datagrams where iPerf expects the total sequence count, including missing packets.

Fix the accounting by:

- Normalizing the terminal sequence ID before sequence comparisons.
- Encoding the terminal sequence count in the ACK.
- Deriving the public received count from the total and lost counts.
- Tracking recent missing sequence IDs in a 64-packet window.
- Reconciliating loss only when a late packet fills a genuine gap, preventing duplicate packets from masking actual loss.

Add loopback regressions covering:

- Trailing loss: `1, 2, -5`
- Recovered out-of-order gap: `1, 3, 2, -4`
- Duplicate packet with outstanding gaps: `1, 3, 3, -5`
- Duplicate of an already recovered packet: `1, 4, 2, 2, -5`