### PR TITLE
tests: subsys: jwt: Revert exclude JWT test from auto tests

### DIFF
--- a/tests/subsys/jwt/tests.yaml
+++ b/tests/subsys/jwt/tests.yaml
@@ -8,8 +8,6 @@ common:
     - qemu_x86
   extra_configs:
     - CONFIG_TEST_RANDOM_GENERATOR=y
-  platform_exclude:
-    - max32657evkit/max32657/ns
 tests:
   libraries.encoding.jwt.ecdsa.psa:
     extra_configs:


### PR DESCRIPTION
This PR reverts commit 6dc0ef4a48212b6228d01cc74bb431fe7fe5fb6a. After HW TRNG support JWT test can be executed.