### PR TITLE
net: Fixes for code-scanning alerts in `subsys/net/lib`

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -224,12 +224,21 @@ static inline bool mdns_iface_is_enabled(struct net_if *iface)
 #if defined(CONFIG_NET_IPV4)
 static struct mdns_responder_context v4_ctx[MAX_IPV4_IFACE_COUNT];
 
+/* The socket service dispatcher keeps a pointer to the poll fd array passed at
+ * registration (and reuses it when a peer dispatcher is unregistered), so it
+ * must outlive init_listener(). Keep it at file scope for that reason.
+ */
+static struct zsock_pollfd ipv4_fds[MAX_IPV4_IFACE_COUNT];
+
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v4_svc, dns_dispatcher_svc_handler,
 				      MDNS_V4_SVC_POLL_COUNT);
 #endif
 
 #if defined(CONFIG_NET_IPV6)
 static struct mdns_responder_context v6_ctx[MAX_IPV6_IFACE_COUNT];
+
+/* See the ipv4_fds comment above: the dispatcher retains this pointer. */
+static struct zsock_pollfd ipv6_fds[MAX_IPV6_IFACE_COUNT];
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v6_svc, dns_dispatcher_svc_handler,
 				      MDNS_V6_SVC_POLL_COUNT);
@@ -1638,9 +1647,9 @@ static int init_listener(void)
 
 #if defined(CONFIG_NET_IPV6)
 	/* Because there is only one IPv6 socket service context for all
-	 * IPv6 sockets, we must collect the sockets in one place.
+	 * IPv6 sockets, we must collect the sockets in one place (ipv6_fds,
+	 * defined at file scope).
 	 */
-	struct zsock_pollfd ipv6_fds[MAX_IPV6_IFACE_COUNT];
 	struct net_sockaddr_in6 local_addr6;
 	int v6;
 
