### PR TITLE
Bluetooth: Host: Run EA reassembly timeout on the Bluetooth workqueue

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -89,6 +89,10 @@ struct fragmented_advertiser {
 
 static struct fragmented_advertiser reassembling_advertiser;
 
+/* The timeout handler runs on the Bluetooth workqueue and is thereby
+ * serialized with the extended advertising report processing, which also
+ * accesses reassembling_advertiser without locking.
+ */
 static void reassembly_timeout_work_handler(struct k_work *work)
 {
 	if (reassembling_advertiser.state == FRAG_ADV_REASSEMBLING) {
@@ -105,7 +109,7 @@ K_WORK_DELAYABLE_DEFINE(reassembly_timeout_work, reassembly_timeout_work_handler
 
 static void reassembly_timeout_work_reschedule(void)
 {
-	int err = k_work_reschedule(&reassembly_timeout_work, REASSEMBLY_TIMEOUT);
+	int err = bt_work_reschedule(&reassembly_timeout_work, REASSEMBLY_TIMEOUT);
 
 	if (err < 0) {
 		LOG_ERR("Failed to reschedule reassembly timeout work: %d", err);


### PR DESCRIPTION
The extended advertising reassembly timeout handler mutates the reassembling_advertiser state, which is also read and written by the extended advertising report processing without any locking. The report processing runs on the Bluetooth workqueue, while the timeout handler was scheduled with k_work_reschedule() and so ran on the system workqueue.

This is serialized only implicitly, by cooperative scheduling: it holds because both workqueues run at cooperative priority (the Bluetooth subsystem clamps SYSTEM_WORKQUEUE_PRIORITY to the cooperative range for this reason) and as long as they share a CPU. The latter is not structural: on SMP builds cooperative threads on different CPUs run concurrently, in which case a timeout firing concurrently with report processing can flip the state mid-sequence, e.g. letting a chain that should have been discarded be delivered.

Schedule the timeout on the Bluetooth workqueue instead, making the serialization structural instead of relying on scheduler characteristics. This also makes the non-blocking k_work_cancel_delayable() performed by the report processing reliably effective, as canceller and handler now share a workqueue. The remaining reset callers (HCI reset complete, bt_finalize_init() and scan teardown) run while no advertising reports are being processed.

This is host-internal work with no application callback, so there are no application-visible context changes.

Builds on the Bluetooth workqueue introduced in #93033.

