### PR TITLE
drivers: adc: lpadc: fix low power hooks

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -961,17 +961,12 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 				return err;
 			}
 		}
-    
-    		if (bandgap_supply != NULL && data->bandgap_channels != 0U) {
+
+		if (bandgap_supply != NULL && data->bandgap_channels != 0U) {
 			err = regulator_disable(bandgap_supply);
 			if (err < 0) {
 				return err;
 			}
-		}
-
-		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
-		if (err < 0 && err != -ENOENT) {
-			return err;
 		}
 
 		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
@@ -1105,8 +1100,6 @@ static int mcux_lpadc_init(const struct device *dev)
 	LPADC_Enable(config->base, false);
 
 	return pm_device_driver_init(dev, mcux_lpadc_pm_callback);
-#else
-	return 0;
 #endif
 
 	return 0;

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -17,6 +17,8 @@
 #include <zephyr/drivers/regulator.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 #include <zephyr/drivers/clock_control.h>
+#include <fsl_clock.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/opamp.h>
 #include <zephyr/pm/policy.h>
@@ -400,8 +402,8 @@ static int mcux_lpadc_start_read(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	ret = adc_sequence_validate_buffer(sequence,
-					   POPCOUNT(sequence->channels), sizeof(uint16_t));
+	ret = adc_sequence_validate_buffer(sequence, POPCOUNT(sequence->channels),
+					   sizeof(uint16_t));
 	if (ret < 0) {
 		return ret;
 	}
@@ -499,19 +501,48 @@ static int mcux_lpadc_read_async(const struct device *dev,
 			struct k_poll_signal *async)
 {
 	struct mcux_lpadc_data *data = dev->data;
+#if CONFIG_PM_DEVICE
+	const struct mcux_lpadc_config *config = dev->config;
+#endif
 	int error;
 
+	pm_device_runtime_get(dev);
 	adc_context_lock(&data->ctx, async ? true : false, async);
-
 	mcux_lpadc_pm_policy_device_power_lock_get(dev);
 
+/*
+ * Re-calibrate on read is only needed on low-power modes
+ * since the peripheral configurations are lost after
+ * entering low-power and ensures proper function after
+ * a power domain turn-off.
+ */
+#if CONFIG_PM_DEVICE
+	/* Do ADC calibration needed before using ADC */
+#if defined(FSL_FEATURE_LPADC_HAS_CTRL_CALOFS) && FSL_FEATURE_LPADC_HAS_CTRL_CALOFS
+#if defined(FSL_FEATURE_LPADC_HAS_OFSTRIM) && FSL_FEATURE_LPADC_HAS_OFSTRIM
+	/* Request offset calibration. */
+#if defined(CONFIG_LPADC_DO_OFFSET_CALIBRATION) && CONFIG_LPADC_DO_OFFSET_CALIBRATION
+	LPADC_DoOffsetCalibration(config->base);
+#else
+#if defined(FSL_FEATURE_LPADC_OFSTRIM_COUNT) && (FSL_FEATURE_LPADC_OFSTRIM_COUNT == 1U)
+	LPADC_SetOffsetValue(config->base, config->offset_a);
+#else
+	LPADC_SetOffsetValue(config->base, config->offset_a, config->offset_b);
+#endif /* FSL_FEATURE_LPADC_OFSTRIM_COUNT */
+#endif /* CONFIG_LPADC_DO_OFFSET_CALIBRATION */
+#endif /* FSL_FEATURE_LPADC_HAS_OFSTRIM */
+	k_busy_wait(1U);
+	LPADC_PrepareAutoCalibration(config->base);
+	LPADC_FinishAutoCalibration(config->base);
+	LPADC_DoAutoCalibration(config->base);
+#endif
+#endif
+	/* Perform ADC reading after calibration */
 	error = mcux_lpadc_start_read(dev, sequence);
 
-	if (error != 0) {
-		mcux_lpadc_pm_policy_device_power_lock_put(dev);
-	}
-
+	mcux_lpadc_pm_policy_device_power_lock_put(dev);
 	adc_context_release(&data->ctx, error);
+	pm_device_runtime_put(dev);
 
 	return error;
 }
@@ -852,6 +883,7 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 {
 	const struct mcux_lpadc_config *config = dev->config;
 	const struct device *regulator = config->ref_supplies;
+	lpadc_config_t adc_config;
 	const struct device *bandgap_supply = config->bandgap_supply;
 	struct mcux_lpadc_data *data = dev->data;
 	int err;
@@ -859,14 +891,25 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 
+		err = clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
+		if (err && err != -ENOSYS) {
+			/* Real error occurred */
+			LOG_ERR("Failed to configure clock: %d", err);
+			return err;
+		}
+
+		err = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (err && err != -ENOSYS) {
+			/* Real error occurred */
+			LOG_ERR("Failed to enable clock: %d", err);
+			return err;
+		}
+
 		if (regulator != NULL) {
 			err = regulator_enable(regulator);
 			if (err < 0) {
 				return err;
 			}
-
-			/* Re-enable the BUF21 buffer (cleared at suspend). */
-			(void)regulator_set_mode(regulator, NXP_VREF_MODE_HIGH_POWER);
 		}
 
 		if (bandgap_supply != NULL && data->bandgap_channels != 0U) {
@@ -881,18 +924,36 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 			return err;
 		}
 
-		LPADC_Enable(config->base, true);
+		/* Re-initialize ADC, previous configurations are lost after disabling clock */
+		LPADC_GetDefaultConfig(&adc_config);
+		adc_config.enableAnalogPreliminary = true;
+		adc_config.referenceVoltageSource  = config->voltage_ref;
+#if defined(FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS) && FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS
+		adc_config.conversionAverageMode   = config->calibration_average;
+#endif
+#if !(DT_ANY_INST_HAS_PROP_STATUS_OKAY(no_power_level))
+		adc_config.powerLevelMode          = config->power_level;
+#endif
+		LPADC_Init(config->base, &adc_config);
+
+#if (defined(FSL_FEATURE_LPADC_FIFO_COUNT) && (FSL_FEATURE_LPADC_FIFO_COUNT == 2U))
+		LPADC_EnableInterrupts(config->base, kLPADC_FIFO0WatermarkInterruptEnable);
+#else
+		LPADC_EnableInterrupts(config->base, kLPADC_FIFOWatermarkInterruptEnable);
+#endif
 
 		return 0;
 
 	case PM_DEVICE_ACTION_SUSPEND:
 
-		LPADC_Enable(config->base, false);
+		/* Disable interrupts before gating clock */
+#if (defined(FSL_FEATURE_LPADC_FIFO_COUNT) && (FSL_FEATURE_LPADC_FIFO_COUNT == 2U))
+		LPADC_DisableInterrupts(config->base, kLPADC_FIFO0WatermarkInterruptEnable);
+#else
+		LPADC_DisableInterrupts(config->base, kLPADC_FIFOWatermarkInterruptEnable);
+#endif
 
-		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
-		if (err < 0 && err != -ENOENT) {
-			return err;
-		}
+		LPADC_Enable(config->base, false);
 
 		if (regulator != NULL) {
 			err = regulator_disable(regulator);
@@ -900,13 +961,23 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 				return err;
 			}
 		}
-
-		if (bandgap_supply != NULL && data->bandgap_channels != 0U) {
+    
+    		if (bandgap_supply != NULL && data->bandgap_channels != 0U) {
 			err = regulator_disable(bandgap_supply);
 			if (err < 0) {
 				return err;
 			}
 		}
+
+		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
+		if (err < 0 && err != -ENOENT) {
+			return err;
+		}
+
+		/* gate the peripheral clock */
+		err = clock_control_off(config->clock_dev, config->clock_subsys);
+		if (err < 0 && err != -ENOENT) {
+			return err;
 
 		return 0;
 
@@ -927,23 +998,6 @@ static int mcux_lpadc_init(const struct device *dev)
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
-	}
-
-	/* Enable necessary regulators */
-	const struct device *regulator = config->ref_supplies;
-
-	if (regulator != NULL) {
-		err = regulator_enable(regulator);
-		if (err) {
-			return err;
-		}
-
-		/* Request the buffered 2.1V output (BUF21) on the NXP VREF
-		 * regulator. enable() only brings up the bandgap; without
-		 * this step BUF21 is left disabled and the LPADC's VREFI
-		 * reference is unbuffered, which causes inaccurate conversions.
-		 */
-		(void)regulator_set_mode(regulator, NXP_VREF_MODE_HIGH_POWER);
 	}
 
 	if (!device_is_ready(config->clock_dev)) {

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -978,6 +978,7 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 		err = clock_control_off(config->clock_dev, config->clock_subsys);
 		if (err < 0 && err != -ENOENT) {
 			return err;
+		}
 
 		return 0;
 

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -974,6 +974,11 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 			return err;
 		}
 
+		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
+		if (err < 0 && err != -ENOENT) {
+			return err;
+		}
+
 		/* gate the peripheral clock */
 		err = clock_control_off(config->clock_dev, config->clock_subsys);
 		if (err < 0 && err != -ENOENT) {

--- a/drivers/regulator/regulator_nxp_vref.c
+++ b/drivers/regulator/regulator_nxp_vref.c
@@ -19,7 +19,22 @@
 
 LOG_MODULE_REGISTER(nxp_vref, CONFIG_REGULATOR_LOG_LEVEL);
 
+#if defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0)
+/*
+ * VREF variant whose output buffer is a fixed nominal 1.2 V that is only
+ * fine-trimmed through UTRIM[VREFTRIM] (6-bit, ~0.5*(4/3) mV per step, factory
+ * value loaded at reset). Expose that trim as a narrow window centred on the
+ * 1.2 V nominal (mid-code = nominal).
+ */
+#define NXP_VREF_TRIM_MASK  VREF_UTRIM_VREFTRIM_MASK
+#define NXP_VREF_TRIM_SHIFT VREF_UTRIM_VREFTRIM_SHIFT
+static const struct linear_range utrim_range =
+	LINEAR_RANGE_INIT(1200000 - (0x20 * 667), 667U, 0x0U, 0x3FU);
+#else
+#define NXP_VREF_TRIM_MASK  VREF_UTRIM_TRIM2V1_MASK
+#define NXP_VREF_TRIM_SHIFT VREF_UTRIM_TRIM2V1_SHIFT
 static const struct linear_range utrim_range = LINEAR_RANGE_INIT(1000000, 100000U, 0x0U, 0xBU);
+#endif
 
 struct regulator_nxp_vref_data {
 	struct regulator_common_data common;
@@ -45,9 +60,15 @@ static int regulator_nxp_vref_set_mode(const struct device *dev, regulator_mode_
 	uint32_t csr = base->CSR;
 	struct regulator_nxp_vref_data *data = dev->data;
 
-	data->mode = mode;
+	/* Validate and save operation mode */
+	if (mode != NXP_VREF_MODE_STANDBY && mode != NXP_VREF_MODE_LOW_POWER &&
+	    mode != NXP_VREF_MODE_HIGH_POWER) {
+		return -EINVAL;
+	} else{
+		data->mode = mode;
+	}
 
-	if( regulator_is_enabled( dev ) ) {
+	if (regulator_is_enabled(dev)) {
 		if (mode == NXP_VREF_MODE_STANDBY) {
 			csr &= ~(VREF_CSR_HI_PWR_LV_MASK | VREF_CSR_BUF21EN_MASK);
 		} else if (mode == NXP_VREF_MODE_LOW_POWER) {
@@ -62,11 +83,6 @@ static int regulator_nxp_vref_set_mode(const struct device *dev, regulator_mode_
 		base->CSR = csr;
 
 		k_busy_wait(config->buf_start_delay);
-	}
-
-	if (mode != NXP_VREF_MODE_STANDBY && mode != NXP_VREF_MODE_LOW_POWER &&
-	    mode != NXP_VREF_MODE_HIGH_POWER) {
-		return -EINVAL;
 	}
 
 	return 0;
@@ -95,12 +111,20 @@ static int regulator_nxp_vref_enable(const struct device *dev)
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
 	struct regulator_nxp_vref_data *data = dev->data;
+	int ret;
 
 	volatile uint32_t *const csr = &base->CSR;
 
-	CLOCK_EnableClock(kCLOCK_Vref0);
+	ret = clock_control_on(config->clock_dev, config->clock_subsys);
+	if (ret) {
+		LOG_ERR("Failed to enable clock: %d", ret);
+		return ret;
+	}
 
-	*csr |= VREF_CSR_LPBGEN_MASK | VREF_CSR_LPBG_BUF_EN_MASK;
+	*csr |= VREF_CSR_LPBGEN_MASK;
+#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0))
+	*csr |= VREF_CSR_LPBG_BUF_EN_MASK;
+#endif
 
 	/* Wait for bandgap startup */
 	k_busy_wait(config->bg_start_time);
@@ -123,14 +147,23 @@ static int regulator_nxp_vref_disable(const struct device *dev)
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
-
+	int ret;
 	/*
 	 * Disable HC Bandgap, LP Bandgap, Buf21, and Lp Bandgap Buffer
 	 * to achieve "Off" mode of VREF
 	 */
-	base->CSR &= ~(VREF_CSR_BUF21EN_MASK | VREF_CSR_HCBGEN_MASK | VREF_CSR_LPBGEN_MASK |
-		       VREF_CSR_LPBG_BUF_EN_MASK);
-	CLOCK_DisableClock(kCLOCK_Vref0);
+	base->CSR &= ~(VREF_CSR_BUF21EN_MASK | VREF_CSR_HCBGEN_MASK | VREF_CSR_LPBGEN_MASK
+#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0))
+		       | VREF_CSR_LPBG_BUF_EN_MASK
+#endif
+	);
+
+	ret = clock_control_off(config->clock_dev, config->clock_subsys);
+	if (ret) {
+		LOG_ERR("Failed to disable clock: %d", ret);
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -152,13 +185,21 @@ static int regulator_nxp_vref_set_voltage(const struct device *dev, int32_t min_
 	uint16_t idx;
 	int ret;
 
+	if(!regulator_is_enabled(dev)) {
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (ret) {
+			LOG_ERR("Failed to enable clock: %d", ret);
+			return ret;
+		}
+	}
+
 	ret = linear_range_get_win_index(&utrim_range, min_uv, max_uv, &idx);
 	if (ret < 0) {
 		return ret;
 	}
 
-	base->UTRIM &= ~VREF_UTRIM_TRIM2V1_MASK;
-	base->UTRIM |= VREF_UTRIM_TRIM2V1_MASK & idx;
+	base->UTRIM = (base->UTRIM & ~NXP_VREF_TRIM_MASK) |
+		      (((uint32_t)idx << NXP_VREF_TRIM_SHIFT) & NXP_VREF_TRIM_MASK);
 
 	return 0;
 }
@@ -171,7 +212,7 @@ static int regulator_nxp_vref_get_voltage(const struct device *dev, int32_t *vol
 	int ret;
 
 	/* Linear range index is the register value */
-	idx = (base->UTRIM & VREF_UTRIM_TRIM2V1_MASK) >> VREF_UTRIM_TRIM2V1_SHIFT;
+	idx = (base->UTRIM & NXP_VREF_TRIM_MASK) >> NXP_VREF_TRIM_SHIFT;
 
 	ret = linear_range_get_value(&utrim_range, idx, volt_uv);
 
@@ -219,11 +260,12 @@ static int regulator_nxp_vref_init(const struct device *dev)
 		}
 	}
 
-	ret = regulator_nxp_vref_disable(dev);
-	CLOCK_EnableClock(kCLOCK_Vref0);
-	if (ret < 0) {
-		return ret;
-	}
+	/* Reset CSR state before initialization */
+	base->CSR &= ~(VREF_CSR_BUF21EN_MASK | VREF_CSR_HCBGEN_MASK | VREF_CSR_LPBGEN_MASK
+#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0))
+		       | VREF_CSR_LPBG_BUF_EN_MASK
+#endif
+	);
 
 	if (config->current_compensation_en) {
 		base->CSR |= VREF_CSR_ICOMPEN_MASK;
@@ -238,7 +280,13 @@ static int regulator_nxp_vref_init(const struct device *dev)
 	}
 
 	/* Clear VREF UTRIM[TRIM2V1] first. */
+#if !(defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0))
+	/*
+	 * Clear VREF UTRIM[TRIM2V1] first. On the VREFTRIM-only variant the trim
+	 * register holds a factory value loaded at reset, so it is left intact.
+	 */
 	base->UTRIM &= ~VREF_UTRIM_TRIM2V1_MASK;
+#endif
 
 	return regulator_common_init(dev, false);
 }

--- a/drivers/regulator/regulator_nxp_vref.c
+++ b/drivers/regulator/regulator_nxp_vref.c
@@ -57,6 +57,7 @@ static int regulator_nxp_vref_set_mode(const struct device *dev, regulator_mode_
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
+
 	uint32_t csr = base->CSR;
 	struct regulator_nxp_vref_data *data = dev->data;
 
@@ -64,9 +65,9 @@ static int regulator_nxp_vref_set_mode(const struct device *dev, regulator_mode_
 	if (mode != NXP_VREF_MODE_STANDBY && mode != NXP_VREF_MODE_LOW_POWER &&
 	    mode != NXP_VREF_MODE_HIGH_POWER) {
 		return -EINVAL;
-	} else{
-		data->mode = mode;
 	}
+
+	data->mode = mode;
 
 	if (regulator_is_enabled(dev)) {
 		if (mode == NXP_VREF_MODE_STANDBY) {
@@ -92,6 +93,7 @@ static int regulator_nxp_vref_get_mode(const struct device *dev, regulator_mode_
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
+
 	uint32_t csr = base->CSR;
 
 	/* Check bits to determine mode */
@@ -185,7 +187,7 @@ static int regulator_nxp_vref_set_voltage(const struct device *dev, int32_t min_
 	uint16_t idx;
 	int ret;
 
-	if(!regulator_is_enabled(dev)) {
+	if (!regulator_is_enabled(dev)) {
 		ret = clock_control_on(config->clock_dev, config->clock_subsys);
 		if (ret) {
 			LOG_ERR("Failed to enable clock: %d", ret);

--- a/drivers/regulator/regulator_nxp_vref.c
+++ b/drivers/regulator/regulator_nxp_vref.c
@@ -19,25 +19,11 @@
 
 LOG_MODULE_REGISTER(nxp_vref, CONFIG_REGULATOR_LOG_LEVEL);
 
-#if defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0)
-/*
- * VREF variant whose output buffer is a fixed nominal 1.2 V that is only
- * fine-trimmed through UTRIM[VREFTRIM] (6-bit, ~0.5*(4/3) mV per step, factory
- * value loaded at reset). Expose that trim as a narrow window centred on the
- * 1.2 V nominal (mid-code = nominal).
- */
-#define NXP_VREF_TRIM_MASK  VREF_UTRIM_VREFTRIM_MASK
-#define NXP_VREF_TRIM_SHIFT VREF_UTRIM_VREFTRIM_SHIFT
-static const struct linear_range utrim_range =
-	LINEAR_RANGE_INIT(1200000 - (0x20 * 667), 667U, 0x0U, 0x3FU);
-#else
-#define NXP_VREF_TRIM_MASK  VREF_UTRIM_TRIM2V1_MASK
-#define NXP_VREF_TRIM_SHIFT VREF_UTRIM_TRIM2V1_SHIFT
 static const struct linear_range utrim_range = LINEAR_RANGE_INIT(1000000, 100000U, 0x0U, 0xBU);
-#endif
 
 struct regulator_nxp_vref_data {
 	struct regulator_common_data common;
+	regulator_mode_t mode;
 };
 
 struct regulator_nxp_vref_config {
@@ -52,70 +38,36 @@ struct regulator_nxp_vref_config {
 	clock_control_subsys_t clock_subsys;
 };
 
-static int regulator_nxp_vref_enable(const struct device *dev)
-{
-	const struct regulator_nxp_vref_config *config = dev->config;
-	VREF_Type *const base = config->base;
-
-	volatile uint32_t *const csr = &base->CSR;
-
-	*csr |= VREF_CSR_LPBGEN_MASK;
-#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0))
-	*csr |= VREF_CSR_LPBG_BUF_EN_MASK;
-#endif
-
-	/* Wait for bandgap startup */
-	k_busy_wait(config->bg_start_time);
-
-	/* Enable high accuracy bandgap */
-	*csr |= VREF_CSR_HCBGEN_MASK;
-
-	/* Monitor until stable */
-	while (!(*csr & VREF_CSR_VREFST_MASK)) {
-		;
-	}
-
-	return 0;
-}
-
-static int regulator_nxp_vref_disable(const struct device *dev)
-{
-	const struct regulator_nxp_vref_config *config = dev->config;
-	VREF_Type *const base = config->base;
-
-	/*
-	 * Disable HC Bandgap, LP Bandgap, Buf21, and (where present) the LP
-	 * Bandgap Buffer to achieve "Off" mode of VREF.
-	 */
-	base->CSR &= ~(VREF_CSR_BUF21EN_MASK | VREF_CSR_HCBGEN_MASK | VREF_CSR_LPBGEN_MASK
-#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0))
-		       | VREF_CSR_LPBG_BUF_EN_MASK
-#endif
-	);
-
-	return 0;
-}
-
 static int regulator_nxp_vref_set_mode(const struct device *dev, regulator_mode_t mode)
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
 	uint32_t csr = base->CSR;
+	struct regulator_nxp_vref_data *data = dev->data;
 
-	if (mode == NXP_VREF_MODE_STANDBY) {
-		csr &= ~(VREF_CSR_HI_PWR_LV_MASK | VREF_CSR_BUF21EN_MASK);
-	} else if (mode == NXP_VREF_MODE_LOW_POWER) {
-		csr &= ~VREF_CSR_HI_PWR_LV_MASK;
-		csr |= VREF_CSR_BUF21EN_MASK;
-	} else if (mode == NXP_VREF_MODE_HIGH_POWER) {
-		csr |= (VREF_CSR_HI_PWR_LV_MASK | VREF_CSR_BUF21EN_MASK);
-	} else {
-		return -EINVAL;
+	data->mode = mode;
+
+	if( regulator_is_enabled( dev ) ) {
+		if (mode == NXP_VREF_MODE_STANDBY) {
+			csr &= ~(VREF_CSR_HI_PWR_LV_MASK | VREF_CSR_BUF21EN_MASK);
+		} else if (mode == NXP_VREF_MODE_LOW_POWER) {
+			csr &= ~VREF_CSR_HI_PWR_LV_MASK;
+			csr |= VREF_CSR_BUF21EN_MASK;
+		} else if (mode == NXP_VREF_MODE_HIGH_POWER) {
+			csr |= (VREF_CSR_HI_PWR_LV_MASK | VREF_CSR_BUF21EN_MASK);
+		} else {
+			return -EINVAL;
+		}
+
+		base->CSR = csr;
+
+		k_busy_wait(config->buf_start_delay);
 	}
 
-	base->CSR = csr;
-
-	k_busy_wait(config->buf_start_delay);
+	if (mode != NXP_VREF_MODE_STANDBY && mode != NXP_VREF_MODE_LOW_POWER &&
+	    mode != NXP_VREF_MODE_HIGH_POWER) {
+		return -EINVAL;
+	}
 
 	return 0;
 }
@@ -135,6 +87,50 @@ static int regulator_nxp_vref_get_mode(const struct device *dev, regulator_mode_
 		*mode = NXP_VREF_MODE_STANDBY;
 	}
 
+	return 0;
+}
+
+static int regulator_nxp_vref_enable(const struct device *dev)
+{
+	const struct regulator_nxp_vref_config *config = dev->config;
+	VREF_Type *const base = config->base;
+	struct regulator_nxp_vref_data *data = dev->data;
+
+	volatile uint32_t *const csr = &base->CSR;
+
+	CLOCK_EnableClock(kCLOCK_Vref0);
+
+	*csr |= VREF_CSR_LPBGEN_MASK | VREF_CSR_LPBG_BUF_EN_MASK;
+
+	/* Wait for bandgap startup */
+	k_busy_wait(config->bg_start_time);
+
+	/* Enable high accuracy bandgap */
+	*csr |= VREF_CSR_HCBGEN_MASK;
+
+	/* Monitor until stable */
+	while (!(*csr & VREF_CSR_VREFST_MASK)) {
+		;
+	}
+
+	/* disable() clears BUF21EN. Restore the selected regulator mode after
+	 * every enable, including the mode configured by regulator-initial-mode.
+	 */
+	return regulator_nxp_vref_set_mode(dev, data->mode);
+}
+
+static int regulator_nxp_vref_disable(const struct device *dev)
+{
+	const struct regulator_nxp_vref_config *config = dev->config;
+	VREF_Type *const base = config->base;
+
+	/*
+	 * Disable HC Bandgap, LP Bandgap, Buf21, and Lp Bandgap Buffer
+	 * to achieve "Off" mode of VREF
+	 */
+	base->CSR &= ~(VREF_CSR_BUF21EN_MASK | VREF_CSR_HCBGEN_MASK | VREF_CSR_LPBGEN_MASK |
+		       VREF_CSR_LPBG_BUF_EN_MASK);
+	CLOCK_DisableClock(kCLOCK_Vref0);
 	return 0;
 }
 
@@ -161,8 +157,8 @@ static int regulator_nxp_vref_set_voltage(const struct device *dev, int32_t min_
 		return ret;
 	}
 
-	base->UTRIM = (base->UTRIM & ~NXP_VREF_TRIM_MASK) |
-		      (((uint32_t)idx << NXP_VREF_TRIM_SHIFT) & NXP_VREF_TRIM_MASK);
+	base->UTRIM &= ~VREF_UTRIM_TRIM2V1_MASK;
+	base->UTRIM |= VREF_UTRIM_TRIM2V1_MASK & idx;
 
 	return 0;
 }
@@ -175,7 +171,7 @@ static int regulator_nxp_vref_get_voltage(const struct device *dev, int32_t *vol
 	int ret;
 
 	/* Linear range index is the register value */
-	idx = (base->UTRIM & NXP_VREF_TRIM_MASK) >> NXP_VREF_TRIM_SHIFT;
+	idx = (base->UTRIM & VREF_UTRIM_TRIM2V1_MASK) >> VREF_UTRIM_TRIM2V1_SHIFT;
 
 	ret = linear_range_get_value(&utrim_range, idx, volt_uv);
 
@@ -196,10 +192,12 @@ static DEVICE_API(regulator, api) = {
 static int regulator_nxp_vref_init(const struct device *dev)
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
+	struct regulator_nxp_vref_data *data = dev->data;
 	VREF_Type *const base = config->base;
 	int ret;
 
 	regulator_common_data_init(dev);
+	data->mode = NXP_VREF_MODE_STANDBY;
 
 	if (config->clock_dev) {
 		if (!device_is_ready(config->clock_dev)) {
@@ -222,6 +220,7 @@ static int regulator_nxp_vref_init(const struct device *dev)
 	}
 
 	ret = regulator_nxp_vref_disable(dev);
+	CLOCK_EnableClock(kCLOCK_Vref0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -238,13 +237,8 @@ static int regulator_nxp_vref_init(const struct device *dev)
 		base->CSR |= VREF_CSR_REGEN_MASK;
 	}
 
-#if !(defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0))
-	/*
-	 * Clear VREF UTRIM[TRIM2V1] first. On the VREFTRIM-only variant the trim
-	 * register holds a factory value loaded at reset, so it is left intact.
-	 */
+	/* Clear VREF UTRIM[TRIM2V1] first. */
 	base->UTRIM &= ~VREF_UTRIM_TRIM2V1_MASK;
-#endif
 
 	return regulator_common_init(dev, false);
 }

--- a/drivers/regulator/regulator_nxp_vref.c
+++ b/drivers/regulator/regulator_nxp_vref.c
@@ -75,10 +75,9 @@ static int regulator_nxp_vref_set_mode(const struct device *dev, regulator_mode_
 		} else if (mode == NXP_VREF_MODE_LOW_POWER) {
 			csr &= ~VREF_CSR_HI_PWR_LV_MASK;
 			csr |= VREF_CSR_BUF21EN_MASK;
-		} else if (mode == NXP_VREF_MODE_HIGH_POWER) {
-			csr |= (VREF_CSR_HI_PWR_LV_MASK | VREF_CSR_BUF21EN_MASK);
 		} else {
-			return -EINVAL;
+			/* mode == NXP_VREF_MODE_HIGH_POWER */
+			csr |= (VREF_CSR_HI_PWR_LV_MASK | VREF_CSR_BUF21EN_MASK);
 		}
 
 		base->CSR = csr;
@@ -117,11 +116,14 @@ static int regulator_nxp_vref_enable(const struct device *dev)
 
 	volatile uint32_t *const csr = &base->CSR;
 
+/* Gating the clock is only needed in low power modes */
+#if CONFIG_PM_DEVICE
 	ret = clock_control_on(config->clock_dev, config->clock_subsys);
 	if (ret) {
 		LOG_ERR("Failed to enable clock: %d", ret);
 		return ret;
 	}
+#endif
 
 	*csr |= VREF_CSR_LPBGEN_MASK;
 #if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0))
@@ -160,11 +162,14 @@ static int regulator_nxp_vref_disable(const struct device *dev)
 #endif
 	);
 
+/* Gating the clock is only needed in low power modes */
+#if CONFIG_PM_DEVICE
 	ret = clock_control_off(config->clock_dev, config->clock_subsys);
 	if (ret) {
 		LOG_ERR("Failed to disable clock: %d", ret);
 		return ret;
 	}
+#endif
 
 	return 0;
 }

--- a/drivers/regulator/regulator_nxp_vref.c
+++ b/drivers/regulator/regulator_nxp_vref.c
@@ -57,7 +57,6 @@ static int regulator_nxp_vref_set_mode(const struct device *dev, regulator_mode_
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
-
 	uint32_t csr = base->CSR;
 	struct regulator_nxp_vref_data *data = dev->data;
 
@@ -92,7 +91,6 @@ static int regulator_nxp_vref_get_mode(const struct device *dev, regulator_mode_
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
-
 	uint32_t csr = base->CSR;
 
 	/* Check bits to determine mode */
@@ -112,8 +110,9 @@ static int regulator_nxp_vref_enable(const struct device *dev)
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
 	struct regulator_nxp_vref_data *data = dev->data;
+#if CONFIG_PM_DEVICE
 	int ret;
-
+#endif
 	volatile uint32_t *const csr = &base->CSR;
 
 /* Gating the clock is only needed in low power modes */
@@ -151,7 +150,10 @@ static int regulator_nxp_vref_disable(const struct device *dev)
 {
 	const struct regulator_nxp_vref_config *config = dev->config;
 	VREF_Type *const base = config->base;
+#if CONFIG_PM_DEVICE
 	int ret;
+#endif
+
 	/*
 	 * Disable HC Bandgap, LP Bandgap, Buf21, and Lp Bandgap Buffer
 	 * to achieve "Off" mode of VREF


### PR DESCRIPTION
MCXW72's ADC does not handle properly low power entry and exit. This generates a high current consumption when ADC is not in use. VREF driver has initialization trouble that conflict with ADC behavior.

Proposed solution: Manage ADC clocks in ADC driver and add proper peripheral re-initialization. Also, fixed VREF initialization flow.

Fixes #115476  