### PR TITLE
drivers: sensor: afbr_s50: fix double completion on evaluation error and uninitialised timestamp

### DIFF
--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -122,6 +122,7 @@ static void data_ready_work_handler(struct rtio_iodev_sqe *iodev_sqe)
 	if (status != STATUS_OK) {
 		LOG_ERR("Data not valid: %d, %d", status, edata->payload.Status);
 		handle_error_on_result(data, -EIO);
+		return;
 	}
 	CHECKIF(Argus_IsDataEvaluationPending(data->platform.argus.handle)) {
 		LOG_WRN("Overrun. More pending data than what we've served.");

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50_decoder.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50_decoder.c
@@ -111,6 +111,7 @@ static int afbr_s50_decoder_decode(const uint8_t *buffer,
 
 		/* Result comes encoded in Q9.22 format */
 		out->shift = 9;
+		out->readings[0].timestamp_delta = 0;
 		out->readings[0].value = edata->payload.Bin.Range;
 
 		*fit = 1;


### PR DESCRIPTION
This PR fixes two independent correctness bugs in the AFBR-S50 driver, one
commit per issue:

- **Init timestamp_delta on distance decode**: the `SENSOR_CHAN_DISTANCE` decode
  path filled in `shift` and `readings[0].value` but never
  `readings[0].timestamp_delta`, so consumers computing per-sample timestamps
  read whatever happened to be in the caller's output buffer. The
  `SENSOR_CHAN_AFBR_S50_PIXELS` branch right next to it already zeroes it.
- **Return after data evaluation error**: when `Argus_EvaluateData()` failed,
  `handle_error_on_result()` completed the RTIO submission with an error and the
  handler then fell through and completed the *same* submission again with
  `rtio_iodev_sqe_ok()`. That double-completes a released SQE — a use-after-free
  on the RTIO queue — and reports success for a measurement that was just
  declared invalid. Every other error path in the function already returns
  immediately.

Fixes: #117253