### PR TITLE
drivers: wifi: siwx91x: Correctly limit SSID length

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -242,7 +242,7 @@ int siwx91x_scan(const struct device *dev,
 	if (IS_ENABLED(CONFIG_WIFI_MGMT_SCAN_SSID_FILT_MAX)) {
 		if (z_scan_config->ssids[0]) {
 			strncpy(ssid.value, z_scan_config->ssids[0], WIFI_SSID_MAX_LEN);
-			ssid.length = strlen(z_scan_config->ssids[0]);
+			ssid.length = strnlen(z_scan_config->ssids[0], WIFI_SSID_MAX_LEN);
 		}
 	}
 


### PR DESCRIPTION
SSIDs have a maximum length of 32 bytes, and the buffer used by the HAL has this size. Ensure the length field matches the data stored in the buffer.

The HAL does not expect the buffer to be null terminated, so it is safe to use strnlen to compute the length.