### PR TITLE
drivers: counter: mcux_ctimer: migrate inputmux capture to mux subsystem

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -217,6 +217,16 @@ Controller Area Network (CAN)
   are processed in the order received on the bus. Out-of-tree users may want to update any
   ``bosch,mram-cfg`` devicetree property overrides to allocate all FIFO elements to RX FIFO0.
 
+Counter
+=======
+
+* :dtcompatible:`nxp,lpc-ctimer` now routes its input capture signal through the generic
+  :ref:`mux <mux_api>` subsystem. The ``inputmux-connections`` property has been removed; describe
+  the routing with an INPUTMUX controller node (:dtcompatible:`nxp,inputmux`) and reference it from
+  the timer node's ``mux-states`` property instead. The cell layout is unchanged, so an existing
+  ``inputmux-connections = <&inputmux0 0 0x06000024>;`` becomes
+  ``mux-states = <&inputmux0 0 0x06000024>;`` (:github:`112088`)
+
 Devicetree
 ==========
 

--- a/drivers/counter/Kconfig.mcux_ctimer
+++ b/drivers/counter/Kconfig.mcux_ctimer
@@ -8,7 +8,7 @@ config COUNTER_MCUX_CTIMER
 	default y
 	depends on DT_HAS_NXP_LPC_CTIMER_ENABLED
 	select COUNTER_SUPPORTS_CAPTURE
-	select NXP_INPUTMUX if COUNTER_CAPTURE
+	select MUX if COUNTER_CAPTURE
 	select PINCTRL if COUNTER_CAPTURE
 	help
 	  Enable support for MCUX CTIMER driver.

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/counter.h>
 #include <fsl_ctimer.h>
 #ifdef CONFIG_COUNTER_CAPTURE
-#include <fsl_inputmux.h>
+#include <zephyr/drivers/mux.h>
 #include <zephyr/drivers/pinctrl.h>
 #endif /* CONFIG_COUNTER_CAPTURE */
 #include <zephyr/logging/log.h>
@@ -51,10 +51,13 @@ struct mcux_lpc_ctimer_data {
 };
 
 #ifdef CONFIG_COUNTER_CAPTURE
-struct mcux_lpc_ctimer_inputmux_entry {
-	INPUTMUX_Type *base;
-	uint16_t channel;
-	uint32_t connection;
+/* One capture input route decoded from the mux-states phandle-array. The
+ * trailing state cell is applied through the mux subsystem, so the routing
+ * hardware is whatever devicetree wires up.
+ */
+struct mcux_lpc_ctimer_mux_entry {
+	const struct device *dev;
+	const struct mux_state *state;
 };
 #endif /* CONFIG_COUNTER_CAPTURE */
 
@@ -69,8 +72,8 @@ struct mcux_lpc_ctimer_config {
 	void (*irq_config_func)(const struct device *dev);
 #ifdef CONFIG_COUNTER_CAPTURE
 	const struct pinctrl_dev_config *pincfg;
-	const struct mcux_lpc_ctimer_inputmux_entry *inputmux_entries;
-	uint8_t inputmux_entries_count;
+	const struct mcux_lpc_ctimer_mux_entry *mux_entries;
+	uint8_t mux_entries_count;
 #endif /* CONFIG_COUNTER_CAPTURE */
 };
 
@@ -268,16 +271,25 @@ static uint32_t mcux_lpc_ctimer_get_freq(const struct device *dev)
 }
 
 #ifdef CONFIG_COUNTER_CAPTURE
-static void mcux_lpc_ctimer_setup_inputmux(const struct mcux_lpc_ctimer_config *config)
+static int mcux_lpc_ctimer_apply_mux(const struct mcux_lpc_ctimer_config *config)
 {
-	for (uint8_t i = 0; i < config->inputmux_entries_count; i++) {
-		const struct mcux_lpc_ctimer_inputmux_entry *entry = &config->inputmux_entries[i];
+	for (uint8_t i = 0; i < config->mux_entries_count; i++) {
+		const struct mcux_lpc_ctimer_mux_entry *entry = &config->mux_entries[i];
+		int err;
 
-		INPUTMUX_Init(entry->base);
-		INPUTMUX_AttachSignal(entry->base, entry->channel,
-				      (inputmux_connection_t)entry->connection);
-		INPUTMUX_Deinit(entry->base);
+		if (!device_is_ready(entry->dev)) {
+			LOG_ERR_DEVICE_NOT_READY(entry->dev);
+			return -ENODEV;
+		}
+
+		err = mux_state_apply(entry->dev, entry->state);
+		if (err) {
+			LOG_ERR("failed to apply mux state %u: %d", i, err);
+			return err;
+		}
 	}
+
+	return 0;
 }
 
 static int mcux_lpc_ctimer_capture_edge(counter_capture_flags_t flags,
@@ -485,7 +497,10 @@ static int mcux_lpc_ctimer_init_common(const struct device *dev)
 		}
 	}
 
