### PR TITLE
samples: nxp: tflm_neutron: do not build without Neutron blobs

### DIFF
--- a/samples/boards/nxp/tflm_neutron/CMakeLists.txt
+++ b/samples/boards/nxp/tflm_neutron/CMakeLists.txt
@@ -7,28 +7,25 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(tflm_neutron)
 
-set(NEUTRON_BLOB_PATH "${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/neutron/rt700/cm33/libNeutronDriver.a")
-
-if(NOT EXISTS "${NEUTRON_BLOB_PATH}")
-    message(STATUS "------------------------------------------------------------")
-    message(STATUS " [AUTOMATION] Missing NXP Neutron NPU Binary Blob!")
-    message(STATUS " [AUTOMATION] Trying 'west blobs fetch hal_nxp' automatically...")
-    message(STATUS "------------------------------------------------------------")
-
-    execute_process(
-        COMMAND west blobs fetch hal_nxp --auto-accept
-        WORKING_DIRECTORY ${WEST_TOPDIR}
-        RESULT_VARIABLE WEST_FETCH_RESULT
-    )
-endif()
-
 # Add application sources (exclude model.hpp from glob)
 file(GLOB app_sources src/*.c src/*.cpp src/*.h)
 target_sources(app PRIVATE ${app_sources})
 
-# Board-specific model include path
+# Board-specific model include path and Neutron blob location
 if(CONFIG_SOC_MIMXRT798S)
-    target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/models/rt700)
+  target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/models/rt700)
+  set(neutron_blob_dir "${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/neutron/rt700/cm33")
 elseif(CONFIG_SOC_MCXN947)
-    target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/models/mcxn)
+  target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/models/mcxn)
+  set(neutron_blob_dir "${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/neutron/mcxn")
+endif()
+
+# The Neutron NPU driver and firmware are distributed as binary blobs. Report
+# their absence here instead of letting the link step fail on a missing
+# archive.
+if(NOT EXISTS "${neutron_blob_dir}/libNeutronDriver.a")
+  message(FATAL_ERROR
+        "The NXP Neutron NPU binary blobs required by this sample are not "
+        "present. Fetch them with:\n"
+        "  west blobs fetch hal_nxp")
 endif()

--- a/samples/boards/nxp/tflm_neutron/tests.yaml
+++ b/samples/boards/nxp/tflm_neutron/tests.yaml
@@ -8,6 +8,9 @@ tests:
     modules:
       - tflite-micro
     build_only: true
+    # The Neutron NPU driver and firmware are binary blobs, which CI does
+    # not fetch. Skip the sample rather than fail the build without them.
+    filter: CONFIG_ZEPHYR_HAL_NXP_MODULE_BLOBS
     platform_allow:
       - mimxrt700_evk/mimxrt798s/cm33_cpu0
       - mcx_n9xx_evk/mcxn947/cpu0


### PR DESCRIPTION
The sample links libNeutronDriver.a and libNeutronFirmware.a from
hal_nxp. Those are binary blobs that CI does not fetch, so twister
fails the sample on all three allowed platforms:

  ninja: error: '.../blobs/neutron/rt700/cm33/libNeutronFirmware.a',
  needed by 'zephyr/zephyr_pre0.elf', missing and no known rule to
  make it

Filter the scenario on ZEPHYR_HAL_NXP_MODULE_BLOBS, the symbol the
build system defines when hal_nxp blobs are present locally, so the
sample is skipped rather than failing where blobs are unavailable.

CMakeLists.txt also tried to paper over missing blobs by running
'west blobs fetch hal_nxp' at configure time. Configuring a build must
not depend on network access, and the result was discarded, so a failed
fetch surfaced only as the link error above. Drop the fetch and report
the missing blobs with an actionable message instead; the README
already documents the manual fetch step. The checked path is now
selected per SoC instead of always testing the RT700 one.

Note that ZEPHYR_HAL_NXP_MODULE_BLOBS tracks any hal_nxp blob being
present, not the Neutron ones specifically. The CMake check covers the
remaining case of a partially populated blob directory.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
