### PR TITLE
Bluetooth: Controller: Fix race in software radio switch timer

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1483,7 +1483,6 @@ uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder)
 	last_pdu_end_us_init(latency_us);
 
 #else /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
-	nrf_timer_task_trigger(SW_SWITCH_TIMER, NRF_TIMER_TASK_CLEAR);
 	SW_SWITCH_TIMER->MODE = 0;
 	SW_SWITCH_TIMER->PRESCALER = HAL_EVENT_TIMER_PRESCALER_VALUE;
 	SW_SWITCH_TIMER->BITMODE = 0; /* 16 bit */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1488,11 +1488,7 @@ uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder)
 	SW_SWITCH_TIMER->PRESCALER = HAL_EVENT_TIMER_PRESCALER_VALUE;
 	SW_SWITCH_TIMER->BITMODE = 0; /* 16 bit */
 
-#if defined(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)
 	hal_sw_switch_timer_start_ppi_config();
-#else /* !CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN */
-	nrf_timer_task_trigger(SW_SWITCH_TIMER, NRF_TIMER_TASK_START);
-#endif /* !CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN */
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 	hal_sw_switch_timer_clear_ppi_config();

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -291,10 +291,10 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
 	nrf_timer_subscribe_set(SW_SWITCH_TIMER,
 				NRF_TIMER_TASK_CLEAR, HAL_SW_SWITCH_TIMER_CLEAR_PPI);
 
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_START,
-				HAL_SW_SWITCH_TIMER_CLEAR_PPI);
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_START,
+					HAL_SW_SWITCH_TIMER_CLEAR_PPI);
+	}
 
 	/* NOTE: nRF5340 may share the DPPI channel being triggered by Radio End,
 	 *       for End time capture and sw_switch DPPI channel toggling.
@@ -476,9 +476,9 @@ static inline void hal_radio_txen_on_sw_switch(uint8_t compare_reg_index, uint8_
 
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, radio_enable_ppi);
 
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+	}
 }
 
 static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
@@ -498,9 +498,9 @@ static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
 	radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, radio_enable_ppi);
 
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+	}
 }
 
 static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_t radio_enable_ppi)
@@ -516,9 +516,9 @@ static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_
 
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, radio_enable_ppi);
 
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+	}
 }
 
 static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,
@@ -538,9 +538,9 @@ static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,
 	radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, radio_enable_ppi);
 
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+	}
 }
 
 static inline void hal_radio_sw_switch_disable(void)
@@ -582,10 +582,10 @@ static inline void hal_radio_sw_switch_b2b_rx_disable(uint8_t compare_reg_index)
 
 static inline void hal_radio_sw_switch_cleanup(void)
 {
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_START);
-	nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP);
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_START);
+		nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP);
+	}
 
 	nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_CLEAR);
 	hal_radio_sw_switch_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -264,11 +264,16 @@ static inline void hal_trigger_aar_ppi_config(void)
 #define HAL_RADIO_GROUP_TASK_ENABLE_PUBLISH_END HAL_RADIO_PUBLISH_PHYEND
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER || CONFIG_BT_CTLR_DF */
 
-/* Start SW-switch timer on event timer start.
+/* Start SW-switch timer setup
  */
 static inline void hal_sw_switch_timer_start_ppi_config(void)
 {
-	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_START, HAL_EVENT_TIMER_START_PPI);
+	/* Switch timer is started on first and subsequent Radio IFS-end events
+	 * (END or PHYEND) which also clear the timer value via HAL_SW_SWITCH_TIMER_CLEAR_PPI DPPI.
+	 *
+	 * No implementation is needed here; hal_sw_switch_timer_clear_ppi_config() sets up the
+	 * switch-timer subscriptions.
+	 */
 }
 
 /* Clear SW-switch timer on packet end:
@@ -285,6 +290,11 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
 			      HAL_SW_SWITCH_TIMER_CLEAR_PPI);
 	nrf_timer_subscribe_set(SW_SWITCH_TIMER,
 				NRF_TIMER_TASK_CLEAR, HAL_SW_SWITCH_TIMER_CLEAR_PPI);
+
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_START,
+				HAL_SW_SWITCH_TIMER_CLEAR_PPI);
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 	/* NOTE: nRF5340 may share the DPPI channel being triggered by Radio End,
 	 *       for End time capture and sw_switch DPPI channel toggling.
@@ -465,6 +475,10 @@ static inline void hal_radio_txen_on_sw_switch(uint8_t compare_reg_index, uint8_
 		HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(radio_enable_ppi);
 
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, radio_enable_ppi);
+
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 }
 
 static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
@@ -483,6 +497,10 @@ static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
 
 	radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, radio_enable_ppi);
+
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 }
 
 static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_t radio_enable_ppi)
@@ -497,6 +515,10 @@ static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_
 		HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(radio_enable_ppi);
 
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, radio_enable_ppi);
+
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 }
 
 static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,
@@ -515,6 +537,10 @@ static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,
 
 	radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, radio_enable_ppi);
+
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP, radio_enable_ppi);
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 }
 
 static inline void hal_radio_sw_switch_disable(void)
@@ -556,6 +582,11 @@ static inline void hal_radio_sw_switch_b2b_rx_disable(uint8_t compare_reg_index)
 
 static inline void hal_radio_sw_switch_cleanup(void)
 {
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_START);
+	nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP);
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+
 	nrf_timer_subscribe_clear(SW_SWITCH_TIMER, NRF_TIMER_TASK_CLEAR);
 	hal_radio_sw_switch_disable();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -424,14 +424,14 @@ static inline void hal_radio_txen_on_sw_switch(uint8_t compare_reg_index, uint8_
 	nrf_ppi_task_endpoint_setup(NRF_PPI, radio_enable_ppi,
 				    HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_TX);
 
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_ppi_fork_endpoint_setup(NRF_PPI, radio_enable_ppi,
-				    (uint32_t)&(SW_SWITCH_TIMER->TASKS_STOP));
-	/* NOTE: HAL_SW_SWITCH_TIMER_CLEAR_PPI is re-enabled by sw_switch(), so the
-	 *       switch timer will be (re)started on the next Radio IFS-end event.
-	 *       No explicit code to enable or set up switch-timer start is required here.
-	 */
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_ppi_fork_endpoint_setup(NRF_PPI, radio_enable_ppi,
+					    (uint32_t)&(SW_SWITCH_TIMER->TASKS_STOP));
+		/* NOTE: HAL_SW_SWITCH_TIMER_CLEAR_PPI is re-enabled by sw_switch(), so the
+		 *       switch timer will be (re)started on the next Radio IFS-end event.
+		 *       No explicit code to enable or set up switch-timer start is required here.
+		 */
+	}
 }
 
 static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
