### PR TITLE
boards: nxp: frdm_mcxa577: enable TSI touch input

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -378,6 +378,14 @@ void board_early_init_hook(void)
 	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToAll);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(tsi0))
+	CLOCK_SetupFRO16KClocking(kCLKE_16K_SYSTEM | kCLKE_16K_COREMAIN | kCLKE_16K_VBAT);
+	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToAll);
+	CLOCK_AttachClk(kFRO_HF_DIV_to_TSI0);
+	CLOCK_SetClockDiv(kCLOCK_DivTSI0, 4);
+	CLOCK_EnableClock(kCLOCK_GateTSI0);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -370,6 +370,14 @@ void board_early_init_hook(void)
 	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToAll);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(tsi0))
+	CLOCK_SetupFRO16KClocking(kCLKE_16K_SYSTEM | kCLKE_16K_COREMAIN | kCLKE_16K_VBAT);
+	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToAll);
+	CLOCK_AttachClk(kFRO_HF_DIV_to_TSI0);
+	CLOCK_SetClockDiv(kCLOCK_DivTSI0, 4);
+	CLOCK_EnableClock(kCLOCK_GateTSI0);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -240,4 +240,13 @@
 			slew-rate = "slow";
 		};
 	};
+
+	pinmux_tsi: pinmux_tsi {
+		group0 {
+			pinmux = <TSI0_CH0_P5_3>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -218,4 +218,13 @@
 			slew-rate = "slow";
 		};
 	};
+
+	pinmux_tsi: pinmux_tsi {
+		group0 {
+			pinmux = <TSI0_CH0_P5_3>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -380,6 +380,18 @@
 	status = "okay";
 };
 
+&tsi0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_tsi>;
+	pinctrl-names = "default";
+	/* On-board electrode E2 is wired to TSI0_CH0 (P5_3). */
+	channel-mask = <0x1>;
+	input-codes = <INPUT_KEY_A>;
+	touch-threshold = <100>;
+	release-threshold = <50>;
+	scan-period-ms = <50>;
+};
+
 nxp_8080_touch_panel_i2c: &lpi2c3 {};
 
 zephyr_mipi_dbi_parallel: &flexio0_lcd {

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -301,6 +301,18 @@
 	status = "okay";
 };
 
+&tsi0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_tsi>;
+	pinctrl-names = "default";
+	/* On-board electrode E2 is wired to TSI0_CH0 (P5_3). */
+	channel-mask = <0x1>;
+	input-codes = <INPUT_KEY_A>;
+	touch-threshold = <100>;
+	release-threshold = <50>;
+	scan-period-ms = <50>;
+};
+
 nxp_8080_touch_panel_i2c: &lpi2c3 {};
 
 zephyr_mipi_dbi_parallel: &flexio0_lcd {

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -32,4 +32,5 @@ supported:
   - rtc
   - crc
   - pwm
+  - tsi
 vendor: nxp

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -302,7 +302,11 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(tsi0))
 	if ((uint32_t)sub_system == MCUX_TSI_CLK) {
+#if defined(CONFIG_SOC_FAMILY_MCXA)
+		CLOCK_EnableClock(kCLOCK_GateTSI0);
+#else
 		CLOCK_EnableClock(kCLOCK_Tsi);
+#endif
 	}
 #endif
 

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -331,7 +331,11 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(tsi0))
 	if ((uint32_t)sub_system == MCUX_TSI_CLK) {
+#if defined(CONFIG_SOC_FAMILY_MCXA)
+		CLOCK_EnableClock(kCLOCK_GateTSI0);
+#else
 		CLOCK_EnableClock(kCLOCK_Tsi);
+#endif
 	}
 #endif
 

--- a/drivers/input/input_mcux_tsi.c
+++ b/drivers/input/input_mcux_tsi.c
@@ -17,6 +17,13 @@
 
 LOG_MODULE_REGISTER(input_mcux_tsi, CONFIG_INPUT_LOG_LEVEL);
 
