### PR TITLE
drivers: mspm0: uart: add driver command API

### DIFF
--- a/drivers/serial/Kconfig.mspm0
+++ b/drivers/serial/Kconfig.mspm0
@@ -12,3 +12,11 @@ config UART_MSPM0
 	select PINCTRL
 	help
 	  This option enables the TI MSPM0 UART driver.
+
+config UART_MSPM0_DRV_CMD
+	bool "Driver Commands"
+	depends on UART_MSPM0
+	depends on UART_DRV_CMD
+	help
+	  This enables the API for applications to send extra commands to the
+	  MSPM0 UART driver.

--- a/drivers/serial/uart_mspm0.c
+++ b/drivers/serial/uart_mspm0.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/dt-bindings/uart/mspm0_uart.h>
+#include <zephyr/drivers/serial/uart_mspm0.h>
 #include <zephyr/irq.h>
 
 /* Driverlib includes */
@@ -439,6 +440,29 @@ static const DL_UART_TX_FIFO_LEVEL uart_mspm0_tx_fifo_level[] = {
 };
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
+#ifdef CONFIG_UART_MSPM0_DRV_CMD
+static int uart_mspm0_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
+{
+	const struct uart_mspm0_config *config = dev->config;
+	int ret;
+
+	switch (cmd) {
+	case UART_MSPM_CMD_SEND_BREAK:
+		if (p) {
+			DL_UART_enableLINSendBreak(config->regs);
+		} else {
+			DL_UART_disableLINSendBreak(config->regs);
+		}
+		ret = 0;
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+	return ret;
+}
+#endif /* CONFIG_UART_MSPM0_DRV_CMD */
+
 static int uart_mspm0_init(const struct device *dev)
 {
 	const struct uart_mspm0_config *config = dev->config;
@@ -500,6 +524,9 @@ static DEVICE_API(uart, uart_mspm0_driver_api) = {
 	.irq_err_enable = uart_mspm0_irq_error_enable,
 	.irq_err_disable = uart_mspm0_irq_error_disable,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#ifdef CONFIG_UART_MSPM0_DRV_CMD
+	.drv_cmd = uart_mspm0_drv_cmd,
+#endif /* CONFIG_UART_MSPM0_DRV_CMD */
 };
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/include/zephyr/drivers/serial/uart_mspm0.h
+++ b/include/zephyr/drivers/serial/uart_mspm0.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Bang & Olufsen A/S, Denmark
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Public header file for the TI MSPM0 UART driver.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_MSPM0_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_MSPM0_H_
+
+/**
+ * @brief Drive or release a break condition on the TX line.
+ *
+ * Intended to be used through uart_drv_cmd() (requires
+ * @kconfig{CONFIG_UART_MSPM0_DRV_CMD}) to generate the break field.
+ *
+ */
+#define UART_MSPM_CMD_SEND_BREAK 0x01
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_MSPM0_H_ */


### PR DESCRIPTION
Driver Command API has been added to `uart_mspm0`. In this way extra functionality of the hardware can be exposed. In this case the ability to send a break signal has been added.