### PR TITLE
drivers: sensor: bmi08x: fix various correctness issues

### DIFF
--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
@@ -261,8 +261,12 @@ static int bmi08x_acc_odr_set(const struct device *dev, uint16_t freq_int, uint1
 {
 	int odr = bmi08x_freq_to_odr_val(freq_int, freq_milli);
 
-	if (odr < BMI08X_ACCEL_ODR_12_5_HZ) {
+	if (odr < 0) {
 		return odr;
+	}
+
+	if (odr < BMI08X_ACCEL_ODR_12_5_HZ || odr > BMI08X_ACCEL_ODR_1600_HZ) {
+		return -ENOTSUP;
 	}
 
 	return bmi08x_accel_reg_field_update(dev, BMI08X_REG_ACCEL_CONF, 0, BMI08X_ACCEL_ODR_MASK,

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
@@ -288,19 +288,22 @@ static const struct bmi08x_range bmi088_acc_range_map[] = {
 static int bmi08x_acc_range_set(const struct device *dev, int32_t range)
 {
 	struct bmi08x_accel_data *data = dev->data;
-	int32_t reg_val = -1;
+	const struct bmi08x_range *range_map;
+	uint16_t range_map_size;
+	int32_t reg_val;
 	int ret;
 
 	if (data->accel_chip_id == BMI085_ACCEL_CHIP_ID) {
-		reg_val = bmi08x_range_to_reg_val(range, bmi085_acc_range_map,
-						  BMI085_ACC_RANGE_MAP_SIZE);
+		range_map = bmi085_acc_range_map;
+		range_map_size = BMI085_ACC_RANGE_MAP_SIZE;
 	} else if (data->accel_chip_id == BMI088_ACCEL_CHIP_ID) {
-		reg_val = bmi08x_range_to_reg_val(range, bmi088_acc_range_map,
-						  BMI088_ACC_RANGE_MAP_SIZE);
+		range_map = bmi088_acc_range_map;
+		range_map_size = BMI088_ACC_RANGE_MAP_SIZE;
 	} else {
 		return -ENODEV;
 	}
 
+	reg_val = bmi08x_range_to_reg_val(range, range_map, range_map_size);
 	if (reg_val < 0) {
 		return reg_val;
 	}
@@ -310,7 +313,8 @@ static int bmi08x_acc_range_set(const struct device *dev, int32_t range)
 		return ret;
 	}
 
-	data->scale = BMI08X_ACC_SCALE(range);
+	data->scale = BMI08X_ACC_SCALE(bmi08x_reg_val_to_range(reg_val, range_map,
+							       range_map_size));
 	data->range = reg_val;
 
 	return ret;

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
@@ -455,8 +455,8 @@ static int bmi08x_temp_channel_get(const struct device *dev, struct sensor_value
 	/* the value ranges in [-504, 496] */
 	/* the scale is 0.125°C/LSB = 125000 micro degrees */
 	temp_micro = temp_int11 * 125000 + 23 * 1000000;
-	val->val1 = temp_micro / 1000000ULL;
-	val->val2 = temp_micro % 1000000ULL;
+	val->val1 = temp_micro / 1000000;
+	val->val2 = temp_micro % 1000000;
 
 	return ret;
 }

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel_decoder.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel_decoder.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/sensor_clock.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/check.h>
 
 #define DT_DRV_COMPAT bosch_bmi08x_accel
@@ -105,13 +106,13 @@ static int bmi08x_decoder_get_size_info(struct sensor_chan_spec chan_spec, size_
 	return 0;
 }
 
-static inline void fixed_point_from_encoded_data(const uint16_t encoded_payload[3], uint8_t shift,
+static inline void fixed_point_from_encoded_data(const uint8_t encoded_payload[6], uint8_t shift,
 						 uint32_t fsr_value_g, q31_t output[3])
 {
 	for (size_t i = 0 ; i < 3 ; i++) {
 		int64_t raw_value;
 
-		raw_value = sign_extend_64(encoded_payload[i], 15);
+		raw_value = sign_extend_64(sys_get_le16(&encoded_payload[2 * i]), 15);
 		raw_value = (raw_value * fsr_value_g << (31 - 5 - 15)) * SENSOR_G / 1000000;
 
 		output[i] = raw_value;
@@ -136,8 +137,8 @@ static inline int bmi08x_decode_one_shot(const struct bmi08x_accel_encoded_data 
 	data_output->shift = 5 + edata->header.range;
 	data_output->header.reading_count = 1;
 	data_output->header.base_timestamp_ns = edata->header.timestamp;
-	fixed_point_from_encoded_data(edata->payload, data_output->shift, fsr_value_g,
-				      data_output->readings[0].values);
+	fixed_point_from_encoded_data((const uint8_t *)edata->payload, data_output->shift,
+				      fsr_value_g, data_output->readings[0].values);
 
 	return ++(*fit);
 }
@@ -189,10 +190,8 @@ static inline int bmi08x_decode_fifo(const struct bmi08x_accel_encoded_data *eda
 
 		if (header_byte == BMI08X_ACCEL_FIFO_FRAME_ACCEL &&
 		    *fit + frame_len <= edata->header.buf_len) {
-			const uint16_t *values = (const uint16_t *)&edata->fifo[*fit + 1];
-
 			fixed_point_from_encoded_data(
-				values, data_output->shift, fsr_value_g,
+				&edata->fifo[*fit + 1], data_output->shift, fsr_value_g,
 				data_output->readings[reading_count].values);
 			data_output->readings[reading_count].timestamp_delta =
 				reading_count * period_ns;

--- a/drivers/sensor/bosch/bmi08x/bmi08x_bus.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_bus.c
@@ -22,11 +22,13 @@ int bmi08x_prep_reg_read_rtio_async(const struct bmi08x_rtio_bus *bus,
 		rtio_sqe_drop_all(ctx);
 		return -ENOMEM;
 	}
-	reg |= BIT(7);
+	if (bus->type == BMI08X_RTIO_BUS_TYPE_SPI) {
+		reg |= BIT(7);
+	}
 	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
 	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
 
-	if (dummy_byte) {
+	if (dummy_byte && bus->type == BMI08X_RTIO_BUS_TYPE_SPI) {
 		struct rtio_sqe *dummy_byte_sqe = rtio_sqe_acquire(ctx);
 
 		if (!dummy_byte_sqe) {

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
@@ -196,7 +196,7 @@ static int bmi08x_gyr_range_set(const struct device *dev, uint16_t range)
 		return ret;
 	}
 
-	bmi08x->scale = BMI08X_GYR_SCALE(range);
+	bmi08x->scale = BMI08X_GYR_SCALE(bmi08x_gyr_reg_val_to_range((uint8_t)reg_val));
 	bmi08x->range = reg_val;
 
 	return ret;

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
@@ -156,17 +156,28 @@ int32_t bmi08x_gyr_reg_val_to_range(uint8_t reg_val)
 
 static int bmi08x_gyr_odr_set(const struct device *dev, uint16_t freq_int, uint16_t freq_milli)
 {
-	int odr = bmi08x_freq_to_odr_val(freq_int, freq_milli);
+	static const struct {
+		uint16_t freq;
+		uint8_t reg_val;
+	} bmi08x_gyr_odr_map[] = {
+		{100, BMI08X_GYRO_BW_12_ODR_100_HZ},	{200, BMI08X_GYRO_BW_23_ODR_200_HZ},
+		{400, BMI08X_GYRO_BW_47_ODR_400_HZ},	{1000, BMI08X_GYRO_BW_116_ODR_1000_HZ},
+		{2000, BMI08X_GYRO_BW_532_ODR_2000_HZ},
+	};
+	size_t i;
 
-	if (odr < 0) {
-		return odr;
-	}
-
-	if (odr < BMI08X_GYRO_BW_532_ODR_2000_HZ || odr > BMI08X_GYRO_BW_32_ODR_100_HZ) {
+	if (freq_milli != 0U) {
 		return -ENOTSUP;
 	}
 
-	return bmi08x_gyro_byte_write(dev, BMI08X_REG_GYRO_BANDWIDTH, (uint8_t)odr);
+	for (i = 0; i < ARRAY_SIZE(bmi08x_gyr_odr_map); i++) {
+		if (freq_int == bmi08x_gyr_odr_map[i].freq) {
+			return bmi08x_gyro_byte_write(dev, BMI08X_REG_GYRO_BANDWIDTH,
+						      bmi08x_gyr_odr_map[i].reg_val);
+		}
+	}
+
+	return -ENOTSUP;
 }
 
 static int bmi08x_gyr_range_set(const struct device *dev, uint16_t range)

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro_stream.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro_stream.c
@@ -133,7 +133,7 @@ static void bmi08x_gyro_gpio_callback(const struct device *port, struct gpio_cal
 {
 	struct bmi08x_gyro_data *data = CONTAINER_OF(cb, struct bmi08x_gyro_data, gpio_cb);
 	const struct device *dev = data->dev;
-	const struct bmi08x_accel_config *cfg = dev->config;
+	const struct bmi08x_gyro_config *cfg = dev->config;
 
 	(void)gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_DISABLE);
 	(void)gpio_remove_callback(cfg->int_gpio.port, &data->gpio_cb);


### PR DESCRIPTION
This PR fixes eight independent correctness bugs in the BMI08X
accelerometer/gyro driver, one commit per issue:

- **Fix gyro ODR attribute register encoding**: the gyro
  `SENSOR_ATTR_SAMPLING_FREQUENCY` handler wrote the index returned by the
  accel-style ODR map lookup straight into the gyro BANDWIDTH register, whose
  encoding is entirely different, programming wrong or reserved
  bandwidth/ODR combinations.
- **Fix sub-zero temperature conversion**: the die-temperature conversion
  performed the division while the intermediate was still unsigned, so
  temperatures below 0 °C produced garbage instead of negative values.
- **Compute accel scale from programmed range**: the accel range setter
  cached the conversion scale from the range the caller requested rather than
  the (rounded) range actually written to the register, skewing all
  subsequent readings when the request was rounded up.
- **Compute gyro scale from programmed range**: same bug in the gyro range
  setter — the cached scale came from the requested dps value instead of the
  programmed range.
- **Reject out-of-range accel ODR requests**: requests below 12.5 Hz fell
  through the lookup and returned a positive value without touching the
  hardware, and 3200 Hz produced a reserved register encoding. Reject both.
- **Use gyro config type in gyro GPIO callback**: the gyro stream GPIO
  callback read `dev->config` through `struct bmi08x_accel_config`; the
  layouts only match by accident and any change to either struct would break
  the interrupt path silently.
- **Fix unaligned/host-endian FIFO accel decoding**: FIFO accel frames were
  decoded by dereferencing `uint16_t *` into an unaligned byte buffer,
  which is both an unaligned access (a fault on strict-alignment targets)
  and wrong on big-endian systems. Use `sys_get_le16()`.
- **Apply SPI read protocol only on SPI bus**: the RTIO async read helper
  unconditionally set the SPI read bit on the register address and inserted
  the accel SPI dummy byte, corrupting the address and shifting every payload
  by one byte for devices on I2C, where the async/stream path is fully
  supported by Kconfig and the bindings.
