### PR TITLE
drivers: sensor: wsen_isds_2536030320001: fix full-scale attribute units and fetch/config edge cases

### DIFF
--- a/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
@@ -565,8 +565,7 @@ static int isds_2536030320001_accel_full_scale_get(const struct device *dev,
 
 	data->accel_range = accel_fs;
 
-	fs->val1 = isds_2536030320001_accel_full_scale_list[accel_fs];
-	fs->val2 = 0;
+	sensor_g_to_ms2(isds_2536030320001_accel_full_scale_list[accel_fs], fs);
 
 	return 0;
 }

--- a/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
@@ -69,8 +69,7 @@ static int isds_2536030320001_sample_fetch(const struct device *dev, enum sensor
 	uint32_t accel_step_sleep_duration, gyro_step_sleep_duration, step_sleep_duration;
 
 	switch (channel) {
-	case SENSOR_CHAN_ALL:
-	case SENSOR_CHAN_AMBIENT_TEMP: {
+	case SENSOR_CHAN_ALL: {
 		if (!wsen_sensor_step_sleep_duration_milli_from_odr_hz(
 			    &isds_2536030320001_accel_odr_list[data->accel_odr],
 			    &accel_step_sleep_duration)) {
@@ -88,6 +87,30 @@ static int isds_2536030320001_sample_fetch(const struct device *dev, enum sensor
 		step_sleep_duration = accel_step_sleep_duration < gyro_step_sleep_duration
 					      ? gyro_step_sleep_duration
 					      : accel_step_sleep_duration;
+		break;
+	}
+	case SENSOR_CHAN_AMBIENT_TEMP: {
+		bool accel_enabled = wsen_sensor_step_sleep_duration_milli_from_odr_hz(
+			&isds_2536030320001_accel_odr_list[data->accel_odr],
+			&accel_step_sleep_duration);
+		bool gyro_enabled = wsen_sensor_step_sleep_duration_milli_from_odr_hz(
+			&isds_2536030320001_gyro_odr_list[data->gyro_odr],
+			&gyro_step_sleep_duration);
+
+		if (!accel_enabled && !gyro_enabled) {
+			LOG_ERR("Accelerometer and gyroscope are disabled.");
+			return -ENOTSUP;
+		}
+
+		if (!gyro_enabled) {
+			step_sleep_duration = accel_step_sleep_duration;
+		} else if (!accel_enabled) {
+			step_sleep_duration = gyro_step_sleep_duration;
+		} else {
+			step_sleep_duration = accel_step_sleep_duration < gyro_step_sleep_duration
+						      ? gyro_step_sleep_duration
+						      : accel_step_sleep_duration;
+		}
 		break;
 	}
 	case SENSOR_CHAN_ACCEL_X:

--- a/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
@@ -606,6 +606,12 @@ static int isds_2536030320001_gyro_full_scale_set(const struct device *dev,
 
 	uint8_t idx;
 
+	if (scale_dps == 0) {
+		/* 0 marks the reserved gaps in isds_2536030320001_gyro_full_scale_list */
+		LOG_ERR("Bad scale %d", scale_dps);
+		return -EINVAL;
+	}
+
 	for (idx = 0; idx < ARRAY_SIZE(isds_2536030320001_gyro_full_scale_list); idx++) {
 		if (isds_2536030320001_gyro_full_scale_list[idx] == scale_dps) {
 			break;

--- a/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
@@ -624,8 +624,7 @@ static int isds_2536030320001_gyro_full_scale_get(const struct device *dev, stru
 
 	data->gyro_range = gyro_fs;
 
-	fs->val1 = isds_2536030320001_gyro_full_scale_list[gyro_fs];
-	fs->val2 = 0;
+	sensor_degrees_to_rad((int32_t)isds_2536030320001_gyro_full_scale_list[gyro_fs], fs);
 
 	return 0;
 }


### PR DESCRIPTION
This PR fixes four independent correctness bugs in the WSEN-ISDS driver, one
commit per issue:

- **Fix accel full-scale unit**: `attr_set(SENSOR_ATTR_FULL_SCALE)` expects the
  value in m/s² (as documented in `sensor.h`) but `attr_get()` returned the
  range in g. A read-modify-write round trip therefore reprogrammed a ±16 g
  device to ±2 g and silently clipped every subsequent sample.
- **Fix gyro full scale unit**: same asymmetry on the gyro channel — the getter
  returned degrees per second while the setter interprets its argument as
  rad/s, so reading back and re-applying the current range collapsed it to the
  smallest supported one.
- **Fix temp fetch when odr is 0**: fetching `SENSOR_CHAN_ALL` (or the
  temperature channel) returned an error whenever either the accelerometer or
  the gyroscope was powered down, making the on-die temperature unusable in
  single-sensor configurations.
- **Reject zero gyro full scale**: a full-scale request of 0 matched a reserved
  padding entry in the gyro range table, programming an invalid CTRL2_G
  encoding while returning success.