### PR TITLE
kernel: arch: make `arch_mem_{map,unmap}()` to return error code, and also implement mapping failure recovery path in `k_mem_map_phys_guard()`

### DIFF
--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -1044,8 +1044,12 @@ static int __arch_mem_unmap(void *addr, size_t size)
  *
  * @param addr 32-bit virtual address to unmap.
  * @param size Size (in bytes) of the memory area to unmap.
+ *
+ * @retval 0 On success
+ * @retval -EINVAL If invalid arguments are given (for example, a NULL
+ *                 address or zero size)
  */
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
 	int ret = __arch_mem_unmap(addr, size);
 
@@ -1054,6 +1058,8 @@ void arch_mem_unmap(void *addr, size_t size)
 	} else {
 		invalidate_tlb_all();
 	}
+
+	return ret;
 }
 
 /**

--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -980,8 +980,10 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
  * @param size Size (in bytes) of the memory area to map.
  * @param flags Memory attributes & permissions. Comp. K_MEM_...
  *              flags in kernel/mm.h.
+ *
+ * @retval 0 on success
  */
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	int ret = __arch_mem_map(virt, phys, size, flags);
 
@@ -991,6 +993,8 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 	} else {
 		invalidate_tlb_all();
 	}
+
+	return ret;
 }
 
 /**

--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -122,7 +122,7 @@ static const struct arm_mmu_flat_range mmu_zephyr_ranges[] = {
 #endif
 };
 
-static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
+static bool arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 				struct arm_mmu_perms_attrs perms_attrs);
 
 /**
@@ -148,21 +148,25 @@ static void invalidate_tlb_all(void)
  * @param va 32-bit virtual address to be mapped.
  * @retval pointer to the L2 table now assigned to the 1 MB
  *         address range the target virtual address is in.
+ *         NULL if no free L2 page table is available.
  */
 static struct arm_mmu_l2_page_table *arm_mmu_assign_l2_table(uint32_t va)
 {
 	struct arm_mmu_l2_page_table *l2_page_table;
 
-	__ASSERT(arm_mmu_l2_tables_free > 0,
-		 "Cannot set up L2 page table for VA 0x%08X: "
-		 "no more free L2 page tables available\n",
-		 va);
-	__ASSERT(l2_page_tables_status[arm_mmu_l2_next_free_table].entries == 0,
-		 "Cannot set up L2 page table for VA 0x%08X: "
-		 "expected empty L2 table at index [%u], but the "
-		 "entries value is %u\n",
-		 va, arm_mmu_l2_next_free_table,
-		 l2_page_tables_status[arm_mmu_l2_next_free_table].entries);
+	if (arm_mmu_l2_tables_free == 0) {
+		LOG_ERR("Cannot set up L2 page table for VA 0x%08X: "
+			"no more free L2 page tables available", va);
+		return NULL;
+	}
+
+	if (l2_page_tables_status[arm_mmu_l2_next_free_table].entries != 0) {
+		LOG_ERR("Cannot set up L2 page table for VA 0x%08X: "
+			"expected empty L2 table at index [%u], but the "
+			"entries value is %u", va, arm_mmu_l2_next_free_table,
+			l2_page_tables_status[arm_mmu_l2_next_free_table].entries);
+		return NULL;
+	}
 
 	/*
 	 * Store in the status dataset of the L2 table to be returned
@@ -459,9 +463,7 @@ static void arm_mmu_l1_map_section(uint32_t va, uint32_t pa,
  * entry has to be broken down to the full 256 4k-wide entries of a
  * L2 page table with identical properties so that afterwards, the
  * modification of the subset can be performed with a 4k granularity.
- * The risk at this point is that all L2 tables are already in use,
- * which will result in an assertion failure in the first contained
- * #arm_mmu_l2_map_page() call.
+ * The risk at this point is that all L2 tables are already in use.
  * @warning While the conversion is being performed, interrupts are
  *          locked globally and the MMU is disabled (the required
  *          Zephyr code & data are still accessible in this state as
@@ -475,8 +477,11 @@ static void arm_mmu_l1_map_section(uint32_t va, uint32_t pa,
  * @param l2_page_table Pointer to an empty L2 page table allocated
  *                      for the purpose of replacing the L1 section
  *                      mapping.
+ *
+ * @retval true Remapping is successful.
+ * @retval false Remapping failed.
  */
-static void arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
+static bool arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
 						 struct arm_mmu_l2_page_table *l2_page_table)
 {
 	struct arm_mmu_perms_attrs perms_attrs = {0};
@@ -485,6 +490,7 @@ static void arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
 	uint32_t rem_size = MB(1);
 	uint32_t reg_val;
 	int lock_key;
+	bool success = true;
 
 	/*
 	 * Extract the permissions and attributes from the current 1 MB section entry.
@@ -540,7 +546,10 @@ static void arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
 	/* Align the target VA to the base address of the section we're converting */
 	va &= ~(MB(1) - 1);
 	while (rem_size > 0) {
-		arm_mmu_l2_map_page(va, va, perms_attrs);
+		if (!arm_mmu_l2_map_page(va, va, perms_attrs)) {
+			success = false;
+			break;
+		}
 		rem_size -= KB(4);
 		va += KB(4);
 	}
@@ -551,6 +560,8 @@ static void arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
 	__set_SCTLR(reg_val);
 
 	arch_irq_unlock(lock_key);
+
+	return success;
 }
 
 /**
@@ -565,8 +576,12 @@ static void arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
  * @param pa 32-bit physical address.
  * @param perms_attrs Permission and attribute bits in the format
  *                    used in the MMU's L2 page table entries.
+ *
+ * @retval true Mapping is successful.
+ * @retval false Mapping failed. Usually means there are no free L2 page
+ *               tables to be assigned.
  */
-static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
+static bool arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 				struct arm_mmu_perms_attrs perms_attrs)
 {
 	struct arm_mmu_l2_page_table *l2_page_table = NULL;
@@ -584,9 +599,11 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 	if (l1_page_table.entries[l1_index].undefined.id == ARM_MMU_PTE_ID_INVALID ||
 	    (l1_page_table.entries[l1_index].undefined.id & ARM_MMU_PTE_ID_SECTION) != 0) {
 		l2_page_table = arm_mmu_assign_l2_table(pa);
-		__ASSERT(l2_page_table != NULL,
-			 "Unexpected L2 page table NULL pointer for VA 0x%08X",
-			 va);
+		if (l2_page_table == NULL) {
+			LOG_ERR("Cannot map virtual address 0x%08X: "
+				"no L2 page table available", va);
+			return false;
+		}
 	}
 
 	/*
@@ -651,7 +668,9 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 		 * first before the individual L2 entry for the page to be mapped is
 		 * accessed. A blank L2 PT has already been assigned above.
 		 */
-		arm_mmu_remap_l1_section_to_l2_table(va, l2_page_table);
+		if (!arm_mmu_remap_l1_section_to_l2_table(va, l2_page_table)) {
+			return false;
+		}
 	}
 
 	/*
@@ -680,6 +699,8 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 	l2_page_table->entries[l2_index].l2_page_4k.pa_base =
 		((pa >> ARM_MMU_PTE_L2_SMALL_PAGE_ADDR_SHIFT) &
 		ARM_MMU_PTE_L2_SMALL_PAGE_ADDR_MASK);
+
+	return true;
 }
 
 /**
@@ -688,8 +709,13 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
  * address by clearing its respective L2 page table entry.
  *
  * @param va 32-bit virtual address to be unmapped.
+ *
+ * @retval true Unmapping is successful, or nothing was mapped at the
+ *              given virtual address.
+ * @retval false The page table entry to be cleared is of an unexpected
+ *               type.
  */
-static void arm_mmu_l2_unmap_page(uint32_t va)
+static bool arm_mmu_l2_unmap_page(uint32_t va)
 {
 	struct arm_mmu_l2_page_table *l2_page_table;
 	uint32_t l1_index = (va >> ARM_MMU_PTE_L1_INDEX_PA_SHIFT) &
@@ -704,7 +730,7 @@ static void arm_mmu_l2_unmap_page(uint32_t va)
 		 * a L2 PT exists, the corresponding PTE is blank - see explanation
 		 * below, the same applies here.
 		 */
-		return;
+		return true;
 	}
 
 	l2_page_table = (struct arm_mmu_l2_page_table *)
@@ -723,7 +749,7 @@ static void arm_mmu_l2_unmap_page(uint32_t va)
 		 * -> Just return, don't decrement the entry counter of the corresponding
 		 * L2 page table, as we're not actually clearing any PTEs.
 		 */
-		return;
+		return true;
 	}
 
 	if ((l2_page_table->entries[l2_index].undefined.id & ARM_MMU_PTE_ID_SMALL_PAGE) !=
@@ -731,12 +757,14 @@ static void arm_mmu_l2_unmap_page(uint32_t va)
 		LOG_ERR("Cannot unmap virtual memory at 0x%08X: invalid "
 			"page table entry type in level 2 page table at "
 			"L1 index [%u], L2 index [%u]", va, l1_index, l2_index);
-		return;
+		return false;
 	}
 
 	l2_page_table->entries[l2_index].word = 0;
 
 	arm_mmu_dec_l2_table_entries(l2_page_table);
