### PR TITLE
samples: bluetooth: peripheral_hr: rename power optimization overlay and reduce flash consumption

### DIFF
--- a/samples/bluetooth/peripheral_hr/boards/stm32wba_pwr_optim.overlay
+++ b/samples/bluetooth/peripheral_hr/boards/stm32wba_pwr_optim.overlay
@@ -21,3 +21,16 @@
 &lptim1 {
 	status = "okay";
 };
+
+/*
+ * Reduce flash usage for the power-optimized setup so the full flash is
+ * not used when it is not necessary, helping reduce power consumption.
+ * the pm_S2ram node is moved accordingly to the end of the used flash.
+ */
+&sram0 {
+	reg = <0x20000000 (DT_SIZE_K(64) - 0x20)>;
+};
+
+&pm_s2ram {
+	reg = <(0x20000000 + DT_SIZE_K(64) - 0x20) 0x20>;
+};


### PR DESCRIPTION
Rename the standby overlay for stm32wba product to a power-optimization focused name so its intent is clear 

Keep the standby-oriented SRAM and PM_S2RAM layout in this overlay to match the power-optimized memory setup and reduce its size for power consumption optimization.

The flash usage has been reduced to 64k for all STM32WBA boards