### PR TITLE
Renesas RA Ethernet driver fix

### DIFF
--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -295,7 +295,11 @@ static int renesas_ra_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	fsp_err_t err;
 	int ret;
 
-	if (k_sem_take(&ctx->tx_sem, K_NO_WAIT) != 0) {
+	/*
+	 * Instead of immediately dropping the packet,
+	 * wait briefly for a free tx descriptor to become available.
+	 */
+	if (k_sem_take(&ctx->tx_sem, K_MSEC(ETHER_TX_TIMEOUT_MS)) != 0) {
 		return -ENOBUFS;
 	}
 

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -295,12 +295,17 @@ static int renesas_ra_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	fsp_err_t err;
 	int ret;
 
+	if (k_sem_take(&ctx->tx_sem, K_NO_WAIT) != 0) {
+		return -ENOBUFS;
+	}
+
 	tx_buf = ctx->txb_header[ctx->txb_idx].buf;
 	ctx->txb_idx = (ctx->txb_idx + 1) % (ctx->txb_num);
 
 	ret = net_pkt_read(pkt, tx_buf, len);
 	if (ret < 0) {
 		LOG_DBG("Failed to copy packet to tx buffer");
+		k_sem_give(&ctx->tx_sem);
 		return ret;
 	}
 	/* Pad short packets */
@@ -313,15 +318,6 @@ static int renesas_ra_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	err = R_ETHER_Write(&ctx->ctrl, tx_buf, len);
 	if (err != FSP_SUCCESS) {
 		LOG_DBG("R_ETHER_Write failed (%d)", err);
-		return -EIO;
-	}
-
-	if (k_sem_take(&ctx->tx_sem, K_NO_WAIT) != 0) {
-		return -ENOBUFS;
-	}
-
-	err = R_ETHER_Write(&ctx->ctrl, tx_buf, len);
-	if (err != FSP_SUCCESS) {
 		k_sem_give(&ctx->tx_sem);
 		return -EIO;
 	}

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -360,7 +360,11 @@ static struct net_pkt *renesas_ra_eth_rx(const struct device *dev)
 
 	err = R_ETHER_Read(&ctx->ctrl, (void *)&rx_buf, &len);
 
-	if ((err != FSP_SUCCESS) && (err != FSP_ERR_ETHER_ERROR_NO_DATA)) {
+	if (err == FSP_ERR_ETHER_ERROR_NO_DATA) {
+		return NULL;
+	}
+
+	if (err != FSP_SUCCESS) {
 		LOG_DBG("Failed to read packets");
 		goto out;
 	}
@@ -402,9 +406,7 @@ static void renesas_ra_eth_thread(void *p1, void *p2, void *p3)
 	while (true) {
 		res = k_sem_take(&ctx->rx_sem, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
 		if (res == 0) {
-			pkt = renesas_ra_eth_rx(dev);
-
-			if (pkt != NULL) {
+			while ((pkt = renesas_ra_eth_rx(dev)) != NULL) {
 				iface = net_pkt_iface(pkt);
 				res = net_recv_data(iface, pkt);
 				if (res < 0) {


### PR DESCRIPTION
During zperf/iperf tests on EK_RA8M1 and EK_RA6M5 evaluation boards I found stability issues with the new driver under load pressure.

1. Duplicate transmission issue: The recent "Renesas Ethernet driver enhance PR" https://github.com/zephyrproject-rtos/zephyr/pull/101411 contains a bug which results in each Ethernet packet being transmitted twice (`renesas_ra_eth_tx()` has two `R_ETHER_Write()` calls).

2. The second change in this PR contains a fix to wait until a buffer becomes available rather dropping packets while transmitting. For context on why: this is the k_sem_take(&ctx->tx_sem, K_NO_WAIT) → k_sem_take(&ctx->tx_sem, K_MSEC(ETHER_TX_TIMEOUT_MS)) — previously a full TX ring caused an immediate silent packet drop; now it blocks briefly for a descriptor to free up, letting TCP's actual send rate get throttled to link rate instead of relying on retransmits to recover from drops. Dropping packet degrades performance significantly. 

3. The third change addresses a similar pressure problem, but this time on the RX side. The RX thread processed exactly one frame per rx_sem credit, but the EDMAC's FR (Frame Received) interrupt bit is level-triggered — it signals "at least one frame is ready," not a count. Under bursty traffic (e.g. zperf tcp download), several frames could complete between interrupt services, but only one got drained per wakeup. Completed-but-undrained frames piled up in the RX descriptor ring until it filled, causing the EDMAC to genuinely drop incoming frames. Fix: the RX thread now drains all currently-pending frames per wakeup (while ((pkt = renesas_ra_eth_rx(dev)) != NULL)) instead of just one. Also fixed a related bug this exposed: renesas_ra_eth_rx() was falling through to R_ETHER_RxBufferUpdate() with an uninitialized buffer pointer whenever R_ETHER_Read() legitimately reported "no data" — it now returns NULL immediately in that case.

All 3 fixes combined result in a a performant and stable Ethernet transmission test using zperf and iperf with these results:

## Renesas EK-RA8M1 evaluation board:
zperf tcp upload 192.168.0.15 5001 10 1024  **83.55 Mbps** 
zperf tcp download                                         **94.72 Mbps** 
<img width="848" height="332" alt="2026-08-09_22-07-36" src="https://github.com/user-attachments/assets/904d4814-4eaa-44c6-91f3-fc201a162058" />
## Renesas EK-RA6M5 evaluation board:

zperf tcp upload 192.168.0.15 5001 10 1024  **39.42 Mbps**
zperf tcp download                                          **46.24 Mbps** 
<img width="847" height="361" alt="2026-08-09_22-05-06" src="https://github.com/user-attachments/assets/f36e6cac-ecb0-4b9c-a9fe-49e5949b658b" />

