### PR TITLE
drivers: sensor: fxls8974: honor range property, fix temperature sign and error paths

### DIFF
--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -303,12 +303,14 @@ static int fxls8974_get_accel_data(const struct device *dev,
 		struct fxls8974_data *data = dev->data;
 		int16_t *raw;
 		uint8_t fsr;
+		int ret = 0;
 
 		k_sem_take(&data->sem, K_FOREVER);
 
 		if (cfg->ops->byte_read(dev, FXLS8974_REG_CTRLREG1, &fsr)) {
 			LOG_ERR("Could not read scale settings");
-			return -EIO;
+			ret = -EIO;
+			goto exit;
 		}
 
 		fsr = (fsr & FXLS8974_CTRLREG1_FSR_MASK) >> 1;
@@ -344,13 +346,16 @@ static int fxls8974_get_accel_data(const struct device *dev,
 				raw = &data->raw[FXLS8974_CHANNEL_ACCEL_Z];
 				break;
 			default:
-				return -ENOTSUP;
+				ret = -ENOTSUP;
+				goto exit;
 			}
 			fxls8974_accel_convert(val, *raw, fsr);
 		}
+
+exit:
 		k_sem_give(&data->sem);
 
-		return 0;
+		return ret;
 }
 
 static int fxls8974_get_temp_data(const struct device *dev, struct sensor_value *val)

--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -442,6 +442,7 @@ static int fxls8974_init(const struct device *dev)
 		struct fxls8974_data *data = dev->data;
 		struct sensor_value odr = {.val1 = 6, .val2 = 250000};
 		uint8_t regVal;
+		uint8_t fsr;
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 		const struct i2c_dt_spec i2c_spec = cfg->bus_cfg.i2c;
@@ -527,9 +528,26 @@ static int fxls8974_init(const struct device *dev)
 			return -EIO;
 		}
 
-		/* Set the +-2G mode */
-		if (cfg->ops->byte_write(dev, FXLS8974_REG_CTRLREG1,
-			FXLS8974_CTRLREG1_FSR_2G)) {
+		switch (cfg->range) {
+		case 2:
+			fsr = FXLS8974_CTRLREG1_FSR_2G;
+			break;
+		case 4:
+			fsr = FXLS8974_CTRLREG1_FSR_4G;
+			break;
+		case 8:
+			fsr = FXLS8974_CTRLREG1_FSR_8G;
+			break;
+		case 16:
+			fsr = FXLS8974_CTRLREG1_FSR_16G;
+			break;
+		default:
+			LOG_ERR("Invalid range %d g", cfg->range);
+			return -EINVAL;
+		}
+
+		if (cfg->ops->reg_field_update(dev, FXLS8974_REG_CTRLREG1,
+			FXLS8974_CTRLREG1_FSR_MASK, fsr)) {
 			LOG_ERR("Could not set range");
 			return -EIO;
 		}
@@ -540,7 +558,7 @@ static int fxls8974_init(const struct device *dev)
 			return -EIO;
 		}
 
-		if ((regVal & FXLS8974_CTRLREG1_FSR_MASK) != FXLS8974_CTRLREG1_FSR_2G) {
+		if ((regVal & FXLS8974_CTRLREG1_FSR_MASK) != fsr) {
 			LOG_ERR("Wrong range selected!");
 			return -EIO;
 		}

--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -272,7 +272,7 @@ static int fxls8974_sample_fetch(const struct device *dev, enum sensor_channel c
 			*raw++ = (buf[i+1] << 8) | (buf[i]);
 		}
 
-		*raw = *(buf+FXLS8974_MAX_ACCEL_BYTES);
+		*raw = (int8_t)*(buf+FXLS8974_MAX_ACCEL_BYTES);
 
 exit:
 		k_sem_give(&data->sem);
@@ -366,6 +366,7 @@ static int fxls8974_get_temp_data(const struct device *dev, struct sensor_value 
 		k_sem_take(&data->sem, K_FOREVER);
 		raw = &data->raw[FXLS8974_CHANNEL_TEMP];
 		val->val1 = *raw+FXLS8974_ZERO_TEMP;
+		val->val2 = 0;
 		k_sem_give(&data->sem);
 
 		return 0;


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the FXLS8974/FXLS8964
driver, one commit per issue:

- **Honor devicetree range property**: the `range` property is parsed into
  `cfg->range` and validated by the binding (2/4/8/16 g), but `init()` ignored
  it and hard-coded ±2 g. A board asking for ±16 g silently got ±2 g and
  clipped every reading above 2 g — while `channel_get()`, which reads the
  full-scale field back from CTRLREG1, applied the right sensitivity for
  whatever was actually programmed, so the range mismatch surfaced only as
  saturation. The write now uses a read-modify-write of the FSR field rather
  than overwriting the whole control register.
- **Release semaphore on error paths**: `fxls8974_get_accel_data()` returned
  `-EIO` on a failed CTRLREG1 read and `-ENOTSUP` on an unknown channel while
  still holding `data->sem`. The semaphore is never re-initialized, so a single
  bus glitch or one unsupported-channel query deadlocked every subsequent
  fetch and read on the device permanently.
- **Sign-extend the raw temperature byte**: the temperature register is a
  signed 8-bit value relative to a 25 °C reference, but it was stored into the
  `int16_t` raw array through an unsigned byte, so any negative offset (below
  25 °C) decoded as ~+230 °C. Also zero `val2`, which was left uninitialized in
  the returned `sensor_value`.