### PR TITLE
maintainers: add VitSolcikNXP as hal_nxp maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6906,6 +6906,7 @@ West:
   maintainers:
     - mmahadevan108
     - zejiang0jason
+    - VitSolcikNXP
   collaborators:
     - manuargue
     - PetervdPerk-NXP


### PR DESCRIPTION
Add VitSolcikNXP to the maintainer list of the hal_nxp west project entry.