### PR TITLE
hwm_v2: narrowly load the SoC being targeted

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -12,6 +12,9 @@ on:
       - 'scripts/build/**'
       - 'scripts/cmake/**'
       - 'scripts/kconfig/**'
+      - 'scripts/list_hardware.py'
+      - 'scripts/schemas/soc-schema.yaml'
+      - 'scripts/tests/hardware/**'
       - '.github/workflows/scripts_tests.yml'
   pull_request:
     branches:
@@ -21,6 +24,9 @@ on:
       - 'scripts/build/**'
       - 'scripts/cmake/**'
       - 'scripts/kconfig/**'
+      - 'scripts/list_hardware.py'
+      - 'scripts/schemas/soc-schema.yaml'
+      - 'scripts/tests/hardware/**'
       - '.github/workflows/scripts_tests.yml'
 
 permissions:
@@ -77,4 +83,4 @@ jobs:
           ZEPHYR_BASE: ./
         run: |
           echo "Run script tests"
-          pytest ./scripts/build ./scripts/cmake ./scripts/kconfig
+          pytest ./scripts/build ./scripts/cmake ./scripts/kconfig ./scripts/tests/hardware

--- a/boards/native/nrf_bsim/board.yml
+++ b/boards/native/nrf_bsim/board.yml
@@ -4,20 +4,29 @@ boards:
   vendor: zephyr
   socs:
   - name: native
+  # Built on the native SoC, but uses the Kconfig of the nRF52 it simulates.
+  requires:
+  - nrf52833
 - name: nrf5340bsim
   full_name: nRF5340 simulated boards (BabbleSim)
   vendor: zephyr
   socs:
   - name: nrf5340
+  # Only the name and cpu-cluster definitions come from the real SoC; the build itself uses the
+  # native SoC (SOC_POSIX), so that tree has to be loaded as well.
+  requires:
+  - native
 - name: nrf54l15bsim
   full_name: nRF54L15 simulated boards (BabbleSim)
   vendor: zephyr
   socs:
   - name: nrf54l15
+  requires:
+  - native
 - name: nrf54lm20bsim
   full_name: nRF54LM20 simulated boards (BabbleSim)
   vendor: zephyr
   socs:
   - name: nrf54lm20a
-# Note the 53 and 54 are referring to the real SOC yamls, but we only use their name and cpu-cluster
-# definitions. In practice these board uses the same native SOC (SOC_POSIX) as the nrf52_bsim
+  requires:
+  - native

--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -178,7 +178,7 @@ endif()
 
 set(format_str "{NAME}\;{DIR}\;")
 set(format_str "${format_str}{REVISION_FORMAT}\;{REVISION_DEFAULT}\;{REVISION_EXACT}\;")
