### PR TITLE
modules: hostap: fix DEBUG_SHOW_KEYS being ignored at init

### DIFF
--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -778,6 +778,7 @@ static void handler(void)
 
 	memset(&params, 0, sizeof(params));
 	params.wpa_debug_level = CONFIG_WIFI_NM_WPA_SUPPLICANT_DEBUG_LEVEL;
+	params.wpa_debug_show_keys = IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_DEBUG_SHOW_KEYS);
 
 	ctx->supplicant = wpa_supplicant_init(&params);
 	if (ctx->supplicant == NULL) {


### PR DESCRIPTION
wpa_supplicant_init() is called with a zero-initialized params struct that only sets wpa_debug_level. This clobbers the compile-time wpa_debug_show_keys value (set via IS_ENABLED(CONFIG_...) in wpa_debug_zephyr.c) back to 0 on every boot, so
CONFIG_WIFI_NM_WPA_SUPPLICANT_DEBUG_SHOW_KEYS=y has no effect and key material (PMK, PTK, KCK, KEK, TK) is always printed as [REMOVED].

Seed params.wpa_debug_show_keys from the Kconfig, mirroring how wpa_debug_level is already handled a line above.

Assisted-by: Claude:claude-opus-4.8