### PR TITLE
dap: add SWO trace capture support

### DIFF
--- a/include/zephyr/dap/dap_link.h
+++ b/include/zephyr/dap/dap_link.h
@@ -17,6 +17,10 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/swdp.h>
 
+#ifdef CONFIG_DAP_SWO
+#include <zephyr/dap/dap_swo.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,6 +58,10 @@ struct dap_link_context {
 		/* Match Mask */
 		uint32_t match_mask;
 	} transfer;
+#ifdef CONFIG_DAP_SWO
+	/* SWO trace capture state */
+	struct dap_swo_context swo;
+#endif
 	/** @endcond */
 };
 

--- a/include/zephyr/dap/dap_swo.h
+++ b/include/zephyr/dap/dap_swo.h
@@ -1,0 +1,160 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup dap_link_interface
+ * @brief SWO trace capture support for the DAP Link API.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DAP_DAP_SWO_H
+#define ZEPHYR_INCLUDE_DAP_DAP_SWO_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/ring_buffer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup dap_link_interface
+ * @{
+ */
+
+struct dap_link_context;
+
+/**
+ * @brief SWO capture backend.
+ *
+ * The DAP subsystem is hardware agnostic: capturing the SWO pin
+ * (typically with a UART receiver) is the application's job. The
+ * application implements this backend, registers it with
+ * dap_swo_backend_register(), and pushes captured bytes into the
+ * trace buffer with dap_swo_rx() while capture is started.
+ */
+struct dap_swo_backend {
+	/**
+	 * Configure the capture rate, in bits per second.
+	 *
+	 * Called with capture stopped. The backend may adjust the rate
+	 * to the nearest one it supports and must write the actual rate
+	 * back through @a baudrate; the actual rate is reported to the
+	 * host (DAP_SWO_Baudrate response).
+	 *
+	 * @retval 0 on success, negative errno otherwise.
+	 */
+	int (*configure)(uint32_t *baudrate);
+	/**
+	 * Start capturing. While started, the backend pushes received
+	 * bytes with dap_swo_rx() (ISR context is fine).
+	 *
+	 * @retval 0 on success, negative errno otherwise.
+	 */
+	int (*start)(void);
+	/**
+	 * Stop capturing. No dap_swo_rx() calls may arrive after this
+	 * returns.
+	 *
+	 * @retval 0 on success, negative errno otherwise.
+	 */
+	int (*stop)(void);
+};
+
+/** @cond INTERNAL_HIDDEN */
+struct dap_swo_context {
+	const struct dap_swo_backend *backend;
+	/* Streaming transport data-available callback (USB backend). */
+	void (*stream_kick)(void);
+	/* Serializes the consumer side and the capture state machine:
+	 * ring reads, the reset on capture start, and the stop paths
+	 * (command, disconnect, transport loss) may run on different
+	 * threads. The producer (dap_swo_rx, ISR) stays lock-free.
+	 */
+	struct k_mutex lock;
+	struct ring_buf rb;
+	uint32_t baudrate;
+	/* Latched error flags (trace overrun, stream error), set from ISR
+	 * and thread context, reported through the trace status byte and
+	 * cleared once reported — see swo_trace_status_take().
+	 */
+	atomic_t err;
+	uint8_t transport;
+	uint8_t mode;
+	bool active;
+	uint8_t buf[CONFIG_DAP_SWO_BUFFER_SIZE];
+};
+/** @endcond */
+
+/**
+ * @brief Register the SWO capture backend.
+ *
+ * Registering advertises SWO UART support (and, with a streaming
+ * capable DAP backend, SWO Streaming Trace) in the DAP capabilities.
+ *
+ * @param[in] dap_link_ctx DAP Link context.
+ * @param[in] backend Capture backend to register.
+ *
+ * @retval 0 Successfully registered.
+ * @retval -EINVAL on a malformed backend (missing callbacks).
+ * @retval -EBUSY if trace capture is currently active.
+ */
+int dap_swo_backend_register(struct dap_link_context *const dap_link_ctx,
+			     const struct dap_swo_backend *backend);
+
+/**
+ * @brief Whether SWO trace capture is currently started.
+ *
+ * @param[in] dap_link_ctx DAP Link context.
+ *
+ * @return true between a successful capture start and the matching
+ * stop (from DAP_SWO_Control, DAP_Disconnect, or transport loss).
+ */
+bool dap_swo_is_active(struct dap_link_context *const dap_link_ctx);
+
+/**
+ * @brief Push captured trace bytes into the trace buffer.
+ *
+ * Called by the capture backend, typically from the receiver ISR.
+ * Bytes that do not fit are dropped and the buffer overrun status
+ * flag is set until the next capture start.
+ *
+ * @param[in] dap_link_ctx DAP Link context.
+ * @param[in] data Captured bytes.
+ * @param[in] len Number of captured bytes.
+ *
+ * @return Number of bytes stored.
+ */
+uint32_t dap_swo_rx(struct dap_link_context *const dap_link_ctx,
+		    const uint8_t *data, uint32_t len);
+
+/**
+ * @brief Report trace data lost in the capture path.
+ *
+ * Called by the capture backend when its receiver lost trace bytes
+ * before they could reach dap_swo_rx() (hardware FIFO overrun, DMA
+ * overwrite, ...). Sets the same overrun status flag as an internal
+ * trace-buffer overflow. Like the reference implementation, the flag
+ * is latched and cleared once reported through a DAP_SWO_Status or
+ * DAP_SWO_Data response (and on capture start), so one transient
+ * overrun does not read as continuous loss for the rest of the
+ * capture. Without this, a receiver-side overrun would read back as
+ * a clean capture. Ignored while capture is stopped. ISR context is
+ * fine.
+ *
+ * @param[in] dap_link_ctx DAP Link context.
+ */
+void dap_swo_overrun(struct dap_link_context *const dap_link_ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DAP_DAP_SWO_H */

--- a/subsys/dap/CMakeLists.txt
+++ b/subsys/dap/CMakeLists.txt
@@ -7,3 +7,4 @@ zephyr_library()
 zephyr_library_sources(cmsis_dap.c)
 
 zephyr_library_sources_ifdef(CONFIG_DAP_BACKEND_USB dap_backend_usb.c)
+zephyr_library_sources_ifdef(CONFIG_DAP_SWO dap_swo.c)

--- a/subsys/dap/Kconfig
+++ b/subsys/dap/Kconfig
@@ -47,6 +47,25 @@ config DAP_BACKEND_USB
 	help
 	  DAP USB backend using bulk endpoints.
 
+config DAP_SWO
+	bool "SWO trace capture (UART mode)"
+	select RING_BUFFER
+	help
+	  Support the DAP_SWO_* command set for Serial Wire Output trace
+	  capture. The application provides the capture backend (typically
+	  a UART receiver on the SWO pin) via dap_swo_backend_register()
+	  and pushes captured bytes with dap_swo_rx(). Trace data reaches
+	  the host either through DAP_SWO_Data responses or, with the USB
+	  backend, through a dedicated bulk IN trace endpoint.
+
+config DAP_SWO_BUFFER_SIZE
+	int "SWO trace buffer size in bytes"
+	depends on DAP_SWO
+	default 2048
+	help
+	  Size of the trace buffer between the capture backend and the
+	  host transport. Reported to the host via DAP_ID_SWO_BUFFER_SIZE.
+
 module = DAP
 module-str = dap
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/dap/cmsis_dap.c
+++ b/subsys/dap/cmsis_dap.c
@@ -123,7 +123,13 @@ static uint16_t dap_info(struct dap_link_context *const ctx,
 		LOG_DBG("ID_UART_TX_BUFFER_SIZE unsupported");
 		break;
 	case DAP_ID_SWO_BUFFER_SIZE:
+#ifdef CONFIG_DAP_SWO
+		LOG_DBG("ID_SWO_BUFFER_SIZE");
+		sys_put_le32(CONFIG_DAP_SWO_BUFFER_SIZE, &info[0]);
+		length = 4U;
+#else
 		LOG_DBG("ID_SWO_BUFFER_SIZE unsupported");
+#endif
 		break;
 	case DAP_ID_PACKET_SIZE:
 		LOG_DBG("ID_PACKET_SIZE");
@@ -224,6 +230,17 @@ static uint16_t dap_disconnect(struct dap_link_context *const ctx,
 	} else {
 		LOG_WRN("DAP device is not connected");
 	}
+
+#ifdef CONFIG_DAP_SWO
+	/* The debug session ends here, and the trace session it
+	 * configured ends with it. This is also half of the ungraceful
+	 * exit recovery (the other half is the DAP backend's transport
+	 * loss hook): a capture left running by a host that never sent
+	 * DAP_SWO_Control(0) is reaped by the next session's or the
+	 * cleanup tool's disconnect instead of leaking until reboot.
+	 */
+	dap_swo_capture_stop(ctx);
+#endif
 
 	response[0] = DAP_OK;
 	atomic_clear_bit(&ctx->state, DAP_STATE_CONNECTED);
@@ -913,6 +930,26 @@ static uint16_t dap_process_cmd(struct dap_link_context *const ctx,
 	case ID_DAP_WRITE_ABORT:
 		retval = dap_writeabort(ctx, request, response);
 		break;
+#ifdef CONFIG_DAP_SWO
+	case ID_DAP_SWO_TRANSPORT:
+		retval = dap_swo_transport_cmd(ctx, request, response);
+		break;
+	case ID_DAP_SWO_MODE:
+		retval = dap_swo_mode_cmd(ctx, request, response);
+		break;
+	case ID_DAP_SWO_BAUDRATE:
+		retval = dap_swo_baudrate_cmd(ctx, request, response);
+		break;
+	case ID_DAP_SWO_CONTROL:
+		retval = dap_swo_control_cmd(ctx, request, response);
+		break;
+	case ID_DAP_SWO_STATUS:
+		retval = dap_swo_status_cmd(ctx, response);
+		break;
+	case ID_DAP_SWO_DATA:
+		retval = dap_swo_data_cmd(ctx, request, response);
+		break;
+#else
 	case ID_DAP_SWO_TRANSPORT:
 		LOG_ERR("SWO Transport unsupported");
 		retval = 1;
@@ -943,6 +980,7 @@ static uint16_t dap_process_cmd(struct dap_link_context *const ctx,
 		retval = 1;
 		*response = DAP_ERROR;
 		break;
+#endif /* CONFIG_DAP_SWO */
 	case ID_DAP_UART_TRANSPORT:
 		LOG_ERR("UART Transport unsupported");
 		retval = 1;
@@ -1034,6 +1072,10 @@ int dap_link_init(struct dap_link_context *const dap_link_ctx)
 	dap_link_ctx->transfer.match_mask = 0U;
 	dap_link_ctx->capabilities = DAP_SUPPORTS_ATOMIC_COMMANDS |
 				     DAP_DP_SUPPORTS_SWD;
+
+#ifdef CONFIG_DAP_SWO
+	dap_swo_init(dap_link_ctx);
+#endif
 
 	return 0;
 }

--- a/subsys/dap/cmsis_dap.h
+++ b/subsys/dap/cmsis_dap.h
@@ -126,11 +126,54 @@
 #define DP_RESEND				0x08U
 #define DP_RDBUFF				0x0CU
 
+/* SWO transport (DAP_SWO_Transport) */
+#define DAP_SWO_TRANSPORT_NONE			0U
+#define DAP_SWO_TRANSPORT_CMD			1U
+#define DAP_SWO_TRANSPORT_EP			2U
+
+/* SWO mode (DAP_SWO_Mode) */
+#define DAP_SWO_MODE_OFF			0U
+#define DAP_SWO_MODE_UART			1U
+#define DAP_SWO_MODE_MANCHESTER			2U
+
+/* SWO trace status (DAP_SWO_Status, DAP_SWO_Data) */
+#define DAP_SWO_STATUS_ACTIVE			BIT(0)
+#define DAP_SWO_STATUS_ERROR			BIT(6)
+#define DAP_SWO_STATUS_OVERRUN			BIT(7)
+
 #define DAP_MBMSG_REGISTER_IFACE		0x0U
 #define DAP_MBMSG_FROM_IFACE			0x1U
 #define DAP_MBMSG_FROM_CONTROLLER		0x2U
 
 uint32_t dap_link_execute_cmd(struct dap_link_context *const dap_link_ctx,
 			      const uint8_t *request, uint8_t *response);
+
+#ifdef CONFIG_DAP_SWO
+/* SWO core, subsystem internal (dap_swo.c) */
+void dap_swo_init(struct dap_link_context *const ctx);
+void dap_swo_stream_bind(struct dap_link_context *const ctx,
+			 void (*kick)(void));
+uint32_t dap_swo_read(struct dap_link_context *const ctx,
+		      uint8_t *dst, uint32_t max_len);
+void dap_swo_stream_error(struct dap_link_context *const ctx);
+void dap_swo_capture_stop(struct dap_link_context *const ctx);
+uint16_t dap_swo_transport_cmd(struct dap_link_context *const ctx,
+			       const uint8_t *const request,
+			       uint8_t *const response);
+uint16_t dap_swo_mode_cmd(struct dap_link_context *const ctx,
+			  const uint8_t *const request,
+			  uint8_t *const response);
+uint16_t dap_swo_baudrate_cmd(struct dap_link_context *const ctx,
+			      const uint8_t *const request,
+			      uint8_t *const response);
+uint16_t dap_swo_control_cmd(struct dap_link_context *const ctx,
+			     const uint8_t *const request,
+			     uint8_t *const response);
+uint16_t dap_swo_status_cmd(struct dap_link_context *const ctx,
+			    uint8_t *const response);
+uint16_t dap_swo_data_cmd(struct dap_link_context *const ctx,
+			  const uint8_t *const request,
+			  uint8_t *const response);
+#endif /* CONFIG_DAP_SWO */
 
 #endif	/* ZEPHYR_INCLUDE_CMSIS_DAP_H_ */

--- a/subsys/dap/dap_backend_usb.c
+++ b/subsys/dap/dap_backend_usb.c
@@ -25,16 +25,36 @@ NET_BUF_POOL_FIXED_DEFINE(dap_func_pool,
 
 UDC_STATIC_BUF_DEFINE(dap_func_buf, 512);
 
+#ifdef CONFIG_DAP_SWO
+NET_BUF_POOL_FIXED_DEFINE(dap_trace_pool,
+			  1, 0, sizeof(struct udc_buf_info), NULL);
+
+/* One trace-EP transfer: full-speed builds never move more than one
+ * 64-byte packet per transfer, so sizing for high speed there would
+ * waste 448 bytes of buffer that no code path can fill.
+ */
+UDC_STATIC_BUF_DEFINE(dap_trace_buf, USBD_SUPPORTS_HIGH_SPEED ? 512 : 64);
+
+static struct k_work dap_trace_work;
+#endif
+
 struct dap_func_desc {
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_out_ep;
 	struct usb_ep_descriptor if0_in_ep;
+#ifdef CONFIG_DAP_SWO
+	struct usb_ep_descriptor if0_swo_in_ep;
+#endif
 	struct usb_ep_descriptor if0_hs_out_ep;
 	struct usb_ep_descriptor if0_hs_in_ep;
+#ifdef CONFIG_DAP_SWO
+	struct usb_ep_descriptor if0_hs_swo_in_ep;
+#endif
 	struct usb_desc_header nil_desc;
 };
 
 #define SAMPLE_FUNCTION_ENABLED		0
+#define DAP_FUNCTION_TRACE_BUSY		1
 
 struct dap_func_data {
 	struct dap_func_desc *const desc;
@@ -71,6 +91,21 @@ static uint8_t dap_func_get_bulk_in(struct usbd_class_data *const c_data)
 	return desc->if0_in_ep.bEndpointAddress;
 }
 
+#ifdef CONFIG_DAP_SWO
+static uint8_t dap_func_get_trace_in(struct usbd_class_data *const c_data)
+{
+	struct dap_func_data *data = usbd_class_get_private(c_data);
+	struct usbd_context *uds_ctx = usbd_class_get_ctx(c_data);
+	struct dap_func_desc *desc = data->desc;
+
+	if (usbd_bus_speed(uds_ctx) == USBD_SPEED_HS) {
+		return desc->if0_hs_swo_in_ep.bEndpointAddress;
+	}
+
+	return desc->if0_swo_in_ep.bEndpointAddress;
+}
+#endif
+
 static int dap_func_request_handler(struct usbd_class_data *c_data,
 				  struct net_buf *buf, int err)
 {
@@ -81,6 +116,30 @@ static int dap_func_request_handler(struct usbd_class_data *c_data,
 	bi = (struct udc_buf_info *)net_buf_user_data(buf);
 	LOG_DBG("Transfer finished %p -> ep 0x%02x, len %u, err %d",
 		(void *)c_data, bi->ep, buf->len, err);
+
+#ifdef CONFIG_DAP_SWO
+	if (bi->ep == dap_func_get_trace_in(c_data)) {
+		size_t lost = buf->len;
+
+		usbd_ep_buf_free(uds_ctx, buf);
+		atomic_clear_bit(&data->state, DAP_FUNCTION_TRACE_BUSY);
+		if (err == 0 &&
+		    atomic_test_bit(&data->state, SAMPLE_FUNCTION_ENABLED)) {
+			k_work_submit(&dap_trace_work);
+		} else if (err != 0) {
+			/* The transfer's bytes were already consumed out
+			 * of the trace ring and are gone with it. Silent
+			 * loss must not read back as a clean capture --
+			 * report it the same way as any other trace loss.
+			 */
+			LOG_WRN("Trace transfer failed (%d), %zu bytes lost",
+				err, lost);
+			dap_swo_stream_error(data->dap_link_ctx);
+		}
+
+		return 0;
+	}
+#endif
 
 	if (atomic_test_bit(&data->state, SAMPLE_FUNCTION_ENABLED) && err == 0) {
 		uint8_t ep = bi->ep;
@@ -185,6 +244,26 @@ static void dap_func_disable(struct usbd_class_data *const c_data)
 	struct dap_func_data *data = usbd_class_get_private(c_data);
 
 	atomic_clear_bit(&data->state, SAMPLE_FUNCTION_ENABLED);
+#ifdef CONFIG_DAP_SWO
+	/* DAP_FUNCTION_TRACE_BUSY is deliberately NOT cleared here: it
+	 * guards the single static trace buffer against the transfer
+	 * that may still be in flight when the configuration goes down.
+	 * The stack completes every queued transfer through the request
+	 * handler (usbd_ep_disable() dequeues with -ECONNABORTED), and
+	 * that completion is the one place the bit is released --
+	 * clearing it early would let a re-enable kick reuse the buffer
+	 * while the controller can still be reading it out.
+	 */
+	/* The transport that was consuming the trace is gone (bus
+	 * reset, detach, reconfiguration). Stop capture rather than
+	 * let it outlive its host: a crashed or unplugged debugger
+	 * never sends DAP_SWO_Control(0), and the leaked capture
+	 * would hold the receiver until reboot.
+	 */
+	if (data->dap_link_ctx != NULL) {
+		dap_swo_capture_stop(data->dap_link_ctx);
+	}
+#endif
 	LOG_INF("Configuration disabled");
 }
 
@@ -226,7 +305,7 @@ static struct dap_func_desc dap_func_desc_##n = {				\
 		.bDescriptorType = USB_DESC_INTERFACE,				\
 		.bInterfaceNumber = 0,						\
 		.bAlternateSetting = 0,						\
-		.bNumEndpoints = 2,						\
+		.bNumEndpoints = COND_CODE_1(CONFIG_DAP_SWO, (3), (2)),		\
 		.bInterfaceClass = USB_BCC_VENDOR,				\
 		.bInterfaceSubClass = 0,					\
 		.bInterfaceProtocol = 0,					\
@@ -253,6 +332,18 @@ static struct dap_func_desc dap_func_desc_##n = {				\
 		.bInterval = 0x00,						\
 	},									\
 										\
+	IF_ENABLED(CONFIG_DAP_SWO, (						\
+	/* SWO trace Endpoint IN */						\
+	.if0_swo_in_ep = {							\
+		.bLength = sizeof(struct usb_ep_descriptor),			\
+		.bDescriptorType = USB_DESC_ENDPOINT,				\
+		.bEndpointAddress = 0x82,					\
+		.bmAttributes = USB_EP_TYPE_BULK,				\
+		.wMaxPacketSize = sys_cpu_to_le16(64U),				\
+		.bInterval = 0x00,						\
+	},									\
+	))									\
+										\
 	/* High-speed Endpoint OUT */						\
 	.if0_hs_out_ep = {							\
 		.bLength = sizeof(struct usb_ep_descriptor),			\
@@ -273,6 +364,18 @@ static struct dap_func_desc dap_func_desc_##n = {				\
 		.bInterval = 0x00,						\
 	},									\
 										\
+	IF_ENABLED(CONFIG_DAP_SWO, (						\
+	/* High-speed SWO trace Endpoint IN */					\
+	.if0_hs_swo_in_ep = {							\
+		.bLength = sizeof(struct usb_ep_descriptor),			\
+		.bDescriptorType = USB_DESC_ENDPOINT,				\
+		.bEndpointAddress = 0x82,					\
+		.bmAttributes = USB_EP_TYPE_BULK,				\
+		.wMaxPacketSize = sys_cpu_to_le16(512),				\
+		.bInterval = 0x00,						\
+	},									\
+	))									\
+										\
 	/* Termination descriptor */						\
 	.nil_desc = {								\
 		.bLength = 0,							\
@@ -284,6 +387,9 @@ const static struct usb_desc_header *dap_func_fs_desc_##n[] = {			\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0,			\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_out_ep,		\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_in_ep,		\
+	IF_ENABLED(CONFIG_DAP_SWO, (						\
+	(struct usb_desc_header *) &dap_func_desc_##n.if0_swo_in_ep,		\
+	))									\
 	(struct usb_desc_header *) &dap_func_desc_##n.nil_desc,			\
 };										\
 										\
@@ -291,6 +397,9 @@ const static struct usb_desc_header *dap_func_hs_desc_##n[] = {			\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0,			\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_hs_out_ep,		\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_hs_in_ep,		\
+	IF_ENABLED(CONFIG_DAP_SWO, (						\
+	(struct usb_desc_header *) &dap_func_desc_##n.if0_hs_swo_in_ep,		\
+	))									\
 	(struct usb_desc_header *) &dap_func_desc_##n.nil_desc,			\
 };
 
@@ -312,6 +421,72 @@ const static struct usb_desc_header *dap_func_hs_desc_##n[] = {			\
 LISTIFY(1, DAP_FUNC_DESCRIPTOR_DEFINE, ())
 LISTIFY(1, DAP_FUNC_FUNCTION_DATA_DEFINE, ())
 
+#ifdef CONFIG_DAP_SWO
+/*
+ * Drain the trace buffer to the trace endpoint, one transfer in
+ * flight at a time. Submitted by the SWO core on new capture data
+ * (via the stream kick) and by the completion of the previous trace
+ * transfer.
+ */
+static void dap_trace_work_handler(struct k_work *work)
+{
+	struct usbd_class_data *const c_data = &dap_func_0;
+	struct dap_func_data *data = usbd_class_get_private(c_data);
+	struct usbd_context *uds_ctx = usbd_class_get_ctx(c_data);
+	struct net_buf *buf;
+	struct udc_buf_info *bi;
+	size_t size;
+	uint32_t len;
+
+	if (!atomic_test_bit(&data->state, SAMPLE_FUNCTION_ENABLED)) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(&data->state, DAP_FUNCTION_TRACE_BUSY)) {
+		return;
+	}
+
+	if (USBD_SUPPORTS_HIGH_SPEED &&
+	    usbd_bus_speed(uds_ctx) == USBD_SPEED_HS) {
+		size = 512U;
+	} else {
+		size = 64U;
+	}
+
+	buf = net_buf_alloc_with_data(&dap_trace_pool, dap_trace_buf,
+				      size, K_NO_WAIT);
+	if (buf == NULL) {
+		LOG_ERR("Failed to allocate trace buffer");
+		atomic_clear_bit(&data->state, DAP_FUNCTION_TRACE_BUSY);
+		return;
+	}
+
+	net_buf_reset(buf);
+	len = dap_swo_read(data->dap_link_ctx, dap_trace_buf, size);
+	if (len == 0U) {
+		net_buf_unref(buf);
+		atomic_clear_bit(&data->state, DAP_FUNCTION_TRACE_BUSY);
+		return;
+	}
+
+	net_buf_add(buf, len);
+	bi = udc_get_buf_info(buf);
+	memset(bi, 0, sizeof(struct udc_buf_info));
+	bi->ep = dap_func_get_trace_in(c_data);
+
+	if (usbd_ep_enqueue(c_data, buf)) {
+		LOG_ERR("Failed to enqueue trace buffer");
+		usbd_ep_buf_free(uds_ctx, buf);
+		atomic_clear_bit(&data->state, DAP_FUNCTION_TRACE_BUSY);
+	}
+}
+
+static void dap_usb_trace_kick(void)
+{
+	k_work_submit(&dap_trace_work);
+}
+#endif /* CONFIG_DAP_SWO */
+
 int dap_link_backend_usb_init(struct dap_link_context *const dap_link_ctx)
 {
 	struct usbd_class_data *const c_data = &dap_func_0;
@@ -322,6 +497,11 @@ int dap_link_backend_usb_init(struct dap_link_context *const dap_link_ctx)
 	}
 
 	data->dap_link_ctx = dap_link_ctx;
+
+#ifdef CONFIG_DAP_SWO
+	k_work_init(&dap_trace_work, dap_trace_work_handler);
+	dap_swo_stream_bind(dap_link_ctx, dap_usb_trace_kick);
+#endif
 
 	return 0;
 }

--- a/subsys/dap/dap_swo.c
+++ b/subsys/dap/dap_swo.c
@@ -1,0 +1,460 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SWO trace capture: DAP_SWO_* command handlers and the trace buffer
+ * between the application's capture backend and the host transport.
+ *
+ * The capture hardware (typically a UART receiver on the SWO pin) is
+ * application property; see struct dap_swo_backend. Captured bytes
+ * land in a ring buffer and leave either through DAP_SWO_Data
+ * responses (transport 1) or through the DAP backend's dedicated
+ * trace endpoint (transport 2, e.g. the USB backend's bulk IN trace
+ * endpoint).
+ *
+ * Concurrency: the ring buffer has one producer (the capture backend,
+ * usually ISR context via dap_swo_rx()) and, by design, one consumer
+ * at a time -- but the consumer side cannot be left to the transport
+ * setting alone. The streaming transport drains from a work item
+ * that outlives both a capture stop (the post-stop residue drain is
+ * intentional) and a transport switch, and capture teardown is
+ * reachable from the command executor (DAP_SWO_Control, DAP_Disconnect)
+ * and the DAP backend (transport loss). The context lock serializes
+ * all of it: every consumer-side ring access, the ring reset on
+ * capture start, and the stop path hold it, so a restart cannot race
+ * a late drain and a transport switch cannot leave two live
+ * consumers. dap_swo_rx() stays lock-free (ISR): the ring buffer
+ * supports one concurrent producer against one concurrent consumer,
+ * and the reset in dap_swo_control_cmd() runs with capture stopped,
+ * when no producer exists.
+ */
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/ring_buffer.h>
+#include <zephyr/dap/dap_link.h>
+#include <zephyr/dap/dap_swo.h>
+
+#include <cmsis_dap.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(dap, CONFIG_DAP_LOG_LEVEL);
+
+/* Latched error flags in dap_swo_context.err. Split so a lost USB
+ * transfer (stream error, bit 6) stays distinguishable from a full
+ * ring or receiver overrun (buffer overrun, bit 7), as the protocol
+ * intends.
+ */
+#define SWO_ERR_OVERRUN BIT(0)
+#define SWO_ERR_STREAM  BIT(1)
+
+/*
+ * Compose the trace status byte and consume the latched error flags,
+ * mirroring the reference implementation: error bits are reported
+ * once (in a DAP_SWO_Status or DAP_SWO_Data response) and cleared, so
+ * a single transient loss does not read as continuous loss for the
+ * rest of the capture. The atomic read-and-clear gives the same
+ * guarantee the reference's banked flags do -- an error racing the
+ * read lands in the next report instead of being lost.
+ */
+static uint8_t swo_trace_status_take(struct dap_swo_context *const swo)
+{
+	atomic_val_t err = atomic_clear(&swo->err);
+	uint8_t status = 0U;
+
+	if (swo->active) {
+		status |= DAP_SWO_STATUS_ACTIVE;
+	}
+
+	if (err & SWO_ERR_STREAM) {
+		status |= DAP_SWO_STATUS_ERROR;
+	}
+
+	if (err & SWO_ERR_OVERRUN) {
+		status |= DAP_SWO_STATUS_OVERRUN;
+	}
+
+	return status;
+}
+
+void dap_swo_init(struct dap_link_context *const ctx)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+
+	swo->backend = NULL;
+	swo->stream_kick = NULL;
+	swo->baudrate = 0U;
+	swo->transport = DAP_SWO_TRANSPORT_NONE;
+	swo->mode = DAP_SWO_MODE_OFF;
+	swo->active = false;
+	atomic_clear(&swo->err);
+	k_mutex_init(&swo->lock);
+	ring_buf_init(&swo->rb, sizeof(swo->buf), swo->buf);
+}
+
+int dap_swo_backend_register(struct dap_link_context *const ctx,
+			     const struct dap_swo_backend *backend)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	int ret = 0;
+
+	if (backend == NULL || backend->configure == NULL ||
+	    backend->start == NULL || backend->stop == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	if (swo->active) {
+		ret = -EBUSY;
+	} else {
+		swo->backend = backend;
+		ctx->capabilities |= DAP_SWO_SUPPORTS_UART;
+		/* Streaming Trace is advertised from the same fact the
+		 * transport-2 admission checks: a bound stream kick. A
+		 * compile-time check would advertise it even when the
+		 * streaming-capable DAP backend failed to come up, and
+		 * the host would get DAP_ERROR from DAP_SWO_Transport(2)
+		 * on a capability the probe itself reported.
+		 */
+		if (swo->stream_kick != NULL) {
+			ctx->capabilities |= DAP_SWO_SUPPORTS_STREAM;
+		}
+	}
+
+	k_mutex_unlock(&swo->lock);
+
+	return ret;
+}
+
+void dap_swo_stream_bind(struct dap_link_context *const ctx,
+			 void (*kick)(void))
+{
+	ctx->swo.stream_kick = kick;
+
+	/* Registration may have run first; the capability follows the
+	 * bind in either order.
+	 */
+	if (kick != NULL && ctx->swo.backend != NULL) {
+		ctx->capabilities |= DAP_SWO_SUPPORTS_STREAM;
+	}
+}
+
+bool dap_swo_is_active(struct dap_link_context *const ctx)
+{
+	return ctx->swo.active;
+}
+
+uint32_t dap_swo_rx(struct dap_link_context *const ctx,
+		    const uint8_t *data, uint32_t len)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	uint32_t stored;
+
+	if (!swo->active) {
+		return 0U;
+	}
+
+	stored = ring_buf_put(&swo->rb, data, len);
+	if (stored < len) {
+		atomic_or(&swo->err, SWO_ERR_OVERRUN);
+	}
+
+	if (swo->transport == DAP_SWO_TRANSPORT_EP &&
+	    swo->stream_kick != NULL && stored > 0U) {
+		swo->stream_kick();
+	}
+
+	return stored;
+}
+
+void dap_swo_overrun(struct dap_link_context *const ctx)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+
+	if (!swo->active) {
+		return;
+	}
+
+	atomic_or(&swo->err, SWO_ERR_OVERRUN);
+}
+
+uint32_t dap_swo_read(struct dap_link_context *const ctx,
+		      uint8_t *dst, uint32_t max_len)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	uint32_t len;
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	/*
+	 * The streaming drain may still be scheduled after the host
+	 * switched transports (legal while capture is inactive): a
+	 * DAP_SWO_Data poll on the new transport would then contend
+	 * for the same ring. Deciding transport and consuming under
+	 * the lock keeps "one consumer" true across the switch --
+	 * a stale drain reads zero instead of stealing bytes.
+	 */
+	if (swo->transport != DAP_SWO_TRANSPORT_EP) {
+		len = 0U;
+	} else {
+		len = ring_buf_get(&swo->rb, dst, max_len);
+	}
+
+	k_mutex_unlock(&swo->lock);
+
+	return len;
+}
+
+void dap_swo_stream_error(struct dap_link_context *const ctx)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+
+	/*
+	 * Trace bytes already consumed out of the ring were lost in
+	 * the transport (e.g. a cancelled USB transfer). This is the
+	 * stream-error status bit, distinct from a buffer overrun,
+	 * and unlike dap_swo_overrun() it must report even after a
+	 * capture stop: the post-stop residue drain can lose bytes
+	 * the same way.
+	 */
+	atomic_or(&swo->err, SWO_ERR_STREAM);
+}
+
+void dap_swo_capture_stop(struct dap_link_context *const ctx)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+
+	/*
+	 * Reachable from DAP_SWO_Control(0), from DAP_Disconnect, and
+	 * from the DAP backend when its transport goes away (e.g. USB
+	 * configuration lost). The last two exist because capture
+	 * state must not outlive the host that created it: a debugger
+	 * that crashed or was unplugged mid-capture never sends the
+	 * stop command, and the leaked capture would hold its receiver
+	 * (and, in the application, whatever the backend claimed)
+	 * until reboot. Serialized by the lock so concurrent stop
+	 * paths cannot double-invoke the backend.
+	 */
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	if (swo->active) {
+		swo->active = false;
+		(void)swo->backend->stop();
+		LOG_DBG("SWO capture stopped");
+	}
+
+	k_mutex_unlock(&swo->lock);
+}
+
+uint16_t dap_swo_transport_cmd(struct dap_link_context *const ctx,
+			       const uint8_t *const request,
+			       uint8_t *const response)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	uint8_t transport = request[0];
+	bool supported;
+
+	switch (transport) {
+	case DAP_SWO_TRANSPORT_NONE:
+	case DAP_SWO_TRANSPORT_CMD:
+		supported = true;
+		break;
+	case DAP_SWO_TRANSPORT_EP:
+		/* Only with a streaming capable DAP backend bound. */
+		supported = swo->stream_kick != NULL;
+		break;
+	default:
+		supported = false;
+		break;
+	}
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	if (!supported || swo->active) {
+		k_mutex_unlock(&swo->lock);
+		LOG_ERR("SWO transport %u rejected (%s)", transport,
+			swo->active ? "capture active" : "unsupported");
+		response[0] = DAP_ERROR;
+		return 1U;
+	}
+
+	swo->transport = transport;
+	k_mutex_unlock(&swo->lock);
+
+	LOG_DBG("SWO transport %u", transport);
+	response[0] = DAP_OK;
+
+	return 1U;
+}
+
+uint16_t dap_swo_mode_cmd(struct dap_link_context *const ctx,
+			  const uint8_t *const request,
+			  uint8_t *const response)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	uint8_t mode = request[0];
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	if ((mode != DAP_SWO_MODE_OFF && mode != DAP_SWO_MODE_UART) ||
+	    swo->active) {
+		k_mutex_unlock(&swo->lock);
+		LOG_ERR("SWO mode %u rejected (%s)", mode,
+			swo->active ? "capture active" : "unsupported");
+		response[0] = DAP_ERROR;
+		return 1U;
+	}
+
+	swo->mode = mode;
+	k_mutex_unlock(&swo->lock);
+
+	LOG_DBG("SWO mode %u", mode);
+	response[0] = DAP_OK;
+
+	return 1U;
+}
+
+uint16_t dap_swo_baudrate_cmd(struct dap_link_context *const ctx,
+			      const uint8_t *const request,
+			      uint8_t *const response)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	uint32_t baudrate = sys_get_le32(request);
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	if (swo->active) {
+		/* The rate cannot change under a running capture; refuse
+		 * without touching the rate that capture is using.
+		 */
+		baudrate = 0U;
+	} else if (swo->backend == NULL || baudrate == 0U ||
+		   swo->backend->configure(&baudrate) != 0) {
+		/* A refused configuration leaves NO configured rate: zero
+		 * was reported, so a later DAP_SWO_Control(1) must not
+		 * silently capture at a stale rate the host no longer
+		 * believes in.
+		 */
+		swo->baudrate = 0U;
+		baudrate = 0U;
+	} else {
+		swo->baudrate = baudrate;
+	}
+
+	k_mutex_unlock(&swo->lock);
+
+	LOG_DBG("SWO baudrate %u", baudrate);
+	sys_put_le32(baudrate, &response[0]);
+
+	return 4U;
+}
+
+uint16_t dap_swo_control_cmd(struct dap_link_context *const ctx,
+			     const uint8_t *const request,
+			     uint8_t *const response)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	uint8_t control = request[0];
+
+	if (control == 0U) {
+		dap_swo_capture_stop(ctx);
+		response[0] = DAP_OK;
+		return 1U;
+	}
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	if (control != 1U || swo->active || swo->backend == NULL ||
+	    swo->mode != DAP_SWO_MODE_UART ||
+	    swo->transport == DAP_SWO_TRANSPORT_NONE ||
+	    swo->baudrate == 0U) {
+		k_mutex_unlock(&swo->lock);
+		LOG_ERR("SWO control %u rejected "
+			"(active %u mode %u transport %u baudrate %u)",
+			control, swo->active, swo->mode, swo->transport,
+			swo->baudrate);
+		response[0] = DAP_ERROR;
+		return 1U;
+	}
+
+	/*
+	 * Under the lock: the streaming transport's work item may
+	 * still be draining the previous session's residue, and the
+	 * ring buffer tolerates exactly one concurrent consumer --
+	 * a reset against a running ring_buf_get() corrupts the
+	 * indices with no error. Holding the lock across the reset
+	 * (and the get, in dap_swo_read()) makes the restart wait
+	 * for a drain in flight instead of racing it.
+	 */
+	ring_buf_reset(&swo->rb);
+	atomic_clear(&swo->err);
+
+	/* active goes true BEFORE the backend enables its receiver: the
+	 * capture ISR can fire in the gap, and dap_swo_rx() drops bytes on
+	 * !active without raising SWO_ERR_OVERRUN — silent capture-path
+	 * loss, the class the error bits exist to report. Setting it early
+	 * is safe: the ring was just reset and no producer exists until
+	 * start() returns.
+	 */
+	swo->active = true;
+
+	if (swo->backend->start() != 0) {
+		swo->active = false;
+		k_mutex_unlock(&swo->lock);
+		response[0] = DAP_ERROR;
+		return 1U;
+	}
+
+	k_mutex_unlock(&swo->lock);
+
+	LOG_DBG("SWO capture started");
+	response[0] = DAP_OK;
+
+	return 1U;
+}
+
+uint16_t dap_swo_status_cmd(struct dap_link_context *const ctx,
+			    uint8_t *const response)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+	response[0] = swo_trace_status_take(swo);
+	sys_put_le32(ring_buf_size_get(&swo->rb), &response[1]);
+	k_mutex_unlock(&swo->lock);
+
+	return 5U;
+}
+
+uint16_t dap_swo_data_cmd(struct dap_link_context *const ctx,
+			  const uint8_t *const request,
+			  uint8_t *const response)
+{
+	struct dap_swo_context *const swo = &ctx->swo;
+	uint16_t max_count = sys_get_le16(request);
+	uint32_t count = 0U;
+
+	k_mutex_lock(&swo->lock, K_FOREVER);
+
+	response[0] = swo_trace_status_take(swo);
+
+	if (swo->transport == DAP_SWO_TRANSPORT_CMD) {
+		/*
+		 * Response layout: command byte (accounted by the
+		 * caller), trace status, two count bytes, data.
+		 */
+		max_count = MIN(max_count, ctx->pkt_size - 4U);
+		count = ring_buf_get(&swo->rb, &response[3], max_count);
+	}
+
+	k_mutex_unlock(&swo->lock);
+
+	sys_put_le16(count, &response[1]);
+
+	return 3U + count;
+}


