### PR TITLE
net: coap: add OSCORE (RFC 8613) multi client support

### DIFF
--- a/doc/services/connectivity/networking/api/coap_oscore.rst
+++ b/doc/services/connectivity/networking/api/coap_oscore.rst
@@ -31,6 +31,9 @@ Additional OSCORE configuration options:
 - :kconfig:option:`CONFIG_COAP_OSCORE_EXCHANGE_CACHE_SIZE`: Number of OSCORE exchanges to track per service
 - :kconfig:option:`CONFIG_COAP_OSCORE_EXCHANGE_LIFETIME_MS`: Lifetime of tracked OSCORE exchanges used to protect
    deferred (separate) responses
+- :kconfig:option:`CONFIG_COAP_OSCORE_CONTEXT_REUSE`: Enable OSCORE support for context reuse across reboots
+- :kconfig:option:`CONFIG_COAP_OSCORE_MASTER_SECRET_MAX_LEN`: Maximum OSCORE Master Secret length in bytes
+- :kconfig:option:`CONFIG_COAP_OSCORE_MASTER_SALT_MAX_LEN`: Maximum OSCORE Master Salt length in bytes
 
 Configuration
 =============
@@ -52,38 +55,36 @@ Server Usage
 
 To enable OSCORE on a CoAP service, define the service with
 :c:macro:`COAP_SERVICE_DEFINE_OSCORE` (or :c:macro:`COAPS_SERVICE_DEFINE_OSCORE`
-for DTLS). The macro statically allocates the per-service OSCORE exchange cache
-and binds a *context provider* callback that returns the security context to
-use. The context is created through the Zephyr OSCORE API; applications do not
-include the underlying uoscore-uedhoc headers directly:
+for DTLS). The macro statically allocates the per-service OSCORE exchange cache.
+Security contexts are created separately through the Zephyr OSCORE API and added
+to a shared pool; applications do not include the underlying uoscore-uedhoc
+headers directly. Incoming requests are matched to the correct context by their
+Recipient ID and ID Context, so a single service can serve multiple clients, each
+with its own context:
 
 .. code-block:: c
 
    #include <zephyr/net/coap_oscore.h>
    #include <zephyr/net/coap_service.h>
 
-   /* Key material must remain valid for the lifetime of the context. */
-   static const uint8_t master_secret[16] = { /* ... */ };
-   static const uint8_t master_salt[8] = { /* ... */ };
-   static const uint8_t sender_id[] = { /* ... */ };
-   static const uint8_t recipient_id[] = { /* ... */ };
-
    static struct coap_oscore_context *my_oscore_ctx;
-
-   /* Provider invoked by the CoAP server when OSCORE processing is needed. */
-   static struct coap_oscore_context *my_oscore_provider(void)
-   {
-       return my_oscore_ctx;
-   }
 
    static uint16_t my_service_port = 5683;
 
-   /* Second argument "true" requires OSCORE for all requests. */
+   /* Final argument "true" requires OSCORE for all requests. */
    COAP_SERVICE_DEFINE_OSCORE(my_service, NULL, &my_service_port,
-                              COAP_SERVICE_AUTOSTART, my_oscore_provider, true);
+                              COAP_SERVICE_AUTOSTART, true);
 
    int my_service_oscore_init(void)
    {
+       /* coap_oscore_context_add() copies the key material, so these
+        * buffers need not outlive the call and can live on the stack.
+        */
+       const uint8_t master_secret[16] = { /* ... */ };
+       const uint8_t master_salt[8] = { /* ... */ };
+       const uint8_t sender_id[] = { /* ... */ };
+       const uint8_t recipient_id[] = { /* ... */ };
+
        struct coap_oscore_init_params params = {
            .master_secret = master_secret,
            .master_secret_len = sizeof(master_secret),
@@ -98,18 +99,21 @@ include the underlying uoscore-uedhoc headers directly:
            .fresh_master_secret_salt = true,
        };
 
-       /* Derive the context once its key material is available. Until the
-        * provider returns non-NULL, the service behaves as OSCORE-disabled.
+       /* Add the context to the shared pool once its key material is
+        * available. Call once per client identity (Recipient ID).
         */
-       return coap_oscore_context_init(&params, &my_oscore_ctx);
+       return coap_oscore_context_add(&params, &my_oscore_ctx);
    }
 
 The number of contexts that can be allocated at once is controlled by
 :kconfig:option:`CONFIG_COAP_OSCORE_MAX_CONTEXTS`. Release a context with
-``coap_oscore_context_free()`` once it is no longer referenced by any client or
-service.
+``coap_oscore_context_remove()``. Contexts are reference-counted: while an
+in-flight request, an active exchange, or an observer still references a context,
+``coap_oscore_context_remove()`` returns ``-EAGAIN`` and the context is retained.
+Retry the removal once those references have been released.
 
-When a service is OSCORE-enabled (its context provider returns a context):
+When a service is OSCORE-enabled (created with an ``OSCORE`` macro and at least one context is added
+to the pool):
 
 1. **Incoming requests**: The server automatically verifies and decrypts OSCORE-protected
    requests (:rfc:`8613` Section 8.2). Resource handlers receive decrypted CoAP messages
@@ -156,11 +160,7 @@ When a service is OSCORE-enabled (its context provider returns a context):
 Known Limitations
 ============================
 
-1. **Single Context**: The current implementation does not support per-client OSCORE
-   contexts within a service. Each service can use only one OSCORE context at a time,
-   so all clients share that context. This is sufficient for many use cases, but it
-   does not allow separate contexts per client.
-2. **Mixed-Service Expired-Exchange Plaintext**: On a mixed service (one that serves
+1. **Mixed-Service Expired-Exchange Plaintext**: On a mixed service (one that serves
    both OSCORE and non-OSCORE clients), a response whose exchange cache entry has
    expired can no longer be matched to its OSCORE state and is sent as plaintext. This
    affects both synchronous and deferred (separate) responses (see

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -30,6 +30,10 @@
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/slist.h>
 
+#if defined(CONFIG_COAP_OSCORE)
+struct coap_oscore_context;
+#endif /* defined(CONFIG_COAP_OSCORE) */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -337,10 +341,10 @@ struct coap_observer {
 	uint8_t tkl;
 #if defined(CONFIG_COAP_OSCORE) || defined(__DOXYGEN__)
 	/**
-	 * True if the observer is OSCORE protected
+	 * Not-NULL if the observer is OSCORE protected
 	 * @kconfig_dep{CONFIG_COAP_OSCORE}
 	 */
-	bool is_oscore;
+	struct coap_oscore_context *oscore_ctx;
 #endif
 };
 
@@ -363,10 +367,10 @@ struct coap_packet {
 #endif
 #if defined(CONFIG_COAP_OSCORE) || defined(__DOXYGEN__)
 	/**
-	 * True if the packet was received OSCORE protected
+	 * Not-NULL if the packet was received OSCORE protected
 	 * @kconfig_dep{CONFIG_COAP_OSCORE}
 	 */
-	bool is_oscore;
+	struct coap_oscore_context *oscore_ctx;
 #endif
 };
 
@@ -1063,10 +1067,11 @@ void coap_observer_init(struct coap_observer *observer,
  * @param observer Observer to be initialized
  * @param request Request on which the observer will be based
  * @param addr Address of the remote device
- * @param is_oscore True if the remote device is sending OSCORE protected
+ * @param oscore_ctx OSCORE context to be used for the observer
  */
 void coap_observer_init_oscore(struct coap_observer *observer, const struct coap_packet *request,
-			       const struct net_sockaddr *addr, bool is_oscore);
+			       const struct net_sockaddr *addr,
+			       struct coap_oscore_context *oscore_ctx);
 #endif /* CONFIG_COAP_OSCORE */
 
 /**

--- a/include/zephyr/net/coap_oscore.h
+++ b/include/zephyr/net/coap_oscore.h
@@ -36,29 +36,10 @@ extern "C" {
  */
 
 /**
- * @brief OSCORE exchange entry.
- *
- * Tracks which server responses need OSCORE protection by matching the client
- * address and request token (RFC 8613 Section 8.3). A CoAP service defined with
- * @ref COAP_SERVICE_DEFINE_OSCORE owns a statically allocated cache of these
- * entries.
- *
- * @kconfig_dep{CONFIG_COAP_OSCORE}
- */
-struct coap_oscore_exchange {
-	struct net_sockaddr_storage addr;  /**< Client address */
-	net_socklen_t addr_len;            /**< Address length */
-	uint8_t token[COAP_TOKEN_MAX_LEN]; /**< Token from the request */
-	uint8_t tkl;                       /**< Token length */
-	int64_t timestamp;                 /**< Creation timestamp */
-};
-
-/**
  * @brief Opaque OSCORE security context.
  *
- * Created with coap_oscore_context_init() and attached to a CoAP client or
- * service. The internal representation is private to the CoAP OSCORE
- * implementation.
+ * Created with coap_oscore_context_add() and used in the internal context pool.
+ * The internal representation is private to the CoAP OSCORE implementation.
  *
  * @kconfig_dep{CONFIG_COAP_OSCORE}
  */
@@ -79,10 +60,9 @@ enum coap_oscore_hkdf {
 /**
  * @brief OSCORE security context derivation parameters (RFC 8613 Section 3.2).
  *
- * @note The buffers referenced by @c master_secret, @c master_salt,
- *       @c id_context and @c sender_id must remain valid for the entire
- *       lifetime of the derived context (until coap_oscore_context_free()).
- *       @c recipient_id is copied internally.
+ * @note coap_oscore_context_add() copies all referenced buffers into the
+ *       context pool, so the caller may free or reuse them as soon as the call
+ *       returns; they need not outlive the derived context.
  *
  * @kconfig_dep{CONFIG_COAP_OSCORE}
  */
@@ -127,13 +107,14 @@ struct coap_oscore_init_params {
 };
 
 /**
- * @brief Initialize an OSCORE security context.
+ * @brief Add an OSCORE security context.
  *
  * Derives the common, sender and recipient contexts from @p params
- * (RFC 8613 Section 3.2) and returns an opaque handle that can be attached to
- * a CoAP client or service. Contexts are allocated from a fixed pool sized by
+ * (RFC 8613 Section 3.2) and adds them to the pool of contexts that can be used with
+ * the CoAP server. Contexts are allocated from a fixed pool sized by
  * @kconfig{CONFIG_COAP_OSCORE_MAX_CONTEXTS} and released with
- * coap_oscore_context_free().
+ * coap_oscore_context_remove(). Each context corresponds to one client identity
+ * (Recipient ID); add one context per client to serve multiple clients concurrently.
  *
  * @kconfig_dep{CONFIG_COAP_OSCORE}
  *
@@ -141,25 +122,52 @@ struct coap_oscore_init_params {
  * @param  ctx    On success, set to the newly created context handle.
  *
  * @retval 0 on success.
- * @retval -EINVAL if @p params or @p ctx is NULL, or a required parameter is
- *         missing, or the context could not be derived.
+ * @retval -EINVAL if @p params is NULL, a required parameter is missing or has
+ *         an invalid size, or the context could not be derived.
+ * @retval -ENOTSUP if @c fresh_master_secret_salt is false while
+ *         @kconfig{CONFIG_COAP_OSCORE_CONTEXT_REUSE} is disabled.
  * @retval -ENOMEM if no free context slot is available.
  */
-int coap_oscore_context_init(struct coap_oscore_init_params *params,
-			     struct coap_oscore_context **ctx);
+int coap_oscore_context_add(const struct coap_oscore_init_params *params,
+			    struct coap_oscore_context **ctx);
 
 /**
- * @brief Release an OSCORE security context.
+ * @brief Remove an OSCORE security context.
  *
- * Returns the context to the pool. The caller must ensure the context is no
- * longer attached to any CoAP client or service before freeing it. Passing
- * NULL is a no-op.
+ * Removes the context from the pool of contexts that can be used with the CoAP
+ * server. The context is reference-counted: if an in-flight request, an active
+ * exchange, or an observer still references it, the context is retained and
+ * -EAGAIN is returned. Retry once those references have been released. Passing
+ * NULL returns -EINVAL.
  *
  * @kconfig_dep{CONFIG_COAP_OSCORE}
  *
- * @param ctx Context previously returned by coap_oscore_context_init().
+ * @param ctx Context handle to remove.
+ *
+ * @retval 0 on success.
+ * @retval -EAGAIN if the context is in use and cannot be removed.
+ * @retval -EINVAL if @p ctx is NULL or not a valid context handle.
  */
-void coap_oscore_context_free(struct coap_oscore_context *ctx);
+int coap_oscore_context_remove(struct coap_oscore_context *ctx);
+
+/**
+ * @brief OSCORE exchange entry.
+ *
+ * Tracks which server responses need OSCORE protection by matching the client
+ * address and request token (RFC 8613 Section 8.3). A CoAP service defined with
+ * @ref COAP_SERVICE_DEFINE_OSCORE owns a statically allocated cache of these
+ * entries.
+ *
+ * @kconfig_dep{CONFIG_COAP_OSCORE}
+ */
+struct coap_oscore_exchange {
+	struct net_sockaddr_storage addr;  /**< Client address */
+	net_socklen_t addr_len;            /**< Address length */
+	uint8_t token[COAP_TOKEN_MAX_LEN]; /**< Token from the request */
+	uint8_t tkl;                       /**< Token length */
+	int64_t timestamp;                 /**< Creation timestamp */
+	struct coap_oscore_context *ctx;   /**< OSCORE context used for this exchange */
+};
 
 /** @} */
 

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -80,14 +80,6 @@ struct coap_service {
 	 * @kconfig_dep{CONFIG_COAP_OSCORE}
 	 */
 	bool oscore_required;
-	/**
-	 * Provider returning the OSCORE security context to use for this service,
-	 * or NULL if the service is not OSCORE-enabled. Invoked by the CoAP server
-	 * when a request/response needs OSCORE processing, so the context can be
-	 * derived lazily once its keying material is available.
-	 * @kconfig_dep{CONFIG_COAP_OSCORE}
-	 */
-	struct coap_oscore_context *(*oscore_ctx_provider)(void);
 #endif
 };
 
@@ -105,8 +97,7 @@ struct coap_service {
 	static struct coap_oscore_exchange _CONCAT(coap_oscore_exchange_cache_,                    \
 						   _name)[CONFIG_COAP_OSCORE_EXCHANGE_CACHE_SIZE];
 #define __z_coap_oscore_cache_ptr(_name) (_CONCAT(coap_oscore_exchange_cache_, _name))
-#define __z_coap_service_oscore(_provider, _required)                                              \
-	.oscore_ctx_provider = (_provider), .oscore_required = (_required),
+#define __z_coap_service_oscore(_required) .oscore_required = (_required),
 #define __z_coap_service_oscore_data(_cache)                                                       \
 	.oscore_exchange_cache = (_cache),
 #else
@@ -118,8 +109,7 @@ struct coap_service {
 
 /* clang-format off */
 #define __z_coap_service_define(_name, _host, _port, _flags, _res_begin, _res_end, _sec_tag_list,  \
-				_sec_tag_list_size, _oscore_provider, _oscore_required,            \
-				_oscore_cache)                                                     \
+				_sec_tag_list_size, _oscore_required, _oscore_cache)               \
 	static struct coap_service_data _CONCAT(coap_service_data_, _name) = {                     \
 		.sock_fd = -1,                                                                     \
 		__z_coap_service_oscore_data(_oscore_cache)                                        \
@@ -133,7 +123,7 @@ struct coap_service {
 		.res_end = (_res_end),                                                             \
 		.data = &_CONCAT(coap_service_data_, _name),                                       \
 		__z_coap_service_secure(_sec_tag_list, _sec_tag_list_size)                         \
-		__z_coap_service_oscore(_oscore_provider, _oscore_required)                        \
+		__z_coap_service_oscore(_oscore_required)                                          \
 	}
 /* clang-format on */
 
@@ -202,7 +192,7 @@ struct coap_service {
 	__z_coap_service_define(_name, _host, _port, _flags,                                       \
 				&_CONCAT(_CONCAT(_coap_resource_, _name), _list_start)[0],         \
 				&_CONCAT(_CONCAT(_coap_resource_, _name), _list_end)[0], NULL, 0,  \
-				NULL, false, NULL)
+				false, NULL)
 
 /**
  * @brief Define a CoAP secure service with static resources.
@@ -233,15 +223,14 @@ struct coap_service {
 	__z_coap_service_define(_name, _host, _port, _flags,                                       \
 				&_CONCAT(_CONCAT(_coap_resource_, _name), _list_start)[0],         \
 				&_CONCAT(_CONCAT(_coap_resource_, _name), _list_end)[0],           \
-				_sec_tag_list, _sec_tag_list_size, NULL, false, NULL)
+				_sec_tag_list, _sec_tag_list_size, false, NULL)
 
 /**
  * @brief Define an OSCORE-enabled CoAP service with static resources.
  *
  * Behaves like @ref COAP_SERVICE_DEFINE but additionally wires OSCORE support
  * (RFC 8613) into the service. A per-service OSCORE exchange cache is allocated
- * statically, and the security context is obtained lazily from
- * @p _oscore_ctx_provider so its keying material can be derived at runtime.
+ * statically.
  *
  * @note Requires @kconfig{CONFIG_COAP_OSCORE}. When that option is disabled the
  * service degrades to a plain @ref COAP_SERVICE_DEFINE.
@@ -250,21 +239,17 @@ struct coap_service {
  * @param _host IP address or hostname associated with the service.
  * @param[inout] _port Pointer to port associated with the service.
  * @param _flags Configuration flags @see @ref COAP_SERVICE_FLAGS.
- * @param _oscore_ctx_provider Function of type
- *        `struct coap_oscore_context *(*)(void)` returning the OSCORE context to
- *        use, or NULL if OSCORE is currently unavailable.
  * @param _oscore_required If true, requests without OSCORE are rejected with
  *        4.01 Unauthorized.
  */
-#define COAP_SERVICE_DEFINE_OSCORE(_name, _host, _port, _flags, _oscore_ctx_provider,              \
-				   _oscore_required)                                               \
+#define COAP_SERVICE_DEFINE_OSCORE(_name, _host, _port, _flags, _oscore_required)                 \
 	extern struct coap_resource _CONCAT(_CONCAT(_coap_resource_, _name), _list_start)[];       \
 	extern struct coap_resource _CONCAT(_CONCAT(_coap_resource_, _name), _list_end)[];         \
 	__z_coap_oscore_cache_define(_name) __z_coap_service_define(                               \
 		_name, _host, _port, _flags,                                                       \
 		&_CONCAT(_CONCAT(_coap_resource_, _name), _list_start)[0],                         \
 		&_CONCAT(_CONCAT(_coap_resource_, _name), _list_end)[0], NULL, 0,                  \
-		(_oscore_ctx_provider), (_oscore_required), __z_coap_oscore_cache_ptr(_name))
+		(_oscore_required), __z_coap_oscore_cache_ptr(_name))
 
 /**
  * @brief Define an OSCORE-enabled CoAP secure (DTLS) service with static resources.
@@ -278,14 +263,11 @@ struct coap_service {
  * @param _flags Configuration flags @see @ref COAP_SERVICE_FLAGS.
  * @param _sec_tag_list DTLS security tag list used to setup a COAPS socket.
  * @param _sec_tag_list_size DTLS security tag list size used to setup a COAPS socket.
- * @param _oscore_ctx_provider Function of type
- *        `struct coap_oscore_context *(*)(void)` returning the OSCORE context to
- *        use, or NULL if OSCORE is currently unavailable.
  * @param _oscore_required If true, requests without OSCORE are rejected with
  *        4.01 Unauthorized.
  */
 #define COAPS_SERVICE_DEFINE_OSCORE(_name, _host, _port, _flags, _sec_tag_list,                    \
-				    _sec_tag_list_size, _oscore_ctx_provider, _oscore_required)    \
+				    _sec_tag_list_size, _oscore_required)                          \
 	BUILD_ASSERT(IS_ENABLED(CONFIG_NET_SOCKETS_ENABLE_DTLS),                                   \
 		     "DTLS is required for CoAP secure (CONFIG_NET_SOCKETS_ENABLE_DTLS)");         \
 	extern struct coap_resource _CONCAT(_CONCAT(_coap_resource_, _name), _list_start)[];       \
