### PR TITLE
drivers: sensor: fxos8700: fix off-by-one in SPI burst read

### DIFF
--- a/drivers/sensor/nxp/fxos8700/fxos8700.c
+++ b/drivers/sensor/nxp/fxos8700/fxos8700.c
@@ -40,14 +40,15 @@ int fxos8700_read_spi(const struct device *dev,
 {
 	const struct fxos8700_config *cfg = dev->config;
 
-	/* Reads must clock out a dummy byte after sending the address. */
-	uint8_t reg_buf[3] = { DIR_READ(reg), ADDR_7(reg), 0 };
-	const struct spi_buf buf[2] = {
-		{ .buf = reg_buf, .len = 3 },
+	/* The address phase is 2 bytes; data starts on the 3rd byte. */
+	uint8_t reg_buf[2] = { DIR_READ(reg), ADDR_7(reg) };
+	const struct spi_buf tx_buf = { .buf = reg_buf, .len = 2 };
+	const struct spi_buf rx_buf[2] = {
+		{ .buf = NULL, .len = 2 },
 		{ .buf = data, .len = length }
 	};
-	const struct spi_buf_set tx = { .buffers = buf, .count = 1 };
-	const struct spi_buf_set rx = { .buffers = buf, .count = 2 };
+	const struct spi_buf_set tx = { .buffers = &tx_buf, .count = 1 };
+	const struct spi_buf_set rx = { .buffers = rx_buf, .count = 2 };
 
 	return spi_transceive_dt(&cfg->bus_cfg.spi, &tx, &rx);
 }


### PR DESCRIPTION
`fxos8700_read_spi()` built a 3-byte buffer holding the two address bytes plus
a dummy byte, and used it as *both* the transmit buffer and the first receive
buffer — so the receive side skipped 3 bytes before storing data.

The device's address phase is only 2 bytes: the driver's own
`fxos8700_byte_read_spi()` performs a 3-byte transceive and takes its result
from `data[2]`, i.e. the third byte is already payload, and
`fxos8700_byte_write_spi()` likewise places its payload at index 2. Skipping 3
bytes therefore discarded the first data byte and shifted every burst read by
one register: accelerometer/magnetometer samples were assembled from the wrong
register pairs, with the final byte of each burst reading past the intended
range.

The burst read now clocks a 2-byte address phase and skips exactly 2 bytes on
receive, so `data[0]` is the first data byte. I2C is unaffected.