### PR TITLE
kernel: mm: value of K_MEM_CACHE_* macros changed

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -68,6 +68,10 @@ Kernel
   keeping ``SCHED_SIMPLE`` for affinity purposes can now use their preferred
   backend directly.
 
+* The underlying values of macros :c:macro:`K_MEM_CACHE_NONE`, :c:macro:`K_MEM_CACHE_WT`
+  and :c:macro:`K_MEM_CACHE_WB` have changed. If the caching attribute is not specified,
+  no caching is now the default instead of write-back caching.
+
 Boards
 ******
 

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -33,13 +33,13 @@
  */
 
 /** No caching. Most drivers want this. */
-#define K_MEM_CACHE_NONE	2
+#define K_MEM_CACHE_NONE	0
 
 /** Write-through caching. Used by certain drivers. */
 #define K_MEM_CACHE_WT		1
 
 /** Full write-back caching. Any RAM mapped wants this. */
-#define K_MEM_CACHE_WB		0
+#define K_MEM_CACHE_WB		2
 
 /*
  * ARM64 Specific flags are defined in arch/arm64/arm_mem.h,

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -579,7 +579,7 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 
 	__ASSERT(!is_anon || (is_anon && page_frames_initialized),
 		 "%s called too early", __func__);
-	__ASSERT((flags & K_MEM_CACHE_MASK) == 0U,
+	__ASSERT((flags & K_MEM_CACHE_MASK) == K_MEM_CACHE_WB,
 		 "%s does not support explicit cache settings", __func__);
 
 	if (((flags & K_MEM_PERM_USER) != 0U) &&


### PR DESCRIPTION
The underlying values of K_MEM_CACHE_* macros have changed so that if caching attribute is not specified, the default behavior now is not to cache the page, instead of the old behavior where write-back was the default.