### PR TITLE
tests: kernel: improve and expand on kernel test documentation

### DIFF
--- a/tests/arch/arc/arc_dsp_sharing/README.txt
+++ b/tests/arch/arc/arc_dsp_sharing/README.txt
@@ -21,14 +21,14 @@ Sample Output:
 
 Running TESTSUITE dsp_sharing
 ===================================================================
-START - test_load_store
+START - test_dsp_load_store
 Load and store OK after 0 (high) + 84 (low) tests
 Load and store OK after 100 (high) + 11926 (low) tests
 Load and store OK after 200 (high) + 23767 (low) tests
 Load and store OK after 300 (high) + 35607 (low) tests
 Load and store OK after 400 (high) + 47448 (low) tests
 Load and store OK after 500 (high) + 59287 (low) tests
- PASS - test_load_store in 10.18 seconds
+ PASS - test_dsp_load_store in 10.18 seconds
 ===================================================================
 START - test_calculation
 complex product calculation OK after 50 (high) + 63297 (low) tests (computed -160)

--- a/tests/arch/arc/arc_dsp_sharing/src/load_store.c
+++ b/tests/arch/arc/arc_dsp_sharing/src/load_store.c
@@ -47,7 +47,7 @@ static volatile bool test_exited;
 static K_SEM_DEFINE(test_exit_sem, 0, 1);
 
 /*
- * Low priority DSP load/store worker for test_load_store().
+ * Low priority DSP load/store worker for test_dsp_load_store().
  *
  * Loads all DSP registers with a known byte pattern, busy-waits to let the
  * high priority thread preempt and use the DSP registers, then stores and
@@ -127,7 +127,7 @@ static void load_store_low(void)
 }
 
 /*
- * High priority DSP load/store worker for test_load_store().
+ * High priority DSP load/store worker for test_dsp_load_store().
  *
  * Repeatedly loads all DSP registers with its own distinct byte pattern and
  * sleeps, forcing context switches to/from the low priority thread. Runs for
@@ -242,7 +242,7 @@ K_THREAD_DEFINE(load_high, THREAD_STACK_SIZE, load_store_high, NULL, NULL, NULL,
  * @see _load_all_dsp_registers()
  * @see _store_all_dsp_registers()
  */
