### PR TITLE
drivers: timer: riscv: prevent timer IRQ storm on SMP with tickless k…

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -104,6 +104,8 @@ static void timer_isr(const void *arg)
 		uint64_t next = last_count + CYC_PER_TICK;
 
 		set_mtimecmp(next);
+	} else {
+		set_mtimecmp(last_count + CYCLES_MAX);
 	}
 
 	sys_clock_announce_locked(dticks, key);


### PR DESCRIPTION
…ernel

On RISC-V SMP systems using the machine timer driver with per-hart mtimecmp registers , the timer ISR can be
re-entered many times before settling, because only one CPU per announce cycle actually reprograms its own mtimecmp.

In tickless mode, timer_isr() relies on sys_clock_set_timeout() being called at the end of sys_clock_announce_locked() to reprogram the comparator. However, on SMP, the announce path has an early return:

  if (IS_ENABLED(CONFIG_SMP) && any_cpu_announcing()) {
      announce_remaining += ticks;
      k_spin_unlock(&timeout_lock, key);
      return;
  }

When multiple harts take the timer IRQ near-simultaneously (which is the common case after smp_timer_init() programs all of them to the same last_count + CYC_PER_TICK value), only the hart that wins timeout_lock runs the full announce path and reprograms its own mtimecmp via sys_clock_set_timeout(). The remaining harts take the early return and their own mtimecmp is left in the past, so the timer IRQ is re-taken immediately after mret. The storm only subsides once every hart has, at some point, been the "winner" of the announce path.

This matches the RISC-V contract that mtimecmp is per-hart (the Linux timer-clint/timer-riscv drivers also index mtimecmp by smp_processor_id()), and it is the driver's responsibility to ensure each hart's comparator is reprogrammed regardless of the kernel's global announce synchronization.

Fix it by pushing the local mtimecmp far ahead (last_count + CYCLES_MAX) before calling sys_clock_announce_locked() in tickless mode. The winning hart will refine the value via sys_clock_set_timeout(); harts that take the SMP early return keep the safe far value and stop re-firing.

The non-tickless path is unchanged: it already reprograms mtimecmp to the next tick before announcing.

The issues I brought up earlier can be found here.
https://github.com/zephyrproject-rtos/zephyr/issues/115442