### PR TITLE
net: Fixes for code-scanning alerts in include/zephyr/net

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -863,10 +863,12 @@ static inline
 enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = (struct ethernet_api *)dev->api;
+	const struct ethernet_api *api;
 	enum ethernet_hw_caps caps = (enum ethernet_hw_caps)0;
 #if defined(CONFIG_NET_DSA)
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
+
+	NET_ASSERT(eth_ctx != NULL);
 
 	if (eth_ctx->dsa_port == DSA_CONDUIT_PORT) {
 		caps = ETHERNET_DSA_CONDUIT_PORT;
@@ -874,6 +876,9 @@ enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 		caps = ETHERNET_DSA_USER_PORT;
 	}
 #endif
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct ethernet_api *)dev->api;
 	if (api == NULL || api->get_capabilities == NULL) {
 		return caps;
 	}
@@ -895,7 +900,13 @@ int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
 			 struct ethernet_config *config)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *eth = (struct ethernet_api *)dev->api;
+	const struct ethernet_api *eth;
+
+	NET_ASSERT(dev != NULL);
+
+	eth = (const struct ethernet_api *)dev->api;
+
+	NET_ASSERT(eth != NULL);
 
 	if (!eth->get_config) {
 		return -ENOTSUP;
@@ -1466,6 +1477,8 @@ static inline bool net_eth_type_is_wifi(struct net_if *iface)
 	const struct ethernet_context *ctx = (struct ethernet_context *)
 		net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	return ctx->eth_if_type == L2_ETH_IF_TYPE_WIFI;
 }
 
@@ -1480,6 +1493,8 @@ static inline bool net_eth_type_is_ethernet(struct net_if *iface)
 {
 	const struct ethernet_context *ctx = (struct ethernet_context *)net_if_l2_data(iface);
 
+	NET_ASSERT(ctx != NULL);
+
 	return ctx->eth_if_type == L2_ETH_IF_TYPE_ETHERNET;
 }
 
@@ -1491,6 +1506,8 @@ static inline bool net_eth_type_is_ethernet(struct net_if *iface)
 static inline void net_eth_set_if_type_wifi(struct net_if *iface)
 {
 	struct ethernet_context *ctx = (struct ethernet_context *)net_if_l2_data(iface);
+
+	NET_ASSERT(ctx != NULL);
 
 	ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
 }

--- a/include/zephyr/net/ethernet_bridge.h
+++ b/include/zephyr/net/ethernet_bridge.h
@@ -147,6 +147,8 @@ static inline bool net_eth_iface_is_bridged(struct ethernet_context *ctx)
 #if defined(CONFIG_NET_ETHERNET_BRIDGE)
 	struct eth_bridge_iface_context *br_ctx;
 
+	NET_ASSERT(ctx != NULL);
+
 	if (ctx->bridge == NULL) {
 		return false;
 	}
