### PR TITLE
sys: cbprintf: separate the buffer increments from the stores

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -723,23 +723,29 @@ do { \
 	uint8_t _loc = (uint8_t)(_idx / sizeof(int)); \
 	if (arg_idx < 1 + _fros_cnt) { \
 		if (_ros_pos_en) { \
-			_ros_pos_buf[_ros_pos_idx++] = _loc; \
+			_ros_pos_buf[_ros_pos_idx] = _loc; \
+			_ros_pos_idx++; \
 		} \
 	} else if (Z_CBPRINTF_IS_PCHAR(_arg, 0)) { \
 		if (_cros_en) { \
 			if (Z_CBPRINTF_IS_X_PCHAR(arg_idx, _arg, _flags)) { \
 				if (_rws_pos_en) { \
-					_rws_buffer[_rws_pos_idx++] = arg_idx - 1; \
-					_rws_buffer[_rws_pos_idx++] = _loc; \
+					_rws_buffer[_rws_pos_idx] = arg_idx - 1; \
+					_rws_pos_idx++; \
+					_rws_buffer[_rws_pos_idx] = _loc; \
+					_rws_pos_idx++; \
 				} \
 			} else { \
 				if (_ros_pos_en) { \
-					_ros_pos_buf[_ros_pos_idx++] = _loc; \
+					_ros_pos_buf[_ros_pos_idx] = _loc; \
+					_ros_pos_idx++; \
 				} \
 			} \
 		} else if (_rws_pos_en) { \
-			_rws_buffer[_rws_pos_idx++] = arg_idx - 1; \
-			_rws_buffer[_rws_pos_idx++] = (uint8_t)(_idx / sizeof(int)); \
+			_rws_buffer[_rws_pos_idx] = arg_idx - 1; \
+			_rws_pos_idx++; \
+			_rws_buffer[_rws_pos_idx] = (uint8_t)(_idx / sizeof(int)); \
+			_rws_pos_idx++; \
 		} else { \
 			/* Neither position buffer is enabled, nothing to record. */ \
 		} \
@@ -874,10 +880,12 @@ do { \
 		/* Append string locations. */ \
 		uint8_t *_pbuf_loc = &_pbuf[_pkg_len]; \
 		for (size_t _ros_idx = 0; _ros_idx < _ros_cnt; _ros_idx++) { \
-			*_pbuf_loc++ = _ros_pos_buf[_ros_idx]; \
+			*_pbuf_loc = _ros_pos_buf[_ros_idx]; \
+			_pbuf_loc++; \
 		} \
 		for (size_t _rws_idx = 0; _rws_idx < (2 * _rws_cnt); _rws_idx++) { \
-			*_pbuf_loc++ = _rws_buffer[_rws_idx]; \
+			*_pbuf_loc = _rws_buffer[_rws_idx]; \
+			_pbuf_loc++; \
 		} \
 	} \
 	/* Store length */ \


### PR DESCRIPTION
Z_CBPRINTF_PACK_ARG2() and Z_CBPRINTF_STATIC_PACKAGE_GENERIC() record
argument positions with buf[idx++] = value and *ptr++ = value.  Each
of those full expressions carries a side effect besides the increment,
which MISRA C:2012 Rule 13.3 asks authors to avoid.  The two macros
are expanded once per argument of every static package, so these eight
lines produce 2592 of the 2617 Rule 13.3 reports in the ECLAIR scan of
qemu_x86.

Store first and advance afterwards.  The objects written and the
counters advanced are distinct, so the split changes nothing about
what the macros do.

The generated code is unaffected: samples/hello_world,
tests/kernel/common and tests/subsys/logging/log_api all produce
byte-identical disassembly for qemu_x86 before and after, with
identical text, data and bss sizes.


on top of another PR with the following commits: https://github.com/zephyrproject-rtos/zephyr/pull/115749
- **sys: cbprintf: give the nested argument size locals distinct names**
- **sys: cbprintf: separate the buffer increments from the stores**
