### PR TITLE
drivers: sensor: bmp180: fix X2 divisor in pressure compensation

### DIFF
--- a/drivers/sensor/bosch/bmp180/bmp180.c
+++ b/drivers/sensor/bosch/bmp180/bmp180.c
@@ -313,7 +313,7 @@ static uint32_t bmp180_compensate_press(struct bmp180_data *data)
 	partial_B3 = (((cal->ac1 * 4 + partial_X3) << data->osr_pressure) + 2) / 4;
 
 	partial_X1 = (cal->ac3 * partial_B6) / 0x2000;
-	partial_X2 = cal->b1 * partial_B6 * (float)(1.0f * partial_B6 / 0x8000000);
+	partial_X2 = cal->b1 * partial_B6 * (float)(1.0f * partial_B6 / BIT(28));
 	partial_X3 = (partial_X1 + partial_X2 + 2) / 4;
 	partial_B4 = (uint64_t)(cal->ac4 * ((int64_t)(partial_X3) + 32768)) >> 15;
 	partial_B7 = (uint64_t)(raw_pressure - partial_B3) * (50000 >> data->osr_pressure);


### PR DESCRIPTION
The datasheet's pressure compensation computes the second `X2` term as

    X2 = (B1 * (B6 * B6 / 2^12)) / 2^16

i.e. `B1 * B6² / 2^28`, but the driver used a divisor of `0x8000000` (2^27),
making the term twice as large as it should be.

`B6` is `B5 - 4000`, so the term vanishes near 25 °C and the error grows with the
square of the distance from it — negligible on a bench at room temperature, a few
hPa around 0 °C, and of order 10 hPa at the extremes of the operating range.

<img width="1336" height="1372" alt="Screenshot_20260812-232540" src="https://github.com/user-attachments/assets/6d415724-df22-4e71-9924-60f14e988809" />
