### PR TITLE
dts: raspberrypi: rp2350: enable die temperature sensor

### DIFF
--- a/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
@@ -515,6 +515,6 @@
 
 	die_temp: dietemp {
 		compatible = "raspberrypi,pico-temp";
-		status = "disabled";
+		status = "okay";
 	};
 };

--- a/samples/sensor/die_temp_polling/boards/pico_plus2_rp2350b_hazard3.overlay
+++ b/samples/sensor/die_temp_polling/boards/pico_plus2_rp2350b_hazard3.overlay
@@ -1,9 +1,0 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2024 TOKITA Hiroshi
- */
-
-&die_temp {
-	status = "okay";
-};

--- a/samples/sensor/die_temp_polling/boards/pico_plus2_rp2350b_m33.overlay
+++ b/samples/sensor/die_temp_polling/boards/pico_plus2_rp2350b_m33.overlay
@@ -1,9 +1,0 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2024 TOKITA Hiroshi
- */
-
-&die_temp {
-	status = "okay";
-};

--- a/samples/sensor/die_temp_polling/boards/rpi_pico2_rp2350a_hazard3.overlay
+++ b/samples/sensor/die_temp_polling/boards/rpi_pico2_rp2350a_hazard3.overlay
@@ -1,8 +1,0 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2024 Andrew Featherstone
- */
-
-/* Pico 2 is compatible with the Pico 1, so reuse. */
-#include "rpi_pico.overlay"

--- a/samples/sensor/die_temp_polling/boards/rpi_pico2_rp2350a_m33.overlay
+++ b/samples/sensor/die_temp_polling/boards/rpi_pico2_rp2350a_m33.overlay
@@ -1,8 +1,0 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2024 Andrew Featherstone
- */
-
-/* Pico 2 is compatible with the Pico 1, so reuse. */
-#include "rpi_pico.overlay"


### PR DESCRIPTION
Enable the RP2350 on-die temperature sensor at SoC level.

The RP2350A and RP2350B devicetrees provide their respective ADC channels, so board-specific sample overlays are no longer needed.

Remove the redundant RP2350 die_temp_polling sample overlays.