### PR TITLE
boards: seeed: xiao_nrf54l*: clock fixes

### DIFF
--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
@@ -175,5 +175,13 @@ dmic_dev: &pdm20 {
 	status = "okay";
 };
 
+&xo {
+	status = "okay";
+};
+
+&lfclk {
+	status = "okay";
+};
+
 /* Include default memory partition configuration file */
 #include <vendor/nordic/nrf54l15_cpuapp_partition.dtsi>

--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
@@ -64,8 +64,3 @@
 &gpiote30 {
 	status = "okay";
 };
-
-&lfclk {
-	k32src = "rc";
-	k32src-accuracy-ppm = <250>;
-};

--- a/boards/seeed/xiao_nrf54lm20a/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/seeed/xiao_nrf54lm20a/nrf54lm20a_cpuapp_common.dtsi
@@ -107,6 +107,18 @@
 	status = "okay";
 };
 
+&xo {
+	status = "okay";
+};
+
+&lfclk {
+	status = "okay";
+};
+
+&xo24m {
+	status = "okay";
+};
+
 &bt_hci_controller {
 	status = "okay";
 };

--- a/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.dts
+++ b/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54lm20_a_b_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54lm20a_cpuflpr.dtsi>
 #include "xiao_nrf54lm20a_nrf54lm20a-common.dtsi"
 
 / {

--- a/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.yaml
+++ b/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.yaml
@@ -9,7 +9,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 96
-flash: 0
+flash: 96
 supported:
   - counter
   - gpio


### PR DESCRIPTION
Fix build regressions on the Seeed XIAO nRF54L15 and XIAO nRF54LM20A boards
after two upstream commits migrated the Nordic DKs but missed the XIAO
siblings:

- `bb485e28fe7` *"dts: Added split clocks to dts."* — added the
  `nordic,nrf-clock-lfclk` binding that the BT controller now requires.
- `876ebb23ce1` *"dts: nordic: nrf54lm20: provide dedicated cpuflpr dtsi"*
  — split out per-SoC vendor cpuflpr dtsi files.

## Impact

- BT samples for `xiao_nrf54l15/nrf54l15/cpuapp` and
  `xiao_nrf54lm20a/nrf54lm20a/cpuapp` fail at `lll_clock.c`:
  `'__P_k32src_accuracy_ppm_IDX_0_ENUM_IDX' undeclared`.
- `xiao_nrf54lm20a/nrf54lm20a/cpuflpr` fails DT parse in
  `dts/riscv/nordic/nrf54lm20_a_b_cpuflpr.dtsi:7`.
- `xiao_nrf54l15` also has a stale `k32src = "rc"` on cpuflpr that
  contradicts the board's external 32 kHz crystal.

## Changes

- **xiao_nrf54l15: enable xo and lfclk on cpuapp** — match the DK; default
  `k32src = "xtal"` is correct.
- **xiao_nrf54l15: drop stale k32src override on cpuflpr** — lfclk is
  owned by cpuapp; DK does not configure it on cpuflpr either.
- **xiao_nrf54lm20a: enable xo, lfclk and xo24m on cpuapp** — match the DK.
- **xiao_nrf54lm20a: use dedicated cpuflpr vendor dtsi** — switch to
  `<vendor/nordic/nrf54lm20a_cpuflpr.dtsi>`, matching the DK migration.

## Testing

west build -b xiao_nrf54l15/nrf54l15/cpuapp      samples/bluetooth/peripheral
west build -b xiao_nrf54lm20a/nrf54lm20a/cpuapp  samples/bluetooth/peripheral
west build -b xiao_nrf54lm20a/nrf54lm20a/cpuflpr samples/hello_world