### PR TITLE
boards: nordic: nrf54l15tag: enable missing clock nodes

### DIFF
--- a/boards/nordic/nrf54l15tag/nrf54l15tag_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_cpuapp_common.dtsi
@@ -55,6 +55,14 @@
 	status = "okay";
 };
 
+&xo {
+	status = "okay";
+};
+
+&lfclk {
+	status = "okay";
+};
+
 &regulators {
 	status = "okay";
 };


### PR DESCRIPTION
Enable `xo` and `lfclk` for consistency with nrf54l15dk board.