### PR TITLE
cpp: name the parameters in the __cxa_atexit declarations

### DIFF
--- a/arch/arm/core/__aeabi_atexit.c
+++ b/arch/arm/core/__aeabi_atexit.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/toolchain.h>
 
-EXTERN_C int __cxa_atexit(void (*destructor)(void *), void *objptr, void *dso);
+EXTERN_C int __cxa_atexit(void (*destructor)(void *obj), void *objptr, void *dso);
 
 /**
  * @brief Register destructor for a global object
@@ -22,7 +22,7 @@ EXTERN_C int __cxa_atexit(void (*destructor)(void *), void *objptr, void *dso);
  *
  * Wrapper for __cxa_atexit()
  */
-int __aeabi_atexit(void *objptr, void (*destructor)(void *), void *dso)
+int __aeabi_atexit(void *objptr, void (*destructor)(void *obj), void *dso)
 {
 	return __cxa_atexit(destructor, objptr, dso);
 }

--- a/lib/cpp/abi/cpp_dtors.c
+++ b/lib/cpp/abi/cpp_dtors.c
@@ -33,7 +33,7 @@ __weak void *__dso_handle;
  *
  * @retval 0 on success.
  */
-int __cxa_atexit(void (*destructor)(void *), void *objptr, void *dso)
+int __cxa_atexit(void (*destructor)(void *obj), void *objptr, void *dso)
 {
 	ARG_UNUSED(destructor);
 	ARG_UNUSED(objptr);


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The C++ ABI __cxa_atexit() stub, its local prototype in the ARM
__aeabi_atexit() wrapper and that wrapper itself left the destructor's
parameter unnamed.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
