### PR TITLE
drivers: display: st7735r: don't request SPI_LOCK_ON when RTIO is enabled

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -29,6 +29,19 @@ LOG_MODULE_REGISTER(display_st7735r, CONFIG_DISPLAY_LOG_LEVEL);
 
 #define ST7735R_PIXEL_SIZE 2u
 
+/*
+ * SPI_LOCK_ON keeps the bus reserved between the individual commands of an
+ * init/write sequence. The RTIO path does not support it: spi_rtio_transceive()
+ * rejects any config with SPI_LOCK_ON set, which would make the very first
+ * command fail with -EINVAL. There the whole transaction is submitted as a
+ * single chain instead, so locking the bus is not needed.
+ */
+#ifdef CONFIG_SPI_RTIO
+#define ST7735R_SPI_LOCK 0
+#else
+#define ST7735R_SPI_LOCK SPI_LOCK_ON
+#endif
+
 struct st7735r_config {
 	const struct device *mipi_dev;
 	const struct mipi_dbi_config dbi_config;
@@ -497,7 +510,7 @@ static DEVICE_API(display, st7735r_api) = {
 				((DT_INST_STRING_UPPER_TOKEN(inst, mipi_mode) == \
 				 MIPI_DBI_MODE_SPI_4WIRE) ? SPI_WORD_SET(8) :	\
 				 SPI_WORD_SET(9)) |				\
-				SPI_HOLD_ON_CS | SPI_LOCK_ON, 0),		\
+				SPI_HOLD_ON_CS | ST7735R_SPI_LOCK, 0),		\
 		.width = DT_INST_PROP(inst, width),				\
 		.height = DT_INST_PROP(inst, height),				\
 		.madctl = DT_INST_PROP(inst, madctl),				\


### PR DESCRIPTION
Fixes #115261.

`display_st7735r.c` hardcodes `SPI_LOCK_ON` in `ST7735R_INIT`. On the RTIO path `spi_rtio_transceive()` rejects that flag with `-EINVAL`, so the first `Sleep Out` command fails and the display never comes up.

This makes the flag conditional: it is only requested when `CONFIG_SPI_RTIO` is not enabled. `SPI_HOLD_ON_CS` is left untouched in both configurations, so CS is still asserted for the duration of a transfer.

### Testing

Verified on hardware — STM32F103C8T6 (`stm32_min_dev@blue`) with an ST7735R panel on SPI1, running `samples/drivers/display`:

- `CONFIG_SPI_RTIO=y`, before: `Couldn't exit sleep`, display dead.
- `CONFIG_SPI_RTIO=y`, after: display initializes and renders the sample correctly.
- Without `CONFIG_SPI_RTIO`: unchanged, still renders correctly.

Also build-tested on `esp32_devkitc` (SPI driver using the generic RTIO fallback).

### Note on SPI_LOCK_ON semantics

`SPI_LOCK_ON` kept the bus reserved *between* the commands of a write sequence (`COLMOD` → `CASET` → `RASET` → `RAMWR`). Without it, another thread could in principle access a different device on the same bus in the middle of that sequence.

This is an inherent limitation of the RTIO path rather than something introduced here — `SPI_LOCK_ON` is deliberately unsupported there (5085a29). No in-tree board with an ST7735R on a natively-RTIO SPI driver shares the display bus with another device, so this is not reachable in practice today.

The same hardcoded `SPI_LOCK_ON` exists in `ls0xx.c`, `ssd16xx.c`, `uc81xx.c` and `display_it8951.c` and would fail the same way under RTIO. I kept this PR scoped to the driver in the issue; happy to extend it if maintainers prefer a single change.
