### PR TITLE
Bluetooth: Host: extract bt_gen_irk() helper for IRK generation

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -679,6 +679,12 @@ static void le_force_rpa_timeout(void)
 }
 
 #if defined(CONFIG_BT_PRIVACY)
+/* Generate a random IRK for the given identity using bt_rand(). */
+static int bt_gen_irk(uint8_t id)
+{
+	return bt_rand(&bt_dev.irk[id], sizeof(bt_dev.irk[id]));
+}
+
 static void rpa_timeout(struct k_work *work)
 {
 	bool adv_enabled;
@@ -1321,7 +1327,7 @@ static int id_create(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 		} else {
 			int err;
 
-			err = bt_rand(&bt_dev.irk[id], 16);
+			err = bt_gen_irk(id);
 			if (err) {
 				return err;
 			}


### PR DESCRIPTION
Currently IRK generation via `bt_rand()` is open-coded in `id_create()`. Extract a shared `bt_gen_irk()` helper so that all IRK generation call sites use the same code path and will always have the same behavior.

This also prepares for the `bt_id_reset_irk()` API (PR #114930) which will use the same helper.

**Changes:**
- Add `static int bt_gen_irk(uint8_t id)` helper (guarded by `CONFIG_BT_PRIVACY`)
- Replace open-coded `bt_rand(&bt_dev.irk[id], 16)` in `id_create()` with `bt_gen_irk(id)`
- Use `sizeof(bt_dev.irk[id])` instead of hardcoded `16`

**Related:** #114930

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYRWTPTRM69T82ZCGTJRFFZ5&panel=chat)