### PR TITLE
drivers: sensor: tsl2540: fix trigger teardown, no-wait mode and gain error handling

### DIFF
--- a/drivers/sensor/ams/tsl2540/tsl2540.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540.c
@@ -139,6 +139,8 @@ static int tsl2540_attr_set_gain(const struct device *dev, enum sensor_gain_tsl2
 		value2 = TSL2540_CFG2_G128;
 		again = TSL2540_AGAIN_S128;
 		break;
+	default:
+		return -EINVAL;
 	}
 
 	if (i2c_reg_write_byte_dt(&cfg->i2c_spec, TSL2540_REG_CFG_1, value) < 0) {
@@ -219,7 +221,7 @@ static int tsl2540_attr_set(const struct device *dev, enum sensor_channel chan,
 #endif /* CONFIG_TSL2540_TRIGGER */
 
 	if (attr == SENSOR_ATTR_GAIN) {
-		tsl2540_attr_set_gain(dev, (enum sensor_gain_tsl2540)val->val1);
+		ret = tsl2540_attr_set_gain(dev, (enum sensor_gain_tsl2540)val->val1);
 		goto exit;
 	}
 
@@ -283,17 +285,20 @@ exit:
 static int tsl2540_setup(const struct device *dev)
 {
 	struct sensor_value integration_time;
+	int ret;
 
 	/* Set ALS integration time */
-	tsl2540_attr_set(dev, (enum sensor_channel)SENSOR_CHAN_LIGHT,
-			 (enum sensor_attribute)SENSOR_ATTR_GAIN,
-			 &(struct sensor_value){.val1 = TSL2540_SENSOR_GAIN_1_2, .val2 = 0});
+	ret = tsl2540_attr_set(dev, (enum sensor_channel)SENSOR_CHAN_LIGHT,
+			       (enum sensor_attribute)SENSOR_ATTR_GAIN,
+			       &(struct sensor_value){.val1 = TSL2540_SENSOR_GAIN_1_2, .val2 = 0});
+	if (ret) {
+		return ret;
+	}
 
 	sensor_value_from_double(&integration_time, 500.0);
-	tsl2540_attr_set(dev, (enum sensor_channel)SENSOR_CHAN_LIGHT,
-			 (enum sensor_attribute)SENSOR_ATTR_INTEGRATION_TIME, &integration_time);
-
-	return 0;
+	return tsl2540_attr_set(dev, (enum sensor_channel)SENSOR_CHAN_LIGHT,
+				(enum sensor_attribute)SENSOR_ATTR_INTEGRATION_TIME,
+				&integration_time);
 }
 
 static int tsl2540_init(const struct device *dev)
@@ -303,6 +308,9 @@ static int tsl2540_init(const struct device *dev)
 	int ret;
 
 	data->enable_mode = TSL2540_ENABLE_DISABLE;
+	/* Hardware reset defaults: CFG1=0x00/CFG2=0x04 (1x gain), ATIME=0x00 */
+	data->again = TSL2540_AGAIN_S1;
+	data->integration_time = 0;
 
 	k_sem_init(&data->sem, 1, K_SEM_MAX_LIMIT);
 

--- a/drivers/sensor/ams/tsl2540/tsl2540.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540.c
@@ -269,7 +269,7 @@ static int tsl2540_attr_set(const struct device *dev, enum sensor_channel chan,
 	case SENSOR_ATTR_TSL2540_CONTINUOUS_NO_WAIT_MODE:
 		data->enable_mode = TSL2540_ENABLE_AEN_PON;
 		ret = i2c_reg_update_byte_dt(&cfg->i2c_spec, TSL2540_CFG3_ADDR, TSL2540_CFG3_MASK,
-						TSL2540_CFG3_DFLT);
+						TSL2540_CFG3_NO_SAI_CONF);
 		break;
 	}
 

--- a/drivers/sensor/ams/tsl2540/tsl2540.h
+++ b/drivers/sensor/ams/tsl2540/tsl2540.h
@@ -63,6 +63,8 @@
 #define TSL2540_CFG3_ADDR 0xAB
 #define TSL2540_CFG3_MASK (BIT(7) | BIT(4))
 #define TSL2540_CFG3_CONF (BIT(7) | BIT(4))
+/* No sleep-after-interrupt, but INT_READ_CLEAR kept so a STATUS read acknowledges AINT */
+#define TSL2540_CFG3_NO_SAI_CONF (BIT(7))
 #define TSL2540_CFG3_DFLT (0)
 
 /* INTENAB(0xDD: 0x00): ASIEN:7 | Reserved:6:5 | AIEN:4 | Reserved:3:0 */

--- a/drivers/sensor/ams/tsl2540/tsl2540_trigger.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540_trigger.c
@@ -124,26 +124,28 @@ int tsl2540_trigger_set(const struct device *dev, const struct sensor_trigger *t
 
 	const struct i2c_dt_spec *i2c_spec = &config->i2c_spec;
 
-	ret = i2c_reg_update_byte_dt(i2c_spec, TSL2540_INTENAB_ADDR,
-					TSL2540_INTENAB_MASK, TSL2540_INTENAB_CONF);
-	if (ret) {
-		LOG_ERR("%#x: I/O error: %d", TSL2540_INTENAB_ADDR, ret);
-		return -EIO;
-	}
-
-	ret = i2c_reg_update_byte_dt(i2c_spec, TSL2540_CFG3_ADDR,
-					TSL2540_CFG3_MASK, TSL2540_CFG3_CONF);
-	if (ret) {
-		LOG_ERR("%#x: I/O error: %d", TSL2540_CFG3_ADDR, ret);
-		return -EIO;
-	}
-
 	k_sem_take(&data->sem, K_FOREVER);
 
 	data->als_handler = handler;
 	data->als_trigger = trig;
 
 	if (handler != NULL) {
+		ret = i2c_reg_update_byte_dt(i2c_spec, TSL2540_INTENAB_ADDR,
+					     TSL2540_INTENAB_MASK, TSL2540_INTENAB_CONF);
+		if (ret) {
+			LOG_ERR("%#x: I/O error: %d", TSL2540_INTENAB_ADDR, ret);
+			k_sem_give(&data->sem);
+			return -EIO;
+		}
+
+		ret = i2c_reg_update_byte_dt(i2c_spec, TSL2540_CFG3_ADDR,
+					     TSL2540_CFG3_MASK, TSL2540_CFG3_CONF);
+		if (ret) {
+			LOG_ERR("%#x: I/O error: %d", TSL2540_CFG3_ADDR, ret);
+			k_sem_give(&data->sem);
+			return -EIO;
+		}
+
 		tsl2540_setup_int(dev, true);
 
 		/* Check whether already asserted */
@@ -151,6 +153,17 @@ int tsl2540_trigger_set(const struct device *dev, const struct sensor_trigger *t
 
 		if (pv > 0) {
 			tsl2540_handle_int(dev);
+		}
+	} else {
+		tsl2540_setup_int(dev, false);
+
+		/* Only clear AIEN: CFG3 also holds the enable mode set through attributes */
+		ret = i2c_reg_update_byte_dt(i2c_spec, TSL2540_INTENAB_ADDR,
+					     TSL2540_INTENAB_MASK, 0);
+		if (ret) {
+			LOG_ERR("%#x: I/O error: %d", TSL2540_INTENAB_ADDR, ret);
+			k_sem_give(&data->sem);
+			return -EIO;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the TSL2540 driver, one
commit per issue:

- **Disable ALS interrupt on trigger removal**: `trigger_set()` enabled AIEN and
  the CFG3 interrupt configuration unconditionally, before even looking at the
  handler, and never disabled anything when called with a NULL handler. Removing
  a trigger therefore left the ALS interrupt asserted on the INT pin forever,
  and simply *querying* the driver with a NULL handler switched the interrupt
  on. The register writes now happen inside the handler-dependent branches, the
  teardown path detaches the GPIO callback and clears AIEN, and the semaphore is
  released on the error paths (which previously returned while still holding it).
- **Propagate gain configuration errors**: `attr_set()` discarded the result of
  `tsl2540_attr_set_gain()` and `tsl2540_setup()` always returned 0, so a failed
  or out-of-range gain request was reported as success while leaving the cached
  analog gain at 0.0 — which `channel_get()` then divides by. Reject unknown
  gains, propagate errors up to `init()`, and seed the cached gain and
  integration time with the hardware reset defaults so a partially failed setup
  cannot leave a zero divisor behind.
- **Keep INT_READ_CLEAR in no-wait mode**: selecting
  `SENSOR_ATTR_TSL2540_CONTINUOUS_NO_WAIT_MODE` cleared all of CFG3, including
  INT_READ_CLEAR, so reading the status register no longer acknowledged AINT.
  With the interrupt latched and never cleared, the trigger fired once and the
  driver stopped reporting further threshold events. Clear only the
  sleep-after-interrupt bit.