### PR TITLE
2 DTS regressions in CI

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -1295,14 +1295,6 @@
 		};
 	};
 
-	inputmux0: inputmux@6000 {
-		compatible = "nxp,inputmux";
-		reg = <0x6000 0x1000>;
-		status = "disabled";
-		#mux-control-cells = <1>;
-		#mux-state-cells = <2>;
-	};
-
 	qdc0: qdc@cf000 {
 		compatible = "nxp,mcux-qdc";
 		reg = <0xcf000 0x1000>;

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -199,6 +199,8 @@
 			vtf_region_default: memory@fdfe0 {
 				compatible = "zephyr,memory-region", "mmio-sram";
 				reg = <0xfdfe0 0x20>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				ranges = <0x0 0xfdfe0 0x20>;
 				zephyr,memory-region = "NRF_VTF_REGION";
 			};


### PR DESCRIPTION
- **dts: arm: nxp: mcxn23x: remove duplicate inputmux node**
- **dts: nordic: nrf7120: fix cell sizes of vtf_region_default node**
