### PR TITLE
twister: sidecars: check host readiness at test-plan time

### DIFF
--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -1233,9 +1233,13 @@ A sidecar has a small lifecycle, driven by Twister for each test instance:
 
 #. **configure** -- the sidecar reads what it needs from the instance and its
    ``sidecar_config`` block before anything is provisioned.
+#. **host check** -- at test-plan time the sidecar reports whether the host
+   provides what it needs (for example, that a required daemon binary is
+   installed). When it does not, the test is *built only* and not executed,
+   exactly like a platform whose simulator is not installed.
 #. **setup** -- called just before the handler runs the test image; it brings
    the host resource up (starts a daemon, creates an interface, ...). If the
-   host side is unavailable -- a required tool is not installed, or bringing the
+   host side still turns out to be unavailable -- for example bringing the
    resource up needs privileges that are not present -- setup reports this and
    Twister *skips* execution instead of failing the test.
 #. **teardown** -- called after the handler returns, in a ``finally`` block, so

--- a/scripts/pylib/twister/twisterlib/sidecars/base.py
+++ b/scripts/pylib/twister/twisterlib/sidecars/base.py
@@ -103,6 +103,16 @@ class Sidecar:
         }
         return {'type': 'object', 'properties': properties, 'additionalProperties': False}
 
+    def host_ready(self) -> bool:
+        """Whether the host provides what this sidecar needs to run.
+
+        Called on a configured sidecar at test-plan time. Returning False
+        demotes the instance to build-only, the same way a missing simulator
+        executable does, instead of discovering the gap at run time. The
+        default assumes no special host requirements.
+        """
+        return True
+
     def cmake_env(self, build_dir: str) -> dict[str, str]:
         """Environment overrides for the CMake configure step.
 

--- a/scripts/pylib/twister/twisterlib/sidecars/virtiofs.py
+++ b/scripts/pylib/twister/twisterlib/sidecars/virtiofs.py
@@ -96,6 +96,10 @@ class VirtiofsSidecar(Sidecar):
         self._virtiofsd_proc = None
         self._virtiofsd_log = None
 
+    def host_ready(self) -> bool:
+        """The test cannot run without a virtiofsd binary on the host."""
+        return self.virtiofsd_bin is not None
+
     def cmake_env(self, build_dir: str) -> dict[str, str]:
         # The static vhost-user-fs device lives in the test's
         # CONFIG_QEMU_EXTRA_FLAGS; inject only the dynamic -chardev socket path

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -301,6 +301,21 @@ class TestInstance(StatusMixin):
                 not simulator.is_runnable():
             target_ready = False
 
+        # A sidecar provisions host-side resources around the run; when the
+        # host lacks what it needs (for example no virtiofsd binary), build
+        # the test but do not try to run it, like a missing simulator.
+        if target_ready and self.sidecar:
+            from twisterlib.sidecars import SidecarImporter
+            try:
+                sidecar = SidecarImporter.get_sidecar(self.sidecar)
+            except ValueError:
+                # Unknown sidecar names are reported at the run stage.
+                sidecar = None
+            if sidecar is not None:
+                sidecar.configure(self)
+                if not sidecar.host_ready():
+                    target_ready = False
+
         if testsuite_runnable := self.testsuite.harness in SUPPORTED_HARNESSES:
             if device_testing:
                 testsuite_runnable = HardwareReservationManager(

--- a/scripts/tests/twister/test_sidecar.py
+++ b/scripts/tests/twister/test_sidecar.py
@@ -115,6 +115,18 @@ def test_virtiofs_configure_defaults_without_config(tmp_path):
     assert sidecar.virtiofs_extra_args == []
 
 
+def test_virtiofs_host_ready_requires_virtiofsd(tmp_path):
+    instance = _make_instance(tmp_path)
+    sidecar = VirtiofsSidecar()
+    with mock.patch.object(VirtiofsSidecar, "find_virtiofsd", return_value=None):
+        sidecar.configure(instance)
+    assert sidecar.host_ready() is False
+
+    with mock.patch.object(VirtiofsSidecar, "find_virtiofsd", return_value="/found"):
+        sidecar.configure(instance)
+    assert sidecar.host_ready() is True
+
+
 def test_virtiofs_config_schema_matches_dataclass():
     assert VirtiofsSidecar.config_schema() == {
         'type': 'object',

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -17,6 +17,7 @@ from twisterlib.error import BuildError
 from twisterlib.handlers import QEMUHandler
 from twisterlib.platform import Simulator
 from twisterlib.runner import TwisterRunner
+from twisterlib.sidecars.virtiofs import VirtiofsSidecar
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 
@@ -89,6 +90,38 @@ def test_check_build_or_run(
          mock.patch('os.path.exists', return_value=False):
         run = testinstance.check_runnable(env.options, env.hwm)
         assert not run
+
+def test_check_runnable_sidecar_host(class_testplan, all_testsuites_dict, platforms_list):
+    """A sidecar whose host requirements are not met demotes the instance to build-only."""
+    class_testplan.testsuites = all_testsuites_dict
+    testsuite = class_testplan.testsuites.get('test_a.check_1')
+    class_testplan.platforms = platforms_list
+    platform = class_testplan.get_platform("demo_board_2")
+    platform.type = 'sim'
+    platform.simulators = [Simulator({"name": "qemu"})]
+    testsuite.harness = 'ztest'
+    testsuite.build_only = False
+    testsuite.slow = False
+    testsuite.sidecar = 'virtiofs'
+
+    testinstance = TestInstance(testsuite, platform, 'zephyr', class_testplan.env.outdir)
+    env = mock.Mock(
+        options=mock.Mock(
+            device_testing=False,
+            enable_slow=False,
+            fixtures=[],
+            filter="",
+            sim_name="qemu"
+        ),
+        hwm=mock.Mock(duts=[])
+    )
+
+    with mock.patch.object(VirtiofsSidecar, 'find_virtiofsd', return_value=None):
+        assert not testinstance.check_runnable(env.options, env.hwm)
+
+    with mock.patch.object(VirtiofsSidecar, 'find_virtiofsd', return_value='/found'):
+        assert testinstance.check_runnable(env.options, env.hwm)
+
 
 TESTDATA_PART_2 = [
     (True, True, True, ["demo_board_2/unit_testing"], "native",


### PR DESCRIPTION
A sidecar could only discover a missing host tool in setup(), just
before executing the test image. The virtiofs sidecar then skipped
the instance at run time and logged a warning on every host without
a virtiofsd binary, which is noise on CI runners where the daemon is
simply not installed.

Introduce Sidecar.host_ready(), consulted from check_runnable() on a
configured sidecar at test-plan time. When the host lacks what the
sidecar needs, the instance is demoted to build-only, exactly like a
platform whose simulator executable is not installed, instead of the
gap surfacing as a late skip plus a warning. The virtiofs sidecar
implements the hook by checking that a virtiofsd binary was resolved;
the setup() guard remains as a safety net for forced runs.

Document the new lifecycle step and add unit tests for host_ready()
and for its wiring in check_runnable().

Assisted-by: Claude:claude-fable-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
