### PR TITLE
debug: coredump: make DEBUG_THREAD_INFO SMP-safe and enumerate per-CPU threads

### DIFF
--- a/scripts/coredump/coredump_parser/elf_parser.py
+++ b/scripts/coredump/coredump_parser/elf_parser.py
@@ -36,6 +36,8 @@ class ThreadInfoOffset(IntEnum):
     THREAD_INFO_OFFSET_T_COOP_FLOAT = 12
     THREAD_INFO_OFFSET_T_ARM_EXC_RETURN = 13
     THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE = 14
+    THREAD_INFO_OFFSET_CPU_STRIDE = 15
+    THREAD_INFO_OFFSET_NUM_CPUS = 16
 
     def __int__(self):
         return self.value
@@ -78,10 +80,14 @@ class CoredumpElfFile:
         return self.kernel_thread_info_offsets is not None
 
     def get_kernel_thread_info_offset(self, thread_info_offset_index):
+        # Check against the count actually read from this target's binary
+        # (_kernel_thread_info_num_offsets), not a hardcoded ceiling: an
+        # older build may have fewer elements than this script knows about,
+        # and a newer field (e.g. THREAD_INFO_OFFSET_NUM_CPUS) must degrade
+        # to "not present" rather than reading garbage/out-of-bounds.
         if (
             self.has_kernel_thread_info()
-            and thread_info_offset_index
-            <= ThreadInfoOffset.THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE
+            and thread_info_offset_index < self.kernel_thread_info_num_offsets
         ):
             return self.kernel_thread_info_offsets[thread_info_offset_index]
         else:

--- a/scripts/coredump/gdbstubs/gdbstub.py
+++ b/scripts/coredump/gdbstubs/gdbstub.py
@@ -185,18 +185,39 @@ class GdbStub(abc.ABC):
 
                 size_t_size = self.elffile.get_kernel_thread_info_size_t_size()
 
-                # First, find and store the thread that _kernel considers current
+                # First, find and store the thread each CPU considers current.
+                # On SMP targets whose offsets table includes CPU_STRIDE/
+                # NUM_CPUS this is one thread per CPU; older or non-SMP
+                # targets don't have those two entries
+                # (get_kernel_thread_info_offset() returns None), so this
+                # degrades to the original single-CPU behavior.
                 k_curr_thread_offset = self.elffile.get_kernel_thread_info_offset(
                     ThreadInfoOffset.THREAD_INFO_OFFSET_K_CURR_THREAD
                 )
-                curr_thread_ptr_bytes = threads_metadata_data[
-                    k_curr_thread_offset : (k_curr_thread_offset + size_t_size)
-                ]
-                curr_thread_ptr = int.from_bytes(curr_thread_ptr_bytes, "little")
-                self.thread_ptrs.append(curr_thread_ptr)
+                cpu_stride = self.elffile.get_kernel_thread_info_offset(
+                    ThreadInfoOffset.THREAD_INFO_OFFSET_CPU_STRIDE
+                )
+                num_cpus = self.elffile.get_kernel_thread_info_offset(
+                    ThreadInfoOffset.THREAD_INFO_OFFSET_NUM_CPUS
+                )
+                if cpu_stride is None or num_cpus is None:
+                    cpu_stride = 0
+                    num_cpus = 1
 
-                thread_count = 1
-                response = b"m1"
+                curr_thread_ptrs = list()
+                for cpu in range(num_cpus):
+                    offset = k_curr_thread_offset + cpu * cpu_stride
+                    ptr_bytes = threads_metadata_data[offset : (offset + size_t_size)]
+                    ptr = int.from_bytes(ptr_bytes, "little")
+                    if ptr != 0 and ptr not in curr_thread_ptrs:
+                        curr_thread_ptrs.append(ptr)
+
+                self.thread_ptrs.extend(curr_thread_ptrs)
+
+                thread_count = len(curr_thread_ptrs)
+                response = b"m" + bytes(f'{1:x}', 'ascii')
+                for i in range(2, thread_count + 1):
+                    response += b"," + bytes(f'{i:x}', 'ascii')
 
                 # Next, find the pointer to the linked list of threads in the _kernel struct
                 k_threads_offset = self.elffile.get_kernel_thread_info_offset(
@@ -207,10 +228,10 @@ class GdbStub(abc.ABC):
                 ]
                 thread_ptr = int.from_bytes(thread_ptr_bytes, "little")
 
