### PR TITLE
[v3.7-branch] tests: mem_map: fix memory exhaustion test on qemu_x86_tiny

### DIFF
--- a/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
+++ b/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Adjust this so that test_k_mem_map_unmap memory exhaustion
+# test can run without failure, as we may run of free pages
+# when there are changes in code and data size.
+CONFIG_DEMAND_PAGING_PAGE_FRAMES_RESERVE=30


### PR DESCRIPTION
The test_k_mem_map_unmap test requires some free physical pages
to work correctly. On qemu_x86_tiny, the physical memory is
artificially limited to test demand paging, which is 320KB as
of writing of this commit message. We also reserve 128KB of
physical memory as swapping area. And we do pin quite lot of
text and data (relatively speaking) in memory. There is not
much memory left for the test. So lower the amount of reserved
memory for paging to leave some pages for the test.

Fixes #79833

Signed-off-by: Daniel Leung <daniel.leung@intel.com>
(cherry picked from commit bda38f033ab52d2711a676783905987251452394)
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
