### PR TITLE
boards: seeed: xiao_nrf54l15: drop stale cpuflpr_sram override

### DIFF
--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
@@ -19,10 +19,6 @@
 	};
 };
 
-&cpuflpr_sram {
-	status = "okay";
-};
-
 &cpuflpr_rram {
 	partitions {
 		#address-cells = <1>;

--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
@@ -21,9 +21,6 @@
 
 &cpuflpr_sram {
 	status = "okay";
-	/* size must be increased due to booting from SRAM */
-	reg = <0x20028000 DT_SIZE_K(96)>;
-	ranges = <0x0 0x20028000 0x18000>;
 };
 
 &cpuflpr_rram {


### PR DESCRIPTION
Commit 630cd71bc60 ("dts: vendor: nordic: nrf54l: Reserve 1kB of RAM for
flpr hiberantion") moved cpuflpr_sram in the vendor dtsi from 0x20028000
down to 0x20027c00, carving the 256KB SoC SRAM into a 159KB cpuapp region,
a 1KB VPR hibernation reservation, and the 96KB cpuflpr region. The
nordic-flpr snippet was updated in the same series to teach cpuapp about
the new layout.

xiao_nrf54l15_nrf54l15_cpuflpr.dts still overrides cpuflpr_sram with the
pre-reservation address 0x20028000. As a result the FLPR image is linked at
0x20028000 while cpuapp's VPR launcher (which follows the snippet)
initialises it at 0x20027c00 - a 1KB offset. The FLPR never boots
correctly, so the IPC endpoint on cpuapp's side never binds. Observed
symptom: multi-core samples that use nordic-flpr hang at "Waiting for FLPR
core..." indefinitely.

The DK does not override cpuflpr_sram at all and inherits the vendor dtsi
cleanly. Drop the override here for the same effect; the "size must be
increased due to booting from SRAM" comment predates the vendor dtsi being
sized correctly and no longer applies.