### PR TITLE
Bluetooth: Host: Monitor: fix timestamp skew on 32 kHz cycle counters

### DIFF
--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -204,7 +204,13 @@ static log_timestamp_t monitor_ts_get(void)
 		cycle = k_cycle_get_32();
 	}
 
-	return (cycle / (sys_clock_hw_cycles_per_sec() / MONITOR_TS_FREQ));
+	/* Convert to 1/10th of a millisecond via microseconds, rather than
+	 * dividing by hw_cycles / MONITOR_TS_FREQ: the latter truncates badly
+	 * for cycle rates that are not a multiple of MONITOR_TS_FREQ (e.g.
+	 * 32768 Hz yields a divisor of 3 instead of 3.2768, making the
+	 * timestamps run 9.2% fast).
+	 */
+	return (log_timestamp_t)(k_cyc_to_us_floor64(cycle) / (USEC_PER_MSEC / 10U));
 }
 
 static inline void encode_hdr(struct bt_monitor_hdr *hdr, log_timestamp_t timestamp,


### PR DESCRIPTION
monitor_ts_get() divided the cycle counter by
sys_clock_hw_cycles_per_sec() / MONITOR_TS_FREQ, truncating the divisor to an integer. With a 32768 Hz cycle counter, common on Bluetooth LE SoCs (both nRF52 and EFR32 use it by default), the divisor becomes 3 instead of 3.2768, making all monitor timestamps run 9.2% fast: one real minute displays as roughly 65.5 seconds in btmon, and the same skew applies to the log core timestamps since monitor_ts_get() is also registered via log_set_timestamp_func().

Convert through microseconds with k_cyc_to_us_floor64() instead, which uses overflow-safe scaled arithmetic for any cycle rate.

Measured on nrf52dk/nrf52832 against k_uptime_get() reported in the same monitor record: before, a record stamped at 54.9 s carried an uptime of 50.3 s (ratio 1.0923); after, records at 16.683 s and 48.811 s carry uptimes of 16683 ms and 48810 ms (ratio 1.0000).
