### PR TITLE
net: drivers: migrate ring_buf users to zero-copy _ptr API

### DIFF
--- a/drivers/ethernet/offload/eth_wch9120.c
+++ b/drivers/ethernet/offload/eth_wch9120.c
@@ -310,8 +310,7 @@ static int ch9120_configure_interrupt(void)
 static void ch9120_uart_cb(const struct device *uart_dev, void *user_data)
 {
 	int rx;
-	int ret;
-	uint32_t claimed_len = 0;
+	uint32_t space;
 	uint32_t total_size = 0;
 	uint8_t *buf;
 	struct ch9120_runtime *data = (struct ch9120_runtime *)user_data;
@@ -329,42 +328,25 @@ static void ch9120_uart_cb(const struct device *uart_dev, void *user_data)
 	if (uart_irq_rx_ready(uart_dev) > 0) {
 
 		while (true) {
-
-			if (!claimed_len) {
-				if (total_size > 0) {
-					ret = ring_buf_put_finish(&sck->rx_buf, total_size);
-					__ASSERT_NO_MSG(ret == 0);
-					total_size = 0;
-				}
-
-				claimed_len = ring_buf_put_claim(&sck->rx_buf, &buf, UINT32_MAX);
-			}
-
-			if (!claimed_len) {
+			space = ring_buf_put_ptr(&sck->rx_buf, &buf, total_size);
+			if (!space) {
 				LOG_ERR("Rx buffer doesn't have enough space");
 				ch9120_uart_flush_rx_fifo(uart_dev);
 				break;
 			}
 
-			rx = uart_fifo_read(uart_dev, buf, claimed_len);
+			rx = uart_fifo_read(uart_dev, buf, space);
 			if (rx <= 0) {
 				break;
 			}
 
-			buf += rx;
 			total_size += rx;
-			claimed_len -= rx;
 		}
 	}
 
 	if (total_size > 0) {
-		ret = ring_buf_put_finish(&sck->rx_buf, total_size);
-		__ASSERT_NO_MSG(ret == 0);
+		ring_buf_commit(&sck->rx_buf, total_size);
 		k_sem_give(&sck->rx_sem);
-	} else {
-		if (claimed_len > 0) {
-			ring_buf_put_finish(&sck->rx_buf, 0);
-		}
 	}
 }
 

--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_uart.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_uart.c
@@ -70,27 +70,25 @@ static void ot_uart_rx_cb(struct k_work *item)
 	uint8_t *data;
 	uint32_t len;
 
-	len = ring_buf_get_claim(otuart->rx_ringbuf, &data,
-				 otuart->rx_ringbuf->size);
+	len = ring_buf_get_ptr(otuart->rx_ringbuf, &data, 0);
 	if (len > 0) {
 		otuart->cb(data, len, otuart->param);
-		ring_buf_get_finish(otuart->rx_ringbuf, len);
+		ring_buf_consume(otuart->rx_ringbuf, len);
 	}
 }
 
 static void uart_tx_handle(const struct device *dev)
 {
-	uint32_t tx_len = 0, len;
+	int rc;
+	uint32_t tx_len;
+	uint32_t len;
 	uint8_t *data;
 
-	len = ring_buf_get_claim(
-		ot_uart.tx_ringbuf, &data,
-		ot_uart.tx_ringbuf->size);
+	len = ring_buf_get_ptr(ot_uart.tx_ringbuf, &data, 0);
 	if (len > 0) {
-		tx_len = uart_fifo_fill(dev, data, len);
-		int err = ring_buf_get_finish(ot_uart.tx_ringbuf, tx_len);
-		(void)err;
-		__ASSERT_NO_MSG(err == 0);
+		rc = uart_fifo_fill(dev, data, len);
+		tx_len = rc > 0 ? (uint32_t)rc : 0;
+		ring_buf_consume(ot_uart.tx_ringbuf, tx_len);
 	} else {
 		uart_irq_tx_disable(dev);
 	}
@@ -98,18 +96,16 @@ static void uart_tx_handle(const struct device *dev)
 
 static void uart_rx_handle(const struct device *dev)
 {
-	uint32_t rd_len = 0, len;
+	int rc;
+	uint32_t rd_len;
+	uint32_t len;
 	uint8_t *data;
 
-	len = ring_buf_put_claim(
-		ot_uart.rx_ringbuf, &data,
-		ot_uart.rx_ringbuf->size);
+	len = ring_buf_put_ptr(ot_uart.rx_ringbuf, &data, 0);
 	if (len > 0) {
-		rd_len = uart_fifo_read(dev, data, len);
-
-		int err = ring_buf_put_finish(ot_uart.rx_ringbuf, rd_len);
-		(void)err;
-		__ASSERT_NO_MSG(err == 0);
+		rc = uart_fifo_read(dev, data, len);
+		rd_len = rc > 0 ? (uint32_t)rc : 0;
+		ring_buf_commit(ot_uart.rx_ringbuf, rd_len);
 	}
 }
 

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -914,10 +914,8 @@ static int ppp_consume_ringbuf(struct ppp_driver_context *ppp)
 {
 	uint8_t *data;
 	size_t len, tmp;
-	int ret;
 
-	len = ring_buf_get_claim(&ppp->rx_ringbuf, &data,
-				 CONFIG_NET_PPP_RINGBUF_SIZE);
+	len = ring_buf_get_ptr(&ppp->rx_ringbuf, &data, 0);
 	if (len == 0) {
 		LOG_DBG("Ringbuf %p is empty!", &ppp->rx_ringbuf);
 		return 0;
@@ -939,10 +937,7 @@ static int ppp_consume_ringbuf(struct ppp_driver_context *ppp)
 		}
 	} while (--tmp);
 
-	ret = ring_buf_get_finish(&ppp->rx_ringbuf, len);
-	if (ret < 0) {
-		LOG_DBG("Cannot flush ring buffer (%d)", ret);
-	}
+	ring_buf_consume(&ppp->rx_ringbuf, len);
 
 	return -EAGAIN;
 }

--- a/drivers/wifi/eswifi/eswifi_bus_uart.c
+++ b/drivers/wifi/eswifi/eswifi_bus_uart.c
@@ -60,10 +60,8 @@ static void eswifi_iface_uart_isr(const struct device *uart_dev,
 	int rx = 0;
 	uint8_t *dst;
 	uint32_t partial_size = 0;
-	uint32_t total_size = 0;
 
 	ARG_UNUSED(user_data);
-
 	uart_irq_update(uart->dev);
 
 	if (uart_irq_rx_ready(uart->dev) <= 0) {
@@ -71,10 +69,7 @@ static void eswifi_iface_uart_isr(const struct device *uart_dev,
 	}
 
 	while (true) {
-		if (!partial_size) {
-			partial_size = ring_buf_put_claim(&uart->rx_rb, &dst,
-							  UINT32_MAX);
-		}
+		partial_size = ring_buf_put_ptr(&uart->rx_rb, &dst, 0);
 		if (!partial_size) {
 			LOG_ERR("Rx buffer doesn't have enough space");
 			eswifi_iface_uart_flush(uart);
@@ -85,13 +80,8 @@ static void eswifi_iface_uart_isr(const struct device *uart_dev,
 		if (rx <= 0) {
 			break;
 		}
-
-		dst += rx;
-		total_size += rx;
-		partial_size -= rx;
+		ring_buf_commit(&uart->rx_rb, rx);
 	}
-
-	ring_buf_put_finish(&uart->rx_rb, total_size);
 }
 
 static char get_fsm_char(int fsm)
@@ -114,7 +104,7 @@ static char get_fsm_char(int fsm)
 
 static int eswifi_uart_get_resp(struct eswifi_uart_data *uart)
 {
-	uint8_t c;
+	uint8_t c = 0;
 
 	while (ring_buf_get(&uart->rx_rb, &c, 1) > 0) {
 		LOG_DBG("FSM: %c, RX: 0x%02x : %c",

--- a/modules/openthread/platform/uart.c
+++ b/modules/openthread/platform/uart.c
@@ -57,34 +57,28 @@ static uint16_t write_length;
 
 static void uart_rx_handle(const struct device *dev)
 {
+	int rc;
 	uint8_t *data;
-	uint32_t len;
-	uint32_t rd_len;
 	bool new_data = false;
 
-	do {
-		len = ring_buf_put_claim(
-			ot_uart.rx_ringbuf, &data,
-			ot_uart.rx_ringbuf->size);
-		if (len > 0) {
-			rd_len = uart_fifo_read(dev, data, len);
-			if (rd_len > 0) {
-				new_data = true;
-			}
+	while (true) {
+		rc = ring_buf_put_ptr(ot_uart.rx_ringbuf, &data, 0);
+		if (rc == 0) {
+			uint8_t discard;
 
-			int err = ring_buf_put_finish(
-				ot_uart.rx_ringbuf, rd_len);
-			(void)err;
-			__ASSERT_NO_MSG(err == 0);
-		} else {
-			uint8_t dummy;
-
-			/* No space in the ring buffer - consume byte. */
 			LOG_WRN("RX ring buffer full.");
-
-			rd_len = uart_fifo_read(dev, &dummy, 1);
+			if (uart_fifo_read(dev, &discard, 1) <= 0) {
+				break;
+			}
+			continue;
 		}
-	} while (rd_len && (rd_len == len));
+		rc = uart_fifo_read(dev, data, rc);
+		if (rc <= 0) {
+			break;
+		}
+		ring_buf_commit(ot_uart.rx_ringbuf, rc);
+		new_data = true;
+	}
 
 	if (new_data) {
 		otSysEventSignalPending();
@@ -189,21 +183,12 @@ void otPlatUartSendDone(void)
 void platformUartProcess(otInstance *aInstance)
 {
 	uint32_t len = 0;
-	const uint8_t *data;
+	uint8_t *data;
 
 	/* Process UART RX */
-	while ((len = ring_buf_get_claim(
-			ot_uart.rx_ringbuf,
-			(uint8_t **)&data,
-			ot_uart.rx_ringbuf->size)) > 0) {
-		int err;
-
+	while ((len = ring_buf_get_ptr(ot_uart.rx_ringbuf, &data, 0)) > 0) {
 		otPlatUartReceived(data, len);
-		err = ring_buf_get_finish(
-				ot_uart.rx_ringbuf,
-				len);
-		(void)err;
-		__ASSERT_NO_MSG(err == 0);
+		ring_buf_consume(ot_uart.rx_ringbuf, len);
 	}
 
 	/* Process UART TX */

--- a/subsys/net/lib/ssh/ssh_transport.c
+++ b/subsys/net/lib/ssh/ssh_transport.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(ssh, CONFIG_SSH_LOG_LEVEL);
 
 #include <zephyr/random/random.h>
 #include <zephyr/zvfs/eventfd.h>
+#include <zephyr/sys/minmax.h>
 
 #include <psa/crypto.h>
 
@@ -265,8 +266,7 @@ int ssh_transport_input(struct ssh_transport *transport)
 	switch (transport->recv_state) {
 	case SSH_RECV_STATE_IDENTITY_INIT: {
 		*rx_pkt = (struct ssh_payload) {
-			.size = MIN(sizeof(transport->rx_buf),
-				    SSH_IDENTITY_MAX_LEN),
+			.size = min(sizeof(transport->rx_buf), SSH_IDENTITY_MAX_LEN),
 			.len = 0,
 			.data = transport->rx_buf
 		};
@@ -667,19 +667,19 @@ int update_channels(struct ssh_transport *transport)
 		/* Send any pending data */
 		while (channel->tx_window_rem > 0 && !ring_buf_is_empty(&channel->tx_ring_buf)) {
 			uint8_t *data;
-			uint32_t len = MIN(channel->tx_mtu, channel->tx_window_rem);
+			uint32_t len = min(channel->tx_mtu, channel->tx_window_rem);
 			struct ssh_channel_event event;
 
 			/* Assuming up to 256 bytes overhead for headers and random padding */
 			BUILD_ASSERT(sizeof(transport->tx_buf) > 256);
 
-			len = MIN(len, sizeof(transport->tx_buf) - 256);
-			len = ring_buf_get_claim(&channel->tx_ring_buf, &data, len);
+			len = min(len, sizeof(transport->tx_buf) - 256);
+			len = min(ring_buf_get_ptr(&channel->tx_ring_buf, &data, 0), len);
 			channel->tx_window_rem -= len;
 
 			ret = ssh_connection_send_channel_data(
 				transport, channel->remote_channel, data, len);
-			ring_buf_get_finish(&channel->tx_ring_buf, len);
+			ring_buf_consume(&channel->tx_ring_buf, len);
 			if (ret != 0) {
 				/* Close channel? */
 				break;
@@ -694,20 +694,20 @@ int update_channels(struct ssh_transport *transport)
 		while (channel->tx_window_rem > 0 &&
 		       !ring_buf_is_empty(&channel->tx_stderr_ring_buf)) {
 			uint8_t *data;
-			uint32_t len = MIN(channel->tx_mtu, channel->tx_window_rem);
+			uint32_t len = min(channel->tx_mtu, channel->tx_window_rem);
 			struct ssh_channel_event event;
 
 			/* Assuming up to 256 bytes overhead for headers and random padding */
 			BUILD_ASSERT(sizeof(transport->tx_buf) > 256);
 
-			len = MIN(len, sizeof(transport->tx_buf) - 256);
-			len = ring_buf_get_claim(&channel->tx_stderr_ring_buf, &data, len);
+			len = min(len, sizeof(transport->tx_buf) - 256);
+			len = min(ring_buf_get_ptr(&channel->tx_stderr_ring_buf, &data, 0), len);
 			channel->tx_window_rem -= len;
 
 			ret = ssh_connection_send_channel_extended_data(
 				transport, channel->remote_channel,
 				SSH_EXTENDED_DATA_STDERR, data, len);
-			ring_buf_get_finish(&channel->tx_stderr_ring_buf, len);
+			ring_buf_consume(&channel->tx_stderr_ring_buf, len);
 			if (ret != 0) {
 				/* Close channel? */
 				break;
@@ -723,7 +723,7 @@ int update_channels(struct ssh_transport *transport)
 		if (channel->rx_window_rem == 0) {
 			uint32_t available_space;
 
-			available_space = MIN(ring_buf_space_get(&channel->rx_ring_buf),
+			available_space = min(ring_buf_space_get(&channel->rx_ring_buf),
 					      ring_buf_space_get(&channel->rx_stderr_ring_buf));
 			if (available_space > 0) {
 				channel->rx_window_rem = available_space;


### PR DESCRIPTION
Migrates the networking subsystem and network drivers from the deprecated
ring_buf claim/finish API to the new zero-copy get_ptr/put_ptr API.

No functional change; mechanical API migration.

Depends on the new ring_buf _ptr API (base #106290).
