### PR TITLE
boards: seeed: xiao_nrf54lm20a: fix cpuflpr flash size

### DIFF
--- a/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.yaml
+++ b/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.yaml
@@ -9,7 +9,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 96
-flash: 0
+flash: 96
 supported:
   - counter
   - gpio


### PR DESCRIPTION
The cpuflpr board target declares `flash: 0`, so twister computes
`plat.flash < ts.min_flash` as true for every test and statically
filters the platform out with "Not enough FLASH". No FLPR-only test
can run on this board.

The FLPR does have flash: xiao_nrf54lm20a_nrf54lm20a_cpuflpr.dts
carves a 96K cpuflpr_code_partition out of cpuflpr_rram, matching the
96K cpuflpr_rram region in nrf54lm20_a_b_cpuflpr.dtsi. Both the
nRF54LM20 DK (nrf54lm20dk_nrf54lm20a_cpuflpr.yaml) and the XIAO
nRF54L15 (xiao_nrf54l15_nrf54l15_cpuflpr.yaml) declare `flash: 96`
for the same layout.

Declare 96 to match.