@@ -459,14 +459,14 @@ static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_
 	nrf_ppi_task_endpoint_setup(NRF_PPI, radio_enable_ppi,
 				    HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_RX);
 
-#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
-	nrf_ppi_fork_endpoint_setup(NRF_PPI, radio_enable_ppi,
-				    (uint32_t)&(SW_SWITCH_TIMER->TASKS_STOP));
-	/* NOTE: HAL_SW_SWITCH_TIMER_CLEAR_PPI is re-enabled by sw_switch(), so the
-	 *       switch timer will be (re)started on the next Radio IFS-end event.
-	 *       No explicit code to enable or set up switch-timer start is required here.
-	 */
-#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		nrf_ppi_fork_endpoint_setup(NRF_PPI, radio_enable_ppi,
+					    (uint32_t)&(SW_SWITCH_TIMER->TASKS_STOP));
+		/* NOTE: HAL_SW_SWITCH_TIMER_CLEAR_PPI is re-enabled by sw_switch(), so the
+		 *       switch timer will be (re)started on the next Radio IFS-end event.
+		 *       No explicit code to enable or set up switch-timer start is required here.
+		 */
+	}
 }
 
 static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -292,11 +292,15 @@ static inline void hal_trigger_aar_ppi_config(void)
 
 #if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
 
-/* Start SW-switch timer on event timer start.
+/* Start SW-switch timer setup.
  */
 static inline void hal_sw_switch_timer_start_ppi_config(void)
 {
-	nrf_ppi_fork_endpoint_setup(NRF_PPI, HAL_EVENT_TIMER_START_PPI,
+	/* Switch timer is started on first and subsequent Radio IFS-end events
+	 * (END or PHYEND; see HAL_RADIO_IFS_EVENTS_END) which also clear the timer
+	 * value via HAL_SW_SWITCH_TIMER_CLEAR_PPI PPI.
+	 */
+	nrf_ppi_fork_endpoint_setup(NRF_PPI, HAL_SW_SWITCH_TIMER_CLEAR_PPI,
 				    (uint32_t)&(SW_SWITCH_TIMER->TASKS_START));
 }
 
@@ -308,6 +312,7 @@ static inline void hal_sw_switch_timer_start_ppi_config(void)
 
 static inline void hal_sw_switch_timer_clear_ppi_config(void)
 {
+	/* Switch timer is cleared (and started via fork) on each Radio IFS-end event. */
 	nrf_ppi_channel_endpoint_setup(
 		NRF_PPI,
 		HAL_SW_SWITCH_TIMER_CLEAR_PPI,
@@ -418,6 +423,15 @@ static inline void hal_radio_txen_on_sw_switch(uint8_t compare_reg_index, uint8_
 
 	nrf_ppi_task_endpoint_setup(NRF_PPI, radio_enable_ppi,
 				    HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_TX);
+
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_ppi_fork_endpoint_setup(NRF_PPI, radio_enable_ppi,
+				    (uint32_t)&(SW_SWITCH_TIMER->TASKS_STOP));
+	/* NOTE: HAL_SW_SWITCH_TIMER_CLEAR_PPI is re-enabled by sw_switch(), so the
+	 *       switch timer will be (re)started on the next Radio IFS-end event.
+	 *       No explicit code to enable or set up switch-timer start is required here.
+	 */
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 }
 
 static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
@@ -444,6 +458,15 @@ static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_
 
 	nrf_ppi_task_endpoint_setup(NRF_PPI, radio_enable_ppi,
 				    HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_RX);
+
+#if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	nrf_ppi_fork_endpoint_setup(NRF_PPI, radio_enable_ppi,
+				    (uint32_t)&(SW_SWITCH_TIMER->TASKS_STOP));
+	/* NOTE: HAL_SW_SWITCH_TIMER_CLEAR_PPI is re-enabled by sw_switch(), so the
+	 *       switch timer will be (re)started on the next Radio IFS-end event.
+	 *       No explicit code to enable or set up switch-timer start is required here.
+	 */
+#endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 }
 
 static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,


### PR DESCRIPTION
Fix race in software switch timer by starting and stopping the switch on Radio End and Radio Enable, respectively.

The Radio PHYEND event and the software-switch timer compare event occurred at the same timer value. This allowed the next RADIO TXEN/RXEN operation to start while PHYEND was resetting the timer for the next software-TIFS interval, leaving the controller in an invalid state.

Relates to commit 5fe53aaa84b0 ("Bluetooth: Controller: Use PPI/DPPI to start s/w switch timer").