### PR TITLE
drivers: sensor: adltc2990: fix current readings being clobbered and stale acq format

### DIFF
--- a/drivers/sensor/adi/adltc2990/adltc2990.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990.c
@@ -378,26 +378,31 @@ static int fetch_pin_current_value(const struct device *dev,
 				   const enum adltc2990_monitoring_type mode,
 				   const enum adltc2990_monitor_pins pin)
 {
+	const struct adltc2990_config *cfg = dev->config;
+	struct adltc2990_data *data = dev->data;
+	int32_t value;
 	int ret;
 
-	ret = fetch_pin_differential_voltage_value(dev, mode, pin);
+	if (mode != VOLTAGE_DIFFERENTIAL) {
+		LOG_DBG("Pin is not configured to measure current");
+		return 0;
+	}
+
+	ret = adltc2990_fetch_property_value(dev, VOLTAGE_DIFFERENTIAL, pin, &value);
 	if (ret) {
 		return ret;
 	}
 
-	const struct adltc2990_config *cfg = dev->config;
-	struct adltc2990_data *data = dev->data;
-
 	switch (pin) {
 	case V1:
 	case V2:
-		data->pins_v1_v2_values[0] *= (ADLTC2990_MICROOHM_CONVERSION_FACTOR /
+		data->current_v1_v2 = value * (ADLTC2990_MICROOHM_CONVERSION_FACTOR /
 					       (float)cfg->pins_v1_v2.pins_current_resistor);
 		break;
 
 	case V3:
 	case V4:
-		data->pins_v3_v4_values[0] *= (ADLTC2990_MICROOHM_CONVERSION_FACTOR /
+		data->current_v3_v4 = value * (ADLTC2990_MICROOHM_CONVERSION_FACTOR /
 					       (float)cfg->pins_v3_v4.pins_current_resistor);
 		break;
 
@@ -599,18 +604,18 @@ static int adltc2990_channel_get(const struct device *dev, enum sensor_channel c
 			LOG_ERR("Sensor is not configured to measure Current");
 			return -EINVAL;
 		}
-		if (mode_v1_v2 == VOLTAGE_DIFFERENTIAL && mode_v3_v4 == VOLTAGE_DIFFERENTIAL) {
-			LOG_DBG("Getting I12 and I34");
-			num_values_v1_v2 = ADLTC2990_CURRENT_VALUES;
-			num_values_v3_v4 = ADLTC2990_CURRENT_VALUES;
-		} else if (mode_v1_v2 == VOLTAGE_DIFFERENTIAL) {
+		if (mode_v1_v2 == VOLTAGE_DIFFERENTIAL) {
 			LOG_DBG("Getting I12");
-			num_values_v1_v2 = ADLTC2990_CURRENT_VALUES;
-		} else if (mode_v3_v4 == VOLTAGE_DIFFERENTIAL) {
-			LOG_DBG("Getting I34");
-			num_values_v3_v4 = ADLTC2990_CURRENT_VALUES;
+			val[offset_index].val1 = data->current_v1_v2 / 1000000;
+			val[offset_index].val2 = data->current_v1_v2 % 1000000;
+			offset_index++;
 		}
-		break;
+		if (mode_v3_v4 == VOLTAGE_DIFFERENTIAL) {
+			LOG_DBG("Getting I34");
+			val[offset_index].val1 = data->current_v3_v4 / 1000000;
+			val[offset_index].val2 = data->current_v3_v4 % 1000000;
+		}
+		return 0;
 
 	case SENSOR_CHAN_AMBIENT_TEMP:
 		if (!(mode_v1_v2 == TEMPERATURE || mode_v3_v4 == TEMPERATURE)) {

--- a/drivers/sensor/adi/adltc2990/adltc2990.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990.c
@@ -143,7 +143,6 @@ int adltc2990_trigger_measurement(const struct device *dev,
 		goto trigger_conversion;
 	}
 
-	data->acq_format = format;
 	uint8_t ctrl_reg_setting;
 
 	if (i2c_reg_read_byte_dt(&cfg->bus, ADLTC2990_REG_CONTROL, &ctrl_reg_setting)) {
@@ -157,6 +156,8 @@ int adltc2990_trigger_measurement(const struct device *dev,
 		LOG_ERR("configuring for single bus failed.");
 		return -EIO;
 	}
+
+	data->acq_format = format;
 
 trigger_conversion:
 	return i2c_reg_write_byte_dt(&cfg->bus, ADLTC2990_REG_TRIGGER, 0x1);

--- a/drivers/sensor/adi/adltc2990/adltc2990_internal.h
+++ b/drivers/sensor/adi/adltc2990/adltc2990_internal.h
@@ -51,6 +51,8 @@ struct adltc2990_data {
 	int32_t supply_voltage;
 	int32_t pins_v1_v2_values[2];
 	int32_t pins_v3_v4_values[2];
+	int32_t current_v1_v2;
+	int32_t current_v3_v4;
 };
 
 struct adltc2990_config {


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the ADLTC2990 driver, one
commit per issue:

- **Cache acq format only after it is written**: `trigger_measurement()`
  stored the requested acquisition format into `data->acq_format` before
  issuing the control-register write. If that write (or the preceding read)
  failed, the driver returned an error but kept the new format cached, so the
  subsequent fetch decoded the registers according to a mode the chip was never
  put into. Cache the format only once the hardware has accepted it.
- **Store current in its own field**: the computed current was scaled in place
  into `pins_v1_v2_values[0]` / `pins_v3_v4_values[0]` — the same slots the
  differential-voltage fetch writes. On the `SENSOR_CHAN_ALL` path the voltage
  step therefore overwrote the just-computed current with the raw differential
  voltage, so `SENSOR_CHAN_CURRENT` returned a voltage in amperes. Give current
  dedicated storage, and skip the computation entirely for pins that are not
  configured as differential (which previously scaled a stale, unrelated value
  by 1/Rsense). `channel_get()` now also fills both current slots independently
  instead of relying on index arithmetic that packed I34 into I12's slot when
  only V3/V4 were differential.