@@ -294,7 +276,7 @@ struct coap_service {
 		__z_coap_service_define(_name, _host, _port, _flags,                               \
 					&_CONCAT(_CONCAT(_coap_resource_, _name), _list_start)[0], \
 					&_CONCAT(_CONCAT(_coap_resource_, _name), _list_end)[0],   \
-					_sec_tag_list, _sec_tag_list_size, (_oscore_ctx_provider), \
+					_sec_tag_list, _sec_tag_list_size,                         \
 					(_oscore_required), __z_coap_oscore_cache_ptr(_name))
 
 /**

--- a/subsys/net/lib/coap/Kconfig.oscore
+++ b/subsys/net/lib/coap/Kconfig.oscore
@@ -30,6 +30,29 @@ config COAP_OSCORE_MAX_CONTEXTS
 	  and verify messages for one CoAP client or service. Increase this if
 	  your application uses more than one OSCORE-enabled endpoint at a time.
 
+config COAP_OSCORE_MASTER_SECRET_MAX_LEN
+	int "Maximum OSCORE Master Secret length in bytes"
+	default 16
+	range 16 64
+	help
+	  Size of the per-context buffer that stores the OSCORE Master Secret.
+	  The Master Secret is application-chosen HKDF input keying material of
+	  variable length (RFC 8613 Section 3.1); the common case for the
+	  AES-CCM-16-64-128 profile is 16 bytes. Increase this if your deployment
+	  provisions longer secrets. Each of the CONFIG_COAP_OSCORE_MAX_CONTEXTS
+	  contexts reserves this many bytes.
+
+config COAP_OSCORE_MASTER_SALT_MAX_LEN
+	int "Maximum OSCORE Master Salt length in bytes"
+	default 8
+	range 0 64
+	help
+	  Size of the per-context buffer that stores the OSCORE Master Salt.
+	  The Master Salt is optional (RFC 8613 Section 3.1) and may be empty;
+	  when present it is commonly 8 bytes. Set to 0 to disable Master Salt
+	  storage entirely (contexts may then only be provisioned with an empty
+	  salt). Increase this if your deployment provisions a longer salt. Each
+	  of the CONFIG_COAP_OSCORE_MAX_CONTEXTS contexts reserves this many bytes.
 
 config COAP_OSCORE_EXCHANGE_CACHE_SIZE
 	int "OSCORE exchange cache size per service"
@@ -41,20 +64,21 @@ config COAP_OSCORE_EXCHANGE_CACHE_SIZE
 	  Each entry stores client address and token information to match
 	  responses to OSCORE requests per RFC 8613 Section 8.3.
 
-	  Synchronous responses and Observe notifications do NOT rely on this
-	  cache for response but still temporarily need a slot in it due to the
-	  fact, that asynchronous behaviour cannot be predicted.
+	  Synchronous responses also go through the cache (the entry is added
+	  before the handler runs and removed after the response is sent).
+	  Observe notifications bypass the cache entirely and use the per-observer
+	  OSCORE context instead. Size the cache to the maximum number of
+	  concurrent in-flight requests you expect.
 
 config COAP_OSCORE_EXCHANGE_LIFETIME_MS
 	int "OSCORE exchange lifetime in milliseconds"
 	default 247000
 	help
-	  Lifetime of a tracked OSCORE exchange entry. These entries are only
-	  used to protect deferred (separate) responses, i.e. responses produced
-	  after the request handler has already returned.
-
-	  Synchronous responses and Observe notifications do NOT rely on this
-	  expiry and are therefore never affected by it.
+	  Lifetime of a tracked OSCORE exchange entry. In practice, expiry only
+	  affects deferred (separate) responses, i.e. responses produced after
+	  the request handler has already returned. Synchronous responses always
+	  find a live entry (it was just created), and Observe notifications
+	  bypass the cache entirely.
 
 	  After this time a deferred exchange entry is considered expired and
 	  removed. A separate response produced later is treated as invalid: on an

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -28,6 +28,10 @@ LOG_MODULE_REGISTER(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <zephyr/net/coap.h>
 #include <zephyr/net/coap_mgmt.h>
 
+#if defined(CONFIG_COAP_OSCORE)
+#include "coap_oscore_internal.h"
+#endif /* CONFIG_COAP_OSCORE */
+
 #define COAP_PATH_ELEM_DELIM '/'
 #define COAP_PATH_ELEM_QUERY '?'
 #define COAP_PATH_ELEM_AMP   '&'
@@ -194,7 +198,7 @@ int coap_packet_init(struct coap_packet *cpkt, uint8_t *data, uint16_t max_len,
 	cpkt->max_len = max_len;
 	cpkt->delta = 0U;
 #if defined(CONFIG_COAP_OSCORE)
-	cpkt->is_oscore = false;
+	cpkt->oscore_ctx = NULL;
 #endif /* defined(CONFIG_COAP_OSCORE) */
 
 	hdr = (ver & 0x3) << 6;
@@ -783,7 +787,7 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 	cpkt->hdr_len = 0U;
 	cpkt->delta = 0U;
 #if defined(CONFIG_COAP_OSCORE)
-	cpkt->is_oscore = false;
+	cpkt->oscore_ctx = NULL;
 #endif /* defined(CONFIG_COAP_OSCORE) */
 
 	/* Token lengths 9-15 are reserved. */
@@ -1990,19 +1994,20 @@ void coap_observer_init(struct coap_observer *observer, const struct coap_packet
 	memcpy(&observer->addr, addr, net_family2size(addr->sa_family));
 
 #if defined(CONFIG_COAP_OSCORE)
-	observer->is_oscore = false;
+	observer->oscore_ctx = NULL;
 #endif
 }
 
 #if defined(CONFIG_COAP_OSCORE)
 void coap_observer_init_oscore(struct coap_observer *observer, const struct coap_packet *request,
-			       const struct net_sockaddr *addr, bool is_oscore)
+			       const struct net_sockaddr *addr,
+			       struct coap_oscore_context *oscore_ctx)
 {
 	observer->tkl = coap_header_get_token(request, observer->token);
 
 	memcpy(&observer->addr, addr, net_family2size(addr->sa_family));
 
-	observer->is_oscore = is_oscore;
+	observer->oscore_ctx = oscore_ctx;
 }
 #endif /* CONFIG_COAP_OSCORE */
 
@@ -2032,6 +2037,18 @@ bool coap_register_observer(struct coap_resource *resource,
 
 	sys_slist_append(&resource->observers, &observer->list);
 
+#if defined(CONFIG_COAP_OSCORE)
+	/* Take the OSCORE context reference the observer holds for its lifetime
+	 * (paired with the release in coap_remove_observer()). A no-op for
+	 * non-OSCORE observers. If the context is already stale, drop the pointer so
+	 * the observer never releases a reference it did not take.
+	 */
+	if (observer->oscore_ctx != NULL &&
+	    coap_oscore_context_inc_refcount(observer->oscore_ctx) != 0) {
+		observer->oscore_ctx = NULL;
+	}
+#endif /* CONFIG_COAP_OSCORE */
+
 	first = resource->age == 0;
 	if (first) {
 		resource->age = COAP_OBSERVE_FIRST_OFFSET;
@@ -2048,6 +2065,16 @@ bool coap_remove_observer(struct coap_resource *resource,
 	if (!sys_slist_find_and_remove(&resource->observers, &observer->list)) {
 		return false;
 	}
+
+#if defined(CONFIG_COAP_OSCORE)
+	/* Release the OSCORE context reference taken in coap_register_observer().
+	 * A no-op for non-OSCORE observers.
+	 */
+	if (observer->oscore_ctx != NULL) {
+		coap_oscore_context_dec_refcount(observer->oscore_ctx);
+		observer->oscore_ctx = NULL;
+	}
+#endif /* CONFIG_COAP_OSCORE */
 
 	coap_observer_raise_event(resource, observer, NET_EVENT_COAP_OBSERVER_REMOVED);
 
@@ -2186,7 +2213,7 @@ int coap_tcp_packet_init(struct coap_packet *cpkt, uint8_t *data,
 	cpkt->max_len = max_len;
 	cpkt->delta = 0U;
 #if defined(CONFIG_COAP_OSCORE)
-	cpkt->is_oscore = false;
+	cpkt->oscore_ctx = NULL;
 #endif /* defined(CONFIG_COAP_OSCORE) */
 
 	/* Assuming packet without options or payload */
@@ -2328,7 +2355,7 @@ int coap_tcp_packet_parse(struct coap_packet *cpkt, uint8_t *data,
 	cpkt->hdr_len = 0U;
 	cpkt->delta = 0U;
 #if defined(CONFIG_COAP_OSCORE)
-	cpkt->is_oscore = false;
+	cpkt->oscore_ctx = NULL;
 #endif /* defined(CONFIG_COAP_OSCORE) */
 
 	tkl = cpkt->data[0] & 0x0f;

--- a/subsys/net/lib/coap/coap_oscore.c
+++ b/subsys/net/lib/coap/coap_oscore.c
@@ -18,21 +18,68 @@ LOG_MODULE_REGISTER(coap_oscore, CONFIG_COAP_LOG_LEVEL);
 
 #include <oscore.h>
 #include <common/oscore_edhoc_error.h>
+#include "oscore/supported_algorithm.h"
+#include "oscore/oscore_coap.h"
 
 #include "coap_oscore_internal.h"
 
 /*
  * Concrete OSCORE context. Publicly this is the opaque struct
  * coap_oscore_context; the uoscore struct context is confined to this file so
- * that no uoscore type leaks into the public CoAP API.
+ * that no uoscore type leaks into the public CoAP API. The Master Secret and
+ * Master Salt buffers are sized by Kconfig (RFC 8613 Section 3.1: the Master
+ * Secret is variable-length keying material and the Master Salt is optional).
  */
 struct coap_oscore_context {
 	struct context ctx;
-	bool in_use;
+	uint8_t master_secret[CONFIG_COAP_OSCORE_MASTER_SECRET_MAX_LEN];
+	uint8_t master_secret_len;
+	uint8_t master_salt[CONFIG_COAP_OSCORE_MASTER_SALT_MAX_LEN];
+	uint8_t master_salt_len;
+	uint8_t sender_id[MAX_KID_LEN];
+	uint8_t sender_id_len;
+	uint8_t recipient_id[MAX_KID_LEN];
+	uint8_t recipient_id_len;
+	uint8_t id_context[MAX_KID_CONTEXT_LEN];
+	uint8_t id_context_len;
+	struct k_mutex lock;
+	atomic_t refcount;
 };
 
 static struct coap_oscore_context oscore_ctx_pool[CONFIG_COAP_OSCORE_MAX_CONTEXTS];
 static K_MUTEX_DEFINE(oscore_ctx_pool_lock);
+
+static bool coap_oscore_refcount_inc_unless_zero(atomic_t *v)
+{
+	atomic_val_t old;
+
+	do {
+		old = atomic_get(v);
+
+		if (old == 0) {
+			return false;
+		}
+
+	} while (!atomic_cas(v, old, old + 1));
+
+	return true;
+}
+
+static bool coap_oscore_refcount_dec_unless_one(atomic_t *v)
+{
+	atomic_val_t old;
+
+	do {
+		old = atomic_get(v);
+
+		if (old <= 1) {
+			return false;
+		}
+
+	} while (!atomic_cas(v, old, old - 1));
+
+	return true;
+}
 
 bool coap_oscore_msg_has_oscore(const struct coap_packet *cpkt)
 {
@@ -57,6 +104,70 @@ int coap_oscore_validate_msg(const struct coap_packet *cpkt)
 	if (payload == NULL || payload_len == 0) {
 		/* RFC 8613 Section 2: OSCORE option present without payload is malformed */
 		LOG_ERR("OSCORE message without payload is malformed (RFC 8613 Section 2)");
+		return -EBADMSG;
+	}
+
+	return 0;
+}
+
+static int coap_oscore_parse_option_identity(const struct coap_option *option, const uint8_t **kid,
+					     uint8_t *kid_len, const uint8_t **id_context,
+					     uint8_t *id_context_len)
+{
+	const uint8_t *value;
+	uint8_t remaining;
+	uint8_t first_byte;
+	uint8_t piv_len;
+
+	if (option == NULL || kid == NULL || kid_len == NULL || id_context == NULL ||
+	    id_context_len == NULL) {
+		return -EINVAL;
+	}
+
+	*kid = NULL;
+	*kid_len = 0;
+	*id_context = NULL;
+	*id_context_len = 0;
+
+	if (option->len == 0) {
+		return 0;
+	}
+
+	value = option->value;
+	remaining = option->len;
+
+	first_byte = *value++;
+	remaining--;
+	piv_len = first_byte & COMP_OSCORE_OPT_PIV_N_MASK;
+
+	if (piv_len > MAX_PIV_LEN || remaining < piv_len) {
+		return -EBADMSG;
+	}
+
+	value += piv_len;
+	remaining -= piv_len;
+
+	if ((first_byte & COMP_OSCORE_OPT_KIDC_H_MASK) != 0U) {
+		if (remaining == 0U) {
+			return -EBADMSG;
+		}
+
+		*id_context_len = *value++;
+		remaining--;
+
+		if (remaining < *id_context_len) {
+			return -EBADMSG;
+		}
+
+		*id_context = value;
+		value += *id_context_len;
+		remaining -= *id_context_len;
+	}
+
+	if ((first_byte & COMP_OSCORE_OPT_KID_K_MASK) != 0U) {
+		*kid = value;
+		*kid_len = remaining;
+	} else if (remaining != 0U) {
 		return -EBADMSG;
 	}
 
@@ -132,8 +243,9 @@ int coap_oscore_protect(uint8_t *coap_msg, uint32_t coap_msg_len, uint8_t *oscor
 		return -EINVAL;
 	}
 
+	k_mutex_lock(&ctx->lock, K_FOREVER);
 	result = coap2oscore(coap_msg, coap_msg_len, oscore_msg, oscore_msg_len, &ctx->ctx);
-
+	k_mutex_unlock(&ctx->lock);
 	if (result != ok) {
 		LOG_ERR("OSCORE protection failed: %d", result);
 		return -EACCES;
@@ -143,11 +255,49 @@ int coap_oscore_protect(uint8_t *coap_msg, uint32_t coap_msg_len, uint8_t *oscor
 	return 0;
 }
 
-int coap_oscore_verify(uint8_t *oscore_msg, uint32_t oscore_msg_len, uint8_t *coap_msg,
-		       uint32_t *coap_msg_len, struct coap_oscore_context *ctx, uint8_t *error_code,
+int coap_oscore_verify(const struct coap_packet *request, uint8_t *oscore_msg,
+		       uint32_t oscore_msg_len, uint8_t *coap_msg, uint32_t *coap_msg_len,
+		       struct coap_oscore_context **ctx, uint8_t *error_code,
 		       bool *needs_echo_challenge)
 {
 	enum err result;
+	struct coap_option option;
+	const uint8_t *kid;
+	const uint8_t *id_context;
+	uint8_t kid_len;
+	uint8_t id_context_len;
+	int ret;
+	bool identity_match_found = false;
+	bool context_candidates[CONFIG_COAP_OSCORE_MAX_CONTEXTS] = {false};
+
+	result = unexpected_result_from_ext_lib;
+
+	if (request == NULL || ctx == NULL || oscore_msg == NULL || coap_msg == NULL ||
+	    coap_msg_len == NULL) {
+		if (error_code != NULL) {
+			*error_code = COAP_RESPONSE_CODE_BAD_REQUEST;
+		}
+		return -EINVAL;
+	}
+
+	*ctx = NULL;
+
+	ret = coap_find_options(request, COAP_OPTION_OSCORE, &option, 1);
+	if (ret <= 0) {
+		if (error_code != NULL) {
+			*error_code = COAP_RESPONSE_CODE_BAD_REQUEST;
+		}
+		return -EINVAL;
+	}
+
+	ret = coap_oscore_parse_option_identity(&option, &kid, &kid_len, &id_context,
+						&id_context_len);
+	if (ret < 0) {
+		if (error_code != NULL) {
+			*error_code = COAP_RESPONSE_CODE_BAD_OPTION;
+		}
+		return -EACCES;
+	}
 
 	if (needs_echo_challenge != NULL) {
 		*needs_echo_challenge = false;
@@ -160,10 +310,68 @@ int coap_oscore_verify(uint8_t *oscore_msg, uint32_t oscore_msg_len, uint8_t *co
 		return -EINVAL;
 	}
 
-	result = oscore2coap(oscore_msg, oscore_msg_len, coap_msg, coap_msg_len, &ctx->ctx);
+	/* Recipient IDs and ID Contexts can be short/low-entropy, so several
+	 * configured contexts may share the same identity. Phase 1 pins every context
+	 * whose identity matches (under the pool lock); phase 2 then runs the
+	 * expensive AEAD verification on each candidate with the pool lock released,
+	 * since only the AEAD tag can disambiguate colliding identities. The pin taken
+	 * in phase 1 keeps each candidate alive after the pool lock is dropped, and
+	 * distinct contexts therefore decrypt concurrently.
+	 */
+	k_mutex_lock(&oscore_ctx_pool_lock, K_FOREVER);
+	for (int i = 0; i < CONFIG_COAP_OSCORE_MAX_CONTEXTS; i++) {
+		if (!coap_oscore_refcount_inc_unless_zero(&oscore_ctx_pool[i].refcount)) {
+			continue;
+		}
 
-	if (result != ok) {
-		LOG_ERR("OSCORE verification failed: %d", result);
+		if (oscore_ctx_pool[i].recipient_id_len == kid_len &&
+		    oscore_ctx_pool[i].id_context_len == id_context_len &&
+		    (kid_len == 0U || memcmp(oscore_ctx_pool[i].recipient_id, kid, kid_len) == 0) &&
+		    (id_context_len == 0U ||
+		     memcmp(oscore_ctx_pool[i].id_context, id_context, id_context_len) == 0)) {
+			identity_match_found = true;
+			context_candidates[i] = true;
+		} else {
+			/* Not a match: drop the pin taken above. */
+			(void)coap_oscore_context_dec_refcount(&oscore_ctx_pool[i]);
+		}
+	}
+	k_mutex_unlock(&oscore_ctx_pool_lock);
+
+	for (int i = 0; i < CONFIG_COAP_OSCORE_MAX_CONTEXTS; i++) {
+		if (!context_candidates[i]) {
+			continue;
+		}
+
+		if (*ctx != NULL) {
+			/* Winner already found; release remaining pinned candidates. */
+			(void)coap_oscore_context_dec_refcount(&oscore_ctx_pool[i]);
+			continue;
+		}
+
+		k_mutex_lock(&oscore_ctx_pool[i].lock, K_FOREVER);
+		result = oscore2coap(oscore_msg, oscore_msg_len, coap_msg, coap_msg_len,
+				     &oscore_ctx_pool[i].ctx);
+		k_mutex_unlock(&oscore_ctx_pool[i].lock);
+
+		if (result != ok && !oscore_err_needs_echo_challenge(result)) {
+			(void)coap_oscore_context_dec_refcount(&oscore_ctx_pool[i]);
+			continue;
+		}
+
+		*ctx = &oscore_ctx_pool[i];
+	}
+
+	if (*ctx == NULL && !identity_match_found) {
+		LOG_DBG("No OSCORE context found returning 4.01 Unauthorized");
+		if (error_code != NULL) {
+			*error_code = COAP_RESPONSE_CODE_UNAUTHORIZED;
+		}
+		return -ENOENT;
+	}
+
+	if (*ctx == NULL || result != ok) {
+		LOG_DBG("OSCORE verification failed: %d", result);
 		if (error_code != NULL) {
 			*error_code = oscore_err_to_coap_code(result);
 		}
@@ -177,8 +385,8 @@ int coap_oscore_verify(uint8_t *oscore_msg, uint32_t oscore_msg_len, uint8_t *co
 	return 0;
 }
 
-int coap_oscore_context_init(struct coap_oscore_init_params *params,
-			     struct coap_oscore_context **ctx)
+int coap_oscore_context_add(const struct coap_oscore_init_params *params,
+			    struct coap_oscore_context **ctx)
 {
 	struct coap_oscore_context *slot = NULL;
 	enum err result;
@@ -208,14 +416,52 @@ int coap_oscore_context_init(struct coap_oscore_init_params *params,
 		return -EINVAL;
 	}
 
+	if (params->master_secret_len > CONFIG_COAP_OSCORE_MASTER_SECRET_MAX_LEN ||
+	    params->master_salt_len > CONFIG_COAP_OSCORE_MASTER_SALT_MAX_LEN ||
+	    params->sender_id_len > MAX_KID_LEN || params->recipient_id_len > MAX_KID_LEN ||
+	    params->id_context_len > MAX_KID_CONTEXT_LEN) {
+		return -EINVAL;
+	}
+
 #if !defined(CONFIG_COAP_OSCORE_CONTEXT_REUSE)
-	/* If context reuse is not enabled, the master secret and salt must be unique at every boot.
-	 */
 	if (!params->fresh_master_secret_salt) {
-		LOG_ERR("Session reuse is not activated. fresh_master_secret_salt must be true");
+		LOG_ERR("Context reuse disabled: fresh_master_secret_salt must be true");
 		return -ENOTSUP;
 	}
 #endif
+
+	k_mutex_lock(&oscore_ctx_pool_lock, K_FOREVER);
+
+	for (int i = 0; i < CONFIG_COAP_OSCORE_MAX_CONTEXTS; i++) {
+		if (atomic_get(&oscore_ctx_pool[i].refcount) == 0) {
+			slot = &oscore_ctx_pool[i];
+			break;
+		}
+	}
+
+	if (slot == NULL) {
+		k_mutex_unlock(&oscore_ctx_pool_lock);
+		LOG_ERR("No free OSCORE context slots (CONFIG_COAP_OSCORE_MAX_CONTEXTS=%d)",
+			CONFIG_COAP_OSCORE_MAX_CONTEXTS);
+		return -ENOMEM;
+	}
+
+	k_mutex_init(&slot->lock);
+
+	slot->master_secret_len = params->master_secret_len;
+	memcpy(slot->master_secret, params->master_secret, params->master_secret_len);
+	slot->master_salt_len = params->master_salt_len;
+	if (params->master_salt_len > 0) {
+		memcpy(slot->master_salt, params->master_salt, params->master_salt_len);
+	}
+	slot->sender_id_len = params->sender_id_len;
+	memcpy(slot->sender_id, params->sender_id, params->sender_id_len);
+	slot->recipient_id_len = params->recipient_id_len;
+	memcpy(slot->recipient_id, params->recipient_id, params->recipient_id_len);
+	slot->id_context_len = params->id_context_len;
+	if (params->id_context_len > 0) {
+		memcpy(slot->id_context, params->id_context, params->id_context_len);
+	}
 
 	/* Map the Zephyr parameters onto the uoscore initialization parameters.
 	 * uoscore keeps pointers to master_secret, master_salt, id_context and
@@ -225,65 +471,80 @@ int coap_oscore_context_init(struct coap_oscore_init_params *params,
 	 * const-correct public API without discarded-qualifier warnings at callers.
 	 */
 	struct oscore_init_params uo_params = {
-		.master_secret = {.len = params->master_secret_len,
-				  .ptr = (uint8_t *)params->master_secret},
-		.sender_id = {.len = params->sender_id_len, .ptr = (uint8_t *)params->sender_id},
-		.recipient_id = {.len = params->recipient_id_len,
-				 .ptr = (uint8_t *)params->recipient_id},
-		.master_salt = {.len = params->master_salt_len,
-				.ptr = (uint8_t *)params->master_salt},
-		.id_context = {.len = params->id_context_len, .ptr = (uint8_t *)params->id_context},
+		.master_secret = {.len = slot->master_secret_len, .ptr = slot->master_secret},
+		.sender_id = {.len = slot->sender_id_len, .ptr = slot->sender_id},
+		.recipient_id = {.len = slot->recipient_id_len, .ptr = slot->recipient_id},
+		.master_salt = {.len = slot->master_salt_len, .ptr = slot->master_salt},
+		.id_context = {.len = slot->id_context_len, .ptr = slot->id_context},
 		.aead_alg =
 			OSCORE_AES_CCM_16_64_128, /* Only one AEAD algorithm supported for now */
 		.hkdf = OSCORE_SHA_256,           /* Only one HKDF algorithm supported for now */
 		.fresh_master_secret_salt = params->fresh_master_secret_salt,
 	};
 
-	k_mutex_lock(&oscore_ctx_pool_lock, K_FOREVER);
-
-	for (int i = 0; i < CONFIG_COAP_OSCORE_MAX_CONTEXTS; i++) {
-		if (!oscore_ctx_pool[i].in_use) {
-			slot = &oscore_ctx_pool[i];
-			slot->in_use = true;
-			break;
-		}
-	}
-
-	k_mutex_unlock(&oscore_ctx_pool_lock);
-
-	if (slot == NULL) {
-		LOG_ERR("No free OSCORE context slots (CONFIG_COAP_OSCORE_MAX_CONTEXTS=%d)",
-			CONFIG_COAP_OSCORE_MAX_CONTEXTS);
-		return -ENOMEM;
-	}
-
 	result = oscore_context_init(&uo_params, &slot->ctx);
 	if (result != ok) {
 		LOG_ERR("oscore_context_init failed: %d", result);
-		k_mutex_lock(&oscore_ctx_pool_lock, K_FOREVER);
 		memset(slot, 0, sizeof(*slot));
 		k_mutex_unlock(&oscore_ctx_pool_lock);
 		return -EINVAL;
 	}
 
+	/* Needs to be last since after this the slot will be visible as live */
+	atomic_set(&slot->refcount, 1);
+
 	*ctx = slot;
+	k_mutex_unlock(&oscore_ctx_pool_lock);
 	return 0;
 }
 
-void coap_oscore_context_free(struct coap_oscore_context *ctx)
+int coap_oscore_context_remove(struct coap_oscore_context *ctx)
 {
 	if (ctx == NULL) {
-		return;
+		return -EINVAL;
 	}
 
 	if (!PART_OF_ARRAY(oscore_ctx_pool, ctx)) {
 		LOG_ERR("Invalid OSCORE context handle");
-		return;
+		return -EINVAL;
 	}
 
 	k_mutex_lock(&oscore_ctx_pool_lock, K_FOREVER);
+	/* Counter should be 1, meaning that the context is not in use by any observer or exchange.
+	 * If it is not 1, then it is in use and cannot be removed.
+	 */
+	if (atomic_cas(&ctx->refcount, 1, 0) == false) {
+		LOG_ERR("OSCORE context is in use, cannot remove");
+		k_mutex_unlock(&oscore_ctx_pool_lock);
+		return -EAGAIN;
+	}
 	memset(ctx, 0, sizeof(*ctx));
 	k_mutex_unlock(&oscore_ctx_pool_lock);
+	return 0;
+}
+
+int coap_oscore_context_inc_refcount(struct coap_oscore_context *ctx)
+{
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	if (!coap_oscore_refcount_inc_unless_zero(&ctx->refcount)) {
+		return -EINVAL;
+	}
+	return 0;
+}
+
+int coap_oscore_context_dec_refcount(struct coap_oscore_context *ctx)
+{
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	if (!coap_oscore_refcount_dec_unless_one(&ctx->refcount)) {
+		return -EINVAL;
+	}
+	return 0;
 }
 
 struct coap_oscore_exchange *coap_oscore_exchange_find(struct coap_oscore_exchange *cache,
@@ -299,6 +560,7 @@ struct coap_oscore_exchange *coap_oscore_exchange_find(struct coap_oscore_exchan
 		}
 
 		if ((now - cache[i].timestamp) > CONFIG_COAP_OSCORE_EXCHANGE_LIFETIME_MS) {
+			(void)coap_oscore_context_dec_refcount(cache[i].ctx);
 			memset(&cache[i], 0, sizeof(cache[i]));
 			continue;
 		}
@@ -313,7 +575,8 @@ struct coap_oscore_exchange *coap_oscore_exchange_find(struct coap_oscore_exchan
 }
 
 int coap_oscore_exchange_add(struct coap_oscore_exchange *cache, const struct net_sockaddr *addr,
-			     net_socklen_t addr_len, const uint8_t *token, uint8_t tkl)
+			     net_socklen_t addr_len, const uint8_t *token, uint8_t tkl,
+			     struct coap_oscore_context *ctx)
 {
 	struct coap_oscore_exchange *entry;
 	int64_t now = k_uptime_get();
@@ -325,6 +588,13 @@ int coap_oscore_exchange_add(struct coap_oscore_exchange *cache, const struct ne
 	entry = coap_oscore_exchange_find(cache, addr, addr_len, token, tkl);
 	if (entry != NULL) {
 		entry->timestamp = now;
+		(void)coap_oscore_context_dec_refcount(entry->ctx);
+		entry->ctx = ctx;
+		if (coap_oscore_context_inc_refcount(entry->ctx) != 0) {
+			/* old context removed but potentially new one could not be added */
+			memset(entry, 0, sizeof(*entry));
+			return -EINVAL;
+		}
 		return 0;
 	}
 
@@ -342,6 +612,12 @@ int coap_oscore_exchange_add(struct coap_oscore_exchange *cache, const struct ne
 	if (addr_len > sizeof(entry->addr)) {
 		return -EINVAL;
 	}
+
+	entry->ctx = ctx;
+	if (coap_oscore_context_inc_refcount(entry->ctx) != 0) {
+		return -EINVAL;
+	}
+
 	memcpy(&entry->addr, addr, addr_len);
 	entry->addr_len = addr_len;
 	memcpy(entry->token, token, tkl);
@@ -359,6 +635,7 @@ void coap_oscore_exchange_remove(struct coap_oscore_exchange *cache,
 
 	entry = coap_oscore_exchange_find(cache, addr, addr_len, token, tkl);
 	if (entry != NULL) {
+		(void)coap_oscore_context_dec_refcount(entry->ctx);
 		memset(entry, 0, sizeof(*entry));
 	}
 }

--- a/subsys/net/lib/coap/coap_oscore_internal.h
+++ b/subsys/net/lib/coap/coap_oscore_internal.h
@@ -53,19 +53,24 @@ int coap_oscore_protect(uint8_t *coap_msg, uint32_t coap_msg_len, uint8_t *oscor
 /**
  * @brief Verify and decrypt an OSCORE-protected message
  *
+ * @param request Original CoAP request packet (for context)
  * @param oscore_msg Input OSCORE-protected message buffer
  * @param oscore_msg_len Length of input OSCORE message
  * @param coap_msg Output buffer for decrypted CoAP message
  * @param coap_msg_len On input: size of output buffer; on output: length of decrypted message
- * @param ctx OSCORE security context
+ * @param ctx On success, set to the matching OSCORE security context with its reference count
+ * incremented; the caller must release it with coap_oscore_context_dec_refcount() once the request
+ * has been fully processed. This held reference prevents the context from being removed while it is
+ * in use. Set to NULL if no matching context is found
  * @param error_code If verification fails, this is set to the appropriate CoAP error code
  * @param needs_echo_challenge Optional; if non-NULL, set to true when the failure requires
  *        an Echo challenge response for replay window synchronization (RFC 8613 Appendix B.1.2)
  * @return 0 on success, negative errno on error
  */
-int coap_oscore_verify(uint8_t *oscore_msg, uint32_t oscore_msg_len, uint8_t *coap_msg,
-		       uint32_t *coap_msg_len, struct coap_oscore_context *ctx,
-		       uint8_t *error_code, bool *needs_echo_challenge);
+int coap_oscore_verify(const struct coap_packet *request, uint8_t *oscore_msg,
+		       uint32_t oscore_msg_len, uint8_t *coap_msg, uint32_t *coap_msg_len,
+		       struct coap_oscore_context **ctx, uint8_t *error_code,
+		       bool *needs_echo_challenge);
 
 /**
  * @brief Find OSCORE exchange entry
@@ -90,10 +95,13 @@ struct coap_oscore_exchange *coap_oscore_exchange_find(struct coap_oscore_exchan
  * @param addr_len Length of the client address
  * @param token Pointer to the request token
  * @param tkl Length of the request token
+ * @param ctx OSCORE security context used for this exchange
+ *
  * @return 0 on success, negative errno on error
  */
 int coap_oscore_exchange_add(struct coap_oscore_exchange *cache, const struct net_sockaddr *addr,
-			     net_socklen_t addr_len, const uint8_t *token, uint8_t tkl);
+			     net_socklen_t addr_len, const uint8_t *token, uint8_t tkl,
+			     struct coap_oscore_context *ctx);
 
 /**
  * @brief Remove OSCORE exchange entry
@@ -107,6 +115,26 @@ int coap_oscore_exchange_add(struct coap_oscore_exchange *cache, const struct ne
 void coap_oscore_exchange_remove(struct coap_oscore_exchange *cache,
 				 const struct net_sockaddr *addr, net_socklen_t addr_len,
 				 const uint8_t *token, uint8_t tkl);
+
+/**
+ * @brief Increment the reference count of an OSCORE context
+ *
+ * @param ctx OSCORE context
+ *
+ * @return 0 on success
+ * @return -EINVAL if @p ctx is NULL or the context is stale (already removed)
+ */
+int coap_oscore_context_inc_refcount(struct coap_oscore_context *ctx);
+
+/**
+ * @brief Decrement the reference count of an OSCORE context
+ *
+ * @param ctx OSCORE context
+ *
+ * @return 0 on success
+ * @return -EINVAL if @p ctx is NULL or the context is already not referenced
+ */
+int coap_oscore_context_dec_refcount(struct coap_oscore_context *ctx);
 
 #endif /* CONFIG_COAP_OSCORE */
 

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -22,6 +22,7 @@ LOG_MODULE_DECLARE(net_coap, CONFIG_COAP_LOG_LEVEL);
 
 #if defined(CONFIG_COAP_OSCORE)
 #include <psa/crypto.h>
+#include <zephyr/net/coap_oscore.h>
 #include "coap_oscore_internal.h"
 
 /* Approximate OSCORE buffer overhead */
@@ -66,16 +67,6 @@ K_MEM_SLAB_DEFINE_STATIC(pending_data, COAP_SERVER_WIRE_MESSAGE_SIZE,
 #endif
 
 #if defined(CONFIG_COAP_OSCORE)
-static inline struct coap_oscore_context *
-coap_service_oscore_ctx(const struct coap_service *service)
-{
-	if (service->oscore_ctx_provider == NULL) {
-		return NULL;
-	}
-
-	return service->oscore_ctx_provider();
-}
-
 static void coap_oscore_finish_exchange(struct coap_oscore_exchange *cache,
 				   const struct coap_packet *cpkt, const struct net_sockaddr *addr,
 				   net_socklen_t addr_len)
@@ -130,11 +121,18 @@ enum coap_oscore_protect_mode {
 	OSCORE_PROTECT_FORCE, /* Force OSCORE protection regardless of exchange state */
 };
 
+struct coap_oscore_protect_params {
+	enum coap_oscore_protect_mode mode;
+#if defined(CONFIG_COAP_OSCORE)
+	struct coap_oscore_context *ctx;
+#endif /* CONFIG_COAP_OSCORE */
+};
+
 static int coap_service_send_internal(const struct coap_service *service,
 				      const struct coap_packet *cpkt,
 				      const struct net_sockaddr *addr, net_socklen_t addr_len,
 				      const struct coap_transmission_parameters *params,
-				      enum coap_oscore_protect_mode oscore_protect_mode);
+				      struct coap_oscore_protect_params *oscore_params);
 
 #if defined(CONFIG_COAP_OSCORE)
 static int init_error_response_packet(struct coap_packet *response,
@@ -163,8 +161,12 @@ static int send_error_response(const struct coap_service *service,
 		return ret;
 	}
 
+	struct coap_oscore_protect_params oscore_params = {
+		.mode = OSCORE_PROTECT_SKIP,
+		.ctx = NULL,
+	};
 	return coap_service_send_internal(service, &response, client_addr, client_addr_len, NULL,
-					  OSCORE_PROTECT_SKIP);
+					  &oscore_params);
 }
 
 /* RFC 8613 Appendix B.1.2: after a reboot with a reused context the recipient replay
@@ -175,7 +177,8 @@ static int send_error_response(const struct coap_service *service,
 static int send_oscore_echo_challenge(const struct coap_service *service,
 				      const struct coap_packet *request,
 				      const struct net_sockaddr *client_addr,
-				      net_socklen_t client_addr_len, uint8_t *buf, size_t buf_len)
+				      net_socklen_t client_addr_len, uint8_t *buf, size_t buf_len,
+				      struct coap_oscore_context *ctx)
 {
 	uint8_t echo_val[OSCORE_ECHO_CHALLENGE_LEN];
 	struct coap_packet response;
@@ -208,8 +211,12 @@ static int send_oscore_echo_challenge(const struct coap_service *service,
 	/* Use coap_service_send_internal with FORCE mode to bypass exchange cache logic
 	 * and ensure OSCORE protection is applied regardless of exchange state.
 	 */
+	struct coap_oscore_protect_params oscore_params = {
+		.mode = OSCORE_PROTECT_FORCE,
+		.ctx = ctx,
+	};
 	ret = coap_service_send_internal(service, &response, client_addr, client_addr_len, NULL,
-					 OSCORE_PROTECT_FORCE);
+					  &oscore_params);
 
 	if (ret == 0) {
 		LOG_DBG("Sent OSCORE Echo challenge for replay window synchronization");
@@ -275,6 +282,9 @@ static int coap_server_process(int sock_fd)
 	ssize_t received;
 	int ret;
 	int flags = ZSOCK_MSG_DONTWAIT;
+#if defined(CONFIG_COAP_OSCORE)
+	struct coap_oscore_context *oscore_ctx = NULL;
+#endif
 
 	if (IS_ENABLED(CONFIG_COAP_SERVER_TRUNCATE_MSGS)) {
 		flags |= ZSOCK_MSG_TRUNC;
@@ -442,37 +452,43 @@ static int coap_server_process(int sock_fd)
 		goto unlock;
 	}
 
-	/* RFC 8613 Section 8.2: Verify and decrypt OSCORE-protected requests */
-	struct coap_oscore_context *oscore_ctx = coap_service_oscore_ctx(service);
+	if (request_has_oscore && service->data->oscore_exchange_cache == NULL) {
+		/* Service is not OSCORE-enabled (no exchange cache), so it can neither
+		 * track the exchange nor protect a response. Reject the unsupported
+		 * critical option instead of decrypting a request we cannot answer.
+		 */
+		LOG_WRN("OSCORE request on non-OSCORE service %s, rejecting", service->name);
+		(void)send_error_response(service, &request, COAP_RESPONSE_CODE_BAD_OPTION,
+					  net_sad(&client_addr), client_addr_len, buf, sizeof(buf));
+		ret = -ENOTSUP;
+		goto unlock;
+	}
 
-	if (oscore_ctx != NULL && request_has_oscore) {
+	if (request_has_oscore) {
 		static uint8_t decrypted_buf[CONFIG_COAP_SERVER_MESSAGE_SIZE];
 		uint32_t decrypted_len = sizeof(decrypted_buf);
 		uint8_t error_code = COAP_RESPONSE_CODE_BAD_REQUEST;
 		bool needs_echo_challenge = false;
 
-		ret = coap_oscore_verify(buf, received, decrypted_buf, &decrypted_len, oscore_ctx,
-					 &error_code, &needs_echo_challenge);
+		ret = coap_oscore_verify(&request, buf, received, decrypted_buf, &decrypted_len,
+					 &oscore_ctx, &error_code, &needs_echo_challenge);
 		if (ret < 0) {
 			if (needs_echo_challenge) {
 				/* RFC 8613 Appendix B.1.2: re-synchronize the recipient replay
 				 * window by challenging the client with a protected Echo option.
 				 */
 				LOG_DBG("OSCORE replay window desync, sending Echo challenge");
-				(void)send_oscore_echo_challenge(service, &request,
-								 net_sad(&client_addr),
-								 client_addr_len, buf, sizeof(buf));
+				(void)send_oscore_echo_challenge(
+					service, &request, net_sad(&client_addr), client_addr_len,
+					buf, sizeof(buf), oscore_ctx);
 			} else {
 				/* RFC 8613 Section 8.2: OSCORE errors are sent as simple CoAP
 				 * responses without OSCORE processing
 				 */
-				LOG_ERR("OSCORE verification failed (%d), sending error %d", ret,
-					error_code);
 				(void)send_error_response(service, &request, error_code,
 							  net_sad(&client_addr), client_addr_len,
 							  buf, sizeof(buf));
 			}
-			ret = -EACCES;
 			goto unlock;
 		}
 
@@ -486,7 +502,6 @@ static int coap_server_process(int sock_fd)
 		}
 
 		LOG_DBG("OSCORE request verified and decrypted");
-		request.is_oscore = true; /* persists into observer via coap_observer_init */
 
 		/* RFC 8613 Section 8.3: Track OSCORE exchanges to protect responses */
 		uint8_t token[COAP_TOKEN_MAX_LEN];
@@ -495,8 +510,8 @@ static int coap_server_process(int sock_fd)
 
 		if (!is_observe) {
 			ret = coap_oscore_exchange_add(service->data->oscore_exchange_cache,
-						  net_sad(&client_addr), client_addr_len, token,
-						  tkl);
+						       net_sad(&client_addr), client_addr_len,
+						       token, tkl, oscore_ctx);
 			if (ret < 0) {
 				if (ret == -ENOMEM) {
 					LOG_WRN("OSCORE exchange full. Sending 5.03 Service "
@@ -515,14 +530,12 @@ static int coap_server_process(int sock_fd)
 				ret = -EINVAL;
 				goto unlock;
 			}
+		} else {
+			request.oscore_ctx =
+				oscore_ctx; /* persists into observer via coap_observer_init */
 		}
-	} else if (oscore_ctx == NULL && request_has_oscore) {
-		LOG_WRN("OSCORE message received but no context configured");
-		(void)send_error_response(service, &request, COAP_RESPONSE_CODE_UNAUTHORIZED,
-					  net_sad(&client_addr), client_addr_len, buf, sizeof(buf));
-		ret = -ENOTSUP;
-		goto unlock;
-	} else if (service->oscore_required && !request_has_oscore) {
+
+	} else if (service->oscore_required) {
 		LOG_WRN("Service requires OSCORE but request is not protected");
 		(void)send_error_response(service, &request, COAP_RESPONSE_CODE_UNAUTHORIZED,
 					  net_sad(&client_addr), client_addr_len, buf, sizeof(buf));
@@ -614,6 +627,12 @@ static int coap_server_process(int sock_fd)
 	}
 
 unlock:
+#if defined(CONFIG_COAP_OSCORE)
+	if (oscore_ctx != NULL) {
+		/* Release the reference taken by coap_oscore_verify() */
+		coap_oscore_context_dec_refcount(oscore_ctx);
+	}
+#endif
 	(void)k_mutex_unlock(&lock);
 
 	return ret;
@@ -917,7 +936,7 @@ static int coap_service_send_internal(const struct coap_service *service,
 				      const struct coap_packet *cpkt,
 				      const struct net_sockaddr *addr, net_socklen_t addr_len,
 				      const struct coap_transmission_parameters *params,
-				      enum coap_oscore_protect_mode oscore_protect_mode)
+				      struct coap_oscore_protect_params *oscore_params)
 {
 	int ret;
 
@@ -948,19 +967,24 @@ static int coap_service_send_internal(const struct coap_service *service,
 
 #if defined(CONFIG_COAP_OSCORE)
 	/* RFC 8613 Section 8.3: Protect responses for OSCORE exchanges */
-	struct coap_oscore_context *oscore_ctx = coap_service_oscore_ctx(service);
+	struct coap_oscore_context *oscore_ctx = NULL;
 
-	if (oscore_ctx != NULL && oscore_protect_mode != OSCORE_PROTECT_SKIP) {
+	if (oscore_params != NULL && oscore_params->mode != OSCORE_PROTECT_SKIP &&
+	    (service->data->oscore_exchange_cache != NULL ||
+	     oscore_params->mode == OSCORE_PROTECT_FORCE)) {
 		uint8_t token[COAP_TOKEN_MAX_LEN];
 		uint8_t tkl = coap_header_get_token(cpkt, token);
-		bool protect = false;
 
 		is_notify = coap_get_option_int(cpkt, COAP_OPTION_OBSERVE) >= 0;
 		is_empty = coap_header_get_code(cpkt) == COAP_CODE_EMPTY;
 
-		if (oscore_protect_mode == OSCORE_PROTECT_FORCE) {
-			/* Force protection regardless of exchange or observer state */
-			protect = true;
+		if (oscore_params->mode == OSCORE_PROTECT_FORCE) {
+			if (oscore_params->ctx == NULL) {
+				LOG_ERR("OSCORE context required for FORCE mode");
+				(void)k_mutex_unlock(&lock);
+				return -EINVAL;
+			}
+			oscore_ctx = oscore_params->ctx;
 		} else if (is_notify) {
 			/* For Observe notifications, find the observer to determine if the response
 			 * needs OSCORE protection
@@ -978,15 +1002,13 @@ static int coap_service_send_internal(const struct coap_service *service,
 								      MAX_OBSERVERS, addr);
 			}
 
-			protect = (observer != NULL) && observer->is_oscore;
-		} else if (is_empty) {
-			protect = false; /* empty ACK/RST: messaging layer only */
-		} else {
+			oscore_ctx = observer ? observer->oscore_ctx : NULL;
+		} else if (!is_empty) {
 			exchange = coap_oscore_exchange_find(service->data->oscore_exchange_cache,
 							     addr, addr_len, token, tkl);
-			protect = (exchange != NULL);
+			oscore_ctx = exchange ? exchange->ctx : NULL;
 		}
-		if (protect) {
+		if (oscore_ctx != NULL) {
 			(void)k_mem_slab_alloc(&coap_oscore_send_buffer, (void **)&oscore_buf,
 					       K_FOREVER);
 			ret = coap_oscore_protect(cpkt->data, cpkt->offset, oscore_buf, &oscore_len,
@@ -1064,7 +1086,7 @@ static int coap_service_send_internal(const struct coap_service *service,
 		 * so release the exchange slot now rather than leaving it stale for the full
 		 * retransmit window if the initial send fails.
 		 */
-		if (oscore_ctx != NULL && oscore_protect_mode != OSCORE_PROTECT_SKIP &&
+		if (oscore_ctx != NULL && oscore_params->mode != OSCORE_PROTECT_SKIP &&
 		    !is_notify && !is_empty && exchange != NULL) {
 			coap_oscore_finish_exchange(service->data->oscore_exchange_cache, cpkt,
 						    addr, addr_len);
@@ -1092,7 +1114,7 @@ send:
 	/* For NON responses and CON when the pending cache was full, remove the exchange
 	 * entry only after a successful send so the application can retry on failure.
 	 */
-	if (!exchange_removed && oscore_ctx != NULL && oscore_protect_mode != OSCORE_PROTECT_SKIP &&
+	if (!exchange_removed && oscore_ctx != NULL && oscore_params->mode != OSCORE_PROTECT_SKIP &&
 	    !is_notify && !is_empty && exchange != NULL) {
 
 		(void)k_mutex_lock(&lock, K_FOREVER);
@@ -1108,8 +1130,13 @@ int coap_service_send(const struct coap_service *service, const struct coap_pack
 		      const struct net_sockaddr *addr, net_socklen_t addr_len,
 		      const struct coap_transmission_parameters *params)
 {
-	return coap_service_send_internal(service, cpkt, addr, addr_len, params,
-					  OSCORE_PROTECT_CACHE);
+	struct coap_oscore_protect_params oscore_params = {
+		.mode = OSCORE_PROTECT_CACHE, /* default to cache-based protection for responses */
+#if defined(CONFIG_COAP_OSCORE)
+		.ctx = NULL,
+#endif /* CONFIG_COAP_OSCORE */
+	};
+	return coap_service_send_internal(service, cpkt, addr, addr_len, params, &oscore_params);
 }
 
 int coap_resource_send(const struct coap_resource *resource, const struct coap_packet *cpkt,
@@ -1170,6 +1197,25 @@ int coap_resource_parse_observe(struct coap_resource *resource, const struct coa
 					      tkl);
 		if (observer != NULL) {
 			/* Client refresh */
+#if defined(CONFIG_COAP_OSCORE)
+			if (request->oscore_ctx != NULL &&
+			    observer->oscore_ctx != request->oscore_ctx) {
+				struct coap_oscore_context *old_ctx = observer->oscore_ctx;
+
+				if (old_ctx != NULL) {
+					(void)coap_oscore_context_dec_refcount(old_ctx);
+				}
+				observer->oscore_ctx = request->oscore_ctx;
+
+				if (coap_oscore_context_inc_refcount(observer->oscore_ctx) != 0) {
+					/* old context removed but potentially new one could not be
+					 * added
+					 */
+					observer->oscore_ctx = NULL;
+					ret = -EINVAL;
+				}
+			}
+#endif /* CONFIG_COAP_OSCORE */
 			goto unlock;
 		}
 
@@ -1181,7 +1227,7 @@ int coap_resource_parse_observe(struct coap_resource *resource, const struct coa
 		}
 
 #if defined(CONFIG_COAP_OSCORE)
-		coap_observer_init_oscore(observer, request, addr, request->is_oscore);
+		coap_observer_init_oscore(observer, request, addr, request->oscore_ctx);
 #else
 		coap_observer_init(observer, request, addr);
 #endif /* CONFIG_COAP_OSCORE */

--- a/tests/net/lib/coap_oscore/CMakeLists.txt
+++ b/tests/net/lib/coap_oscore/CMakeLists.txt
@@ -4,8 +4,11 @@ cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(coap_oscore)
 
-file(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+if(COAP_OSCORE_SALT_ONLY)
+  target_sources(app PRIVATE src/salt.c)
+else()
+  target_sources(app PRIVATE src/main.c)
+endif()
 target_include_directories(app PRIVATE
   ${ZEPHYR_BASE}/subsys/net/ip
   ${ZEPHYR_BASE}/subsys/net/lib/coap

--- a/tests/net/lib/coap_oscore/src/main.c
+++ b/tests/net/lib/coap_oscore/src/main.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_COAP_OSCORE)
 
+#include <oscore.h>
 #include "oscore/nvm.h"
 
 /*
@@ -43,6 +44,9 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_DBG);
  * fresh client and server context from it so sender sequence numbers start from
  * zero. A second, non-OSCORE-required ("mixed") service exercises the code paths
  * that differ between required and mixed services.
+ *
+ * Server contexts are added to the CoAP OSCORE pool; the simulated client is an
+ * external peer and drives uoscore (coap2oscore/oscore2coap) directly.
  */
 
 static const uint8_t oscore_master_secret[] = {
@@ -60,9 +64,12 @@ static const uint8_t oscore_deferred_payload[] = "deferred-response";
 static const uint8_t oscore_mixed_payload[] = "mixed-response";
 static const uint8_t oscore_secure_payload[] = "encrypted-response";
 
-static int oscore_make_ctx_detailed(const uint8_t *sender_id, size_t sender_id_len,
-				    const uint8_t *recipient_id, size_t recipient_id_len,
-				    bool fresh, struct coap_oscore_context **ctx)
+/* Simulated client's uoscore context, reused across tests to avoid large stacks. */
+static struct context oscore_client_uctx;
+
+static int oscore_make_server_ctx_detailed(const uint8_t *sender_id, size_t sender_id_len,
+					   const uint8_t *recipient_id, size_t recipient_id_len,
+					   bool fresh, struct coap_oscore_context **ctx)
 {
 	struct coap_oscore_init_params params = {
 		.master_secret = oscore_master_secret,
@@ -78,15 +85,36 @@ static int oscore_make_ctx_detailed(const uint8_t *sender_id, size_t sender_id_l
 		.fresh_master_secret_salt = fresh,
 	};
 
-	return coap_oscore_context_init(&params, ctx);
+	return coap_oscore_context_add(&params, ctx);
 }
 
-static int oscore_make_ctx(const uint8_t *sender_id, size_t sender_id_len,
-			   const uint8_t *recipient_id, size_t recipient_id_len,
-			   struct coap_oscore_context **ctx)
+static int oscore_make_server_ctx(const uint8_t *sender_id, size_t sender_id_len,
+				  const uint8_t *recipient_id, size_t recipient_id_len,
+				  struct coap_oscore_context **ctx)
 {
-	return oscore_make_ctx_detailed(sender_id, sender_id_len, recipient_id, recipient_id_len,
-					true, ctx);
+	return oscore_make_server_ctx_detailed(sender_id, sender_id_len, recipient_id,
+					       recipient_id_len, true, ctx);
+}
+
+/* Initialize the simulated client directly through uoscore (external peer). */
+static int oscore_make_client_ctx(const uint8_t *sender_id, size_t sender_id_len,
+				  const uint8_t *recipient_id, size_t recipient_id_len,
+				  bool fresh, struct context *ctx)
+{
+	struct oscore_init_params params = {
+		.master_secret = {.len = sizeof(oscore_master_secret),
+				  .ptr = (uint8_t *)oscore_master_secret},
+		.sender_id = {.len = sender_id_len, .ptr = (uint8_t *)sender_id},
+		.recipient_id = {.len = recipient_id_len, .ptr = (uint8_t *)recipient_id},
+		.id_context = {.len = 0, .ptr = NULL},
+		.master_salt = {.len = sizeof(oscore_master_salt),
+				.ptr = (uint8_t *)oscore_master_salt},
+		.aead_alg = OSCORE_AES_CCM_16_64_128,
+		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = fresh,
+	};
+
+	return oscore_context_init(&params, ctx) == ok ? 0 : -EINVAL;
 }
 
 static net_socklen_t oscore_addr_len(const struct net_sockaddr *addr)
@@ -141,16 +169,15 @@ static int oscore_build_request(struct coap_packet *req, uint8_t *buf, size_t bu
 	return 0;
 }
 
-static int oscore_send_protected(int sock, struct coap_oscore_context *ctx,
+static int oscore_send_protected(int sock, struct context *ctx,
 				 const struct net_sockaddr_in6 *dst, const struct coap_packet *req)
 {
 	uint8_t protected[COAP_BUF_SIZE];
 	uint32_t protected_len = sizeof(protected);
 	int ret;
 
-	ret = coap_oscore_protect(req->data, req->offset, protected, &protected_len, ctx);
-	if (ret < 0) {
-		return ret;
+	if (coap2oscore(req->data, req->offset, protected, &protected_len, ctx) != ok) {
+		return -EBADMSG;
 	}
 
 	ret = zsock_sendto(sock, protected, protected_len, 0, (const struct net_sockaddr *)dst,
@@ -182,12 +209,11 @@ static int oscore_recv(int sock, int timeout_ms, uint8_t *buf, size_t buf_len)
 }
 
 /* Receive, parse and OSCORE-verify a response, returning the decrypted inner packet. */
-static int oscore_recv_verify(int sock, int timeout_ms, struct coap_oscore_context *ctx,
+static int oscore_recv_verify(int sock, int timeout_ms, struct context *ctx,
 			      uint8_t *inner_buf, uint32_t *inner_len, struct coap_packet *inner)
 {
 	uint8_t recv_buf[COAP_BUF_SIZE];
 	struct coap_packet outer;
-	uint8_t oscore_error = 0;
 	int len;
 	int ret;
 
@@ -205,10 +231,8 @@ static int oscore_recv_verify(int sock, int timeout_ms, struct coap_oscore_conte
 		return -ENOMSG;
 	}
 
-	ret = coap_oscore_verify(recv_buf, outer.offset, inner_buf, inner_len, ctx, &oscore_error,
-				 NULL);
-	if (ret < 0) {
-		return ret;
+	if (oscore2coap(recv_buf, outer.offset, inner_buf, inner_len, ctx) != ok) {
+		return -EBADMSG;
 	}
 
 	return coap_packet_parse(inner, inner_buf, *inner_len, NULL, 0);
@@ -217,12 +241,6 @@ static int oscore_recv_verify(int sock, int timeout_ms, struct coap_oscore_conte
 /* Secure (OSCORE-required) service*/
 static uint16_t oscore_secure_service_port = 56839;
 static struct coap_oscore_context *oscore_secure_service_ctx;
-
-/* Provider invoked by the CoAP server when OSCORE processing is needed. */
-static struct coap_oscore_context *oscore_secure_service_provider(void)
-{
-	return oscore_secure_service_ctx;
-}
 
 static int oscore_secure_get(struct coap_resource *resource, struct coap_packet *request,
 			     struct net_sockaddr *addr, net_socklen_t addr_len)
@@ -265,11 +283,6 @@ static int oscore_secure_get(struct coap_resource *resource, struct coap_packet 
 /* Mixed (non-OSCORE-required) service. */
 static uint16_t oscore_mixed_service_port = 56840;
 static struct coap_oscore_context *oscore_mixed_service_ctx;
-
-static struct coap_oscore_context *oscore_mixed_service_provider(void)
-{
-	return oscore_mixed_service_ctx;
-}
 
 /* State captured by the separate-response handler for a later (deferred) reply. */
 struct oscore_saved_request {
@@ -460,11 +473,9 @@ static int oscore_mixed_get(struct coap_resource *resource, struct coap_packet *
 	return 0;
 }
 
-COAP_SERVICE_DEFINE_OSCORE(oscore_secure_service, NULL, &oscore_secure_service_port, 0,
-			   oscore_secure_service_provider, true);
+COAP_SERVICE_DEFINE_OSCORE(oscore_secure_service, NULL, &oscore_secure_service_port, 0, true);
 
-COAP_SERVICE_DEFINE_OSCORE(oscore_mixed_service, NULL, &oscore_mixed_service_port, 0,
-			   oscore_mixed_service_provider, false);
+COAP_SERVICE_DEFINE_OSCORE(oscore_mixed_service, NULL, &oscore_mixed_service_port, 0, false);
 
 static const char *const oscore_observe_path[] = {"observe", NULL};
 static const char *const oscore_separate_path[] = {"separate", NULL};
@@ -611,13 +622,18 @@ ZTEST(coap_oscore, test_oscore_exchange_cache)
 	};
 	uint8_t token1[] = {0x01, 0x02, 0x03, 0x04};
 	uint8_t token2[] = {0x05, 0x06, 0x07, 0x08};
+	struct coap_oscore_context *ctx;
+
+	zassert_ok(oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id),
+					  oscore_client_id, sizeof(oscore_client_id), &ctx),
+		   "Should create context");
 
 	/* Initialize cache */
 	memset(cache, 0, sizeof(cache));
 
 	/* Test: Add entry to cache */
 	int ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr1, sizeof(addr1),
-					   token1, sizeof(token1));
+					   token1, sizeof(token1), ctx);
 	zassert_ok(ret, "Should add exchange entry");
 
 	/* Test: Find the entry */
@@ -631,7 +647,7 @@ ZTEST(coap_oscore, test_oscore_exchange_cache)
 
 	/* Test: Add another entry with different address */
 	ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr2, sizeof(addr2), token2,
-				       sizeof(token2));
+				       sizeof(token2), ctx);
 	zassert_ok(ret, "Should add second exchange entry");
 
 	/* Test: Find second entry */
@@ -641,7 +657,7 @@ ZTEST(coap_oscore, test_oscore_exchange_cache)
 
 	/* Test: Update existing entry */
 	ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr1, sizeof(addr1), token1,
-				       sizeof(token1));
+				       sizeof(token1), ctx);
 	zassert_ok(ret, "Should update exchange entry");
 
 	entry = coap_oscore_exchange_find(cache, (struct net_sockaddr *)&addr1, sizeof(addr1),
@@ -660,6 +676,11 @@ ZTEST(coap_oscore, test_oscore_exchange_cache)
 	entry = coap_oscore_exchange_find(cache, (struct net_sockaddr *)&addr2, sizeof(addr2),
 					  token2, sizeof(token2));
 	zassert_not_null(entry, "Second entry should still exist");
+
+	/* Release remaining reference and return the context to the pool. */
+	coap_oscore_exchange_remove(cache, (struct net_sockaddr *)&addr2, sizeof(addr2), token2,
+				    sizeof(token2));
+	zassert_ok(coap_oscore_context_remove(ctx), "Should remove context");
 }
 
 ZTEST(coap_oscore, test_oscore_exchange_expiry)
@@ -672,13 +693,18 @@ ZTEST(coap_oscore, test_oscore_exchange_expiry)
 	};
 	uint8_t token[] = {0x01, 0x02, 0x03, 0x04};
 	int ret;
+	struct coap_oscore_context *ctx;
+
+	zassert_ok(oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id),
+					  oscore_client_id, sizeof(oscore_client_id), &ctx),
+		   "Should create context");
 
 	/* Initialize cache */
 	memset(cache, 0, sizeof(cache));
 
 	/* Add non-Observe exchange */
 	ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr, sizeof(addr), token,
-				       sizeof(token));
+				       sizeof(token), ctx);
 	zassert_ok(ret, "Should add exchange");
 
 	/* Entry should be found initially */
@@ -695,6 +721,9 @@ ZTEST(coap_oscore, test_oscore_exchange_expiry)
 	entry = coap_oscore_exchange_find(cache, (struct net_sockaddr *)&addr, sizeof(addr), token,
 					  sizeof(token));
 	zassert_is_null(entry, "Expired entry should be cleared");
+
+	/* Expiry released the reference; the context returns to the pool. */
+	zassert_ok(coap_oscore_context_remove(ctx), "Should remove context");
 }
 
 ZTEST(coap_oscore, test_oscore_exchange_cache_eviction)
@@ -707,11 +736,16 @@ ZTEST(coap_oscore, test_oscore_exchange_cache_eviction)
 	};
 	uint8_t token[] = {0x01, 0x02, 0x03, 0x04};
 	int ret;
+	struct coap_oscore_context *ctx;
 
 	zassert(CONFIG_COAP_OSCORE_EXCHANGE_CACHE_SIZE >= 2,
 		"Cache size must be at least 2 for eviction test");
 	zassert(CONFIG_COAP_OSCORE_EXCHANGE_CACHE_SIZE < 0xFF,
 		"Cache size must be less than 0xFF for eviction test");
+
+	zassert_ok(oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id),
+					  oscore_client_id, sizeof(oscore_client_id), &ctx),
+		   "Should create context");
 
 	/* Initialize cache */
 	memset(cache, 0, sizeof(cache));
@@ -724,7 +758,7 @@ ZTEST(coap_oscore, test_oscore_exchange_cache_eviction)
 		token[0] = i + 1;
 
 		ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr, sizeof(addr),
-					       token, sizeof(token));
+					       token, sizeof(token), ctx);
 		zassert_ok(ret, "Should add entry %d", i);
 
 		/* Small delay to ensure different timestamps */
@@ -752,7 +786,7 @@ ZTEST(coap_oscore, test_oscore_exchange_cache_eviction)
 	token[0] = 0xFF;
 
 	ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&new_addr, sizeof(new_addr),
-				       token, sizeof(token));
+				       token, sizeof(token), ctx);
 	zassert_equal(ret, -ENOMEM, "Should prevent adding new entry when cache is full");
 
 	/* Verify new entry does not exist */
@@ -779,6 +813,18 @@ ZTEST(coap_oscore, test_oscore_exchange_cache_eviction)
 						  token, sizeof(token));
 		zassert_not_null(entry, "No entry should have been evicted");
 	}
+
+	/* Drain all references so the context returns to the pool. */
+	for (int i = 0; i < CONFIG_COAP_OSCORE_EXCHANGE_CACHE_SIZE; i++) {
+		struct net_sockaddr_in6 addr = addr_base;
+
+		addr.sin6_addr.s6_addr[15] = i + 1;
+		token[0] = i + 1;
+
+		coap_oscore_exchange_remove(cache, (struct net_sockaddr *)&addr, sizeof(addr),
+					    token, sizeof(token));
+	}
+	zassert_ok(coap_oscore_context_remove(ctx), "Should remove context");
 }
 
 /* A secure service returns an OSCORE protected response. */
@@ -789,7 +835,7 @@ ZTEST(coap_oscore, test_oscore_e2e_response_encrypted)
 	uint32_t inner_len = sizeof(innerbuf);
 	uint8_t token[] = {0x11, 0x22, 0x33, 0x44};
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_packet req;
 	struct coap_packet inner;
 	const uint8_t *payload;
@@ -797,11 +843,11 @@ ZTEST(coap_oscore, test_oscore_e2e_response_encrypted)
 	int sock;
 	int ret;
 
-	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-			      sizeof(oscore_server_id), &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_secure_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_secure_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_secure_service);
@@ -829,8 +875,8 @@ ZTEST(coap_oscore, test_oscore_e2e_response_encrypted)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_secure_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
 }
 
@@ -846,8 +892,8 @@ ZTEST(coap_oscore, test_oscore_required_rejects_plaintext)
 	int sock;
 	int ret;
 
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_secure_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_secure_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_secure_service);
@@ -874,7 +920,8 @@ ZTEST(coap_oscore, test_oscore_required_rejects_plaintext)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
-	coap_oscore_context_free(oscore_secure_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
 }
 
@@ -891,7 +938,7 @@ ZTEST(coap_oscore, test_oscore_mixed_sync_and_plaintext)
 	uint32_t inner_len = sizeof(innerbuf);
 	uint8_t token[] = {0xA1, 0xA2, 0xA3, 0xA4};
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_mixed_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_packet req;
 	struct coap_packet inner;
 	struct coap_packet rsp;
@@ -900,11 +947,11 @@ ZTEST(coap_oscore, test_oscore_mixed_sync_and_plaintext)
 	int sock;
 	int ret;
 
-	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-			      sizeof(oscore_server_id), &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_mixed_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_mixed_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_mixed_service);
@@ -951,8 +998,8 @@ ZTEST(coap_oscore, test_oscore_mixed_sync_and_plaintext)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_mixed_service), "Failed to stop mixed service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_mixed_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_mixed_service_ctx),
+		   "Should remove server context");
 	oscore_mixed_service_ctx = NULL;
 }
 
@@ -968,17 +1015,17 @@ ZTEST(coap_oscore, test_oscore_observe_notifications_encrypted)
 	uint32_t inner_len;
 	uint8_t token[] = {0xC1, 0xC2, 0xC3, 0xC4};
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_packet req;
 	struct coap_packet inner;
 	int sock;
 	int ret;
 
-	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-			      sizeof(oscore_server_id), &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_secure_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_secure_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_secure_service);
@@ -1030,14 +1077,14 @@ ZTEST(coap_oscore, test_oscore_observe_notifications_encrypted)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_secure_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
 }
 
 /*
  * A plaintext observer registered on a mixed service must get plaintext
- * notifications: observer->is_oscore gates the protection.
+ * notifications: observer->oscore_ctx gates the protection.
  */
 ZTEST(coap_oscore, test_oscore_observe_plaintext_not_encrypted)
 {
@@ -1050,8 +1097,8 @@ ZTEST(coap_oscore, test_oscore_observe_plaintext_not_encrypted)
 	int sock;
 	int ret;
 
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_mixed_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_mixed_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_mixed_service);
@@ -1099,7 +1146,8 @@ ZTEST(coap_oscore, test_oscore_observe_plaintext_not_encrypted)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_mixed_service), "Failed to stop mixed service");
-	coap_oscore_context_free(oscore_mixed_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_mixed_service_ctx),
+		   "Should remove server context");
 	oscore_mixed_service_ctx = NULL;
 }
 
@@ -1116,7 +1164,7 @@ ZTEST(coap_oscore, test_oscore_empty_ack_and_deferred)
 	uint32_t inner_len = sizeof(innerbuf);
 	uint8_t token[] = {0xE1, 0xE2, 0xE3, 0xE4};
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_oscore_exchange *entry;
 	struct coap_packet req;
 	struct coap_packet ack;
@@ -1128,11 +1176,11 @@ ZTEST(coap_oscore, test_oscore_empty_ack_and_deferred)
 
 	oscore_deferred.valid = false;
 
-	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-			      sizeof(oscore_server_id), &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_secure_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_secure_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_secure_service);
@@ -1185,8 +1233,8 @@ ZTEST(coap_oscore, test_oscore_empty_ack_and_deferred)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_secure_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
 }
 
@@ -1200,7 +1248,7 @@ ZTEST(coap_oscore, test_oscore_deferred_after_expiry_required_dropped)
 	uint8_t recvbuf[COAP_BUF_SIZE];
 	uint8_t token[] = {0xF1, 0xF2, 0xF3, 0xF4};
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_oscore_exchange *entry;
 	struct coap_packet req;
 	int sock;
@@ -1208,11 +1256,11 @@ ZTEST(coap_oscore, test_oscore_deferred_after_expiry_required_dropped)
 
 	oscore_deferred.valid = false;
 
-	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-			      sizeof(oscore_server_id), &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_secure_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_secure_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_secure_service);
@@ -1247,8 +1295,8 @@ ZTEST(coap_oscore, test_oscore_deferred_after_expiry_required_dropped)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_secure_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
 }
 
