### PR TITLE
net: gptp: request a TX timestamp for Pdelay_Req

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -301,6 +301,7 @@ struct net_pkt *gptp_prepare_pdelay_req(int port)
 	}
 
 	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
+	net_pkt_set_tx_timestamping(pkt, true);
 
 	port_ds = GPTP_PORT_DS(port);
 	req = GPTP_PDELAY_REQ(pkt);


### PR DESCRIPTION
#114187 made TX timestamping opt-in and flagged Sync and Pdelay_Resp (5950810b0e0), which looks complete if you go by timestamp callback registrations. That question even came up in review, and that was the conclusion. 

The catch is Pdelay_Req, it's the third event message, but it has no callback, so nothing shows up in that audit. Its egress timestamp is t1 of the peer delay measurement, and gptp_md_compute_prop_time() just reads it back off the retained packet later. 

While drivers still timestamped anything with the PTP ethertype this didn't matter, but the same PR removed
that fallback (680606c5255), so now t1 is always zero, neighborPropDelay comes out as roughly t4/2, asCapable gets cleared on every exchange, and the port sits in DISABLED forever. The node keeps running happily and just never sends another Sync.

It's just a one liner to get the timestamp when the request is prepared. Found and verified on MCXN947 (eth_nxp_enet_qos). 

Before it had asCapable no and a reported propagation time of 4294967295 ns and after now has asCapable yes with ~1275 ns measured peer delay, port reaches MASTER and Sync flows again. Any driver #114187 converted to flag-only gating (eth_nxp_enet, stm32_hal_v2, xmc4xxx, the NETC/DSA paths) has the same exposure.