### PR TITLE
drivers: pcie: msi: map MSI-X table as non-cacheable

### DIFF
--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -98,7 +98,8 @@ static bool map_msix_table_entries(pcie_bdf_t bdf,
 
 	k_mem_map_phys_bare((uint8_t **)&mapped_table,
 			    bar.phys_addr + table_offset,
-			    n_vector * PCIE_MSIR_TABLE_ENTRY_SIZE, K_MEM_PERM_RW);
+			    n_vector * PCIE_MSIR_TABLE_ENTRY_SIZE,
+			    K_MEM_CACHE_NONE | K_MEM_PERM_RW);
 
 	for (i = 0; i < n_vector; i++) {
 		vectors[i].msix_vector = (struct msix_vector *)


### PR DESCRIPTION
MSI-X table is device memory. Map it with K_MEM_CACHE_NONE so vector and control register writes are not cached on architectures that require uncached MMIO for MSI-X programming.