### PR TITLE
drivers: serial: nrfx_uarte: bound RXTO wait in pm_suspend to avoid indefinite hang

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -3060,10 +3060,15 @@ static int uarte_pm_suspend(const struct device *dev)
 			}
 #endif
 			nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPRX);
-			while (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO)) {
-				/* Busy wait for event to register */
-				Z_SPIN_DELAY(2);
-			}
+			/* RXSTARTED may be a stale event from a previous firmware (e.g. a
+			 * chain-loading bootloader), in which case STOPRX yields no RXTO.
+			 * The wait should be bounded to avoid hanging forever.
+			 */
+			bool got_rxto;
+
+			NRFX_WAIT_FOR(nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO),
+				      1000, 1, got_rxto);
+
 			nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
 			nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
 			nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);


### PR DESCRIPTION
## Problem summary
`uarte_pm_suspend()`'s non-async branch triggers `NRF_UARTE_TASK_STOPRX` whenever `NRF_UARTE_EVENT_RXSTARTED` is set, then waits **unconditionally** for `NRF_UARTE_EVENT_RXTO` before proceeding to disable the peripheral:

```c
while (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO)) {
        Z_SPIN_DELAY(2);
}
```

`RXSTARTED` can be set without RX ever having actually run *during the current boot* if the peripheral was previously used by another firmware image that chain-loads into this one without a CPU/peripheral reset (e.g. a bootloader that leaves UARTE register state behind and jumps straight to the application). In that case `STOPRX` produces no `RXTO`, and this loop spins forever - hanging the whole system in a PM suspend callback, indefinitely, with no way to recover.

**Observed issue:** Old bootloader (in the field) UART rx enabled, no power management loads a new application which has `disable-rx` set in DT and power management enabled. -> Boot hangs.

## Fix

Replace the endless busy wait with the `NRFX_WAIT_FOR()` bounded-wait macro, similar as present in `wait_for_tx_stopped()` for the equivalent TX-side wait on TXSTOPPED.

Wait up to 1000 * 1us = 1ms for RXTO, then unconditionally clear the RX event state and continue. In the
normal/healthy case RXTO follows STOPRX almost immediately (worst case about one byte time), so this adds no observable delay in the common case. It only bounds the non-happy case where RXTO never arrives.

## Notes for reviewers

* This is a general driver robustness fix, not specific to any particular bootloader or board. `uarte_pm_suspend()` should never spin indefinitely regardless of why RXTO doesn't arrive.
* The bounded-wait pattern mirrors the existing `wait_for_tx_stopped()` in the same file, which already uses `NRFX_WAIT_FOR(..., 1000, 1, res)` for the equivalent TX-side wait.