### PR TITLE
twister: add console monitor

### DIFF
--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -1946,6 +1946,50 @@ contain:
     Data fields captured by the ``record`` option of the
     :ref:`console harness <twister_console_harness>`, when configured.
 
+.. _twister_console_monitor:
+
+Live Run Monitoring
+*******************
+
+For long runs it can be hard to tell from the scrolling console output what
+twister is actually doing: what is queued, what each job is building or
+running right now, and which tests have already failed and why. The
+``--console-monitor`` option replaces the normal output with a live
+full-screen dashboard in the terminal for the duration of the run:
+
+.. code-block:: console
+
+   $ west twister -T tests/kernel --console-monitor
+
+The dashboard shows overall progress with pass/fail/error/filtered
+breakdowns and an estimated time to completion, the set of test instances
+currently *in flight* with the pipeline stage each one is in (``cmake``,
+``build``, ``run``, ...), and a scrollable table of every test instance in
+the plan, including statically filtered ones. Normal log output goes to
+:file:`twister.log` in the meantime.
+
+Navigation: :kbd:`Tab` cycles the table filter
+(all/active/failures/passed/queued/filtered), :kbd:`f` jumps straight to
+the failures view, and :kbd:`/` starts an incremental text search over
+instance names and failure reasons (:kbd:`Esc` clears it). Move the
+selection with the arrow keys or :kbd:`j`/:kbd:`k` and press :kbd:`Enter`
+to open the detail view for an instance: its pipeline stage timeline, the
+list of failing test cases with their reasons, and the tail of its log
+files (:kbd:`l` switches between the available logs, :kbd:`j`/:kbd:`k` or
+the arrow keys scroll, :kbd:`g`/:kbd:`G` jump to the top/end, and the view
+follows new output while pinned to the end) -- particularly useful for
+inspecting failures while the rest of the run continues.
+
+When the run finishes the dashboard stays up so failures can be inspected;
+pressing :kbd:`q` leaves it, after which reports are written and twister
+exits as usual. Pressing :kbd:`q` while the run is still going leaves the
+dashboard early and resumes the normal console output. The option requires
+an interactive terminal and is ignored otherwise (e.g. in CI).
+
+The monitor observes the run without influencing it: monitoring events are
+delivered on a best-effort basis and are dropped rather than ever delaying
+the build/run pipeline.
+
 .. _twister_test_config:
 
 Twister Configuration File

