### PR TITLE
drivers: clock_control: max32: add ERFO capacitance config via DTS

### DIFF
--- a/drivers/clock_control/clock_control_max32.c
+++ b/drivers/clock_control/clock_control_max32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -156,6 +156,13 @@ static int max32_clkctrl_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(gcr), sysclk_prescaler)
 	/* Setup divider */
 	Wrap_MXC_SYS_SetClockDiv(sysclk_prescaler(ADI_MAX32_SYSCLK_PRESCALER));
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(clk_erfo), capacitance_erfoctrl)
+	/* Setup capacitance for ERFO */
+	int erfo_cap = DT_PROP(DT_NODELABEL(clk_erfo), capacitance_erfoctrl);
+
+	MXC_FCR->erfoctrl = erfo_cap;
 #endif
 
 	return 0;

--- a/drivers/clock_control/clock_control_max32.c
+++ b/drivers/clock_control/clock_control_max32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -156,6 +156,13 @@ static int max32_clkctrl_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(gcr), sysclk_prescaler)
 	/* Setup divider */
 	Wrap_MXC_SYS_SetClockDiv(sysclk_prescaler(ADI_MAX32_SYSCLK_PRESCALER));
+#endif
+
+#if defined(CONFIG_SOC_MAX32657) && DT_NODE_HAS_PROP(DT_NODELABEL(clk_erfo), capacitance_erfoctrl)
+	/* Setup capacitance for ERFO */
+	int erfo_cap = DT_PROP(DT_NODELABEL(clk_erfo), capacitance_erfoctrl);
+
+	MXC_FCR->erfoctrl = erfo_cap;
 #endif
 
 	return 0;

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -99,9 +99,10 @@
 		};
 
 		clk_erfo: clk_erfo {
-			compatible = "fixed-clock";
+			compatible = "adi,max32-erfo";
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(32)>;
+			capacitance-erfoctrl = <0>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -92,16 +92,19 @@
 		};
 
 		clk_ertco: clk_ertco {
-			compatible = "fixed-clock";
+			compatible = "adi,max32-ertco";
 			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			capacitance-rtcx1 = <0xf>;
+			capacitance-rtcx2 = <0xf>;
 			status = "disabled";
 		};
 
 		clk_erfo: clk_erfo {
-			compatible = "fixed-clock";
+			compatible = "adi,max32-erfo";
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(32)>;
+			capacitance-erfoctrl = <0>;
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/clock/adi,max32-erfo.yaml
+++ b/dts/bindings/clock/adi,max32-erfo.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "adi,max32-erfo"
+
+include: fixed-clock.yaml
+
+properties:
+  capacitance-erfoctrl:
+    type: int
+    description: ERFO load capacitance in pF. Refer to documentation on the
+                 ERFO Control register for guidance on how to set the register.

--- a/dts/bindings/clock/adi,max32-erfo.yaml
+++ b/dts/bindings/clock/adi,max32-erfo.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "adi,max32-erfo"
+
+include: fixed-clock.yaml
+
+properties:
+  capacitance-erfoctrl:
+    type: int
+    description: This is only supported on MAX32657. Refer to documentation on the
+                 ERFO Control register for guidance on how to set the register.

--- a/dts/bindings/clock/adi,max32-ertco.yaml
+++ b/dts/bindings/clock/adi,max32-ertco.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "adi,max32-ertco"
+
+include: fixed-clock.yaml
+
+properties:
+  capacitance-rtcx1:
+    type: int
+    description: ERTCO load capacitance for 32KIN in pF.
+  capacitance-rtcx2:
+    type: int
+    description: ERTCO load capacitance for 32KOUT in pF.


### PR DESCRIPTION
Add support for configuring ERFO in/out capacitance through device tree on MAX32657.