### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -330,7 +330,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 7ad67106c3253d03ae4bd8ab48e6bdf7bc46f43e
+      revision: aa32eaaad41cc345e6f6e6633368a4766fe23c25
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  aa32eaaad41cc345e6f6e6633368a4766fe23c25

Brings following Zephyr relevant fixes:

  - aa32eaaa boot: zephyr: add new boot_image_jump hook
  - a2c719a5 boot: zephyr: migrate USB DFU to Device-next
  - 395eda6a boot: zephyr: remove legacy USB product override
  - 7a3fd7e7 boot: zephyr: migrate CDC ACM serial recovery tov USB_DEVICE_STACK_NEXT
  - dc74f965 samples: runtime-source: zephyr: app: Fix testcase file
  - c5ebdb7f boot: zephyr: Fix boot banner
  - d2889e74 boot: serial: charge the whole read loop against the timeout
  - 183a05f2 boot: boot_serial: Add check for image ID validity
  - 2ec5cd2f boot: bootutil: swap: Initialise swap state variables
  - 400f9a72 boot: boot_serial: Validate finished update is complete
  - 6f870a66 boot: serial: end serial recovery on inactivity
  - f7ef3ba7 boot: zephyr: cmake: Fix automatic logical sector erase size usage
  - 3e12a7cc boot: zephyr: flash_map_extended: Add missing partitions
  - a0b83d6e boot: boards: add board conf file for frdm_mcxl255
  - 8eeff01c boot: bootutil: Guard code only used for encryption with EC256/X25519
  - c6d9a0ad bootutil: crypto: aes_ctr: allow PSA_CRYPTO together with MBED_TLS
  - 67112867 boot: bootutil: include encrypted_psa.c for MCUBOOT_USE_PSA_CRYPTO
  - 74fe6102 boot: bootutil: Use MCUBOOT_USE_PSA_CRYPTO to select PSA crypto backend
  - b1b886ec boot: zephyr: socs: add esp32c61 and esp32s31 config
  - a902c80e boot: zephyr: socs: drop redundant esp32 libc config
  - d23c1895 boot: bootutil: Remove excess flash_area_close function calls
  - e9abe4f0 boot: bootutil: bound the hashed span to the image's area
  - 9fb70f00 boot: bootutil: size split_image_check hash by digest
  - c8a4cb55 boot: bootutil: Allow ports to size the image hash buffer
  - c024826f boot: bootutil: feed watchdog in bootutil_img_hash
  - cd403948 boot: bootutil: fix typo with MCUBOOT_HW_ROLLBACK_PROT_LOCK
  - 72ac00dc boot: zepyhr: boards: add MR-NAVQ95B overlay
  - 5098d8ee boot: bootutil: require exact hash TLV length
  - 2cf8fbcb boot_serial: honour MCUBOOT_LOGICAL_SECTOR_SIZE for the secondary slot offset

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.