+
+	return true;
 }
 
 /**
@@ -793,7 +821,11 @@ int z_arm_mmu_init(void)
 				rem_size -= MB(1);
 				pa += MB(1);
 			} else {
-				arm_mmu_l2_map_page(pa, pa, perms_attrs);
+				bool success = arm_mmu_l2_map_page(pa, pa, perms_attrs);
+
+				__ASSERT(success, "Cannot map PA 0x%08X at boot time", pa);
+				ARG_UNUSED(success);
+
 				rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
 				pa += KB(4);
 			}
@@ -824,7 +856,11 @@ int z_arm_mmu_init(void)
 				va += MB(1);
 				pa += MB(1);
 			} else {
-				arm_mmu_l2_map_page(va, pa, perms_attrs);
+				bool success = arm_mmu_l2_map_page(va, pa, perms_attrs);
+
+				__ASSERT(success, "Cannot map VA 0x%08X at boot time", va);
+				ARG_UNUSED(success);
+
 				rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
 				va += KB(4);
 				pa += KB(4);
@@ -899,7 +935,9 @@ int z_arm_mmu_init(void)
  * @param size Size (in bytes) of the memory area to map.
  * @param flags Memory attributes & permissions. Comp. K_MEM_...
  *              flags in kernel/mm.h.
- * @retval 0 on success, -EINVAL if an invalid parameter is detected.
+ * @retval 0 on success, -EINVAL if an invalid parameter is detected,
+ *         -ENOTSUP if the requested cache mode is not supported,
+ *         -ENOMEM if no page table could be allocated for the mapping.
  */
 static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
@@ -922,7 +960,6 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 		conv_flags |= MT_NORMAL;
 		break;
 	case K_MEM_CACHE_NONE:
-	default:
 		conv_flags |= MT_DEVICE;
 		break;
 	case K_MEM_CACHE_WB:
@@ -942,7 +979,10 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 		conv_flags |= MATTR_CACHE_OUTER_WT_nWA;
 		conv_flags |= MATTR_CACHE_INNER_WT_nWA;
 		break;
-
+	default:
+		LOG_ERR("Cannot map physical memory at 0x%08X: unsupported cache mode",
+			(uint32_t)phys);
+		return -ENOTSUP;
 	}
 
 	if (flags & K_MEM_PERM_RW) {
@@ -957,7 +997,14 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 	key = arch_irq_lock();
 
 	while (rem_size > 0) {
-		arm_mmu_l2_map_page(va, pa, perms_attrs);
+		if (!arm_mmu_l2_map_page(va, pa, perms_attrs)) {
+			/* Some pages may have already been mapped in this loop.
+			 * The caller is expected to unmap the entire range in
+			 * order to clean up the partial mapping.
+			 */
+			arch_irq_unlock(key);
+			return -ENOMEM;
+		}
 		rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
 		va += KB(4);
 		pa += KB(4);
@@ -973,7 +1020,6 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
  * Maps memory according to the parameters provided by the caller
  * at run-time. This function wraps the ARMv7 MMU specific implementation
  * #__arch_mem_map() for the upper layers of the memory management.
- * If the map operation fails, a kernel panic will be triggered.
  *
  * @param virt 32-bit target virtual address.
  * @param phys 32-bit physical address.
@@ -981,18 +1027,23 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
  * @param flags Memory attributes & permissions. Comp. K_MEM_...
  *              flags in kernel/mm.h.
  *
- * @retval 0 on success
+ * @retval 0 On success
+ * @retval -EINVAL If invalid arguments are given (for example, a zero size)
+ * @retval -ENOTSUP If the requested cache mode is not supported
+ * @retval -ENOMEM If no page table could be allocated for the mapping
  */
 int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	int ret = __arch_mem_map(virt, phys, size, flags);
 
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("__arch_mem_map() returned %d", ret);
-		k_panic();
-	} else {
-		invalidate_tlb_all();
 	}
+
+	/* Even a failed mapping may have modified the page tables before
+	 * bailing out, so the TLB has to be invalidated in any case.
+	 */
+	invalidate_tlb_all();
 
 	return ret;
 }
@@ -1004,7 +1055,9 @@ int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
  *
  * @param addr 32-bit virtual address to unmap.
  * @param size Size (in bytes) of the memory area to unmap.
- * @retval 0 on success, -EINVAL if an invalid parameter is detected.
+ * @retval 0 on success, -EINVAL if an invalid parameter is detected,
+ *         -EFAULT if a page table entry of an unexpected type was
+ *         encountered.
  */
 static int __arch_mem_unmap(void *addr, size_t size)
 {
@@ -1026,7 +1079,10 @@ static int __arch_mem_unmap(void *addr, size_t size)
 	key = arch_irq_lock();
 
 	while (rem_size > 0) {
-		arm_mmu_l2_unmap_page(va);
+		if (!arm_mmu_l2_unmap_page(va)) {
+			arch_irq_unlock(key);
+			return -EFAULT;
+		}
 		rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
 		va += KB(4);
 	}
@@ -1048,16 +1104,21 @@ static int __arch_mem_unmap(void *addr, size_t size)
  * @retval 0 On success
  * @retval -EINVAL If invalid arguments are given (for example, a NULL
  *                 address or zero size)
+ * @retval -EFAULT If a page table entry of an unexpected type was
+ *                 encountered
  */
 int arch_mem_unmap(void *addr, size_t size)
 {
 	int ret = __arch_mem_unmap(addr, size);
 
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("__arch_mem_unmap() returned %d", ret);
-	} else {
-		invalidate_tlb_all();
 	}
+
+	/* Even a failed unmap may have modified the page tables before
+	 * bailing out, so the TLB has to be invalidated in any case.
+	 */
+	invalidate_tlb_all();
 
 	return ret;
 }

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1275,11 +1275,13 @@ int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 	return ret;
 }
 
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
 	remove_map(&kernel_ptables, "generic", (uintptr_t)addr, size);
 	sync_domains((uintptr_t)addr, size, "mem_unmap");
 	invalidate_tlb_all();
+
+	return 0;
 }
 
 int arch_page_phys_get(void *virt, uintptr_t *phys)

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -89,9 +89,6 @@ static uint64_t *new_table(void)
 
 	MMU_LOG_ERR("CONFIG_MAX_XLAT_TABLES is too small");
 
-	/* Unfortunately many code paths are not ready for failure */
-	k_panic();
-
 	return NULL;
 }
 
@@ -411,11 +408,12 @@ move_on:
 	return 0;
 }
 
