### PR TITLE
arm64: correct CNTHCTL_EL2 access comments

### DIFF
--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -172,8 +172,8 @@
 #define HCR_API_BIT		BIT(41)	/* Trap pointer authentication instructions */
 
 /* CNTHCTL_EL2: Counter-timer Hypervisor Control register */
-#define CNTHCTL_EL2_EL1PCTEN	BIT(0)	/* Enable EL1 access to physical counter timer */
-#define CNTHCTL_EL2_EL1PCEN	BIT(1)	/* Enable EL1 access to physical counter */
+#define CNTHCTL_EL2_EL1PCTEN	BIT(0)	/* Enable EL1 access to physical counter */
+#define CNTHCTL_EL2_EL1PCEN	BIT(1)	/* Enable EL1 access to physical timer */
 
 /* PAC Key Registers - System register encodings */
 #define APIAKeyLo_EL1		S3_0_C2_C1_0


### PR DESCRIPTION
EL1PCTEN controls access to the physical counter, while EL1PCEN controls access to the EL1 physical timer. Correct the descriptions so they match the Arm architecture definitions.