### PR TITLE
drivers: sensor: bmc150_magn: fix DRDY pin config and attr error handling

### DIFF
--- a/drivers/sensor/bosch/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bosch/bmc150_magn/bmc150_magn.c
@@ -453,8 +453,7 @@ static int bmc150_magn_attr_set(const struct device *dev,
 #endif
 #if defined(BMC150_MAGN_SET_ATTR_REP)
 	case SENSOR_ATTR_OVERSAMPLING:
-		bmc150_magn_attr_set_rep(dev, chan, val);
-		break;
+		return bmc150_magn_attr_set_rep(dev, chan, val);
 #endif
 	default:
 		return -EINVAL;

--- a/drivers/sensor/bosch/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bosch/bmc150_magn/bmc150_magn_trigger.c
@@ -158,7 +158,10 @@ int bmc150_magn_init_interrupt(const struct device *dev)
 		return -ENODEV;
 	}
 
-	gpio_pin_configure_dt(&config->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	if (gpio_pin_configure_dt(&config->int_gpio, GPIO_INPUT) < 0) {
+		LOG_DBG("failed to configure DRDY gpio");
+		return -EIO;
+	}
 
 	gpio_init_callback(&data->gpio_cb,
 			   bmc150_magn_gpio_drdy_callback,


### PR DESCRIPTION
This PR fixes two correctness bugs in the BMC150 magnetometer driver, one
commit per issue:

- **Configure DRDY pin as input**: `gpio_pin_configure_dt()` was called with
  `GPIO_INT_EDGE_TO_ACTIVE`, which is an interrupt flag rejected by
  `gpio_pin_configure()` (assertion failure with `CONFIG_ASSERT=y`) and
  leaves the pin direction unset, with the return value ignored on top.
  Configure the pin as a plain input and check the result; edge selection is
  already handled by `setup_drdy()` via `gpio_pin_interrupt_configure_dt()`.
- **Propagate oversampling attr errors**: the `SENSOR_ATTR_OVERSAMPLING`
  case discarded the return value of `bmc150_magn_attr_set_rep()`, so
  out-of-range repetition values, ODR conflicts, unsupported channels and
  bus failures were all silently reported as success.