### PR TITLE
mgmt: hawkbit: attach @file blocks to Doxygen groups

### DIFF
--- a/include/zephyr/mgmt/hawkbit.h
+++ b/include/zephyr/mgmt/hawkbit.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief hawkBit legacy header file
+ * @ingroup hawkbit
  */
 
 #ifndef ZEPHYR_INCLUDE_MGMT_HAWKBIT_H_

--- a/include/zephyr/mgmt/hawkbit/autohandler.h
+++ b/include/zephyr/mgmt/hawkbit/autohandler.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief hawkBit autohandler header file
+ * @ingroup hawkbit_autohandler
  */
 
 /**

--- a/include/zephyr/mgmt/hawkbit/config.h
+++ b/include/zephyr/mgmt/hawkbit/config.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief hawkBit configuration header file
+ * @ingroup hawkbit_config
  */
 
 /**

--- a/include/zephyr/mgmt/hawkbit/event.h
+++ b/include/zephyr/mgmt/hawkbit/event.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief hawkBit event header file
+ * @ingroup hawkbit_event
  */
 
 /**

--- a/include/zephyr/mgmt/hawkbit/hawkbit.h
+++ b/include/zephyr/mgmt/hawkbit/hawkbit.h
@@ -8,6 +8,7 @@
 /**
  * @file
  * @brief hawkBit main header file
+ * @ingroup hawkbit
  */
 
 /**


### PR DESCRIPTION
Add `@ingroup` to the existing `@file` blocks so the hawkBit headers are attached to their Doxygen groups in the generated API documentation.