### PR TITLE
lorawan: improve Doxygen coverage

### DIFF
--- a/include/zephyr/lorawan/emul.h
+++ b/include/zephyr/lorawan/emul.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the LoRaWAN emulator backend APIs.
+ * @ingroup lorawan_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_LORAWAN_EMUL_H_
 #define ZEPHYR_INCLUDE_LORAWAN_EMUL_H_
 

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -107,7 +107,9 @@ enum lorawan_message_type {
  * @brief  LoRaWAN downlink flags.
  */
 enum lorawan_dl_flags {
+	/** The network server has more downlink data queued */
 	LORAWAN_DATA_PENDING = BIT(0),
+	/** The network time was updated from the network server */
 	LORAWAN_TIME_UPDATED = BIT(1),
 };
 


### PR DESCRIPTION
Add the missing `@file` block to the LoRaWAN emulator header and
document the downlink flag values.

Documentation only, no functional change.