### PR TITLE
drivers: auxdisplay: Add TM1650 7-segment display driver

### DIFF
--- a/drivers/auxdisplay/CMakeLists.txt
+++ b/drivers/auxdisplay/CMakeLists.txt
@@ -15,4 +15,5 @@ zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_NXP_SLCD auxdisplay_nxp_slcd.c)
 zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_PT6314 auxdisplay_pt6314.c)
 zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_SERLCD auxdisplay_serlcd.c)
 zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_TM1637 auxdisplay_tm1637.c)
+zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_TM1650 auxdisplay_tm1650.c)
 # zephyr-keep-sorted-stop

--- a/drivers/auxdisplay/Kconfig
+++ b/drivers/auxdisplay/Kconfig
@@ -29,6 +29,7 @@ source "drivers/auxdisplay/Kconfig.nxp_slcd"
 source "drivers/auxdisplay/Kconfig.pt6314"
 source "drivers/auxdisplay/Kconfig.serlcd"
 source "drivers/auxdisplay/Kconfig.tm1637"
+source "drivers/auxdisplay/Kconfig.tm1650"
 # zephyr-keep-sorted-stop
 
 endif # AUXDISPLAY

--- a/drivers/auxdisplay/Kconfig.tm1650
+++ b/drivers/auxdisplay/Kconfig.tm1650
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Smile
+
+config AUXDISPLAY_TM1650
+	bool "Titan Micro TM1650 7-segment display support"
+	default y
+	depends on DT_HAS_TITANMEC_TM1650_ENABLED
+	select I2C
+	help
+	  Enable driver for TM (Shenzhen Titan Micro Elec) TM1650 7-segment LED display.
+	  This driver supports 4-digit 7-segment displays commonly found in clock modules
+	  and simple numeric displays.
+
+	  The TM1650 uses an I2C compatible two-wire serial interface (CLK and DIO) and can control
+	  up to 4 digits with brightness control.
+
+	  This driver implements the auxdisplay API, allowing generic display usage.

