### PR TITLE
drivers: sensor: icm45686: fix various correctness issues

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -377,6 +377,11 @@ static int icm45686_init(const struct device *dev)
 		return err;
 	}
 
+	if (read_val != cfg->whoami) {
+		LOG_ERR("Unexpected WHO_AM_I: 0x%02X (expected 0x%02X)", read_val, cfg->whoami);
+		return -ENODEV;
+	}
+
 	/* Sensor Configuration */
 	err = icm456xx_set_accel_mode(&data->driver, cfg->settings.accel.pwr_mode);
 	if (err < 0) {
@@ -483,7 +488,7 @@ static int icm45686_init(const struct device *dev)
 	 (pwr_mode == ICM45686_DT_GYRO_LN && odr <= ICM45686_DT_GYRO_ODR_12_5) || \
 	 (pwr_mode == ICM45686_DT_GYRO_OFF))
 
-#define ICM45686_INIT(inst) \
+#define ICM45686_INIT(inst, whoami_val) \
  \
 	RTIO_DEFINE(icm45686_rtio_ctx_##inst, 32, 32); \
  \
@@ -519,6 +524,7 @@ static int icm45686_init(const struct device *dev)
 		}, \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}), \
 		.apex = DT_INST_ENUM_IDX(inst, apex), \
