### PR TITLE
drivers: dma: esp32: reject a zero-length block

### DIFF
--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -408,6 +408,11 @@ static int dma_esp32_config_descriptor(struct dma_esp32_channel *dma_channel,
 			}
 
 			block_size = block->block_size;
+
+			if (block_size == 0) {
+				LOG_ERR("Zero-length DMA block is not allowed");
+				return -EINVAL;
+			}
 		}
 
 		uint32_t buffer_size;
@@ -767,6 +772,11 @@ static int dma_esp32_reload(const struct device *dev, uint32_t channel, uint32_t
 
 	dma_channel = &config->dma_channel[channel];
 	desc_iter = dma_channel->desc_list;
+
+	if (size == 0) {
+		LOG_ERR("Zero-length DMA block is not allowed for a reload");
+		return -EINVAL;
+	}
 
 	if (size > ARRAY_SIZE(dma_channel->desc_list) *
 		   DMA_DESCRIPTOR_BUFFER_MAX_SIZE_4B_ALIGNED) {


### PR DESCRIPTION
Fixes #115720.

A block whose `block_size` is zero is currently accepted, and the descriptor built from it goes to the hardware with a length of zero and the owner bit set to DMA. `dma_esp32_reload()` has the same shape, so a reload of size zero does the same.

The reason it slips through is that `block_size == 0` is also the loop's own signal that it needs to fetch the next block, so a zero-length block reads as one that has already finished. This rejects it rather than skipping it: skipping would change the block chain the caller asked for, and zero is almost always an arithmetic mistake the caller would rather hear about than have silently absorbed.

## Does this break any existing caller?

Five in-tree call sites reach `dma_esp32_reload()` on Espressif SoCs, and I traced each one rather than assuming.

`video_esp32_dvp.c` passes `active_vbuf->bytesused`, which `video_esp32_enqueue()` sets to `pitch * height` before the buffer ever enters the FIFO, so it is the full frame size. The two in `uart_esp32.c` pass `rx_len - rx_counter` under a guard that the counter is strictly below the length, and `rx_len` itself for a fresh buffer. The RX one in `i2s_esp32.c` computes a chunk length that falls back to the maximum when the modulo comes out zero.

That leaves the TX one in `i2s_esp32.c`, which takes `mem_block_len` directly. It can be zero, but only if an application enqueued a zero-length I2S block, which is the case this change exists to reject, and it now surfaces as `-EIO` from `i2s_write()` instead of a descriptor that transfers nothing. I would rather state that plainly than claim no caller can reach it.

## Verification

Built for `esp32s3_devkitc/esp32s3/procpu` and `esp32p4_function_ev_board/esp32p4/hpcore`, so both the AHB and the AXI instances of this driver are covered.

The rejected path itself is not exercised by an in-tree test. I have hardware for the AHB side and can add a runtime case if a reviewer would like one, though it would only be asserting that an invalid argument is refused.
