### PR TITLE
cmake: emu: qemu: restore the pflash drives on the command line

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -71,12 +71,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/qemu/dumpdtb.cmake)
 if(CONFIG_FLASH_INTEL_PFLASH_CFI01)
   if(CONFIG_X86)
     # X86 Needs an initial bios file in pflash0 slot
-    list(APPEND QEMU_EXTRA_FLAGS
+    qemu_append_extra_flags(
       -drive file=${HOST_TOOLS_HOME}/usr/share/qemu/bios-256k.bin,if=pflash,format=raw,unit=0
     )
   endif()
 
-  list(APPEND QEMU_EXTRA_FLAGS
+  qemu_append_extra_flags(
     -drive file=${ZEPHYR_BINARY_DIR}/pflash.img,if=pflash,format=raw,unit=1
   )
 


### PR DESCRIPTION
The CONFIG_FLASH_INTEL_PFLASH_CFI01 block still contributed its two
-drive options by appending to the QEMU_EXTRA_FLAGS variable. Since
the qemu_append_*() API was introduced, qemu.cmake reads that variable
exactly once, near the top of the file, to seed the EXTRA slot with
what boards left behind. The block runs after that seeding, so its
options never reached the command line.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
