### PR TITLE
scripts: Install ECDSA python package

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -29,3 +29,6 @@ PyGithub
 
 # used to generate devicetree dependency graphs
 graphviz
+
+# used to generate ECDSA signature for MAX32657 MCUBoot that validated by BootROM
+ecdsa>=0.19.0


### PR DESCRIPTION
MAX32657 MCUBoot image need to be signed if Secure Boot ROM has been enabled. In that case MCUBoot image need to be signed. The sign process being done by python script which uses ECDSA package.

This PR install ECDSA python package.