### PR TITLE
tests: uart_errors: remove SPI props from sercom5 for pic32cm_jh01_cpro

### DIFF
--- a/tests/drivers/uart/uart_errors/boards/pic32cm_jh01_cpro.overlay
+++ b/tests/drivers/uart/uart_errors/boards/pic32cm_jh01_cpro.overlay
@@ -24,6 +24,12 @@ dut_aux: &sercom5 {
 	compatible = "microchip,sercom-g1-uart";
 	#address-cells = <1>;
 	#size-cells = <0>;
+
+	/* sercom5 is configured for SPI, drop SPI-related properties to allow UART use */
+	/delete-property/ dipo;
+	/delete-property/ dopo;
+	/delete-property/ cs-gpios;
+
 	current-speed = <115200>;
 	rxpo = <1>;
 	txpo = <0>;


### PR DESCRIPTION
Board DTS now configures sercom5 as SPI (since commit bc295c9fc8a);
the overlay switches it to UART, but devicetree overlays merge rather
than replace, so the SPI-only dipo, dopo and cs-gpios properties
survived. They are not declared in the microchip,sercom-g1-uart
binding, so the build failed with:

  devicetree error: 'dipo' appears in /soc/sercom@42001800, but is not
  declared in 'properties:' in microchip,sercom-g1-uart.yaml

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116039

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
