### PR TITLE
drivers: sensor: apds9960: fix devicetree gain and pulse-length register encoding

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -704,6 +704,16 @@ Sensor
   a mux controller node (for example :dtcompatible:`nxp,mcux-xbar`) and reference it from the
   decoder node's ``mux-states`` property instead. (:github:`112088`)
 
+* The ``pgain``, ``again``, ``ppulse-length`` and ``pled-boost`` properties of
+  :dtcompatible:`avago,apds9960` used to spell the 2-bit register fields they select in hex
+  (``0x00``/``0x01``/``0x10``/``0x11``) and now take the physical value they select instead: gain
+  multipliers for ``pgain`` (``1``/``2``/``4``/``8``) and ``again`` (``1``/``4``/``16``/``64``),
+  microseconds for ``ppulse-length`` (``4``/``8``/``16``/``32``) and percent for ``pled-boost``
+  (``100``/``150``/``200``/``300``). Most of the old values are rejected by the new enums, but
+  ``pgain = <0x01>`` and ``again = <0x01>`` still build and now select 1x rather than 2x and 4x,
+  so update them explicitly. Nodes that do not set these properties are unaffected
+  (:github:`116079`).
+
 Serial
 ======
 

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -711,8 +711,8 @@ static DEVICE_API(sensor, apds9960_driver_api) = {
 		APDS9960_CONFIG_INTERRUPT(i)                                                       \
 		.pgain = DT_INST_ENUM_IDX(i, pgain) << 1,                                          \
 		.again = DT_INST_ENUM_IDX(i, again),                                               \
-		.ppcount = DT_INST_ENUM_IDX(i, ppulse_length) |                                    \
-			   (DT_INST_PROP(i, ppulse_count) - 1),                                    \
+		.ppcount = (DT_INST_ENUM_IDX(i, ppulse_length) << 6) |                             \
+			   ((DT_INST_PROP(i, ppulse_count) - 1) & 0x3F),                           \
 		.pled_boost = DT_INST_ENUM_IDX(i, pled_boost) << 4,                                \
 		APDS9960_CONFIG_GESTURE(i)                                                         \
 	};                                                                                         \

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -709,7 +709,7 @@ static DEVICE_API(sensor, apds9960_driver_api) = {
 	static const struct apds9960_config apds9960_config_##i = {                                \
 		.i2c = I2C_DT_SPEC_INST_GET(i),                                                    \
 		APDS9960_CONFIG_INTERRUPT(i)                                                       \
-		.pgain = DT_INST_ENUM_IDX(i, pgain) << 1,                                          \
+		.pgain = DT_INST_ENUM_IDX(i, pgain) << 2,                                          \
 		.again = DT_INST_ENUM_IDX(i, again),                                               \
 		.ppcount = (DT_INST_ENUM_IDX(i, ppulse_length) << 6) |                             \
 			   ((DT_INST_PROP(i, ppulse_count) - 1) & 0x3F),                           \

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -709,10 +709,11 @@ static DEVICE_API(sensor, apds9960_driver_api) = {
 	static const struct apds9960_config apds9960_config_##i = {                                \
 		.i2c = I2C_DT_SPEC_INST_GET(i),                                                    \
 		APDS9960_CONFIG_INTERRUPT(i)                                                       \
-		.pgain = DT_INST_PROP(i, pgain) << 1,                                              \
-		.again = DT_INST_PROP(i, again),                                                   \
-		.ppcount = DT_INST_PROP(i, ppulse_length) | (DT_INST_PROP(i, ppulse_count) - 1),   \
-		.pled_boost = DT_INST_PROP(i, pled_boost) << 4,                                    \
+		.pgain = DT_INST_ENUM_IDX(i, pgain) << 1,                                          \
+		.again = DT_INST_ENUM_IDX(i, again),                                               \
+		.ppcount = DT_INST_ENUM_IDX(i, ppulse_length) |                                    \
+			   (DT_INST_PROP(i, ppulse_count) - 1),                                    \
+		.pled_boost = DT_INST_ENUM_IDX(i, pled_boost) << 4,                                \
 		APDS9960_CONFIG_GESTURE(i)                                                         \
 	};                                                                                         \
                                                                                                    \

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -18,48 +18,65 @@ properties:
 
   pled-boost:
     type: int
-    default: 0x01
-    description: Proximity LED Boost Current
+    default: 150
+    description: |
+      Additional LDR current during proximity and gesture LED pulses, as a
+      percentage of the current LDRIVE selects. The default favours range over
+      power; raise it when cover glass attenuates the LED.
     enum:
-      - 0x00 # 100
-      - 0x01 # 150
-      - 0x10 # 200
-      - 0x11 # 300
+      - 100
+      - 150
+      - 200
+      - 300
 
   pgain:
     type: int
-    default: 0x01
-    description: ALS and Color Gain
+    default: 2
+    description: |
+      Proximity gain, as a multiplier. The driver's proximity thresholds are
+      set against the default; raise it to detect objects further away, and
+      lower it if nearby objects saturate the proximity ADC.
     enum:
-      - 0x00 # 1x
-      - 0x01 # 4x
-      - 0x10 # 4x
-      - 0x11 # 8x
+      - 1
+      - 2
+      - 4
+      - 8
 
   again:
     type: int
-    default: 0x01
-    description: ALS and Color Gain
+    default: 4
+    description: |
+      ALS and color gain, as a multiplier. The default leaves the clear channel
+      headroom in ordinary indoor light; raise it for dim environments, and
+      lower it if the clear channel saturates.
     enum:
-      - 0x00 # 1x
-      - 0x01 # 4x
-      - 0x10 # 16x
-      - 0x11 # 64x
+      - 1
+      - 4
+      - 16
+      - 64
 
   ppulse-length:
     type: int
-    default: 0x01
-    description: Proximity Pulse Length
+    default: 8
+    description: |
+      LED-on pulse width during a proximity LDR pulse, in microseconds. The
+      default matches the sensor's reset value and the datasheet's proximity
+      test conditions; longer pulses gather more signal per pulse.
     enum:
-      - 0x00 # 4us
-      - 0x01 # 8us
-      - 0x10 # 16us
-      - 0x11 # 32us
+      - 4
+      - 8
+      - 16
+      - 32
 
   ppulse-count:
     type: int
-    default: 0x8
-    description: Proximity Pulse Count
+    default: 8
+    min: 1
+    max: 64
+    description: |
+      Number of proximity pulses emitted per proximity measurement. The default
+      is the driving condition the datasheet recommends; other counts trade
+      measurement time and average LED current against range.
 
   proximity:
     type: int


### PR DESCRIPTION
The APDS9960 bindings described four 2-bit register fields by spelling the field value in hex — `0x00`/`0x01`/`0x10`/`0x11` — where binary was meant. The last two entries are really 16 and 17, and the driver passed them through to the registers unchanged. Fixing that turned up two field-placement bugs behind it.

### Devicetree

`pgain`, `again`, `ppulse-length` and `pled-boost` now take the physical value they select rather than a register field spelled in hex:

| property | old | new |
| --- | --- | --- |
| `pgain` | `0x00`/`0x01`/`0x10`/`0x11` | `1`/`2`/`4`/`8` (multiplier) |
| `again` | `0x00`/`0x01`/`0x10`/`0x11` | `1`/`4`/`16`/`64` (multiplier) |
| `ppulse-length` | `0x00`/`0x01`/`0x10`/`0x11` | `4`/`8`/`16`/`32` (µs) |
| `pled-boost` | `0x00`/`0x01`/`0x10`/`0x11` | `100`/`150`/`200`/`300` (%) |

The enums were already ordered to match the register encoding, so `DT_INST_ENUM_IDX()` recovers the field value with no lookup table, as `we,wsen-tids-2521020222501` and others already do. The defaults were translated to keep selecting the same settings.

The `pgain` entries were also mislabelled — the old comments listed 4x twice, where the part does 1x/2x/4x/8x.

### Driver fixes

* **`ppulse-length` never reached PPLEN.** The selection was OR'd straight into `ppcount`, landing in the pulse-count bits instead of PPLEN (bits 7:6) of register 0x8E. Every configuration ran with 4 µs pulses, and the 16/32 µs selections corrupted the pulse count on top of that. Now shifted into PPLEN, with the count masked to the six bits the field has.
* **`pgain` never reached PGAIN.** It was shifted by one instead of two, so it landed below CONTROL[3:2] and was masked away entirely — every board ran at 1x proximity gain regardless of devicetree.

### Behaviour change

No in-tree node sets any of these properties, so every board in tree uses the defaults — and two of those defaults were not being honoured. After this series they are:

* proximity gain: 1x → 2x
* proximity pulse length: 4 µs → 8 µs

ALS gain (4x) and LED boost (150%) were already correct and are unchanged.

### Migration

Out-of-tree nodes that set these properties need updating, so there is a migration guide entry. Most old values are rejected outright by the new enums; the two that still build are `pgain = <0x01>` (was 2x, now 1x) and `again = <0x01>` (was 4x, now 1x), which the guide calls out explicitly. `again = <0x10>` and `ppulse-length = <0x10>` happen to keep their meaning.