### PR TITLE
tests bsim: Deprecate old CI scripts/tests lists

### DIFF
--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -8,6 +8,9 @@
 set -ue
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root directory}"
 
+echo "This script is deprecated and will be removed in a future release.\
+ Please build these tests using twister"
+
 export BOARD="${BOARD:-nrf5340bsim/nrf5340/cpuapp}"
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -12,6 +12,9 @@ export BOARD="${BOARD:-nrf5340bsim/nrf5340/cpuapp}"
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source
 
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/tester/compile.sh
+
 app=tests/bsim/bluetooth/ll/conn conf_file=prj_split_privacy.conf sysbuild=1  compile
 app=tests/bsim/bluetooth/ll/throughput sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/throughput conf_overlay=overlay-no_phy_update.conf sysbuild=1 compile
@@ -20,5 +23,9 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf sysbuild=1 
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group.conf sysbuild=1 compile
+
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
@@ -13,5 +13,6 @@ export BOARD="${BOARD:-nrf5340bsim/nrf5340/cpunet}"
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
@@ -8,6 +8,9 @@
 set -ue
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root directory}"
 
+echo "This script is deprecated and will be removed in a future release.\
+ Please build these tests using twister"
+
 export BOARD="${BOARD:-nrf5340bsim/nrf5340/cpunet}"
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -9,6 +9,9 @@
 set -ue
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root directory}"
 
+echo "This script is deprecated and will be removed in a future release.\
+ Please build these tests using twister"
+
 export BOARD="${BOARD:-nrf54l15bsim/nrf54l15/cpuapp}"
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -25,4 +25,8 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf  compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf compile
 
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
+
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -13,7 +13,17 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Note: We do not parallelize the call into the build of the host, ll and mesh images as those
 # are already building many images in parallel in themselves, and otherwise we would be
 # launching too many parallel builds which can lead to a too high system load.
+# On the other hand the audio compile script, only builds one image. So we parallelize it with
+# the rest to save a couple of seconds.
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
+if [ ${BOARD} == "nrf52_bsim/native" ]; then
+	${ZEPHYR_BASE}/tests/bsim/bluetooth/hci_uart/compile.sh
+fi
+${ZEPHYR_BASE}/tests/bsim/bluetooth/tester/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -8,6 +8,9 @@
 set -ue
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root directory}"
 
+echo "This script is deprecated and will be removed in a future release.\
+ Please build these tests using twister"
+
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Note: We do not parallelize the call into the build of the host, ll and mesh images as those

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -1,3 +1,3 @@
 # Search paths(s) for tests which will be run in the nrf52bsim
 # This file is used in CI to select which tests are run
-tests/bsim/bluetooth/ll/
+tests/bsim/bluetooth/

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -1,3 +1,3 @@
 # Search paths(s) for tests which will be run in the nrf52bsim
-# This file is used in CI to select which tests are run
+# This file is deprecated and will be removed in a future release. Please use twister directly
 tests/bsim/bluetooth/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -6,3 +6,13 @@ tests/bsim/bluetooth/ll/multiple_id/
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
+tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
+tests/bsim/bluetooth/samples/peripheral_gap_svc/
+tests/bsim/bluetooth/audio_samples/
+tests/bsim/bluetooth/audio/
+tests/bsim/bluetooth/host/gatt/notify_stress/
+tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis.sh
+tests/bsim/bluetooth/host/misc/hfc/
+tests/bsim/bluetooth/host/misc/hfc_multilink/
+tests/bsim/bluetooth/host/privacy/peripheral
+tests/bsim/bluetooth/tester/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -1,5 +1,5 @@
 # Search paths(s) for tests which will be run in the nrf5340 split stack configuration
-# This file is used in CI to select which tests are run
+# This file is deprecated and will be removed in a future release. Please use twister directly
 tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
 tests/bsim/bluetooth/ll/throughput/
 tests/bsim/bluetooth/ll/multiple_id/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt
@@ -2,3 +2,15 @@
 # built in the net core)
 # This file is used in CI to select which tests are run
 tests/bsim/bluetooth/ll/
+tests/bsim/bluetooth/host/att/eatt_notif
+tests/bsim/bluetooth/host/misc/disable
+tests/bsim/bluetooth/host/misc/unregister_conn_cb
+tests/bsim/bluetooth/host/adv/periodic
+tests/bsim/bluetooth/host/adv/extended
+tests/bsim/bluetooth/host/adv/chain
+tests/bsim/bluetooth/host/l2cap/send_on_connect
+tests/bsim/bluetooth/host/central
+tests/bsim/bluetooth/host/privacy/central
+tests/bsim/bluetooth/host/gatt/authorization
+tests/bsim/bluetooth/host/gatt/general
+tests/bsim/bluetooth/host/gatt/caching

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt
@@ -1,6 +1,6 @@
 # Search paths(s) for tests which will be run in the nrf5340 net core (both app, host and controller
 # built in the net core)
-# This file is used in CI to select which tests are run
+# This file is deprecated and will be removed in a future release. Please use twister directly
 tests/bsim/bluetooth/ll/
 tests/bsim/bluetooth/host/att/eatt_notif
 tests/bsim/bluetooth/host/misc/disable

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -1,5 +1,5 @@
 # Search paths(s) for tests which will be run in the nrf54l15 app core
-# This file is used in CI to select which tests are run
+# This file is deprecated and will be removed in a future release. Please use twister directly
 tests/bsim/bluetooth/ll/advx/
 tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
 tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -8,3 +8,7 @@ tests/bsim/bluetooth/ll/multiple_id/
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
+tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
+tests/bsim/bluetooth/samples/peripheral_gap_svc/
+tests/bsim/bluetooth/audio_samples/
+tests/bsim/bluetooth/audio/

--- a/tests/bsim/compile.sh
+++ b/tests/bsim/compile.sh
@@ -9,6 +9,9 @@ set -ue
 
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root directory}"
 
+echo "This script is deprecated and will be removed in a future release.\
+ Please build these tests using twister"
+
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/compile.sh


### PR DESCRIPTION
    tests bsim: Deprecate old compile scripts and tests lists
    
    Deprecate the old compile scripts and tests lists which were used by CI.
    Even though this is not a tipical API, some users where using them,
    and there is no hurry to remove them, so let's be nice to them.
    
-----------

    tests bsim BT: Bring back old tests lists content
    
    These tests lists and scripts are not used anymore by CI, but they
    are used by some users for their own local/downstream testing.
    
    While we were transitioning to twister yaml definitions, and CI was still
    using them, they were progressively prunned to not build/run what was
    already covered by twister.
    Once CI did not use them anymore, they were left with the content from the
    last time they were.
    
    Let's revert them to the state before the prunning, so users can still use
    them as before while they transition they workflows to twister.
    After we can just deprecate and remove them.
