### PR TITLE
shell: suffix the structured help magic value with U

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -330,7 +330,7 @@ struct shell_cmd_help {
  * @brief Magic number used to identify the beginning of a structured help
  * message when cast to a char pointer.
  */
-#define SHELL_STRUCTURED_HELP_MAGIC 0x86D20BC4
+#define SHELL_STRUCTURED_HELP_MAGIC 0x86D20BC4U
 
 /**
  * @endcond


### PR DESCRIPTION
SHELL_STRUCTURED_HELP_MAGIC does not fit in a signed int, so the
literal already has unsigned type; MISRA C:2012 Rule 7.2 requires that
to be stated explicitly with a U suffix.

Add the suffix.  The value and its type are unchanged.

Tested by running twister on qemu_x86 for tests/subsys/shell.
