### PR TITLE
drivers: wifi: nxp: fix NULL pointer dereference in net_get_if_ip_addr

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_net.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_net.c
@@ -1341,7 +1341,11 @@ int net_get_if_ip_addr(uint32_t *ip, void *intrfc_handle)
 	interface_t *if_handle = (interface_t *)intrfc_handle;
 	struct net_if_ipv4 *ipv4 = if_handle->netif->config.ip.ipv4;
 
-	*ip = NET_IPV4_ADDR_U32(ipv4->unicast[0].ipv4.address);
+	if (ipv4 != NULL) {
+		*ip = NET_IPV4_ADDR_U32(ipv4->unicast[0].ipv4.address);
+	} else {
+		*ip = 0U;
+	}
 #else
 	ARG_UNUSED(intrfc_handle);
 	*ip = 0U;


### PR DESCRIPTION
net_get_if_ip_addr() dereferences config.ip.ipv4 without NULL check. When STA interface has never been brought up (dormant since init), this pointer is NULL. On RT1060, the NULL dereference reads ITCM code memory at address 0x4, returning a non-zero value that is misinterpreted as a valid IP address, causing is_sta_ipv4_connected() to incorrectly return true and breaking MEF host sleep wakeup.

The system does not crash because address 0x00000000 on RT1060 maps to ITCM (Instruction Tightly Coupled Memory), which contains valid relocated code (.itcm_text_reloc section). Reading from this region is a legal memory access at the hardware level, so no HardFault or MemManage fault is triggered.

Add NULL check for ipv4 pointer before accessing unicast address.