### PR TITLE
doc: net: coap: fix inline code snippets

### DIFF
--- a/doc/services/connectivity/networking/api/coap_client.rst
+++ b/doc/services/connectivity/networking/api/coap_client.rst
@@ -34,7 +34,7 @@ The following is an example of a CoAP client initialization and request sending:
 
 .. code-block:: c
 
-    static struct coap_client;
+    static struct coap_client client;
     struct coap_client_request req = { 0 };
 
     coap_client_init(&client, NULL);
@@ -95,7 +95,7 @@ the server for a resource that it expects to be large enough to require a blockw
 
 .. code-block:: c
 
-    static struct coap_client;
+    static struct coap_client client;
     struct coap_client_request req = { 0 };
 
     coap_client_init(&client, NULL);
@@ -153,7 +153,7 @@ The callback can then be registered for the PUT/POST request instead of a payloa
     strcpy(req.path, "lorem-ipsum");
     req.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN;
     req.cb = response_cb;
-    req.payload_cb = lore_ipsum_cb,
+    req.payload_cb = lorem_ipsum_cb,
 
     ret = coap_client_req(&client, sock, &address, &req, -1);
 

--- a/doc/services/connectivity/networking/api/coap_server.rst
+++ b/doc/services/connectivity/networking/api/coap_server.rst
@@ -206,8 +206,8 @@ of CoAP services. An example using a temperature sensor can look like:
 
     static void temp_notify(struct coap_resource *resource, struct coap_observer *observer)
     {
-        send_temperature(resource, &observer->addr, sizeof(observer->addr), resource->age, 0,
-                         observer->token, observer->tkl, false);
+        send_temperature(resource, net_sad(&observer->addr), sizeof(observer->addr), resource->age,
+                         0, observer->token, observer->tkl, false);
     }
 
     static const char * const temp_resource_path[] = { "sensors", "temp1", NULL };


### PR DESCRIPTION
Fixes small issues with the inline code blocks:

*  `struct coap_client` is missing a variable name.
*  Typo in `req.payload_cb` callback name.
*  The type of `observer->addr` is `struct net_sockaddr_storage`. This is an incompatible type and should be cast before use.