### PR TITLE
posix: mutex: remove structurally dead code

### DIFF
--- a/subsys/portability/posix/options/mutex.c
+++ b/subsys/portability/posix/options/mutex.c
@@ -140,7 +140,6 @@ static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
 				(void)k_sleep(K_FOREVER);
 			} while (true);
 			CODE_UNREACHABLE;
-			break;
 		case PTHREAD_MUTEX_RECURSIVE:
 			if (lock_count >= MUTEX_MAX_REC_LOCK) {
 				LOG_DBG("Mutex %p locked recursively too many times", m);


### PR DESCRIPTION
Fixes a Coverity warning (CID 524461) where a `break;` statement was placed immediately after `CODE_UNREACHABLE`, making it structurally dead.

`CODE_UNREACHABLE` expands to `__builtin_unreachable()`, so any subsequent statements in the same scope are unreachable and result in dead code warnings from static analysis tools.

Fixes #99981