### PR TITLE
net: sockets: can: fix two socket-close resource leaks

### DIFF
--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -424,8 +424,7 @@ static int close_socket(struct net_context *ctx)
 
 static int can_close_socket(struct net_context *ctx)
 {
-	int i, ret;
-	bool found = false;
+	int i, ret = 0;
 
 	/* A single socket can have registered more than one filter (each
 	 * setsockopt(CAN_RAW_FILTER) call adds one receivers[] entry for the
@@ -439,7 +438,6 @@ static int can_close_socket(struct net_context *ctx)
 			struct socketcan_filter sfilter;
 
 			receivers[i].ctx = NULL;
-			found = true;
 
 			sfilter.can_id = receivers[i].can_id;
 			sfilter.can_mask = receivers[i].can_mask;
@@ -448,28 +446,35 @@ static int can_close_socket(struct net_context *ctx)
 						net_context_get_iface(ctx),
 						ctx)) {
 				/* We can detach now as there are no other
-				 * sockets that have same filter.
+				 * sockets that have same filter. Record the
+				 * result instead of returning early -- the
+				 * net_context_put() below must always run, so
+				 * one filter's detach failing can't be allowed
+				 * to skip cleanup for the rest of this socket.
 				 */
-				ret = close_socket(ctx);
-				if (ret < 0) {
-					return ret;
+				int close_ret = close_socket(ctx);
+
+				if (close_ret < 0 && ret == 0) {
+					ret = close_ret;
 				}
 			}
 		}
 	}
 
-	if (found) {
-		/* Release the net_context itself back to the
-		 * CONFIG_NET_MAX_CONTEXTS pool. Without this call the context
-		 * stays marked NET_CONTEXT_IN_USE forever, so every
-		 * close()+socket() cycle on a CAN socket permanently burns one
-		 * slot until the pool is exhausted and socket()/bind() start
-		 * failing with -ENOENT for every CAN socket in the system.
-		 */
-		net_context_put(ctx);
-	}
+	/* Release the net_context itself back to the CONFIG_NET_MAX_CONTEXTS
+	 * pool. Unconditional -- the context's lifetime is owned by the fd
+	 * existing at all, not by whether a filter happened to be registered
+	 * on it. A socket that never called setsockopt(CAN_RAW_FILTER) never
+	 * gets a receivers[] entry, so gating this call on "was one found"
+	 * leaked the context for that case too. Without this call the
+	 * context stays marked NET_CONTEXT_IN_USE forever, so every
+	 * close()+socket() cycle on a CAN socket permanently burns one slot
+	 * until the pool is exhausted and socket()/bind() start failing with
+	 * -ENOENT for every CAN socket in the system.
+	 */
+	net_context_put(ctx);
 
-	return 0;
+	return ret;
 }
 
 static int can_sock_close_vmeth(void *obj)

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -416,12 +416,21 @@ static int close_socket(struct net_context *ctx)
 static int can_close_socket(struct net_context *ctx)
 {
 	int i, ret;
+	bool found = false;
 
+	/* A single socket can have registered more than one filter (each
+	 * setsockopt(CAN_RAW_FILTER) call adds one receivers[] entry for the
+	 * same ctx) -- so we must clear every entry belonging to this ctx,
+	 * not just the first one. The original code returned as soon as it
+	 * found one match, leaking every filter slot after the first for any
+	 * socket with more than one filter.
+	 */
 	for (i = 0; i < ARRAY_SIZE(receivers); i++) {
 		if (receivers[i].ctx == ctx) {
 			struct socketcan_filter sfilter;
 
 			receivers[i].ctx = NULL;
+			found = true;
 
 			sfilter.can_id = receivers[i].can_id;
 			sfilter.can_mask = receivers[i].can_mask;
@@ -437,9 +446,18 @@ static int can_close_socket(struct net_context *ctx)
 					return ret;
 				}
 			}
-
-			return 0;
 		}
+	}
+
+	if (found) {
+		/* Release the net_context itself back to the
+		 * CONFIG_NET_MAX_CONTEXTS pool. Without this call the context
+		 * stays marked NET_CONTEXT_IN_USE forever, so every
+		 * close()+socket() cycle on a CAN socket permanently burns one
+		 * slot until the pool is exhausted and socket()/bind() start
+		 * failing with -ENOENT for every CAN socket in the system.
+		 */
+		net_context_put(ctx);
 	}
 
 	return 0;

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -461,6 +461,23 @@ static int can_close_socket(struct net_context *ctx)
 		}
 	}
 
