### PR TITLE
arch: riscv: fix SMP secondary boot handshake races

### DIFF
--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -12,6 +12,7 @@
 #include <zephyr/arch/riscv/csr.h>
 #include <zephyr/arch/riscv/irq.h>
 #include "asm_macros.inc"
+#include <smp_boot.h>
 
 #ifdef CONFIG_RISCV_S_MODE
 /* mcounteren bits */
@@ -26,8 +27,7 @@ GTEXT(__reset)
 
 /* imports */
 GTEXT(z_prep_c)
-GDATA(riscv_cpu_wake_flag)
-GDATA(riscv_cpu_sp)
+GDATA(riscv_cpu_boot_slots)
 GTEXT(arch_secondary_cpu_init)
 #ifdef CONFIG_RISCV_S_MODE_INTERNAL_SBI
 GTEXT(__m_mode_sbi_handler)
@@ -213,24 +213,93 @@ s_mode_entry:
 
 boot_secondary_core:
 #if CONFIG_MP_MAX_NUM_CPUS > 1
-	la t0, riscv_cpu_wake_flag
-	li t1, -1
-	sr t1, 0(t0)
-	la t0, riscv_cpu_boot_flag
-	sr zero, 0(t0)
+	/*
+	 * Scan riscv_cpu_boot_slots[] for the slot the primary hart
+	 * published for us: wake flag set, hartid matching ours (a0).
+	 */
+	la t0, riscv_cpu_boot_slots
+	li t1, RISCV_CPU_BOOT_SLOT_SIZE * CONFIG_MP_MAX_NUM_CPUS
+	add t1, t0, t1		/* t1: end of riscv_cpu_boot_slots[] */
+	li t5, 0		/* t5: current slot index */
+#ifdef CONFIG_PM_CPU_OPS
+	/*
+	 * With PM_CPU_OPS, the platform CPU-start mechanism does not release
+	 * this hart until the primary calls pm_cpu_on(). The primary does so
+	 * after initializing BSS and publishing the boot slot, so pre-arm all
+	 * configured CPU slots (their count comes from the devicetree).
+	 */
+	li t4, -1
+#if CONFIG_MP_MAX_NUM_CPUS < __riscv_xlen
+	srli t4, t4, __riscv_xlen - CONFIG_MP_MAX_NUM_CPUS
+#endif
+#else
+	/*
+	 * t4: bitmask of armed slots. A slot is armed once it was observed
+	 * with a clear wake flag, or cleared by us after rejecting a
+	 * publication (see below). A set wake flag is accepted only on an
+	 * armed slot, i.e. it was provably stored by the primary after the
+	 * slot was last clear, which garbage (cold boot) or stale slots
+	 * (RAM retained on a warm reboot) never satisfy.
+	 */
+	li t4, 0
+#endif
 
 wait_secondary_wake_flag:
-	la t0, riscv_cpu_wake_flag
-	lr t0, 0(t0)
-	bne a0, t0, wait_secondary_wake_flag
+	lr t2, RISCV_CPU_BOOT_SLOT_WAKE_FLAG_OFF(t0)
+	beqz t2, mark_slot_seen_clear
 
-	/* Acquire fence: orders our loads after the primary's stores */
+	/*
+	 * Acquire fence: pairs with the primary's release fence of every
+	 * publication, so the loads below never read pre-publication
+	 * values once a set wake flag was observed.
+	 */
 	fence r, rw
 
-	/* Set up stack */
-	la t0, riscv_cpu_sp
-	lr sp, 0(t0)
+	lr t3, RISCV_CPU_BOOT_SLOT_HARTID_OFF(t0)
+	bne t3, a0, wait_next_slot
 
