### PR TITLE
infineon: name the parameters in function declarations

### DIFF
--- a/drivers/interrupt_controller/intc_xmc4xxx.c
+++ b/drivers/interrupt_controller/intc_xmc4xxx.c
@@ -54,7 +54,8 @@ static const uint16_t port_line_mapping[DT_INST_PROP_LEN(0, port_line_mapping)] 
 
 int intc_xmc4xxx_gpio_enable_interrupt(int port_id, int pin, enum gpio_int_mode mode,
 				       enum gpio_int_trig trig,
-				       void (*fn)(const struct device *, int), void *user_data)
+				       void (*fn)(const struct device *dev, int pin),
+				       void *user_data)
 {
 	const struct device *dev = DEVICE_DT_INST_GET(0);
 	struct intc_xmc4xxx_data *data = dev->data;

--- a/include/zephyr/drivers/interrupt_controller/intc_xmc4xxx.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_xmc4xxx.h
@@ -26,7 +26,8 @@
  */
 
 int intc_xmc4xxx_gpio_enable_interrupt(int port_id, int pin, enum gpio_int_mode mode,
-		enum gpio_int_trig trig, void(*fn)(const struct device*, int), void *user_data);
+		enum gpio_int_trig trig, void (*fn)(const struct device *dev, int pin),
+		void *user_data);
 
 /**
  * @brief Disable interrupt for specific port_id and pin combination

--- a/soc/infineon/cat1c/xmc7200/soc.h
+++ b/soc/infineon/cat1c/xmc7200/soc.h
@@ -26,7 +26,7 @@
 		       (void (*)(const void *))(void *)isr_handler,            \
 		       DEVICE_DT_INST_GET(n));
 
-void enable_sys_int(uint32_t int_num, uint32_t priority, void(*isr)(const void *),
+void enable_sys_int(uint32_t int_num, uint32_t priority, void (*isr)(const void *param),
 		    const void *arg);
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/infineon/cat1c/xmc7200/soc_m0p.c
+++ b/soc/infineon/cat1c/xmc7200/soc_m0p.c
@@ -23,7 +23,8 @@ void soc_prep_hook(void)
 	SystemCoreClockUpdate();
 }
 
-void enable_sys_int(uint32_t int_num, uint32_t priority, void (*isr)(const void *), const void *arg)
+void enable_sys_int(uint32_t int_num, uint32_t priority, void (*isr)(const void *param),
+		    const void *arg)
 {
 	/* Interrupts are not supported on cm0p */
 	k_fatal_halt(K_ERR_CPU_EXCEPTION);

--- a/soc/infineon/cat1c/xmc7200/soc_m7.c
+++ b/soc/infineon/cat1c/xmc7200/soc_m7.c
@@ -17,7 +17,8 @@
 
 __attribute__((section(".dtcm_bss"))) struct _isr_table_entry sys_int_table[CPUSS_SYSTEM_INT_NR];
 
-void enable_sys_int(uint32_t int_num, uint32_t priority, void (*isr)(const void *), const void *arg)
+void enable_sys_int(uint32_t int_num, uint32_t priority, void (*isr)(const void *param),
+		    const void *arg)
 {
 	/* IRQ_PRIO_LOWEST = 6 */
 	if (priority <= IRQ_PRIO_LOWEST) {


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The XMC4xxx GPIO interrupt helper and the XMC7200 system interrupt
helper declared their callback parameters with bare types.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
