### PR TITLE
tests: bluetooth: controller: give the faked SOC_COMPATIBLE_NRF a type

### DIFF
--- a/tests/bluetooth/controller/ctrl_api/Kconfig
+++ b/tests/bluetooth/controller/ctrl_api/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_chmu/Kconfig
+++ b/tests/bluetooth/controller/ctrl_chmu/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_cis_create/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cis_create/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_cis_terminate/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_collision/Kconfig
+++ b/tests/bluetooth/controller/ctrl_collision/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_conn_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_conn_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_cte_req/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cte_req/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_data_length_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_data_length_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_encrypt/Kconfig
+++ b/tests/bluetooth/controller/ctrl_encrypt/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_feature_exchange/Kconfig
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_hci/Kconfig
+++ b/tests/bluetooth/controller/ctrl_hci/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_invalid/Kconfig
+++ b/tests/bluetooth/controller/ctrl_invalid/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_le_ping/Kconfig
+++ b/tests/bluetooth/controller/ctrl_le_ping/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_min_used_chans/Kconfig
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_periodic_sync/Kconfig
+++ b/tests/bluetooth/controller/ctrl_periodic_sync/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_phy_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_phy_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_sca_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_sca_update/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_terminate/Kconfig
+++ b/tests/bluetooth/controller/ctrl_terminate/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/Kconfig
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_tx_queue/Kconfig
+++ b/tests/bluetooth/controller/ctrl_tx_queue/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_unsupported/Kconfig
+++ b/tests/bluetooth/controller/ctrl_unsupported/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT

--- a/tests/bluetooth/controller/ctrl_version/Kconfig
+++ b/tests/bluetooth/controller/ctrl_version/Kconfig
@@ -5,6 +5,7 @@
 # the following configs been set
 
 config SOC_COMPATIBLE_NRF
+	bool
 	default y
 
 config BT_CTLR_DATA_LEN_UPDATE_SUPPORT


### PR DESCRIPTION
The Bluetooth controller unit tests build for unit_testing but exercise
the Nordic link layer, so each one fakes the SoC it is emulating with a
typeless 'config SOC_COMPATIBLE_NRF' carrying only a default.

A typeless config only assigns a value if the symbol is given a type
somewhere else, and the only place that types SOC_COMPATIBLE_NRF is
soc/nordic/Kconfig. The tests were therefore relying on the Nordic SoC
tree being loaded for a board that has nothing to do with Nordic. When
only the SoC tree of the board being targeted is loaded, the symbol stays
untyped, BT_LLL_VENDOR_NORDIC loses its dependency, none of the
BT_CTLR_*_SUPPORT symbols it selects come up, and Kconfig aborts on the
resulting unsatisfied dependencies.

Declare the symbol bool in the tests that fake it, which is the pattern
tests/bluetooth/controller/common/Kconfig already uses for
DT_HAS_ZEPHYR_BT_HCI_LL_SW_SPLIT_ENABLED.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
