### PR TITLE
drivers: regulator: mspm0: rewrite VREF driver using native register access

### DIFF
--- a/drivers/regulator/Kconfig.mspm0
+++ b/drivers/regulator/Kconfig.mspm0
@@ -6,7 +6,6 @@ config REGULATOR_MSPM0_VREF
 	depends on REGULATOR
 	depends on DT_HAS_TI_MSPM0_VREF_ENABLED
 	default y
-	select USE_MSPM0_DL_VREF
 	help
 	  Enable the MSPM0 VREF driver
 

--- a/drivers/regulator/regulator_mspm0_vref.c
+++ b/drivers/regulator/regulator_mspm0_vref.c
@@ -84,7 +84,7 @@ struct regulator_mspm0_vref_regs {
 struct regulator_mspm0_vref_data {
 	struct regulator_common_data common;
 	uint32_t regulator_uv;
-	uint16_t sh_cycle_count;
+	uint16_t sample_cycle_count;
 	uint16_t hold_cycle_count;
 	bool sh_mode_enable;
 };
@@ -104,8 +104,9 @@ static void regulator_mspm0_vref_configure(const struct regulator_mspm0_vref_con
 								 : VREF_CTL0_BUFCONFIG_2_5V;
 
 	config->regs->ctl0 = buf_config | (data->sh_mode_enable ? VREF_CTL0_SHMODE : 0);
-	config->regs->ctl2 = FIELD_PREP(VREF_CTL2_SHCYCLE, data->sh_cycle_count) |
-			     FIELD_PREP(VREF_CTL2_HCYCLE, data->hold_cycle_count);
+	config->regs->ctl2 =
+		FIELD_PREP(VREF_CTL2_SHCYCLE, data->sample_cycle_count + data->hold_cycle_count) |
+		FIELD_PREP(VREF_CTL2_HCYCLE, data->hold_cycle_count);
 }
 
 static int regulator_mspm0_vref_enable(const struct device *dev)
@@ -311,7 +312,7 @@ static DEVICE_API(regulator, mspm0_vref_api) = {
 	static struct regulator_mspm0_vref_data data_##n = {					\
 		.regulator_uv = DT_INST_PROP(n, regulator_uv),                                     \
 		.sh_mode_enable = DT_INST_PROP(n, ti_sample_hold_enable),                          \
-		.sh_cycle_count = DT_INST_PROP(n, ti_sample_cycles),                               \
+		.sample_cycle_count = DT_INST_PROP(n, ti_sample_cycles),                           \
 		.hold_cycle_count = DT_INST_PROP(n, ti_hold_cycles),                               \
 	};											\
 												\

--- a/drivers/regulator/regulator_mspm0_vref.c
+++ b/drivers/regulator/regulator_mspm0_vref.c
@@ -6,15 +6,12 @@
 
 #define DT_DRV_COMPAT ti_mspm0_vref
 
-#include <errno.h>
 #include <zephyr/drivers/regulator.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/regulator/mspm0_vref.h>
 #include <zephyr/logging/log.h>
-
-/* TI Driverlib includes */
-#include <ti/driverlib/dl_vref.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(vref, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -22,28 +19,109 @@ LOG_MODULE_REGISTER(vref, CONFIG_LOG_DEFAULT_LEVEL);
 #define VREF_1_4V	1400000
 #define VREF_2_5V	2500000
 
+struct regulator_mspm0_vref_gprcm {
+	volatile uint32_t pwren;      /**< Power Enable register, offset: 0x00 */
+	volatile uint32_t rstctl;     /**< Reset Control register, offset: 0x04 */
+	uint8_t reserved_1[0xC];      /**< Reserved, offset: 0x08 - 0x14 */
+	volatile const uint32_t stat; /**< Status register, offset: 0x14 */
+};
+
+struct regulator_mspm0_vref_regs {
+	uint8_t reserved_1[0x800];                        /**< Reserved, offset: 0x000 - 0x800 */
+	volatile struct regulator_mspm0_vref_gprcm gprcm; /**< Power/reset control, offset: 0x800 */
+	uint8_t reserved_2[0x7E8];                        /**< Reserved, offset: 0x818 - 0x1000 */
+	volatile uint32_t clkdiv; /**< Clock Divider register, offset: 0x1000 */
+	uint8_t reserved_3[0x4];  /**< Reserved, offset: 0x1004 - 0x1008 */
+	volatile uint32_t clksel; /**< Clock Selection register, offset: 0x1008 */
+	uint8_t reserved_4[0xF4]; /**< Reserved, offset: 0x100C - 0x1100 */
+	volatile uint32_t ctl0;   /**< Control 0 register, offset: 0x1100 */
+	volatile uint32_t ctl1;   /**< Control 1 register, offset: 0x1104 */
+	volatile uint32_t ctl2;   /**< Control 2 register, offset: 0x1108 */
+	volatile uint32_t v2ien;  /**< V2I Enable register, offset: 0x110C */
+};
+
+/* pwren bits */
+#define VREF_PWREN_ENABLE     BIT(0)
+#define VREF_PWREN_KEY        GENMASK(31, 24)
+#define VREF_PWREN_KEY_UNLOCK 0x26U
+
+/* rstctl bits */
+#define VREF_RSTCTL_RESETASSERT  BIT(0)
+#define VREF_RSTCTL_RESETSTKYCLR BIT(1)
+#define VREF_RSTCTL_KEY          GENMASK(31, 24)
+#define VREF_RSTCTL_KEY_UNLOCK   0xB1U
+
+/* stat bits */
+#define VREF_STAT_RESETSTKY BIT(16)
+
+/* clkdiv bits */
+#define VREF_CLKDIV_RATIO        GENMASK(2, 0)
+#define VREF_CLKDIV_RATIO_VAL(x) ((x) - 1)
+
+/* clksel bits */
+#define VREF_CLKSEL_LFCLK_SEL  BIT(1)
+#define VREF_CLKSEL_MFCLK_SEL  BIT(2)
+#define VREF_CLKSEL_BUSCLK_SEL BIT(3)
+
+/* ctl0 bits */
+#define VREF_CTL0_ENABLE           BIT(0)
+#define VREF_CTL0_COMP_VREF_ENABLE BIT(1)
+#define VREF_CTL0_BUFCONFIG        BIT(7)
+#define VREF_CTL0_BUFCONFIG_2_5V   0U
+#define VREF_CTL0_BUFCONFIG_1_4V   VREF_CTL0_BUFCONFIG
+#define VREF_CTL0_SHMODE           BIT(8)
+
+/* ctl1 bits */
+#define VREF_CTL1_READY BIT(0)
+
+/* ctl2 bits */
+#define VREF_CTL2_SHCYCLE GENMASK(15, 0)
+#define VREF_CTL2_HCYCLE  GENMASK(31, 16)
+
+/* v2ien bits */
+#define VREF_V2IEN_V2I_EN BIT(0)
+
 struct regulator_mspm0_vref_data {
 	struct regulator_common_data common;
-	DL_VREF_Config vref_cfg;
+	uint32_t regulator_uv;
+	uint16_t sh_cycle_count;
+	uint16_t hold_cycle_count;
+	bool sh_mode_enable;
 };
 
 struct regulator_mspm0_vref_config {
 	struct regulator_common_config common;
 	const struct pinctrl_dev_config *vref_pin;
-	DL_VREF_ClockConfig vref_clock_cfg;
-	VREF_Regs *regs;
+	struct regulator_mspm0_vref_regs *regs;
+	uint32_t clock_sel;
+	uint32_t clock_div;
 };
+
+static void regulator_mspm0_vref_configure(const struct regulator_mspm0_vref_config *config,
+					   struct regulator_mspm0_vref_data *data)
+{
+	uint32_t buf_config = (data->regulator_uv == VREF_1_4V) ? VREF_CTL0_BUFCONFIG_1_4V
+								 : VREF_CTL0_BUFCONFIG_2_5V;
+
+	config->regs->ctl0 = buf_config | (data->sh_mode_enable ? VREF_CTL0_SHMODE : 0);
+	config->regs->ctl2 = FIELD_PREP(VREF_CTL2_SHCYCLE, data->sh_cycle_count) |
+			     FIELD_PREP(VREF_CTL2_HCYCLE, data->hold_cycle_count);
+}
 
 static int regulator_mspm0_vref_enable(const struct device *dev)
 {
-	DL_VREF_enableInternalRef(((const struct regulator_mspm0_vref_config *)dev->config)->regs);
+	const struct regulator_mspm0_vref_config *config = dev->config;
+
+	config->regs->ctl0 |= VREF_CTL0_ENABLE;
 
 	return 0;
 }
 
 static int regulator_mspm0_vref_disable(const struct device *dev)
 {
-	DL_VREF_disableInternalRef(((const struct regulator_mspm0_vref_config *)dev->config)->regs);
+	const struct regulator_mspm0_vref_config *config = dev->config;
+
+	config->regs->ctl0 &= ~VREF_CTL0_ENABLE;
 
 	return 0;
 }
@@ -61,7 +139,7 @@ static int regulator_mspm0_vref_get_voltage(const struct device *dev, int32_t *v
 	k_mutex_lock(&data->common.lock, K_FOREVER);
 #endif
 
-	if (config->regs->CTL0 & VREF_CTL0_BUFCONFIG_MASK) {
+	if (config->regs->ctl0 & VREF_CTL0_BUFCONFIG) {
 		*volt_uv = VREF_1_4V;
 	} else {
 		*volt_uv = VREF_2_5V;
@@ -96,18 +174,14 @@ static int regulator_mspm0_vref_set_voltage(const struct device *dev, int32_t mi
 #endif
 
 	if (data->common.refcnt != 0) {
-		volt_get = (config->regs->CTL0 & VREF_CTL0_BUFCONFIG_MASK) ? VREF_1_4V : VREF_2_5V;
+		volt_get = (config->regs->ctl0 & VREF_CTL0_BUFCONFIG) ? VREF_1_4V : VREF_2_5V;
 		if (volt_set != volt_get) {
 			ret = -EBUSY;
 			goto out;
 		}
 	} else {
-		if (volt_set == VREF_2_5V) {
-			data->vref_cfg.bufConfig = DL_VREF_BUFCONFIG_OUTPUT_2_5V;
-		} else {
-			data->vref_cfg.bufConfig = DL_VREF_BUFCONFIG_OUTPUT_1_4V;
-		}
-		DL_VREF_configReference(config->regs, &data->vref_cfg);
+		data->regulator_uv = volt_set;
+		regulator_mspm0_vref_configure(config, data);
 	}
 out:
 
@@ -131,7 +205,7 @@ static int regulator_mspm0_vref_get_mode(const struct device *dev, regulator_mod
 	k_mutex_lock(&data->common.lock, K_FOREVER);
 #endif
 
-	if (config->regs->CTL0 & VREF_CTL0_SHMODE_MASK) {
+	if (config->regs->ctl0 & VREF_CTL0_SHMODE) {
 		*mode = MSPM0_VREF_MODE_SHMODE;
 	} else {
 		*mode = MSPM0_VREF_MODE_NORMAL;
@@ -156,8 +230,8 @@ static int regulator_mspm0_vref_set_mode(const struct device *dev, regulator_mod
 #endif
 
 	if (data->common.refcnt != 0) {
-		mode_get = (config->regs->CTL0 & VREF_CTL0_SHMODE_MASK) ? MSPM0_VREF_MODE_SHMODE
-			    : MSPM0_VREF_MODE_NORMAL;
+		mode_get = (config->regs->ctl0 & VREF_CTL0_SHMODE) ? MSPM0_VREF_MODE_SHMODE
+								   : MSPM0_VREF_MODE_NORMAL;
 		if (mode_get != mode) {
 			ret = -EBUSY;
 			goto out;
@@ -165,16 +239,16 @@ static int regulator_mspm0_vref_set_mode(const struct device *dev, regulator_mod
 	} else {
 		switch (mode) {
 		case MSPM0_VREF_MODE_SHMODE:
-			data->vref_cfg.shModeEnable = DL_VREF_SHMODE_ENABLE;
+			data->sh_mode_enable = true;
 			break;
 		case MSPM0_VREF_MODE_NORMAL:
-			data->vref_cfg.shModeEnable = DL_VREF_SHMODE_DISABLE;
+			data->sh_mode_enable = false;
 			break;
 		default:
 			ret = -EINVAL;
 			goto out;
 		}
-		DL_VREF_configReference(config->regs, &data->vref_cfg);
+		regulator_mspm0_vref_configure(config, data);
 	}
 out:
 
@@ -200,10 +274,13 @@ static int regulator_mspm0_vref_init(const struct device *dev)
 	}
 
 	/* Enable power */
-	DL_VREF_enablePower(config->regs);
-	delay_cycles(CONFIG_MSPM0_PERIPH_STARTUP_DELAY);
-	DL_VREF_configReference(config->regs, &data->vref_cfg);
-	DL_VREF_setClockConfig(config->regs, &config->vref_clock_cfg);
+	config->regs->gprcm.pwren =
+		FIELD_PREP(VREF_PWREN_KEY, VREF_PWREN_KEY_UNLOCK) | VREF_PWREN_ENABLE;
+	k_busy_wait(k_cyc_to_us_ceil32(CONFIG_MSPM0_PERIPH_STARTUP_DELAY));
+	regulator_mspm0_vref_configure(config, data);
+	config->regs->clksel = config->clock_sel;
+	config->regs->clkdiv =
+		FIELD_PREP(VREF_CLKDIV_RATIO, VREF_CLKDIV_RATIO_VAL(config->clock_div));
 
 	ret = regulator_common_init(dev, false);
 	if (ret) {
@@ -223,34 +300,23 @@ static DEVICE_API(regulator, mspm0_vref_api) = {
 	.get_mode = regulator_mspm0_vref_get_mode,
 };
 
-#define VREF_CLOCK_DIVIDE_RATIO(n)	CONCAT(DL_VREF_CLOCK_DIVIDE_, DT_INST_PROP(n, ti_clk_div))
-
 #define REGULATOR_MSPM0_VREF_DEFINE(n)								\
 												\
 	PINCTRL_DT_INST_DEFINE(n);								\
 												\
 	static struct regulator_mspm0_vref_data data_##n = {					\
-		.vref_cfg = {									\
-			.vrefEnable = DL_VREF_ENABLE_DISABLE,					\
-			.bufConfig = (DT_INST_PROP(n, regulator_uv) == VREF_1_4V		\
-					? DL_VREF_BUFCONFIG_OUTPUT_1_4V				\
-					: DL_VREF_BUFCONFIG_OUTPUT_2_5V),			\
-			.shModeEnable = DT_INST_PROP(n, ti_sample_hold_enable)			\
-				? DL_VREF_SHMODE_ENABLE : DL_VREF_SHMODE_DISABLE,		\
-			.shCycleCount = DT_INST_PROP(n, ti_sample_cycles),			\
-			.holdCycleCount = DT_INST_PROP(n, ti_hold_cycles),			\
-		},										\
+		.regulator_uv = DT_INST_PROP(n, regulator_uv),                                     \
+		.sh_mode_enable = DT_INST_PROP(n, ti_sample_hold_enable),                          \
+		.sh_cycle_count = DT_INST_PROP(n, ti_sample_cycles),                               \
+		.hold_cycle_count = DT_INST_PROP(n, ti_hold_cycles),                               \
 	};											\
 												\
 	static const struct regulator_mspm0_vref_config config_##n = {				\
 		.common = REGULATOR_DT_INST_COMMON_CONFIG_INIT(n),				\
 		.vref_pin = PINCTRL_DT_INST_DEV_CONFIG_GET(n),					\
-		.regs = (VREF_Regs *)DT_INST_REG_ADDR(n),					\
-		.vref_clock_cfg = {								\
-			.clockSel =								\
-			MSPM0_CLOCK_PERIPH_REG_MASK(DT_INST_CLOCKS_CELL(n, clk)),		\
-			.divideRatio = VREF_CLOCK_DIVIDE_RATIO(n),				\
-		},										\
+		.regs = (struct regulator_mspm0_vref_regs *)DT_INST_REG_ADDR(n),                   \
+		.clock_sel = MSPM0_CLOCK_PERIPH_REG_MASK(DT_INST_CLOCKS_CELL(n, clk)),             \
+		.clock_div = DT_INST_PROP(n, ti_clk_div),                                          \
 	};											\
 												\
 DEVICE_DT_INST_DEFINE(n, regulator_mspm0_vref_init, NULL, &data_##n,				\

--- a/drivers/regulator/regulator_mspm0_vref.c
+++ b/drivers/regulator/regulator_mspm0_vref.c
@@ -129,7 +129,9 @@ static int regulator_mspm0_vref_disable(const struct device *dev)
 static int regulator_mspm0_vref_get_voltage(const struct device *dev, int32_t *volt_uv)
 {
 	const struct regulator_mspm0_vref_config *config = dev->config;
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 	struct regulator_mspm0_vref_data *data = dev->data;
+#endif
 
 	if (volt_uv == NULL) {
 		return -EINVAL;
@@ -195,7 +197,9 @@ out:
 static int regulator_mspm0_vref_get_mode(const struct device *dev, regulator_mode_t *mode)
 {
 	const struct regulator_mspm0_vref_config *config = dev->config;
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 	struct regulator_mspm0_vref_data *data = dev->data;
+#endif
 
 	if (mode == NULL) {
 		return -EINVAL;


### PR DESCRIPTION
Rewrite the MSPM0 regulator drive using native register I/O instead of relying on driverlib HAL.

This is part of a greater effort for removing driverlib dependency for MSPM0 and reuse IPs for MSPM33/AM13.

https://github.com/zephyrproject-rtos/zephyr/pull/115444 uses this PR.