### PR TITLE
Bluetooth: MPL: Implement playing speed

### DIFF
--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -2081,10 +2081,66 @@ static int8_t get_playback_speed(void)
 	return media_player.playback_speed_param;
 }
 
+static int8_t get_supported_playback_speed(int8_t speed)
+{
+	if (speed > media_player.playback_speed_param) {
+		/* MCS spec section 3.8.1 states:
+		 * If the value written is not supported and is greater than the existing Playback
+		 * Speed characteristic, then the server should set the Playback Speed
+		 * characteristic to the next higher supported playback speed
+		 */
+		if (speed > MEDIA_PROXY_PLAYBACK_SPEED_UNITY) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE;
+		} else if (speed > MEDIA_PROXY_PLAYBACK_SPEED_HALF) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_UNITY;
+		} else if (speed > MEDIA_PROXY_PLAYBACK_SPEED_QUARTER) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_HALF;
+		} else {
+			return MEDIA_PROXY_PLAYBACK_SPEED_QUARTER;
+		}
+	} else if (speed < media_player.playback_speed_param) {
+		/* MCS spec section 3.8.1 states:
+		 * If the value written is not supported and is less than the existing Playback
+		 * Speed characteristic, then the server should set the Playback Speed
+		 * characteristic to the next lower supported playback speed
+		 */
+		if (speed < MEDIA_PROXY_PLAYBACK_SPEED_HALF) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_QUARTER;
+		} else if (speed < MEDIA_PROXY_PLAYBACK_SPEED_UNITY) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_HALF;
+		} else if (speed < MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_UNITY;
+		} else {
+			return MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE;
+		}
+	} else {
+		return speed;
+	}
+}
+
 static void set_playback_speed(int8_t speed)
 {
 	/* Set new speed parameter and notify, if different from current */
 	if (speed != media_player.playback_speed_param) {
+		/* This MPL only supports MEDIA_PROXY_PLAYBACK_SPEED_QUARTER,
+		 * MEDIA_PROXY_PLAYBACK_SPEED_HALF, MEDIA_PROXY_PLAYBACK_SPEED_UNITY and
+		 * MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE.
+		 * For unsupported values the MCS specification states:
+		 *
+		 * MCS spec section 3.8.1 states:
+		 * If the server does not support the value written, the server shall set
+		 * the Playback Speed characteristic to a supported value.
+		 */
+		int8_t supported_playback_speed = get_supported_playback_speed(speed);
+
+		if (speed != supported_playback_speed) {
+			if (speed != supported_playback_speed) {
+				LOG_DBG("Changed speed from %d to %d", speed,
+					supported_playback_speed);
+			}
+			speed = supported_playback_speed;
+		}
+
 		media_player.playback_speed_param = speed;
 		media_proxy_pl_playback_speed_cb(media_player.playback_speed_param);
 	}
@@ -2330,6 +2386,23 @@ static uint8_t get_content_ctrl_id(void)
 	return media_player.content_ctrl_id;
 }
 
+static float get_playing_speed(void)
+{
+	switch (media_player.playback_speed_param) {
+	case MEDIA_PROXY_PLAYBACK_SPEED_QUARTER:
+		return 0.25F;
+	case MEDIA_PROXY_PLAYBACK_SPEED_HALF:
+		return 0.50F;
+	case MEDIA_PROXY_PLAYBACK_SPEED_UNITY:
+		return 1.00F;
+	case MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE:
+		return 2.00F;
+	default:
+		LOG_WRN("Unexpected playback_speed_param: %d", media_player.playback_speed_param);
+		return 1.00F;
+	}
+}
+
 static void pos_work_cb(struct k_work *work)
 {
 	const int32_t pos_diff_cs = TRACK_POS_WORK_DELAY_MS / 10; /* position is in centiseconds*/
@@ -2340,7 +2413,7 @@ static void pos_work_cb(struct k_work *work)
 		/* When seeking, apply the seeking speed factor */
 		set_relative_track_position(pos_diff_cs * media_player.seeking_speed_factor);
 	} else if (media_player.state == MEDIA_PROXY_STATE_PLAYING) {
-		set_relative_track_position(pos_diff_cs);
+		set_relative_track_position((int32_t)(pos_diff_cs * get_playing_speed()));
 	}
 
 	if (media_player.track_pos == media_player.group->track->duration) {

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -2081,11 +2081,63 @@ static int8_t get_playback_speed(void)
 	return media_player.playback_speed_param;
 }
 
