### PR TITLE
tests: drivers: mipi_dbi: run the api scenario on native_sim

### DIFF
--- a/tests/drivers/mipi_dbi/api/overlays/mipi_dbi_bitbang.overlay
+++ b/tests/drivers/mipi_dbi/api/overlays/mipi_dbi_bitbang.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Hsiu-Chi Tsai
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The eight data lines share one emulated port, so this also covers the driver's
+ * single-port lookup-table path rather than only its per-pin fallback.
+ */
+/ {
+	mipi_dbi: mipi_dbi {
+		status = "okay";
+		compatible = "zephyr,mipi-dbi-bitbang";
+		reset-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		wr-gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		rd-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		data-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>,
+			     <&gpio0 1 GPIO_ACTIVE_HIGH>,
+			     <&gpio0 2 GPIO_ACTIVE_HIGH>,
+			     <&gpio0 3 GPIO_ACTIVE_HIGH>,
+			     <&gpio0 4 GPIO_ACTIVE_HIGH>,
+			     <&gpio0 5 GPIO_ACTIVE_HIGH>,
+			     <&gpio0 6 GPIO_ACTIVE_HIGH>,
+			     <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};

--- a/tests/drivers/mipi_dbi/api/src/main.c
+++ b/tests/drivers/mipi_dbi/api/src/main.c
@@ -7,12 +7,14 @@
 #include <zephyr/drivers/mipi_dbi.h>
 #include <zephyr/ztest.h>
 
+#if DT_NODE_HAS_COMPAT(DT_NODELABEL(mipi_dbi), zephyr_mipi_dbi_bitbang)
+BUILD_ASSERT(DT_PROP_LEN(DT_NODELABEL(mipi_dbi), data_gpios) == 8,
+	     "the bit-banged fixture must declare an eight-bit data bus");
+#endif
+
 static const uint8_t modes[] = {
 	MIPI_DBI_MODE_8080_BUS_8_BIT,
-/*
- * A bit-banged controller drives exactly as many data lines as its
- * data-gpios property lists, so only the matching mode belongs here.
- */
+/* A bit-banged controller drives only the width its data-gpios lists. */
 #if !DT_NODE_HAS_COMPAT(DT_NODELABEL(mipi_dbi), zephyr_mipi_dbi_bitbang)
 #ifndef MULTIPLE_INSTANCES
 	MIPI_DBI_MODE_8080_BUS_9_BIT,
@@ -30,7 +32,7 @@ static const struct device *const devices[] = {DEVICE_DT_GET(DT_NODELABEL(mipi_d
 ZTEST(mipi_dbi_api, test_mipi_dbi_command_write)
 {
 	int ret;
-	struct mipi_dbi_config config;
+	struct mipi_dbi_config config = {0};
 
 	uint8_t cmd = 0xff;
 	uint8_t data[] = {0x00, 0xff, 0x00, 0xff};
@@ -39,7 +41,7 @@ ZTEST(mipi_dbi_api, test_mipi_dbi_command_write)
 		for (int j = 0; j < ARRAY_SIZE(modes); ++j) {
 			config.mode = modes[j];
 			ret = mipi_dbi_command_write(devices[i], &config, cmd, data, sizeof(data));
-			zassert_equal(ret, 0, "Expected 0 but was %u", ret);
+			zassert_equal(ret, 0, "Expected 0 but was %d", ret);
 		}
 	}
 }
@@ -47,7 +49,7 @@ ZTEST(mipi_dbi_api, test_mipi_dbi_command_write)
 ZTEST(mipi_dbi_api, test_mipi_dbi_command_write_cmd_only)
 {
 	int ret;
-	struct mipi_dbi_config config;
+	struct mipi_dbi_config config = {0};
 
 	uint8_t cmd = 0xff;
 
@@ -55,7 +57,7 @@ ZTEST(mipi_dbi_api, test_mipi_dbi_command_write_cmd_only)
 		for (int j = 0; j < ARRAY_SIZE(modes); ++j) {
 			config.mode = modes[j];
 			ret = mipi_dbi_command_write(devices[i], &config, cmd, NULL, 0);
-			zassert_equal(ret, 0, "Expected 0 but was %u", ret);
+			zassert_equal(ret, 0, "Expected 0 but was %d", ret);
 		}
 	}
 }
@@ -63,8 +65,12 @@ ZTEST(mipi_dbi_api, test_mipi_dbi_command_write_cmd_only)
 ZTEST(mipi_dbi_api, test_mipi_dbi_write_display)
 {
 	int ret;
-	struct mipi_dbi_config config;
-	struct display_buffer_descriptor descriptor;
+	struct mipi_dbi_config config = {0};
+	struct display_buffer_descriptor descriptor = {
+		.width = 2,
+		.height = 1,
+		.pitch = 2,
+	};
 
 	uint8_t data[] = {0x00, 0xff, 0x00, 0xff};
 
@@ -75,7 +81,7 @@ ZTEST(mipi_dbi_api, test_mipi_dbi_write_display)
 			config.mode = modes[j];
 			ret = mipi_dbi_write_display(devices[i], &config, data, &descriptor,
 						      PIXEL_FORMAT_RGB_565);
-			zassert_equal(ret, 0, "Expected 0 but was %u", ret);
+			zassert_equal(ret, 0, "Expected 0 but was %d", ret);
 		}
 	}
 }
@@ -85,10 +91,8 @@ ZTEST(mipi_dbi_api, test_mipi_dbi_reset)
 	int ret;
 
 	for (int i = 0; i < ARRAY_SIZE(devices); ++i) {
-		for (int j = 0; j < ARRAY_SIZE(modes); ++j) {
-			ret = mipi_dbi_reset(devices[i], 100);
-			zassert_equal(ret, 0, "Expected 0 but was %u", ret);
-		}
+		ret = mipi_dbi_reset(devices[i], 100);
+		zassert_equal(ret, 0, "Expected 0 but was %d", ret);
 	}
 }
 

