### PR TITLE
boards: nxp: frdm_a_s32k344: add initial board support

### DIFF
--- a/boards/nxp/frdm_a_s32k344/Kconfig.defconfig
+++ b/boards/nxp/frdm_a_s32k344/Kconfig.defconfig
@@ -1,0 +1,33 @@
+# Copyright 2023-2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_FRDM_A_S32K344
+
+if SERIAL
+
+config UART_CONSOLE
+	default y
+
+endif # SERIAL
+
+if SPI
+
+config GPIO_INIT_PRIORITY
+	default 10
+
+config SPI_INIT_PRIORITY
+	default 10
+
+if WDT_NXP_FS26
+
+config WDT_NXP_FS26_INIT_PRIORITY
+	default 10
+
+endif # WDT_NXP_FS26
+
+endif # SPI
+
+config NET_L2_ETHERNET
+	default y if !NET_LOOPBACK && !NET_TEST
+
+endif # BOARD_FRDM_A_S32K344

--- a/boards/nxp/frdm_a_s32k344/Kconfig.frdm_a_s32k344
+++ b/boards/nxp/frdm_a_s32k344/Kconfig.frdm_a_s32k344
@@ -1,0 +1,6 @@
+# Copyright 2023-2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_FRDM_A_S32K344
+	select SOC_S32K344
+	select SOC_PART_NUMBER_PS32K344EHVPBS

--- a/boards/nxp/frdm_a_s32k344/Kconfig.sysbuild
+++ b/boards/nxp/frdm_a_s32k344/Kconfig.sysbuild
@@ -1,0 +1,19 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_FRDM_A_S32K344_S32K344_MCUBOOT
+
+choice BOOTLOADER
+	default BOOTLOADER_MCUBOOT
+endchoice
+
+# Use direct-XIP mode (dual-slot) on S32K3
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_DIRECT_XIP
+endchoice
+
+choice BOOT_SIGNATURE_TYPE
+	default BOOT_SIGNATURE_TYPE_RSA
+endchoice
+
+endif # BOARD_FRDM_A_S32K344_S32K344_MCUBOOT

--- a/boards/nxp/frdm_a_s32k344/board.cmake
+++ b/boards/nxp/frdm_a_s32k344/board.cmake
@@ -1,0 +1,19 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(trace32
+  "--startup-args"
+    "elfFile=${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}"
+)
+if(${CONFIG_XIP})
+  board_runner_args(trace32 "loadTo=flash")
+else()
+  board_runner_args(trace32 "loadTo=sram")
+endif()
+
+board_runner_args(jlink "--device=S32K344" "--reset-after-load")
+board_runner_args(pyocd "--target=s32k344")
+
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/trace32.board.cmake)

--- a/boards/nxp/frdm_a_s32k344/board.yml
+++ b/boards/nxp/frdm_a_s32k344/board.yml
@@ -1,0 +1,8 @@
+board:
+  name: frdm_a_s32k344
+  full_name: FRDM-A-S32K344
+  vendor: nxp
+  socs:
+    - name: s32k344
+      variants:
+        - name: mcuboot

