### PR TITLE
drivers: haptics: Multi write fixes for CS40L26

### DIFF
--- a/drivers/haptics/cirrus/cs40l26.c
+++ b/drivers/haptics/cirrus/cs40l26.c
@@ -537,14 +537,14 @@ static int cs40l26_irq_config(const struct device *const dev)
 		return ret;
 	}
 
-	ret = cs40lxx_multi_write(&config->io_bus, cs40l26_irq_masks,
-				  ARRAY_SIZE(cs40l26_irq_masks));
+	ret = cs40lxx_raw_multi_write(&config->io_bus, cs40l26_irq_masks,
+				      ARRAY_SIZE(cs40l26_irq_masks));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = cs40lxx_multi_write(&config->io_bus, cs40l26_irq_clear,
-				  ARRAY_SIZE(cs40l26_irq_clear));
+	ret = cs40lxx_raw_multi_write(&config->io_bus, cs40l26_irq_clear,
+				      ARRAY_SIZE(cs40l26_irq_clear));
 	if (ret < 0) {
 		return ret;
 	}


### PR DESCRIPTION
Fixes the same issue addressed in #114981 but for CS40L26. For CS40L26, this issue leads to malformed masks for the first IRQ register and then IRQ storms. This problem becomes apparent when disabling runtime PM because otherwise the power sequencer correctly writes IRQ masks when exiting hibernation.