### PR TITLE
dt-bindings: gpio: add ST Zio connector definition

### DIFF
--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -8,6 +8,7 @@
 #include <st/f4/stm32f446Xe.dtsi>
 #include <st/f4/stm32f446z(c-e)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_zio_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/st/nucleo_f446ze/st_zio_connector.dtsi
+++ b/boards/st/nucleo_f446ze/st_zio_connector.dtsi
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Michele Vaccari
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-zio-header.h>
+
+/*
+ * ST Zio connector pin mapping for the NUCLEO-F446ZE board.
+ *
+ * Pinout taken from UM1974 (Rev 11), Table 18 "NUCLEO-F446ZE and
+ * NUCLEO-F722ZE pin assignments", covering the Zio connectors CN7, CN8, CN9
+ * and CN10.
+ *
+ * Only pins routed to an STM32 GPIO are listed below; power, ground and other
+ * dedicated pins (AREF, IOREF, NRST, 3V3, 5V, VIN, AVDD, AGND, NC) are
+ * omitted. PE2 is exposed on both CN9 pin 14 and CN10 pin 25 (only one
+ * function can be used at a time); both positions are mapped and annotated.
+ */
+
+/ {
+	st_zio_header: st-zio-header {
+		compatible = "st-zio-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_ZIO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_ZIO_CN7_1 0 &gpioc 6 0>,   /* D16 */
+			   <ST_ZIO_CN7_2 0 &gpiob 8 0>,   /* D15 */
+			   <ST_ZIO_CN7_3 0 &gpiob 15 0>,  /* D17 */
+			   <ST_ZIO_CN7_4 0 &gpiob 9 0>,   /* D14 */
+			   <ST_ZIO_CN7_5 0 &gpiob 13 0>,  /* D18 */
+			   <ST_ZIO_CN7_7 0 &gpiob 12 0>,  /* D19 */
+			   <ST_ZIO_CN7_9 0 &gpioa 15 0>,  /* D20 */
+			   <ST_ZIO_CN7_10 0 &gpioa 5 0>,  /* D13 */
+			   <ST_ZIO_CN7_11 0 &gpioc 7 0>,  /* D21 */
+			   <ST_ZIO_CN7_12 0 &gpioa 6 0>,  /* D12 */
+			   <ST_ZIO_CN7_13 0 &gpiob 5 0>,  /* D22 */
+			   <ST_ZIO_CN7_14 0 &gpioa 7 0>,  /* D11 */
+			   <ST_ZIO_CN7_15 0 &gpiob 3 0>,  /* D23 */
+			   <ST_ZIO_CN7_16 0 &gpiod 14 0>, /* D10 */
+			   <ST_ZIO_CN7_17 0 &gpioa 4 0>,  /* D24 */
+			   <ST_ZIO_CN7_18 0 &gpiod 15 0>, /* D9 */
+			   <ST_ZIO_CN7_19 0 &gpiob 4 0>,  /* D25 */
+			   <ST_ZIO_CN7_20 0 &gpiof 12 0>, /* D8 */
+			   <ST_ZIO_CN8_2 0 &gpioc 8 0>,   /* D43 */
+			   <ST_ZIO_CN8_4 0 &gpioc 9 0>,   /* D44 */
+			   <ST_ZIO_CN8_6 0 &gpioc 10 0>,  /* D45 */
+			   <ST_ZIO_CN8_8 0 &gpioc 11 0>,  /* D46 */
+			   <ST_ZIO_CN8_10 0 &gpioc 12 0>, /* D47 */
+			   <ST_ZIO_CN8_12 0 &gpiod 2 0>,  /* D48 */
+			   <ST_ZIO_CN8_14 0 &gpiog 2 0>,  /* D49 */
+			   <ST_ZIO_CN8_16 0 &gpiog 3 0>,  /* D50 */
+			   <ST_ZIO_CN9_1 0 &gpioa 3 0>,   /* A0 */
+			   <ST_ZIO_CN9_2 0 &gpiod 7 0>,   /* D51 */
+			   <ST_ZIO_CN9_3 0 &gpioc 0 0>,   /* A1 */
+			   <ST_ZIO_CN9_4 0 &gpiod 6 0>,   /* D52 */
+			   <ST_ZIO_CN9_5 0 &gpioc 3 0>,   /* A2 */
+			   <ST_ZIO_CN9_6 0 &gpiod 5 0>,   /* D53 */
+			   <ST_ZIO_CN9_7 0 &gpiof 3 0>,   /* A3 */
+			   <ST_ZIO_CN9_8 0 &gpiod 4 0>,   /* D54 */
+			   <ST_ZIO_CN9_9 0 &gpiof 5 0>,   /* A4 (default; PB9 via solder bridge) */
+			   <ST_ZIO_CN9_10 0 &gpiod 3 0>,  /* D55 */
+			   <ST_ZIO_CN9_11 0 &gpiof 10 0>, /* A5 (default; PB8 via solder bridge) */
+			   <ST_ZIO_CN9_14 0 &gpioe 2 0>,  /* D56, shared with CN10 pin 25 */
+			   <ST_ZIO_CN9_16 0 &gpioe 4 0>,  /* D57 */
+			   <ST_ZIO_CN9_17 0 &gpiof 2 0>,  /* D70 */
+			   <ST_ZIO_CN9_18 0 &gpioe 5 0>,  /* D58 */
+			   <ST_ZIO_CN9_19 0 &gpiof 1 0>,  /* D69 */
+			   <ST_ZIO_CN9_20 0 &gpioe 6 0>,  /* D59 */
+			   <ST_ZIO_CN9_21 0 &gpiof 0 0>,  /* D68 */
+			   <ST_ZIO_CN9_22 0 &gpioe 3 0>,  /* D60 */
+			   <ST_ZIO_CN9_24 0 &gpiof 8 0>,  /* D61 */
+			   <ST_ZIO_CN9_25 0 &gpiod 0 0>,  /* D67 */
+			   <ST_ZIO_CN9_26 0 &gpiof 7 0>,  /* D62 */
+			   <ST_ZIO_CN9_27 0 &gpiod 1 0>,  /* D66 */
+			   <ST_ZIO_CN9_28 0 &gpiof 9 0>,  /* D63 */
+			   <ST_ZIO_CN9_29 0 &gpiog 0 0>,  /* D65 */
+			   <ST_ZIO_CN9_30 0 &gpiog 1 0>,  /* D64 */
+			   <ST_ZIO_CN10_2 0 &gpiof 13 0>, /* D7 */
+			   <ST_ZIO_CN10_4 0 &gpioe 9 0>,  /* D6 */
+			   <ST_ZIO_CN10_6 0 &gpioe 11 0>, /* D5 */
+			   <ST_ZIO_CN10_7 0 &gpiob 1 0>,  /* A6 */
+			   <ST_ZIO_CN10_8 0 &gpiof 14 0>, /* D4 */
+			   <ST_ZIO_CN10_9 0 &gpioc 2 0>,  /* A7 */
+			   <ST_ZIO_CN10_10 0 &gpioe 13 0>, /* D3 */
+			   <ST_ZIO_CN10_11 0 &gpiof 4 0>,  /* A8 */
+			   <ST_ZIO_CN10_12 0 &gpiof 15 0>, /* D2 */
+			   <ST_ZIO_CN10_13 0 &gpiob 6 0>,  /* D26 */
+			   <ST_ZIO_CN10_14 0 &gpiog 14 0>, /* D1 */
+			   <ST_ZIO_CN10_15 0 &gpiob 2 0>,  /* D27 */
+			   <ST_ZIO_CN10_16 0 &gpiog 9 0>,  /* D0 */
+			   <ST_ZIO_CN10_18 0 &gpioe 8 0>,  /* D42 */
+			   <ST_ZIO_CN10_19 0 &gpiod 13 0>, /* D28 */
+			   <ST_ZIO_CN10_20 0 &gpioe 7 0>,  /* D41 */
+			   <ST_ZIO_CN10_21 0 &gpiod 12 0>, /* D29 */
+			   <ST_ZIO_CN10_23 0 &gpiod 11 0>, /* D30 */
+			   <ST_ZIO_CN10_24 0 &gpioe 10 0>, /* D40 */
+			   <ST_ZIO_CN10_25 0 &gpioe 2 0>,  /* D31, shared with CN9 pin 14 */
+			   <ST_ZIO_CN10_26 0 &gpioe 12 0>, /* D39 */
+			   <ST_ZIO_CN10_28 0 &gpioe 14 0>, /* D38 */
+			   <ST_ZIO_CN10_29 0 &gpioa 0 0>,  /* D32 */
+			   <ST_ZIO_CN10_30 0 &gpioe 15 0>, /* D37 */
+			   <ST_ZIO_CN10_31 0 &gpiob 0 0>,  /* D33 */
+			   <ST_ZIO_CN10_32 0 &gpiob 10 0>, /* D36 */
+			   <ST_ZIO_CN10_33 0 &gpioe 0 0>,  /* D34 */
+			   <ST_ZIO_CN10_34 0 &gpiob 11 0>; /* D35 */
+	};
+};

