### PR TITLE
pmci: mctp: improve Doxygen coverage

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -299,6 +299,13 @@
 @{
 @}
 
+@brief Management Component Transport Protocol (MCTP)
+@defgroup mctp MCTP
+@ingroup device_mgmt
+@details Bus bindings connecting Zephyr transports to the libmctp protocol stack.
+@{
+@}
+
 @brief Connectivity
 @defgroup connectivity Connectivity
 @ingroup os_services

--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_common.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_common.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief Internal definitions shared by the MCTP I2C GPIO controller and target bindings.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I2C_GPIO_COMMON_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I2C_GPIO_COMMON_H_
 

--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_controller.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_controller.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief MCTP bus binding over I2C with GPIO signaling, controller side.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I2C_GPIO_CONTROLLER_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I2C_GPIO_CONTROLLER_H_
 

--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief MCTP bus binding over I2C with GPIO signaling, target side.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I2C_GPIO_TARGET_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I2C_GPIO_TARGET_H_
 

--- a/include/zephyr/pmci/mctp/mctp_i3c_common.h
+++ b/include/zephyr/pmci/mctp/mctp_i3c_common.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief Internal definitions shared by the MCTP I3C controller and target bindings.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_COMMON_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_COMMON_H_
 

--- a/include/zephyr/pmci/mctp/mctp_i3c_controller.h
+++ b/include/zephyr/pmci/mctp/mctp_i3c_controller.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief MCTP bus binding over I3C using IBI signaling, controller side.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_CONTROLLER_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_CONTROLLER_H_
 

--- a/include/zephyr/pmci/mctp/mctp_i3c_endpoint.h
+++ b/include/zephyr/pmci/mctp/mctp_i3c_endpoint.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief Internal driver API for MCTP I3C endpoint devices.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_ENDPOINT_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_ENDPOINT_H_
 

--- a/include/zephyr/pmci/mctp/mctp_i3c_target.h
+++ b/include/zephyr/pmci/mctp/mctp_i3c_target.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief MCTP bus binding over I3C using IBI signaling, target side.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_TARGET_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_I3C_TARGET_H_
 

--- a/include/zephyr/pmci/mctp/mctp_memory.h
+++ b/include/zephyr/pmci/mctp/mctp_memory.h
@@ -8,6 +8,7 @@
 /**
  * @file
  * @brief MCTP memory management functions
+ * @ingroup mctp
  */
 
 #ifndef ZEPHYR_MCTP_MEMORY_H_

--- a/include/zephyr/pmci/mctp/mctp_uart.h
+++ b/include/zephyr/pmci/mctp/mctp_uart.h
@@ -5,6 +5,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief MCTP bus binding over the Zephyr asynchronous UART interface.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_UART_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_UART_H_
 

--- a/include/zephyr/pmci/mctp/mctp_usb.h
+++ b/include/zephyr/pmci/mctp/mctp_usb.h
@@ -18,18 +18,37 @@
 #include <zephyr/sys/iterable_sections.h>
 #include <libmctp.h>
 
-/* MCTP class subclass options */
+/**
+ * @name MCTP class subclass options
+ *
+ * Values accepted as the subclass argument of MCTP_USB_DEFINE().
+ * @{
+ */
+/** Management controller */
 #define USBD_MCTP_SUBCLASS_MANAGEMENT_CONTROLLER   0
+/** Managed device endpoint */
 #define USBD_MCTP_SUBCLASS_MANAGED_DEVICE_ENDPOINT 0
+/** Host interface endpoint */
 #define USBD_MCTP_SUBCLASS_HOST_INTERFACE_ENDPOINT 1
+/** @} */
 
-/* MCTP class protocol options */
+/**
+ * @name MCTP class protocol options
+ *
+ * Values accepted as the protocol argument of MCTP_USB_DEFINE().
+ * @{
+ */
+/** MCTP protocol version 1.x */
 #define USBD_MCTP_PROTOCOL_1_X 1
+/** MCTP protocol version 2.x */
 #define USBD_MCTP_PROTOCOL_2_X 2
+/** @} */
 
+/** @cond INTERNAL_HIDDEN */
 /* Binding-specific defines, internal use */
 #define MCTP_USB_HEADER_SIZE       4
 #define MCTP_USB_MAX_PACKET_LENGTH 255
+/** @endcond INTERNAL_HIDDEN */
 
 /**
  * @brief An MCTP binding for Zephyr's USB device stack

--- a/include/zephyr/pmci/mctp/mctp_usb.h
+++ b/include/zephyr/pmci/mctp/mctp_usb.h
@@ -6,6 +6,12 @@
  *
  */
 
+/**
+ * @file
+ * @brief MCTP bus binding over the Zephyr USB device stack.
+ * @ingroup mctp
+ */
+
 #ifndef ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_USB_H_
 #define ZEPHYR_INCLUDE_PMCI_MCTP_MCTP_USB_H_
 


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/115409/docs/doxygen/html/group__mctp.html

Add the missing `@file` blocks to the MCTP headers.

MCTP had no Doxygen group, so none of its APIs were reachable from the
API index. Add an MCTP group under Device Management and attach theheaders to it. 

Document the USB class subclass and protocol constants, and hide the
binding-internal defines.

Documentation only, no functional change.