### PR TITLE
kernel: Fix a race in the kernel's use of z_waitq_head()

### DIFF
--- a/kernel/deadline.c
+++ b/kernel/deadline.c
@@ -30,7 +30,8 @@
  *
  * If the thread is currently queued the scheduler re-inserts it so that
  * run-queue ordering (including rbtree invariants) is preserved.  May be
- * called from any context; takes and releases _sched_spinlock internally.
+ * called from any context; takes and releases the scheduler's spinlock
+ * internally.
  *
  * @param thread   Thread whose deadline is being updated.
  * @param deadline New absolute deadline value (raw cycle counter).

--- a/kernel/deadline.c
+++ b/kernel/deadline.c
@@ -17,6 +17,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <kspinlock.h>
 #include <ksched.h>
 #include <run_q.h>
 #include <zephyr/internal/syscall_handler.h>
@@ -36,7 +37,7 @@
  */
 void z_sched_prio_deadline_set(struct k_thread *thread, int deadline)
 {
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		if (z_is_thread_queued(thread)) {
 			dequeue_thread(thread);
 			thread->base.prio_deadline = deadline;

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -113,7 +113,7 @@ static void event_post_walk_op(int status, void *data)
 	/*
 	 * Note: z_sched_wake_thread_locked() is safe
 	 * to call here because this walk_op callback
-	 * is invoked with _sched_spinlock held.
+	 * is invoked with the scheduler spinlock held.
 	 */
 	ARG_UNUSED(status);
 	struct event_walk_data *walk_data = data;
@@ -163,7 +163,7 @@ static int event_walk_op(struct k_thread *thread, void *data)
 		/*
 		 * Note: z_sched_wake_thread_locked() is safe
 		 * to call here because this walk_op callback
-		 * is invoked with _sched_spinlock held.
+		 * is invoked with the scheduler spinlock held.
 		 */
 		arch_thread_return_value_set(thread, 0);
 		z_sched_wake_thread_locked(thread);

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 
 #include <zephyr/kernel_structs.h>
+#include <kspinlock.h>
 #include <kernel_internal.h>
 #include <timeout_q.h>
 #include <kthread.h>
@@ -38,17 +39,9 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 #define Z_ASSERT_VALID_PRIO(prio, entry_point) __ASSERT((prio) == -1, "")
 #endif /* CONFIG_MULTITHREADING */
 
-#if (CONFIG_MP_MAX_NUM_CPUS == 1)
-#define LOCK_SCHED_SPINLOCK
-#else
-#define LOCK_SCHED_SPINLOCK   K_SPINLOCK(&_sched_spinlock)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-extern struct k_spinlock _sched_spinlock;
 
 extern struct k_thread _thread_dummy;
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -60,6 +60,7 @@ int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 void z_pend_thread(struct k_thread *thread, _wait_q_t *wait_q,
 		   k_timeout_t timeout);
 void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
+void z_reschedule_locked(k_spinlock_key_t key);
 void z_reschedule_irqlock(uint32_t key);
 int z_unpend_all(_wait_q_t *wait_q);
 bool z_thread_prio_set(struct k_thread *thread, int prio);

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -94,15 +94,15 @@ void move_current_to_end_of_prio_q(void);
 
 /*
  * Internal scheduler functions exposed for use by thread lifecycle code
- * (thread.c). These operate under _sched_spinlock and must not be called
- * without holding it.
+ * (thread.c). These operate under the scheduler's spinlock and must not be
+ * called without holding it.
  */
 
 /**
  * @brief Halt a thread, suspending or terminating it.
  *
  * Shared implementation for k_thread_suspend() and k_thread_abort(). The
- * caller must hold _sched_spinlock; this function releases it before
+ * caller must hold the scheduler's spinlock; this function releases it before
  * returning (possibly after a context switch).
  *
  * @param thread  Thread to halt.
@@ -114,8 +114,8 @@ void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key, bool terminate
 /**
  * @brief Ready a thread while the scheduler spinlock is already held.
  *
- * Equivalent to the internal ready_thread() helper. Callers must hold
- * _sched_spinlock.
+ * Equivalent to the internal ready_thread() helper. Callers must hold the
+ * scheduler's spinlock.
  *
  * @param thread Thread to make ready.
  */
@@ -125,7 +125,7 @@ void z_sched_ready_locked(struct k_thread *thread);
  * @brief Add a thread to a wait queue while the scheduler spinlock is held.
  *
  * Moves the thread out of the run queue and onto the specified wait queue.
- * Callers must hold _sched_spinlock.
+ * Callers must hold the scheduler's spinlock.
  *
  * @param thread  Thread to pend.
  * @param wait_q  Wait queue to add the thread to (may be NULL).
@@ -136,7 +136,7 @@ void z_sched_add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q);
  * @brief Remove a thread from the run queue (scheduler spinlock must be held).
  *
  * Called by sleep.c to unready the current thread before arming its wakeup
- * timeout.  Callers must already hold _sched_spinlock.
+ * timeout.  Callers must already hold the scheduler's spinlock.
  *
  * @param thread Thread to remove from the run queue.
  */
@@ -236,10 +236,10 @@ static inline void unpend_thread_no_timeout(struct k_thread *thread)
  * timeout it had pending. Returns the thread, or NULL if the wait_q was
  * empty.
  *
- * Caller MUST hold _sched_spinlock and MUST complete the wake (set return
- * value, ready the thread) under the same lock acquisition before releasing
- * it. Otherwise a racing in-flight timeout handler can ready the thread
- * before the caller's wake state is in place, exposing the woken thread
+ * Caller MUST hold the scheduler's spinlock and MUST complete the wake (set
+ * return value, ready the thread) under the same lock acquisition before
+ * releasing it. Otherwise a racing in-flight timeout handler can ready the
+ * thread before the caller's wake state is in place, exposing the woken thread
  * to a stale swap_retval. The pre-1b8c7a3 dticks-cancel check used to
  * close this window; doing all the wake work atomically under the sched
  * lock is now the way.
