### PR TITLE
net: mqtt: add v5.0 subscribe options

### DIFF
--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -112,6 +112,25 @@ enum mqtt_qos {
 	MQTT_QOS_2_EXACTLY_ONCE  = 0x02
 };
 
+#if defined(CONFIG_MQTT_VERSION_5_0) || defined(__DOXYGEN__)
+/** @brief MQTT v5.0 Retain Handling options. (MQTT 5.0, chapter 3.3.1.3) */
+enum mqtt_retain_handling {
+	/** Send the retained messages matching the Topic Filter
+	 *  of the subscription to the Client at the time of the subscribe.
+	 */
+	MQTT_RH_0_SEND_AT_SUBSCRIBE = 0x00,
+
+	/** If the subscription did not already exist, send all retained message matching
+	 *  the Topic Filter of the subscription to the Client, and if the subscription
+	 *  did exist do not send the retained messages.
+	 */
+	MQTT_RH_1_SEND_IF_NEW = 0x01,
+
+	/** Do not send retained messages at the time of the subscribe. */
+	MQTT_RH_2_DO_NOT_SEND = 0x02
+};
+#endif /* CONFIG_MQTT_VERSION_5_0 */
+
 /** @brief MQTT 3.1 CONNACK return codes. */
 enum mqtt_conn_return_code {
 	/** Connection accepted. */
@@ -266,6 +285,14 @@ struct mqtt_topic {
 	 *  @ref mqtt_qos for details.
 	 */
 	uint8_t qos;
+#if defined(CONFIG_MQTT_VERSION_5_0) || defined(__DOXYGEN__)
+	/** MQTT 5.0, chapter 3.8.3.1 No Local subscription option. */
+	uint8_t no_local;
+	/** MQTT 5.0, chapter 3.8.3.1 Retain As Published subscription option. */
+	uint8_t retain_as_published;
+	/** MQTT 5.0, chapter 3.8.3.1 Retain Handling subscription option. */
+	uint8_t retain_handling;
+#endif
 };
 
 /** @brief Abstracts MQTT UTF-8 encoded string pair.

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -1349,6 +1349,39 @@ static int subscribe_properties_encode(const struct mqtt_subscription_list *para
 }
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 
+static int subscribe_options_encode(const struct mqtt_client *client,
+				    const struct mqtt_topic *topic, struct buf_ctx *buf)
+{
+	int err;
+	uint8_t subscribe_options;
+
+	/* In both v3.1.1 and v5.0 QoS should be checked to avoid
+	 * it overflowing into the reserved bits, leading to the server
+	 * flagging the SUBSCRIBE packet as malformed.
+	 */
+	if (topic->qos > MQTT_QOS_2_EXACTLY_ONCE) {
+		return -EINVAL;
+	}
+	subscribe_options = topic->qos & 0x03;
+#if defined(CONFIG_MQTT_VERSION_5_0)
+	if (mqtt_is_version_5_0(client)) {
+		if (topic->retain_handling > MQTT_RH_2_DO_NOT_SEND) {
+			return -EINVAL;
+		}
+		subscribe_options |= (topic->no_local & 0x01) << 2;
+		subscribe_options |= (topic->retain_as_published & 0x01) << 3;
+		subscribe_options |= (topic->retain_handling & 0x03) << 4;
+	}
+#endif /* CONFIG_MQTT_VERSION_5_0 */
+
+	err = pack_uint8(subscribe_options, buf);
+	if (err != 0) {
+		return err;
+	}
+
+	return 0;
+}
+
 int subscribe_encode(const struct mqtt_client *client,
 		     const struct mqtt_subscription_list *param,
 		     struct buf_ctx *buf)
@@ -1385,7 +1418,7 @@ int subscribe_encode(const struct mqtt_client *client,
 			return err_code;
 		}
 
-		err_code = pack_uint8(param->list[i].qos, buf);
+		err_code = subscribe_options_encode(client, &param->list[i], buf);
 		if (err_code != 0) {
 			return err_code;
 		}


### PR DESCRIPTION
Hi,
In a future project we might need the 'no_local' flag contained in the subscription specification of MQTT v5.0.
So I have added all the subscribe options contained in MQTT V5.0 spec, section 3.8.3.1 ([link](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html)), since they seemed to be missing.   

- [x] All missing flags have been added to the struct (only if v5 is enabled).
- [x] Replaced the pack_uint8 function with a dedicated one for packing QoS and subscription options
- [x] Added a check on QoS (should be at most 2).
**TESTING**
- [x] Tested on a board we have in the office (Renesas RA6M3), with a mosquitto broker on my PC.
- [x] Had two topics where the board published and was subscribed to, printed on console what it received. The one without 'no local' flag received all the self published messages back, the one with 'no local' was not receiving them as intended.
- [x] Tested compiling for both v3.1.1 (without using the extra parameters in the struct) and v5.0.
