### PR TITLE
tests bsim bluetooth ll multiple_id: Stop the simulation when it passes

### DIFF
--- a/tests/bsim/bluetooth/ll/multiple_id/src/main.c
+++ b/tests/bsim/bluetooth/ll/multiple_id/src/main.c
@@ -58,6 +58,8 @@ static void test_central_main(void)
 
 	PASS("Central tests passed\n");
 
+	bs_trace_silent_exit(0);
+
 	return;
 
 exit:
@@ -98,6 +100,8 @@ static void test_central_multiple_main(void)
 	k_sleep(K_SECONDS(1));
 
 	PASS("Central tests passed\n");
+
+	bs_trace_silent_exit(0);
 
 	return;
 
@@ -151,9 +155,14 @@ static void test_peripheral_multilink_main(void)
 		goto exit;
 	}
 
-	k_sleep(K_SECONDS(3));
-
 	PASS("Peripheral tests passed\n");
+
+	/* Wait a little so all centrals complete. Ideally we would just have a backchannel
+	 * and wait for all peripherals to report passed.
+	 */
+	k_sleep(K_SECONDS(30));
+
+	bs_trace_silent_exit(0);
 
 	return;
 


### PR DESCRIPTION
There is no need to continue the simulation once it passes. Let's stop it to save CI time.

This saves ~40% of the runtime of these 3 tests.