### PR TITLE
modules: hostap: Increase supplicant stack size

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -72,9 +72,7 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	# overflow issues. Need to identify the cause for higher stack usage.
 	default 8600 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE || WIFI_USAGE_MODE_STA_AP
 	default 8000 if WIFI_NM_WPA_SUPPLICANT_P2P
-	# This is needed to handle stack overflow issues on nRF Wi-Fi drivers.
-	default 6300 if WIFI_NM_WPA_SUPPLICANT_AP
-	default 5800
+	default 6300
 
 config WIFI_NM_WPA_SUPPLICANT_WQ_STACK_SIZE
 	int "Stack size for wpa_supplicant iface workqueue"


### PR DESCRIPTION
Due to changes for handing over EAPoL packets to Wi-Fi driver instead of passing them to network stack, stack usage has increased on supplicant thread. Increase the stack size of supplicant thread to handle this.