### PR TITLE
hostap: Add new mgmt ops to get net interface type from driver

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -2524,6 +2524,20 @@ static int device_wlan_pm_action(const struct device *dev, enum pm_device_action
 PM_DEVICE_DT_INST_DEFINE(0, device_wlan_pm_action);
 #endif
 
+static uint32_t nxp_wifi_get_iface_caps(const struct device *dev,
+					    struct net_if *iface)
+{
+#ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
+	if (iface == (struct net_if *)net_get_uap_interface()) {
+		/* uap interface: second net_if on this device */
+		return BIT(WIFI_TYPE_SAP);
+	}
+#endif
+
+	/* mlan interface: default STA */
+	return BIT(WIFI_TYPE_STA);
+}
+
 static const struct wifi_mgmt_ops nxp_wifi_sta_mgmt = {
 	.get_version = nxp_wifi_version,
 	.scan = nxp_wifi_scan,
@@ -2552,6 +2566,7 @@ static const struct wifi_mgmt_ops nxp_wifi_sta_mgmt = {
 	.set_twt = nxp_wifi_set_twt,
 #endif
 	.set_rts_threshold = nxp_wifi_set_rts_threshold,
+	.get_iface_caps = nxp_wifi_get_iface_caps,
 };
 
 #if defined(CONFIG_WIFI_NM) && !defined(CONFIG_WIFI_NM_WPA_SUPPLICANT)
@@ -2638,6 +2653,7 @@ static const struct wifi_mgmt_ops nxp_wifi_uap_mgmt = {
 #endif
 	.ap_sta_disconnect = nxp_wifi_uap_disconnect_sta,
 	.set_rts_threshold = nxp_wifi_ap_set_rts_threshold,
+	.get_iface_caps = nxp_wifi_get_iface_caps,
 };
 
 #if defined(CONFIG_WIFI_NM) && !defined(CONFIG_WIFI_NM_HOSTAPD_AP)

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -2404,6 +2404,18 @@ struct wifi_mgmt_ops {
 			struct net_if *iface,
 			struct wifi_p2p_params *params);
 #endif
+	/** Get interface supported roles (static driver capability).
+	 * Read once by the supplicant at interface-add time, and treated
+	 * as a static per-interface property. A driver cannot use it to
+	 * signal a role change at runtime.
+	 *
+	 * @param dev  Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to query.
+	 *
+	 * @return BIT(enum wifi_nm_iface_type) of supported roles.
+	 * Return 0 to let the caller use the default.
+	 */
+	 uint32_t (*get_iface_caps)(const struct device *dev, struct net_if *iface);
 };
 
 /** Wi-Fi management offload API */

--- a/include/zephyr/net/wifi_nm.h
+++ b/include/zephyr/net/wifi_nm.h
@@ -39,6 +39,8 @@ enum wifi_nm_iface_type {
 	WIFI_TYPE_STA = 0,
 	/** IEEE 802.11 Wi-Fi Soft AP */
 	WIFI_TYPE_SAP,
+	/** MAX of Wi-Fi interface type */
+	WIFI_TYPE_MAX,
 };
 
 /**

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -340,6 +340,54 @@ static void zephyr_hostap_ctrl_iface_msg_cb(void *ctx, int level, enum wpa_msg_t
 #endif
 }
 
+static int supplicant_register_iface_type(struct net_if *iface)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api;
+	struct wifi_nm_instance *nm = wifi_nm_get_instance("wifi_supplicant");
+	uint32_t caps = 0;
+	int ret;
+
+	if (dev == NULL || nm == NULL) {
+		return -EINVAL;
+	}
+
+	off_api = (struct net_wifi_mgmt_offload *)dev->api;
+
+	/* Query driver for its static role capabilities.
+	 * If the driver does not implement get_iface_caps, fall back to
+	 * WIFI_TYPE_STA plus WIFI_TYPE_SAP when CONFIG_WIFI_NM_WPA_SUPPLICANT_AP
+	 * is enabled.
+	 */
+	if (off_api != NULL && off_api->wifi_mgmt_api != NULL &&
+	    off_api->wifi_mgmt_api->get_iface_caps != NULL) {
+		caps = off_api->wifi_mgmt_api->get_iface_caps(dev, iface);
+	}
+	caps &= BIT_MASK(WIFI_TYPE_MAX);
+
+	if (caps == 0) {
+		/* No caps declared: default to STA */
+		caps = BIT(WIFI_TYPE_STA);
+		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP)) {
+			caps |= BIT(WIFI_TYPE_SAP);
+		}
+	}
+
+	/* Register each declared role */
+	for (enum wifi_nm_iface_type type = WIFI_TYPE_STA;
+	     type < WIFI_TYPE_MAX; type++) {
+		if (!(caps & BIT(type))) {
+			continue;
+		}
+		ret = wifi_nm_register_mgd_type_iface(nm, type, iface);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
 static int add_interface(struct supplicant_context *ctx, struct net_if *iface)
 {
 	struct wpa_supplicant *wpa_s;
@@ -388,27 +436,11 @@ static int add_interface(struct supplicant_context *ctx, struct net_if *iface)
 		goto out;
 	}
 
-	ret = wifi_nm_register_mgd_type_iface(wifi_nm_get_instance("wifi_supplicant"),
-					      WIFI_TYPE_STA,
-					      iface);
-	if (ret) {
+	ret = supplicant_register_iface_type(iface);
+	if (ret != 0) {
 		LOG_ERR("Failed to register mgd iface with native stack %s (%d)",
 			ifname, ret);
 		goto out;
-	}
-
-	if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP)) {
-		/* In SoftAP-via-supplicant mode the same interface can also act
-		 * as an AP, so register it as SAP capable too.
-		 */
-		ret = wifi_nm_register_mgd_type_iface(wifi_nm_get_instance("wifi_supplicant"),
-						      WIFI_TYPE_SAP,
-						      iface);
-		if (ret) {
-			LOG_ERR("Failed to register mgd SAP iface with native stack %s (%d)",
-				ifname, ret);
-			goto out;
-		}
 	}
 
 	supplicant_generate_state_event(ifname, NET_EVENT_SUPPLICANT_CMD_IFACE_ADDED, 0);

--- a/subsys/net/l2/wifi/wifi_nm.c
+++ b/subsys/net/l2/wifi/wifi_nm.c
@@ -148,6 +148,7 @@ int wifi_nm_unregister_mgd_iface(struct wifi_nm_instance *nm, struct net_if *ifa
 	for (int i = 0; i < CONFIG_WIFI_NM_MAX_MANAGED_INTERFACES; i++) {
 		if (nm->mgd_ifaces[i].iface == iface) {
 			nm->mgd_ifaces[i].iface = NULL;
+			nm->mgd_ifaces[i].type = 0;
 			k_mutex_unlock(&wifi_nm_lock);
 			return 0;
 		}


### PR DESCRIPTION
In del_interface(), function wifi_nm_unregister_mgd_iface() will be called to clear nm->mgd_ifaces[].iface pointer. When add_interface() was call when doing interface initialization again, all interfaces will be added in "wifi_supplicant" instance and forced with type WIFI_TYPE_STA, regardless of real net interface capability.
To fix this issue, add new mgmt ops get_iface_caps() to get real capability from driver. If this ops is implemented in driver, call it to get real capability and set type correspondingly. If not, always return STA capibility.
One more fix is to clear type in wifi_nm_unregister_mgd_iface().