### PR TITLE
twister: handlers: do not set "Unknown Error" reason on passing tests

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -955,8 +955,13 @@ class QEMUHandlerBase(Handler):
         handler.instance.status = status
         if reason:
             handler.instance.reason = reason
-        else:
+        elif status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
             handler.instance.reason = "Unknown Error"
+        else:
+            # Not a failure (e.g. a pass): no reason to report. Clear it
+            # rather than keep it, so a stale reason from an earlier retry
+            # iteration cannot stick to a now-passing instance.
+            handler.instance.reason = None
 
     @staticmethod
     def _extend_timeout_on_status(harness):

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1484,13 +1484,16 @@ TESTDATA_24 = [
     (TwisterStatus.FAIL, 'Execution error', TwisterStatus.FAIL, 'Execution error'),
     (TwisterStatus.FAIL, 'unexpected eof', TwisterStatus.FAIL, 'unexpected eof'),
     (TwisterStatus.FAIL, 'unexpected byte', TwisterStatus.FAIL, 'unexpected byte'),
-    (TwisterStatus.NONE, None, TwisterStatus.NONE, 'Unknown Error'),
+    (TwisterStatus.FAIL, None, TwisterStatus.FAIL, 'Unknown Error'),
+    (TwisterStatus.PASS, None, TwisterStatus.PASS, None),
+    (TwisterStatus.NONE, None, TwisterStatus.NONE, None),
 ]
 
 @pytest.mark.parametrize(
     '_status, _reason, expected_status, expected_reason',
     TESTDATA_24,
-    ids=['timeout', 'failed', 'unexpected eof', 'unexpected byte', 'unknown']
+    ids=['timeout', 'failed', 'unexpected eof', 'unexpected byte',
+         'failed unknown', 'passed no reason', 'unknown']
 )
 def test_qemuhandler_thread_update_instance_info(
     mocked_instance,


### PR DESCRIPTION
The QEMU monitor thread's _thread_update_instance_info() stamped the
instance reason with "Unknown Error" whenever the harness provided no
reason, regardless of the resulting status. Passing harnesses supply
no reason, so every passing QEMU test instance silently carried
reason="Unknown Error". The classic console output only prints the
reason for failures, which kept this invisible, but trying to view
status using other means reveals this issue.

Only fall back to "Unknown Error" when the status is actually a
failure (failed/error) and no more specific reason is known. For
non-failure results clear the reason instead of keeping it, so a
stale reason from an earlier retry iteration cannot stick to a
now-passing instance.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
