### PR TITLE
boards: st: nucleo_c562re: Enable peripherals

### DIFF
--- a/boards/st/nucleo_c562re/doc/index.rst
+++ b/boards/st/nucleo_c562re/doc/index.rst
@@ -68,6 +68,25 @@ use both functions simultaneously.
 
 For more details please refer to `STM32 Nucleo-64 board User Manual`_.
 
+CAN FD
+======
+
+The board has an onboard CAN FD transceiver connected to ``FDCAN1``:
+
+- ``PB8``: CAN receive (CAN_RX)
+- ``PB9``: CAN transmit (CAN_TX)
+- ``PE2``: transceiver standby control (low for normal operation, high for standby)
+
+The CAN FD bus is available on connector ``CN18`` with the following pinout:
+
+- pin 1: CANH
+- pin 2: CANL
+- pin 3: GND
+
+The CAN connections use solder bridges ``SB32`` (PE2), ``SB36`` (PB8), and
+``SB34`` (PB9), which are populated in the default configuration. ``JP9``
+connects the onboard 120-ohm termination resistor when set to ON.
+
 USB
 ===
 

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -24,6 +24,7 @@
 
 	aliases {
 		led0 = &green_led_1;
+		rtc = &rtc;
 		sw0 = &user_button;
 	};
 
@@ -46,6 +47,10 @@
 			label = "LD1";
 		};
 	};
+};
+
+&clk_lse {
+	status = "okay";
 };
 
 &clk_hse {
@@ -133,6 +138,12 @@
 	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK(APB3, 21)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -21,6 +21,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &fdcan1;
 	};
 
 	aliases {
@@ -61,6 +62,13 @@
 			pwms = <&pwm1 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "LD1";
 		};
+	};
+
+	can_phy0: can-phy0 {
+		compatible = "microchip,mcp2562fd", "can-transceiver-gpio";
+		standby-gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
 	};
 };
 
@@ -227,5 +235,17 @@
 zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+/* Make sure SB32, SB34, and SB36 are fitted (default configuration).
+ * Set JP9 to ON to enable 120 Ohm termination on the board.
+ */
+&fdcan1 {
+	clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
+		 <&rcc STM32_SRC_HSE FDCAN_SEL(3)>;
+	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_pb9>;
+	pinctrl-names = "default";
+	phys = <&can_phy0>;
 	status = "okay";
 };

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -8,6 +8,7 @@
 #include <st/c5/stm32c562Xe.dtsi>
 #include <st/c5/stm32c5(5-6)2r(c-e)tx-pinctrl.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "arduino_r3_connector.dtsi"
 #include "st_morpho_connector.dtsi"
 
@@ -25,6 +26,7 @@
 	aliases {
 		die-temp0 = &die_temp;
 		led0 = &green_led_1;
+		pwm-led0 = &green_pwm_led;
 		rtc = &rtc;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
@@ -44,8 +46,18 @@
 		compatible = "gpio-leds";
 
 		green_led_1: led_1 {
-			/* LD1 may conflict with SPI1 SCK on PA5 */
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
+			label = "LD1";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		/* PA5 is shared with SPI1/PWM1. Prioritized for SPI1 in default. */
+		status = "disabled";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm1 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "LD1";
 		};
 	};
