### PR TITLE
debug: coredump: fix z_thread_monitor_lock held across SMP dump I/O

### DIFF
--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -171,6 +171,20 @@ config DEBUG_COREDUMP_THREADS_METADATA
 	  Core dump will contain the threads metadata section containing
 	  any necessary data to enable debugging threads
 
+config DEBUG_COREDUMP_THREAD_SNAPSHOT_MAX
+	int "Maximum threads snapshotted per SMP coredump"
+	default 64
+	depends on SMP && DEBUG_COREDUMP_MEMORY_DUMP_THREADS
+	help
+	  On SMP, coredump snapshots the thread-list pointers while briefly
+	  holding z_thread_monitor_lock, then releases the lock before the slow
+	  per-thread dump I/O so a concurrent k_thread_abort() on another CPU is
+	  not stalled for the whole dump. This bounds how many threads that
+	  snapshot can hold. If the system has more monitored threads than this
+	  value the dump is truncated to the first N. Increase it to capture
+	  every thread on a system with many threads; it costs N pointers of
+	  stack on the fatal path.
+
 config DEBUG_COREDUMP_DUMP_THREAD_PRIV_STACK
 	bool "Dump privilege stack of user threads"
 	default y

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -44,6 +44,20 @@ static struct coredump_backend_api
 #define DT_DRV_COMPAT zephyr_coredump
 #endif
 
+/*
+ * Upper bound on the number of threads snapshotted (see the SMP path in
+ * process_memory_region_list()) while z_thread_monitor_lock is held, before
+ * releasing it and running the slow per-thread dump I/O lock-free. Exposed as
+ * CONFIG_DEBUG_COREDUMP_THREAD_SNAPSHOT_MAX so a system with more monitored
+ * threads than the default can capture all of them (at the cost of that many
+ * pointers of fatal-path stack); systems that exceed it dump only the first N.
+ */
+#if defined(CONFIG_DEBUG_COREDUMP_THREAD_SNAPSHOT_MAX)
+#define COREDUMP_THREAD_SNAPSHOT_MAX CONFIG_DEBUG_COREDUMP_THREAD_SNAPSHOT_MAX
+#else
+#define COREDUMP_THREAD_SNAPSHOT_MAX 64
+#endif
+
 #if defined(CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT_FOR_CURRENT) &&                           \
 	CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT_FOR_CURRENT >= 0
 #define STACK_TOP_LIMIT_FOR_CURRENT                                                                \
@@ -186,6 +200,31 @@ void process_memory_region_list(struct k_thread *current)
 #ifdef CONFIG_SMP
 		k_spinlock_key_t key = {0};
 		bool locked = false;
+		/*
+		 * Snapshot the thread pointers while holding
+		 * z_thread_monitor_lock, then release it before calling
+		 * dump_thread() for each snapshotted thread below.
+		 * dump_thread() can be slow (e.g. the UDP backend transmits
+		 * every thread's stack over the network), and holding this
+		 * lock across that I/O starves any other CPU whose thread
+		 * naturally exits while the dump is in progress: its
+		 * k_thread_abort() -> halt_thread() -> z_thread_monitor_exit()
+		 * path needs this same lock, so that CPU would spin for the
+		 * entire dump duration instead of completing a normal exit.
+		 *
+		 * Like k_thread_foreach_unlocked(), the snapshot stabilizes the
+		 * list for traversal but does not pin each thread object against
+		 * concurrent teardown once the lock is dropped. This is safe here
+		 * because it runs only from the fatal path: the panicking CPU has
+		 * IRQs locked and does not reschedule, so it cannot itself free a
+		 * thread mid-dump, and a peer CPU that aborts a thread blocks in
+		 * halt_thread() -> z_thread_monitor_exit() waiting on the very
+		 * lock this loop just released and re-derefs nothing until the
+		 * dump completes. (The freeze/thaw follow-up additionally holds
+		 * the peers frozen for the duration.)
+		 */
+		struct k_thread *snapshot[COREDUMP_THREAD_SNAPSHOT_MAX];
+		unsigned int snapshot_count = 0;
 
 		/*
 		 * Try to take z_thread_monitor_lock so the list is stable
@@ -213,22 +252,40 @@ void process_memory_region_list(struct k_thread *current)
 #else
 		locked = k_spin_trylock(&z_thread_monitor_lock, &key) == 0;
 #endif /* CONFIG_SPIN_VALIDATE */
+
+		for (thread = _kernel.threads, n = 0;
+		     (thread != NULL) && (n < max_threads);
+		     thread = thread->next_thread, n++) {
+			if (snapshot_count < COREDUMP_THREAD_SNAPSHOT_MAX) {
+				snapshot[snapshot_count++] = thread;
+			}
+			/*
+			 * If the list is longer than the snapshot capacity the
+			 * dump is truncated to the first N threads rather than
+			 * risking unbounded fatal-path stack; raise
+			 * CONFIG_DEBUG_COREDUMP_THREAD_SNAPSHOT_MAX to capture
+			 * more. A mid-dump diagnostic is deliberately not
+			 * emitted here: it would inject stray bytes into the
+			 * backend's coredump stream and break host-side parsing.
+			 */
+		}
+
+		if (locked) {
+			k_spin_unlock(&z_thread_monitor_lock, key);
+		}
+
+		for (n = 0; n < snapshot_count; n++) {
+			dump_thread(snapshot[n], snapshot[n] == current);
+		}
 #else
 		/*
 		 * On uniprocessor, IRQs are already locked by the exception
 		 * entry path so no other context can modify the list.
 		 */
-#endif /* CONFIG_SMP */
-
 		for (thread = _kernel.threads, n = 0;
 		     (thread != NULL) && (n < max_threads);
 		     thread = thread->next_thread, n++) {
 			dump_thread(thread, thread == current);
-		}
-
-#ifdef CONFIG_SMP
-		if (locked) {
-			k_spin_unlock(&z_thread_monitor_lock, key);
 		}
 #endif /* CONFIG_SMP */
 


### PR DESCRIPTION
The SMP thread-list walk in process_memory_region_list() held z_thread_monitor_lock for the entire per-thread dump loop, including each thread's dump_thread() call. For slow backends (e.g. the UDP logging backend, which transmits every thread's stack over the network) this can hold the lock for seconds.

If another CPU's thread exits naturally during that window, k_thread_abort() -> halt_thread() -> z_thread_monitor_exit() needs the same lock and spins until the entire dump completes. Confirmed on versalnet_apu_se9/amd_versalnet_apu/smp via a live backtrace showing exactly that spin (arm_gic_irq_is_pending <- arch_spin_relax <- k_spin_lock <- halt_thread <- z_impl_k_thread_abort) while CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING_UDP was mid-dump.

Snapshot the thread pointers into a small bounded array while holding the lock, then release it before calling dump_thread() for each snapshotted thread, so slow per-thread I/O never runs with the lock held. Confirmed on hardware: hs6_smp_udp_backend now completes and captures all 165 UDP datagrams cleanly, with no regression on the non-SMP path.

This is split out of https://github.com/zephyrproject-rtos/zephyr/pull/114934 per @nashif's review request 