### PR TITLE
Bluetooth: Classic: Remove bt_hfp_hf.hf_buffer

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_hf_internal.h
@@ -223,7 +223,6 @@ struct bt_hfp_hf {
 	/* SCL work */
 	struct k_work slc_work;
 
-	char hf_buffer[HF_MAX_BUF_LEN];
 	struct at_client at;
 	uint32_t hf_features;
 	uint32_t ag_features;


### PR DESCRIPTION
Remove bt_hfp_hf.hf_buffer as it is unused.