### PR TITLE
drivers: sensor: bmm350: fix suspended device on bad ODR/OSR and stuck stream

### DIFF
--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -558,13 +558,6 @@ static int set_mag_odr_osr(const struct device *dev, const struct sensor_value *
 	osr_bits = ((rx_buf[2] & BMM350_AVG_MSK) >> BMM350_AVG_POS);
 	odr_bits = ((rx_buf[2] & BMM350_ODR_MSK) >> BMM350_ODR_POS);
 
-	/* to change sampling rate, device needs to suspend first */
-	ret = bmm350_set_powermode(dev, BMM350_SUSPEND_MODE);
-	if (ret < 0) {
-		LOG_ERR("failed to set suspend mode");
-		return -EIO;
-	}
-
 	if (odr) {
 		odr_bits = mag_odr_to_reg(odr);
 	}
@@ -575,8 +568,17 @@ static int set_mag_odr_osr(const struct device *dev, const struct sensor_value *
 			return -EINVAL;
 		}
 	}
+
+	/* to change sampling rate, device needs to suspend first */
+	ret = bmm350_set_powermode(dev, BMM350_SUSPEND_MODE);
+	if (ret < 0) {
+		LOG_ERR("failed to set suspend mode");
+		return -EIO;
+	}
+
 	if (bmm350_set_odr_performance((enum bmm350_data_rates)odr_bits, osr_bits, dev) < 0) {
 		LOG_ERR("bmm350_set_odr_performance failed");
+		(void)bmm350_set_powermode(dev, BMM350_NORMAL_MODE);
 		return -EIO;
 	}
 

--- a/drivers/sensor/bosch/bmm350/bmm350_stream.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_stream.c
@@ -125,6 +125,7 @@ static void bmm350_event_handler(const struct device *dev)
 			      &buf, &buf_len);
 	CHECKIF(err != 0 || buf_len < sizeof(struct bmm350_encoded_data)) {
 		LOG_ERR("Failed to allocate BMM350 encoded buffer: %d", err);
+		(void)atomic_set(&data->stream.state, BMM350_STREAM_ON);
 		bmm350_stream_result(dev, -ENOMEM);
 		return;
 	}
@@ -137,6 +138,7 @@ static void bmm350_event_handler(const struct device *dev)
 					 edata->payload.buf, sizeof(edata->payload.buf),
 					 &read_sqe);
 	CHECKIF(err < 0 || !read_sqe) {
+		(void)atomic_set(&data->stream.state, BMM350_STREAM_ON);
 		bmm350_stream_result(dev, err);
 		return;
 	}


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the BMM350 magnetometer
driver, one commit per issue:

- **Validate ODR/OSR before suspending device**: the attribute handler put the
  device into suspend mode *before* validating the requested oversampling
  value, so an out-of-range value returned -EINVAL with the sensor left
  suspended and no way for the caller to know sampling had stopped. The
  requested value is now validated before any power-mode change.
- **Restore stream state on event error paths**: the streaming event handler
  set the stream state to BUSY on entry but left it set when it bailed out on
  an error, so every subsequent event was dropped as "already busy" and the
  stream never recovered. The state is now restored on those paths.