### PR TITLE
arch: isr_tables: allow local declaration without vector table

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -546,7 +546,7 @@ config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
 config ISR_TABLES_LOCAL_DECLARATION
 	bool "ISR tables created locally and placed by linker"
 	depends on ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
-	depends on GEN_IRQ_VECTOR_TABLE
+	depends on GEN_ISR_TABLES
 	help
 	  Enable new scheme of interrupt tables generation.
 	  This is totally different generator that would create tables entries locally

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -271,6 +271,8 @@ struct z_shared_isr_table_entry z_shared_sw_isr_table[];
  * the linker script chunks.
  */
 #define Z_ISR_DECLARE_DIRECT(irq, flags, func)                                                     \
+	BUILD_ASSERT(IS_ENABLED(CONFIG_GEN_IRQ_VECTOR_TABLE),                                     \
+		"CONFIG_GEN_IRQ_VECTOR_TABLE is required for direct interrupts");                  \
 	BUILD_ASSERT(IS_ENABLED(CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_ADDRESS) ||                        \
 		IS_ENABLED(CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_CODE),                                  \
 		"CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_{ADDRESS,CODE} not set");                         \

--- a/tests/arch/common/gen_isr_table/tests.yaml
+++ b/tests/arch/common/gen_isr_table/tests.yaml
@@ -67,7 +67,6 @@ tests:
       - cdns_swerv/s400/pmp/whisper
       - cdns_swerv/s420/whisper
       - cdns_swerv/s420/64/whisper
-      - it8xxx2_evb
     filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
     extra_configs:
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y


### PR DESCRIPTION
CONFIG_ISR_TABLES_LOCAL_DECLARATION previously depended on CONFIG_GEN_IRQ_VECTOR_TABLE. However, the local declaration mechanism handles both hardware vector tables (for direct ISRs via CONFIG_GEN_IRQ_VECTOR_TABLE) and software ISR tables (for regular ISRs via CONFIG_GEN_SW_ISR_TABLE).

Platforms with CONFIG_GEN_SW_ISR_TABLE=y and
CONFIG_GEN_IRQ_VECTOR_TABLE=n (such as RISC-V) could not enable CONFIG_ISR_TABLES_LOCAL_DECLARATION, which also prevented enabling CONFIG_LTO.

Relax the dependency from GEN_IRQ_VECTOR_TABLE to GEN_ISR_TABLES, and add an explicit build assertion in Z_ISR_DECLARE_DIRECT to guard against declaring direct interrupts on targets without a vector table. Also re-enable it8xxx2_evb in gen_isr_table_local tests.