### PR TITLE
arch: arm64: mmu: fix TLBI operand shift in invalidate_tlb_page()

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1501,17 +1501,26 @@ void z_arm64_swap_mem_domains(struct k_thread *incoming)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_DEMAND_PAGING
+/*
+ * The TLBI VAE1 address field is VA[55:12] regardless of the
+ * translation granule (ARM ARM), so the operand is always
+ * virt >> TLBI_VA_SHIFT, not virt >> PAGE_SIZE_SHIFT.
+ */
+#define TLBI_VA_SHIFT 12
+
 static inline void invalidate_tlb_page(uintptr_t virt)
 {
 #ifdef CONFIG_SMP
 	/* Use IS variant to broadcast to all CPUs in Inner Shareable domain */
-	__asm__ volatile (
-	"dsb ishst; tlbi vae1is, %0; dsb ish; isb"
-	: : "r" (virt >> PAGE_SIZE_SHIFT) : "memory");
+	__asm__ volatile("dsb ishst; tlbi vae1is, %0; dsb ish; isb"
+			 :
+			 : "r"(virt >> TLBI_VA_SHIFT)
+			 : "memory");
 #else
-	__asm__ volatile (
-	"dsb ishst; tlbi vae1, %0; dsb ish; isb"
-	: : "r" (virt >> PAGE_SIZE_SHIFT) : "memory");
+	__asm__ volatile("dsb ishst; tlbi vae1, %0; dsb ish; isb"
+			 :
+			 : "r"(virt >> TLBI_VA_SHIFT)
+			 : "memory");
 #endif
 }
 


### PR DESCRIPTION
The TLBI VAE1 address field is VA[55:12] regardless of the translation granule (ARM ARM), but invalidate_tlb_page() shifted the address by PAGE_SIZE_SHIFT. With 16 KB/64 KB pages the hardware then invalidated a different entry and the intended page's translation survived: paged-out frames stayed accessible through the stale TLB entry, and the dirty-page write transition escalated into a fatal fault loop.

Shift by 12 unconditionally, matching Linux's __TLBI_VADDR().

Fixes #115708