@@ -1263,7 +1311,7 @@ ZTEST(coap_oscore, test_oscore_deferred_after_expiry_mixed_plaintext)
 	uint8_t recvbuf[COAP_BUF_SIZE];
 	uint8_t token[] = {0x1A, 0x2B, 0x3C, 0x4D};
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_mixed_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_oscore_exchange *entry;
 	struct coap_packet req;
 	struct coap_packet rsp;
@@ -1272,11 +1320,11 @@ ZTEST(coap_oscore, test_oscore_deferred_after_expiry_mixed_plaintext)
 
 	oscore_deferred.valid = false;
 
-	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-			      sizeof(oscore_server_id), &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_mixed_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_mixed_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_mixed_service);
@@ -1314,8 +1362,8 @@ ZTEST(coap_oscore, test_oscore_deferred_after_expiry_mixed_plaintext)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_mixed_service), "Failed to stop mixed service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_mixed_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_mixed_service_ctx),
+		   "Should remove server context");
 	oscore_mixed_service_ctx = NULL;
 }
 
@@ -1334,11 +1382,16 @@ ZTEST(coap_oscore, test_oscore_empty_ack_does_not_clear_exchange)
 	uint8_t token[] = {0xAA, 0xBB, 0xCC, 0xDD};
 	struct coap_oscore_exchange *entry;
 	int ret;
