### PR TITLE
Bluetooth: Classic: Remove struct bt_avctp_event_cb

### DIFF
--- a/subsys/bluetooth/host/classic/avctp_internal.h
+++ b/subsys/bluetooth/host/classic/avctp_internal.h
@@ -154,10 +154,6 @@ struct bt_avctp_server {
 	sys_snode_t node;
 };
 
-struct bt_avctp_event_cb {
-	int (*accept)(struct bt_conn *conn, struct bt_avctp **session);
-};
-
 /* Initialize AVCTP layer*/
 void bt_avctp_init(void);
 


### PR DESCRIPTION
struct bt_avctp_event_cb was unused.