### PR TITLE
boards: htpa eval board: enable 16-bit SMC data

### DIFF
--- a/boards/heimann/htpa_eval/htpa_eval-common.dtsi
+++ b/boards/heimann/htpa_eval/htpa_eval-common.dtsi
@@ -109,8 +109,7 @@
 
 			ext_sram_bus: ext-sram@0 {
 				reg = <0>;
-				/* this needs: PR #112329 */
-				/* atmel,smc-data-bus-width = <16>; */
+				atmel,smc-data-bus-width = <16>;
 				atmel,smc-write-mode = "nwe";
 				atmel,smc-read-mode = "nrd";
 				atmel,smc-setup-timing = <1 1 1 1>;


### PR DESCRIPTION
With this commit we enable the 16bit mode for the
external 1MB sram on the htpa eval board.

(its a SAME70q20b board and is related to the PR #112329 to enabled that new feature)