### PR TITLE
boards: nxp: Expose Arduino/Uno SPI on FRDM-MCXN236 board

### DIFF
--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -144,6 +144,14 @@
 	status = "okay";
 };
 
+&gpio3 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
 &gpio1 {
 	status = "okay";
 };
@@ -328,7 +336,7 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
-&flexcomm3_lpspi3 {
+arduino_spi: &flexcomm3_lpspi3 {
 	pinctrl-0 = <&pinmux_flexcomm3_lpspi>;
 	pinctrl-names = "default";
 };

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
@@ -15,6 +15,8 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_gpio
+  - arduino_spi
   - can
   - counter
   - dma


### PR DESCRIPTION
Adjust the devicetree to expose the `arduino_spi` bus, and update the board metadata to properly note the supported arduino GPIO/SPI.