### PR TITLE
drivers: input: ch9350l: fix mouse delta decoding and button event type

### DIFF
--- a/drivers/input/input_ch9350l.c
+++ b/drivers/input/input_ch9350l.c
@@ -41,12 +41,6 @@ LOG_MODULE_REGISTER(input_ch9350l, CONFIG_INPUT_LOG_LEVEL);
 #define CH9350L_FRAME_MOUSE_BUTTON_BYTE	0
 #define CH9350L_FRAME_MOUSE_X_BYTE	1
 #define CH9350L_FRAME_MOUSE_Y_BYTE	3
-#define CH9350L_FRAME_MOUSE_RELMID	0x7FFF
-#define CH9350L_FRAME_MOUSE_RELNEG	0x8000
-
-#define CH9350L_RAWMOUSE_TO_REL(_val) (_val > CH9350L_FRAME_MOUSE_RELMID ?			\
-	-(CH9350L_FRAME_MOUSE_RELMID - (const int16_t)(_val - CH9350L_FRAME_MOUSE_RELNEG))	\
-	: (const int16_t)_val)
 
 #define CH9350L_FRAME_MOUSE_BTN_LEFT	0x1
 #define CH9350L_FRAME_MOUSE_BTN_RIGHT	0x2
@@ -165,22 +159,20 @@ static void ch9350l_mouse(const struct device *dev, const uint8_t *values, uint8
 {
 	struct ch9350l_data *data = dev->data;
 	const uint8_t button = values[CH9350L_FRAME_MOUSE_BUTTON_BYTE];
-	const uint16_t raw_x = sys_get_le16(&values[CH9350L_FRAME_MOUSE_X_BYTE]);
-	const uint16_t raw_y = sys_get_le16(&values[CH9350L_FRAME_MOUSE_Y_BYTE]);
-	const int16_t x = CH9350L_RAWMOUSE_TO_REL(raw_x);
-	const int16_t y = CH9350L_RAWMOUSE_TO_REL(raw_y);
+	const int16_t x = (int16_t)sys_get_le16(&values[CH9350L_FRAME_MOUSE_X_BYTE]);
+	const int16_t y = (int16_t)sys_get_le16(&values[CH9350L_FRAME_MOUSE_Y_BYTE]);
 
 	input_report(dev, INPUT_EV_REL, INPUT_REL_X, x, true, K_FOREVER);
 	input_report(dev, INPUT_EV_REL, INPUT_REL_Y, y, true, K_FOREVER);
 
 	for (size_t i = 0; i < 8; i++) {
 		if (button & BIT(i) && !(data->last_mouse_btns & BIT(i))) {
-			if (input_report(dev, INPUT_EV_DEVICE,
+			if (input_report(dev, INPUT_EV_KEY,
 				ch9350l_mouse_map(dev, BIT(i)), 1, true, K_FOREVER)) {
 				LOG_ERR("Input failed to be enqueued");
 			}
 		} else if (data->last_mouse_btns & BIT(i) && !(button & BIT(i))) {
-			if (input_report(dev, INPUT_EV_DEVICE,
+			if (input_report(dev, INPUT_EV_KEY,
 				ch9350l_mouse_map(dev, BIT(i)), 0, true, K_FOREVER)) {
 				LOG_ERR("Input failed to be enqueued");
 			}


### PR DESCRIPTION
Two independent defects in `ch9350l_mouse()`.

**Relative delta decoding is off by one.** The negative branch of `CH9350L_RAWMOUSE_TO_REL()` reduces to `raw - 65535` rather than `raw - 65536`, so `0xFFFF` decodes to `0`, `0xFFFE` to `-1` and `0x8000` to `-32767`. `0x0000` and `0xFFFF` both decode to `0`, so the mapping is not injective and cannot match any signed 16-bit wire format.

Slow leftward or upward motion — the single-count deltas a mouse emits most often — reports a delta of 0 and the pointer does not move at all, while larger negative deltas are each one count short and drift the pointer right and down. Decode the field directly as a signed 16-bit little-endian value and drop the now-unused macro and defines.

**Buttons used `INPUT_EV_DEVICE` instead of `INPUT_EV_KEY`**, while `ch9350l_kb()` uses `INPUT_EV_KEY` under identical conditions and the binding maps buttons to `INPUT_BTN_*` codes. Clicks are silently dropped by type-filtering consumers such as `input_longpress` and `input_double_tap`.