### PR TITLE
Revert "drivers: gnss: Add L5 system support"

### DIFF
--- a/drivers/gnss/gnss_dump.c
+++ b/drivers/gnss/gnss_dump.c
@@ -73,18 +73,6 @@ static const char *gnss_system_to_str(enum gnss_system system)
 		return "SBAS";
 	case GNSS_SYSTEM_IMES:
 		return "IMES";
-	case GNSS_SYSTEM_GPS_L5:
-		return "GPS_L5";
-	case GNSS_SYSTEM_GALILEO_L5:
-		return "GALILEO_L5";
-	case GNSS_SYSTEM_QZSS_L5:
-		return "QZSS_L5";
-	case GNSS_SYSTEM_BEIDOU_B1C:
-		return "BEIDOU B1C";
-	case GNSS_SYSTEM_BEIDOU_B2A:
-		return "BEIDOU B2a";
-	case GNSS_SYSTEM_QZSS_L1S:
-		return "QZSS L1S";
 	}
 
 	return "unknown";

--- a/drivers/gnss/gnss_nmea0183.c
+++ b/drivers/gnss/gnss_nmea0183.c
@@ -73,14 +73,13 @@ static void align_satellite_with_gnss_system(enum gnss_system sv_system,
 {
 	switch (sv_system) {
 	case GNSS_SYSTEM_GPS:
-	case GNSS_SYSTEM_GPS_L5:
 		if (satellite->prn > GNSS_NMEA0183_GSV_PRN_GPS_RANGE) {
 			satellite->system = GNSS_SYSTEM_SBAS;
 			satellite->prn += GNSS_NMEA0183_GSV_PRN_SBAS_OFFSET;
 			break;
 		}
 
-		satellite->system = sv_system;
+		satellite->system = GNSS_SYSTEM_GPS;
 		break;
 
 	case GNSS_SYSTEM_GLONASS:
@@ -89,21 +88,16 @@ static void align_satellite_with_gnss_system(enum gnss_system sv_system,
 		break;
 
 	case GNSS_SYSTEM_GALILEO:
-	case GNSS_SYSTEM_GALILEO_L5:
-		satellite->system = sv_system;
+		satellite->system = GNSS_SYSTEM_GALILEO;
 		break;
 
 	case GNSS_SYSTEM_BEIDOU:
-	case GNSS_SYSTEM_BEIDOU_B1C:
-	case GNSS_SYSTEM_BEIDOU_B2A:
-		satellite->system = sv_system;
+		satellite->system = GNSS_SYSTEM_BEIDOU;
 		satellite->prn -= GNSS_NMEA0183_GSV_PRN_BEIDOU_OFFSET;
 		break;
 
 	case GNSS_SYSTEM_QZSS:
-	case GNSS_SYSTEM_QZSS_L5:
-	case GNSS_SYSTEM_QZSS_L1S:
-		satellite->system = sv_system;
+		satellite->system = GNSS_SYSTEM_QZSS;
 		break;
 
 	case GNSS_SYSTEM_IRNSS:

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -78,18 +78,6 @@ enum gnss_system {
 	GNSS_SYSTEM_SBAS = BIT(6),
 	/** Indoor Messaging System (IMES) */
 	GNSS_SYSTEM_IMES = BIT(7),
-	/** Global Positioning System (GPS) L5 */
-	GNSS_SYSTEM_GPS_L5 = BIT(8),
-	/** Galileo L5 */
-	GNSS_SYSTEM_GALILEO_L5 = BIT(9),
-	/** Quasi-Zenith Satellite System (QZSS) L5 */
-	GNSS_SYSTEM_QZSS_L5 = BIT(10),
-	/** BeiDou Navigation Satellite System B1C */
-	GNSS_SYSTEM_BEIDOU_B1C = BIT(11),
-	/** BeiDou Navigation Satellite System B2a */
-	GNSS_SYSTEM_BEIDOU_B2A = BIT(12),
-	/** Quasi-Zenith Satellite System (QZSS) L1S Augmentation service */
-	GNSS_SYSTEM_QZSS_L1S = BIT(13),
 };
 
 /** Type storing bitmask of GNSS systems */


### PR DESCRIPTION
The individual bands within a GNSS constellation do not count as a new system. This commit was overloading the meaning of `gnss_system`, as demonstrated by:
 * The NMEA handling has no way to result in these new defines
 * The new defines have no meaning in several in-tree contexts (e.g in `struct gnss_satellite`)
 * The commit changed the meaning of `GNSS_SYSTEM_GPS` for example to mean the whole GPS constellation in some contexts, and the L1 band of the GPS constellation in others.

The real problem is the limitation of the `set_enabled_systems` API, which is insufficiently flexible to communicate individual bands within a GNSS system.

The correct solution is to add a new `gnss_signals` define, implement a new `set/get_enabled_signals` API and deprecate
`set/get_enabled_systems`.

This reverts commit f8800c8ab396ee08945221a9064f61e037e51066.