### PR TITLE
boards: arduino: opta: update compatible of SDIO node

### DIFF
--- a/boards/arduino/opta/arduino_opta-common.dtsi
+++ b/boards/arduino/opta/arduino_opta-common.dtsi
@@ -217,12 +217,12 @@
 };
 
 sdhc: &sdmmc1 {
-	compatible = "st,stm32-sdio";
+	compatible = "st,stm32-sdmmc";
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
-	sdhi-on-gpios = <&gpioj 1 GPIO_ACTIVE_HIGH>;
+	pwr-gpios = <&gpioj 1 GPIO_ACTIVE_HIGH>;
 	power-delay-ms = <50>;
 	interrupts = <49 0>;
 	interrupt-names = "event";

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m4_defconfig
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m4_defconfig
@@ -12,3 +12,7 @@ CONFIG_HW_STACK_PROTECTION=y
 
 # Use zephyr,code-partition as flash offset
 CONFIG_USE_DT_CODE_PARTITION=y
+
+# Use STM32 SDHC driver for SDIO
+# (disables the legacy SDMMC disk driver)
+CONFIG_SDMMC_STM32=n


### PR DESCRIPTION
The "st,stm32-sdio" compatible no longer exists. Update the board accordingly, as done in 43be811f2bb5d7943011ad185276ba5a18f9e06f.

Fixes #112805