--- a/boards/st/nucleo_u575zi_q/doc/index.rst
+++ b/boards/st/nucleo_u575zi_q/doc/index.rst
@@ -15,6 +15,7 @@ board:
 - Two types of extension resources:
 
   - Arduino Uno V3 connectivity
+  - ST Zio connector (CN7, CN8, CN9, CN10) extending Arduino Uno V3
   - ST morpho extension pin headers for full access to all STM32 I/Os
 
 - On-board ST-LINK/V3E debugger/programmer

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -8,6 +8,7 @@
 #include <st/u5/stm32u575Xi.dtsi>
 #include <st/u5/stm32u575zitxq-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_zio_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/st/nucleo_u575zi_q/st_zio_connector.dtsi
+++ b/boards/st/nucleo_u575zi_q/st_zio_connector.dtsi
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Michele Vaccari
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-zio-header.h>
+
+/*
+ * ST Zio connector pin mapping for the NUCLEO-U575ZI-Q board.
+ *
+ * Pinout taken from UM2861 (Rev 10), "8.1 Zio connectors supporting ARDUINO
+ * Uno V3", Table 15 (CN7), Table 16 (CN8), Table 17 (CN9) and Table 18 (CN10).
+ *
+ * Only pins routed to an STM32 GPIO are listed below; power, ground and other
+ * dedicated pins (VREFP, IOREF, NRST, 3V3, 5V, VIN, AVDD, AGND, NC) are
+ * omitted. Some STM32 pins are exposed on two Zio positions through mutually
+ * exclusive alternate functions (e.g. SAI_D vs SPI_B on CN7, OCTOSPI vs motor
+ * control on CN10); such shared pins are annotated below.
+ */
+
+/ {
+	st_zio_header: st-zio-header {
+		compatible = "st-zio-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_ZIO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_ZIO_CN7_1 0 &gpioc 6 0>,   /* D16 */
+			   <ST_ZIO_CN7_2 0 &gpiob 8 0>,   /* D15 */
+			   <ST_ZIO_CN7_3 0 &gpiod 11 0>,  /* D17 */
+			   <ST_ZIO_CN7_4 0 &gpiob 9 0>,   /* D14 */
+			   <ST_ZIO_CN7_5 0 &gpiob 13 0>,  /* D18 */
+			   <ST_ZIO_CN7_7 0 &gpiod 12 0>,  /* D19 */
+			   <ST_ZIO_CN7_9 0 &gpioa 4 0>,   /* D20, shared with CN7 pin 17 */
+			   <ST_ZIO_CN7_10 0 &gpioa 5 0>,  /* D13 */
+			   <ST_ZIO_CN7_11 0 &gpiob 4 0>,  /* D21, shared with CN7 pin 19 */
+			   <ST_ZIO_CN7_12 0 &gpioa 6 0>,  /* D12 */
+			   <ST_ZIO_CN7_13 0 &gpiob 5 0>,  /* D22 */
+			   <ST_ZIO_CN7_14 0 &gpioa 7 0>,  /* D11 */
+			   <ST_ZIO_CN7_15 0 &gpiob 3 0>,  /* D23 */
+			   <ST_ZIO_CN7_16 0 &gpiod 14 0>, /* D10 */
+			   <ST_ZIO_CN7_17 0 &gpioa 4 0>,  /* D24, shared with CN7 pin 9 */
+			   <ST_ZIO_CN7_18 0 &gpiod 15 0>, /* D9 */
+			   <ST_ZIO_CN7_19 0 &gpiob 4 0>,  /* D25, shared with CN7 pin 11 */
+			   <ST_ZIO_CN7_20 0 &gpiof 12 0>, /* D8 */
+			   <ST_ZIO_CN8_2 0 &gpioc 8 0>,   /* D43 */
+			   <ST_ZIO_CN8_4 0 &gpioc 9 0>,   /* D44 */
+			   <ST_ZIO_CN8_6 0 &gpioc 10 0>,  /* D45 */
+			   <ST_ZIO_CN8_8 0 &gpioc 11 0>,  /* D46 */
+			   <ST_ZIO_CN8_10 0 &gpioc 12 0>, /* D47 */
+			   <ST_ZIO_CN8_12 0 &gpiod 2 0>,  /* D48 */
+			   <ST_ZIO_CN8_14 0 &gpiof 3 0>,  /* D49 */
+			   <ST_ZIO_CN8_16 0 &gpiof 5 0>,  /* D50 */
+			   <ST_ZIO_CN9_1 0 &gpioa 3 0>,   /* A0 */
+			   <ST_ZIO_CN9_2 0 &gpiod 7 0>,   /* D51 */
+			   <ST_ZIO_CN9_3 0 &gpioa 2 0>,   /* A1, shared with CN10 pin 13 */
+			   <ST_ZIO_CN9_4 0 &gpiod 6 0>,   /* D52 */
+			   <ST_ZIO_CN9_5 0 &gpioc 3 0>,   /* A2 */
+			   <ST_ZIO_CN9_6 0 &gpiod 5 0>,   /* D53 */
+			   <ST_ZIO_CN9_7 0 &gpiob 0 0>,   /* A3, shared with CN10 pin 21 */
+			   <ST_ZIO_CN9_8 0 &gpiod 4 0>,   /* D54 */
+			   <ST_ZIO_CN9_9 0 &gpioc 1 0>,   /* A4 */
+			   <ST_ZIO_CN9_10 0 &gpiod 3 0>,  /* D55 */
+			   <ST_ZIO_CN9_11 0 &gpioc 0 0>,  /* A5 */
+			   <ST_ZIO_CN9_13 0 &gpiob 2 0>,  /* D72 */
+			   <ST_ZIO_CN9_14 0 &gpioe 2 0>,  /* D56 */
+			   <ST_ZIO_CN9_15 0 &gpiob 6 0>,  /* D71 */
+			   <ST_ZIO_CN9_16 0 &gpioe 4 0>,  /* D57 */
+			   <ST_ZIO_CN9_17 0 &gpiof 2 0>,  /* D70 */
+			   <ST_ZIO_CN9_18 0 &gpioe 5 0>,  /* D58 */
+			   <ST_ZIO_CN9_19 0 &gpiof 1 0>,  /* D69 */
+			   <ST_ZIO_CN9_20 0 &gpioe 6 0>,  /* D59 */
+			   <ST_ZIO_CN9_21 0 &gpiof 0 0>,  /* D68 */
+			   <ST_ZIO_CN9_22 0 &gpioe 3 0>,  /* D60 */
+			   <ST_ZIO_CN9_24 0 &gpiof 8 0>,  /* D61 */
+			   <ST_ZIO_CN9_25 0 &gpiod 0 0>,  /* D67 */
+			   <ST_ZIO_CN9_26 0 &gpiof 7 0>,  /* D62 */
+			   <ST_ZIO_CN9_27 0 &gpiod 1 0>,  /* D66 */
+			   <ST_ZIO_CN9_28 0 &gpiof 9 0>,  /* D63 */
+			   <ST_ZIO_CN9_29 0 &gpiog 0 0>,  /* D65 */
+			   <ST_ZIO_CN9_30 0 &gpiog 1 0>,  /* D64 */
+			   <ST_ZIO_CN10_2 0 &gpiof 13 0>, /* D7 */
+			   <ST_ZIO_CN10_4 0 &gpioe 9 0>,  /* D6 */
+			   <ST_ZIO_CN10_6 0 &gpioe 11 0>, /* D5 */
+			   <ST_ZIO_CN10_7 0 &gpiob 1 0>,  /* A6 */
+			   <ST_ZIO_CN10_8 0 &gpiof 14 0>, /* D4 */
+			   <ST_ZIO_CN10_9 0 &gpioc 2 0>,  /* A7 */
+			   <ST_ZIO_CN10_10 0 &gpioe 13 0>, /* D3 */
+			   <ST_ZIO_CN10_11 0 &gpioa 1 0>,  /* A8 */
+			   <ST_ZIO_CN10_12 0 &gpiof 15 0>, /* D2 */
+			   <ST_ZIO_CN10_13 0 &gpioa 2 0>,  /* D26, shared with CN9 pin 3 */
+			   <ST_ZIO_CN10_14 0 &gpiog 7 0>,  /* D1 */
+			   <ST_ZIO_CN10_15 0 &gpiob 10 0>, /* D27, shared with CN10 pin 32 */
+			   <ST_ZIO_CN10_16 0 &gpiog 8 0>,  /* D0 */
+			   <ST_ZIO_CN10_18 0 &gpioe 8 0>,  /* D42 */
+			   <ST_ZIO_CN10_19 0 &gpioe 15 0>, /* D28, shared with CN10 pin 30 */
+			   <ST_ZIO_CN10_20 0 &gpioe 7 0>,  /* D41 */
+			   <ST_ZIO_CN10_21 0 &gpiob 0 0>,  /* D29, shared with CN9 pin 7 */
+			   <ST_ZIO_CN10_23 0 &gpioe 12 0>, /* D30, shared with CN10 pin 26 */
+			   <ST_ZIO_CN10_24 0 &gpioe 10 0>, /* D40 */
+			   <ST_ZIO_CN10_25 0 &gpioe 14 0>, /* D31, shared with CN10 pin 28 */
+			   <ST_ZIO_CN10_26 0 &gpioe 12 0>, /* D39, shared with CN10 pin 23 */
+			   <ST_ZIO_CN10_28 0 &gpioe 14 0>, /* D38, shared with CN10 pin 25 */
+			   <ST_ZIO_CN10_29 0 &gpioa 0 0>,  /* D32 */
+			   <ST_ZIO_CN10_30 0 &gpioe 15 0>, /* D37, shared with CN10 pin 19 */
+			   <ST_ZIO_CN10_31 0 &gpioa 8 0>,  /* D33 */
+			   <ST_ZIO_CN10_32 0 &gpiob 10 0>, /* D36, shared with CN10 pin 15 */
+			   <ST_ZIO_CN10_33 0 &gpioe 0 0>,  /* D34 */
+			   <ST_ZIO_CN10_34 0 &gpiob 11 0>; /* D35 */
+	};
+};
+
+/*
+ * ST Zio connector alternate node labels.
+ *
+ * OCTOSPI1 (OCTOSPIM port 1) is routed to the Zio connector (D26-D31):
+ * NCS=PA2 (D26), CLK=PB10 (D27), IO0=PE12 (D30), IO1=PB0 (D29),
+ * IO2=PE14 (D31), IO3=PE15 (D28).
+ */
+st_zio_qspi: &octospi1 {};

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -268,6 +268,19 @@ Relevant devicetree node labels:
 - ``st_morpho_flash_spi``
 
 
