### PR TITLE
drivers: serial: silabs: fix TX interrupt storm in usart and gecko drivers

### DIFF
--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -235,9 +235,8 @@ static int uart_gecko_fifo_read(const struct device *dev, uint8_t *rx_data,
 static void uart_gecko_irq_tx_enable(const struct device *dev)
 {
 	const struct uart_gecko_config *config = dev->config;
-	uint32_t mask = USART_IEN_TXBL | USART_IEN_TXC;
 
-	USART_IntEnable(config->base, mask);
+	USART_IntEnable(config->base, USART_IEN_TXBL);
 }
 
 static void uart_gecko_irq_tx_disable(const struct device *dev)
@@ -246,6 +245,7 @@ static void uart_gecko_irq_tx_disable(const struct device *dev)
 	uint32_t mask = USART_IEN_TXBL | USART_IEN_TXC;
 
 	USART_IntDisable(config->base, mask);
+	USART_IntClear(config->base, USART_IF_TXC);
 }
 
 static int uart_gecko_irq_tx_complete(const struct device *dev)

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -213,7 +213,7 @@ static void uart_silabs_irq_tx_enable(const struct device *dev)
 	const struct uart_silabs_config *config = dev->config;
 
 	(void)uart_silabs_pm_lock_get(dev, UART_SILABS_PM_LOCK_TX);
-	USART_IntEnable(config->base, USART_IEN_TXBL | USART_IEN_TXC);
+	USART_IntEnable(config->base, USART_IEN_TXBL);
 }
 
 static void uart_silabs_irq_tx_disable(const struct device *dev)
@@ -221,6 +221,7 @@ static void uart_silabs_irq_tx_disable(const struct device *dev)
 	const struct uart_silabs_config *config = dev->config;
 
 	USART_IntDisable(config->base, USART_IEN_TXBL | USART_IEN_TXC);
+	USART_IntClear(config->base, USART_IF_TXC);
 	(void)uart_silabs_pm_lock_put(dev, UART_SILABS_PM_LOCK_TX);
 }
 


### PR DESCRIPTION
The Silabs USART and legacy Gecko serial drivers enable the TXC (transmit complete) interrupt from `uart_irq_tx_enable()` alongside TXBL, but nothing in the standard interrupt-driven flow ever clears the TXC flag: it is write-1-to-clear, and the only function that clears it is `uart_irq_tx_complete()`, which typical interrupt handlers (the console, the shell backend, the Bluetooth monitor — anything servicing only `uart_irq_tx_ready()` / `uart_irq_rx_ready()`) never call.

Once the first transmission completes, TXC stays pending forever. From then on the UART interrupt re-enters continuously whenever TX is enabled, spinning at hardware interrupt priority between TXBL servicing opportunities — one byte time apart at the configured baud rate. The driver's own `irq_is_pending()` does not include TXC, so the documented `while (uart_irq_update() && uart_irq_is_pending())` handler idiom cannot even observe the interrupt cause it is being invoked for.

**Impact measured on xg24_rb4186c** (found via Bluetooth monitor stress testing): 82017 ISR entries for 1811 productive TX-ready services. The storm throttles every thread on the CPU to the UART byte rate while TX is active, and starves the radio hard enough to break Bluetooth link supervision under sustained load. With the fix, the same workload shows 805139 productive services in 806757 ISR entries.

**Relationship to #115644** (commit 3a6406439c5a): that fix corrected flag clearing *inside* `irq_tx_complete()` and `err_check()`, but did not change TXC being enabled as an NVIC interrupt source that no standard handler acknowledges. The storm above was measured with #115644 already merged.

**Per driver:**

- `uart_silabs_usart.c`: fixed and validated on hardware (xg24_rb4186c / BRD4186B, counters above).
- `uart_gecko.c`: shares the exact vulnerable structure (TXC enabled, no stale-flag clearing in enable/disable, `irq_is_pending()` blind to TXC); fixed identically. Build-tested for `slwrb4104a` with `CONFIG_UART_INTERRUPT_DRIVEN=y`, not run on Series 0/1 hardware.
- `uart_silabs_eusart.c`: **verified unaffected** on the same xg24 hardware (497 ISR entries / 497 productive for a 512-byte transmission with the unmodified driver). Its `irq_tx_enable()`/`irq_tx_disable()` already clear stale TXC, which prevents the pending-flag-from-previous-transmission mechanism from arming. No change needed.

The fix in both drivers: only enable TXBL, which is sufficient to pace FIFO refills, and clear the stale TXC flag when TX is disabled so `uart_irq_tx_complete()` cannot report a completion from a previous transmission. TXC remains readable through `uart_irq_tx_complete()`, which uses the raw interrupt flag rather than the enabled mask.

An alternative considered and rejected: requiring handlers to call `uart_irq_tx_complete()` every pass to acknowledge TXC would be a new, undocumented contract that no in-tree interrupt handler follows today.
