### PR TITLE
bluetooth: classic: sdp: improve error handling in sdp_client_get_total

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1782,11 +1782,16 @@ static void sdp_client_params_iterator(struct bt_sdp_client *session)
 	}
 }
 
-static uint16_t sdp_client_get_total(struct bt_sdp_client *session,
-				  struct net_buf *buf, uint16_t *total)
+static int sdp_client_get_total(struct bt_sdp_client *session, struct net_buf *buf, uint16_t *total,
+				uint16_t *removed)
 {
-	uint16_t pulled;
+	struct net_buf_simple_state state;
+	int err;
 	uint8_t seq;
+	uint32_t len;
+
+	*total = 0;
+	*removed = 0;
 
 	/*
 	 * Pull value of total octets of all attributes available to be
@@ -1795,35 +1800,60 @@ static uint16_t sdp_client_get_total(struct bt_sdp_client *session,
 	 * was sent. For subsequent calls related to the same SSA request input
 	 * buf and in/out function parameters stays neutral.
 	 */
-	if (session->cstate.length == 0U) {
-		seq = net_buf_pull_u8(buf);
-		pulled = 1U;
-		switch (seq) {
-		case BT_SDP_SEQ8:
-			*total = net_buf_pull_u8(buf);
-			pulled += 1U;
-			break;
-		case BT_SDP_SEQ16:
-			*total = net_buf_pull_be16(buf);
-			pulled += 2U;
-			break;
-		case BT_SDP_SEQ32:
-			*total = net_buf_pull_be32(buf);
-			pulled += 4U;
-			break;
-		default:
-			LOG_WRN("Sequence type 0x%02x not handled", seq);
-			*total = 0U;
-			break;
-		}
-
-		LOG_DBG("Total %u octets of all attributes", *total);
-	} else {
-		pulled = 0U;
-		*total = 0U;
+	if (session->cstate.length != 0U) {
+		return 0;
 	}
 
-	return pulled;
+	net_buf_simple_save(&buf->b, &state);
+
+	if (buf->len < sizeof(seq)) {
+		LOG_WRN("Buffer size %u too small for sequence type", buf->len);
+		err = -EMSGSIZE;
+		goto failed;
+	}
+
+	seq = net_buf_pull_u8(buf);
+	if (((seq & BT_SDP_TYPE_DESC_MASK) != BT_SDP_SEQ_UNSPEC) ||
+	    ((seq & BT_SDP_SIZE_DESC_MASK) < BT_SDP_SIZE_INDEX_OFFSET)) {
+		LOG_WRN("Sequence type 0x%02x not valid", seq);
+		err = -EINVAL;
+		goto failed;
+	}
+
+	if (buf->len < BIT((seq & BT_SDP_SIZE_DESC_MASK) - BT_SDP_SIZE_INDEX_OFFSET)) {
+		LOG_WRN("Malformed packet");
+		err = -EMSGSIZE;
+		goto failed;
+	}
+
+	switch (seq) {
+	case BT_SDP_SEQ8:
+		*total = net_buf_pull_u8(buf);
+		break;
+	case BT_SDP_SEQ16:
+		*total = net_buf_pull_be16(buf);
+		break;
+	case BT_SDP_SEQ32:
+		len = net_buf_pull_be32(buf);
+		if (len > UINT16_MAX) {
+			LOG_WRN("Sequence length exceeds uint16_t max");
+			err = -E2BIG;
+			goto failed;
+		}
+		*total = len;
+		break;
+	default:
+		LOG_ERR("seq has been checked, should not reach here");
+		CODE_UNREACHABLE;
+	}
+
+	*removed = state.len - buf->len;
+	LOG_DBG("Total %u octets of all attributes", *total);
+	return 0;
+
+failed:
+	net_buf_simple_restore(&buf->b, &state);
+	return err;
 }
 
 static uint16_t get_ss_record_len(struct net_buf *buf)
@@ -2467,6 +2497,8 @@ static int sdp_client_receive_ssa_sa(struct bt_sdp_client *session, struct net_b
 	struct bt_sdp_pdu_cstate *cstate;
 	uint16_t frame_len;
 	uint16_t total;
+	uint16_t removed;
+	int err;
 
 	/* Check the buffer len for the frame_len field */
 	if (buf->len < sizeof(frame_len)) {
@@ -2507,8 +2539,6 @@ static int sdp_client_receive_ssa_sa(struct bt_sdp_client *session, struct net_b
 	 */
 	if (frame_len == 0 && cstate->length != 0) {
 		/* Notify current received data */
-		int err;
-
 		err = sdp_client_ssa_sa_notify(session);
 		if (err != 0) {
 			LOG_ERR("Failed to notify received data: %d", err);
@@ -2527,7 +2557,19 @@ static int sdp_client_receive_ssa_sa(struct bt_sdp_client *session, struct net_b
 	}
 
 	/* Get total value of all attributes to be collected */
-	frame_len -= sdp_client_get_total(session, buf, &total);
+	err = sdp_client_get_total(session, buf, &total, &removed);
+	if (err != 0) {
+		LOG_ERR("Failed to get total value: %d", err);
+		return err;
+	}
+
+	if (frame_len < removed) {
+		LOG_ERR("Invalid frame length");
+		return -EINVAL;
+	}
+
+	frame_len -= removed;
+
 	/*
 	 * If total is not 0, there are two valid cases,
 	 * Case 1, the continuation state length is 0, the frame_len should equal total,


### PR DESCRIPTION
Refactor `sdp_client_get_total()` to add comprehensive error handling and validation for SDP sequence parsing.

Check the remaining buffer length before pulling data from the buffer. Using `BT_SDP_SEQ_UNSPEC` to check the SEQ type. And only handle the frame if the total length is valid.

The function now properly validates input data and returns appropriate error codes, preventing potential buffer underflow and invalid data processing in SDP client operations.