### PR TITLE
dts: bindings: mmc: renesas: Remove max-bus-freq requirement

### DIFF
--- a/dts/bindings/sdhc/renesas,rcar-mmc.yaml
+++ b/dts/bindings/sdhc/renesas,rcar-mmc.yaml
@@ -17,9 +17,6 @@ properties:
   pinctrl-names:
     required: true
 
-  max-bus-freq:
-    required: true
-
   non-removable:
     type: boolean
     description: |


### PR DESCRIPTION
sdhc.yaml already provides a default value for max-bus-freq, so requiring the property does not make sense. Remove it.