### PR TITLE
kernel: thread_entry: fix include for TLS stack canaries

### DIFF
--- a/kernel/sys/thread_entry.c
+++ b/kernel/sys/thread_entry.c
@@ -13,13 +13,13 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cfi.h>
-#ifdef CONFIG_CURRENT_THREAD_USE_TLS
-#include <zephyr/random/random.h>
 
+#ifdef CONFIG_CURRENT_THREAD_USE_TLS
 Z_THREAD_LOCAL k_tid_t z_tls_current;
 #endif
 
 #ifdef CONFIG_STACK_CANARIES_TLS
+#include <zephyr/random/random.h>
 extern Z_THREAD_LOCAL volatile uintptr_t __stack_chk_guard;
 #endif /* CONFIG_STACK_CANARIES_TLS */
 
@@ -56,7 +56,7 @@ FUNC_NORETURN void z_thread_entry(k_thread_entry_t entry,
 	sys_rand_get((uint8_t *)&stack_guard, sizeof(stack_guard));
 	__stack_chk_guard = stack_guard;
 	__stack_chk_guard <<= 8;
-#endif	/* CONFIG_STACK_CANARIES */
+#endif	/* CONFIG_STACK_CANARIES_TLS */
 	entry(p1, p2, p3);
 
 	k_thread_abort(k_current_get());


### PR DESCRIPTION
### Problem
zephyr/random/random.h was included under `CONFIG_CURRENT_THREAD_USE_TLS`, but `sys_rand_get()` is only used under `CONFIG_STACK_CANARIES_TLS` - the two symbols default to y together, so this went unnoticed. With `STACK_CANARIES_TLS=y` and `CURRENT_THREAD_USE_TLS=n` , the build fails with an implicit declaration of sys_rand_get.

### Fix
Move the include from `#ifdef CONFIG_CURRENT_THREAD_USE_TLS` to `#ifdef CONFIG_STACK_CANARIES_TLS`. Also fixes the mismatched `#endif` comment.

Pure build fix, no functional change.

### Verification
```
CONFIG_STACK_CANARIES=y
CONFIG_THREAD_LOCAL_STORAGE=y
CONFIG_STACK_CANARIES_TLS=y
CONFIG_CURRENT_THREAD_USE_TLS=n
```

```
west build -b qemu_x86
```