### PR TITLE
drivers: can: mcan: set TX/RX FIFO sizes based on CAN mode

### DIFF
--- a/drivers/can/Kconfig.mcan
+++ b/drivers/can/Kconfig.mcan
@@ -7,3 +7,12 @@ config CAN_MCAN
 	bool
 	help
 	  Enable the Bosch M_CAN CAN IP module driver backend.
+
+config CAN_MCAN_FIXED_MRAM_LAYOUT
+	bool # hidden
+	help
+	  Always use 64 bytes deep RX/TX buffer elements regardless of whether CONFIG_CAN_FD_MODE is
+	  enabled.
+
+	  Drivers for Bosch M_CAN IP instances using fixed Message RAM layout (without TXESC/RXESC
+	  registers) must select this.

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -53,6 +53,7 @@ config CAN_STM32_FDCAN
 	default y
 	depends on DT_HAS_ST_STM32_FDCAN_ENABLED
 	select CAN_MCAN
+	select CAN_MCAN_FIXED_MRAM_LAYOUT
 	select PINCTRL
 
 if CAN_STM32_FDCAN

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1377,6 +1377,7 @@ int can_mcan_configure_mram(const struct device *dev, uintptr_t mrba, uintptr_t 
 		return err;
 	}
 
+#if defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT)
 	/* 64 byte Tx Buffer data fields size */
 	reg = CAN_MCAN_TXESC_TBDS;
 	err = can_mcan_write_reg(dev, CAN_MCAN_TXESC, reg);
@@ -1390,6 +1391,7 @@ int can_mcan_configure_mram(const struct device *dev, uintptr_t mrba, uintptr_t 
 	if (err != 0) {
 		return err;
 	}
+#endif /* defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT) */
 
 	return 0;
 }

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -937,8 +937,13 @@ struct can_mcan_rx_fifo_hdr {
 struct can_mcan_rx_fifo {
 	struct can_mcan_rx_fifo_hdr hdr;
 	union {
+#if defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT)
 		uint8_t data[64];
 		uint32_t data_32[16];
+#else /* defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT) */
+		uint8_t data[8];
+		uint32_t data_32[2];
+#endif /* !defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT) */
 	};
 } __packed __aligned(4);
 
@@ -978,8 +983,13 @@ struct can_mcan_tx_buffer_hdr {
 struct can_mcan_tx_buffer {
 	struct can_mcan_tx_buffer_hdr hdr;
 	union {
+#if defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT)
 		uint8_t data[64];
 		uint32_t data_32[16];
+#else /* defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT) */
+		uint8_t data[8];
+		uint32_t data_32[2];
+#endif /* !defined(CONFIG_CAN_FD_MODE) || defined(CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT) */
 	};
 } __packed __aligned(4);
 


### PR DESCRIPTION
Set the MCAN TX/RX FIFO sizes based on CAN_FD_MODE. This allows more efficient use of MRAM if CAN_FD_MODE is disabled.

Some Bosch M_CAN IPs (e.g. the ones used in certain STM32 families) use a fixed Message RAM layout, where RX/TX buffer elements are always of a fixed size. These drivers must now select CONFIG_CAN_MCAN_FIXED_MRAM_LAYOUT.

This builds upon the proposed implementation by @rerickson1 in https://github.com/zephyrproject-rtos/zephyr/pull/109513 with an added work-around for Bosch M_CAN IPs with a fixed Message RAM layout.