+	/* Accept the wake flag only on a slot armed earlier */
+	li t6, 1
+	sll t6, t6, t5
+	and t3, t4, t6
+	bnez t3, slot_armed
+
+	/*
+	 * Our hartid but not armed: we may have started scanning only
+	 * after the primary published. Reject this publication: clear
+	 * the wake flag ourselves and arm the slot. The primary
+	 * re-publishes once it observes the clear, and only that later
+	 * store is accepted on a later pass.
+	 */
+	sr zero, RISCV_CPU_BOOT_SLOT_WAKE_FLAG_OFF(t0)
+	or t4, t4, t6
+	j wait_next_slot
+
+slot_armed:
+	/* Our slot: set up the stack provided by the primary hart */
+	lr sp, RISCV_CPU_BOOT_SLOT_SP_OFF(t0)
+
+	/* Consume the slot so it cannot match again on a later re-boot */
+	sr zero, RISCV_CPU_BOOT_SLOT_WAKE_FLAG_OFF(t0)
+
+	/* Order the slot consume above before the boot flag store below */
+	fence w, w
+	j secondary_stack_ready
+
+mark_slot_seen_clear:
+	li t6, 1
+	sll t6, t6, t5
+	or t4, t4, t6
+
+wait_next_slot:
+	addi t0, t0, RISCV_CPU_BOOT_SLOT_SIZE
+	addi t5, t5, 1
+	bltu t0, t1, wait_secondary_wake_flag
+	la t0, riscv_cpu_boot_slots	/* wrap around to the first slot */
+	li t5, 0
+	j wait_secondary_wake_flag
+
+secondary_stack_ready:
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	/* Initialize tp early so TLS-based stack canaries work on secondary CPUs */
 	mv s2, a0		/* save hartid across TLS init calls */

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -224,6 +224,9 @@ wait_secondary_wake_flag:
 	lr t0, 0(t0)
 	bne a0, t0, wait_secondary_wake_flag
 
+	/* Acquire fence: orders our loads after the primary's stores */
+	fence r, rw
+
 	/* Set up stack */
 	la t0, riscv_cpu_sp
 	lr sp, 0(t0)

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -12,6 +12,7 @@
 #include <zephyr/arch/riscv/irq.h>
 #include <zephyr/drivers/pm_cpu_ops.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/sys/barrier.h>
 #if defined(CONFIG_RISCV_IMSIC)
 #include <zephyr/drivers/interrupt_controller/riscv_imsic.h>
 #endif
@@ -39,6 +40,9 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	riscv_cpu_sp = K_KERNEL_STACK_BUFFER(stack) + sz;
 	riscv_cpu_boot_flag = 0U;
+
+	/* Release fence: publish the handshake stores before the wake flag */
+	barrier_dsync_fence_full();
 
 #ifdef CONFIG_PM_CPU_OPS
 	if (pm_cpu_on(cpu_num, (uintptr_t)&__start)) {

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -16,15 +16,29 @@
 #if defined(CONFIG_RISCV_IMSIC)
 #include <zephyr/drivers/interrupt_controller/riscv_imsic.h>
 #endif
+#include <smp_boot.h>
 
-volatile struct {
+volatile struct riscv_cpu_boot_slot {
+	uintptr_t wake_flag;
+	uintptr_t hartid;
+	void *sp;
 	arch_cpustart_t fn;
 	void *arg;
-} riscv_cpu_init[CONFIG_MP_MAX_NUM_CPUS];
+} riscv_cpu_boot_slots[CONFIG_MP_MAX_NUM_CPUS];
 
-volatile uintptr_t __noinit riscv_cpu_wake_flag;
+BUILD_ASSERT(offsetof(struct riscv_cpu_boot_slot, wake_flag) == RISCV_CPU_BOOT_SLOT_WAKE_FLAG_OFF);
+BUILD_ASSERT(offsetof(struct riscv_cpu_boot_slot, hartid) == RISCV_CPU_BOOT_SLOT_HARTID_OFF);
+BUILD_ASSERT(offsetof(struct riscv_cpu_boot_slot, sp) == RISCV_CPU_BOOT_SLOT_SP_OFF);
+BUILD_ASSERT(offsetof(struct riscv_cpu_boot_slot, fn) == RISCV_CPU_BOOT_SLOT_FN_OFF);
+BUILD_ASSERT(offsetof(struct riscv_cpu_boot_slot, arg) == RISCV_CPU_BOOT_SLOT_ARG_OFF);
+BUILD_ASSERT(sizeof(struct riscv_cpu_boot_slot) == RISCV_CPU_BOOT_SLOT_SIZE);
+
+#if !defined(CONFIG_PM_CPU_OPS) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+/* reset.S tracks per-slot armed state in one bit per slot of a register */
+BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 8 * sizeof(uintptr_t));
+#endif
+
 volatile uintptr_t riscv_cpu_boot_flag;
