### PR TITLE
boards: antmicro: improve stm32h7_renode_reference_board support

### DIFF
--- a/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
+++ b/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
@@ -38,6 +38,8 @@ tmp108: Sensors.TMP108 @ i2c1 0x48
 
 lps25hb: Sensors.LPS25HB @ i2c1 0x5D
 
+lsm6dso: Sensors.LSM6DSO_IMU @ i2c1 0x6A
+
 usart2:
     frequency: 200000000
 

--- a/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.resc
+++ b/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.resc
@@ -13,7 +13,7 @@ showAnalyzer sysbus.usart2
 macro reset
 """
     sysbus LoadELF $elf
-    cpu EnableZephyrMode
+    cpu EnableZephyrMode "CONFIG_TICKLESS_KERNEL"
     cpu VectorTableOffset `sysbus GetSymbolAddress "_vector_table"`
 """
 runMacro $reset


### PR DESCRIPTION
Update supporting Renode platform file and script for Antmicro's STM32H7 Renode Reference Platform.