@@ -270,8 +270,8 @@ static ALWAYS_INLINE struct k_thread *z_unpend_first_thread_locked(_wait_q_t *wa
  * Given a wait_q, wake up the highest priority thread on the queue. If the
  * queue was empty just return false.
  *
- * Otherwise, do the following, in order,  holding _sched_spinlock the entire
- * time so that the thread state is guaranteed not to change:
+ * Otherwise, do the following, in order,  holding the scheduler's spinlock the
+ *  entire time so that the thread state is guaranteed not to change:
  * - Set the thread's swap return values to swap_retval and swap_data
  * - un-pend and ready the thread, but do not invoke the scheduler.
  *

--- a/kernel/include/kspinlock.h
+++ b/kernel/include/kspinlock.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_
+#define ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_
+
+#include <zephyr/spinlock.h>
+#include <stdbool.h>
+
+extern struct k_spinlock _sched_spinlock;
+
+/**
+ * The intent of LOCK_SCHED_SPINLOCK is to lock the scheduler's spinlock for
+ * the scope that follows (e.g. LOCK_SCHED_SPINLOCK { ... }). However, on
+ * single core systems, the scheduler's spinlock is not needed when the locked
+ * region would otherwise be encapsulated by another spinlock (as that spinlock
+ * would degenerate into an IRQ lock). For that degenerate case, this macro
+ * will expand to nothing.
+ */
+#if (CONFIG_MP_MAX_NUM_CPUS == 1)
+#define LOCK_SCHED_SPINLOCK
+#else
+#define LOCK_SCHED_SPINLOCK   K_SPINLOCK(&_sched_spinlock)
+#endif
+
+/**
+ * @brief Always lock the scheduler's spinlock for the scope that follows
+ *
+ * Unlike LOCK_SCHED_SPINLOCK, this macro will always lock the scheduler's
+ * spinlock--even on single core systems.
+ */
+#define Z_SCHED_SPINLOCK K_SPINLOCK(&_sched_spinlock)
+
+
+/**
+ * @brief Check if a spinlock is the scheduler's spinlock
+ *
+ * @retval true if is, false otherwise
+ */
+static ALWAYS_INLINE bool z_is_sched_spinlock(struct k_spinlock *lock)
+{
+	return (lock == &_sched_spinlock);
+}
+
+/**
+ * @brief Transfer ownership of the scheduler's spinlock
+ */
+static ALWAYS_INLINE void z_sched_spinlock_transfer_owner(void)
+{
+#ifdef CONFIG_SPIN_VALIDATE
+	z_spin_lock_transfer_owner(&_sched_spinlock);
+#endif
+}
+
+
+/**
+ * @brief Release the scheduler's spinlock without restoring interrupts
+ */
+static ALWAYS_INLINE void z_sched_spinlock_release(void)
+{
+	k_spin_release(&_sched_spinlock);
+}
+
+/**
+ * @brief Lock the scheduler's spinlock
+ */
+static ALWAYS_INLINE k_spinlock_key_t z_sched_spinlock_lock(void)
+{
+	return k_spin_lock(&_sched_spinlock);
+}
+
+/**
+ * @brief Unlock the scheduler's spinlock
+ */
+static ALWAYS_INLINE void z_sched_spinlock_unlock(k_spinlock_key_t key)
+{
+	k_spin_unlock(&_sched_spinlock, key);
+}
+
+#endif /* ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_ */

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -6,6 +6,7 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_KSWAP_H_
 #define ZEPHYR_KERNEL_INCLUDE_KSWAP_H_
 
+#include <kspinlock.h>
 #include <ksched.h>
 #include <run_q.h>
 #include <zephyr/spinlock.h>
@@ -19,8 +20,6 @@ extern void z_check_stack_sentinel(void);
 #else
 #define z_check_stack_sentinel() /**/
 #endif /* CONFIG_STACK_SENTINEL */
-
-extern struct k_spinlock _sched_spinlock;
 
 /* In SMP, the irq_lock() is a spinlock which is implicitly released
  * and reacquired on context switch to preserve the existing
@@ -97,13 +96,13 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 	 * have it.  We "release" other spinlocks here.  But we never
 	 * drop the interrupt lock.
 	 */
-	if (is_spinlock && lock != NULL && lock != &_sched_spinlock) {
+	if (is_spinlock && (lock != NULL) && !z_is_sched_spinlock(lock)) {
 		k_spin_release(lock);
 	}
 	if (IS_ENABLED(CONFIG_SMP) || IS_ENABLED(CONFIG_SPIN_VALIDATE)) {
 		/* Taking a nested uniprocessor lock in void context is a noop */
-		if (!is_spinlock || lock != &_sched_spinlock) {
-			(void)k_spin_lock(&_sched_spinlock);
+		if (!is_spinlock || !z_is_sched_spinlock(lock)) {
+			(void)z_sched_spinlock_lock();
 		}
 	}
 
@@ -131,9 +130,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		z_time_slice_reset(new_thread);
 #endif /* CONFIG_TIMESLICING */
 
-#ifdef CONFIG_SPIN_VALIDATE
-		z_spin_lock_transfer_owner(&_sched_spinlock);
-#endif /* CONFIG_SPIN_VALIDATE */
+		z_sched_spinlock_transfer_owner();
 
 		arch_cohere_stacks(old_thread, NULL, new_thread);
 
@@ -161,10 +158,10 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 			new_thread->switch_handle = NULL;
 			barrier_dmem_fence_full(); /* write barrier */
 		}
-		k_spin_release(&_sched_spinlock);
+		z_sched_spinlock_release();
 		arch_switch(newsh, &old_thread->switch_handle);
 	} else {
-		k_spin_release(&_sched_spinlock);
+		z_sched_spinlock_release();
 	}
 
 	if (is_spinlock) {

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -227,7 +227,7 @@ static inline void z_swap_unlocked(void)
 #endif /* !CONFIG_USE_SWITCH */
 
 /**
- * @brief - Like z_swap() but it is known that _sched_spinlock is already held.
+ * @brief - Like z_swap() but it is known that the scheduler's spinlock is already held.
  */
 static inline int z_swap_locked(k_spinlock_key_t key)
 {

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -227,6 +227,14 @@ static inline void z_swap_unlocked(void)
 #endif /* !CONFIG_USE_SWITCH */
 
 /**
+ * @brief - Like z_swap() but it is known that _sched_spinlock is already held.
+ */
+static inline int z_swap_locked(k_spinlock_key_t key)
+{
+	return z_swap(&_sched_spinlock, key);
+}
+
+/**
  * Set up a "dummy" thread, used at early initialization to launch the
  * first thread on a CPU.
  *

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -19,8 +19,8 @@ void z_sched_init(void);
 
 /**
  * @brief Update the scheduler cache and reschedule, releasing the scheduler
- * spinlock.  Callers must hold _sched_spinlock before calling; the lock is
- * released (via reschedule) before this returns.
+ * spinlock.  Callers must hold the scheduler's spinlock before calling; the
+ * lock is released (via reschedule) before this returns.
  *
  * @param key Spinlock key obtained from z_sched_spinlock_lock().
  */
@@ -60,8 +60,9 @@ typedef void (*_waitq_post_walk_cb_t)(int status, void *data);
  *
  * This function walks the wait queue invoking the `walk_func` callback function
  * on each waiting thread (except if stopped earlier by a non-zero return value),
- * followed by a single call of `post_func`, all while holding `_sched_spinlock`.
- * This can be useful for routines that need to operate on multiple waiting threads.
+ * followed by a single call of `post_func`, all while holding the scheduler's
+ * spinlock. This is useful for routines that need to operate on multiple
+ * waiting threads.
  *
  * CAUTION! As a wait queue is of indeterminate length, the scheduler will be
  * locked for an indeterminate amount of time. This may impact system performance.
@@ -88,7 +89,7 @@ int z_sched_waitq_walk(_wait_q_t *wait_q, _waitq_walk_cb_t walk_func,
  * Given a specific thread, wake it up. This routine assumes that the given
  * thread is not on the timeout queue.
  *
- * @warning Caller must hold _sched_spinlock when calling this function!
+ * @warning Caller must hold the scheduler's spinlock when calling this function!
  *
  * @param thread Given thread to wake up.
  *

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -22,7 +22,7 @@ void z_sched_init(void);
  * spinlock.  Callers must hold _sched_spinlock before calling; the lock is
  * released (via reschedule) before this returns.
  *
- * @param key Spinlock key obtained from k_spin_lock(&_sched_spinlock).
+ * @param key Spinlock key obtained from z_sched_spinlock_lock().
  */
 void z_sched_lock_reschedule(k_spinlock_key_t key);
 

--- a/kernel/include/wait_q.h
+++ b/kernel/include/wait_q.h
@@ -14,6 +14,7 @@
 #include <zephyr/sys/rb.h>
 #include <timeout_q.h>
 #include <priority_q.h>
+#include <kspinlock.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +47,7 @@ static inline void z_waitq_init(_wait_q_t *w)
 	};
 }
 
-static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+static inline struct k_thread *z_waitq_head_locked(_wait_q_t *w)
 {
 	return (struct k_thread *)rb_get_min(&w->waitq.tree);
 }
@@ -89,12 +90,33 @@ static inline void z_waitq_init(_wait_q_t *w)
 	sys_dlist_init(&w->waitq);
 }
 
-static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+static inline struct k_thread *z_waitq_head_locked(_wait_q_t *w)
 {
 	return (struct k_thread *)sys_dlist_peek_head(&w->waitq);
 }
 
 #endif /* !CONFIG_WAITQ_SCALABLE */
+
+static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+{
+	struct k_thread *thread = NULL;
+
+	/*
+	 * On a single core system, all callers of this function are already
+	 * protected by a spinlock held by the caller. On those systems there
+	 * is no need to lock the scheduler's spinlock. However, on SMP systems
+	 * the caller controlled spinlock is insufficient as the thread timeout
+	 * handler may be running on another CPU. Use LOCK_SCHED_SPINLOCK
+	 * to protect the scope as necessary.
+	 */
+
+	LOCK_SCHED_SPINLOCK {
+		thread = z_waitq_head_locked(w);
+	}
+
+	return thread;
+}
+
 
 #ifdef __cplusplus
 }

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
-#include <wait_q.h>
 
 typedef void * (sys_heap_allocator_t)(struct sys_heap *heap, size_t align, size_t bytes);
 