-volatile void *riscv_cpu_sp;
 
 extern void __start(void);
 
@@ -35,25 +49,43 @@ void soc_interrupt_init(void);
 void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
-	riscv_cpu_init[cpu_num].fn = fn;
-	riscv_cpu_init[cpu_num].arg = arg;
-
-	riscv_cpu_sp = K_KERNEL_STACK_BUFFER(stack) + sz;
+	riscv_cpu_boot_slots[cpu_num].wake_flag = 0U;
+	riscv_cpu_boot_slots[cpu_num].hartid = _kernel.cpus[cpu_num].arch.hartid;
+	riscv_cpu_boot_slots[cpu_num].sp = K_KERNEL_STACK_BUFFER(stack) + sz;
+	riscv_cpu_boot_slots[cpu_num].fn = fn;
+	riscv_cpu_boot_slots[cpu_num].arg = arg;
 	riscv_cpu_boot_flag = 0U;
 
-	/* Release fence: publish the handshake stores before the wake flag */
+	/* Release fence: publish the slot stores before the wake flag */
 	barrier_dsync_fence_full();
+	riscv_cpu_boot_slots[cpu_num].wake_flag = 1U;
 
 #ifdef CONFIG_PM_CPU_OPS
 	if (pm_cpu_on(cpu_num, (uintptr_t)&__start)) {
+		riscv_cpu_boot_slots[cpu_num].wake_flag = 0U;
 		printk("Failed to boot secondary CPU %d\n", cpu_num);
 		return;
 	}
 #endif
 
 	while (riscv_cpu_boot_flag == 0U) {
-		riscv_cpu_wake_flag = _kernel.cpus[cpu_num].arch.hartid;
+#ifndef CONFIG_PM_CPU_OPS
+		/*
+		 * A secondary that started scanning only after the
+		 * publication above arms the slot by clearing the wake
+		 * flag itself. Re-publish once that clear becomes
+		 * visible; the flag the secondary accepts therefore
+		 * always post-dates its arming.
+		 */
+		if (riscv_cpu_boot_slots[cpu_num].wake_flag == 0U) {
+			barrier_dsync_fence_full();
+			riscv_cpu_boot_slots[cpu_num].wake_flag = 1U;
+		}
+#endif
 	}
+
+	/* Restore the slot to its clear state after the secondary consumed it */
+	riscv_cpu_boot_slots[cpu_num].wake_flag = 0U;
 }
 
 void arch_secondary_cpu_init(int hartid)
@@ -108,5 +140,5 @@ void arch_secondary_cpu_init(int hartid)
 	z_riscv_imsic_secondary_init();
 #endif /* CONFIG_RISCV_IMSIC && CONFIG_SMP */
 	soc_per_core_init_hook();
-	riscv_cpu_init[cpu_num].fn(riscv_cpu_init[cpu_num].arg);
+	riscv_cpu_boot_slots[cpu_num].fn(riscv_cpu_boot_slots[cpu_num].arg);
 }

