### PR TITLE
net: wifi: hostap: nan: add Kconfig for max SSI length

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -64,7 +64,7 @@ extern "C" {
 #define WIFI_MGMT_SKIP_INACTIVITY_POLL IS_ENABLED(CONFIG_WIFI_MGMT_AP_STA_SKIP_INACTIVITY_POLL)
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
-#define WIFI_NAN_MAX_SSI_LEN            128
+#define WIFI_NAN_MAX_SSI_LEN            CONFIG_WIFI_NAN_MAX_SSI_LEN
 #define WIFI_NAN_MAX_SERVICE_NAME_LEN   64
 #define WIFI_NAN_RESP_SIZE              64
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN */
@@ -1640,7 +1640,7 @@ struct wifi_nan_publish_params {
 	/* Service specific information (binary data) */
 	uint8_t ssi[WIFI_NAN_MAX_SSI_LEN];
 	/* Actual length of SSI data */
-	uint8_t ssi_len;
+	uint16_t ssi_len;
 	/* Unsolicited transmission (true by default) */
 	bool unsolicited;
 	/* Solicited transmission (true by default) */
@@ -1655,7 +1655,7 @@ struct wifi_nan_update_publish_params {
 	/* Service specific information (binary data) */
 	uint8_t ssi[WIFI_NAN_MAX_SSI_LEN];
 	/* Actual length of SSI data */
-	uint8_t ssi_len;
+	uint16_t ssi_len;
 };
 
 /** This structure is used to configure wlan nan subscribe parameters */
@@ -1673,7 +1673,7 @@ struct wifi_nan_subscribe_params {
 	/* Service specific information (binary data) */
 	uint8_t ssi[WIFI_NAN_MAX_SSI_LEN];
 	/* Actual length of SSI data */
-	uint8_t ssi_len;
+	uint16_t ssi_len;
 };
 
 /** This structure is used to configure nan transmit parameters */
@@ -1687,7 +1687,7 @@ struct wifi_nan_transmit_params {
 	/* Service specific information (binary data) */
 	uint8_t ssi[WIFI_NAN_MAX_SSI_LEN];
 	/* Actual length of SSI data */
-	uint8_t ssi_len;
+	uint16_t ssi_len;
 };
 
 /** @brief Wi-Fi NAN parameters */

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -524,6 +524,18 @@ config WIFI_NM_WPA_SUPPLICANT_NAN
 	bool "NAN (Neighbor Awareness Networking) support"
 	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
 
+config WIFI_NAN_MAX_SSI_LEN
+	int "Maximum length of NAN service specific info"
+	depends on WIFI_NM_WPA_SUPPLICANT_NAN
+	default 128
+	help
+	  Maximum NAN Service Specific Info (SSI) payload length in bytes.
+	  This value is stored inline in NAN event and request structures,
+	  so increasing it raises the net_mgmt event queue footprint by
+	  roughly CONFIG_NET_MGMT_EVENT_QUEUE_SIZE times this value.
+	  Users needing larger SSI payloads (e.g. Matter PAF commissioning
+	  with MTU=350) should set this to the required size.
+
 config WIFI_NM_WPA_SUPPLICANT_11AC
 	bool "IEEE 802.11ac VHT support"
 	depends on WIFI_NM_WPA_SUPPLICANT_AP || WIFI_NM_HOSTAPD_AP

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -4713,10 +4713,10 @@ static int parse_nan_args_publish(const struct shell *sh, size_t argc, char *arg
 			break;
 		}
 		case 'd': {
-			int ssi_len = hex2bin(state->optarg, strlen(state->optarg),
+			size_t ssi_len = hex2bin(state->optarg, strlen(state->optarg),
 					      params->publish.ssi,
 					      sizeof(params->publish.ssi));
-			if (ssi_len < 0) {
+			if (ssi_len == 0 && strlen(state->optarg) > 0) {
 				PR_ERROR("Invalid SSI hex string\n");
 				return -EINVAL;
 			}
@@ -4806,10 +4806,10 @@ static int parse_nan_args_update_publish(const struct shell *sh, size_t argc, ch
 			params->update_publish.publish_id = shell_strtol(state->optarg, 10, &ret);
 			break;
 		case 'd': {
-			int ssi_len = hex2bin(state->optarg, strlen(state->optarg),
+			size_t ssi_len = hex2bin(state->optarg, strlen(state->optarg),
 					      params->update_publish.ssi,
 					      sizeof(params->update_publish.ssi));
-			if (ssi_len < 0) {
+			if (ssi_len == 0 && strlen(state->optarg) > 0) {
 				PR_ERROR("Invalid SSI hex string\n");
 				return -EINVAL;
 			}
@@ -4879,10 +4879,10 @@ static int parse_nan_args_subscribe(const struct shell *sh, size_t argc, char *a
 			params->subscribe.freq = shell_strtoul(state->optarg, 10, &ret);
 			break;
 		case 'd': {
-			int ssi_len = hex2bin(state->optarg, strlen(state->optarg),
+			size_t ssi_len = hex2bin(state->optarg, strlen(state->optarg),
 					      params->subscribe.ssi,
 					      sizeof(params->subscribe.ssi));
-			if (ssi_len < 0) {
+			if (ssi_len == 0 && strlen(state->optarg) > 0) {
 				PR_ERROR("Invalid SSI hex string\n");
 				return -EINVAL;
 			}
@@ -4975,10 +4975,10 @@ static int parse_nan_args_transmit(const struct shell *sh, size_t argc, char *ar
 			}
 			break;
 		case 'd': {
-			int ssi_len = hex2bin(state->optarg, strlen(state->optarg),
+			size_t ssi_len = hex2bin(state->optarg, strlen(state->optarg),
 					      params->transmit.ssi,
 					      sizeof(params->transmit.ssi));
-			if (ssi_len < 0) {
+			if (ssi_len == 0 && strlen(state->optarg) > 0) {
 				PR_ERROR("Invalid SSI hex string\n");
 				return -EINVAL;
 			}


### PR DESCRIPTION
Add CONFIG_WIFI_NAN_MAX_SSI_LEN Kconfig option to configure the
maximum NAN Service Specific Info (SSI) payload length. The value
is stored inline in NAN structures; default is 128 bytes to preserve
existing footprint.

Widen ssi_len fields in NAN parameter structures from uint8_t to
uint16_t to support SSI payloads larger than 255 bytes.

Fix wifi_shell.c hex2bin() check: hex2bin() returns size_t and
signals failure with 0, not a negative value.