### PR TITLE
sys: atomic: only expose the documentation prototypes to Doxygen

### DIFF
--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -269,6 +269,15 @@ static inline void atomic_set_bit_to(atomic_t *target, int bit, bool val)
 	}
 }
 
+/*
+ * The declarations below exist only so that Doxygen has a single place to
+ * document the low-level atomic API.  Every backend selected above already
+ * declares these functions, and does so with internal linkage when they are
+ * static inline, so repeating them here unqualified would violate MISRA
+ * C:2012 Rule 8.8.
+ */
+#ifdef __DOXYGEN__
+
 /**
  * @brief Atomic compare-and-set.
  *
@@ -501,6 +510,8 @@ atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
  * @return Previous value of @a target.
  */
 atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
+
+#endif /* __DOXYGEN__ */
 
 /**
  * @}


### PR DESCRIPTION
atomic.h first includes one of the four low-level backends, each of
which declares the sixteen primitives, and then declares them again
without a storage class purely so Doxygen has one place to document
them.  Three of the backends define the primitives static inline, so
those identifiers have internal linkage and the unqualified
re-declarations violate MISRA C:2012 Rule 8.8.  That accounts for all
1440 Rule 8.8 findings in the scan: sixteen declarations seen from
ninety translation units.

Wrap the documentation block in __DOXYGEN__, which the doxyfile
already predefines.  Every backend selected above the block declares
all sixteen functions, so nothing loses a declaration.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
