### PR TITLE
drivers: serial: silabs: Only clear processed flags

### DIFF
--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -181,17 +181,18 @@ static int eusart_err_check(const struct device *dev)
 
 	if (flags & EUSART_IF_RXOF) {
 		err |= UART_ERROR_OVERRUN;
+		EUSART_IntClear(config->eusart, EUSART_IF_RXOF);
 	}
 
 	if (flags & EUSART_IF_PERR) {
 		err |= UART_ERROR_PARITY;
+		EUSART_IntClear(config->eusart, EUSART_IF_PERR);
 	}
 
 	if (flags & EUSART_IF_FERR) {
 		err |= UART_ERROR_FRAMING;
+		EUSART_IntClear(config->eusart, EUSART_IF_FERR);
 	}
-
-	EUSART_IntClear(config->eusart, EUSART_IF_RXOF | EUSART_IF_PERR | EUSART_IF_FERR);
 
 	return err;
 }
@@ -252,9 +253,12 @@ static int eusart_irq_tx_complete(const struct device *dev)
 	const struct eusart_config *config = dev->config;
 	uint32_t flags = EUSART_IntGet(config->eusart);
 
-	EUSART_IntClear(config->eusart, EUSART_IF_TXC);
+	if (flags & EUSART_IF_TXC) {
+		EUSART_IntClear(config->eusart, EUSART_IF_TXC);
+		return 1;
+	}
 
-	return !!(flags & EUSART_IF_TXC);
+	return 0;
 }
 
 static int eusart_irq_tx_ready(const struct device *dev)

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -167,17 +167,18 @@ static int uart_silabs_err_check(const struct device *dev)
 
 	if (flags & USART_IF_RXOF) {
 		err |= UART_ERROR_OVERRUN;
+		USART_IntClear(config->base, USART_IF_RXOF);
 	}
 
 	if (flags & USART_IF_PERR) {
 		err |= UART_ERROR_PARITY;
+		USART_IntClear(config->base, USART_IF_PERR);
 	}
 
 	if (flags & USART_IF_FERR) {
 		err |= UART_ERROR_FRAMING;
+		USART_IntClear(config->base, USART_IF_FERR);
 	}
-
-	USART_IntClear(config->base, USART_IF_RXOF | USART_IF_PERR | USART_IF_FERR);
 
 	return err;
 }
@@ -228,9 +229,12 @@ static int uart_silabs_irq_tx_complete(const struct device *dev)
 	const struct uart_silabs_config *config = dev->config;
 	uint32_t flags = USART_IntGet(config->base);
 
-	USART_IntClear(config->base, USART_IF_TXC);
+	if (flags & USART_IF_TXC) {
+		USART_IntClear(config->base, USART_IF_TXC);
+		return 1;
+	}
 
-	return !!(flags & USART_IF_TXC);
+	return 0;
 }
 
 static int uart_silabs_irq_tx_ready(const struct device *dev)


### PR DESCRIPTION
In interrupt handlers, only clear interrupt flags that have been processed. This fixes a race condition where an interrupt that was raised after flags were read for processing was prematurely cleared without the corresponding action being taken.

When this condition was met, irq_tx_complete() never reported that transmission was complete, while err_check() failed to report errors.