### PR TITLE
dsp: improve Doxygen coverage

### DIFF
--- a/include/zephyr/dsp/basicmath.h
+++ b/include/zephyr/dsp/basicmath.h
@@ -6,6 +6,7 @@
  * @file zephyr/dsp/basicmath.h
  *
  * @brief Public APIs for DSP basicmath
+ * @ingroup math_dsp_basic
  */
 
 #ifndef ZEPHYR_INCLUDE_DSP_BASICMATH_H_

--- a/include/zephyr/dsp/basicmath_f16.h
+++ b/include/zephyr/dsp/basicmath_f16.h
@@ -6,6 +6,7 @@
  * @file zephyr/dsp/basicmath_f16.h
  *
  * @brief Public APIs for DSP basicmath for 16 bit floating point
+ * @ingroup math_dsp_basic
  */
 
 #ifndef ZEPHYR_INCLUDE_DSP_BASICMATH_F16_H_

--- a/include/zephyr/dsp/dsp.h
+++ b/include/zephyr/dsp/dsp.h
@@ -6,6 +6,7 @@
  * @file zephyr/dsp/dsp.h
  *
  * @brief Public APIs for Digital Signal Processing (DSP) math.
+ * @ingroup math_dsp
  */
 
 #ifndef ZEPHYR_INCLUDE_DSP_DSP_H_

--- a/include/zephyr/dsp/dsp.h
+++ b/include/zephyr/dsp/dsp.h
@@ -12,18 +12,36 @@
 #ifndef ZEPHYR_INCLUDE_DSP_DSP_H_
 #define ZEPHYR_INCLUDE_DSP_DSP_H_
 
+/**
+ * @brief Storage class specifier of the DSP functions.
+ *
+ * Expands to `static` when @kconfig{CONFIG_DSP_BACKEND_HAS_STATIC} is enabled,
+ * and to nothing otherwise.
+ */
 #ifdef CONFIG_DSP_BACKEND_HAS_STATIC
 #define DSP_FUNC_SCOPE static
 #else
 #define DSP_FUNC_SCOPE
 #endif
 
+/**
+ * @brief Qualifier for data buffers passed to the DSP functions.
+ *
+ * Expands to a backend specific qualifier when
+ * @kconfig{CONFIG_DSP_BACKEND_HAS_AGU} is enabled, and to nothing otherwise.
+ */
 #ifdef CONFIG_DSP_BACKEND_HAS_AGU
 #define DSP_DATA __agu
 #else
 #define DSP_DATA
 #endif
 
+/**
+ * @brief Qualifier for statically allocated data used by the DSP functions.
+ *
+ * Same as @ref DSP_DATA, and additionally places the data in a dedicated
+ * section when @kconfig{CONFIG_DSP_BACKEND_HAS_XDATA_SECTION} is enabled.
+ */
 #ifdef CONFIG_DSP_BACKEND_HAS_XDATA_SECTION
 #define DSP_STATIC_DATA DSP_DATA __attribute__((section(".Xdata")))
 #else

--- a/include/zephyr/dsp/print_format.h
+++ b/include/zephyr/dsp/print_format.h
@@ -2,6 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Helper macros for printing Q values.
+ * @ingroup math_printing
+ */
+
 #ifndef ZEPHYR_INCLUDE_DSP_PRINT_FORMAT_H_
 #define ZEPHYR_INCLUDE_DSP_PRINT_FORMAT_H_
 

--- a/include/zephyr/dsp/types.h
+++ b/include/zephyr/dsp/types.h
@@ -2,6 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Fractional and floating point data types for DSP operations.
+ * @ingroup math_dsp
+ */
+
 #ifndef ZEPHYR_INCLUDE_DSP_TYPES_H_
 #define ZEPHYR_INCLUDE_DSP_TYPES_H_
 

--- a/include/zephyr/dsp/utils.h
+++ b/include/zephyr/dsp/utils.h
@@ -8,6 +8,7 @@
  * @file zephyr/dsp/utils.h
  *
  * @brief Extra utility functions for DSP
+ * @ingroup math_dsp_utils_shifts
  */
 
 #ifndef ZEPHYR_INCLUDE_DSP_UTILS_H_


### PR DESCRIPTION
Attach the `@file` blocks of the DSP headers to their Doxygen groups so
their contents show up in the API documentation.

Document `DSP_FUNC_SCOPE`, `DSP_DATA` and `DSP_STATIC_DATA`, including
the Kconfig option that selects each expansion.

Documentation only, no functional change.