### PR TITLE
drivers: sensor: adt7420: don't disable the other trigger's interrupt

### DIFF
--- a/drivers/sensor/adi/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adi/adt7420/adt7420_trigger.c
@@ -187,15 +187,18 @@ int adt7420_trigger_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	setup_int(dev, false);
-	setup_ct(dev, false);
-
 	if (trig->type != SENSOR_TRIG_THRESHOLD) {
 		LOG_ERR("Unsupported sensor trigger");
 		return -ENOTSUP;
 	}
 
 	if (trig->chan == SENSOR_CHAN_ADT7420_CRIT_TEMP) {
+		if (cfg->ct_gpio.port == NULL) {
+			return -ENOTSUP;
+		}
+
+		setup_ct(dev, false);
+
 		drv_data->ct_handler = handler;
 		if (handler != NULL) {
 			drv_data->ct_trigger = trig;
@@ -210,6 +213,12 @@ int adt7420_trigger_set(const struct device *dev,
 			}
 		}
 	} else {
+		if (cfg->int_gpio.port == NULL) {
+			return -ENOTSUP;
+		}
+
+		setup_int(dev, false);
+
 		drv_data->th_handler = handler;
 
 		if (handler != NULL) {


### PR DESCRIPTION
`adt7420_trigger_set()` unconditionally disabled the GPIO interrupts for both
the INT and CT pins before configuring the requested trigger, but only
re-enabled the one belonging to the trigger being set. On a board wiring both
pins, registering a trigger on one channel therefore silently and permanently
killed a trigger already registered on the other.

Each disable is now scoped to its own `trig->chan` branch and guarded on that
pin actually being present, and the `SENSOR_TRIG_THRESHOLD` validation is
hoisted above any GPIO change so an unsupported trigger type no longer
disturbs the interrupt configuration on its way to returning -ENOTSUP.