### PR TITLE
drivers: sensor: lis2dw12: honour odr=0 and clamp wake-up threshold encoding

### DIFF
--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -69,7 +69,12 @@ static int lis2dw12_set_odr(const struct device *dev, uint16_t odr)
 
 	/* check if power off */
 	if (odr == 0U) {
-		return lis2dw12_data_rate_set(ctx, LIS2DW12_XL_ODR_OFF);
+		int ret = lis2dw12_data_rate_set(ctx, LIS2DW12_XL_ODR_OFF);
+
+		if (ret == 0) {
+			lis2dw12->odr = 0;
+		}
+		return ret;
 	}
 
 	val =  LIS2DW12_ODR_TO_REG(odr);

--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -216,6 +216,9 @@ static int lis2dw12_config(const struct device *dev, enum sensor_channel chan,
 #define THRESHOLD_MG_TO_WK_THS_REG(thr_mg, lsb_mg) \
 	((thr_mg + (lsb_mg / 2)) / lsb_mg)
 
+/* Maximum value of the 6-bit WK_THS field */
+#define WK_THS_MAX	63U
+
 static int lis2dw12_attr_set_thresh(const struct device *dev,
 					enum sensor_channel chan,
 					enum sensor_attribute attr,
@@ -255,6 +258,12 @@ static int lis2dw12_attr_set_thresh(const struct device *dev,
 	 */
 	lsb_mg = MG_TO_WK_THS_LSB(FS_RANGE_TO_MG(range));
 	reg = THRESHOLD_MG_TO_WK_THS_REG(thr_mg, lsb_mg);
+
+	/* rounding can push a threshold just below full scale to 64, which the HAL masks to 0 */
+	if (reg > WK_THS_MAX) {
+		LOG_WRN("Threshold %u mg clamped to %u mg", thr_mg, WK_THS_MAX * (uint32_t)lsb_mg);
+		reg = WK_THS_MAX;
+	}
 
 	LOG_DBG("Threshold %d mg -> fs: %u mg -> reg = %d LSBs",
 			thr_mg, FS_RANGE_TO_MG(range), reg);

--- a/drivers/sensor/st/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.h
@@ -27,7 +27,8 @@
 
 /* Return ODR reg value based on data rate set */
 #define LIS2DW12_ODR_TO_REG(_odr) \
-	((_odr <= 1) ? LIS2DW12_XL_ODR_1Hz6_LP_ONLY : \
+	((_odr == 0) ? LIS2DW12_XL_ODR_OFF : \
+	 (_odr <= 1) ? LIS2DW12_XL_ODR_1Hz6_LP_ONLY : \
 	 (_odr <= 12) ? LIS2DW12_XL_ODR_12Hz5 : \
 	 ((31 - __builtin_clz(_odr / 25))) + 3)
 


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the LIS2DW12 driver, one
commit per issue:

- **Honour odr=0 power off state**: `LIS2DW12_ODR_TO_REG()` has no arm for the
  power-off state — its first test is `_odr <= 1`, so 0 maps to the 1.6 Hz
  low-power rate. `PM_DEVICE_ACTION_RESUME` re-applies the cached ODR through
  that macro, so a device configured with `odr = <0>` (or powered off at
  runtime) silently started converting again after a suspend/resume cycle,
  defeating the power saving it was configured for. Add the OFF arm and keep the
  cached ODR in sync when a runtime power-off succeeds.
- **Clamp wake-up threshold to 6-bit max**: the wake-up threshold is validated
  against full scale but then encoded into `WK_THS`, a 6-bit field whose largest
  value is 63 LSBs. The rounding in the mg-to-LSB conversion pushes thresholds
  in the top ~0.8% of full scale to 64, which the HAL masks back down to 0 — the
  most sensitive setting possible. Asking for the *least* sensitive wake-up
  threshold therefore produced a continuous wake-up interrupt. Clamp the
  computed value.