### PR TITLE
drivers: reset: add ch32 reset controller

### DIFF
--- a/drivers/reset/CMakeLists.txt
+++ b/drivers/reset/CMakeLists.txt
@@ -23,4 +23,5 @@ zephyr_library_sources_ifdef(CONFIG_RESET_RTS5817 reset_rts5817.c)
 zephyr_library_sources_ifdef(CONFIG_RESET_SF32LB reset_sf32lb.c)
 zephyr_library_sources_ifdef(CONFIG_RESET_STM32 reset_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_RESET_SYNA_SR100 reset_syna_sr100.c)
+zephyr_library_sources_ifdef(CONFIG_RESET_WCH_CH32 reset_wch_ch32.c)
 # zephyr-keep-sorted-stop

--- a/drivers/reset/Kconfig
+++ b/drivers/reset/Kconfig
@@ -46,6 +46,7 @@ rsource "Kconfig.rts5817"
 rsource "Kconfig.sf32lb"
 rsource "Kconfig.stm32"
 rsource "Kconfig.syna_sr100"
+rsource "Kconfig.wch"
 # zephyr-keep-sorted-stop
 
 endif # RESET

--- a/drivers/reset/Kconfig.wch
+++ b/drivers/reset/Kconfig.wch
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config RESET_WCH_CH32
+	bool "CH32 Reset Controller Driver"
+	default y
+	depends on DT_HAS_WCH_CH32_RCC_RCTL_ENABLED

--- a/drivers/reset/reset_wch_ch32.c
+++ b/drivers/reset/reset_wch_ch32.c
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT wch_ch32_rcc_rctl
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/reset.h>
+#include <zephyr/arch/common/sys_bitops.h>
+
+#define CH32_RESET_REG_OFFEST(id) (((id) >> 5U) & 0xFFU)
+#define CH32_RESET_REG_BIT(id)    ((id) & 0x1FU)
+
+struct reset_ch32_config {
+	mem_addr_t base;
+};
+
+static int reset_ch32_status(const struct device *dev, uint32_t id, uint8_t *status)
+{
+	const struct reset_ch32_config *const config = dev->config;
+
+	*status = !!sys_test_bit(config->base + CH32_RESET_REG_OFFEST(id), CH32_RESET_REG_BIT(id));
+
+	return 0;
+}
+
+static int reset_ch32_line_assert(const struct device *dev, uint32_t id)
+{
+	const struct reset_ch32_config *const config = dev->config;
+
+	sys_set_bit(config->base + CH32_RESET_REG_OFFEST(id), CH32_RESET_REG_BIT(id));
+
+	return 0;
+}
+
+static int reset_ch32_line_deassert(const struct device *dev, uint32_t id)
+{
+	const struct reset_ch32_config *const config = dev->config;
+
+	sys_clear_bit(config->base + CH32_RESET_REG_OFFEST(id), CH32_RESET_REG_BIT(id));
+
+	return 0;
+}
+
+static int reset_ch32_line_toggle(const struct device *dev, uint32_t id)
+{
+	reset_ch32_line_assert(dev, id);
+	reset_ch32_line_deassert(dev, id);
+
+	return 0;
+}
+
+static DEVICE_API(reset, reset_ch32_drive_api) = {
+	.status = reset_ch32_status,
+	.line_assert = reset_ch32_line_assert,
+	.line_deassert = reset_ch32_line_deassert,
+	.line_toggle = reset_ch32_line_toggle,
+};
+
+static const struct reset_ch32_config reset_ch32_config = {
+	.base = DT_REG_ADDR(DT_INST_PARENT(0)),
+};
+
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &reset_ch32_config, PRE_KERNEL_1,
+		      CONFIG_RESET_INIT_PRIORITY, &reset_ch32_drive_api);

--- a/drivers/serial/Kconfig.wch_usart
+++ b/drivers/serial/Kconfig.wch_usart
@@ -10,3 +10,14 @@ config UART_WCH_USART
 	select PINCTRL
 	help
 	  This option enables the USART driver for CH32V00x SoC family.
+
+if UART_WCH_USART
+
+config UART_WCH_USART_RESET
+	bool "Reset USART peripheral before use"
+	depends on RESET
+	default y
+	help
+	  Reset the USART peripheral before use using the reset subsystem.
+
+endif

