### PR TITLE
drivers: gpio: mcux_igpio: lock interrupts around DR read-modify-write

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #if __has_include("soc.h")
 #include <soc.h>
 #endif
@@ -42,6 +43,9 @@ struct mcux_igpio_data {
 
 	/* port ISR callback routine address */
 	sys_slist_t callbacks;
+
+	/* serializes the read-modify-write of DR and GDIR */
+	struct k_spinlock lock;
 };
 
 static GPIO_Type *get_base(const struct device *dev)
@@ -53,6 +57,7 @@ static int mcux_igpio_configure(const struct device *dev,
 				gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct mcux_igpio_config *config = dev->config;
+	struct mcux_igpio_data *data = dev->data;
 	GPIO_Type *base = get_base(dev);
 
 	struct pinctrl_soc_pin pin_cfg;
@@ -212,15 +217,17 @@ static int mcux_igpio_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if (flags & GPIO_OUTPUT_INIT_HIGH) {
-		GPIO_WritePinOutput(base, pin, 1);
-	}
+	K_SPINLOCK(&data->lock) {
+		if (flags & GPIO_OUTPUT_INIT_HIGH) {
+			GPIO_PinWrite(base, pin, 1);
+		}
 
-	if (flags & GPIO_OUTPUT_INIT_LOW) {
-		GPIO_WritePinOutput(base, pin, 0);
-	}
+		if (flags & GPIO_OUTPUT_INIT_LOW) {
+			GPIO_PinWrite(base, pin, 0);
+		}
 
-	WRITE_BIT(base->GDIR, pin, flags & GPIO_OUTPUT);
+		WRITE_BIT(base->GDIR, pin, flags & GPIO_OUTPUT);
+	}
 
 	return 0;
 }
@@ -239,9 +246,12 @@ static int mcux_igpio_port_set_masked_raw(const struct device *dev,
 					  uint32_t mask,
 					  uint32_t value)
 {
+	struct mcux_igpio_data *data = dev->data;
 	GPIO_Type *base = get_base(dev);
 
-	base->DR = (base->DR & ~mask) | (mask & value);
+	K_SPINLOCK(&data->lock) {
+		base->DR = (base->DR & ~mask) | (mask & value);
+	}
 
 	return 0;
 }
@@ -249,9 +259,12 @@ static int mcux_igpio_port_set_masked_raw(const struct device *dev,
 static int mcux_igpio_port_set_bits_raw(const struct device *dev,
 					uint32_t mask)
 {
+	struct mcux_igpio_data *data = dev->data;
 	GPIO_Type *base = get_base(dev);
 
-	GPIO_PortSet(base, mask);
+	K_SPINLOCK(&data->lock) {
+		GPIO_PortSet(base, mask);
+	}
 
 	return 0;
 }
@@ -259,9 +272,12 @@ static int mcux_igpio_port_set_bits_raw(const struct device *dev,
 static int mcux_igpio_port_clear_bits_raw(const struct device *dev,
 					  uint32_t mask)
 {
+	struct mcux_igpio_data *data = dev->data;
 	GPIO_Type *base = get_base(dev);
 
-	GPIO_PortClear(base, mask);
+	K_SPINLOCK(&data->lock) {
+		GPIO_PortClear(base, mask);
+	}
 
 	return 0;
 }
@@ -269,9 +285,12 @@ static int mcux_igpio_port_clear_bits_raw(const struct device *dev,
 static int mcux_igpio_port_toggle_bits(const struct device *dev,
 				       uint32_t mask)
 {
+	struct mcux_igpio_data *data = dev->data;
 	GPIO_Type *base = get_base(dev);
 
-	GPIO_PortToggle(base, mask);
+	K_SPINLOCK(&data->lock) {
+		GPIO_PortToggle(base, mask);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The four port writers update `DR` with an unlocked read-modify-write, so two
contexts driving different pins of the same port can lose an update.

This cannot be left to the HAL, because the atomic `DR_SET`/`DR_CLEAR`/
`DR_TOGGLE` aliases do not exist on every part. On `MIMX8ML8` all three
`FSL_FEATURE_IGPIO_HAS_DR_*` macros are 0, matching the hardware — from the
*i.MX 8M Plus Applications Processor Reference Manual*, Rev. 3, 08/2024:

- **§8.3.5.1.1 "GPIO memory map"** — exactly eight registers (`DR`, `GDIR`,
  `PSR`, `ICR1`, `ICR2`, `IMR`, `ISR`, `EDGE_SEL`), no set/clear/toggle alias.
- **§8.3.4.2 "GPIO Write Mode"** — driving an output is a plain write to `DR`.

With no hardware set/clear register, atomicity has to come from software.
~~`gpio_imx.c`, the other driver for this same `nxp,imx-gpio` compatible, already
does the same.~~
A spinlock is used rather than irq_lock() so a concurrent write from another
CPU is also covered on an SMP build.

Builds clean on `imx8mp_evk/mimx8ml8/m7` (no aliases) and `mimxrt1060_evk`
(has aliases). Not verified on hardware; the fix follows from the register
semantics.