-static void del_mapping(uint64_t *table, uintptr_t virt, size_t size,
+static bool del_mapping(uint64_t *table, uintptr_t virt, size_t size,
 			unsigned int level)
 {
 	size_t step, level_size = 1ULL << LEVEL_TO_VA_SIZE_SHIFT(level);
 	uint64_t *pte, *subtable;
+	bool success = true;
 
 	for ( ; size; virt += step, size -= step) {
 		step = level_size - (virt & (level_size - 1));
@@ -430,12 +428,23 @@ static void del_mapping(uint64_t *table, uintptr_t virt, size_t size,
 
 		if (step != level_size && is_block_desc(*pte)) {
 			/* need to split this block mapping */
-			expand_to_table(pte, level);
+			if (!expand_to_table(pte, level)) {
+				/* Without the split, clearing this entry would
+				 * unmap the whole block, including memory
+				 * outside of the requested range. Leave it
+				 * alone and report the failure instead.
+				 */
+				MMU_LOG_ERR("cannot split block mapping at 0x%lx", virt);
+				success = false;
+				continue;
+			}
 		}
 
 		if (is_table_desc(*pte, level)) {
 			subtable = pte_desc_table(*pte);
-			del_mapping(subtable, virt, step, level + 1);
+			if (!del_mapping(subtable, virt, step, level + 1)) {
+				success = false;
+			}
 			if (!is_table_unused(subtable)) {
 				continue;
 			}
@@ -446,6 +455,8 @@ static void del_mapping(uint64_t *table, uintptr_t virt, size_t size,
 		*pte = 0;
 		table_usage(pte, -1);
 	}
+
+	return success;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -619,7 +630,9 @@ static int globalize_table(uint64_t *dst_table, uint64_t *src_table, uintptr_t v
 		    is_table_desc(dst_table[i], level)) {
 			uint64_t *subtable = pte_desc_table(dst_table[i]);
 
-			del_mapping(subtable, virt, step, level + 1);
+			if (!del_mapping(subtable, virt, step, level + 1)) {
+				return -ENOMEM;
+			}
 			if (is_table_unused(subtable)) {
 				/* unreference the empty table */
 				dst_table[i] = 0;
@@ -854,18 +867,21 @@ static int add_map(struct arm_mmu_ptables *ptables, const char *name,
 	return ret;
 }
 
-static void remove_map(struct arm_mmu_ptables *ptables, const char *name,
-		       uintptr_t virt, size_t size)
+static int remove_map(struct arm_mmu_ptables *ptables, const char *name,
+		      uintptr_t virt, size_t size)
 {
 	k_spinlock_key_t key;
+	bool success;
 
 	MMU_DEBUG("unmmap [%s]: virt %lx size %lx\n", name, virt, size);
 	__ASSERT(((virt | size) & (CONFIG_MMU_PAGE_SIZE - 1)) == 0,
 		 "address/size are not page aligned\n");
 
 	key = k_spin_lock(&xlat_lock);
-	del_mapping(ptables->base_xlat_table, virt, size, BASE_XLAT_LEVEL);
+	success = del_mapping(ptables->base_xlat_table, virt, size, BASE_XLAT_LEVEL);
 	k_spin_unlock(&xlat_lock, key);
+
+	return success ? 0 : -ENOMEM;
 }
 
 static void invalidate_tlb_all(void)
@@ -1164,6 +1180,14 @@ void z_arm64_mm_init(bool is_primary_core)
 	 */
 	if (is_primary_core) {
 		kernel_ptables.base_xlat_table = new_table();
+		__ASSERT(kernel_ptables.base_xlat_table != NULL,
+			 "Cannot allocate base translation table\n");
+		if (kernel_ptables.base_xlat_table == NULL) {
+			/* Without the base translation table nothing can be
+			 * mapped, so there is no way to continue booting.
+			 */
+			arch_system_halt(K_ERR_KERNEL_PANIC);
+		}
 		setup_page_tables(&kernel_ptables);
 	}
 
@@ -1171,8 +1195,9 @@ void z_arm64_mm_init(bool is_primary_core)
 	enable_mmu_el1(&kernel_ptables, flags);
 }
 
-static void sync_domains(uintptr_t virt, size_t size, const char *name)
+static int sync_domains(uintptr_t virt, size_t size, const char *name)
 {
+	int result = 0;
 #ifdef CONFIG_USERSPACE
 	sys_snode_t *node;
 	struct arch_mem_domain *domain;
@@ -1187,10 +1212,17 @@ static void sync_domains(uintptr_t virt, size_t size, const char *name)
 		ret = globalize_page_range(domain_ptables, &kernel_ptables, virt, size, name, true);
 		if (ret) {
 			LOG_ERR("globalize_page_range() returned %d", ret);
+			/* Keep synchronizing the remaining domains so that
+			 * as few of them as possible are left inconsistent
+			 * with the kernel page tables, but remember that
+			 * this operation did not fully succeed.
+			 */
+			result = ret;
 		}
 	}
 	k_spin_unlock(&z_mem_domain_lock, key);
 #endif
+	return result;
 }
 
 static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
@@ -1263,25 +1295,43 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	int ret = __arch_mem_map(virt, phys, size, flags);
+	int sync_ret;
 
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("__arch_mem_map() returned %d", ret);
-		k_panic();
-	} else {
-		sync_domains((uintptr_t)virt, size, "mem_map");
-		invalidate_tlb_all();
 	}
+
+	/* Even a failed mapping may have modified the kernel page tables
+	 * before bailing out, so the memory domains have to be synchronized
+	 * and the TLB invalidated in any case.
+	 */
+	sync_ret = sync_domains((uintptr_t)virt, size, "mem_map");
+	if (ret == 0) {
+		ret = sync_ret;
+	}
+
+	invalidate_tlb_all();
 
 	return ret;
 }
 
 int arch_mem_unmap(void *addr, size_t size)
 {
-	remove_map(&kernel_ptables, "generic", (uintptr_t)addr, size);
-	sync_domains((uintptr_t)addr, size, "mem_unmap");
+	int ret = remove_map(&kernel_ptables, "generic", (uintptr_t)addr, size);
+	int sync_ret;
+
+	if (ret != 0) {
+		LOG_ERR("remove_map() returned %d", ret);
+	}
+
+	sync_ret = sync_domains((uintptr_t)addr, size, "mem_unmap");
+	if (ret == 0) {
+		ret = sync_ret;
+	}
+
 	invalidate_tlb_all();
 
-	return 0;
+	return ret;
 }
 
 int arch_page_phys_get(void *virt, uintptr_t *phys)

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1260,7 +1260,7 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 	return add_map(ptables, "generic", phys, (uintptr_t)virt, size, entry_flags);
 }
 
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	int ret = __arch_mem_map(virt, phys, size, flags);
 
@@ -1271,6 +1271,8 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 		sync_domains((uintptr_t)virt, size, "mem_map");
 		invalidate_tlb_all();
 	}
+
+	return ret;
 }
 
 void arch_mem_unmap(void *addr, size_t size)

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1236,14 +1236,9 @@ static pentry_t flags_to_entry(uint32_t flags)
 }
 
 /* map new region virt..virt+size to phys with provided arch-neutral flags */
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
-	int ret;
-
-	ret = range_map_unlocked(virt, phys, size, flags_to_entry(flags),
-				 MASK_ALL, 0);
-	__ASSERT_NO_MSG(ret == 0);
-	ARG_UNUSED(ret);
+	return range_map_unlocked(virt, phys, size, flags_to_entry(flags), MASK_ALL, 0);
 }
 
 /* unmap region addr..addr+size, reset entries and flush TLB */

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -978,7 +978,7 @@ static int page_map_set(pentry_t *ptables, void *virt, pentry_t entry_val,
 		 * If the PS bit is not supported at some level (like
 		 * in a PML4 entry) it is always reserved and must be 0
 		 */
-		CHECKIF(!((*entryp & MMU_PS) == 0U)) {
+		if ((*entryp & MMU_PS) != 0U) {
 			/* Cannot continue since we cannot split
 			 * bigpage mappings.
 			 */
@@ -989,7 +989,7 @@ static int page_map_set(pentry_t *ptables, void *virt, pentry_t entry_val,
 
 		table = next_table(*entryp, level);
 
-		CHECKIF(!(table != NULL)) {
+		if (table == NULL) {
 			/* Cannot continue since table is NULL,
 			 * and it cannot be dereferenced in next loop
 			 * iteration.
@@ -1074,8 +1074,12 @@ static int range_map_ptables(pentry_t *ptables, void *virt, uintptr_t phys,
 
 		ret2 = page_map_set(ptables, dest_virt, entry_val, NULL, mask,
 				   options);
-		ARG_UNUSED(ret2);
-		CHECKIF(ret2 != 0) {
+
+		/* Propagating a failure from the level below is not a caller
+		 * programming error, so it must not be compiled out by the
+		 * CHECKIF() configuration.
+		 */
+		if (ret2 != 0) {
 			ret = ret2;
 		}
 	}
@@ -1152,8 +1156,7 @@ static int range_map(void *virt, uintptr_t phys, size_t size,
 		ret2 = range_map_ptables(domain->ptables, virt, phys, size,
 					 entry_flags, mask,
 					 options | OPTION_USER);
-		ARG_UNUSED(ret2);
-		CHECKIF(ret2 != 0) {
+		if (ret2 != 0) {
 			ret = ret2;
 		}
 	}
@@ -1161,8 +1164,7 @@ static int range_map(void *virt, uintptr_t phys, size_t size,
 
 	ret2 = range_map_ptables(z_x86_kernel_ptables, virt, phys, size,
 				 entry_flags, mask, options);
-	ARG_UNUSED(ret2);
-	CHECKIF(ret2 != 0) {
+	if (ret2 != 0) {
 		ret = ret2;
 	}
 
@@ -1190,7 +1192,16 @@ static inline int range_map_unlocked(void *virt, uintptr_t phys, size_t size,
 	return ret;
 }
 
-static pentry_t flags_to_entry(uint32_t flags)
+/**
+ * Translate arch-neutral mapping flags to page table entry flags
+ *
+ * @param flags Arch-neutral mapping flags
+ * @param [out] entry_flags_p Resulting page table entry flags
+ *
+ * @retval 0 if successful
+ * @retval -ENOTSUP if the requested caching mode is not supported
+ */
+static int flags_to_entry(uint32_t flags, pentry_t *entry_flags_p)
 {
 	pentry_t entry_flags = MMU_P;
 
@@ -1210,8 +1221,8 @@ static pentry_t flags_to_entry(uint32_t flags)
 	case K_MEM_CACHE_WB:
 		break;
 	default:
-		__ASSERT(false, "bad memory mapping flags 0x%x", flags);
-		break;
+		LOG_ERR("bad memory mapping flags 0x%x", flags);
+		return -ENOTSUP;
 	}
 
 	if ((flags & K_MEM_PERM_RW) != 0U) {
@@ -1232,13 +1243,23 @@ static pentry_t flags_to_entry(uint32_t flags)
 		entry_flags |= MMU_A;
 	}
 
-	return entry_flags;
+	*entry_flags_p = entry_flags;
+
+	return 0;
 }
 
 /* map new region virt..virt+size to phys with provided arch-neutral flags */
 int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
-	return range_map_unlocked(virt, phys, size, flags_to_entry(flags), MASK_ALL, 0);
+	pentry_t entry_flags;
+	int ret;
+
+	ret = flags_to_entry(flags, &entry_flags);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return range_map_unlocked(virt, phys, size, entry_flags, MASK_ALL, 0);
 }
 
 /* unmap region addr..addr+size, reset entries and flush TLB */

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1242,14 +1242,9 @@ int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 }
 
 /* unmap region addr..addr+size, reset entries and flush TLB */
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
-	int ret;
-
-	ret = range_map_unlocked(addr, 0, size, 0, 0,
-				 OPTION_FLUSH | OPTION_CLEAR);
-	__ASSERT_NO_MSG(ret == 0);
-	ARG_UNUSED(ret);
+	return range_map_unlocked(addr, 0, size, 0, 0, OPTION_FLUSH | OPTION_CLEAR);
 }
 
 #ifdef K_MEM_IS_VM_KERNEL

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -968,7 +968,7 @@ static inline void __arch_mem_unmap(void *vaddr)
 #endif /* CONFIG_USERSPACE */
 }
 
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
 	uint32_t va = (uint32_t)addr;
 	uint32_t rem_size = (uint32_t)size;
@@ -976,12 +976,12 @@ void arch_mem_unmap(void *addr, size_t size)
 
 	if (addr == NULL) {
 		LOG_ERR("Cannot unmap NULL pointer");
-		return;
+		return -EINVAL;
 	}
 
 	if (size == 0) {
 		LOG_ERR("Cannot unmap virtual memory with zero size");
-		return;
+		return -EINVAL;
 	}
 
 	key = k_spin_lock(&xtensa_mmu_lock);
@@ -1002,6 +1002,8 @@ void arch_mem_unmap(void *addr, size_t size)
 	}
 
 	k_spin_unlock(&xtensa_mmu_lock, key);
+
+	return 0;
 }
 
 /* This should be implemented in the SoC layer.

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -367,7 +367,7 @@ enum dup_action {
 	COPY,
 };
 
-static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup_action action);
+static bool dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup_action action);
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_XTENSA_MMU_USE_DEFAULT_MAPPINGS
@@ -727,7 +727,9 @@ static bool l2_page_table_map(uint32_t *l1_table, void *vaddr, uintptr_t phys,
 	}
 #ifdef CONFIG_USERSPACE
 	else {
-		dup_l2_table_if_needed(l1_table, l1_pos, COPY);
+		if (!dup_l2_table_if_needed(l1_table, l1_pos, COPY)) {
+			return false;
+		}
 	}
 #endif
 
@@ -823,9 +825,10 @@ int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 		attrs |= XTENSA_MMU_CACHED_WT;
 		break;
 	case K_MEM_CACHE_NONE:
-		__fallthrough;
-	default:
 		break;
+	default:
+		LOG_ERR("Unsupported memory mapping cache mode");
+		return -ENOTSUP;
 	}
 
 	if ((flags & K_MEM_PERM_RW) == K_MEM_PERM_RW) {
@@ -840,8 +843,15 @@ int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 	key = k_spin_lock(&xtensa_mmu_lock);
 
 	while (rem_size > 0) {
-		if (!__arch_mem_map((void *)va, pa, attrs, is_user)) {
-			k_panic();
+		bool success = __arch_mem_map((void *)va, pa, attrs, is_user);
+
+		if (!success) {
+			/* Since some pages may have already been mapped in this loop.
+			 * We simply break out of this loop so TLB IPI can be sent,
+			 * and page tables flushed if cached.
+			 */
+			ret = -ENOMEM;
+			break;
 		}
 
 		rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
