### PR TITLE
drivers: xen: forward vcpu in context domctls

### DIFF
--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -67,7 +67,7 @@ int xen_domctl_getvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt)
 	xen_domctl_t domctl = {
 		.cmd = XEN_DOMCTL_getvcpucontext,
 		.domain = domid,
-		.u.vcpucontext.vcpu = 0,
+		.u.vcpucontext.vcpu = vcpu,
 	};
 
 	set_xen_guest_handle(domctl.u.vcpucontext.ctxt, ctxt);
@@ -80,7 +80,7 @@ int xen_domctl_setvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt)
 	xen_domctl_t domctl = {
 		.cmd = XEN_DOMCTL_setvcpucontext,
 		.domain = domid,
-		.u.vcpucontext.vcpu = 0,
+		.u.vcpucontext.vcpu = vcpu,
 	};
 
 	set_xen_guest_handle(domctl.u.vcpucontext.ctxt, ctxt);


### PR DESCRIPTION
Use the vcpu argument when issuing XEN_DOMCTL_getvcpucontext and XEN_DOMCTL_setvcpucontext. The wrappers already accept a target vCPU, but always forwarded vCPU0 to Xen.

This lets Dom0 callers get or set the context of secondary vCPUs in SMP domains.

Assisted-by: Codex:gpt-5 cpp-code-map