### PR TITLE
drivers: usb: udc_dwc2: skip unallocated FIFOs when calculating address

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1125,12 +1125,22 @@ static int dwc2_set_dedicated_fifo(const struct device *dev,
 			dwc2_unset_unused_fifo(dev);
 		}
 
-		if ((ep_idx - 1) != 0U) {
-			txfaddr = dwc2_get_txfdep(dev, ep_idx - 2) +
-				  dwc2_get_txfaddr(dev, ep_idx - 2);
-		} else {
-			txfaddr = priv->rxfifo_depth +
-				MIN(UDC_DWC2_FIFO0_DEPTH, priv->max_txfifo_depth[0]);
+		/* Chain the FIFO off the closest lower-numbered TxFIFO that has
+		 * actually been allocated. IN endpoints with wMaxPacketSize 0,
+		 * such as the alternate setting 0 isochronous endpoints of the
+		 * BT HCI class, are activated without a FIFO, so their size and
+		 * address registers still hold the power-on values and must not
+		 * be used as a base address.
+		 */
+		txfaddr = priv->rxfifo_depth +
+			MIN(UDC_DWC2_FIFO0_DEPTH, priv->max_txfifo_depth[0]);
+
+		for (uint8_t i = ep_idx - 1U; i > 0U; i--) {
+			if (priv->txf_set & BIT(i)) {
+				txfaddr = dwc2_get_txfdep(dev, i - 1) +
+					  dwc2_get_txfaddr(dev, i - 1);
+				break;
+			}
 		}
 
 		if (priv->txf_set & BIT(ep_idx)) {


### PR DESCRIPTION
With dynamic FIFO sizing, an IN endpoint with wMaxPacketSize equal to zero is activated without allocating a TxFIFO. Its FIFO register therefore retains its reset value, which does not describe the current dynamic FIFO layout.

Using that register to calculate the address of the next TxFIFO may cause overlapping allocations, unused gaps, or a false -ENOMEM error.

Find the closest lower-numbered allocated TxFIFO using txf_set and place the new FIFO after it. Fall back to the end of FIFO0 when none exists.
