### PR TITLE
tracing: refactor tracing_buffer to zero-copy ring_buf API

### DIFF
--- a/subsys/tracing/include/tracing_buffer.h
+++ b/subsys/tracing/include/tracing_buffer.h
@@ -9,6 +9,7 @@
 
 #include <stdbool.h>
 #include <zephyr/types.h>
+#include <zephyr/sys/ring_buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,91 +21,6 @@ extern "C" {
 void tracing_buffer_init(void);
 
 /**
- * @brief Tracing buffer is empty or not.
- *
- * @return true if the ring buffer is empty, or false if not.
- */
-bool tracing_buffer_is_empty(void);
-
-/**
- * @brief Get free space in the tracing buffer.
- *
- * @return Tracing buffer free space (in bytes).
- */
-uint32_t tracing_buffer_space_get(void);
-
-/**
- * @brief Get tracing buffer capacity (max size).
- *
- * @return Tracing buffer capacity (in bytes).
- */
-uint32_t tracing_buffer_capacity_get(void);
-
-/**
- * @brief Try to allocate buffer in the tracing buffer.
- *
- * @param data Pointer to the address. It's set to a location
- *             within the tracing buffer.
- * @param size Requested buffer size (in bytes).
- *
- * @return Size of allocated buffer which can be smaller than
- *         requested if there isn't enough free space or buffer wraps.
- */
-uint32_t tracing_buffer_put_claim(uint8_t **data, uint32_t size);
-
-/**
- * @brief Indicate number of bytes written to the allocated buffer.
- *
- * @param size Number of bytes written to the allocated buffer.
- *
- * @retval 0 Successful operation.
- * @retval -EINVAL Given @a size exceeds free space of tracing buffer.
- */
-int tracing_buffer_put_finish(uint32_t size);
-
-/**
- * @brief Write data to tracing buffer.
- *
- * @param data Address of data.
- * @param size Data size (in bytes).
- *
- * @retval Number of bytes written to tracing buffer.
- */
-uint32_t tracing_buffer_put(uint8_t *data, uint32_t size);
-
-/**
- * @brief Get address of the first valid data in tracing buffer.
- *
- * @param data Pointer to the address. It's set to a location pointing to
- *             the first valid data within the tracing buffer.
- * @param size Requested buffer size (in bytes).
- *
- * @return Size of valid buffer which can be smaller than requested
- *         if there isn't enough valid data or buffer wraps.
- */
-uint32_t tracing_buffer_get_claim(uint8_t **data, uint32_t size);
-
-/**
- * @brief Indicate number of bytes read from claimed buffer.
- *
- * @param size Number of bytes read from claimed buffer.
- *
- * @retval 0 Successful operation.
- * @retval -EINVAL Given @a size exceeds available data of tracing buffer.
- */
-int tracing_buffer_get_finish(uint32_t size);
-
-/**
- * @brief Read data from tracing buffer to output buffer.
- *
- * @param data Address of the output buffer.
- * @param size Data size (in bytes).
- *
- * @retval Number of bytes written to the output buffer.
- */
-uint32_t tracing_buffer_get(uint8_t *data, uint32_t size);
-
-/**
  * @brief Get buffer from tracing command buffer.
  *
  * @param data Pointer to tracing command buffer start address.
@@ -112,6 +28,13 @@ uint32_t tracing_buffer_get(uint8_t *data, uint32_t size);
  * @return Tracing command buffer size (in bytes).
  */
 uint32_t tracing_cmd_buffer_alloc(uint8_t **data);