-	mcux_lpc_ctimer_setup_inputmux(config);
+	ret = mcux_lpc_ctimer_apply_mux(config);
+	if (ret != 0) {
+		return ret;
+	}
 #endif /* CONFIG_COUNTER_CAPTURE */
 
 	for (uint8_t chan = 0; chan < NUM_CHANNELS; chan++) {
@@ -562,33 +577,33 @@ static DEVICE_API(counter, mcux_ctimer_driver_api) = {
 #define COUNTER_LPC_CTIMER_PINCTRL_INIT(id) \
 	.pincfg = COND_CODE_1(DT_INST_NODE_HAS_PROP(id, pinctrl_0), \
 				 (PINCTRL_DT_INST_DEV_CONFIG_GET(id)), (NULL)),
-#define COUNTER_LPC_CTIMER_INPUTMUX_ENTRY(node_id, prop, idx) \
+#define COUNTER_LPC_CTIMER_MUX_ENTRY(node_id, prop, idx) \
 	{ \
-		.base = (INPUTMUX_Type *)DT_REG_ADDR(DT_PHANDLE_BY_IDX(node_id, prop, idx)), \
-		.channel = (uint16_t)DT_PHA_BY_IDX(node_id, prop, idx, channel), \
-		.connection = (uint32_t)DT_PHA_BY_IDX(node_id, prop, idx, connection), \
+		.dev = MUX_STATE_DT_DEV_GET_BY_IDX(node_id, idx), \
+		.state = MUX_STATE_DT_GET_BY_IDX(node_id, idx), \
 	}
-#define COUNTER_LPC_CTIMER_INPUTMUX_DEFINE(id) \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(id, inputmux_connections), \
-		    (static const struct mcux_lpc_ctimer_inputmux_entry \
-			    mcux_lpc_ctimer_inputmux_entries_##id[] = { \
-			    DT_INST_FOREACH_PROP_ELEM_SEP(id, inputmux_connections, \
-							 COUNTER_LPC_CTIMER_INPUTMUX_ENTRY, (,)) \
+#define COUNTER_LPC_CTIMER_MUX_DEFINE(id) \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(id, mux_states), \
+		    (MUX_STATE_DT_INST_SPEC_DEFINE_ALL(id); \
+		     static const struct mcux_lpc_ctimer_mux_entry \
+			    mcux_lpc_ctimer_mux_entries_##id[] = { \
+			    DT_INST_FOREACH_PROP_ELEM_SEP(id, mux_states, \
+							 COUNTER_LPC_CTIMER_MUX_ENTRY, (,)) \
 		    };), ())
-#define COUNTER_LPC_CTIMER_INPUTMUX_INIT(id) \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(id, inputmux_connections), \
-		    (.inputmux_entries = mcux_lpc_ctimer_inputmux_entries_##id, \
-		     .inputmux_entries_count = DT_INST_PROP_LEN(id, inputmux_connections),), ())
+#define COUNTER_LPC_CTIMER_MUX_INIT(id) \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(id, mux_states), \
+		    (.mux_entries = mcux_lpc_ctimer_mux_entries_##id, \
+		     .mux_entries_count = ARRAY_SIZE(mcux_lpc_ctimer_mux_entries_##id),), ())
 #else
 #define COUNTER_LPC_CTIMER_PINCTRL_DEFINE(id)
 #define COUNTER_LPC_CTIMER_PINCTRL_INIT(id)
-#define COUNTER_LPC_CTIMER_INPUTMUX_DEFINE(id)
-#define COUNTER_LPC_CTIMER_INPUTMUX_INIT(id)
+#define COUNTER_LPC_CTIMER_MUX_DEFINE(id)
+#define COUNTER_LPC_CTIMER_MUX_INIT(id)
 #endif /* CONFIG_COUNTER_CAPTURE */
 
 #define COUNTER_LPC_CTIMER_DEVICE(id) \
 	COUNTER_LPC_CTIMER_PINCTRL_DEFINE(id) \
-	COUNTER_LPC_CTIMER_INPUTMUX_DEFINE(id) \
+	COUNTER_LPC_CTIMER_MUX_DEFINE(id) \
 	static void mcux_lpc_ctimer_irq_config_##id(const struct device *dev);                     \
 	static struct mcux_lpc_ctimer_config mcux_lpc_ctimer_config_##id = { \
 		.info = {						\
@@ -604,7 +619,7 @@ static DEVICE_API(counter, mcux_ctimer_driver_api) = {
 		.input = DT_INST_PROP(id, input),					\
 		.prescale = DT_INST_PROP(id, prescale),				\
 		COUNTER_LPC_CTIMER_PINCTRL_INIT(id) \
-		COUNTER_LPC_CTIMER_INPUTMUX_INIT(id) \
+		COUNTER_LPC_CTIMER_MUX_INIT(id) \
 		.irq_config_func = mcux_lpc_ctimer_irq_config_##id,	\
 	};                     \
 	PM_DEVICE_DT_INST_DEFINE(id, mcux_lpc_ctimer_pm_action);                                   \

--- a/dts/bindings/counter/nxp,lpc-ctimer.yaml
+++ b/dts/bindings/counter/nxp,lpc-ctimer.yaml
@@ -5,7 +5,7 @@ description: NXP MCUX Standard Timer/Counter
 
 compatible: "nxp,lpc-ctimer"
 
-include: [base.yaml, pinctrl-device.yaml]
+include: [base.yaml, pinctrl-device.yaml, mux-consumer.yaml]
 
 properties:
   reg:
@@ -34,19 +34,17 @@ properties:
     required: true
     description: prescale value
 
-  inputmux-connections:
+  mux-states:
     type: phandle-array
-    specifier-space: inputmux
     description: |
-      INPUTMUX routing for CTIMER capture inputs. Each phandle-array entry
-      is <&inputmuxN channel connection> where:
-        - &inputmuxN is the INPUTMUX node providing the route
-        - channel is the CAPTSEL destination index (0..3)
+      CTIMER capture input routing. Optional; only needed when counter
+      capture is used. Each entry is <&inputmuxN index connection>:
+        - &inputmuxN is the INPUTMUX mux controller providing the route
+        - index is the CAPTSEL destination index (0..3)
         - connection is an inputmux_connection_t value from
           fsl_inputmux_connections.h
-
       Example (route CT_INP15 to CTIMER2 CAPTSEL[0] via INPUTMUX0):
-        inputmux-connections = <&inputmux0 0 0x06000010>;
+        mux-states = <&inputmux0 0 0x06000010>;
 
 counter-capture-cells:
   - channel

--- a/tests/drivers/counter/counter_capture/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/counter/counter_capture/boards/frdm_mcxa153.overlay
@@ -46,9 +46,9 @@
 	prescale = <95>;
 	/*
 	 * Route CTIMER1 match 1 to CTIMER2 CAPTSEL[0] via INPUTMUX0.
-	 * Cells: <&inputmux0 channel connection> where connection is
+	 * Cells: <&inputmux0 index connection> where connection is
 	 * kINPUTMUX_Ctimer1M1ToTimer2Captsel = 36U | (TIMER2CAPTSEL0 << 20)
 	 * = 0x06000024.
 	 */
-	inputmux-connections = <&inputmux0 0 0x06000024>;
+	mux-states = <&inputmux0 0 0x06000024>;
 };


### PR DESCRIPTION
The mux subsystem rework converted the PWM and qdec INPUTMUX consumers to mux-states and deleted the #inputmux-cells specifier space, but this driver was left behind on inputmux-connections, so enabling capture now fails at devicetree parse time (counter_capture on frdm_mcxa153).

Convert it the same way as pwm_mcux_ctimer: mux-states in the binding and test overlay (same cells, renamed), a mux_state_apply() loop in the driver with its error propagated out of init, select MUX in Kconfig, and the missing Counter entry in the 4.5 migration guide.

Fixes #115616