### PR TITLE
drivers: spi: add ADI AXI SPI Engine driver

### DIFF
--- a/drivers/spi/CMakeLists.txt
+++ b/drivers/spi/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE spi_handlers.c)
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ESP32_SPIM spi_esp32_spim.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_S32_SPI spi_nxp_s32.c)
+zephyr_library_sources_ifdef(CONFIG_SPI_ADI_AXI_SPI_ENGINE spi_adi_axi_spi_engine.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_AMBIQ_BLEIF spi_ambiq_bleif.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_AMBIQ_SPIC spi_ambiq_spic.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_AMBIQ_SPID spi_ambiq_spid.c)

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -104,6 +104,7 @@ module-str = spi
 source "subsys/logging/Kconfig.template.log_config"
 
 # zephyr-keep-sorted-start
+source "drivers/spi/Kconfig.adi_axi_spi_engine"
 source "drivers/spi/Kconfig.ambiq"
 source "drivers/spi/Kconfig.ameba"
 source "drivers/spi/Kconfig.andes_atcspi200"

--- a/drivers/spi/Kconfig.adi_axi_spi_engine
+++ b/drivers/spi/Kconfig.adi_axi_spi_engine
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SPI_ADI_AXI_SPI_ENGINE
+	bool "Analog Devices AXI SPI Engine controller"
+	default y
+	depends on DT_HAS_ADI_AXI_SPI_ENGINE_ENABLED
+	help
+	  SPI controller driver for the Analog Devices AXI SPI Engine core.
+	  Register-mode transfers use the standard Zephyr SPI API; the
+	  autonomous offload path (DMA-driven MS/s streaming) is exposed as a
+	  vendor extension in <zephyr/drivers/spi/spi_adi_axi_spi_engine.h>.

