### PR TITLE
STM32WBA: Integrate STM32CubeWBA v1.10.0

### DIFF
--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -36,6 +36,8 @@ static const struct flash_parameters flash_stm32_parameters = {
 
 K_SEM_DEFINE(flash_busy, 0, 1);
 
+K_MUTEX_DEFINE(fm_mutex);
+
 static void flash_callback(FM_FlashOp_Status_t status)
 {
 	LOG_DBG("%d", status);
@@ -286,6 +288,22 @@ void flash_stm32wba_page_layout(const struct device *dev, const struct flash_pag
 
 	*layout = &stm32wba_flash_layout;
 	*layout_size = 1;
+}
+
+FM_Cmd_Status_t FM_MutexTake(void)
+{
+	FM_Cmd_Status_t error = FM_OK;
+
+	k_mutex_lock(&fm_mutex, K_FOREVER);
+	return error;
+}
+
+FM_Cmd_Status_t FM_MutexRelease(void)
+{
+	FM_Cmd_Status_t error = FM_OK;
+
+	k_mutex_unlock(&fm_mutex);
+	return error;
 }
 
 static DEVICE_API(flash, flash_stm32_api) = {

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 9b6fb9e0ee432d12a31b6327a3690d243b74d178
+      revision: pull/398/head
       path: modules/hal/stm32
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: e7c0d3cd97bec297b70f506e2047640b83569d87
+      revision: 33576ef05e529cad803f210cc95b52b607757c96
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update west.yml to point to the recent changes for hal_stm32.

Override FM_MutexTake and FM_MutexRelease function definitions to comply
with the changes introduced in STM32CubeWBA v1.10.0.

Supplementary PR [#398](https://github.com/zephyrproject-rtos/hal_stm32/pull/398)