### PR TITLE
tests: bluetooth: tester: add set extended inquiry response command

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_gap.h
+++ b/tests/bluetooth/tester/src/btp/btp_gap.h
@@ -457,6 +457,13 @@ struct btp_gap_pawr_configure_cmd {
 	uint8_t num_response_slots;
 } __packed;
 
+#define BTP_GAP_SET_EXTENDED_INQUIRY_RESPONSE	0x35
+struct btp_gap_set_extended_inquiry_response_cmd {
+	uint8_t fec_required;
+	uint8_t eir_data_len;
+	uint8_t eir_data[];
+} __packed;
+
 /* events */
 #define BTP_GAP_EV_NEW_SETTINGS			0x80
 struct btp_gap_new_settings_ev {

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -3122,6 +3122,56 @@ static uint8_t send_subrate_request(const void *cmd, uint16_t cmd_len, void *rsp
 }
 #endif /* defined(CONFIG_BT_SUBRATING) */
 
+#if defined(CONFIG_BT_CLASSIC)
+
+#define BTP_EIR_DATA_MAX 2
+
+static uint8_t set_extended_inquiry_response(const void *cmd, uint16_t cmd_len, void *rsp,
+					     uint16_t *rsp_len)
+{
+	const struct btp_gap_set_extended_inquiry_response_cmd *cp = cmd;
+	struct net_buf_simple data;
+	int err;
+	size_t eir_count = 0;
+	struct bt_data eir[BTP_EIR_DATA_MAX];
+
+	if ((cmd_len < sizeof(*cp)) || (cmd_len != sizeof(*cp) + cp->eir_data_len)) {
+		return BTP_STATUS_FAILED;
+	}
+
+	net_buf_simple_init_with_data(&data, (void *)cp->eir_data, cp->eir_data_len);
+	while (data.len >= (sizeof(uint8_t) + sizeof(uint8_t))) {
+		if (eir_count >= ARRAY_SIZE(eir)) {
+			LOG_ERR("Too many EIR elements (%zu > %zu)", eir_count, ARRAY_SIZE(eir));
+			return BTP_STATUS_FAILED;
+		}
+
+		eir[eir_count].type = net_buf_simple_pull_u8(&data);
+		eir[eir_count].data_len = net_buf_simple_pull_u8(&data);
+		if (data.len < eir[eir_count].data_len) {
+			LOG_ERR("Short EIR data (%u < %u)", data.len, eir[eir_count].data_len);
+			return BTP_STATUS_FAILED;
+		}
+
+		eir[eir_count].data = net_buf_simple_pull_mem(&data, eir[eir_count].data_len);
+		eir_count++;
+	}
+
+	if (data.len > 0) {
+		LOG_ERR("Malformed EIR data, %u bytes left in buffer", data.len);
+		return BTP_STATUS_FAILED;
+	}
+
+	err = bt_br_write_eir(eir, eir_count, cp->fec_required > 0 ? true : false);
+	if (err < 0) {
+		LOG_ERR("Failed to set eir data: %d", err);
+		return BTP_STATUS_FAILED;
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+#endif /* defined(CONFIG_BT_CLASSIC) */
+
 static const struct btp_handler handlers[] = {
 	{
 		.opcode = BTP_GAP_READ_SUPPORTED_COMMANDS,
@@ -3372,6 +3422,13 @@ static const struct btp_handler handlers[] = {
 		.func = ead_decrypt_data,
 	},
 #endif /* defined(CONFIG_BT_EAD) */
+#if defined(CONFIG_BT_CLASSIC)
+	{
+		.opcode = BTP_GAP_SET_EXTENDED_INQUIRY_RESPONSE,
+		.expect_len = BTP_HANDLER_LENGTH_VARIABLE,
+		.func = set_extended_inquiry_response,
+	},
+#endif /* defined(CONFIG_BT_CLASSIC) */
 };
 
 uint8_t tester_init_gap(void)


### PR DESCRIPTION
Add BTP_GAP_SET_EXTENDED_INQUIRY_RESPONSE command handler to support setting Extended Inquiry Response (EIR) data for Bluetooth Classic.

The implementation parses EIR data from the command payload, validates buffer boundaries, and calls `bt_br_write_eir()` to write the EIR to controller.

Limited to BTP_EIR_DATA_MAX (2) EIR entries with proper length validation to prevent buffer overflows.

The changes for auto-pts is [here](https://github.com/auto-pts/auto-pts/pull/1826)