### PR TITLE
drivers: sensor: rm3100: set read bit on one-shot measurement read

### DIFF
--- a/drivers/sensor/pni/rm3100/rm3100.c
+++ b/drivers/sensor/pni/rm3100/rm3100.c
@@ -90,7 +90,7 @@ static void rm3100_submit_one_shot(const struct device *dev, struct rtio_iodev_s
 		return;
 	}
 
-	uint8_t val = RM3100_REG_MX;
+	uint8_t val = RM3100_REG_MX | REG_READ_BIT;
 
 	rtio_sqe_prep_tiny_write(write_sqe,
 				 data->rtio.iodev,


### PR DESCRIPTION
`rm3100_submit_one_shot()` prepared the address phase of the measurement burst
with the bare `RM3100_REG_MX` value, while every other register read in the
driver — the synchronous bus helper and both reads in the streaming path — ORs
in `REG_READ_BIT`.

On SPI that bit is the R/W flag, so the device interpreted the one-shot transfer
as a *write* to MX and never shifted measurement data out; the decoder then
converted whatever the MISO line happened to hold. Set the read bit to match the
other paths.