### PR TITLE
Bluetooth: Host: Flush pending ID/IRK store work in bt_disable()

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4851,6 +4851,10 @@ int bt_disable(void)
 	/* Some functions rely on checking this bitfield */
 	memset(bt_dev.supported_commands, 0x00, sizeof(bt_dev.supported_commands));
 
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_settings_flush();
+	}
+
 	/* Reset IDs and corresponding keys. */
 	bt_dev.id_count = 0;
 #if defined(CONFIG_BT_SMP)

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -572,6 +572,20 @@ int bt_settings_delete_irk(void)
 	return bt_settings_delete("irk", 0, NULL);
 }
 
+void bt_settings_flush(void)
+{
+	struct k_work_sync sync;
+
+	/* The store handlers read the identity state that bt_disable() is
+	 * about to reset. Running after the reset they would persist empty or
+	 * torn records, while canceling them would silently lose the latest
+	 * identity update. Complete any pending stores now, while the state
+	 * is still valid.
+	 */
+	(void)k_work_flush(&store_id_work, &sync);
+	(void)k_work_flush(&store_irk_work, &sync);
+}
+
 int bt_settings_store_link_key(const bt_addr_le_t *addr, const void *value, size_t val_len)
 {
 	return bt_settings_store("link_key", 0, addr, value, val_len);

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -40,6 +40,8 @@ void bt_settings_save_id(void);
 
 int bt_settings_init(void);
 
+void bt_settings_flush(void);
+
 int bt_settings_store_sc(uint8_t id, const bt_addr_le_t *addr, const void *value, size_t val_len);
 int bt_settings_delete_sc(uint8_t id, const bt_addr_le_t *addr);
 


### PR DESCRIPTION
bt_settings_store_id() and bt_settings_store_irk() defer the actual settings write to a work item that reads bt_dev.id_addr/bt_dev.irk with a length derived from bt_dev.id_count at execution time.

bt_disable() resets bt_dev.id_count without waiting for those work items. If a store is still pending at that point, the handler later computes a zero-length record and persists an empty "bt/id" or "bt/irk" entry, erasing the identity stored in the settings backend. If the handler is mid-execution, it can read the identity data while it is being reset, persisting a torn record.

Simply canceling the work items would trade one bug for another: an identity created or updated shortly before bt_disable() would silently never reach the settings backend, and a later bt_enable() would load stale identity data. Instead, add bt_settings_flush(), which completes any pending stores while the identity state is still valid, and call it from bt_disable() before the identity state is reset.
