### PR TITLE
net: dns: Rename struct dns_server to avoid C++ name clash

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1233,6 +1233,13 @@ Bluetooth Services
 Networking
 **********
 
+* The ``struct dns_server`` type nested in :c:struct:`dns_resolve_context` has been
+  renamed to ``struct dns_server_info``. A C++ class member cannot share the name of
+  its enclosing class, so the old tag made ``<zephyr/net/dns_resolve.h>`` impossible to
+  include from C++. No field was renamed, so accesses such as
+  ``ctx->servers[i].dns_server_addr`` are unaffected; only code that names the type
+  itself, for example in a ``CONTAINER_OF()`` call, needs updating.
+
 * Various IP routing related Kconfig options will have now ``IPV6`` prefix added to
   them. This is done so that we can have IPv4 routing symbols that provide same
   functionality as IPv6 ones but can be controlled separately.

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -503,8 +503,8 @@ enum dns_resolve_context_state {
  * DNS resolve context structure.
  */
 struct dns_resolve_context {
-	/** List of configured DNS servers */
-	struct dns_server {
+	/** Information about one configured DNS server */
+	struct dns_server_info {
 		/** DNS server address storage */
 		union {
 			/** DNS server information */
@@ -535,7 +535,7 @@ struct dns_resolve_context {
 		/** Dispatch DNS data between resolver and responder */
 		struct dns_socket_dispatcher dispatcher;
 /** @endcond */
-	} servers[DNS_RESOLVER_MAX_POLL];
+	} servers[DNS_RESOLVER_MAX_POLL]; /**< List of configured DNS servers */
 
 /** @cond INTERNAL_HIDDEN */
 	/** Socket polling for each server connection */

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -252,6 +252,9 @@ struct mqtt_topic_alias {
 
 	/** Topic name size. */
 	uint16_t topic_size;
+#elif defined(CONFIG_CPP)
+	/* C++ does not allow empty structs, add an extra 1 byte. */
+	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };
 
@@ -406,6 +409,9 @@ struct mqtt_common_ack_properties {
 		/** User Property property was present. */
 		bool has_user_prop;
 	} rx;
+#elif defined(CONFIG_CPP)
+	/* C++ does not allow empty structs, add an extra 1 byte. */
+	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };
 
@@ -624,6 +630,9 @@ struct mqtt_disconnect_param {
 			bool has_server_reference;
 		} rx;
 	} prop;
+#elif defined(CONFIG_CPP)
+	/* C++ does not allow empty structs, add an extra 1 byte. */
+	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };
 
@@ -658,6 +667,9 @@ struct mqtt_auth_param {
 			bool has_user_prop;
 		} rx;
 	} prop;
