### PR TITLE
cmake: reject CMake 4.1.0 due to GENEX_STRIP regression

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1161,6 +1161,48 @@ endfunction()
 
 # 1.5. Misc.
 
+# zephyr_reject_cmake_version(<broken_since> <fixed_in> <reason>)
+#
+# Reject CMake releases that are known to break the Zephyr build because of an
+# upstream regression that Zephyr cannot reasonably work around.
+#
+# Versions in the half-open range [broken_since, fixed_in) are rejected, so
+# 'fixed_in' names the first release that works again and is reported as the
+# version to upgrade to. Pass NONE for 'fixed_in' when no fixed release exists
+# yet; every version from 'broken_since' onwards is then rejected.
+function(zephyr_reject_cmake_version broken_since fixed_in reason)
+  # Flag entries that can no longer trigger because the whole broken range is at
+  # or below the required minimum CMake version. Such calls are dead code and
+  # should be removed when the minimum is bumped; warn the developer instead of
+  # silently keeping them.
+  if(NOT fixed_in STREQUAL NONE AND
+     fixed_in VERSION_LESS_EQUAL CMAKE_MINIMUM_REQUIRED_VERSION)
+    message(AUTHOR_WARNING
+      "zephyr_reject_cmake_version(${broken_since} ${fixed_in} ...) is obsolete: "
+      "the minimum required CMake version is ${CMAKE_MINIMUM_REQUIRED_VERSION}, so "
+      "this range can no longer be selected. Please remove this call.")
+    return()
+  endif()
+
+  if(CMAKE_VERSION VERSION_LESS broken_since)
+    return()
+  endif()
+
+  if(NOT fixed_in STREQUAL NONE AND CMAKE_VERSION VERSION_GREATER_EQUAL fixed_in)
+    return()
+  endif()
+
+  if(fixed_in STREQUAL NONE)
+    set(upgrade_hint "Please use a different CMake version.")
+  else()
+    set(upgrade_hint "Please upgrade to CMake ${fixed_in} or newer.")
+  endif()
+
+  message(FATAL_ERROR
+    "CMake ${CMAKE_VERSION} is not supported by Zephyr due to ${reason}. "
+    "${upgrade_hint}")
+endfunction()
+
 # zephyr_check_compiler_flag is a part of Zephyr's toolchain
 # infrastructure. It should be used when testing toolchain
 # capabilities and it should normally be used in place of the

--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -10,6 +10,8 @@
 
 include_guard(GLOBAL)
 
+include(extensions)
+
 # The code line below defines the real minimum supported CMake version.
 #
 # Unfortunately CMake requires the toplevel CMakeLists.txt file to define the
@@ -49,6 +51,13 @@ find_package(ZephyrAppConfiguration
   NO_CMAKE_SYSTEM_PATH
   NO_CMAKE_SYSTEM_PACKAGE_REGISTRY
 )
+
+# CMake 4.1.0 has a regression in string(GENEX_STRIP) that fails to strip
+# nested generator expressions, corrupting the flags computed by
+# compiler_simple_options() into bogus linker arguments such as ':>' and
+# ':-Os>'. See https://gitlab.kitware.com/cmake/cmake/-/work_items/27133
+zephyr_reject_cmake_version(4.1.0 4.1.1
+  "a regression in string(GENEX_STRIP) that produces invalid linker arguments")
 
 # Prepare user cache
 list(APPEND zephyr_cmake_modules python)

--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -24,6 +24,25 @@ message(STATUS "Application: ${APPLICATION_SOURCE_DIR}")
 # to CMake 3.20; this produces different binaries.
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 
+# Some individual CMake releases contain regressions that break the Zephyr
+# build in ways that are hard to diagnose. Reject them here with a helpful
+# message instead of letting the build fail later in a confusing way. Add a
+# zephyr_reject_cmake_version() call below for each unsupported release.
+function(zephyr_reject_cmake_version version reason)
+  if(CMAKE_VERSION VERSION_EQUAL ${version})
+    message(FATAL_ERROR
+      "CMake ${CMAKE_VERSION} is not supported by Zephyr due to ${reason}. "
+      "Please use a different CMake version.")
+  endif()
+endfunction()
+
+# CMake 4.1.0 has a regression in string(GENEX_STRIP) that fails to strip
+# nested generator expressions, corrupting the flags computed by
+# compiler_simple_options() into bogus linker arguments such as ':>' and
+# ':-Os>'. See https://gitlab.kitware.com/cmake/cmake/-/work_items/27133
+zephyr_reject_cmake_version(4.1.0
+  "a regression in string(GENEX_STRIP) that produces invalid linker arguments (fixed in CMake 4.1.1)")
+
 # Find and execute workspace build configuration
 find_package(ZephyrBuildConfiguration
   QUIET NO_POLICY_SCOPE

--- a/doc/build/cmake/index.rst
+++ b/doc/build/cmake/index.rst
@@ -343,6 +343,44 @@ target. This is accomplished in a straightforward manner with *objdump*.
     :width: 80%
 
 
+.. _cmake-unsupported-versions:
+
+Supported CMake versions
+========================
+
+Zephyr enforces a minimum CMake version, but individual CMake releases
+occasionally ship regressions that break the build. Such a release can be
+rejected at configuration time with the ``zephyr_reject_cmake_version()`` helper
+(defined in :zephyr_file:`cmake/modules/extensions.cmake`); the core denylist is
+applied in :zephyr_file:`cmake/modules/zephyr_default.cmake`:
+
+.. code-block:: cmake
+
+   zephyr_reject_cmake_version(4.1.0 4.1.1
+     "a regression in string(GENEX_STRIP) that produces invalid linker arguments")
+
+Versions in the half-open range ``[broken_since, fixed_in)`` are rejected, and
+``fixed_in`` is reported as the version to upgrade to (use ``NONE`` when no fix
+exists yet). This turns a cryptic downstream failure into a clear error.
+
+.. note::
+
+   This is a denylist of versions *known* to be broken; it does not imply every
+   other version is supported. CI tests a single CMake version (see the
+   :ref:`getting_started` guide), and others are best-effort.
+
+Add an entry only when all of the following hold:
+
+* the defect is upstream and cannot reasonably be worked around in Zephyr;
+* it has been observed to break a real Zephyr build, not just reported upstream;
+* a working CMake version exists for users to move to.
+
+Because the helper lives in ``extensions.cmake``, a call may also be guarded (for
+example by ``CMAKE_HOST_WIN32``) or placed in a module, to cover regressions that
+only affect specific configurations. Entries whose range is at or below the
+minimum required version are reported with an ``AUTHOR_WARNING`` so they are
+removed when the minimum is bumped.
+
 .. _build_system_scripts:
 
 Supporting Scripts and Tools


### PR DESCRIPTION
CMake 4.1.0 has a regression in `string(GENEX_STRIP)` that fails to strip nested generator expressions. This corrupts the compiler flags computed by `compiler_simple_options()` into bogus linker arguments such as ':>' and ':-Os>', causing the link stage to fail with confusing errors.

Add a helper that aborts configuration with a clear message when a known-broken CMake version is detected, so users get an actionable error instead of a cryptic link failure. The regression is fixed in CMake 4.1.1.

Ref: https://github.com/zephyrproject-rtos/zephyr/issues/115372