### PR TITLE
net: tls_credentials_shell: fix OOB write in digest buffer

### DIFF
--- a/subsys/net/lib/tls_credentials/Kconfig.shell
+++ b/subsys/net/lib/tls_credentials/Kconfig.shell
@@ -27,6 +27,7 @@ config TLS_CREDENTIALS_SHELL_CRED_OUTPUT_WIDTH
 config TLS_CREDENTIALS_SHELL_DIGEST_BUF_SIZE
 	int "Buffer for generating credentials digests"
 	default 48
+	range 3 65535
 	help
 	   The amount of preallocated buffer (in bytes) for temporarily storing credential digests.
 

--- a/subsys/net/lib/tls_credentials/tls_credentials_shell.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_shell.c
@@ -77,6 +77,8 @@ BUILD_ASSERT(
  */
 static char cred_out_buf[CONFIG_TLS_CREDENTIALS_SHELL_CRED_OUTPUT_WIDTH + 1];
 static char cred_digest_buf[CONFIG_TLS_CREDENTIALS_SHELL_DIGEST_BUF_SIZE + 1];
+BUILD_ASSERT(CONFIG_TLS_CREDENTIALS_SHELL_DIGEST_BUF_SIZE >= 3,
+	     "CONFIG_TLS_CREDENTIALS_SHELL_DIGEST_BUF_SIZE must be >= 3 to hold \"N/A\"");
 
 /* Internal buffer used for storing and retrieving credentials.
  * +1 byte for potential NULL termination.


### PR DESCRIPTION
strcpy(cred_digest_buf, "N/A") in tls_cred_cmd_list() writes 4 bytes unconditionally, but the buffer size is controlled by CONFIG_TLS_CREDENTIALS_SHELL_DIGEST_BUF_SIZE with no enforced minimum, allowing values of 1 or 2 to produce an out-of-bounds write into adjacent BSS memory.

- Add `range 3 65535` to Kconfig to block invalid values at configuration time
- Add BUILD_ASSERT to avoid defconfigs bypassing the Kconfig constraint