### PR TITLE
sys: time_units: replace the octal divisor fallback with 1U

### DIFF
--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -170,7 +170,7 @@ static inline unsigned int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * GNU extension; 2. everything in this file is designed to be computed
  * at compile time anyway.
  */
-#define z_tmcvt_divisor(a, b) ((a)/(b) ? (a)/(b) : 01u)
+#define z_tmcvt_divisor(a, b) ((a)/(b) ? (a)/(b) : 1U)
 
 /*
  * Compute the offset needed to round the result correctly when


### PR DESCRIPTION
z_tmcvt_divisor() falls back to a literal 1 when the ratio of the two
frequencies truncates to zero, but it was spelled 01u.  That is an
octal constant, which MISRA C:2012 Rule 7.1 forbids outright, and it
is by far the single largest source of findings in the ECLAIR scan:
all 611 Rule 7.1 violations reported for qemu_x86 come from this one
literal, reached through every k_*_to_*_* conversion macro.

Spell it 1U.  The value is identical, so no conversion changes.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
