### PR TITLE
soc: renesas: define DT_CHOSEN_Z_FLASH where it is used

### DIFF
--- a/soc/renesas/rz/rza2m/Kconfig.defconfig
+++ b/soc/renesas/rz/rza2m/Kconfig.defconfig
@@ -9,6 +9,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config NUM_IRQS
 	default 512
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rza3ul/Kconfig.defconfig
+++ b/soc/renesas/rz/rza3ul/Kconfig.defconfig
@@ -12,6 +12,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/osc,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzg2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzg2l/Kconfig.defconfig
@@ -9,6 +9,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzg2ul/Kconfig.defconfig
+++ b/soc/renesas/rz/rzg2ul/Kconfig.defconfig
@@ -9,6 +9,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzg3e/Kconfig.defconfig
+++ b/soc/renesas/rz/rzg3e/Kconfig.defconfig
@@ -9,6 +9,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzg3s/Kconfig.defconfig
+++ b/soc/renesas/rz/rzg3s/Kconfig.defconfig
@@ -10,6 +10,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzn2h/Kconfig.defconfig
+++ b/soc/renesas/rz/rzn2h/Kconfig.defconfig
@@ -12,6 +12,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzn2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzn2l/Kconfig.defconfig
@@ -12,6 +12,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzt2h/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2h/Kconfig.defconfig
@@ -12,6 +12,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzt2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2l/Kconfig.defconfig
@@ -12,6 +12,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzt2m/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2m/Kconfig.defconfig
@@ -13,6 +13,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cm33
+++ b/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cm33
@@ -9,6 +9,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cr8
+++ b/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cr8
@@ -12,6 +12,9 @@ config FPU
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(div,$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency),4)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzv2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzv2l/Kconfig.defconfig
@@ -9,6 +9,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/rz/rzv2n/Kconfig.defconfig
+++ b/soc/renesas/rz/rzv2n/Kconfig.defconfig
@@ -9,6 +9,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 

--- a/soc/renesas/smartbond/da1469x/Kconfig.defconfig
+++ b/soc/renesas/smartbond/da1469x/Kconfig.defconfig
@@ -25,6 +25,9 @@ config SYS_CLOCK_TICKS_PER_SEC
 config USE_DT_CODE_PARTITION
 	default y if MCUBOOT
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 


### PR DESCRIPTION
The Renesas RZ and Smartbond DA1469x Kconfig.defconfig files derive
FLASH_SIZE, FLASH_BASE_ADDRESS and BUILD_OUTPUT_ADJUST_LMA from
$(DT_CHOSEN_Z_FLASH), but never assign that preprocessor variable.

Kconfig.zephyr does assign it, at a point after the SoC Kconfig.defconfig
files have already been sourced, so these trees were picking up the
assignment from an unrelated vendor's tree that happened to be parsed
first, the way the ST, NXP and Realtek trees each assign it for
themselves.

Assign the variable in the files that use it, as the other SoC trees do.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
