### PR TITLE
drivers: sensor: fxls8974: apply ODR changes in standby mode

### DIFF
--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -145,7 +145,9 @@ static int fxls8974_set_odr(const struct device *dev,
 				const struct sensor_value *val, enum fxls8974_wake mode)
 {
 		const struct fxls8974_config *cfg = dev->config;
+		int ret;
 		uint8_t odr;
+		uint8_t was_active = FXLS8974_ACTIVE_OFF;
 		/* val int32 */
 		switch (val->val1) {
 		case 3200:
@@ -205,16 +207,36 @@ static int fxls8974_set_odr(const struct device *dev,
 
 		LOG_DBG("Set %s ODR to 0x%02x", (mode == FXLS8974_WAKE) ? "wake" : "sleep", odr);
 
-		/* Change the attribute and restore active mode. */
+		if (fxls8974_get_active(dev, &was_active)) {
+			LOG_ERR("Could not read active state before ODR change");
+			return -EIO;
+		}
+
+		if (was_active != FXLS8974_ACTIVE_OFF) {
+			if (fxls8974_set_active(dev, FXLS8974_ACTIVE_OFF)) {
+				LOG_ERR("Could not enter standby to change ODR");
+				return -EIO;
+			}
+		}
+
 		if (mode == FXLS8974_WAKE) {
-			return cfg->ops->reg_field_update(dev, FXLS8974_REG_CTRLREG3,
+			ret = cfg->ops->reg_field_update(dev, FXLS8974_REG_CTRLREG3,
 				FXLS8974_CTRLREG3_WAKE_ODR_MASK,
 				odr<<4);
 		} else {
-			return cfg->ops->reg_field_update(dev, FXLS8974_REG_CTRLREG3,
+			ret = cfg->ops->reg_field_update(dev, FXLS8974_REG_CTRLREG3,
 				FXLS8974_CTRLREG3_SLEEP_ODR_MASK,
 				odr);
 		}
+
+		if (was_active != FXLS8974_ACTIVE_OFF) {
+			if (fxls8974_set_active(dev, FXLS8974_ACTIVE_ON)) {
+				LOG_ERR("Could not restore active mode after ODR change");
+				return -EIO;
+			}
+		}
+
+		return ret;
 }
 
 static int fxls8974_attr_set(const struct device *dev,


### PR DESCRIPTION
The FXLS8974 only latches writes to its configuration registers (including CTRL_REG3, which holds the wake/sleep ODR fields) while the device is in STANDBY mode. Writes performed while the device is ACTIVE are silently ignored by the part.

fxls8974_set_odr() only wrote CTRL_REG3 directly. This worked during init(), where the device is still in standby after the software reset, but not at runtime: when the application changes the sampling frequency via sensor_attr_set(SENSOR_ATTR_SAMPLING_FREQUENCY), the device is already ACTIVE, so the register update was dropped without any error. The reported ODR stayed at its init value (6.25 Hz) regardless of the requested rate, producing duplicate samples when polled faster.

Save the current active state, drop to standby, update the ODR, then restore the previous active state. During init the device is already in standby, so the behaviour there is unchanged.

Fixes #115986 