### PR TITLE
drivers: ieee802154: mcxw: restore channel after CSL RX

### DIFF
--- a/drivers/ieee802154/ieee802154_mcxw.c
+++ b/drivers/ieee802154/ieee802154_mcxw.c
@@ -1407,6 +1407,12 @@ phyStatus_t pd_mac_sap_handler(void *msg, instanceId_t instance)
 		k_free(msg);
 	}
 
+	/* Restore main channel after a CSL RX slot on a temporary channel.
+	 * Channel restore is needed for both successful (gPdDataInd_c) and
+	 * failed (gPlmeTimeoutInd_c) CSL receptions.
+	 */
+	rf_restore_main_channel();
+
 	/* Always stop, the CSL restarts as needed */
 	stop_csl_receiver();
 


### PR DESCRIPTION
`rf_restore_main_channel()` was missing in `pd_mac_sap_handler()` (successful CSL RX path), leaving the PHY on the temporary CSL channel after a successful reception. It was already present in `plme_mac_sap_handler()` for the timeout path.

Add the missing call before `stop_csl_receiver()` so the main network channel is always restored after any CSL RX slot.