--- a/drivers/auxdisplay/auxdisplay_tm1650.c
+++ b/drivers/auxdisplay/auxdisplay_tm1650.c
@@ -1,0 +1,303 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Smile
+ */
+
+#define DT_DRV_COMPAT titanmec_tm1650
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/auxdisplay.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(tm1650_auxdisplay, CONFIG_AUXDISPLAY_LOG_LEVEL);
+
+/*
+ * TM1650 protocol commands
+ * Convert 8-bit TM1650 addresses to 7-bit I2C addresses.
+ */
+#define TM1650_CMD_DISP_ADDR_BASE (0x68 >> 1)
+#define TM1650_CMD_SYS_ADDR       (0x48 >> 1)
+
+/* TM1650 segment bit definitions */
+#define TM1650_BLANK     (0)    /* No segments lit */
+#define TM1650_DP_BIT    BIT(7) /* Decimal point */
+#define TM1650_MINUS_BIT BIT(6) /* Segment G only */
+
+/* TM1650 capabilities */
+#define TM1650_BRIGHTNESS_MAX	7
+#define TM1650_BRIGHTNESS_MIN	0
+
+/* Segment mapping: A=bit0, B=bit1, C=bit2, D=bit3, E=bit4, F=bit5, G=bit6; DP=bit7 */
+static const uint8_t digit_segment_codes[] = {
+	0x3F, /* 0 */
+	0x06, /* 1 */
+	0x5B, /* 2 */
+	0x4F, /* 3 */
+	0x66, /* 4 */
+	0x6D, /* 5 */
+	0x7D, /* 6 */
+	0x07, /* 7 */
+	0x7F, /* 8 */
+	0x6F, /* 9 */
+};
+
+/* Look-up table matching brightness (0-7) to TM1650 brightness levels */
+static const uint8_t table_brightness[] = {
+	0x10, /* Level 1 */
+	0x20, /* Level 2 */
+	0x30, /* Level 3 */
+	0x40, /* Level 4 */
+	0x50, /* Level 5 */
+	0x60, /* Level 6 */
+	0x70, /* Level 7 */
+	0x00, /* Level 8 */
+};
+
+struct tm1650_config {
+	struct auxdisplay_capabilities capabilities;
+	struct i2c_dt_spec i2c;
+};
+
+struct tm1650_data {
+	uint8_t display_buffer[4];  /* raw segment data for maximum 4 digits */
+	int16_t cursor_x;
+	int16_t cursor_y;
+	uint8_t current_brightness; /* level (0-7) */
+	bool display_on;
+};
+
+static inline int tm1650_write_cmd(const struct device *dev, uint8_t addr, uint8_t data_byte)
+{
+	const struct tm1650_config *cfg = dev->config;
+
+	return i2c_write(cfg->i2c.bus, &data_byte, 1, addr);
+}
+
+static int tm1650_config_display(const struct device *dev)
+{
+	struct tm1650_data *data = dev->data;
+	uint8_t sys_config = table_brightness[data->current_brightness] | data->display_on;
+
+	return tm1650_write_cmd(dev, TM1650_CMD_SYS_ADDR, sys_config);
+}
+
+static int tm1650_write_display(const struct device *dev)
+{
+	struct tm1650_data *data = dev->data;
+	const struct tm1650_config *cfg = dev->config;
+	int err;
+
+	for (int i = 0; i < cfg->capabilities.columns; i++) {
+		err = tm1650_write_cmd(dev, TM1650_CMD_DISP_ADDR_BASE + i*0x1U,
+				       data->display_buffer[i]);
+		if (err != 0) {
+			return err;
+		}
+	}
+	return 0;
+}
+
+/* auxdisplay driver API */
+
+static int tm1650_auxdisplay_write(const struct device *dev, const uint8_t *buf, uint16_t len)
+{
+	struct tm1650_data *data = dev->data;
+	const struct tm1650_config *cfg = dev->config;
+	uint32_t pos = 0;
+	uint16_t i = 0;
+
+	while (i < len && pos < cfg->capabilities.columns) {
+		char c = buf[i];
+		uint8_t segment_code = 0;
+		bool valid_char = false;
+
+		if (c >= '0' && c <= '9') {
+			segment_code = digit_segment_codes[c - '0'];
+			valid_char = true;
+		} else if (c == '-') {
+			segment_code = TM1650_MINUS_BIT;
+			valid_char = true;
+		} else if (c == ' ') {
+			segment_code = TM1650_BLANK;
+			valid_char = true;
+		} else {
+			valid_char = false;
+		}
+
+		if (valid_char) {
+			/* Check if next character is a decimal point */
+			if (i + 1 < len && buf[i + 1] == '.') {
+				segment_code |= TM1650_DP_BIT; /* Add decimal point */
+				i += 2; /* Skip both the character and the '.' */
+			} else {
+				i++; /* Move to next character */
+			}
+
+			data->display_buffer[data->cursor_x] = segment_code;
+			data->cursor_x = (data->cursor_x + 1) % cfg->capabilities.columns;
+		} else {
+			/* Skip unknown characters */
+			i++;
+		}
+	}
+
+	return tm1650_write_display(dev);
+}
+
+static int tm1650_auxdisplay_clear(const struct device *dev)
+{
+	struct tm1650_data *data = dev->data;
+
+	memset(data->display_buffer, TM1650_BLANK, sizeof(data->display_buffer));
+	data->cursor_x = 0;
+	data->cursor_y = 0;
+
+	return tm1650_write_display(dev);
+}
+
+static int tm1650_auxdisplay_set_brightness(const struct device *dev, uint8_t brightness)
+{
+	struct tm1650_data *data = dev->data;
+
+	if (brightness > TM1650_BRIGHTNESS_MAX) {
+		return -EINVAL;
+	}
+	data->current_brightness = brightness;
+
+	return tm1650_config_display(dev);
+}
+
+static int tm1650_auxdisplay_get_brightness(const struct device *dev, uint8_t *brightness)
+{
+	struct tm1650_data *data = dev->data;
+
+	*brightness = data->current_brightness;
+	return 0;
+}
+
+static int tm1650_auxdisplay_display_on(const struct device *dev)
+{
+	struct tm1650_data *data = dev->data;
+
+	data->display_on = true;
+
+	return tm1650_config_display(dev);
+}
+
+static int tm1650_auxdisplay_display_off(const struct device *dev)
+{
+	struct tm1650_data *data = dev->data;
+
+	data->display_on = false;
+
+	return tm1650_config_display(dev);
+}
+
+static int tm1650_auxdisplay_cursor_position_set(const struct device *dev,
+						 enum auxdisplay_position type,
+						 int16_t x, int16_t y)
+{
+	const struct tm1650_config *cfg = dev->config;
+	struct tm1650_data *data = dev->data;
+
+	switch (type) {
+	case AUXDISPLAY_POSITION_RELATIVE:
+		x += data->cursor_x;
+		y += data->cursor_y;
+		break;
+	case AUXDISPLAY_POSITION_RELATIVE_DIRECTION:
+		return -ENOTSUP;
+	case AUXDISPLAY_POSITION_ABSOLUTE:
+		/* x, y already in absolute coordinates */
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (x < 0 || y < 0 || x >= cfg->capabilities.columns || y >= cfg->capabilities.rows) {
+		return -EINVAL;
+	}
+
+	data->cursor_x = x;
+	data->cursor_y = y;
+	return 0;
+}
+
+static int tm1650_auxdisplay_cursor_position_get(const struct device *dev, int16_t *x, int16_t *y)
+{
+	struct tm1650_data *data = dev->data;
+
+	*x = data->cursor_x;
+	*y = data->cursor_y;
+	return 0;
+}
+
+static int tm1650_auxdisplay_capabilities_get(const struct device *dev,
+					      struct auxdisplay_capabilities *cap)
+{
+	const struct tm1650_config *cfg = dev->config;
+
+	memcpy(cap, &cfg->capabilities, sizeof(*cap));
+	return 0;
+}
+
+/* Device initialization */
+
+static int tm1650_initialize(const struct device *dev)
+{
+	const struct tm1650_config *cfg = dev->config;
+	struct tm1650_data *data = dev->data;
+
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
+		return -ENODEV;
+	}
+
+	data->display_on = true;
+	data->current_brightness = cfg->capabilities.brightness.minimum;
+
+	if (tm1650_config_display(dev) != 0) {
+		LOG_ERR("Failed to configure display");
+		return -ENXIO;
+	}
+
+	if (tm1650_auxdisplay_clear(dev) != 0) {
+		LOG_ERR("Failed to clear display");
+		return -ENXIO;
+	}
+	return 0;
+}
+
+static DEVICE_API(auxdisplay, tm1650_auxdisplay_api) = {
+	.write = tm1650_auxdisplay_write,
+	.clear = tm1650_auxdisplay_clear,
+	.brightness_set = tm1650_auxdisplay_set_brightness,
+	.brightness_get = tm1650_auxdisplay_get_brightness,
+	.display_on = tm1650_auxdisplay_display_on,
+	.display_off = tm1650_auxdisplay_display_off,
+	.cursor_position_set = tm1650_auxdisplay_cursor_position_set,
+	.cursor_position_get = tm1650_auxdisplay_cursor_position_get,
+	.capabilities_get = tm1650_auxdisplay_capabilities_get,
+};
+
+#define TM1650_INIT(n)                                                                             \
+	static const struct tm1650_config tm1650_config_##n = {                                    \
+		.capabilities =                                                                    \
+			{                                                                          \
+				.columns = DT_INST_PROP(n, columns),                               \
+				.rows = DT_INST_PROP(n, rows),                                     \
+				.brightness = {                                                    \
+					.minimum = TM1650_BRIGHTNESS_MIN,                          \
+					.maximum = TM1650_BRIGHTNESS_MAX,                          \
+				},                                                                 \
+			},                                                                         \
+		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
+	};                                                                                         \
+	static struct tm1650_data tm1650_data_##n;                                                 \
+	DEVICE_DT_INST_DEFINE(n, tm1650_initialize, NULL, &tm1650_data_##n, &tm1650_config_##n,    \
+			      POST_KERNEL, CONFIG_AUXDISPLAY_INIT_PRIORITY,                        \
+			      &tm1650_auxdisplay_api);
+
+DT_INST_FOREACH_STATUS_OKAY(TM1650_INIT)

