### PR TITLE
ARC: Fix SMP and atomic memory ordering

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -17,11 +17,29 @@ config CPU_ARCEM
 
 config CPU_ARCHS
 	bool
-	select ATOMIC_OPERATIONS_BUILTIN
-	select BARRIER_OPERATIONS_BUILTIN
+	select ATOMIC_OPERATIONS_ARCH if ARC_MWDT_MEM_ORDERING_WORKAROUND
+	select ATOMIC_OPERATIONS_BUILTIN if !ARC_MWDT_MEM_ORDERING_WORKAROUND
+	select BARRIER_OPERATIONS_ARCH if ARC_MWDT_MEM_ORDERING_WORKAROUND
+	select BARRIER_OPERATIONS_BUILTIN if !ARC_MWDT_MEM_ORDERING_WORKAROUND
 	help
 	  This option signifies the use of an ARC HS CPU
 
+config ARC_MWDT_MEM_ORDERING_WORKAROUND
+	bool
+	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
+	help
+	  Route the atomic and barrier APIs through the ARC backends in
+	  include/zephyr/arch/arc/ instead of the compiler builtins.
+
+	  MWDT lowers every __atomic_* operation to a barrier-free llock/scond
+	  library routine, drops the memory-order argument, and implements
+	  __sync_synchronize() as a bare return, so the builtins provide
+	  atomicity without the ordering that Zephyr's APIs promise. ARC GNU
+	  GCC emits the required dmb instructions itself and is unaffected.
+
+	  This is a temporary workaround. Once MWDT implements memory ordering
+	  for the atomic builtins, revert this symbol together with the two
+	  ARC backend headers so that ARC HS goes back to the builtins.
 
 choice
 	prompt "ARC Instruction Set"

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -120,7 +120,15 @@ _exc_return:
 
 	/* Save old thread into switch handle which is required by z_sched_switch_spin which
 	 * will be called during old thread abort.
+	 *
+	 * On SMP publish switch_handle only after all prior context stores are
+	 * globally visible. ARC HS is weakly ordered, so a store-store barrier
+	 * is required before the lock-free switch_handle publish that is
+	 * polled by other cores in z_sched_switch_spin().
 	 */
+#ifdef CONFIG_SMP
+	dmb ARC_DMB_STORE
+#endif
 	STR r2, r2, ___thread_t_switch_handle_OFFSET
 
 	MOVR r2, r0

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -175,7 +175,13 @@ _secondary_core_wait:
 	ld r1, [arc_cpu_wake_flag]
 	brne r0, r1, _secondary_core_wait
 
+	/* acquire: arc_cpu_sp must not be read before the flag was observed */
+	dmb ARC_DMB_LOAD
 	LDR sp, arc_cpu_sp
+	/* the arc_cpu_sp read must complete before the primary core sees the
+	 * acknowledgment below, as it reuses arc_cpu_sp for the next core
+	 */
+	dmb ARC_DMB_LOAD_STORE
 	/* signal primary core that secondary core runs */
 	st 0, [arc_cpu_wake_flag]
 

--- a/arch/arc/core/smp.c
+++ b/arch/arc/core/smp.c
@@ -17,6 +17,7 @@
 #include <zephyr/platform/hooks.h>
 #include <arc_irq_offload.h>
 #include <kernel_arch_func.h>
+#include <zephyr/sys/barrier.h>
 
 volatile struct {
 	arch_cpustart_t fn;
@@ -53,12 +54,22 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 	 */
 	arc_cpu_sp = K_KERNEL_STACK_BUFFER(stack) + sz;
 
+	/* Publish _curr_cpu[], arc_cpu_init[] and arc_cpu_sp before the
+	 * secondary core can observe the wake flag.
+	 */
+	barrier_dmem_fence_full();
+
 	arc_cpu_wake_flag = cpu_num;
 
 	/* wait secondary cpu to start */
 	while (arc_cpu_wake_flag != 0U) {
 		;
 	}
+
+	/* The next call reuses arc_cpu_sp, so that store must not become
+	 * visible before this core has observed the acknowledgment.
+	 */
+	barrier_dmem_fence_full();
 }
 
 #ifdef CONFIG_SMP

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -417,12 +417,19 @@ fpu_skip_load :
 	_save_callee_saved_regs
 	/* Save old thread into switch handle which is required by z_sched_switch_spin.
 	 * NOTE: we shouldn't save anything related to old thread context after this point!
-	 * TODO: we should add SMP write-after-write data memory barrier here, as we want all
-	 * previous writes completed before setting switch_handle which is polled by other cores
-	 * in z_sched_switch_spin in case of SMP. Though it's not likely that this issue
-	 * will reproduce in real world as there is some gap before reading switch_handle and
-	 * reading rest of the data we've stored before.
+	 *
+	 * On SMP we must ensure that all of the callee-saved register stores above
+	 * (and the stack-pointer store into k_thread) are globally visible BEFORE
+	 * switch_handle is published. switch_handle is polled lock-free by other
+	 * cores in z_sched_switch_spin(); ARC HS is weakly ordered (in-order issue
+	 * but micro-arch store buffering/queuing), so without a store-store barrier
+	 * a remote core can observe a non-NULL switch_handle and start restoring
+	 * this thread's context before the register/SP saves have landed, leading
+	 * to corrupted callee-saved state on the incoming thread.
 	 */
