### PR TITLE
MAINTAINERS: add label for demand paging area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1329,6 +1329,8 @@ Demand Paging:
   tests:
     - kernel.demand_paging
     - sample.demand_paging
+  labels:
+    - "area: Demand Paging"
 
 Device Driver Model:
   status: maintained


### PR DESCRIPTION
Add missing label for demand paging.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
