### PR TITLE
samples: sensor: qdec: enable EQDC on RT118x boards

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -106,6 +106,14 @@ static int mcux_ccm_on(const struct device *dev,
 		CLOCK_EnableClock(kCLOCK_Xbar1 + instance);
 		return 0;
 #endif
+#if defined(CONFIG_EQDC_MCUX) && defined(CONFIG_SOC_SERIES_IMXRT118X)
+	case IMX_CCM_ENC1_CLK:
+	case IMX_CCM_ENC2_CLK:
+	case IMX_CCM_ENC3_CLK:
+	case IMX_CCM_ENC4_CLK:
+		CLOCK_EnableClock(kCLOCK_Enc1 + instance);
+		return 0;
+#endif
 #ifdef CONFIG_MEMC_MCUX_FLEXSPI
 #ifdef CONFIG_SOC_MIMX9352
 	case IMX_CCM_FLEXSPI_CLK:
@@ -461,6 +469,15 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 		*rate = 32768U;
 		return 0;
 #endif
+#endif
+
+#if defined(CONFIG_EQDC_MCUX) && defined(CONFIG_SOC_SERIES_IMXRT118X)
+	case IMX_CCM_ENC1_CLK:
+	case IMX_CCM_ENC2_CLK:
+	case IMX_CCM_ENC3_CLK:
+	case IMX_CCM_ENC4_CLK:
+		clock_root = kCLOCK_Root_Bus_Wakeup;
+		break;
 #endif
 
 	default:

--- a/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
@@ -1698,6 +1698,55 @@
 		num-locks = <64>;
 		status = "disabled";
 	};
+
+	xbar1: xbar@2750000 {
+		compatible = "nxp,mcux-xbar";
+		reg = <0x2750000 0x100>;
+		clocks = <&ccm IMX_CCM_XBAR1_CLK 0 0>;
+		#mux-control-cells = <1>;
+		#mux-state-cells = <2>;
+		status = "disabled";
+	};
+
+	eqdc1: eqdc@2710000 {
+		compatible = "nxp,mcux-eqdc";
+		reg = <0x2710000 0x4000>;
+		interrupts = <185 0>;
+		interrupt-names = "index";
+		clocks = <&ccm IMX_CCM_ENC1_CLK 0 0>;
+		counts-per-revolution = <1>;
+		status = "disabled";
+	};
+
+	eqdc2: eqdc@2720000 {
+		compatible = "nxp,mcux-eqdc";
+		reg = <0x2720000 0x4000>;
+		interrupts = <186 0>;
+		interrupt-names = "index";
+		clocks = <&ccm IMX_CCM_ENC2_CLK 0 0>;
+		counts-per-revolution = <1>;
+		status = "disabled";
+	};
+
+	eqdc3: eqdc@2730000 {
+		compatible = "nxp,mcux-eqdc";
+		reg = <0x2730000 0x4000>;
+		interrupts = <187 0>;
+		interrupt-names = "index";
+		clocks = <&ccm IMX_CCM_ENC3_CLK 0 0>;
+		counts-per-revolution = <1>;
+		status = "disabled";
+	};
+
+	eqdc4: eqdc@2740000 {
+		compatible = "nxp,mcux-eqdc";
+		reg = <0x2740000 0x4000>;
+		interrupts = <188 0>;
+		interrupt-names = "index";
+		clocks = <&ccm IMX_CCM_ENC4_CLK 0 0>;
+		counts-per-revolution = <1>;
+		status = "disabled";
+	};
 };
 
 &flexspi {

--- a/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
+++ b/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
@@ -181,6 +181,16 @@
 /** XBAR3 peripheral clock identifier */
 #define IMX_CCM_XBAR3_CLK             0x2902UL
 
+/* ENC (EQDC) */
+/** ENC1/EQDC1 peripheral clock identifier */
+#define IMX_CCM_ENC1_CLK               0x2A00UL
+/** ENC2/EQDC2 peripheral clock identifier */
+#define IMX_CCM_ENC2_CLK               0x2A01UL
+/** ENC3/EQDC3 peripheral clock identifier */
+#define IMX_CCM_ENC3_CLK               0x2A02UL
+/** ENC4/EQDC4 peripheral clock identifier */
+#define IMX_CCM_ENC4_CLK               0x2A03UL
+
 /* QTMR */
 #define IMX_CCM_QTMR_CLK               0x6000UL
 #define IMX_CCM_QTMR1_CLK              0x6000UL

--- a/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
+++ b/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
@@ -179,6 +179,16 @@
 /** XBAR3 peripheral clock identifier */
 #define IMX_CCM_XBAR3_CLK             0x2902UL
 
+/* ENC (EQDC) */
+/** ENC1/EQDC1 peripheral clock identifier */
+#define IMX_CCM_ENC1_CLK               0x2A00UL
+/** ENC2/EQDC2 peripheral clock identifier */
+#define IMX_CCM_ENC2_CLK               0x2A01UL
+/** ENC3/EQDC3 peripheral clock identifier */
+#define IMX_CCM_ENC3_CLK               0x2A02UL
+/** ENC4/EQDC4 peripheral clock identifier */
+#define IMX_CCM_ENC4_CLK               0x2A03UL
+
 /* QTMR */
 #define IMX_CCM_QTMR_CLK               0x6000UL
 #define IMX_CCM_QTMR1_CLK              0x6000UL

--- a/samples/sensor/qdec/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/samples/sensor/qdec/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc1;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	/* Change Jumper J30 and J35 from 1-2 to 2-3 */
+	/* Wire J1-8 <-> J1-14 and J1-10 <-> J51-10 */
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio2 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio2 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	eqdc1_default: eqdc1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_12_xbar_inout18>,
+				 <&iomuxc_gpio_ad_19_xbar_inout19>;
+			input-enable;
+		};
+	};
+};
+
+&xbar1 {
+	status = "okay";
+};
+
+&eqdc1 {
+	status = "okay";
+	pinctrl-0 = <&eqdc1_default>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	prescaler = <11>;
+	input-filter-period = <1>;
+	/*
+	 * mux-states cells = <output, input>:
+	 *   XBAR_INOUT18 -> EQDC1 PHASEA  output=87, input=18
+	 *   XBAR_INOUT19 -> EQDC1 PHASEB  output=88, input=19
+	 */
+	mux-states = <&xbar1 87 18>,
+		     <&xbar1 88 19>;
+};

