### PR TITLE
posix: features: state unsupported options as text, not commented code

### DIFF
--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -42,7 +42,7 @@
 #define _POSIX_NO_TRUNC         (0)
 #define _POSIX_VDISABLE         ('\0')
 
-/* #define _POSIX_ADVISORY_INFO (-1L) */
+/* _POSIX_ADVISORY_INFO: not supported */
 
 #ifdef CONFIG_POSIX_ASYNCHRONOUS_IO
 #define _POSIX_ASYNCHRONOUS_IO _POSIX_VERSION
@@ -60,7 +60,7 @@
 #define _POSIX_IPV6 _POSIX_VERSION
 #endif
 
-/* #define _POSIX_JOB_CONTROL (-1L) */
+/* _POSIX_JOB_CONTROL: not supported */
 
 #ifdef CONFIG_POSIX_MAPPED_FILES
 #define _POSIX_MAPPED_FILES _POSIX_VERSION
@@ -82,7 +82,7 @@
 #define _POSIX_MESSAGE_PASSING _POSIX_VERSION
 #endif
 
-/* #define _POSIX_PRIORITIZED_IO (-1L) */
+/* _POSIX_PRIORITIZED_IO: not supported */
 
 #ifdef CONFIG_POSIX_PRIORITY_SCHEDULING
 #define _POSIX_PRIORITY_SCHEDULING _POSIX_VERSION
@@ -96,8 +96,8 @@
 #define _POSIX_READER_WRITER_LOCKS _POSIX_VERSION
 #endif
 
-/* #define _POSIX_REGEXP (-1L) */
-/* #define _POSIX_SAVED_IDS (-1L) */
+/* _POSIX_REGEXP: not supported */
+/* _POSIX_SAVED_IDS: not supported */
 
 #ifdef CONFIG_POSIX_SEMAPHORES
 #define _POSIX_SEMAPHORES _POSIX_VERSION
@@ -107,14 +107,14 @@
 #define _POSIX_SHARED_MEMORY_OBJECTS _POSIX_VERSION
 #endif
 
-/* #define _POSIX_SHELL (-1L) */
-/* #define _POSIX_SPAWN (-1L) */
+/* _POSIX_SHELL: not supported */
+/* _POSIX_SPAWN: not supported */
 
 #ifdef CONFIG_POSIX_SPIN_LOCKS
 #define _POSIX_SPIN_LOCKS _POSIX_VERSION
 #endif
 
-/* #define _POSIX_SPORADIC_SERVER (-1L) */
+/* _POSIX_SPORADIC_SERVER: not supported */
 
 #ifdef CONFIG_POSIX_SYNCHRONIZED_IO
 #define _POSIX_SYNCHRONIZED_IO _POSIX_VERSION
@@ -144,11 +144,11 @@
 #define _POSIX_THREAD_PRIORITY_SCHEDULING _POSIX_VERSION
 #endif
 
-/* #define _POSIX_THREAD_PROCESS_SHARED (-1L) */
-/* #define _POSIX_THREAD_ROBUST_PRIO_INHERIT (-1L) */
-/* #define _POSIX_THREAD_ROBUST_PRIO_PROTECT (-1L) */
+/* _POSIX_THREAD_PROCESS_SHARED: not supported */
+/* _POSIX_THREAD_ROBUST_PRIO_INHERIT: not supported */
+/* _POSIX_THREAD_ROBUST_PRIO_PROTECT: not supported */
 
-/* #define _POSIX_THREAD_SPORADIC_SERVER (-1L) */
+/* _POSIX_THREAD_SPORADIC_SERVER: not supported */
 
 #ifdef CONFIG_POSIX_THREADS
 #ifndef _POSIX_THREADS
@@ -160,53 +160,53 @@
 #define _POSIX_TIMEOUTS _POSIX_VERSION
 #endif
 
-/* #define _POSIX_TRACE (-1L) */
-/* #define _POSIX_TRACE_EVENT_FILTER (-1L) */
-/* #define _POSIX_TRACE_INHERIT (-1L) */
-/* #define _POSIX_TRACE_LOG (-1L) */
-/* #define _POSIX_TYPED_MEMORY_OBJECTS (-1L) */
+/* _POSIX_TRACE: not supported */
+/* _POSIX_TRACE_EVENT_FILTER: not supported */
+/* _POSIX_TRACE_INHERIT: not supported */
+/* _POSIX_TRACE_LOG: not supported */
+/* _POSIX_TYPED_MEMORY_OBJECTS: not supported */
 
 /*
  * POSIX v6 Options
  */
