### PR TITLE
posix: name the parameters in function declarations

### DIFF
--- a/include/zephyr/posix/dirent.h
+++ b/include/zephyr/posix/dirent.h
@@ -31,8 +31,8 @@ int readdir_r(DIR *ZRESTRICT dirp, struct dirent *ZRESTRICT entry,
 #endif
 void rewinddir(DIR *dirp);
 #if (_POSIX_C_SOURCE >= 200809L) || (_XOPEN_SOURCE >= 700)
-int scandir(const char *dir, struct dirent ***namelist, int (*sel)(const struct dirent *),
-	    int (*compar)(const struct dirent **, const struct dirent **));
+int scandir(const char *dir, struct dirent ***namelist, int (*sel)(const struct dirent *entry),
+	    int (*compar)(const struct dirent **a, const struct dirent **b));
 #endif
 #if defined(_XOPEN_SOURCE)
 void seekdir(DIR *dirp, long loc);

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -435,7 +435,7 @@ int pthread_join(pthread_t thread, void **status);
 int pthread_cancel(pthread_t pthread);
 int pthread_detach(pthread_t thread);
 int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
-		   void *(*threadroutine)(void *), void *arg);
+		   void *(*threadroutine)(void *arg), void *arg);
 int pthread_setcancelstate(int state, int *oldstate);
 int pthread_setcanceltype(int type, int *oldtype);
 void pthread_testcancel(void);
@@ -457,7 +457,7 @@ int pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock);
 int pthread_rwlock_unlock(pthread_rwlock_t *rwlock);
 int pthread_rwlock_wrlock(pthread_rwlock_t *rwlock);
 int pthread_key_create(pthread_key_t *key,
-		void (*destructor)(void *));
+		void (*destructor)(void *value));
 int pthread_key_delete(pthread_key_t key);
 int pthread_setspecific(pthread_key_t key, const void *value);
 void *pthread_getspecific(pthread_key_t key);

--- a/subsys/portability/posix/options/key.c
+++ b/subsys/portability/posix/options/key.c
@@ -98,7 +98,7 @@ static pthread_key_obj *to_posix_key(pthread_key_t *key)
  * See IEEE 1003.1
  */
 int pthread_key_create(pthread_key_t *key,
-		void (*destructor)(void *))
+		void (*destructor)(void *value))
 {
 	pthread_key_obj *new_key;
 

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -585,7 +585,7 @@ static void posix_thread_recycle(void)
  *
  * See IEEE 1003.1
  */
-int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadroutine)(void *),
+int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadroutine)(void *arg),
 		   void *arg)
 {
 	int err;


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
scandir(), pthread_create() and pthread_key_create() declared their
callback parameters with bare types, in both the headers and the
implementation.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
