### PR TITLE
drivers: entropy: mcux_trng: fix buffer overflow on odd lengths

### DIFF
--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -9,12 +9,14 @@
 #define DT_DRV_COMPAT nxp_kinetis_trng
 
 #include <errno.h>
+#include <string.h>
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/random/random.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/util.h>
 
 #include "fsl_trng.h"
 
@@ -29,9 +31,53 @@ static int entropy_mcux_trng_get_entropy(const struct device *dev,
 	const struct mcux_entropy_config *config = dev->config;
 	status_t status;
 
-	status = TRNG_GetRandomData(config->base, buffer, length);
-	if (status != kStatus_Success) {
-		return -EIO;
+	/*
+	 * TRNG_GetRandomData() writes random data in 32-bit word
+	 * granularity. With TRNG_SW_HEALTH_TESTS enabled the SDK always
+	 * copies full words, which overflows a caller buffer whose length
+	 * is not a multiple of 4 bytes.
+	 *
+	 * Process an unaligned prefix through a bounce word, followed by
+	 * the aligned bulk directly, and finally a non-word-size tail
+	 * through the bounce word. This keeps the number of SDK calls low
+	 * without allowing an unaligned store or an overrun of the caller
+	 * buffer.
+	 */
+	if ((length > 0U) &&
+	    ((uintptr_t)buffer % sizeof(uint32_t) != 0U)) {
+		uint32_t word;
+		uint16_t leading = sizeof(word) -
+			((uintptr_t)buffer % sizeof(word));
+
+		leading = MIN(length, leading);
+		status = TRNG_GetRandomData(config->base, &word, sizeof(word));
+		if (status != kStatus_Success) {
+			return -EIO;
+		}
+		memcpy(buffer, &word, leading);
+		buffer += leading;
+		length -= leading;
+	}
+
+	if (length >= sizeof(uint32_t)) {
+		uint16_t aligned = length & ~0x3U;
+
+		status = TRNG_GetRandomData(config->base, buffer, aligned);
+		if (status != kStatus_Success) {
+			return -EIO;
+		}
+		buffer += aligned;
+		length -= aligned;
+	}
+
+	if (length > 0U) {
+		uint32_t word;
+
+		status = TRNG_GetRandomData(config->base, &word, sizeof(word));
+		if (status != kStatus_Success) {
+			return -EIO;
+		}
+		memcpy(buffer, &word, length);
 	}
 
 	return 0;


### PR DESCRIPTION
## Description

The entropy MCUX TRNG driver (`nxp,kinetis-trng`) forwarded the caller
buffer and length directly to the SDK `TRNG_GetRandomData()`. That function
may write random data in 32-bit word granularity, and when the SDK is built
with `TRNG_SW_HEALTH_TESTS` enabled it always copies full 4-byte words.

For a requested length that is not a multiple of 4, the SDK writes past the
end of the caller buffer. `tests/drivers/entropy/api` intentionally requests
`BUFFER_LENGTH - 1` (9) bytes and checks a guard byte, and this overflow was
detected on `mimxrt685_aud_evk/mimxrt685s/cm33`:

```
Error: entropy_get_entropy buffer overflow
Assertion failed at tests/drivers/entropy/api/src/main.c:109
```

## Fix

Use a fast path that preserves the original single-call behaviour while
staying safe on odd lengths:

- **Word-aligned buffer, length multiple of 4** -> one `TRNG_GetRandomData()`
  call, no memcpy (same as before this fix).
- **Word-aligned buffer, odd length** -> fetch the word-aligned bulk in one
  call, then copy the trailing 1-3 bytes through a bounce word (2 calls).
- **Non word-aligned buffer** -> fetch each word into an aligned bounce
  variable and `memcpy` the requested bytes, since the SDK's 32-bit stores
  could fault on an unaligned destination.

In all cases the driver never writes past `buffer[length - 1]`, independent
of the SDK's internal word granularity or `TRNG_SW_HEALTH_TESTS`.

This addresses the review feedback on the previous PR that the naive
per-word loop added overhead for the common multiple-of-4 case.

## Testing

- `tests/drivers/entropy/api` on `mimxrt685_aud_evk/mimxrt685s/cm33`

Fixes #115591

Supersedes #115592, which was auto-closed by GitHub after a force-push to
the head branch and can no longer be reopened.

## Review context from #115592

Preserving the review feedback from the superseded PR so it is not lost:

- **@zejiang0jason** ([r3733699196](https://github.com/zephyrproject-rtos/zephyr/pull/115592#discussion_r3733699196)):
  > The whole process is split to byte by byte, is it low efficient? Could
  > it be done by split the calculation to word aligned part and
  > non-word-aligned part? Then only two times of `TRNG_GetRandomData` is
  > enough.

- **@butok** ([r3734071378](https://github.com/zephyrproject-rtos/zephyr/pull/115592#discussion_r3734071378)):
  > The solution should work. But before, it was called only once. Now it
  > is called every 4 bytes + memcopy(). This brings performance overhead
  > for all cases, even when it is not required (when the length is a
  > multiple of 4).

**How this PR addresses that feedback:** the driver no longer loops per word
for every request. A word-aligned buffer with a multiple-of-4 length uses a
single `TRNG_GetRandomData()` call (restoring the original behaviour), an odd
length adds only one extra call for the 1-3 byte tail, and the per-word bounce
loop is kept solely as a fallback for the rare non word-aligned buffer, where
the SDK's 32-bit stores could otherwise fault.
