### PR TITLE
scripts: zspdx: add SPDX 3.1 support

### DIFF
--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -90,8 +90,12 @@ Choosing an SPDX version
 select another version with the ``--spdx-version`` option.
 
 SPDX 2.3 is a superset of 2.2 and adds fields such as ``PrimaryPackagePurpose``. Pick SPDX 2.x for
-compatibility with tooling that does not yet understand SPDX 3.0; pick SPDX 3.0 for the richer,
-machine-readable build provenance described in :ref:`west-spdx-build-profile`.
+compatibility with tooling that does not yet understand SPDX 3; pick SPDX 3.0 or above for the
+richer, machine-readable build provenance described in :ref:`west-spdx-build-profile`.
+
+.. note::
+
+   SPDX 3.1 support is experimental: the SPDX 3.1 specification is still in development.
 
 Generating SPDX documents
 -------------------------
@@ -216,7 +220,7 @@ Command-line options
 - ``-s SPDX_DIR``: specifies an alternate directory where the SPDX documents
   should be written instead of :file:`BUILD_DIR/spdx/`.
 
-- ``--spdx-version {2.2,2.3,3.0}``: specifies which SPDX specification version to use.
+- ``--spdx-version {2.2,2.3,3.0,3.1}``: specifies which SPDX specification version to use.
   Defaults to ``2.3``. See :ref:`west-spdx-versions` for the differences between
   the versions.
 

--- a/scripts/pylib/zspdx/model.py
+++ b/scripts/pylib/zspdx/model.py
@@ -111,6 +111,7 @@ class SBOMFile:
         path: Absolute file path on disk.
         relative_path: File path relative to the owning component's base directory.
         hashes: File hashes keyed by hash algorithm name.
+        size: File size in bytes.
         concluded_license: Concluded license expression for the file.
         license_info_in_file: License identifiers detected in the file.
         copyright_text: Copyright text detected for the file.
@@ -122,6 +123,7 @@ class SBOMFile:
     path: str
     relative_path: str = ""
     hashes: dict[str, str] = field(default_factory=dict)
+    size: int | None = None
     concluded_license: str = NOASSERTION
     license_info_in_file: list[str] = field(default_factory=list)
     copyright_text: str = NOASSERTION

--- a/scripts/pylib/zspdx/scanner.py
+++ b/scripts/pylib/zspdx/scanner.py
@@ -208,6 +208,7 @@ def scan_sbom_graph(cfg, sbom_graph):
                 _logger.warning("unable to get hashes for file %s; skipping", f.path)
                 continue
             h_sha1, h_sha256, h_md5 = hashes
+            f.size = os.path.getsize(f.path)
             f.hashes["SHA1"] = h_sha1
             if cfg.do_sha256:
                 f.hashes["SHA256"] = h_sha256

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -665,6 +665,9 @@ class SPDX3Serializer:
                 hash_obj.hashValue = hash_value
                 file_element.verifiedUsing.append(hash_obj)
 
+        if self.spdx_version == SPDX_VERSION_3_1 and file_obj.size is not None:
+            file_element.software_artifactSize = file_obj.size
+
         # License information will be added via relationships after file creation
 
         self.elements.append(file_element)

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import logging
 import os
 import re
@@ -27,6 +28,7 @@ from zspdx.serializers.helpers import (
     normalize_spdx_name,
 )
 from zspdx.spdxids import get_unique_file_id
+from zspdx.version import SPDX_VERSION_3_0, SPDX_VERSION_3_1
 
 _logger = logging.getLogger(__name__)
 
@@ -50,9 +52,24 @@ class SPDX3Serializer:
     # does not provide an absolute URI of its own.
     _DEFAULT_BUILD_TYPE = "urn:spdx.dev:zephyr-cmake"
 
-    def __init__(self, sbom_graph: SBOMGraph, spdx_version=None):
+    def __init__(self, sbom_graph: SBOMGraph, spdx_version=SPDX_VERSION_3_0):
         self.sbom_data = sbom_graph
