### PR TITLE
drivers: sensor: mpu6050: fix die temperature offset constant

### DIFF
--- a/drivers/sensor/tdk/mpu6050/mpu6050.c
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.c
@@ -53,7 +53,7 @@ static inline void mpu6050_convert_temp(enum mpu6050_device_type device_type,
 
 	case DEVICE_TYPE_MPU6050:
 	default:
-		tmp_val = (tmp_val / 340) + 36000000;
+		tmp_val = (tmp_val / 340) + 36530000;
 	};
 
 	val->val1 = tmp_val / 1000000;


### PR DESCRIPTION
The MPU6050 die-temperature conversion applied a 36.00 °C offset, but the
InvenSense MPU-6000/6050 register map specifies

    Temperature in °C = TEMP_OUT / 340 + 36.53

so every `SENSOR_CHAN_DIE_TEMP` reading came back 0.53 °C low.

Use 36530000 microdegrees.

<img width="1341" height="1036" alt="Screenshot_20260820-223536" src="https://github.com/user-attachments/assets/ce2e9067-6dbb-46d6-ac41-d48fa7cd6434" />
