### PR TITLE
Realtek EC timer updates

### DIFF
--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -58,7 +58,8 @@ static uint32_t rtmr_get_counter(void)
 {
 	uint32_t counter = RTMR_REG->CNT;
 
-	if ((counter == 0) && (RTMR_REG->CTRL & RTOSTMR_CTRL_EN_Msk)) {
+	if ((counter == 0) && (RTMR_REG->CTRL & RTOSTMR_CTRL_EN_Msk) &&
+	    !(RTMR_REG->INTSTS & RTOSTMR_INTSTS_STS_Msk)) {
 		counter = previous_cnt;
 	}
 

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -18,6 +18,7 @@
 
 #include <reg/reg_rtmr.h>
 #include <reg/reg_system.h>
+#include <soc_clock.h>
 
 #define RTS5912_SCCON_REG_BASE ((SYSTEM_Type *)(DT_REG_ADDR(DT_NODELABEL(sccon))))
 
@@ -46,6 +47,11 @@ static struct k_spinlock lock;
 static uint32_t accumulated_cycles;
 static uint32_t previous_cnt;      /* Record the counter set into RTMR */
 static uint32_t last_announcement; /* Record the last tick announced to system */
+
+#if defined(CONFIG_PM)
+static uint64_t cyc_sleep_compensated;
+static uint32_t cyc_enter_heavy_sleep;
+#endif
 
 static void rtmr_restart(uint32_t counter)
 {
@@ -199,6 +205,26 @@ uint32_t sys_clock_cycle_get_32(void)
 
 	return ret;
 }
+
+#if defined(CONFIG_PM)
+void rts5912_clock_capture_low_freq_timer(void)
+{
+	cyc_enter_heavy_sleep = sys_clock_cycle_get_32();
+}
+
+void rts5912_clock_compensate_system_timer(void)
+{
+	uint32_t cyc_exit_heavy_sleep = sys_clock_cycle_get_32();
+	uint32_t cyc_elapsed = (cyc_exit_heavy_sleep - cyc_enter_heavy_sleep) & RTMR_COUNTER_MSK;
+
+	cyc_sleep_compensated += cyc_elapsed;
+}
+
+uint64_t rts5912_clock_get_sleep_ticks(void)
+{
+	return cyc_sleep_compensated / CYCLES_PER_TICK;
+}
+#endif /* CONFIG_PM */
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
 

--- a/soc/realtek/ec/rts5912/power.c
+++ b/soc/realtek/ec/rts5912/power.c
@@ -10,6 +10,7 @@
 
 #include <reg/reg_system.h>
 #include "device_power.h"
+#include "soc_clock.h"
 
 static void realtek_WFI(void)
 {
@@ -37,6 +38,8 @@ static void rts5912_heavy_sleep(void)
 
 	sys_reg->SLPCTRL |= (SYSTEM_SLPCTRL_SLPMDSEL_Msk | SYSTEM_SLPCTRL_GPIOWKEN_Msk);
 
+	rts5912_clock_capture_low_freq_timer();
+
 	realtek_WFI();
 
 	/* If we were running on the PLL before sleep, wait for it to become
@@ -54,6 +57,8 @@ static void rts5912_heavy_sleep(void)
 			sys_reg->PLLCTRL &= ~SYSTEM_PLLCTRL_EN_Msk; /* Disable PLL */
 		}
 	}
+
+	rts5912_clock_compensate_system_timer();
 
 	after_rts5912_sleep();
 }

--- a/soc/realtek/ec/rts5912/soc_clock.h
+++ b/soc/realtek/ec/rts5912/soc_clock.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_REALTEK_RTS5912_SOC_CLOCK_H_
+#define ZEPHYR_SOC_REALTEK_RTS5912_SOC_CLOCK_H_
+
+#include <stdint.h>
+
+#if defined(CONFIG_PM)
+void rts5912_clock_capture_low_freq_timer(void);
+void rts5912_clock_compensate_system_timer(void);
+uint64_t rts5912_clock_get_sleep_ticks(void);
+#endif
+
+#endif /* ZEPHYR_SOC_REALTEK_RTS5912_SOC_CLOCK_H_ */

--- a/tests/kernel/sys_timer/timer_monotonic/src/main.c
+++ b/tests/kernel/sys_timer/timer_monotonic/src/main.c
@@ -80,4 +80,59 @@ ZTEST(timer_fn, test_timer)
 	zassert_false(test_frequency(), "test frequency failed");
 }
 
+/**
+ * @brief Test monotonic timer while interrupts are locked
+ *
+ * Verifies that k_cycle_get_32() remains monotonic and correctly accounts
+ * for elapsed cycles even across a timer expiration when interrupts are disabled.
+ */
+ZTEST(timer_fn, test_timer_monotonic_irq_locked)
+{
+	struct k_timer timer;
+	uint32_t t_before, t_during, t_after;
+	unsigned int key;
+	int iter;
+
+	k_timer_init(&timer, NULL, NULL);
+
+	for (iter = 0; iter < 10; iter++) {
+		/* Set a short timer to expire in 5ms */
+		k_timer_start(&timer, K_MSEC(5), K_FOREVER);
+
+		/* Wait a small duration so some cycles elapse */
+		k_busy_wait(1000);
+
+		/* Sample cycles immediately before locking interrupts */
+		t_before = k_cycle_get_32();
+
+		/* Lock interrupts so timer ISR cannot execute when timer expires */
+		key = irq_lock();
+
+		/* Busy-wait 10ms (longer than the remaining 4ms on the timer) */
+		k_busy_wait(10000);
+
+		/* Sample cycles with interrupts still locked */
+		t_during = k_cycle_get_32();
+
+		/* Unlock interrupts */
+		irq_unlock(key);
+
+		t_after = k_cycle_get_32();
+
+		TC_PRINT("iter %d: t_before = %u, t_during = %u, t_after = %u (diff = %d)\n",
+			 iter, t_before, t_during, t_after, (int32_t)(t_during - t_before));
+
+		/* Verify cycle counter did not jump backwards */
+		zassert_true((int32_t)(t_during - t_before) > 0,
+			     "Timer went backward while IRQs locked! diff=%d (before=%u, during=%u)",
+			     (int32_t)(t_during - t_before), t_before, t_during);
+
+		zassert_true((int32_t)(t_after - t_during) >= 0,
+			     "Timer went backward after IRQs unlocked! diff=%d (during=%u, after=%u)",
+			     (int32_t)(t_after - t_during), t_during, t_after);
+
+		k_timer_stop(&timer);
+	}
+}
+
 ZTEST_SUITE(timer_fn, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Fix an underflow bug in the Realtek EC timer if k_cycle_get_32() is called with interrupts locked.

Add a new unit test that verifies timer monotonic operation with interrupts locked.

Add functions to track the amount of time the Realtek EC spends in heavy sleep.