### PR TITLE
net: lib: wifi_credentials: fix overwriting a PSA-backed entry

### DIFF
--- a/include/zephyr/net/wifi_credentials.h
+++ b/include/zephyr/net/wifi_credentials.h
@@ -175,6 +175,9 @@ int wifi_credentials_get_by_ssid_personal(const char *ssid, size_t ssid_len,
 /**
  * @brief Set credentials for given SSID.
  *
+ * @note Storing credentials for an SSID that is already stored overwrites the existing
+ *       entry rather than adding a second one. Only distinct SSIDs consume storage slots.
+ *
  * @param[in] ssid		SSID to look for
  * @param[in] ssid_len		length of SSID
  * @param[in] type		Wi-Fi security type
@@ -213,6 +216,9 @@ int wifi_credentials_get_by_ssid_personal_struct(const char *ssid, size_t ssid_l
 
 /**
  * @brief Set credentials for given SSID by struct.
+ *
+ * @note Storing credentials for an SSID that is already stored overwrites the existing
+ *       entry rather than adding a second one. Only distinct SSIDs consume storage slots.
  *
  * @param[in] creds		credentials Pointer to struct from which credentials are loaded
  *

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
@@ -42,8 +42,14 @@ int wifi_credentials_store_entry(size_t idx, const void *buf, size_t buf_len)
 	psa_status_t ret;
 	psa_key_attributes_t key_attributes = {0};
 	psa_key_id_t key_id;
+	psa_key_id_t entry_key_id = idx + ZEPHYR_PSA_WIFI_CREDENTIALS_KEY_ID_RANGE_BEGIN;
 
-	psa_set_key_id(&key_attributes, idx + ZEPHYR_PSA_WIFI_CREDENTIALS_KEY_ID_RANGE_BEGIN);
+	ret = psa_destroy_key(entry_key_id);
+	if (ret != PSA_SUCCESS && ret != PSA_ERROR_INVALID_HANDLE) {
+		LOG_ERR("psa_destroy_key failed, err: %d", ret);
+	}
+
+	psa_set_key_id(&key_attributes, entry_key_id);
 	psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_EXPORT);
 	psa_set_key_lifetime(&key_attributes, PSA_KEY_LIFETIME_PERSISTENT);
 	psa_set_key_algorithm(&key_attributes, PSA_ALG_NONE);


### PR DESCRIPTION
wifi_credentials_set_personal_struct() reuses the index of an SSID that is already stored, so storing credentials for a known SSID asks the backend to replace the key held under that index. psa_import_key() refuses to import onto a key ID that is already taken and returns PSA_ERROR_ALREADY_EXISTS, which the backend reported as -EEXIST.
Updating the credentials of a stored network was therefore impossible, even though the library documents that adding credentials for the same SSID twice overwrites the older entry.

Destroy the key held under the entry's key ID before importing the new one. The entry keeps its index, so the documented
overwriting credentials does not change internal indices still holds.

NCSDK-40653