### PR TITLE
drivers: adc: add optional ref_internal_get

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -184,10 +184,14 @@ New APIs and options
 
 * ADC
 
-  * Optional :c:member:`adc_driver_api.ref_internal_get` callback so
-    :c:func:`adc_ref_internal` can return a driver-owned runtime millivolt
-    scale (static :c:member:`adc_driver_api.ref_internal` remains the
-    fallback when the callback is NULL)
+  * Optional :c:member:`adc_driver_api.ref_get` callback and
+    :c:func:`adc_ref_get` so applications and
+    :c:func:`adc_raw_to_millivolts_dt` can use a driver-owned runtime
+    millivolt scale for any :c:enum:`adc_reference`. Static
+    :c:member:`adc_driver_api.ref_internal` remains the fallback for
+    :c:enumerator:`ADC_REF_INTERNAL` when the callback is NULL.
+    :c:func:`adc_raw_to_millivolts_dt` falls back to channel DT
+    ``zephyr,vref-mv`` when :c:func:`adc_ref_get` fails.
 
 * Architectures
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -182,6 +182,13 @@ New APIs and options
 
 .. zephyr-keep-sorted-start re(^\* \w) ignorecase
 
+* ADC
+
+  * Optional :c:member:`adc_driver_api.ref_internal_get` callback so
+    :c:func:`adc_ref_internal` can return a driver-owned runtime millivolt
+    scale (static :c:member:`adc_driver_api.ref_internal` remains the
+    fallback when the callback is NULL)
+
 * Architectures
 
   * :kconfig:option:`CONFIG_ARM_MPU_CM7_UNMAPPED_REGION` (Arm Cortex-M7 catch-all MPU region

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -279,11 +279,55 @@ static uint16_t adc_emul_get_ref_voltage(struct adc_emul_data *data,
 	return voltage;
 }
 
-static uint16_t adc_emul_ref_internal_get(const struct device *dev)
+static int adc_emul_ref_get(const struct device *dev, enum adc_reference ref,
+			    uint16_t *vref_mv)
 {
 	struct adc_emul_data *data = dev->data;
+	uint16_t voltage;
+	bool supported = true;
 
-	return adc_emul_get_ref_voltage(data, ADC_REF_INTERNAL);
+	k_mutex_lock(&data->cfg_mtx, K_FOREVER);
+
+	switch (ref) {
+	case ADC_REF_VDD_1:
+		voltage = data->ref_vdd;
+		break;
+	case ADC_REF_VDD_1_2:
+		voltage = data->ref_vdd / 2;
+		break;
+	case ADC_REF_VDD_1_3:
+		voltage = data->ref_vdd / 3;
+		break;
+	case ADC_REF_VDD_1_4:
+		voltage = data->ref_vdd / 4;
+		break;
+	case ADC_REF_INTERNAL:
+		voltage = data->ref_int;
+		break;
+	case ADC_REF_EXTERNAL0:
+		voltage = data->ref_ext0;
+		break;
+	case ADC_REF_EXTERNAL1:
+		voltage = data->ref_ext1;
+		break;
+	default:
+		supported = false;
+		voltage = 0;
+		break;
+	}
+
+	k_mutex_unlock(&data->cfg_mtx);
+
+	if (!supported) {
+		return -ENOTSUP;
+	}
+
+	if (voltage == 0U) {
+		return -ENODATA;
+	}
+
+	*vref_mv = voltage;
+	return 0;
 }
 
 static int adc_emul_channel_setup(const struct device *dev,
@@ -630,7 +674,7 @@ static int adc_emul_init(const struct device *dev)
 		.channel_setup = adc_emul_channel_setup,		\
 		.read = adc_emul_read,					\
 		.ref_internal = DT_INST_PROP(_num, ref_internal_mv),	\
-		.ref_internal_get = adc_emul_ref_internal_get,		\
+		.ref_get = adc_emul_ref_get,				\
 		IF_ENABLED(CONFIG_ADC_ASYNC,				\
 			(.read_async = adc_emul_read_async,))		\
 	};								\

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -232,53 +232,6 @@ int adc_emul_ref_voltage_set(const struct device *dev, enum adc_reference ref,
 	return err;
 }
 
-/**
- * @brief Convert @p ref to reference voltage value in mV
- *
- * @param data Internal data of ADC emulator
- * @param ref Select which reference source should be used
- *
- * @return Reference voltage in mV
- * @return 0 on error
- */
-static uint16_t adc_emul_get_ref_voltage(struct adc_emul_data *data,
-					 enum adc_reference ref)
-{
-	uint16_t voltage;
-
-	k_mutex_lock(&data->cfg_mtx, K_FOREVER);
-
-	switch (ref) {
-	case ADC_REF_VDD_1:
-		voltage = data->ref_vdd;
-		break;
-	case ADC_REF_VDD_1_2:
-		voltage = data->ref_vdd / 2;
-		break;
-	case ADC_REF_VDD_1_3:
-		voltage = data->ref_vdd / 3;
-		break;
-	case ADC_REF_VDD_1_4:
-		voltage = data->ref_vdd / 4;
-		break;
-	case ADC_REF_INTERNAL:
-		voltage = data->ref_int;
-		break;
-	case ADC_REF_EXTERNAL0:
-		voltage = data->ref_ext0;
-		break;
-	case ADC_REF_EXTERNAL1:
-		voltage = data->ref_ext1;
-		break;
-	default:
-		voltage = 0;
-	}
-
-	k_mutex_unlock(&data->cfg_mtx);
-
-	return voltage;
-}
-
 static int adc_emul_ref_get(const struct device *dev, enum adc_reference ref,
 			    uint16_t *vref_mv)
 {
@@ -328,6 +281,24 @@ static int adc_emul_ref_get(const struct device *dev, enum adc_reference ref,
 
 	*vref_mv = voltage;
 	return 0;
+}
+
+/**
+ * @brief Convert @p ref to reference voltage value in mV
+ *
+ * @param data Internal data of ADC emulator
+ * @param ref Select which reference source should be used
+ *
+ * @return Reference voltage in mV
+ * @return 0 on error
+ */
+static uint16_t adc_emul_get_ref_voltage(struct adc_emul_data *data,
+					 enum adc_reference ref)
+{
+	uint16_t voltage;
+	int err = adc_emul_ref_get(data->dev, ref, &voltage);
+
+	return err == 0 ? voltage : 0;
 }
 
 static int adc_emul_channel_setup(const struct device *dev,

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -279,6 +279,13 @@ static uint16_t adc_emul_get_ref_voltage(struct adc_emul_data *data,
 	return voltage;
 }
 
+static uint16_t adc_emul_ref_internal_get(const struct device *dev)
+{
+	struct adc_emul_data *data = dev->data;
+
+	return adc_emul_get_ref_voltage(data, ADC_REF_INTERNAL);
+}
+
 static int adc_emul_channel_setup(const struct device *dev,
 				  const struct adc_channel_cfg *channel_cfg)
 {
@@ -623,6 +630,7 @@ static int adc_emul_init(const struct device *dev)
 		.channel_setup = adc_emul_channel_setup,		\
 		.read = adc_emul_read,					\
 		.ref_internal = DT_INST_PROP(_num, ref_internal_mv),	\
+		.ref_internal_get = adc_emul_ref_internal_get,		\
 		IF_ENABLED(CONFIG_ADC_ASYNC,				\
 			(.read_async = adc_emul_read_async,))		\
 	};								\

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -1011,6 +1011,13 @@ typedef int (*adc_api_read_async)(const struct device *dev,
 				  struct k_poll_signal *async);
 
 /**
+ * @brief Type definition of ADC API function for getting the internal
+ *        reference voltage in millivolts.
+ * See adc_ref_internal() for related public helper.
+ */
+typedef uint16_t (*adc_api_ref_internal_get)(const struct device *dev);
+
+/**
  * @driver_ops{ADC}
  */
 __subsystem struct adc_driver_api {
@@ -1043,6 +1050,14 @@ __subsystem struct adc_driver_api {
 	 * Set to 0 if internal reference is not supported.
 	 */
 	uint16_t ref_internal;
+	/**
+	 * @driver_ops_optional Get the current internal reference voltage
+	 * in millivolts.
+	 * When NULL, adc_ref_internal() returns @c ref_internal.
+	 * When implemented, return the live cache if valid, otherwise the
+	 * instance DT / @c ref_internal fallback.
+	 */
+	adc_api_ref_internal_get ref_internal_get;
 };
 
 /** @} */
@@ -1298,14 +1313,26 @@ static inline int z_impl_adc_get_decoder(const struct device *dev,
  * Returns the voltage corresponding to @ref ADC_REF_INTERNAL,
  * measured in millivolts.
  *
+ * When the driver provides @c ref_internal_get, that callback is used.
+ * Otherwise, the static @c ref_internal field from the driver API is
+ * returned. Drivers that implement @c ref_internal_get may update the
+ * value over time (for example after hardware calibration); this does
+ * not change the function signature.
+ *
  * @param dev Pointer to the device structure for the driver instance.
  *
- * @return a positive value is the reference voltage value.  Returns
+ * @return A positive value is the reference voltage value.  Returns
  * zero if reference voltage information is not available.
  */
 static inline uint16_t adc_ref_internal(const struct device *dev)
 {
-	return DEVICE_API_GET(adc, dev)->ref_internal;
+	const struct adc_driver_api *api = DEVICE_API_GET(adc, dev);
+
+	if (api->ref_internal_get != NULL) {
+		return api->ref_internal_get(dev);
+	}
+
+	return api->ref_internal;
 }
 
 /**

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -1011,11 +1011,12 @@ typedef int (*adc_api_read_async)(const struct device *dev,
 				  struct k_poll_signal *async);
 
 /**
- * @brief Type definition of ADC API function for getting the internal
- *        reference voltage in millivolts.
- * See adc_ref_internal() for related public helper.
+ * @brief Type definition of ADC API function for getting a reference
+ *        voltage in millivolts.
+ * See adc_ref_get() for related public helper.
  */
-typedef uint16_t (*adc_api_ref_internal_get)(const struct device *dev);
+typedef int (*adc_api_ref_get)(const struct device *dev, enum adc_reference ref,
+			       uint16_t *vref_mv);
 
 /**
  * @driver_ops{ADC}
@@ -1047,17 +1048,22 @@ __subsystem struct adc_driver_api {
 	/**
 	 * @driver_ops_mandatory Internal reference voltage, in millivolts.
 	 *
-	 * Set to 0 if internal reference is not supported.
+	 * Set to 0 if internal reference is not supported. Used as the
+	 * fallback for @ref ADC_REF_INTERNAL when @c ref_get is NULL.
 	 */
 	uint16_t ref_internal;
 	/**
-	 * @driver_ops_optional Get the current internal reference voltage
-	 * in millivolts.
-	 * When NULL, adc_ref_internal() returns @c ref_internal.
-	 * When implemented, return the live cache if valid, otherwise the
-	 * instance DT / @c ref_internal fallback.
+	 * @driver_ops_optional Get the current voltage for a selected
+	 * reference in millivolts.
+	 *
+	 * When NULL, @ref adc_ref_get falls back to @c ref_internal for
+	 * @ref ADC_REF_INTERNAL and returns @c -ENOTSUP for other
+	 * references. When implemented, return the live/runtime value
+	 * (for example a cached measurement); return @c -ENODATA when the
+	 * reference is supported but no millivolt value is known yet, or
+	 * @c -ENOTSUP when the reference is not supported by the device.
 	 */
-	adc_api_ref_internal_get ref_internal_get;
+	adc_api_ref_get ref_get;
 };
 
 /** @} */
@@ -1308,16 +1314,58 @@ static inline int z_impl_adc_get_decoder(const struct device *dev,
 #endif /* CONFIG_ADC_STREAM */
 
 /**
+ * @brief Get the voltage for a selected ADC reference.
+ *
+ * Returns the millivolt scale associated with @p ref for @p dev. When the
+ * driver provides @c ref_get, that callback is used. Otherwise,
+ * @ref ADC_REF_INTERNAL falls back to the static @c ref_internal field
+ * and other references return @c -ENOTSUP.
+ *
+ * Drivers that implement @c ref_get are responsible for any DT /
+ * @c ref_internal fallback for @ref ADC_REF_INTERNAL.
+ *
+ * @param[in]  dev      Pointer to the device structure for the driver instance.
+ * @param[in]  ref      Reference whose millivolt scale is requested.
+ * @param[out] vref_mv  Destination for the reference voltage in millivolts.
+ *
+ * @retval 0          On success; @p vref_mv holds the voltage in millivolts.
+ * @retval -EINVAL    If @p vref_mv is NULL.
+ * @retval -ENOTSUP   If the reference is not supported / no value source exists.
+ * @retval -ENODATA   If the reference is supported but no millivolt value is known.
+ */
+static inline int adc_ref_get(const struct device *dev, enum adc_reference ref,
+			      uint16_t *vref_mv)
+{
+	const struct adc_driver_api *api;
+
+	if (vref_mv == NULL) {
+		return -EINVAL;
+	}
+
+	api = DEVICE_API_GET(adc, dev);
+
+	if (api->ref_get != NULL) {
+		return api->ref_get(dev, ref, vref_mv);
+	}
+
+	if (ref != ADC_REF_INTERNAL) {
+		return -ENOTSUP;
+	}
+
+	*vref_mv = api->ref_internal;
+	return (*vref_mv == 0U) ? -ENODATA : 0;
+}
+
+/**
  * @brief Get the internal reference voltage.
  *
  * Returns the voltage corresponding to @ref ADC_REF_INTERNAL,
- * measured in millivolts.
+ * measured in millivolts. This is a convenience wrapper around
+ * @ref adc_ref_get.
  *
- * When the driver provides @c ref_internal_get, that callback is used.
- * Otherwise, the static @c ref_internal field from the driver API is
- * returned. Drivers that implement @c ref_internal_get may update the
- * value over time (for example after hardware calibration); this does
- * not change the function signature.
+ * Drivers that implement @c ref_get may update the value over time
+ * (for example after hardware calibration); this does not change the
+ * function signature.
  *
  * @param dev Pointer to the device structure for the driver instance.
  *
@@ -1326,13 +1374,12 @@ static inline int z_impl_adc_get_decoder(const struct device *dev,
  */
 static inline uint16_t adc_ref_internal(const struct device *dev)
 {
-	const struct adc_driver_api *api = DEVICE_API_GET(adc, dev);
+	uint16_t vref_mv;
+	int ret;
 
-	if (api->ref_internal_get != NULL) {
-		return api->ref_internal_get(dev);
-	}
+	ret = adc_ref_get(dev, ADC_REF_INTERNAL, &vref_mv);
 
-	return api->ref_internal;
+	return ret == 0 ? vref_mv : 0U;
 }
 
 /**
@@ -1342,8 +1389,8 @@ static inline uint16_t adc_ref_internal(const struct device *dev)
  * ADC measurement to a physical voltage.
  *
  * @param ref_mv the reference voltage used for the measurement, in
- * millivolts.  This may be from adc_ref_internal() or a known
- * external reference.
+ * millivolts.  This may be from adc_ref_get(), adc_ref_internal() or
+ * a known external reference.
  *
  * @param gain the ADC gain configuration used to sample the input
  *
@@ -1419,19 +1466,20 @@ static inline int adc_raw_to_microvolts(int32_t ref_mv, enum adc_gain gain, uint
  * @see adc_raw_to_x_fn
  */
 static inline int adc_raw_to_x_dt_chan(adc_raw_to_x_fn conv_func,
-					    const struct adc_dt_spec *spec,
-					    const struct adc_channel_cfg *channel_cfg,
-					    int32_t *valp)
+				       const struct adc_dt_spec *spec,
+				       const struct adc_channel_cfg *channel_cfg,
+				       int32_t *valp)
 {
 	int32_t vref_mv;
+	uint16_t vref_mv_u16;
 	uint8_t resolution;
 
 	if (!spec->channel_cfg_dt_node_exists) {
 		return -ENOTSUP;
 	}
 
-	if (channel_cfg->reference == ADC_REF_INTERNAL) {
-		vref_mv = (int32_t)adc_ref_internal(spec->dev);
+	if (adc_ref_get(spec->dev, channel_cfg->reference, &vref_mv_u16) == 0) {
+		vref_mv = (int32_t)vref_mv_u16;
 	} else {
 		vref_mv = spec->vref_mv;
 	}

--- a/include/zephyr/drivers/adc/adc_emul.h
+++ b/include/zephyr/drivers/adc/adc_emul.h
@@ -125,8 +125,8 @@ int adc_emul_raw_value_func_set(const struct device *dev, unsigned int chan,
  * @return 0 on success
  * @return -EINVAL if an invalid argument is provided
  *
- * @note INTERNAL updates are also observed by @ref adc_ref_internal() when
- *       the emul provides @c ref_internal_get.
+ * @note Updates are also observed by @ref adc_ref_get() /
+ *       @ref adc_ref_internal() when the emul provides @c ref_get.
  */
 int adc_emul_ref_voltage_set(const struct device *dev, enum adc_reference ref,
 			     uint16_t value);

--- a/include/zephyr/drivers/adc/adc_emul.h
+++ b/include/zephyr/drivers/adc/adc_emul.h
@@ -124,6 +124,9 @@ int adc_emul_raw_value_func_set(const struct device *dev, unsigned int chan,
  *
  * @return 0 on success
  * @return -EINVAL if an invalid argument is provided
+ *
+ * @note INTERNAL updates are also observed by @ref adc_ref_internal() when
+ *       the emul provides @c ref_internal_get.
  */
 int adc_emul_ref_voltage_set(const struct device *dev, enum adc_reference ref,
 			     uint16_t value);

--- a/tests/drivers/adc/adc_emul/src/main.c
+++ b/tests/drivers/adc/adc_emul/src/main.c
@@ -737,6 +737,60 @@ ZTEST_USER(adc_emul, test_adc_emul_ref_voltage_set)
 	check_empty_samples(samples * 2);
 }
 
+ZTEST_USER(adc_emul, test_adc_ref_internal_tracks_emul_ref_voltage_set)
+{
+	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	uint16_t before = adc_ref_internal(adc_dev);
+	int ret;
+
+	zassert_true(before > 0, "expected non-zero DT internal ref");
+
+	ret = adc_emul_ref_voltage_set(adc_dev, ADC_REF_INTERNAL, 2500);
+	zassert_ok(ret, "adc_emul_ref_voltage_set failed: %d", ret);
+	zassert_equal(adc_ref_internal(adc_dev), 2500,
+		      "adc_ref_internal did not observe emul set");
+
+	zassert_ok(adc_emul_ref_voltage_set(adc_dev, ADC_REF_INTERNAL, before));
+}
+
+ZTEST_USER(adc_emul, test_adc_raw_to_millivolts_dt_tracks_emul_ref_internal)
+{
+	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const uint16_t runtime_ref_mv = 2500;
+	const int32_t raw_value = BIT(ADC_RESOLUTION) / 2;
+	const int32_t expected_mv = runtime_ref_mv / 2;
+	int32_t output = raw_value;
+	int ret;
+
+	/* clang-format off */
+	static const struct adc_dt_spec adc_internal_spec = {
+		.dev = DEVICE_DT_GET(ADC_DEVICE_NODE),
+		.channel_id = ADC_1ST_CHANNEL_ID,
+		.channel_cfg_dt_node_exists = true,
+		.channel_cfg = {
+			.gain = ADC_GAIN_1,
+			.reference = ADC_REF_INTERNAL,
+			.acquisition_time = ADC_ACQUISITION_TIME,
+			.channel_id = ADC_1ST_CHANNEL_ID,
+		},
+		.resolution = ADC_RESOLUTION,
+	};
+	/* clang-format on */
+
+	channel_setup(adc_dev, ADC_REF_INTERNAL, ADC_GAIN_1, ADC_1ST_CHANNEL_ID);
+
+	ret = adc_emul_ref_voltage_set(adc_dev, ADC_REF_INTERNAL, runtime_ref_mv);
+	zassert_ok(ret, "adc_emul_ref_voltage_set failed: %d", ret);
+
+	ret = adc_raw_to_millivolts_dt(&adc_internal_spec, &output);
+	zassert_ok(ret, "adc_raw_to_millivolts_dt() failed with code %d", ret);
+	zassert_within(expected_mv, output, MV_OUTPUT_EPS,
+		       "conversion did not track runtime internal ref");
+
+	zassert_ok(adc_emul_ref_voltage_set(adc_dev, ADC_REF_INTERNAL,
+					    ADC_REF_INTERNAL_MV));
+}
+
 void *adc_emul_setup(void)
 {
 	k_object_access_grant(get_adc_device(), k_current_get());

--- a/tests/drivers/adc/adc_emul/src/main.c
+++ b/tests/drivers/adc/adc_emul/src/main.c
@@ -791,6 +791,87 @@ ZTEST_USER(adc_emul, test_adc_raw_to_millivolts_dt_tracks_emul_ref_internal)
 					    ADC_REF_INTERNAL_MV));
 }
 
+ZTEST_USER(adc_emul, test_adc_ref_get_tracks_emul_refs)
+{
+	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	uint16_t mv = 0;
+	int ret;
+
+	ret = adc_ref_get(adc_dev, ADC_REF_INTERNAL, &mv);
+	zassert_ok(ret, "adc_ref_get(INTERNAL) failed: %d", ret);
+	zassert_equal(mv, ADC_REF_INTERNAL_MV,
+		      "unexpected default INTERNAL ref");
+
+	ret = adc_emul_ref_voltage_set(adc_dev, ADC_REF_VDD_1, 3000);
+	zassert_ok(ret, "adc_emul_ref_voltage_set(VDD) failed: %d", ret);
+
+	ret = adc_ref_get(adc_dev, ADC_REF_VDD_1, &mv);
+	zassert_ok(ret, "adc_ref_get(VDD_1) failed: %d", ret);
+	zassert_equal(mv, 3000, "unexpected VDD_1 ref");
+
+	ret = adc_ref_get(adc_dev, ADC_REF_VDD_1_2, &mv);
+	zassert_ok(ret, "adc_ref_get(VDD_1_2) failed: %d", ret);
+	zassert_equal(mv, 1500, "unexpected VDD_1_2 scaled ref");
+
+	ret = adc_emul_ref_voltage_set(adc_dev, ADC_REF_EXTERNAL0, 1800);
+	zassert_ok(ret, "adc_emul_ref_voltage_set(EXTERNAL0) failed: %d", ret);
+
+	ret = adc_ref_get(adc_dev, ADC_REF_EXTERNAL0, &mv);
+	zassert_ok(ret, "adc_ref_get(EXTERNAL0) failed: %d", ret);
+	zassert_equal(mv, 1800, "unexpected EXTERNAL0 ref");
+
+	ret = adc_ref_get(adc_dev, ADC_REF_INTERNAL, NULL);
+	zassert_equal(ret, -EINVAL, "NULL vref_mv should be -EINVAL");
+
+	zassert_ok(adc_emul_ref_voltage_set(adc_dev, ADC_REF_EXTERNAL0, 0));
+	ret = adc_ref_get(adc_dev, ADC_REF_EXTERNAL0, &mv);
+	zassert_equal(ret, -ENODATA,
+		      "unset EXTERNAL0 should return -ENODATA, got %d", ret);
+
+	zassert_ok(adc_emul_ref_voltage_set(adc_dev, ADC_REF_VDD_1, 0));
+	zassert_ok(adc_emul_ref_voltage_set(adc_dev, ADC_REF_INTERNAL,
+					    ADC_REF_INTERNAL_MV));
+}
+
+ZTEST_USER(adc_emul, test_adc_raw_to_millivolts_dt_tracks_emul_ref_vdd)
+{
+	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const uint16_t runtime_ref_mv = 2400;
+	const int32_t raw_value = BIT(ADC_RESOLUTION) / 2;
+	const int32_t expected_mv = runtime_ref_mv / 2;
+	int32_t output = raw_value;
+	int ret;
+
+	/* clang-format off */
+	static const struct adc_dt_spec adc_vdd_spec = {
+		.dev = DEVICE_DT_GET(ADC_DEVICE_NODE),
+		.channel_id = ADC_1ST_CHANNEL_ID,
+		.channel_cfg_dt_node_exists = true,
+		.channel_cfg = {
+			.gain = ADC_GAIN_1,
+			.reference = ADC_REF_VDD_1,
+			.acquisition_time = ADC_ACQUISITION_TIME,
+			.channel_id = ADC_1ST_CHANNEL_ID,
+		},
+		/* Intentionally stale DT value: runtime ref_get must win. */
+		.vref_mv = 1000,
+		.resolution = ADC_RESOLUTION,
+	};
+	/* clang-format on */
+
+	ret = adc_emul_ref_voltage_set(adc_dev, ADC_REF_VDD_1, runtime_ref_mv);
+	zassert_ok(ret, "adc_emul_ref_voltage_set failed: %d", ret);
+
+	channel_setup(adc_dev, ADC_REF_VDD_1, ADC_GAIN_1, ADC_1ST_CHANNEL_ID);
+
+	ret = adc_raw_to_millivolts_dt(&adc_vdd_spec, &output);
+	zassert_ok(ret, "adc_raw_to_millivolts_dt() failed with code %d", ret);
+	zassert_within(expected_mv, output, MV_OUTPUT_EPS,
+		       "conversion did not track runtime VDD ref");
+
+	zassert_ok(adc_emul_ref_voltage_set(adc_dev, ADC_REF_VDD_1, 0));
+}
+
 void *adc_emul_setup(void)
 {
 	k_object_access_grant(get_adc_device(), k_current_get());


### PR DESCRIPTION
### Problem

[`adc_ref_internal()`](https://docs.zephyrproject.org/latest/doxygen/html/group__adc__interface.html#gad11845f5621d0b0d03da4b6484d79aa4) today always returns the static [`adc_driver_api.ref_internal`](https://docs.zephyrproject.org/latest/doxygen/html/structadc__driver__api.html#ad12d4f5fa0eb0e45e14553deab0edbed) value, usually from DT. That fits a fixed bandgap, but not ADCs that convert against a supply/rail whose millivolt scale is only known accurately at runtime (factory cal + sense channel, etc.). Apps then bypass `adc_raw_to_millivolts_dt()` / `adc_ref_internal()` with a hand-rolled scale, and in-tree consumers (sensors, etc.) stay wrong.

See also the RFC #113971 for context and design discussion, including why there is no public setter.

### Solution (this PR)

Add an optional driver op:

- `uint16_t (*ref_internal_get)(const struct device *dev)`

`adc_ref_internal()` calls it when non-NULL; otherwise it returns static `ref_internal` as before. Drivers own any cache/update path themselves.

Also:

- `adc_emul` installs `ref_internal_get` over existing INTERNAL storage so `adc_emul_ref_voltage_set()` exercises the dynamic path in host tests
- release-notes entry for the behavior change (not a new public application API)

### Non-goals / follow-ups

- No `adc_ref_internal_set()` and no enum-keyed get/set (per RFC review)
- No vendor measurement yet (e.g. STM32 VREFINT → VREF+); planned as a stacked PR that only installs this getter and updates driver-owned cache
- External / provider-style references (regulator / `reference-supplies`) remain separate from this change

### Testing

- `west twister -T tests/drivers/adc/adc_emul -p native_sim`