### PR TITLE
Bluetooth: Controller: Fix retained RX node leak on invalid PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -693,6 +693,12 @@ void llcp_rp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		llcp_rx_node_release(ctx);
+
 		llcp_rr_complete(conn);
 		ctx->state = RP_CC_STATE_IDLE;
 		break;
@@ -834,6 +840,12 @@ void llcp_lp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		llcp_rx_node_release(ctx);
+
 		llcp_lr_complete(conn);
 		ctx->state = LP_CC_STATE_IDLE;
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -789,6 +789,12 @@ void llcp_lp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		llcp_rx_node_release(ctx);
+
 		lp_cu_complete(conn, ctx);
 		break;
 	}
@@ -1404,6 +1410,12 @@ void llcp_rp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		llcp_rx_node_release(ctx);
+
 		rp_cu_complete(conn, ctx);
 		break;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -1404,6 +1404,15 @@ void llcp_rp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		if (ctx->node_ref.rx) {
+			llcp_rx_node_release(ctx);
+			ctx->node_ref.rx = NULL;
+		}
+
 		rp_cu_complete(conn, ctx);
 		break;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -896,6 +896,15 @@ void llcp_lp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		if (ctx->node_ref.rx) {
+			llcp_rx_node_release(ctx);
+			ctx->node_ref.rx = NULL;
+		}
+
 		llcp_lr_complete(conn);
 		ctx->state = LP_PU_STATE_IDLE;
 		break;
@@ -1310,6 +1319,15 @@ void llcp_rp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		if (ctx->node_ref.rx) {
+			llcp_rx_node_release(ctx);
+			ctx->node_ref.rx = NULL;
+		}
+
 		llcp_rr_complete(conn);
 		ctx->state = RP_PU_STATE_IDLE;
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -896,6 +896,12 @@ void llcp_lp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		llcp_rx_node_release(ctx);
+
 		llcp_lr_complete(conn);
 		ctx->state = LP_PU_STATE_IDLE;
 		break;
@@ -1310,6 +1316,12 @@ void llcp_rp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		/* Invalid behaviour */
 		/* Invalid PDU received so terminate connection */
 		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+
+		/* Release any retained RX node before completing the procedure,
+		 * the node would otherwise be leaked
+		 */
+		llcp_rx_node_release(ctx);
+
 		llcp_rr_complete(conn);
 		ctx->state = RP_PU_STATE_IDLE;
 		break;

--- a/tests/bluetooth/controller/ctrl_cis_create/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_create/src/main.c
@@ -1054,4 +1054,205 @@ ZTEST(cis_create, test_cc_create_central_rem_reject)
 }
 
 
