### PR TITLE
boards: st: nucleo_h7x5zi_q: drop arduino_serial from cortex-m4 variant

### DIFF
--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
@@ -9,7 +9,6 @@ ram: 128
 flash: 1024
 supported:
   - arduino_gpio
-  - arduino_serial
   - arduino_spi
   - gpio
   - netif:eth

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
@@ -9,7 +9,6 @@ ram: 128
 flash: 1024
 supported:
   - arduino_gpio
-  - arduino_serial
   - arduino_spi
   - gpio
   - netif:eth


### PR DESCRIPTION
Fix build issues on samples where `arduino_serial` depend on, but `Nucleo_h7x5zi_q` Cortex `M4` core doesn't enable `LPUART` peripheral.

This also avoids advertising Arduino Serial support on the M4 target where shared dual-core peripheral ownership can cause unsafe conflicts.

To reproduce : 

`west build -p -b nucleo_h755zi_q/stm32h755xx/m4 samples/bluetooth/peripheral_hr -T sample.bluetooth.peripheral_hr.frdm_kw41z_shield`