### PR TITLE
rtio: improve Doxygen coverage of the RTIO headers

### DIFF
--- a/include/zephyr/rtio/cqe.h
+++ b/include/zephyr/rtio/cqe.h
@@ -45,6 +45,12 @@ extern "C" {
  */
 #define RTIO_CQE_FLAG_MEMPOOL_BUFFER BIT(0)
 
+/**
+ * @brief Get the flag bits of a CQE flags value
+ *
+ * @param flags The CQE flags value
+ * @return The flag portion of the flags field.
+ */
 #define RTIO_CQE_FLAG_GET(flags) FIELD_GET(GENMASK(7, 0), (flags))
 
 /**
@@ -82,7 +88,9 @@ extern "C" {
  * @brief A completion queue event
  */
 struct rtio_cqe {
+	/** @cond INTERNAL_HIDDEN */
 	struct mpsc_node q;
+	/** @endcond */
 
 	int32_t result; /**< Result from operation */
 	void *userdata; /**< Associated userdata with operation */

--- a/include/zephyr/rtio/cqe.h
+++ b/include/zephyr/rtio/cqe.h
@@ -9,6 +9,7 @@
 /**
  * @file
  * @brief RTIO Completion Queue Events and Related Functions
+ * @ingroup rtio
  */
 
 

--- a/include/zephyr/rtio/iodev.h
+++ b/include/zephyr/rtio/iodev.h
@@ -47,10 +47,10 @@ struct rtio_iodev_api {
  * @brief An IO device with a function table for submitting requests
  */
 struct rtio_iodev {
-	/* Function pointer table */
+	/** Function pointer table */
 	const struct rtio_iodev_api *api;
 
-	/* Data associated with this iodev */
+	/** Data associated with this iodev */
 	void *data;
 };
 

--- a/include/zephyr/rtio/iodev.h
+++ b/include/zephyr/rtio/iodev.h
@@ -9,6 +9,7 @@
 /**
  * @file
  * @brief RTIO I/O Device and Related Functions
+ * @ingroup rtio
  */
 
 #ifndef ZEPHYR_INCLUDE_RTIO_IODEV_H_

--- a/include/zephyr/rtio/regmap.h
+++ b/include/zephyr/rtio/regmap.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Helpers for reading and writing device register lists through RTIO.
+ * @ingroup rtio
+ */
+
 #ifndef ZEPHYR_INCLUDE_RTIO_REGMAP_H_
 #define ZEPHYR_INCLUDE_RTIO_REGMAP_H_
 

--- a/include/zephyr/rtio/regmap.h
+++ b/include/zephyr/rtio/regmap.h
@@ -27,6 +27,7 @@ struct rtio_regs {
 	/** Number of registers in the list **/
 	size_t rtio_regs_num;
 
+	/** Description of a single memory chunk **/
 	struct rtio_regs_list {
 		/** Register address **/
 		uint8_t reg_addr;
@@ -36,7 +37,7 @@ struct rtio_regs {
 
 		/** Length of the buffer in bytes **/
 		size_t len;
-	} *rtio_regs_list;
+	} *rtio_regs_list; /**< Array of rtio_regs_num memory chunks **/
 };
 
 /**
@@ -46,9 +47,9 @@ struct rtio_regs {
  * a bus-related handling (e.g. rtio_read_regs_async)
  */
 typedef enum {
-	RTIO_BUS_I2C,
-	RTIO_BUS_SPI,
-	RTIO_BUS_I3C,
+	RTIO_BUS_I2C, /**< I2C bus */
+	RTIO_BUS_SPI, /**< SPI bus */
+	RTIO_BUS_I3C, /**< I3C bus */
 } rtio_bus_type;
 
 /**
@@ -81,7 +82,7 @@ static inline bool rtio_is_i3c(rtio_bus_type bus_type)
 	return (bus_type == RTIO_BUS_I3C);
 }
 
-/*
+/**
  * @brief Create a chain of SQEs representing a bus transaction to read a reg.
  *
  * The RTIO-enabled bus driver is instrumented to perform bus read ops

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -86,18 +86,18 @@ struct rtio {
 	struct k_sem *consume_sem;
 #endif
 
-	/* Total number of completions */
+	/** Total number of completions */
 	atomic_t cq_count;
 
-	/* Number of completions that were unable to be submitted with results
-	 * due to the cq spsc being full
+	/** Number of completions that could not be submitted with their results
+	 * because the completion queue was full
 	 */
 	atomic_t xcqcnt;
 
-	/* Submission queue object pool with free list */
+	/** Submission queue object pool with free list */
 	struct rtio_sqe_pool *sqe_pool;
 
-	/* Complete queue object pool with free list */
+	/** Completion queue object pool with free list */
 	struct rtio_cqe_pool *cqe_pool;
 
 #ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
@@ -105,10 +105,10 @@ struct rtio {
 	struct sys_mem_blocks *block_pool;
 #endif
 
-	/* Submission queue */
+	/** Submission queue */
 	struct mpsc sq;
 
-	/* Completion queue */
+	/** Completion queue */
 	struct mpsc cq;
 };
 
@@ -190,6 +190,8 @@ static inline uint16_t __rtio_compute_mempool_block_index(const struct rtio *r, 
 }
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 static inline int rtio_block_pool_alloc(struct rtio *r, size_t min_sz,
 					  size_t max_sz, uint8_t **buf, uint32_t *buf_len)
 {
@@ -243,6 +245,8 @@ static inline void rtio_block_pool_free(struct rtio *r, void *buf, uint32_t buf_
 	sys_mem_blocks_free_contiguous(r->block_pool, buf, num_blks);
 #endif
 }
+
+/** @endcond */
 
 
 /** The memory partition associated with all RTIO context information */
@@ -646,9 +650,13 @@ static inline int z_impl_rtio_cqe_get_mempool_buffer(const struct rtio *r, struc
 #endif
 }
 
+/** @cond INTERNAL_HIDDEN */
+
 void rtio_executor_submit(struct rtio *r);
 void rtio_executor_ok(struct rtio_iodev_sqe *iodev_sqe, int result);
 void rtio_executor_err(struct rtio_iodev_sqe *iodev_sqe, int result);
+
+/** @endcond */
 
 /**
  * @brief Inform the executor of a submission completion with success

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -9,6 +9,7 @@
 /**
  * @file
  * @brief Real-Time IO device API for moving bytes with low effort
+ * @ingroup rtio
  *
  * RTIO is a context for asynchronous batch operations using a submission and completion queue.
  *

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -86,18 +86,16 @@ struct rtio {
 	struct k_sem *consume_sem;
 #endif
 
-	/* Total number of completions */
+	/** Total number of completions */
 	atomic_t cq_count;
 
-	/* Number of completions that were unable to be submitted with results
-	 * due to the cq spsc being full
-	 */
+	/** Number of completions dropped because no CQE was available */
 	atomic_t xcqcnt;
 
-	/* Submission queue object pool with free list */
+	/** Submission queue object pool with free list */
 	struct rtio_sqe_pool *sqe_pool;
 
-	/* Complete queue object pool with free list */
+	/** Completion queue object pool with free list */
 	struct rtio_cqe_pool *cqe_pool;
 
 #ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
@@ -105,10 +103,10 @@ struct rtio {
 	struct sys_mem_blocks *block_pool;
 #endif
 
-	/* Submission queue */
+	/** Submission queue */
 	struct mpsc sq;
 
-	/* Completion queue */
+	/** Completion queue */
 	struct mpsc cq;
 };
 
@@ -190,6 +188,8 @@ static inline uint16_t __rtio_compute_mempool_block_index(const struct rtio *r, 
 }
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 static inline int rtio_block_pool_alloc(struct rtio *r, size_t min_sz,
 					  size_t max_sz, uint8_t **buf, uint32_t *buf_len)
 {
@@ -243,6 +243,8 @@ static inline void rtio_block_pool_free(struct rtio *r, void *buf, uint32_t buf_
 	sys_mem_blocks_free_contiguous(r->block_pool, buf, num_blks);
 #endif
 }
+
+/** @endcond */
 
 
 /** The memory partition associated with all RTIO context information */
@@ -646,9 +648,13 @@ static inline int z_impl_rtio_cqe_get_mempool_buffer(const struct rtio *r, struc
 #endif
 }
 
+/** @cond INTERNAL_HIDDEN */
+
 void rtio_executor_submit(struct rtio *r);
 void rtio_executor_ok(struct rtio_iodev_sqe *iodev_sqe, int result);
 void rtio_executor_err(struct rtio_iodev_sqe *iodev_sqe, int result);
+
+/** @endcond */
 
 /**
  * @brief Inform the executor of a submission completion with success

--- a/include/zephyr/rtio/sqe.h
+++ b/include/zephyr/rtio/sqe.h
@@ -322,6 +322,7 @@ struct rtio_sqe {
 	 */
 	void *userdata;
 
+	/** Operation specific arguments, selected by the op code */
 	union {
 
 		/** OP_TX */
@@ -344,7 +345,7 @@ struct rtio_sqe {
 
 		/** OP_CALLBACK */
 		struct {
-			rtio_callback_t callback;
+			rtio_callback_t callback; /**< Function to run */
 			void *arg0; /**< Last argument given to callback */
 		} callback;
 
@@ -369,8 +370,8 @@ struct rtio_sqe {
 		/** OP_I3C_CONFIGURE */
 		struct {
 			/* enum i3c_config_type type; */
-			int type;
-			void *config;
+			int type; /**< Configuration type, an enum i3c_config_type value */
+			void *config; /**< Configuration to apply */
 		} i3c_config;
 
 		/** OP_I3C_CCC */
@@ -379,8 +380,10 @@ struct rtio_sqe {
 
 		/** OP_AWAIT */
 		struct {
+			/** @cond INTERNAL_HIDDEN */
 			atomic_t ok;
-			rtio_signaled_t callback;
+			/** @endcond */
+			rtio_signaled_t callback; /**< Function to run once signaled */
 			void *userdata;
 		} await;
 	};
@@ -393,10 +396,10 @@ struct rtio_sqe {
  * May be cast safely to and from a rtio_sqe as they occupy the same memory provided by the pool
  */
 struct rtio_iodev_sqe {
-	struct rtio_sqe sqe;
-	struct mpsc_node q;
-	struct rtio_iodev_sqe *next;
-	struct rtio *r;
+	struct rtio_sqe sqe; /**< Submission this entry carries */
+	struct mpsc_node q; /**< Link used to enqueue this entry */
+	struct rtio_iodev_sqe *next; /**< Next entry in the chain or transaction, NULL if last */
+	struct rtio *r; /**< RTIO context the submission belongs to */
 };
 
 
@@ -476,6 +479,13 @@ static inline void rtio_sqe_prep_read_with_pool(struct rtio_sqe *sqe,
 	sqe->flags = RTIO_SQE_MEMPOOL_BUFFER;
 }
 
+/**
+ * @brief Prepare a multishot read op submission with context's mempool
+ *
+ * The submission keeps producing completions until it is canceled.
+ *
+ * @see rtio_sqe_prep_read_with_pool()
+ */
 static inline void rtio_sqe_prep_read_multishot(struct rtio_sqe *sqe,
 						const struct rtio_iodev *iodev, int8_t prio,
 						void *userdata)

--- a/include/zephyr/rtio/sqe.h
+++ b/include/zephyr/rtio/sqe.h
@@ -9,6 +9,7 @@
 /**
  * @file
  * @brief RTIO Submission Queue Events and Related Functions
+ * @ingroup rtio
  */
 
 

--- a/include/zephyr/rtio/work.h
+++ b/include/zephyr/rtio/work.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief RTIO work queues for executing blocking operations asynchronously.
+ * @ingroup rtio
+ */
+
 #ifndef ZEPHYR_INCLUDE_RTIO_WORK_H_
 #define ZEPHYR_INCLUDE_RTIO_WORK_H_
 


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

- Adds the missing `@file` blocks, each attached to the `rtio` Doxygen
  group.
- Documents the queue, iodev, CQE, SQE and regmap members.
- Hides the RTIO executor internals, which are implementation details
  rather than API.

Documentation only, no functional change.