### PR TITLE
drivers: sensor: lsm6dso16is: fix various correctness issues

### DIFF
--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -525,15 +525,14 @@ static int lsm6dso16is_gyro_channel_get(enum sensor_channel chan,
 static void lsm6dso16is_gyro_channel_get_temp(struct sensor_value *val,
 					  struct lsm6dso16is_data *data)
 {
-	int32_t micro_c;
-
 	/* convert units to micro Celsius. Raw temperature samples are
 	 * expressed in 256 LSB/deg_C units. And LSB output is 0 at 25 C.
 	 */
-	micro_c = (data->temp_sample * 1000000) / 256;
+	int64_t temp_sample = data->temp_sample;
+	int64_t micro_c = (temp_sample * 1000000LL) / 256;
 
-	val->val1 = micro_c / 1000000 + 25;
-	val->val2 = micro_c % 1000000;
+	val->val1 = (int32_t)(micro_c / 1000000) + 25;
+	val->val2 = (int32_t)(micro_c % 1000000);
 }
 #endif
 

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -613,8 +613,7 @@ static inline void lsm6dso16is_hum_convert(struct sensor_value *val,
 	rh /= (ht->x1 - ht->x0);
 
 	/* convert humidity to integer and fractional part */
-	val->val1 = rh;
-	val->val2 = rh * 1000000;
+	(void)sensor_value_from_float(val, rh);
 }
 
 static inline void lsm6dso16is_press_convert(struct sensor_value *val,

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -64,8 +64,17 @@ static int lsm6dso16is_accel_range_to_fs_val(int32_t range)
 	return -EINVAL;
 }
 
-static const uint16_t lsm6dso16is_gyro_fs_map[] = {250, 125, 500, 0, 1000, 0, 2000};
-static const uint16_t lsm6dso16is_gyro_fs_sens[] = {2, 1, 4, 0, 8, 0, 16};
+/* 125 dps is selected by the FS_125 bit, all other ranges by FS_G[1:0] */
+#define LSM6DSO16IS_GYRO_FS_125DPS		0x10
+#define LSM6DSO16IS_GYRO_FS_125DPS_IDX		4
+
+static const uint16_t lsm6dso16is_gyro_fs_map[] = {250, 500, 1000, 2000, 125};
+static const uint16_t lsm6dso16is_gyro_fs_sens[] = {2, 4, 8, 16, 1};
+
+static inline uint8_t lsm6dso16is_gyro_fs_idx(uint8_t fs)
+{
+	return (fs == LSM6DSO16IS_GYRO_FS_125DPS) ? LSM6DSO16IS_GYRO_FS_125DPS_IDX : (fs & 0x3);
+}
 
 static int lsm6dso16is_gyro_range_to_fs_val(int32_t range)
 {
@@ -73,6 +82,10 @@ static int lsm6dso16is_gyro_range_to_fs_val(int32_t range)
 
 	for (i = 0; i < ARRAY_SIZE(lsm6dso16is_gyro_fs_map); i++) {
 		if (range == lsm6dso16is_gyro_fs_map[i]) {
+			if (i == LSM6DSO16IS_GYRO_FS_125DPS_IDX) {
+				return LSM6DSO16IS_GYRO_FS_125DPS;
+			}
+
 			return i;
 		}
 	}
@@ -237,7 +250,7 @@ static int lsm6dso16is_gyro_range_set(const struct device *dev, int32_t range)
 		return -EIO;
 	}
 
-	data->gyro_gain = (lsm6dso16is_gyro_fs_sens[fs] * GAIN_UNIT_G);
+	data->gyro_gain = (lsm6dso16is_gyro_fs_sens[lsm6dso16is_gyro_fs_idx(fs)] * GAIN_UNIT_G);
 	return 0;
 }
 
@@ -785,7 +798,8 @@ static int lsm6dso16is_init_chip(const struct device *dev)
 		LOG_ERR("failed to set gyroscope range %d", fs);
 		return -EIO;
 	}
-	lsm6dso16is->gyro_gain = (lsm6dso16is_gyro_fs_sens[fs] * GAIN_UNIT_G);
+	lsm6dso16is->gyro_gain =
+		(lsm6dso16is_gyro_fs_sens[lsm6dso16is_gyro_fs_idx(fs)] * GAIN_UNIT_G);
 
 	odr = cfg->gyro_odr;
 	LOG_DBG("gyro odr is %d", odr);

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -280,7 +280,7 @@ static int lsm6dso16is_gyro_config(const struct device *dev,
 			return -EIO;
 		}
 
-		return lsm6dso16is_xl_hm_mode_set(ctx, mode);
+		return lsm6dso16is_gy_hm_mode_set(ctx, mode);
 	default:
 		LOG_DBG("Gyro attribute not supported.");
 		return -ENOTSUP;

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is_trigger.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is_trigger.c
@@ -19,6 +19,11 @@
 
 LOG_MODULE_DECLARE(LSM6DSO16IS, CONFIG_SENSOR_LOG_LEVEL);
 
