### PR TITLE
usb: name the parameters in function declarations

### DIFF
--- a/include/zephyr/usb/usb_device.h
+++ b/include/zephyr/usb/usb_device.h
@@ -385,7 +385,7 @@ typedef void (*usb_transfer_callback)(uint8_t ep, int tsize, void *priv);
  * If a USB class driver wants to use high-level transfer functions, driver
  * needs to register this callback as usb endpoint callback.
  */
-__deprecated void usb_transfer_ep_callback(uint8_t ep, enum usb_dc_ep_cb_status_code);
+__deprecated void usb_transfer_ep_callback(uint8_t ep, enum usb_dc_ep_cb_status_code status);
 
 /**
  * @brief Start a transfer

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -1211,7 +1211,7 @@ static void usb_register_status_callback(usb_dc_status_callback cb)
 	usb_dev.status_callback = cb;
 }
 
-static int foreach_ep(int (* endpoint_callback)(const struct usb_ep_cfg_data *))
+static int foreach_ep(int (*endpoint_callback)(const struct usb_ep_cfg_data *ep_data))
 {
 	struct usb_ep_cfg_data *ep_data;
 


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
usb_transfer_ep_callback() and the endpoint iteration helper declared
their parameters with bare types.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
