### PR TITLE
pm: device_runtime: Add macro for adaptive runtime PM puts

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -299,6 +299,7 @@ New APIs and options
   * :c:macro:`LOG_INST_DBG_PM_DEVICE_RUNTIME_PUT`
   * :c:macro:`LOG_INST_WRN_PM_DEVICE_RUNTIME_PUT`
   * :c:macro:`LOG_INST_ERR_PM_DEVICE_RUNTIME_PUT`
+  * :c:macro:`PM_DEVICE_RUNTIME_PUT_ASYNC_IF_ENABLED`
 
 * Ring buffer
 

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -228,6 +228,20 @@ static inline int pm_device_runtime_usage(const struct device *dev)
 #endif
 
 /**
+ * @brief Suspend a device based on usage count (asynchronously if enabled).
+ *
+ * @details Call @ref pm_device_runtime_put_async() if @kconfig{CONFIG_PM_DEVICE_RUNTIME_ASYNC}
+ * is enabled. Otherwise, fall back to @ref pm_device_runtime_put().
+ *
+ * @param dev Device instance.
+ * @param delay Minimum amount of time before triggering the action.
+ */
+#define PM_DEVICE_RUNTIME_PUT_ASYNC_IF_ENABLED(dev, delay) \
+	COND_CODE_1(IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME_ASYNC), \
+		    (pm_device_runtime_put_async(dev, delay)), \
+		    (pm_device_runtime_put(dev)))
+
+/**
  * @brief Writes a "failed to resume" debug message to the log.
  *
  * @details Writes a "failed to resume" debug message to the log using the

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -562,6 +562,47 @@ ZTEST(device_runtime_api, test_log_macros)
 	zassert_str_equal(test_log.msg, "Failed to suspend test_dev (-5)", "unexpected log output");
 }
 
+ZTEST(device_runtime_api, test_helper_macros)
+{
+	enum pm_device_state state;
+	int ret;
+
+	ret = pm_device_runtime_get(test_dev);
+	zassert_equal(ret, 0);
+	zassert_equal(pm_device_runtime_usage(test_dev), 1);
+
+	(void)pm_device_state_get(test_dev, &state);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME_ASYNC
+	if (!IS_ENABLED(CONFIG_TEST_PM_DEVICE_ISR_SAFE)) {
+		test_driver_pm_async(test_dev);
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME_ASYNC */
+
+	ret = PM_DEVICE_RUNTIME_PUT_ASYNC_IF_ENABLED(test_dev, K_NO_WAIT);
+	zassert_equal(ret, 0);
+	zassert_equal(pm_device_runtime_usage(test_dev), 0);
+
+	(void)pm_device_state_get(test_dev, &state);
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME_ASYNC
+	if (IS_ENABLED(CONFIG_TEST_PM_DEVICE_ISR_SAFE)) {
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+	} else {
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
+
+		test_driver_pm_done(test_dev);
+		k_yield();
+
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+	}
+#else /* !CONFIG_PM_DEVICE_RUNTIME_ASYNC */
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+#endif /* CONFIG_PM_DEVICE_RUNTIME_ASYNC */
+}
+
 void *device_runtime_api_setup(void)
 {
 	test_dev = device_get_binding("test_driver");


### PR DESCRIPTION
Device drivers and subsystems that do not specifically require synchronous or asynchronous device suspensions should defer to the application via `CONFIG_PM_DEVICE_RUNTIME_ASYNC`.

But, device drivers and subsystems that want to optionally support asynchronous runtime PM puts must implement a check that looks like...

```
if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME_ASYNC)) {
        (void)pm_device_runtime_put_async(dev, K_NO_WAIT);
} else {
        (void)pm_device_runtime_put(dev);
}
```

...because `pm_device_runtime_put_async()` resolves to `-ENOSYS` when `CONFIG_PM_DEVICE_RUNTIME_ASYNC=n`.

An in-tree example of this is `/drivers/flash/flash_mspi_nor.c`:

https://github.com/zephyrproject-rtos/zephyr/blob/9fec73bf4827cf3c26c96350cf007d76ec78e4c0/drivers/flash/flash_mspi_nor.c#L252-L262

This PR adds a macro `PM_DEVICE_RUNTIME_ASYNC_IF_ENABLED()` that resolves to `pm_device_runtime_put_async()` when `CONFIG_PM_DEVICE_RUNTIME_ASYNC=y` and `pm_device_runtime_put()` otherwise, which would simplify the example above to

```
(void)PM_DEVICE_RUNTIME_PUT_ASYNC_IF_ENABLED(dev, K_NO_WAIT);
```

Adding a visible macro will also encourage device drivers and subsystems to support asynchronous puts when impartial.