### PR TITLE
toolchain: factor out the pushsection/popsection directives

### DIFF
--- a/include/zephyr/app_memory/app_memdomain.h
+++ b/include/zephyr/app_memory/app_memdomain.h
@@ -93,24 +93,13 @@ struct z_app_region {
 #define Z_PROGBITS_SYM "@"
 #endif
 
-#if defined(CONFIG_ARC) && defined(__CCAC__)
-/* ARC MWDT assembler has slightly different pushsection/popsection directives
- * names.
- */
-#define Z_PUSHSECTION_DIRECTIV		".pushsect"
-#define Z_POPSECTION_DIRECTIVE		".popsect"
-#else
-#define Z_PUSHSECTION_DIRECTIV		".pushsection"
-#define Z_POPSECTION_DIRECTIVE		".popsection"
-#endif
-
 #define Z_APPMEM_PLACEHOLDER(name) \
 	__asm__ ( \
-		Z_PUSHSECTION_DIRECTIV " " STRINGIFY(K_APP_DMEM_SECTION(name)) \
+		PUSHSECTION_DIRECTIVE " " STRINGIFY(K_APP_DMEM_SECTION(name)) \
 			",\"aw\"," Z_PROGBITS_SYM "progbits\n\t" \
 		".global " STRINGIFY(name) "_placeholder\n\t" \
 		STRINGIFY(name) "_placeholder:\n\t" \
-		Z_POPSECTION_DIRECTIVE "\n\t")
+		POPSECTION_DIRECTIVE "\n\t")
 
 /**
  * @brief Define an application memory partition with linker support

--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -62,6 +62,25 @@
 #endif
 
 /*
+ * Assembler directives to emit into a section other than the current one and
+ * then restore it, for use from inline assembly.
+ *
+ * Example:
+ *
+ *    __asm__(PUSHSECTION_DIRECTIVE " .my_section,\"\"\n\t"
+ *            ".asciz \"payload\"\n\t"
+ *            POPSECTION_DIRECTIVE);
+ */
+#if defined(CONFIG_ARC) && defined(__CCAC__)
+/* The ARC MWDT assembler spells these differently. */
+  #define PUSHSECTION_DIRECTIVE ".pushsect"
+  #define POPSECTION_DIRECTIVE  ".popsect"
+#else
+  #define PUSHSECTION_DIRECTIVE ".pushsection"
+  #define POPSECTION_DIRECTIVE  ".popsection"
+#endif
+
+/*
  * General directive for assembly code, to align the following symbol, in bytes.
  *
  * Example:


### PR DESCRIPTION
The ARC MWDT assembler spells these ".pushsect"/".popsect", which
app_memdomain.h carried a local workaround for. Any other header emitting
inline assembly into a named section needs the same treatment, so move the
abstraction to <zephyr/toolchain/common.h> next to the other
assembler-dialect helpers (SECTION, ALIGN) and use it from the one existing
caller.

The macros are spelled without a Z_ prefix: like SECTION and ALIGN they are
meant to be used by any code emitting inline assembly, not just by kernel
internals. The local copy also misspelled the push one as
Z_PUSHSECTION_DIRECTIV.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
