### PR TITLE
scripts: coredump: gdbstub: add ARM64 thread-walk support

### DIFF
--- a/scripts/coredump/gdbstubs/arch/arm64.py
+++ b/scripts/coredump/gdbstubs/arch/arm64.py
@@ -8,6 +8,8 @@ import binascii
 import logging
 import struct
 
+from coredump_parser.elf_parser import ThreadInfoOffset
+
 from gdbstubs.gdbstub import GdbStub
 
 logger = logging.getLogger("gdbstub")
@@ -57,6 +59,17 @@ class GdbStub_ARM64(GdbStub):
 
     GDB_SIGNAL_DEFAULT = 7
     GDB_G_PKT_NUM_REGS = 33
+
+    # struct _callee_saved (include/zephyr/arch/arm64/thread.h): 14 uint64_t
+    # fields -- x19..x29, sp_el0, sp_elx, lr -- saved directly into the
+    # k_thread struct by z_arm64_context_switch() (arch/arm64/core/switch.S)
+    # for any thread that isn't currently running. Not individually exposed
+    # via the generic thread-info offsets table (only sp_elx is, as
+    # THREAD_INFO_OFFSET_T_STACK_PTR), so the struct base is derived from
+    # that single known offset instead.
+    CALLEE_SAVED_STRUCT = "<" + ("Q" * 14)
+    CALLEE_SAVED_SIZE = struct.calcsize(CALLEE_SAVED_STRUCT)
+    CALLEE_SAVED_SP_ELX_INDEX = 12  # 0-based index of sp_elx within the struct
 
     def __init__(self, logfile, elffile):
         super().__init__(logfile=logfile, elffile=elffile)
@@ -111,15 +124,15 @@ class GdbStub_ARM64(GdbStub):
         else:
             logger.debug("LR=0x%016x PC=0x%016x (no FP/SP)", tu[19], tu[21])
 
-    def handle_register_group_read_packet(self):
+    def send_registers_packet(self, registers):
         reg_fmt = "<Q"
 
         idx = 0
         pkt = b''
 
         while idx < self.GDB_G_PKT_NUM_REGS:
-            if idx in self.registers:
-                bval = struct.pack(reg_fmt, self.registers[idx])
+            if idx in registers:
+                bval = struct.pack(reg_fmt, registers[idx])
                 pkt += binascii.hexlify(bval)
             else:
                 # Register not in coredump -> unknown value
@@ -130,9 +143,69 @@ class GdbStub_ARM64(GdbStub):
 
         self.put_gdb_packet(pkt)
 
+    def handle_register_group_read_packet(self):
+        if not self.elffile.has_kernel_thread_info():
+            self.send_registers_packet(self.registers)
+        else:
+            self.handle_thread_register_group_read_packet()
+
     def handle_register_single_read_packet(self, pkt):
         # Mark registers as "<unavailable>".
         # 'p' packets are usually used for registers
         # other than the general ones (e.g. eax, ebx)
         # so we can safely reply "xxxxxxxx" here.
         self.put_gdb_packet(b'x' * 16)
