### PR TITLE
drivers: sensor: icm42x70: fix mutex leaks, error handling and FIFO stride

### DIFF
--- a/drivers/sensor/tdk/icm42x70/icm42670.c
+++ b/drivers/sensor/tdk/icm42x70/icm42670.c
@@ -34,19 +34,28 @@ static uint32_t convert_gyr_fs_to_bitfield(uint32_t val, uint16_t *fs)
 
 static int icm42670_set_gyro_odr(struct icm42x70_data *drv_data, const struct sensor_value *val)
 {
+	uint16_t gyro_hz;
+	int err;
+
 	if (val->val1 <= 1600 && val->val1 >= 12) {
-		if (drv_data->gyro_hz == 0) {
-			inv_imu_set_gyro_frequency(
-				&drv_data->driver,
-				convert_freq_to_bitfield(val->val1, &drv_data->gyro_hz));
-			inv_imu_enable_gyro_low_noise_mode(&drv_data->driver);
-		} else {
-			inv_imu_set_gyro_frequency(
-				&drv_data->driver,
-				convert_freq_to_bitfield(val->val1, &drv_data->gyro_hz));
+		bool was_disabled = (drv_data->gyro_hz == 0);
+
+		err = inv_imu_set_gyro_frequency(&drv_data->driver,
+						 convert_freq_to_bitfield(val->val1, &gyro_hz));
+		if (err != 0) {
+			return -EIO;
+		}
+		drv_data->gyro_hz = gyro_hz;
+		if (was_disabled) {
+			if (inv_imu_enable_gyro_low_noise_mode(&drv_data->driver) != 0) {
+				return -EIO;
+			}
 		}
 	} else if (val->val1 == 0) {
-		inv_imu_disable_gyro(&drv_data->driver);
+		err = inv_imu_disable_gyro(&drv_data->driver);
+		if (err != 0) {
+			return -EIO;
+		}
 		drv_data->gyro_hz = val->val1;
 	} else {
 		LOG_ERR("Incorrect sampling value");
@@ -58,13 +67,19 @@ static int icm42670_set_gyro_odr(struct icm42x70_data *drv_data, const struct se
 static int icm42670_set_gyro_fs(struct icm42x70_data *drv_data, const struct sensor_value *val)
 {
 	int32_t val_dps = sensor_rad_to_degrees(val);
+	uint16_t gyro_fs;
+	int err;
 
 	if (val_dps > 2000 || val_dps < 250) {
 		LOG_ERR("Incorrect fullscale value");
 		return -EINVAL;
 	}
-	inv_imu_set_gyro_fsr(&drv_data->driver,
-			     convert_gyr_fs_to_bitfield(val_dps, &drv_data->gyro_fs));
+	err = inv_imu_set_gyro_fsr(&drv_data->driver,
+				   convert_gyr_fs_to_bitfield(val_dps, &gyro_fs));
+	if (err != 0) {
+		return -EIO;
+	}
+	drv_data->gyro_fs = gyro_fs;
 	LOG_DBG("Set gyro fullscale to: %d dps", drv_data->gyro_fs);
 	return 0;
 }
@@ -73,17 +88,20 @@ int icm42670_gyro_config(struct icm42x70_data *drv_data, enum sensor_attribute a
 			 const struct sensor_value *val)
 {
 	if (attr == SENSOR_ATTR_SAMPLING_FREQUENCY) {
-		icm42670_set_gyro_odr(drv_data, val);
+		return icm42670_set_gyro_odr(drv_data, val);
 
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
-		icm42670_set_gyro_fs(drv_data, val);
+		return icm42670_set_gyro_fs(drv_data, val);
 
 	} else if ((enum sensor_attribute_icm42x70)attr == SENSOR_ATTR_BW_FILTER_LPF) {
 		if (val->val1 > 180) {
 			LOG_ERR("Incorrect low pass filter bandwidth value");
 			return -EINVAL;
 		}
-		inv_imu_set_gyro_ln_bw(&drv_data->driver, convert_ln_bw_to_bitfield(val->val1));
+		if (inv_imu_set_gyro_ln_bw(&drv_data->driver,
+					   convert_ln_bw_to_bitfield(val->val1)) != 0) {
+			return -EIO;
+		}
 
 	} else {
 		LOG_ERR("Unsupported attribute");

--- a/drivers/sensor/tdk/icm42x70/icm42x70.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70.c
@@ -603,8 +603,12 @@ static int icm42x70_fetch_from_fifo(const struct device *dev)
 	struct icm42x70_data *data = dev->data;
 	int status = 0;
 	uint8_t int_status;
-	uint16_t packet_size = FIFO_HEADER_SIZE + FIFO_ACCEL_DATA_SIZE + FIFO_GYRO_DATA_SIZE +
-			       FIFO_TEMP_DATA_SIZE + FIFO_TS_FSYNC_SIZE;
+	uint16_t packet_size =
+		data->driver.fifo_highres_enabled
+			? FIFO_20BYTES_PACKET_SIZE
+			: (FIFO_HEADER_SIZE + FIFO_ACCEL_DATA_SIZE +
+			   (IS_ENABLED(CONFIG_USE_EMD_ICM42670) ? FIFO_GYRO_DATA_SIZE : 0) +
+			   FIFO_TEMP_DATA_SIZE + FIFO_TS_FSYNC_SIZE);
 	uint16_t fifo_idx = 0;
 
 	/* Ensure data ready status bit is set */
@@ -648,10 +652,28 @@ static int icm42x70_fetch_from_fifo(const struct device *dev)
 
 		for (uint16_t i = 0; i < packet_count; i++) {
 			inv_imu_sensor_event_t event;
+			uint8_t header = data->driver.fifo_data[fifo_idx];
+			uint16_t frame_size = packet_size;
+
+			if (!(header & (FIFO_HEADER_MSG | FIFO_HEADER_HEADER_20))) {
+				frame_size = FIFO_HEADER_SIZE + FIFO_TEMP_DATA_SIZE;
+				if (header & FIFO_HEADER_ACC) {
+					frame_size += FIFO_ACCEL_DATA_SIZE;
+				}
+				if (IS_ENABLED(CONFIG_USE_EMD_ICM42670) &&
+				    (header & FIFO_HEADER_GYRO)) {
+					frame_size += FIFO_GYRO_DATA_SIZE;
+				}
+				if ((header & FIFO_HEADER_TMST) ||
+				    (IS_ENABLED(CONFIG_USE_EMD_ICM42670) &&
+				     (header & FIFO_HEADER_FSYNC))) {
+					frame_size += FIFO_TS_FSYNC_SIZE;
+				}
+			}
 
 			status |= inv_imu_decode_fifo_frame(
 				&data->driver, &data->driver.fifo_data[fifo_idx], &event);
-			fifo_idx += packet_size;
+			fifo_idx += frame_size;
 
 			/* Check for error */
 			if (status != 0) {

--- a/drivers/sensor/tdk/icm42x70/icm42x70.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70.c
@@ -242,54 +242,70 @@ static uint8_t convert_bitfield_to_acc_fs(uint8_t bitfield)
 static int icm42x70_set_accel_power_mode(struct icm42x70_data *drv_data,
 					 const struct sensor_value *val)
 {
-	if ((val->val1 == ICM42X70_LOW_POWER_MODE) &&
-	    (drv_data->accel_pwr_mode != ICM42X70_LOW_POWER_MODE)) {
+	int err = 0;
+
+	if (val->val1 == drv_data->accel_pwr_mode) {
+		return 0;
+	}
+
+	if (val->val1 == ICM42X70_LOW_POWER_MODE) {
 		if (drv_data->accel_hz != 0) {
 			if (drv_data->accel_hz <= 400) {
-				inv_imu_enable_accel_low_power_mode(&drv_data->driver);
+				err = inv_imu_enable_accel_low_power_mode(&drv_data->driver);
 			} else {
 				LOG_ERR("Not supported ATTR value");
 				return -EINVAL;
 			}
 		}
-		drv_data->accel_pwr_mode = val->val1;
-	} else if ((val->val1 == ICM42X70_LOW_NOISE_MODE) &&
-		   (drv_data->accel_pwr_mode != ICM42X70_LOW_NOISE_MODE)) {
+	} else if (val->val1 == ICM42X70_LOW_NOISE_MODE) {
 		if (drv_data->accel_hz != 0) {
 			if (drv_data->accel_hz >= 12) {
-				inv_imu_enable_accel_low_noise_mode(&drv_data->driver);
+				err = inv_imu_enable_accel_low_noise_mode(&drv_data->driver);
 			} else {
 				LOG_ERR("Not supported ATTR value");
 				return -EINVAL;
 			}
 		}
-		drv_data->accel_pwr_mode = val->val1;
 	} else {
 		LOG_ERR("Not supported ATTR value");
 		return -EINVAL;
 	}
+	if (err != 0) {
+		return -EIO;
+	}
+	drv_data->accel_pwr_mode = val->val1;
 	return 0;
 }
 
 static int icm42x70_set_accel_odr(struct icm42x70_data *drv_data, const struct sensor_value *val)
 {
+	uint16_t accel_hz;
+	int err;
+
 	if (val->val1 <= 1600 && val->val1 >= 1) {
-		if (drv_data->accel_hz == 0) {
-			inv_imu_set_accel_frequency(
-				&drv_data->driver,
-				convert_freq_to_bitfield(val->val1, &drv_data->accel_hz));
+		bool was_disabled = (drv_data->accel_hz == 0);
+
+		err = inv_imu_set_accel_frequency(&drv_data->driver,
+						  convert_freq_to_bitfield(val->val1, &accel_hz));
+		if (err != 0) {
+			return -EIO;
+		}
+		drv_data->accel_hz = accel_hz;
+		if (was_disabled) {
 			if (drv_data->accel_pwr_mode == ICM42X70_LOW_POWER_MODE) {
-				inv_imu_enable_accel_low_power_mode(&drv_data->driver);
+				err = inv_imu_enable_accel_low_power_mode(&drv_data->driver);
 			} else if (drv_data->accel_pwr_mode == ICM42X70_LOW_NOISE_MODE) {
-				inv_imu_enable_accel_low_noise_mode(&drv_data->driver);
+				err = inv_imu_enable_accel_low_noise_mode(&drv_data->driver);
 			}
-		} else {
-			inv_imu_set_accel_frequency(
-				&drv_data->driver,
-				convert_freq_to_bitfield(val->val1, &drv_data->accel_hz));
+			if (err != 0) {
+				return -EIO;
+			}
 		}
 	} else if (val->val1 == 0) {
-		inv_imu_disable_accel(&drv_data->driver);
+		err = inv_imu_disable_accel(&drv_data->driver);
+		if (err != 0) {
+			return -EIO;
+		}
 		drv_data->accel_hz = val->val1;
 	} else {
 		LOG_ERR("Incorrect sampling value");
@@ -300,12 +316,19 @@ static int icm42x70_set_accel_odr(struct icm42x70_data *drv_data, const struct s
 
 static int icm42x70_set_accel_fs(struct icm42x70_data *drv_data, const struct sensor_value *val)
 {
+	uint8_t accel_fs;
+	int err;
+
 	if (val->val1 > 16 || val->val1 < 2) {
 		LOG_ERR("Incorrect fullscale value");
 		return -EINVAL;
 	}
-	inv_imu_set_accel_fsr(&drv_data->driver,
-			      convert_acc_fs_to_bitfield(val->val1, &drv_data->accel_fs));
+	err = inv_imu_set_accel_fsr(&drv_data->driver,
+				    convert_acc_fs_to_bitfield(val->val1, &accel_fs));
+	if (err != 0) {
+		return -EIO;
+	}
+	drv_data->accel_fs = accel_fs;
 	LOG_DBG("Set accel full scale to: %d G", drv_data->accel_fs);
 	return 0;
 }
@@ -314,27 +337,33 @@ static int icm42x70_accel_config(struct icm42x70_data *drv_data, enum sensor_att
 				 const struct sensor_value *val)
 {
 	if (attr == SENSOR_ATTR_CONFIGURATION) {
-		icm42x70_set_accel_power_mode(drv_data, val);
+		return icm42x70_set_accel_power_mode(drv_data, val);
 
 	} else if (attr == SENSOR_ATTR_SAMPLING_FREQUENCY) {
-		icm42x70_set_accel_odr(drv_data, val);
+		return icm42x70_set_accel_odr(drv_data, val);
 
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
-		icm42x70_set_accel_fs(drv_data, val);
+		return icm42x70_set_accel_fs(drv_data, val);
 
 	} else if ((enum sensor_attribute_icm42x70)attr == SENSOR_ATTR_BW_FILTER_LPF) {
 		if (val->val1 > 180) {
 			LOG_ERR("Incorrect low pass filter bandwidth value");
 			return -EINVAL;
 		}
-		inv_imu_set_accel_ln_bw(&drv_data->driver, convert_ln_bw_to_bitfield(val->val1));
+		if (inv_imu_set_accel_ln_bw(&drv_data->driver,
+					    convert_ln_bw_to_bitfield(val->val1)) != 0) {
+			return -EIO;
+		}
 
 	} else if ((enum sensor_attribute_icm42x70)attr == SENSOR_ATTR_AVERAGING) {
 		if (val->val1 > 64 || val->val1 < 2) {
 			LOG_ERR("Incorrect averaging filter value");
 			return -EINVAL;
 		}
-		inv_imu_set_accel_lp_avg(&drv_data->driver, convert_lp_avg_to_bitfield(val->val1));
+		if (inv_imu_set_accel_lp_avg(&drv_data->driver,
+					     convert_lp_avg_to_bitfield(val->val1)) != 0) {
+			return -EIO;
+		}
 	} else {
 		LOG_ERR("Unsupported attribute");
 		return -EINVAL;
@@ -799,6 +828,7 @@ static int icm42x70_attr_set(const struct device *dev, enum sensor_channel chan,
 			     enum sensor_attribute attr, const struct sensor_value *val)
 {
 	struct icm42x70_data *drv_data = dev->data;
+	int res = 0;
 
 	__ASSERT_NO_MSG(val != NULL);
 
@@ -808,41 +838,51 @@ static int icm42x70_attr_set(const struct device *dev, enum sensor_channel chan,
 		if (attr == SENSOR_ATTR_CONFIGURATION) {
 #ifdef CONFIG_TDK_APEX
 			if (val->val1 == TDK_APEX_PEDOMETER) {
-				icm42x70_apex_enable(&drv_data->driver);
-				icm42x70_apex_enable_pedometer(dev, &drv_data->driver);
+				res = icm42x70_apex_enable(&drv_data->driver);
+				if (res == 0) {
+					res = icm42x70_apex_enable_pedometer(dev,
+									     &drv_data->driver);
+				}
 			} else if (val->val1 == TDK_APEX_TILT) {
-				icm42x70_apex_enable(&drv_data->driver);
-				icm42x70_apex_enable_tilt(&drv_data->driver);
+				res = icm42x70_apex_enable(&drv_data->driver);
+				if (res == 0) {
+					res = icm42x70_apex_enable_tilt(&drv_data->driver);
+				}
 			} else if (val->val1 == TDK_APEX_SMD) {
-				icm42x70_apex_enable(&drv_data->driver);
-				icm42x70_apex_enable_smd(&drv_data->driver);
+				res = icm42x70_apex_enable(&drv_data->driver);
+				if (res == 0) {
+					res = icm42x70_apex_enable_smd(&drv_data->driver);
+				}
 			} else if (val->val1 == TDK_APEX_WOM) {
-				icm42x70_apex_enable_wom(&drv_data->driver);
+				res = icm42x70_apex_enable_wom(&drv_data->driver);
 			} else {
 				LOG_ERR("Not supported ATTR value");
+				res = -EINVAL;
 			}
+#else
+			res = -ENOTSUP;
 #endif
 		} else {
 			LOG_ERR("Not supported ATTR");
-			return -EINVAL;
+			res = -EINVAL;
 		}
 	} else if (SENSOR_CHANNEL_IS_ACCEL(chan)) {
-		icm42x70_accel_config(drv_data, attr, val);
+		res = icm42x70_accel_config(drv_data, attr, val);
 #if CONFIG_USE_EMD_ICM42670
 	} else if ((SENSOR_CHANNEL_IS_GYRO(chan)) &&
 		   ((drv_data->imu_whoami == INV_ICM42670P_WHOAMI) ||
 		    (drv_data->imu_whoami == INV_ICM42670S_WHOAMI))) {
-		icm42670_gyro_config(drv_data, attr, val);
+		res = icm42670_gyro_config(drv_data, attr, val);
 #endif
 	} else {
 		LOG_ERR("Unsupported channel");
 		(void)drv_data;
-		return -EINVAL;
+		res = -EINVAL;
 	}
 
 	icm42x70_unlock(dev);
 
-	return 0;
+	return res;
 }
 
 static int icm42x70_attr_get(const struct device *dev, enum sensor_channel chan,

--- a/drivers/sensor/tdk/icm42x70/icm42x70_apex.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70_apex.c
@@ -109,8 +109,17 @@ void icm42x70_apex_pedometer_cadence_convert(struct sensor_value *val, uint8_t r
 {
 	int64_t conv_val;
 
-	/* Converting u6.2 */
-	conv_val = (int64_t)(dmp_odr_hz << 2) * 1000000 / (raw_val + (raw_val & 0x03));
+	/*
+	 * raw_val is the number of samples between two steps, in u6.2 format:
+	 * cadence (steps/s) = dmp_odr_hz / (raw_val / 4)
+	 */
+	if (raw_val == 0) {
+		val->val1 = 0;
+		val->val2 = 0;
+		return;
+	}
+
+	conv_val = (int64_t)dmp_odr_hz * 4 * 1000000 / raw_val;
 	val->val1 = conv_val / 1000000;
 	val->val2 = conv_val % 1000000;
 }

--- a/drivers/sensor/tdk/icm42x70/icm42x70_trigger.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70_trigger.c
@@ -81,20 +81,16 @@ int icm42x70_trigger_set(const struct device *dev, const struct sensor_trigger *
 		return -EINVAL;
 	}
 
+	if (trig->type != SENSOR_TRIG_DATA_READY &&
+	    !(IS_ENABLED(CONFIG_TDK_APEX) && trig->type == SENSOR_TRIG_MOTION)) {
+		return -ENOTSUP;
+	}
+
 	icm42x70_lock(dev);
 	gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_DISABLE);
 
-	if (trig->type == SENSOR_TRIG_DATA_READY) {
-		data->data_ready_handler = handler;
-		data->data_ready_trigger = trig;
-#ifdef CONFIG_TDK_APEX
-	} else if (trig->type == SENSOR_TRIG_MOTION) {
-		data->data_ready_handler = handler;
-		data->data_ready_trigger = trig;
-#endif
-	} else {
-		return -ENOTSUP;
-	}
+	data->data_ready_handler = handler;
+	data->data_ready_trigger = trig;
 
 	icm42x70_unlock(dev);
 	gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);

--- a/drivers/sensor/tdk/icm45686/icm45686_apex.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_apex.c
@@ -131,8 +131,17 @@ void icm45686_apex_pedometer_cadence_convert(struct sensor_value *val, uint8_t r
 {
 	int64_t conv_val;
 
-	/* Converting u6.2 */
-	conv_val = (int64_t)(dmp_odr_hz << 2) * 1000000 / (raw_val + (raw_val & 0x03));
+	/*
+	 * raw_val is the number of samples between two steps, in u6.2 format:
+	 * cadence (steps/s) = dmp_odr_hz / (raw_val / 4)
+	 */
+	if (raw_val == 0) {
+		val->val1 = 0;
+		val->val2 = 0;
+		return;
+	}
+
+	conv_val = (int64_t)dmp_odr_hz * 4 * 1000000 / raw_val;
 	val->val1 = conv_val / 1000000;
 	val->val2 = conv_val % 1000000;
 }


### PR DESCRIPTION
This PR fixes five independent correctness bugs in the ICM42X70 driver, one
commit per issue:

- **Propagate attr_set configuration errors**: `attr_set()` discarded the
  return value of every accel/gyro/APEX configuration helper and always
  reported success, and the helpers themselves dropped their HAL status codes.
  Two of its early-return paths also left the driver mutex held, deadlocking
  every subsequent driver call. Errors are now propagated, cached settings are
  only committed after the corresponding bus write succeeds, and all paths
  reach the unlock.
- **Fix mutex leak on unsupported trigger**: `trigger_set()` took the driver
  mutex and disabled the GPIO interrupt before validating the trigger type, so
  an unsupported type returned -ENOTSUP with the mutex still held and the
  interrupt left masked. The type is now validated before either.
- **Fix FIFO frame stride on gyro-less parts**: the FIFO packet size
  hard-coded 6 gyroscope bytes, which do not exist in the ICM42370P frame
  format (the HAL never enables gyro data in the FIFO for that part), so every
  frame after the first was decoded from a misaligned offset. The stride is now
  derived from the configured device and the per-frame FIFO header.
- **Fix APEX pedometer cadence conversion**: the cadence conversion divided by
  `raw_val + (raw_val & 0x03)`, double-counting the u6.2 fractional bits, and
  divided by zero when no steps had been recorded. It now divides by the sample
  count alone and returns 0 steps/s for a zero count. The same copy/pasted
  conversion in the ICM45686 APEX support is fixed here too.