### PR TITLE
tests: Bluetooth: Audio: Add common stream_started_cb

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -581,15 +581,11 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 
 static void stream_started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 	struct bt_bap_ep_info info;
 	struct bt_conn *ep_conn;
 	int err;
 
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	UNSET_FLAG(test_stream->flag_audio_received);
+	bap_common_stream_started_cb(stream);
 
 	err = bt_bap_ep_get_info(stream->ep, &info);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -180,13 +180,11 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 
 static void stream_started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 	struct bt_bap_ep_info info;
 	struct bt_conn *ep_conn;
 	int err;
 
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
+	bap_common_stream_started_cb(stream);
 
 	err = bt_bap_ep_get_info(stream->ep, &info);
 	if (err != 0) {
@@ -222,12 +220,6 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 	ep_conn = bt_bap_ep_get_conn(stream->ep);
 	if (ep_conn != NULL) {
 		FAIL("Invalid conn from endpoint: %p", ep_conn);
-		return;
-	}
-
-	err = bap_stream_tx_register(stream);
-	if (err != 0) {
-		FAIL("Failed to register stream %p for TX: %d\n", stream, err);
 		return;
 	}
 
@@ -318,12 +310,6 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source, bool 
 	if (err != 0) {
 		LOG_ERR("Unable to create broadcast source: %d", err);
 		return err;
-	}
-
-	for (size_t i = 0U; i < stream_cnt; i++) {
-		struct audio_test_stream *test_stream = &broadcast_source_streams[i];
-
-		test_stream->tx_sdu_size = preset_16_1_1.qos.sdu;
 	}
 
 	return 0;
@@ -426,12 +412,6 @@ static void test_broadcast_source_reconfig(struct bt_bap_broadcast_source *sourc
 	if (err != 0) {
 		FAIL("Unable to reconfigure broadcast source: %d\n", err);
 		return;
-	}
-
-	for (size_t i = 0U; i < stream_cnt; i++) {
-		struct audio_test_stream *test_stream = &broadcast_source_streams[i];
-
-		test_stream->tx_sdu_size = preset_16_1_1.qos.sdu;
 	}
 
 	/* Update the BASE */

--- a/tests/bsim/bluetooth/audio/src/bap_common.c
+++ b/tests/bsim/bluetooth/audio/src/bap_common.c
@@ -20,6 +20,7 @@
 #include <zephyr/logging/log.h>
 
 #include "bap_common.h"
+#include "bap_stream_tx.h"
 #include "common.h"
 
 LOG_MODULE_REGISTER(bap_common);
@@ -172,4 +173,29 @@ void bap_unicast_stream_disconnected_cb(struct bt_bap_stream *stream, uint8_t re
 	LOG_INF("Disconnected stream %p with reason %u", stream, reason);
 
 	UNSET_FLAG(test_stream->stopping);
+}
+
+void bap_common_stream_started_cb(struct bt_bap_stream *stream)
+{
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
+	test_stream->seq_num = 0U;
+	test_stream->tx_cnt = 0U;
+	(void)memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
+	test_stream->rx_cnt = 0U;
+	test_stream->valid_rx_cnt = 0U;
+	UNSET_FLAG(test_stream->flag_audio_received);
+	test_stream->last_rx_failed = false;
+
+	LOG_INF("Stream %p started", stream);
+
+	if (bap_stream_tx_can_send(stream)) {
+		int err;
+
+		err = bap_stream_tx_register(stream);
+		if (err != 0) {
+			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
+			return;
+		}
+	}
 }

--- a/tests/bsim/bluetooth/audio/src/bap_common.h
+++ b/tests/bsim/bluetooth/audio/src/bap_common.h
@@ -121,4 +121,5 @@ bool bap_stream_is_streaming(const struct bt_bap_stream *bap_stream);
 bool cap_stream_is_streaming(const struct bt_cap_stream *cap_stream);
 bool audio_test_stream_is_streaming(const struct audio_test_stream *test_stream);
 void bap_unicast_stream_disconnected_cb(struct bt_bap_stream *stream, uint8_t reason);
+void bap_common_stream_started_cb(struct bt_bap_stream *stream);
 #endif /* ZEPHYR_TEST_BSIM_BT_AUDIO_TEST_COMMON_ */

--- a/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
@@ -43,13 +43,12 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 			   struct net_buf *buf)
 {
 	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-	static bool last_failed;
 
 	test_stream->rx_cnt++;
 	if ((info->flags & BT_ISO_FLAGS_VALID) != 0) {
 		if (memcmp(buf->data, mock_iso_data, buf->len) == 0) {
 			test_stream->valid_rx_cnt++;
-			last_failed = false;
+			test_stream->last_rx_failed = false;
 
 			if (test_stream->valid_rx_cnt >= MIN_SEND_COUNT) {
 				SET_FLAG(test_stream->flag_audio_received);

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -105,11 +105,7 @@ static void stream_codec_configured(struct bt_bap_stream *stream,
 
 static void stream_qos_configured(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
 	LOG_INF("QoS set stream %p", stream);
-
-	test_stream->tx_sdu_size = stream->qos->sdu;
 
 	atomic_inc(&flag_stream_qos_configured);
 }
@@ -123,17 +119,7 @@ static void stream_enabled(struct bt_bap_stream *stream)
 
 static void stream_started(struct bt_bap_stream *stream)
 {
-	LOG_INF("Started stream %p", stream);
-
-	if (bap_stream_tx_can_send(stream)) {
-		int err;
-
-		err = bap_stream_tx_register(stream);
-		if (err != 0) {
-			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-			return;
-		}
-	}
+	bap_common_stream_started_cb(stream);
 
 	SET_FLAG(flag_stream_started);
 }

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -156,15 +156,11 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
 	ARG_UNUSED(rsp);
 
 	LOG_INF("QoS: stream %p qos %p", stream, qos);
 
 	print_qos(qos);
-
-	test_stream->tx_sdu_size = qos->sdu;
 
 	return 0;
 }
@@ -309,17 +305,7 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 
 static void stream_started_cb(struct bt_bap_stream *stream)
 {
-	LOG_INF("Started: stream %p", stream);
-
-	if (bap_stream_tx_can_send(stream)) {
-		int err;
-
-		err = bap_stream_tx_register(stream);
-		if (err != 0) {
-			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-			return;
-		}
-	}
+	bap_common_stream_started_cb(stream);
 
 	SET_FLAG(flag_stream_started);
 }

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -454,27 +454,13 @@ static struct bt_le_per_adv_sync_cb bap_pa_sync_cb = {
 	.term = bap_pa_sync_terminated_cb,
 };
 
-static void started_cb(struct bt_bap_stream *stream)
-{
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-	UNSET_FLAG(test_stream->flag_audio_received);
-
-	LOG_INF("Stream %p started", stream);
-}
-
 static void stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
 	LOG_INF("Stream %p stopped with reason 0x%02X", stream, reason);
 }
 
 static struct bt_bap_stream_ops broadcast_stream_ops = {
-	.started = started_cb,
+	.started = bap_common_stream_started_cb,
 	.stopped = stopped_cb,
 	.recv = bap_stream_rx_recv_cb,
 };
@@ -506,26 +492,9 @@ static void unicast_stream_enabled_cb(struct bt_bap_stream *stream)
 
 static void unicast_stream_started(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+	bap_common_stream_started_cb(stream);
 
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-	UNSET_FLAG(test_stream->flag_audio_received);
-
-	LOG_INF("Started stream %p", stream);
-
-	if (bap_stream_tx_can_send(stream)) {
-		int err;
-
-		err = bap_stream_tx_register(stream);
-		if (err != 0) {
-			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-			return;
-		}
-	} else if (bap_stream_rx_can_recv(stream)) {
+	if (bap_stream_rx_can_recv(stream)) {
 		expect_rx = true;
 	}
 }

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -382,29 +382,6 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 	}
 }
 
-static void stream_started_cb(struct bt_bap_stream *stream)
-{
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-
-	LOG_DBG("Started stream %p", stream);
-
-	if (bap_stream_tx_can_send(stream)) {
-		int err;
-
-		err = bap_stream_tx_register(stream);
-		if (err != 0) {
-			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-			return;
-		}
-	}
-}
-
 static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
 	LOG_DBG("Stopped stream %p with reason 0x%02X", stream, reason);
@@ -460,7 +437,7 @@ static void init(void)
 		.endpoint = endpoint_cb,
 	};
 	static struct bt_bap_stream_ops stream_ops = {
-		.started = stream_started_cb,
+		.started = bap_common_stream_started_cb,
 		.stopped = stream_stopped_cb,
 		.sent = bap_stream_tx_sent_cb,
 	};

--- a/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
@@ -243,15 +243,7 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 
 static void stream_started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-
-	LOG_DBG("Started stream %p", stream);
+	bap_common_stream_started_cb(stream);
 
 	SET_FLAG(flag_stream_started);
 }

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -101,19 +101,7 @@ static const struct named_lc3_preset lc3_broadcast_presets[] = {
 
 static void broadcast_stream_started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-	int err;
-
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-
-	LOG_INF("Stream %p started", stream);
-
-	err = bap_stream_tx_register(stream);
-	if (err != 0) {
-		FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-		return;
-	}
+	bap_common_stream_started_cb(stream);
 
 	k_sem_give(&sem_broadcast_stream_started);
 }
@@ -402,12 +390,6 @@ static void test_broadcast_audio_create(struct bt_cap_broadcast_source **broadca
 	if (err != 0) {
 		FAIL("Unable to start broadcast source: %d\n", err);
 		return;
-	}
-
-	for (size_t i = 0U; i < ARRAY_SIZE(broadcast_source_streams); i++) {
-		struct audio_test_stream *test_stream = &broadcast_source_streams[i];
-
-		test_stream->tx_sdu_size = create_param.qos->sdu;
 	}
 
 	LOG_INF("Broadcast source created with %zu broadcast_streams",
@@ -832,11 +814,6 @@ static int test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	}
 
 	stream_count = param->stream_cnt;
-	for (size_t i = 0U; i < stream_count; i++) {
-		struct audio_test_stream *test_stream = &broadcast_source_streams[i];
-
-		test_stream->tx_sdu_size = create_param.qos->sdu;
-	}
 
 	test_broadcast_audio_start(broadcast_source, adv);
 	setup_extended_adv_data(broadcast_source, adv);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -172,30 +172,6 @@ static void unicast_stream_enabled(struct bt_bap_stream *stream)
 	LOG_INF("Enabled stream %p", stream);
 }
 
-static void unicast_stream_started(struct bt_bap_stream *stream)
-{
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-	UNSET_FLAG(test_stream->flag_audio_received);
-
-	LOG_INF("Started stream %p", stream);
-
-	if (bap_stream_tx_can_send(stream)) {
-		int err;
-
-		err = bap_stream_tx_register(stream);
-		if (err != 0) {
-			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-			return;
-		}
-	}
-}
-
 static void unicast_stream_metadata_updated(struct bt_bap_stream *stream)
 {
 	LOG_INF("Metadata updated stream %p", stream);
@@ -242,7 +218,7 @@ static struct bt_bap_stream_ops unicast_stream_ops = {
 	.codec_configured = unicast_stream_codec_configured,
 	.qos_configured = unicast_stream_qos_configured,
 	.enabled = unicast_stream_enabled,
-	.started = unicast_stream_started,
+	.started = bap_common_stream_started_cb,
 	.metadata_updated = unicast_stream_metadata_updated,
 	.disabled = unicast_stream_disabled,
 	.stopped = unicast_stream_stopped,

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -137,10 +137,11 @@ void backchannel_sync_clear_all(void);
 struct audio_test_stream {
 	struct bt_cap_stream stream;
 
+	/* TX */
 	uint16_t seq_num;
 	size_t tx_cnt;
-	uint16_t tx_sdu_size;
 
+	/* RX */
 	struct bt_iso_recv_info last_info;
 	size_t rx_cnt;
 	size_t valid_rx_cnt;

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -187,26 +187,7 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 
 static void stream_started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-	UNSET_FLAG(test_stream->flag_audio_received);
-
-	LOG_INF("Started stream %p", stream);
-
-	if (bap_stream_tx_can_send(stream)) {
-		int err;
-
-		err = bap_stream_tx_register(stream);
-		if (err != 0) {
-			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-			return;
-		}
-	}
+	bap_common_stream_started_cb(stream);
 
 	k_sem_give(&sem_stream_started);
 }
@@ -1258,12 +1239,6 @@ static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *para
 	if (err != 0) {
 		FAIL("Failed to create broadcast source: %d\n", err);
 		return -ENOEXEC;
-	}
-
-	for (size_t i = 0U; i < param->stream_cnt; i++) {
-		struct audio_test_stream *test_stream = &broadcast_streams[i];
-
-		test_stream->tx_sdu_size = create_param.qos->sdu;
 	}
 
 	broadcast_audio_start(broadcast_source, adv);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -89,26 +89,9 @@ static void unicast_stream_enabled_cb(struct bt_bap_stream *stream)
 
 static void unicast_stream_started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+	bap_common_stream_started_cb(stream);
 
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-	UNSET_FLAG(test_stream->flag_audio_received);
-
-	LOG_INF("Started stream %p", stream);
-
-	if (bap_stream_tx_can_send(stream)) {
-		int err;
-
-		err = bap_stream_tx_register(stream);
-		if (err != 0) {
-			FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-			return;
-		}
-	} else if (bap_stream_rx_can_recv(stream)) {
+	if (bap_stream_rx_can_recv(stream)) {
 		expect_rx = true;
 	}
 

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
@@ -106,14 +106,7 @@ static struct bt_bap_broadcast_sink_cb broadcast_sink_cbs = {
 
 static void started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
-	test_stream->rx_cnt = 0U;
-	test_stream->valid_rx_cnt = 0U;
-	UNSET_FLAG(test_stream->flag_audio_received);
-
-	LOG_INF("Stream %p started", stream);
+	bap_common_stream_started_cb(stream);
 }
 
 static void stopped_cb(struct bt_bap_stream *stream, uint8_t reason)

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -27,6 +27,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
+#include "bap_common.h"
 #include "bap_stream_tx.h"
 #include "bstests.h"
 #include "common.h"
@@ -66,19 +67,7 @@ static struct bt_le_ext_adv *adv;
 
 static void started_cb(struct bt_bap_stream *stream)
 {
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-	int err;
-
-	test_stream->seq_num = 0U;
-	test_stream->tx_cnt = 0U;
-
-	LOG_INF("Stream %p started", stream);
-
-	err = bap_stream_tx_register(stream);
-	if (err != 0) {
-		FAIL("Failed to register stream %p for TX: %d\n", stream, err);
-		return;
-	}
+	bap_common_stream_started_cb(stream);
 
 	k_sem_give(&sem_started);
 }


### PR DESCRIPTION
Many profiles implemented their own nearly identical stream_started_cb. This meant not only duplicated code, but also callbacks that not always did the same expected behavior.

Added a new bap_common_stream_started_cb that can be used directly as a callback, or be called by the profiles own callback if the profile test needs any additional checks.