### PR TITLE
Bluetooth: Controller: Discard PDU exceeding max length

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -827,6 +827,15 @@ static void isr_rx(void *param)
 			}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+			/* Discard the received PDU, whether unencrypted or the
+			 * decrypted, with length that exceeds the configured
+			 * maximum receive data length used to setup the radio
+			 * packet reception.
+			 */
+			if (pdu_rx->len > cis_lll->rx.max_pdu) {
+				goto isr_rx_done;
+			}
+
 			/* Enqueue Rx ISO PDU */
 			node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
 			node_rx->hdr.handle = cis_lll->handle;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -45,6 +45,7 @@
 
 static int init_reset(void);
 static void isr_done(void *param);
+static uint16_t max_rx_octets_get(struct lll_conn *lll);
 static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 			     uint8_t *is_rx_enqueue,
 			     struct node_tx **tx_release, uint8_t *is_done);
@@ -374,8 +375,9 @@ void lll_conn_isr_rx(void *param)
 		err = isr_rx_pdu(lll, pdu_data_rx, &is_rx_enqueue, &tx_release,
 				 &is_done);
 		if (err) {
-			/* Disable radio trx switch on MIC failure for both
-			 * central and peripheral, and close the radio event.
+			/* Disable radio trx switch on MIC or length failure for
+			 * both central and peripheral, and close the radio
+			 * event.
 			 */
 			radio_isr_set(isr_done, param);
 			radio_disable();
@@ -847,16 +849,7 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	pdu_data_rx = (void *)node_rx->pdu;
 	pdu_data_rx->len = 0U;
 
-#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
-	max_rx_octets = lll->dle.eff.max_rx_octets;
-#else /* !CONFIG_BT_CTLR_DATA_LENGTH */
-	max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
-#endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
-
-	if ((PDU_DC_CTRL_RX_SIZE_MAX > PDU_DC_PAYLOAD_SIZE_MIN) &&
-	    (max_rx_octets < PDU_DC_CTRL_RX_SIZE_MAX)) {
-		max_rx_octets = PDU_DC_CTRL_RX_SIZE_MAX;
-	}
+	max_rx_octets = max_rx_octets_get(lll);
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	phy = lll->phy_rx;
@@ -1090,6 +1083,25 @@ static inline bool ctrl_pdu_len_check(uint8_t len)
 
 }
 
+static uint16_t max_rx_octets_get(struct lll_conn *lll)
+{
+	uint16_t max_rx_octets;
+
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+	max_rx_octets = lll->dle.eff.max_rx_octets;
+#else /* !CONFIG_BT_CTLR_DATA_LENGTH */
+	ARG_UNUSED(lll);
+	max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
+#endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
+
+	if ((PDU_DC_CTRL_RX_SIZE_MAX > PDU_DC_PAYLOAD_SIZE_MIN) &&
+	    (max_rx_octets < PDU_DC_CTRL_RX_SIZE_MAX)) {
+		max_rx_octets = PDU_DC_CTRL_RX_SIZE_MAX;
+	}
+
+	return max_rx_octets;
+}
+
 static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 			     uint8_t *is_rx_enqueue,
 			     struct node_tx **tx_release, uint8_t *is_done)
@@ -1251,6 +1263,17 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 				mic_state = LLL_CONN_MIC_PASS;
 			}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+			/* Discard the received PDU, whether unencrypted or the
+			 * decrypted, with length that exceeds the configured
+			 * maximum receive data length used to setup the radio
+			 * packet reception. Encrypted PDUs include the MIC in
+			 * their on-air length, hence the check is performed here
+			 * after decryption.
+			 */
+			if (pdu_data_rx->len > max_rx_octets_get(lll)) {
+				return -EINVAL;
+			}
 
 			/* Enqueue non-empty PDU */
 			*is_rx_enqueue = 1U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -642,6 +642,18 @@ static void isr_rx(void *param)
 			}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+			/* Discard the received PDU, whether unencrypted or the
+			 * decrypted, with length that exceeds the configured
+			 * maximum receive data length used to setup the radio
+			 * packet reception.
+			 */
+			if (pdu_rx->len > cis_lll->rx.max_pdu) {
+				radio_isr_set(isr_done, param);
+				radio_disable();
+
+				return;
+			}
+
 			/* Enqueue Rx ISO PDU */
 			node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
 			node_rx->hdr.handle = cis_lll->handle;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -862,7 +862,12 @@ static void isr_rx(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	}
 
 	pdu = (void *)node_rx->pdu;
-	if (unlikely((pdu->type != PDU_ADV_TYPE_EXT_IND) || !pdu->len)) {
+	if (unlikely((pdu->type != PDU_ADV_TYPE_EXT_IND) || !pdu->len ||
+		     (pdu->len > LL_EXT_OCTETS_RX_MAX))) {
+		/* Discard received PDU with length that exceeds the configured
+		 * maximum receive data length used to setup the radio packet
+		 * reception.
+		 */
 		err = -EINVAL;
 
 		goto isr_rx_do_close;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -751,6 +751,15 @@ static void isr_rx(void *param)
 				}
 			}
 
+			/* Discard the received PDU, whether unencrypted or the
+			 * decrypted, with length that exceeds the configured
+			 * maximum receive data length used to setup the radio
+			 * packet reception.
+			 */
+			if (pdu->len > lll->max_pdu) {
+				goto isr_rx_done;
+			}
+
 			ull_iso_pdu_rx_alloc();
 
 			handle = LL_BIS_SYNC_HANDLE_FROM_IDX(stream_handle);


### PR DESCRIPTION
Discard received PDU with length that exceed configured
maximum data length.

Fixes: #119035