### PR TITLE
drivers: sensor: bmg160: fix any-motion threshold and INT pin config

### DIFF
--- a/drivers/sensor/bosch/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bosch/bmg160/bmg160_trigger.c
@@ -105,7 +105,7 @@ int bmg160_slope_config(const struct device *dev, enum sensor_attribute attr,
 		}
 
 		return bmg160_write_byte(dev, BMG160_REG_THRES,
-					 any_th_dps & BMG160_THRES_MASK);
+					 any_th_reg_val & BMG160_THRES_MASK);
 	} else if (attr == SENSOR_ATTR_SLOPE_DUR) {
 		/* slope duration can be 4, 8, 12 or 16 samples */
 		if (val->val1 != 4 && val->val1 != 8 &&

--- a/drivers/sensor/bosch/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bosch/bmg160/bmg160_trigger.c
@@ -259,7 +259,7 @@ int bmg160_trigger_init(const struct device *dev)
 	bmg160->work.handler = bmg160_work_cb;
 #endif
 
-	ret = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	ret = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INPUT);
 	if (ret < 0) {
 		return ret;
 	}


### PR DESCRIPTION
This PR fixes two correctness bugs in the BMG160 gyroscope driver's trigger
support, one commit per issue:

- **Write scaled any-motion threshold to THRES reg**: the slope
  configuration computed the proper register encoding from the requested
  dps threshold but then wrote the raw dps value to the ANY_TH register,
  discarding the computed value and programming a wrong threshold.
- **Configure INT pin as input, not interrupt flags**:
  `gpio_pin_configure_dt()` was called with `GPIO_INT_EDGE_TO_ACTIVE`, an
  interrupt flag rejected by `gpio_pin_configure()` (assertion failure with
  `CONFIG_ASSERT=y`), leaving the pin direction unset. Edge selection is
  handled separately via `gpio_pin_interrupt_configure_dt()`.