### PR TITLE
drivers: dma: stm32: fix IRQ controlling state machine

### DIFF
--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
@@ -17,6 +17,7 @@ supported:
   - uart
   - gpio
   - counter
+  - dma
   - i2c
   - pwm
   - netif:eth

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
@@ -13,6 +13,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - ptp_clock
+  - spi
   - uart
   - gpio
   - counter

--- a/boards/st/nucleo_h7s3l8/twister.yaml
+++ b/boards/st/nucleo_h7s3l8/twister.yaml
@@ -17,6 +17,7 @@ supported:
   - netif:eth
   - rtc
   - usbd
+  - spi
 vendor: st
 variants:
   nucleo_h7s3l8/stm32h7s3xx:

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -324,6 +324,8 @@ static int dma_stm32_configure(const struct device *dev,
 		stream->user_data = config->user_data;
 		stream->cyclic = false;
 		return 0;
+	} else {
+		stream->hal_override = false;
 	}
 
 	if (config->head_block->block_size > DMA_STM32_MAX_DATA_ITEMS) {

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -85,6 +85,38 @@ static void dma_stm32_clear_stream_irq(const struct device *dev, uint32_t id)
 	stm32_dma_clear_stream_irq(dma, id);
 }
 
+static void dma_stm32_enable_stream_irq(const struct device *dev, uint32_t id)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	struct dma_stm32_stream *stream = &config->streams[id];
+	uint32_t stream_nr = dma_stm32_id_to_stream(id);
+
+	/* Always enable the transfer error interrupt */
+	LL_DMA_EnableIT_TE(dma, stream_nr);
+
+	/* Enable transfer complete ISR if in non-cyclic mode or a callback is requested */
+	if (!stream->cyclic || stream->dma_callback != NULL) {
+		LL_DMA_EnableIT_TC(dma, stream_nr);
+	}
+
+	/* Enable Half-Transfer irq if circular mode is enabled and a callback is requested */
+	if (stream->cyclic && stream->dma_callback != NULL) {
+		LL_DMA_EnableIT_HT(dma, stream_nr);
+	}
+}
+
+static void dma_stm32_disable_stream_irq(const struct device *dev, uint32_t id)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	uint32_t stream_nr = dma_stm32_id_to_stream(id);
+
+	LL_DMA_DisableIT_TE(dma, stream_nr);
+	LL_DMA_DisableIT_TC(dma, stream_nr);
+	LL_DMA_DisableIT_HT(dma, stream_nr);
+}
+
 static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
@@ -310,8 +342,6 @@ static int dma_stm32_configure(const struct device *dev,
 		return -EBUSY;
 	}
 
-	dma_stm32_clear_stream_irq(dev, id);
-
 	/* Check potential DMA override (if id parameters and stream are valid) */
 	if (config->linked_channel == STM32_DMA_HAL_OVERRIDE) {
 		/* DMA channel is overridden by HAL DMA
@@ -527,19 +557,6 @@ static int dma_stm32_configure(const struct device *dev,
 #endif
 	LL_DMA_Init(dma, dma_stm32_id_to_stream(id), &DMA_InitStruct);
 
-	/* Always enable the transfer error interrupt */
-	LL_DMA_EnableIT_TE(dma, dma_stm32_id_to_stream(id));
-
-	/* Enable transfer complete ISR if in non-cyclic mode or a callback is requested */
-	if (!stream->cyclic || stream->dma_callback != NULL) {
-		LL_DMA_EnableIT_TC(dma, dma_stm32_id_to_stream(id));
-	}
-
-	/* Enable Half-Transfer irq if circular mode is enabled and a callback is requested */
-	if (stream->cyclic && stream->dma_callback != NULL) {
-		LL_DMA_EnableIT_HT(dma, dma_stm32_id_to_stream(id));
-	}
-
 #if defined(CONFIG_DMA_STM32_V1)
 	if (DMA_InitStruct.FIFOMode == LL_DMA_FIFOMODE_ENABLE) {
 		LL_DMA_EnableFifoMode(dma, dma_stm32_id_to_stream(id));
@@ -598,11 +615,7 @@ static int dma_stm32_reload(const struct device *dev, uint32_t id,
 				     size / stream->dst_size);
 	}
 
-	/* When reloading the dma, the stream is busy again before enabling */
-	stream->busy = true;
-
-	stm32_dma_enable_stream(dma, id);
-
+	dma_start(dev, id + STM32_DMA_STREAM_OFFSET);
 	return 0;
 }
 
