### PR TITLE
video: improve Doxygen coverage of the video API headers

### DIFF
--- a/include/zephyr/drivers/video/stm32_dcmipp.h
+++ b/include/zephyr/drivers/video/stm32_dcmipp.h
@@ -14,9 +14,50 @@
 #define ZEPHYR_INCLUDE_VIDEO_STM32_DCMIPP_H_
 
 /* Prototypes of ISP external handler weak functions */
+
+/**
+ * @brief Notify the external ISP handler of a VSYNC event
+ *
+ * The DCMIPP driver calls this hook on each VSYNC event, indicating that new
+ * statistics are available. A weak no-op implementation is provided; an
+ * external ISP handler can override it.
+ *
+ * @param hdcmipp HAL DCMIPP handle
+ * @param Pipe DCMIPP pipe on which the VSYNC event occurred
+ */
 void stm32_dcmipp_isp_vsync_update(DCMIPP_HandleTypeDef *hdcmipp, uint32_t Pipe);
+
+/**
+ * @brief Initialize the external ISP handler
+ *
+ * The DCMIPP driver calls this hook during driver initialization. A weak
+ * no-op implementation is provided; an external ISP handler can override it.
+ *
+ * @param hdcmipp HAL DCMIPP handle
+ * @param source Pointer to the video source device
+ *
+ * @return 0 on success, negative errno code on failure
+ */
 int stm32_dcmipp_isp_init(DCMIPP_HandleTypeDef *hdcmipp, const struct device *source);
+
+/**
+ * @brief Start the external ISP handler
+ *
+ * The DCMIPP driver calls this hook when video capture starts. A weak no-op
+ * implementation is provided; an external ISP handler can override it.
+ *
+ * @return 0 on success, negative errno code on failure
+ */
 int stm32_dcmipp_isp_start(void);
+
+/**
+ * @brief Stop the external ISP handler
+ *
+ * The DCMIPP driver calls this hook when video capture stops. A weak no-op
+ * implementation is provided; an external ISP handler can override it.
+ *
+ * @return 0 on success, negative errno code on failure
+ */
 int stm32_dcmipp_isp_stop(void);
 
 #endif /* ZEPHYR_INCLUDE_VIDEO_STM32_DCMIPP_H_ */

--- a/include/zephyr/drivers/video/stm32_dcmipp.h
+++ b/include/zephyr/drivers/video/stm32_dcmipp.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ISP handler hooks for the STM32 DCMIPP video driver.
+ * @ingroup video_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_VIDEO_STM32_DCMIPP_H_
 #define ZEPHYR_INCLUDE_VIDEO_STM32_DCMIPP_H_
 

