### PR TITLE
doc: doxygen: expand more ZTEST macros in doxygen

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2597,7 +2597,9 @@ PREDEFINED             = __DOXYGEN__ \
                          "ZTEST(suite, fn)=void fn(void)" \
                          "ZTEST_USER(suite, fn)=void fn(void)" \
                          "ZTEST_USER_F(suite, fn)=void fn(void)" \
-                         "ZTEST_F(suite, fn)=void fn(void)"
+                         "ZTEST_F(suite, fn)=void fn(void)" \
+                         "ZTEST_P(suite, fn)=void fn(void)" \
+                         "ZTEST_USER_P(suite, fn)=void fn(void)"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
This will allow expansion of various ZTEST macros to display the actual
test function rather than the ZTEST macro itself.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
