### PR TITLE
dts: riscv: ite: move pinctrl container node to root

### DIFF
--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -24,6 +24,11 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	pinctrl: pin-controller {
+		compatible = "ite,it8xxx2-pinctrl";
+		status = "okay";
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -560,11 +565,6 @@
 				   &wuc_wu36   /* GPN6 */
 				   &wuc_wu37>; /* GPN7 */
 			#gpio-cells = <2>;
-		};
-
-		pinctrl: pin-controller {
-			compatible = "ite,it8xxx2-pinctrl";
-			status = "okay";
 		};
 
 		pinctrla: pinctrl@f01610 {

--- a/dts/riscv/ite/it81xx2.dtsi
+++ b/dts/riscv/ite/it81xx2.dtsi
@@ -7,6 +7,11 @@
 #include <ite/it8xxx2.dtsi>
 
 / {
+	pinctrl: pin-controller {
+		compatible = "ite,it8xxx2-pinctrl";
+		status = "okay";
+	};
+
 	soc {
 		gpiogcr: gpio-gcr@f01600 {
 			compatible = "ite,it8xxx2-gpiogcr";
@@ -50,11 +55,6 @@
 			ngpios = <8>;
 			gpio-controller;
 			#gpio-cells = <2>;
-		};
-
-		pinctrl: pin-controller {
-			compatible = "ite,it8xxx2-pinctrl";
-			status = "okay";
 		};
 
 		pinctrla: pinctrl@f01610 {

--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -7,6 +7,11 @@
 #include <ite/it8xxx2.dtsi>
 
 / {
+	pinctrl: pin-controller {
+		compatible = "ite,it8xxx2-pinctrl";
+		status = "okay";
+	};
+
 	soc {
 		sram0: memory@80100000 {
 			compatible = "mmio-sram";
@@ -436,11 +441,6 @@
 			interrupt-parent = <&intc>;
 			keyboard-controller;
 			#gpio-cells = <2>;
-		};
-
-		pinctrl: pin-controller {
-			compatible = "ite,it8xxx2-pinctrl";
-			status = "okay";
 		};
 
 		pinctrla: pinctrl@f01660 {


### PR DESCRIPTION
Move the ite,it8xxx2-pinctrl container node from the /soc node to the root / node.

The pin-controller node is a logical container for pin configuration states rather than a memory-mapped bus peripheral on the SoC bus. When located inside /soc, DTC treats its children as addressable by the SoC bus address/size cells, triggering avoid_unnecessary_addr_size warnings/errors. Moving it to the root matches the convention used across other SoC families in Zephyr (such as npcx and rp2040).

Assisted-by: Antigravity:gemini-1.5-pro