### PR TITLE
Bluetooth: Classic: Guard limited discoverable timeout during disable

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1318,6 +1318,19 @@ static void bt_br_limited_discoverable_timeout_handler(struct k_work *work)
 		return;
 	}
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		/* bt_disable() is in progress or has completed, so the
+		 * transport may already be closed and no HCI commands can be
+		 * sent here. The controller scan state is handled by the
+		 * disable procedure itself (HCI Reset), or deliberately left
+		 * intact for controllers with the no-reset quirk. If
+		 * disabling fails and the stack resumes operation,
+		 * BT_DEV_READY gets restored with this timer still armed, so
+		 * the limited discoverable deadline keeps being honored.
+		 */
+		return;
+	}
+
 	err = bt_br_set_discoverable(false, false);
 	if (err) {
 		LOG_WRN("Disable discoverable failure (err %d)", err);


### PR DESCRIPTION
The limited discoverable duration timer is only canceled by bt_br_set_discoverable(false, ...). Nothing on the bt_disable() path stops it.

In the normal disable path this goes unnoticed, because hci_reset_complete() clears BT_DEV_LIMITED_DISCOVERABLE_MODE and a late firing of the timer is a no-op. But when the HCI driver has the no-reset quirk, the flag survives, and the timer can then fire with the transport closed: the handler calls bt_br_set_discoverable(false, false), which sends HCI_Write_Scan_Enable through bt_hci_cmd_send_sync(). No response can ever arrive, so the call ends in the 10 second "Controller unresponsive" assertion.

Canceling the timer in bt_disable() would trade this for a different bug: disabling can fail and resume operation (the driver close op is optional, so bt_hci_close() may return -ENOSYS, and an actual close failure also restores the stack to an operational state), and a canceled timer would then leave the controller in limited discoverable mode indefinitely.

Instead, guard the timeout handler with BT_DEV_READY: a timeout that fires while the stack is disabled (or is being disabled) becomes a no-op, while a failed bt_disable() restores BT_DEV_READY with the timer still armed, so the limited discoverable deadline keeps being honored.
