### PR TITLE
drivers: sensor: ina2xx: fix INA230 data layout and negative voltage scaling

### DIFF
--- a/drivers/sensor/ti/ina2xx/ina230.h
+++ b/drivers/sensor/ti/ina2xx/ina230.h
@@ -32,10 +32,8 @@
 #define INA236_REG_DEVICE_ID       0x3F
 
 struct ina230_data {
+	struct ina2xx_data common;
 	const struct device *dev;
-	int16_t current;
-	uint16_t bus_voltage;
-	uint16_t power;
 #ifdef CONFIG_INA230_TRIGGER
 	const struct device *gpio;
 	struct gpio_callback gpio_cb;

--- a/drivers/sensor/ti/ina2xx/ina2xx_get.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_get.c
@@ -38,9 +38,7 @@ static int ina2xx_get_bus_voltage(const struct device *dev, struct sensor_value 
 		return -ENOTSUP;
 	}
 
-	value.s32 = (ch->mult * value.s32) / ch->div;
-
-	return sensor_value_from_micro(val, value.s32);
+	return sensor_value_from_micro(val, ((int64_t)ch->mult * value.s32) / (int32_t)ch->div);
 #else
 	return -ENOTSUP;
 #endif /* CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE */
@@ -75,9 +73,7 @@ static int ina2xx_get_shunt_voltage(const struct device *dev, struct sensor_valu
 		return -ENOTSUP;
 	}
 
-	value.s32 = (ch->mult * value.s32) / ch->div;
-
-	return sensor_value_from_micro(val, value.s32);
+	return sensor_value_from_micro(val, ((int64_t)ch->mult * value.s32) / (int32_t)ch->div);
 #else
 	return -ENOTSUP;
 #endif /* CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE */


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the INA2xx driver family,
one commit per issue:

- **Fix INA230 device data struct layout**: `struct ina230_data` did not embed
  `struct ina2xx_data` as its first member, although the INA230/232/236
  instances share the common `ina2xx_sample_fetch()`/`channel_get()` code that
  casts `dev->data` to `struct ina2xx_data`. Fetching a sample therefore wrote
  raw register values over whatever those bytes actually held — including the
  cached device pointer the alert trigger relies on. The common struct is now
  embedded first, mirroring `struct ina237_data`, and three now-dead fields are
  dropped.
- **Fix sign loss in voltage scaling**: the bus- and shunt-voltage conversions
  performed their scaling in unsigned arithmetic, so a negative sample became
  a large positive value. On an INA226 measuring reverse current, VSHUNT (which
  is signed and uses a 2500/1000 multiplier/divisor) reported a large positive
  voltage instead of a negative one. The scaling is now done in signed 64-bit.