### PR TITLE
drivers: sensor: lis2de12: honour enable argument for DRDY interrupt routing

### DIFF
--- a/drivers/sensor/st/lis2de12/lis2de12_trigger.c
+++ b/drivers/sensor/st/lis2de12/lis2de12_trigger.c
@@ -43,7 +43,7 @@ static int lis2de12_enable_xl_int(const struct device *dev, int enable)
 		return ret;
 	}
 
-	val.i1_zyxda = 1;
+	val.i1_zyxda = enable ? 1 : 0;
 
 	return lis2de12_pin_int1_config_set(ctx, &val);
 }
@@ -101,9 +101,12 @@ static void lis2de12_handle_interrupt(const struct device *dev)
 			break;
 		}
 
-		if ((status.zyxda) && (lis2de12->handler_drdy_acc != NULL)) {
-			lis2de12->handler_drdy_acc(dev, lis2de12->trig_drdy_acc);
+		if (lis2de12->handler_drdy_acc == NULL) {
+			/* ZYXDA is only cleared by reading the output registers */
+			break;
 		}
+
+		lis2de12->handler_drdy_acc(dev, lis2de12->trig_drdy_acc);
 	}
 
 	gpio_pin_interrupt_configure_dt(lis2de12->drdy_gpio,


### PR DESCRIPTION
`lis2de12_enable_xl_int()` takes an `enable` argument and is called with
`LIS2DE12_DIS_BIT` from the trigger-removal path, but it hard-coded the
CTRL_REG3 `I1_ZYXDA` routing bit to 1 — so the bit was only ever set, never
cleared.

Removing a data-ready trigger therefore cleared `handler_drdy_acc` while leaving
INT1 still routed and asserted. The next data-ready edge ran
`lis2de12_handle_interrupt()`, which loops while `STATUS_REG.ZYXDA` is set;
`ZYXDA` is only cleared by reading the output registers, which is the handler's
job — and there was no longer a handler. The loop spun forever on the trigger
thread (or the system work queue), hammering the bus.

Program the routing bit from the `enable` argument, and break out of the handling
loop when no handler is registered so an interrupt already in flight during
teardown cannot wedge either.