### PR TITLE
drivers: sensor: adxl355: fix various correctness issues

### DIFF
--- a/drivers/sensor/adi/adxl355/adxl355.c
+++ b/drivers/sensor/adi/adxl355/adxl355.c
@@ -908,6 +908,7 @@ static int adxl355_attr_set(const struct device *dev, enum sensor_channel chan,
 {
 	/* Changes to the configurations setting must be made in Standby Mode */
 	int ret = 0;
+	int err;
 
 	if (val == NULL) {
 		LOG_ERR("Null pointer passed for sensor value");
@@ -940,7 +941,8 @@ static int adxl355_attr_set(const struct device *dev, enum sensor_channel chan,
 			break;
 		default:
 			LOG_ERR("Channel %u not supported for configuration attribute", chan);
-			return -ENOTSUP;
+			ret = -ENOTSUP;
+			break;
 		}
 		break;
 	case SENSOR_ATTR_OFFSET:
@@ -952,7 +954,8 @@ static int adxl355_attr_set(const struct device *dev, enum sensor_channel chan,
 			break;
 		default:
 			LOG_ERR("Channel %u not supported for offset attribute", chan);
-			return -ENOTSUP;
+			ret = -ENOTSUP;
+			break;
 		}
 		break;
 	case SENSOR_ATTR_ADXL355_FIFO_WATERMARK:
@@ -990,18 +993,22 @@ static int adxl355_attr_set(const struct device *dev, enum sensor_channel chan,
 		break;
 	default:
 		LOG_ERR("Attribute not supported");
-		return -ENOTSUP;
+		ret = -ENOTSUP;
+		break;
 	}
 	if (ret != 0) {
 		LOG_ERR("Failed to set attribute");
-		return ret;
 	}
-	ret = adxl355_set_op_mode(dev, ADXL355_MEASURE);
-	if (ret != 0) {
-		LOG_ERR("Failed to set measurement mode after attribute set");
-		return ret;
+
+	err = adxl355_set_op_mode(dev, ADXL355_MEASURE);
+	if (err != 0) {
+		LOG_ERR("Failed to restore measurement mode: %d", err);
+		if (ret == 0) {
+			ret = err;
+		}
 	}
-	return 0;
+
+	return ret;
 }
 
 /**

--- a/drivers/sensor/adi/adxl355/adxl355.h
+++ b/drivers/sensor/adi/adxl355/adxl355.h
@@ -291,7 +291,6 @@ struct adxl355_data {
 #ifdef CONFIG_ADXL355_TRIGGER
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
-	bool route_to_int2;
 
 	sensor_trigger_handler_t drdy_handler;
 	const struct sensor_trigger *drdy_trigger;

--- a/drivers/sensor/adi/adxl355/adxl355_decoder.c
+++ b/drivers/sensor/adi/adxl355/adxl355_decoder.c
@@ -291,7 +291,7 @@ static int adxl355_get_size_info(struct sensor_chan_spec channel, size_t *base_s
  */
 static bool adxl355_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
 {
-#ifdef CONFIG_ADXL355_STREAM
+#ifndef CONFIG_ADXL355_STREAM
 	return false;
 #endif
 	const struct adxl355_fifo_data *fifo_data = (const struct adxl355_fifo_data *)buffer;

--- a/drivers/sensor/adi/adxl355/adxl355_rtio.c
+++ b/drivers/sensor/adi/adxl355/adxl355_rtio.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <string.h>
+
 #include "adxl355.h"
 #include <zephyr/logging/log.h>
 #include <zephyr/rtio/work.h>
@@ -20,10 +22,13 @@ static void adxl355_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
 {
 	const struct sensor_read_config *config =
 		(const struct sensor_read_config *)iodev_sqe->sqe.iodev->data;
+	const struct device *dev = config->sensor;
+	struct adxl355_data *data = dev->data;
 	int rc;
 	uint8_t *buffer;
 	uint32_t buffer_len;
-	uint32_t min_buffer_len = sizeof(struct adxl355_fifo_data) + (config->count * 9);
+	uint32_t min_buffer_len = sizeof(struct adxl355_sample);
+	uint8_t raw_data[9];
 
 	rc = rtio_sqe_rx_buf(iodev_sqe, min_buffer_len, min_buffer_len, &buffer, &buffer_len);
 	if (rc != 0) {
@@ -31,6 +36,23 @@ static void adxl355_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
 		rtio_iodev_sqe_err(iodev_sqe, rc);
 		return;
 	}
+
+	rc = adxl355_reg_read(dev, ADXL355_XDATA3, raw_data, sizeof(raw_data));
+	if (rc != 0) {
+		LOG_ERR("Failed to read sample data");
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+
+	struct adxl355_sample *sample = (struct adxl355_sample *)buffer;
+
+	/* The decoder reads x/y/z as raw big-endian register bytes. */
+	memset(sample, 0, sizeof(*sample));
+	memcpy(&sample->x, &raw_data[0], 3);
+	memcpy(&sample->y, &raw_data[3], 3);
+	memcpy(&sample->z, &raw_data[6], 3);
+	sample->range = data->range;
+
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
 }
 

--- a/drivers/sensor/adi/adxl355/adxl355_stream.c
+++ b/drivers/sensor/adi/adxl355/adxl355_stream.c
@@ -59,8 +59,8 @@ void adxl355_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 	if (fifo_watermark_irq != data->fifo_watermark_irq) {
 		data->fifo_watermark_irq = fifo_watermark_irq;
 		ret = adxl355_reg_update(dev, ADXL355_INT_MAP,
-					 data->route_to_int2 ? ADXL355_INT_MAP_FIFO_FULL_EN2_MSK
-							     : ADXL355_INT_MAP_FIFO_FULL_EN1_MSK,
+					 cfg_355->route_to_int2 ? ADXL355_INT_MAP_FIFO_FULL_EN2_MSK
+								: ADXL355_INT_MAP_FIFO_FULL_EN1_MSK,
 					 fifo_watermark_irq);
 		if (ret < 0) {
 			LOG_ERR("Failed to update interrupt map: %d", ret);

--- a/drivers/sensor/adi/adxl355/adxl355_stream.c
+++ b/drivers/sensor/adi/adxl355/adxl355_stream.c
@@ -56,8 +56,8 @@ void adxl355_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 		}
 	}
 
-	if (fifo_watermark_irq != data->fifo_watermark) {
-		data->fifo_watermark = fifo_watermark_irq;
+	if (fifo_watermark_irq != data->fifo_watermark_irq) {
+		data->fifo_watermark_irq = fifo_watermark_irq;
 		ret = adxl355_reg_update(dev, ADXL355_INT_MAP,
 					 data->route_to_int2 ? ADXL355_INT_MAP_FIFO_FULL_EN2_MSK
 							     : ADXL355_INT_MAP_FIFO_FULL_EN1_MSK,

--- a/drivers/sensor/adi/adxl355/adxl355_trigger.c
+++ b/drivers/sensor/adi/adxl355/adxl355_trigger.c
@@ -94,6 +94,7 @@ int adxl355_trigger_set(const struct device *dev, const struct sensor_trigger *t
 	uint8_t int_mask;
 	uint8_t int_en;
 	int ret;
+	int err;
 
 	ret = adxl355_set_op_mode(dev, ADXL355_STANDBY);
 	if (ret < 0) {
@@ -104,7 +105,7 @@ int adxl355_trigger_set(const struct device *dev, const struct sensor_trigger *t
 	ret = gpio_pin_interrupt_configure_dt(&cfg->interrupt_gpio, GPIO_INT_DISABLE);
 	if (ret) {
 		LOG_ERR("Failed to disable interrupt: %d", ret);
-		return ret;
+		goto restore_mode;
 	}
 
 	switch (trig->type) {
@@ -127,7 +128,8 @@ int adxl355_trigger_set(const struct device *dev, const struct sensor_trigger *t
 		break;
 	default:
 		LOG_ERR("Unsupported trigger type: %d", trig->type);
-		return -ENOTSUP;
+		ret = -ENOTSUP;
+		goto restore_irq;
 	}
 
 	if (handler == NULL) {
@@ -141,13 +143,13 @@ int adxl355_trigger_set(const struct device *dev, const struct sensor_trigger *t
 	ret = adxl355_reg_update(dev, ADXL355_INT_MAP, int_mask, int_en);
 	if (ret) {
 		LOG_ERR("Failed to update interrupt map: %d", ret);
-		return ret;
+		goto restore_irq;
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&cfg->interrupt_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret) {
 		LOG_ERR("Failed to enable interrupt: %d", ret);
-		return ret;
+		goto restore_mode;
 	}
 
 	ret = adxl355_set_op_mode(dev, ADXL355_MEASURE);
@@ -157,6 +159,19 @@ int adxl355_trigger_set(const struct device *dev, const struct sensor_trigger *t
 	}
 
 	return 0;
+
+restore_irq:
+	err = gpio_pin_interrupt_configure_dt(&cfg->interrupt_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	if (err) {
+		LOG_ERR("Failed to restore interrupt: %d", err);
+	}
+restore_mode:
+	err = adxl355_set_op_mode(dev, ADXL355_MEASURE);
+	if (err) {
+		LOG_ERR("Failed to restore measurement mode: %d", err);
+	}
+
+	return ret;
 }
 
 int adxl355_init_interrupt(const struct device *dev)

--- a/drivers/sensor/adi/adxl355/adxl355_trigger.c
+++ b/drivers/sensor/adi/adxl355/adxl355_trigger.c
@@ -50,11 +50,9 @@ static void adxl355_gpio_callback(const struct device *dev, struct gpio_callback
 		LOG_ERR("Failed to disable interrupt: %d", ret);
 		return;
 	}
-#ifdef CONFIG_ADXL355_TRIGGER_OWN_THREAD
 #ifdef CONFIG_ADXL355_STREAM
 	adxl355_stream_irq_handler(data->dev);
 #endif /* CONFIG_ADXL355_STREAM */
-#endif /* !CONFIG_ADXL355_TRIGGER_OWN_THREAD */
 
 #if defined(CONFIG_ADXL355_TRIGGER_OWN_THREAD)
 	k_sem_give(&data->gpio_sem);


### PR DESCRIPTION
This PR fixes six independent correctness bugs in the ADXL355 driver, mostly
in the RTIO/streaming paths, one commit per issue:

- **Read sample data in async one-shot fetch**: the async one-shot submit
  path allocated the output buffer and completed the sqe without ever
  issuing the bus read, returning uninitialized memory as sample data.
- **Restore measurement mode on error paths**: attr_set/trigger_set place
  the device in STANDBY to reprogram it; on intermediate failures they
  returned without restoring measurement mode, silently halting all
  subsequent sampling.
- **Fix IRQ flag clobbering cached FIFO watermark**: the stream submit path
  stored a 0/1 interrupt-route flag into the struct field holding the cached
  FIFO watermark sample count, corrupting subsequent FIFO reads.
- **Fix inverted stream guard in has_trigger**: an inverted preprocessor
  condition compiled the trigger check out exactly when streaming support
  was enabled, so `has_trigger()` always returned false in streaming builds.
- **Call stream IRQ handler in all trigger modes**: the GPIO callback only
  dispatched the streaming IRQ handler when `CONFIG_ADXL355_TRIGGER_OWN_THREAD`
  was selected; with global-thread (or no trigger thread) streaming
  interrupts were never serviced.
- **Fix INT_MAP bit selection in stream submit**: stream submit consulted a
  never-initialized `data->route_to_int2` flag instead of the devicetree
  configuration, programming the wrong INT_MAP bit on boards wired to INT2.