### PR TITLE
dts: arm: nxp: rt1010: fix DCP base address

### DIFF
--- a/dts/arm/nxp/imxrt/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1010.dtsi
@@ -118,6 +118,21 @@
 		/* Remove SEMC, it doesn't exist on RT1010 */
 		/delete-node/ semc0@402f0000;
 
+		/* Fixup DCP, it has a different base address on RT1010.
+		 * The shared nxp_rt10xx.dtsi places DCP at 0x402fc000
+		 * (valid for RT105x/RT106x), but on the RT1011 the DCP
+		 * lives at 0x400f0000. Accessing 0x402fc000 hits an
+		 * unimplemented AIPS slot and faults during DCP_Init.
+		 */
+		/delete-node/ dcp@402fc000;
+
+		dcp: dcp@400f0000 {
+			compatible = "nxp,mcux-dcp";
+			reg = <0x400f0000 0x4000>;
+			interrupts = <50 0>, <51 0>;
+			status = "okay";
+		};
+
 		/* Fixup LPI2C1 and LPI2C2, they have different base addr on RT1010 */
 		/delete-node/ i2c@403f0000;
 		/delete-node/ i2c@403f4000;


### PR DESCRIPTION
Fixes #115606.

The shared `nxp_rt10xx.dtsi` places the DCP crypto engine at `0x402fc000`, which is correct for RT105x/RT106x but wrong for the RT1011. On RT1011 the DCP is located at `0x400f0000` (MCUX HAL `MIMXRT1011_COMMON.h`).

Accessing `0x402fc000` during `DCP_Init()` hits an unimplemented AIPS slot and triggers an imprecise data bus fault (Zephyr fatal error 26) before `main()` -- e.g. running `samples/drivers/crypto` on `mimxrt1010_evk/mimxrt1011`.

Relocate the DCP node to `0x400f0000` for RT1011, using the same SoC-fixup override pattern already present in `nxp_rt1010.dtsi` (GPIO2, FlexSPI, SEMC).

**Verification (on hardware, LPC-LINK2 / EVK-MIMXRT1010):**
- Before: bus fault inside `DCP_Init()` during POST_KERNEL init.
- After: generated DT shows `dcp@400f0000`; boot proceeds past `crypto_dcp_init` into `main()`.

Assisted-by: GitHubCopilot:claude-opus-4.8
Signed-off-by: Hake Huang <hake.huang@nxp.com>
