### PR TITLE
drivers: sensor: adxl367: fix various correctness issues

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -808,8 +808,13 @@ static int adxl367_attr_set_thresh(const struct device *dev,
 	value = (int32_t) llvalue;
 
 	threshold.value = value;
-	threshold.enable = cfg->activity_th.enable;
-	threshold.referenced = cfg->activity_th.referenced;
+	if (attr == SENSOR_ATTR_UPPER_THRESH) {
+		threshold.enable = cfg->activity_th.enable;
+		threshold.referenced = cfg->activity_th.referenced;
+	} else {
+		threshold.enable = cfg->inactivity_th.enable;
+		threshold.referenced = cfg->inactivity_th.referenced;
+	}
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -465,9 +465,9 @@ int adxl367_set_fifo_sample_sets_nb(const struct device *dev,
 {
 	struct adxl367_data *data = dev->data;
 	int ret;
-	uint8_t fifo_samples_msb = sets_nb & BIT(9) ? 1U : 0U;
+	uint8_t fifo_samples_msb = sets_nb & BIT(8) ? 1U : 0U;
 
-	/* bit 9 goes to FIFO_SAMPLES from ADXL367_FIFO_CONTROL */
+	/* bit 8 goes to FIFO_SAMPLES from ADXL367_FIFO_CONTROL */
 	ret = data->hw_tf->write_reg_mask(dev, ADXL367_FIFO_CONTROL,
 					  ADXL367_FIFO_CONTROL_FIFO_SAMPLES_MSK,
 					  FIELD_PREP(ADXL367_FIFO_CONTROL_FIFO_SAMPLES_MSK,

--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -469,7 +469,7 @@ static int adxl367_decode_12b_stream(const uint8_t *buffer, struct sensor_chan_s
 		if (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
 			struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
-			memset(data, 0, sizeof(struct sensor_three_axis_data));
+			memset(data, 0, sizeof(struct sensor_q31_data));
 			data->header.base_timestamp_ns = base_ts;
 			data->header.reading_count = 1;
 			data->shift = 8;
@@ -558,7 +558,7 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 			if (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
 				struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
-				memset(data, 0, sizeof(struct sensor_three_axis_data));
+				memset(data, 0, sizeof(struct sensor_q31_data));
 				data->header.base_timestamp_ns = base_ts;
 				data->header.reading_count = 1;
 				data->shift = 8;

--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -96,8 +96,9 @@ static inline void adxl367_temp_convert_q31(q31_t *out, const uint8_t *buff,
 			data_in |= ADXL367_COMPLEMENT;
 		}
 
-		*out = ((data_in - ADXL367_TEMP_25C) / ADXL367_TEMP_SENSITIVITY
-				+ ADXL367_TEMP_BIAS_TEST_CONDITION) * ADXL367_TEMP_QSCALE;
+		*out = (q31_t)(((int64_t)(data_in - ADXL367_TEMP_25C) * ADXL367_TEMP_QSCALE)
+				/ ADXL367_TEMP_SENSITIVITY
+				+ (int64_t)ADXL367_TEMP_BIAS_TEST_CONDITION * ADXL367_TEMP_QSCALE);
 	}
 }
 

--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -757,7 +757,7 @@ static bool adxl367_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigg
 	case SENSOR_TRIG_FIFO_WATERMARK:
 		return (ADXL367_STATUS_FIFO_WATERMARK & data->int_status);
 	case SENSOR_TRIG_FIFO_FULL:
-		return (ADXL367_STATUS_FIFO_WATERMARK & data->int_status);
+		return (ADXL367_STATUS_FIFO_OVERRUN & data->int_status);
 	default:
 		return false;
 	}

--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -634,6 +634,7 @@ static int adxl367_decoder_get_frame_count(const uint8_t *buffer,
 		case SENSOR_CHAN_ACCEL_Y:
 		case SENSOR_CHAN_ACCEL_Z:
 		case SENSOR_CHAN_ACCEL_XYZ:
+		case SENSOR_CHAN_DIE_TEMP:
 			*frame_count = 1;
 			ret = 0;
 			break;

--- a/drivers/sensor/adi/adxl367/adxl367_stream.c
+++ b/drivers/sensor/adi/adxl367/adxl367_stream.c
@@ -212,7 +212,7 @@ static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 
 	switch (data->fifo_config.fifo_read_mode) {
 	case ADXL367_8B:
-		fifo_bytes = fifo_packet_cnt;
+		fifo_bytes = fifo_packet_cnt * sample_numb;
 		break;
 	case ADXL367_12B: {
 		unsigned int fifo_bits = fifo_packet_cnt * sample_numb * 12;
@@ -245,7 +245,7 @@ static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 		break;
 	}
 	default:
-		fifo_bytes = fifo_packet_cnt * 2;
+		fifo_bytes = fifo_packet_cnt * sample_numb * 2;
 		packet_size *= 2;
 		break;
 	}


### PR DESCRIPTION
This PR fixes seven independent correctness bugs in the ADXL367 driver, one
commit per issue:

- **Fix FIFO full trigger check in decoder**: `has_trigger()` mapped
  `SENSOR_TRIG_FIFO_FULL` to the FIFO *watermark* status bit, so FIFO-full
  triggers fired on the wrong condition.
- **Fix FIFO byte count in stream read**: the streaming path computed the
  FIFO read length without multiplying by the number of samples per set,
  reading only 1/N of the available FIFO content each round.
- **Use inactivity config for lower threshold**: the inactivity threshold
  attribute path reused the *activity* threshold's enable/referenced
  devicetree configuration instead of the inactivity one.
- **Fix truncation in streaming temp Q31 convert**: the temperature
  conversion divided the raw value by the sensitivity before applying the
  Q31 scaling, truncating readings to whole degrees.
- **Support DIE_TEMP in one-shot frame count**: `get_frame_count()` rejected
  `SENSOR_CHAN_DIE_TEMP` for one-shot reads even though the decoder supports
  decoding it, making temperature streaming/decode unusable via the new API.
- **Fix memset size in DIE_TEMP decode branches**: the temperature decode
  paths cleared the output `sensor_q31_data` with
  `sizeof(struct sensor_three_axis_data)`, overwriting memory past the
  output structure.
- **Fix FIFO sample count MSB bit**: the FIFO watermark is a 9-bit value
  (8 LSBs in FIFO_SAMPLES + 1 MSB in FIFO_CONTROL), so the MSB is bit 8, not
  bit 9; watermarks of 256..511 sample sets wrapped modulo 256. Matches ADI's
  Linux IIO driver (the bug is inherited from ADI's no-OS code).
