### PR TITLE
drivers: sensor: iis3dwb: fix RTIO sqe completion and decoder status source

### DIFF
--- a/drivers/sensor/st/iis3dwb/iis3dwb.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb.c
@@ -175,63 +175,11 @@ static void iis3dwb_submit_one_shot(const struct device *dev, struct rtio_iodev_
 		case SENSOR_CHAN_ACCEL_Z:
 		case SENSOR_CHAN_ACCEL_XYZ:
 			edata->has_accel = 1;
-
-			struct rtio_regs outx_regs;
-			struct rtio_regs_list xl_regs_list[] = {
-				{
-					0x80 | IIS3DWB_OUTX_L_A, /* SPI read transaction */
-					(uint8_t *)edata->accel,
-					6,
-				},
-			};
-
-			outx_regs.rtio_regs_list = xl_regs_list;
-			outx_regs.rtio_regs_num = ARRAY_SIZE(xl_regs_list);
-
-			/*
-			 * Prepare rtio enabled bus to read IIS3DWB_OUTX_L_A register
-			 * where accelerometer data is available.
-			 * Then iis3dwb_one_shot_complete_cb callback will be invoked.
-			 *
-			 * STMEMSC API equivalent code:
-			 *
-			 *   uint8_t accel_raw[6];
-			 *
-			 *   iis3dwb_acceleration_raw_get(&dev_ctx, accel_raw);
-			 */
-			rtio_read_regs_async(data->rtio_ctx, data->iodev, RTIO_BUS_SPI, &outx_regs,
-					     iodev_sqe, dev, iis3dwb_one_shot_complete_cb);
 			break;
 
 #if defined(CONFIG_IIS3DWB_ENABLE_TEMP)
 		case SENSOR_CHAN_DIE_TEMP:
 			edata->has_temp = 1;
-
-			struct rtio_regs outt_regs;
-			struct rtio_regs_list t_regs_list[] = {
-				{
-					0x80 | IIS3DWB_OUT_TEMP_L, /* SPI read transaction */
-					(uint8_t *)&edata->temp,
-					2,
-				},
-			};
-
-			outt_regs.rtio_regs_list = t_regs_list;
-			outt_regs.rtio_regs_num = ARRAY_SIZE(t_regs_list);
-
-			/*
-			 * Prepare rtio enabled bus to read IIS3DWB_OUT_TEMP_L register
-			 * where temperature data is available.
-			 * Then iis3dwb_one_shot_complete_cb callback will be invoked.
-			 *
-			 * STMEMSC API equivalent code:
-			 *
-			 *   int16_t val;
-			 *
-			 *   iis3dwb_temperature_raw_get(&dev_ctx, &val);
-			 */
-			rtio_read_regs_async(data->rtio_ctx, data->iodev, RTIO_BUS_SPI, &outt_regs,
-					     iodev_sqe, dev, iis3dwb_one_shot_complete_cb);
 			break;
 #endif
 
@@ -242,7 +190,48 @@ static void iis3dwb_submit_one_shot(const struct device *dev, struct rtio_iodev_
 
 	if (edata->has_accel == 0 && edata->has_temp == 0) {
 		rtio_iodev_sqe_err(iodev_sqe, -EIO);
+		return;
 	}
+
+	struct rtio_regs out_regs;
+	struct rtio_regs_list regs_list[2];
+	size_t num_regs = 0;
+
+	if (edata->has_accel) {
+		regs_list[num_regs].reg_addr = 0x80 | IIS3DWB_OUTX_L_A; /* SPI read transaction */
+		regs_list[num_regs].bufp = (uint8_t *)edata->accel;
+		regs_list[num_regs].len = 6;
+		num_regs++;
+	}
+
+#if defined(CONFIG_IIS3DWB_ENABLE_TEMP)
+	if (edata->has_temp) {
+		regs_list[num_regs].reg_addr = 0x80 | IIS3DWB_OUT_TEMP_L; /* SPI read transaction */
+		regs_list[num_regs].bufp = (uint8_t *)&edata->temp;
+		regs_list[num_regs].len = 2;
+		num_regs++;
+	}
+#endif
+
+	out_regs.rtio_regs_list = regs_list;
+	out_regs.rtio_regs_num = num_regs;
+
+	/*
+	 * Prepare rtio enabled bus to read the IIS3DWB_OUTX_L_A and/or IIS3DWB_OUT_TEMP_L
+	 * registers where accelerometer and temperature data are available.
+	 * Then iis3dwb_one_shot_complete_cb callback will be invoked once, when all the
+	 * requested registers have been read.
+	 *
+	 * STMEMSC API equivalent code:
+	 *
+	 *   uint8_t accel_raw[6];
+	 *   int16_t val;
+	 *
+	 *   iis3dwb_acceleration_raw_get(&dev_ctx, accel_raw);
+	 *   iis3dwb_temperature_raw_get(&dev_ctx, &val);
+	 */
+	rtio_read_regs_async(data->rtio_ctx, data->iodev, RTIO_BUS_SPI, &out_regs, iodev_sqe, dev,
+			     iis3dwb_one_shot_complete_cb);
 }
 
 void iis3dwb_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)

