### PR TITLE
scripts: dts: edtlib: interrupt-parent case for min-len/max-len

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1850,6 +1850,13 @@ class Node:
         if prop_min_len is not None or prop_max_len is not None:
             if isinstance(val, (list, bytes)):
                 val_len = len(val)
+
+                # "interrupts" is specific since it's a int array of phandle arguments implicitly
+                # related to a common controller. We need to consider the controller cells size.
+                if name == "interrupts":
+                    interrupt_cells = _interrupt_cells(_interrupt_parent(self._node))
+                    val_len = val_len // interrupt_cells
+
                 if prop_min_len is not None and val_len < prop_min_len:
                     _err(f"value of property '{name}' on {self.path} in "
                          f"{self.edt.dts_path} has length {val_len}, which is less than the "

--- a/scripts/dts/python-devicetree/tests/test-bindings/interrupt-3-cell-consumer.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/interrupt-3-cell-consumer.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Consumer of interrupt controller with three cells
+
+compatible: "interrupt-3-cell-consumer"
+
+properties:
+  interrupts:
+    type: array
+    min-len: 2
+    max-len: 3
+
+  interrupt-names:
+    type: string-array

--- a/scripts/dts/python-devicetree/tests/test-bindings/min-max-len.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/min-max-len.yaml
@@ -27,3 +27,8 @@ properties:
     type: uint8-array
     min-len: 2
     max-len: 4
+
+  interrupts:
+    type: array
+    min-len: 2
+    max-len: 3

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -21,6 +21,7 @@
 		};
 
 		node {
+			compatible = "interrupt-3-cell-consumer";
 			interrupts = <1 2 3 4 5 6>;
 			interrupt-names = "foo", "bar";
 			interrupt-parent = <&{/interrupt-parent-test/controller}>;

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -1083,6 +1083,48 @@ def test_prop_range_len_errs(tmp_path):
         f"{str(dts_file)} has length 1, which is less than the "
         f"'min-len' value in {binding_path} (2)")
 
+    # interrupts specific: get #interrupt-cells from parent interrupt controller
+    write_and_check(
+        """\
+/dts-v1/;
+/ {
+	controller {
+		interrupt-controller;
+		#interrupt-cells = <3>;
+	};
+
+    itr-range-len-node {
+        compatible = "min-max-len";
+		interrupt-parent = <&{/controller}>;
+        interrupts = <1 2 3 4 5 6 7 8 9 10 11 12>;
+    };
+};
+""",
+        f"value of property 'interrupts' on /itr-range-len-node in "
+        f"{str(dts_file)} has length 4, which is greater than the "
+        f"'max-len' value in {binding_path} (3)")
+
+    # interrupts specific: get #interrupt-cells from parent interrupt controller
+    write_and_check(
+        """\
+/dts-v1/;
+/ {
+	controller {
+		interrupt-controller;
+		#interrupt-cells = <3>;
+	};
+
+    itr-range-len-node {
+        compatible = "min-max-len";
+		interrupt-parent = <&{/controller}>;
+        interrupts = <1 2 3>;
+    };
+};
+""",
+        f"value of property 'interrupts' on /itr-range-len-node in "
+        f"{str(dts_file)} has length 1, which is less than the "
+        f"'min-len' value in {binding_path} (2)")
+
 def test_prop_range_binding_errs(tmp_path):
     '''Test errors in binding definitions with invalid min:/max:'''
 


### PR DESCRIPTION
Consider the interrupt controller cells size when checking `min-len`/`max-len` over an `interrupts` DT property.

~~Allow `interrupts-extended` DT property to define an `interrupts` DT property set as `required`.~~
*(edited): Initially planned but there is more to handle to consider `interrupts` and `interrupt-extended` as alternate properties for a common purpose.*
