### PR TITLE
drivers: sensor: bq274xx: fix shutdown/resume power management

### DIFF
--- a/drivers/sensor/ti/bq274xx/bq274xx.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx.c
@@ -788,7 +788,11 @@ static int bq274xx_enter_shutdown_mode(const struct device *dev)
 static int bq274xx_exit_shutdown_mode(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
+	struct bq274xx_data *data = dev->data;
 	int ret;
+
+	/* Leaving shutdown mode triggers a POR, the gauge configuration is lost */
+	data->configured = false;
 
 	ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
 	if (ret < 0) {

--- a/drivers/sensor/ti/bq274xx/bq274xx.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx.c
@@ -833,11 +833,15 @@ static int bq274xx_pm_action(const struct device *dev,
 	int ret;
 
 	switch (action) {
-	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = bq274xx_enter_shutdown_mode(dev);
 		break;
 	case PM_DEVICE_ACTION_RESUME:
 		ret = bq274xx_exit_shutdown_mode(dev);
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
+	case PM_DEVICE_ACTION_TURN_OFF:
+		ret = 0;
 		break;
 	default:
 		ret = -ENOTSUP;


### PR DESCRIPTION
This PR fixes two related power-management bugs in the BQ274XX fuel gauge
driver, one commit per issue:

- **Reconfigure gauge after shutdown resume**: leaving shutdown mode triggers
  a POR that clears the gauge configuration, but `data->configured` was only
  ever set to true and never cleared. With lazy configuration enabled, a
  device that had been shut down and resumed therefore skipped
  `gauge_configure()` and kept running with the chip's default (unconfigured)
  parameters. The flag is now cleared on shutdown exit.
- **Enter shutdown on PM SUSPEND action**: shutdown mode was wired to
  `PM_DEVICE_ACTION_TURN_OFF`, which the PM subsystem only issues from the
  suspended state, so the device could never actually reach shutdown — a
  suspend request returned -ENOTSUP first. Enter shutdown on
  `PM_DEVICE_ACTION_SUSPEND` and accept TURN_ON/TURN_OFF as no-ops, matching
  the resume path that already exits shutdown.