### PR TITLE
drivers: i2s: honour the configured timeout in i2s_buf_write()

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -459,6 +459,16 @@ I2C
   timeout is now using the generic ``zephyr,transfer-timeout-ms`` property
   instead of ``transfer-timeout-ms``, default to 500ms.
 
+I2S
+===
+
+* :c:func:`i2s_buf_write` now honours the ``timeout`` from the stream configuration when it
+  allocates the transmit block. It previously waited forever, so the documented ``-EAGAIN``
+  return was unreachable, as was ``-ENOMEM`` in a multithreaded build. A caller that relied
+  on the unbounded wait can set ``timeout`` to ``SYS_FOREVER_MS``, but the same field also
+  bounds the driver's enqueue wait, so no single value reproduces the old combination of an
+  unbounded allocation and a bounded enqueue.
+
 Input
 =====
 

--- a/drivers/i2s/i2s_common.c
+++ b/drivers/i2s/i2s_common.c
@@ -42,9 +42,10 @@ int z_impl_i2s_buf_write(const struct device *dev, void *buf, size_t size)
 		return -EINVAL;
 	}
 
-	ret = k_mem_slab_alloc(tx_cfg->mem_slab, &mem_block, K_FOREVER);
+	ret = k_mem_slab_alloc(tx_cfg->mem_slab, &mem_block,
+			       SYS_TIMEOUT_MS(tx_cfg->timeout));
 	if (ret < 0) {
-		return -ENOMEM;
+		return ret;
 	}
 
 	memcpy(mem_block, (void *)buf, size);

--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -100,9 +100,10 @@ static inline int z_vrfy_i2s_buf_write(const struct device *dev,
 		return -EINVAL;
 	}
 
-	ret = k_mem_slab_alloc(tx_cfg->mem_slab, &mem_block, K_FOREVER);
+	ret = k_mem_slab_alloc(tx_cfg->mem_slab, &mem_block,
+			       SYS_TIMEOUT_MS(tx_cfg->timeout));
 	if (ret < 0) {
-		return -ENOMEM;
+		return ret;
 	}
 
 	ret = k_usermode_from_copy(mem_block, buf, size);

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -318,7 +318,8 @@ struct i2s_config {
 	/** Size of one RX/TX memory block (buffer) in bytes. */
 	size_t block_size;
 	/** Read/Write timeout. Number of milliseconds to wait in case TX queue
-	 * is full or RX queue is empty, or 0, or SYS_FOREVER_MS.
+	 * is full or RX queue is empty, or 0, or SYS_FOREVER_MS. i2s_buf_write()
+	 * also applies it to the transmit block allocation.
 	 */
 	int32_t timeout;
 };
@@ -513,6 +514,10 @@ static inline int i2s_write(const struct device *dev, void *mem_block,
  * This function acquires a memory block from the I2S channel TX queue
  * and copies the provided data buffer into it. It is otherwise equivalent
  * to i2s_write().
+ *
+ * The timeout configured in @ref i2s_config applies independently to acquiring
+ * the memory block and to enqueueing it, so in the worst case this call can
+ * block for twice that period rather than once.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param buf Pointer to a buffer containing the data to transmit.

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_errors.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_errors.c
@@ -154,3 +154,44 @@ ZTEST_USER(i2s_errors, test_i2s_improper_block_size_write)
 		err, 0,
 		"I2S attempting write with incorrect block size did not raise error, err=%d", err);
 }
+
+static void write_to_exhausted_slab(int32_t timeout, int expected)
+{
+	int err;
+	char tx_data[BLOCK_SIZE] = {0};
+	struct i2s_config test_config = { .word_size = 16U,
+					  .channels = 2U,
+					  .format = I2S_FMT_DATA_FORMAT_I2S,
+					  .frame_clk_freq = FRAME_CLK_FREQ,
+					  .block_size = BLOCK_SIZE,
+					  .timeout = timeout,
+					  .options = I2S_OPT_FRAME_CLK_CONTROLLER |
+						     I2S_OPT_BIT_CLK_CONTROLLER,
+					  .mem_slab = &tx_mem_slab };
+
+	err = i2s_configure(dev_i2s, I2S_DIR_TX, &test_config);
+	zassert_equal(err, 0, "Unexpected error when configuring I2S interface: %d", err);
+
+	for (int i = 0; i < NUM_TX_BLOCKS; i++) {
+		err = i2s_buf_write(dev_i2s, tx_data, BLOCK_SIZE);
+		zassert_equal(err, 0, "Write %d of %d failed, err=%d", i + 1, NUM_TX_BLOCKS,
+			      err);
+	}
+
+	err = i2s_buf_write(dev_i2s, tx_data, BLOCK_SIZE);
+	zassert_equal(err, expected, "I2S write on an exhausted slab returned %d, expected %d",
+		      err, expected);
+
+	err = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DROP);
+	zassert_equal(err, 0, "Unexpected error when dropping the TX queue: %d", err);
+}
+
+ZTEST(i2s_errors, test_i2s_write_exhausted_slab_no_wait)
+{
+	write_to_exhausted_slab(0, -ENOMEM);
+}
+
+ZTEST_USER(i2s_errors, test_i2s_write_exhausted_slab_timeout)
+{
+	write_to_exhausted_slab(TIMEOUT, -EAGAIN);
+}


### PR DESCRIPTION
`i2s_buf_write()` acquires its memory block with `K_FOREVER`, so on a multithreaded build neither error code it documents for that step can be produced: `-ENOMEM` because `K_FOREVER` does not return it, which also leaves the `if (ret < 0)` below the call as dead code, and `-EAGAIN` because nothing ever times out. An application that exhausts the TX slab blocks forever instead of being told. Without `CONFIG_MULTITHREADING` the slab treats every timeout as no-wait, so only `-EAGAIN` is unreachable there.

Passing the configured timeout through fixes both, and `k_mem_slab_alloc()` already returns exactly the two documented codes, so the errno goes back unchanged rather than being flattened to `-ENOMEM`.

Fixes #113333

## Two stages, not one deadline

Drivers already apply the same configured timeout when enqueueing the block, so after this change the call can spend it twice, once acquiring and once enqueueing. Making it a single end-to-end deadline would need a way to pass the remaining time into `i2s_write()`, and the API has no room for that today, so I documented it as a per-stage bound rather than quietly leave the impression it is one.

That also means no single `timeout` value reproduces the old combination of an unbounded acquisition and a bounded enqueue, which is what the migration note now says.

## A related problem I am deliberately keeping out of this PR

Several drivers pass `i2s_config.timeout` straight into `K_MSEC()`. `Z_TIMEOUT_MS()` is `MAX(t, 0)`, so `SYS_FOREVER_MS` becomes `K_NO_WAIT` there, and the field documents `SYS_FOREVER_MS` as a valid value. Four drivers do this; the twenty other call sites in the subsystem already convert with `SYS_TIMEOUT_MS()`. It predates this change and is a driver fix rather than an API one, so I filed it separately as #116030.

## Testing

The two new tests queue `NUM_TX_BLOCKS` blocks without starting the stream, which leaves every one of them owned by the driver, then check that the next call reports `-ENOMEM` with a timeout of 0 and `-EAGAIN` with a finite one. Both fail before the driver's `write()`, so no loopback fixture is involved. Draining through `i2s_buf_write()` rather than the slab API keeps this usable from a user thread, since `k_mem_slab_alloc()` is not a syscall, so one helper covers the supervisor and userspace copies of the allocation.

Built for `esp32s3_devkitc/esp32s3/procpu`. I have not run the suite on hardware; it needs the loopback fixture.
