### PR TITLE
boards: adi: Fix APARD32690 partitions to not require MCUBoot

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690.dtsi
+++ b/boards/adi/apard32690/apard32690_max32690.dtsi
@@ -26,35 +26,21 @@
 };
 
 &flash0 {
-	/* Partition table for MCUBoot. 64 KiB for bootloader, 480 KiB each for slot0 and slot1 */
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
 
-		boot_partition: partition@0 {
+		m4_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(128)>;
+			label = "image-m4";
+			reg = <0x0 DT_SIZE_M(1)>;
 		};
 
-		/* Slot0 and Slot1 are used to boot the M4 core */
-		slot0_partition: partition@20000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-0";
-			reg = <0x20000 DT_SIZE_K(956)>;
-		};
-
-		slot1_partition: partition@10f000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-1";
-			reg = <0x10f000 DT_SIZE_K(964)>;
-		};
-
-		storage_partition: partition@200000 {
+		storage_partition: partition@100000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x200000 DT_SIZE_M(1)>;
+			reg = <0x100000 DT_SIZE_K(64)>;
 		};
 	};
 };
@@ -65,16 +51,10 @@
 		#size-cells = <1>;
 		ranges;
 
-		rv32_slot0: rv32_partition@0 {
+		rv32_partition: rv32_partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-rv32";
-			reg = <0x0 DT_SIZE_K(96)>;
-		};
-
-		rv32_slot1: rv32_partition@18000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-rv32-1";
-			reg = <0x18000 DT_SIZE_K(96)>;
+			reg = <0x0 DT_SIZE_K(192)>;
 		};
 
 		rv32_storage_partition: rv32_partition@30000 {

--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -24,8 +24,8 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
-		zephyr,code-rv32-partition = &rv32_slot0;
+		zephyr,code-partition = &m4_partition;
+		zephyr,code-rv32-partition = &rv32_partition;
 	};
 
 	buttons {

--- a/boards/adi/apard32690/apard32690_max32690_rv32.dts
+++ b/boards/adi/apard32690/apard32690_max32690_rv32.dts
@@ -25,7 +25,7 @@
 		zephyr,sram = &sram8;
 		zephyr,flash-controller = &flc1;
 		zephyr,flash = &flash1;
-		zephyr,code-partition = &rv32_slot0;
+		zephyr,code-partition = &rv32_partition;
 		zephyr,settings-partition = &rv32_storage_partition;
 	};
 


### PR DESCRIPTION
Simplify the apard32690 board partitions to avoid requiring MCUBoot by default.