### PR TITLE
drivers/smbus: it51xxx: Add PEC support and shell command

### DIFF
--- a/drivers/smbus/Kconfig.it51xxx
+++ b/drivers/smbus/Kconfig.it51xxx
@@ -4,6 +4,7 @@
 config SMBUS_ITE_IT51XXX
 	bool "ITE SMBus driver"
 	default y
+	select CRC
 	depends on DT_HAS_ITE_IT51XXX_SMBUS_ENABLED
 	help
 	  Enable ITE SMBus driver.

--- a/drivers/smbus/smbus_ite_it51xxx.c
+++ b/drivers/smbus/smbus_ite_it51xxx.c
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/crc.h>
 #include <zephyr/sys/util.h>
 
 #include "smbus_utils.h"
@@ -193,9 +194,38 @@ struct smbus_it51xxx_data {
 	uint8_t blk_len;
 	/* Host Notify peripheral address captured from NDADR */
 	uint8_t notify_addr;
+	uint8_t pec_crc;
+	uint8_t pec_recv;
 	bool blk_is_write;
 	bool blk_active;
+	bool pec_sw;
 };
+
+static inline void it51xxx_smb_pec_update(const struct device *dev, const uint8_t *buf, size_t len)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+
+	data->pec_crc = crc8_ccitt(data->pec_crc, buf, len);
+}
+
+static inline bool it51xxx_smb_pec_sw_check(const struct device *dev, enum smbus_direction rw,
+					    uint8_t protocol)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	/*
+	 * SMBus Process Call and FIFO mode of Block Read do not support PEC hardware check.
+	 */
+	if ((protocol == SMBUS_CMD_PROC_CALL) ||
+	    (cfg->fifo_enable && protocol == SMBUS_CMD_BLOCK && rw == SMBUS_MSG_READ)) {
+		data->pec_sw = true;
+	} else {
+		data->pec_sw = false;
+	}
+
+	return data->pec_sw;
+}
 
 static void it51xxx_smb_reset(const struct device *dev)
 {
@@ -233,6 +263,9 @@ static inline void it51xxx_smb_xfer_reset(struct smbus_it51xxx_data *data, uint1
 	data->blk_idx = 0;
 	data->blk_len = 0;
 	data->blk_rlen = NULL;
+	data->pec_sw = false;
+	data->pec_crc = 0;
+	data->pec_recv = 0;
 	k_sem_reset(&data->xfer_done);
 }
 
@@ -314,20 +347,59 @@ static void it51xxx_smb_host_disable(const struct device *dev, uint8_t status)
 	sys_write8(status, cfg->host_base + SMB_HOSTARn);
 }
 
