### PR TITLE
board: nordic: nrf93m1dk: migrate to new nrf-clock dt layout

### DIFF
--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_common.dtsi
@@ -103,6 +103,18 @@
 	status = "okay";
 };
 
+&xo {
+	status = "okay";
+};
+
+&lfclk {
+	status = "okay";
+
+	/* DK does no have 32kHz crystal, use the internal RC oscillator */
+	k32src = "rc";
+	k32src-accuracy-ppm = <250>;
+};
+
 &gpregret1 {
 	status = "okay";
 

--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_defconfig
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2026 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-# DK does no have 32kHz crystal, use the internal RC oscillator
-CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
-
 # Enable UART driver
 CONFIG_SERIAL=y
 

--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_ns_defconfig
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_ns_defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2026 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-# DK does no have 32kHz crystal, use the internal RC oscillator
-CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
-
 CONFIG_ARM_MPU=y
 CONFIG_ARM_TRUSTZONE_M=y
 

--- a/boards/nordic/nrf93m1dk/pre_dt_board.cmake
+++ b/boards/nordic/nrf93m1dk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@X010e000 & clock@X010e000 & xo@X010e000 & lfclk@X010e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
The nrf93m1dk was not migrated to the new nrf-clock dt layout added with #104658. This commits migrates it.