@@ -870,8 +880,12 @@ int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
  *
  * @note If all L2 PTEs in the L2 table are illegal, the L2 table will be
  *       unmapped from L1 and is returned to the pool.
+ *
+ * @retval true Unmapping is successful, or the address was not mapped.
+ * @retval false Unmapping failed. Usually means there are no free L2 tables to be
+ *               allocated for copy-on-write of a shared L2 table.
  */
-static void l2_page_table_unmap(uint32_t *l1_table, void *vaddr)
+static bool l2_page_table_unmap(uint32_t *l1_table, void *vaddr)
 {
 	uint32_t l1_pos = XTENSA_MMU_L1_POS((uint32_t)vaddr);
 	uint32_t l2_pos = XTENSA_MMU_L2_POS((uint32_t)vaddr);
@@ -886,11 +900,13 @@ static void l2_page_table_unmap(uint32_t *l1_table, void *vaddr)
 		/* We shouldn't be unmapping an illegal entry.
 		 * Return true so that we can invalidate ITLB too.
 		 */
-		return;
+		return true;
 	}
 
 #ifdef CONFIG_USERSPACE
-	dup_l2_table_if_needed(l1_table, l1_pos, COPY);
+	if (!dup_l2_table_if_needed(l1_table, l1_pos, COPY)) {
+		return false;
+	}
 #endif
 
 	l2_table = (uint32_t *)PTE_PPN_GET(l1_table[l1_pos]);
@@ -938,6 +954,8 @@ end:
 	if (exec) {
 		xtensa_itlb_vaddr_invalidate(vaddr);
 	}
+
+	return true;
 }
 
 /**
@@ -948,24 +966,42 @@ end:
  * This should only be called by @ref arch_mem_unmap to remove the mapping in the L2 tables.
  *
  * @param[in] vaddr Virtual address to be unmapped.
+ *
+ * @retval true Memory unmapped.
+ * @retval false Unmapping failed.
  */
