### PR TITLE
drivers: input: gt911: use endian-aware constants

### DIFF
--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -20,8 +20,8 @@
 LOG_MODULE_REGISTER(gt911, CONFIG_INPUT_LOG_LEVEL);
 
 /* GT911 used registers */
-#define GT911_DEVICE_ID  BSWAP_16(0x8140U)
-#define GT911_REG_STATUS BSWAP_16(0x814EU)
+#define GT911_DEVICE_ID  0x8140U
+#define GT911_REG_STATUS 0x814EU
 
 /* REG_TD_STATUS: Touch points. */
 #define GT911_TOUCH_POINTS_MSK 0x0FU
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(gt911, CONFIG_INPUT_LOG_LEVEL);
 #define GT911_TOUCH_STATUS_MSK (1 << 7U)
 
 /* The GT911's config */
-#define GT911_REG_CONFIG                  BSWAP_16(0x8047U)
+#define GT911_REG_CONFIG                  0x8047U
 #define GT911_REG_CONFIG_VERSION          GT911_REG_CONFIG
 #define GT911_REG_CONFIG_TOUCH_NUM_OFFSET 0x5
 #define GT911_REG_CONFIG_SIZE             186U
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(gt911, CONFIG_INPUT_LOG_LEVEL);
 /* Points registers */
 #define GT911_REG_POINT_0       0x814F
 #define GT911_POINT_OFFSET      0x8
-#define GT911_REG_POINT_ADDR(n) BSWAP_16(GT911_REG_POINT_0 + GT911_POINT_OFFSET * n)
+#define GT911_REG_POINT_ADDR(n) (GT911_REG_POINT_0 + GT911_POINT_OFFSET * n)
 
 /** GT911 configuration (DT). */
 struct gt911_config {
@@ -130,7 +130,7 @@ static int gt911_process(const struct device *dev)
 	static struct gt911_point_reg prev_point_reg[CONFIG_INPUT_GT911_MAX_TOUCH_POINTS];
 
 	/* obtain number of touch points */
-	reg_addr = GT911_REG_STATUS;
+	reg_addr = sys_cpu_to_be16(GT911_REG_STATUS);
 	r = gt911_i2c_write_read(dev, &reg_addr, sizeof(reg_addr), &status, sizeof(status));
 	if (r < 0) {
 		return r;
@@ -150,8 +150,8 @@ static int gt911_process(const struct device *dev)
 	points = min(status & GT911_TOUCH_POINTS_MSK, CONFIG_INPUT_GT911_MAX_TOUCH_POINTS);
 
 	/* need to clear the status */
-	static const uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS,
-						(uint8_t)(GT911_REG_STATUS >> 8), 0};
+	static const uint8_t clear_buffer[3] = {(uint8_t)(GT911_REG_STATUS >> 8),
+						(uint8_t)GT911_REG_STATUS, 0};
 
 	r = gt911_i2c_write(dev, clear_buffer, sizeof(clear_buffer));
 	if (r < 0) {
@@ -160,7 +160,7 @@ static int gt911_process(const struct device *dev)
 
 	/* current points array */
 	for (i = 0; i < points; i++) {
-		reg_addr = GT911_REG_POINT_ADDR(i);
+		reg_addr = sys_cpu_to_be16(GT911_REG_POINT_ADDR(i));
 		r = gt911_i2c_write_read(dev, &reg_addr, sizeof(reg_addr), &point_reg[i],
 					 sizeof(point_reg[i]));
 
@@ -365,7 +365,7 @@ static int gt911_init(const struct device *dev)
 
 	/* check the Device ID first: '911' */
 	uint32_t reg_id = 0;
-	uint16_t reg_addr = GT911_DEVICE_ID;
+	uint16_t reg_addr = sys_cpu_to_be16(GT911_DEVICE_ID);
 
 	if (config->alt_addr != 0x0) {
 		/*
@@ -393,7 +393,7 @@ static int gt911_init(const struct device *dev)
 		LOG_ERR("Device did not respond to I2C request");
 		return r;
 	}
-	switch (reg_id) {
+	switch (sys_cpu_to_le32(reg_id)) {
 	case GT911_PRODUCT_ID:
 	case GT912_PRODUCT_ID:
 	case GT927_PRODUCT_ID:
@@ -402,15 +402,15 @@ static int gt911_init(const struct device *dev)
 	case GT9271_PRODUCT_ID:
 		break;
 	default:
-		LOG_ERR("Unexpected device id: %08x ", reg_id);
+		LOG_ERR("Unexpected device id: %08x ", sys_cpu_to_le32(reg_id));
 		return -ENODEV;
 	}
 
 	/* need to setup the firmware first: read and write */
 	uint8_t gt911_config_firmware[GT911_REG_CONFIG_SIZE + 2] = {
-		(uint8_t)GT911_REG_CONFIG, (uint8_t)(GT911_REG_CONFIG >> 8)};
+		(uint8_t)(GT911_REG_CONFIG >> 8), (uint8_t)GT911_REG_CONFIG};
 
-	reg_addr = GT911_REG_CONFIG;
+	reg_addr = sys_cpu_to_be16(GT911_REG_CONFIG);
 	r = gt911_i2c_write_read(dev, &reg_addr, sizeof(reg_addr), gt911_config_firmware + 2,
 				 GT911_REG_CONFIG_SIZE);
 	if (r < 0) {


### PR DESCRIPTION
 This PR updates the GT911 driver to use endian-aware constants for register addresses and product IDs:

  - **Use endian-aware register address constants**

    The 16-bit GT911 register addresses are forced to bus-byte-order for I2C transfers. Using `sys_cpu_to_be16()` keeps the existing swapped representation on little-endian systems while avoiding the wrong swap on big-endian systems.

  - **Use endian-aware product ID constants**

    Add `sys_cpu_ro_le32()` conversion to the chip IDs. This ensure consistent and correct behavior on big-edian systems.