+/*
+ * channel_mask is a uint32_t, so only channels 0..31 are addressable even on
+ * SoCs whose TSI has more than 32 channels (e.g. MCXA577 = 70). Clamp the
+ * usable width so the state array and mask checks never exceed 32 channels.
+ */
+#define MCUX_TSI_MAX_CHANNELS MIN(FSL_FEATURE_TSI_CHANNEL_COUNT, 32)
+
 struct tsi_channel_state {
 	uint16_t baseline;
 	uint16_t counter;
@@ -50,7 +57,7 @@ struct mcux_tsi_data {
 	const struct device *dev;
 
 	/* Channel states */
-	struct tsi_channel_state channels[FSL_FEATURE_TSI_CHANNEL_COUNT];
+	struct tsi_channel_state channels[MCUX_TSI_MAX_CHANNELS];
 
 	/* Current scanning channel */
 	uint8_t current_channel;
@@ -135,7 +142,7 @@ static void mcux_tsi_isr(const struct device *dev)
 		uint16_t counter = TSI_GetCounter(base);
 		uint8_t ch_idx = data->current_channel;
 
-		if (ch_idx < FSL_FEATURE_TSI_CHANNEL_COUNT) {
+		if (ch_idx < MCUX_TSI_MAX_CHANNELS) {
 			struct tsi_channel_state *ch = &data->channels[ch_idx];
 
 			/* Update channel data */
@@ -163,7 +170,7 @@ static void mcux_tsi_process_work_handler(struct k_work *work)
 	uint8_t ch_idx = data->current_channel;
 
 	/* Process channel data in work handler instead of ISR */
-	if (ch_idx < FSL_FEATURE_TSI_CHANNEL_COUNT) {
+	if (ch_idx < MCUX_TSI_MAX_CHANNELS) {
 		mcux_tsi_process_channel(dev, ch_idx);
 	}
 }
@@ -219,9 +226,13 @@ static int mcux_tsi_init(const struct device *dev)
 	uint32_t mask = config->channel_mask;
 	uint8_t enabled_channels = POPCOUNT(mask);
 
-	if (mask & ~BIT_MASK(FSL_FEATURE_TSI_CHANNEL_COUNT)) {
-		LOG_ERR("Channel mask 0x%x exceeds %d channels", mask,
-			FSL_FEATURE_TSI_CHANNEL_COUNT);
+	/*
+	 * Valid channel bits are 0..MCUX_TSI_MAX_CHANNELS-1. GENMASK is used
+	 * instead of BIT_MASK because MCUX_TSI_MAX_CHANNELS can be 32, and
+	 * BIT_MASK(32) would shift a 32-bit long by its full width (UB).
+	 */
+	if (mask & ~GENMASK(MCUX_TSI_MAX_CHANNELS - 1, 0)) {
+		LOG_ERR("Channel mask 0x%x exceeds %u channels", mask, MCUX_TSI_MAX_CHANNELS);
 		return -EINVAL;
 	}
 
@@ -280,7 +291,7 @@ static int mcux_tsi_init(const struct device *dev)
 	TSI_SelfCapCalibrate(base, &cal_data);
 
 	/* Initialize channel states */
-	for (uint8_t i = 0; i < FSL_FEATURE_TSI_CHANNEL_COUNT; i++) {
+	for (uint8_t i = 0; i < MCUX_TSI_MAX_CHANNELS; i++) {
 		if (config->channel_mask & BIT(i)) {
 			data->channels[i].baseline = cal_data.calibratedData[i];
 			data->channels[i].counter = 0;
@@ -328,7 +339,7 @@ static int mcux_tsi_init(const struct device *dev)
 			DT_INST_CLOCKS_CELL(n, name),				\
 		.irq_config_func = mcux_tsi_irq_config_##n,			\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
-		.num_channels = FSL_FEATURE_TSI_CHANNEL_COUNT,			\
+		.num_channels = MCUX_TSI_MAX_CHANNELS,			\
 		.input_code_count = DT_INST_PROP_LEN(n, input_codes),		\
 		.input_codes = mcux_tsi_input_codes_##n,			\
 		.channel_mask = DT_INST_PROP(n, channel_mask),			\

--- a/drivers/input/input_mcux_tsi.c
+++ b/drivers/input/input_mcux_tsi.c
@@ -219,9 +219,16 @@ static int mcux_tsi_init(const struct device *dev)
 	uint32_t mask = config->channel_mask;
 	uint8_t enabled_channels = POPCOUNT(mask);
 
-	if (mask & ~BIT_MASK(FSL_FEATURE_TSI_CHANNEL_COUNT)) {
-		LOG_ERR("Channel mask 0x%x exceeds %d channels", mask,
-			FSL_FEATURE_TSI_CHANNEL_COUNT);
+	/*
+	 * channel_mask is 32-bit, so only channels 0..31 are addressable here
+	 * even on SoCs whose TSI has more than 32 channels (e.g. MCXA577 = 70);
+	 * clamp the width to avoid a shift-count overflow in BIT_MASK().
+	 */
+	uint32_t max_channels = MIN(FSL_FEATURE_TSI_CHANNEL_COUNT, 32);
+
+	if (mask & ~BIT_MASK(max_channels)) {
+		LOG_ERR("Channel mask 0x%x exceeds %u channels", mask,
+			max_channels);
 		return -EINVAL;
 	}
 

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -943,6 +943,14 @@
 		interrupts = <113 0>;
 		clocks = <&syscon MCUX_TRNG_CLK>;
 	};
+
+	tsi0: tsi@c3000 {
+		compatible = "nxp,tsi-input";
+		reg = <0xc3000 0x1000>;
+		interrupts = <124 0>, <125 0>;
+		clocks = <&syscon MCUX_TSI_CLK>;
+		status = "disabled";
+	};
 };
 
 &systick {

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -865,6 +865,14 @@
 		resets = <&reset NXP_SYSCON_RESET(0, 14)>;
 		status = "disabled";
 	};
+
+	tsi0: tsi@c3000 {
+		compatible = "nxp,tsi-input";
+		reg = <0xc3000 0x1000>;
+		interrupts = <124 0>, <125 0>;
+		clocks = <&syscon MCUX_TSI_CLK>;
+		status = "disabled";
+	};
 };
 
 &systick {


### PR DESCRIPTION
Enable the on-board self-capacitive touch electrode E2 on frdm_mcxa577 by wiring up the existing nxp,tsi-input driver, following upstream commit that added TSI to the mcx_n9xx/n5xx boards.

Add a tsi0 node to the shared MCXA5x SoC devicetree (base offset 0xc3000, End-of-Scan / Out-of-Scan IRQs 124/125, MCUX_TSI_CLK), disabled by default. On the board, add the TSI0_CH0 (P5_3) pinctrl group, enable &tsi0 mapping E2 -> INPUT_KEY_A, and mark tsi as supported.

Two pre-existing driver issues only surface on MCXA577 and are fixed here so the board can boot and scan:

- input: mcux_tsi checked the channel mask against BIT_MASK() of the full HW channel count. MCXA577 has 70 channels, so BIT_MASK(70) overflowed the 32-bit shift. channel_mask is a uint32_t and only addresses channels 0..31, so clamp the width to MIN(count, 32).

- clock_control: mcux_syscon enabled only the TSI clock gate. On MCXA the peripheral also needs a functional clock source; without it the driver's init-time calibration faulted the CPU and the kernel never reached the console. Attach kFRO_HF_DIV_to_TSI0 with divider 10 and then enable kCLOCK_GateTSI0, matching the SDK TSI example.

tested: samples/subsys/input/input_dump