### PR TITLE
drivers: i2c: stm32: Fix stalled semaphore on bus recovery

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -70,6 +70,8 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	uint32_t i2c_clock = 0U;
 	int ret;
 
+	__ASSERT(k_sem_count_get(&data->bus_mutex) == 0, "Bus is not locked");
+
 	if (cfg->pclk_len > 1) {
 		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[1],
 					   &i2c_clock) < 0) {
@@ -86,13 +88,11 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 
 	data->dev_config = config;
 
-	k_sem_take(&data->bus_mutex, K_FOREVER);
-
 #ifdef CONFIG_PM_DEVICE_RUNTIME
 	ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
 	if (ret < 0) {
 		LOG_ERR("failure Enabling I2C clock");
-		goto out;
+		return ret;
 	}
 #endif
 
@@ -102,7 +102,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 #endif
 	ret = i2c_stm32_configure_timing(dev, i2c_clock);
 	if (ret < 0) {
-		goto out;
+		return ret;
 	}
 
 	if (data->smbalert_active) {
@@ -113,14 +113,11 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	ret = clock_control_off(clk, (clock_control_subsys_t)&cfg->pclken[0]);
 	if (ret < 0) {
 		LOG_ERR("failure disabling I2C clock");
-		goto out;
+		return ret;
 	}
 #endif
 
-out:
-	k_sem_give(&data->bus_mutex);
-
-	return ret;
+	return 0;
 }
 
 #define OPERATION(msg) (((struct i2c_msg *) msg)->flags & I2C_MSG_RW_MASK)
@@ -209,8 +206,21 @@ out_sem:
 	return ret;
 }
 
+static int i2c_stm32_configure(const struct device *dev,
+				uint32_t dev_config_raw)
+{
+	struct i2c_stm32_data *data = dev->data;
+	int ret;
+
+	k_sem_take(&data->bus_mutex, K_FOREVER);
+	ret = i2c_stm32_runtime_configure(dev, dev_config_raw);
+	k_sem_give(&data->bus_mutex);
+
+	return ret;
+}
+
 DEVICE_API(i2c, i2c_stm32_driver_api) = {
-	.configure = i2c_stm32_runtime_configure,
+	.configure = i2c_stm32_configure,
 	.transfer = i2c_stm32_transfer,
 	.get_config = i2c_stm32_get_config,
 #if defined(CONFIG_I2C_STM32_BUS_RECOVERY)
@@ -273,7 +283,10 @@ int i2c_stm32_init(const struct device *dev)
 
 	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
+	k_sem_take(&data->bus_mutex, K_FOREVER);
 	ret = i2c_stm32_runtime_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
+	k_sem_give(&data->bus_mutex);
+
 	if (ret < 0) {
 		LOG_ERR("i2c: failure initializing");
 		return ret;

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -169,6 +169,10 @@ int i2c_stm32_transaction(const struct device *dev,
 			  uint16_t periph);
 #endif /* CONFIG_I2C_RTIO */
 
+/* Reconfigure I2C bus according to @p config
+ * This function must be called with bus mutex locked (k_sem_take(i2c_stm32_data::bus_mutex))
+ * unless CONFIG_I2C_RTIO is enabled (in which case there is no bus_mutex to take).
+ */
 int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config);
 
 #ifdef CONFIG_I2C_TARGET

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -223,6 +223,7 @@ int i2c_stm32_recover_bus(const struct device *dev)
 	};
 	uint32_t device_config = data->dev_config;
 	int error = 0;
+	int ret2;
 
 	LOG_ERR("attempting to recover bus");
 
@@ -282,15 +283,22 @@ int i2c_stm32_recover_bus(const struct device *dev)
 	}
 
 restore:
-	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	ret2 = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret2 != 0) {
+		return (error != 0) ? error : ret2;
+	}
 
 	/* Re-initialize the I2C peripheral after GPIO-based bus recovery.
 	 * pinctrl_apply_state() restores the pin configuration, but the
 	 * peripheral registers remain in a faulted state. Re-running
 	 * runtime_configure() restores the peripheral to a working state.
 	 */
-	if (i2c_stm32_runtime_configure(dev, device_config) != 0) {
-		LOG_ERR("failed to restore I2C peripheral after bus recovery");
+	ret2 = i2c_stm32_runtime_configure(dev, device_config);
+	if (ret2 != 0) {
+		LOG_ERR("failed to restore I2C peripheral after bus recovery: %d", ret2);
+		if (error == 0) {
+			return ret2;
+		}
 	}
 
 #ifndef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -221,7 +221,8 @@ int i2c_stm32_recover_bus(const struct device *dev)
 		.set_sda = i2c_stm32_bitbang_set_sda,
 		.get_sda = i2c_stm32_bitbang_get_sda,
 	};
