### PR TITLE
wifi: name the parameters in function declarations

### DIFF
--- a/drivers/wifi/bflb/wifi6/bflb_wifi_net.c
+++ b/drivers/wifi/bflb/wifi6/bflb_wifi_net.c
@@ -637,7 +637,7 @@ void wl80211_tcpip_input(uint8_t vif_type, void *rxhdr, void *buf, uint32_t frm_
 
 /* TX for control frames (EAPOL). Bypasses sem/backpressure -- uses nolimit WRAM alloc. */
 int wl80211_output_raw(uint8_t vif_type, void *buffer, uint16_t len, unsigned int flags,
-		       void (*cb)(void *), void *opaque)
+		       void (*cb)(void *opaque), void *opaque)
 {
 	const size_t hdr_size = sizeof(struct wl80211_mac_tx_desc);
 	const size_t total = TX_CTX_PAD + hdr_size + len;

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -22,7 +22,7 @@ static esp_hosted_config_t esp_hosted_config = {
 
 static esp_hosted_data_t esp_hosted_data = {0};
 
-static int esp_hosted_recv(struct net_if *, void *, size_t);
+static int esp_hosted_recv(struct net_if *iface, void *buf, size_t len);
 
 static size_t esp_hosted_get_iface(const struct device *dev)
 {

--- a/modules/hostap/src/supp_events.h
+++ b/modules/hostap/src/supp_events.h
@@ -71,7 +71,7 @@ int supplicant_send_wifi_mgmt_disc_event(void *ctx, int reason_code);
 #ifdef CONFIG_AP
 int supplicant_send_wifi_mgmt_ap_status(void *ctx,
 					enum net_event_wifi_cmd event,
-					enum wifi_ap_status);
+					enum wifi_ap_status ap_status);
 int supplicant_send_wifi_mgmt_ap_sta_event(void *ctx,
 					   enum net_event_wifi_cmd event,
 					   void *data);

--- a/modules/nrf_wifi/os/shim.c
+++ b/modules/nrf_wifi/os/shim.c
@@ -1081,7 +1081,8 @@ static void *zep_shim_timer_alloc(void)
 	return timer;
 }
 
-static void zep_shim_timer_init(void *timer, void (*callback)(unsigned long), unsigned long data)
+static void zep_shim_timer_init(void *timer, void (*callback)(unsigned long callbk_data),
+				unsigned long data)
 {
 	((struct timer_list *)timer)->function = callback;
 	((struct timer_list *)timer)->data = data;

--- a/modules/nrf_wifi/os/work.c
+++ b/modules/nrf_wifi/os/work.c
@@ -120,8 +120,8 @@ static int workqueue_init(void)
 	return 0;
 }
 
-void work_init(struct zep_work_item *item, void (*callback)(unsigned long),
-		  unsigned long data)
+void work_init(struct zep_work_item *item, void (*callback)(unsigned long callbk_data),
+	       unsigned long data)
 {
 	item->callback = callback;
 	item->data = data;

--- a/modules/nrf_wifi/os/work.h
+++ b/modules/nrf_wifi/os/work.h
@@ -30,7 +30,7 @@ struct zep_work_item {
 	enum zep_work_type type;
 };
 
-struct zep_work_item *work_alloc(enum zep_work_type);
+struct zep_work_item *work_alloc(enum zep_work_type type);
 
 void work_init(struct zep_work_item *work, void (*callback)(unsigned long callbk_data),
 		  unsigned long data);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -5006,8 +5006,8 @@ static int parse_nan_args_transmit(const struct shell *sh, size_t argc, char *ar
 /* Common NAN command dispatcher */
 static int cmd_wifi_nan_exec(const struct shell *sh, size_t argc, char *argv[],
 			     struct wifi_nan_params *params,
-			     int (*parse_fn)(const struct shell *, size_t, char **,
-					     struct wifi_nan_params *),
+			     int (*parse_fn)(const struct shell *sh, size_t argc, char **argv,
+					     struct wifi_nan_params *params),
 			     const char *parse_err_msg,
 			     const char *exec_err_msg,
 			     const char *success_msg,


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The Wi-Fi NAN shell dispatcher, the esp_hosted and Bouffalo Lab drivers
and the hostap and nrf_wifi glue declared callbacks with bare types.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
