### PR TITLE
drivers: interrupt_controller: gicv3_its: fix CBASER size encoding

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -446,7 +446,7 @@ static void its_setup_cmd_queue(const struct device *dev)
 	/* Zero out cmd table */
 	memset(cfg->cmd_queue, 0, cfg->cmd_queue_size);
 
-	reg |= MASK_SET(cfg->cmd_queue_size / SIZE_4K, GITS_CBASER_SIZE);
+	reg |= MASK_SET((cfg->cmd_queue_size / SIZE_4K) - 1, GITS_CBASER_SIZE);
 	reg |= MASK_SET(GIC_BASER_SHARE_INNER, GITS_CBASER_SHAREABILITY);
 	reg |= MASK_SET((uintptr_t)cfg->cmd_queue >> GITS_CBASER_ADDR_SHIFT, GITS_CBASER_ADDR);
 	reg |= MASK_SET(GIC_BASER_CACHE_RAWAWB, GITS_CBASER_OUTER_CACHE);


### PR DESCRIPTION
GITS_CBASER.Size is encoded as (number of 4KB pages) - 1 per the GICv3 ITS specification. Write pages-1 instead of the raw page count.