-static inline void __arch_mem_unmap(void *vaddr)
+static inline bool __arch_mem_unmap(void *vaddr)
 {
-	l2_page_table_unmap(xtensa_kernel_ptables, vaddr);
+	bool ret;
+
+	ret = l2_page_table_unmap(xtensa_kernel_ptables, vaddr);
+	if (!ret) {
+		LOG_ERR("Cannot unmap virtual address (%p)", vaddr);
+	}
 
 #ifdef CONFIG_USERSPACE
-	sys_snode_t *node;
-	struct arch_mem_domain *domain;
-	k_spinlock_key_t key;
+	if (ret) {
+		sys_snode_t *node;
+		struct arch_mem_domain *domain;
+		k_spinlock_key_t key;
 
-	key = k_spin_lock(&z_mem_domain_lock);
-	SYS_SLIST_FOR_EACH_NODE(&xtensa_domain_list, node) {
-		domain = CONTAINER_OF(node, struct arch_mem_domain, node);
+		key = k_spin_lock(&z_mem_domain_lock);
+		SYS_SLIST_FOR_EACH_NODE(&xtensa_domain_list, node) {
+			domain = CONTAINER_OF(node, struct arch_mem_domain, node);
 
-		(void)l2_page_table_unmap(domain->ptables, vaddr);
+			ret = l2_page_table_unmap(domain->ptables, vaddr);
+			if (!ret) {
+				LOG_ERR("Cannot unmap virtual address (%p) for domain %p",
+					vaddr, domain);
+
+				break;
+			}
+		}
+		k_spin_unlock(&z_mem_domain_lock, key);
 	}
-	k_spin_unlock(&z_mem_domain_lock, key);
 #endif /* CONFIG_USERSPACE */
+
+	return ret;
 }
 
 int arch_mem_unmap(void *addr, size_t size)
@@ -973,6 +1009,7 @@ int arch_mem_unmap(void *addr, size_t size)
 	uint32_t va = (uint32_t)addr;
 	uint32_t rem_size = (uint32_t)size;
 	k_spinlock_key_t key;
+	int ret = 0;
 
 	if (addr == NULL) {
 		LOG_ERR("Cannot unmap NULL pointer");
@@ -987,7 +1024,14 @@ int arch_mem_unmap(void *addr, size_t size)
 	key = k_spin_lock(&xtensa_mmu_lock);
 
 	while (rem_size > 0) {
-		__arch_mem_unmap((void *)va);
+		if (!__arch_mem_unmap((void *)va)) {
+			/* Since some pages may have already been unmapped in this loop,
+			 * we simply break out of this loop so TLB IPI can be sent,
+			 * and page tables flushed if cached.
+			 */
+			ret = -ENOMEM;
+			break;
+		}
 
 		rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
 		va += KB(4);
@@ -1003,7 +1047,7 @@ int arch_mem_unmap(void *addr, size_t size)
 
 	k_spin_unlock(&xtensa_mmu_lock, key);
 
-	return 0;
+	return ret;
 }
 
 /* This should be implemented in the SoC layer.
@@ -1249,13 +1293,8 @@ static uint32_t *dup_l2_table(uint32_t *src_l2_table, enum dup_action action)
 
 	l2_table = alloc_l2_table();
 
-	/* Duplicating L2 tables is a must-have and must-success operation.
-	 * If we are running out of free L2 tables to be allocated, we cannot
-	 * continue.
-	 */
-	__ASSERT_NO_MSG(l2_table != NULL);
 	if (l2_table == NULL) {
-		arch_system_halt(K_ERR_KERNEL_PANIC);
+		return NULL;
 	}
 
 	switch (action) {
@@ -1375,8 +1414,11 @@ static uint32_t *dup_l1_table(void)
  * @param[in] action Action during duplication.
  *                   RESTORE to restore PTEs to the attributes stored in the backup bits.
  *                   COPY to copy PTEs from source without modifications.
+ *
+ * @retval true Duplication is done, or is not needed.
+ * @retval false Duplication failed. Usually means there are no free L2 tables to be allocated.
  */
-static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup_action action)
+static bool dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup_action action)
 {
 	uint32_t *l2_table, *src_l2_table;
 	k_spinlock_key_t key;
@@ -1387,10 +1429,15 @@ static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup
 	if (l2_page_tables_counter[l2_table_to_counter_pos(src_l2_table)] == 1) {
 		/* Only one user of L2 table, no need to duplicate. */
 		k_spin_unlock(&xtensa_counter_lock, key);
-		return;
+		return true;
 	}
 
 	l2_table = dup_l2_table(src_l2_table, action);
+	if (l2_table == NULL) {
+		k_spin_unlock(&xtensa_counter_lock, key);
+		LOG_ERR("Cannot duplicate L2 page table %p", src_l2_table);
+		return false;
+	}
 
 	/* The page table is using kernel ASID because we don't
 	 * user thread manipulate it.
@@ -1402,6 +1449,8 @@ static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup
 	k_spin_unlock(&xtensa_counter_lock, key);
 
 	sys_cache_data_flush_range((void *)l2_table, L2_PAGE_TABLE_SIZE);
+
+	return true;
 }
 
 int arch_mem_domain_init(struct k_mem_domain *domain)
@@ -1543,7 +1592,15 @@ static void region_map_update(uint32_t *l1_table, uintptr_t start,
 		}
 
 #ifdef CONFIG_USERSPACE
-		dup_l2_table_if_needed(l1_table, l1_pos, RESTORE);
+		if (!dup_l2_table_if_needed(l1_table, l1_pos, RESTORE)) {
+			/* There is no way to report the failure back to the caller,
+			 * and the memory domain would be left in an inconsistent
+			 * state with only part of the region updated. So forcibly
+			 * halt the system.
+			 */
+			LOG_ERR("Cannot update mapping of 0x%08x", page);
+			arch_system_halt(K_ERR_KERNEL_PANIC);
+		}
 #endif
 
 		l2_table = (uint32_t *)PTE_PPN_GET(l1_table[l1_pos]);

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -798,7 +798,7 @@ static inline bool __arch_mem_map(void *vaddr, uintptr_t paddr, uint32_t attrs, 
 	return ret;
 }
 
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	uint32_t va = (uint32_t)virt;
 	uint32_t pa = (uint32_t)phys;
@@ -806,11 +806,12 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 	uint32_t attrs = 0;
 	k_spinlock_key_t key;
 	bool is_user;
+	int ret = 0;
 
 	if (size == 0) {
 		LOG_ERR("Cannot map physical memory at 0x%08X: invalid "
 			"zero size", (uint32_t)phys);
-		k_panic();
+		return -EINVAL;
 	}
 
 	switch (flags & K_MEM_CACHE_MASK) {
@@ -857,6 +858,8 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 	}
 
 	k_spin_unlock(&xtensa_mmu_lock, key);
+
+	return ret;
 }
 
 /**

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -2086,6 +2086,11 @@ Architectures
 * The RISC-V specific ``CONFIG_EXTRA_EXCEPTION_INFO`` has been removed. Use
   :kconfig:option:`CONFIG_EXCEPTION_DEBUG` instead. The option is unchanged on Arm and SPARC.
 
+* Both :c:func:`arch_mem_map` and :c:func:`arch_mem_unmap` have changed from
+  returning ``void`` to ``int`` so that the caller can react to error code when
+  assertion is disabled. If assertion is enabled, it currently retains mostly
+  the previous behavior of halting the system.
+
 Video
 =====
 

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -391,7 +391,11 @@ static int sys_mm_drv_unmap_page_wflush(void *virt, bool flush_data)
 	if (flush_data) {
 		sys_cache_data_flush_range(virt, CONFIG_MM_DRV_PAGE_SIZE);
 #ifdef CONFIG_MMU
-		arch_mem_unmap(virt, CONFIG_MM_DRV_PAGE_SIZE);
+		ret = arch_mem_unmap(virt, CONFIG_MM_DRV_PAGE_SIZE);
+		__ASSERT(ret == 0, "arch_mem_unmap() failed %d\n", ret);
+		if (ret != 0) {
+			k_panic();
+		}
 #endif
 	}
 

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -277,7 +277,12 @@ int sys_mm_drv_map_page(void *virt, uintptr_t phys, uint32_t flags)
 	tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-	arch_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	ret = arch_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	__ASSERT(ret == 0, "arch_mem_map() failed %d\n", ret);
+	if (ret != 0) {
+		/* TODO: properly handle failed arch_mem_map(). */
+		k_panic();
+	}
 #endif
 	/*
 	 * Invalid the cache of the newly mapped virtual page to
@@ -471,7 +476,12 @@ int sys_mm_drv_update_page_flags(void *virt, uint32_t flags)
 	tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-	arch_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	ret = arch_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	__ASSERT(ret == 0, "arch_mem_map() failed %d\n", ret);
+	if (ret != 0) {
+		/* TODO: properly handle failed arch_mem_map(); */
+		k_panic();
+	}
 #endif
 
 out:
@@ -854,8 +864,15 @@ static void adsp_mm_save_context(void *storage_buffer)
 			tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-			arch_mem_map(UINT_TO_POINTER(phys_addr), phys_addr, CONFIG_MM_DRV_PAGE_SIZE,
-				     K_MEM_CACHE_WB | K_MEM_PERM_RW);
+			int ret = arch_mem_map(UINT_TO_POINTER(phys_addr), phys_addr,
+					       CONFIG_MM_DRV_PAGE_SIZE,
+					       K_MEM_CACHE_WB | K_MEM_PERM_RW);
+
+			__ASSERT(ret == 0, "arch_mem_map() failed %d\n", ret);
+			if (ret != 0) {
+				/* TODO: properly handle failed arch_mem_map() */
+				k_panic();
+			}
 #endif
 
 			/* Invalidate cache to avoid stalled data

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -365,8 +365,13 @@ int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
  *
  * @param addr Page-aligned base virtual address to un-map
  * @param size Page-aligned region size
+ *
+ * @retval 0 On success
+ * @retval -EINVAL If invalid arguments are given
+ * @retval -errno Other negative error codes may be returned by
+ *                architecture-specific implementations for other failure modes
  */
-void arch_mem_unmap(void *addr, size_t size);
+int arch_mem_unmap(void *addr, size_t size);
 
 /**
  * Update page frame database with reserved pages

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -329,8 +329,16 @@ static inline bool arch_is_in_isr(void);
  * @param phys Page-aligned Source physical address to map
  * @param size Page-aligned size of the mapped memory region in bytes
  * @param flags Caching, access and control flags, see K_MAP_* macros
+ *
+ * @retval 0 On success
+ * @retval -EINVAL If invalid arguments are given
+ * @retval -ENOTSUP If the requested cache/attribute combination in @a flags
+ *                  is not supported by the target architecture
+ * @retval -ENOMEM If the underlying page table could not be updated
+ * @retval -errno Other negative error codes may be returned by
+ *                architecture-specific implementations for other failure modes
  */
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
 
 /**
  * Remove mappings for a provided virtual address range

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -565,12 +565,18 @@ static int map_anon_page(void *addr, uint32_t flags)
 		 * unmap those first before returning the page frame back
 		 * to the list.
 		 */
-		arch_mem_unmap(addr, CONFIG_MMU_PAGE_SIZE);
-#endif
+		int unmap_ret = arch_mem_unmap(addr, CONFIG_MMU_PAGE_SIZE);
 
-		/* Mapping failed: give the page frame back before bailing out. */
-		page_frame_free_locked(pf);
-		return ret;
+		__ASSERT(unmap_ret == 0, "%s: cannot undo failed mapping %d\n", __func__,
+			 unmap_ret);
+
+		if (unmap_ret == 0)
+#endif
+		{
+			/* Mapping failed: give the page frame back before bailing out. */
+			page_frame_free_locked(pf);
+			return ret;
+		}
 	}
 
 	if (lock) {
@@ -635,9 +641,19 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 	/* Unmap both guard pages to make sure accessing them
 	 * will generate fault.
 	 */
-	arch_mem_unmap(dst, CONFIG_MMU_PAGE_SIZE);
-	arch_mem_unmap(dst + CONFIG_MMU_PAGE_SIZE + size,
-		       CONFIG_MMU_PAGE_SIZE);
+	ret = arch_mem_unmap(dst, CONFIG_MMU_PAGE_SIZE);
+	__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
+	if (ret != 0) {
+		dst = NULL;
+		goto out;
+	}
+
+	ret = arch_mem_unmap(dst + CONFIG_MMU_PAGE_SIZE + size, CONFIG_MMU_PAGE_SIZE);
+	__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
+	if (ret != 0) {
+		dst = NULL;
+		goto out;
+	}
 
 	/* Skip over the "before" guard page in returned address. */
 	dst += CONFIG_MMU_PAGE_SIZE;
@@ -757,7 +773,10 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 				 * Simply get rid of the MMU entry and free
 				 * corresponding backing store.
 				 */
-				arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+				ret = arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+				__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__,
+					 ret);
+
 				k_mem_paging_backing_store_location_free(location);
 				continue;
 			case ARCH_PAGE_LOCATION_PAGED_IN:
@@ -808,7 +827,15 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 				goto out;
 			}
 