@@ -169,6 +171,8 @@ static inline bool net_eth_iface_is_bridged(struct ethernet_context *ctx)
 static inline struct net_if *net_eth_get_bridge(struct ethernet_context *ctx)
 {
 #if defined(CONFIG_NET_ETHERNET_BRIDGE)
+	NET_ASSERT(ctx != NULL);
+
 	return ctx->bridge;
 #else
 	return NULL;

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -799,6 +799,7 @@ struct net_if *net_context_get_iface(struct net_context *context)
 static inline void net_context_set_iface(struct net_context *context,
 					 struct net_if *iface)
 {
+	NET_ASSERT(context);
 	NET_ASSERT(iface);
 
 	context->iface = (uint8_t)net_if_get_by_iface(iface);
@@ -815,6 +816,7 @@ static inline void net_context_set_iface(struct net_context *context,
 static inline void net_context_bind_iface(struct net_context *context,
 					  struct net_if *iface)
 {
+	NET_ASSERT(context);
 	NET_ASSERT(iface);
 
 	context->flags |= NET_CONTEXT_BOUND_TO_IFACE;

--- a/include/zephyr/net/net_offload.h
+++ b/include/zephyr/net/net_offload.h
@@ -147,11 +147,13 @@ static inline int net_offload_get(struct net_if *iface,
 				  enum net_ip_protocol ip_proto,
 				  struct net_context **context)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->get);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->get(family, type, ip_proto, context);
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->get);
+
+	return offload->get(family, type, ip_proto, context);
 }
 
 /**
@@ -172,11 +174,13 @@ static inline int net_offload_bind(struct net_if *iface,
 				   const struct net_sockaddr *addr,
 				   net_socklen_t addrlen)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->bind);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->bind(context, addr, addrlen);
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->bind);
+
+	return offload->bind(context, addr, addrlen);
 }
 
 /**
@@ -195,11 +199,13 @@ static inline int net_offload_listen(struct net_if *iface,
 				     struct net_context *context,
 				     int backlog)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->listen);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->listen(context, backlog);
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->listen);
+
+	return offload->listen(context, backlog);
 }
 
 /**
@@ -239,11 +245,13 @@ static inline int net_offload_connect(struct net_if *iface,
 				      k_timeout_t timeout,
 				      void *user_data)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->connect);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->connect(
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->connect);
+
+	return offload->connect(
 		context, addr, addrlen, cb,
 		timeout_to_int32(timeout),
 		user_data);
@@ -282,11 +290,13 @@ static inline int net_offload_accept(struct net_if *iface,
 				     k_timeout_t timeout,
 				     void *user_data)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->accept);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->accept(
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->accept);
+
+	return offload->accept(
 		context, cb,
 		timeout_to_int32(timeout),
 		user_data);
@@ -324,11 +334,13 @@ static inline int net_offload_send(struct net_if *iface,
 				   k_timeout_t timeout,
 				   void *user_data)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->send);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->send(
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->send);
+
+	return offload->send(
 		pkt, cb,
 		timeout_to_int32(timeout),
 		user_data);
@@ -370,11 +382,13 @@ static inline int net_offload_sendto(struct net_if *iface,
 				     k_timeout_t timeout,
 				     void *user_data)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->sendto);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->sendto(
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->sendto);
+
+	return offload->sendto(
 		pkt, dst_addr, addrlen, cb,
 		timeout_to_int32(timeout),
 		user_data);
@@ -419,11 +433,13 @@ static inline int net_offload_recv(struct net_if *iface,
 				   k_timeout_t timeout,
 				   void *user_data)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->recv);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->recv(
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->recv);
+
+	return offload->recv(
 		context, cb,
 		timeout_to_int32(timeout),
 		user_data);
@@ -445,11 +461,13 @@ static inline int net_offload_recv(struct net_if *iface,
 static inline int net_offload_put(struct net_if *iface,
 				  struct net_context *context)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(net_if_offload(iface));
-	NET_ASSERT(net_if_offload(iface)->put);
+	struct net_offload *offload = net_if_offload(iface);
 
-	return net_if_offload(iface)->put(context);
+	NET_ASSERT(iface);
+	NET_ASSERT(offload);
+	NET_ASSERT(offload->put);
+
+	return offload->put(context);
 }
 
 #else

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -430,17 +430,17 @@ static inline struct net_if *net_pkt_iface(struct net_pkt *pkt)
 
 static inline void net_pkt_set_iface(struct net_pkt *pkt, struct net_if *iface)
 {
+	struct net_linkaddr *lladdr = net_if_get_link_addr(iface);
+
 	pkt->iface = iface;
 
 	/* If the network interface is set in pkt, then also set the type of
 	 * the network address that is stored in pkt. This is done here so
 	 * that the address type is properly set and is not forgotten.
 	 */
-	if (iface) {
-		uint8_t type = net_if_get_link_addr(iface)->type;
-
-		pkt->lladdr_src.type = type;
-		pkt->lladdr_dst.type = type;
+	if (lladdr != NULL) {
+		pkt->lladdr_src.type = lladdr->type;
+		pkt->lladdr_dst.type = lladdr->type;
 	}
 }
 

--- a/include/zephyr/net/offloaded_netdev.h
+++ b/include/zephyr/net/offloaded_netdev.h
@@ -76,8 +76,14 @@ BUILD_ASSERT(offsetof(struct offloaded_if_api, iface_api) == 0);
  */
 static inline bool net_off_is_wifi_offloaded(struct net_if *iface)
 {
-	const struct offloaded_if_api *api = (const struct offloaded_if_api *)
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct offloaded_if_api *api;
+
+	NET_ASSERT(dev != NULL);
+
+	api = (const struct offloaded_if_api *)dev->api;
+
+	NET_ASSERT(api != NULL);
 
 	return api->get_type && api->get_type() == L2_OFFLOADED_NET_IF_TYPE_WIFI;
 }

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -308,8 +308,14 @@ static inline void net_virtual_enable(struct net_if *iface)
 static inline enum virtual_interface_caps
 net_virtual_get_iface_capabilities(struct net_if *iface)
 {
-	const struct virtual_interface_api *virt =
-		(struct virtual_interface_api *)net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct virtual_interface_api *virt;
+
+	NET_ASSERT(dev != NULL);
+
+	virt = (const struct virtual_interface_api *)dev->api;
+
+	NET_ASSERT(virt != NULL);
 
 	if (!virt->get_capabilities) {
 		return (enum virtual_interface_caps)0;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2873,6 +2873,7 @@ static int context_sendto(struct net_context *context,
 	net_sa_family_t family;
 	size_t alloc_len;
 	size_t tmp_len;
+	uint16_t proto;
 	int ret;
 #if defined(CONFIG_NET_UDP_OPTIONS)
 	struct net_udp_opt_info udp_opts = { 0 };
@@ -3181,8 +3182,9 @@ static int context_sendto(struct net_context *context,
 	context->send_cb = cb;
 	context->user_data = user_data;
 
-	if (IS_ENABLED(CONFIG_NET_TCP) &&
-	    net_context_get_proto(context) == NET_IPPROTO_TCP &&
+	proto = net_context_get_proto(context);
+
+	if (IS_ENABLED(CONFIG_NET_TCP) && proto == NET_IPPROTO_TCP &&
 	    !net_if_is_ip_offloaded(net_context_get_iface(context))) {
 		goto skip_alloc;
 	}
@@ -3193,8 +3195,7 @@ static int context_sendto(struct net_context *context,
 		return -ENOBUFS;
 	}
 
-	tmp_len = net_pkt_available_payload_buffer(
-				pkt, net_context_get_proto(context));
+	tmp_len = net_pkt_available_payload_buffer(pkt, proto);
 	if (tmp_len < alloc_len) {
 		if (net_context_get_type(context) == NET_SOCK_DGRAM ||
 		    net_context_get_type(context) == NET_SOCK_RAW) {
@@ -3260,8 +3261,7 @@ skip_alloc:
 		}
 
 		ret = net_try_send_data(pkt, timeout);
-	} else if (IS_ENABLED(CONFIG_NET_UDP) &&
-	    net_context_get_proto(context) == NET_IPPROTO_UDP) {
+	} else if (IS_ENABLED(CONFIG_NET_UDP) && proto == NET_IPPROTO_UDP) {
 		ret = context_setup_udp_packet(context, family, pkt, buf, len, msghdr,
 					       dst_addr, addrlen, dont_fragment);
 		if (ret < 0) {
@@ -3276,8 +3276,7 @@ skip_alloc:
 		}
 
 		ret = net_try_send_data(pkt, timeout);
-	} else if (IS_ENABLED(CONFIG_NET_TCP) &&
-		   net_context_get_proto(context) == NET_IPPROTO_TCP) {
+	} else if (IS_ENABLED(CONFIG_NET_TCP) && proto == NET_IPPROTO_TCP) {
 
 		ret = net_tcp_queue(context, buf, len, msghdr);
 		if (ret < 0) {


### PR DESCRIPTION
This should be the last batch of code scanning fixes in the Networking subsys itself (excluding tests).

Fix GCC static analyzer NULL-dereference reports in public networking headers under `include/zephyr/net`. Most fixes document invariants with `NET_ASSERT` on derived pointers. Two `net_pkt.h` alerts are resolved at the root in `context_sendto()`, and one `net_pkt_set_iface()` alert is handled with an equivalent link-address guard.

### Alerts fixed

#### net: ethernet: Assert on the device and the context in the inline helpers

- [#1538](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1538) — `include/zephyr/net/ethernet.h:866` — dereference of NULL `dev`
- [#1539](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1539) — `include/zephyr/net/ethernet.h:898` — dereference of NULL `dev`
- [#1536](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1536) — `include/zephyr/net/ethernet.h:1469` — dereference of NULL `ctx`
- [#1537](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1537) — `include/zephyr/net/ethernet.h:1495` — dereference of NULL `ctx`

#### net: bridge: Assert on the ethernet context in the inline helpers

- [#1540](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1540) — `include/zephyr/net/ethernet_bridge.h:150` — dereference of NULL `ctx`
- [#1541](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1541) — `include/zephyr/net/ethernet_bridge.h:172` — dereference of NULL `0`
- [#1542](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1542) — `include/zephyr/net/ethernet_bridge.h:172` — dereference of NULL `ctx`

#### net: offloaded_netdev: Assert on the device and its API

- [#1550](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1550) — `include/zephyr/net/offloaded_netdev.h:79` — dereference of NULL `0`

#### net: virtual: Assert on the device and its API

- [#1551](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1551) — `include/zephyr/net/virtual.h:311` — dereference of NULL `0`

#### net: offload: Fetch the offload API only once in the inline helpers

- [#1544](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1544) — `include/zephyr/net/net_offload.h:179` — dereference of NULL `0`
- [#1545](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1545) — `include/zephyr/net/net_offload.h:377` — dereference of NULL `0`
- [#1546](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1546) — `include/zephyr/net/net_offload.h:426` — dereference of NULL `0`

#### net: pkt: Use the link address as the guard in net_pkt_set_iface()

- [#1548](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1548) — `include/zephyr/net/net_pkt.h:440` — dereference of NULL `0`

#### net: context: Assert on the context in the interface setters

- [#1543](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1543) — `include/zephyr/net/net_context.h:804` — dereference of NULL `context`

#### net: context: Read the socket protocol only once in context_sendto()

- [#1547](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1547) — `include/zephyr/net/net_pkt.h:428` — dereference of NULL `pkt`
- [#1549](https://github.com/zephyrproject-rtos/zephyr/security/code-scanning/1549) — `include/zephyr/net/net_pkt.h:666` — dereference of NULL `pkt`

Fixes #116053