### PR TITLE
net: mdns_responder: fix wrong A/AAAA addrs on multi-homed hosts

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -571,7 +571,8 @@ static int send_response(int sock,
 			 struct net_sockaddr *src_addr,
 			 size_t addrlen,
 			 struct net_buf *query,
-			 enum dns_rr_type qtype)
+			 enum dns_rr_type qtype,
+			 struct net_if *recv_if)
 {
 	struct net_if *iface;
 	net_socklen_t dst_len;
@@ -586,7 +587,12 @@ static int send_response(int sock,
 		return ret;
 	}
 
-	if (family == NET_AF_INET6) {
+	/* Use the interface the query arrived on (per-socket BINDTODEVICE) so
+	 * A/AAAA records advertise addresses on that link.
+	 */
+	if (recv_if != NULL) {
+		iface = recv_if;
+	} else if (family == NET_AF_INET6) {
 		iface = net_if_ipv6_select_src_iface(&net_sin6(src_addr)->sin6_addr);
 	} else {
 		iface = net_if_ipv4_select_src_iface(&net_sin(src_addr)->sin_addr);
@@ -618,7 +624,8 @@ static void send_sd_response(int sock,
 			     net_sa_family_t family,
 			     struct net_sockaddr *src_addr,
 			     size_t addrlen,
-			     struct net_buf *result)
+			     struct net_buf *result,
+			     struct net_if *recv_if)
 {
 	struct net_if *iface;
 	net_socklen_t dst_len;
@@ -667,7 +674,12 @@ static void send_sd_response(int sock,
 		return;
 	}
 
-	if (family == NET_AF_INET6) {
+	/* Use the interface the query arrived on (per-socket BINDTODEVICE) so
+	 * DNS-SD records advertise addresses on that link.
+	 */
+	if (recv_if != NULL) {
+		iface = recv_if;
+	} else if (family == NET_AF_INET6) {
 		iface = net_if_ipv6_select_src_iface(&net_sin6(src_addr)->sin6_addr);
 	} else {
 		iface = net_if_ipv4_select_src_iface(&net_sin(src_addr)->sin_addr);
@@ -783,7 +795,8 @@ static int dns_read(int sock,
 		    struct net_buf *dns_data,
 		    size_t len,
 		    struct net_sockaddr *src_addr,
-		    size_t addrlen)
+		    size_t addrlen,
+		    struct net_if *recv_if)
 {
 	/* Helper struct to track the dns msg received from the server */
 	const char *hostname = net_hostname_get();
@@ -860,10 +873,10 @@ static int dns_read(int sock,
 				family == NET_AF_INET ? "IPv4" : "IPv6", "query",
 				hostname, ".local");
 			send_response(sock, family, src_addr, addrlen,
-				      result, qtype);
+				      result, qtype, recv_if);
 		} else if (IS_ENABLED(CONFIG_MDNS_RESPONDER_DNS_SD)
 			&& qtype == DNS_RR_TYPE_PTR) {
-			send_sd_response(sock, family, src_addr, addrlen, result);
+			send_sd_response(sock, family, src_addr, addrlen, result, recv_if);
 		}
 
 	} while (--queries);
@@ -1442,9 +1455,15 @@ static int dispatcher_cb(struct dns_socket_dispatcher *ctx, int sock,
 			 struct net_sockaddr *addr, size_t addrlen,
 			 struct net_buf *dns_data, size_t len)
 {
+	struct net_if *recv_if = NULL;
 	int ret;
 
-	ret = dns_read(sock, dns_data, len, addr, addrlen);
+	/* Use the bound iface so replies match the link the query arrived on. */
+	if (ctx->ifindex > 0) {
+		recv_if = net_if_get_by_index(ctx->ifindex);
+	}
+
+	ret = dns_read(sock, dns_data, len, addr, addrlen, recv_if);
 	if (ret < 0 && ret != -EINVAL && ret != -ENOENT) {
 		NET_DBG("%s read failed (%d)", "mDNS", ret);
 	}

--- a/tests/net/lib/mdns_responder/src/main.c
+++ b/tests/net/lib/mdns_responder/src/main.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(mdns_resp_test);
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/net/udp.h>
 #include <zephyr/ztest.h>
 
 #include "dns_pack.h"
@@ -124,6 +125,62 @@ static int igmp_report_count;
 static struct service_info services[EXT_RECORDS_NUM];
 static struct dns_sd_rec records[EXT_RECORDS_NUM];
 
+/*
+ * Multi-homed mDNS test topology
+ *
+ *   iface1 (default route)
+ *   iface2 (query ingress)
+ *
+ * A/AAAA answers must come from iface2 (per-socket BINDTODEVICE), not from
+ * net_if_ipv6_select_src_iface() toward the querier.
+ */
+static struct net_in6_addr mh_iface2_gua = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+					    0x28, 0x61, 0x82, 0x56, 0x28, 0x61, 0x82, 0x56 } } };
+						/* 2001:db8::2861:8256:2861:8256 */
+static struct net_in6_addr mh_iface2_ll = { { { 0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+					    0, 0, 0, 0, 0, 0, 0, 0x2 } } }; /* fe80::2 */
+static struct net_in6_addr mh_querier_ll = { { { 0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+					      0, 0, 0, 0, 0, 0, 0, 0x99 } } }; /* fe80::99 */
+static struct net_in6_addr mh_iface1_prefix = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+						    0, 0, 0, 0, 0, 0, 0, 0 } } };
+						    /* 2001:db8::/64 */
+static struct net_in6_addr mh_iface2_prefix = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+						    0x28, 0x61, 0x82, 0x56, 0, 0, 0, 0 } } };
+						    /* 2001:db8:0:2861:8256::/96 */
+
+/* Capture the first mDNS response pkt while mh_capture_active (see sender_iface). */
+static bool mh_capture_active;
+static K_SEM_DEFINE(mh_response_sem, 0, 1);
+static struct net_pkt *mh_response_pkt;
+
+static void mh_reset_capture(void)
+{
+	mh_capture_active = false;
+
+	if (mh_response_pkt != NULL) {
+		net_pkt_unref(mh_response_pkt);
+		mh_response_pkt = NULL;
+	}
+
+	while (k_sem_take(&mh_response_sem, K_NO_WAIT) == 0) {
+		/* NOP */
+	}
+}
+
+static bool mh_mdns_udp_pkt(struct net_pkt *pkt)
+{
+	struct net_udp_hdr *udp;
+
+	if (!IS_ENABLED(CONFIG_NET_UDP) || net_pkt_family(pkt) != NET_AF_INET6) {
+		return false;
+	}
+
+	udp = net_udp_get_hdr(pkt, NULL);
+
+	return udp != NULL &&
+	       (net_ntohs(udp->src_port) == 5353U || net_ntohs(udp->dst_port) == 5353U);
+}
+
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -178,7 +235,13 @@ static int sender_iface(const struct device *dev, struct net_pkt *pkt)
 		hdr = NET_IPV6_HDR(pkt);
 
 		if (net_ipv6_addr_cmp_raw(hdr->dst, mdns_server_ipv6_addr)) {
-			if (responses_count < MAX_RESP_PKTS) {
+			/* Multi-homed test: grab the outgoing mDNS response separately. */
+			if (mh_capture_active && mh_response_pkt == NULL &&
+			    mh_mdns_udp_pkt(pkt)) {
+				net_pkt_ref(pkt);
+				mh_response_pkt = pkt;
+				k_sem_give(&mh_response_sem);
+			} else if (responses_count < MAX_RESP_PKTS) {
 				net_pkt_ref(pkt);
 				response_pkts[responses_count++] = pkt;
 				k_sem_give(&wait_data);
@@ -363,6 +426,8 @@ static void cleanup(void *d)
 			free_service(&services[i]);
 		}
 	}
+
+	mh_reset_capture();
 }
 
 static void send_msg(const uint8_t *data, size_t len)