-set(format_str "${format_str}{REVISIONS}\;{SOCS}\;{QUALIFIERS}")
+set(format_str "${format_str}{REVISIONS}\;{SOCS}\;{SOC_REQUIRES}\;{QUALIFIERS}")
 
 list(TRANSFORM BOARD_DIRECTORIES PREPEND "--board-dir=" OUTPUT_VARIABLE board_dir_arg)
 execute_process(${list_boards_commands} --board=${BOARD} ${board_dir_arg}
@@ -194,7 +194,7 @@ endif()
 if(NOT "${ret_board}" STREQUAL "")
   string(STRIP "${ret_board}" ret_board)
   set(single_val "NAME;REVISION_FORMAT;REVISION_DEFAULT;REVISION_EXACT")
-  set(multi_val  "DIR;REVISIONS;SOCS;QUALIFIERS")
+  set(multi_val  "DIR;REVISIONS;SOCS;SOC_REQUIRES;QUALIFIERS")
   cmake_parse_arguments(LIST_BOARD "" "${single_val}" "${multi_val}" ${ret_board})
   list(GET LIST_BOARD_DIR 0 BOARD_DIR)
   set(BOARD_DIR ${BOARD_DIR} CACHE PATH "Main board directory for board (${BOARD})" FORCE)

--- a/cmake/modules/hwm_v2.cmake
+++ b/cmake/modules/hwm_v2.cmake
@@ -43,10 +43,48 @@ list(APPEND ARCH_ROOT ${ZEPHYR_BASE})
 list(TRANSFORM ARCH_ROOT PREPEND "--arch-root=" OUTPUT_VARIABLE arch_root_args)
 list(TRANSFORM SOC_ROOT PREPEND "--soc-root=" OUTPUT_VARIABLE soc_root_args)
 
+# Only the SoC being targeted is loaded into the build system, together with any SoC listed in
+# the 'requires' property of its soc.yml entry. This keeps the SoC namespace isolated: a build
+# only sees the Kconfig symbols and CMake variables of the SoC trees it actually needs, which
+# also cuts CMake configuration time and memory usage significantly.
+#
+# A SoC which is defined in terms of a SoC owned by another soc.yml tree, such as a SiP wrapping
+# a die from another vendor, must opt in to seeing that tree, for example:
+#
+#   socs:
+#     - name: <sip>
+#       requires:
+#         - <die>
+#
+# A board which pairs SoC trees that are independent of each other, such as a simulated board
+# built on one SoC while using the Kconfig of the SoC it simulates, declares the extra trees the
+# same way in its board.yml:
+#
+#   boards:
+#     - name: <board>
+#       socs:
+#         - name: <soc>
+#       requires:
+#         - <other-soc>
+#
+# Setting HWM_LOAD_ALL_SOCS loads every SoC from every SoC root instead, restoring the legacy
+# behaviour where all SoC namespaces are visible to each other. This is an escape hatch for
+# out-of-tree users who cannot express their dependencies with 'requires' yet, and comes at the
+# cost of the configuration time and memory usage mentioned above.
+if(HWM_LOAD_ALL_SOCS OR NOT BOARD_QUALIFIERS)
+  set(soc_filter --socs)
+else()
+  string(REPLACE "/" ";" split_board_qualifiers ";${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(soc_filter --soc ${target_soc})
+  foreach(soc ${LIST_BOARD_SOC_REQUIRES})
+    list(APPEND soc_filter --soc ${soc})
+  endforeach()
+endif()
+
 execute_process(COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/list_hardware.py
                 ${arch_root_args} ${soc_root_args}
-                --archs --socs
-                --cmakeformat={TYPE}\;{NAME}\;{DIR}
+                --archs ${soc_filter} --cmakeformat={TYPE}\;{NAME}\;{DIR}
                 OUTPUT_VARIABLE ret_hw
                 ERROR_VARIABLE err_hw
                 RESULT_VARIABLE ret_val

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -364,6 +364,33 @@ If multiple boards are placed in the same board folder, then the file
      ...
    ...
 
+.. _board_porting_requires:
+
+Boards pairing several SoC trees
+================================
+
+A build loads the Kconfig and CMake trees of the SoC that the board target selects. It also loads
+the trees of any SoC listed in that board's ``requires`` property:
+
+.. code-block:: yaml
+
+   boards:
+   - name: <board-name>
+     vendor: <board-vendor>
+     socs:
+     - name: <soc>
+     requires:
+     - <other-soc>
+
+Each entry names a SoC as it is written in a :file:`soc.yml` file, not a Kconfig symbol. The SoC
+may come from any SoC root. Anything that SoC requires in turn is loaded as well.
+
+Only add this property when the board cannot be built without the extra tree. A board whose SoC
+is described completely by its own :file:`soc.yml` entry does not need it, and neither does a
+board whose SoC already declares what it depends on, which is covered by
+:ref:`soc_porting_requires`. This property exists for cases where a board combines multiple SoCs which
+have no relationship to each other outside that board, such as a simulated board built on one SoC
+
 
 .. _default_board_configuration:
 

--- a/doc/hardware/porting/soc_porting.rst
+++ b/doc/hardware/porting/soc_porting.rst
@@ -90,8 +90,9 @@ The mandatory files are:
    the Kconfig ``SOC`` setting.
    If the ``soc.yml`` describes a SoC family and series, then those must also
    be defined in this file. Kconfig settings outside of the SoC tree must not be
-   selected. To select general Zephyr Kconfig settings the :file:`Kconfig` file
-   must be used.
+   selected, unless the SoC tree they belong to has been declared with the
+   ``requires`` property, see :ref:`soc_porting_requires`. To select general
+   Zephyr Kconfig settings the :file:`Kconfig` file must be used.
 
 #. :file:`CMakeLists.txt`: CMake file loaded by the Zephyr build system. This
    CMake file can define additional include paths and/or source files to be used
@@ -140,6 +141,39 @@ Multiple SoCs and SoC series in a common folder can be described in the
              - name: <soc2>
          - name: <series-2-name>
            ...
+
+.. _soc_porting_requires:
+
+SoCs requiring other SoC trees
+==============================
+
+A build only loads the Kconfig and CMake trees of the SoC it targets, so the Kconfig symbols and
+CMake variables of every other SoC are invisible to it. This keeps SoC namespaces isolated from
+each other and keeps the configuration step fast, as the SoC trees of unrelated vendors are never
+parsed.
+
+Some SoC definitions are, however, written in terms of another SoC that lives in a different
+:file:`soc.yml` tree. The typical case is a System-in-Package (SiP), which Zephyr currently models
+as a SoC: the SiP is the part the user sees on the board, while the die inside it is a SoC
+maintained in another vendor's tree. Such a SoC must declare the SoCs it needs with the
+``requires`` property:
+
+.. code-block:: yaml
+
+   socs:
+     - name: <sip>
+       requires:
+         - <die>
+
+The build system then loads the trees of ``<sip>`` and ``<die>``, and of anything ``<die>`` itself
+requires. Nothing else is loaded.
+
+Each entry names a SoC as it is written in a :file:`soc.yml` file, not a Kconfig symbol. The SoC
+may come from any SoC root. Referencing a SoC that cannot be found is an error.
+
+Only declare a ``requires`` entry when the SoC definition cannot stand on its own. It is not
+needed by a SoC that selects a symbol from a SoC in the *same* :file:`soc.yml` tree, which is how
+SoC variants within a vendor tree are normally described.
 
 
 Write your SoC devicetree

--- a/doc/hardware/porting/soc_porting.rst
+++ b/doc/hardware/porting/soc_porting.rst
@@ -175,6 +175,17 @@ Only declare a ``requires`` entry when the SoC definition cannot stand on its ow
 needed by a SoC that selects a symbol from a SoC in the *same* :file:`soc.yml` tree, which is how
 SoC variants within a vendor tree are normally described.
 
+When the pairing is a property of a single board rather than of the SoC, declare it in that
+board's :file:`board.yml` instead, see :ref:`board_porting_requires`.
+
+.. note::
+
+   As a last resort, setting the CMake variable ``HWM_LOAD_ALL_SOCS`` loads every SoC from every
+   SoC root, for example ``west build -b <board> -- -DHWM_LOAD_ALL_SOCS=y``. This restores the
+   legacy behaviour where all SoC trees are visible to each other, at the cost of a slower and
+   more memory hungry configuration step. It exists for out-of-tree users who cannot express their
+   dependencies with ``requires`` yet and should not be relied on by in-tree SoCs.
+
 
 Write your SoC devicetree
 *************************

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -42,6 +42,15 @@ Build System
   :kconfig:option:`CONFIG_SOC`, :kconfig:option:`CONFIG_SOC_SERIES`,
   :kconfig:option:`CONFIG_SOC_FAMILY` and ``SOC_FULL_DIR``.
 
+* A build now only loads the Kconfig and CMake trees of the SoC it targets, instead of the trees of
+  every SoC in every SoC root. A SoC whose definition refers to a SoC from another :file:`soc.yml`
+  tree, such as a SiP modelled as a SoC wrapping a die from another vendor, must now declare that
+  dependency with the ``requires`` property in its :file:`soc.yml` entry, see
+  :ref:`soc_porting_requires`. A board that pairs two otherwise independent SoC trees declares the
+  same property in its :file:`board.yml`, see :ref:`board_porting_requires`. As a temporary escape
+  hatch, setting the CMake variable ``HWM_LOAD_ALL_SOCS`` restores the previous behaviour of
+  loading all SoC trees.
+
 Kernel
 ******
 

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -108,6 +108,8 @@ class Board:
     revisions: list[str] = field(default_factory=list, compare=False)
     socs: list[Soc] = field(default_factory=list, compare=False)
     variants: list[str] = field(default_factory=list, compare=False)
+    # Names of SoCs whose trees must be loaded in addition to the one the board target selects.
+    requires: list[str] = field(default_factory=list, compare=False)
 
     @property
     def dir(self):
@@ -195,6 +197,7 @@ def load_v2_boards(board_name, board_yml, systems):
                            board.get('revision', {}).get('revisions', [])],
                 socs=socs,
                 variants=[Variant.from_dict(v) for v in board.get('variants', [])],
+                requires=list(board.get('requires', [])),
                 hwm='v2',
             )
             board_qualifiers = board_v2_qualifiers(boards[board['name']])
@@ -213,6 +216,7 @@ def extend_v2_boards(boards, board_extensions):
         if board is None:
             continue
         board.directories.append(e['dir'])
+        board.requires.extend(r for r in e.get('requires', []) if r not in board.requires)
 
         for v in e.get('variants', []):
             node = board.from_qualifier(v['qualifier'])
@@ -347,6 +351,7 @@ def dump_v2_boards(args):
                 REVISIONS='REVISIONS;' + ';'.join(
                           [x.name for x in b.revisions]),
                 SOCS='SOCS;' + ';'.join([s.name for s in b.socs]),
+                SOC_REQUIRES='SOC_REQUIRES;' + ';'.join(b.requires),
                 QUALIFIERS='QUALIFIERS;' + ';'.join(qualifiers_list)
             )
             print(info)

