### PR TITLE
drivers: reset: align Kconfig prompts with style guide

### DIFF
--- a/drivers/reset/Kconfig.arm_scmi
+++ b/drivers/reset/Kconfig.arm_scmi
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_ARM_SCMI
-	bool "ARM SCMI based reset driver"
+	bool "ARM SCMI reset driver"
 	depends on ARM_SCMI_RESET_HELPERS
 	default y
 	help

--- a/drivers/reset/Kconfig.gd32
+++ b/drivers/reset/Kconfig.gd32
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_GD32
-	bool "GD32 Reset Controller Driver"
+	bool "GD32 reset driver"
 	default y
 	depends on DT_HAS_GD_GD32_RCTL_ENABLED

--- a/drivers/reset/Kconfig.intel_socfpga
+++ b/drivers/reset/Kconfig.intel_socfpga
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_INTEL_SOCFPGA
-	bool "Intel SoC FPGA Reset Controller driver"
+	bool "Intel SoC FPGA reset driver"
 	default y
 	depends on DT_HAS_INTEL_SOCFPGA_RESET_ENABLED
 	help

--- a/drivers/reset/Kconfig.lpc_syscon
+++ b/drivers/reset/Kconfig.lpc_syscon
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_NXP_SYSCON
-	bool "NXP Syscon Reset controller driver"
+	bool "NXP Syscon reset driver"
 	default y
 	depends on DT_HAS_NXP_LPC_SYSCON_RESET_ENABLED
 	help

--- a/drivers/reset/Kconfig.npcx
+++ b/drivers/reset/Kconfig.npcx
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_NPCX
-	bool "Nuvoton NPCX embedded controller (EC) reset controller driver"
+	bool "Nuvoton NPCX embedded controller (EC) reset driver"
 	default y
 	depends on DT_HAS_NUVOTON_NPCX_RST_ENABLED
 	help

--- a/drivers/reset/Kconfig.numaker
+++ b/drivers/reset/Kconfig.numaker
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_NUMAKER
-	bool "Nuvoton NuMaker reset controller driver"
+	bool "Nuvoton NuMaker reset driver"
 	default y
 	depends on DT_HAS_NUVOTON_NUMAKER_RST_ENABLED
 	help

--- a/drivers/reset/Kconfig.nxp_mrcc
+++ b/drivers/reset/Kconfig.nxp_mrcc
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_NXP_MRCC
-	bool "NXP MRCC Reset controller driver"
+	bool "NXP MRCC reset driver"
 	default y
 	depends on DT_HAS_NXP_MRCC_RESET_ENABLED
 	help

--- a/drivers/reset/Kconfig.rpi_pico
+++ b/drivers/reset/Kconfig.rpi_pico
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_RPI_PICO
-	bool "Raspberry Pi Reset Controller driver"
+	bool "Raspberry Pi reset driver"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_RESET_ENABLED

--- a/drivers/reset/Kconfig.rts5817
+++ b/drivers/reset/Kconfig.rts5817
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_RTS5817
-	bool "RTS5817 Reset Controller Driver"
+	bool "RTS5817 reset driver"
 	default y
 	depends on DT_HAS_REALTEK_RTS5817_RESET_ENABLED
 	help

--- a/drivers/reset/Kconfig.sf32lb
+++ b/drivers/reset/Kconfig.sf32lb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_SF32LB
-	bool "SF32LB Reset Controller"
+	bool "SF32LB reset driver"
 	default y
 	depends on DT_HAS_SIFLI_SF32LB_RCC_RCTL_ENABLED
 	help

--- a/drivers/reset/Kconfig.stm32
+++ b/drivers/reset/Kconfig.stm32
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_STM32
-	bool "STM32 reset driver"
+	bool "STM32 RCC reset driver"
 	default y
 	depends on DT_HAS_ST_STM32_RCC_RCTL_ENABLED

--- a/drivers/reset/Kconfig.stm32
+++ b/drivers/reset/Kconfig.stm32
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_STM32
-	bool "STM32 Reset Controller Driver"
+	bool "STM32 reset driver"
 	default y
 	depends on DT_HAS_ST_STM32_RCC_RCTL_ENABLED


### PR DESCRIPTION
Align reset driver prompts with the Kconfig style guide (doc/contribute/style/kconfig.rst), which specifies for /drivers:

`* **Drivers (/drivers)**: Use the format ``{Driver Type}_{Driver Name}`` for symbols and ``{Driver Name} {Driver Type} driver`` for prompts.`

The driver type is "reset" (matching the RESET_ prefix), so prompts take the "<name> reset driver" form. Prompt-only changes and no symbol renames.

Part of #7272

Scope:
- Changed (11): arm_scmi, gd32, intel_socfpga, lpc_syscon, npcx, numaker, nxp_mrcc, rpi_pico, rts5817, sf32lb, stm32.
- Already compliant: aspeed, syna_sr100, mmio, mchp_mss.
- Left as-is: the top-level 'menuconfig RESET' prompt ("Reset controller drivers") - it's the subsystem menu, not an individual driver, so the per-driver prompt format doesn't apply.
- Follow-up: mchp, focaltech, nxp_rstctl embed "reset" in the IP block name; need discussion before rewording.
