### PR TITLE
drivers: mfd: rv3028: fix compilation without int-gpios

### DIFF
--- a/drivers/mfd/mfd_rv3028.c
+++ b/drivers/mfd/mfd_rv3028.c
@@ -531,7 +531,7 @@ static int mfd_rv3028_init(const struct device *dev)
 		.backup = RV3028_BACKUP_FROM_DT_INST(inst),                                        \
 		.cof = DT_INST_ENUM_IDX_OR(inst, clkout_frequency, RV3028_CLKOUT_FD_LOW),          \
 		IF_ENABLED(RV3028_INT_GPIOS_IN_USE, (.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst,    \
-						    int_gpios, {0}))),              \
+						    int_gpios, {0}),))                             \
 	};                                                                                         \
                                                                                                    \
 	static struct mfd_rv3028_data mfd_rv3028_data##inst;                                       \


### PR DESCRIPTION
Fix a compilation error if rv3028 node has no `int-gpios` property, incorrectly expands to `,,`.

```
In file included from /home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:34,
                 from /home/user/west_workspace/zephyr/include/zephyr/sys/util.h:17,
                 from /home/user/west_workspace/zephyr/include/zephyr/sys/atomic.h:24,
                 from /home/user/west_workspace/zephyr/include/zephyr/kernel_includes.h:25,
                 from /home/user/west_workspace/zephyr/include/zephyr/kernel.h:17,
                 from /home/user/west_workspace/zephyr/drivers/mfd/mfd_rv3028.c:8:
/home/user/west_workspace/zephyr/drivers/mfd/mfd_rv3028.c:534:70: error: expected expression before ',' token
  534 |                                                     int_gpios, {0}))),              \
      |                                                                      ^
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:72:26: note: in definition of macro '__DEBRACKET'
   72 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:59:9: note: in expansion of macro '__COND_CODE'
   59 |         __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:210:9: note: in expansion of macro 'Z_COND_CODE_1'
  210 |         Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree.h:5669:9: note: in expansion of macro 'COND_CODE_1'
 5669 |         COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT),   \
      |         ^~~~~~~~~~~
/home/user/west_workspace/main_app/build/zephyr/include/generated/zephyr/devicetree_generated.h:49776:54: note: in expansion of macro 'MFD_RV3028_DEFINE'
49776 | #define DT_FOREACH_OKAY_INST_microcrystal_rv3028(fn) fn(0)
      |                                                      ^~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:146:36: note: in expansion of macro 'DT_FOREACH_OKAY_INST_microcrystal_rv3028'
  146 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
/home/user/west_workspace/zephyr/drivers/mfd/mfd_rv3028.c:543:1: note: in expansion of macro 'DT_INST_FOREACH_STATUS_OKAY'
  543 | DT_INST_FOREACH_STATUS_OKAY(MFD_RV3028_DEFINE)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```