### PR TITLE
cmsis: fixes: runtime control block size

### DIFF
--- a/subsys/portability/cmsis_rtos_v2/event_flags.c
+++ b/subsys/portability/cmsis_rtos_v2/event_flags.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/portability/cmsis_types.h>
+#include <zephyr/sys/check.h>
 #include <string.h>
 
 K_MEM_SLAB_DEFINE_TYPE(cmsis_rtos_event_cb_slab, struct cmsis_rtos_event_cb,
@@ -36,7 +37,9 @@ osEventFlagsId_t osEventFlagsNew(const osEventFlagsAttr_t *attr)
 	}
 
 	if (attr->cb_mem != NULL) {
-		__ASSERT(attr->cb_size == sizeof(struct cmsis_rtos_event_cb), "Invalid cb_size\n");
+		CHECKIF(attr->cb_size < sizeof(struct cmsis_rtos_event_cb)) {
+			return NULL;
+		}
 		events = (struct cmsis_rtos_event_cb *)attr->cb_mem;
 	} else if (k_mem_slab_alloc(&cmsis_rtos_event_cb_slab, (void **)&events, K_MSEC(100)) !=
 		   0) {

--- a/subsys/portability/cmsis_rtos_v2/mempool.c
+++ b/subsys/portability/cmsis_rtos_v2/mempool.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/portability/cmsis_types.h>
+#include <zephyr/sys/check.h>
 #include <string.h>
 #include "wrapper.h"
 
@@ -47,8 +48,9 @@ osMemoryPoolId_t osMemoryPoolNew(uint32_t block_count, uint32_t block_size,
 	}
 
 	if (attr->cb_mem != NULL) {
-		__ASSERT(attr->cb_size == sizeof(struct cmsis_rtos_mempool_cb),
-			 "Invalid cb_size\n");
+		CHECKIF(attr->cb_size < sizeof(struct cmsis_rtos_mempool_cb)) {
+			return NULL;
+		}
 		mslab = (struct cmsis_rtos_mempool_cb *)attr->cb_mem;
 	} else if (k_mem_slab_alloc(&cv2_mem_slab, (void **)&mslab, K_MSEC(100)) != 0) {
 		return NULL;

--- a/subsys/portability/cmsis_rtos_v2/msgq.c
+++ b/subsys/portability/cmsis_rtos_v2/msgq.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/portability/cmsis_types.h>
+#include <zephyr/sys/check.h>
 #include <string.h>
 #include "wrapper.h"
 
@@ -45,7 +46,9 @@ osMessageQueueId_t osMessageQueueNew(uint32_t msg_count, uint32_t msg_size,
 	}
 
 	if (attr->cb_mem != NULL) {
-		__ASSERT(attr->cb_size == sizeof(struct cmsis_rtos_msgq_cb), "Invalid cb_size\n");
+		CHECKIF(attr->cb_size < sizeof(struct cmsis_rtos_msgq_cb)) {
+			return NULL;
+		}
 		msgq = (struct cmsis_rtos_msgq_cb *)attr->cb_mem;
 	} else if (k_mem_slab_alloc(&cmsis_rtos_msgq_cb_slab, (void **)&msgq, K_MSEC(100)) != 0) {
 		return NULL;

--- a/subsys/portability/cmsis_rtos_v2/mutex.c
+++ b/subsys/portability/cmsis_rtos_v2/mutex.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/portability/cmsis_types.h>
+#include <zephyr/sys/check.h>
 #include <string.h>
 #include "wrapper.h"
 
@@ -40,7 +41,9 @@ osMutexId_t osMutexNew(const osMutexAttr_t *attr)
 	__ASSERT(!(attr->attr_bits & osMutexRobust), "Zephyr does not support osMutexRobust.\n");
 
 	if (attr->cb_mem != NULL) {
-		__ASSERT(attr->cb_size == sizeof(struct cmsis_rtos_mutex_cb), "Invalid cb_size\n");
+		CHECKIF(attr->cb_size < sizeof(struct cmsis_rtos_mutex_cb)) {
+			return NULL;
+		}
 		mutex = (struct cmsis_rtos_mutex_cb *)attr->cb_mem;
 	} else if (k_mem_slab_alloc(&cmsis_rtos_mutex_cb_slab, (void **)&mutex, K_MSEC(100)) != 0) {
 		return NULL;

--- a/subsys/portability/cmsis_rtos_v2/semaphore.c
+++ b/subsys/portability/cmsis_rtos_v2/semaphore.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/portability/cmsis_types.h>
+#include <zephyr/sys/check.h>
 #include <string.h>
 
 K_MEM_SLAB_DEFINE_TYPE(cmsis_rtos_semaphore_cb_slab, struct cmsis_rtos_semaphore_cb,
@@ -35,8 +36,9 @@ osSemaphoreId_t osSemaphoreNew(uint32_t max_count, uint32_t initial_count,
 	}
 
 	if (attr->cb_mem != NULL) {
-		__ASSERT(attr->cb_size == sizeof(struct cmsis_rtos_semaphore_cb),
-			 "Invalid cb_size\n");
+		CHECKIF(attr->cb_size < sizeof(struct cmsis_rtos_semaphore_cb)) {
+			return NULL;
+		}
 		semaphore = (struct cmsis_rtos_semaphore_cb *)attr->cb_mem;
 	} else if (k_mem_slab_alloc(&cmsis_rtos_semaphore_cb_slab, (void **)&semaphore,
 				    K_MSEC(100)) != 0) {

--- a/subsys/portability/cmsis_rtos_v2/thread.c
+++ b/subsys/portability/cmsis_rtos_v2/thread.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/check.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/portability/cmsis_types.h>
 #include "wrapper.h"
@@ -123,6 +124,10 @@ osThreadId_t osThreadNew(osThreadFunc_t threadfunc, void *arg, const osThreadAtt
 	}
 
 	if (attr->cb_mem == NULL && num_dynamic_cb >= CONFIG_CMSIS_V2_THREAD_MAX_COUNT) {
+		return NULL;
+	}
+
+	CHECKIF(attr->cb_mem != NULL && attr->cb_size < sizeof(struct cmsis_rtos_thread_cb)) {
 		return NULL;
 	}
 

--- a/subsys/portability/cmsis_rtos_v2/timer.c
+++ b/subsys/portability/cmsis_rtos_v2/timer.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/portability/cmsis_types.h>
+#include <zephyr/sys/check.h>
 #include <string.h>
 
 #define ACTIVE     1
@@ -52,7 +53,9 @@ osTimerId_t osTimerNew(osTimerFunc_t func, osTimerType_t type, void *argument,
 	}
 
 	if (attr->cb_mem != NULL) {
-		__ASSERT(attr->cb_size == sizeof(struct cmsis_rtos_timer_cb), "Invalid cb_size\n");
+		CHECKIF(attr->cb_size < sizeof(struct cmsis_rtos_timer_cb)) {
+			return NULL;
+		}
 		timer = (struct cmsis_rtos_timer_cb *)attr->cb_mem;
 	} else if (k_mem_slab_alloc(&cmsis_rtos_timer_cb_slab, (void **)&timer, K_MSEC(100)) != 0) {
 		return NULL;


### PR DESCRIPTION
Use CHECKIF in places that are being checked only through asserts.