### PR TITLE
drivers: sensor: bma4xx: fix various correctness issues

### DIFF
--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -190,7 +190,7 @@ static int bma4xx_attr_set_bwp(const struct sensor_value *val,
 		return -EINVAL;
 	}
 
-	new_config->accel_bwp = (((uint8_t)val->val1) << BMA4XX_SHIFT_ACC_CONF_BWP);
+	new_config->accel_bwp = (uint8_t)val->val1;
 
 	return 0;
 }

--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -185,8 +185,9 @@ static int bma4xx_attr_set_range(const struct sensor_value *val,
 static int bma4xx_attr_set_bwp(const struct sensor_value *val,
 			       struct bma4xx_runtime_config *new_config)
 {
-	/* Require that `val2` is unused, and that `val1` is in range of a valid BWP */
-	if (val->val2 || val->val1 < BMA4XX_BWP_OSR4_AVG1 || val->val1 > BMA4XX_BWP_RES_AVG128) {
+	/* Ensure a valid BWP for performance mode, the only mode currently supported */
+	if (val->val2 != 0 || val->val1 < BMA4XX_BWP_OSR4_AVG1 ||
+	    val->val1 > BMA4XX_BWP_NORM_AVG4) {
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/bosch/bma4xx/bma4xx_common.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_common.c
@@ -77,11 +77,6 @@ int bma4xx_configure(const struct device *dev, struct bma4xx_runtime_config *cfg
 		__ASSERT(res == 0, "%s could not flush fifo", __func__);
 	}
 
-	/* Switch to performance power mode */
-	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_ACCEL_CONFIG,
-					   FIELD_PREP(BMA4XX_BIT_ACC_PERF_MODE, 1));
-	__ASSERT(res == 0, "%s could not enable performance power mode", __func__);
-
 	/* Enable non-latch mode
 	 * Regarding the discussion in the Bosch Community, enabling latch mode on bma4xx
 	 * might result in multiple FIFO interrupts. Therefore, it is recommended to use
@@ -111,8 +106,9 @@ int bma4xx_configure(const struct device *dev, struct bma4xx_runtime_config *cfg
 					   FIELD_PREP(BMA4XX_MASK_ACC_RANGE, cfg->accel_fs_range));
 	__ASSERT(res == 0, "%s could not write acceleration range", __func__);
 
-	/* Write data rate and bandwidth */
-	uint8_t odr_bw_value = FIELD_PREP(BMA4XX_MASK_ACC_CONF_ODR, cfg->accel_odr) |
+	/* Write data rate, bandwidth and performance power mode */
+	uint8_t odr_bw_value = FIELD_PREP(BMA4XX_BIT_ACC_PERF_MODE, 1) |
+			       FIELD_PREP(BMA4XX_MASK_ACC_CONF_ODR, cfg->accel_odr) |
 			       FIELD_PREP(BMA4XX_MASK_ACC_CONF_BWP, cfg->accel_bwp);
 
 	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_ACCEL_CONFIG, odr_bw_value);

--- a/drivers/sensor/bosch/bma4xx/bma4xx_common.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_common.c
@@ -72,8 +72,7 @@ int bma4xx_configure(const struct device *dev, struct bma4xx_runtime_config *cfg
 						   FIELD_PREP(BMA4XX_FIFO_ACC_EN, 0));
 		__ASSERT(res == 0, "%s could not disable fifo acceleration", __func__);
 
-		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_CMD,
-						   FIELD_PREP(BMA4XX_CMD_FIFO_FLUSH, 1));
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_CMD, BMA4XX_CMD_FIFO_FLUSH);
 		__ASSERT(res == 0, "%s could not flush fifo", __func__);
 	}
 

--- a/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.c
@@ -69,7 +69,23 @@ int bma4xx_init_interrupt(const struct device *dev)
 int bma4xx_enable_interrupt1(const struct device *dev, struct bma4xx_runtime_config *new_cfg)
 {
 	struct bma4xx_data *data = dev->data;
+	const struct bma4xx_config *cfg = dev->config;
+	uint8_t io_ctrl = BMA4XX_BIT_INT1_IO_CTRL_OUTPUT_EN;
 	uint8_t value = 0;
+	int ret;
+
+	/* The INT1 pad is disabled after reset. Enable it as a push-pull output whose active
+	 * level follows the polarity declared for int1-gpios, so that the edge-to-active GPIO
+	 * interrupt armed by the streaming code sees the assertion edge.
+	 */
+	if ((cfg->gpio_interrupt.dt_flags & GPIO_ACTIVE_LOW) == 0) {
+		io_ctrl |= BMA4XX_BIT_INT1_IO_CTRL_LVL;
+	}
+
+	ret = data->hw_ops->write_reg(dev, BMA4XX_REG_INT1_IO_CTRL, io_ctrl);
+	if (ret != 0) {
+		return ret;
+	}
 
 	if (new_cfg->interrupt1_fifo_wm) {
 		value |= FIELD_PREP(BMA4XX_BIT_INT_MAP_DATA_INT1_FWM, 1);

--- a/dts/bindings/sensor/bosch,bma4xx-common.yaml
+++ b/dts/bindings/sensor/bosch,bma4xx-common.yaml
@@ -7,3 +7,6 @@ properties:
     description: |
       Identifies pin for the INT1 signal on the sensor.  The sensor
       INT2,3,4 signals are not supported by the driver.
+
+      The driver configures INT1 as a push-pull output whose active level
+      follows the polarity flag of this property.


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the BMA4XX driver, one
commit per issue:

- **Fix double shift of BWP value in attr_set**: the bandwidth-parameter
  attribute stored an already-shifted field value, which `FIELD_PREP()` then
  shifted again when composing ACC_CONF, so the programmed BWP was always 0
  regardless of the requested value. The cached value now stays in the same
  unshifted domain used by `chip_init()`.
- **Keep perf mode bit in ACC_CONF write**: `configure()` set the
  `acc_perf_mode` bit in a standalone write and then wrote the ODR/bandwidth
  value to the same register without it, clearing the bit it had just set.
  The perf-mode bit is now folded into the single ODR/bandwidth write.
- **Write correct FIFO flush command value**: the FIFO flush wrote
  `FIELD_PREP(BMA4XX_CMD_FIFO_FLUSH, 1)` (0x10) to the CMD register instead
  of the command value itself (0xB0), so the FIFO was never flushed — the
  other CMD writes in the driver and the emulator both use the raw value.
- **Enable the INT1 pin output for streaming**: `enable_interrupt1()` mapped
  the FIFO watermark/full sources to INT1 but never wrote INT1_IO_CTRL,
  leaving the pad disabled as the soft reset at init leaves it, so no edge
  ever reached the host and streaming could not complete. The pin is now
  configured as a push-pull active-high output first.