### PR TITLE
arch: riscv: pmp: panic when memory-attr regions exceed PMP slots

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -460,11 +460,14 @@ static unsigned int set_pmp_mem_attr(unsigned int *index_p,
 
 		uint8_t perm = DT_MEM_RISCV_TO_PMP_PERM(region[idx].dt_attr);
 
-		if (perm || (region[idx].dt_attr & DT_MEM_RISCV_TYPE_EMPTY)) {
-			set_pmp_entry(index_p, perm,
-				(uintptr_t)(region[idx].dt_addr),
-				(size_t)(region[idx].dt_size),
-				pmp_addr, pmp_cfg, index_limit);
+		if ((perm || (region[idx].dt_attr & DT_MEM_RISCV_TYPE_EMPTY)) &&
+		    !set_pmp_entry(index_p, perm, (uintptr_t)(region[idx].dt_addr),
+				   (size_t)(region[idx].dt_size), pmp_addr, pmp_cfg, index_limit)) {
+			LOG_ERR("cannot install mem-attr region %zu "
+				"(start=%#lx size=%#zx)",
+				idx, (unsigned long)region[idx].dt_addr,
+				(size_t)region[idx].dt_size);
+			k_panic();
 		}
 	}
 


### PR DESCRIPTION
set_pmp_mem_attr() ignored the result of set_pmp_entry(), so when the zephyr,memory-attr regions needed more PMP slots than available, the trailing regions were silently dropped and their permissions never enforced (default-allowed per the RISC-V privileged spec).

Log the region that could not be installed and call k_panic() so a configuration that cannot be honored fails the boot loudly instead of silently degrading security.

Fixes #113777