### PR TITLE
drivers: input: gt911: keep previous touch state per instance

### DIFF
--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -57,6 +57,18 @@ struct gt911_config {
 	uint8_t alt_addr;
 };
 
+/** gt911 point reg */
+struct gt911_point_reg {
+	uint8_t id;        /*!< Track ID. */
+	uint8_t low_x;     /*!< Low byte of x coordinate. */
+	uint8_t high_x;    /*!< High byte of x coordinate. */
+	uint8_t low_y;     /*!< Low byte of y coordinate. */
+	uint8_t high_y;    /*!< High byte of x coordinate. */
+	uint8_t low_size;  /*!< Low byte of point size. */
+	uint8_t high_size; /*!< High byte of point size. */
+	uint8_t reserved;  /*!< Reserved. */
+};
+
 /** GT911 data. */
 struct gt911_data {
 	/** Device pointer. */
@@ -65,6 +77,10 @@ struct gt911_data {
 	struct k_work work;
 	/** Actual device I2C address */
 	uint8_t actual_address;
+	/** Number of touch points reported by the previous scan. */
+	uint8_t prev_points;
+	/** Touch points reported by the previous scan. */
+	struct gt911_point_reg prev_point_reg[CONFIG_INPUT_GT911_MAX_TOUCH_POINTS];
 #ifdef CONFIG_INPUT_GT911_INTERRUPT
 	/** Interrupt GPIO callback. */
 	struct gpio_callback int_gpio_cb;
@@ -78,18 +94,6 @@ struct gt911_data {
 };
 
 INPUT_TOUCH_STRUCT_CHECK(struct gt911_config);
-
-/** gt911 point reg */
-struct gt911_point_reg {
-	uint8_t id;        /*!< Track ID. */
-	uint8_t low_x;     /*!< Low byte of x coordinate. */
-	uint8_t high_x;    /*!< High byte of x coordinate. */
-	uint8_t low_y;     /*!< Low byte of y coordinate. */
-	uint8_t high_y;    /*!< High byte of x coordinate. */
-	uint8_t low_size;  /*!< Low byte of point size. */
-	uint8_t high_size; /*!< High byte of point size. */
-	uint8_t reserved;  /*!< Reserved. */
-};
 
 /*
  * Device-specific wrappers around i2c_write_dt and i2c_write_read_dt.
@@ -116,6 +120,7 @@ static int gt911_i2c_write_read(const struct device *dev, const void *write_buf,
 
 static int gt911_process(const struct device *dev)
 {
+	struct gt911_data *data = dev->data;
 	int r;
 	uint16_t reg_addr;
 	uint8_t status;
@@ -124,9 +129,7 @@ static int gt911_process(const struct device *dev)
 	uint16_t row;
 	uint16_t col;
 	uint8_t points;
-	static uint8_t prev_points;
 	struct gt911_point_reg point_reg[CONFIG_INPUT_GT911_MAX_TOUCH_POINTS];
-	static struct gt911_point_reg prev_point_reg[CONFIG_INPUT_GT911_MAX_TOUCH_POINTS];
 
 	/* obtain number of touch points */
 	reg_addr = GT911_REG_STATUS;
@@ -181,28 +184,30 @@ static int gt911_process(const struct device *dev)
 	}
 
 	/* release events */
-	for (i = 0; i < prev_points; i++) {
+	for (i = 0; i < data->prev_points; i++) {
 		/* We look for the prev_point in the current points list */
 		for (j = 0; j < points; j++) {
-			if (prev_point_reg[i].id == point_reg[j].id) {
+			if (data->prev_point_reg[i].id == point_reg[j].id) {
 				break;
 			}
 		}
 
 		if (j == points) {
 			if (CONFIG_INPUT_GT911_MAX_TOUCH_POINTS > 1) {
-				input_report_abs(dev, INPUT_ABS_MT_SLOT, prev_point_reg[i].id, true,
-						 K_FOREVER);
+				input_report_abs(dev, INPUT_ABS_MT_SLOT,
+						 data->prev_point_reg[i].id, true, K_FOREVER);
 			}
-			row = ((prev_point_reg[i].high_y) << 8U) | prev_point_reg[i].low_y;
-			col = ((prev_point_reg[i].high_x) << 8U) | prev_point_reg[i].low_x;
+			row = ((data->prev_point_reg[i].high_y) << 8U) |
+			      data->prev_point_reg[i].low_y;
+			col = ((data->prev_point_reg[i].high_x) << 8U) |
+			      data->prev_point_reg[i].low_x;
 			input_touchscreen_report_pos(dev, col, row, K_FOREVER);
 			input_report_key(dev, INPUT_BTN_TOUCH, 0, true, K_FOREVER);
 		}
 	}
 
-	memcpy(prev_point_reg, point_reg, sizeof(point_reg));
-	prev_points = points;
+	memcpy(data->prev_point_reg, point_reg, sizeof(point_reg));
+	data->prev_points = points;
 
 	return 0;
 }


### PR DESCRIPTION
`gt911_process()` tracks the previous scan in function-scope statics
(`prev_points` and `prev_point_reg[]`). `GT911_INIT` is expanded by
`DT_INST_FOREACH_STATUS_OKAY`, so every panel shares one snapshot even though
`gt911_process()` is passed the device it is working on.

With two `goodix,gt911` nodes the release loop compares one device's current
point ids against the other's cached points, and the `memcpy` overwrites the
snapshot with whichever ran last. A release on the first panel carries the
second panel's coordinates, and the second panel's still-active touch is erased
from the cache, so its real lift finds `prev_points == 0` and emits no release
at all, latching `BTN_TOUCH=1`. This is aliasing rather than a data race, so
workqueue serialization does not help.

Move both into `struct gt911_data`, and move `struct gt911_point_reg` above it
so it can be used as a member.