### PR TITLE
tests: subsys: Limit platforms in STM unittests

### DIFF
--- a/tests/subsys/debug/cs_trace_defmt/tests.yaml
+++ b/tests/subsys/debug/cs_trace_defmt/tests.yaml
@@ -1,5 +1,7 @@
 tests:
   debug.cs_trace_defmt:
     tags: debug
+    platform_allow:
+      - native_sim
     integration_platforms:
       - native_sim

--- a/tests/subsys/debug/mipi_stp_decoder/tests.yaml
+++ b/tests/subsys/debug/mipi_stp_decoder/tests.yaml
@@ -2,5 +2,7 @@ tests:
   debug.mipi_stp_decoder:
     filter: not CONFIG_BIG_ENDIAN
     tags: stp_decoder
+    platform_allow:
+      - native_sim
     integration_platforms:
       - native_sim

--- a/tests/subsys/logging/log_frontend_stmesp_demux/tests.yaml
+++ b/tests/subsys/logging/log_frontend_stmesp_demux/tests.yaml
@@ -2,12 +2,12 @@ common:
   filter: not CONFIG_BIG_ENDIAN
   tags:
     - coresight_stm
+  platform_allow:
+    - native_sim
+  integration_platforms:
+    - native_sim
 tests:
-  debug.coresight.stp_demux:
-    integration_platforms:
-      - native_sim
+  debug.coresight.stp_demux: {}
   debug.coresight.stp_demux_max_utilization:
-    integration_platforms:
-      - native_sim
     extra_configs:
       - CONFIG_LOG_FRONTEND_STMESP_DEMUX_MAX_UTILIZATION=y


### PR DESCRIPTION
Cs_trace_defmt, mipi_stp_decoder and log_frontend_stmesp_demux verify correct operation of STM logging.
Due to missing `platform_allow`, these tests execute on platforms that does NOT support STM.

Limit `platform_allow` list for STM unittests to nativ_sim.