### PR TITLE
drivers: ethernet: phy: vsc8541: Add pad edge-rate control

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -42,6 +42,9 @@ LOG_MODULE_REGISTER(microchip_vsc8541, CONFIG_PHY_LOG_LEVEL);
 
 /* Extended Register */
 #define PHY_REG_PAGE2_RGMII_CONTROL         PHY_REG(PHY_PAGE_2, 0x14)
+#define PHY_REG_PAGE2_WOL_MAC_IF_CONTROL    PHY_REG(PHY_PAGE_2, 0x1B)
+
+#define PHY_REG_PAGE2_WOL_MAC_IF_CONTROL_PAD_EDGE_RATE GENMASK(7, 5)
 
 #define PHY_REG_PAGE0_EXT_DEV_AUX_DUPLEX    BIT(5)
 #define PHY_REG_PAGE0_INT_MASK_MDINT_EN     BIT(15)
@@ -63,6 +66,7 @@ struct mc_vsc8541_config {
 	enum phy_link_speed default_speeds;
 	uint8_t rgmii_rx_clk_delay;
 	uint8_t rgmii_tx_clk_delay;
+	uint8_t pad_edge_rate;
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	const struct gpio_dt_spec reset_gpio;
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios) */
@@ -201,6 +205,19 @@ static int phy_mc_vsc8541_reset(const struct device *dev)
 			return -ETIMEDOUT;
 		}
 	} while ((reg & MII_BMCR_RESET) != 0U);
+
+	/* Configure the MAC interface pad edge rate. */
+	ret = phy_mc_vsc8541_read(dev, PHY_REG_PAGE2_WOL_MAC_IF_CONTROL, &reg);
+	if (ret < 0) {
+		return ret;
+	}
+	reg &= ~PHY_REG_PAGE2_WOL_MAC_IF_CONTROL_PAD_EDGE_RATE;
+	reg |= FIELD_PREP(PHY_REG_PAGE2_WOL_MAC_IF_CONTROL_PAD_EDGE_RATE,
+			  cfg->pad_edge_rate);
+	ret = phy_mc_vsc8541_write(dev, PHY_REG_PAGE2_WOL_MAC_IF_CONTROL, reg);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/* configure the RGMII clk delay */
 	reg = 0x0;
@@ -654,6 +671,7 @@ static int phy_mc_vsc8541_init(const struct device *dev)
 		.microchip_interface_type = DT_INST_ENUM_IDX(n, microchip_interface_type),         \
 		.rgmii_rx_clk_delay = DT_INST_PROP(n, microchip_rgmii_rx_clk_delay),               \
 		.rgmii_tx_clk_delay = DT_INST_PROP(n, microchip_rgmii_tx_clk_delay),               \
+		.pad_edge_rate = DT_INST_PROP(n, microchip_pad_edge_rate),                         \
 		.default_speeds = PHY_INST_GENERATE_DEFAULT_SPEEDS(n),                             \
 		RESET_GPIO(n)                                                                      \
 		INTERRUPT_GPIO(n)};                                                                \

--- a/dts/bindings/ethernet/phy/microchip,vsc8541.yaml
+++ b/dts/bindings/ethernet/phy/microchip,vsc8541.yaml
@@ -47,6 +47,18 @@ properties:
       Used to configure the TX clock delay for RGMII interface. The value can be
       0 to 7. Refer to the datasheet for more details on the delay settings.
 
+  microchip,pad-edge-rate:
+    type: int
+    default: 7
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: |
+      Edge-rate setting for the PHY's MAC-interface output pins, including
+      RXD, RX_CLK/CRS_DV/RX_CTL, and MDIO read data. Zero selects the slowest
+      edge rate and 7 selects the fastest edge rate and power-on default.
+      Slower settings can reduce MAC-interface power consumption, EMI, and
+      signal overshoot or ringing. Refer to the datasheet for the recommended
+      setting at a given VDDMAC voltage.
+
   default-speeds:
     default: ["10BASE Half-Duplex", "10BASE Full-Duplex", "100BASE Half-Duplex",
               "100BASE Full-Duplex", "1000BASE Half-Duplex", "1000BASE Full-Duplex"]


### PR DESCRIPTION
The VSC8541 MAC-interface pad edge rate depends on the VDDMAC supply voltage and board-level signal-integrity requirements. The driver currently leaves the setting at its reset default, so boards cannot select the value recommended for their electrical design.

Add a microchip,pad-edge-rate devicetree property accepting values 0 through 7. Default it to 7 to preserve existing behavior, and program the selected value into page 2 register 27 after the PHY software reset.

Here is a diff between rate 7 to 0.
<img width="1920" height="1080" alt="vsc8541-rxd0-rate7-vs-rate0" src="https://github.com/user-attachments/assets/7d3fac7b-8b08-4edd-8221-e998e2192a83" />
