### PR TITLE
drivers: uaol: fix silent link failure after runtime PM suspend

### DIFF
--- a/drivers/uaol/uaol_intel_adsp.c
+++ b/drivers/uaol/uaol_intel_adsp.c
@@ -668,12 +668,18 @@ static int uaol_intel_adsp_config(const struct device *dev, int stream, struct u
 			goto out;
 		}
 
+		LOG_DBG("link initialized, frame counter aligned");
+
 		dp->is_initialized = true;
 	}
 
 	/* Program the FIFO Start Address Offset and Channel Mapping */
 	sys_write16(cfg->fifo_start_offset, UAOLxPCMSyFSA_ADDR(dp, stream));
 	sys_write16(cfg->channel_map, UAOLxPCMSyCM_ADDR(dp, stream));
+
+	LOG_DBG("stream %d: FSA 0x%04x, CM 0x%04x, rate %u, chan %u, bits %u, mps %u",
+		stream, cfg->fifo_start_offset, cfg->channel_map, cfg->sample_rate,
+		cfg->channels, cfg->sample_bits, cfg->sio_credit_size);
 
 	uaol_intel_adsp_program_format(dev, stream, cfg->sample_rate, cfg->channels,
 				       cfg->sample_bits, cfg->sio_credit_size,

--- a/drivers/uaol/uaol_intel_adsp.c
+++ b/drivers/uaol/uaol_intel_adsp.c
@@ -209,6 +209,11 @@ static int uaol_intel_adsp_set_power(const struct device *dev, bool power)
 
 	dp->is_powered_up = power;
 
+	/* The link power domain retains neither the BDF nor the frame alignment */
+	if (!power) {
+		dp->is_initialized = false;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
The UAOL link initialization - programming the target BDF and aligning the
UAOL frame counter to the xHCI micro-frame counter - is guarded by a flag
that is never cleared, but the link power domain does not retain either of
them. After the first runtime PM cycle the link keeps running with a frame
counter that no longer matches the xHCI, the isochronous data lands in the
wrong micro-frame, and the device silently transfers nothing. No error is
reported anywhere.

The first patch clears the flag on power down so the link is initialized
again on the next config(). The second adds debug logs for the link
initialization and the per-stream configuration, which is what made this
diagnosable in the first place.

Tested on Panther Lake with a USB headset: playback used to work only for
the first stream after firmware load and was silent afterwards, and now
stays good across repeated playback and capture streams.