--- a/scripts/pylib/twister/twisterlib/consolemonitor.py
+++ b/scripts/pylib/twister/twisterlib/consolemonitor.py
@@ -1,0 +1,599 @@
+# vim: set syntax=python ts=4 :
+#
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Live console dashboard for a twister run (``--console-monitor``).
+
+Renders a ``top``-style curses dashboard in the terminal running twister:
+overall progress, in-flight jobs with their pipeline stage, a scrollable
+and filterable instance table, and a per-instance detail view with the
+stage timeline, failing test cases and log tails.
+
+The UI runs in a thread of the twister process and observes the run
+through :class:`LocalMonitorSource`, which reads the thread-safe state
+maintained by ``twisterlib/runmonitor.py`` -- it is strictly an observer
+and cannot influence the run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import threading
+import time
+
+# Counter line: (counter name, display label, color class).
+COUNTER_FIELDS = (
+    ('passed', 'passed', 'passed'),
+    ('failed', 'failed', 'failed'),
+    ('error', 'error', 'error'),
+    ('notrun', 'built-only', 'not run'),
+    ('skipped', 'skipped', 'skipped'),
+    ('filtered_configs', 'filtered', 'filtered'),
+)
+
+FILTERS = ('all', 'active', 'failures', 'passed', 'queued', 'filtered')
+
+
+def format_duration(seconds) -> str:
+    """Human-friendly duration: 42s / 3m 10s / 2h 05m."""
+    if seconds is None:
+        return ''
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, secs = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {secs:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes:02d}m"
+
+
+def progress_bar(counters: dict, width: int) -> str:
+    """Render an ASCII progress bar over the to-do total.
+
+    Mirrors the semantics of the console output: the denominator excludes
+    statically filtered instances.
+    """
+    total = max(0, counters.get('total', 0) - counters.get('filtered_static', 0))
+    done = max(0, counters.get('done', 0) - counters.get('filtered_static', 0))
+    width = max(10, width)
+    if total == 0:
+        return '[' + ' ' * width + ']  0/0'
+    filled = round(width * min(done, total) / total)
+    pct = int(100 * done / total)
+    return f"[{'#' * filled}{'-' * (width - filled)}] {done}/{total} ({pct}%)"
+
+
+def eta(counters: dict, elapsed: float) -> float | None:
+    """Naive remaining-time estimate from average per-instance rate."""
+    total = max(0, counters.get('total', 0) - counters.get('filtered_static', 0))
+    done = max(0, counters.get('done', 0) - counters.get('filtered_static', 0))
+    if done <= 5 or done >= total or elapsed <= 0:
+        return None
+    return elapsed * (total - done) / done
+
+
+def match_filter(row: dict, name: str) -> bool:
+    if name == 'active':
+        return bool(row.get('current_op'))
+    if name == 'failures':
+        return row.get('status') in ('failed', 'error')
+    if name == 'passed':
+        return row.get('status') == 'passed'
+    if name == 'queued':
+        return row.get('status') == 'none' and not row.get('current_op')
+    if name == 'filtered':
+        return row.get('status') in ('filtered', 'skipped')
+    return True
+
+
+def sort_rows(rows: list[dict]) -> list[dict]:
+    """Active first, then failures, then the rest, each by name."""
+    order = {
+        'failed': 1,
+        'error': 1,
+        'passed': 3,
+        'not run': 4,
+        'none': 5,
+        'skipped': 6,
+        'filtered': 7,
+    }
+
+    def key(row):
+        primary = 0 if row.get('current_op') else order.get(row.get('status'), 5)
+        return (primary, row.get('name', ''))
+
+    return sorted(rows, key=key)
+
+
+def status_cell(row: dict) -> tuple[str, str]:
+    """(text, color-class) for a row's status column."""
+    if row.get('current_op'):
+        return row['current_op'], 'running'
+    status = row.get('status') or 'none'
+    label = {'none': 'queued', 'not run': 'built'}.get(status, status)
+    return label, status
+
+
+def failing_cases(detail: dict) -> list[dict]:
+    """The test cases of an instance detail that need attention."""
+    return [
+        case
+        for case in detail.get('testcases', [])
+        if case.get('status') in ('failed', 'error', 'blocked')
+    ]
+
+
+class Snapshot:
+    """Latest data pulled from the monitor source."""
+
+    def __init__(self):
+        self.summary: dict | None = None
+        self.rows: list[dict] = []
+        self.connected = False
+        self.ever_connected = False
+
+    def poll(self, source) -> None:
+        try:
+            self.summary = source.summary()
+            self.rows = source.instances()
+            self.connected = True
+            self.ever_connected = True
+        except (OSError, ValueError, KeyError):
+            self.connected = False
+
+    def state_label(self) -> str:
+        if self.connected:
+            return (self.summary or {}).get('meta', {}).get('state', 'running').upper()
+        return 'CONNECTING...'
+
+
+class LocalMonitorSource:
+    """Reads a RunMonitor's state in-process for the console dashboard.
+
+    The MonitorState JSON methods provide the thread-safe snapshotting; the
+    UI thread never touches the state's internals directly.
+    """
+
+    MAX_TAIL = 1024 * 1024
+
+    def __init__(self, monitor):
+        self.monitor = monitor
+        self.base_url = monitor.state.meta.get('outdir', 'local run')
+
+    def summary(self) -> dict:
+        return json.loads(self.monitor.state.summary_json(self.monitor.results))
+
+    def instances(self) -> list[dict]:
+        return json.loads(self.monitor.state.instances_json())['instances']
+
+    def instance(self, name: str) -> dict:
+        payload = self.monitor.state.instance_json(name)
+        if payload is None:
+            raise KeyError(name)
+        return json.loads(payload)
+
+    def log_tail(self, name: str, fname: str, tail: int = 16 * 1024) -> str:
+        path = self.monitor.state.log_path(name, fname)
+        if path is None:
+            return ''
+        tail = max(1, min(tail, self.MAX_TAIL))
+        size = os.path.getsize(path)
+        with open(path, 'rb') as f:
+            if size > tail:
+                f.seek(size - tail)
+            data = f.read(tail)
+        if size > tail:
+            data = b'[... truncated ...]\n' + data
+        return data.decode(errors='replace')
+
+
+class ConsoleUI:
+    """Full-screen curses dashboard. All curses use is contained here."""
+
+    def __init__(self, client: LocalMonitorSource, interval: float):
+        self.client = client
+        self.interval = interval
+        self.curses = None  # the curses module, bound in run()
+        # Embedded mode: the UI runs inside the twister process itself
+        # (--console-monitor); adjusts the key hints and quit semantics.
+        self.embedded = False
+        # External request to leave the UI (e.g. the run was interrupted).
+        self.stop_requested = threading.Event()
+        self.snap = Snapshot()
+        self.filter_idx = 0
+        self.scroll = 0
+        self.selected = 0
+        self.search = ''  # substring filter over instance name + reason
+        self.search_mode = False  # '/' pressed: keys edit the search text
+        self.detail: dict | None = None  # /api/instance payload when open
+        self.detail_log: str | None = None  # current log file name
+        self.detail_log_text = ''
+        self.log_scroll = 0
+        self.last_poll = 0.0
+
+    # -- data ------------------------------------------------------------
+
+    def visible_rows(self) -> list[dict]:
+        name = FILTERS[self.filter_idx]
+        rows = [r for r in self.snap.rows if match_filter(r, name)]
+        if self.search:
+            needle = self.search.lower()
+            rows = [
+                r
+                for r in rows
+                if needle in (r.get('name', '') + ' ' + (r.get('reason') or '')).lower()
+            ]
+        return sort_rows(rows)
+
+    def poll_if_due(self) -> bool:
+        if time.monotonic() - self.last_poll < self.interval:
+            return False
+        self.last_poll = time.monotonic()
+        self.snap.poll(self.client)
+        if self.detail is not None:
+            self.refresh_detail()
+        return True
+
+    def refresh_detail(self) -> None:
+        try:
+            self.detail = self.client.instance(self.detail['name'])
+            logs = [entry['file'] for entry in self.detail.get('logs', [])]
+            if logs and self.detail_log not in logs:
+                preferred = 'handler.log' if 'handler.log' in logs else logs[0]
+                self.detail_log = preferred
+            if self.detail_log:
+                self.detail_log_text = self.client.log_tail(self.detail['name'], self.detail_log)
+        except (OSError, ValueError, KeyError):
+            pass
+
+    def open_detail(self, row: dict) -> None:
+        self.detail = {'name': row['name']}
+        self.detail_log = None
+        self.detail_log_text = ''
+        self.log_scroll = 0
+        self.refresh_detail()
+
+    def cycle_log(self) -> None:
+        logs = [entry['file'] for entry in (self.detail or {}).get('logs', [])]
+        if not logs:
+            return
+        try:
+            idx = logs.index(self.detail_log)
+        except ValueError:
+            idx = -1
+        self.detail_log = logs[(idx + 1) % len(logs)]
+        self.log_scroll = 0
+        self.refresh_detail()
+
+    # -- rendering -------------------------------------------------------
+
+    COLOR_CLASSES = (
+        'passed',
+        'failed',
+        'error',
+        'not run',
+        'skipped',
+        'filtered',
+        'running',
+        'none',
+        'header',
+    )
+
+    def init_colors(self, curses) -> dict:
+        colors = dict.fromkeys(self.COLOR_CLASSES, 0)
+        if not curses.has_colors():
+            return colors
+        curses.start_color()
+        curses.use_default_colors()
+        mapping = {
+            'passed': curses.COLOR_GREEN,
+            'failed': curses.COLOR_RED,
+            'error': curses.COLOR_RED,
+            'not run': curses.COLOR_CYAN,
+            'skipped': curses.COLOR_YELLOW,
+            'filtered': curses.COLOR_YELLOW,
+            'running': curses.COLOR_MAGENTA,
+            'none': -1,
+            'header': curses.COLOR_BLUE,
+        }
+        for i, (cls, fg) in enumerate(mapping.items(), start=1):
+            curses.init_pair(i, fg, -1)
+            colors[cls] = curses.color_pair(i)
+        return colors
+
+    def run(self) -> int:
+        import curses
+
+        self.curses = curses
+        return curses.wrapper(self._main, curses)
+
+    def _addstr(self, win, y, x, text, attr=0):
+        """addstr that clips to the window instead of raising.
+
+        curses raises when writing the bottom-right cell or during a resize
+        race; both are harmless for a redrawn-every-tick dashboard.
+        """
+        maxy, maxx = win.getmaxyx()
+        if y < 0 or y >= maxy or x >= maxx - 1:
+            return
+        with contextlib.suppress(Exception):
+            win.addstr(y, x, text[: maxx - x - 1], attr)
+
+    def _reassert_terminal_modes(self, stdscr, curses) -> None:
+        """Put the terminal back into curses mode if something disturbed it.
+
+        Test runs can spawn tools that reset the tty (echo back on,
+        canonical mode), which would make the UI stop responding to keys and
+        echo raw escape sequences instead. Cheap to re-assert, so do it on
+        every poll tick.
+        """
+        with contextlib.suppress(Exception):
+            curses.noecho()
+            curses.cbreak()
+            stdscr.keypad(True)
+            curses.curs_set(0)
+
+    def _main(self, stdscr, curses) -> int:
+        colors = self.init_colors(curses)
+        curses.curs_set(0)
+        stdscr.timeout(200)  # getch() tick; polling is time-based
+
+        while not self.stop_requested.is_set():
+            if self.poll_if_due():
+                self._reassert_terminal_modes(stdscr, curses)
+            stdscr.erase()
+            height, width = stdscr.getmaxyx()
+            self.draw_header(stdscr, curses, colors, width)
+            if self.detail is not None:
+                self.draw_detail(stdscr, colors, height, width)
+            else:
+                self.draw_table(stdscr, colors, height, width)
+            self.draw_keybar(stdscr, curses, height, width)
+            stdscr.refresh()
+
+            key = stdscr.getch()
+            if key == -1:
+                continue
+            if not self.handle_key(key, curses, height):
+                return 0
+        return 0
+
+    def draw_header(self, win, curses, colors, width) -> None:
+        summary = self.snap.summary or {}
+        counters = summary.get('counters', {})
+        meta = summary.get('meta', {})
+        state = self.snap.state_label()
+        elapsed = None
+        if meta:
+            elapsed = (meta.get('end') or summary.get('now', 0)) - meta.get('start', 0)
+        head = f" twister monitor  {self.client.base_url}  [{state}]"
+        if elapsed is not None:
+            head += f"  elapsed {format_duration(elapsed)}"
+            remaining = eta(counters, elapsed)
+            if remaining is not None and meta.get('state') == 'running':
+                head += f"  ~{format_duration(remaining)} left"
+            if counters.get('iteration', 1) > 1:
+                head += f"  iteration {counters['iteration']}"
+        self._addstr(win, 0, 0, head.ljust(width), colors['header'] | curses.A_BOLD)
+
+        self._addstr(win, 1, 1, progress_bar(counters, max(10, width - 30)))
+
+        x = 1
+        active = sum(1 for r in self.snap.rows if r.get('current_op'))
+        for field, label, cls in COUNTER_FIELDS:
+            text = f"{label}:{counters.get(field, 0)}  "
+            self._addstr(win, 2, x, text, colors.get(cls, 0))
+            x += len(text)
+        self._addstr(win, 2, x, f"in-flight:{active}", colors['running'])
+
+        tabs = '  '.join(
+            f"[{f}]" if i == self.filter_idx else f" {f} " for i, f in enumerate(FILTERS)
+        )
+        if self.search_mode:
+            tabs += f"   search: {self.search}_"
+        elif self.search:
+            tabs += f"   search: {self.search}"
+        self._addstr(win, 3, 1, tabs, curses.A_BOLD)
+
+    HEADER_LINES = 4
+    KEYBAR_LINES = 1
+    MAX_FAILING_CASES = 8
+
+    def table_height(self, height) -> int:
+        return max(1, height - self.HEADER_LINES - self.KEYBAR_LINES - 1)
+
+    def draw_table(self, win, colors, height, width) -> None:
+        rows = self.visible_rows()
+        page = self.table_height(height)
+        self.selected = max(0, min(self.selected, len(rows) - 1))
+        if self.selected < self.scroll:
+            self.scroll = self.selected
+        elif self.selected >= self.scroll + page:
+            self.scroll = self.selected - page + 1
+
+        y = self.HEADER_LINES
+        plat_w = 24
+        stat_w = 15
+        suite_w = max(20, width - plat_w - stat_w - 30)
+        header = f" {'platform':<{plat_w}} {'suite':<{suite_w}} {'status':<{stat_w}} time"
+        self._addstr(win, y, 0, header, colors['header'])
+        for i, row in enumerate(rows[self.scroll : self.scroll + page]):
+            idx = self.scroll + i
+            label, cls = status_cell(row)
+            timecol = (
+                format_duration(row.get('execution_time')) if row.get('execution_time') else ''
+            )
+            reason = row.get('reason') or ''
+            line = (
+                f" {row.get('platform', ''):<{plat_w}.{plat_w}}"
+                f" {row.get('suite', ''):<{suite_w}.{suite_w}}"
+                f" {label:<{stat_w}.{stat_w}} {timecol:<8} {reason}"
+            )
+            attr = colors.get(cls, 0)
+            if idx == self.selected:
+                attr |= self.curses.A_REVERSE
+            self._addstr(win, y + 1 + i, 0, line.ljust(width - 1), attr)
+        if not rows:
+            self._addstr(win, y + 2, 2, '(no instances match this filter)')
+
+    def draw_detail(self, win, colors, height, width) -> None:
+        detail = self.detail or {}
+        y = self.HEADER_LINES
+        label, cls = status_cell(detail)
+        self._addstr(win, y, 1, detail.get('name', ''), colors['header'])
+        line = f"status: {label}"
+        if detail.get('reason'):
+            line += f"  reason: {detail['reason']}"
+        if detail.get('retries'):
+            line += f"  retries: {detail['retries']}"
+        self._addstr(win, y + 1, 1, line, colors.get(cls, 0))
+
+        ops = detail.get('ops', [])
+        stages = '  '.join(
+            f"{o['op']}:" + (format_duration(o['duration']) if o.get('end') else '...') for o in ops
+        )
+        self._addstr(win, y + 2, 1, f"pipeline: {stages}" if stages else 'pipeline: (queued)')
+
+        cases = detail.get('testcases', [])
+        bad = failing_cases(detail)
+        self._addstr(win, y + 3, 1, f"cases: {len(cases)} total, {len(bad)} failing")
+        y += 4
+
+        # List the failing test cases with their reasons, so a failure can
+        # be understood without leaving the dashboard.
+        for case in bad[: self.MAX_FAILING_CASES]:
+            text = f"  {case['name']}"
+            if case.get('reason'):
+                text += f"  ({case['reason']})"
+            self._addstr(win, y, 1, text, colors['failed'])
+            y += 1
+        if len(bad) > self.MAX_FAILING_CASES:
+            self._addstr(
+                win,
+                y,
+                1,
+                f"  ... and {len(bad) - self.MAX_FAILING_CASES} more failing cases",
+                colors['failed'],
+            )
+            y += 1
+
+        logs = [entry['file'] for entry in detail.get('logs', [])]
+        logline = f"log: {self.detail_log or '(none)'}"
+        if len(logs) > 1:
+            logline += f"  ({'  '.join(logs)} - press l to switch)"
+        self._addstr(win, y, 1, logline, colors['header'])
+        y += 1
+
+        log_area = max(1, height - y - self.KEYBAR_LINES)
+        lines = self.detail_log_text.splitlines()
+        max_scroll = max(0, len(lines) - log_area)
+        # log_scroll counts lines up from the end of the log; 0 means the
+        # view is pinned to the tail and follows new output on refresh.
+        self.log_scroll = max(0, min(self.log_scroll, max_scroll))
+        start = max(0, len(lines) - log_area - self.log_scroll)
+        for i, text in enumerate(lines[start : start + log_area]):
+            self._addstr(win, y + i, 1, text)
+
+    def draw_keybar(self, win, curses, height, width) -> None:
+        if self.search_mode:
+            keys = " type to filter   enter apply   esc clear   backspace delete"
+            self._addstr(win, height - 1, 0, keys.ljust(width - 1), curses.A_REVERSE)
+            return
+        if self.embedded:
+            finished = (self.snap.summary or {}).get('meta', {}).get('state') == 'finished'
+            if finished:
+                quit_hint = 'q continue (write reports and exit)'
+            else:
+                quit_hint = 'q leave monitor (run continues)   ctrl-c abort run'
+        else:
+            quit_hint = 'q quit'
+        if self.detail is None:
+            keys = (
+                f" {quit_hint}   enter detail   f failures   / search"
+                "   j/k or arrows select   tab filter   r refresh"
+            )
+        else:
+            keys = (
+                f" {quit_hint}   esc back   l switch log"
+                "   j/k or arrows scroll   g/G top/end   r refresh"
+            )
+        self._addstr(win, height - 1, 0, keys.ljust(width - 1), curses.A_REVERSE)
+
+    # -- input -----------------------------------------------------------
+
+    def _handle_search_key(self, key, curses) -> None:
+        """Edit the search text while '/' input mode is active."""
+        if key in (curses.KEY_ENTER, ord('\n'), ord('\r')):
+            self.search_mode = False
+        elif key == 27:  # ESC: cancel the search entirely
+            self.search = ''
+            self.search_mode = False
+        elif key in (curses.KEY_BACKSPACE, 127, 8):
+            self.search = self.search[:-1]
+        elif 32 <= key <= 126:
+            self.search += chr(key)
+        self.selected = self.scroll = 0
+
+    def _select_failure_filter(self) -> None:
+        """Toggle between the failures view and everything."""
+        failures = FILTERS.index('failures')
+        self.filter_idx = 0 if self.filter_idx == failures else failures
+        self.selected = self.scroll = 0
+
+    def handle_key(self, key, curses, height) -> bool:
+        page = self.table_height(height)
+        if self.search_mode and self.detail is None:
+            self._handle_search_key(key, curses)
+            return True
+        if key in (ord('q'), ord('Q')):
+            return False
+        if key == ord('r'):
+            self.last_poll = 0
+        elif self.detail is None:
+            if key == ord('\t'):
+                self.filter_idx = (self.filter_idx + 1) % len(FILTERS)
+                self.selected = self.scroll = 0
+            elif key == ord('f'):
+                self._select_failure_filter()
+            elif key == ord('/'):
+                self.search_mode = True
+            elif key == 27 and self.search:  # ESC clears an applied search
+                self.search = ''
+                self.selected = self.scroll = 0
+            elif key in (curses.KEY_UP, ord('k')):
+                self.selected -= 1
+            elif key in (curses.KEY_DOWN, ord('j')):
+                self.selected += 1
+            elif key == curses.KEY_PPAGE:
+                self.selected -= page
+            elif key == curses.KEY_NPAGE:
+                self.selected += page
+            elif key in (ord('g'), curses.KEY_HOME):
+                self.selected = 0
+            elif key in (ord('G'), curses.KEY_END):
+                self.selected = len(self.visible_rows()) - 1
+            elif key in (curses.KEY_ENTER, ord('\n'), ord('\r')):
+                rows = self.visible_rows()
+                if rows:
+                    self.open_detail(rows[min(self.selected, len(rows) - 1)])
+        else:
+            if key == 27:  # ESC
+                self.detail = None
+            elif key == ord('l'):
+                self.cycle_log()
+            elif key in (curses.KEY_UP, ord('k')):
+                self.log_scroll += 1
+            elif key in (curses.KEY_DOWN, ord('j')):
+                self.log_scroll -= 1
+            elif key == curses.KEY_PPAGE:
+                self.log_scroll += page
+            elif key == curses.KEY_NPAGE:
+                self.log_scroll -= page
+            elif key in (ord('g'), curses.KEY_HOME):
+                self.log_scroll = len(self.detail_log_text.splitlines())
+            elif key in (ord('G'), curses.KEY_END):
+                self.log_scroll = 0
+        return True

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -860,6 +860,18 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
         help="Call multiple times to increase verbosity.")
 
     parser.add_argument(
+        "--console-monitor", action="store_true",
+        help="Show a live full-screen dashboard for the run in this terminal "
+             "instead of the normal scrolling output: progress, in-flight "
+             "jobs with their pipeline stage, and a filterable instance "
+             "table with per-instance details and logs. Requires an "
+             "interactive terminal (ignored otherwise). Press q to leave "
+             "the dashboard; while the run is still going, normal console "
+             "output resumes, and after it finishes, reports are written as "
+             "usual. Normal log output goes to twister.log while the "
+             "dashboard is shown.")
+
+    parser.add_argument(
         "-ll",
         "--log-level",
         type=str.upper,

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -33,6 +33,7 @@ from twisterlib import ZEPHYR_BASE
 from twisterlib.environment import strip_ansi_sequences
 from twisterlib.hardwaredata import CompoundHardwareData
 from twisterlib.platform import Platform
+from twisterlib.runmonitor import console_ui_active
 from twisterlib.statuses import TwisterStatus
 
 if TYPE_CHECKING:
@@ -406,8 +407,12 @@ class BinaryHandler(Handler):
             return
 
         stderr_log = f"{self.instance.build_dir}/handler_stderr.log"
+        # Keep the binary away from the terminal's stdin while the
+        # --console-monitor UI owns it, so it cannot steal or re-mode it.
+        stdin = subprocess.DEVNULL if console_ui_active() else None
         with open(stderr_log, "w+") as stderr_log_fp, subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=stderr_log_fp, cwd=self.build_dir, env=env
+            command, stdin=stdin, stdout=subprocess.PIPE, stderr=stderr_log_fp,
+            cwd=self.build_dir, env=env
         ) as proc:
             logger.debug(f"Spawning BinaryHandler Thread for {self.name}")
             t = threading.Thread(target=self._output_handler, args=(proc, harness,), daemon=True)