--- a/scripts/list_hardware.py
+++ b/scripts/list_hardware.py
@@ -179,7 +179,7 @@ class Systems:
         leave their CMake variables out of sync with the Kconfig that is loaded for them anyway,
         which breaks any SoC whose CONFIG_SOC resolves to a sibling in the same tree.
         '''
-        folders = {f for name in names for f in self.get_soc(name).folder}
+        folders = {f for s in self.get_soc_closure(names) for f in s.folder}
         return (
             [s for s in self._socs if folders.intersection(s.folder)],
             [s for s in self._series if folders.intersection(s.folder)],
@@ -192,6 +192,35 @@ class Systems:
         except StopIteration:
             sys.exit(f"ERROR: SoC '{name}' is not found, please ensure that the SoC exists "
                      f"and that soc-root containing '{name}' has been correctly defined.")
+
+    def get_soc_closure(self, names):
+        '''Return the given SoCs together with the transitive closure of the SoCs they list in
+        the 'requires' property of their soc.yml entry.
+
+        The SoC trees of all returned SoCs must be loaded by the build system for the given
+        SoCs to be usable.
+        '''
+        socs = []
+        seen = set()
+        pending = [(name, None) for name in names]
+
+        while pending:
+            soc_name, required_by = pending.pop(0)
+            if soc_name in seen:
+                continue
+            seen.add(soc_name)
+
+            soc = next((s for s in self._socs if s.name == soc_name), None)
+            if soc is None:
+                required_by_msg = f", required by SoC '{required_by}'," if required_by else ''
+                sys.exit(f"ERROR: SoC '{soc_name}'{required_by_msg} is not found, please ensure "
+                         f"that the SoC exists and that soc-root containing '{soc_name}' has "
+                         "been correctly defined.")
+
+            socs.append(soc)
+            pending.extend((r, soc_name) for r in soc.requires)
+
+        return socs
 
 
 @dataclass

--- a/scripts/list_hardware.py
+++ b/scripts/list_hardware.py
@@ -167,6 +167,22 @@ class Systems:
     def get_extended_socs(self):
         return self._extended_socs
 
+    def get_loaded_trees(self, names):
+        '''Return the SoCs, series and families described by the soc.yml trees holding the given
+        SoCs.
+
+        The unit the build system loads is the soc.yml tree, not the individual SoC, so a lookup
+        must report everything a selected tree describes. Reporting only the SoCs asked for would
+        leave their CMake variables out of sync with the Kconfig that is loaded for them anyway,
+        which breaks any SoC whose CONFIG_SOC resolves to a sibling in the same tree.
+        '''
+        folders = {f for name in names for f in self.get_soc(name).folder}
+        return (
+            [s for s in self._socs if folders.intersection(s.folder)],
+            [s for s in self._series if folders.intersection(s.folder)],
+            [f for f in self._families if folders.intersection(f.folder)],
+        )
+
     def get_soc(self, name):
         try:
             return next(s for s in self._socs if s.name == name)
@@ -313,9 +329,6 @@ def dump_v2_archs(args):
 
 
 def dump_v2_system(args, type, system):
-    if args.soc is not None and system.name != args.soc:
-        return
-
     if args.soc_family is not None and (type != "soc" or system.family is None or \
        system.family != args.soc_family):
         return
@@ -359,13 +372,20 @@ def dump_v2_system(args, type, system):
 def dump_v2_systems(args):
     systems = find_v2_systems(args)
 
-    for f in systems.get_families():
+    if args.soc is not None:
+        socs, series, families = systems.get_loaded_trees([args.soc])
+    else:
+        socs = systems.get_socs()
+        families = systems.get_families()
+        series = systems.get_series()
+
+    for f in families:
         dump_v2_system(args, 'family', f)
 
-    for s in systems.get_series():
+    for s in series:
         dump_v2_system(args, 'series', s)
 
-    for s in systems.get_socs():
+    for s in socs:
         dump_v2_system(args, 'soc', s)
 
 

--- a/scripts/list_hardware.py
+++ b/scripts/list_hardware.py
@@ -315,7 +315,8 @@ def add_args(parser):
     parser.add_argument("--soc-root", dest='soc_roots', default=[],
                         type=Path, action='append',
                         help='add a SoC root, may be given more than once')
-    parser.add_argument("--soc", default=None, help='lookup the specific soc')
+    parser.add_argument("--soc", dest='socs_lookup', default=[], action='append',
+                        help='lookup the specific soc, may be given more than once')
     parser.add_argument("--soc-series", default=None, help='lookup the specific soc series')
     parser.add_argument("--soc-family", default=None, help='lookup the specific family')
     parser.add_argument("--socs", action='store_true', help='lookup all socs')
@@ -408,8 +409,8 @@ def dump_v2_system(args, type, system):
 def dump_v2_systems(args):
     systems = find_v2_systems(args)
 
-    if args.soc is not None:
-        socs, series, families = systems.get_loaded_trees([args.soc])
+    if args.socs_lookup:
+        socs, series, families = systems.get_loaded_trees(args.socs_lookup)
     else:
         socs = systems.get_socs()
         families = systems.get_families()
@@ -427,7 +428,7 @@ def dump_v2_systems(args):
 
 if __name__ == '__main__':
     args = parse_args()
-    if any([args.socs, args.soc, args.soc_series, args.soc_family]):
+    if any([args.socs, args.socs_lookup, args.soc_series, args.soc_family]):
         dump_v2_systems(args)
     if args.archs or args.arch is not None:
         dump_v2_archs(args)

--- a/scripts/list_hardware.py
+++ b/scripts/list_hardware.py
@@ -6,7 +6,7 @@
 import argparse
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePath
 
 import jsonschema
@@ -62,7 +62,8 @@ class Systems:
                 series = Series(s['name'], [folder], f['name'], [])
                 socs = [(Soc(soc['name'],
                              [c['name'] for c in soc.get('cpuclusters', [])],
-                             [folder], s['name'], f['name']))
+                             [folder], s['name'], f['name'],
+                             list(soc.get('requires', []))))
                         for soc in s.get('socs', [])]
                 series.socs.extend(socs)
                 self._series.append(series)
@@ -71,7 +72,8 @@ class Systems:
                 family.socs.extend(socs)
             socs = [(Soc(soc['name'],
                          [c['name'] for c in soc.get('cpuclusters', [])],
-                         [folder], None, f['name']))
+                         [folder], None, f['name'],
+                         list(soc.get('requires', []))))
                     for soc in f.get('socs', [])]
             self._socs.extend(socs)
             self._families.append(family)
@@ -80,7 +82,8 @@ class Systems:
             series = Series(s['name'], [folder], '', [])
             socs = [(Soc(soc['name'],
                          [c['name'] for c in soc.get('cpuclusters', [])],
-                         [folder], s['name'], ''))
+                         [folder], s['name'], '',
+                         list(soc.get('requires', []))))
                     for soc in s.get('socs', [])]
             series.socs.extend(socs)
             self._series.append(series)
@@ -89,11 +92,11 @@ class Systems:
         for soc in data.get('socs', []):
             if soc.get('name') is not None:
                 self._socs.append(Soc(soc['name'], [c['name'] for c in soc.get('cpuclusters', [])],
-                                  [folder], '', ''))
+                                  [folder], '', '', list(soc.get('requires', []))))
             elif soc.get('extend') is not None:
                 self._extended_socs.append(Soc(soc['extend'],
                                            [c['name'] for c in soc.get('cpuclusters', [])],
-                                           [folder], '', ''))
+                                           [folder], '', '', list(soc.get('requires', []))))
             else:
                 # This should not happen if schema validation passed
                 sys.exit(f'ERROR: Malformed "socs" section in SoC file: {soc_yaml}\n'
@@ -198,11 +201,15 @@ class Soc:
     folder: list[str]
     series: str = ''
     family: str = ''
+    # Names of other SoCs whose Kconfig and CMake trees must be loaded together with this SoC,
+    # for example when a SiP is described as a SoC wrapping a die maintained in another SoC tree.
+    requires: list[str] = field(default_factory=list)
 
     def extend(self, soc):
         if self.name == soc.name:
             self.cpuclusters.extend(soc.cpuclusters)
             self.folder.extend(soc.folder)
+            self.requires.extend(r for r in soc.requires if r not in self.requires)
 
 
 @dataclass

--- a/scripts/schemas/board-schema.yaml
+++ b/scripts/schemas/board-schema.yaml
@@ -64,6 +64,15 @@ $defs:
       vendor:
         type: string
         description: SoC family of the SoC on the board.
+      requires:
+        type: array
+        description: |
+          Names of SoCs whose Kconfig and CMake trees must be loaded in addition to the tree of
+          the SoC the board target selects. Use this when a board pairs SoC trees that are
+          independent of each other, such as a simulated board built on one SoC while using the
+          Kconfig of the SoC it simulates.
+        items:
+          type: string
       revision:
         type: object
         properties:

--- a/scripts/schemas/soc-schema.yaml
+++ b/scripts/schemas/soc-schema.yaml
@@ -30,6 +30,14 @@ $defs:
         type: array
         items:
           $ref: "#/$defs/cpucluster"
+      requires:
+        type: array
+        description: |
+          Names of other SoCs whose Kconfig and CMake trees must be loaded together with this
+          SoC. Use this when a SoC definition refers to symbols owned by a SoC maintained in a
+          different soc.yml tree, for example a SiP wrapping a die from another vendor.
+        items:
+          type: string
     required:
       - name
     additionalProperties: false
@@ -45,6 +53,14 @@ $defs:
             type: array
             items:
               $ref: "#/$defs/cpucluster"
+          requires:
+            type: array
+            description: |
+              Names of other SoCs whose Kconfig and CMake trees must be loaded together with this
+              SoC. Use this when a SoC definition refers to symbols owned by a SoC maintained in a
+              different soc.yml tree, for example a SiP wrapping a die from another vendor.
+            items:
+              type: string
         required:
           - name
         additionalProperties: false
@@ -57,6 +73,14 @@ $defs:
             type: array
             items:
               $ref: "#/$defs/cpucluster"
+          requires:
+            type: array
+            description: |
+              Names of other SoCs whose Kconfig and CMake trees must be loaded together with this
+              SoC. Use this when a SoC definition refers to symbols owned by a SoC maintained in a
+              different soc.yml tree, for example a SiP wrapping a die from another vendor.
+            items:
+              type: string
         required:
           - extend
         additionalProperties: false

--- a/scripts/tests/hardware/test_list_hardware.py
+++ b/scripts/tests/hardware/test_list_hardware.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the SoC lookup logic in scripts/list_hardware.py: the resolution of the 'requires'
+property which lets a SoC pull in the SoC trees it is defined in terms of, and the selection of
+the soc.yml trees a lookup reports.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ZEPHYR_BASE = Path(__file__).parents[3]
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts'))
+
+from list_hardware import Systems  # noqa: E402
+
+VENDOR_A = '''
+family:
+  - name: family_a
+    series:
+      - name: series_a
+        socs:
+          - name: soc_a
+          - name: soc_a2
+'''
+
+VENDOR_B = '''
+socs:
+  - name: sip_b
+    requires:
+      - soc_a
+'''
+
+VENDOR_C = '''
+socs:
+  - name: sip_c
+    requires:
+      - sip_b
+'''
+
+
+def load(*yamls):
+    systems = Systems()
+    for folder, soc_yaml in yamls:
+        systems.extend(Systems(folder, soc_yaml))
+    return systems
+
+
+def names(socs):
+    return [s.name for s in socs]
+
+
+def test_closure_of_soc_without_requires():
+    systems = load(('vendor_a', VENDOR_A))
+    assert names(systems.get_soc_closure(['soc_a'])) == ['soc_a']
+
+
+def test_closure_pulls_in_required_soc():
+    systems = load(('vendor_a', VENDOR_A), ('vendor_b', VENDOR_B))
+    closure = systems.get_soc_closure(['sip_b'])
+    assert names(closure) == ['sip_b', 'soc_a']
+    assert sorted(f for s in closure for f in s.folder) == ['vendor_a', 'vendor_b']
+
+
+def test_closure_is_transitive():
+    systems = load(('vendor_a', VENDOR_A), ('vendor_b', VENDOR_B), ('vendor_c', VENDOR_C))
+    assert names(systems.get_soc_closure(['sip_c'])) == ['sip_c', 'sip_b', 'soc_a']
+
+
+def test_closure_does_not_pull_in_unrelated_socs():
+    systems = load(('vendor_a', VENDOR_A), ('vendor_b', VENDOR_B))
+    assert 'soc_a2' not in names(systems.get_soc_closure(['sip_b']))
+
+
+def test_closure_of_cyclic_requires_terminates():
+    cyclic_x = 'socs:\n  - name: soc_x\n    requires:\n      - soc_y\n'
+    cyclic_y = 'socs:\n  - name: soc_y\n    requires:\n      - soc_x\n'
+    systems = load(('vendor_x', cyclic_x), ('vendor_y', cyclic_y))
+    assert names(systems.get_soc_closure(['soc_x'])) == ['soc_x', 'soc_y']
+
+
+def test_closure_of_unknown_required_soc_errors_out():
+    systems = load(('vendor_b', VENDOR_B))
+    with pytest.raises(SystemExit) as exc:
+        systems.get_soc_closure(['sip_b'])
+    assert "required by SoC 'sip_b'" in str(exc.value)
+
+
+def test_requires_can_be_added_by_extending_a_soc():
+    extension = 'socs:\n  - extend: soc_a\n    requires:\n      - soc_a2\n'
+    systems = load(('vendor_a', VENDOR_A), ('vendor_ext', extension))
+    assert names(systems.get_soc_closure(['soc_a'])) == ['soc_a', 'soc_a2']
+
+
+def test_loaded_trees_report_the_whole_tree():
+    # A tree is loaded whole, so a lookup of soc_a must also report its siblings, otherwise a
+    # SoC whose CONFIG_SOC resolves to soc_a2 would have no SOC_<name>_DIR.
+    systems = load(('vendor_a', VENDOR_A))
+    socs, series, families = systems.get_loaded_trees(['soc_a'])
+    assert names(socs) == ['soc_a', 'soc_a2']
+    assert names(series) == ['series_a']
+    assert names(families) == ['family_a']
+
+
+def test_loaded_trees_follow_requires_across_trees():
+    systems = load(('vendor_a', VENDOR_A), ('vendor_b', VENDOR_B), ('vendor_c', VENDOR_C))
+    socs, _, families = systems.get_loaded_trees(['sip_c'])
+    # sip_c requires sip_b which requires soc_a, so all three trees are reported whole.
+    assert set(names(socs)) == {'sip_c', 'sip_b', 'soc_a', 'soc_a2'}
+    assert names(families) == ['family_a']
+
+
+def test_loaded_trees_of_an_independent_soc_pull_in_nothing_else():
+    systems = load(('vendor_a', VENDOR_A), ('vendor_b', VENDOR_B))
+    socs, _, families = systems.get_loaded_trees(['soc_a'])
+    assert 'sip_b' not in names(socs)
+    assert names(families) == ['family_a']

--- a/scripts/tests/hardware/test_list_hardware.py
+++ b/scripts/tests/hardware/test_list_hardware.py
@@ -89,6 +89,16 @@ def test_closure_of_unknown_required_soc_errors_out():
     assert "required by SoC 'sip_b'" in str(exc.value)
 
 
+def test_closure_accepts_several_starting_socs():
+    systems = load(('vendor_a', VENDOR_A), ('vendor_b', VENDOR_B))
+    assert names(systems.get_soc_closure(['soc_a2', 'sip_b'])) == ['soc_a2', 'sip_b', 'soc_a']
+
+
+def test_closure_deduplicates_across_starting_socs():
+    systems = load(('vendor_a', VENDOR_A), ('vendor_b', VENDOR_B))
+    assert names(systems.get_soc_closure(['sip_b', 'soc_a'])) == ['sip_b', 'soc_a']
+
+
 def test_requires_can_be_added_by_extending_a_soc():
     extension = 'socs:\n  - extend: soc_a\n    requires:\n      - soc_a2\n'
     systems = load(('vendor_a', VENDOR_A), ('vendor_ext', extension))

--- a/soc/antmicro/myra/soc.yml
+++ b/soc/antmicro/myra/soc.yml
@@ -1,2 +1,6 @@
 socs:
   - name: myra
+    # The Myra is a SiP built around an STMicroelectronics STM32G491RE die, so the STM32 SoC
+    # tree has to be loaded together with this one.
+    requires:
+      - stm32g491xx

--- a/soc/arm/beetle/soc.yml
+++ b/soc/arm/beetle/soc.yml
@@ -1,4 +1,0 @@
-series:
-- name: beetle
-  socs:
-  - name: beetle_r0

--- a/soc/arm/soc.yml
+++ b/soc/arm/soc.yml
@@ -30,6 +30,9 @@ family:
     socs:
     - name: designstart_fpga_cortex_m1
     - name: designstart_fpga_cortex_m3
+  - name: beetle
+    socs:
+    - name: beetle_r0
 - name: arm64
   series:
   - name: fvp_aem

--- a/soc/oct/osd32mp15x/soc.yml
+++ b/soc/oct/osd32mp15x/soc.yml
@@ -1,2 +1,6 @@
 socs:
   - name: osd32mp15x
+    # The OSD32MP15x is a SiP built around an STMicroelectronics STM32MP15x die, so the STM32
+    # SoC tree has to be loaded together with this one.
+    requires:
+      - stm32mp157cxx

--- a/tests/bluetooth/controller/ctrl_api/Kconfig
+++ b/tests/bluetooth/controller/ctrl_api/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_chmu/Kconfig
+++ b/tests/bluetooth/controller/ctrl_chmu/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_cis_create/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cis_create/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_cis_terminate/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_collision/Kconfig
+++ b/tests/bluetooth/controller/ctrl_collision/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_conn_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_conn_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_cte_req/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cte_req/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_data_length_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_data_length_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_encrypt/Kconfig
+++ b/tests/bluetooth/controller/ctrl_encrypt/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_feature_exchange/Kconfig
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_hci/Kconfig
+++ b/tests/bluetooth/controller/ctrl_hci/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_invalid/Kconfig
+++ b/tests/bluetooth/controller/ctrl_invalid/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_le_ping/Kconfig
+++ b/tests/bluetooth/controller/ctrl_le_ping/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_min_used_chans/Kconfig
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_periodic_sync/Kconfig
+++ b/tests/bluetooth/controller/ctrl_periodic_sync/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_phy_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_phy_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_sca_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_sca_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_terminate/Kconfig
+++ b/tests/bluetooth/controller/ctrl_terminate/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/Kconfig
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_tx_queue/Kconfig
+++ b/tests/bluetooth/controller/ctrl_tx_queue/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_unsupported/Kconfig
+++ b/tests/bluetooth/controller/ctrl_unsupported/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_version/Kconfig
+++ b/tests/bluetooth/controller/ctrl_version/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT


### PR DESCRIPTION
A build currently loads the Kconfig and CMake trees of **every** SoC in every SoC root, so an
nRF52 build parses the STM32, NXP, Espressif and Intel trees it will never use. This series
loads only the tree of the SoC the board target selects.

The blocker for doing that has been the two SiPs modelled as SoCs, `osd32mp15x` and `myra`,
whose Kconfig reaches into the STMicroelectronics tree. Rather than removing them, this series
lets a SoC **declare** the trees it is defined in terms of:

```yaml
# soc/oct/osd32mp15x/soc.yml
socs:
  - name: osd32mp15x
    requires:
      - stm32mp157cxx
```

The build system resolves that transitively and loads exactly those trees, so the SiPs keep
working, `soc/st` still has zero visibility of `soc/nordic`, and the dependency is explicit and
reviewable instead of implicit in "everything is loaded anyway".

Boards get the same property, for the case where the pairing belongs to the board rather than to
either SoC. The BabbleSim boards are the in-tree example: they build on the `native` SoC while
using the Kconfig of the Nordic SoC they simulate.

```yaml
# boards/native/nrf_bsim/board.yml
- name: nrf5340bsim
  socs:
  - name: nrf5340
  requires:
  - native
```

`HWM_LOAD_ALL_SOCS` restores the old behaviour (`-DHWM_LOAD_ALL_SOCS=y`) as an escape hatch for
out-of-tree users who cannot express their dependencies yet. It is documented as not for in-tree
use.

This reinstates cf15ee1fa63e ("cmake: modules: hwm_v2: Narrowly load a SoC target"), reverted in
94f0908052ee, on top of the tree fixes and the `requires` mechanism the earlier attempt was
missing.

## Results

Configuring `hello_world` for `nrf52840dk/nrf52840`:

| | before | after |
|---|---|---|
| SoC Kconfig trees sourced | 136 | 1 |
| Kconfig files parsed | 4964 | 3337 |
| configure wall time | 5.43 s | 4.91 s (**-9.6%**) |
| peak configure RSS | 169 MB | 96 MB (**-43%**) |

Across seven boards the configure step is 5-14% faster and uses 42-67% less memory; the worst
case before was `frdm_k64f` at 621 MB peak, now 203 MB. The two SiP boards land in the same band
as everything else — `myra_sip_baseboard` parses 125 SoC Kconfig files against a plain STM32
board's 123, so declaring the extra tree costs exactly the SiP wrapper's own two files.

## Latent bugs this exposes

Narrow loading turns "my SoC tree accidentally depends on another vendor's" from invisible into a
build failure. Four such dependencies existed in tree and are fixed here:

- **`soc/arm/beetle`** carried its own `soc.yml` although it sits inside `soc/arm` and is already
  reached from there, so it was a separate tree that had to be loaded alongside `soc/arm` for
  `SOC_FAMILY_ARM`. It is now described as a series of the arm family. Without this, `v2m_beetle`
  silently lost `CONFIG_SOC_FAMILY="arm"`.
- **`soc/renesas/rz` and `soc/renesas/smartbond/da1469x`** derive `FLASH_BASE_ADDRESS` and
  `FLASH_SIZE` from `$(DT_CHOSEN_Z_FLASH)` but never assign it. `Kconfig.zephyr` assigns it only
  after the SoC defconfigs are sourced, so these trees were inheriting the assignment from an
  unrelated vendor's tree. With one tree loaded both values came out 0 and the link failed.
- **22 Bluetooth controller unit tests** fake the SoC they emulate with a typeless
  `config SOC_COMPATIBLE_NRF` + `default y`. A typeless config only assigns a value if the symbol
  is typed elsewhere, and the only place that types it is `soc/nordic/Kconfig` - so tests running
  on `unit_testing` depended on the Nordic tree being loaded.
- **`max32658`** selects `SOC_MAX32657`, so `CONFIG_SOC` resolves to a sibling of the name the
  board target selects. A lookup is therefore resolved at soc.yml **tree** granularity rather than
  per SoC, which is the granularity the build system actually loads at; otherwise
  `SOC_<name>_DIR` is undefined and `SOC_FULL_DIR` comes out empty.

Each is fixed in its own commit before the commit that switches the loading behaviour, so no
commit in the series leaves the tree broken.

## Notes for reviewers

- `requires` is deliberately neutral about what a SiP *is*, so it does not prejudge #69546 or
  #84107. It equally covers chiplets and any other SoC-referencing-SoC case, and these entries can
  be dropped if a real SiP model lands later.
- The dead `config SOC default "myra"/"osd32mp15x"` lines are removed. They were already
  unreachable: the STM32 tree is sourced first, so `CONFIG_SOC` already resolved to the die. 
  EDIT: check_compliance.py requires every SoC name in a soc.yml to appear as a default of config SOC. Removing the config SOC default "osd32mp15x" / "myra" lines broke that invariant. Need to see if this check is still relevant for this usecase and if it needs to be modifed.
- Open question: `requires` on a board is board-wide rather than per-qualifier. For the BabbleSim
  boards each entry has a single SoC so it is exact, but a multi-SoC board declaring `requires`
  would load the extra tree for all of its targets. Tightening that means threading the qualifier
  through the `list_boards.py` output; happy to do it if reviewers prefer it now.
- Also worth considering separately: moving the `DT_CHOSEN_*` assignments in `Kconfig.zephyr`
  above the SoC defconfig includes would close the Renesas class of bug permanently and let the
  ST, NXP and Realtek trees drop their local copies.

Fixes #113468

