### PR TITLE
drivers: sensor: icm42605: fix full-scale programming, temperature and triggers

### DIFF
--- a/drivers/sensor/tdk/icm42605/icm42605.c
+++ b/drivers/sensor/tdk/icm42605/icm42605.c
@@ -19,8 +19,9 @@
 
 LOG_MODULE_REGISTER(ICM42605, CONFIG_SENSOR_LOG_LEVEL);
 
+/* Indexed by GYRO_FS_* selector, i.e. 0 = 2000 dps ... 7 = 15.625 dps */
 static const uint16_t icm42605_gyro_sensitivity_x10[] = {
-	1310, 655, 328, 164
+	164, 328, 655, 1310, 2620, 5243, 10486, 20972
 };
 
 /* see "Accelerometer Measurements" section from register map description */
@@ -278,6 +279,7 @@ static int icm42605_attr_set(const struct device *dev,
 				return -EINVAL;
 			} else {
 				drv_data->accel_sf = val->val1;
+				drv_data->accel_sensitivity_shift = 11 + val->val1;
 			}
 		} else {
 			LOG_ERR("Not supported ATTR");
@@ -303,6 +305,8 @@ static int icm42605_attr_set(const struct device *dev,
 				return -EINVAL;
 			} else {
 				drv_data->gyro_sf = val->val1;
+				drv_data->gyro_sensitivity_x10 =
+					icm42605_gyro_sensitivity_x10[val->val1];
 			}
 		} else {
 			LOG_ERR("Not supported ATTR");
@@ -400,8 +404,8 @@ static int icm42605_init(const struct device *dev)
 	icm42605_data_init(drv_data, cfg);
 	icm42605_sensor_init(dev);
 
-	drv_data->accel_sensitivity_shift = 14 - 3;
-	drv_data->gyro_sensitivity_x10 = icm42605_gyro_sensitivity_x10[3];
+	drv_data->accel_sensitivity_shift = 11 + cfg->accel_fs;
+	drv_data->gyro_sensitivity_x10 = icm42605_gyro_sensitivity_x10[cfg->gyro_fs];
 
 #ifdef CONFIG_ICM42605_TRIGGER
 	if (icm42605_init_interrupt(dev) < 0) {

--- a/drivers/sensor/tdk/icm42605/icm42605.c
+++ b/drivers/sensor/tdk/icm42605/icm42605.c
@@ -207,7 +207,7 @@ static int icm42605_sample_fetch(const struct device *dev,
 			}
 			if (!(drv_data->fifo_data[0] & BIT_FIFO_HEAD_GYRO)) {
 				drv_data->temp =
-					(int16_t)(drv_data->fifo_data[7]);
+					(int16_t)(int8_t)drv_data->fifo_data[7];
 			} else {
 				if (!(drv_data->fifo_data[7] ==
 				      FIFO_GYRO0_RESET_VALUE &&
@@ -224,7 +224,7 @@ static int icm42605_sample_fetch(const struct device *dev,
 						+ (drv_data->fifo_data[12]);
 				}
 				drv_data->temp =
-					(int16_t)(drv_data->fifo_data[13]);
+					(int16_t)(int8_t)drv_data->fifo_data[13];
 			}
 		} else {
 			if (drv_data->fifo_data[0] & BIT_FIFO_HEAD_GYRO) {
@@ -243,7 +243,7 @@ static int icm42605_sample_fetch(const struct device *dev,
 						+ (drv_data->fifo_data[6]);
 				}
 				drv_data->temp =
-					(int16_t)(drv_data->fifo_data[7]);
+					(int16_t)(int8_t)drv_data->fifo_data[7];
 			}
 		}
 	}

--- a/drivers/sensor/tdk/icm42605/icm42605_setup.c
+++ b/drivers/sensor/tdk/icm42605/icm42605_setup.c
@@ -26,7 +26,7 @@ int icm42605_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	}
 	databuf &= ~BIT_ACCEL_FSR;
 
-	databuf |= a_sf;
+	databuf |= (a_sf << SHIFT_ACCEL_FS_SEL) & BIT_ACCEL_FSR;
 
 	result = inv_spi_single_write(&cfg->spi, REG_ACCEL_CONFIG0, &databuf);
 
@@ -37,7 +37,7 @@ int icm42605_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	}
 
 	databuf &= ~BIT_GYRO_FSR;
