### PR TITLE
drivers: input: gt911: clamp reported touch point count

### DIFF
--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -13,6 +13,7 @@
 #include <zephyr/input/input.h>
 #include <zephyr/input/input_touch.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/pm/pm.h>
 
 #include <zephyr/logging/log.h>
@@ -143,9 +144,10 @@ static int gt911_process(const struct device *dev)
 	/*
 	 * Note- since we program the max number of touch inputs during init,
 	 * the controller won't report more than the maximum number of touch
-	 * points we are configured to support
+	 * points we are configured to support. Clamp anyway so that corrupted
+	 * data on the bus cannot overflow the point array.
 	 */
-	points = status & GT911_TOUCH_POINTS_MSK;
+	points = min(status & GT911_TOUCH_POINTS_MSK, CONFIG_INPUT_GT911_MAX_TOUCH_POINTS);
 
 	/* need to clear the status */
 	static const uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS,


### PR DESCRIPTION
### Description

The fix clamps the count of the touch points to the array size to avoid an unexpected overflow.

`gt911_process()` derives the touch point count from the device status register:

    points = status & GT911_TOUCH_POINTS_MSK;   /* 0..15 */

and then uses it as the loop bound when filling a stack array sized to `CONFIG_INPUT_GT911_MAX_TOUCH_POINTS`, which the Kconfig restricts to `range 1 5` (default 1):

    struct gt911_point_reg point_reg[CONFIG_INPUT_GT911_MAX_TOUCH_POINTS];

The existing comment assumes the controller cannot report more points than the value programmed into its config registers during init. That assumption only holds as long as the data coming back over I2C is trustworthy. With a stuck/noisy bus or a misbehaving chip,  `points` can reach 15 and the driver writes beyond the array, corrupting the stack.

No early return is used because the status register clear happens further down. Clamping also keeps `prev_points` / `prev_point_reg` consistent so release events are still paired correctly.

### Testing

Build tested. Behaviour is unchanged for a correctly configured controller, which never reports more than the configured maximum.

Fixes: #116414