### PR TITLE
serial/console/shell: migrate ring_buf users to zero-copy _ptr API

### DIFF
--- a/drivers/serial/uart_bitbang.c
+++ b/drivers/serial/uart_bitbang.c
@@ -265,9 +265,9 @@ static void uart_bitbang_tx_counter_top_interrupt(const struct device *dev, void
 	switch (data->tx_state) {
 	case UART_BITBANG_IDLE:
 		/* Claim the next data */
-		size = ring_buf_get_claim(data->tx_ringbuf, (uint8_t **)&data->tx_data,
-					  sizeof(uint16_t));
-		if (size == sizeof(uint16_t)) {
+		size = ring_buf_get_ptr(data->tx_ringbuf,
+					(uint8_t **)&data->tx_data, 0);
+		if (sizeof(uint16_t) <= size) {
 			/* Start next transmission */
 			data->tx_index = 0;
 			data->tx_parity = uart_bitbang_compute_parity(uart_dev, *data->tx_data);
@@ -333,7 +333,7 @@ static void uart_bitbang_tx_counter_top_interrupt(const struct device *dev, void
 		break;
 	case UART_BITBANG_COMPLETE:
 		/* Terminate current transfer */
-		ring_buf_get_finish(data->tx_ringbuf, sizeof(uint16_t));
+		ring_buf_consume(data->tx_ringbuf, sizeof(uint16_t));
 		data->tx_state = UART_BITBANG_IDLE;
 		break;
 	}

--- a/drivers/serial/uart_bridge.c
+++ b/drivers/serial/uart_bridge.c
@@ -137,8 +137,8 @@ static void uart_bridge_handle_rx(const struct device *dev,
 		&data->peer[uart_bridge_get_idx(dev, bridge_dev, true)];
 
 	uint8_t *recv_buf;
-	int rb_len, recv_len;
-	int ret;
+	uint32_t rb_len;
+	int recv_len;
 
 	if (ring_buf_space_get(&own_data->rb) < RING_BUF_FULL_THRESHOLD) {
 		LOG_DBG("%s: buffer full: pause", dev->name);
@@ -147,7 +147,7 @@ static void uart_bridge_handle_rx(const struct device *dev,
 		return;
 	}
 
-	rb_len = ring_buf_put_claim(&own_data->rb, &recv_buf, RING_BUF_SIZE);
+	rb_len = ring_buf_put_ptr(&own_data->rb, &recv_buf, 0);
 	if (rb_len == 0) {
 		LOG_WRN("%s: ring_buf full", dev->name);
 		return;
@@ -155,17 +155,11 @@ static void uart_bridge_handle_rx(const struct device *dev,
 
 	recv_len = uart_fifo_read(dev, recv_buf, rb_len);
 	if (recv_len < 0) {
-		ring_buf_put_finish(&own_data->rb, 0);
 		LOG_ERR("%s: rx error: %d", dev->name, recv_len);
 		return;
 	}
 
-	ret = ring_buf_put_finish(&own_data->rb, recv_len);
-	if (ret < 0) {
-		LOG_ERR("%s: ring_buf_put_finish error: %d", dev->name, rb_len);
-		return;
-	}
-
+	ring_buf_commit(&own_data->rb, (uint32_t)recv_len);
 	uart_irq_tx_enable(peer_dev);
 }
 
@@ -181,10 +175,10 @@ static void uart_bridge_handle_tx(const struct device *dev,
 		&data->peer[uart_bridge_get_idx(dev, bridge_dev, false)];
 
 	uint8_t *send_buf;
-	int rb_len, sent_len;
-	int ret;
+	uint32_t rb_len;
+	int sent_len;
 
-	rb_len = ring_buf_get_claim(&peer_data->rb, &send_buf, RING_BUF_SIZE);
+	rb_len = ring_buf_get_ptr(&peer_data->rb, &send_buf, 0);
 	if (rb_len == 0) {
 		LOG_DBG("%s: buffer empty, disable tx irq", dev->name);
 		uart_irq_tx_disable(dev);
@@ -193,16 +187,11 @@ static void uart_bridge_handle_tx(const struct device *dev,
 
 	sent_len = uart_fifo_fill(dev, send_buf, rb_len);
 	if (sent_len < 0) {
-		ring_buf_get_finish(&peer_data->rb, 0);
 		LOG_ERR("%s: tx error: %d", dev->name, sent_len);
 		return;
 	}
 
-	ret = ring_buf_get_finish(&peer_data->rb, sent_len);
-	if (ret < 0) {
-		LOG_ERR("ring_buf_get_finish error: %d", ret);
-		return;
-	}
+	ring_buf_consume(&peer_data->rb, (uint32_t)sent_len);
 
 	if (peer_data->paused &&
 	    ring_buf_space_get(&peer_data->rb) > RING_BUF_FULL_THRESHOLD) {

--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -139,7 +139,7 @@ static void tx_work_handler(struct k_work *work)
 		 * peers, and the same chunk is sent to everyone. This avoids
 		 * managing separate read pointers: one per connection.
 		 */
-		len = ring_buf_get_claim(dev_data->uart.tx_ringbuf, &data, chunk_size);
+		len = MIN(ring_buf_get_ptr(dev_data->uart.tx_ringbuf, &data, 0), chunk_size);
 		if (len > 0) {
 			err = bt_nus_inst_send(NULL, dev_data->bt.inst, data, len);
 			if (err) {
@@ -147,7 +147,7 @@ static void tx_work_handler(struct k_work *work)
 			}
 		}
 
-		ring_buf_get_finish(dev_data->uart.tx_ringbuf, len);
+		ring_buf_consume(dev_data->uart.tx_ringbuf, len);
 	} while (len > 0 && !err);
 
 	if ((ring_buf_space_get(dev_data->uart.tx_ringbuf) > 0) && dev_data->uart.tx_irq_ena) {

--- a/samples/drivers/uart/passthrough/src/main.c
+++ b/samples/drivers/uart/passthrough/src/main.c
@@ -70,7 +70,7 @@ static void uart_cb(const struct device *dev, void *ctx)
 			break;
 		}
 
-		len = ring_buf_put_claim(patch->rx_ring_buf, &buf, RING_BUF_SIZE);
+		len = ring_buf_put_ptr(patch->rx_ring_buf, &buf, 0);
 		if (len == 0) {
 			/* no space for Rx, disable the IRQ */
 			uart_irq_rx_disable(patch->rx_dev);
@@ -87,11 +87,7 @@ static void uart_cb(const struct device *dev, void *ctx)
 		}
 		len = ret;
 
-		ret = ring_buf_put_finish(patch->rx_ring_buf, len);
-		if (ret != 0) {
-			patch->rx_error = true;
-			break;
-		}
+		ring_buf_commit(patch->rx_ring_buf, len);
 	}
 }
 
@@ -111,7 +107,7 @@ static void passthrough(struct patch_info *patch)
 		patch->rx_overflow = false;
 	}
 
-	len = ring_buf_get_claim(patch->rx_ring_buf, &buf, RING_BUF_SIZE);
+	len = ring_buf_get_ptr(patch->rx_ring_buf, &buf, 0);
 	if (len == 0) {
 		goto done;
 	}
@@ -122,11 +118,7 @@ static void passthrough(struct patch_info *patch)
 	}
 	len = ret;
 
-	ret = ring_buf_get_finish(patch->rx_ring_buf, len);
-	if (ret < 0) {
-		goto error;
-	}
-
+	ring_buf_consume(patch->rx_ring_buf, len);
 done:
 	uart_irq_rx_enable(patch->rx_dev);
 	return;

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -35,39 +35,35 @@ static void tty_uart_isr(const struct device *dev, void *user_data)
 
 static void uart_rx_handle(const struct device *dev, struct tty_serial *tty)
 {
-	uint8_t *data;
+	int rc;
 	uint32_t len;
-	int rd_len;
+	uint8_t *data;
 	bool new_data = false;
-	int err;
 
-	do {
-		len = ring_buf_put_claim(&tty->rx_buf, &data, ring_buf_capacity_get(&tty->rx_buf));
-		if (len > 0) {
-			rd_len = uart_fifo_read(dev, data, len);
+	while (true) {
+		len = ring_buf_put_ptr(&tty->rx_buf, &data, 0);
+		if (len == 0) {
+			/* No space in the ring buffer - drop one byte and warn user. */
+			uint8_t dummy;
 
-			if (rd_len > 0) {
-				new_data = true;
-			}
-
-			err = ring_buf_put_finish(&tty->rx_buf, rd_len);
-			__ASSERT_NO_MSG(err == 0);
-			ARG_UNUSED(err);
-			if (rd_len < len) {
-				/* No more data in the FIFO, exit loop. */
+			tty_write(tty, "~", 1);
+			if (uart_fifo_read(dev, &dummy, 1) <= 0) {
 				break;
 			}
-		} else {
-			uint8_t dummy;
-			const char dummy_char = '~';
-
-			/* Try to give a clue to user that some input was lost */
-			tty_write(tty, &dummy_char, sizeof(dummy_char));
-
-			/* No space in the ring buffer - consume byte. */
-			rd_len = uart_fifo_read(dev, &dummy, 1);
+			continue;
 		}
-	} while (rd_len > 0);
+
+		rc = uart_fifo_read(dev, data, len);
+		__ASSERT_NO_MSG(rc >= 0);
+		if (rc <= 0) {
+			break;
+		}
+		ring_buf_commit(&tty->rx_buf, (uint32_t)rc);
+		new_data = true;
+		if (rc < len) {
+			break;
+		}
+	}
 
 	if (new_data) {
 		k_event_post(&tty->signal_event, TTY_SIGNAL_RXRDY);
@@ -76,16 +72,17 @@ static void uart_rx_handle(const struct device *dev, struct tty_serial *tty)
 
 static void uart_tx_handle(const struct device *dev, struct tty_serial *tty)
 {
-	uint32_t len;
+	int rc;
+	uint32_t available;
 	uint8_t *data;
-	int err;
 
-	len = ring_buf_get_claim(&tty->tx_buf, &data, ring_buf_capacity_get(&tty->tx_buf));
-	if (len > 0) {
-		len = uart_fifo_fill(dev, data, len);
-		err = ring_buf_get_finish(&tty->tx_buf, len);
-		__ASSERT_NO_MSG(err == 0);
-		ARG_UNUSED(err);
+	available = ring_buf_get_ptr(&tty->tx_buf, &data, 0);
+	if (available > 0) {
+		rc = uart_fifo_fill(dev, data, available);
+		__ASSERT(rc >= 0, "uart_fifo_fill() failed:%d", rc);
+		if (likely(rc > 0)) {
+			ring_buf_consume(&tty->tx_buf, (uint32_t)rc);
+		}
 	} else {
 		uart_irq_tx_disable(dev);
 		atomic_clear(&tty->tx_busy);

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -573,8 +573,8 @@ static void mqtt_evt_handler(struct mqtt_client *const client, const struct mqtt
 
 		while (payload_left > 0) {
 			/* Attempt to claim `payload_left` bytes of buffer in rb */
-			size = (size_t)ring_buf_put_claim(&sh->rx_rb, &sh->rx_rb_ptr,
-							  payload_left);
+			size = (size_t)MIN(ring_buf_put_ptr(&sh->rx_rb, &sh->rx_rb_ptr, 0),
+					   payload_left);
 			/* Read `size` bytes of payload from mqtt */
 			rc = mqtt_read_publish_payload_blocking(client, sh->rx_rb_ptr, size);
 
@@ -586,7 +586,7 @@ static void mqtt_evt_handler(struct mqtt_client *const client, const struct mqtt
 
 			size = (size_t)rc;
 			/* Indicate that `size` bytes of payload has been written into rb */
-			(void)ring_buf_put_finish(&sh->rx_rb, size);
+			ring_buf_commit(&sh->rx_rb, size);
 			/* Update `payload_left` */
 			payload_left -= size;
 			/* Tells the shell that we have new data for it */

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -101,6 +101,7 @@ static void async_callback(const struct device *dev, struct uart_event *evt, voi
 
 static void uart_rx_handle(const struct device *dev, struct shell_uart_int_driven *sh_uart)
 {
+	int rc;
 	uint8_t *data;
 	uint32_t len;
 	uint32_t rd_len;
@@ -110,11 +111,12 @@ static void uart_rx_handle(const struct device *dev, struct shell_uart_int_drive
 #endif
 
 	do {
-		len = ring_buf_put_claim(&sh_uart->rx_ringbuf, &data,
-					 sh_uart->rx_ringbuf.size);
+		len = ring_buf_put_ptr(&sh_uart->rx_ringbuf, &data, 0);
 
 		if (len > 0) {
-			rd_len = uart_fifo_read(dev, data, len);
+			rc = uart_fifo_read(dev, data, len);
+			__ASSERT_NO_MSG(rc >= 0);
+			rd_len = (rc >= 0) ? (uint32_t)rc : 0;
 
 			/* If there is any new data to be either taken into
 			 * ring buffer or consumed by the SMP, signal the
@@ -137,16 +139,15 @@ static void uart_rx_handle(const struct device *dev, struct shell_uart_int_drive
 				}
 			}
 #endif /* CONFIG_MCUMGR_TRANSPORT_SHELL */
-			int err = ring_buf_put_finish(&sh_uart->rx_ringbuf, rd_len);
-			(void)err;
-			__ASSERT_NO_MSG(err == 0);
+			ring_buf_commit(&sh_uart->rx_ringbuf, rd_len);
 		} else {
 			uint8_t dummy;
 
 			/* No space in the ring buffer - consume byte. */
 			LOG_WRN("RX ring buffer full.");
 
-			rd_len = uart_fifo_read(dev, &dummy, 1);
+			rc = uart_fifo_read(dev, &dummy, 1);
+			rd_len = (rc > 0) ? (uint32_t)rc : 0;
 #ifdef CONFIG_MCUMGR_TRANSPORT_SHELL
 			/* If successful in getting byte from the fifo, try
 			 * feeding it to SMP as a part of mcumgr frame.
@@ -198,8 +199,9 @@ static void dtr_timer_handler(struct k_timer *timer)
 
 static void uart_tx_handle(const struct device *dev, struct shell_uart_int_driven *sh_uart)
 {
+	int rc;
 	uint32_t len;
-	const uint8_t *data;
+	uint8_t *data;
 
 	if (!uart_dtr_check(dev)) {
 		/* Wait for DTR signal before sending anything to output. */
@@ -208,15 +210,12 @@ static void uart_tx_handle(const struct device *dev, struct shell_uart_int_drive
 		return;
 	}
 
-	len = ring_buf_get_claim(&sh_uart->tx_ringbuf, (uint8_t **)&data,
-				 sh_uart->tx_ringbuf.size);
+	len = ring_buf_get_ptr(&sh_uart->tx_ringbuf, &data, 0);
 	if (len) {
-		int err;
-
-		len = uart_fifo_fill(dev, data, len);
-		err = ring_buf_get_finish(&sh_uart->tx_ringbuf, len);
-		__ASSERT_NO_MSG(err == 0);
-		ARG_UNUSED(err);
+		rc = uart_fifo_fill(dev, data, len);
+		__ASSERT_NO_MSG(rc >= 0);
+		len = (rc >= 0) ? (uint32_t)rc : 0;
+		ring_buf_consume(&sh_uart->tx_ringbuf, len);
 	} else {
 		uart_irq_tx_disable(dev);
 		atomic_set(&sh_uart->tx_busy, 0);

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -269,8 +269,7 @@ static void tx_work_handler(struct k_work *work)
 		return;
 	}
 
-	len = ring_buf_get_claim(dev_data->tx_ringbuf, &data,
-				 CONFIG_USB_CDC_ACM_RINGBUF_SIZE);
+	len = ring_buf_get_ptr(dev_data->tx_ringbuf, &data, 0);
 
 	if (!len) {
 		LOG_DBG("Nothing to send");
@@ -294,7 +293,7 @@ static void tx_work_handler(struct k_work *work)
 	usb_transfer(ep, data, len, USB_TRANS_WRITE,
 		     cdc_acm_write_cb, dev_data);
 
-	ring_buf_get_finish(dev_data->tx_ringbuf, len);
+	ring_buf_consume(dev_data->tx_ringbuf, len);
 }
 
 static void cdc_acm_read_cb(uint8_t ep, int size, void *priv)

--- a/tests/drivers/uart/uart_async_dual/src/main.c
+++ b/tests/drivers/uart/uart_async_dual/src/main.c
@@ -195,7 +195,7 @@ static void fill_tx(struct test_tx_data *data)
 		return;
 	}
 
-	while ((len = ring_buf_put_claim(&data->rbuf, &buf, 255)) > 0) {
+	while ((len = ring_buf_put_ptr(&data->rbuf, &buf, 0)) > 0) {
 		uint8_t r = (sys_rand8_get() % MAX_PACKET_LEN) % len;
 		uint8_t packet_len = MAX(r, MIN_PACKET_LEN);
 
@@ -205,7 +205,7 @@ static void fill_tx(struct test_tx_data *data)
 			buf[i] = packet_len - i;
 		}
 
-		ring_buf_put_finish(&data->rbuf, packet_len);
+		ring_buf_commit(&data->rbuf, packet_len);
 	}
 }
 
@@ -236,7 +236,7 @@ static void try_tx(const struct device *dev, bool irq)
 			return;
 		}
 
-		len = ring_buf_get_claim(&tx_data.rbuf, &buf, 255);
+		len = MIN(ring_buf_get_ptr(&tx_data.rbuf, &buf, 0), 255U);
 		if (len > 0) {
 			err = uart_tx(dev, buf, len, TX_TIMEOUT);
 			zassert_equal(err, 0,
@@ -295,7 +295,7 @@ static void on_tx_done(const struct device *dev, struct uart_event *evt)
 	}
 
 	/* Finish previous data chunk and start new if any pending. */
-	ring_buf_get_finish(&tx_data.rbuf, evt->data.tx.len);
+	ring_buf_consume(&tx_data.rbuf, evt->data.tx.len);
 	atomic_set(&tx_data.busy, 0);
 	try_tx(dev, true);
 }


### PR DESCRIPTION
Migrates the serial/UART drivers and console-style I/O backends from the
deprecated ring_buf claim/finish API to the new zero-copy
get_ptr/put_ptr API.

No functional change; mechanical API migration.

Depends on the new ring_buf _ptr API (base #106290).
