### PR TITLE
Bluetooth: CAP: Shell: Refactor cap_unicast_ac_param

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -251,13 +251,22 @@ extern struct shell_stream unicast_streams[CONFIG_BT_ISO_MAX_CHAN];
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 
+struct cap_unicast_ac_cis_param {
+	bool has_snk;
+	bool has_src;
+	enum bt_audio_location snk_loc;
+	enum bt_audio_location src_loc;
+};
+
+struct cap_unicast_ac_conn_param {
+	size_t cis_cnt;
+	struct cap_unicast_ac_cis_param cis_param[BAP_UNICAST_AC_MAX_PAIR];
+};
+
 struct cap_unicast_ac_param {
 	char *name;
 	size_t conn_cnt;
-	size_t snk_cnt[BAP_UNICAST_AC_MAX_CONN];
-	size_t src_cnt[BAP_UNICAST_AC_MAX_CONN];
-	size_t snk_chan_cnt;
-	size_t src_chan_cnt;
+	struct cap_unicast_ac_conn_param conn_param[BAP_UNICAST_AC_MAX_CONN];
 };
 
 extern struct unicast_group default_unicast_group;

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -609,29 +609,42 @@ static int cap_ac_unicast_start(const struct cap_unicast_ac_param *param,
 	size_t src_ep_cnt = 0U;
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-#if UNICAST_SINK_SUPPORTED
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			snk_eps[snk_ep_cnt] = snks[bt_conn_index(connected_conns[i])][j];
-			if (snk_eps[snk_ep_cnt] == NULL) {
-				bt_shell_error("No sink[%zu][%zu] endpoint available", i, j);
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
+		size_t conn_snk_ep_cnt = 0U;
+		size_t conn_src_ep_cnt = 0U;
 
-				return -ENOEXEC;
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
+
+			if (cis_param->has_snk &&
+			    IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)) {
+				snk_eps[snk_ep_cnt] =
+					snks[bt_conn_index(connected_conns[i])][conn_snk_ep_cnt];
+				if (snk_eps[snk_ep_cnt] == NULL) {
+					bt_shell_error("No sink[%zu][%zu] endpoint available", i,
+						       conn_snk_ep_cnt);
+
+					return -ENOEXEC;
+				}
+				conn_snk_ep_cnt++;
+				snk_ep_cnt++;
 			}
-			snk_ep_cnt++;
-		}
-#endif /* UNICAST_SINK_SUPPORTED */
 
-#if UNICAST_SRC_SUPPORTED
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			src_eps[src_ep_cnt] = srcs[bt_conn_index(connected_conns[i])][j];
-			if (src_eps[src_ep_cnt] == NULL) {
-				bt_shell_error("No source[%zu][%zu] endpoint available", i, j);
+			if (cis_param->has_src &&
+			    IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)) {
+				src_eps[src_ep_cnt] =
+					srcs[bt_conn_index(connected_conns[i])][conn_src_ep_cnt];
+				if (src_eps[src_ep_cnt] == NULL) {
+					bt_shell_error("No source[%zu][%zu] endpoint available", i,
+						       conn_src_ep_cnt);
 
-				return -ENOEXEC;
+					return -ENOEXEC;
+				}
+				conn_src_ep_cnt++;
+				src_ep_cnt++;
 			}
-			src_ep_cnt++;
 		}
-#endif /* UNICAST_SRC_SUPPORTED  */
 	}
 
 	if (snk_ep_cnt != snk_cnt) {
@@ -668,30 +681,37 @@ static int cap_ac_unicast_start(const struct cap_unicast_ac_param *param,
 
 	/* CAP Start */
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			struct bt_cap_unicast_audio_start_stream_param *stream_param =
-				&cap_initiator_audio_start_stream_params[stream_cnt];
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
 
-			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = snk_codec_cfgs[snk_stream_cnt];
-			stream_param->ep = snk_eps[snk_stream_cnt];
-			stream_param->stream = snk_cap_streams[snk_stream_cnt];
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
 
-			snk_stream_cnt++;
-			stream_cnt++;
-		}
+			if (cis_param->has_snk) {
+				struct bt_cap_unicast_audio_start_stream_param *stream_param =
+					&cap_initiator_audio_start_stream_params[stream_cnt];
 
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			struct bt_cap_unicast_audio_start_stream_param *stream_param =
-				&cap_initiator_audio_start_stream_params[stream_cnt];
+				stream_param->member.member = connected_conns[i];
+				stream_param->codec_cfg = snk_codec_cfgs[snk_stream_cnt];
+				stream_param->ep = snk_eps[snk_stream_cnt];
+				stream_param->stream = snk_cap_streams[snk_stream_cnt];
 
-			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = src_codec_cfgs[src_stream_cnt];
-			stream_param->ep = src_eps[src_stream_cnt];
-			stream_param->stream = src_cap_streams[src_stream_cnt];
+				snk_stream_cnt++;
+				stream_cnt++;
+			}
 
-			src_stream_cnt++;
-			stream_cnt++;
+			if (cis_param->has_src) {
+				struct bt_cap_unicast_audio_start_stream_param *stream_param =
+					&cap_initiator_audio_start_stream_params[stream_cnt];
+
+				stream_param->member.member = connected_conns[i];
+				stream_param->codec_cfg = src_codec_cfgs[src_stream_cnt];
+				stream_param->ep = src_eps[src_stream_cnt];
+				stream_param->stream = src_cap_streams[src_stream_cnt];
+
+				src_stream_cnt++;
+				stream_cnt++;
+			}
 		}
 	}
 
