### PR TITLE
drivers: sensor: als31300: fix magnetic field scaling and Q31 encoding shift

### DIFF
--- a/drivers/sensor/als31300/als31300.c
+++ b/drivers/sensor/als31300/als31300.c
@@ -73,18 +73,13 @@ void als31300_parse_registers(const uint8_t *buf, struct als31300_readings *read
  * @brief Convert raw magnetic field value to microgauss
  * This function converts the 12-bit signed raw magnetic field value to
  * microgauss units
- * Formula: microgauss = (raw_value * 500 * 1000000) / 4096
+ * Based on datasheet formula: gauss = raw_value / sensitivity
  * @param raw_value Signed 12-bit magnetic field value
  * @return Magnetic field in microgauss
  */
 int32_t als31300_convert_to_gauss(int16_t raw_value)
 {
-	/* Convert to microgauss
-	 * For 500G full scale: (raw_value * 500 * 1000000) / 4096
-	 * This gives us the fractional part in microgauss
-	 */
-	return ((int64_t)raw_value * ALS31300_FULL_SCALE_RANGE_GAUSS * 1000000) /
-	       ALS31300_12BIT_RESOLUTION;
+	return ((int64_t)raw_value * 1000000) / ALS31300_SENSITIVITY_LSB_PER_GAUSS;
 }
 
 /**

--- a/drivers/sensor/als31300/als31300.h
+++ b/drivers/sensor/als31300/als31300.h
@@ -79,9 +79,8 @@
 #define ALS31300_REG29_RESERVED_SHIFT 21
 
 /* ALS31300 sensitivity and conversion constants */
-#define ALS31300_FULL_SCALE_RANGE_GAUSS 500  /* 500 gauss full scale */
-#define ALS31300_12BIT_RESOLUTION       4096 /* 2^12 for 12-bit resolution */
-#define ALS31300_12BIT_SIGN_BIT_INDEX   11   /* Sign bit position for 12-bit values (0-based) */
+#define ALS31300_SENSITIVITY_LSB_PER_GAUSS 4  /* ALS31300-500; -1000/-2000/-JOY differ */
+#define ALS31300_12BIT_SIGN_BIT_INDEX      11 /* Sign bit position for 12-bit values (0-based) */
 
 /* ALS31300 EEPROM Register 0x02 bit field definitions */
 #define ALS31300_EEPROM_CUSTOMER_EE_MASK  GENMASK(4, 0) /* Bits 4:0 */

--- a/drivers/sensor/als31300/als31300_decoder.c
+++ b/drivers/sensor/als31300/als31300_decoder.c
@@ -55,12 +55,12 @@ static void als31300_convert_raw_to_q31_magn(int16_t raw_value, q31_t *q31_out)
 	/* Convert to microgauss using integer arithmetic */
 	int32_t microgauss = als31300_convert_to_gauss(raw_value);
 
-	/* Convert to Q31 format: Q31 = (value * 2^shift) / 1000000
-	 * For magnetic field, we use shift=16, so the full scale is ±2^(31-16) = ±32768 gauss
+	/* Convert to Q31 format: Q31 = (value * 2^(31 - shift)) / 1000000
+	 * For magnetic field, we use shift=16, so the full scale is ±2^16 = ±65536 gauss
 	 * This gives us good resolution for the ±500G range of the ALS31300
-	 * microgauss * 2^16 / 1000000 = microgauss * 65536 / 1000000
+	 * microgauss * 2^15 / 1000000 = microgauss * 32768 / 1000000
 	 */
-	*q31_out = (q31_t)(((int64_t)microgauss << ALS31300_MAGN_SHIFT) / 1000000);
+	*q31_out = (q31_t)(((int64_t)microgauss << (31 - ALS31300_MAGN_SHIFT)) / 1000000);
 }
 
 /**
@@ -73,12 +73,12 @@ static void als31300_convert_temp_to_q31(uint16_t raw_temp, q31_t *q31_out)
 	/* Convert to microcelsius using integer arithmetic */
 	int32_t microcelsius = als31300_convert_temperature(raw_temp);
 
-	/* Convert to Q31 format: Q31 = (value * 2^shift) / 1000000
-	 * For temperature, we use shift=16, so the full scale is ±2^(31-16) = ±32768°C
+	/* Convert to Q31 format: Q31 = (value * 2^(31 - shift)) / 1000000
+	 * For temperature, we use shift=16, so the full scale is ±2^16 = ±65536°C
 	 * This gives us good resolution for typical temperature ranges (-40°C to +125°C)
-	 * microcelsius * 2^16 / 1000000 = microcelsius * 65536 / 1000000
+	 * microcelsius * 2^15 / 1000000 = microcelsius * 32768 / 1000000
 	 */
-	*q31_out = (q31_t)(((int64_t)microcelsius << ALS31300_TEMP_SHIFT) / 1000000);
+	*q31_out = (q31_t)(((int64_t)microcelsius << (31 - ALS31300_TEMP_SHIFT)) / 1000000);
 }
 
 /**


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the ALS31300 driver, one commit per issue. Each is a factor of two, and on the RTIO path they happened to cancel out — so the streaming magnetometer readings looked roughly right while both the synchronous magnetometer path and the streaming *temperature* path were wrong.

- **Fix Q31 encoding shift in decoder**: the decoder encoded values as `value << shift`, but the Zephyr Q31 convention is `real = q31 * 2^shift / 2^31`, i.e. the encoder must shift by `31 - shift`. With `shift = 16` published in the decoded data header, every magnetic field and temperature reading came out at twice its true value.
- **Scale magnetic data by the datasheet sensitivity**: `als31300_convert_to_gauss()` derived its scale as 500 G / 4096 codes. The raw value is sign-extended 12-bit and only spans 2048 codes, which by itself made every `sensor_channel_get()` magnetometer reading half the actual field. But the [datasheet](https://www.allegromicro.com/-/media/files/datasheets/als31300-datasheet.ashx) doesn't define the scale that way at all — it specifies sensitivity directly (4 LSB/G for the ALS31300-500) and gives `gauss = raw / sensitivity`, with a worked example of `-1018 LSB ÷ 4 LSB/G = -254 G`. The ±500 G in the part number is the Optimized Sensing Range, not the code-range endpoint: at 4 LSB/G the ±2048 codes actually reach ±512 G, so deriving the scale from 500/2048 would still leave a systematic 2.3% error. Use the specified sensitivity instead.

The driver assumes the ALS31300-500. The -1000, -2000 and -JOY variants are trimmed to different sensitivities and would need a devicetree property to support, which the header now notes.
