### PR TITLE
drivers: sdhc: sam_hsmci: Fix inverted manual transfer width

### DIFF
--- a/drivers/sdhc/sam_hsmci.c
+++ b/drivers/sdhc/sam_hsmci.c
@@ -538,11 +538,11 @@ static int sam_hsmci_request_inner(const struct device *dev, struct sdhc_command
 		if ((sd_data->block_size & 0x3) == 0 && (((uint32_t)sd_data->data) & 0x3) == 0) {
 			size = (sd_data->block_size + 3) >> 2;
 			hsmci->HSMCI_MR &= ~HSMCI_MR_FBYTE;
-			byte_mode = true;
+			byte_mode = false;
 		} else {
 			size = sd_data->block_size;
 			hsmci->HSMCI_MR |= HSMCI_MR_FBYTE;
-			byte_mode = false;
+			byte_mode = true;
 		}
 
 		hsmci->HSMCI_BLKR =


### PR DESCRIPTION
The byte_mode flag handed to hsmci_do_manual_transfer() was inverted with respect to the HSMCI_MR.FBYTE setting it is derived from.

When the block size is a multiple of four and the buffer is word aligned, FBYTE is cleared to select 32-bit FIFO accesses and the transfer count is computed in words, yet byte_mode was set to true. The transfer routine then walked the buffer with a uint8_t pointer and stored only the least significant byte of each word read from HSMCI_RDR, filling just the first quarter of the buffer. Writes were corrupted symmetrically, zero extending every buffer byte into a 32-bit HSMCI_TDR write. The data phase still drained the FIFO, so the request reported success while the payload was wrong.

The other branch was wrong in the opposite direction: byte mode selected a uint32_t pointer while the transfer count was in bytes, overrunning the caller buffer by a factor of four.

Only SAM E70/V71 are affected. SAM4E defines HSMCI_MR.PDCMODE and defaults to the PDC path, where this code is not compiled.

Fixes the read, write and erase cases of
tests/drivers/disk/disk_access on sam_v71_xult.