### PR TITLE
mgmt: mcumgr: fs_mgmt: Reject paths with parent directory references

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -148,6 +148,22 @@ static void file_close_work_handler(struct k_work *work)
 	k_sem_give(&fs_mgmt_ctxt.lock_sem);
 }
 
+static bool fs_mgmt_path_has_parent_reference(const char *path)
+{
+	const char *p = path;
+
+	while (*p != '\0') {
+		if ((p[0] == '.' && p[1] == '.') && (p == path || p[-1] == '/') &&
+		    (p[2] == '\0' || p[2] == '/')) {
+			return true;
+		}
+
+		++p;
+	}
+
+	return false;
+}
+
 static int fs_mgmt_filelen(const char *path, size_t *out_len)
 {
 	struct fs_dirent dirent;
@@ -278,6 +294,10 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 
 	memcpy(path, name.value, name.len);
 	path[name.len] = '\0';
+
+	if (fs_mgmt_path_has_parent_reference(path)) {
+		return MGMT_ERR_EINVAL;
+	}
 
 	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME)) {
 		return MGMT_ERR_EBUSY;
@@ -430,6 +450,10 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 
 	memcpy(file_name, name.value, name.len);
 	file_name[name.len] = '\0';
+
+	if (fs_mgmt_path_has_parent_reference(file_name)) {
+		return MGMT_ERR_EINVAL;
+	}
 
 	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME)) {
 		return MGMT_ERR_EBUSY;
@@ -667,6 +691,10 @@ static int fs_mgmt_file_status(struct smp_streamer *ctxt)
 	memcpy(path, name.value, name.len);
 	path[name.len] = '\0';
 
+	if (fs_mgmt_path_has_parent_reference(path)) {
+		return MGMT_ERR_EINVAL;
+	}
+
 #if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
 	/* Send request to application to check if access should be allowed or not */
 	status = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
@@ -759,6 +787,10 @@ static int fs_mgmt_file_hash_checksum(struct smp_streamer *ctxt)
 	/* Copy strings and ensure they are null-teminated */
 	memcpy(path, name.value, name.len);
 	path[name.len] = '\0';
+
+	if (fs_mgmt_path_has_parent_reference(path)) {
+		return MGMT_ERR_EINVAL;
+	}
 
 	if (type.len != 0) {
 		memcpy(type_arr, type.value, type.len);


### PR DESCRIPTION
The download, upload, stat and hash/checksum handlers copied the client-supplied file path into a fixed-size buffer and passed it straight to the filesystem layer, without checking its contents.

On filesystems that resolve ".." components themselves (e.g. FatFS), this allowed a path such as "/SD:/allowed/../invalid.bin" to reach a location outside a directory that an application's CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK callback intended to restrict access to, since the hook only sees the unresolved path.

Reject any path containing a ".." component before it reaches fs_open()/fs_stat() in all four handlers.