### PR TITLE
llext: improve Doxygen coverage of the LLEXT headers

### DIFF
--- a/include/zephyr/llext/buf_loader.h
+++ b/include/zephyr/llext/buf_loader.h
@@ -16,6 +16,7 @@ extern "C" {
 /**
  * @file
  * @brief LLEXT buffer loader implementation.
+ * @ingroup llext_loader_apis
  *
  * @addtogroup llext_loader_apis
  * @{

--- a/include/zephyr/llext/elf.h
+++ b/include/zephyr/llext/elf.h
@@ -218,6 +218,7 @@ struct elf64_shdr {
 #define SHF_MASKOS 0x0ff00000           /**< OS specific flags */
 #define SHF_LLEXT_HAS_RELOCS 0x00100000 /**< Section is a target for relocations */
 
+/** Mask selecting the basic section flags */
 #define SHF_BASIC_TYPE_MASK	(SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR)
 
 /**

--- a/include/zephyr/llext/fs_loader.h
+++ b/include/zephyr/llext/fs_loader.h
@@ -17,6 +17,7 @@ extern "C" {
 /**
  * @file
  * @brief LLEXT filesystem loader implementation.
+ * @ingroup llext_loader_apis
  *
  * @addtogroup llext_loader_apis
  * @{

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -170,11 +170,29 @@ struct llext {
 	/** @endcond */
 };
 
+/**
+ * @brief Get the ELF section headers of an extension.
+ *
+ * The section headers are only available if the extension was loaded with
+ * @ref llext_load_param.keep_section_info set, and until
+ * @ref llext_free_inspection_data is called for it.
+ *
+ * @param ext Extension to inspect.
+ *
+ * @return Pointer to the first of @ref llext_section_count section headers.
+ */
 static inline const elf_shdr_t *llext_section_headers(const struct llext *ext)
 {
 	return ext->sect_hdrs;
 }
 
+/**
+ * @brief Get the number of ELF sections of an extension.
+ *
+ * @param ext Extension to inspect.
+ *
+ * @return Number of sections.
+ */
 static inline unsigned int llext_section_count(const struct llext *ext)
 {
 	return ext->sect_cnt;

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -16,6 +16,7 @@ extern "C" {
 /**
  * @file
  * @brief Private header for linkable loadable extensions
+ * @ingroup internal_api
  */
 
 /** @cond ignore */


### PR DESCRIPTION
Part of an ongoing sweep to improve Doxygen coverage of the public API
headers.

Adds the missing `@file` blocks, each attached to its Doxygen group,
across the LLEXT headers, and documents the ELF section inspection
helpers.

Documentation only, no functional change.