### PR TITLE
sys: __assert: rename internal __ASSERT_UNREACHABLE

### DIFF
--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -82,11 +82,12 @@ void assert_post_action(const char *file, unsigned int line);
  * When the assert test mode is enabled, the default kernel fatal error handler
  * and the custom assert hook function may return in order to allow the test to
  * proceed.
+ * NOTE: this macro is INTERNAL and should not be used outside of this header!
  */
 #ifdef CONFIG_ASSERT_TEST
-#define __ASSERT_UNREACHABLE
+#define __ASSERT_AFTER_TRIGGER_UNREACHABILITY_MARKER
 #else
-#define __ASSERT_UNREACHABLE CODE_UNREACHABLE
+#define __ASSERT_AFTER_TRIGGER_UNREACHABILITY_MARKER CODE_UNREACHABLE
 #endif
 
 #ifdef __cplusplus
@@ -98,7 +99,7 @@ void assert_post_action(const char *file, unsigned int line);
 		if (unlikely(!(test))) {                                  \
 			__ASSERT_LOC(test);                               \
 			__ASSERT_POST_ACTION();                           \
-			__ASSERT_UNREACHABLE;                             \
+			__ASSERT_AFTER_TRIGGER_UNREACHABILITY_MARKER;     \
 		}                                                         \
 	} while (false)
 
@@ -108,7 +109,7 @@ void assert_post_action(const char *file, unsigned int line);
 			__ASSERT_LOC(test);                               \
 			__ASSERT_MSG_INFO(fmt, ##__VA_ARGS__);            \
 			__ASSERT_POST_ACTION();                           \
-			__ASSERT_UNREACHABLE;                             \
+			__ASSERT_AFTER_TRIGGER_UNREACHABILITY_MARKER;     \
 		}                                                         \
 	} while (false)
 


### PR DESCRIPTION
This macro is supposed to be an internal implementation detail of the assert header, but this is often not understood and the macro ends up used to "trigger an assert panic if this code path is reached" which is NOT what it does: it's just an alias for `CODE_UNREACHABLE` when assertions are enabled and not under test (`CONFIG_TEST_ASSERT=n`)!

Given the confusion caused by this internal helper's name proven by the repeated misuse, rename it into something else which is purposely long and convoluted to make misunderstanding and misusing it impossible... and add a note in the comment right above its definition to really get the point across, just in case.

~~Depends on #115641~~ merged