### PR TITLE
udc: mcux: enable vbus detect

### DIFF
--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -844,6 +844,9 @@ static int udc_mcux_driver_preinit(const struct device *dev)
 	data->caps.rwup = false;
 	data->caps.mps0 = USB_MCUX_MPS0;
 	data->caps.hs = true;
+#if (defined USB_DEVICE_CONFIG_DETACH_ENABLE) && (USB_DEVICE_CONFIG_DETACH_ENABLE > 0U)
+	data->caps.can_detect_vbus = true;
+#endif
 	priv->dev = dev;
 
 	pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -796,7 +796,11 @@ static int udc_mcux_driver_preinit(const struct device *dev)
 	if ((priv->controller_id == kUSB_ControllerLpcIp3511Hs0) ||
 	    (priv->controller_id == kUSB_ControllerLpcIp3511Hs1)) {
 		data->caps.hs = true;
+#if (defined USB_DEVICE_CONFIG_DETACH_ENABLE) && (USB_DEVICE_CONFIG_DETACH_ENABLE > 0U)
+		data->caps.can_detect_vbus = true;
+#endif
 	}
+
 	priv->dev = dev;
 
 	pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
@@ -121,6 +121,8 @@ BUILD_ASSERT(NUM_INSTS <= 1, "Only one USB device supported");
 #define USB_DEVICE_CONFIG_SOF_NOTIFICATIONS (1U)
 #endif
 
+#define USB_DEVICE_CONFIG_DETACH_ENABLE (1U)
+
 #endif
 
 #endif /* __USB_DEVICE_CONFIG_H__ */


### PR DESCRIPTION
The MCUX EHCI and IP3511 controllers can detect VBUS state when the underlying MCUX USB device hal drivers are built with USB_DEVICE_CONFIG_DETACH_ENABLE. Set the can_detect_vbus capability accordingly so the USB device stack can rely on hardware VBUS detection when available.