### PR TITLE
MAINTAINERS: Add Thalley to Bluetooth Controller

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -662,6 +662,7 @@ Bluetooth Controller:
     - wopu-ot
     - erbr-ot
     - Tronil
+    - Thalley
   files:
     - doc/services/connectivity/bluetooth/bluetooth-ctlr-arch.rst
     - doc/services/connectivity/bluetooth/img/ctlr*


### PR DESCRIPTION
Thalley is actively reviewing controller PRs and have contributed a few fixes as well. Add Thalley as Collaborator for automatic review assignment.