-                if thread_ptr != curr_thread_ptr:
+                if thread_ptr not in curr_thread_ptrs:
                     self.thread_ptrs.append(thread_ptr)
                     thread_count += 1
-                    response += b"," + bytes(str(thread_count), 'ascii')
+                    response += b"," + bytes(f'{thread_count:x}', 'ascii')
 
                 # Next walk the linked list, counting the number of threads and construct
                 # the response for qfThreadInfo along the way
@@ -228,7 +249,7 @@ class GdbStub(abc.ABC):
                             thread_ptr = None
                             continue
 
-                        if thread_ptr != curr_thread_ptr:
+                        if thread_ptr not in curr_thread_ptrs:
                             self.thread_ptrs.append(thread_ptr)
                             thread_count += 1
                             response += b"," + bytes(f'{thread_count:x}', 'ascii')

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -337,15 +337,18 @@ config EXCEPTION_STACK_TRACE
 #
 config DEBUG_THREAD_INFO
 	bool "Thread awareness support"
-	depends on !SMP
 	select THREAD_MONITOR
 	select THREAD_NAME
 	help
 	  This option exports an array of offsets to kernel structs to allow
 	  for debugger RTOS plugins to determine the state of running threads.
-	  Not supported on SMP: thread_info.c exports K_CURR_THREAD which
-	  only reflects cpus[0].current, confusing live RTOS debugger plugins
-	  on multi-core systems.
+	  On SMP, thread_info.c's K_CURR_THREAD offset by itself only reflects
+	  cpus[0].current; CPU_STRIDE and NUM_CPUS are also exported so a
+	  debugger plugin that knows about them can read every CPU's current
+	  thread (cpus[i].current = K_CURR_THREAD + i * CPU_STRIDE). A plugin
+	  that doesn't know about them simply keeps seeing cpus[0] only, same
+	  as before -- these two entries are additions, not a change to the
+	  meaning of any existing one.
 
 rsource "coredump/Kconfig"
 rsource "symtab/Kconfig"

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -121,17 +121,14 @@ config DEBUG_COREDUMP_MEMORY_DUMP_THREADS
 	bool "Threads"
 	depends on ARCH_SUPPORTS_COREDUMP_THREADS
 	select THREAD_STACK_INFO
-	select DEBUG_THREAD_INFO if !SMP
-	select THREAD_MONITOR if SMP
+	select DEBUG_THREAD_INFO
 	select DEBUG_COREDUMP_THREADS_METADATA
 	help
 	  Dumps the thread struct and stack of all
 	  threads and all data required to debug threads.
 	  On SMP systems all per-CPU ISR stacks are included.
-	  On non-SMP systems DEBUG_THREAD_INFO is also selected, providing
-	  kernel struct offsets for offline GDB thread enumeration.
-	  On SMP systems only THREAD_MONITOR is selected (DEBUG_THREAD_INFO
-	  is not SMP-safe due to the K_CURR_THREAD offset in thread_info.c).
+	  DEBUG_THREAD_INFO provides kernel struct offsets for offline GDB
+	  thread enumeration on both SMP and non-SMP systems.
 
 config DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM
 	bool "RAM defined by linker section"
@@ -165,8 +162,7 @@ config DEBUG_COREDUMP_SHELL
 config DEBUG_COREDUMP_THREADS_METADATA
 	bool "Threads metadata"
 	depends on ARCH_SUPPORTS_COREDUMP_THREADS
-	select DEBUG_THREAD_INFO if !SMP
-	select THREAD_MONITOR if SMP
+	select DEBUG_THREAD_INFO
 	help
 	  Core dump will contain the threads metadata section containing
 	  any necessary data to enable debugging threads

