### PR TITLE
twister: script harness: Also find scripts in subdirectories

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -645,6 +645,7 @@ Bluetooth Audio:
   tests:
     - bluetooth.audio
     - sample.bluetooth.audio
+    - tests.bsim.bluetooth.audio
 
 Bluetooth Classic:
   status: maintained

--- a/doc/develop/twister/harness/script.rst
+++ b/doc/develop/twister/harness/script.rst
@@ -15,7 +15,7 @@ providing shared subprocess execution, output streaming, and log handling.
 tests_scripts: <list of script paths> (default tests_scripts)
     Specify a list of shell script paths, relative to the test source
     directory, that need to be executed when a test scenario runs.
-    Each entry can be a path to a single file or a directory.
+    Each entry can be a path to a single file, a directory, or a glob pattern.
     When a directory is specified, all ``.sh`` files in that directory,
     including its sub-directories, are collected (excluding files starting with ``_``).
     The default is the ``tests_scripts`` directory.

--- a/doc/develop/twister/harness/script.rst
+++ b/doc/develop/twister/harness/script.rst
@@ -16,9 +16,9 @@ tests_scripts: <list of script paths> (default tests_scripts)
     Specify a list of shell script paths, relative to the test source
     directory, that need to be executed when a test scenario runs.
     Each entry can be a path to a single file or a directory.
-    When a directory is specified, all ``.sh`` files in that directory
-    are collected (excluding files starting with ``_``). The default
-    is the ``tests_scripts`` directory.
+    When a directory is specified, all ``.sh`` files in that directory,
+    including its sub-directories, are collected (excluding files starting with ``_``).
+    The default is the ``tests_scripts`` directory.
 
     .. code-block:: yaml
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -430,7 +430,12 @@ class Script(Harness):
 
     def run(self, timeout: float) -> bool:
         self.instance.testcases = []
-        for script in self._get_test_scripts():
+
+        all_scripts = self._get_test_scripts()
+        if not all_scripts:
+            self._log_error("No scripts found!")
+
+        for script in all_scripts:
             if not os.path.exists(script):
                 self._handle_missing_script(script)
                 continue
@@ -449,12 +454,15 @@ class Script(Harness):
         self._update_test_status()
         return True
 
-    def _handle_missing_script(self, script: str) -> None:
-        reason = f"{script} not found!"
+    def _log_error(self, reason: str) -> None:
         logger.error(reason)
-        self._add_testcase_from_script(script, rc=-1, reason=reason)
         with open(self.log_file_path, 'a') as log_file:
             log_file.write(reason + '\n\n')
+
+    def _handle_missing_script(self, script: str) -> None:
+        reason = f"{script} not found!"
+        self._add_testcase_from_script(script, rc=-1, reason=reason)
+        self._log_error(reason)
 
     def _get_env(self) -> dict[str, str]:
         """Return environment variables with BOARD set to the platform name."""

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -471,10 +471,18 @@ class Script(Harness):
         env['BOARD'] = self.instance.platform.name
         return env
 
+    @staticmethod
+    def _path_is_glob(path: str) -> bool:
+        """Return True if there are glob wildcard characters."""
+        return bool(re.search(r'[*?\[]', path))
+
     def _get_test_scripts(self) -> list[str]:
         """Return list of test scripts resolved from harness config."""
         input_sources = self.instance.testsuite.harness_config.tests_scripts or ['tests_scripts']
         tests_scripts = []
