### PR TITLE
dts: vendor: nordic: nrf7120: Add clock source to cpu DTS node

### DIFF
--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -22,6 +22,7 @@
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
 			device_type = "cpu";
+			clocks = <&hfpll>;
 			clock-frequency = <DT_FREQ_M(256)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -37,6 +38,7 @@
 			compatible = "nordic,vpr", "riscv";
 			reg = <1>;
 			device_type = "cpu";
+			clocks = <&hfpll>;
 			clock-frequency = <DT_FREQ_M(256)>;
 			riscv,isa-base = "rv32e";
 			riscv,isa-extensions = "e", "m", "c", "zicsr";


### PR DESCRIPTION
nrf7120 cpu DTS node is missing of clock source causes it is not referencing the clock-frequency attribute for SystemCoreClock variable. The SystemCoreClock variable fallbacks to 16MHz causing clock scaling issues for some timer tests.