### PR TITLE
drivers: sensor: mtch9010: fix DELTA parsing, sleep timeout and GPIO guard

### DIFF
--- a/drivers/sensor/microchip/mtch9010/mtch9010.c
+++ b/drivers/sensor/microchip/mtch9010/mtch9010.c
@@ -46,7 +46,7 @@ static int mtch9010_configure_gpio(const struct device *dev);
 static int mtch9010_configure_int_gpio(const struct device *dev);
 static int mtch9010_device_reset(const struct device *dev);
 static int mtch9010_timeout_receive(const struct device *dev, char *buffer, uint8_t buffer_len,
-				    uint16_t milliseconds);
+				    uint32_t milliseconds);
 static int mtch9010_lock_settings(const struct device *dev);
 static int mtch9010_update_heartbeat(const struct device *dev);
 
@@ -350,8 +350,8 @@ static int mtch9010_init(const struct device *dev)
 #ifdef CONFIG_MTCH9010_OVERRIDE_DELAY_ENABLE
 	/* Print warning */
 	if (config->sleep_time != 0) {
-		uint16_t timeout =
-			(config->sleep_time) * 1000 + CONFIG_MTCH9010_SAMPLE_DELAY_TIMEOUT_MS;
+		uint32_t timeout =
+			(config->sleep_time_s) * 1000 + CONFIG_MTCH9010_SAMPLE_DELAY_TIMEOUT_MS;
 		LOG_INST_WRN(config->log, "Device will wait up-to %u ms when fetching samples",
 			     (timeout));
 	}
