### PR TITLE
soc: espressif: move bluetooth rx stack default to soc

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.esp32
+++ b/drivers/bluetooth/hci/Kconfig.esp32
@@ -10,9 +10,6 @@ config HEAP_MEM_POOL_ADD_SIZE_ESP_BT
 	help
 	  Additional heap size reserved for Bluetooth driver usage.
 
-configdefault BT_RX_STACK_SIZE
-	default 2048 if BT_SETTINGS
-
 choice ESP_BT_HEAP
 	prompt "Bluetooth heap type"
 	default ESP_BT_HEAP_SYSTEM

--- a/soc/espressif/common/Kconfig.defconfig
+++ b/soc/espressif/common/Kconfig.defconfig
@@ -49,16 +49,6 @@ config ROM_START_OFFSET
 
 endif # BOOTLOADER_MCUBOOT
 
-if BT_ESP32
-
-config BT_BUF_ACL_TX_COUNT
-	default 10
-
-config BT_BUF_EVT_RX_COUNT
-	default 20
-
-endif # BT_ESP32
-
 if PM && TICKLESS_KERNEL
 
 choice PM_PREWAKEUP_CONV_MODE
@@ -112,7 +102,12 @@ config ROM_START_OFFSET
 
 endif # BOOTLOADER_MCUBOOT
 
+endif # XTENSA
+
 if BT_ESP32
+
+configdefault BT_RX_STACK_SIZE
+	default 2048 if BT_SETTINGS
 
 config BT_BUF_ACL_TX_COUNT
 	default 10
@@ -121,5 +116,3 @@ config BT_BUF_EVT_RX_COUNT
 	default 20
 
 endif # BT_ESP32
-
-endif # XTENSA


### PR DESCRIPTION
Move the BT_RX_STACK_SIZE default out of the HCI driver Kconfig and into the common Espressif defconfig, next to the other Bluetooth subsystem defaults.

The BT_ESP32 block is now shared by both architectures instead of being duplicated under RISCV and XTENSA, so the stack default also applies to the Xtensa targets.

ref: https://github.com/zephyrproject-rtos/zephyr/pull/114553