--- a/boards/nxp/frdm_a_s32k344/doc/index.rst
+++ b/boards/nxp/frdm_a_s32k344/doc/index.rst
@@ -1,0 +1,396 @@
+.. zephyr:board:: frdm_a_s32k344
+
+Overview
+********
+
+`NXP FRDM-A-S32K344`_ is a development board for general-purpose industrial and
+automotive applications. It features an `NXP S32K344`_ general-purpose automotive
+microcontroller based on an Arm Cortex-M7 core (Lock-Step).
+
+Hardware
+********
+
+- NXP S32K344
+
+  - Arm Cortex-M7 (Lock-Step), 160 MHz (Max.)
+  - 4 MB of program flash
+  - 512KB (incl. 192KB TCM)
+  - Error-Correcting Code (ECC) on all memories
+  - Ethernet 100 Mbps, CAN FD, FlexIO, QSPI
+  - 12-bit 1 Msps ADC, 16-bit eMIOS timer
+
+- `NXP FS26 Safety System Basis Chip`_
+
+- Interfaces
+
+  - Console UART
+  - 6x CAN FD
+  - 100Base-T1 Ethernet
+  - JST-GH connectors and I/O headers for I2C, SPI, GPIO,
+    PWM, etc.
+
+More information about the hardware and design resources can be found at
+`NXP FRDM-A-S32K344`_ website.
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Connections and IOs
+===================
+
+Each GPIO port is divided into two banks: low bank, from pin 0 to 15, and high
+bank, from pin 16 to 31. For example, ``PTA2`` is the pin 2 of ``gpioa_l`` (low
+bank), and ``PTA20`` is the pin 4 of ``gpioa_h`` (high bank).
+
+The GPIO controller provides the option to route external input pad interrupts
+to either the SIUL2 EIRQ or WKPU interrupt controllers, as supported by the SoC.
+By default, GPIO interrupts are routed to SIUL2 EIRQ interrupt controller,
+unless they are explicitly configured to be directed to the WKPU interrupt
+controller, as outlined in :zephyr_file:`dts/bindings/gpio/nxp,siul2-gpio.yaml`.
+
+To find information about which GPIOs are compatible with each interrupt
+controller, refer to the device reference manual.
+
+.. note::
+
+   It is important to highlight that the current board configuration lacks
+   support for wake-up events and power-management features. WKPU functionality
+   is restricted solely to serving as an interrupt controller.
+
+LEDs
+----
+
+The FRDM-A-S32K344 board has one user RGB LED:
+
+=======================  =====  =====  ===================================
+Devicetree node          Color  Pin    Pin Functions
+=======================  =====  =====  ===================================
+led0 / user_led1_red     Red    PTA29  EMIOS1 CH12
+led1 / user_led1_green   Green  PTA30  EMIOS1 CH13
+led2 / user_led1_blue    Blue   PTA31  FXIO D0 / EMIOS1 CH14
+=======================  =====  =====  ===================================
+
+Buttons
+-------
+
+The FRDM-A-S32K344 board has two user buttons:
+
+=======================  =====  =====  ==============
+Devicetree node          Label  Pin    Pin Functions
+=======================  =====  =====  ==============
+sw0 / user_button_1      SW2    PTB26  WKUP41
+sw1 / user_button_2      SW3    PTB19  WKUP38
+=======================  =====  =====  ==============
+
+System Clock
+============
+
+The Arm Cortex-M7 (Lock-Step) are configured to run at 160 MHz.
+
+Serial Console
+==============
+
+By default, the serial console is provided through ``lpuart6`` on the on-board
+OpenSDA debugger (K26 MCU) via the USB-C connector ``J11``.
+
+=========  =====  ============
+Connector  Pin    Pin Function
+=========  =====  ============
+J11        PTA16  LPUART6_TX
+J11        PTA15  LPUART6_RX
+=========  =====  ============
+
+Console Output
+--------------
+
+.. note::
+
+   UART console bring-up has been verified so far by flashing via the
+   on-board OpenSDA debugger's stock `P&E Micro`_ firmware using `NXP S32
+   Design Studio`_, and connecting to the OpenSDA CDC serial port at
+   115200 8N1. J-Link, TRACE32, and pyOCD flashing/debugging (see
+   `Programming and Debugging`_ below) are still expected to work and
+   remain to be verified.
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build ... ***
+   Hello World! frdm_a_s32k344/s32k344
+
+CAN
+===
+
+FRDM-A-S32K344 exposes ``flexcan0`` through an on-board `NXP TJA1043`_ High-Speed
+CAN Transceiver with Standby mode, routed to connector ``J15``. CAN FD is
+supported up to 5 Mbit/s.
+
+===============  =======  ===============  ================
+Devicetree node  Pin      Pin Function     Bus Connector
+===============  =======  ===============  ================
+flexcan0         | PTA6   | PTA6_CAN0_RX   | J15-1 (CANH)
+                 | PTA7   | PTA7_CAN0_TX   | J15-2 (CANL)
+===============  =======  ===============  ================
+
+Additional TJA1043 control lines (see UM12406 Table 11):
+
+=========  ==========  ==========  ==============================
+Signal     Pin         Default     Description
+=========  ==========  ==========  ==============================
+CAN0_ERRN  PTA11       routed      TJA1043 error output
+CAN0_EN    PTC21       routed      TJA1043 mode-select EN
+CAN0_STB   PTC20       routed      TJA1043 standby STB
+CAN0_INH   FS26 WAKE1  not routed  CAN wake-up path to FS26 WAKE1
+CAN0_WAKE  PTE25       not routed  TJA1043 local wake-up input
+=========  ==========  ==========  ==============================
+
+.. note::
+   CAN signals are referenced to the VSUP voltage rail. By default, when
+   using the FS26 VBOOST feature, these lines are referenced to 8 V.
+   If power delivery is enabled, it is recommended to supply 9 V, 12 V,
+   or 15 V. In such cases, VSUP will follow the input voltage level
+   accordingly.
+
+``flexcan0`` is configured with ``number-of-mb = <96>`` in
+``dts/arm/nxp/s32/nxp_s32k344_m7.dtsi``. Each 512-byte RAM region holds
+32 classic CAN MBs or 7 CAN FD MBs, giving the following effective counts:
+
+===============  ===========  ==========  ======  ======================
+Devicetree node  Mode         MB size     MBs     Calculation
+===============  ===========  ==========  ======  ======================
+flexcan0         Classic CAN  8 bytes     96      3 regions × 32
+flexcan0         CAN FD       64 bytes    21      96 × 7 / 32
+===============  ===========  ==========  ======  ======================
+
+Set the RX filter count per instance using the ``max-filters`` devicetree
+property. When omitted, the driver falls back to
+:kconfig:option:`CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS` (default 13 for
+classic CAN, 5 for CAN FD). ``max-filters`` must be smaller than the
+effective MB count.
+
+.. note::
+   The `NXP FRDM-A-S32K344`_ board already includes an on-board 120 Ohm
+   split termination network (two 60.4 Ohm resistors, R176 and R178) for
+   the CAN interface (J15). Therefore, no external termination is required
+   when this board is connected at the ends of a CAN bus.
+
+I2C
+===
+
+I2C is provided through the LPI2C interface. On the FRDM-A-S32K344 board,
+the I2C pins are routed by default to the on-board sensors and USB Power Delivery controllers.
+
+=========  ====  ====================
+Interface  Pin   Pin Function
+=========  ====  ====================
+LPI2C      PTC7  LPI2C_SCL
+LPI2C      PTC6  LPI2C_SDA
+=========  ====  ====================
+
+The following on-board components are connected to this I2C bus:
+* **NXP FXLS8964AF**: Automotive Accelerometer
+* **NXP P3T1750**: Automotive Temperature Sensor
+* **NXP PTN5110 & NX20P3483**: USB Power Delivery PHY and Power Switch
+
+ADC
+===
+
+ADC is provided through 12-bit ADC SAR controller with 3 instances, each supporting up to
+24 channels. ADC channels are divided into 3 groups (precision, standard and external).
+
+.. note::
+   All channels of an instance only run on 1 group channel at the same time.
+
+FS26 SBC Watchdog
+=================
+
+On normal operation after the board is powered on, there is a window of 256 ms
+on which the FS26 watchdog must be serviced with a good token refresh, otherwise
+the watchdog will signal a reset to the MCU. This board configuration enables
+the FS26 watchdog driver that handles this initialization.
+
+External Flash
+==============
+
+The on-board Winbond W25Q64J 64M-bit multi-I/O serial NOR Flash memory is connected
+to the QSPI controller. This board configuration selects it as the
+default external flash memory for execution-in-place (XiP) or data storage.
+
+Ethernet
+========
+
+This board features a single instance of Ethernet Media Access Controller (EMAC)
+interfacing with a `KSZ8091RNDIA`_ 100BASE-T Ethernet PHY.
+
+The Ethernet signals are routed directly to the on-board RJ45 connector (J7),
+enabling robust network communication and evaluation for automotive and industrial applications.
+
+.. todo::
+   The Ethernet PHY devicetree node reuses the microchip,ksz8081 driver, since
+   Zephyr has no dedicated KSZ8091 binding. Both parts share the same base
+   register map; KSZ8091 only adds EEE/WOL on top, which are not used here.
+   Verify Ethernet link-up works on FRDM-A-S32K344 board.
+
+Programming and Debugging
+=========================
+
+.. todo::
+
+   None of the J-Link, TRACE32, or pyOCD runners below have been verified on
+   FRDM-A-S32K344 board yet.
+
+.. zephyr:board-supported-runners::
+
+Applications for the ``frdm_a_s32k344`` board can be built in the usual way as
+documented in :ref:`build_an_application`.
+
+This board configuration supports `Lauterbach TRACE32`_, `SEGGER J-Link`_ and `pyOCD`_
+West runners for flashing and debugging. Follow the steps described in
+:ref:`lauterbach-trace32-debug-host-tools`, :ref:`jlink-debug-host-tools` and
+:ref:`pyocd-debug-host-tools`, to set up the required host tools.
+
+If using TRACE32, ensure you have version >= 2024.09 installed
+
+Flashing
+========
+
+.. todo::
+
+   Verify ``west flash`` actually works on FRDM-A-S32K344 board via J-Link, TRACE32,
+   and pyOCD before publishing.
+
+Run the ``west flash`` command to flash the application using SEGGER J-Link.
+Alternatively, run ``west flash -r trace32`` to use Lauterbach TRACE32, or
+``west flash -r pyocd`` to use pyOCD.
+
+The Lauterbach TRACE32 runner supports additional options that can be passed
+through command line:
+
+.. code-block:: console
+
+   west flash -r trace32 --startup-args elfFile=<elf_path> loadTo=<flash/sram>
+      eraseFlash=<yes/no> verifyFlash=<yes/no>
+
+Where:
+
+- ``<elf_path>`` is the path to the Zephyr application ELF in the output
+  directory
+- ``loadTo=flash`` loads the application to the SoC internal program flash
+  (:kconfig:option:`CONFIG_XIP` must be set), and ``loadTo=sram`` load the
+  application to SRAM. Default is ``flash``.
+- ``eraseFlash=yes`` erases the whole content of SoC internal flash before the
+  application is downloaded to either Flash or SRAM. This routine takes time to
+  execute. Default is ``no``.
+- ``verifyFlash=yes`` verify the SoC internal flash content after programming
+  (use together with ``loadTo=flash``). Default is ``no``.
+
+For example, to erase and verify flash content:
+
+.. code-block:: console
+
+   west flash -r trace32 --startup-args elfFile=build/zephyr/zephyr.elf loadTo=flash eraseFlash=yes verifyFlash=yes
+
+MCUboot
+=======
+
+This board supports app chain-loading using MCUboot.
+
+Build & Flash
+-------------
+
+.. todo::
+
+   Verify this MCUboot build/flash procedure against the FRDM-A-S32K344 board
+   and cross-check with UM12406.
+
+To build MCUboot and the ``flash_shell`` sample application together and
+generate HEX files suitable for flashing, run:
+
+.. code-block:: console
+
+   west build -p -b frdm_a_s32k344/s32k344/mcuboot samples/drivers/flash_shell --sysbuild
+   west flash
+
+The resulting artifacts are:
+
+* MCUboot: ``build/mcuboot/zephyr/zephyr.hex``
+* App (unsigned): ``build/flash_shell/zephyr/zephyr.hex``
+
+Troubleshooting
+---------------
+
+    If MCUboot prints “Image in the primary slot is not valid” or stalls after
+    “Jumping to the first image slot”, the app was likely signed with a 512-byte header.
+    Re-sign with --header-size 0x400 and re-flash.
+
+    Do not add an IVT to MCUboot-chainloaded applications;
+    it’s only emitted for standalone/XIP images or MCUboot itself.
+
+Debugging
+=========
+
+.. todo::
+
+   Verify ``west debug`` actually works on FRDM-A-S32K344 board via J-Link, TRACE32,
+   and pyOCD before publishing.
+
+The reset switch ``SW4`` allows a manual reset of the S32K344 MCU. While reset is
+asserted, the reset indicator LED ``D17`` stays lit.
+
+Run the ``west debug`` command to start a GDB session using SEGGER J-Link.
+Alternatively, run ``west debug -r trace32`` or ``west debug -r pyocd``
+to launch the Lauterbach TRACE32 or pyOCD software debugging interface respectively.
+
+Configuring a Console
+======================
+
+We will use the on-board OpenSDA interface as a USB-to-serial adapter for the
+serial console, reached through the USB-C connector ``J11``.
+
+Use the following settings with your serial terminal of choice (minicom, putty, etc.):
+
+- Speed: 115200
+- Data: 8 bits
+- Parity: None
+- Stop bits: 1
+
+.. include:: ../../common/board-footer.rst.inc
+
+References
+**********
+
+.. target-notes::
+
+.. _NXP FRDM-A-S32K344:
+   https://www.nxp.com/design/design-center/development-boards-and-designs/FRDM-A-S32K344
+
+.. _NXP S32K344:
+   https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-auto-general-purpose-mcus/s32k3-microcontrollers-for-automotive-general-purpose:S32K3
+
+.. _NXP FS26 Safety System Basis Chip:
+   https://www.nxp.com/products/power-management/pmics-and-sbcs/safety-sbcs/safety-system-basis-chip-with-low-power-fit-for-asil-d:FS26
+
+.. _NXP TJA1043:
+   https://www.nxp.com/products/interfaces/can-transceivers/can-with-flexible-data-rate/high-speed-can-transceiver-with-standby-and-sleep-mode:TJA1043
+
+.. _UM12406:
+   https://docs.nxp.com/bundle/UM12406/page/topics/Overview.html
+
+.. _KSZ8091RNDIA:
+   https://www.microchip.com/en-us/product/ksz8091
+
+.. _P&E Micro:
+   https://www.pemicro.com/opensda/
+
+.. _NXP S32 Design Studio:
+   https://www.nxp.com/design/design-center/software/automotive-software-and-tools/s32-design-studio-ide:S32DS
+
+.. _Lauterbach TRACE32:
+   https://www.lauterbach.com
+
+.. _SEGGER J-Link:
+   https://wiki.segger.com/NXP_S32K3xx
+
+.. _pyOCD:
+   https://pyocd.io/

--- a/boards/nxp/frdm_a_s32k344/doc/index.rst
+++ b/boards/nxp/frdm_a_s32k344/doc/index.rst
@@ -21,14 +21,6 @@ Hardware
 
 - `NXP FS26 Safety System Basis Chip`_
 
-- Interfaces
-
-  - Console UART
-  - 6x CAN FD
-  - 100Base-T1 Ethernet
-  - JST-GH connectors and I/O headers for I2C, SPI, GPIO,
-    PWM, etc.
-
 More information about the hardware and design resources can be found at
 `NXP FRDM-A-S32K344`_ website.
 
@@ -225,12 +217,6 @@ interfacing with a `KSZ8091RNDIA`_ 100BASE-T Ethernet PHY.
 
 The Ethernet signals are routed directly to the on-board RJ45 connector (J7),
 enabling robust network communication and evaluation for automotive and industrial applications.
-
-.. todo::
-   The Ethernet PHY devicetree node reuses the microchip,ksz8081 driver, since
-   Zephyr has no dedicated KSZ8091 binding. Both parts share the same base
-   register map; KSZ8091 only adds EEE/WOL on top, which are not used here.
-   Verify Ethernet link-up works on FRDM-A-S32K344 board.
 
 Programming and Debugging
 =========================

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344-pinctrl.dtsi
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344-pinctrl.dtsi
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2023,2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/s32/S32K344_K324_K314_172HDQFP-pinctrl.h>
+
+&pinctrl {
+	eirq0_default: eirq0_default {
+		group1 {
+			pinmux = <PTB26_EIRQ13>;
+			input-enable;
+		};
+	};
+
+	lpuart5_default: lpuart5_default {
+		group1 {
+			pinmux = <PTB27_LPUART5_TX_O>;
+			output-enable;
+		};
+
+		group2 {
+			pinmux = <PTB28_LPUART5_RX>;
+			input-enable;
+		};
+	};
+
+	lpuart6_default: lpuart6_default {
+		group1 {
+			pinmux = <PTA16_LPUART6_TX_O>;
+			output-enable;
+		};
+
+		group2 {
+			pinmux = <PTA15_LPUART6_RX>;
+			input-enable;
+		};
+	};
+
+	lpuart9_default: lpuart9_default {
+		group1 {
+			pinmux = <PTB3_LPUART9_TX_O>;
+			output-enable;
+		};
+
+		group2 {
+			pinmux = <PTB2_LPUART9_RX>;
+			input-enable;
+		};
+	};
+
+	qspi0_default: qspi0_default {
+		group1 {
+			pinmux = <(PTD11_QUADSPI_IOFA0_O | PTD11_QUADSPI_IOFA0_I)>,
+				 <(PTD7_QUADSPI_IOFA1_O | PTD7_QUADSPI_IOFA1_I)>,
+				 <(PTD12_QUADSPI_IOFA2_O | PTD12_QUADSPI_IOFA2_I)>,
+				 <(PTC2_QUADSPI_IOFA3_O | PTC2_QUADSPI_IOFA3_I)>;
+			output-enable;
+			input-enable;
+		};
+
+		group2 {
+			pinmux = <PTD10_QUADSPI_SCKFA_O>;
+			output-enable;
+		};
+
+		group3 {
+			pinmux = <PTC3_QUADSPI_PCSFA>;
+			output-enable;
+			bias-pull-up;
+		};
+	};
+
+	flexcan0_default: flexcan0_default {
+		group1 {
+			pinmux = <PTA6_CAN0_RX>;
+			input-enable;
+		};
+
+		group2 {
+			pinmux = <PTA7_CAN0_TX>;
+			output-enable;
+		};
+	};
+
+	lpi2c1_default: lpi2c1_default {
+		group1 {
+			pinmux = <(PTC6_LPI2C1_SDA_I | PTC6_LPI2C1_SDA_O)>,
+				 <(PTC7_LPI2C1_SCL_I | PTC7_LPI2C1_SCL_O)>;
+			input-enable;
+			output-enable;
+		};
+	};
+
+	lpspi0_default: lpspi0_default {
+		group1 {
+			pinmux = <PTC8_LPSPI0_SCK_O>, <PTB1_LPSPI0_SOUT_O>,
+				 <PTB0_LPSPI0_PCS0_O>;
+			output-enable;
+		};
+
+		group2 {
+			pinmux = <PTC9_LPSPI0_SIN_I>;
+			input-enable;
+		};
+	};
+
+	emac0_default: emac0_default {
+		group1 {
+			pinmux = <PTD9_EMAC_MII_RMII_RXD0>,
+				 <PTD8_EMAC_MII_RMII_RXD1>,
+				 <PTC16_EMAC_MII_RMII_RX_ER>,
+				 <PTC15_EMAC_MII_RMII_RX_DV>,
+				 <PTC0_EMAC_MII_RMII_TX_CLK>;
+			input-enable;
+		};
+
+		group2 {
+			pinmux = <PTB5_EMAC_MII_RMII_TXD0>,
+				 <PTB4_EMAC_MII_RMII_TXD1>,
+				 <PTE9_EMAC_MII_RMII_TX_EN>;
+		};
+	};
+
+	mdio0_default: mdio0_default {
+		group1 {
+			pinmux = <(PTD16_EMAC_MII_RMII_MDIO_O | PTD16_EMAC_MII_RMII_MDIO_I)>;
+			input-enable;
+			output-enable;
+		};
+
+		group2 {
+			pinmux = <PTD17_EMAC_MII_RMII_MDC>;
+			output-enable;
+		};
+	};
+
+	emios0_default: emios0_default {
+		group1 {
+			pinmux = <PTB12_EMIOS_0_CH0_X_O>, <PTB13_EMIOS_0_CH1_G_O>,
+				 <PTB14_EMIOS_0_CH2_G_O>, <PTB15_EMIOS_0_CH3_G_O>,
+				 <PTB16_EMIOS_0_CH4_G_O>, <PTB17_EMIOS_0_CH5_G_O>;
+			output-enable;
+		};
+	};
+
+	emios1_default: emios1_default {
+		group1 {
+			pinmux = <PTA29_EMIOS_1_CH12_H_O>,
+				 <PTA30_EMIOS_1_CH13_H_O>,
+				 <PTA31_EMIOS_1_CH14_H_O>;
+			output-enable;
+		};
+	};
+
+	flexio0_pwm_default: flexio0_pwm_default {
+		group1 {
+			pinmux = <PTA17_FXIO_D19_O>, <PTE7_FXIO_D11_O>;
+			output-enable;
+		};
+	};
+};

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.dts
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.dts
@@ -22,16 +22,18 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		ivt_header: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "ivt-header";
 			reg = <0x00000000 0x100>;
 		};
 
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x00000100 (DT_SIZE_K(4048) - 0x100)>;
 		};

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.dts
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.dts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "frdm_a_s32k344_common.dtsi"
+
+/ {
+	chosen {
+		zephyr,code-partition = &code_partition;
+		zephyr,flash = &flash0;
+	};
+};
+
+&c40fc {
+	status = "okay";
+};
+
+&flash0 {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ivt_header: partition@0 {
+			label = "ivt-header";
+			reg = <0x00000000 0x100>;
+		};
+
+		code_partition: partition@100 {
+			label = "code-partition";
+			reg = <0x00000100 (DT_SIZE_K(4048) - 0x100)>;
+		};
+	};
+};

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.yaml
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: frdm_a_s32k344
+name: NXP FRDM-A-S32K344
+type: mcu
+arch: arm
+ram: 512
+flash: 4096
+toolchain:
+  - zephyr
+supported:
+  - adc
+  - can
+  - counter
+  - display
+  - dma
+  - flash
+  - gpio
+  - i2c
+  - netif:eth
+  - pwm
+  - spi
+  - uart
+  - watchdog
+vendor: nxp

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.yaml
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.yaml
@@ -6,7 +6,7 @@ name: NXP FRDM-A-S32K344
 type: mcu
 arch: arm
 ram: 512
-flash: 4096
+flash: 4048
 toolchain:
   - zephyr
 supported:

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.yaml
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344.yaml
@@ -13,7 +13,6 @@ supported:
   - adc
   - can
   - counter
-  - display
   - dma
   - flash
   - gpio

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_common.dtsi
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_common.dtsi
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm/nxp/s32/nxp_s32k344_m7.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <freq.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include "frdm_a_s32k344-pinctrl.dtsi"
+
+/ {
+	model = "NXP FRDM-A-S32K344";
+	compatible = "nxp,frdm_a_s32k344";
+
+	chosen {
+		zephyr,sram = &sram0_1;
+		zephyr,flash = &flash0;
+		zephyr,itcm = &itcm;
+		zephyr,dtcm = &dtcm;
+		zephyr,console = &lpuart6;
+		zephyr,shell-uart = &lpuart6;
+		zephyr,flash-controller = &c40fc;
+		zephyr,canbus = &flexcan0;
+	};
+
+	aliases {
+		dma0 = &edma0;
+		led0 = &user_led1_red;
+		led1 = &user_led1_green;
+		led2 = &user_led1_blue;
+		sw0 = &user_button_1;
+		sw1 = &user_button_2;
+		watchdog0 = &swt0;
+		/* For pwm test suites */
+		pwm-0 = &emios0_pwm;
+		pwm-1 = &flexio0_pwm;
+		red-pwm-led = &user_led1_red_pwm;
+		green-pwm-led = &user_led1_green_pwm;
+		blue-pwm-led = &user_led1_blue_pwm;
+		pwm-led0 = &user_led1_blue_pwm;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		user_led1_red: user_led1_red {
+			gpios = <&gpioa_h 13 GPIO_ACTIVE_HIGH>;
+			label = "User RGB LED1 RED";
+		};
+
+		user_led1_green: user_led1_green {
+			gpios = <&gpioa_h 14 GPIO_ACTIVE_HIGH>;
+			label = "User RGB LED1 GREEN";
+		};
+
+		user_led1_blue: user_led1_blue {
+			gpios = <&gpioa_h 15 GPIO_ACTIVE_HIGH>;
+			label = "User RGB LED1 BLUE";
+		};
+	};
+
+	/* gpio-leds and pwm-leds are the same RGB LED and cannot be used at the same time. */
+	pwmleds {
+		compatible = "pwm-leds";
+
+		user_led1_red_pwm: user_led1_red {
+			pwms = <&emios1_pwm 12 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+
+		user_led1_green_pwm: user_led1_green {
+			pwms = <&emios1_pwm 13 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+
+		user_led1_blue_pwm: user_led1_blue {
+			pwms = <&emios1_pwm 14 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_button_1: button_0 {
+			label = "User SW2";
+			gpios = <&gpiob_h 10 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		user_button_2: button_1 {
+			label = "User SW3";
+			gpios = <&gpiob_h 3 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
+		};
+	};
+
+	can_phy0: can-phy0 {
+		compatible = "nxp,tja1043", "can-transceiver-gpio";
+		enable-gpios = <&gpioc_h 5 GPIO_ACTIVE_HIGH>;
+		standby-gpios = <&gpioc_h 4 GPIO_ACTIVE_LOW>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
+	};
+};
+
+&pmc {
+	lm-reg;
+};
+
+&gpioa_h {
+	status = "okay";
+};
+
+&gpioe_l {
+	status = "okay";
+};
+
+/* Enable gpio to control the CAN transceivers and LEDs */
+
+&gpiob_h {
+	status = "okay";
+};
+
+&gpioc_h {
+	status = "okay";
+};
+
+&gpiod_l {
+	status = "okay";
+};
+
+&gpiod_h {
+	status = "okay";
+};
+
+&gpiob_l {
+	status = "okay";
+};
+
+&gpioe_h {
+	status = "okay";
+};
+
+&eirq0 {
+	pinctrl-0 = <&eirq0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&lpuart5 {
+	pinctrl-0 = <&lpuart5_default>;
+	pinctrl-names = "default";
+	dmas = <&edma0 16 44>, <&edma0 17 45>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart6 {
+	pinctrl-0 = <&lpuart6_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&lpuart9 {
+	pinctrl-0 = <&lpuart9_default>;
+	pinctrl-names = "default";
+	dmas = <&edma0 4 39>, <&edma0 5 40>;
+	dma-names = "tx", "rx";
+};
+
+/* External flash is a WINBOND W25Q64JV 64 Mbit serial NOR (UM12406, section 11) */
+&qspi0 {
+	pinctrl-0 = <&qspi0_default>;
+	pinctrl-names = "default";
+	data-rate = "SDR";
+	a-rx-clock-source = "LOOPBACK";
+	a-dll-mode = "BYPASSED";
+	ahb-buffers-masters = <0 1 2 3>;
+	ahb-buffers-sizes = <0 0 0 256>;
+	ahb-buffers-all-masters;
+	status = "okay";
+
+	w25q64jv: w25q64jv@0 {
+		compatible = "nxp,s32-qspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(64)>;
+		jedec-id = [ef 40 17];
+		quad-enable-requirements = "S2B1v1";
+		readoc = "1-4-4";
+		writeoc = "1-4-4";
+		has-32k-erase;
+		max-program-buffer-size = <256>;
+		write-block-size = <1>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				label = "storage";
+				reg = <0x0 0x100000>;
+			};
+		};
+	};
+};
+
+&flexcan0 {
+	pinctrl-0 = <&flexcan0_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy0>;
+	status = "okay";
+};
+
+&lpi2c1 {
+	pinctrl-0 = <&lpi2c1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
+};
+
+&lpspi0 {
+	pinctrl-0 = <&lpspi0_default>;
+	pinctrl-names = "default";
+	data-pin-config = "sdo-in,sdi-out";
+	status = "okay";
+
+	fs26_wdt: watchdog@0 {
+		compatible = "nxp,fs26-wdog";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(5)>;
+		type = "challenger";
+		int-gpios = <&gpioe_h 2 GPIO_ACTIVE_LOW>;
+		status = "okay";
+	};
+};
+
+&emac0 {
+	pinctrl-0 = <&emac0_default>;
+	pinctrl-names = "default";
+	phy-connection-type = "rmii";
+	zephyr,random-mac-address;
+	phy-handle = <&phy>;
+	status = "okay";
+};
+
+&mdio0 {
+	pinctrl-0 = <&mdio0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	/*
+	 * The board's actual PHY is a Microchip KSZ8091RNDIA-TRU14 (see UM12406
+	 * Table 12). Zephyr has no dedicated nxp,ksz8091 binding,
+	 * both parts share the same base register map (control/status/ID/clock registers);
+	 * KSZ8091 only adds EEE/WOL, which are not enabled here.
+	 */
+	phy: ethernet-phy@0 {
+		compatible = "microchip,ksz8081";
+		status = "okay";
+		reg = <0x00>;
+		reset-gpios = <&gpioe_h 5 GPIO_ACTIVE_LOW>; /* PTE21, ENET_RESET */
+		microchip,interface-type = "rmii";
+	};
+};
+
+&emios0 {
+	clock-divider = <200>;
+	status = "okay";
+
+	emios0_pwm: pwm {
+		pinctrl-0 = <&emios0_default>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		/* Default clock for internal counter for PWM channel 0-7 is 100Khz */
+		pwm_0 {
+			channel = <0>;
+			pwm-mode = "OPWFMB";
+			prescaler = <8>;
+		};
+
+		pwm_1 {
+			channel = <1>;
+			pwm-mode = "OPWFMB";
+			prescaler = <8>;
+		};
+
+		pwm_2 {
+			channel = <2>;
+			pwm-mode = "OPWFMB";
+			prescaler = <8>;
+		};
+
+		pwm_3 {
+			channel = <3>;
+			pwm-mode = "OPWFMB";
+			prescaler = <8>;
+		};
+
+		pwm_4 {
+			channel = <4>;
+			pwm-mode = "OPWFMB";
+			prescaler = <8>;
+		};
+
+		pwm_5 {
+			channel = <5>;
+			pwm-mode = "OPWFMB";
+			prescaler = <8>;
+		};
+	};
+};
+
+&emios1 {
+	clock-divider = <200>;
+	status = "okay";
+
+	master_bus {
+		/*
+		 * Timebase for PWM led, setting clock 50KHz for internal counter,
+		 * default period is 1000 cycles <-> 20ms.
+		 */
+		emios1_bus_a {
+			prescaler = <16>;
+			mode = "MCB_UP_COUNTER";
+			status = "okay";
+		};
+	};
+
+	emios1_pwm: pwm {
+		pinctrl-0 = <&emios1_default>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		rgb_red {
+			channel = <12>;
+			master-bus = <&emios1_bus_a>;
+			pwm-mode = "OPWMB";
+		};
+
+		rgb_green {
+			channel = <13>;
+			master-bus = <&emios1_bus_a>;
+			pwm-mode = "OPWMB";
+		};
+
+		rgb_blue {
+			channel = <14>;
+			master-bus = <&emios1_bus_a>;
+			pwm-mode = "OPWMB";
+		};
+	};
+};
+
+&flexio0 {
+	status = "okay";
+
+	flexio0_pwm: flexio0_pwm {
+		pinctrl-0 = <&flexio0_pwm_default>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		pwm_0 {
+			pin-id = <19>;
+			prescaler = <1>;
+		};
+
+		pwm_1 {
+			pin-id = <11>;
+			prescaler = <1>;
+		};
+	};
+};
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_common.dtsi
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_common.dtsi
@@ -33,7 +33,7 @@
 		led2 = &user_led1_blue;
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
-		watchdog0 = &swt0;
+		watchdog0 = &fs26_wdt;
 		/* For pwm test suites */
 		pwm-0 = &emios0_pwm;
 		pwm-1 = &flexio0_pwm;

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_defconfig
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_defconfig
@@ -1,0 +1,20 @@
+# Copyright 2023-2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BUILD_OUTPUT_HEX=y
+
+# Run from internal Flash
+CONFIG_XIP=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Use no-cached memory for HAL
+CONFIG_NOCACHE_MEMORY=y
+
+# Drivers
+CONFIG_SERIAL=y
+CONFIG_WATCHDOG=y
+
+# Serial console
+CONFIG_CONSOLE=y

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.dts
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.dts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "frdm_a_s32k344_common.dtsi"
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+		zephyr,flash = &flash0;
+	};
+};
+
+&c40fc {
+	status = "okay";
+};
+
+&flash0 {
+	status = "okay";
+
+	/* Replace any board-default partitions with the MCUboot layout */
+	/delete-node/ partitions;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ivt_header: partition@0 {
+			label = "ivt-header";
+			reg = <0x00000000 256>;
+		};
+
+		/* pad up to the 8 KiB sector boundary at 0x2000 */
+		ivt_pad: partition@100 {
+			label = "ivt_pad";
+			reg = <0x00000100 (DT_SIZE_K(8) - 256)>;
+		};
+
+		/* MCUboot @ 0x2000 (128 KiB here; adjust if you use 64 KiB) */
+		boot_partition: partition@2000 {
+			label = "mcuboot";
+			reg = <0x00002000 DT_SIZE_K(128)>;
+		};
+
+		/* Primary image (slot 0) */
+		slot0_partition: partition@22000 {
+			label = "image-0";
+			reg = <0x00022000 DT_SIZE_K(1920)>;
+		};
+
+		/* Secondary image (slot 1) — start right after slot0 ends */
+		slot1_partition: partition@202000 {
+			label = "image-1";
+			reg = <0x00202000 DT_SIZE_K(1920)>;
+		};
+	};
+};

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.dts
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.dts
@@ -25,35 +25,40 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		ivt_header: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "ivt-header";
 			reg = <0x00000000 256>;
 		};
 
 		/* pad up to the 8 KiB sector boundary at 0x2000 */
 		ivt_pad: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "ivt_pad";
 			reg = <0x00000100 (DT_SIZE_K(8) - 256)>;
 		};
 
 		/* MCUboot @ 0x2000 (128 KiB here; adjust if you use 64 KiB) */
 		boot_partition: partition@2000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00002000 DT_SIZE_K(128)>;
 		};
 
 		/* Primary image (slot 0) */
 		slot0_partition: partition@22000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00022000 DT_SIZE_K(1920)>;
 		};
 
 		/* Secondary image (slot 1) — start right after slot0 ends */
 		slot1_partition: partition@202000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00202000 DT_SIZE_K(1920)>;
 		};

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.yaml
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.yaml
@@ -1,0 +1,27 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: frdm_a_s32k344/s32k344/mcuboot
+name: NXP FRDM-A-S32K344 (S32K344, MCUboot)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+ram: 320
+flash: 1919
+sysbuild: true
+supported:
+  - adc
+  - can
+  - counter
+  - display
+  - dma
+  - flash
+  - gpio
+  - i2c
+  - netif:eth
+  - pwm
+  - spi
+  - uart
+  - watchdog
+vendor: nxp

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.yaml
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot.yaml
@@ -14,7 +14,6 @@ supported:
   - adc
   - can
   - counter
-  - display
   - dma
   - flash
   - gpio

--- a/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot_defconfig
+++ b/boards/nxp/frdm_a_s32k344/frdm_a_s32k344_s32k344_mcuboot_defconfig
@@ -1,0 +1,17 @@
+# Copyright 2023-2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BUILD_OUTPUT_HEX=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Use no-cached memory for HAL
+CONFIG_NOCACHE_MEMORY=y
+
+# Drivers
+CONFIG_SERIAL=y
+CONFIG_WATCHDOG=y
+
+# Serial console
+CONFIG_CONSOLE=y

--- a/boards/nxp/frdm_a_s32k344/support/debug.cmm
+++ b/boards/nxp/frdm_a_s32k344/support/debug.cmm
@@ -1,0 +1,13 @@
+;*******************************************************************************
+;   Copyright 2023 NXP                                                         *
+;   SPDX-License-Identifier: Apache-2.0                                        *
+;                                                                              *
+;   Lauterbach TRACE32 start-up script for debugging frdm_a_s32k344           *
+;                                                                              *
+;*******************************************************************************
+
+ENTRY %LINE &args
+
+DO ~~~~/startup.cmm command=debug &args
+
+ENDDO

--- a/boards/nxp/frdm_a_s32k344/support/flash.cmm
+++ b/boards/nxp/frdm_a_s32k344/support/flash.cmm
@@ -1,0 +1,13 @@
+;*******************************************************************************
+;   Copyright 2023 NXP                                                         *
+;   SPDX-License-Identifier: Apache-2.0                                        *
+;                                                                              *
+;   Lauterbach TRACE32 start-up script for flashing frdm_a_s32k344            *
+;                                                                              *
+;*******************************************************************************
+
+ENTRY %LINE &args
+
+DO ~~~~/startup.cmm command=flash &args
+
+ENDDO

--- a/boards/nxp/frdm_a_s32k344/support/startup.cmm
+++ b/boards/nxp/frdm_a_s32k344/support/startup.cmm
@@ -1,0 +1,128 @@
+;*******************************************************************************
+;   Copyright 2023 NXP                                                         *
+;                                                                              *
+;   Lauterbach Trace32 start-up script for S32K344 / Cortex-M7                 *
+;                                                                              *
+;   Parameters:                                                                *
+;   - command     operation to execute                                         *
+;                 valid values: flash, debug                                   *
+;   - elfFile     filepath of ELF to load                                      *
+;   - loadTo      if "flash", the application will be downloaded to SoC        *
+;                 program flash by a flash programming routine; if "sram" it   *
+;                 will be downloaded to SoC SRAM.                              *
+;                 valid values: flash, sram                                    *
+;                 default: flash                                               *
+;   - eraseFlash  if set to "yes", the whole content in Flash device will be   *
+;                 erased before the application is downloaded to either Flash  *
+;                 or SRAM. This routine takes time to execute                  *
+;                 default: "no"                                                *
+;   - verifyFlash if set to "yes", verify after program application to Flash   *
+;                 default: "no"                                                *
+;*******************************************************************************
+
+ENTRY %LINE &args
+
+&command=STRing.SCANAndExtract("&args","command=","")
+&elfFile=STRing.SCANAndExtract("&args","elfFile=","")
+&loadTo=STRing.SCANAndExtract("&args","loadTo=","flash")
+&eraseFlash=STRing.SCANAndExtract("&args","eraseFlash=","no")
+&verifyFlash=STRing.SCANAndExtract("&args","verifyFlash=","no")
+
+IF ("&elfFile"=="")
+(
+  PRINT %ERROR "Missing ELF file path"
+  PLIST
+  STOP
+  ENDDO
+)
+
+; Initialize debugger
+RESet
+SYStem.RESet
+SYStem.CPU S32K344-M7
+SYStem.CONFIG.DEBUGPORTTYPE JTAG
+SYStem.Option.DUALPORT ON
+SYStem.Option.DisMode THUMB
+SYStem.MemAccess DAP
+SYStem.JtagClock 10MHz
+Trace.DISable
+TrOnchip.Set MMERR OFF
+TrOnchip.Set BUSERR OFF
+SYStem.Up
+
+; Init SRAM
+DO ~~/demo/arm/hardware/s32k3/misc/init_sram.cmm
+
+; Only declares flash, does not execute flash programming
+DO ~~/demo/arm/flash/s32k3.cmm PREPAREONLY
+
+; The prepare cmm is protecting flash area for HSE firmware, but
+; since HSE firmware usage feature is not enabled, this region can
+; be used by application core, marked as programmable.
+FLASH.CHANGEtype 0x007D4000--0x7F3FFF TARGET
+
+IF ("&eraseFlash"=="yes")
+(
+  FLASH.Erase ALL
+)
+
+IF ("&loadTo"=="flash")
+(
+  ; Switch target flash to reprogramming state, erase virtual flash programming memory,
+  ; all target non-empty flash sectors are marked as pending, to be reprogrammed.
+  FLASH.ReProgram ALL /Erase
+
+  ; Write contents of the file to virtual Flash programming memory
+  Data.LOAD.Elf &elfFile
+
+  ; Program only changed sectors to target flash and erase obsolete code
+  FLASH.ReProgram off
+
+  IF ("&verifyFlash"=="yes")
+  (
+    Data.LOAD.Elf &elfFile /DIFF
+
+    IF FOUND()
+    (
+      AREA.view
+      PRINT %ERROR "ERROR ! Failed to download the code to flash"
+      Data.LOAD.Elf &elfFile /ComPare
+      ENDDO
+    )
+  )
+
+  ; Reset the processor
+  SYStem.Up
+)
+ELSE
+(
+  ; Init ITCM
+  DO ~~/demo/arm/hardware/s32k3/misc/init_itcm.cmm
+
+  Data.LOAD.Elf &elfFile
+)
+
+IF ("&command"=="flash")
+(
+  ; Execute the application and quit
+  Go
+  QUIT
+)
+ELSE IF ("&command"=="debug")
+(
+  ; Setup minimal debug environment
+  WinCLEAR
+  SETUP.Var.%SpotLight
+  WinPOS 0. 0. 120. 30.
+  List.auto
+  WinPOS 125. 0. 80. 10.
+  Frame.view
+  WinPOS 125. 18.
+  Register.view /SpotLight
+)
+ELSE
+(
+  PRINT %ERROR "Invalid command"
+)
+
+ENDDO


### PR DESCRIPTION
Add initial board support for the NXP FRDM-A-S32K344 development board, based on the NXP S32K344 automotive/industrial MCU (Arm Cortex-M7 Lock-Step, 160 MHz).

Board files were initially copied from the mr_canhubk3 board (same S32K3 SoC family) and then adapted to match the FRDM-A-S32K344 schematic and UM12406 user manual: pin assignments, DMA channel mappings, and unused/leftover configuration were corrected or removed to match this board's wiring.

Supported peripherals:
- Console UART (LPUART6) via on-board OpenSDA (K26 MCU), J11
- Two LIN UARTs: LPUART9 (LIN1) and LPUART5 (LIN2), per UM12406
- User RGB LED (GPIO and PWM variants) and two user buttons
- FlexCAN0 with on-board NXP TJA1043 transceiver (J15)
- LPI2C1 (on-board accelerometer, temperature sensor, USB-PD PHY)
- LPSPI0 with NXP FS26 safety SBC watchdog
- QSPI external NOR flash (Winbond W25Q64JV)
- Ethernet (EMAC/MDIO) to on-board Microchip KSZ8091 PHY
- eMIOS and FlexIO PWM
- MCUboot chain-loading variant (frdm_a_s32k344/s32k344/mcuboot)

Flashing/debugging is supported via J-Link, pyOCD and Lauterbach TRACE32. UART console bring-up has been verified by flashing via the on-board OpenSDA debugger's stock P&E Micro firmware, using NXP S32 Design Studio; J-Link, TRACE32 and pyOCD flashing/debugging remain to be verified on real hardware. See boards/nxp/frdm_a_s32k344/doc/index.rst for details on what has and hasn't been verified on the FRDM-A-S32K344.

Part of #115731