### PR TITLE
shell: backends: uart: Fix asynchronous API

### DIFF
--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -512,7 +512,8 @@ static int async_read(struct shell_uart_async *sh_uart,
 	buf_available = uart_async_rx_data_consume(async_rx, blen);
 #endif
 
-	if (!buf_available) {
+	/* Return if no free buffers available or UART is not waiting for new RX buffer. */
+	if (!buf_available || ((sh_uart->pending_rx_req == 0) && sh_uart->rx_enabled)) {
 		return 0;
 	}
 


### PR DESCRIPTION
Fix regression introduced by 069d3a76521f. async_read() function was allocating new buffer even when UART was not expecting it. Buffer pool was quickly drained and shell was unresponsive. Added additional check to attempt to allocate new a new buffer only if UART is waiting for new buffer (UART is disabled or there is unhandled RX buffer request).

Fixes #115180.