### PR TITLE
net: quic: Implement key update for 1-RTT packets

### DIFF
--- a/subsys/net/lib/quic/quic.c
+++ b/subsys/net/lib/quic/quic.c
@@ -1008,6 +1008,29 @@ ZTESTABLE_STATIC void quic_crypto_context_destroy(struct quic_crypto_context *ct
 }
 
 /*
+ * Destroy the key update state: the previous- and next-generation RX keys
+ * and the current traffic secrets, which could otherwise be used to derive
+ * every future generation.
+ */
+ZTESTABLE_STATIC void quic_key_update_destroy(struct quic_key_update *ku)
+{
+	if (ku->prev_rx_pp.initialized) {
+		psa_destroy_key(ku->prev_rx_pp.key_id);
+	}
+
+	if (ku->next_rx_pp.initialized) {
+		psa_destroy_key(ku->next_rx_pp.key_id);
+	}
+
+	crypto_zero(&ku->prev_rx_pp, sizeof(ku->prev_rx_pp));
+	crypto_zero(&ku->next_rx_pp, sizeof(ku->next_rx_pp));
+	crypto_zero(ku->next_rx_secret, sizeof(ku->next_rx_secret));
+	crypto_zero(ku->rx_secret, sizeof(ku->rx_secret));
+	crypto_zero(ku->tx_secret, sizeof(ku->tx_secret));
+	ku->initialized = false;
+}
+
+/*
  * HKDF-Extract (RFC 5869 Section 2.2)
  * PRK = HMAC-Hash(salt, IKM)
  */
@@ -2039,6 +2062,116 @@ static bool quic_pp_setup_ex(struct quic_pp_cipher *pp_cipher,
 }
 
 /*
+ * RFC 9001 Section 6.1: the next-generation traffic secret is derived from
+ * the current one with the "quic ku" label. The header protection key is
+ * not updated.
+ */
+ZTESTABLE_STATIC int quic_ku_next_secret(const struct quic_key_update *ku,
+					 const uint8_t *secret, uint8_t *next)
+{
+	return quic_hkdf_expand_label_ex(ku->hash_alg,
+					 secret, ku->secret_len,
+					 (const uint8_t *)"quic ku",
+					 sizeof("quic ku") - 1,
+					 NULL, 0,
+					 next, ku->secret_len);
+}
+
+/*
+ * Move the send direction to the next key generation: derive the next TX
+ * traffic secret, replace the TX packet protection cipher with one keyed
+ * from it, and flip the TX key phase bit. The old send keys are destroyed;
+ * unlike receive keys they are never needed again.
+ */
+static int quic_ku_advance_tx(struct quic_endpoint *ep)
+{
+	struct quic_key_update *ku = &ep->crypto.ku;
+	struct quic_pp_cipher next_pp = { 0 };
+	uint8_t next_secret[QUIC_HASH_MAX_LEN];
+	int ret = 0;
+
+	if (quic_ku_next_secret(ku, ku->tx_secret, next_secret) != 0) {
+		ret = -EIO;
+		goto out;
+	}
+
+	if (!quic_pp_setup_ex(&next_pp, ku->hash_alg, ku->cipher_algo,
+			      next_secret, ku->secret_len)) {
+		ret = -EIO;
+		goto out;
+	}
+
+	/* The send path reads the TX key phase while building the header and
+	 * the TX cipher while encrypting, both under send_lock. A peer-initiated
+	 * update runs this transition on the RX thread, so serialize the whole
+	 * generation swap with sends (and with a concurrent local initiation);
+	 * otherwise a send can emit a header for one generation and encrypt with
+	 * the other, or use the cipher after it was destroyed.
+	 */
+	k_mutex_lock(&ep->send_lock, K_FOREVER);
+
+	psa_destroy_key(ep->crypto.application.tx.pp.key_id);
+	ep->crypto.application.tx.pp = next_pp;
+
+	memcpy(ku->tx_secret, next_secret, ku->secret_len);
+	ku->tx_phase ^= 1U;
+	ku->tx_phase_first_pn = ep->tx_pn.application;
+	ku->tx_phase_acked = false;
+
+	k_mutex_unlock(&ep->send_lock);
+
+out:
+	crypto_zero(next_secret, sizeof(next_secret));
+	crypto_zero(&next_pp, sizeof(next_pp));
+
+	return ret;
+}
+
+/*
+ * Start a key update (RFC 9001 Section 6.1). Packets sent from here on are
+ * protected with the next-generation keys and carry a flipped key phase
+ * bit; the peer is expected to move its own send keys to the same phase.
+ *
+ * Runs in whatever thread the caller is in; like the rest of the endpoint
+ * crypto state it relies on the caller not racing the RX path for the
+ * same endpoint.
+ *
+ * TODO: there is no production caller yet, so a Zephyr endpoint can follow a
+ * peer-initiated update but never starts one itself. RFC 9001 Section 6.6
+ * requires initiating an update before the AEAD confidentiality limit is
+ * reached; wire this to packet-protection usage accounting so keys rotate
+ * before their usage limit rather than only in response to the peer.
+ */
+int quic_endpoint_initiate_key_update(struct quic_endpoint *ep)
+{
+	struct quic_key_update *ku = &ep->crypto.ku;
+
+	/* RFC 9001 Section 6.1: an endpoint must not initiate a key update
+	 * prior to having confirmed the handshake. The application keys
+	 * alone are not enough; a client installs them before
+	 * HANDSHAKE_DONE arrives.
+	 */
+	if (!ku->initialized || !ep->crypto.application.initialized ||
+	    !ep->handshake_confirmed) {
+		return -ENOTCONN;
+	}
+
+	/* RFC 9001 Section 6.1: an endpoint must not initiate another
+	 * update until the peer has acknowledged a packet sent in the
+	 * current phase. A phase comparison is not enough: with
+	 * simultaneous updates the phases align while the peer has not
+	 * decrypted anything of ours in this generation, and updating
+	 * again would put the phase bit back where the peer expects it
+	 * while skipping a generation, silently ending the connection.
+	 */
+	if (!ku->tx_phase_acked) {
+		return -EBUSY;
+	}
+
+	return quic_ku_advance_tx(ep);
+}
+
+/*
  * Initialize connection with Initial encryption level.
  *
  * Called when a connection is established, using the Destination Connection ID
@@ -2557,13 +2690,85 @@ static struct quic_crypto_context *quic_get_crypto_context(struct quic_endpoint 
 /*
  * Result structure for fully decrypted packet.
  */
