### PR TITLE
manifest: tf-m: Include BL2 watchdog support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -402,7 +402,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: f684baa30751d23f3e450fa1598428dec0bf73c6
+      revision: 2e7df188dc130c02eac4aa608f27f3b232681ccc
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update trusted-firmware-m revision to include watchdog support in BL2.

Feeding the watchdog in the bootloader (BL2) is necessary for some platforms for long-running tasks such as swapping to a new firmware image after a update.