### PR TITLE
include: name the parameters in function declarations

### DIFF
--- a/include/zephyr/kernel/obj_core.h
+++ b/include/zephyr/kernel/obj_core.h
@@ -281,7 +281,7 @@ struct k_obj_type *k_obj_type_find(uint32_t type_id);
  * @retval non-zero if walk is terminated by the callback; otherwise 0
  */
 int k_obj_type_walk_locked(struct k_obj_type *type,
-			   int (*func)(struct k_obj_core *, void *),
+			   int (*func)(struct k_obj_core *obj_core, void *data),
 				  void *data);
 
 /**
@@ -303,7 +303,7 @@ int k_obj_type_walk_locked(struct k_obj_type *type,
  * @retval non-zero if walk is terminated by the callback; otherwise 0
  */
 int k_obj_type_walk_unlocked(struct k_obj_type *type,
-			     int (*func)(struct k_obj_core *, void *),
+			     int (*func)(struct k_obj_core *obj_core, void *data),
 			     void *data);
 
 /**

--- a/include/zephyr/posix/fnmatch.h
+++ b/include/zephyr/posix/fnmatch.h
@@ -50,7 +50,7 @@
 extern "C" {
 #endif
 
-int fnmatch(const char *, const char *, int);
+int fnmatch(const char *pattern, const char *string, int flags);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/sys/libc-hooks.h
+++ b/include/zephyr/sys/libc-hooks.h
@@ -44,7 +44,7 @@ __syscall size_t zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 
 #endif /* CONFIG_NEWLIB_LIBC */
 
-void __stdout_hook_install(int (*hook)(int));
+void __stdout_hook_install(int (*hook)(int c));
 
 #ifdef CONFIG_USERSPACE
 #ifdef CONFIG_COMMON_LIBC_MALLOC

--- a/lib/libc/picolibc/stdio.c
+++ b/lib/libc/picolibc/stdio.c
@@ -56,7 +56,7 @@ FILE *const stdin = &__stdin;
 FILE *const stdout = &__stdout;
 STDIO_ALIAS(stderr);
 
-void __stdout_hook_install(int (*hook)(int))
+void __stdout_hook_install(int (*hook)(int c))
 {
 	_stdout_hook = hook;
 	__stdout.flags |= _FDEV_SETUP_WRITE;


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to
be named, including the parameters of function pointer parameters.
The object core walk callbacks, fnmatch() and the stdout hook were
declared with unnamed parameters.

Name them after the arguments the documentation already describes.
Declarations only, no functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
