### PR TITLE
drivers: sensor: lps2xdf: fix pressure decimal part in 4060 hPa full scale

### DIFF
--- a/drivers/sensor/st/lps2xdf/lps2xdf.c
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.c
@@ -92,7 +92,7 @@ static inline void lps2xdf_press_convert(const struct device *dev,
 {
 	const struct lps2xdf_config *const cfg = dev->config;
 	int32_t press_tmp = raw_val >> 8; /* raw value is left aligned (24 msb) */
-	int divider;
+	int divider, factor;
 
 	/* Pressure sensitivity is:
 	 * - 4096 LSB/hPa for Full-Scale of 260 - 1260 hPa:
@@ -101,15 +101,16 @@ static inline void lps2xdf_press_convert(const struct device *dev,
 	 */
 	if (cfg->fs == 0) {
 		divider = 40960;
+		/* For the decimal part use (3125 / 128) as a factor instead of
+		 * (1000000 / 40960) to avoid int32 overflow
+		 */
+		factor = 3125;
 	} else {
 		divider = 20480;
+		factor = 6250;
 	}
 	val->val1 = press_tmp / divider;
-
-	/* For the decimal part use (3125 / 128) as a factor instead of
-	 * (1000000 / 40960) to avoid int32 overflow
-	 */
-	val->val2 = (press_tmp % divider) * 3125 / 128;
+	val->val2 = (press_tmp % divider) * factor / 128;
 }
 
 


### PR DESCRIPTION
`lps2xdf_press_convert()` selects the integer divider from the configured full
scale (40960 for the 4096 LSB/hPa mode, 20480 for the 2048 LSB/hPa mode) but
always scaled the fractional part with the `3125 / 128` factor, which is the
overflow-avoiding form of `1000000 / 40960` and therefore only correct in the
1260 hPa mode.

In the 4060 hPa full-scale mode the decimal part came out at half its true
value, so a reading of e.g. 100.5 kPa was reported as 100.25 kPa. Select the
factor alongside the divider (`6250 / 128` for the 4060 hPa mode); the widened
product still fits comfortably in `int32_t`.