### PR TITLE
boards: add integration tag to platforms with limited coverage..

### DIFF
--- a/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
+++ b/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
@@ -17,3 +17,4 @@ testing:
     - kernel
     - userspace
     - trusted-firmware-m
+    - integration

--- a/boards/arm/mps2/mps2_an521_cpu1.yaml
+++ b/boards/arm/mps2/mps2_an521_cpu1.yaml
@@ -15,3 +15,4 @@ testing:
   only_tags:
     - arm
     - fpu
+    - integration

--- a/boards/arm/mps3/mps3_corstone300_an547_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone300_an547_ns.yaml
@@ -18,3 +18,4 @@ testing:
   default: true
   only_tags:
     - trusted-firmware-m
+    - integration

--- a/boards/arm/mps3/mps3_corstone300_an552_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone300_an552_ns.yaml
@@ -14,3 +14,4 @@ testing:
   default: true
   only_tags:
     - trusted-firmware-m
+    - integration

--- a/boards/arm/mps3/mps3_corstone300_fvp_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone300_fvp_ns.yaml
@@ -15,3 +15,4 @@ testing:
   timeout_multiplier: 4
   only_tags:
     - trusted-firmware-m
+    - integration

--- a/boards/arm/mps3/mps3_corstone310_an555_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone310_an555_ns.yaml
@@ -14,3 +14,4 @@ testing:
   default: true
   only_tags:
     - trusted-firmware-m
+    - integration

--- a/boards/arm/mps3/mps3_corstone310_fvp_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone310_fvp_ns.yaml
@@ -15,3 +15,4 @@ testing:
   timeout_multiplier: 4
   only_tags:
     - trusted-firmware-m
+    - integration

--- a/boards/cdns/swerv/twister.yaml
+++ b/boards/cdns/swerv/twister.yaml
@@ -5,6 +5,7 @@ toolchain:
 testing:
   only_tags:
     - kernel
+    - integration
   ignore_tags:
     - benchmark
 variants:

--- a/boards/mediatek/mt8186/mt8186_mt8186_adsp.yaml
+++ b/boards/mediatek/mt8186/mt8186_mt8186_adsp.yaml
@@ -8,4 +8,5 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration
 vendor: mediatek

--- a/boards/mediatek/mt8188/mt8188_mt8188_adsp.yaml
+++ b/boards/mediatek/mt8188/mt8188_mt8188_adsp.yaml
@@ -8,4 +8,5 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration
 vendor: mediatek

--- a/boards/mediatek/mt8195/mt8195_mt8195_adsp.yaml
+++ b/boards/mediatek/mt8195/mt8195_mt8195_adsp.yaml
@@ -8,4 +8,5 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration
 vendor: mediatek

--- a/boards/mediatek/mt8196/mt8196_mt8196_adsp.yaml
+++ b/boards/mediatek/mt8196/mt8196_mt8196_adsp.yaml
@@ -8,4 +8,5 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration
 vendor: mediatek

--- a/boards/mediatek/mt8365/mt8365_mt8365_adsp.yaml
+++ b/boards/mediatek/mt8365/mt8365_mt8365_adsp.yaml
@@ -8,4 +8,5 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration
 vendor: mediatek

--- a/boards/nxp/imx8qm_mek/imx8qm_mek_mimx8qm6_adsp.yaml
+++ b/boards/nxp/imx8qm_mek/imx8qm_mek_mimx8qm6_adsp.yaml
@@ -8,4 +8,5 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration
 vendor: nxp

--- a/boards/nxp/imx8qxp_mek/imx8qxp_mek_mimx8qx6_adsp.yaml
+++ b/boards/nxp/imx8qxp_mek/imx8qxp_mek_mimx8qx6_adsp.yaml
@@ -8,4 +8,5 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration
 vendor: nxp

--- a/boards/nxp/imx8ulp_evk/imx8ulp_evk_mimx8ud7_adsp.yaml
+++ b/boards/nxp/imx8ulp_evk/imx8ulp_evk_mimx8ud7_adsp.yaml
@@ -8,3 +8,4 @@ testing:
   only_tags:
     - kernel
     - sof
