### PR TITLE
drivers: console: drop the duplicated console hook prototypes

### DIFF
--- a/drivers/console/wch_sdi_console.c
+++ b/drivers/console/wch_sdi_console.c
@@ -10,6 +10,8 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/sys/winstream.h>
 
 #define TX_TIMEOUT   1000000
@@ -39,14 +41,6 @@ struct wch_sdi_console_data {
 };
 
 static struct wch_sdi_console_data wch_sdi_console_data_0;
-
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
-#endif
-
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
-#endif
 
 static int wch_sdi_console_putc(int ch)
 {

--- a/drivers/console/whisper_console.c
+++ b/drivers/console/whisper_console.c
@@ -8,6 +8,8 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/sys/printk-hooks.h>
 
 #define CONSOLE_OUT_ADDR (DT_REG_ADDR(DT_CHOSEN(zephyr_console)))
 
@@ -21,17 +23,13 @@ int arch_printk_char_out(int c)
 	return 0;
 }
 
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
-#else
+#if !defined(CONFIG_STDOUT_CONSOLE)
 #define __stdout_hook_install(x)                                                                   \
 	do { /* nothing */                                                                         \
 	} while ((0))
 #endif
 
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
-#else
+#if !defined(CONFIG_PRINTK)
 #define __printk_hook_install(x)                                                                   \
 	do { /* nothing */                                                                         \
 	} while ((0))


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The WCH SDI and Whisper console drivers re-declared the stdout and
printk hook install functions locally instead of including the headers
that already declare them, and both copies left the hook parameter
unnamed. Include <zephyr/sys/libc-hooks.h> and
<zephyr/sys/printk-hooks.h> instead. The Whisper console keeps its no-op
fallbacks for the configurations where the hooks are not built in.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
