### PR TITLE
drivers: counter: dw_timer: clock request and missing include fixes

### DIFF
--- a/drivers/counter/counter_dw_timer.c
+++ b/drivers/counter/counter_dw_timer.c
@@ -12,6 +12,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(dw_timer, CONFIG_COUNTER_LOG_LEVEL);
 

--- a/drivers/counter/counter_dw_timer.c
+++ b/drivers/counter/counter_dw_timer.c
@@ -318,7 +318,8 @@ static int counter_dw_timer_init(const struct device *timer_dev)
 
 	/*
 	 * get clock rate from clock_frequency property if valid,
-	 * otherwise, get clock rate from clock manager
+	 * otherwise, request the clock from the clock manager and get its
+	 * rate
 	 */
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
 	struct counter_dw_timer_drv_data *const data = DEV_DATA(timer_dev);
@@ -327,6 +328,13 @@ static int counter_dw_timer_init(const struct device *timer_dev)
 		LOG_ERR("clock controller device not ready");
 		return -ENODEV;
 	}
+
+	ret = clock_control_on(timer_config->clk_dev, timer_config->clkid);
+	if (ret != 0 && ret != -ENOSYS && ret != -EALREADY) {
+		LOG_ERR("Unable to enable clock: err:%d", ret);
+		return ret;
+	}
+
 	ret = clock_control_get_rate(timer_config->clk_dev,
 					timer_config->clkid, &data->freq);
 	if (ret != 0) {


### PR DESCRIPTION
Two independent fixes to the Synopsys DesignWare timer counter driver, both found while enabling it on a new SoC.

1. Request the clock before reading its rate

 `counter_dw_timer_init()` reads the timer clock rate from the clock controller but never requests the clock, so it relies on the clock already being enabled by other means. `clock_control_get_rate()` is documented to return `-EAGAIN` when a driver cannot report the rate of a  clock that is off.  So request the clock with clock_control_on() before reading its rate.
 
 2. Include `zephyr/irq.h`
 
The driver calls `IRQ_CONNECT()` and `irq_enable()` but never includes  `zephyr/irq.h`, relying on it arriving indirectly. Fix this.

**Impact on existing users**

Two in-tree users:
`dts/arm64/intel/intel_socfpga_agilex5.dtsi` : The clock driver only implements (`clock_control_agilex5.c`) `get_rate` and `clock_control_on `returns `-ENOSYS` which is tolerated in patch 1 and the behavior is unchanged.

`dts/arm64/intel/intel_socfpga_agilex.dtsi `: Uses the `clock-frequency` property, `DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)` is false and the whole clock controller block is compiled away. So the behavior is unchanged.
