### PR TITLE
lpcxpresso11u68: fix ARM architecture test failures

### DIFF
--- a/boards/nxp/lpcxpresso11u68/lpcxpresso11u68_defconfig
+++ b/boards/nxp/lpcxpresso11u68/lpcxpresso11u68_defconfig
@@ -2,9 +2,10 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=48000000
 CONFIG_GPIO=y
 CONFIG_BUILD_OUTPUT_HEX=y
-# Since the board has little memory (32k), stack sizes are lowered
-# so that the application has more RAM for itself.
-CONFIG_MAIN_STACK_SIZE=512
+# The Cortex-M0+ has no dedicated exception stack: exception handlers and
+# main-thread work share this stack. Keep sufficient headroom for ztest's
+# final UART summary and post-test scheduling on the 32 KiB SRAM device.
+CONFIG_MAIN_STACK_SIZE=1024
 CONFIG_ISR_STACK_SIZE=768
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/tests/arch/arm/arm_irq_advanced_features/boards/lpcxpresso11u68.conf
+++ b/tests/arch/arm/arm_irq_advanced_features/boards/lpcxpresso11u68.conf
@@ -1,0 +1,3 @@
+# IRQ 39 is not software-pendable on LPC11U68.
+# Use an unused first-level NVIC IRQ below the reserved high-vector range.
+CONFIG_TEST_DIRECT_IRQ_MAX=32

--- a/tests/arch/arm/arm_sw_vector_relay/Kconfig
+++ b/tests/arch/arm/arm_sw_vector_relay/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_SKIP_IRQS
+	string "Vector-table entries excluded from relay verification"
+	default ""
+	help
+	  Comma-separated vector-table entry numbers that the relay test must
+	  not verify. Use this for board-required vector-table contents that
+	  cannot contain the vector relay handler.

--- a/tests/arch/arm/arm_sw_vector_relay/boards/lpcxpresso11u68.conf
+++ b/tests/arch/arm/arm_sw_vector_relay/boards/lpcxpresso11u68.conf
@@ -1,0 +1,2 @@
+# The LPC11U68 boot ROM stores its vector-table checksum in word 7.
+CONFIG_TEST_SKIP_IRQS="7"

--- a/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
+++ b/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
@@ -15,6 +15,33 @@ extern uint32_t _vector_table;
 extern uint32_t __vector_relay_handler;
 extern uint32_t _vector_table_pointer;
 
+static bool skip_irq(int irq)
+{
+	const char *list = CONFIG_TEST_SKIP_IRQS;
+
+	while (*list != '\0') {
+		int entry = 0;
+
+		while (*list == ' ' || *list == ',') {
+			list++;
+		}
+
+		while (*list >= '0' && *list <= '9') {
+			entry = (entry * 10) + (*list - '0');
+			list++;
+		}
+
+		if (entry == irq) {
+			return true;
+		}
+
+		while (*list != '\0' && *list != ',') {
+			list++;
+		}
+	}
+
+	return false;
+}
 
 /**
  * @brief Test the ARM Software Vector Relay functionality.
@@ -34,6 +61,10 @@ ZTEST(arm_sw_vector_relay, test_arm_sw_vector_relay)
 	const uint32_t *vector_relay_table_addr_val = (uint32_t *)(vector_relay_table_addr);
 
 	for (int i = 2; i < 16 + CONFIG_NUM_IRQS; i++) {
+		if (skip_irq(i)) {
+			continue;
+		}
+
 		zassert_true(vector_relay_table_addr_val[i] == vector_relay_handler_func,
 			     "vector relay table not pointing to the relay handler: 0x%x, 0x%x\n",
 			     vector_relay_table_addr_val[i], vector_relay_handler_func);


### PR DESCRIPTION
## Summary

- Fix ARM architecture test failures on LPCXpresso11U68.
- Skip the boot ROM checksum vector during software vector relay testing.
- Use a lower software-pendable IRQ for the dynamic direct IRQ test.
- Increase the board main stack to prevent ztest post-test faults.

## Testing

- `west build -p always -b lpcxpresso11u68 tests/arch/arm/arm_sw_vector_relay`
- Tested the complete ARM test suite on physical LPCXpresso11U68 hardware.

Fixes: #115783
