### PR TITLE
.github: don't cancel PR metadata checks on label events

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -13,7 +13,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  # Label changes are delivered as one event per label, so a bulk (un)labeling
+  # spawns several runs at once. Keying the group on the action and the label
+  # keeps those runs apart so they do not cancel each other and leave this
+  # required check reported as "cancelled". The label name is empty for the
+  # push events, which therefore keep sharing a group and still supersede each
+  # other.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}-${{ github.event.action }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The PR Metadata Check workflow triggers on labeled/unlabeled in addition
to synchronize, and puts every pull_request event into a single
concurrency group with cancel-in-progress enabled.

GitHub delivers one pull_request event per label, so when several labels
are applied at once all of the resulting runs land in the same group and
cancel each other. The "Prevent Merging" check then reports as cancelled
even though an identical run succeeded for the same SHA, and because it
is a required check the PR is left blocked. 24 of the last 100 runs of
this workflow were cancelled this way.

Key the concurrency group on the event action and the label name as well.
Runs for distinct labels no longer contend, so none of them is cancelled.
Both fields are empty for the push events, which keep sharing a group and
still supersede each other.

This does not change what the check reports: do_not_merge.py re-reads the
pull request over the API and iterates its current labels rather than the
ones carried in the event payload, so every run evaluates the same live
state regardless of which event started it.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
