### PR TITLE
drivers: sensor: max30210: fix sample fetch, triggers and threshold handling

### DIFF
--- a/drivers/sensor/adi/max30210/max30210.c
+++ b/drivers/sensor/adi/max30210/max30210.c
@@ -701,11 +701,46 @@ static int max30210_sample_fetch(const struct device *dev, enum sensor_channel c
 {
 	struct max30210_data *data = dev->data;
 	uint8_t temp_data[2];
+	uint8_t convert;
 	int ret;
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		LOG_ERR("Unsupported channel: %d", chan);
 		return -ENOTSUP;
+	}
+
+	ret = max30210_reg_read(dev, TEMP_CONVERT, &convert, 1);
+	if (ret < 0) {
+		LOG_ERR("Failed to read TEMP_CONVERT: %d", ret);
+		return ret;
+	}
+
+	if (!(convert & AUTO_MODE_MASK)) {
+		ret = max30210_reg_write(dev, TEMP_CONVERT, convert | CONVERT_T_MASK);
+		if (ret < 0) {
+			LOG_ERR("Failed to start conversion: %d", ret);
+			return ret;
+		}
+
+		/* CONVERT_T self-clears once the single-shot conversion completes */
+		for (int i = 0; i < MAX30210_CONVERSION_POLL_COUNT; i++) {
+			k_sleep(K_MSEC(MAX30210_CONVERSION_POLL_INTERVAL_MS));
+
+			ret = max30210_reg_read(dev, TEMP_CONVERT, &convert, 1);
+			if (ret < 0) {
+				LOG_ERR("Failed to read TEMP_CONVERT: %d", ret);
+				return ret;
+			}
+
+			if (!(convert & CONVERT_T_MASK)) {
+				break;
+			}
+		}
+
+		if (convert & CONVERT_T_MASK) {
+			LOG_ERR("Timed out waiting for conversion to complete");
+			return -ETIMEDOUT;
+		}
 	}
 
 	ret = max30210_reg_read(dev, TEMP_DATA_MSB, temp_data, 2);

--- a/drivers/sensor/adi/max30210/max30210.c
+++ b/drivers/sensor/adi/max30210/max30210.c
@@ -133,21 +133,6 @@ static int max30210_attr_set_continuous_conversion_mode(const struct device *dev
 }
 
 /**
- * @brief Validate whole part for MAX30210 temperature thresholds
- *
- * @param val Sensor Value Pointer
- * @return int 0 on success, negative error code on failure
- */
-static int max30210_validate_whole_part(const struct sensor_value *val)
-{
-	if (val->val1 < 0 || val->val1 > MAX30210_TEMP_MAX_C) {
-		LOG_ERR("Invalid whole part for THRESH\n");
-		return -EINVAL;
-	}
-	return 0;
-}
-
-/**
  * @brief Validate fractional parts for MAX30210 temperature thresholds
  *
  * @param val Sensor Value Pointer
@@ -164,6 +149,39 @@ static int max30210_validate_fractional_parts(const struct sensor_value *val)
 }
 
 /**
+ * @brief Validate a MAX30210 temperature threshold and convert it to register counts
+ *
+ * @param val Sensor Value Pointer
+ * @param counts Pointer to store the threshold in register counts
+ * @return int 0 on success, negative error code on failure
+ */
+static int max30210_validate_threshold(const struct sensor_value *val, int16_t *counts)
+{
+	int64_t thresh;
+
+	if (val->val2 <= -MAX30210_TEMP_FRAC_MAX_UC || val->val2 >= MAX30210_TEMP_FRAC_MAX_UC ||
+	    val->val2 % MAX30210_TEMP_FRAC_STEP_UC != 0) {
+		LOG_ERR("Invalid fractional part for THRESH\n");
+		return -EINVAL;
+	}
+
+	if ((val->val1 > 0 && val->val2 < 0) || (val->val1 < 0 && val->val2 > 0)) {
+		LOG_ERR("Mismatched signs for THRESH\n");
+		return -EINVAL;
+	}
+
+	thresh = (int64_t)val->val1 * MAX30210_TEMP_COUNTS_PER_C +
+		 ((int64_t)val->val2 * MAX30210_TEMP_COUNTS_PER_C) / MAX30210_TEMP_FRAC_MAX_UC;
+	if (thresh < INT16_MIN || thresh > INT16_MAX) {
+		LOG_ERR("THRESH out of range\n");
+		return -EINVAL;
+	}
+
+	*counts = (int16_t)thresh;
+	return 0;
+}
+
+/**
  * @brief Set Temperature Threshold for MAX30210
  *
  * @param dev Device Pointer
@@ -176,32 +194,21 @@ static int max30210_attr_set_threshold(const struct device *dev, const struct se
 {
 	int ret;
 	struct max30210_data *temp_data = dev->data;
-	uint16_t whole_numbers_data;
-	uint16_t fractional_data;
-
-	ret = max30210_validate_whole_part(val);
-	if (ret < 0) {
-		LOG_ERR("Failed to validate whole part for THRESH: %d\n", ret);
-		return ret;
-	}
-
-	ret = max30210_validate_fractional_parts(val);
-	if (ret < 0) {
-		LOG_ERR("Failed to validate fractional part for THRESH: %d\n", ret);
-		return ret;
-	}
-
-	whole_numbers_data = (val->val1) * MAX30210_TEMP_COUNTS_PER_C;
-	fractional_data = (val->val2 * MAX30210_TEMP_COUNTS_PER_C) / MAX30210_TEMP_FRAC_MAX_UC;
-	uint16_t thresh = whole_numbers_data + fractional_data;
+	int16_t thresh;
 	uint8_t thresh_data[2];
 
-	sys_put_be16(thresh, thresh_data);
+	ret = max30210_validate_threshold(val, &thresh);
+	if (ret < 0) {
+		LOG_ERR("Failed to validate THRESH: %d\n", ret);
+		return ret;
+	}
+
+	sys_put_be16((uint16_t)thresh, thresh_data);
 	if (upper) {
-		temp_data->temp_alarm_high_setup = thresh;
+		temp_data->temp_alarm_high_setup = (uint16_t)thresh;
 		ret = max30210_reg_write_multiple(dev, TEMP_ALARM_HIGH_MSB, thresh_data, 2);
 	} else {
-		temp_data->temp_alarm_low_setup = thresh;
+		temp_data->temp_alarm_low_setup = (uint16_t)thresh;
 		ret = max30210_reg_write_multiple(dev, TEMP_ALARM_LOW_MSB, thresh_data, 2);
 	}
 	if (ret < 0) {

--- a/drivers/sensor/adi/max30210/max30210.c
+++ b/drivers/sensor/adi/max30210/max30210.c
@@ -329,16 +329,32 @@ static int max30210_attr_set_temp_inc_fast_thresh(const struct device *dev,
 	uint16_t whole_numbers_data;
 	uint16_t fractional_data;
 
+	/* Highest possible whole number is 1 degrees celsius */
+	ret = max30210_validate_fast_thresh_whole_part(val);
+	if (ret < 0) {
+		LOG_ERR("Invalid whole part for INC FAST THRESH\n");
+		return -EINVAL;
+	}
+
+	/* Validate value is non-negative, <= 1 degree, and a multiple of 0.005 degrees */
+	ret = max30210_validate_fractional_parts(val);
+	if (ret < 0) {
+		LOG_ERR("Invalid fractional part for INC FAST THRESH\n");
+		return -EINVAL;
+	}
+
 	whole_numbers_data = (val->val1) * MAX30210_TEMP_COUNTS_PER_C;
-	fractional_data = ((val->val2) / MAX30210_TEMP_FRAC_MAX_UC) * MAX30210_TEMP_COUNTS_PER_C;
-	uint8_t inc_fast_thresh = whole_numbers_data + fractional_data;
+	fractional_data = (val->val2 * MAX30210_TEMP_COUNTS_PER_C) / MAX30210_TEMP_FRAC_MAX_UC;
+	uint16_t thresh = whole_numbers_data + fractional_data;
 
-	temp_data->temp_inc_fast_thresh = inc_fast_thresh;
-
-	if (inc_fast_thresh > MAX30210_TEMP_SLOPE_MAX_REG_VALUE) {
+	if (thresh > MAX30210_TEMP_SLOPE_MAX_REG_VALUE) {
 		LOG_ERR("INC FAST THRESH exceeds maximum value\n");
 		return -EINVAL;
 	}
+
+	uint8_t inc_fast_thresh = (uint8_t)thresh;
+
+	temp_data->temp_inc_fast_thresh = inc_fast_thresh;
 
 	ret = max30210_reg_write(dev, TEMP_INC_FAST_THRESH, inc_fast_thresh);
 	if (ret < 0) {
@@ -378,15 +394,17 @@ static int max30210_attr_set_temp_dec_fast_thresh(const struct device *dev,
 	}
 
 	whole_numbers_data = (val->val1) * MAX30210_TEMP_COUNTS_PER_C;
-	fractional_data = ((val->val2) / MAX30210_TEMP_FRAC_MAX_UC) * MAX30210_TEMP_COUNTS_PER_C;
-	uint8_t dec_fast_thresh = whole_numbers_data + fractional_data;
+	fractional_data = (val->val2 * MAX30210_TEMP_COUNTS_PER_C) / MAX30210_TEMP_FRAC_MAX_UC;
+	uint16_t thresh = whole_numbers_data + fractional_data;
 
-	temp_data->temp_dec_fast_thresh = dec_fast_thresh;
-
-	if (dec_fast_thresh > MAX30210_TEMP_SLOPE_MAX_REG_VALUE) {
+	if (thresh > MAX30210_TEMP_SLOPE_MAX_REG_VALUE) {
 		LOG_ERR("DEC FAST THRESH exceeds maximum value\n");
 		return -EINVAL;
 	}
+
+	uint8_t dec_fast_thresh = (uint8_t)thresh;
+
+	temp_data->temp_dec_fast_thresh = dec_fast_thresh;
 
 	ret = max30210_reg_write(dev, TEMP_DEC_FAST_THRESH, dec_fast_thresh);
 	if (ret < 0) {

--- a/drivers/sensor/adi/max30210/max30210.h
+++ b/drivers/sensor/adi/max30210/max30210.h
@@ -190,6 +190,9 @@
 #define MAX30210_TEMP_REG_BYTES           2
 #define MAX30210_TEMP_SLOPE_MAX_REG_VALUE 255
 
+#define MAX30210_CONVERSION_POLL_INTERVAL_MS 5
+#define MAX30210_CONVERSION_POLL_COUNT       20
+
 struct max30210_config {
 	struct i2c_dt_spec i2c;
 

--- a/drivers/sensor/adi/max30210/max30210_trigger.c
+++ b/drivers/sensor/adi/max30210/max30210_trigger.c
@@ -237,7 +237,7 @@ int max30210_trigger_set(const struct device *dev, const struct sensor_trigger *
 		int_en = 0;
 	}
 
-	if (sys_count_bits(&int_mask, sizeof(int_mask)) > 1) {
+	if (handler && sys_count_bits(&int_mask, sizeof(int_mask)) > 1) {
 		int_en = 0x3;
 	}
 

--- a/drivers/sensor/adi/max30210/max30210_trigger.c
+++ b/drivers/sensor/adi/max30210/max30210_trigger.c
@@ -146,7 +146,7 @@ int max30210_trigger_set(const struct device *dev, const struct sensor_trigger *
 		max30210_reg_read(dev, TEMP_ALARM_HIGH_MSB, temp_hi_setup, 2);
 		data->temp_alarm_high_setup = (temp_hi_setup[0] << 8) | temp_hi_setup[1];
 
-		if (data->temp_alarm_high_setup >= 0x7FFF) {
+		if ((int16_t)data->temp_alarm_high_setup == INT16_MAX) {
 			LOG_ERR("Temperature high threshold not set\n");
 		}
 


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the MAX30210 temperature
sensor driver, one commit per issue:

- **Start a conversion in sample_fetch**: `sample_fetch()` read the
  temperature registers without ever starting a conversion or checking the
  TEMP_RDY status, so it returned success with whatever the last conversion
  left behind — or with never-initialised data on the first call.
- **Fix trigger disable enabling interrupts**: unregistering a
  `SENSOR_TRIG_THRESHOLD` trigger wrote the multi-bit INTERRUPT_ENABLE payload
  unconditionally, *setting* TEMP_HI_EN/TEMP_LO_EN instead of clearing them —
  so removing a trigger enabled the very interrupts it was meant to disable.
  The payload override is now gated on the handler being non-NULL.
- **Allow sub-zero alarm thresholds**: the alarm threshold setter rejected
  negative values even though the part and the register encoding support
  them, making it impossible to set a below-zero alarm through the sensor API.
- **Fix INC/DEC fast threshold conversion**: the fractional part was divided
  before being scaled, so the sub-degree component was always truncated to
  zero and only whole-degree thresholds could be programmed. The scaling now
  matches the ordinary threshold path, the sum is range-checked in a wider
  type before narrowing to the register byte, and the increment helper runs
  the same whole/fractional validation as its decrement twin.