@@ -75,8 +74,6 @@ void k_free(void *ptr)
 		struct k_heap *heap = *heap_ref;
 		k_spinlock_key_t key = k_spin_lock(&heap->lock);
 
-		__ASSERT(z_waitq_head(&heap->wait_q) == NULL,
-			 "unexpected heap waiters");
 		sys_heap_free(&heap->heap, ptr);
 		k_spin_unlock(&heap->lock, key);
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -110,6 +110,8 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 int k_msgq_cleanup(struct k_msgq *msgq)
 {
 	int ret = 0;
+	k_spinlock_key_t key = k_spin_lock(&msgq->lock);
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, cleanup, msgq);
 
 	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
@@ -123,6 +125,7 @@ int k_msgq_cleanup(struct k_msgq *msgq)
 	}
 
 out:
+	k_spin_unlock(&msgq->lock, key);
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, cleanup, msgq, ret);
 	return ret;
 }

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -148,7 +148,7 @@ static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,
 	if (msgq->used_msgs < msgq->max_msgs) {
 		/* message queue isn't full. Try to hand the message
 		 * directly to the longest-waiting receiver, atomically
-		 * under _sched_spinlock so a racing in-flight timeout
+		 * under the scheduler's spinlock so a racing in-flight timeout
 		 * handler cannot wake the receiver before the message
 		 * has been copied into its buffer.
 		 */
@@ -312,8 +312,8 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 				((size_t)(uintptr_t)(msgq->buffer_end - msgq->write_ptr) >=
 					msgq->msg_size));
 
-		/* handle first thread waiting to write (if any).
-		 * Done atomically under _sched_spinlock so we read the
+		/* handle first thread waiting to write (if any). Done
+		 * atomically under the scheduler's spinlock so we read the
 		 * sender's swap_data and complete the wake before any
 		 * racing in-flight timeout handler can wake the sender.
 		 */

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -107,14 +107,19 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 #include <zephyr/syscalls/k_msgq_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-int k_msgq_cleanup(struct k_msgq *msgq)
+int z_msgq_cleanup(struct k_msgq *msgq, __maybe_unused bool locked)
 {
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, cleanup, msgq);
+
 	int ret = 0;
 	k_spinlock_key_t key = k_spin_lock(&msgq->lock);
 
-	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, cleanup, msgq);
+	CHECKIF(locked && (z_waitq_head_locked(&msgq->wait_q) != NULL)) {
+		ret = -EBUSY;
+		goto out;
+	}
 
-	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
+	CHECKIF(!locked && (z_waitq_head(&msgq->wait_q) != NULL)) {
 		ret = -EBUSY;
 		goto out;
 	}
@@ -128,6 +133,11 @@ out:
 	k_spin_unlock(&msgq->lock, key);
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, cleanup, msgq, ret);
 	return ret;
