### PR TITLE
arch: common: allow disabling the exception dump

### DIFF
--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -38,8 +38,22 @@ config ARCH_SUPPORTS_ROM_OFFSET
 	  script, which will place a block of 0x0 of size
 	  CONFIG_ROM_START_OFFSET at the start of the ROM region.
 
+config EXCEPTION_DUMP
+	bool "Exception dump"
+	default y
+	help
+	  Print the register, fault cause and stack trace information
+	  collected by the architecture fault handlers.
+
+	  Disabling this removes the dump call sites and their format
+	  strings from the image. This is useful for size constrained
+	  builds such as bootloaders, where the dump would otherwise be
+	  compiled in unconditionally whenever LOG is disabled, because
+	  the printk fallback has no level filtering of its own.
+
 config EXCEPTION_DUMP_HOOK
 	bool "Exceptions printing hooks"
+	depends on EXCEPTION_DUMP
 	help
 	  Enables hook for configuring an additional method for delivering
 	  exeption prints through similar interface as printk or LOG.

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -191,6 +191,8 @@ New APIs and options
 
   * :kconfig:option:`CONFIG_ARM_MPU_CM7_UNMAPPED_REGION` (Arm Cortex-M7 catch-all MPU region
     for unmapped addresses, erratum 1013783 workaround)
+  * :kconfig:option:`CONFIG_EXCEPTION_DUMP` (enabled by default, can be disabled to compile
+    out the fault handler output on size constrained builds)
 
 * Audio
 

--- a/include/zephyr/arch/exception.h
+++ b/include/zephyr/arch/exception.h
@@ -10,6 +10,15 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <stdarg.h>
+#include <zephyr/toolchain.h>
+
+/** @brief Dummy function to trigger exception dump argument type checking. */
+static inline __printf_like(1, 2) void arch_exception_dump_arg_check(const char *fmt, ...)
+{
+	ARG_UNUSED(fmt);
+}
+
 #if defined(CONFIG_EXCEPTION_DUMP_HOOK)
 
 #include <stdbool.h>
@@ -89,7 +98,14 @@ static inline void arch_exception_call_dump_hook(const char *format, ...)
 	}
 }
 
-#if defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
+#if !defined(CONFIG_EXCEPTION_DUMP)
+#define EXCEPTION_DUMP(format, ...)                                                                \
+	do {                                                                                       \
+		if (0) {                                                                           \
+			arch_exception_dump_arg_check(format, ##__VA_ARGS__);                      \
+		}                                                                                  \
+	} while (false)
+#elif defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
 #define EXCEPTION_DUMP(format, ...) arch_exception_call_dump_hook(format "\n",  ##__VA_ARGS__)
 #elif defined(CONFIG_LOG)
 #define EXCEPTION_DUMP(format, ...) arch_exception_call_dump_hook(format "\n",  ##__VA_ARGS__); \
@@ -101,7 +117,14 @@ static inline void arch_exception_call_dump_hook(const char *format, ...)
 
 #else
 
-#if defined(CONFIG_LOG)
+#if !defined(CONFIG_EXCEPTION_DUMP)
+#define EXCEPTION_DUMP(format, ...)                                                                \
+	do {                                                                                       \
+		if (0) {                                                                           \
+			arch_exception_dump_arg_check(format, ##__VA_ARGS__);                      \
+		}                                                                                  \
+	} while (false)
+#elif defined(CONFIG_LOG)
 #define EXCEPTION_DUMP(...) LOG_ERR(__VA_ARGS__)
 #else
 #define EXCEPTION_DUMP(format, ...) printk(format "\n", ##__VA_ARGS__)


### PR DESCRIPTION
The fault handlers reach printk when LOG is disabled, and printk has no level filtering, so the register dump and its format strings are linked in unconditionally. Add EXCEPTION_DUMP, enabled by default, so size constrained builds can compile the dump out.

The disabled variant keeps its arguments under an if (0) argument checker, mirroring the logging subsystem, so format specifiers stay type checked and argument side effects are preserved without emitting unused variable warnings.

Spot this during mcuboot .conf changes:

`CONFIG_LOG=n` consumes ~1.4kb more RAM than the below:
```c
CONFIG_MCUBOOT_LOG_LEVEL_OFF=y
CONFIG_LOG_DEFAULT_LEVEL=0
```