### PR TITLE
boards: espressif: esp32p4: declare DMA support

### DIFF
--- a/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
+++ b/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
@@ -10,6 +10,7 @@ testing:
     - heap
 supported:
   - counter
+  - dma
   - entropy
   - gpio
   - hwinfo

--- a/boards/espressif/esp32p4x_function_ev_board/esp32p4x_function_ev_board_hpcore.yaml
+++ b/boards/espressif/esp32p4x_function_ev_board/esp32p4x_function_ev_board_hpcore.yaml
@@ -7,6 +7,7 @@ toolchain:
   - zephyr
 supported:
   - counter
+  - dma
   - entropy
   - gpio
   - hwinfo


### PR DESCRIPTION
The two ESP32-P4 HP-core board yamls do not list `dma` in `supported`, so twister filters out every test that declares `depends_on: dma` before the board's own overlay is ever consulted. Every other GDMA-capable Espressif application core lists it, and the original ESP32 correctly does not, since it has no GDMA.

What makes this worth fixing rather than leaving alone is that the test support already exists. `tests/drivers/dma/chan_blen_transfer/socs/` and `tests/drivers/dma/loop_transfer/socs/` both carry an `esp32p4_hpcore.overlay` enabling `&dma` and a tuned `.conf`, committed with an Espressif copyright header, and neither has ever been selected. The filter also hides itself: filtered instances are only printed at `-vv` or above, so a run reports success having built nothing.

## Verification

On `esp32p4_function_ev_board/esp32p4/hpcore`, before the change:

```
drivers.dma.loop_transfer                    FILTERED: No hardware support for {'dma'}
drivers.dma.chan_blen_transfer               FILTERED: No hardware support for {'dma'}
drivers.dma.chan_blen_transfer.low_footprint FILTERED: No hardware support for {'dma'}
3 test scenarios (3 configurations) selected, 3 configurations filtered
```

and after:

```
0 of 2 executed test configurations passed (0.00%), 2 built (not run), 0 failed, 0 errored
```

So the two suites with matching overlays now build cleanly. The remaining DMA suites stay filtered by their own `platform_allow`, which has no Espressif entries.

I do not have P4 hardware, so this changes what gets built, not what gets run. If an Espressif maintainer would rather these stayed off until someone can run them on a board, I am happy to drop it.