### PR TITLE
drivers: sensor: lsm9ds0_mfd: fix die temperature units and magn ODR mapping

### DIFF
--- a/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -140,8 +140,7 @@ static inline int lsm9ds0_mfd_magn_set_odr_raw(const struct device *dev,
 static const struct {
 	int freq_int;
 	int freq_micro;
-} lsm9ds0_mfd_magn_odr_map[] = { {0, 0},
-				 {3, 125000},
+} lsm9ds0_mfd_magn_odr_map[] = { {3, 125000},
 				 {6, 250000},
 				 {12, 500000},
 				 {25, 0},

--- a/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -553,10 +553,17 @@ static int lsm9ds0_mfd_channel_get(const struct device *dev,
 		return lsm9ds0_mfd_get_magn(dev, chan, val);
 #endif
 #if !defined(LSM9DS0_MFD_TEMP_DISABLED)
-	case SENSOR_CHAN_DIE_TEMP:
-		val->val1 = data->sample_temp;
-		val->val2 = 0;
-		return 0;
+	case SENSOR_CHAN_DIE_TEMP: {
+		/*
+		 * OUT_TEMP_[LH]_XM hold a 12-bit right-justified two's
+		 * complement value, 8 LSB/degC, relative to a ~25 degC
+		 * reference. Re-normalise the sign from bit 11 (a no-op when
+		 * the device already sign-extends bits 15:12) and convert.
+		 */
+		int32_t raw = sign_extend((uint32_t)(uint16_t)data->sample_temp, 11);
+
+		return sensor_value_from_micro(val, (int64_t)raw * 125000 + 25000000);
+	}
 #endif
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the LSM9DS0 MFD driver, one
commit per issue:

- **Convert DIE_TEMP to degrees Celsius**: `channel_get()` returned the raw
  12-bit sample count as `val1` with `val2` hardcoded to 0, while every other
  channel in the driver converts to SI units — so the temperature channel
  reported an LSB count rather than degrees, unscaled and with no sign
  handling. The 12-bit two's-complement sample is now sign-normalised and
  converted at 8 LSB/°C with the reference offset applied.
- **Fix magnetometer runtime ODR mapping**: the runtime ODR table carried a
  phantom leading 0 Hz entry, so every index was shifted by one relative to
  the CTRL_REG5_XM M_ODR encoding (0 = 3.125 Hz … 5 = 100 Hz). Each requested
  rate programmed the next rate up, and the top entry wrote a reserved code.