### PR TITLE
MAINTAINERS: Add Alex9360 as TI MSPM collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6046,6 +6046,7 @@ TI MSPM Platforms:
   collaborators:
     - d-philpot
     - Aman-Lachhiramka-ti
+    - Alex9360
   files:
     - soc/ti/mspm/
     - boards/ti/*mspm*/


### PR DESCRIPTION
@Alex9360  has been actively contributing to MSPM support in Zephyr and there is continuous development by migrating drivers from HAL-based implementations to native Zephyr drivers. Adding collaborator status will help support ongoing maintenance and timely reviews.

contribution to mspm family:
- #94737 
- #94736