### PR TITLE
pwm_nrfx: No glitch on 0% just like on 100%

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -200,6 +200,7 @@ static int pwm_nrfx_set_cycles(const struct device *dev, uint32_t channel,
 	if (pulse_cycles == 0) {
 		/* Constantly inactive (duty 0%). */
 		compare_value = 0;
+		needs_pwm = IS_ENABLED(CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100);
 	} else if (pulse_cycles >= period_cycles) {
 		/* Constantly active (duty 100%). */
 		/* This value is always greater than or equal to COUNTERTOP. */


### PR DESCRIPTION
I have 4 LEDs driven by the same PWM block and make one of them blink, the others off. I see that the remaining three are glitching a little on on every blink.