### PR TITLE
drivers: pcie: improve Doxygen coverage

### DIFF
--- a/include/zephyr/drivers/pcie/controller.h
+++ b/include/zephyr/drivers/pcie/controller.h
@@ -2,6 +2,7 @@
  * @file
  *
  * @brief Public APIs for the PCIe Controllers drivers.
+ * @ingroup pcie_controller_interface
  */
 
 /*

--- a/include/zephyr/drivers/pcie/controller.h
+++ b/include/zephyr/drivers/pcie/controller.h
@@ -344,27 +344,33 @@ struct pcie_ctrl_config {
 	 */
 	const struct device *msi_parent;
 #endif
-	/* Configuration space physical address */
+	/** Configuration space physical address */
 	uintptr_t cfg_addr;
-	/* Configuration space physical size */
+	/** Configuration space physical size */
 	size_t cfg_size;
-	/* BAR regions translation ranges count */
+	/** BAR regions translation ranges count */
 	size_t ranges_count;
-	/* BAR regions translation ranges table */
+	/** BAR regions translation ranges table */
 	struct {
-		/* Flags as defined in the PCI Bus Binding to IEEE Std 1275-1994 */
+		/** Flags as defined in the PCI Bus Binding to IEEE Std 1275-1994 */
 		uint32_t flags;
-		/* bus-centric offset from the start of the region */
+		/** bus-centric offset from the start of the region */
 		uintptr_t pcie_bus_addr;
-		/* CPU-centric offset from the start of the region */
+		/** CPU-centric offset from the start of the region */
 		uintptr_t host_map_addr;
-		/* region size */
+		/** region size */
 		size_t map_length;
 	} ranges[];
 };
 
