### PR TITLE
drivers: sensor: bmi160: fix various correctness issues

### DIFF
--- a/drivers/sensor/bosch/bmi160/bmi160.c
+++ b/drivers/sensor/bosch/bmi160/bmi160.c
@@ -759,7 +759,7 @@ static int bmi160_attr_get(const struct device *dev, enum sensor_channel chan,
 					int32_t udeg =
 						(FIELD_GET(GENMASK((2 * i) + 1, 2 * i), data[6])
 						 << 8) |
-						data[3 + i];
+						(uint8_t)data[3 + i];
 
 					udeg |= 0 - (udeg & 0x200);
 					udeg *= 61000;

--- a/drivers/sensor/bosch/bmi160/bmi160.c
+++ b/drivers/sensor/bosch/bmi160/bmi160.c
@@ -962,10 +962,10 @@ static int bmi160_temp_channel_get(const struct device *dev,
 	struct bmi160_data *data = dev->data;
 
 	/* the scale is 1/2^9/LSB = 1953 micro degrees */
-	int32_t temp_micro = BMI160_TEMP_OFFSET * 1000000ULL + data->sample.temperature * 1953ULL;
+	int32_t temp_micro = BMI160_TEMP_OFFSET * 1000000 + (int16_t)data->sample.temperature * 1953;
 
-	val->val1 = temp_micro / 1000000ULL;
-	val->val2 = temp_micro % 1000000ULL;
+	val->val1 = temp_micro / 1000000;
+	val->val2 = temp_micro % 1000000;
 
 	return 0;
 }

--- a/drivers/sensor/bosch/bmi160/bmi160.c
+++ b/drivers/sensor/bosch/bmi160/bmi160.c
@@ -1163,10 +1163,10 @@ int bmi160_pm(const struct device *dev, enum pm_device_action action)
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		bmi160_resume(dev);
+		ret = bmi160_resume(dev);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		bmi160_suspend(dev);
+		ret = bmi160_suspend(dev);
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/drivers/sensor/bosch/bmi160/bmi160.c
+++ b/drivers/sensor/bosch/bmi160/bmi160.c
@@ -859,7 +859,7 @@ static int bmi160_sample_fetch(const struct device *dev,
 		if (data->pmu_sts.raw == 0U) {
 			return -EINVAL;
 		}
-		return bmi160_word_read(dev, BMI160_REG_TEMPERATURE0, &data->sample.temperature);
+		return bmi160_word_read(dev, BMI160_REG_TEMPERATURE0, &data->temperature);
 	}
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
@@ -962,7 +962,7 @@ static int bmi160_temp_channel_get(const struct device *dev,
 	struct bmi160_data *data = dev->data;
 
 	/* the scale is 1/2^9/LSB = 1953 micro degrees */
-	int32_t temp_micro = BMI160_TEMP_OFFSET * 1000000 + (int16_t)data->sample.temperature * 1953;
+	int32_t temp_micro = BMI160_TEMP_OFFSET * 1000000 + (int16_t)data->temperature * 1953;
 
 	val->val1 = temp_micro / 1000000;
 	val->val2 = temp_micro % 1000000;

--- a/drivers/sensor/bosch/bmi160/bmi160.h
+++ b/drivers/sensor/bosch/bmi160/bmi160.h
@@ -473,7 +473,6 @@ union bmi160_pmu_status {
 /* Each sample has X, Y and Z */
 union bmi160_sample {
 	uint8_t raw[BMI160_BUF_SIZE];
-	uint16_t temperature;
 	struct {
 #if !defined(CONFIG_BMI160_GYRO_PMU_SUSPEND)
 		uint16_t gyr[BMI160_AXES];
@@ -500,6 +499,7 @@ struct bmi160_data {
 #endif
 	union bmi160_pmu_status pmu_sts;
 	union bmi160_sample sample;
+	uint16_t temperature;
 	struct bmi160_scale scale;
 
 #ifdef CONFIG_BMI160_TRIGGER_OWN_THREAD

--- a/drivers/sensor/bosch/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bosch/bmi160/bmi160_trigger.c
@@ -199,14 +199,23 @@ int bmi160_acc_slope_config(const struct device *dev,
 
 		acc_range_g = bmi160_acc_reg_val_to_range(reg_val);
 
+		if (val->val1 < 0 || val->val2 < 0) {
+			return -EINVAL;
+		}
+
 		slope_th_ums2 = val->val1 * 1000000 + val->val2;
+
+		if (slope_th_ums2 == 0U) {
+			return -EINVAL;
+		}
 
 		/* make sure the provided threshold does not exceed range / 2 */
 		if (slope_th_ums2 > (acc_range_g / 2 * SENSOR_G)) {
 			return -EINVAL;
 		}
 
-		reg_val = (slope_th_ums2 - 1) * 512U / (acc_range_g * SENSOR_G);
+		reg_val = (uint64_t)(slope_th_ums2 - 1) * 512U /
+			  (acc_range_g * SENSOR_G);
 
 		if (bmi160_byte_write(dev, BMI160_REG_INT_MOTION1,
 				      reg_val) < 0) {

--- a/drivers/sensor/bosch/bmi160/emul_bmi160.c
+++ b/drivers/sensor/bosch/bmi160/emul_bmi160.c
@@ -101,7 +101,7 @@ static void reg_write(const struct emul *target, int regn, int val)
 					shift = BMI160_PMU_STATUS_MAG_POS;
 					break;
 				}
-				data->pmu_status &= 3 << shift;
+				data->pmu_status &= ~(3 << shift);
 				data->pmu_status |= pmu_val << shift;
 				LOG_DBG("   * pmu %s = %x, new status %x", pmu_name[which], pmu_val,
 					data->pmu_status);


### PR DESCRIPTION
This PR fixes six independent correctness bugs in the BMI160 driver and its
emulator, one commit per issue:

- **Fix sign handling of die temperature**: the raw temperature word was used
  unsigned in the conversion, so temperatures below the 23 °C offset wrapped
  and reported as ~+150 °C. Interpret the register as int16_t.
- **Keep die temperature out of the sample union**: the cached temperature
  word overlaid the first gyro/accel sample in `union bmi160_sample`, so a
  `SENSOR_CHAN_DIE_TEMP` fetch clobbered the cached X-axis sample, and a
  `SENSOR_CHAN_ALL` fetch overwrote the temperature with gyro X data that
  `channel_get()` then converted into a bogus temperature. Move it to its own
  field in `struct bmi160_data`.
- **Fix sign corruption in gyro offset readback**: the 10-bit gyro offset is
  rebuilt from 2 MSBs in OFFSET_EN plus an 8-bit LSB read into an `int8_t`
  array; integer promotion sign-extended LSB values >= 0x80 and flooded the
  upper bits, making the explicit 10-bit sign extension that follows a no-op.
- **Avoid overflow in anymotion threshold calc**: `(slope_th_ums2 - 1) * 512`
  was computed in 32-bit arithmetic and wraps for thresholds above ~0.855 g,
  which the range check explicitly allows from the 2g range up. Widen to
  64-bit, and reject negative/zero threshold inputs that would underflow the
  subtraction.
- **Propagate PM suspend/resume errors**: `bmi160_pm()` ignored the return
  values of `bmi160_resume()`/`bmi160_suspend()`, reporting success to the PM
  subsystem even when the PMU register writes failed.
- **Fix PMU status mask in emulator**: the PMU command emulation used a
  non-inverted mask in its read-modify-write, keeping only the field being
  written and clearing every other sensor's power state.