+
+/**
+ * @brief Get the tracing ring buffer.
+ *
+ * @return Pointer to the tracing ring buffer.
+ */
+struct ring_buf *tracing_buffer_get_ring_buf(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/include/tracing_format_common.h
+++ b/subsys/tracing/include/tracing_format_common.h
@@ -9,6 +9,7 @@
 
 #include <stdarg.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/ring_buffer.h>
 #include <zephyr/tracing/tracing_format.h>
 
 #ifdef __cplusplus
@@ -21,6 +22,7 @@ extern "C" {
 typedef struct {
 	int status;
 	uint32_t length;
+	struct ring_buf *rb;
 } tracing_ctx_t;
 
 /**

--- a/subsys/tracing/tracing_buffer.c
+++ b/subsys/tracing/tracing_buffer.c
@@ -17,53 +17,13 @@ uint32_t tracing_cmd_buffer_alloc(uint8_t **data)
 	return sizeof(tracing_cmd_buffer);
 }
 
-uint32_t tracing_buffer_put_claim(uint8_t **data, uint32_t size)
+struct ring_buf *tracing_buffer_get_ring_buf(void)
 {
-	return ring_buf_put_claim(&tracing_ring_buf, data, size);
-}
-
-int tracing_buffer_put_finish(uint32_t size)
-{
-	return ring_buf_put_finish(&tracing_ring_buf, size);
-}
-
-uint32_t tracing_buffer_put(uint8_t *data, uint32_t size)
-{
-	return ring_buf_put(&tracing_ring_buf, data, size);
-}
-
-uint32_t tracing_buffer_get_claim(uint8_t **data, uint32_t size)
-{
-	return ring_buf_get_claim(&tracing_ring_buf, data, size);
-}
-
-int tracing_buffer_get_finish(uint32_t size)
-{
-	return ring_buf_get_finish(&tracing_ring_buf, size);
-}
-
-uint32_t tracing_buffer_get(uint8_t *data, uint32_t size)
-{
-	return ring_buf_get(&tracing_ring_buf, data, size);
+	return &tracing_ring_buf;
 }
 
 void tracing_buffer_init(void)
 {
 	ring_buf_init(&tracing_ring_buf,
 		      sizeof(tracing_buffer), tracing_buffer);
-}
-
-bool tracing_buffer_is_empty(void)
-{
-	return ring_buf_is_empty(&tracing_ring_buf);
-}
-
-uint32_t tracing_buffer_capacity_get(void)
-{
-	return ring_buf_capacity_get(&tracing_ring_buf);
-}
-
-uint32_t tracing_buffer_space_get(void)
-{
-	return ring_buf_space_get(&tracing_ring_buf);
 }

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/ring_buffer.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
 #include <tracing_backend.h>
@@ -53,25 +54,22 @@ static K_THREAD_STACK_DEFINE(tracing_thread_stack,
 
 static void tracing_thread_func(void *dummy1, void *dummy2, void *dummy3)
 {
-	uint8_t *transferring_buf;
-	uint32_t transferring_length, tracing_buffer_max_length;
+	uint8_t *buf;
+	uint32_t len;
+	struct ring_buf *rb = tracing_buffer_get_ring_buf();
 
 	tracing_thread_tid = k_current_get();
 
-	tracing_buffer_max_length = tracing_buffer_capacity_get();
-
 	while (true) {
-		if (tracing_buffer_is_empty()) {
-			k_sem_take(&tracing_thread_sem, K_FOREVER);
-		} else {
-			transferring_length =
-				tracing_buffer_get_claim(
-						&transferring_buf,
-						tracing_buffer_max_length);
-			tracing_buffer_handle(transferring_buf,
-					      transferring_length);
-			tracing_buffer_get_finish(transferring_length);
+		while (true) {
+			len = ring_buf_get_ptr(rb, &buf, 0);
+			if (len == 0) {
+				break;
+			}
+			tracing_buffer_handle(buf, len);
+			ring_buf_consume(rb, len);
 		}
+		k_sem_take(&tracing_thread_sem, K_FOREVER);
 	}
 }
 

--- a/subsys/tracing/tracing_format_async.c
+++ b/subsys/tracing/tracing_format_async.c
@@ -6,6 +6,7 @@
 
 #define DISABLE_SYSCALL_TRACING
 
+#include <zephyr/sys/ring_buffer.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
 #include <tracing_format_common.h>
@@ -22,7 +23,7 @@ void tracing_format_string(const char *str, ...)
 	va_start(args, str);
 
 	TRACING_LOCK();
-	before_put_is_empty = tracing_buffer_is_empty();
+	before_put_is_empty = ring_buf_is_empty(tracing_buffer_get_ring_buf());
 	put_success = tracing_format_string_put(str, args);
 	TRACING_UNLOCK();
 
@@ -44,7 +45,7 @@ void tracing_format_raw_data(uint8_t *data, uint32_t length)
 	}
 
 	TRACING_LOCK();
-	before_put_is_empty = tracing_buffer_is_empty();
+	before_put_is_empty = ring_buf_is_empty(tracing_buffer_get_ring_buf());
 	put_success = tracing_format_raw_data_put(data, length);
 	TRACING_UNLOCK();
 
@@ -64,7 +65,7 @@ void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count)
 	}
 
 	TRACING_LOCK();
-	before_put_is_empty = tracing_buffer_is_empty();
+	before_put_is_empty = ring_buf_is_empty(tracing_buffer_get_ring_buf());
 	put_success = tracing_format_data_put(tracing_data_array, count);
 	TRACING_UNLOCK();
 

--- a/subsys/tracing/tracing_format_common.c
+++ b/subsys/tracing/tracing_format_common.c
@@ -6,18 +6,21 @@
 
 #include <string.h>
 #include <zephyr/sys/cbprintf.h>
+#include <zephyr/sys/ring_buffer.h>
+#include <zephyr/sys/minmax.h>
 #include <tracing_buffer.h>
 #include <tracing_format_common.h>
 
 static int str_put(int c, void *ctx)
 {
 	tracing_ctx_t *str_ctx = (tracing_ctx_t *)ctx;
+	struct ring_buf *rb = str_ctx->rb;
 
 	if (str_ctx->status == 0) {
 		uint8_t *buf;
 		uint32_t claimed_size;
 
-		claimed_size = tracing_buffer_put_claim(&buf, 1);
+		claimed_size = ring_buf_put_ptr(rb, &buf, str_ctx->length);
 		if (claimed_size) {
 			*buf = (uint8_t)c;
 			str_ctx->length++;
@@ -31,25 +34,28 @@ static int str_put(int c, void *ctx)
 
 bool tracing_format_string_put(const char *str, va_list args)
 {
+	struct ring_buf *rb = tracing_buffer_get_ring_buf();
 	tracing_ctx_t str_ctx = {0};
+
+	str_ctx.rb = rb;
 
 	(void)cbvprintf(str_put, (void *)&str_ctx, str, args);
 
 	if (str_ctx.status == 0) {
-		tracing_buffer_put_finish(str_ctx.length);
+		ring_buf_commit(rb, str_ctx.length);
 		return true;
 	}
 
-	tracing_buffer_put_finish(0);
 	return false;
 }
 
 bool tracing_format_raw_data_put(uint8_t *data, uint32_t size)
 {
-	uint32_t space = tracing_buffer_space_get();
+	struct ring_buf *rb = tracing_buffer_get_ring_buf();
+	uint32_t space = ring_buf_space_get(rb);
 
 	if (space >= size) {
-		tracing_buffer_put(data, size);
+		ring_buf_put(rb, data, size);
 		return true;
 	}
 
@@ -58,16 +64,18 @@ bool tracing_format_raw_data_put(uint8_t *data, uint32_t size)
 
 bool tracing_format_data_put(tracing_data_t *tracing_data_array, uint32_t count)
 {
+	struct ring_buf *rb = tracing_buffer_get_ring_buf();
 	uint32_t total_size = 0U;
 
 	for (uint32_t i = 0; i < count; i++) {
 		tracing_data_t *tracing_data =
 				tracing_data_array + i;
 		uint8_t *data = tracing_data->data, *buf;
-		uint32_t length = tracing_data->length, claimed_size;
+		uint32_t claimed_size;
+		uint32_t length = tracing_data->length;
 
 		do {
-			claimed_size = tracing_buffer_put_claim(&buf, length);
+			claimed_size = min(ring_buf_put_ptr(rb, &buf, total_size), length);
 			memcpy(buf, data, claimed_size);
 			total_size += claimed_size;
 			length -= claimed_size;
@@ -75,11 +83,10 @@ bool tracing_format_data_put(tracing_data_t *tracing_data_array, uint32_t count)
 		} while (length && claimed_size);
 
 		if (length && claimed_size == 0) {
-			tracing_buffer_put_finish(0);
 			return false;
 		}
 	}
 
-	tracing_buffer_put_finish(total_size);
+	ring_buf_commit(rb, total_size);
 	return true;
 }

--- a/subsys/tracing/tracing_format_sync.c
+++ b/subsys/tracing/tracing_format_sync.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/ring_buffer.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
 #include <tracing_format_common.h>
@@ -13,13 +14,11 @@ void tracing_format_string(const char *str, ...)
 	uint8_t *data;
 	va_list args;
 	bool put_success;
-	uint32_t length, tracing_buffer_size;
+	uint32_t length;
 
 	if (!is_tracing_enabled()) {
 		return;
 	}
-
-	tracing_buffer_size = tracing_buffer_capacity_get();
 
 	va_start(args, str);
 
@@ -27,9 +26,9 @@ void tracing_format_string(const char *str, ...)
 	put_success = tracing_format_string_put(str, args);
 
 	if (put_success) {
-		length = tracing_buffer_get_claim(&data, tracing_buffer_size);
+		length = ring_buf_get_ptr(tracing_buffer_get_ring_buf(), &data, 0);
 		tracing_buffer_handle(data, length);
-		tracing_buffer_get_finish(length);
+		ring_buf_consume(tracing_buffer_get_ring_buf(), length);
 	} else {
 		tracing_packet_drop_handle();
 	}
@@ -53,21 +52,19 @@ void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count)
 {
 	uint8_t *data;
 	bool put_success;
-	uint32_t length, tracing_buffer_size;
+	uint32_t length;
 
 	if (!is_tracing_enabled()) {
 		return;
 	}
 
-	tracing_buffer_size = tracing_buffer_capacity_get();
-
 	TRACING_LOCK();
 	put_success = tracing_format_data_put(tracing_data_array, count);
 
 	if (put_success) {
-		length = tracing_buffer_get_claim(&data, tracing_buffer_size);
+		length = ring_buf_get_ptr(tracing_buffer_get_ring_buf(), &data, 0);
 		tracing_buffer_handle(data, length);
-		tracing_buffer_get_finish(length);
+		ring_buf_consume(tracing_buffer_get_ring_buf(), length);
 	} else {
 		tracing_packet_drop_handle();
 	}


### PR DESCRIPTION
Refactors the tracing buffer to use the new zero-copy ring_buf
get_ptr/put_ptr API instead of the deprecated claim/finish API. This also
removes the now-redundant local wrappers in tracing_buffer, simplifying the
tracing buffer implementation.

No functional change to tracing behavior.

Depends on the new ring_buf _ptr API (base #106290).