### PR TITLE
modbus: support native PTY UART

### DIFF
--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -38,6 +38,15 @@ or removed in the application overlay file
 The USB to RS-485 adapter connects to the USB port of a computer.
 The two A+, B- lines should be connected to the RS-485 shield.
 
+Using NATIVE PTY UART
+=====================
+
+When building for native_sim, the console and Modbus UART are connected to
+pseudo-terminals (PTYs) on the host system.
+
+The PTYs are created dynamically when the application starts, allowing the UART
+interfaces to be accessed and tested without physical serial hardware.
+
 Using CDC ACM UART
 ==================
 

--- a/samples/subsys/modbus/rtu_server/boards/native_sim.overlay
+++ b/samples/subsys/modbus/rtu_server/boards/native_sim.overlay
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ *Copyright (c) 2026 Wilmers Messtechnik GmbH
+ */
+
+/ {
+	aliases {
+		led0 = &led0;
+		led1 = &led0;
+		led2 = &led0;
+	};
+
+	uart1: uart_1 {
+		compatible = "zephyr,native-pty-uart";
+		status = "okay";
+		current-speed = <19200>;
+
+		modbus0 {
+			compatible = "zephyr,modbus-serial";
+			status = "okay";
+		};
+	};
+};

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -576,8 +576,12 @@ static inline int configure_uart(struct modbus_context *ctx,
 	}
 
 	if (uart_configure(cfg->dev, &uart_cfg) != 0) {
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_native_pty_uart)
+		LOG_WRN("Native PTY uart does not support configure");
+#else
 		LOG_ERR("Failed to configure UART");
 		return -EINVAL;
+#endif
 	}
 
 	return 0;


### PR DESCRIPTION
The native PTY UART provided by native_sim does not implement runtime configuration of the uart using uart_configure. As a consequence, modbus initialisation fails with an error message.

As a workaround, a failure to configure the uart during modbus initialisation will be ignored graciously if a
native PTY uart is enabled, and a warning message is issued instead of an error.

Tested using:
- app: samples/subsys/modbus/rtu_server
- board: native_sim