--- a/include/zephyr/video/controls.h
+++ b/include/zephyr/video/controls.h
@@ -43,6 +43,7 @@ extern "C" {
  * @name Base class control IDs
  * @{
  */
+/** Base ID of the base class control IDs */
 #define VIDEO_CID_BASE 0x00980900
 
 /** Picture brightness, or more precisely, the black level. */
@@ -179,6 +180,7 @@ enum video_colorfx {
  * @name Stateful codec controls IDs
  * @{
  */
+/** Base ID of the stateful codec class control IDs */
 #define VIDEO_CID_CODEC_CLASS_BASE 0x00990900
 
 /**
@@ -189,6 +191,7 @@ enum video_colorfx {
  * @name Camera class controls IDs
  * @{
  */
+/** Base ID of the camera class control IDs */
 #define VIDEO_CID_CAMERA_CLASS_BASE 0x009a0900
 
 /** Enables automatic adjustments of the exposure time and/or iris aperture.
@@ -367,6 +370,7 @@ enum video_camera_orientation {
  * @name Camera Flash class control IDs
  * @{
  */
+/** Base ID of the camera flash class control IDs */
 #define VIDEO_CID_FLASH_CLASS_BASE 0x009c0900
 
 /**
@@ -377,6 +381,7 @@ enum video_camera_orientation {
  * @name JPEG class control IDs
  * @{
  */
+/** Base ID of the JPEG class control IDs */
 #define VIDEO_CID_JPEG_CLASS_BASE 0x009d0900
 
 /** Quality (Q) factor of the JPEG algorithm, also increasing the data size */
@@ -390,6 +395,7 @@ enum video_camera_orientation {
  * @name Image Source class control IDs
  * @{
  */
+/** Base ID of the image source class control IDs */
 #define VIDEO_CID_IMAGE_SOURCE_CLASS_BASE 0x009e0900
 
 /**
@@ -409,6 +415,7 @@ enum video_camera_orientation {
  * @name Image Processing class control IDs
  * @{
  */
+/** Base ID of the image processing class control IDs */
 #define VIDEO_CID_IMAGE_PROC_CLASS_BASE 0x009f0900
 
 /** Link frequency, applicable for the CSI2 based devices */
@@ -439,6 +446,7 @@ enum video_camera_orientation {
  * @name Vendor-specific class control IDs
  * @{
  */
+/** Base ID of the vendor specific class control IDs */
 #define VIDEO_CID_PRIVATE_BASE 0x08000000
 
 /**
@@ -448,6 +456,10 @@ enum video_camera_orientation {
 /**
  * @name Query flags, to be ORed with the control ID
  * @{
+ */
+/**
+ * When ORed with the control ID of a query, the next supported control with an ID greater
+ * than the one given is returned instead of that exact control.
  */
 #define VIDEO_CTRL_FLAG_NEXT_CTRL 0x80000000
 

--- a/include/zephyr/video/types.h
+++ b/include/zephyr/video/types.h
@@ -175,25 +175,25 @@ struct video_caps {
 struct video_ctrl_range {
 	/** control minimum value, inclusive */
 	union {
-		int32_t min;
-		int64_t min64;
+		int32_t min;   /**< Value for 32 bit control types */
+		int64_t min64; /**< Value for 64 bit control types */
 	};
 	/** control maximum value, inclusive */
 	union {
-		int32_t max;
-		int64_t max64;
+		int32_t max;   /**< Value for 32 bit control types */
+		int64_t max64; /**< Value for 64 bit control types */
 	};
 	/** control value step */
 	union {
-		int32_t step;
-		int64_t step64;
+		int32_t step;   /**< Value for 32 bit control types */
+		int64_t step64; /**< Value for 64 bit control types */
 	};
 	/** control default value for VIDEO_CTRL_TYPE_INTEGER, _BOOLEAN, _MENU or
 	 * _INTEGER_MENU, not valid for other types
 	 */
 	union {
-		int32_t def;
-		int64_t def64;
+		int32_t def;   /**< Value for 32 bit control types */
+		int64_t def64; /**< Value for 64 bit control types */
 	};
 };
 
@@ -208,8 +208,8 @@ struct video_control {
 	uint32_t id;
 	/** control value */
 	union {
-		int32_t val;
-		int64_t val64;
+		int32_t val;   /**< Value for 32 bit control types */
+		int64_t val64; /**< Value for 64 bit control types */
 	};
 };
 
@@ -233,8 +233,8 @@ struct video_ctrl_query {
 	struct video_ctrl_range range;
 	/** menu if control is of menu type */
 	union {
-		const char *const *menu;
-		const int64_t *int_menu;
+		const char *const *menu;  /**< Entries of a VIDEO_CTRL_TYPE_MENU control */
+		const int64_t *int_menu;  /**< Entries of a VIDEO_CTRL_TYPE_INTEGER_MENU control */
 	};
 };
 
@@ -347,7 +347,9 @@ struct video_frmival_enum {
 	enum video_frmival_type type;
 	/** the actual frame interval */
 	union {
+		/** Interval of a VIDEO_FRMIVAL_TYPE_DISCRETE device */
 		struct video_frmival discrete;
+		/** Interval range of a VIDEO_FRMIVAL_TYPE_STEPWISE device */
 		struct video_frmival_stepwise stepwise;
 	};
 };


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` block to `drivers/video/stm32_dcmipp.h` and
  documents the external ISP handler hooks it declares.
- Documents the base IDs that open each video control class, and the
  struct union members in `video/types.h`.

Documentation only, no functional change.