### PR TITLE
drivers: rtc: improve Doxygen coverage

### DIFF
--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -21,6 +21,11 @@
  * @version 0.1.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup rtc_interface_ext Device-specific RTC API extensions
+ *
+ * @{
+ * @}
  */
 
 #include <zephyr/kernel.h>

--- a/include/zephyr/drivers/rtc/mcp7940n.h
+++ b/include/zephyr/drivers/rtc/mcp7940n.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Register layout and API for the MCP7940N RTC based counter driver.
+ * @ingroup counter_interface_ext
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_MCP7940N_H_
 #define ZEPHYR_INCLUDE_DRIVERS_RTC_MCP7940N_H_
 

--- a/include/zephyr/drivers/rtc/mcux_snvs_rtc.h
+++ b/include/zephyr/drivers/rtc/mcux_snvs_rtc.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Real-time clock control based on the MCUX IMX SNVS counter API.
+ * @ingroup counter_interface_ext
  *
  * The core Zephyr API to this device is as a counter.
  *

--- a/include/zephyr/drivers/rtc/rtc_fake.h
+++ b/include/zephyr/drivers/rtc/rtc_fake.h
@@ -7,7 +7,7 @@
 /**
  * @file
  * @brief Fake RTC driver API for testing purposes.
- * @ingroup rtc_interface
+ * @ingroup rtc_fake
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_RTC_FAKE_H_
@@ -20,30 +20,98 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Fake RTC driver API functions.
+ * @defgroup rtc_fake Fake RTC
+ * @ingroup io_emulators
+ * @ingroup rtc_interface
+ * @{
+ */
+
+/**
+ * @brief Set the time of the fake RTC.
+ *
+ * @see rtc_set_time
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_set_time, const struct device *, const struct rtc_time *);
+
+/**
+ * @brief Get the time of the fake RTC.
+ *
+ * @see rtc_get_time
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_get_time, const struct device *, struct rtc_time *);
 
 #ifdef CONFIG_RTC_ALARM
+/**
+ * @brief Get the supported alarm time fields of the fake RTC.
+ *
+ * @see rtc_alarm_get_supported_fields
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_supported_fields, const struct device *, uint16_t,
 			uint16_t *);
+
+/**
+ * @brief Set the alarm time of the fake RTC.
+ *
+ * @see rtc_alarm_set_time
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_time, const struct device *, uint16_t, uint16_t,
 			const struct rtc_time *);
+
+/**
+ * @brief Get the alarm time of the fake RTC.
+ *
+ * @see rtc_alarm_get_time
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_time, const struct device *, uint16_t, uint16_t *,
 			struct rtc_time *);
+
+/**
+ * @brief Test if a fake RTC alarm is pending.
+ *
+ * @see rtc_alarm_is_pending
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_is_pending, const struct device *, uint16_t);
+
+/**
+ * @brief Set the alarm callback of the fake RTC.
+ *
+ * @see rtc_alarm_set_callback
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_callback, const struct device *, uint16_t,
 			rtc_alarm_callback, void *);
 #endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
+/**
+ * @brief Set the update callback of the fake RTC.
+ *
+ * @see rtc_update_set_callback
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_update_set_callback, const struct device *,
 			rtc_update_callback, void *);
 #endif /* CONFIG_RTC_UPDATE */
 
 #ifdef CONFIG_RTC_CALIBRATION
+/**
+ * @brief Set the calibration of the fake RTC.
+ *
+ * @see rtc_set_calibration
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_set_calibration, const struct device *, int32_t);
+
+/**
+ * @brief Get the calibration of the fake RTC.
+ *
+ * @see rtc_get_calibration
+ */
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_get_calibration, const struct device *, int32_t *);
 #endif /* CONFIG_RTC_CALIBRATION */
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/rtc/rtc_fake.h
+++ b/include/zephyr/drivers/rtc/rtc_fake.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Fake RTC driver API for testing purposes.
+ * @ingroup rtc_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_RTC_FAKE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_RTC_RTC_FAKE_H_
 

--- a/include/zephyr/drivers/rtc/rtc_max31331.h
+++ b/include/zephyr/drivers/rtc/rtc_max31331.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief MAX31331 RTC driver specific API.
+ * @ingroup rtc_interface_ext
+ */
+
 #ifndef ZEPHYR_INCLUDE_RTC_RTC_MAX31331_H
 #define ZEPHYR_INCLUDE_RTC_RTC_MAX31331_H
 


### PR DESCRIPTION
Add the missing `@file` blocks to the RTC driver headers and attach them
to their Doxygen groups.

Add an `rtc_interface_ext` group, mirroring the existing "Device-specific
xxx API extensions" group, and place the device-specific headers in
it or in `counter_interface_ext` so they are not mixed into the generic
RTC and counter API groups.


Documentation only, no functional change.