### PR TITLE
tests: posix: add min_ram for dynamic_stack test

### DIFF
--- a/tests/subsys/portability/posix/threads_base/tests.yaml
+++ b/tests/subsys/portability/posix/threads_base/tests.yaml
@@ -37,6 +37,7 @@ tests:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
   posix.threads_base.dynamic_stack:
+    min_ram: 128
     extra_configs:
       - CONFIG_DYNAMIC_THREAD=y
       - CONFIG_THREAD_STACK_INFO=y


### PR DESCRIPTION
The `posix.threads_base.dynamic_stack` test scenario requires at least 16 KB for `CONFIG_HEAP_MEM_POOL_SIZE` and 16 KB for `CONFIG_TEST_EXTRA_STACK_SIZE`. When combined with OS overhead, kernel stacks, BSS, and data, the memory footprint exceeds the default 64 KB SRAM limit typical of constrained boards (e.g., `qemu_cortex_m3`).

This commit sets `min_ram: 128` specifically for the `dynamic_stack` scenario to correctly skip the test on boards lacking sufficient memory, preventing spurious RAM overflow linkage errors during automated testing.

Fixes #114095