### PR TITLE
soc: nxp: imxrt11xx: collect MCUX QuickAccess sections

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
@@ -33,4 +33,14 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   endif()
 endif()
 
+# The MCUX HAL emits code/data into custom "CodeQuickAccess" and
+# "DataQuickAccess" input sections (e.g. fsl_romapi.c). Explicitly collect
+# them so they are not left as orphan output sections. As orphans, the
+# companion ".ARM.exidxCodeQuickAccess" unwind table (kept when
+# CONFIG_ARCH_STACKWALK is set, as in sample.perf) can be placed >1 GB from
+# the code, overflowing the 31-bit R_ARM_PREL31 relocation and failing the
+# link with "relocation truncated to fit: R_ARM_PREL31".
+zephyr_linker_sources(ROM_SECTIONS quick_access_code.ld)
+zephyr_linker_sources(DATA_SECTIONS quick_access_data.ld)
+
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/imxrt/imxrt11xx/quick_access_code.ld
+++ b/soc/nxp/imxrt/imxrt11xx/quick_access_code.ld
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The MCUX HAL places selected functions (e.g. fsl_romapi.c) into a
+ * custom "CodeQuickAccess" input section via AT_QUICKACCESS_SECTION_CODE.
+ * When it is left as an orphan section the linker also emits an orphan
+ * ".ARM.exidxCodeQuickAccess" unwind-index table (kept whenever
+ * CONFIG_ARCH_STACKWALK / CONFIG_FRAME_POINTER is set, e.g. sample.perf).
+ * The R_ARM_PREL31 relocation in that exidx entry is only 31-bit PC
+ * relative and overflows when the orphan code and its exidx table are
+ * placed more than 1 GB apart, producing:
+ *   relocation truncated to fit: R_ARM_PREL31 against `CodeQuickAccess'
+ * Collecting the section into the image ROM region keeps the code and
+ * its exidx entry together and resolves the overflow.
+ */
+SECTION_PROLOGUE(.code_quick_access,,)
+{
+	. = ALIGN(4);
+	KEEP(*(CodeQuickAccess))
+	. = ALIGN(4);
+} GROUP_LINK_IN(ROMABLE_REGION)

--- a/soc/nxp/imxrt/imxrt11xx/quick_access_data.ld
+++ b/soc/nxp/imxrt/imxrt11xx/quick_access_data.ld
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Companion to quick_access_code.ld: collect the MCUX HAL
+ * "DataQuickAccess" input section (AT_QUICKACCESS_SECTION_DATA) so it is
+ * not left as an orphan output section. Placed in the initialized data
+ * region alongside the rest of .data.
+ */
+SECTION_DATA_PROLOGUE(.data_quick_access,,)
+{
+	. = ALIGN(4);
+	KEEP(*(DataQuickAccess))
+	. = ALIGN(4);
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
This fixes a link failure of `sample.perf` on
`mimxrt1170_evk@A/mimxrt1176/cm7`:

```
modules/hal_nxp/libmodules__hal_nxp.a(fsl_romapi.c.obj):(.ARM.exidxCodeQuickAccess+0x0):
relocation truncated to fit: R_ARM_PREL31 against `CodeQuickAccess'
collect2: error: ld returned 1 exit status
```

### Root cause
- `sample.perf` sets `CONFIG_FRAME_POINTER=y`, enabling
  `CONFIG_ARCH_STACKWALK`, which makes the Cortex-M linker keep the
  `.ARM.exidx` unwind tables.
- The MCUX HAL places `ROM_FLEXSPI_NorFlash_ClearCache()`
  (`fsl_romapi.c`) into a custom `CodeQuickAccess` input section via
  `AT_QUICKACCESS_SECTION_CODE`.
- The RT11xx SoC had **no linker rule to collect** `CodeQuickAccess` /
  `DataQuickAccess`, so `CodeQuickAccess` became an orphan section and
  GCC emitted an orphan `.ARM.exidxCodeQuickAccess` table. Code and its
  exidx entry ended up > 1 GB apart, overflowing the 31-bit
  `R_ARM_PREL31` relocation.

### Fix
Add SoC linker snippets for RT11xx that collect `CodeQuickAccess` into
the ROM text region and `DataQuickAccess` into the initialized data
region, so the sections are no longer orphans and each code section
stays adjacent to its unwind data.

### Test
```
west build -p -b mimxrt1170_evk@A/mimxrt1176/cm7 samples/subsys/profiling/perf
```

Fixes #115625