-        self.spdx_version = spdx_version  # Not used for SPDX 3.0, but kept for API consistency
+        self.spdx_version = spdx_version
+
+        # Select the SPDX 3.x Python bindings matching the requested spec version.
+        # v3.1 is a strict superset of v3.0.1 with identical public class names, so
+        # only the binding module (which drives the emitted JSON-LD @context) and the
+        # specVersion string differ; the rest of the serializer stays version-agnostic.
+        if spdx_version == SPDX_VERSION_3_0:
+            self.spec_version = "3.0.1"
+            bindings = "v3_0_1"
+        elif spdx_version == SPDX_VERSION_3_1:
+            self.spec_version = "3.1.0"
+            bindings = "v3_1"
+        else:
+            raise ValueError(f"Unsupported SPDX version: {spdx_version}")
+        global spdx
+        spdx = getattr(importlib.import_module("spdx_python_model"), bindings)
 
         # Track SPDX 3.0 elements
         self.elements = []  # All SPDX3 elements (packages, files, relationships, etc.)
@@ -174,7 +191,7 @@ class SPDX3Serializer:
             self.creation_info.createdBy.append(self.creator_agent._id)
             # createdUsing references the Tool that created this SPDX document (optional)
             self.creation_info.createdUsing.append(self.tool._id)
-            self.creation_info.specVersion = "3.0.1"
+            self.creation_info.specVersion = self.spec_version
             self.elements.append(self.creation_info)
 
             # Now set the tool's and agent's creationInfo

--- a/scripts/pylib/zspdx/version.py
+++ b/scripts/pylib/zspdx/version.py
@@ -7,11 +7,13 @@ from packaging.version import Version
 SPDX_VERSION_2_2 = Version("2.2")
 SPDX_VERSION_2_3 = Version("2.3")
 SPDX_VERSION_3_0 = Version("3.0")
+SPDX_VERSION_3_1 = Version("3.1")
 
 SUPPORTED_SPDX_VERSIONS = [
     SPDX_VERSION_2_2,
     SPDX_VERSION_2_3,
     SPDX_VERSION_3_0,
+    SPDX_VERSION_3_1,
 ]
 
 

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -14,7 +14,12 @@ from build_helpers import forward_logging_to_west
 script_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, os.path.join(script_dir, "pylib/"))
 from zspdx.sbom import SBOMConfig, make_spdx, setup_cmake_query  # noqa: E402
-from zspdx.version import SPDX_VERSION_2_3, SUPPORTED_SPDX_VERSIONS, parse  # noqa: E402
+from zspdx.version import (  # noqa: E402
+    SPDX_VERSION_2_3,
+    SPDX_VERSION_3_1,
+    SUPPORTED_SPDX_VERSIONS,
+    parse,
+)
 
 SPDX_DESCRIPTION = """\
 This command creates an SPDX bill of materials following the completion
@@ -107,6 +112,8 @@ class ZephyrSpdx(WestCommand):
         except Exception:
             self.die(f"Invalid SPDX version: {args.spdx_version}")
         cfg.spdx_version = version_obj
+        if version_obj == SPDX_VERSION_3_1:
+            self.wrn("SPDX 3.1 support is experimental; the 3.1 spec is still in development.")
         if args.namespace_prefix:
             cfg.namespace_prefix = args.namespace_prefix
         else:


### PR DESCRIPTION
Add SPDX 3.1 as a selectable output version for `west spdx`.

- `west spdx --spdx-version 3.1` selects the `v3_1` bindings from
  spdx-python-model; the serializer stays version-agnostic since 3.1 is a
  strict superset of 3.0.1, and only the JSON-LD `@context` and
  `specVersion` differ.
- The new SPDX 3.1 `software_artifactSize` field is supported: each file's
  size is captured in the SBOM model at scan time, and emitted when serializing 3.1 output.

The 3.1 spec is still work-in-progress, but supporting it enables building
upcoming SBOM features on top (e.g. hardware profile, requirements
traceability), which will come as follow-up PRs.
