### PR TITLE
drivers: ethernet: improve Doxygen coverage

### DIFF
--- a/include/zephyr/drivers/ethernet/eth_adin2111.h
+++ b/include/zephyr/drivers/ethernet/eth_adin2111.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for the ADIN2111 Ethernet controller driver APIs.
+ * @ingroup ethernet
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ETH_ADIN2111_H__
 #define ZEPHYR_INCLUDE_DRIVERS_ETH_ADIN2111_H__
 

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for NXP ENET Ethernet driver internal definitions.
+ * @ingroup ethernet
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ETH_NXP_ENET_H__
 #define ZEPHYR_INCLUDE_DRIVERS_ETH_NXP_ENET_H__
 

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 /*
  * Reasons for callback to a driver:
  *
@@ -80,6 +82,8 @@ extern void nxp_enet_driver_cb(const struct device *dev,
 				enum nxp_enet_driver dev_type,
 				enum nxp_enet_callback_reason event,
 				void *data);
+
+/** INTERNAL_HIDDEN @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet_qos.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet_qos.h
@@ -16,6 +16,8 @@
 #include <fsl_device_registers.h>
 #include <zephyr/drivers/clock_control.h>
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Different platforms named the peripheral different in the register definitions */
 #if defined(CONFIG_SOC_FAMILY_MCXN) || defined(CONFIG_SOC_FAMILY_MCXA)
 #undef ENET
@@ -56,5 +58,7 @@ struct nxp_enet_qos_config {
 	enet_qos_t *base;
 };
 #define ENET_QOS_MODULE_CFG(module_dev) ((struct nxp_enet_qos_config *) module_dev->config)
+
+/** INTERNAL_HIDDEN @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ETH_NXP_ENET_H__ */

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet_qos.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet_qos.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for NXP ENET QOS Ethernet driver internal definitions.
+ * @ingroup ethernet
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ETH_NXP_ENET_QOS_H__
 #define ZEPHYR_INCLUDE_DRIVERS_ETH_NXP_ENET_QOS_H__
 


### PR DESCRIPTION
Add the missing `@file` blocks to the Ethernet driver headers and attach
them to the Ethernet Doxygen group.

The NXP ENET and ENET QOS headers hold definitions shared between
cooperating drivers, so their contents are placed behind
`@cond INTERNAL_HIDDEN` and kept out of the generated documentation.

Documentation only, no functional change.