### PR TITLE
kernel: Remove redundant K_FOREVER timeout check from thread schedule

### DIFF
--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -57,8 +57,9 @@ static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t dela
 		z_add_thread_timeout(thread, delay);
 	}
 #else
-	ARG_UNUSED(delay);
-	k_thread_start(thread);
+	if (!K_TIMEOUT_EQ(delay, K_FOREVER)) {
+		k_thread_start(thread);
+	}
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 }
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -103,10 +103,7 @@ static void z_init_static_threads(void)
 	STRUCT_SECTION_FOREACH(_static_thread_data, thread_data) {
 		k_timeout_t init_delay = Z_THREAD_INIT_DELAY(thread_data);
 
-		if (!K_TIMEOUT_EQ(init_delay, K_FOREVER)) {
-			thread_schedule_new(thread_data->init_thread,
-					    init_delay);
-		}
+		thread_schedule_new(thread_data->init_thread, init_delay);
 	}
 	k_sched_unlock();
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1004,9 +1004,7 @@ k_tid_t z_impl_k_thread_create(struct k_thread *new_thread,
 	z_setup_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
 			  prio, options, NULL);
 
-	if (!K_TIMEOUT_EQ(delay, K_FOREVER)) {
-		thread_schedule_new(new_thread, delay);
-	}
+	thread_schedule_new(new_thread, delay);
 
 	return new_thread;
 }
@@ -1075,9 +1073,7 @@ k_tid_t z_vrfy_k_thread_create(struct k_thread *new_thread,
 	z_setup_new_thread(new_thread, stack, stack_size,
 			   entry, p1, p2, p3, prio, options, NULL);
 
-	if (!K_TIMEOUT_EQ(delay, K_FOREVER)) {
-		thread_schedule_new(new_thread, delay);
-	}
+	thread_schedule_new(new_thread, delay);
 
 	return new_thread;
 }


### PR DESCRIPTION
Calling thread_schedule_new with a timeout not equal to K_NO_WAIT will result in a z_add_timeout call, in the much common configuration CONFIG_SYS_CLOCK_EXISTS=y, which returns early on K_FOREVER making the compare redundant.

When !CONFIG_SYS_CLOCK_EXISTS the behavior is kept such that a timeout value of K_FOREVER still results in a nop.

Footprint reduction,

```
benchmark.kernel.footprints.default
 frdm_k64f/mk64f12
  ROM (-0.10%)    -24   current size   24160 bytes
 disco_l475_iot1/stm32l475xx
  ROM (-0.10%)    -24   current size   24640 bytes
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.08%)    -24   current size   28412 bytes
 nrf51dk/nrf51822
  ROM (-0.07%)    -16   current size   22916 bytes
 hifive1_revb/fe310_g002
  ROM (-0.09%)    -20   current size   21242 bytes

benchmark.kernel.footprints.pm
 frdm_k64f/mk64f12
  ROM (-0.09%)    -24   current size   27040 bytes
 disco_l475_iot1/stm32l475xx
  ROM (-0.08%)    -24   current size   31489 bytes
 iotdk/arc_iot
  RAM (-0.05%)    -16   current size   34261 bytes
  ROM (-0.07%)    -16   current size   24127 bytes

benchmark.kernel.footprints.userspace
 frdm_k64f/mk64f12
  ROM (-0.06%)    -36   current size   63416 bytes
 disco_l475_iot1/stm32l475xx
  ROM (-0.06%)    -36   current size   63776 bytes

sample.bluetooth.audio.unicast_client
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.01%)    -24   current size  255969 bytes

sample.bluetooth.audio.unicast_server
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.01%)    -24   current size  262630 bytes

sample.bluetooth.beacon-coex
 nrf52840dk/nrf52840
  ROM (-0.04%)    -24   current size   64754 bytes

sample.bluetooth.central_hr.bt_ll_sw_split.extended
 nrf52840dk/nrf52840
  ROM (-0.01%)    -24   current size  183213 bytes

sample.bluetooth.central_hr.bt_ll_sw_split.phy_coded
 nrf52840dk/nrf52840
  ROM (-0.01%)    -24   current size  186629 bytes

sample.bluetooth.hci_ipc
 nrf5340dk/nrf5340/cpunet
  ROM (-0.02%)    -24   current size  112512 bytes

sample.bluetooth.hci_ipc.bis.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -24   current size  224668 bytes

sample.bluetooth.hci_ipc.cis.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -24   current size  198544 bytes

sample.bluetooth.hci_ipc.df.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -24   current size  184688 bytes

sample.bluetooth.hci_ipc.df.no_phy_coded.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -24   current size  180528 bytes

sample.bluetooth.hci_ipc.iso.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -24   current size  210444 bytes

sample.bluetooth.hci_ipc.iso_broadcast.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.02%)    -24   current size  115592 bytes

sample.bluetooth.hci_ipc.iso_central.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.02%)    -24   current size  151832 bytes

sample.bluetooth.hci_ipc.iso_peripheral.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.02%)    -24   current size  147344 bytes

sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.02%)    -24   current size  117716 bytes

sample.bluetooth.hci_ipc.mesh.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.02%)    -24   current size  123428 bytes

sample.bluetooth.mesh_demo
 bbc_microbit/nrf51822
  ROM (-0.01%)    -16   current size  154112 bytes

sample.net.sockets.echo_client
 frdm_k64f/mk64f12
  ROM (-0.01%)    -24   current size  228388 bytes

sample.net.sockets.echo_client.802154.rf2xx.arduino
 frdm_k64f/mk64f12
  ROM (-0.01%)    -24   current size  224672 bytes

sample.net.sockets.echo_client.mcr20a
 frdm_k64f/mk64f12
  ROM (-0.01%)    -24   current size  211104 bytes

sample.net.sockets.echo_server
 frdm_k64f/mk64f12
  ROM (-0.01%)    -24   current size  232732 bytes

sample.net.sockets.echo_server.802154.rf2xx.arduino
 frdm_k64f/mk64f12
  ROM (-0.01%)    -24   current size  227568 bytes

sample.net.sockets.echo_server.mcr20a
 frdm_k64f/mk64f12
  ROM (-0.01%)    -24   current size  212620 bytes

sample.net.sockets.echo_server.usbd_cdc_ncm
 frdm_k64f/mk64f12
  ROM (-0.01%)    -24   current size  255284 bytes
  ```