### PR TITLE
portability: cmsis_types: improve Doxygen coverage

### DIFF
--- a/include/zephyr/portability/cmsis_types.h
+++ b/include/zephyr/portability/cmsis_types.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for CMSIS-RTOSv2 object control block structures.
+ * @ingroup os_services
+ */
+
 #ifndef ZEPHYR_INCLUDE_PORTABILITY_CMSIS_TYPES_H_
 #define ZEPHYR_INCLUDE_PORTABILITY_CMSIS_TYPES_H_
 

--- a/include/zephyr/portability/cmsis_types.h
+++ b/include/zephyr/portability/cmsis_types.h
@@ -24,12 +24,14 @@
  * thread control block. Control block is initialized within `osThreadNew()`.
  */
 struct cmsis_rtos_thread_cb {
+	/** @cond INTERNAL_HIDDEN */
 	sys_dnode_t node;
 	struct k_thread z_thread;
 	struct k_poll_signal poll_signal;
 	struct k_poll_event poll_event;
 	uint32_t signal_results;
 	uint32_t attr_bits;
+	/** @endcond */
 };
 
 /**
@@ -39,6 +41,7 @@ struct cmsis_rtos_thread_cb {
  * timer control block. Control block is initialized within `osTimerNew()`.
  */
 struct cmsis_rtos_timer_cb {
+	/** @cond INTERNAL_HIDDEN */
 	struct k_timer z_timer;
 	osTimerType_t type;
 	uint32_t status;
@@ -46,6 +49,7 @@ struct cmsis_rtos_timer_cb {
 	const char *name;
 	void (*callback_function)(void *argument);
 	void *arg;
+	/** @endcond */
 };
 
 /**
@@ -55,10 +59,12 @@ struct cmsis_rtos_timer_cb {
  * mutex control block. Control block is initialized within `osMutexNew()`.
  */
 struct cmsis_rtos_mutex_cb {
+	/** @cond INTERNAL_HIDDEN */
 	struct k_mutex z_mutex;
 	bool is_cb_dynamic_allocation;
 	const char *name;
 	uint32_t state;
+	/** @endcond */
 };
 
 /**
@@ -68,9 +74,11 @@ struct cmsis_rtos_mutex_cb {
  * semaphore control block. Control block is initialized within `osSemaphoreNew()`.
  */
 struct cmsis_rtos_semaphore_cb {
+	/** @cond INTERNAL_HIDDEN */
 	struct k_sem z_semaphore;
 	bool is_cb_dynamic_allocation;
 	const char *name;
+	/** @endcond */
 };
 
 /**
@@ -80,11 +88,13 @@ struct cmsis_rtos_semaphore_cb {
  * memory pool control block. Control block is initialized within `osMemoryPoolNew()`.
  */
 struct cmsis_rtos_mempool_cb {
+	/** @cond INTERNAL_HIDDEN */
 	struct k_mem_slab z_mslab;
 	void *pool;
 	char is_dynamic_allocation;
 	bool is_cb_dynamic_allocation;
 	const char *name;
+	/** @endcond */
 };
 
 /**
@@ -94,11 +104,13 @@ struct cmsis_rtos_mempool_cb {
  * message queue control block. Control block is initialized within `osMessageQueueNew()`.
  */
 struct cmsis_rtos_msgq_cb {
+	/** @cond INTERNAL_HIDDEN */
 	struct k_msgq z_msgq;
 	void *pool;
 	char is_dynamic_allocation;
 	bool is_cb_dynamic_allocation;
 	const char *name;
+	/** @endcond */
 };
 
 /**
@@ -108,9 +120,11 @@ struct cmsis_rtos_msgq_cb {
  * event flag control block. Control block is initialized within `osEventFlagsNew()`.
  */
 struct cmsis_rtos_event_cb {
+	/** @cond INTERNAL_HIDDEN */
 	struct k_event z_event;
 	bool is_cb_dynamic_allocation;
 	const char *name;
+	/** @endcond */
 };
 
 #endif /* ZEPHYR_INCLUDE_PORTABILITY_CMSIS_TYPES_H_ */


### PR DESCRIPTION
Add the missing `@file` block to the CMSIS-RTOSv2 types header.

The control block structures are only public so that applications can
allocate them when using manual user-defined allocation for RTOS
objects. Their members are initialized and used by the CMSIS-RTOSv2
compatibility layer, so hide them from the generated documentation.

Documentation only, no functional change.