### PR TITLE
lib: notify: fix C23 incompatible function pointer types

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -457,7 +457,7 @@ static int trigger_start(const struct device *dev)
 	 */
 	if (drv_data->request_clock) {
 		sys_notify_init_callback(&drv_data->clk_cli.notify,
-					 clock_started_callback);
+					 (sys_notify_generic_callback)clock_started_callback);
 		ret = request_clock(drv_data);
 		if (ret < 0) {
 			drv_data->active = false;

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -227,7 +227,8 @@ static void calibration_handler(struct k_timer *timer)
 		return;
 	}
 
-	sys_notify_init_callback(&hf_cal_cli.notify, calibration_finished_callback);
+	sys_notify_init_callback(&hf_cal_cli.notify,
+				 (sys_notify_generic_callback)calibration_finished_callback);
 	(void)onoff_request(z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF),
 			    &hf_cal_cli);
 }

--- a/drivers/clock_control/clock_control_nrf_common.c
+++ b/drivers/clock_control/clock_control_nrf_common.c
@@ -372,7 +372,7 @@ int nrf_clock_control_request_sync(const struct device *dev, const struct nrf_cl
 		return -EWOULDBLOCK;
 	}
 
-	sys_notify_init_callback(&req.cli.notify, sync_cb);
+	sys_notify_init_callback(&req.cli.notify, (sys_notify_generic_callback)sync_cb);
 
 	err = nrf_clock_control_request(dev, spec, &req.cli);
 	if (err < 0) {

--- a/drivers/clock_control/clock_control_nrf_fll16m.c
+++ b/drivers/clock_control/clock_control_nrf_fll16m.c
@@ -114,7 +114,8 @@ static void fll16m_work_handler(struct k_work *work)
 		int rc;
 
 		/* Bypass mode requires HFXO to be running first. */
-		sys_notify_init_callback(&dev_data->hfxo_cli.notify, hfxo_cb);
+		sys_notify_init_callback(&dev_data->hfxo_cli.notify,
+					 (sys_notify_generic_callback)hfxo_cb);
 		rc = nrf_clock_control_request(hfxo, NULL, &dev_data->hfxo_cli);
 		if (rc < 0) {
 			clock_config_update_end(&dev_data->clk_cfg, rc);

--- a/drivers/clock_control/clock_control_nrf_xo.c
+++ b/drivers/clock_control/clock_control_nrf_xo.c
@@ -81,7 +81,8 @@ static void calibration_handler(struct k_timer *timer)
 		return;
 	}
 
-	sys_notify_init_callback(&hf_cal_cli.notify, calibration_finished_callback);
+	sys_notify_init_callback(&hf_cal_cli.notify,
+				 (sys_notify_generic_callback)calibration_finished_callback);
 	(void)onoff_request(&((common_clock_data_t *)CLOCK_DEVICE_XO->data)->mgr, &hf_cal_cli);
 }
 

