### PR TITLE
drivers: i2c: stm32: Better explicit bus recovery dependency on GPIOs

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -53,6 +53,9 @@ config I2C_STM32_BUS_RECOVERY
 	help
 	  Enable STM32 driver bus recovery support via GPIO bitbanging.
 
+config I2C_BUS_RECOVERY
+	depends on GPIO
+
 config I2C_STM32_V2_TIMING
 	bool "compute the I2C V2 bus timing"
 	depends on I2C_STM32_V2


### PR DESCRIPTION
Explicit the dependency on `CONFIG_I2C_BUS_RECOVERY` on `CONFIG_GPIO` for STM32 I2C drivers. This change makes the build sequence to emit a config warning message when product sets the former but not the latter.

This warning message may help one knowing that the target I2C bus recovery is not enabled instead of silently keeping
`CONFIG_I2C_STM32_BUS_RECOVERY` disable. It is a workaround for the Kconfig circular dependency issue preventing an I2C driver Kconfig file using `select GPIO` upon GPIO needs for I2C bus recovery support.