+	struct coap_oscore_context *ctx;
+
+	zassert_ok(oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id),
+					  oscore_client_id, sizeof(oscore_client_id), &ctx),
+		   "Should create context");
 
 	memset(cache, 0, sizeof(cache));
 
 	ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr, sizeof(addr), token,
-				       sizeof(token));
+				       sizeof(token), ctx);
 	zassert_ok(ret, "Should add exchange entry");
 
 	/* Empty ACK removal uses a zero-length token; it must not match. */
@@ -1347,6 +1400,11 @@ ZTEST(coap_oscore, test_oscore_empty_ack_does_not_clear_exchange)
 	entry = coap_oscore_exchange_find(cache, (struct net_sockaddr *)&addr, sizeof(addr), token,
 					  sizeof(token));
 	zassert_not_null(entry, "tkl=0 removal must not clear the real (tkl>0) entry");
+
+	/* Release the surviving entry and return the context to the pool. */
+	coap_oscore_exchange_remove(cache, (struct net_sockaddr *)&addr, sizeof(addr), token,
+				    sizeof(token));
+	zassert_ok(coap_oscore_context_remove(ctx), "Should remove context");
 }
 
 /*
@@ -1359,7 +1417,7 @@ ZTEST(coap_oscore, test_oscore_ssn_persisted_to_nvm)
 	uint32_t inner_len;
 	uint8_t token[] = {0xC1, 0xC2, 0xC3, 0xC4};
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_packet req;
 	struct coap_packet inner;
 	int sock;
@@ -1377,11 +1435,11 @@ ZTEST(coap_oscore, test_oscore_ssn_persisted_to_nvm)
 	 */
 	zassert_equal(nvm_write_ssn(&nvm_key, 0), ok, "Failed to seed SSN in NVM");
 
