### PR TITLE
drivers: virtio: improve Doxygen coverage

### DIFF
--- a/include/zephyr/drivers/virtio.h
+++ b/include/zephyr/drivers/virtio.h
@@ -41,21 +41,83 @@ typedef uint16_t (*virtio_enumerate_queues)(
 );
 
 /**
- * @brief Virtio api structure
+ * @def_driverbackendgroup{VIRTIO,virtio_interface}
+ * @{
+ */
+
+/**
+ * @brief Type definition of VIRTIO API function for getting a virtqueue.
+ * See virtio_get_virtqueue() for argument descriptions.
+ */
+typedef struct virtq *(*virtio_api_get_virtqueue)(const struct device *dev, uint16_t queue_idx);
+
+/**
+ * @brief Type definition of VIRTIO API function for notifying a virtqueue.
+ * See virtio_notify_virtqueue() for argument descriptions.
+ */
+typedef void (*virtio_api_notify_virtqueue)(const struct device *dev, uint16_t queue_idx);
+
+/**
+ * @brief Type definition of VIRTIO API function for getting the device specific config.
+ * See virtio_get_device_specific_config() for argument descriptions.
+ */
+typedef void *(*virtio_api_get_device_specific_config)(const struct device *dev);
+
+/**
+ * @brief Type definition of VIRTIO API function for reading a device feature bit.
+ * See virtio_read_device_feature_bit() for argument descriptions.
+ */
+typedef bool (*virtio_api_read_device_feature_bit)(const struct device *dev, int bit);
+
+/**
+ * @brief Type definition of VIRTIO API function for writing a driver feature bit.
+ * See virtio_write_driver_feature_bit() for argument descriptions.
+ */
+typedef int (*virtio_api_write_driver_feature_bit)(const struct device *dev, int bit, bool value);
+
+/**
+ * @brief Type definition of VIRTIO API function for committing the feature bits.
+ * See virtio_commit_feature_bits() for argument descriptions.
+ */
+typedef int (*virtio_api_commit_feature_bits)(const struct device *dev);
+
+/**
+ * @brief Type definition of VIRTIO API function for initializing the virtqueues.
+ * See virtio_init_virtqueues() for argument descriptions.
+ */
+typedef int (*virtio_api_init_virtqueues)(
+	const struct device *dev, uint16_t num_queues, virtio_enumerate_queues cb, void *opaque
+);
+
+/**
+ * @brief Type definition of VIRTIO API function for finalizing the initialization.
+ * See virtio_finalize_init() for argument descriptions.
+ */
+typedef void (*virtio_api_finalize_init)(const struct device *dev);
+
+/**
+ * @driver_ops{VIRTIO}
  */
 __subsystem struct virtio_driver_api {
-	struct virtq *(*get_virtqueue)(const struct device *dev, uint16_t queue_idx);
-	void (*notify_virtqueue)(const struct device *dev, uint16_t queue_idx);
-	void *(*get_device_specific_config)(const struct device *dev);
-	bool (*read_device_feature_bit)(const struct device *dev, int bit);
-	int (*write_driver_feature_bit)(const struct device *dev, int bit, bool value);
-	int (*commit_feature_bits)(const struct device *dev);
-	int (*init_virtqueues)(
-		const struct device *dev, uint16_t num_queues, virtio_enumerate_queues cb,
-		void *opaque
-	);
-	void (*finalize_init)(const struct device *dev);
+	/** @driver_ops_mandatory @copybrief virtio_get_virtqueue */
+	virtio_api_get_virtqueue get_virtqueue;
+	/** @driver_ops_mandatory @copybrief virtio_notify_virtqueue */
+	virtio_api_notify_virtqueue notify_virtqueue;
+	/** @driver_ops_mandatory @copybrief virtio_get_device_specific_config */
+	virtio_api_get_device_specific_config get_device_specific_config;
+	/** @driver_ops_mandatory @copybrief virtio_read_device_feature_bit */
+	virtio_api_read_device_feature_bit read_device_feature_bit;
+	/** @driver_ops_mandatory @copybrief virtio_write_driver_feature_bit */
+	virtio_api_write_driver_feature_bit write_driver_feature_bit;
+	/** @driver_ops_mandatory @copybrief virtio_commit_feature_bits */
+	virtio_api_commit_feature_bits commit_feature_bits;
+	/** @driver_ops_mandatory @copybrief virtio_init_virtqueues */
+	virtio_api_init_virtqueues init_virtqueues;
+	/** @driver_ops_mandatory @copybrief virtio_finalize_init */
+	virtio_api_finalize_init finalize_init;
 };
+
+/** @} */
 
 /**
  * Returns virtqueue at given idx

--- a/include/zephyr/drivers/virtio/virtio_config.h
+++ b/include/zephyr/drivers/virtio/virtio_config.h
@@ -7,6 +7,7 @@
 
 /**
  * @file
+ * @ingroup virtio_interface
  *
  * VIRTIO common definitions based on the specification.
  *

--- a/include/zephyr/drivers/virtio/virtqueue.h
+++ b/include/zephyr/drivers/virtio/virtqueue.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the VIRTIO virtqueue API.
+ * @ingroup virtqueue_interface
+ */
+
 #ifndef ZEPHYR_VIRTIO_VIRTQUEUE_H_
 #define ZEPHYR_VIRTIO_VIRTQUEUE_H_
 #include <stdint.h>


### PR DESCRIPTION
Adopt the driver backend API Doxygen convention for the VIRTIO driver
API: place the operations in a "Driver Backend API" subgroup, define a
typedef for each operation, and annotate the operations structure with
`@driver_ops`, marking all operations as mandatory with their briefs
copied from the public wrapper functions.

Attach the virtqueue and VIRTIO config `@file` blocks to their Doxygen
groups.

No functional change.