### PR TITLE
lib: utils: rb: describe the CHECK() debug switch in prose

### DIFF
--- a/lib/utils/rb.c
+++ b/lib/utils/rb.c
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* These assertions are very useful when debugging the tree code
- * itself, but produce significant performance degradation as they are
- * checked many times per operation.  Leave them off unless you're
- * working on the rbtree code itself
+/* Internal consistency assertions are very useful when debugging the tree
+ * code itself, but produce significant performance degradation as they are
+ * checked many times per operation.  They are therefore compiled out: define
+ * CHECK() as __ASSERT_NO_MSG() instead when working on the rbtree code itself.
  */
 #define CHECK(n) /**/
-/* #define CHECK(n) __ASSERT_NO_MSG(n) */
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/rb.h>


### PR DESCRIPTION
The commented out CHECK() definition is an instruction to whoever
debugs the rbtree code, not code that is meant to be restored as is,
and MISRA C:2012 Directive 4.4 does not allow commented out code.

Fold it into the surrounding comment as a sentence.  The empty CHECK()
definition that is actually compiled is unchanged.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