-	ret = oscore_make_ctx_detailed(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-				       sizeof(oscore_server_id), false, &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), false, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-			      sizeof(oscore_client_id), &oscore_secure_service_ctx);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &oscore_secure_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_secure_service);
@@ -1433,8 +1491,8 @@ ZTEST(coap_oscore, test_oscore_ssn_persisted_to_nvm)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_secure_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
 
 	zassert_equal(nvm_read_ssn(&nvm_key, &stored_ssn), ok, "Failed to read SSN from NVM");
@@ -1456,7 +1514,7 @@ ZTEST(coap_oscore, test_oscore_replay_window_echo_resync)
 	uint8_t echo_val[16];
 	uint16_t echo_len;
 	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
-	struct coap_oscore_context *client_ctx;
+	struct context *client_ctx = &oscore_client_uctx;
 	struct coap_packet req;
 	struct coap_packet inner;
 	struct coap_option echo_opt;
@@ -1483,11 +1541,12 @@ ZTEST(coap_oscore, test_oscore_replay_window_echo_resync)
 	/* Fresh client, but a server whose reused context lost its replay window
 	 * (fresh_master_secret_salt = false => starts in the ECHO_REBOOT state).
 	 */
-	ret = oscore_make_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
-			      sizeof(oscore_server_id), &client_ctx);
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_ctx);
 	zassert_ok(ret, "Client context init failed (%d)", ret);
