### PR TITLE
drivers: dac: mspm0: Convert to native register access

### DIFF
--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <dt-bindings/adc/adc.h>
 
 / {
 	model = "TI LP_MSPM0G3507/MSPM0G3507";
@@ -46,6 +47,12 @@
 		pwm_led0: pwm_led0 {
 			pwms = <&pwma0 0 PWM_MSEC(100) PWM_POLARITY_NORMAL>;
 		};
+	};
+
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -132,6 +139,34 @@
 
 &dac0 {
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,resolution = <12>;
+		zephyr,buffered;
+	};
+};
+
+&adc0 {
+	clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+	ti,clk-divider = <1>;
+	ti,clk-range = <6>;
+	max-result-reg = <12>;
+	pinctrl-0 = <&analog_pb25>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
 };
 
 &spi0 {

--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
@@ -12,6 +12,7 @@ supported:
   - uart
   - gpio
   - can
+  - adc
   - dac
   - spi
   - vref

--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <dt-bindings/adc/adc.h>
 
 / {
 	model = "TI LP_MSPM0G3519";
@@ -67,6 +68,12 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
 };
 
 &cpu0 {
@@ -117,6 +124,34 @@
 
 &dac0 {
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,resolution = <12>;
+		zephyr,buffered;
+	};
+};
+
+&adc0 {
+	clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+	ti,clk-divider = <1>;
+	ti,clk-range = <6>;
+	max-result-reg = <12>;
+	pinctrl-0 = <&analog_pb25>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
 };
 
 &spi0 {

--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
@@ -12,6 +12,7 @@ supported:
   - uart
   - gpio
   - can
+  - adc
   - dac
   - spi
   - vref

--- a/drivers/dac/Kconfig.mspm0
+++ b/drivers/dac/Kconfig.mspm0
@@ -1,13 +1,13 @@
 # TI MSPM0 DAC Driver Configuration
 
 # Copyright (c) 2026 Linumiz
+# Copyright (c) 2026 Texas Instruments Incorporated
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_MSPM0
 	bool "TI MSPM0 Digital To Analog Converter (DAC) Driver"
 	default y
 	depends on DT_HAS_TI_MSPM0_DAC_ENABLED
-	select USE_MSPM0_DL_DAC12
 	help
 	  Enable support for the DAC (Digital-to-Analog Converter)
 	  peripheral driver for Texas Instruments MSPM0 G-Series MCUs.

--- a/drivers/dac/dac_mspm0.c
+++ b/drivers/dac/dac_mspm0.c
@@ -75,9 +75,9 @@ static int dac_mspm0_channel_setup(const struct device *dev,
 	 * and the external DAC_OUT pin. HW does not allow separate control.
 	 */
 	if (channel_cfg->internal) {
-		DL_DAC12_enableOutputPin(regs);
-	} else {
 		DL_DAC12_disableOutputPin(regs);
+	} else {
+		DL_DAC12_enableOutputPin(regs);
 	}
 
 	DL_DAC12_enable(regs);

--- a/drivers/dac/dac_mspm0.c
+++ b/drivers/dac/dac_mspm0.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2026 Linumiz
+ * Copyright (c) 2026 Texas Instruments Incorporated
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,9 +11,131 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/dac.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
 
-/* TI Driverlib includes */
-#include <ti/driverlib/dl_dac12.h>
+struct dac12_gen_event_regs {
+	volatile uint32_t iidx;  /* !< (@ 0x00001050) Interrupt index */
+	uint32_t reserved0;      /* !< Reserved*/
+	volatile uint32_t imask; /* !< (@ 0x00001058) Interrupt mask */
+	uint32_t reserved1;      /* !< Reserved*/
+	volatile uint32_t ris;   /* !< (@ 0x00001060) Raw interrupt status */
+	uint32_t reserved2;      /* !< Reserved*/
+	volatile uint32_t mis;   /* !< (@ 0x00001068) Masked interrupt status */
+	uint32_t reserved3;      /* !< Reserved*/
+	volatile uint32_t iset;  /* !< (@ 0x00001070) Interrupt set */
+	uint32_t reserved4;      /* !< Reserved*/
+	volatile uint32_t iclr;  /* !< (@ 0x00001078) Interrupt clear */
+};
+
+struct dac12_cpu_init_regs {
+	volatile uint32_t iidx;  /* !< (@ 0x00001020) Interrupt index */
+	uint32_t reserved0;      /* !< Reserved*/
+	volatile uint32_t imask; /* !< (@ 0x00001028) Interrupt mask */
+	uint32_t reserved1;      /* !< Reserved*/
+	volatile uint32_t ris;   /* !< (@ 0x00001030) Raw interrupt status */
+	uint32_t reserved2;      /* !< Reserved*/
+	volatile uint32_t mis;   /* !< (@ 0x00001038) Masked interrupt status */
+	uint32_t reserved3;      /* !< Reserved*/
+	volatile uint32_t iset;  /* !< (@ 0x00001040) Interrupt set */
+	uint32_t reserved4;      /* !< Reserved*/
+	volatile uint32_t iclr;  /* !< (@ 0x00001048) Interrupt clear */
+};
+
+struct dac12_gprcm_regs {
+	volatile uint32_t pwren;  /* !< (@ 0x00000800) Power enable */
+	volatile uint32_t rstctl; /* !< (@ 0x00000804) Reset Control */
+	uint32_t reserved0[3];    /* !< Reserved*/
+	volatile uint32_t stat;   /* !< (@ 0x00000814) Status Register */
+};
+
+struct dac12_regs {
+	uint32_t reserved0[256];
+	volatile uint32_t fsub_0;              /* !< (@ 0x00000400) Subscriber Port 0 */
+	uint32_t reserved1[16];                /* !< Reserved*/
+	volatile uint32_t fpub_1;              /* !< (@ 0x00000444) Publisher port 1 */
+	uint32_t reserved2[238];               /* !< Reserved*/
+	struct dac12_gprcm_regs gprcm;         /* !< (@ 0x00000800) */
+	uint32_t reserved3[514];               /* !< Reserved*/
+	struct dac12_cpu_init_regs cpu_int;    /* !< (@ 0x00001020) */
+	uint32_t reserved4;                    /* !< Reserved*/
+	struct dac12_gen_event_regs gen_event; /* !< (@ 0x00001050) */
+	uint32_t reserved5[25];                /* !< Reserved*/
+	volatile uint32_t evt_mode;            /* !< (@ 0x000010E0) Event Mode */
+	uint32_t reserved6[6];                 /* !< Reserved*/
+	volatile uint32_t desc;                /* !< (@ 0x000010FC) Module Description */
+	volatile uint32_t ctl0;                /* !< (@ 0x00001100) Control 0 */
+	uint32_t reserved7[3];                 /* !< Reserved*/
+	volatile uint32_t ctl1;                /* !< (@ 0x00001110) Control 1 */
+	uint32_t reserved8[3];                 /* !< Reserved*/
+	volatile uint32_t ctl2;                /* !< (@ 0x00001120) Control 2 */
+	uint32_t reserved9[3];                 /* !< Reserved*/
+	volatile uint32_t ctl3;                /* !< (@ 0x00001130) Control 3 */
+	uint32_t reserved10[3];                /* !< Reserved*/
+	volatile uint32_t calctl;              /* !< (@ 0x00001140) Calibration control */
+	uint32_t reserved11[7];                /* !< Reserved*/
+	volatile uint32_t caldata;             /* !< (@ 0x00001160) Calibration data */
+	uint32_t reserved12[39];               /* !< Reserved*/
+	volatile uint32_t data0;               /* !< (@ 0x00001200) Data 0 */
+};
+
+/*
+ * Compile-time checks
+ */
+BUILD_ASSERT(offsetof(struct dac12_regs, gprcm) == 0x0800U);
+BUILD_ASSERT(offsetof(struct dac12_regs, cpu_int) == 0x1020U);
+BUILD_ASSERT(offsetof(struct dac12_regs, gen_event) == 0x1050U);
+BUILD_ASSERT(offsetof(struct dac12_regs, ctl0) == 0x1100U);
+BUILD_ASSERT(offsetof(struct dac12_regs, ctl1) == 0x1110U);
+BUILD_ASSERT(offsetof(struct dac12_regs, calctl) == 0x1140U);
+BUILD_ASSERT(offsetof(struct dac12_regs, data0) == 0x1200U);
+
+/*
+ * Bit-field constants
+ */
+
+#ifndef CONFIG_HAS_MSPM0_SDK
+/* DAC12_RSTCTL Bits */
+#define DAC12_RSTCTL_RESETSTKYCLR_CLR   BIT(1)      /* !< Clear reset sticky bit */
+#define DAC12_RSTCTL_RESETASSERT_ASSERT BIT(0)      /* !< Assert reset */
+#define DAC12_RSTCTL_KEY_UNLOCK_W       0xB1000000U /* !< KEY to allow write access */
+
+/* GPRCM.PWREN — writing the unlock key + enable bit powers the peripheral on */
+#define DAC12_PWREN_KEY_UNLOCK_W  0x26000000U
+#define DAC12_PWREN_ENABLE_ENABLE BIT(0)
+
+/* CTL0 — main DAC enable/disable, resolution, and data format */
+#define DAC12_CTL0_ENABLE_SET  BIT(0) /* bit 0: DAC on */
+#define DAC12_CTL0_ENABLE_MASK BIT(0)
+#define DAC12_CTL0_RES_MASK    BIT(8) /* bit 8: resolution select */
+#define DAC12_CTL0_RES__8BITS  0x0
+#define DAC12_CTL0_RES__12BITS BIT(8)
+#define DAC12_CTL0_DFM_MASK    BIT(16) /* bit 16: data format (binary vs 2s-comp) */
+#define DAC12_CTL0_DFM_BINARY  0x0
+
+/* CTL1 — output amplifier, voltage reference, and output pin routing */
+#define DAC12_CTL1_AMPEN_MASK      BIT(0)
+#define DAC12_CTL1_AMPEN_ENABLE    BIT(0)  /* bit 0: amplifier enable */
+#define DAC12_CTL1_AMPHIZ_MASK     BIT(1)  /* bit 1: amp-off output state */
+#define DAC12_CTL1_AMPHIZ_PULLDOWN BIT(1)  /* pull DAC_OUT to 0 V when amp is off */
+#define DAC12_CTL1_REFSP_MASK      BIT(8)  /* bit 8: positive reference select */
+#define DAC12_CTL1_REFSP_VDDA      0x0     /* use VDDA as VR+ */
+#define DAC12_CTL1_REFSP_VEREFP    BIT(8)  /* use VEREFP pin as VR+ */
+#define DAC12_CTL1_REFSN_MASK      BIT(9)  /* bit 9: negative reference select */
+#define DAC12_CTL1_REFSN_VEREFN    0x0     /* use VEREFN pin as VR- */
+#define DAC12_CTL1_REFSN_VSSA      BIT(9)  /* use VSSA as VR- */
+#define DAC12_CTL1_OPS_MASK        BIT(24) /* bit 24: output pin select */
+#define DAC12_CTL1_OPS_OUT0        BIT(24) /* route output to DAC_OUT pin */
+
+/* CALCTL — self-calibration trigger and trim source select */
+#define DAC12_CALCTL_CALON_ACTIVE               BIT(0) /* bit 0: calibration running */
+#define DAC12_CALCTL_CALSEL_SELFCALIBRATIONTRIM BIT(1) /* bit 1: use self-cal trim */
+
+/* GEN_EVENT.RIS — raw interrupt status flags */
+#define DAC12_GEN_EVENT_RIS_MODRDYIFG_SET BIT(1) /* bit 1: DAC core is ready */
+
+/* DATA0 — the value written here appears on the DAC output */
+#define DAC12_DATA0_DATA_VALUE_MASK GENMASK(11, 0) /* bits [11:0]: 12-bit data field */
+#endif
 
 #define DAC_RESOLUTION_8BIT	8
 #define DAC_RESOLUTION_12BIT	12
@@ -23,28 +146,25 @@
 #define DAC_PRIMARY_CHANNEL_ID	0
 #define DAC_READY_TIMEOUT_US	1000
 
+#define DAC12_VREF_SOURCE_VEREFP_VEREFN (DAC12_CTL1_REFSP_VEREFP | DAC12_CTL1_REFSN_VEREFN)
+#define DAC12_VREF_SOURCE_VDDA_VSSA     (DAC12_CTL1_REFSP_VDDA | DAC12_CTL1_REFSN_VSSA)
+
 struct dac_mspm0_config {
-	DEVICE_MMIO_ROM;
-	DL_DAC12_VREF_SOURCE dac_vref_src;
+	struct dac12_regs *base;
+	uint32_t vref_ctl1_bits;
 };
 
 struct dac_mspm0_data {
-	DEVICE_MMIO_RAM;
 	struct k_mutex lock;
 	uint8_t resolution;
 };
-
-static inline DAC12_Regs *dac_mspm0_regs(const struct device *dev)
-{
-	return (DAC12_Regs *)DEVICE_MMIO_GET(dev);
-}
 
 static int dac_mspm0_channel_setup(const struct device *dev,
 				   const struct dac_channel_cfg *channel_cfg)
 {
 	const struct dac_mspm0_config *config = dev->config;
 	struct dac_mspm0_data *data = dev->data;
-	DAC12_Regs *regs = dac_mspm0_regs(dev);
+	struct dac12_regs *regs = config->base;
 
 	if (channel_cfg->channel_id != DAC_PRIMARY_CHANNEL_ID) {
 		return -EINVAL;
@@ -57,43 +177,48 @@ static int dac_mspm0_channel_setup(const struct device *dev,
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
-	/* DAC must be disabled before configuration */
-	DL_DAC12_disable(regs);
+	/* disable DAC before reconfiguring */
+	regs->ctl0 &= ~DAC12_CTL0_ENABLE_MASK;
 
-	DL_DAC12_configDataFormat(regs, DL_DAC12_REPRESENTATION_BINARY,
-				  (channel_cfg->resolution == DAC_RESOLUTION_12BIT) ?
-				  DL_DAC12_RESOLUTION_12BIT : DL_DAC12_RESOLUTION_8BIT);
+	/* set data format (binary) and resolution in ctl0 */
+	uint32_t res_bits = (channel_cfg->resolution == DAC_RESOLUTION_12BIT)
+				    ? DAC12_CTL0_RES__12BITS
+				    : DAC12_CTL0_RES__8BITS;
 
-	/* buffered must be true to enable amplifier for output drive */
-	DL_DAC12_setAmplifier(regs,
-			      (channel_cfg->buffered) ? DL_DAC12_AMP_ON : DL_DAC12_AMP_OFF_0V);
+	regs->ctl0 =
+		(regs->ctl0 & ~(DAC12_CTL0_DFM_MASK | DAC12_CTL0_RES_MASK)) |
+		((DAC12_CTL0_DFM_BINARY | res_bits) & (DAC12_CTL0_DFM_MASK | DAC12_CTL0_RES_MASK));
 
-	DL_DAC12_setReferenceVoltageSource(regs, config->dac_vref_src);
+	/* configure amplifier, voltage reference, and output routing in ctl1 */
+	uint32_t amp_bits =
+		channel_cfg->buffered ? DAC12_CTL1_AMPEN_ENABLE : DAC12_CTL1_AMPHIZ_PULLDOWN;
+	uint32_t ops_bits = channel_cfg->internal ? 0U : DAC12_CTL1_OPS_OUT0;
+	uint32_t ctl1_mask = DAC12_CTL1_AMPEN_MASK | DAC12_CTL1_AMPHIZ_MASK |
+			     DAC12_CTL1_REFSP_MASK | DAC12_CTL1_REFSN_MASK | DAC12_CTL1_OPS_MASK;
 
-	/*
-	 * CTL1.OPS controls output to both internal modules (OPA, ADC, COMP)
-	 * and the external DAC_OUT pin. HW does not allow separate control.
-	 */
-	if (channel_cfg->internal) {
-		DL_DAC12_disableOutputPin(regs);
-	} else {
-		DL_DAC12_enableOutputPin(regs);
-	}
+	regs->ctl1 = (regs->ctl1 & ~ctl1_mask) |
+		     ((amp_bits | config->vref_ctl1_bits | ops_bits) & ctl1_mask);
 
-	DL_DAC12_enable(regs);
+	/* re-enable the DAC */
+	regs->ctl0 |= DAC12_CTL0_ENABLE_SET;
 
-	/* Wait for DAC core and output buffer to settle */
-	if (!WAIT_FOR(DL_DAC12_getInterruptStatus(regs,
-						  DL_DAC12_INTERRUPT_MODULE_READY),
-		      DAC_READY_TIMEOUT_US, k_busy_wait(1))) {
+	/* Wait for the DAC core and amplifier to settle */
+	if (!WAIT_FOR(regs->gen_event.ris & DAC12_GEN_EVENT_RIS_MODRDYIFG_SET, DAC_READY_TIMEOUT_US,
+		      k_busy_wait(1))) {
 		k_mutex_unlock(&data->lock);
 		return -ETIMEDOUT;
 	}
 
 	data->resolution = channel_cfg->resolution;
 
+	/* self-calibrate offset error if amplifier is active */
 	if (channel_cfg->buffered) {
-		DL_DAC12_performSelfCalibrationBlocking(regs);
+		regs->calctl = DAC12_CALCTL_CALON_ACTIVE | DAC12_CALCTL_CALSEL_SELFCALIBRATIONTRIM;
+		if (!WAIT_FOR(regs->calctl & DAC12_CALCTL_CALON_ACTIVE, DAC_READY_TIMEOUT_US,
+			      k_busy_wait(1))) {
+			k_mutex_unlock(&data->lock);
+			return -ETIMEDOUT;
+		}
 	}
 
 	k_mutex_unlock(&data->lock);
@@ -103,8 +228,9 @@ static int dac_mspm0_channel_setup(const struct device *dev,
 
 static int dac_mspm0_write_value(const struct device *dev, uint8_t channel, uint32_t value)
 {
+	const struct dac_mspm0_config *config = dev->config;
 	struct dac_mspm0_data *data = dev->data;
-	DAC12_Regs *regs = dac_mspm0_regs(dev);
+	struct dac12_regs *regs = config->base;
 	int ret = 0;
 
 	k_mutex_lock(&data->lock, K_FOREVER);
@@ -120,14 +246,13 @@ static int dac_mspm0_write_value(const struct device *dev, uint8_t channel, uint
 			ret = -EINVAL;
 			goto unlock;
 		}
-		DL_DAC12_output12(regs, value);
-
+		regs->data0 = value & DAC12_DATA0_DATA_VALUE_MASK;
 	} else {
 		if (value > DAC8_MAX_VALUE) {
 			ret = -EINVAL;
 			goto unlock;
 		}
-		DL_DAC12_output8(regs, (uint8_t)value);
+		regs->data0 = (uint8_t)value;
 	}
 
 unlock:
@@ -137,10 +262,12 @@ unlock:
 
 static int dac_mspm0_init(const struct device *dev)
 {
-	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+	const struct dac_mspm0_config *config = dev->config;
 
-	DL_DAC12_enablePower(dac_mspm0_regs(dev));
-	delay_cycles(CONFIG_MSPM0_PERIPH_STARTUP_DELAY);
+	config->base->gprcm.rstctl = DAC12_RSTCTL_KEY_UNLOCK_W | DAC12_RSTCTL_RESETSTKYCLR_CLR |
+				     DAC12_RSTCTL_RESETASSERT_ASSERT;
+
+	config->base->gprcm.pwren = DAC12_PWREN_KEY_UNLOCK_W | DAC12_PWREN_ENABLE_ENABLE;
 
 	return 0;
 }
@@ -153,10 +280,10 @@ static DEVICE_API(dac, dac_mspm0_driver_api) = {
 #define DAC_MSPM0_DEFINE(id)									\
 												\
 	static const struct dac_mspm0_config dac_mspm0_config_##id = {				\
-		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(id)),						\
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(id, vref),                                    \
-			    (.dac_vref_src = DL_DAC12_VREF_SOURCE_VEREFP_VEREFN),		\
-			    (.dac_vref_src = DL_DAC12_VREF_SOURCE_VDDA_VSSA)),			\
+		.base = (struct dac12_regs *)DT_INST_REG_ADDR(id),				\
+		.vref_ctl1_bits = COND_CODE_1(DT_INST_NODE_HAS_PROP(id, vref),			\
+			DAC12_VREF_SOURCE_VEREFP_VEREFN,					\
+			DAC12_VREF_SOURCE_VDDA_VSSA),						\
 	};											\
 												\
 	static struct dac_mspm0_data dac_mspm0_data_##id = {					\

--- a/tests/drivers/dac/dac_loopback/dac0-channel0-adc0-channel4.overlay
+++ b/tests/drivers/dac/dac_loopback/dac0-channel0-adc0-channel4.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&dac0 0 &adc0 4>;
+		io-channel-names = "dac1", "adc1";
+	};
+};

--- a/tests/drivers/dac/dac_loopback/tests.yaml
+++ b/tests/drivers/dac/dac_loopback/tests.yaml
@@ -19,6 +19,12 @@ tests:
       - xg24_dk2601b
       - xg24_ek2703a
       - xg24_rb4187c
+  drivers.dac.loopback.dac0_chan0_adc0_chan4:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dac0-channel0-adc0-channel4.overlay"
+    platform_allow:
+      - lp_mspm0g3507
+      - lp_mspm0g3519
   drivers.dac.loopback.dac1_chan1_adc1_chan0:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="dac1-channel1-adc1-channel0.overlay"


### PR DESCRIPTION
Add MSPM0 DAC driver with native register access and lp_mspm0g3507/g3519 board support in sample and tests

### Changes:

- Replace TI DriverLib (`dl_dac12.h`) with a native `dac12_regs` register map
- Add sample and `dac_api`, `dac_loopback` test overlays for lp_mspm0g3507 and lp_mspm0g3519; 
    - DAC output on PA15 (J3 pin 30)
    - ADC input on PB25(Channel 4, J3 pin 26)

### Testing

  | Board | `dac_api` | `dac_loopback` |
  |---|---| --- |
  | lp_mspm0g3507 | PASS | PASS |
  | lp_mspm0g3519 | PASS | PASS |

### Testing Logs (Passing):

#### `dac_api` test
```
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-11193-g45fa2a030dec
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - Writing JSON report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform                 | ID   | Serial device   |
|--------------------------|------|-----------------|
| lp_mspm0g3507/mspm0g3507 | none | /dev/ttyACM0    |

INFO    - JOBS: 24
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/2 lp_mspm0g3507/mspm0g3507  drivers.dac.api.dac0_channel0                      PASSED (device: none, 4.975s <zephyr/gnu>)
INFO    - 2/2 lp_mspm0g3507/mspm0g3507  drivers.dac.api                                    PASSED (device: none, 4.736s <zephyr/gnu>)

INFO    - 10 test scenarios (10 configurations) selected, 8 configurations filtered (8 by static filter, 0 at runtime).
INFO    - 2 of 2 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 15.32 seconds.
INFO    - 2 of 2 executed test cases passed (100.00%) on 1 out of total 1676 platforms (0.06%).
INFO    - 2 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                    | ID   |   Counter |   Failures |
|--------------------------|------|-----------|------------|
| lp_mspm0g3507/mspm0g3507 | none |         2 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

####  `dac_loopback` test

```
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-11199-g21ba3f07b9ac
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - Writing JSON report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform                 | ID   | Serial device   |
|--------------------------|------|-----------------|
| lp_mspm0g3519/mspm0g3519 | none | /dev/ttyACM0    |

INFO    - JOBS: 24
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/2 lp_mspm0g3519/mspm0g3519  drivers.dac.loopback.dac0_chan0_adc0_chan4         PASSED (device: none, 6.185s <zephyr/gnu>)
INFO    - 2/2 lp_mspm0g3519/mspm0g3519  drivers.dac.loopback                               PASSED (device: none, 5.999s <zephyr/gnu>)

INFO    - 6 test scenarios (6 configurations) selected, 4 configurations filtered (4 by static filter, 0 at runtime).
INFO    - 2 of 2 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 17.64 seconds.
INFO    - 2 of 2 executed test cases passed (100.00%) on 1 out of total 1676 platforms (0.06%).
INFO    - 2 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                    | ID   |   Counter |   Failures |
|--------------------------|------|-----------|------------|
| lp_mspm0g3519/mspm0g3519 | none |         2 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/antpc/Development/zephyr_folder/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

### Waveform Output (from the sample):
<img width="1509" height="907" alt="Screenshot from 2026-08-11 17-52-26" src="https://github.com/user-attachments/assets/35e7948f-5666-4e67-af9a-cd5dc100f574" />


