### PR TITLE
Bluetooth: HCI: Remove non-existent BT_HCI_RAW_CMD_EXT feature

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -61,12 +61,6 @@ config BT_HCI_RAW_H4_ENABLE
 	  This option enables use of H:4 transport for HCI RAW access at
 	  build time.
 
-config BT_HCI_RAW_CMD_EXT
-	bool "RAW HCI Command Extension"
-	help
-	  This option enables HCI RAW command extension so the driver can
-	  register it own command table extension.
-
 config BT_PERIPHERAL
 	bool "Peripheral Role support"
 	select BT_BROADCASTER


### PR DESCRIPTION
Relates to commit 26d97164be26 ("Bluetooth: HCI: Use H:4 encoding for buffers") which deleted struct
bt_hci_raw_cmd_ext and bt_hci_raw_cmd_ext_register() from hci_raw.h with no replacement — bt_send() now just forwards buffers straight to the driver. The orphaned CONFIG_BT_HCI_RAW_CMD_EXT symbol made it look like the feature still existed.