### PR TITLE
drivers: sensor: adxl372: fix streaming and decoder correctness issues

### DIFF
--- a/drivers/sensor/adi/adxl372/adxl372.c
+++ b/drivers/sensor/adi/adxl372/adxl372.c
@@ -759,6 +759,8 @@ static int adxl372_probe(const struct device *dev)
 		return ret;
 	}
 
+	data->odr = cfg->odr;
+
 	ret = adxl372_set_wakeup_rate(dev, cfg->wur);
 	if (ret) {
 		return ret;

--- a/drivers/sensor/adi/adxl372/adxl372_decoder.c
+++ b/drivers/sensor/adi/adxl372/adxl372_decoder.c
@@ -147,6 +147,7 @@ static int adxl372_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 
 		buffer = sample_end;
 		*fit = (uintptr_t)sample_end;
+		sample_num++;
 		count++;
 	}
 	data->header.reading_count = count;

--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -74,7 +74,7 @@ void adxl372_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 		(const struct sensor_read_config *)iodev_sqe->sqe.iodev->data;
 	struct adxl372_data *data = (struct adxl372_data *)dev->data;
 	const struct adxl372_dev_config *cfg_372 = dev->config;
-	uint8_t int_value = (uint8_t)~ADXL372_INT1_MAP_FIFO_FULL_MSK;
+	uint8_t int_value = 0;
 	uint8_t fifo_full_irq = 0;
 
 	int rc = gpio_pin_interrupt_configure_dt(&cfg_372->interrupt, GPIO_INT_DISABLE);

--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -341,7 +341,7 @@ static void adxl372_process_status1_cb(struct rtio *r, const struct rtio_sqe *sq
 
 	bool fifo_full_irq = false;
 
-	if ((fifo_wmark_cfg != NULL) && (fifo_full_cfg != NULL) &&
+	if (((fifo_wmark_cfg != NULL) || (fifo_full_cfg != NULL)) &&
 	    FIELD_GET(ADXL372_INT1_MAP_FIFO_FULL_MSK, status1)) {
 		fifo_full_irq = true;
 	}
@@ -371,7 +371,15 @@ static void adxl372_process_status1_cb(struct rtio *r, const struct rtio_sqe *sq
 		return;
 	}
 
-	enum sensor_stream_data_opt data_opt = MIN(fifo_wmark_cfg->opt, fifo_full_cfg->opt);
+	enum sensor_stream_data_opt data_opt;
+
+	if ((fifo_wmark_cfg != NULL) && (fifo_full_cfg == NULL)) {
+		data_opt = fifo_wmark_cfg->opt;
+	} else if ((fifo_wmark_cfg == NULL) && (fifo_full_cfg != NULL)) {
+		data_opt = fifo_full_cfg->opt;
+	} else {
+		data_opt = MIN(fifo_wmark_cfg->opt, fifo_full_cfg->opt);
+	}
 
 	if (data_opt == SENSOR_STREAM_DATA_NOP || data_opt == SENSOR_STREAM_DATA_DROP) {
 		uint8_t *buf;


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the ADXL372 driver, one
commit per issue:

- **Fix streaming with a single FIFO trigger**: the STATUS_1 callback
  required *both* the watermark and FIFO-full trigger configs to be non-NULL
  before honoring the FIFO_FULL bit, while stream submit accepts either
  trigger on its own. With one trigger configured the callback always took
  the early return, so the FIFO was never drained and the pending sqe never
  completed. The guard is now `||`, with the NULL-safe option selection used
  by the sibling adxl362/adxl367 drivers.
- **Fix INT1_MAP value when disabling FIFO IRQ**: the disable path passed
  `~ADXL372_INT1_MAP_FIFO_FULL_MSK` (0xFB) as the *value* to
  `write_reg_mask()`, which does not mask the data argument, so every other
  INT1_MAP bit — including INT_LOW — was set. Pass 0, matching the sibling
  ADXL367 driver's disable idiom.
- **Cache devicetree ODR in driver data**: `data->odr` was never initialised
  from the configured ODR, so FIFO stream frame headers always reported the
  400 Hz default and the decoder computed sample timestamps from the wrong
  period.
- **Increment sample_num in decode loop**: the streaming decoder never
  advanced its sample counter, so every frame decoded in a single call was
  emitted with an identical `timestamp_delta` instead of advancing ones.