### PR TITLE
drivers: sensor: icp201xx: fix trigger teardown, interrupt mask polarity and negative conversions

### DIFF
--- a/drivers/sensor/tdk/icp201xx/icp201xx_drv.c
+++ b/drivers/sensor/tdk/icp201xx/icp201xx_drv.c
@@ -196,8 +196,7 @@ static void icp201xx_convert_pressure(struct sensor_value *val, int32_t raw_val)
 		raw_val |= 0xFFF00000;
 	}
 	/* P = (POUT/2^17)*40kPa + 70kPa */
-	val->val1 = (raw_val * 40) / 131072 + 70;
-	val->val2 = ((uint64_t)(raw_val * 40) % 131072) * 1000000 / 131072;
+	sensor_value_from_micro(val, ((int64_t)raw_val * 40 * 1000000) / 131072 + 70000000);
 }
 
 static void icp201xx_convert_temperature(struct sensor_value *val, int32_t raw_val)
@@ -207,8 +206,7 @@ static void icp201xx_convert_temperature(struct sensor_value *val, int32_t raw_v
 		raw_val |= 0xFFF00000;
 	}
 	/* T = (TOUT/2^18)*65C + 25C */
-	val->val1 = (raw_val * 65) / 262144 + 25;
-	val->val2 = ((uint64_t)(raw_val * 65) % 262144) * 1000000 / 262144;
+	sensor_value_from_micro(val, ((int64_t)raw_val * 65 * 1000000) / 262144 + 25000000);
 }
 
 static int icp201xx_channel_get(const struct device *dev, enum sensor_channel chan,

--- a/drivers/sensor/tdk/icp201xx/icp201xx_trigger.c
+++ b/drivers/sensor/tdk/icp201xx/icp201xx_trigger.c
@@ -101,6 +101,7 @@ static int icp201xx_pressure_interrupt(const struct device *dev, struct sensor_v
 {
 	int16_t pressure_value, pressure_delta_value;
 	uint8_t int_mask = 0;
+	uint8_t enabled;
 	int rc = 0;
 	struct icp201xx_data *data = (struct icp201xx_data *)dev->data;
 
@@ -109,8 +110,10 @@ static int icp201xx_pressure_interrupt(const struct device *dev, struct sensor_v
 	/* PABS = (P(kPa)-70kPa)/40kPa*2^13 */
 	pressure_value =
 		(8192 * (pressure.val1 - 70) + ((8192 * (uint64_t)pressure.val2) / 1000000)) / 40;
+	enabled = (uint8_t)~int_mask &
+		  (ICP201XX_INT_MASK_PRESS_ABS | ICP201XX_INT_MASK_PRESS_DELTA);
 	rc |= inv_icp201xx_set_press_notification_config(&(data->icp_device),
-							 ~int_mask | ICP201XX_INT_MASK_PRESS_ABS,
+							 enabled | ICP201XX_INT_MASK_PRESS_ABS,
 							 pressure_value, pressure_delta_value);
 	return rc;
 }
@@ -120,6 +123,7 @@ static int icp201xx_pressure_change_interrupt(const struct device *dev,
 {
 	int16_t pressure_value, pressure_delta_value;
 	uint8_t int_mask = 0;
+	uint8_t enabled;
 	int rc = 0;
 	struct icp201xx_data *data = (struct icp201xx_data *)dev->data;
 
@@ -129,8 +133,10 @@ static int icp201xx_pressure_change_interrupt(const struct device *dev,
 	pressure_delta_value =
 		(16384 * pressure_delta.val1 + (16384 * (uint64_t)pressure_delta.val2 / 1000000)) /
 		80;
+	enabled = (uint8_t)~int_mask &
+		  (ICP201XX_INT_MASK_PRESS_ABS | ICP201XX_INT_MASK_PRESS_DELTA);
 	rc |= inv_icp201xx_set_press_notification_config(&(data->icp_device),
-							 ~int_mask | ICP201XX_INT_MASK_PRESS_DELTA,
+							 enabled | ICP201XX_INT_MASK_PRESS_DELTA,
 							 pressure_value, pressure_delta_value);
 	return rc;
 }

--- a/drivers/sensor/tdk/icp201xx/icp201xx_trigger.c
+++ b/drivers/sensor/tdk/icp201xx/icp201xx_trigger.c
@@ -186,14 +186,32 @@ int icp201xx_trigger_set(const struct device *dev, const struct sensor_trigger *
 
 	icp201xx_mutex_lock(dev);
 	gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_DISABLE);
-	if (handler == NULL) {
-		return -1;
-	}
 
 	if ((trig->type != SENSOR_TRIG_DATA_READY) && (trig->type != SENSOR_TRIG_DELTA) &&
 	    (trig->type != SENSOR_TRIG_THRESHOLD)) {
 		icp201xx_mutex_unlock(dev);
 		return -ENOTSUP;
+	}
+
+	if (handler == NULL) {
+		if (trig->type == SENSOR_TRIG_DATA_READY) {
+			drv_data->drdy_handler = NULL;
+			drv_data->drdy_trigger = NULL;
+		} else if (trig->type == SENSOR_TRIG_DELTA) {
+			drv_data->delta_handler = NULL;
+			drv_data->delta_trigger = NULL;
+		} else {
+			drv_data->threshold_handler = NULL;
+			drv_data->threshold_trigger = NULL;
+		}
+
+		if ((drv_data->drdy_handler != NULL) || (drv_data->delta_handler != NULL) ||
+		    (drv_data->threshold_handler != NULL)) {
+			gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_LEVEL_LOW);
+		}
+
+		icp201xx_mutex_unlock(dev);
+		return 0;
 	}
 
 	if (trig->type == SENSOR_TRIG_DATA_READY) {


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the ICP201xx driver, one commit per issue:

* **Fix mutex leak when unregistering trigger**: `icp201xx_trigger_set()` took the driver mutex and then returned `-1` immediately if `handler == NULL`, without ever unlocking. Since the sensor API uses a NULL handler to *remove* a trigger, the standard unregister call permanently deadlocked every subsequent fetch, attribute access and trigger operation on the device. Handle the NULL-handler case properly: clear the matching handler, keep the GPIO interrupt enabled only while some other trigger is still armed, and unlock.
* **Fix inverted pressure interrupt mask**: `set_press_notification_config()` takes the set of interrupts to *enable*, while `get_press_notification_config()` returns the raw INT_MASK register bits, in which a set bit means *masked*. The driver passed `~int_mask | ...` straight through, so arming a pressure threshold or delta trigger un-masked every interrupt source on the device — FIFO watermark, overflow and underflow included — turning the INT pin into a continuous interrupt source. Convert the register bits to an enable set before OR-ing in the requested trigger.
* **Fix conversion of negative raw values**: both the pressure and temperature conversions computed `val2` by casting a negative product to `uint64_t` before taking the remainder, producing an enormous positive fractional part, and computed `val1` with a truncating division that left `val1` and `val2` with opposite signs — violating the `sensor_value` contract. Any temperature below 25 °C or pressure below 70 kPa (i.e. roughly any altitude above 3000 m) decoded to nonsense. Compute both in signed 64-bit micro-units and let `sensor_value_from_micro()` split them.
