### PR TITLE
kernel:  name the parameters in function declarations

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -337,7 +337,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #endif /* CONFIG_MMU */
 
 #ifdef CONFIG_BOOTARGS
-	extern int main(int, char **);
+	extern int main(int argc, char **argv);
 	extern char **sys_boot_prepare_main_args(int *argc);
 
 	int argc = 0;

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -1265,7 +1265,7 @@ static K_MUTEX_DEFINE(z_mm_paging_lock);
 #endif
 
 static void virt_region_foreach(void *addr, size_t size,
-				void (*func)(void *))
+				void (*func)(void *vaddr))
 {
 	k_mem_assert_virtual_region(addr, size);
 

--- a/kernel/obj_core.c
+++ b/kernel/obj_core.c
@@ -114,7 +114,7 @@ struct k_obj_type *k_obj_type_find(uint32_t type_id)
 }
 
 int k_obj_type_walk_locked(struct k_obj_type *type,
-			   int (*func)(struct k_obj_core *, void *),
+			   int (*func)(struct k_obj_core *obj_core, void *data),
 			   void *data)
 {
 	k_spinlock_key_t  key;
@@ -138,7 +138,7 @@ int k_obj_type_walk_locked(struct k_obj_type *type,
 }
 
 int k_obj_type_walk_unlocked(struct k_obj_type *type,
-			   int (*func)(struct k_obj_core *, void *),
+			   int (*func)(struct k_obj_core *obj_core, void *data),
 			   void *data)
 {
 	struct k_obj_core *obj_core;


### PR DESCRIPTION
- **kernel: obj_core: name the walk callback parameters**
- **kernel: init: name the main() parameters**
- **kernel: mmu: name parameter in virt_region_foreach**
