### PR TITLE
sys: ring_buffer: split the chained assignments in the reset helper

### DIFF
--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -87,8 +87,12 @@ int ring_buf_area_finish(struct ring_buf *buf, struct ring_buf_index *ring,
  */
 static inline void ring_buf_internal_reset(struct ring_buf *buf, ring_buf_idx_t value)
 {
-	buf->put.head = buf->put.tail = buf->put.base = value;
-	buf->get.head = buf->get.tail = buf->get.base = value;
+	buf->put.head = value;
+	buf->put.tail = value;
+	buf->put.base = value;
+	buf->get.head = value;
+	buf->get.tail = value;
+	buf->get.base = value;
 }
 
 /** @endcond */


### PR DESCRIPTION
ring_buf_internal_reset() assigned the same value to six fields with
two chained assignments.  MISRA C:2012 Rule 13.4 forbids using the
result of an assignment, which a chain necessarily does.

Write the six assignments out individually.  The generated code and
behaviour are unchanged.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
