### PR TITLE
drivers: sensor: ti_hdc302x: fix probe, conversion wait, signs and triggers

### DIFF
--- a/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
+++ b/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
@@ -214,15 +214,10 @@ static void convert_sensor_value(uint16_t *raw_value, struct sensor_value *senso
 		/* Integer part */
 		sensor_val->val1 = (int32_t)(numerator / UINT16_MAX);
 
-		/* Fractional part in microseconds */
+		/* Fractional part in micro-units, keeping the sign of the result */
 		remainder = (int32_t)(numerator % UINT16_MAX);
-		if (remainder < 0) {
-			/* Handle negative remainders properly */
-			sensor_val->val1 -= 1;
-			remainder += UINT16_MAX;
-		}
 
-		/* Convert remainder to microseconds: remainder * 1000000 / 65535 */
+		/* Convert remainder to micro-units: remainder * 1000000 / 65535 */
 		sensor_val->val2 = ((int64_t)remainder * 1000000LL) / UINT16_MAX;
 	} else {
 		sensor_micro = (int64_t)sensor_val->val1 * 1000000LL + (int64_t)sensor_val->val2;

--- a/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
+++ b/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
@@ -961,8 +961,12 @@ static int ti_hdc302x_init(const struct device *dev)
 		return rc;
 	}
 
-	if (verify_crc(manufacturer_id_buf, 2, manufacturer_id_buf[2]) != true &&
-	    sys_get_be16(manufacturer_id_buf) != HDC_302X_MANUFACTURER_ID) {
+	if (!verify_crc(manufacturer_id_buf, 2, manufacturer_id_buf[2])) {
+		LOG_ERR("Manufacturer ID CRC verification failed");
+		return -EIO;
+	}
+
+	if (sys_get_be16(manufacturer_id_buf) != HDC_302X_MANUFACTURER_ID) {
 		LOG_ERR("Invalid manufacturer ID: 0x%04X (expected 0x%04X)",
 			sys_get_be16(manufacturer_id_buf), HDC_302X_MANUFACTURER_ID);
 		return -EINVAL;

--- a/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
+++ b/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
@@ -51,6 +51,7 @@ struct ti_hdc302x_config {
 };
 
 struct ti_hdc302x_data {
+	const struct device *dev;
 	struct gpio_callback cb_int;
 	sensor_trigger_handler_t th_handler;
 	const struct sensor_trigger *th_trigger;
@@ -300,13 +301,14 @@ static int read_sensor_data(const struct device *dev, uint8_t *buf, size_t len)
 	return i2c_read_dt(&config->bus, buf, len);
 }
 
-static void interrupt_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+static void interrupt_callback(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
+	ARG_UNUSED(port);
 	ARG_UNUSED(pins);
 	struct ti_hdc302x_data *data = CONTAINER_OF(cb, struct ti_hdc302x_data, cb_int);
 
 	if (data->th_handler != NULL) {
-		data->th_handler(dev, data->th_trigger);
+		data->th_handler(data->dev, data->th_trigger);
 	}
 }
 
@@ -948,6 +950,7 @@ static int ti_hdc302x_init(const struct device *dev)
 	int rc;
 
 	/* Initialize default settings */
+	data->dev = dev;
 	data->power_mode = HDC302X_SENSOR_POWER_MODE_0;
 	data->interval = HDC302X_SENSOR_MEAS_INTERVAL_MANUAL;
 	data->t_offset = 0;

--- a/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
+++ b/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
@@ -160,6 +160,15 @@ static const uint8_t
 			[HDC302X_SENSOR_MEAS_INTERVAL_10] = {0x27, 0xFF},
 		},
 };
+
+/* Maximum measurement duration per power mode, in microseconds (datasheet Table 7-3) */
+static const uint16_t meas_duration_us[HDC302X_SENSOR_POWER_MODE_MAX] = {
+	[HDC302X_SENSOR_POWER_MODE_0] = 12500,
+	[HDC302X_SENSOR_POWER_MODE_1] = 7500,
+	[HDC302X_SENSOR_POWER_MODE_2] = 5000,
+	[HDC302X_SENSOR_POWER_MODE_3] = 3700,
+};
+
 /**
  * @brief Verify CRC for a given data buffer.
  */
@@ -322,6 +331,9 @@ static int ti_hdc302x_sample_fetch(const struct device *dev, enum sensor_channel
 			LOG_ERR("Failed to trigger manual measurement: %d", rc);
 			return rc;
 		}
+
+		/* The sensor NACKs the read until the conversion has completed */
+		k_sleep(K_USEC(meas_duration_us[data->power_mode]));
 	} else {
 		rc = write_command(dev, REG_MEAS_AUTO_READ, 2);
 		if (rc < 0) {


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the TI HDC302x driver, one
commit per issue:

- **Fix manufacturer ID probe condition**: the probe fused the CRC check and
  the ID comparison with `&&`, so a device with a valid CRC but the wrong
  manufacturer ID passed identification. Split into two independent guards
  returning -EIO and -EINVAL respectively, matching the file's existing
  CRC-check convention.
- **Fix sign of negative sensor values**: the conversion borrowed from the
  integer part for negative results, producing a positive `val2` with a
  negative `val1` (raw 1000 yielded {-43, 670328} instead of {-42, -329671}),
  violating the `sensor_value` contract for sub-zero temperatures.
- **Wait for conversion before reading data**: `sample_fetch()` issued the
  trigger-on-demand command and read the result immediately, with no wait for
  the conversion to complete — so in the driver's default manual/LPM0
  configuration the device NACKed the read. A per-power-mode measurement
  duration table is now used to wait the required time.
- **Pass sensor device to trigger handler**: the `SENSOR_TRIG_DELTA` handler
  was invoked with the GPIO controller device received by the GPIO callback
  rather than the sensor device, so handlers that used the pointer (e.g. to
  call `sensor_channel_get()`) operated on the wrong device. The driver now
  stores a back-pointer to itself and passes that.