### PR TITLE
kernel/lib: rename reserved labels/variables

### DIFF
--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -114,7 +114,7 @@ int k_msgq_cleanup(struct k_msgq *msgq)
 
 	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
 		ret = -EBUSY;
-		goto exit;
+		goto out;
 	}
 
 	if ((msgq->flags & K_MSGQ_FLAG_ALLOC) != 0U) {
@@ -122,7 +122,7 @@ int k_msgq_cleanup(struct k_msgq *msgq)
 		msgq->flags &= ~K_MSGQ_FLAG_ALLOC;
 	}
 
-exit:
+out:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, cleanup, msgq, ret);
 	return ret;
 }

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -161,7 +161,7 @@ int z_impl_k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len, k_
 
 	if (unlikely(pipe_resetting(pipe))) {
 		rc = -ECANCELED;
-		goto exit;
+		goto out;
 	}
 
 	for (;;) {
@@ -212,7 +212,7 @@ int z_impl_k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len, k_
 			break;
 		}
 	}
-exit:
+out:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_pipe, write, pipe, rc);
 	if (need_resched) {
 		z_reschedule(&pipe->lock, key);
@@ -234,7 +234,7 @@ int z_impl_k_pipe_read(struct k_pipe *pipe, uint8_t *data, size_t len, k_timeout
 
 	if (unlikely(pipe_resetting(pipe))) {
 		rc = -ECANCELED;
-		goto exit;
+		goto out;
 	}
 
 	for (;;) {
@@ -262,7 +262,7 @@ int z_impl_k_pipe_read(struct k_pipe *pipe, uint8_t *data, size_t len, k_timeout
 			break;
 		}
 	}
-exit:
+out:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_pipe, read, pipe, rc);
 	if (need_resched) {
 		z_reschedule(&pipe->lock, key);

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1178,11 +1178,11 @@ static char *encode_float(double value,
 	}
 
 	/* Round the value to the last digit being printed. */
-	uint64_t round = BIT64(59); /* 0.5 */
+	uint64_t rounding = BIT64(59); /* 0.5 */
 	while (decimals-- != 0) {
-		_ldiv10(&round);
+		_ldiv10(&rounding);
 	}
-	fract += round;
+	fract += rounding;
 	/* Make sure rounding didn't make fract >= 1.0 */
 	if (fract >= BIT64(60)) {
 		_ldiv10(&fract);

--- a/lib/utils/timeutil.c
+++ b/lib/utils/timeutil.c
@@ -52,23 +52,23 @@ int64_t timeutil_timegm64(const struct tm *tm)
 	unsigned int m = tm->tm_mon + 1;
 	unsigned int d = tm->tm_mday - 1;
 	int64_t ndays = time_days_from_civil(y, m, d);
-	int64_t time = tm->tm_sec;
+	int64_t secs = tm->tm_sec;
 
-	time += 60LL * (tm->tm_min + 60LL * tm->tm_hour);
-	time += 86400LL * ndays;
+	secs += 60LL * (tm->tm_min + 60LL * tm->tm_hour);
+	secs += 86400LL * ndays;
 
-	return time;
+	return secs;
 }
 
 time_t timeutil_timegm(const struct tm *tm)
 {
-	int64_t time = timeutil_timegm64(tm);
-	time_t rv = (time_t)time;
+	int64_t secs = timeutil_timegm64(tm);
+	time_t rv = (time_t)secs;
 
 	errno = 0;
 	if ((sizeof(rv) == sizeof(int32_t))
-	    && ((time < (int64_t)INT32_MIN)
-		|| (time > (int64_t)INT32_MAX))) {
+	    && ((secs < (int64_t)INT32_MIN)
+		|| (secs > (int64_t)INT32_MAX))) {
 		errno = ERANGE;
 		rv = -1;
 	}


### PR DESCRIPTION
- **kernel: rename the reserved 'exit' labels to 'out'**
- **lib: os: cbprintf: rename the reserved local variable 'round'**
- **lib: utils: timeutil: rename the reserved local variable 'time'**
