### PR TITLE
drivers: modem: hl7800: fix bogus @kconfig reference

### DIFF
--- a/include/zephyr/drivers/modem/hl7800.h
+++ b/include/zephyr/drivers/modem/hl7800.h
@@ -731,7 +731,7 @@ int32_t mdm_hl7800_set_bands(const char *bands);
 /**
  * @brief Set the log level for the modem.
  *
- * @note It cannot be set higher than @kconfig{CONFIG_MODEM_LOG_LEVEL}.
+ * @note It cannot be set higher than CONFIG_MODEM_LOG_LEVEL.
  * If debug level is desired, then it must be compiled with that level.
  *
  * @param level 0 (None) - 4 (Debug)


### PR DESCRIPTION
CONFIG_MODEM_LOG_LEVEL is not an actual Kconfig symbol; don't use @kconfig{} to reference it.