-struct quic_decrypted_packet {
-	uint8_t *payload;           /* Decrypted frames */
-	size_t payload_len;         /* Length of decrypted payload */
-	uint64_t packet_number;     /* Full reconstructed packet number */
-	enum quic_packet_type type; /* Packet type */
-	uint8_t first_byte;         /* Header byte with protection removed */
-};
+/*
+ * Trial-decrypt a 1-RTT packet whose key phase bit does not match the
+ * current RX phase with the next-generation keys (RFC 9001 Section 6.3).
+ * The phase bit is attacker controlled until the AEAD check passes, so
+ * nothing changes on failure: the packet is dropped and every key stays
+ * as it was. On success the update commits atomically: the send keys
+ * follow the peer to the new phase first if needed, then the current RX
+ * keys become the previous generation, kept for reordered packets.
+ */
+static int quic_ku_rx_try_next(struct quic_endpoint *ep,
+			       uint64_t full_pn,
+			       const uint8_t *header, size_t header_len,
+			       const uint8_t *ciphertext, size_t ciphertext_len,
+			       uint8_t *plaintext, size_t plaintext_size,
+			       size_t *plaintext_len)
+{
+	struct quic_key_update *ku = &ep->crypto.ku;
+	struct quic_crypto_context *crypto = &ep->crypto.application;
+	int ret;
+
+	/* The next-generation keys are derived once per generation and kept
+	 * across failed trials (RFC 9001 Section 6.3), so a forged phase bit
+	 * costs one AEAD check like any other forged packet instead of a key
+	 * derivation per packet.
+	 */
+	if (!ku->next_rx_pp.initialized) {
+		ret = quic_ku_next_secret(ku, ku->rx_secret, ku->next_rx_secret);
+		if (ret != 0) {
+			return ret;
+		}
+
+		if (!quic_pp_setup_ex(&ku->next_rx_pp, ku->hash_alg,
+				      ku->cipher_algo, ku->next_rx_secret,
+				      ku->secret_len)) {
+			crypto_zero(ku->next_rx_secret, sizeof(ku->next_rx_secret));
+			return -EIO;
+		}
+	}
+
+	ret = quic_decrypt_payload(&ku->next_rx_pp, full_pn, header, header_len,
+				   ciphertext, ciphertext_len,
+				   plaintext, plaintext_size, plaintext_len);
+	if (ret != 0) {
+		/* Unauthenticated phase flip: drop the packet, keep every
+		 * key as it was, retain the derived candidate.
+		 */
+		return ret;
+	}
+
+	if (ku->tx_phase == ku->rx_phase) {
+		/* The peer initiated this update, so move our send keys to
+		 * the new phase too (RFC 9001 Section 6.2). Do it before
+		 * committing the RX side so a failure leaves the whole
+		 * state untouched and the peer's next packet retries the
+		 * update from scratch.
+		 */
+		ret = quic_ku_advance_tx(ep);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	if (ku->prev_rx_pp.initialized) {
+		psa_destroy_key(ku->prev_rx_pp.key_id);
+	}
+	ku->prev_rx_pp = crypto->rx.pp;
+	crypto->rx.pp = ku->next_rx_pp;
+	crypto_zero(&ku->next_rx_pp, sizeof(ku->next_rx_pp));
+
+	memcpy(ku->rx_secret, ku->next_rx_secret, ku->secret_len);
+	crypto_zero(ku->next_rx_secret, sizeof(ku->next_rx_secret));
+	ku->rx_phase ^= 1U;
+	ku->rx_phase_first_pn = full_pn;
+
+	NET_DBG("[EP:%p/%d] Key update committed, RX phase %u from pn %" PRIu64,
+		ep, quic_get_by_ep(ep), ku->rx_phase, full_pn);
+
+	return 0;
+}
 
 /**
  * Decrypt a complete QUIC packet (header protection + AEAD).
@@ -2584,16 +2789,19 @@ struct quic_decrypted_packet {
  *
  * @return 0 on success, <0 on failure
  */
-static int quic_decrypt_packet(struct quic_endpoint *ep,
-			       const uint8_t *packet,
-			       size_t packet_len,
-			       size_t pn_offset,
-			       enum quic_packet_type ptype,
-			       uint8_t *plaintext,
-			       size_t plaintext_size,
-			       struct quic_decrypted_packet *result)
+ZTESTABLE_STATIC int quic_decrypt_packet(struct quic_endpoint *ep,
+					 const uint8_t *packet,
+					 size_t packet_len,
+					 size_t pn_offset,
+					 enum quic_packet_type ptype,
+					 uint8_t *plaintext,
+					 size_t plaintext_size,
+					 struct quic_decrypted_packet *result)
 {
 	struct quic_crypto_context *crypto;
+	struct quic_key_update *ku = &ep->crypto.ku;
+	struct quic_pp_cipher *rx_pp;
+	bool try_next_generation = false;
 	uint8_t first_byte;
 	uint32_t truncated_pn;
 	size_t pn_length;
@@ -2696,13 +2904,51 @@ static int quic_decrypt_packet(struct quic_endpoint *ep,
 		NET_HEXDUMP_DBG(ciphertext, MIN(ciphertext_len, 48), "ciphertext (first 48):");
 	}
 
-	/* Step 5: Decrypt payload */
-	ret = quic_decrypt_payload(&crypto->rx.pp,
-				   full_pn,
-				   header_aad, header_len,
-				   ciphertext, ciphertext_len,
-				   plaintext, plaintext_size,
-				   &result->payload_len);
+	/* Step 5: Select the RX keys by the key phase bit (RFC 9001
+	 * Section 6.3) and decrypt the payload
+	 */
+	rx_pp = &crypto->rx.pp;
+
+	if (ptype == QUIC_PACKET_TYPE_1RTT && ku->initialized &&
+	    ((first_byte & QUIC_SHORT_KEY_PHASE_MASK) != 0U) != (ku->rx_phase != 0U)) {
+		bool reordered = full_pn < ku->rx_phase_first_pn &&
+				 ku->prev_rx_pp.initialized;
+
+		/* A conformant peer does not initiate a key update before the
+		 * handshake is confirmed (RFC 9001 Section 6.1), and responding
+		 * to one would advance our own send keys before confirmation.
+		 * Reject the packet without rotating; the caller closes the
+		 * connection with KEY_UPDATE_ERROR.
+		 */
+		if (!reordered && !ep->handshake_confirmed) {
+			NET_DBG("[EP:%p/%d] Key phase flip before handshake confirmed",
+				ep, quic_get_by_ep(ep));
+			QUIC_EP_STAT_INC(ep, drop_rx);
+			return -EPROTO;
+		}
+
+		if (reordered) {
+			/* Reordered packet from before the last update */
+			rx_pp = &ku->prev_rx_pp;
+		} else {
+			try_next_generation = true;
+		}
+	}
+
+	if (try_next_generation) {
+		ret = quic_ku_rx_try_next(ep, full_pn,
+					  header_aad, header_len,
+					  ciphertext, ciphertext_len,
+					  plaintext, plaintext_size,
+					  &result->payload_len);
+	} else {
+		ret = quic_decrypt_payload(rx_pp,
+					   full_pn,
+					   header_aad, header_len,
+					   ciphertext, ciphertext_len,
+					   plaintext, plaintext_size,
+					   &result->payload_len);
+	}
 	if (ret != 0) {
 		NET_DBG("Payload decryption failed (%d)", ret);
 		if (ret == -EBADMSG) {
@@ -2719,6 +2965,16 @@ static int quic_decrypt_packet(struct quic_endpoint *ep,
 	/* Step 6: Update largest packet number */
 	if (full_pn > *largest_pn) {
 		*largest_pn = full_pn;
+	}
+
+	/* Track the lowest packet number seen in the current phase so
+	 * reordered previous-generation packets keep resolving to the
+	 * previous keys after an update.
+	 */
+	if (ptype == QUIC_PACKET_TYPE_1RTT && ku->initialized &&
+	    !try_next_generation && rx_pp == &crypto->rx.pp &&
+	    full_pn < ku->rx_phase_first_pn) {
+		ku->rx_phase_first_pn = full_pn;
 	}
 
 	/* Fill result */
@@ -3236,6 +3492,7 @@ static int quic_endpoint_unref(struct quic_endpoint *ep)
 	quic_crypto_context_destroy(&ep->crypto.handshake);
 	quic_crypto_context_destroy(&ep->crypto.application);
 	quic_crypto_context_destroy(&ep->crypto.early);
+	quic_key_update_destroy(&ep->crypto.ku);
 
 	if (ep->parent != NULL) {
 		/* The ref was taken in process_long_header() when we assigned
@@ -5776,11 +6033,11 @@ static int tls_suite_to_quic_cipher(uint16_t cipher_suite)
 /*
  * Setup ciphers with explicit hash algorithm for handshake/application levels
  */
-static bool quic_setup_ciphers_ex(struct quic_ciphers *ciphers,
-				  psa_algorithm_t hash_alg,
-				  int cipher_algo,
-				  const uint8_t *secret,
-				  size_t secret_len)
+ZTESTABLE_STATIC bool quic_setup_ciphers_ex(struct quic_ciphers *ciphers,
+					    psa_algorithm_t hash_alg,
+					    int cipher_algo,
+					    const uint8_t *secret,
+					    size_t secret_len)
 {
 	if (!quic_hp_setup_ex(&ciphers->hp, hash_alg, cipher_algo,
 			      secret, secret_len)) {
@@ -5919,6 +6176,29 @@ static int quic_tls_secret_callback(void *user_data,
 	}
 
 	crypto_ctx->initialized = true;
+
+	if (level == QUIC_SECRET_LEVEL_APPLICATION) {
+		struct quic_key_update *ku = &ep->crypto.ku;
+
+		/* Keep the generation 0 traffic secrets so later key
+		 * updates can derive the next generations (RFC 9001
+		 * Section 6). QUIC_HASH_MAX_LEN covers every negotiable
+		 * hash, so the length always fits.
+		 */
+		memcpy(ku->rx_secret, rx_secret, secret_len);
+		memcpy(ku->tx_secret, tx_secret, secret_len);
+		ku->secret_len = secret_len;
+		ku->hash_alg = hash_alg;
+		ku->cipher_algo = cipher_algo;
+		ku->rx_phase = 0U;
+		ku->tx_phase = 0U;
+		ku->rx_phase_first_pn = UINT64_MAX;
+		ku->tx_phase_first_pn = 0U;
+		ku->tx_phase_acked = false;
+		ku->prev_rx_pp.initialized = false;
+		ku->next_rx_pp.initialized = false;
+		ku->initialized = true;
+	}
 
 	NET_DBG("Crypto context for level %d initialized successfully", level);
 
@@ -6739,8 +7019,13 @@ static int quic_handshake_complete(struct quic_endpoint *ep)
 		return ret;
 	}
 
-	/* Send HANDSHAKE_DONE frame (only server sends this) */
+	/* Send HANDSHAKE_DONE frame (only server sends this). The server
+	 * confirms the handshake as soon as it completes (RFC 9001
+	 * Section 4.1.2).
+	 */
 	if (ep->is_server) {
+		ep->handshake_confirmed = true;
+
 		ret = quic_send_handshake_done(ep);
 		if (ret != 0) {
 			NET_ERR("Failed to send HANDSHAKE_DONE");
@@ -8562,6 +8847,15 @@ static int process_short_header(struct quic_endpoint *ep,
 				  plaintext, sizeof(plaintext),
 				  &decrypted);
 	if (ret != 0) {
+		if (ret == -EPROTO) {
+			/* Peer flipped the key phase before the handshake was
+			 * confirmed (RFC 9001 Section 6.1). Terminate the
+			 * connection instead of rotating keys.
+			 */
+			quic_endpoint_send_transport_close(
+				target_ep, QUIC_ERROR_KEY_UPDATE_ERROR, 0,
+				"Key update before handshake confirmed");
+		}
 		NET_ERR("[EP:%p/%d] Failed to decrypt short header packet: %d",
 			target_ep, quic_get_by_ep(target_ep), ret);
 		goto out;
@@ -8570,31 +8864,6 @@ static int process_short_header(struct quic_endpoint *ep,
 	NET_DBG("[EP:%p/%d] Short header packet %" PRIu64 ", payload %zu bytes",
 		target_ep, quic_get_by_ep(target_ep), decrypted.packet_number,
 		decrypted.payload_len);
-
-	/*
-	 * RFC 9001 Section 6: a peer signals a key update by flipping the key
-	 * phase bit. A conforming update protects the packet with the
-	 * next-generation keys, so it fails AEAD above and never reaches this
-	 * check; until key update support lands such packets are dropped, as
-	 * unauthenticated data must not tear the connection down, and the
-	 * connection goes quiet until the idle timeout. What this catches is
-	 * a packet that decrypted with the current keys yet carries a flipped
-	 * phase bit: only a peer that changed the bit without rotating its
-	 * keys produces that, which Section 6 does not permit, so tell it why
-	 * we are closing.
-	 */
-	if ((decrypted.first_byte & QUIC_SHORT_KEY_PHASE_MASK) != 0) {
-		NET_DBG("[EP:%p/%d] Peer started a key update, which is not supported",
-			target_ep, quic_get_by_ep(target_ep));
-		QUIC_EP_STAT_INC(target_ep, drop_rx);
-		quic_endpoint_send_transport_close(target_ep,
-						   QUIC_ERROR_KEY_UPDATE_ERROR, 0,
-						   "Key update not supported");
-		quic_endpoint_notify_streams_closed(target_ep);
-
-		ret = -EPROTO;
-		goto out;
-	}
 
 	/* Process frames at APPLICATION level */
 	ret = handle_crypto_level_packet(target_ep, QUIC_SECRET_LEVEL_APPLICATION,

--- a/subsys/net/lib/quic/quic_internal.h
+++ b/subsys/net/lib/quic/quic_internal.h
@@ -527,6 +527,60 @@ struct quic_crypto_context {
 };
 
 /**
+ * RFC 9001 Section 6 key update state for 1-RTT packet protection.
+ * Only the packet protection key and IV rotate on an update; the header
+ * protection keys are derived once and never change.
+ */
+struct quic_key_update {
+	/** Current-generation 1-RTT traffic secrets. Advanced in place with
+	 * the "quic ku" label on every update, so the next generation can
+	 * always be derived but older ones cannot be recovered.
+	 */
+	uint8_t rx_secret[QUIC_HASH_MAX_LEN];
+	uint8_t tx_secret[QUIC_HASH_MAX_LEN];
+	size_t secret_len;
+	psa_algorithm_t hash_alg;
+	int cipher_algo;
+
+	/** Previous-generation RX packet protection, kept so packets
+	 * reordered from before the latest update still decrypt.
+	 */
+	struct quic_pp_cipher prev_rx_pp;
+
+	/** Next-generation RX packet protection and the secret it was keyed
+	 * from, derived once on the first phase mismatch and retained across
+	 * failed trial decrypts (RFC 9001 Section 6.3), consumed when an
+	 * update commits. Caching keeps a forged phase bit as cheap to
+	 * reject as any other forged packet.
+	 */
+	struct quic_pp_cipher next_rx_pp;
+	uint8_t next_rx_secret[QUIC_HASH_MAX_LEN];
+
+	/** Lowest packet number decrypted in the current RX key phase.
+	 * Packets below it with a flipped phase bit belong to the previous
+	 * generation, at or above it to the next one.
+	 */
+	uint64_t rx_phase_first_pn;
+
+	/** First packet number sent in the current TX key phase. */
+	uint64_t tx_phase_first_pn;
+
+	/** Key phase bit expected on received packets. */
+	uint8_t rx_phase;
+
+	/** Key phase bit set on sent packets. */
+	uint8_t tx_phase;
+
+	/** The peer has acknowledged a packet sent in the current TX phase.
+	 * RFC 9001 Section 6.1 requires this before a new update may be
+	 * initiated.
+	 */
+	bool tx_phase_acked;
+
+	bool initialized;
+};
+
+/**
  * Out-of-order CRYPTO frame segment metadata.
  * Data is stored directly into the reassembly buffer at the correct offset.
  */
@@ -569,6 +623,15 @@ struct quic_deferred_0rtt_packet {
 	uint8_t data[CONFIG_QUIC_ENDPOINT_PENDING_DATA_LEN];
 };
 #endif /* CONFIG_QUIC_0RTT */
+
+/** Result of decrypting one protected packet */
+struct quic_decrypted_packet {
+	uint8_t *payload;           /* Decrypted frames */
+	size_t payload_len;         /* Length of decrypted payload */
+	uint64_t packet_number;     /* Full reconstructed packet number */
+	enum quic_packet_type type; /* Packet type */
+	uint8_t first_byte;         /* Header byte with protection removed */
+};
 
 /**
  * Long header information parsed from an incoming packet, used for initial
@@ -630,6 +693,9 @@ struct quic_endpoint {
 		struct quic_crypto_context handshake;
 		struct quic_crypto_context application;
 		struct quic_crypto_context early;
+
+		/** Key update state for the application level */
+		struct quic_key_update ku;
 
 		/** Crypto stream state per level (Initial, Handshake, 1-RTT) */
 		struct quic_crypto_stream stream[3];
@@ -938,6 +1004,12 @@ struct quic_endpoint {
 
 	/** Have we notified streams about endpoint closing */
 	bool is_closing_notified : 1;
+
+	/** Handshake confirmed (RFC 9001 Section 4.1.2): on the server when
+	 * the handshake completes, on the client when HANDSHAKE_DONE is
+	 * received. Gates key update initiation.
+	 */
+	bool handshake_confirmed : 1;
 };
 
 struct quic_context;
@@ -1301,6 +1373,24 @@ void quic_stream_foreach(quic_stream_cb_t cb, void *user_data);
 int quic_prepare_rejected_early_data_replay(struct quic_endpoint *ep);
 int quic_replay_rejected_early_data(struct quic_endpoint *ep);
 
+/**
+ * @brief Initiate a key update (RFC 9001 Section 6.1).
+ *
+ * Moves the send keys of the application level to the next generation and
+ * flips the key phase bit on subsequently sent 1-RTT packets. The peer is
+ * expected to follow to the same phase.
+ *
+ * @param ep Endpoint with a confirmed handshake.
+ *
+ * @retval 0 on success
+ * @retval -ENOTCONN if the handshake is not confirmed or the application
+ *         keys are not installed yet
+ * @retval -EBUSY if no packet of the current key phase has been
+ *         acknowledged yet (RFC 9001 Section 6.1)
+ * @retval -EIO if deriving or installing the next keys failed
+ */
+int quic_endpoint_initiate_key_update(struct quic_endpoint *ep);
+
 #if defined(CONFIG_NET_TEST)
 /* Test-only function declarations */
 struct quic_context *quic_get_context(int sock);
@@ -1360,6 +1450,22 @@ int quic_decrypt_payload(struct quic_pp_cipher *pp, uint64_t packet_number,
 
 int quic_flush_deferred_crypto(struct quic_endpoint *ep);
 void quic_crypto_context_destroy(struct quic_crypto_context *ctx);
+void quic_key_update_destroy(struct quic_key_update *ku);
+bool quic_setup_ciphers_ex(struct quic_ciphers *ciphers,
+			   psa_algorithm_t hash_alg,
+			   int cipher_algo,
+			   const uint8_t *secret,
+			   size_t secret_len);
+int quic_ku_next_secret(const struct quic_key_update *ku,
+			const uint8_t *secret, uint8_t *next);
+int quic_decrypt_packet(struct quic_endpoint *ep,
+			const uint8_t *packet,
+			size_t packet_len,
+			size_t pn_offset,
+			enum quic_packet_type ptype,
+			uint8_t *plaintext,
+			size_t plaintext_size,
+			struct quic_decrypted_packet *result);
 int quic_build_version_negotiation_packet(uint8_t *out,
 					  size_t out_len,
 					  const uint8_t *peer_scid,

--- a/subsys/net/lib/quic/quic_packet.c
+++ b/subsys/net/lib/quic/quic_packet.c
@@ -1345,6 +1345,17 @@ static int handle_ack_frame(struct quic_endpoint *ep,
 	ranges[range_idx].start = largest_ack - first_ack_range;
 	range_idx++;
 
+	/* RFC 9001 Section 6.1: a new key update may only be initiated once
+	 * the peer has acknowledged a packet sent in the current key phase.
+	 * The peer acknowledging a packet number from this phase means it
+	 * decrypted it, so record that the gate is open.
+	 */
+	if (level == QUIC_SECRET_LEVEL_APPLICATION && ep->crypto.ku.initialized &&
+	    !ep->crypto.ku.tx_phase_acked &&
+	    largest_ack >= ep->crypto.ku.tx_phase_first_pn) {
+		ep->crypto.ku.tx_phase_acked = true;
+	}
+
 	NET_DBG("[EP:%p/%d] ACK frame: largest=%" PRIu64 ", delay=%" PRIu64
 		", ranges=%" PRIu64 ", first_range=%" PRIu64,
 		ep, quic_get_by_ep(ep), largest_ack, ack_delay, ack_range_count,
@@ -2167,9 +2178,12 @@ static int handle_1rtt_packet(struct quic_pkt *pkt)
 			NET_DBG("[EP:%p/%d] Received HANDSHAKE_DONE frame", ep, quic_get_by_ep(ep));
 			pos++;
 
-			/* Mark handshake as complete on client side */
+			/* Mark handshake as complete and confirmed on client
+			 * side (RFC 9001 Section 4.1.2)
+			 */
 			if (!ep->is_server) {
 				ep->crypto.tls.state = QUIC_TLS_STATE_CONNECTED;
+				ep->handshake_confirmed = true;
 			}
 
 			break;
@@ -2422,6 +2436,7 @@ ZTESTABLE_STATIC int handle_crypto_level_packet(struct quic_endpoint *ep,
 				saw_other_frame = true;
 				if (!ep->is_server) {
 					ep->crypto.tls.state = QUIC_TLS_STATE_CONNECTED;
+					ep->handshake_confirmed = true;
 
 					/* Discard Initial and Handshake spaces */
 					quic_recovery_discard_pn_space(ep,

--- a/subsys/net/lib/quic/quic_tls.c
+++ b/subsys/net/lib/quic/quic_tls.c
@@ -5592,14 +5592,16 @@ static int build_short_header(struct quic_endpoint *ep,
 	 * Fixed Bit = 1
 	 * Spin Bit = 0 (TODO: implement latency spin bit)
 	 * Reserved = 0 (will be protected)
-	 * Key Phase = 0 (TODO: implement key update)
+	 * Key Phase = current TX key phase (RFC 9001 Section 6)
 	 * Packet Number Length = pn_len - 1
 	 */
 	if (pos >= out_size) {
 		return -ENOBUFS;
 	}
 
-	out[pos++] = 0x40 | ((pn_len - 1) & 0x03);
+	out[pos++] = 0x40 |
+		     (ep->crypto.ku.tx_phase != 0U ? QUIC_SHORT_KEY_PHASE_MASK : 0U) |
+		     ((pn_len - 1) & 0x03);
 
 	/* Destination Connection ID (no length prefix in short header) */
 	if (pos + ep->peer_cid_len > out_size) {

--- a/tests/net/lib/quic/src/main.c
+++ b/tests/net/lib/quic/src/main.c
@@ -5728,6 +5728,570 @@ ZTEST(net_socket_quic, test_470_connection_statistics_track_traffic)
 #endif
 }
 
+static struct quic_endpoint *quic_test_sock_endpoint(int sock)
+{
+	struct quic_context *ctx;
+	struct quic_endpoint *ep;
+
+	ctx = quic_get_context(sock);
+	zassert_not_null(ctx, "Failed to get QUIC context for socket %d", sock);
+	ep = SYS_SLIST_PEEK_HEAD_CONTAINER(&ctx->endpoints, ep, node);
+	zassert_not_null(ep, "Failed to get QUIC endpoint for socket %d", sock);
+
+	return ep;
+}
+
+static void quic_test_echo_round(int stream_sock, const uint8_t *tx, size_t tx_len,
+				 uint8_t *rx, size_t rx_size)
+{
+	struct zsock_pollfd pfd = {
+		.fd = stream_sock,
+		.events = ZSOCK_POLLIN,
+	};
+	size_t rcvd = 0;
+	int ret;
+
+	ret = quic_test_send_all(stream_sock, tx, tx_len);
+	zassert_ok(ret, "Failed to send data (%d)", ret);
+
+	while (rcvd < tx_len) {
+		pfd.revents = 0;
+
+		ret = zsock_poll(&pfd, 1, POLL_TIMEOUT_MS);
+		zassert_true(ret > 0, "Poll failed or timed out (%d)",
+			     ret < 0 ? -errno : 0);
+
+		ret = zsock_recv(stream_sock, rx + rcvd, rx_size - rcvd, 0);
+		zassert_true(ret > 0, "Failed to receive data (%d)", -errno);
+		rcvd += ret;
+	}
+
+	zassert_equal(rcvd, tx_len, "Echo length mismatch");
+	zassert_mem_equal(tx, rx, tx_len, "Echo payload mismatch");
+}
+
+/* Test 471: RFC 9001 Section 6 key update. The client initiates an update,
+ * data still flows in both directions afterwards, the server follows to the
+ * new phase, and repeated updates keep working.
+ */
+ZTEST(net_socket_quic, test_471_key_update_round_trips)
+{
+	struct net_sockaddr_storage server_addr;
+	struct net_sockaddr_storage client_addr;
+	sec_tag_t server_sec_tags[] = {
+		SERVER_CERTIFICATE_TAG,
+	};
+	sec_tag_t client_sec_tags[] = {
+		CA_CERTIFICATE_TAG,
+	};
+	static const char * const alpn_list[] = {
+		"test-quic",
+		NULL
+	};
+	static uint8_t tx_buf[] = "Hello across a key update!";
+	static uint8_t rx_buf[64];
+	struct quic_endpoint *client_ep;
+	struct quic_endpoint *server_ep;
+	int server_sock, client_sock, client_stream_sock, server_stream_sock;
+	int server_connected_sock;
+	k_tid_t tid;
+	int ret;
+
+	static K_THREAD_STACK_DEFINE(server_ku_thread_stack, STACK_SIZE);
+	static struct k_thread server_ku_thread_data;
+	static struct config server_ku_data;
+
+	ret = loopback_set_packet_drop_ratio(0.0);
+	zassert_ok(ret, "Failed to set packet drop ratio (%d)", ret);
+
+	ret = k_sem_init(&server_ku_data.sem, 0, 1);
+	zassert_ok(ret, "Failed to initialize semaphore (%d)", ret);
+
+	ret = net_ipaddr_parse(LOCAL_ADDR_IPV4_STR4, strlen(LOCAL_ADDR_IPV4_STR4),
+			       (struct net_sockaddr *)&server_addr);
+	zassert_true(ret, "Failed to parse server IP address");
+
+	ret = net_ipaddr_parse(REMOTE_ADDR_IPV4_STR4, strlen(REMOTE_ADDR_IPV4_STR4),
+			       (struct net_sockaddr *)&client_addr);
+	zassert_true(ret, "Failed to parse client IP address");
+
+	prepare_quic_socket(&server_sock, NULL,
+			    (const struct net_sockaddr *)&server_addr);
+	prepare_quic_socket(&client_sock,
+			    (const struct net_sockaddr *)&server_addr,
+			    (const struct net_sockaddr *)&client_addr);
+
+	zassert_true(server_sock >= 0, "Failed to create server socket");
+	zassert_true(client_sock >= 0, "Failed to create client socket");
+
+	setup_quic_certs(server_sock, server_sec_tags, ARRAY_SIZE(server_sec_tags));
+	setup_alpn(server_sock, alpn_list, ARRAY_SIZE(alpn_list));
+
+	server_ku_data.sock = server_sock;
+	server_ku_data.counter = 1;
+	server_ku_data.error = 0;
+	server_ku_data.connected_sock = -1;
+	server_ku_data.stream_recv_sock = -1;
+	server_ku_data.accept_delay_ms = 0;
+	server_ku_data.test_done = false;
+
+	tid = k_thread_create(&server_ku_thread_data, server_ku_thread_stack,
+			      K_THREAD_STACK_SIZEOF(server_ku_thread_stack),
+			      server_thread, &server_ku_data, NULL, NULL,
+			      K_PRIO_PREEMPT(1), 0, K_FOREVER);
+
+	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+		k_thread_name_set(&server_ku_thread_data, "quic_srv_ku");
+	}
+
+	k_thread_start(tid);
+
+	ret = k_sem_take(&server_ku_data.sem, K_FOREVER);
+	zassert_ok(ret, "Failed to take semaphore (%d)", ret);
+
+	setup_quic_certs(client_sock, client_sec_tags, ARRAY_SIZE(client_sec_tags));
+	setup_alpn(client_sock, alpn_list, ARRAY_SIZE(alpn_list));
+
+	client_stream_sock = quic_stream_open(client_sock, QUIC_STREAM_CLIENT,
+					      QUIC_STREAM_BIDIRECTIONAL, 0);
+	zassert_true(client_stream_sock >= 0, "Failed to open client stream (%d)",
+		     client_stream_sock);
+
+	/* Generation 0 exchange, both phases 0 */
+	quic_test_echo_round(client_stream_sock, tx_buf, sizeof(tx_buf),
+			     rx_buf, sizeof(rx_buf));
+
+	client_ep = quic_test_sock_endpoint(client_sock);
+	zassert_true(client_ep->crypto.ku.initialized,
+		     "Key update state not initialized after handshake");
+	zassert_equal(client_ep->crypto.ku.tx_phase, 0U, "Unexpected initial TX phase");
+	zassert_equal(client_ep->crypto.ku.rx_phase, 0U, "Unexpected initial RX phase");
+
+	for (int round = 1; round <= 3; round++) {
+		uint8_t expected_phase = round & 1;
+
+		/* Let in-flight acknowledgements drain so the RX thread is
+		 * not sending with the TX key the update replaces.
+		 */
+		k_msleep(50);
+
+		ret = quic_endpoint_initiate_key_update(client_ep);
+		zassert_ok(ret, "Failed to initiate key update %d (%d)", round, ret);
+		zassert_equal(client_ep->crypto.ku.tx_phase, expected_phase,
+			      "TX phase did not flip on update %d", round);
+
+		/* RFC 9001 Section 6.1: no new update until the peer caught
+		 * up with this one.
+		 */
+		ret = quic_endpoint_initiate_key_update(client_ep);
+		zassert_equal(ret, -EBUSY,
+			      "Second initiate before completion returned %d", ret);
+
+		quic_test_echo_round(client_stream_sock, tx_buf, sizeof(tx_buf),
+				     rx_buf, sizeof(rx_buf));
+
+		/* The echo came back protected with the server's updated
+		 * keys, so receiving it means our RX side followed.
+		 */
+		zassert_equal(client_ep->crypto.ku.rx_phase, expected_phase,
+			      "RX phase did not follow on update %d", round);
+	}
+
+	server_ku_data.test_done = true;
+
+	ret = zsock_close(client_stream_sock);
+	zassert_equal(ret, 0, "Failed to close client stream (%d)", ret);
+
+	ret = k_thread_join(&server_ku_thread_data, K_MSEC(500));
+	zassert_equal(ret, 0, "Cannot join thread (%d)", ret);
+
+	zassert_equal(server_ku_data.error, 0, "Server thread reported error (%d)",
+		      server_ku_data.error);
+
+	server_connected_sock = server_ku_data.connected_sock;
+	zassert_true(server_connected_sock >= 0, "Invalid connected socket (%d)",
+		     server_connected_sock);
+
+	/* The server followed the client through every update */
+	server_ep = quic_test_sock_endpoint(server_connected_sock);
+	zassert_equal(server_ep->crypto.ku.tx_phase, 1U,
+		      "Server TX phase did not follow the updates");
+	zassert_equal(server_ep->crypto.ku.rx_phase, 1U,
+		      "Server RX phase did not follow the updates");
+
+	server_stream_sock = server_ku_data.stream_recv_sock;
+	zassert_true(server_stream_sock >= 0, "Invalid server stream socket (%d)",
+		     server_stream_sock);
+
+	ret = quic_stream_close(server_stream_sock);
+	zassert_equal(ret, 0, "Failed to close server stream %d (%d)",
+		      server_stream_sock, ret);
+
+	ret = quic_connection_close(server_connected_sock);
+	zassert_equal(ret, 0, "Failed to close server connection %d (%d)",
+		      server_connected_sock, ret);
+
+	ret = quic_connection_close(client_sock);
+	zassert_equal(ret, 0, "Failed to close client connection (%d)", ret);
+
+	ret = quic_connection_close(server_sock);
+	zassert_equal(ret, 0, "Failed to close server connection (%d)", ret);
+}
+
+/* Test 472: a key update cannot start before the handshake has produced
+ * application keys.
+ */
+ZTEST(net_socket_quic, test_472_key_update_requires_application_keys)
+{
+	struct quic_endpoint *ep;
+	int ret, sock;
+
+	sock = quic_connection_open((struct net_sockaddr *)&remote_addr_ipv4,
+				    (struct net_sockaddr *)&local_addr_ipv4);
+	zassert_true(sock >= 0, "Failed to open QUIC connection (%d)", sock);
+
+	ep = quic_test_sock_endpoint(sock);
+
+	ret = quic_endpoint_initiate_key_update(ep);
+	zassert_equal(ret, -ENOTCONN,
+		      "Key update before handshake returned %d", ret);
+
+	ret = quic_connection_close(sock);
+	zassert_ok(ret, "Failed to close connection (%d)", ret);
+}
+
+/* Give the endpoint 1-RTT keys and key update state derived from a known
+ * secret, as the TLS secret callback would after a real handshake.
+ */
+static void quic_test_setup_app_keys(struct quic_endpoint *ep,
+				     const uint8_t *secret, size_t secret_len)
+{
+	struct quic_key_update *ku = &ep->crypto.ku;
+
+	memset(ep, 0, sizeof(*ep));
+
+	/* Model an endpoint whose handshake is confirmed: quic_ku_advance_tx()
+	 * takes send_lock, and the receive path only rotates keys once the
+	 * handshake is confirmed.
+	 */
+	k_mutex_init(&ep->send_lock);
+	ep->handshake_confirmed = true;
+
+	zassert_true(quic_setup_ciphers_ex(&ep->crypto.application.rx,
+					   PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   secret, secret_len),
+		     "Failed to set up RX ciphers");
+	zassert_true(quic_setup_ciphers_ex(&ep->crypto.application.tx,
+					   PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   secret, secret_len),
+		     "Failed to set up TX ciphers");
+	ep->crypto.application.initialized = true;
+
+	memcpy(ku->rx_secret, secret, secret_len);
+	memcpy(ku->tx_secret, secret, secret_len);
+	ku->secret_len = secret_len;
+	ku->hash_alg = PSA_ALG_SHA_256;
+	ku->cipher_algo = QUIC_CIPHER_AES_128_GCM;
+	ku->rx_phase_first_pn = UINT64_MAX;
+	ku->initialized = true;
+}
+
+/* Build a protected 1-RTT packet the way a peer would: payload protection
+ * from the given generation's keys, header protection always from the
+ * original one (the HP key never rotates, RFC 9001 Section 6).
+ */
+static size_t quic_test_build_1rtt_packet(struct quic_pp_cipher *pp,
+					  struct quic_hp_cipher *hp,
+					  uint64_t pn, bool phase,
+					  const uint8_t *payload, size_t payload_len,
+					  uint8_t *out, size_t out_size)
+{
+	const size_t pn_offset = 1;
+	const size_t pn_len = 2;
+	size_t header_len = pn_offset + pn_len;
+	size_t ct_len = 0;
+	int ret;
+
+	out[0] = 0x40 | (phase ? QUIC_SHORT_KEY_PHASE_MASK : 0) | (pn_len - 1);
+	out[1] = (pn >> 8) & 0xFF;
+	out[2] = pn & 0xFF;
+
+	ret = quic_encrypt_payload(pp, pn, out, header_len,
+				   payload, payload_len,
+				   &out[header_len], out_size - header_len,
+				   &ct_len);
+	zassert_ok(ret, "Failed to encrypt payload (%d)", ret);
+
+	ret = quic_encrypt_header(out, header_len + ct_len, pn_offset, pn_len,
+				  hp->key_id, hp->cipher_algo);
+	zassert_ok(ret, "Failed to protect header (%d)", ret);
+
+	return header_len + ct_len;
+}
+
+static void quic_test_destroy_ciphers(struct quic_ciphers *ciphers)
+{
+	if (ciphers->hp.initialized) {
+		psa_destroy_key(ciphers->hp.key_id);
+		ciphers->hp.initialized = false;
+	}
+
+	if (ciphers->pp.initialized) {
+		psa_destroy_key(ciphers->pp.key_id);
+		ciphers->pp.initialized = false;
+	}
+}
+
+/* Test 473: after a peer-initiated key update commits, a reordered packet
+ * from before the update still decrypts with the retained
+ * previous-generation keys and does not disturb the new phase.
+ */
+ZTEST(net_socket_quic, test_473_key_update_keeps_previous_generation_keys)
+{
+	static const uint8_t secret[32] = {
+		0x3a, 0x5c, 0x11, 0xe9, 0x27, 0x80, 0x4d, 0xb2,
+		0x66, 0x0f, 0xc4, 0x39, 0x9d, 0x71, 0x28, 0x5e,
+		0xaa, 0x13, 0xf6, 0x42, 0x8b, 0xd0, 0x37, 0x6c,
+		0x91, 0x2e, 0x58, 0xc7, 0x04, 0xbf, 0x6a, 0xd5,
+	};
+	static const uint8_t msg0[16] = "generation zero";
+	static const uint8_t msg1[16] = "generation one.";
+	struct quic_endpoint *ep = &test_ep_a;
+	struct quic_ciphers peer_gen0 = { 0 };
+	struct quic_ciphers peer_gen1 = { 0 };
+	struct quic_decrypted_packet result;
+	uint8_t s1[QUIC_HASH_MAX_LEN];
+	uint8_t packet[128];
+	uint8_t plaintext[128];
+	size_t len;
+	int ret;
+
+	quic_test_setup_app_keys(ep, secret, sizeof(secret));
+
+	zassert_true(quic_setup_ciphers_ex(&peer_gen0, PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   secret, sizeof(secret)),
+		     "Failed to set up peer generation 0 ciphers");
+
+	ret = quic_ku_next_secret(&ep->crypto.ku, secret, s1);
+	zassert_ok(ret, "Failed to derive the next-generation secret (%d)", ret);
+
+	zassert_true(quic_setup_ciphers_ex(&peer_gen1, PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   s1, sizeof(secret)),
+		     "Failed to set up peer generation 1 ciphers");
+
+	/* Plain generation 0 packet */
+	len = quic_test_build_1rtt_packet(&peer_gen0.pp, &peer_gen0.hp, 1, false,
+					  msg0, sizeof(msg0),
+					  packet, sizeof(packet));
+	ret = quic_decrypt_packet(ep, packet, len, 1, QUIC_PACKET_TYPE_1RTT,
+				  plaintext, sizeof(plaintext), &result);
+	zassert_ok(ret, "Failed to decrypt generation 0 packet (%d)", ret);
+	zassert_mem_equal(result.payload, msg0, sizeof(msg0),
+			  "Generation 0 payload mismatch");
+
+	/* The peer initiates a key update: flipped phase bit, generation 1
+	 * payload keys, unchanged header protection.
+	 */
+	len = quic_test_build_1rtt_packet(&peer_gen1.pp, &peer_gen0.hp, 5, true,
+					  msg1, sizeof(msg1),
+					  packet, sizeof(packet));
+	ret = quic_decrypt_packet(ep, packet, len, 1, QUIC_PACKET_TYPE_1RTT,
+				  plaintext, sizeof(plaintext), &result);
+	zassert_ok(ret, "Failed to decrypt generation 1 packet (%d)", ret);
+	zassert_mem_equal(result.payload, msg1, sizeof(msg1),
+			  "Generation 1 payload mismatch");
+	zassert_equal(ep->crypto.ku.rx_phase, 1U, "RX phase did not advance");
+	zassert_equal(ep->crypto.ku.tx_phase, 1U, "TX keys did not follow the peer");
+	zassert_equal(ep->crypto.ku.rx_phase_first_pn, 5U,
+		      "Wrong first packet number for the new phase");
+	zassert_true(ep->crypto.ku.prev_rx_pp.initialized,
+		     "Previous-generation keys were not kept");
+
+	/* A generation 0 packet reordered to after the update */
+	len = quic_test_build_1rtt_packet(&peer_gen0.pp, &peer_gen0.hp, 2, false,
+					  msg0, sizeof(msg0),
+					  packet, sizeof(packet));
+	ret = quic_decrypt_packet(ep, packet, len, 1, QUIC_PACKET_TYPE_1RTT,
+				  plaintext, sizeof(plaintext), &result);
+	zassert_ok(ret, "Failed to decrypt reordered previous-generation packet (%d)",
+		   ret);
+	zassert_mem_equal(result.payload, msg0, sizeof(msg0),
+			  "Previous-generation payload mismatch");
+	zassert_equal(ep->crypto.ku.rx_phase, 1U,
+		      "A reordered old packet must not change the phase");
+	zassert_equal(ep->crypto.ku.rx_phase_first_pn, 5U,
+		      "A reordered old packet must not move the phase boundary");
+
+	quic_test_destroy_ciphers(&peer_gen0);
+	quic_test_destroy_ciphers(&peer_gen1);
+	quic_crypto_context_destroy(&ep->crypto.application);
+	quic_key_update_destroy(&ep->crypto.ku);
+}
+
+/* Test 474: a forged key phase flip fails the trial decrypt and leaves the
+ * whole key update state untouched, while the derived candidate keys are
+ * retained (RFC 9001 Section 6.3) and used when the real update arrives.
+ */
+ZTEST(net_socket_quic, test_474_forged_key_phase_flip_leaves_state_untouched)
+{
+	static const uint8_t secret[32] = {
+		0xd5, 0x6a, 0xbf, 0x04, 0xc7, 0x58, 0x2e, 0x91,
+		0x6c, 0x37, 0xd0, 0x8b, 0x42, 0xf6, 0x13, 0xaa,
+		0x5e, 0x28, 0x71, 0x9d, 0x39, 0xc4, 0x0f, 0x66,
+		0xb2, 0x4d, 0x80, 0x27, 0xe9, 0x11, 0x5c, 0x3a,
+	};
+	static const uint8_t msg0[16] = "generation zero";
+	static const uint8_t msg1[16] = "generation one.";
+	struct quic_endpoint *ep = &test_ep_a;
+	struct quic_ciphers peer_gen0 = { 0 };
+	struct quic_ciphers peer_gen1 = { 0 };
+	struct quic_decrypted_packet result;
+	uint8_t rx_secret_snapshot[QUIC_HASH_MAX_LEN];
+	uint8_t s1[QUIC_HASH_MAX_LEN];
+	uint8_t packet[128];
+	uint8_t plaintext[128];
+	size_t len;
+	int ret;
+
+	quic_test_setup_app_keys(ep, secret, sizeof(secret));
+
+	zassert_true(quic_setup_ciphers_ex(&peer_gen0, PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   secret, sizeof(secret)),
+		     "Failed to set up peer generation 0 ciphers");
+
+	ret = quic_ku_next_secret(&ep->crypto.ku, secret, s1);
+	zassert_ok(ret, "Failed to derive the next-generation secret (%d)", ret);
+
+	zassert_true(quic_setup_ciphers_ex(&peer_gen1, PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   s1, sizeof(secret)),
+		     "Failed to set up peer generation 1 ciphers");
+
+	len = quic_test_build_1rtt_packet(&peer_gen0.pp, &peer_gen0.hp, 1, false,
+					  msg0, sizeof(msg0),
+					  packet, sizeof(packet));
+	ret = quic_decrypt_packet(ep, packet, len, 1, QUIC_PACKET_TYPE_1RTT,
+				  plaintext, sizeof(plaintext), &result);
+	zassert_ok(ret, "Failed to decrypt generation 0 packet (%d)", ret);
+
+	memcpy(rx_secret_snapshot, ep->crypto.ku.rx_secret,
+	       sizeof(rx_secret_snapshot));
+
+	/* Forged flip: the phase bit is set but the payload is still
+	 * protected with generation 0 keys, so the trial decrypt with the
+	 * generation 1 keys must fail.
+	 */
+	len = quic_test_build_1rtt_packet(&peer_gen0.pp, &peer_gen0.hp, 6, true,
+					  msg0, sizeof(msg0),
+					  packet, sizeof(packet));
+	ret = quic_decrypt_packet(ep, packet, len, 1, QUIC_PACKET_TYPE_1RTT,
+				  plaintext, sizeof(plaintext), &result);
+	zassert_equal(ret, -EBADMSG, "Forged phase flip must fail AEAD (%d)", ret);
+	zassert_equal(ep->crypto.ku.rx_phase, 0U,
+		      "A failed trial must not change the RX phase");
+	zassert_equal(ep->crypto.ku.tx_phase, 0U,
+		      "A failed trial must not change the TX phase");
+	zassert_false(ep->crypto.ku.prev_rx_pp.initialized,
+		      "A failed trial must not shift the generations");
+	zassert_true(ep->crypto.ku.next_rx_pp.initialized,
+		     "The derived candidate keys should be retained");
+	zassert_mem_equal(ep->crypto.ku.rx_secret, rx_secret_snapshot,
+			  sizeof(rx_secret_snapshot),
+			  "A failed trial must not advance the RX secret");
+
+	/* The real update commits with the retained candidate keys */
+	len = quic_test_build_1rtt_packet(&peer_gen1.pp, &peer_gen0.hp, 6, true,
+					  msg1, sizeof(msg1),
+					  packet, sizeof(packet));
+	ret = quic_decrypt_packet(ep, packet, len, 1, QUIC_PACKET_TYPE_1RTT,
+				  plaintext, sizeof(plaintext), &result);
+	zassert_ok(ret, "Failed to decrypt the real generation 1 packet (%d)", ret);
+	zassert_mem_equal(result.payload, msg1, sizeof(msg1),
+			  "Generation 1 payload mismatch");
+	zassert_equal(ep->crypto.ku.rx_phase, 1U, "RX phase did not advance");
+	zassert_false(ep->crypto.ku.next_rx_pp.initialized,
+		      "The candidate keys must be consumed on commit");
+
+	quic_test_destroy_ciphers(&peer_gen0);
+	quic_test_destroy_ciphers(&peer_gen1);
+	quic_crypto_context_destroy(&ep->crypto.application);
+	quic_key_update_destroy(&ep->crypto.ku);
+}
+
+/* Test 475: a peer must not initiate a key update before the handshake is
+ * confirmed (RFC 9001 Section 6.1). A phase flip received while the handshake
+ * is not yet confirmed is rejected without rotating either the receive or the
+ * send keys, so the connection can be closed with KEY_UPDATE_ERROR.
+ */
+ZTEST(net_socket_quic, test_475_key_update_before_handshake_confirmed_is_rejected)
+{
+	static const uint8_t secret[32] = {
+		0x27, 0x6b, 0xd4, 0x0a, 0x8f, 0x13, 0xc9, 0x52,
+		0xe0, 0x7d, 0x31, 0xaa, 0x64, 0xb8, 0x1f, 0x46,
+		0x9c, 0x02, 0xf5, 0x7e, 0x38, 0xd1, 0x6a, 0x23,
+		0xbc, 0x49, 0x85, 0x0e, 0x71, 0xa6, 0x5d, 0xf2,
+	};
+	static const uint8_t msg[16] = "premature updte";
+	struct quic_endpoint *ep = &test_ep_a;
+	struct quic_ciphers peer_gen0 = { 0 };
+	struct quic_ciphers peer_gen1 = { 0 };
+	struct quic_decrypted_packet result;
+	uint8_t s1[QUIC_HASH_MAX_LEN];
+	uint8_t packet[128];
+	uint8_t plaintext[128];
+	uint8_t rx_phase_before;
+	uint8_t tx_phase_before;
+	size_t len;
+	int ret;
+
+	quic_test_setup_app_keys(ep, secret, sizeof(secret));
+
+	/* Model a connection whose handshake is not yet confirmed. */
+	ep->handshake_confirmed = false;
+	rx_phase_before = ep->crypto.ku.rx_phase;
+	tx_phase_before = ep->crypto.ku.tx_phase;
+
+	/* Header protection never rotates; payload protection uses the next
+	 * generation, and the key phase bit is flipped: a key update.
+	 */
+	zassert_true(quic_setup_ciphers_ex(&peer_gen0, PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   secret, sizeof(secret)),
+		     "Failed to set up peer generation 0 ciphers");
+
+	ret = quic_ku_next_secret(&ep->crypto.ku, secret, s1);
+	zassert_ok(ret, "Failed to derive the next-generation secret (%d)", ret);
+
+	zassert_true(quic_setup_ciphers_ex(&peer_gen1, PSA_ALG_SHA_256,
+					   QUIC_CIPHER_AES_128_GCM,
+					   s1, sizeof(secret)),
+		     "Failed to set up peer generation 1 ciphers");
+
+	len = quic_test_build_1rtt_packet(&peer_gen1.pp, &peer_gen0.hp, 1, true,
+					  msg, sizeof(msg), packet, sizeof(packet));
+
+	ret = quic_decrypt_packet(ep, packet, len, 1, QUIC_PACKET_TYPE_1RTT,
+				  plaintext, sizeof(plaintext), &result);
+	zassert_equal(ret, -EPROTO,
+		      "A pre-confirmation key update must be rejected (%d)", ret);
+	zassert_equal(ep->crypto.ku.rx_phase, rx_phase_before,
+		      "The RX phase must not rotate before handshake confirmation");
+	zassert_equal(ep->crypto.ku.tx_phase, tx_phase_before,
+		      "The TX phase must not advance before handshake confirmation");
+	zassert_false(ep->crypto.ku.next_rx_pp.initialized,
+		      "No candidate keys should be committed for a rejected update");
+
+	quic_test_destroy_ciphers(&peer_gen0);
+	quic_test_destroy_ciphers(&peer_gen1);
+	quic_crypto_context_destroy(&ep->crypto.application);
+	quic_key_update_destroy(&ep->crypto.ku);
+}
+
 ZTEST(net_socket_quic, test_480_retry_token_round_trip)
 {
 	static const uint8_t orig_dcid[] = {


### PR DESCRIPTION
RFC 9001 Section 6 rotates the packet protection keys during a
connection: a sender derives the next-generation traffic secret with
the "quic ku" label, protects new packets with keys from it, and
signals the change by flipping the key phase bit. The header
protection keys never change. Until now the phase bit was only used
to detect an update and close the connection, so keys were never
rotated and a peer-initiated update ended the connection at the idle
timeout.
