### PR TITLE
soc: ite: Add deep sleep time measurement

### DIFF
--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -369,6 +369,29 @@ void arch_busy_wait(uint32_t usec_to_wait)
 }
 #endif
 
+#ifdef CONFIG_PM
+static uint64_t cyc_deep_sleep_total;
+static uint32_t cyc_enter_deep_sleep;
+
+void ite_ec_clock_capture_low_freq_timer(void)
+{
+	cyc_enter_deep_sleep = ~read_timer_obser(FREE_RUN_TIMER);
+}
+
+void ite_ec_clock_compensate_system_timer(void)
+{
+	uint32_t now = ~read_timer_obser(FREE_RUN_TIMER);
+	uint32_t cyc_elapsed_in_deep = now - cyc_enter_deep_sleep;
+
+	cyc_deep_sleep_total += cyc_elapsed_in_deep;
+}
+
+uint64_t ite_ec_clock_get_sleep_ticks(void)
+{
+	return k_cyc_to_ticks_floor64(cyc_deep_sleep_total);
+}
+#endif /* CONFIG_PM */
+
 static int sys_clock_driver_init(void)
 {
 	int ret;

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -396,7 +396,7 @@ static int timer_init(enum ext_timer_idx ext_timer,
 	return 0;
 }
 
-bool ite_ec_timer_block_idle(void)
+bool ite_it8xxx2_timer_block_idle(void)
 {
 	return (IT8XXX2_EXT_CNTOX(EVENT_TIMER) < IDLE_BLOCK_TIMER_TICKS) ||
 	       (IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER) < IDLE_BLOCK_TIMER_TICKS);

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -402,6 +402,29 @@ bool ite_it8xxx2_timer_block_idle(void)
 	       (IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER) < IDLE_BLOCK_TIMER_TICKS);
 }
 
+#ifdef CONFIG_PM
+static uint64_t cyc_deep_sleep_total;
+static uint32_t cyc_enter_deep_sleep;
+
+void ite_ec_clock_capture_low_freq_timer(void)
+{
+	cyc_enter_deep_sleep = ~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER));
+}
+
+void ite_ec_clock_compensate_system_timer(void)
+{
+	uint32_t now = ~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER));
+	uint32_t cyc_elapsed_in_deep = now - cyc_enter_deep_sleep;
+
+	cyc_deep_sleep_total += cyc_elapsed_in_deep;
+}
+
+uint64_t ite_ec_clock_get_sleep_ticks(void)
+{
+	return k_cyc_to_ticks_floor64(cyc_deep_sleep_total);
+}
+#endif /* CONFIG_PM */
+
 static int sys_clock_driver_init(void)
 {
 	int ret;

--- a/soc/ite/ec/common/power.c
+++ b/soc/ite/ec/common/power.c
@@ -7,12 +7,15 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
 #include <soc.h>
+#include <soc_timer.h>
 
 /* Handle when enter deep doze mode. */
 static void ite_power_soc_deep_doze(void)
 {
+	ite_ec_clock_capture_low_freq_timer();
 	/* Enter deep doze mode */
 	riscv_idle(CHIP_PLL_DEEP_DOZE, MSTATUS_IEN);
+	ite_ec_clock_compensate_system_timer();
 }
 
 /* Invoke Low Power/System Off specific Tasks */

--- a/soc/ite/ec/common/soc_timer.h
+++ b/soc/ite/ec/common/soc_timer.h
@@ -4,24 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _ITE_IT8XXX2_SOC_TIMER_H_
-#define _ITE_IT8XXX2_SOC_TIMER_H_
+#ifndef _ITE_EC_SOC_TIMER_H_
+#define _ITE_EC_SOC_TIMER_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifdef CONFIG_SOC_IT8XXX2
-bool ite_ec_timer_block_idle(void);
-#else
-static inline bool ite_ec_timer_block_idle(void)
-{
-	return false;
-}
-#endif /* CONFIG_SOC_IT8XXX2 */
+#include <stdint.h>
+#include <stdbool.h>
+
+bool ite_it8xxx2_timer_block_idle(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* _ITE_IT8XXX2_SOC_TIMER_H_ */
+#endif /* _ITE_EC_SOC_TIMER_H_ */

--- a/soc/ite/ec/common/soc_timer.h
+++ b/soc/ite/ec/common/soc_timer.h
@@ -16,6 +16,23 @@ extern "C" {
 
 bool ite_it8xxx2_timer_block_idle(void);
 
+#ifdef CONFIG_PM
+void ite_ec_clock_capture_low_freq_timer(void);
+void ite_ec_clock_compensate_system_timer(void);
+uint64_t ite_ec_clock_get_sleep_ticks(void);
+#else
+static inline void ite_ec_clock_capture_low_freq_timer(void)
+{
+}
+static inline void ite_ec_clock_compensate_system_timer(void)
+{
+}
+static inline uint64_t ite_ec_clock_get_sleep_ticks(void)
+{
+	return 0;
+}
+#endif /* CONFIG_PM */
+
 #ifdef __cplusplus
 }
 #endif

--- a/soc/ite/ec/it8xxx2/soc.c
+++ b/soc/ite/ec/it8xxx2/soc.c
@@ -359,7 +359,7 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	 * Due to this hardware limitation, SoC should skip entering idle mode if
 	 * the remaining timer value is less than 150µs(safe margin).
 	 */
-	if (ite_ec_timer_block_idle()) {
+	if (ite_it8xxx2_timer_block_idle()) {
 		goto __no_idle;
 	}
 #endif /* defined(CONFIG_I2C_ITE_ENHANCE) && defined(CONFIG_I2C_TARGET_BUFFER_MODE) */


### PR DESCRIPTION
Track the time spent in deep doze / sleep states on ITE EC SoCs (IT8xxx2, IT51xxx) by capturing the 32.768 kHz free-run timer timestamp before entering deep sleep and accumulating elapsed cycles upon waking.