### PR TITLE
kvss: add @file Doxygen blocks to NVS and ZMS headers

### DIFF
--- a/include/zephyr/kvss/nvs.h
+++ b/include/zephyr/kvss/nvs.h
@@ -4,6 +4,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for the Non-volatile Storage (NVS) API.
+ * @ingroup nvs
+ */
+
 #ifndef ZEPHYR_INCLUDE_KVSS_NVS_H_
 #define ZEPHYR_INCLUDE_KVSS_NVS_H_
 

--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -5,6 +5,13 @@
  *
  * ZMS: Zephyr Memory Storage
  */
+
+/**
+ * @file
+ * @brief Header file for the Zephyr Memory Storage (ZMS) API.
+ * @ingroup zms
+ */
+
 #ifndef ZEPHYR_INCLUDE_KVSS_ZMS_H_
 #define ZEPHYR_INCLUDE_KVSS_ZMS_H_
 


### PR DESCRIPTION
Add missing @file blocks so the NVS and ZMS headers show up properly in the generated API documentation, attached to their respective Doxygen groups.