### PR TITLE
drivers: ethernet: dwc_mac: nxp: add support for the mcxe31b

### DIFF
--- a/boards/nxp/frdm_mcxe31b/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxe31b/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_FRDM_MCXE31B
+
+configdefault NET_L2_ETHERNET
+	default y
+
+endif # BOARD_FRDM_MCXE31B

--- a/boards/nxp/frdm_mcxe31b/doc/index.rst
+++ b/boards/nxp/frdm_mcxe31b/doc/index.rst
@@ -71,6 +71,40 @@ controller, refer to the device reference manual.
 +-------+-------------+---------------------------+
 | PTA6  | FLEXCAN0    | CAN0 RX                   |
 +-------+-------------+---------------------------+
+| PTB4  | EMAC        | Ethernet MDIO             |
++-------+-------------+---------------------------+
+| PTB5  | EMAC        | Ethernet MDC              |
++-------+-------------+---------------------------+
+| PTC0  | EMAC        | Ethernet RMII RXD1        |
++-------+-------------+---------------------------+
+| PTC1  | EMAC        | Ethernet RMII RXD0        |
++-------+-------------+---------------------------+
+| PTC2  | EMAC        | Ethernet RMII TXD0        |
++-------+-------------+---------------------------+
+| PTC3  | GPIO        | Ethernet PHY reset        |
++-------+-------------+---------------------------+
+| PTC17 | EMAC        | Ethernet RMII RX_DV       |
++-------+-------------+---------------------------+
+| PTD7  | EMAC        | Ethernet RMII TXD1        |
++-------+-------------+---------------------------+
+| PTD11 | EMAC        | Ethernet RMII REF_CLK     |
++-------+-------------+---------------------------+
+| PTD12 | EMAC        | Ethernet RMII TX_EN       |
++-------+-------------+---------------------------+
+
+Ethernet
+========
+
+The board carries a Microchip LAN8741 10/100 Mbit/s PHY on MDIO address 0,
+connected to the MCXE31B EMAC over RMII. The EMAC is a Synopsys DesignWare
+Ethernet QoS core and is driven by the generic
+:zephyr_file:`drivers/ethernet/dwc_mac` driver, not by the NXP HAL based
+``eth_nxp_enet_qos`` driver.
+
+The PHY sources the 50 MHz RMII reference clock, which the SoC takes in on
+``PTD11`` and divides by two to clock the MAC's MII side. The driver also
+supports MII, selected with ``phy-connection-type``, though this board is
+wired for RMII.
 
 System Clock
 ============

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
@@ -135,6 +135,46 @@
 		};
 	};
 
