### PR TITLE
drivers: i2s: esp32: cancel the deferred TX timer on stop

### DIFF
--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -577,6 +577,9 @@ static void IRAM_ATTR i2s_esp32_tx_stop_transfer(const struct device *dev)
 {
 	const struct i2s_esp32_cfg *dev_cfg = dev->config;
 	const struct i2s_esp32_stream *stream = &dev_cfg->tx;
+	struct i2s_esp32_data *dev_data = dev->data;
+
+	k_timer_stop(&dev_data->tx_deferred_transfer_timer);
 
 #if SOC_GDMA_SUPPORTED
 	dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);


### PR DESCRIPTION
Fixes #115505.

The deferred-completion timer is started when the TX queue runs dry and `CONFIG_I2S_ESP32_ALLOWED_EMPTY_TX_QUEUE_DEFERRAL_TIME_MS` is non-zero, and nothing ever cancels it. Left armed when the stream ends, it fires afterwards and runs the completion path against whatever state the device has reached. After a DROP that is a device already back in `READY`, and the block it consumes belongs to whatever was queued next.

`i2s_esp32_tx_stop_transfer()` is the right place for it because it is the one boundary every path that ends TX ownership goes through: DROP, a fatal callback, a completed STOP or DRAIN, and the rollback when the second direction of an `I2S_DIR_BOTH` start fails. Cancelling in the trigger cases instead would miss the callback paths.

## The self-call, which is the part worth checking

The timer's own expiry function ends at `tx_disable:` and calls this helper, so with this change the handler stops the timer that is currently expiring. That is safe, but not for an obvious reason: `z_try_abort_timeout()` only reports the in-flight case when the caller is not the CPU announcing the timeout, so a handler stopping its own timer takes the "not active" path and the call is a no-op. The timer is one-shot, started with a `K_NO_WAIT` period, so nothing re-arms behind it.

The other caller reaches the same function directly rather than through an expiry, and there the timer is simply not running, which `k_timer_stop()` documents as permitted and without effect.

## What this does not do

`k_timer_stop()` does not wait for an expiry function already executing on another CPU. I want to be accurate about where that comes from: it is **not** in the `k_timer_stop()` documentation, only in the implementation comment in `kernel/timer.c`, and neither `timer_lock` nor `timeout_lock` is held across the user callback. `k_timer_cleanup()` is the kernel's cancel-and-wait primitive, but it asserts it is not called from an ISR, so it cannot be used on this path.

So this closes the window where the timer fires long after the stream ended, which is the one that actually bites, and it does not claim to be a full barrier against a handler already running. Making it one would need a change to how this driver serialises against its own callbacks, which belongs with #115499 rather than here.

## Verification

Built for `esp32s3_devkitc/esp32s3/procpu` and `esp32_devkitc/esp32/procpu`, covering both the GDMA and the non-GDMA halves of the file.

I have not reproduced the stale expiry on hardware. The deferral is off by default, and reaching it needs a starved TX queue and a DROP inside the deferral window.