### PR TITLE
drivers: sensor: icm566xx: fix various correctness issues

### DIFF
--- a/drivers/sensor/tdk/icm566xx/icm566xx.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.c
@@ -205,7 +205,7 @@ static int icm566xx_accel_config(struct icm566xx_data *drv_data, enum sensor_att
 		icm566xx_set_accel_frequency(&drv_data->driver, val->val1);
 
 		if (val->val1 && c_mode == PWR_MGMT0_ACCEL_MODE_OFF) {
-			if (val->val1 >= ACCEL_CONFIG0_ACCEL_ODR_12_5_HZ) {
+			if (val->val1 <= ACCEL_CONFIG0_ACCEL_ODR_12_5_HZ) {
 				icm566xx_set_accel_mode(&drv_data->driver, PWR_MGMT0_ACCEL_MODE_LN);
 			} else {
 				icm566xx_set_accel_mode(&drv_data->driver, PWR_MGMT0_ACCEL_MODE_LP);
@@ -239,7 +239,7 @@ static int icm566xx_gyro_config(struct icm566xx_data *drv_data, enum sensor_attr
 		icm566xx_set_gyro_frequency(&drv_data->driver, val->val1);
 
 		if (val->val1 && c_mode == PWR_MGMT0_GYRO_MODE_OFF) {
-			if (val->val1 >= GYRO_CONFIG0_GYRO_ODR_12_5_HZ) {
+			if (val->val1 <= GYRO_CONFIG0_GYRO_ODR_12_5_HZ) {
 				icm566xx_set_gyro_mode(&drv_data->driver, PWR_MGMT0_GYRO_MODE_LN);
 			} else {
 				icm566xx_set_gyro_mode(&drv_data->driver, PWR_MGMT0_GYRO_MODE_LP);

--- a/drivers/sensor/tdk/icm566xx/icm566xx.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.c
@@ -127,7 +127,7 @@ void icm566xx_gyro_rads(uint8_t fs, int32_t in, bool high_res, int32_t *out_rads
 		CODE_UNREACHABLE;
 	}
 
-	total_urads = ((int64_t)in * SENSOR_PI * 10000LL) / (sensitivity * 180LL);
+	total_urads = ((int64_t)in * SENSOR_PI * 1000LL) / (sensitivity * 180LL);
 	*out_rads = (int32_t)(total_urads / 1000000LL);
 	*out_urads = (int32_t)(total_urads % 1000000LL);
 }

--- a/drivers/sensor/tdk/icm566xx/icm566xx.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.c
@@ -645,13 +645,13 @@ static int icm566xx_init(const struct device *dev)
 }
 
 #define ICM566XX_VALID_ACCEL_ODR(pwr_mode, odr)                                                    \
-	((pwr_mode == ICM566XX_DT_ACCEL_LP && odr > ICM566XX_DT_ACCEL_ODR_400) ||                 \
-	 (pwr_mode == ICM566XX_DT_ACCEL_LN && odr < ICM566XX_DT_ACCEL_ODR_12_5) ||                \
+	((pwr_mode == ICM566XX_DT_ACCEL_LP && odr >= ICM566XX_DT_ACCEL_ODR_400) ||                \
+	 (pwr_mode == ICM566XX_DT_ACCEL_LN && odr <= ICM566XX_DT_ACCEL_ODR_12_5) ||               \
 	 (pwr_mode == ICM566XX_DT_ACCEL_OFF))
 
 #define ICM566XX_VALID_GYRO_ODR(pwr_mode, odr)                                                     \
-	((pwr_mode == ICM566XX_DT_GYRO_LP && odr > ICM566XX_DT_GYRO_ODR_400) ||                   \
-	 (pwr_mode == ICM566XX_DT_GYRO_LN && odr < ICM566XX_DT_GYRO_ODR_12_5) ||                  \
+	((pwr_mode == ICM566XX_DT_GYRO_LP && odr >= ICM566XX_DT_GYRO_ODR_400) ||                  \
+	 (pwr_mode == ICM566XX_DT_GYRO_LN && odr <= ICM566XX_DT_GYRO_ODR_12_5) ||                 \
 	 (pwr_mode == ICM566XX_DT_GYRO_OFF))
 
 #define ICM566XX_INIT(inst)                                                                        \

--- a/drivers/sensor/tdk/icm566xx/icm566xx.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.c
@@ -216,7 +216,13 @@ static int icm566xx_accel_config(struct icm566xx_data *drv_data, enum sensor_att
 			LOG_ERR("Wrong config with accel mode");
 		}
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
-		icm566xx_set_accel_fsr(&drv_data->driver, val->val1);
+		int err = icm566xx_set_accel_fsr(&drv_data->driver, val->val1);
+
+		if (err != 0) {
+			return err;
+		}
+
+		drv_data->edata.header.accel_fs = val->val1;
 	} else if ((enum sensor_attribute_icm566xx)attr == SENSOR_ATTR_BW_FILTER_LPF) {
 		icm566xx_set_accel_ln_bw(&drv_data->driver, val->val1);
 	} else if ((enum sensor_attribute_icm566xx)attr == SENSOR_ATTR_AVERAGING) {
@@ -250,7 +256,13 @@ static int icm566xx_gyro_config(struct icm566xx_data *drv_data, enum sensor_attr
 			LOG_ERR("Wrong config with gyro mode");
 		}
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
-		icm566xx_set_gyro_fsr(&drv_data->driver, val->val1);
+		int err = icm566xx_set_gyro_fsr(&drv_data->driver, val->val1);
+
+		if (err != 0) {
+			return err;
+		}
+
+		drv_data->edata.header.gyro_fs = val->val1;
 	} else if ((enum sensor_attribute_icm566xx)attr == SENSOR_ATTR_BW_FILTER_LPF) {
 		icm566xx_set_gyro_ln_bw(&drv_data->driver, val->val1);
 	} else {

--- a/drivers/sensor/tdk/icm566xx/icm566xx.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.c
@@ -197,79 +197,91 @@ static pwr_mgmt0_gyro_mode_t icm566xx_get_gyro_mode(inv_imu_device_t *s)
 static int icm566xx_accel_config(struct icm566xx_data *drv_data, enum sensor_attribute attr,
 				 const struct sensor_value *val)
 {
+	int err = 0;
+
 	if (attr == SENSOR_ATTR_CONFIGURATION) {
-		icm566xx_set_accel_mode(&drv_data->driver, val->val1);
+		err = icm566xx_set_accel_mode(&drv_data->driver, val->val1);
 	} else if (attr == SENSOR_ATTR_SAMPLING_FREQUENCY) {
 		pwr_mgmt0_accel_mode_t c_mode = icm566xx_get_accel_mode(&drv_data->driver);
 
-		icm566xx_set_accel_frequency(&drv_data->driver, val->val1);
+		err = icm566xx_set_accel_frequency(&drv_data->driver, val->val1);
+		if (err < 0) {
+			return err;
+		}
 
 		if (val->val1 && c_mode == PWR_MGMT0_ACCEL_MODE_OFF) {
 			if (val->val1 <= ACCEL_CONFIG0_ACCEL_ODR_12_5_HZ) {
-				icm566xx_set_accel_mode(&drv_data->driver, PWR_MGMT0_ACCEL_MODE_LN);
+				err = icm566xx_set_accel_mode(&drv_data->driver,
+							      PWR_MGMT0_ACCEL_MODE_LN);
 			} else {
-				icm566xx_set_accel_mode(&drv_data->driver, PWR_MGMT0_ACCEL_MODE_LP);
+				err = icm566xx_set_accel_mode(&drv_data->driver,
+							      PWR_MGMT0_ACCEL_MODE_LP);
 			}
 		} else if (val->val1 == 0) {
-			icm566xx_set_accel_mode(&drv_data->driver, PWR_MGMT0_ACCEL_MODE_OFF);
+			err = icm566xx_set_accel_mode(&drv_data->driver, PWR_MGMT0_ACCEL_MODE_OFF);
 		} else {
 			LOG_ERR("Wrong config with accel mode");
 		}
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
-		int err = icm566xx_set_accel_fsr(&drv_data->driver, val->val1);
-
+		err = icm566xx_set_accel_fsr(&drv_data->driver, val->val1);
 		if (err != 0) {
 			return err;
 		}
 
 		drv_data->edata.header.accel_fs = val->val1;
 	} else if ((enum sensor_attribute_icm566xx)attr == SENSOR_ATTR_BW_FILTER_LPF) {
-		icm566xx_set_accel_ln_bw(&drv_data->driver, val->val1);
+		err = icm566xx_set_accel_ln_bw(&drv_data->driver, val->val1);
 	} else if ((enum sensor_attribute_icm566xx)attr == SENSOR_ATTR_AVERAGING) {
-		icm566xx_set_accel_lp_avg(&drv_data->driver, val->val1);
+		err = icm566xx_set_accel_lp_avg(&drv_data->driver, val->val1);
 	} else {
 		LOG_ERR("Unsupported attribute");
 		return -EINVAL;
 	}
-	return 0;
+	return err;
 }
 
 static int icm566xx_gyro_config(struct icm566xx_data *drv_data, enum sensor_attribute attr,
 				const struct sensor_value *val)
 {
+	int err = 0;
+
 	if (attr == SENSOR_ATTR_CONFIGURATION) {
-		icm566xx_set_gyro_mode(&drv_data->driver, val->val1);
+		err = icm566xx_set_gyro_mode(&drv_data->driver, val->val1);
 	} else if (attr == SENSOR_ATTR_SAMPLING_FREQUENCY) {
 		pwr_mgmt0_gyro_mode_t c_mode = icm566xx_get_gyro_mode(&drv_data->driver);
 
-		icm566xx_set_gyro_frequency(&drv_data->driver, val->val1);
+		err = icm566xx_set_gyro_frequency(&drv_data->driver, val->val1);
+		if (err < 0) {
+			return err;
+		}
 
 		if (val->val1 && c_mode == PWR_MGMT0_GYRO_MODE_OFF) {
 			if (val->val1 <= GYRO_CONFIG0_GYRO_ODR_12_5_HZ) {
-				icm566xx_set_gyro_mode(&drv_data->driver, PWR_MGMT0_GYRO_MODE_LN);
+				err = icm566xx_set_gyro_mode(&drv_data->driver,
+							     PWR_MGMT0_GYRO_MODE_LN);
 			} else {
-				icm566xx_set_gyro_mode(&drv_data->driver, PWR_MGMT0_GYRO_MODE_LP);
+				err = icm566xx_set_gyro_mode(&drv_data->driver,
+							     PWR_MGMT0_GYRO_MODE_LP);
 			}
 		} else if (val->val1 == 0) {
-			icm566xx_set_gyro_mode(&drv_data->driver, PWR_MGMT0_GYRO_MODE_OFF);
+			err = icm566xx_set_gyro_mode(&drv_data->driver, PWR_MGMT0_GYRO_MODE_OFF);
 		} else {
 			LOG_ERR("Wrong config with gyro mode");
 		}
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
-		int err = icm566xx_set_gyro_fsr(&drv_data->driver, val->val1);
-
+		err = icm566xx_set_gyro_fsr(&drv_data->driver, val->val1);
 		if (err != 0) {
 			return err;
 		}
 
 		drv_data->edata.header.gyro_fs = val->val1;
 	} else if ((enum sensor_attribute_icm566xx)attr == SENSOR_ATTR_BW_FILTER_LPF) {
-		icm566xx_set_gyro_ln_bw(&drv_data->driver, val->val1);
+		err = icm566xx_set_gyro_ln_bw(&drv_data->driver, val->val1);
 	} else {
 		LOG_ERR("Unsupported attribute");
 		return -EINVAL;
 	}
-	return 0;
+	return err;
 }
 
 static int icm566xx_attr_set(const struct device *dev, enum sensor_channel chan,
@@ -283,9 +295,9 @@ static int icm566xx_attr_set(const struct device *dev, enum sensor_channel chan,
 		LOG_ERR("Unsupported channel");
 		return -EINVAL;
 	} else if (SENSOR_CHANNEL_IS_ACCEL(chan)) {
-		icm566xx_accel_config(drv_data, attr, val);
+		return icm566xx_accel_config(drv_data, attr, val);
 	} else if (SENSOR_CHANNEL_IS_GYRO(chan)) {
-		icm566xx_gyro_config(drv_data, attr, val);
+		return icm566xx_gyro_config(drv_data, attr, val);
 	} else {
 		LOG_ERR("Unsupported channel");
 		(void)drv_data;
@@ -626,7 +638,7 @@ static int icm566xx_init(const struct device *dev)
 	 */
 	k_sleep(K_MSEC(1));
 
-	icm566xx_set_accel_ln_bw(&data->driver, cfg->settings.accel.lpf);
+	err = icm566xx_set_accel_ln_bw(&data->driver, cfg->settings.accel.lpf);
 	if (err < 0) {
 		LOG_ERR("Failed to set Accel BW settings: %d", err);
 		return err;

--- a/drivers/sensor/tdk/icm566xx/icm566xx_decoder.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx_decoder.c
@@ -236,7 +236,7 @@ int icm566xx_encode(const struct device *dev, const struct sensor_chan_spec *con
 		    const size_t num_channels, uint8_t *buf)
 {
 	struct icm566xx_encoded_data *edata = (struct icm566xx_encoded_data *)buf;
-	const struct icm566xx_config *dev_config = dev->config;
+	const struct icm566xx_data *data = dev->data;
 	uint64_t cycles;
 	int err;
 
@@ -252,8 +252,8 @@ int icm566xx_encode(const struct device *dev, const struct sensor_chan_spec *con
 	}
 
 	edata->header.events = 0;
-	edata->header.accel_fs = dev_config->settings.accel.fs;
-	edata->header.gyro_fs = dev_config->settings.gyro.fs;
+	edata->header.accel_fs = data->edata.header.accel_fs;
+	edata->header.gyro_fs = data->edata.header.gyro_fs;
 	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
 
 	return 0;

--- a/drivers/sensor/tdk/icm566xx/icm566xx_decoder.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx_decoder.c
@@ -378,9 +378,13 @@ static int icm566xx_one_shot_decode(const uint8_t *buffer, struct sensor_chan_sp
 
 		int32_t raw_reading;
 #if defined(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
-		int pos = icm566xx_get_channel_position(chan_spec.chan_type);
+		if (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
+			raw_reading = edata->payload.temp;
+		} else {
+			int pos = icm566xx_get_channel_position(chan_spec.chan_type);
 
-		raw_reading = get_raw_reading_by_position(edata, pos);
+			raw_reading = get_raw_reading_by_position(edata, pos);
+		}
 #else
 		raw_reading =
 			edata->payload.readings[icm566xx_get_channel_position(chan_spec.chan_type)];

--- a/include/zephyr/dt-bindings/sensor/icm566xx.h
+++ b/include/zephyr/dt-bindings/sensor/icm566xx.h
@@ -111,7 +111,7 @@
 #define ICM566XX_DT_GYRO_ODR_100	9  /**< 100 Hz (LN or LP mode) */
 #define ICM566XX_DT_GYRO_ODR_50		10 /**< 50 Hz (LN or LP mode) */
 #define ICM566XX_DT_GYRO_ODR_25		11 /**< 25 Hz (LN or LP mode) */
-#define ICM566XX_DT_GYRO_ODR_12_5	1  /**< 12.5 Hz (LN or LP mode) */
+#define ICM566XX_DT_GYRO_ODR_12_5	12 /**< 12.5 Hz (LN or LP mode) */
 #define ICM566XX_DT_GYRO_ODR_6_25	13 /**< 6.25 Hz (LP mode only) */
 #define ICM566XX_DT_GYRO_ODR_3_125	14 /**< 3.125 Hz (LP mode only) */
 #define ICM566XX_DT_GYRO_ODR_1_5625	15 /**< 1.5625 Hz (LP mode only) */


### PR DESCRIPTION
This PR fixes six independent correctness bugs in the ICM566XX driver and its
devicetree bindings, one commit per issue:

- **Fix 10x error in gyro rad/s conversion**: the µrad/s numerator used a
  10000 multiplier where the sensitivity encoding (milli-LSB per dps) calls
  for 1000, so every gyro reading was ten times too large at every full
  scale — a saturated ±2000 dps sample decoded as 349 rad/s instead of 34.9.
- **dt-bindings: fix gyro 12.5 Hz ODR value**: `ICM566XX_DT_GYRO_ODR_12_5`
  was defined as `1` in the middle of a 9,10,11,_,13,14,15 sequence,
  colliding with another rate. The accompanying `ICM566XX_VALID_*_ODR()`
  macros also used `>`/`<` where `>=`/`<=` is needed, rejecting the very
  12.5 Hz and 400 Hz rates the header documents as valid in each power mode.
- **Fix inverted LN/LP mode auto-selection**: when a sampling frequency was
  set on a powered-off accel/gyro, the comparison against the 12.5 Hz ODR
  code selected low-noise mode for low rates and low-power mode for high
  rates — backwards, since the ODR encoding counts down with frequency.
- **Track full-scale changes made at runtime**: `SENSOR_ATTR_FULL_SCALE`
  reprogrammed the hardware but never updated the cached full scale used to
  scale samples, so readings after a runtime range change were converted
  with the devicetree value. The cache is now updated after a successful
  write and `encode()` reads it instead of the static config.
- **Fix one-shot die temp decode on ICM56686**: the ICM56686 branch of the
  one-shot decoder passed `-EINVAL` itself into the conversion as the raw
  sample value.
- **Propagate attribute configuration errors**: the accel/gyro attribute
  helpers discarded the return value of every HAL setter and `attr_set()`
  ignored the helpers' results, so failed configuration was reported as
  success.

Note: the ICM45686 PR touches one line in this driver too (the dropped
`icm566xx_set_accel_ln_bw()` return in `init()`, which is copy/pasted between
the two drivers), so a trivial conflict is possible depending on merge order.