### PR TITLE
tests: Bluetooth: Audio: Log valid_rx_cnt

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
@@ -75,7 +75,8 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 		log_stream_err(test_stream, info, buf);
 
 		if (test_stream->valid_rx_cnt > 1U) {
-			FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
+			FAIL("Duplicated timestamp received after %u valid RX: %u\n",
+			     test_stream->valid_rx_cnt, test_stream->last_info.ts);
 		}
 	}
 
@@ -83,7 +84,8 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 		log_stream_err(test_stream, info, buf);
 
 		if (test_stream->valid_rx_cnt > 1U) {
-			FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
+			FAIL("Duplicated PSN received after %u valid RX: %u\n",
+			     test_stream->valid_rx_cnt, test_stream->last_info.seq_num);
 		}
 	}
 
@@ -93,7 +95,7 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 
 		if (test_stream->valid_rx_cnt > 1U &&
 		    !TEST_FLAG(test_stream->flag_audio_received)) {
-			FAIL("ISO receive error\n");
+			FAIL("ISO receive error after %u valid RX\n", test_stream->valid_rx_cnt);
 		}
 	}
 
@@ -101,7 +103,7 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 		log_stream_err(test_stream, info, buf);
 
 		if (!TEST_FLAG(test_stream->stopping) && test_stream->valid_rx_cnt > 1U) {
-			FAIL("ISO receive lost\n");
+			FAIL("ISO receive lost after %u valid RX\n", test_stream->valid_rx_cnt);
 		}
 	}
 }


### PR DESCRIPTION
When failing due to various reasons, the tests will now also log the number of success RX to give more information on when this happens.