+static int8_t get_supported_playback_speed(int8_t speed)
+{
+	if (speed > media_player.playback_speed_param) {
+		/* MCS spec section 3.8.1 states:
+		 * If the value written is not supported and is greater than the existing Playback
+		 * Speed characteristic, then the server should set the Playback Speed
+		 * characteristic to the next higher supported playback speed
+		 */
+		if (speed > MEDIA_PROXY_PLAYBACK_SPEED_UNITY) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE;
+		} else if (speed > MEDIA_PROXY_PLAYBACK_SPEED_HALF) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_UNITY;
+		} else if (speed > MEDIA_PROXY_PLAYBACK_SPEED_QUARTER) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_HALF;
+		} else {
+			return MEDIA_PROXY_PLAYBACK_SPEED_QUARTER;
+		}
+	} else if (speed < media_player.playback_speed_param) {
+		/* MCS spec section 3.8.1 states:
+		 * If the value written is not supported and is less than the existing Playback
+		 * Speed characteristic, then the server should set the Playback Speed
+		 * characteristic to the next lower supported playback speed
+		 */
+		if (speed < MEDIA_PROXY_PLAYBACK_SPEED_HALF) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_QUARTER;
+		} else if (speed < MEDIA_PROXY_PLAYBACK_SPEED_UNITY) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_HALF;
+		} else if (speed < MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE) {
+			return MEDIA_PROXY_PLAYBACK_SPEED_UNITY;
+		} else {
+			return MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE;
+		}
+	} else {
+		return speed;
+	}
+}
+
 static void set_playback_speed(int8_t speed)
 {
 	/* Set new speed parameter and notify, if different from current */
 	if (speed != media_player.playback_speed_param) {
-		media_player.playback_speed_param = speed;
+		/* This MPL only supports MEDIA_PROXY_PLAYBACK_SPEED_QUARTER,
+		 * MEDIA_PROXY_PLAYBACK_SPEED_HALF, MEDIA_PROXY_PLAYBACK_SPEED_UNITY and
+		 * MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE.
+		 * For unsupported values the MCS specification states:
+		 *
+		 * MCS spec section 3.8.1 states:
+		 * If the server does not support the value written, the server shall set
+		 * the Playback Speed characteristic to a supported value.
+		 */
+		int8_t supported_playback_speed = get_supported_playback_speed(speed);
+
+		if (speed != supported_playback_speed) {
+			LOG_DBG("Changed speed from %d to %d", speed, supported_playback_speed);
+		}
+
+		media_player.playback_speed_param = supported_playback_speed;
 		media_proxy_pl_playback_speed_cb(media_player.playback_speed_param);
 	}
 }
@@ -2330,18 +2382,49 @@ static uint8_t get_content_ctrl_id(void)
 	return media_player.content_ctrl_id;
 }
 
-static void pos_work_cb(struct k_work *work)
+/** Calculates the new relative position depending on the sate and seeking/playing speed factor
+ *
+ * @return New relative postion in centiseconds (may be negative)
+ */
+static int32_t get_pos_diff_cs(void)
 {
-	const int32_t pos_diff_cs = TRACK_POS_WORK_DELAY_MS / 10; /* position is in centiseconds*/
-
-	ARG_UNUSED(work);
+	int32_t pos_diff_ms = TRACK_POS_WORK_DELAY_MS;
 
 	if (media_player.state == MEDIA_PROXY_STATE_SEEKING) {
 		/* When seeking, apply the seeking speed factor */
-		set_relative_track_position(pos_diff_cs * media_player.seeking_speed_factor);
+		pos_diff_ms *= media_player.seeking_speed_factor;
 	} else if (media_player.state == MEDIA_PROXY_STATE_PLAYING) {
-		set_relative_track_position(pos_diff_cs);
+		/* When playing, apply the playing speed */
+		switch (media_player.playback_speed_param) {
+		case MEDIA_PROXY_PLAYBACK_SPEED_QUARTER:
+			pos_diff_ms /= 4;
+			break;
+		case MEDIA_PROXY_PLAYBACK_SPEED_HALF:
+			pos_diff_ms /= 2;
+			break;
+		case MEDIA_PROXY_PLAYBACK_SPEED_UNITY:
+			/* no-op */
+			break;
+		case MEDIA_PROXY_PLAYBACK_SPEED_DOUBLE:
+			pos_diff_ms *= 2;
+			break;
+		default:
+			LOG_WRN("Unexpected playback_speed_param: %d",
+				media_player.playback_speed_param);
+			break;
+		}
+	} else {
+		LOG_ERR("Unexpected media_player.state: %u", media_player.state);
 	}
+
+	return pos_diff_ms / 10; /* position is in centiseconds*/
+}
+
+static void pos_work_cb(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	set_relative_track_position(get_pos_diff_cs());
 
 	if (media_player.track_pos == media_player.group->track->duration) {
 		/* Go to next track */

--- a/tests/bsim/bluetooth/audio/src/mcc_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcc_test.c
@@ -1833,9 +1833,6 @@ static void test_set_playback_speed(int8_t pb_speed)
 	}
 
 	WAIT_FOR_FLAG(playback_speed_set);
-	if (g_pb_speed != pb_speed) {
-		FAIL("Playback speed failed: Incorrect playback speed\n");
-	}
 
 	LOG_INF("Playback speed set succeeded");
 }

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -1409,9 +1409,6 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	WAIT_FOR_FLAG(playback_speed);
-	if (g_pb_speed != pb_speed) {
-		FAIL("Playback speed failed: Incorrect playback speed\n");
-	}
 	LOG_INF("Playback speed set succeeded");
 
 	/* Read seeking speed *************************************/


### PR DESCRIPTION
The playback_speed_param value was not used to correct adjust the position while in the playing or state.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/111587