### PR TITLE
linker: Add a BSS linker location option

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1308,6 +1308,7 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    Subsequent calls to zephyr_linker_sources with the same file(s) will remove
 #    these from the original location. Only the last call is considered.
 # <location> is one of
+#    BSS           Inside the bss output section.
 #    NOINIT        Inside the noinit output section.
 #    RWDATA        Inside the data output section.
 #    RODATA        Inside the rodata output section.
@@ -1327,9 +1328,9 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    be alphanumeric, and the keys are sorted alphabetically. If no key is
 #    given, the key 'default' is used. Keys are case-sensitive.
 #
-# Use NOINIT, RWDATA, and RODATA unless they don't work for your use case.
+# Use BSS, NOINIT, RWDATA, and RODATA unless they don't work for your use case.
 #
-# When placing into NOINIT, RWDATA, RODATA, ROM_START, RAMFUNC_SECTION,
+# When placing into BSS, NOINIT, RWDATA, RODATA, ROM_START, RAMFUNC_SECTION,
 # NOCACHE_SECTION, DTCM_SECTION or ITCM_SECTION the contents of the files will
 # be placed inside an output section, so assume the section definition is
 # already present, e.g.:
@@ -1364,6 +1365,7 @@ function(zephyr_linker_sources location)
   set(data_sections_path "${snippet_base}/snippets-data-sections.ld")
   set(text_sections_path "${snippet_base}/snippets-text-sections.ld")
   set(rom_start_path     "${snippet_base}/snippets-rom-start.ld")
+  set(bss_path           "${snippet_base}/snippets-bss.ld")
   set(noinit_path        "${snippet_base}/snippets-noinit.ld")
   set(rwdata_path        "${snippet_base}/snippets-rwdata.ld")
   set(rodata_path        "${snippet_base}/snippets-rodata.ld")
@@ -1381,6 +1383,7 @@ function(zephyr_linker_sources location)
     file(WRITE ${data_sections_path} "")
     file(WRITE ${text_sections_path} "")
     file(WRITE ${rom_start_path} "")
+    file(WRITE ${bss_path} "")
     file(WRITE ${noinit_path} "")
     file(WRITE ${rwdata_path} "")
     file(WRITE ${rodata_path} "")
@@ -1404,6 +1407,8 @@ function(zephyr_linker_sources location)
     set(snippet_path "${text_sections_path}")
   elseif("${location}" STREQUAL "ROM_START")
     set(snippet_path "${rom_start_path}")
+  elseif("${location}" STREQUAL "BSS")
+    set(snippet_path "${bss_path}")
   elseif("${location}" STREQUAL "NOINIT")
     set(snippet_path "${noinit_path}")
   elseif("${location}" STREQUAL "RWDATA")

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -260,6 +260,11 @@ SECTIONS {
 		. = ALIGN(4);
 		__bss_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 		*(".bss")
 		*(".bss.*")
 		*(".bss$*")

--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -410,6 +410,11 @@ GROUP_END(OCM)
         . = ALIGN(4);
         __bss_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
         *(.bss)
         *(".bss.*")
         *(COMMON)

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -437,6 +437,11 @@ _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_sta
 	__bss_start = .;
 	__kernel_ram_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 	*(.bss)
 	*(".bss.*")
 	*(COMMON)

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -283,6 +283,11 @@ SECTIONS
         . = ALIGN(8);
         __bss_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
         *(.bss)
         *(".bss.*")
         *(COMMON)

--- a/include/zephyr/arch/mips/linker.ld
+++ b/include/zephyr/arch/mips/linker.ld
@@ -156,6 +156,12 @@ SECTIONS
 		 */
 		 . = ALIGN(4);
 		 __bss_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 		 *(.dynbss)
 		 *(.sbss)
 		 *(.sbss.*)

--- a/include/zephyr/arch/openrisc/linker.ld
+++ b/include/zephyr/arch/openrisc/linker.ld
@@ -190,6 +190,12 @@ SECTIONS
 		 */
 		 . = ALIGN(4);
 		 __bss_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 		 *(.dynbss)
 		 *(.sbss)
 		 *(.sbss.*)

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -328,6 +328,12 @@ SECTIONS
 		 */
 		 . = ALIGN(4);
 		 __bss_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 		 *(.sbss)
 		 *(".sbss.*")
 		 *(.bss)

--- a/include/zephyr/arch/rx/linker.ld
+++ b/include/zephyr/arch/rx/linker.ld
@@ -283,6 +283,12 @@ SECTIONS
 	{
 		_bss = .;
 		__bss_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 		*(.bss)
 		*(.bss.**)
 		*(COMMON)

--- a/include/zephyr/arch/sparc/linker.ld
+++ b/include/zephyr/arch/sparc/linker.ld
@@ -129,6 +129,12 @@ SECTIONS
 		 */
 		 . = ALIGN(4);
 		 __bss_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 		 *(.dynbss)
 		 *(.bss)
 		 *(.bss.*)

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -386,6 +386,11 @@ SECTION_PROLOGUE(.x86shadowstack.arr,,)
 	__kernel_ram_start = .;
 	__bss_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 	*(.bss)
 	*(".bss.*")
 	*(COMMON)

--- a/include/zephyr/arch/x86/intel64/linker.ld
+++ b/include/zephyr/arch/x86/intel64/linker.ld
@@ -165,6 +165,12 @@ SECTIONS
 #endif
 	__kernel_ram_start = .;
 	__bss_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-bss.ld>
+
 	*(.bss)
 	*(.bss.*)
 	*(COMMON)


### PR DESCRIPTION
Allow applications to add special named sections to BSS or add linker symbols around certain BSS objects without having to define their own BSS area in RAM_SECTIONS that has to be memset separate of the rest of BSS.