### PR TITLE
soc: microchip: fix stack corruption during SRAM initialization

### DIFF
--- a/soc/microchip/pic32c/pic32cm_jh/Kconfig
+++ b/soc/microchip/pic32c/pic32cm_jh/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_FAMILY_MICROCHIP_PIC32CM_JH
@@ -8,5 +8,5 @@ config SOC_FAMILY_MICROCHIP_PIC32CM_JH
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_HAS_ARM_MPU
-	select SOC_RESET_HOOK
+	select SOC_EARLY_RESET_HOOK
 	select CLOCK_CONTROL

--- a/soc/microchip/pic32c/pic32cm_jh/common/soc.c
+++ b/soc/microchip/pic32c/pic32cm_jh/common/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,38 +16,29 @@
 #define SRAM0_SIZE DT_REG_SIZE(SRAM0_NODE)
 
 /**
- * @brief Initialize (clear) the SRAM region defined by DT node sram0.
+ * @brief Early Reset hook to run SoC-specific initialization.
+ *
+ * This function performs 32-bit writes to clear the entire SRAM very early at reset.
  *
  * After reset, SRAM content (data + ECC bits) is random and ECC is enabled by default.
  * Any 8-bit or 16-bit write may trigger single or double ECC errors due to the internal
  * read-modify-write of 32-bit words. Therefore, the SRAM must be initialized before use
  * to ensure ECC correctness.
  *
- * This function performs 32-bit writes to clear the entire SRAM safely.
- * It is intended for reuse across all SoCs that feature ECC-enabled SRAM.
- *
- * @note
- * This SRAM initialization is specific to device families with ECC-enabled SRAM
- * and should not be included in the generic architecture configuration.
- * The function is best invoked from the soc_reset_hook of the relevant device family,
- * which is called before stack initialization and before transitioning to C code.
+ * Implementing it naked with assembly code guarantees no stack access happens during
+ * the initialization.
  */
-static void soc_mchp_sram_ecc_initialization(void)
+__attribute__((naked)) void soc_early_reset_hook(void)
 {
-	volatile uint32_t *ram_start = (uint32_t *)SRAM0_BASE;
-	volatile uint32_t *ram_end = (uint32_t *)(SRAM0_BASE + SRAM0_SIZE);
-
-	for (; ram_start < ram_end; ++ram_start) {
-		*ram_start = 0U;
-	}
-}
-
-/**
- * @brief Reset hook to run SoC-specific initialization.
- *
- * This is invoked very early at reset.
- */
-void soc_reset_hook(void)
-{
-	soc_mchp_sram_ecc_initialization();
+	/* sram initialization */
+	__asm__ volatile(
+		"	ldr  r0, =%c[start]\n"
+		"	ldr  r1, =%c[end]\n"
+		"	movs r2, #0\n"
+		"loop:\n"
+		"	stmia r0!, {r2}\n"
+		"	cmp  r0, r1\n"
+		"	blo  loop\n"
+		"	bx   lr\n"
+		:: [start] "i" (SRAM0_BASE), [end] "i" (SRAM0_BASE + SRAM0_SIZE));
 }


### PR DESCRIPTION
Perform SRAM initialization before configuring main stack pointer, without using stack