### PR TITLE
Cbprintf fp conversion fixes

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1195,6 +1195,7 @@ static char *encode_float(double value,
 	fract += round;
 	/* Make sure rounding didn't make fract >= 1.0 */
 	if (fract >= BIT64(60)) {
+		fract += 5U; /* Round to nearest rather than truncate */
 		_ldiv10(&fract);
 		decexp++;
 	}

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1073,8 +1073,10 @@ static char *encode_float(double value,
 	fract <<= EXPONENT_BITS;
 	fract &= ~SIGN_MASK;
 
+	bool is_zero = (expo | fract) == 0;
+
 	/* Non-zero values need normalization. */
-	if ((expo | fract) != 0) {
+	if (!is_zero) {
 		if (is_subnormal) {
 			/* Fraction is subnormal.  Normalize it and correct
 			 * the exponent.
@@ -1141,6 +1143,14 @@ static char *encode_float(double value,
 	 * integer part.
 	 */
 	fract >>= (4 - expo);
+
+	/* The scaling loops can land just below 0.1, where the leading digit
+	 * would come out as a zero.  Restore 0.1 <= fract < 1.0.
+	 */
+	while (!is_zero && (fract < (BIT64(60) / 10U))) {
+		fract *= 10U;
+		decexp--;
+	}
 
 	if ((c == 'g') || (c == 'G')) {
 		/* Use the specified precision and exponent to select the

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1153,6 +1153,11 @@ static char *encode_float(double value,
 	}
 
 	if ((c == 'g') || (c == 'G')) {
+		/* ISO C: a precision of zero is taken as one. */
+		if (precision == 0) {
+			precision = 1;
+		}
+
 		/* Use the specified precision and exponent to select the
 		 * representation and correct the precision and zero-pruning
 		 * in accordance with the ISO C rule.


### PR DESCRIPTION
Fixes a few edge cases of `cbprintf`

A comparison of `main`, the fixed version and libc can be tried here: https://godbolt.org/z/63s5139e7

| defect | format | input | upstream | fixed | libc |
|---|---|---|---|---|---|
| fraction left below 0.1 | `%.10e` | `9.999999999e-20` | `0.9999999999e-18` | `9.9999999990e-20` | `9.9999999990e-20` |
| carry rescale truncated | `%.3e` | `9999.5` | `0.999e+05` | `1.000e+04` | `1.000e+04` |
| `%g` precision 0 not taken as 1 | `%.0g` | `0.8` | `1` | `0.8` | `0.8` |

