### PR TITLE
dts: arm: st: f1: add missing kernel clock for TIM8

### DIFF
--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -180,7 +180,8 @@
 		timers8: timers@40013400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>,
+				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
 			resets = <&rctl STM32_RESET(APB2, 13)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";


### PR DESCRIPTION
Add missing `clocks` cell for the kernel clock on TIM8 in DTSI for high-/XL-density STM32F1 devices, which prevented use of the peripheral as the driver expects this cell to be present.

Fixes #115467