### PR TITLE
drivers: sensor: ism330dhcx: fix endless loop in interrupt handler

### DIFF
--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
@@ -182,11 +182,12 @@ static void ism330dhcx_handle_interrupt(const struct device *dev)
 			return;
 		}
 
-		if ((status.xlda == 0) && (status.gda == 0)
+		if (!((status.xlda && (ism330dhcx->handler_drdy_acc != NULL)) ||
+		      (status.gda && (ism330dhcx->handler_drdy_gyr != NULL))
 #if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
-					&& (status.tda == 0)
+		      || (status.tda && (ism330dhcx->handler_drdy_temp != NULL))
 #endif
-					) {
+		      )) {
 			break;
 		}
 


### PR DESCRIPTION
`ism330dhcx_handle_interrupt()` looped until every data-ready bit in STATUS_REG
cleared, but a data-ready bit is only cleared when a handler reads the
corresponding output registers. The dispatch below the check is already
handler-qualified, so if an enabled data-ready source has no registered handler
— e.g. only an accelerometer trigger is registered while the gyroscope is also
enabled and producing data — nothing ever clears that bit and the loop spins
forever, hanging the trigger thread or the system workqueue.

The exit condition now matches the dispatch: the loop terminates when no
pending source has a registered handler.

The same defect exists in the lsm6dso and lsm6dso16is drivers and is fixed in
their respective PRs.