### PR TITLE
libc: common: expose end of malloc arena

### DIFF
--- a/include/zephyr/sys/libc-hooks.h
+++ b/include/zephyr/sys/libc-hooks.h
@@ -103,6 +103,21 @@ extern struct k_mem_partition z_libc_partition;
 /* C library memory partitions */
 #define Z_LIBC_DATA K_APP_DMEM(z_libc_partition)
 
+#if defined(CONFIG_COMMON_LIBC_MALLOC) && (CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE != 0)
+/**
+ * @brief Return the upper bound of the libc malloc heap.
+ *
+ * Returns the address one byte past the end of the memory region handed to
+ * sys_heap_init() for the common libc malloc arena, which includes the
+ * heap end-marker written by sys_heap_init(). This boundary can be used by
+ * power-management code to determine the memory that must be retained across
+ * a retention sleep.
+ *
+ * @return Address of the first byte above the malloc heap.
+ */
+uintptr_t z_libc_heap_end(void);
+#endif /* CONFIG_COMMON_LIBC_MALLOC && CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE != 0 */
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -115,6 +115,7 @@ extern char _heap_sentry[];
 # endif /* else ALLOCATE_HEAP_AT_STARTUP */
 
 Z_LIBC_DATA static struct sys_heap z_malloc_heap;
+static uintptr_t z_malloc_heap_end;
 
 #if defined(CONFIG_SYS_HEAP_KASAN_MALLOC) && defined(HEAP_STATIC)
 #include <zephyr/sys/heap_kasan.h>
@@ -239,8 +240,14 @@ static int malloc_prepare(void)
 #endif
 
 	sys_heap_init(&z_malloc_heap, heap_base, heap_size);
+	z_malloc_heap_end = POINTER_TO_UINT(heap_base) + heap_size;
 
 	return 0;
+}
+
+uintptr_t z_libc_heap_end(void)
+{
+	return z_malloc_heap_end;
 }
 
 void *realloc(void *ptr, size_t requested_size)

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2026 Atmosic
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,6 +46,9 @@
 #endif
 #ifdef CONFIG_COMMON_LIBC_MALLOC
 #include <sys_malloc.h>
+#endif
+#if defined(CONFIG_COMMON_LIBC_MALLOC) && (CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE != 0)
+#include <zephyr/sys/libc-hooks.h>
 #endif
 
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
@@ -1356,6 +1360,15 @@ ZTEST(libc_common, test_malloc)
 #else
 	ztest_test_skip();
 #endif /* CONFIG_COMMON_LIBC_MALLOC && CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE > 220 */
+}
+
+ZTEST(libc_common, test_malloc_heap_end)
+{
+#if defined(CONFIG_COMMON_LIBC_MALLOC) && (CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE != 0)
+	zassert_not_equal(z_libc_heap_end(), 0U, "z_libc_heap_end returned an uninitialized value");
+#else
+	ztest_test_skip();
+#endif
 }
 /**
  * @}


### PR DESCRIPTION
Add z_libc_heap_end() to return the address immediately above the common
libc malloc arena.

The sys_heap end-marker is written at the top of the arena by sys_heap_init(),
but is not reported through heap listener allocation callbacks. Exposing the
arena boundary allows power-management code to retain the SRAM bank containing
the end-marker during retention sleep and prevents heap corruption after wakeup.

The helper is generic and has no platform-specific dependencies.