### PR TITLE
tests: kernel: cover some gaps in kernel tests

### DIFF
--- a/tests/kernel/multiprocessing/smp/src/main.c
+++ b/tests/kernel/multiprocessing/smp/src/main.c
@@ -684,6 +684,27 @@ ZTEST(smp, test_get_cpu)
 	k_thread_join(thread_id, K_FOREVER);
 }
 
+/**
+ * @brief Verify the number of active CPUs honors the configured maximum
+ *
+ * @ingroup kernel_smp_tests
+ *
+ * @details The maximum number of CPUs is configurable via
+ * CONFIG_MP_MAX_NUM_CPUS. Verify that the number of CPUs the kernel brought up
+ * and reports through arch_num_cpus() is at least one and never exceeds the
+ * configured maximum.
+ *
+ * @see arch_num_cpus()
+ */
+ZTEST(smp, test_num_cpus)
+{
+	unsigned int num_cpus = arch_num_cpus();
+
+	zassert_between_inclusive(num_cpus, 1, CONFIG_MP_MAX_NUM_CPUS,
+				  "active CPUs (%u) outside the configured range [1, %d]",
+				  num_cpus, CONFIG_MP_MAX_NUM_CPUS);
+}
+
 #ifdef CONFIG_TRACE_SCHED_IPI
 /* global variable for testing send IPI */
 static volatile int sched_ipi_has_called;

--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -302,6 +302,70 @@ ZTEST(sleep, test_sleep_forever)
 	k_sem_take(&test_thread_sem, K_FOREVER);
 }
 
+static volatile int32_t wakeup_remaining;
+
+static void early_wake_thread_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	/* Sleep for a long duration; the main thread wakes us well before it
+	 * elapses. Capture the remaining time reported by k_sleep().
+	 */
+	wakeup_remaining = k_sleep(K_SECONDS(10));
+	k_sem_give(&test_thread_sem);
+}
+
+/**
+ * @brief Verify k_sleep() reports the remaining time when woken early
+ *
+ * @details Put a thread to sleep for a long, finite duration and wake it with
+ * k_wakeup() before that duration elapses. k_sleep() must return the amount of
+ * time that was still remaining, which is non-zero and does not exceed the
+ * originally requested duration.
+ *
+ * Test steps:
+ * - Start a thread that sleeps for 10 seconds and stores k_sleep()'s return.
+ * - Yield so the thread begins sleeping, let ~100 ms pass, then wake it with
+ *   k_wakeup().
+ * - Inspect the stored return value.
+ *
+ * Expected result:
+ * - k_sleep() returns a value greater than zero and less than the requested
+ *   10000 ms, i.e. it reports the time that was still remaining.
+ *
+ * @see k_sleep()
+ * @see k_wakeup()
+ */
+ZTEST(sleep, test_sleep_wakeup_returns_remaining)
+{
+	test_objects_init();
+	wakeup_remaining = 0;
+
+	test_thread_id = k_thread_create(&test_thread_data,
+					 test_thread_stack,
+					 THREAD_STACK,
+					 early_wake_thread_entry,
+					 0, 0, NULL, TEST_THREAD_PRIORITY,
+					 0, K_NO_WAIT);
+
+	/* Allow early_wake_thread_entry to start. */
+	k_yield();
+
+	/* Let part of the sleep elapse, then wake it well before 10 seconds. */
+	k_msleep(100);
+	k_wakeup(test_thread_id);
+	k_sem_take(&test_thread_sem, K_FOREVER);
+
+	zassert_true(wakeup_remaining > 0,
+		     "k_sleep() reported %d ms remaining; expected > 0",
+		     wakeup_remaining);
+	zassert_true(wakeup_remaining < 10000,
+		     "k_sleep() reported %d ms remaining; expected less than the "
+		     "requested 10000", wakeup_remaining);
+}
+
 /*test case main entry*/
 static void *sleep_setup(void)
 {

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -105,9 +105,6 @@ ZTEST(threads_lifecycle_1cpu, test_threads_abort_repeat)
 	ztest_test_pass();
 }
 
-bool abort_called;
-void *block;
-
 static void delayed_thread_entry(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
@@ -123,6 +120,11 @@ static void delayed_thread_entry(void *p1, void *p2, void *p3)
  * @ingroup kernel_thread_tests
  * @brief Test abort on delayed thread before it has started
  * execution
+ *
+ * @details Create a thread with a 100ms start delay and abort it while
+ * it is still waiting to start. Sleep past the original start deadline
+ * and verify the thread never ran: a broken abort would have let the
+ * thread start and set execute_flag.
  *
  * @see k_thread_abort()
  */
@@ -150,9 +152,15 @@ ZTEST(threads_lifecycle_1cpu, test_delayed_thread_abort)
 
 	k_thread_abort(tid);
 
+	/* Sleep past the thread's original 100ms start deadline. A working
+	 * abort keeps execute_flag at 0; a broken abort would let the thread
+	 * start and set it to 1.
+	 */
+	k_msleep(100);
+
 	/* Test point: Test abort of thread before its execution*/
-	zassert_false(execute_flag == 1, "Delayed thread is has executed"
-		      " before cancellation");
+	zassert_true(execute_flag == 0, "Delayed thread has executed"
+		     " after its start deadline despite being aborted");
 
 	/* Restore the priority */
 	k_thread_priority_set(k_current_get(), current_prio);

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -1017,6 +1017,30 @@ ZTEST(timer_api, test_timer_expiry_in_isr)
 	k_timer_stop(&isr_ctx_timer);
 }
 
+static struct k_timer cleanup_timer;
+
+/**
+ * @brief Test releasing the resources associated with a timer
+ *
+ * @ingroup kernel_timer_tests
+ *
+ * @details Start and stop a timer so it has no pending waiters, then call
+ * k_timer_cleanup() and verify it succeeds (returns 0), indicating the timer's
+ * resources may be released.
+ *
+ * @see k_timer_cleanup()
+ */
+ZTEST(timer_api, test_timer_cleanup)
+{
+	k_timer_init(&cleanup_timer, NULL, NULL);
+	k_timer_start(&cleanup_timer, K_MSEC(DURATION), K_NO_WAIT);
+	k_timer_stop(&cleanup_timer);
+
+	/* No threads are waiting on the timer, so cleanup must succeed. */
+	zassert_equal(k_timer_cleanup(&cleanup_timer), 0,
+		      "cleanup of an idle timer should succeed");
+}
+
 #if defined(CONFIG_MULTITHREADING)
 static struct k_timer cleanup_pending_timer;
 static struct k_thread cleanup_thread;


### PR DESCRIPTION
- **tests: kernel: sleep: verify remaining time reported on early wakeup**
- **tests: kernel: smp: add test for configurable CPU count**
- **tests: kernel: timer: cover k_timer_cleanup() of an idle timer**
- **tests: kernel: threads: make delayed abort test verify the abort**
