### PR TITLE
stm32: fix double-include in DTS/DTSI files

### DIFF
--- a/boards/st/nucleo_l452re/nucleo_l452re.dts
+++ b/boards/st/nucleo_l452re/nucleo_l452re.dts
@@ -8,7 +8,6 @@
 /dts-v1/;
 #include "nucleo_l452re_common.dtsi"
 #include <st/l4/stm32l452r(c-e)tx-pinctrl.dtsi>
-#include "arduino_r3_connector.dtsi"
 #include "st_morpho_connector.dtsi"
 
 / {

--- a/boards/st/nucleo_l452re/nucleo_l452re_stm32l452xx_p.dts
+++ b/boards/st/nucleo_l452re/nucleo_l452re_stm32l452xx_p.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include "nucleo_l452re_common.dtsi"
 #include <st/l4/stm32l452retxp-pinctrl.dtsi>
+#include "st_morpho_connector_p.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L452RE-P-NUCLEO board";

--- a/boards/st/nucleo_l452re/nucleo_l452re_stm32l452xx_p.dts
+++ b/boards/st/nucleo_l452re/nucleo_l452re_stm32l452xx_p.dts
@@ -8,7 +8,6 @@
 /dts-v1/;
 #include "nucleo_l452re_common.dtsi"
 #include <st/l4/stm32l452retxp-pinctrl.dtsi>
-#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L452RE-P-NUCLEO board";

--- a/boards/st/nucleo_l452re/st_morpho_connector_p.dtsi
+++ b/boards/st/nucleo_l452re/st_morpho_connector_p.dtsi
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_L_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_L_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_L_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_L_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_L_13 0 &gpiob 12 0>,
+			   <ST_MORPHO_L_15 0 &gpioa 13 0>,
+			   <ST_MORPHO_L_17 0 &gpioa 14 0>,
+			   <ST_MORPHO_L_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_L_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_L_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_L_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_L_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_L_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_L_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_L_32 0 &gpioc 3 0>,
+			   <ST_MORPHO_L_34 0 &gpioc 2 0>,
+			   <ST_MORPHO_L_35 0 &gpiob 4 0>,
+			   <ST_MORPHO_L_36 0 &gpioc 1 0>,
+			   <ST_MORPHO_L_37 0 &gpiob 9 0>,
+			   <ST_MORPHO_L_38 0 &gpioc 0 0>,
+			   <ST_MORPHO_R_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_R_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_R_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_R_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_R_5 0 &gpiob 7 0>,
+			   <ST_MORPHO_R_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_R_10 0 &gpiob 0 0>,
+			   <ST_MORPHO_R_11 0 &gpiob 13 0>,
+			   <ST_MORPHO_R_12 0 &gpioa 10 0>,
+			   <ST_MORPHO_R_13 0 &gpiob 14 0>,
+			   <ST_MORPHO_R_14 0 &gpioa 9 0>,
+			   <ST_MORPHO_R_15 0 &gpiob 15 0>,
+			   <ST_MORPHO_R_16 0 &gpiob 11 0>,
+			   <ST_MORPHO_R_17 0 &gpioa 11 0>,
+			   <ST_MORPHO_R_18 0 &gpiob 2 0>,
+			   <ST_MORPHO_R_19 0 &gpioa 8 0>,
+			   <ST_MORPHO_R_21 0 &gpiob 6 0>,
+			   <ST_MORPHO_R_22 0 &gpiob 1 0>,
+			   <ST_MORPHO_R_23 0 &gpioc 7 0>,
+			   <ST_MORPHO_R_24 0 &gpioa 7 0>,
+			   <ST_MORPHO_R_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_R_26 0 &gpioa 6 0>,
+			   <ST_MORPHO_R_27 0 &gpioa 15 0>,
+			   <ST_MORPHO_R_28 0 &gpioa 5 0>,
+			   <ST_MORPHO_R_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_R_30 0 &gpioa 4 0>,
+			   <ST_MORPHO_R_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_R_33 0 &gpioa 12 0>,
+			   <ST_MORPHO_R_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_R_35 0 &gpioa 9 0>, /* SB34=OFF, SB35=ON */
+			   <ST_MORPHO_R_36 0 &gpioa 3 0>,
+			   <ST_MORPHO_R_37 0 &gpioa 10 0>, /* SB32=OFF, SB33=ON */
+			   <ST_MORPHO_R_38 0 &gpioa 2 0>;
+	};
+};

--- a/dts/arm/st/h7/stm32h755.dtsi
+++ b/dts/arm/st/h7/stm32h755.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/h7/stm32h7_dualcore.dtsi>
 #include <st/h7/stm32h745.dtsi>
 
 / {


### PR DESCRIPTION
Found by @kylebonnici

\+ add missing Morpho connector for affected board while at it