### PR TITLE
device: improve Doxygen coverage of the device model headers

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -548,12 +548,19 @@ struct device {
 	 * @kconfig{CONFIG_PM_DEVICE} is enabled).
 	 */
 	union {
+		/** Info common to all device PM variants */
 		struct pm_device_base *pm_base;
+		/** Info for a device using generic PM */
 		struct pm_device *pm;
+		/** Info for a device using synchronous PM */
 		struct pm_device_isr *pm_isr;
 	};
 #endif
 #if defined(CONFIG_DEVICE_DT_METADATA) || defined(__DOXYGEN__)
+	/**
+	 * Devicetree metadata associated with the device (only available if
+	 * @kconfig{CONFIG_DEVICE_DT_METADATA} is enabled).
+	 */
 	const struct device_dt_metadata *dt_meta;
 #endif /* CONFIG_DEVICE_DT_METADATA */
 };

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief APIs and macros for the Zephyr device model.
+ * @ingroup device_model
+ */
+
 #ifndef ZEPHYR_INCLUDE_DEVICE_H_
 #define ZEPHYR_INCLUDE_DEVICE_H_
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -241,6 +241,7 @@ extern "C" {
  *
  */
 struct spi_cs_control {
+	/** Chip select control parameters, interpreted according to @c cs_is_gpio */
 	union {
 		struct {
 			/**
@@ -271,7 +272,11 @@ struct spi_cs_control {
 			uint32_t hold_ns;
 		};
 	};
-	/* To keep track of which form of this struct is valid */
+	/**
+	 * True when the chip select is controlled by a GPIO (@c gpio and @c delay
+	 * fields), false when it is handled by the SPI controller itself
+	 * (@c setup_ns and @c hold_ns fields).
+	 */
 	bool cs_is_gpio;
 };
 
@@ -803,11 +808,15 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 
 /** @} */
 
+/** @cond INTERNAL_HIDDEN */
+
 #define SPI_STATS_RX_BYTES_INC(dev_)
 #define SPI_STATS_TX_BYTES_INC(dev_)
 #define SPI_STATS_TRANSFER_ERROR_INC(dev_)
 
 #define spi_transceive_stats(dev, error, tx_bufs, rx_bufs)
+
+/** @endcond */
 
 #endif /*CONFIG_SPI_STATS*/
 

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Public APIs for the system initialization infrastructure.
+ * @ingroup sys_init
+ */
+
 #ifndef ZEPHYR_INCLUDE_INIT_H_
 #define ZEPHYR_INCLUDE_INIT_H_
 


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` blocks to `device.h` and `init.h`, attached
  to their Doxygen groups.
- Documents the power management union and the devicetree metadata
  pointer of `struct device`.

Documentation only, no functional change.
