### PR TITLE
drivers: stepper: improve Doxygen coverage

### DIFF
--- a/include/zephyr/drivers/stepper/stepper.h
+++ b/include/zephyr/drivers/stepper/stepper.h
@@ -26,6 +26,11 @@ extern "C" {
  * @defgroup stepper_interface Stepper
  * @ingroup io_interfaces
  *
+ * @defgroup stepper_interface_ext Device-specific stepper API extensions
+ * @ingroup stepper_interface
+ * @{
+ * @}
+ *
  * @defgroup stepper_hw_driver Stepper Hardware Driver
  * @brief Interfaces for stepper hardware drivers
  * @ingroup stepper_interface

--- a/include/zephyr/drivers/stepper/stepper_drv84xx.h
+++ b/include/zephyr/drivers/stepper/stepper_drv84xx.h
@@ -2,6 +2,7 @@
  * @file drivers/stepper/stepper_drv84xx.h
  *
  * @brief Public API for DRV84XX Stepper Controller Specific Functions
+ * @ingroup stepper_interface_ext
  *
  */
 

--- a/include/zephyr/drivers/stepper/stepper_drv84xx.h
+++ b/include/zephyr/drivers/stepper/stepper_drv84xx.h
@@ -2,6 +2,7 @@
  * @file drivers/stepper/stepper_drv84xx.h
  *
  * @brief Public API for DRV84XX Stepper Controller Specific Functions
+ * @ingroup drv84xx_stepper_ctrl
  *
  */
 
@@ -13,6 +14,13 @@
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_STEPPER_STEPPER_DRV84XX_H_
 #define ZEPHYR_INCLUDE_DRIVERS_STEPPER_STEPPER_DRV84XX_H_
+
+/**
+ * @brief TI DRV84XX Stepper Controller
+ * @defgroup drv84xx_stepper_ctrl DRV84XX Stepper Controller
+ * @ingroup stepper_interface_ext
+ * @{
+ */
 
 #include <stdint.h>
 #include <zephyr/drivers/stepper/stepper.h>
@@ -30,6 +38,10 @@ extern "C" {
  * @retval <0 Error code dependent on the gpio controller of the microstep pins
  */
 int drv84xx_microstep_recovery(const struct device *dev);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/stepper/stepper_tmcm3216.h
+++ b/include/zephyr/drivers/stepper/stepper_tmcm3216.h
@@ -6,10 +6,18 @@
 /**
  * @file stepper_tmcm3216.h
  * @brief Public API for ADI TMCM-3216 stepper motor controller
+ * @ingroup tmcm3216_stepper_ctrl
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_STEPPER_TMCM3216_H_
 #define ZEPHYR_INCLUDE_DRIVERS_STEPPER_TMCM3216_H_
+
+/**
+ * @brief ADI TMCM-3216 Stepper Controller
+ * @defgroup tmcm3216_stepper_ctrl TMCM-3216 Stepper Controller
+ * @ingroup stepper_interface_ext
+ * @{
+ */
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/stepper/stepper.h>
@@ -62,6 +70,10 @@ int tmcm3216_get_actual_velocity(const struct device *dev, int32_t *velocity);
  * @return 0 on success, negative errno on failure
  */
 int tmcm3216_get_status(const struct device *dev, struct tmcm3216_status *status);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/stepper/stepper_tmcm3216.h
+++ b/include/zephyr/drivers/stepper/stepper_tmcm3216.h
@@ -6,6 +6,7 @@
 /**
  * @file stepper_tmcm3216.h
  * @brief Public API for ADI TMCM-3216 stepper motor controller
+ * @ingroup stepper_interface_ext
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_STEPPER_TMCM3216_H_

--- a/include/zephyr/drivers/stepper/stepper_trinamic.h
+++ b/include/zephyr/drivers/stepper/stepper_trinamic.h
@@ -2,6 +2,7 @@
  * @file drivers/stepper/stepper_trinamic.h
  *
  * @brief Public API for Trinamic Stepper Controller Specific Functions
+ * @ingroup trinamic_stepper_ctrl
  *
  */
 
@@ -18,7 +19,7 @@
 /**
  * @brief Trinamic Stepper Controller
  * @defgroup trinamic_stepper_ctrl Trinamic Stepper Controller
- * @ingroup stepper_ctrl
+ * @ingroup stepper_interface_ext
  * @since 4.0
  * @version 0.9.0
  * @{

--- a/include/zephyr/drivers/stepper/stepper_trinamic.h
+++ b/include/zephyr/drivers/stepper/stepper_trinamic.h
@@ -32,8 +32,10 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 #define TMC_RAMP_VACTUAL_SHIFT  23
 #define TMC_RAMP_XACTUAL_SHIFT  31
+/** @endcond */
 
 /**
  * @brief Trinamic Stepper StallGuard Settings
@@ -55,27 +57,44 @@ struct tmc_stallguard_settings {
  * @brief Trinamic Stepper Ramp Generator data
  */
 struct tmc_ramp_generator_data {
+	/** Motor start velocity */
 	uint32_t vstart;
+	/** First acceleration/deceleration phase threshold velocity */
 	uint32_t v1;
+	/** Motion ramp target velocity */
 	uint32_t vmax;
+	/** First acceleration between VSTART and V1 */
 	uint16_t a1;
+	/** Second acceleration between V1 and VMAX */
 	uint16_t amax;
+	/** Deceleration between V1 and VSTOP */
 	uint16_t d1;
+	/** Deceleration between VMAX and V1 */
 	uint16_t dmax;
+	/** Motor stop velocity */
 	uint32_t vstop;
+	/** Waiting time after ramping down to zero velocity before next movement */
 	uint16_t tzerowait;
+	/** Hold and run current settings (combined IHOLD_IRUN register value) */
 	uint32_t iholdrun;
+	/** Controller family specific ramp parameters */
 	union {
-		/* TMC50XX specific */
+		/** TMC50XX specific ramp parameters */
 		struct {
+			/** Lower threshold velocity for switching on CoolStep and StallGuard */
 			uint32_t vcoolthrs;
+			/** Velocity threshold for switching to a different chopper mode */
 			uint32_t vhigh;
 		};
-		/* TMC51XX specific */
+		/** TMC51XX specific ramp parameters */
 		struct {
+			/** Delay time from stand still to motor current power down */
 			uint32_t tpowerdown;
+			/** Upper velocity threshold for StealthChop voltage PWM mode */
 			uint32_t tpwmthrs;
+			/** Lower threshold velocity for switching on CoolStep and StallGuard */
 			uint32_t tcoolthrs;
+			/** Velocity threshold for switching to a different chopper mode */
 			uint32_t thigh;
 		};
 	};
@@ -102,6 +121,13 @@ struct tmc_ramp_generator_data {
 			     TMC5XXX_IHOLD(DT_PROP(node, ihold)) |		\
 			     TMC5XXX_IHOLDDELAY(DT_PROP(node, iholddelay))),
 
+/**
+ * @brief Get TMC50XX Stepper Ramp Generator data from DT
+ *
+ * @param node DT node identifier
+ *
+ * @return struct tmc_ramp_generator_data
+ */
 #define TMC_RAMP_DT_SPEC_GET_TMC50XX(node)					\
 	{									\
 		TMC_RAMP_DT_SPEC_GET_COMMON(node)				\
@@ -109,6 +135,13 @@ struct tmc_ramp_generator_data {
 		.vcoolthrs = DT_PROP(node, vcoolthrs),				\
 	}
 
+/**
+ * @brief Get TMC51XX Stepper Ramp Generator data from DT
+ *
+ * @param node DT driver instance number
+ *
+ * @return struct tmc_ramp_generator_data
+ */
 #define TMC_RAMP_DT_SPEC_GET_TMC51XX(node)					\
 	{									\
 		TMC_RAMP_DT_SPEC_GET_COMMON(DT_DRV_INST(node))			\


### PR DESCRIPTION
Add a `stepper_interface_ext` group, mirroring the existing "Device-specific ADC API extensions" group, and give the DRV84XX, TMCM-3216 and Trinamic headers a per-device group under it so the vendor specific APIs are listed together instead of being left out of the API tree or mixed into the generic stepper groups.

Document the fields of `struct tmc_ramp_generator_data` and the `TMC_RAMP_DT_SPEC_GET_TMC50XX` / `TMC_RAMP_DT_SPEC_GET_TMC51XX` helper macros, and hide the two internal register sign-bit positions behind `@cond INTERNAL_HIDDEN`.

https://builds.zephyrproject.io/zephyr/pr/115378/docs/doxygen/html/group__stepper__interface__ext.html

Documentation only, no functional change.