@@ -427,7 +432,10 @@ class BinaryHandler(Handler):
 
         # FIXME: This is needed when killing the simulator, the console is
         # garbled and needs to be reset. Did not find a better way to do that.
-        if sys.stdout.isatty():
+        # Must not run while the --console-monitor curses UI owns the
+        # terminal: stty sane would knock it out of cbreak/noecho mode and
+        # kill its keyboard handling.
+        if sys.stdout.isatty() and not console_ui_active():
             subprocess.call(["stty", "sane"], stdin=sys.stdout)
 
         self._update_instance_info(harness)
@@ -1211,7 +1219,9 @@ class QEMUHandler(QEMUHandlerBase):
         logger.debug(f"Spawning QEMUHandler Thread for {self.name}")
         self.thread.start()
         thread_max_time = time.time() + self.get_test_timeout()
-        if sys.stdout.isatty():
+        # See BinaryHandler._handle: never reset the terminal while the
+        # --console-monitor curses UI owns it.
+        if sys.stdout.isatty() and not console_ui_active():
             subprocess.call(["stty", "sane"], stdin=sys.stdout)
 
         logger.debug(f"Running {self.name} ({self.type_str})")
@@ -1219,9 +1229,13 @@ class QEMUHandler(QEMUHandlerBase):
         failure_type = self.FailureType.NONE
         qemu_pid = None
 
