### PR TITLE
lib: libc: name the parameters in function declarations

### DIFF
--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -34,7 +34,7 @@ static int _stdout_hook_default(int c)
 
 static int (*_stdout_hook)(int) = _stdout_hook_default;
 
-void __stdout_hook_install(int (*hook)(int))
+void __stdout_hook_install(int (*hook)(int c))
 {
 	_stdout_hook = hook;
 }

--- a/lib/libc/armstdc/src/libc-hooks.c
+++ b/lib/libc/armstdc/src/libc-hooks.c
@@ -16,7 +16,7 @@ static int _stdout_hook_default(int c)
 
 static int (*_stdout_hook)(int) = _stdout_hook_default;
 
-void __stdout_hook_install(int (*hook)(int))
+void __stdout_hook_install(int (*hook)(int c))
 {
 	_stdout_hook = hook;
 }

--- a/lib/libc/iar/src/libc-hooks.c
+++ b/lib/libc/iar/src/libc-hooks.c
@@ -16,7 +16,7 @@ static int _stdout_hook_default(int c)
 
 static int (*_stdout_hook)(int) = _stdout_hook_default;
 
-void __stdout_hook_install(int (*hook)(int))
+void __stdout_hook_install(int (*hook)(int c))
 {
 	_stdout_hook = hook;
 }

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -37,9 +37,9 @@ void *bsearch(const void *key, const void *array,
 	      int (*cmp)(const void *key, const void *element));
 
 void qsort_r(void *base, size_t nmemb, size_t size,
-	     int (*compar)(const void *, const void *, void *), void *arg);
+	     int (*compar)(const void *a, const void *b, void *arg), void *arg);
 void qsort(void *base, size_t nmemb, size_t size,
-	   int (*compar)(const void *, const void *));
+	   int (*compar)(const void *a, const void *b));
 
 #define EXIT_SUCCESS 0
 #define EXIT_FAILURE 1

--- a/lib/libc/newlib/include/string.h
+++ b/lib/libc/newlib/include/string.h
@@ -24,10 +24,11 @@ extern "C" {
  * them from newlib
  */
 #if !__MISC_VISIBLE && !__POSIX_VISIBLE
-char *strtok_r(char *__restrict, const char *__restrict, char **__restrict);
+char *strtok_r(char *__restrict __s, const char *__restrict __delim,
+	       char **__restrict __save_ptr);
 #endif
 #if __POSIX_VISIBLE < 200809L
-size_t strnlen(const char *, size_t);
+size_t strnlen(const char *__s, size_t __maxlen);
 #endif
 
 #ifdef __cplusplus

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -167,7 +167,7 @@ static int _stdout_hook_default(int c)
 
 static int (*_stdout_hook)(int) = _stdout_hook_default;
 
-void __stdout_hook_install(int (*hook)(int))
+void __stdout_hook_install(int (*hook)(int c))
 {
 	_stdout_hook = hook;
 }


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The stdout hook install helper is defined once per C library and only the
minimal and picolibc versions named the hook's character argument. The
minimal stdlib.h and the newlib string.h overrides also declared their
parameters with bare types.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
