### PR TITLE
drivers: input: xpt2046: re-arm gpio callback on read error

### DIFF
--- a/drivers/input/input_xpt2046.c
+++ b/drivers/input/input_xpt2046.c
@@ -142,7 +142,7 @@ static void xpt2046_work_handler(struct k_work *kw)
 
 	for (int i = 0; i < rounds; i++) {
 		if (xpt2046_read_and_cumulate(&config->bus, &tx_bufs, &rx_bufs, &meas) != 0) {
-			return;
+			goto reenable_cb;
 		}
 	}
 	meas.x /= rounds;
@@ -185,6 +185,7 @@ static void xpt2046_work_handler(struct k_work *kw)
 		k_work_reschedule(&data->dwork, K_MSEC(100));
 	}
 
+reenable_cb:
 	ret = gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
 	if (ret < 0) {
 		LOG_ERR("Could not set gpio callback");


### PR DESCRIPTION
`xpt2046_isr_handler()` unconditionally removes the GPIO callback before
submitting the work item, and the `gpio_add_callback()` at the end of
`xpt2046_work_handler()` is the only place it is ever registered again. The
averaging loop returns early on a SPI failure, jumping over that call:

```c
	for (int i = 0; i < rounds; i++) {
		if (xpt2046_read_and_cumulate(&config->bus, &tx_bufs, &rx_bufs, &meas) != 0) {
			return;         /* callback never re-added */
		}
	}