### PR TITLE
scripts: runners: blackmagicprobe: disable pagination during flashing

### DIFF
--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -169,6 +169,7 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
 
         command = (self.gdb +
                    ['-ex', "set confirm off",
+                    '-ex', "set pagination off",
                     '-ex', f"target extended-remote {self.gdb_serial}"] +
                     self.connect_rst_enable_arg +
                    ['-ex', "monitor swdp_scan",

--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -38,6 +38,7 @@ EXPECTED_COMMANDS = {
     'flash':
     ([RC_GDB,
       '-ex', "set confirm off",
+      '-ex', "set pagination off",
       '-ex', "target extended-remote {}".format(TEST_GDB_SERIAL),
       '-ex', "monitor swdp_scan",
       '-ex', "attach 1",


### PR DESCRIPTION
Flashing using a blackmagic probe sometimes requires user interaction which is unnecessary.
I opened an issue about this ( #115153  ) and was asked to submit a pull request.

This pr disables pagination which prevents the dialog from appearing.
