### PR TITLE
drivers: sensor: lsm6dso: fix embedded sensor init, drain loop and humidity

### DIFF
--- a/drivers/sensor/st/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx.c
@@ -399,8 +399,7 @@ static inline int iis2iclx_hum_convert(struct sensor_value *val,
 	rh /= (ht->x1 - ht->x0);
 
 	/* convert humidity to integer and fractional part */
-	val->val1 = rh;
-	val->val2 = rh * 1000000;
+	sensor_value_from_float(val, rh);
 
 	return 0;
 }

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -577,8 +577,7 @@ static inline void ism330dhcx_hum_convert(const struct device *dev, struct senso
 	rh /= (ht->x1 - ht->x0);
 
 	/* convert humidity to integer and fractional part */
-	val->val1 = rh;
-	val->val2 = rh * 1000000;
+	sensor_value_from_float(val, rh);
 }
 
 static inline void ism330dhcx_press_convert(const struct device *dev, struct sensor_value *val)

--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -576,8 +576,7 @@ static inline void lsm6dso_hum_convert(struct sensor_value *val,
 	rh /= (ht->x1 - ht->x0);
 
 	/* convert humidity to integer and fractional part */
-	val->val1 = rh;
-	val->val2 = rh * 1000000;
+	sensor_value_from_float(val, rh);
 }
 
 static inline void lsm6dso_press_convert(struct sensor_value *val,

--- a/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
@@ -55,12 +55,16 @@ static int lsm6dso_enable_tilt_int(const struct device *dev, int enable)
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	int ret = 0;
-	lsm6dso_emb_sens_t sens;
+	lsm6dso_emb_sens_t sens = {0};
+
+	if (lsm6dso_embedded_sens_get(ctx, &sens) < 0) {
+		LOG_ERR("Failed to read embedded sensor state");
+		return -EIO;
+	}
 
 	sens.tilt = enable;
 
-	ret += lsm6dso_embedded_sens_set(ctx, &sens);
-	if (ret < 0) {
+	if (lsm6dso_embedded_sens_set(ctx, &sens) < 0) {
 		LOG_ERR("Failed to enable tilt");
 		return -EIO;
 	}

--- a/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
@@ -19,6 +19,11 @@
 
 LOG_MODULE_DECLARE(LSM6DSO, CONFIG_SENSOR_LOG_LEVEL);
 
+/* Data-ready flags are only cleared when the handler reads the output data
+ * registers, which a handler is not required to do, so bound the drain loop.
+ */
+#define LSM6DSO_MAX_DRAIN_ITERATIONS 4
+
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 /**
  * lsm6dso_enable_t_int - TEMP enable selected int pin to generate interrupt
@@ -423,6 +428,7 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lsm6dso_all_sources_t sources;
 	bool pending_status = false;
+	unsigned int drain = 0;
 
 	while (1) {
 
@@ -460,6 +466,10 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 			break;
 		}
 
+		if (++drain >= LSM6DSO_MAX_DRAIN_ITERATIONS) {
+			break;
+		}
+
 	}
 
 #if defined(CONFIG_LSM6DSO_TILT)
@@ -490,6 +500,7 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lsm6dso_status_reg_t status;
+	unsigned int drain = 0;
 
 	while (1) {
 		if (lsm6dso_status_reg_get(ctx, &status) < 0) {
@@ -497,9 +508,10 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 			return;
 		}
 
-		if ((status.xlda == 0) && (status.gda == 0)
+		if (!(status.xlda && (lsm6dso->handler_drdy_acc != NULL)) &&
+		    !(status.gda && (lsm6dso->handler_drdy_gyr != NULL))
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
-		    && (status.tda == 0)
+		    && !(status.tda && (lsm6dso->handler_drdy_temp != NULL))
 #endif
 		) {
 			break;
@@ -518,6 +530,10 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 			lsm6dso->handler_drdy_temp(dev, lsm6dso->trig_drdy_temp);
 		}
 #endif
+
+		if (++drain >= LSM6DSO_MAX_DRAIN_ITERATIONS) {
+			break;
+		}
 	}
 
 	gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy, GPIO_INT_EDGE_TO_ACTIVE);


### PR DESCRIPTION
This PR fixes three independent correctness bugs found in the LSM6DSO driver,
one commit per issue:

- **Fix uninitialised embedded sensor struct**: `lsm6dso_enable_tilt_int()`
  declared an `lsm6dso_emb_sens_t` on the stack, set only the tilt bit, and
  wrote the whole struct to EMB_FUNC_EN_A/EMB_FUNC_EN_B. Stack residue in the
  other members could therefore enable the pedometer, significant-motion or
  FSM engines at random. The struct is now zero-initialised and the current
  embedded-function state is read back first, so only the tilt bit changes.
- **Bound the data-ready drain loop**: `handle_interrupt()` looped until every
  data-ready status bit cleared, but a bit is only cleared when a handler
  reads the corresponding output registers. With an enabled data-ready source
  that has no registered handler (or a handler that defers the fetch), the
  loop never terminated, hanging the trigger thread or the system workqueue.
  The exit condition is now handler-qualified and the loop is additionally
  bounded; the GPIO interrupt is re-armed afterwards as before, so nothing is
  lost.
- **Fix sensor hub humidity value conversion**: the humidity converter set
  `val1 = rh` *and* `val2 = rh * 1000000`, i.e. it put the whole value in the
  fractional field instead of the remainder — roughly doubling the reported
  %RH and leaving `val2` far outside its ±999999 range. Replaced with
  `sensor_value_from_float()`. The same copy/pasted code exists in the
  ism330dhcx and iis2iclx sensor-hub converters and is fixed here too;
  lsm6dso16is and lsm6dsv16x carry the same bug and are fixed in their own
  PRs.