### PR TITLE
drivers: serial: ns16550: add 'dlf-auto' for dynamic fractional baud rate

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -45,7 +45,8 @@
 LOG_MODULE_REGISTER(uart_ns16550, CONFIG_UART_LOG_LEVEL);
 
 #define UART_NS16550_PCP_ENABLED DT_ANY_INST_HAS_PROP_STATUS_OKAY(pcp)
-#define UART_NS16550_DLF_ENABLED DT_ANY_INST_HAS_PROP_STATUS_OKAY(dlf)
+#define UART_NS16550_DLF_ENABLED UTIL_OR(DT_ANY_INST_HAS_PROP_STATUS_OKAY(dlf), \
+				DT_ANY_INST_HAS_BOOL_STATUS_OKAY(dlf_auto))
 #define UART_NS16550_DMAS_ENABLED DT_ANY_INST_HAS_PROP_STATUS_OKAY(dmas)
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
@@ -366,6 +367,9 @@ struct uart_ns16550_dev_config {
 #if UART_NS16550_RESET_ENABLED
 	struct reset_dt_spec reset_spec;
 #endif
+#if UART_NS16550_DLF_ENABLED
+	bool dlf_auto;
+#endif
 	bool loopback;
 };
 
@@ -531,6 +535,38 @@ static uint32_t get_uart_baudrate_divisor(const struct device *dev,
 #endif
 }
 
+#if UART_NS16550_DLF_ENABLED
+/*
+ * Calculate the integer divisor and DLF value together to reduce baudrate
+ * error. The DW_apb_uart DLF register provides 1/64-divisor resolution:
+ *
+ *     divisor = DLL/DLH + DLF / 64
+ */
+#define DLF_RESOLUTION 64U
+
+static uint32_t get_uart_baudrate_divisor_dlf(uint32_t baud_rate, uint32_t pclk,
+					      uint8_t *dlf_out)
+{
+	/* Fixed-point target divisor, scaled by DLF_RESOLUTION. */
+	uint64_t scaled = ((uint64_t)pclk * DLF_RESOLUTION + (baud_rate << 3)) /
+			   (baud_rate << 4);
+	uint32_t divisor = (uint32_t)(scaled / DLF_RESOLUTION);
+	uint32_t dlf = (uint32_t)(scaled % DLF_RESOLUTION);
+
+	if (divisor == 0U) {
+		/*
+		 * The requested baud rate requires a divisor below 1. Clamp it to 1
+		 * to avoid writing 0 to DLL/DLH, which disables the baud-rate generator.
+		 */
+		divisor = 1U;
+		dlf = 0U;
+	}
+
+	*dlf_out = (uint8_t)dlf;
+	return divisor;
+}
+#endif /* UART_NS16550_DLF_ENABLED */
+
 #ifdef CONFIG_UART_NS16550_ITE_HIGH_SPEED_BAUDRATE
 static uint32_t get_ite_uart_baudrate_divisor(const struct device *dev,
 					      uint32_t baud_rate,
@@ -588,6 +624,15 @@ static void set_baud_rate(const struct device *dev, uint32_t baud_rate, uint32_t
 #else
 		divisor = get_uart_baudrate_divisor(dev, baud_rate, pclk);
 #endif
+
+#if UART_NS16550_DLF_ENABLED
+		if (dev_cfg->dlf_auto) {
+			divisor = get_uart_baudrate_divisor_dlf(baud_rate, pclk,
+								&dev_data->dlf);
+			ns16550_outbyte(dev_cfg, DLF(dev), dev_data->dlf);
+		}
+#endif
+
 		/* set the DLAB to access the baud rate divisor registers */
 		lcr_cache = ns16550_inbyte(dev_cfg, LCR(dev));
 		ns16550_outbyte(dev_cfg, LCR(dev), LCR_DLAB | lcr_cache);
@@ -2096,6 +2141,8 @@ static DEVICE_API(uart, uart_ns16550_driver_api) = {
 			(.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),))              \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, resets),                         \
 			(.reset_spec = RESET_DT_SPEC_INST_GET(n),))                  \
+		IF_ENABLED(UART_NS16550_DLF_ENABLED,                                 \
+			(.dlf_auto = DT_INST_PROP(n, dlf_auto),))                    \
 		.loopback = DT_INST_PROP(n, loopback),
 
 #define UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                                  \

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -18,6 +18,23 @@ properties:
     type: int
     description: divisor latch fraction (DLF, if supported)
 
+  dlf-auto:
+    type: boolean
+    description: |
+      Automatically compute the fractional divisor (DLF) alongside the
+      integer baud rate divisor (DLL/DLH), instead of pairing a static 'dlf'
+      value with a plain integer divisor.
+
+      This reduces baud rate error compared to an integer-only divisor,
+      particularly when clock-frequency is relatively low (e.g., tens of MHz)
+      relative to the target baud rate. Only applicable to DW_apb_uart-compatible
+      implementations where the DLF register has a 1/64 resolution; do not set
+      this for other 'dlf'-capable hardware with a different fractional scale.
+
+      When set, this takes precedence over a static 'dlf' property: the 'dlf'
+      property is ignored, and the fractional divisor is recomputed dynamically
+      on every baud rate change.
+
   io-mapped:
     type: boolean
     description: specify registers are IO mapped or memory mapped


### PR DESCRIPTION
The driver currently computes the integer baud rate divisor (DLL/DLH) purely from clock-frequency and current-speed via integer division in get_uart_baudrate_divisor(), and treats the optional 'dlf' property as an independent, statically configured register write that never factors into the baud rate calculation.

For DW_apb_uart-compatible UARTs with a fixed, relatively low pclk (tens of MHz) compared to the desired baud rate, the plain integer divisor introduces a significant rounding error. For example, at pclk = 25 MHz targeting 115200 baud, the integer-only divisor rounds to 14, giving an effective baud rate of 111607 (-3.12% error), whereas the divisor/DLF pair 13/36 (divisor 13 + 36/64) gives an effective baud rate of 115207 (+0.006% error).

Add an opt-in 'dlf-auto' boolean devicetree property. When set, the driver computes the integer divisor and the DLF fractional value together using 1/64-resolution fixed-point math (the resolution documented for DW_apb_uart's DLF register), instead of using the integer-only divisor with a hardcoded 'dlf' value.

This is purely additive: when 'dlf-auto' is not set, the behavior for existing 'dlf' users (e.g., boards/syna/sr100) is unchanged.