### PR TITLE
subsys: net: lib: wifi_credentials: Add feedback on errors

### DIFF
--- a/subsys/net/lib/wifi_credentials/wifi_credentials.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials.c
@@ -340,6 +340,7 @@ int wifi_credentials_delete_by_ssid(const char *ssid, size_t ssid_len)
 	idx = lookup_idx(ssid, ssid_len);
 	if (idx == -1) {
 		LOG_DBG("WiFi credentials entry was not found");
+		ret = -ENOENT;
 		goto exit;
 	}
 

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -142,6 +142,7 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 	size_t offset = 0;
 	long channel;
 	long mfp = WIFI_MFP_OPTIONAL;
+	int ret;
 
 	while ((opt = sys_getopt_long(argc, argv, "s:p:k:w:b:c:m:t:a:K:h",
 				      long_options, &opt_index)) != -1) {
@@ -302,7 +303,6 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	struct net_if *iface = net_if_get_wifi_sta();
-	int ret;
 
 	/* Load the enterprise credentials if needed */
 	if (creds.header.type == WIFI_SECURITY_TYPE_EAP_TLS ||
@@ -318,7 +318,13 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 	}
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE */
 
-	return wifi_credentials_set_personal_struct(&creds);
+	ret = wifi_credentials_set_personal_struct(&creds);
+
+	if (ret != 0) {
+		shell_error(sh, "Failed to add network credentials, err: %d", ret);
+	}
+
+	return ret;
 }
 
 static int cmd_delete_network(const struct shell *sh, size_t argc, char *argv[])
@@ -340,7 +346,15 @@ static int cmd_delete_network(const struct shell *sh, size_t argc, char *argv[])
 	wifi_clear_enterprise_credentials();
 #endif /* CONFIG_WIFI_SHELL_RUNTIME_CERTIFICATES */
 
-	return wifi_credentials_delete_by_ssid(argv[1], strlen(argv[1]));
+	int ret = wifi_credentials_delete_by_ssid(argv[1], strlen(argv[1]));
+
+	if (ret == -ENOENT) {
+		shell_error(sh, "No matching network with SSID: \"%s\" found", argv[1]);
+	} else if (ret != 0) {
+		shell_error(sh, "Failed to delete network credentials, err: %d", ret);
+	}
+
+	return ret;
 }
 
 static int cmd_list_networks(const struct shell *sh, size_t argc, char *argv[])


### PR DESCRIPTION
Add feedback when Wi-Fi shell add/delete commands fail.

Example on deleting creds for an unknown SSID, before:
```
uart:~$ wifi cred delete nonExistingSSID                                                                                                                  
        Deleting network ssid: "nonExistingSSID", ssid_len: 15               
```

```
uart:~$ wifi cred delete nonExistingSSID                                                                                                                  
        Deleting network ssid: "nonExistingSSID", ssid_len: 15               
No matching network with ssid: "nonExistingSSID" found    
```