+#ifdef CONFIG_SMP
+	dmb ARC_DMB_STORE
+#endif
 	STR r2, r2, ___thread_t_switch_handle_OFFSET
 .endm
 

--- a/include/zephyr/arch/arc/arch.h
+++ b/include/zephyr/arch/arc/arch.h
@@ -86,6 +86,9 @@
 #error "Non-multithreading mode isn't supported on SMP targets"
 #endif
 
+/* ARC HS DMB instruction operand masks. */
+#include <zephyr/arch/arc/dmb.h>
+
 #ifndef _ASMLANGUAGE
 
 #ifdef __cplusplus

--- a/include/zephyr/arch/arc/atomic_arc.h
+++ b/include/zephyr/arch/arc/atomic_arc.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 GlobalFoundries Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief MWDT implementation of the atomic operations API for ARC HS.
+ *
+ * The public documentation for these operations lives in <zephyr/sys/atomic.h>.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARC_ATOMIC_ARC_H_
+#define ZEPHYR_INCLUDE_ARCH_ARC_ATOMIC_ARC_H_
+
+#ifndef __CCAC__
+/* ARC GNU GCC brackets every __ATOMIC_SEQ_CST operation with dmb 3 by itself,
+ * so it keeps using <zephyr/sys/atomic_builtin.h>.
+ */
+#error "The ARC atomic backend is a MWDT-only workaround"
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/atomic_types.h>
+#include <zephyr/sys/barrier.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Included from <atomic.h> */
+
+/** @cond INTERNAL_HIDDEN */
+
+/* MWDT lowers every __atomic_* operation to a barrier-free llock/scond library
+ * routine (__Sync_*_4) and drops the memory-order argument on the way, so the
+ * atomicity half of __ATOMIC_SEQ_CST is honoured but the ordering half is not.
+ * Supply the missing ordering here.
+ */
+#define Z_ARC_SEQ_CST(expr)						\
+	({								\
+		__typeof__(expr) _z_arc_ret;				\
+		barrier_dmem_fence_full();				\
+		_z_arc_ret = (expr);					\
+		barrier_dmem_fence_full();				\
+		_z_arc_ret;						\
+	})
+
+static ALWAYS_INLINE bool atomic_cas(atomic_t *target, atomic_val_t old_value,
+				     atomic_val_t new_value)
+{
+	return Z_ARC_SEQ_CST(__atomic_compare_exchange_n(target, &old_value,
+							 new_value, 0,
+							 __ATOMIC_SEQ_CST,
+							 __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE bool atomic_ptr_cas(atomic_ptr_t *target,
+					 atomic_ptr_val_t old_value,
+					 atomic_ptr_val_t new_value)
+{
+	return Z_ARC_SEQ_CST(__atomic_compare_exchange_n(target, &old_value,
+							 new_value, 0,
+							 __ATOMIC_SEQ_CST,
+							 __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_add(atomic_t *target, atomic_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_fetch_add(target, value, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_fetch_sub(target, value, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_inc(atomic_t *target)
+{
+	return atomic_add(target, 1);
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_dec(atomic_t *target)
+{
+	return atomic_sub(target, 1);
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_get(const atomic_t *target)
+{
+	return Z_ARC_SEQ_CST(__atomic_load_n(target, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target)
+{
+	return Z_ARC_SEQ_CST(__atomic_load_n(target, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_set(atomic_t *target, atomic_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_exchange_n(target, value, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target,
+						     atomic_ptr_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_exchange_n(target, value, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_clear(atomic_t *target)
+{
+	return atomic_set(target, 0);
+}
+
+static ALWAYS_INLINE atomic_ptr_val_t atomic_ptr_clear(atomic_ptr_t *target)
+{
+	return atomic_ptr_set(target, NULL);
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_or(atomic_t *target, atomic_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_fetch_or(target, value, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_fetch_xor(target, value, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_and(atomic_t *target, atomic_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_fetch_and(target, value, __ATOMIC_SEQ_CST));
+}
+
+static ALWAYS_INLINE atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value)
+{
+	return Z_ARC_SEQ_CST(__atomic_fetch_nand(target, value, __ATOMIC_SEQ_CST));
+}
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARC_ATOMIC_ARC_H_ */

--- a/include/zephyr/arch/arc/barrier.h
+++ b/include/zephyr/arch/arc/barrier.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026 GlobalFoundries Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_ARCH_ARC_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARC_BARRIER_H_
+
+#ifndef ZEPHYR_INCLUDE_SYS_BARRIER_H_
+#error Please include <zephyr/sys/barrier.h>
+#endif
+
+#ifndef __CCAC__
+/* ARC GNU GCC lowers the barrier builtins correctly, so it keeps using
+ * <zephyr/sys/barrier_builtin.h>. Only MWDT needs this backend.
+ */
+#error "The ARC barrier backend is a MWDT-only workaround"
+#endif
+
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/arc/dmb.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* MWDT implements __sync_synchronize() as a bare return and emits no dmb for
+ * __atomic_thread_fence(), so emit the ARC barrier instructions directly.
+ */
+
+static ALWAYS_INLINE void z_barrier_sync_synchronize(void)
+{
+	__asm__ volatile("dmb " STRINGIFY(ARC_DMB_LOAD_STORE) ::: "memory");
+}
+
+static ALWAYS_INLINE void z_barrier_dmem_fence_full(void)
+{
+	__asm__ volatile("dmb " STRINGIFY(ARC_DMB_LOAD_STORE) ::: "memory");
+}
+
+static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
+{
+	/* dsync additionally stalls until the prior data accesses completed */
+	__asm__ volatile("dsync" ::: "memory");
+}
+
+static ALWAYS_INLINE void z_barrier_isync_fence_full(void)
+{
+	/* sync is ARC's pipeline-affecting synchronization */
+	__asm__ volatile("sync" ::: "memory");
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARC_BARRIER_H_ */

--- a/include/zephyr/arch/arc/dmb.h
+++ b/include/zephyr/arch/arc/dmb.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2026 GlobalFoundries Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ARC HS DMB instruction operand masks (_ARCVER >= 0x51)
+ *
+ * The dmb operand is a 3-bit mask of the data accesses to order.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARC_DMB_H_
+#define ZEPHYR_INCLUDE_ARCH_ARC_DMB_H_
+
+/** Order prior loads before subsequent loads and stores. */
+#define ARC_DMB_LOAD       1
+
+/** Order prior stores before subsequent stores. */
+#define ARC_DMB_STORE      2
+
+/** Order prior loads and stores before subsequent loads and stores. */
+#define ARC_DMB_LOAD_STORE 3
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARC_DMB_H_ */

--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -37,6 +37,9 @@ extern "C" {
 # ifdef CONFIG_XTENSA
 /* Not all Xtensa toolchains support GCC-style atomic intrinsics */
 # include <zephyr/arch/xtensa/atomic_xtensa.h>
+# elif defined(CONFIG_ARC)
+/* MWDT ignores the memory-order argument of the atomic builtins */
+# include <zephyr/arch/arc/atomic_arc.h>
 # else
 /* Other arch specific implementation */
 # include <zephyr/sys/atomic_arch.h>

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -20,6 +20,8 @@
 # include <zephyr/arch/arm/barrier.h>
 # elif defined(CONFIG_ARM64)
 # include <zephyr/arch/arm64/barrier.h>
+# elif defined(CONFIG_ARC)
+# include <zephyr/arch/arc/barrier.h>
 # endif
 #elif defined(CONFIG_BARRIER_OPERATIONS_BUILTIN)
 #include <zephyr/sys/barrier_builtin.h>


### PR DESCRIPTION
ARC HS is weakly ordered, so some SMP handshakes need explicit memory barriers:
- Adds a store barrier before publishing `switch_handle`, ensuring the saved thread context is visible before another CPU restores it.
- Adds the required ordering around the secondary CPU boot handshake and stack-pointer exchange.
- Adds an MWDT-only workaround for atomic and barrier builtins that provide atomicity but do not apply the requested memory ordering.

The MWDT workaround adds full barriers around Zephyr atomic operations and implements the barrier APIs using ARC inline assembly. GCC keeps using its existing builtins and is unaffected.

The MWDT workaround is temporary and can be reverted once the toolchain supports the required memory ordering. The SMP handshake fixes should remain.