@@ -630,6 +643,7 @@ static int dma_stm32_start(const struct device *dev, uint32_t id)
 	stream->busy = true;
 
 	dma_stm32_clear_stream_irq(dev, id);
+	dma_stm32_enable_stream_irq(dev, id);
 	stm32_dma_enable_stream(dma, id);
 
 	return 0;
@@ -660,15 +674,7 @@ static int dma_stm32_stop(const struct device *dev, uint32_t id)
 		return 0;
 	}
 
-#if !defined(CONFIG_DMAMUX_STM32) \
-	|| defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32MP1X)
-	LL_DMA_DisableIT_TC(dma, dma_stm32_id_to_stream(id));
-#endif /* CONFIG_DMAMUX_STM32 */
-
-#if defined(CONFIG_DMA_STM32_V1)
-	stm32_dma_disable_fifo_irq(dma, id);
-#endif
-
+	dma_stm32_disable_stream_irq(dev, id);
 	dma_stm32_clear_stream_irq(dev, id);
 	dma_stm32_disable_stream(dma, id);
 

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -99,7 +99,6 @@ bool stm32_dma_is_enabled_stream(DMA_TypeDef *dma, uint32_t id);
 int stm32_dma_disable_stream(DMA_TypeDef *dma, uint32_t id);
 
 #ifdef CONFIG_DMA_STM32_V1
-void stm32_dma_disable_fifo_irq(DMA_TypeDef *dma, uint32_t id);
 bool stm32_dma_check_fifo_mburst(LL_DMA_InitTypeDef *DMAx);
 uint32_t stm32_dma_get_fifo_threshold(uint16_t fifo_mode_control);
 uint32_t stm32_dma_get_mburst(struct dma_config *config, bool source_periph);

--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -339,11 +339,6 @@ int stm32_dma_disable_stream(DMA_TypeDef *dma, uint32_t id)
 	return 0;
 }
 
