### PR TITLE
drivers: mipi_dbi: bitbang: initialise the transfer mutex

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_bitbang.c
+++ b/drivers/mipi_dbi/mipi_dbi_bitbang.c
@@ -190,11 +190,11 @@ static int mipi_dbi_bitbang_reset(const struct device *dev, k_timeout_t delay)
 static int mipi_dbi_bitbang_init(const struct device *dev)
 {
 	const struct mipi_dbi_bitbang_config *config = dev->config;
+	struct mipi_dbi_bitbang_data *data = dev->data;
 	const char *failed_pin = NULL;
 	int ret = 0;
-#if MIPI_DBI_8_BIT_MODE
-	struct mipi_dbi_bitbang_data *data = dev->data;
-#endif
+
+	k_mutex_init(&data->lock);
 
 	if (gpio_is_ready_dt(&config->cmd_data)) {
 		ret = gpio_pin_configure_dt(&config->cmd_data, GPIO_OUTPUT_ACTIVE);


### PR DESCRIPTION
`mipi_dbi_bitbang_data` has a `k_mutex` that `mipi_dbi_bitbang_write_helper()` locks, but nothing calls `k_mutex_init()` on it. The instance data is a zero-filled static struct, so the uncontended path works and the current single-threaded tests pass, while the wait queue and the kernel object metadata are never set up.

`mipi_dbi_spi.c` initialises its own lock in init, so this brings the bitbang driver in line with its sibling.

It goes at the top of the function rather than the end because the GPIO configuration below can jump to the failure path and return early.

The `data` pointer moves out of the `MIPI_DBI_8_BIT_MODE` guard, since the mutex is present in every configuration. Built for `native_sim` with an eight line and a sixteen line data bus so both sides of that guard are covered.

Found while adding native_sim coverage for this driver in #115831.
