### PR TITLE
drivers: gpio: mcux_igpio: do not read-modify-write the W1C ISR

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -348,7 +348,7 @@ static int mcux_igpio_pin_interrupt_configure(const struct device *dev,
 	}
 
 	WRITE_BIT(base->EDGE_SEL, pin, trig == GPIO_INT_TRIG_BOTH);
-	WRITE_BIT(base->ISR, pin, 1);
+	base->ISR = BIT(pin);
 	WRITE_BIT(base->IMR, pin, 1);
 
 	irq_unlock(key);


### PR DESCRIPTION
`pin_interrupt_configure()` cleared the pin's stale edge with
`WRITE_BIT(base->ISR, pin, 1)`, which expands to `base->ISR |= BIT(pin)`.

`ISR` is write-1-to-clear, so the read returns every latched flag on the port and
writing the value back clears them all - configuring one pin discards the pending
interrupts of every other pin on the same port. From the *i.MX 8M Plus
Applications Processor Reference Manual*, Rev. 3, 08/2024:

- **§8.3.5.1.1 "GPIO memory map"** - `ISR` at offset `18h`, access **`W1C`**.
- **§8.3.5.1.8.4 "Fields"** - "*Status flags are cleared by writing a 1 to the
  corresponding bit position*" and "*The value of this register is independent of
  the value in IMR register*", so flags latch on masked pins too and are lost as
  well.

Builds clean on `imx8mp_evk/mimx8ml8/m7`. Not verified on hardware; the fix
follows from the register semantics.
