### PR TITLE
drivers: sensor: lsm9ds1: fix ODR validation, cached ODR seeding and gyro overflow

### DIFF
--- a/drivers/sensor/st/lsm9ds1/lsm9ds1.c
+++ b/drivers/sensor/st/lsm9ds1/lsm9ds1.c
@@ -181,6 +181,10 @@ static int lsm9ds1_gyro_odr_set(const struct device *dev, uint16_t freq)
 	int ret;
 
 	odr = lsm9ds1_gyro_freq_to_odr_val(freq);
+	if (odr < 0) {
+		LOG_DBG("gyroscope sampling frequency not supported");
+		return odr;
+	}
 
 	if (odr == data->gyro_odr) {
 		return 0;
@@ -228,6 +232,10 @@ static int lsm9ds1_accel_odr_set(const struct device *dev, uint16_t freq)
 	if (old_odr & GYRO_ODR_MASK) {
 
 		odr = lsm9ds1_gyro_freq_to_odr_val(freq);
+		if (odr < 0) {
+			LOG_DBG("gyroscope sampling frequency not supported");
+			return odr;
+		}
 
 		if (odr == data->gyro_odr) {
 			return 0;
@@ -251,13 +259,13 @@ static int lsm9ds1_accel_odr_set(const struct device *dev, uint16_t freq)
 	} else {
 
 		odr = lsm9ds1_accel_freq_to_odr_val(freq);
+		if (odr < 0) {
+			LOG_DBG("accelerometer sampling frequency not supported");
+			return odr;
+		}
 
 		if (odr == data->accel_odr) {
 			return 0;
-		}
-
-		if (odr < 0) {
-			return odr;
 		}
 
 		ret = lsm9ds1_accel_set_odr_raw(dev, odr);

--- a/drivers/sensor/st/lsm9ds1/lsm9ds1.c
+++ b/drivers/sensor/st/lsm9ds1/lsm9ds1.c
@@ -649,6 +649,10 @@ static int lsm9ds1_init(const struct device *dev)
 		return ret;
 	}
 
+	/* imu_odr packs CTRL_REG6_XL.odr_xl in bits 6:4 and CTRL_REG1_G.odr_g in bits 2:0 */
+	data->accel_odr = (cfg->imu_odr >> 4) & GYRO_ODR_MASK;
+	data->gyro_odr = cfg->imu_odr & GYRO_ODR_MASK;
+
 	fs = cfg->accel_range;
 	LOG_DBG("accel range is %d\n", fs);
 	ret = lsm9ds1_xl_full_scale_set(ctx, fs);

--- a/drivers/sensor/st/lsm9ds1/lsm9ds1.c
+++ b/drivers/sensor/st/lsm9ds1/lsm9ds1.c
@@ -499,7 +499,7 @@ static inline void lsm9ds1_gyro_convert(struct sensor_value *val, int raw_val, u
 {
 	/* Sensitivity is exposed in udps/LSB */
 	/* Convert to rad/s */
-	sensor_10udegrees_to_rad((raw_val * (int32_t)sensitivity) / 10, val);
+	sensor_10udegrees_to_rad((int32_t)(((int64_t)raw_val * sensitivity) / 10), val);
 }
 
 static inline int lsm9ds1_gyro_get_channel(enum sensor_channel chan, struct sensor_value *val,


### PR DESCRIPTION
This PR fixes three independent correctness bugs in the LSM9DS1 driver, one
commit per issue:

- **Reject unsupported sampling frequencies**: `lsm9ds1_*_freq_to_odr_val()`
  returns `-EINVAL` for a frequency above the highest supported rate, but two of
  the three call sites used the result without checking it. The negative value
  was then assigned into the 3-bit `odr_xl` / `odr_g` register bitfield, so
  requesting e.g. 1000 Hz silently programmed ODR code 7 — a reserved encoding
  for the accelerometer — and the driver reported success. The accelerometer
  path did check, but only *after* comparing against the cached ODR, so an
  invalid request that happened to match the cache returned 0 as well.
- **Seed cached ODR values at init**: `data->accel_odr` / `data->gyro_odr` were
  left at zero until an ODR was set at runtime, but `PM_DEVICE_ACTION_RESUME`
  restores the ODR registers *from those cached fields*. A device configured
  purely from devicetree therefore came back from suspend with both ODRs
  programmed to 0 — power-down — and silently stopped producing samples. Seed
  the cache from the `imu-odr` devicetree property at init.
- **Fix gyro conversion overflow at 2000 dps**: `raw_val * sensitivity` was
  evaluated in 32-bit arithmetic. At the 2000 dps full scale (70000 µdps/LSB) a
  raw reading beyond ~30600 counts — about 92% of full scale — overflows
  `int32_t` and the reported angular rate wraps sign. Widen the product to
  64-bit before the divide.