### PR TITLE
drivers: sensor: icm4268x: fix various correctness issues

### DIFF
--- a/drivers/sensor/tdk/icm4268x/icm4268x.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x.c
@@ -127,7 +127,7 @@ static int icm4268x_sample_fetch(const struct device *dev, enum sensor_channel c
 	}
 
 	for (int i = 0; i < 7; i++) {
-		data->readings[i] = sys_le16_to_cpu((readings[i * 2] << 8) | readings[i * 2 + 1]);
+		data->readings[i] = (int16_t)sys_get_be16(&readings[i * 2]);
 	}
 
 	return 0;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_common.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_common.c
@@ -386,7 +386,11 @@ int icm4268x_safely_configure(const struct device *dev, struct icm4268x_cfg *cfg
 	if (ret == 0) {
 		drv_data->cfg = *cfg;
 	} else {
-		ret = icm4268x_configure(dev, &drv_data->cfg);
+		int rb = icm4268x_configure(dev, &drv_data->cfg);
+
+		if (rb != 0) {
+			LOG_ERR("Failed to rollback configuration");
+		}
 	}
 
 	return ret;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -616,10 +616,22 @@ static int icm4268x_one_shot_decode(const uint8_t *buffer, struct sensor_chan_sp
 			return -EINVAL;
 		}
 
-		icm4268x_convert_raw_to_q31(
-			&cfg, chan_spec.chan_type,
-			edata->readings[icm4268x_get_channel_position(chan_spec.chan_type)],
-			&out->readings[0].value);
+		if (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
+			icm4268x_convert_raw_to_q31(
+				&cfg, chan_spec.chan_type,
+				edata->readings[icm4268x_get_channel_position(chan_spec.chan_type)],
+				&out->readings[0].value);
+		} else {
+			int8_t pos = icm4268x_get_channel_position(chan_spec.chan_type);
+			int8_t base = pos >= 4 ? 4 : 1;
+			int8_t axis = pos - base;
+
+			icm4268x_convert_raw_to_q31(
+				&cfg, chan_spec.chan_type,
+				header->axis_align[axis].sign *
+					edata->readings[base + header->axis_align[axis].index],
+				&out->readings[0].value);
+		}
 		*fit = 1;
 		return 1;
 	}
@@ -640,17 +652,22 @@ static int icm4268x_one_shot_decode(const uint8_t *buffer, struct sensor_chan_sp
 			return -EINVAL;
 		}
 
+		int8_t base = icm4268x_get_channel_position(chan_spec.chan_type - 3);
+
 		icm4268x_convert_raw_to_q31(
 			&cfg, chan_spec.chan_type - 3,
-			edata->readings[icm4268x_get_channel_position(chan_spec.chan_type - 3)],
+			header->axis_align[0].sign *
+				edata->readings[base + header->axis_align[0].index],
 			&out->readings[0].x);
 		icm4268x_convert_raw_to_q31(
 			&cfg, chan_spec.chan_type - 2,
-			edata->readings[icm4268x_get_channel_position(chan_spec.chan_type - 2)],
+			header->axis_align[1].sign *
+				edata->readings[base + header->axis_align[1].index],
 			&out->readings[0].y);
 		icm4268x_convert_raw_to_q31(
 			&cfg, chan_spec.chan_type - 1,
-			edata->readings[icm4268x_get_channel_position(chan_spec.chan_type - 1)],
+			header->axis_align[2].sign *
+				edata->readings[base + header->axis_align[2].index],
 			&out->readings[0].z);
 		*fit = 1;
 		return 1;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -251,7 +251,7 @@ static inline q31_t icm4268x_read_temperature_from_packet(const uint8_t *pkt)
 			((temperature100 - whole * sensitivity) * INT64_C(1000000)) / sensitivity;
 	}
 	__ASSERT_NO_MSG(whole >= -512 && whole <= 511);