--- a/tests/drivers/mipi_dbi/api/src/main.c
+++ b/tests/drivers/mipi_dbi/api/src/main.c
@@ -9,9 +9,15 @@
 
 static const uint8_t modes[] = {
 	MIPI_DBI_MODE_8080_BUS_8_BIT,
+/*
+ * A bit-banged controller drives exactly as many data lines as its
+ * data-gpios property lists, so only the matching mode belongs here.
+ */
+#if !DT_NODE_HAS_COMPAT(DT_NODELABEL(mipi_dbi), zephyr_mipi_dbi_bitbang)
 #ifndef MULTIPLE_INSTANCES
 	MIPI_DBI_MODE_8080_BUS_9_BIT,
 	MIPI_DBI_MODE_8080_BUS_16_BIT,
+#endif
 #endif
 };
 

--- a/tests/drivers/mipi_dbi/api/tests.yaml
+++ b/tests/drivers/mipi_dbi/api/tests.yaml
@@ -5,7 +5,11 @@ common:
 
 tests:
   drivers.mipi_dbi.api:
-    filter: dt_nodelabel_enabled("mipi-dbi")
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_args:
+      - DTC_OVERLAY_FILE=overlays/mipi_dbi_bitbang.overlay
   drivers.mipi_dbi.rpi_pico.pio0.single_split:
     platform_allow:
       - rpi_pico/rp2040


### PR DESCRIPTION
`drivers.mipi_dbi.api` has never executed. Its filter is `dt_nodelabel_enabled("mipi-dbi")`, and a devicetree label cannot contain a dash, so that lookup never matches and twister filters the scenario at runtime on every platform.

```
$ python3 -c "import sys; sys.path.insert(0,'scripts/dts/python-devicetree/src'); \
  from devicetree import dtlib; dtlib.DT('/tmp/a.dts')"   # a.dts holds 'mipi-dbi: node {};'
devicetree.dtlib.DTError: /tmp/a.dts:3 (column 10): parse error: expected '{', '=', or ';'
```

