### PR TITLE
soc: ite: it8xxx2: Move timer_5ms_one_shot

### DIFF
--- a/soc/ite/ec/it8xxx2/soc.c
+++ b/soc/ite/ec/it8xxx2/soc.c
@@ -194,8 +194,6 @@ static const struct pll_config_t pll_configuration[PLL_FREQ_CNT] = {
 
 void __soc_ram_code chip_run_pll_sequence(const struct pll_config_t *pll)
 {
-	/* Enable HW timer to wakeup chip from the sleep mode */
-	timer_5ms_one_shot();
 	/*
 	 * Configure PLL clock dividers.
 	 * Writing data to these registers doesn't change the
@@ -204,6 +202,9 @@ void __soc_ram_code chip_run_pll_sequence(const struct pll_config_t *pll)
 	 * The following code is intended to make the system
 	 * enter sleep mode, and wait HW timer to wakeup chip to
 	 * complete PLL update.
+	 *
+	 * Note: HW timer wakeup (timer_5ms_one_shot()) is started by caller
+	 * before calling this function.
 	 */
 	IT8XXX2_ECPM_PLLFREQR = pll->pll_freq;
 	/* Pre-set FND clock frequency = PLL / 3 */
@@ -251,6 +252,8 @@ static void chip_configure_pll(const struct pll_config_t *pll)
 		 */
 		espi_ite_ec_enable_pad_ctrl(ESPI_ITE_SOC_DEV, false);
 #endif
+		/* Enable HW timer to wakeup chip from the sleep mode */
+		timer_5ms_one_shot();
 		/* Run change PLL sequence */
 		chip_run_pll_sequence(pll);
 #ifdef CONFIG_ESPI


### PR DESCRIPTION
Calling timer_5ms_one_shot() from chip_run_pll_sequence() can result in a R_RISCV_RVC_JUMP linker relocation truncaction error because timer_5ms_one_shot() links into flash, and chip_run_pll_sequence() links into RAM.

Move the timer_5ms_one_shot() call out of chip_run_pll_sequence() and into chip_configure_pll() right before chip_run_pll_sequence() is invoked.

Tested on IT8xxx2 EC board.


Assisted-by: Antigravity:gemini-1.5-pro