### PR TITLE
arch: x86: ia32: describe the stacked callee-saved registers in prose

### DIFF
--- a/include/zephyr/arch/x86/ia32/thread.h
+++ b/include/zephyr/arch/x86/ia32/thread.h
@@ -62,16 +62,9 @@ struct _callee_saved {
 	unsigned long esp;
 
 	/*
-	 * The following registers are considered non-volatile, i.e.
-	 * callee-save,
-	 * but their values are pushed onto the stack rather than stored in the
-	 * TCS
-	 * structure:
-	 *
-	 *  unsigned long ebp;
-	 *  unsigned long ebx;
-	 *  unsigned long esi;
-	 *  unsigned long edi;
+	 * The EBP, EBX, ESI and EDI registers are also considered
+	 * non-volatile, i.e. callee-save, but their values are pushed onto
+	 * the stack rather than stored in the TCS structure.
 	 */
 
 };


### PR DESCRIPTION
The _callee_saved comment listed EBP, EBX, ESI and EDI as commented
out declarations, which MISRA C:2012 Directive 4.4 flags as commented
out code.  They were never meant to be code; they document registers
that live on the stack rather than in the structure.

Say that in a sentence instead.  Comment only.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
