### PR TITLE
modules: hal_nordic: nrfx: bump nrfx API version to 4.5.0

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -9,7 +9,7 @@
 
 /* Define nrfx API version used in Zephyr. */
 #define NRFX_CONFIG_API_VER_MAJOR 4
-#define NRFX_CONFIG_API_VER_MINOR 1
+#define NRFX_CONFIG_API_VER_MINOR 5
 #define NRFX_CONFIG_API_VER_MICRO 0
 
 /* Macros used in zephyr-specific config files. */


### PR DESCRIPTION
Updated API version after nrf 4.5.0 integration.