-			arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+			ret = arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+			__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
+			if (ret != 0) {
+				/* Fail to unmap. Must bail without releasing any resources
+				 * as the page is still mapped.
+				 */
+				goto out;
+			}
+
 #ifdef CONFIG_DEMAND_PAGING
 			if (IS_ENABLED(CONFIG_EVICTION_TRACKING) &&
 			    (!k_mem_page_frame_is_pinned(pf))) {
@@ -827,7 +854,14 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 		 * have been unmapped. We just need to unmapped the in-between
 		 * region [addr, (addr + size)).
 		 */
-		arch_mem_unmap(addr, size);
+		ret = arch_mem_unmap(addr, size);
+		__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
+		if (ret != 0) {
+			/* Fail to unmap. Must bail without releasing any resources
+			 * as some pages are still be mapped.
+			 */
+			goto out;
+		}
 	}
 
 	/* There are guard pages just before and after the mapped
@@ -863,7 +897,12 @@ int k_mem_update_flags(void *addr, size_t size, uint32_t flags)
 
 	/* TODO: detect and handle paged-out memory as well */
 
-	arch_mem_unmap(addr, size);
+	ret = arch_mem_unmap(addr, size);
+	__ASSERT(ret == 0, "%s: arch_mem_unmap failed %d\n", __func__, ret);
+	if (ret != 0) {
+		goto out;
+	}
+
 	ret = arch_mem_map(addr, phys, size, flags);
 	__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
 
@@ -1013,6 +1052,7 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size)
 	uintptr_t aligned_virt, addr_offset;
 	size_t aligned_size;
 	k_spinlock_key_t key;
+	int ret;
 
 	addr_offset = k_mem_region_align(&aligned_virt, &aligned_size,
 					 POINTER_TO_UINT(virt), size,
@@ -1027,8 +1067,18 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size)
 	LOG_DBG("arch_mem_unmap(0x%lx, %zu) offset %lu",
 		aligned_virt, aligned_size, addr_offset);
 
-	arch_mem_unmap(UINT_TO_POINTER(aligned_virt), aligned_size);
+	ret = arch_mem_unmap(UINT_TO_POINTER(aligned_virt), aligned_size);
+	__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
+	if (ret != 0) {
+		/* Fail to unmap. We cannot free the virtual memory region
+		 * as some pages are still be mapped.
+		 */
+		goto out;
+	}
+
 	virt_region_free(UINT_TO_POINTER(aligned_virt), aligned_size);
+
+out:
 	k_spin_unlock(&z_mm_lock, key);
 }
 

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -526,13 +526,13 @@ static int map_anon_page(void *addr, uint32_t flags)
 	struct k_mem_page_frame *pf;
 	uintptr_t phys;
 	bool lock = (flags & K_MEM_MAP_LOCK) != 0U;
+	int ret;
 
 	pf = free_page_frame_list_get();
 	if (pf == NULL) {
 #ifdef CONFIG_DEMAND_PAGING
 		uintptr_t location;
 		bool dirty;
-		int ret;
 
 		pf = k_mem_paging_eviction_select(&dirty);
 		if (pf == NULL) {
@@ -556,7 +556,22 @@ static int map_anon_page(void *addr, uint32_t flags)
 	}
 
 	phys = k_mem_page_frame_to_phys(pf);
-	arch_mem_map(addr, phys, CONFIG_MMU_PAGE_SIZE, flags);
+	ret = arch_mem_map(addr, phys, CONFIG_MMU_PAGE_SIZE, flags);
+	__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
+	if (ret != 0) {
+#ifdef CONFIG_USERSPACE
+		/* The mapping above may have already succeeded in some
+		 * memory domains but failing in the middle. So we need to
+		 * unmap those first before returning the page frame back
+		 * to the list.
+		 */
+		arch_mem_unmap(addr, CONFIG_MMU_PAGE_SIZE);
+#endif
+
+		/* Mapping failed: give the page frame back before bailing out. */
+		page_frame_free_locked(pf);
+		return ret;
+	}
 
 	if (lock) {
 		k_mem_page_frame_set(pf, K_MEM_PAGE_FRAME_PINNED);
@@ -634,10 +649,15 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 		if ((flags & K_MEM_MAP_LOCK) == 0) {
 			flags |= K_MEM_MAP_UNPAGED;
 			VIRT_FOREACH(dst, size, pos) {
-				arch_mem_map(pos,
-					     uninit ? ARCH_UNPAGED_ANON_UNINIT
-						    : ARCH_UNPAGED_ANON_ZERO,
-					     CONFIG_MMU_PAGE_SIZE, flags);
+				ret = arch_mem_map(pos,
+						   uninit ? ARCH_UNPAGED_ANON_UNINIT
+							  : ARCH_UNPAGED_ANON_ZERO,
+						   CONFIG_MMU_PAGE_SIZE, flags);
+				__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
+				if (ret != 0) {
+					dst = NULL;
+					goto out;
+				}
 			}
 			LOG_DBG("memory mapping anon pages %p to %p unpaged", dst, pos-1);
 			/* skip the memset() below */
@@ -660,13 +680,12 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 			}
 		}
 	} else {
-		/* Mapping known physical memory.
-		 *
-		 * arch_mem_map() is a void function and does not return
-		 * anything. Arch code usually uses ASSERT() to catch
-		 * mapping errors. Assume this works correctly for now.
-		 */
-		arch_mem_map(dst, phys, size, flags);
+		/* Mapping known physical memory. */
+		ret = arch_mem_map(dst, phys, size, flags);
+		__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
+		if (ret != 0) {
+			dst = NULL;
+		}
 	}
 
 out:
@@ -845,7 +864,8 @@ int k_mem_update_flags(void *addr, size_t size, uint32_t flags)
 	/* TODO: detect and handle paged-out memory as well */
 
 	arch_mem_unmap(addr, size);
-	arch_mem_map(addr, phys, size, flags);
+	ret = arch_mem_map(addr, phys, size, flags);
+	__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
 
 out:
 	k_spin_unlock(&z_mm_lock, key);
@@ -903,6 +923,7 @@ void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32
 	uint8_t *dest_addr;
 	size_t num_bits;
 	size_t offset;
+	int ret;
 
 #ifndef CONFIG_KERNEL_DIRECT_MAP
 	__ASSERT(!(flags & K_MEM_DIRECT_MAP), "The direct-map is not enabled");
@@ -965,7 +986,11 @@ void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32
 	LOG_DBG("arch_mem_map(%p, 0x%lx, %zu, %x) offset %lu", (void *)dest_addr,
 		aligned_phys, aligned_size, flags, addr_offset);
 
-	arch_mem_map(dest_addr, aligned_phys, aligned_size, flags);
+	ret = arch_mem_map(dest_addr, aligned_phys, aligned_size, flags);
+	__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
+	if (ret != 0) {
+		goto fail;
+	}
 	k_spin_unlock(&z_mm_lock, key);
 
 	*virt_ptr = dest_addr + addr_offset;
@@ -1066,12 +1091,19 @@ static void z_paging_ondemand_section_map(void)
 	size_t size;
 	uintptr_t location;
 	uint32_t flags;
+	int ret;
 
 	size = (uintptr_t)lnkr_ondemand_text_size;
 	flags = K_MEM_MAP_UNPAGED | K_MEM_PERM_EXEC | K_MEM_CACHE_WB;
 	VIRT_FOREACH(lnkr_ondemand_text_start, size, addr) {
 		k_mem_paging_backing_store_location_query(addr, &location);
-		arch_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+
+		ret = arch_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		__ASSERT(ret == 0, "arch_mem_map() returned %d", ret);
+		if (ret != 0) {
+			k_panic();
+		}
+
 		sys_bitarray_set_region(&virt_region_bitmap, 1,
 					virt_to_bitmap_offset(addr, CONFIG_MMU_PAGE_SIZE));
 	}
@@ -1080,7 +1112,13 @@ static void z_paging_ondemand_section_map(void)
 	flags = K_MEM_MAP_UNPAGED | K_MEM_CACHE_WB;
 	VIRT_FOREACH(lnkr_ondemand_rodata_start, size, addr) {
 		k_mem_paging_backing_store_location_query(addr, &location);
-		arch_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+
+		ret = arch_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		__ASSERT(ret == 0, "arch_mem_map() returned %d", ret);
+		if (ret != 0) {
+			k_panic();
+		}
+
 		sys_bitarray_set_region(&virt_region_bitmap, 1,
 					virt_to_bitmap_offset(addr, CONFIG_MMU_PAGE_SIZE));
 	}

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -520,13 +520,24 @@ static inline void do_backing_store_page_out(uintptr_t location);
  * page-ins as memory is mapped and physical RAM or backing store storage will
  * not be used if the mapped memory is unused. The cost is an empty physical
  * page of zeroes.
+ *
+ * @param addr Virtual address to map the page frame to
+ * @param flags Mapping flags
+ * @param[out] recovered Set to false if a failed mapping could not be undone,
+ *                       which means the page may still be mapped and its page
+ *                       frame cannot be reused.
+ *
+ * @retval 0 On success
+ * @retval -errno On failure
  */