+/* data ready flags are only cleared by reading the output registers, so bound
+ * the drain loop in case a handler defers the actual sample fetch
+ */
+#define LSM6DSO16IS_MAX_DRDY_LOOPS	8
+
 #if defined(CONFIG_LSM6DSO16IS_ENABLE_TEMP)
 /**
  * lsm6dso16is_enable_t_int - TEMP enable selected int pin to generate interrupt
@@ -204,17 +209,18 @@ static void lsm6dso16is_handle_interrupt(const struct device *dev)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lsm6dso16is_status_reg_t status;
 
-	while (1) {
+	for (int i = 0; i < LSM6DSO16IS_MAX_DRDY_LOOPS; i++) {
 		if (lsm6dso16is_status_reg_get(ctx, &status) < 0) {
 			LOG_DBG("failed reading status reg");
-			return;
+			break;
 		}
 
-		if ((status.xlda == 0) && (status.gda == 0)
+		if (!((status.xlda && (lsm6dso16is->handler_drdy_acc != NULL)) ||
+		      (status.gda && (lsm6dso16is->handler_drdy_gyr != NULL))
 #if defined(CONFIG_LSM6DSO16IS_ENABLE_TEMP)
-					&& (status.tda == 0)
+		      || (status.tda && (lsm6dso16is->handler_drdy_temp != NULL))
 #endif
-					) {
+		     )) {
 			break;
 		}
 

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is_trigger.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is_trigger.c
@@ -48,7 +48,7 @@ static int lsm6dso16is_enable_t_int(const struct device *dev, int enable)
 		return ret;
 	}
 
-	val.drdy_temp = 1;
+	val.drdy_temp = enable;
 
 	return lsm6dso16is_pin_int2_route_set(ctx, val);
 }
@@ -80,7 +80,7 @@ static int lsm6dso16is_enable_xl_int(const struct device *dev, int enable)
 			return ret;
 		}
 
-		val.drdy_xl = 1;
+		val.drdy_xl = enable;
 
 		ret = lsm6dso16is_pin_int1_route_set(ctx, val);
 	} else {
@@ -92,7 +92,7 @@ static int lsm6dso16is_enable_xl_int(const struct device *dev, int enable)
 			return ret;
 		}
 
-		val.drdy_xl = 1;
+		val.drdy_xl = enable;
 
 		ret = lsm6dso16is_pin_int2_route_set(ctx, val);
 	}
@@ -126,7 +126,7 @@ static int lsm6dso16is_enable_g_int(const struct device *dev, int enable)
 			return ret;
 		}
 
-		val.drdy_gy = 1;
+		val.drdy_gy = enable;
 
 		ret = lsm6dso16is_pin_int1_route_set(ctx, val);
 	} else {
@@ -138,7 +138,7 @@ static int lsm6dso16is_enable_g_int(const struct device *dev, int enable)
 			return ret;
 		}
 
-		val.drdy_gy = 1;
+		val.drdy_gy = enable;
 
 		ret = lsm6dso16is_pin_int2_route_set(ctx, val);
 	}


### PR DESCRIPTION
This PR fixes six independent correctness bugs in the LSM6DSO16IS driver, one
commit per issue:

- **Fix gyroscope full-scale encoding**: the gyro full-scale range and gain
  tables were copied from the LSM6DSO, whose register encoding differs from
  the LSM6DSO16IS. The result was zero gain at 2000 dps, an out-of-bounds
  table read at 125 dps, and wrong sensitivities at 500 and 1000 dps — on both
  the devicetree init path and `attr_set`. Replaced with the LSM6DSO16IS
  encoding, including a helper to map the FS_125 register value.
- **Fix gyro high-performance mode setter**: the gyro
  `SENSOR_ATTR_CONFIGURATION` handler called the *accelerometer's*
  `xl_hm_mode` setter, so it wrote CTRL6_C instead of CTRL7_G — configuring
  the wrong sensor while leaving the gyro untouched.
- **Fix die temperature 32-bit overflow**: the conversion scaled by 1000000 in
  32-bit arithmetic, overflowing outside roughly 16.6–33.4 °C and corrupting
  `SENSOR_CHAN_DIE_TEMP` at ordinary temperatures. Widened to 64-bit, matching
  the already-correct lsm6dsv16x sibling.
- **Fix humidity fractional part conversion**: the sensor-hub humidity
  converter set `val1 = rh` *and* `val2 = rh * 1000000`, putting the whole
  value in the fractional field — roughly doubling the reported %RH and
  leaving `val2` out of range.
- **Honor enable arg in int routing**: the five data-ready routing assignments
  hardcoded `1` instead of using the `enable` argument, so
  `sensor_trigger_set()` with a NULL handler never cleared the INT1/INT2 route
  bit and triggers could not be disabled.
- **Bound the data ready drain loop**: `handle_interrupt()` looped until all
  data-ready bits cleared, but a bit only clears when a handler reads the
  output registers — so an enabled source with no registered handler hung the
  trigger thread. The exit test is now handler-qualified and bounded, and a
  status-read error breaks out so the GPIO interrupt is always re-armed.