### PR TITLE
drivers: power: fix the SAM SUPC wakeup source ID accessor

### DIFF
--- a/include/zephyr/drivers/power/atmel_sam_supc.h
+++ b/include/zephyr/drivers/power/atmel_sam_supc.h
@@ -10,7 +10,7 @@
 #define SAM_DT_SUPC_CONTROLLER DEVICE_DT_GET(DT_NODELABEL(supc))
 
 #define SAM_DT_SUPC_WAKEUP_SOURCE_ID(node_id) \
-	DT_PROP_BY_IDX(node_id, wakeup_source_id wakeup_source_id)
+	DT_PHA(node_id, wakeup_source_id, wakeup_source_id)
 
 #define SAM_DT_INST_SUPC_WAKEUP_SOURCE_ID(inst) \
 	SAM_DT_SUPC_WAKEUP_SOURCE_ID(DT_DRV_INST(inst))


### PR DESCRIPTION
SAM_DT_SUPC_WAKEUP_SOURCE_ID() passed the property name and the specifier cell name as a single argument to DT_PROP_BY_IDX(), which takes a node identifier, a property and an index.

wakeup-source-id is a phandle-array with one specifier cell, as declared by the atmel,sam-supc binding, so the cell value has to be read with DT_PHA().

No node in the tree sets a wakeup-source-id property yet, so the macro is never expanded and the mistake produced no build failure.

Assisted-by: Claude:fable-5