+        # As in BinaryHandler._handle: no terminal stdin for QEMU while the
+        # --console-monitor UI owns the terminal.
+        stdin = subprocess.DEVNULL if console_ui_active() else None
         with open(self.stdout_fn, "w") as stdout_fp, \
             open(self.stderr_fn, "w") as stderr_fp, subprocess.Popen(
             command,
+            stdin=stdin,
             stdout=stdout_fp,
             stderr=stderr_fp,
             cwd=self.build_dir

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -955,8 +955,13 @@ class QEMUHandlerBase(Handler):
         handler.instance.status = status
         if reason:
             handler.instance.reason = reason
-        else:
+        elif status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
             handler.instance.reason = "Unknown Error"
+        else:
+            # Not a failure (e.g. a pass): no reason to report. Clear it
+            # rather than keep it, so a stale reason from an earlier retry
+            # iteration cannot stick to a now-passing instance.
+            handler.instance.reason = None
 
     @staticmethod
     def _extend_timeout_on_status(harness):

--- a/scripts/pylib/twister/twisterlib/log_helper.py
+++ b/scripts/pylib/twister/twisterlib/log_helper.py
@@ -65,6 +65,32 @@ def setup_logging(outdir, log_file, log_level, timestamps):
     logger.addHandler(file_handler)
 
 
+def mute_console_logging():
+    '''Detach the console (stream) handlers from the twister logger.
+
+    File handlers are kept, so everything still lands in twister.log. Used
+    while a full-screen UI (--console-monitor) owns the terminal. Returns
+    the removed handlers for restore_console_logging().
+    '''
+    logger = logging.getLogger("twister")
+    muted = [
+        handler for handler in logger.handlers
+        if isinstance(handler, logging.StreamHandler)
+        and not isinstance(handler, logging.FileHandler)
+    ]
+    for handler in muted:
+        logger.removeHandler(handler)
+    return muted
+
+
+def restore_console_logging(handlers):
+    '''Re-attach handlers previously removed by mute_console_logging().'''
+    logger = logging.getLogger("twister")
+    for handler in handlers:
+        if handler not in logger.handlers:
+            logger.addHandler(handler)
+
+
 def close_logging():
     logger = logging.getLogger("twister")
     handlers = logger.handlers[:]

--- a/scripts/pylib/twister/twisterlib/runmonitor.py
+++ b/scripts/pylib/twister/twisterlib/runmonitor.py
@@ -1,0 +1,351 @@
+# vim: set syntax=python ts=4 :
+#
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Live run monitoring core for twister.
+
+The runner's worker processes emit plain-dict events (one per pipeline op
+start/completion) over a ``multiprocessing.Queue``; a drain thread in the
+main process folds them into an in-memory :class:`MonitorState` -- one row
+per test instance, initialized from the test plan so statically filtered
+instances are visible too.
+
+This module is transport-free: observers read the state in-process. The
+``--console-monitor`` dashboard (``twisterlib/consolemonitor.py``) is one
+such observer; serving the same state remotely can be layered on top.
+
+Monitoring is strictly an observer: events are emitted with ``put_nowait``
+and dropped on any queue error, so a monitor can never stall or fail the
+run itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import multiprocessing
+import os
+import queue
+import threading
+import time
+
+logger = logging.getLogger('twister')
+
+# Shared flag telling the worker processes whether the --console-monitor UI
+# currently owns the terminal. Created in the main process before the
+# workers are forked (so they inherit the shared memory) and cleared the
+# moment the UI exits, letting normal console behaviour (progress ticker,
+# terminal resets) resume immediately when the user leaves the dashboard
+# mid-run. Deliberately a module global rather than an options attribute:
+# options travels inside pickled TestInstance objects through the manager
+# queues, and multiprocessing.Value cannot be pickled that way.
+_ui_active_flag = None
+
+# ExecutionCounter attributes mirrored into the monitor summary.
+SUMMARY_COUNTERS = (
+    'total',
+    'done',
+    'iteration',
+    'passed',
+    'failed',
+    'error',
+    'skipped',
+    'filtered_configs',
+    'filtered_static',
+    'filtered_runtime',
+    'notrun',
+    'warnings',
+    'cases',
+    'filtered_cases',
+    'skipped_cases',
+    'passed_cases',
+    'notrun_cases',
+    'failed_cases',
+    'error_cases',
+    'blocked_cases',
+    'none_cases',
+    'started_cases',
+)
+
+# Only these files from an instance's build directory are exposed to
+# monitor log viewers.
+LOG_FILE_ALLOWLIST = (
+    'build.log',
+    'handler.log',
+    'device.log',
+    'twister_harness.log',
+    'valgrind.log',
+)
+
+
+def create_ui_active_flag():
+    """Arm the UI-active flag; call in the main process before forking."""
+    global _ui_active_flag
+    _ui_active_flag = multiprocessing.Value('i', 1)
+    return _ui_active_flag
+
+
+def clear_ui_active_flag() -> None:
+    """The UI exited: workers switch back to normal console behaviour."""
+    if _ui_active_flag is not None:
+        _ui_active_flag.value = 0
+
+
+def console_ui_active() -> bool:
+    """True while the --console-monitor UI owns the terminal."""
+    flag = _ui_active_flag
+    return flag is not None and flag.value == 1
+
+
+def status_str(status) -> str:
+    """Map a TwisterStatus (or raw string) to a JSON-friendly string.
+
+    TwisterStatus is a str-mixin Enum, so TwisterStatus.NONE.value is the
+    literal string 'None' -- normalize that (and empty/None) to 'none'.
+    """
+    value = getattr(status, 'value', status)
+    return value if value and value != 'None' else 'none'
+
+
+def make_event(kind: str, op: str, instance, **extra) -> dict:
+    """Serialize an instance's pipeline transition into a plain-dict event.
+
+    Runs in the worker process, so everything must reduce to picklable
+    scalars here. The final 'report' op additionally carries the per-testcase
+    results and metrics so the monitor state is complete without ever
+    touching live TestInstance objects across processes.
+    """
+    evt = {
+        'kind': kind,
+        'op': op,
+        'name': instance.name,
+        'ts': time.time(),
+        'status': status_str(instance.status),
+        'reason': instance.reason,
+    }
+    evt.update(extra)
+    if kind == 'op_done' and op == 'report':
+        evt['testcases'] = [
+            {
+                'name': tc.name,
+                'status': status_str(tc.status),
+                'reason': tc.reason,
+                'duration': tc.duration,
+            }
+            for tc in instance.testcases
+        ]
+        evt['metrics'] = {
+            k: v for k, v in instance.metrics.items() if isinstance(v, (int, float, str))
+        }
+        evt['execution_time'] = instance.execution_time
+        evt['build_time'] = instance.build_time
+        evt['retries'] = instance.retries
+    return evt
+
+
+class MonitorState:
+    """Thread-safe model of the run: one row per test instance plus metadata.
+
+    Rows are created from the test plan before execution starts (so statically
+    filtered/skipped instances are visible too) and updated exclusively by
+    apply_event(); all reads serialize to JSON under the same lock.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.rows: dict[str, dict] = {}
+        self.meta: dict = {
+            'state': 'running',
+            'start': time.time(),
+            'end': None,
+        }
+
+    def init_plan(self, instances: dict, outdir: str) -> None:
+        with self._lock:
+            self.meta['outdir'] = outdir
+            for name, instance in instances.items():
+                self.rows[name] = {
+                    'name': name,
+                    'platform': instance.platform.name,
+                    'suite': instance.testsuite.name,
+                    'toolchain': instance.toolchain,
+                    'status': status_str(instance.status),
+                    'reason': instance.reason,
+                    'run': instance.run,
+                    'build_dir': os.path.relpath(instance.build_dir, outdir),
+                    'current_op': None,
+                    'op_since': None,
+                    'ops': [],
+                    'testcases': [],
+                    'metrics': {},
+                    'execution_time': 0,
+                    'build_time': 0,
+                    'retries': 0,
+                    'updated': None,
+                }
+
+    def set_meta(self, **kwargs) -> None:
+        with self._lock:
+            self.meta.update(kwargs)
+
+    def note_iteration(self, iteration: int) -> None:
+        with self._lock:
+            self.meta['iteration'] = iteration
+
+    def finish(self) -> None:
+        with self._lock:
+            self.meta['state'] = 'finished'
+            self.meta['end'] = time.time()
+
+    def apply_event(self, evt: dict) -> None:
+        with self._lock:
+            row = self.rows.get(evt.get('name'))
+            if row is None:
+                return
+            row['status'] = evt.get('status', row['status'])
+            row['reason'] = evt.get('reason', row['reason'])
+            row['updated'] = evt.get('ts')
+            op = evt.get('op')
+            if evt.get('kind') == 'op_start':
+                row['current_op'] = op
+                row['op_since'] = evt.get('ts')
+                row['ops'].append(
+                    {
+                        'op': op,
+                        'start': evt.get('ts'),
+                        'end': None,
+                        'duration': None,
+                        'status': None,
+                    }
+                )
+            elif evt.get('kind') == 'op_done':
+                row['current_op'] = None
+                row['op_since'] = None
+                # Close the most recent open entry for this op.
+                for entry in reversed(row['ops']):
+                    if entry['op'] == op and entry['end'] is None:
+                        entry['end'] = evt.get('ts')
+                        entry['duration'] = evt.get('duration')
+                        entry['status'] = evt.get('status')
+                        break
+                for key in (
+                    'testcases',
+                    'metrics',
+                    'execution_time',
+                    'build_time',
+                    'retries',
+                ):
+                    if key in evt:
+                        row[key] = evt[key]
+
+    # Compact row: everything an instance table needs, without the
+    # potentially large ops/testcases payloads.
+    _COMPACT_FIELDS = (
+        'name',
+        'platform',
+        'suite',
+        'toolchain',
+        'status',
+        'reason',
+        'run',
+        'current_op',
+        'op_since',
+        'execution_time',
+        'retries',
+        'updated',
+    )
+
+    def instances_json(self) -> str:
+        with self._lock:
+            compact = [{k: row[k] for k in self._COMPACT_FIELDS} for row in self.rows.values()]
+            return json.dumps({'now': time.time(), 'instances': compact})
+
+    def instance_json(self, name: str) -> str | None:
+        with self._lock:
+            row = self.rows.get(name)
+            if row is None:
+                return None
+            detail = dict(row)
+            outdir = self.meta.get('outdir')
+        # Filesystem scan outside the lock; build_dir may not exist yet.
+        logs = []
+        if outdir:
+            build_dir = os.path.join(outdir, detail['build_dir'])
+            for fname in LOG_FILE_ALLOWLIST:
+                path = os.path.join(build_dir, fname)
+                if os.path.isfile(path):
+                    logs.append({'file': fname, 'size': os.path.getsize(path)})
+        detail['logs'] = logs
+        return json.dumps(detail)
+
+    def summary_json(self, results) -> str:
+        counters = {}
+        if results is not None:
+            counters = {name: getattr(results, name) for name in SUMMARY_COUNTERS}
+        with self._lock:
+            meta = dict(self.meta)
+            active = sum(1 for row in self.rows.values() if row['current_op'])
+        return json.dumps(
+            {
+                'now': time.time(),
+                'meta': meta,
+                'counters': counters,
+                'active': active,
+            }
+        )
+
+    def log_path(self, name: str, fname: str) -> str | None:
+        """Resolve a validated log file path for an instance, or None."""
+        if fname not in LOG_FILE_ALLOWLIST:
+            return None
+        with self._lock:
+            row = self.rows.get(name)
+            outdir = self.meta.get('outdir')
+        if row is None or not outdir:
+            return None
+        path = os.path.join(outdir, row['build_dir'], fname)
+        # Belt and braces: never follow a path outside the output directory.
+        if not os.path.realpath(path).startswith(os.path.realpath(outdir) + os.sep):
+            return None
+        return path if os.path.isfile(path) else None
+
+
+class RunMonitor:
+    """Owns the monitor state and the event drain thread for one run."""
+
+    def __init__(self, event_queue, results):
+        self.event_queue = event_queue
+        self.results = results
+        self.state = MonitorState()
+        self._stop = threading.Event()
+        self._threads: list[threading.Thread] = []
+
+    def start(self) -> bool:
+        drain = threading.Thread(target=self._drain, name='twister-monitor-drain', daemon=True)
+        self._threads = [drain]
+        drain.start()
+        return True
+
+    def _drain(self):
+        while not self._stop.is_set():
+            try:
+                evt = self.event_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            except (EOFError, OSError):
+                break
+            self.state.apply_event(evt)
+
+    def finish(self):
+        """Mark the run finished; observers keep working until twister exits."""
+        # Give the drain thread a moment to catch up with the tail of the
+        # event queue before declaring the final state.
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            if self.event_queue.empty():
+                break
+            time.sleep(0.1)
+        self.state.finish()
+
+    def stop(self):
+        self._stop.set()

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import traceback
 from collections import deque
@@ -56,6 +57,7 @@ from twisterlib.environment import TwisterEnv
 from twisterlib.harness import Harness, HarnessImporter
 from twisterlib.log_helper import log_command
 from twisterlib.platform import Platform
+from twisterlib.runmonitor import console_ui_active, make_event
 from twisterlib.sidecars import SidecarImporter
 from twisterlib.testinstance import TestInstance
 from twisterlib.testplan import change_skip_to_error_if_integration
@@ -1459,7 +1461,11 @@ class ProjectBuilder(FilterBuilder):
 
             if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
                 self.log_info_file(self.options.inline_logs)
-        else:
+        elif not console_ui_active():
+            # The single-line progress ticker owns stdout; skip it while the
+            # full-screen console monitor owns the terminal. The gate is the
+            # live UI flag, not the option, so the ticker resumes as soon as
+            # the user leaves the dashboard mid-run.
             completed_perc = 0
             if total_to_do > 0:
                 completed_perc = int(
@@ -1876,6 +1882,99 @@ class TwisterRunner:
         self.jobs = 1
         self.results = None
         self.jobserver = None
+        # multiprocessing.Queue carrying run-monitor events from the worker
+        # processes; stays None unless monitoring is enabled.
+        self.event_queue = None
+
+    def _emit_event(self, kind, op, instance, **extra):
+        '''Post a monitoring event; never let monitoring break the pipeline.'''
+        if self.event_queue is None:
+            return
+        with contextlib.suppress(Exception):
+            self.event_queue.put_nowait(make_event(kind, op, instance, **extra))
+
+    def _console_monitor_wanted(self):
+        '''--console-monitor requested and usable in this environment.'''
+        if getattr(self.options, 'console_monitor', False) is not True:
+            return False
+        if not (sys.stdout.isatty() and sys.stdin.isatty()):
+            logger.warning(
+                "console monitor requires an interactive terminal, "
+                "continuing with normal output"
+            )
+            return False
+        try:
+            import curses  # noqa: F401
+        except ImportError:
+            logger.warning(
+                "console monitor requires curses (unavailable on this "
+                "platform), continuing with normal output"
+            )
+            return False
+        return True
+
+    def _start_monitors(self):
+        '''Start the run monitor and console UI if --console-monitor is on.
+
+        Returns (monitor, console_ui, console_ui_thread), all None when
+        monitoring is off. The monitor and UI objects hold threads, so they
+        are deliberately NOT stored on self: self is pickled/forked into the
+        worker processes, which only need the picklable event_queue.
+        '''
+        if not self._console_monitor_wanted():
+            return None, None, None
+        from twisterlib.runmonitor import RunMonitor
+
+        self.event_queue = mp.Queue()
+        monitor = RunMonitor(self.event_queue, self.results)
+        monitor.state.init_plan(self.instances, self.options.outdir)
+        monitor.state.set_meta(
+            jobs=self.jobs,
+            version=getattr(self.env, 'version', ''),
+            iteration=1,
+        )
+        if not monitor.start():
+            self.event_queue = None
+            return None, None, None
+
+        console_ui, ui_thread = self._start_console_ui(monitor)
+        return monitor, console_ui, ui_thread
+
+    def _start_console_ui(self, monitor):
+        '''Run the console dashboard in a thread of this (main) process.
+
+        Console logging is muted while the UI owns the terminal (everything
+        still goes to twister.log) and restored when the UI exits, whether
+        the user left with 'q' or the run ended.
+        '''
+        from twisterlib.consolemonitor import ConsoleUI, LocalMonitorSource
+        from twisterlib.log_helper import mute_console_logging, restore_console_logging
+
+        ui = ConsoleUI(LocalMonitorSource(monitor), interval=1.0)
+        ui.embedded = True
+        muted = mute_console_logging()
+        # Arm the shared UI-active flag the worker processes watch: while it
+        # is set they skip the progress ticker and terminal resets. It is
+        # cleared the moment the UI exits so normal output resumes
+        # immediately, even when the user leaves the dashboard mid-run. Must
+        # be created here, before execute() forks the workers.
+        from twisterlib.runmonitor import clear_ui_active_flag, create_ui_active_flag
+
+        create_ui_active_flag()
+
+        def run_ui():
+            try:
+                ui.run()
+            except Exception as e:
+                logger.error(f"console monitor UI failed: {e}")
+            finally:
+                clear_ui_active_flag()
+                restore_console_logging(muted)
+                logger.info("Console monitor closed")
+
+        thread = threading.Thread(target=run_ui, name='twister-console-ui', daemon=True)
+        thread.start()
+        return ui, thread
 
     def run(self):
 
@@ -1914,10 +2013,15 @@ class TwisterRunner:
 
         self.update_counting_before_pipeline()
 
+        monitor, console_ui, console_ui_thread = self._start_monitors()
+
+        aborted = False
         while True:
             self.results.iteration_increment()
 
             if self.results.iteration > 1:
+                if monitor:
+                    monitor.state.note_iteration(self.results.iteration)
                 logger.info(f"{self.results.iteration} Iteration:")
                 time.sleep(self.options.retry_interval)  # waiting for the system to settle down
                 self.results.done = self.results.total - self.results.failed
@@ -1928,13 +2032,18 @@ class TwisterRunner:
             else:
                 self.results.done = self.results.filtered_static + self.results.skipped
 
-            self.execute(processing_queue, processing_ready)
+            aborted = self.execute(processing_queue, processing_ready) is True
 
             for inst in processing_ready.values():
                 inst.metrics["handler_time"] = inst.execution_time
                 self.instances[inst.name] = inst
 
-            print("")
+            if console_ui is None:
+                print("")
+
+            if aborted:
+                # The user interrupted the run; do not start retry iterations.
+                break
 
             retry_errors = False
             if self.results.error and self.options.retry_build_errors:
@@ -1943,6 +2052,24 @@ class TwisterRunner:
             retries = retries - 1
             if retries == 0 or ( self.results.failed == 0 and not retry_errors):
                 break
+
+        if monitor:
+            monitor.finish()
+        if console_ui_thread and console_ui_thread.is_alive():
+            if aborted or not sys.stdout.isatty():
+                # The run was interrupted (or the terminal went away): shut
+                # the dashboard down instead of waiting for a keypress.
+                console_ui.stop_requested.set()
+                console_ui_thread.join(timeout=5)
+            else:
+                # Leave the dashboard up so failures can be inspected; the
+                # user exits it with 'q', then reports are written as usual.
+                # A Ctrl-C here counts as that exit, not as a hang.
+                try:
+                    console_ui_thread.join()
+                except KeyboardInterrupt:
+                    console_ui.stop_requested.set()
+                    console_ui_thread.join(timeout=5)
 
         self.show_brief()
 
@@ -2043,8 +2170,14 @@ class TwisterRunner:
                 break
             else:
                 instance: TestInstance = task['test']
+                op = task.get('op')
                 pb = ProjectBuilder(instance, self.env, self.jobserver)
+                self._emit_event('op_start', op, instance)
+                op_start_time = time.time()
                 pb.process(processing_queue, processing_ready, task, lock, results)
+                self._emit_event(
+                    'op_done', op, pb.instance, duration=time.time() - op_start_time
+                )
                 if (
                     self.env.options.quit_on_failure
                     and pb.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]
@@ -2068,7 +2201,11 @@ class TwisterRunner:
             logger.error(f"General exception: {e}\n{traceback.format_exc()}")
             sys.exit(1)
 
-    def execute(self, processing_queue: deque, processing_ready: dict[str, TestInstance]):
+    def execute(self, processing_queue: deque, processing_ready: dict[str, TestInstance]) -> bool:
+        '''Run the worker processes to completion.
+
+        Returns True if the execution was interrupted by the user.
+        '''
         lock = Lock()
         logger.info("Adding tasks to the queue...")
         self.add_tasks_to_queue(processing_queue, self.options.build_only, self.options.test_only,
@@ -2096,6 +2233,8 @@ class TwisterRunner:
             logger.info("Execution interrupted")
             for p in processes:
                 p.terminate()
+            return True
+        return False
 
     @staticmethod
     def get_cmake_filter_stages(filt, logic_keys):

--- a/scripts/tests/twister/test_consolemonitor.py
+++ b/scripts/tests/twister/test_consolemonitor.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the twister console dashboard (twisterlib.consolemonitor).
+"""
+
+import logging
+import queue
+import time
+from types import SimpleNamespace
+
+import pytest
+from twisterlib.consolemonitor import (
+    FILTERS,
+    ConsoleUI,
+    LocalMonitorSource,
+    Snapshot,
+    eta,
+    failing_cases,
+    format_duration,
+    match_filter,
+    progress_bar,
+    sort_rows,
+    status_cell,
+)
+from twisterlib.runmonitor import SUMMARY_COUNTERS, RunMonitor, make_event
+from twisterlib.statuses import TwisterStatus
+
+
+def test_format_duration():
+    assert format_duration(None) == ''
+    assert format_duration(42) == '42s'
+    assert format_duration(190) == '3m 10s'
+    assert format_duration(7500) == '2h 05m'
+
+
+def test_progress_bar():
+    counters = {'total': 10, 'done': 5, 'filtered_static': 0}
+    bar = progress_bar(counters, 10)
+    assert bar == '[#####-----] 5/10 (50%)'
+    # statically filtered instances are excluded from the denominator
+    counters = {'total': 12, 'done': 7, 'filtered_static': 2}
+    assert '5/10' in progress_bar(counters, 10)
+    assert '0/0' in progress_bar({}, 10)
+
+
+def test_eta():
+    counters = {'total': 100, 'done': 50, 'filtered_static': 0}
+    assert eta(counters, 100.0) == pytest.approx(100.0)
+    # too few samples or done: no estimate
+    assert eta({'total': 100, 'done': 2}, 100.0) is None
+    assert eta({'total': 100, 'done': 100}, 100.0) is None
+
+
+def test_match_filter():
+    running = {'status': 'none', 'current_op': 'build'}
+    failed = {'status': 'failed', 'current_op': None}
+    queued = {'status': 'none', 'current_op': None}
+    assert match_filter(running, 'active')
+    assert not match_filter(queued, 'active')
+    assert match_filter(failed, 'failures')
+    assert match_filter(queued, 'queued')
+    assert all(match_filter(r, 'all') for r in (running, failed, queued))
+
+
+def test_sort_rows_active_then_failures():
+    rows = [
+        {'name': 'c', 'status': 'passed', 'current_op': None},
+        {'name': 'b', 'status': 'failed', 'current_op': None},
+        {'name': 'a', 'status': 'none', 'current_op': 'run'},
+    ]
+    assert [r['name'] for r in sort_rows(rows)] == ['a', 'b', 'c']
+
+
+def test_status_cell():
+    assert status_cell({'current_op': 'cmake'}) == ('cmake', 'running')
+    assert status_cell({'status': 'failed'}) == ('failed', 'failed')
+    assert status_cell({'status': 'none'}) == ('queued', 'none')
+    assert status_cell({'status': 'not run'}) == ('built', 'not run')
+
+
+def test_failing_cases():
+    detail = {
+        'testcases': [
+            {'name': 'a', 'status': 'passed'},
+            {'name': 'b', 'status': 'failed', 'reason': 'assert'},
+            {'name': 'c', 'status': 'blocked'},
+            {'name': 'd', 'status': 'error'},
+        ]
+    }
+    assert [c['name'] for c in failing_cases(detail)] == ['b', 'c', 'd']
+    assert failing_cases({}) == []
+
+
+def mock_instance(name, outdir):
+    platform, toolchain, suite = name.split('/', 2)
+    return SimpleNamespace(
+        name=name,
+        platform=SimpleNamespace(name=platform),
+        testsuite=SimpleNamespace(name=suite),
+        toolchain=toolchain,
+        status=TwisterStatus.NONE,
+        reason=None,
+        run=True,
+        build_dir=f'{outdir}/{name}',
+        testcases=[],
+        metrics={},
+        execution_time=0,
+        build_time=0,
+        retries=0,
+    )
+
+
+@pytest.fixture
+def local_monitor(tmp_path):
+    """A RunMonitor with one instance, as --console-monitor uses it."""
+    results = SimpleNamespace(**{name: 0 for name in SUMMARY_COUNTERS})
+    mon = RunMonitor(queue.Queue(), results)
+    instance = mock_instance('native_sim/host/tests.a', str(tmp_path))
+    mon.state.init_plan({instance.name: instance}, str(tmp_path))
+    assert mon.start()
+    yield mon, instance
+    mon.stop()
+
+
+def test_local_source_reads_state_in_process(local_monitor, tmp_path):
+    mon, instance = local_monitor
+    source = LocalMonitorSource(mon)
+
+    assert source.summary()['meta']['state'] == 'running'
+    assert source.instances()[0]['name'] == instance.name
+    assert source.instance(instance.name)['name'] == instance.name
+    with pytest.raises(KeyError):
+        source.instance('bogus')
+
+    # events flow through the drain thread into the source
+    mon.event_queue.put(make_event('op_start', 'build', instance))
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if source.instances()[0]['current_op'] == 'build':
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail('event did not reach the local monitor state')
+
+
+def test_local_source_log_tail(local_monitor, tmp_path):
+    mon, instance = local_monitor
+    source = LocalMonitorSource(mon)
+    assert source.log_tail(instance.name, 'build.log') == ''
+
+    build_dir = tmp_path / instance.name
+    build_dir.mkdir(parents=True)
+    (build_dir / 'build.log').write_text('line 1\nline 2\n')
+    assert 'line 2' in source.log_tail(instance.name, 'build.log')
+    assert source.log_tail(instance.name, 'build.log', tail=4).startswith('[... truncated ...]')
+    # allowlist still applies in-process
+    assert source.log_tail(instance.name, 'zephyr.elf') == ''
+
+
+def test_snapshot_with_local_source(local_monitor):
+    mon, instance = local_monitor
+    instance.status = TwisterStatus.FAIL
+    instance.reason = 'Timeout'
+    mon.state.apply_event(make_event('op_done', 'report', instance, duration=0.1))
+
+    snap = Snapshot()
+    snap.poll(LocalMonitorSource(mon))
+    assert snap.connected
+    assert snap.state_label() == 'RUNNING'
+    row = snap.rows[0]
+    assert row['status'] == 'failed'
+    assert row['reason'] == 'Timeout'
+    assert match_filter(row, 'failures')
+
+    mon.state.finish()
+    snap.poll(LocalMonitorSource(mon))
+    assert snap.state_label() == 'FINISHED'
+
+
+def make_ui(rows):
+    ui = ConsoleUI(client=SimpleNamespace(), interval=1.0)
+    ui.snap.rows = rows
+    return ui
+
+
+def sample_rows():
+    return [
+        {'name': 'p1/t/a.pass', 'status': 'passed', 'current_op': None, 'reason': None},
+        {'name': 'p1/t/b.fail', 'status': 'failed', 'current_op': None, 'reason': 'Timeout'},
+        {'name': 'p2/t/c.fail', 'status': 'failed', 'current_op': None, 'reason': 'Exited'},
+        {'name': 'p2/t/d.queued', 'status': 'none', 'current_op': None, 'reason': None},
+    ]
+
+
+def test_ui_vi_keys_move_selection():
+    curses = pytest.importorskip('curses')
+    ui = make_ui(sample_rows())
+    assert ui.selected == 0
+    ui.handle_key(ord('j'), curses, height=30)
+    ui.handle_key(ord('j'), curses, height=30)
+    assert ui.selected == 2
+    ui.handle_key(ord('k'), curses, height=30)
+    assert ui.selected == 1
+    ui.handle_key(ord('G'), curses, height=30)
+    assert ui.selected == len(ui.visible_rows()) - 1
+    ui.handle_key(ord('g'), curses, height=30)
+    assert ui.selected == 0
+
+
+def test_ui_failures_hotkey_toggles_filter():
+    curses = pytest.importorskip('curses')
+    ui = make_ui(sample_rows())
+    ui.handle_key(ord('f'), curses, height=30)
+    assert FILTERS[ui.filter_idx] == 'failures'
+    assert all(r['status'] in ('failed', 'error') for r in ui.visible_rows())
+    assert len(ui.visible_rows()) == 2
+    ui.handle_key(ord('f'), curses, height=30)
+    assert FILTERS[ui.filter_idx] == 'all'
+
+
+def test_ui_search_filters_rows():
+    curses = pytest.importorskip('curses')
+    ui = make_ui(sample_rows())
+    ui.handle_key(ord('/'), curses, height=30)
+    assert ui.search_mode
+    for c in 'Timeout':
+        ui.handle_key(ord(c), curses, height=30)
+    ui.handle_key(ord('\n'), curses, height=30)
+    assert not ui.search_mode
+    assert ui.search == 'Timeout'
+    # search matches name and reason, case-insensitively
+    assert [r['name'] for r in ui.visible_rows()] == ['p1/t/b.fail']
+    # backspace editing
+    ui.handle_key(ord('/'), curses, height=30)
+    ui.handle_key(curses.KEY_BACKSPACE, curses, height=30)
+    assert ui.search == 'Timeou'
+    # ESC cancels the search entirely
+    ui.handle_key(27, curses, height=30)
+    assert ui.search == ''
+    assert len(ui.visible_rows()) == 4
+
+
+def test_ui_q_ignored_while_searching():
+    curses = pytest.importorskip('curses')
+    ui = make_ui(sample_rows())
+    ui.handle_key(ord('/'), curses, height=30)
+    # 'q' is a search character here, not quit
+    assert ui.handle_key(ord('q'), curses, height=30) is True
+    assert ui.search == 'q'
+    ui.handle_key(27, curses, height=30)
+    assert ui.handle_key(ord('q'), curses, height=30) is False
+
+
+def test_console_monitor_needs_tty():
+    """--console-monitor is ignored in non-interactive environments."""
+    from twisterlib.runner import TwisterRunner
+
+    options = SimpleNamespace(console_monitor=True)
+    runner = TwisterRunner({}, {}, SimpleNamespace(options=options))
+    # pytest runs without a tty, so the guard must trip
+    assert runner._console_monitor_wanted() is False
+    assert runner._start_monitors() == (None, None, None)
+    assert runner.event_queue is None
+
+
+def test_mute_restore_console_logging(tmp_path):
+    from twisterlib.log_helper import mute_console_logging, restore_console_logging
+
+    logger = logging.getLogger('twister')
+    saved = logger.handlers[:]
+    try:
+        logger.handlers.clear()
+        stream = logging.StreamHandler()
+        filehandler = logging.FileHandler(tmp_path / 'twister.log')
+        logger.addHandler(stream)
+        logger.addHandler(filehandler)
+
+        muted = mute_console_logging()
+        assert muted == [stream]
+        assert logger.handlers == [filehandler]
+
+        restore_console_logging(muted)
+        assert stream in logger.handlers
+        filehandler.close()
+    finally:
+        logger.handlers = saved

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1484,13 +1484,16 @@ TESTDATA_24 = [
     (TwisterStatus.FAIL, 'Execution error', TwisterStatus.FAIL, 'Execution error'),
     (TwisterStatus.FAIL, 'unexpected eof', TwisterStatus.FAIL, 'unexpected eof'),
     (TwisterStatus.FAIL, 'unexpected byte', TwisterStatus.FAIL, 'unexpected byte'),
-    (TwisterStatus.NONE, None, TwisterStatus.NONE, 'Unknown Error'),
+    (TwisterStatus.FAIL, None, TwisterStatus.FAIL, 'Unknown Error'),
+    (TwisterStatus.PASS, None, TwisterStatus.PASS, None),
+    (TwisterStatus.NONE, None, TwisterStatus.NONE, None),
 ]
 
 @pytest.mark.parametrize(
     '_status, _reason, expected_status, expected_reason',
     TESTDATA_24,
-    ids=['timeout', 'failed', 'unexpected eof', 'unexpected byte', 'unknown']
+    ids=['timeout', 'failed', 'unexpected eof', 'unexpected byte',
+         'failed unknown', 'passed no reason', 'unknown']
 )
 def test_qemuhandler_thread_update_instance_info(
     mocked_instance,

--- a/scripts/tests/twister/test_runmonitor.py
+++ b/scripts/tests/twister/test_runmonitor.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the twister run monitor core (twisterlib.runmonitor).
+"""
+
+import json
+import os
+import queue
+import time
+from types import SimpleNamespace
+
+import pytest
+from twisterlib.runmonitor import (
+    LOG_FILE_ALLOWLIST,
+    SUMMARY_COUNTERS,
+    MonitorState,
+    RunMonitor,
+    make_event,
+    status_str,
+)
+from twisterlib.statuses import TwisterStatus
+
+
+def mock_instance(name='native_sim/host/tests.dummy', outdir='/tmp/out'):
+    platform, toolchain, *_ = name.split('/')
+    return SimpleNamespace(
+        name=name,
+        platform=SimpleNamespace(name=platform),
+        testsuite=SimpleNamespace(name=name.split('/', 2)[2]),
+        toolchain=toolchain,
+        status=TwisterStatus.NONE,
+        reason=None,
+        run=True,
+        build_dir=os.path.join(outdir, name),
+        testcases=[
+            SimpleNamespace(
+                name=f'{name}.case1',
+                status=TwisterStatus.PASS,
+                reason=None,
+                duration=1.5,
+            ),
+        ],
+        metrics={'used_ram': 2048, 'used_rom': 4096, 'unpicklable': object()},
+        execution_time=2.5,
+        build_time=10.0,
+        retries=0,
+    )
+
+
+def test_status_str():
+    assert status_str(TwisterStatus.PASS) == 'passed'
+    assert status_str(TwisterStatus.NONE) == 'none'
+    assert status_str(None) == 'none'
+    assert status_str('failed') == 'failed'
+
+
+def test_make_event_op_start():
+    instance = mock_instance()
+    evt = make_event('op_start', 'cmake', instance)
+    assert evt['kind'] == 'op_start'
+    assert evt['op'] == 'cmake'
+    assert evt['name'] == instance.name
+    assert evt['status'] == 'none'
+    assert 'testcases' not in evt
+
+
+def test_make_event_report_carries_results():
+    instance = mock_instance()
+    instance.status = TwisterStatus.PASS
+    evt = make_event('op_done', 'report', instance, duration=0.1)
+    assert evt['status'] == 'passed'
+    assert evt['testcases'][0]['status'] == 'passed'
+    assert evt['metrics'] == {'used_ram': 2048, 'used_rom': 4096}
+    assert evt['execution_time'] == 2.5
+    # events must be JSON serializable end to end
+    json.dumps(evt)
+
+
+def make_state(outdir):
+    instance = mock_instance(outdir=str(outdir))
+    state = MonitorState()
+    state.init_plan({instance.name: instance}, str(outdir))
+    return state, instance
+
+
+def test_state_event_lifecycle(tmp_path):
+    state, instance = make_state(tmp_path)
+    row = state.rows[instance.name]
+    assert row['status'] == 'none'
+
+    state.apply_event(make_event('op_start', 'build', instance))
+    assert row['current_op'] == 'build'
+    assert row['ops'][-1]['end'] is None
+
+    instance.status = TwisterStatus.PASS
+    state.apply_event(make_event('op_done', 'build', instance, duration=3.0))
+    assert row['current_op'] is None
+    assert row['ops'][-1]['duration'] == 3.0
+    assert row['status'] == 'passed'
+
+    state.apply_event(make_event('op_done', 'report', instance, duration=0.1))
+    assert row['testcases'][0]['name'] == f'{instance.name}.case1'
+
+    # unknown instances must be ignored, not crash
+    state.apply_event({'kind': 'op_start', 'op': 'build', 'name': 'bogus', 'ts': 0})
+
+
+def test_state_json_snapshots(tmp_path):
+    state, instance = make_state(tmp_path)
+    results = SimpleNamespace(**{name: 0 for name in SUMMARY_COUNTERS})
+
+    summary = json.loads(state.summary_json(results))
+    assert summary['meta']['state'] == 'running'
+    assert 'total' in summary['counters']
+
+    rows = json.loads(state.instances_json())['instances']
+    assert rows[0]['name'] == instance.name
+
+    detail = json.loads(state.instance_json(instance.name))
+    assert detail['name'] == instance.name
+    assert detail['logs'] == []
+    assert state.instance_json('bogus') is None
+
+    state.finish()
+    assert json.loads(state.summary_json(results))['meta']['state'] == 'finished'
+
+
+def test_log_path_validation(tmp_path):
+    state, instance = make_state(tmp_path)
+    build_dir = tmp_path / instance.name
+    build_dir.mkdir(parents=True)
+    log = build_dir / 'build.log'
+    log.write_text('hello build')
+
+    assert state.log_path(instance.name, 'build.log') == str(log)
+    # not in the allowlist
+    assert state.log_path(instance.name, '../../secret') is None
+    assert state.log_path(instance.name, 'zephyr.elf') is None
+    # unknown instance / missing file
+    assert state.log_path('bogus', 'build.log') is None
+    assert state.log_path(instance.name, 'handler.log') is None
+
+
+def test_run_monitor_drains_events(tmp_path):
+    results = SimpleNamespace(**{name: 0 for name in SUMMARY_COUNTERS})
+    mon = RunMonitor(queue.Queue(), results)
+    instance = mock_instance(outdir=str(tmp_path))
+    mon.state.init_plan({instance.name: instance}, str(tmp_path))
+    assert mon.start()
+    try:
+        mon.event_queue.put(make_event('op_start', 'cmake', instance))
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if mon.state.rows[instance.name]['current_op'] == 'cmake':
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail('event did not reach the monitor state')
+        mon.finish()
+        assert mon.state.meta['state'] == 'finished'
+    finally:
+        mon.stop()
+
+
+def test_allowlist_is_logs_only():
+    assert all(f.endswith('.log') for f in LOG_FILE_ALLOWLIST)
+
+
+def test_console_ui_active():
+    import twisterlib.runmonitor as runmonitor
+
+    saved = runmonitor._ui_active_flag
+    try:
+        # no flag armed: monitoring is off
+        runmonitor._ui_active_flag = None
+        assert runmonitor.console_ui_active() is False
+        # clearing without a flag must be a no-op, not a crash
+        runmonitor.clear_ui_active_flag()
+
+        # armed by the runner while the UI owns the terminal
+        runmonitor.create_ui_active_flag()
+        assert runmonitor.console_ui_active() is True
+        # cleared the moment the UI exits
+        runmonitor.clear_ui_active_flag()
+        assert runmonitor.console_ui_active() is False
+    finally:
+        runmonitor._ui_active_flag = saved


### PR DESCRIPTION
On long runs the scrolling console output makes it hard to tell what
twister is actually doing: what is queued, which pipeline stage every
job is in, and which tests already failed and why. Add a
--console-monitor option that replaces the normal output with a live,
top-style full-screen dashboard for the duration of the run.

[![asciicast](https://asciinema.org/a/jbLpFAoXSZpn3oFl.svg)](https://asciinema.org/a/jbLpFAoXSZpn3oFl)