### PR TITLE
mgmt: ec_host_cmd: prevent OUT EP re-arm while command active

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
@@ -373,6 +373,16 @@ static void ec_host_cmd_enable(struct usbd_class_data *const c_data)
 		return;
 	}
 
+	/* Prevent re-arming RX DMA while a command is being processed or sent. */
+	if (ctx->state == USB_EC_HOST_CMD_STATE_PROCESSING ||
+	    ctx->state == USB_EC_HOST_CMD_STATE_SENDING) {
+		LOG_WRN("Skip re-arming OUT EP in state: %s", state_name[ctx->state]);
+		if (ctx->pending_event) {
+			ec_host_cmd_signal_event(c_data);
+		}
+		return;
+	}
+
 	/* Update EP IN address. Buf is allocated in the backend init procedure. */
 	bi = udc_get_buf_info(ctx->usb_tx_buf);
 	bi->ep = ec_host_cmd_get_in_bulk_ep(c_data);


### PR DESCRIPTION
In `ec_host_cmd_enable()`, check if the backend is currently in the PROCESSING or SENDING state. If so, skip re-allocating and enqueuing the Bulk-OUT endpoint buffer to avoid modifying the active receive buffer during command processing. Signal any pending event before returning.