### PR TITLE
drivers: flash: esp32: use relative timeout when locking async mutex

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -549,7 +549,7 @@ static IRAM_ATTR int flash_esp32_read_async(const struct device *dev, off_t addr
 	if (k_is_in_isr()) {
 		return -EINVAL;
 	}
-	if (k_mutex_lock(&data->lock, K_TIMEOUT_ABS_SEC(CONFIG_ESP_FLASH_ASYNC_TIMEOUT))) {
+	if (k_mutex_lock(&data->lock, K_SECONDS(CONFIG_ESP_FLASH_ASYNC_TIMEOUT))) {
 		return -ETIMEDOUT;
 	}
 	req->op = FLASH_OP_READ;
@@ -573,7 +573,7 @@ static IRAM_ATTR int flash_esp32_write_async(const struct device *dev, off_t add
 	if (k_is_in_isr()) {
 		return -EINVAL;
 	}
-	if (k_mutex_lock(&data->lock, K_TIMEOUT_ABS_SEC(CONFIG_ESP_FLASH_ASYNC_TIMEOUT))) {
+	if (k_mutex_lock(&data->lock, K_SECONDS(CONFIG_ESP_FLASH_ASYNC_TIMEOUT))) {
 		return -ETIMEDOUT;
 	}
 	req->op = FLASH_OP_WRITE;
@@ -596,7 +596,7 @@ static IRAM_ATTR int flash_esp32_erase_async(const struct device *dev, off_t sta
 	if (k_is_in_isr()) {
 		return -EINVAL;
 	}
-	if (k_mutex_lock(&data->lock, K_TIMEOUT_ABS_SEC(CONFIG_ESP_FLASH_ASYNC_TIMEOUT))) {
+	if (k_mutex_lock(&data->lock, K_SECONDS(CONFIG_ESP_FLASH_ASYNC_TIMEOUT))) {
 		return -ETIMEDOUT;
 	}
 	req->op = FLASH_OP_ERASE;


### PR DESCRIPTION
The asynchronous read/write/erase handlers passed
K_TIMEOUT_ABS_SEC(CONFIG_ESP_FLASH_ASYNC_TIMEOUT) to k_mutex_lock().
That macro builds an absolute deadline measured from system boot
rather than a relative timeout. Once the system uptime exceeds
CONFIG_ESP_FLASH_ASYNC_TIMEOUT seconds the deadline always lies in
the past, so any contended lock attempt fails immediately and the
flash operation returns -ETIMEDOUT without ever being submitted.
Uncontended calls are unaffected because k_mutex_lock() takes a
fast path that ignores the timeout, which is why the failure only
shows up under concurrent access.

Use K_SECONDS() so that the configured value is honoured as a
relative timeout, matching the Kconfig help text.

Fixes #115594