+}
+
+int k_msgq_cleanup(struct k_msgq *msgq)
+{
+	return z_msgq_cleanup(msgq, false);
 }
 
 static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -154,7 +154,7 @@ static int32_t held_mutexes_highest_waiter_prio(struct k_thread *thread,
 		SYS_SLIST_FOR_EACH_NODE(&thread->held_mutexes, node) {
 			struct k_mutex *m =
 				CONTAINER_OF(node, struct k_mutex, held_node);
-			struct k_thread *waiter = z_waitq_head(&m->wait_q);
+			struct k_thread *waiter = z_waitq_head_locked(&m->wait_q);
 
 			if (waiter != NULL) {
 				int32_t wprio = z_get_new_prio_with_ceiling(waiter->base.prio);

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -439,8 +439,8 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 #endif
 
 	/* Pick the new owner (if any) and complete the wake atomically
-	 * under _sched_spinlock, so a racing in-flight timeout handler
-	 * cannot observe a half-initialized wake-up.
+	 * under the scheduler's spinlock, so a racing in-flight timeout
+	 * handler cannot observe a half-initialized wake-up.
 	 */
 	LOCK_SCHED_SPINLOCK {
 		new_owner = z_unpend_first_thread_locked(&mutex->wait_q);

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -51,6 +51,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
+#include <kspinlock.h>
 #include <ksched.h>
 #include <scheduler.h>
 #include <kthread.h>

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -315,7 +315,7 @@ void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
 			thread_halt_spin(thread, key);
 		} else  {
 			add_to_waitq_locked(_current, wq);
-			z_swap(&_sched_spinlock, key);
+			z_swap_locked(key);
 		}
 		/* The target's next_up self-halt path passed NULL to
 		 * halt_thread() and could not retry on -EAGAIN; an
@@ -339,7 +339,7 @@ void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
 				k_panic();
 				key = z_sched_spinlock_lock();
 			}
-			z_swap(&_sched_spinlock, key);
+			z_swap_locked(key);
 			__ASSERT(!terminate, "aborted _current back from dead");
 		} else {
 			z_sched_spinlock_unlock(key);
@@ -396,11 +396,11 @@ void z_sched_lock_reschedule(k_spinlock_key_t key)
 
 void z_sched_yield(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	runq_yield();
 	update_cache(1);
-	z_swap(&_sched_spinlock, key);
+	z_swap_locked(key);
 }
 
 /* _sched_spinlock must be held */
@@ -519,7 +519,7 @@ int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	(void) z_sched_spinlock_lock();
 	pend_locked(_current, wait_q, timeout);
 	k_spin_release(lock);
-	return z_swap(&_sched_spinlock, key);
+	return z_swap_locked(key);
 }
 
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q)
@@ -941,11 +941,11 @@ static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state
 
 void z_thread_suspend_current(struct k_thread *thread)
 {
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	z_mark_thread_as_suspended(thread);
 	z_metairq_preempted_clear(thread);
 	dequeue_thread(thread);
 	update_cache(1);
-	z_swap(&_sched_spinlock, key);
+	z_swap_locked(key);
 }

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -33,7 +33,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 extern struct k_thread *pending_current;
 #endif
 
-struct k_spinlock _sched_spinlock;
+struct k_spinlock _sched_spinlock;  /* The scheduler's spinlock */
 
 /* Storage to "complete" the context switch from an invalid/incomplete thread
  * context (ex: exiting an ISR that aborted _current)
@@ -320,9 +320,9 @@ void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
 		/* The target's next_up self-halt path passed NULL to
 		 * halt_thread() and could not retry on -EAGAIN; an
 		 * in-flight handler on a third CPU may not have run yet
-		 * (it is blocked on _sched_spinlock and will only acquire
-		 * it after we drop it via the swap/spin above). Wait now,
-		 * outside any lock, before the caller may free the thread
+		 * (it is blocked on the scheduler spinlock and will only
+		 * acquire it after we drop it via the swap/spin above). Wait
+		 * now, outside any lock, before the caller may free the thread
 		 * storage. The handler, when it runs, sees _THREAD_DEAD /
 		 * _THREAD_SUSPENDED and either bails (killed check) or
 		 * no-ops in ready_thread() (z_is_thread_ready() rejects
@@ -389,7 +389,7 @@ static void reschedule(struct k_spinlock *lock, k_spinlock_key_t key)
 }
 
 /**
- * Like reschedule(), but _sched_spinlock is known to be the locked lock.
+ * Like reschedule(), but the scheduler's spinlock is known to be the lock.
  */
 static void reschedule_locked(k_spinlock_key_t key)
 {
@@ -411,7 +411,7 @@ void z_sched_yield(void)
 	z_swap_locked(key);
 }
 
-/* _sched_spinlock must be held */
+/* The scheduler's spinlock must be held */
 static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 {
 	/* A thread must not already be on a wait queue when added to a new one. */
@@ -461,7 +461,7 @@ void z_unpend_thread_no_timeout(struct k_thread *thread)
 
 void z_sched_wake_thread_locked(struct k_thread *thread)
 {
-	/* No K_SPINLOCK: caller must hold _sched_spinlock when calling */
+	/* No K_SPINLOCK: caller must hold the scheduler's spinlock when calling */
 	bool killed = (thread->base.thread_state &
 			(_THREAD_DEAD | _THREAD_ABORTING));
 
@@ -627,8 +627,8 @@ void z_reschedule_irqlock(uint32_t key)
 	if (resched(key) && need_swap()) {
 		z_swap_irqlock(key);
 	} else {
-		/* TODO: We only hold the IRQ lock here, not _sched_spinlock,
-		 * violating the locking requirement documented in
+		/* TODO: We only hold the IRQ lock here, not the scheduler's
+		 * spinlock, violating the locking requirement documented in
 		 * signal_pending_ipi(). This can result in added delayed
 		 * rescheduling.
 		 */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
+#include <kspinlock.h>
 #include <ksched.h>
 #include <zephyr/spinlock.h>
 #include <wait_q.h>
@@ -215,7 +216,7 @@ static inline void ready_thread(struct k_thread *thread)
 
 void z_ready_thread(struct k_thread *thread)
 {
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		if (thread_active_elsewhere(thread) == NULL) {
 			ready_thread(thread);
 		}
@@ -237,7 +238,7 @@ static void unready_thread(struct k_thread *thread)
  */
 void z_unready_thread(struct k_thread *thread)
 {
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		unready_thread(thread);
 	}
 }
@@ -248,7 +249,7 @@ void z_sched_unready_locked(struct k_thread *thread) ALIAS_OF(unready_thread);
 /* This routine only used for testing purposes */
 void z_yield_testing_only(void)
 {
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		move_current_to_end_of_prio_q();
 	}
 }
@@ -266,7 +267,7 @@ static void thread_halt_spin(struct k_thread *thread, k_spinlock_key_t key)
 			    z_is_thread_aborting(_current) ? _THREAD_DEAD : _THREAD_SUSPENDED,
 			    &key);
 	}
-	k_spin_unlock(&_sched_spinlock, key);
+	z_sched_spinlock_unlock(key);
 	while (z_is_thread_halting(thread)) {
 		unsigned int k = arch_irq_lock();
 
@@ -334,14 +335,14 @@ void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
 		halt_thread(thread, terminate ? _THREAD_DEAD : _THREAD_SUSPENDED, &key);
 		if ((thread == _current) && !arch_is_in_isr()) {
 			if (z_is_thread_essential(thread)) {
-				k_spin_unlock(&_sched_spinlock, key);
+				z_sched_spinlock_unlock(key);
 				k_panic();
-				key = k_spin_lock(&_sched_spinlock);
+				key = z_sched_spinlock_lock();
 			}
 			z_swap(&_sched_spinlock, key);
 			__ASSERT(!terminate, "aborted _current back from dead");
 		} else {
-			k_spin_unlock(&_sched_spinlock, key);
+			z_sched_spinlock_unlock(key);
 		}
 	}
 	/* NOTE: the scheduler lock has been released.  Don't put
@@ -436,14 +437,14 @@ void z_pend_thread(struct k_thread *thread, _wait_q_t *wait_q,
 		   k_timeout_t timeout)
 {
 	__ASSERT_NO_MSG(thread == _current || is_thread_dummy(thread));
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		pend_locked(thread, wait_q, timeout);
 	}
 }
 
 void z_unpend_thread_no_timeout(struct k_thread *thread)
 {
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		if (thread->base.pended_on != NULL) {
 			unpend_thread_no_timeout(thread);
 		}
@@ -473,7 +474,7 @@ void z_thread_timeout(struct _timeout *timeout)
 	struct k_thread *thread = CONTAINER_OF(timeout,
 					       struct k_thread, base.timeout);
 
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		/* A concurrent waker (e.g. a sem give on another CPU) may
 		 * have unpended and readied the thread, after which the
 		 * thread could run and re-pend elsewhere -- possibly with no
@@ -505,7 +506,7 @@ int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 #if defined(CONFIG_TIMESLICING) && defined(CONFIG_SWAP_NONATOMIC)
 	pending_current = _current;
 #endif /* CONFIG_TIMESLICING && CONFIG_SWAP_NONATOMIC */
-	__ASSERT_NO_MSG(sizeof(_sched_spinlock) == 0 || lock != &_sched_spinlock);
+	__ASSERT_NO_MSG((sizeof(struct k_spinlock) == 0) || !z_is_sched_spinlock(lock));
 
 	/* We do a "lock swap" prior to calling z_swap(), such that
 	 * the caller's lock gets released as desired.  But we ensure
@@ -515,7 +516,7 @@ int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	 * API that doesn't expect to be called with scheduler lock
 	 * held.
 	 */
-	(void) k_spin_lock(&_sched_spinlock);
+	(void) z_sched_spinlock_lock();
 	pend_locked(_current, wait_q, timeout);
 	k_spin_release(lock);
 	return z_swap(&_sched_spinlock, key);
@@ -525,7 +526,7 @@ struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q)
 {
 	struct k_thread *thread = NULL;
 
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		thread = _priq_wait_best(&wait_q->waitq);
 
 		if (thread != NULL) {
@@ -538,16 +539,16 @@ struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q)
 
 void z_unpend_thread(struct k_thread *thread)
 {
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	if (thread->base.pended_on != NULL) {
 		unpend_thread_no_timeout(thread);
 	}
 	while (z_try_abort_thread_timeout(thread) == -EAGAIN) {
-		k_spin_unlock(&_sched_spinlock, key);
-		key = k_spin_lock(&_sched_spinlock);
+		z_sched_spinlock_unlock(key);
+		key = z_sched_spinlock_lock();
 	}
-	k_spin_unlock(&_sched_spinlock, key);
+	z_sched_spinlock_unlock(key);
 }
 
 /* Priority set utility that does no rescheduling, it just changes the
@@ -558,7 +559,7 @@ bool z_thread_prio_set(struct k_thread *thread, int prio)
 	bool need_sched = false;
 	int old_prio = thread->base.prio;
 
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		need_sched = z_is_thread_ready(thread);
 
 		if (need_sched) {
@@ -691,7 +692,7 @@ void *z_get_next_switch_handle(void *interrupted)
 #ifdef CONFIG_SMP
 	void *ret = NULL;
 
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		struct k_thread *old_thread = _current, *new_thread;
 
 		__ASSERT(old_thread->switch_handle == NULL || is_thread_dummy(old_thread),
@@ -716,14 +717,12 @@ void *z_get_next_switch_handle(void *interrupted)
 			z_time_slice_reset(new_thread);
 #endif /* CONFIG_TIMESLICING */
 
-#ifdef CONFIG_SPIN_VALIDATE
-			/* Changed _current!  Update the spinlock
+			/* Changed _current!  Update the scheduler's spinlock
 			 * bookkeeping so the validation doesn't get
 			 * confused when the "wrong" thread tries to
 			 * release the lock.
 			 */
-			z_spin_lock_transfer_owner(&_sched_spinlock);
-#endif /* CONFIG_SPIN_VALIDATE */
+			z_sched_spinlock_transfer_owner();
 
 			/* A queued (runnable) old/current thread
 			 * needs to be added back to the run queue
@@ -765,21 +764,23 @@ int z_unpend_all(_wait_q_t *wait_q)
 {
 	int need_sched = 0;
 	struct k_thread *thread;
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
-	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
-		unpend_thread_no_timeout(thread);
-		/* Abort the timeout and ready the thread unconditionally. If
-		 * the timeout handler is in flight on another CPU, the abort
-		 * flags it superseded and z_thread_timeout() bails when it
-		 * runs -- so it will NOT ready the thread, we must.
-		 */
-		(void)z_try_abort_thread_timeout(thread);
-		ready_thread(thread);
-		need_sched = 1;
+	Z_SCHED_SPINLOCK {
+		for (thread = z_waitq_head(wait_q);
+		     thread != NULL;
+		     thread = z_waitq_head(wait_q)) {
+			unpend_thread_no_timeout(thread);
+			/* Abort the timeout and ready the thread unconditionally. If
+			 * the timeout handler is in flight on another CPU, the abort
+			 * flags it superseded and z_thread_timeout() bails when it
+			 * runs -- so it will NOT ready the thread, we must.
+			 */
+			(void)z_try_abort_thread_timeout(thread);
+			ready_thread(thread);
+			need_sched = 1;
+		}
 	}
 
-	k_spin_unlock(&_sched_spinlock, key);
 	return need_sched;
 }
 
