### PR TITLE
drivers: sensor: pixart: fix streaming trigger parsing and decoder issues

### DIFF
--- a/drivers/sensor/pixart/paa3905/paa3905_stream.c
+++ b/drivers/sensor/pixart/paa3905/paa3905_stream.c
@@ -267,7 +267,7 @@ void paa3905_stream_submit(const struct device *dev,
 	struct paa3905_stream stream = {0};
 
 	for (size_t i = 0 ; i < read_config->count ; i++) {
-		switch (read_config->channels[i].chan_type) {
+		switch (read_config->triggers[i].trigger) {
 		case SENSOR_TRIG_DATA_READY:
 			stream.settings.enabled.drdy = true;
 			stream.settings.opt.drdy = read_config->triggers[i].opt;

--- a/drivers/sensor/pixart/paa3905/paa3905_stream.c
+++ b/drivers/sensor/pixart/paa3905/paa3905_stream.c
@@ -26,6 +26,7 @@ static inline void handle_result_on_error(const struct device *dev, int err)
 	struct paa3905_data *data = dev->data;
 	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
 
+	k_timer_stop(&data->stream.timer);
 	data->stream.iodev_sqe = NULL;
 	rtio_iodev_sqe_err(iodev_sqe, err);
 }
@@ -81,10 +82,6 @@ static void paa3905_complete_result(struct rtio *ctx,
 		edata->header.channels |= paa3905_encode_channel(SENSOR_CHAN_POS_DXYZ);
 	}
 
-	if (data->stream.settings.enabled.drdy) {
-		start_drdy_backup_timer(dev);
-	}
-
 	/* Flush RTIO bus CQEs */
 	do {
 		cqe = rtio_cqe_consume(ctx);
@@ -97,8 +94,12 @@ static void paa3905_complete_result(struct rtio *ctx,
 	} while (cqe != NULL);
 
 	if (err < 0) {
-		rtio_iodev_sqe_err(iodev_sqe, err);
+		handle_result_on_error(dev, err);
 		return;
+	}
+
+	if (data->stream.settings.enabled.drdy) {
+		start_drdy_backup_timer(dev);
 	}
 
 	/** Attempt chip recovery if erratic behavior is detected  */

--- a/drivers/sensor/pixart/pat9136/pat9136_decoder.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_decoder.c
@@ -98,7 +98,7 @@ static void pat9136_convert_raw_to_q31(struct pat9136_encoded_data *edata,
 		intermediate = (((int64_t)reading * INT64_C(1000000) * 25.4));
 		intermediate /= resolution;
 
-		intermediate *= ((int64_t)INT32_MAX + 1) / ((1 << shift) * INT64_C(1000000));
+		intermediate = (intermediate * (INT64_C(1) << (31 - shift))) / INT64_C(1000000);
 
 		*out = CLAMP(intermediate, INT32_MIN, INT32_MAX);
 

--- a/drivers/sensor/pixart/pat9136/pat9136_stream.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_stream.c
@@ -167,6 +167,12 @@ static void pat9136_stream_get_data(const struct device *dev)
 		return;
 	}
 
+	/** Only the LOWER resolution registers are read below, as the UPPER
+	 * ones always read back zero (resolution is capped to 199).
+	 */
+	buf->header.resolution.x = 0;
+	buf->header.resolution.y = 0;
+
 	/* X Resolution used for decoding DXY in mm */
 	{
 		val = REG_RESOLUTION_X_LOWER | REG_SPI_READ_BIT;

--- a/drivers/sensor/pixart/pat9136/pat9136_stream.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_stream.c
@@ -332,7 +332,7 @@ void pat9136_stream_submit(const struct device *dev,
 	struct pat9136_stream stream = {0};
 
 	for (size_t i = 0 ; i < read_config->count ; i++) {
-		switch (read_config->channels[i].chan_type) {
+		switch (read_config->triggers[i].trigger) {
 		case SENSOR_TRIG_DATA_READY:
 			stream.settings.enabled.drdy = true;
 			stream.settings.opt.drdy = read_config->triggers[i].opt;

--- a/drivers/sensor/pixart/pat9136/pat9136_stream.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_stream.c
@@ -159,11 +159,13 @@ static void pat9136_stream_get_data(const struct device *dev)
 	CHECKIF(!write_res_x_sqe || !read_res_x_sqe ||
 		!write_res_y_sqe || !read_res_y_sqe ||
 		!write_sqe || !read_sqe || !cb_sqe) {
+		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
 		LOG_ERR("Failed to acquire RTIO SQE's. Dropping all pending SQE's");
 		rtio_sqe_drop_all(data->rtio.ctx);
 
 		data->stream.iodev_sqe = NULL;
-		rtio_iodev_sqe_err(data->stream.iodev_sqe, -ENOMEM);
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
 		return;
 	}
 


### PR DESCRIPTION
This PR fixes five independent correctness bugs across the two PixArt motion
sensor drivers, one commit per issue.

**Both drivers:**
- **Read stream triggers from correct union member**: the stream submit paths
  switched on `read_config->channels[i].chan_type` while comparing
  `SENSOR_TRIG_*` constants and reading `triggers[i].opt`. `channels` and
  `triggers` alias the same union with different element strides, so any
  trigger past index 0 decoded garbage and streaming aborted with -ENOTSUP.
  Both drivers now switch on `read_config->triggers[i].trigger`, matching
  every other streaming driver and these drivers' own error messages.

**paa3905:**
- **Fix dangling stream SQE on bus error**: the bus-error path completed the
  SQE with `rtio_iodev_sqe_err()` without clearing `data->stream.iodev_sqe`,
  after the data-ready backup timer had already been re-armed — so the timer
  later fired against an SQE already returned to the RTIO pool. The timer is
  now started only after the error check, the error path goes through the
  helper that clears the stored SQE, and that helper stops the timer.

**pat9136:**
- **Zero resolution high bytes when streaming**: the streaming path read only
  the RESOLUTION low registers, leaving the upper byte of the cached
  resolution stale, so decoded motion was scaled with a corrupted resolution.
- **Fix zeroed q31 scale for mm channels**: the millimetre scale factor
  performed its integer division before the multiplication, so the computed
  q31 scale was always 0 and every distance decoded as zero.
- **Fix NULL SQE on RTIO acquire failure**: the SQE-exhaustion path called
  `rtio_iodev_sqe_err()` with a NULL pointer.