### PR TITLE
drivers: sensor: bmp388: fix SPI calibration read and unbounded data-ready wait

### DIFF
--- a/drivers/sensor/bosch/bmp388/bmp388.c
+++ b/drivers/sensor/bosch/bmp388/bmp388.c
@@ -8,6 +8,7 @@
  * https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp388-ds001.pdf
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/pm/device.h>
@@ -220,19 +221,34 @@ static int bmp388_sample_fetch(const struct device *dev,
 {
 	struct bmp388_data *bmp3xx = dev->data;
 	uint8_t raw[BMP388_SAMPLE_BUFFER_SIZE];
+	k_timepoint_t end;
 	int ret = 0;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
 	pm_device_busy_set(dev);
 
+	/* Allow up to two conversion periods (ODR index 0 is 200Hz, i.e. 5ms). */
+	end = sys_timepoint_calc(K_MSEC(2U * (5U << bmp3xx->odr)));
+
 	/* Wait for status to indicate that data is ready. */
-	raw[0] = 0U;
-	while ((raw[0] & BMP388_STATUS_DRDY_PRESS) == 0U) {
+	while (true) {
 		ret = bmp388_reg_read(dev, BMP388_REG_STATUS, raw, 1);
 		if (ret < 0) {
 			goto error;
 		}
+
+		if ((raw[0] & BMP388_STATUS_DRDY_PRESS) != 0U) {
+			break;
+		}
+
+		if (sys_timepoint_expired(end)) {
+			LOG_ERR("Timed out waiting for data ready");
+			ret = -EAGAIN;
+			goto error;
+		}
+
+		k_sleep(K_MSEC(1));
 	}
 
 	ret = bmp388_reg_read(dev,

--- a/drivers/sensor/bosch/bmp388/bmp388.h
+++ b/drivers/sensor/bosch/bmp388/bmp388.h
@@ -168,6 +168,9 @@ struct bmp388_cal_data {
 	int8_t p11;
 } __packed;
 
+/* Largest single burst read performed by the driver: the NVM calibration block. */
+#define BMP388_MAX_READ_SIZE MAX(BMP388_SAMPLE_BUFFER_SIZE, (int)sizeof(struct bmp388_cal_data))
+
 struct bmp388_sample {
 	uint32_t press;
 	uint32_t raw_temp;

--- a/drivers/sensor/bosch/bmp388/bmp388_spi.c
+++ b/drivers/sensor/bosch/bmp388/bmp388_spi.c
@@ -26,21 +26,21 @@ static int bmp388_reg_read_spi(const union bmp388_bus *bus, uint8_t regaddr, uin
 {
 	int ret;
 
-	if ((size <= 0) || (size > BMP388_SAMPLE_BUFFER_SIZE)) {
+	if ((size <= 0) || (size > BMP388_MAX_READ_SIZE)) {
 		return -EINVAL;
 	}
 
-	uint8_t buffer[size + 2];
+	uint8_t buffer[BMP388_MAX_READ_SIZE + 2];
 	const struct spi_buf rxtx_buf = {
-		.buf = &buffer,
-		.len = ARRAY_SIZE(buffer),
+		.buf = buffer,
+		.len = size + 2,
 	};
 	const struct spi_buf_set rxtx = {
 		.buffers = &rxtx_buf,
 		.count = 1
 	};
 
-	memset(buffer, 0x00, ARRAY_SIZE(buffer));
+	memset(buffer, 0x00, size + 2);
 	buffer[0] = (regaddr) | 0x80;
 
 	ret = spi_transceive_dt(&bus->spi, &rxtx, &rxtx);


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the BMP388/BMP390 driver, one
commit per issue:

- **Fix SPI reads larger than 6 bytes**: the SPI read backend rejected any
  transfer larger than `BMP388_SAMPLE_BUFFER_SIZE` (6 bytes), but `init()` reads
  the 21-byte NVM calibration block in a single burst. Every SPI-attached BMP388
  therefore failed to initialise with `-EINVAL`; only I2C worked. Bound the
  transfer by the largest burst the driver actually performs and size the shared
  tx/rx buffer from that (also replacing a VLA whose length came from a caller
  argument).
- **Bound the data-ready busy-wait**: `sample_fetch()` polled the STATUS
  `drdy_press` bit in a tight loop with no timeout and no yielding. If the chip
  is in sleep mode, was reset by a glitch, or simply never asserts data-ready,
  the calling thread spins forever at its own priority while hammering the bus —
  starving lower-priority work and, on a cooperative thread, the whole system.
  Bound the wait to two conversion periods derived from the configured ODR,
  return `-EAGAIN` on expiry, and sleep between polls.