--- a/drivers/serial/uart_wch_usart.c
+++ b/drivers/serial/uart_wch_usart.c
@@ -10,6 +10,9 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
+#ifdef CONFIG_UART_WCH_USART_RESET
+#include <zephyr/drivers/reset.h>
+#endif
 #include <zephyr/irq.h>
 
 #include <hal_ch32fun.h>
@@ -17,6 +20,9 @@
 struct usart_wch_config {
 	USART_TypeDef *regs;
 	const struct device *clock_dev;
+#ifdef CONFIG_UART_WCH_USART_RESET
+	const struct reset_dt_spec reset;
+#endif
 	uint32_t current_speed;
 	uint8_t parity;
 	uint8_t clock_id;
@@ -42,6 +48,14 @@ static int usart_wch_init(const struct device *dev)
 	int err;
 
 	clock_control_on(config->clock_dev, clock_sys);
+
+#ifdef CONFIG_UART_WCH_USART_RESET
+	if (!device_is_ready(config->reset.dev)) {
+		return -ENODEV;
+	}
+
+	(void)reset_line_toggle_dt(&config->reset);
+#endif
 
 	err = pinctrl_apply_state(config->pin_cfg, PINCTRL_STATE_DEFAULT);
 	if (err != 0) {
@@ -307,7 +321,7 @@ static DEVICE_API(uart, usart_wch_driver_api) = {
 #define USART_WCH_IRQ_HANDLER(idx)                                                                 \
 	static void usart_wch_irq_config_func_##idx(const struct device *dev)                      \
 	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority), usart_wch_isr,        \
+		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority), usart_wch_isr,          \
 			    DEVICE_DT_INST_GET(idx), 0);                                           \
 		irq_enable(DT_INST_IRQN(idx));                                                     \
 	}
@@ -315,6 +329,12 @@ static DEVICE_API(uart, usart_wch_driver_api) = {
 #define USART_WCH_IRQ_HANDLER_DECL(idx)
 #define USART_WCH_IRQ_HANDLER_FUNC(idx)
 #define USART_WCH_IRQ_HANDLER(idx)
+#endif
+
+#ifdef CONFIG_UART_WCH_USART_RESET
+#define USART_WCH_RESET(idx) .reset = RESET_DT_SPEC_INST_GET(idx),
+#else
+#define USART_WCH_RESET(_)
 #endif
 
 #define USART_WCH_INIT(idx)                                                                        \
@@ -328,7 +348,7 @@ static DEVICE_API(uart, usart_wch_driver_api) = {
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                              \
 		.clock_id = DT_INST_CLOCKS_CELL(idx, id),                                          \
 		.pin_cfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                    \
-		USART_WCH_IRQ_HANDLER_FUNC(idx)};                                                  \
+		USART_WCH_RESET(idx) USART_WCH_IRQ_HANDLER_FUNC(idx)};                             \
 	DEVICE_DT_INST_DEFINE(idx, &usart_wch_init, NULL, &usart_wch_##idx##_data,                 \
 			      &usart_wch_##idx##_config, PRE_KERNEL_1,                             \
 			      CONFIG_SERIAL_INIT_PRIORITY, &usart_wch_driver_api);                 \

--- a/dts/bindings/reset/wch,ch32-rcc-rctl.yaml
+++ b/dts/bindings/reset/wch,ch32-rcc-rctl.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  CH32 Reset and Clock Control (RCC) Reset Controller.
+
+  This node is in charge of reset control for peripherals.
+
+  Use the standard resets property to set the reset line of a peripheral, e.g.:
+
+    usart1: serial@xxx {
+      ...
+      /* Cell contains information about Reset register offset and bit */
+      resets = <&rctl CH32_RESET(APB2, 14)>;
+      ...
+    };
+
+compatible: "wch,ch32-rcc-rctl"
+
+include: [reset-controller.yaml, base.yaml]
+
+properties:
+  "#reset-cells":
+    const: 1
+
+reset-cells:
+  - id

--- a/dts/bindings/serial/wch,usart.yaml
+++ b/dts/bindings/serial/wch,usart.yaml
@@ -2,8 +2,11 @@ description: WCH CH32V00x UART
 
 compatible: "wch,usart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:
