### PR TITLE
net: Fix generation of IPv6 IID and TCP ISN secret keys

### DIFF
--- a/modules/openthread/platform/infra_if.c
+++ b/modules/openthread/platform/infra_if.c
@@ -199,14 +199,17 @@ static void handle_ra_from_ot(const uint8_t *buffer, uint16_t buffer_length)
 							      (struct net_in6_addr *)pio->prefix,
 							      pio->prefix_len, pio->valid_lifetime);
 			i += sizeof(struct net_icmpv6_nd_opt_prefix_info);
-			net_ipv6_addr_generate_iid(
+			if (net_ipv6_addr_generate_iid(
 				ail_iface_ptr, (struct net_in6_addr *)pio->prefix,
 				COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
 				     ((uint8_t *)&ail_iface_ptr->config.ip.ipv6->network_counter),
 				     (NULL)), COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
 				     (sizeof(ail_iface_ptr->config.ip.ipv6->network_counter)),
 				     (0U)), 0U, &addr_to_add_from_pio,
-							       net_if_get_link_addr(ail_iface_ptr));
+				net_if_get_link_addr(ail_iface_ptr)) < 0) {
+				break;
+			}
+
 			ifaddr = net_if_ipv6_addr_lookup(&addr_to_add_from_pio, NULL);
 			if (ifaddr != NULL) {
 				net_if_addr_set_lf(ifaddr, true);

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -936,7 +936,14 @@ static int gen_stable_iid(uint8_t if_index,
 	}
 
 	if (!once) {
-		sys_rand_get(&secret_key, sizeof(secret_key));
+		/* The secret key must not be guessable, otherwise the
+		 * generated IIDs could be predicted. RFC 7217 ch 5
+		 */
+		if (sys_csrand_get(secret_key, sizeof(secret_key)) != 0) {
+			NET_ERR("Cannot generate secret key for stable IID");
+			return -EIO;
+		}
+
 		once = true;
 	}
 

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2442,6 +2442,7 @@ static inline void handle_prefix_autonomous(struct net_pkt *pkt,
 			 net_if_get_link_addr(iface));
 	if (ret < 0) {
 		NET_WARN("IPv6 IID generation issue (%d)", ret);
+		return;
 	}
 
 	ifaddr = net_if_ipv6_addr_lookup(&addr, NULL);

--- a/subsys/net/ip/ipv6_pe.c
+++ b/subsys/net/ip/ipv6_pe.c
@@ -255,7 +255,16 @@ static int gen_temporary_iid(struct net_if *iface,
 	       MIN(sizeof(buf.mac), net_if_get_link_addr(iface)->len));
 
 	if (!once) {
-		sys_rand_get(&secret_key, sizeof(secret_key));
+		/* The secret key must not be guessable, otherwise the
+		 * generated temporary IIDs could be predicted and the
+		 * privacy extension would not provide any protection.
+		 * RFC 8981 ch 3.3.2
+		 */
+		if (sys_csrand_get(secret_key, sizeof(secret_key)) != 0) {
+			NET_ERR("Cannot generate secret key for temporary IID");
+			return -EIO;
+		}
+
 		once = true;
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2415,6 +2415,30 @@ static uint32_t seq_scale(uint32_t seq)
 }
 
 static uint8_t unique_key[16]; /* MD5 128 bits as described in RFC6528 */
+static bool unique_key_valid;
+
+/* The secret key must not be known to an off-path attacker, otherwise the
+ * ISN can be computed from the four-tuple alone. RFC 6528 ch 3
+ */
+static int tcp_init_isn_key(void)
+{
+	int ret = 0;
+
+	k_mutex_lock(&tcp_lock, K_FOREVER);
+
+	if (!unique_key_valid) {
+		ret = sys_csrand_get(unique_key, sizeof(unique_key));
+		if (ret == 0) {
+			unique_key_valid = true;
+		} else {
+			NET_ERR("Cannot generate secret key for TCP ISN");
+		}
+	}
+
+	k_mutex_unlock(&tcp_lock);
+
+	return ret;
+}
 
 static uint32_t tcpv6_init_isn(struct net_in6_addr *saddr,
 			       struct net_in6_addr *daddr,
@@ -2436,12 +2460,6 @@ static uint32_t tcpv6_init_isn(struct net_in6_addr *saddr,
 
 	uint8_t hash[16];
 	size_t hash_len;
-	static bool once;
-
-	if (!once) {
-		sys_csrand_get(unique_key, sizeof(unique_key));
-		once = true;
-	}
 
 	memcpy(buf.key, unique_key, sizeof(buf.key));
 
@@ -2471,15 +2489,8 @@ static uint32_t tcpv4_init_isn(struct net_in_addr *saddr,
 
 	uint8_t hash[16];
 	size_t hash_len;
-	static bool once;
-
-	if (!once) {
-		sys_csrand_get(unique_key, sizeof(unique_key));
-		once = true;
-	}
 
 	memcpy(buf.key, unique_key, sizeof(unique_key));
-
 
 	psa_hash_compute(PSA_ALG_SHA_256, (const unsigned char *)&buf, sizeof(buf),
 			 hash, sizeof(hash), &hash_len);
@@ -2491,12 +2502,13 @@ static uint32_t tcpv4_init_isn(struct net_in_addr *saddr,
 
 #define tcpv6_init_isn(...) (0UL)
 #define tcpv4_init_isn(...) (0UL)
+#define tcp_init_isn_key() (-ENOTSUP)
 
 #endif /* CONFIG_NET_TCP_ISN_RFC6528 */
 
 static uint32_t tcp_init_isn(struct net_sockaddr *saddr, struct net_sockaddr *daddr)
 {
-	if (IS_ENABLED(CONFIG_NET_TCP_ISN_RFC6528)) {
+	if (IS_ENABLED(CONFIG_NET_TCP_ISN_RFC6528) && tcp_init_isn_key() == 0) {
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    saddr->sa_family == NET_AF_INET6) {
 			return tcpv6_init_isn(&net_sin6(saddr)->sin6_addr,

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -478,13 +478,14 @@ static int interface_attach(struct net_if *iface, struct net_if *lower_iface)
 				 net_if_get_link_addr(iface));
 			if (ret < 0) {
 				NET_WARN("IPv6 IID generation issue (%d)", ret);
-			}
-
-			ifaddr = net_if_ipv6_addr_add(iface, &iid, NET_ADDR_AUTOCONF, 0);
-			if (!ifaddr) {
-				NET_ERR("Cannot add %s address to interface %p",
-					net_sprint_ipv6_addr(&iid),
-					iface);
+			} else {
+				ifaddr = net_if_ipv6_addr_add(iface, &iid,
+							      NET_ADDR_AUTOCONF, 0);
+				if (!ifaddr) {
+					NET_ERR("Cannot add %s address to interface %p",
+						net_sprint_ipv6_addr(&iid),
+						iface);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Generate the RFC 7217 stable IID and RFC 8981 privacy extension secret keys
  with `sys_csrand_get()` instead of `sys_rand_get()`, and fail IID generation
  rather than deriving addresses from a predictable key.
- Skip address configuration in the `net_ipv6_addr_generate_iid()` callers that
  only warned on failure and went on to install `::` or uninitialized stack memory.
- Check the result of the RFC 6528 TCP ISN key generation, which previously left
  the key zeroed on failure, and generate it once from a single guarded helper
  instead of two independent flags sharing one key.

Fixes: #116527