### PR TITLE
MAINTAINERS: Promote kedareswararao to Xilinx Platforms maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -7567,10 +7567,10 @@ Xilinx Platforms:
   status: maintained
   maintainers:
     - michalsimek
+    - kedareswararao
   collaborators:
     - henrikbrixandersen
     - ibirnbaum
-    - kedareswararao
     - neeliajay
     - venodela
   files:


### PR DESCRIPTION
Move kedareswararao from collaborators to maintainers for the Xilinx Platforms area. Along with Michal, I will be actively reviewing and testing the pull requests for AMD platforms.