### PR TITLE
drivers: sensor: ad2s1210: fix swapped RES0/RES1 encoding for 12/14-bit

### DIFF
--- a/drivers/sensor/adi/ad2s1210/ad2s1210.c
+++ b/drivers/sensor/adi/ad2s1210/ad2s1210.c
@@ -598,10 +598,10 @@ static int ad2s1210_set_resolution(const struct device *dev, enum ad2s1210_res r
 	case AD2S1210_RES_10BIT:
 		break;
 	case AD2S1210_RES_12BIT:
-		control |= AD2S1210_CONTROL_RES1_MASK;
+		control |= AD2S1210_CONTROL_RES0_MASK;
 		break;
 	case AD2S1210_RES_14BIT:
-		control |= AD2S1210_CONTROL_RES0_MASK;
+		control |= AD2S1210_CONTROL_RES1_MASK;
 		break;
 	case AD2S1210_RES_16BIT:
 		control |= (AD2S1210_CONTROL_RES1_MASK | AD2S1210_CONTROL_RES0_MASK);


### PR DESCRIPTION
`ad2s1210_set_resolution()` programmed the control register's RES1:RES0 field
with `0b10` for 12-bit and `0b01` for 14-bit — the reverse of the documented
encoding (`00` = 10-bit, `01` = 12-bit, `10` = 14-bit, `11` = 16-bit), which
ADI's own Linux IIO driver spells out as `AD2S1210_RES_12 = 0b01` /
`AD2S1210_RES_14 = 0b10` in the same two-bit field.

A board asking for 12-bit therefore ran the part at 14-bit and vice versa, so
position and velocity readings were scaled by a factor of four in the wrong
direction. The RES0/RES1 GPIO lines are driven from the same `control` value a
few lines further down, so the pin states were inconsistent with the requested
resolution too.