### PR TITLE
kernel: kernel_offsets: put the include guard before the includes

### DIFF
--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -3,12 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_
+#define ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_
+
 #include <zephyr/device.h>
 #include <zephyr/pm/device.h>
 #include "kernel_internal.h"
-
-#ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_
-#define ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_
 
 #include <zephyr/syscall_list.h>
 


### PR DESCRIPTION
kernel_offsets.h pulls in three headers before defining its own
include guard, so the guard is not the first thing in the file as
MISRA C:2012 Directive 4.10 requires.

Move the guard above the includes.  The header is still only used by
the offsets generator, and the includes stay inside the guard.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
