### PR TITLE
drivers: fuel_gauge: reject oversized len

### DIFF
--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -30,19 +30,12 @@ static inline int z_vrfy_fuel_gauge_get_props(const struct device *dev,
 					      const fuel_gauge_prop_t *props,
 					      union fuel_gauge_prop_val *vals, size_t len)
 {
-	union fuel_gauge_prop_val k_vals[len];
-	fuel_gauge_prop_t k_props[len];
-
 	K_OOPS(K_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_property));
 
-	K_OOPS(k_usermode_from_copy(k_vals, vals, len * sizeof(union fuel_gauge_prop_val)));
-	K_OOPS(k_usermode_from_copy(k_props, props, len * sizeof(fuel_gauge_prop_t)));
+	K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(props, len, sizeof(fuel_gauge_prop_t)));
+	K_OOPS(K_SYSCALL_MEMORY_ARRAY_WRITE(vals, len, sizeof(union fuel_gauge_prop_val)));
 
-	int ret = z_impl_fuel_gauge_get_props(dev, k_props, k_vals, len);
-
-	K_OOPS(k_usermode_to_copy(vals, k_vals, len * sizeof(union fuel_gauge_prop_val)));
-
-	return ret;
+	return z_impl_fuel_gauge_get_props(dev, props, vals, len);
 }
 
 #include <zephyr/syscalls/fuel_gauge_get_props_mrsh.c>
@@ -63,17 +56,12 @@ static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev,
 					      const fuel_gauge_prop_t *props,
 					      const union fuel_gauge_prop_val *vals, size_t len)
 {
-	union fuel_gauge_prop_val k_vals[len];
-	fuel_gauge_prop_t k_props[len];
-
 	K_OOPS(K_SYSCALL_DRIVER_FUEL_GAUGE(dev, set_property));
 
-	K_OOPS(k_usermode_from_copy(k_vals, vals, len * sizeof(union fuel_gauge_prop_val)));
-	K_OOPS(k_usermode_from_copy(k_props, props, len * sizeof(fuel_gauge_prop_t)));
+	K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(props, len, sizeof(fuel_gauge_prop_t)));
+	K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(vals, len, sizeof(union fuel_gauge_prop_val)));
 
-	int ret = z_impl_fuel_gauge_set_props(dev, k_props, k_vals, len);
-
-	return ret;
+	return z_impl_fuel_gauge_set_props(dev, props, vals, len);
 }
 
 #include <zephyr/syscalls/fuel_gauge_set_props_mrsh.c>


### PR DESCRIPTION
The userspace verifiers for fuel_gauge_get_props() and fuel_gauge_set_props() declared two variable-length arrays sized by the caller-supplied len argument:

  union fuel_gauge_prop_val k_vals[len];
  fuel_gauge_prop_t k_props[len];

Both VLAs were allocated before any validation, including before the K_SYSCALL_DRIVER_FUEL_GAUGE() object check. Fix it.

Fixes: #116420