+
+    def arch_supports_thread_operations(self):
+        return True
+
+    def handle_thread_register_group_read_packet(self):
+        # For selected_thread 0, use the register data retrieved from the
+        # dump's arch section (the faulting/current thread's real ESF).
+        if self.selected_thread == 0:
+            self.send_registers_packet(self.registers)
+            return
+
+        thread_ptr = self.thread_ptrs[self.selected_thread]
+
+        # THREAD_INFO_OFFSET_T_STACK_PTR is offsetof(k_thread, callee_saved.sp_elx)
+        # on ARM64 (see subsys/debug/thread_info.c) -- back out the base of
+        # the callee_saved struct from it so the rest of its fields can be
+        # read too.
+        t_stack_ptr_offset = self.elffile.get_kernel_thread_info_offset(
+            ThreadInfoOffset.THREAD_INFO_OFFSET_T_STACK_PTR
+        )
+        callee_saved_offset = t_stack_ptr_offset - (self.CALLEE_SAVED_SP_ELX_INDEX * 8)
+
+        barray = self.get_memory(thread_ptr + callee_saved_offset, self.CALLEE_SAVED_SIZE)
+
+        thread_registers = dict()
+
+        if barray is not None:
+            tu = struct.unpack(self.CALLEE_SAVED_STRUCT, barray)
+
+            thread_registers[RegNum.X19] = tu[0]
+            thread_registers[RegNum.X20] = tu[1]
+            thread_registers[RegNum.X21] = tu[2]
+            thread_registers[RegNum.X22] = tu[3]
+            thread_registers[RegNum.X23] = tu[4]
+            thread_registers[RegNum.X24] = tu[5]
+            thread_registers[RegNum.X25] = tu[6]
+            thread_registers[RegNum.X26] = tu[7]
+            thread_registers[RegNum.X27] = tu[8]
+            thread_registers[RegNum.X28] = tu[9]
+            thread_registers[RegNum.X29] = tu[10]
+            # tu[11] is sp_el0 (EL0/userspace stack, unused by kernel-only
+            # threads) -- not mapped to a GDB register slot.
+            sp_elx = tu[12]
+            lr = tu[13]
+
+            thread_registers[RegNum.SP_EL0] = sp_elx  # SP to unwind from
+            thread_registers[RegNum.LR] = lr
+            # A non-running thread resumes via `ret` inside
+            # z_arm64_context_switch(), i.e. execution continues at the
+            # saved LR -- use it as PC so GDB can unwind from where the
+            # thread will resume.
+            thread_registers[RegNum.PC] = lr
+
+        self.send_registers_packet(thread_registers)

--- a/scripts/coredump/gdbstubs/gdbstub.py
+++ b/scripts/coredump/gdbstubs/gdbstub.py
@@ -249,7 +249,10 @@ class GdbStub(abc.ABC):
                     thread_index_str += chr(pkt[n])
 
                 thread_id = int(thread_index_str, 16)
-                if len(self.thread_ptrs) > thread_id:
+                # thread_id is 1-based and indexed below as thread_id - 1, so the
+                # last valid id equals len(self.thread_ptrs); use >= to include it
+                # (a bare > dropped the final thread's name/state in info threads).
+                if len(self.thread_ptrs) >= thread_id:
                     thread_info_bytes += b'name: '
                     thread_ptr = self.thread_ptrs[thread_id - 1]
                     t_name_offset = self.elffile.get_kernel_thread_info_offset(


### PR DESCRIPTION
GdbStub_ARM64 never implemented arch_supports_thread_operations(), so it always inherited the base class's `return False`. In practice this meant `info threads` in GDB only ever showed the single faulting thread, even for CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS dumps that structurally contain every thread's k_thread struct and stack -- the data was already there, this script just had no path to expose it.

Add that path by reading each non-current thread's saved context out of its k_thread.callee_saved struct. On ARM64,
z_arm64_context_switch() (arch/arm64/core/switch.S) stores a non-running thread's x19-x29, sp_elx, and lr directly into that struct (unlike Cortex-M, which pushes a hardware exception frame onto the thread's own stack), and a resumed thread continues via `ret` using the saved lr, so lr doubles as the thread's resume PC.

The generic thread-info offsets table (subsys/debug/thread_info.c) only exposes sp_elx individually, as
THREAD_INFO_OFFSET_T_STACK_PTR = offsetof(k_thread, callee_saved.sp_elx). Derive the base of the callee_saved struct from that single offset instead of adding new table entries, keeping this a self-contained script change.

Validated on versalnet_apu_se9 hardware coredumps: non-SMP THREADS-mode scenarios now enumerate all threads (e.g. 10 for the coredump_threads ztest: 7 worker threads, test_crash, idle, main) with correct names and distinct, semantically valid backtraces, with no change to MIN/LINKER_RAM or SMP scenarios (which have no thread-list data to walk in the first place).

This is split out of https://github.com/zephyrproject-rtos/zephyr/pull/114934 per @nashif's review request