### PR TITLE
drivers: spi: spi_stm32: Assert chip-select with zero-byte transaction

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1980,6 +1980,9 @@ static int transceive(const struct device *dev,
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, bits2bytes(config->operation));
 
 	if (!spi_stm32_transfer_ongoing(data)) {
+		if (config->operation & SPI_HOLD_ON_CS) {
+			spi_stm32_cs_control(dev, true);
+		}
 		goto end;
 	}
 


### PR DESCRIPTION
Assert CS with zero-byte transaction since BLE HCI SPI (`hci_spi_st.c`) driver relies on zero-byte transaction for asserting CS.

This feature was broken by the commit [drivers: spi: stm32: simplify the use of fifo for st,stm32h7-spi compat](https://github.com/zephyrproject-rtos/zephyr/commit/1628f86398072b9c076e4839c5af19d845164214) introduced in PR #110265.

It fixes the SPI communication for radio co-processors (RCPs).