### PR TITLE
boards: arm: mps3/mps4: fix broken non-secure flash devicetree

### DIFF
--- a/boards/arm/mps3/mps3_common_ns.dtsi
+++ b/boards/arm/mps3/mps3_common_ns.dtsi
@@ -5,7 +5,7 @@
  */
 
 / {
-	flash_controller: flash-controller@@28000000 {
+	flash_controller: flash-controller@28000000 {
 		reg = <0x28000000 DT_SIZE_M(8)>;
 		ranges;
 		#address-cells = <1>;

--- a/boards/arm/mps3/mps3_corstone300_an547_ns.dts
+++ b/boards/arm/mps3/mps3_corstone300_an547_ns.dts
@@ -21,7 +21,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &isram_ns;
-		zephyr,flash = &reserved_memory;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 

--- a/boards/arm/mps3/mps3_corstone300_an552_ns.dts
+++ b/boards/arm/mps3/mps3_corstone300_an552_ns.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &isram_ns;
-		zephyr,flash = &reserved_memory;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 

--- a/boards/arm/mps3/mps3_corstone300_fvp_ns.dts
+++ b/boards/arm/mps3/mps3_corstone300_fvp_ns.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &isram_ns;
-		zephyr,flash = &reserved_memory;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 

--- a/boards/arm/mps3/mps3_corstone310_an555_ns.dts
+++ b/boards/arm/mps3/mps3_corstone310_an555_ns.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &isram_ns;
-		zephyr,flash = &reserved_memory;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 

--- a/boards/arm/mps3/mps3_corstone310_fvp_ns.dts
+++ b/boards/arm/mps3/mps3_corstone310_fvp_ns.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &isram_ns;
-		zephyr,flash = &reserved_memory;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 

--- a/boards/arm/mps4/mps4_common_ns.dtsi
+++ b/boards/arm/mps4/mps4_common_ns.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 / {
-	flash_controller: flash-controller@@28000000 {
+	flash_controller: flash-controller@28000000 {
 		reg = <0x28000000 DT_SIZE_M(8)>;
 		ranges;
 		#address-cells = <1>;

--- a/boards/arm/mps4/mps4_corstone315_fvp_ns.dts
+++ b/boards/arm/mps4/mps4_corstone315_fvp_ns.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram;
-		zephyr,flash = &reserved_memory;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 

--- a/boards/arm/mps4/mps4_corstone320_fvp_ns.dts
+++ b/boards/arm/mps4/mps4_corstone320_fvp_ns.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram;
-		zephyr,flash = &reserved_memory;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 


### PR DESCRIPTION
Commit aa583373c244 ("boards: arm: Update to zephyr,mapped-partition
binding") replaced the reserved-memory node with a flash-controller node
on mps3 and mps4, but left two mistakes that make every non-secure board
variant fail before compilation starts:

  devicetree error: boards/arm/mps3/mps3_common_ns.dtsi:8 (column 47):
  parse error: multiple '@' in node name

  devicetree error: /chosen: undefined node label 'reserved_memory'

Drop the duplicated '@' from the node name, and repoint zephyr,flash at
the flash0 node that now holds the soc-nv-flash compatible, matching
what the same commit did for mps2_an521_cpu0_ns.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
