### PR TITLE
tests: bsim: Bluetooth: Tune LL multiple connection simulation timeout

### DIFF
--- a/tests/bsim/bluetooth/ll/multiple_id/src/main.c
+++ b/tests/bsim/bluetooth/ll/multiple_id/src/main.c
@@ -151,7 +151,10 @@ static void test_peripheral_multilink_main(void)
 		goto exit;
 	}
 
-	k_sleep(K_SECONDS(3));
+	/* Symmetric to Central waiting to ensure there is no connection failed to be established
+	 * before we complete the test.
+	 */
+	k_sleep(K_SECONDS(1));
 
 	PASS("Peripheral tests passed\n");
 
@@ -164,7 +167,7 @@ exit:
 
 static void test_multiple_init(void)
 {
-	bst_ticker_set_next_tick_absolute(2400e6);
+	bst_ticker_set_next_tick_absolute(2040e6);
 	bst_result = In_progress;
 }
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
@@ -18,6 +18,6 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_multiple_id_prj_conf -RealEncry
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -rs=7
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=2410e6 $@ -argschannel -at=40
+  -D=2 -sim_length=2041e6 $@ -argschannel -at=40
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
@@ -27,6 +27,6 @@ done
 let device_count=$central_count+1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=$device_count -sim_length=1800e6 $@ -argschannel -at=40
+  -D=$device_count -sim_length=480e6 $@ -argschannel -at=40
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
@@ -27,6 +27,6 @@ done
 let device_count=$peripheral_count+1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=$device_count -sim_length=1800e6 $@ -argschannel -at=40
+  -D=$device_count -sim_length=300e6 $@ -argschannel -at=40
 
 wait_for_background_jobs


### PR DESCRIPTION
Tune the LL multiple connection test's simulation timeout to avoid redundant processing time that causes CI failure when the simulation is slow at high loads on the servers.