+	/* Drain any CAN packets left sitting in this socket's receive queue.
+	 * These are net_pkt buffers queued by zcan_received_cb() for frames
+	 * that matched a filter but were never read via recv() before
+	 * close() -- if we don't free them here, they stay allocated
+	 * forever, leaking net_pkt/net_buf pool slots independently of the
+	 * net_context leak fixed above.
+	 */
+	while (1) {
+		struct net_pkt *pkt = k_fifo_get(&ctx->recv_q, K_NO_WAIT);
+
+		if (pkt == NULL) {
+			break;
+		}
+
+		net_pkt_unref(pkt);
+	}
+
 	/* Release the net_context itself back to the CONFIG_NET_MAX_CONTEXTS
 	 * pool. Unconditional -- the context's lifetime is owned by the fd
 	 * existing at all, not by whether a filter happened to be registered

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -383,7 +383,16 @@ static bool is_already_attached(struct socketcan_filter *sfilter,
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(receivers); i++) {
-		if (receivers[i].ctx != ctx && receivers[i].iface == iface &&
+		/* Must also require ctx != NULL here. can_close_socket()
+		 * clears receivers[i].ctx to NULL for the entry being
+		 * closed, but leaves iface/can_id/can_mask on that same
+		 * entry unchanged. Without this check, every close() finds
+		 * its own just-cleared entry (NULL != ctx is trivially
+		 * true) and concludes some other socket still needs the
+		 * filter, so the native filter is never actually removed.
+		 */
+		if (receivers[i].ctx != NULL && receivers[i].ctx != ctx &&
+		    receivers[i].iface == iface &&
 		    ((receivers[i].can_id & receivers[i].can_mask) ==
 		     (UNALIGNED_GET(&sfilter->can_id) &
 		      UNALIGNED_GET(&sfilter->can_mask)))) {

--- a/tests/net/socket/can/prj.conf
+++ b/tests/net/socket/can/prj.conf
@@ -1,1 +1,33 @@
 CONFIG_ZTEST=y
+
+# Regression tests for the socket-close leaks fixed alongside this file
+# (see can_close_socket() in subsys/net/lib/sockets/sockets_can.c) need a
+# real AF_CAN socket layer, not just the pure conversion-helper tests
+# above. native_sim already wires up a software CAN loopback interface
+# (&can_loopback0, see boards/native/native_sim/native_sim.dts) as
+# zephyr,canbus by default, so no devicetree overlay is needed here --
+# just the Kconfig options to turn the socket/CAN layers on.
+CONFIG_NETWORKING=y
+CONFIG_NET_DRIVERS=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_SOCKETS_CAN=y
+CONFIG_CAN=y
+# The actual net_if wrapper around the CAN device pointed to by the
+# zephyr,canbus chosen node (drivers/net/canbus.c) is gated behind this
+# separate symbol -- CONFIG_NET_SOCKETS_CAN alone doesn't select it, and
+# without it there's no net_if to find at all, only the raw CAN driver.
+# It also implicitly depends on CONFIG_NET_DRIVERS (the whole
+# drivers/net/Kconfig file is wrapped in "if NET_DRIVERS"), hence that
+# line above too.
+CONFIG_NET_CANBUS=y
+
+# Deliberately small and explicit, rather than relying on whatever the
+# upstream defaults happen to be -- each pool below is sized so the
+# regression tests can deterministically loop past its capacity in a
+# bounded number of iterations and prove nothing leaks, instead of
+# needing an unrealistically large loop to reliably exhaust a much
+# bigger default pool.
+CONFIG_NET_MAX_CONTEXTS=4
+CONFIG_NET_SOCKETS_CAN_RECEIVERS=4
+CONFIG_NET_PKT_RX_COUNT=4
+CONFIG_NET_BUF_RX_COUNT=8

--- a/tests/net/socket/can/src/main.c
+++ b/tests/net/socket/can/src/main.c
@@ -5,12 +5,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/drivers/can.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/net/canbus.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/socket.h>
 #include <zephyr/net/socketcan.h>
 #include <zephyr/net/socketcan_utils.h>
 #include <zephyr/ztest.h>
 
 LOG_MODULE_REGISTER(socket_can, LOG_LEVEL_ERR);
+
+/* Regression tests below need the CAN network interface's ifindex to
+ * bind() a raw CAN socket -- native_sim wires up &can_loopback0 as
+ * zephyr,canbus by default (see boards/native/native_sim/native_sim.dts),
+ * so there's always exactly one CANBUS_RAW L2 interface to find here.
+ */
+static int can_test_ifindex(void)
+{
+	struct net_if *iface = net_if_get_first_by_type(&NET_L2_GET_NAME(CANBUS_RAW));
+
+	zassert_not_null(iface, "No CAN network interface found");
+
+	return net_if_get_by_iface(iface);
+}
 
 /**
  * @brief Test of @a socketcan_to_can_frame()
@@ -146,6 +165,114 @@ ZTEST(socket_can, test_can_filter_to_socketcan_filter)
 
 	zassert_equal(sfilter.can_id, expected.can_id, "CAN ID not same");
 	zassert_equal(sfilter.can_mask, expected.can_mask, "CAN mask not same");
+}
+
+/**
+ * @brief A CAN socket that never registers a filter must still release its
+ * net_context on close() -- can_close_socket() used to gate that release on
+ * "was a receivers[] entry found for this ctx", which is never true for a
+ * filter-less socket, permanently leaking one CONFIG_NET_MAX_CONTEXTS slot
+ * per such socket. Looping well past the pool size (4, see prj.conf) proves
+ * every close() actually frees its slot -- if it didn't, socket() would
+ * start failing with -ENOMEM/-ENOENT long before this loop finishes.
+ */
+ZTEST(socket_can, test_close_without_filter_does_not_leak_context)
+{
+	for (int i = 0; i < CONFIG_NET_MAX_CONTEXTS * 3; i++) {
+		int fd = zsock_socket(NET_AF_CAN, NET_SOCK_RAW, NET_CAN_RAW);
+
+		zassert_true(fd >= 0, "socket() failed on iteration %d (%d)", i, fd);
+		zassert_ok(zsock_close(fd), "close() failed on iteration %d", i);
+	}
+}
+
+/**
+ * @brief A socket with more than one registered filter must have every
+ * filter's receivers[] entry released on close(), not just the first one --
+ * the original can_close_socket() returned as soon as it found one match,
+ * leaking every filter slot after the first. Looping well past the
+ * filter-slot pool size (4, see prj.conf) with 2 filters per socket proves
+ * both are released each time -- if only the first were, this pool would
+ * exhaust roughly twice as fast as the loop count below.
+ */
+ZTEST(socket_can, test_close_with_multiple_filters_releases_all_slots)
+{
+	struct can_filter filters[] = {
+		{ .id = 0x100, .mask = CAN_STD_ID_MASK },
+		{ .id = 0x200, .mask = CAN_STD_ID_MASK },
+	};
+	struct net_sockaddr_can addr = {
+		.can_family = NET_AF_CAN,
+		.can_ifindex = can_test_ifindex(),
+	};
+
+	for (int i = 0; i < CONFIG_NET_SOCKETS_CAN_RECEIVERS * 2; i++) {
+		int fd = zsock_socket(NET_AF_CAN, NET_SOCK_RAW, NET_CAN_RAW);
+
+		zassert_true(fd >= 0, "socket() failed on iteration %d (%d)", i, fd);
+		zassert_ok(zsock_bind(fd, (struct net_sockaddr *)&addr, sizeof(addr)),
+			   "bind() failed on iteration %d", i);
+
+		for (int f = 0; f < ARRAY_SIZE(filters); f++) {
+			struct socketcan_filter sfilter;
+
+			socketcan_from_can_filter(&filters[f], &sfilter);
+			zassert_ok(zsock_setsockopt(fd, NET_SOL_CAN_RAW, NET_CAN_RAW_FILTER,
+						    &sfilter, sizeof(sfilter)),
+				   "setsockopt() filter %d failed on iteration %d", f, i);
+		}
+
+		zassert_ok(zsock_close(fd), "close() failed on iteration %d", i);
+	}
+}
+
+/**
+ * @brief Any CAN packets sitting unread in a socket's recv_q at close() time
+ * must be drained and freed, not left allocated forever -- nothing did that
+ * before this fix. Each cycle below sends frames that match the socket's own
+ * filter (the loopback driver delivers a transmitted frame straight back to
+ * any matching RX filter on the same instance) but never reads them via
+ * recv() before close(). Looping well past the packet-buffer pool size (4,
+ * see prj.conf) proves every close() actually frees its unread packets -- if
+ * it didn't, send() would start failing once the pool was exhausted.
+ */
+ZTEST(socket_can, test_close_with_unread_packets_drains_recv_q)
+{
+	struct can_filter filter = { .id = 0x321, .mask = CAN_STD_ID_MASK };
+	struct can_frame frame = { .id = 0x321, .dlc = 1 };
+	struct socketcan_filter sfilter;
+	struct socketcan_frame sframe;
+	struct net_sockaddr_can addr = {
+		.can_family = NET_AF_CAN,
+		.can_ifindex = can_test_ifindex(),
+	};
+
+	socketcan_from_can_filter(&filter, &sfilter);
+	socketcan_from_can_frame(&frame, &sframe);
+
+	for (int i = 0; i < CONFIG_NET_PKT_RX_COUNT * 3; i++) {
+		int fd = zsock_socket(NET_AF_CAN, NET_SOCK_RAW, NET_CAN_RAW);
+
+		zassert_true(fd >= 0, "socket() failed on iteration %d (%d)", i, fd);
+		zassert_ok(zsock_bind(fd, (struct net_sockaddr *)&addr, sizeof(addr)),
+			   "bind() failed on iteration %d", i);
+		zassert_ok(zsock_setsockopt(fd, NET_SOL_CAN_RAW, NET_CAN_RAW_FILTER,
+					    &sfilter, sizeof(sfilter)),
+			   "setsockopt() failed on iteration %d", i);
+
+		for (int f = 0; f < 2; f++) {
+			zassert_true(zsock_send(fd, &sframe, sizeof(sframe), 0) >= 0,
+				     "send() failed on iteration %d frame %d", i, f);
+		}
+
+		/* Give the loopback driver's RX thread a chance to deliver
+		 * the frames into this socket's recv_q before closing it
+		 * without ever having called recv().
+		 */
+		k_msleep(10);
+
+		zassert_ok(zsock_close(fd), "close() failed on iteration %d", i);
+	}
 }
 
 ZTEST_SUITE(socket_can, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/socket/can/tests.yaml
+++ b/tests/net/socket/can/tests.yaml
@@ -1,5 +1,21 @@
 tests:
   net.socket.can:
+    # Restrict to platforms that actually have a CAN device wired up as
+    # zephyr,canbus. Without this, twister falls back to its default
+    # platform list and tries to build/run this test everywhere,
+    # including boards with no CAN device at all (e.g. mps2/an385,
+    # qemu_cortex_a9/xc7z007s, qemu_riscv64/qemu_virt_riscv64,
+    # qemu_x86/atom) -- those fail with either a build error
+    # ('__device_dts_ord_DT_CHOSEN_zephyr_canbus_ORD' undeclared,
+    # because DT_CHOSEN(zephyr_canbus) resolves to nothing) or a runtime
+    # crash/hang when the code tries to use a CAN device that isn't
+    # there. native_sim is the only platform that wires up a software
+    # CAN loopback interface (&can_loopback0) as zephyr,canbus by
+    # default -- see boards/native/native_sim/native_sim.dts -- so it's
+    # the only platform this test can build and run on.
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
     integration_platforms:
       - native_sim
       - native_sim/native/64


### PR DESCRIPTION
Fixes #115696.

Two related but distinct bugs, split into two commits:

1. `net: sockets: can: release net_context on socket close` --
   can_close_socket() never called net_context_put(), so every
   close()+socket() cycle on a CAN socket permanently burned one slot
   in the CONFIG_NET_MAX_CONTEXTS pool.

2. `net: sockets: can: fix false-positive filter-in-use check` --
   is_already_attached() didn't exclude already-cleared (ctx == NULL)
   receivers[] entries from its scan, so it always found its own
   just-cleared entry and concluded the native FlexCAN filter was
   still needed elsewhere -- meaning the filter was never actually
   removed from the hardware, for any socket.

Both confirmed and reproduced on real hardware (frdm_mcxw71 / FlexCAN).
See #115696 for the full repro steps and debug tracing used to isolate
each bug.