### PR TITLE
drivers: timer: riscv_machine: use the generic timer core

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -90,6 +90,14 @@ static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
+	/* Disarm the IRQ. MTIP is level sensitive: it stays asserted while
+	 * mtime is past mtimecmp, and writing mtimecmp is the only way to
+	 * clear it. Push the compare out of reach so this interrupt fires
+	 * once for the deadline it was armed with, whether or not another
+	 * one is programmed afterwards.
+	 */
+	set_mtimecmp(UINT64_MAX);
+
 	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t now = mtime();

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <limits.h>
-
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/timer/system_timer.h>
@@ -18,27 +16,6 @@
 #define MTIME_REG    DT_INST_REG_ADDR_BY_NAME(0, mtime)
 #define MTIMECMP_REG DT_INST_REG_ADDR_BY_NAME(0, mtimecmp)
 #define TIMER_IRQN   DT_INST_IRQN(0)
-
-#define CYC_PER_TICK (uint32_t)(sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-
-/* the unsigned long cast limits divisions to native CPU register width */
-#define cycle_diff_t   unsigned long
-#define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
-
-/*
- * Maximum number of cycles to wait between two sys_clock_announce() reports:
- * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
- * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
- * servicing latency so a late report still fits, then add the LSB so the value
- * clears a run of low set bits for a nicer literal in the generated assembly.
- */
-#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
-#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
-
-static uint64_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = TIMER_IRQN;
@@ -86,6 +63,30 @@ static uint64_t mtime(void)
 #endif
 }
 
+/*
+ * Free-running mtime counter plus an absolute mtimecmp compare: a COMPARE
+ * backend. mtime is 64 bits wide. The generic core owns the tick accounting;
+ * this driver only reads the counter and arms the comparator. The public
+ * cycle counter is the raw mtime scaled by the DT divider, so it overrides
+ * the core's default.
+ */
+#define TIMER_CORE_BACKEND_COMPARE_ORDERED
+#define TIMER_CORE_HAVE_CYCLE_GET_32
+#define TIMER_CORE_HAVE_CYCLE_GET_64
+#define TIMER_CORE_COUNTER_WIDTH 64
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return mtime();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	set_mtimecmp(cycles);
+}
+
+#include "system_timer_generic.h"
+
 static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
@@ -98,58 +99,7 @@ static void timer_isr(const void *arg)
 	 */
 	set_mtimecmp(UINT64_MAX);
 
-	k_spinlock_key_t key = sys_clock_lock();
-
-	uint64_t now = mtime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_count += (cycle_diff_t)dticks * CYC_PER_TICK;
-	last_ticks += dticks;
-	last_elapsed = 0;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint64_t next = last_count + CYC_PER_TICK;
-
-		set_mtimecmp(next);
-	}
-
-	sys_clock_announce_locked(dticks, key);
-}
-
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
-{
-	ARG_UNUSED(idle);
-
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	uint64_t cyc;
-
-	cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
-	if ((cyc - last_count) > CYCLES_MAX) {
-		cyc = last_count + CYCLES_MAX;
-	}
-	set_mtimecmp(cyc);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	uint64_t now = mtime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_elapsed = dticks;
-	return dticks;
+	timer_core_announce();
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -165,9 +115,7 @@ uint64_t sys_clock_cycle_get_64(void)
 static int sys_clock_driver_init(void)
 {
 	IRQ_CONNECT(TIMER_IRQN, 0, timer_isr, NULL, 0);
-	last_ticks = mtime() / CYC_PER_TICK;
-	last_count = last_ticks * CYC_PER_TICK;
-	set_mtimecmp(last_count + CYC_PER_TICK);
+	timer_core_init();
 	irq_enable(TIMER_IRQN);
 	return 0;
 }
@@ -175,7 +123,7 @@ static int sys_clock_driver_init(void)
 #ifdef CONFIG_SMP
 void smp_timer_init(void)
 {
-	set_mtimecmp(last_count + CYC_PER_TICK);
+	timer_core_smp_prime();
 	irq_enable(TIMER_IRQN);
 }
 #endif


### PR DESCRIPTION
Converts the riscv_machine_timer system-timer driver to the generic tickless timer core
that landed in #115844. The core takes over the tick accounting, and what is
left here is the cycle-domain primitives for this hardware. The commit log says
which shape the hardware is and which `TIMER_CORE_*` knobs that implies.
