### PR TITLE
boards: blues: Add USB support to Cygnet board

### DIFF
--- a/boards/blues/cygnet/cygnet.dts
+++ b/boards/blues/cygnet/cygnet.dts
@@ -68,6 +68,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &pll {
 	div-m = <1>;
 	mul-n = <20>;
@@ -134,6 +138,12 @@
 &rtc {
 	clocks = <&rcc STM32_CLOCK(APB1, 28)>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
+	status = "okay";
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/boards/blues/cygnet/cygnet.yaml
+++ b/boards/blues/cygnet/cygnet.yaml
@@ -19,4 +19,5 @@ supported:
   - feather_serial
   - feather_i2c
   - feather_spi
+  - usbd
 vendor: blues


### PR DESCRIPTION
Update the Cygnet board definition to allow using the exposed device USB.