### PR TITLE
MAINTAINERS: add initial MSPM0 development team as MSPM platform collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6046,6 +6046,7 @@ TI MSPM Platforms:
   collaborators:
     - d-philpot
     - Aman-Lachhiramka-ti
+    - SanjayyyV
   files:
     - soc/ti/mspm/
     - boards/ti/*mspm*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6098,6 +6098,7 @@ TI MSPM Platforms:
     - Alex9360
     - SanjayyyV
     - karthi012
+    - Girinandha-M
   files:
     - soc/ti/mspm/
     - boards/ti/*mspm*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6097,6 +6097,7 @@ TI MSPM Platforms:
     - Aman-Lachhiramka-ti
     - Alex9360
     - SanjayyyV
+    - karthi012
   files:
     - soc/ti/mspm/
     - boards/ti/*mspm*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6099,6 +6099,7 @@ TI MSPM Platforms:
     - SanjayyyV
     - karthi012
     - Girinandha-M
+    - santhosh-c-c
   files:
     - soc/ti/mspm/
     - boards/ti/*mspm*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6096,6 +6096,7 @@ TI MSPM Platforms:
     - d-philpot
     - Aman-Lachhiramka-ti
     - Alex9360
+    - SanjayyyV
   files:
     - soc/ti/mspm/
     - boards/ti/*mspm*/


### PR DESCRIPTION
This PR adds the initial MSPM development team (@SanjayyyV, @karthi012, @Girinandha-M, @santhosh-c-c) as collaborators for the MSPM platform in `MAINTAINERS.yml`.

Over the past several months, we have contributed to the MSPM platform:
@SanjayyyV:
- SoC PM: https://github.com/zephyrproject-rtos/zephyr/pull/94834
- Entropy/TRNG: https://github.com/zephyrproject-rtos/zephyr/pull/94733
- Watchdog: https://github.com/zephyrproject-rtos/zephyr/pull/95304

@karthi012:
- RTC: https://github.com/zephyrproject-rtos/zephyr/pull/90844
- DMA: https://github.com/zephyrproject-rtos/zephyr/pull/91502
- Flash: https://github.com/zephyrproject-rtos/zephyr/pull/91500

@Girinandha-M:
- AES: https://github.com/zephyrproject-rtos/zephyr/pull/100981
- AES: https://github.com/zephyrproject-rtos/zephyr/pull/94734 
- VREF: https://github.com/zephyrproject-rtos/zephyr/pull/94732

@santhosh-c-c:
- DAC: https://github.com/zephyrproject-rtos/zephyr/pull/94725
- SPI: https://github.com/zephyrproject-rtos/zephyr/pull/94726
- CAN: https://github.com/zephyrproject-rtos/zephyr/pull/97092

Development has accelerated recently with the platform transition from HAL-based implementations to native Zephyr drivers, resulting in a steady stream of new changes.

Adding us as collaborators will help:
- improve review bandwidth for MSPM-related changes,
- provide faster feedback on platform development,
- assist with ongoing maintenance as native driver support continues to expand.