### PR TITLE
dts: infineon: pse84: Set default state for autanalog and children to disabled

### DIFF
--- a/dts/arm/infineon/edge/pse84/pse84.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.dtsi
@@ -317,6 +317,7 @@
 			wakeup-source;
 			interrupts = <57 4>, <58 4>;
 			interrupt-names = "autanalog", "autanalog_fifo";
+			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges;
@@ -324,6 +325,7 @@
 			ctb0: ctb0@0 {
 				compatible = "infineon,autanalog-ctb";
 				reg = <0x0 0x1000>;
+				status = "disabled";
 				#address-cells = <1>;
 				#size-cells = <0>;
 			};
@@ -331,6 +333,7 @@
 			ctb1: ctb1@10000 {
 				compatible = "infineon,autanalog-ctb";
 				reg = <0x10000 0x1000>;
+				status = "disabled";
 				#address-cells = <1>;
 				#size-cells = <0>;
 			};

--- a/dts/arm/infineon/edge/pse84/pse84_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84_s.dtsi
@@ -330,6 +330,7 @@
 			wakeup-source;
 			interrupts = <57 4>, <58 4>;
 			interrupt-names = "autanalog", "autanalog_fifo";
+			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges;
@@ -337,6 +338,7 @@
 			ctb0: ctb0@0 {
 				compatible = "infineon,autanalog-ctb";
 				reg = <0x0 0x1000>;
+				status = "disabled";
 				#address-cells = <1>;
 				#size-cells = <0>;
 			};
@@ -344,6 +346,7 @@
 			ctb1: ctb1@10000 {
 				compatible = "infineon,autanalog-ctb";
 				reg = <0x10000 0x1000>;
+				status = "disabled";
 				#address-cells = <1>;
 				#size-cells = <0>;
 			};

--- a/samples/boards/infineon/autanalog/fir_fifo/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/boards/infineon/autanalog/fir_fifo/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -15,6 +15,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;

--- a/samples/drivers/adc/adc_dt/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/adc/adc_dt/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
@@ -13,6 +13,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;

--- a/samples/drivers/adc/adc_dt/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/adc/adc_dt/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -14,6 +14,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;

--- a/samples/drivers/adc/adc_sequence/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -13,6 +13,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;

--- a/samples/drivers/dac/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/dac/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -16,6 +16,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &dac0 {
 	status = "okay";
 	clocks = <&peri0_group2_8bit_0>;

--- a/samples/drivers/opamp/output_measure/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/opamp/output_measure/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -33,7 +33,13 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &ctb1 {
+	status = "okay";
+
 	opamp1: opamp@1 {
 		compatible = "infineon,autanalog-ctb-opamp";
 		reg = <1>;

--- a/tests/drivers/adc/adc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/adc/adc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
@@ -13,6 +13,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;

--- a/tests/drivers/adc/adc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/adc/adc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -13,6 +13,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;

--- a/tests/drivers/adc/adc_error_cases/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/adc/adc_error_cases/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -13,6 +13,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 	#address-cells = <1>;

--- a/tests/drivers/build_all/comparator/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/build_all/comparator/boards/kit_pse84_eval_common.overlay
@@ -39,6 +39,10 @@
 	input-n = "local_vref";
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &ptcomp0 {
 	status = "okay";
 

--- a/tests/drivers/build_all/opamp/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/build_all/opamp/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -14,7 +14,13 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &ctb0 {
+	status = "okay";
+
 	opamp0: opamp@0 {
 		compatible = "infineon,autanalog-ctb-opamp";
 		reg = <0>;

--- a/tests/drivers/comparator/gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55_ptcomp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55_ptcomp.overlay
@@ -19,6 +19,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &ptcomp0 {
 	status = "okay";
 

--- a/tests/drivers/dac/dac_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/dac/dac_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -15,6 +15,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &dac0 {
 	status = "okay";
 	clocks = <&peri0_group2_8bit_0>;

--- a/tests/drivers/dac/dac_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -16,6 +16,10 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &dac0 {
 	status = "okay";
 	clocks = <&peri0_group2_8bit_0>;

--- a/tests/drivers/opamp/opamp_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/opamp/opamp_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -14,7 +14,13 @@
 	};
 };
 
+&autanalog {
+	status = "okay";
+};
+
 &ctb0 {
+	status = "okay";
+
 	opamp0: opamp@0 {
 		compatible = "infineon,autanalog-ctb-opamp";
 		reg = <0>;


### PR DESCRIPTION
Set default state for autanalog and children to disabled and enable the nodes as needed in the tests and samples overlays.