-	ret = oscore_make_ctx_detailed(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
-				       sizeof(oscore_client_id), false, &oscore_secure_service_ctx);
+	ret = oscore_make_server_ctx_detailed(oscore_server_id, sizeof(oscore_server_id),
+					      oscore_client_id, sizeof(oscore_client_id), false,
+					      &oscore_secure_service_ctx);
 	zassert_ok(ret, "Server context init failed (%d)", ret);
 
 	ret = coap_service_start(&oscore_secure_service);
@@ -1542,8 +1601,8 @@ ZTEST(coap_oscore, test_oscore_replay_window_echo_resync)
 
 	zassert_ok(zsock_close(sock), "Failed to close socket");
 	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
-	coap_oscore_context_free(client_ctx);
-	coap_oscore_context_free(oscore_secure_service_ctx);
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
 }
 

--- a/tests/net/lib/coap_oscore/src/main.c
+++ b/tests/net/lib/coap_oscore/src/main.c
@@ -53,11 +53,22 @@ static const uint8_t oscore_master_secret[] = {
 	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 	0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
 };
+static const uint8_t oscore_alt_master_secret[] = {
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x11,
+};
 static const uint8_t oscore_master_salt[] = {
 	0x9E, 0x7C, 0xA9, 0x22, 0x23, 0x78, 0x63, 0x40,
 };
 static const uint8_t oscore_client_id[] = {0x01};
 static const uint8_t oscore_server_id[] = {0x02};
+static const uint8_t oscore_shared_id_context[] = {0xA0, 0xA1, 0xA2};
+/* A second client/server identity pair for the multi-client tests. Distinct
+ * Sender/Recipient IDs derive independent keys, so each client's traffic is only
+ * decryptable with its own context (RFC 8613 Section 3.2).
+ */
+static const uint8_t oscore_client_b_id[] = {0x03};
+static const uint8_t oscore_server_b_id[] = {0x04};
 
 static const uint8_t oscore_notify_payload[] = "notify-payload";
 static const uint8_t oscore_deferred_payload[] = "deferred-response";
@@ -66,6 +77,8 @@ static const uint8_t oscore_secure_payload[] = "encrypted-response";
 
 /* Simulated client's uoscore context, reused across tests to avoid large stacks. */
 static struct context oscore_client_uctx;
+/* Second simulated client, used by the multi-client tests. */
+static struct context oscore_client_b_uctx;
 
 static int oscore_make_server_ctx_detailed(const uint8_t *sender_id, size_t sender_id_len,
 					   const uint8_t *recipient_id, size_t recipient_id_len,
@@ -98,8 +111,8 @@ static int oscore_make_server_ctx(const uint8_t *sender_id, size_t sender_id_len
 
 /* Initialize the simulated client directly through uoscore (external peer). */
 static int oscore_make_client_ctx(const uint8_t *sender_id, size_t sender_id_len,
-				  const uint8_t *recipient_id, size_t recipient_id_len,
-				  bool fresh, struct context *ctx)
+				  const uint8_t *recipient_id, size_t recipient_id_len, bool fresh,
+				  struct context *ctx)
 {
 	struct oscore_init_params params = {
 		.master_secret = {.len = sizeof(oscore_master_secret),
@@ -169,8 +182,8 @@ static int oscore_build_request(struct coap_packet *req, uint8_t *buf, size_t bu
 	return 0;
 }
 
-static int oscore_send_protected(int sock, struct context *ctx,
-				 const struct net_sockaddr_in6 *dst, const struct coap_packet *req)
+static int oscore_send_protected(int sock, struct context *ctx, const struct net_sockaddr_in6 *dst,
+				 const struct coap_packet *req)
 {
 	uint8_t protected[COAP_BUF_SIZE];
 	uint32_t protected_len = sizeof(protected);
@@ -209,8 +222,8 @@ static int oscore_recv(int sock, int timeout_ms, uint8_t *buf, size_t buf_len)
 }
 
 /* Receive, parse and OSCORE-verify a response, returning the decrypted inner packet. */
-static int oscore_recv_verify(int sock, int timeout_ms, struct context *ctx,
-			      uint8_t *inner_buf, uint32_t *inner_len, struct coap_packet *inner)
+static int oscore_recv_verify(int sock, int timeout_ms, struct context *ctx, uint8_t *inner_buf,
+			      uint32_t *inner_len, struct coap_packet *inner)
 {
 	uint8_t recv_buf[COAP_BUF_SIZE];
 	struct coap_packet outer;
@@ -223,6 +236,39 @@ static int oscore_recv_verify(int sock, int timeout_ms, struct context *ctx,
 	}
 
 	ret = coap_packet_parse(&outer, recv_buf, len, NULL, 0);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!coap_oscore_msg_has_oscore(&outer)) {
+		return -ENOMSG;
+	}
+
+	if (oscore2coap(recv_buf, outer.offset, inner_buf, inner_len, ctx) != ok) {
+		return -EBADMSG;
+	}
+
+	return coap_packet_parse(inner, inner_buf, *inner_len, NULL, 0);
+}
+
+/* Verify captured OSCORE bytes with a specific client context, without consuming
+ * the socket. Used to prove per-client isolation: a response protected for one
+ * client must not decrypt with another client's context.
+ */
+static int oscore_verify_raw(const uint8_t *raw, int raw_len, struct context *ctx,
+			     uint8_t *inner_buf, uint32_t *inner_len, struct coap_packet *inner)
+{
+	uint8_t recv_buf[COAP_BUF_SIZE];
+	struct coap_packet outer;
+	int ret;
+
+	if (raw_len <= 0 || raw_len > (int)sizeof(recv_buf)) {
+		return -EINVAL;
+	}
+
+	memcpy(recv_buf, raw, raw_len);
+
+	ret = coap_packet_parse(&outer, recv_buf, raw_len, NULL, 0);
 	if (ret < 0) {
 		return ret;
 	}
@@ -645,6 +691,10 @@ ZTEST(coap_oscore, test_oscore_exchange_cache)
 	zassert_equal(entry->tkl, sizeof(token1), "Token length should match");
 	zassert_mem_equal(entry->token, token1, sizeof(token1), "Token should match");
 
+	/* Active exchanges retain the context until their references are released. */
+	zassert_equal(coap_oscore_context_remove(ctx), -EAGAIN,
+		      "Context with active exchanges must not be removable");
+
 	/* Test: Add another entry with different address */
 	ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr2, sizeof(addr2), token2,
 				       sizeof(token2), ctx);
@@ -706,6 +756,10 @@ ZTEST(coap_oscore, test_oscore_exchange_expiry)
 	ret = coap_oscore_exchange_add(cache, (struct net_sockaddr *)&addr, sizeof(addr), token,
 				       sizeof(token), ctx);
 	zassert_ok(ret, "Should add exchange");
+
+	/* Active exchanges retain the context until expiry/removal drops references. */
+	zassert_equal(coap_oscore_context_remove(ctx), -EAGAIN,
+		      "Context with an active exchange must not be removable");
 
 	/* Entry should be found initially */
 	struct coap_oscore_exchange *entry;
@@ -858,6 +912,95 @@ ZTEST(coap_oscore, test_oscore_e2e_response_encrypted)
 
 	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
 				   token, sizeof(token), 0x2001, "e2e", -1);
+	zassert_ok(ret, "Failed to build request (%d)", ret);
+
+	ret = oscore_send_protected(sock, client_ctx, &dst, &req);
+	zassert_ok(ret, "Failed to send request (%d)", ret);
+
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client_ctx, innerbuf, &inner_len, &inner);
+	zassert_equal(ret, 0, "OSCORE response verify/parse failed (%d)", ret);
+	zassert_equal(coap_header_get_code(&inner), COAP_RESPONSE_CODE_CONTENT,
+		      "Unexpected inner response code");
+
+	payload = coap_packet_get_payload(&inner, &payload_len);
+	zassert_not_null(payload, "Missing decrypted payload");
+	zassert_equal(payload_len, sizeof(oscore_secure_payload) - 1, "Unexpected payload length");
+	zassert_mem_equal(payload, oscore_secure_payload, payload_len, "Unexpected payload");
+
+	zassert_ok(zsock_close(sock), "Failed to close socket");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
+		   "Should remove server context");
+	oscore_secure_service_ctx = NULL;
+}
+
+/* An end-to-end exchange using RFC 8613-legal key material outside the common
+ * 16-byte Master Secret / 8-byte Master Salt case: a 32-byte Master Secret and an
+ * absent (empty) Master Salt. Confirms the wrapper accepts variable/optional
+ * lengths and that uoscore derives matching keys on both sides.
+ */
+ZTEST(coap_oscore, test_oscore_e2e_variable_key_lengths)
+{
+	static const uint8_t secret32[] = {
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+		0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+		0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+	};
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len = sizeof(innerbuf);
+	uint8_t token[] = {0x55, 0x66, 0x77, 0x88};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct context *client_ctx = &oscore_client_uctx;
+	struct coap_packet req;
+	struct coap_packet inner;
+	const uint8_t *payload;
+	uint16_t payload_len;
+	int sock;
+	int ret;
+
+	/* Server context: 32-byte secret, no Master Salt. */
+	struct coap_oscore_init_params server_params = {
+		.master_secret = secret32,
+		.master_secret_len = sizeof(secret32),
+		.sender_id = oscore_server_id,
+		.sender_id_len = sizeof(oscore_server_id),
+		.recipient_id = oscore_client_id,
+		.recipient_id_len = sizeof(oscore_client_id),
+		.master_salt = NULL,
+		.master_salt_len = 0,
+		.aead_alg = COAP_OSCORE_AEAD_AES_CCM_16_64_128,
+		.hkdf = COAP_OSCORE_HKDF_SHA_256,
+		.fresh_master_secret_salt = true,
+	};
+
+	ret = coap_oscore_context_add(&server_params, &oscore_secure_service_ctx);
+	zassert_ok(ret, "Server context init failed (%d)", ret);
+
+	/* Simulated client context derived from the same material. */
+	struct oscore_init_params client_params = {
+		.master_secret = {.len = sizeof(secret32), .ptr = (uint8_t *)secret32},
+		.sender_id = {.len = sizeof(oscore_client_id), .ptr = (uint8_t *)oscore_client_id},
+		.recipient_id = {.len = sizeof(oscore_server_id),
+				 .ptr = (uint8_t *)oscore_server_id},
+		.id_context = {.len = 0, .ptr = NULL},
+		.master_salt = {.len = 0, .ptr = NULL},
+		.aead_alg = OSCORE_AES_CCM_16_64_128,
+		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
+	};
+
+	zassert_equal(oscore_context_init(&client_params, client_ctx), ok,
+		      "Client context init failed");
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock = oscore_client_socket();
+	zassert_true(sock >= 0, "Failed to create socket (%d)", -errno);
+
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token, sizeof(token), 0x2002, "e2e", -1);
 	zassert_ok(ret, "Failed to build request (%d)", ret);
 
 	ret = oscore_send_protected(sock, client_ctx, &dst, &req);