--- a/dts/bindings/auxdisplay/titanmec,tm1650.yaml
+++ b/dts/bindings/auxdisplay/titanmec,tm1650.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Smile
+
+description: TM1650 7-segment LED display controller
+
+compatible: "titanmec,tm1650"
+
+include: ["i2c-device.yaml", "auxdisplay-device.yaml"]
+
+properties:
+  rows:
+    const: 1
+    description: TM1650 only supports 1 row (up to 4 digits).
+
+  columns:
+    enum: [1, 2, 3, 4]
+    description: |
+      Number of digits connected to the TM1650. The TM1650 supports up
+      to 4 of 7-segment digits.
+
+examples:
+  - |
+    &i2c {
+      status = "okay";
+
+      auxdisplay_0: auxdisplay@24 {
+        compatible = "titanmec,tm1650";
+        status = "okay";
+        reg = <0x24>; /* 7 MSB of TM1650 system command address 0x48 */
+        columns = <4>;
+        rows = <1>;
+      };
+    };

--- a/samples/drivers/auxdisplay_digits/src/main.c
+++ b/samples/drivers/auxdisplay_digits/src/main.c
@@ -22,8 +22,8 @@ LOG_MODULE_REGISTER(auxdisplay_sample, LOG_LEVEL_DBG);
 #define AUXDISPLAY_DIGIT_COUNT (DT_PROP(DT_NODELABEL(slcd_panel), columns) * \
 	DT_PROP(DT_NODELABEL(slcd_panel), rows))
 #else
