### PR TITLE
Bluetooth: Fix CSRK sign counter handling and persistence

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -474,15 +474,31 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 	}
 
 	if (hdr->code == BT_ATT_OP_SIGNED_WRITE_CMD) {
+		net_buf_simple_save(&buf->b, &state);
+
 		err = bt_smp_sign(chan->att->conn, buf);
-		if (err) {
+		if (err != 0) {
 			LOG_ERR("Error signing data");
-			net_buf_unref(buf);
+			/* Restore the buffer state, since the callers retain
+			 * ownership of the buffer on failure and may retry
+			 * sending it later.
+			 */
+			net_buf_simple_restore(&buf->b, &state);
 			return err;
 		}
-	}
 
-	net_buf_simple_save(&buf->b, &state);
+		/* Keep the pre-signing state saved above: bt_smp_sign()
+		 * already consumed and persisted a sign counter value, so if
+		 * the send below fails the buffer must be restored to its
+		 * unsigned form. Retrying will then sign it again (consuming
+		 * the next counter value, which is fine since the spec only
+		 * requires the counter to strictly increase). Restoring the
+		 * already-signed state instead would let a retry append a
+		 * second signature onto a buffer sized for only one.
+		 */
+	} else {
+		net_buf_simple_save(&buf->b, &state);
+	}
 
 	data->att_chan = chan;
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5249,6 +5249,19 @@ int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf)
 		return -ENOENT;
 	}
 
+	/* Fail closed when the counter space is exhausted, instead of
+	 * wrapping around and reusing counter values, which the peer
+	 * would reject as replays. The final possible value is never used
+	 * for signing, since a receiver cannot accept it without its own
+	 * next expected value wrapping (see bt_smp_sign_verify()). A new
+	 * pairing needs to distribute a fresh CSRK to resume signing.
+	 */
+	if (keys->local_csrk.cnt == UINT32_MAX) {
+		LOG_ERR("Sign counter of local CSRK for %s exhausted",
+			bt_conn_dst_str(conn));
+		return -EOVERFLOW;
+	}
+
 	/* Reserve space for data signature */
 	net_buf_add(buf, 12);
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5186,12 +5186,39 @@ int bt_smp_sign_verify(struct bt_conn *conn, struct net_buf *buf)
 		return -ENOENT;
 	}
 
-	/* Copy signing count */
-	cnt = sys_cpu_to_le32(keys->remote_csrk.cnt);
-	memcpy(net_buf_tail(buf) - sizeof(sig), &cnt, sizeof(cnt));
+	cnt = sys_get_le32(sig);
+
+	/* The Signing Algorithm is performed with the received counter
+	 * value, and replay protection is done by rejecting counter values
+	 * that have already been used (Core Spec v6.2, Vol 3, Part C,
+	 * Section 10.4.2, the last version to specify data signing before
+	 * its removal in v6.3). Values greater than the expected next one
+	 * are accepted, since the peer may consume counter values for
+	 * signed PDUs that never end up being received, e.g. when it
+	 * retries a failed send with a fresh signature or disconnects with
+	 * signed PDUs still queued.
+	 */
+	if (cnt < keys->remote_csrk.cnt) {
+		LOG_WRN("Rejecting already used sign counter %u from %s", cnt,
+			bt_conn_dst_str(conn));
+		return -EBADMSG;
+	}
+
+	/* Fail closed when the received counter is the final possible
+	 * value: accepting it would wrap the next expected value around
+	 * to zero, re-opening the replay window for every previously used
+	 * counter value. The counter space of the CSRK is then exhausted,
+	 * and signing can only resume once a new pairing distributes a
+	 * fresh CSRK.
+	 */
+	if (cnt == UINT32_MAX) {
+		LOG_WRN("Sign counter of remote CSRK for %s exhausted",
+			bt_conn_dst_str(conn));
+		return -EOVERFLOW;
+	}
 
 	LOG_DBG("Sign data len %zu key %s count %u", buf->len - sizeof(sig),
-		bt_hex(keys->remote_csrk.val, 16), keys->remote_csrk.cnt);
+		bt_hex(keys->remote_csrk.val, 16), cnt);
 
 	err = smp_sign_buf(keys->remote_csrk.val, buf->data,
 			   buf->len - sizeof(sig));
@@ -5205,7 +5232,7 @@ int bt_smp_sign_verify(struct bt_conn *conn, struct net_buf *buf)
 		return -EBADMSG;
 	}
 
-	keys->remote_csrk.cnt++;
+	keys->remote_csrk.cnt = cnt + 1U;
 
 	return 0;
 }

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5234,6 +5234,23 @@ int bt_smp_sign_verify(struct bt_conn *conn, struct net_buf *buf)
 
 	keys->remote_csrk.cnt = cnt + 1U;
 
