### PR TITLE
drivers: sensor: tsl2591: fix attr_set error handling and gain caching

### DIFF
--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -286,24 +286,25 @@ static int tsl2591_set_persist(const struct device *dev, int32_t persist_filter)
 static int tsl2591_set_gain(const struct device *dev, enum sensor_gain_tsl2591 gain)
 {
 	struct tsl2591_data *data = dev->data;
+	uint16_t again_scale;
 	uint8_t gain_mode;
 	int ret;
 
 	switch (gain) {
 	case TSL2591_SENSOR_GAIN_LOW:
-		data->again = TSL2591_GAIN_SCALE_LOW;
+		again_scale = TSL2591_GAIN_SCALE_LOW;
 		gain_mode = TSL2591_GAIN_MODE_LOW;
 		break;
 	case TSL2591_SENSOR_GAIN_MED:
-		data->again = TSL2591_GAIN_SCALE_MED;
+		again_scale = TSL2591_GAIN_SCALE_MED;
 		gain_mode = TSL2591_GAIN_MODE_MED;
 		break;
 	case TSL2591_SENSOR_GAIN_HIGH:
-		data->again = TSL2591_GAIN_SCALE_HIGH;
+		again_scale = TSL2591_GAIN_SCALE_HIGH;
 		gain_mode = TSL2591_GAIN_MODE_HIGH;
 		break;
 	case TSL2591_SENSOR_GAIN_MAX:
-		data->again = TSL2591_GAIN_SCALE_MAX;
+		again_scale = TSL2591_GAIN_SCALE_MAX;
 		gain_mode = TSL2591_GAIN_MODE_MAX;
 		break;
 	default:
@@ -314,9 +315,12 @@ static int tsl2591_set_gain(const struct device *dev, enum sensor_gain_tsl2591 g
 	ret = tsl2591_reg_update(dev, TSL2591_REG_CONFIG, TSL2591_AGAIN_MASK, gain_mode);
 	if (ret < 0) {
 		LOG_ERR("Failed to set gain mode");
+		return ret;
 	}
 
-	return ret;
+	data->again = again_scale;
+
+	return 0;
 }
 
 static int tsl2591_set_integration(const struct device *dev, int32_t integration_time)

--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -185,11 +185,16 @@ static int tsl2591_set_threshold(const struct device *dev, enum sensor_attribute
 	const struct tsl2591_data *data = dev->data;
 	const struct tsl2591_config *config = dev->config;
 	uint64_t cpl;
-	uint32_t raw;
+	uint64_t raw;
 	uint16_t thld;
 	uint8_t thld_reg;
 	uint8_t cmd[3];
 	int ret;
+
+	if (val->val1 < 0 || val->val2 < 0) {
+		LOG_ERR("Threshold value must not be negative");
+		return -EINVAL;
+	}
 
 	/* Convert from relative strength of visible light to raw value */
 	cpl = (uint32_t)data->atime * data->again;
@@ -201,7 +206,7 @@ static int tsl2591_set_threshold(const struct device *dev, enum sensor_attribute
 		return -EOVERFLOW;
 	}
 
-	thld = sys_cpu_to_le16(raw);
+	thld = sys_cpu_to_le16((uint16_t)raw);
 	thld_reg = attr == SENSOR_ATTR_LOWER_THRESH ? TSL2591_REG_AILTL : TSL2591_REG_AIHTL;
 
 	cmd[0] = TSL2591_NORMAL_CMD | thld_reg;

--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -405,8 +405,12 @@ static int tsl2591_attr_set(const struct device *dev, enum sensor_channel chan,
 
 exit:
 	if (data->powered_on) {
-		ret = tsl2591_reg_update(dev, TSL2591_REG_ENABLE, TSL2591_POWER_MASK,
-					 TSL2591_POWER_ON);
+		int pon_ret = tsl2591_reg_update(dev, TSL2591_REG_ENABLE, TSL2591_POWER_MASK,
+						 TSL2591_POWER_ON);
+
+		if (ret == 0) {
+			ret = pon_ret;
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
This PR fixes three correctness bugs in the TSL2591 ambient light sensor
driver, one commit per issue:

- **Preserve attr_set error on power restore**: `attr_set()` powers the
  device down, applies the attribute, then powers it back up — but returned
  the result of the final power-on call, so failed or unsupported attribute
  writes were reported as success whenever the power-up succeeded.
- **Update cached gain only after register write**: `set_gain()` updated the
  cached gain scale (`data->again`) before writing the control register; if
  the I2C write failed, the cached scale diverged from the hardware gain and
  all subsequent lux conversions were silently wrong.
- **Fix threshold overflow check truncation**: the interrupt threshold
  computation truncated its 64-bit intermediate to uint32_t *before* the
  range check, so wrapped values could pass validation and program bogus
  thresholds.