### PR TITLE
drivers: gnss: ignore padded empty GSV satellite entries

### DIFF
--- a/drivers/gnss/gnss_nmea0183.c
+++ b/drivers/gnss/gnss_nmea0183.c
@@ -673,6 +673,11 @@ int gnss_nmea0183_parse_gsv_svs(const char **argv, uint16_t argc,
 
 	sv_args_size = (argc - GNSS_NMEA0183_GSV_HDR_ARG_CNT) / GNSS_NMEA0183_GSV_SV_ARG_CNT;
 
+	/* Some receivers pad the last GSV message with empty satellite fields */
+	while ((sv_args_size > 0) && (sv_args[sv_args_size - 1].prn[0] == '\0')) {
+		sv_args_size--;
+	}
+
 	if (size < sv_args_size) {
 		return -ENOMEM;
 	}

--- a/tests/drivers/gnss/gnss_nmea0183/src/main.c
+++ b/tests/drivers/gnss/gnss_nmea0183/src/main.c
@@ -648,6 +648,51 @@ static const struct gnss_satellite gbgsv_8_8_25_sats[] = {
 	 .system = GNSS_SYSTEM_BEIDOU, .is_tracked = true},
 };
 
+/*
+ * Some receivers pad the last GSV message with empty satellite fields
+ *
+ * $GPGSV,1,1,03,10,,,25,12,,,28,15,,,16,,,,*76
+ */
+const char *gpgsv_1_1_3[21] = {
+	"$GPGSV",
+	"1",
+	"1",
+	"03",
+	"10",
+	"",
+	"",
+	"25",
+	"12",
+	"",
+	"",
+	"28",
+	"15",
+	"",
+	"",
+	"16",
+	"",
+	"",
+	"",
+	"",
+	"76",
+};
+
+static const struct gnss_nmea0183_gsv_header gpgsv_1_1_3_header = {
+	.system = GNSS_SYSTEM_GPS,
+	.number_of_messages = 1,
+	.message_number = 1,
+	.number_of_svs = 3
+};
+
+static const struct gnss_satellite gpgsv_1_1_3_sats[] = {
+	{.prn = 10, .elevation = 0, .azimuth = 0, .snr = 25,
+	 .system = GNSS_SYSTEM_GPS, .is_tracked = true},
+	{.prn = 12, .elevation = 0, .azimuth = 0, .snr = 28,
+	 .system = GNSS_SYSTEM_GPS, .is_tracked = true},
+	{.prn = 15, .elevation = 0, .azimuth = 0, .snr = 16,
+	 .system = GNSS_SYSTEM_GPS, .is_tracked = true},
+};
+
 struct test_gsv_sample {
 	const char **argv;
 	uint16_t argc;
@@ -673,6 +718,8 @@ static const struct test_gsv_sample gsv_samples[] = {
 	 .satellites = glgsv_8_7_25_sats, .number_of_svs = ARRAY_SIZE(glgsv_8_7_25_sats)},
 	{.argv = gbgsv_8_8_25, .argc = ARRAY_SIZE(gbgsv_8_8_25), .header = &gbgsv_8_8_25_header,
 	 .satellites = gbgsv_8_8_25_sats, .number_of_svs = ARRAY_SIZE(gbgsv_8_8_25_sats)},
+	{.argv = gpgsv_1_1_3, .argc = ARRAY_SIZE(gpgsv_1_1_3), .header = &gpgsv_1_1_3_header,
+	 .satellites = gpgsv_1_1_3_sats, .number_of_svs = ARRAY_SIZE(gpgsv_1_1_3_sats)},
 };
 
 ZTEST(gnss_nmea0183, test_gsv_parse_headers)


### PR DESCRIPTION
Some GNSS receivers pad the last GSV message of a sequence with empty
satellite fields, e.g.:

$GPGSV,1,1,03,10,,,25,12,,,28,15,,,16,,,,*76

This message contains 3 satellites but 4 satellite field groups.
gnss_nmea0183_parse_gsv_svs() derived the satellite count from the
argument count alone, so the empty trailing group was parsed as a
satellite (empty fields are parsed as 0 by gnss_parse_atoi). As a
result satellites_length exceeded the number of SVs reported in the
GSV header, the equality check in gnss_nmea0183_match_gsv_callback()
never passed, and gnss_publish_satellites() was never called.

Fix this by trimming trailing satellite field groups whose PRN field
is empty before parsing, so the function returns the number of
satellites actually present in the message.