-	databuf |= g_sf;
+	databuf |= (g_sf << SHIFT_GYRO_FS_SEL) & BIT_GYRO_FSR;
 
 	result = inv_spi_single_write(&cfg->spi, REG_GYRO_CONFIG0, &databuf);
 

--- a/drivers/sensor/tdk/icm42605/icm42605_setup.c
+++ b/drivers/sensor/tdk/icm42605/icm42605_setup.c
@@ -425,6 +425,7 @@ int icm42605_turn_on_sensor(const struct device *dev)
 
 int icm42605_turn_off_sensor(const struct device *dev)
 {
+	struct icm42605_data *drv_data = dev->data;
 	const struct icm42605_config *cfg = dev->config;
 	uint8_t v = 0;
 	int result = 0;
@@ -445,6 +446,8 @@ int icm42605_turn_off_sensor(const struct device *dev)
 	k_msleep(100);
 
 	icm42605_turn_off_fifo(dev);
+
+	drv_data->sensor_started = false;
 
 	return 0;
 }

--- a/drivers/sensor/tdk/icm42605/icm42605_trigger.c
+++ b/drivers/sensor/tdk/icm42605/icm42605_trigger.c
@@ -21,6 +21,7 @@ int icm42605_trigger_set(const struct device *dev,
 {
 	struct icm42605_data *drv_data = dev->data;
 	const struct icm42605_config *cfg = dev->config;
+	int ret;
 
 	if (trig->type != SENSOR_TRIG_DATA_READY
 	    && trig->type != SENSOR_TRIG_TAP
@@ -50,11 +51,19 @@ int icm42605_trigger_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (drv_data->sensor_started) {
+		/* The tap detection engine is only programmed as part of the
+		 * FIFO/APEX setup, so it has to be re-applied when a trigger is
+		 * registered while the sensor is already running.
+		 */
+		ret = icm42605_turn_on_fifo(dev);
+	} else {
+		ret = icm42605_turn_on_sensor(dev);
+	}
+
 	gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);
 
-	icm42605_turn_on_sensor(dev);
-
-	return 0;
+	return ret;
 }
 
 static void icm42605_gpio_callback(const struct device *dev,


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the ICM42605 driver, one
commit per issue:

- **Apply full-scale selector to FS_SEL field**: `set_fs()` OR-ed the raw
  accel/gyro full-scale index into ACCEL_CONFIG0/GYRO_CONFIG0 without shifting
  it into the FS_SEL field (bits 7:5), so it landed in the ODR bits instead.
  The `accel-fs`/`gyro-fs` devicetree properties therefore never took effect
  and corrupted the configured ODR. The shift and field mask are now applied,
  and the conversion scale factors are derived from the range actually
  programmed.
- **Sign-extend FIFO temperature byte**: the 8-bit FIFO temperature is a
  two's-complement value, but it was widened as unsigned, so every reading
  below the 25 °C reference decoded as roughly +87…+148 °C.
- **Clear sensor_started on power-down**: `turn_off_sensor()` never cleared the
  flag, so a later `turn_on_sensor()` hit its `-EALREADY` early return and the
  part stayed powered down — a trigger could never be re-armed after being
  removed.
- **Enable tap when sensor already started**: registering a tap or double-tap
  trigger after a data-ready trigger called `turn_on_sensor()`, which returns
  `-EALREADY` and skips the APEX/SIGNAL_PATH_RESET/INT_SOURCE6 block that
  actually enables tap detection — so the trigger was registered in software
  but never armed in hardware. It now enables the FIFO path directly in that
  case, arms the GPIO interrupt only after the registers are written, and
  propagates the return value.