--- a/samples/sensor/qdec/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/samples/sensor/qdec/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc1;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	/* Change Jumper J30 and J35 from 1-2 to 2-3 */
+	/* Wire J1-8 <-> J1-14 and J1-10 <-> J51-10 */
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio2 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio2 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	eqdc1_default: eqdc1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_12_xbar_inout18>,
+				 <&iomuxc_gpio_ad_19_xbar_inout19>;
+			input-enable;
+		};
+	};
+};
+
+&xbar1 {
+	status = "okay";
+};
+
+&eqdc1 {
+	status = "okay";
+	pinctrl-0 = <&eqdc1_default>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	prescaler = <11>;
+	input-filter-period = <1>;
+	/*
+	 * mux-states cells = <output, input>:
+	 *   XBAR_INOUT18 -> EQDC1 PHASEA  output=87, input=18
+	 *   XBAR_INOUT19 -> EQDC1 PHASEB  output=88, input=19
+	 */
+	mux-states = <&xbar1 87 18>,
+		     <&xbar1 88 19>;
+};

--- a/samples/sensor/qdec/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/samples/sensor/qdec/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc1;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	/* Wire J44-6 <-> J44-12 and J44-8 <-> J44-10 */
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio5 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio5 6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	eqdc1_default: eqdc1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_sd_b1_01_xbar_inout21>,
+				 <&iomuxc_gpio_sd_b1_03_xbar_inout23>;
+			input-enable;
+		};
+	};
+};
+
+&xbar1 {
+	status = "okay";
+};
+
+&eqdc1 {
+	status = "okay";
+	pinctrl-0 = <&eqdc1_default>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	/*
+	 * The RPM formula requires POSDPERH to cover the full software sampling
+	 * window (1 s) without POSDPER saturating at 0xFFFF.  With the ~132 MHz
+	 * ENC clock (kCLOCK_Root_Bus_Wakeup) the prescaler N must satisfy:
+	 *
+	 *   132e6 / 2^N * 1s < 65535  =>  2^N > 2015  =>  N >= 11
+	 *
+	 * prescaler = 11 gives presc_clk = 132e6 / 2048 = ~64 kHz, so the
+	 * maximum 1-second count is ~64453, safely below 65535.
+	 */
+	prescaler = <11>;
+	input-filter-period = <1>;
+	/*
+	 * mux-states cells = <output, input>:
+	 *   XBAR_INOUT21 -> EQDC1 PHASEA  output=87, input=21
+	 *   XBAR_INOUT23 -> EQDC1 PHASEB  output=88, input=23
+	 */
+	mux-states = <&xbar1 87 21>,
+		     <&xbar1 88 23>;
+};

--- a/samples/sensor/qdec/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/samples/sensor/qdec/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/ {
+	aliases {
+		qdec0 = &eqdc1;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	/* Wire J44-6 <-> J44-12 and J44-8 <-> J44-10 */
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio5 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio5 6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	eqdc1_default: eqdc1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_sd_b1_01_xbar_inout21>,
+				 <&iomuxc_gpio_sd_b1_03_xbar_inout23>;
+			input-enable;
+		};
+	};
+};
+
+&xbar1 {
+	status = "okay";
+};
+
+&eqdc1 {
+	status = "okay";
+	pinctrl-0 = <&eqdc1_default>;
+	pinctrl-names = "default";
+	counts-per-revolution = <120>;
+	prescaler = <11>;
+	input-filter-period = <1>;
+	/*
+	 * mux-states cells = <output, input>:
+	 *   XBAR_INOUT21 -> EQDC1 PHASEA  output=87, input=21
+	 *   XBAR_INOUT23 -> EQDC1 PHASEB  output=88, input=23
+	 */
+	mux-states = <&xbar1 87 21>,
+		     <&xbar1 88 23>;
+};


### PR DESCRIPTION
Introduces xbar and eqdc1-4 device tree nodes into the RT118x SoC dtsi.
Improve clock control driver for EQDC peripheral.
Enables the samples/sensor/qdec sample on MIMXRT1180-EVK and FRDM-IMXRT1186 (both CM33 and CM7 cores)
