### PR TITLE
drivers: sensor: max30009: fix various correctness issues

### DIFF
--- a/drivers/sensor/adi/max30009/max30009.c
+++ b/drivers/sensor/adi/max30009/max30009.c
@@ -375,6 +375,7 @@ static int max30009_set_bioz_config1(const struct device *dev)
 {
 	int ret;
 	const struct max30009_dev_config *cfg = dev->config;
+	struct max30009_data *data = dev->data;
 	/*
 	 * I/Q channel enables are deliberately left off here. Per the datasheet
 	 * ("Enabling and Disabling the PLL"), BIOZ_I_EN/BIOZ_Q_EN must be set
@@ -392,6 +393,7 @@ static int max30009_set_bioz_config1(const struct device *dev)
 		LOG_ERR("Failed to write BioZ Configuration 1: %d", ret);
 		return ret;
 	}
+	data->bioz_adc_osr_code = cfg->bioz_cfg.cfg_1.bioz_adc_osr;
 	return 0;
 }
 
@@ -1135,6 +1137,10 @@ static int max30009_attr_set(const struct device *dev, enum sensor_channel chan,
 	}
 	if (ret != 0) {
 		LOG_ERR("Failed to write attr %d: %d", attr, ret);
+	} else if ((uint16_t)attr == SENSOR_ATTR_MAX30009_ADC_OSR) {
+		struct max30009_data *data = dev->data;
+
+		data->bioz_adc_osr_code = reg_val;
 	}
 
 	/* Re-enable the PLL if it was stopped, even when the write failed. */

--- a/drivers/sensor/adi/max30009/max30009.c
+++ b/drivers/sensor/adi/max30009/max30009.c
@@ -1086,6 +1086,41 @@ static const struct max30009_attr_desc *max30009_attr_lookup(uint16_t attr)
 	return NULL;
 }
 
