### PR TITLE
boards: antmicro: renode_reference_board: fix flash definition

### DIFF
--- a/boards/antmicro/stm32h7_renode_reference_board/stm32h7_renode_reference_board.dts
+++ b/boards/antmicro/stm32h7_renode_reference_board/stm32h7_renode_reference_board.dts
@@ -42,7 +42,7 @@
 		pwm-led2 = &green_pwm_led_2;
 		pwm-led3 = &green_pwm_led_3;
 		rtc = &rtc;
-		spi-flash0 = &mt25ql01g;
+		spi-flash0 = &is25lp01gj;
 		sw0 = &btn0;
 		sw1 = &btn1;
 		sw2 = &btn2;
@@ -352,7 +352,7 @@ zephyr_udc0: &usbotg_fs {
 	flash-id = <1>;
 	status = "okay";
 
-	mt25ql01g: qspi-nor-flash@0 {
+	is25lp01gj: qspi-nor-flash@0 {
 		compatible = "st,stm32-qspi-nor";
 		reg = <0>;
 		size = <DT_SIZE_M(1024)>; /* 1Gb = 128MB */

--- a/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
+++ b/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
@@ -47,7 +47,7 @@ timer3:
 watchdog:
     frequency: 32000
 
-qspiFlash: SPI.Micron_MT25Q @ qspi
+qspiFlash: SPI.ISSI_IS25WP @ qspi
     underlyingMemory: flashMem
 
 flashMem: Memory.MappedMemory @ sysbus 0x90000000


### PR DESCRIPTION
Updated the board devicetree and Renode repl to reflect the correct external flash chip model.