### PR TITLE
tests: bsim: use 'application' in required_applications

### DIFF
--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/tests.yaml
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/tests.yaml
@@ -18,5 +18,5 @@ tests:
     extra_args:
       CONF_FILE=prj_llcp.conf
     required_applications:
-      - name: bluetooth.ll.edtt.hci_test_app.dut
+      - application: bluetooth.ll.edtt.hci_test_app.dut
         path: ../hci_test_app

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/tests.yaml
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/tests.yaml
@@ -28,4 +28,4 @@ tests:
     extra_args:
       CONF_FILE=prj_tst_llcp.conf
     required_applications:
-      - name: bluetooth.ll.edtt.hci_test_app.dut
+      - application: bluetooth.ll.edtt.hci_test_app.dut


### PR DESCRIPTION
The 'name' field of required_applications is deprecated in favour of
'application', and these two scenarios are the last in-tree users.
Every twister invocation that parses them logs a deprecation warning,
which shows up as two counted warnings in each CI twister-build shard.

Rename the field; behaviour is unchanged since twister maps 'name'
onto 'application' internally.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