-	uint32_t bitrate_cfg = i2c_map_dt_bitrate(config->bitrate) | I2C_MODE_CONTROLLER;
+	uint32_t device_config = data->dev_config;
+	uint32_t bb_config;
 	int error = 0;
 
 	LOG_ERR("attempting to recover bus");
@@ -259,7 +260,13 @@ int i2c_stm32_recover_bus(const struct device *dev)
 
 	i2c_bitbang_init(&bitbang_ctx, &bitbang_io, (void *)config);
 
-	error = i2c_bitbang_configure(&bitbang_ctx, bitrate_cfg);
+	if (I2C_SPEED_GET(device_config) == I2C_SPEED_DT) {
+		bb_config = i2c_map_dt_bitrate(cfg->bitrate) | I2C_MODE_CONTROLLER;
+	} else {
+		bb_config = device_config;
+	}
+
+	error = i2c_bitbang_configure(&bitbang_ctx, bb_config);
 	if (error != 0) {
 		LOG_ERR("failed to configure I2C bitbang (err %d)", error);
 		goto restore;
@@ -278,7 +285,7 @@ restore:
 	 * peripheral registers remain in a faulted state. Re-running
 	 * runtime_configure() restores the peripheral to a working state.
 	 */
-	if (i2c_stm32_runtime_configure(dev, bitrate_cfg) != 0) {
+	if (i2c_stm32_runtime_configure(dev, device_config) != 0) {
 		LOG_ERR("failed to restore I2C peripheral after bus recovery");
 	}
 

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -222,7 +222,6 @@ int i2c_stm32_recover_bus(const struct device *dev)
 		.get_sda = i2c_stm32_bitbang_get_sda,
 	};
 	uint32_t device_config = data->dev_config;
-	uint32_t bb_config;
 	int error = 0;
 
 	LOG_ERR("attempting to recover bus");
@@ -260,16 +259,21 @@ int i2c_stm32_recover_bus(const struct device *dev)
 
 	i2c_bitbang_init(&bitbang_ctx, &bitbang_io, (void *)config);
 
-	if (I2C_SPEED_GET(device_config) == I2C_SPEED_DT) {
-		bb_config = i2c_map_dt_bitrate(cfg->bitrate) | I2C_MODE_CONTROLLER;
-	} else {
-		bb_config = device_config;
-	}
-
-	error = i2c_bitbang_configure(&bitbang_ctx, bb_config);
-	if (error != 0) {
-		LOG_ERR("failed to configure I2C bitbang (err %d)", error);
-		goto restore;
+	/* Use Fast speed (highest supported by bitbang) if not standard speed (bitbang default) */
+	switch (I2C_SPEED_GET(device_config)) {
+	case I2C_SPEED_STANDARD:
+		break;
+	case I2C_SPEED_DT:
+		if (config->bitrate == I2C_BITRATE_STANDARD) {
+			break;
+		}
+		__fallthrough;
+	default:
+		error = i2c_bitbang_configure(&bitbang_ctx, I2C_SPEED_SET(I2C_SPEED_FAST));
+		if (error != 0) {
+			LOG_ERR("failed to configure I2C bitbang (err %d)", error);
+			goto restore;
+		}
 	}
 
 	error = i2c_bitbang_recover_bus(&bitbang_ctx);

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -514,7 +514,10 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 
 	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
+	k_sem_take(&data->bus_mutex, K_FOREVER);
 	ret = i2c_stm32_runtime_configure(dev, bitrate_cfg);
+	k_sem_give(&data->bus_mutex);
+
 	if (ret < 0) {
 		LOG_ERR("i2c: failure initializing");
 		return ret;

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -508,7 +508,10 @@ int i2c_stm32_target_register(const struct device *dev,
 
 	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
+	k_sem_take(&data->bus_mutex, K_FOREVER);
 	ret = i2c_stm32_runtime_configure(dev, bitrate_cfg);
+	k_sem_give(&data->bus_mutex);
+
 	if (ret < 0) {
 		LOG_ERR("i2c: failure initializing");
 		return ret;


### PR DESCRIPTION
Correct the STM32 I2C bus recovery sequence in the non-RTIO driver where bus semaphore (acting as a mutex) was taken twice before this change. Fix that by taking the semaphore outside of the `i2c_stm32_recover_bus()` and `i2c_stm32_runtime_configure()` functions.

Execute bus recovery a I2C speed up to Fast (400kbs) since software bitbang sequence does not support higher rates.

Fixes: #115649