### PR TITLE
drivers: input: tma525b: fix inverted application mode check

### DIFF
--- a/drivers/input/input_tma525b.c
+++ b/drivers/input/input_tma525b.c
@@ -235,6 +235,7 @@ static int tma525b_chip_init(const struct device *dev)
 	uint8_t read_buf[2];
 	int ret;
 	int retry = 0;
+	bool ready = false;
 
 	/* Power on sequence */
 	if (config->pwr_gpio.port != NULL) {
@@ -264,6 +265,7 @@ static int tma525b_chip_init(const struct device *dev)
 			if ((read_buf[0] == 0x02U && read_buf[1] == 0x00U) ||
 			    read_buf[1] == 0xFFU) {
 				LOG_INF("TMA525B entered application mode");
+				ready = true;
 				break;
 			}
 		}
@@ -271,7 +273,7 @@ static int tma525b_chip_init(const struct device *dev)
 		retry++;
 	}
 
-	if (retry == 0U) {
+	if (!ready) {
 		LOG_ERR("TMA525B failed to enter application mode");
 		return -ENODEV;
 	}


### PR DESCRIPTION
`tma525b_chip_init()` only increments `retry` when a poll fails, and breaks out
of the loop *before* the increment. `retry == 0` is therefore exactly the case
where the controller answered correctly on the very first read — yet that is
the condition used to report failure:

```c
        if (ret == 0) {
                if ((read_buf[0] == 0x02U && read_buf[1] == 0x00U) ||
                    read_buf[1] == 0xFFU) {
                        LOG_INF("TMA525B entered application mode");
                        break;          /* retry still 0 */
                }
        }
        k_sleep(K_MSEC(TMA525B_BOOT_DELAY_MS));
        retry++;
}

if (retry == 0U) {              /* == "we succeeded immediately" */
        LOG_ERR("TMA525B failed to enter application mode");
        return -ENODEV;
}