-	return FIELD_PREP(GENMASK(31, 22), whole) | (fraction * GENMASK64(21, 0) / 1000000);
+	return (q31_t)(((int64_t)whole << 22) + (((int64_t)fraction << 22) / INT64_C(1000000)));
 }
 
 static int icm4268x_read_imu_from_packet(const uint8_t *pkt, bool is_accel, int fs,

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -232,15 +232,15 @@ static inline q31_t icm4268x_read_temperature_from_packet(const uint8_t *pkt)
 
 	/* Temperature always assumes a shift of 9 for a range of (-273,273) C */
 	if (FIELD_GET(FIFO_HEADER_20, pkt[0]) == 1) {
-		temperature = (pkt[0xd] << 8) | pkt[0xe];
+		temperature = (int16_t)((pkt[0xd] << 8) | pkt[0xe]);
 
 		icm4268x_temp_c(temperature, &whole, &fraction);
 	} else {
 		if (FIELD_GET(FIFO_HEADER_ACCEL, pkt[0]) == 1 &&
 		    FIELD_GET(FIFO_HEADER_GYRO, pkt[0]) == 1) {
-			temperature = pkt[0xd];
+			temperature = (int8_t)pkt[0xd];
 		} else {
-			temperature = pkt[0x7];
+			temperature = (int8_t)pkt[0x7];
 		}
 
 		int64_t sensitivity = 207;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -293,7 +293,7 @@ static int icm4268x_read_imu_from_packet(const uint8_t *pkt, bool is_accel, int 
 			return -ENODATA;
 		}
 	} else {
-		signed_value = unsigned_value | (0 - (unsigned_value & BIT(16)));
+		signed_value = unsigned_value | (0 - (unsigned_value & BIT(15)));
 	}
 
 	*out = (q31_t)(signed_value * scale[is_accel][is_hires]);

--- a/drivers/sensor/tdk/icm4268x/icm4268x_rtio.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_rtio.c
@@ -39,7 +39,7 @@ static int icm4268x_rtio_sample_fetch(const struct device *dev, int16_t readings
 	}
 
 	for (int i = 0; i < 7; i++) {
-		readings[i] = sys_le16_to_cpu((buffer[i * 2] << 8) | buffer[i * 2 + 1]);
+		readings[i] = (int16_t)sys_get_be16(&buffer[i * 2]);
 	}
 
 	return 0;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
@@ -133,6 +133,12 @@ static void icm4268x_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, int
 		return;
 	}
 
+	struct sensor_read_config *read_config =
+		(struct sensor_read_config *)streaming_sqe->sqe.iodev->data;
+	struct sensor_stream_trigger *fifo_ths_cfg =
+		icm4268x_get_read_config_trigger(read_config, SENSOR_TRIG_FIFO_WATERMARK);
+	bool has_fifo_data = fifo_ths_cfg && fifo_ths_cfg->opt == SENSOR_STREAM_DATA_INCLUDE;
+
 	struct icm4268x_fifo_data *edata = (struct icm4268x_fifo_data *)buf;
 	struct icm4268x_fifo_data hdr = {
 		.header = {
@@ -148,7 +154,7 @@ static void icm4268x_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, int
 		.int_status = drv_data->int_status,
 		.gyro_odr = drv_data->cfg.gyro_odr,
 		.accel_odr = drv_data->cfg.accel_odr,
-		.fifo_count = drv_data->cfg.fifo_wm,
+		.fifo_count = has_fifo_data ? drv_data->cfg.fifo_wm : 0,
 		.rtc_freq = drv_data->cfg.rtc_freq,
 	};
 	*edata = hdr;


### PR DESCRIPTION
This PR fixes seven independent correctness bugs in the ICM4268X driver, one
commit per issue:

- **Fix sign extension of 16-bit FIFO samples**: the non-hires FIFO decode
  path sign-extended 16-bit samples using `BIT(16)` as the sign bit instead
  of `BIT(15)`, so negative accel/gyro FIFO samples decoded as large positive
  values.
- **Fix q31 temperature packing for negatives**: the q31 temperature value
  was assembled by OR-ing the fractional part into the shifted whole part,
  which corrupts the two's-complement representation for sub-zero
  temperatures. Compute it arithmetically in 64-bit instead.
- **Do not mask configure error on rollback**: when applying a new
  configuration failed, `icm4268x_safely_configure()` returned the result of
  restoring the previous configuration — success in the common case — so
  callers (e.g. attribute setters) saw their failed reconfiguration reported
  as having succeeded.
- **Apply axis-align in one-shot decoder**: the FIFO decode path honors the
  devicetree axis alignment (index/sign) configuration, but the one-shot
  decode path read the raw readings array directly, ignoring axis remapping
  entirely.
- **Fix fifo_count when FIFO data is not read**: the stream completion
  callback unconditionally set the header's `fifo_count` to the watermark
  byte count even for interrupts (e.g. FIFO full without data opt-in) where
  no FIFO data was actually transferred into the buffer.
- **Fix sample byte order on big-endian targets**: `sample_fetch` applied
  `sys_le16_to_cpu()` to values that had already been assembled byte-wise
  into CPU order, corrupting all readings on big-endian targets.
- **Sign-extend FIFO temperature samples**: the FIFO temperature is signed
  (8-bit at 2.07 LSB/°C, 16-bit hires at 132.48 LSB/°C, both offset at 25 °C)
  but was read as unsigned, so anything below 25 °C decoded as a large bogus
  positive value (10 °C → ~134 °C) and could trip the range assert.
