### PR TITLE
drivers: rtc: add support for customizable centuries to infineon impl

### DIFF
--- a/drivers/rtc/rtc_infineon.c
+++ b/drivers/rtc/rtc_infineon.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Cypress Semiconductor Corporation (an Infineon company) or
- * an affiliate of Cypress Semiconductor Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -78,8 +78,8 @@ static cy_stc_syspm_callback_t _ifx_cat1_rtc_pm_cb = {
 
 #define _IFX_CAT1_RTC_WAIT_ONE_MS() Cy_SysLib_Delay(_IFX_CAT1_RTC_RETRY_DELAY_MS);
 
-/* Internal macro to validate RTC year parameter falls within 21st century */
-#define IFX_CAT1_RTC_VALID_CENTURY(year) ((year) >= _IFX_CAT1_RTC_INIT_CENTURY)
+/* Internal macro to validate RTC year parameter */
+#define IFX_CAT1_RTC_VALID_CENTURY(year) ((year) >= _IFX_CAT1_RTC_TM_YEAR_BASE)
 
 #define MAX_IFX_CAT1_CAL (60)
 
@@ -143,7 +143,10 @@ static void _ifx_cat1_rtc_from_pdl_time(cy_stc_rtc_config_t *pdlTime, const int 
 	 * driver.
 	 */
 	z_time->tm_mon = (int)(pdlTime->month - 1u);
-	z_time->tm_wday = (int)(pdlTime->dayOfWeek - 1u);
+
+	/* pdlTime->dayOfWeek is incorrect for years <2000 - redo calculation */
+	z_time->tm_wday =
+		(int)(Cy_RTC_ConvertDayOfWeek(pdlTime->date, pdlTime->month, (uint32_t)year) - 1u);
 
 	/* year day not known in pdl RTC structure without conversion */
 	z_time->tm_yday = -1;


### PR DESCRIPTION
The underlying RTC hardware used by Infineon only supports a 2 digit year.  The PDL hardcoded an assumption that the current century is 2000, and this assumption was propagated into the Zephyr driver.  The only real impact the PDL hardcoded century has on Zephyr is that Cy_RTC_GetDateAndTime returns the wrong day-of-week value.

Removing the 20xx-century restriction by updating the minimum valid year to match tm (19xx) and performing day-of-week calculations using the correct century.