### PR TITLE
drivers: sensor: bme280: don't advertise humidity data on BMP280 in RTIO path

### DIFF
--- a/drivers/sensor/bosch/bme280/bme280_async.c
+++ b/drivers/sensor/bosch/bme280/bme280_async.c
@@ -23,6 +23,8 @@ void bme280_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
 	const struct device *dev = cfg->sensor;
+	const struct bme280_data *data = dev->data;
+	const bool has_hum = (data->chip_id == BME280_CHIP_ID);
 	const struct sensor_chan_spec *const channels = cfg->channels;
 	const size_t num_channels = cfg->count;
 
@@ -55,14 +57,14 @@ void bme280_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 			edata->has_temp = 1;
 			break;
 		case SENSOR_CHAN_HUMIDITY:
-			edata->has_humidity = 1;
+			edata->has_humidity = has_hum ? 1 : 0;
 			break;
 		case SENSOR_CHAN_PRESS:
 			edata->has_press = 1;
 			break;
 		case SENSOR_CHAN_ALL:
 			edata->has_temp = 1;
-			edata->has_humidity = 1;
+			edata->has_humidity = has_hum ? 1 : 0;
 			edata->has_press = 1;
 			break;
 		default:


### PR DESCRIPTION
`bme280_submit_sync()` set `edata->has_humidity` unconditionally, for both an
explicit `SENSOR_CHAN_HUMIDITY` request and `SENSOR_CHAN_ALL`. But the fetch
helper only populates `comp_humidity` when the part is a BME280 — the BMP280
has no humidity sensor and its register block is three bytes shorter.

On a BMP280, an RTIO read therefore came back with the humidity flag set over an
untouched `comp_humidity` field, and the decoder happily reported those
uninitialised bytes as a valid relative-humidity sample. The synchronous
`bme280_channel_get()` path already guards this with an explicit chip-ID check
and returns `-ENOTSUP`; gate the encoded flag the same way so the decoder
reports no humidity frames instead.