### PR TITLE
drivers: crypto: mebdtls_shim: Don't select MBEDTLS_ENABLE_HEAP

### DIFF
--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -24,7 +24,7 @@ source "subsys/logging/Kconfig.template.log_config"
 config CRYPTO_MBEDTLS_SHIM
 	bool "Mbed TLS shim driver [EXPERIMENTAL]"
 	select PSA_CRYPTO
-	select MBEDTLS_ENABLE_HEAP
+	select MBEDTLS_ENABLE_HEAP if PSA_CRYPTO_PROVIDER_MBEDTLS
 	imply PSA_WANT_ALG_SHA_224
 	imply PSA_WANT_ALG_SHA_256
 	imply PSA_WANT_ALG_SHA_384
@@ -36,8 +36,11 @@ config CRYPTO_MBEDTLS_SHIM
 	imply PSA_WANT_ALG_GCM
 	select EXPERIMENTAL
 	help
-	  Enable Mbed TLS shim layer compliant with crypto APIs. You will need
-	  to fill in a relevant value to CONFIG_MBEDTLS_HEAP_SIZE.
+	  Enable Mbed TLS shim layer compliant with crypto APIs.
+
+	  If Mbed TLS is embedded in the application
+	  (CONFIG_PSA_CRYPTO_PROVIDER_MBEDTLS is enabled), you will
+	  need to fill in a relevant value to CONFIG_MBEDTLS_HEAP_SIZE.
 
 config CRYPTO_MBEDTLS_SHIM_DRV_NAME
 	string "Device name for Mbed TLS Pseudo device"

--- a/modules/mbedtls/Kconfig.tf-psa-crypto
+++ b/modules/mbedtls/Kconfig.tf-psa-crypto
@@ -126,11 +126,13 @@ config MBEDTLS_ENABLE_HEAP
 	bool "Global heap for mbed TLS"
 	select MBEDTLS_MEMORY_BUFFER_ALLOC_C
 	help
-	  This option enables the mbedtls to use the heap. This setting must
+	  This option enables the mbedtls to use a dedicated heap. This setting must
 	  be global so that various applications and libraries in Zephyr do not
 	  try to do this themselves as there can be only one heap defined
 	  in mbedtls. If this is enabled, and MBEDTLS_INIT is enabled then the
 	  Zephyr will, during the device startup, initialize the heap automatically.
+
+	  When disabled, mbedtls uses the system default heap.
 
 if MBEDTLS_ENABLE_HEAP
 


### PR DESCRIPTION
Remove enabling of CONFIG_MBEDTLS_ENABLE_HEAP upon CRYPTO_MBEDTLS_SHIM=y. It is not needed since crypto_mbedtls_shim driver does not make explicit allocations in Mbed TLS heap.

This change also fixes a build issues occurring since commit c20d1c864606 was merged that lead to unexpected `twister` build failures like the ones shown below when building a sample with TF-M embedded (in which case Mbed TLS is not linked into the Zephyr application).

In the twister build cases below, the build should be skipped by twister (filtered out since no chosen node found) but since config generation fails, twister cannot even tests whether or not the platform should be skipped.

Testing on **nucleo_l552ze_q//ns**:
```bash
$ west twister -p nucleo_l552ze_q/stm32l552xx/ns -s sample.mgmt.osdp.peripheral_device
(snip)
ERROR   - nucleo_l552ze_q/stm32l552xx/ns sample.mgmt.osdp.peripheral_device            ERROR: CMake build failure
(snip)
INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    0, failed:    0, error:    1
(snip)
INFO    - The following issues were found (showing the top 10 items):
INFO    - 1) sample.mgmt.osdp.peripheral_device on nucleo_l552ze_q/stm32l552xx/ns (zephyr/gnu) error (CMake build failure - warning: MBEDTLS_ENABLE_HEAP (defined at modules/mbedtls/Kconfig.tf-psa-crypto:125, modules/mbedtls/Kconfig.tf-psa-crypto:125) has direct dependencies MBEDTLS || (MBEDTLS && 0) with value n, but is currently being y-selected by the following symbols:)
```
Testing on **nrf7120dk/nrf7120/cpuapp/ns**:

```shell
$ west twister -b -p nrf7120dk/nrf7120/cpuapp/ns -s sample.mgmt.osdp.peripheral_device
(snip)
ERROR   - nrf7120dk/nrf7120/cpuapp/ns sample.mgmt.osdp.peripheral_device               ERROR: CMake build failure
(snip)
INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    0, failed:    0, error:    1
(snip)
INFO    - The following issues were found (showing the top 10 items):
INFO    - 1) sample.mgmt.osdp.peripheral_device on nrf7120dk/nrf7120/cpuapp/ns (zephyr/gnu) error (CMake build failure - warning: MBEDTLS_ENABLE_HEAP (defined at modules/mbedtls/Kconfig.tf-psa-crypto:125, modules/mbedtls/Kconfig.tf-psa-crypto:125) has direct dependencies MBEDTLS || (MBEDTLS && 0) with value n, but is currently being y-selected by the following symbols:)
```

With this change applied, each of the 2 `twister` commands above succeeds with the info trace message:
```
INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    1, failed:    0, error:    0
```