### PR TITLE
arch: arm: aarch32: mmu: add weak hook for extra MMU regions

### DIFF
--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -615,7 +615,7 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 		l1_page_table.entries[l1_index].l2_page_table_ref.zero0 = 0;
 		l1_page_table.entries[l1_index].l2_page_table_ref.zero1 = 0;
 		l1_page_table.entries[l1_index].l2_page_table_ref.impl_def = 0;
-		l1_page_table.entries[l1_index].l2_page_table_ref.domain = 0; /* TODO */
+		l1_page_table.entries[l1_index].l2_page_table_ref.domain = perms_attrs.domain;
 		l1_page_table.entries[l1_index].l2_page_table_ref.non_sec =
 			perms_attrs.non_sec;
 		l1_page_table.entries[l1_index].l2_page_table_ref.l2_page_table_address =
@@ -642,6 +642,13 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 			l1_page_table.entries[l1_index].l2_page_table_ref.non_sec =
 				perms_attrs.non_sec;
 		}
+
+		if (l1_page_table.entries[l1_index].l2_page_table_ref.domain !=
+		    perms_attrs.domain) {
+			l1_page_table.entries[l1_index].l2_page_table_ref.domain =
+				perms_attrs.domain;
+		}
+
 	} else if (l1_page_table.entries[l1_index].undefined.reserved != 0) {
 		/*
 		 * The matching L1 PT entry currently holds a 1 MB section entry
@@ -739,6 +746,40 @@ static void arm_mmu_l2_unmap_page(uint32_t va)
 	arm_mmu_dec_l2_table_entries(l2_page_table);
 }
 
+static void arm_mmu_map_region(const struct arm_mmu_region *region)
+{
+	uint32_t pa       = (uint32_t)region->base_pa;
+	uint32_t va       = (uint32_t)region->base_va;
+	uint32_t rem_size = (uint32_t)region->size;
+	uint32_t attrs    = region->attrs;
+	struct arm_mmu_perms_attrs perms_attrs;
+
+	perms_attrs = arm_mmu_convert_attr_flags(attrs);
+
+	while (rem_size > 0) {
+		if (rem_size >= MB(1) &&
+		    (pa & 0xFFFFF) == 0 &&
+		    (va & 0xFFFFF) == 0 &&
+		    pa == va &&
+		    (attrs & MATTR_MAY_MAP_L1_SECTION)) {
+			arm_mmu_l1_map_section(va, pa, perms_attrs);
+			rem_size -= MB(1);
+			va += MB(1);
+			pa += MB(1);
+		} else {
+			arm_mmu_l2_map_page(va, pa, perms_attrs);
+			rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
+			va += KB(4);
+			pa += KB(4);
+		}
+	}
+}
+
+void __weak z_arm_mmu_extra_regions(arm_mmu_region_func_t region_func)
+{
+	ARG_UNUSED(region_func);
+}
+
 /**
  * @brief MMU boot-time initialization function
  * Initializes the MMU at boot time. Sets up the page tables and
@@ -831,6 +872,11 @@ int z_arm_mmu_init(void)
 			}
 		}
 	}
+	/* 
+	 * Set up the user-defined extra memory regions after pre-defined 
+	 * regions in case of overwrite scenarios 
+	 */
+	z_arm_mmu_extra_regions(arm_mmu_map_region);
 
 	/* Clear TTBR1 */
 	__asm__ volatile("mcr p15, 0, %0, c2, c0, 1" : : "r"(reg_val));

--- a/include/zephyr/arch/arm/mmu/arm_mmu.h
+++ b/include/zephyr/arch/arm/mmu/arm_mmu.h
@@ -142,6 +142,9 @@ extern const struct arm_mmu_config mmu_config;
 
 int z_arm_mmu_init(void);
 
+typedef void (*arm_mmu_region_func_t)(const struct arm_mmu_region *region);
+void z_arm_mmu_extra_regions(arm_mmu_region_func_t region_func);
+
 #endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_MMU_ARM_MMU_H_ */


### PR DESCRIPTION
Boards and applications targeting ARMv7-A SoCs with MMU enabled frequently need to map peripherals not present in the upstream SoC mmu_regions[] table, or override existing entries with different attributes. As far as I know, currently the only way to achieve this is to override the entire mmu_config object with __weak, which loses all future upstream additions to the SoC table silently.

Changes: 
arch/arm/core/mmu/arm_mmu.c:
- Add arm_mmu_map_region(), a static helper that applies the same L1-section-vs-L2-page logic as z_arm_mmu_init() for a single struct arm_mmu_region, suitable for use as a callback.
- Add __weak z_arm_mmu_extra_regions(), a no-op by default, called by z_arm_mmu_init() after the mmu_config loop. When not overridden the compiler eliminates the call entirely.
- Fix arm_mmu_l2_map_page() to update the L1 entry domain field when remapping an existing region, consistent with the existing NS bit handling. Without this fix, overriding an MT_STRONGLY_ORDERED entry with MT_NORMAL left a stale DOMAIN_DEVICE in the L1 entry.

include/zephyr/arch/arm/mmu/arm_mmu.h:
- Add arm_mmu_region_func_t typedef.
- Add z_arm_mmu_extra_regions() declaration with full documentation and usage example.

Usage: 
For the Zynq7000 for instance, to add PL peripherals or override existing PS entries, create a single file in the application containing:

    void z_arm_mmu_extra_regions(arm_mmu_region_func_t region_func)
    {
        static const struct arm_mmu_region extra[] = {
            MMU_REGION_FLAT_ENTRY("pl_custom_ip",
                                  0x43C00000, 0x10000,
                                  MT_DEVICE | MATTR_SHARED |
                                  MPERM_R | MPERM_W),
        };
        for (int i = 0; i < ARRAY_SIZE(extra); i++) {
            region_func(&extra[i]);
        }
    }