+/**
+ * @brief Check whether another STATUS1 reader is active.
+ *
+ * The PLL lock poll in max30009_pll_set_enable() reads the clear-on-read
+ * STATUS1 register, so it must not run while the stream or trigger paths may
+ * also read STATUS1: the poll would consume their pending events (A_FULL,
+ * FIFO_DATA_RDY) and they would consume the lock bits the poll waits for.
+ *
+ * @param dev Device pointer
+ * @return true if a stream request is pending or a trigger handler is set.
+ */
+static bool max30009_status1_readers_active(const struct device *dev)
+{
+	const struct max30009_data *data = dev->data;
+
+#ifdef CONFIG_MAX30009_STREAM
+	if (data->sqe != NULL) {
+		return true;
+	}
+#endif /* CONFIG_MAX30009_STREAM */
+#ifdef CONFIG_MAX30009_TRIGGER
+	const struct max30009_trigger_data *trig = &data->trig;
+
+	if (trig->drdy_handler != NULL || trig->dc_loff_nl_handler != NULL ||
+	    trig->dc_loff_nh_handler != NULL || trig->dc_loff_pl_handler != NULL ||
+	    trig->dc_loff_ph_handler != NULL || trig->drv_oor_handler != NULL ||
+	    trig->bioz_undr_handler != NULL || trig->bioz_over_handler != NULL ||
+	    trig->lon_handler != NULL) {
+		return true;
+	}
+#endif /* CONFIG_MAX30009_TRIGGER */
+	ARG_UNUSED(data);
+	return false;
+}
+
 static int max30009_attr_set(const struct device *dev, enum sensor_channel chan,
 			     enum sensor_attribute attr, const struct sensor_value *val)
 {
@@ -1123,6 +1158,10 @@ static int max30009_attr_set(const struct device *dev, enum sensor_channel chan,
 
 	/* Acquisition/drive-path fields must be changed with the PLL stopped. */
 	if (desc->flags & MAX30009_ATTR_PLL_OFF) {
+		if (max30009_status1_readers_active(dev)) {
+			return -EBUSY;
+		}
+
 		ret = max30009_pll_set_enable(dev, false);
 		if (ret != 0) {
 			return ret;

--- a/drivers/sensor/adi/max30009/max30009.h
+++ b/drivers/sensor/adi/max30009/max30009.h
@@ -487,6 +487,7 @@ struct max30009_data {
 	int pll_clk;
 	int bioz_adc_clk;
 	int bioz_synth_clk;
+	uint8_t bioz_adc_osr_code;
 #ifdef CONFIG_MAX30009_TRIGGER
 	const struct device *dev;
 	struct gpio_callback gpio_cb;

--- a/drivers/sensor/adi/max30009/max30009_decoder.c
+++ b/drivers/sensor/adi/max30009/max30009_decoder.c
@@ -89,18 +89,21 @@ static int max30009_decoder_decode(const uint8_t *buffer, struct sensor_chan_spe
 				int32_t sample = sign_extend(fifo_data & MAX30009_FIFO_DATA_FIELD,
 							     MAX30009_FIFO_DATA_SIGN_BIT);
 
-				/*
-				 * timestamp marks the newest sample (FIFO interrupt time), so
-				 * back-date each sample by its distance from the newest one.
-				 */
-				out[count].header.base_timestamp_ns =
-					data->timestamp -
-					(uint64_t)(total_samples - 1 - samples_seen) *
-						data->sample_period_ns;
-				out[count].header.reading_count = 1;
-				out[count].shift = 0;
-				out[count].readings[0].timestamp_delta = 0;
-				out[count].readings[0].value = sample;
+				if (count == 0) {
+					/*
+					 * timestamp marks the newest sample (FIFO interrupt
+					 * time), so back-date to the first decoded sample by
+					 * its distance from the newest one.
+					 */
+					out->header.base_timestamp_ns =
+						data->timestamp -
+						(uint64_t)(total_samples - 1 - samples_seen) *
+							data->sample_period_ns;
+					out->shift = 0;
+				}
+				out->readings[count].timestamp_delta =
+					(samples_seen - start_offset) * data->sample_period_ns;
+				out->readings[count].value = sample;
 				count++;
 			}
 			samples_seen++;
@@ -108,6 +111,7 @@ static int max30009_decoder_decode(const uint8_t *buffer, struct sensor_chan_spe
 		buffer += MAX30009_FIFO_BYTES_PER_SAMPLE;
 	}
 
+	out->header.reading_count = count;
 	*fit += count;
 	return count;
 }

--- a/drivers/sensor/adi/max30009/max30009_stream.c
+++ b/drivers/sensor/adi/max30009/max30009_stream.c
@@ -122,7 +122,7 @@ static void max30009_flush_rtio(const struct device *dev)
 
 	if (sqe == NULL || complete_op == NULL) {
 		LOG_ERR("Failed to acquire RTIO SQEs");
-		rtio_iodev_sqe_err(data->sqe, -ENOMEM);
+		rtio_sqe_drop_all(data->rtio_ctx);
 		gpio_pin_interrupt_configure_dt(&cfg->interrupt_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 		return;
 	}

--- a/drivers/sensor/adi/max30009/max30009_stream.c
+++ b/drivers/sensor/adi/max30009/max30009_stream.c
@@ -17,9 +17,8 @@ LOG_MODULE_DECLARE(MAX30009);
  */
 static uint32_t max30009_sample_period_ns(const struct device *dev)
 {
-	const struct max30009_dev_config *cfg = dev->config;
 	struct max30009_data *data = dev->data;
-	uint32_t adc_osr = MAX30009_BIOZ_ADC_OSR_BASE << cfg->bioz_cfg.cfg_1.bioz_adc_osr;
+	uint32_t adc_osr = MAX30009_BIOZ_ADC_OSR_BASE << data->bioz_adc_osr_code;
 
 	if (data->bioz_adc_clk <= 0) {
 		return 0;


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the MAX30009 driver, one
commit per issue:

- **Fix decoder writing array of q31_data structs**: the decoder emitted one
  full `struct sensor_q31_data` per sample instead of populating the
  header's flexible `readings[]` array, overflowing the caller-provided
  output buffer for multi-sample decodes.
- **Fix NULL deref in flush_rtio error path**: the error path called
  `rtio_iodev_sqe_err(data->sqe)` after `data->sqe` had already been NULLed
  and the sqe completed, dereferencing NULL and double-completing on flush
  failures.
- **Track runtime ADC OSR for sample period**: the streaming timestamp
  increment was computed from the devicetree ADC OSR only, so changing the
  OSR at runtime via `SENSOR_ATTR_MAX30009_ADC_OSR` left all subsequent
  stream timestamps wrong.
- **Reject PLL-off attr writes while events armed**: attributes that require
  a PLL off/on cycle poll the clear-on-read STATUS1 register while waiting
  for lock; doing that while the stream or trigger paths are armed consumes
  their pending A_FULL/FIFO_DATA_RDY events (and vice versa). Return -EBUSY
  in that case instead of silently racing.