### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 581cc8c8d922b062101ab2cc252c4b4699b0dae9
+      revision: c84230d0329a2ce5e449bbd556d6854861a6eee7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 0aaa9aa812877cb6bc020df8260d0607a3f0ec1a


### PR DESCRIPTION
Update the HW models module to:
c84230d0329a2ce5e449bbd556d6854861a6eee7

Including the following:
c84230d 52833 GPIO Config: bugfix: GPIO P1 *has* SENSE mechanism 
e0a5389 UART: PTY backend: minor fix
ec678a1 UART: PTY backend: Add option to connect to stdin/out
47f6e2a UART: FIFO backend: Add missing parameter name 
46aa466 UART: Added support for EasyDMA LIST_Array mode
8bba241 UART: Add TASK_DMAEND support
e218c00 UART: Fix DMA.MATCH.CANDIDATE shadowing