### PR TITLE
 tests: drivers: spi: loopback: add lp_mspm0g3519 support

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3519.conf
+++ b/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3519.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_LOOPBACK_MODE_LOOP=y
+CONFIG_SPI_ASYNC=n
+CONFIG_GPIO=y

--- a/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3519.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3519.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi0 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/tests.yaml
+++ b/tests/drivers/spi/spi_loopback/tests.yaml
@@ -491,6 +491,3 @@ tests:
     extra_args:
       - DTC_OVERLAY_FILE="boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}_sci_b_spi.overlay"
       - CONF_FILE="prj.conf" # to exclude "boards/${BOARD}_${NORMALIZED_BOARD_QUALIFIERS}.overlay"
-  drivers.spi.mspm0.loopback:
-    platform_allow:
-      - lp_mspm0g3507


### PR DESCRIPTION
This PR adds SPI loopback test support for the LP-MSPM0G3519 LaunchPad and removes a redundant MSPM0-specific test scenario.