### PR TITLE
drivers: sensor: fdc2x1x: fix frequency conversion scaling and FREF_DIVIDER width

### DIFF
--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
@@ -39,8 +39,12 @@ static void fdc2x1x_raw_to_freq(const struct device *dev,
 		*freq = (cfg->ch_cfg[ch].fin_sel * fref_mhz *
 			 data->channel_buf[ch]) / pow(2, 28);
 	} else {
+		/* OUTPUT_GAIN codes 0..3 select a gain of 1/4/8/16 */
+		static const uint8_t gain_shift[4] = { 0, 2, 3, 4 };
+
 		*freq = cfg->ch_cfg[ch].fin_sel * fref_mhz *
-			((data->channel_buf[ch] / pow(2, 12 + cfg->output_gain)) +
+			((data->channel_buf[ch] /
+			  pow(2, 12 + gain_shift[cfg->output_gain & 0x3])) +
 			 (cfg->ch_cfg[ch].offset / pow(2, 16)));
 	}
 }

--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
@@ -32,12 +32,14 @@ static void fdc2x1x_raw_to_freq(const struct device *dev,
 {
 	struct fdc2x1x_data *data = dev->data;
 	const struct fdc2x1x_config *cfg = dev->config;
+	/* f_REFx = f_CLK / CHx_FREF_DIVIDER, in MHz */
+	double fref_mhz = (cfg->fref / 1000.0) / cfg->ch_cfg[ch].fref_divider;
 
 	if (data->fdc221x) {
-		*freq = (cfg->ch_cfg[ch].fin_sel * (cfg->fref / 1000.0) *
+		*freq = (cfg->ch_cfg[ch].fin_sel * fref_mhz *
 			 data->channel_buf[ch]) / pow(2, 28);
 	} else {
-		*freq = cfg->ch_cfg[ch].fin_sel * (cfg->fref / 1000.0) *
+		*freq = cfg->ch_cfg[ch].fin_sel * fref_mhz *
 			((data->channel_buf[ch] / pow(2, 12 + cfg->output_gain)) +
 			 (cfg->ch_cfg[ch].offset / pow(2, 16)));
 	}

--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x.h
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x.h
@@ -67,8 +67,8 @@
 #define FDC2X1X_CLK_DIV_CHX_FIN_SEL_SET(x)          (((x) & 0x3) << 12)
 #define FDC2X1X_CLK_DIV_CHX_FIN_SEL_GET(x)          (((x) >> 12) & 0x3)
 #define FDC2X1X_CLK_DIV_CHX_FREF_DIV_MSK            GENMASK(9, 0)
-#define FDC2X1X_CLK_DIV_CHX_FREF_DIV_SET(x)         ((x) & 0x1FF)
-#define FDC2X1X_CLK_DIV_CHX_FREF_DIV_GET(x)         (((x) >> 0) & 0x1FF)
+#define FDC2X1X_CLK_DIV_CHX_FREF_DIV_SET(x)         ((x) & 0x3FF)
+#define FDC2X1X_CLK_DIV_CHX_FREF_DIV_GET(x)         (((x) >> 0) & 0x3FF)
 
 /* STATUS Field Descriptions */
 #define FDC2X1X_STATUS_ERR_CHAN(x)                  (((x) >> 14) & 0x3)


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the FDC2x1x driver, one
commit per issue:

- **Fix truncated FREF_DIVIDER field width**: `CHx_FREF_DIVIDER` is a 10-bit
  field — as the driver's own `FDC2X1X_CLK_DIV_CHX_FREF_DIV_MSK` (`GENMASK(9, 0)`)
  and the devicetree binding (`max: 1023`) both state — but the SET/GET macros
  masked to 9 bits. Any `fref-divider` of 512 or more was silently programmed
  and read back modulo 512.
- **Apply reference divider in freq conversion**: `fdc2x1x_raw_to_freq()`
  computed the sensor frequency from the raw reference clock, ignoring
  `CHx_FREF_DIVIDER` entirely. Since the divider is a required devicetree
  property that boards set to keep the reference within the conversion range,
  any value other than 1 scaled every frequency — and therefore every reported
  capacitance — by that factor.
- **Fix output gain scaling in freq conversion**: the `OUTPUT_GAIN` codes 0..3
  select a gain of 1/4/8/16, but the 12-bit conversion path used the raw
  register code directly as a power-of-two exponent. Any non-zero gain
  therefore reported twice the actual frequency and a quarter of the actual
  capacitance. Map the code to its real log2(gain).