+	/* The sign counter is bound to the lifetime of the CSRK, not to a
+	 * single power cycle. Without persisting each accepted value, a
+	 * reboot would restore the counter stored at pairing time, making
+	 * previously captured Signed Write Commands verify (replay) again.
+	 *
+	 * Fail closed if the new value cannot be persisted, so that no
+	 * command gets executed unless it is also protected from replay.
+	 * The incremented in-memory value is kept, since the peer has
+	 * already consumed this counter value and expects the next one.
+	 */
+	err = bt_keys_store(keys);
+	if (err != 0) {
+		LOG_ERR("Unable to store updated sign counter for %s",
+			bt_conn_dst_str(conn));
+		return err;
+	}
+
 	return 0;
 }
 
@@ -5279,6 +5296,21 @@ int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf)
 	}
 
 	keys->local_csrk.cnt++;
+
+	/* Persist the new counter value so that a reboot does not lead to
+	 * reuse of an already used value, which the peer would reject.
+	 *
+	 * On failure the increment is reverted: the PDU is not sent in
+	 * that case, so the counter value has not been consumed and must
+	 * be used for the next attempt to stay in sync with the peer.
+	 */
+	err = bt_keys_store(keys);
+	if (err != 0) {
+		LOG_ERR("Unable to store updated sign counter for %s",
+			bt_conn_dst_str(conn));
+		keys->local_csrk.cnt--;
+		return err;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This PR started out as a fix for missing sign counter persistence (#115879) and grew related fixes for issues found along the way, covering the handling of CSRK sign counters for ATT Signed Write Commands. One commit per fix, in the order below.

### SMP: Verify signed data using the received sign counter

bt_smp_sign_verify() substituted the locally expected sign counter value into the received PDU before running the Signing Algorithm, effectively requiring the peer's counter to match the expected value exactly. The Core Specification instead requires authentication to be performed with the received counter value, with replay protection provided by rejecting counter values that have already been used (Core Spec v6.2, Vol 3, Part C, Section 10.4.2 and Vol 3, Part H, Section 2.4.5 — v6.2 being the last version to specify the data signing feature, before its removal in v6.3). Requiring an exact match permanently desynchronizes signing as soon as the peer skips a counter value, which can happen for legitimate reasons: the peer may consume counter values for signed PDUs that never end up being received, e.g. when retrying a locally failed send with a fresh signature or when disconnecting with signed PDUs still queued. Recovery from that state would require re-pairing.

The final possible counter value (0xFFFFFFFF) is rejected as CSRK exhaustion rather than accepted, since accepting it would wrap the next expected value around to zero, re-opening the replay window for every previously used counter value.

### SMP: Fail closed on local sign counter exhaustion

bt_smp_sign() incremented the local sign counter without bound, so after signing with the final possible value it would silently wrap around to zero and start reusing counter values, which a compliant peer rejects as replays. It now fails closed with -EOVERFLOW once the counter space of the CSRK is exhausted, making it explicit that a new pairing needs to distribute a fresh CSRK before signing can resume. Per the spec's own note, exhausting a 32-bit sign counter takes roughly 117 years at 100,000 signed messages a day, so this is a purely defensive measure.

### ATT: Fix buffer handling on signed write send failure

chan_send() unreferenced the buffer when bt_smp_sign() failed, but its callers retain ownership of the buffer on failure and may requeue it for a later retry, resulting in a freed buffer being requeued (or freed a second time) whenever signing an outgoing Signed Write Command failed. In addition, the buffer state is now saved before signing and restored on send failure, so that a retried buffer is signed fresh instead of growing an extra 12-octet signature on each attempt.

### SMP: Persist CSRK sign counters across reboots

The local and remote CSRK sign counters are part of the bt_keys storage blob, but were only ever written to persistent storage when the bond was initially stored upon pairing completion, i.e. with a counter value of 0. The increments done at runtime by bt_smp_sign() and bt_smp_sign_verify() were never written back to storage.

As a consequence, after a reboot the remote sign counter would be restored to its pairing-time value. Since ATT Signed Write Commands are sent in plaintext over an unencrypted connection, a passive eavesdropper could capture them and replay the entire sequence in its original order after the reboot, passing signature verification again. This defeats the replay protection required by the Core Specification, which ties the sign counter to the lifetime of the CSRK rather than to a power cycle. Security erratum 26047, integrated in Core Spec v6.2, states this requirement explicitly: "Conforming implementations shall be required to store the last verified SignCounter in the security database if data signing is used" (listed in Core Spec v6.3, Vol 1, Part C, Section 16.3).

Similarly, the local sign counter would be restored to its pairing-time value, causing the device to reuse already-used counter values when signing, which a compliant peer will reject as replays.

Fix this by storing the keys after each counter increment. Note that CSRKs are only ever distributed for bonding pairings, so the keys being stored here are guaranteed to already have a settings entry, and bt_keys_store() is a no-op when CONFIG_BT_SETTINGS is disabled.

Fixes #115879