### PR TITLE
drivers: i2s: esp32: return the TX block when the DMA fails

### DIFF
--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -439,6 +439,12 @@ void IRAM_ATTR i2s_esp32_tx_compl_transfer(struct k_timer *timer)
 	if (err < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		LOG_DBG("Failed to restart TX transfer: %d", err);
+		stream->data->dma_pending = false;
+		if (stream->data->mem_block != NULL) {
+			k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+		}
+		stream->data->mem_block = NULL;
+		stream->data->mem_block_len = 0;
 		goto tx_disable;
 	}
 
@@ -559,6 +565,12 @@ static int i2s_esp32_tx_start_transfer(const struct device *dev)
 	err = i2s_esp32_start_dma(dev, I2S_DIR_TX);
 	if (err < 0) {
 		LOG_DBG("Failed to start TX DMA transfer: %d", err);
+		stream->data->dma_pending = false;
+		if (stream->data->mem_block != NULL) {
+			k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+		}
+		stream->data->mem_block = NULL;
+		stream->data->mem_block_len = 0;
 		return -EIO;
 	}
 


### PR DESCRIPTION
Two TX paths take a block off the queue, record it in `stream->data->mem_block`, and then return without giving it back when the DMA call fails: the start in `i2s_esp32_tx_start_transfer()` and the restart in `i2s_esp32_tx_compl_transfer()`. `transferring` is never set either, so nothing downstream treats the stream as owning anything, and the next attempt overwrites the pointer. The slab drains one block per failure.

`i2s_esp32_rx_callback()` already meets the identical failure at its own restart and frees the block, clears `mem_block` and `mem_block_len`, and stops. This is TX doing what RX already does, at both sites.

Fixes #115504

## Why both TX frees check for NULL and RX does not

RX frees a block it has just taken from `k_mem_slab_alloc()`, so it cannot be NULL. Both TX blocks arrive through `i2s_write()`, and neither the generic wrapper nor `i2s_esp32_write()` rejects a NULL `mem_block`, so the queue can hold one and the restart path can dequeue it.

`k_mem_slab_free()` only validates its argument under `CONFIG_MEM_SLAB_POINTER_VALIDATE`, which defaults to `ASSERT`:

https://github.com/zephyrproject-rtos/zephyr/blob/main/kernel/mem_slab.c#L48-L58

So in an ordinary build the free goes straight to `*(char **)mem = slab->free_list`. Today `i2s_esp32_config_dma()` rejects the NULL on the non-GDMA path and the call returns a quiet `-EIO`; an unguarded free would turn that into a store through NULL, and at the restart site that happens in the DMA callback.

Both sites also clear `dma_pending`, so the failure state does not depend on the stop path clearing it.

## The `I2S_DIR_BOTH` rollback, TX side only

With RX started and TX failed, `rx.transferring` is true and `tx.transferring` is false, so the arm that stops RX is the one that runs, and TX has now cleaned up after itself. The mirror case cannot occur, because `i2s_esp32_start_transfer()` starts RX first and skips TX entirely when RX fails.

That is the TX half only. `i2s_esp32_rx_stop_transfer()` clears `mem_block` without freeing it, so the RX block the rollback releases is still dropped. That is the stop-path ownership problem #113310 and #113311 are about, not something this patch introduces.

I checked this against #113311 rather than assuming: cherry-picking either onto the other applies cleanly, they touch different functions, and they can land in either order.

## Testing

Build tested only, on `esp32s3_devkitc/esp32s3/procpu` and `doit_esp32_devkit_v1/esp32/procpu`. The second target is there because this code sits among `#if SOC_GDMA_SUPPORTED` blocks and the original ESP32 is what compiles the other half. I checked that rather than assuming: `dma_stop` is referenced in the S3 map and absent from the ESP32 one, which is the expected split.

I did not add a regression test. Both paths need a DMA failure induced on the device, so there is nothing a hardware-agnostic test could assert here. If a reviewer sees a way to fault-inject it, I am happy to add one.
