### PR TITLE
boards: nxp: frdm_mcxa577: enable FlexSPI NOR flash

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -347,6 +347,14 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_HF_to_FLEXCAN0);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexspi))
+	/* FRO_HF (192 MHz) / 4 = 48 MHz FlexSPI root clock */
+	CLOCK_SetClockDiv(kCLOCK_DivFLEXSPI0, 4U);
+	CLOCK_AttachClk(kFRO_HF_to_FLEXSPI);
+	CLOCK_EnableClock(kCLOCK_GateFLEXSPI0);
+	RESET_ReleasePeripheralReset(kFLEXSPI0_RST_SHIFT_RSTn);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexio0))
 	CLOCK_SetClockDiv(kCLOCK_DivFLEXIO0, 1u);
 	CLOCK_AttachClk(kFRO_HF_to_FLEXIO0);

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -168,6 +168,28 @@
 		};
 	};
 
+	pinmux_flexspi: pinmux_flexspi {
+		group0 {
+			pinmux = <FLEXSPI0_A_SS0_B_P3_0>,
+				 <FLEXSPI0_A_SCLK_P3_7>,
+				 <FLEXSPI0_A_DQS_P3_6>,
+				 <FLEXSPI0_A_DATA0_P3_8>,
+				 <FLEXSPI0_A_DATA1_P3_9>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <FLEXSPI0_A_DATA2_P3_10>,
+				 <FLEXSPI0_A_DATA3_P3_11>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+			bias-pull-up;
+		};
+	};
+
 	pinmux_flexio_lcd: pinmux_flexio_lcd {
 		group0 {
 			pinmux = <FLEXIO0_D0_P0_8>,

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -231,6 +231,77 @@
 	};
 };
 
+&flexspi {
+	status = "okay";
+	pinctrl-0 = <&pinmux_flexspi>;
+	pinctrl-names = "default";
+	ahb-prefetch;
+	ahb-bufferable;
+	ahb-cacheable;
+	ahb-read-addr-opt;
+	combination-mode;
+	rx-clock-source = <1>;
+
+	/* WINBOND W25Q64JV flash memory */
+	ext_flash_ctrl: flash-controller@0 {
+		compatible = "nxp,imx-flexspi-nor";
+		status = "okay";
+		size = <DT_SIZE_M(64)>;
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
+		jedec-id = [ef 40 17];
+		cs-interval-unit = <1>;
+		cs-interval = <2>;
+		cs-hold-time = <3>;
+		cs-setup-time = <3>;
+		data-valid-time = <2>;
+		column-space = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x90000000 DT_SIZE_M(8)>;
+
+		w25q64: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(8)>;
+			erase-block-size = <DT_SIZE_K(4)>;
+			write-block-size = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			partitions {
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				ext_boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
+					label = "ext-mcuboot";
+					reg = <0x00000000 DT_SIZE_K(80)>;
+				};
+
+				ext_slot0_partition: partition@14000 {
+					compatible = "zephyr,mapped-partition";
+					label = "ext-image-0";
+					reg = <0x00014000 DT_SIZE_M(3)>;
+				};
+
+				ext_slot1_partition: partition@314000 {
+					compatible = "zephyr,mapped-partition";
+					label = "ext-image-1";
+					reg = <0x00314000 DT_SIZE_M(3)>;
+				};
+
+				ext_storage_partition: partition@614000 {
+					compatible = "zephyr,mapped-partition";
+					label = "ext-storage";
+					reg = <0x00614000 DT_SIZE_K(1968)>;
+				};
+			};
+		};
+	};
+};
+
 &enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet_qos>;


### PR DESCRIPTION
Enable the on-board Winbond W25Q64JV (8 MB, quad-SPI) external NOR flash via the FlexSPI0 controller so flash_mcux_flexspi_nor.c is built and usable on frdm_mcxa577.

- add pinmux_flexspi (Port A1, P3 SS0/SCLK/DQS/DATA0-3)
- enable &flexspi and add the nxp,imx-flexspi-nor controller with a soc-nv-flash child (jedec-id ef 40 17, matches the JV part)
- init the FlexSPI root clock in board.c (FRO_HF/4 = 48 MHz, gate, reset release), gated on the flexspi node being enabled

tested the sample: zephyr/samples/drivers/flash_shell 