+/*
+ * Central-initiated CIS Create procedure.
+ * Peripheral has notified its Host of the CIS request, and thereby retains an
+ * RX node for the later CIS Established notification. Before the Host replies,
+ * and thus before the retained RX node is consumed, an unexpected LL Control
+ * PDU is received.
+ *
+ * The unexpected PDU is routed to the active remote procedure, which takes the
+ * invalid PDU path and completes the procedure. The retained RX node must be
+ * released, and the reference cleared, before the procedure is completed.
+ * Otherwise the retained node reference is leaked and llcp_rr_check_done()
+ * asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_S  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    |                           |   LL_CIS_REQ              |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |      LE CIS Request       |                           |
+ *    |<--------------------------|                           |
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(cis_create, test_cc_create_periph_rem_unexpected_pdu_awaiting_reply)
+{
+	struct node_rx_conn_iso_req cis_req = {
+		.cig_id = 0x01,
+		.cis_handle = 0x00,
+		.cis_id = 0x02
+	};
+	struct pdu_data_llctrl_version_ind remote_version_ind = {
+		.version_number = 0x55,
+		.company_id = 0xABCD,
+		.sub_version_number = 0x1234,
+	};
+	struct node_rx_pdu *ntf;
+
+	/* Prepare mocked call to ll_conn_iso_stream_get() */
+	ll_conn_iso_stream_get_fake.return_val = &cis_mock;
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, the CIS request is passed on to the Host and an RX node is
+	 * retained for the later CIS Established notification
+	 */
+	lt_tx(LL_CIS_REQ, &conn, &remote_cis_req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* There should be exactly one host notification */
+	ut_rx_node(NODE_CIS_REQUEST, &ntf, &cis_req);
+	ut_rx_q_is_empty();
+
+	/* Release Ntf */
+	release_ntf(ntf);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while awaiting the Host reply and thus
+	 * before the retained RX node has been consumed
+	 */
+	lt_tx(LL_VERSION_IND, &conn, &remote_version_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
+/*
+ * Central-initiated CIS Create procedure.
+ * The Central retains an RX node for the CIS Established notification while
+ * awaiting the LL_CIS_RSP. Before the response is received, and thus before the
+ * retained RX node is consumed, an unexpected LL Control PDU is received.
+ *
+ * The unexpected PDU is routed to the active local procedure, which takes the
+ * invalid PDU path and completes the procedure. The retained RX node must be
+ * released, and the reference cleared, before the procedure is completed.
+ * Otherwise the retained node reference is leaked and llcp_lr_check_done()
+ * asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_C  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    | LE CIS Create             |                           |
+ *    |-------------------------->|                           |
+ *    |                           |   LL_CIS_REQ              |
+ *    |                           |-------------------------->|
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(cis_create, test_cc_create_central_unexpected_pdu_awaiting_rsp)
+{
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = PDU_DATA_LLCTRL_TYPE_CIS_REQ
+	};
+	struct ll_conn_iso_stream *cis;
+	struct node_tx *tx;
+	uint8_t err;
+
+	/* Prepare mocked call to ll_conn_iso_stream_get() */
+	ll_conn_iso_stream_get_fake.return_val = &cis_mock;
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	conn.llcp.fex.valid = 1;
+	conn.llcp.fex.features_peer |= BIT64(BT_LE_FEAT_BIT_CIS_PERIPHERAL);
+
+	/* Setup default CIS/CIG parameters */
+	cis = ll_conn_iso_stream_get(LL_CIS_HANDLE_BASE);
+	cis->lll.acl_handle = conn.lll.handle;
+	cis->group->cig_id = local_cis_req.cig_id;
+	cis->cis_id = local_cis_req.cis_id;
+	cis->lll.tx.phy = local_cis_req.c_phy;
+	cis->lll.rx.phy = local_cis_req.p_phy;
+	cis->group->c_sdu_interval = 0;
+	cis->group->p_sdu_interval = 0;
+	cis->lll.tx.max_pdu = MAX_xDU;
+	cis->lll.rx.max_pdu = MAX_xDU;
+	cis->c_max_sdu = MAX_xDU;
+	cis->p_max_sdu = MAX_xDU;
+	cis->group->iso_interval = local_cis_req.iso_interval;
+	cis->framed = 0;
+	cis->lll.nse = local_cis_req.nse;
+	cis->lll.sub_interval = 0;
+	cis->lll.tx.bn = local_cis_req.c_bn;
+	cis->lll.rx.bn = local_cis_req.p_bn;
+	cis->lll.tx.ft = local_cis_req.c_ft;
+	cis->lll.rx.ft = local_cis_req.p_ft;
+
+	err = ull_cp_cis_create(&conn, cis);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_CIS_REQ, &conn, &tx, &local_cis_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while awaiting the LL_CIS_RSP and thus
+	 * before the retained RX node has been consumed
+	 */
+	lt_tx(LL_UNKNOWN_RSP, &conn, &unknown_rsp);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
 ZTEST_SUITE(cis_create, NULL, NULL, cis_create_setup, NULL, NULL);

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -5030,6 +5030,80 @@ ZTEST(periph_rem_invalid, test_conn_update_periph_rem_invalid_param)
 	conn_update_ind.interval = interval;
 }
 
+/*
+ * Central-initiated Connection Update procedure.
+ * Peripheral accepts a Connection Update with a future instant, and thereby
+ * retains the RX node for the later host notification. Before the instant is
+ * reached, and thus before the retained RX node is consumed, an unexpected LL
+ * Control PDU is received.
+ *
+ * The unexpected PDU is routed to the active remote Connection Update
+ * procedure, which takes the invalid PDU path and completes the procedure. The
+ * retained RX node must be released, and the reference cleared, before the
+ * procedure is completed. Otherwise the retained node reference is leaked and
+ * llcp_rr_check_done() asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_P  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    |                           |  LL_CONNECTION_UPDATE_IND |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(periph_rem_invalid, test_conn_update_periph_rem_unexpected_pdu_awaiting_instant)
+{
+	struct pdu_data_llctrl_length_req length_req = { .max_rx_octets = 251U,
+							 .max_rx_time = 2120U,
+							 .max_tx_octets = 251U,
+							 .max_tx_time = 2120U };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, valid Connection Update with a future instant, RX node is retained
+	 * by the remote procedure for the later host notification
+	 */
+	conn_update_ind.instant = event_counter(&conn) + 6U;
+	lt_tx(LL_CONNECTION_UPDATE_IND, &conn, &conn_update_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while the instant has not been reached
+	 * and the retained RX node has not been consumed
+	 */
+	lt_tx(LL_LENGTH_REQ, &conn, &length_req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 /*
  * Peripheral-initiated Connection Parameters Request procedure.

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -5030,6 +5030,80 @@ ZTEST(periph_rem_invalid, test_conn_update_periph_rem_invalid_param)
 	conn_update_ind.interval = interval;
 }
 
+/*
+ * Central-initiated Connection Update procedure.
+ * Peripheral accepts a Connection Update with a future instant, and thereby
+ * retains the RX node for the later host notification. Before the instant is
+ * reached, and thus before the retained RX node is consumed, an unexpected LL
+ * Control PDU is received.
+ *
+ * The unexpected PDU is routed to the active remote Connection Update
+ * procedure, which takes the invalid PDU path and completes the procedure. The
+ * retained RX node must be released, and the reference cleared, before the
+ * procedure is completed. Otherwise the retained node reference is leaked and
+ * llcp_rr_check_done() asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_P  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    |                           |  LL_CONNECTION_UPDATE_IND |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(periph_rem_invalid, test_conn_update_periph_rem_unexpected_pdu_awaiting_instant)
+{
+	struct pdu_data_llctrl_length_req length_req = { .max_rx_octets = 251U,
+							 .max_rx_time = 2120U,
+							 .max_tx_octets = 251U,
+							 .max_tx_time = 2120U };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, valid Connection Update with a future instant, RX node is retained
+	 * by the remote procedure for the later host notification
+	 */
+	conn_update_ind.instant = event_counter(&conn) + 6U;
+	lt_tx(LL_CONNECTION_UPDATE_IND, &conn, &conn_update_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while the instant has not been reached
+	 * and the retained RX node has not been consumed
+	 */
+	lt_tx(LL_LENGTH_REQ, &conn, &length_req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 /*
  * Peripheral-initiated Connection Parameters Request procedure.
@@ -5102,6 +5176,104 @@ ZTEST(periph_rem_invalid, test_conn_param_req_periph_rem_invalid_param)
 
 	/* Restore interval for other tests */
 	conn_update_ind.interval = interval;
+}
+
+/*
+ * Peripheral-initiated Connection Parameters Request procedure.
+ * Peripheral accepts the central's Connection Update with a future instant,
+ * and thereby retains the RX node for the later host notification. Before the
+ * instant is reached, and thus before the retained RX node is consumed, an
+ * unexpected LL Control PDU is received.
+ *
+ * The unexpected PDU is routed to the active local procedure, which takes the
+ * invalid PDU path and completes the procedure. The retained RX node must be
+ * released, and the reference cleared, before the procedure is completed.
+ * Otherwise the retained node reference is leaked and llcp_lr_check_done()
+ * asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_P  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    | LE Connection Update      |                           |
+ *    |-------------------------->|                           |
+ *    |                           | LL_CONNECTION_PARAM_REQ   |
+ *    |                           |-------------------------->|
+ *    |                           |                           |
+ *    |                           |  LL_CONNECTION_UPDATE_IND |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(periph_rem_invalid, test_conn_update_periph_loc_unexpected_pdu_awaiting_instant)
+{
+	struct pdu_data_llctrl_reject_ind reject_ind = {
+		.error_code = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE
+	};
+	struct node_tx *tx;
+	uint8_t err;
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate a Connection Parameter Request Procedure */
+	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
+
+	/* Prepare */
+	event_prepare(&conn);
+	conn_param_req.reference_conn_event_count = event_counter(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_CONNECTION_PARAM_REQ, &conn, &tx, &conn_param_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, valid Connection Update with a future instant, RX node is retained
+	 * by the local procedure for the later host notification
+	 */
+	conn_update_ind.instant = event_counter(&conn) + 6U;
+	lt_tx(LL_CONNECTION_UPDATE_IND, &conn, &conn_update_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while the instant has not been reached
+	 * and the retained RX node has not been consumed
+	 */
+	lt_tx(LL_REJECT_IND, &conn, &reject_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
 }
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -1691,5 +1691,109 @@ ZTEST(phy_periph, test_phy_update_periph_rem_no_actual_change)
 		      llcp_ctx_buffers_free());
 }
 
+/*
+ * Central-initiated PHY Update procedure.
+ * Peripheral accepts a PHY Update with a future instant, and thereby retains
+ * the RX node for the later host notification. Before the instant is reached,
+ * and thus before the retained RX node is consumed, an unexpected LL Control
+ * PDU is received.
+ *
+ * The unexpected PDU is routed to the active remote PHY Update procedure,
+ * which takes the invalid PDU path and completes the procedure. The retained
+ * RX node must be released, and the reference cleared, before the procedure is
+ * completed. Otherwise the retained node reference is leaked and
+ * llcp_rr_check_done() asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_P  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    |                           |               LL_PHY_REQ  |
+ *    |                           |<--------------------------|
+ *    |                           |  LL_PHY_RSP               |
+ *    |                           |-------------------------->|
+ *    |                           |          LL_PHY_UPDATE_IND|
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(phy_periph, test_phy_update_periph_rem_unexpected_pdu_awaiting_instant)
+{
+	struct node_tx *tx;
+	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_1M, .tx_phys = PHY_2M };
+	struct pdu_data_llctrl_phy_req rsp = { .rx_phys = PHY_1M | PHY_2M | PHY_CODED,
+					       .tx_phys = PHY_1M | PHY_2M | PHY_CODED };
+	struct pdu_data_llctrl_phy_upd_ind ind = { .instant = 7,
+						   .c_to_p_phy = 0,
+						   .p_to_c_phy = PHY_2M };
+	struct pdu_data_llctrl_length_req length_req = { .max_rx_octets = 251U,
+							 .max_rx_time = 2120U,
+							 .max_tx_octets = 251U,
+							 .max_tx_time = 2120U };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx */
+	lt_tx(LL_PHY_REQ, &conn, &req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_RSP, &conn, &tx, &rsp);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx, valid PHY Update with a future instant, RX node is retained by
+	 * the remote procedure for the later host notification
+	 */
+	ind.instant = event_counter(&conn) + 6;
+	lt_tx(LL_PHY_UPDATE_IND, &conn, &ind);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while the instant has not been reached
+	 * and the retained RX node has not been consumed
+	 */
+	lt_tx(LL_LENGTH_REQ, &conn, &length_req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
 ZTEST_SUITE(phy_central, NULL, NULL, phy_setup, NULL, NULL);
 ZTEST_SUITE(phy_periph, NULL, NULL, phy_setup, NULL, NULL);

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -1691,5 +1691,216 @@ ZTEST(phy_periph, test_phy_update_periph_rem_no_actual_change)
 		      llcp_ctx_buffers_free());
 }
 
+/*
+ * Central-initiated PHY Update procedure.
+ * Peripheral accepts a PHY Update with a future instant, and thereby retains
+ * the RX node for the later host notification. Before the instant is reached,
+ * and thus before the retained RX node is consumed, an unexpected LL Control
+ * PDU is received.
+ *
+ * The unexpected PDU is routed to the active remote PHY Update procedure,
+ * which takes the invalid PDU path and completes the procedure. The retained
+ * RX node must be released, and the reference cleared, before the procedure is
+ * completed. Otherwise the retained node reference is leaked and
+ * llcp_rr_check_done() asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_P  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    |                           |               LL_PHY_REQ  |
+ *    |                           |<--------------------------|
+ *    |                           |  LL_PHY_RSP               |
+ *    |                           |-------------------------->|
+ *    |                           |          LL_PHY_UPDATE_IND|
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(phy_periph, test_phy_update_periph_rem_unexpected_pdu_awaiting_instant)
+{
+	struct node_tx *tx;
+	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_1M, .tx_phys = PHY_2M };
+	struct pdu_data_llctrl_phy_req rsp = { .rx_phys = PHY_1M | PHY_2M | PHY_CODED,
+					       .tx_phys = PHY_1M | PHY_2M | PHY_CODED };
+	struct pdu_data_llctrl_phy_upd_ind ind = { .instant = 7,
+						   .c_to_p_phy = 0,
+						   .p_to_c_phy = PHY_2M };
+	struct pdu_data_llctrl_length_req length_req = { .max_rx_octets = 251U,
+							 .max_rx_time = 2120U,
+							 .max_tx_octets = 251U,
+							 .max_tx_time = 2120U };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx */
+	lt_tx(LL_PHY_REQ, &conn, &req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_RSP, &conn, &tx, &rsp);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx, valid PHY Update with a future instant, RX node is retained by
+	 * the remote procedure for the later host notification
+	 */
+	ind.instant = event_counter(&conn) + 6;
+	lt_tx(LL_PHY_UPDATE_IND, &conn, &ind);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while the instant has not been reached
+	 * and the retained RX node has not been consumed
+	 */
+	lt_tx(LL_LENGTH_REQ, &conn, &length_req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
+/*
+ * Peripheral-initiated PHY Update procedure.
+ * The peripheral initiates a local PHY Update, and the central replies with a
+ * PHY Update with a future instant, which the local procedure retains as the
+ * RX node for the later host notification. Before the instant is reached, and
+ * thus before the retained RX node is consumed, an unexpected LL Control PDU
+ * is received.
+ *
+ * The unexpected PDU is routed to the active local PHY Update procedure, which
+ * takes the invalid PDU path and completes the procedure. The retained RX node
+ * must be released, and the reference cleared, before the procedure is
+ * completed. Otherwise the retained node reference is leaked and
+ * llcp_lr_check_done() asserts.
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_P  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    | Initiate PHY Update       |                           |
+ *    |-------------------------->|                           |
+ *    |                           | LL_PHY_REQ                |
+ *    |                           |-------------------------->|
+ *    |                           |          LL_PHY_UPDATE_IND|
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |      LL_<UNEXPECTED_PDU>  |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ */
+ZTEST(phy_periph, test_phy_update_periph_loc_unexpected_pdu_awaiting_instant)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_2M, .tx_phys = PHY_2M };
+	struct pdu_data_llctrl_phy_upd_ind phy_update_ind = { .c_to_p_phy = PHY_2M,
+							      .p_to_c_phy = PHY_2M };
+	struct pdu_data_llctrl_reject_ind reject_ind = { };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate an PHY Update Procedure */
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_REQ, &conn, &tx, &req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx, valid PHY Update with a future instant, RX node is retained by
+	 * the local procedure for the later host notification
+	 */
+	phy_update_ind.instant = event_counter(&conn) + 6;
+	lt_tx(LL_PHY_UPDATE_IND, &conn, &phy_update_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx, unexpected LL Control PDU while the instant has not been reached
+	 * and the retained RX node has not been consumed
+	 */
+	lt_tx(LL_REJECT_IND, &conn, &reject_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* There should be no host notifications */
+	ut_rx_q_is_empty();
+
+	/* All contexts should have been released */
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
 ZTEST_SUITE(phy_central, NULL, NULL, phy_setup, NULL, NULL);
 ZTEST_SUITE(phy_periph, NULL, NULL, phy_setup, NULL, NULL);


### PR DESCRIPTION
Connection Update / Connection Parameter procedure
-----
The remote Connection Update / Connection Parameter procedure retains
the RX node for later host notification, for example when accepting a
LL_CONNECTION_UPDATE_IND with a future instant.

If an unexpected LL Control PDU arrives before that retained node is
consumed, it is routed to the active remote procedure and takes the
invalid PDU path in llcp_rp_cu_rx(). That path completed the procedure
without releasing the retained RX node, violating the invariant checked
in llcp_rr_check_done() and leaking the referenced RX node memory.

Release the retained RX node and clear the reference before completing
the procedure.

Add a unit test to tests/bluetooth/controller/ctrl_conn_update that
sends a valid LL_CONNECTION_UPDATE_IND with a future instant, followed
by an unexpected LL_LENGTH_REQ before the instant is reached. Without
the fix the test triggers the retained node assertion in
ull_llcp_remote.c; with the fix the connection is terminated with
BT_HCI_ERR_LMP_PDU_NOT_ALLOWED and all procedure contexts are released.

Verified with the ctrl_conn_update, ctrl_invalid, ctrl_collision and
ctrl_terminate controller unit tests, all passing.

PHY Update procedure
----
The local and remote PHY Update procedures retain the RX node for the
later host notification, for example when accepting a LL_PHY_UPDATE_IND
with a future instant.

If an unexpected LL Control PDU arrives before that retained node is
consumed, it is routed to the active procedure and takes the invalid
PDU path in llcp_lp_pu_rx() / llcp_rp_pu_rx(). Those paths completed
the procedure without releasing the retained RX node, violating the
invariant checked in llcp_lr_check_done() / llcp_rr_check_done() and
leaking the referenced RX node memory.

Release the retained RX node and clear the reference before completing
the procedure, mirroring the same fix in the Connection Update
procedure.

Add a unit test to tests/bluetooth/controller/ctrl_phy_update that
completes the remote PHY Update request with a future instant, then
sends an unexpected LL_LENGTH_REQ before the instant is reached.
Without the fix the test triggers the retained node assertion in
ull_llcp_remote.c; with the fix the connection is terminated with
BT_HCI_ERR_LMP_PDU_NOT_ALLOWED and all procedure contexts are released.

Verified with the ctrl_phy_update, ctrl_conn_update, ctrl_invalid and
ctrl_collision controller unit tests, all passing.

CIS Create procedure
----
The local and remote CIS Create procedures retain an RX node for the
later host notification, for example when accepting a CIS_IND with a
future instant, or while awaiting the Host reply to a CIS request.

If an unexpected LL Control PDU arrives before that retained node is
consumed, it is routed to the active procedure and takes the invalid
PDU path in llcp_lp_cc_rx() or llcp_rp_cc_rx(). Those paths
completed the procedure without releasing the retained RX node,
violating the invariant checked in llcp_lr_check_done() and
llcp_rr_check_done(), and leaking the referenced RX node memory.

Release the retained RX node before completing the procedure,
mirroring the fix already applied to the remote Connection Update and
the PHY Update procedures.

Add unit tests to tests/bluetooth/controller/ctrl_cis_create that
inject an unexpected LL Control PDU while a retained RX node is
pending. Without the fix each test triggers the retained node
assertion in ull_llcp_local.c or ull_llcp_remote.c; with the fix the
connection is terminated with BT_HCI_ERR_LMP_PDU_NOT_ALLOWED and all
procedure contexts are released.

Fixes: #116509