### PR TITLE
drivers: input: cf1133: probe the controller before arming interrupt

### DIFF
--- a/drivers/input/input_cf1133.c
+++ b/drivers/input/input_cf1133.c
@@ -278,6 +278,16 @@ static int cf1133_init(const struct device *dev)
 	data->dev = dev;
 	k_work_init(&data->work, cf1133_work_handler);
 
+	/*
+	 * Probe the controller before arming anything that can call
+	 * cf1133_process(), which relies on data->pixel_length.
+	 */
+	ret = cf1133_ts_init(dev);
+	if (ret < 0) {
+		LOG_ERR("Init information of sensor failed: %d", ret);
+		return ret;
+	}
+
 #ifdef CONFIG_INPUT_CF1133_INTERRUPT
 
 	LOG_DBG("Int conf for TS gpio: %p", &config->int_gpio);
@@ -313,11 +323,6 @@ static int cf1133_init(const struct device *dev)
 		      K_MSEC(CONFIG_INPUT_CF1133_PERIOD_MS));
 #endif
 
-	ret = cf1133_ts_init(dev);
-	if (ret < 0) {
-		LOG_ERR("Init information of sensor failed: %d", ret);
-		return ret;
-	}
 	return 0;
 }
 


### PR DESCRIPTION
`cf1133_init()` registers the GPIO callback and configures the interrupt — or
starts the polling timer — *before* calling `cf1133_ts_init()`, which is the
only assigner of `data->pixel_length`. When it fails, init returns with the
callback still registered and the timer still running.

`cf1133_process()` sizes its read as `1 + SUPPORTED_POINT * data->pixel_length`
(one byte when `pixel_length` is 0) into a fixed
`uint8_t buffer[1 + SUPPORTED_POINT * PIXEL_DATA_LENGTH_A]`, then
unconditionally dereferences `buffer[1..3]` for the valid bit and both
coordinates.

A transient NAK at boot therefore leaves every subsequent interrupt edge, or
every 10 ms timer tick, decoding uninitialized stack: whenever bit 7 of the
garbage is set the driver emits `BTN_TOUCH=1` at a random coordinate, for the
life of the system. The same window exists at startup before `ts_init()` runs.

Probe the controller first, right after `k_work_init()` — it only needs the I2C
bus, which is already validated above. Nothing that can fail then follows the
arming step. `input_gt911.c` arms at the very end of init for the same reason.