### PR TITLE
drivers: sensor: mmc56x3: fix configuration clobbering and stale RTIO temp

### DIFF
--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -138,13 +138,31 @@ int mmc56x3_chip_set_decimation_filter(const struct device *dev, bool bw0, bool 
 	struct mmc56x3_data *data = dev->data;
 	struct mmc56x3_config *config = &data->config;
 
-	data->ctrl1_cache |= (bw0 ? BIT(0) : 0);
-	data->ctrl1_cache |= (bw1 ? BIT(1) : 0);
+	uint8_t ctrl1 = data->ctrl1_cache;
 
-	config->bw0 = bw0;
-	config->bw1 = bw1;
+	if (bw0) {
+		ctrl1 |= BIT(0);
+	} else {
+		ctrl1 &= ~BIT(0);
+	}
 
-	return mmc56x3_reg_write(dev, MMC56X3_REG_INTERNAL_CTRL_1, data->ctrl1_cache);
+	if (bw1) {
+		ctrl1 |= BIT(1);
+	} else {
+		ctrl1 &= ~BIT(1);
+	}
+
+	int ret = mmc56x3_reg_write(dev, MMC56X3_REG_INTERNAL_CTRL_1, ctrl1);
+
+	if (ret < 0) {
+		LOG_DBG("Setting bandwidth bits failed: %d", ret);
+	} else {
+		data->ctrl1_cache = ctrl1;
+		config->bw0 = bw0;
+		config->bw1 = bw1;
+	}
+
+	return ret;
 }
 
 static int mmc56x3_chip_init(const struct device *dev)

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -366,7 +366,8 @@ static int mmc56x3_chip_configure(const struct device *dev, struct mmc56x3_confi
 static int mmc56x3_attr_set(const struct device *dev, enum sensor_channel chan,
 			    enum sensor_attribute attr, const struct sensor_value *val)
 {
-	struct mmc56x3_config new_config = {};
+	struct mmc56x3_data *data = dev->data;
+	struct mmc56x3_config new_config = data->config;
 	int ret = 0;
 
 	__ASSERT_NO_MSG(val != NULL);

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -251,6 +251,7 @@ static int mmc56x3_wait_until_ready(const struct device *dev)
 int mmc56x3_sample_fetch_helper(const struct device *dev, enum sensor_channel chan,
 				struct mmc56x3_data *data)
 {
+	struct mmc56x3_data *drv_data = dev->data;
 	int32_t raw_magn_x, raw_magn_y, raw_magn_z;
 	int ret;
 
@@ -258,7 +259,12 @@ int mmc56x3_sample_fetch_helper(const struct device *dev, enum sensor_channel ch
 		/* Temperature cannot be read in continuous mode */
 		uint8_t raw_temp;
 
-		ret = mmc56x3_reg_write(dev, MMC56X3_REG_INTERNAL_CTRL_0, MMC56X3_CMD_TAKE_MEAS_T);
+		/*
+		 * The take measurement bits are self-clearing, but Auto_SR_en in the same
+		 * register is not, so the cached configuration must be written along them.
+		 */
+		ret = mmc56x3_reg_write(dev, MMC56X3_REG_INTERNAL_CTRL_0,
+					drv_data->ctrl0_cache | MMC56X3_CMD_TAKE_MEAS_T);
 		if (ret < 0) {
 			return ret;
 		}
@@ -266,7 +272,8 @@ int mmc56x3_sample_fetch_helper(const struct device *dev, enum sensor_channel ch
 		k_timer_start(&meas_req_timer, K_MSEC(10), K_NO_WAIT);
 		k_timer_status_sync(&meas_req_timer);
 
-		ret = mmc56x3_reg_write(dev, MMC56X3_REG_INTERNAL_CTRL_0, MMC56X3_CMD_TAKE_MEAS_M);
+		ret = mmc56x3_reg_write(dev, MMC56X3_REG_INTERNAL_CTRL_0,
+					drv_data->ctrl0_cache | MMC56X3_CMD_TAKE_MEAS_M);
 		if (ret < 0) {
 			return ret;
 		}

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -126,7 +126,7 @@ static int mmc56x3_chip_set_continuous_mode(const struct device *dev, uint16_t o
 	return ret;
 }
 
-static bool mmc56x3_is_continuous_mode(const struct device *dev)
+bool mmc56x3_is_continuous_mode(const struct device *dev)
 {
 	struct mmc56x3_data *data = dev->data;
 

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.h
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.h
@@ -144,6 +144,8 @@ int mmc56x3_sample_fetch(const struct device *dev, enum sensor_channel chan);
 int mmc56x3_sample_fetch_helper(const struct device *dev, enum sensor_channel chan,
 				struct mmc56x3_data *data);
 
+bool mmc56x3_is_continuous_mode(const struct device *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3_async.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3_async.c
@@ -47,11 +47,14 @@ void mmc56x3_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 	edata->has_magn_y = 0;
 	edata->has_magn_z = 0;
 
+	/* Temperature cannot be read in continuous mode */
+	const bool has_temp = !mmc56x3_is_continuous_mode(dev);
+
 	/* Check if the requested channels are supported */
 	for (size_t i = 0; i < num_channels; i++) {
 		switch (channels[i].chan_type) {
 		case SENSOR_CHAN_AMBIENT_TEMP:
-			edata->has_temp = 1;
+			edata->has_temp = has_temp;
 			break;
 		case SENSOR_CHAN_MAGN_X:
 			edata->has_magn_x = 1;
@@ -68,7 +71,7 @@ void mmc56x3_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 			edata->has_magn_z = 1;
 			break;
 		case SENSOR_CHAN_ALL:
-			edata->has_temp = 1;
+			edata->has_temp = has_temp;
 			edata->has_magn_x = 1;
 			edata->has_magn_y = 1;
 			edata->has_magn_z = 1;


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the MMC56X3 magnetometer
driver, one commit per issue:

- **Keep unrelated attributes on attr_set**: `attr_set()` built its working
  configuration from a zero-initialised struct rather than the cached live
  configuration, so setting any one attribute reprogrammed — and effectively
  disabled — all the others.
- **Fix bandwidth bits never being cleared**: the decimation-filter helper only
  ever OR-ed the bandwidth bits into Internal Control 1, so a bandwidth could
  be raised but never lowered, and the shadow cache was updated even when the
  I2C write failed. It now does an explicit set/clear read-modify-write and
  commits the cache only on success.
- **Preserve ctrl0 config on one-shot measure**: the one-shot fetch wrote bare
  command values to Internal Control 0, clearing the sticky Auto_SR_en bit set
  at init. The command bits are now OR-ed onto the cached register value.
- **Don't report temp in continuous mode**: the RTIO path always advertised a
  temperature reading, but the device does not produce one in continuous mode,
  so the decoder converted uninitialised bytes from the RTIO buffer. The
  encoded flag is now gated on the operating mode, so the decoder returns
  -ENODATA instead.