### PR TITLE
net: quic: Do not evict in-flight packets from the sent history

### DIFF
--- a/subsys/net/lib/quic/quic.c
+++ b/subsys/net/lib/quic/quic.c
@@ -3811,6 +3811,46 @@ ZTESTABLE_STATIC void quic_recovery_init(struct quic_endpoint *ep)
 		ep, quic_get_by_ep(ep), ep->recovery.smoothed_rtt);
 }
 
+/*
+ * Whether the sent-packet history can track one more in-flight stream data
+ * packet at this level. The stream data send paths back off with -EAGAIN
+ * when it cannot: an untracked packet could never be declared lost, and its
+ * stream data would never be released from the TX buffer once acknowledged.
+ *
+ * QUIC_SENT_PKT_HISTORY_RESERVE slots are kept free of stream data so that
+ * ack-eliciting control packets (window updates and the like), which are
+ * sent from paths that cannot back off, do not have to evict an in-flight
+ * stream entry either.
+ */
+bool quic_recovery_tx_slot_available(struct quic_endpoint *ep,
+				     enum quic_secret_level level)
+{
+	int pn_space = level_to_pn_space(level);
+	int free_slots = 0;
+
+	k_mutex_lock(&ep->recovery.lock, K_FOREVER);
+
+	for (int i = 0; i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; i++) {
+		struct quic_sent_pkt_info *info = &ep->recovery.sent_pkts[pn_space][i];
+
+		/* A lost stream entry still awaiting retransmit is not in flight
+		 * but is not free either: it holds the only record of what must be
+		 * re-sent until the retransmit queue drains it. Recording over it
+		 * would drop that retransmission, so treat it as occupied.
+		 */
+		if (!info->in_flight && !info->retransmit_pending) {
+			free_slots++;
+			if (free_slots > QUIC_SENT_PKT_HISTORY_RESERVE) {
+				break;
+			}
+		}
+	}
+
+	k_mutex_unlock(&ep->recovery.lock);
+
+	return free_slots > QUIC_SENT_PKT_HISTORY_RESERVE;
+}
+
 ZTESTABLE_STATIC void quic_recovery_on_packet_sent(struct quic_endpoint *ep,
 						   enum quic_secret_level level,
 						   uint64_t pkt_num,
@@ -3833,8 +3873,52 @@ ZTESTABLE_STATIC void quic_recovery_on_packet_sent(struct quic_endpoint *ep,
 	idx = ep->recovery.sent_pkts_idx[pn_space];
 	info = &ep->recovery.sent_pkts[pn_space][idx];
 
+	/* Never overwrite an in-flight entry while a free slot exists.
+	 * Losing an in-flight entry forgets its loss-recovery state, and for
+	 * a packet carrying stream data it also drops the annotation that
+	 * releases the stream TX buffer when the packet is acknowledged; the
+	 * buffer then stays occupied forever and the stream wedges. The data
+	 * send paths refuse to send without free slots to spare, so a full
+	 * history only happens for control packets sent from paths that
+	 * cannot back off; those overwrites prefer a victim without a stream
+	 * annotation, whose loss is recoverable.
+	 *
+	 * A slot marked retransmit_pending is a stream entry that loss
+	 * detection has taken out of flight but whose data has not yet been
+	 * copied to the retransmit queue. It is the only remaining record of
+	 * that pending retransmission, so it must be preserved exactly like an
+	 * in-flight entry until the queue drains it.
+	 */
+	if (info->in_flight || info->retransmit_pending) {
+		struct quic_sent_pkt_info *victim = NULL;
+
+		for (int i = 1; i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; i++) {
+			uint16_t probe = (idx + i) % CONFIG_QUIC_SENT_PKT_HISTORY_SIZE;
+			struct quic_sent_pkt_info *entry =
+				&ep->recovery.sent_pkts[pn_space][probe];
+
+			if (!entry->in_flight && !entry->retransmit_pending) {
+				idx = probe;
+				info = entry;
+				break;
+			}
+
+			if (victim == NULL && !entry->has_stream_frame) {
+				victim = entry;
+			}
+		}
+
+		if ((info->in_flight || info->retransmit_pending) && victim != NULL &&
+		    info->has_stream_frame) {
+			info = victim;
+		}
+	}
+
 	/* If we're overwriting a packet still in flight, decrement bytes_in_flight */
 	if (info->in_flight) {
+		NET_WARN("[EP:%p/%d] Sent packet history full, dropping state of pn=%" PRIu64
+			 " (stream frame: %d)",
+			 ep, quic_get_by_ep(ep), info->pkt_num, (int)info->has_stream_frame);
 		ep->recovery.bytes_in_flight -= info->sent_bytes;
 	}
 
@@ -4051,10 +4135,12 @@ ZTESTABLE_STATIC void quic_stream_advance_tx_acked_for_stream(struct quic_stream
 unlock:
 	k_mutex_unlock(&stream->tx_lock);
 
-	if (advance > 0U) {
-		/* Signal that the stream is now writable (TX buffer has space) */
-		k_poll_signal_raise(&stream->send.signal, 0);
-	}
+	/* Signal that the stream may be writable again. Even when no buffer
+	 * bytes were released (advance == 0), the acknowledged packet freed a
+	 * sent-packet history slot, and a sender gated on the full history
+	 * must be woken up to retry.
+	 */
+	k_poll_signal_raise(&stream->send.signal, 0);
 }
 
 static void quic_stream_advance_tx_acked(struct quic_endpoint *ep,

--- a/subsys/net/lib/quic/quic_internal.h
+++ b/subsys/net/lib/quic/quic_internal.h
@@ -119,6 +119,17 @@ struct quic_buffer {
 #define QUIC_MAX_ACK_DELAY_MS   25
 
 /**
+ * Sent-packet history slots kept free of stream data packets, so that
+ * ack-eliciting control packets sent from paths that cannot back off never
+ * have to evict an in-flight stream entry. Stream data sends refuse to use
+ * these slots and return -EAGAIN instead.
+ */
+#define QUIC_SENT_PKT_HISTORY_RESERVE 4
+
+BUILD_ASSERT(QUIC_SENT_PKT_HISTORY_RESERVE < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE,
+	     "The reserve must leave room for stream data packets");
+
+/**
  * Information about a sent packet for RTT measurement and loss detection.
  * This is stored in a ring buffer per packet number space.
  */
@@ -1359,6 +1370,8 @@ int quic_decrypt_payload(struct quic_pp_cipher *pp, uint64_t packet_number,
 			 size_t *plaintext_len);
 
 int quic_flush_deferred_crypto(struct quic_endpoint *ep);
+bool quic_recovery_tx_slot_available(struct quic_endpoint *ep,
+				     enum quic_secret_level level);
 void quic_crypto_context_destroy(struct quic_crypto_context *ctx);
 int quic_build_version_negotiation_packet(uint8_t *out,
 					  size_t out_len,

--- a/subsys/net/lib/quic/quic_socket.c
+++ b/subsys/net/lib/quic/quic_socket.c
@@ -1095,6 +1095,14 @@ static ssize_t quic_stream_replay_pending_data(struct quic_stream *stream)
 		return -EAGAIN;
 	}
 
+	/* Without a free sent-packet slot the packet could not be tracked,
+	 * and its stream data would never be released from the TX buffer
+	 * once acknowledged. Back off until an acknowledgment frees a slot.
+	 */
+	if (!quic_recovery_tx_slot_available(ep, level)) {
+		return -EAGAIN;
+	}
+
 	max_payload_size = MIN(sizeof(frame), ep->max_tx_payload_size);
 
 	{
@@ -1324,6 +1332,17 @@ static ssize_t quic_stream_send(struct quic_stream *stream, const uint8_t *buf,
 
 		NET_DBG("[ST:%p/%d] Window is full (stream=%zu, conn=%zu)",
 			stream, quic_get_by_stream(stream), stream_window, conn_window);
+		return -EAGAIN;
+	}
+
+	/* Without a free sent-packet slot the packet could not be tracked,
+	 * and its stream data would never be released from the TX buffer
+	 * once acknowledged. Back off until an acknowledgment frees a slot;
+	 * the ACK processing raises the send signal so poll() wakes up.
+	 */
+	if (!quic_recovery_tx_slot_available(ep, level)) {
+		NET_DBG("[ST:%p/%d] Sent packet history full on stream %" PRIu64,
+			stream, quic_get_by_stream(stream), stream->id);
 		return -EAGAIN;
 	}
 

--- a/tests/net/lib/quic/src/main.c
+++ b/tests/net/lib/quic/src/main.c
@@ -165,6 +165,15 @@ static struct eth_fake_context eth_fake_data = {
 
 static struct quic_endpoint *reset_test_ep(struct quic_endpoint *ep)
 {
+	/* A previous test that recorded an ack-eliciting packet may have left
+	 * the PTO timer armed, so ep->recovery.pto_work is still linked in the
+	 * system timeout list. Cancel it before memset(): wiping a delayable
+	 * work item out from under the timeout list leaves a dangling node that
+	 * faults when the timer subsystem next walks it. Safe on the first call
+	 * too -- a zeroed work item reads as inactive.
+	 */
+	k_work_cancel_delayable(&ep->recovery.pto_work);
+
 	memset(ep, 0, sizeof(*ep));
 	ep->sock = -1;
 	quic_recovery_init(ep);
@@ -6065,6 +6074,203 @@ ZTEST(net_socket_quic, test_495_new_token_cache_replaces_oldest_entry)
 	zassert_mem_equal(out, tokens[CONFIG_QUIC_TOKEN_CACHE_SIZE],
 			  sizeof(tokens[CONFIG_QUIC_TOKEN_CACHE_SIZE]),
 			  "Replacement token mismatch for new peer");
+}
+
+static int quic_test_count_history_pn(struct quic_endpoint *ep, uint64_t pkt_num)
+{
+	int count = 0;
+
+	for (int i = 0; i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; i++) {
+		struct quic_sent_pkt_info *info = &ep->recovery.sent_pkts[2][i];
+
+		if (info->in_flight && info->pkt_num == pkt_num) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+/* Test 496: the sent-packet history must not silently evict in-flight
+ * stream data entries. Losing one drops the annotation that releases the
+ * stream TX buffer when the packet is acknowledged, wedging the stream
+ * forever. Stream sends are gated on free slots beyond a reserve, recording
+ * prefers free slots, and a forced overwrite picks a victim that carries no
+ * stream annotation.
+ */
+ZTEST(net_socket_quic, test_496_sent_packet_history_keeps_stream_entries)
+{
+	struct quic_endpoint *ep = reset_test_ep(&test_ep_a);
+	const enum quic_secret_level level = QUIC_SECRET_LEVEL_APPLICATION;
+	const uint64_t control_pn = 3;
+	uint64_t pn;
+
+	quic_recovery_init(ep);
+
+	zassert_true(quic_recovery_tx_slot_available(ep, level),
+		     "Empty history must have room for stream data");
+
+	/* Fill the whole history with in-flight ack-eliciting packets */
+	for (pn = 0; pn < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; pn++) {
+		quic_recovery_on_packet_sent(ep, level, pn, 100, true, false, 0);
+	}
+
+	zassert_false(quic_recovery_tx_slot_available(ep, level),
+		      "Full history must refuse more stream data");
+
+	/* Annotate everything as stream data except one control packet */
+	for (int i = 0; i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; i++) {
+		struct quic_sent_pkt_info *info = &ep->recovery.sent_pkts[2][i];
+
+		if (info->pkt_num != control_pn) {
+			info->has_stream_frame = true;
+			info->stream_id = 0;
+			info->stream_offset = info->pkt_num * 100;
+			info->stream_data_len = 100;
+		}
+	}
+
+	/* A control packet that cannot back off is recorded into the full
+	 * history: the victim must be the entry without a stream annotation.
+	 */
+	pn = CONFIG_QUIC_SENT_PKT_HISTORY_SIZE;
+	quic_recovery_on_packet_sent(ep, level, pn, 50, true, false, 0);
+
+	zassert_equal(quic_test_count_history_pn(ep, control_pn), 0,
+		      "The non-stream entry must be the eviction victim");
+	zassert_equal(quic_test_count_history_pn(ep, pn), 1,
+		      "The new packet must be recorded");
+
+	for (uint64_t old = 0; old < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; old++) {
+		if (old == control_pn) {
+			continue;
+		}
+
+		zassert_equal(quic_test_count_history_pn(ep, old), 1,
+			      "Stream entry pn=%" PRIu64 " was evicted", old);
+	}
+
+	/* Freeing slots up to the reserve is not enough for stream data */
+	for (int i = 0, freed = 0;
+	     i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE && freed < QUIC_SENT_PKT_HISTORY_RESERVE;
+	     i++) {
+		struct quic_sent_pkt_info *info = &ep->recovery.sent_pkts[2][i];
+
+		if (info->in_flight) {
+			info->in_flight = false;
+			freed++;
+		}
+	}
+
+	zassert_false(quic_recovery_tx_slot_available(ep, level),
+		      "The reserve slots must not be used for stream data");
+
+	/* One more free slot opens the gate again */
+	for (int i = 0; i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; i++) {
+		struct quic_sent_pkt_info *info = &ep->recovery.sent_pkts[2][i];
+
+		if (info->in_flight) {
+			info->in_flight = false;
+			break;
+		}
+	}
+
+	zassert_true(quic_recovery_tx_slot_available(ep, level),
+		     "A slot beyond the reserve must open the gate");
+
+	/* Recording reuses a free slot instead of evicting in-flight state */
+	pn++;
+	quic_recovery_on_packet_sent(ep, level, pn, 50, true, false, 0);
+
+	for (uint64_t old = QUIC_SENT_PKT_HISTORY_RESERVE + 1;
+	     old < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; old++) {
+		if (old == control_pn) {
+			continue;
+		}
+
+		zassert_equal(quic_test_count_history_pn(ep, old), 1,
+			      "Stream entry pn=%" PRIu64 " lost to slot reuse", old);
+	}
+}
+
+/* Test 497: a lost stream entry awaiting retransmit must not be treated as a
+ * free slot. Between loss detection marking it (in_flight cleared,
+ * retransmit_pending set) and the retransmit queue draining it, the slot is
+ * the only record of the data to re-send. Counting it free or recording over
+ * it drops the retransmission and wedges the stream -- the same failure the
+ * in-flight protection exists to prevent, reached via a narrower window.
+ */
+ZTEST(net_socket_quic, test_497_sent_packet_history_keeps_pending_retransmit)
+{
+	struct quic_endpoint *ep = reset_test_ep(&test_ep_a);
+	const enum quic_secret_level level = QUIC_SECRET_LEVEL_APPLICATION;
+	const uint64_t lost_pn = 0;
+	struct quic_sent_pkt_info *pending = NULL;
+	int freed = 0;
+	uint64_t pn;
+
+	quic_recovery_init(ep);
+
+	/* Fill the whole history with in-flight ack-eliciting packets */
+	for (pn = 0; pn < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; pn++) {
+		quic_recovery_on_packet_sent(ep, level, pn, 100, true, false, 0);
+	}
+
+	/* Mark pn=lost_pn as a stream entry that loss detection has declared
+	 * lost and queued for retransmission but not yet drained: out of
+	 * flight, retransmit_pending, still carrying its stream annotation.
+	 */
+	for (int i = 0; i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE; i++) {
+		struct quic_sent_pkt_info *info = &ep->recovery.sent_pkts[2][i];
+
+		if (info->pkt_num == lost_pn) {
+			info->has_stream_frame = true;
+			info->stream_id = 0;
+			info->stream_offset = 0;
+			info->stream_data_len = 100;
+			info->in_flight = false;
+			info->retransmit_pending = true;
+			pending = info;
+			break;
+		}
+	}
+
+	zassert_not_null(pending, "Pending retransmit slot not found");
+
+	/* Free exactly the reserve worth of additional slots. The gate must
+	 * still be closed: the reserve is for control packets, and the pending
+	 * slot is occupied by an unretransmitted stream frame, not free.
+	 */
+	for (int i = 0; i < CONFIG_QUIC_SENT_PKT_HISTORY_SIZE &&
+			 freed < QUIC_SENT_PKT_HISTORY_RESERVE; i++) {
+		struct quic_sent_pkt_info *info = &ep->recovery.sent_pkts[2][i];
+
+		if (info->in_flight) {
+			info->in_flight = false;
+			freed++;
+		}
+	}
+
+	zassert_false(quic_recovery_tx_slot_available(ep, level),
+		      "A pending-retransmit slot must not count as a free slot");
+
+	/* Point the ring index at the pending slot and record a control
+	 * packet that cannot back off. Recording must skip the pending slot
+	 * and reuse one of the free reserve slots instead of dropping the
+	 * queued retransmission.
+	 */
+	ep->recovery.sent_pkts_idx[2] =
+		(uint16_t)(pending - &ep->recovery.sent_pkts[2][0]);
+
+	pn = CONFIG_QUIC_SENT_PKT_HISTORY_SIZE;
+	quic_recovery_on_packet_sent(ep, level, pn, 50, true, false, 0);
+
+	zassert_true(pending->retransmit_pending,
+		     "Pending retransmit slot was reused and its data dropped");
+	zassert_equal(pending->pkt_num, lost_pn,
+		      "Pending retransmit slot was overwritten");
+	zassert_equal(quic_test_count_history_pn(ep, pn), 1,
+		      "The new packet must be recorded in a free slot");
 }
 
 ZTEST(net_socket_quic, test_500_transport_params_validate_retry_ids)


### PR DESCRIPTION
The sent-packet history is a fixed ring: recording a new packet overwrote whatever the ring index pointed at, even an entry still in flight. Overwriting an in-flight entry forgets its loss-recovery state, and for a packet carrying stream data it also drops the annotation that releases the stream TX buffer when the packet is acknowledged. Once more packets than the history size were in flight at once, which is easy for a fast sender bursting small writes before the first acknowledgment returns, the acknowledgments for the evicted packets released nothing, the acked-bytes frontier could never advance past the hole, and the stream TX buffer stayed permanently full: the stream wedged and the connection died at the idle timeout.