-static int map_anon_page(void *addr, uint32_t flags)
+static int map_anon_page(void *addr, uint32_t flags, bool *recovered)
 {
 	struct k_mem_page_frame *pf;
 	uintptr_t phys;
 	bool lock = (flags & K_MEM_MAP_LOCK) != 0U;
 	int ret;
+
+	*recovered = true;
 
 	pf = free_page_frame_list_get();
 	if (pf == NULL) {
@@ -570,13 +581,19 @@ static int map_anon_page(void *addr, uint32_t flags)
 		__ASSERT(unmap_ret == 0, "%s: cannot undo failed mapping %d\n", __func__,
 			 unmap_ret);
 
-		if (unmap_ret == 0)
-#endif
-		{
-			/* Mapping failed: give the page frame back before bailing out. */
-			page_frame_free_locked(pf);
+		if (unmap_ret != 0) {
+			/* The page may still be mapped in some memory domains,
+			 * so the page frame cannot be given back to the free
+			 * list for reuse.
+			 */
+			*recovered = false;
 			return ret;
 		}
+#endif
+
+		/* Mapping failed: give the page frame back before bailing out. */
+		page_frame_free_locked(pf);
+		return ret;
 	}
 
 	if (lock) {
@@ -594,9 +611,162 @@ static int map_anon_page(void *addr, uint32_t flags)
 	return 0;
 }
 
+/**
+ * Undo pages previously established by map_anon_page().
+ *
+ * Only used to roll back a partial k_mem_map_phys_guard() failure
+ * via the anonymous memory path, the pages are known to be
+ * currently mapped and not paged out.
+ *
+ * @param virt Start virtual address to unmap pages
+ * @param sz Size of memory region to be unmapped
+ *
+ * @retval 0 On success
+ * @retval -errno On failure
+ */
+static int unmap_anon_pages(void *virt, size_t sz)
+{
+	uint8_t *pos;
+	uintptr_t phys;
+	struct k_mem_page_frame *pf;
+	int ret = 0;
+
+	VIRT_FOREACH(virt, sz, pos) {
+#ifdef CONFIG_DEMAND_PAGING
+		enum arch_page_location status;
+		uintptr_t location;
+
+		status = arch_page_location_get(pos, &location);
+		switch (status) {
+		case ARCH_PAGE_LOCATION_PAGED_OUT:
+			/*
+			 * No pf is associated with this mapping.
+			 * Simply get rid of the MMU entry and free
+			 * corresponding backing store.
+			 */
+			ret = arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+			__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__,
+				 ret);
+
+			k_mem_paging_backing_store_location_free(location);
+
+			if (ret != 0) {
+				goto unmap_anon_out;
+			}
+
+			continue;
+		case ARCH_PAGE_LOCATION_PAGED_IN:
+			/*
+			 * The page is in memory but it may not be
+			 * accessible in order to manage tracking
+			 * of the ARCH_DATA_PAGE_ACCESSED flag
+			 * meaning arch_page_phys_get() could fail.
+			 * Still, we know the actual phys address.
+			 */
+			phys = location;
+			ret = 0;
+			break;
+		default:
+			ret = arch_page_phys_get(pos, &phys);
+			break;
+		}
+#else
+		ret = arch_page_phys_get(pos, &phys);
+#endif
+		__ASSERT(ret == 0, "%s: cannot unmap an unmapped address %p", __func__, pos);
+		if (ret != 0) {
+			/* Found an address not mapped. Do not continue. */
+			goto unmap_anon_out;
+		}
+
+		__ASSERT(k_mem_is_page_frame(phys), "%s: 0x%lx is not a page frame", __func__,
+			 phys);
+		if (!k_mem_is_page_frame(phys)) {
+			/* Physical address has no corresponding page frame
+			 * description in the page frame array.
+			 * This should not happen. Do not continue.
+			 */
+			goto unmap_anon_out;
+		}
+
+		/* Grab the corresponding page frame from physical address */
+		pf = k_mem_phys_to_page_frame(phys);
+
+		__ASSERT(k_mem_page_frame_is_mapped(pf), "%s: 0x%lx is not a mapped page frame",
+			 __func__, phys);
+		if (!k_mem_page_frame_is_mapped(pf)) {
+			/* Page frame is not marked mapped.
+			 * This should not happen. Do not continue.
+			 */
+			goto unmap_anon_out;
+		}
+
+		ret = arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+		__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
+		if (ret != 0) {
+			/* Fail to unmap. Must bail without releasing any resources
+			 * as the page is still mapped.
+			 */
+			goto unmap_anon_out;
+		}
+
+#ifdef CONFIG_DEMAND_PAGING
+		if (IS_ENABLED(CONFIG_EVICTION_TRACKING) &&
+		    (!k_mem_page_frame_is_pinned(pf))) {
+			k_mem_paging_eviction_remove(pf);
+		}
+#endif
+
+		/* Put the page frame back into free list */
+		page_frame_free_locked(pf);
+	}
+
+unmap_anon_out:
+	return ret;
+}
+
+#ifdef CONFIG_DEMAND_MAPPING
+/**
+ * Undo demand mapped pages previously established by map_anon_page().
+ *
+ * Only used to roll back a partial k_mem_map_phys_guard() failure
+ * via the demand mapped path where pages are mapped with flags
+ * K_MEM_MAP_UNPAGED.
+ *
+ * @param virt Start virtual address to umap pages
+ * @param sz Size of memory region to be unmapped
+ *
+ * @retval true When able to unmap all pages.
+ * @retval false When fails to unmap some pages.
+ */
+static bool undo_demand_mapped_pages(void *virt, size_t sz)
+{
+	uint8_t *undo_pos;
+	bool success = true;
+	int ret;
+
+	/* Undo the pages mapped before the failure. */
+	VIRT_FOREACH(virt, sz, undo_pos) {
+		ret = arch_mem_unmap(undo_pos, CONFIG_MMU_PAGE_SIZE);
+		__ASSERT(ret == 0, "%s: cannot undo mapped pages %d", __func__, ret);
+
+		/* Failed to undo one mapped page. Though we still
+		 * want to continue unmapping the remaining mapped
+		 * pages to reclaim them.
+		 */
+		if (ret != 0) {
+			success = false;
+		}
+	}
+
+	return success;
+}
+#endif
+
 void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_anon)
 {
 	uint8_t *dst;
+	uint8_t *region;
 	size_t total_size;
 	int ret;
 	k_spinlock_key_t key;
@@ -632,23 +802,28 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 
 	key = k_spin_lock(&z_mm_lock);
 
-	dst = virt_region_alloc(total_size, CONFIG_MMU_PAGE_SIZE);
-	if (dst == NULL) {
+	region = virt_region_alloc(total_size, CONFIG_MMU_PAGE_SIZE);
+	if (region == NULL) {
 		/* Address space has no free region */
+		dst = NULL;
 		goto out;
 	}
 
 	/* Unmap both guard pages to make sure accessing them
 	 * will generate fault.
+	 *
+	 * Note that a failed unmap may have left the guard page mapped in
+	 * some memory domains, so the virtual region cannot be freed for
+	 * reuse.
 	 */
-	ret = arch_mem_unmap(dst, CONFIG_MMU_PAGE_SIZE);
+	ret = arch_mem_unmap(region, CONFIG_MMU_PAGE_SIZE);
 	__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
 	if (ret != 0) {
 		dst = NULL;
 		goto out;
 	}
 
-	ret = arch_mem_unmap(dst + CONFIG_MMU_PAGE_SIZE + size, CONFIG_MMU_PAGE_SIZE);
+	ret = arch_mem_unmap(region + CONFIG_MMU_PAGE_SIZE + size, CONFIG_MMU_PAGE_SIZE);
 	__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
 	if (ret != 0) {
 		dst = NULL;
@@ -656,7 +831,7 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 	}
 
 	/* Skip over the "before" guard page in returned address. */
-	dst += CONFIG_MMU_PAGE_SIZE;
+	dst = region + CONFIG_MMU_PAGE_SIZE;
 
 	if (is_anon) {
 		/* Mapping from anonymous memory */
@@ -671,8 +846,33 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 						   CONFIG_MMU_PAGE_SIZE, flags);
 				__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
 				if (ret != 0) {
+					size_t unmap_sz = pos - dst;
+
+					if (IS_ENABLED(CONFIG_USERSPACE)) {
+						/* Note that it is unmapping an extra page due to
+						 * the possibility that the mapping above has
+						 * already updated some memory domains but fail in
+						 * the middle. So we need to include the failed
+						 * page to unmap those that have been mapped so
+						 * far.
+						 */
+						unmap_sz += CONFIG_MMU_PAGE_SIZE;
+					}
+
+					bool success = undo_demand_mapped_pages(dst, unmap_sz);
+
 					dst = NULL;
-					goto out;
+
+					if (success) {
+						goto fail;
+					} else {
+						/* Cannot fully recover from mapping
+						 * failure. We cannot free the allocated
+						 * virtual memory region since some of
+						 * the page may still be mapped.
+						 */
+						goto out;
+					}
 				}
 			}
 			LOG_DBG("memory mapping anon pages %p to %p unpaged", dst, pos-1);
@@ -682,16 +882,25 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 #endif
 		{
 			VIRT_FOREACH(dst, size, pos) {
-				ret = map_anon_page(pos, flags);
+				bool recovered;
+
+				ret = map_anon_page(pos, flags, &recovered);
 
 				if (ret != 0) {
-					/* TODO:
-					 * call k_mem_unmap(dst, pos - dst)
-					 * when implemented in #28990 and
-					 * release any guard virtual page as well.
-					 */
+					int unmap_ret = unmap_anon_pages(dst, pos - dst);
+
 					dst = NULL;
-					goto out;
+
+					if ((unmap_ret == 0) && recovered) {
+						goto fail;
+					} else {
+						/* Cannot fully recover from mapping
+						 * failure. We cannot free the allocated
+						 * virtual memory region since some of
+						 * the page may still be mapped.
+						 */
+						goto out;
+					}
 				}
 			}
 		}
@@ -700,7 +909,20 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 		ret = arch_mem_map(dst, phys, size, flags);
 		__ASSERT(ret == 0, "%s: arch_mem_map failed %d\n", __func__, ret);
 		if (ret != 0) {
+			/* Clean up any partial mapping left behind. */
+			ret = arch_mem_unmap(dst, size);
+			__ASSERT(ret == 0, "%s: cannot undo mapped pages %d", __func__, ret);
+
 			dst = NULL;
+
+			if (ret != 0) {
+				/* Cannot fully undo all the mappings. There might still be pages
+				 * mapped. So we cannot free the allocated virtual memory region.
+				 */
+				goto out;
+			} else {
+				goto fail;
+			}
 		}
 	}
 