@@ -1604,6 +1747,576 @@ ZTEST(coap_oscore, test_oscore_replay_window_echo_resync)
 	zassert_ok(coap_oscore_context_remove(oscore_secure_service_ctx),
 		   "Should remove server context");
 	oscore_secure_service_ctx = NULL;
+}
+
+/*
+ * Two clients with distinct Recipient IDs are served concurrently from the
+ * context pool. The server selects the context by the request KID (RFC 8613
+ * Section 8.2), so each client's response only decrypts with its own context.
+ */
+ZTEST(coap_oscore, test_oscore_multi_client_dispatch)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t rawbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len;
+	uint8_t token_a[] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t token_b[] = {0x55, 0x66, 0x77, 0x88};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct context *client_a = &oscore_client_uctx;
+	struct context *client_b = &oscore_client_b_uctx;
+	struct coap_oscore_context *ctx_a = NULL;
+	struct coap_oscore_context *ctx_b = NULL;
+	struct coap_packet req;
+	struct coap_packet inner;
+	const uint8_t *payload;
+	uint16_t payload_len;
+	int sock_a;
+	int sock_b;
+	int len;
+	int ret;
+
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_a);
+	zassert_ok(ret, "Client A context init failed (%d)", ret);
+	ret = oscore_make_client_ctx(oscore_client_b_id, sizeof(oscore_client_b_id),
+				     oscore_server_b_id, sizeof(oscore_server_b_id), true,
+				     client_b);
+	zassert_ok(ret, "Client B context init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &ctx_a);
+	zassert_ok(ret, "Server context A init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_b_id, sizeof(oscore_server_b_id),
+				     oscore_client_b_id, sizeof(oscore_client_b_id), &ctx_b);
+	zassert_ok(ret, "Server context B init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock_a = oscore_client_socket();
+	zassert_true(sock_a >= 0, "Failed to create socket A (%d)", -errno);
+	sock_b = oscore_client_socket();
+	zassert_true(sock_b >= 0, "Failed to create socket B (%d)", -errno);
+
+	/* Client A: the server must answer using context A. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_a, sizeof(token_a), 0x9001, "e2e", -1);
+	zassert_ok(ret, "Failed to build request A (%d)", ret);
+	ret = oscore_send_protected(sock_a, client_a, &dst, &req);
+	zassert_ok(ret, "Failed to send request A (%d)", ret);
+
+	len = oscore_recv(sock_a, LONG_TIMEOUT, rawbuf, sizeof(rawbuf));
+	zassert_true(len > 0, "Timed out waiting for response A (%d)", len);
+
+	/* Isolation: client B's context must not decrypt client A's response. */
+	inner_len = sizeof(innerbuf);
+	ret = oscore_verify_raw(rawbuf, len, client_b, innerbuf, &inner_len, &inner);
+	zassert_not_equal(ret, 0, "Client B must not decrypt client A's response");
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_verify_raw(rawbuf, len, client_a, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client A response verify/parse failed (%d)", ret);
+	payload = coap_packet_get_payload(&inner, &payload_len);
+	zassert_not_null(payload, "Missing decrypted payload A");
+	zassert_mem_equal(payload, oscore_secure_payload, sizeof(oscore_secure_payload) - 1,
+			  "Unexpected payload A");
+
+	/* Client B: the server must answer using context B. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_b, sizeof(token_b), 0x9002, "e2e", -1);
+	zassert_ok(ret, "Failed to build request B (%d)", ret);
+	ret = oscore_send_protected(sock_b, client_b, &dst, &req);
+	zassert_ok(ret, "Failed to send request B (%d)", ret);
+
+	len = oscore_recv(sock_b, LONG_TIMEOUT, rawbuf, sizeof(rawbuf));
+	zassert_true(len > 0, "Timed out waiting for response B (%d)", len);
+
+	/* Isolation: client A's context must not decrypt client B's response. */
+	inner_len = sizeof(innerbuf);
+	ret = oscore_verify_raw(rawbuf, len, client_a, innerbuf, &inner_len, &inner);
+	zassert_not_equal(ret, 0, "Client A must not decrypt client B's response");
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_verify_raw(rawbuf, len, client_b, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client B response verify/parse failed (%d)", ret);
+	payload = coap_packet_get_payload(&inner, &payload_len);
+	zassert_not_null(payload, "Missing decrypted payload B");
+	zassert_mem_equal(payload, oscore_secure_payload, sizeof(oscore_secure_payload) - 1,
+			  "Unexpected payload B");
+
+	zassert_ok(zsock_close(sock_a), "Failed to close socket A");
+	zassert_ok(zsock_close(sock_b), "Failed to close socket B");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	zassert_ok(coap_oscore_context_remove(ctx_a), "Should remove server context A");
+	zassert_ok(coap_oscore_context_remove(ctx_b), "Should remove server context B");
+}
+
+/*
+ * Two contexts share Recipient ID and ID Context, forcing trial decryption.
+ * The first candidate has different key material and must fail; the later
+ * candidate must still decrypt the same wire request successfully.
+ */
+ZTEST(coap_oscore, test_oscore_multi_client_trial_decrypt_same_identity)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len = sizeof(innerbuf);
+	uint8_t token[] = {0x31, 0x32, 0x33, 0x34};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct context *client = &oscore_client_uctx;
+	struct coap_oscore_context *ctx_bad = NULL;
+	struct coap_oscore_context *ctx_good = NULL;
+	struct coap_packet req;
+	struct coap_packet inner;
+	const uint8_t *payload;
+	uint16_t payload_len;
+	struct oscore_init_params client_params = {
+		.master_secret = {.len = sizeof(oscore_master_secret),
+				  .ptr = (uint8_t *)oscore_master_secret},
+		.sender_id = {.len = sizeof(oscore_client_id), .ptr = (uint8_t *)oscore_client_id},
+		.recipient_id = {.len = sizeof(oscore_server_id),
+				 .ptr = (uint8_t *)oscore_server_id},
+		.id_context = {.len = sizeof(oscore_shared_id_context),
+			       .ptr = (uint8_t *)oscore_shared_id_context},
+		.master_salt = {.len = sizeof(oscore_master_salt),
+				.ptr = (uint8_t *)oscore_master_salt},
+		.aead_alg = OSCORE_AES_CCM_16_64_128,
+		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
+	};
+	struct coap_oscore_init_params bad_params = {
+		.master_secret = oscore_alt_master_secret,
+		.master_secret_len = sizeof(oscore_alt_master_secret),
+		.sender_id = oscore_server_id,
+		.sender_id_len = sizeof(oscore_server_id),
+		.recipient_id = oscore_client_id,
+		.recipient_id_len = sizeof(oscore_client_id),
+		.master_salt = oscore_master_salt,
+		.master_salt_len = sizeof(oscore_master_salt),
+		.id_context = oscore_shared_id_context,
+		.id_context_len = sizeof(oscore_shared_id_context),
+		.aead_alg = COAP_OSCORE_AEAD_AES_CCM_16_64_128,
+		.hkdf = COAP_OSCORE_HKDF_SHA_256,
+		.fresh_master_secret_salt = true,
+	};
+	struct coap_oscore_init_params good_params = {
+		.master_secret = oscore_master_secret,
+		.master_secret_len = sizeof(oscore_master_secret),
+		.sender_id = oscore_server_id,
+		.sender_id_len = sizeof(oscore_server_id),
+		.recipient_id = oscore_client_id,
+		.recipient_id_len = sizeof(oscore_client_id),
+		.master_salt = oscore_master_salt,
+		.master_salt_len = sizeof(oscore_master_salt),
+		.id_context = oscore_shared_id_context,
+		.id_context_len = sizeof(oscore_shared_id_context),
+		.aead_alg = COAP_OSCORE_AEAD_AES_CCM_16_64_128,
+		.hkdf = COAP_OSCORE_HKDF_SHA_256,
+		.fresh_master_secret_salt = true,
+	};
+	int sock;
+	int ret;
+
+	zassert_equal(oscore_context_init(&client_params, client), ok,
+		      "Client context init failed");
+
+	/* Insert failing candidate first so successful context is later in the pool. */
+	ret = coap_oscore_context_add(&bad_params, &ctx_bad);
+	zassert_ok(ret, "Bad server context init failed (%d)", ret);
+	ret = coap_oscore_context_add(&good_params, &ctx_good);
+	zassert_ok(ret, "Good server context init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock = oscore_client_socket();
+	zassert_true(sock >= 0, "Failed to create socket (%d)", -errno);
+
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token, sizeof(token), 0xA101, "e2e", -1);
+	zassert_ok(ret, "Failed to build request (%d)", ret);
+	ret = oscore_send_protected(sock, client, &dst, &req);
+	zassert_ok(ret, "Failed to send request (%d)", ret);
+
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Response verify/parse failed (%d)", ret);
+	zassert_equal(coap_header_get_code(&inner), COAP_RESPONSE_CODE_CONTENT,
+		      "Expected 2.05 Content, got %u", coap_header_get_code(&inner));
+
+	payload = coap_packet_get_payload(&inner, &payload_len);
+	zassert_not_null(payload, "Missing decrypted payload");
+	zassert_equal(payload_len, sizeof(oscore_secure_payload) - 1, "Unexpected payload length");
+	zassert_mem_equal(payload, oscore_secure_payload, payload_len, "Unexpected payload");
+
+	zassert_ok(zsock_close(sock), "Failed to close socket");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	zassert_ok(coap_oscore_context_remove(ctx_bad), "Should remove server context bad");
+	zassert_ok(coap_oscore_context_remove(ctx_good), "Should remove server context good");
+}
+
+/*
+ * A protected request whose KID matches no context in the pool is rejected with
+ * a plaintext 4.01 Unauthorized (RFC 8613 Section 8.2), never silently accepted.
+ */
+ZTEST(coap_oscore, test_oscore_multi_client_unknown_kid_rejected)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t recvbuf[COAP_BUF_SIZE];
+	uint8_t token[] = {0x21, 0x22, 0x23, 0x24};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct context *unknown = &oscore_client_b_uctx;
+	struct coap_oscore_context *ctx_a = NULL;
+	struct coap_packet req;
+	struct coap_packet rsp;
+	int sock;
+	int ret;
+
+	/* The server only knows client A; the wire request carries an unknown KID. */
+	ret = oscore_make_client_ctx(oscore_client_b_id, sizeof(oscore_client_b_id),
+				     oscore_server_b_id, sizeof(oscore_server_b_id), true, unknown);
+	zassert_ok(ret, "Unknown client context init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &ctx_a);
+	zassert_ok(ret, "Server context init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock = oscore_client_socket();
+	zassert_true(sock >= 0, "Failed to create socket (%d)", -errno);
+
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token, sizeof(token), 0xA001, "e2e", -1);
+	zassert_ok(ret, "Failed to build request (%d)", ret);
+	ret = oscore_send_protected(sock, unknown, &dst, &req);
+	zassert_ok(ret, "Failed to send request (%d)", ret);
+
+	ret = oscore_recv(sock, LONG_TIMEOUT, recvbuf, sizeof(recvbuf));
+	zassert_true(ret > 0, "Timed out waiting for response (%d)", ret);
+	ret = coap_packet_parse(&rsp, recvbuf, ret, NULL, 0);
+	zassert_ok(ret, "Failed to parse response (%d)", ret);
+	zassert_false(coap_oscore_msg_has_oscore(&rsp), "Error response must be plaintext");
+	zassert_equal(coap_header_get_code(&rsp), COAP_RESPONSE_CODE_UNAUTHORIZED,
+		      "Expected 4.01 Unauthorized, got %u", coap_header_get_code(&rsp));
+
+	zassert_ok(zsock_close(sock), "Failed to close socket");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	zassert_ok(coap_oscore_context_remove(ctx_a), "Should remove server context");
+}
+
+/*
+ * Two clients observe the same resource concurrently. A single
+ * coap_resource_notify() fans out one notification per observer, each protected
+ * with that observer's own context (observer->oscore_ctx).
+ */
+ZTEST(coap_oscore, test_oscore_multi_client_observe_notifications)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len;
+	uint8_t token_a[] = {0xC1, 0xC2, 0xC3, 0xC4};
+	uint8_t token_b[] = {0xB1, 0xB2, 0xB3, 0xB4};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct context *client_a = &oscore_client_uctx;
+	struct context *client_b = &oscore_client_b_uctx;
+	struct coap_oscore_context *ctx_a = NULL;
+	struct coap_oscore_context *ctx_b = NULL;
+	struct coap_packet req;
+	struct coap_packet inner;
+	int sock_a;
+	int sock_b;
+	int ret;
+
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_a);
+	zassert_ok(ret, "Client A context init failed (%d)", ret);
+	ret = oscore_make_client_ctx(oscore_client_b_id, sizeof(oscore_client_b_id),
+				     oscore_server_b_id, sizeof(oscore_server_b_id), true,
+				     client_b);
+	zassert_ok(ret, "Client B context init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &ctx_a);
+	zassert_ok(ret, "Server context A init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_b_id, sizeof(oscore_server_b_id),
+				     oscore_client_b_id, sizeof(oscore_client_b_id), &ctx_b);
+	zassert_ok(ret, "Server context B init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock_a = oscore_client_socket();
+	zassert_true(sock_a >= 0, "Failed to create socket A (%d)", -errno);
+	sock_b = oscore_client_socket();
+	zassert_true(sock_b >= 0, "Failed to create socket B (%d)", -errno);
+
+	/* Both clients register an observation. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_a, sizeof(token_a), 0xB001, "observe", 0);
+	zassert_ok(ret, "Failed to build observe request A (%d)", ret);
+	ret = oscore_send_protected(sock_a, client_a, &dst, &req);
+	zassert_ok(ret, "Failed to send observe request A (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_a, LONG_TIMEOUT, client_a, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client A initial notification failed (%d)", ret);
+	zassert_true(coap_get_option_int(&inner, COAP_OPTION_OBSERVE) >= 0,
+		     "Client A initial notification must carry the Observe option");
+
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_b, sizeof(token_b), 0xB002, "observe", 0);
+	zassert_ok(ret, "Failed to build observe request B (%d)", ret);
+	ret = oscore_send_protected(sock_b, client_b, &dst, &req);
+	zassert_ok(ret, "Failed to send observe request B (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_b, LONG_TIMEOUT, client_b, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client B initial notification failed (%d)", ret);
+	zassert_true(coap_get_option_int(&inner, COAP_OPTION_OBSERVE) >= 0,
+		     "Client B initial notification must carry the Observe option");
+
+	/* One notify fans out one protected notification per observer. */
+	ret = coap_resource_notify(&oscore_observe_resource);
+	zassert_ok(ret, "coap_resource_notify failed (%d)", ret);
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_a, LONG_TIMEOUT, client_a, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client A notification verify/parse failed (%d)", ret);
+	zassert_true(coap_get_option_int(&inner, COAP_OPTION_OBSERVE) >= 0,
+		     "Client A notification must carry the Observe option");
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_b, LONG_TIMEOUT, client_b, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client B notification verify/parse failed (%d)", ret);
+	zassert_true(coap_get_option_int(&inner, COAP_OPTION_OBSERVE) >= 0,
+		     "Client B notification must carry the Observe option");
+
+	/* Deregister both and drain the final responses. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_a, sizeof(token_a), 0xB003, "observe", 1);
+	zassert_ok(ret, "Failed to build deregister request A (%d)", ret);
+	ret = oscore_send_protected(sock_a, client_a, &dst, &req);
+	zassert_ok(ret, "Failed to send deregister request A (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_a, LONG_TIMEOUT, client_a, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client A deregister response failed (%d)", ret);
+
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_b, sizeof(token_b), 0xB004, "observe", 1);
+	zassert_ok(ret, "Failed to build deregister request B (%d)", ret);
+	ret = oscore_send_protected(sock_b, client_b, &dst, &req);
+	zassert_ok(ret, "Failed to send deregister request B (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_b, LONG_TIMEOUT, client_b, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client B deregister response failed (%d)", ret);
+
+	zassert_ok(zsock_close(sock_a), "Failed to close socket A");
+	zassert_ok(zsock_close(sock_b), "Failed to close socket B");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	zassert_ok(coap_oscore_context_remove(ctx_a), "Should remove server context A");
+	zassert_ok(coap_oscore_context_remove(ctx_b), "Should remove server context B");
+}
+
+/*
+ * Deregistering one client's observation must not disturb the other's: after
+ * client A cancels, a notify reaches only client B.
+ */
+ZTEST(coap_oscore, test_oscore_multi_client_observe_independent_deregister)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len;
+	uint8_t token_a[] = {0xC1, 0xC2, 0xC3, 0xC4};
+	uint8_t token_b[] = {0xB1, 0xB2, 0xB3, 0xB4};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct context *client_a = &oscore_client_uctx;
+	struct context *client_b = &oscore_client_b_uctx;
+	struct coap_oscore_context *ctx_a = NULL;
+	struct coap_oscore_context *ctx_b = NULL;
+	struct coap_packet req;
+	struct coap_packet inner;
+	int sock_a;
+	int sock_b;
+	int ret;
+
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client_a);
+	zassert_ok(ret, "Client A context init failed (%d)", ret);
+	ret = oscore_make_client_ctx(oscore_client_b_id, sizeof(oscore_client_b_id),
+				     oscore_server_b_id, sizeof(oscore_server_b_id), true,
+				     client_b);
+	zassert_ok(ret, "Client B context init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &ctx_a);
+	zassert_ok(ret, "Server context A init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_b_id, sizeof(oscore_server_b_id),
+				     oscore_client_b_id, sizeof(oscore_client_b_id), &ctx_b);
+	zassert_ok(ret, "Server context B init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock_a = oscore_client_socket();
+	zassert_true(sock_a >= 0, "Failed to create socket A (%d)", -errno);
+	sock_b = oscore_client_socket();
+	zassert_true(sock_b >= 0, "Failed to create socket B (%d)", -errno);
+
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_a, sizeof(token_a), 0xB101, "observe", 0);
+	zassert_ok(ret, "Failed to build observe request A (%d)", ret);
+	ret = oscore_send_protected(sock_a, client_a, &dst, &req);
+	zassert_ok(ret, "Failed to send observe request A (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_a, LONG_TIMEOUT, client_a, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client A initial notification failed (%d)", ret);
+
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_b, sizeof(token_b), 0xB102, "observe", 0);
+	zassert_ok(ret, "Failed to build observe request B (%d)", ret);
+	ret = oscore_send_protected(sock_b, client_b, &dst, &req);
+	zassert_ok(ret, "Failed to send observe request B (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_b, LONG_TIMEOUT, client_b, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client B initial notification failed (%d)", ret);
+
+	/* Client A cancels its observation. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_a, sizeof(token_a), 0xB103, "observe", 1);
+	zassert_ok(ret, "Failed to build deregister request A (%d)", ret);
+	ret = oscore_send_protected(sock_a, client_a, &dst, &req);
+	zassert_ok(ret, "Failed to send deregister request A (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_a, LONG_TIMEOUT, client_a, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client A deregister response failed (%d)", ret);
+
+	/* Only client B still observes. */
+	ret = coap_resource_notify(&oscore_observe_resource);
+	zassert_ok(ret, "coap_resource_notify failed (%d)", ret);
+
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_b, LONG_TIMEOUT, client_b, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client B must still receive notifications (%d)", ret);
+	zassert_true(coap_get_option_int(&inner, COAP_OPTION_OBSERVE) >= 0,
+		     "Client B notification must carry the Observe option");
+
+	ret = oscore_recv(sock_a, SHORT_TIMEOUT, innerbuf, sizeof(innerbuf));
+	zassert_equal(ret, -ETIMEDOUT, "Deregistered client A must not receive notifications (%d)",
+		      ret);
+
+	/* Client B cancels; drain the final response. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token_b, sizeof(token_b), 0xB104, "observe", 1);
+	zassert_ok(ret, "Failed to build deregister request B (%d)", ret);
+	ret = oscore_send_protected(sock_b, client_b, &dst, &req);
+	zassert_ok(ret, "Failed to send deregister request B (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock_b, LONG_TIMEOUT, client_b, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Client B deregister response failed (%d)", ret);
+
+	zassert_ok(zsock_close(sock_a), "Failed to close socket A");
+	zassert_ok(zsock_close(sock_b), "Failed to close socket B");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+	zassert_ok(coap_oscore_context_remove(ctx_a), "Should remove server context A");
+	zassert_ok(coap_oscore_context_remove(ctx_b), "Should remove server context B");
+}
+
+/*
+ * A context referenced by an active observer is retained: coap_oscore_context_remove()
+ * returns -EAGAIN until the observer is deregistered and its reference released.
+ */
+ZTEST(coap_oscore, test_oscore_context_refcount_blocks_removal_with_observer)
+{
+	uint8_t reqbuf[COAP_BUF_SIZE];
+	uint8_t innerbuf[COAP_BUF_SIZE];
+	uint32_t inner_len;
+	uint8_t token[] = {0xC1, 0xC2, 0xC3, 0xC4};
+	struct net_sockaddr_in6 dst = oscore_loopback_dst(oscore_secure_service_port);
+	struct context *client = &oscore_client_uctx;
+	struct coap_oscore_context *ctx = NULL;
+	struct coap_packet req;
+	struct coap_packet inner;
+	int sock;
+	int ret;
+
+	ret = oscore_make_client_ctx(oscore_client_id, sizeof(oscore_client_id), oscore_server_id,
+				     sizeof(oscore_server_id), true, client);
+	zassert_ok(ret, "Client context init failed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &ctx);
+	zassert_ok(ret, "Server context init failed (%d)", ret);
+
+	ret = coap_service_start(&oscore_secure_service);
+	zassert_ok(ret, "Failed to start service (%d)", ret);
+
+	sock = oscore_client_socket();
+	zassert_true(sock >= 0, "Failed to create socket (%d)", -errno);
+
+	/* Register a protected observation: the observer takes a reference. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token, sizeof(token), 0xB201, "observe", 0);
+	zassert_ok(ret, "Failed to build observe request (%d)", ret);
+	ret = oscore_send_protected(sock, client, &dst, &req);
+	zassert_ok(ret, "Failed to send observe request (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Initial notification failed (%d)", ret);
+
+	/* The referenced context cannot be removed yet. */
+	zassert_equal(coap_oscore_context_remove(ctx), -EAGAIN,
+		      "Context with an active observer must not be removable");
+
+	/* Deregister: the observer releases its reference. */
+	ret = oscore_build_request(&req, reqbuf, sizeof(reqbuf), COAP_TYPE_CON, COAP_METHOD_GET,
+				   token, sizeof(token), 0xB202, "observe", 1);
+	zassert_ok(ret, "Failed to build deregister request (%d)", ret);
+	ret = oscore_send_protected(sock, client, &dst, &req);
+	zassert_ok(ret, "Failed to send deregister request (%d)", ret);
+	inner_len = sizeof(innerbuf);
+	ret = oscore_recv_verify(sock, LONG_TIMEOUT, client, innerbuf, &inner_len, &inner);
+	zassert_ok(ret, "Deregister response failed (%d)", ret);
+
+	/* Now the context is free to be removed. */
+	zassert_ok(coap_oscore_context_remove(ctx), "Context should be removable after deregister");
+
+	zassert_ok(zsock_close(sock), "Failed to close socket");
+	zassert_ok(coap_service_stop(&oscore_secure_service), "Failed to stop service");
+}
+
+/*
+ * The context pool is bounded by CONFIG_COAP_OSCORE_MAX_CONTEXTS: once full,
+ * adding another client's context fails with -ENOMEM, and freeing a slot lets
+ * the next client in.
+ */
+ZTEST(coap_oscore, test_oscore_context_pool_exhaustion)
+{
+	static const uint8_t client_c_id[] = {0x05};
+	static const uint8_t server_c_id[] = {0x06};
+	struct coap_oscore_context *ctx_a = NULL;
+	struct coap_oscore_context *ctx_b = NULL;
+	struct coap_oscore_context *ctx_c = NULL;
+	int ret;
+
+	zassert_equal(CONFIG_COAP_OSCORE_MAX_CONTEXTS, 2,
+		      "This test assumes a pool of exactly two contexts");
+
+	ret = oscore_make_server_ctx(oscore_server_id, sizeof(oscore_server_id), oscore_client_id,
+				     sizeof(oscore_client_id), &ctx_a);
+	zassert_ok(ret, "First context add should succeed (%d)", ret);
+	ret = oscore_make_server_ctx(oscore_server_b_id, sizeof(oscore_server_b_id),
+				     oscore_client_b_id, sizeof(oscore_client_b_id), &ctx_b);
+	zassert_ok(ret, "Second context add should succeed (%d)", ret);
+
+	/* Pool full: a third distinct client cannot be served. */
+	ret = oscore_make_server_ctx(server_c_id, sizeof(server_c_id), client_c_id,
+				     sizeof(client_c_id), &ctx_c);
+	zassert_equal(ret, -ENOMEM, "Third context add must fail when the pool is full (%d)", ret);
+	zassert_is_null(ctx_c, "Failed add must not return a context");
+
+	/* Freeing a slot lets the next client in. */
+	zassert_ok(coap_oscore_context_remove(ctx_a), "Should remove first context");
+	ret = oscore_make_server_ctx(server_c_id, sizeof(server_c_id), client_c_id,
+				     sizeof(client_c_id), &ctx_c);
+	zassert_ok(ret, "Context add should succeed after freeing a slot (%d)", ret);
+
+	zassert_ok(coap_oscore_context_remove(ctx_b), "Should remove second context");
+	zassert_ok(coap_oscore_context_remove(ctx_c), "Should remove third context");
 }
 
 #else

--- a/tests/net/lib/coap_oscore/src/salt.c
+++ b/tests/net/lib/coap_oscore/src/salt.c
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/net/coap.h>
+
+#include "coap_oscore_internal.h"
+
+#define COAP_BUF_SIZE 128
+
+static const uint8_t test_master_secret[] = {
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+};
+static const uint8_t test_client_id[] = {0x01};
+static const uint8_t test_server_id[] = {0x02};
+
+ZTEST(coap_oscore_salt, test_oscore_master_salt_zero_encrypt_decrypt)
+{
+	uint8_t plain[COAP_BUF_SIZE];
+	uint8_t protected[COAP_BUF_SIZE];
+	uint8_t decrypted[COAP_BUF_SIZE];
+	uint8_t token[] = {0xaa, 0xbb};
+	const uint8_t payload[] = "salt-ok";
+	struct coap_packet req;
+	struct coap_packet outer;
+	struct coap_packet dec;
+	struct coap_oscore_context *ctx_client;
+	struct coap_oscore_context *ctx_server;
+	struct coap_oscore_context *ctx_verified = NULL;
+	struct coap_oscore_init_params params_client = {
+		.master_secret = test_master_secret,
+		.master_secret_len = sizeof(test_master_secret),
+		.sender_id = test_client_id,
+		.sender_id_len = sizeof(test_client_id),
+		.recipient_id = test_server_id,
+		.recipient_id_len = sizeof(test_server_id),
+		.master_salt = NULL,
+		.master_salt_len = 0,
+		.aead_alg = COAP_OSCORE_AEAD_AES_CCM_16_64_128,
+		.hkdf = COAP_OSCORE_HKDF_SHA_256,
+		.fresh_master_secret_salt = true,
+	};
+	struct coap_oscore_init_params params_server = {
+		.master_secret = test_master_secret,
+		.master_secret_len = sizeof(test_master_secret),
+		.sender_id = test_server_id,
+		.sender_id_len = sizeof(test_server_id),
+		.recipient_id = test_client_id,
+		.recipient_id_len = sizeof(test_client_id),
+		.master_salt = NULL,
+		.master_salt_len = 0,
+		.aead_alg = COAP_OSCORE_AEAD_AES_CCM_16_64_128,
+		.hkdf = COAP_OSCORE_HKDF_SHA_256,
+		.fresh_master_secret_salt = true,
+	};
+	uint32_t protected_len = sizeof(protected);
+	uint32_t decrypted_len = sizeof(decrypted);
+	const uint8_t *dec_payload;
+	uint16_t dec_payload_len;
+	uint8_t error_code = 0;
+	int ret;
+	bool needs_echo_challenge = false;
+
+	ret = coap_oscore_context_add(&params_client, &ctx_client);
+	zassert_ok(ret, "Client context add failed (%d)", ret);
+
+	ret = coap_oscore_context_add(&params_server, &ctx_server);
+	zassert_ok(ret, "Server context add failed (%d)", ret);
+
+	ret = coap_packet_init(&req, plain, sizeof(plain), COAP_VERSION_1, COAP_TYPE_CON,
+			       sizeof(token), token, COAP_METHOD_POST, 0x1234);
+	zassert_ok(ret, "CoAP request init failed (%d)", ret);
+
+	ret = coap_packet_append_option(&req, COAP_OPTION_URI_PATH, (const uint8_t *)"salt", 4);
+	zassert_ok(ret, "URI path append failed (%d)", ret);
+
+	ret = coap_packet_append_payload_marker(&req);
+	zassert_ok(ret, "Payload marker append failed (%d)", ret);
+
+	ret = coap_packet_append_payload(&req, payload, sizeof(payload) - 1);
+	zassert_ok(ret, "Payload append failed (%d)", ret);
+
+	ret = coap_oscore_protect(req.data, req.offset, protected, &protected_len, ctx_client);
+	zassert_ok(ret, "coap_oscore_protect failed (%d)", ret);
+
+	ret = coap_packet_parse(&outer, protected, protected_len, NULL, 0);
+	zassert_ok(ret, "Outer packet parse failed (%d)", ret);
+	zassert_true(coap_oscore_msg_has_oscore(&outer), "Expected OSCORE option");
+
+	ret = coap_oscore_verify(&outer, protected, protected_len, decrypted, &decrypted_len,
+				 &ctx_verified, &error_code, &needs_echo_challenge);
+	zassert_ok(ret, "coap_oscore_verify failed (%d, code=%u)", ret, error_code);
+	zassert_true(ctx_verified == ctx_server, "Verify chose unexpected context");
+	zassert_false(needs_echo_challenge, "Did not expect Echo challenge");
+
+	ret = coap_oscore_context_dec_refcount(ctx_verified);
+	zassert_ok(ret, "Context dec refcount failed (%d)", ret);
+
+	ret = coap_packet_parse(&dec, decrypted, decrypted_len, NULL, 0);
+	zassert_ok(ret, "Decrypted packet parse failed (%d)", ret);
+
+	dec_payload = coap_packet_get_payload(&dec, &dec_payload_len);
+	zassert_not_null(dec_payload, "Missing decrypted payload");
+	zassert_equal(dec_payload_len, sizeof(payload) - 1, "Unexpected decrypted payload length");
+	zassert_mem_equal(dec_payload, payload, dec_payload_len, "Decrypted payload mismatch");
+
+	ret = coap_oscore_context_remove(ctx_server);
+	zassert_ok(ret, "Server context remove failed (%d)", ret);
+
+	ret = coap_oscore_context_remove(ctx_client);
+	zassert_ok(ret, "Client context remove failed (%d)", ret);
+}
+
+ZTEST_SUITE(coap_oscore_salt, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/lib/coap_oscore/tests.yaml
+++ b/tests/net/lib/coap_oscore/tests.yaml
@@ -10,12 +10,24 @@ tests:
       - CONFIG_COAP_OSCORE_MAX_CONTEXTS=2
       - CONFIG_COAP_OSCORE_EXCHANGE_CACHE_SIZE=4
       - CONFIG_COAP_OSCORE_EXCHANGE_LIFETIME_MS=60000
+      - CONFIG_COAP_OSCORE_MASTER_SECRET_MAX_LEN=32
       - CONFIG_COAP_OSCORE_CONTEXT_REUSE=y
       - CONFIG_FLASH=y
       - CONFIG_FLASH_MAP=y
       - CONFIG_NVS=y
       - CONFIG_SETTINGS=y
       - CONFIG_SETTINGS_NVS=y
+
+  net.coap.oscore_master_salt_zero_storage:
+    min_ram: 64
+    min_flash: 192
+    tags: net
+    depends_on: netif
+    extra_args:
+      - COAP_OSCORE_SALT_ONLY=ON
+    extra_configs:
+      - CONFIG_COAP_OSCORE_MASTER_SALT_MAX_LEN=0
+      - CONFIG_COAP_OSCORE_MAX_CONTEXTS=2
 
   net.coap.oscore_no_oscore:
     min_ram: 48


### PR DESCRIPTION
Replace the per-service OSCORE context provider callback with a shared, reference-counted context pool that the server searches by Recipient ID. This lets a single service protect exchanges for multiple clients concurrently, each identified by its own OSCORE context, instead of being limited to one lazily-provided context per service.

Rework the public API accordingly:

  - `coap_oscore_context_init()` becomes `coap_oscore_context_add()`, which takes const params and inserts the derived context into the pool.
  - `coap_oscore_context_free()` becomes `coap_oscore_context_remove()`, which is reference-counted and returns `-EAGAIN` while an in-flight request, active exchange, or observer still references the context.
  - Drop the `_oscore_ctx_provider` argument from `COAP_SERVICE_DEFINE_OSCORE` and `COAPS_SERVICE_DEFINE_OSCORE`.