### PR TITLE
soc: nxp: mcxa: enable SPC active-mode bandgap from devicetree

### DIFF
--- a/dts/bindings/power/nxp,spc.yaml
+++ b/dts/bindings/power/nxp,spc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP System Power Control (SPC)
@@ -28,3 +28,16 @@ properties:
       configured value against the levels the DCDC can actually produce.
       When this property is absent, the SoC leaves the active-mode DCDC
       output voltage untouched.
+
+  active-mode-bandgap-buffer:
+    type: boolean
+    description: |
+      Enable the buffered output of the SPC bandgap voltage reference in active
+      mode. The bandgap core itself is already running whenever a voltage
+      detect or a normal-drive-strength regulator needs it.
+      It is required for blocks outside the SPC to sample it,
+      such as the ADC bandgap input channel.
+      The buffer is enabled during system initialization and stays enabled
+      for the lifetime of the application, including across Deep Power Down
+      resume. It draws additional current, so it is opt-in. When this property
+      is absent the SoC leaves the active-mode bandgap configuration untouched.

--- a/soc/nxp/mcx/mcxa/power.c
+++ b/soc/nxp/mcx/mcxa/power.c
@@ -198,6 +198,14 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		/* re-build clock tree */
 		board_early_init_hook();
 
+#if DT_PROP(DT_INST(0, nxp_spc), active_mode_bandgap_buffer)
+		/* Deep Power Down resets ACTIVE_CFG[BGMODE]
+		 * back to its reset value, so the buffer must be re-applied here.
+		 */
+		(void)SPC_SetActiveModeBandgapModeConfig(MCXA_SPC_ADDR,
+							 kSPC_BandgapEnabledBufferEnabled);
+#endif
+
 		/* idle-thread stack is nearly full, it is easy to reach the
 		 * PSPLIM limit on resume. Drop the limit here, the next context
 		 * switch re-establishes the per-thread PSPLIM.

--- a/soc/nxp/mcx/mcxa/soc.c
+++ b/soc/nxp/mcx/mcxa/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,27 +16,49 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <soc.h>
-#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+
+#ifdef CONFIG_DT_HAS_NXP_SPC_ENABLED
 #include <fsl_spc.h>
-#include <fsl_cmc.h>
-#define MCXA_CMC	((CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc)))
 #define MCXA_SPC	((SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc)))
 #endif
 
 #ifdef CONFIG_SOC_RESET_HOOK
+
+#if (defined(CONFIG_PM) || defined(CONFIG_POWEROFF)) && defined(CONFIG_DT_HAS_NXP_CMC_ENABLED)
+#include <fsl_cmc.h>
+#define MCXA_CMC	((CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc)))
+#endif
+
 void soc_reset_hook(void)
 {
-#if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
+#if (defined(CONFIG_PM) || defined(CONFIG_POWEROFF)) && defined(CONFIG_DT_HAS_NXP_CMC_ENABLED) && \
+	defined(CONFIG_DT_HAS_NXP_SPC_ENABLED)
 	if ((CMC_GetSystemResetStatus(MCXA_CMC) & kCMC_WakeUpReset) != 0UL) {
 		SPC_ClearPeriphIOIsolationFlag(MCXA_SPC);
 		SPC_ClearPowerDomainLowPowerRequestFlag(MCXA_SPC, kSPC_PowerDomain0);
 		SPC_ClearLowPowerRequest(MCXA_SPC);
 	}
 #endif
+
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	SystemInit();
 #endif /* ! CONFIG_TRUSTED_EXECUTION_NONSECURE */
 }
+#endif
+
+#if defined(CONFIG_DT_HAS_NXP_SPC_ENABLED) && \
+	DT_PROP(DT_INST(0, nxp_spc), active_mode_bandgap_buffer)
+static int mcxa_spc_bandgap_init(void)
+{
+	/* The buffer drives the bandgap reference, so blocks outside
+	 * the SPC (e.g. the LPADC bandgap input channel) can sample it.
+	 */
+	(void)SPC_SetActiveModeBandgapModeConfig(MCXA_SPC, kSPC_BandgapEnabledBufferEnabled);
+
+	return 0;
+}
+
+SYS_INIT(mcxa_spc_bandgap_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif
 
 void enable_ecc(uint32_t mask)


### PR DESCRIPTION
Enables the buffered active-mode bandgap when the SPC node carries active-mode-bandgap-buffer, sampled on the ADC internal Bandgap channel (~1 V).

Tested on frdm_mcxa153/156/266/344 (ADC private test).