### PR TITLE
drivers: i3c: add help text to I3C_CONTROLLER and I3C_TARGET

### DIFF
--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -38,10 +38,20 @@ endchoice
 config I3C_CONTROLLER
 	bool
 	default y if I3C_DUAL_ROLE || I3C_CONTROLLER_ROLE_ONLY
+	help
+	  Indicates that support for acting as an I3C controller is enabled.
+	  This internal option is derived automatically from the I3C mode
+	  selection (I3C_CONTROLLER_ROLE_ONLY or I3C_DUAL_ROLE) and is not
+	  meant to be set directly.
 
 config I3C_TARGET
 	bool
 	default y if I3C_DUAL_ROLE || I3C_TARGET_ROLE_ONLY
+	help
+	  Indicates that support for acting as an I3C target is enabled.
+	  This internal option is derived automatically from the I3C mode
+	  selection (I3C_TARGET_ROLE_ONLY or I3C_DUAL_ROLE) and is not meant
+	  to be set directly.
 
 config I3C_SHELL
 	bool "I3C Shell"


### PR DESCRIPTION
Added help text for the I3C_CONTROLLER and I3C_TARGET options. While these are promptless, they are worth explaining and should show up in the Kconfig reference doc page so that cross-references to them can be resolved.