--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -89,7 +89,7 @@ static void clk_request(const struct device *dev, struct onoff_client *cli,
 {
 	int err;
 
-	sys_notify_init_callback(&cli->notify, callback);
+	sys_notify_init_callback(&cli->notify, (sys_notify_generic_callback)callback);
 #ifdef CONFIG_CLOCK_CONTROL_NRF
 	err = onoff_request(mgr, cli);
 #else

--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -869,7 +869,8 @@ static int trigger_start(const struct device *dev)
 	 * first. If not, start the transfer directly.
 	 */
 	if (drv_data->request_clock) {
-		sys_notify_init_callback(&drv_data->clk_cli.notify, clock_started_callback);
+		sys_notify_init_callback(&drv_data->clk_cli.notify,
+					 (sys_notify_generic_callback)clock_started_callback);
 		ret = audio_clock_request(drv_data);
 		if (ret < 0) {
 			tdm_uninit(drv_data);

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -706,7 +706,7 @@ static int trigger_start(const struct device *dev)
 	 */
 	if (drv_data->request_clock) {
 		sys_notify_init_callback(&drv_data->clk_cli.notify,
-					 clock_started_callback);
+					 (sys_notify_generic_callback)clock_started_callback);
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
 		ret = onoff_request(drv_data->clk_mgr, &drv_data->clk_cli);
 #else

--- a/drivers/sensor/nordic/temp/temp_nrf5.c
+++ b/drivers/sensor/nordic/temp/temp_nrf5.c
@@ -64,7 +64,7 @@ static int temp_nrf5_sample_fetch(const struct device *dev,
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
 
-	sys_notify_init_callback(&cli.notify, hfclk_on_callback);
+	sys_notify_init_callback(&cli.notify, (sys_notify_generic_callback)hfclk_on_callback);
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
 	r = onoff_request(data->clk_mgr, &cli);
 #else

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2992,7 +2992,8 @@ static void uarte_pm_resume(const struct device *dev)
 	int err;
 
 	k_sem_reset(&data->hfxo_ready);
-	sys_notify_init_callback(&data->hfxo_client.notify, uarte_hfxo_active);
+	sys_notify_init_callback(&data->hfxo_client.notify,
+				 (sys_notify_generic_callback)uarte_hfxo_active);
 	err = onoff_request(mgr, &data->hfxo_client);
 	__ASSERT_NO_MSG(err >= 0);
 
@@ -3080,7 +3081,8 @@ static int uarte_pm_suspend(const struct device *dev)
 	struct onoff_manager *mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
 	int onoff_err;
 
-	sys_notify_init_callback(&data->hfxo_client.notify, uarte_hfxo_active);
+	sys_notify_init_callback(&data->hfxo_client.notify,
+				 (sys_notify_generic_callback)uarte_hfxo_active);
 	onoff_err = onoff_cancel_or_release(mgr, &data->hfxo_client);
 	__ASSERT_NO_MSG(onoff_err >= 0);
 #endif

--- a/include/zephyr/sys/notify.h
+++ b/include/zephyr/sys/notify.h
@@ -94,8 +94,13 @@ struct sys_notify;
  *   sys_notify_fetch_result().  Expected values are
  *   service-specific, but the value shall be non-negative if the
  *   operation succeeded, and negative if the operation failed.
+ *
+ * The signature is service-specific, so a callback must be cast to
+ * @c sys_notify_generic_callback when it is registered, e.g.
+ * @c (sys_notify_generic_callback)my_callback, and cast back to its own
+ * signature by the service that invokes it.
  */
-typedef void (*sys_notify_generic_callback)();
+typedef void (*sys_notify_generic_callback)(void);
 
 /**
  * @brief State associated with notification for an asynchronous

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
@@ -58,7 +58,7 @@ void nrf_802154_clock_hfclk_start(void)
 	__ASSERT_NO_MSG(mgr != NULL);
 #endif
 
-	sys_notify_init_callback(&hfclk_cli.notify, hfclk_on_callback);
+	sys_notify_init_callback(&hfclk_cli.notify, (sys_notify_generic_callback)hfclk_on_callback);
 
 	/*
 	 * todo: replace constlat request with PM policy API when
@@ -112,7 +112,7 @@ void nrf_802154_clock_hfclk_stop(void)
 
 void nrf_802154_clock_hfclk_start(void)
 {
-	sys_notify_init_callback(&hfclk_cli.notify, hfclk_on_callback);
+	sys_notify_init_callback(&hfclk_cli.notify, (sys_notify_generic_callback)hfclk_on_callback);
 	int ret = nrf_clock_control_request(DEVICE_DT_GET(DT_NODELABEL(hfxo)), NULL, &hfclk_cli);
 
 	__ASSERT_NO_MSG(ret >= 0);

--- a/samples/boards/nordic/clock_control/src/main.c
+++ b/samples/boards/nordic/clock_control/src/main.c
@@ -82,7 +82,7 @@ int main(void)
 		return 0;
 	}
 
-	sys_notify_init_callback(&cli.notify, sample_notify_cb);
+	sys_notify_init_callback(&cli.notify, (sys_notify_generic_callback)sample_notify_cb);
 
 	k_sleep(SAMPLE_PRE_REQUEST_TIMEOUT);
 

--- a/soc/nordic/common/mram_latency.c
+++ b/soc/nordic/common/mram_latency.c
@@ -116,7 +116,7 @@ int mram_no_latency_sync_request(void)
 	}
 
 	k_sem_init(&req.sem, 0, 1);
-	sys_notify_init_callback(&req.cli.notify, sync_req_cb);
+	sys_notify_init_callback(&req.cli.notify, (sys_notify_generic_callback)sync_req_cb);
 	rv = onoff_request(&mram_latency_mgr, &req.cli);
 	if (rv < 0) {
 		return rv;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -56,7 +56,7 @@ static int blocking_on(const struct device *dev, uint32_t timeout)
 	int err;
 
 	k_sem_init(&state.sem, 0, 1);
-	sys_notify_init_callback(&state.cli.notify, clock_ready);
+	sys_notify_init_callback(&state.cli.notify, (sys_notify_generic_callback)clock_ready);
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
 	err = onoff_request(mgr, &state.cli);
 #else

--- a/tests/boards/nrf/mram_latency/src/main.c
+++ b/tests/boards/nrf/mram_latency/src/main.c
@@ -53,13 +53,13 @@ ZTEST(mram_latency, test_basic_requests)
 	k_sem_init(&req1.sem, 0, 1);
 	k_sem_init(&req2.sem, 0, 1);
 
-	sys_notify_init_callback(&req1.cli.notify, basic_cb);
+	sys_notify_init_callback(&req1.cli.notify, (sys_notify_generic_callback)basic_cb);
 	exp_state = ONOFF_STATE_OFF;
 	/* Req: 0->1 trigger to on */
 	rv = mram_no_latency_request(&req1.cli);
 	zassert_equal(rv, exp_state, "Unexpected rv:%d (exp:%d)", rv, exp_state);
 
-	sys_notify_init_callback(&req2.cli.notify, basic_cb);
+	sys_notify_init_callback(&req2.cli.notify, (sys_notify_generic_callback)basic_cb);
 	exp_state = ONOFF_STATE_TO_ON;
 	/* Req: 1->2 */
 	rv = mram_no_latency_request(&req2.cli);
@@ -84,7 +84,7 @@ ZTEST(mram_latency, test_basic_requests)
 	rv = mram_no_latency_cancel_or_release(&req1.cli);
 	zassert_equal(rv, exp_state, "Unexpected rv:%d (exp:%d)", rv, exp_state);
 
-	sys_notify_init_callback(&req1.cli.notify, basic_cb);
+	sys_notify_init_callback(&req1.cli.notify, (sys_notify_generic_callback)basic_cb);
 	exp_state = ONOFF_STATE_OFF;
 
 	/* Req: 0->1 triggered to on while in to off. */
@@ -105,7 +105,7 @@ static void timeout(struct k_timer *timer)
 	uint32_t exp_state;
 	int rv;
 
-	sys_notify_init_callback(&req->cli.notify, basic_cb);
+	sys_notify_init_callback(&req->cli.notify, (sys_notify_generic_callback)basic_cb);
 	exp_state = ONOFF_STATE_OFF;
 	rv = mram_no_latency_request(&req->cli);
 	zassert_equal(rv, exp_state, "Unexpected rv:%d (exp:%d)", rv, exp_state);

--- a/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
+++ b/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
@@ -151,7 +151,7 @@ ZTEST(clock_control_onoff, test_clock_release_from_callback)
 	clock_off();
 	k_busy_wait(100);
 
-	sys_notify_init_callback(&cli.notify, request_cb);
+	sys_notify_init_callback(&cli.notify, (sys_notify_generic_callback)request_cb);
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
 	err = onoff_request(mgr, &cli);
 #else

--- a/tests/lib/notify/src/main.c
+++ b/tests/lib/notify/src/main.c
@@ -181,14 +181,14 @@ ZTEST(sys_notify_api, test_callback)
 	zassert_equal(rc, -EINVAL,
 		      "invalid not diagnosed");
 
-	sys_notify_init_callback(&notify, callback);
+	sys_notify_init_callback(&notify, (sys_notify_generic_callback)callback);
 	notify.method.callback = NULL;
 	rc = sys_notify_validate(&notify);
 	zassert_equal(rc, -EINVAL,
 		      "null callback not invalid");
 
 	memset(&notify, 0xac, sizeof(notify));
-	sys_notify_init_callback(&notify, callback);
+	sys_notify_init_callback(&notify, (sys_notify_generic_callback)callback);
 	rc = sys_notify_validate(&notify);
 	zassert_equal(rc, 0,
 		      "init_spinwait invalid");

--- a/tests/lib/onoff/src/main.c
+++ b/tests/lib/onoff/src/main.c
@@ -216,7 +216,7 @@ static void isr_reset(struct k_timer *timer)
 static void reset_cli(void)
 {
 	onoff_cli = (struct onoff_client){};
-	sys_notify_init_callback(&onoff_cli.notify, callback);
+	sys_notify_init_callback(&onoff_cli.notify, (sys_notify_generic_callback)callback);
 }
 
 static void reset_callback(void)


### PR DESCRIPTION
Fixes #115690.

`sys_notify_generic_callback` is declared with an empty parameter list, which C23 redefines from "unspecified arguments" to `(void)`. Every service registering a callback through `sys_notify_init_callback()` therefore fails to compile under `CONFIG_STD_C23=y`.

Unlike `cbprintf_cb` in #107174, this typedef cannot be given one true prototype — the signature is deliberately service-specific and each service casts it back to its own type on invocation. This keeps the type erasure and makes the conversions explicit instead:

- give the typedef an explicit `(void)` prototype, stating the C23 meaning;
- document that both registration and invocation cast;
- add `(sys_notify_generic_callback)` at the 24 registration sites.

`lib/utils/onoff.c` already cast in the invoke direction, so only registration sites changed. No functional change.

<details>
<summary>Why one commit rather than splitting out the tests and sample</summary>

The header change and the casts have to land together: with the typedef fixed but a call site un-cast, that call site does not compile. Splitting the tests and sample into a second commit would leave a broken intermediate commit, so this is kept as one mechanical change.

</details>

## Verification

Built against `eaa480916f4`, before and after, with Zephyr SDK 1.0.1 (`arm-zephyr-eabi-gcc` 14.3.0) and host GCC 13.3.0.

| Build | before | after |
| --- | --- | --- |
| `native_sim tests/lib/notify` — `CONFIG_STD_C23=y`, `CONFIG_COMPILER_WARNINGS_AS_ERRORS=y` | ❌ 2 errors | ✅ builds, **4/4 tests pass** |
| `native_sim tests/lib/onoff` — same flags | — | ✅ builds, **all tests pass** |
| `nrf54l15dk/nrf54l15/cpuapp samples/boards/nordic/clock_control` — `CONFIG_STD_C23=y` | ❌ errors in sample + `clock_control_nrf_common.c` | ✅ builds |
| the same three at default C17 | ✅ | ✅ |

`scripts/checkpatch.pl --git` reports no style problems.

<details>
<summary>Commands</summary>

```shell
# fails on main, builds here
west build -b native_sim tests/lib/notify \
  -- -DCONFIG_STD_C23=y -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y

west build -b native_sim tests/lib/onoff \
  -- -DCONFIG_STD_C23=y -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y

west build -b nrf54l15dk/nrf54l15/cpuapp samples/boards/nordic/clock_control \
  -- -DCONF_FILE=configs/nrfx_clock.conf \
     -DDTC_OVERLAY_FILE=configs/nrfx_xo.overlay \
     -DCONFIG_STD_C23=y
```

</details>

<details>
<summary>Test output</summary>

```
SUITE PASS - 100.00% [sys_notify_api]: pass = 4, fail = 0, skip = 0, total = 4
 - PASS - [sys_notify_api.test_callback]
 - PASS - [sys_notify_api.test_signal]
 - PASS - [sys_notify_api.test_spinwait]
 - PASS - [sys_notify_api.test_validate]
PROJECT EXECUTION SUCCESSFUL
```

</details>

The nRF sample links to the same size at C17 and at C23 with this change applied (`FLASH: 26184 B`), consistent with the casts being purely a type-system change.

---

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5[1m] on behalf of @JPHutchins. I was asked to diagnose why an application could not be built with `CONFIG_STD_C23=y` against Zephyr, to prepare the upstream fix for the `sys_notify` typedef that blocked it, and to open this pull request. I ran every build and test listed above.
