### PR TITLE
drivers: ieee802154: esp32: Add blobs verify

### DIFF
--- a/drivers/ieee802154/CMakeLists.txt
+++ b/drivers/ieee802154/CMakeLists.txt
@@ -8,6 +8,10 @@ if(CONFIG_BUILD_ONLY_NO_BLOBS)
   ---------------------------------------------------------------------------
   ")
 else()
+  if(CONFIG_DT_HAS_ESPRESSIF_ESP32_IEEE802154_ENABLED)
+    zephyr_blobs_verify(MODULE hal_espressif REQUIRED)
+  endif()
+
   if(CONFIG_DT_HAS_ST_STM32WBA_IEEE802154_ENABLED)
     zephyr_blobs_verify(MODULE hal_stm32 REQUIRED)
   endif()


### PR DESCRIPTION
Currently, it is possible to link a IEEE802.15.4 build with stale blobs. Add blobs verify directive to enforce blobs version check while building.