### PR TITLE
ztest: compare test_status against an explicit enumerator

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -97,7 +97,7 @@ static void __ztest_show_suite_summary(void);
 static void end_report(void)
 {
 	__ztest_show_suite_summary();
-	if (test_status) {
+	if (test_status != ZTEST_STATUS_OK) {
 		TC_END_REPORT(TC_FAIL);
 	} else {
 		TC_END_REPORT(TC_PASS);


### PR DESCRIPTION
end_report() used the enum valued test_status directly as the
controlling expression of an if statement.  MISRA C:2012 Rule 14.4
requires that expression to have essentially boolean type.

Compare against ZTEST_STATUS_OK instead, matching how the rest of the
file tests this variable.  No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
