### PR TITLE
cleanup: remove my email from copyright notices

### DIFF
--- a/boards/adafruit/feather_esp32c6/adafruit_feather_esp32c6_connector.dtsi
+++ b/boards/adafruit/feather_esp32c6/adafruit_feather_esp32c6_connector.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Richard Osterloh <richard.osterloh@gmail.com>
  * Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  * Copyright (c) 2026 Hong Nguyen <hong.nguyen.k54@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/boards/adafruit/feather_esp32c6/adafruit_feather_esp32c6_hpcore.dts
+++ b/boards/adafruit/feather_esp32c6/adafruit_feather_esp32c6_hpcore.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  * Copyright (c) 2026 Hong Nguyen <hong.nguyen.k54@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/boards/adafruit/feather_esp32s2/Kconfig.adafruit_feather_esp32s2
+++ b/boards/adafruit/feather_esp32s2/Kconfig.adafruit_feather_esp32s2
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ADAFRUIT_FEATHER_ESP32S2

--- a/boards/adafruit/feather_esp32s2/Kconfig.adafruit_feather_esp32s2_tft
+++ b/boards/adafruit/feather_esp32s2/Kconfig.adafruit_feather_esp32s2_tft
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ADAFRUIT_FEATHER_ESP32S2_TFT

--- a/boards/adafruit/feather_esp32s2/Kconfig.adafruit_feather_esp32s2_tft_reverse
+++ b/boards/adafruit/feather_esp32s2/Kconfig.adafruit_feather_esp32s2_tft_reverse
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ADAFRUIT_FEATHER_ESP32S2_TFT_REVERSE

--- a/boards/adafruit/feather_esp32s2/Kconfig.defconfig
+++ b/boards/adafruit/feather_esp32s2/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_ADAFRUIT_FEATHER_ESP32S2_TFT || BOARD_ADAFRUIT_FEATHER_ESP32S2_TFT_REVERSE

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>.
+ * Copyright (c) 2025 Philipp Steiner.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2.dts
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_B.overlay
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_B.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_C.overlay
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_C.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_common.dtsi
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_tft.dts
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_tft.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_tft_reverse.dts
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_tft_reverse.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/board.c
+++ b/boards/adafruit/feather_esp32s2/board.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/boards/adafruit/feather_esp32s2/feather_connector.dtsi
+++ b/boards/adafruit/feather_esp32s2/feather_connector.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Richard Osterloh <richard.osterloh@gmail.com>
  * Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s2/feather_connector_tft.dtsi
+++ b/boards/adafruit/feather_esp32s2/feather_connector_tft.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Richard Osterloh <richard.osterloh@gmail.com>
  * Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
 # Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 config HEAP_MEM_POOL_ADD_SIZE_BOARD

--- a/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.adafruit_feather_esp32s3_tft_reverse
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.adafruit_feather_esp32s3_tft_reverse
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
 # Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ADAFRUIT_FEATHER_ESP32S3_TFT_REVERSE

--- a/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.defconfig
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.defconfig
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_ADAFRUIT_FEATHER_ESP32S3_TFT_REVERSE_ESP32S3_PROCPU

--- a/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse-pinctrl.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse_appcpu.dts
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse_appcpu.dts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/adafruit/feather_esp32s3_tft_reverse/feather_connector.dtsi
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/feather_connector.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Richard Osterloh <richard.osterloh@gmail.com>
  * Copyright (c) 2024 Leon Rinkel <leon@rinkel.me>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/drivers/fuel_gauge/lc709203f/Kconfig
