### PR TITLE
drivers: sensor: lis2dh: fix SPI error handling, temperature and ODR guards

### DIFF
--- a/drivers/sensor/st/lis2dh/lis2dh.c
+++ b/drivers/sensor/st/lis2dh/lis2dh.c
@@ -74,12 +74,20 @@ static int lis2dh_sample_fetch_temp(const struct device *dev)
 		if (cfg->temperature.fractional_bits == 0) {
 			lis2dh->temperature.val2 = 0;
 		} else {
-			lis2dh->temperature.val2 =
-				(raw[0] >> (8 - cfg->temperature.fractional_bits));
-			lis2dh->temperature.val2 = (lis2dh->temperature.val2 * 1000000);
-			lis2dh->temperature.val2 >>= cfg->temperature.fractional_bits;
-			if (lis2dh->temperature.val1 < 0) {
-				lis2dh->temperature.val2 *= -1;
+			int32_t frac = raw[0] >> (8 - cfg->temperature.fractional_bits);
+
+			frac = (frac * 1000000) >> cfg->temperature.fractional_bits;
+
+			if (lis2dh->temperature.val1 < 0 && frac != 0) {
+				/*
+				 * The raw value is two's complement, so the fractional
+				 * part is always a positive addend.  Renormalize it so
+				 * that val1 and val2 have the same sign.
+				 */
+				lis2dh->temperature.val1 += 1;
+				lis2dh->temperature.val2 = frac - 1000000;
+			} else {
+				lis2dh->temperature.val2 = frac;
 			}
 		}
 	}

--- a/drivers/sensor/st/lis2dh/lis2dh.c
+++ b/drivers/sensor/st/lis2dh/lis2dh.c
@@ -214,6 +214,7 @@ static int lis2dh_acc_odr_set(const struct device *dev, uint16_t freq)
 	int odr;
 	int status;
 	uint8_t value;
+	bool lp;
 	struct lis2dh_data *data = dev->data;
 
 	odr = lis2dh_freq_to_odr_val(freq);
@@ -226,14 +227,21 @@ static int lis2dh_acc_odr_set(const struct device *dev, uint16_t freq)
 		return status;
 	}
 
+	lp = (value & LIS2DH_LP_EN_BIT_MASK) != 0U;
+
 	/* some odr values cannot be set in certain power modes */
-	if ((value & LIS2DH_LP_EN_BIT_MASK) == 0U && odr == LIS2DH_ODR_8) {
+	if (!lp && (odr == LIS2DH_ODR_8 || odr == LIS2DH_ODR_9 + 1)) {
+		/* 1620 Hz and 5376 Hz are low power mode only */
+		return -ENOTSUP;
+	}
+
+	if (lp && odr == LIS2DH_ODR_9) {
+		/* 1344 Hz is normal/high resolution mode only */
 		return -ENOTSUP;
 	}
 
 	/* adjust odr index for LP enabled mode, see table above */
-	if (((value & LIS2DH_LP_EN_BIT_MASK) == LIS2DH_LP_EN_BIT_MASK) &&
-		(odr == LIS2DH_ODR_9 + 1)) {
+	if (lp && odr == LIS2DH_ODR_9 + 1) {
 		odr--;
 	}
 

--- a/drivers/sensor/st/lis2dh/lis2dh_spi.c
+++ b/drivers/sensor/st/lis2dh/lis2dh_spi.c
@@ -133,8 +133,13 @@ static int lis2dh_spi_update_reg(const struct device *dev, uint8_t reg_addr,
 				  uint8_t mask, uint8_t value)
 {
 	uint8_t tmp_val;
+	int status;
 
-	lis2dh_raw_read(dev, reg_addr, &tmp_val, 1);
+	status = lis2dh_raw_read(dev, reg_addr, &tmp_val, 1);
+	if (status < 0) {
+		return status;
+	}
+
 	tmp_val = (tmp_val & ~mask) | (value & mask);
 
 	return lis2dh_raw_write(dev, reg_addr, &tmp_val, 1);

--- a/drivers/sensor/st/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/st/lis2dh/lis2dh_trigger.c
@@ -190,8 +190,15 @@ static int lis2dh_trigger_anym_tap_set(const struct device *dev,
 		lis2dh->trig_tap = trig;
 	}
 
-	if ((handler == NULL) || (status < 0)) {
+	if (status < 0) {
 		return status;
+	}
+
+	/* both int2 sources were torn down above, so only stay down if neither
+	 * of them is registered any more
+	 */
+	if ((lis2dh->handler_anymotion == NULL) && (lis2dh->handler_tap == NULL)) {
+		return 0;
 	}
 
 	/* serialize start of int2 in thread to synchronize output sampling


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the LIS2DH driver, one
commit per issue:

- **Check read status in SPI update_reg**: the SPI read-modify-write helper
  ignored the result of its register read and merged the mask into an
  uninitialised stack byte when the read failed, writing garbage back to the
  device and reporting success. The read status is now checked before the
  write.
- **Fix negative die temperature conversion**: for negative temperature
  deltas the fractional part was negated rather than renormalised, so results
  below the reference were off by a full degree (e.g. -0.25 °C reported as
  -1 + 0.75). The value is now renormalised properly, keeping `val1` and
  `val2` consistent in sign.
- **Complete power-mode ODR validation**: the ODR/power-mode guard was
  asymmetric. Requesting 5376 Hz outside low-power mode wrote a reserved
  CTRL_REG1 code, and requesting 1344 Hz *in* low-power mode programmed the
  code that means 5376 Hz there. Both combinations are now rejected with
  -ENOTSUP, preserving the existing 1620 Hz rejection and 5376 Hz folding.
- **Re-arm INT2 when one shared trigger remains**: the DELTA and TAP triggers
  share the INT2 line. Unregistering either one disabled the pin interrupt
  outright, silently and permanently killing the other trigger if it was still
  registered. INT2 now stays armed while any trigger still needs it.