### PR TITLE
drivers: sensor: mlx90394: fix register cache coherency and async submits

### DIFF
--- a/drivers/sensor/melexis/mlx90394/mlx90394.c
+++ b/drivers/sensor/melexis/mlx90394/mlx90394.c
@@ -139,29 +139,43 @@ static inline int mlx90394_update_register(const struct device *dev, const uint8
 					   const uint8_t new_val, uint8_t *old_value)
 {
 	const struct mlx90394_config *cfg = dev->config;
+	int rc;
 
-	if (new_val != *old_value) {
-		*old_value = new_val;
-		return i2c_reg_write_byte_dt(&cfg->i2c, reg_addr, new_val);
+	if (new_val == *old_value) {
+		return 0;
 	}
-	return 0;
+
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, reg_addr, new_val);
+	if (rc == 0) {
+		*old_value = new_val;
+	}
+
+	return rc;
 }
 
-static inline int mlx90394_sync_config_val(const struct device *dev)
+static inline int mlx90394_sync_config_val(const struct device *dev,
+					   enum mlx90394_reg_config_val config_val)
 {
 	struct mlx90394_data *data = dev->data;
 	uint8_t updated_ctrl2;
+	int rc;
 
-	updated_ctrl2 = MLX90394_FIELD_MOD(MLX90394_CTRL2_CONFIG, data->config_val,
+	updated_ctrl2 = MLX90394_FIELD_MOD(MLX90394_CTRL2_CONFIG, config_val,
 					   data->ctrl_reg_values.ctrl2);
 
-	return mlx90394_update_register(dev, MLX90394_REG_CTRL2, updated_ctrl2,
-					&data->ctrl_reg_values.ctrl2);
+	rc = mlx90394_update_register(dev, MLX90394_REG_CTRL2, updated_ctrl2,
+				      &data->ctrl_reg_values.ctrl2);
+	if (rc == 0) {
+		data->config_val = config_val;
+	}
+
+	return rc;
 }
 
 static inline int mlx90394_fs_set(const struct device *dev, const struct sensor_value *val)
 {
 	struct mlx90394_data *data = dev->data;
+	enum mlx90394_reg_config_val config_val;
 
 	/*
 	 * in low current mode, only High Range is possible
@@ -176,12 +190,12 @@ static inline int mlx90394_fs_set(const struct device *dev, const struct sensor_
 	 * HIGH_RANGE
 	 */
 	if (val->val1 > MLX90394_ATTR_FS_LOW_G) {
-		data->config_val = MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_NOISE;
+		config_val = MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_NOISE;
 	} else {
-		data->config_val = MLX90394_CTRL2_CONFIG_HIGH_SENSITIVITY_LOW_NOISE;
+		config_val = MLX90394_CTRL2_CONFIG_HIGH_SENSITIVITY_LOW_NOISE;
 	}
 
-	return mlx90394_sync_config_val(dev);
+	return mlx90394_sync_config_val(dev, config_val);
 }
 
 static inline int mlx90394_fs_get(const struct device *dev, struct sensor_value *val)
@@ -205,16 +219,14 @@ static inline int mlx90394_low_noise_set(const struct device *dev, struct sensor
 	switch (data->config_val) {
 	case MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_CURRENT: {
 		if (val->val1) {
-			data->config_val = MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_NOISE;
-
-			return mlx90394_sync_config_val(dev);
+			return mlx90394_sync_config_val(
+				dev, MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_NOISE);
 		}
 	} break;
 	case MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_NOISE: {
 		if (val->val1 == 0) {
-			data->config_val = MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_CURRENT;
-
-			return mlx90394_sync_config_val(dev);
+			return mlx90394_sync_config_val(
+				dev, MLX90394_CTRL2_CONFIG_HIGH_RANGE_LOW_CURRENT);
 		}
 	} break;
 	case MLX90394_CTRL2_CONFIG_HIGH_SENSITIVITY_LOW_NOISE: {

--- a/drivers/sensor/melexis/mlx90394/mlx90394_async.c
+++ b/drivers/sensor/melexis/mlx90394/mlx90394_async.c
@@ -101,6 +101,11 @@ void mlx90394_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 	struct mlx90394_data *data = dev->data;
 	uint64_t cycles;
 
+	if (k_work_delayable_is_pending(&data->async_fetch_work)) {
+		rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
+		return;
+	}
+
 	rc = mlx90394_trigger_measurement_internal(dev, cfg->channels->chan_type);
 	if (rc != 0) {
 		LOG_ERR("Failed to trigger measurement");


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the MLX90394 driver, one
commit per issue:

- **Update register cache only on write success**: `update_register()`
  committed the new byte to the shadow cache before issuing the I2C write,
  and the config helper stored the desired configuration unconditionally. A
  failed CTRL2 write therefore left the cache claiming a configuration the
  hardware never received — leaving the driver scaling samples with the wrong
  (10x off) factor, and making a retry with the same value a no-op that
  falsely reported success. The write now happens first and the cache is
  updated only after it succeeds.
- **Reject overlapping async submissions**: `submit()` overwrote the single
  shared `work_ctx.iodev_sqe` slot when a second submission arrived while the
  delayed fetch work was still pending. Since `k_work_schedule()` is a no-op
  on an already-scheduled item, the first sqe was orphaned and never
  completed. Overlapping submissions now fail with -EBUSY instead.