### PR TITLE
cmake: sca: eclair: deviate Rule 10.3 for likely() and unlikely()

### DIFF
--- a/cmake/sca/eclair/ECL/deviations.ecl
+++ b/cmake/sca/eclair/ECL/deviations.ecl
@@ -183,6 +183,14 @@ dimension is higher than omitting the dimension."
 -config=MC3A2.R10.4,etypes={safe,"any()","preserved_integer_constant()||sibling(rhs,preserved_integer_constant())"}
 -doc_end
 
+-doc_begin="The likely() and unlikely() macros hand a truth value to the GCC builtin
+__builtin_expect(), whose parameters are declared long.  The conversion from the
+essentially Boolean argument to the essentially signed parameter is value-preserving,
+and the result is immediately compared against 0, so no information is lost and the
+intent of the rule is met."
+-config=MC3A2.R10.3,reports+={deliberate,"any_area(any_loc(any_exp(macro(name(likely||unlikely)))))"}
+-doc_end
+
 -doc_begin="Shifting non-negative integers to the right is safe."
 -config=MC3A2.R10.1,etypes+={safe,
   "stmt(node(binary_operator)&&operator(shr))",


### PR DESCRIPTION
likely() and unlikely() hand a truth value to __builtin_expect(),
whose parameters GCC declares as long.  The resulting conversion from
an essentially Boolean expression to an essentially signed one is what
MISRA C:2012 Rule 10.3 objects to, and because the macros are used
throughout the kernel this single pair of definitions accounts for
2261 of the 6595 Rule 10.3 reports in the ECLAIR scan of qemu_x86.

The conversion is value-preserving and the result is immediately
compared against 0, so nothing is lost and the intent of the rule is
met.  Rewriting the macros to select a signed value explicitly does
silence the reports, but it perturbs the most heavily used
branch-hint macro in the tree for no reduction in risk, so record a
deviation instead.  These macros already carry a deliberate Directive
4.9 deviation in zephyr_common_config.ecl, and Rule 8.8 is already
deviated for generated syscall declarations on the same reasoning:
the construct is imposed by a mechanism outside the coding standard's
model.

The selector follows the existing Rule 11.6 deviation for
__LOG_ARG_CAST.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
