### PR TITLE
drivers: pwm: sam0_tcc: hold LUPD while writing buffers

### DIFF
--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -81,9 +81,25 @@ static int pwm_sam0_set_cycles(const struct device *dev, uint32_t channel,
 	regs->CCBUF[channel].reg = TCC_CCBUF_CCBUF(pulse_cycles);
 	regs->PERBUF.reg = TCC_PERBUF_PERBUF(period_cycles);
 #else
-	/* SAMD21 naming */
-	regs->CCB[channel].reg = TCC_CCB_CCB(pulse_cycles);
-	regs->PERB.reg = TCC_PERB_PERB(period_cycles);
+	/*
+	 * SAMD21 naming. Writing the buffered PER/CC while the counter runs
+	 * can lose the transfer: for a short window around each update
+	 * condition the buffer write does not reach PER/CC. The window is a
+	 * fixed duration, so the shorter the current period the more likely a
+	 * write lands in it, and at the init value of PER=1 the period is
+	 * stuck. Neither the update lock nor a forced update fully closes it.
+	 *
+	 * Disable the counter, write PER/CC directly, then re-enable. With the
+	 * counter stopped there is no update condition to race, so the write
+	 * always takes effect. This restarts the counter, so a period change
+	 * is not glitch-free.
+	 */
+	regs->CTRLA.bit.ENABLE = 0;
+	wait_synchronization(regs);
+	regs->CC[channel].reg = TCC_CC_CC(pulse_cycles);
+	regs->PER.reg = TCC_PER_PER(period_cycles);
+	regs->CTRLA.bit.ENABLE = 1;
+	wait_synchronization(regs);
 #endif
 
 	if (invert != inverted) {


### PR DESCRIPTION
 ## Problem

  On SAMD21 and SAMR21, pwm_set_cycles() can return success without changing the PWM period.

  The failure occurs most often after boot. Initialization sets PER=1, so the counter updates every two cycles. A failed write leaves the period at 1, and no visible output appears.

  ## Root cause

  The driver wrote PERB and CCB while the counter was running. Hardware transfers these buffers into PER and CC on an update condition.

  A buffer write can collide with an update condition. The collision drops the write, so the new value never reaches PER or CC.

  The collision window has a fixed duration. Short periods produce more update conditions and increase the failure rate.

  ## Previous approaches

  Holding CTRLB.LUPD reduced the loss rate from approximately 56% to 27%. It did not remove the race.

  Using LUPD with CMD=UPDATE reduced the loss rate to approximately 1%. It also did not remove the race.

  Both approaches leave the counter running. The counter can still produce an update condition during the write sequence.

  ## Fix

  Disable the counter before updating the PWM values.

  Write PER and CC directly, then re-enable the counter. A disabled counter cannot produce an update condition, so the writes complete reliably.

  ## Tradeoff

  Re-enabling the counter restarts it from zero. Period and pulse changes are not glitch-free.

  This change selects reliable updates instead of glitch-free updates.

  ## Scope

  This change affects only the existing PERB and CCB register path:

  - SAMD21
  - SAMR21

  Families using PERBUF and CCBUF keep the existing buffered update path:

  - SAMC20 and SAMC21
  - SAMD51
  - SAME51, SAME53, and SAME54
  - SAML21
  - SAMR34 and SAMR35

  ## Testing

  Testing used an ATSAMR21G18A. The issue was also reproduced on ATSAMD21G18A and ATSAMD21E18A.

  The test first configured a short period. It then set a target period and measured overflow timing.

  Coverage included all update phases and a range of current periods.

  - Previous buffered path: approximately 50% of writes were lost.
  - Worst update phase: up to 100% of writes were lost.
  - Direct stopped-counter path: no writes were lost.
  - Stress testing completed without a failure.
  - Measured periods matched the requested values.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/116310

Assisted-by: Codex:gpt-5, Claude:opus-4.8