### PR TITLE
boards: st: nucleo_c562re: add pyocd runner configuration

### DIFF
--- a/boards/st/nucleo_c562re/board.cmake
+++ b/boards/st/nucleo_c562re/board.cmake
@@ -4,7 +4,9 @@
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stlink_gdbserver "--apid=1")
+board_runner_args(pyocd "--target=stm32c562ret6")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Adding configuration for support pyocd.