### PR TITLE
soc: st: common: Enable debug in low power modes on F4

### DIFF
--- a/soc/st/stm32/common/soc_config.c
+++ b/soc/st/stm32/common/soc_config.c
@@ -72,6 +72,7 @@ static int st_stm32_common_config(void)
 
 #if defined(CONFIG_SOC_SERIES_STM32C5X) || \
 	defined(CONFIG_SOC_SERIES_STM32F1X) || \
+	defined(CONFIG_SOC_SERIES_STM32F4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L1X)
 	LL_DBGMCU_EnableDBGSleepMode();
 	LL_DBGMCU_EnableDBGStopMode();
@@ -97,6 +98,7 @@ static int st_stm32_common_config(void)
 /* keeping in mind that debugging draws a lot of power we explicitly disable when not needed */
 #if defined(CONFIG_SOC_SERIES_STM32C5X) || \
 	defined(CONFIG_SOC_SERIES_STM32F1X) || \
+	defined(CONFIG_SOC_SERIES_STM32F4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L1X)
 	LL_DBGMCU_DisableDBGSleepMode();
 	LL_DBGMCU_DisableDBGStopMode();


### PR DESCRIPTION
#115490 
Enable/disable debug in Sleep/Stop/Standby modes on F4xx series upon CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP.