### PR TITLE
modem: migrate ring_buf usage to zero-copy _ptr API

### DIFF
--- a/drivers/modem/modem_iface_uart_interrupt.c
+++ b/drivers/modem/modem_iface_uart_interrupt.c
@@ -52,7 +52,7 @@ static void modem_iface_uart_isr(const struct device *uart_dev,
 {
 	struct modem_context *ctx;
 	struct modem_iface_uart_data *data;
-	int rx = 0, ret;
+	int rx = 0;
 	uint8_t *dst;
 	uint32_t partial_size = 0;
 	uint32_t total_size = 0;
@@ -64,20 +64,16 @@ static void modem_iface_uart_isr(const struct device *uart_dev,
 	if (!ctx || !ctx->iface.iface_data) {
 		return;
 	}
+	uart_irq_update(ctx->iface.dev);
+
+	if (uart_irq_rx_ready(ctx->iface.dev) <= 0) {
+		return;
+	}
 
 	data = (struct modem_iface_uart_data *)(ctx->iface.iface_data);
 	/* get all of the data off UART as fast as we can */
 	while (true) {
-		uart_irq_update(ctx->iface.dev);
-
-		if (uart_irq_rx_ready(ctx->iface.dev) <= 0) {
-			break;
-		}
-
-		if (!partial_size) {
-			partial_size = ring_buf_put_claim(&data->rx_rb, &dst,
-							  UINT32_MAX);
-		}
+		partial_size = ring_buf_put_ptr(&data->rx_rb, &dst, 0);
 		if (!partial_size) {
 			if (data->hw_flow_control) {
 				uart_irq_rx_disable(ctx->iface.dev);
@@ -90,16 +86,11 @@ static void modem_iface_uart_isr(const struct device *uart_dev,
 
 		rx = uart_fifo_read(ctx->iface.dev, dst, partial_size);
 		if (rx <= 0) {
-			continue;
+			break;
 		}
-
-		dst += rx;
+		ring_buf_commit(&data->rx_rb, rx);
 		total_size += rx;
-		partial_size -= rx;
 	}
-
-	ret = ring_buf_put_finish(&data->rx_rb, total_size);
-	__ASSERT_NO_MSG(ret == 0);
 
 	if (total_size > 0) {
 		k_sem_give(&data->rx_sem);

--- a/subsys/modem/backends/modem_backend_uart_isr.c
+++ b/subsys/modem/backends/modem_backend_uart_isr.c
@@ -31,7 +31,7 @@ static void modem_backend_uart_isr_irq_handler_receive_ready(struct modem_backen
 	int ret;
 
 	receive_rb = &backend->isr.receive_rdb[backend->isr.receive_rdb_used];
-	size = ring_buf_put_claim(receive_rb, &buffer, UINT32_MAX);
+	size = ring_buf_put_ptr(receive_rb, &buffer, 0);
 	if (size == 0) {
 		/* This can be caused by
 		 * - a too long CONFIG_MODEM_BACKEND_UART_ISR_RECEIVE_IDLE_TIMEOUT_MS
@@ -39,17 +39,15 @@ static void modem_backend_uart_isr_irq_handler_receive_ready(struct modem_backen
 		 * relatively to the (too high) baud rate and amount of incoming data.
 		 */
 		LOG_WRN("Receive buffer overrun");
-		ring_buf_put_finish(receive_rb, 0);
 		ring_buf_reset(receive_rb);
-		size = ring_buf_put_claim(receive_rb, &buffer, UINT32_MAX);
+		size = ring_buf_put_ptr(receive_rb, &buffer, 0);
 	}
 
 	ret = uart_fifo_read(backend->uart, buffer, size);
 	if (ret <= 0) {
-		ring_buf_put_finish(receive_rb, 0);
 		return;
 	}
-	ring_buf_put_finish(receive_rb, (uint32_t)ret);
+	ring_buf_commit(receive_rb, (uint32_t)ret);
 
 	if (ring_buf_space_get(receive_rb) > ring_buf_capacity_get(receive_rb) / 20) {
 		/*
@@ -77,12 +75,10 @@ static void modem_backend_uart_isr_irq_handler_transmit_ready(struct modem_backe
 		return;
 	}
 
-	size = ring_buf_get_claim(&backend->isr.transmit_rb, &buffer, UINT32_MAX);
+	size = ring_buf_get_ptr(&backend->isr.transmit_rb, &buffer, 0);
 	ret = uart_fifo_fill(backend->uart, buffer, size);
-	if (ret < 0) {
-		ring_buf_get_finish(&backend->isr.transmit_rb, 0);
-	} else {
-		ring_buf_get_finish(&backend->isr.transmit_rb, (uint32_t)ret);
+	if (ret >= 0) {
+		ring_buf_consume(&backend->isr.transmit_rb, (uint32_t)ret);
 
 		/* Update transmit buf capacity tracker */
 		atomic_sub(&backend->isr.transmit_buf_len, (uint32_t)ret);

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1769,11 +1769,11 @@ static void modem_cmux_transmit_handler(struct k_work *item)
 			break;
 		}
 
-		reserved_size = ring_buf_get_claim(&cmux->transmit_rb, &reserved, UINT32_MAX);
+		reserved_size = ring_buf_get_ptr(&cmux->transmit_rb,
+						 &reserved, 0);
 
 		ret = modem_pipe_transmit(cmux->pipe, reserved, reserved_size);
 		if (ret < 0) {
-			ring_buf_get_finish(&cmux->transmit_rb, 0);
 			if (ret != -EPERM) {
 				LOG_ERR("Failed to %s %u bytes. (%d)",
 					"transmit", reserved_size, ret);
@@ -1781,7 +1781,7 @@ static void modem_cmux_transmit_handler(struct k_work *item)
 			break;
 		}
 
-		ring_buf_get_finish(&cmux->transmit_rb, (uint32_t)ret);
+		ring_buf_consume(&cmux->transmit_rb, (uint32_t)ret);
 
 		if (ret < reserved_size) {
 			LOG_DBG("Transmitted only %u out of %u bytes at once.", ret, reserved_size);

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -446,11 +446,11 @@ static void modem_ppp_send_handler(struct k_work *item)
 		}
 
 		/* Claim as much space as possible */
-		reserved_size = ring_buf_put_claim(&ppp->transmit_rb, &reserved, UINT32_MAX);
+		reserved_size = ring_buf_put_ptr(&ppp->transmit_rb, &reserved, 0);
 		/* Push wrapped data into claimed buffer */
 		pushed = modem_ppp_wrap(ppp, reserved, reserved_size);
 		/* Limit claimed data to what was actually pushed */
-		ring_buf_put_finish(&ppp->transmit_rb, pushed);
+		ring_buf_commit(&ppp->transmit_rb, pushed);
 
 		if (ppp->transmit_state == MODEM_PPP_TRANSMIT_STATE_IDLE) {
 			net_pkt_unref(ppp->tx_pkt);
@@ -463,15 +463,14 @@ static void modem_ppp_send_handler(struct k_work *item)
 #endif
 
 	while (!ring_buf_is_empty(&ppp->transmit_rb)) {
-		reserved_size = ring_buf_get_claim(&ppp->transmit_rb, &reserved, UINT32_MAX);
+		reserved_size = ring_buf_get_ptr(&ppp->transmit_rb, &reserved, 0);
 
 		ret = modem_pipe_transmit(ppp->pipe, reserved, reserved_size);
 		if (ret < 0) {
-			ring_buf_get_finish(&ppp->transmit_rb, 0);
 			break;
 		}
 
-		ring_buf_get_finish(&ppp->transmit_rb, (uint32_t)ret);
+		ring_buf_consume(&ppp->transmit_rb, (uint32_t)ret);
 
 		if (ret < reserved_size) {
 			break;

--- a/tests/subsys/modem/backends/uart/src/main.c
+++ b/tests/subsys/modem/backends/uart/src/main.c
@@ -122,7 +122,7 @@ static int transmit_prng(uint32_t remaining)
 	int ret;
 
 	fill_transmit_ring_buf();
-	reserved_size = ring_buf_get_claim(&transmit_ring_buf, &reserved, UINT32_MAX);
+	reserved_size = ring_buf_get_ptr(&transmit_ring_buf, &reserved, 0);
 	transmit_size = MIN(transmit_size_prng_random(), reserved_size);
 	transmit_size = MIN(remaining, transmit_size);
 	ret = modem_pipe_transmit(pipe, reserved, transmit_size);
@@ -131,7 +131,7 @@ static int transmit_prng(uint32_t remaining)
 	}
 	printk("TX: %u,%u\n", transmit_size, (uint32_t)ret);
 	__ASSERT(ret <= remaining, "Impossible number of bytes sent %u", (uint32_t)ret);
-	ring_buf_get_finish(&transmit_ring_buf, ret);
+	ring_buf_consume(&transmit_ring_buf, ret);
 	return ret;
 }
 


### PR DESCRIPTION
Migrates the modem drivers and modem subsystem from the deprecated
ring_buf claim/finish API to the new zero-copy get_ptr/put_ptr API.

No functional change; mechanical API migration.

Depends on the new ring_buf _ptr API (base #106290).
