### PR TITLE
bluetooth: name the parameters in function declarations

### DIFF
--- a/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
@@ -76,8 +76,12 @@ static const cy_stc_ble_config_t psoc6_bless_config = {
 	.hw = &psoc6_bless_hw_config,
 };
 
-static void psoc6_bless_rx_thread(void *, void *, void *)
+static void psoc6_bless_rx_thread(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	while (true) {
 		k_sem_take(&psoc6_bless_rx_sem, K_MSEC(BLE_THREAD_SEM_TMOUT_MS));
 		Cy_BLE_ProcessEvents();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -1415,7 +1415,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	return -EINVAL;
 }
 
-static void isr_tx(struct lll_scan_aux *lll_aux, void (*isr)(void *), void *param)
+static void isr_tx(struct lll_scan_aux *lll_aux, void (*isr)(void *arg), void *param)
 {
 	struct node_rx_pdu *node_rx_prof;
 	struct node_rx_pdu *node_rx;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -491,7 +491,7 @@ static uint32_t calculate_tifs(uint8_t len)
 }
 
 static uint8_t init(uint8_t chan, uint8_t phy, int8_t tx_power,
-		    bool cte, void (*isr)(void *))
+		    bool cte, void (*isr)(void *param))
 {
 	int err;
 	uint8_t ret;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
@@ -157,7 +157,7 @@ static void isr_rx(void *param)
 	}
 }
 
-static uint8_t init(uint8_t chan, uint8_t phy, void (*isr)(void *))
+static uint8_t init(uint8_t chan, uint8_t phy, void (*isr)(void *param))
 {
 	int err;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -587,7 +587,7 @@ void llcp_lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx);
  */
 void llcp_rr_set_incompat(struct ll_conn *conn, enum proc_incompat incompat);
 bool llcp_rr_get_collision(struct ll_conn *conn);
-void llcp_rr_set_paused_cmd(struct ll_conn *conn, enum llcp_proc);
+void llcp_rr_set_paused_cmd(struct ll_conn *conn, enum llcp_proc proc);
 enum llcp_proc llcp_rr_get_paused_cmd(struct ll_conn *conn);
 struct proc_ctx *llcp_rr_peek(struct ll_conn *conn);
 bool llcp_rr_ispaused(struct ll_conn *conn);


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The LLCP remote request helper, the LLL test and scan helpers and the
PSoC 6 BLESS receive thread left parameters unnamed. The BLESS thread
gets ARG_UNUSED() for the arguments it deliberately ignores.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