@@ -122,7 +134,6 @@
 };
 
 &spi1 {
-	/* SPI1 SCK may conflict with LD1 (Green LED) on PA5 */
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpioc 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -168,6 +179,18 @@
 
 &iwdg {
 	status = "okay";
+};
+
+&timers1 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm1: pwm {
+		pinctrl-0 = <&tim1_ch3_pa5>;
+		pinctrl-names = "default";
+		/* NOTE: Disabled by default, PWM1 conflicts with SPI1 */
+		status = "disabled";
+	};
 };
 
 &die_temp {

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -193,6 +193,20 @@
 	};
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1 &adc1_in8_pc0>;
+	pinctrl-names = "default";
+	status = "okay";
+	vref-mv = <3300>;
+};
+
+&adc2 {
+	pinctrl-0 = <&adc2_in6_pb0 &adc2_in5_pc5>;
+	pinctrl-names = "default";
+	status = "okay";
+	vref-mv = <3300>;
+};
+
 &die_temp {
 	status = "okay";
 };

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -23,6 +23,7 @@
 	};
 
 	aliases {
+		die-temp0 = &die_temp;
 		led0 = &green_led_1;
 		rtc = &rtc;
 		sw0 = &user_button;
@@ -166,6 +167,10 @@
 };
 
 &iwdg {
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -29,6 +29,7 @@
 		pwm-led0 = &green_pwm_led;
 		rtc = &rtc;
 		sw0 = &user_button;
+		volt-sensor0 = &vref;
 		watchdog0 = &iwdg;
 	};
 
@@ -208,6 +209,10 @@
 };
 
 &die_temp {
+	status = "okay";
+};
+
+&vref {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -156,6 +156,10 @@
 	status = "okay";
 };
 
+&rng {
+	status = "okay";
+};
+
 zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -26,6 +26,7 @@
 		led0 = &green_led_1;
 		rtc = &rtc;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 
 	gpio_keys {
@@ -161,6 +162,10 @@
 };
 
 &rng {
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -156,6 +156,10 @@
 	status = "okay";
 };
 
+&crc {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -208,6 +208,14 @@
 	vref-mv = <3300>;
 };
 
+&dac1 {
+	clocks = <&rcc STM32_CLOCK(AHB2, 11)>,
+		 <&rcc STM32_SRC_PSIS ADCDAC_SEL(1)>;
+	pinctrl-0 = <&dac1_out1_pa4>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &die_temp {
 	status = "okay";
 };

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
   - arduino_serial

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -10,6 +10,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - crc
   - entropy
   - gpio
   - i2c

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - can
   - crc
   - dac
   - entropy

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -14,6 +14,7 @@ supported:
   - entropy
   - gpio
   - i2c
+  - pwm
   - rtc
   - spi
   - uart

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_spi
   - gpio
   - i2c
+  - rtc
   - spi
   - uart
   - usbd

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -10,6 +10,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - entropy
   - gpio
   - i2c
   - rtc

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -18,6 +18,7 @@ supported:
   - spi
   - uart
   - usbd
+  - watchdog
 ram: 128
 flash: 512
 vendor: st

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - crc
+  - dac
   - entropy
   - gpio
   - i2c

--- a/samples/basic/fade_led/boards/nucleo_c562re.overlay
+++ b/samples/basic/fade_led/boards/nucleo_c562re.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TOKITA Hiroshi
+ */
+
+/ {
+	leds {
+		status = "disabled";
+	};
+
+	pwmleds {
+		status = "okay";
+	};
+};
+
+&pwm1 {
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_dt/boards/nucleo_c562re.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_c562re.overlay
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TOKITA Hiroshi
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 0>, <&adc1 1>, <&adc2 6>, <&adc2 5>, <&adc1 8>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@8 {
+		reg = <8>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&adc2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/boards/nucleo_c562re.overlay
+++ b/samples/drivers/dac/boards/nucleo_c562re.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac1>;
+		dac-channel-id = <1>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/led/pwm/boards/nucleo_c562re.overlay
+++ b/samples/drivers/led/pwm/boards/nucleo_c562re.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TOKITA Hiroshi
+ */
+
+/ {
+	leds {
+		status = "disabled";
+	};
+
+	pwmleds {
+		status = "okay";
+	};
+};
+
+&pwm1 {
+	status = "okay";
+};


### PR DESCRIPTION
Add/Enable peripherals

- adc
- can
- crc
- dac
- entropy
- pwm
- rtc
- watchdog
- die-temp
- voltage-sensor