+    required: true
+
+  resets:
     required: true

--- a/dts/riscv/wch/ch32h417/ch32h417.dtsi
+++ b/dts/riscv/wch/ch32h417/ch32h417.dtsi
@@ -9,6 +9,7 @@
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+#include <zephyr/dt-bindings/reset/ch32_20x_30x-reset.h>
 
 / {
 	#address-cells = <1>;
@@ -81,6 +82,7 @@
 			compatible = "wch,usart";
 			reg = <0x40013800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
+			resets = <&rctl CH32_RESET(APB2, 14)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <53>;
 			status = "disabled";
@@ -90,6 +92,7 @@
 			compatible = "wch,usart";
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			resets = <&rctl CH32_RESET(APB1, 8)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <117>;
 			status = "disabled";
@@ -100,6 +103,11 @@
 			reg = <0x40021000 0x38>;
 			#clock-cells = <1>;
 			status = "okay";
+
+			rctl: reset-controller {
+				compatible = "wch,ch32-rcc-rctl";
+				#reset-cells = <1>;
+			};
 		};
 	};
 };

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/ch32v00x-clocks.h>
+#include <zephyr/dt-bindings/reset/ch32v00x-reset.h>
 #include <zephyr/dt-bindings/dma/ch32v003-dma.h>
 
 / {
@@ -137,6 +138,7 @@
 			compatible = "wch,usart";
 			reg = <0x40013800 0x10>;
 			clocks = <&rcc CH32V00X_CLOCK_USART1>;
+			resets = <&rctl CH32_RESET(APB2, 14)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <32>;
 		};
@@ -146,6 +148,11 @@
 			reg = <0x40021000 0x10>;
 			#clock-cells = <1>;
 			status = "okay";
