### PR TITLE
dts: bindings: spi: stm32-spi-subghz: drop use-subghz-nss property

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -812,7 +812,7 @@ static void spi_stm32_cs_control(const struct device *dev, bool on __maybe_unuse
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
 	const struct spi_stm32_config *cfg = dev->config;
 
-	if (cfg->use_subghzspi_nss) {
+	if (cfg->is_subghzspi) {
 		if (on) {
 			LL_PWR_SelectSUBGHZSPI_NSS();
 		} else {
@@ -2071,26 +2071,21 @@ static DEVICE_API(spi, api_funcs) = {
 	.release = spi_stm32_release,
 };
 
-static bool spi_stm32_is_subghzspi(const struct device *dev)
-{
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
-	const struct spi_stm32_config *cfg = dev->config;
-
-	return cfg->use_subghzspi_nss;
-#else
-	ARG_UNUSED(dev);
-	return false;
-#endif /* st_stm32_spi_subghz */
-}
-
 static int spi_stm32_pinctrl_apply(const struct device *dev, uint8_t id)
 {
 	const struct spi_stm32_config *config = dev->config;
 	int err;
 
-	if (spi_stm32_is_subghzspi(dev)) {
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
+	if (config->is_subghzspi) {
+		/*
+		 * Skip call to pinctrl_apply_state() for SUBGHZSPI.
+		 * The function would error out because that node
+		 * lacks pinctrl, but this is known and expected.
+		 */
 		return 0;
 	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz) */
 
 	/* Move pins to requested state */
 	err = pinctrl_apply_state(config->pcfg, id);
@@ -2282,9 +2277,8 @@ static int spi_stm32_init(const struct device *dev)
 			DT_INST_STRING_UPPER_TOKEN(id, st_spi_data_width)),	\
 		.ioswp = DT_INST_PROP(id, ioswp),				\
 		STM32_SPI_IRQ_HANDLER_FUNC(id)					\
-		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz),	\
-			   (.use_subghzspi_nss =				\
-				DT_INST_PROP_OR(id, use_subghzspi_nss, false),))\
+		IF_ENABLED(DT_INST_NODE_HAS_COMPAT(id, st_stm32_spi_subghz),	\
+			   (.is_subghzspi = true,))				\
 		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi), (		\
 			.midi_clocks = DT_INST_PROP(id, midi_clock),		\
 			.mssi_clocks = DT_INST_PROP(id, mssi_clock),		\

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -41,7 +41,7 @@ struct spi_stm32_config {
 	bool ioswp: 1;
 	bool soft_nss: 1;
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
-	bool use_subghzspi_nss: 1;
+	bool is_subghzspi: 1;
 #endif
 };
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -386,7 +386,6 @@
 			clocks = <&rcc STM32_CLOCK(APB3, 0)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
-			use-subghzspi-nss;
 
 			radio@0 {
 				compatible = "st,stm32wl-subghz-radio";

--- a/dts/bindings/spi/st,stm32-spi-subghz.yaml
+++ b/dts/bindings/spi/st,stm32-spi-subghz.yaml
@@ -10,11 +10,3 @@ include:
     property-blocklist:
       - pinctrl-0
       - pinctrl-names
-
-properties:
-  use-subghzspi-nss:
-    type: boolean
-    required: true
-    description: |
-      Control the SUBGHZPI NSS line using the PWR HAL functions. This is for
-      the special purpose SUBGHZSPI interface found in the STM32WL series.


### PR DESCRIPTION
The property was both `boolean` and `required: true` so it was always present on nodes with the compatible (i.e., STM32WL5 "SUBGHZSPI" node). The SPI driver serialized this property into field `use_subghzspi_nss`, but it really acted as `is_subghzspi` instead... which does not require a specific property: the SUBGHZSPI node can be identified by its special compatible `st,stm32-spi-subghz` alone!

Drop the `use-subghz-nss` property from the binding since it is useless, and update the STM32WL SoC DTSI accordingly. In the STM32 SPI driver, rename the `use_subghzspi_nss` field to `is_subghzspi` and initialize it to true iff an SPI node has the special compatible. While at it, inline function spi_stm32_is_subghzspi() into its only caller and add a comment explaining why the check is needed to slightly simplify the driver.