### PR TITLE
scripts: runners: probe-rs: Rename 'attach' RTT command to 'rtt'

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -5,7 +5,7 @@ Building, Flashing and Debugging
 
 Zephyr provides several :ref:`west extension commands <west-extensions>` for
 building, flashing, and interacting with Zephyr programs running on a board:
-``build``, ``flash``, ``debug``, ``debugserver`` and ``attach``.
+``build``, ``flash``, ``debug``, ``debugserver``, ``rtt``, and ``attach``.
 
 For information on adding board support for the flashing and debugging
 commands, see :ref:`flash-and-debug-support` in the board porting guide.

--- a/scripts/west_commands/runners/probe_rs.py
+++ b/scripts/west_commands/runners/probe_rs.py
@@ -67,7 +67,7 @@ class ProbeRsBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'rtt'},
                           dev_id=True,
                           erase=True,
                           reset=True,
@@ -124,8 +124,8 @@ class ProbeRsBinaryRunner(ZephyrBinaryRunner):
             self.do_flash(**kwargs)
         elif command in ('debug', 'debugserver'):
             self.do_debug_debugserver(command, **kwargs)
-        elif command == 'attach':
-            self.do_attach(**kwargs)
+        elif command == 'rtt':
+            self.do_rtt(**kwargs)
 
     def do_flash(self, **kwargs):
         download_args = []
@@ -180,7 +180,7 @@ class ProbeRsBinaryRunner(ZephyrBinaryRunner):
         self.check_call_ignore_sigint([self.probe_rs, 'gdb']
                         + self.args + debug_args)
 
-    def do_attach(self, **kwargs):
+    def do_rtt(self, **kwargs):
         '''Attach to RTT logging using probe-rs attach command.'''
         attach_cmd = [self.probe_rs, 'attach'] + self.args + [self.elf_name]
         self.logger.info('Starting RTT session')


### PR DESCRIPTION
The attach capability for the probe-rs runner currently does RTT, but attach is supposed to be for attaching to a debug server, not RTT. Changing 'attach' instances to 'rtt' allows `west rtt` to be used as it's supposed to be.

Signed off by: William Jeffreys wjeffreys96@gmail.com