### PR TITLE
Bluetooth: Classic: HFP: Cancel AG work items on disconnect

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -3663,6 +3663,8 @@ static void hfp_ag_disconnected(struct bt_rfcomm_dlc *dlc)
 	struct bt_hfp_ag_call *call;
 
 	k_work_cancel_delayable(&ag->tx_work);
+	k_work_cancel_delayable(&ag->ongoing_call_work);
+	k_work_cancel(&ag->slc_work);
 
 	tx = ag_get_tx(ag, &ag->tx_pending);
 	while (tx != NULL) {


### PR DESCRIPTION
hfp_ag_disconnected() cancels the TX work and the per-call work items (via release_call()), but leaves ongoing_call_work and slc_work untouched. Nothing else cancels them on the disconnect path either: ongoing_call_work is only canceled when the application reports the ongoing calls in time, and slc_work is never canceled anywhere.

A work item that survives the disconnect is more than just a stale timeout: hfp_ag_disconnected() clears ag->acl_conn, which marks the AG slot as reusable, and hfp_ag_create() then wipes the whole struct with memset() when the slot is picked up for a new connection. Zeroing a delayable work whose timeout is still linked into the kernel timeout list, or a work item still queued on a workqueue, corrupts the kernel's bookkeeping.

Cancel both work items when the connection goes down, next to the existing TX work cancellation.

Fixes: #116859