@@ -1234,5 +1299,141 @@ ZTEST(test_mdns_responder, test_excluded_listener_slot_marked_closed)
 	}
 }
 #endif /* CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL */
+
+/*
+ * Parse the mDNS response and verify every AAAA answer belongs to expect
+ * (the interface that received the query) and not to forbid.
+ */
+static void mh_check_aaaa_on_iface(struct net_pkt *pkt, struct net_if *expect,
+				   struct net_if *forbid)
+{
+	struct dns_header resp_header;
+	struct dns_rr resp_record;
+	struct net_in6_addr resp_addr;
+	uint16_t ancount;
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_set_overwrite(pkt, true);
+	zassert_ok(net_pkt_skip(pkt, NET_IPV6UDPH_LEN), "net_pkt skip failed");
+	zassert_ok(net_pkt_read(pkt, &resp_header, sizeof(resp_header)), "net_pkt read failed");
+
+	ancount = net_ntohs(resp_header.ancount);
+	zassert_true(ancount > 0, "Expected at least one answer");
+
+	for (uint16_t i = 0; i < ancount; i++) {
+		skip_labels(pkt);
+		zassert_ok(net_pkt_read(pkt, &resp_record, sizeof(resp_record)),
+			   "net_pkt read failed");
+		zassert_equal(net_ntohs(resp_record.type), DNS_RR_TYPE_AAAA,
+			      "Expected AAAA answer only");
+		zassert_equal(net_ntohs(resp_record.rdlength), sizeof(struct net_in6_addr),
+			      "Invalid AAAA length");
+		zassert_ok(net_pkt_read(pkt, &resp_addr, sizeof(resp_addr)),
+			   "net_pkt read failed");
+		zassert_not_null(net_if_ipv6_addr_lookup_by_iface(expect, &resp_addr),
+				 "AAAA should belong to query iface");
+		zassert_is_null(net_if_ipv6_addr_lookup_by_iface(forbid, &resp_addr),
+				"AAAA must not come from other iface");
+	}
+}
+
+/*
+ * Inject a raw IPv6/UDP mDNS query on iface as if received from the network.
+ * The packet is handed to net_recv_data() on that interface.
+ */
+static void mh_send_query(struct net_if *iface, const struct net_in6_addr *src,
+			  const struct net_in6_addr *dst, const uint8_t *data, size_t len)
+{
+	struct net_pkt *pkt;
+	uint8_t v6_buf[40];
+	uint16_t payload_len = len + NET_UDPH_LEN;
+
+	pkt = net_pkt_alloc_with_buffer(iface, NET_IPV6UDPH_LEN + len, NET_AF_UNSPEC, 0, K_FOREVER);
+	zassert_not_null(pkt, "PKT is null");
+
+	memset(v6_buf, 0, sizeof(v6_buf));
+	v6_buf[0] = 0x60;
+	memcpy(&v6_buf[8], src->s6_addr, 16);
+	memcpy(&v6_buf[24], dst->s6_addr, 16);
+	v6_buf[6] = NET_IPPROTO_UDP;
+	v6_buf[7] = 255;
+
+	zassert_ok(net_pkt_write(pkt, v6_buf, 4), "pkt write for v6 start failed");
+	zassert_ok(net_pkt_write_be16(pkt, payload_len), "pkt write for v6 payload len failed");
+	zassert_ok(net_pkt_write(pkt, &v6_buf[6], sizeof(v6_buf) - 6),
+		   "pkt write for v6 rest failed");
+	zassert_ok(net_pkt_write_be16(pkt, 5353), "pkt write for UDP src port failed");
+	zassert_ok(net_pkt_write_be16(pkt, 5353), "pkt write for UDP dst port failed");
+	zassert_ok(net_pkt_write_be16(pkt, payload_len), "pkt write for UDP length failed");
+	zassert_ok(net_pkt_write_be16(pkt, 0), "pkt write for UDP checksum failed");
+	zassert_ok(net_pkt_write(pkt, data, len), "net_pkt_write() for data failed");
+	zassert_ok(net_recv_data(iface, pkt), "net_recv_data() failed");
+}
+
+/*
+ * On a multi-homed host, mDNS AAAA answers must use an address from the
+ * interface that received the query (socket BINDTODEVICE / recv iface),
+ * not net_if_ipv6_select_src_iface() toward the querier.
+ *
+ * Layout:
+ *   - iface1: default route, 2001:db8::/64
+ *   - iface2: on-link /96, hosts the querier (fe80::99) and the GUA to advertise
+ *
+ * Query is injected on iface2; response AAAA must come from iface2, not iface1.
+ */
+ZTEST(test_mdns_responder, test_multihomed_aaaa_on_recv_iface)
+{
+	/* DNS query: zephyr.local, type AAAA, class IN */
+	static const uint8_t hostname_query[] = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x06, 0x7a, 0x65, 0x70, 0x68, 0x79, 0x72, 0x05, 0x6c, 0x6f, 0x63, 0x61, 0x6c,
+		0x00, 0x00, 0x1c, 0x00, 0x01
+	};
+	struct net_in6_addr mcast = { { { 0xff, 0x02, 0, 0, 0, 0, 0, 0,
+					 0, 0, 0, 0, 0, 0, 0, 0xfb } } }; /* ff02::fb */
+	struct net_if *iface2 = net_if_get_by_index(2);
+	struct net_if_addr *ifaddr;
+	int res;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL);
+
+	zassert_not_null(iface2, "iface2 missing");
+
+	mh_response_pkt = NULL;
+	mh_capture_active = true;
+	test_started = true;
+
+	/* iface1: upstream /64; made default so src selection would prefer it. */
+	(void)net_if_ipv6_prefix_add(iface1, &mh_iface1_prefix, 64,
+				     NET_IPV6_ND_INFINITE_LIFETIME);
+	/* iface2: on-link /96 and the addresses the responder should advertise. */
+	(void)net_if_ipv6_prefix_add(iface2, &mh_iface2_prefix, 96,
+				     NET_IPV6_ND_INFINITE_LIFETIME);
+
+	ifaddr = net_if_ipv6_addr_add(iface2, &mh_iface2_ll, NET_ADDR_MANUAL, 0);
+	zassert_not_null(ifaddr, "Failed to add iface2 LL");
+	ifaddr->addr_state = NET_ADDR_PREFERRED;
+
+	ifaddr = net_if_ipv6_addr_add(iface2, &mh_iface2_gua, NET_ADDR_MANUAL, 0);
+	zassert_not_null(ifaddr, "Failed to add iface2 GUA");
+	ifaddr->addr_state = NET_ADDR_PREFERRED;
+
+	net_ipv6_nbr_add(iface2, &mh_querier_ll, net_if_get_link_addr(iface2), false,
+			 NET_IPV6_NBR_STATE_STATIC);
+
+	net_if_set_default(iface1);
+	net_if_up(iface2);
+	k_sleep(K_MSEC(500));
+
+	/* Query arrives on iface2 from link-local querier fe80::99. */
+	mh_send_query(iface2, &mh_querier_ll, &mcast, hostname_query, sizeof(hostname_query));
+
+	res = k_sem_take(&mh_response_sem, RESPONSE_TIMEOUT);
+	zassert_ok(res, "Did not receive mDNS response on iface2");
+
+	mh_check_aaaa_on_iface(mh_response_pkt, iface2, iface1);
+
+	mh_reset_capture();
+}
 
 ZTEST_SUITE(test_mdns_responder, NULL, test_setup, before, cleanup, NULL);


### PR DESCRIPTION
On multi-homed hosts, mDNS replies already go out the correct interface (each listener socket is bound with `SO_BINDTODEVICE`), but A/AAAA/DNS-SD answers were built using `net_if_*_select_src_iface()` toward the querier. For link-local queriers that can fall back to the default interface and advertise addresses from the wrong link.

Build answers from the interface the query was received on (the socket's bound interface), not from route-based selection toward the querier. Added a  regression test (`test_multihomed_aaaa_on_recv_iface`) with a link-local querier on iface2; skip it when `CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL` is not set.
