### PR TITLE
wifi: Report the real band in interface status

### DIFF
--- a/drivers/wifi/ameba/ameba_wifi_drv.c
+++ b/drivers/wifi/ameba/ameba_wifi_drv.c
@@ -12,6 +12,7 @@
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #include <zephyr/device.h>
 #include <soc.h>
 #include "diag.h"
@@ -214,11 +215,7 @@ static int ameba_scan_done_cb(unsigned int scanned_AP_num, void *user_data)
 			memcpy(res.mac, scanned_AP_info->BSSID.octet, WIFI_MAC_ADDR_LEN);
 			res.mac_length = WIFI_MAC_ADDR_LEN;
 			res.security = WIFI_SECURITY_TYPE_NONE;
-			if (res.channel > 14) {
-				res.band = WIFI_FREQ_BAND_5_GHZ;
-			} else {
-				res.band = WIFI_FREQ_BAND_2_4_GHZ;
-			}
+			res.band = wifi_utils_chan_to_band(res.channel);
 
 			switch (scanned_AP_info->security & ~ENTERPRISE_ENABLED) {
 			case RTW_SECURITY_OPEN:
@@ -544,11 +541,7 @@ static int ameba_wifi_status(const struct device *dev, struct net_if *iface,
 	wifi_get_setting_zephyr(idx, status->ssid, (uint8_t *)&status->ssid_len, status->bssid,
 				&status->channel, &security_type);
 
-	if (status->channel > 11) {
-		status->band = WIFI_FREQ_BAND_5_GHZ;
-	} else {
-		status->band = WIFI_FREQ_BAND_2_4_GHZ;
-	}
+	status->band = wifi_utils_chan_to_band(status->channel);
 
 	status->link_mode = WIFI_LINK_MODE_UNKNOWN;
 	status->mfp = WIFI_MFP_DISABLE;

--- a/drivers/wifi/bflb/wifi6/bflb_wifi_mgmt.c
+++ b/drivers/wifi/bflb/wifi6/bflb_wifi_mgmt.c
@@ -16,6 +16,7 @@
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/wifi.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/logging/log.h>
 
@@ -185,7 +186,7 @@ static int bflb_wifi_channel(const struct device *dev, struct net_if *iface,
 
 		if (ch > 0) {
 			channel->channel = ch;
-			channel->band = (ch <= 14) ? WIFI_FREQ_BAND_2_4_GHZ : WIFI_FREQ_BAND_5_GHZ;
+			channel->band = wifi_utils_chan_to_band(ch);
 		}
 		return 0;
 	}
@@ -326,8 +327,7 @@ static int bflb_wifi_status(const struct device *dev, struct net_if *iface,
 
 		if (wl80211_glb.ap_chan_freq > 0) {
 			status->channel = wl80211_freq_to_channel(wl80211_glb.ap_chan_freq);
-			status->band = (status->channel <= 14) ? WIFI_FREQ_BAND_2_4_GHZ
-							       : WIFI_FREQ_BAND_5_GHZ;
+			status->band = wifi_utils_chan_to_band(status->channel);
 		}
 		status->beacon_interval = wl80211_glb.ap_beacon_interval;
 
@@ -355,7 +355,7 @@ static int bflb_wifi_status(const struct device *dev, struct net_if *iface,
 	ch = wl80211_sta_get_channel();
 	if (ch > 0) {
 		status->channel = ch;
-		status->band = (ch <= 14) ? WIFI_FREQ_BAND_2_4_GHZ : WIFI_FREQ_BAND_5_GHZ;
+		status->band = wifi_utils_chan_to_band(ch);
 	} else {
 		status->band = WIFI_FREQ_BAND_UNKNOWN;
 	}

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #if defined(CONFIG_NET_CONNECTION_MANAGER_CONNECTIVITY_WIFI_MGMT)
 #include <zephyr/net/conn_mgr/connectivity_wifi_mgmt.h>
 #endif
@@ -394,7 +395,7 @@ static void scan_done_handler(void)
 		strncpy(res.ssid, ap_record.ssid, ssid_len);
 		res.rssi = ap_record.rssi;
 		res.channel = ap_record.primary;
-		res.band = ap_record.primary <= 14 ? WIFI_FREQ_BAND_2_4_GHZ : WIFI_FREQ_BAND_5_GHZ;
+		res.band = wifi_utils_chan_to_band(res.channel);
 
 		memcpy(res.mac, ap_record.bssid, WIFI_MAC_ADDR_LEN);
 		res.mac_length = WIFI_MAC_ADDR_LEN;
@@ -1610,7 +1611,8 @@ static int esp32_wifi_status(const struct device *dev __unused,
 	status->ssid[WIFI_SSID_MAX_LEN-1] = '\0';
 	/* We know it is NUL terminated, so we can use strlen */
 	status->ssid_len = strlen(data->status.ssid);
-	status->band = WIFI_FREQ_BAND_2_4_GHZ;
+	/* Derived from the channel below, once the channel is known. */
+	status->band = WIFI_FREQ_BAND_UNKNOWN;
 	status->link_mode = WIFI_LINK_MODE_UNKNOWN;
 	status->mfp = WIFI_MFP_DISABLE;
 	status->wpa3_ent_type = WIFI_WPA3_ENTERPRISE_NA;
@@ -1632,6 +1634,7 @@ static int esp32_wifi_status(const struct device *dev __unused,
 
 			status->iface_mode = WIFI_MODE_INFRA;
 			status->channel = ap_info.primary;
+			status->band = wifi_utils_chan_to_band(status->channel);
 			status->rssi = ap_info.rssi;
 			memcpy(status->bssid, ap_info.bssid, WIFI_MAC_ADDR_LEN);
 
@@ -1655,6 +1658,7 @@ static int esp32_wifi_status(const struct device *dev __unused,
 			status->iface_mode = WIFI_MODE_AP;
 			status->link_mode = WIFI_LINK_MODE_UNKNOWN;
 			status->channel = conf.ap.channel;
+			status->band = wifi_utils_chan_to_band(status->channel);
 			status->beacon_interval = conf.ap.beacon_interval;
 
 		} else {

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -29,6 +29,7 @@ LOG_MODULE_REGISTER(wifi_esp_at, CONFIG_WIFI_LOG_LEVEL);
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_offload.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #include <zephyr/net/conn_mgr/connectivity_wifi_mgmt.h>
 
 #include "esp.h"
@@ -407,6 +408,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_cwlap)
 	}
 
 	res.channel = strtol(channel, NULL, 10);
+	res.band = wifi_utils_chan_to_band(res.channel);
 
 	if (dev->scan_cb) {
 		dev->scan_cb(dev->net_iface, 0, &res);
@@ -437,7 +439,6 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_cwjap_status)
 	char *str = &cwjap_buf[sizeof("+CWJAP:") - 1];
 	char *str_end = cwjap_buf + len;
 
-	status->band = WIFI_FREQ_BAND_2_4_GHZ;
 	status->iface_mode = WIFI_MODE_INFRA;
 
 	if (flags & EDF_STA_CONNECTED) {
@@ -478,6 +479,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_cwjap_status)
 	}
 
 	status->channel = strtol(channel, NULL, 10);
+	status->band = wifi_utils_chan_to_band(status->channel);
 	status->rssi = strtol(rssi, NULL, 10);
 
 	return str - cwjap_buf;

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -523,7 +523,8 @@ static int esp_hosted_status(const struct device *dev, struct net_if *iface,
 	size_t itf = esp_hosted_get_iface(dev);
 
 	status->state = data->state[itf];
-	status->band = WIFI_FREQ_BAND_2_4_GHZ;
+	/* Derived from the channel below, once the channel is known. */
+	status->band = WIFI_FREQ_BAND_UNKNOWN;
 	status->link_mode = WIFI_LINK_MODE_UNKNOWN;
 	status->wpa3_ent_type = WIFI_WPA3_ENTERPRISE_NA;
 	status->mfp = WIFI_MFP_DISABLE;
@@ -543,6 +544,7 @@ static int esp_hosted_status(const struct device *dev, struct net_if *iface,
 	if (itf == ESP_HOSTED_STA_IF) {
 		status->security = esp_hosted_prot_to_sec(ctrl_msg.resp_get_ap_config.sec_prot);
 		status->channel = ctrl_msg.resp_get_ap_config.chnl;
+		status->band = wifi_utils_chan_to_band(status->channel);
 		status->rssi = ctrl_msg.resp_get_ap_config.rssi;
 		status->ssid_len = MIN(ctrl_msg.resp_get_ap_config.ssid.size, WIFI_SSID_MAX_LEN);
 		memcpy(status->ssid, ctrl_msg.resp_get_ap_config.ssid.bytes, status->ssid_len);
@@ -550,6 +552,7 @@ static int esp_hosted_status(const struct device *dev, struct net_if *iface,
 	} else {
 		status->security = esp_hosted_prot_to_sec(ctrl_msg.resp_get_softap_config.sec_prot);
 		status->channel = ctrl_msg.resp_get_softap_config.chnl;
+		status->band = wifi_utils_chan_to_band(status->channel);
 		status->ssid_len =
 			MIN(ctrl_msg.resp_get_softap_config.ssid.size, WIFI_SSID_MAX_LEN);
 		memcpy(status->ssid, ctrl_msg.resp_get_softap_config.ssid.bytes, status->ssid_len);
@@ -577,6 +580,7 @@ static int esp_hosted_scan(const struct device *dev,
 
 		result.rssi = ap_list[i].rssi;
 		result.channel = ap_list[i].chnl;
+		result.band = wifi_utils_chan_to_band(result.channel);
 		result.security = esp_hosted_prot_to_sec(ap_list[i].sec_prot);
 
 		if (ap_list[i].ssid.size) {

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.h
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.h
@@ -14,6 +14,7 @@
 #include <zephyr/net/wifi.h>
 #include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/net/wifi_nm.h>
+#include <zephyr/net/wifi_utils.h>
 #include <zephyr/net/conn_mgr/connectivity_wifi_mgmt.h>
 
 #include <pb_encode.h>

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -554,6 +554,9 @@ int eswifi_mgmt_iface_status(const struct device *dev,
 	status->state = WIFI_STATE_COMPLETED;
 	status->ssid_len = strnlen(sta->ssid, WIFI_SSID_MAX_LEN);
 	strncpy(status->ssid, sta->ssid, status->ssid_len);
+	/* The ISM43362 is a 2.4 GHz only part and does not report the channel
+	 * it is on, so the band cannot be derived from the channel here.
+	 */
 	status->band = WIFI_FREQ_BAND_2_4_GHZ;
 	status->channel = 0;
 

--- a/drivers/wifi/hwsim/wifi_hwsim.c
+++ b/drivers/wifi/hwsim/wifi_hwsim.c
@@ -140,6 +140,9 @@ static int hwsim_mgmt_scan(const struct device *dev, struct net_if *iface,
 		res.channel = r->channel;
 		res.rssi = r->tx_power_dbm;
 		res.security = (enum wifi_security_type)r->security;
+		/* The simulated radio is 2.4 GHz by construction, see the
+		 * channel to frequency mapping in hwsim_mgmt_ap_enable().
+		 */
 		res.band = WIFI_FREQ_BAND_2_4_GHZ;
 		memcpy(res.mac, r->bssid, 6);
 		res.mac_length = 6;
@@ -219,6 +222,9 @@ static int hwsim_mgmt_iface_status(const struct device *dev, struct net_if *ifac
 
 	memset(status, 0, sizeof(*status));
 	status->channel = radio->channel;
+	/* Fixed rather than derived from the channel: the simulated radio only
+	 * ever operates in the 2.4 GHz band.
+	 */
 	status->band = WIFI_FREQ_BAND_2_4_GHZ;
 	memcpy(status->bssid, radio->ap_mode ? radio->bssid : radio->ap_bssid, 6);
 	memcpy(status->ssid, radio->ssid, radio->ssid_len);

--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -18,6 +18,7 @@
 
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #ifdef CONFIG_PM_DEVICE
 #include <zephyr/pm/device.h>
 #ifdef CONFIG_PM_MCUX_GPC
@@ -913,8 +914,7 @@ static int nxp_wifi_process_results(unsigned int count)
 
 		res.rssi = -scan_result.rssi;
 		res.channel = scan_result.channel;
-		res.band = scan_result.channel > 14 ?
-			   WIFI_FREQ_BAND_5_GHZ : WIFI_FREQ_BAND_2_4_GHZ;
+		res.band = wifi_utils_chan_to_band(scan_result.channel);
 
 		res.security = WIFI_SECURITY_TYPE_NONE;
 
@@ -1381,10 +1381,16 @@ static int nxp_wifi_uap_status(const struct device *dev,
 			}
 
 			if (nxp_wlan_uap_network.channel != 0) {
-				status->band = nxp_wlan_uap_network.channel > 14 ?
-					WIFI_FREQ_BAND_5_GHZ : WIFI_FREQ_BAND_2_4_GHZ;
+				status->band =
+					wifi_utils_chan_to_band(nxp_wlan_uap_network.channel);
 			} else {
-				status->band = nxp_wlan_uap_network.acs_band;
+				/* ACS has not picked a channel yet, so report the
+				 * band it was asked to scan. acs_band is 1 for
+				 * 5 GHz and 0 for 2.4 GHz.
+				 */
+				status->band = nxp_wlan_uap_network.acs_band
+						       ? WIFI_FREQ_BAND_5_GHZ
+						       : WIFI_FREQ_BAND_2_4_GHZ;
 			}
 
 			status->security = nxp_wifi_key_mgmt_to_zephyr(
@@ -1472,8 +1478,7 @@ static int nxp_wifi_status(const struct device *dev,
 #else
 			status->twt_capable = false;
 #endif
-			status->band = nxp_wlan_network.channel > 14 ? WIFI_FREQ_BAND_5_GHZ
-								     : WIFI_FREQ_BAND_2_4_GHZ;
+			status->band = wifi_utils_chan_to_band(nxp_wlan_network.channel);
 			status->security = nxp_wifi_key_mgmt_to_zephyr(
 				nxp_wlan_network.security.key_mgmt,
 				nxp_wlan_network.security.pwe_derivation);

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/version.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/net/wifi_utils.h>
 
 #include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
@@ -57,6 +58,9 @@ int siwx91x_status(const struct device *dev,
 
 	memset(status, 0, sizeof(*status));
 
+	/* Derived from the channel below, once the channel is known. */
+	status->band = WIFI_FREQ_BAND_UNKNOWN;
+
 	status->state = sidev->state;
 	if (sidev->state <= WIFI_STATE_INACTIVE) {
 		return 0;
@@ -73,10 +77,6 @@ int siwx91x_status(const struct device *dev,
 	status->ssid_len = strlen(status->ssid);
 	status->wpa3_ent_type = WIFI_WPA3_ENTERPRISE_NA;
 
-	if (interface & SL_WIFI_2_4GHZ_INTERFACE) {
-		status->band = WIFI_FREQ_BAND_2_4_GHZ;
-	}
-
 	if (FIELD_GET(SIWX91X_INTERFACE_MASK, interface) == SL_WIFI_CLIENT_INTERFACE) {
 		sl_wifi_operational_statistics_t operational_statistics = { };
 
@@ -86,6 +86,7 @@ int siwx91x_status(const struct device *dev,
 		status->link_mode = wlan_info.wireless_mode;
 		status->iface_mode = WIFI_MODE_INFRA;
 		status->channel = wlan_info.channel_number;
+		status->band = wifi_utils_chan_to_band(status->channel);
 		if (status->link_mode >= WIFI_6) {
 			status->twt_capable = true;
 		}
@@ -129,6 +130,7 @@ int siwx91x_status(const struct device *dev,
 		status->iface_mode = WIFI_MODE_AP;
 		status->mfp = WIFI_MFP_DISABLE;
 		status->channel = wlan_info.channel_number;
+		status->band = wifi_utils_chan_to_band(status->channel);
 		status->beacon_interval = sl_ap_cfg.beacon_interval;
 		status->dtim_period = sl_ap_cfg.dtim_beacon_count;
 		status->link_mode = WIFI_4;

--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/logging/log.h>
+#include <zephyr/net/wifi_utils.h>
 
 #include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
@@ -38,16 +39,16 @@ static void siwx91x_report_scan_res(struct siwx91x_dev *sidev, sl_wifi_scan_resu
 		.mac_length = sizeof(result->scan_info[item].bssid),
 		.security = WIFI_SECURITY_TYPE_UNKNOWN,
 		.mfp = WIFI_MFP_UNKNOWN,
-		.band = WIFI_FREQ_BAND_2_4_GHZ,
+		.band = WIFI_FREQ_BAND_UNKNOWN,
 	};
 
 	if (result->scan_count == 0) {
 		return;
 	}
 
-	if (result->scan_info[item].rf_channel <= 0 || result->scan_info[item].rf_channel > 14) {
+	tmp.band = wifi_utils_chan_to_band(tmp.channel);
+	if (tmp.band != WIFI_FREQ_BAND_2_4_GHZ) {
 		LOG_WRN("Unexpected scan result");
-		tmp.band = WIFI_FREQ_BAND_UNKNOWN;
 	}
 
 	memcpy(tmp.ssid, result->scan_info[item].ssid, tmp.ssid_length);

--- a/include/zephyr/net/wifi_utils.h
+++ b/include/zephyr/net/wifi_utils.h
@@ -13,6 +13,9 @@
 #ifndef ZEPHYR_INCLUDE_NET_WIFI_UTILS_H_
 #define ZEPHYR_INCLUDE_NET_WIFI_UTILS_H_
 
+#include <zephyr/net/wifi.h>
+#include <zephyr/net/wifi_mgmt.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -149,6 +152,22 @@ bool wifi_utils_validate_chan_5g(uint16_t chan);
  * @retval false if the channel is not valid for the band.
  */
 bool wifi_utils_validate_chan_6g(uint16_t chan);
+
+/**
+ * @brief Get the frequency band a channel belongs to.
+ *
+ * @details Channel numbers are not unique across bands: 1-14 are valid in both the
+ * 2.4 GHz and the 6 GHz band, and the 5 GHz and 6 GHz numbering overlaps above 14.
+ * The channel number alone cannot resolve that, so the lowest matching band is
+ * returned. A caller that already knows its radio is operating in the 6 GHz band
+ * must not use this function.
+ *
+ * @param chan Channel to look up.
+ *
+ * @return The band the channel belongs to.
+ * @retval WIFI_FREQ_BAND_UNKNOWN if the channel is not valid in any band.
+ */
+enum wifi_frequency_bands wifi_utils_chan_to_band(uint16_t chan);
 
 /**
  * @}

--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -771,7 +771,7 @@ int hostapd_ap_status(const struct device *dev __unused, struct net_if *net_ifac
 
 	os_memcpy(status->bssid, hapd->own_addr, WIFI_MAC_ADDR_LEN);
 	status->iface_mode = WIFI_MODE_AP;
-	status->band = wpas_band_to_zephyr(wpas_freq_to_band(iface->freq));
+	status->band = wpas_freq_to_zephyr_band(iface->freq);
 	key_mgmt = bss->wpa_key_mgmt;
 	proto = bss->wpa;
 	sae_pwe = bss->sae_pwe;

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -317,9 +317,18 @@ static inline int chan_to_freq(int chan)
 	return freq;
 }
 
-enum wifi_frequency_bands wpas_band_to_zephyr(enum wpa_radio_work_band band)
+enum wifi_frequency_bands wpas_freq_to_zephyr_band(int freq)
 {
-	switch (band) {
+	if (freq <= 0) {
+		return WIFI_FREQ_BAND_UNKNOWN;
+	}
+
+	/* The supplicant lumps 6 GHz in with 5 GHz, so ask separately. */
+	if (is_6ghz_freq(freq)) {
+		return WIFI_FREQ_BAND_6_GHZ;
+	}
+
+	switch (wpas_freq_to_band(freq)) {
 	case BAND_2_4_GHZ:
 		return WIFI_FREQ_BAND_2_4_GHZ;
 	case BAND_5_GHZ:
@@ -1597,7 +1606,7 @@ int supplicant_status(const struct device *dev __unused, struct net_if *iface,
 
 	if (wpa_s->wpa_state >= WPA_ASSOCIATED) {
 		struct wpa_ssid *ssid = wpa_s->current_ssid;
-		u8 channel;
+		u8 channel = 0;
 		struct signal_poll_resp signal_poll;
 		u8 *_ssid;
 		size_t ssid_len;
@@ -1617,7 +1626,7 @@ int supplicant_status(const struct device *dev __unused, struct net_if *iface,
 		key_mgmt = ssid->key_mgmt;
 		sae_pwe = wpa_s->conf->sae_pwe;
 		os_memcpy(status->bssid, wpa_s->bssid, WIFI_MAC_ADDR_LEN);
-		status->band = wpas_band_to_zephyr(wpas_freq_to_band(wpa_s->assoc_freq));
+		status->band = wpas_freq_to_zephyr_band(wpa_s->assoc_freq);
 		status->wpa3_ent_type = wpas_key_mgmt_to_zephyr_wpa3_ent(key_mgmt);
 		status->security = wpas_key_mgmt_to_zephyr(0, ssid, key_mgmt, proto, sae_pwe);
 #ifdef CONFIG_WEP
@@ -1639,7 +1648,12 @@ int supplicant_status(const struct device *dev __unused, struct net_if *iface,
 		 * does when associating.
 		 */
 		status->mfp = get_mfp(wpas_get_ssid_pmf(wpa_s, ssid));
-		ieee80211_freq_to_chan(wpa_s->assoc_freq, &channel);
+		if (ieee80211_freq_to_chan(wpa_s->assoc_freq, &channel) == NUM_HOSTAPD_MODES) {
+			/* The frequency is not in any known band, so the
+			 * channel was left untouched.
+			 */
+			channel = 0;
+		}
 		status->channel = channel;
 
 		if (ssid_len == 0) {

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -21,7 +21,7 @@
 #define MAC_STR_LEN 18 /* for ':' or '-' separated MAC address string */
 #define CHAN_NUM_LEN 6 /* for space-separated channel numbers string */
 
-enum wifi_frequency_bands wpas_band_to_zephyr(enum wpa_radio_work_band band);
+enum wifi_frequency_bands wpas_freq_to_zephyr_band(int freq);
 
 enum wifi_wpa3_enterprise_type wpas_key_mgmt_to_zephyr_wpa3_ent(int key_mgmt);
 

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_wifi_mgmt, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_log.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #ifdef CONFIG_WIFI_NM
 #include <zephyr/net/wifi_nm.h>
 #endif /* CONFIG_WIFI_NM */
@@ -698,11 +699,7 @@ static int wifi_neighbor_rep_complete(uint64_t mgmt_request, struct net_if *ifac
 
 	for (int i = 0; i < roaming_params.neighbor_rep.neighbor_cnt; i++) {
 		params.band_chan[i].channel = roaming_params.neighbor_rep.neighbor_ap[i].channel;
-		if (params.band_chan[i].channel > 14) {
-			params.band_chan[i].band = WIFI_FREQ_BAND_5_GHZ;
-		} else {
-			params.band_chan[i].band = WIFI_FREQ_BAND_2_4_GHZ;
-		}
+		params.band_chan[i].band = wifi_utils_chan_to_band(params.band_chan[i].channel);
 	}
 	if (wifi_mgmt_api == NULL || wifi_mgmt_api->candidate_scan == NULL) {
 		return -ENOTSUP;

--- a/subsys/net/l2/wifi/wifi_utils.c
+++ b/subsys/net/l2/wifi/wifi_utils.c
@@ -103,6 +103,29 @@ bool wifi_utils_validate_chan(uint8_t band,
 	return result;
 }
 
+
+enum wifi_frequency_bands wifi_utils_chan_to_band(uint16_t chan)
+{
+	/* The 2.4 GHz (1-14) and 6 GHz (1, 2, 5, 9, ...) channel numbers overlap, as
+	 * do the 5 GHz and 6 GHz ones above 14. A channel number on its own cannot
+	 * resolve that, so return the lowest band it is valid in. Every open coded
+	 * conversion this replaces made the same assumption.
+	 */
+	if (wifi_utils_validate_chan_2g(chan)) {
+		return WIFI_FREQ_BAND_2_4_GHZ;
+	}
+
+	if (wifi_utils_validate_chan_5g(chan)) {
+		return WIFI_FREQ_BAND_5_GHZ;
+	}
+
+	if (wifi_utils_validate_chan_6g(chan)) {
+		return WIFI_FREQ_BAND_6_GHZ;
+	}
+
+	return WIFI_FREQ_BAND_UNKNOWN;
+}
+
 /**
  * @brief Get the next Wi-Fi 6GHz channel based on the given (valid) channel.
  * The function handles the initial edge cases (1 -> 2, 2 -> 5) and then increments by 4.

--- a/tests/net/wifi/wifi_utils/CMakeLists.txt
+++ b/tests/net/wifi/wifi_utils/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wifi_utils)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/net/wifi/wifi_utils/prj.conf
+++ b/tests/net/wifi/wifi_utils/prj.conf
@@ -1,0 +1,11 @@
+CONFIG_NETWORKING=y
+CONFIG_NET_TEST=y
+CONFIG_NET_IPV6=n
+CONFIG_NET_IPV4=y
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_L2_WIFI_MGMT=y
+CONFIG_NET_LOG=y
+CONFIG_ZTEST=y
+
+# The test only exercises the utility functions, no driver is needed.
+CONFIG_ETH_DRIVER=n

--- a/tests/net/wifi/wifi_utils/src/main.c
+++ b/tests/net/wifi/wifi_utils/src/main.c
@@ -1,0 +1,78 @@
+/* main.c - Wi-Fi utility function tests */
+
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include <zephyr/net/wifi.h>
+#include <zephyr/net/wifi_utils.h>
+
+struct chan_to_band_test {
+	uint16_t chan;
+	enum wifi_frequency_bands band;
+};
+
+static const struct chan_to_band_test chan_to_band_tests[] = {
+	/* Not valid in any band. An interface that is not associated
+	 * reports channel 0 and must not be claimed to be on 2.4 GHz.
+	 */
+	{0, WIFI_FREQ_BAND_UNKNOWN},
+	{15, WIFI_FREQ_BAND_UNKNOWN},
+	{234, WIFI_FREQ_BAND_UNKNOWN},
+
+	/* 2.4 GHz. These are also valid 6 GHz channel numbers, the
+	 * lower band wins.
+	 */
+	{1, WIFI_FREQ_BAND_2_4_GHZ},
+	{6, WIFI_FREQ_BAND_2_4_GHZ},
+	{14, WIFI_FREQ_BAND_2_4_GHZ},
+
+	/* 5 GHz. Channel 108 is the one from the original bug report. */
+	{36, WIFI_FREQ_BAND_5_GHZ},
+	{108, WIFI_FREQ_BAND_5_GHZ},
+	{165, WIFI_FREQ_BAND_5_GHZ},
+
+	/* 6 GHz, i.e. above 14 and not a valid 5 GHz channel. */
+	{17, WIFI_FREQ_BAND_6_GHZ},
+	{33, WIFI_FREQ_BAND_6_GHZ},
+	{233, WIFI_FREQ_BAND_6_GHZ},
+};
+
+ZTEST(net_wifi_utils, test_chan_to_band)
+{
+	for (int i = 0; i < ARRAY_SIZE(chan_to_band_tests); i++) {
+		const struct chan_to_band_test *test = &chan_to_band_tests[i];
+
+		zexpect_equal(wifi_utils_chan_to_band(test->chan), test->band,
+			      "Channel %u mapped to band %d, expected %d", test->chan,
+			      wifi_utils_chan_to_band(test->chan), test->band);
+	}
+}
+
+ZTEST(net_wifi_utils, test_chan_to_band_agrees_with_validators)
+{
+	/* Whatever band is returned, the channel must be valid in it, and
+	 * an unknown band must mean no band accepts the channel.
+	 */
+	for (uint16_t chan = 0; chan <= 300; chan++) {
+		enum wifi_frequency_bands band = wifi_utils_chan_to_band(chan);
+
+		if (band == WIFI_FREQ_BAND_UNKNOWN) {
+			zexpect_false(wifi_utils_validate_chan_2g(chan),
+				      "Channel %u is valid in 2.4 GHz", chan);
+			zexpect_false(wifi_utils_validate_chan_5g(chan),
+				      "Channel %u is valid in 5 GHz", chan);
+			zexpect_false(wifi_utils_validate_chan_6g(chan),
+				      "Channel %u is valid in 6 GHz", chan);
+		} else {
+			zexpect_true(wifi_utils_validate_chan(band, chan),
+				     "Channel %u is not valid in band %d", chan, band);
+		}
+	}
+}
+
+ZTEST_SUITE(net_wifi_utils, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/wifi/wifi_utils/tests.yaml
+++ b/tests/net/wifi/wifi_utils/tests.yaml
@@ -1,0 +1,10 @@
+common:
+  tags:
+    - wifi
+    - net
+  platform_allow:
+    - native_sim
+  integration_platforms:
+    - native_sim
+tests:
+  net.wifi.utils: {}


### PR DESCRIPTION
Couple of wifi drivers were hard coding 2.4GHz band instead of using the real value.

I was not able to fully test this as I don't have suitable hw.

Fixes #116063
