### PR TITLE
drivers: sensor: lsm6dsv16x: fix various correctness issues

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -1653,8 +1653,8 @@ static int lsm6dsv16x_pm_action(const struct device *dev, enum pm_device_action 
 			    CONFIG_I3C_RTIO),				\
 		   (LSM6DSV16X_I3C_RTIO_DEFINE(inst, prefix)));		\
 	static struct lsm6dsv16x_data prefix##_data_##inst = {		\
-		IF_ENABLED(UNTIL_AND(CONFIG_LSM6DSV16X_STREAM,		\
-				     CONFIG_I3C_RTIO),			\
+		IF_ENABLED(UTIL_AND(CONFIG_LSM6DSV16X_STREAM,		\
+				    CONFIG_I3C_RTIO),			\
 			(.rtio_ctx = &prefix##_rtio_ctx_##inst,		\
 			 .iodev = &prefix##_i3c_iodev_##inst,		\
 			 .bus_type = RTIO_BUS_I3C,))			\

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -981,7 +981,7 @@ static int lsm6dsv16x_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lsm6dsv16x_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -746,7 +746,7 @@ static int lsm6dsv16x_accel_get_config(const struct device *dev,
 
 		mode = (odr >> 4) & 0xf;
 
-		val->val1 = lsm6dsv16x_odr_map[mode][data->accel_freq];
+		val->val1 = lsm6dsv16x_odr_map[mode][data->accel_freq & 0x0f];
 		val->val2 = 0;
 		break;
 	}
@@ -824,7 +824,7 @@ static int lsm6dsv16x_gyro_get_config(const struct device *dev,
 
 		mode = (odr >> 4) & 0xf;
 
-		val->val1 = lsm6dsv16x_odr_map[mode][data->gyro_freq];
+		val->val1 = lsm6dsv16x_odr_map[mode][data->gyro_freq & 0x0f];
 		val->val2 = 0;
 		break;
 	}

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -1170,8 +1170,8 @@ static inline void lsm6dsv16x_hum_convert(struct sensor_value *val,
 	rh /= (ht->x1 - ht->x0);
 
 	/* convert humidity to integer and fractional part */
-	val->val1 = rh;
-	val->val2 = rh * 1000000;
+	val->val1 = (int32_t)rh;
+	val->val2 = (rh - (int32_t)rh) * 1000000;
 }
 
 static inline void lsm6dsv16x_press_convert(struct sensor_value *val,

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.c
@@ -257,7 +257,11 @@ static int lsm6dsv16x_decoder_get_frame_count(const uint8_t *buffer,
 		case LSM6DSV16X_SENSORHUB_SLAVE2_TAG:
 		case LSM6DSV16X_SENSORHUB_SLAVE3_TAG: {
 			uint8_t k = fifo_tag - LSM6DSV16X_SENSORHUB_SLAVE1_TAG;
-			enum sensor_channel ctype = lsm6dsv16x_shub_type(k);
+			enum sensor_channel ctype = SENSOR_CHAN_COMMON_COUNT;
+
+			if (k < edata->num_ext_dev) {
+				ctype = lsm6dsv16x_shub_type(edata->shub_ext[k]);
+			}
 
 			switch (ctype) {
 			case SENSOR_CHAN_MAGN_XYZ:
@@ -618,7 +622,11 @@ static int lsm6dsv16x_decode_fifo(const uint8_t *buffer, struct sensor_chan_spec
 		case LSM6DSV16X_SENSORHUB_SLAVE2_TAG:
 		case LSM6DSV16X_SENSORHUB_SLAVE3_TAG: {
 			uint8_t k = fifo_tag - LSM6DSV16X_SENSORHUB_SLAVE1_TAG;
-			enum sensor_channel ctype = lsm6dsv16x_shub_type(k);
+			enum sensor_channel ctype = SENSOR_CHAN_COMMON_COUNT;
+
+			if (k < edata->num_ext_dev) {
+				ctype = lsm6dsv16x_shub_type(edata->shub_ext[k]);
+			}
 
 			if ((uintptr_t)buffer < *fit) {
 				/* This frame was already decoded, move on to the next frame */

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.h
@@ -37,6 +37,10 @@ struct lsm6dsv16x_fifo_data {
 	uint16_t temp_batch_odr: 4;
 	uint16_t sflp_batch_odr: 3;
 	uint16_t reserved_2: 1;
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+	uint8_t num_ext_dev;
+	uint8_t shub_ext[LSM6DSV16X_SHUB_MAX_NUM_TARGETS];
+#endif
 } __attribute__((__packed__));
 
 struct lsm6dsv16x_rtio_data {

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
@@ -117,7 +117,6 @@ static void lsm6dsv16x_submit_sample(const struct device *dev, struct rtio_iodev
 	rc = sensor_clock_get_cycles(&cycles);
 	if (rc != 0) {
 		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
 		goto err;
 	}
 

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -510,9 +510,7 @@ static void lsm6dsv16x_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe
 	ARG_UNUSED(result);
 
 	const struct device *dev = arg;
-#if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	const struct lsm6dsv16x_config *config = dev->config;
-#endif
 	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
 	struct rtio *rtio = lsm6dsv16x->rtio_ctx;
 	struct gpio_dt_spec *irq_gpio = lsm6dsv16x->drdy_gpio;
@@ -608,7 +606,8 @@ static void lsm6dsv16x_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe
 		struct lsm6dsv16x_rtio_data hdr = {
 			.header = {
 				.is_fifo = false,
-				.accel_fs_idx = lsm6dsv16x->accel_fs,
+				.accel_fs_idx = LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX(
+					config->accel_fs_map[lsm6dsv16x->accel_fs]),
 				.gyro_fs = lsm6dsv16x->gyro_fs,
 				.timestamp = lsm6dsv16x->timestamp,
 			},

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -20,18 +20,20 @@ static void lsm6dsv16x_config_drdy(const struct device *dev, struct trigger_conf
 {
 	const struct lsm6dsv16x_config *config = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
-	lsm6dsv16x_pin_int_route_t pin_int = { 0 };
+	lsm6dsv16x_pin_int_route_t pin_int;
 	int16_t buf[3];
 
 	/* dummy read: re-trigger interrupt */
 	lsm6dsv16x_acceleration_raw_get(ctx, buf);
 
-	pin_int.drdy_xl = PROPERTY_ENABLE;
-
-	/* Set pin interrupt */
+	/* Set pin interrupt, preserving already routed sources */
 	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {
+		lsm6dsv16x_pin_int1_route_get(ctx, &pin_int);
+		pin_int.drdy_xl = trig_cfg.int_drdy ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 		lsm6dsv16x_pin_int1_route_set(ctx, &pin_int);
 	} else {
+		lsm6dsv16x_pin_int2_route_get(ctx, &pin_int);
+		pin_int.drdy_xl = trig_cfg.int_drdy ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 		lsm6dsv16x_pin_int2_route_set(ctx, &pin_int);
 	}
 }
@@ -82,6 +84,7 @@ static void lsm6dsv16x_config_fifo(const struct device *dev, struct trigger_conf
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
 	uint8_t fifo_wtm = 0;
 	lsm6dsv16x_pin_int_route_t pin_int = { 0 };
+	lsm6dsv16x_pin_int_route_t route;
 	lsm6dsv16x_fifo_xl_batch_t xl_batch = LSM6DSVXXX_DT_XL_NOT_BATCHED;
 	lsm6dsv16x_fifo_gy_batch_t gy_batch = LSM6DSVXXX_DT_GY_NOT_BATCHED;
 	lsm6dsv16x_fifo_temp_batch_t temp_batch = LSM6DSVXXX_DT_TEMP_NOT_BATCHED;
@@ -206,11 +209,17 @@ static void lsm6dsv16x_config_fifo(const struct device *dev, struct trigger_conf
 	lsm6dsv16x_sh_master_set(ctx, PROPERTY_ENABLE);
 #endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 
-	/* Set pin interrupt (fifo_th could be on or off) */
+	/* Set pin interrupt (fifo_th could be on or off), preserving already routed sources */
 	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {
-		lsm6dsv16x_pin_int1_route_set(ctx, &pin_int);
+		lsm6dsv16x_pin_int1_route_get(ctx, &route);
+		route.fifo_th = pin_int.fifo_th;
+		route.fifo_full = pin_int.fifo_full;
+		lsm6dsv16x_pin_int1_route_set(ctx, &route);
 	} else {
-		lsm6dsv16x_pin_int2_route_set(ctx, &pin_int);
+		lsm6dsv16x_pin_int2_route_get(ctx, &route);
+		route.fifo_th = pin_int.fifo_th;
+		route.fifo_full = pin_int.fifo_full;
+		lsm6dsv16x_pin_int2_route_set(ctx, &route);
 	}
 }
 

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -465,6 +465,11 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 	};
 	/* clang-format on */
 
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+	hdr.num_ext_dev = lsm6dsv16x->num_ext_dev;
+	memcpy(hdr.shub_ext, lsm6dsv16x->shub_ext, sizeof(hdr.shub_ext));
+#endif
+
 	memcpy(buf, &hdr, sizeof(hdr));
 	read_buf = buf + sizeof(hdr);
 

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
@@ -496,7 +496,7 @@ enum sensor_channel lsm6dsv16x_shub_type(uint8_t k)
 {
 	struct lsm6dsv16x_shub_slist *sp;
 
-	if (k > LSM6DSV16X_SHUB_MAX_NUM_TARGETS) {
+	if (k >= ARRAY_SIZE(lsm6dsv16x_shub_slist)) {
 		return SENSOR_CHAN_COMMON_COUNT;
 	}
 


### PR DESCRIPTION
This PR fixes eight independent correctness bugs in the LSM6DSV16X driver,
one commit per issue:

- **Propagate sample_fetch errors**: `lsm6dsv16x_sample_fetch()` accumulated
  bus errors from the accel/gyro/temp/sensor-hub fetch helpers into `ret` but
  unconditionally returned 0, so I/O failures were reported as success and
  callers consumed stale samples.
- **Fix `UTIL_AND` typo in I3C streaming guard**: the instantiation macro used
  a non-existent `UNTIL_AND` token, which silently compiled out the
  `rtio_ctx`/`iodev`/`bus_type` initializers for I3C devices with streaming
  enabled, leaving the RTIO context NULL at runtime.
- **Fix accel FS index in drdy streaming path**: the data-ready streaming path
  stored the raw full-scale register value into the decoder header instead of
  converting it with `LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX`, producing wrong
  (e.g. half-scale) accelerometer readings on LSM6DSV32X.
- **Fix OOB odr_map index for high-accuracy ODR**: `attr_get(SENSOR_ATTR_SAMPLING_FREQUENCY)`
  indexed `lsm6dsv16x_odr_map[]` with the full ODR register value; for
  high-accuracy ODR devicetree configurations the HA bits made the index run
  past the end of the table. Mask to the low nibble first.
- **Fix fractional part of humidity value**: the sensor-hub humidity
  conversion stored the entire humidity value in `val2` (micro-percent)
  instead of splitting integer part into `val1` and remainder into `val2`.
- **Fix FIFO sensor hub tag type mapping**: FIFO `SLAVEn` tags were mapped
  through the compile-time slave list instead of the runtime-detected external
  device list, so with a partially populated bus the decoder attributed frames
  to the wrong channel type. Also fixes an off-by-one in the
  `lsm6dsv16x_shub_type()` bounds check.
- **Fix double completion of iodev_sqe**: the sensor-clock failure path in
  `lsm6dsv16x_submit_sample()` completed the RTIO sqe with
  `rtio_iodev_sqe_err()` and then fell through to the shared error label,
  completing the same sqe twice.
- **Preserve interrupt routes in stream config**: the streaming path wrote full
  interrupt-route structs containing only its own bit (ST's
  `pin_intX_route_set()` rewrites every route bit), so arming the DRDY stream
  trigger cleared the FIFO watermark/full routing and vice versa. Use
  read-modify-write as the trigger path already does, and honor the disable
  flag in the DRDY path, which unconditionally enabled the route.
