### PR TITLE
scripts: dts: only warn on a locally declared required default

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -426,7 +426,15 @@ If property ``foo`` is missing in a matching node, then the output will be as
 if ``foo = <3>;`` had appeared in the DTS (except YAML data types are used for
 the default value).
 
-Note that combining ``default:`` with ``required: true`` will raise an error.
+Note that a binding which declares both ``default:`` and ``required: true``
+for the same property will produce a warning, since the two settings are
+redundant: ``required: true`` already fails the build when the property is
+missing, so the default can never apply. A binding may still override an
+inherited ``default:`` with ``required: true`` to force an explicit value;
+this is well defined and is not reported. A binding which is only ever
+reached through ``include:`` is not loaded on its own during a build, so
+the warning for it is seen when the documentation is generated rather
+than when an application is built.
 
 For rules related to ``default`` in upstream Zephyr bindings, see
 :ref:`dt-bindings-default-rules`.

--- a/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
+++ b/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
@@ -11,14 +11,12 @@ include: [auxdisplay-device.yaml, i2c-device.yaml]
 properties:
   columns:
     type: int
-    default: 16
     enum:
       - 16
       - 20
 
   rows:
     type: int
-    default: 2
     enum:
       - 2
       - 4

--- a/dts/bindings/gpio/adi,max14906-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14906-gpio.yaml
@@ -11,7 +11,6 @@ properties:
     const: 2
   ngpios:
     type: int
-    required: true
     const: 4
     description: Number of gpios supported
   drdy-gpios:

--- a/dts/bindings/gpio/adi,max14916-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14916-gpio.yaml
@@ -11,7 +11,6 @@ properties:
     const: 2
   ngpios:
     type: int
-    required: true
     const: 8
     description: Number of gpios supported
   drdy-gpios:

--- a/dts/bindings/gpio/adi,max14917-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14917-gpio.yaml
@@ -10,7 +10,6 @@ properties:
     const: 2
   ngpios:
     type: int
-    required: true
     const: 8
     description: Number of gpios supported
   vddok-gpios:

--- a/dts/bindings/gpio/adi,max2219x-base-gpio.yaml
+++ b/dts/bindings/gpio/adi,max2219x-base-gpio.yaml
@@ -9,7 +9,6 @@ properties:
     const: 2
   ngpios:
     type: int
-    required: true
     const: 8
     description: Number of gpios supported
   drdy-gpios:

--- a/dts/bindings/gpio/cypress,cy8c95xx-gpio-port.yaml
+++ b/dts/bindings/gpio/cypress,cy8c95xx-gpio-port.yaml
@@ -15,7 +15,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 8
 
 gpio-cells:

--- a/dts/bindings/gpio/diodes,pi4ioe5v6408.yaml
+++ b/dts/bindings/gpio/diodes,pi4ioe5v6408.yaml
@@ -20,7 +20,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 8
 
   int-gpios:

--- a/dts/bindings/gpio/infineon,tle9104-gpio.yaml
+++ b/dts/bindings/gpio/infineon,tle9104-gpio.yaml
@@ -18,7 +18,6 @@ properties:
 
   ngpios:
     type: int
-    required: true
     const: 4
     description: Number of GPIOs supported
 

--- a/dts/bindings/gpio/nxp,pca6408.yaml
+++ b/dts/bindings/gpio/nxp,pca6408.yaml
@@ -6,5 +6,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 8

--- a/dts/bindings/gpio/nxp,pca6416.yaml
+++ b/dts/bindings/gpio/nxp,pca6416.yaml
@@ -6,5 +6,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 16

--- a/dts/bindings/gpio/nxp,pca9538.yaml
+++ b/dts/bindings/gpio/nxp,pca9538.yaml
@@ -8,5 +8,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 8

--- a/dts/bindings/gpio/nxp,pca9539.yaml
+++ b/dts/bindings/gpio/nxp,pca9539.yaml
@@ -8,5 +8,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 16

--- a/dts/bindings/gpio/nxp,pca9554.yaml
+++ b/dts/bindings/gpio/nxp,pca9554.yaml
@@ -8,5 +8,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 8

--- a/dts/bindings/gpio/nxp,pca9555.yaml
+++ b/dts/bindings/gpio/nxp,pca9555.yaml
@@ -8,5 +8,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 16

--- a/dts/bindings/gpio/nxp,pcal6408.yaml
+++ b/dts/bindings/gpio/nxp,pcal6408.yaml
@@ -6,5 +6,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 8

