### PR TITLE
MCTP over I2C+GPIO fixes

### DIFF
--- a/subsys/pmci/mctp/mctp_i2c_gpio_target.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_target.c
@@ -176,6 +176,10 @@ int mctp_i2c_gpio_target_stop(struct i2c_target_config *config)
 		}
 	}
 
+	/* After stop, a new register must be selected */
+	b->reg_addr = MCTP_I2C_GPIO_INVALID_ADDR;
+	b->rxtx = false;
+
 	return 0;
 }
 

--- a/subsys/pmci/mctp/mctp_i2c_gpio_target.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_target.c
@@ -115,17 +115,16 @@ int mctp_i2c_gpio_target_read_processed(struct i2c_target_config *config, uint8_
 	struct mctp_binding_i2c_gpio_target *b =
 		CONTAINER_OF(config, struct mctp_binding_i2c_gpio_target, i2c_target_cfg);
 
-	b->tx_idx += 1;
-
 	if (b->reg_addr != MCTP_I2C_GPIO_TX_MSG_ADDR) {
 		goto out;
 	}
 
-	if (b->tx_idx > b->tx_pkt->end) {
+	if (b->tx_idx + 1 >= b->tx_pkt->end) {
 		LOG_WRN("rrp past end reg %d", b->reg_addr);
 		return -EIO;
 	}
 
+	b->tx_idx += 1;
 	*val = b->tx_pkt->data[b->tx_idx];
 
 out:

--- a/subsys/pmci/mctp/mctp_i2c_gpio_target.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_target.c
@@ -98,6 +98,11 @@ int mctp_i2c_gpio_target_read_requested(struct i2c_target_config *config, uint8_
 		*val = pkt_len;
 		break;
 	case MCTP_I2C_GPIO_TX_MSG_ADDR:
+		if (b->tx_pkt == NULL || b->tx_pkt->start >= b->tx_pkt->end) {
+			LOG_WRN("No packet to send");
+			ret = -EIO;
+			break;
+		}
 		b->rxtx = true;
 		*val = b->tx_pkt->data[b->tx_pkt->start];
 		b->tx_idx = b->tx_pkt->start;
@@ -117,6 +122,11 @@ int mctp_i2c_gpio_target_read_processed(struct i2c_target_config *config, uint8_
 
 	if (b->reg_addr != MCTP_I2C_GPIO_TX_MSG_ADDR) {
 		goto out;
+	}
+
+	if (b->tx_pkt == NULL)  {
+		LOG_WRN("No packet to process");
+		return -EIO;
 	}
 
 	if (b->tx_idx + 1 >= b->tx_pkt->end) {


### PR DESCRIPTION
Some fixes, all around some "protocol confusion"[1]:
  - Off-by-one reading if a buggy controller issued a longer reading than expected;
  - A buggy controller could ask a read with no packet to be read

[1] "Protocol" here is the simple protocol used by the target to accept readings from the controller. It was supposed to write to a "register" and read either the length of the available packet or the packet data. But a buggy controller could confuse the target, so some checks are added.

Fixes: #117353