### PR TITLE
Bluetooth: Host: Remove unused bt_testing_tx_tid_get()

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4701,20 +4701,12 @@ static void rx_work_handler(struct k_work *work)
 	}
 }
 
-#if defined(CONFIG_BT_TESTING)
-k_tid_t bt_testing_tx_tid_get(void)
-{
-	/* We now TX everything from the syswq */
-	return k_sys_work_q.thread_id;
-}
-
-#if defined(CONFIG_BT_ISO)
+#if defined(CONFIG_BT_TESTING) && defined(CONFIG_BT_ISO)
 void bt_testing_set_iso_mtu(uint16_t mtu)
 {
 	bt_dev.le.iso_mtu = mtu;
 }
-#endif /* CONFIG_BT_ISO */
-#endif /* CONFIG_BT_TESTING */
+#endif /* CONFIG_BT_TESTING && CONFIG_BT_ISO */
 
 int bt_enable(bt_ready_cb_t cb)
 {

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/prj.conf
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/prj.conf
@@ -11,9 +11,6 @@ CONFIG_BT_DEVICE_NAME="Sequential"
 CONFIG_BT_GATT_CLIENT=y
 CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION=n
 
-# Enable bt_testing_tx_tid_get()
-CONFIG_BT_TESTING=y
-
 # Replace `Execute` with `gdb --args` in the shell script
 # and get a nice backtrace on assert
 CONFIG_ARCH_POSIX_TRAP_ON_FATAL=y

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
@@ -33,9 +33,6 @@ DEFINE_FLAG_STATIC(flag_data_length_updated);
 
 static struct bt_conn *dconn;
 
-/* Defined in hci_core.c */
-extern k_tid_t bt_testing_tx_tid_get(void);
-
 static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	if (conn_err) {

--- a/tests/bsim/bluetooth/host/att/sequential/dut/prj.conf
+++ b/tests/bsim/bluetooth/host/att/sequential/dut/prj.conf
@@ -9,7 +9,7 @@ CONFIG_BT_DEVICE_NAME="Sequential"
 CONFIG_BT_GATT_CLIENT=y
 CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION=n
 
-# Enable bt_testing_tx_tid_get()
+# Enable bt_conn_suspend_tx()
 CONFIG_BT_TESTING=y
 
 # Replace `Execute` with `gdb --args` in the shell script

--- a/tests/bsim/bluetooth/host/misc/disconnect/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/dut/src/main.c
@@ -31,9 +31,6 @@ DEFINE_FLAG_STATIC(flag_data_length_updated);
 
 static atomic_t notifications;
 
-/* Defined in hci_core.c */
-extern k_tid_t bt_testing_tx_tid_get(void);
-
 static struct bt_conn *dconn;
 
 static void connected(struct bt_conn *conn, uint8_t conn_err)


### PR DESCRIPTION
The last callers of bt_testing_tx_tid_get() were removed by commit 28be8909a6c5 ("Bluetooth: host: remove TX thread"), which also changed the function to return the system workqueue thread. That return value has in turn been stale since
commit f101976e31fd ("Bluetooth: Host: Run tx processor on its own thread") moved TX processing to a dedicated thread whenever CONFIG_BT_TX_PROCESSOR_THREAD is enabled (the default).

Instead of fixing the return value of a function nobody calls, remove it, together with the leftover extern declarations in the bsim tests. The att/pipeline test enabled CONFIG_BT_TESTING solely for this function, so drop it there. The att/sequential test claimed the same in a comment, but actually also depends on CONFIG_BT_TESTING for bt_conn_suspend_tx(), so only the stale comment is corrected there.