### PR TITLE
sensing: improve Doxygen coverage

### DIFF
--- a/include/zephyr/sensing/sensing.h
+++ b/include/zephyr/sensing/sensing.h
@@ -37,6 +37,7 @@ extern "C" {
  * @brief Sensor Version
  */
 struct sensing_sensor_version {
+	/** The version as a whole value or split into its individual fields. */
 	union {
 		uint32_t value; /**< The version represented as a 32-bit value. */
 		struct {
@@ -208,6 +209,7 @@ struct sensing_sensor_config {
 	/** \ref SENSING_SENSITIVITY_INDEX_ALL */
 	int8_t data_field; /**< Data field of the sensor configuration. */
 
+	/** Configuration value, the member to use is selected by the attribute. */
 	union {
 		/** Interval between two sensor samples in microseconds (us). */
 		uint32_t interval;


### PR DESCRIPTION
Document the anonymous unions of the sensing sensor version and
configuration structures.

Documentation only, no functional change.