### PR TITLE
authentication: improve Doxygen coverage of FIDO2 and biometrics headers

### DIFF
--- a/include/zephyr/authentication/fido2/fido2.h
+++ b/include/zephyr/authentication/fido2/fido2.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief FIDO2 authenticator public API.
+ * @ingroup fido2
  */
 
 #ifndef ZEPHYR_INCLUDE_AUTHENTICATION_FIDO2_FIDO2_H_

--- a/include/zephyr/authentication/fido2/fido2_attestation.h
+++ b/include/zephyr/authentication/fido2/fido2_attestation.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief FIDO2 attestation callback API.
+ * @ingroup fido2
  */
 
 #ifndef ZEPHYR_INCLUDE_AUTHENTICATION_FIDO2_FIDO2_ATTESTATION_H_

--- a/include/zephyr/authentication/fido2/fido2_storage.h
+++ b/include/zephyr/authentication/fido2/fido2_storage.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief FIDO2 credential storage API.
+ * @ingroup fido2
  */
 
 #ifndef ZEPHYR_INCLUDE_AUTHENTICATION_FIDO2_FIDO2_STORAGE_H_

--- a/include/zephyr/authentication/fido2/fido2_transport.h
+++ b/include/zephyr/authentication/fido2/fido2_transport.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief FIDO2 transport abstraction API.
+ * @ingroup fido2
  */
 
 #ifndef ZEPHYR_INCLUDE_AUTHENTICATION_FIDO2_FIDO2_TRANSPORT_H_

--- a/include/zephyr/authentication/fido2/fido2_types.h
+++ b/include/zephyr/authentication/fido2/fido2_types.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief FIDO2 shared type definitions.
+ * @ingroup fido2
  */
 
 #ifndef ZEPHYR_INCLUDE_AUTHENTICATION_FIDO2_FIDO2_TYPES_H_

--- a/include/zephyr/authentication/fido2/fido2_up.h
+++ b/include/zephyr/authentication/fido2/fido2_up.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief FIDO2 user presence abstraction API.
+ * @ingroup fido2
  */
 
 #ifndef ZEPHYR_INCLUDE_AUTHENTICATION_FIDO2_FIDO2_UP_H_

--- a/include/zephyr/drivers/biometrics/emul.h
+++ b/include/zephyr/drivers/biometrics/emul.h
@@ -8,6 +8,7 @@
  * @file
  *
  * @brief Test helper APIs for the biometrics emulator.
+ * @ingroup biometrics_emulator
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_BIOMETRICS_EMUL_H_


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

Attaches the `@file` block of each FIDO2 header to the `fido2` group,
and the biometrics emulator header to the `biometrics_emulator` group,
so the files are listed under the right API group in the generated
documentation.

Documentation only, no functional change.