### PR TITLE
soc: nordic: nrf53: add support for anomaly 166

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_kconfig.h
+++ b/modules/hal_nordic/nrfx/nrfx_kconfig.h
@@ -445,6 +445,12 @@
 	CONFIG_NRF52_ANOMALY_109_WORKAROUND_EGU_INSTANCE
 #endif
 
+#ifdef CONFIG_SOC_NRF53_ANOMALY_166_WORKAROUND
+#define NRF53_ERRATA_166_ENABLE_WORKAROUND 1
+#else
+#define NRF53_ERRATA_166_ENABLE_WORKAROUND 0
+#endif
+
 /* If local or global DPPIC peripherals are used, provide the following macro
  * definitions required by the interconnect/ipct layer:
  * - NRFX_IPCTx_PUB_CONFIG_ALLOWED_CHANNELS_MASK_BY_INST_NUM(inst_num)

--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -123,6 +123,15 @@ endif
 
 if SOC_NRF5340_CPUAPP
 
+config SOC_NRF53_ANOMALY_166_WORKAROUND
+	bool "Workaround for nRF5340 anomaly 166"
+	depends on "$(dt_node_int_prop_int,$(VREGMAIN_PATH),regulator-initial-mode)" = 0
+	help
+	  Indicates that the workaround for the anomaly 166 that affects
+	  the nRF5340 SoC should be applied.
+	  The workaround applies only to application core and VREGMAIN in LDO mode.
+	  It is disabled by default as it increases power consumption noticeably.
+
 config SOC_DCDC_NRF53X_APP
 	bool
 	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED

--- a/soc/nordic/nrf53/soc.c
+++ b/soc/nordic/nrf53/soc.c
@@ -558,6 +558,12 @@ void soc_early_init_hook(void)
 #if defined(CONFIG_SOC_DCDC_NRF53X_APP) || \
 	(DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
+#elif (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_LDO)
+	if (NRF_ERRATA_DYNAMIC_CHECK(53, 166)) {
+		*((volatile uint32_t *)0x50300C00) = 0x00009375ul;
+		*((volatile uint32_t *)0x503000E4) = 0x0ul;
+		*((volatile uint32_t *)0x50300C00) = 0x00009375ul;
+	}
 #endif
 #if defined(CONFIG_SOC_DCDC_NRF53X_NET) || \
 	(DT_PROP(DT_NODELABEL(vregradio), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)


### PR DESCRIPTION
Add workaround and Kconfig for nRF53 Series Anomaly 166, that affects VREGMAIN in LDO mode.
Workaround remains disabled by default.