### PR TITLE
testsuite: busy_sim: migrate ring_buf usage to zero-copy _ptr API

### DIFF
--- a/subsys/testsuite/busy_sim/busy_sim.c
+++ b/subsys/testsuite/busy_sim/busy_sim.c
@@ -58,15 +58,14 @@ static void rng_pool_work_handler(struct k_work *work)
 	uint32_t len;
 	const struct busy_sim_config *config = busy_sim_dev->config;
 
-	len = ring_buf_put_claim(&rnd_rbuf, &buf, BUFFER_SIZE - 1);
+	len = ring_buf_put_ptr(&rnd_rbuf, &buf, 0);
 	if (len) {
 		int err = entropy_get_entropy(config->entropy, buf, len);
 
 		if (err == 0) {
-			ring_buf_put_finish(&rnd_rbuf, len);
+			ring_buf_commit(&rnd_rbuf, len);
 			return;
 		}
-		ring_buf_put_finish(&rnd_rbuf, 0);
 	}
 
 	k_work_submit(work);


### PR DESCRIPTION
Migrates the busy_sim test helper from the deprecated ring_buf
claim/finish API to the new zero-copy get_ptr/put_ptr API.

No functional change; mechanical API migration.

Depends on the new ring_buf _ptr API (base #106290).