### PR DESCRIPTION
Implement the `DAP_SWO_*` command set (Transport, Mode, Baudrate, Control, Status, Data) that `subsys/dap`'s command dispatcher already routes as error stubs, behind a new `CONFIG_DAP_SWO` option, including the standard transport 2 (dedicated bulk IN trace endpoint) in the USB backend.

## Why

The `DAP_SWO_*` command set is the *only* way existing tooling can consume SWO trace from a CMSIS-DAP probe. Every mainstream client is built against it: pyOCD polls `DAP_SWO_Data` and reads the dedicated trace endpoint on v2 probes ([SWO/SWV docs](https://pyocd.io/docs/swo_swv.html) — probe support is discovered from the `DAP_Info` capabilities bits, with no path for trace arriving outside the probe protocol), OpenOCD implements the full verb set including the streaming endpoint ([cmsis_dap.c](https://openocd.org/doc/doxygen/html/cmsis__dap_8c.html)), and the commands have been part of the [CMSIS-DAP specification](https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__swo__gr.html) since v1.1.0. The workaround probes otherwise reach for — streaming SWO bytes out a side channel such as an extra CDC-ACM interface — is invisible to all of these tools and forces a bespoke host utility on every user.

The verbs have been dispatched as error stubs since the subsystem was introduced (#53798), so a Zephyr-based probe currently has no way to expose standard SWO trace at all. This PR fills that gap.

## Design

- **The subsystem stays hardware agnostic.** How SWO is physically captured differs per probe (a UART peripheral on the SWO pin, usually), so the application provides the capture backend: `dap_swo_backend_register()` takes `configure(baudrate in/out)/start/stop` callbacks, and the backend pushes captured bytes with the ISR-safe `dap_swo_rx()`. Registering a backend is what advertises SWO UART support (capabilities bit 2) — a build with `CONFIG_DAP_SWO=y` but no backend keeps answering `DAP_ERROR`.
- **Trace buffer** between the capture backend and the host transport: a ring buffer sized by `CONFIG_DAP_SWO_BUFFER_SIZE`, reported to the host via `DAP_ID_SWO_BUFFER_SIZE`. Overrun sets the sticky status bit (7) until the next capture start, per the CMSIS-DAP spec.
- **Both host transports**: transport 1 serves data through `DAP_SWO_Data` responses (what pyOCD uses by default); transport 2 adds a dedicated bulk IN trace endpoint to the USB backend (`bNumEndpoints` 2→3, FS and HS), drained by a work item with a single transfer in flight, kicked on capture data and on transfer completion. With the USB backend enabled, registration also advertises SWO Streaming Trace (capabilities bit 6). The core→backend coupling is a callback bound at backend init, so neither side calls into the other under `#ifdef`.
- Mode UART only; Manchester is rejected (capabilities bit 3 stays clear).

Without `CONFIG_DAP_SWO` (default) the descriptors, capabilities and command responses are byte-for-byte unchanged.

## Testing

- `samples/subsys/dap` builds clean on `nrf52840dk/nrf52840` both with and without `-DCONFIG_DAP_SWO=y` (the sample itself is unchanged and registers no backend).
- The feature is being brought up on our probe firmware (MCX A-series, full-speed USB device, UART capture backend on the SWO pin): descriptor layout, `DAP_Info` responses and the command state machine verified against pyOCD's expectations at the protocol level. Hardware-in-the-loop trace-capture validation (ITM stimulus target, byte-exact stream comparison at 375/750 kbaud) is in progress on the same rig we used for #113262; results will be posted here.