-/*
- * Fills the pcie_ctrl_config.ranges table from DT
+/**
+ * @brief Fill a pcie_ctrl_config.ranges table entry from devicetree
+ *
+ * Intended to be used with DT_FOREACH_RANGE to fill the whole table from the
+ * controller's ranges property.
+ *
+ * @param node_id PCIe controller devicetree node identifier
+ * @param idx Index of the entry in the ranges property
  */
 #define PCIE_RANGE_FORMAT(node_id, idx)							\
 {											\

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
@@ -2,6 +2,7 @@
  * @file
  *
  * @brief Public APIs for the PCIe EP drivers.
+ * @ingroup pcie_interface
  */
 
 /*

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
@@ -19,28 +19,32 @@
 #include <zephyr/kernel.h>
 #include <stdint.h>
 
+/** @brief PCIe outbound memory address range type */
 enum pcie_ob_mem_type {
 	PCIE_OB_ANYMEM,  /**< PCIe OB window within any address range */
 	PCIE_OB_LOWMEM,  /**< PCIe OB window within 32-bit address range */
 	PCIE_OB_HIGHMEM, /**< PCIe OB window above 32-bit address range */
 };
 
+/** @brief Type of interrupt raised to the Host */
 enum pci_ep_irq_type {
 	PCIE_EP_IRQ_LEGACY,	/**< Raise Legacy interrupt */
 	PCIE_EP_IRQ_MSI,	/**< Raise MSI interrupt */
 	PCIE_EP_IRQ_MSIX,	/**< Raise MSIX interrupt */
 };
 
+/** @brief Direction of data transfer between Host and endpoint device */
 enum xfer_direction {
 	HOST_TO_DEVICE,		/**< Read from Host */
 	DEVICE_TO_HOST,		/**< Write to Host */
 };
 
+/** @brief PCIe reset interrupt type */
 enum pcie_reset {
 	PCIE_PERST,	/**< Cold reset */
 	PCIE_PERST_INB,	/**< Inband hot reset */
 	PCIE_FLR,	/**< Functional Level Reset */
-	PCIE_RESET_MAX
+	PCIE_RESET_MAX	/**< Number of PCIe reset types */
 };
 
 /**
@@ -56,25 +60,84 @@ enum pcie_reset {
 
 typedef void (*pcie_ep_reset_callback_t)(void *arg);
 
+/**
+ * @def_driverbackendgroup{PCIe Endpoint,pcie_interface}
+ * @{
+ */
+
+/**
+ * @brief Type definition of PCIe EP API function for reading the configuration space.
+ * See pcie_ep_conf_read() for argument descriptions.
+ */
+typedef int (*pcie_ep_api_conf_read)(const struct device *dev, uint32_t offset,
+				     uint32_t *data);
+
+/**
+ * @brief Type definition of PCIe EP API function for writing the configuration space.
+ * See pcie_ep_conf_write() for argument descriptions.
+ */
+typedef void (*pcie_ep_api_conf_write)(const struct device *dev, uint32_t offset,
+				       uint32_t data);
+
+/**
+ * @brief Type definition of PCIe EP API function for mapping a Host address.
+ * See pcie_ep_map_addr() for argument descriptions.
+ */
+typedef int (*pcie_ep_api_map_addr)(const struct device *dev, uint64_t pcie_addr,
+				    uint64_t *mapped_addr, uint32_t size,
+				    enum pcie_ob_mem_type ob_mem_type);
+
+/**
+ * @brief Type definition of PCIe EP API function for unmapping a Host address.
+ * See pcie_ep_unmap_addr() for argument descriptions.
+ */
+typedef void (*pcie_ep_api_unmap_addr)(const struct device *dev, uint64_t mapped_addr);
+
+/**
+ * @brief Type definition of PCIe EP API function for raising an interrupt to the Host.
+ * See pcie_ep_raise_irq() for argument descriptions.
+ */
+typedef int (*pcie_ep_api_raise_irq)(const struct device *dev,
+				     enum pci_ep_irq_type irq_type,
+				     uint32_t irq_num);
+
+/**
+ * @brief Type definition of PCIe EP API function for registering a reset callback.
+ * See pcie_ep_register_reset_cb() for argument descriptions.
+ */
+typedef int (*pcie_ep_api_register_reset_cb)(const struct device *dev,
+					     enum pcie_reset reset,
+					     pcie_ep_reset_callback_t cb, void *arg);
+
+/**
+ * @brief Type definition of PCIe EP API function for data transfer using the system DMA.
+ * See pcie_ep_dma_xfer() for argument descriptions.
+ */
+typedef int (*pcie_ep_api_dma_xfer)(const struct device *dev, uint64_t mapped_addr,
+				    uintptr_t local_addr, uint32_t size,
+				    enum xfer_direction dir);
+
+/**
+ * @driver_ops{PCIe Endpoint}
+ */
 __subsystem struct pcie_ep_driver_api {
-	int (*conf_read)(const struct device *dev, uint32_t offset,
-			 uint32_t *data);
-	void (*conf_write)(const struct device *dev, uint32_t offset,
-			   uint32_t data);
-	int (*map_addr)(const struct device *dev, uint64_t pcie_addr,
-			uint64_t *mapped_addr, uint32_t size,
-			enum pcie_ob_mem_type ob_mem_type);
-	void (*unmap_addr)(const struct device *dev, uint64_t mapped_addr);
-	int (*raise_irq)(const struct device *dev,
-			 enum pci_ep_irq_type irq_type,
-			 uint32_t irq_num);
-	int (*register_reset_cb)(const struct device *dev,
-				 enum pcie_reset reset,
-				 pcie_ep_reset_callback_t cb, void *arg);
-	int (*dma_xfer)(const struct device *dev, uint64_t mapped_addr,
-			uintptr_t local_addr, uint32_t size,
-			enum xfer_direction dir);
+	/** @driver_ops_mandatory @copybrief pcie_ep_conf_read */
+	pcie_ep_api_conf_read conf_read;
+	/** @driver_ops_mandatory @copybrief pcie_ep_conf_write */
+	pcie_ep_api_conf_write conf_write;
+	/** @driver_ops_mandatory @copybrief pcie_ep_map_addr */
+	pcie_ep_api_map_addr map_addr;
+	/** @driver_ops_mandatory @copybrief pcie_ep_unmap_addr */
+	pcie_ep_api_unmap_addr unmap_addr;
+	/** @driver_ops_mandatory @copybrief pcie_ep_raise_irq */
+	pcie_ep_api_raise_irq raise_irq;
+	/** @driver_ops_optional @copybrief pcie_ep_register_reset_cb */
+	pcie_ep_api_register_reset_cb register_reset_cb;
+	/** @driver_ops_optional @copybrief pcie_ep_dma_xfer */
+	pcie_ep_api_dma_xfer dma_xfer;
 };
+
+/** @} */
 
 /**
  * @brief Read PCIe EP configuration space

--- a/include/zephyr/drivers/pcie/msi.h
+++ b/include/zephyr/drivers/pcie/msi.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the PCIe MSI and MSI-X support APIs.
+ * @ingroup pcie_host_msi_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_MSI_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PCIE_MSI_H_
 

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the PCIe driver APIs.
+ * @ingroup pcie_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_PCIE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PCIE_PCIE_H_
 

--- a/include/zephyr/drivers/pcie/vc.h
+++ b/include/zephyr/drivers/pcie/vc.h
@@ -30,27 +30,28 @@ extern "C" {
 
 #include <zephyr/drivers/pcie/pcie.h>
 
-/*
- * 1 default VC + 7 extended VCs
+/**
+ * Maximum number of Virtual Channels: 1 default VC + 7 extended VCs
  */
 #define PCIE_VC_MAX_COUNT 8U
 
-#define PCIE_VC_SET_TC0 BIT(0)
-#define PCIE_VC_SET_TC1 BIT(1)
-#define PCIE_VC_SET_TC2 BIT(2)
-#define PCIE_VC_SET_TC3 BIT(3)
-#define PCIE_VC_SET_TC4 BIT(4)
-#define PCIE_VC_SET_TC5 BIT(5)
-#define PCIE_VC_SET_TC6 BIT(6)
-#define PCIE_VC_SET_TC7 BIT(7)
+#define PCIE_VC_SET_TC0 BIT(0) /**< Map Traffic Class 0 to a VC */
+#define PCIE_VC_SET_TC1 BIT(1) /**< Map Traffic Class 1 to a VC */
+#define PCIE_VC_SET_TC2 BIT(2) /**< Map Traffic Class 2 to a VC */
+#define PCIE_VC_SET_TC3 BIT(3) /**< Map Traffic Class 3 to a VC */
+#define PCIE_VC_SET_TC4 BIT(4) /**< Map Traffic Class 4 to a VC */
+#define PCIE_VC_SET_TC5 BIT(5) /**< Map Traffic Class 5 to a VC */
+#define PCIE_VC_SET_TC6 BIT(6) /**< Map Traffic Class 6 to a VC */
+#define PCIE_VC_SET_TC7 BIT(7) /**< Map Traffic Class 7 to a VC */
 
+/** @brief Traffic Class (TC) to Virtual Channel (VC) map */
 struct pcie_vctc_map {
-	/*
+	/**
 	 * Map the TCs for each VC by setting bits relevantly
 	 * Note: one bit cannot be set more than once among the VCs
 	 */
 	uint8_t vc_tc[PCIE_VC_MAX_COUNT];
-	/*
+	/**
 	 * Number of VCs being addressed
 	 */
 	int vc_count;

--- a/include/zephyr/drivers/pcie/vc.h
+++ b/include/zephyr/drivers/pcie/vc.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the PCIe Virtual Channel support APIs.
+ * @ingroup pcie_vc_host_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_VC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PCIE_VC_H_
 


### PR DESCRIPTION
Add the missing `@file` blocks to the PCIe headers and attach them to
their Doxygen groups.

Adopt the driver backend API Doxygen convention for the PCIe endpoint
driver API: place the operations in a "Driver Backend API" subgroup,
define a typedef for each operation, and annotate the operations
structure with `@driver_ops`.

Document the PCIe controller configuration structure, the range table
helper macro, and the Traffic Class to Virtual Channel mapping.

No functional change.