--- a/dts/bindings/gpio/nxp,pcal6408a.yaml
+++ b/dts/bindings/gpio/nxp,pcal6408a.yaml
@@ -10,5 +10,4 @@ include: nxp,pcal64xxa-base.yaml
 
 properties:
   ngpios:
-    required: true
     const: 8

--- a/dts/bindings/gpio/nxp,pcal6416.yaml
+++ b/dts/bindings/gpio/nxp,pcal6416.yaml
@@ -6,5 +6,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 16

--- a/dts/bindings/gpio/nxp,pcal6416a.yaml
+++ b/dts/bindings/gpio/nxp,pcal6416a.yaml
@@ -9,5 +9,4 @@ include: nxp,pcal64xxa-base.yaml
 
 properties:
   ngpios:
-    required: true
     const: 16

--- a/dts/bindings/gpio/nxp,pcal6524.yaml
+++ b/dts/bindings/gpio/nxp,pcal6524.yaml
@@ -8,5 +8,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 24

--- a/dts/bindings/gpio/nxp,pcal9538.yaml
+++ b/dts/bindings/gpio/nxp,pcal9538.yaml
@@ -6,5 +6,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 8

--- a/dts/bindings/gpio/nxp,pcal9539.yaml
+++ b/dts/bindings/gpio/nxp,pcal9539.yaml
@@ -6,5 +6,4 @@ include: nxp,pca_series.yaml
 
 properties:
   ngpios:
-    required: true
     const: 16

--- a/dts/bindings/gpio/nxp,pcal9722.yaml
+++ b/dts/bindings/gpio/nxp,pcal9722.yaml
@@ -25,7 +25,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 22
 
 gpio-cells:

--- a/dts/bindings/gpio/nxp,pcf857x.yaml
+++ b/dts/bindings/gpio/nxp,pcf857x.yaml
@@ -11,7 +11,6 @@ include: [i2c-device.yaml, gpio-controller.yaml]
 
 properties:
   ngpios:
-    required: true
     enum:
       - 8
       - 16

--- a/dts/bindings/gpio/nxp,sc18im704-gpio.yaml
+++ b/dts/bindings/gpio/nxp,sc18im704-gpio.yaml
@@ -13,7 +13,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 8
 
 gpio-cells:

--- a/dts/bindings/gpio/nxp,sc18is606-gpio.yaml
+++ b/dts/bindings/gpio/nxp,sc18is606-gpio.yaml
@@ -15,7 +15,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 3
 
 gpio-cells:

--- a/dts/bindings/gpio/raspberrypi,bcm283x-gpio.yaml
+++ b/dts/bindings/gpio/raspberrypi,bcm283x-gpio.yaml
@@ -9,7 +9,6 @@ include: [gpio-controller.yaml, base.yaml]
 
 properties:
   ngpios:
-    required: true
     const: 8
 
   "#gpio-cells":

--- a/dts/bindings/gpio/semtech,sx1509b.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b.yaml
@@ -12,7 +12,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 16
 
   nint-gpios:

--- a/dts/bindings/gpio/ti,ads1x4s0x-gpio.yaml
+++ b/dts/bindings/gpio/ti,ads1x4s0x-gpio.yaml
@@ -18,7 +18,6 @@ properties:
 
   ngpios:
     type: int
-    required: true
     const: 4
     description: Number of gpios supported
 

--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -13,7 +13,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 8
     description: |
       Number of GPIOs available on port expander.

--- a/dts/bindings/gpio/x-powers,axp192-gpio.yaml
+++ b/dts/bindings/gpio/x-powers,axp192-gpio.yaml
@@ -25,7 +25,6 @@ properties:
     const: 2
 
   ngpios:
-    required: true
     const: 6
     description: |
       Number of GPIOs available on axp192.

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -101,6 +101,16 @@ def _compute_hash(path: str) -> str:
     hasher.update(path.encode())
     return base64.b64encode(hasher.digest(), altchars=b'__').decode().rstrip('=')
 
+
+@dataclass
+class _LocalProps:
+    # The properties a binding declares on its own, before any
+    # 'include:' is merged in, and the same for its 'child-binding:'.
+
+    props: dict
+    child: Optional["_LocalProps"]
+
+
 #
 # Public classes
 #