@@ -848,8 +849,8 @@ static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state
 			 */
 			if (key != NULL) {
 				while (z_try_abort_thread_timeout(thread) == -EAGAIN) {
-					k_spin_unlock(&_sched_spinlock, *key);
-					*key = k_spin_lock(&_sched_spinlock);
+					z_sched_spinlock_unlock(*key);
+					*key = z_sched_spinlock_lock();
 				}
 			}
 			unpend_all(&thread->join_queue);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -388,10 +388,18 @@ static void reschedule(struct k_spinlock *lock, k_spinlock_key_t key)
 	}
 }
 
+/**
+ * Like reschedule(), but _sched_spinlock is known to be the locked lock.
+ */
+static void reschedule_locked(k_spinlock_key_t key)
+{
+	return reschedule(&_sched_spinlock, key);
+}
+
 void z_sched_lock_reschedule(k_spinlock_key_t key)
 {
 	update_cache(0);
-	reschedule(&_sched_spinlock, key);
+	reschedule_locked(key);
 }
 
 void z_sched_yield(void)
@@ -611,6 +619,8 @@ bool z_thread_prio_set(struct k_thread *thread, int prio)
 }
 
 void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key) ALIAS_OF(reschedule);
+
+void z_reschedule_locked(k_spinlock_key_t key) ALIAS_OF(reschedule_locked);
 
 void z_reschedule_irqlock(uint32_t key)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -776,9 +776,9 @@ int z_unpend_all(_wait_q_t *wait_q)
 	struct k_thread *thread;
 
 	Z_SCHED_SPINLOCK {
-		for (thread = z_waitq_head(wait_q);
+		for (thread = z_waitq_head_locked(wait_q);
 		     thread != NULL;
-		     thread = z_waitq_head(wait_q)) {
+		     thread = z_waitq_head_locked(wait_q)) {
 			unpend_thread_no_timeout(thread);
 			/* Abort the timeout and ready the thread unconditionally. If
 			 * the timeout handler is in flight on another CPU, the abort
@@ -798,7 +798,9 @@ static inline void unpend_all(_wait_q_t *wait_q)
 {
 	struct k_thread *thread;
 
-	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
+	for (thread = z_waitq_head_locked(wait_q);
+	     thread != NULL;
+	     thread = z_waitq_head_locked(wait_q)) {
 		unpend_thread_no_timeout(thread);
 		arch_thread_return_value_set(thread, 0);
 		/* See z_unpend_all(): the in-flight handler bails on the

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -111,7 +111,7 @@ int z_sched_waitq_walk(_wait_q_t *wait_q, _waitq_walk_cb_t walk_func,
 
 		/*
 		 * Invoke post-walk callback. This is done while
-		 * still holding _sched_spinlock to enable atomic
+		 * still holding the scheduler spinlock to enable atomic
 		 * operations (from the scheduler's point of view).
 		 */
 		if (post_func != NULL) {

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
+#include <kspinlock.h>
 #include <ksched.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/spinlock.h>
@@ -25,7 +26,7 @@ void z_sched_init(void)
 
 void k_sched_lock(void)
 {
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		SYS_PORT_TRACING_FUNC(k_thread, sched_lock);
 
 		__ASSERT(!arch_is_in_isr(), "");
@@ -41,7 +42,7 @@ void k_sched_unlock(void)
 {
 	SYS_PORT_TRACING_FUNC(k_thread, sched_unlock);
 
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	__ASSERT(_current->base.sched_locked != 0U, "");
 	__ASSERT(!arch_is_in_isr(), "");
@@ -53,7 +54,7 @@ void z_impl_k_reschedule(void)
 {
 	k_spinlock_key_t key;
 
-	key = k_spin_lock(&_sched_spinlock);
+	key = z_sched_spinlock_lock();
 
 	z_sched_lock_reschedule(key);
 }
@@ -86,7 +87,7 @@ int z_sched_waitq_walk(_wait_q_t *wait_q, _waitq_walk_cb_t walk_func,
 	struct k_thread *thread;
 	int  status = 0;
 
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 #ifndef CONFIG_WAITQ_SCALABLE
 		struct k_thread *tmp;
 

--- a/kernel/sleep.c
+++ b/kernel/sleep.c
@@ -62,7 +62,7 @@ k_ticks_t z_impl_k_sleep_ticks(k_timeout_t timeout)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 #if defined(CONFIG_TIMESLICING) && defined(CONFIG_SWAP_NONATOMIC)
 	pending_current = _current;
@@ -71,7 +71,7 @@ k_ticks_t z_impl_k_sleep_ticks(k_timeout_t timeout)
 	expected_wakeup_ticks = (uint32_t)z_add_thread_timeout(_current, timeout);
 	z_mark_thread_as_sleeping(_current);
 
-	(void)z_swap(&_sched_spinlock, key);
+	(void)z_swap_locked(key);
 
 	/* There is no meaningful remainder to report for K_FOREVER: reaching
 	 * this point at all means a k_wakeup() cut the sleep short.

--- a/kernel/smp/cpu_mask.c
+++ b/kernel/smp/cpu_mask.c
@@ -4,11 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
+#include <kspinlock.h>
 #include <ksched.h>
 #include <zephyr/spinlock.h>
-
-extern struct k_spinlock _sched_spinlock;
-
 
 # ifdef CONFIG_SMP
 /* The mask width scales with CONFIG_MP_MAX_NUM_CPUS, up to 32 bits */
@@ -25,7 +23,7 @@ static int cpu_mask_mod(k_tid_t thread, uint32_t enable_mask, uint32_t disable_m
 		 "Running threads cannot change CPU pin");
 #endif /* CONFIG_SCHED_CPU_MASK_PIN_ONLY */
 
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		if (z_is_thread_prevented_from_running(thread)) {
 			thread->base.cpu_mask |= enable_mask;
 			thread->base.cpu_mask  &= ~disable_mask;

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -19,6 +19,7 @@
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <kernel_internal.h>
+#include <stdbool.h>
 
 #ifdef CONFIG_OBJ_CORE_STACK
 static struct k_obj_type obj_type_stack;
@@ -77,17 +78,21 @@ static inline int32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 #include <zephyr/syscalls/k_stack_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-int k_stack_cleanup(struct k_stack *stack)
+int z_stack_cleanup(struct k_stack *stack, __maybe_unused bool locked)
 {
-	k_spinlock_key_t key = k_spin_lock(&stack->lock);
-
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, cleanup, stack);
 
-	CHECKIF(z_waitq_head(&stack->wait_q) != NULL) {
-		k_spin_unlock(&stack->lock, key);
-		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, -EAGAIN);
+	int ret = 0;
+	k_spinlock_key_t key = k_spin_lock(&stack->lock);
 
-		return -EAGAIN;
+	CHECKIF(locked && (z_waitq_head_locked(&stack->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto out;
+	}
+
+	CHECKIF(!locked && (z_waitq_head(&stack->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto out;
 	}
 
 	if ((stack->flags & K_STACK_FLAG_ALLOC) != (uint8_t)0) {
@@ -96,10 +101,16 @@ int k_stack_cleanup(struct k_stack *stack)
 		stack->flags &= ~K_STACK_FLAG_ALLOC;
 	}
 
+out:
 	k_spin_unlock(&stack->lock, key);
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, 0);
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, ret);
 
-	return 0;
+	return ret;
+}
+
+int k_stack_cleanup(struct k_stack *stack)
+{
+	return z_stack_cleanup(stack, false);
 }
 
 int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -79,9 +79,12 @@ static inline int32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 
 int k_stack_cleanup(struct k_stack *stack)
 {
+	k_spinlock_key_t key = k_spin_lock(&stack->lock);
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, cleanup, stack);
 
 	CHECKIF(z_waitq_head(&stack->wait_q) != NULL) {
+		k_spin_unlock(&stack->lock, key);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, -EAGAIN);
 
 		return -EAGAIN;
@@ -93,6 +96,7 @@ int k_stack_cleanup(struct k_stack *stack)
 		stack->flags &= ~K_STACK_FLAG_ALLOC;
 	}
 
+	k_spin_unlock(&stack->lock, key);
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, 0);
 
 	return 0;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1643,13 +1643,13 @@ void z_impl_k_thread_suspend(k_tid_t thread)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	if (unlikely(z_is_thread_suspended(thread))) {
 
 		/* The target thread is already suspended. Nothing to do. */
 
-		k_spin_unlock(&_sched_spinlock, key);
+		z_sched_spinlock_unlock(key);
 		return;
 	}
 
@@ -1724,10 +1724,10 @@ static inline void z_vrfy_k_wakeup(k_tid_t thread)
 void z_thread_abort(struct k_thread *thread)
 {
 	bool essential = z_is_thread_essential(thread);
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	if (z_is_thread_dead(thread)) {
-		k_spin_unlock(&_sched_spinlock, key);
+		z_sched_spinlock_unlock(key);
 		return;
 	}
 
@@ -1781,7 +1781,7 @@ int z_impl_k_thread_join(struct k_thread *thread, k_timeout_t timeout)
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_thread, join, thread, timeout, ret);
 
-	k_spin_unlock(&_sched_spinlock, key);
+	z_sched_spinlock_unlock(key);
 	return ret;
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1671,18 +1671,18 @@ void z_impl_k_thread_resume(k_tid_t thread)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_thread, resume, thread);
 
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	/* Do not try to resume a thread that was not suspended */
 	if (unlikely(!z_is_thread_suspended(thread))) {
-		k_spin_unlock(&_sched_spinlock, key);
+		z_sched_spinlock_unlock(key);
 		return;
 	}
 
 	z_mark_thread_as_not_suspended(thread);
 	z_sched_ready_locked(thread);
 
-	z_reschedule(&_sched_spinlock, key);
+	z_reschedule_locked(key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_thread, resume, thread);
 }
@@ -1700,15 +1700,15 @@ void z_impl_k_wakeup(k_tid_t thread)
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_thread, wakeup, thread);
 
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 
 	if (z_is_thread_sleeping(thread)) {
 		(void)z_try_abort_thread_timeout(thread);
 		z_mark_thread_as_not_sleeping(thread);
 		z_sched_ready_locked(thread);
-		z_reschedule(&_sched_spinlock, key);
+		z_reschedule_locked(key);
 	} else {
-		k_spin_unlock(&_sched_spinlock, key);
+		z_sched_spinlock_unlock(key);
 	}
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1754,7 +1754,7 @@ void z_impl_k_thread_abort(k_tid_t thread)
 
 int z_impl_k_thread_join(struct k_thread *thread, k_timeout_t timeout)
 {
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 	int ret;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_thread, join, thread, timeout);
@@ -1773,7 +1773,7 @@ int z_impl_k_thread_join(struct k_thread *thread, k_timeout_t timeout)
 		z_add_thread_timeout(_current, timeout);
 
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_thread, join, thread, timeout);
-		ret = z_swap(&_sched_spinlock, key);
+		ret = z_swap_locked(key);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_thread, join, thread, timeout, ret);
 
 		return ret;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -138,24 +138,22 @@ void z_timer_expiration_handler(struct _timeout *t)
 		return;
 	}
 
-	thread = z_waitq_head(&timer->wait_q);
+	LOCK_SCHED_SPINLOCK {
+		thread = z_waitq_head_locked(&timer->wait_q);
 
-	if (thread == NULL) {
-		k_spin_unlock(&timer_lock, key);
-		return;
+		if (thread != NULL) {
+			unpend_thread_no_timeout(thread);
+			arch_thread_return_value_set(thread, 0);
+			z_sched_ready_locked(thread);
+		}
 	}
-
-	z_unpend_thread_no_timeout(thread);
-
-	arch_thread_return_value_set(thread, 0);
 
 	k_spin_unlock(&timer_lock, key);
 
-	z_ready_thread(thread);
 }
 
 
-int k_timer_cleanup(struct k_timer *timer)
+int z_timer_cleanup(struct k_timer *timer, __maybe_unused bool locked)
 {
 	/* Not callable from an ISR: this is the one timer path that can
 	 * spin waiting for an in-flight handler, and an ISR spinning here
@@ -165,6 +163,7 @@ int k_timer_cleanup(struct k_timer *timer)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, cleanup, timer);
 
+	int ret = 0;
 	k_spinlock_key_t key;
 
 	/* Refuse if anyone is still pending on the timer's wait queue
@@ -174,10 +173,14 @@ int k_timer_cleanup(struct k_timer *timer)
 retry:
 	key = k_spin_lock(&timer_lock);
 
-	CHECKIF(z_waitq_head(&timer->wait_q) != NULL) {
-		k_spin_unlock(&timer_lock, key);
-		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, -EAGAIN);
-		return -EAGAIN;
+	CHECKIF(locked && (z_waitq_head_locked(&timer->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto out;
+	}
+
+	CHECKIF(!locked && (z_waitq_head(&timer->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto out;
 	}
 
 	/* Cancel the timeout AND wait for any in-flight expiration
@@ -198,11 +201,17 @@ retry:
 		goto retry;
 	}
 
+out:
 	k_spin_unlock(&timer_lock, key);
 
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, 0);
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, ret);
 
-	return 0;
+	return ret;
+}
+
+int k_timer_cleanup(struct k_timer *timer)
+{
+	return z_timer_cleanup(timer, false);
 }
 
 

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
+#include <kspinlock.h>
 #include <kswap.h>
 #include <ksched.h>
 #include <ipi.h>
@@ -112,29 +113,28 @@ static ALWAYS_INLINE bool thread_defines_time_slice_size(struct k_thread *thread
 
 void k_sched_time_slice_set(int32_t slice, int prio)
 {
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	Z_SCHED_SPINLOCK {
 
-	slice_ticks = k_ms_to_ticks_ceil32(slice);
-	slice_max_prio = prio;
+		slice_ticks = k_ms_to_ticks_ceil32(slice);
+		slice_max_prio = prio;
 
-	/*
-	 * Threads that define their own time slice size should not have
-	 * their time slices reset here as a thread-specific time slice size
-	 * take precedence over the global time slice size.
-	 */
+		/*
+		 * Threads that define their own time slice size should not have
+		 * their time slices reset here as a thread-specific time slice size
+		 * take precedence over the global time slice size.
+		 */
 
-	if (!thread_defines_time_slice_size(_current)) {
-		z_time_slice_reset(_current);
+		if (!thread_defines_time_slice_size(_current)) {
+			z_time_slice_reset(_current);
+		}
 	}
-
-	k_spin_unlock(&_sched_spinlock, key);
 }
 
 #ifdef CONFIG_TIMESLICE_PER_THREAD
 void k_thread_time_slice_set(struct k_thread *thread, int32_t thread_slice_ticks,
 			     k_thread_timeslice_fn_t expired, void *data)
 {
-	K_SPINLOCK(&_sched_spinlock) {
+	Z_SCHED_SPINLOCK {
 		thread->base.slice_ticks = thread_slice_ticks;
 		thread->base.slice_expired = expired;
 		thread->base.slice_data = data;
@@ -146,13 +146,13 @@ void k_thread_time_slice_set(struct k_thread *thread, int32_t thread_slice_ticks
 /* Called out of each timer and IPI interrupt */
 void z_time_slice(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	k_spinlock_key_t key = z_sched_spinlock_lock();
 	struct k_thread *curr = _current;
 
 #ifdef CONFIG_SWAP_NONATOMIC
 	if (pending_current == curr) {
 		z_time_slice_reset(curr);
-		k_spin_unlock(&_sched_spinlock, key);
+		z_sched_spinlock_unlock(key);
 		return;
 	}
 	pending_current = NULL;
@@ -169,9 +169,10 @@ void z_time_slice(void)
 		k_thread_timeslice_fn_t handler = curr->base.slice_expired;
 
 		if (handler != NULL) {
-			k_spin_unlock(&_sched_spinlock, key);
+			z_sched_spinlock_unlock(key);
 			handler(curr, curr->base.slice_data);
-			key = k_spin_lock(&_sched_spinlock);
+			key = z_sched_spinlock_lock();
+
 			/* The handler ran with the lock dropped and may have
 			 * changed this thread's slice configuration, so the
 			 * cached size is stale; recompute before rearming.
@@ -201,5 +202,5 @@ void z_time_slice(void)
 #endif
 		}
 	}
-	k_spin_unlock(&_sched_spinlock, key);
+	z_sched_spinlock_unlock(key);
 }

--- a/kernel/userspace/mem_domain.c
+++ b/kernel/userspace/mem_domain.c
@@ -360,7 +360,7 @@ void z_mem_domain_init_thread(struct k_thread *thread)
 	k_spin_unlock(&z_mem_domain_lock, key);
 }
 
-/* Called when thread aborts during teardown tasks. _sched_spinlock is held */
+/* Called when thread aborts during teardown tasks. The scheduler's spinlock is held */
 void z_mem_domain_exit_thread(struct k_thread *thread)
 {
 	int ret;

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -75,9 +75,13 @@ static struct k_spinlock obj_lock;         /* kobj struct data */
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 extern uint8_t _thread_idx_map[CONFIG_MAX_THREAD_BYTES];
+
+extern int z_msgq_cleanup(struct k_msgq *q, bool locked);
+extern int z_stack_cleanup(struct k_stack *stack, bool locked);
+extern int z_timer_cleanup(struct k_timer *timer, bool locked);
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 
-static void clear_perms_cb(struct k_object *ko, void *ctx_ptr);
+static void unref_check(struct k_object *ko, uintptr_t index, bool locked);
 
 const char *otype_to_str(enum k_objects otype)
 {
@@ -252,6 +256,13 @@ static struct dyn_obj *dyn_object_find(const void *obj)
 	k_spin_unlock(&lists_lock, key);
 
 	return node;
+}
+
+static void clear_perms_cb(struct k_object *ko, void *ctx_ptr)
+{
+	uintptr_t id = (uintptr_t)ctx_ptr;
+
+	unref_check(ko, id, false);
 }
 
 /**
@@ -655,8 +666,11 @@ static unsigned int thread_index_get(struct k_thread *thread)
 /* Caller must hold lists_lock for the duration of this call so that the
  * sys_dlist_remove() below is mutually exclusive with concurrent
  * obj_list traversal in k_object_wordlist_foreach() on another CPU.
+ *
+ * Note: The 'locked' parameter in this function refers to the scheduler's
+ * spinlock.
  */
-static void unref_check(struct k_object *ko, uintptr_t index)
+static void unref_check(struct k_object *ko, uintptr_t index, bool locked)
 {
 	k_spinlock_key_t key = k_spin_lock(&obj_lock);
 
@@ -687,10 +701,10 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	 */
 	switch (ko->type) {
 	case K_OBJ_MSGQ:
-		k_msgq_cleanup((struct k_msgq *)ko->name);
+		(void)z_msgq_cleanup((struct k_msgq *)ko->name, locked);
 		break;
 	case K_OBJ_STACK:
-		k_stack_cleanup((struct k_stack *)ko->name);
+		(void)z_stack_cleanup((struct k_stack *)ko->name, locked);
 		break;
 	case K_OBJ_TIMER:
 		/* k_timer_cleanup() does not check whether the timer has
@@ -699,7 +713,7 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 		 * explicitly here.
 		 */
 		if ((ko->flags & K_OBJ_FLAG_INITIALIZED) != 0U) {
-			k_timer_cleanup((struct k_timer *)ko->name);
+			(void)z_timer_cleanup((struct k_timer *)ko->name, locked);
 		}
 		break;
 	default:
@@ -759,27 +773,34 @@ void k_thread_perms_clear(struct k_object *ko, struct k_thread *thread)
 #ifdef CONFIG_DYNAMIC_OBJECTS
 		k_spinlock_key_t key = k_spin_lock(&lists_lock);
 
-		unref_check(ko, index);
+		unref_check(ko, index, false);
 		k_spin_unlock(&lists_lock, key);
 #else
-		unref_check(ko, index);
+		unref_check(ko, index, false);
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 	}
 }
 
-static void clear_perms_cb(struct k_object *ko, void *ctx_ptr)
+static void clear_perms_cb_locked(struct k_object *ko, void *ctx_ptr)
 {
 	uintptr_t id = (uintptr_t)ctx_ptr;
 
-	unref_check(ko, id);
+	unref_check(ko, id, true);
 }
 
+/*
+ * The only place where this routine is presently used in the Zephyr tree
+ * is in halt_thread() when a thread is being aborted and the scheduler's
+ * spinlock is held. The knowledge that the scheduler's spinlock is held must
+ * be passed down to the lower layers so that they do not try to reacquire the
+ * spinlock (leading to deadlock).
+ */
 void k_thread_perms_all_clear(struct k_thread *thread)
 {
 	uintptr_t index = thread_index_get(thread);
 
 	if ((int)index != -1) {
-		k_object_wordlist_foreach(clear_perms_cb, (void *)index);
+		k_object_wordlist_foreach(clear_perms_cb_locked, (void *)index);
 	}
 }
 


### PR DESCRIPTION
This set of commits can be divided into two parts.

**Part 1.** Abstract the manipulation of the scheduler's spinlock. The scheduler's spinlock is used across multiple kernel C and header files. Its use the header files was getting cumbersome and starting to show order dependency smells. Creating a private kernel header file for manipulating the scheduler spinlock simplifies things and makes it easier to manage (and implement part 2).

**Part 2.** Fixing the race condition. On SMP systems, z_waitq_head() requires that the scheduler's spinlock be held. This adds z_waitq_head_locked() to cover cases where the scheduler's spinlock is already held, and updates z_waitq_head() to lock the scheduler's spinlock if necessary (it is not necessary on single core systems as it is always called inside an IRQ locked section). The scheduler spinlock is necessary on SMP as another CPU may execute the thread timeout handler thereby modifying the wait queue.

Fixes #115756