### PR TITLE
tests: fs: lib_link: give the suite a real test case

### DIFF
--- a/tests/subsys/fs/lib_link/src/main.c
+++ b/tests/subsys/fs/lib_link/src/main.c
@@ -4,7 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <string.h>
 #include <zephyr/ztest.h>
 
+#include <ff.h>
+#include <lfs.h>
+
 ZTEST_SUITE(lib_link, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST(lib_link, test_fs_libraries_linked)
+{
+	/*
+	 * The primary assertion of this test is the build itself: with only
+	 * CONFIG_FILE_SYSTEM_LIB_LINK enabled (no CONFIG_FILE_SYSTEM), the
+	 * underlying file system libraries must compile and link. Referencing
+	 * an API symbol from the libraries meant for direct application use
+	 * additionally forces the linker to resolve them, so the libraries
+	 * cannot be silently garbage-collected out of the image.
+	 */
+	zassert_not_null(f_mount, "FAT library not linked");
+	zassert_not_null(lfs_mount, "littlefs library not linked");
+}


### PR DESCRIPTION
The lib_link suite was registered with ZTEST_SUITE() but contained no
ZTEST() cases: the intended assertion was the build itself (the FS
libraries must compile and link with only CONFIG_FILE_SYSTEM_LIB_LINK
enabled). An empty ztest suite leaves twister's synthetic scenario
test case without any status, so every platform this scenario runs on
reports "A None status detected in instance ..." - 35 counted
warnings per CI twister-build run.

Add a test case that takes the address of an API symbol from the
libraries meant for direct application use (FAT's f_mount, littlefs'
lfs_mount). This gives the suite a real, reportable test case and
also strengthens the link-time claim: the linker now has to resolve
symbols from the libraries instead of potentially garbage-collecting
all of their objects out of the image.

Assisted-by: Claude:claude-fable-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