+++ b/drivers/fuel_gauge/lc709203f/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/drivers/fuel_gauge/lc709203f/emul_lc709203f.c
+++ b/drivers/fuel_gauge/lc709203f/emul_lc709203f.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/drivers/fuel_gauge/lc709203f/lc709203f.c
+++ b/drivers/fuel_gauge/lc709203f/lc709203f.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/drivers/fuel_gauge/lc709203f/lc709203f.h
+++ b/drivers/fuel_gauge/lc709203f/lc709203f.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/bindings/fuel-gauge/onnn,lc709203f.yaml
+++ b/dts/bindings/fuel-gauge/onnn,lc709203f.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2025 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 description: |

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -1,7 +1,7 @@
 /*
  * Copyright 2022 Google LLC
  * Copyright 2023 Microsoft Corporation
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * Copyright (c) 2026 Analog Devices Inc.
  *

--- a/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_B.overlay
+++ b/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_B.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_C.overlay
+++ b/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_C.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_tft.overlay
+++ b/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_tft.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_tft_reverse.overlay
+++ b/samples/drivers/fuel_gauge/boards/adafruit_feather_esp32s2_tft_reverse.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/drivers/fuel_gauge/src/main.c
+++ b/samples/drivers/fuel_gauge/src/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023 Alvaro Garcia Gomez <maxpowel@gmail.com>
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * Copyright (c) 2026 Analog Devices Inc.
  *

--- a/samples/net/ptp/src/main.c
+++ b/samples/net/ptp/src/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/ptp/Kconfig
+++ b/subsys/net/lib/ptp/Kconfig
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 BayLibre
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PTP

--- a/subsys/net/lib/ptp/btca.c
+++ b/subsys/net/lib/ptp/btca.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/ptp/clock.h
+++ b/subsys/net/lib/ptp/clock.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/ptp/msg.h
+++ b/subsys/net/lib/ptp/msg.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/ptp/port.h
+++ b/subsys/net/lib/ptp/port.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/ptp/transport.c
+++ b/subsys/net/lib/ptp/transport.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 BayLibre SAS
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/shell/ptp.c
+++ b/subsys/net/lib/shell/ptp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Intel Corporation
  * Copyright (c) 2021 Nordic Semiconductor
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/drivers/fuel_gauge/lc709203f/src/test_lc709203f.c
+++ b/tests/drivers/fuel_gauge/lc709203f/src/test_lc709203f.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2025 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/Kconfig.unit
+++ b/tests/net/ptp/Kconfig.unit
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 # These white-box unit tests compile selected PTP implementation files

--- a/tests/net/ptp/btca_state_machine/Kconfig
+++ b/tests/net/ptp/btca_state_machine/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/btca_state_machine/src/main.c
+++ b/tests/net/ptp/btca_state_machine/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/clock_decision/Kconfig
+++ b/tests/net/ptp/clock_decision/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/clock_decision/src/main.c
+++ b/tests/net/ptp/clock_decision/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/clock_wakeup/Kconfig
+++ b/tests/net/ptp/clock_wakeup/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/clock_wakeup/src/main.c
+++ b/tests/net/ptp/clock_wakeup/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/foreign_master/Kconfig
+++ b/tests/net/ptp/foreign_master/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/foreign_master/src/main.c
+++ b/tests/net/ptp/foreign_master/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/msg_parse/src/main.c
+++ b/tests/net/ptp/msg_parse/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/msg_post_recv/Kconfig
+++ b/tests/net/ptp/msg_post_recv/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/msg_post_recv/src/main.c
+++ b/tests/net/ptp/msg_post_recv/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/port_events/Kconfig
+++ b/tests/net/ptp/port_events/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/port_events/src/main.c
+++ b/tests/net/ptp/port_events/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/state_matrix/Kconfig
+++ b/tests/net/ptp/state_matrix/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/state_matrix/src/main.c
+++ b/tests/net/ptp/state_matrix/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/net/ptp/transport_retry/Kconfig
+++ b/tests/net/ptp/transport_retry/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+# Copyright (c) 2026 Philipp Steiner
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "../Kconfig.unit"

--- a/tests/net/ptp/transport_retry/src/main.c
+++ b/tests/net/ptp/transport_retry/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) 2026 Philipp Steiner
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Remove my email address from copyright notices across board, fuel-gauge, networking, sample, and test files

As reference: https://github.com/zephyrproject-rtos/zephyr/pull/115363#discussion_r3735282110