@@ -201,7 +211,8 @@ class Binding:
 
     def __init__(self, path: Optional[str], fname2path: dict[str, str],
                  raw: Any = None, require_compatible: bool = True,
-                 require_description: bool = True, require_title: bool = False):
+                 require_description: bool = True, require_title: bool = False,
+                 local_props: Optional[_LocalProps] = None):
         """
         Binding constructor.
 
@@ -235,6 +246,12 @@ class Binding:
           "title:" line. If False, a missing "title:" is not an error.
           Either way, "title:" must be a string if it is present in
           the binding.
+
+        local_props:
+          Optional properties declared before any "include:" was merged
+          in. Must be given when 'raw' has already been merged, as is
+          the case for child bindings. May be left out, in which case
+          it is taken from 'raw'.
         """
         self.path: Optional[str] = path
         self._fname2path: dict[str, str] = fname2path
@@ -245,6 +262,12 @@ class Binding:
                 _err("you must provide either a 'path' or a 'raw' argument")
             with open(path, encoding="utf-8") as f:
                 raw = yaml.load(f, Loader=_BindingLoader)
+
+        # Save the properties declared locally, for this binding and any
+        # nested child bindings, before included files are merged in.
+        if local_props is None:
+            local_props = _local_props(raw)
+        self._local_props: _LocalProps = local_props
 
         # Merge any included files into self.raw. This also pulls in
         # inherited child binding definitions, so it has to be done
@@ -262,7 +285,8 @@ class Binding:
                 path, fname2path,
                 raw=raw["child-binding"],
                 require_compatible=False,
-                require_description=False)
+                require_description=False,
+                local_props=local_props.child or _LocalProps({}, None))
         else:
             self.child_binding = None
 
@@ -516,7 +540,8 @@ class Binding:
                          f"'properties: {prop_name}: ...' in {self.path}, "
                          f"expected one of {', '.join(ok_prop_keys)}")
 
-            _check_prop_by_type(prop_name, options, self.path)
+            _check_prop_by_type(prop_name, options, self.path,
+                                self._local_props.props.get(prop_name) or {})
 
             for true_false_opt in ["required", "deprecated"]:
                 if true_false_opt in options:
