### PR TITLE
drivers: serial: nrfx_uarte: fix CBWT RX disable with pending ENDRX

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1002,7 +1002,7 @@ static int rx_disable(const struct device *dev, bool api)
 	async_rx->stoprx_deferred = false;
 	if (async_rx->next_buf != NULL) {
 		nrf_uarte_shorts_disable(uarte, NRF_UARTE_SHORT_ENDRX_STARTRX);
-		if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDRX)) {
+		if (!IS_CBWT(dev) && nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDRX)) {
 			/* The short may have already started the next buffer. Stopping it now
 			 * would overwrite RX.AMOUNT before the pending ENDRX is processed.
 			 * RX remains active until that ISR runs, so ENDRX must be serviced

--- a/tests/boards/nrf/uarte/Kconfig
+++ b/tests/boards/nrf/uarte/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Nordic UARTE tests"
+
+source "Kconfig.zephyr"
+
+config NRF_UARTE_TEST_CBWT
+	bool "Run the Count Bytes With Timer regression test"

--- a/tests/boards/nrf/uarte/boards/nrf54l15dk_nrf54l15_cpuapp_cbwt.overlay
+++ b/tests/boards/nrf/uarte/boards/nrf54l15dk_nrf54l15_cpuapp_cbwt.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer21 {
+	status = "reserved";
+};
+
+&uart21 {
+	timer = <&timer21>;
+};

--- a/tests/boards/nrf/uarte/src/main.c
+++ b/tests/boards/nrf/uarte/src/main.c
@@ -21,9 +21,14 @@
 #define STRESS_ITERATIONS 128
 
 #define DMAEND_SUPPORTED IS_ENABLED(CONFIG_UARTE_NRFX_UARTE_HAS_DMAEND)
+#define CBWT_ENABLED                                                                               \
+	(IS_ENABLED(CONFIG_UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER) &&                             \
+	 DT_NODE_HAS_PROP(UART_NODE, timer))
 
 BUILD_ASSERT(DT_NODE_HAS_PROP(UART_NODE, frame_timeout_supported));
 BUILD_ASSERT(NRF_UARTE_HAS_FRAME_TIMEOUT);
+BUILD_ASSERT(!IS_ENABLED(CONFIG_NRF_UARTE_TEST_CBWT) || CBWT_ENABLED);
+BUILD_ASSERT(!IS_ENABLED(CONFIG_NRF_UARTE_TEST_CBWT) || !DMAEND_SUPPORTED);
 #if DMAEND_SUPPORTED
 BUILD_ASSERT(DT_NODE_HAS_PROP(UART_NODE, dmaend_supported));
 BUILD_ASSERT(NRF_UARTE_HAS_DMAEND_TASK);
@@ -202,6 +207,9 @@ static void validation_reset(void)
 #if DMAEND_SUPPORTED
 	state.response_short = FRAME_TIMEOUT_SHORT_DMAEND;
 	state.no_response_short = FRAME_TIMEOUT_SHORT_DMAEND;
+#elif CBWT_ENABLED
+	state.response_short = FRAME_TIMEOUT_SHORTS_DISABLED;
+	state.no_response_short = FRAME_TIMEOUT_SHORTS_DISABLED;
 #else
 	state.response_short = FRAME_TIMEOUT_SHORT_STOPRX;
 	state.no_response_short = FRAME_TIMEOUT_SHORT_STOPRX;
@@ -209,11 +217,13 @@ static void validation_reset(void)
 	zassert_ok(uart_callback_set(UART_DEV, uart_callback, NULL));
 }
 
+#if !defined(CONFIG_NRF_UARTE_TEST_CBWT)
 static void transmit(size_t len)
 {
 	zassert_ok(uart_tx(UART_DEV, tx_buf, len, 100 * USEC_PER_MSEC));
 	zassert_ok(k_sem_take(&tx_done, K_MSEC(100)));
 }
+#endif
 
 static void receiver_start(size_t len, int32_t timeout)
 {
@@ -228,6 +238,7 @@ static void *suite_setup(void)
 	return NULL;
 }
 
+#if !defined(CONFIG_NRF_UARTE_TEST_CBWT)
 ZTEST(nrf_uarte, test_frame_timeout_rollover)
 {
 	static const enum test_event expected_events[] = {
@@ -399,11 +410,15 @@ ZTEST(nrf_uarte, test_rollover_stress)
 	zassert_ok(k_sem_take(&rx_disabled, K_MSEC(100)));
 	frame_timeout_shorts_assert(FRAME_TIMEOUT_SHORTS_DISABLED);
 }
+#endif
 
 ZTEST(nrf_uarte, test_disable_with_pending_endrx)
 {
 	size_t event_count;
 	unsigned int key;
+#if DMAEND_SUPPORTED || CBWT_ENABLED
+	NRF_UARTE_Type *uarte = (NRF_UARTE_Type *)DT_REG_ADDR(UART_NODE);
+#endif
 
 	validation_reset();
 	state.supply_once = true;
@@ -411,12 +426,23 @@ ZTEST(nrf_uarte, test_disable_with_pending_endrx)
 	receiver_start(sizeof(rx_buf[0]), RX_TIMEOUT_US);
 
 	key = irq_lock();
+#if CBWT_ENABLED
+	zassert_equal(nrf_uarte_shorts_get(uarte, NRF_UARTE_SHORT_ENDRX_STARTRX),
+		      NRF_UARTE_SHORT_ENDRX_STARTRX);
+#endif
+#if DMAEND_SUPPORTED || CBWT_ENABLED
+	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
+	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
+#endif
+#if DMAEND_SUPPORTED
+	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_FRAME_TIMEOUT);
+#endif
 	zassert_ok(uart_tx(UART_DEV, tx_buf, sizeof(tx_buf), 100 * USEC_PER_MSEC));
 	k_busy_wait(2 * RX_TIMEOUT_US);
 #if DMAEND_SUPPORTED
-	NRF_UARTE_Type *uarte = (NRF_UARTE_Type *)DT_REG_ADDR(UART_NODE);
-
 	zassert_true(nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_FRAME_TIMEOUT));
+#endif
+#if DMAEND_SUPPORTED || CBWT_ENABLED
 	zassert_true(nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDRX));
 	zassert_true(nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXSTARTED));
 #endif
@@ -440,6 +466,7 @@ ZTEST(nrf_uarte, test_disable_with_pending_endrx)
 	k_sleep(K_MSEC(2));
 	zassert_equal(event_count, state.request_count + state.release_count[0] +
 					   state.release_count[1] + state.disabled_count);
+	zassert_equal(state.stopped_count, 0);
 
 	validation_reset();
 	receiver_start(sizeof(rx_buf[0]), RX_TIMEOUT_US);

--- a/tests/boards/nrf/uarte/tests.yaml
+++ b/tests/boards/nrf/uarte/tests.yaml
@@ -15,3 +15,13 @@ tests:
     integration_platforms:
       - nrf7120dk/nrf7120/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+
+  boards.nrf.uarte.cbwt:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_cbwt.overlay
+    extra_configs:
+      - CONFIG_NRF_UARTE_TEST_CBWT=y
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Do not defer STOPRX when CBWT is active because CBWT does not process ENDRX interrupts. Trigger STOPRX immediately to complete RX teardown and prevent subsequent uart_rx_enable() calls from returning -EBUSY.

Fixes #115897
Fixes #115899
