### PR TITLE
net: coap: mark COAP OSCORE as experimental

### DIFF
--- a/subsys/net/lib/coap/Kconfig.oscore
+++ b/subsys/net/lib/coap/Kconfig.oscore
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config COAP_OSCORE
-	bool "OSCORE support for CoAP (RFC 8613)"
+	bool "OSCORE support for CoAP (RFC 8613) [EXPERIMENTAL]"
 	depends on UOSCORE
 	depends on PSA_CRYPTO
+	select EXPERIMENTAL
 	help
 	  Enable Object Security for Constrained RESTful Environments (OSCORE)
 	  support for CoAP server. OSCORE provides end-to-end protection of


### PR DESCRIPTION
OSCORE support for CoAP (RFC 8613) is a new addition and its API and behavior may still change. Add "select EXPERIMENTAL" to the COAP_OSCORE symbol so that enabling it emits the standard experimental warning and users are aware of its maturity level.