### PR TITLE
pm: device_runtime: fix maybe-uninitialized warning

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -95,7 +95,7 @@ static bool runtime_usage_put_fast(struct pm_device *pm)
  */
 static int runtime_usage_put(struct pm_device *pm)
 {
-	int ret;
+	int ret = 0;
 
 	__ASSERT_NO_MSG(pm != NULL);
 	/* Caller must hold the per-device semaphore, except in pre-kernel


### PR DESCRIPTION
K_SPINLOCK() expands to a for loop, so the compiler cannot prove the
guarded block always executes and warns that ret is used uninitialized
on return from runtime_usage_put():

  subsys/pm/device_runtime.c:116:16: warning: 'ret' may be used
  uninitialized [-Wmaybe-uninitialized]

Both branches inside the block assign ret, so this is a false positive.
Initialize ret at declaration, matching runtime_usage_put_fast() which
already initializes its return value for the same reason.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