--- a/drivers/spi/spi_adi_axi_spi_engine.c
+++ b/drivers/spi/spi_adi_axi_spi_engine.c
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Driver for the Analog Devices AXI SPI Engine core.
+ *
+ * Implements the standard Zephyr SPI controller API for register-mode
+ * (command-FIFO) transfers. The autonomous offload path used for MS/s
+ * conversion streaming is exposed as a vendor extension in
+ * <zephyr/drivers/spi/spi_adi_axi_spi_engine.h>.
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/spi/spi_adi_axi_spi_engine.h>
+
+#define DT_DRV_COMPAT adi_axi_spi_engine
+
+#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(adi_axi_spi_engine);
+
+#include "spi_context.h"
+#include "spi_rtio.h"
+
+#define SPI_ENGINE_REG_VERSION			0x00
+#define SPI_ENGINE_REG_DATA_WIDTH		0x0C
+#define SPI_ENGINE_REG_RESET			0x40
+#define SPI_ENGINE_REG_INT_ENABLE		0x80
+#define SPI_ENGINE_REG_INT_PENDING		0x84
+#define SPI_ENGINE_REG_INT_SOURCE		0x88
+#define SPI_ENGINE_REG_SYNC_ID			0xC0
+#define SPI_ENGINE_REG_CMD_FIFO_ROOM		0xD0
+#define SPI_ENGINE_REG_SDO_FIFO_ROOM		0xD4
+#define SPI_ENGINE_REG_SDI_FIFO_LEVEL		0xD8
+#define SPI_ENGINE_REG_CMD_FIFO			0xE0
+#define SPI_ENGINE_REG_SDO_DATA_FIFO		0xE4
+#define SPI_ENGINE_REG_SDI_DATA_FIFO		0xE8
+
+#define SPI_ENGINE_INST_TRANSFER		0x00
+#define SPI_ENGINE_INST_ASSERT			0x01
+#define SPI_ENGINE_INST_CONFIG			0x02
+#define SPI_ENGINE_INST_MISC			0x03
+
+#define SPI_ENGINE_CMD_REG_CLK_DIV		0x00
+#define SPI_ENGINE_CMD_REG_CONFIG		0x01
+/* CONFIG sub-register 0x02: bits-per-word for TRANSFER instruction. */
+#define SPI_ENGINE_CMD_REG_XFER_BITS		0x02
+/* CONFIG sub-registers 0x03/0x04: SDI/SDO lane masks for multi-lane builds. */
+#define SPI_ENGINE_CMD_REG_SDI_MASK		0x03
+#define SPI_ENGINE_CMD_REG_SDO_MASK		0x04
+
+#define SPI_ENGINE_MISC_SYNC			0x00
+
+/* CONFIG sub-register 0x01. CPHA/CPOL are ordered the opposite way round to
+ * Zephyr's SPI_MODE_CPOL/SPI_MODE_CPHA, so mode must be remapped bit by bit
+ * rather than passed through as a field.
+ */
+#define SPI_ENGINE_CONFIG_CPHA			BIT(0)
+#define SPI_ENGINE_CONFIG_CPOL			BIT(1)
+#define SPI_ENGINE_CONFIG_3WIRE			BIT(2)
+#define SPI_ENGINE_CONFIG_SDO_IDLE		BIT(3)
+
+/* TRANSFER encodes its word count in arg2 (8 bits), zero-based. */
+#define SPI_ENGINE_MAX_XFER_WORDS		256
+
+#define SPI_ENGINE_INSTRUCTION_TRANSFER_W	0x01
+#define SPI_ENGINE_INSTRUCTION_TRANSFER_R	0x02
+#define SPI_ENGINE_INSTRUCTION_TRANSFER_RW	0x03
+
+#define SPI_ENGINE_REG_OFFLOAD_CTRL(x)		(0x100 + (0x20 * (x)))
+#define SPI_ENGINE_REG_OFFLOAD_RESET(x)		(0x108 + (0x20 * (x)))
+#define SPI_ENGINE_REG_OFFLOAD_CMD_MEM(x)	(0x110 + (0x20 * (x)))
+#define SPI_ENGINE_REG_OFFLOAD_SDO_MEM(x)	(0x114 + (0x20 * (x)))
+
+/* HDL decodes inst from cmd[14:12], CONFIG sub-reg from cmd[10:8].
+ * arg1 MUST be 3-bit-masked to avoid SDO_LANE_CONFIG aliasing to CLK_DIV.
+ */
+#define SPI_ENGINE_CMD(inst, arg1, arg2) \
+	((((inst) & 0x07) << 12) | (((arg1) & 0x07) << 8) | ((arg2) & 0xFF))
+
+#define SPI_ENGINE_CMD_TRANSFER(rw, n) \
+	SPI_ENGINE_CMD(SPI_ENGINE_INST_TRANSFER, (rw), (n))
+
+#define SPI_ENGINE_CMD_ASSERT(delay, cs) \
+	SPI_ENGINE_CMD(SPI_ENGINE_INST_ASSERT, (delay), (cs))
+
+#define SPI_ENGINE_CMD_CONFIG(reg, val) \
+	SPI_ENGINE_CMD(SPI_ENGINE_INST_CONFIG, (reg), (val))
+
+#define SPI_ENGINE_CMD_SYNC(id) \
+	SPI_ENGINE_CMD(SPI_ENGINE_INST_MISC, SPI_ENGINE_MISC_SYNC, (id))
+
+/* CS assert pattern: bit == 0 asserts (active low); 0xFF deasserts all. */
+#define SPI_ENGINE_CS_DEASSERT			SPI_ENGINE_CMD_ASSERT(0x03, 0xFF)
+#define SPI_ENGINE_CS_ASSERT(pattern)		SPI_ENGINE_CMD_ASSERT(0x03, (pattern))
+
+struct axi_spi_engine_config {
+	DEVICE_MMIO_ROM;
+	uint32_t ref_clock_hz;
+	uint32_t data_width;	/* default word size when spi_config leaves it 0 */
+	uint32_t num_cs;
+};
+
+struct axi_spi_engine_data {
+	DEVICE_MMIO_RAM;
+	struct spi_context ctx;
+	uint32_t version;
+	uint32_t max_data_width;
+	uint32_t num_sdi;	/* number of SDI lanes synthesized in HDL */
+	uint32_t sync_id;	/* SYNC command tag, incremented per transfer */
+};
+
+static inline uint32_t spi_eng_read(const struct device *dev, uint32_t reg)
+{
+	return sys_read32(DEVICE_MMIO_GET(dev) + reg);
+}
+
+static inline void spi_eng_write(const struct device *dev, uint32_t reg,
+				 uint32_t val)
+{
+	sys_write32(val, DEVICE_MMIO_GET(dev) + reg);
+}
+
+static int spi_eng_write_cmd(const struct device *dev, uint32_t cmd)
+{
+	uint32_t timeout = 10000;
+
+	while (spi_eng_read(dev, SPI_ENGINE_REG_CMD_FIFO_ROOM) == 0) {
+		if (--timeout == 0) {
+			LOG_ERR("cmd FIFO full timeout");
+			return -ETIMEDOUT;
+		}
+		k_busy_wait(1);
+	}
+
+	spi_eng_write(dev, SPI_ENGINE_REG_CMD_FIFO, cmd);
+	return 0;
+}
+
+/*
+ * Run one command-FIFO transfer for the current spi_context buffers.
+ *
+ * The core loads a program then executes it: push the command sequence
+ * (CLK_DIV, XFER_BITS, lane masks, CS assert, TRANSFER, CS deassert, SYNC),
+ * stream all SDO words, poll SYNC_ID, then drain the SDI FIFO into the rx
+ * buffer.
+ */
+static int spi_eng_do_transfer(const struct device *dev,
+			       const struct spi_config *config)
+{
+	const struct axi_spi_engine_config *cfg = dev->config;
+	struct axi_spi_engine_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
+	uint8_t word_size;
+	uint32_t bytes_per_word;
+	uint32_t tx_bytes;
+	uint32_t rx_bytes;
+	uint32_t words;
+	uint32_t clk_div;
+	uint32_t my_sync_id;
+	uint32_t poll_timeout;
+	uint8_t cs_pattern;
+	uint32_t xfer_cmd;
+	uint8_t cfg_reg;
+	bool have_tx;
+	bool have_rx;
+	int ret;
+
+	word_size = SPI_WORD_SIZE_GET(config->operation);
+	if (word_size == 0) {
+		word_size = cfg->data_width;
+	}
+	bytes_per_word = (word_size + 7) / 8;
+
+	tx_bytes = spi_context_total_tx_len(ctx);
+	rx_bytes = spi_context_total_rx_len(ctx);
+	have_tx = (tx_bytes > 0);
+	have_rx = (rx_bytes > 0);
+
+	words = DIV_ROUND_UP(MAX(tx_bytes, rx_bytes), bytes_per_word);
+	if (words == 0) {
+		return 0;
+	}
+	if (words > SPI_ENGINE_MAX_XFER_WORDS) {
+		LOG_ERR("transfer of %u words exceeds %u-word limit", words,
+			SPI_ENGINE_MAX_XFER_WORDS);
+		return -ENOTSUP;
+	}
+
+	/* SCLK = ref_clk / (2 * (clk_div + 1)), so clk_div is rounded up:
+	 * spi_config.frequency is a maximum, and flooring would overshoot it
+	 * (ref=160MHz, freq=30MHz would floor to clk_div=1 => 40MHz).
+	 */
+	if (config->frequency == 0 ||
+	    config->frequency >= cfg->ref_clock_hz / 2) {
+		clk_div = 0;
+	} else {
+		clk_div = DIV_ROUND_UP(cfg->ref_clock_hz,
+				       2 * config->frequency) - 1;
+		if (clk_div > 255) {
+			/* Clamping here would run SCLK faster than requested. */
+			LOG_ERR("frequency %u Hz too low for ref_clk %u Hz",
+				config->frequency, cfg->ref_clock_hz);
+			return -EINVAL;
+		}
+	}
+
+	cs_pattern = (uint8_t)~BIT(config->slave);
+
+	if (have_tx && have_rx) {
+		xfer_cmd = SPI_ENGINE_CMD_TRANSFER(
+			SPI_ENGINE_INSTRUCTION_TRANSFER_RW, words - 1);
+	} else if (have_tx) {
+		xfer_cmd = SPI_ENGINE_CMD_TRANSFER(
+			SPI_ENGINE_INSTRUCTION_TRANSFER_W, words - 1);
+	} else {
+		xfer_cmd = SPI_ENGINE_CMD_TRANSFER(
+			SPI_ENGINE_INSTRUCTION_TRANSFER_R, words - 1);
+	}
+
+	/* Disable offload module before command-FIFO transfers. */
+	spi_eng_write(dev, SPI_ENGINE_REG_OFFLOAD_CTRL(0), 0);
+
+	my_sync_id = data->sync_id;
+
+	ret = spi_eng_write_cmd(dev,
+		SPI_ENGINE_CMD_CONFIG(SPI_ENGINE_CMD_REG_CLK_DIV, clk_div));
+	if (ret) {
+		return ret;
+	}
+	ret = spi_eng_write_cmd(dev,
+		SPI_ENGINE_CMD_CONFIG(SPI_ENGINE_CMD_REG_XFER_BITS, word_size));
+	if (ret) {
+		return ret;
+	}
+	/* Multi-lane builds require explicit lane masks; pin to primary lane. */
+	if (data->num_sdi > 1) {
+		ret = spi_eng_write_cmd(dev,
+			SPI_ENGINE_CMD_CONFIG(SPI_ENGINE_CMD_REG_SDI_MASK, 0x01));
+		if (ret) {
+			return ret;
+		}
+		ret = spi_eng_write_cmd(dev,
+			SPI_ENGINE_CMD_CONFIG(SPI_ENGINE_CMD_REG_SDO_MASK, 0x01));
+		if (ret) {
+			return ret;
+		}
+	}
+	cfg_reg = 0;
+	if (config->operation & SPI_MODE_CPOL) {
+		cfg_reg |= SPI_ENGINE_CONFIG_CPOL;
+	}
+	if (config->operation & SPI_MODE_CPHA) {
+		cfg_reg |= SPI_ENGINE_CONFIG_CPHA;
+	}
+	ret = spi_eng_write_cmd(dev,
+		SPI_ENGINE_CMD_CONFIG(SPI_ENGINE_CMD_REG_CONFIG, cfg_reg));
+	if (ret) {
+		return ret;
+	}
+	ret = spi_eng_write_cmd(dev, SPI_ENGINE_CS_DEASSERT);
+	if (ret) {
+		return ret;
+	}
+	ret = spi_eng_write_cmd(dev, SPI_ENGINE_CS_ASSERT(cs_pattern));
+	if (ret) {
+		return ret;
+	}
+	ret = spi_eng_write_cmd(dev, xfer_cmd);
+	if (ret) {
+		return ret;
+	}
+	ret = spi_eng_write_cmd(dev, SPI_ENGINE_CS_DEASSERT);
+	if (ret) {
+		return ret;
+	}
+	ret = spi_eng_write_cmd(dev, SPI_ENGINE_CMD_SYNC(my_sync_id & 0xFF));
+	if (ret) {
+		return ret;
+	}
+
+	/* Push SDO words packed MSB-first, sourcing bytes from the tx bufs. */
+	if (have_tx) {
+		for (uint32_t i = 0; i < words; i++) {
+			uint32_t word = 0;
+			uint32_t timeout = 10000;
+
+			for (uint32_t b = 0; b < bytes_per_word; b++) {
+				uint8_t byte = 0;
+
+				if (spi_context_tx_buf_on(ctx)) {
+					byte = *ctx->tx_buf;
+					spi_context_update_tx(ctx, 1, 1);
+				}
+				word |= (uint32_t)byte <<
+					(word_size - (b + 1) * 8);
+			}
+
+			while (spi_eng_read(dev,
+				SPI_ENGINE_REG_SDO_FIFO_ROOM) == 0) {
+				if (--timeout == 0) {
+					return -ETIMEDOUT;
+				}
+				k_busy_wait(1);
+			}
+			spi_eng_write(dev, SPI_ENGINE_REG_SDO_DATA_FIFO, word);
+		}
+	}
+
+	/* Poll SYNC_ID until our id is seen. */
+	poll_timeout = 100000;
+	while (spi_eng_read(dev, SPI_ENGINE_REG_SYNC_ID) !=
+	       (my_sync_id & 0xFF)) {
+		if (--poll_timeout == 0) {
+			LOG_ERR("sync_id 0x%02x not seen — engine stalled",
+				my_sync_id & 0xFF);
+			return -ETIMEDOUT;
+		}
+		k_busy_wait(1);
+	}
+
+	data->sync_id = (my_sync_id + 1) & 0xFF;
+	if (data->sync_id == 0) {
+		data->sync_id = 1;
+	}
+
+	/* Pop and unpack SDI words MSB-first into the rx bufs. */
+	if (have_rx) {
+		for (uint32_t i = 0; i < words; i++) {
+			uint32_t timeout = 10000;
+			uint32_t word;
+
+			while (spi_eng_read(dev,
+				SPI_ENGINE_REG_SDI_FIFO_LEVEL) == 0) {
+				if (--timeout == 0) {
+					return -ETIMEDOUT;
+				}
+				k_busy_wait(1);
+			}
+			word = spi_eng_read(dev, SPI_ENGINE_REG_SDI_DATA_FIFO);
+
+			for (uint32_t b = 0; b < bytes_per_word; b++) {
+				uint8_t byte = (word >>
+					(word_size - (b + 1) * 8)) & 0xFF;
+
+				if (spi_context_rx_buf_on(ctx)) {
+					*ctx->rx_buf = byte;
+					spi_context_update_rx(ctx, 1, 1);
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int spi_eng_configure(const struct device *dev,
+			     const struct spi_config *config)
+{
+	const struct axi_spi_engine_config *cfg = dev->config;
+	struct axi_spi_engine_data *data = dev->data;
+	uint8_t word_size;
+
+	if (spi_context_configured(&data->ctx, config)) {
+		return 0;
+	}
+
+	/* Tested directly rather than via spi_context_is_slave(), which
+	 * dereferences ctx->config — still NULL until it is set below.
+	 */
+	if (config->operation & SPI_OP_MODE_SLAVE) {
+		LOG_ERR("slave mode not supported");
+		return -ENOTSUP;
+	}
+	/* The core shifts MSB-first on a dedicated SDO/SDI pair and drives CS
+	 * active-low from the ASSERT instruction; none of these are expressible.
+	 */
+	if (config->operation & (SPI_MODE_LOOP | SPI_TRANSFER_LSB |
+				 SPI_HALF_DUPLEX | SPI_FRAME_FORMAT_TI |
+				 SPI_CS_ACTIVE_HIGH)) {
+		LOG_ERR("unsupported operation flags 0x%x",
+			(unsigned int)config->operation);
+		return -ENOTSUP;
+	}
+	if ((config->operation & SPI_LINES_MASK) != SPI_LINES_SINGLE) {
+		LOG_ERR("only single-line SPI supported");
+		return -ENOTSUP;
+	}
+	if (spi_cs_is_gpio(config)) {
+		/* CS is asserted by the ASSERT instruction inside the command
+		 * program, so a GPIO CS is not wired up.
+		 */
+		LOG_ERR("cs-gpios not supported, use the core's hardware CS");
+		return -ENOTSUP;
+	}
+
+	word_size = SPI_WORD_SIZE_GET(config->operation);
+	if (word_size == 0) {
+		word_size = cfg->data_width;
+	}
+	/* The pack/unpack loops shift by (word_size - (b + 1) * 8), which
+	 * underflows for sizes that are not a whole number of bytes.
+	 */
+	if (word_size % 8 != 0) {
+		LOG_ERR("word size %u not a multiple of 8", word_size);
+		return -ENOTSUP;
+	}
+	if (word_size > data->max_data_width) {
+		LOG_ERR("word size %u exceeds hardware width %u", word_size,
+			data->max_data_width);
+		return -ENOTSUP;
+	}
+	if (config->slave >= cfg->num_cs) {
+		LOG_ERR("cs %u out of range (num-cs=%u)",
+			config->slave, cfg->num_cs);
+		return -EINVAL;
+	}
+
+	data->ctx.config = config;
+	return 0;
+}
+
+static int axi_spi_engine_transceive(const struct device *dev,
+				     const struct spi_config *config,
+				     const struct spi_buf_set *tx_bufs,
+				     const struct spi_buf_set *rx_bufs)
+{
+	struct axi_spi_engine_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
+	int ret;
+
+	spi_context_lock(ctx, false, NULL, NULL, config);
+
+	ret = spi_eng_configure(dev, config);
+	if (ret) {
+		goto out;
+	}
+
+	spi_context_buffers_setup(ctx, tx_bufs, rx_bufs, 1);
+
+	ret = spi_eng_do_transfer(dev, config);
+
+out:
+	spi_context_release(ctx, ret);
+	return ret;
+}
+
+static int axi_spi_engine_release(const struct device *dev,
+				  const struct spi_config *config)
+{
+	struct axi_spi_engine_data *data = dev->data;
+
+	ARG_UNUSED(config);
+	spi_context_unlock_unconditionally(&data->ctx);
+	return 0;
+}
+
+/* Offload extension; see <zephyr/drivers/spi/spi_adi_axi_spi_engine.h>. */
+int spi_engine_offload_load(const struct device *dev,
+			    struct spi_engine_offload_msg *msg)
+{
+	/* Reset offload engine */
+	spi_eng_write(dev, SPI_ENGINE_REG_OFFLOAD_RESET(0), 0x01);
+	spi_eng_write(dev, SPI_ENGINE_REG_OFFLOAD_RESET(0), 0x00);
+
+	/* Load commands into offload command memory */
+	for (uint32_t i = 0; i < msg->num_commands; i++) {
+		spi_eng_write(dev, SPI_ENGINE_REG_OFFLOAD_CMD_MEM(0),
+			      msg->commands[i]);
+	}
+
+	/* Load TX data if present */
+	if (msg->tx_data) {
+		for (uint32_t i = 0; i < msg->tx_len; i++) {
+			spi_eng_write(dev, SPI_ENGINE_REG_OFFLOAD_SDO_MEM(0),
+				      msg->tx_data[i]);
+		}
+	}
+
+	return 0;
+}
+
+int spi_engine_offload_enable(const struct device *dev, bool enable)
+{
+	spi_eng_write(dev, SPI_ENGINE_REG_OFFLOAD_CTRL(0), enable ? 0x0001 : 0);
+	return 0;
+}
+
+static int axi_spi_engine_init(const struct device *dev)
+{
+	const struct axi_spi_engine_config *cfg = dev->config;
+	struct axi_spi_engine_data *data = dev->data;
+	uint32_t data_width_reg;
+	int ret;
+
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
+	data->version = spi_eng_read(dev, SPI_ENGINE_REG_VERSION);
+	data->sync_id = 1;
+
+	/* Soft reset */
+	spi_eng_write(dev, SPI_ENGINE_REG_RESET, 0x01);
+	k_busy_wait(100);
+	spi_eng_write(dev, SPI_ENGINE_REG_RESET, 0x00);
+
+	/* bits[15:0] = data_width, bits[23:16] = num_of_sdi */
+	data_width_reg = spi_eng_read(dev, SPI_ENGINE_REG_DATA_WIDTH);
+	data->max_data_width = data_width_reg & 0xFFFF;
+	if (data->max_data_width == 0) {
+		data->max_data_width = cfg->data_width;
+	}
+	data->num_sdi = (data_width_reg >> 16) & 0xFF;
+	if (data->num_sdi == 0) {
+		data->num_sdi = 1;
+	}
+
+	/* Disable all interrupts initially */
+	spi_eng_write(dev, SPI_ENGINE_REG_INT_ENABLE, 0);
+	spi_eng_write(dev, SPI_ENGINE_REG_INT_PENDING, 0xFF);
+
+	ret = spi_context_cs_configure_all(&data->ctx);
+	if (ret < 0) {
+		return ret;
+	}
+	spi_context_unlock_unconditionally(&data->ctx);
+
+	LOG_INF("AXI SPI Engine v%d.%d.%c — ref_clk=%u Hz, "
+		"data_width=%u, hw_max_width=%u",
+		data->version >> 16,
+		(data->version >> 8) & 0xff,
+		data->version & 0xff,
+		cfg->ref_clock_hz,
+		cfg->data_width,
+		data->max_data_width);
+
+	return 0;
+}
+
+static DEVICE_API(spi, axi_spi_engine_driver_api) = {
+	.transceive = axi_spi_engine_transceive,
+	.release = axi_spi_engine_release,
+#ifdef CONFIG_SPI_RTIO
+	.iodev_submit = spi_rtio_iodev_default_submit,
+#endif
+};
+
+#define AXI_SPI_ENGINE_INIT(n)						\
+	static struct axi_spi_engine_data axi_spi_engine_data_##n = {	\
+		SPI_CONTEXT_INIT_LOCK(axi_spi_engine_data_##n, ctx),	\
+		SPI_CONTEXT_INIT_SYNC(axi_spi_engine_data_##n, ctx),	\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
+	};								\
+	static const struct axi_spi_engine_config			\
+		axi_spi_engine_config_##n = {				\
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),			\
+		.ref_clock_hz = DT_INST_PROP(n, adi_ref_clock_hz),	\
+		.data_width = DT_INST_PROP(n, adi_data_width),		\
+		.num_cs = DT_INST_PROP(n, adi_num_cs),			\
+	};								\
+	SPI_DEVICE_DT_INST_DEFINE(n,					\
+			      axi_spi_engine_init,			\
+			      NULL,					\
+			      &axi_spi_engine_data_##n,			\
+			      &axi_spi_engine_config_##n,		\
+			      POST_KERNEL,				\
+			      CONFIG_SPI_INIT_PRIORITY,			\
+			      &axi_spi_engine_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AXI_SPI_ENGINE_INIT)

--- a/dts/bindings/spi/adi,axi-spi-engine.yaml
+++ b/dts/bindings/spi/adi,axi-spi-engine.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Analog Devices AXI SPI Engine controller
+
+compatible: "adi,axi-spi-engine"
+
+include: spi-controller.yaml
+
+properties:
+  reg:
+    required: true
+  adi,ref-clock-hz:
+    type: int
+    required: true
+    description: Reference clock frequency in Hz (SPI Engine core clock)
+  adi,data-width:
+    type: int
+    default: 8
+    description: |
+      Default SPI word size in bits (8, 16, 24, or 32) used when a transfer's
+      spi_config leaves the word size unset.
+  adi,num-cs:
+    type: int
+    default: 1
+    enum: [1, 2, 3, 4, 5, 6, 7, 8]
+    description: |
+      Number of chip select lines. Capped at 8 because the CS assert pattern
+      is the 8-bit arg2 field of the ASSERT instruction.

--- a/include/zephyr/drivers/spi/spi_adi_axi_spi_engine.h
+++ b/include/zephyr/drivers/spi/spi_adi_axi_spi_engine.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Vendor extension for the Analog Devices AXI SPI Engine.
+ *
+ * In offload mode a fixed command program is loaded once into the core's
+ * command memory and replayed autonomously on every external trigger (e.g. a
+ * PWMGEN CNV pulse), streaming the captured SDI data to an AXI DMAC with no
+ * per-sample CPU cost.
+ *
+ * Zephyr has no generic SPI-offload framework, so this is exposed as a
+ * driver-specific extension alongside the standard SPI controller API rather
+ * than through it. Register-mode transfers still use spi_transceive(); only
+ * the offload program setup lives here. The device handle is the SPI
+ * controller device itself.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SPI_SPI_ADI_AXI_SPI_ENGINE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SPI_SPI_ADI_AXI_SPI_ENGINE_H_
+
+#include <zephyr/device.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Build a raw SPI Engine command word.
+ *
+ * Bit layout: [14:12]=instruction, [10:8]=arg1, [7:0]=arg2.
+ * @p _arg1 MUST be 3-bit-masked to avoid SDO_LANE_CONFIG aliasing to CLK_DIV.
+ *
+ * @param _inst Instruction field (3 bits).
+ * @param _arg1 First argument field (3 bits).
+ * @param _arg2 Second argument field (8 bits).
+ */
+#define SPI_ENGINE_CMD_BUILD(_inst, _arg1, _arg2)                                                  \
+	((((_inst) & 0x07) << 12) | (((_arg1) & 0x07) << 8) | ((_arg2) & 0xFF))
+
+/** @brief Build a CONFIG command that sets the clock divider to @p _div. */
+#define SPI_ENGINE_CMD_BUILD_CONFIG_CLK_DIV(_div)    SPI_ENGINE_CMD_BUILD(0x02, 0x00, (_div))
+/** @brief Build a CONFIG command that sets the SPI mode to @p _mode. */
+#define SPI_ENGINE_CMD_BUILD_CONFIG_MODE(_mode)      SPI_ENGINE_CMD_BUILD(0x02, 0x01, (_mode))
+/** @brief Build a CONFIG command that sets the transfer width to @p _bits. */
+#define SPI_ENGINE_CMD_BUILD_CONFIG_XFER_BITS(_bits) SPI_ENGINE_CMD_BUILD(0x02, 0x02, (_bits))
+
+/** @brief Build a TRANSFER command that reads @p _n words. */
+#define SPI_ENGINE_CMD_BUILD_READ_N_WORDS(_n)       SPI_ENGINE_CMD_BUILD(0x00, 0x02, ((_n) - 1))
+/** @brief Build a TRANSFER command that writes @p _n words. */
+#define SPI_ENGINE_CMD_BUILD_WRITE_N_WORDS(_n)      SPI_ENGINE_CMD_BUILD(0x00, 0x01, ((_n) - 1))
+/** @brief Build a TRANSFER command that writes and reads @p _n words. */
+#define SPI_ENGINE_CMD_BUILD_WRITE_READ_N_WORDS(_n) SPI_ENGINE_CMD_BUILD(0x00, 0x03, ((_n) - 1))
+
+/** @brief Build a CHIPSELECT command that deasserts all chip-select lines. */
+#define SPI_ENGINE_CMD_BUILD_CS_LOW              SPI_ENGINE_CMD_BUILD(0x01, 0x03, 0x00)
+/** @brief Build a CHIPSELECT command that asserts all chip-select lines. */
+#define SPI_ENGINE_CMD_BUILD_CS_HIGH             SPI_ENGINE_CMD_BUILD(0x01, 0x03, 0xFF)
+/** @brief Build a CHIPSELECT command that sets the CS lines to @p _cs_pattern. */
+#define SPI_ENGINE_CMD_BUILD_ASSERT(_cs_pattern) SPI_ENGINE_CMD_BUILD(0x01, 0x03, (_cs_pattern))
+
+/** @brief Build a SYNC command carrying identifier @p _id. */
+#define SPI_ENGINE_CMD_BUILD_SYNC(_id)      SPI_ENGINE_CMD_BUILD(0x03, 0x00, (_id))
+/** @brief Build a SLEEP command that idles for @p _cycles core clock cycles. */
+#define SPI_ENGINE_CMD_BUILD_SLEEP(_cycles) SPI_ENGINE_CMD_BUILD(0x03, 0x01, (_cycles))
+
+/**
+ * @brief Offload program description.
+ */
+struct spi_engine_offload_msg {
+	/** Array of SPI Engine command words (built with the
+	 *  SPI_ENGINE_CMD_BUILD_* macros) replayed on each trigger.
+	 */
+	uint32_t *commands;
+	/** Number of entries in @ref spi_engine_offload_msg::commands. */
+	uint32_t num_commands;
+	/** Optional SDO words preloaded into offload SDO memory, or NULL for
+	 *  read-only programs.
+	 */
+	uint32_t *tx_data;
+	/** Number of entries in @ref spi_engine_offload_msg::tx_data. */
+	uint32_t tx_len;
+	/** Optional consumer-side (DMAC) capture address hint. */
+	uint32_t rx_addr;
+	/** Optional producer-side address hint. */
+	uint32_t tx_addr;
+};
+
+/**
+ * @brief Load an offload command program into the SPI Engine.
+ *
+ * Resets the offload module and writes @p msg into the core's command
+ * (and optional SDO) memory. Does not start execution; call
+ * spi_engine_offload_enable() once the downstream DMAC is armed.
+ *
+ * @param dev SPI Engine controller device (compatible "adi,axi-spi-engine").
+ * @param msg Offload program to load.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int spi_engine_offload_load(const struct device *dev, struct spi_engine_offload_msg *msg);
+
+/**
+ * @brief Enable or disable autonomous offload execution.
+ *
+ * When enabled, the loaded program is replayed on every external trigger.
+ * Must be enabled before the first trigger arrives, otherwise the engine
+ * and the ADC drift out of frame.
+ *
+ * @param dev    SPI Engine controller device.
+ * @param enable true to start offload replay, false to stop.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int spi_engine_offload_enable(const struct device *dev, bool enable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SPI_SPI_ADI_AXI_SPI_ENGINE_H_ */


### PR DESCRIPTION
Implements support for the [AXI SPI Engine](https://analogdevicesinc.github.io/hdl/library/spi_engine/axi_spi_engine.html)
custom AXI IP core from Analog Devices.

Depends on #115303.

This is an FPGA soft-IP core used on ADI high-speed evaluation boards. Hardware
tested on a Zedboard with an AD4630-20; the Zedboard PR is #111154, and a sample
using this with a high-speed ADC will follow.

The core is not a classic shift-register peripheral — it is a small sequencer.
You push a command program into a FIFO (`CLK_DIV`, `XFER_BITS`, lane masks,
`ASSERT`, `TRANSFER`, `SYNC`), stream the SDO words, poll the `SYNC_ID` register
until the program retires, then drain the SDI FIFO. That is what
`spi_eng_do_transfer()` does, and it maps cleanly onto the standard
`spi_transceive()` API.

## Why there is a driver-specific API header

The second thing the core can do does not map onto the SPI API at all.

In *offload mode* the same command program is written once into a dedicated
command memory and then replayed **autonomously by the hardware on every
external trigger** — typically a PWM/CNV pulse driving the ADC's conversion
input. The captured SDI words never pass through the CPU; they leave the core on
a streaming interface. There is no transfer to submit, no buffer to hand over,
and no completion to wait for. It is a configuration of the core, not a
transaction.

There is no generic SPI-offload abstraction in-tree to express that, so I
exposed it as a driver-specific extension header, following the existing
convention for driver-specific APIs that sit alongside a standard class driver
(`include/zephyr/drivers/ethernet/eth_adin2111.h`,
`include/zephyr/drivers/pwm/max2221x.h`,
`include/zephyr/drivers/haptics/cs40l26.h`).

`include/zephyr/drivers/spi/spi_adi_axi_spi_engine.h`:

```c
int spi_engine_offload_load(const struct device *dev,
                            struct spi_engine_offload_msg *msg);
int spi_engine_offload_enable(const struct device *dev, bool enable);
```

Two functions, taking the SPI controller device itself as the handle. The
standard `transceive`/`release` API is untouched and remains the only way to do
normal transfers; `transceive` explicitly disables the offload module before
building its program, so the two paths cannot interleave.

I would really appreciate feedback on this API. If the preferred direction is an
RTIO iodev, a generic `spi_offload` op set, or something else already planned, I
am happy to rework it.

## How this hooks up to the DMAC

The offload path is one half of a hardware pipeline; the other half is an
`adi,axi-dmac` in the same fabric. The wiring is in the FPGA design, not in
software:

```
PWM/CNV trigger -> SPI Engine (offload) -> AXI DMAC -> memory
```

Software's job is only to arm both ends in the right order:

1. The consumer builds the command program with the `SPI_ENGINE_CMD_BUILD_*`
   macros (`CS_LOW`, `TRANSFER`, `CS_HIGH`, `SYNC`) and calls
   `spi_engine_offload_load()`. This resets the offload module and fills the
   command (and optional SDO) memory. Nothing runs yet.
2. The consumer arms the DMAC for the destination buffer using the normal Zephyr
   DMA API.
3. The consumer calls `spi_engine_offload_enable(dev, true)`. From here, every
   trigger produces one conversion's worth of data straight into memory.

Ordering matters and is documented on the API: if offload is enabled before the
DMAC is armed, the first triggers are dropped and the engine and the ADC drift
out of frame.

`struct spi_engine_offload_msg` carries optional `rx_addr`/`tx_addr` hints so a
consumer can keep the two addresses together, but the driver itself never
touches the DMAC — it has no handle on it and no dependency on it. A design that
routes the stream somewhere else works unchanged.

Note this means the offload half has no in-tree consumer in this PR; the ADC
driver that uses it (AD4630) is separate work. The register-mode half is
complete and self-contained. If reviewers would rather the offload header land
together with its first user, I can drop it from this PR and resubmit it
alongside the ADC.
