### PR TITLE
llext: arm64: reject out-of-range relocation values

### DIFF
--- a/arch/arm64/core/elf.c
+++ b/arch/arm64/core/elf.c
@@ -205,7 +205,7 @@ static int movw_reloc_handler(elf_rela_t *rel, elf_word reloc_type, uintptr_t lo
 			      uintptr_t sym_base_addr)
 {
 	int64_t x;
-	uint32_t imm;
+	uint64_t imm;
 	int lsb = 0; /* LSB of X to be used */
 	bool is_movnz = false;
 	enum aarch64_reloc_type type = AARCH64_RELOC_TYPE_ABS;

--- a/arch/arm64/core/elf.c
+++ b/arch/arm64/core/elf.c
@@ -413,10 +413,11 @@ static int imm_reloc_handler(elf_rela_t *rel, elf_word reloc_type, uintptr_t loc
 	/* Mask X sign bit and upper bits. */
 	x = (int64_t)(x & ~BIT_MASK(len - 1)) >> (len - 1);
 
-	/* Incrementing X will either overflow and set it to 0 or
-	 * set it 1. Any other case indicates that there was an overflow in relocation.
+	/* A value that fits a signed len-bit field leaves either all-zero
+	 * (positive) or all-one (negative) bits above the field, so the
+	 * check value is exactly 0 or -1. Anything else is an overflow.
 	 */
-	if ((int64_t)x++ > 1) {
+	if (x < -1 || x > 0) {
 		return -ERANGE;
 	}
 


### PR DESCRIPTION
Two defects in the AArch64 llext relocation handlers made the overflow checks accept values that do not fit the patched instruction field, which was then silently patched with a truncated immediate.

imm_reloc_handler() tested its sign-extension check value (exactly 0 or -1 for in-range values) with x++ > 1, accepting check value 1 and all negative overflows; reject everything but 0 and -1. movw_reloc_handler() truncated to 32 bits before the range check, so values like 2^32 + 5 aliased into range; check the untruncated value, unsigned for UABS relocations and [-65536, 65535] for MOVN-encoded (SABS/PREL) ones.

Fixes #115707