+#elif defined(CONFIG_CPP)
+	/* C++ does not allow empty structs, add an extra 1 byte. */
+	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };
 

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -143,6 +143,7 @@ struct net_pkt {
 
 	/** @cond ignore */
 
+#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP_OPTIONS)
 	/* TCP or UDP are mutually exclusive so they can share the same memory */
 	union {
 #if defined(CONFIG_NET_TCP)
@@ -154,6 +155,7 @@ struct net_pkt {
 		uint16_t udp_opt_surplus_len;
 #endif
 	};
+#endif /* CONFIG_NET_TCP || CONFIG_NET_UDP_OPTIONS */
 
 #if defined(CONFIG_NET_PKT_ORIG_IFACE)
 	struct net_if *orig_iface; /* Original network interface */

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -511,7 +511,7 @@ static int dispatcher_cb(struct dns_socket_dispatcher *my_ctx, int sock,
 			 struct net_buf *dns_data, size_t len)
 {
 	struct dns_resolve_context *ctx = my_ctx->resolve_ctx;
-	struct dns_server *server;
+	struct dns_server_info *server;
 	struct net_buf *dns_cname = NULL;
 	uint16_t query_hash = 0U;
 	uint16_t dns_id = 0U;
@@ -538,7 +538,7 @@ static int dispatcher_cb(struct dns_socket_dispatcher *my_ctx, int sock,
 	 * can both bind the reply to a server we actually queried and handle
 	 * a per-server failure below.
 	 */
-	server = CONTAINER_OF(my_ctx, struct dns_server, dispatcher);
+	server = CONTAINER_OF(my_ctx, struct dns_server_info, dispatcher);
 	server_idx = (int)(server - ctx->servers);
 	if (server_idx < 0 || server_idx >= SERVER_COUNT) {
 		server_idx = -1;
@@ -626,7 +626,7 @@ unlock:
 
 static int register_dispatcher(struct dns_resolve_context *ctx,
 			       const struct net_socket_service_desc *svc,
-			       struct dns_server *server,
+			       struct dns_server_info *server,
 			       struct net_sockaddr *local,
 			       size_t local_len,
 			       const struct net_in6_addr *addr6,

--- a/subsys/net/lib/tftp/tftp_client.c
+++ b/subsys/net/lib/tftp/tftp_client.c
@@ -60,7 +60,7 @@ static int send_data(int sock, struct tftpc *client, uint32_t block_no, const ui
 		.events = ZSOCK_POLLIN,
 	};
 
-	LOG_DBG("Client send data: block no %u, size %u", block_no, data_size + TFTP_HEADER_SIZE);
+	LOG_DBG("Client send data: block no %u, size %zu", block_no, data_size + TFTP_HEADER_SIZE);
 
 	do {
 		if (send_count > TFTP_REQ_RETX) {

--- a/tests/net/cpp/CMakeLists.txt
+++ b/tests/net/cpp/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(net_cpp)
+
+file(GLOB app_sources src/*.cpp)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/net/cpp/prj.conf
+++ b/tests/net/cpp/prj.conf
@@ -1,0 +1,36 @@
+CONFIG_CPP=y
+CONFIG_ZTEST=y
+CONFIG_ZTEST_STACK_SIZE=2048
+
+# CoAP and DHCPv6 pull in sys_rand_get(), which has no implementation on
+# platforms without a hardware entropy driver, such as mps2/an385.
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+CONFIG_NETWORKING=y
+CONFIG_NET_TEST=y
+CONFIG_NET_IPV4=y
+CONFIG_NET_IPV6=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_SOCKETS_SERVICE=y
+
+# The point of this test is to compile as many networking headers as possible
+# in a C++ translation unit, so enable the options that those headers need in
+# order to expose their structures. Adding an option here is only worthwhile if
+# a header in src/main.cpp needs it.
+CONFIG_DNS_RESOLVER=y
+CONFIG_MDNS_RESPONDER=y
+CONFIG_DNS_SD=y
+CONFIG_NET_DHCPV4=y
+CONFIG_NET_DHCPV6=y
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_L2_ETHERNET_MGMT=y
+CONFIG_NET_MGMT=y
+CONFIG_NET_MGMT_EVENT=y
+CONFIG_NET_CONNECTION_MANAGER=y
+CONFIG_NET_HOSTNAME_ENABLE=y
+CONFIG_COAP=y
+CONFIG_COAP_CLIENT=y
+CONFIG_MQTT_LIB=y
+CONFIG_MQTT_SN_LIB=y
+CONFIG_TFTP_LIB=y
+CONFIG_NET_CONFIG_AUTO_INIT=n

--- a/tests/net/cpp/src/main.cpp
+++ b/tests/net/cpp/src/main.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Networking public headers have to be usable from C++ applications. Nothing
+ * here is executed, the value of the test is that every header below is parsed
+ * by a C++ compiler. C++ rejects constructs that C accepts, for example a
+ * struct member sharing the name of the struct that encloses it, and such a
+ * header breaks every C++ application that includes it.
+ *
+ * Add a header here when it is meant to be included by applications. Headers
+ * that only device drivers include are out of scope.
+ */
+
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_stats.h>
+
+#include <zephyr/net/socket.h>
+#include <zephyr/net/socket_poll.h>
+#include <zephyr/net/socket_service.h>
+
+#include <zephyr/net/conn_mgr_connectivity.h>
+#include <zephyr/net/dhcpv4.h>
+#include <zephyr/net/dhcpv6.h>
+#include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/dns_sd.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/ethernet_mgmt.h>
+#include <zephyr/net/hostname.h>
+#include <zephyr/net/icmp.h>
+#include <zephyr/net/mdns_responder.h>
+
+#include <zephyr/net/coap.h>
+#include <zephyr/net/coap_client.h>
+#include <zephyr/net/coap_link_format.h>
+#include <zephyr/net/mqtt.h>
+#include <zephyr/net/mqtt_sn.h>
+#include <zephyr/net/tftp.h>
+
+#include <zephyr/ztest.h>
+
+/* Reference the members that public headers keep for source compatibility, so
+ * that the test covers the members and not only the enclosing types.
+ */
+static struct dns_resolve_context test_dns_ctx;
+static struct coap_pending test_coap_pending;
+
+ZTEST(net_cpp, test_headers_are_cpp_compatible)
+{
+	test_dns_ctx.servers[0].dns_server_addr.ss_family = NET_AF_INET;
+	zassert_equal(test_dns_ctx.servers[0].dns_server.sa_family, NET_AF_INET);
+
+	test_coap_pending.addr_storage.ss_family = NET_AF_INET6;
+	zassert_equal(test_coap_pending.addr.sa_family, NET_AF_INET6);
+}
+
+ZTEST_SUITE(net_cpp, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/cpp/tests.yaml
+++ b/tests/net/cpp/tests.yaml
@@ -1,0 +1,20 @@
+common:
+  depends_on: netif
+  tags:
+    - net
+    - cpp
+  integration_platforms:
+    - native_sim
+    - qemu_x86
+tests:
+  net.cpp.headers: {}
+  # The C++ standard variants only need to compile, the headers they parse are
+  # the same ones the default variant already runs.
+  net.cpp.headers.cpp17:
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP17=y
+  net.cpp.headers.cpp20:
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP20=y


### PR DESCRIPTION
struct dns_resolve_context has a nested struct tagged dns_server whose
first member is also called dns_server. C++ does not allow a member to
share the name of the class that encloses it, as the name collides with
the injected-class-name, so every C++ translation unit that pulls in
<zephyr/net/dns_resolve.h> fails to compile:

  error: 'dns_resolve_context::dns_server::<unnamed union>::dns_server'
  has the same name as the class in which it is declared

The struct used to be anonymous and therefore had no injected-class-name
to collide with. It was given the dns_server tag in commit
https://github.com/zephyrproject-rtos/zephyr/commit/1eb4a709e826893ae206f774ebc835f6aa8a8ad3 ("net: dns: Allow using resolver and responder at the same
time") so that the reply handler could recover the server entry with
CONTAINER_OF(), which is the only thing the tag is used for.

Rename the tag to dns_server_info rather than the member. The member is
what applications actually reference, and the anonymous union it sits in
exists precisely to keep those references working, whereas the tag was
never meant to be part of the API. Nothing else in the struct changes,
so ctx->servers[i].dns_server and ctx->servers[i].dns_server_addr are
untouched.

Fixes #115947
