### PR TITLE
drivers: wifi: nxp: Enable RF test mode for IW416 and IW61X

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1098,7 +1098,7 @@ config NXP_WIFI_TX_RX_HISTOGRAM
 
 config NXP_WIFI_RF_TEST_MODE
 	bool "WLAN RF Test Mode"
-	default y if NXP_RW610 || NXP_IW610
+	default y if NXP_RW610 || NXP_IW610 || NXP_IW61X || NXP_IW416
 	help
 	  This option enables WLAN test mode commands.
 


### PR DESCRIPTION
Enable NXP_WIFI_RF_TEST_MODE by default for IW416 and IW61X.