### PR TITLE
drivers: i2c: stm32: Select I2C_STM32_INTERRUPT upon I2C_RTIO

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -16,7 +16,7 @@ config I2C_STM32_V1
 	bool
 	default y
 	depends on DT_HAS_ST_STM32_I2C_V1_ENABLED
-	select I2C_STM32_INTERRUPT if I2C_TARGET
+	select I2C_STM32_INTERRUPT if I2C_TARGET || I2C_RTIO
 	help
 	  Driver variant matching `st,stm32-i2c-v1` compatible.
 
@@ -24,11 +24,9 @@ config I2C_STM32_V2
 	bool
 	default y
 	depends on DT_HAS_ST_STM32_I2C_V2_ENABLED
-	select I2C_STM32_INTERRUPT if I2C_TARGET
+	select I2C_STM32_INTERRUPT if I2C_TARGET || I2C_RTIO
 	help
 	  Driver variant matching `st,stm32-i2c-v2` compatible.
-	  If I2C_TARGET is enabled it selects I2C_STM32_INTERRUPT, since target mode
-	  is only supported by this driver with interrupts enabled.
 
 config I2C_STM32_INTERRUPT
 	bool "STM32 MCU I2C Interrupt Support"


### PR DESCRIPTION
`CONFIG_I2C_RTIO=y` enables `CONFIG_I2C_STM32_INTERRUPT` since STM32 I2C RTIO drivers are only supported with interrupts enabled.

Remove the sentence in `I2C_STM32_V2` config symbol description about `I2C_STM32_INTERRUPT` selection since it's already explicitly stated by the `select` command and makes `I2C_STM32_V2` description more consistent regarding `I2C_STM32_V1` description.