@@ -3027,6 +3052,24 @@ def _check_prop_filter(name: str, value: Optional[list[str]],
         _err(f"'{name}' value {value} in '{binding_path}' should be a list")
 
 
+def _local_props(raw: Any) -> _LocalProps:
+    # Returns the properties 'raw' declares on its own, and the same for
+    # any nested 'child-binding:'. Each entry is copied, as
+    # _merge_props() merges into them in place.
+
+    if not isinstance(raw, dict):
+        return _LocalProps({}, None)
+
+    return _LocalProps(
+        {
+            name: dict(options)
+            for name, options in (raw.get("properties") or {}).items()
+            if isinstance(options, dict)
+        },
+        _local_props(raw["child-binding"]) if "child-binding" in raw else None,
+    )
+
+
 def _merge_props(to_dict: dict,
                  from_dict: dict,
                  parent: Optional[str],
@@ -3116,7 +3159,8 @@ def _is_plain_int(val: Any) -> TypeGuard[int]:
 
 def _check_prop_by_type(prop_name: str,
                         options: dict,
-                        binding_path: Optional[str]) -> None:
+                        binding_path: Optional[str],
+                        local_options: dict) -> None:
     # Binding._check_properties() helper. Checks 'type:', 'default:',
     # 'const:', 'specifier-space:', 'min:' and 'max:' for the property
     # named 'prop_name'
@@ -3241,7 +3285,9 @@ def _check_prop_by_type(prop_name: str,
              f"'type: {prop_type}' for '{prop_name}' in "
              f"'properties:' in '{binding_path}'")
 
-    if options.get("required"):
+    # Overriding an inherited 'default:' with 'required: true' is well
+    # defined, so only report a binding that declares both itself.
+    if local_options.get("required") and "default" in local_options:
         _LOG.warning(f"Property '{prop_name}' is required in '{binding_path}', "
                      "it should not have a default value")
 

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/default_base.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/default_base.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Base file declaring a "default:" value at each nesting level,
+# for testing bindings which override them with "required: true".
+
+properties:
+  prop-with-default:
+    type: int
+    default: 1
+
+child-binding:
+  properties:
+    child-prop-with-default:
+      type: int
+      default: 2
+
+  child-binding:
+    properties:
+      grandchild-prop-with-default:
+        type: int
+        default: 3

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/default_override.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/default_override.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This binding overrides an inherited "default:" with "required: true"
+# at each nesting level, which is well defined and is not reported.
+
+include: default_base.yaml
+
+properties:
+  prop-with-default:
+    required: true
+
+child-binding:
+  properties:
+    child-prop-with-default:
+      required: true
+
+  child-binding:
+    properties:
+      grandchild-prop-with-default:
+        required: true

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/default_override_include.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/default_override_include.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This binding declares nothing on its own, and inherits the child
+# bindings which override a "default:" with "required: true".
+# Nothing is declared locally here, so nothing is reported.
+
+include: default_override.yaml

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/default_required.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/default_required.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This binding declares both "default:" and "required: true" for the
+# same property at each nesting level, which is redundant and reported.
+
+properties:
+  prop-required-with-default:
+    type: int
+    required: true
+    default: 1
+
+child-binding:
+  properties:
+    child-prop-required-with-default:
+      type: int
+      required: true
+      default: 2
+
+  child-binding:
+    properties:
+      grandchild-prop-required-with-default:
+        type: int
+        required: true
+        default: 3

--- a/scripts/dts/python-devicetree/tests/test_edtlib_binding_init.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib_binding_init.py
@@ -52,6 +52,7 @@ independently of any actual devicetree model (edtlib.EDT instance).
 # pylint: disable=too-many-statements
 
 import contextlib
+import logging
 import os
 from collections.abc import Generator
 from typing import Any
@@ -74,6 +75,11 @@ YAML_KNOWN_BASE_BINDINGS: dict[str, str] = {
     # Test applied rules for compatible strings and descriptions.
     "compat_desc_base.yaml": "test-bindings-init/compat_desc_base.yaml",
     "compat_desc.yaml": "test-bindings-init/compat_desc.yaml",
+    # Declares a "default:" at each nesting level, to test overriding
+    # them with "required: true".
+    "default_base.yaml": "test-bindings-init/default_base.yaml",
+    # Overrides the above, to test including such a binding.
+    "default_override.yaml": "test-bindings-init/default_override.yaml",
 }
 
 
@@ -1091,6 +1097,49 @@ def test_invalid_binding_default_override() -> None:
         load_binding("test-bindings-init/invalid_grandchild_propdefault.yaml")
     assert "grandchild-prop-default" in str(e)
     assert "'3' replaced with '999'" in str(e)
+
+
+def test_required_overriding_inherited_default(caplog) -> None:
+    """An including binding may override an inherited "default:" with
+    "required: true" to force an explicit value.
+
+    This is well defined and should not be reported.
+
+    Tested up to the grandchild-binding level.
+    """
+    with caplog.at_level(logging.WARNING):
+        load_binding("test-bindings-init/default_override.yaml")
+    assert "should not have a default value" not in caplog.text
+
+
+def test_required_overriding_inherited_default_included(caplog) -> None:
+    """A binding which declares no child binding of its own, but inherits
+    one overriding a "default:" with "required: true", declares nothing
+    locally and should not be reported either.
+    """
+    with caplog.at_level(logging.WARNING):
+        load_binding("test-bindings-init/default_override_include.yaml")
+    assert "should not have a default value" not in caplog.text
+
+
+def test_required_with_local_default(caplog) -> None:
+    """A binding which declares both "default:" and "required: true" for
+    the same property should be reported, as the default can never apply.
+
+    Tested up to the grandchild-binding level.
+    """
+    with caplog.at_level(logging.WARNING):
+        load_binding("test-bindings-init/default_required.yaml")
+
+    warnings = [
+        rec.getMessage()
+        for rec in caplog.records
+        if "should not have a default value" in rec.getMessage()
+    ]
+    assert len(warnings) == 3
+    assert any("'prop-required-with-default'" in msg for msg in warnings)
+    assert any("'child-prop-required-with-default'" in msg for msg in warnings)
+    assert any("'grandchild-prop-required-with-default'" in msg for msg in warnings)
 
 
 def test_invalid_binding_enum_override() -> None:


### PR DESCRIPTION
The check that warns when a binding declares both `required: true` and
`default:` for the same property runs on the property settings left
after `include:` files are merged. A binding that inherits a `default:`
and deliberately overrides it with `required: true` was therefore
reported, even though that combination is well defined: the required
check runs first and fails the build when the property is absent, so
the inherited default never applies.

Keep a copy of the properties each binding declares on its own, taken
before includes are merged, and warn only when both settings come from
the same file. Included files are merged in place, which also covers
nested child bindings, so the copy is handed down to each child binding
in turn.

Also drops the now-redundant `required: true` from bindings that inherit
a `default:`, but only where a `const:` or `enum:` still rejects that
default, so an absent property remains a build failure.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/115573