The same file with `mipi_dbi:` parses. Both `dt_nodelabel_enabled()` implementations, in `scripts/kconfig/kconfigfunctions.py` and in twister's `expr_parser.py`, are an exact `edt.label2node.get(label)`, so there is no spelling of a dashed label that could match.

Correcting the spelling on its own would revive a suite that fails. Every board defining the `mipi_dbi` label backs it with `zephyr,mipi-dbi-spi`, and the suite drives only the three 8080 modes; `mipi_dbi_spi_write_helper()` handles `MIPI_DBI_MODE_SPI_3WIRE` and `MIPI_DBI_MODE_SPI_4WIRE` and falls through to `-ENOTSUP` for anything else, while the assertions expect 0.

So this gives the scenario a controller it can drive instead: a bit-banged 8080 node on the native_sim emulated GPIO port, selected with `platform_allow` and added with `EXTRA_DTC_OVERLAY_FILE` like the `rpi_pico` scenarios beside it. On `native_sim` that also pulls in `boards/native_sim.overlay` from #110156, whose `zephyr,mipi-dbi-spi` node sits on the `vnd,gpio` stub and fails init with -95, so the scenario turns `CONFIG_MIPI_DBI_SPI` off the way the config scenario does; the two colour-coding checks from that overlay come along and pass. The fixture's eight data lines share one port, so the driver takes its lookup-table path rather than the per-pin fallback.

`zephyr,mipi-dbi-bitbang` had no in-tree devicetree user before this, so this is also its first coverage.

A bit-banged controller takes its bus width from `DT_INST_PROP_LEN(n, data_gpios)`, so the suite's 9- and 16-bit modes are skipped when the bound controller is `zephyr,mipi-dbi-bitbang`. This fixture has eight data lines and exercises 8080 8-bit only.

The second commit gives the tests deterministic inputs: `struct mipi_dbi_config` is zero-initialised before `.mode` is set, the display buffer descriptor carries `width`, `height` and `pitch` next to `buf_size`, the reset test no longer repeats once per transfer mode, and four `%u` on a signed `ret` become `%d`. The third replaces the `__ASSERT_NO_MSG` in the suite setup with `zassert_true`, so a missing controller fails the suite instead of halting the binary.

Measured with twister on this branch:

```
before  (main at the time) 8 configurations filtered (7 static, 1 at runtime), 0 of 0 executed
after   native_sim            6 of 6 executed test cases passed  (4 api, 2 colour-coding from the board overlay)
        native_sim/native/64  4 of 4 executed test cases passed
```

This is intentionally a return-code smoke test: it proves the node binds, the driver initialises, and the mode matching its data lines is accepted. Checking the GPIO mapping and the waveform is out of scope here, and this is how far that goes. I broke the bit-banged write path six ways, one at a time, and all four cases passed every time: data port never written, data byte inverted, data byte forced to zero, D/C inverted, CS never asserted, WR strobe never raised. The fixture puts all eight data lines on one port, so `init()` sets `single_port` and the LUT branch is the live one; the per-pin fallback beside it does not run here. Catching any of these would need the emulated port read back at the strobe edges.

`native_sim/native/64` is in `platform_allow` but does not appear in this PR's CI, and adding `integration_platforms` to this scenario would not change that. The plan for a change under `tests/` comes from `DirectTestStrategy`, which runs twister without `--integration`, and in that mode a suite with a `platform_allow` gets the intersection of the default platforms and that allowlist when the intersection is non-empty (`testplan.py`). `native_sim` is a default platform and `/64` is not, so the intersection is `native_sim` alone. The later `--load-tests` step runs the plan it was given rather than widening it. I checked this by generating the plan with and without the field, which gave the same instances, and with `--integration`, which gave both. The `/64` figures below are from a separate local run.

The alternative I did not take: keep the scenario generic and have the suite ask the bound controller which modes it supports, so an SPI-backed `mipi_dbi` node would exercise the SPI modes instead. That is a larger change to a suite I do not own, and I would rather it be chosen than assumed. Happy to go that way if you prefer.

Fixes #114741



