### PR TITLE
drivers: sensor: ens160: fix SPI multi-byte write payload

### DIFF
--- a/drivers/sensor/ens160/ens160_spi.c
+++ b/drivers/sensor/ens160/ens160_spi.c
@@ -123,7 +123,7 @@ static int ens160_write_data_spi(const struct device *dev, uint8_t reg, uint8_t 
 			.len = 1,
 		},
 		{
-			.buf = &data,
+			.buf = data,
 			.len = len,
 		}
 	};


### PR DESCRIPTION
`ens160_write_data_spi()` set the payload `spi_buf` to `&data` — the address of
the `uint8_t *` parameter itself, a stack location — rather than `data`. The
transfer therefore clocked out `len` bytes of the pointer variable's own
representation instead of the caller's buffer, so every multi-byte register
write (the temperature/humidity compensation values) programmed garbage into the
device.

It type-checks because `spi_buf.buf` is `void *`. The read path in the same file
and the I2C implementation both pass `data` directly; do the same here.