### PR TITLE
boards: shields: nxp_m2_wifi_bt: increase BT RX stack size

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -153,6 +153,7 @@ configdefault LIBLC3
 
 configdefault BT_RX_STACK_SIZE
 	default 4096 if LIBLC3
+	default 2048 if BT_SETTINGS && !BT_MESH
 
 if SHELL
 


### PR DESCRIPTION
When Bluetooth is built with CONFIG_BT_SETTINGS and the RX processing runs on its own workqueue (CONFIG_BT_RECV_WORKQ_BT), the host may write data to flash directly from the "BT RX WQ" thread, for example when the remote device's CCC (Client Characteristic Configuration) values are persisted to settings storage after a GATT connection.

On boards using the NXP M.2 Wi-Fi/BT shield, the flash backend may have a deep call chain (e.g. FlexSPI NOR on MIMXRT1060-EVK), so doing this flash write from the RX thread can overflow the default BT RX stack (1200 bytes). Raise the baseline to 2048 for all boards using this shield.

The default is conditioned on BT_SETTINGS && !BT_MESH so that it only applies when settings storage is in use and does not override the larger Mesh defaults (2600/2800/3092) defined in the host Kconfig.