-/* #define _POSIX_V6_ILP32_OFF32 (-1L) */
-/* #define _POSIX_V6_ILP32_OFFBIG (-1L) */
-/* #define _POSIX_V6_LP64_OFF64 (-1L) */
-/* #define _POSIX_V6_LPBIG_OFFBIG (-1L) */
+/* _POSIX_V6_ILP32_OFF32: not supported */
+/* _POSIX_V6_ILP32_OFFBIG: not supported */
+/* _POSIX_V6_LP64_OFF64: not supported */
+/* _POSIX_V6_LPBIG_OFFBIG: not supported */
 
 /*
  * POSIX v7 Options
  */
-/* #define _POSIX_V7_ILP32_OFF32 (-1L) */
-/* #define _POSIX_V7_ILP32_OFFBIG (-1L) */
-/* #define _POSIX_V7_LP64_OFF64 (-1L) */
-/* #define _POSIX_V7_LPBIG_OFFBIG (-1L) */
+/* _POSIX_V7_ILP32_OFF32: not supported */
+/* _POSIX_V7_ILP32_OFFBIG: not supported */
+/* _POSIX_V7_LP64_OFF64: not supported */
+/* _POSIX_V7_LPBIG_OFFBIG: not supported */
 
 /*
  * POSIX2 Options
  */
-/* #define _POSIX2_VERSION (-1) */
+/* _POSIX2_VERSION: not supported */
 #define _POSIX2_C_BIND _POSIX_VERSION
-/* #define _POSIX2_C_DEV (-1) */
-/* #define _POSIX2_CHAR_TERM (-1L) */
-/* #define _POSIX2_FORT_DEV (-1L) */
-/* #define _POSIX2_FORT_RUN (-1L) */
-/* #define _POSIX2_LOCALEDEF (-1L) */
-/* #define _POSIX2_PBS (-1L) */
-/* #define _POSIX2_PBS_ACCOUNTING (-1L) */
-/* #define _POSIX2_PBS_CHECKPOINT (-1L) */
-/* #define _POSIX2_PBS_LOCATE (-1L) */
-/* #define _POSIX2_PBS_MESSAGE (-1L) */
-/* #define _POSIX2_PBS_TRACK (-1L) */
-/* #define _POSIX2_SW_DEV (-1L) */
-/* #define _POSIX2_UPE (-1L) */
+/* _POSIX2_C_DEV: not supported */
+/* _POSIX2_CHAR_TERM: not supported */
+/* _POSIX2_FORT_DEV: not supported */
+/* _POSIX2_FORT_RUN: not supported */
+/* _POSIX2_LOCALEDEF: not supported */
+/* _POSIX2_PBS: not supported */
+/* _POSIX2_PBS_ACCOUNTING: not supported */
+/* _POSIX2_PBS_CHECKPOINT: not supported */
+/* _POSIX2_PBS_LOCATE: not supported */
+/* _POSIX2_PBS_MESSAGE: not supported */
+/* _POSIX2_PBS_TRACK: not supported */
+/* _POSIX2_SW_DEV: not supported */
+/* _POSIX2_UPE: not supported */
 
 /*
  * X/Open System Interfaces
  */
 #define _XOPEN_VERSION 700
-/* #define _XOPEN_CRYPT (-1L) */
-/* #define _XOPEN_ENH_I18N (-1L) */
+/* _XOPEN_CRYPT: not supported */
+/* _XOPEN_ENH_I18N: not supported */
 #if defined(CONFIG_XSI_REALTIME) ||                                                                \
 	(defined(CONFIG_POSIX_FSYNC) && defined(CONFIG_POSIX_MEMLOCK) &&                           \
 	 defined(CONFIG_POSIX_MEMLOCK_RANGE) && defined(CONFIG_POSIX_MESSAGE_PASSING) &&           \
@@ -214,14 +214,14 @@
 	 defined(CONFIG_POSIX_SHARED_MEMORY_OBJECTS) && defined(CONFIG_POSIX_SYNCHRONIZED_IO))
 #define _XOPEN_REALTIME _XOPEN_VERSION
 #endif
-/* #define _XOPEN_REALTIME_THREADS (-1L) */
-/* #define _XOPEN_SHM (-1L) */
+/* _XOPEN_REALTIME_THREADS: not supported */
+/* _XOPEN_SHM: not supported */
 
 #ifdef CONFIG_XOPEN_STREAMS
 #define _XOPEN_STREAMS _XOPEN_VERSION
 #endif
 
-/* #define _XOPEN_UNIX (-1L) */
-/* #define _XOPEN_UUCP (-1L) */
+/* _XOPEN_UNIX: not supported */
+/* _XOPEN_UUCP: not supported */
 
 #endif /* ZEPHYR_INCLUDE_POSIX_POSIX_FEATURES_H_ */


### PR DESCRIPTION
posix_features.h records the POSIX options Zephyr does not implement
as commented out #define lines.  MISRA C:2012 Directive 4.4 does not
allow code to be commented out, and the lines are not code anyway:
they document what is absent.

Rewrite each of them as a plain statement that the option is not
supported.  Comments only, no preprocessor output changes.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
