### PR TITLE
drivers: sensor: lsm6dsl: fix sensor hub addressing, scaling and error path

### DIFF
--- a/drivers/sensor/st/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl.c
@@ -593,7 +593,7 @@ static inline void lsm6dsl_magn_convert(struct sensor_value *val, int raw_val,
 {
 	double dval;
 
-	/* Sensitivity is exposed in mgauss/LSB */
+	/* Sensitivity is exposed in ugauss/LSB */
 	dval = (double)(raw_val * sensitivity);
 	val->val1 = (int32_t)dval / 1000000;
 	val->val2 = (int32_t)dval % 1000000;

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
@@ -471,7 +471,10 @@ int lsm6dsl_shub_read_external_chip(const struct device *dev, uint8_t *buf,
 {
 	struct lsm6dsl_data *data = dev->data;
 
-	data->hw_tf->read_data(dev, LSM6DSL_REG_SENSORHUB1, buf, len);
+	if (data->hw_tf->read_data(dev, LSM6DSL_REG_SENSORHUB1, buf, len) < 0) {
+		LOG_DBG("failed to read external chip data");
+		return -EIO;
+	}
 
 	return 0;
 }

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
@@ -131,7 +131,8 @@ static const uint8_t lis3mdl_odr_bits[] = {
 #define LIS3MDL_MD_CONTINUOUS          0x00
 
 /* Others */
-#define LIS3MDL_SENSITIVITY       6842
+/* 6842 LSB/gauss at the +/-4 gauss full scale left by reset */
+#define LIS3MDL_SENSITIVITY       (1000000.0f / 6842.0f)
 
 static int lsm6dsl_lis3mdl_init(const struct device *dev, uint8_t i2c_addr)
 {

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl_shub.c
@@ -354,7 +354,7 @@ static int lsm6dsl_shub_read_slave_reg(const struct device *dev,
 	struct lsm6dsl_data *data = dev->data;
 	uint8_t slave[3];
 
-	slave[0] = (slv_addr << 1) | LSM6DSL_EMBEDDED_SLVX_READ;
+	slave[0] = slv_addr | LSM6DSL_EMBEDDED_SLVX_READ;
 	slave[1] = slv_reg;
 	slave[2] = (len & 0x7);
 
@@ -384,7 +384,7 @@ static int lsm6dsl_shub_write_slave_reg(const struct device *dev,
 	uint8_t cnt = 0U;
 
 	while (cnt < len) {
-		slv_cfg[0] = (slv_addr << 1) & ~LSM6DSL_EMBEDDED_SLVX_READ;
+		slv_cfg[0] = slv_addr & ~LSM6DSL_EMBEDDED_SLVX_READ;
 		slv_cfg[1] = slv_reg + cnt;
 
 		if (lsm6dsl_shub_write_embedded_regs(dev,
@@ -448,7 +448,7 @@ static int lsm6dsl_shub_set_data_channel(const struct device *dev)
 	}
 
 	/* Set data channel for slave device */
-	slv_cfg[0] = (slv_i2c_addr << 1) | LSM6DSL_EMBEDDED_SLVX_READ;
+	slv_cfg[0] = slv_i2c_addr | LSM6DSL_EMBEDDED_SLVX_READ;
 	slv_cfg[1] = lsm6dsl_shub_sens_list[0].out_data_addr;
 	slv_cfg[2] = lsm6dsl_shub_sens_list[0].out_data_len;
 	if (lsm6dsl_shub_write_embedded_regs(dev,


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the LSM6DSL sensor-hub
support, one commit per issue:

- **Fix double shift of shub slave address**: the addresses in
  `lsm6dsl_shub_sens_list[]` are already 8-bit (the table says so — e.g.
  0x38/0x3C for LIS2MDL, 0xB8/0xBA for LPS22HB), but the SLVx_ADD writes
  shifted them left again. In a `uint8_t` that truncates 0xB8 to 0x70, so the
  configured external sensor was never addressed correctly.
- **Fix LIS3MDL shub magnetometer sensitivity**: 6842 is the LIS3MDL
  *LSB/gauss* divider at the reset-default ±4 gauss full scale, but it was
  stored in `magn_sensitivity`, which the conversion uses as a µgauss/LSB
  multiplier — inflating every magnetometer reading by about 46.8x. Use
  1000000/6842 µgauss/LSB, consistent with the sibling LIS2MDL entry's 1500,
  and correct the stale mgauss/LSB unit comment on the conversion helper.
- **Check bus error when reading ext sensor**: the external-sensor fetch
  ignored the return value of the sensor-hub read, so a bus failure was
  reported as a successful fetch and the caller consumed uninitialised data.