### PR TITLE
modbus: improve Doxygen coverage

### DIFF
--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -509,8 +509,13 @@ struct modbus_server_param {
 	uint8_t unit_id;
 };
 
+/**
+ * @brief Raw ADU callback parameter
+ */
 struct modbus_raw_cb {
+	/** Callback function used to send a raw ADU */
 	modbus_raw_cb_t raw_tx_cb;
+	/** Pointer to the user data passed to the callback function */
 	void *user_data;
 };
 
@@ -521,13 +526,16 @@ struct modbus_raw_cb {
 struct modbus_iface_param {
 	/** Mode of the interface */
 	enum modbus_mode mode;
+	/** Role specific parameter of the interface */
 	union {
+		/** Server parameter of the interface */
 		struct modbus_server_param server;
 		/** Amount of time client will wait for
 		 *  a response from the server.
 		 */
 		uint32_t rx_timeout;
 	};
+	/** Transport specific parameter of the interface */
 	union {
 		/** Serial support parameter of the interface */
 		struct modbus_serial_param serial;

--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -21,6 +21,12 @@
  */
 
 /**
+ * @file
+ * @brief Header file for the MODBUS transport protocol API.
+ * @ingroup modbus
+ */
+
+/**
  * @brief MODBUS transport protocol API
  * @defgroup modbus MODBUS
  * @ingroup connectivity


### PR DESCRIPTION
Add the missing `@file` block to the MODBUS header and document the raw
ADU callback structure and the anonymous unions of the interface
parameter structure.

Documentation only, no functional change.