### PR TITLE
drivers: sensor: akm09918c: track power-down after RTIO measurement

### DIFF
--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
@@ -64,6 +64,8 @@ void akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe
 		writeByte_sqe->flags |= RTIO_SQE_CHAINED;
 		rtio_sqe_prep_callback_no_cqe(cb_sqe, akm09918_after_start_cb, (void *)iodev_sqe,
 					      NULL);
+		/* The device returns to power-down mode after a single measurement */
+		data->mode = AKM09918C_CNTL2_PWR_DOWN;
 		rtio_submit(data->rtio_ctx, 0);
 	} else {
 		rtio_sqe_drop_all(data->rtio_ctx);


### PR DESCRIPTION
`akm09918c_submit()` writes `CNTL2 = SINGLE_MEASURE` unconditionally, but never
updates `data->mode`. The AKM09918C returns to power-down by itself once a
single measurement completes, so after any RTIO read the cached mode no longer
describes the device.

`akm09918c_start_measurement_blocking()` only issues its own `CNTL2` write when
the cached mode is power-down. Mixing an RTIO read with the synchronous API on a
device left in a continuous mode therefore left the driver believing it was
still free-running while the part was actually powered down — every subsequent
`sample_fetch()` found DRDY clear and returned `-EBUSY`, permanently.

Set the cached mode to power-down when the single measurement is issued.