### PR TITLE
Warn when deprecated include/zephyr/sys_clock.h is used

### DIFF
--- a/drivers/timer/system_timer_generic.h
+++ b/drivers/timer/system_timer_generic.h
@@ -135,7 +135,7 @@
 #define ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_
 
 #include <zephyr/drivers/timer/system_timer.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 
 #if (defined(TIMER_CORE_BACKEND_COMPARE_ORDERED) + \

--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -10,4 +10,6 @@
  * @deprecated Please include zephyr/sys/clock.h straight instead
  */
 
+#warning "include/zephyr/sys_clock.h is deprecated, please use 'include/zephyr/sys/clock.h' instead"
+
 #include <zephyr/sys/clock.h>

--- a/tests/drivers/counter/counter_conversions/src/main.c
+++ b/tests/drivers/counter/counter_conversions/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/ztest.h>
 
 /*

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 1fad84dd567809ba69cc519c7bc58bc6458d1654
+      revision: 5978c2877c25d9b8d19c6e363cf7e5f478ca7cdd
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Emit a build warning when deprecated **include/zephyr/sys_clock.h** is used.

Preparatory commits remove remaining occurrences of inclusion of that file in the Zephyr source tree. All other occurrences have already been updated through #112127.

Depends on a change in NXP HAL (https://github.com/zephyrproject-rtos/hal_nxp/pull/781) now merged but Zephyr has not yet synced with.
~~Depends-on: #115562~~
**(edited) #115562 was merged but change reverted in aeafe3af2a0e29dd808af3fb5f71303f4f9a9c33. Manifest update to sync on NXP HAL is now part of this series.**



