### PR TITLE
drivers: sensor: bmi323: fix channel_get units, PM resume and no-data marker

### DIFF
--- a/drivers/sensor/bosch/bmi323/bmi323.c
+++ b/drivers/sensor/bosch/bmi323/bmi323.c
@@ -90,11 +90,6 @@ static void bosch_bmi323_value_to_sensor_value(struct sensor_value *result, int1
 	result->val2 = frac_part;
 }
 
-static bool bosch_bmi323_value_is_valid(int16_t value)
-{
-	return ((uint16_t)value == 0x8000) ? false : true;
-}
-
 static int bosch_bmi323_validate_chip_id(const struct device *dev)
 {
 	uint16_t sensor_id;

--- a/drivers/sensor/bosch/bmi323/bmi323.c
+++ b/drivers/sensor/bosch/bmi323/bmi323.c
@@ -1200,9 +1200,11 @@ static int bosch_bmi323_pm_resume(const struct device *dev)
 		return ret;
 	}
 
-	/* Soft reset restores chip to power-on defaults: 8g accel, 2000dps gyro */
-	data->acc_full_scale = 8000;  /* ±8G in milli-G */
-	data->gyro_full_scale = 2000000;  /* ±2000dps in micro-dps */
+	if (!data->pm_state_saved) {
+		/* Soft reset restores chip to power-on defaults: 8g accel, 2000dps gyro */
+		data->acc_full_scale = 8000;  /* ±8G in milli-G */
+		data->gyro_full_scale = 2000000;  /* ±2000dps in micro-dps */
+	}
 
 	ret = bosch_bmi323_bus_init(dev);
 
@@ -1227,6 +1229,53 @@ static int bosch_bmi323_pm_resume(const struct device *dev)
 		return ret;
 	}
 