+	pinmux_emac: pinmux_emac {
+		group1 {
+			/* RMII outputs. The slowest slew rate matches NXP's
+			 * reference pin configuration for this board.
+			 */
+			pinmux = <PTC2_EMAC_MII_RMII_TXD0>,
+				 <PTD7_EMAC_MII_RMII_TXD1>,
+				 <PTD12_EMAC_MII_RMII_TX_EN>;
+			output-enable;
+			slew-rate = "slowest";
+		};
+
+		group2 {
+			pinmux = <PTC1_EMAC_MII_RMII_RXD0>,
+				 <PTC0_EMAC_MII_RMII_RXD1>,
+				 <PTC17_EMAC_MII_RMII_RX_DV>;
+			input-enable;
+		};
+
+		group3 {
+			/* 50 MHz RMII reference clock supplied by the PHY */
+			pinmux = <PTD11_EMAC_MII_RMII_TX_CLK>;
+			input-enable;
+			slew-rate = "slowest";
+		};
+	};
+
+	pinmux_emac_mdio: pinmux_emac_mdio {
+		group1 {
+			pinmux = <(PTB4_EMAC_MII_RMII_MDIO_O | PTB4_EMAC_MII_RMII_MDIO_I)>;
+			input-enable;
+			output-enable;
+		};
+
+		group2 {
+			pinmux = <PTB5_EMAC_MII_RMII_MDC>;
+			output-enable;
+		};
+	};
+
 	pinmux_sai_0: pinmux_sai_0 {
 		group1 {
 			/* Each entry combines the pad's output mux with its

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -186,6 +186,29 @@
 	status = "okay";
 };
 
+&emac {
+	pinctrl-0 = <&pinmux_emac>;
+	pinctrl-names = "default";
+	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&pinmux_emac_mdio>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	/* Microchip LAN8741 */
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+		reset-gpios = <&gpioc_l 3 GPIO_ACTIVE_LOW>;
+		reset-assert-duration-us = <25000>;
+		reset-deassertion-timeout-ms = <25>;
+	};
+};
+
 /*
  * SAI0 on header J1: D0 = PTB2, BCLK = PTC12, SYNC = PTC13. The
  * transmitter drives all three pads and each pad's input buffer feeds

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -23,4 +23,5 @@ supported:
   - pwm
   - i2s
   - spi
+  - netif:eth
 vendor: nxp

--- a/drivers/clock_control/clock_control_nxp_mc_cgm.c
+++ b/drivers/clock_control/clock_control_nxp_mc_cgm.c
@@ -41,6 +41,61 @@ const clock_pcfs_config_t pcfs_config = {.maxAllowableIDDchange = NXP_PLL_MAXIDO
 					 .clkSrcFreq = NXP_PLL_CLKSRCFREQ};
 #endif
 
+#define MC_CGM_EMAC_NODE DT_NODELABEL(emac)
+
+/*
+ * The EMAC RX/TX/TS source muxes have to be attached before the MAC leaves
+ * reset, and which source is correct depends on the PHY interface selected in
+ * devicetree. Only set them up on SoCs that have an EMAC and only when it is
+ * actually enabled.
+ */
+#if defined(FSL_FEATURE_CLOCK_HAS_EMAC) && (FSL_FEATURE_CLOCK_HAS_EMAC != 0U) && \
+	DT_NODE_HAS_STATUS_OKAY(MC_CGM_EMAC_NODE)
+#define MC_CGM_HAS_EMAC 1
+
+/*
+ * Clock rates the PHY drives into the SoC, both fixed by IEEE 802.3: RMII
+ * supplies a single 50 MHz reference, MII separate transmit and receive clocks
+ * that run at 25 MHz for 100 Mbps.
+ */
+#define MC_CGM_EMAC_RMII_REF_CLK_HZ 50000000U
+#define MC_CGM_EMAC_MII_CLK_HZ      25000000U
+
+#if DT_ENUM_HAS_VALUE(MC_CGM_EMAC_NODE, phy_connection_type, rmii)
+/*
+ * The one reference clock feeds all three domains, and the MAC clocks its
+ * MII-side logic at half the RMII rate.
+ */
+#define MC_CGM_EMAC_TXPAD_CLK_HZ MC_CGM_EMAC_RMII_REF_CLK_HZ
+#define MC_CGM_EMAC_RXPAD_CLK_HZ 0U
+#define MC_CGM_EMAC_RX_ATTACH    kEMAC_RMII_TX_CLK_to_EMAC_RX
+#define MC_CGM_EMAC_RX_SRC       CLOCK_EMAC_RMII_TX_CLK
+#define MC_CGM_EMAC_TS_ATTACH    kEMAC_RMII_TX_CLK_to_EMAC_TS
+#define MC_CGM_EMAC_TS_SRC       CLOCK_EMAC_RMII_TX_CLK
+#define MC_CGM_EMAC_CLK_DIV      2U
+#elif DT_ENUM_HAS_VALUE(MC_CGM_EMAC_NODE, phy_connection_type, mii)
+/*
+ * The PHY drives the transmit and receive clocks on separate pads, already at
+ * the MII-side rate. The timestamp unit is fed from the transmit clock, which
+ * means it follows the link speed - fine at 100 Mbps, ten times slower at
+ * 10 Mbps.
+ */
+#define MC_CGM_EMAC_TXPAD_CLK_HZ MC_CGM_EMAC_MII_CLK_HZ
+#define MC_CGM_EMAC_RXPAD_CLK_HZ MC_CGM_EMAC_MII_CLK_HZ
+#define MC_CGM_EMAC_RX_ATTACH    kEMAC_RX_CLK_to_EMAC_RX
+#define MC_CGM_EMAC_RX_SRC       CLOCK_EMAC_RX_CLK
+#define MC_CGM_EMAC_TS_ATTACH    kEMAC_RMII_TX_CLK_to_EMAC_TS
+#define MC_CGM_EMAC_TS_SRC       CLOCK_EMAC_RMII_TX_CLK
+#define MC_CGM_EMAC_CLK_DIV      1U
+#else
+#error "Unsupported PHY connection type for the MCXE Ethernet MAC"
+#endif
+
+/* The transmit clock always comes off the same pad, in either mode. */
+#define MC_CGM_EMAC_TX_ATTACH kEMAC_RMII_TX_CLK_to_EMAC_TX
+#define MC_CGM_EMAC_TX_SRC    CLOCK_EMAC_RMII_TX_CLK
+#endif
+
 /*
  * SDK defines FSL_FEATURE_SOC_<IP>_COUNT as `(N)` with parentheses, which
  * breaks Zephyr's LISTIFY (it token-pastes LEN into a macro name and needs
@@ -119,6 +174,9 @@ static const struct mc_cgm_gate_entry mc_cgm_gate_map[] = {
 	LISTIFY(MC_CGM_COUNT(FSL_FEATURE_SOC_I2S_COUNT),
 		MC_CGM_GATE_ENTRY, (,), SAI, Sai),
 #endif
+#if defined(MC_CGM_HAS_EMAC)
+	{ MCUX_EMAC_CLK, kCLOCK_Emac },
+#endif
 };
 
 /*
@@ -189,6 +247,77 @@ static const struct mc_cgm_rate_entry *mc_cgm_lookup_rate(uint32_t subsys)
 	return NULL;
 }
 
+#if defined(MC_CGM_HAS_EMAC)
+/*
+ * SELSTAT sits in the same bits of every mux status register, so one mask
+ * covers all three. Assert it rather than leaving it to chance.
+ */
+#define MC_CGM_EMAC_SELSTAT_MASK MC_CGM_MUX_7_CSS_SELSTAT_MASK
+BUILD_ASSERT(MC_CGM_MUX_8_CSS_SELSTAT_MASK == MC_CGM_EMAC_SELSTAT_MASK);
+BUILD_ASSERT(MC_CGM_MUX_9_CSS_SELSTAT_MASK == MC_CGM_EMAC_SELSTAT_MASK);
+
+/*
+ * Every EMAC clock domain is derived from a clock the PHY drives into the SoC,
+ * so these must run only once the pads are muxed: the glitchless MC_CGM mux
+ * refuses to switch to a source that is not toggling and silently leaves the
+ * domain on FIRC, which is close enough to keep framing packets but far enough
+ * off to corrupt every one of them. CLOCK_AttachClk() reports success either
+ * way, so check the status register.
+ */
+struct mc_cgm_emac_clk {
+	volatile const uint32_t *css;
+	uint32_t src;
+	clock_attach_id_t attach;
+	clock_div_name_t div_name;
+};
+
+static const struct mc_cgm_emac_clk mc_cgm_emac_rx_clk = {
+	.attach = MC_CGM_EMAC_RX_ATTACH,
+	.div_name = kCLOCK_DivEmacRxClk,
+	.css = &MC_CGM->MUX_7_CSS,
+	.src = MC_CGM_EMAC_RX_SRC,
+};
+
+static const struct mc_cgm_emac_clk mc_cgm_emac_tx_clk = {
+	.attach = MC_CGM_EMAC_TX_ATTACH,
+	.div_name = kCLOCK_DivEmacTxClk,
+	.css = &MC_CGM->MUX_8_CSS,
+	.src = MC_CGM_EMAC_TX_SRC,
+};
+
+static const struct mc_cgm_emac_clk mc_cgm_emac_ts_clk = {
+	.attach = MC_CGM_EMAC_TS_ATTACH,
+	.div_name = kCLOCK_DivEmacTsClk,
+	.css = &MC_CGM->MUX_9_CSS,
+	.src = MC_CGM_EMAC_TS_SRC,
+};
+
+static int mc_cgm_emac_attach(const struct mc_cgm_emac_clk *clk)
+{
+	/* Tell the SDK what the PHY drives into the pads; software state only. */
+	CLOCK_SetEmacRmiiTxClkFreq(MC_CGM_EMAC_TXPAD_CLK_HZ);
+	if (MC_CGM_EMAC_RXPAD_CLK_HZ != 0U) {
+		CLOCK_SetEmacRxClkFreq(MC_CGM_EMAC_RXPAD_CLK_HZ);
+	}
+
+	if (CLOCK_AttachClk(clk->attach) != kStatus_Success) {
+		return -EIO;
+	}
+
+	if (FIELD_GET(MC_CGM_EMAC_SELSTAT_MASK, *clk->css) != clk->src) {
+		LOG_ERR("EMAC clock did not switch to source %u; "
+			"is the pin muxed and is the PHY driving it?", clk->src);
+		return -EIO;
+	}
+
+	if (CLOCK_SetClkDiv(clk->div_name, MC_CGM_EMAC_CLK_DIV) != kStatus_Success) {
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif /* defined(MC_CGM_HAS_EMAC) */
+
 static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsys_t sub_system)
 {
 	uint32_t clock_name = (uint32_t)sub_system;
@@ -209,6 +338,14 @@ static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsy
 	case MCUX_TEMPSENSE_CLK:
 		CLOCK_EnableClock(kCLOCK_TempSensor);
 		return 0;
+#endif
+#if defined(MC_CGM_HAS_EMAC)
+	case MCUX_EMACRX_CLK:
+		return mc_cgm_emac_attach(&mc_cgm_emac_rx_clk);
+	case MCUX_EMACTX_CLK:
+		return mc_cgm_emac_attach(&mc_cgm_emac_tx_clk);
+	case MCUX_EMACTS_CLK:
+		return mc_cgm_emac_attach(&mc_cgm_emac_ts_clk);
 #endif
 	case MCUX_SIRC_CLK:
 		return 0;
@@ -236,6 +373,12 @@ static int mc_cgm_clock_control_off(const struct device *dev, clock_control_subs
 #if defined(CONFIG_NXP_TEMPSENSE)
 	case MCUX_TEMPSENSE_CLK:
 		CLOCK_DisableClock(kCLOCK_TempSensor);
+		return 0;
+#endif
+#if defined(MC_CGM_HAS_EMAC)
+	case MCUX_EMACRX_CLK:
+	case MCUX_EMACTX_CLK:
+	case MCUX_EMACTS_CLK:
 		return 0;
 #endif
 	case MCUX_SIRC_CLK:
@@ -273,8 +416,23 @@ static int mc_cgm_get_subsys_rate(const struct device *dev, clock_control_subsys
 		*rate = CLOCK_GetCoreClkFreq();
 		return 0;
 	case MCUX_AIPSPLAT_CLK:
+#if defined(MC_CGM_HAS_EMAC)
+	/* The EMAC CSR (register) interface is clocked from AIPS_PLAT_CLK. */
+	case MCUX_EMAC_CLK:
+#endif
 		*rate = CLOCK_GetAipsPlatClkFreq();
 		return 0;
+#if defined(MC_CGM_HAS_EMAC)
+	case MCUX_EMACRX_CLK:
+		*rate = CLOCK_GetEmacRxClkFreq();
+		return 0;
+	case MCUX_EMACTX_CLK:
+		*rate = CLOCK_GetEmacTxClkFreq();
+		return 0;
+	case MCUX_EMACTS_CLK:
+		*rate = CLOCK_GetEmacTsClkFreq();
+		return 0;
+#endif
 	case MCUX_HSE_CLK:
 		*rate = CLOCK_GetHseClkFreq();
 		return 0;

--- a/drivers/ethernet/dwc_mac/CMakeLists.txt
+++ b/drivers/ethernet/dwc_mac/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_PERFECT eth_d
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ETH_DWMAC_MMU eth_dwmac_mmu.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_ESP32_DWC_ETHER_1000 eth_esp32_dwc_ether_1000.c)
+zephyr_library_sources_ifdef(CONFIG_ETH_NXP_DWC_ETHER_QOS eth_nxp_dwc_ether_qos.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_STM32_DWC_ETHER_1000 eth_stm32_dwc_ether_1000.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_STM32_DWC_ETHER_QOS eth_stm32_dwc_ether_qos.c)
 # zephyr-keep-sorted-stop

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -11,6 +11,9 @@ config ETH_DWC_ETHER_QOS_CORE
 	bool
 	depends on NET_BUF_FIXED_DATA_SIZE
 	select CACHE_MANAGEMENT if DCACHE
+	# The DMA descriptor rings are not cache maintained, so they need an
+	# uncached region, which on ARM can only be carved out by the MPU.
+	select ARM_MPU if CPU_HAS_ARM_MPU && DCACHE
 	help
 	  This is a driver for the Synopsys DesignWare Ethernet MAC 10/100/1G Quality-of-Service,
 	  also referred to as "dwc_ether_qos".
@@ -20,6 +23,9 @@ config ETH_DWC_ETHER_1000_CORE
 	bool
 	depends on NET_BUF_FIXED_DATA_SIZE
 	select CACHE_MANAGEMENT if DCACHE
+	# The DMA descriptor rings are not cache maintained, so they need an
+	# uncached region, which on ARM can only be carved out by the MPU.
+	select ARM_MPU if CPU_HAS_ARM_MPU && DCACHE
 	help
 	  This is a driver for the Synopsys DesignWare Ethernet MAC 10/100/1G Universal,
 	  also referred to as "dwc_ether_mac10_100_1000_universal".

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -42,6 +42,20 @@ config ETH_ESP32_DWC_ETHER_1000
 	help
 	  This enables the Synopsys DesignWare MAC driver for ESP32 SoCs.
 
+config ETH_NXP_DWC_ETHER_QOS
+	bool "Driver for DWC Ethernet QoS-based NXP"
+	depends on SOC_SERIES_MCXE31X
+	depends on DT_HAS_NXP_ENET_QOS_ENABLED
+	select ETH_DWC_ETHER_QOS_CORE
+	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
+	select PINCTRL
+	select HWINFO
+	select CRC
+	default y
+	help
+	  This enables the Synopsys DesignWare MAC driver on NXP MCXE series
+	  SoCs, where the IP is named EMAC.
+
 config ETH_STM32_DWC_ETHER_QOS
 	bool "Driver for DWC Ethernet QoS-based STM32"
 	depends on !ETH_STM32_HAL

--- a/drivers/ethernet/dwc_mac/eth_nxp_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_nxp_dwc_ether_qos.c
@@ -1,0 +1,217 @@
+/*
+ * Driver for Synopsys DesignWare MAC
+ *
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NXP specific glue.
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
+
+#define DT_DRV_COMPAT nxp_enet_qos
+
+#include <sys/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/irq.h>
+#include <fsl_device_registers.h>
+
+#include "eth_dwmac_priv.h"
+
+/* The DMA bus master interface is 32-bit on this IP */
+#define DATA_BUS_WIDTH 32
+
+DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
+
+#if DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
+#define PHY_MODE 0U
+#elif DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)
+#define PHY_MODE 1U
+#else
+#error "Unsupported PHY connection type"
+#endif
+
+/*
+ * OUI used when devicetree carries no MAC address and one has to be derived
+ * from the chip's unique ID. NXP prints a per-board address from this same OUI
+ * on the board label, but does not store it anywhere the SoC can read; set
+ * local-mac-address in devicetree to use that one instead.
+ */
+#define NXP_OUI_BYTE_0 0x00
+#define NXP_OUI_BYTE_1 0x04
+#define NXP_OUI_BYTE_2 0x9f
+
+/* Locally administered address bit of the first MAC octet */
+#define ETH_MAC_LAA_BIT 0x02
+
+PINCTRL_DT_INST_DEFINE(0);
+static const struct pinctrl_dev_config *eth0_pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0);
+
+/* The mc_cgm clock cell is itself named "name", hence the repetition. */
+#define NXP_ETH_CLOCK_SUBSYS(clk)                                                                 \
+	(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(0, clk, name)
+
+static const clock_control_subsys_t eth0_clocks[] = {
+	NXP_ETH_CLOCK_SUBSYS(tx),
+	NXP_ETH_CLOCK_SUBSYS(rx),
+	NXP_ETH_CLOCK_SUBSYS(ptp),
+	NXP_ETH_CLOCK_SUBSYS(mac),
+};
+
+int dwmac_bus_init(const struct device *dev)
+{
+	const struct dwmac_config *cfg = dev->config;
+	int ret;
+
+	/* Mux the pads first: the clocks below are derived from what they carry. */
+	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("Could not configure ethernet pins");
+		return ret;
+	}
+
+	/* Select the PHY interface. */
+	DCM_GPR->DCMRWF1 = (DCM_GPR->DCMRWF1 & ~DCM_GPR_DCMRWF1_RMII_MII_SEL_MASK) |
+			   DCM_GPR_DCMRWF1_RMII_MII_SEL(PHY_MODE);
+
+	/*
+	 * The transmit, receive and timestamp clocks are derived from clocks the
+	 * PHY drives into the SoC, which is why the pads are muxed first.
+	 */
+	for (size_t n = 0; n < ARRAY_SIZE(eth0_clocks); n++) {
+		ret = clock_control_on(cfg->clock, eth0_clocks[n]);
+		if (ret != 0) {
+			LOG_ERR("Failed to enable ethernet clock #%zu (%d)", n, ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+#define DESCRIPTOR_ALIGNMENT ((DATA_BUS_WIDTH) / (BITS_PER_BYTE))
+#if defined(CONFIG_NOCACHE_MEMORY)
+#define __desc_mem __nocache __aligned(DESCRIPTOR_ALIGNMENT)
+#else
+/*
+ * The core driver maintains the cache for the packet buffers but not for the
+ * descriptors, so those have to live in memory the DMA and the CPU see alike.
+ */
+BUILD_ASSERT(!IS_ENABLED(CONFIG_DCACHE),
+	     "DMA descriptors would be cached; enable CONFIG_ARM_MPU to get a nocache region");
+#define __desc_mem __aligned(DESCRIPTOR_ALIGNMENT)
+#endif
+
+/* Descriptor rings in uncached memory */
+static struct dwmac_dma_desc dwmac_tx_descs[NB_TX_DESCS] __desc_mem;
+static struct dwmac_dma_desc dwmac_rx_descs[NB_RX_DESCS] __desc_mem;
+
+static int nxp_load_mac_addr(const struct net_eth_mac_config *cfg, uint8_t *mac_addr)
+{
+	uint8_t unique_device_id[16] = {0};
+	ssize_t uuid_length;
+	uint32_t hash;
+	int ret;
+
+	ret = net_eth_mac_load(cfg, mac_addr);
+	if (ret != -ENODATA) {
+		if (ret < 0) {
+			LOG_ERR("Failed to load MAC address (%d)", ret);
+		}
+
+		return ret;
+	}
+
+	/*
+	 * Nothing defined by the user, hash the chip's unique ID. Note this is
+	 * not universally unique, it just is probably unique on a network.
+	 */
+	uuid_length = hwinfo_get_device_id(unique_device_id,
+					   sizeof(unique_device_id));
+	if (uuid_length <= 0) {
+		/*
+		 * Hashing the empty buffer would give every affected board the
+		 * same address, so refuse rather than hand out a duplicate.
+		 */
+		return (uuid_length < 0) ? (int)uuid_length : -ENODATA;
+	}
+
+	hash = crc24_pgp(unique_device_id, (size_t)uuid_length);
+
+	/* Setting LAA bit because it is not guaranteed universally unique */
+	mac_addr[0] = NXP_OUI_BYTE_0 | ETH_MAC_LAA_BIT;
+	mac_addr[1] = NXP_OUI_BYTE_1;
+	mac_addr[2] = NXP_OUI_BYTE_2;
+	mac_addr[3] = FIELD_GET(0xFF0000, hash);
+	mac_addr[4] = FIELD_GET(0x00FF00, hash);
+	mac_addr[5] = FIELD_GET(0x0000FF, hash);
+
+	return 0;
+}
+
+#define NXP_ETH_IRQ_CONNECT(name)                                                                  \
+	do {                                                                                       \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, name, irq),                                     \
+			    DT_INST_IRQ_BY_NAME(0, name, priority), dwmac_isr,                     \
+			    DEVICE_DT_INST_GET(0), 0);                                             \
+		irq_enable(DT_INST_IRQ_BY_NAME(0, name, irq));                                     \
+	} while (0)
+
+int dwmac_platform_init(const struct device *dev)
+{
+	const struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
+	struct dwmac_priv *p = dev->data;
+
+	p->tx_descs = dwmac_tx_descs;
+	p->rx_descs = dwmac_rx_descs;
+
+	/* basic configuration for this platform */
+	DWMAC_REG_WRITE(MAC_CONF,
+			MAC_CONF_PS |
+			MAC_CONF_FES |
+			MAC_CONF_DM);
+	DWMAC_REG_WRITE(DMA_SYSBUS_MODE,
+			DMA_SYSBUS_MODE_AAL |
+			DMA_SYSBUS_MODE_FB);
+
+	/*
+	 * Set up IRQs (still masked for now). The MAC raises DMA transfer
+	 * completion on the dedicated tx/rx lines and everything else on the
+	 * common line, so all three share the same handler.
+	 */
+	NXP_ETH_IRQ_CONNECT(common);
+	NXP_ETH_IRQ_CONNECT(tx);
+	NXP_ETH_IRQ_CONNECT(rx);
+
+	return nxp_load_mac_addr(&mac_cfg, p->mac_addr);
+}
+
+/* Our private device instance */
+static const struct dwmac_config dwmac_config = {
+	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(0)),
+	.phy_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(0, phy_handle)),
+	.clock = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
+	.mac_clk = NXP_ETH_CLOCK_SUBSYS(mac),
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	.ptp_clock = DEVICE_DT_GET(DT_INST_CHILD(0, ptp_clock)),
+	.ptp_clk = NXP_ETH_CLOCK_SUBSYS(ptp),
+#endif
+};
+
+static struct dwmac_priv dwmac_instance;
+
+ETH_NET_DEVICE_DT_INST_DEFINE(0,
+			      dwmac_probe,
+			      NULL,
+			      &dwmac_instance,
+			      &dwmac_config,
+			      CONFIG_ETH_INIT_PRIORITY,
+			      &dwmac_api,
+			      NET_ETH_MTU);

--- a/drivers/ethernet/eth_nxp_enet_qos/Kconfig
+++ b/drivers/ethernet/eth_nxp_enet_qos/Kconfig
@@ -5,6 +5,7 @@ menuconfig ETH_NXP_ENET_QOS
 	bool "NXP ENET QOS Ethernet Driver"
 	default y
 	depends on DT_HAS_NXP_ENET_QOS_ENABLED
+	depends on SOC_FAMILY_MCXA || SOC_FAMILY_MCXN
 	depends on NET_BUF_FIXED_DATA_SIZE
 	select PINCTRL
 	help

--- a/drivers/ethernet/mdio/Kconfig.nxp_enet_qos
+++ b/drivers/ethernet/mdio/Kconfig.nxp_enet_qos
@@ -4,7 +4,7 @@
 config MDIO_NXP_ENET_QOS
 	bool "NXP ENET QoS MDIO driver"
 	default y
-	depends on DT_HAS_NXP_ENET_QOS_ENABLED
+	depends on ETH_NXP_ENET_QOS
 	depends on DT_HAS_SNPS_DWMAC_MDIO_ENABLED
 	help
 	  Enable NXP ENET QOS (Quality of Service) MDIO driver.

--- a/dts/arm/nxp/mcx/mcxe/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxe/nxp_mcxe31x_common.dtsi
@@ -292,12 +292,29 @@
 	};
 
 	emac: emac@480000 {
-		compatible = "nxp,emac", "snps,dwmac";
+		compatible = "nxp,enet-qos", "snps,dwmac";
 		reg = <0x480000 0x120c>;
-		interrupts = <105 0>;
+		clocks = <&mc_cgm MCUX_EMAC_CLK>,
+			 <&mc_cgm MCUX_EMACTX_CLK>,
+			 <&mc_cgm MCUX_EMACRX_CLK>,
+			 <&mc_cgm MCUX_EMACTS_CLK>;
+		clock-names = "mac", "tx", "rx", "ptp";
+		interrupts = <105 0>, <106 0>, <107 0>;
+		interrupt-names = "common", "tx", "rx";
 		snps,multicast-filter-bins = <64>;
 		snps,perfect-filter-entries = <3>;
 		status = "disabled";
+
+		mdio: mdio {
+			compatible = "snps,dwmac-mdio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		ptp_clock: ptp-clock {
+			compatible = "snps,dwmac-ptp-clock";
+		};
 	};
 
 	emios_0: emios@88000 {

--- a/include/zephyr/dt-bindings/clock/nxp_mc_cgm.h
+++ b/include/zephyr/dt-bindings/clock/nxp_mc_cgm.h
@@ -112,6 +112,8 @@
 #define MCUX_EMACRX_CLK MCUX_MC_CGM_CLK_ID(0x2C, 0x01)
 #define MCUX_EMACTX_CLK MCUX_MC_CGM_CLK_ID(0x2C, 0x02)
 #define MCUX_EMACTS_CLK MCUX_MC_CGM_CLK_ID(0x2C, 0x03)
+/** EMAC module clock: gates the IP and clocks its CSR (register) interface */
+#define MCUX_EMAC_CLK   MCUX_MC_CGM_CLK_ID(0x2C, 0x05)
 
 #define MCUX_TEMPSENSE_CLK MCUX_MC_CGM_CLK_ID(0x2C, 0x04)
 

--- a/samples/net/ptp/tests.yaml
+++ b/samples/net/ptp/tests.yaml
@@ -34,3 +34,4 @@ tests:
       - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
       - stm32h573i_dk
       - esp32p4x_function_ev_board/esp32p4/hpcore
+      - frdm_mcxe31b


### PR DESCRIPTION
For the NXP MCXE31B mcu there is currently no
driver support for the ethernet controller, add it via
the generic dwc_mac driver.

This currently is the only NXP board I own with a Ethernet port. Unfortunately without a Ethernet driver in zephyr until now.

```
[00:00:00.000,000] <inf> dwmac_core: HW version 5.10
```

dhcpv4 and ptp sample work with this