### PR TITLE
net: tcp: add opt-in contiguous TX buffer support

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -84,6 +84,7 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt);
 static bool is_destination_local(struct net_pkt *pkt);
 static void tcp_out(struct tcp *conn, uint8_t flags);
 static const char *tcp_state_to_str(enum tcp_state state, bool prefix);
+static int tcp_pkt_peek(struct net_pkt *to, struct net_pkt *from, size_t pos, size_t len);
 
 int (*tcp_send_cb)(struct net_pkt *pkt) = NULL;
 size_t (*tcp_recv_cb)(struct tcp *conn, struct net_pkt *pkt) = NULL;
@@ -1585,27 +1586,21 @@ err:
 	tcp_pkt_unref(rst);
 }
 
-static int tcp_out_ext(struct tcp *conn, uint8_t flags, struct net_pkt *data,
-		       uint32_t seq)
+static int tcp_out_ext(struct tcp *conn, uint8_t flags, size_t data_len, uint32_t seq)
 {
-	size_t alloc_len = sizeof(struct tcphdr);
 	struct net_pkt *pkt;
 	int ret = 0;
 
-	if (conn->send_options.mss_found) {
-		alloc_len += sizeof(uint32_t);
-	}
-
-	pkt = tcp_pkt_alloc(conn, alloc_len);
-	if (!pkt) {
+	/* The allocation adds the IP and TCP header estimate on top of the
+	 * requested length, so the headers written below and the copied
+	 * payload share the same buffer. The whole segment ends up in a
+	 * single net_buf when it fits in one buffer, larger segments span
+	 * multiple fragments.
+	 */
+	pkt = tcp_pkt_alloc(conn, data_len);
+	if (pkt == NULL) {
 		ret = -ENOBUFS;
 		goto out;
-	}
-
-	if (data) {
-		/* Append the data buffer to the pkt */
-		net_pkt_append_buffer(pkt, data->buffer);
-		data->buffer = NULL;
 	}
 
 	ret = ip_header_add(conn, pkt);
@@ -1624,6 +1619,19 @@ static int tcp_out_ext(struct tcp *conn, uint8_t flags, struct net_pkt *data,
 		ret = net_tcp_set_mss_opt(conn, pkt);
 		if (ret < 0) {
 			tcp_pkt_unref(pkt);
+			goto out;
+		}
+	}
+
+	if (data_len > 0) {
+		/* Copy the payload right after the headers, without
+		 * consuming the send queue: the queued data is dropped
+		 * only when the peer acknowledges it.
+		 */
+		ret = tcp_pkt_peek(pkt, &conn->send_data, conn->unacked_len, data_len);
+		if (ret < 0) {
+			tcp_pkt_unref(pkt);
+			ret = -ENOBUFS;
 			goto out;
 		}
 	}
@@ -1661,7 +1669,7 @@ out:
 
 static void tcp_out(struct tcp *conn, uint8_t flags)
 {
-	(void)tcp_out_ext(conn, flags, NULL /* no data */, conn->seq + conn->unacked_len);
+	(void)tcp_out_ext(conn, flags, 0 /* no data */, conn->seq + conn->unacked_len);
 }
 
 static int tcp_pkt_pull(struct net_pkt *pkt, size_t len)
@@ -1736,10 +1744,12 @@ out:
 	return ret;
 }
 
+/* Copy len bytes of data from the "from" packet at offset pos to the current
+ * cursor position of the "to" packet, without consuming the copied data.
+ */
 static int tcp_pkt_peek(struct net_pkt *to, struct net_pkt *from, size_t pos,
 			size_t len)
 {
-	net_pkt_cursor_init(to);
 	net_pkt_cursor_init(from);
 
 	if (pos) {
@@ -1855,7 +1865,6 @@ static int tcp_send_data(struct tcp *conn)
 {
 	int ret = 0;
 	int len;
-	struct net_pkt *pkt;
 
 	len = MIN(tcp_unsent_len(conn), conn_mss(conn));
 	if (len < 0) {
@@ -1868,21 +1877,7 @@ static int tcp_send_data(struct tcp *conn)
 		goto out;
 	}
 
-	pkt = tcp_pkt_alloc(conn, len);
-	if (!pkt) {
-		NET_ERR("[%p] packet allocation failed, len=%d", conn, len);
-		ret = -ENOBUFS;
-		goto out;
-	}
-
-	ret = tcp_pkt_peek(pkt, &conn->send_data, conn->unacked_len, len);
-	if (ret < 0) {
-		tcp_pkt_unref(pkt);
-		ret = -ENOBUFS;
-		goto out;
-	}
-
-	ret = tcp_out_ext(conn, PSH | ACK, pkt, conn->seq + conn->unacked_len);
+	ret = tcp_out_ext(conn, PSH | ACK, (size_t)len, conn->seq + conn->unacked_len);
 	if (ret == 0) {
 		conn->unacked_len += len;
 
@@ -1893,13 +1888,9 @@ static int tcp_send_data(struct tcp *conn)
 			net_stats_update_tcp_sent(conn->iface, len);
 			net_stats_update_tcp_seg_sent(conn->iface);
 		}
+	} else if (ret == -ENOBUFS) {
+		NET_ERR("[%p] packet allocation failed, len=%d", conn, len);
 	}
-
-	/* The data we want to send, has been moved to the send queue so we
-	 * can unref the head net_pkt. If there was an error, we need to remove
-	 * the packet anyway.
-	 */
-	tcp_pkt_unref(pkt);
 
 	conn_send_data_dump(conn);
 
@@ -1990,10 +1981,10 @@ static void tcp_resend_data(struct k_work *work)
 
 	switch (conn->state) {
 	case TCP_SYN_SENT:
-		(void)tcp_out_ext(conn, SYN, NULL, conn->seq - 1);
+		(void)tcp_out_ext(conn, SYN, 0, conn->seq - 1);
 		break;
 	case TCP_SYN_RECEIVED:
-		(void)tcp_out_ext(conn, SYN | ACK, NULL, conn->seq - 1);
+		(void)tcp_out_ext(conn, SYN | ACK, 0, conn->seq - 1);
 		break;
 	case TCP_ESTABLISHED:
 	case TCP_CLOSE_WAIT:
@@ -2020,7 +2011,7 @@ static void tcp_resend_data(struct k_work *work)
 	case TCP_FIN_WAIT_1:
 	case TCP_CLOSING:
 	case TCP_LAST_ACK:
-		(void)tcp_out_ext(conn, FIN | ACK, NULL, conn->seq - 1);
+		(void)tcp_out_ext(conn, FIN | ACK, 0, conn->seq - 1);
 		break;
 	default:
 		goto out;
@@ -2170,7 +2161,7 @@ static void tcp_send_keepalive_probe(struct k_work *work)
 	k_work_reschedule_for_queue(&tcp_work_q, &conn->keepalive_timer,
 				    K_SECONDS(conn->keep_intvl));
 
-	(void)tcp_out_ext(conn, ACK, NULL, conn->seq + conn->unacked_len - 1);
+	(void)tcp_out_ext(conn, ACK, 0, conn->seq + conn->unacked_len - 1);
 }
 #endif /* CONFIG_NET_TCP_KEEPALIVE */
 
@@ -2181,7 +2172,7 @@ static void tcp_send_zwp(struct k_work *work)
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
-	(void)tcp_out_ext(conn, ACK, NULL, conn->seq + conn->unacked_len - 1);
+	(void)tcp_out_ext(conn, ACK, 0, conn->seq + conn->unacked_len - 1);
 
 	tcp_derive_rto(conn);
 
@@ -4011,7 +4002,7 @@ static int tcp_start_handshake(struct tcp *conn)
 	k_mutex_lock(&conn->lock, K_FOREVER);
 	tcp_check_sock_options(conn);
 	conn->send_options.mss_found = true;
-	ret = tcp_out_ext(conn, SYN, NULL /* no data */, conn->seq);
+	ret = tcp_out_ext(conn, SYN, 0 /* no data */, conn->seq);
 	if (ret < 0) {
 		k_mutex_unlock(&conn->lock);
 		return ret;

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -374,6 +374,11 @@ static inline int net_tcp_put(struct net_context *context, bool force_close)
 
 #define NET_TCP_MAX_OPT_SIZE  8
 
+#if defined(CONFIG_NET_TEST) && defined(CONFIG_NET_NATIVE_TCP)
+/** @brief Test hook to intercept TCP TX packets. Only for unit tests. */
+extern int (*tcp_send_cb)(struct net_pkt *pkt);
+#endif
+
 #if defined(CONFIG_NET_NATIVE_TCP)
 void net_tcp_init(void);
 #else

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -60,20 +60,20 @@
 #endif
 
 #define tcp_pkt_ref(_pkt) net_pkt_ref(_pkt)
+/* The allocation includes a headroom estimate for the IP and TCP headers
+ * plus options, so a zero length allocates enough buffer space for a
+ * segment without payload.
+ */
 #define tcp_pkt_alloc(_conn, _len)					\
 ({									\
 	struct net_pkt *_pkt;						\
 									\
-	if ((_len) > 0) {						\
-		_pkt = net_pkt_alloc_with_buffer(			\
-			(_conn)->iface,					\
-			(_len),						\
-			net_context_get_family((_conn)->context),	\
-			NET_IPPROTO_TCP,				\
-			TCP_PKT_ALLOC_TIMEOUT);				\
-	} else {							\
-		_pkt = net_pkt_alloc(TCP_PKT_ALLOC_TIMEOUT);		\
-	}								\
+	_pkt = net_pkt_alloc_with_buffer(				\
+		(_conn)->iface,						\
+		(_len),							\
+		net_context_get_family((_conn)->context),		\
+		NET_IPPROTO_TCP,					\
+		TCP_PKT_ALLOC_TIMEOUT);					\
 									\
 	tp_pkt_alloc(_pkt, tp_basename(__FILE__), __LINE__);		\
 									\

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -159,6 +159,14 @@ static void verify_flags(struct tcphdr *th, uint8_t flags,
 #define test_verify_flags(_th, _flags) \
 	verify_flags(_th, _flags, __func__, __LINE__)
 
+/* State captured by the tcp_send_cb TX intercept hook (see
+ * test_contiguous_tx).
+ */
+static int send_cb_total_calls;
+static int send_cb_data_calls;
+static int send_cb_data_frags;
+static size_t send_cb_data_payload_len;
+
 struct net_tcp_context {
 	uint8_t mac_addr[sizeof(struct net_eth_addr)];
 	struct net_linkaddr ll_addr;
@@ -429,6 +437,49 @@ static int read_tcp_header(struct net_pkt *pkt, struct tcphdr *th)
 	return 0;
 fail:
 	return -EINVAL;
+}
+
+/* TX intercept hook used by test_contiguous_tx. It exercises the tcp_send_cb
+ * branch of tcp_out_ext(), records how the data segment was assembled, and
+ * then hands the packet to the normal send path. The hook takes ownership of
+ * pkt: net_send_data() consumes the reference on success, and we release it
+ * explicitly on failure.
+ */
+static int test_tcp_send_cb(struct net_pkt *pkt)
+{
+	struct tcphdr th;
+	int ret;
+
+	send_cb_total_calls++;
+
+	if (read_tcp_header(pkt, &th) == 0 && (th.th_flags & PSH)) {
+		size_t hdr_len = net_pkt_ip_hdr_len(pkt) +
+				 net_pkt_ip_opts_len(pkt) + (th.th_off * 4U);
+		struct net_buf *buf = pkt->buffer;
+		int frags = 0;
+
+		while (buf != NULL) {
+			frags++;
+			buf = buf->frags;
+		}
+
+		send_cb_data_calls++;
+		send_cb_data_frags = frags;
+		send_cb_data_payload_len = net_pkt_get_len(pkt) - hdr_len;
+	}
+
+	/* Restore the packet state that read_tcp_header() changed before the
+	 * packet continues down the send path.
+	 */
+	net_pkt_set_overwrite(pkt, false);
+	net_pkt_cursor_init(pkt);
+
+	ret = net_send_data(pkt);
+	if (ret < 0) {
+		net_pkt_unref(pkt);
+	}
+
+	return ret;
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)
@@ -3271,4 +3322,87 @@ ZTEST(net_tcp, test_server_fin_ack_after_data)
 	k_sleep(K_MSEC(CONFIG_NET_TCP_TIME_WAIT_DELAY));
 }
 
-ZTEST_SUITE(net_tcp, NULL, presetup, NULL, NULL, NULL);
+/* Verify how outgoing TCP data segments are assembled by intercepting them
+ * with the tcp_send_cb hook: a small data segment must consist of a single
+ * net_buf fragment carrying exactly the sent bytes right after the TCP
+ * header. This also verifies that tcp_out_ext() hands the packet off to the
+ * hook cleanly, as the hook takes ownership of the outgoing packet.
+ */
+ZTEST(net_tcp, test_contiguous_tx)
+{
+	struct net_context *ctx;
+	uint8_t data = 0x41;
+	int data_frags;
+	size_t data_payload_len;
+	int data_calls;
+	int total_calls;
+	int ret;
+
+	send_cb_total_calls = 0;
+	send_cb_data_calls = 0;
+	send_cb_data_frags = 0;
+	send_cb_data_payload_len = 0;
+
+	t_state = T_SYN;
+	test_case_no = TEST_CLIENT_IPV4;
+	seq = ack = 0;
+
+	/* Install the TX intercept hook. The net_tcp_after() teardown clears it
+	 * again so it never leaks into another test, even if an assertion below
+	 * aborts this one.
+	 */
+	tcp_send_cb = test_tcp_send_cb;
+
+	ret = net_context_get(NET_AF_INET, NET_SOCK_STREAM, NET_IPPROTO_TCP, &ctx);
+	zassert_ok(ret, "Failed to get net_context");
+
+	net_context_ref(ctx);
+
+	ret = net_context_connect(ctx, (struct net_sockaddr *)&peer_addr_s,
+				  sizeof(struct net_sockaddr_in),
+				  NULL, K_MSEC(100), NULL);
+	zassert_ok(ret, "Failed to connect to peer");
+
+	test_sem_take(K_MSEC(100), __LINE__);
+
+	ret = net_context_send(ctx, &data, 1, NULL, K_NO_WAIT, NULL);
+	zassert_true(ret >= 0, "Failed to send data to peer (%d)", ret);
+
+	test_sem_take(K_MSEC(100), __LINE__);
+
+	net_context_put(ctx);
+
+	/* Peer will release the semaphore after it receives ACK to FIN | ACK */
+	test_sem_take(K_MSEC(100), __LINE__);
+
+	k_sleep(K_MSEC(CONFIG_NET_TCP_TIME_WAIT_DELAY));
+
+	/* Snapshot the captured state and uninstall the hook before asserting,
+	 * so a failed assertion cannot leave the hook installed.
+	 */
+	total_calls = send_cb_total_calls;
+	data_calls = send_cb_data_calls;
+	data_frags = send_cb_data_frags;
+	data_payload_len = send_cb_data_payload_len;
+	tcp_send_cb = NULL;
+
+	zassert_true(total_calls > 0, "TX intercept hook was never invoked");
+	zassert_equal(data_calls, 1, "Expected exactly one data segment, got %d", data_calls);
+
+	zassert_equal(data_frags, 1, "Expected single net_buf fragment, got %d", data_frags);
+
+	zassert_equal(data_payload_len, 1,
+		      "Unexpected data segment payload length %zu (expected 1)", data_payload_len);
+}
+
+/* Always clear the TX intercept hook after every test so a test that installs
+ * it (and possibly aborts) cannot affect the following tests.
+ */
+static void net_tcp_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	tcp_send_cb = NULL;
+}
+
+ZTEST_SUITE(net_tcp, NULL, presetup, NULL, net_tcp_after, NULL);


### PR DESCRIPTION
Each outgoing TCP segment was assembled from two allocations: a
header-only net_pkt, plus the payload net_pkt whose buffer chain was
appended after the headers. The IP/TCP header space that
net_pkt_alloc_with_buffer() already estimates and reserves for the
payload packet was left unused, so every data segment cost an extra
net_pkt and an extra net_buf.

Allocate one net_pkt sized for the payload only and use the header
space the allocator already reserves: write the IP and TCP headers
first and copy the payload right after them. This drops the separate
header-only allocation, and the whole segment lands in a single
net_buf fragment whenever it fits in one buffer, which helps drivers
that prefer contiguous data. Larger segments simply span multiple
fragments as before, so this applies to any buffer configuration and
needs no Kconfig option. Because the allocator's header estimate
also accounts for the TCP options, a segment that carries both an
MSS option and payload stays correct by construction.

Fixes #83260
