### PR TITLE
Bluetooth: Host: Schedule conn deferred_work on the Bluetooth workqueue

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2109,8 +2109,8 @@ static void le_conn_update_complete(struct net_buf *buf)
 			   evt->status == BT_HCI_ERR_UNSUPP_LL_PARAM_VAL &&
 			   conn->le.conn_param_retry_countdown) {
 			conn->le.conn_param_retry_countdown--;
-			k_work_schedule(&conn->deferred_work,
-					K_MSEC(CONFIG_BT_CONN_PARAM_RETRY_TIMEOUT));
+			bt_work_schedule(&conn->deferred_work,
+					 K_MSEC(CONFIG_BT_CONN_PARAM_RETRY_TIMEOUT));
 		} else {
 			if (IS_ENABLED(CONFIG_BT_USER_CONN_PARAM_REJECTED)) {
 				/* A host-initiated (auto) update is only reported as a

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1201,7 +1201,7 @@ void bt_iso_cleanup_acl(struct bt_conn *iso)
 			LOG_DBG("Trigger disconnect work for ACL %p", acl);
 
 			__maybe_unused const int err =
-				k_work_schedule(&acl->deferred_work, K_NO_WAIT);
+				bt_work_schedule(&acl->deferred_work, K_NO_WAIT);
 
 			__ASSERT(err >= 0, "Failed to retrigger conn->deferred_work for %p", acl);
 		}


### PR DESCRIPTION
Commit 22896cb8d6f2 ("Bluetooth: Host: Route LE host work items to the Bluetooth workqueue") moved conn->deferred_work to the dedicated Bluetooth workqueue, but two producers were missed and still schedule it with plain k_work_schedule(), which targets the system workqueue: the peripheral connection parameter update retry path in hci_core.c, and the ISO path that retriggers the deferred work to finalize an ACL disconnection once the last CIS reference is gone.

When either of these fires, the deferred work handler - including disconnected() callback delivery and the connection teardown chain - runs on the system workqueue, contradicting the documented v4.5 context change and breaking the same-queue property that makes the non-blocking cancellations of this work item safe.

Use bt_work_schedule() in both places so that every producer of conn->deferred_work targets the Bluetooth workqueue.

Follow-up to #93033, which performed the deferred_work migration these two call sites escaped.
