### PR TITLE
subsys: shell: shell_help: handle intentional indentation

### DIFF
--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -106,7 +106,17 @@ static void formatted_text_print(const struct shell *sh, const char *str,
 		 * not begin with a space.
 		 */
 		while (isspace((int) (*(str + offset))) != 0) {
+			bool is_newline = (*(str + offset) == '\n');
+
 			++offset;
+
+			if (is_newline) {
+				/* Stop after consuming the newline so that
+				 * intentional indentation spaces that follow
+				 * are preserved for the next iteration.
+				 */
+				break;
+			}
 		}
 
 		z_cursor_next_line_move(sh);


### PR DESCRIPTION
The whitespace-skipping loop in formatted_text_print() advances past every character for which isspace() returns non-zero. Because isspace() matches both newlines and ordinary spaces, any leading spaces that follow
a '\n' in a help string were being discarded, stripping intentional indentation from continuation lines.

Fix this by breaking out of the loop immediately after consuming the '\n'. The newline itself must still be skipped to prevent an empty line from being printed, but the spaces that follow it on the next line are part of the author's intended layout and must be preserved.

Before this fix, a help string such as:

```
  "[-v] [-n <count>]\n"
  "    Options:\n"
  "        -v          verbose output\n"
  "        -n <count>  number of iterations (default: 1)"
```

was rendered as:

```
  test - [-v] [-n <count>]
         Options:
         -v          verbose output
         -n <count>  number of iterations (default: 1)
```

After this fix:

```
  test - [-v] [-n <count>]
             Options:
                 -v          verbose output
                 -n <count>  number of iterations (default: 1)
```