### PR TITLE
instrumentation: improve Doxygen coverage

### DIFF
--- a/include/zephyr/instrumentation/instrumentation.h
+++ b/include/zephyr/instrumentation/instrumentation.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the code instrumentation subsystem APIs.
+ * @ingroup instrumentation_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_INSTRUMENTATION_INSTRUMENTATION_H_
 #define ZEPHYR_INCLUDE_INSTRUMENTATION_INSTRUMENTATION_H_
 

--- a/include/zephyr/instrumentation/instrumentation.h
+++ b/include/zephyr/instrumentation/instrumentation.h
@@ -71,12 +71,17 @@ struct instr_event_context {
  *        on the code and additional fields in the header.
  */
 struct instr_record {
+	/** Record header. */
 	struct instr_header header;
+	/** Address of the function the event was generated for. */
 	void *callee;
+	/** Address of the caller of the function the event was generated for. */
 	void *caller;
+	/** Time the event was generated, in nanoseconds. */
 	uint64_t timestamp;
+	/** Event payload. */
 	union {
-		struct instr_event_context context; /* Context data */
+		struct instr_event_context context; /**< Context data */
 		/* Add more payloads here */
 	};
 } __packed;


### PR DESCRIPTION
Add the missing `@file` block to the instrumentation header and document
the instrumentation record structure members.

Documentation only, no functional change.