### PR TITLE
boards: nxp: fix multicore image load addresses

### DIFF
--- a/boards/nxp/frdm_imxrt1186/Kconfig
+++ b/boards/nxp/frdm_imxrt1186/Kconfig
@@ -13,15 +13,6 @@ config CM7_BOOT_FROM_FLASH
 	  If enabled, the CM7 core will run directly from flash (XIP).
 	  If disabled, the CM7 core will run from ITCM memory.
 
-# Define the FlexSPI offset for CM7
-config CM7_FLEXSPI_OFFSET
-	hex "CM7 FlexSPI offset"
-	depends on SECOND_CORE_MCUX && BOARD_FRDM_IMXRT1186_MIMXRT1186_CM33
-	default 0x04000000
-	help
-	  This is the FlexSPI2 offset for CM7 on FRDM-IMXRT1186.
-	  Flash is connected to FlexSPI2, which is mapped at 0x04000000 on CM7.
-
 config BOARD_NXP_SPECIFIC_MPU_SETTINGS
 	bool "Use default MPU settings for NXP boards"
 	default y if CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS

--- a/boards/nxp/frdm_imxrt1186/Kconfig.defconfig
+++ b/boards/nxp/frdm_imxrt1186/Kconfig.defconfig
@@ -40,14 +40,11 @@ DT_CHOSEN_ZEPHYR_FLASH = zephyr,flash
 if !CM7_BOOT_FROM_FLASH
 
 # Adjust the offset of the output image if building for RT118x SOC in RAM
-# Note: For FRDM-IMXRT1186, HyperRAM is on FlexSPI (0x28000000) and flash is on FlexSPI2 (0x04000000)
-# Use FlexSPI2 base address since flash (where CM7 image is stored) is connected to FlexSPI2
-FLEXSPI_BASE := $(dt_nodelabel_reg_addr_hex,flexspi2,1)
 M7_CODE_BASE := $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_ZEPHYR_FLASH))
 IMAGE_M7_ADDR := $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M7))
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(IMAGE_M7_ADDR) + $(FLEXSPI_BASE) - $(M7_CODE_BASE))"
+	default "($(IMAGE_M7_ADDR) - $(M7_CODE_BASE))"
 
 endif # !CM7_BOOT_FROM_FLASH
 endif # SECOND_CORE_MCUX && BOARD_FRDM_IMXRT1186_MIMXRT1186_CM7

--- a/boards/nxp/mimxrt1160_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1160_evk/Kconfig.defconfig
@@ -21,8 +21,7 @@ DT_CHOSEN_IMAGE_M4 = nxp,m4-partition
 
 # Adjust the offset of the output image if building for RT11xx SOC
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M4)) + \
-	$(dt_node_reg_addr_hex,/soc/spi@400cc000,1)) - \
+	default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M4)) - \
 	$(dt_node_reg_addr_hex,/soc/ocram@20200000)"
 
 endif

--- a/boards/nxp/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1170_evk/Kconfig.defconfig
@@ -21,8 +21,7 @@ DT_CHOSEN_IMAGE_M4 = nxp,m4-partition
 
 # Adjust the offset of the output image if building for RT11xx SOC
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M4)) + \
-	$(dt_node_reg_addr_hex,/soc/spi@400cc000,1)) - \
+	default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M4)) - \
 	$(dt_node_reg_addr_hex,/soc/ocram@20200000)"
 
 endif

--- a/boards/nxp/mimxrt1180_evk/Kconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig
@@ -13,14 +13,6 @@ config CM7_BOOT_FROM_FLASH
 	  If enabled, the CM7 core will run directly from flash (XIP).
 	  If disabled, the CM7 core will run from ITCM memory.
 
-# Define the FlexSPI offset for CM7
-config CM7_FLEXSPI_OFFSET
-	hex "CM7 FlexSPI offset"
-	depends on SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM33
-	default 0x28000000
-	help
-	  This is the FlexSPI offset for CM7.
-
 config BOARD_NXP_SPECIFIC_MPU_SETTINGS
 	bool "Use default MPU settings for NXP boards"
 	default y if CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS

--- a/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
@@ -40,12 +40,11 @@ DT_CHOSEN_ZEPHYR_FLASH = zephyr,flash
 if !CM7_BOOT_FROM_FLASH
 
 # Adjust the offset of the output image if building for RT118x SOC in RAM
-FLEXSPI_BASE := $(dt_nodelabel_reg_addr_hex,flexspi,1)
 M7_CODE_BASE := $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_ZEPHYR_FLASH))
 IMAGE_M7_ADDR := $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M7))
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(IMAGE_M7_ADDR) + $(FLEXSPI_BASE) - $(M7_CODE_BASE))"
+	default "($(IMAGE_M7_ADDR) - $(M7_CODE_BASE))"
 
 endif # !CM7_BOOT_FROM_FLASH
 endif # SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM7

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -156,9 +156,9 @@ const __imx_boot_container_section container boot_header = {
 
 /* Handle CM7 core initialization based on execution mode */
 #if !defined(CONFIG_CM7_BOOT_FROM_FLASH)
-#define CM7_BOOT_ADDRESS   (CM7_FLASH_ADDR + CONFIG_CM7_FLEXSPI_OFFSET - ADJUSTED_LMA)
+#define CM7_BOOT_ADDRESS   (CM7_FLASH_ADDR - ADJUSTED_LMA)
 #else
-#define CM7_BOOT_ADDRESS   (CM7_FLASH_ADDR + CONFIG_CM7_FLEXSPI_OFFSET)
+#define CM7_BOOT_ADDRESS   CM7_FLASH_ADDR
 #endif /* defined(CONFIG_CM7_BOOT_FROM_FLASH) */
 #endif /* (defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)) */
 


### PR DESCRIPTION
Mapped partitions already resolve to CPU-visible flash addresses. Stop adding the FlexSPI mapping base a second time when adjusting the load addresses of secondary-core images.