+ST Zio
+------
+
+STM32 Nucleo-144 development boards from ST Microelectronics expose the ST Zio
+connector, an extension of the Arduino Uno V3 connector that gives access to
+more of the STM32 I/Os through four headers (CN7, CN8, CN9 and CN10).
+
+Relevant devicetree node labels:
+
+- ``st_zio_header``  See :dtcompatible:`st-zio-header` for details on GPIO pin definitions
+  and includes for use in devicetree files.
+
+
 STMod+
 ------
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -352,6 +352,8 @@ New Drivers
 
   * Diodes/Pericom PI4IOE5V6408 8-bit I2C-bus I/O expander
     (:dtcompatible:`diodes,pi4ioe5v6408`).
+  * ST Zio connector for STM32 Nucleo-144 boards
+    (:dtcompatible:`st-zio-header`).
 
 * Input
 

--- a/dts/bindings/gpio/st-zio-header.yaml
+++ b/dts/bindings/gpio/st-zio-header.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Michele Vaccari
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  GPIO pins exposed on ST Zio connector.
+
+  The ST Zio connector extends the ARDUINO Uno V3 connectivity. It consists in
+  four female headers (CN7, CN8, CN9 and CN10) available on STM32 Nucleo-144
+  boards. They can be used to connect ARDUINO Uno V3 compatible shields, while
+  exposing additional STM32 signals compared to the ARDUINO Uno V3 connector.
+
+  Use ST_ZIO_* constants in <zephyr/dt-bindings/gpio/st-zio-header.h>
+  to refer to specific pins using convenient constant names.
+
+compatible: "st-zio-header"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/include/zephyr/dt-bindings/gpio/st-zio-header.h
+++ b/include/zephyr/dt-bindings/gpio/st-zio-header.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Michele Vaccari
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ST Zio header pin constants
+ * @ingroup st-zio-header
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ST_ZIO_HEADER_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ST_ZIO_HEADER_H_
+
+/**
+ * @defgroup st-zio-header ST Zio header
+ * @brief Constants for pins exposed on ST Zio header
+ * @ingroup devicetree-gpio-pin-headers
+ * @{
+ */
+
+/** ST Zio pin mask (0...99). */
+#define ST_ZIO_PIN_MASK 0xFF
+
+/* CN7 connector (upper right) */
+#define ST_ZIO_CN7_1  0  /**< CN7 pin 1 */
+#define ST_ZIO_CN7_2  1  /**< CN7 pin 2 */
+#define ST_ZIO_CN7_3  2  /**< CN7 pin 3 */
+#define ST_ZIO_CN7_4  3  /**< CN7 pin 4 */
+#define ST_ZIO_CN7_5  4  /**< CN7 pin 5 */
+#define ST_ZIO_CN7_6  5  /**< CN7 pin 6 */
+#define ST_ZIO_CN7_7  6  /**< CN7 pin 7 */
+#define ST_ZIO_CN7_8  7  /**< CN7 pin 8 */
+#define ST_ZIO_CN7_9  8  /**< CN7 pin 9 */
+#define ST_ZIO_CN7_10 9  /**< CN7 pin 10 */
+#define ST_ZIO_CN7_11 10 /**< CN7 pin 11 */
+#define ST_ZIO_CN7_12 11 /**< CN7 pin 12 */
+#define ST_ZIO_CN7_13 12 /**< CN7 pin 13 */
+#define ST_ZIO_CN7_14 13 /**< CN7 pin 14 */
+#define ST_ZIO_CN7_15 14 /**< CN7 pin 15 */
+#define ST_ZIO_CN7_16 15 /**< CN7 pin 16 */
+#define ST_ZIO_CN7_17 16 /**< CN7 pin 17 */
+#define ST_ZIO_CN7_18 17 /**< CN7 pin 18 */
+#define ST_ZIO_CN7_19 18 /**< CN7 pin 19 */
+#define ST_ZIO_CN7_20 19 /**< CN7 pin 20 */
+
+/* CN8 connector (upper left) */
+#define ST_ZIO_CN8_1  20 /**< CN8 pin 1 */
+#define ST_ZIO_CN8_2  21 /**< CN8 pin 2 */
+#define ST_ZIO_CN8_3  22 /**< CN8 pin 3 */
+#define ST_ZIO_CN8_4  23 /**< CN8 pin 4 */
+#define ST_ZIO_CN8_5  24 /**< CN8 pin 5 */
+#define ST_ZIO_CN8_6  25 /**< CN8 pin 6 */
+#define ST_ZIO_CN8_7  26 /**< CN8 pin 7 */
+#define ST_ZIO_CN8_8  27 /**< CN8 pin 8 */
+#define ST_ZIO_CN8_9  28 /**< CN8 pin 9 */
+#define ST_ZIO_CN8_10 29 /**< CN8 pin 10 */
+#define ST_ZIO_CN8_11 30 /**< CN8 pin 11 */
+#define ST_ZIO_CN8_12 31 /**< CN8 pin 12 */
+#define ST_ZIO_CN8_13 32 /**< CN8 pin 13 */
+#define ST_ZIO_CN8_14 33 /**< CN8 pin 14 */
+#define ST_ZIO_CN8_15 34 /**< CN8 pin 15 */
+#define ST_ZIO_CN8_16 35 /**< CN8 pin 16 */
+
+/* CN9 connector (lower left) */
+#define ST_ZIO_CN9_1  36 /**< CN9 pin 1 */
+#define ST_ZIO_CN9_2  37 /**< CN9 pin 2 */
+#define ST_ZIO_CN9_3  38 /**< CN9 pin 3 */
+#define ST_ZIO_CN9_4  39 /**< CN9 pin 4 */
+#define ST_ZIO_CN9_5  40 /**< CN9 pin 5 */
+#define ST_ZIO_CN9_6  41 /**< CN9 pin 6 */
+#define ST_ZIO_CN9_7  42 /**< CN9 pin 7 */
+#define ST_ZIO_CN9_8  43 /**< CN9 pin 8 */
+#define ST_ZIO_CN9_9  44 /**< CN9 pin 9 */
+#define ST_ZIO_CN9_10 45 /**< CN9 pin 10 */
+#define ST_ZIO_CN9_11 46 /**< CN9 pin 11 */
+#define ST_ZIO_CN9_12 47 /**< CN9 pin 12 */
+#define ST_ZIO_CN9_13 48 /**< CN9 pin 13 */
+#define ST_ZIO_CN9_14 49 /**< CN9 pin 14 */
+#define ST_ZIO_CN9_15 50 /**< CN9 pin 15 */
+#define ST_ZIO_CN9_16 51 /**< CN9 pin 16 */
+#define ST_ZIO_CN9_17 52 /**< CN9 pin 17 */
+#define ST_ZIO_CN9_18 53 /**< CN9 pin 18 */
+#define ST_ZIO_CN9_19 54 /**< CN9 pin 19 */
+#define ST_ZIO_CN9_20 55 /**< CN9 pin 20 */
+#define ST_ZIO_CN9_21 56 /**< CN9 pin 21 */
+#define ST_ZIO_CN9_22 57 /**< CN9 pin 22 */
+#define ST_ZIO_CN9_23 58 /**< CN9 pin 23 */
+#define ST_ZIO_CN9_24 59 /**< CN9 pin 24 */
+#define ST_ZIO_CN9_25 60 /**< CN9 pin 25 */
+#define ST_ZIO_CN9_26 61 /**< CN9 pin 26 */
+#define ST_ZIO_CN9_27 62 /**< CN9 pin 27 */
+#define ST_ZIO_CN9_28 63 /**< CN9 pin 28 */
+#define ST_ZIO_CN9_29 64 /**< CN9 pin 29 */
+#define ST_ZIO_CN9_30 65 /**< CN9 pin 30 */
+
+/* CN10 connector (lower right) */
+#define ST_ZIO_CN10_1  66 /**< CN10 pin 1 */
+#define ST_ZIO_CN10_2  67 /**< CN10 pin 2 */
+#define ST_ZIO_CN10_3  68 /**< CN10 pin 3 */
+#define ST_ZIO_CN10_4  69 /**< CN10 pin 4 */
+#define ST_ZIO_CN10_5  70 /**< CN10 pin 5 */
+#define ST_ZIO_CN10_6  71 /**< CN10 pin 6 */
+#define ST_ZIO_CN10_7  72 /**< CN10 pin 7 */
+#define ST_ZIO_CN10_8  73 /**< CN10 pin 8 */
+#define ST_ZIO_CN10_9  74 /**< CN10 pin 9 */
+#define ST_ZIO_CN10_10 75 /**< CN10 pin 10 */
+#define ST_ZIO_CN10_11 76 /**< CN10 pin 11 */
+#define ST_ZIO_CN10_12 77 /**< CN10 pin 12 */
+#define ST_ZIO_CN10_13 78 /**< CN10 pin 13 */
+#define ST_ZIO_CN10_14 79 /**< CN10 pin 14 */
+#define ST_ZIO_CN10_15 80 /**< CN10 pin 15 */
+#define ST_ZIO_CN10_16 81 /**< CN10 pin 16 */
+#define ST_ZIO_CN10_17 82 /**< CN10 pin 17 */
+#define ST_ZIO_CN10_18 83 /**< CN10 pin 18 */
+#define ST_ZIO_CN10_19 84 /**< CN10 pin 19 */
+#define ST_ZIO_CN10_20 85 /**< CN10 pin 20 */
+#define ST_ZIO_CN10_21 86 /**< CN10 pin 21 */
+#define ST_ZIO_CN10_22 87 /**< CN10 pin 22 */
+#define ST_ZIO_CN10_23 88 /**< CN10 pin 23 */
+#define ST_ZIO_CN10_24 89 /**< CN10 pin 24 */
+#define ST_ZIO_CN10_25 90 /**< CN10 pin 25 */
+#define ST_ZIO_CN10_26 91 /**< CN10 pin 26 */
+#define ST_ZIO_CN10_27 92 /**< CN10 pin 27 */
+#define ST_ZIO_CN10_28 93 /**< CN10 pin 28 */
+#define ST_ZIO_CN10_29 94 /**< CN10 pin 29 */
+#define ST_ZIO_CN10_30 95 /**< CN10 pin 30 */
+#define ST_ZIO_CN10_31 96 /**< CN10 pin 31 */
+#define ST_ZIO_CN10_32 97 /**< CN10 pin 32 */
+#define ST_ZIO_CN10_33 98 /**< CN10 pin 33 */
+#define ST_ZIO_CN10_34 99 /**< CN10 pin 34 */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ST_ZIO_HEADER_H_ */


### PR DESCRIPTION
See the description in section **7.14 ST Zio connectors** of document [UM1974](https://www.st.com/content/ccc/resource/technical/document/user_manual/group0/26/49/90/2e/33/0d/4a/da/DM00244518/files/DM00244518.pdf/jcr:content/translations/en.DM00244518.pdf)

I plan to add support for the [X-NUCLEO-GFX02Z1](https://www.st.com/en/evaluation-tools/x-nucleo-gfx02z1.html) shield on two boards, but while implementing it I realized it would be more portable to first add the definition of this connector.

From the [STM32 Nucleo-144 boards data brief](https://www.st.com/resource/en/data_brief/nucleo-u575zi-q.pdf) you can find the proper user manual for the Zio connector pinout as follows:
- [UM2861](https://www.st.com/resource/en/user_manual/dm00789949.pdf) for [NUCLEO-U575ZI-Q](https://www.st.com/en/evaluation-tools/nucleo-u575zi-q.html)
- [UM1974](https://www.st.com/resource/en/user_manual/dm00244518.pdf) for [NUCLEO-F446ZE](https://www.st.com/en/evaluation-tools/nucleo-f446ze.html)