### PR TITLE
drivers: sensor: lis2mdl: fix die temperature sign and stale single-shot semaphore

### DIFF
--- a/drivers/sensor/st/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl.c
@@ -120,8 +120,8 @@ static void lis2mdl_channel_get_temp(const struct device *dev,
 	struct lis2mdl_data *drv_data = dev->data;
 
 	/* formula is temp = 25 + (temp / 8) C */
-	val->val1 = 25  + drv_data->temp_sample / 8;
-	val->val2 = (drv_data->temp_sample % 8) * 1000000 / 8;
+	sensor_value_from_micro(val,
+				25000000LL + ((int64_t)drv_data->temp_sample * 1000000LL) / 8);
 }
 
 static int lis2mdl_channel_get(const struct device *dev,

--- a/drivers/sensor/st/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl.c
@@ -193,6 +193,9 @@ static int get_single_mode_raw_data(const struct device *dev,
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	int rc = 0;
 
+	/* drop any count left over from a conversion nobody consumed */
+	k_sem_reset(&lis2mdl->fetch_sem);
+
 	rc = lis2mdl_operating_mode_set(ctx, LIS2MDL_SINGLE_TRIGGER);
 	if (rc) {
 		LOG_ERR("set single mode failed");


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the LIS2MDL driver, one
commit per issue:

- **Fix sign mismatch in die temperature**: the +25 °C offset was added to
  `val1` *after* the raw sample had already been split into integer and
  fractional parts, so any reading below 25 °C came back with a positive `val1`
  and a negative `val2` — a `sensor_value` the API forbids, and one that
  `sensor_value_to_double()` turns into a temperature roughly 1 °C off in the
  wrong direction. Build the value in micro-Celsius and let
  `sensor_value_from_micro()` split it.
- **Reset fetch_sem before single-shot trigger**: `fetch_sem` is given on every
  DRDY event, including conversions nobody is waiting on — a DRDY arriving
  after a fetch has already timed out, or the single-shot conversion the driver
  itself starts from `pm_action()` on resume. The next `sample_fetch()` then
  took the leftover count immediately, read the registers before the new
  conversion completed, and returned the *previous* conversion's data. Once out
  of step it stays out of step, so the driver silently reports one-sample-stale
  magnetometer data indefinitely. Discard any stale count before starting a
  conversion.