### PR TITLE
sys: util: put the include guard before the direct-include check

### DIFF
--- a/include/zephyr/sys/util_internal_is_eq.h
+++ b/include/zephyr/sys/util_internal_is_eq.h
@@ -11,12 +11,12 @@
  * @brief Internal helper macros backing Z_IS_EQ().
  */
 
+#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_IS_EQ_H_
+#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_IS_EQ_H_
+
 #ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_
 #error "This header should not be used directly, please include util_internal.h instead"
 #endif /* ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_ */
-
-#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_IS_EQ_H_
-#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_IS_EQ_H_
 
 #define Z_IS_0_EQ_0(...)   \,
 #define Z_IS_0U_EQ_0(...)  \,

--- a/include/zephyr/sys/util_internal_util_dec.h
+++ b/include/zephyr/sys/util_internal_util_dec.h
@@ -15,12 +15,12 @@
  * @cond INTERNAL_HIDDEN
  */
 
+#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_DEC_H_
+#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_DEC_H_
+
 #ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_
 #error "This header should not be used directly, please include util_internal.h instead"
 #endif /* ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_ */
-
-#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_DEC_H_
-#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_DEC_H_
 
 #define Z_UTIL_DEC_0 0
 #define Z_UTIL_DEC_1 0

--- a/include/zephyr/sys/util_internal_util_inc.h
+++ b/include/zephyr/sys/util_internal_util_inc.h
@@ -15,12 +15,12 @@
  * @cond INTERNAL_HIDDEN
  */
 
+#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_INC_H_
+#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_INC_H_
+
 #ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_
 #error "This header should not be used directly, please include util_internal.h instead"
 #endif /* ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_ */
-
-#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_INC_H_
-#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_INC_H_
 
 #define Z_UTIL_INC_0 1
 #define Z_UTIL_INC_1 2

--- a/include/zephyr/sys/util_internal_util_x2.h
+++ b/include/zephyr/sys/util_internal_util_x2.h
@@ -15,12 +15,12 @@
  * @cond INTERNAL_HIDDEN
  */
 
+#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_X2_H_
+#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_X2_H_
+
 #ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_
 #error "This header should not be used directly, please include util_internal.h instead"
 #endif /* ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_H_ */
-
-#ifndef ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_X2_H_
-#define ZEPHYR_INCLUDE_SYS_UTIL_INTERNAL_UTIL_X2_H_
 
 #define Z_UTIL_X2_0 0
 #define Z_UTIL_X2_1 2

--- a/include/zephyr/sys/util_listify.h
+++ b/include/zephyr/sys/util_listify.h
@@ -10,12 +10,12 @@
  * @brief Internal helper macros backing UTIL_LISTIFY().
  */
 
+#ifndef ZEPHYR_INCLUDE_SYS_UTIL_LISTIFY_H_
+#define ZEPHYR_INCLUDE_SYS_UTIL_LISTIFY_H_
+
 #ifndef ZEPHYR_INCLUDE_SYS_UTIL_LOOPS_H_
 #error "This header should not be used directly, please include util_loops.h instead"
 #endif /* ZEPHYR_INCLUDE_SYS_UTIL_LOOPS_H_ */
-
-#ifndef ZEPHYR_INCLUDE_SYS_UTIL_LISTIFY_H_
-#define ZEPHYR_INCLUDE_SYS_UTIL_LISTIFY_H_
 
 #define Z_UTIL_LISTIFY_0(F, sep, ...)
 


### PR DESCRIPTION
These internal headers open with an #ifndef/#error block that rejects
a direct include, and only then define their own include guard.  MISRA
C:2012 Directive 4.10 wants the guard to be the first thing in the
file.

Swap the two blocks.  The #error is still the first thing evaluated
when the header is included on its own, and because it aborts the
translation unit the guard being defined first has no effect.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
