### PR TITLE
NXP: mcxw7x: Fix mcxw7x lpi2c clock control

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -591,6 +591,16 @@ static int mcux_lpi2c_init(const struct device *dev)
 	}
 #endif /* CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY */
 
+	error = clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
+	if (error != 0) {
+		/* Check if error is due to lack of support */
+		if (error != -ENOSYS) {
+			/* Real error occurred */
+			LOG_ERR("Failed to configure clock: %d", error);
+			return error;
+		}
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -314,7 +314,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		interrupts = <39 0>;
-		clocks = <&clk_ctrl MCXW_CLOCK(0xe0, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+		clocks = <&clk_ctrl MCXW_CLOCK(0xcc, MCXW_CLK_IP_MUX_FRO_192M_DIV,
 					       MCXW_CLK_DIV_BY_16,
 					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";
@@ -327,7 +327,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		interrupts = <40 0>;
-		clocks = <&clk_ctrl MCXW_CLOCK(0xe4, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+		clocks = <&clk_ctrl MCXW_CLOCK(0xd0, MCXW_CLK_IP_MUX_FRO_192M_DIV,
 					       MCXW_CLK_DIV_BY_16,
 					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";


### PR DESCRIPTION
Pull request #101937 changed the way clock control is managed for the NXP MCXW7x. 
This PR only ported a subset of peripherals and broke at least i2c (potentially more peripherals too) 

This PR resolves the issue by assigning the correct address in the DTS and adding clock control in the lpi2c driver.