-ZTEST(dsp_sharing, test_load_store)
+ZTEST(dsp_sharing, test_dsp_load_store)
 {
 	/* Initialise test states */
 	test_exited = false;

--- a/tests/arch/arc/arc_dsp_sharing/tests.yaml
+++ b/tests/arch/arc/arc_dsp_sharing/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  arch.arc.dsp_sharing.test_load_store:
+  arch.arc.dsp_sharing.test_dsp_load_store:
     filter: CONFIG_ISA_ARCV2 and CONFIG_CPU_HAS_DSP
     platform_allow: nsim/nsim_em11d
   arch.arc.dsp_sharing.test_calculation:

--- a/tests/arch/common/interrupt/src/dynamic_isr.c
+++ b/tests/arch/common/interrupt/src/dynamic_isr.c
@@ -83,6 +83,20 @@ ZTEST(interrupt_feature, test_isr_dynamic)
 #define TEST_IRQ_DYN_LINE 5
 #endif
 
+/**
+ * @brief Test dynamic ISR installation, enable and disable
+ *
+ * @ingroup kernel_interrupt_tests
+ *
+ * @details Install a dynamic ISR at run time with arch_irq_connect_dynamic(),
+ * confirm the interrupt is initially disabled (its handler has not run), enable
+ * the line, trigger it and confirm the handler runs with the configured
+ * parameter, then disable the line again.
+ *
+ * @see arch_irq_connect_dynamic()
+ * @see irq_enable()
+ * @see irq_disable()
+ */
 ZTEST(interrupt_feature, test_isr_dynamic)
 {
 	int vector_num;

--- a/tests/arch/common/interrupt/src/multilevel_irq.c
+++ b/tests/arch/common/interrupt/src/multilevel_irq.c
@@ -9,6 +9,16 @@
 #include <zephyr/irq_multilevel.h>
 #include <zephyr/ztest.h>
 
+/**
+ * @brief Test the multi-level interrupt encoding API
+ *
+ * @ingroup kernel_interrupt_tests
+ *
+ * @details Exercise the multi-level IRQ encoding helpers against second-level
+ * interrupt numbers obtained from the devicetree, verifying conversion between
+ * raw and Zephyr-encoded IRQ numbers, parent (aggregator) resolution and IRQ
+ * level queries. This exercises the kernel support for multi-level interrupts.
+ */
 ZTEST(interrupt_feature, test_multi_level_api)
 {
 	/* Zephyr multilevel-encoded IRQ */
@@ -63,6 +73,16 @@ ZTEST(interrupt_feature, test_multi_level_api)
 }
 
 #ifdef CONFIG_3RD_LEVEL_INTERRUPTS
+/**
+ * @brief Test the multi-level interrupt encoding API for third-level interrupts
+ *
+ * @ingroup kernel_interrupt_tests
+ *
+ * @details Exercise the multi-level IRQ encoding helpers against third-level
+ * interrupt numbers obtained from the devicetree, verifying conversion and
+ * parent resolution across three interrupt levels. This exercises the kernel
+ * support for multi-level interrupts.
+ */
 ZTEST(interrupt_feature, test_multi_level_api_l3)
 {
 	/* Zephyr multilevel-encoded IRQ */

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -81,7 +81,8 @@ DEVICE_DT_DEFINE(DT_INST(2, fakedeferdriver), fakedeferdriver_init, NULL, NULL, 
  *
  * @ingroup kernel_device_tests
  *
- * @see device_get_binding(), DEVICE_DEFINE()
+ * @see device_get_binding()
+ * @see DEVICE_DEFINE()
  */
 ZTEST(device, test_dummy_device)
 {
@@ -111,7 +112,8 @@ ZTEST(device, test_dummy_device)
  *
  * Validates device binding for an existing device object.
  *
- * @see device_get_binding(), DEVICE_DEFINE()
+ * @see device_get_binding()
+ * @see DEVICE_DEFINE()
  */
 ZTEST_USER(device, test_dynamic_name)
 {
@@ -129,7 +131,8 @@ ZTEST_USER(device, test_dynamic_name)
  * Validates binding of a random device driver(non-defined driver) named
  * "ANOTHER_BOGUS_NAME".
  *
- * @see device_get_binding(), DEVICE_DEFINE()
+ * @see device_get_binding()
+ * @see DEVICE_DEFINE()
  */
 ZTEST_USER(device, test_bogus_dynamic_name)
 {
@@ -146,7 +149,8 @@ ZTEST_USER(device, test_bogus_dynamic_name)
  *
  * Validates device binding for device object when given dynamic name is null.
  *
- * @see device_get_binding(), DEVICE_DEFINE()
+ * @see device_get_binding()
+ * @see DEVICE_DEFINE()
  */
 ZTEST_USER(device, test_null_dynamic_name)
 {
@@ -295,6 +299,19 @@ SYS_INIT_NAMED(init3, init_fn, APPLICATION, 2);
 SYS_INIT_NAMED(init4, init_fn, APPLICATION, 99);
 SYS_INIT_NAMED(init5, init_fn, APPLICATION, 999);
 
+/**
+ * @brief Test registering multiple initialization functions
+ *
+ * @ingroup kernel_device_tests
+ *
+ * @details Register the same initialization function multiple times with
+ * SYS_INIT() and SYS_INIT_NAMED() at the same initialization level but
+ * different priorities, and verify that every registered entry is invoked
+ * during system initialization.
+ *
+ * @see SYS_INIT()
+ * @see SYS_INIT_NAMED()
+ */
 ZTEST(device, test_sys_init_multiple)
 {
 	zassert_equal(sys_init_counter, 6, "");

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -62,6 +62,18 @@ static void usr_fp_thread_entry_2(void *p1, void *p2, void *p3)
 	}
 }
 
+/**
+ * @brief Test enabling and disabling floating point context preservation
+ *
+ * @details Create an FP-capable thread with the K_FP_OPTS thread options and
+ * verify the options are set, then exercise k_float_disable() on it. On
+ * architectures that support disabling another thread's FP context the options
+ * are cleared; on ARM (Cortex-M/R) disabling a thread other than the current
+ * one is rejected with -EINVAL; on architectures without support the call
+ * returns -ENOTSUP.
+ *
+ * @ingroup kernel_fpsharing_tests
+ */
 ZTEST(k_float_disable, test_k_float_disable_common)
 {
 	test_ret = TC_PASS;
@@ -119,6 +131,16 @@ ZTEST(k_float_disable, test_k_float_disable_common)
 #endif
 }
 
+/**
+ * @brief Test disabling floating point context preservation from user mode
+ *
+ * @details Create an FP-capable user thread that disables its own floating
+ * point context preservation through the k_float_disable() system call, and
+ * verify the call reports the architecture-defined result (success where
+ * supported, -ENOTSUP otherwise).
+ *
+ * @ingroup kernel_fpsharing_tests
+ */
 ZTEST(k_float_disable, test_k_float_disable_syscall)
 {
 	test_ret = TC_PASS;
@@ -269,8 +291,26 @@ static void sup_fp_thread_entry(void *p1, void *p2, void *p3)
 	}
 }
 
+#endif /* CONFIG_ARM && CONFIG_DYNAMIC_INTERRUPTS */
+
+/**
+ * @brief Verify k_float_disable() is rejected when called from an ISR
+ *
+ * @details Create an FP-capable supervisor thread with the K_FP_REGS thread
+ * option, then call k_float_disable() on that thread from interrupt context.
+ * The call targets a thread other than the current one, so it must fail with
+ * -EINVAL, and the target thread's K_FP_REGS option must be left untouched.
+ *
+ * The test is skipped on platforms other than ARM with dynamic interrupts,
+ * since it needs a dynamically connected interrupt to run code in ISR context.
+ *
+ * @ingroup kernel_fpsharing_tests
+ *
+ * @see k_float_disable()
+ */
 ZTEST(k_float_disable, test_k_float_disable_irq)
 {
+#if defined(CONFIG_ARM) && defined(CONFIG_DYNAMIC_INTERRUPTS)
 	test_ret = TC_PASS;
 
 	k_thread_priority_set(k_current_get(), PRIORITY);
@@ -291,13 +331,10 @@ ZTEST(k_float_disable, test_k_float_disable_irq)
 	bool ok = test_ret == TC_PASS;
 
 	zassert_true(ok, "");
-}
 #else
-ZTEST(k_float_disable, test_k_float_disable_irq)
-{
 	TC_PRINT("This is not an ARM system with DYNAMIC_INTERRUPTS.\n");
 	ztest_test_skip();
-}
 #endif /* CONFIG_ARM && CONFIG_DYNAMIC_INTERRUPTS */
+}
 
 ZTEST_SUITE(k_float_disable, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/fpu_sharing/generic/src/load_store.c
+++ b/tests/kernel/fpu_sharing/generic/src/load_store.c
@@ -104,8 +104,10 @@ static K_SEM_DEFINE(test_exit_sem, 0, 1);
  *
  * @ingroup kernel_fpsharing_tests
  *
- * @see k_sched_time_slice_set(), memset(),
- * _load_all_float_registers(), _store_all_float_registers()
+ * @see k_sched_time_slice_set()
+ * @see memset()
+ * @see _load_all_float_registers()
+ * @see _store_all_float_registers()
  */
 static void load_store_low(void)
 {
@@ -315,6 +317,17 @@ K_THREAD_DEFINE(load_low, THREAD_STACK_SIZE, load_store_low, NULL, NULL, NULL,
 K_THREAD_DEFINE(load_high, THREAD_STACK_SIZE, load_store_high, NULL, NULL, NULL,
 		THREAD_HIGH_PRIORITY, THREAD_FP_FLAGS, K_TICKS_FOREVER);
 
+/**
+ * @brief Test preservation of the floating point context across context switches
+ *
+ * @details Run two FP-capable threads that continuously load a unique set of
+ * values into all floating point registers and, after being switched out and
+ * back in, verify the register contents are unchanged. This exercises the
+ * kernel saving and restoring each thread's floating point context across
+ * context switches.
+ *
+ * @ingroup kernel_fpsharing_tests
+ */
 ZTEST(fpu_sharing_generic, test_load_store)
 {
 	/* Initialise test states */

--- a/tests/kernel/fpu_sharing/generic/src/pi.c
+++ b/tests/kernel/fpu_sharing/generic/src/pi.c
@@ -174,6 +174,17 @@ K_THREAD_DEFINE(pi_low, THREAD_STACK_SIZE, calculate_pi_low, NULL, NULL, NULL,
 K_THREAD_DEFINE(pi_high, THREAD_STACK_SIZE, calculate_pi_high, NULL, NULL, NULL,
 		THREAD_HIGH_PRIORITY, THREAD_FP_FLAGS, K_TICKS_FOREVER);
 
+/**
+ * @brief Test preservation of the floating point context under concurrent use
+ *
+ * @details Run two FP-capable threads that repeatedly compute pi using the
+ * floating point unit and verify each computation matches the reference value.
+ * Because both threads share the floating point unit, a correct result depends
+ * on the kernel preserving each thread's floating point context across context
+ * switches.
+ *
+ * @ingroup kernel_fpsharing_tests
+ */
 ZTEST(fpu_sharing_generic, test_pi)
 {
 	/* Initialise test states */

--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -154,7 +154,7 @@ static void sem_multiple_threads_wait_helper(void *p1, void *p2, void *p3)
  *
  * @see sys_sem_init()
  */
-ZTEST(sys_sem, test_basic_sem_test)
+ZTEST(sys_sem, test_sys_sem_basic)
 {
 	int32_t ret_value;
 
@@ -209,7 +209,7 @@ ZTEST(sys_sem, test_basic_sem_test)
  * @see sys_sem_give()
  * @see sys_sem_count_get()
  */
-ZTEST(sys_sem, test_simple_sem_from_isr)
+ZTEST(sys_sem, test_sys_sem_simple_from_isr)
 {
 	uint32_t signal_count;
 
@@ -244,7 +244,7 @@ ZTEST(sys_sem, test_simple_sem_from_isr)
  * @see sys_sem_give()
  * @see sys_sem_count_get()
  */
-ZTEST_USER(sys_sem, test_simple_sem_from_task)
+ZTEST_USER(sys_sem, test_sys_sem_simple_from_task)
 {
 	uint32_t signal_count;
 
@@ -278,7 +278,7 @@ ZTEST_USER(sys_sem, test_simple_sem_from_task)
  * @see sys_sem_take()
  * @see sys_sem_count_get()
  */
-ZTEST_USER(sys_sem, test_sem_take_no_wait)
+ZTEST_USER(sys_sem, test_sys_sem_take_no_wait)
 {
 	uint32_t signal_count;
 	int32_t ret_value;
@@ -317,7 +317,7 @@ ZTEST_USER(sys_sem, test_sem_take_no_wait)
  *
  * @see sys_sem_take()
  */
-ZTEST_USER(sys_sem, test_sem_take_no_wait_fails)
+ZTEST_USER(sys_sem, test_sys_sem_take_no_wait_fails)
 {
 	uint32_t signal_count;
 	int32_t ret_value;
@@ -353,7 +353,7 @@ ZTEST_USER(sys_sem, test_sem_take_no_wait_fails)
  *
  * @see sys_sem_take()
  */
-ZTEST_USER(sys_sem_1cpu, test_sem_take_timeout_fails)
+ZTEST_USER(sys_sem_1cpu, test_sys_sem_take_timeout_fails)
 {
 	int32_t ret_value;
 
@@ -385,7 +385,7 @@ ZTEST_USER(sys_sem_1cpu, test_sem_take_timeout_fails)
  * @see sys_sem_take()
  * @see sys_sem_give()
  */
-ZTEST_USER(sys_sem, test_sem_take_timeout)
+ZTEST_USER(sys_sem, test_sys_sem_take_timeout)
 {
 	int32_t ret_value;
 #ifdef CONFIG_USERSPACE
@@ -426,7 +426,7 @@ ZTEST_USER(sys_sem, test_sem_take_timeout)
  * @see sys_sem_take()
  * @see sys_sem_give()
  */
-ZTEST_USER(sys_sem_1cpu, test_sem_take_timeout_forever)
+ZTEST_USER(sys_sem_1cpu, test_sys_sem_take_timeout_forever)
 {
 	int32_t ret_value;
 #ifdef CONFIG_USERSPACE
@@ -467,7 +467,7 @@ ZTEST_USER(sys_sem_1cpu, test_sem_take_timeout_forever)
  * @see sys_sem_take()
  * @see sys_sem_give()
  */
-ZTEST(sys_sem_1cpu, test_sem_take_timeout_isr)
+ZTEST(sys_sem_1cpu, test_sys_sem_take_timeout_isr)
 {
 	int32_t ret_value;
 
@@ -514,7 +514,7 @@ static void sem_take_kernel_user(void *p1, void *p2, void *p3)
  * @see sys_sem_take()
  * @see sys_sem_give()
  */
-ZTEST(sys_sem_1cpu, test_sem_take_kernel_user)
+ZTEST(sys_sem_1cpu, test_sys_sem_take_kernel_user)
 {
 #ifdef CONFIG_USERSPACE
 	int thread_flags = K_USER;
@@ -560,7 +560,7 @@ ZTEST(sys_sem_1cpu, test_sem_take_kernel_user)
  * @see sys_sem_take()
  * @see sys_sem_give()
  */
-ZTEST_USER(sys_sem_1cpu, test_sem_take_multiple)
+ZTEST_USER(sys_sem_1cpu, test_sys_sem_take_multiple)
 {
 	uint32_t signal_count;
 #ifdef CONFIG_USERSPACE
@@ -680,7 +680,7 @@ ZTEST_USER(sys_sem_1cpu, test_sem_take_multiple)
  * @see sys_sem_take()
  * @see sys_sem_count_get()
  */
-ZTEST(sys_sem, test_sem_give_take_from_isr)
+ZTEST(sys_sem, test_sys_sem_give_take_from_isr)
 {
 	uint32_t signal_count;
 
@@ -727,7 +727,7 @@ ZTEST(sys_sem, test_sem_give_take_from_isr)
  * @see sys_sem_give()
  * @see sys_sem_count_get()
  */
-ZTEST_USER(sys_sem, test_sem_give_limit)
+ZTEST_USER(sys_sem, test_sys_sem_give_limit)
 {
 	int32_t ret_value;
 	uint32_t signal_count;
@@ -787,7 +787,7 @@ ZTEST_USER(sys_sem, test_sem_give_limit)
  * @see sys_sem_give()
  * @see sys_sem_count_get()
  */
-ZTEST_USER(sys_sem_1cpu, test_sem_multiple_threads_wait)
+ZTEST_USER(sys_sem_1cpu, test_sys_sem_multiple_threads_wait)
 {
 	uint32_t signal_count;
 	int32_t ret_value;

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -334,7 +334,8 @@ ZTEST(syscalls, test_string_nlen_maxsize_zero)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_usermode_string_alloc_copy(), strcmp()
+ * @see k_usermode_string_alloc_copy()
+ * @see strcmp()
  */
 ZTEST_USER(syscalls, test_user_string_alloc_copy)
 {
@@ -359,7 +360,8 @@ ZTEST_USER(syscalls, test_user_string_alloc_copy)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_usermode_string_copy(), strcmp()
+ * @see k_usermode_string_copy()
+ * @see strcmp()
  */
 ZTEST_USER(syscalls, test_user_string_copy)
 {
@@ -383,7 +385,8 @@ ZTEST_USER(syscalls, test_user_string_copy)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see memcpy(), k_usermode_to_copy()
+ * @see memcpy()
+ * @see k_usermode_to_copy()
  */
 ZTEST_USER(syscalls, test_to_copy)
 {
@@ -410,11 +413,32 @@ void run_test_arg64(void)
 		      "syscall (arg64_big) didn't match impl");
 }
 
+/**
+ * @brief Test passing 64-bit arguments through a system call
+ *
+ * @details Invoke system calls that take 64-bit arguments from user mode and
+ * verify the values received by the implementation match those passed in,
+ * confirming user threads can perform privileged operations through system
+ * calls with wide arguments.
+ *
+ * @ingroup kernel_memprotect_tests
+ * @see syscall_arg64()
+ */
 ZTEST_USER(syscalls, test_arg64)
 {
 	run_test_arg64();
 }
 
+/**
+ * @brief Test passing the maximum number of system call arguments
+ *
+ * @details Invoke a system call from user mode that takes more arguments than
+ * fit in registers and verify the implementation receives all of them intact,
+ * confirming user threads can perform privileged operations through system
+ * calls with many arguments.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 ZTEST_USER(syscalls, test_more_args)
 {
 	zassert_equal(more_args(1, 2, 3, 4, 5, 6, 7),
@@ -474,6 +498,15 @@ void syscall_switch_stress(void *arg1, void *arg2, void *arg3)
 	}
 }
 
+/**
+ * @brief Stress test system calls under concurrency
+ *
+ * @details Spawn many user threads that hammer the test system calls in a tight
+ * loop across all CPUs, smoking out concurrency problems in the system call
+ * path used by user threads to perform privileged operations.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 ZTEST(syscalls_extended, test_syscall_switch_stress)
 {
 	uintptr_t i;
@@ -527,7 +560,15 @@ void test_syscall_context_user(void *p1, void *p2, void *p3)
 		     "not reported in user syscall");
 }
 
-/* Show that z_is_in_syscall() works properly */
+/**
+ * @brief Test detection of user system call context
+ *
+ * @details Show that k_is_in_user_syscall() correctly reports whether execution
+ * is inside a system call invoked from user mode: false in a supervisor thread
+ * and in a supervisor-mode call, true when invoked from a user thread. This
+ * exercises the system call mechanism that lets user threads perform privileged
+ * operations.
+ */
 ZTEST(syscalls, test_syscall_context)
 {
 	/* We're a regular supervisor thread. */

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -787,7 +787,8 @@ ZTEST(userspace_domain, test_domain_add_thread_drop_to_user)
 	drop_user(&alt_bool);
 }
 
-/* @brief Test adding application memory partition to memory domain
+/**
+ * @brief Test adding application memory partition to memory domain
  *
  * @details Show that adding a partition to a domain and then dropping to user
  * mode works as expected.
@@ -838,7 +839,8 @@ ZTEST(userspace_domain_ctx, test_domain_add_thread_context_switch)
 	spawn_user(&alt_bool);
 }
 
-/* Show that adding a partition to a domain and then switching to another
+/**
+ * Show that adding a partition to a domain and then switching to another
  * user thread in the same domain works as expected.
  *
  * @ingroup kernel_memprotect_tests
@@ -925,7 +927,8 @@ static struct k_sem recycle_sem;
  * @details Test recycle valid/invalid kernel object, see if
  * perms_count changes as expected.
  *
- * @see k_object_recycle(), k_object_find()
+ * @see k_object_recycle()
+ * @see k_object_find()
  *
  * @ingroup kernel_memprotect_tests
  */

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1013,7 +1013,7 @@ static inline void z_vrfy_check_syscall_context(void)
 }
 #include <zephyr/syscalls/check_syscall_context_mrsh.c>
 
-ZTEST_USER(userspace, test_syscall_context)
+ZTEST_USER(userspace, test_userspace_syscall_context)
 {
 	check_syscall_context();
 }

--- a/tests/kernel/mem_slab/mslab_stats/src/main.c
+++ b/tests/kernel/mem_slab/mslab_stats/src/main.c
@@ -12,6 +12,14 @@
 
 K_MEM_SLAB_DEFINE(kmslab, BLK_SZ, NUM_BLOCKS, 4);
 
+/**
+ * @brief Verify memory slab statistics routines reject invalid parameters
+ *
+ * @details Call the memory slab runtime statistics query and reset routines
+ * with invalid parameters and verify they return -EINVAL.
+ *
+ * @ingroup kernel_memory_slab_tests
+ */
 ZTEST(lib_mem_slab_stats_test, test_mem_slab_stats_invalid_params)
 {
 	struct sys_memory_stats  stats;
@@ -40,6 +48,15 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_stats_invalid_params)
 		      status, -EINVAL);
 }
 
+/**
+ * @brief Verify memory slab runtime usage statistics
+ *
+ * @details Query the runtime statistics of a memory slab and verify that the
+ * reported free, allocated and maximum-allocated byte counts track block
+ * allocations and frees, and that resetting the maximum works.
+ *
+ * @ingroup kernel_memory_slab_tests
+ */
 ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 {
 	struct sys_memory_stats  stats;

--- a/tests/kernel/multiprocessing/smp/src/main.c
+++ b/tests/kernel/multiprocessing/smp/src/main.c
@@ -186,7 +186,9 @@ static void child_fn(void *p1, void *p2, void *p3)
  * @ingroup kernel_smp_tests
  *
  * @details Verify whether thread running on other core is
- * parent thread from child thread
+ * parent thread from child thread. Relies on the SMP initialization having
+ * brought up the secondary CPUs so that a child thread can run on a different
+ * core than its parent.
  */
 ZTEST(smp, test_cpu_id_threads)
 {

--- a/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
+++ b/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
@@ -262,6 +262,19 @@ ZTEST(mutex_api, test_mutex_init)
 	zassert_equal(k_mutex_unlock(&tmutex), 0);
 }
 
+/**
+ * @brief Verify reentrant locking with a waiter blocking forever.
+ *
+ * @details
+ * A thread holds the mutex while a second thread blocks on it with K_FOREVER;
+ * the waiter acquires the mutex once it is released. Exercised on both a
+ * run-time initialized mutex and a compile-time K_MUTEX_DEFINE() mutex.
+ *
+ * @ingroup kernel_mutex_tests
+ * @see k_mutex_init()
+ * @see k_mutex_lock()
+ * @see k_mutex_unlock()
+ */
 ZTEST_USER(mutex_api_1cpu, test_mutex_reent_lock_forever)
 {
 	/**TESTPOINT: test k_mutex_init mutex*/
@@ -274,6 +287,17 @@ ZTEST_USER(mutex_api_1cpu, test_mutex_reent_lock_forever)
 	k_thread_abort(&tdata);
 }
 
+/**
+ * @brief Verify locking a held mutex with K_NO_WAIT fails immediately.
+ *
+ * @details
+ * While the mutex is held by another thread, a K_NO_WAIT lock attempt must
+ * return without blocking. Exercised on a run-time and a K_MUTEX_DEFINE() mutex.
+ *
+ * @ingroup kernel_mutex_tests
+ * @see k_mutex_lock()
+ * @see k_mutex_unlock()
+ */
 ZTEST_USER(mutex_api, test_mutex_reent_lock_no_wait)
 {
 	/**TESTPOINT: test k_mutex_init mutex*/
@@ -283,6 +307,17 @@ ZTEST_USER(mutex_api, test_mutex_reent_lock_no_wait)
 	tmutex_test_lock(&kmutex, tThread_entry_lock_no_wait);
 }
 
+/**
+ * @brief Verify locking a held mutex with a finite timeout times out.
+ *
+ * @details
+ * While the mutex is held, a lock attempt with a finite timeout must fail once
+ * the timeout elapses without the mutex being released.
+ *
+ * @ingroup kernel_mutex_tests
+ * @see k_mutex_lock()
+ * @see k_mutex_unlock()
+ */
 ZTEST_USER(mutex_api, test_mutex_reent_lock_timeout_fail)
 {
 	/**TESTPOINT: test k_mutex_init mutex*/
@@ -292,6 +327,17 @@ ZTEST_USER(mutex_api, test_mutex_reent_lock_timeout_fail)
 	tmutex_test_lock_timeout(&kmutex, tThread_entry_lock_no_wait);
 }
 
+/**
+ * @brief Verify a timed lock succeeds once the mutex is released in time.
+ *
+ * @details
+ * A lock attempt with a finite timeout must succeed when the holding thread
+ * releases the mutex before the timeout elapses.
+ *
+ * @ingroup kernel_mutex_tests
+ * @see k_mutex_lock()
+ * @see k_mutex_unlock()
+ */
 ZTEST_USER(mutex_api_1cpu, test_mutex_reent_lock_timeout_pass)
 {
 	/**TESTPOINT: test k_mutex_init mutex*/
@@ -301,6 +347,19 @@ ZTEST_USER(mutex_api_1cpu, test_mutex_reent_lock_timeout_pass)
 	tmutex_test_lock_timeout(&kmutex, tThread_entry_lock_no_wait);
 }
 
+/**
+ * @brief Verify basic mutex lock and unlock.
+ *
+ * @details
+ * Lock and then unlock the mutex from a single thread and confirm the
+ * operations succeed, on both a run-time initialized mutex and a compile-time
+ * K_MUTEX_DEFINE() mutex.
+ *
+ * @ingroup kernel_mutex_tests
+ * @see k_mutex_init()
+ * @see k_mutex_lock()
+ * @see k_mutex_unlock()
+ */
 ZTEST_USER(mutex_api_1cpu, test_mutex_lock_unlock)
 {
 	/**TESTPOINT: test k_mutex_init mutex*/

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -60,9 +60,10 @@
 /* global variable for mutual exclusion test */
 uint32_t critical_var;
 
+/** Per-thread timeout descriptor used by the multi-timeout test helpers. */
 struct timeout_info {
-	uint32_t timeout;
-	struct k_sem *sema;
+	uint32_t timeout;    /**< Requested take timeout in milliseconds. */
+	struct k_sem *sema;  /**< Semaphore the thread waits on. */
 };
 
 /******************************************************************************/
@@ -249,8 +250,24 @@ ZTEST_USER(semaphore, test_k_sem_define)
 }
 
 /**
- * @brief Test synchronization of threads with semaphore
- * @see k_sem_init(), #K_SEM_DEFINE(x)
+ * @brief Verify a semaphore synchronizes two threads.
+ *
+ * @details
+ * A semaphore is used to hand off execution between two threads, exercising both
+ * a run-time initialized semaphore (k_sem_init()) and a compile-time defined one
+ * (K_SEM_DEFINE()). One thread gives the semaphore while the other takes it,
+ * confirming that a run-time defined semaphore is usable for synchronization.
+ *
+ * Test steps:
+ * - Initialize a semaphore at run time with k_sem_init().
+ * - Hand off between two threads via k_sem_give()/k_sem_take().
+ * - Repeat the hand off using a compile-time K_SEM_DEFINE() semaphore.
+ *
+ * Expected result:
+ * - Both threads synchronize correctly using either semaphore.
+ *
+ * @see k_sem_init()
+ * @see K_SEM_DEFINE()
  */
 ZTEST_USER(semaphore, test_sem_thread2thread)
 {
@@ -264,8 +281,24 @@ ZTEST_USER(semaphore, test_sem_thread2thread)
 }
 
 /**
- * @brief Test synchronization between thread and irq
- * @see k_sem_init(), #K_SEM_DEFINE(x)
+ * @brief Verify a semaphore synchronizes a thread with an ISR.
+ *
+ * @details
+ * A semaphore is given from interrupt context and taken from thread context,
+ * exercising both a run-time initialized semaphore and a compile-time defined
+ * one, to confirm a semaphore can be used to synchronize across the thread/ISR
+ * boundary.
+ *
+ * Test steps:
+ * - Initialize a semaphore at run time and give it from an ISR.
+ * - Take it from the thread and verify synchronization.
+ * - Repeat with a compile-time K_SEM_DEFINE() semaphore.
+ *
+ * Expected result:
+ * - The thread and ISR synchronize correctly using either semaphore.
+ *
+ * @see k_sem_init()
+ * @see K_SEM_DEFINE()
  */
 ZTEST(semaphore, test_sem_thread2isr)
 {
@@ -278,30 +311,32 @@ ZTEST(semaphore, test_sem_thread2isr)
 	tsema_thread_isr(&ksema);
 }
 
+/** Parameter set for the parameterized test_sem_init_validity test. */
+struct sem_init_case {
+	uint32_t init_val;     /**< Initial semaphore count passed to k_sem_init(). */
+	uint32_t max_val;      /**< Maximum semaphore count passed to k_sem_init(). */
+	int      expected_ret; /**< Expected k_sem_init() return value. */
+};
+
 /**
  * @brief Parameterized k_sem_init() validity test.
  *
+ * @details
  * The existing test_k_sem_init() checks 3 hardcoded (init, max) combinations
  * in a single test body.  Here each combination is a separate named invocation
  * so that Twister output immediately identifies which specific combination
  * caused a failure (e.g. "test_sem_init_validity[cases/3]").
  *
  * Valid combinations must return 0; invalid ones must return -EINVAL:
- *  - max == 0                          → -EINVAL
- *  - init > max                        → -EINVAL
- *  - init == max (boundary)            → 0
- *  - init < max                        → 0
- *  - large but valid max               → 0
+ *  - max == 0                          -> -EINVAL
+ *  - init > max                        -> -EINVAL
+ *  - init == max (boundary)            -> 0
+ *  - init < max                        -> 0
+ *  - large but valid max               -> 0
  *
  * @ingroup kernel_semaphore_tests
  * @see k_sem_init()
  */
-struct sem_init_case {
-	uint32_t init_val;
-	uint32_t max_val;
-	int      expected_ret;
-};
-
 ZTEST_USER_P(semaphore, test_sem_init_validity)
 {
 	const struct sem_init_case *tc =
@@ -339,7 +374,21 @@ ZTEST_INSTANTIATE_TEST_SUITE_P(cases, semaphore,
 			       test_sem_init_validity, sem_init_cases_vals);
 
 /**
- * @brief Test k_sem_reset() API
+ * @brief Verify k_sem_reset() sets the semaphore count back to zero.
+ *
+ * @details
+ * After giving a semaphore so its count is non-zero, k_sem_reset() must return
+ * the count to zero. A subsequent non-blocking take then fails with -EBUSY and a
+ * timed take fails with -EAGAIN, and the semaphore remains usable afterwards.
+ *
+ * Test steps:
+ * - Initialize a semaphore and give it once (count becomes 1).
+ * - Call k_sem_reset() and read the count.
+ * - Attempt k_sem_take() with K_NO_WAIT and with a finite timeout.
+ *
+ * Expected result:
+ * - Count is zero after reset; take returns -EBUSY (no wait) and -EAGAIN (timeout).
+ *
  * @see k_sem_reset()
  */
 ZTEST_USER(semaphore, test_sem_reset)
@@ -367,6 +416,18 @@ ZTEST_USER(semaphore, test_sem_reset)
 	expect_k_sem_count_get_nomsg(&msg_sema, 0);
 }
 
+/**
+ * @brief Verify that resetting a semaphore aborts pending acquisitions.
+ *
+ * @details
+ * A waiter blocks on k_sem_take() with K_FOREVER while another thread resets
+ * the semaphore. The pending acquisition must be aborted and return -EAGAIN,
+ * and the semaphore must remain functional afterwards.
+ *
+ * @ingroup kernel_semaphore_tests
+ * @see k_sem_reset()
+ * @see k_sem_take()
+ */
 ZTEST_USER(semaphore, test_sem_reset_waiting)
 {
 	int32_t ret_value;
@@ -393,7 +454,22 @@ ZTEST_USER(semaphore, test_sem_reset_waiting)
 }
 
 /**
- * @brief Test k_sem_count_get() API
+ * @brief Verify k_sem_count_get() reports the count without acquiring.
+ *
+ * @details
+ * k_sem_count_get() must return the current semaphore count without consuming
+ * it, and the reported count must track give/take operations: it increments on
+ * each give (saturating at the maximum) and decrements on each take.
+ *
+ * Test steps:
+ * - Read the count right after initialization.
+ * - Give the semaphore and read the count again.
+ * - Repeatedly give up to (and beyond) the maximum and read the count.
+ *
+ * Expected result:
+ * - The returned count matches the expected value at each step and never exceeds
+ *   the configured maximum.
+ *
  * @see k_sem_count_get()
  */
 ZTEST_USER(semaphore, test_sem_count_get)
@@ -475,7 +551,20 @@ ZTEST_USER(semaphore, test_sem_give_from_thread)
 }
 
 /**
- * @brief Test if k_sem_take() decreases semaphore count
+ * @brief Verify k_sem_take() succeeds and decrements when the count is positive.
+ *
+ * @details
+ * While the count is greater than zero, a non-blocking k_sem_take() must acquire
+ * the semaphore immediately and decrement the count by one on each call.
+ *
+ * Test steps:
+ * - Give the semaphore several times to raise its count.
+ * - Repeatedly call k_sem_take() with K_NO_WAIT.
+ * - Read the count after each take.
+ *
+ * Expected result:
+ * - Each take returns 0 and the count decreases by one each time.
+ *
  * @see k_sem_take()
  */
 ZTEST_USER(semaphore, test_sem_take_no_wait)
@@ -497,7 +586,20 @@ ZTEST_USER(semaphore, test_sem_take_no_wait)
 }
 
 /**
- * @brief Test k_sem_take() when there is no semaphore to take
+ * @brief Verify k_sem_take() with no wait fails when the count is zero.
+ *
+ * @details
+ * When the count is zero and no timeout is provided (K_NO_WAIT), k_sem_take()
+ * must not block and must return -EBUSY, leaving the count unchanged at zero.
+ *
+ * Test steps:
+ * - Reset the semaphore so its count is zero.
+ * - Call k_sem_take() with K_NO_WAIT repeatedly.
+ * - Read the count after each attempt.
+ *
+ * Expected result:
+ * - Each take returns -EBUSY and the count remains zero.
+ *
  * @see k_sem_take()
  */
 ZTEST_USER(semaphore, test_sem_take_no_wait_fails)
@@ -607,7 +709,21 @@ ZTEST_USER(semaphore, test_sem_take_timeout_forever)
 }
 
 /**
- * @brief Test k_sem_take() with timeout in ISR context
+ * @brief Verify k_sem_take() with a timeout is satisfied by an ISR give.
+ *
+ * @details
+ * A thread blocks on k_sem_take() with a finite timeout while a helper gives the
+ * semaphore from interrupt context before the timeout elapses, so the take must
+ * succeed.
+ *
+ * Test steps:
+ * - Reset the semaphore so its count is zero.
+ * - Start a helper that gives the semaphore from an ISR.
+ * - Call k_sem_take() with a finite timeout.
+ *
+ * Expected result:
+ * - k_sem_take() returns 0 (acquired before the timeout expires).
+ *
  * @see k_sem_take()
  */
 ZTEST(semaphore_1cpu, test_sem_take_timeout_isr)
@@ -631,6 +747,10 @@ ZTEST(semaphore_1cpu, test_sem_take_timeout_isr)
 
 /**
  * @brief Test semaphore take operation by multiple threads
+ * @details
+ * Several threads of differing priorities wait on the same semaphore. When the
+ * semaphore is given, the highest-priority (and, among equal priorities, the
+ * longest-waiting) thread must be the one that acquires it.
  * @ingroup kernel_semaphore_tests
  * @see k_sem_take()
  */
@@ -787,7 +907,8 @@ ZTEST_USER(semaphore, test_sem_take_multiple)
  *   as expected.
  * - Verify the max times a semaphore can be taken.
  * @ingroup kernel_semaphore_tests
- * @see k_sem_count_get(), k_sem_give()
+ * @see k_sem_count_get()
+ * @see k_sem_give()
  */
 ZTEST_USER(semaphore, test_k_sem_correct_count_limit)
 {
@@ -833,7 +954,21 @@ ZTEST_USER(semaphore, test_k_sem_correct_count_limit)
 }
 
 /**
- * @brief Test semaphore give and take and its count from ISR
+ * @brief Verify a semaphore can be given and taken from ISR context.
+ *
+ * @details
+ * Give the semaphore from an ISR up to its maximum, then take it from an ISR back
+ * down to zero, checking the count after every operation to confirm give/take
+ * work correctly from interrupt context.
+ *
+ * Test steps:
+ * - Reset the semaphore so its count is zero.
+ * - Give from an ISR until the maximum count, checking the count each time.
+ * - Take from an ISR until zero, checking the count each time.
+ *
+ * Expected result:
+ * - The count tracks every give/take and ends at zero.
+ *
  * @see k_sem_give()
  */
 ZTEST(semaphore, test_sem_give_take_from_isr)
@@ -870,9 +1005,25 @@ void sem_multiple_threads_wait_helper(void *p1, void *p2, void *p3)
 
 
 /**
- * @brief Test multiple semaphore take and give with wait
+ * @brief Verify all waiters are released as the semaphore is given repeatedly.
+ *
+ * @details
+ * Several threads block on the same semaphore. Giving the semaphore once per
+ * waiter must release each of them exactly once. The scenario is run twice to
+ * confirm the wait queue is left empty and reusable after the first round.
+ *
+ * Test steps:
+ * - Start TOTAL_THREADS_WAITING threads, each blocking on the semaphore.
+ * - Give the semaphore once per waiting thread.
+ * - Confirm every thread acquired it and the counts return to zero.
+ * - Repeat the whole sequence a second time.
+ *
+ * Expected result:
+ * - All waiters are released each round and the wait queue ends empty.
+ *
  * @ingroup kernel_semaphore_tests
- * @see k_sem_take(), k_sem_give()
+ * @see k_sem_take()
+ * @see k_sem_give()
  */
 ZTEST(semaphore, test_sem_multiple_threads_wait)
 {
@@ -919,9 +1070,25 @@ ZTEST(semaphore, test_sem_multiple_threads_wait)
 }
 
 /**
- * @brief Test semaphore timeout period
+ * @brief Verify k_sem_take() honors the requested timeout duration.
+ *
+ * @details
+ * On an unavailable semaphore, k_sem_take() with a one-second timeout must block
+ * for at least that long before returning -EAGAIN, confirming the timeout period
+ * is actually observed (and a K_NO_WAIT take returns promptly).
+ *
+ * Test steps:
+ * - Reset the semaphore so its count is zero.
+ * - Record uptime, call k_sem_take() with a 1-second timeout, record uptime.
+ * - Verify the elapsed time is at least one second and the return is -EAGAIN.
+ *
+ * Expected result:
+ * - The timed take blocks for >= 1 second and returns -EAGAIN.
+ *
  * @ingroup kernel_semaphore_tests
- * @see k_sem_take(), k_sem_give(), k_sem_reset()
+ * @see k_sem_take()
+ * @see k_sem_give()
+ * @see k_sem_reset()
  */
 ZTEST(semaphore, test_sem_measure_timeouts)
 {
@@ -977,9 +1144,25 @@ void sem_measure_timeout_from_thread_helper(void *p1, void *p2, void *p3)
 
 
 /**
- * @brief Test timeout of semaphore from thread
+ * @brief Verify a timed k_sem_take() returns early when given by a thread.
+ *
+ * @details
+ * A thread blocks on k_sem_take() with a one-second timeout while a lower
+ * priority thread gives the semaphore well before the timeout. The take must
+ * therefore return success in less than the full timeout period.
+ *
+ * Test steps:
+ * - Reset the semaphores and start a helper thread that gives the semaphore.
+ * - Synchronize, then call k_sem_take() with a 1-second timeout.
+ * - Measure the elapsed time.
+ *
+ * Expected result:
+ * - k_sem_take() returns 0 and the elapsed time is well under one second.
+ *
  * @ingroup kernel_semaphore_tests
- * @see k_sem_give(), k_sem_reset(), k_sem_take()
+ * @see k_sem_give()
+ * @see k_sem_reset()
+ * @see k_sem_take()
  */
 ZTEST(semaphore, test_sem_measure_timeout_from_thread)
 {
@@ -1035,9 +1218,25 @@ void sem_multiple_take_and_timeouts_helper(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test multiple semaphore take with timeouts
+ * @brief Verify threads waiting on one semaphore time out in timeout order.
+ *
+ * @details
+ * Several threads block on the same semaphore with different timeouts. With none
+ * of them ever given the semaphore, they must time out (-EAGAIN) in ascending
+ * order of their timeout values; the observed order is recorded via a pipe and
+ * checked.
+ *
+ * Test steps:
+ * - Start threads that each take the semaphore with a distinct timeout.
+ * - Record each thread's timeout value as it expires.
+ * - Compare the expiry order against the expected ascending order.
+ *
+ * Expected result:
+ * - Threads time out with -EAGAIN in increasing timeout order.
+ *
  * @ingroup kernel_semaphore_tests
- * @see k_sem_take(), k_sem_reset()
+ * @see k_sem_take()
+ * @see k_sem_reset()
  */
 ZTEST(semaphore_1cpu, test_sem_multiple_take_and_timeouts)
 {
@@ -1104,9 +1303,25 @@ void sem_multi_take_timeout_diff_sem_helper(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test sequence of multiple semaphore timeouts
+ * @brief Verify timeout ordering across waiters on different semaphores.
+ *
+ * @details
+ * Threads block with different timeouts on two different semaphores. None are
+ * given, so every thread must time out (-EAGAIN), and the global expiry order
+ * must follow the ascending timeout values regardless of which semaphore each
+ * thread waited on.
+ *
+ * Test steps:
+ * - Start threads waiting on two semaphores, each with a distinct timeout.
+ * - Record each expiry as it happens.
+ * - Verify the expiries occur in ascending timeout order.
+ *
+ * Expected result:
+ * - All takes return -EAGAIN and expire in ascending timeout order.
+ *
  * @ingroup kernel_semaphore_tests
- * @see k_sem_take(), k_sem_reset()
+ * @see k_sem_take()
+ * @see k_sem_reset()
  */
 ZTEST(semaphore, test_sem_multi_take_timeout_diff_sem)
 {

--- a/tests/kernel/sys_timer/cycle64/src/main.c
+++ b/tests/kernel/sys_timer/cycle64/src/main.c
@@ -42,6 +42,17 @@ uint32_t timeout(uint64_t prev, uint64_t now)
 	return (uint32_t)next;
 }
 
+/**
+ * @brief Test the 64-bit hardware cycle counter across a 32-bit wrap
+ *
+ * @details Read the 64-bit hardware cycle counter repeatedly across the point
+ * where its lower 32 bits wrap around and verify that the full 64-bit value
+ * continues to increase monotonically, confirming the counter provides a
+ * 64-bit cycle count.
+ *
+ * @ingroup kernel_timer_tests
+ * @see k_cycle_get_64()
+ */
 ZTEST(cycle64_tests, test_32bit_wrap_around)
 {
 	enum {

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -79,7 +79,8 @@ static void customdata_entry(void *p1, void *p2, void *p3)
  * @ingroup kernel_thread_tests
  * @brief Test thread custom data get/set from coop thread
  *
- * @see k_thread_custom_data_get(), k_thread_custom_data_set()
+ * @see k_thread_custom_data_get()
+ * @see k_thread_custom_data_set()
  */
 ZTEST(threads_lifecycle_1cpu, test_customdata_get_set_coop)
 {
@@ -101,7 +102,9 @@ static void thread_name_entry(void *p1, void *p2, void *p3)
 /**
  * @ingroup kernel_thread_tests
  * @brief Test thread name get/set from supervisor thread
- * @see k_thread_name_get(), k_thread_name_copy(), k_thread_name_set()
+ * @see k_thread_name_get()
+ * @see k_thread_name_copy()
+ * @see k_thread_name_set()
  */
 ZTEST(threads_lifecycle, test_thread_name_get_set)
 {
@@ -142,7 +145,8 @@ struct k_sem sem;
 /**
  * @ingroup kernel_thread_tests
  * @brief Test thread name get/set from user thread
- * @see k_thread_name_copy(), k_thread_name_set()
+ * @see k_thread_name_copy()
+ * @see k_thread_name_set()
  */
 ZTEST_USER(threads_lifecycle, test_thread_name_user_get_set)
 {
@@ -211,7 +215,8 @@ ZTEST_USER(threads_lifecycle, test_thread_name_user_get_set)
 /**
  * @ingroup kernel_thread_tests
  * @brief Test thread custom data get/set from preempt thread
- * @see k_thread_custom_data_get(), k_thread_custom_data_set()
+ * @see k_thread_custom_data_get()
+ * @see k_thread_custom_data_set()
  */
 ZTEST_USER(threads_lifecycle_1cpu, test_customdata_get_set_preempt)
 {
@@ -257,6 +262,17 @@ static void enter_user_mode_entry(void *p1, void *p2, void *p3)
 				 k_current_get(), NULL, NULL);
 }
 
+/**
+ * @brief Verify a thread can run with user-mode (unprivileged) privileges.
+ *
+ * @details
+ * Create a thread that calls k_thread_user_mode_enter() so it transitions to
+ * user mode, confirming the kernel can create threads with a defined privilege
+ * level.
+ *
+ * @ingroup kernel_thread_tests
+ * @see k_thread_user_mode_enter()
+ */
 ZTEST_USER(threads_lifecycle, test_user_mode)
 {
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,

--- a/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
@@ -15,9 +15,10 @@ static int thread2_data;
 K_SEM_DEFINE(sem_thread2, 0, 1);
 K_SEM_DEFINE(sem_thread1, 0, 1);
 
+/** Arguments passed to the ISR that changes a thread's priority. */
 struct isr_arg {
-	k_tid_t thread;
-	int     prio;
+	k_tid_t thread;  /**< Thread whose priority is changed. */
+	int     prio;    /**< Priority to set from the ISR. */
 };
 
 static struct isr_arg prio_args;
@@ -65,7 +66,8 @@ void thread2_set_prio_test(void *p1, void *p2, void *p3)
  * current thread. It then sets the priority of the thread to a
  * higher value, and checks that the priority has been set correctly.
  *
- * @see k_thread_priority_set(), k_thread_priority_get()
+ * @see k_thread_priority_set()
+ * @see k_thread_priority_get()
  */
 ZTEST(threads_lifecycle, test_threads_priority_set)
 {
@@ -135,7 +137,8 @@ ZTEST(threads_lifecycle, test_threads_priority_set)
  * @details This test verifies that thread priorities can be changed
  * correctly when invoked from an interrupt service routine (ISR).
  *
- * @see k_thread_priority_set(), k_thread_priority_get()
+ * @see k_thread_priority_set()
+ * @see k_thread_priority_get()
  */
 ZTEST(threads_lifecycle, test_isr_threads_priority_set_)
 {

--- a/tests/kernel/threads/thread_error_case/src/main.c
+++ b/tests/kernel/threads/thread_error_case/src/main.c
@@ -187,7 +187,7 @@ static void create_negative_test_thread(int choice)
  *
  * @see k_thread_start()
  */
-ZTEST_USER(thread_error_case, test_thread_start)
+ZTEST_USER(thread_error_case, test_thread_start_error)
 {
 	create_negative_test_thread(THREAD_START);
 }

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -8,10 +8,11 @@
 #include <zephyr/ztest.h>
 #include <zephyr/types.h>
 
+/** Bookkeeping shared with the timer expiry/stop callbacks. */
 struct timer_data {
-	int expire_cnt;
-	int stop_cnt;
-	int64_t timestamp;
+	int expire_cnt;     /**< Number of times the expiry function ran. */
+	int stop_cnt;       /**< Number of times the stop function ran. */
+	int64_t timestamp;  /**< Uptime captured at the last expiry. */
 };
 
 #define DURATION 100
@@ -186,8 +187,11 @@ static void status_stop(struct k_timer *timer)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_stop(), k_uptime_get(),
- * k_busy_wait()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_stop()
+ * @see k_uptime_get()
+ * @see k_busy_wait()
  */
 ZTEST_USER(timer_api, test_timer_duration_period)
 {
@@ -214,7 +218,9 @@ ZTEST_USER(timer_api, test_timer_duration_period)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_status_get()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_status_get()
  */
 ZTEST(timer_api, test_timer_init_runtime)
 {
@@ -244,8 +250,11 @@ ZTEST(timer_api, test_timer_init_runtime)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_stop, k_uptime_get(),
- * k_busy_wait()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_stop()
+ * @see k_uptime_get()
+ * @see k_busy_wait()
  *
  */
 ZTEST_USER(timer_api, test_timer_restart)
@@ -279,8 +288,11 @@ ZTEST_USER(timer_api, test_timer_restart)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_stop(), k_uptime_get(),
- * k_busy_wait()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_stop()
+ * @see k_uptime_get()
+ * @see k_busy_wait()
  */
 ZTEST_USER(timer_api, test_timer_period_0)
 {
@@ -316,8 +328,11 @@ ZTEST_USER(timer_api, test_timer_period_0)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_stop(), k_uptime_get(),
- * k_busy_wait()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_stop()
+ * @see k_uptime_get()
+ * @see k_busy_wait()
  */
 ZTEST_USER(timer_api, test_timer_period_k_forever)
 {
@@ -355,8 +370,11 @@ ZTEST_USER(timer_api, test_timer_period_k_forever)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_stop(), k_uptime_get(),
- * k_busy_wait()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_stop()
+ * @see k_uptime_get()
+ * @see k_busy_wait()
  */
 ZTEST_USER(timer_api, test_timer_expirefn_null)
 {
@@ -399,8 +417,12 @@ static void tick_sync(void)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_status_sync(),
- * k_timer_stop(), k_uptime_get(), k_uptime_delta()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_status_sync()
+ * @see k_timer_stop()
+ * @see k_uptime_get()
+ * @see k_uptime_delta()
  */
 ZTEST_USER(timer_api, test_timer_periodicity)
 {
@@ -467,8 +489,11 @@ ZTEST_USER(timer_api, test_timer_periodicity)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_status_get(),
- * k_timer_remaining_get(), k_timer_stop()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_status_get()
+ * @see k_timer_remaining_get()
+ * @see k_timer_stop()
  */
 ZTEST_USER(timer_api, test_timer_status_get)
 {
@@ -496,8 +521,11 @@ ZTEST_USER(timer_api, test_timer_status_get)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_status_get(),
- * k_timer_stop(), k_busy_wait()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_status_get()
+ * @see k_timer_stop()
+ * @see k_busy_wait()
  */
 ZTEST_USER(timer_api, test_timer_status_get_anytime)
 {
@@ -530,8 +558,10 @@ ZTEST_USER(timer_api, test_timer_status_get_anytime)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_status_sync(),
- * k_timer_stop()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_status_sync()
+ * @see k_timer_stop()
  */
 ZTEST_USER(timer_api, test_timer_status_sync)
 {
@@ -570,8 +600,11 @@ ZTEST_USER(timer_api, test_timer_status_sync)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_start(), K_TIMER_DEFINE(), k_timer_stop()
- * k_uptime_get(), k_busy_wait()
+ * @see k_timer_start()
+ * @see K_TIMER_DEFINE()
+ * @see k_timer_stop()
+ * @see k_uptime_get()
+ * @see k_busy_wait()
  */
 ZTEST_USER(timer_api, test_timer_k_define)
 {
@@ -654,8 +687,11 @@ static void user_data_timer_handler(struct k_timer *timer)
  *
  * @ingroup kernel_timer_tests
  *
- * @see K_TIMER_DEFINE(), k_timer_user_data_set(), k_timer_start(),
- * k_timer_user_data_get(), k_timer_stop()
+ * @see K_TIMER_DEFINE()
+ * @see k_timer_user_data_set()
+ * @see k_timer_start()
+ * @see k_timer_user_data_get()
+ * @see k_timer_stop()
  */
 ZTEST_USER(timer_api, test_timer_user_data)
 {
@@ -706,8 +742,10 @@ ZTEST_USER(timer_api, test_timer_user_data)
  *
  * @ingroup kernel_timer_tests
  *
- * @see k_timer_init(), k_timer_start(), k_timer_stop(),
- * k_timer_remaining_get()
+ * @see k_timer_init()
+ * @see k_timer_start()
+ * @see k_timer_stop()
+ * @see k_timer_remaining_get()
  */
 
 ZTEST_USER(timer_api, test_timer_remaining)
@@ -996,7 +1034,8 @@ static void isr_ctx_expire(struct k_timer *timer)
  * expired, verify the callback ran and that it observed itself running in
  * interrupt context.
  *
- * @see k_timer_start(), k_is_in_isr()
+ * @see k_timer_start()
+ * @see k_is_in_isr()
  */
 ZTEST(timer_api, test_timer_expiry_in_isr)
 {
@@ -1046,7 +1085,8 @@ static void cleanup_waiter(void *p1, void *p2, void *p3)
  * timer, call k_timer_cleanup() and verify it returns -EAGAIN, indicating the
  * cleanup could not be performed. Then stop the timer to release the waiter.
  *
- * @see k_timer_cleanup(), k_timer_status_sync()
+ * @see k_timer_cleanup()
+ * @see k_timer_status_sync()
  */
 ZTEST(timer_api, test_timer_cleanup_pending)
 {

--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -319,6 +319,16 @@ static const struct ztest_param_values conversion_vals = {
 	.name_cb = conversion_name,
 };
 
+/**
+ * @brief Test conversion between time units
+ *
+ * @details Exercise the kernel time-unit conversion routines over a large set
+ * of source/target frequencies, bit widths and rounding modes, converting
+ * values between milliseconds, microseconds, nanoseconds, system ticks and
+ * hardware cycles and verifying each result is within the rounding-mode bound.
+ *
+ * @ingroup kernel_timer_tests
+ */
 ZTEST_P(timer_api, test_time_conversions)
 {
 	const struct test_rec *t = ZTEST_GET_PARAM_PTR(struct test_rec);

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -302,7 +302,14 @@ ZTEST(work, test_null_queue)
 	zassert_equal(rc, -EINVAL);
 }
 
-/* Basic single-CPU check submitting with a non-blocking handler. */
+/**
+ * @brief Verify submitting a work item to a started queue runs its handler.
+ *
+ * @details
+ * Basic single-CPU check submitting with a non-blocking handler.
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_simple_queue)
 {
 	int rc;
@@ -410,7 +417,14 @@ ZTEST(work, test_smp_simple_queue)
 	zassert_equal(rc, 0);
 }
 
-/* Basic single-CPU check submitting with a blocking handler */
+/**
+ * @brief Verify flushing a work item blocks until its handler completes.
+ *
+ * @details
+ * Basic single-CPU check submitting with a blocking handler
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_sync_queue)
 {
 	int rc;
@@ -445,9 +459,15 @@ ZTEST(work_1cpu, test_1cpu_sync_queue)
 	zassert_equal(coophi_counter(), 1);
 }
 
-/* Verify that if a work item is submitted while it is being run by a
+/**
+ * @brief Verify a work item handler can resubmit the work item.
+ *
+ * @details
+ * Verify that if a work item is submitted while it is being run by a
  * queue thread it gets submitted to the queue it's running on, to
  * prevent reentrant invocation, at least on a single CPU.
+ *
+ * @ingroup kernel_workqueue_tests
  */
 ZTEST(work_1cpu, test_1cpu_reentrant_queue)
 {
@@ -524,7 +544,13 @@ ZTEST(work_1cpu, test_1cpu_queued_flush)
 	zassert_false(k_work_flush(&common_work1, &work_sync));
 }
 
-/* Single CPU submit a work item and wait for flush after it's started.
+/**
+ * @brief Verify flushing a running work item waits for it to finish.
+ *
+ * @details
+ * Single CPU submit a work item and wait for flush after it's started.
+ *
+ * @ingroup kernel_workqueue_tests
  */
 ZTEST(work_1cpu, test_1cpu_running_flush)
 {
@@ -588,8 +614,14 @@ ZTEST(work_1cpu, test_1cpu_delayed_flush)
 	zassert_equal(rc, 0);
 }
 
-/* Single CPU cancel before work item is unqueued should complete
+/**
+ * @brief Verify cancelling a work item that is still queued.
+ *
+ * @details
+ * Single CPU cancel before work item is unqueued should complete
  * immediately.
+ *
+ * @ingroup kernel_workqueue_tests
  */
 ZTEST(work_1cpu, test_1cpu_queued_cancel)
 {
@@ -611,7 +643,14 @@ ZTEST(work_1cpu, test_1cpu_queued_cancel)
 	zassert_equal(coophi_counter(), 0);
 }
 
-/* Single CPU cancel before work item is unqueued should not wait. */
+/**
+ * @brief Verify cancelling a queued work item and waiting for completion.
+ *
+ * @details
+ * Single CPU cancel before work item is unqueued should not wait.
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_queued_cancel_sync)
 {
 	int rc;
@@ -639,8 +678,14 @@ ZTEST(work_1cpu, test_1cpu_queued_cancel_sync)
 	zassert_equal(coophi_counter(), 0);
 }
 
-/* Single CPU cancel before scheduled work item is queued should
+/**
+ * @brief Verify cancelling a delayable work item before it expires.
+ *
+ * @details
+ * Single CPU cancel before scheduled work item is queued should
  * complete immediately.
+ *
+ * @ingroup kernel_workqueue_tests
  */
 ZTEST(work_1cpu, test_1cpu_delayed_cancel)
 {
@@ -742,7 +787,14 @@ static void test_running_cancel_cb(struct k_timer *timer)
 	handler_release();
 }
 
-/* Single CPU test cancellation after work starts. */
+/**
+ * @brief Verify cancelling a work item whose handler is running.
+ *
+ * @details
+ * Single CPU test cancellation after work starts.
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_running_cancel)
 {
 	struct test_running_cancel_timer *ctx = &test_running_cancel_ctx;
@@ -936,7 +988,14 @@ static void test_drain_wait_cb(struct k_timer *timer)
 	ctx->submit_rc = k_work_submit_to_queue(&coophi_queue, &ctx->work);
 }
 
-/* Single CPU submit an item and wait for it to drain. */
+/**
+ * @brief Verify draining a work queue waits for queued items to finish.
+ *
+ * @details
+ * Single CPU submit an item and wait for it to drain.
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_drain_wait)
 {
 	struct test_drain_wait_timer *ctx = &test_drain_wait_ctx;
@@ -980,7 +1039,14 @@ ZTEST(work_1cpu, test_1cpu_drain_wait)
 	zassert_equal(ctx->submit_rc, -EBUSY);
 }
 
-/* Single CPU submit item, drain with plug, test, then unplug. */
+/**
+ * @brief Verify submission is blocked while a queue is plugged for drain.
+ *
+ * @details
+ * Single CPU submit item, drain with plug, test, then unplug.
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_plugged_drain)
 {
 	int rc;
@@ -1037,7 +1103,14 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 	zassert_equal(coophi_counter(), 2);
 }
 
-/* Single CPU test delayed submission */
+/**
+ * @brief Verify scheduling a delayable work item runs it after the delay.
+ *
+ * @details
+ * Single CPU test delayed submission
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_basic_schedule)
 {
 	int rc;
@@ -1186,7 +1259,14 @@ ZTEST(work_1cpu, test_1cpu_immed_schedule)
 	zassert_equal(rc, 0);
 }
 
-/* Single CPU test that delayed work can be rescheduled. */
+/**
+ * @brief Verify rescheduling a delayable work item updates its delay.
+ *
+ * @details
+ * Single CPU test that delayed work can be rescheduled.
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_basic_reschedule)
 {
 	int rc;
@@ -1382,7 +1462,14 @@ ZTEST(work_1cpu, test_1cpu_queue_no_yield)
 	k_sem_init(&sync_sem, 0, 1);
 }
 
-/* Basic functionality with the system work queue. */
+/**
+ * @brief Verify submitting a work item to the system work queue.
+ *
+ * @details
+ * Basic functionality with the system work queue.
+ *
+ * @ingroup kernel_workqueue_tests
+ */
 ZTEST(work_1cpu, test_1cpu_system_queue)
 {
 	int rc;
@@ -1535,9 +1622,12 @@ static void order_handler(struct k_work *work)
 	}
 }
 
-/* Verify work items are processed in submission order. */
 /**
  * @brief Verify a work queue processes work items in submission order
+ *
+ * @details
+ * Verify work items are processed in submission order.
+ *
  * @ingroup kernel_workqueue_tests
  */
 ZTEST(work_1cpu, test_1cpu_queue_order)

--- a/tests/lib/multi_heap/src/test_mheap_api.c
+++ b/tests/lib/multi_heap/src/test_mheap_api.c
@@ -207,6 +207,17 @@ ZTEST(mheap_api, test_mheap_malloc_free)
 
 
 
+/**
+ * @brief Test to demonstrate k_realloc() API usage
+ *
+ * @ingroup k_heap_api_tests
+ *
+ * @details The test resizes blocks previously allocated from the system heap
+ * with k_realloc(), growing and shrinking allocations and verifying the
+ * contents are preserved and that allocation back to the system heap works.
+ *
+ * @see k_realloc()
+ */
 ZTEST(mheap_api, test_mheap_realloc)
 {
 	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
@@ -261,6 +272,17 @@ ZTEST(mheap_api, test_mheap_calloc)
 	k_free(mem);
 }
 
+/**
+ * @brief Test to demonstrate k_aligned_alloc() API usage
+ *
+ * @ingroup k_heap_api_tests
+ *
+ * @details The test allocates blocks from the system heap with k_aligned_alloc()
+ * using several alignment values and verifies each returned pointer satisfies
+ * the requested alignment before freeing it.
+ *
+ * @see k_aligned_alloc()
+ */
 ZTEST(mheap_api, test_k_aligned_alloc)
 {
 	void *r;
@@ -301,7 +323,9 @@ ZTEST(mheap_api, test_k_aligned_alloc)
  *
  * @ingroup k_heap_api_tests
  *
- * @see k_thread_system_pool_assign(), z_thread_malloc(), k_free()
+ * @see k_thread_system_pool_assign()
+ * @see z_thread_malloc()
+ * @see k_free()
  */
 ZTEST(mheap_api, test_sys_heap_mem_pool_assign)
 {
@@ -330,7 +354,8 @@ ZTEST(mheap_api, test_sys_heap_mem_pool_assign)
  *
  * @ingroup k_heap_api_tests
  *
- * @see z_thread_malloc(), k_free()
+ * @see z_thread_malloc()
+ * @see k_free()
  */
 ZTEST(mheap_api, test_malloc_in_isr)
 {


### PR DESCRIPTION
- **tests: kernel: semaphore: document test cases**
- **tests: kernel: threads: document test cases**
- **tests: kernel: timer, sys_timer: document test cases**
- **tests: kernel: mutex: document test cases**
- **tests: kernel: workq: document test cases**
- **tests: kernel: fpu_sharing: document test cases**
- **tests: kernel: mem_slab: document test cases**
- **tests: lib: multi_heap: document test cases**
- **tests: kernel: mem_protect: document test cases**
- **tests: arch: interrupt: document test cases**
- **tests: kernel: device, smp: document test cases**
- **tests: give test cases unique, namespaced names**