--- a/arch/riscv/include/smp_boot.h
+++ b/arch/riscv/include/smp_boot.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Process Mission
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_ARCH_RISCV_INCLUDE_SMP_BOOT_H_
+#define ZEPHYR_ARCH_RISCV_INCLUDE_SMP_BOOT_H_
+
+/*
+ * Layout of one per-CPU boot handshake slot in riscv_cpu_boot_slots[], shared
+ * between smp.c and reset.S; pinned by BUILD_ASSERT() in smp.c.
+ */
+
+#if defined(CONFIG_64BIT)
+#define RISCV_CPU_BOOT_SLOT_REG_SIZE 8
+#else
+#define RISCV_CPU_BOOT_SLOT_REG_SIZE 4
+#endif
+
+#define RISCV_CPU_BOOT_SLOT_WAKE_FLAG_OFF 0
+#define RISCV_CPU_BOOT_SLOT_HARTID_OFF    (1 * RISCV_CPU_BOOT_SLOT_REG_SIZE)
+#define RISCV_CPU_BOOT_SLOT_SP_OFF        (2 * RISCV_CPU_BOOT_SLOT_REG_SIZE)
+#define RISCV_CPU_BOOT_SLOT_FN_OFF        (3 * RISCV_CPU_BOOT_SLOT_REG_SIZE)
+#define RISCV_CPU_BOOT_SLOT_ARG_OFF       (4 * RISCV_CPU_BOOT_SLOT_REG_SIZE)
+#define RISCV_CPU_BOOT_SLOT_SIZE          (5 * RISCV_CPU_BOOT_SLOT_REG_SIZE)
+
+#endif /* ZEPHYR_ARCH_RISCV_INCLUDE_SMP_BOOT_H_ */


### PR DESCRIPTION
## Summary

The RISC-V M-mode SMP secondary boot handshake had two races on
platforms where every hart runs from the reset vector (e.g. QEMU
virt), split into two patches:

1. **Ordering** (`arch: riscv: add memory barriers to SMP secondary boot handshake`): RISC-V uses RVWMO, so the primary's stores to the handshake data were not guaranteed visible before the wake flag store, and the secondary's loads were not ordered after matching the wake flag. Adds a release fence on the primary before the secondary is released (and before every wake flag publication) and an acquire fence on the secondary after observing a set wake flag.

2. **Data authenticity and liveness** (`arch: riscv: make SMP secondary boot handshake per-CPU`): the initial stack pointer was passed through a single global (`riscv_cpu_sp`), so a slow secondary could read a value overwritten by a later `arch_cpu_start()` for another CPU (two harts sharing one stack). Reworks the handshake into a per-CPU slot array (`riscv_cpu_boot_slots[]`) carrying wake_flag/hartid/sp/fn/arg.

   On non-`CONFIG_PM_CPU_OPS` builds, each secondary tracks armed slots in a register bitmask. A slot becomes armed after the secondary has either observed its wake flag clear or, when arriving after publication, rejected that publication by clearing the matching slot itself. The primary detects this clear and re-publishes the wake flag with release ordering. The secondary accepts only a later publication on an armed slot, after an acquire fence and a matching hartid check.

   This rejects cold-boot garbage and warm-reboot residue deterministically without relying on the secondary observing the BSS-zeroed window. It also guarantees progress for a secondary that starts scanning after the primary's initial publication. Consumed slots are restored to the clear state after the handshake completes.

## Acceptance criteria status

- [x] Ordering race fixed with release/acquire fence pair (patch 1)
- [x] Per-CPU handshake data; no shared stack possible (patch 2)
- [x] Cold-boot garbage / warm-reboot residue cannot false-match
      (armed-clear protocol; verified by gdb poison test)
- [x] Late secondary cannot miss the only acceptable publication
      (self-clear followed by conditional re-publication)
- [x] No new Kconfig options; no binding changes
- [ ] End-to-end warm reboot on QEMU: blocked by local environment
      (see Known limitations)

## Known limitations

- `CONFIG_PM_CPU_OPS` path (level trigger, publish before
  `pm_cpu_on()`) is compile-guarded only: there is no RISC-V
  PM_CPU_OPS driver in-tree, so it is untestable on current hardware/
  QEMU; the code is kept for symmetry with the pre-existing `#ifdef`.
- Local QEMU (SDK 10.0.2 and system 8.2.2) loses serial output after
  `system_reset` and the second boot stalls in console/device init
  (never reaches `arch_cpu_start`), so an end-to-end warm reboot
  cannot be demonstrated in this environment; the stale-slot scenario
  was verified deterministically via the gdb poison test instead.
- `CONFIG_MP_MAX_NUM_CPUS` is limited to XLEN on non-PM_CPU_OPS
  RISC-V SMP builds (per-slot bitmask in one register), enforced by a
  compile-time `BUILD_ASSERT`.

Fixes #113866