### PR TITLE
drivers: sensor: lis2du12: read interrupt mode before modifying it

### DIFF
--- a/drivers/sensor/st/lis2du12/lis2du12_trigger.c
+++ b/drivers/sensor/st/lis2du12/lis2du12_trigger.c
@@ -121,7 +121,7 @@ int lis2du12_enable_delta_int(const struct device *dev, int enable)
 
 	lis2du12_int_mode_t int_mode;
 
-	if (lis2du12_interrupt_mode_set(ctx, &int_mode) < 0) {
+	if (lis2du12_interrupt_mode_get(ctx, &int_mode) < 0) {
 		LOG_ERR("failed reading int mode");
 		return -EIO;
 	}


### PR DESCRIPTION
`lis2du12_enable_delta_int()` performs a read-modify-write on the interrupt
mode, but the read step called `lis2du12_interrupt_mode_set()` instead of
`..._get()`. The `int_mode` struct is uninitialised at that point, so arming or
disarming a delta trigger wrote whatever was on the stack into `INTERRUPT_CFG`
and `CTRL1` — corrupting interrupt polarity, latching and the pin routing —
before the intended `enable` update was applied on top of the same garbage.

The wake-up-mode block immediately above uses the correct
`wake_up_mode_get()` / `wake_up_mode_set()` pair, which is what makes this read
as a copy/paste slip. Use `lis2du12_interrupt_mode_get()` for the read.