### PR TITLE
tests: subsys: fs: add nrf7120dk to littlefs

### DIFF
--- a/tests/subsys/fs/littlefs/boards/nrf7120dk_nrf7120_cpuapp.conf
+++ b/tests/subsys/fs/littlefs/boards/nrf7120dk_nrf7120_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE=4096

--- a/tests/subsys/fs/littlefs/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/subsys/fs/littlefs/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi00 {
+	status = "disabled";
+};
+
+&mspi00 {
+	status = "okay";
+};
+
+&mx25u25645g {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		small_partition: partition@0 {
+			label = "small";
+			reg = <0x0 0x10000>;
+		};
+	};
+};


### PR DESCRIPTION
This commit adds support for the internal flash of the nrf7120dk to tests/subsys/fs/littlefs