@@ -398,7 +398,7 @@ static int mtch9010_command_send(const struct device *dev, const char *str)
 
 /* Returns the number of bytes received */
 static int mtch9010_timeout_receive(const struct device *dev, char *buffer, uint8_t buffer_len,
-				    uint16_t milliseconds)
+				    uint32_t milliseconds)
 {
 	const struct mtch9010_config *config = (const struct mtch9010_config *)dev->config;
 	const struct device *uart_dev = config->uart_dev;
@@ -748,12 +748,12 @@ static int mtch9010_sample_fetch(const struct device *dev, enum sensor_channel c
 		}
 
 		/* Blocking Wait for Sensor Data */
-		uint16_t timeout = CONFIG_MTCH9010_SAMPLE_DELAY_TIMEOUT_MS;
+		uint32_t timeout = CONFIG_MTCH9010_SAMPLE_DELAY_TIMEOUT_MS;
 
 		if (config->sleep_time != 0) {
 
 #ifdef CONFIG_MTCH9010_OVERRIDE_DELAY_ENABLE
-			timeout = (config->sleep_time) * 1000 +
+			timeout = (config->sleep_time_s) * 1000 +
 				  CONFIG_MTCH9010_SAMPLE_DELAY_TIMEOUT_MS;
 #else
 			LOG_INST_ERR(config->log, "Wake mode is disabled if sleep period is "
@@ -917,6 +917,10 @@ static DEVICE_API(sensor, mtch9010_api_funcs) = {
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, sleep_period),\
 		(DT_INST_ENUM_IDX(inst, sleep_period)), (0))
 
+#define MTCH9010_SLEEP_TIME_SEC_INIT(inst)                                                         \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, sleep_period),\
+		(DT_INST_PROP(inst, sleep_period)), (0))
+
 #define MTCH9010_OUTPUT_MODE_INIT(inst)                                                            \
 	COND_CODE_0(DT_INST_PROP_OR(inst, extended_output_enable, false),\
 		(MTCH9010_OUTPUT_FORMAT_CURRENT),\
@@ -957,6 +961,7 @@ static DEVICE_API(sensor, mtch9010_api_funcs) = {
 		.enable_cfg_gpio = GPIO_DT_SPEC_GET_OR(DT_DRV_INST(inst), cfg_en_gpios, {0}),      \
 		.mode = MTCH9010_OPERATING_MODE_INIT(inst),                                        \
 		.sleep_time = MTCH9010_SLEEP_TIME_INIT(inst),                                      \
+		.sleep_time_s = MTCH9010_SLEEP_TIME_SEC_INIT(inst),                                \
 		.extended_mode_enable = DT_INST_PROP_OR(inst, extended_output_enable, false),      \
 		.format = MTCH9010_OUTPUT_MODE_INIT(inst),                                         \
 		.ref_mode = MTCH9010_REF_MODE_INIT(inst),                                          \

--- a/drivers/sensor/microchip/mtch9010/mtch9010.c
+++ b/drivers/sensor/microchip/mtch9010/mtch9010.c
@@ -578,7 +578,7 @@ int mtch9010_decode_char_buffer(const char *buffer, uint8_t format, struct mtch9
 	}
 
 	/* Check to see if the first digit is valid */
-	if (isdigit(buffer[0]) == 0) {
+	if ((isdigit((unsigned char)buffer[0]) == 0) && (buffer[0] != '-')) {
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/microchip/mtch9010/mtch9010.c
+++ b/drivers/sensor/microchip/mtch9010/mtch9010.c
@@ -714,6 +714,11 @@ static int mtch9010_sample_fetch(const struct device *dev, enum sensor_channel c
 	case SENSOR_CHAN_MTCH9010_OUT_STATE: {
 		/* I/O output state - poll GPIO */
 
+		if (config->out_gpio.port == NULL) {
+			LOG_INST_ERR(config->log, "OUT GPIO not configured");
+			return -ENOTSUP;
+		}
+
 		data->last_out_state = gpio_pin_get_dt(&config->out_gpio);
 		if (data->last_out_state < 0) {
 			LOG_ERR("GPIO Error %d", data->last_out_state);

--- a/drivers/sensor/microchip/mtch9010/mtch9010_priv.h
+++ b/drivers/sensor/microchip/mtch9010/mtch9010_priv.h
@@ -130,8 +130,10 @@ struct mtch9010_config {
 	const struct gpio_dt_spec heartbeat_gpio;
 	/* Operating mode (Capacitive / Conductive) */
 	uint8_t mode;
-	/* Sleep Time of device in seconds. Set to 0 for Wake on Request */
+	/* Sleep Time command index of device. Set to 0 for Wake on Request */
 	int sleep_time;
+	/* Sleep Time of device in seconds. Set to 0 for Wake on Request */
+	uint16_t sleep_time_s;
 	/* Set to true if extended format output is configured */
 	bool extended_mode_enable;
 	/* Format of the UART Output Data */

--- a/tests/drivers/sensor/mtch9010/src/main.c
+++ b/tests/drivers/sensor/mtch9010/src/main.c
@@ -31,6 +31,7 @@ ZTEST(mtch9010_utility, test_result_decode)
 	const char *test_pattern_3 = "999 12405\n\r";
 	const char *test_pattern_4 = "0 1234\n\r";
 	const char *test_pattern_5 = "100 -99\n\r";
+	const char *test_pattern_6 = "-99\n\r";
 
 	/* Bad Decodes */
 	const char *bad_decode_pattern_1 = "10\n\r";
@@ -76,6 +77,12 @@ ZTEST(mtch9010_utility, test_result_decode)
 					  &test_result);
 	zassert_equal(ret, 0, "Unable to decode test_pattern_5");
 	zassert_equal(test_result.measurement, 100, "Decoded value does not match expected");
+	zassert_equal(test_result.delta, -99, "Decoded value does not match expected");
+
+	/* Test Negative Delta in Delta only format */
+	ret = mtch9010_decode_char_buffer(test_pattern_6, MTCH9010_OUTPUT_FORMAT_DELTA,
+					  &test_result);
+	zassert_equal(ret, 0, "Unable to decode test_pattern_6");
 	zassert_equal(test_result.delta, -99, "Decoded value does not match expected");
 
 	/* Test Bad Decode 1 - Incorrect format */


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the MTCH9010 driver, one
commit per issue:

- **Accept negative values in DELTA format**: the UART response parser
  required the first character to be a digit, so in DELTA output format every
  negative delta was rejected as malformed and the fetch failed. The guard
  now also accepts a leading '-' (and casts to `unsigned char` for
  `isdigit()`); a regression case for a negative delta is added to the
  driver's test.
- **Fix sleep period timeout computation**: `sleep_time` holds the
  devicetree *enum index*, but the fetch/init timeout math used it as a value
  in seconds, producing timeouts far shorter than the configured sleep
  period. The seconds value is now carried alongside the enum index used for
  the UART command, and the timeout locals are widened to `uint32_t` so the
  longest period does not overflow.
- **Guard OUT_STATE fetch on missing GPIO**: the
  `SENSOR_CHAN_MTCH9010_OUT_STATE` fetch called `gpio_pin_get_dt()`
  unconditionally, dereferencing a NULL port when the optional
  `output-gpios` property is absent. It now returns -ENOTSUP, matching the
  guard already present on the sibling fetch path.