### PR TITLE
drivers: spi: nxp_lpspi: Don't print unintialized variable

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -69,7 +69,7 @@ static inline void lpspi_handle_rx_irq(const struct device *dev)
 
 	base->SR = LPSPI_SR_RDF_MASK;
 
-	LOG_DBG("RX FIFO: %d, RX BUF: %p", rx_fsr, ctx->rx_buf);
+	LOG_DBG("RX BUF: %p", ctx->rx_buf);
 
 	while ((rx_fsr = rx_fifo_cur_len(base)) > 0 && spi_context_rx_on(ctx)) {
 		words_read = lpspi_rx_buf_write_words(dev, rx_fsr);


### PR DESCRIPTION
Remove the unintialized variable from a DBG print to prevent compiler warnings when the log level is set to debug.