@@ -715,13 +937,17 @@ out:
 	}
 
 	return dst;
+
+fail:
+	/* Release the whole region, including the guard pages. */
+	virt_region_free(region, total_size);
+
+	goto out;
 }
 
 void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 {
-	uintptr_t phys;
 	uint8_t *pos;
-	struct k_mem_page_frame *pf;
 	k_spinlock_key_t key;
 	size_t total_size;
 	int ret;
@@ -760,91 +986,13 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 
 	if (is_anon) {
 		/* Unmapping anonymous memory */
-		VIRT_FOREACH(addr, size, pos) {
-#ifdef CONFIG_DEMAND_PAGING
-			enum arch_page_location status;
-			uintptr_t location;
-
-			status = arch_page_location_get(pos, &location);
-			switch (status) {
-			case ARCH_PAGE_LOCATION_PAGED_OUT:
-				/*
-				 * No pf is associated with this mapping.
-				 * Simply get rid of the MMU entry and free
-				 * corresponding backing store.
-				 */
-				ret = arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
-				__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__,
-					 ret);
-
-				k_mem_paging_backing_store_location_free(location);
-				continue;
-			case ARCH_PAGE_LOCATION_PAGED_IN:
-				/*
-				 * The page is in memory but it may not be
-				 * accessible in order to manage tracking
-				 * of the ARCH_DATA_PAGE_ACCESSED flag
-				 * meaning arch_page_phys_get() could fail.
-				 * Still, we know the actual phys address.
-				 */
-				phys = location;
-				ret = 0;
-				break;
-			default:
-				ret = arch_page_phys_get(pos, &phys);
-				break;
-			}
-#else
-			ret = arch_page_phys_get(pos, &phys);
-#endif
-			__ASSERT(ret == 0,
-				 "%s: cannot unmap an unmapped address %p",
-				 __func__, pos);
-			if (ret != 0) {
-				/* Found an address not mapped. Do not continue. */
-				goto out;
-			}
-
-			__ASSERT(k_mem_is_page_frame(phys),
-				 "%s: 0x%lx is not a page frame", __func__, phys);
-			if (!k_mem_is_page_frame(phys)) {
-				/* Physical address has no corresponding page frame
-				 * description in the page frame array.
-				 * This should not happen. Do not continue.
-				 */
-				goto out;
-			}
-
-			/* Grab the corresponding page frame from physical address */
-			pf = k_mem_phys_to_page_frame(phys);
-
-			__ASSERT(k_mem_page_frame_is_mapped(pf),
-				 "%s: 0x%lx is not a mapped page frame", __func__, phys);
-			if (!k_mem_page_frame_is_mapped(pf)) {
-				/* Page frame is not marked mapped.
-				 * This should not happen. Do not continue.
-				 */
-				goto out;
-			}
-
-			ret = arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
-			__ASSERT(ret == 0, "%s: arch_mem_unmap() returned %d", __func__, ret);
-			if (ret != 0) {
-				/* Fail to unmap. Must bail without releasing any resources
-				 * as the page is still mapped.
-				 */
-				goto out;
-			}
-
-#ifdef CONFIG_DEMAND_PAGING
-			if (IS_ENABLED(CONFIG_EVICTION_TRACKING) &&
-			    (!k_mem_page_frame_is_pinned(pf))) {
-				k_mem_paging_eviction_remove(pf);
-			}
-#endif
-
-			/* Put the page frame back into free list */
-			page_frame_free_locked(pf);
+		ret = unmap_anon_pages(addr, size);
+		__ASSERT(ret == 0, "%s: unmap_anon_pages() returned %d", __func__, ret);
+		if (ret != 0) {
+			/* Fail to unmap. Must bail without releasing any resources
+			 * as some pages are still be mapped.
+			 */
+			goto out;
 		}
 	} else {
 		/*

--- a/tests/arch/arm64/arm64_mmu/src/main.c
+++ b/tests/arch/arm64/arm64_mmu/src/main.c
@@ -62,7 +62,8 @@ static int mem_map_test(uintptr_t virt_addr, uintptr_t phys_addr, size_t size)
 	zassert_true(mapped_tables_usage > initial_tables_usage,
 		     "%#x vs %#x", mapped_tables_usage, initial_tables_usage);
 
-	arch_mem_unmap((void *)virt_addr, size);
+	ret = arch_mem_unmap((void *)virt_addr, size);
+	zassert_ok(ret, "arch_mem_unmap() returned %d", ret);
 
 	int unmapped_nb_free_tables = arm64_mmu_nb_free_tables();
 	int unmapped_tables_usage = arm64_mmu_tables_total_usage();
@@ -181,7 +182,8 @@ ZTEST(arm64_mmu, test_arm64_mmu_05_hole_in_block)
 	 * Now poke a hole in the middle of this block mapping, effectively
 	 * splitting it in two disjoint sub-mappings.
 	 */
-	arch_mem_unmap((void *)(virt + CONFIG_MMU_PAGE_SIZE), CONFIG_MMU_PAGE_SIZE);
+	ret = arch_mem_unmap((void *)(virt + CONFIG_MMU_PAGE_SIZE), CONFIG_MMU_PAGE_SIZE);
+	zassert_ok(ret, "arch_mem_unmap() returned %d", ret);
 
 	int split_nb_free_tables = arm64_mmu_nb_free_tables();
 	int split_tables_usage = arm64_mmu_tables_total_usage();
@@ -204,7 +206,8 @@ ZTEST(arm64_mmu, test_arm64_mmu_05_hole_in_block)
 	/*
 	 * Then free it all.
 	 */
-	arch_mem_unmap((void *)virt, size);
+	ret = arch_mem_unmap((void *)virt, size);
+	zassert_ok(ret, "arch_mem_unmap() returned %d", ret);
 
 	int unmapped_nb_free_tables = arm64_mmu_nb_free_tables();
 	int unmapped_tables_usage = arm64_mmu_tables_total_usage();

--- a/tests/arch/arm64/arm64_mmu/src/main.c
+++ b/tests/arch/arm64/arm64_mmu/src/main.c
@@ -45,11 +45,10 @@ static void *arm64_mmu_test_init(void)
 
 static int mem_map_test(uintptr_t virt_addr, uintptr_t phys_addr, size_t size)
 {
-	/*
-	 * This is not defined to return any error but the implementation
-	 * will call k_panic() if an error occurs.
-	 */
-	arch_mem_map((void *)virt_addr, phys_addr, size, K_MEM_ARM_NORMAL_NC);
+	int ret;
+
+	ret = arch_mem_map((void *)virt_addr, phys_addr, size, K_MEM_ARM_NORMAL_NC);
+	zassert_ok(ret, "arch_mem_map() returned %d", ret);
 
 	int mapped_nb_free_tables = arm64_mmu_nb_free_tables();
 	int mapped_tables_usage = arm64_mmu_tables_total_usage();
@@ -161,8 +160,10 @@ ZTEST(arm64_mmu, test_arm64_mmu_05_hole_in_block)
 	uintptr_t virt = TEST_VIRT_ADDR & ~(block_size - 1);
 	uintptr_t phys = TEST_PHYS_ADDR & ~(block_size - 1);
 	size_t size = block_size;
+	int ret;
 
-	arch_mem_map((void *)virt, phys, size, K_MEM_ARM_NORMAL_NC);
+	ret = arch_mem_map((void *)virt, phys, size, K_MEM_ARM_NORMAL_NC);
+	zassert_ok(ret, "arch_mem_map() returned %d", ret);
 
 	int mapped_nb_free_tables = arm64_mmu_nb_free_tables();
 	int mapped_tables_usage = arm64_mmu_tables_total_usage();


### PR DESCRIPTION
- Changed both `arch_mem_map()` and `arch_mem_unmap()` to return error code. This retains mostly previous behavior of halting the system if assertion is enabled.
- Modified `k_mem_map_phys_guard()` to recovery from mapping failures by unmapping already mapped pages.