### PR TITLE
drivers: sensor: tad2144: fix init without int-gpios, triggers and error paths

### DIFF
--- a/drivers/sensor/tdk/tad2144/Kconfig
+++ b/drivers/sensor/tdk/tad2144/Kconfig
@@ -39,7 +39,6 @@ endchoice
 
 config TAD2144_TRIGGER
 	bool
-	default y
 
 config TAD2144_THREAD_PRIORITY
 	int "Thread priority"

--- a/drivers/sensor/tdk/tad2144/tad214x_drv.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_drv.c
@@ -43,6 +43,7 @@ static int tad214x_sample_fetch(const struct device *dev, const enum sensor_chan
 {
 	struct tad214x_data *data = (struct tad214x_data *)dev->data;
 	const struct tad214x_config *cfg = dev->config;
+	int rc = 0;
 
 	tad214x_mutex_lock(dev);
 
@@ -50,10 +51,13 @@ static int tad214x_sample_fetch(const struct device *dev, const enum sensor_chan
 		data->angle = data->encoder_position;
 
 	} else {
-		TAD214x_GetData(&data->tad214x_device, &data->angle, &data->temperature);
+		if (TAD214x_GetData(&data->tad214x_device, &data->angle,
+				    &data->temperature) != INV_ERROR_SUCCESS) {
+			rc = -EIO;
+		}
 	}
 	tad214x_mutex_unlock(dev);
-	return 0;
+	return rc;
 }
 
 static void tad214x_convert_encoder(struct sensor_value *val, uint16_t raw_val)

--- a/drivers/sensor/tdk/tad2144/tad214x_drv.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_drv.c
@@ -64,21 +64,21 @@ static void tad214x_convert_encoder(struct sensor_value *val, uint16_t raw_val)
 {
 	raw_val = raw_val*36000/16384;
 	val->val1 = raw_val / 100;
-	val->val2 = (raw_val % 100) * 1000;
+	val->val2 = (raw_val % 100) * 10000;
 }
 
 static void tad214x_convert_angle(struct sensor_value *val, uint16_t raw_val)
 {
 	raw_val = ((uint32_t)raw_val*36000/65535+18000) % 36000;
 	val->val1 = raw_val / 100;
-	val->val2 = (raw_val % 100) * 1000;
+	val->val2 = (raw_val % 100) * 10000;
 }
 
 static void tad214x_convert_temperature(struct sensor_value *val, int16_t raw_val)
 {
 	raw_val = (2500 + raw_val*10/16);
 	val->val1 = raw_val / 100;
-	val->val2 = (raw_val % 100) * 1000;
+	val->val2 = (raw_val % 100) * 10000;
 }
 
 static int tad214x_channel_get(const struct device *dev, enum sensor_channel chan,

--- a/drivers/sensor/tdk/tad2144/tad214x_drv.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_drv.c
@@ -209,13 +209,15 @@ static int tad214x_init(const struct device *dev)
 		inv_tad214x_sleep_us(30000);
 	}
 
-	if (IS_ENABLED(CONFIG_TAD2144_TRIGGER)) {
+#ifdef CONFIG_TAD2144_TRIGGER
+	if (config->if_mode == IF_ENC || config->gpio_int.port != NULL) {
 		rc = tad214x_trigger_init(dev);
 		if (rc < 0) {
 			LOG_ERR("Failed to initialize interrupt.");
 			return rc;
 		}
 	}
+#endif
 
 	/* successful init, return 0 */
 	return 0;

--- a/drivers/sensor/tdk/tad2144/tad214x_i2c.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_i2c.c
@@ -26,6 +26,7 @@ static int tad214x_read_reg_i2c(const union tad214x_bus *bus, uint8_t reg, uint1
 	uint8_t write_buf[TAD214X_BUFFER_LEN];
 	uint8_t read_buf[TAD214X_BUFFER_LEN];
 	uint8_t calc_crc;
+	int rc;
 
 	if (size * 2 + 1 > TAD214X_BUFFER_LEN) {
 		LOG_ERR("Size error: %d", size);
@@ -35,8 +36,15 @@ static int tad214x_read_reg_i2c(const union tad214x_bus *bus, uint8_t reg, uint1
 	write_buf[0] = reg;
 	write_buf[1] = crc8(&reg, 1, 0x1D, 0xFF, false) ^ 0xFF;
 
-	i2c_write(bus->i2c.bus, write_buf, 2, bus->i2c.addr);
-	i2c_read(bus->i2c.bus, read_buf, size * 2 + 1, bus->i2c.addr);
+	rc = i2c_write(bus->i2c.bus, write_buf, 2, bus->i2c.addr);
+	if (rc < 0) {
+		return rc;
+	}
+
+	rc = i2c_read(bus->i2c.bus, read_buf, size * 2 + 1, bus->i2c.addr);
+	if (rc < 0) {
+		return rc;
+	}
 
 	calc_crc = crc8(read_buf, size * 2, 0x1D, 0xFF, false) ^ 0xFF;
 	if (calc_crc != read_buf[size * 2]) {
@@ -69,8 +77,7 @@ static int tad214x_write_reg_i2c(const union tad214x_bus *bus, uint8_t reg, uint
 	msg.len = 1U + (size * 2) + 1U;
 	msg.flags = I2C_MSG_WRITE | I2C_MSG_STOP;
 
-	i2c_transfer(bus->i2c.bus, &msg, 1, bus->i2c.addr);
-	return 0;
+	return i2c_transfer(bus->i2c.bus, &msg, 1, bus->i2c.addr);
 }
 
 const struct tad214x_bus_io tad214x_bus_io_i2c = {

--- a/drivers/sensor/tdk/tad2144/tad214x_trigger.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_trigger.c
@@ -193,6 +193,10 @@ int tad214x_trigger_set(const struct device *dev, const struct sensor_trigger *t
 	struct tad214x_data *drv_data = dev->data;
 	const struct tad214x_config *cfg = dev->config;
 
+	if (cfg->if_mode != IF_ENC && cfg->gpio_int.port == NULL) {
+		return -ENOTSUP;
+	}
+
 	tad214x_mutex_lock(dev);
 
 	if (trig->type == SENSOR_TRIG_DATA_READY) {

--- a/drivers/sensor/tdk/tad2144/tad214x_trigger.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_trigger.c
@@ -37,6 +37,36 @@ static void tad214x_gpio_callback(const struct device *dev, struct gpio_callback
 #endif
 }
 
+static void tad214x_handle_enc(const struct device *dev)
+{
+	struct tad214x_data *drv_data = dev->data;
+	const struct tad214x_config *cfg = dev->config;
+
+	static volatile uint8_t last_encoder_state;
+	int val_a = gpio_pin_get_dt(&cfg->gpio_enca); /* encA */
+	int val_b = gpio_pin_get_dt(&cfg->gpio_encb); /* encB */
+	int val_z = gpio_pin_get_dt(&cfg->gpio_encz);  /* encZ */
+
+	uint8_t current_state = (val_a << 1) | val_b;
+	/* Check for index pulse (Z channel) */
+	if (val_z) {
+		/* Reset position on index pulse */
+		drv_data->encoder_position = 0;
+	} else if (current_state != last_encoder_state) {
+		if (((last_encoder_state == 0x00) && (current_state == 0x02)) ||
+			((last_encoder_state == 0x01) && (current_state == 0x00)) ||
+			((last_encoder_state == 0x02) && (current_state == 0x03)) ||
+			((last_encoder_state == 0x03) && (current_state == 0x01))) {
+			drv_data->encoder_position++;
+		} else {
+			drv_data->encoder_position--;
+		}
+	}
+
+	drv_data->encoder_position = drv_data->encoder_position % 16384;
+	last_encoder_state = current_state;
+}
+
 static void tad214x_thread_cb(const struct device *dev)
 {
 	struct tad214x_data *drv_data = dev->data;
@@ -47,6 +77,8 @@ static void tad214x_thread_cb(const struct device *dev)
 		gpio_pin_interrupt_configure_dt(&cfg->gpio_enca, GPIO_INT_DISABLE);
 		gpio_pin_interrupt_configure_dt(&cfg->gpio_encb, GPIO_INT_DISABLE);
 		gpio_pin_interrupt_configure_dt(&cfg->gpio_encz, GPIO_INT_DISABLE);
+
+		tad214x_handle_enc(dev);
 	} else {
 		gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_DISABLE);
 	}
@@ -152,40 +184,6 @@ int tad214x_trigger_init(const struct device *dev)
 	return 0;
 }
 
-static void tad214x_handle_enc(const struct device *dev, const struct sensor_trigger *trig)
-{
-	struct tad214x_data *drv_data = dev->data;
-	const struct tad214x_config *cfg = dev->config;
-
-	if (trig->type == SENSOR_TRIG_DATA_READY) {
-		static volatile uint8_t last_encoder_state;
-
-		int val_a = gpio_pin_get_dt(&cfg->gpio_enca); /* encA */
-		int val_b = gpio_pin_get_dt(&cfg->gpio_encb); /* encB */
-		int val_z = gpio_pin_get_dt(&cfg->gpio_encz);  /* encZ */
-
-		uint8_t current_state = (val_a << 1) | val_b;
-		/* Check for index pulse (Z channel) */
-		if (val_z) {
-			/* Reset position on index pulse */
-			drv_data->encoder_position = 0;
-		} else if (current_state != last_encoder_state) {
-			if (((last_encoder_state == 0x00) && (current_state == 0x02)) ||
-				((last_encoder_state == 0x01) && (current_state == 0x00)) ||
-				((last_encoder_state == 0x02) && (current_state == 0x03)) ||
-				((last_encoder_state == 0x03) && (current_state == 0x01))) {
-				drv_data->encoder_position++;
-			} else {
-				drv_data->encoder_position--;
-			}
-		}
-
-		drv_data->encoder_position = drv_data->encoder_position % 16384;
-		last_encoder_state = current_state;
-	}
-}
-
-
 int tad214x_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
 			 sensor_trigger_handler_t handler)
 {
@@ -205,12 +203,17 @@ int tad214x_trigger_set(const struct device *dev, const struct sensor_trigger *t
 			gpio_pin_interrupt_configure_dt(&cfg->gpio_encb, GPIO_INT_DISABLE);
 			gpio_pin_interrupt_configure_dt(&cfg->gpio_encz, GPIO_INT_DISABLE);
 
-			drv_data->drdy_handler = tad214x_handle_enc;
+			drv_data->drdy_handler = handler;
 			drv_data->drdy_trigger = trig;
 
-			gpio_pin_interrupt_configure_dt(&cfg->gpio_enca, GPIO_INT_EDGE_BOTH);
-			gpio_pin_interrupt_configure_dt(&cfg->gpio_encb, GPIO_INT_EDGE_BOTH);
-			gpio_pin_interrupt_configure_dt(&cfg->gpio_encz, GPIO_INT_EDGE_BOTH);
+			if (handler != NULL) {
+				gpio_pin_interrupt_configure_dt(&cfg->gpio_enca,
+								GPIO_INT_EDGE_BOTH);
+				gpio_pin_interrupt_configure_dt(&cfg->gpio_encb,
+								GPIO_INT_EDGE_BOTH);
+				gpio_pin_interrupt_configure_dt(&cfg->gpio_encz,
+								GPIO_INT_EDGE_BOTH);
+			}
 		} else {
 			if (handler == NULL) {
 				tad214x_mutex_unlock(dev);


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the TAD214x driver, one
commit per issue:

- **Don't fail init without int-gpios**: `init()` unconditionally ran the
  trigger setup, so any I2C or SPI instance without the optional `int-gpios`
  property failed to initialise. Trigger init is now gated on an interrupt
  GPIO actually being present, `trigger_set()` returns -ENOTSUP on
  interrupt-less instances instead of dereferencing a NULL port, and the
  redundant `default y` on the trigger Kconfig is dropped so the "none" option
  is reachable.
- **Honour trigger handler in encoder mode**: the encoder branch of
  `trigger_set()` overwrote the caller's handler with the driver's internal
  quadrature decoder, so applications never received encoder events, and
  passing a NULL handler could not disable the trigger. The internal decoder
  is now an ordinary internal step, the caller's handler is stored, and a NULL
  handler leaves the ENCA/ENCB/ENCZ interrupts disabled.
- **Propagate bus and sample fetch errors**: `sample_fetch()` returned 0
  unconditionally, and the I2C helpers discarded every transfer result — so a
  failed read was reported as a successful fetch, with the CRC then evaluated
  over an untouched stack buffer. Errors are now propagated.
- **Fix fractional part scaling in channel_get**: all three converters
  (encoder, angle, temperature) produce a centi-unit intermediate but scaled
  the remainder into `val2` by 1000 instead of 10000, making the reported
  fraction ten times too small on every non-zero remainder.