### PR TITLE
drivers: sensor: ccs811: report I2C errors from baseline fetch

### DIFF
--- a/drivers/sensor/ams/ccs811/ccs811.c
+++ b/drivers/sensor/ams/ccs811/ccs811.c
@@ -130,7 +130,7 @@ int ccs811_baseline_fetch(const struct device *dev)
 	rc = i2c_write_read_dt(&config->i2c, &cmd, sizeof(cmd), (uint8_t *)&baseline,
 			       sizeof(baseline));
 	set_wake(dev, false);
-	if (rc <= 0) {
+	if (rc == 0) {
 		rc = baseline;
 	}
 


### PR DESCRIPTION
`ccs811_baseline_fetch()` is documented to return the baseline value or a
negative errno, but it tested the `i2c_write_read_dt()` result with `rc <= 0` —
which is true on failure as well as on success. A failed transfer therefore
overwrote the errno with the uninitialised stack contents of `baseline` and
returned that to the caller, which reads as either a plausible baseline value or
a nonsensical negative error, depending on what happened to be on the stack.

Test for success with `rc == 0`.