### PR TITLE
dts: riscv: espressif: esp32p4: enable light sleep via LP timer (rtc_timer)

### DIFF
--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -13,7 +13,7 @@
 #if defined(SOC_RTC_TIMER_V2) && SOC_RTC_TIMER_V2
 #define SOC_HAS_LP_TIMER 1
 #include <soc/lp_timer_struct.h>
-#if defined(CONFIG_SOC_SERIES_ESP32C5)
+#if defined(CONFIG_SOC_SERIES_ESP32C5) || defined(CONFIG_SOC_SERIES_ESP32P4)
 #define LP_TIMER_INT_ST_ALARM LP_TIMER.int_st.soc_wakeup_int_st
 #else
 #define LP_TIMER_INT_ST_ALARM LP_TIMER.int_st.alarm

--- a/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
+++ b/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
@@ -242,6 +242,15 @@
 			};
 		};
 
+		rtc_timer: rtc_timer@50112000 {
+			compatible = "espressif,esp32-rtc-timer";
+			reg = <0x50112000 DT_SIZE_K(1)>;
+			clocks = <&clock ESP32_MODULE_MAX>;
+			interrupts = <LP_TIMER_REG0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
+			interrupt-parent = <&intc>;
+			status = "disabled";
+		};
+
 		trng0: trng@50126000 {
 			compatible = "espressif,esp32-trng";
 			reg = <0x50126000 0x4>;


### PR DESCRIPTION
ESP32-P4 declares the `light_sleep` power state in its dtsi(`power-state-name = "standby"`), but the light sleep path in `soc/espressif/common/power.c` requires the `rtc_timer` (LP timer) counter device as its wakeup timer at runtime. The P4 dtsi has no such node, so light sleep is silently skipped at runtime (`samples/boards/espressif/light_sleep` keeps printing "Sleep skipped").

Additionally, the `LP_TIMER_INT_ST_ALARM` macro in `drivers/counter/counter_esp32_rtc.c` special-cases only ESP32-C5 to read
`int_st.soc_wakeup_int_st`. ESP32-P4 has the same LP timer register layout (its `int_st` register has no `alarm` field), so merely enabling the node fails to compile.

This PR contains two commits:

1. `drivers: counter: esp32: fix LP timer int_st read on ESP32-P4` — extend the `soc_wakeup_int_st` special case to ESP32-P4.
2. `dts: riscv: espressif: esp32p4: add rtc_timer node` — add the `rtc_timer@50112000` node (disabled), matching the layout used  by esp32c5/c6/h2. Users enable it and set `wakeup-source` via overlay; the `light_sleep` sample's `app.overlay` already does this, so no sample changes are needed.