@@ -1750,7 +1759,6 @@ static int init_listener(void)
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
-	struct zsock_pollfd ipv4_fds[MAX_IPV4_IFACE_COUNT];
 	struct net_sockaddr_in local_addr4;
 	int v4;
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -1514,6 +1514,7 @@ static int dispatcher_cb(struct dns_socket_dispatcher *ctx, int sock,
 static int register_dispatcher(struct mdns_responder_context *ctx,
 			       const struct net_socket_service_desc *svc,
 			       struct net_sockaddr *local,
+			       size_t local_len,
 			       int ifindex,
 			       struct zsock_pollfd *fds,
 			       size_t fds_len)
@@ -1536,9 +1537,17 @@ static int register_dispatcher(struct mdns_responder_context *ctx,
 	svc->pev[0].event.fd = ctx->sock;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && local->sa_family == NET_AF_INET6) {
+		if (local_len < sizeof(struct net_sockaddr_in6)) {
+			return -EINVAL;
+		}
+
 		memcpy(&ctx->dispatcher.local_addr, local,
 		       sizeof(struct net_sockaddr_in6));
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) && local->sa_family == NET_AF_INET) {
+		if (local_len < sizeof(struct net_sockaddr_in)) {
+			return -EINVAL;
+		}
+
 		memcpy(&ctx->dispatcher.local_addr, local,
 		       sizeof(struct net_sockaddr_in));
 	} else {
@@ -1747,7 +1756,8 @@ static int init_listener(void)
 		}
 
 		ret = register_dispatcher(&v6_ctx[i], &v6_svc, (struct net_sockaddr *)&local_addr6,
-					  ifindex, ipv6_fds, ARRAY_SIZE(ipv6_fds));
+					  sizeof(local_addr6), ifindex, ipv6_fds,
+					  ARRAY_SIZE(ipv6_fds));
 		if (ret < 0 && ret != -EALREADY) {
 			NET_DBG("Cannot register %s %s socket service (%d)",
 				"IPv6", "mDNS", ret);
@@ -1856,7 +1866,8 @@ static int init_listener(void)
 		}
 
 		ret = register_dispatcher(&v4_ctx[i], &v4_svc, (struct net_sockaddr *)&local_addr4,
-					  ifindex, ipv4_fds, ARRAY_SIZE(ipv4_fds));
+					  sizeof(local_addr4), ifindex, ipv4_fds,
+					  ARRAY_SIZE(ipv4_fds));
 		if (ret < 0 && ret != -EALREADY) {
 			NET_DBG("Cannot register %s %s socket service (%d)",
 				"IPv4", "mDNS", ret);

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -709,6 +709,7 @@ static int register_dispatcher(struct dns_resolve_context *ctx,
 			       const struct net_socket_service_desc *svc,
 			       struct dns_server *server,
 			       struct net_sockaddr *local,
+			       size_t local_len,
 			       const struct net_in6_addr *addr6,
 			       const struct net_in_addr *addr4)
 {
@@ -723,11 +724,19 @@ static int register_dispatcher(struct dns_resolve_context *ctx,
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    server->dns_server.sa_family == NET_AF_INET6) {
+		if (local_len < sizeof(struct net_sockaddr_in6)) {
+			return -EINVAL;
+		}
+
 		memcpy(&server->dispatcher.local_addr,
 		       local,
 		       sizeof(struct net_sockaddr_in6));
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   server->dns_server.sa_family == NET_AF_INET) {
+		if (local_len < sizeof(struct net_sockaddr_in)) {
+			return -EINVAL;
+		}
+
 		memcpy(&server->dispatcher.local_addr,
 		       local,
 		       sizeof(struct net_sockaddr_in));
@@ -1180,7 +1189,7 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 		}
 
 		ret = register_dispatcher(ctx, svc, &ctx->servers[i], local_addr,
-					  addr6, addr4);
+					  addr_len, addr6, addr4);
 		if (ret < 0) {
 			if (ret == -EALREADY) {
 				/* The dispatcher deduplicates registrations by

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -497,30 +497,54 @@ static bool lwm2m_validate_time_resource_lenghts(uint16_t resource_length, uint1
 
 static int lwm2m_check_buf_sizes(uint8_t data_type, uint16_t resource_length, uint16_t buf_length)
 {
+	size_t expected_len;
+
 	switch (data_type) {
 	case LWM2M_RES_TYPE_OPAQUE:
 	case LWM2M_RES_TYPE_STRING:
 		if (resource_length > buf_length) {
 			return -ENOMEM;
 		}
-		break;
+		return 0;
 	case LWM2M_RES_TYPE_U32:
-	case LWM2M_RES_TYPE_U16:
-	case LWM2M_RES_TYPE_U8:
-	case LWM2M_RES_TYPE_S64:
 	case LWM2M_RES_TYPE_S32:
+		expected_len = sizeof(uint32_t);
+		break;
+	case LWM2M_RES_TYPE_U16:
 	case LWM2M_RES_TYPE_S16:
+		expected_len = sizeof(uint16_t);
+		break;
+	case LWM2M_RES_TYPE_U8:
 	case LWM2M_RES_TYPE_S8:
+		expected_len = sizeof(uint8_t);
+		break;
 	case LWM2M_RES_TYPE_BOOL:
+		expected_len = sizeof(bool);
+		break;
+	case LWM2M_RES_TYPE_S64:
+		expected_len = sizeof(int64_t);
+		break;
 	case LWM2M_RES_TYPE_FLOAT:
+		expected_len = sizeof(double);
+		break;
 	case LWM2M_RES_TYPE_OBJLNK:
-		if (resource_length != buf_length) {
-			return -EINVAL;
-		}
+		expected_len = sizeof(struct lwm2m_objlnk);
 		break;
 	default:
 		return 0;
 	}
+
+	/* For fixed-width types the switch statements in the get/set paths access
+	 * the buffers using the C type matching the resource data type, so both
+	 * the resource data and the user buffer must be exactly that size. Merely
+	 * checking that the two lengths match is not enough: a buffer smaller than
+	 * the accessed type (e.g. reading a float resource into a bool via the
+	 * wrong getter) would overflow.
+	 */
+	if (resource_length != expected_len || buf_length != expected_len) {
+		return -EINVAL;
+	}
+
 	return 0;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -222,7 +222,7 @@ static int oma_tlv_get(struct oma_tlv *tlv, struct lwm2m_input_context *in,
 	uint8_t len_pos = 1U;
 	size_t tlv_len;
 	uint16_t tmp_offset;
-	uint8_t buf[2];
+	uint8_t buf[2] = {0};
 	int ret;
 
 	tmp_offset = in->offset;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -641,7 +641,7 @@ static int get_float(struct lwm2m_input_context *in, double *value)
 static int get_string(struct lwm2m_input_context *in, uint8_t *buf, size_t buflen)
 {
 	struct cbor_in_fmt_data *fd;
-	int len;
+	size_t len;
 
 	fd = engine_get_in_user_data(in);
 	if (!fd || !fd->current) {
@@ -652,7 +652,9 @@ static int get_string(struct lwm2m_input_context *in, uint8_t *buf, size_t bufle
 	if (len >= buflen) {
 		return -ENOMEM;
 	}
-	memcpy(buf, fd->current->record_union.union_vs.value, len);
+	if (len > 0) {
+		memcpy(buf, fd->current->record_union.union_vs.value, len);
+	}
 	buf[len] = '\0';
 
 	fd->current = NULL;
@@ -746,7 +748,7 @@ static int do_write_op_item(struct lwm2m_message *msg, struct record *rec)
 	}
 
 	/* If there's no name then the basename forms the path */
-	if (rec->record_n_present) {
+	if (rec != NULL && rec->record_n_present) {
 		len = MIN(sizeof(name) - 1, rec->record_n.record_n.len);
 		snprintk(name, len + 1, "%s", rec->record_n.record_n.value);
 	}

--- a/subsys/net/lib/tls_credentials/tls_credentials_digest_raw.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_digest_raw.c
@@ -42,8 +42,14 @@ int credential_digest_raw(struct tls_credential *credential, void *dest, size_t 
 	err = base64_encode(dest, *len, &written, digest_buf, sizeof(digest_buf));
 	*len = err ? 0 : written;
 
-	/* Clean up. */
-	memset(digest_buf, 0, sizeof(digest_buf));
+	/* Clean up. Clear via a volatile pointer so the compiler cannot
+	 * optimize the wipe of the intermediate digest away.
+	 */
+	volatile uint8_t *p = digest_buf;
+
+	for (size_t i = 0; i < sizeof(digest_buf); i++) {
+		p[i] = 0U;
+	}
 
 	return err;
 }


### PR DESCRIPTION
Fixes a batch of GitHub code-scanning alerts (GCC static analyzer, Sanitizers, SonarCloud) in `subsys/net/lib`. Each alert is addressed by a dedicated commit; similar findings in the same area are grouped into one commit:

#### `net: lwm2m: Fix NULL access in SenML CBOR write handling`
- [#1661](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1661) — GCC analyzer `-Wanalyzer-null-dereference`, `lwm2m/lwm2m_rw_senml_cbor.c:749` (`dereference of NULL 'rec'`)
- [#1782](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1782) — Sanitizers (UBSAN) `ubsan-null-pointer`, `lwm2m/lwm2m_rw_senml_cbor.c:655` (`NULL` passed to `memcpy`)
#### `net: lib: tls_credentials: Prevent digest wipe from being optimized out`
- [#1007](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1007) — SonarCloud `c:S5798`, `tls_credentials/tls_credentials_digest_raw.c:46` (`memset` likely optimized away)
#### `net: lwm2m: Validate buffer size against resource data type`
- [#1735](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1735) — GCC analyzer `-Wanalyzer-out-of-bounds`, `lwm2m/lwm2m_registry.c:913`
- [#1736](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1736) — GCC analyzer `-Wanalyzer-out-of-bounds`, `lwm2m/lwm2m_registry.c:943`
- [#1737](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1737) — GCC analyzer `-Wanalyzer-out-of-bounds`, `lwm2m/lwm2m_registry.c:951`
- [#1738](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1738) — GCC analyzer `-Wanalyzer-out-of-bounds`, `lwm2m/lwm2m_registry.c:955`
- [#1739](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1739) — GCC analyzer `-Wanalyzer-out-of-bounds`, `lwm2m/lwm2m_registry.c:959`
- [#1740](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1740) — GCC analyzer `-Wanalyzer-out-of-bounds`, `lwm2m/lwm2m_registry.c:971`
- [#1741](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1741) — GCC analyzer `-Wanalyzer-out-of-bounds`, `lwm2m/lwm2m_registry.c:975`
#### `net: mdns_responder: Use static storage for listener poll arrays`
- [#1795](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1795) — Sanitizers (ASAN) `asan-stack-use-after-return`, `sockets/sockets_service.c:101`
#### `net: dns: Bound dispatcher local address copy by source length`
- [#1733](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1733) — GCC analyzer `-Wanalyzer-out-of-bounds`, `dns/mdns_responder.c:1530` (`stack-based buffer over-read`)
- [#1734](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1734) — GCC analyzer `-Wanalyzer-out-of-bounds`, `dns/resolve.c:726` (`stack-based buffer over-read`)
#### `net: lwm2m: Zero-initialize OMA TLV read buffer`
- [#1767](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1767) — GCC analyzer `-Wanalyzer-use-of-uninitialized-value`, `lwm2m/lwm2m_rw_oma_tlv.c:243` (`use of uninitialized value 'buf[1]'`)

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/115535
