### PR TITLE
drivers: sensor: grow_r502a: fix RX length bound and LED API locking

### DIFF
--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -1209,6 +1209,7 @@ static int grow_r502a_led_set_color(const struct device *dev, uint32_t led,
 static int grow_r502a_led_on(const struct device *dev, uint32_t led)
 {
 	struct grow_r502a_data *drv_data = dev->data;
+	int ret;
 
 	if (!drv_data->led_color) {
 		drv_data->led_color = R502A_LED_COLOR_BLUE;
@@ -1219,16 +1220,27 @@ static int grow_r502a_led_on(const struct device *dev, uint32_t led)
 		.color_idx = drv_data->led_color,
 	};
 
-	return fps_led_control(dev, &led_ctrl);
+	k_mutex_lock(&drv_data->lock, K_FOREVER);
+	ret = fps_led_control(dev, &led_ctrl);
+	k_mutex_unlock(&drv_data->lock);
+
+	return ret;
 }
 
 static int grow_r502a_led_off(const struct device *dev, uint32_t led)
 {
+	struct grow_r502a_data *drv_data = dev->data;
+	int ret;
+
 	struct r502a_led_params led_ctrl = {
 		.ctrl_code = R502A_LED_CTRL_OFF_ALWAYS,
 	};
 
-	return fps_led_control(dev, &led_ctrl);
+	k_mutex_lock(&drv_data->lock, K_FOREVER);
+	ret = fps_led_control(dev, &led_ctrl);
+	k_mutex_unlock(&drv_data->lock);
+
+	return ret;
 }
 
 static DEVICE_API(led, grow_r502a_leds_api) = {

--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -70,7 +70,7 @@ static int transceive_packet(const struct device *dev, union r502a_packet *tx_pa
 static int r502a_validate_rx_packet(union r502a_packet *rx_packet)
 {
 	uint16_t recv_cks = 0, calc_cks = 0;
-	uint8_t cks_start_idx;
+	uint16_t cks_start_idx;
 
 	if (sys_be16_to_cpu(rx_packet->start) == R502A_STARTCODE) {
 		LOG_DBG("startcode matched 0x%X", sys_be16_to_cpu(rx_packet->start));
@@ -103,7 +103,8 @@ static int r502a_validate_rx_packet(union r502a_packet *rx_packet)
 
 	const uint16_t packet_len = sys_be16_to_cpu(rx_packet->len);
 
-	if (packet_len < R502A_CHECKSUM_LEN || packet_len > CONFIG_R502A_DATA_PKT_SIZE) {
+	if (packet_len < R502A_CHECKSUM_LEN ||
+	    packet_len > (R502A_MAX_BUF_SIZE - R502A_HEADER_LEN)) {
 		LOG_ERR("Invalid packet length %d", packet_len);
 		return -EINVAL;
 	}


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the GROW_R502A fingerprint
sensor driver, one commit per issue:

- **Serialize LED API with the driver mutex**: the LED device exposed by this
  driver shares the sensor's data struct, UART transport buffers and
  semaphores, but `led_on()`/`led_off()` drove the transport without taking
  `drv_data->lock`. An LED call concurrent with a fingerprint operation
  therefore corrupted the in-flight transaction. Both entry points now take the
  same mutex as every other transport user.
- **Fix RX packet length bound**: the receive path bounded the incoming wire
  length by the payload-only data-packet size, which excludes the 2-byte
  checksum that is part of the same length field — so every full-size data
  packet was rejected as over-length. The bound is now the receive buffer's
  body capacity, and the checksum offset is widened so a 256-byte package
  length cannot truncate it.