### PR TITLE
drivers: sensor: pcnt_esp32: enable unit interrupts in init

### DIFF
--- a/drivers/sensor/espressif/pcnt_esp32/pcnt_esp32.c
+++ b/drivers/sensor/espressif/pcnt_esp32/pcnt_esp32.c
@@ -309,6 +309,14 @@ int pcnt_esp32_init(const struct device *dev)
 		return ret;
 	}
 
+	/* Unmask the events at the peripheral, now that a handler is installed. */
+	for (uint8_t i = 0; i < config->unit_len; i++) {
+		uint8_t u = config->unit_config[i].idx;
+
+		pcnt_ll_clear_intr_status(data->hal.dev, BIT(u));
+		pcnt_ll_enable_intr(data->hal.dev, BIT(u), true);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
The init routine enables the high/low limit events, but those only set the comparator enable in `PCNT_Un_CONF0_REG`: the event stays masked out of `PCNT_INT_ST_REG` until `PCNT_INT_ENA_REG` is set. The ISR never ran, so the software accumulator extending the 16-bit counter never advanced and the reported count silently wrapped. The pending-wrap compensation in `pcnt_esp32_read_count()` was inert too, as it reads the masked status.

Registering a threshold trigger was the only way to get a working count, because `trigger_set()` does the same `clear_intr_status()` + `enable_intr()` pair.

Arm the interrupt for every unit after the ISR is allocated, as ESP-IDF's `pcnt_unit_alloc()` does when count accumulation is requested.

References:
- [ESP32 TRM v5.8](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) §23.2.3 ("five watchpoints that share one interrupt; interrupt generation can be enabled or disabled for each individual watchpoint") and §23.3, which lists `PCNT_INT_ENA_REG` @ 0x0088 and `PCNT_INT_ST_REG` @ 0x0084 as the *masked* status, separate from the `PCNT_THR_H_LIM_EN_Un` comparator enable in `PCNT_Un_CONF0_REG`.
- ESP-IDF [`pulse_cnt.c`](https://github.com/espressif/esp-idf/blob/master/components/esp_driver_pcnt/src/pulse_cnt.c), `pcnt_unit_alloc()`: installs the ISR when `flags.accum_count` is set, then `pcnt_ll_enable_intr(hal.dev, PCNT_LL_UNIT_WATCH_EVENT(unit_id), to_install_isr)` — same `BIT(unit)` mask, same ordering.
