### PR TITLE
drivers: sensor: scd4x: restart measurement on rejected attributes and fix offset overflow

### DIFF
--- a/drivers/sensor/sensirion/scd4x/scd4x.c
+++ b/drivers/sensor/sensirion/scd4x/scd4x.c
@@ -659,6 +659,7 @@ int scd4x_attr_set(const struct device *dev, enum sensor_channel chan, enum sens
 		   const struct sensor_value *val)
 {
 	const struct scd4x_config *cfg = dev->config;
+	bool stopped = false;
 	int ret;
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP &&
@@ -672,99 +673,115 @@ int scd4x_attr_set(const struct device *dev, enum sensor_channel chan, enum sens
 			LOG_ERR("Failed to set idle mode.");
 			return ret;
 		}
+		stopped = true;
 	}
 
 	if (val->val1 < 0 || val->val2 < 0) {
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out;
 	}
 
 	switch ((enum sensor_attribute_scd4x)attr) {
 	case SENSOR_ATTR_SCD4X_TEMPERATURE_OFFSET:
 		if (val->val1 > SCD4X_TEMPERATURE_OFFSET_IDX_MAX) {
-			return -EINVAL;
+			ret = -EINVAL;
+			goto out;
 		}
 		ret = scd4x_set_temperature_offset(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set temperature offset.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_SENSOR_ALTITUDE:
 		if (val->val1 > SCD4X_SENSOR_ALTITUDE_IDX_MAX) {
-			return -EINVAL;
+			ret = -EINVAL;
+			goto out;
 		}
 		ret = scd4x_set_sensor_altitude(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set sensor altitude.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_AMBIENT_PRESSURE:
 		if (val->val1 > SCD4X_AMBIENT_PRESSURE_IDX_MAX || val->val1 < 700) {
-			return -EINVAL;
+			ret = -EINVAL;
+			goto out;
 		}
 		ret = scd4x_set_ambient_pressure(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set ambient pressure.");
-			return ret;
+			goto out;
 		}
-		/* return 0 to not call scd4x_start_measurement */
-		return 0;
+		break;
 	case SENSOR_ATTR_SCD4X_AUTOMATIC_CALIB_ENABLE:
 		if (val->val1 > SCD4X_BOOL_IDX_MAX) {
-			return -EINVAL;
+			ret = -EINVAL;
+			goto out;
 		}
 		ret = scd4x_set_automatic_calib_enable(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set automatic calib enable.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_SELF_CALIB_INITIAL_PERIOD:
 		if (val->val1 % 4) {
-			return -EINVAL;
+			ret = -EINVAL;
+			goto out;
 		}
 		if (cfg->model == SCD4X_MODEL_SCD40) {
 			LOG_ERR("SELF_CALIB_INITIAL_PERIOD not available for SCD40.");
-			return -ENOTSUP;
+			ret = -ENOTSUP;
+			goto out;
 		}
 		ret = scd4x_set_self_calib_initial_period(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set self calib initial period.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_SELF_CALIB_STANDARD_PERIOD:
 		if (val->val1 % 4) {
-			return -EINVAL;
+			ret = -EINVAL;
+			goto out;
 		}
 		if (cfg->model == SCD4X_MODEL_SCD40) {
 			LOG_ERR("SELF_CALIB_STANDARD_PERIOD not available for SCD40.");
-			return -ENOTSUP;
+			ret = -ENOTSUP;
+			goto out;
 		}
 		ret = scd4x_set_self_calib_standard_period(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set self calib standard period.");
-			return ret;
+			goto out;
 		}
 		break;
 	default:
-		return -ENOTSUP;
+		ret = -ENOTSUP;
+		goto out;
 	}
 
-	ret = scd4x_setup_measurement(dev);
-	if (ret < 0) {
-		LOG_ERR("Failed to setup measurement.");
-		return ret;
+	ret = 0;
+out:
+	if (stopped) {
+		int rc = scd4x_setup_measurement(dev);
+
+		if (rc < 0) {
+			LOG_ERR("Failed to setup measurement.");
+			return (ret != 0) ? ret : rc;
+		}
 	}
 
-	return 0;
+	return ret;
 }
 
 static int scd4x_attr_get(const struct device *dev, enum sensor_channel chan,
 			  enum sensor_attribute attr, struct sensor_value *val)
 {
 	const struct scd4x_config *cfg = dev->config;
+	bool stopped = false;
 	int ret;
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP &&
@@ -779,6 +796,7 @@ static int scd4x_attr_get(const struct device *dev, enum sensor_channel chan,
 			LOG_ERR("Failed to set idle mode.");
 			return ret;
 		}
+		stopped = true;
 	}
 
 	switch ((enum sensor_attribute_scd4x)attr) {
@@ -786,64 +804,71 @@ static int scd4x_attr_get(const struct device *dev, enum sensor_channel chan,
 		ret = scd4x_get_temperature_offset(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to get temperature offset.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_SENSOR_ALTITUDE:
 		ret = scd4x_get_sensor_altitude(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to get sensor altitude.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_AMBIENT_PRESSURE:
 		ret = scd4x_get_ambient_pressure(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to get ambient pressure.");
-			return ret;
+			goto out;
 		}
-		/* return 0 to not call scd4x_setup_measurement */
-		return 0;
+		break;
 	case SENSOR_ATTR_SCD4X_AUTOMATIC_CALIB_ENABLE:
 		ret = scd4x_get_automatic_calib_enable(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to get automatic calib.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_SELF_CALIB_INITIAL_PERIOD:
 		if (cfg->model == SCD4X_MODEL_SCD40) {
 			LOG_ERR("SELF_CALIB_INITIAL_PERIOD not available for SCD40.");
-			return -ENOTSUP;
+			ret = -ENOTSUP;
+			goto out;
 		}
 		ret = scd4x_get_self_calib_initial_period(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set get self calib initial period.");
-			return ret;
+			goto out;
 		}
 		break;
 	case SENSOR_ATTR_SCD4X_SELF_CALIB_STANDARD_PERIOD:
 		if (cfg->model == SCD4X_MODEL_SCD40) {
 			LOG_ERR("SELF_CALIB_STANDARD_PERIOD not available for SCD40.");
-			return -ENOTSUP;
+			ret = -ENOTSUP;
+			goto out;
 		}
 		ret = scd4x_get_self_calib_standard_period(dev, val);
 		if (ret < 0) {
 			LOG_ERR("Failed to set get self calib standard period.");
-			return ret;
+			goto out;
 		}
 		break;
 	default:
-		return -ENOTSUP;
+		ret = -ENOTSUP;
+		goto out;
 	}
 
-	ret = scd4x_setup_measurement(dev);
-	if (ret < 0) {
-		LOG_ERR("Failed to setup measurement.");
-		return ret;
+	ret = 0;
+out:
+	if (stopped) {
+		int rc = scd4x_setup_measurement(dev);
+
+		if (rc < 0) {
+			LOG_ERR("Failed to setup measurement.");
+			return (ret != 0) ? ret : rc;
+		}
 	}
 
-	return 0;
+	return ret;
 }
 
 static int scd4x_init(const struct device *dev)

--- a/drivers/sensor/sensirion/scd4x/scd4x.c
+++ b/drivers/sensor/sensirion/scd4x/scd4x.c
@@ -311,12 +311,12 @@ static int scd4x_get_temperature_offset(const struct device *dev, struct sensor_
 		return ret;
 	}
 
-	int32_t temp;
+	int64_t temp;
 
 	/*Calculation from Datasheet*/
 	temp = sys_get_be16(rx_buf) * SCD4X_MAX_TEMP;
 	val->val1 = (int32_t)(temp / 0xFFFF);
-	val->val2 = ((temp % 0xFFFF) * 1000000) / 0xFFFF;
+	val->val2 = (int32_t)(((temp % 0xFFFF) * 1000000) / 0xFFFF);
 
 	return 0;
 }


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the SCD4x driver, one commit
per issue:

- **Restart measurement on rejected attributes**: `attr_set()` and `attr_get()`
  stop the periodic measurement *before* validating the value and the attribute,
  but every validation failure returned directly — leaving the sensor parked in
  idle (or, in single-shot mode, powered down) with no way back short of a
  reboot. A single `-EINVAL` from an out-of-range altitude, or a `-ENOTSUP` from
  querying an SCD41-only attribute on an SCD40, silently froze `sample_fetch()`
  forever. Route all post-stop exits through a common tail that restarts the
  measurement whenever it was actually stopped, and report the original error in
  preference to a restart failure.
- **Fix overflow in temperature offset getter**: `get_temperature_offset()`
  computed the fractional part as `(temp % 0xFFFF) * 1000000` in 32-bit
  arithmetic. The remainder can reach 65534, so the product overflows `int32_t`
  for any remainder above ~2147, i.e. for all but the smallest offsets, and the
  reported micro-degrees were garbage. Widen the intermediate to `int64_t`,
  matching the conversion already used in `channel_get()`.