### PR TITLE
logging: dictionary: include log_strings in database_gen

### DIFF
--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -466,6 +466,20 @@ def extract_static_strings(elf, database, section_extraction=False):
                 )
                 break
 
+    # Always extract NUL-terminated strings from stripped sections (e.g.
+    # log_strings) before parsing log instances so module names resolve.
+    for sect_name in REMOVED_STRING_SECTIONS:
+        if sect_name in elf_sections:
+            before = len(string_mappings)
+            string_mappings = extract_strings_in_one_section(
+                elf_sections[sect_name], string_mappings
+            )
+            logger.info(
+                "Found %d strings in section '%s'",
+                len(string_mappings) - before,
+                sect_name,
+            )
+
     if section_extraction:
         # Extract strings from ELF sections
         string_sections = list(STATIC_STRING_SECTIONS)


### PR DESCRIPTION
## Summary

- When `CONFIG_LOG_FMT_SECTION_STRIP` is enabled, format strings and module names live in the ELF `log_strings` section.
- `database_gen` already loads that section for DWARF lookups, but never ran the NUL-terminated section scanner on it.
- Under LTO, DWARF alone is often insufficient, leaving incomplete `string_mappings` and `unknown` log instances.
- This change always merges NUL-terminated `log_strings` entries into `string_mappings` before parsing log instances.

Fixes #115815

## Test plan

- [x] Ran patched vs stock `database_gen.py` on a real app ELF with non-empty `log_strings` (LTO + strip): stock had ~192/`194` `unknown` instances and far fewer mappings; patched resolved all instance names and added the stripped strings.
- [ ] CI / Twister as required by maintainers