### PR TITLE
cbprintf: coding guidelines fixes

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -592,12 +592,12 @@ extern "C" {
 	__auto_type __v = Z_ARGIFY(Z_CONSTIFY(v)); \
 	/* Static code analysis may complain about unused variable. */ \
 	(void)__v; \
-	size_t __arg_size = _Generic((v), \
+	size_t __measured_size = _Generic((v), \
 		float : sizeof(double), \
 		default : \
 			sizeof((__v)) /* NOLINT(bugprone-sizeof-expression) */ \
 		); \
-	__arg_size; \
+	__measured_size; \
 })
 #endif
 
@@ -621,8 +621,8 @@ extern "C" {
 		/* Static code analysis may complain about unused variable. */ \
 		(void)_v; \
 		(void)_d; \
-		size_t arg_size = Z_CBPRINTF_ARG_SIZE(arg); \
-		size_t _wsize = arg_size / sizeof(int); \
+		size_t _stored_size = Z_CBPRINTF_ARG_SIZE(arg); \
+		size_t _wsize = _stored_size / sizeof(int); \
 		z_cbprintf_wcpy((int *)(buf), \
 			      (int *) _Generic(Z_ARGIFY(arg), float : &_d, default : &_v), \
 			      _wsize); \
@@ -713,7 +713,7 @@ do { \
 		(_idx) += sizeof(int); \
 		(_align_offset) += sizeof(int); \
 	} \
-	uint32_t _arg_size = Z_CBPRINTF_ARG_SIZE(_arg); \
+	uint32_t _packed_size = Z_CBPRINTF_ARG_SIZE(_arg); \
 	uint8_t _loc = (uint8_t)(_idx / sizeof(int)); \
 	if (arg_idx < 1 + _fros_cnt) { \
 		if (_ros_pos_en) { \
@@ -743,8 +743,8 @@ do { \
 	if ((_buf) && (_idx) < (int)(_max)) { \
 		Z_CBPRINTF_STORE_ARG(&(_buf)[(_idx)], _arg); \
 	} \
-	(_idx) += (_arg_size); \
-	(_align_offset) += (_arg_size); \
+	(_idx) += (_packed_size); \
+	(_align_offset) += (_packed_size); \
 } while (false)
 
 /** @brief Package single argument.

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -734,7 +734,11 @@ do { \
 		} else if (_rws_pos_en) { \
 			_rws_buffer[_rws_pos_idx++] = arg_idx - 1; \
 			_rws_buffer[_rws_pos_idx++] = (uint8_t)(_idx / sizeof(int)); \
+		} else { \
+			/* Neither position buffer is enabled, nothing to record. */ \
 		} \
+	} else { \
+		/* Not a read-only string argument, nothing to record. */ \
 	} \
 	if ((_buf) && (_idx) < (int)(_max)) { \
 		Z_CBPRINTF_STORE_ARG(&(_buf)[(_idx)], _arg); \


### PR DESCRIPTION
- **sys: cbprintf: terminate the argument packing if-else chains**
- **sys: cbprintf: give the nested argument size locals distinct names**
