### PR TITLE
boards: adi: Note feather SPI/I2C supported by MAX32655FTHR

### DIFF
--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
@@ -17,6 +17,8 @@ supported:
   - adc
   - counter
   - rtc_counter
+  - feather_i2c
+  - feather_spi
   - pwm
   - flash
 ram: 64


### PR DESCRIPTION
Update the board metadata for the MAX32655FTHR to properly note it supports the feather SPI/I2C bus connections for feather shields.