### PR TITLE
boards: nordic: nrf93m1dk: v0.4.0 variant

### DIFF
--- a/boards/nordic/nrf93m1dk/board.yml
+++ b/boards/nordic/nrf93m1dk/board.yml
@@ -4,11 +4,12 @@ board:
   vendor: nordic
   revision:
     format: major.minor.patch
-    default: "0.3.0"
+    default: "0.4.0"
     revisions:
     - name: "0.1.0"
     - name: "0.2.0"
     - name: "0.3.0"
+    - name: "0.4.0"
   socs:
   - name: nrf54l15
     variants:
@@ -36,6 +37,10 @@ runners:
         - nrf93m1dk@0.3.0/nrf54l15/cpuapp/ns
         - nrf93m1dk@0.3.0/nrf54l15/cpuflpr
         - nrf93m1dk@0.3.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.4.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.4.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.4.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.4.0/nrf54l15/cpuflpr/xip
     '--erase':
     - runners:
       - jlink
@@ -55,6 +60,10 @@ runners:
         - nrf93m1dk@0.3.0/nrf54l15/cpuapp/ns
         - nrf93m1dk@0.3.0/nrf54l15/cpuflpr
         - nrf93m1dk@0.3.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.4.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.4.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.4.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.4.0/nrf54l15/cpuflpr/xip
     '--reset':
     - runners:
       - jlink
@@ -74,3 +83,7 @@ runners:
         - nrf93m1dk@0.3.0/nrf54l15/cpuapp/ns
         - nrf93m1dk@0.3.0/nrf54l15/cpuflpr
         - nrf93m1dk@0.3.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.4.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.4.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.4.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.4.0/nrf54l15/cpuflpr/xip

--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_common_0_4_0.dtsi
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_common_0_4_0.dtsi
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf93m1dk_nrf54l15_common_0_3_0.dtsi"
+
+/* The only v0.4.0 change with respect to v0.3.0 is the loading
+ * of the PUYA P25Q64SL SPI flash instead of the Macronix MX25R64.
+ */
+/delete-node/ &mx25r64;
+
+&spi00 {
+	p25q64: p25q64sl@0 {
+		compatible = "jedec,spi-nor";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+		jedec-id = [85 60 17];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <3000>;
+		t-exit-dpd = <35000>;
+		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+	};
+};

--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_0_4_0.overlay
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_0_4_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf93m1dk_nrf54l15_common_0_4_0.dtsi"

--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_ns_0_4_0.overlay
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_ns_0_4_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf93m1dk_nrf54l15_common_0_4_0.dtsi"


### PR DESCRIPTION
Add the v0.4.0 hardware variant, and make it the default build revision.

My understanding is that v0.3.0 ran out of stock months ago and any DKs handed out since are v0.4.0, hence the update to the default revision. Also worth noting that the public schematics for the v0.4.0 still show the Macronix flash, but Nordic support says all v0.4.0's have the PUYA flash.