### PR TITLE
boards: seeed: xiao_nrf54lm20a: enable gpio3

### DIFF
--- a/boards/seeed/xiao_nrf54lm20a/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/seeed/xiao_nrf54lm20a/nrf54lm20a_cpuapp_common.dtsi
@@ -87,6 +87,10 @@
 	status = "okay";
 };
 
+&gpio3 {
+	status = "okay";
+};
+
 &gpiote20 {
 	status = "okay";
 };

--- a/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.dts
+++ b/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.dts
@@ -50,6 +50,10 @@
 	status = "okay";
 };
 
+&gpio3 {
+	status = "okay";
+};
+
 &gpiote20 {
 	status = "okay";
 };


### PR DESCRIPTION
seeed_xiao_connector.dtsi maps 11 of the 28 XIAO connector pins to
&gpio3: D11-D18 to gpio3 0-7 and D25-D27 to gpio3 9-11. But no file in
the board enables that port, so those pins are unusable - referencing
one from an application overlay fails to build because the GPIO
controller is not okay.

Enable gpio3 on both cores, next to gpio0/gpio1/gpio2. The nRF54LM20
DK already does this for the same SoC.