### PR TITLE
doc: installation_linux: document `libusb1-devel` dependency for fedora

### DIFF
--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -87,7 +87,8 @@ need one.
 
          sudo dnf group install development-tools c-development
          sudo dnf install cmake ninja-build gperf dfu-util dtc wget which \
-           python3-pip python3-tkinter xz file python3-devel SDL2-devel
+           python3-pip python3-tkinter xz file python3-devel SDL2-devel \
+           libusb1-devel
 
    .. group-tab:: Clear Linux
 


### PR DESCRIPTION
Document that `libusb1-devel` is a necessary dependency on Fedora.

Users are otherwise left to investigate the following error on `west packages pip --install`:

```
Exception: pkg-config package 'libusb-1.0 >= 1.0.9' not found
```