### PR TITLE
drivers: counter: rpi_pico_timer: fix 32-bit timerawl wraparound

### DIFF
--- a/drivers/counter/counter_rpi_pico_timer.c
+++ b/drivers/counter/counter_rpi_pico_timer.c
@@ -83,7 +83,7 @@ static int counter_rpi_pico_timer_set_alarm(const struct device *dev, uint8_t id
 	absolute_time_t alarm_at;
 	bool missed;
 
-	update_us_since_boot(&alarm_at, config->timer->timerawl + target);
+	update_us_since_boot(&alarm_at, timer_time_us_64(config->timer) + target);
 
 	if (alarm_cfg->ticks > counter_rpi_pico_timer_get_top_value(dev)) {
 		return -EINVAL;


### PR DESCRIPTION
counter_rpi_pico_timer_set_alarm() computed the alarm target using only the low 32 bits of the hardware's free-running microsecond counter (TIMERAWL), which wraps every ~71.6 minutes. Once uptime exceeded this, every subsequent alarm target was computed against a stale/wrapped "now", causing timer_hardware_alarm_set_target() to always report the target as missed. This made counter_set_channel_alarm() return -ETIME permanently until reboot.

Fix by reading the full 64-bit hardware time instead of the truncated low word.

Fixes #115552


Assisted-by: Claude:claude-sonnet-5