### PR TITLE
drivers: sensor: adxl362: fix FIFO header ODR and streamed temperature

### DIFF
--- a/drivers/sensor/adi/adxl362/adxl362_decoder.c
+++ b/drivers/sensor/adi/adxl362/adxl362_decoder.c
@@ -11,7 +11,6 @@
 
 /* (2^31 / 2^8(shift) */
 #define ADXL362_TEMP_QSCALE   8388608
-#define ADXL362_TEMP_LSB_PER_C 15
 
 #define ADXL362_COMPLEMENT         0xf000
 
@@ -49,8 +48,10 @@ static inline void adxl362_temp_convert_q31(q31_t *out, int16_t data_in)
 		data_in |= ADXL362_COMPLEMENT;
 	}
 
-	*out = ((data_in - ADXL362_TEMP_BIAS_LSB) / ADXL362_TEMP_LSB_PER_C
-			+ ADXL362_TEMP_BIAS_TEST_CONDITION) * ADXL362_TEMP_QSCALE;
+	int32_t milli_c = (data_in - ADXL362_TEMP_BIAS_LSB) * ADXL362_TEMP_MC_PER_LSB +
+			  (ADXL362_TEMP_BIAS_TEST_CONDITION * 1000);
+
+	*out = (q31_t)(((int64_t)milli_c * ADXL362_TEMP_QSCALE) / 1000);
 }
 
 static inline void adxl362_accel_convert_q31(q31_t *out, int16_t data_in, int32_t range)

--- a/drivers/sensor/adi/adxl362/adxl362_stream.c
+++ b/drivers/sensor/adi/adxl362/adxl362_stream.c
@@ -199,6 +199,7 @@ static void adxl362_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	hdr->timestamp = data->timestamp;
 	hdr->int_status = data->status;
 	hdr->selected_range = data->selected_range;
+	hdr->accel_odr = data->accel_odr;
 	hdr->has_tmp = data->en_temp_read;
 
 	uint32_t buf_avail = buf_len;


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the ADXL362 driver, one
commit per issue:

- **Populate accel_odr in FIFO header**: the streaming path never filled in
  the encoded header's `accel_odr` field, leaving it zero. The decoder uses
  that field to index the sample-period table, so it read out of bounds and
  computed sample timestamps from a bogus period.
- **Fix streamed die temperature resolution**: the streaming temperature
  conversion divided by a decoder-local sensitivity of 15 LSB/°C before
  applying the Q31 scale, truncating readings to whole degrees — and that
  sensitivity disagreed with the driver header's own 65 m°C/LSB constant used
  by the synchronous path. The conversion now uses the header constant and
  keeps the fractional part via a 64-bit intermediate.