+	if (data->pm_state_saved) {
+		uint16_t buf[2];
+
+		buf[0] = data->saved_acc_conf;
+		buf[1] = data->saved_gyro_conf;
+
+		ret = bosch_bmi323_bus_write_words(dev, IMU_BOSCH_BMI323_REG_ACC_CONF, buf, 2);
+
+		if (ret < 0) {
+			LOG_WRN("Failed to restore acc/gyro config");
+
+			return ret;
+		}
+
+		buf[0] = data->saved_feature_io0;
+
+		ret = bosch_bmi323_bus_write_words(dev, IMU_BOSCH_BMI323_REG_FEATURE_IO0, buf, 1);
+
+		if (ret < 0) {
+			LOG_WRN("Failed to restore feature config");
+
+			return ret;
+		}
+
+		buf[0] = IMU_BOSCH_BMI323_REG_VALUE(FEATURE_IO_STATUS, STATUS, SET);
+
+		ret = bosch_bmi323_bus_write_words(dev, IMU_BOSCH_BMI323_REG_FEATURE_IO_STATUS, buf,
+						   1);
+
+		if (ret < 0) {
+			LOG_WRN("Failed to commit feature config");
+
+			return ret;
+		}
+
+		buf[0] = data->saved_int_map1;
+		buf[1] = data->saved_int_map2;
+
+		ret = bosch_bmi323_bus_write_words(dev, IMU_BOSCH_BMI323_REG_INT_MAP1, buf, 2);
+
+		if (ret < 0) {
+			LOG_WRN("Failed to restore interrupt mapping");
+
+			return ret;
+		}
+	}
+
 	ret = gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret < 0) {
 		LOG_WRN("Failed to configure int");
@@ -1239,12 +1288,45 @@ static int bosch_bmi323_pm_resume(const struct device *dev)
 static int bosch_bmi323_pm_suspend(const struct device *dev)
 {
 	const struct bosch_bmi323_config *config = (const struct bosch_bmi323_config *)dev->config;
+	struct bosch_bmi323_data *data = (struct bosch_bmi323_data *)dev->data;
+	uint16_t buf[2];
 	int ret;
 
 	ret = gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_DISABLE);
 	if (ret < 0) {
 		LOG_WRN("Failed to disable int");
 	}
+
+	ret = bosch_bmi323_bus_read_words(dev, IMU_BOSCH_BMI323_REG_ACC_CONF, buf, 2);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->saved_acc_conf = buf[0];
+	data->saved_gyro_conf = buf[1];
+
+	ret = bosch_bmi323_bus_read_words(dev, IMU_BOSCH_BMI323_REG_INT_MAP1, buf, 2);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->saved_int_map1 = buf[0];
+	data->saved_int_map2 = buf[1];
+
+	ret = bosch_bmi323_bus_read_words(dev, IMU_BOSCH_BMI323_REG_FEATURE_IO0, buf, 1);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->saved_feature_io0 = buf[0];
+	data->pm_state_saved = true;
+
+	data->acc_samples_valid = false;
+	data->gyro_samples_valid = false;
+	data->temperature_valid = false;
 
 	/* Soft reset device to put it into suspend */
 	return bosch_bmi323_soft_reset(dev);

--- a/drivers/sensor/bosch/bmi323/bmi323.c
+++ b/drivers/sensor/bosch/bmi323/bmi323.c
@@ -67,27 +67,28 @@ static int bosch_bmi323_bus_write_words(const struct device *dev, uint8_t offset
 	return bus->api->write_words(bus->context, offset, words, words_count);
 }
 
-static int32_t bosch_bmi323_lsb_from_fullscale(int64_t fullscale)
-{
-	return (fullscale * 1000) / INT16_MAX;
-}
-
 /* lsb is the value of one 1/1000000 LSB */
 static int64_t bosch_bmi323_value_to_micro(int16_t value, int32_t lsb)
 {
 	return ((int64_t)value) * lsb;
 }
 
-/* lsb is the value of one 1/1000000 LSB */
-static void bosch_bmi323_value_to_sensor_value(struct sensor_value *result, int16_t value,
-						   int32_t lsb)
+/* fullscale is the accelerometer range in milli-G */
+static void bosch_bmi323_acc_to_sensor_value(struct sensor_value *result, int16_t value,
+					     int64_t fullscale)
 {
-	int64_t ll_value = (int64_t)value * lsb;
-	int32_t int_part = (int32_t)(ll_value / 1000000);
-	int32_t frac_part = (int32_t)(ll_value % 1000000);
+	int64_t micro = ((int64_t)value * fullscale * SENSOR_G) / (1000LL * INT16_MAX);
 
-	result->val1 = int_part;
-	result->val2 = frac_part;
+	(void)sensor_value_from_micro(result, micro);
+}
+
+/* fullscale is the gyroscope range in milli-dps */
+static void bosch_bmi323_gyro_to_sensor_value(struct sensor_value *result, int16_t value,
+					      int64_t fullscale)
+{
+	int64_t micro = ((int64_t)value * fullscale * SENSOR_PI) / (180000LL * INT16_MAX);
+
+	(void)sensor_value_from_micro(result, micro);
 }
 
 static int bosch_bmi323_validate_chip_id(const struct device *dev)
@@ -886,7 +887,6 @@ static int bosch_bmi323_driver_api_fetch_acc_samples(const struct device *dev)
 	struct sensor_value full_scale;
 	int16_t *buf = (int16_t *)data->acc_samples;
 	int ret;
-	int32_t lsb;
 
 	if (data->acc_full_scale == 0) {
 		ret = bosch_bmi323_driver_api_get_acc_full_scale(dev, &full_scale);
@@ -910,12 +910,10 @@ static int bosch_bmi323_driver_api_fetch_acc_samples(const struct device *dev)
 		return -ENODATA;
 	}
 
-	lsb = bosch_bmi323_lsb_from_fullscale(data->acc_full_scale);
-
 	/* Reuse vector backwards to avoid overwriting the raw values */
-	bosch_bmi323_value_to_sensor_value(&data->acc_samples[2], buf[2], lsb);
-	bosch_bmi323_value_to_sensor_value(&data->acc_samples[1], buf[1], lsb);
-	bosch_bmi323_value_to_sensor_value(&data->acc_samples[0], buf[0], lsb);
+	bosch_bmi323_acc_to_sensor_value(&data->acc_samples[2], buf[2], data->acc_full_scale);
+	bosch_bmi323_acc_to_sensor_value(&data->acc_samples[1], buf[1], data->acc_full_scale);
+	bosch_bmi323_acc_to_sensor_value(&data->acc_samples[0], buf[0], data->acc_full_scale);
 
 	data->acc_samples_valid = true;
 
@@ -928,7 +926,6 @@ static int bosch_bmi323_driver_api_fetch_gyro_samples(const struct device *dev)
 	struct sensor_value full_scale;
 	int16_t *buf = (int16_t *)data->gyro_samples;
 	int ret;
-	int32_t lsb;
 
 	if (data->gyro_full_scale == 0) {
 		ret = bosch_bmi323_driver_api_get_gyro_full_scale(dev, &full_scale);
@@ -953,12 +950,10 @@ static int bosch_bmi323_driver_api_fetch_gyro_samples(const struct device *dev)
 		return -ENODATA;
 	}
 
-	lsb = bosch_bmi323_lsb_from_fullscale(data->gyro_full_scale);
-
 	/* Reuse vector backwards to avoid overwriting the raw values */
-	bosch_bmi323_value_to_sensor_value(&data->gyro_samples[2], buf[2], lsb);
-	bosch_bmi323_value_to_sensor_value(&data->gyro_samples[1], buf[1], lsb);
-	bosch_bmi323_value_to_sensor_value(&data->gyro_samples[0], buf[0], lsb);
+	bosch_bmi323_gyro_to_sensor_value(&data->gyro_samples[2], buf[2], data->gyro_full_scale);
+	bosch_bmi323_gyro_to_sensor_value(&data->gyro_samples[1], buf[1], data->gyro_full_scale);
+	bosch_bmi323_gyro_to_sensor_value(&data->gyro_samples[0], buf[0], data->gyro_full_scale);
 
 	data->gyro_samples_valid = true;
 
@@ -1198,7 +1193,7 @@ static int bosch_bmi323_pm_resume(const struct device *dev)
 	if (!data->pm_state_saved) {
 		/* Soft reset restores chip to power-on defaults: 8g accel, 2000dps gyro */
 		data->acc_full_scale = 8000;  /* ±8G in milli-G */
-		data->gyro_full_scale = 2000000;  /* ±2000dps in micro-dps */
+		data->gyro_full_scale = 2000000;  /* ±2000dps in milli-dps */
 	}
 
 	ret = bosch_bmi323_bus_init(dev);
@@ -1372,7 +1367,7 @@ static int bosch_bmi323_init(const struct device *dev)
 
 	/* Initialize to chip power-on defaults: 8g accel, 2000dps gyro */
 	data->acc_full_scale = 8000;  /* ±8G in milli-G */
-	data->gyro_full_scale = 2000000;  /* ±2000dps in micro-dps */
+	data->gyro_full_scale = 2000000;  /* ±2000dps in milli-dps */
 
 #ifdef CONFIG_SENSOR_ASYNC_API
 	/* Init MPSC ring buffer indices */

--- a/drivers/sensor/bosch/bmi323/bmi323.h
+++ b/drivers/sensor/bosch/bmi323/bmi323.h
@@ -224,6 +224,13 @@ struct bosch_bmi323_data {
 	uint32_t acc_full_scale;
 	uint32_t gyro_full_scale;
 
+	uint16_t saved_acc_conf;
+	uint16_t saved_gyro_conf;
+	uint16_t saved_int_map1;
+	uint16_t saved_int_map2;
+	uint16_t saved_feature_io0;
+	bool pm_state_saved;
+
 	struct gpio_callback gpio_callback;
 	const struct sensor_trigger *trigger;
 	sensor_trigger_handler_t trigger_handler;

--- a/drivers/sensor/bosch/bmi323/bmi323.h
+++ b/drivers/sensor/bosch/bmi323/bmi323.h
@@ -272,6 +272,15 @@ struct bmi323_reading {
 	int16_t temperature;
 };
 
+/* The BMI323 returns 0x8000 in a data register when no valid sample is
+ * available, e.g. the sensor is disabled or its first conversion has not
+ * completed yet.
+ */
+static inline bool bosch_bmi323_value_is_valid(int16_t value)
+{
+	return ((uint16_t)value != 0x8000);
+}
+
 /* RTIO support structures */
 #ifdef CONFIG_SENSOR_ASYNC_API
 

--- a/drivers/sensor/bosch/bmi323/bmi323_async.c
+++ b/drivers/sensor/bosch/bmi323/bmi323_async.c
@@ -235,7 +235,7 @@ static void bmi323_complete_cb(struct rtio *r, const struct rtio_sqe *sqe,
 	edata->has_temp         = fetch_temp;
 	/* acc_full_scale is in milli-G, convert to G */
 	edata->accel_range      = (data->acc_full_scale / 1000);
-	/* gyro_full_scale is in micro-dps, convert to dps */
+	/* gyro_full_scale is in milli-dps, convert to dps */
 	edata->gyro_range       = (data->gyro_full_scale / 1000);
 	edata->reading          = reading;
 

--- a/drivers/sensor/bosch/bmi323/bmi323_async.c
+++ b/drivers/sensor/bosch/bmi323/bmi323_async.c
@@ -202,6 +202,14 @@ static void bmi323_complete_cb(struct rtio *r, const struct rtio_sqe *sqe,
 	reading.gyro_z     = (int16_t)sys_get_le16(&data_raw[10]);
 	reading.temperature = (int16_t)sys_get_le16(&data_raw[12]);
 
+	fetch_accel = fetch_accel && bosch_bmi323_value_is_valid(reading.accel_x) &&
+		      bosch_bmi323_value_is_valid(reading.accel_y) &&
+		      bosch_bmi323_value_is_valid(reading.accel_z);
+	fetch_gyro = fetch_gyro && bosch_bmi323_value_is_valid(reading.gyro_x) &&
+		     bosch_bmi323_value_is_valid(reading.gyro_y) &&
+		     bosch_bmi323_value_is_valid(reading.gyro_z);
+	fetch_temp = fetch_temp && bosch_bmi323_value_is_valid(reading.temperature);
+
 	rc = rtio_sqe_rx_buf(iodev_sqe, sizeof(*edata), sizeof(*edata),
 			&buf, &buf_len);
 	if (rc != 0) {


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the BMI323 driver, one
commit per issue:

- **Restore chip configuration on PM resume**: `pm_suspend()` issues a soft
  reset, which returns ACC_CONF/GYRO_CONF (power mode, ODR, range) and
  INT_MAP1/INT_MAP2 to their power-on defaults, but `pm_resume()` restored
  none of it — so after any PM cycle the sensor came back disabled and with
  its interrupts unmapped. Suspend now saves those registers and resume writes
  them back, keeping the cached full scales rather than clobbering them with
  reset defaults. Cold boot is unchanged.
- **Reject 0x8000 no-data marker in RTIO path**: the synchronous path already
  treats 0x8000 as the "no data available" marker, but the RTIO completion
  path decoded it as a real full-scale reading. The check is now shared, and
  channels whose samples are invalid are excluded from the frame so the
  decoder reports -ENODATA instead of a bogus saturated value.
- **Fix units of synchronous channel_get**: the sync path converted samples
  with a unit-agnostic helper that yielded accelerometer values in **g** and
  gyroscope values in **deg/s**, while the Zephyr sensor API (and this
  driver's own RTIO decoder) require m/s² and rad/s — so every synchronous
  reading was off by roughly 9.8x and 57x respectively. Replaced with
  SI-aware accel/gyro converters and corrected the stale unit comments.