### PR TITLE
tests: drivers: sensor: fix duplicate I2C and I3C addresses for icm56686

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1665,9 +1665,9 @@ test_i2c_adxl313: adxl313@d8 {
 	reg = <0xd8>;
 };
 
-test_i2c_icm56686: icm56686@68 {
+test_i2c_icm56686: icm56686@d9 {
 	compatible = "invensense,icm56686";
-	reg = <0x68>;
+	reg = <0xd9>;
 	int-gpios = <&test_gpio 0 GPIO_ACTIVE_HIGH>;
 
 	accel-fs = <0>;

--- a/tests/drivers/build_all/sensor/i3c.dtsi
+++ b/tests/drivers/build_all/sensor/i3c.dtsi
@@ -79,7 +79,7 @@ test_i3c_bmp581: bmp581@800000803e0000004 {
 test_i3c_icm56686: icm56686@680000046a00000011 {
 	compatible = "invensense,icm56686";
 	reg = <0x68 0x0 0x0>;
-	assigned-address = <0x6a>;
+	assigned-address = <0x9>;
 	int-gpios = <&test_gpio 0 GPIO_ACTIVE_HIGH>;
 
 	accel-fs = <0>;

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -539,9 +539,9 @@ test_spi_max30009: max30009@41 {
 	int-gpios = <&test_gpio 0 0>;
 };
 
-test_spi_icm56686: icm56686@0 {
+test_spi_icm56686: icm56686@42 {
 	compatible = "invensense,icm56686";
-	reg = <0>;
+	reg = <0x42>;
 	spi-max-frequency = <1000000>;
 	int-gpios = <&test_gpio 0 GPIO_ACTIVE_HIGH>;
 


### PR DESCRIPTION
Change device address in I2C, SPI, I3C for ICM566xx to fix duplicate bus address issues.

This is a follow-up for the merged PR #112362 to address the review feedback regarding the test build failures.

Signed-off-by: Aaron Kim <aaron.kim@tdk.com>