+        # In _script_names we save the relative path of the script inside the directory, in cases
+        # where we may have scripts with the same names in different sub-directories, so they don't
+        # end with the same testname.
         self._script_names = {}
         for src in input_sources:
             source = os.path.normpath(
@@ -488,9 +496,22 @@ class Script(Harness):
                     if os.path.basename(s).startswith('_'):
                         continue
                     tests_scripts.append(s)
-                    # Save the relative path of the script inside the directory, so scripts with
-                    # the same names in different sub-directories don't end with the same testname
                     self._script_names[s] = os.path.relpath(s, source).replace(os.sep, '.')
+            elif self._path_is_glob(source):
+                # When the user provides a glob pattern, we use it as is
+                scripts = sorted(glob(source, recursive=True))
+                # Drop plain directories (which the glob may have matched)
+                scripts = [s for s in scripts if os.path.isfile(s)]
+                if not scripts:
+                    logger.warning(f"No scripts found matching pattern: {src}")
+                for s in scripts:
+                    tests_scripts.append(s)
+                    rel = os.path.relpath(s, self.source_dir)
+                    if rel.startswith('..'):
+                        # For relative paths above source_dir, let's just take the basename
+                        self._script_names[s] = os.path.basename(s)
+                    else:
+                        self._script_names[s] = rel.replace(os.sep, '.')
             else:
                 # A directly specified file or non-existent path are included as-is
                 tests_scripts.append(source)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -419,6 +419,7 @@ class Script(Harness):
         self.running_dir = None
         self.log_prefix = None
         self._output = []
+        self._script_names = {}
 
     def configure(self, instance: TestInstance):
         super().configure(instance)
@@ -474,16 +475,22 @@ class Script(Harness):
         """Return list of test scripts resolved from harness config."""
         input_sources = self.instance.testsuite.harness_config.tests_scripts or ['tests_scripts']
         tests_scripts = []
+        self._script_names = {}
         for src in input_sources:
             source = os.path.normpath(
                 os.path.join(self.source_dir, os.path.expanduser(os.path.expandvars(src)))
             )
             if os.path.isdir(source):
-                # Get all .sh files in the directory, excluding those starting with '_'
-                scripts = glob(os.path.join(source, "*.sh"))
-                tests_scripts.extend(
-                    s for s in scripts if not os.path.basename(s).startswith('_')
-                )
+                # Get all .sh files in the directory and sub-directories,
+                # excluding those starting with '_'
+                scripts = sorted(glob(os.path.join(source, "**", "*.sh"), recursive=True))
+                for s in scripts:
+                    if os.path.basename(s).startswith('_'):
+                        continue
+                    tests_scripts.append(s)
+                    # Save the relative path of the script inside the directory, so scripts with
+                    # the same names in different sub-directories don't end with the same testname
+                    self._script_names[s] = os.path.relpath(s, source).replace(os.sep, '.')
             else:
                 # A directly specified file or non-existent path are included as-is
                 tests_scripts.append(source)
@@ -545,7 +552,7 @@ class Script(Harness):
     def _add_testcase_from_script(
         self, script: str, rc: int, duration: float = 0.0, reason: str = ''
     ) -> None:
-        script_name = os.path.basename(script)
+        script_name = self._script_names.get(script, os.path.basename(script))
         tc_name = f"{self.id}.{script_name}"
         tc = self.instance.add_testcase(tc_name)
         tc.duration = duration

--- a/tests/bsim/bluetooth/audio/tests.yaml
+++ b/tests/bsim/bluetooth/audio/tests.yaml
@@ -1,17 +1,22 @@
 common:
-  timeout: 3600
+  timeout: 1500
   tags:
     - bluetooth
   depends_on: bsim
   sysbuild: true
   harness: bsim
+  platform_allow:
+    - nrf52_bsim
+    - nrf54l15bsim/nrf54l15/cpuapp
+    - nrf5340bsim/nrf5340/cpuapp
 
 tests:
+  # Note: By now twister's bsim(script) harness does not parallelize tests scripts
+  # that are part of the same test. As we have lots of test scripts for this, we split it in several
+  # chunks so they are at least parallelized at that level.
+  # See #116077
+
   bluetooth.audio:
-    platform_allow:
-      - nrf52_bsim
-      - nrf54l15bsim/nrf54l15/cpuapp
-      - nrf5340bsim/nrf5340/cpuapp
     extra_args:
       - EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
       - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE=""
@@ -20,4 +25,22 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_audio_prj_conf
       tests_scripts:
-        - test_scripts/
+        - test_scripts/[!_]*.sh
+
+  bluetooth.audio.audio_config.cap:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts/audio_config_tests/cap*
+    required_applications:
+      - application: bluetooth.audio
+
+  bluetooth.audio.audio_config.gmap:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts/audio_config_tests/gmap*
+    required_applications:
+      - application: bluetooth.audio

--- a/tests/bsim/bluetooth/audio/tests.yaml
+++ b/tests/bsim/bluetooth/audio/tests.yaml
@@ -16,7 +16,7 @@ tests:
   # chunks so they are at least parallelized at that level.
   # See #116077
 
-  bluetooth.audio:
+  tests.bsim.bluetooth.audio:
     extra_args:
       - EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
       - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE=""
@@ -27,20 +27,20 @@ tests:
       tests_scripts:
         - test_scripts/[!_]*.sh
 
-  bluetooth.audio.audio_config.cap:
+  tests.bsim.bluetooth.audio.audio_config.cap:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - test_scripts/audio_config_tests/cap*
     required_applications:
-      - application: bluetooth.audio
+      - application: tests.bsim.bluetooth.audio
 
-  bluetooth.audio.audio_config.gmap:
+  tests.bsim.bluetooth.audio.audio_config.gmap:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - test_scripts/audio_config_tests/gmap*
     required_applications:
-      - application: bluetooth.audio
+      - application: tests.bsim.bluetooth.audio

--- a/tests/bsim/bluetooth/audio/tests.yaml
+++ b/tests/bsim/bluetooth/audio/tests.yaml
@@ -1,23 +1,23 @@
 common:
-  timeout: 1500
+  timeout: 3600
   tags:
     - bluetooth
   depends_on: bsim
   sysbuild: true
   harness: bsim
-  harness_config:
-    fixture: bsim_multi_test
-    bsim_exe_name: tests_bsim_bluetooth_audio_prj_conf
-    tests_scripts:
-      - test_scripts
 
 tests:
   bluetooth.audio:
     platform_allow:
       - nrf52_bsim
       - nrf54l15bsim/nrf54l15/cpuapp
-    extra_args:
-      EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
-  bluetooth.audio.nrf5340cpuapp:
-    platform_allow:
       - nrf5340bsim/nrf5340/cpuapp
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE=""
+      # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_audio_prj_conf
+      tests_scripts:
+        - test_scripts/


### PR DESCRIPTION
3 related changes to twister's script harness and 2 changes to a test definition which exercise them.
(The PR can be split if desired, though the audio test definition change serves as a test of the twister functionality)

1. twister: script harness: Handle gracefully not finding any script
    
    We may also not find any script at all (say the folder is empty,
    or there is no tests_scripts folder).
    Let's handle it gracefully too, by printing an appropriate
    message instead of pointing at the build log.
    
    This fixes more cases than what was covered by
    60643b7b05d939816994ab197681407e64bf4f78

2. twister: script harness: Also find scripts in subdirectories
    
    When a directory is provided, find scripts in directories and sub-directories.
    This is what users expect (what run_parallel.sh does)
    
    Note that now we also name the tests not just based on the "basename" of the file, but on the relative path to the test scripts folder, so we ensure we have unique tests names.
    
    We also sort the globing output to be nicer to users and independent of the underlying glob order.

3. twister: script harness: Allow providing globs in tests_scripts
    
    Let users provide their own globs. When they do, let's just use the provided glob as is.
    run_parallel.sh also supports this, and it is a quite useful feature.

------

4. tests/bsim/bluetooth/audio: Merge both tests and increase timeout
    
    This test covers **many** subtests, let's increase the timeout to 1h so it does not timeout in slower machines.
    
    Let's also join both test definitions, we do not need to have a separate one just before of the extra config file.

5. tests/bsim/bluetooth/audio: Split audio config tests
    
    Unlike run_parallel.sh, twister's script harness does not parallelize
    individual scripts inside a test. As this "test" has **lots** of
    individual scripts, running them in serial take a lot of time.
    Let's parallelize them a bit by splitting the test in 3 parts.
    



