### PR TITLE
bluetooth: classic: rfcomm: add API to send Remote Line Status command

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -316,6 +316,50 @@ struct net_buf *bt_rfcomm_create_pdu(struct net_buf_pool *pool);
  */
 int bt_rfcomm_send_rpn_cmd(struct bt_rfcomm_dlc *dlc, struct bt_rfcomm_rpn *rpn);
 
+/** @brief Remote Line Status value: No error */
+#define BT_RFCOMM_RLS_NO_ERR (0x00U)
+
+/** @brief Remote Line Status value: error occurred
+ *
+ *  @param err Error code to be set in the RLS value; must be one of the following values:
+ *             @ref BT_RFCOMM_RLS_ERR_OVERRUN_ERROR, @ref BT_RFCOMM_RLS_ERR_PARITY_ERROR, or
+ *             @ref BT_RFCOMM_RLS_ERR_FRAMING_ERROR.
+ *
+ *  @return RLS value with error code set.
+ */
+#define BT_RFCOMM_RLS_ERR(err) (BIT(0) | (err))
+
+/** @brief Overrun Error - Received character overwrote an unread character */
+#define BT_RFCOMM_RLS_ERR_OVERRUN_ERROR BIT(1)
+
+/** @brief Parity Error - Received character's parity was incorrect */
+#define BT_RFCOMM_RLS_ERR_PARITY_ERROR BIT(2)
+
+/** @brief Framing Error - a character did not terminate with a stop bit */
+#define BT_RFCOMM_RLS_ERR_FRAMING_ERROR BIT(3)
+
+/**
+ * @brief Send Remote Line Status Command
+ *
+ * Send remote line status with specific rls value @p line_status to the RFCOMM DLC.
+ * For @p line_status, the BIT(4-7) are reserved and must be set to 0.
+ * The BIT(0-3) indicate the Line Status.
+ * If the BIT(0) is set to 0, there is no error occurred.
+ * If the BIT(0) is set to 1, the error is indicated by BIT(1-3) with the following values:
+ * @ref BT_RFCOMM_RLS_ERR_OVERRUN_ERROR - Received character overwrote an unread
+ * character.
+ * @ref BT_RFCOMM_RLS_ERR_PARITY_ERROR - Received character's parity was incorrect.
+ * @ref BT_RFCOMM_RLS_ERR_FRAMING_ERROR - a character did not terminate with a stop bit.
+ *
+ * @p line_status can be created using @ref BT_RFCOMM_RLS_NO_ERR and @ref BT_RFCOMM_RLS_ERR macros.
+ *
+ * @param dlc Pointer to the RFCOMM DLC
+ * @param line_status Line Status value
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int bt_rfcomm_send_rls_cmd(struct bt_rfcomm_dlc *dlc, uint8_t line_status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -750,6 +750,37 @@ static int rfcomm_send_rls(struct bt_rfcomm_dlc *dlc, uint8_t cr,
 	return rfcomm_send(dlc->session, buf);
 }
 
+#define RFCOMM_RLS_MASK GENMASK(3, 0)
+#define RFCOMM_RLS_ERROR_FLAG_MASK BIT(0)
+#define RFCOMM_RLS_ERROR_CODE_MASK GENMASK(3, 1)
+
+#define RFCOMM_RLS_VALID(line_status) \
+	(((line_status) & ~RFCOMM_RLS_MASK) == 0 && \
+	 (((line_status) & RFCOMM_RLS_ERROR_FLAG_MASK) == 0 || \
+	  ((line_status) & RFCOMM_RLS_ERROR_CODE_MASK) != 0))
+
+int bt_rfcomm_send_rls_cmd(struct bt_rfcomm_dlc *dlc, uint8_t line_status)
+{
+	if (dlc == NULL) {
+		return -EINVAL;
+	}
+
+	if (!RFCOMM_RLS_VALID(line_status)) {
+		LOG_ERR("Invalid line status: 0x%02x", line_status);
+		return -EINVAL;
+	}
+
+	if (dlc->session == NULL || dlc->state != BT_RFCOMM_STATE_CONNECTED) {
+		LOG_ERR("dlc %p not connected", dlc);
+		return -ENOTCONN;
+	}
+
+	LOG_DBG("dlc %p sending RLS(0x%02x) on session %p", dlc, line_status, dlc->session);
+
+	/* Send the RLS command */
+	return rfcomm_send_rls(dlc, BT_RFCOMM_MSG_CMD_CR, line_status);
+}
+
 static int rfcomm_send_rpn(struct bt_rfcomm_session *session, uint8_t cr,
 			   struct bt_rfcomm_rpn *rpn)
 {

--- a/subsys/bluetooth/host/classic/shell/spp.c
+++ b/subsys/bluetooth/host/classic/shell/spp.c
@@ -680,6 +680,40 @@ static int cmd_spp_disconnect(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_spp_rls(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	struct bt_spp_endpoint *ep;
+	uint8_t line_status = BT_RFCOMM_RLS_NO_ERR;
+
+	ep = bt_spp_get_active_ep();
+	if (ep == NULL) {
+		shell_error(sh, "SPP: no active connection");
+		return -ENOEXEC;
+	}
+
+	if (argc == 2) {
+		if (strcmp(argv[1], "overrun") == 0) {
+			line_status = BT_RFCOMM_RLS_ERR(BT_RFCOMM_RLS_ERR_OVERRUN_ERROR);
+		} else if (strcmp(argv[1], "parity") == 0) {
+			line_status = BT_RFCOMM_RLS_ERR(BT_RFCOMM_RLS_ERR_PARITY_ERROR);
+		} else if (strcmp(argv[1], "framing") == 0) {
+			line_status = BT_RFCOMM_RLS_ERR(BT_RFCOMM_RLS_ERR_FRAMING_ERROR);
+		} else {
+			shell_help(sh);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
+
+	err = bt_rfcomm_send_rls_cmd(&ep->rfcomm_dlc, line_status);
+	if (err != 0) {
+		shell_error(sh, "SPP: send RLS failed (err=%d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	spp_cmds,
 	SHELL_CMD_ARG(register_with_channel, NULL, "<channel>",
@@ -693,6 +727,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "<bt-uuid16|bt-uuid32|bt-uuid128> e.g. 1101 or 00001101-0000-1000-8000-00805F9B34FB",
 		      cmd_spp_connect_by_uuid, 2, 0),
 	SHELL_CMD_ARG(send, NULL, "send [length of packet(s)]", cmd_spp_send, 1, 1),
+	SHELL_CMD_ARG(rls, NULL, "[overrun|parity|framing]", cmd_spp_rls, 1, 1),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_spp_disconnect, 1, 0),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
* bluetooth: classic: rfcomm: add API to send Remote Line Status command

Add public API `bt_rfcomm_send_rls_cmd()` to allow applications to send Remote Line Status (RLS) commands to RFCOMM DLC connections.

The new API validates the DLC connection state and sends RLS commands with application-specified line status values to report serial port errors such as overrun, parity, and framing errors.

Add helper macros `RFCOMM_RLS_NO_ERR`, `RFCOMM_RLS_ERR()`, `RFCOMM_RLS_ERR_OVERRUN_ERROR`, `RFCOMM_RLS_ERR_PARITY_ERROR`, and `RFCOMM_RLS_ERR_FRAMING_ERROR` to simplify construction of line status values.

* bluetooth: classic: shell: add RLS command to SPP shell

Add a new shell command `spp rls` to allow testing of the RFCOMM Remote Line Status (RLS) functionality through the SPP shell interface.

The command accepts optional error type parameters (overrun, parity, or framing) to simulate serial port errors. When no parameter is provided, it sends a no-error status.

The implementation uses the newly added `bt_rfcomm_send_rls_cmd()` API to send RLS commands on the active SPP connection.
