### PR TITLE
soc: espressif: Allow user mode to read flash rodata

### DIFF
--- a/soc/espressif/esp32c5/pmp_regions.c
+++ b/soc/espressif/esp32c5/pmp_regions.c
@@ -35,6 +35,19 @@ extern char _iram_text_end[];
 PMP_SOC_REGION_DEFINE(esp32c5_iram_text, _iram_text_start, _iram_text_end, PMP_R | PMP_X);
 
 /*
+ * Flash-mapped read-only data (DROM).
+ *
+ * Const data and string literals live in a separate MMU window from
+ * executable flash text (__rom_region). Without an explicit PMP entry,
+ * user mode cannot read that window. Use _image_rodata_* so sections
+ * after __rodata_region_end that still map into DROM are covered.
+ */
+extern char _image_rodata_start[];
+extern char _image_rodata_end[];
+
+PMP_SOC_REGION_DEFINE(esp32c5_flash_rodata, _image_rodata_start, _image_rodata_end, PMP_R);
+
+/*
  * ESP32-C5 peripheral region.
  *
  * Memory-mapped I/O registers (UART, SPI, I2C, GPIO, PMU, etc.) live

--- a/soc/espressif/esp32c6/pmp_regions.c
+++ b/soc/espressif/esp32c6/pmp_regions.c
@@ -37,3 +37,16 @@ extern char _iram_text_start[];
 extern char _iram_text_end[];
 
 PMP_SOC_REGION_DEFINE(esp32c6_iram_text, _iram_text_start, _iram_text_end, PMP_R | PMP_X);
+
+/*
+ * Flash-mapped read-only data (DROM).
+ *
+ * Const data and string literals live in a separate MMU window from
+ * executable flash text (__rom_region). Without an explicit PMP entry,
+ * user mode cannot read that window. Use _image_rodata_* so sections
+ * after __rodata_region_end that still map into DROM are covered.
+ */
+extern char _image_rodata_start[];
+extern char _image_rodata_end[];
+
+PMP_SOC_REGION_DEFINE(esp32c6_flash_rodata, _image_rodata_start, _image_rodata_end, PMP_R);

--- a/soc/espressif/esp32p4/pmp_regions.c
+++ b/soc/espressif/esp32p4/pmp_regions.c
@@ -35,6 +35,19 @@ extern char _iram_text_end[];
 PMP_SOC_REGION_DEFINE(esp32p4_iram_text, _iram_text_start, _iram_text_end, PMP_R | PMP_X);
 
 /*
+ * Flash-mapped read-only data (DROM).
+ *
+ * Const data and string literals live in a separate MMU window from
+ * executable flash text (__rom_region). Without an explicit PMP entry,
+ * user mode cannot read that window. Use _image_rodata_* so sections
+ * after __rodata_region_end that still map into DROM are covered.
+ */
+extern char _image_rodata_start[];
+extern char _image_rodata_end[];
+
+PMP_SOC_REGION_DEFINE(esp32p4_flash_rodata, _image_rodata_start, _image_rodata_end, PMP_R);
+
+/*
  * ESP32-P4 peripheral region.
  *
  * HP peripherals at 0x50000000-0x50200000 and LP peripherals at 0x50100000+.


### PR DESCRIPTION
Flash constants live in a DROM window separate from executable text. PMP already covers the text region, but without a matching read entry for DROM, user mode faults as soon as it touches const data. Add a read-only PMP region over the full image rodata range on C5, C6, and P4.