### PR TITLE
drivers: serial: nrfx_uarte: Fix case with mixed instance configuration

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -81,6 +81,7 @@ config UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER
 config UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER_LEGACY
 	bool "Use TIMER to count RX bytes on legacy platforms"
 	depends on UART_ASYNC_API
+	depends on !$(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_UARTE),frame-timeout-supported,True)
 	select NRFX_GPPI
 	help
 	  Method used on nRF52x, nRF53x and nRF91x series.

--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -19,7 +19,7 @@ config UART_$(nrfx_uart_num)_ASYNC
 
 config UART_$(nrfx_uart_num)_NRF_USE_TIMER
 	bool
-	depends on UART_ASYNC_API
+	depends on UART_$(nrfx_uart_num)_ASYNC
 	depends on $(dt_nodelabel_has_prop,uart$(nrfx_uart_num),timer)
 	depends on HAS_HW_NRF_UARTE$(nrfx_uart_num)
 	default y

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -3310,17 +3310,28 @@ static int uarte_instance_deinit(const struct device *dev)
 
 #define UARTE_TIMER_IRQ_PRIO(idx) DT_IRQ(DT_PHANDLE(UARTE(idx), timer), priority)
 
-#define UARTE_COUNT_BYTES_WITH_TIMER_COMMON_CONFIG(idx)						\
-	.timer_regs = COND_CODE_1(UARTE_HAS_PROP(idx, timer),					\
-		(UARTE_TIMER_REG(DT_PHANDLE(UARTE(idx), timer))),				\
-		(COND_CODE_1(CONFIG_UART_##idx##_NRF_HW_ASYNC,					\
-			     (UARTE_TIMER_REG(UARTE_TIMER_NODE(idx))),				\
-			     (NULL)))),								\
+#define UARTE_IS_CBWT(idx)                                                         \
+	UTIL_AND(IS_ENABLED(CONFIG_UART_##idx##_COUNT_BYTES_WITH_TIMER),           \
+		 IS_ENABLED(CONFIG_UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER))
+
+#define UARTE_IS_CBWT_LEGACY(idx)                                                  \
+	UTIL_AND(IS_ENABLED(CONFIG_UART_##idx##_COUNT_BYTES_WITH_TIMER_LEGACY),    \
+		 IS_ENABLED(CONFIG_UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER_LEGACY))
+
+#define UARTE_USE_TIMER_PROP(idx)                                                  \
+	COND_CODE_1(UTIL_OR(UARTE_IS_CBWT(idx), UARTE_IS_CBWT_LEGACY(idx)),        \
+		    (UARTE_HAS_PROP(idx, timer)), (0))
+
+#define UARTE_COUNT_BYTES_WITH_TIMER_COMMON_CONFIG(idx)                            \
+	.timer_regs = COND_CODE_1(UARTE_USE_TIMER_PROP(idx),                       \
+		(UARTE_TIMER_REG(DT_PHANDLE(UARTE(idx), timer))),                  \
+		(COND_CODE_1(CONFIG_UART_##idx##_NRF_HW_ASYNC,                     \
+			(UARTE_TIMER_REG(UARTE_TIMER_NODE(idx))),                  \
+			(NULL)))),                                                 \
 	.uarte_irqn = DT_IRQN(UARTE(idx)),
 
-
 #define UARTE_COUNT_BYTES_WITH_TIMER_CONFIG(idx)					\
-	IF_ENABLED(UARTE_HAS_PROP(idx, timer),						\
+	IF_ENABLED(UARTE_IS_CBWT(idx),							\
 		(.timer_irqn = UARTE_TIMER_IRQN(idx),					\
 		 .bounce_buf = {							\
 			uart##idx##_bounce_buf,						\
@@ -3335,8 +3346,7 @@ static int uarte_instance_deinit(const struct device *dev)
 	__ASSERT_NO_MSG(UARTE_TIMER_IRQ_PRIO(idx) == DT_IRQ(UARTE(idx), priority))
 
 #define UARTE_TIMER_IRQ_CONNECT(idx, func)						\
-	IF_ENABLED(UTIL_AND(IS_ENABLED(CONFIG_UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER),	\
-			    UARTE_HAS_PROP(idx, timer)),				\
+	IF_ENABLED(UARTE_IS_CBWT(idx),							\
 		(UARTE_COUNT_BYTES_WITH_TIMER_VALIDATE_CONFIG(idx);			\
 		 IRQ_CONNECT(UARTE_TIMER_IRQN(idx), UARTE_TIMER_IRQ_PRIO(idx), func,	\
 			     DEVICE_DT_GET(UARTE(idx)), 0);				\
@@ -3344,8 +3354,7 @@ static int uarte_instance_deinit(const struct device *dev)
 
 /* Macro sets flag to indicate that uart use different interrupt priority than the system clock. */
 #define UARTE_HAS_VAR_PRIO(idx)									\
-	COND_CODE_1(UTIL_AND(IS_ENABLED(CONFIG_UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER),	\
-			    UARTE_HAS_PROP(idx, timer)),					\
+	COND_CODE_1(UARTE_IS_CBWT(idx),								\
 		   (((DT_IRQ(UARTE(idx), priority) != DT_IRQ(DT_NODELABEL(grtc), priority)) ?	\
 		    UARTE_CFG_FLAG_VAR_IRQ : 0)), (0))
 
@@ -3486,8 +3495,7 @@ static int uarte_instance_deinit(const struct device *dev)
  * Macro determines if delayed initialization needs to be applied.
  */
 #define UARTE_INIT_AFTER_GPPI(idx)							\
-	COND_CODE_1(UTIL_AND(CONFIG_UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER,		\
-			     UARTE_HAS_PROP(idx, timer)),				\
+	COND_CODE_1(UARTE_IS_CBWT(idx),							\
 		    (UTIL_OR(IS_ENABLED(CONFIG_GPPI_EXT_ALLOCATOR_CLI),			\
 			     UTIL_AND(IS_ENABLED(CONFIG_NRFX_GPPI_SD2PPI_GLOBAL),	\
 				      IS_ENABLED(CONFIG_IRONSIDE_SE_CALL)))), (0))
@@ -3514,8 +3522,7 @@ static int uarte_instance_deinit(const struct device *dev)
 	UARTE_INT_DRIVEN(idx);						       \
 	PINCTRL_DT_DEFINE(UARTE(idx));					       \
 	IF_ENABLED(CONFIG_UART_##idx##_ASYNC, (				       \
-		IF_ENABLED(UTIL_AND(IS_ENABLED(CONFIG_UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER), \
-			   UARTE_HAS_PROP(idx, timer)),			       \
+		IF_ENABLED(UARTE_IS_CBWT(idx),				       \
 		(static uint8_t uart##idx##_bounce_buf[CONFIG_UART_NRFX_UARTE_BOUNCE_BUF_LEN] \
 			DMM_MEMORY_SECTION(UARTE(idx));			       \
 		static struct uarte_async_rx_cbwt uart##idx##_bounce_data;     \


### PR DESCRIPTION
Compilation was failing when one instance is using interrupt driven API and another one is using asynchronous API with TIMER byte counting. Compilation was also failing if instance had timer property in DT but Kconfig was indicating use of the interrupt driven API.