@@ -704,60 +724,20 @@ static int cap_ac_unicast_start(const struct cap_unicast_ac_param *param,
 }
 
 static int set_unicast_codec_config(const struct shell *sh, struct shell_stream *sh_stream,
-				    struct named_lc3_preset *preset, size_t conn_cnt, size_t ep_cnt,
-				    size_t chan_cnt, size_t conn_index, size_t ep_index)
+				    struct named_lc3_preset *preset,
+				    enum bt_audio_location location, size_t conn_index,
+				    size_t ep_index)
 {
-	enum bt_audio_location new_chan_alloc;
 	enum bt_audio_location chan_alloc;
 	int err;
 
 	copy_unicast_stream_preset(sh_stream, preset);
 
-	if (chan_cnt == 1U) {
-		/* - When we have a single channel on a single connection then we make it mono
-		 * - When we have a single channel on a multiple connections then we make it left on
-		 *   the first connection and right on the second connection
-		 * - When we have multiple channels streams for a connection, we make them either
-		 *   left or right, regardless of the connection count
-		 */
-		if (ep_cnt == 1) {
-			if (conn_cnt == 1) {
-				new_chan_alloc = BT_AUDIO_LOCATION_MONO_AUDIO;
-			} else if (conn_cnt == 2) {
-				if (conn_index == 0) {
-					new_chan_alloc = BT_AUDIO_LOCATION_FRONT_LEFT;
-				} else if (conn_index == 1) {
-					new_chan_alloc = BT_AUDIO_LOCATION_FRONT_RIGHT;
-				} else {
-					return 0;
-				}
-			} else {
-				return 0;
-			}
-		} else if (ep_cnt == 2) {
-			if (ep_index == 0) {
-				new_chan_alloc = BT_AUDIO_LOCATION_FRONT_LEFT;
-			} else if (ep_index == 1) {
-				new_chan_alloc = BT_AUDIO_LOCATION_FRONT_RIGHT;
-			} else {
-				return 0;
-			}
-		} else {
-			return 0;
-		}
-	} else if (chan_cnt == 2U) {
+	if (location != BT_AUDIO_LOCATION_MONO_AUDIO) {
 		/* Some audio configuration requires multiple sink channels,
 		 * so multiply the SDU based on the channel count
 		 */
-		sh_stream->qos.sdu *= chan_cnt;
-
-		/* If a stream has 2 channels, we make it stereo */
-		new_chan_alloc = BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT;
-
-	} else {
-		shell_error(sh, "Could not set chan alloc for chan_cnt %zu", chan_cnt);
-
-		return -EINVAL;
+		sh_stream->qos.sdu *= sys_count_bits(&location, sizeof(location));
 	}
 
 	err = bt_audio_codec_cfg_get_chan_allocation(&sh_stream->codec_cfg, &chan_alloc, false);
@@ -772,13 +752,13 @@ static int set_unicast_codec_config(const struct shell *sh, struct shell_stream 
 		}
 	}
 
-	if (chan_alloc != new_chan_alloc) {
-		shell_info(sh,
-			   "[%zu][%zu]: Overwriting existing channel allocation 0x%08X with 0x%08X "
-			   "for conn_cnt %zu and chan_cnt %zu",
-			   conn_index, ep_index, chan_alloc, new_chan_alloc, conn_cnt, chan_cnt);
+	if (chan_alloc != location) {
+		shell_info(
+			sh,
+			"[%zu][%zu]: Overwriting existing channel allocation 0x%08X with 0x%08X ",
+			conn_index, ep_index, chan_alloc, location);
 
-		err = bt_audio_codec_cfg_set_chan_allocation(&sh_stream->codec_cfg, new_chan_alloc);
+		err = bt_audio_codec_cfg_set_chan_allocation(&sh_stream->codec_cfg, location);
 		if (err < 0) {
 			return err;
 		}
@@ -832,11 +812,15 @@ static int cap_ac_create_unicast_group(const struct cap_unicast_ac_param *param,
 	}
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < MAX(param->snk_cnt[i], param->src_cnt[i]); j++) {
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
+
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
 			struct bt_cap_unicast_group_stream_pair_param *stream_pair_param =
 				&cap_initiator_unicast_group_pair_params[pair_cnt];
 
-			if (param->snk_cnt[i] > j) {
+			if (cis_param->has_snk) {
 				stream_pair_param->tx_param =
 					&snk_group_stream_params[snk_stream_cnt];
 				snk_stream_cnt++;
@@ -844,7 +828,7 @@ static int cap_ac_create_unicast_group(const struct cap_unicast_ac_param *param,
 				stream_pair_param->tx_param = NULL;
 			}
 
-			if (param->src_cnt[i] > j) {
+			if (cis_param->has_src) {
 				stream_pair_param->rx_param =
 					&src_group_stream_params[src_stream_cnt];
 				src_stream_cnt++;
@@ -876,8 +860,9 @@ int cap_ac_unicast(const struct shell *sh, const struct cap_unicast_ac_param *pa
 	struct shell_stream *snk_uni_streams[BAP_UNICAST_AC_MAX_SNK];
 	struct shell_stream *src_uni_streams[BAP_UNICAST_AC_MAX_SRC];
 	size_t conn_avail_cnt;
-	size_t snk_cnt = 0U;
-	size_t src_cnt = 0U;
+	size_t total_snk_cnt;
+	size_t total_src_cnt;
+	size_t total_cis_cnt;
 	size_t total_cnt;
 	int err;
 
@@ -900,23 +885,77 @@ int cap_ac_unicast(const struct shell *sh, const struct cap_unicast_ac_param *pa
 	}
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
+	total_snk_cnt = 0U;
+	total_src_cnt = 0U;
+	total_cis_cnt = 0U;
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
+
+		if (conn_param->cis_cnt > BAP_UNICAST_AC_MAX_SNK) {
+			shell_error(sh, "Invalid param->conn_param[%zu].cis_cnt: %zu", i,
+				    conn_param->cis_cnt);
+			return -ENOEXEC;
+		}
+
+		if (conn_param->cis_cnt > BAP_UNICAST_AC_MAX_SRC) {
+			shell_error(sh, "Invalid param->conn_param[%zu].cis_cnt: %zu", i,
+				    conn_param->cis_cnt);
+			return -ENOEXEC;
+		}
+
 		/* Verify conn values */
-		if (param->snk_cnt[i] > BAP_UNICAST_AC_MAX_SNK) {
-			shell_error(sh, "Invalid conn_snk_cnt[%zu]: %zu", i, param->snk_cnt[i]);
-			return -ENOEXEC;
-		}
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
 
-		if (param->src_cnt[i] > BAP_UNICAST_AC_MAX_SRC) {
-			shell_error(sh, "Invalid conn_src_cnt[%zu]: %zu", i, param->src_cnt[i]);
-			return -ENOEXEC;
-		}
+			if (cis_param->has_snk) {
+				total_snk_cnt++;
+				if (total_snk_cnt > BAP_UNICAST_AC_MAX_SNK) {
+					shell_error(sh, "Invalid total_snk_cnt: %zu",
+						    total_snk_cnt);
+					return -ENOEXEC;
+				}
 
-		total_cnt += param->snk_cnt[i] + param->src_cnt[i];
-		if (total_cnt > ARRAY_SIZE(unicast_streams)) {
-			shell_error(sh, "Cannot start %zu streams (max supported is %zu)",
-				    total_cnt, ARRAY_SIZE(unicast_streams));
-			return -ENOEXEC;
+				if (!IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)) {
+					shell_error(sh,
+						    "Invalid "
+						    "param->conn_param[%zu].cis_param[%zu].has_snk",
+						    i, j);
+					return -ENOEXEC;
+				}
+			}
+
+			if (cis_param->has_src) {
+				total_src_cnt++;
+				if (total_src_cnt > BAP_UNICAST_AC_MAX_SRC) {
+					shell_error(sh, "Invalid total_src_cnt: %zu",
+						    total_src_cnt);
+					return -ENOEXEC;
+				}
+
+				if (!IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)) {
+					shell_error(sh,
+						    "Invalid "
+						    "param->conn_param[%zu].cis_param[%zu]."
+						    "has_snk",
+						    i, j);
+					return -ENOEXEC;
+				}
+			}
+
+			total_cis_cnt++;
+			if (total_cis_cnt > BAP_UNICAST_AC_MAX_PAIR) {
+				shell_error(sh, "Invalid total_cis_cnt: %zu", total_cis_cnt);
+				return -ENOEXEC;
+			}
+
+			total_cnt +=
+				(cis_param->has_snk ? 1U : 0U) + (cis_param->has_src ? 1U : 0U);
+			if (total_cnt > ARRAY_SIZE(unicast_streams)) {
+				shell_error(sh, "Cannot start %zu streams (max supported is %zu)",
+					    total_cnt, ARRAY_SIZE(unicast_streams));
+				return -ENOEXEC;
+			}
 		}
 	}
 
@@ -940,55 +979,63 @@ int cap_ac_unicast(const struct shell *sh, const struct cap_unicast_ac_param *pa
 	 * endpoints matches the audio configuration
 	 */
 	total_cnt = 0U;
+	total_snk_cnt = 0U;
+	total_src_cnt = 0U;
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			struct shell_stream *snk_uni_stream;
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
 
-			snk_uni_stream = snk_uni_streams[snk_cnt] = &unicast_streams[total_cnt];
+		/* Verify conn values */
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
 
-			err = set_unicast_codec_config(sh, snk_uni_stream, &default_sink_preset,
-						       param->conn_cnt, param->snk_cnt[i],
-						       param->snk_chan_cnt, i, j);
-			if (err != 0) {
-				shell_error(sh, "Failed to set codec configuration: %d", err);
+			if (cis_param->has_snk) {
+				snk_uni_streams[total_snk_cnt] = &unicast_streams[total_cnt];
 
-				return -ENOEXEC;
+				err = set_unicast_codec_config(sh, snk_uni_streams[total_snk_cnt],
+							       &default_sink_preset,
+							       cis_param->snk_loc, i, j);
+				if (err != 0) {
+					shell_error(sh, "Failed to set codec configuration: %d",
+						    err);
+
+					return -ENOEXEC;
+				}
+
+				total_snk_cnt++;
+				total_cnt++;
 			}
 
-			snk_cnt++;
-			total_cnt++;
-		}
+			if (cis_param->has_src) {
+				src_uni_streams[total_src_cnt] = &unicast_streams[total_cnt];
 
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			struct shell_stream *src_uni_stream;
+				err = set_unicast_codec_config(sh, src_uni_streams[total_src_cnt],
+							       &default_source_preset,
+							       cis_param->src_loc, i, j);
+				if (err != 0) {
+					shell_error(sh, "Failed to set codec configuration: %d",
+						    err);
 
-			src_uni_stream = src_uni_streams[src_cnt] = &unicast_streams[total_cnt];
+					return -ENOEXEC;
+				}
 
-			err = set_unicast_codec_config(sh, src_uni_stream, &default_source_preset,
-						       param->conn_cnt, param->src_cnt[i],
-						       param->src_chan_cnt, i, j);
-			if (err != 0) {
-				shell_error(sh, "Failed to set codec configuration: %d", err);
-
-				return -ENOEXEC;
+				total_src_cnt++;
+				total_cnt++;
 			}
-
-			src_cnt++;
-			total_cnt++;
 		}
 	}
 
-	err = cap_ac_create_unicast_group(param, snk_uni_streams, snk_cnt, src_uni_streams,
-					  src_cnt);
+	err = cap_ac_create_unicast_group(param, snk_uni_streams, total_snk_cnt, src_uni_streams,
+					  total_src_cnt);
 	if (err != 0) {
 		shell_error(sh, "Failed to create group: %d", err);
 
 		return -ENOEXEC;
 	}
 
-	shell_print(sh, "Starting %zu streams for %s", snk_cnt + src_cnt, param->name);
-	err = cap_ac_unicast_start(param, connected_conns, snk_uni_streams, snk_cnt,
-				   src_uni_streams, src_cnt);
+	shell_print(sh, "Starting %zu streams for %s", total_snk_cnt + total_src_cnt, param->name);
+	err = cap_ac_unicast_start(param, connected_conns, snk_uni_streams, total_snk_cnt,
+				   src_uni_streams, total_src_cnt);
 	if (err != 0) {
 		shell_error(sh, "Failed to start unicast audio: %d", err);
 
@@ -1012,10 +1059,12 @@ static int cmd_cap_ac_1(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_1",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -1031,10 +1080,12 @@ static int cmd_cap_ac_2(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_2",
 		.conn_cnt = 1U,
-		.snk_cnt = {0U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -1050,10 +1101,13 @@ static int cmd_cap_ac_3(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_3",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -1069,10 +1123,13 @@ static int cmd_cap_ac_4(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_4",
 		.conn_cnt = 1,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 2U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -1088,10 +1145,14 @@ static int cmd_cap_ac_5(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_5",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 2U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -1108,10 +1169,16 @@ static int cmd_cap_ac_6_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_6_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -1127,10 +1194,18 @@ static int cmd_cap_ac_6_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_6_II",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {0U, 0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -1147,10 +1222,16 @@ static int cmd_cap_ac_7_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_7_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U}, /* TODO: These should be separate CIS */
-		.src_cnt = {1U}, /* TODO: These should be separate CIS */
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = false,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -1165,10 +1246,18 @@ static int cmd_cap_ac_7_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_7_II",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 0U},
-		.src_cnt = {0U, 1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = false,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -1184,10 +1273,17 @@ static int cmd_cap_ac_8_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_8_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -1203,10 +1299,19 @@ static int cmd_cap_ac_8_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_8_II",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -1222,10 +1327,16 @@ static int cmd_cap_ac_9_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_9_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {0U},
-		.src_cnt = {2U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[0].cis_param[1].has_snk = false,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
 	};
 
 	ARG_UNUSED(argc);
@@ -1241,10 +1352,18 @@ static int cmd_cap_ac_9_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_9_II",
 		.conn_cnt = 2U,
-		.snk_cnt = {0U, 0U},
-		.src_cnt = {1U, 1U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = false,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
 	};
 
 	ARG_UNUSED(argc);
@@ -1260,10 +1379,13 @@ static int cmd_cap_ac_10(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_10",
 		.conn_cnt = 1U,
-		.snk_cnt = {0U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 2U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
 	};
 
 	ARG_UNUSED(argc);
@@ -1279,10 +1401,18 @@ static int cmd_cap_ac_11_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_11_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {2U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
 	};
 
 	ARG_UNUSED(argc);
@@ -1300,10 +1430,20 @@ static int cmd_cap_ac_11_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_11_II",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
 	};
 
 	ARG_UNUSED(argc);

--- a/subsys/bluetooth/audio/shell/gmap.c
+++ b/subsys/bluetooth/audio/shell/gmap.c
@@ -316,10 +316,12 @@ static int cmd_gmap_ac_1(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_1",
 		.conn_cnt = 1,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -335,10 +337,12 @@ static int cmd_gmap_ac_2(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_2",
 		.conn_cnt = 1,
-		.snk_cnt = {0U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -354,10 +358,13 @@ static int cmd_gmap_ac_3(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_3",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -373,10 +380,13 @@ static int cmd_gmap_ac_4(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_4",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 2U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -392,10 +402,14 @@ static int cmd_gmap_ac_5(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_5",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 2U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -412,10 +426,16 @@ static int cmd_gmap_ac_6_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_6_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -431,10 +451,18 @@ static int cmd_gmap_ac_6_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_6_II",
 		.conn_cnt = 2,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {0U, 0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = false,
 	};
 
 	ARG_UNUSED(argc);
@@ -452,10 +480,18 @@ static int cmd_gmap_ac_7_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_7_II",
 		.conn_cnt = 2,
-		.snk_cnt = {1U, 0U},
-		.src_cnt = {0U, 1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = false,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -471,10 +507,17 @@ static int cmd_gmap_ac_8_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_8_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -490,10 +533,19 @@ static int cmd_gmap_ac_8_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_8_II",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
 	};
 
 	ARG_UNUSED(argc);
@@ -509,10 +561,18 @@ static int cmd_gmap_ac_11_i(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_11_I",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {2U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
 	};
 
 	ARG_UNUSED(argc);
@@ -530,10 +590,20 @@ static int cmd_gmap_ac_11_ii(const struct shell *sh, size_t argc, char **argv)
 	const struct cap_unicast_ac_param param = {
 		.name = "AC_11_II",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
 	};
 
 	ARG_UNUSED(argc);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -58,13 +58,22 @@ LOG_MODULE_REGISTER(cap_initiator_unicast_test);
 #define CONTEXT  (BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED)
 #define LOCATION (BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT)
 
-struct cap_initiator_ac_param {
+struct cap_unicast_ac_cis_param {
+	bool has_snk;
+	bool has_src;
+	enum bt_audio_location snk_loc;
+	enum bt_audio_location src_loc;
+};
+
+struct cap_unicast_ac_conn_param {
+	size_t cis_cnt;
+	struct cap_unicast_ac_cis_param cis_param[CAP_AC_MAX_PAIR];
+};
+
+struct cap_unicast_ac_param {
 	char *name;
 	size_t conn_cnt;
-	size_t snk_cnt[CAP_AC_MAX_CONN];
-	size_t src_cnt[CAP_AC_MAX_CONN];
-	size_t snk_chan_cnt;
-	size_t src_chan_cnt;
+	struct cap_unicast_ac_conn_param conn_param[CAP_AC_MAX_CONN];
 	const struct named_lc3_preset *snk_named_preset;
 	const struct named_lc3_preset *src_named_preset;
 };
@@ -1219,7 +1228,7 @@ static const struct named_lc3_preset *cap_get_named_preset(const char *preset_ar
 	return NULL;
 }
 
-static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_param *param,
+static int cap_initiator_ac_create_unicast_group(const struct cap_unicast_ac_param *param,
 						 struct unicast_stream *snk_uni_streams[],
 						 size_t snk_cnt,
 						 struct unicast_stream *src_uni_streams[],
@@ -1250,6 +1259,7 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_p
 	 * and direction
 	 */
 	for (size_t i = 0U; i < snk_cnt; i++) {
+
 		snk_group_stream_params[i].qos_cfg = snk_qos[i];
 		snk_group_stream_params[i].stream =
 			cap_stream_from_audio_test_stream(&snk_uni_streams[i]->stream);
@@ -1258,11 +1268,18 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_p
 		src_group_stream_params[i].qos_cfg = src_qos[i];
 		src_group_stream_params[i].stream =
 			cap_stream_from_audio_test_stream(&src_uni_streams[i]->stream);
+
+		LOG_ERR("%zu %zu %p", i, src_cnt, src_group_stream_params[i].stream);
 	}
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < MAX(param->snk_cnt[i], param->src_cnt[i]); j++) {
-			if (param->snk_cnt[i] > j) {
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
+
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
+
+			if (cis_param->has_snk) {
 				pair_params[pair_cnt].tx_param =
 					&snk_group_stream_params[snk_stream_cnt];
 				snk_stream_cnt++;
@@ -1270,7 +1287,7 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_p
 				pair_params[pair_cnt].tx_param = NULL;
 			}
 
-			if (param->src_cnt[i] > j) {
+			if (cis_param->has_src) {
 				pair_params[pair_cnt].rx_param =
 					&src_group_stream_params[src_stream_cnt];
 				src_stream_cnt++;
@@ -1289,7 +1306,7 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_p
 	return bt_cap_unicast_group_create(&group_param, unicast_group);
 }
 
-static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_param *param,
+static int cap_initiator_ac_cap_unicast_start(const struct cap_unicast_ac_param *param,
 					      struct unicast_stream *snk_uni_streams[],
 					      size_t snk_cnt,
 					      struct unicast_stream *src_uni_streams[],
@@ -1313,30 +1330,39 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 	ARG_UNUSED(unicast_group);
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		const uint8_t conn_index = bt_conn_index(connected_conns[i]);
-#if UNICAST_SINK_SUPPORTED
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			snk_eps[snk_ep_cnt] = unicast_sink_eps[conn_index][j];
-			if (snk_eps[snk_ep_cnt] == NULL) {
-				FAIL("No sink[%u][%zu] endpoint available\n", conn_index, j);
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
+		size_t conn_snk_ep_cnt = 0U;
+		size_t conn_src_ep_cnt = 0U;
 
-				return -ENODEV;
+		/* Verify conn values */
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
+
+			if (cis_param->has_snk) {
+				snk_eps[snk_ep_cnt] = unicast_sink_eps[i][conn_snk_ep_cnt];
+				if (snk_eps[snk_ep_cnt] == NULL) {
+					FAIL("No sink[%u][%zu] endpoint available\n", i,
+					     conn_snk_ep_cnt);
+
+					return -ENODEV;
+				}
+				conn_snk_ep_cnt++;
+				snk_ep_cnt++;
 			}
-			snk_ep_cnt++;
-		}
-#endif /* UNICAST_SINK_SUPPORTED */
 
-#if UNICAST_SRC_SUPPORTED
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			src_eps[src_ep_cnt] = unicast_source_eps[conn_index][j];
-			if (src_eps[src_ep_cnt] == NULL) {
-				FAIL("No source[%u][%zu] endpoint available\n", conn_index, j);
+			if (cis_param->has_src) {
+				src_eps[src_ep_cnt] = unicast_source_eps[i][conn_src_ep_cnt];
+				if (src_eps[src_ep_cnt] == NULL) {
+					FAIL("No source[%u][%zu] endpoint available\n", i,
+					     conn_src_ep_cnt);
 
-				return -ENODEV;
+					return -ENODEV;
+				}
+				conn_src_ep_cnt++;
+				src_ep_cnt++;
 			}
-			src_ep_cnt++;
 		}
-#endif /* UNICAST_SRC_SUPPORTED > 0 */
 	}
 
 	if (snk_ep_cnt != snk_cnt) {
@@ -1367,55 +1393,54 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 
 	/* CAP Start */
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			struct bt_cap_unicast_audio_start_stream_param *stream_param =
-				&stream_params[stream_cnt];
-			struct bt_audio_codec_cfg *codec_cfg = snk_codec_cfgs[snk_stream_cnt];
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
 
-			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = codec_cfg;
-			stream_param->ep = snk_eps[snk_stream_cnt];
-			stream_param->stream = snk_cap_streams[snk_stream_cnt];
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
 
-			snk_stream_cnt++;
-			stream_cnt++;
+			if (cis_param->has_snk) {
+				struct bt_cap_unicast_audio_start_stream_param *stream_param =
+					&stream_params[stream_cnt];
+				struct bt_audio_codec_cfg *codec_cfg =
+					snk_codec_cfgs[snk_stream_cnt];
+				int err;
 
-			/* If we have more than 1 connection or stream in one direction, we set the
-			 * location bit accordingly
-			 */
-			if (param->conn_cnt > 1U || param->snk_cnt[i] > 1U) {
-				const int err = bt_audio_codec_cfg_set_chan_allocation(
-					codec_cfg, (enum bt_audio_location)BIT(i));
+				stream_param->member.member = connected_conns[i];
+				stream_param->codec_cfg = codec_cfg;
+				stream_param->ep = snk_eps[snk_stream_cnt];
+				stream_param->stream = snk_cap_streams[snk_stream_cnt];
 
+				snk_stream_cnt++;
+				stream_cnt++;
+
+				err = bt_audio_codec_cfg_set_chan_allocation(codec_cfg,
+									     cis_param->snk_loc);
 				if (err < 0) {
-					FAIL("Failed to set channel allocation: %d\n", err);
+					FAIL("Failed to set snk channel allocation: %d\n", err);
 					return err;
 				}
 			}
-		}
 
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			struct bt_cap_unicast_audio_start_stream_param *stream_param =
-				&stream_params[stream_cnt];
-			struct bt_audio_codec_cfg *codec_cfg = src_codec_cfgs[src_stream_cnt];
+			if (cis_param->has_src) {
+				struct bt_cap_unicast_audio_start_stream_param *stream_param =
+					&stream_params[stream_cnt];
+				struct bt_audio_codec_cfg *codec_cfg =
+					src_codec_cfgs[src_stream_cnt];
+				int err;
 
-			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = codec_cfg;
-			stream_param->ep = src_eps[src_stream_cnt];
-			stream_param->stream = src_cap_streams[src_stream_cnt];
+				stream_param->member.member = connected_conns[i];
+				stream_param->codec_cfg = codec_cfg;
+				stream_param->ep = src_eps[src_stream_cnt];
+				stream_param->stream = src_cap_streams[src_stream_cnt];
 
-			src_stream_cnt++;
-			stream_cnt++;
+				src_stream_cnt++;
+				stream_cnt++;
 
-			/* If we have more than 1 connection or stream in one direction, we set the
-			 * location bit accordingly
-			 */
-			if (param->conn_cnt > 1U || param->src_cnt[i] > 1U) {
-				const int err = bt_audio_codec_cfg_set_chan_allocation(
-					codec_cfg, (enum bt_audio_location)BIT(i));
-
+				err = bt_audio_codec_cfg_set_chan_allocation(codec_cfg,
+									     cis_param->src_loc);
 				if (err < 0) {
-					FAIL("Failed to set channel allocation: %d\n", err);
+					FAIL("Failed to set src channel allocation: %d\n", err);
 					return err;
 				}
 			}
@@ -1429,87 +1454,78 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 	return bt_cap_initiator_unicast_audio_start(&start_param);
 }
 
-static int cap_initiator_ac_unicast(const struct cap_initiator_ac_param *param,
+static int cap_initiator_ac_unicast(const struct cap_unicast_ac_param *param,
 				    struct bt_cap_unicast_group **unicast_group)
 {
 	/* Allocate params large enough for any params, but only use what is required */
 	struct unicast_stream *snk_uni_streams[CAP_AC_MAX_SNK];
 	struct unicast_stream *src_uni_streams[CAP_AC_MAX_SRC];
-	size_t snk_cnt = 0U;
-	size_t src_cnt = 0U;
+	size_t total_snk_cnt = 0U;
+	size_t total_src_cnt = 0U;
+	size_t total_cnt = 0U;
 	int err;
-
-	if (param->conn_cnt > CAP_AC_MAX_CONN) {
-		FAIL("Invalid conn_cnt: %zu\n", param->conn_cnt);
-
-		return -EINVAL;
-	}
-
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		/* Verify conn values */
-		if (param->snk_cnt[i] > CAP_AC_MAX_SNK) {
-			FAIL("Invalid param->snk_cnt[%zu]: %zu\n", i, param->snk_cnt[i]);
-
-			return -EINVAL;
-		}
-
-		if (param->src_cnt[i] > CAP_AC_MAX_SRC) {
-			FAIL("Invalid param->src_cnt[%zu]: %zu\n", i, param->src_cnt[i]);
-
-			return -EINVAL;
-		}
-	}
 
 	/* Set all endpoints from multiple connections in a single array, and verify that the known
 	 * endpoints matches the audio configuration
 	 */
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			snk_cnt++;
-		}
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
 
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			src_cnt++;
+		/* Verify conn values */
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
+
+			if (cis_param->has_snk) {
+				snk_uni_streams[total_snk_cnt] = &unicast_streams[total_cnt];
+
+				if (param->snk_named_preset == NULL) {
+					FAIL("No sink preset available\n");
+					return -EINVAL;
+				}
+
+				copy_unicast_stream_preset(snk_uni_streams[total_snk_cnt],
+							   param->snk_named_preset);
+
+				if (cis_param->snk_loc != BT_AUDIO_LOCATION_MONO_AUDIO) {
+					/* Some audio configuration requires multiple channels,
+					 * so multiply the SDU based on the channel count
+					 */
+					snk_uni_streams[total_snk_cnt]->qos.sdu *= sys_count_bits(
+						&cis_param->snk_loc, sizeof(cis_param->snk_loc));
+				}
+
+				total_snk_cnt++;
+				total_cnt++;
+			}
+
+			if (cis_param->has_src) {
+				src_uni_streams[total_src_cnt] = &unicast_streams[total_cnt];
+
+				if (param->src_named_preset == NULL) {
+					FAIL("No source preset available\n");
+					return -EINVAL;
+				}
+
+				copy_unicast_stream_preset(src_uni_streams[total_src_cnt],
+							   param->src_named_preset);
+
+				if (cis_param->src_loc != BT_AUDIO_LOCATION_MONO_AUDIO) {
+					/* Some audio configuration requires multiple channels,
+					 * so multiply the SDU based on the channel count
+					 */
+					src_uni_streams[total_src_cnt]->qos.sdu *= sys_count_bits(
+						&cis_param->src_loc, sizeof(cis_param->src_loc));
+				}
+
+				total_src_cnt++;
+				total_cnt++;
+			}
 		}
 	}
 
-	/* Setup arrays of parameters based on the preset for easier access. This also copies the
-	 * preset so that we can modify them (e.g. update the metadata)
-	 */
-	for (size_t i = 0U; i < snk_cnt; i++) {
-		snk_uni_streams[i] = &unicast_streams[i];
-
-		if (param->snk_named_preset == NULL) {
-			FAIL("No sink preset available\n");
-			return -EINVAL;
-		}
-
-		copy_unicast_stream_preset(snk_uni_streams[i], param->snk_named_preset);
-
-		/* Some audio configuration requires multiple sink channels,
-		 * so multiply the SDU based on the channel count
-		 */
-		snk_uni_streams[i]->qos.sdu *= param->snk_chan_cnt;
-	}
-
-	for (size_t i = 0U; i < src_cnt; i++) {
-		src_uni_streams[i] = &unicast_streams[i + snk_cnt];
-
-		if (param->src_named_preset == NULL) {
-			FAIL("No sink preset available\n");
-			return -EINVAL;
-		}
-
-		copy_unicast_stream_preset(src_uni_streams[i], param->src_named_preset);
-
-		/* Some audio configuration requires multiple source channels,
-		 * so multiply the SDU based on the channel count
-		 */
-		src_uni_streams[i]->qos.sdu *= param->src_chan_cnt;
-	}
-
-	err = cap_initiator_ac_create_unicast_group(param, snk_uni_streams, snk_cnt,
-						    src_uni_streams, src_cnt, unicast_group);
+	err = cap_initiator_ac_create_unicast_group(param, snk_uni_streams, total_snk_cnt,
+						    src_uni_streams, total_src_cnt, unicast_group);
 	if (err != 0) {
 		FAIL("Failed to create group: %d\n", err);
 
@@ -1518,9 +1534,9 @@ static int cap_initiator_ac_unicast(const struct cap_initiator_ac_param *param,
 
 	UNSET_FLAG(flag_started);
 
-	LOG_INF("Starting %zu streams for %s", snk_cnt + src_cnt, param->name);
-	err = cap_initiator_ac_cap_unicast_start(param, snk_uni_streams, snk_cnt, src_uni_streams,
-						 src_cnt, *unicast_group);
+	LOG_INF("Starting %zu streams for %s", total_snk_cnt + total_src_cnt, param->name);
+	err = cap_initiator_ac_cap_unicast_start(param, snk_uni_streams, total_snk_cnt,
+						 src_uni_streams, total_src_cnt, *unicast_group);
 	if (err != 0) {
 		FAIL("Failed to start unicast audio: %d\n\n", err);
 
@@ -1533,11 +1549,15 @@ static int cap_initiator_ac_unicast(const struct cap_initiator_ac_param *param,
 	return 0;
 }
 
-static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
+static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
 {
 	struct bt_cap_unicast_group *unicast_group;
 	bool expect_tx = false;
 	bool expect_rx = false;
+	size_t total_snk_cnt;
+	size_t total_src_cnt;
+	size_t total_cis_cnt;
+	size_t total_cnt;
 
 	LOG_INF("Running test for %s with Sink Preset %s and Source Preset %s", param->name,
 	       param->snk_named_preset != NULL ? param->snk_named_preset->name : "None",
@@ -1551,6 +1571,80 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	if (param->snk_named_preset == NULL && param->src_named_preset == NULL) {
 		FAIL("No presets available\n");
 		return;
+	}
+
+	total_cnt = 0U;
+	total_snk_cnt = 0U;
+	total_src_cnt = 0U;
+	total_cis_cnt = 0U;
+	for (size_t i = 0U; i < param->conn_cnt; i++) {
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
+
+		if (conn_param->cis_cnt > CAP_AC_MAX_PAIR) {
+			FAIL("Invalid param->conn_param[%zu].cis_cnt: %zu", i, conn_param->cis_cnt);
+
+			return;
+		}
+
+		if (conn_param->cis_cnt > CAP_AC_MAX_PAIR) {
+			FAIL("Invalid param->conn_param[%zu].cis_cnt: %zu", i, conn_param->cis_cnt);
+
+			return;
+		}
+
+		/* Verify conn values */
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
+
+			if (cis_param->has_snk) {
+				total_snk_cnt++;
+				if (total_snk_cnt > CAP_AC_MAX_SNK) {
+					FAIL("Invalid total_snk_cnt: %zu\n", total_snk_cnt);
+					return;
+				}
+
+				if (!IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)) {
+					FAIL("Invalid "
+					     "param->conn_param[%zu].cis_param[%zu].has_snk",
+					     i, j);
+
+					return;
+				}
+			}
+
+			if (cis_param->has_src) {
+				total_src_cnt++;
+				if (total_src_cnt > CAP_AC_MAX_SRC) {
+					FAIL("Invalid total_src_cnt: %zu\n", total_src_cnt);
+					return;
+				}
+
+				if (!IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)) {
+					FAIL("Invalid "
+					     "param->conn_param[%zu].cis_param[%zu].has_snk",
+					     i, j);
+
+					return;
+				}
+			}
+
+			total_cis_cnt++;
+			if (total_cis_cnt > CAP_AC_MAX_PAIR) {
+				FAIL("Invalid total_cis_cnt: %zu\n", total_cis_cnt);
+
+				return;
+			}
+
+			total_cnt +=
+				(cis_param->has_snk ? 1U : 0U) + (cis_param->has_src ? 1U : 0U);
+			if (total_cnt > ARRAY_SIZE(unicast_streams)) {
+				FAIL("Cannot start %zu streams (max supported is %zu)", total_cnt,
+				     ARRAY_SIZE(unicast_streams));
+
+				return;
+			}
+		}
 	}
 
 	init();
@@ -1573,18 +1667,27 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	}
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
+		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
+		bool discovered_snk = false;
+		bool discovered_src = false;
+
 		update_security(connected_conns[i]);
 
 		discover_cas(connected_conns[i]);
 
-		if (param->snk_cnt[i] > 0U) {
-			discover_sink(connected_conns[i]);
-			expect_tx = true;
-		}
+		for (size_t j = 0U; j < conn_param->cis_cnt; j++) {
+			const struct cap_unicast_ac_cis_param *cis_param =
+				&conn_param->cis_param[j];
 
-		if (param->src_cnt[i] > 0U) {
-			discover_source(connected_conns[i]);
-			expect_rx = true;
+			if (cis_param->has_snk && !discovered_snk) {
+				discover_sink(connected_conns[i]);
+				expect_tx = true;
+			}
+
+			if (cis_param->has_src && !discovered_src) {
+				discover_source(connected_conns[i]);
+				expect_rx = true;
+			}
 		}
 	}
 
@@ -1623,13 +1726,16 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 
 static void test_cap_initiator_ac_1(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_1",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
@@ -1639,13 +1745,16 @@ static void test_cap_initiator_ac_1(void)
 
 static void test_cap_initiator_ac_2(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_2",
 		.conn_cnt = 1U,
-		.snk_cnt = {0U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = NULL,
 		.src_named_preset = src_named_preset,
 	};
@@ -1655,13 +1764,17 @@ static void test_cap_initiator_ac_2(void)
 
 static void test_cap_initiator_ac_3(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_3",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1671,13 +1784,17 @@ static void test_cap_initiator_ac_3(void)
 
 static void test_cap_initiator_ac_4(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_4",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 2U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
@@ -1687,13 +1804,18 @@ static void test_cap_initiator_ac_4(void)
 
 static void test_cap_initiator_ac_5(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_5",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 2U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1703,13 +1825,20 @@ static void test_cap_initiator_ac_5(void)
 
 static void test_cap_initiator_ac_6_i(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_6_i",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
@@ -1719,13 +1848,22 @@ static void test_cap_initiator_ac_6_i(void)
 
 static void test_cap_initiator_ac_6_ii(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_6_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {0U, 0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 0U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
@@ -1735,14 +1873,20 @@ static void test_cap_initiator_ac_6_ii(void)
 
 static void test_cap_initiator_ac_7_i(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_7_i",
 		.conn_cnt = 1U,
-		/*  TODO: These should be in different CIS but will be in the same currently */
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = false,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1752,13 +1896,22 @@ static void test_cap_initiator_ac_7_i(void)
 
 static void test_cap_initiator_ac_7_ii(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_7_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 0U},
-		.src_cnt = {0U, 1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = false,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1768,13 +1921,21 @@ static void test_cap_initiator_ac_7_ii(void)
 
 static void test_cap_initiator_ac_8_i(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_8_i",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1784,13 +1945,23 @@ static void test_cap_initiator_ac_8_i(void)
 
 static void test_cap_initiator_ac_8_ii(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_8_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 0U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1800,13 +1971,20 @@ static void test_cap_initiator_ac_8_ii(void)
 
 static void test_cap_initiator_ac_9_i(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_9_i",
 		.conn_cnt = 1U,
-		.snk_cnt = {0U},
-		.src_cnt = {2U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[0].cis_param[1].has_snk = false,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+
 		.snk_named_preset = NULL,
 		.src_named_preset = src_named_preset,
 	};
@@ -1816,13 +1994,22 @@ static void test_cap_initiator_ac_9_i(void)
 
 static void test_cap_initiator_ac_9_ii(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_9_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {0U, 0U},
-		.src_cnt = {1U, 1U},
-		.snk_chan_cnt = 0U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = false,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+
 		.snk_named_preset = NULL,
 		.src_named_preset = src_named_preset,
 	};
@@ -1831,13 +2018,17 @@ static void test_cap_initiator_ac_9_ii(void)
 }
 static void test_cap_initiator_ac_10(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_10",
 		.conn_cnt = 1U,
-		.snk_cnt = {0U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 2U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1847,13 +2038,22 @@ static void test_cap_initiator_ac_10(void)
 
 static void test_cap_initiator_ac_11_i(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_11_i",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {2U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
@@ -1863,13 +2063,24 @@ static void test_cap_initiator_ac_11_i(void)
 
 static void test_cap_initiator_ac_11_ii(void)
 {
-	const struct cap_initiator_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_11_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 1U},
-		.snk_chan_cnt = 1U,
-		.src_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -49,34 +49,8 @@ LOG_MODULE_REGISTER(cap_initiator_unicast_test);
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)
 #define UNICAST_SRC_SUPPORTED  (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0)
 
-#define CAP_AC_MAX_CONN   2U
-#define CAP_AC_MAX_SNK    (2U * CAP_AC_MAX_CONN)
-#define CAP_AC_MAX_SRC    (2U * CAP_AC_MAX_CONN)
-#define CAP_AC_MAX_PAIR   MAX(CAP_AC_MAX_SNK, CAP_AC_MAX_SRC)
-#define CAP_AC_MAX_STREAM (CAP_AC_MAX_SNK + CAP_AC_MAX_SRC)
-
 #define CONTEXT  (BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED)
 #define LOCATION (BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT)
-
-struct cap_unicast_ac_cis_param {
-	bool has_snk;
-	bool has_src;
-	enum bt_audio_location snk_loc;
-	enum bt_audio_location src_loc;
-};
-
-struct cap_unicast_ac_conn_param {
-	size_t cis_cnt;
-	struct cap_unicast_ac_cis_param cis_param[CAP_AC_MAX_PAIR];
-};
-
-struct cap_unicast_ac_param {
-	char *name;
-	size_t conn_cnt;
-	struct cap_unicast_ac_conn_param conn_param[CAP_AC_MAX_CONN];
-	const struct named_lc3_preset *snk_named_preset;
-	const struct named_lc3_preset *src_named_preset;
-};
 
 extern enum bst_result_t bst_result;
 
@@ -91,8 +65,8 @@ static struct bt_bap_ep
 	*unicast_sink_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
 static struct bt_bap_ep
 	*unicast_source_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
-static struct unicast_stream unicast_streams[CAP_AC_MAX_STREAM];
-static struct bt_conn *connected_conns[CAP_AC_MAX_CONN];
+static struct unicast_stream unicast_streams[CAP_UNICAST_AC_MAX_STREAM];
+static struct bt_conn *connected_conns[CAP_UNICAST_AC_MAX_CONN];
 static size_t connected_conn_cnt;
 static const struct named_lc3_preset *snk_named_preset;
 static const struct named_lc3_preset *src_named_preset;
@@ -1235,12 +1209,14 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_unicast_ac_par
 						 size_t src_cnt,
 						 struct bt_cap_unicast_group **unicast_group)
 {
-	struct bt_cap_unicast_group_stream_param snk_group_stream_params[CAP_AC_MAX_SNK] = {0};
-	struct bt_cap_unicast_group_stream_param src_group_stream_params[CAP_AC_MAX_SRC] = {0};
-	struct bt_cap_unicast_group_stream_pair_param pair_params[CAP_AC_MAX_PAIR] = {0};
+	struct bt_cap_unicast_group_stream_param snk_group_stream_params[CAP_UNICAST_AC_MAX_SNK] = {
+		0};
+	struct bt_cap_unicast_group_stream_param src_group_stream_params[CAP_UNICAST_AC_MAX_SRC] = {
+		0};
+	struct bt_cap_unicast_group_stream_pair_param pair_params[CAP_UNICAST_AC_MAX_PAIR] = {0};
 	struct bt_cap_unicast_group_param group_param = {0};
-	struct bt_bap_qos_cfg *snk_qos[CAP_AC_MAX_SNK];
-	struct bt_bap_qos_cfg *src_qos[CAP_AC_MAX_SRC];
+	struct bt_bap_qos_cfg *snk_qos[CAP_UNICAST_AC_MAX_SNK];
+	struct bt_bap_qos_cfg *src_qos[CAP_UNICAST_AC_MAX_SRC];
 	size_t snk_stream_cnt = 0U;
 	size_t src_stream_cnt = 0U;
 	size_t pair_cnt = 0U;
@@ -1313,14 +1289,15 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_unicast_ac_param 
 					      size_t src_cnt,
 					      struct bt_cap_unicast_group *unicast_group)
 {
-	struct bt_cap_unicast_audio_start_stream_param stream_params[CAP_AC_MAX_STREAM] = {0};
-	struct bt_audio_codec_cfg *snk_codec_cfgs[CAP_AC_MAX_SNK] = {0};
-	struct bt_audio_codec_cfg *src_codec_cfgs[CAP_AC_MAX_SRC] = {0};
-	struct bt_cap_stream *snk_cap_streams[CAP_AC_MAX_SNK] = {0};
-	struct bt_cap_stream *src_cap_streams[CAP_AC_MAX_SRC] = {0};
+	struct bt_cap_unicast_audio_start_stream_param stream_params[CAP_UNICAST_AC_MAX_STREAM] = {
+		0};
+	struct bt_audio_codec_cfg *snk_codec_cfgs[CAP_UNICAST_AC_MAX_SNK] = {0};
+	struct bt_audio_codec_cfg *src_codec_cfgs[CAP_UNICAST_AC_MAX_SRC] = {0};
+	struct bt_cap_stream *snk_cap_streams[CAP_UNICAST_AC_MAX_SNK] = {0};
+	struct bt_cap_stream *src_cap_streams[CAP_UNICAST_AC_MAX_SRC] = {0};
 	struct bt_cap_unicast_audio_start_param start_param = {0};
-	struct bt_bap_ep *snk_eps[CAP_AC_MAX_SNK] = {0};
-	struct bt_bap_ep *src_eps[CAP_AC_MAX_SRC] = {0};
+	struct bt_bap_ep *snk_eps[CAP_UNICAST_AC_MAX_SNK] = {0};
+	struct bt_bap_ep *src_eps[CAP_UNICAST_AC_MAX_SRC] = {0};
 	size_t snk_stream_cnt = 0U;
 	size_t src_stream_cnt = 0U;
 	size_t stream_cnt = 0U;
@@ -1458,8 +1435,8 @@ static int cap_initiator_ac_unicast(const struct cap_unicast_ac_param *param,
 				    struct bt_cap_unicast_group **unicast_group)
 {
 	/* Allocate params large enough for any params, but only use what is required */
-	struct unicast_stream *snk_uni_streams[CAP_AC_MAX_SNK];
-	struct unicast_stream *src_uni_streams[CAP_AC_MAX_SRC];
+	struct unicast_stream *snk_uni_streams[CAP_UNICAST_AC_MAX_SNK];
+	struct unicast_stream *src_uni_streams[CAP_UNICAST_AC_MAX_SRC];
 	size_t total_snk_cnt = 0U;
 	size_t total_src_cnt = 0U;
 	size_t total_cnt = 0U;
@@ -1549,7 +1526,7 @@ static int cap_initiator_ac_unicast(const struct cap_unicast_ac_param *param,
 	return 0;
 }
 
-static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
+void test_cap_initiator_unicast_ac(const struct cap_unicast_ac_param *param)
 {
 	struct bt_cap_unicast_group *unicast_group;
 	bool expect_tx = false;
@@ -1563,7 +1540,7 @@ static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
 	       param->snk_named_preset != NULL ? param->snk_named_preset->name : "None",
 	       param->src_named_preset != NULL ? param->src_named_preset->name : "None");
 
-	if (param->conn_cnt > CAP_AC_MAX_CONN) {
+	if (param->conn_cnt > CAP_UNICAST_AC_MAX_CONN) {
 		FAIL("Invalid conn_cnt: %zu\n", param->conn_cnt);
 		return;
 	}
@@ -1580,13 +1557,13 @@ static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
 		const struct cap_unicast_ac_conn_param *conn_param = &param->conn_param[i];
 
-		if (conn_param->cis_cnt > CAP_AC_MAX_PAIR) {
+		if (conn_param->cis_cnt > CAP_UNICAST_AC_MAX_PAIR) {
 			FAIL("Invalid param->conn_param[%zu].cis_cnt: %zu", i, conn_param->cis_cnt);
 
 			return;
 		}
 
-		if (conn_param->cis_cnt > CAP_AC_MAX_PAIR) {
+		if (conn_param->cis_cnt > CAP_UNICAST_AC_MAX_PAIR) {
 			FAIL("Invalid param->conn_param[%zu].cis_cnt: %zu", i, conn_param->cis_cnt);
 
 			return;
@@ -1599,7 +1576,7 @@ static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
 
 			if (cis_param->has_snk) {
 				total_snk_cnt++;
-				if (total_snk_cnt > CAP_AC_MAX_SNK) {
+				if (total_snk_cnt > CAP_UNICAST_AC_MAX_SNK) {
 					FAIL("Invalid total_snk_cnt: %zu\n", total_snk_cnt);
 					return;
 				}
@@ -1615,7 +1592,7 @@ static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
 
 			if (cis_param->has_src) {
 				total_src_cnt++;
-				if (total_src_cnt > CAP_AC_MAX_SRC) {
+				if (total_src_cnt > CAP_UNICAST_AC_MAX_SRC) {
 					FAIL("Invalid total_src_cnt: %zu\n", total_src_cnt);
 					return;
 				}
@@ -1630,7 +1607,7 @@ static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
 			}
 
 			total_cis_cnt++;
-			if (total_cis_cnt > CAP_AC_MAX_PAIR) {
+			if (total_cis_cnt > CAP_UNICAST_AC_MAX_PAIR) {
 				FAIL("Invalid total_cis_cnt: %zu\n", total_cis_cnt);
 
 				return;
@@ -1727,7 +1704,7 @@ static void test_cap_initiator_ac(const struct cap_unicast_ac_param *param)
 static void test_cap_initiator_ac_1(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_1",
+		.name = "gmap_ac_1",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1740,13 +1717,13 @@ static void test_cap_initiator_ac_1(void)
 		.src_named_preset = NULL,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_2(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_2",
+		.name = "gmap_ac_2",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1759,13 +1736,13 @@ static void test_cap_initiator_ac_2(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_3(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_3",
+		.name = "gmap_ac_3",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1779,13 +1756,13 @@ static void test_cap_initiator_ac_3(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_4(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_4",
+		.name = "gmap_ac_4",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1799,13 +1776,13 @@ static void test_cap_initiator_ac_4(void)
 		.src_named_preset = NULL,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_5(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_5",
+		.name = "gmap_ac_5",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1820,13 +1797,13 @@ static void test_cap_initiator_ac_5(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_6_i(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_6_i",
+		.name = "gmap_ac_6_i",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 2U,
@@ -1843,13 +1820,13 @@ static void test_cap_initiator_ac_6_i(void)
 		.src_named_preset = NULL,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_6_ii(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_6_ii",
+		.name = "gmap_ac_6_ii",
 		.conn_cnt = 2U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1868,13 +1845,13 @@ static void test_cap_initiator_ac_6_ii(void)
 		.src_named_preset = NULL,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_7_i(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_7_i",
+		.name = "gmap_ac_7_i",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 2U,
@@ -1891,13 +1868,13 @@ static void test_cap_initiator_ac_7_i(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_7_ii(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_7_ii",
+		.name = "gmap_ac_7_ii",
 		.conn_cnt = 2U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1916,13 +1893,13 @@ static void test_cap_initiator_ac_7_ii(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_8_i(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_8_i",
+		.name = "gmap_ac_8_i",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 2U,
@@ -1940,13 +1917,13 @@ static void test_cap_initiator_ac_8_i(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_8_ii(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_8_ii",
+		.name = "gmap_ac_8_ii",
 		.conn_cnt = 2U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -1966,13 +1943,13 @@ static void test_cap_initiator_ac_8_ii(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_9_i(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_9_i",
+		.name = "gmap_ac_9_i",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 2U,
@@ -1989,13 +1966,13 @@ static void test_cap_initiator_ac_9_i(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_9_ii(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_9_ii",
+		.name = "gmap_ac_9_ii",
 		.conn_cnt = 2U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -2014,12 +1991,12 @@ static void test_cap_initiator_ac_9_ii(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 static void test_cap_initiator_ac_10(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_10",
+		.name = "gmap_ac_10",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -2033,13 +2010,13 @@ static void test_cap_initiator_ac_10(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_11_i(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_11_i",
+		.name = "gmap_ac_11_i",
 		.conn_cnt = 1U,
 
 		.conn_param[0].cis_cnt = 2U,
@@ -2058,13 +2035,13 @@ static void test_cap_initiator_ac_11_i(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_cap_initiator_ac_11_ii(void)
 {
 	const struct cap_unicast_ac_param param = {
-		.name = "ac_11_ii",
+		.name = "gmap_ac_11_ii",
 		.conn_cnt = 2U,
 
 		.conn_param[0].cis_cnt = 1U,
@@ -2085,7 +2062,7 @@ static void test_cap_initiator_ac_11_ii(void)
 		.src_named_preset = src_named_preset,
 	};
 
-	test_cap_initiator_ac(&param);
+	test_cap_initiator_unicast_ac(&param);
 }
 
 static void test_args(int argc, char *argv[])

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -14,6 +14,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/cap.h>
@@ -184,4 +185,31 @@ bap_stream_from_audio_test_stream(struct audio_test_stream *test_stream)
 	return bap_stream_from_cap_stream(cap_stream_from_audio_test_stream(test_stream));
 }
 
+#define CAP_UNICAST_AC_MAX_CONN   2U
+#define CAP_UNICAST_AC_MAX_SNK    (2U * CAP_UNICAST_AC_MAX_CONN)
+#define CAP_UNICAST_AC_MAX_SRC    (2U * CAP_UNICAST_AC_MAX_CONN)
+#define CAP_UNICAST_AC_MAX_PAIR   MAX(CAP_UNICAST_AC_MAX_SNK, CAP_UNICAST_AC_MAX_SRC)
+#define CAP_UNICAST_AC_MAX_STREAM (CAP_UNICAST_AC_MAX_SNK + CAP_UNICAST_AC_MAX_SRC)
+
+struct cap_unicast_ac_cis_param {
+	bool has_snk;
+	bool has_src;
+	enum bt_audio_location snk_loc;
+	enum bt_audio_location src_loc;
+};
+
+struct cap_unicast_ac_conn_param {
+	size_t cis_cnt;
+	struct cap_unicast_ac_cis_param cis_param[CAP_UNICAST_AC_MAX_PAIR];
+};
+
+struct cap_unicast_ac_param {
+	char *name;
+	size_t conn_cnt;
+	struct cap_unicast_ac_conn_param conn_param[CAP_UNICAST_AC_MAX_CONN];
+	const struct named_lc3_preset *snk_named_preset;
+	const struct named_lc3_preset *src_named_preset;
+};
+
+void test_cap_initiator_unicast_ac(const struct cap_unicast_ac_param *param);
 #endif /* ZEPHYR_TEST_BSIM_BT_AUDIO_TEST_ */

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -48,33 +48,16 @@ LOG_MODULE_REGISTER(gmap_ugg_test);
 
 #if defined(CONFIG_BT_GMAP)
 
-#define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)
-#define UNICAST_SRC_SUPPORTED  (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0)
-
 #define CONTEXT  (BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_GAME)
 #define LOCATION (BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT)
 
 #define GMAP_BROADCAST_AC_MAX_STREAM 2U
-#define GMAP_UNICAST_AC_MAX_CONN     2U
-#define GMAP_UNICAST_AC_MAX_SNK      (2U * GMAP_UNICAST_AC_MAX_CONN)
-#define GMAP_UNICAST_AC_MAX_SRC      (2U * GMAP_UNICAST_AC_MAX_CONN)
-#define GMAP_UNICAST_AC_MAX_PAIR     MAX(GMAP_UNICAST_AC_MAX_SNK, GMAP_UNICAST_AC_MAX_SRC)
-#define GMAP_UNICAST_AC_MAX_STREAM   (GMAP_UNICAST_AC_MAX_SNK + GMAP_UNICAST_AC_MAX_SRC)
 
 extern enum bst_result_t bst_result;
 static const struct named_lc3_preset *snk_named_preset;
 static const struct named_lc3_preset *src_named_preset;
 static const struct named_lc3_preset *broadcast_named_preset;
 
-struct gmap_unicast_ac_param {
-	char *name;
-	size_t conn_cnt;
-	size_t snk_cnt[GMAP_UNICAST_AC_MAX_CONN];
-	size_t src_cnt[GMAP_UNICAST_AC_MAX_CONN];
-	size_t snk_chan_cnt;
-	const struct named_lc3_preset *snk_named_preset;
-	const struct named_lc3_preset *src_named_preset;
-};
 struct gmap_broadcast_ac_param {
 	char *name;
 	size_t stream_cnt;
@@ -110,28 +93,11 @@ static struct named_lc3_preset gmap_broadcast_presets[] = {
 struct named_lc3_preset named_preset;
 
 static struct audio_test_stream broadcast_streams[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
-static struct unicast_stream unicast_streams[GMAP_UNICAST_AC_MAX_STREAM];
-static struct bt_cap_stream *started_unicast_streams[GMAP_UNICAST_AC_MAX_STREAM];
-static size_t started_unicast_streams_cnt;
-static struct bt_bap_ep
-	*sink_eps[GMAP_UNICAST_AC_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
-static struct bt_bap_ep
-	*source_eps[GMAP_UNICAST_AC_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
-static struct bt_conn *connected_conns[GMAP_UNICAST_AC_MAX_CONN];
-static size_t connected_conn_cnt;
 
-static K_SEM_DEFINE(sem_stream_started, 0U,
-		    MAX(ARRAY_SIZE(unicast_streams), ARRAY_SIZE(broadcast_streams)));
-static K_SEM_DEFINE(sem_stream_stopped, 0U,
-		    MAX(ARRAY_SIZE(unicast_streams), ARRAY_SIZE(broadcast_streams)));
+static K_SEM_DEFINE(sem_stream_started, 0U, ARRAY_SIZE(broadcast_streams));
+static K_SEM_DEFINE(sem_stream_stopped, 0U, ARRAY_SIZE(broadcast_streams));
 
-CREATE_FLAG(flag_cas_discovered);
-CREATE_FLAG(flag_started);
-CREATE_FLAG(flag_updated);
-CREATE_FLAG(flag_stopped);
 CREATE_FLAG(flag_mtu_exchanged);
-CREATE_FLAG(flag_sink_discovered);
-CREATE_FLAG(flag_source_discovered);
 CREATE_FLAG(flag_gmap_discovered);
 
 const struct named_lc3_preset *gmap_get_named_preset(bool is_unicast, enum bt_audio_dir dir,
@@ -237,137 +203,6 @@ static struct bt_bap_stream_ops stream_ops = {
 	.recv = bap_stream_rx_recv_cb,
 };
 
-static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
-				      const struct bt_csip_set_coordinator_set_member *member,
-				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
-{
-	ARG_UNUSED(conn);
-	ARG_UNUSED(member);
-
-	if (err != 0) {
-		FAIL("Failed to discover CAS: %d\n", err);
-
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER)) {
-		if (csis_inst == NULL) {
-			FAIL("Failed to discover CAS CSIS\n");
-
-			return;
-		}
-
-		LOG_INF("Found CAS with CSIS %p", csis_inst);
-	} else {
-		LOG_INF("Found CAS");
-	}
-
-	SET_FLAG(flag_cas_discovered);
-}
-
-static void unicast_start_complete_cb(int err, struct bt_conn *conn)
-{
-	if (err != 0) {
-		FAIL("Failed to start (failing conn %p): %d\n", conn, err);
-
-		return;
-	}
-
-	SET_FLAG(flag_started);
-}
-
-static void unicast_update_complete_cb(int err, struct bt_conn *conn)
-{
-	if (err != 0) {
-		FAIL("Failed to update (failing conn %p): %d\n", conn, err);
-
-		return;
-	}
-
-	SET_FLAG(flag_updated);
-}
-
-static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
-{
-	if (err != 0) {
-		FAIL("Failed to stop (failing conn %p): %d\n", conn, err);
-
-		return;
-	}
-
-	SET_FLAG(flag_stopped);
-}
-
-static struct bt_cap_initiator_cb cap_cb = {
-	.unicast_discovery_complete = cap_discovery_complete_cb,
-	.unicast_start_complete = unicast_start_complete_cb,
-	.unicast_update_complete = unicast_update_complete_cb,
-	.unicast_stop_complete = unicast_stop_complete_cb,
-};
-
-static void add_remote_sink_ep(struct bt_conn *conn, struct bt_bap_ep *ep)
-{
-	for (size_t i = 0U; i < ARRAY_SIZE(sink_eps[bt_conn_index(conn)]); i++) {
-		if (sink_eps[bt_conn_index(conn)][i] == NULL) {
-			LOG_DBG("Conn %p: Sink #%zu: ep %p", conn, i, ep);
-			sink_eps[bt_conn_index(conn)][i] = ep;
-			break;
-		}
-	}
-}
-
-static void add_remote_source_ep(struct bt_conn *conn, struct bt_bap_ep *ep)
-{
-	for (size_t i = 0U; i < ARRAY_SIZE(source_eps[bt_conn_index(conn)]); i++) {
-		if (source_eps[bt_conn_index(conn)][i] == NULL) {
-			LOG_DBG("Conn %p: Source #%zu: ep %p", conn, i, ep);
-			source_eps[bt_conn_index(conn)][i] = ep;
-			break;
-		}
-	}
-}
-
-static void bap_pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
-			      const struct bt_audio_codec_cap *codec_cap)
-{
-	LOG_DBG("conn %p codec_cap %p dir 0x%02x", conn, codec_cap, dir);
-
-	print_codec_cap(codec_cap);
-}
-
-static void bap_endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
-{
-	if (dir == BT_AUDIO_DIR_SINK) {
-		add_remote_sink_ep(conn, ep);
-	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		add_remote_source_ep(conn, ep);
-	}
-}
-
-static void bap_discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
-{
-	ARG_UNUSED(conn);
-
-	if (err != 0) {
-		FAIL("Discovery failed for dir %u: %d\n", dir, err);
-		return;
-	}
-
-	if (dir == BT_AUDIO_DIR_SINK) {
-		LOG_INF("Sink discover complete");
-		SET_FLAG(flag_sink_discovered);
-	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		LOG_INF("Source discover complete");
-		SET_FLAG(flag_source_discovered);
-	}
-}
-
-static struct bt_bap_unicast_client_cb unicast_client_cbs = {
-	.pac_record = bap_pac_record_cb,
-	.endpoint = bap_endpoint_cb,
-	.discover = bap_discover_cb,
-};
-
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
 	ARG_UNUSED(conn);
@@ -421,49 +256,6 @@ static const struct bt_gmap_cb gmap_cb = {
 	.discover = gmap_discover_cb,
 };
 
-static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf_simple *buf)
-{
-	struct bt_conn *conn;
-	int err;
-
-	ARG_UNUSED(buf);
-
-	/* Check for connectable, extended advertising */
-	if (((info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) == 0) ||
-	    ((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE)) == 0) {
-		/* We're only interested in connectable extended advertising */
-	}
-
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, info->addr);
-	if (conn != NULL) {
-		/* Already connected to this device */
-		bt_conn_unref(conn);
-		return;
-	}
-
-	LOG_INF("Device found: %s (RSSI %d)", bt_addr_le_str(info->addr), info->rssi);
-
-	/* connect only to devices in close proximity */
-	if (info->rssi < -70) {
-		FAIL("RSSI too low");
-		return;
-	}
-
-	LOG_INF("Stopping scan");
-	if (bt_le_scan_stop()) {
-		FAIL("Could not stop scan");
-		return;
-	}
-
-	err = bt_conn_le_create(info->addr, BT_CONN_LE_CREATE_CONN,
-				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
-						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
-				&connected_conns[connected_conn_cnt]);
-	if (err != 0) {
-		FAIL("Could not connect to peer: %d", err);
-	}
-}
-
 static void init(void)
 {
 	const struct bt_gmap_feat features = {
@@ -471,9 +263,6 @@ static void init(void)
 			     BT_GMAP_UGG_FEAT_MULTISINK),
 	};
 	const enum bt_gmap_role role = BT_GMAP_ROLE_UGG;
-	static struct bt_le_scan_cb scan_cb = {
-		.recv = scan_recv_cb,
-	};
 	int err;
 
 	err = bt_enable(NULL);
@@ -486,27 +275,10 @@ static void init(void)
 	bap_stream_tx_init();
 
 	bt_gatt_cb_register(&gatt_callbacks);
-	err = bt_le_scan_cb_register(&scan_cb);
+	err = bt_le_scan_cb_register(&common_scan_cb);
 	if (err != 0) {
 		FAIL("Failed to register scan callbacks (err %d)\n", err);
 		return;
-	}
-
-	err = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
-	if (err != 0) {
-		FAIL("Failed to register BAP callbacks (err %d)\n", err);
-		return;
-	}
-
-	err = bt_cap_initiator_register_cb(&cap_cb);
-	if (err != 0) {
-		FAIL("Failed to register CAP callbacks (err %d)\n", err);
-		return;
-	}
-
-	for (size_t i = 0U; i < ARRAY_SIZE(unicast_streams); i++) {
-		bt_cap_stream_ops_register(
-			cap_stream_from_audio_test_stream(&unicast_streams[i].stream), &stream_ops);
 	}
 
 	for (size_t i = 0U; i < ARRAY_SIZE(broadcast_streams); i++) {
@@ -533,18 +305,6 @@ static void deinit(void)
 {
 	int err;
 
-	err = bt_cap_initiator_unregister_cb(&cap_cb);
-	if (err != 0) {
-		FAIL("Failed to unregister CAP callbacks (err %d)\n", err);
-		return;
-	}
-
-	err = bt_bap_unicast_client_unregister_cb(&unicast_client_cbs);
-	if (err != 0) {
-		FAIL("Failed to unregister BAP callbacks (err %d)\n", err);
-		return;
-	}
-
 	err = bt_gatt_cb_unregister(&gatt_callbacks);
 	if (err != 0) {
 		FAIL("Failed to unregister GATT callbacks (err %d)\n", err);
@@ -566,37 +326,6 @@ static void scan_and_connect(void)
 
 	LOG_INF("Scanning successfully started");
 	WAIT_FOR_FLAG(flag_connected);
-	connected_conn_cnt++;
-}
-
-static void discover_sink(struct bt_conn *conn)
-{
-	int err;
-
-	UNSET_FLAG(flag_sink_discovered);
-
-	err = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SINK);
-	if (err != 0) {
-		LOG_ERR("Failed to discover sink: %d", err);
-		return;
-	}
-
-	WAIT_FOR_FLAG(flag_sink_discovered);
-}
-
-static void discover_source(struct bt_conn *conn)
-{
-	int err;
-
-	UNSET_FLAG(flag_source_discovered);
-
-	err = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SOURCE);
-	if (err != 0) {
-		LOG_ERR("Failed to discover source: %d", err);
-		return;
-	}
-
-	WAIT_FOR_FLAG(flag_source_discovered);
 }
 
 static void discover_gmas(struct bt_conn *conn)
@@ -614,455 +343,34 @@ static void discover_gmas(struct bt_conn *conn)
 	WAIT_FOR_FLAG(flag_gmap_discovered);
 }
 
-static void discover_cas(struct bt_conn *conn)
+static void test_gmap(void)
 {
 	int err;
-
-	UNSET_FLAG(flag_cas_discovered);
-
-	err = bt_cap_initiator_unicast_discover(conn);
-	if (err != 0) {
-		LOG_ERR("Failed to discover CAS: %d", err);
-		return;
-	}
-
-	WAIT_FOR_FLAG(flag_cas_discovered);
-}
-
-static int gmap_unicast_ac_create_unicast_group(const struct gmap_unicast_ac_param *param,
-						struct unicast_stream *snk_uni_streams[],
-						size_t snk_cnt,
-						struct unicast_stream *src_uni_streams[],
-						size_t src_cnt,
-						struct bt_cap_unicast_group **unicast_group)
-{
-	struct bt_cap_unicast_group_stream_param
-		snk_group_stream_params[GMAP_UNICAST_AC_MAX_SNK] = {0};
-	struct bt_cap_unicast_group_stream_param
-		src_group_stream_params[GMAP_UNICAST_AC_MAX_SRC] = {0};
-	struct bt_cap_unicast_group_stream_pair_param pair_params[GMAP_UNICAST_AC_MAX_PAIR] = {0};
-	struct bt_cap_unicast_group_param group_param = {0};
-	size_t snk_stream_cnt = 0U;
-	size_t src_stream_cnt = 0U;
-	size_t pair_cnt = 0U;
-
-	/* Create Group
-	 *
-	 * First setup the individual stream parameters and then match them in pairs by connection
-	 * and direction
-	 */
-	for (size_t i = 0U; i < snk_cnt; i++) {
-		snk_group_stream_params[i].qos_cfg = &snk_uni_streams[i]->qos;
-		snk_group_stream_params[i].stream =
-			cap_stream_from_audio_test_stream(&snk_uni_streams[i]->stream);
-	}
-	for (size_t i = 0U; i < src_cnt; i++) {
-		src_group_stream_params[i].qos_cfg = &src_uni_streams[i]->qos;
-		src_group_stream_params[i].stream =
-			cap_stream_from_audio_test_stream(&src_uni_streams[i]->stream);
-	}
-
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < MAX(param->snk_cnt[i], param->src_cnt[i]); j++) {
-			if (param->snk_cnt[i] > j) {
-				pair_params[pair_cnt].tx_param =
-					&snk_group_stream_params[snk_stream_cnt];
-				snk_stream_cnt++;
-			} else {
-				pair_params[pair_cnt].tx_param = NULL;
-			}
-
-			if (param->src_cnt[i] > j) {
-				pair_params[pair_cnt].rx_param =
-					&src_group_stream_params[src_stream_cnt];
-				src_stream_cnt++;
-			} else {
-				pair_params[pair_cnt].rx_param = NULL;
-			}
-
-			pair_cnt++;
-		}
-	}
-
-	group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	group_param.params = pair_params;
-	group_param.params_count = pair_cnt;
-
-	return bt_cap_unicast_group_create(&group_param, unicast_group);
-}
-
-static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
-				     struct unicast_stream *snk_uni_streams[], size_t snk_cnt,
-				     struct unicast_stream *src_uni_streams[], size_t src_cnt,
-				     struct bt_cap_unicast_group *unicast_group)
-{
-	struct bt_cap_unicast_audio_start_stream_param stream_params[GMAP_UNICAST_AC_MAX_STREAM] = {
-		0};
-	struct bt_audio_codec_cfg *snk_codec_cfgs[GMAP_UNICAST_AC_MAX_SNK] = {0};
-	struct bt_audio_codec_cfg *src_codec_cfgs[GMAP_UNICAST_AC_MAX_SRC] = {0};
-	struct bt_cap_stream *snk_cap_streams[GMAP_UNICAST_AC_MAX_SNK] = {0};
-	struct bt_cap_stream *src_cap_streams[GMAP_UNICAST_AC_MAX_SRC] = {0};
-	struct bt_cap_unicast_audio_start_param start_param = {0};
-	struct bt_bap_ep *snk_eps[GMAP_UNICAST_AC_MAX_SNK] = {0};
-	struct bt_bap_ep *src_eps[GMAP_UNICAST_AC_MAX_SRC] = {0};
-	size_t snk_stream_cnt = 0U;
-	size_t src_stream_cnt = 0U;
-	size_t stream_cnt = 0U;
-	size_t snk_ep_cnt = 0U;
-	size_t src_ep_cnt = 0U;
-	int err;
-
-	ARG_UNUSED(unicast_group);
-
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-#if UNICAST_SINK_SUPPORTED
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			snk_eps[snk_ep_cnt] = sink_eps[bt_conn_index(connected_conns[i])][j];
-			if (snk_eps[snk_ep_cnt] == NULL) {
-				FAIL("No sink[%zu][%zu] endpoint available\n", i, j);
-
-				return -ENODEV;
-			}
-			snk_ep_cnt++;
-		}
-#endif /* UNICAST_SINK_SUPPORTED */
-
-#if UNICAST_SRC_SUPPORTED
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			src_eps[src_ep_cnt] = source_eps[bt_conn_index(connected_conns[i])][j];
-			if (src_eps[src_ep_cnt] == NULL) {
-				FAIL("No source[%zu][%zu] endpoint available\n", i, j);
-
-				return -ENODEV;
-			}
-			src_ep_cnt++;
-		}
-#endif /* UNICAST_SRC_SUPPORTED > 0 */
-	}
-
-	if (snk_ep_cnt != snk_cnt) {
-		FAIL("Sink endpoint and stream count mismatch: %zu != %zu\n", snk_ep_cnt, snk_cnt);
-
-		return -EINVAL;
-	}
-
-	if (src_ep_cnt != src_cnt) {
-		FAIL("Source endpoint and stream count mismatch: %zu != %zu\n", src_ep_cnt,
-		     src_cnt);
-
-		return -EINVAL;
-	}
-
-	/* Setup arrays of parameters based on the preset for easier access. This also copies the
-	 * preset so that we can modify them (e.g. update the metadata)
-	 */
-	for (size_t i = 0U; i < snk_cnt; i++) {
-		snk_cap_streams[i] = cap_stream_from_audio_test_stream(&snk_uni_streams[i]->stream);
-		snk_codec_cfgs[i] = &snk_uni_streams[i]->codec_cfg;
-	}
-
-	for (size_t i = 0U; i < src_cnt; i++) {
-		src_cap_streams[i] = cap_stream_from_audio_test_stream(&src_uni_streams[i]->stream);
-		src_codec_cfgs[i] = &src_uni_streams[i]->codec_cfg;
-	}
-
-	/* CAP Start */
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			struct bt_cap_unicast_audio_start_stream_param *stream_param =
-				&stream_params[stream_cnt];
-			struct bt_audio_codec_cfg *codec_cfg = snk_codec_cfgs[snk_stream_cnt];
-
-			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = codec_cfg;
-			stream_param->ep = snk_eps[snk_stream_cnt];
-			stream_param->stream = snk_cap_streams[snk_stream_cnt];
-
-			snk_stream_cnt++;
-			stream_cnt++;
-
-			/* If we have more than 1 connection or stream in one direction, we set the
-			 * location bit accordingly
-			 */
-			if (param->conn_cnt > 1U || param->snk_cnt[i] > 1U) {
-				err = bt_audio_codec_cfg_set_chan_allocation(
-					codec_cfg, (enum bt_audio_location)BIT(i));
-
-				if (err < 0) {
-					FAIL("Failed to set channel allocation: %d\n", err);
-					return err;
-				}
-			}
-		}
-
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			struct bt_cap_unicast_audio_start_stream_param *stream_param =
-				&stream_params[stream_cnt];
-			struct bt_audio_codec_cfg *codec_cfg = src_codec_cfgs[src_stream_cnt];
-
-			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = codec_cfg;
-			stream_param->ep = src_eps[src_stream_cnt];
-			stream_param->stream = src_cap_streams[src_stream_cnt];
-
-			src_stream_cnt++;
-			stream_cnt++;
-
-			/* If we have more than 1 connection or stream in one direction, we set the
-			 * location bit accordingly
-			 */
-			if (param->conn_cnt > 1U || param->src_cnt[i] > 1U) {
-				err = bt_audio_codec_cfg_set_chan_allocation(
-					codec_cfg, (enum bt_audio_location)BIT(i));
-
-				if (err < 0) {
-					FAIL("Failed to set channel allocation: %d\n", err);
-					return err;
-				}
-			}
-		}
-	}
-
-	start_param.stream_params = stream_params;
-	start_param.count = stream_cnt;
-	start_param.type = BT_CAP_SET_TYPE_AD_HOC;
-
-	err = bt_cap_initiator_unicast_audio_start(&start_param);
-	if (err == 0) {
-		for (size_t i = 0U; i < start_param.count; i++) {
-			started_unicast_streams[i] = start_param.stream_params[i].stream;
-		}
-
-		started_unicast_streams_cnt = start_param.count;
-	}
-
-	return err;
-}
-
-static int gmap_ac_unicast(const struct gmap_unicast_ac_param *param,
-			   struct bt_cap_unicast_group **unicast_group)
-{
-	/* Allocate params large enough for any params, but only use what is required */
-	struct unicast_stream *snk_uni_streams[GMAP_UNICAST_AC_MAX_SNK];
-	struct unicast_stream *src_uni_streams[GMAP_UNICAST_AC_MAX_SRC];
-	size_t snk_cnt = 0U;
-	size_t src_cnt = 0U;
-	int err;
-
-	if (param->conn_cnt > GMAP_UNICAST_AC_MAX_CONN) {
-		FAIL("Invalid conn_cnt: %zu\n", param->conn_cnt);
-
-		return -EINVAL;
-	}
-
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		/* Verify conn values */
-		if (param->snk_cnt[i] > GMAP_UNICAST_AC_MAX_SNK) {
-			FAIL("Invalid conn_snk_cnt[%zu]: %zu\n", i, param->snk_cnt[i]);
-
-			return -EINVAL;
-		}
-
-		if (param->src_cnt[i] > GMAP_UNICAST_AC_MAX_SRC) {
-			FAIL("Invalid conn_src_cnt[%zu]: %zu\n", i, param->src_cnt[i]);
-
-			return -EINVAL;
-		}
-	}
-
-	/* Get total count of sink and source streams to setup */
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
-			snk_cnt++;
-		}
-
-		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
-			src_cnt++;
-		}
-	}
-
-	/* Setup arrays of parameters based on the preset for easier access. This also copies the
-	 * preset so that we can modify them (e.g. update the metadata)
-	 */
-	for (size_t i = 0U; i < snk_cnt; i++) {
-		snk_uni_streams[i] = &unicast_streams[i];
-
-		copy_unicast_stream_preset(snk_uni_streams[i], param->snk_named_preset);
-
-		/* Some audio configuration requires multiple sink channels,
-		 * so multiply the SDU based on the channel count
-		 */
-		snk_uni_streams[i]->qos.sdu *= param->snk_chan_cnt;
-	}
-
-	for (size_t i = 0U; i < src_cnt; i++) {
-		src_uni_streams[i] = &unicast_streams[i + snk_cnt];
-		copy_unicast_stream_preset(src_uni_streams[i], param->src_named_preset);
-	}
-
-	err = gmap_unicast_ac_create_unicast_group(param, snk_uni_streams, snk_cnt, src_uni_streams,
-						   src_cnt, unicast_group);
-	if (err != 0) {
-		FAIL("Failed to create group: %d\n", err);
-
-		return err;
-	}
-
-	UNSET_FLAG(flag_started);
-
-	LOG_INF("Starting %zu streams for %s", snk_cnt + src_cnt, param->name);
-	err = gmap_ac_cap_unicast_start(param, snk_uni_streams, snk_cnt, src_uni_streams, src_cnt,
-					*unicast_group);
-	if (err != 0) {
-		FAIL("Failed to start unicast audio: %d\n\n", err);
-
-		return err;
-	}
-
-	WAIT_FOR_FLAG(flag_started);
-
-	/* let other devices know we have started what we wanted */
-	backchannel_sync_send_all();
-
-	return 0;
-}
-
-static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicast_group)
-{
-	struct bt_cap_unicast_audio_stop_param param;
-	int err;
-
-	ARG_UNUSED(unicast_group);
-
-	UNSET_FLAG(flag_stopped);
-
-	param.type = BT_CAP_SET_TYPE_AD_HOC;
-	param.count = started_unicast_streams_cnt;
-	param.streams = started_unicast_streams;
-	param.release = true;
-
-	err = bt_cap_initiator_unicast_audio_stop(&param);
-	if (err != 0) {
-		FAIL("Failed to start unicast audio: %d\n", err);
-		return;
-	}
-
-	WAIT_FOR_FLAG(flag_stopped);
-
-	started_unicast_streams_cnt = 0U;
-	memset(started_unicast_streams, 0, sizeof(started_unicast_streams));
-}
-
-static void unicast_group_delete(struct bt_cap_unicast_group *unicast_group)
-{
-	int err;
-
-	err = bt_cap_unicast_group_delete(unicast_group);
-	if (err != 0) {
-		FAIL("Failed to create group: %d\n", err);
-		return;
-	}
-}
-
-static void wait_for_data(void)
-{
-	LOG_INF("Waiting for data");
-
-	ARRAY_FOR_EACH_PTR(unicast_streams, unicast_stream) {
-		if (bap_stream_rx_can_recv(&unicast_stream->stream.stream.bap_stream) &&
-		    audio_test_stream_is_streaming(&unicast_stream->stream)) {
-			WAIT_FOR_FLAG(unicast_stream->stream.flag_audio_received);
-		}
-	}
-
-	LOG_INF("Data received");
-}
-
-static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
-{
-	struct bt_cap_unicast_group *unicast_group;
-	bool expect_tx = false;
-	bool expect_rx = false;
-
-	LOG_INF("Running test for %s with Sink Preset %s and Source Preset %s", param->name,
-	       param->snk_named_preset != NULL ? param->snk_named_preset->name : "None",
-	       param->src_named_preset != NULL ? param->src_named_preset->name : "None");
-
-	if (param->conn_cnt > GMAP_UNICAST_AC_MAX_CONN) {
-		FAIL("Invalid conn_cnt: %zu\n", param->conn_cnt);
-		return;
-	}
 
 	init();
 
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		UNSET_FLAG(flag_mtu_exchanged);
+	UNSET_FLAG(flag_mtu_exchanged);
 
-		scan_and_connect();
+	scan_and_connect();
 
-		WAIT_FOR_FLAG(flag_mtu_exchanged);
+	WAIT_FOR_FLAG(flag_mtu_exchanged);
 
-		LOG_INF("Connected %zu/%zu", i + 1, param->conn_cnt);
-	}
+	LOG_INF("Connected");
 
-	if (connected_conn_cnt < param->conn_cnt) {
-		FAIL("Only %zu/%u connected devices, please connect additional devices for this "
-		     "audio configuration\n",
-		     connected_conn_cnt, param->conn_cnt);
+	update_security(default_conn);
+
+	discover_gmas(default_conn);
+	discover_gmas(default_conn); /* test that we can discover twice */
+
+	backchannel_sync_send_all();
+
+	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err != 0) {
+		FAIL("Failed to disconnect: %d\n", err);
 		return;
 	}
 
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		update_security(connected_conns[i]);
-
-		discover_cas(connected_conns[i]);
-
-		if (param->snk_cnt[i] > 0U) {
-			discover_sink(connected_conns[i]);
-			expect_tx = true;
-		}
-
-		if (param->src_cnt[i] > 0U) {
-			discover_source(connected_conns[i]);
-			expect_rx = true;
-		}
-
-		discover_gmas(connected_conns[i]);
-		discover_gmas(connected_conns[i]); /* test that we can discover twice */
-	}
-
-	gmap_ac_unicast(param, &unicast_group);
-
-	if (expect_tx) {
-		/* Wait until acceptors have received expected data */
-		backchannel_sync_wait_all();
-	}
-
-	if (expect_rx) {
-		wait_for_data();
-	}
-
-	cap_initiator_unicast_audio_stop(unicast_group);
-
-	unicast_group_delete(unicast_group);
-	unicast_group = NULL;
-
-	for (size_t i = 0U; i < param->conn_cnt; i++) {
-		const int err =
-			bt_conn_disconnect(connected_conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-
-		if (err != 0) {
-			FAIL("Failed to disconnect conn[%zu]: %d\n", i, err);
-		}
-
-		bt_conn_drop(&connected_conns[i]);
-	}
-
-	deinit();
-
-	PASS("GMAP UGG passed for %s with Sink Preset %s and Source Preset %s\n", param->name,
-	     param->snk_named_preset != NULL ? param->snk_named_preset->name : "None",
-	     param->src_named_preset != NULL ? param->src_named_preset->name : "None");
+	PASS("GMAP UGG passed\n");
 }
 
 static void setup_extended_adv_data(struct bt_cap_broadcast_source *source,
@@ -1270,184 +578,297 @@ static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *para
 	return 0;
 }
 
+static void test_gmap_ac(const struct cap_unicast_ac_param *param)
+{
+	const struct bt_gmap_feat features = {
+		.ugg_feat = (BT_GMAP_UGG_FEAT_MULTIPLEX | BT_GMAP_UGG_FEAT_96KBPS_SOURCE |
+			     BT_GMAP_UGG_FEAT_MULTISINK),
+	};
+	const enum bt_gmap_role role = BT_GMAP_ROLE_UGG;
+	int err;
+
+	err = bt_gmap_register(role, features);
+	if (err != 0) {
+		FAIL("Failed to register GMAS (err %d)\n", err);
+
+		return;
+	}
+
+	test_cap_initiator_unicast_ac(param);
+}
+
 static void test_gmap_ac_1(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_1",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_2(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_2",
 		.conn_cnt = 1U,
-		.snk_cnt = {0U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = false,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = NULL,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_3(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_3",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_4(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_4",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 2U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_5(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_5",
 		.conn_cnt = 1U,
-		.snk_cnt = {1U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 2U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc =
+			BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_6_i(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_6_i",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {0U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_6_ii(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_6_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {0U, 0U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = false,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = NULL,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_7_ii(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_7_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 0U},
-		.src_cnt = {0U, 1U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = false,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_8_i(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_8_i",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_8_ii(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_8_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 0U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = false,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_MONO_AUDIO,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_11_i(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_11_i",
 		.conn_cnt = 1U,
-		.snk_cnt = {2U},
-		.src_cnt = {2U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 2U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[0].cis_param[1].has_snk = true,
+		.conn_param[0].cis_param[1].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[0].cis_param[1].has_src = true,
+		.conn_param[0].cis_param[1].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_11_ii(void)
 {
-	const struct gmap_unicast_ac_param param = {
+	const struct cap_unicast_ac_param param = {
 		.name = "ac_11_ii",
 		.conn_cnt = 2U,
-		.snk_cnt = {1U, 1U},
-		.src_cnt = {1U, 1U},
-		.snk_chan_cnt = 1U,
+
+		.conn_param[0].cis_cnt = 1U,
+
+		.conn_param[0].cis_param[0].has_snk = true,
+		.conn_param[0].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+		.conn_param[0].cis_param[0].has_src = true,
+		.conn_param[0].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_LEFT,
+
+		.conn_param[1].cis_cnt = 1U,
+
+		.conn_param[1].cis_param[0].has_snk = true,
+		.conn_param[1].cis_param[0].snk_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+		.conn_param[1].cis_param[0].has_src = true,
+		.conn_param[1].cis_param[0].src_loc = BT_AUDIO_LOCATION_FRONT_RIGHT,
+
 		.snk_named_preset = snk_named_preset,
 		.src_named_preset = src_named_preset,
 	};
 
-	test_gmap_ugg_unicast_ac(&param);
+	test_gmap_ac(&param);
 }
 
 static void test_gmap_ac_12(void)
@@ -1527,6 +948,13 @@ static void test_args(int argc, char *argv[])
 }
 
 static const struct bst_test_instance test_gmap_ugg[] = {
+	{
+		.test_id = "gmap_ugg",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_gmap,
+		.test_args_f = test_args,
+	},
 	{
 		.test_id = "gmap_ugg_ac_1",
 		.test_pre_init_f = test_init,

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_gmap"
+VERBOSITY_LEVEL=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running GMAP UGG and UGT test =========\n\n"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=gmap_ugg \
+  -RealEncryption=1 -rs=24 -D=2
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=gmap_ugt \
+  -RealEncryption=1 -rs=46 -D=2
+
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Refactor cap_unicast_ac_param to be more expressive. This simplifies some setup while moving some of the choices to the parameters instead.
Additionally this allows for AC_7_1 which was not supported by the existing definition.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/113824
fixes https://github.com/zephyrproject-rtos/zephyr/issues/111153