### PR TITLE
dts: arm: st: stm32mp133.dtsi: add fdcan nodes

### DIFF
--- a/dts/arm/st/mp13/stm32mp133.dtsi
+++ b/dts/arm/st/mp13/stm32mp133.dtsi
@@ -35,5 +35,29 @@
 				compatible = "snps,dwmac-ptp-clock";
 			};
 		};
+
+		fdcan1: can@4400e000 {
+			compatible = "st,stm32h7-fdcan";
+			reg = <0x4400e000 0x400>, <0x44011000 0x1400>;
+			reg-names = "m_can", "message_ram";
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>;
+			interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 22 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "int0", "int1";
+			bosch,mram-cfg = <0x0 28 8 6 0 0 3 3>;
+			status = "disabled";
+		};
+
+		fdcan2: can@4400f000 {
+			compatible = "st,stm32h7-fdcan";
+			reg = <0x4400f000 0x400>, <0x44011000 0x2800>;
+			reg-names = "m_can", "message_ram";
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>;
+			interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 23 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "int0", "int1";
+			bosch,mram-cfg = <0x1400 28 8 6 0 0 3 3>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
Add FDCAN nodes in non-secure context to dtsi.