### PR TITLE
net: Fixes for code-scanning alerts in subsys/net/ip

### DIFF
--- a/subsys/net/ip/ipv4_acd.c
+++ b/subsys/net/ip/ipv4_acd.c
@@ -271,6 +271,7 @@ enum net_verdict net_ipv4_acd_input(struct net_if *iface, struct net_pkt *pkt)
 	struct net_arp_hdr *arp_hdr;
 	struct net_if_ipv4 *ipv4;
 	struct net_linkaddr *dst_lladdr;
+	struct net_linkaddr *ll_addr;
 
 	if (net_pkt_get_len(pkt) < sizeof(struct net_arp_hdr)) {
 		NET_DBG("Invalid ARP header (len %zu, min %zu bytes)",
@@ -285,6 +286,10 @@ enum net_verdict net_ipv4_acd_input(struct net_if *iface, struct net_pkt *pkt)
 		return NET_DROP;
 	}
 
+	ll_addr = net_if_get_link_addr(iface);
+
+	NET_ASSERT(ll_addr != NULL);
+
 	arp_hdr = NET_ARP_HDR(pkt);
 
 	k_mutex_lock(&lock, K_FOREVER);
@@ -293,7 +298,6 @@ enum net_verdict net_ipv4_acd_input(struct net_if *iface, struct net_pkt *pkt)
 		struct net_if_addr *ifaddr =
 			CONTAINER_OF(current, struct net_if_addr, acd_node);
 		struct net_if *addr_iface = net_if_get_by_index(ifaddr->ifindex);
-		struct net_linkaddr *ll_addr;
 
 		if (iface != addr_iface) {
 			continue;
@@ -302,8 +306,6 @@ enum net_verdict net_ipv4_acd_input(struct net_if *iface, struct net_pkt *pkt)
 		if (ifaddr->acd_state != IPV4_ACD_PROBE) {
 			continue;
 		}
-
-		ll_addr = net_if_get_link_addr(addr_iface);
 
 		/* RFC 5227, ch. 2.1.1 Probe Details:
 		 * - ARP Request/Reply with Sender IP address match OR,
@@ -346,7 +348,6 @@ enum net_verdict net_ipv4_acd_input(struct net_if *iface, struct net_pkt *pkt)
 	 */
 	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		struct net_if_addr *ifaddr = &ipv4->unicast[i].ipv4;
-		struct net_linkaddr *ll_addr = net_if_get_link_addr(iface);
 
 		if (!ifaddr->is_used) {
 			continue;

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1144,8 +1144,12 @@ struct net_nbr *net_ipv6_get_nbr(struct net_if *iface, uint8_t idx)
 
 static inline uint8_t get_llao_len(struct net_if *iface)
 {
-	uint8_t total_len = net_if_get_link_addr(iface)->len +
-			 sizeof(struct net_icmpv6_nd_opt_hdr);
+	struct net_linkaddr *lladdr = net_if_get_link_addr(iface);
+	uint8_t total_len;
+
+	NET_ASSERT(lladdr != NULL);
+
+	total_len = lladdr->len + sizeof(struct net_icmpv6_nd_opt_hdr);
 
 	return ROUND_UP(total_len, 8U);
 }
@@ -1158,6 +1162,8 @@ static inline bool set_llao(struct net_pkt *pkt,
 		.type = type,
 		.len  = llao_len >> 3,
 	};
+
+	NET_ASSERT(lladdr != NULL);
 
 	if (net_pkt_write(pkt, &opt_hdr,
 			  sizeof(struct net_icmpv6_nd_opt_hdr)) ||

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -794,7 +794,7 @@ static int bind_default(struct net_context *context)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
-		struct net_sockaddr_in6 addr6;
+		struct net_sockaddr_in6 addr6 = { 0 };
 
 		addr6.sin6_family = NET_AF_INET6;
 		memcpy(&addr6.sin6_addr, net_ipv6_unspecified_address(),
@@ -808,7 +808,7 @@ static int bind_default(struct net_context *context)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
-		struct net_sockaddr_in addr4;
+		struct net_sockaddr_in addr4 = { 0 };
 
 		addr4.sin_family = NET_AF_INET;
 		addr4.sin_addr.s_addr = NET_INADDR_ANY;
@@ -821,7 +821,7 @@ static int bind_default(struct net_context *context)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) && family == NET_AF_PACKET) {
-		struct net_sockaddr_ll ll_addr;
+		struct net_sockaddr_ll ll_addr = { 0 };
 		struct net_if *iface = net_context_get_iface(context);
 
 		ll_addr.sll_family = NET_AF_PACKET;

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -175,10 +175,12 @@ static void net_post_init(void)
 
 static inline void copy_ll_addr(struct net_pkt *pkt)
 {
-	memcpy(net_pkt_lladdr_src(pkt), net_pkt_lladdr_if(pkt),
-	       sizeof(struct net_linkaddr));
-	memcpy(net_pkt_lladdr_dst(pkt), net_pkt_lladdr_if(pkt),
-	       sizeof(struct net_linkaddr));
+	struct net_linkaddr *lladdr_if = net_pkt_lladdr_if(pkt);
+
+	NET_ASSERT(lladdr_if != NULL);
+
+	memcpy(net_pkt_lladdr_src(pkt), lladdr_if, sizeof(struct net_linkaddr));
+	memcpy(net_pkt_lladdr_dst(pkt), lladdr_if, sizeof(struct net_linkaddr));
 }
 
 /* Check if the IPv{4|6} addresses are proper. As this can be expensive,

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -449,6 +449,8 @@ static inline void init_iface(struct net_if *iface)
 	const struct device *dev = net_if_get_device(iface);
 	const struct net_if_api *api;
 
+	NET_ASSERT(dev != NULL);
+
 	if (!device_is_ready(dev)) {
 		NET_ERR("Iface %p device not ready", iface);
 		return;
@@ -715,10 +717,11 @@ struct net_if *net_if_get_first_up(void)
 
 static enum net_l2_flags l2_flags_get(struct net_if *iface)
 {
+	const struct net_l2 *l2 = net_if_l2(iface);
 	enum net_l2_flags flags = 0;
 
-	if (net_if_l2(iface) && net_if_l2(iface)->get_flags) {
-		flags = net_if_l2(iface)->get_flags(iface);
+	if (l2 != NULL && l2->get_flags != NULL) {
+		flags = l2->get_flags(iface);
 	}
 
 	return flags;
@@ -6278,6 +6281,10 @@ int net_if_addr_unref(struct net_if *iface,
 
 enum net_verdict net_if_recv_data(struct net_if *iface, struct net_pkt *pkt)
 {
+	const struct net_l2 *l2 = net_if_l2(iface);
+
+	NET_ASSERT(l2 != NULL);
+
 	if (IS_ENABLED(CONFIG_NET_PROMISCUOUS_MODE) &&
 	    net_if_is_promisc(iface)) {
 		struct net_pkt *new_pkt;
@@ -6289,7 +6296,7 @@ enum net_verdict net_if_recv_data(struct net_if *iface, struct net_pkt *pkt)
 		}
 	}
 
-	return net_if_l2(iface)->recv(iface, pkt);
+	return l2->recv(iface, pkt);
 }
 
 void net_if_register_link_cb(struct net_if_link_cb *link,
@@ -6431,7 +6438,8 @@ static void notify_iface_up(struct net_if *iface)
 		/* CAN does not require link address. */
 	} else {
 		if (!net_if_is_offloaded(iface)) {
-			NET_ASSERT(net_if_get_link_addr(iface)->len > 0);
+			NET_ASSERT(net_if_get_link_addr(iface) != NULL &&
+				   net_if_get_link_addr(iface)->len > 0);
 		}
 	}
 

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -614,11 +614,14 @@ int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
 	}
 
 	if (net_route_ll_addr_supported(iface)) {
-		memcpy(net_pkt_lladdr_src(pkt)->addr,
-		       net_pkt_lladdr_if(pkt)->addr,
-		       net_pkt_lladdr_if(pkt)->len);
-		net_pkt_lladdr_src(pkt)->type = net_pkt_lladdr_if(pkt)->type;
-		net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_if(pkt)->len;
+		struct net_linkaddr *lladdr_if = net_pkt_lladdr_if(pkt);
+
+		NET_ASSERT(lladdr_if != NULL);
+
+		memcpy(net_pkt_lladdr_src(pkt)->addr, lladdr_if->addr,
+		       lladdr_if->len);
+		net_pkt_lladdr_src(pkt)->type = lladdr_if->type;
+		net_pkt_lladdr_src(pkt)->len = lladdr_if->len;
 	}
 
 	return net_send_data(pkt);


### PR DESCRIPTION
Fixes 14 open GCC static analyzer alerts in `subsys/net/ip`.

Most findings are false positives caused by inline interface accessors (`net_if_l2()`, `net_if_get_link_addr()`, `net_if_get_device()`) returning NULL when passed a NULL interface. The fixes assert that these pointers are valid at the use site, which matches how the rest of the networking stack handles the same pattern.

### Fixed alerts

#### net: core: Assert that the interface link address is valid

- [#1465](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1465) — `-Wanalyzer-null-argument` in `net_core.c:178` (`copy_ll_addr()` / `memcpy()` source)
- [#1466](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1466) — `-Wanalyzer-null-argument` in `net_core.c:180` (`copy_ll_addr()` / `memcpy()` source)

#### net: ipv4: acd: Assert that the interface link address is valid

- [#1566](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1566) — `-Wanalyzer-null-dereference` in `ipv4_acd.c:318` (ARP probe conflict check)
- [#1567](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1567) — `-Wanalyzer-null-dereference` in `ipv4_acd.c:357` (passive conflict detection)

#### net: ipv6: nbr: Assert that the link address pointers are valid

- [#1568](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1568) — `-Wanalyzer-null-dereference` in `ipv6_nbr.c:1147` (`get_llao_len()`)
- [#1569](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1569) — `-Wanalyzer-null-dereference` in `ipv6_nbr.c:1164` (`set_llao()`)

#### net: route: Assert that the interface link address is valid

- [#1574](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1574) — `-Wanalyzer-null-dereference` in `route.c:619` (`net_route_packet_if()`)
- [#1575](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1575) — `-Wanalyzer-null-dereference` in `route.c:620` (`net_route_packet_if()`)
- [#1576](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1576) — `-Wanalyzer-null-dereference` in `route.c:621` (`net_route_packet_if()`)

#### net: context: Zero-initialize the default bind addresses

- [#1766](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1766) — `-Wanalyzer-use-of-uninitialized-value` in `net_context.c:976` (`bind_default()` / `sin6_scope_id`)

#### net: if: Assert that interface accessors return valid pointers

- [#1570](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1570) — `-Wanalyzer-null-dereference` in `net_if.c:457` (`init_iface()` / `dev->api`)
- [#1571](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1571) — `-Wanalyzer-null-dereference` in `net_if.c:6292` (`net_if_recv_data()` / `net_if_l2()`)
- [#1572](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1572) — `-Wanalyzer-null-dereference` in `net_if.c:6434` (`notify_iface_up()` / link address length check)
- [#1573](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1573) — `-Wanalyzer-null-dereference` in `net_if.c:721` (`l2_flags_get()` / `net_if_l2()`)

Fixes #116022
