### PR TITLE
instrumentation: migrate ring_buf usage to zero-copy _ptr API

### DIFF
--- a/subsys/instrumentation/common/instr_common.c
+++ b/subsys/instrumentation/common/instr_common.c
@@ -296,7 +296,7 @@ void instr_dump_buffer_uart(void)
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	uint8_t *transferring_buf;
-	uint32_t transferring_length, instr_buffer_max_length;
+	uint32_t transferring_length;
 
 	/* Make sure instrumentation is disabled. */
 	instr_disable();
@@ -304,19 +304,15 @@ void instr_dump_buffer_uart(void)
 	/* Initiator mark */
 	printk("-*-#");
 
-	instr_buffer_max_length = instr_buffer_capacity_get();
-
-	while (!instr_buffer_is_empty()) {
+	while (!ring_buf_is_empty(instr_buffer_get_ring_buf())) {
 		transferring_length =
-			instr_buffer_get_claim(
-					&transferring_buf,
-					instr_buffer_max_length);
+			ring_buf_get_ptr(instr_buffer_get_ring_buf(), &transferring_buf, 0);
 
 		for (uint32_t i = 0; i < transferring_length; i++) {
 			uart_poll_out(uart_dev, transferring_buf[i]);
 		}
 
-		instr_buffer_get_finish(transferring_length);
+		ring_buf_consume(instr_buffer_get_ring_buf(), transferring_length);
 	}
 
 	/* Terminator mark */
@@ -506,30 +502,12 @@ static void set_up_record(struct instr_record *record, enum instr_event_types ty
 
 static bool instr_record_data_put(struct instr_record *record)
 {
-	uint32_t total_size = 0U;
-
-	uint8_t *data = (uint8_t *) record, *buf;
-	uint32_t length = sizeof(struct instr_record), claimed_size;
-
 	/* If record won't fit, free enough space in the buffer */
-	if (instr_buffer_space_get() < sizeof(struct instr_record)) {
-		instr_buffer_get(NULL, sizeof(struct instr_record));
+	if (ring_buf_space_get(instr_buffer_get_ring_buf()) < sizeof(struct instr_record)) {
+		ring_buf_consume(instr_buffer_get_ring_buf(), sizeof(struct instr_record));
 	}
 
-	do {
-		claimed_size = instr_buffer_put_claim(&buf, length);
-		memcpy(buf, data, claimed_size);
-		total_size += claimed_size;
-		length -= claimed_size;
-		data += claimed_size;
-	} while (length && claimed_size);
-
-	if (length && claimed_size == 0) {
-		instr_buffer_put_finish(0);
-		return false;
-	}
-
-	instr_buffer_put_finish(total_size);
+	ring_buf_put(instr_buffer_get_ring_buf(), (uint8_t *)record, sizeof(struct instr_record));
 	return true;
 }
 
@@ -585,7 +563,8 @@ void instr_event_handler(enum instr_event_types type, void *callee, void *caller
 		struct instr_record record;
 
 		if (!IS_ENABLED(CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_BUFFER_OVERWRITE) &&
-				instr_buffer_space_get() < sizeof(struct instr_record)) {
+		    ring_buf_space_get(instr_buffer_get_ring_buf()) <
+			    sizeof(struct instr_record)) {
 			_instr_tracing_disabled = true;
 			return;
 		}

--- a/subsys/instrumentation/include/instr_buffer.h
+++ b/subsys/instrumentation/include/instr_buffer.h
@@ -9,6 +9,7 @@
 
 #include <stdbool.h>
 #include <zephyr/types.h>
+#include <zephyr/sys/ring_buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,89 +21,11 @@ extern "C" {
 void instr_buffer_init(void);
 
 /**
- * @brief Instrumentation buffer is empty or not.
+ * @brief Get the instrumentation ring buffer.
  *
- * @return true if the ring buffer is empty, or false if not.
+ * @return Pointer to the instrumentation ring buffer.
  */
-bool instr_buffer_is_empty(void);
-
-/**
- * @brief Get free space in the instrumentation buffer.
- *
- * @return Instrumentation buffer free space (in bytes).
- */
-uint32_t instr_buffer_space_get(void);
-
-/**
- * @brief Get instrumentation buffer capacity (max size).
- *
- * @return Instrumentation buffer capacity (in bytes).
- */
-uint32_t instr_buffer_capacity_get(void);
-
-/**
- * @brief Try to allocate buffer in the instrumentation buffer.
- *
- * @param data Pointer to the address. It's set to a location
- *             within the instrumentation buffer.
- * @param size Requested buffer size (in bytes).
- *
- * @return Size of allocated buffer which can be smaller than
- *         requested if there isn't enough free space or buffer wraps.
- */
-uint32_t instr_buffer_put_claim(uint8_t **data, uint32_t size);
-
-/**
- * @brief Indicate number of bytes written to the allocated buffer.
- *
- * @param size Number of bytes written to the allocated buffer.
- *
- * @retval 0 Successful operation.
- * @retval -EINVAL Given @a size exceeds free space of instrumentation buffer.
- */
-int instr_buffer_put_finish(uint32_t size);
-
-/**
- * @brief Write data to instrumentation buffer.
- *
- * @param data Address of data.
- * @param size Data size (in bytes).
- *
- * @retval Number of bytes written to instrumentation buffer.
- */
-uint32_t instr_buffer_put(uint8_t *data, uint32_t size);
-
-/**
- * @brief Get address of the first valid data in instrumentation buffer.
- *
- * @param data Pointer to the address. It's set to a location pointing to
- *             the first valid data within the instrumentation buffer.
- * @param size Requested buffer size (in bytes).
- *
- * @return Size of valid buffer which can be smaller than requested
- *         if there isn't enough valid data or buffer wraps.
- */
-uint32_t instr_buffer_get_claim(uint8_t **data, uint32_t size);
-
-/**
- * @brief Indicate number of bytes read from claimed buffer.
- *
- * @param size Number of bytes read from claimed buffer.
- *
- * @retval 0 Successful operation.
- * @retval -EINVAL Given @a size exceeds available data of instrumentation buffer.
- */
-int instr_buffer_get_finish(uint32_t size);
-
-/**
- * @brief Read data from instrumentation buffer to output buffer.
- *
- * @param data Address of the output buffer.
- * @param size Data size (in bytes).
- *
- * @retval Number of bytes written to the output buffer.
- */
-uint32_t instr_buffer_get(uint8_t *data, uint32_t size);
+struct ring_buf *instr_buffer_get_ring_buf(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/instrumentation/ringbuffer/ringbuffer.c
+++ b/subsys/instrumentation/ringbuffer/ringbuffer.c
@@ -10,53 +10,13 @@
 static struct ring_buf instr_ring_buf;
 static uint8_t instr_buffer[CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_TRACE_BUFFER_SIZE + 1];
 
-uint32_t instr_buffer_put_claim(uint8_t **data, uint32_t size)
+struct ring_buf *instr_buffer_get_ring_buf(void)
 {
-	return ring_buf_put_claim(&instr_ring_buf, data, size);
-}
-
-int instr_buffer_put_finish(uint32_t size)
-{
-	return ring_buf_put_finish(&instr_ring_buf, size);
-}
-
-uint32_t instr_buffer_put(uint8_t *data, uint32_t size)
-{
-	return ring_buf_put(&instr_ring_buf, data, size);
-}
-
-uint32_t instr_buffer_get_claim(uint8_t **data, uint32_t size)
-{
-	return ring_buf_get_claim(&instr_ring_buf, data, size);
-}
-
-int instr_buffer_get_finish(uint32_t size)
-{
-	return ring_buf_get_finish(&instr_ring_buf, size);
-}
-
-uint32_t instr_buffer_get(uint8_t *data, uint32_t size)
-{
-	return ring_buf_get(&instr_ring_buf, data, size);
+	return &instr_ring_buf;
 }
 
 void instr_buffer_init(void)
 {
 	ring_buf_init(&instr_ring_buf,
 		      sizeof(instr_buffer), instr_buffer);
-}
-
-bool instr_buffer_is_empty(void)
-{
-	return ring_buf_is_empty(&instr_ring_buf);
-}
-
-uint32_t instr_buffer_capacity_get(void)
-{
-	return ring_buf_capacity_get(&instr_ring_buf);
-}
-
-uint32_t instr_buffer_space_get(void)
-{
-	return ring_buf_space_get(&instr_ring_buf);
 }


### PR DESCRIPTION
Migrates the instrumentation subsystem ring buffer to the new zero-copy
ring_buf get_ptr/put_ptr API and drops the local claim/finish-based
wrappers in instr_buffer.

No functional change; mechanical API migration.

Depends on the new ring_buf _ptr API (base #106290).
