### PR TITLE
tests/bsim: Remove incorrect comment in scripts

### DIFF
--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -4,7 +4,6 @@
 
 # This script runs the Babblesim CI BT tests.
 # It can also be run locally.
-# Note it will produce its output in ${ZEPHYR_BASE}/bsim_bt/
 
 export ZEPHYR_BASE="${ZEPHYR_BASE:-${PWD}}"
 cd ${ZEPHYR_BASE}

--- a/tests/bsim/ci.net.sh
+++ b/tests/bsim/ci.net.sh
@@ -4,7 +4,6 @@
 
 # This script runs the Babblesim CI networking tests.
 # It can also be run locally.
-# Note it will produce its output in ${ZEPHYR_BASE}/bsim_bt/
 
 export ZEPHYR_BASE="${ZEPHYR_BASE:-${PWD}}"
 cd ${ZEPHYR_BASE}

--- a/tests/bsim/ci.uart.sh
+++ b/tests/bsim/ci.uart.sh
@@ -4,7 +4,6 @@
 
 # This script runs the Babblesim CI UART tests.
 # It can also be run locally.
-# Note it will produce its output in ${ZEPHYR_BASE}/bsim_out/
 
 export ZEPHYR_BASE="${ZEPHYR_BASE:-${PWD}}"
 cd ${ZEPHYR_BASE}


### PR DESCRIPTION
Since we changed all these to use twister, this comment is not applicable anymore. The output is placed in twister-out