### PR TITLE
drivers: gpio: bee: allow configuring pins as open-drain

### DIFF
--- a/drivers/gpio/gpio_bee.c
+++ b/drivers/gpio/gpio_bee.c
@@ -192,9 +192,16 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 
 	__ASSERT(pad_pin < TOTAL_PIN_NUM, "gpio port or pin error");
 
-	if (flags & GPIO_OPEN_SOURCE) {
+	if ((flags & GPIO_SINGLE_ENDED) != 0 && (flags & GPIO_LINE_OPEN_DRAIN) == 0) {
 		return -ENOTSUP;
 	}
+
+#if defined(CONFIG_SOC_SERIES_RTL8752H)
+	if ((flags & GPIO_OPEN_DRAIN) == GPIO_OPEN_DRAIN) {
+		/* RTL8752H does not provides a hardware open-drain output mode. */
+		return -ENOTSUP;
+	}
+#endif
 
 	if ((flags & GPIO_INPUT) && (flags & GPIO_OUTPUT)) {
 		return -ENOTSUP;

--- a/drivers/gpio/gpio_bee.c
+++ b/drivers/gpio/gpio_bee.c
@@ -168,11 +168,14 @@ static void gpio_bee_fill_init_struct(GPIO_InitTypeDef *init_struct, uint32_t gp
 	init_struct->GPIO_OutPutMode =
 		flags & GPIO_OPEN_DRAIN ? GPIO_OUTPUT_OPENDRAIN : GPIO_OUTPUT_PUSHPULL;
 #endif
-	init_struct->GPIO_ITCmd = flags & GPIO_INT_ENABLE ? ENABLE : DISABLE;
-	init_struct->GPIO_ITTrigger =
-		flags & GPIO_INT_EDGE ? GPIO_INT_Trigger_EDGE : GPIO_INT_Trigger_LEVEL;
-	init_struct->GPIO_ITPolarity = flags & GPIO_INT_LOW_0 ? GPIO_INT_POLARITY_ACTIVE_LOW
-							      : GPIO_INT_POLARITY_ACTIVE_HIGH;
+	/*
+	 * gpio_pin_configure() never carries interrupt flags; the trigger,
+	 * polarity and enable are owned by gpio_pin_interrupt_configure(). Keep
+	 * the interrupt disabled here: GPIO_Init() only writes the interrupt
+	 * registers when GPIO_ITCmd is ENABLE, so this leaves an already armed
+	 * interrupt untouched instead of clobbering its trigger/polarity.
+	 */
+	init_struct->GPIO_ITCmd = DISABLE;
 }
 
 static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpio_flags_t flags)
@@ -192,9 +195,16 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 
 	__ASSERT(pad_pin < TOTAL_PIN_NUM, "gpio port or pin error");
 
-	if (flags & GPIO_OPEN_SOURCE) {
+	if ((flags & GPIO_SINGLE_ENDED) != 0 && (flags & GPIO_LINE_OPEN_DRAIN) == 0) {
 		return -ENOTSUP;
 	}
+
+#if defined(CONFIG_SOC_SERIES_RTL8752H)
+	if ((flags & GPIO_OPEN_DRAIN) == GPIO_OPEN_DRAIN) {
+		/* RTL8752H does not provide a hardware open-drain output mode. */
+		return -ENOTSUP;
+	}
+#endif
 
 	if ((flags & GPIO_INPUT) && (flags & GPIO_OUTPUT)) {
 		return -ENOTSUP;
@@ -221,33 +231,44 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 	Pad_Dedicated_Config(pad_pin, DISABLE);
 #endif
-	Pad_Config(pad_pin, PAD_PINMUX_MODE, PAD_IS_PWRON, pull_config,
-		   (flags & GPIO_OUTPUT) ? PAD_OUT_ENABLE : PAD_OUT_DISABLE,
-		   (flags & GPIO_OUTPUT_INIT_HIGH) ? PAD_OUT_HIGH : PAD_OUT_LOW);
-	Pinmux_Config(pad_pin, DWGPIO);
-
-	switch (flags & (GPIO_OUTPUT | GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOW)) {
-	case (GPIO_OUTPUT_HIGH):
-		BEE_GPIO_WRITE_BIT(port_base, gpio_bit, 1);
-		break;
-	case (GPIO_OUTPUT_LOW):
-		BEE_GPIO_WRITE_BIT(port_base, gpio_bit, 0);
-		break;
-	default:
-		break;
-	}
-
-	/* to avoid trigger gpio interrupt */
-	if (debounce_ms && (flags & GPIO_INT_ENABLE)) {
-		BEE_GPIO_INT_CONFIG(port_base, gpio_bit, DISABLE);
+	if (flags & GPIO_OUTPUT) {
+		switch (flags & (GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOW)) {
+		case GPIO_OUTPUT_INIT_HIGH:
+			BEE_GPIO_WRITE_BIT(port_base, gpio_bit, 1);
+			break;
+		case GPIO_OUTPUT_INIT_LOW:
+			BEE_GPIO_WRITE_BIT(port_base, gpio_bit, 0);
+			break;
+		default:
+			break;
+		}
 		BEE_GPIO_INIT(port_base, &gpio_init_struct);
-		BEE_GPIO_MASK_INT_CONFIG(port_base, gpio_bit, ENABLE);
-		BEE_GPIO_INT_CONFIG(port_base, gpio_bit, ENABLE);
-		k_busy_wait(data->array[pin].pin_debounce_ms * 2 * USEC_PER_MSEC);
-		BEE_GPIO_CLEAR_INT_PENDING_BIT(port_base, gpio_bit);
-		BEE_GPIO_MASK_INT_CONFIG(port_base, gpio_bit, DISABLE);
+		/*
+		 * Route (Pinmux_Config) before committing to pinmux mode
+		 * (Pad_Config), reverse of the input path: the other order enters
+		 * pinmux mode while routing still points at the previous function,
+		 * glitching the driven line. Do not reorder.
+		 */
+		Pinmux_Config(pad_pin, DWGPIO);
+		Pad_Config(pad_pin, PAD_PINMUX_MODE, PAD_IS_PWRON, pull_config, PAD_OUT_ENABLE,
+			   (flags & GPIO_OUTPUT_INIT_HIGH) ? PAD_OUT_HIGH : PAD_OUT_LOW);
 	} else {
-		BEE_GPIO_INIT(port_base, &gpio_init_struct);
+		Pad_Config(pad_pin, PAD_PINMUX_MODE, PAD_IS_PWRON, pull_config, PAD_OUT_DISABLE,
+			   PAD_OUT_LOW);
+		Pinmux_Config(pad_pin, DWGPIO);
+
+		/* to avoid trigger gpio interrupt */
+		if (debounce_ms && GPIO_GET_INT_ENABLE(port_base, gpio_bit)) {
+			BEE_GPIO_INT_CONFIG(port_base, gpio_bit, DISABLE);
+			BEE_GPIO_INIT(port_base, &gpio_init_struct);
+			BEE_GPIO_MASK_INT_CONFIG(port_base, gpio_bit, ENABLE);
+			BEE_GPIO_INT_CONFIG(port_base, gpio_bit, ENABLE);
+			k_busy_wait(data->array[pin].pin_debounce_ms * 2 * USEC_PER_MSEC);
+			BEE_GPIO_CLEAR_INT_PENDING_BIT(port_base, gpio_bit);
+			BEE_GPIO_MASK_INT_CONFIG(port_base, gpio_bit, DISABLE);
+		} else {
+			BEE_GPIO_INIT(port_base, &gpio_init_struct);
+		}
 	}
 
 	key = irq_lock();


### PR DESCRIPTION
GPIO_OPEN_DRAIN and GPIO_OPEN_SOURCE share the GPIO_SINGLE_ENDED bit and differ only in GPIO_LINE_OPEN_DRAIN. The open-source rejection test masked with GPIO_OPEN_SOURCE, which also matches open-drain, so any attempt to configure a pin as open-drain wrongly returned -ENOTSUP.

Detect open-source on the GPIO_LINE_OPEN_DRAIN bit instead so open-drain is accepted, and reject open-drain only on RTL8752H: open-drain is supported on all current and future Bee ICs, and RTL8752H is the sole older part without a hardware open-drain output mode, so a blacklist is intentional here.