### PR TITLE
manifest: Update nrf_wifi with latest rpu bins

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -356,7 +356,7 @@ manifest:
       revision: c84230d0329a2ce5e449bbd556d6854861a6eee7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 0aaa9aa812877cb6bc020df8260d0607a3f0ec1a
+      revision: fc0872109ec4c006d32843a202b129db33cf16b9
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 01032a8a7bdfdd541686f5dfa3671e602b9fcbff


### PR DESCRIPTION
    1.Firmware display scan fixes for SSID length clamping issue and
      incorrect security type issue for WPA2-PSK AP.
    2.Radio test fixes of multiple Token usage in Tx test and OFDM rates restriction
      based on configured regulatory domain.
    3.Aggregation support in Raw Tx mode.
    4.Diabling watchdog during quiet period.
    5.RPU Version update from 1.2.14.9 to 1.2.14.10.