### PR TITLE
dts: arm: nxp: rw6xx: fix invalid flexcomm clocks phandle-array

### DIFF
--- a/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
@@ -266,7 +266,7 @@
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x106000 0x1000>;
 		interrupts = <14 0>;
-		clocks = <&clkctl1 MCUX_FLEXCOMM0_CLK &clkctl1 MCUX_FLEXCOMM0_LP_CLK>;
+		clocks = <&clkctl1 MCUX_FLEXCOMM0_CLK>, <&clkctl1 MCUX_FLEXCOMM0_LP_CLK>;
 		clock-names = "default", "sleep";
 		resets = <&rstctl1 NXP_SYSCON_RESET(0, 8)>;
 		dmas = <&dma0 0>, <&dma0 1>;
@@ -281,7 +281,7 @@
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x107000 0x1000>;
 		interrupts = <15 0>;
-		clocks = <&clkctl1 MCUX_FLEXCOMM1_CLK &clkctl1 MCUX_FLEXCOMM1_LP_CLK>;
+		clocks = <&clkctl1 MCUX_FLEXCOMM1_CLK>, <&clkctl1 MCUX_FLEXCOMM1_LP_CLK>;
 		clock-names = "default", "sleep";
 		resets = <&rstctl1 NXP_SYSCON_RESET(0, 9)>;
 		dmas = <&dma0 2>, <&dma0 3>;
@@ -296,7 +296,7 @@
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x108000 0x1000>;
 		interrupts = <16 0>;
-		clocks = <&clkctl1 MCUX_FLEXCOMM2_CLK &clkctl1 MCUX_FLEXCOMM2_LP_CLK>;
+		clocks = <&clkctl1 MCUX_FLEXCOMM2_CLK>, <&clkctl1 MCUX_FLEXCOMM2_LP_CLK>;
 		clock-names = "default", "sleep";
 		resets = <&rstctl1 NXP_SYSCON_RESET(0, 10)>;
 		dmas = <&dma0 4>, <&dma0 5>;
@@ -311,7 +311,7 @@
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x109000 0x1000>;
 		interrupts = <17 0>;
-		clocks = <&clkctl1 MCUX_FLEXCOMM3_CLK &clkctl1 MCUX_FLEXCOMM3_LP_CLK>;
+		clocks = <&clkctl1 MCUX_FLEXCOMM3_CLK>, <&clkctl1 MCUX_FLEXCOMM3_LP_CLK>;
 		clock-names = "default", "sleep";
 		resets = <&rstctl1 NXP_SYSCON_RESET(0, 11)>;
 		dmas = <&dma0 6>, <&dma0 7>;


### PR DESCRIPTION
The flexcomm0..flexcomm3 nodes declared their two clocks as a single phandle-array cell block:

    clocks = <&clkctl1 MCUX_FLEXCOMMx_CLK &clkctl1 MCUX_FLEXCOMMx_LP_CLK>;

A phandle-array entry has a fixed shape <&phandle specifier...> where the number of specifiers is fixed by the referenced node's #clock-cells. Two phandle groups therefore cannot share one < > block; the combining of < > groups is only valid for plain integer arrays. Each phandle plus its specifier must be its own cell block.

Split the two clocks into separate cells so the property is a valid phandle-array:

    clocks = <&clkctl1 MCUX_FLEXCOMMx_CLK>, <&clkctl1 MCUX_FLEXCOMMx_LP_CLK>;

flexcomm14 has a single clock and is unchanged.