### PR TITLE
drivers: sensor: ms5607: report pressure in kPa instead of mbar

### DIFF
--- a/drivers/sensor/meas/ms5607/ms5607.c
+++ b/drivers/sensor/meas/ms5607/ms5607.c
@@ -151,8 +151,9 @@ static int ms5607_channel_get(const struct device *dev,
 		val->val2 = data->temperature % 100 * 10000;
 		break;
 	case SENSOR_CHAN_PRESS:
-		val->val1 = data->pressure / 100;
-		val->val2 = data->pressure % 100 * 10000;
+		/* Internal value is (mbar * 100), so factor to kPa is 1000 */
+		val->val1 = data->pressure / 1000;
+		val->val2 = data->pressure % 1000 * 1000;
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
`ms5607_compensate()` produces pressure in units of 0.01 mbar (i.e. Pa), as the
MEAS conversion sequence specifies, but `channel_get()` only divided by 100 —
yielding millibars. `SENSOR_CHAN_PRESS` is defined in kilopascal, so every
reading was reported 10x too large: standard atmospheric pressure came out as
1013 kPa instead of 101.3 kPa.

Scale by 1000 instead. The sibling `ms5837` driver, which shares the same
compensation output format, already does exactly this.