--- a/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
@@ -241,7 +241,7 @@ static void iis3dwb_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, int
 		memset(buf, 0, buf_len);
 		rx_data->header.is_fifo = 1;
 		rx_data->header.timestamp = iis3dwb->timestamp;
-		rx_data->header.int_status = iis3dwb->fifo_status[0];
+		rx_data->header.int_status = iis3dwb->fifo_status[1];
 		rx_data->fifo_count = 0;
 		rx_data->fifo_mode_sel = 0;
 
@@ -295,7 +295,7 @@ static void iis3dwb_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, int
 			.is_fifo = 1,
 			.range = iis3dwb->range,
 			.timestamp = iis3dwb->timestamp,
-			.int_status = iis3dwb->fifo_status[0],
+			.int_status = iis3dwb->fifo_status[1],
 		},
 		.fifo_count = fifo_count,
 		.accel_batch_odr = iis3dwb->accel_batch_odr,

--- a/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
@@ -528,10 +528,8 @@ void iis3dwb_stream_irq_handler(const struct device *dev)
 		 */
 		rtio_read_regs_async(iis3dwb->rtio_ctx, iis3dwb->iodev, RTIO_BUS_SPI, &fifo_regs,
 				     iis3dwb->streaming_sqe, dev, iis3dwb_read_fifo_cb);
-	}
-
-	/* handle drdy trigger */
-	if (iis3dwb->trig_cfg.int_drdy) {
+	} else if (iis3dwb->trig_cfg.int_drdy) {
+		/* handle drdy trigger */
 		iis3dwb->status = 0;
 
 		struct rtio_regs fifo_regs;

--- a/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
@@ -380,8 +380,9 @@ static void iis3dwb_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe, i
 		return;
 	}
 
-	if (data_ready->opt == SENSOR_STREAM_DATA_NOP ||
-	    data_ready->opt == SENSOR_STREAM_DATA_DROP) {
+	if (data_ready != NULL &&
+	    (data_ready->opt == SENSOR_STREAM_DATA_NOP ||
+	     data_ready->opt == SENSOR_STREAM_DATA_DROP)) {
 		uint8_t *buf;
 		uint32_t buf_len;
 
@@ -406,6 +407,8 @@ static void iis3dwb_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe, i
 		rtio_iodev_sqe_ok(iis3dwb->streaming_sqe, 0);
 		iis3dwb->streaming_sqe = NULL;
 		gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+
+		return;
 	}
 
 	/*


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the IIS3DWB driver, one
commit per issue:

- **Fix double completion of the same RTIO sqe**: the one-shot submit path
  issued a separate `rtio_read_regs_async()` chain per requested channel, each
  carrying the same `rtio_iodev_sqe` and completion callback — so a read
  config naming more than one channel completed that sqe several times,
  corrupting the RTIO sqe free list. All requested channels are now collected
  into a single register list and issued as one chain. The stream IRQ handler's
  data-ready branch is likewise made exclusive so at most one chain owns the
  streaming sqe per interrupt.
- **Return after completing DRDY NOP/DROP SQE**: the data-ready path completed
  the SQE and then fell through instead of returning, so the code below
  dereferenced state belonging to the already-completed submission.
- **Use FIFO_STATUS2 for decoder int_status**: the encoded header's
  `int_status` was filled from FIFO_STATUS1, which holds the low byte of the
  sample count, rather than FIFO_STATUS2, which holds the FIFO_WTM_IA and
  FIFO_FULL_IA flags that `decoder_has_trigger()` tests. Watermark and
  FIFO-full trigger reporting was therefore driven by an unrelated counter
  value.