### PR TITLE
net: Fixes for code-scanning alerts in subsys/net/l2

### DIFF
--- a/subsys/net/l2/canbus/canbus_raw.c
+++ b/subsys/net/l2/canbus/canbus_raw.c
@@ -30,14 +30,19 @@ static inline enum net_verdict canbus_recv(struct net_if *iface,
 
 static inline int canbus_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct canbus_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct canbus_api *api;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;
 	}
 
-	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
+	ret = net_l2_send(api->send, dev, iface, pkt);
 	if (!ret) {
 		ret = net_pkt_get_len(pkt);
 		net_pkt_unref(pkt);

--- a/subsys/net/l2/dummy/dummy.c
+++ b/subsys/net/l2/dummy/dummy.c
@@ -20,7 +20,12 @@ LOG_MODULE_REGISTER(net_l2_dummy, LOG_LEVEL_NONE);
 static inline enum net_verdict dummy_recv(struct net_if *iface,
 					  struct net_pkt *pkt)
 {
-	const struct dummy_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct dummy_api *api;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (api == NULL) {
 		return NET_DROP;
@@ -35,9 +40,14 @@ static inline enum net_verdict dummy_recv(struct net_if *iface,
 
 static inline int dummy_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct dummy_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct dummy_api *api;
 	size_t pkt_len;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;
@@ -49,7 +59,7 @@ static inline int dummy_send(struct net_if *iface, struct net_pkt *pkt)
 	 */
 	pkt_len = net_pkt_get_len(pkt);
 
-	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
+	ret = net_l2_send(api->send, dev, iface, pkt);
 	if (!ret) {
 		if (IS_ENABLED(CONFIG_NET_STATISTICS)) {
 			NET_DBG("Sending pkt %p len %zu", pkt, pkt_len);
@@ -66,7 +76,12 @@ static inline int dummy_send(struct net_if *iface, struct net_pkt *pkt)
 static inline int dummy_enable(struct net_if *iface, bool state)
 {
 	int ret = 0;
-	const struct dummy_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct dummy_api *api;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;
@@ -74,11 +89,11 @@ static inline int dummy_enable(struct net_if *iface, bool state)
 
 	if (!state) {
 		if (api->stop) {
-			ret = api->stop(net_if_get_device(iface));
+			ret = api->stop(dev);
 		}
 	} else {
 		if (api->start) {
-			ret = api->start(net_if_get_device(iface));
+			ret = api->start(dev);
 		}
 	}
 

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -60,6 +60,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	struct ud *br_user_data = user_data;
 	struct eth_bridge_iface_context *ctx;
 	enum virtual_interface_caps caps;
+	const struct device *dev;
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(VIRTUAL)) {
 		return;
@@ -70,7 +71,11 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		return;
 	}
 
-	ctx = net_if_get_device(iface)->data;
+	dev = net_if_get_device(iface);
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
 
 	br_user_data->cb(ctx, br_user_data->user_data);
 }
@@ -97,11 +102,17 @@ struct net_if *eth_bridge_get_by_index(int index)
 
 int eth_bridge_iface_add(struct net_if *br, struct net_if *iface)
 {
-	struct eth_bridge_iface_context *ctx = net_if_get_device(br)->data;
+	const struct device *dev = net_if_get_device(br);
+	struct eth_bridge_iface_context *ctx;
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 	bool found = false;
 	int count = 0;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+	NET_ASSERT(eth_ctx != NULL);
+
+	ctx = dev->data;
 
 #if defined(CONFIG_NET_DSA)
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET) ||
@@ -137,6 +148,8 @@ int eth_bridge_iface_add(struct net_if *br, struct net_if *iface)
 		/* Calculate how many interfaces are added to this bridge */
 		if (ctx->eth_iface[i] != NULL) {
 			struct ethernet_context *tmp = net_if_l2_data(ctx->eth_iface[i]);
+
+			NET_ASSERT(tmp != NULL);
 
 			if (tmp->bridge == br) {
 				count++;
@@ -194,10 +207,16 @@ int eth_bridge_iface_add(struct net_if *br, struct net_if *iface)
 
 int eth_bridge_iface_remove(struct net_if *br, struct net_if *iface)
 {
-	struct eth_bridge_iface_context *ctx = net_if_get_device(br)->data;
+	const struct device *dev = net_if_get_device(br);
+	struct eth_bridge_iface_context *ctx;
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
 	bool found = false;
 	int count = 0;
+
+	NET_ASSERT(dev != NULL);
+	NET_ASSERT(eth_ctx != NULL);
+
+	ctx = dev->data;
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
 		return -EINVAL;
@@ -225,6 +244,8 @@ int eth_bridge_iface_remove(struct net_if *br, struct net_if *iface)
 		/* Calculate how many interfaces are added to this bridge */
 		if (ctx->eth_iface[i] != NULL) {
 			struct ethernet_context *tmp = net_if_l2_data(ctx->eth_iface[i]);
+
+			NET_ASSERT(tmp != NULL);
 
 			if (tmp->bridge == br) {
 				count++;
@@ -346,9 +367,15 @@ static void unique_linkaddr(uint8_t *linkaddr, size_t len, uint8_t id)
 
 static void bridge_iface_init(struct net_if *iface)
 {
-	struct eth_bridge_iface_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct eth_bridge_iface_context *ctx;
 	struct virtual_interface_context *vctx = net_if_l2_data(iface);
 	char name[MAX_BRIDGE_NAME_LEN];
+
+	NET_ASSERT(dev != NULL);
+	NET_ASSERT(vctx != NULL);
+
+	ctx = dev->data;
 
 	k_mutex_init(&ctx->lock);
 
@@ -525,10 +552,15 @@ static struct net_pkt *bridge_resolve_local_dst(struct net_if *bridge, struct ne
 static enum net_verdict bridge_iface_send_process(struct net_if *iface,
 						  struct net_pkt *pkt)
 {
-	struct eth_bridge_iface_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct eth_bridge_iface_context *ctx;
 	struct net_if *orig_iface;
 	struct net_pkt *send_pkt;
 	int fwd_iface_num = 0;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
 
 	/* Resolve the destination link address of locally originated IPv4
 	 * traffic before flooding, otherwise the Ethernet layer defaults it to
@@ -613,7 +645,12 @@ int bridge_iface_send(struct net_if *iface, struct net_pkt *pkt)
 
 static enum net_verdict bridge_iface_recv(struct net_if *iface, struct net_pkt *pkt)
 {
-	struct eth_bridge_iface_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct eth_bridge_iface_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
 
 	if (DEBUG_RX) {
 		char str[sizeof("RX bridge xx")];

--- a/subsys/net/l2/ethernet/bridge/bridge_input.c
+++ b/subsys/net/l2/ethernet/bridge/bridge_input.c
@@ -100,6 +100,10 @@ static int eth_bridge_forward(struct net_if *bridge, struct net_if *orig_iface, 
 static enum net_verdict eth_bridge_handle_locally(struct net_if *bridge, struct net_if *orig_iface,
 						  struct net_pkt *pkt)
 {
+	const struct net_l2 *l2 = net_if_l2(bridge);
+
+	NET_ASSERT(l2 != NULL);
+
 	net_pkt_set_iface(pkt, bridge);
 	net_pkt_set_orig_iface(pkt, orig_iface);
 
@@ -107,9 +111,9 @@ static enum net_verdict eth_bridge_handle_locally(struct net_if *bridge, struct 
 		pkt, net_if_get_by_iface(bridge),
 		net_if_get_by_iface(orig_iface));
 
-	NET_ASSERT(net_if_l2(bridge)->recv != NULL);
+	NET_ASSERT(l2->recv != NULL);
 
-	return net_if_l2(bridge)->recv(bridge, pkt);
+	return l2->recv(bridge, pkt);
 }
 
 static inline bool is_link_local_addr(struct net_eth_addr *addr)
@@ -132,9 +136,13 @@ enum net_verdict eth_bridge_input_process(struct net_if *iface, struct net_pkt *
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	struct net_if *bridge = net_eth_get_bridge(ctx);
 	struct net_eth_addr *dst_addr = (struct net_eth_addr *)(net_pkt_lladdr_dst(pkt)->addr);
-	struct net_eth_addr *bridge_addr =
-		(struct net_eth_addr *)(net_if_get_link_addr(bridge)->addr);
+	struct net_linkaddr *bridge_lladdr = net_if_get_link_addr(bridge);
+	struct net_eth_addr *bridge_addr;
 	enum net_verdict verdict = NET_DROP;
+
+	NET_ASSERT(bridge_lladdr != NULL);
+
+	bridge_addr = (struct net_eth_addr *)bridge_lladdr->addr;
 
 	/* Lookup FDB table to forward */
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_FDB)

--- a/subsys/net/l2/ethernet/eth_stats.h
+++ b/subsys/net/l2/ethernet/eth_stats.h
@@ -17,7 +17,13 @@
 static inline struct net_stats_eth *eth_stats_get_common(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_api *api;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (api->get_stats_type != NULL) {
 		return api->get_stats_type(dev, iface, ETHERNET_STATS_TYPE_COMMON);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -220,7 +220,11 @@ static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_add
 	};
 
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_api *api;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	/* Make sure we're an ethernet device */
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
@@ -265,6 +269,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	bool is_vlan_pkt = false;
 	bool handled = false;
 	struct net_linkaddr *lladdr;
+	struct net_linkaddr *mac_addr;
 	uint16_t type;
 	bool dst_broadcast, dst_eth_multicast, dst_iface_addr;
 	struct net_if *iface_eth = iface;
@@ -339,11 +344,14 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	}
 
 	lladdr = net_pkt_lladdr_dst(pkt);
+	mac_addr = net_if_get_link_addr(iface);
+
+	NET_ASSERT(mac_addr != NULL);
 
 	net_pkt_set_ll_proto_type(pkt, type);
 	dst_broadcast = net_eth_is_addr_broadcast((struct net_eth_addr *)lladdr->addr);
 	dst_eth_multicast = net_eth_is_addr_multicast((struct net_eth_addr *)lladdr->addr);
-	dst_iface_addr = net_linkaddr_cmp(net_if_get_link_addr(iface), lladdr);
+	dst_iface_addr = net_linkaddr_cmp(mac_addr, lladdr);
 
 	if (is_vlan_pkt) {
 		print_vlan_ll_addrs(pkt, type, net_pkt_vlan_tci(pkt),
@@ -362,7 +370,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		 * are different.
 		 */
 		NET_DBG("Dropping frame, not for me [%s]",
-			net_sprint_ll_addr(net_if_get_link_addr(iface)->addr,
+			net_sprint_ll_addr(mac_addr->addr,
 					   sizeof(struct net_eth_addr)));
 		goto drop;
 	}
@@ -683,11 +691,16 @@ static void ethernet_update_tx_stats(struct net_if *iface, struct net_pkt *pkt)
 
 static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct ethernet_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *api;
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	uint16_t ptype = net_htons(net_pkt_ll_proto_type(pkt));
 	struct net_pkt *orig_pkt = pkt;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	NET_ASSERT(api != NULL);
 	NET_ASSERT(api->send != NULL);
@@ -771,7 +784,7 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 	net_pkt_cursor_init(pkt);
 
 send:
-	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
+	ret = net_l2_send(api->send, dev, iface, pkt);
 	if (ret != 0) {
 		eth_stats_update_errors_tx(iface);
 		goto arp_error;
@@ -806,9 +819,13 @@ arp_error:
 static inline int ethernet_enable(struct net_if *iface, bool state)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *eth = dev->api;
+	const struct ethernet_api *eth;
 	struct net_linkaddr *mac_addr;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	eth = dev->api;
 
 	NET_ASSERT(eth != NULL);
 
@@ -839,6 +856,8 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 	 */
 	mac_addr = net_if_get_link_addr(iface);
 
+	NET_ASSERT(mac_addr != NULL);
+
 	if ((mac_addr->len != NET_ETH_ADDR_LEN) ||
 	    !net_eth_is_addr_valid((struct net_eth_addr *)mac_addr->addr)) {
 		NET_ERR("Invalid MAC address for iface %d (%p)", net_if_get_by_iface(iface), iface);
@@ -851,6 +870,8 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 enum net_l2_flags ethernet_flags(struct net_if *iface)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	return ctx->ethernet_l2_flags;
 }
@@ -911,6 +932,8 @@ void net_eth_carrier_set(struct net_if *iface, bool carrier_up)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	if (atomic_test_and_set_bit_to(&ctx->flags, ETH_CARRIER_UP, carrier_up)) {
 		k_work_submit(&ctx->carrier_work);
 	}
@@ -919,7 +942,11 @@ void net_eth_carrier_set(struct net_if *iface, bool carrier_up)
 const struct device *net_eth_get_phy(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_api *api;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	NET_ASSERT(api != NULL);
 
@@ -938,7 +965,11 @@ const struct device *net_eth_get_phy(struct net_if *iface)
 const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_api *api;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	NET_ASSERT(api != NULL);
 
@@ -1038,6 +1069,8 @@ void ethernet_init(struct net_if *iface)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	enum ethernet_hw_caps caps;
+
+	NET_ASSERT(ctx != NULL);
 
 	NET_DBG("Initializing Ethernet L2 %p for iface %d (%p)", ctx,
 		net_if_get_by_iface(iface), iface);

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -32,10 +32,14 @@ static int ethernet_set_config(uint64_t mgmt_request,
 {
 	struct ethernet_req_params *params = (struct ethernet_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_api *api;
 	struct ethernet_config config = { 0 };
 	enum ethernet_config_type type;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;
@@ -214,10 +218,14 @@ static int ethernet_get_config(uint64_t mgmt_request,
 {
 	struct ethernet_req_params *params = (struct ethernet_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_api *api;
 	struct ethernet_config config = { 0 };
 	int ret = 0;
 	enum ethernet_config_type type;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -41,7 +41,11 @@ struct gptp_clock_data gptp_clock;
 int gptp_get_port_number(struct net_if *iface)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	int port = ctx->gptp_port;
+	int port;
+
+	NET_ASSERT(ctx != NULL);
+
+	port = ctx->gptp_port;
 
 	if (port >= GPTP_PORT_START && port <= GPTP_PORT_END) {
 		return port;
@@ -53,6 +57,8 @@ int gptp_set_port_number(struct net_if *iface, uint16_t port)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	const struct device *clk;
+
+	NET_ASSERT(ctx != NULL);
 
 	clk = net_eth_get_ptp_clock(iface);
 	if (clk == NULL) {
@@ -83,18 +89,23 @@ static void gptp_compute_clock_identity(int port)
 {
 	struct net_if *iface = GPTP_PORT_IFACE(port);
 	struct gptp_default_ds *default_ds;
+	struct net_linkaddr *ll_addr;
 
 	default_ds = GPTP_DEFAULT_DS();
 
 	if (iface) {
-		default_ds->clk_id[0] = net_if_get_link_addr(iface)->addr[0];
-		default_ds->clk_id[1] = net_if_get_link_addr(iface)->addr[1];
-		default_ds->clk_id[2] = net_if_get_link_addr(iface)->addr[2];
+		ll_addr = net_if_get_link_addr(iface);
+
+		NET_ASSERT(ll_addr != NULL);
+
+		default_ds->clk_id[0] = ll_addr->addr[0];
+		default_ds->clk_id[1] = ll_addr->addr[1];
+		default_ds->clk_id[2] = ll_addr->addr[2];
 		default_ds->clk_id[3] = 0xFF;
 		default_ds->clk_id[4] = 0xFE;
-		default_ds->clk_id[5] = net_if_get_link_addr(iface)->addr[3];
-		default_ds->clk_id[6] = net_if_get_link_addr(iface)->addr[4];
-		default_ds->clk_id[7] = net_if_get_link_addr(iface)->addr[5];
+		default_ds->clk_id[5] = ll_addr->addr[3];
+		default_ds->clk_id[6] = ll_addr->addr[4];
+		default_ds->clk_id[7] = ll_addr->addr[5];
 	}
 }
 

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -557,7 +557,14 @@ static void gptp_state_machine(void)
 
 	/* Manage port states. */
 	for (port = GPTP_PORT_START; port <= GPTP_PORT_END; port++) {
-		struct gptp_port_ds *port_ds = GPTP_PORT_DS(port);
+		struct gptp_port_ds *port_ds;
+
+		/* gptp_add_port() never registers more ports than the per-port
+		 * arrays can hold, so this only makes that bound explicit.
+		 */
+		NET_ASSERT(GPTP_PORT_INDEX(port) < CONFIG_NET_GPTP_NUM_PORTS);
+
+		port_ds = GPTP_PORT_DS(port);
 
 		/* If interface is down, don't move forward */
 		if (net_if_flag_is_set(GPTP_PORT_IFACE(port), NET_IF_UP)) {

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -640,6 +640,11 @@ static void gptp_mi_site_ss_send_to_pss(void)
 	state = &GPTP_STATE()->site_ss;
 
 	for (port = GPTP_PORT_START; port <= GPTP_PORT_END; port++) {
+		/* gptp_add_port() never registers more ports than the per-port
+		 * arrays can hold, so this only makes that bound explicit.
+		 */
+		NET_ASSERT(GPTP_PORT_INDEX(port) < CONFIG_NET_GPTP_NUM_PORTS);
+
 		pss_send = &GPTP_PORT_STATE(port)->pss_send;
 		pss_send->pss_sync_ptr = &state->pss_send;
 		pss_send->rcvd_pss_sync = true;

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -107,6 +107,7 @@ static struct vlan_context *get_vlan_ctx(struct net_if *main_iface,
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(interfaces, vctx, tmp, node) {
 		enum virtual_interface_caps caps;
+		const struct device *dev;
 
 		if (vctx->virtual_iface == NULL) {
 			continue;
@@ -117,7 +118,11 @@ static struct vlan_context *get_vlan_ctx(struct net_if *main_iface,
 			continue;
 		}
 
-		ctx = net_if_get_device(vctx->virtual_iface)->data;
+		dev = net_if_get_device(vctx->virtual_iface);
+
+		NET_ASSERT(dev != NULL);
+
+		ctx = dev->data;
 
 		if (any_tag) {
 			if (ctx->tag != NET_VLAN_TAG_UNSPEC) {
@@ -340,6 +345,8 @@ static void setup_link_address(struct vlan_context *ctx)
 
 	ll_addr = net_if_get_link_addr(ctx->attached_to);
 
+	NET_ASSERT(ll_addr != NULL);
+
 	(void)net_if_set_link_addr(ctx->iface,
 				   ll_addr->addr,
 				   ll_addr->len,
@@ -349,9 +356,15 @@ static void setup_link_address(struct vlan_context *ctx)
 int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	const struct ethernet_api *eth = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *eth;
 	struct vlan_context *vlan;
 	int ret;
+
+	NET_ASSERT(ctx != NULL);
+	NET_ASSERT(dev != NULL);
+
+	eth = dev->api;
 
 	if (!eth) {
 		return -ENOENT;
@@ -414,8 +427,7 @@ int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 		setup_link_address(vlan);
 
 		if (eth->vlan_setup) {
-			eth->vlan_setup(net_if_get_device(iface),
-					iface, vlan->tag, true);
+			eth->vlan_setup(dev, iface, vlan->tag, true);
 		}
 
 		ethernet_mgmt_raise_vlan_enabled_event(vlan->iface, vlan->tag);
@@ -432,6 +444,7 @@ int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
 {
 	const struct ethernet_api *eth;
+	const struct device *dev;
 	struct vlan_context *vlan;
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET) &&
@@ -448,7 +461,13 @@ int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
 		return -ESRCH;
 	}
 
-	eth = net_if_get_device(vlan->attached_to)->api;
+	dev = net_if_get_device(vlan->attached_to);
+
+	NET_ASSERT(dev != NULL);
+
+	eth = dev->api;
+
+	NET_ASSERT(eth != NULL);
 
 	k_mutex_lock(&lock, K_FOREVER);
 
@@ -459,8 +478,7 @@ int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
 	vlan->tag = NET_VLAN_TAG_UNSPEC;
 
 	if (eth->vlan_setup) {
-		eth->vlan_setup(net_if_get_device(vlan->attached_to),
-				vlan->attached_to, tag, false);
+		eth->vlan_setup(dev, vlan->attached_to, tag, false);
 	}
 
 	ethernet_mgmt_raise_vlan_disabled_event(vlan->iface, tag);
@@ -531,7 +549,14 @@ static int vlan_interface_stop(const struct device *dev)
 
 static int vlan_interface_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	struct vlan_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct vlan_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (ctx->attached_to == NULL) {
 		return -ENOENT;
@@ -557,7 +582,14 @@ static int vlan_interface_send(struct net_if *iface, struct net_pkt *pkt)
 static enum net_verdict vlan_interface_recv(struct net_if *iface,
 					    struct net_pkt *pkt)
 {
-	struct vlan_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct vlan_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (net_pkt_vlan_tag(pkt) != ctx->tag) {
 		return NET_CONTINUE;
@@ -607,7 +639,14 @@ int vlan_alloc_buffer(struct net_if *iface, struct net_pkt *pkt, size_t size,
 static int vlan_interface_attach(struct net_if *vlan_iface,
 				 struct net_if *iface)
 {
-	struct vlan_context *ctx = net_if_get_device(vlan_iface)->data;
+	const struct device *dev = net_if_get_device(vlan_iface);
+	struct vlan_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (iface == NULL) {
 		NET_DBG("VLAN interface %d (%p) detached from %d (%p)",
@@ -626,7 +665,14 @@ static int vlan_interface_attach(struct net_if *vlan_iface,
 
 static void vlan_iface_init(struct net_if *iface)
 {
-	struct vlan_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct vlan_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -111,6 +111,8 @@ inline bool ieee802154_prepare_for_ack(struct net_if *iface, struct net_pkt *pkt
 		struct ieee802154_fcf_seq *fs = (struct ieee802154_fcf_seq *)frag->data;
 		struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+		NET_ASSERT(ctx != NULL);
+
 		ctx->ack_seq = fs->sequence;
 		if (k_sem_count_get(&ctx->ack_lock) == 1U) {
 			k_sem_take(&ctx->ack_lock, K_NO_WAIT);
@@ -125,6 +127,8 @@ inline bool ieee802154_prepare_for_ack(struct net_if *iface, struct net_pkt *pkt
 enum net_verdict ieee802154_handle_ack(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	if (ieee802154_radio_get_hw_capabilities(iface) & IEEE802154_HW_TX_RX_ACK) {
 		__ASSERT_NO_MSG(ctx->ack_seq == 0U);
@@ -155,6 +159,8 @@ inline int ieee802154_wait_for_ack(struct net_if *iface, bool ack_required)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	int ret;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (!ack_required ||
 	    (ieee802154_radio_get_hw_capabilities(iface) & IEEE802154_HW_TX_RX_ACK)) {
@@ -298,6 +304,8 @@ static bool ieee802154_check_dst_addr(struct net_if *iface, struct ieee802154_mh
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	bool ret = false;
 
+	NET_ASSERT(ctx != NULL);
+
 	/* Apply filtering requirements from section 6.7.2 c)-e). For a)-b),
 	 * see ieee802154_parse_fcf_seq()
 	 */
@@ -366,12 +374,18 @@ out:
 
 static enum net_verdict ieee802154_recv(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct ieee802154_radio_api *radio = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
 	enum net_verdict verdict = NET_CONTINUE;
 	struct ieee802154_fcf_seq *fs;
 	struct ieee802154_mpdu mpdu;
 	bool is_broadcast;
 	size_t ll_hdr_len;
+
+	NET_ASSERT(dev != NULL);
+	NET_ASSERT(dev->api != NULL);
+
+	radio = dev->api;
 
 	/* The IEEE 802.15.4 stack assumes that drivers provide a single-fragment package. */
 	__ASSERT_NO_MSG(pkt->buffer && pkt->buffer->frags == NULL);
@@ -381,7 +395,7 @@ static enum net_verdict ieee802154_recv(struct net_if *iface, struct net_pkt *pk
 	}
 
 	/* validate LL destination address (when IEEE802154_HW_FILTER not available) */
-	if (!(radio->get_capabilities(net_if_get_device(iface)) & IEEE802154_HW_FILTER) &&
+	if (!(radio->get_capabilities(dev) & IEEE802154_HW_FILTER) &&
 	    !ieee802154_check_dst_addr(iface, &mpdu.mhr)) {
 		return NET_DROP;
 	}
@@ -513,6 +527,9 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 	struct ieee802154_6lo_fragment_ctx frag_ctx;
 #endif
 
+	NET_ASSERT(iface != NULL);
+	NET_ASSERT(ctx != NULL);
+
 	if (frame_buf == NULL) {
 		frame_buf = net_buf_alloc(&tx_frame_buf_pool, K_FOREVER);
 	}
@@ -641,6 +658,8 @@ static int ieee802154_enable(struct net_if *iface, bool state)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	NET_DBG("iface %p %s", iface, state ? "up" : "down");
 
 	k_sem_take(&ctx->ctx_lock, K_FOREVER);
@@ -663,6 +682,8 @@ static enum net_l2_flags ieee802154_flags(struct net_if *iface)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	/* No need for locking as these flags are set once
 	 * during L2 initialization and then never changed.
 	 */
@@ -674,8 +695,14 @@ NET_L2_INIT(IEEE802154_L2, ieee802154_recv, ieee802154_send, ieee802154_enable, 
 void ieee802154_init(struct net_if *iface)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
-	const uint8_t *eui64_be = net_if_get_link_addr(iface)->addr;
+	struct net_linkaddr *link_addr = net_if_get_link_addr(iface);
 	int16_t tx_power = CONFIG_NET_L2_IEEE802154_RADIO_DFLT_TX_POWER;
+	const uint8_t *eui64_be;
+
+	NET_ASSERT(ctx != NULL);
+	NET_ASSERT(link_addr != NULL);
+
+	eui64_be = link_addr->addr;
 
 	NET_DBG("Initializing IEEE 802.15.4 stack on iface %p", iface);
 

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -472,6 +472,8 @@ void ieee802154_compute_header_and_authtag_len(struct net_if *iface, struct net_
 
 	ctx = (struct ieee802154_context *)net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	k_sem_take(&ctx->ctx_lock, K_FOREVER);
 
 	sec_ctx = &ctx->sec_ctx;
@@ -890,6 +892,8 @@ struct net_pkt *ieee802154_create_mac_cmd_frame(struct net_if *iface, enum ieee8
 	struct net_pkt *pkt = NULL;
 	uint8_t *p_buf, *p_start;
 
+	NET_ASSERT(ctx != NULL);
+
 	k_sem_take(&ctx->ctx_lock, K_FOREVER);
 
 	/* It would be costly to compute the size when actual frames are never
@@ -972,6 +976,8 @@ bool ieee802154_decipher_data_frame(struct net_if *iface, struct net_pkt *pkt,
 	struct ieee802154_mhr *mhr = &mpdu->mhr;
 	struct ieee802154_address *src;
 	bool ret = false;
+
+	NET_ASSERT(ctx != NULL);
 
 	k_sem_take(&ctx->ctx_lock, K_FOREVER);
 

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -40,6 +40,8 @@ enum net_verdict ieee802154_handle_beacon(struct net_if *iface,
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	int beacon_hdr_len;
 
+	NET_ASSERT(ctx != NULL);
+
 	NET_DBG("Beacon received");
 
 	if (!ctx->scan_ctx) {
@@ -80,6 +82,8 @@ static int ieee802154_cancel_scan(uint64_t mgmt_request, struct net_if *iface,
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	ARG_UNUSED(data);
 	ARG_UNUSED(len);
 
@@ -104,6 +108,8 @@ static int ieee802154_scan(uint64_t mgmt_request, struct net_if *iface,
 	struct ieee802154_req_params *scan;
 	struct net_pkt *pkt = NULL;
 	int ret;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (len != sizeof(struct ieee802154_req_params) || !data) {
 		return -EINVAL;
@@ -313,6 +319,8 @@ enum net_verdict ieee802154_handle_mac_command(struct net_if *iface,
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	if (mpdu->command->cfi == IEEE802154_CFI_ASSOCIATION_RESPONSE) {
 		if (mpdu->command->assoc_res.status !=
 		    IEEE802154_ASF_SUCCESSFUL) {
@@ -444,6 +452,8 @@ static int ieee802154_associate(uint64_t mgmt_request, struct net_if *iface,
 	struct ieee802154_command *cmd;
 	struct net_pkt *pkt;
 	int ret = 0;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (len != sizeof(struct ieee802154_req_params) || !data) {
 		NET_ERR("Could not associate: invalid request");
@@ -665,6 +675,8 @@ static int ieee802154_disassociate(uint64_t mgmt_request, struct net_if *iface,
 	struct ieee802154_command *cmd;
 	struct net_pkt *pkt;
 
+	NET_ASSERT(ctx != NULL);
+
 	ARG_UNUSED(data);
 	ARG_UNUSED(len);
 
@@ -738,6 +750,8 @@ static int ieee802154_set_ack(uint64_t mgmt_request, struct net_if *iface,
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	ARG_UNUSED(data);
 	ARG_UNUSED(len);
 
@@ -767,6 +781,8 @@ static int ieee802154_set_parameters(uint64_t mgmt_request,
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	uint16_t value;
 	int ret = 0;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (!data) {
 		return -EINVAL;
@@ -822,14 +838,17 @@ static int ieee802154_set_parameters(uint64_t mgmt_request,
 	} else if (mgmt_request == NET_REQUEST_IEEE802154_SET_COORD_SHORT_ADDR) {
 		ctx->coord_short_addr = value;
 	} else if (mgmt_request == NET_REQUEST_IEEE802154_SET_EXT_ADDR) {
+		struct net_linkaddr *link_addr = net_if_get_link_addr(iface);
 		uint8_t ext_addr_le[IEEE802154_EXT_ADDR_LENGTH];
+
+		NET_ASSERT(link_addr != NULL);
 
 		sys_memcpy_swap(ext_addr_le, data, IEEE802154_EXT_ADDR_LENGTH);
 
 		if (memcmp(ctx->ext_addr, ext_addr_le, IEEE802154_EXT_ADDR_LENGTH)) {
 			memcpy(ctx->ext_addr, ext_addr_le, IEEE802154_EXT_ADDR_LENGTH);
 
-			if (net_if_get_link_addr(iface)->len == IEEE802154_EXT_ADDR_LENGTH) {
+			if (link_addr->len == IEEE802154_EXT_ADDR_LENGTH) {
 				set_linkaddr_to_ext_addr(iface, ctx);
 			}
 
@@ -896,6 +915,8 @@ static int ieee802154_get_parameters(uint64_t mgmt_request,
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	uint16_t *value;
 	int ret = 0;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (!data) {
 		return -EINVAL;
@@ -971,6 +992,8 @@ static int ieee802154_set_security_settings(uint64_t mgmt_request,
 	struct ieee802154_security_params *params;
 	int ret = 0;
 
+	NET_ASSERT(ctx != NULL);
+
 	if (len != sizeof(struct ieee802154_security_params) || !data) {
 		return -EINVAL;
 	}
@@ -1008,6 +1031,8 @@ static int ieee802154_get_security_settings(uint64_t mgmt_request,
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	struct ieee802154_security_params *params;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (len != sizeof(struct ieee802154_security_params) || !data) {
 		return -EINVAL;

--- a/subsys/net/l2/ieee802154/ieee802154_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_utils.h
@@ -15,6 +15,7 @@
 #define __IEEE802154_UTILS_H__
 
 #include <zephyr/net/ieee802154_radio.h>
+#include <zephyr/net/net_core.h>
 #include <zephyr/net/net_log.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -24,101 +25,133 @@
 
 static inline enum ieee802154_hw_caps ieee802154_radio_get_hw_capabilities(struct net_if *iface)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio) {
 		return 0;
 	}
 
-	return radio->get_capabilities(net_if_get_device(iface));
+	return radio->get_capabilities(dev);
 }
 
 static inline int ieee802154_radio_cca(struct net_if *iface)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio) {
 		return -ENOENT;
 	}
 
-	return radio->cca(net_if_get_device(iface));
+	return radio->cca(dev);
 }
 
 static inline int ieee802154_radio_set_channel(struct net_if *iface, uint16_t channel)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio) {
 		return -ENOENT;
 	}
 
-	return radio->set_channel(net_if_get_device(iface), channel);
+	return radio->set_channel(dev, channel);
 }
 
 static inline int ieee802154_radio_set_tx_power(struct net_if *iface, int16_t dbm)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio) {
 		return -ENOENT;
 	}
 
-	return radio->set_txpower(net_if_get_device(iface), dbm);
+	return radio->set_txpower(dev, dbm);
 }
 
 static inline int ieee802154_radio_tx(struct net_if *iface, enum ieee802154_tx_mode mode,
 				      struct net_pkt *pkt, struct net_buf *buf)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio) {
 		return -ENOENT;
 	}
 
-	return radio->tx(net_if_get_device(iface), mode, pkt, buf);
+	return radio->tx(dev, mode, pkt, buf);
 }
 
 static inline int ieee802154_radio_start(struct net_if *iface)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio) {
 		return -ENOENT;
 	}
 
-	return radio->start(net_if_get_device(iface));
+	return radio->start(dev);
 }
 
 static inline int ieee802154_radio_stop(struct net_if *iface)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio) {
 		return -ENOENT;
 	}
 
-	return radio->stop(net_if_get_device(iface));
+	return radio->stop(dev);
 }
 
 static inline int ieee802154_radio_attr_get(struct net_if *iface,
 					    enum ieee802154_attr attr,
 					    struct ieee802154_attr_value *value)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (!radio || !radio->attr_get) {
 		return -ENOENT;
 	}
 
-	return radio->attr_get(net_if_get_device(iface), attr, value);
+	return radio->attr_get(dev, attr, value);
 }
 
 /**
@@ -129,16 +162,20 @@ static inline int ieee802154_radio_attr_get(struct net_if *iface,
  */
 static inline void ieee802154_radio_filter_ieee_addr(struct net_if *iface, uint8_t *ieee_addr)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
+
+	if (radio && (radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.ieee_addr = ieee_addr;
 
-		if (radio->filter(net_if_get_device(iface), true,
+		if (radio->filter(dev, true,
 				  IEEE802154_FILTER_TYPE_IEEE_ADDR,
 				  &filter) != 0) {
 			NET_WARN("Could not apply IEEE address filter");
@@ -148,16 +185,20 @@ static inline void ieee802154_radio_filter_ieee_addr(struct net_if *iface, uint8
 
 static inline void ieee802154_radio_filter_short_addr(struct net_if *iface, uint16_t short_addr)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
+
+	if (radio && (radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.short_addr = short_addr;
 
-		if (radio->filter(net_if_get_device(iface), true,
+		if (radio->filter(dev, true,
 				  IEEE802154_FILTER_TYPE_SHORT_ADDR,
 				  &filter) != 0) {
 			NET_WARN("Could not apply short address filter");
@@ -167,16 +208,20 @@ static inline void ieee802154_radio_filter_short_addr(struct net_if *iface, uint
 
 static inline void ieee802154_radio_filter_pan_id(struct net_if *iface, uint16_t pan_id)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
+
+	if (radio && (radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.pan_id = pan_id;
 
-		if (radio->filter(net_if_get_device(iface), true,
+		if (radio->filter(dev, true,
 				  IEEE802154_FILTER_TYPE_PAN_ID,
 				  &filter) != 0) {
 			NET_WARN("Could not apply PAN ID filter");
@@ -186,16 +231,20 @@ static inline void ieee802154_radio_filter_pan_id(struct net_if *iface, uint16_t
 
 static inline void ieee802154_radio_filter_src_ieee_addr(struct net_if *iface, uint8_t *ieee_addr)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
+
+	if (radio && (radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.ieee_addr = ieee_addr;
 
-		if (radio->filter(net_if_get_device(iface), true,
+		if (radio->filter(dev, true,
 				  IEEE802154_FILTER_TYPE_SRC_IEEE_ADDR,
 				  &filter) != 0) {
 			NET_WARN("Could not apply SRC IEEE address filter");
@@ -205,16 +254,20 @@ static inline void ieee802154_radio_filter_src_ieee_addr(struct net_if *iface, u
 
 static inline void ieee802154_radio_filter_src_short_addr(struct net_if *iface, uint16_t short_addr)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
+
+	if (radio && (radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.short_addr = short_addr;
 
-		if (radio->filter(net_if_get_device(iface), true,
+		if (radio->filter(dev, true,
 				  IEEE802154_FILTER_TYPE_SRC_SHORT_ADDR,
 				  &filter) != 0) {
 			NET_WARN("Could not apply SRC short address filter");
@@ -224,16 +277,20 @@ static inline void ieee802154_radio_filter_src_short_addr(struct net_if *iface, 
 
 static inline void ieee802154_radio_remove_src_ieee_addr(struct net_if *iface, uint8_t *ieee_addr)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
+
+	if (radio && (radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.ieee_addr = ieee_addr;
 
-		if (radio->filter(net_if_get_device(iface), false,
+		if (radio->filter(dev, false,
 				  IEEE802154_FILTER_TYPE_SRC_IEEE_ADDR,
 				  &filter) != 0) {
 			NET_WARN("Could not remove SRC IEEE address filter");
@@ -243,17 +300,21 @@ static inline void ieee802154_radio_remove_src_ieee_addr(struct net_if *iface, u
 
 static inline void ieee802154_radio_remove_src_short_addr(struct net_if *iface, uint16_t short_addr)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (radio && (short_addr != IEEE802154_SHORT_ADDRESS_NOT_ASSOCIATED) &&
-		(radio->get_capabilities(net_if_get_device(iface)) &
+		(radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.short_addr = short_addr;
 
-		if (radio->filter(net_if_get_device(iface), false,
+		if (radio->filter(dev, false,
 				  IEEE802154_FILTER_TYPE_SRC_SHORT_ADDR,
 				  &filter) != 0) {
 			NET_WARN("Could not remove SRC short address filter");
@@ -263,17 +324,21 @@ static inline void ieee802154_radio_remove_src_short_addr(struct net_if *iface, 
 
 static inline void ieee802154_radio_remove_pan_id(struct net_if *iface, uint16_t pan_id)
 {
-	const struct ieee802154_radio_api *radio =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ieee802154_radio_api *radio;
+
+	NET_ASSERT(dev != NULL);
+
+	radio = dev->api;
 
 	if (radio && (pan_id != IEEE802154_PAN_ID_NOT_ASSOCIATED) &&
-		(radio->get_capabilities(net_if_get_device(iface)) &
+		(radio->get_capabilities(dev) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
 		filter.pan_id = pan_id;
 
-		if (radio->filter(net_if_get_device(iface), false,
+		if (radio->filter(dev, false,
 				  IEEE802154_FILTER_TYPE_PAN_ID,
 				  &filter) != 0) {
 			NET_WARN("Could not remove PAN ID filter");

--- a/subsys/net/l2/offloaded_netdev/offloaded_netdev.c
+++ b/subsys/net/l2/offloaded_netdev/offloaded_netdev.c
@@ -10,7 +10,12 @@
 
 static inline int offloaded_netdev_if_enable(struct net_if *iface, bool state)
 {
-	const struct offloaded_if_api *off_if = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct offloaded_if_api *off_if;
+
+	NET_ASSERT(dev != NULL);
+
+	off_if = dev->api;
 
 	if (!off_if || !(off_if->enable)) {
 		return 0;

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -49,7 +49,8 @@ struct net_if *ppp_fsm_iface(struct ppp_fsm *fsm)
 {
 	struct ppp_context *ctx = ppp_fsm_ctx(fsm);
 
-	NET_ASSERT(ctx->iface);
+	NET_ASSERT(ctx != NULL);
+	NET_ASSERT(ctx->iface != NULL);
 
 	return ctx->iface;
 }
@@ -57,6 +58,8 @@ struct net_if *ppp_fsm_iface(struct ppp_fsm *fsm)
 static bool ppp_fsm_is_dead(struct ppp_fsm *fsm)
 {
 	struct ppp_context *ctx = ppp_fsm_ctx(fsm);
+
+	NET_ASSERT(ctx != NULL);
 
 	return ctx->phase == PPP_DEAD;
 }
@@ -414,6 +417,8 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 	switch (type) {
 	case PPP_CODE_REJ: {
 		struct ppp_context *ctx = ppp_fsm_ctx(fsm);
+
+		NET_ASSERT(ctx != NULL);
 
 		len = net_pkt_get_len(req_pkt);
 		len = MIN(len, ctx->lcp.my_options.mru);
@@ -1043,6 +1048,8 @@ enum net_verdict ppp_fsm_input(struct ppp_fsm *fsm, uint16_t proto,
 	uint16_t length;
 	int ret;
 	struct ppp_context *ctx = ppp_fsm_ctx(fsm);
+
+	NET_ASSERT(ctx != NULL);
 
 	ret = net_pkt_read_u8(pkt, &code);
 	if (ret < 0) {

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -32,10 +32,11 @@ static int ipv6cp_add_iid(struct ppp_context *ctx, struct net_pkt *pkt)
 {
 	uint8_t *iid = ctx->ipv6cp.my_options.iid;
 	size_t iid_len = sizeof(ctx->ipv6cp.my_options.iid);
-	struct net_linkaddr *linkaddr;
+	struct net_linkaddr *linkaddr = net_if_get_link_addr(ctx->iface);
 	int ret;
 
-	linkaddr = net_if_get_link_addr(ctx->iface);
+	NET_ASSERT(linkaddr != NULL);
+
 	if (linkaddr->len == 8) {
 		memcpy(iid, linkaddr->addr, iid_len);
 	} else {

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -81,6 +81,8 @@ static enum net_verdict process_ppp_msg(struct net_if *iface,
 	uint8_t hi;
 	int ret;
 
+	NET_ASSERT(ctx != NULL);
+
 	if (!ctx->is_ready_to_serve) {
 		goto quit;
 	}
@@ -194,9 +196,17 @@ static enum net_verdict ppp_recv(struct net_if *iface,
 
 static int ppp_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct ppp_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
 	struct ppp_context *ctx = net_if_l2_data(iface);
+	const struct ppp_api *api;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+	NET_ASSERT(ctx != NULL);
+
+	api = dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG) {
 		net_pkt_hexdump(pkt, "send L2");
@@ -227,7 +237,7 @@ static int ppp_send(struct net_if *iface, struct net_pkt *pkt)
 		}
 	}
 
-	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
+	ret = net_l2_send(api->send, dev, iface, pkt);
 	if (!ret) {
 		ret = net_pkt_get_len(pkt);
 		ppp_update_tx_stats(iface, pkt, ret);
@@ -240,6 +250,8 @@ static int ppp_send(struct net_if *iface, struct net_pkt *pkt)
 static enum net_l2_flags ppp_flags(struct net_if *iface)
 {
 	struct ppp_context *ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	return ctx->ppp_l2_flags;
 }
@@ -257,10 +269,17 @@ static void ppp_open_async(struct ppp_context *ctx)
 
 static int ppp_up(struct net_if *iface)
 {
-	const struct ppp_api *ppp = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ppp_api *ppp;
+
+	NET_ASSERT(dev != NULL);
+
+	ppp = dev->api;
+
+	NET_ASSERT(ppp != NULL);
 
 	if (ppp->start) {
-		ppp->start(net_if_get_device(iface));
+		ppp->start(dev);
 	}
 
 	return 0;
@@ -327,8 +346,15 @@ static int ppp_lcp_lower_down(struct ppp_context *ctx)
 /* Bring down network interface by terminating all protocols */
 static int ppp_down(struct net_if *iface)
 {
-	const struct ppp_api *ppp = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
 	struct ppp_context *ctx = net_if_l2_data(iface);
+	const struct ppp_api *ppp;
+
+	NET_ASSERT(dev != NULL);
+
+	ppp = dev->api;
+
+	NET_ASSERT(ppp != NULL);
 
 	if (net_if_is_carrier_ok(iface)) {
 		/* Terminate protocols and close LCP */
@@ -344,7 +370,7 @@ static int ppp_down(struct net_if *iface)
 
 	if (ppp->stop) {
 		/* Inform L2 PPP device that PPP link is down */
-		ppp->stop(net_if_get_device(iface));
+		ppp->stop(dev);
 	}
 
 	return 0;
@@ -354,6 +380,8 @@ static int ppp_enable(struct net_if *iface, bool state)
 {
 	struct ppp_context *ctx = net_if_l2_data(iface);
 	int ret;
+
+	NET_ASSERT(ctx != NULL);
 
 	/* Set the desired network interface state */
 	ctx->is_enabled = state;
@@ -381,6 +409,9 @@ uint32_t ppp_peer_async_control_character_map(struct net_if *iface)
 	__ASSERT(net_if_l2(iface) == &NET_L2_GET_NAME(PPP), "Not PPP L2");
 #endif /* !CONFIG_ZTEST */
 	ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
+
 	if (ctx->phase < PPP_NETWORK) {
 		return NET_PPP_DEFAULT_ASYNC_MAP;
 	}
@@ -554,6 +585,8 @@ void net_ppp_init(struct net_if *iface)
 {
 	struct ppp_context *ctx = net_if_l2_data(iface);
 	uint8_t count = 0;
+
+	NET_ASSERT(ctx != NULL);
 
 	NET_DBG("Initializing PPP L2 %p for iface %p", ctx, iface);
 

--- a/subsys/net/l2/ppp/ppp_stats.h
+++ b/subsys/net/l2/ppp/ppp_stats.h
@@ -16,15 +16,21 @@
 static inline void ppp_stats_update_bytes_rx(struct net_if *iface,
 					     uint32_t bytes)
 {
-	const struct ppp_api *api = (const struct ppp_api *)
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ppp_api *api;
 	struct net_stats_ppp *stats;
+
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct ppp_api *)dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (!api->get_stats) {
 		return;
 	}
 
-	stats = api->get_stats(net_if_get_device(iface));
+	stats = api->get_stats(dev);
 	if (!stats) {
 		return;
 	}
@@ -35,15 +41,21 @@ static inline void ppp_stats_update_bytes_rx(struct net_if *iface,
 static inline void ppp_stats_update_bytes_tx(struct net_if *iface,
 					     uint32_t bytes)
 {
-	const struct ppp_api *api = (const struct ppp_api *)
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ppp_api *api;
 	struct net_stats_ppp *stats;
+
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct ppp_api *)dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (!api->get_stats) {
 		return;
 	}
 
-	stats = api->get_stats(net_if_get_device(iface));
+	stats = api->get_stats(dev);
 	if (!stats) {
 		return;
 	}
@@ -53,15 +65,21 @@ static inline void ppp_stats_update_bytes_tx(struct net_if *iface,
 
 static inline void ppp_stats_update_pkts_rx(struct net_if *iface)
 {
-	const struct ppp_api *api = (const struct ppp_api *)
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ppp_api *api;
 	struct net_stats_ppp *stats;
+
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct ppp_api *)dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (!api->get_stats) {
 		return;
 	}
 
-	stats = api->get_stats(net_if_get_device(iface));
+	stats = api->get_stats(dev);
 	if (!stats) {
 		return;
 	}
@@ -71,15 +89,21 @@ static inline void ppp_stats_update_pkts_rx(struct net_if *iface)
 
 static inline void ppp_stats_update_pkts_tx(struct net_if *iface)
 {
-	const struct ppp_api *api = (const struct ppp_api *)
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ppp_api *api;
 	struct net_stats_ppp *stats;
+
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct ppp_api *)dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (!api->get_stats) {
 		return;
 	}
 
-	stats = api->get_stats(net_if_get_device(iface));
+	stats = api->get_stats(dev);
 	if (!stats) {
 		return;
 	}
@@ -89,15 +113,21 @@ static inline void ppp_stats_update_pkts_tx(struct net_if *iface)
 
 static inline void ppp_stats_update_drop_rx(struct net_if *iface)
 {
-	const struct ppp_api *api = ((const struct ppp_api *)
-		net_if_get_device(iface)->api);
+	const struct device *dev = net_if_get_device(iface);
+	const struct ppp_api *api;
 	struct net_stats_ppp *stats;
+
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct ppp_api *)dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (!api->get_stats) {
 		return;
 	}
 
-	stats = api->get_stats(net_if_get_device(iface));
+	stats = api->get_stats(dev);
 	if (!stats) {
 		return;
 	}
@@ -107,15 +137,21 @@ static inline void ppp_stats_update_drop_rx(struct net_if *iface)
 
 static inline void ppp_stats_update_fcs_error_rx(struct net_if *iface)
 {
-	const struct ppp_api *api = ((const struct ppp_api *)
-		net_if_get_device(iface)->api);
+	const struct device *dev = net_if_get_device(iface);
+	const struct ppp_api *api;
 	struct net_stats_ppp *stats;
+
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct ppp_api *)dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	if (!api->get_stats) {
 		return;
 	}
 
-	stats = api->get_stats(net_if_get_device(iface));
+	stats = api->get_stats(dev);
 	if (!stats) {
 		return;
 	}

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -66,7 +66,14 @@ static int virt_dev_init(const struct device *dev)
 
 static void iface_init(struct net_if *iface)
 {
-	struct ipip_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct ipip_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (ctx->init_done) {
 		return;
@@ -134,11 +141,18 @@ static uint8_t ipv4_get_tos(struct net_pkt *pkt)
 
 static int interface_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	struct ipip_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct ipip_context *ctx;
 	struct net_pkt *tmp = NULL;
 	uint8_t nexthdr;
 	uint8_t tos = 0;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	if (ctx->attached_to == NULL) {
 		return -ENOENT;
@@ -292,10 +306,17 @@ static bool verify_remote_addr(struct ipip_context *ctx,
 static enum net_verdict interface_recv(struct net_if *iface,
 				       struct net_pkt *pkt)
 {
-	struct ipip_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct ipip_context *ctx;
 	struct net_pkt_cursor hdr_start;
 	uint8_t iptype;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	net_pkt_cursor_backup(pkt, &hdr_start);
 
@@ -444,6 +465,7 @@ static enum net_verdict interface_recv(struct net_if *iface,
 static int interface_attach(struct net_if *iface, struct net_if *lower_iface)
 {
 	struct ipip_context *ctx;
+	const struct device *dev;
 
 	if (net_if_get_by_iface(iface) < 0) {
 		return -ENOENT;
@@ -451,7 +473,14 @@ static int interface_attach(struct net_if *iface, struct net_if *lower_iface)
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	ctx = net_if_get_device(iface)->data;
+	dev = net_if_get_device(iface);
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
+
 	ctx->attached_to = lower_iface;
 	ctx->iface = iface;
 
@@ -498,7 +527,14 @@ static int interface_set_config(struct net_if *iface,
 				enum virtual_interface_config_type type,
 				const struct virtual_interface_config *config)
 {
-	struct ipip_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct ipip_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	switch (type) {
 	case VIRTUAL_INTERFACE_CONFIG_TYPE_PEER_ADDRESS:
@@ -583,7 +619,14 @@ static int interface_get_config(struct net_if *iface,
 				enum virtual_interface_config_type type,
 				struct virtual_interface_config *config)
 {
-	struct ipip_context *ctx = net_if_get_device(iface)->data;
+	const struct device *dev = net_if_get_device(iface);
+	struct ipip_context *ctx;
+
+	NET_ASSERT(dev != NULL);
+
+	ctx = dev->data;
+
+	NET_ASSERT(ctx != NULL);
 
 	switch (type) {
 	case VIRTUAL_INTERFACE_CONFIG_TYPE_PEER_ADDRESS:

--- a/subsys/net/l2/virtual/virtual.c
+++ b/subsys/net/l2/virtual/virtual.c
@@ -29,6 +29,7 @@ static enum net_verdict virtual_recv(struct net_if *iface,
 	struct net_if *filtered_iface = NULL;
 	enum net_verdict verdict;
 	sys_slist_t *interfaces;
+	const struct device *dev;
 
 	interfaces = &iface->config.virtual_interfaces;
 
@@ -37,7 +38,11 @@ static enum net_verdict virtual_recv(struct net_if *iface,
 			continue;
 		}
 
-		api = net_if_get_device(ctx->virtual_iface)->api;
+		dev = net_if_get_device(ctx->virtual_iface);
+
+		NET_ASSERT(dev != NULL);
+
+		api = dev->api;
 		if (!api || api->recv == NULL) {
 			continue;
 		}
@@ -103,7 +108,11 @@ static enum net_verdict virtual_recv(struct net_if *iface,
 	/* If there are no virtual interfaces attached, then pass the packet
 	 * to the actual virtual network interface.
 	 */
-	api = net_if_get_device(iface)->api;
+	dev = net_if_get_device(iface);
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 	if (!api || api->recv == NULL) {
 		goto drop;
 	}
@@ -145,9 +154,14 @@ silent_drop:
 
 static int virtual_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct virtual_interface_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct virtual_interface_api *api;
 	size_t pkt_len;
 	int ret;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;
@@ -179,14 +193,21 @@ static int virtual_enable(struct net_if *iface, bool state)
 {
 	const struct virtual_interface_api *virt;
 	struct virtual_interface_context *ctx;
+	const struct device *dev;
 	int ret = 0;
 
-	virt = net_if_get_device(iface)->api;
+	dev = net_if_get_device(iface);
+
+	NET_ASSERT(dev != NULL);
+
+	virt = dev->api;
 	if (!virt) {
 		return -ENOENT;
 	}
 
 	ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	if (state) {
 		/* Take the interfaces below this interface up as
@@ -211,17 +232,19 @@ static int virtual_enable(struct net_if *iface, bool state)
 
 			net_if_up(ctx->iface);
 			ctx = net_if_l2_data(ctx->iface);
+
+			NET_ASSERT(ctx != NULL);
 		}
 
 		if (virt->start) {
-			ret = virt->start(net_if_get_device(iface));
+			ret = virt->start(dev);
 		}
 
 		return ret;
 	}
 
 	if (virt->stop) {
-		ret = virt->stop(net_if_get_device(iface));
+		ret = virt->stop(dev);
 	}
 
 	return ret;
@@ -230,6 +253,8 @@ static int virtual_enable(struct net_if *iface, bool state)
 enum net_l2_flags virtual_flags(struct net_if *iface)
 {
 	struct virtual_interface_context *ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	return ctx->virtual_l2_flags;
 }
@@ -260,6 +285,7 @@ int net_virtual_interface_attach(struct net_if *virtual_iface,
 {
 	const struct virtual_interface_api *api;
 	struct virtual_interface_context *ctx;
+	const struct device *dev;
 	bool up = false;
 
 	if (net_if_get_by_iface(virtual_iface) < 0 ||
@@ -271,12 +297,18 @@ int net_virtual_interface_attach(struct net_if *virtual_iface,
 		return -EINVAL;
 	}
 
-	api = net_if_get_device(virtual_iface)->api;
-	if (api->attach == NULL) {
+	dev = net_if_get_device(virtual_iface);
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
+	if (api == NULL || api->attach == NULL) {
 		return -ENOENT;
 	}
 
 	ctx = net_if_l2_data(virtual_iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	if (ctx->iface) {
 		if (iface != NULL) {
@@ -391,6 +423,8 @@ struct net_if *net_virtual_get_iface(struct net_if *iface)
 
 	ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	return ctx->iface;
 }
 
@@ -407,6 +441,8 @@ char *net_virtual_get_name(struct net_if *iface, char *buf, size_t len)
 	}
 
 	ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	strncpy(buf, ctx->name, MIN(len, sizeof(ctx->name)));
 	buf[len - 1] = '\0';
@@ -428,6 +464,8 @@ void net_virtual_set_name(struct net_if *iface, const char *name)
 
 	ctx = net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	strncpy(ctx->name, name, ARRAY_SIZE(ctx->name) - 1);
 	ctx->name[ARRAY_SIZE(ctx->name) - 1] = '\0';
 }
@@ -447,6 +485,9 @@ enum net_l2_flags net_virtual_set_flags(struct net_if *iface,
 	}
 
 	ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
+
 	old_flags = ctx->virtual_l2_flags;
 	ctx->virtual_l2_flags = flags;
 
@@ -464,6 +505,9 @@ void net_virtual_init(struct net_if *iface)
 	}
 
 	ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
+
 	if (ctx->is_init) {
 		return;
 	}

--- a/subsys/net/l2/virtual/virtual_mgmt.c
+++ b/subsys/net/l2/virtual/virtual_mgmt.c
@@ -20,9 +20,13 @@ static int virtual_interface_set_config(uint64_t mgmt_request,
 	struct virtual_interface_req_params *params =
 				(struct virtual_interface_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct virtual_interface_api *api = dev->api;
+	const struct virtual_interface_api *api;
 	struct virtual_interface_config config = { 0 };
 	enum virtual_interface_config_type type;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;
@@ -96,10 +100,14 @@ static int virtual_interface_get_config(uint64_t mgmt_request,
 	struct virtual_interface_req_params *params =
 				(struct virtual_interface_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct virtual_interface_api *api = dev->api;
+	const struct virtual_interface_api *api;
 	struct virtual_interface_config config = { 0 };
 	enum virtual_interface_config_type type;
 	int ret = 0;
+
+	NET_ASSERT(dev != NULL);
+
+	api = dev->api;
 
 	if (!api) {
 		return -ENOENT;


### PR DESCRIPTION
Fixes the open GitHub code-scanning alerts (GCC static analyzer) in `subsys/net/l2`. 85 of the 88 alerts share a single root cause and are addressed by one commit per L2; the remaining 3 are an unrelated out-of-bounds finding in gPTP.

### NULL pointer — 85 alerts

84 × `-Wanalyzer-null-dereference` and 1 × `-Wanalyzer-null-argument`, all with
the same root cause: the inline interface accessors in `include/zephyr/net/net_if.h` — `net_if_get_device()`, `net_if_l2_data()`, `net_if_l2()` and `net_if_get_link_addr()` — return `NULL` when passed a `NULL` interface, so the analyzer follows that branch into every unchecked dereference of their result.

Representative report (the other 84 are the same finding at other call sites):
- [#1578](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1578) — GCC analyzer `-Wanalyzer-null-dereference`, `dummy/dummy.c:23` (`dereference of NULL '0'`)

Fixed by, one commit per L2:
- `net: ethernet: Assert that interface accessors return valid pointers` — 25 alerts
- `net: ieee802154: Assert that interface accessors return valid pointers` — 23 alerts
- `net: ppp: Assert that context pointers are valid` — 17 alerts
- `net: virtual: Assert that interface accessors return valid pointers` — 13 alerts
- `net: l2: Assert that the interface device pointer is valid` — 5 alerts
- `net: gptp: Assert that interface accessors return valid pointers` — 2 alerts

### Out of bounds — 3 alerts

- [#1730](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1730) — GCC analyzer `-Wanalyzer-out-of-bounds`, `ethernet/gptp/gptp.c:552` (`buffer over-read`)
- [#1731](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1731) — GCC analyzer `-Wanalyzer-out-of-bounds`, `ethernet/gptp/gptp_mi.c:644` (`buffer overflow`)
- [#1732](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1732) — GCC analyzer `-Wanalyzer-out-of-bounds`, `ethernet/gptp/gptp_mi.c:645` (`buffer overflow`)

Fixed by:
- `net: gptp: Make the per-port array bound explicit`

Fixes #115932
