### PR TITLE
 dts: bindings: net: wireless: st,stm32wba-radio: Require interrupt names

### DIFF
--- a/dts/bindings/net/wireless/st,stm32wba-radio.yaml
+++ b/dts/bindings/net/wireless/st,stm32wba-radio.yaml
@@ -15,3 +15,11 @@ properties:
 
   interrupts:
     required: true
+    # Do not set min-len/max-len due to DT parsing process issues.
+    # Rely on interrupt-names for the consistency.
+
+  interrupt-names:
+    required: true
+    enum: ["radio", "radio-sw-low"]
+    min-len: 2
+    max-len: 2


### PR DESCRIPTION
Make `interrupt-names` DT description required for "st,stm32wba-radio" compatible nodes for consistency since these are expected by the driver and bound element counts (both interrupts are needed) and supported name values.