### PR TITLE
soc: infineon: fix perf sample link with CONFIG_ARCH_STACKWALK

### DIFF
--- a/soc/infineon/cat1b/cyw20829/linker.ld
+++ b/soc/infineon/cat1b/cyw20829/linker.ld
@@ -174,7 +174,7 @@ SECTIONS
 
 	__text_region_end = .;
 
-#if defined (CONFIG_CPP)
+#if defined (CONFIG_CPP) || defined(CONFIG_RUST) || defined(CONFIG_ARCH_STACKWALK)
 	SECTION_PROLOGUE(.ARM.extab,,)
 	{
 	/*

--- a/soc/infineon/edge/pse84/linker_exclude_syslib.ld
+++ b/soc/infineon/edge/pse84/linker_exclude_syslib.ld
@@ -167,6 +167,22 @@ SECTIONS
 
 	__text_region_end = .;
 
+	/*
+	 * Code relocated into ITCM (see itcm_mem.ld: .cy_itcm) gets its own
+	 * .ARM.exidx/.ARM.extab unwind entries when -funwind-tables is enabled
+	 * (CONFIG_ARCH_STACKWALK). Those entries would otherwise be gathered into
+	 * the main exidx table in ROMABLE_REGION, from where the R_ARM_PREL31
+	 * relocation back to the ITCM code cannot be encoded ("relocation
+	 * truncated to fit"). The Cortex-M stack unwinder does not consume these
+	 * tables, so drop the ITCM ones. Listed before the .ARM.extab/.ARM.exidx
+	 * output sections so they are matched here first.
+	 */
+	/DISCARD/ :
+	{
+	*(.ARM.exidx.cy_itcm*)
+	*(.ARM.extab.cy_itcm*)
+	}
+
 #if defined (CONFIG_CPP) || defined(CONFIG_RUST) || defined(CONFIG_ARCH_STACKWALK)
 	SECTION_PROLOGUE(.ARM.extab,,)
 	{

--- a/soc/infineon/edge/pse84/linker_exclude_syslib.ld
+++ b/soc/infineon/edge/pse84/linker_exclude_syslib.ld
@@ -167,7 +167,7 @@ SECTIONS
 
 	__text_region_end = .;
 
-#if defined (CONFIG_CPP) || defined(CONFIG_RUST)
+#if defined (CONFIG_CPP) || defined(CONFIG_RUST) || defined(CONFIG_ARCH_STACKWALK)
 	SECTION_PROLOGUE(.ARM.extab,,)
 	{
 	/*


### PR DESCRIPTION
When `CONFIG_ARCH_STACKWALK` is enabled, the Arm core build adds
`-funwind-tables` (see `arch/arm/core/CMakeLists.txt`), so C code emits
`.ARM.extab` / `.ARM.exidx` exception-unwinding sections. This exposed two
issues in the Infineon SOC linker scripts when building, for example, the
`perf` sample (which selects `CONFIG_ARCH_STACKWALK` via the new Arm Cortex-M
profiling backend).

### 1. Place `.ARM.extab` when `CONFIG_ARCH_STACKWALK` is set

The generic Cortex-M linker script
(`include/zephyr/arch/arm/cortex_m/scripts/linker.ld`) already guards the
`.ARM.extab` output section with
`CONFIG_CPP || CONFIG_RUST || CONFIG_ARCH_STACKWALK`. The Infineon `cat1b`
(cyw20829) and `edge` (pse84) SOC linker scripts override the generic one and
were missing the `CONFIG_ARCH_STACKWALK` case, so `.ARM.extab` became an orphan
section and the link failed under strict orphan-section handling. This syncs
the guard with the generic script.

### 2. pse84: drop unwind tables for ITCM-relocated code

On pse84, `cy_device.c` / `cy_gpio.c` are relocated into ITCM (`.cy_itcm`, see
`itcm_mem.ld`). With `-funwind-tables` the compiler emits
`.ARM.exidx.cy_itcm` entries for that code, which are gathered into the main
exidx table in `ROMABLE_REGION`. The `R_ARM_PREL31` relocation from that table
back to the ITCM code cannot be encoded, so the link fails with
`relocation truncated to fit: R_ARM_PREL31 against .cy_itcm`. The Cortex-M
stack unwinder does not consume these tables, so the ITCM-relocated ones are
discarded.

### Test

Built `samples/subsys/profiling/perf` with `CONFIG_ARCH_STACKWALK=y`:

- `cyw920829m2evk_02/cyw20829b1340` links cleanly (no `.ARM.extab` orphan).
- `kit_pse84_eval/pse846gps2dbzc4a/m55` and `/m33` link cleanly (no orphan and
  no `R_ARM_PREL31` truncation).

Signed-off-by: Bill Waters <bill.waters@infineon.com>
