### PR TITLE
net: lib: mcp: extract tools/call arguments with the JSON object walker

### DIFF
--- a/subsys/net/lib/mcp/mcp_json.c
+++ b/subsys/net/lib/mcp/mcp_json.c
@@ -441,63 +441,65 @@ static int parse_tools_list_request(char *buf, size_t len, struct mcp_message *m
 
 static bool extract_arguments_json(char *buf, size_t len, char *dst, size_t dst_sz)
 {
-	const char *args_key;
-	const char *args_start;
-	const char *args_end;
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+	char *params = NULL;
+	size_t params_len = 0;
 	size_t args_len;
-	int brace_count = 0;
 
 	if ((buf == NULL) || (dst == NULL) || (dst_sz == 0)) {
 		return false;
 	}
 
-	args_key = strstr(buf, "\"arguments\"");
-	if (args_key == NULL) {
+	/* Find the top-level "params" object. */
+	if (json_obj_separate_parse_init(&obj, buf, len) < 0) {
 		return false;
 	}
 
-	args_start = strchr(args_key, ':');
-	if (args_start == NULL) {
-		return false;
-	}
-	args_start++;
-
-	while (*args_start == ' ' || *args_start == '\t' || *args_start == '\n' ||
-	       *args_start == '\r') {
-		args_start++;
-	}
-
-	if (*args_start != '{') {
-		return false;
-	}
-
-	args_end = args_start;
-	brace_count = 0;
-
-	do {
-		if (*args_end == '{') {
-			brace_count++;
-		} else if (*args_end == '}') {
-			brace_count--;
-		} else {
-			;
+	while ((json_obj_next_key_value(&obj, &kv) == 0) && (kv.key != NULL)) {
+		if (kv.key_len == strlen("params") &&
+		    memcmp(kv.key, "params", kv.key_len) == 0) {
+			params = kv.value.start;
+			params_len = (size_t)(kv.value.end - kv.value.start);
+			break;
 		}
-		args_end++;
+	}
 
-		if (args_end >= buf + len) {
+	if (params == NULL) {
+		return false;
+	}
+
+	/*
+	 * The "arguments" object is tool-specific and cannot be described
+	 * statically, so walk the members of "params" and hand the tool the raw
+	 * object rather than decode it. The walker is string- and depth-aware, so
+	 * braces inside argument string values do not throw off the extraction.
+	 */
+	if (json_obj_separate_parse_init(&obj, params, params_len) < 0) {
+		return false;
+	}
+
+	while ((json_obj_next_key_value(&obj, &kv) == 0) && (kv.key != NULL)) {
+		if (kv.key_len != strlen("arguments") ||
+		    memcmp(kv.key, "arguments", kv.key_len) != 0) {
+			continue;
+		}
+
+		if (kv.value.start == NULL || *kv.value.start != '{') {
 			return false;
 		}
-	} while (brace_count > 0);
 
-	args_len = args_end - args_start;
-	if (args_len >= dst_sz) {
-		return false;
+		args_len = (size_t)(kv.value.end - kv.value.start);
+		if (args_len >= dst_sz) {
+			return false;
+		}
+
+		memcpy(dst, kv.value.start, args_len);
+		dst[args_len] = '\0';
+		return true;
 	}
 
-	memcpy(dst, args_start, args_len);
-	dst[args_len] = '\0';
-
-	return true;
+	return false;
 }
 
 static int parse_tools_call_request(char *buf, size_t len, struct mcp_message *msg)

--- a/tests/net/lib/mcp/src/main.c
+++ b/tests/net/lib/mcp/src/main.c
@@ -1458,6 +1458,27 @@ ZTEST(mcp_server_tests, test_11_health_monitor)
 	printk("=== Health monitor test completed ===\n");
 }
 
+/* A tools/call argument object with an unbalanced brace inside a string value
+ * must reach the tool intact. A byte-level brace counter closes the object early
+ * at the in-string '}'; the JSON object walker is string-aware, so the whole
+ * object is delivered.
+ */
+ZTEST(mcp_server_tests, test_12_tools_call_arguments_braces_in_string)
+{
+	reset_tool_execution_tracking();
+	register_test_tools();
+
+	send_tools_call_request(valid_client_binding, 3200, "test_success_tool",
+				"{\"filter\":\"a}b\"}");
+
+	zassert_equal(tool_execution_count, 1, "tool should execute once");
+	zassert_true(strcmp(last_execution_arguments, "{\"filter\":\"a}b\"}") == 0,
+		     "arguments with a brace in a string must reach the tool intact, got '%s'",
+		     last_execution_arguments);
+
+	cleanup_test_tools();
+}
+
 static void *mcp_server_tests_setup(void)
 {
 	int ret;


### PR DESCRIPTION
The tools/call `arguments` object is tool-specific and cannot be described by a compile-time JSON descriptor, so it was pulled out of the request by hand: a `strstr()` search for `"arguments"` followed by a byte-level brace counter. Both steps are structure-blind. The search matches the literal text inside any string value, and the counter balances braces that appear inside string values, so an argument such as `{"filter":"a}b"}` is truncated at the in-string `}`.

This walks the `params` object with `json_obj_separate_parse_init()` / `json_obj_next_key_value()` and hands the tool the raw `arguments` value span instead. The walker is string- and depth-aware, so braces in string values no longer break extraction, and the hand-rolled scanner is removed.

A regression test (`test_12_tools_call_arguments_braces_in_string`) sends `{"filter":"a}b"}` and asserts the tool receives it intact; it fails on the old scanner and passes here.

This is one in-tree consumer of the object-member walker added in #113033.