### PR TITLE
scripts: gen_kobject_list: fix crash on const array members

### DIFF
--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -319,6 +319,13 @@ class ConstType:
     def __repr__(self):
         return f"<const {self.child_type}>"
 
+    @property
+    def size(self):
+        # A const qualifier does not change the storage size, so delegate
+        # to the underlying type. Needed when a const-qualified type is
+        # used as an array member and ArrayType computes element strides.
+        return type_env[self.child_type].size
+
     def has_kobject(self):
         if self.child_type not in type_env:
             return False


### PR DESCRIPTION
**Description**

`ArrayType.get_kobjects()` computes each element address using `mt.size` to stride through the array. When the array member type resolves to a `ConstType` (a `const`-qualified kernel object), this raised:

```
AttributeError: 'ConstType' object has no attribute 'size'
```

`ConstType` only defined `child_type`, `has_kobject()` and `get_kobjects()`. This adds a `size` property that delegates to the underlying child type, mirroring the existing delegation in `has_kobject()`/`get_kobjects()`. A `const` qualifier does not change storage size, so returning the child type size is correct.

**Fixes** #115618