### PR TITLE
drivers: sensor: lis2dux12: fix various correctness issues

### DIFF
--- a/drivers/sensor/st/lis2dux12/lis2dux12.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12.c
@@ -51,20 +51,21 @@ static const float lis2dux12_odr_map[LIS2DUX12_DT_ODR_END] = {FOREACH_ODR_ENUM(G
 
 static int lis2dux12_freq_to_odr_val(const struct device *dev, uint16_t freq)
 {
-	const struct lis2dux12_config *cfg = dev->config;
 	int odr;
+
+	ARG_UNUSED(dev);
 
 	for (odr = LIS2DUX12_DT_ODR_OFF; odr < LIS2DUX12_DT_ODR_END; odr++) {
 		/*
-		 * In case power-mode is HP, skip the ULP odrs in order to
-		 * avoid to erroneously break the loop sooner than expected.
-		 * In HP mode the correct ODRs must be found from
-		 * LIS2DUX12_DT_ODR_6Hz on.
+		 * Skip the ULP odrs in order to avoid to erroneously break
+		 * the loop sooner than expected: the map is not monotonic
+		 * around them (25 Hz ULP comes before 6 Hz), so the correct
+		 * ODRs must be found from LIS2DUX12_DT_ODR_6Hz on. ULP odrs
+		 * remain selectable through the devicetree odr property.
 		 */
-		if ((cfg->pm == LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE) &&
-		    ((odr == LIS2DUX12_DT_ODR_1Hz_ULP) ||
-		     (odr == LIS2DUX12_DT_ODR_3Hz_ULP) ||
-		     (odr == LIS2DUX12_DT_ODR_25Hz_ULP))) {
+		if ((odr == LIS2DUX12_DT_ODR_1Hz_ULP) ||
+		    (odr == LIS2DUX12_DT_ODR_3Hz_ULP) ||
+		    (odr == LIS2DUX12_DT_ODR_25Hz_ULP)) {
 			continue;
 		}
 

--- a/drivers/sensor/st/lis2dux12/lis2dux12_decoder.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_decoder.c
@@ -282,6 +282,15 @@ static int lis2dux12_decode_fifo(const uint8_t *buffer, struct sensor_chan_spec 
 				continue;
 			}
 
+			if (count + 1 >= max_count) {
+				/*
+				 * Not enough room for both samples of this 2X frame.
+				 * Since *fit is not advanced, the frame is decoded on
+				 * the next call.
+				 */
+				return count;
+			}
+
 			out->shift = accel_range[header->range];
 
 			out->readings[count].timestamp_delta =

--- a/drivers/sensor/st/lis2dux12/lis2dux12_decoder.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_decoder.c
@@ -288,9 +288,9 @@ static int lis2dux12_decode_fifo(const uint8_t *buffer, struct sensor_chan_spec 
 				(xl_count - 2) * accel_period_ns(edata->accel_odr,
 								 edata->accel_batch_odr);
 
-			x = *(int16_t *)&buffer[0];
-			y = *(int16_t *)&buffer[1];
-			z = *(int16_t *)&buffer[2];
+			x = (int16_t)((int8_t)buffer[1]) * 256;
+			y = (int16_t)((int8_t)buffer[2]) * 256;
+			z = (int16_t)((int8_t)buffer[3]) * 256;
 
 			out->readings[count].x = Q31_SHIFT_MICROVAL(scale * x, out->shift);
 			out->readings[count].y = Q31_SHIFT_MICROVAL(scale * y, out->shift);
@@ -301,9 +301,9 @@ static int lis2dux12_decode_fifo(const uint8_t *buffer, struct sensor_chan_spec 
 				(xl_count - 1) * accel_period_ns(edata->accel_odr,
 								 edata->accel_batch_odr);
 
-			x = *(int16_t *)&buffer[3];
-			y = *(int16_t *)&buffer[4];
-			z = *(int16_t *)&buffer[5];
+			x = (int16_t)((int8_t)buffer[4]) * 256;
+			y = (int16_t)((int8_t)buffer[5]) * 256;
+			z = (int16_t)((int8_t)buffer[6]) * 256;
 			out->readings[count].x = Q31_SHIFT_MICROVAL(scale * x, out->shift);
 			out->readings[count].y = Q31_SHIFT_MICROVAL(scale * y, out->shift);
 			out->readings[count].z = Q31_SHIFT_MICROVAL(scale * z, out->shift);

--- a/drivers/sensor/st/lis2dux12/lis2dux12_rtio.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_rtio.c
@@ -96,7 +96,6 @@ static void lis2dux12_submit_sample(const struct device *dev, struct rtio_iodev_
 	rc = sensor_clock_get_cycles(&cycles);
 	if (rc != 0) {
 		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
 		goto err;
 	}
 

--- a/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
@@ -322,6 +322,7 @@ static void lis2dux12_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe,
 	if (res != 0) {
 		rtio_iodev_sqe_err(lis2dux12->streaming_sqe, res);
 		lis2dux12->streaming_sqe = NULL;
+		gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 		return;
 	}
 
@@ -419,6 +420,9 @@ static void lis2dux12_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe,
 		rtio_read_regs_async(lis2dux12->rtio_ctx, lis2dux12->iodev, lis2dux12->bus_type,
 				     &fifo_regs, lis2dux12->streaming_sqe, dev,
 				     lis2dux12_complete_op_cb);
+	} else {
+		/* spurious interrupt: re-arm the irq and wait for next drdy event */
+		gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	}
 }
 


### PR DESCRIPTION
This PR fixes five independent correctness bugs in the LIS2DUX12 driver, one
commit per issue:

- **Fix FIFO 2x accel sample decode offsets**: the `XL_ONLY_2X` FIFO frame
  packs two signed 8-bit XYZ sample sets in the 6 bytes after the tag; the
  decoder instead read overlapping little-endian `int16_t`s starting at the
  tag byte itself, producing garbage for both samples. Decode the 8-bit
  samples at bytes 1..6 scaled by 256, matching the reference implementation
  in STMicroelectronics/lis2dux12-pid.
- **Fix OOB write decoding FIFO 2X frames**: each 2X frame emits two
  readings, but the decode loop only bounds-checked `count < max_count`
  once per frame, writing the second reading one element past the
  caller-provided output buffer when the frame straddled the limit.
- **Fix double completion of RTIO sqe**: the sensor-clock failure branch in
  the submit path completed the sqe with `rtio_iodev_sqe_err()` and then
  fell through to the shared error handling, completing the same sqe twice.
- **Skip ULP entries in ODR lookup for all modes**: the ODR map is not
  monotonic (ULP and LP entries interleave), so the first-match lookup made
  the 6/12.5/25 Hz low-power entries unreachable and silently selected
  25 Hz ULP for any 4-25 Hz request regardless of the configured power mode.
- **Re-arm drdy irq on spurious status callback**: if the status read
  callback ran with no data-ready bit set (spurious edge), it returned with
  the GPIO interrupt still disabled and the streaming sqe pending, stalling
  the stream permanently. Re-enable the interrupt and keep waiting instead.