+		.whoami = whoami_val, \
 	}; \
 	static struct icm45686_data icm45686_data_##inst = { \
 		.edata.header = { \
@@ -556,20 +562,20 @@ static int icm45686_init(const struct device *dev)
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT invensense_icm45605
-DT_INST_FOREACH_STATUS_OKAY(ICM45686_INIT)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(ICM45686_INIT, WHO_AM_I_ICM45605)
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT invensense_icm45605s
-DT_INST_FOREACH_STATUS_OKAY(ICM45686_INIT)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(ICM45686_INIT, WHO_AM_I_ICM45605S)
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT invensense_icm45686
-DT_INST_FOREACH_STATUS_OKAY(ICM45686_INIT)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(ICM45686_INIT, WHO_AM_I_ICM45686)
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT invensense_icm45686s
-DT_INST_FOREACH_STATUS_OKAY(ICM45686_INIT)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(ICM45686_INIT, WHO_AM_I_ICM45686S)
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT invensense_icm45688p
-DT_INST_FOREACH_STATUS_OKAY(ICM45686_INIT)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(ICM45686_INIT, WHO_AM_I_ICM45688P)

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -432,7 +432,7 @@ static int icm45686_init(const struct device *dev)
 	 */
 	k_sleep(K_MSEC(1));
 
-	icm456xx_set_accel_ln_bw(&data->driver, cfg->settings.accel.lpf);
+	err = icm456xx_set_accel_ln_bw(&data->driver, cfg->settings.accel.lpf);
 	if (err < 0) {
 		LOG_ERR("Failed to set Accel BW settings: %d", err);
 		return err;

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -203,6 +203,7 @@ static int icm45686_channel_get(const struct device *dev, enum sensor_channel ch
 		} else if ((cfg->apex == TDK_APEX_TILT) || (cfg->apex == TDK_APEX_SMD)) {
 			val[0].val1 = data->apex_status;
 		}
+		break;
 #endif
 
 	default:

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -176,6 +176,7 @@ struct icm45686_config {
 	} settings;
 	struct gpio_dt_spec int_gpio;
 	uint8_t apex;
+	uint8_t whoami;
 };
 
 static inline void icm45686_accel_ms(uint8_t fs, int32_t in, bool high_res, int32_t *out_ms,

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -73,6 +73,9 @@ static int icm45686_get_shift(enum sensor_channel channel, int accel_fs, int gyr
 		case ICM45686_DT_GYRO_FS_31_25:
 			*shift = 5;
 			return 0;
+		case ICM45686_DT_GYRO_FS_15_625:
+			*shift = 4;
+			return 0;
 		default:
 			return -EINVAL;
 		}

--- a/drivers/sensor/tdk/icm45686/icm45686_reg.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_reg.h
@@ -67,7 +67,11 @@
 #define REG_FIFO_CONFIG3_FIFO_EN(val)       ((val) & BIT_MASK(1))
 
 /* Misc. Defines */
-#define WHO_AM_I_ICM45686 0xE9
+#define WHO_AM_I_ICM45605  0xE5
+#define WHO_AM_I_ICM45605S 0xEB
+#define WHO_AM_I_ICM45686  0xE9
+#define WHO_AM_I_ICM45686S 0xEE
+#define WHO_AM_I_ICM45688P 0xE7
 
 #define REG_IREG_PREPARE_WRITE_ARRAY(base, reg, val)                                               \
 	{                                                                                          \

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -161,6 +161,8 @@ static void icm45686_complete_handler(struct rtio *ctx, const struct rtio_sqe *s
 			icm45686_stream_result(dev, -ENOMEM);
 			return;
 		}
+		rtio_submit(data->bus.rtio.ctx, 0);
+
 		icm45686_stream_result(dev, 0);
 		return;
 	}

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -548,6 +548,7 @@ int icm45686_stream_init(const struct device *dev)
 			LOG_ERR("Failed to configure interrupt");
 		}
 
+		memset(&int_config, INV_IMU_DISABLE, sizeof(int_config));
 		err = icm456xx_set_config_int(&data->driver, INV_IMU_INT1, &int_config);
 		if (err) {
 			LOG_ERR("Failed to disable all INTs");

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -185,7 +185,7 @@ static void icm45686_event_handler(const struct device *dev)
 {
 	struct icm45686_data *data = dev->data;
 	const struct icm45686_config *cfg = dev->config;
-	const struct sensor_read_config *read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
+	const struct sensor_read_config *read_cfg;
 	uint8_t val = 0;
 	uint64_t cycles;
 	int err;
@@ -209,6 +209,8 @@ static void icm45686_event_handler(const struct device *dev)
 		data->stream.settings.enabled.fifo_full = false;
 		return;
 	}
+
+	read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
 
 	if (atomic_cas(&data->stream.state, ICM45686_STREAM_ON, ICM45686_STREAM_BUSY) == false) {
 		LOG_WRN("Event handler triggered while a stream is in progress! Ignoring");

--- a/drivers/sensor/tdk/icm566xx/icm566xx.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.c
@@ -614,7 +614,7 @@ static int icm566xx_init(const struct device *dev)
 	 */
 	k_sleep(K_MSEC(1));
 
-	icm566xx_set_accel_ln_bw(&data->driver, cfg->settings.accel.lpf);
+	err = icm566xx_set_accel_ln_bw(&data->driver, cfg->settings.accel.lpf);
 	if (err < 0) {
 		LOG_ERR("Failed to set Accel BW settings: %d", err);
 		return err;

--- a/drivers/sensor/tdk/icm566xx/icm566xx_stream.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx_stream.c
@@ -184,7 +184,7 @@ static void icm566xx_event_handler(const struct device *dev)
 {
 	struct icm566xx_data *data = dev->data;
 	const struct icm566xx_config *cfg = dev->config;
-	const struct sensor_read_config *read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
+	const struct sensor_read_config *read_cfg;
 	uint8_t val = 0;
 	uint64_t cycles;
 	int err;
@@ -208,6 +208,8 @@ static void icm566xx_event_handler(const struct device *dev)
 		data->stream.settings.enabled.fifo_full = false;
 		return;
 	}
+
+	read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
 
 	if (atomic_cas(&data->stream.state, ICM566XX_STREAM_ON, ICM566XX_STREAM_BUSY) == false) {
 		LOG_WRN("Event handler triggered while a stream is in progress! Ignoring");


### PR DESCRIPTION
This PR fixes seven independent correctness bugs in the ICM45686 driver, one
commit per issue. Two of them also correct the identical copy/pasted code in
the sibling ICM566XX driver.

- **Validate WHO_AM_I register value**: `init()` read WHO_AM_I into a local
  and never compared it, so a wrong or absent device initialised silently.
  The expected ID is now carried per variant (0xE5/0xEB/0xE9/0xEE/0xE7 for
  ICM45605/45605S/45686/45686S/45688P, matching hal_tdk's `INV_IMU_WHOAMI`)
  and a mismatch returns -ENODEV.
- **Add missing break in APEX channel_get**: the `SENSOR_CHAN_APEX_MOTION`
  case filled in the pedometer/WOM/tilt/SMD results and then fell through to
  `default: return -ENOTSUP`, so APEX data was always reported as
  unsupported despite being valid.
- **Add missing 15.625 dps gyro shift case**: `get_shift()` had no case for
  `ICM45686_DT_GYRO_FS_15_625`, so async decoding at that full scale failed.
- **Init int_config before writing INT1 config**: the streaming init passed
  an uninitialized `inv_imu_int_state_t` to `icm456xx_set_config_int()`,
  writing stack garbage into INT1_CONFIG0/INT1_CONFIG1 — every byte's LSB is
  an interrupt-enable bit. The sync and trigger paths already memset it.
- **Fix NULL deref in stream event handler**: the handler dereferenced
  `stream.iodev_sqe` to fetch the read config *before* the NULL/cancelled
  guard that exists precisely for that state. Defer the assignment past the
  guard (also fixed in icm566xx_stream.c).
- **Submit prepared FIFO flush write**: the FIFO-flush branch prepared the
  FIFO_CONFIG2 flush SQEs but never called `rtio_submit()`, so the flush
  never executed.
- **Check accel LPF configuration return value**: the return of
  `icm456xx_set_accel_ln_bw()` was discarded while the following `if (err < 0)`
  re-tested the stale, provably non-negative gyro result, making the check
  dead (same in icm566xx.c).