### PR TITLE
drivers: sensor: icm4268x_emul: don't use __ASSERT_UNREACHABLE

### DIFF
--- a/drivers/sensor/tdk/icm4268x/icm4268x_emul.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_emul.c
@@ -164,7 +164,8 @@ static void icm4268x_emul_get_accel_settings(const struct emul *target, int *fs_
 		shift_out = 5;
 		break;
 	default:
-		__ASSERT_UNREACHABLE;
+		__ASSERT_NO_MSG(false);
+		CODE_UNREACHABLE;
 	}
 
 	if (fs_g) {
@@ -255,7 +256,8 @@ static void icm4268x_emul_get_gyro_settings(const struct emul *target, int *fs_m
 		shift_out = -1; /* +/- 0.27256 */
 		break;
 	default:
-		__ASSERT_UNREACHABLE;
+		__ASSERT_NO_MSG(false);
+		CODE_UNREACHABLE;
 	}
 
 	if (fs_mdps) {
@@ -367,7 +369,8 @@ static int icm4268x_emul_backend_set_channel(const struct emul *target, struct s
 			reg_addr = REG_ACCEL_DATA_Z1;
 			break;
 		default:
-			__ASSERT_UNREACHABLE;
+			__ASSERT_NO_MSG(false);
+			CODE_UNREACHABLE;
 		}
 		icm4268x_emul_get_accel_settings(target, NULL, &sensitivity, NULL);
 		reg_val = ((value_unshifted * sensitivity / Q31_SCALE) * 1000000LL) / SENSOR_G;
@@ -386,7 +389,8 @@ static int icm4268x_emul_backend_set_channel(const struct emul *target, struct s
 			reg_addr = REG_GYRO_DATA_Z1;
 			break;
 		default:
-			__ASSERT_UNREACHABLE;
+			__ASSERT_NO_MSG(false);
+			CODE_UNREACHABLE;
 		}
 		icm4268x_emul_get_gyro_settings(target, NULL, &sensitivity, NULL);
 		reg_val =


### PR DESCRIPTION
The `__ASSERT_UNREACHABLE` macro is a PRIVATE helper macro used in the implementation of the actual `__ASSERT` macros. It should not be used except by the `__assert.h` header itself; in fact, the macro is never defined if assertions are not enabled.

Replace this private macro's usage in the aforementioned driver with `__ASSERT_NO_MSG(0)` which will trigger a proper assertion panic if reached, which seemed to be the intent here.