+
+			rctl: reset-controller {
+				compatible = "wch,ch32-rcc-rctl";
+				#reset-cells = <1>;
+			};
 		};
 
 		dma1: dma@40020000 {

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/ch32v00x-clocks.h>
+#include <zephyr/dt-bindings/reset/ch32v00x-reset.h>
 #include <zephyr/dt-bindings/dma/ch32v003-dma.h>
 
 / {
@@ -145,6 +146,7 @@
 			compatible = "wch,usart";
 			reg = <0x40013800 0x10>;
 			clocks = <&rcc CH32V00X_CLOCK_USART1>;
+			resets = <&rctl CH32_RESET(APB2, 14)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <32>;
 			status = "disabled";
@@ -154,6 +156,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x10>;
 			clocks = <&rcc CH32V00X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB2, 13)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <39>;
 			status = "disabled";
@@ -164,6 +167,11 @@
 			reg = <0x40021000 0x10>;
 			#clock-cells = <1>;
 			status = "okay";
+
+			rctl: reset-controller {
+				compatible = "wch,ch32-rcc-rctl";
+				#reset-cells = <1>;
+			};
 		};
 
 		dma1: dma@40020000 {

--- a/dts/riscv/wch/ch32v103/ch32v103.dtsi
+++ b/dts/riscv/wch/ch32v103/ch32v103.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/ch32v10x-clocks.h>
+#include <zephyr/dt-bindings/reset/ch32v20x_30x-reset.h>
 
 / {
 	clocks {
@@ -140,6 +141,7 @@
 			compatible = "wch,usart";
 			reg = <0x40013800 0x20>;
 			clocks = <&rcc CH32V10X_CLOCK_USART1>;
+			resets = <&rctl CH32_RESET(APB2, 14)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <53>;
 			status = "disabled";
@@ -149,6 +151,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V10X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";
@@ -181,6 +184,11 @@
 			reg = <0x40021000 16>;
 			#clock-cells = <1>;
 			status = "okay";
+
+			rctl: reset-controller {
+				compatible = "wch,ch32-rcc-rctl";
+				#reset-cells = <1>;
+			};
 		};
 
 		dma1: dma@40020000 {

--- a/dts/riscv/wch/ch32v103/ch32v103c8t6.dtsi
+++ b/dts/riscv/wch/ch32v103/ch32v103c8t6.dtsi
@@ -22,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V10X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v103/ch32v103c8u6.dtsi
+++ b/dts/riscv/wch/ch32v103/ch32v103c8u6.dtsi
@@ -22,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V10X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v103/ch32v103r8t6.dtsi
+++ b/dts/riscv/wch/ch32v103/ch32v103r8t6.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V10X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203c6t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203c6t.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203c8t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203c8t.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";
@@ -21,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -30,6 +32,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203f8p.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203f8p.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203g6u.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203g6u.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203g8r.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203g8r.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203k6t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203k6t.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203k8t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203k8t.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";
@@ -21,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -30,6 +32,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -13,6 +13,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v208/ch32v208cbu.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208cbu.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -21,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v208/ch32v208rbt.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208rbt.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -21,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v208/ch32v208wbu.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208wbu.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -21,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -24,6 +24,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";
@@ -33,6 +34,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";
@@ -21,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			resets = <&rctl CH32_RESET(APB1, 20)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <69>;
 			status = "disabled";
@@ -30,6 +32,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			resets = <&rctl CH32_RESET(APB1, 6)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <87>;
 			status = "disabled";
@@ -39,6 +42,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			resets = <&rctl CH32_RESET(APB1, 7)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <88>;
 			status = "disabled";
@@ -48,6 +52,7 @@
 			compatible = "wch,usart";
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			resets = <&rctl CH32_RESET(APB1, 8)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <89>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";
@@ -21,6 +22,7 @@
 			compatible = "wch,usart";
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			resets = <&rctl CH32_RESET(APB1, 20)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <69>;
 			status = "disabled";
@@ -30,6 +32,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			resets = <&rctl CH32_RESET(APB1, 6)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <87>;
 			status = "disabled";
@@ -39,6 +42,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			resets = <&rctl CH32_RESET(APB1, 7)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <88>;
 			status = "disabled";
@@ -48,6 +52,7 @@
 			compatible = "wch,usart";
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			resets = <&rctl CH32_RESET(APB1, 8)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <89>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v305/ch32v305.dtsi
+++ b/dts/riscv/wch/ch32v305/ch32v305.dtsi
@@ -24,6 +24,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";
@@ -33,6 +34,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -42,6 +44,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";
@@ -51,6 +54,7 @@
 			compatible = "wch,usart";
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			resets = <&rctl CH32_RESET(APB1, 20)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <69>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -49,6 +49,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";
@@ -58,6 +59,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -67,6 +69,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";
@@ -76,6 +79,7 @@
 			compatible = "wch,usart";
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			resets = <&rctl CH32_RESET(APB1, 20)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <69>;
 			status = "disabled";
@@ -85,6 +89,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			resets = <&rctl CH32_RESET(APB1, 6)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <87>;
 			status = "disabled";
@@ -94,6 +99,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			resets = <&rctl CH32_RESET(APB1, 7)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <88>;
 			status = "disabled";
@@ -103,6 +109,7 @@
 			compatible = "wch,usart";
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			resets = <&rctl CH32_RESET(APB1, 8)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <89>;
 			status = "disabled";

--- a/dts/riscv/wch/ch32v317/ch32v317.dtsi
+++ b/dts/riscv/wch/ch32v317/ch32v317.dtsi
@@ -49,6 +49,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";
@@ -58,6 +59,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			resets = <&rctl CH32_RESET(APB1, 18)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <55>;
 			status = "disabled";
@@ -67,6 +69,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			resets = <&rctl CH32_RESET(APB1, 19)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <68>;
 			status = "disabled";
@@ -76,6 +79,7 @@
 			compatible = "wch,usart";
 			reg = <0x40005000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			resets = <&rctl CH32_RESET(APB1, 20)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <69>;
 			status = "disabled";
@@ -85,6 +89,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			resets = <&rctl CH32_RESET(APB1, 6)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <87>;
 			status = "disabled";
@@ -94,6 +99,7 @@
 			compatible = "wch,usart";
 			reg = <0x40001c00 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			resets = <&rctl CH32_RESET(APB1, 7)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <88>;
 			status = "disabled";
@@ -103,6 +109,7 @@
 			compatible = "wch,usart";
 			reg = <0x40002000 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			resets = <&rctl CH32_RESET(APB1, 8)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <89>;
 			status = "disabled";

--- a/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
+++ b/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+#include <zephyr/dt-bindings/reset/ch32v20x_30x-reset.h>
 
 / {
 	chosen {
@@ -142,6 +143,7 @@
 			compatible = "wch,usart";
 			reg = <0x40013800 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
+			resets = <&rctl CH32_RESET(APB2, 14)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <53>;
 			status = "disabled";
@@ -174,6 +176,11 @@
 			reg = <0x40021000 16>;
 			#clock-cells = <1>;
 			status = "okay";
+
+			rctl: reset-controller {
+				compatible = "wch,ch32-rcc-rctl";
+				#reset-cells = <1>;
+			};
 		};
 
 		rng: rng@40023c00 {

--- a/include/zephyr/dt-bindings/reset/ch32-common.h
+++ b/include/zephyr/dt-bindings/reset/ch32-common.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Fiona Behrens
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief CH32 reset controller devicetree common helper macros
+ * @ingroup reset_controller_ch32
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32_COMMON_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32_COMMON_H_
+
+/**
+ * @defgroup reset_controller_ch32 CH32 reset controller helpers
+ * @ingroup reset_controller_interface
+ *
+ * @brief Macros for encoding CH32 peripheral reset cells.
+ *
+ * Devicetree macro for encoding peripheral reset on CH32 devices, for use with the
+ * <tt>wch,ch32-rcc-rctl</tt> compatible reset controller.
+ *
+ * Each SoC family header (for example @c ch32v20x_30x-reset.h) defines the RCC bus reset register
+ * offsets for that family as @c CH32_RESET_BUS_<bus> constants. A peripheral reset cell is the
+ * encoded with @c CH32_RESET() by combining a bus constant with the bit position of the
+ * peripheral's reset line within that bus reset register.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/reset/ch32v20x_30x-reset.h>
+ *
+ * &usart1 {
+ *         resets = <&rctl CH32_RESET(APB2, 14)>;
+ * }
+ * @endcode
+ * @{
+ */
+
+/**
+ * @brief Encode a peripheral reset cell value for the <tt>wch,ch32-rcc-rctl</tt> binding.
+ *
+ * Packs an RCC bus register offest and a bit position into one 32-bit reset cell value.
+ *
+ * Bits [4:0] hold the reset bit position within the 32-bit RCC bus register;
+ * bits [16:5] hold the RCC register byte offset relative to the RCC base address.
+ *
+ * @param bus RCC bus name.
+ * @param bit Bit position of the peripheral's reset line within the bus reset register.
+ */
+#define CH32_RESET(bus, bit) (((CH32_RESET_BUS_##bus) << 5U) | (bit))
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32_COMMON_H_ */

--- a/include/zephyr/dt-bindings/reset/ch32v00x-reset.h
+++ b/include/zephyr/dt-bindings/reset/ch32v00x-reset.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Fiona Behrens
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief CH32 reset controller devicetree helper macros for CH32V00X.
+ * @ingroup reset_controller_ch32
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32V00X_RESET_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32V00X_RESET_H_
+
+#include "ch32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
+
+/* RCC bus reset register offset */
+#define CH32_RESET_BUS_APB2 0x0C
+#define CH32_RESET_BUS_APB1 0x10
+
+/** @endcond */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32V00X_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/ch32v20x_30x-reset.h
+++ b/include/zephyr/dt-bindings/reset/ch32v20x_30x-reset.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Fiona Behrens
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief CH32 reset controller devicetree helper macros for CH32V20X-V30X.
+ * @ingroup reset_controller_ch32
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32V20X_30X_RESET_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32V20X_30X_RESET_H_
+
+#include "ch32-common.h"
+
+/** @cond INTERNAL_HIDDEN */
+
+/* RCC bus reset register offset */
+#define CH32_RESET_BUS_APB2 0x0C
+#define CH32_RESET_BUS_APB1 0x10
+#define CH32_RESET_BUS_AHB  0x28
+
+/** @endcond */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_CH32V20X_30X_RESET_H_ */


### PR DESCRIPTION
Add reset driver for the reset part of the ch32 rcc.

Use this new reset driven in `wch,usart` to reset the usart peripheral before use.