+    - integration

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_f1.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_f1.yaml
@@ -7,4 +7,5 @@ toolchain:
 testing:
   only_tags:
     - kernel
+    - integration
 vendor: nxp

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.yaml
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.yaml
@@ -24,3 +24,4 @@ supported:
 testing:
   only_tags:
     - kernel
+    - integration

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi1.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi1.yaml
@@ -15,4 +15,5 @@ toolchain:
 testing:
   only_tags:
     - kernel
+    - integration
 vendor: nxp

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.yaml
@@ -15,4 +15,5 @@ toolchain:
 testing:
   only_tags:
     - kernel
+    - integration
 vendor: nxp

--- a/boards/qemu/cortex_a53/qemu_cortex_a53_qemu_cortex_a53_xip.yaml
+++ b/boards/qemu/cortex_a53/qemu_cortex_a53_qemu_cortex_a53_xip.yaml
@@ -12,4 +12,5 @@ testing:
   default: true
   only_tags:
     - xip
+    - integration
 vendor: qemu

--- a/boards/qemu/riscv32_xip/qemu_riscv32_xip.yaml
+++ b/boards/qemu/riscv32_xip/qemu_riscv32_xip.yaml
@@ -11,3 +11,4 @@ testing:
   default: true
   only_tags:
     - xip
+    - integration

--- a/boards/qemu/x86/qemu_x86_atom_nokpti.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_nokpti.yaml
@@ -12,6 +12,7 @@ testing:
     - kernel
     - userspace
     - llext
+    - integration
   ignore_tags:
     - benchmark
 ram: 3000

--- a/boards/qemu/x86/qemu_x86_atom_nommu.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_nommu.yaml
@@ -11,4 +11,5 @@ testing:
   only_tags:
     - kernel
     - userspace
+    - integration
 vendor: qemu

--- a/boards/qemu/x86/qemu_x86_atom_nopae.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_nopae.yaml
@@ -12,6 +12,7 @@ testing:
     - kernel
     - userspace
     - llext
+    - integration
   ignore_tags:
     - benchmark
 ram: 3000

--- a/boards/qemu/x86/qemu_x86_atom_virt.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_virt.yaml
@@ -12,6 +12,7 @@ testing:
     - kernel
     - userspace
     - llext
+    - integration
   ignore_tags:
     - benchmark
 ram: 3000

--- a/boards/qemu/x86/qemu_x86_atom_xip.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_xip.yaml
@@ -11,5 +11,6 @@ testing:
   only_tags:
     - xip
     - llext
+    - integration
 ram: 3000
 vendor: qemu

--- a/boards/qemu/x86/qemu_x86_tiny.yaml
+++ b/boards/qemu/x86/qemu_x86_tiny.yaml
@@ -12,6 +12,7 @@ testing:
     - kernel
     - userspace
     - llext
+    - integration
   ignore_tags:
     - benchmark
 ram: 384

--- a/boards/qemu/x86_64/qemu_x86_64_atom_nokpti.yaml
+++ b/boards/qemu/x86_64/qemu_x86_64_atom_nokpti.yaml
@@ -14,6 +14,7 @@ testing:
     - kernel
     - userspace
     - llext
+    - integration
   ignore_tags:
     - benchmark
 ram: 3000

--- a/boards/qemu/x86_lakemont/qemu_x86_lakemont.yaml
+++ b/boards/qemu/x86_lakemont/qemu_x86_lakemont.yaml
@@ -11,6 +11,7 @@ testing:
   default: true
   only_tags:
     - kernel
+    - integration
   ignore_tags:
     - benchmark
 ram: 3000

--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -41,6 +41,7 @@ SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'sim
 # value means the simulator was not found and the test cannot be executed.
 SIM_PROGRAM_CMAKE_VARS = {
     'armfvp': 'ARMFVP',
+    'whisper': 'WHISPER_BIN',
 }
 
 # Failure reason reported when the console output contains an unexpected

--- a/tests/integration/kernel/tests.yaml
+++ b/tests/integration/kernel/tests.yaml
@@ -1,4 +1,4 @@
 tests:
   integration.kernel:
     tags:
-      - kernel
+      - integration


### PR DESCRIPTION
provide some coverage in some platforms where filtering is very heavy and focused on one or two areas.