+static inline void it51xxx_smb_pec_setup(const struct device *dev, enum smbus_direction rw,
+					 uint8_t protocol)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	if (!(data->dev_config & SMBUS_MODE_PEC) || protocol == SMBUS_CMD_QUICK) {
+		/*
+		 * No PEC for this transaction; clear any stale MAHPF from a previous
+		 * PEC transaction
+		 */
+		data->pec_sw = false;
+		sys_write8(SMB_MAHPCE, cfg->host_base + SMB_SPESRn);
+		return;
+	}
+
+	if (it51xxx_smb_pec_sw_check(dev, rw, protocol)) {
+		sys_write8(SMB_MAHPCE, cfg->host_base + SMB_SPESRn);
+	} else {
+		/* Supports HW PEC calculation */
+		sys_write8(SMB_MAHPCE | SMB_MAHPF, cfg->host_base + SMB_SPESRn);
+	}
+}
+
 static inline void it51xxx_smb_target_addr(const struct device *dev, uint16_t addr,
 					   enum smbus_direction rw)
 {
 	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
 	uint8_t target_addr;
 
 	target_addr = (uint8_t)((addr << 1) | (rw == SMBUS_MSG_READ ? SMB_DIR : 0));
 	sys_write8(target_addr, cfg->host_base + SMB_TRASLAn);
+
+	if (data->pec_sw) {
+		/*
+		 * FIFO Block Read: target_addr (=ADDR+R) is what's written to TRASLAn,
+		 * but on the wire the command byte still goes out under ADDR+W first;
+		 * ADDR+R only appears later via the hardware's own repeated START. PEC must
+		 * be seeded with the actual first byte on the wire (ADDR+W), not target_addr.
+		 */
+		if (rw == SMBUS_MSG_READ) {
+			target_addr &= ~SMB_DIR;
+		}
+		it51xxx_smb_pec_update(dev, &target_addr, 1);
+	}
 }
 
 static void it51xxx_smb_write_cmd(const struct device *dev, enum smbus_direction rw, uint8_t cmd,
 				  uint8_t protocol)
 {
 	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
 
 	/* Optional read/write command byte */
 	switch (protocol) {
@@ -347,11 +419,16 @@ static void it51xxx_smb_write_cmd(const struct device *dev, enum smbus_direction
 		sys_write8(cmd, cfg->host_base + SMB_HOCMDRn);
 		break;
 	}
+
+	if (data->pec_sw) {
+		it51xxx_smb_pec_update(dev, &cmd, 1);
+	}
 }
 
 static void it51xxx_smb_write_data(const struct device *dev, uint8_t *buf, size_t count)
 {
 	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
 
 	LOG_DBG("%s: count=%u buf[0]=0x%02x", dev->name, count, buf[0]);
 
@@ -360,6 +437,10 @@ static void it51xxx_smb_write_data(const struct device *dev, uint8_t *buf, size_
 	if (count > 1) {
 		LOG_DBG("%s: buf[1]=0x%02x", dev->name, buf[1]);
 		sys_write8(buf[1], cfg->host_base + SMB_D1REGn);
+	}
+
+	if (data->pec_sw) {
+		it51xxx_smb_pec_update(dev, buf, count);
 	}
 }
 
@@ -426,6 +507,7 @@ static inline int smbus_it51xxx_get_start_cmd(const struct device *dev, uint8_t 
 static int it51xxx_smb_set_protocol(const struct device *dev, uint8_t protocol)
 {
 	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
 	int ret;
 	uint8_t start_cmd;
 
@@ -433,6 +515,10 @@ static int it51xxx_smb_set_protocol(const struct device *dev, uint8_t protocol)
 	if (ret) {
 		it51xxx_smb_host_disable(dev, 0);
 		return ret;
+	}
+
+	if (data->dev_config & SMBUS_MODE_PEC && protocol != SMBUS_CMD_QUICK) {
+		start_cmd |= SMB_PEC_EN;
 	}
 
 	LOG_DBG("%s: IRQ num=%u start_cmd=0x%02x", dev->name, cfg->smbus_irq, start_cmd);
@@ -460,6 +546,9 @@ static int it51xxx_smb_parsing_err(const struct device *dev)
 	if (data->err == ETIMEDOUT) {
 		/* Connection timed out */
 		LOG_ERR("Transaction time out");
+	} else if (data->err == EINVAL) {
+		/* PEC check error */
+		LOG_ERR("PEC check error");
 	} else {
 		/* Host error bits message*/
 		if (data->err & SMB_TMOE) {
@@ -516,11 +605,25 @@ static inline uint8_t it51xxx_smb_protocol_data_len(uint8_t protocol)
 static inline void it51xxx_smb_read_data(const struct device *dev, uint8_t *buf, uint8_t count)
 {
 	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
 
 	buf[0] = sys_read8(cfg->host_base + SMB_D0REGn);
 
 	if (count > 1) {
 		buf[1] = sys_read8(cfg->host_base + SMB_D1REGn);
+	}
+
+	if (data->pec_sw) {
+		/* Repeated-start Read address byte, as it appears on the wire */
+		uint8_t addr_r_byte = (uint8_t)((data->xfer_addr << 1) | SMB_DIR);
+
+		it51xxx_smb_pec_update(dev, &addr_r_byte, 1);
+		it51xxx_smb_pec_update(dev, buf, count);
+		/*
+		 * PEC data is loaded from the SMBus into this register and is then
+		 * read by software
+		 */
+		data->pec_recv = sys_read8(cfg->host_base + SMB_PECERCRn);
 	}
 }
 
@@ -556,7 +659,48 @@ static int it51xxx_smb_fifo_block_read_data(const struct device *dev, uint8_t *r
 		rx_buf[i] = sys_read8(cfg->host_base + SMB_HOBDBRn);
 	}
 
+	if (data->pec_sw) {
+		/* Repeated-start Read address byte, as it appears on the wire */
+		uint8_t addr_r_byte = (uint8_t)((data->xfer_addr << 1) | SMB_DIR);
+
+		it51xxx_smb_pec_update(dev, &addr_r_byte, 1);
+		it51xxx_smb_pec_update(dev, &byte_count, 1);
+		it51xxx_smb_pec_update(dev, rx_buf, byte_count);
+		/*
+		 * PEC data is loaded from the SMBus into this register and is then
+		 * read by software
+		 */
+		data->pec_recv = sys_read8(cfg->host_base + SMB_PECERCRn);
+	}
+
 	return 0;
+}
+
+static void it51xxx_smb_pec_verify(const struct device *dev, uint8_t protocol)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	/* Only if this transaction actually requested PEC */
+	if (!(data->dev_config & SMBUS_MODE_PEC) || protocol == SMBUS_CMD_QUICK) {
+		return;
+	}
+
+	if (!data->pec_sw) {
+		uint8_t spesr = sys_read8(cfg->host_base + SMB_SPESRn);
+
+		/* HW PEC check */
+		if (spesr & SMB_MAHPCE) {
+			/* W/C the error bit */
+			sys_write8(SMB_MAHPCE, cfg->host_base + SMB_SPESRn);
+			data->err = EINVAL;
+		}
+	} else {
+		/* SW PEC check */
+		if (data->pec_crc != data->pec_recv) {
+			data->err = EINVAL;
+		}
+	}
 }
 
 static int it51xxx_smbus_xfer(const struct device *dev, uint16_t periph_addr,
@@ -582,6 +726,12 @@ static int it51xxx_smbus_xfer(const struct device *dev, uint16_t periph_addr,
 
 	/* Enable SMBus host interface */
 	it51xxx_smb_host_enable(dev);
+
+	/*
+	 * Must run before it51xxx_smb_target_addr(): decides HW vs SW PEC
+	 * for this transaction, and SW-PEC CRC accumulation starts there.
+	 */
+	it51xxx_smb_pec_setup(dev, rw, protocol);
 
 	/* Target address + R/W bit */
 	it51xxx_smb_target_addr(dev, periph_addr, rw);
@@ -620,9 +770,14 @@ static int it51xxx_smbus_xfer(const struct device *dev, uint16_t periph_addr,
 	}
 
 	if (cfg->fifo_enable && protocol == SMBUS_CMD_BLOCK && rw == SMBUS_MSG_READ) {
-		it51xxx_smb_fifo_block_read_data(dev, rx_buf, rx_cnt);
+		ret = it51xxx_smb_fifo_block_read_data(dev, rx_buf, rx_cnt);
+		if (ret) {
+			goto done;
+		}
 	}
 
+	/* PEC check */
+	it51xxx_smb_pec_verify(dev, protocol);
 done:
 	if (cfg->fifo_enable && protocol == SMBUS_CMD_BLOCK) {
 		it51xxx_smb_fifo_enable(dev, false);
@@ -676,6 +831,10 @@ static int smbus_it51xxx_configure(const struct device *dev, uint32_t config_val
 	if ((config_value & SMBUS_MODE_CONTROLLER) == 0) {
 		LOG_ERR("%s: Only controller mode is supported", dev->name);
 		return -EIO;
+	}
+
+	if (config_value & SMBUS_MODE_PEC) {
+		LOG_INF("%s: PEC enabled", dev->name);
 	}
 
 	if (config_value & SMBUS_MODE_HOST_NOTIFY) {

--- a/drivers/smbus/smbus_shell.c
+++ b/drivers/smbus/smbus_shell.c
@@ -399,6 +399,49 @@ static int cmd_smbus_block_read(const struct shell *sh,
 	return 0;
 }
 
+/* smbus pec <device> <0|1> */
+static int cmd_smbus_pec(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	uint32_t config;
+	int enable;
+	int ret = 0;
+
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+
+	enable = shell_strtol(argv[2], 10, &ret);
+	if (ret) {
+		shell_error(sh, "Failed to parse enable: %d", ret);
+		return ret;
+	}
+
+	ret = smbus_get_config(dev, &config);
+	if (ret < 0) {
+		shell_error(sh, "SMBus: Failed to get config (%d)", ret);
+		return ret;
+	}
+
+	if (enable) {
+		config |= SMBUS_MODE_PEC;
+	} else {
+		config &= ~SMBUS_MODE_PEC;
+	}
+
+	ret = smbus_configure(dev, config);
+	if (ret < 0) {
+		shell_error(sh, "SMBus: Failed to set config (%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "PEC %s", enable ? "enabled" : "disabled");
+
+	return 0;
+}
+
 /* Device name autocompletion support */
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
@@ -458,6 +501,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_smbus_cmds,
 		      "SMBus: Block Read command\n"
 		      "Usage: block_read <device> <addr> <cmd>",
 		      cmd_smbus_block_read, 4, 0),
+	SHELL_CMD_ARG(pec, &dsub_device_name,
+		      "SMBus: enable/disable PEC\n"
+		      "Usage: pec <device> <0|1>",
+		      cmd_smbus_pec, 3, 0),
 	SHELL_SUBCMD_SET_END     /* Array terminated. */
 );
 /* clang-format off */

--- a/tests/drivers/smbus/smbus_it51xxx/src/smbus_host_test.c
+++ b/tests/drivers/smbus/smbus_it51xxx/src/smbus_host_test.c
@@ -10,6 +10,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/smbus.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/crc.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/ztest.h>
 
@@ -24,6 +25,7 @@ LOG_MODULE_REGISTER(smbus_api_test, LOG_LEVEL_INF);
  *
  * Test groups:
  *   - protocol coverage: one test per SMBus API entry point
+ *   - PEC: positive (write + read) and negative (corrupted read PEC)
  *   - Host Notify: callback registration mechanics
  *   - error paths: address NACK, invalid block params, target NACK
  */
@@ -35,6 +37,13 @@ static const struct device *const target_bus = DEVICE_DT_GET(DT_ALIAS(i2c_target
 #define SMBUS_TEST_UNUSED_ADDR 0x70
 
 #define SMBUS_HOST_NOTIFY_MAX_PORT 2
+
+static uint8_t pec_calc(const uint8_t *bytes, size_t len)
+{
+	uint8_t crc = 0;
+
+	return crc8_ccitt(crc, bytes, len);
+}
 
 /* Suite setup / before/ after / teardown */
 static void *smbus_api_setup(void)
@@ -236,6 +245,125 @@ ZTEST(smbus_api, test_block_pcall_not_supported)
 
 	/* smbus_it51xxx_block_pcall() is not currently supported */
 	zassert_equal(ret, -ENOSYS, "expected -ENOSYS, got %d", ret);
+}
+
+/* PEC test */
+ZTEST(smbus_api, test_pec_byte_data_write)
+{
+	int ret;
+	uint8_t wire[3];
+	uint8_t expected_pec;
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER | SMBUS_MODE_PEC);
+	zassert_equal(ret, 0, "smbus_configure(PEC) failed: %d", ret);
+
+	ret = smbus_byte_data_write(host, SMBUS_TEST_TARGET_ADDR, 0x11, 0x22);
+	zassert_equal(ret, 0, "smbus_byte_data_write (PEC) failed: %d", ret);
+
+	/* The PEC is calculated for comparison with the PEC obtained after actual transmission */
+	wire[0] = (uint8_t)(SMBUS_TEST_TARGET_ADDR << 1) | 0;
+	wire[1] = 0x11;
+	wire[2] = 0x22;
+	expected_pec = pec_calc(wire, sizeof(wire));
+	LOG_INF("Byte data write: expected pec=0x%02x", expected_pec);
+
+	zassert_equal(test_target_write_len(), 3, "expected cmd+data+PEC");
+	zassert_equal(test_target_write_buf()[2], expected_pec,
+		      "PEC mismatch: hw=0x%02x expected=0x%02x", test_target_write_buf()[2],
+		      expected_pec);
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER);
+	zassert_equal(ret, 0, "smbus_configure(restore) failed: %d", ret);
+}
+
+ZTEST(smbus_api, test_pec_byte_data_read)
+{
+	int ret;
+	uint8_t wire[4];
+	uint8_t expected_pec;
+	uint8_t preload[2];
+	uint8_t val = 0;
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER | SMBUS_MODE_PEC);
+	zassert_equal(ret, 0, "smbus_configure(PEC) failed: %d", ret);
+
+	/* The PEC is calculated for comparison with the PEC obtained after actual transmission */
+	wire[0] = (uint8_t)(SMBUS_TEST_TARGET_ADDR << 1) | 0;
+	wire[1] = 0x12;
+	wire[2] = (uint8_t)(SMBUS_TEST_TARGET_ADDR << 1) | 1;
+	wire[3] = 0x9b;
+	expected_pec = pec_calc(wire, sizeof(wire));
+	LOG_INF("Byte data read: expected pec=0x%02x", expected_pec);
+
+	preload[0] = wire[3];
+	preload[1] = expected_pec;
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_byte_data_read(host, SMBUS_TEST_TARGET_ADDR, 0x12, &val);
+
+	zassert_equal(ret, 0, "smbus_byte_data_read (PEC) failed: %d", ret);
+	zassert_equal(val, 0x9b, "wrong data byte");
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER);
+	zassert_equal(ret, 0, "smbus_configure(restore) failed: %d", ret);
+}
+
+ZTEST(smbus_api, test_pec_byte_data_read_corrupt)
+{
+	int ret;
+	/* Deliberately wrong PEC byte */
+	uint8_t preload[2] = {0x9b, 0x00};
+	uint8_t val = 0;
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER | SMBUS_MODE_PEC);
+	zassert_equal(ret, 0, "smbus_configure(PEC) failed: %d", ret);
+
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_byte_data_read(host, SMBUS_TEST_TARGET_ADDR, 0x12, &val);
+
+	zassert_equal(ret, -EIO, "expected -EIO on PEC mismatch, got %d", ret);
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER);
+	zassert_equal(ret, 0, "smbus_configure(restore) failed: %d", ret);
+}
+
+ZTEST(smbus_api, test_pec_block_read)
+{
+	int ret;
+	uint8_t wire[6];
+	uint8_t expected_pec;
+	uint8_t preload[4];
+	uint8_t out_buf[SMBUS_BLOCK_BYTES_MAX];
+	uint8_t len = 0;
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER | SMBUS_MODE_PEC);
+	zassert_equal(ret, 0, "smbus_configure(PEC) failed: %d", ret);
+
+	/* The PEC is calculated for comparison with the PEC obtained after actual transmission */
+	wire[0] = (uint8_t)(SMBUS_TEST_TARGET_ADDR << 1) | 0;
+	wire[1] = 0x12;
+	wire[2] = (uint8_t)(SMBUS_TEST_TARGET_ADDR << 1) | 1;
+	wire[3] = 0x02;
+	wire[4] = 0x1f;
+	wire[5] = 0x1e;
+	expected_pec = pec_calc(wire, sizeof(wire));
+	LOG_INF("Byte data read: expected pec=0x%02x", expected_pec);
+
+	preload[0] = wire[3];
+	preload[1] = wire[4];
+	preload[2] = wire[5];
+	preload[3] = expected_pec;
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_block_read(host, SMBUS_TEST_TARGET_ADDR, 0x12, &len, out_buf);
+	zassert_equal(ret, 0, "smbus_byte_data_read (PEC) failed: %d", ret);
+	zassert_equal(len, 2, "wrong data len");
+	/* The comparison data does not include length and PEC data */
+	zassert_mem_equal(out_buf, &preload[1], sizeof(preload) - 2, "wrong block data read back");
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER);
+	zassert_equal(ret, 0, "smbus_configure(restore) failed: %d", ret);
 }
 
 /* Host Notify test */


### PR DESCRIPTION
Add SMBus PEC support for the it51xxx driver and a shell command to enable or disable PEC at runtime.
Also add test coverage for SMBus PEC generation and verification, including corrupted PEC handling and Block Read transactions.