### PR TITLE
drivers: serial: nrfx_uarte: Fix calculation of an internal variable

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -3242,7 +3242,7 @@ static int uarte_instance_deinit(const struct device *dev)
 		 },									\
 		 .bounce_buf_len = sizeof(uart##idx##_bounce_buf) / 2,			\
 		 .bounce_buf_swap_len = UARTE_BUF_SWAP_LEN(sizeof(uart##idx##_bounce_buf) / 2,\
-				UARTE_US_TO_BYTES(UARTE_PROP(idx, current_speed))),	\
+				UARTE_PROP(idx, current_speed)),	\
 		 .cbwt_data = &uart##idx##_bounce_data,))
 
 #define UARTE_COUNT_BYTES_WITH_TIMER_VALIDATE_CONFIG(idx) \


### PR DESCRIPTION
bounce_buf_swap_len variable is used when mode that uses TIMER to count RX bytes was used. Macro for calculating that variable was invoked with incorrect argument as UARTE_US_TO_BYTES was applied to baudrate argument. Because of that
CONFIG_UART_NRFX_UARTE_BOUNCE_BUF_SWAP_LATENCY was in fact not applied.