### PR TITLE
Support the NXP_HAL layer's full upstreaming of SecureSubSystem

### DIFF
--- a/drivers/entropy/entropy_nxp_ele.c
+++ b/drivers/entropy/entropy_nxp_ele.c
@@ -1,7 +1,7 @@
 /* entropy_nxp_ele.c - NXP ELE entropy driver */
 
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,17 +15,74 @@
 #include <zephyr/sys/util.h>
 #include <soc.h>
 
-#include "sss_crypto.h"
+#include <fsl_sss_mgmt.h>
+#include <fsl_sss_sscp.h>
+#include <fsl_sscp_mu.h>
+
+#define ENTROPY_ELE_MAX_WAIT     (0xFFFFFFFFu)
+#define ENTROPY_ELE_QUALITY_HIGH (0u)
 
 struct entropy_ele_data_str {
 	struct k_sem sem_lock;
 };
 
+static int ele_get_session_local(sscp_context_t *sscp_ctx, sss_sscp_session_t *session)
+{
+	int result = -EIO;
+
+	__ASSERT_NO_MSG(session != NULL);
+
+	if (ELEMU_mu_wait_for_ready(ELEMUA, ENTROPY_ELE_MAX_WAIT) != kStatus_Success) {
+		goto exit;
+	}
+
+	if (sscp_mu_init(sscp_ctx, (ELEMU_Type *)(uintptr_t)ELEMUA) != kStatus_SSCP_Success) {
+		goto exit;
+	}
+
+	if (sss_sscp_open_session(session, CONFIG_MCUX_SECURE_SUBSYSTEM_SESSION_ID,
+				  kType_SSS_Ele200, sscp_ctx) != kStatus_SSS_Success) {
+		goto exit;
+	}
+
+	result = 0;
+exit:
+	return result;
+}
+
+static int entropy_ele_get_entropy_internal(uint8_t *buf, uint16_t len)
+{
+	sss_sscp_session_t session = {0};
+	sscp_context_t sscp_ctx = {0};
+	sss_sscp_rng_t rng_ctx = {0};
+	int result = -EIO;
+
+	if (ele_get_session_local(&sscp_ctx, &session) != 0) {
+		goto exit;
+	}
+
+	if (sss_sscp_rng_context_init(&session, &rng_ctx, ENTROPY_ELE_QUALITY_HIGH) !=
+	    kStatus_SSS_Success) {
+		goto exit;
+	}
+
+	if (sss_sscp_rng_get_random(&rng_ctx, buf, len) != kStatus_SSS_Success) {
+		goto exit;
+	}
+
+	if (sss_sscp_rng_free(&rng_ctx) != kStatus_SSS_Success) {
+		goto exit;
+	}
+
+	result = 0;
+exit:
+	return result;
+}
+
 static struct entropy_ele_data_str entropy_ele_data;
 
 static int entropy_ele_get_entropy(const struct device *dev, uint8_t *buf, uint16_t len)
 {
-	sss_sscp_rng_t ctx;
 	int result = -EIO;
 
 	__ASSERT_NO_MSG(buf != NULL);
@@ -33,36 +90,29 @@ static int entropy_ele_get_entropy(const struct device *dev, uint8_t *buf, uint1
 
 	k_sem_take(&entropy_ele_data.sem_lock, K_FOREVER);
 
-	if (CRYPTO_InitHardware() != kStatus_Success) {
-		goto exit;
-	}
+	result = entropy_ele_get_entropy_internal(buf, len);
 
-	if (sss_sscp_rng_context_init(&g_sssSession, &ctx, 0u) != kStatus_SSS_Success) {
-		goto exit;
-	}
-
-	if (sss_sscp_rng_get_random(&ctx, buf, len) != kStatus_SSS_Success) {
-		goto exit;
-	}
-
-	if (sss_sscp_rng_free(&ctx) != kStatus_SSS_Success) {
-		goto exit;
-	}
-
-	result = 0;
-
-exit:
 	k_sem_give(&entropy_ele_data.sem_lock);
+
 	return result;
 }
 
 static int entropy_ele_init(const struct device *dev)
 {
+	int result = -EIO;
+
 	__ASSERT_NO_MSG(&entropy_ele_data == dev->data);
 
 	k_sem_init(&entropy_ele_data.sem_lock, 1, 1);
 
-	return 0;
+	k_sem_take(&entropy_ele_data.sem_lock, K_FOREVER);
+
+	/* We request 0 data length just to initialize the TRNG */
+	result = entropy_ele_get_entropy_internal(NULL, 0);
+
+	k_sem_give(&entropy_ele_data.sem_lock);
+
+	return result;
 }
 
 static DEVICE_API(entropy, entropy_ele_api_funcs) = {.get_entropy = entropy_ele_get_entropy};

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/Kconfig
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/Kconfig
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+rsource "Kconfig.crypto"
 rsource "Kconfig.multicore"

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/Kconfig.crypto
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/Kconfig.crypto
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Zephyr-aligned Kconfig files for NXP cryptography modules
+osource "$(ZEPHYR_HAL_NXP_MODULE_DIR)/mcux/middleware/mcux-secure-subsystem/zephyr/Kconfig"

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 14d44be6e81e0e98582f9bf3eb202e055309badf
+      revision: 11340dae1c61ae2b979e708cbaf6cb7aa102b5e2
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This change updates the ELE entropy entrypoint to directly only use SSSAPI.

A new Kconfig reference is added for the Zephyr-aligned SSS Kconfig originally added to enable downstream Zephyr support.

Edit:
Related PR on NXP_HAL side https://github.com/zephyrproject-rtos/hal_nxp/pull/786

Edit 2:

### Binary blob information

- Binary blob origin
  - NXP-sourced code precompiled into an encrypted and signed firmware image.
- Type of blob (precompiled library, firmware image)
  - Encrypted and signed firmware image.
- Zephyr module that the blob(s) will be referenced from
  - NXP HAL.
- Brief description of what the blob(s) do
  - EdgeLock2Go enablement, support of additional cryptographic algorithms.
- What other components do the blob(s) depend on, if any?
  - Future PSA components, once upstreamed, may contitionally depend on these blobs (e.g. EL2GO).
  - Connectivity stacks may, for certain usecases, depend on these blobs (e.g. accelerated SPAKE2+).
- License the blob(s) are distributed under.
  - LA_OPT_Online Code Hosting NXP_Software_License - v1.4 May 2025