### PR TITLE
soc: espressif: refresh flash timing after psram tuning

### DIFF
--- a/soc/espressif/common/esp_psram.c
+++ b/soc/espressif/common/esp_psram.c
@@ -10,6 +10,11 @@
 #include <esp_private/esp_psram_extram.h>
 #include <hal/cache_hal.h>
 #include <zephyr/multi_heap/shared_multi_heap.h>
+#if defined(CONFIG_ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING)
+#include <esp_flash.h>
+#include <esp_private/spi_flash_os.h>
+#include <hal/spi_flash_hal.h>
+#endif
 
 extern int _instruction_reserved_start;
 extern int _instruction_reserved_end;
@@ -31,6 +36,34 @@ int esp_psram_smh_init(void)
 	return shared_multi_heap_add(&smh_psram, NULL);
 }
 
+#if defined(CONFIG_ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING)
+/*
+ * PSRAM timing tuning reprograms the MSPI core clock, which is shared
+ * between flash and PSRAM. The esp_flash driver latched the flash
+ * timing into its HAL context back in esp_flash_config(), so those
+ * cached values are stale once tuning has run and SPI1 accesses
+ * (erase, write) fail. Re-read the timing the tuning code settled on.
+ */
+static void esp_psram_refresh_flash_timing(void)
+{
+	spi_flash_hal_context_t *host;
+	spi_flash_hal_timing_config_t timing = {0};
+
+	if (!spi_flash_timing_is_tuned() || esp_flash_default_chip == NULL) {
+		return;
+	}
+
+	host = (spi_flash_hal_context_t *)esp_flash_default_chip->host;
+
+	spi_timing_get_flash_timing_param(&timing);
+
+	host->clock_conf = timing.clock_config;
+	host->extra_dummy = timing.extra_dummy;
+	host->cs_setup = timing.cs_setup;
+	host->cs_hold = timing.cs_hold;
+}
+#endif
+
 void esp_init_psram(void)
 {
 	intptr_t mapped_vaddr = 0;
@@ -49,6 +82,10 @@ void esp_init_psram(void)
 		ets_printf("Failed to Initialize external RAM, aborting.\n");
 		return;
 	}
+
+#if defined(CONFIG_ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING)
+	esp_psram_refresh_flash_timing();
+#endif
 
 #if !defined(CONFIG_SOC_SERIES_ESP32)
 	cache_hal_invalidate_addr((uint32_t)&_instruction_reserved_start,

--- a/soc/espressif/esp32c5/Kconfig.caps
+++ b/soc/espressif/esp32c5/Kconfig.caps
@@ -5,6 +5,10 @@ config ESP32_SOC_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
+config ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING
+	bool
+	default y
+
 config ESP32_SOC_PM_SUPPORT_TOP_PD
 	bool
 	default y

--- a/soc/espressif/esp32p4/Kconfig.caps
+++ b/soc/espressif/esp32p4/Kconfig.caps
@@ -20,3 +20,7 @@ config ESP32_SOC_PM_CPU_RETENTION_BY_SW
 config ESP32_SOC_ETM_SUPPORTED
 	bool
 	default y
+
+config ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING
+	bool
+	default y

--- a/soc/espressif/esp32s3/Kconfig.caps
+++ b/soc/espressif/esp32s3/Kconfig.caps
@@ -12,3 +12,7 @@ config ESP32_SOC_FLASH_SUPPORTED
 config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
+
+config ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING
+	bool
+	default y


### PR DESCRIPTION
PSRAM timing tuning reprograms the MSPI core clock, which is shared between flash and PSRAM. The esp_flash driver had already cached the flash timing in its HAL context during
esp_flash_config(), so the stale values made SPI1 erase and write operations fail once tuning ran.

Re-read the timing settled on by the tuning code after PSRAM chip init. This restores flash access on ESP32-S3 with octal PSRAM at 80 MHz.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/115662