-#define AUXDISPLAY_DIGIT_COUNT (DT_PROP(AUXDISPLAY_NODE, columns) * \
-	DT_PROP(AUXDISPLAY_NODE, rows))
+#define AUXDISPLAY_DIGIT_COUNT (DT_PROP_OR(AUXDISPLAY_NODE, columns, 1) * \
+	DT_PROP_OR(AUXDISPLAY_NODE, rows, 1))
 #endif
 
 static const struct device *const dev = DEVICE_DT_GET(AUXDISPLAY_NODE);

--- a/samples/drivers/auxdisplay_digits/src/main.c
+++ b/samples/drivers/auxdisplay_digits/src/main.c
@@ -18,9 +18,12 @@ LOG_MODULE_REGISTER(auxdisplay_sample, LOG_LEVEL_DBG);
 #define AUXDISPLAY_NODE        DT_NODELABEL(auxdisplay_0)
 #if DT_NODE_HAS_COMPAT(AUXDISPLAY_NODE, gpio_7_segment)
 #define AUXDISPLAY_DIGIT_COUNT DT_PROP_LEN(AUXDISPLAY_NODE, digit_gpios)
-#else
+#elif DT_NODE_EXISTS(DT_NODELABEL(slcd_panel))
 #define AUXDISPLAY_DIGIT_COUNT (DT_PROP(DT_NODELABEL(slcd_panel), columns) * \
 	DT_PROP(DT_NODELABEL(slcd_panel), rows))
+#else
+#define AUXDISPLAY_DIGIT_COUNT (DT_PROP(AUXDISPLAY_NODE, columns) * \
+	DT_PROP(AUXDISPLAY_NODE, rows))
 #endif
 
 static const struct device *const dev = DEVICE_DT_GET(AUXDISPLAY_NODE);

--- a/tests/drivers/build_all/auxdisplay/i2c_devices.overlay
+++ b/tests/drivers/build_all/auxdisplay/i2c_devices.overlay
@@ -41,6 +41,14 @@
 				columns = <16>;
 				rows = <2>;
 			};
+
+			test_tm1650: tm1650@24 {
+				compatible = "titanmec,tm1650";
+				reg = <0x24>;
+				status = "okay";
+				columns = <4>;
+				rows = <1>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
Add a new driver for TM1650 device. 

The driver support :
* 4 digit 7-segment display with decimal point
* auxdisplay API
* control over I2C
* display on/off
* brightness control (8 levels)

Also modify auxdisplay_digits sample to allow using it with more auxdisplay devices.