### PR TITLE
drivers: dali: select GPIO in DALI_PWM

### DIFF
--- a/drivers/dali/Kconfig.pwm
+++ b/drivers/dali/Kconfig.pwm
@@ -9,6 +9,7 @@ config DALI_PWM
 	depends on DT_HAS_ZEPHYR_DALI_PWM_ENABLED
 	select PWM
 	select COUNTER
+	select GPIO
 	help
 	  Enable DALI driver for generic PWM MCUs.
 


### PR DESCRIPTION
The PWM DALI driver unconditionally uses the GPIO API for its
required rx-gpios pin, but DALI_PWM only selected PWM and COUNTER.
The sample built anyway because ST board defconfigs used to enable
CONFIG_GPIO; since commit 90b9c954f00 ("boards: st: *: don't enable
CONFIG_GPIO by default") the nucleo_f091rc build fails to link with
an undefined reference to the GPIOA device. Select GPIO so the
driver pulls in its own dependency.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
