### PR TITLE
soc: espressif: make __rom_region_size absolute for PMP

### DIFF
--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -952,7 +952,7 @@ SECTIONS
     /* Align for PMP granularity requirements */
     MPU_MIN_SIZE_ALIGN
     __rom_region_end = ABSOLUTE(.);
-    __rom_region_size = __rom_region_end - __rom_region_start;
+    __rom_region_size = ABSOLUTE(__rom_region_end - __rom_region_start);
     _etext = .;
 
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -911,7 +911,7 @@ SECTIONS
     /* Align for PMP granularity requirements */
     MPU_MIN_SIZE_ALIGN
     __rom_region_end = ABSOLUTE(.);
-    __rom_region_size = __rom_region_end - __rom_region_start;
+    __rom_region_size = ABSOLUTE(__rom_region_end - __rom_region_start);
     _etext = .;
 
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)

--- a/soc/espressif/esp32p4/default.ld
+++ b/soc/espressif/esp32p4/default.ld
@@ -911,7 +911,7 @@ SECTIONS
     /* Align for PMP granularity requirements */
     MPU_MIN_SIZE_ALIGN
     __rom_region_end = ABSOLUTE(.);
-    __rom_region_size = __rom_region_end - __rom_region_start;
+    __rom_region_size = ABSOLUTE(__rom_region_end - __rom_region_start);
     _etext = .;
 
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
## Summary

- Force `__rom_region_size` to be an absolute linker symbol on ESP32-C5, ESP32-C6, and ESP32-P4.
- Without `ABSOLUTE()`, the symbol is section-relative inside the ROM output section, so PMP init treats its ELF value as a size and programs an oversized ROM TOR entry that can cover the peripheral window (`0x60000000+`).
- The incorrect map did not show up as a boot failure on physical SoCs in practice; it was caught while bringing up Espressif’s QEMU fork for ESP32-C6 (QEMU support for Zephyr will be proposed upstream separately).

## Problem

In `soc/espressif/esp32{c5,c6,p4}/default.ld`, `__rom_region_size` is assigned inside an output section as:

```ld
__rom_region_size = __rom_region_end - __rom_region_start;
```

GNU ld then emits a **section-relative** ELF symbol. Zephyr’s RISC-V PMP setup uses `(size_t)&__rom_region_size` (equivalently the symbol’s address) as the ROM region length when installing the TOR entry. That turns a small flash span (e.g. `0x3160`) into a huge top address (`0x42000000 + 0x42003160 = 0x84003160`), overlapping MMIO.

## Fix

```ld
__rom_region_size = ABSOLUTE(__rom_region_end - __rom_region_start);
```

Same change in the three affected Espressif RISC-V linker scripts.

## Test plan

- [x] Rebuilt `samples/hello_world` for `esp32c6_devkitc/esp32c6/hpcore` before and after the change; compared `zephyr.map` / `readelf`.
- [x] **Before** (`__rom_region_size` section-relative — value equals `__rom_region_end` / section VMA, not the size):

```text
0x42003160                        __rom_region_end = ABSOLUTE (.)
0x42003160                        __rom_region_size = (__rom_region_end - __rom_region_start)
0x42003160                        _etext = .
```

`readelf -s`: `__rom_region_size` → `42003160` in section `.flash.text` (not `ABS`).

- [x] **After** (absolute size `0x3160`):

```text
0x42003160                        __rom_region_end = ABSOLUTE (.)
0x00003160                        __rom_region_size = ABSOLUTE ((__rom_region_end - __rom_region_start))
0x42003160                        _etext = .
```

`readelf -s`: `__rom_region_size` → `00003160 ABS`.

- [x] ESP32-C6 boots to Hello World under Espressif QEMU after the fix (previously Store/AMO access fault in `pmu_init` when the oversized ROM PMP entry was active).