### PR TITLE
boards: st: stm32f429i_disc1: fix mirrored display on ILI9341

### DIFF
--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -76,6 +76,7 @@
 			width = <240>;
 			height = <320>;
 			rotation = <180>;
+			h-mirror;
 			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 			pwctrla = [39 2c 00 34 02];
 			pwctrlb = [00 c1 30];


### PR DESCRIPTION
The ILI9341 display on stm32f429i_disc1 renders content horizontally mirrored due to the physical orientation of the panel on the board. Add the h-mirror property to the ili9341 node so the driver toggles the MX bit in the MADCTL register, correcting the left-right flip.

Here is the issue Image
<img width="512" height="683" alt="image" src="https://github.com/user-attachments/assets/e320a9ec-4fcf-4f1c-94eb-9dd4509347f1" />

Here is the fix
<img width="512" height="683" alt="image" src="https://github.com/user-attachments/assets/84a3e7a2-de52-49e0-b0c3-1d5b9317606d" />
