### PR TITLE
drivers: sensor: adxl345: fix FIFO buffer bounds and RTIO sample handling

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -526,6 +526,8 @@ static int adxl345_init(const struct device *dev)
 	if (rc) {
 		return rc;
 	}
+
+	data->odr = cfg->odr;
 #endif
 
 	rc = adxl345_reg_read_byte(dev, ADXL345_DATA_FORMAT_REG, &full_res);

--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -114,7 +114,7 @@ int adxl345_reg_write_mask(const struct device *dev,
 	}
 
 	tmp &= ~mask;
-	tmp |= data;
+	tmp |= (data & mask);
 
 	return adxl345_reg_write_byte(dev, reg_addr, tmp);
 }

--- a/drivers/sensor/adi/adxl345/adxl345_rtio.c
+++ b/drivers/sensor/adi/adxl345/adxl345_rtio.c
@@ -31,6 +31,10 @@ static void adxl345_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
 
 	struct adxl345_sample *data = (struct adxl345_sample *)buffer;
 
+#ifdef CONFIG_ADXL345_STREAM
+	data->is_fifo = 0;
+#endif /* CONFIG_ADXL345_STREAM */
+
 	rc = adxl345_read_sample(dev, data);
 	if (rc != 0) {
 		LOG_ERR("Failed to fetch samples");

--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -203,6 +203,8 @@ static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 
 	((struct adxl345_fifo_data *)buf)->fifo_byte_count = read_len;
 
+	uint16_t read_samples = read_len / sample_set_size;
+
 	uint8_t *read_buf = buf + sizeof(*hdr);
 
 	/* Flush completions */
@@ -227,8 +229,9 @@ static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	}
 
 
-	data->fifo_samples = fifo_samples;
-	for (size_t i = 0; i < fifo_samples; i++) {
+	data->fifo_total_bytes = 0;
+	data->fifo_samples = read_samples;
+	for (size_t i = 0; i < read_samples; i++) {
 		struct rtio_sqe *write_fifo_addr = rtio_sqe_acquire(data->rtio_ctx);
 		struct rtio_sqe *read_fifo_data = rtio_sqe_acquire(data->rtio_ctx);
 
@@ -246,7 +249,7 @@ static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 		if (cfg->bus_type == ADXL345_BUS_I2C) {
 			read_fifo_data->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
 		}
-		if (i == fifo_samples-1) {
+		if (i == read_samples - 1U) {
 			struct rtio_sqe *complete_op = rtio_sqe_acquire(data->rtio_ctx);
 
 			read_fifo_data->flags |= RTIO_SQE_CHAINED;


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the ADXL345 driver, one
commit per issue:

- **Bound FIFO read loop by buffer length**: the streaming FIFO loop queued
  and wrote one frame per hardware sample count, ignoring the clamped
  `read_len` returned when `rtio_sqe_rx_buf()` hands back a shorter buffer than
  requested — writing past the end of the RTIO buffer pool allocation. The
  loop and its last-iteration completion test are now bounded by the clamped
  length, and the byte counter is reset at the start of each batch.
- **Mask data in read-modify-write helper**: `reg_write_mask()` cleared the
  masked bits and then OR-ed in the caller's data argument without masking it,
  so callers passing complemented values (as the interrupt-routing paths do)
  set bits outside the mask, clobbering unrelated INT_MAP routing.
- **Clear is_fifo in one-shot RTIO fetch**: the one-shot path never cleared the
  `is_fifo` flag in the sample struct, so a one-shot read following a streaming
  read could be decoded as FIFO data.
- **Cache ODR configured at init**: `data->odr` was only ever written by the
  ODR attribute setter, never initialised from the devicetree configuration,
  so streaming headers reported index 0 and the decoder computed sample
  timestamps from the wrong period until an application happened to set the
  ODR at runtime.

Fixes: #117495