### PR TITLE
tests drivers gpio_basic_api: Add runable bsim variant of these tests

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/main.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/main.c
@@ -15,7 +15,7 @@
 #include "device_imx.h"
 #elif defined(CONFIG_BOARD_MIMXRT1050_EVK)
 #include <fsl_iomuxc.h>
-#elif defined(CONFIG_BOARD_NRF52_BSIM)
+#elif defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
 #include <NRF_GPIO.h>
 #endif
 
@@ -64,13 +64,18 @@ static void board_setup(void)
 	zassert_true(device_is_ready(dev), "GPIO dev is not ready");
 	int rc = gpio_add_callback(dev, &gpio_emul_callback);
 	__ASSERT(rc == 0, "gpio_add_callback() failed: %d", rc);
-#elif defined(CONFIG_BOARD_NRF52_BSIM)
+#elif defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
 	static bool done;
 
 	if (!done) {
 		done = true;
 		/* This functions allows to programmatically short-circuit SOC GPIO pins */
+#if defined(CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUAPP)
+		/* The 5340/cpuapp GPIO 1, is the HW models GPIO port 3 */
+		nrf_gpio_backend_register_short(3, PIN_OUT, 3, PIN_IN);
+#else
 		nrf_gpio_backend_register_short(1, PIN_OUT, 1, PIN_IN);
+#endif
 	}
 #endif
 }

--- a/tests/drivers/gpio/gpio_basic_api/tests.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/tests.yaml
@@ -13,19 +13,37 @@ tests:
     min_flash: 34
     filter: dt_compat_enabled("test-gpio-basic-api") and not dt_compat_enabled("arduino-header-r3")
 
-  drivers.gpio.nrf_sense_edge:
+  drivers.gpio.2pin.bsim:
     platform_allow:
-      - nrf52840dk/nrf52840
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpuapp
       - nrf5340bsim/nrf5340/cpunet
+      - nrf54l15bsim/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf52_bsim
+    harness_config: {} # The GPIO loopback is set programmatically at runtime in the test
+
+  drivers.gpio.nrf_sense_edge:
+    platform_allow:
+      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
-      - nrf54l15bsim/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: "DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840.overlay;\
                  boards/nrf52840dk_nrf52840_sense_edge.overlay"
+
+  drivers.gpio.nrf_sense_edge.bsim:
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpunet
+      - nrf54l15bsim/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf52_bsim
+    extra_args: "DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840.overlay;\
+                 boards/nrf52840dk_nrf52840_sense_edge.overlay"
+    harness_config: {} # The GPIO loopback is set programmatically at runtime in the test
 
   drivers.gpio.nrf_sense_edge.nrf54l:
     platform_allow:

--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 581cc8c8d922b062101ab2cc252c4b4699b0dae9
+      revision: c84230d0329a2ce5e449bbd556d6854861a6eee7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 0aaa9aa812877cb6bc020df8260d0607a3f0ec1a


### PR DESCRIPTION
    tests drivers gpio_basic_api: Add runable bsim variant of these tests
    
    This tests can be run and pass on the nrf*bsim targets.
    Let's add a variant which does not require any fixture so it runs in CI.
    This will runtime test the nrfx driver.
    
-------

    tests/drivers/gpio/gpio_basic_api: Set loopback for all bsim targets
    
    Set the pins loopback for other bsim targets also programatically
    so the test can be run (and pass) without needing to pass any
    runtime configuartion from command line.
    

Sits on top of this PR as it needs a fix coming with it:
* #115933 