### PR TITLE
drivers: gpio: dw: add pinctrl support

### DIFF
--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -7,5 +7,6 @@ config GPIO_DW
 	bool "Designware GPIO"
 	default y
 	depends on DT_HAS_SNPS_DESIGNWARE_GPIO_ENABLED
+	select PINCTRL if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_GPIO),pinctrl-0)
 	help
 	  Enable driver for Designware GPIO

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -20,6 +20,10 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
 
+#if defined(CONFIG_PINCTRL)
+#include <zephyr/drivers/pinctrl.h>
+#endif
+
 #include "gpio_dw.h"
 
 #include <zephyr/logging/log.h>
@@ -476,12 +480,14 @@ static int gpio_dw_initialize(const struct device *port)
 	const struct gpio_dw_config *config = DEV_CFG(port);
 	mem_addr_t base_addr;
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(resets) || GPIO_DW_PINCTRL_ENABLED
+	int ret;
+#endif
+
 	DEVICE_MMIO_NAMED_MAP(port, gpio_mmio, K_MEM_CACHE_NONE);
 
 	/* Reset GPIO only if reset controller driver is supported */
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(resets)
-	int ret;
-
 	if (config->reset.dev != NULL) {
 		if (!device_is_ready(config->reset.dev)) {
 			LOG_ERR("Reset controller device not ready");
@@ -495,6 +501,16 @@ static int gpio_dw_initialize(const struct device *port)
 		}
 	}
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(resets) */
+
+#if GPIO_DW_PINCTRL_ENABLED
+	if (config->pcfg != NULL) {
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			LOG_ERR("Failed to apply pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif /* GPIO_DW_PINCTRL_ENABLED */
 
 	if (dw_interrupt_support(config)) {
 
@@ -527,6 +543,18 @@ static int gpio_dw_initialize(const struct device *port)
 #define GPIO_DW_RESET_SPEC_INIT(n)								\
 	.reset = RESET_DT_SPEC_INST_GET(n),							\
 
+#if GPIO_DW_PINCTRL_ENABLED
+#define GPIO_DW_PINCTRL_DEFINE(n)								\
+	IF_ENABLED(DT_INST_PINCTRL_HAS_NAME(n, default),					\
+		   (PINCTRL_DT_INST_DEFINE(n);))
+#define GPIO_DW_PINCTRL_CONFIG(n)								\
+	IF_ENABLED(DT_INST_PINCTRL_HAS_NAME(n, default),					\
+		   (.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),))
+#else
+#define GPIO_DW_PINCTRL_DEFINE(n)
+#define GPIO_DW_PINCTRL_CONFIG(n)
+#endif
+
 #define GPIO_DW_INIT(n)										\
 	static void gpio_config_##n##_irq(const struct device *port)				\
 	{											\
@@ -534,12 +562,15 @@ static int gpio_dw_initialize(const struct device *port)
 		LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), GPIO_DW_CFG_IRQ, (), n)			\
 	}											\
 												\
+	GPIO_DW_PINCTRL_DEFINE(n)								\
+												\
 	static const struct gpio_dw_config gpio_dw_config_##n = {				\
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(n),					\
 		DEVICE_MMIO_NAMED_ROM_INIT(gpio_mmio, DT_DRV_INST(n)),				\
 		.irq_num = COND_CODE_1(DT_INST_IRQ_HAS_IDX(n, 0), (DT_INST_IRQN(n)), (0)),	\
 		.ngpios = DT_INST_PROP(n, ngpios),						\
 		.config_func = gpio_config_##n##_irq,						\
+		GPIO_DW_PINCTRL_CONFIG(n)							\
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, resets),					\
 			(GPIO_DW_RESET_SPEC_INIT(n)))						\
 	};											\

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#define GPIO_DW_PINCTRL_ENABLED DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+
 typedef void (*gpio_config_irq_t)(const struct device *port);
 
 struct gpio_dw_config {
@@ -27,6 +29,9 @@ struct gpio_dw_config {
 	uint32_t ngpios;
 	uint32_t irq_num; /* set to 0 if GPIO port cannot interrupt */
 	gpio_config_irq_t config_func;
+#if GPIO_DW_PINCTRL_ENABLED
+	const struct pinctrl_dev_config *pcfg;
+#endif
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(resets)
 	const struct reset_dt_spec reset;
 #endif

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -5,7 +5,7 @@ description: Synopsys DesignWare GPIO
 
 compatible: "snps,designware-gpio"
 
-include: [gpio-controller.yaml, base.yaml, reset-device.yaml]
+include: [gpio-controller.yaml, base.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
### Summary
On SoCs that route the DesignWare GPIO signals through a pin controller, the pins must be muxed to their GPIO function before the controller can drive them. Add an optional "default" pinctrl state to the binding and apply it during initialization.   Everything is conditional on `DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)`, and  `pcfg` is populated per instance via `DT_INST_PINCTRL_HAS_NAME(n, default)`. So existing users that do not describe pin muxing are unaffected.

### Testing
Build tested `samples/hello_world` on two of the current users of  `snps,designware-gpio` (`em_starterkit/emsk_em9d` and `intel_socfpga_agilex5_socdk`) with `gpio_dw.c` compiled in.

The new path is verified on hardware on an Alif Ensemble E8 AI/ML AppKit(`boards/alif/ensemble_e8_ak/`), where the GPIO controllers are behind the Alif pin controller:  `samples/basic/blinky` drives the three channels of the on-board multicolor LED and `samples/basic/button` reports the correct codes for all five navigation joystick switches. GPIO support for Ensemble SoCs and the Appkit is not upstream yet (as it depends on this PR) and will follow in a separate PR.
