### PR TITLE
drivers: sensor: max32664c: fix SCD mode, skin contact channel and config

### DIFF
--- a/drivers/sensor/adi/max32664c/max32664c.c
+++ b/drivers/sensor/adi/max32664c/max32664c.c
@@ -711,7 +711,11 @@ static int max32664c_channel_get(const struct device *dev, enum sensor_channel c
 		break;
 	}
 	case SENSOR_CHAN_MAX32664C_SKIN_CONTACT: {
-		val->val1 = data->report.scd_state;
+		if (data->op_mode == MAX32664C_OP_MODE_SCD) {
+			val->val1 = data->scd.scd_classifier;
+		} else {
+			val->val1 = data->report.scd_state;
+		}
 		break;
 	}
 	default: {

--- a/drivers/sensor/adi/max32664c/max32664c.c
+++ b/drivers/sensor/adi/max32664c/max32664c.c
@@ -714,7 +714,11 @@ static int max32664c_channel_get(const struct device *dev, enum sensor_channel c
 		if (data->op_mode == MAX32664C_OP_MODE_SCD) {
 			val->val1 = data->scd.scd_classifier;
 		} else {
+#ifdef CONFIG_MAX32664C_USE_EXTENDED_REPORTS
+			val->val1 = data->ext.scd_state;
+#else
 			val->val1 = data->report.scd_state;
+#endif
 		}
 		break;
 	}

--- a/drivers/sensor/adi/max32664c/max32664c.h
+++ b/drivers/sensor/adi/max32664c/max32664c.h
@@ -185,8 +185,8 @@ struct max32664c_data {
 
 	enum max32664c_device_mode op_mode; /**< Current device mode */
 
-	uint8_t motion_time;              /**< Motion time in milliseconds */
-	uint8_t motion_threshold;         /**< Motion threshold in milli-g */
+	uint16_t motion_time;             /**< Motion time in milliseconds */
+	uint16_t motion_threshold;        /**< Motion threshold in milli-g */
 	uint8_t led_current[3];           /**< LED current in mA */
 	uint8_t min_integration_time_idx;
 	uint8_t min_sampling_rate_idx;

--- a/drivers/sensor/adi/max32664c/max32664c_worker.c
+++ b/drivers/sensor/adi/max32664c/max32664c_worker.c
@@ -98,6 +98,19 @@ static void max32664c_parse_and_push_raw(const struct device *dev)
 	max32664c_push_to_queue(&data->raw_report_queue, &report);
 }
 
+/** @brief          Process the buffer to get the skin contact detection data from the sensor hub.
+ *  @param dev      Pointer to device
+ */
+static void max32664c_parse_and_push_scd(const struct device *dev)
+{
+	struct max32664c_data *data = dev->data;
+	struct max32664c_scd_report_t report;
+
+	report.scd_classifier = data->max32664_i2c_buffer[1];
+
+	max32664c_push_to_queue(&data->scd_report_queue, &report);
+}
+
 #ifdef CONFIG_MAX32664C_USE_EXTENDED_REPORTS
 /** @brief          Process the buffer to get the extended report data from the sensor hub.
  *  @param dev      Pointer to device
@@ -290,6 +303,8 @@ void max32664c_worker(const struct device *dev)
 
 		uint8_t tx[2] = {0x12, 0x01};
 
+		data->max32664_i2c_buffer[0] = 0;
+
 		switch (data->op_mode) {
 		case MAX32664C_OP_MODE_RAW: {
 			/* Get all samples to clear the FIFO */
@@ -350,6 +365,21 @@ void max32664c_worker(const struct device *dev)
 			break;
 		}
 #endif /* CONFIG_MAX32664C_USE_EXTENDED_REPORTS */
+		case MAX32664C_OP_MODE_SCD: {
+			/* Get all samples to clear the FIFO */
+			max32664c_i2c_transmit(
+				dev, tx, 2, data->max32664_i2c_buffer,
+				(fifo * (sizeof(struct max32664c_scd_report_t))) + 1,
+				MAX32664C_DEFAULT_CMD_DELAY);
+
+			if (data->max32664_i2c_buffer[0] != 0) {
+				break;
+			}
+
+			max32664c_parse_and_push_scd(dev);
+
+			break;
+		}
 		default: {
 			break;
 		}


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the MAX32664C driver, one
commit per issue:

- **Drain the FIFO in SCD only mode**: the worker thread had no case for the
  skin-contact-detection operating mode, so in SCD-only configurations no
  samples were ever read from the sensor and the whole pipeline was dead.
- **Fix skin contact channel data source**: `SENSOR_CHAN_MAX32664C_SKIN_CONTACT`
  always read `data->report.scd_state`, which is never populated in SCD mode
  (the classifier result lives in the SCD report) nor in builds using
  extended reports. Select the source that the active mode and build
  configuration actually fill in.
- **Fix motion config value truncation**: the motion time and motion
  threshold settings are 16-bit, but were passed through `uint8_t`
  parameters, silently corrupting any value above 255 — including the
  binding's own 500 mg default threshold.