-void stm32_dma_disable_fifo_irq(DMA_TypeDef *dma, uint32_t id)
-{
-	LL_DMA_DisableIT_FE(dma, dma_stm32_id_to_stream(id));
-}
-
 uint32_t stm32_dma_get_mburst(struct dma_config *config, bool source_periph)
 {
 	uint32_t mem_data_size, mem_burst_size;

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -423,6 +423,8 @@ static int dma_stm32_configure(const struct device *dev,
 		stream->dma_callback = config->dma_callback;
 		stream->user_data = config->user_data;
 		return 0;
+	} else {
+		stream->hal_override = false;
 	}
 
 	if (config->head_block->block_size > DMA_STM32_MAX_DATA_ITEMS) {

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -225,6 +225,34 @@ void stm32_dma_clear_stream_irq(DMA_TypeDef *dma, uint32_t id)
 	LL_DMA_ClearFlag_SUSP(STM32_DMA_GET_CHANNEL(dma, id));
 }
 
+static void stm32_dma_enable_stream_irq(const struct device *dev, uint32_t id)
+{
+	const struct dma_stm32_config *config = dev->config;
+	struct dma_stm32_stream *stream = &config->streams[id];
+	DMA_TypeDef *dma = (DMA_TypeDef *)config->base;
+
+	LL_DMA_EnableIT_TC(STM32_DMA_GET_CHANNEL(dma, id));
+	LL_DMA_EnableIT_USE(STM32_DMA_GET_CHANNEL(dma, id));
+	LL_DMA_EnableIT_ULE(STM32_DMA_GET_CHANNEL(dma, id));
+	LL_DMA_EnableIT_DTE(STM32_DMA_GET_CHANNEL(dma, id));
+
+	if (stream->cyclic) {
+		LL_DMA_EnableIT_HT(STM32_DMA_GET_CHANNEL(dma, id));
+	}
+}
+
+static void stm32_dma_disable_stream_irq(const struct device *dev, uint32_t id)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)config->base;
+
+	LL_DMA_DisableIT_TC(STM32_DMA_GET_CHANNEL(dma, id));
+	LL_DMA_DisableIT_USE(STM32_DMA_GET_CHANNEL(dma, id));
+	LL_DMA_DisableIT_ULE(STM32_DMA_GET_CHANNEL(dma, id));
+	LL_DMA_DisableIT_DTE(STM32_DMA_GET_CHANNEL(dma, id));
+	LL_DMA_DisableIT_HT(STM32_DMA_GET_CHANNEL(dma, id));
+}
+
 bool stm32_dma_is_irq_happened(DMA_TypeDef *dma, uint32_t id)
 {
 	if (dma_stm32_is_te_active(dma, id)) {
@@ -410,8 +438,6 @@ static int dma_stm32_configure(const struct device *dev,
 		return -EBUSY;
 	}
 
-	dma_stm32_clear_stream_irq(dev, id);
-
 	/* Check potential DMA override (if id parameters and stream are valid) */
 	if (config->linked_channel == STM32_DMA_HAL_OVERRIDE) {
 		/* DMA channel is overridden by HAL DMA
@@ -573,7 +599,8 @@ static int dma_stm32_configure(const struct device *dev,
 	/* The request ID is stored in the dma_slot */
 	LL_DMA_SetPeriphRequest(STM32_DMA_GET_CHANNEL(dma, id), config->dma_slot);
 
-	if (config->head_block->source_reload_en == 0) {
+	stream->cyclic = config->head_block->source_reload_en != 0;
+	if (!stream->cyclic) {
 		LL_DMA_SetLinkStepMode(STM32_DMA_GET_CHANNEL(dma, id),
 				       STM32_DMA_LINKEDLIST_EXECUTION_NODE);
 		/* Initialize the DMA structure in non-cyclic mode only */
@@ -608,11 +635,8 @@ static int dma_stm32_configure(const struct device *dev,
 					(uint32_t)&linked_list_node[0]);
 
 		/* Continuous transfers with Linked List */
-		stream->cyclic = true;
 		LL_DMA_SetLinkStepMode(STM32_DMA_GET_CHANNEL(dma, id),
 				       STM32_DMA_LINKEDLIST_EXECUTION_Q);
-
-		LL_DMA_EnableIT_HT(STM32_DMA_GET_CHANNEL(dma, id));
 	}
 
 #ifdef CONFIG_ARM_SECURE_FIRMWARE
@@ -655,11 +679,6 @@ static int dma_stm32_configure(const struct device *dev,
 	}
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
-	LL_DMA_EnableIT_TC(STM32_DMA_GET_CHANNEL(dma, id));
-	LL_DMA_EnableIT_USE(STM32_DMA_GET_CHANNEL(dma, id));
-	LL_DMA_EnableIT_ULE(STM32_DMA_GET_CHANNEL(dma, id));
-	LL_DMA_EnableIT_DTE(STM32_DMA_GET_CHANNEL(dma, id));
-
 	return ret;
 }
 
@@ -688,11 +707,7 @@ static int dma_stm32_reload(const struct device *dev, uint32_t id,
 	LL_DMA_ConfigAddresses(STM32_DMA_GET_CHANNEL(dma, id), src, dst);
 	LL_DMA_SetBlkDataLength(STM32_DMA_GET_CHANNEL(dma, id), size);
 
-	/* When reloading the dma, the stream is busy again before enabling */
-	stream->busy = true;
-
-	stm32_dma_enable_stream(dma, id);
-
+	dma_start(dev, id);
 	return 0;
 }
 
@@ -717,7 +732,7 @@ static int dma_stm32_start(const struct device *dev, uint32_t id)
 	stream->busy = true;
 
 	dma_stm32_clear_stream_irq(dev, id);
-
+	stm32_dma_enable_stream_irq(dev, id);
 	stm32_dma_enable_stream(dma, id);
 
 	return 0;
@@ -800,11 +815,7 @@ static int dma_stm32_stop(const struct device *dev, uint32_t id)
 		return 0;
 	}
 
-	LL_DMA_DisableIT_TC(STM32_DMA_GET_CHANNEL(dma, id));
-	LL_DMA_DisableIT_USE(STM32_DMA_GET_CHANNEL(dma, id));
-	LL_DMA_DisableIT_ULE(STM32_DMA_GET_CHANNEL(dma, id));
-	LL_DMA_DisableIT_DTE(STM32_DMA_GET_CHANNEL(dma, id));
-
+	stm32_dma_disable_stream_irq(dev, id);
 	dma_stm32_clear_stream_irq(dev, id);
 	dma_stm32_disable_stream(dma, id);
 

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
@@ -1,0 +1,6 @@
+#
+# Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
@@ -1,0 +1,46 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Set div-q to get test clk freq into acceptable SPI freq range */
+&pll {
+	div-q = <8>;
+};
+
+&sram2 {
+	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
+};
+
+&spi1 {
+	status = "okay";
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h7s3l8_stm32h7s3xx_ext_flash_app.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h7s3l8_stm32h7s3xx_ext_flash_app.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NOCACHE_MEMORY=y
+# Executing from external flash adds cache-miss latency to the polling loop
+CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=30

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h7s3l8_stm32h7s3xx_ext_flash_app.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h7s3l8_stm32h7s3xx_ext_flash_app.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Lower PLL1_Q to bring the SPI1 kernel clock into an acceptable range */
+&pll {
+	div-q = <6>;
+};
+
+&sram2 {
+	status = "okay";
+	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
+};
+
+&spi1 {
+	dmas = <&gpdma1 0 52 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 51 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	st,fifo-threshold = <8>;
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+};
+
+&gpdma1 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	dmas = <&dmamux1 2 44 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 3 43 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};


### PR DESCRIPTION
This is a follow-up on #102014 which I didn't manage to attend to in time. To sum up that thread, I proposed a change to control all IRQ enabling/disabling in the `dma_config()` call, to allow the DMA state machine to be started or reloaded again after a stop, as currently it's not possible. This change itself broke several UART async API tests. So the rest of the changes are made to ensure all tests are passing.

1. I have added `nucleo_h755zi_q` board support for the mentioned tests, as that's the closest hardware I have to the one where @djiatsaf-st found the problems.
2. I found a lot of overlap in the logic between `dma_stm32` and `dma_stm32u5` drivers, so I applied the same changes on both, but importantly I have only run tests on `nucleo_h755zi_q`, so **the tests should be performed on `stm32u5` compatible hardware** too, before merging.
3. One additional smaller bugfix is added to the DMA drivers, to provide a code path for `hal_override` flag to be cleared.

EDIT: instead of only configuring the IRQs in the `dma_config()` call, I have reworked the logic to enable IRQs only in `dma_start()` and disable everything in `dma_stop()`.
~~A related change is that `dma_reload()` no longer enables the DMA stream, so it is required to call `dma_start()`, which will enable the IRQs (and doesn't terminate early due to reload having enabled the stream before).~~ After the discussion below, dma_reload explicitly calls dma_start to maintain compatibility with existing drivers.