--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -25,11 +25,9 @@ enum {
 	THREAD_INFO_OFFSET_T_COOP_FLOAT,
 	THREAD_INFO_OFFSET_T_ARM_EXC_RETURN,
 	THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE,
+	THREAD_INFO_OFFSET_CPU_STRIDE,
+	THREAD_INFO_OFFSET_NUM_CPUS,
 };
-
-#if CONFIG_MP_MAX_NUM_CPUS > 1
-#error "This code doesn't work properly with multiple CPUs enabled"
-#endif
 
 /* Forward-compatibility notes: 1) Only append items to this table; otherwise
  * debugger plugin versions that expect fewer items will read garbage values.
@@ -157,6 +155,18 @@ const size_t _kernel_thread_info_offsets[] = {
 #else
 	[THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE] = THREAD_INFO_UNIMPLEMENTED,
 #endif /* CONFIG_ARC */
+
+	/*
+	 * THREAD_INFO_OFFSET_K_CURR_THREAD above is offsetof(struct _cpu,
+	 * current), applied directly to the dumped struct z_kernel -- this
+	 * only gives cpus[0].current, because struct _cpu cpus[] is the
+	 * first field of struct z_kernel (offset 0) on every arch. On SMP,
+	 * every other CPU's current thread is at
+	 * K_CURR_THREAD_offset + i * CPU_STRIDE for i in [1, NUM_CPUS).
+	 * On non-SMP, NUM_CPUS is 1 and these are unused.
+	 */
+	[THREAD_INFO_OFFSET_CPU_STRIDE] = sizeof(struct _cpu),
+	[THREAD_INFO_OFFSET_NUM_CPUS] = CONFIG_MP_MAX_NUM_CPUS,
 };
 
 extern const size_t __attribute__((alias("_kernel_thread_info_offsets")))


### PR DESCRIPTION
Makes DEBUG_THREAD_INFO usable on SMP and teaches the host-side coredump scripts to enumerate one current thread per CPU.
  Previously DEBUG_THREAD_INFO carried depends on !SMP and thread_info.c #error'd out for CONFIG_MP_MAX_NUM_CPUS > 1, so
  offline GDB thread enumeration from a coredump was unavailable on multi-core targets — even though the THREADS-mode dump
  already contains every thread's k_thread struct and stack.

  This is split out of #114934 per @nashif's review request 
  (https://github.com/zephyrproject-rtos/zephyr/pull/114934#issuecomment) to keep this low-risk, independently-useful piece
  separate from the freeze/thaw machinery. It is self-contained and can merge on its own.

  What changes

  Target (subsys/debug)
  • Drop DEBUG_THREAD_INFO's depends on !SMP and remove the #error in thread_info.c.
  • Append two new offset-table entries — CPU_STRIDE (sizeof(struct _cpu)) and NUM_CPUS (CONFIG_MP_MAX_NUM_CPUS) — so a
    consumer can compute every CPU's current thread as cpus[i].current = K_CURR_THREAD + i * CPU_STRIDE.
  • DEBUG_COREDUMP_MEMORY_DUMP_THREADS / DEBUG_COREDUMP_THREADS_METADATA now select DEBUG_THREAD_INFO unconditionally
    instead of falling back to THREAD_MONITOR on SMP.

  Host (scripts/coredump)
  • gdbstub.py: the qfThreadInfo walk enumerates one current thread per CPU instead of one total.
  • elf_parser.py: exposes the two new entries and bounds get_kernel_thread_info_offset() by the count actually read from
    the target binary (instead of a hardcoded ceiling).

  Backward compatibility

  The two offset entries are append-only, so they don't change the interpretation of any existing offset:
  • A debugger plugin / older host script that doesn't know about them keeps seeing cpus[0] only, exactly as before.
  • On non-SMP or older builds, elf_parser returns None for the new entries and gdbstub.py degrades to the original
    single-CPU behavior.
