### PR TITLE
net: lib: tls_credentials: Select PSA_CRYPTO in the PS backend

### DIFF
--- a/subsys/net/lib/tls_credentials/Kconfig
+++ b/subsys/net/lib/tls_credentials/Kconfig
@@ -28,6 +28,7 @@ config TLS_CREDENTIALS_BACKEND_VOLATILE
 config TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE
 	bool "TLS credentials management protected storage backend"
 	depends on BUILD_WITH_TFM || SECURE_STORAGE
+	select PSA_CRYPTO
 	select PSA_WANT_ALG_SHA_256
 	# This backend builds storage UIDs that use the full 64-bit range
 	# (see tls_credential_get_uid()). TF-M's Protected Storage supports that


### PR DESCRIPTION
PSA_WANT_ALG_SHA_256 is defined inside an "if PSA_CRYPTO" block, so selecting it without enabling PSA_CRYPTO aborts Kconfig on TF-M targets, where SECURE_STORAGE (and thus its implicit PSA_CRYPTO select) is unavailable.

Fixes #115404