### PR TITLE
net: Use net_sockaddr_storage for address storage

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_net.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_net.c
@@ -1165,14 +1165,17 @@ int net_get_if_addr(struct net_ip_config *addr, void *intrfc_handle)
 		int i;
 
 		for (i = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS; i++) {
-			if (ctx->servers[i].dns_server.sa_family == AF_INET) {
+			struct net_sockaddr *server_addr =
+				net_sad(&ctx->servers[i].dns_server_addr);
+
+			if (ctx->servers[i].dns_server_addr.ss_family == AF_INET) {
 				if (i == 0) {
-					addr->ipv4.dns1 = net_sin(&ctx->servers[i].dns_server)
-								  ->sin_addr.s_addr;
+					addr->ipv4.dns1 =
+						net_sin(server_addr)->sin_addr.s_addr;
 				}
 				if (i == 1) {
-					addr->ipv4.dns2 = net_sin(&ctx->servers[i].dns_server)
-								  ->sin_addr.s_addr;
+					addr->ipv4.dns2 =
+						net_sin(server_addr)->sin_addr.s_addr;
 				}
 			}
 		}

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -419,7 +419,13 @@ struct coap_transmission_parameters {
  * @brief Represents a request awaiting for an acknowledgment (ACK).
  */
 struct coap_pending {
-	struct net_sockaddr addr; /**< Remote address */
+	/** CoAP remote address storage */
+	union {
+/** @cond INTERNAL_HIDDEN */
+		struct net_sockaddr addr; /**< Remote address. Use the addr_storage instead. */
+/** @endcond */
+		struct net_sockaddr_storage addr_storage; /**< Remote address storage */
+	};
 	int64_t t0;           /**< Time when the request was sent */
 	uint32_t timeout;     /**< Timeout in ms */
 	uint16_t id;          /**< Message id */

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -271,8 +271,15 @@ struct dns_socket_dispatcher {
 
 	/** Type of the socket (resolver / responder) */
 	enum dns_socket_type type;
-	/** Local endpoint address (used when binding the socket) */
-	struct net_sockaddr local_addr;
+	/** Local endpoint address storage */
+	union {
+		/** Local endpoint address (used when binding the socket) */
+		struct net_sockaddr_storage local_addr_storage;
+/** @cond INTERNAL_HIDDEN */
+		/* Use the local_addr_storage instead of this one. */
+		struct net_sockaddr local_addr;
+/** @endcond */
+	};
 	/** DNS socket dispatcher callback is called for incoming traffic */
 	dns_socket_dispatcher_cb cb;
 	/** Socket descriptors to poll */
@@ -373,7 +380,14 @@ struct dns_addrinfo {
 			net_socklen_t ai_addrlen;
 
 			/** NET_AF_INET or NET_AF_INET6 address info */
-			struct net_sockaddr ai_addr;
+			union {
+				/** Socket address info storage */
+				struct net_sockaddr_storage ai_addr_storage;
+/** @cond INTERNAL_HIDDEN */
+				/** Socket address info (use ai_addr_storage instead) */
+				struct net_sockaddr ai_addr;
+/** @endcond */
+			};
 
 			/** NET_AF_LOCAL Canonical name of the address */
 			char ai_canonname[DNS_MAX_NAME_SIZE + 1];
@@ -491,8 +505,14 @@ enum dns_resolve_context_state {
 struct dns_resolve_context {
 	/** List of configured DNS servers */
 	struct dns_server {
-		/** DNS server information */
-		struct net_sockaddr dns_server;
+		/** DNS server address storage */
+		union {
+			/** DNS server information */
+			struct net_sockaddr_storage dns_server_addr;
+/** @cond INTERNAL_HIDDEN */
+			struct net_sockaddr dns_server;
+/** @endcond */
+		};
 
 		/** Connection to the DNS server */
 		int sock;
@@ -629,7 +649,7 @@ struct mdns_probe_user_data {
 };
 
 struct mdns_responder_context {
-	struct net_sockaddr server_addr;
+	struct net_sockaddr_storage server_addr;
 	struct dns_socket_dispatcher dispatcher;
 	struct zsock_pollfd fds[1];
 	int sock;

--- a/include/zephyr/net/ftp_client.h
+++ b/include/zephyr/net/ftp_client.h
@@ -269,7 +269,13 @@ typedef void (*ftp_client_callback_t)(const uint8_t *msg, uint16_t len);
 
 /** FTP client context. */
 struct ftp_client {
-	struct net_sockaddr remote; /**< Server address */
+	/** Remote server address storage */
+	union {
+		struct net_sockaddr_storage remote_addr;  /**< Server address */
+/** @cond INTERNAL_HIDDEN */
+		struct net_sockaddr remote; /**< Server address (use remote_addr instead) */
+/** @endcond */
+	};
 	bool connected; /**< Server connected flag */
 	int ctrl_sock; /**< Control socket */
 	int data_sock; /**< Data socket */

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -209,7 +209,14 @@ enum lwm2m_socket_states {
  */
 struct lwm2m_ctx {
 	/** Destination address storage */
-	struct net_sockaddr remote_addr;
+	union {
+		/** Destination address */
+		struct net_sockaddr_storage remote_addr_storage;
+/** @cond INTERNAL_HIDDEN */
+		/* Use remote_addr_storage instead of remote_addr */
+		struct net_sockaddr remote_addr;
+/** @endcond */
+	};
 
 	/** @cond INTERNAL_HIDDEN
 	 * Private CoAP and networking structures + 1 is for RD Client own message

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -858,7 +858,15 @@ struct mqtt_transport {
 
 #if defined(CONFIG_SOCKS)
 	struct {
-		struct net_sockaddr addr;
+		/** SOCKS5 proxy address storage */
+		union {
+			/** SOCKS5 proxy address */
+			struct net_sockaddr_storage addr_storage;
+/** @cond INTERNAL_HIDDEN */
+			/* Use the addr_storage instead of this one. */
+			struct net_sockaddr addr;
+/** @endcond */
+		};
 		net_socklen_t addrlen;
 	} proxy;
 #endif

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -228,8 +228,15 @@ struct mqtt_sn_transport_udp {
 	/** Socket FD */
 	int sock;
 
-	/** Address of broadcasts */
-	struct net_sockaddr bcaddr;
+	/** Broadcast address storage */
+	union {
+		/** Address of broadcasts */
+		struct net_sockaddr_storage bcaddr_storage;
+/** @cond INTERNAL_HIDDEN */
+		/* Use the bcaddr_storage instead of this one. */
+		struct net_sockaddr bcaddr;
+/** @endcond */
+	};
 	net_socklen_t bcaddrlen;
 };
 

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -127,8 +127,15 @@ typedef void (*tftp_callback_t)(const struct tftp_evt *evt);
  *       GET or PUT API with the `tftpc` structure.
  */
 struct tftpc {
-	/** Socket address pointing to the remote TFTP server */
-	struct net_sockaddr server;
+	/** Socket address storage */
+	union {
+		/** Socket address pointing to the remote TFTP server */
+		struct net_sockaddr_storage server_addr;
+/** @cond INTERNAL_HIDDEN */
+		/* Do not access this directly, use server_addr instead */
+		struct net_sockaddr server;
+/** @endcond */
+	};
 
 	/** Event notification callback. No notification if NULL */
 	tftp_callback_t callback;

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -53,7 +53,15 @@ struct zperf_upload_params {
 	uint64_t unix_offset_us;
 	zperf_data_load_custom data_loader;
 	void *data_loader_ctx;
-	struct net_sockaddr peer_addr;
+	/** Peer address storage */
+	union {
+		/** Peer address to upload to */
+		struct net_sockaddr_storage peer_addr_storage;
+/** @cond INTERNAL_HIDDEN */
+		/* Use the peer_addr_storage instead of this one. */
+		struct net_sockaddr peer_addr;
+/** @endcond */
+	};
 	uint32_t duration_ms;
 	uint32_t rate_kbps;
 	uint16_t packet_size;
@@ -72,7 +80,15 @@ struct zperf_upload_params {
 
 struct zperf_download_params {
 	uint16_t port;
-	struct net_sockaddr addr;
+	/** Local address storage */
+	union {
+		/** Local address to bind to */
+		struct net_sockaddr_storage addr_storage;
+/** @cond INTERNAL_HIDDEN */
+		/* Use the addr_storage instead of this one. */
+		struct net_sockaddr addr;
+/** @endcond */
+	};
 	char if_name[NET_IFNAMSIZ];
 };
 

--- a/samples/net/cellular_modem/src/main.c
+++ b/samples/net/cellular_modem/src/main.c
@@ -491,27 +491,29 @@ int main(void)
 	}
 
 	{
+		struct sockaddr *ai_addr = net_sad(&sample_test_dns_addrinfo.ai_addr_storage);
 		char ip_str[INET6_ADDRSTRLEN];
 		const void *src;
 
-		switch (sample_test_dns_addrinfo.ai_addr.sa_family) {
+		switch (sample_test_dns_addrinfo.ai_addr_storage.ss_family) {
 		case AF_INET:
-			src = &net_sin(&sample_test_dns_addrinfo.ai_addr)->sin_addr;
-			port = &net_sin(&sample_test_dns_addrinfo.ai_addr)->sin_port;
+			src = &net_sin(ai_addr)->sin_addr;
+			port = &net_sin(ai_addr)->sin_port;
 			break;
 		case AF_INET6:
-			src = &net_sin6(&sample_test_dns_addrinfo.ai_addr)->sin6_addr;
-			port = &net_sin6(&sample_test_dns_addrinfo.ai_addr)->sin6_port;
+			src = &net_sin6(ai_addr)->sin6_addr;
+			port = &net_sin6(ai_addr)->sin6_port;
 			break;
 		default:
 			printk("Unsupported address family\n");
 			return -1;
 		}
-		inet_ntop(sample_test_dns_addrinfo.ai_addr.sa_family, src, ip_str, sizeof(ip_str));
+		inet_ntop(sample_test_dns_addrinfo.ai_addr_storage.ss_family, src, ip_str,
+			  sizeof(ip_str));
 		printk("Resolved to %s\n", ip_str);
 	}
 
-	ret = sample_echo_packet(&sample_test_dns_addrinfo.ai_addr,
+	ret = sample_echo_packet(net_sad(&sample_test_dns_addrinfo.ai_addr_storage),
 				 sample_test_dns_addrinfo.ai_addrlen, port);
 
 	if (ret < 0) {
@@ -519,7 +521,7 @@ int main(void)
 		return -1;
 	}
 
-	ret = sample_transmit_packets(&sample_test_dns_addrinfo.ai_addr,
+	ret = sample_transmit_packets(net_sad(&sample_test_dns_addrinfo.ai_addr_storage),
 				      sample_test_dns_addrinfo.ai_addrlen, port);
 
 	if (ret < 0) {
@@ -547,7 +549,7 @@ int main(void)
 	/* Wait a bit to avoid (unsuccessfully) trying to send the first echo packet too quickly. */
 	k_sleep(K_SECONDS(5));
 
-	ret = sample_echo_packet(&sample_test_dns_addrinfo.ai_addr,
+	ret = sample_echo_packet(net_sad(&sample_test_dns_addrinfo.ai_addr_storage),
 				 sample_test_dns_addrinfo.ai_addrlen, port);
 
 	if (ret < 0) {

--- a/samples/net/common/tunnel.c
+++ b/samples/net/common/tunnel.c
@@ -54,20 +54,21 @@ static void iface_cb(struct net_if *iface, void *user_data)
 
 static int setup_iface(struct net_if *iface, const char *ipaddr)
 {
+	struct net_sockaddr_storage addr;
+	struct net_sockaddr *sa = net_sad(&addr);
 	struct net_if_addr *ifaddr;
-	struct net_sockaddr addr;
 
 	/* Before setting up tunnel, make sure it will be ignored by conn_mgr */
 	conn_mgr_ignore_iface(iface);
 
-	if (!net_ipaddr_parse(ipaddr, strlen(ipaddr), &addr)) {
+	if (!net_ipaddr_parse(ipaddr, strlen(ipaddr), sa)) {
 		LOG_ERR("Tunnel peer address \"%s\" invalid.", ipaddr);
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.ss_family == NET_AF_INET6) {
 		ifaddr = net_if_ipv6_addr_add(iface,
-					      &net_sin6(&addr)->sin6_addr,
+					      &net_sin6(sa)->sin6_addr,
 					      NET_ADDR_MANUAL, 0);
 		if (!ifaddr) {
 			LOG_ERR("Cannot add %s to interface %d",
@@ -76,9 +77,9 @@ static int setup_iface(struct net_if *iface, const char *ipaddr)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && addr.ss_family == NET_AF_INET) {
 		ifaddr = net_if_ipv4_addr_add(iface,
-					      &net_sin(&addr)->sin_addr,
+					      &net_sin(sa)->sin_addr,
 					      NET_ADDR_MANUAL, 0);
 		if (!ifaddr) {
 			LOG_ERR("Cannot add %s to interface %d",
@@ -93,7 +94,8 @@ static int setup_iface(struct net_if *iface, const char *ipaddr)
 int init_tunnel(void)
 {
 	struct virtual_interface_req_params params = { 0 };
-	struct net_sockaddr peer = { 0 };
+	struct net_sockaddr_storage peer = { 0 };
+	struct net_sockaddr *peer_sa = net_sad(&peer);
 	struct ud ud;
 	int ret;
 	int mtu;
@@ -107,36 +109,36 @@ int init_tunnel(void)
 
 	if (!net_ipaddr_parse(NET_SAMPLE_COMMON_TUNNEL_PEER_ADDR,
 			      strlen(NET_SAMPLE_COMMON_TUNNEL_PEER_ADDR),
-			      &peer)) {
+			      peer_sa)) {
 		LOG_ERR("Tunnel peer address \"%s\" invalid.",
 			NET_SAMPLE_COMMON_TUNNEL_PEER_ADDR);
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && peer.sa_family == NET_AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && peer.ss_family == NET_AF_INET6) {
 		struct net_if *iface;
 
 		iface = net_if_ipv6_select_src_iface(
-					&net_sin6(&peer)->sin6_addr);
+					&net_sin6(peer_sa)->sin6_addr);
 		ud.peer = iface;
 		params.family = NET_AF_INET6;
 		net_ipaddr_copy(&params.peer6addr,
-				&net_sin6(&peer)->sin6_addr);
+				&net_sin6(peer_sa)->sin6_addr);
 		mtu = NET_ETH_MTU - sizeof(struct net_ipv6_hdr);
 
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && peer.sa_family == NET_AF_INET) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && peer.ss_family == NET_AF_INET) {
 		struct net_if *iface;
 
 		iface = net_if_ipv4_select_src_iface(
-					&net_sin(&peer)->sin_addr);
+					&net_sin(peer_sa)->sin_addr);
 		ud.peer = iface;
 		params.family = NET_AF_INET;
 		net_ipaddr_copy(&params.peer4addr,
-				&net_sin(&peer)->sin_addr);
+				&net_sin(peer_sa)->sin_addr);
 		mtu = NET_ETH_MTU - sizeof(struct net_ipv4_hdr);
 
 	} else {
-		LOG_ERR("Invalid address family %d", peer.sa_family);
+		LOG_ERR("Invalid address family %d", peer.ss_family);
 		return -EINVAL;
 	}
 

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -66,10 +66,10 @@ void dns_result_cb(enum dns_resolve_status status,
 
 	if (info->ai_family == NET_AF_INET) {
 		hr_family = "IPv4";
-		addr = &net_sin(&info->ai_addr)->sin_addr;
+		addr = &net_sin(net_sad(&info->ai_addr_storage))->sin_addr;
 	} else if (info->ai_family == NET_AF_INET6) {
 		hr_family = "IPv6";
-		addr = &net_sin6(&info->ai_addr)->sin6_addr;
+		addr = &net_sin6(net_sad(&info->ai_addr_storage))->sin6_addr;
 	} else {
 		LOG_ERR("Invalid IP address family %d", info->ai_family);
 		return;
@@ -115,10 +115,10 @@ void mdns_result_cb(enum dns_resolve_status status,
 
 	if (info->ai_family == NET_AF_INET) {
 		hr_family = "IPv4";
-		addr = &net_sin(&info->ai_addr)->sin_addr;
+		addr = &net_sin(net_sad(&info->ai_addr_storage))->sin_addr;
 	} else if (info->ai_family == NET_AF_INET6) {
 		hr_family = "IPv6";
-		addr = &net_sin6(&info->ai_addr)->sin6_addr;
+		addr = &net_sin6(net_sad(&info->ai_addr_storage))->sin6_addr;
 	} else {
 		LOG_ERR("Invalid IP address family %d", info->ai_family);
 		return;

--- a/samples/net/tftp_client/src/tftp-client.c
+++ b/samples/net/tftp_client/src/tftp-client.c
@@ -37,7 +37,7 @@ static void tftp_event_callback(const struct tftp_evt *evt)
 
 static int tftp_init(const char *hostname)
 {
-	struct sockaddr remote_addr;
+	struct sockaddr_storage remote_addr;
 	struct addrinfo *res, hints = {0};
 	int ret;
 
@@ -51,11 +51,12 @@ static int tftp_init(const char *hostname)
 		return -ENOENT;
 	}
 
-	memcpy(&remote_addr, res->ai_addr, sizeof(remote_addr));
+	memcpy(&remote_addr, res->ai_addr, res->ai_addrlen);
 	freeaddrinfo(res);
 
 	/* Save sockaddr into TFTP client handler */
-	memcpy(&client.server, &remote_addr, sizeof(client.server));
+	memcpy(&client.server_addr, &remote_addr, sizeof(client.server_addr));
+
 	/* Register TFTP client callback */
 	client.callback = tftp_event_callback;
 

--- a/samples/net/zperf/src/main.c
+++ b/samples/net/zperf/src/main.c
@@ -112,7 +112,7 @@ static void selftest_fill_upload(struct zperf_upload_params *param, int family,
 	}
 
 	memset(param, 0, sizeof(*param));
-	selftest_fill_addr(&param->peer_addr, family);
+	selftest_fill_addr(net_sad(&param->peer_addr_storage), family);
 	param->duration_ms = SELFTEST_DURATION_MS;
 	param->packet_size = packet_size;
 	param->rate_kbps = rate_kbps;

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -67,6 +67,8 @@ static inline
 void conn_register_debug(struct net_conn *conn,
 			 uint16_t remote_port, uint16_t local_port)
 {
+	struct net_sockaddr *remote_addr = net_sad(&conn->remote_addr);
+	struct net_sockaddr *local_addr = net_sad(&conn->local_addr);
 	char dst[NET_IPV6_ADDR_LEN];
 	char src[NET_IPV6_ADDR_LEN];
 
@@ -74,11 +76,11 @@ void conn_register_debug(struct net_conn *conn,
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    conn->family == NET_AF_INET6) {
 			snprintk(dst, sizeof(dst), "%s",
-				 net_sprint_ipv6_addr(&net_sin6(&conn->remote_addr)->sin6_addr));
+				 net_sprint_ipv6_addr(&net_sin6(remote_addr)->sin6_addr));
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 			   conn->family == NET_AF_INET) {
 			snprintk(dst, sizeof(dst), "%s",
-				 net_sprint_ipv4_addr(&net_sin(&conn->remote_addr)->sin_addr));
+				 net_sprint_ipv4_addr(&net_sin(remote_addr)->sin_addr));
 		} else {
 			snprintk(dst, sizeof(dst), "%s", "?");
 		}
@@ -90,11 +92,11 @@ void conn_register_debug(struct net_conn *conn,
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    conn->family == NET_AF_INET6) {
 			snprintk(src, sizeof(src), "%s",
-				 net_sprint_ipv6_addr(&net_sin6(&conn->local_addr)->sin6_addr));
+				 net_sprint_ipv6_addr(&net_sin6(local_addr)->sin6_addr));
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 			   conn->family == NET_AF_INET) {
 			snprintk(src, sizeof(src), "%s",
-				 net_sprint_ipv4_addr(&net_sin(&conn->local_addr)->sin_addr));
+				 net_sprint_ipv4_addr(&net_sin(local_addr)->sin_addr));
 		} else {
 			snprintk(src, sizeof(src), "%s", "?");
 		}
@@ -166,6 +168,9 @@ static struct net_conn *conn_find_handler(struct net_if *iface,
 	k_mutex_lock(&conn_lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn_used, conn, tmp, node) {
+		struct net_sockaddr *conn_local = net_sad(&conn->local_addr);
+		struct net_sockaddr *conn_remote = net_sad(&conn->remote_addr);
+
 		if (conn->proto != proto) {
 			continue;
 		}
@@ -182,21 +187,19 @@ static struct net_conn *conn_find_handler(struct net_if *iface,
 			if (IS_ENABLED(CONFIG_NET_IPV6) &&
 			    local_addr->sa_family == NET_AF_INET6 &&
 			    local_addr->sa_family ==
-			    conn->local_addr.sa_family) {
+			    conn->local_addr.ss_family) {
 				if (!net_ipv6_addr_cmp(
 					    &net_sin6(local_addr)->sin6_addr,
-					    &net_sin6(&conn->local_addr)->
-								sin6_addr)) {
+					    &net_sin6(conn_local)->sin6_addr)) {
 					continue;
 				}
 			} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 				   local_addr->sa_family == NET_AF_INET &&
 				   local_addr->sa_family ==
-				   conn->local_addr.sa_family) {
+				   conn->local_addr.ss_family) {
 				if (!net_ipv4_addr_cmp(
 					    &net_sin(local_addr)->sin_addr,
-					    &net_sin(&conn->local_addr)->
-								sin_addr)) {
+					    &net_sin(conn_local)->sin_addr)) {
 					continue;
 				}
 			} else {
@@ -206,8 +209,7 @@ static struct net_conn *conn_find_handler(struct net_if *iface,
 			continue;
 		}
 
-		if (net_sin(&conn->local_addr)->sin_port !=
-		    net_htons(local_port)) {
+		if (net_sin(conn_local)->sin_port != net_htons(local_port)) {
 			continue;
 		}
 
@@ -219,21 +221,19 @@ static struct net_conn *conn_find_handler(struct net_if *iface,
 			if (IS_ENABLED(CONFIG_NET_IPV6) &&
 			    remote_addr->sa_family == NET_AF_INET6 &&
 			    remote_addr->sa_family ==
-			    conn->remote_addr.sa_family) {
+			    conn->remote_addr.ss_family) {
 				if (!net_ipv6_addr_cmp(
 					    &net_sin6(remote_addr)->sin6_addr,
-					    &net_sin6(&conn->remote_addr)->
-								sin6_addr)) {
+					    &net_sin6(conn_remote)->sin6_addr)) {
 					continue;
 				}
 			} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 				   remote_addr->sa_family == NET_AF_INET &&
 				   remote_addr->sa_family ==
-				   conn->remote_addr.sa_family) {
+				   conn->remote_addr.ss_family) {
 				if (!net_ipv4_addr_cmp(
 					    &net_sin(remote_addr)->sin_addr,
-					    &net_sin(&conn->remote_addr)->
-								sin_addr)) {
+					    &net_sin(conn_remote)->sin_addr)) {
 					continue;
 				}
 			} else {
@@ -246,8 +246,7 @@ static struct net_conn *conn_find_handler(struct net_if *iface,
 			continue;
 		}
 
-		if (net_sin(&conn->remote_addr)->sin_port !=
-		    net_htons(remote_port)) {
+		if (net_sin(conn_remote)->sin_port != net_htons(remote_port)) {
 			continue;
 		}
 
@@ -315,7 +314,7 @@ static int net_conn_change_remote(struct net_conn *conn,
 
 	if (remote_port) {
 		conn->flags |= NET_CONN_REMOTE_PORT_SPEC;
-		net_sin(&conn->remote_addr)->sin_port = net_htons(remote_port);
+		net_sin(net_sad(&conn->remote_addr))->sin_port = net_htons(remote_port);
 	} else {
 		conn->flags &= ~NET_CONN_REMOTE_PORT_SPEC;
 	}
@@ -369,7 +368,7 @@ static int net_conn_change_local(struct net_conn *conn,
 
 	if (local_port > 0U) {
 		conn->flags |= NET_CONN_LOCAL_PORT_SPEC;
-		net_sin(&conn->local_addr)->sin_port = net_htons(local_port);
+		net_sin(net_sad(&conn->local_addr))->sin_port = net_htons(local_port);
 	} else {
 		conn->flags &= ~NET_CONN_LOCAL_PORT_SPEC;
 	}
@@ -757,7 +756,7 @@ enum net_verdict net_conn_raw_ip_input(struct net_pkt *pkt,
 		/* Apply protocol-specific matching criteria... */
 
 		if (((conn->flags & NET_CONN_LOCAL_ADDR_SET) != 0U) &&
-		    !conn_addr_cmp(pkt, ip_hdr, &conn->local_addr, false)) {
+		    !conn_addr_cmp(pkt, ip_hdr, net_sad(&conn->local_addr), false)) {
 			continue; /* wrong local address */
 		}
 
@@ -920,6 +919,9 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 	k_mutex_lock(&conn_lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn_used, conn, node) {
+		struct net_sockaddr *conn_local = net_sad(&conn->local_addr);
+		struct net_sockaddr *conn_remote = net_sad(&conn->remote_addr);
+
 		/* Is the candidate connection matching the packet's protocol within the family? */
 		if (conn->proto != proto) {
 			continue; /* wrong protocol */
@@ -954,22 +956,22 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 			 * address and port?
 			 */
 			if ((conn->flags & NET_CONN_REMOTE_PORT_SPEC) != 0 &&
-			    net_sin(&conn->remote_addr)->sin_port != src_port) {
+			    net_sin(conn_remote)->sin_port != src_port) {
 				continue; /* wrong remote port */
 			}
 
 			if ((conn->flags & NET_CONN_LOCAL_PORT_SPEC) != 0 &&
-			    net_sin(&conn->local_addr)->sin_port != dst_port) {
+			    net_sin(conn_local)->sin_port != dst_port) {
 				continue; /* wrong local port */
 			}
 
 			if ((conn->flags & NET_CONN_REMOTE_ADDR_SET) != 0 &&
-			    !conn_addr_cmp(pkt, ip_hdr, &conn->remote_addr, true)) {
+			    !conn_addr_cmp(pkt, ip_hdr, conn_remote, true)) {
 				continue; /* wrong remote address */
 			}
 
 			if ((conn->flags & NET_CONN_LOCAL_ADDR_SET) != 0 &&
-			    !conn_addr_cmp(pkt, ip_hdr, &conn->local_addr, false)) {
+			    !conn_addr_cmp(pkt, ip_hdr, conn_local, false)) {
 
 				/* Check if we could do a v4-mapping-to-v6 and the IPv6 socket
 				 * has no IPV6_V6ONLY option set and if the local IPV6 address
@@ -981,7 +983,7 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 					      pkt_family == NET_AF_INET &&
 					      !conn->v6only &&
 					      net_ipv6_is_addr_unspecified(
-						      &net_sin6(&conn->local_addr)->sin6_addr))) {
+						      &net_sin6(conn_local)->sin6_addr))) {
 						continue; /* wrong local address */
 					}
 				} else {

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -55,10 +55,10 @@ struct net_conn {
 	sys_snode_t node;
 
 	/** Remote socket address */
-	struct net_sockaddr remote_addr;
+	struct net_sockaddr_storage remote_addr;
 
 	/** Local socket address */
-	struct net_sockaddr local_addr;
+	struct net_sockaddr_storage local_addr;
 
 	/** Callback to be called when matching net packet is received */
 	net_conn_cb_t cb;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -587,8 +587,10 @@ int net_context_get(net_sa_family_t family, enum net_sock_type type, uint16_t pr
 			IS_ENABLED(CONFIG_NET_INITIAL_IPV4_MCAST_LOOP);
 #endif
 		if (IS_ENABLED(CONFIG_NET_IP)) {
-			(void)memset(&contexts[i].remote, 0, sizeof(struct net_sockaddr));
-			(void)memset(&contexts[i].local, 0, sizeof(struct net_sockaddr));
+			(void)memset(&contexts[i].remote_storage, 0,
+				     sizeof(contexts[i].remote_storage));
+			(void)memset(&contexts[i].local_storage, 0,
+				     sizeof(contexts[i].local_storage));
 
 			if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
 				struct net_sockaddr_in6 *addr6 =
@@ -1429,7 +1431,8 @@ int net_context_connect(struct net_context *context,
 			void *user_data)
 {
 	struct net_sockaddr *laddr = NULL;
-	struct net_sockaddr local_addr __unused;
+	struct net_sockaddr_storage local_addr_storage __maybe_unused = { 0 };
+	struct net_sockaddr *local_addr = net_sad(&local_addr_storage);
 	uint16_t lport, rport;
 	int ret;
 
@@ -1455,7 +1458,7 @@ int net_context_connect(struct net_context *context,
 	if (IS_ENABLED(CONFIG_NET_UDP) && addr->sa_family == NET_AF_UNSPEC &&
 	    net_context_get_type(context) == NET_SOCK_DGRAM) {
 		context->flags &= ~NET_CONTEXT_REMOTE_ADDR_SET;
-		memset(&context->remote, 0, sizeof(context->remote));
+		memset(&context->remote_storage, 0, sizeof(context->remote_storage));
 		ret = 0;
 		goto unlock;
 	}
@@ -1520,15 +1523,15 @@ int net_context_connect(struct net_context *context,
 		}
 
 		net_sin6(&context->local)->sin6_family = NET_AF_INET6;
-		net_sin6(&local_addr)->sin6_family = NET_AF_INET6;
-		net_sin6(&local_addr)->sin6_port = lport =
+		net_sin6(local_addr)->sin6_family = NET_AF_INET6;
+		net_sin6(local_addr)->sin6_port = lport =
 			net_sin6(&context->local)->sin6_port;
 
 		if (net_context_is_local_addr_set(context)) {
-			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
+			net_ipaddr_copy(&net_sin6(local_addr)->sin6_addr,
 				     &net_sin6(&context->local)->sin6_addr);
 
-			laddr = &local_addr;
+			laddr = local_addr;
 		}
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == NET_AF_INET) {
@@ -1568,15 +1571,15 @@ int net_context_connect(struct net_context *context,
 		}
 
 		net_sin(&context->local)->sin_family = NET_AF_INET;
-		net_sin(&local_addr)->sin_family = NET_AF_INET;
-		net_sin(&local_addr)->sin_port = lport =
+		net_sin(local_addr)->sin_family = NET_AF_INET;
+		net_sin(local_addr)->sin_port = lport =
 			net_sin(&context->local)->sin_port;
 
 		if (net_context_is_local_addr_set(context)) {
-			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+			net_ipaddr_copy(&net_sin(local_addr)->sin_addr,
 				       &net_sin(&context->local)->sin_addr);
 
-			laddr = &local_addr;
+			laddr = local_addr;
 		}
 	} else {
 		ret = -EINVAL; /* Not IPv4 or IPv6 */
@@ -3975,9 +3978,10 @@ static int recv_dgram(struct net_context *context,
 		      k_timeout_t timeout,
 		      void *user_data)
 {
-	struct net_sockaddr local_addr = {
-		.sa_family = net_context_get_family(context),
+	struct net_sockaddr_storage local_addr_storage = {
+		.ss_family = net_context_get_family(context),
 	};
+	struct net_sockaddr *local_addr = net_sad(&local_addr_storage);
 	struct net_sockaddr *laddr = NULL;
 	uint16_t lport = 0U;
 	int ret;
@@ -3992,22 +3996,22 @@ static int recv_dgram(struct net_context *context,
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_context_get_family(context) == NET_AF_INET6) {
 		if (net_context_is_local_addr_set(context)) {
-			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
+			net_ipaddr_copy(&net_sin6(local_addr)->sin6_addr,
 				     &net_sin6(&context->local)->sin6_addr);
 
-			laddr = &local_addr;
+			laddr = local_addr;
 		}
 
-		net_sin6(&local_addr)->sin6_port =
+		net_sin6(local_addr)->sin6_port =
 			net_sin6(&context->local)->sin6_port;
 		lport = net_sin6(&context->local)->sin6_port;
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == NET_AF_INET) {
 		if (net_context_is_local_addr_set(context)) {
-			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+			net_ipaddr_copy(&net_sin(local_addr)->sin_addr,
 				      &net_sin(&context->local)->sin_addr);
 
-			laddr = &local_addr;
+			laddr = local_addr;
 		}
 
 		lport = net_sin(&context->local)->sin_port;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2523,7 +2523,8 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 	struct tcp *conn = NULL;
 	struct net_context *context = NULL;
 	net_sa_family_t af = net_pkt_family(pkt);
-	struct net_sockaddr local_addr = { 0 };
+	struct net_sockaddr_storage local_addr_storage = { 0 };
+	struct net_sockaddr *local_addr = net_sad(&local_addr_storage);
 	int ret;
 
 	ret = net_context_get(af, NET_SOCK_STREAM, NET_IPPROTO_TCP, &context);
@@ -2561,19 +2562,22 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 
 	net_sin(&context->local)->sin_family = af;
 
-	local_addr.sa_family = net_context_get_family(context);
+	local_addr->sa_family = net_context_get_family(context);
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_context_get_family(context) == NET_AF_INET6) {
-		net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
+		net_ipaddr_copy(&net_sin6(local_addr)->sin6_addr,
 				&conn->src.sin6.sin6_addr);
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == NET_AF_INET) {
-		net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+		net_ipaddr_copy(&net_sin(local_addr)->sin_addr,
 				&conn->src.sin.sin_addr);
 	}
 
-	ret = net_context_bind(context, &local_addr, sizeof(local_addr));
+	ret = net_context_bind(context, local_addr,
+			       local_addr->sa_family == NET_AF_INET6 ?
+			       sizeof(struct net_sockaddr_in6) :
+			       sizeof(struct net_sockaddr_in));
 	if (ret < 0) {
 		NET_DBG("[%p] Cannot bind accepted context, connection reset", conn);
 		net_context_put(context);
@@ -2603,19 +2607,19 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 
 	if (!(IS_ENABLED(CONFIG_NET_TEST_PROTOCOL) ||
 	      IS_ENABLED(CONFIG_NET_TEST))) {
-		conn->seq = tcp_init_isn(&local_addr, &context->remote);
+		conn->seq = tcp_init_isn(local_addr, &context->remote);
 	}
 
 	conn->isn = conn->seq;
 
 	NET_DBG("[%p] local: %s, remote: %s", conn,
-		net_sprint_addr(local_addr.sa_family,
-				(const void *)&net_sin(&local_addr)->sin_addr),
+		net_sprint_addr(local_addr->sa_family,
+				(const void *)&net_sin(local_addr)->sin_addr),
 		net_sprint_addr(context->remote.sa_family,
 				(const void *)&net_sin(&context->remote)->sin_addr));
 
 	ret = net_conn_register(NET_IPPROTO_TCP, NET_SOCK_STREAM, af,
-				&context->remote, &local_addr,
+				&context->remote, local_addr,
 				net_ntohs(conn->dst.sin.sin_port),/* local port */
 				net_ntohs(conn->src.sin.sin_port),/* remote port */
 				context, tcp_recv, context,
@@ -4205,7 +4209,8 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 		   void *user_data)
 {
 	struct tcp *conn = context->tcp;
-	struct net_sockaddr local_addr = { };
+	struct net_sockaddr_storage local_addr_storage = { 0 };
+	struct net_sockaddr *local_addr = net_sad(&local_addr_storage);
 	uint16_t local_port, remote_port;
 
 	if (!conn) {
@@ -4219,9 +4224,9 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 	}
 
 	conn->accept_cb = cb;
-	local_addr.sa_family = net_context_get_family(context);
+	local_addr->sa_family = net_context_get_family(context);
 
-	switch (local_addr.sa_family) {
+	switch (local_addr->sa_family) {
 		struct net_sockaddr_in *in;
 		struct net_sockaddr_in6 *in6;
 
@@ -4230,7 +4235,7 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 			return -EINVAL;
 		}
 
-		in = (struct net_sockaddr_in *)&local_addr;
+		in = (struct net_sockaddr_in *)local_addr;
 
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&in->sin_addr,
@@ -4249,7 +4254,7 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 			return -EINVAL;
 		}
 
-		in6 = (struct net_sockaddr_in6 *)&local_addr;
+		in6 = (struct net_sockaddr_in6 *)local_addr;
 
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&in6->sin6_addr,
@@ -4276,10 +4281,10 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 
 	return net_conn_register(net_context_get_proto(context),
 				 net_context_get_type(context),
-				 local_addr.sa_family,
+				 local_addr->sa_family,
 				 context->flags & NET_CONTEXT_REMOTE_ADDR_SET ?
 				 &context->remote : NULL,
-				 &local_addr,
+				 local_addr,
 				 remote_port, local_port,
 				 context, tcp_recv, context,
 				 &context->conn_handler);
@@ -4603,19 +4608,23 @@ static void test_cb_register(net_sa_family_t family, enum net_sock_type type,
 			     uint16_t local_port, net_conn_cb_t cb)
 {
 	struct net_conn_handle *conn_handle = NULL;
-	const struct net_sockaddr addr = { .sa_family = family, };
+	struct net_sockaddr_storage addr_storage = { 0 };
+	struct net_sockaddr *addr = net_sad(&addr_storage);
+	int ret;
 
-	int ret = net_conn_register(proto,
-				    type,
-				    family,
-				    &addr,	/* remote address */
-				    &addr,	/* local address */
-				    local_port,
-				    remote_port,
-				    NULL,
-				    cb,
-				    NULL,	/* user_data */
-				    &conn_handle);
+	addr->sa_family = family;
+
+	ret = net_conn_register(proto,
+				type,
+				family,
+				addr,	/* remote address */
+				addr,	/* local address */
+				local_port,
+				remote_port,
+				NULL,
+				cb,
+				NULL,	/* user_data */
+				&conn_handle);
 	if (ret < 0) {
 		NET_ERR("net_conn_register(): %d", ret);
 	}

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -77,13 +77,13 @@ struct net_capture {
 	/**
 	 * Peer (inner) tunnel IP address.
 	 */
-	struct net_sockaddr peer;
+	struct net_sockaddr_storage peer;
 
 	/**
 	 * Local (inner) tunnel IP address. This will be set
 	 * as a local address to tunnel network interface.
 	 */
-	struct net_sockaddr local;
+	struct net_sockaddr_storage local;
 
 	/**
 	 * Is this context setup already
@@ -129,8 +129,8 @@ void net_capture_foreach(net_capture_cb_t cb, void *user_data)
 		info.capture_dev = ctx->dev;
 		info.capture_iface = ctx->capture_iface;
 		info.tunnel_iface = ctx->tunnel_iface;
-		info.peer = &ctx->peer;
-		info.local = &ctx->local;
+		info.peer = net_sad(&ctx->peer);
+		info.local = net_sad(&ctx->local);
 		info.is_enabled = ctx->is_enabled;
 
 		k_mutex_unlock(&lock);
@@ -282,9 +282,10 @@ int net_capture_setup(const char *remote_addr, const char *my_local_addr,
 	struct virtual_interface_req_params params = { 0 };
 	struct net_context *context = NULL;
 	struct net_if *ipip_iface = NULL;
-	struct net_sockaddr remote = { 0 };
-	struct net_sockaddr local = { 0 };
-	struct net_sockaddr peer = { 0 };
+	struct net_sockaddr_storage remote = { 0 };
+	struct net_sockaddr_storage local = { 0 };
+	struct net_sockaddr_storage peer = { 0 };
+	struct net_sockaddr *remote_sa = net_sad(&remote);
 	struct net_if *remote_iface;
 	struct net_capture *ctx;
 	int local_addr_len;
@@ -298,40 +299,40 @@ int net_capture_setup(const char *remote_addr, const char *my_local_addr,
 		goto fail;
 	}
 
-	if (!net_ipaddr_parse(remote_addr, strlen(remote_addr), &remote)) {
+	if (!net_ipaddr_parse(remote_addr, strlen(remote_addr), remote_sa)) {
 		NET_ERR("IPIP tunnel %s address \"%s\" invalid.",
 			"remote", remote_addr);
 		ret = -EINVAL;
 		goto fail;
 	}
 
-	if (!net_ipaddr_parse(peer_addr, strlen(peer_addr), &peer)) {
+	if (!net_ipaddr_parse(peer_addr, strlen(peer_addr), net_sad(&peer))) {
 		NET_ERR("IPIP tunnel %s address \"%s\" invalid.",
 			"peer", peer_addr);
 		ret = -EINVAL;
 		goto fail;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && remote.sa_family == NET_AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && remote.ss_family == NET_AF_INET6) {
 		remote_iface = net_if_ipv6_select_src_iface(
-						&net_sin6(&remote)->sin6_addr);
+						&net_sin6(remote_sa)->sin6_addr);
 		params.family = NET_AF_INET6;
 		net_ipaddr_copy(&params.peer6addr,
-				&net_sin6(&remote)->sin6_addr);
+				&net_sin6(remote_sa)->sin6_addr);
 		orig_mtu = net_if_get_mtu(remote_iface);
 		mtu = orig_mtu - sizeof(struct net_ipv6_hdr) -
 			sizeof(struct net_udp_hdr);
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && remote.sa_family == NET_AF_INET) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && remote.ss_family == NET_AF_INET) {
 		remote_iface = net_if_ipv4_select_src_iface(
-						&net_sin(&remote)->sin_addr);
+						&net_sin(remote_sa)->sin_addr);
 		params.family = NET_AF_INET;
 		net_ipaddr_copy(&params.peer4addr,
-				&net_sin(&remote)->sin_addr);
+				&net_sin(remote_sa)->sin_addr);
 		orig_mtu = net_if_get_mtu(remote_iface);
 		mtu = orig_mtu - sizeof(struct net_ipv4_hdr) -
 			sizeof(struct net_udp_hdr);
 	} else {
-		NET_ERR("Invalid address family %d", remote.sa_family);
+		NET_ERR("Invalid address family %d", remote.ss_family);
 		ret = -EINVAL;
 		goto fail;
 	}
@@ -380,16 +381,16 @@ int net_capture_setup(const char *remote_addr, const char *my_local_addr,
 		goto fail;
 	}
 
-	ret = setup_iface(ipip_iface, my_local_addr, &local, &local_addr_len);
+	ret = setup_iface(ipip_iface, my_local_addr, net_sad(&local), &local_addr_len);
 	if (ret < 0) {
 		NET_ERR("Cannot set IP address %s to tunnel interface",
 			my_local_addr);
 		goto fail;
 	}
 
-	if (peer.sa_family != local.sa_family) {
+	if (peer.ss_family != local.ss_family) {
 		NET_ERR("Peer and local address are not the same family "
-			"(%d vs %d)", peer.sa_family, local.sa_family);
+			"(%d vs %d)", peer.ss_family, local.ss_family);
 		ret = -EINVAL;
 		goto fail;
 	}
@@ -412,12 +413,12 @@ int net_capture_setup(const char *remote_addr, const char *my_local_addr,
 	memcpy(&ctx->peer, &peer, local_addr_len);
 	memcpy(&ctx->local, &local, local_addr_len);
 
-	if (net_sin(&ctx->peer)->sin_port == 0) {
-		net_sin(&ctx->peer)->sin_port = net_htons(DEFAULT_PORT);
+	if (net_sin(net_sad(&ctx->peer))->sin_port == 0) {
+		net_sin(net_sad(&ctx->peer))->sin_port = net_htons(DEFAULT_PORT);
 	}
 
-	if (net_sin(&ctx->local)->sin_port == 0) {
-		net_sin(&ctx->local)->sin_port = net_htons(DEFAULT_PORT);
+	if (net_sin(net_sad(&ctx->local))->sin_port == 0) {
+		net_sin(net_sad(&ctx->local))->sin_port = net_htons(DEFAULT_PORT);
 	}
 
 	ret = net_virtual_interface_attach(ctx->tunnel_iface, remote_iface);
@@ -456,7 +457,7 @@ static int capture_cleanup(const struct device *dev)
 		net_context_put(ctx->context);
 	}
 
-	(void)cleanup_iface(ctx->tunnel_iface, &ctx->local);
+	(void)cleanup_iface(ctx->tunnel_iface, net_sad(&ctx->local));
 
 	ctx->tunnel_iface = NULL;
 	ctx->in_use = false;
@@ -611,6 +612,8 @@ static int capture_send(const struct device *dev, struct net_if *iface,
 			struct net_pkt *pkt)
 {
 	struct net_capture *ctx = dev->data;
+	struct net_sockaddr *ctx_local = net_sad(&ctx->local);
+	struct net_sockaddr *ctx_peer = net_sad(&ctx->peer);
 	enum net_verdict verdict;
 	struct net_pkt *ip;
 	int ret;
@@ -620,9 +623,9 @@ static int capture_send(const struct device *dev, struct net_if *iface,
 		return -ENOENT;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.sa_family == NET_AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.ss_family == NET_AF_INET) {
 		len = sizeof(struct net_ipv4_hdr);
-	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.sa_family == NET_AF_INET6) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.ss_family == NET_AF_INET6) {
 		len = sizeof(struct net_ipv6_hdr);
 	} else {
 		return -EINVAL;
@@ -637,7 +640,7 @@ static int capture_send(const struct device *dev, struct net_if *iface,
 	}
 
 	net_pkt_set_context(ip, ctx->context);
-	net_pkt_set_family(ip, ctx->local.sa_family);
+	net_pkt_set_family(ip, ctx->local.ss_family);
 	net_pkt_set_iface(ip, ctx->tunnel_iface);
 
 	ret = net_pkt_alloc_buffer(ip, len, NET_IPPROTO_UDP, PKT_ALLOC_TIME);
@@ -646,15 +649,15 @@ static int capture_send(const struct device *dev, struct net_if *iface,
 		return ret;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.sa_family == NET_AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.ss_family == NET_AF_INET) {
 		net_pkt_set_ipv4_ttl(ip,
 				     net_if_ipv4_get_ttl(ctx->tunnel_iface));
 
-		ret = net_ipv4_create(ip, &net_sin(&ctx->local)->sin_addr,
-				      &net_sin(&ctx->peer)->sin_addr);
-	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.sa_family == NET_AF_INET6) {
-		ret = net_ipv6_create(ip, &net_sin6(&ctx->local)->sin6_addr,
-				      &net_sin6(&ctx->peer)->sin6_addr);
+		ret = net_ipv4_create(ip, &net_sin(ctx_local)->sin_addr,
+				      &net_sin(ctx_peer)->sin_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.ss_family == NET_AF_INET6) {
+		ret = net_ipv6_create(ip, &net_sin6(ctx_local)->sin6_addr,
+				      &net_sin6(ctx_peer)->sin6_addr);
 	} else {
 		CODE_UNREACHABLE;
 	}
@@ -664,8 +667,8 @@ static int capture_send(const struct device *dev, struct net_if *iface,
 		return ret;
 	}
 
-	(void)net_udp_create(ip, net_sin(&ctx->local)->sin_port,
-			     net_sin(&ctx->peer)->sin_port);
+	(void)net_udp_create(ip, net_sin(ctx_local)->sin_port,
+			     net_sin(ctx_peer)->sin_port);
 
 	net_buf_frag_add(ip->buffer, pkt->buffer);
 	pkt->buffer = ip->buffer;
@@ -678,17 +681,17 @@ static int capture_send(const struct device *dev, struct net_if *iface,
 	net_pkt_set_context(pkt, NULL);
 	net_pkt_set_captured(pkt, true);
 	net_pkt_set_iface(pkt, ctx->tunnel_iface);
-	net_pkt_set_family(pkt, ctx->local.sa_family);
+	net_pkt_set_family(pkt, ctx->local.ss_family);
 	net_pkt_set_ipv6_ext_len(pkt, 0);
 
 	net_pkt_cursor_init(pkt);
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.sa_family == NET_AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.ss_family == NET_AF_INET) {
 		net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
 		net_pkt_set_ipv4_opts_len(pkt, 0);
 
 		net_ipv4_finalize(pkt, NET_IPPROTO_UDP);
-	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.sa_family == NET_AF_INET6) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.ss_family == NET_AF_INET6) {
 		net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 		net_pkt_set_ipv6_ext_opt_len(pkt, 0);
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1634,7 +1634,9 @@ int coap_pending_init(struct coap_pending *pending,
 
 	pending->id = coap_header_get_id(request);
 
-	memcpy(&pending->addr, addr, sizeof(*addr));
+	memcpy(&pending->addr_storage, addr,
+	       addr->sa_family == NET_AF_INET ?
+			sizeof(struct net_sockaddr_in) : sizeof(struct net_sockaddr_in6));
 
 	if (params) {
 		pending->params = *params;

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -647,7 +647,8 @@ static void coap_server_retransmit(void)
 
 		if (coap_pending_cycle(pending)) {
 			ret = zsock_sendto(service->data->sock_fd, pending->data, pending->len, 0,
-					   &pending->addr, ADDRLEN(&pending->addr));
+					   net_sad(&pending->addr_storage),
+					   ADDRLEN(net_sad(&pending->addr_storage)));
 			if (ret < 0) {
 				LOG_ERR("Failed to send pending retransmission for %s (%d)",
 					service->name, ret);
@@ -656,7 +657,8 @@ static void coap_server_retransmit(void)
 		} else {
 			LOG_WRN("Packet retransmission failed for %s", service->name);
 
-			coap_service_remove_observer(service, NULL, &pending->addr, NULL, 0U);
+			coap_service_remove_observer(service, NULL,
+						     net_sad(&pending->addr_storage), NULL, 0U);
 			coap_server_free(pending->data);
 			coap_pending_clear(pending);
 		}

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -240,15 +240,19 @@ static void dns_result_cb(enum dns_resolve_status status,
 		}
 
 		if (IS_ENABLED(CONFIG_NET_IPV4) && info->ai_family == NET_AF_INET) {
+			struct net_sockaddr *ai_addr = net_sad(&info->ai_addr_storage);
+
 			sntp_addrlen = info->ai_addrlen;
 			sntp_addr.ss_family = NET_AF_INET;
 			net_ipv4_addr_copy_raw(net_sin(net_sad(&sntp_addr))->sin_addr.s4_addr,
-					       net_sin(&info->ai_addr)->sin_addr.s4_addr);
+					       net_sin(ai_addr)->sin_addr.s4_addr);
 		} else if (IS_ENABLED(CONFIG_NET_IPV6) && info->ai_family == NET_AF_INET6) {
+			struct net_sockaddr *ai_addr = net_sad(&info->ai_addr_storage);
+
 			sntp_addrlen = info->ai_addrlen;
 			sntp_addr.ss_family = NET_AF_INET6;
 			net_ipv6_addr_copy_raw(net_sin6(net_sad(&sntp_addr))->sin6_addr.s6_addr,
-					       net_sin6(&info->ai_addr)->sin6_addr.s6_addr);
+					       net_sin6(ai_addr)->sin6_addr.s6_addr);
 		} else {
 			/* Ignore. */
 			return;

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -2081,20 +2081,21 @@ int net_dhcpv4_init(void)
 	uint64_t events =
 		IS_ENABLED(CONFIG_NET_DHCPV4_RESTART_ON_IF_UP) ?
 		(NET_EVENT_IF_UP | NET_EVENT_IF_DOWN) : NET_EVENT_IF_DOWN;
-	struct net_sockaddr local_addr;
+	struct net_sockaddr_storage local_addr_storage;
+	struct net_sockaddr *local_addr = net_sad(&local_addr_storage);
 	int ret;
 
 	NET_DBG("");
 
-	net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+	net_ipaddr_copy(&net_sin(local_addr)->sin_addr,
 			net_ipv4_unspecified_address());
-	local_addr.sa_family = NET_AF_INET;
+	local_addr->sa_family = NET_AF_INET;
 
 	/* Register UDP input callback on
 	 * DHCPV4_SERVER_PORT(67) and DHCPV4_CLIENT_PORT(68) for
 	 * all dhcpv4 related incoming packets.
 	 */
-	ret = net_udp_register(NET_AF_INET, NULL, &local_addr,
+	ret = net_udp_register(NET_AF_INET, NULL, local_addr,
 			       0, DHCPV4_CLIENT_PORT,
 			       NULL, net_dhcpv4_input, NULL, NULL);
 	if (ret < 0) {

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -2980,14 +2980,15 @@ void net_dhcpv6_restart(struct net_if *iface)
 
 int net_dhcpv6_init(void)
 {
-	struct net_sockaddr unspec_addr = {0};
+	struct net_sockaddr_storage unspec_addr_storage = {0};
+	struct net_sockaddr *unspec_addr = net_sad(&unspec_addr_storage);
 	int ret;
 
-	net_ipaddr_copy(&net_sin6(&unspec_addr)->sin6_addr,
+	net_ipaddr_copy(&net_sin6(unspec_addr)->sin6_addr,
 			net_ipv6_unspecified_address());
-	unspec_addr.sa_family = NET_AF_INET6;
+	unspec_addr->sa_family = NET_AF_INET6;
 
-	ret = net_udp_register(NET_AF_INET6, NULL, &unspec_addr,
+	ret = net_udp_register(NET_AF_INET6, NULL, unspec_addr,
 			       0, DHCPV6_CLIENT_PORT,
 			       NULL, dhcpv6_input, NULL, NULL);
 	if (ret < 0) {

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -125,7 +125,7 @@ static int recv_data(struct net_socket_service_event *pev)
 	struct dns_socket_dispatcher *dispatcher;
 	net_socklen_t optlen = sizeof(int);
 	struct net_buf *dns_data = NULL;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr;
 	net_socklen_t addrlen;
 	int family, sock_error;
 	int ret = 0, len;
@@ -176,7 +176,7 @@ static int recv_data(struct net_socket_service_event *pev)
 
 	ret = zsock_recvfrom(pev->event.fd, dns_data->data,
 			     net_buf_max_len(dns_data), 0,
-			     (struct net_sockaddr *)&addr, &addrlen);
+			     net_sad(&addr), &addrlen);
 	if (ret < 0) {
 		ret = -errno;
 		NET_ERR("recv failed on IPv%d socket (%d)",
@@ -187,7 +187,7 @@ static int recv_data(struct net_socket_service_event *pev)
 	len = ret;
 
 	ret = dns_dispatch(dispatcher, pev->event.fd,
-			   (struct net_sockaddr *)&addr, addrlen,
+			   net_sad(&addr), addrlen,
 			   dns_data, len);
 free_buf:
 	if (dns_data) {
@@ -232,10 +232,10 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 		 * already registered.
 		 */
 		if (ctx->type == entry->type &&
-		    ctx->local_addr.sa_family == entry->local_addr.sa_family &&
+		    ctx->local_addr_storage.ss_family == entry->local_addr_storage.ss_family &&
 		    ctx->ifindex == entry->ifindex) {
-			if (net_sin(&entry->local_addr)->sin_port ==
-			    net_sin(&ctx->local_addr)->sin_port) {
+			if (net_sin(net_sad(&entry->local_addr_storage))->sin_port ==
+			    net_sin(net_sad(&ctx->local_addr_storage))->sin_port) {
 				dup = true;
 				continue;
 			}
@@ -248,9 +248,9 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 		 * can catch possible duplicates.
 		 */
 		if (found == NULL && ctx->type != entry->type &&
-		    ctx->local_addr.sa_family == entry->local_addr.sa_family) {
-			if (net_sin(&entry->local_addr)->sin_port ==
-			    net_sin(&ctx->local_addr)->sin_port) {
+		    ctx->local_addr_storage.ss_family == entry->local_addr_storage.ss_family) {
+			if (net_sin(net_sad(&entry->local_addr_storage))->sin_port ==
+			    net_sin(net_sad(&ctx->local_addr_storage))->sin_port) {
 				found = entry;
 				continue;
 			}
@@ -299,14 +299,14 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 
 	ctx->buf_timeout = DNS_BUF_TIMEOUT;
 
-	if (ctx->local_addr.sa_family == NET_AF_INET) {
+	if (ctx->local_addr_storage.ss_family == NET_AF_INET) {
 		addrlen = sizeof(struct net_sockaddr_in);
 	} else {
 		addrlen = sizeof(struct net_sockaddr_in6);
 	}
 
 	/* Bind and then register a socket service with this combo */
-	ret = zsock_bind(ctx->sock, &ctx->local_addr, addrlen);
+	ret = zsock_bind(ctx->sock, net_sad(&ctx->local_addr_storage), addrlen);
 	if (ret < 0) {
 		ret = -errno;
 		NET_DBG("Cannot bind DNS socket %d (%d)", ctx->sock, ret);
@@ -317,10 +317,10 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 	 * Store the actual socket name so later dispatcher registrations do
 	 * not treat distinct resolver sockets as duplicate port-0 sockets.
 	 */
-	if (net_sin(&ctx->local_addr)->sin_port == 0) {
+	if (net_sin(net_sad(&ctx->local_addr_storage))->sin_port == 0) {
 		net_socklen_t socklen = addrlen;
 
-		ret = zsock_getsockname(ctx->sock, &ctx->local_addr, &socklen);
+		ret = zsock_getsockname(ctx->sock, net_sad(&ctx->local_addr_storage), &socklen);
 		if (ret < 0) {
 			ret = -errno;
 			NET_DBG("Cannot get DNS socket %d name (%d)", ctx->sock,

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -1034,7 +1034,7 @@ static int send_probe(struct mdns_responder_context *ctx)
 	int ret;
 
 	NET_DBG("%s %s %s to our hostname %s%s iface %d", "mDNS",
-		ctx->dispatcher.local_addr.sa_family == NET_AF_INET ? "IPv4" : "IPv6",
+		ctx->dispatcher.local_addr_storage.ss_family == NET_AF_INET ? "IPv4" : "IPv6",
 		"probe", hostname, ".local", net_if_get_by_iface(ctx->iface));
 
 	ret = 0;
@@ -1042,14 +1042,15 @@ static int send_probe(struct mdns_responder_context *ctx)
 		local_port = sys_rand16_get() | 0x8000;
 		ret++;
 	} while (net_context_port_in_use(NET_IPPROTO_UDP, local_port,
-					 &ctx->dispatcher.local_addr) && ret < PORT_COUNT);
+					 net_sad(&ctx->dispatcher.local_addr_storage)) &&
+		 ret < PORT_COUNT);
 	if (ret >= PORT_COUNT) {
 		NET_ERR("No available port, %s probe fails!", "mDNS");
 		ret = -EIO;
 		goto out;
 	}
 
-	if (ctx->dispatcher.local_addr.sa_family == NET_AF_INET) {
+	if (ctx->dispatcher.local_addr_storage.ss_family == NET_AF_INET) {
 		create_ipv4_addr((struct net_sockaddr_in *)&server);
 	} else {
 		create_ipv6_addr(&server);
@@ -1150,8 +1151,8 @@ static void probing(struct k_work *work)
 		}
 
 		NET_DBG("Cannot send %s mDNS probe (%d, errno %d)",
-			ctx->dispatcher.local_addr.sa_family == NET_AF_INET ? "IPv4" :
-			(ctx->dispatcher.local_addr.sa_family == NET_AF_INET6 ? "IPv6" :
+			ctx->dispatcher.local_addr_storage.ss_family == NET_AF_INET ? "IPv4" :
+			(ctx->dispatcher.local_addr_storage.ss_family == NET_AF_INET6 ? "IPv6" :
 			 ""),
 			ret, errno);
 	}
@@ -1482,14 +1483,14 @@ static int register_dispatcher(struct mdns_responder_context *ctx,
 			return -EINVAL;
 		}
 
-		memcpy(&ctx->dispatcher.local_addr, local,
+		memcpy(&ctx->dispatcher.local_addr_storage, local,
 		       sizeof(struct net_sockaddr_in6));
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) && local->sa_family == NET_AF_INET) {
 		if (local_len < sizeof(struct net_sockaddr_in)) {
 			return -EINVAL;
 		}
 
-		memcpy(&ctx->dispatcher.local_addr, local,
+		memcpy(&ctx->dispatcher.local_addr_storage, local,
 		       sizeof(struct net_sockaddr_in));
 	} else {
 		return -ENOTSUP;
@@ -1533,7 +1534,7 @@ static int pre_init_listener(void)
 		 * is initialized does not try to send on it.
 		 */
 		v6_ctx[i].sock = -1;
-		v6_ctx[i].dispatcher.local_addr.sa_family = NET_AF_INET6;
+		v6_ctx[i].dispatcher.local_addr_storage.ss_family = NET_AF_INET6;
 		v6_ctx[i].dispatcher.svc = &v6_svc;
 
 		k_work_init_delayable(&v6_ctx[i].probe_timer, probing);
@@ -1565,7 +1566,7 @@ static int pre_init_listener(void)
 		 * is initialized does not try to send on it.
 		 */
 		v4_ctx[i].sock = -1;
-		v4_ctx[i].dispatcher.local_addr.sa_family = NET_AF_INET;
+		v4_ctx[i].dispatcher.local_addr_storage.ss_family = NET_AF_INET;
 		v4_ctx[i].dispatcher.svc = &v4_svc;
 
 		k_work_init_delayable(&v4_ctx[i].probe_timer, probing);

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -416,7 +416,7 @@ static void join_ipv6_mcast_group(struct net_if *iface, void *user_data)
 
 static void dns_postprocess_server(struct dns_resolve_context *ctx, int idx)
 {
-	struct net_sockaddr *addr = &ctx->servers[idx].dns_server;
+	struct net_sockaddr *addr = net_sad(&ctx->servers[idx].dns_server_addr);
 
 	if (addr->sa_family == NET_AF_INET) {
 		ctx->servers[idx].is_mdns = server_is_mdns(NET_AF_INET, addr);
@@ -642,21 +642,21 @@ static int register_dispatcher(struct dns_resolve_context *ctx,
 	server->dispatcher.ifindex = server->if_index;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
-	    server->dns_server.sa_family == NET_AF_INET6) {
+	    server->dns_server_addr.ss_family == NET_AF_INET6) {
 		if (local_len < sizeof(struct net_sockaddr_in6)) {
 			return -EINVAL;
 		}
 
-		memcpy(&server->dispatcher.local_addr,
+		memcpy(&server->dispatcher.local_addr_storage,
 		       local,
 		       sizeof(struct net_sockaddr_in6));
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
-		   server->dns_server.sa_family == NET_AF_INET) {
+		   server->dns_server_addr.ss_family == NET_AF_INET) {
 		if (local_len < sizeof(struct net_sockaddr_in)) {
 			return -EINVAL;
 		}
 
-		memcpy(&server->dispatcher.local_addr,
+		memcpy(&server->dispatcher.local_addr_storage,
 		       local,
 		       sizeof(struct net_sockaddr_in));
 	} else {
@@ -696,13 +696,14 @@ static bool is_server_name_found(struct dns_resolve_context *ctx,
 				 const char *iface_str)
 {
 	ARRAY_FOR_EACH(ctx->servers, i) {
-		if (ctx->servers[i].dns_server.sa_family == NET_AF_INET ||
-		    ctx->servers[i].dns_server.sa_family == NET_AF_INET6) {
+		if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET ||
+		    ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET6) {
 			char addr_str[NET_INET6_ADDRSTRLEN];
 			size_t addr_len;
 
-			if (net_addr_ntop(ctx->servers[i].dns_server.sa_family,
-					  &net_sin(&ctx->servers[i].dns_server)->sin_addr,
+			if (net_addr_ntop(ctx->servers[i].dns_server_addr.ss_family,
+					  &net_sin(net_sad(&ctx->servers[i].dns_server_addr))
+											->sin_addr,
 					  addr_str, sizeof(addr_str)) == NULL) {
 				continue;
 			}
@@ -737,9 +738,11 @@ static int idx_of_server_addr(struct dns_resolve_context *ctx,
 			      int if_index)
 {
 	ARRAY_FOR_EACH(ctx->servers, i) {
-		if (ctx->servers[i].dns_server.sa_family == addr->sa_family &&
-		    memcmp(&ctx->servers[i].dns_server, addr,
-			   sizeof(ctx->servers[i].dns_server)) == 0) {
+		if (ctx->servers[i].dns_server_addr.ss_family == addr->sa_family &&
+		    memcmp(&ctx->servers[i].dns_server_addr, addr,
+			   ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET6 ?
+			   sizeof(struct net_sockaddr_in6) :
+			   sizeof(struct net_sockaddr_in)) == 0) {
 			if (if_index == 0 ||
 			    (if_index > 0 &&
 			     ctx->servers[i].if_index != if_index)) {
@@ -756,7 +759,7 @@ static int idx_of_server_addr(struct dns_resolve_context *ctx,
 static int get_free_slot(struct dns_resolve_context *ctx)
 {
 	ARRAY_FOR_EACH(ctx->servers, i) {
-		if (ctx->servers[i].dns_server.sa_family == 0) {
+		if (ctx->servers[i].dns_server_addr.ss_family == 0) {
 			return i;
 		}
 	}
@@ -907,9 +910,10 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 
 		ctx->servers[idx].source = source;
 
-		addr = &ctx->servers[idx].dns_server;
+		addr = net_sad(&ctx->servers[idx].dns_server_addr);
 
-		(void)memset(addr, 0, sizeof(*addr));
+		(void)memset(&ctx->servers[idx].dns_server_addr, 0,
+			     sizeof(ctx->servers[idx].dns_server_addr));
 
 		ret = net_ipaddr_parse(servers[i], server_len, addr);
 		if (!ret) {
@@ -944,8 +948,9 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 					       interfaces == NULL ? 0 : interfaces[i]);
 		if (found_idx != -1) {
 			NET_DBG("Server %s already exists",
-				net_sprint_addr(ctx->servers[i].dns_server.sa_family,
-						&net_sin(&ctx->servers[i].dns_server)->sin_addr));
+				net_sprint_addr(ctx->servers[i].dns_server_addr.ss_family,
+						&net_sin(net_sad(&ctx->servers[i].dns_server_addr))
+										      ->sin_addr));
 			continue;
 		}
 
@@ -954,15 +959,18 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 		idx = get_free_slot(ctx);
 		if (idx < 0) {
 			NET_DBG("No free slots for server %s",
-				net_sprint_addr(ctx->servers[i].dns_server.sa_family,
-						&net_sin(&ctx->servers[i].dns_server)->sin_addr));
+				net_sprint_addr(ctx->servers[i].dns_server_addr.ss_family,
+						&net_sin(net_sad(&ctx->servers[i].dns_server_addr))
+										      ->sin_addr));
 			break;
 		}
 
 		ctx->servers[idx].source = source;
 
-		memcpy(&ctx->servers[idx].dns_server, servers_sa[i],
-		       sizeof(ctx->servers[idx].dns_server));
+		memcpy(&ctx->servers[idx].dns_server_addr, servers_sa[i],
+		       servers_sa[i]->sa_family == NET_AF_INET6 ?
+		       sizeof(struct net_sockaddr_in6) :
+		       sizeof(struct net_sockaddr_in));
 
 		if (interfaces != NULL) {
 			ctx->servers[idx].if_index = interfaces[i];
@@ -989,9 +997,9 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 	}
 
 	for (i = 0, count = 0;
-	     i < SERVER_COUNT && ctx->servers[i].dns_server.sa_family != 0; i++) {
+	     i < SERVER_COUNT && ctx->servers[i].dns_server_addr.ss_family != 0; i++) {
 
-		if (ctx->servers[i].dns_server.sa_family == NET_AF_INET6) {
+		if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 			local_addr = (struct net_sockaddr *)&local_addr6;
 			addr_len = sizeof(struct net_sockaddr_in6);
@@ -1005,7 +1013,7 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 #endif
 		}
 
-		if (ctx->servers[i].dns_server.sa_family == NET_AF_INET) {
+		if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 			local_addr = (struct net_sockaddr *)&local_addr4;
 			addr_len = sizeof(struct net_sockaddr_in);
@@ -1029,13 +1037,14 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 			/* Socket already exists, so skip it */
 			NET_DBG("Socket %d already exists for %s",
 				ctx->servers[i].sock,
-				net_sprint_addr(ctx->servers[i].dns_server.sa_family,
-						&net_sin(&ctx->servers[i].dns_server)->sin_addr));
+				net_sprint_addr(ctx->servers[i].dns_server_addr.ss_family,
+						&net_sin(net_sad(&ctx->servers[i].dns_server_addr))
+										      ->sin_addr));
 			count++;
 			continue;
 		}
 
-		ret = zsock_socket(ctx->servers[i].dns_server.sa_family,
+		ret = zsock_socket(ctx->servers[i].dns_server_addr.ss_family,
 				   NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 		if (ret < 0) {
 			ret = -errno;
@@ -1048,40 +1057,42 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 		/* Try to bind to the interface if it is set */
 		if (ctx->servers[i].if_index > 0) {
 			ret = bind_to_iface(ctx->servers[i].sock,
-					    &ctx->servers[i].dns_server,
+					    net_sad(&ctx->servers[i].dns_server_addr),
 					    ctx->servers[i].if_index);
 			if (ret < 0) {
 				zsock_close(ctx->servers[i].sock);
 				ctx->servers[i].sock = -1;
-				ctx->servers[i].dns_server.sa_family = 0;
+				ctx->servers[i].dns_server_addr.ss_family = 0;
 				continue;
 			}
 
 			iface = net_if_get_by_index(ctx->servers[i].if_index);
 			NET_DBG("Binding %s to %d",
-				net_sprint_addr(ctx->servers[i].dns_server.sa_family,
-						&net_sin(&ctx->servers[i].dns_server)->sin_addr),
+				net_sprint_addr(ctx->servers[i].dns_server_addr.ss_family,
+						&net_sin(net_sad(&ctx->servers[i].dns_server_addr))
+										       ->sin_addr),
 				ctx->servers[i].if_index);
 		} else {
 			iface = NULL;
 		}
 
-		if (ctx->servers[i].dns_server.sa_family == NET_AF_INET6) {
+		if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET6) {
 			if (iface == NULL) {
 				iface = net_if_ipv6_select_src_iface(
-					&net_sin6(&ctx->servers[i].dns_server)->sin6_addr);
+					&net_sin6(net_sad(&ctx->servers[i].dns_server_addr))
+										->sin6_addr);
 			}
 
 			addr6 = net_if_ipv6_select_src_addr(iface,
-					&net_sin6(&ctx->servers[i].dns_server)->sin6_addr);
+				&net_sin6(net_sad(&ctx->servers[i].dns_server_addr))->sin6_addr);
 		} else {
 			if (iface == NULL) {
 				iface = net_if_ipv4_select_src_iface(
-					&net_sin(&ctx->servers[i].dns_server)->sin_addr);
+				    &net_sin(net_sad(&ctx->servers[i].dns_server_addr))->sin_addr);
 			}
 
 			addr4 = net_if_ipv4_select_src_addr(iface,
-					&net_sin(&ctx->servers[i].dns_server)->sin_addr);
+				&net_sin(net_sad(&ctx->servers[i].dns_server_addr))->sin_addr);
 		}
 
 		ARRAY_FOR_EACH(ctx->fds, j) {
@@ -1103,7 +1114,7 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 			NET_DBG("Cannot set %s to socket (%d)", "polling", ret);
 			zsock_close(ctx->servers[i].sock);
 			ctx->servers[i].sock = -1;
-			ctx->servers[i].dns_server.sa_family = 0;
+			ctx->servers[i].dns_server_addr.ss_family = 0;
 			continue;
 		}
 
@@ -1134,8 +1145,8 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 		if (IS_ENABLED(CONFIG_NET_MGMT_EVENT_INFO)) {
 			net_mgmt_event_notify_with_info(
 				NET_EVENT_DNS_SERVER_ADD,
-				iface, (void *)&ctx->servers[i].dns_server,
-				sizeof(struct net_sockaddr));
+				iface, (void *)&ctx->servers[i].dns_server_addr,
+				sizeof(ctx->servers[i].dns_server_addr));
 		} else {
 			net_mgmt_event_notify(NET_EVENT_DNS_SERVER_ADD, iface);
 		}
@@ -1578,9 +1589,9 @@ static int dns_validate_record(struct dns_resolve_context *ctx, struct dns_msg_t
 	case DNS_RESPONSE_IP: {
 		if (*answer_type == DNS_RR_TYPE_A) {
 			address_size = DNS_IPV4_LEN;
-			addr = (uint8_t *)&net_sin(&info->ai_addr)->sin_addr;
+			addr = (uint8_t *)&net_sin(net_sad(&info->ai_addr_storage))->sin_addr;
 			info->ai_family = NET_AF_INET;
-			info->ai_addr.sa_family = NET_AF_INET;
+			info->ai_addr_storage.ss_family = NET_AF_INET;
 			info->ai_addrlen = sizeof(struct net_sockaddr_in);
 		} else if (*answer_type == DNS_RR_TYPE_AAAA) {
 /* We cannot resolve IPv6 address if IPv6 is
@@ -1590,9 +1601,9 @@ static int dns_validate_record(struct dns_resolve_context *ctx, struct dns_msg_t
  */
 #if defined(CONFIG_NET_IPV6)
 			address_size = DNS_IPV6_LEN;
-			addr = (uint8_t *)&net_sin6(&info->ai_addr)->sin6_addr;
+			addr = (uint8_t *)&net_sin6(net_sad(&info->ai_addr_storage))->sin6_addr;
 			info->ai_family = NET_AF_INET6;
-			info->ai_addr.sa_family = NET_AF_INET6;
+			info->ai_addr_storage.ss_family = NET_AF_INET6;
 			info->ai_addrlen = sizeof(struct net_sockaddr_in6);
 #else
 			return DNS_EAI_FAMILY;
@@ -2048,8 +2059,8 @@ static int dns_write(struct dns_resolve_context *ctx,
 	char *query_name;
 
 	sock = ctx->servers[server_idx].sock;
-	family = ctx->servers[server_idx].dns_server.sa_family;
-	server = &ctx->servers[server_idx].dns_server;
+	family = ctx->servers[server_idx].dns_server_addr.ss_family;
+	server = net_sad(&ctx->servers[server_idx].dns_server_addr);
 	dns_id = ctx->queries[query_idx].id;
 	query_type = ctx->queries[query_idx].query_type;
 
@@ -2357,7 +2368,8 @@ int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 	k_timeout_t tout;
 	struct net_buf *dns_data = NULL;
 	struct net_buf *dns_qname = NULL;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr;
+	struct net_sockaddr *sa = net_sad(&addr);
 	int ret, i = -1;
 	bool mdns_query = false;
 #ifdef CONFIG_DNS_RESOLVER_CACHE
@@ -2380,7 +2392,7 @@ int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 		return -EINVAL;
 	}
 
-	ret = net_ipaddr_parse(query, strlen(query), &addr);
+	ret = net_ipaddr_parse(query, strlen(query), sa);
 	if (ret) {
 		/* The query name was already in numeric form, no
 		 * need to continue further.
@@ -2388,14 +2400,14 @@ int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 		struct dns_addrinfo info = { 0 };
 
 		if (type == DNS_QUERY_TYPE_A) {
-			if (net_sin(&addr)->sin_family == NET_AF_INET6) {
+			if (net_sin(sa)->sin_family == NET_AF_INET6) {
 				return -EPFNOSUPPORT;
 			}
 
-			memcpy(net_sin(&info.ai_addr), net_sin(&addr),
+			memcpy(net_sin(net_sad(&info.ai_addr_storage)), net_sin(sa),
 			       sizeof(struct net_sockaddr_in));
 			info.ai_family = NET_AF_INET;
-			info.ai_addr.sa_family = NET_AF_INET;
+			info.ai_addr_storage.ss_family = NET_AF_INET;
 			info.ai_addrlen = sizeof(struct net_sockaddr_in);
 		} else if (type == DNS_QUERY_TYPE_AAAA) {
 			/* We do not support AI_V4MAPPED atm, so if the user
@@ -2404,15 +2416,15 @@ int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 			 * the error to EINVAL, the EPFNOSUPPORT is returned
 			 * here so that we can find it easily.
 			 */
-			if (net_sin(&addr)->sin_family == NET_AF_INET) {
+			if (net_sin(sa)->sin_family == NET_AF_INET) {
 				return -EPFNOSUPPORT;
 			}
 
 #if defined(CONFIG_NET_IPV6)
-			memcpy(net_sin6(&info.ai_addr), net_sin6(&addr),
+			memcpy(net_sin6(net_sad(&info.ai_addr_storage)), net_sin6(sa),
 			       sizeof(struct net_sockaddr_in6));
 			info.ai_family = NET_AF_INET6;
-			info.ai_addr.sa_family = NET_AF_INET6;
+			info.ai_addr_storage.ss_family = NET_AF_INET6;
 			info.ai_addrlen = sizeof(struct net_sockaddr_in6);
 #else
 			return -EAFNOSUPPORT;
@@ -2461,11 +2473,11 @@ try_resolve:
 
 			struct net_in_addr addr4 = NET_INADDR_LOOPBACK_INIT;
 
-			memcpy(&net_sin(&info.ai_addr)->sin_addr, &addr4,
+			memcpy(&net_sin(net_sad(&info.ai_addr_storage))->sin_addr, &addr4,
 			       sizeof(struct net_in_addr));
 
 			info.ai_family = NET_AF_INET;
-			info.ai_addr.sa_family = NET_AF_INET;
+			info.ai_addr_storage.ss_family = NET_AF_INET;
 			info.ai_addrlen = sizeof(struct net_sockaddr_in);
 
 		} else if (type == DNS_QUERY_TYPE_AAAA) {
@@ -2475,11 +2487,11 @@ try_resolve:
 
 			struct net_in6_addr addr6 = NET_IN6ADDR_LOOPBACK_INIT;
 
-			memcpy(&net_sin6(&info.ai_addr)->sin6_addr, &addr6,
+			memcpy(&net_sin6(net_sad(&info.ai_addr_storage))->sin6_addr, &addr6,
 			       sizeof(struct net_in6_addr));
 
 			info.ai_family = NET_AF_INET6;
-			info.ai_addr.sa_family = NET_AF_INET6;
+			info.ai_addr_storage.ss_family = NET_AF_INET6;
 			info.ai_addrlen = sizeof(struct net_sockaddr_in6);
 		} else {
 			return -EINVAL;
@@ -2513,11 +2525,11 @@ try_resolve:
 					return -ENOENT;
 				}
 
-				memcpy(&net_sin(&info.ai_addr)->sin_addr, paddr,
-				       sizeof(struct net_in_addr));
+				memcpy(&net_sin(net_sad(&info.ai_addr_storage))->sin_addr,
+				       paddr, sizeof(struct net_in_addr));
 
 				info.ai_family = NET_AF_INET;
-				info.ai_addr.sa_family = NET_AF_INET;
+				info.ai_addr_storage.ss_family = NET_AF_INET;
 				info.ai_addrlen = sizeof(struct net_sockaddr_in);
 
 			} else if (type == DNS_QUERY_TYPE_AAAA) {
@@ -2533,11 +2545,11 @@ try_resolve:
 					return -ENOENT;
 				}
 
-				memcpy(&net_sin6(&info.ai_addr)->sin6_addr, paddr,
-				       sizeof(struct net_in6_addr));
+				memcpy(&net_sin6(net_sad(&info.ai_addr_storage))->sin6_addr,
+				       paddr, sizeof(struct net_in6_addr));
 
 				info.ai_family = NET_AF_INET6;
-				info.ai_addr.sa_family = NET_AF_INET6;
+				info.ai_addr_storage.ss_family = NET_AF_INET6;
 				info.ai_addrlen = sizeof(struct net_sockaddr_in6);
 			} else {
 				return -EINVAL;
@@ -2690,20 +2702,20 @@ static int dns_server_close(struct dns_resolve_context *ctx,
 
 	(void)dns_dispatcher_unregister(&ctx->servers[server_idx].dispatcher);
 
-	if (ctx->servers[server_idx].dns_server.sa_family == NET_AF_INET6) {
+	if (ctx->servers[server_idx].dns_server_addr.ss_family == NET_AF_INET6) {
 		iface = net_if_ipv6_select_src_iface(
-			&net_sin6(&ctx->servers[server_idx].dns_server)->sin6_addr);
+			&net_sin6(net_sad(&ctx->servers[server_idx].dns_server_addr))->sin6_addr);
 	} else {
 		iface = net_if_ipv4_select_src_iface(
-			&net_sin(&ctx->servers[server_idx].dns_server)->sin_addr);
+			&net_sin(net_sad(&ctx->servers[server_idx].dns_server_addr))->sin_addr);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_MGMT_EVENT_INFO)) {
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_DNS_SERVER_DEL,
 			iface,
-			(void *)&ctx->servers[server_idx].dns_server,
-			sizeof(struct net_sockaddr));
+			(void *)&ctx->servers[server_idx].dns_server_addr,
+			sizeof(ctx->servers[server_idx].dns_server_addr));
 	} else {
 		net_mgmt_event_notify(NET_EVENT_DNS_SERVER_DEL, iface);
 	}
@@ -2711,7 +2723,7 @@ static int dns_server_close(struct dns_resolve_context *ctx,
 	zsock_close(closed_sock);
 
 	ctx->servers[server_idx].sock = -1;
-	ctx->servers[server_idx].dns_server.sa_family = 0;
+	ctx->servers[server_idx].dns_server_addr.ss_family = 0;
 
 	return 0;
 }
@@ -2772,17 +2784,19 @@ static bool dns_server_exists(struct dns_resolve_context *ctx,
 {
 	for (int i = 0; i < SERVER_COUNT; i++) {
 		if (IS_ENABLED(CONFIG_NET_IPV4) && (addr->sa_family == NET_AF_INET) &&
-		    (ctx->servers[i].dns_server.sa_family == NET_AF_INET)) {
+		    (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET)) {
 			if (net_ipv4_addr_cmp(&net_sin(addr)->sin_addr,
-					      &net_sin(&ctx->servers[i].dns_server)->sin_addr)) {
+					      &net_sin(net_sad(&ctx->servers[i].dns_server_addr))
+										->sin_addr)) {
 				return true;
 			}
 		}
 
 		if (IS_ENABLED(CONFIG_NET_IPV6) && (addr->sa_family == NET_AF_INET6) &&
-		    (ctx->servers[i].dns_server.sa_family == NET_AF_INET6)) {
+		    (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET6)) {
 			if (net_ipv6_addr_cmp(&net_sin6(addr)->sin6_addr,
-					      &net_sin6(&ctx->servers[i].dns_server)->sin6_addr)) {
+					      &net_sin6(net_sad(&ctx->servers[i].dns_server_addr))
+										->sin6_addr)) {
 				return true;
 			}
 		}
@@ -2797,13 +2811,14 @@ static bool dns_servers_exists(struct dns_resolve_context *ctx,
 {
 	if (servers) {
 		for (int i = 0; i < SERVER_COUNT && servers[i]; i++) {
-			struct net_sockaddr addr;
+			struct net_sockaddr_storage addr;
+			struct net_sockaddr *sa = net_sad(&addr);
 
-			if (!net_ipaddr_parse(servers[i], strlen(servers[i]), &addr)) {
+			if (!net_ipaddr_parse(servers[i], strlen(servers[i]), sa)) {
 				continue;
 			}
 
-			if (!dns_server_exists(ctx, &addr)) {
+			if (!dns_server_exists(ctx, sa)) {
 				return false;
 			}
 		}

--- a/subsys/net/lib/ftp/ftp_client.c
+++ b/subsys/net/lib/ftp/ftp_client.c
@@ -88,7 +88,7 @@ static int new_ftp_connection(struct ftp_client *client, enum ftp_channel_type c
 		return -EINVAL;
 	}
 
-	*sock = zsock_socket(client->remote.sa_family, NET_SOCK_STREAM, proto);
+	*sock = zsock_socket(client->remote_addr.ss_family, NET_SOCK_STREAM, proto);
 	if (*sock < 0) {
 		ret = -errno;
 		LOG_ERR("socket(data) failed: %d", ret);
@@ -109,15 +109,15 @@ static int new_ftp_connection(struct ftp_client *client, enum ftp_channel_type c
 	}
 
 	/* Connect to remote host */
-	if (client->remote.sa_family == NET_AF_INET) {
-		net_sin(&client->remote)->sin_port = net_htons(port);
+	if (client->remote_addr.ss_family == NET_AF_INET) {
+		net_sin(net_sad(&client->remote_addr))->sin_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in);
 	} else {
-		net_sin6(&client->remote)->sin6_port = net_htons(port);
+		net_sin6(net_sad(&client->remote_addr))->sin6_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in6);
 	}
 
-	ret = zsock_connect(*sock, &client->remote, addrlen);
+	ret = zsock_connect(*sock, net_sad(&client->remote_addr), addrlen);
 	if (ret < 0) {
 		ret = -errno;
 		LOG_ERR("connect(data) failed: %d", ret);
@@ -597,7 +597,7 @@ int ftp_open(struct ftp_client *client, const char *hostname, uint16_t port, int
 		goto out;
 	}
 
-	memcpy(&client->remote, ai->ai_addr, ai->ai_addrlen);
+	memcpy(&client->remote_addr, ai->ai_addr, ai->ai_addrlen);
 	zsock_freeaddrinfo(ai);
 
 	client->sec_tag = sec_tag;
@@ -1251,7 +1251,7 @@ int ftp_init(struct ftp_client *client, ftp_client_callback_t ctrl_callback,
 	client->ctrl_callback = ctrl_callback;
 	client->data_callback = data_callback;
 
-	memset(&client->remote, 0, sizeof(client->remote));
+	memset(&client->remote_addr, 0, sizeof(client->remote_addr));
 
 	k_mutex_init(&client->lock);
 #if CONFIG_FTP_CLIENT_KEEPALIVE_TIME > 0

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -138,12 +138,13 @@ int lwm2m_open_socket(struct lwm2m_ctx *client_ctx)
 		/* open socket */
 
 		if (IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) && client_ctx->use_dtls) {
-			client_ctx->sock_fd = zsock_socket(client_ctx->remote_addr.sa_family,
-							   NET_SOCK_DGRAM, NET_IPPROTO_DTLS_1_2);
+			client_ctx->sock_fd = zsock_socket(
+				client_ctx->remote_addr_storage.ss_family,
+				NET_SOCK_DGRAM, NET_IPPROTO_DTLS_1_2);
 		} else {
 			client_ctx->sock_fd =
-				zsock_socket(client_ctx->remote_addr.sa_family, NET_SOCK_DGRAM,
-					     NET_IPPROTO_UDP);
+				zsock_socket(client_ctx->remote_addr_storage.ss_family,
+					     NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 		}
 
 		if (client_ctx->sock_fd < 0) {
@@ -702,11 +703,12 @@ static int socket_recv_message(struct lwm2m_ctx *client_ctx)
 	static uint8_t in_buf[NET_IPV6_MTU];
 	net_socklen_t from_addr_len;
 	ssize_t len;
-	static struct net_sockaddr from_addr;
+	static struct net_sockaddr_storage from_addr;
+	struct net_sockaddr *from_sa = net_sad(&from_addr);
 
 	from_addr_len = sizeof(from_addr);
 	len = zsock_recvfrom(client_ctx->sock_fd, in_buf, sizeof(in_buf) - 1, ZSOCK_MSG_DONTWAIT,
-			     &from_addr, &from_addr_len);
+			     from_sa, &from_addr_len);
 
 	if (len < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -726,7 +728,7 @@ static int socket_recv_message(struct lwm2m_ctx *client_ctx)
 	}
 
 	in_buf[len] = 0U;
-	lwm2m_udp_receive(client_ctx, in_buf, len, &from_addr);
+	lwm2m_udp_receive(client_ctx, in_buf, len, from_sa);
 
 	return 0;
 }
@@ -1215,16 +1217,17 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 		goto error;
 	}
 
-	if ((client_ctx->remote_addr).sa_family == NET_AF_INET) {
+	if ((client_ctx->remote_addr_storage).ss_family == NET_AF_INET) {
 		addr_len = sizeof(struct net_sockaddr_in);
-	} else if ((client_ctx->remote_addr).sa_family == NET_AF_INET6) {
+	} else if ((client_ctx->remote_addr_storage).ss_family == NET_AF_INET6) {
 		addr_len = sizeof(struct net_sockaddr_in6);
 	} else {
 		ret = -EPROTONOSUPPORT;
 		goto error;
 	}
 
-	if (zsock_connect(client_ctx->sock_fd, &client_ctx->remote_addr, addr_len) < 0) {
+	if (zsock_connect(client_ctx->sock_fd,
+			  net_sad(&client_ctx->remote_addr_storage), addr_len) < 0) {
 		ret = -errno;
 		LOG_ERR("Cannot connect UDP (%d)", ret);
 		goto error;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -674,7 +674,8 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 		goto cleanup_unlock;
 	}
 
-	r = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr, NULL);
+	r = coap_pending_init(msg->pending, &msg->cpkt,
+			      net_sad(&msg->ctx->remote_addr_storage), NULL);
 	if (r < 0) {
 		LOG_ERR("Unable to initialize a pending "
 			"retransmission (err:%d).",
@@ -2672,7 +2673,8 @@ static int lwm2m_response_promote_to_con(struct lwm2m_message *msg)
 		return -ENOMEM;
 	}
 
-	ret = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr, NULL);
+	ret = coap_pending_init(msg->pending, &msg->cpkt,
+				net_sad(&msg->ctx->remote_addr_storage), NULL);
 	if (ret < 0) {
 		LOG_ERR("Unable to initialize a pending "
 			"retransmission (err:%d).",
@@ -3144,7 +3146,8 @@ msg_init:
 		LOG_DBG("[%s] NOTIFY MSG START: %u/%u/%u(%u) token:'%s' [%s] %lld",
 			obs->resource_update ? "MANUAL" : "AUTO", path->obj_id, path->obj_inst_id,
 			path->res_id, path->level, sprint_token(obs->token, obs->tkl),
-			lwm2m_sprint_ip_addr(&ctx->remote_addr), (long long)k_uptime_get());
+			lwm2m_sprint_ip_addr(net_sad(&ctx->remote_addr_storage)),
+			(long long)k_uptime_get());
 
 		obj_inst = get_engine_obj_inst(path->obj_id, path->obj_inst_id);
 		if (!obj_inst) {
@@ -3156,7 +3159,8 @@ msg_init:
 	} else {
 		LOG_DBG("[%s] NOTIFY MSG START: (Composite)) token:'%s' [%s] %lld",
 			obs->resource_update ? "MANUAL" : "AUTO",
-			sprint_token(obs->token, obs->tkl), lwm2m_sprint_ip_addr(&ctx->remote_addr),
+			sprint_token(obs->token, obs->tkl),
+			lwm2m_sprint_ip_addr(net_sad(&ctx->remote_addr_storage)),
 			(long long)k_uptime_get());
 	}
 
@@ -3380,17 +3384,17 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 	url[off + len] = '\0';
 
 	/* initialize remote_addr */
-	(void)memset(&client_ctx->remote_addr, 0, sizeof(client_ctx->remote_addr));
+	(void)memset(&client_ctx->remote_addr_storage, 0, sizeof(client_ctx->remote_addr_storage));
 
 	/* try and set IP address directly */
-	client_ctx->remote_addr.sa_family = NET_AF_INET6;
+	client_ctx->remote_addr_storage.ss_family = NET_AF_INET6;
 	ret = net_addr_pton(NET_AF_INET6, url + off,
-			    &((struct net_sockaddr_in6 *)&client_ctx->remote_addr)->sin6_addr);
+			&((struct net_sockaddr_in6 *)&client_ctx->remote_addr_storage)->sin6_addr);
 	/* Try to parse again using NET_AF_INET */
 	if (ret < 0) {
-		client_ctx->remote_addr.sa_family = NET_AF_INET;
+		client_ctx->remote_addr_storage.ss_family = NET_AF_INET;
 		ret = net_addr_pton(NET_AF_INET, url + off,
-				&((struct net_sockaddr_in *)&client_ctx->remote_addr)->sin_addr);
+			&((struct net_sockaddr_in *)&client_ctx->remote_addr_storage)->sin_addr);
 	}
 
 	if (ret < 0) {
@@ -3413,8 +3417,9 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 			goto cleanup;
 		}
 
-		memcpy(&client_ctx->remote_addr, res->ai_addr, sizeof(client_ctx->remote_addr));
-		client_ctx->remote_addr.sa_family = res->ai_family;
+		memcpy(&client_ctx->remote_addr_storage, res->ai_addr,
+		       sizeof(client_ctx->remote_addr_storage));
+		client_ctx->remote_addr_storage.ss_family = res->ai_family;
 		zsock_freeaddrinfo(res);
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 		/** copy url pointer to be used in socket */
@@ -3428,10 +3433,12 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 	}
 
 	/* set port */
-	if (client_ctx->remote_addr.sa_family == NET_AF_INET6) {
-		net_sin6(&client_ctx->remote_addr)->sin6_port = net_htons(parser.port);
-	} else if (client_ctx->remote_addr.sa_family == NET_AF_INET) {
-		net_sin(&client_ctx->remote_addr)->sin_port = net_htons(parser.port);
+	if (client_ctx->remote_addr_storage.ss_family == NET_AF_INET6) {
+		net_sin6(net_sad(&client_ctx->remote_addr_storage))->sin6_port =
+			net_htons(parser.port);
+	} else if (client_ctx->remote_addr_storage.ss_family == NET_AF_INET) {
+		net_sin(net_sad(&client_ctx->remote_addr_storage))->sin_port =
+			net_htons(parser.port);
 	} else {
 		ret = -EPROTONOSUPPORT;
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -764,7 +764,7 @@ static void engine_observe_node_init(struct observe_node *obs, const uint8_t *to
 	}
 
 	LOG_DBG("token:'%s' addr:%s", sprint_token(token, tkl),
-		lwm2m_sprint_ip_addr(&ctx->remote_addr));
+		lwm2m_sprint_ip_addr(net_sad(&ctx->remote_addr_storage)));
 }
 
 static void remove_observer_path_from_list(struct lwm2m_ctx *ctx, struct observe_node *obs,
@@ -915,7 +915,7 @@ static int engine_add_observer(struct lwm2m_message *msg, const uint8_t *token, 
 
 		LOG_DBG("OBSERVER DUPLICATE %u/%u/%u(%u) [%s]", msg->path.obj_id,
 			msg->path.obj_inst_id, msg->path.res_id, msg->path.level,
-			lwm2m_sprint_ip_addr(&msg->ctx->remote_addr));
+			lwm2m_sprint_ip_addr(net_sad(&msg->ctx->remote_addr_storage)));
 
 		lwm2m_engine_observer_refresh_notified_values(obs);
 
@@ -1007,7 +1007,7 @@ static int engine_add_composite_observer(struct lwm2m_message *msg, const uint8_
 		}
 
 		LOG_DBG("OBSERVER Composite DUPLICATE [%s]",
-			lwm2m_sprint_ip_addr(&msg->ctx->remote_addr));
+			lwm2m_sprint_ip_addr(net_sad(&msg->ctx->remote_addr_storage)));
 
 		lwm2m_engine_observer_refresh_notified_values(obs);
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1023,7 +1023,7 @@ static int sm_send_registration(bool send_obj_support_data,
 
 	/* log the registration attempt */
 	LOG_DBG("registration sent [%s]",
-		lwm2m_sprint_ip_addr(&client.ctx->remote_addr));
+		lwm2m_sprint_ip_addr(net_sad(&client.ctx->remote_addr_storage)));
 
 	return 0;
 

--- a/subsys/net/lib/midi2/netmidi2.c
+++ b/subsys/net/lib/midi2/netmidi2.c
@@ -721,7 +721,8 @@ static void netmidi2_service_handler(struct net_socket_service_event *pev)
 	int ret;
 	struct netmidi2_ep *ep = pev->user_data;
 	struct zsock_pollfd *pfd = &pev->event;
-	struct net_sockaddr peer_addr;
+	struct net_sockaddr_storage peer_addr;
+	struct net_sockaddr *peer_sa = net_sad(&peer_addr);
 	net_socklen_t peer_addr_len = sizeof(peer_addr);
 	struct net_buf *rxbuf;
 
@@ -732,7 +733,7 @@ static void netmidi2_service_handler(struct net_socket_service_event *pev)
 	}
 
 	ret = zsock_recvfrom(pfd->fd, rxbuf->data, rxbuf->size, 0,
-			     &peer_addr, &peer_addr_len);
+			     peer_sa, &peer_addr_len);
 	if (ret < 0) {
 		LOG_ERR("Rx error: %d (%d)", ret, errno);
 		goto end;
@@ -752,7 +753,7 @@ static void netmidi2_service_handler(struct net_socket_service_event *pev)
 	/* Parse contained command packets */
 	ret = 0;
 	while (ret == 0 && rxbuf->len >= 4) {
-		ret = netmidi2_dispatch_cmdpkt(ep, &peer_addr, peer_addr_len, rxbuf);
+		ret = netmidi2_dispatch_cmdpkt(ep, peer_sa, peer_addr_len, rxbuf);
 	}
 
 end:

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -250,7 +250,7 @@ int mqtt_client_set_proxy(struct mqtt_client *client,
 		}
 
 		client->transport.proxy.addrlen = addrlen;
-		memcpy(&client->transport.proxy.addr, proxy_addr, addrlen);
+		memcpy(&client->transport.proxy.addr_storage, proxy_addr, addrlen);
 
 		return 0;
 	}

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
@@ -54,7 +54,7 @@ int mqtt_client_tcp_connect(struct mqtt_client *client)
 	if (client->transport.proxy.addrlen != 0) {
 		ret = setsockopt(client->transport.tcp.sock,
 				 ZSOCK_SOL_SOCKET, ZSOCK_SO_SOCKS5,
-				 &client->transport.proxy.addr,
+				 net_sad(&client->transport.proxy.addr_storage),
 				 client->transport.proxy.addrlen);
 		if (ret < 0) {
 			goto error;

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -67,7 +67,7 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 	if (client->transport.proxy.addrlen != 0) {
 		ret = setsockopt(client->transport.tls.sock,
 				 ZSOCK_SOL_SOCKET, ZSOCK_SO_SOCKS5,
-				 &client->transport.proxy.addr,
+				 net_sad(&client->transport.proxy.addr_storage),
 				 client->transport.proxy.addrlen);
 		if (ret < 0) {
 			goto error;

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -48,10 +48,10 @@ static char *get_ip_str(const struct net_sockaddr *sa, char *s, size_t maxlen)
 
 static int get_multicast_ttl(struct mqtt_sn_transport_udp *udp, int *ttl, net_socklen_t *ttl_len)
 {
-	if (udp->bcaddr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
+	if (udp->bcaddr_storage.ss_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
 		return zsock_getsockopt(udp->sock, NET_IPPROTO_IP, ZSOCK_IP_MULTICAST_TTL, ttl,
 					ttl_len);
-	} else if (udp->bcaddr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
+	} else if (udp->bcaddr_storage.ss_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
 		return zsock_getsockopt(udp->sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_MULTICAST_HOPS, ttl,
 					ttl_len);
 	}
@@ -62,10 +62,10 @@ static int get_multicast_ttl(struct mqtt_sn_transport_udp *udp, int *ttl, net_so
 
 static int set_multicast_ttl(struct mqtt_sn_transport_udp *udp, int *ttl, net_socklen_t ttl_len)
 {
-	if (udp->bcaddr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
+	if (udp->bcaddr_storage.ss_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
 		return zsock_setsockopt(udp->sock, NET_IPPROTO_IP, ZSOCK_IP_MULTICAST_TTL, ttl,
 					ttl_len);
-	} else if (udp->bcaddr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
+	} else if (udp->bcaddr_storage.ss_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
 		return zsock_setsockopt(udp->sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_MULTICAST_HOPS, ttl,
 					ttl_len);
 	}
@@ -79,7 +79,7 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(transport);
 	int err;
 	int errno_backup;
-	struct net_sockaddr addrm;
+	struct net_sockaddr_storage addrm;
 	int optval;
 	struct net_if *iface;
 
@@ -87,7 +87,7 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		return -EALREADY;
 	}
 
-	udp->sock = zsock_socket(udp->bcaddr.sa_family, NET_SOCK_DGRAM, 0);
+	udp->sock = zsock_socket(udp->bcaddr_storage.ss_family, NET_SOCK_DGRAM, 0);
 	if (udp->sock < 0) {
 		return -errno;
 	}
@@ -105,13 +105,13 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		char ip[NET_INET6_ADDRSTRLEN], *out;
 		uint16_t port = 0;
 
-		out = get_ip_str((struct net_sockaddr *)&udp->bcaddr, ip, sizeof(ip));
-		switch (udp->bcaddr.sa_family) {
+		out = get_ip_str(net_sad(&udp->bcaddr_storage), ip, sizeof(ip));
+		switch (udp->bcaddr_storage.ss_family) {
 		case NET_AF_INET:
-			port = net_ntohs(((struct net_sockaddr_in *)&udp->bcaddr)->sin_port);
+			port = net_ntohs(net_sin(net_sad(&udp->bcaddr_storage))->sin_port);
 			break;
 		case NET_AF_INET6:
-			port = net_ntohs(((struct net_sockaddr_in6 *)&udp->bcaddr)->sin6_port);
+			port = net_ntohs(net_sin6(net_sad(&udp->bcaddr_storage))->sin6_port);
 			break;
 		default:
 			break;
@@ -122,20 +122,20 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		}
 	}
 
-	switch (udp->bcaddr.sa_family) {
+	switch (udp->bcaddr_storage.ss_family) {
 	case NET_AF_INET:
 		if (IS_ENABLED(CONFIG_NET_IPV4)) {
-			addrm.sa_family = NET_AF_INET;
+			addrm.ss_family = NET_AF_INET;
 			((struct net_sockaddr_in *)&addrm)->sin_port =
-				((struct net_sockaddr_in *)&udp->bcaddr)->sin_port;
+				((struct net_sockaddr_in *)&udp->bcaddr_storage)->sin_port;
 			((struct net_sockaddr_in *)&addrm)->sin_addr.s_addr = NET_INADDR_ANY;
 		}
 		break;
 	case NET_AF_INET6:
 		if (IS_ENABLED(CONFIG_NET_IPV6)) {
-			addrm.sa_family = NET_AF_INET6;
+			addrm.ss_family = NET_AF_INET6;
 			((struct net_sockaddr_in6 *)&addrm)->sin6_port =
-				((struct net_sockaddr_in6 *)&udp->bcaddr)->sin6_port;
+				((struct net_sockaddr_in6 *)&udp->bcaddr_storage)->sin6_port;
 			memcpy(&((struct net_sockaddr_in6 *)&addrm)->sin6_addr, &net_in6addr_any,
 			       sizeof(struct net_in6_addr));
 			break;
@@ -145,19 +145,19 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		return -EINVAL;
 	}
 
-	err = zsock_bind(udp->sock, &addrm, sizeof(addrm));
+	err = zsock_bind(udp->sock, net_sad(&addrm), sizeof(addrm));
 	if (err) {
 		errno_backup = errno;
 		LOG_ERR("Error during bind: %d", errno_backup);
 		return errno_backup;
 	}
 
-	if (udp->bcaddr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
-		struct net_sockaddr_in *bcaddr_in = (struct net_sockaddr_in *)&udp->bcaddr;
+	if (udp->bcaddr_storage.ss_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
+		struct net_sockaddr_in *bcaddr_in = (struct net_sockaddr_in *)&udp->bcaddr_storage;
 		struct net_ip_mreqn mreqn;
 
 		iface = net_if_ipv4_select_src_iface(
-			&((struct net_sockaddr_in *)&udp->bcaddr)->sin_addr);
+			&((struct net_sockaddr_in *)&udp->bcaddr_storage)->sin_addr);
 
 		mreqn = (struct net_ip_mreqn) {
 			.imr_multiaddr = bcaddr_in->sin_addr,
@@ -169,8 +169,9 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		if (err < 0 && errno != EALREADY) {
 			return -errno;
 		}
-	} else if (udp->bcaddr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
-		struct net_sockaddr_in6 *bcaddr_in6 = (struct net_sockaddr_in6 *)&udp->bcaddr;
+	} else if (udp->bcaddr_storage.ss_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
+		struct net_sockaddr_in6 *bcaddr_in6 =
+						(struct net_sockaddr_in6 *)&udp->bcaddr_storage;
 		struct net_ipv6_mreq mreq;
 
 		iface = net_if_ipv6_select_src_iface(
@@ -235,7 +236,8 @@ static int tp_udp_sendto(struct mqtt_sn_transport *transport, void *buf, size_t 
 			}
 		}
 
-		rc = zsock_sendto(udp->sock, buf, sz, 0, &udp->bcaddr, udp->bcaddrlen);
+		rc = zsock_sendto(udp->sock, buf, sz, 0,
+				  net_sad(&udp->bcaddr_storage), udp->bcaddrlen);
 	} else {
 		LOG_HEXDUMP_DBG(buf, sz, "Sending Addressed UDP packet");
 		rc = zsock_sendto(udp->sock, buf, sz, 0, dest_addr, addrlen);
@@ -311,7 +313,7 @@ int mqtt_sn_transport_udp_init(struct mqtt_sn_transport_udp *udp, struct net_soc
 
 	udp->sock = -1;
 
-	memcpy(&udp->bcaddr, bcaddr, addrlen);
+	memcpy(&udp->bcaddr_storage, bcaddr, addrlen);
 	udp->bcaddrlen = addrlen;
 
 	return 0;

--- a/subsys/net/lib/ocpp/ocpp.c
+++ b/subsys/net/lib/ocpp/ocpp.c
@@ -126,8 +126,8 @@ static int ocpp_connect_to_cs(struct ocpp_info *ctx)
 	int ret;
 	struct websocket_request config = {0};
 	struct ocpp_upstream_info *ui = &ctx->ui;
-	struct net_sockaddr addr_buf;
-	struct net_sockaddr *addr = &addr_buf;
+	struct net_sockaddr_storage addr_buf;
+	struct net_sockaddr *addr = net_sad(&addr_buf);
 	int addr_size;
 
 	if (ui->csi.sa_family == NET_AF_INET) {

--- a/subsys/net/lib/ptp/msg.h
+++ b/subsys/net/lib/ptp/msg.h
@@ -304,7 +304,7 @@ struct ptp_msg {
 	/** Single-linked list of TLVs attached to the message. */
 	sys_slist_t tlvs;
 	/** Protocol address of the sender/receiver of the message. */
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr;
 };
 
 /**

--- a/subsys/net/lib/ptp/transport.c
+++ b/subsys/net/lib/ptp/transport.c
@@ -295,32 +295,33 @@ static int transport_l2_open(struct net_if *iface)
 static int transport_send_udp(int socket, int port, void *buf, int length,
 			      struct net_sockaddr *addr)
 {
-	struct net_sockaddr m_addr;
+	struct net_sockaddr_storage m_addr_storage;
+	struct net_sockaddr *m_addr = net_sad(&m_addr_storage);
 	net_socklen_t addrlen;
 	int cnt;
 
 	if (!addr) {
 		if (IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL)) {
-			m_addr.sa_family = NET_AF_INET;
-			net_sin(&m_addr)->sin_port = net_htons(port);
+			m_addr->sa_family = NET_AF_INET;
+			net_sin(m_addr)->sin_port = net_htons(port);
 			if (transport_is_pdelay_msg(buf)) {
-				net_sin(&m_addr)->sin_addr.s_addr = pdelay_mcast_addr_ipv4.s_addr;
+				net_sin(m_addr)->sin_addr.s_addr = pdelay_mcast_addr_ipv4.s_addr;
 			} else {
-				net_sin(&m_addr)->sin_addr.s_addr = mcast_addr_ipv4.s_addr;
+				net_sin(m_addr)->sin_addr.s_addr = mcast_addr_ipv4.s_addr;
 			}
 
 		} else if (IS_ENABLED(CONFIG_PTP_UDP_IPV6_PROTOCOL)) {
-			m_addr.sa_family = NET_AF_INET6;
-			net_sin6(&m_addr)->sin6_port = net_htons(port);
+			m_addr->sa_family = NET_AF_INET6;
+			net_sin6(m_addr)->sin6_port = net_htons(port);
 			if (transport_is_pdelay_msg(buf)) {
-				memcpy(&net_sin6(&m_addr)->sin6_addr, &pdelay_mcast_addr_ipv6,
+				memcpy(&net_sin6(m_addr)->sin6_addr, &pdelay_mcast_addr_ipv6,
 				       sizeof(struct net_in6_addr));
 			} else {
-				memcpy(&net_sin6(&m_addr)->sin6_addr, &mcast_addr_ipv6,
+				memcpy(&net_sin6(m_addr)->sin6_addr, &mcast_addr_ipv6,
 				       sizeof(struct net_in6_addr));
 			}
 		}
-		addr = &m_addr;
+		addr = m_addr;
 	}
 
 	addrlen = IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL) ? sizeof(struct net_sockaddr_in)
@@ -463,7 +464,8 @@ int ptp_transport_sendto(struct ptp_port *port, struct ptp_msg *msg, enum ptp_so
 		return transport_send_l2(port, port->socket[PTP_SOCKET_EVENT], msg, length);
 	}
 
-	return transport_send_udp(port->socket[idx], socket_port[idx], msg, length, &msg->addr);
+	return transport_send_udp(port->socket[idx], socket_port[idx], msg, length,
+				  net_sad(&msg->addr));
 }
 
 static void transport_init_recv_msghdr(struct ptp_msg *msg, struct net_msghdr *msghdr,

--- a/subsys/net/lib/shell/conn.c
+++ b/subsys/net/lib/shell/conn.c
@@ -63,43 +63,41 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 #endif
 	struct net_shell_user_data *data = user_data;
 	const struct shell *sh = data->sh;
+	struct net_sockaddr *local = net_sad(&conn->local_addr);
+	struct net_sockaddr *remote = net_sad(&conn->remote_addr);
 	int *count = data->user_data;
 	/* +7 for []:port */
 	char addr_local[ADDR_LEN + 7];
 	char addr_remote[ADDR_LEN + 7] = "";
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && conn->local_addr.sa_family == NET_AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && conn->local_addr.ss_family == NET_AF_INET6) {
 		snprintk(addr_local, sizeof(addr_local), "[%s]:%u",
-			 net_sprint_ipv6_addr(
-				 &net_sin6(&conn->local_addr)->sin6_addr),
-			 net_ntohs(net_sin6(&conn->local_addr)->sin6_port));
+			 net_sprint_ipv6_addr(&net_sin6(local)->sin6_addr),
+			 net_ntohs(net_sin6(local)->sin6_port));
 		snprintk(addr_remote, sizeof(addr_remote), "[%s]:%u",
-			 net_sprint_ipv6_addr(
-				 &net_sin6(&conn->remote_addr)->sin6_addr),
-			 net_ntohs(net_sin6(&conn->remote_addr)->sin6_port));
+			 net_sprint_ipv6_addr(&net_sin6(remote)->sin6_addr),
+			 net_ntohs(net_sin6(remote)->sin6_port));
 
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && conn->local_addr.sa_family == NET_AF_INET) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && conn->local_addr.ss_family == NET_AF_INET) {
 		snprintk(addr_local, sizeof(addr_local), "%s:%d",
-			 net_sprint_ipv4_addr(
-				 &net_sin(&conn->local_addr)->sin_addr),
-			 net_ntohs(net_sin(&conn->local_addr)->sin_port));
+			 net_sprint_ipv4_addr(&net_sin(local)->sin_addr),
+			 net_ntohs(net_sin(local)->sin_port));
 		snprintk(addr_remote, sizeof(addr_remote), "%s:%d",
-			 net_sprint_ipv4_addr(
-				 &net_sin(&conn->remote_addr)->sin_addr),
-			 net_ntohs(net_sin(&conn->remote_addr)->sin_port));
+			 net_sprint_ipv4_addr(&net_sin(remote)->sin_addr),
+			 net_ntohs(net_sin(remote)->sin_port));
 
-	} else if (conn->local_addr.sa_family == NET_AF_UNSPEC) {
+	} else if (conn->local_addr.ss_family == NET_AF_UNSPEC) {
 		snprintk(addr_local, sizeof(addr_local), "AF_UNSPEC");
-	} else if (conn->local_addr.sa_family == NET_AF_PACKET) {
+	} else if (conn->local_addr.ss_family == NET_AF_PACKET) {
 		snprintk(addr_local, sizeof(addr_local), "AF_PACKET");
 	} else {
 		snprintk(addr_local, sizeof(addr_local), "AF_UNK(%d)",
-			 conn->local_addr.sa_family);
+			 conn->local_addr.ss_family);
 	}
 
 	PR("[%2d] %p %p  %s\t%16s\t%16s\n",
 	   (*count) + 1, conn, conn->cb,
-	   net_proto2str(conn->local_addr.sa_family, conn->proto),
+	   net_proto2str(conn->local_addr.ss_family, conn->proto),
 	   addr_local, addr_remote);
 
 	(*count)++;

--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -39,13 +39,13 @@ static void dns_result_cb(enum dns_resolve_status status,
 		switch (info->ai_family) {
 		case NET_AF_INET:
 			net_addr_ntop(NET_AF_INET,
-				      &net_sin(&info->ai_addr)->sin_addr,
+				      &net_sin(net_sad(&info->ai_addr_storage))->sin_addr,
 				      str, sizeof(str));
 			break;
 
 		case NET_AF_INET6:
 			net_addr_ntop(NET_AF_INET6,
-				      &net_sin6(&info->ai_addr)->sin6_addr,
+				      &net_sin6(net_sad(&info->ai_addr_storage))->sin6_addr,
 				      str, sizeof(str));
 			break;
 
@@ -142,6 +142,8 @@ static void print_dns_info(const struct shell *sh,
 
 	for (i = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS +
 		     DNS_MAX_MCAST_SERVERS; i++) {
+		struct net_sockaddr *server_addr =
+			net_sad(&ctx->servers[i].dns_server_addr);
 		char iface_name[NET_IFNAMSIZ] = { 0 };
 
 		if (ctx->servers[i].if_index > 0) {
@@ -154,12 +156,11 @@ static void print_dns_info(const struct shell *sh,
 			}
 		}
 
-		if (ctx->servers[i].dns_server.sa_family == NET_AF_INET) {
+		if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET) {
 			PR("\t%s:%u%s%s%s%s%s\n",
 			   net_sprint_ipv4_addr(
-				   &net_sin(&ctx->servers[i].dns_server)->
-				   sin_addr),
-			   net_ntohs(net_sin(&ctx->servers[i].dns_server)->sin_port),
+				   &net_sin(server_addr)->sin_addr),
+			   net_ntohs(net_sin(server_addr)->sin_port),
 			   printable_iface(iface_name, " via ", ""),
 			   printable_iface(iface_name, iface_name, ""),
 			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ? " (" : "",
@@ -167,12 +168,11 @@ static void print_dns_info(const struct shell *sh,
 					dns_get_source_str(ctx->servers[i].source) : "",
 			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ? ")" : "");
 
-		} else if (ctx->servers[i].dns_server.sa_family == NET_AF_INET6) {
+		} else if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET6) {
 			PR("\t[%s]:%u%s%s%s%s%s\n",
 			   net_sprint_ipv6_addr(
-				   &net_sin6(&ctx->servers[i].dns_server)->
-				   sin6_addr),
-			   net_ntohs(net_sin6(&ctx->servers[i].dns_server)->sin6_port),
+				   &net_sin6(server_addr)->sin6_addr),
+			   net_ntohs(net_sin6(server_addr)->sin6_port),
 			   printable_iface(iface_name, " via ", ""),
 			   printable_iface(iface_name, iface_name, ""),
 			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ? " (" : "",
@@ -509,14 +509,14 @@ static int cmd_net_dns_service(const struct shell *sh, size_t argc, char *argv[]
 		switch (info.ai_family) {
 		case NET_AF_INET:
 			cp = net_addr_ntop(NET_AF_INET,
-					   &net_sin(&info.ai_addr)->sin_addr,
+					   &net_sin(net_sad(&info.ai_addr_storage))->sin_addr,
 					   str.in4, sizeof(str.in4));
 			PR("AF_INET %s:%u\n", cp ? cp : "<invalid>", port);
 			break;
 
 		case NET_AF_INET6:
 			cp = net_addr_ntop(NET_AF_INET6,
-					   &net_sin6(&info.ai_addr)->sin6_addr,
+					   &net_sin6(net_sad(&info.ai_addr_storage))->sin6_addr,
 					   str.in6, sizeof(str.in6));
 			PR("AF_INET6 [%s]:%u\n", cp ? cp : "<invalid>", port);
 			break;

--- a/subsys/net/lib/shell/http_client.c
+++ b/subsys/net/lib/shell/http_client.c
@@ -189,7 +189,7 @@ static void http_client_dns_cb(enum dns_resolve_status status, struct dns_addrin
 		return;
 	}
 
-	ctx->sa = *(net_sas(&info->ai_addr));
+	ctx->sa = info->ai_addr_storage;
 	ctx->sa.ss_family = info->ai_family;
 	ctx->err = 0;
 }

--- a/subsys/net/lib/shell/tcp.c
+++ b/subsys/net/lib/shell/tcp.c
@@ -102,8 +102,10 @@ static void tcp_connect(const struct shell *sh, char *host, uint16_t port,
 			struct net_context **ctx)
 {
 	struct net_if *iface = net_if_get_default();
-	struct net_sockaddr myaddr;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage myaddr;
+	struct net_sockaddr_storage addr;
+	struct net_sockaddr *my_sa = net_sad(&myaddr);
+	struct net_sockaddr *sa = net_sad(&addr);
 	struct net_nbr *nbr;
 	int addrlen;
 	int family;
@@ -111,73 +113,73 @@ static void tcp_connect(const struct shell *sh, char *host, uint16_t port,
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && !IS_ENABLED(CONFIG_NET_IPV4)) {
 		ret = net_addr_pton(NET_AF_INET6, host,
-				    &net_sin6(&addr)->sin6_addr);
+				    &net_sin6(sa)->sin6_addr);
 		if (ret < 0) {
 			PR_WARNING("Invalid IPv6 address\n");
 			return;
 		}
 
-		net_sin6(&addr)->sin6_port = net_htons(port);
+		net_sin6(sa)->sin6_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in6);
 
-		nbr = net_ipv6_nbr_lookup(NULL, &net_sin6(&addr)->sin6_addr);
+		nbr = net_ipv6_nbr_lookup(NULL, &net_sin6(sa)->sin6_addr);
 		if (nbr) {
 			iface = nbr->iface;
 		}
 
-		get_my_ipv6_addr(iface, &myaddr);
-		family = addr.sa_family = myaddr.sa_family = NET_AF_INET6;
+		get_my_ipv6_addr(iface, my_sa);
+		family = sa->sa_family = my_sa->sa_family = NET_AF_INET6;
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   !IS_ENABLED(CONFIG_NET_IPV6)) {
 		ARG_UNUSED(nbr);
 
-		ret = net_addr_pton(NET_AF_INET, host, &net_sin(&addr)->sin_addr);
+		ret = net_addr_pton(NET_AF_INET, host, &net_sin(sa)->sin_addr);
 		if (ret < 0) {
 			PR_WARNING("Invalid IPv4 address\n");
 			return;
 		}
 
-		get_my_ipv4_addr(iface, &myaddr);
-		net_sin(&addr)->sin_port = net_htons(port);
+		get_my_ipv4_addr(iface, my_sa);
+		net_sin(sa)->sin_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in);
-		family = addr.sa_family = myaddr.sa_family = NET_AF_INET;
+		family = sa->sa_family = my_sa->sa_family = NET_AF_INET;
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   IS_ENABLED(CONFIG_NET_IPV4)) {
 		ret = net_addr_pton(NET_AF_INET6, host,
-				    &net_sin6(&addr)->sin6_addr);
+				    &net_sin6(sa)->sin6_addr);
 		if (ret < 0) {
 			ret = net_addr_pton(NET_AF_INET, host,
-					    &net_sin(&addr)->sin_addr);
+					    &net_sin(sa)->sin_addr);
 			if (ret < 0) {
 				PR_WARNING("Invalid IP address\n");
 				return;
 			}
 
-			net_sin(&addr)->sin_port = net_htons(port);
+			net_sin(sa)->sin_port = net_htons(port);
 			addrlen = sizeof(struct net_sockaddr_in);
 
-			get_my_ipv4_addr(iface, &myaddr);
-			family = addr.sa_family = myaddr.sa_family = NET_AF_INET;
+			get_my_ipv4_addr(iface, my_sa);
+			family = sa->sa_family = my_sa->sa_family = NET_AF_INET;
 		} else {
-			net_sin6(&addr)->sin6_port = net_htons(port);
+			net_sin6(sa)->sin6_port = net_htons(port);
 			addrlen = sizeof(struct net_sockaddr_in6);
 
 			nbr = net_ipv6_nbr_lookup(NULL,
-						  &net_sin6(&addr)->sin6_addr);
+						  &net_sin6(sa)->sin6_addr);
 			if (nbr) {
 				iface = nbr->iface;
 			}
 
-			get_my_ipv6_addr(iface, &myaddr);
-			family = addr.sa_family = myaddr.sa_family = NET_AF_INET6;
+			get_my_ipv6_addr(iface, my_sa);
+			family = sa->sa_family = my_sa->sa_family = NET_AF_INET6;
 		}
 	} else {
 		PR_WARNING("No IPv6 nor IPv4 is enabled\n");
 		return;
 	}
 
-	print_connect_info(sh, family, &myaddr, &addr);
+	print_connect_info(sh, family, my_sa, sa);
 
 	ret = net_context_get(family, NET_SOCK_STREAM, NET_IPPROTO_TCP, ctx);
 	if (ret < 0) {
@@ -185,7 +187,7 @@ static void tcp_connect(const struct shell *sh, char *host, uint16_t port,
 		return;
 	}
 
-	ret = net_context_bind(*ctx, &myaddr, addrlen);
+	ret = net_context_bind(*ctx, my_sa, addrlen);
 	if (ret < 0) {
 		PR_WARNING("Cannot bind TCP (%d)\n", ret);
 		return;
@@ -205,7 +207,7 @@ static void tcp_connect(const struct shell *sh, char *host, uint16_t port,
 
 	net_context_ref(*ctx);
 
-	ret = net_context_connect(*ctx, &addr, addrlen, tcp_connected,
+	ret = net_context_connect(*ctx, sa, addrlen, tcp_connected,
 				  CONNECT_TIMEOUT, NULL);
 	if (ret < 0) {
 		PR_WARNING("Connect failed!\n");

--- a/subsys/net/lib/shell/udp.c
+++ b/subsys/net/lib/shell/udp.c
@@ -66,7 +66,8 @@ static int cmd_net_udp_bind(const struct shell *sh, size_t argc, char *argv[])
 	int ret;
 
 	struct net_if *iface;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr = { 0 };
+	struct net_sockaddr *sa = net_sad(&addr);
 	int addrlen;
 
 	if (argc < 3) {
@@ -89,13 +90,13 @@ static int cmd_net_udp_bind(const struct shell *sh, size_t argc, char *argv[])
 
 	memset(&addr, 0, sizeof(addr));
 
-	ret = net_ipaddr_parse(addr_str, strlen(addr_str), &addr);
+	ret = net_ipaddr_parse(addr_str, strlen(addr_str), sa);
 	if (ret < 0) {
 		PR_WARNING("Cannot parse address \"%s\"\n", addr_str);
 		return ret;
 	}
 
-	ret = net_context_get(addr.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
+	ret = net_context_get(addr.ss_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
 			      &udp_ctx);
 	if (ret < 0) {
 		PR_WARNING("Cannot get UDP context (%d)\n", ret);
@@ -104,18 +105,18 @@ static int cmd_net_udp_bind(const struct shell *sh, size_t argc, char *argv[])
 
 	udp_shell = sh;
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
-		net_sin6(&addr)->sin6_port = net_htons(port);
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.ss_family == NET_AF_INET6) {
+		net_sin6(sa)->sin6_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in6);
 
 		iface = net_if_ipv6_select_src_iface(
-				&net_sin6(&addr)->sin6_addr);
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
-		net_sin(&addr)->sin_port = net_htons(port);
+				&net_sin6(sa)->sin6_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.ss_family == NET_AF_INET) {
+		net_sin(sa)->sin_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in);
 
 		iface = net_if_ipv4_select_src_iface(
-				&net_sin(&addr)->sin_addr);
+				&net_sin(sa)->sin_addr);
 	} else {
 		PR_WARNING("IPv6 and IPv4 are disabled, cannot %s.\n", "bind");
 		goto release_ctx;
@@ -128,7 +129,7 @@ static int cmd_net_udp_bind(const struct shell *sh, size_t argc, char *argv[])
 
 	net_context_set_iface(udp_ctx, iface);
 
-	ret = net_context_bind(udp_ctx, &addr, addrlen);
+	ret = net_context_bind(udp_ctx, sa, addrlen);
 	if (ret < 0) {
 		PR_WARNING("Binding to UDP port failed (%d)\n", ret);
 		goto release_ctx;
@@ -194,7 +195,8 @@ static int cmd_net_udp_send(const struct shell *sh, size_t argc, char *argv[])
 	bool should_release_ctx = false;
 
 	struct net_if *iface;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr = { 0 };
+	struct net_sockaddr *sa = net_sad(&addr);
 	int addrlen;
 
 	if (argc < 4) {
@@ -212,7 +214,7 @@ static int cmd_net_udp_send(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	memset(&addr, 0, sizeof(addr));
-	ret = net_ipaddr_parse(host, strlen(host), &addr);
+	ret = net_ipaddr_parse(host, strlen(host), sa);
 	if (ret < 0) {
 		PR_WARNING("Cannot parse address \"%s\"\n", host);
 		return ret;
@@ -220,7 +222,7 @@ static int cmd_net_udp_send(const struct shell *sh, size_t argc, char *argv[])
 
 	/* Re-use already bound context if possible, or allocate temporary one. */
 	if (udp_ctx == NULL || !net_context_is_used(udp_ctx)) {
-		ret = net_context_get(addr.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP, &udp_ctx);
+		ret = net_context_get(addr.ss_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP, &udp_ctx);
 		if (ret < 0) {
 			PR_WARNING("Cannot get UDP context (%d)\n", ret);
 			return ret;
@@ -230,18 +232,18 @@ static int cmd_net_udp_send(const struct shell *sh, size_t argc, char *argv[])
 
 	udp_shell = sh;
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
-		net_sin6(&addr)->sin6_port = net_htons(port);
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.ss_family == NET_AF_INET6) {
+		net_sin6(sa)->sin6_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in6);
 
 		iface = net_if_ipv6_select_src_iface(
-				&net_sin6(&addr)->sin6_addr);
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
-		net_sin(&addr)->sin_port = net_htons(port);
+				&net_sin6(sa)->sin6_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.ss_family == NET_AF_INET) {
+		net_sin(sa)->sin_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in);
 
 		iface = net_if_ipv4_select_src_iface(
-				&net_sin(&addr)->sin_addr);
+				&net_sin(sa)->sin_addr);
 	} else {
 		PR_WARNING("IPv6 and IPv4 are disabled, cannot %s.\n", "send");
 		goto release_ctx;
@@ -260,7 +262,7 @@ static int cmd_net_udp_send(const struct shell *sh, size_t argc, char *argv[])
 		goto release_ctx;
 	}
 
-	ret = net_context_sendto(udp_ctx, payload, strlen(payload), &addr,
+	ret = net_context_sendto(udp_ctx, payload, strlen(payload), sa,
 				 addrlen, udp_sent, K_FOREVER, NULL);
 	if (ret < 0) {
 		PR_WARNING("Sending packet failed (%d)\n", ret);
@@ -301,7 +303,8 @@ static int cmd_net_udp_dplpmtud(const struct shell *sh, size_t argc, char *argv[
 	long port_long;
 	uint16_t port;
 	struct net_if *iface;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr;
+	struct net_sockaddr *sa = net_sad(&addr);
 	int addrlen;
 	int enable = 1;
 	int ret;
@@ -328,13 +331,13 @@ static int cmd_net_udp_dplpmtud(const struct shell *sh, size_t argc, char *argv[
 
 	memset(&addr, 0, sizeof(addr));
 
-	ret = net_ipaddr_parse(host, strlen(host), &addr);
+	ret = net_ipaddr_parse(host, strlen(host), sa);
 	if (ret < 0) {
 		PR_WARNING("Cannot parse address \"%s\"\n", host);
 		return -EINVAL;
 	}
 
-	ret = net_context_get(addr.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
+	ret = net_context_get(addr.ss_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
 			      &udp_ctx);
 	if (ret < 0) {
 		PR_WARNING("Cannot get UDP context (%d)\n", ret);
@@ -343,14 +346,14 @@ static int cmd_net_udp_dplpmtud(const struct shell *sh, size_t argc, char *argv[
 
 	udp_shell = sh;
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
-		net_sin6(&addr)->sin6_port = net_htons(port);
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.ss_family == NET_AF_INET6) {
+		net_sin6(sa)->sin6_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in6);
-		iface = net_if_ipv6_select_src_iface(&net_sin6(&addr)->sin6_addr);
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
-		net_sin(&addr)->sin_port = net_htons(port);
+		iface = net_if_ipv6_select_src_iface(&net_sin6(sa)->sin6_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.ss_family == NET_AF_INET) {
+		net_sin(sa)->sin_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in);
-		iface = net_if_ipv4_select_src_iface(&net_sin(&addr)->sin_addr);
+		iface = net_if_ipv4_select_src_iface(&net_sin(sa)->sin_addr);
 	} else {
 		PR_WARNING("IPv6 and IPv4 are disabled, cannot probe.\n");
 		ret = -EAFNOSUPPORT;
@@ -366,7 +369,7 @@ static int cmd_net_udp_dplpmtud(const struct shell *sh, size_t argc, char *argv[
 	net_context_set_iface(udp_ctx, iface);
 
 	/* A connected UDP context gives the prober a fixed destination. */
-	ret = net_context_connect(udp_ctx, &addr, addrlen, NULL, K_NO_WAIT, NULL);
+	ret = net_context_connect(udp_ctx, sa, addrlen, NULL, K_NO_WAIT, NULL);
 	if (ret < 0) {
 		PR_WARNING("Cannot connect UDP context (%d)\n", ret);
 		goto release_ctx;
@@ -422,7 +425,8 @@ static int cmd_net_udp_dplpmtud_server(const struct shell *sh, size_t argc,
 	long port_long;
 	uint16_t port;
 	struct net_if *iface;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr;
+	struct net_sockaddr *sa = net_sad(&addr);
 	int addrlen;
 	int enable = 1;
 	int ret;
@@ -449,13 +453,13 @@ static int cmd_net_udp_dplpmtud_server(const struct shell *sh, size_t argc,
 
 	memset(&addr, 0, sizeof(addr));
 
-	ret = net_ipaddr_parse(addr_str, strlen(addr_str), &addr);
+	ret = net_ipaddr_parse(addr_str, strlen(addr_str), sa);
 	if (ret < 0) {
 		PR_WARNING("Cannot parse address \"%s\"\n", addr_str);
 		return -EINVAL;
 	}
 
-	ret = net_context_get(addr.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
+	ret = net_context_get(addr.ss_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
 			      &udp_ctx);
 	if (ret < 0) {
 		PR_WARNING("Cannot get UDP context (%d)\n", ret);
@@ -464,14 +468,14 @@ static int cmd_net_udp_dplpmtud_server(const struct shell *sh, size_t argc,
 
 	udp_shell = sh;
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
-		net_sin6(&addr)->sin6_port = net_htons(port);
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.ss_family == NET_AF_INET6) {
+		net_sin6(sa)->sin6_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in6);
-		iface = net_if_ipv6_select_src_iface(&net_sin6(&addr)->sin6_addr);
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
-		net_sin(&addr)->sin_port = net_htons(port);
+		iface = net_if_ipv6_select_src_iface(&net_sin6(sa)->sin6_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.ss_family == NET_AF_INET) {
+		net_sin(sa)->sin_port = net_htons(port);
 		addrlen = sizeof(struct net_sockaddr_in);
-		iface = net_if_ipv4_select_src_iface(&net_sin(&addr)->sin_addr);
+		iface = net_if_ipv4_select_src_iface(&net_sin(sa)->sin_addr);
 	} else {
 		PR_WARNING("IPv6 and IPv4 are disabled, cannot bind.\n");
 		ret = -EAFNOSUPPORT;
@@ -486,7 +490,7 @@ static int cmd_net_udp_dplpmtud_server(const struct shell *sh, size_t argc,
 
 	net_context_set_iface(udp_ctx, iface);
 
-	ret = net_context_bind(udp_ctx, &addr, addrlen);
+	ret = net_context_bind(udp_ctx, sa, addrlen);
 	if (ret < 0) {
 		PR_WARNING("Binding to UDP port failed (%d)\n", ret);
 		goto release_ctx;

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -83,7 +83,7 @@ static void dns_resolve_cb(enum dns_resolve_status status,
 		state->ai_arr[state->idx - 1].ai_next = ai;
 	}
 
-	memcpy(&ai->_ai_addr, &info->ai_addr, info->ai_addrlen);
+	memcpy(&ai->_ai_addr, &info->ai_addr_storage, info->ai_addrlen);
 	net_sin(net_sad(&ai->_ai_addr))->sin_port = state->port;
 	ai->ai_addr = net_sad(&ai->_ai_addr);
 	ai->ai_addrlen = info->ai_addrlen;

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1159,7 +1159,7 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
 static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
 {
 	struct tls_context *tls_ctx = ctx;
-	net_socklen_t addrlen = sizeof(struct net_sockaddr);
+	net_socklen_t addrlen = sizeof(struct net_sockaddr_storage);
 	struct net_sockaddr_storage addr = { 0 };
 	int err;
 	ssize_t received;
@@ -1215,7 +1215,7 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
 static int dtls_client_rx(void *ctx, unsigned char *buf, size_t len)
 {
 	struct tls_context *tls_ctx = ctx;
-	net_socklen_t addrlen = sizeof(struct net_sockaddr);
+	net_socklen_t addrlen = sizeof(struct net_sockaddr_storage);
 	struct net_sockaddr_storage addr = { 0 };
 	ssize_t received;
 
@@ -1361,7 +1361,7 @@ static int dtls_server_switch_active_session_by_cid(struct tls_context *tls_ctx)
 		 * static buffer for the purpose, and protect it with a mutex to
 		 * avoid races in case multiple DTLS server sockets run in parallel.
 		 */
-		addrlen = sizeof(struct net_sockaddr);
+		addrlen = sizeof(struct net_sockaddr_storage);
 		len = zsock_recvfrom(tls_ctx->sock, &dtls_helper_buf, sizeof(dtls_helper_buf),
 				     ZSOCK_MSG_DONTWAIT | ZSOCK_MSG_PEEK,
 				     net_sad(&addr), &addrlen);
@@ -1399,7 +1399,7 @@ static int dtls_server_switch_active_session_by_cid(struct tls_context *tls_ctx)
  */
 static int dtls_server_switch_session_on_rx(struct tls_context *tls_ctx)
 {
-	net_socklen_t addrlen = sizeof(struct net_sockaddr);
+	net_socklen_t addrlen = sizeof(struct net_sockaddr_storage);
 	struct net_sockaddr_storage addr = { 0 };
 	uint8_t tmp_buf;
 	int ret;

--- a/subsys/net/lib/socks/socks.c
+++ b/subsys/net/lib/socks/socks.c
@@ -190,7 +190,7 @@ int net_socks5_connect(struct net_context *ctx, const struct net_sockaddr *addr,
 {
 	struct net_sockaddr_storage proxy;
 	struct net_sockaddr *proxy_sa = net_sad(&proxy);
-	net_socklen_t proxy_len;
+	net_socklen_t proxy_len = sizeof(proxy);
 	int type;
 	int ret;
 

--- a/subsys/net/lib/socks/socks.c
+++ b/subsys/net/lib/socks/socks.c
@@ -188,7 +188,8 @@ static int socks5_tcp_connect(struct net_context *ctx,
 int net_socks5_connect(struct net_context *ctx, const struct net_sockaddr *addr,
 		       net_socklen_t addrlen)
 {
-	struct net_sockaddr proxy;
+	struct net_sockaddr_storage proxy;
+	struct net_sockaddr *proxy_sa = net_sad(&proxy);
 	net_socklen_t proxy_len;
 	int type;
 	int ret;
@@ -199,18 +200,18 @@ int net_socks5_connect(struct net_context *ctx, const struct net_sockaddr *addr,
 		return -ENOTSUP;
 	}
 
-	ret = net_context_get_option(ctx, NET_OPT_SOCKS5, &proxy, &proxy_len);
+	ret = net_context_get_option(ctx, NET_OPT_SOCKS5, proxy_sa, &proxy_len);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Connect to Proxy Server */
-	ret = net_context_connect(ctx, &proxy, proxy_len, NULL,
+	ret = net_context_connect(ctx, proxy_sa, proxy_len, NULL,
 				  K_MSEC(CONFIG_NET_SOCKETS_CONNECT_TIMEOUT),
 				  NULL);
 	if (ret < 0) {
 		return ret;
 	}
 
-	return socks5_tcp_connect(ctx, &proxy, proxy_len, addr, addrlen);
+	return socks5_tcp_connect(ctx, proxy_sa, proxy_len, addr, addrlen);
 }

--- a/subsys/net/lib/tftp/tftp_client.c
+++ b/subsys/net/lib/tftp/tftp_client.c
@@ -12,7 +12,7 @@ LOG_MODULE_REGISTER(tftp_client, CONFIG_TFTP_LOG_LEVEL);
 #include "tftp_client.h"
 
 #define ADDRLEN(sa) \
-	(sa.sa_family == NET_AF_INET ? \
+	(sa->sa_family == NET_AF_INET ? \
 		sizeof(struct net_sockaddr_in) : sizeof(struct net_sockaddr_in6))
 
 /*
@@ -196,8 +196,9 @@ static int send_request(int sock, struct tftpc *client,
 			remote_file);
 
 		/* Send the request to the server */
-		ret = zsock_sendto(sock, client->tftp_buf, req_size, 0, &client->server,
-				   ADDRLEN(client->server));
+		ret = zsock_sendto(sock, client->tftp_buf, req_size, 0,
+				   net_sad(&client->server_addr),
+				   ADDRLEN(net_sad(&client->server_addr)));
 		if (ret < 0) {
 			break;
 		}
@@ -216,11 +217,12 @@ static int send_request(int sock, struct tftpc *client,
 		}
 
 		/* Receive data from the TFTP Server. */
-		struct net_sockaddr from_addr;
+		struct net_sockaddr_storage from_addr;
+		struct net_sockaddr *from_sa = net_sad(&from_addr);
 		net_socklen_t from_addr_len = sizeof(from_addr);
 
 		ret = zsock_recvfrom(sock, client->tftp_buf, TFTPC_MAX_BUF_SIZE, 0,
-				     &from_addr, &from_addr_len);
+				     from_sa, &from_addr_len);
 		if (ret < TFTP_HEADER_SIZE) {
 			req_size = make_request(client->tftp_buf, request,
 						remote_file, mode);
@@ -228,7 +230,7 @@ static int send_request(int sock, struct tftpc *client,
 		}
 
 		/* Limit communication to the specific address:port */
-		if (zsock_connect(sock, &from_addr, from_addr_len) < 0) {
+		if (zsock_connect(sock, from_sa, from_addr_len) < 0) {
 			ret = -errno;
 			LOG_ERR("connect failed, err %d", ret);
 			break;
@@ -258,7 +260,7 @@ int tftp_get(struct tftpc *client, const char *remote_file, const char *mode)
 		return -EINVAL;
 	}
 
-	sock = zsock_socket(client->server.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	sock = zsock_socket(client->server_addr.ss_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 	if (sock < 0) {
 		LOG_ERR("Failed to create UDP socket: %d", errno);
 		return -errno;
@@ -383,7 +385,7 @@ int tftp_put(struct tftpc *client, const char *remote_file, const char *mode,
 		return -EINVAL;
 	}
 
-	sock = zsock_socket(client->server.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	sock = zsock_socket(client->server_addr.ss_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 	if (sock < 0) {
 		LOG_ERR("Failed to create UDP socket: %d", errno);
 		return -errno;

--- a/subsys/net/lib/wireguard/wg.c
+++ b/subsys/net/lib/wireguard/wg.c
@@ -478,7 +478,8 @@ static void crypto_init(struct wg_context *ctx)
 
 static int wireguard_init(void)
 {
-	struct net_sockaddr local_addr = { 0 };
+	struct net_sockaddr_storage local_addr_storage = { 0 };
+	struct net_sockaddr *local_addr = net_sad(&local_addr_storage);
 	const struct device *dev;
 	struct wg_context *ctx;
 	uint16_t port;
@@ -512,20 +513,20 @@ static int wireguard_init(void)
 	crypto_init(ctx);
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		local_addr.sa_family = NET_AF_INET6;
+		local_addr->sa_family = NET_AF_INET6;
 
 		/* Note that if IPv4 is enabled, then v4-to-v6-mapping option
 		 * is set and the system will use the IPv6 socket to provide
 		 * IPv4 connectivity.
 		 */
 	} else if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		local_addr.sa_family = NET_AF_INET;
+		local_addr->sa_family = NET_AF_INET;
 	}
 
 	if (CONFIG_WIREGUARD_PORT > 0) {
 		port = CONFIG_WIREGUARD_PORT;
 	} else {
-		port = get_port(&local_addr);
+		port = get_port(local_addr);
 		if (port == 0) {
 			port = WG_DEFAULT_PORT;
 		}
@@ -533,9 +534,9 @@ static int wireguard_init(void)
 		NET_INFO("Wireguard service port %d", port);
 	}
 
-	ret = net_udp_register(local_addr.sa_family,
+	ret = net_udp_register(local_addr->sa_family,
 			       NULL,
-			       &local_addr,
+			       local_addr,
 			       0,
 			       port,
 			       NULL,

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -221,11 +221,11 @@ static int zperf_bind_host(const struct shell *sh,
 
 	if (argc >= 3) {
 		char *addr_str = argv[2];
-		struct net_sockaddr addr;
+		struct net_sockaddr_storage addr;
 
 		memset(&addr, 0, sizeof(addr));
 
-		ret = net_ipaddr_parse(addr_str, strlen(addr_str), &addr);
+		ret = net_ipaddr_parse(addr_str, strlen(addr_str), net_sad(&addr));
 		if (ret < 0) {
 			shell_fprintf(sh, SHELL_WARNING,
 				      "Cannot parse address \"%s\"\n",
@@ -233,7 +233,7 @@ static int zperf_bind_host(const struct shell *sh,
 			return ret;
 		}
 
-		memcpy(&param->addr, &addr, sizeof(struct net_sockaddr));
+		memcpy(&param->addr_storage, &addr, sizeof(addr));
 	}
 
 	return 0;
@@ -839,9 +839,10 @@ static int execute_upload(const struct shell *sh,
 		shell_fprintf(sh, SHELL_NORMAL, "Starting...\n");
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && param->peer_addr.sa_family == NET_AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) &&
+	    param->peer_addr_storage.ss_family == NET_AF_INET6) {
 		struct net_sockaddr_in6 *ipv6 =
-				(struct net_sockaddr_in6 *)&param->peer_addr;
+				net_sin6(net_sad(&param->peer_addr_storage));
 		/* For IPv6, we should make sure that neighbor discovery
 		 * has been done for the peer. So send ping here, wait
 		 * some time and start the test after that.
@@ -1136,7 +1137,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 		shell_fprintf(sh, SHELL_NORMAL, "Connecting to %s\n",
 			      net_sprint_ipv6_addr(&ipv6.sin6_addr));
 
-		memcpy(&param.peer_addr, &ipv6, sizeof(ipv6));
+		memcpy(&param.peer_addr_storage, &ipv6, sizeof(ipv6));
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && !IS_ENABLED(CONFIG_NET_IPV6)) {
@@ -1155,7 +1156,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 		shell_fprintf(sh, SHELL_NORMAL, "Connecting to %s\n",
 			      net_sprint_ipv4_addr(&ipv4.sin_addr));
 
-		memcpy(&param.peer_addr, &ipv4, sizeof(ipv4));
+		memcpy(&param.peer_addr_storage, &ipv4, sizeof(ipv4));
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && IS_ENABLED(CONFIG_NET_IPV4)) {
@@ -1177,13 +1178,13 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 				      "Connecting to %s\n",
 				      net_sprint_ipv4_addr(&ipv4.sin_addr));
 
-			memcpy(&param.peer_addr, &ipv4, sizeof(ipv4));
+			memcpy(&param.peer_addr_storage, &ipv4, sizeof(ipv4));
 		} else {
 			shell_fprintf(sh, SHELL_NORMAL,
 				      "Connecting to %s\n",
 				      net_sprint_ipv6_addr(&ipv6.sin6_addr));
 
-			memcpy(&param.peer_addr, &ipv6, sizeof(ipv6));
+			memcpy(&param.peer_addr_storage, &ipv6, sizeof(ipv6));
 		}
 	}
 
@@ -1378,7 +1379,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 			      "Connecting to %s\n",
 			      net_sprint_ipv6_addr(&ipv6_addr_dst.sin6_addr));
 
-		memcpy(&param.peer_addr, &ipv6_addr_dst, sizeof(ipv6_addr_dst));
+		memcpy(&param.peer_addr_storage, &ipv6_addr_dst, sizeof(ipv6_addr_dst));
 	} else {
 		if (net_ipv4_is_addr_unspecified(&ipv4_addr_dst.sin_addr)) {
 			shell_fprintf(sh, SHELL_WARNING,
@@ -1390,7 +1391,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 			      "Connecting to %s\n",
 			      net_sprint_ipv4_addr(&ipv4_addr_dst.sin_addr));
 
-		memcpy(&param.peer_addr, &ipv4_addr_dst, sizeof(ipv4_addr_dst));
+		memcpy(&param.peer_addr_storage, &ipv4_addr_dst, sizeof(ipv4_addr_dst));
 	}
 
 	if (argc > 2) {

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -33,10 +33,10 @@ static zperf_callback tcp_session_cb;
 static void *tcp_user_data;
 static bool tcp_server_running;
 static uint16_t tcp_server_port;
-static struct net_sockaddr tcp_server_addr;
+static struct net_sockaddr_storage tcp_server_addr;
 
 static struct zsock_pollfd fds[SOCK_ID_MAX];
-static struct net_sockaddr sock_addr[SOCK_ID_MAX];
+static struct net_sockaddr_storage sock_addr[SOCK_ID_MAX];
 
 static void tcp_svc_handler(struct net_socket_service_event *pev);
 
@@ -110,7 +110,7 @@ static void tcp_receiver_cleanup(void)
 		if (fds[i].fd >= 0) {
 			zsock_close(fds[i].fd);
 			fds[i].fd = -1;
-			memset(&sock_addr[i], 0, sizeof(struct net_sockaddr));
+			memset(&sock_addr[i], 0, sizeof(sock_addr[i]));
 		}
 	}
 
@@ -126,9 +126,9 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 	int i, ret = 0;
 	int family, sock, sock_error = 0;
 	int default_error = EIO;
-	struct net_sockaddr addr_incoming_conn;
+	struct net_sockaddr_storage addr_incoming_conn;
 	net_socklen_t optlen = sizeof(int);
-	net_socklen_t addrlen = sizeof(struct net_sockaddr);
+	net_socklen_t addrlen = sizeof(addr_incoming_conn);
 
 	if (!tcp_server_running) {
 		return -ENOENT;
@@ -173,10 +173,10 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 			}
 
 			if (i < SOCK_ID_MAX) {
-				tcp_received(&sock_addr[i], 0);
+				tcp_received(net_sad(&sock_addr[i]), 0);
 				zsock_close(fds[i].fd);
 				fds[i].fd = -1;
-				memset(&sock_addr[i], 0, sizeof(struct net_sockaddr));
+				memset(&sock_addr[i], 0, sizeof(sock_addr[i]));
 				(void)net_socket_service_register(&svc_tcp, fds,
 								  ARRAY_SIZE(fds),
 								  NULL);
@@ -196,7 +196,7 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 	if (fds[SOCK_ID_IPV4_LISTEN].fd == pev->event.fd ||
 	    fds[SOCK_ID_IPV6_LISTEN].fd == pev->event.fd) {
 		sock = zsock_accept(pev->event.fd,
-				    &addr_incoming_conn,
+				    net_sad(&addr_incoming_conn),
 				    &addrlen);
 		if (sock < 0) {
 			ret = -errno;
@@ -249,11 +249,11 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 		if (i == SOCK_ID_MAX) {
 			NET_ERR("Descriptor %d not found.", pev->event.fd);
 		} else {
-			tcp_received(&sock_addr[i], ret);
+			tcp_received(net_sad(&sock_addr[i]), ret);
 			if (ret == 0) {
 				zsock_close(fds[i].fd);
 				fds[i].fd = -1;
-				memset(&sock_addr[i], 0, sizeof(struct net_sockaddr));
+				memset(&sock_addr[i], 0, sizeof(sock_addr[i]));
 
 				(void)net_socket_service_register(&svc_tcp, fds,
 								  ARRAY_SIZE(fds),
@@ -314,6 +314,7 @@ out:
 
 static int zperf_tcp_receiver_init(void)
 {
+	struct net_sockaddr *server_sa = net_sad(&tcp_server_addr);
 	int ret;
 	int family;
 
@@ -321,7 +322,7 @@ static int zperf_tcp_receiver_init(void)
 		fds[i].fd = -1;
 	}
 
-	family = tcp_server_addr.sa_family;
+	family = tcp_server_addr.ss_family;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && (family == NET_AF_INET || family == NET_AF_UNSPEC)) {
 		struct net_sockaddr_in *in4_addr = zperf_get_sin();
@@ -335,7 +336,7 @@ static int zperf_tcp_receiver_init(void)
 			goto error;
 		}
 
-		addr = &net_sin(&tcp_server_addr)->sin_addr;
+		addr = &net_sin(server_sa)->sin_addr;
 
 		if (!net_ipv4_is_addr_unspecified(addr)) {
 			memcpy(&in4_addr->sin_addr, addr,
@@ -358,12 +359,12 @@ use_any_ipv4:
 		NET_INFO("Binding to %s",
 			 net_sprint_ipv4_addr(&in4_addr->sin_addr));
 
-		memcpy(net_sin(&sock_addr[SOCK_ID_IPV4_LISTEN]), in4_addr,
+		memcpy(&sock_addr[SOCK_ID_IPV4_LISTEN], in4_addr,
 		       sizeof(struct net_sockaddr_in));
 
 		ret = tcp_bind_listen_connection(
 				&fds[SOCK_ID_IPV4_LISTEN],
-				&sock_addr[SOCK_ID_IPV4_LISTEN]);
+				net_sad(&sock_addr[SOCK_ID_IPV4_LISTEN]));
 		if (ret < 0) {
 			goto error;
 		}
@@ -381,7 +382,7 @@ use_any_ipv4:
 			goto error;
 		}
 
-		addr = &net_sin6(&tcp_server_addr)->sin6_addr;
+		addr = &net_sin6(server_sa)->sin6_addr;
 
 		if (!net_ipv6_is_addr_unspecified(addr)) {
 			memcpy(&in6_addr->sin6_addr, addr,
@@ -406,12 +407,12 @@ use_any_ipv6:
 		NET_INFO("Binding to %s",
 			 net_sprint_ipv6_addr(&in6_addr->sin6_addr));
 
-		memcpy(net_sin6(&sock_addr[SOCK_ID_IPV6_LISTEN]), in6_addr,
+		memcpy(&sock_addr[SOCK_ID_IPV6_LISTEN], in6_addr,
 		       sizeof(struct net_sockaddr_in6));
 
 		ret = tcp_bind_listen_connection(
 				&fds[SOCK_ID_IPV6_LISTEN],
-				&sock_addr[SOCK_ID_IPV6_LISTEN]);
+				net_sad(&sock_addr[SOCK_ID_IPV6_LISTEN]));
 		if (ret < 0) {
 			goto error;
 		}
@@ -445,7 +446,7 @@ int zperf_tcp_download(const struct zperf_download_params *param,
 	tcp_session_cb = callback;
 	tcp_user_data = user_data;
 	tcp_server_port = param->port;
-	memcpy(&tcp_server_addr, &param->addr, sizeof(struct net_sockaddr));
+	memcpy(&tcp_server_addr, &param->addr_storage, sizeof(tcp_server_addr));
 
 	ret = zperf_tcp_receiver_init();
 	if (ret < 0) {

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -151,7 +151,7 @@ int zperf_tcp_upload(const struct zperf_upload_params *param,
 		return -EINVAL;
 	}
 
-	sock = zperf_prepare_upload_sock(&param->peer_addr, param->options.tos,
+	sock = zperf_prepare_upload_sock(net_sad(&param->peer_addr_storage), param->options.tos,
 					 param->options.priority, param->options.tcp_nodelay,
 					 NET_IPPROTO_TCP);
 	if (sock < 0) {
@@ -205,7 +205,7 @@ static void tcp_upload_async_work(struct k_work *work)
 	upload_ctx->callback(ZPERF_SESSION_STARTED, NULL,
 			     upload_ctx->user_data);
 
-	sock = zperf_prepare_upload_sock(&param.peer_addr, param.options.tos,
+	sock = zperf_prepare_upload_sock(net_sad(&param.peer_addr_storage), param.options.tos,
 					 param.options.priority, param.options.tcp_nodelay,
 					 NET_IPPROTO_TCP);
 
@@ -280,7 +280,7 @@ int zperf_tcp_upload_async(const struct zperf_upload_params *param,
 	struct session *ses;
 	k_tid_t tid;
 
-	ses = get_free_session(&param->peer_addr, SESSION_TCP);
+	ses = get_free_session(net_sad(&param->peer_addr_storage), SESSION_TCP);
 	if (ses == NULL) {
 		NET_ERR("Cannot get a session!");
 		return -ENOENT;

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -305,7 +305,9 @@ static void zperf_udp_leave_mcast(int sock)
 	struct net_sockaddr *sa = net_sad(&addr);
 	net_socklen_t addr_len = sizeof(addr);
 
-	zsock_getsockname(sock, sa, &addr_len);
+	if (zsock_getsockname(sock, sa, &addr_len) < 0) {
+		return;
+	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && addr.ss_family == NET_AF_INET) {
 		struct net_sockaddr_in *addr4 = net_sin(sa);

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -44,7 +44,7 @@ static zperf_callback udp_session_cb;
 static void *udp_user_data;
 static bool udp_server_running;
 static uint16_t udp_server_port;
-static struct net_sockaddr udp_server_addr;
+static struct net_sockaddr_storage udp_server_addr;
 
 struct zsock_pollfd fds[SOCK_ID_MAX] = { 0 };
 
@@ -301,21 +301,22 @@ static void zperf_udp_join_mcast_ipv6(char *if_name, struct net_in6_addr *addr)
 static void zperf_udp_leave_mcast(int sock)
 {
 	struct net_if *iface = NULL;
-	struct net_sockaddr addr = {0};
-	net_socklen_t addr_len = NET_IPV6_ADDR_SIZE;
+	struct net_sockaddr_storage addr = {0};
+	struct net_sockaddr *sa = net_sad(&addr);
+	net_socklen_t addr_len = sizeof(addr);
 
-	zsock_getsockname(sock, &addr, &addr_len);
+	zsock_getsockname(sock, sa, &addr_len);
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
-		struct net_sockaddr_in *addr4 = (struct net_sockaddr_in *)&addr;
+	if (IS_ENABLED(CONFIG_NET_IPV4) && addr.ss_family == NET_AF_INET) {
+		struct net_sockaddr_in *addr4 = net_sin(sa);
 
 		if (net_ipv4_is_addr_mcast(&addr4->sin_addr)) {
 			net_ipv4_igmp_leave(iface, &addr4->sin_addr);
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
-		struct net_sockaddr_in6 *addr6 = (struct net_sockaddr_in6 *)&addr;
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.ss_family == NET_AF_INET6) {
+		struct net_sockaddr_in6 *addr6 = net_sin6(sa);
 
 		if (net_ipv6_is_addr_mcast(&addr6->sin6_addr)) {
 			net_ipv6_mld_leave(iface, &addr6->sin6_addr);
@@ -349,7 +350,8 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 	int ret = 1;
 	int family, sock_error = 0;
 	int default_error = EIO;
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr;
+	struct net_sockaddr *sa = net_sad(&addr);
 	net_socklen_t optlen = sizeof(int);
 	net_socklen_t addrlen = sizeof(addr);
 
@@ -383,7 +385,7 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 
 	while (ret > 0) {
 		ret = zsock_recvfrom(pev->event.fd, buf, sizeof(buf), ZSOCK_MSG_DONTWAIT,
-				     &addr, &addrlen);
+				     sa, &addrlen);
 		if ((ret < 0) && (errno == EAGAIN)) {
 			ret = 0;
 			break;
@@ -398,7 +400,7 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 			goto error;
 		}
 
-		udp_received(pev->event.fd, &addr, buf, ret);
+		udp_received(pev->event.fd, sa, buf, ret);
 	}
 	return ret;
 
@@ -422,6 +424,7 @@ static void udp_svc_handler(struct net_socket_service_event *pev)
 
 static int zperf_udp_receiver_init(void)
 {
+	struct net_sockaddr *server_sa = net_sad(&udp_server_addr);
 	int ret;
 	int family;
 
@@ -429,7 +432,7 @@ static int zperf_udp_receiver_init(void)
 		fds[i].fd = -1;
 	}
 
-	family = udp_server_addr.sa_family;
+	family = udp_server_addr.ss_family;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && (family == NET_AF_INET || family == NET_AF_UNSPEC)) {
 		const struct net_in_addr *in4_addr = NULL;
@@ -444,7 +447,7 @@ static int zperf_udp_receiver_init(void)
 			goto error;
 		}
 
-		in4_addr = &net_sin(&udp_server_addr)->sin_addr;
+		in4_addr = &net_sin(server_sa)->sin_addr;
 
 		if (!net_ipv4_is_addr_unspecified(in4_addr)) {
 			memcpy(&in4_addr_my->sin_addr, in4_addr,
@@ -498,7 +501,7 @@ use_any_ipv4:
 			goto error;
 		}
 
-		in6_addr = &net_sin6(&udp_server_addr)->sin6_addr;
+		in6_addr = &net_sin6(server_sa)->sin6_addr;
 
 		if (!net_ipv6_is_addr_unspecified(in6_addr)) {
 			memcpy(&in6_addr_my->sin6_addr, in6_addr,
@@ -571,7 +574,7 @@ int zperf_udp_download(const struct zperf_download_params *param,
 	udp_session_cb = callback;
 	udp_user_data  = user_data;
 	udp_server_port = param->port;
-	memcpy(&udp_server_addr, &param->addr, sizeof(struct net_sockaddr));
+	memcpy(&udp_server_addr, &param->addr_storage, sizeof(udp_server_addr));
 
 	if (param->if_name[0]) {
 		/*

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -231,6 +231,7 @@ static int udp_upload(int sock, int port,
 {
 	size_t header_size =
 		sizeof(struct zperf_udp_datagram) + sizeof(struct zperf_client_hdr_v1);
+	struct net_sockaddr *peer_addr = net_sad(&param->peer_addr_storage);
 	uint32_t duration_in_ms = param->duration_ms;
 	uint32_t packet_size = param->packet_size;
 	uint32_t rate_in_kbps = param->rate_kbps;
@@ -375,12 +376,12 @@ static int udp_upload(int sock, int port,
 	end_time = k_uptime_ticks();
 	usecs64 = param->unix_offset_us + k_ticks_to_us_floor64(end_time - start_time);
 
-	if (param->peer_addr.sa_family == NET_AF_INET) {
-		if (net_ipv4_is_addr_mcast(&net_sin(&param->peer_addr)->sin_addr)) {
+	if (param->peer_addr_storage.ss_family == NET_AF_INET) {
+		if (net_ipv4_is_addr_mcast(&net_sin(peer_addr)->sin_addr)) {
 			is_mcast_pkt = true;
 		}
-	} else if (param->peer_addr.sa_family == NET_AF_INET6) {
-		if (net_ipv6_is_addr_mcast(&net_sin6(&param->peer_addr)->sin6_addr)) {
+	} else if (param->peer_addr_storage.ss_family == NET_AF_INET6) {
+		if (net_ipv6_is_addr_mcast(&net_sin6(peer_addr)->sin6_addr)) {
 			is_mcast_pkt = true;
 		}
 	} else {
@@ -405,6 +406,7 @@ static int udp_upload(int sock, int port,
 int zperf_udp_upload(const struct zperf_upload_params *param,
 		     struct zperf_results *result)
 {
+	struct net_sockaddr *peer_addr;
 	int port = 0;
 	int sock;
 	int ret;
@@ -414,17 +416,19 @@ int zperf_udp_upload(const struct zperf_upload_params *param,
 		return -EINVAL;
 	}
 
-	if (param->peer_addr.sa_family == NET_AF_INET) {
-		port = net_ntohs(net_sin(&param->peer_addr)->sin_port);
-	} else if (param->peer_addr.sa_family == NET_AF_INET6) {
-		port = net_ntohs(net_sin6(&param->peer_addr)->sin6_port);
+	peer_addr = net_sad(&param->peer_addr_storage);
+
+	if (param->peer_addr_storage.ss_family == NET_AF_INET) {
+		port = net_ntohs(net_sin(peer_addr)->sin_port);
+	} else if (param->peer_addr_storage.ss_family == NET_AF_INET6) {
+		port = net_ntohs(net_sin6(peer_addr)->sin6_port);
 	} else {
 		NET_ERR("Invalid address family (%d)",
-			param->peer_addr.sa_family);
+			param->peer_addr_storage.ss_family);
 		return -EINVAL;
 	}
 
-	sock = zperf_prepare_upload_sock(&param->peer_addr, param->options.tos,
+	sock = zperf_prepare_upload_sock(peer_addr, param->options.tos,
 					 param->options.priority, 0,
 					 NET_IPPROTO_UDP);
 	if (sock < 0) {
@@ -510,7 +514,7 @@ int zperf_udp_upload_async(const struct zperf_upload_params *param,
 	struct session *ses;
 	k_tid_t tid;
 
-	ses = get_free_session(&param->peer_addr, SESSION_UDP);
+	ses = get_free_session(net_sad(&param->peer_addr_storage), SESSION_UDP);
 	if (ses == NULL) {
 		NET_ERR("Cannot get a session!");
 		return -ENOENT;

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -1132,7 +1132,7 @@ static void ra_message(void)
 	/* Check if RDNSS was added correctly. */
 	ctx = dns_resolve_get_default();
 	zassert_equal(ctx->state, DNS_RESOLVE_CONTEXT_ACTIVE);
-	dns_server = (struct net_sockaddr_in6 *)&ctx->servers[0].dns_server;
+	dns_server = net_sin6(net_sad(&ctx->servers[0].dns_server_addr));
 	zassert_equal(dns_server->sin6_family, dns_addr.sin6_family);
 	zassert_equal(dns_server->sin6_port, dns_addr.sin6_port);
 	zassert_mem_equal(&dns_server->sin6_addr, &dns_addr.sin6_addr,

--- a/tests/net/lib/dns_dispatcher/src/main.c
+++ b/tests/net/lib/dns_dispatcher/src/main.c
@@ -254,7 +254,7 @@ ZTEST(dns_dispatcher, test_dispatcher_pair_cleanup)
 	responder.fds_len = 1;
 	responder.sock = responder_sock;
 	responder.svc = &test_pair_svc;
-	memcpy(&responder.local_addr, &local, sizeof(local));
+	memcpy(&responder.local_addr_storage, &local, sizeof(local));
 
 	resolver.type = DNS_SOCKET_RESOLVER;
 	resolver.cb = test_dispatch_cb;
@@ -262,7 +262,7 @@ ZTEST(dns_dispatcher, test_dispatcher_pair_cleanup)
 	resolver.fds_len = 1;
 	resolver.sock = resolver_sock;
 	resolver.svc = &test_pair_svc;
-	memcpy(&resolver.local_addr, &local, sizeof(local));
+	memcpy(&resolver.local_addr_storage, &local, sizeof(local));
 
 	zassert_ok(dns_dispatcher_register(&responder), "Cannot register responder");
 	zassert_ok(dns_dispatcher_register(&resolver), "Cannot register resolver");
@@ -329,8 +329,8 @@ ZTEST(dns_dispatcher, test_dns_dispatcher_ephemeral_ports)
 	zassert_true(ctx->servers[0].sock >= 0, "First server socket not open");
 	zassert_true(ctx->servers[1].sock >= 0, "Second server socket not open");
 
-	port0 = net_sin(&ctx->servers[0].dispatcher.local_addr)->sin_port;
-	port1 = net_sin(&ctx->servers[1].dispatcher.local_addr)->sin_port;
+	port0 = net_sin(net_sad(&ctx->servers[0].dispatcher.local_addr_storage))->sin_port;
+	port1 = net_sin(net_sad(&ctx->servers[1].dispatcher.local_addr_storage))->sin_port;
 
 	/* Both registrations must have captured their real ephemeral port. */
 	zassert_not_equal(port0, 0, "First dispatcher port not resolved");

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -495,13 +495,13 @@ ZTEST(dns_resolve, test_dns_query_ipv4_server_count)
 			continue;
 		}
 
-		if (ctx->servers[i].dns_server.sa_family == NET_AF_INET6) {
+		if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET6) {
 			continue;
 		}
 
 		count++;
 
-		if (net_sin(&ctx->servers[i].dns_server)->sin_port ==
+		if (net_sin(net_sad(&ctx->servers[i].dns_server_addr))->sin_port ==
 		    net_ntohs(53)) {
 			port++;
 		}
@@ -525,13 +525,13 @@ ZTEST(dns_resolve, test_dns_query_ipv6_server_count)
 			continue;
 		}
 
-		if (ctx->servers[i].dns_server.sa_family == NET_AF_INET) {
+		if (ctx->servers[i].dns_server_addr.ss_family == NET_AF_INET) {
 			continue;
 		}
 
 		count++;
 
-		if (net_sin6(&ctx->servers[i].dns_server)->sin6_port ==
+		if (net_sin6(net_sad(&ctx->servers[i].dns_server_addr))->sin6_port ==
 		    net_ntohs(53)) {
 			port++;
 		}
@@ -773,8 +773,8 @@ static void inject_empty_dns_response(struct dns_resolve_context *ctx,
 	ret = ctx->servers[server_idx].dispatcher.cb(
 		&ctx->servers[server_idx].dispatcher,
 		ctx->servers[server_idx].sock,
-		&ctx->servers[server_idx].dns_server,
-		dns_server_addr_len(&ctx->servers[server_idx].dns_server),
+		net_sad(&ctx->servers[server_idx].dns_server_addr),
+		dns_server_addr_len(net_sad(&ctx->servers[server_idx].dns_server_addr)),
 		dns_data, len);
 	zassert_equal(ret, 0, "Cannot inject DNS response");
 
@@ -812,8 +812,8 @@ static void inject_refused_dns_response(struct dns_resolve_context *ctx,
 	ret = ctx->servers[server_idx].dispatcher.cb(
 		&ctx->servers[server_idx].dispatcher,
 		ctx->servers[server_idx].sock,
-		&ctx->servers[server_idx].dns_server,
-		dns_server_addr_len(&ctx->servers[server_idx].dns_server),
+		net_sad(&ctx->servers[server_idx].dns_server_addr),
+		dns_server_addr_len(net_sad(&ctx->servers[server_idx].dns_server_addr)),
 		dns_data, len);
 	zassert_true(ret == 0 || ret == DNS_EAI_FAIL,
 		     "Unexpected REFUSED response status %d", ret);
@@ -877,8 +877,8 @@ static void inject_success_dns_response(struct dns_resolve_context *ctx,
 	ret = ctx->servers[server_idx].dispatcher.cb(
 		&ctx->servers[server_idx].dispatcher,
 		ctx->servers[server_idx].sock,
-		&ctx->servers[server_idx].dns_server,
-		dns_server_addr_len(&ctx->servers[server_idx].dns_server),
+		net_sad(&ctx->servers[server_idx].dns_server_addr),
+		dns_server_addr_len(net_sad(&ctx->servers[server_idx].dns_server_addr)),
 		dns_data, len);
 	zassert_equal(ret, 0, "Cannot inject DNS response");
 
@@ -1351,7 +1351,7 @@ void dns_result_numeric_cb(enum dns_resolve_status status,
 
 	if (info && info->ai_family == NET_AF_INET) {
 #if defined(CONFIG_NET_IPV4)
-		if (net_ipv4_addr_cmp(&net_sin(&info->ai_addr)->sin_addr,
+		if (net_ipv4_addr_cmp(&net_sin(net_sad(&info->ai_addr_storage))->sin_addr,
 				      &my_addr2) != true) {
 			zassert_true(false, "IPv4 address does not match");
 		}
@@ -1360,7 +1360,7 @@ void dns_result_numeric_cb(enum dns_resolve_status status,
 
 	if (info && info->ai_family == NET_AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
-		if (net_ipv6_addr_cmp(&net_sin6(&info->ai_addr)->sin6_addr,
+		if (net_ipv6_addr_cmp(&net_sin6(net_sad(&info->ai_addr_storage))->sin6_addr,
 				      &my_addr3) != true) {
 			zassert_true(false, "IPv6 address does not match");
 		}

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
@@ -101,7 +101,7 @@ ZTEST(lwm2m_engine, test_start_stop)
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
 	k_mutex_init(&ctx.lock);
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 	ctx.desthostname = host_name;
@@ -132,7 +132,7 @@ ZTEST(lwm2m_engine, test_pause_resume)
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
 	k_mutex_init(&ctx.lock);
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 
@@ -158,7 +158,7 @@ ZTEST(lwm2m_engine, test_engine_add_service)
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
 	k_mutex_init(&ctx.lock);
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 	ctx.load_credentials = NULL;
 
 	ret = lwm2m_engine_start(&ctx);
@@ -199,7 +199,7 @@ ZTEST(lwm2m_engine, test_connect_fail)
 	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 
 	errno = ENETDOWN;
 	z_impl_zsock_connect_fake.return_val = -1;
@@ -218,7 +218,7 @@ ZTEST(lwm2m_engine, test_socket_suspend_resume_connection)
 	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 
 	ret = lwm2m_engine_start(&ctx);
 	zassert_equal(ret, 0);
@@ -242,7 +242,7 @@ ZTEST(lwm2m_engine, test_check_notifications)
 	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 	sys_slist_init(&ctx.observer);
 
 	obs.last_timestamp = k_uptime_get();
@@ -357,7 +357,7 @@ ZTEST(lwm2m_engine, test_retransmit_request)
 	k_mutex_init(&ctx.lock);
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 
 	pending_1.t0 = k_uptime_get();
 	pending_1.timeout = 200U;
@@ -387,7 +387,7 @@ ZTEST(lwm2m_engine, test_socket_recv)
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
 	k_mutex_init(&ctx.lock);
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 
 	set_socket_events(ZSOCK_POLLIN);
@@ -411,7 +411,7 @@ ZTEST(lwm2m_engine, test_socket_send)
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
 	k_mutex_init(&ctx.lock);
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	sys_slist_init(&ctx.queued_messages);
 	msg.ctx = &ctx;
@@ -443,7 +443,7 @@ ZTEST(lwm2m_engine, test_security)
 	my_data_len = snprintk(my_buf, sizeof(my_buf), "-----BEGIN SOMETHING");
 
 	k_mutex_init(&ctx.lock);
-	ctx.remote_addr.sa_family = NET_AF_INET;
+	ctx.remote_addr_storage.ss_family = NET_AF_INET;
 	ctx.sock_fd = -1;
 	ctx.load_credentials = NULL;
 	ctx.desthostname = host_name;
@@ -498,7 +498,7 @@ ZTEST(lwm2m_engine, test_socket_state)
 {
 	int ret;
 	struct lwm2m_ctx ctx = {
-		.remote_addr.sa_family = NET_AF_INET,
+		.remote_addr_storage.ss_family = NET_AF_INET,
 		.sock_fd = -1,
 		.set_socket_state = socket_state,
 	};

--- a/tests/net/lib/zperf/src/main.c
+++ b/tests/net/lib/zperf/src/main.c
@@ -121,7 +121,7 @@ static void fill_upload_params(struct zperf_upload_params *param)
 		      "Failed to parse loopback address");
 
 	memset(param, 0, sizeof(*param));
-	memcpy(&param->peer_addr, &peer, sizeof(peer));
+	memcpy(&param->peer_addr_storage, &peer, sizeof(peer));
 	param->duration_ms = TEST_DURATION_MS;
 	param->packet_size = TEST_PACKET_SIZE;
 	param->rate_kbps = TEST_RATE_KBPS;


### PR DESCRIPTION
Store network socket addresses in sockaddr_storage. Go through relevant network code in `subsys/net` and friends and convert the code.

Fixes #104845