### PR TITLE
audio: improve Doxygen coverage

### DIFF
--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Public API header file for Audio Codec
+ * @ingroup audio_codec_interface
  *
  * This file contains the Audio Codec APIs
  */

--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -156,13 +156,17 @@ typedef union {
 			       /* Other DAI types go here */
 } audio_dai_cfg_t;
 
-/*
+/**
  * DAI Route types
  */
 typedef enum {
+	/** Bypass, neither the playback nor the capture path is configured */
 	AUDIO_ROUTE_BYPASS,
+	/** Playback path only */
 	AUDIO_ROUTE_PLAYBACK,
+	/** Both the playback and the capture paths */
 	AUDIO_ROUTE_PLAYBACK_CAPTURE,
+	/** Capture path only */
 	AUDIO_ROUTE_CAPTURE,
 } audio_route_t;
 

--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -209,12 +209,14 @@ struct pdm_chan_cfg {
  * Input configuration structure for the DMIC configuration API
  */
 struct dmic_cfg {
+	/** PDM interface configuration */
 	struct pdm_io_cfg io;
 	/**
 	 * Array of pcm_stream_cfg for application to provide
 	 * configuration for each stream
 	 */
 	struct pcm_stream_cfg *streams;
+	/** PDM channel configuration */
 	struct pdm_chan_cfg channel;
 };
 

--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -10,6 +10,7 @@
 /**
  * @file
  * @brief Public API header file for Digital Microphones
+ * @ingroup audio_dmic_interface
  *
  * This file contains the Digital Microphone APIs
  */

--- a/include/zephyr/audio/midi.h
+++ b/include/zephyr/audio/midi.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for MIDI 2.0 Universal MIDI Packet (UMP) definitions.
+ * @ingroup midi_ump
+ */
+
 #ifndef ZEPHYR_INCLUDE_AUDIO_MIDI_H_
 #define ZEPHYR_INCLUDE_AUDIO_MIDI_H_
 


### PR DESCRIPTION
Attach the `@file` blocks of the audio headers to their Doxygen groups,
adding the missing block to the MIDI header, and document the DAI route
types and the remaining DMIC configuration members.

Documentation only, no functional change.