### PR TITLE
modules: name the parameters in function declarations

### DIFF
--- a/modules/hal_bouffalolab/shim/btblecontroller_port_os.c
+++ b/modules/hal_bouffalolab/shim/btblecontroller_port_os.c
@@ -75,7 +75,7 @@ static void task_entry_wrapper(void *p1, void *p2, void *p3)
  * stack_size is in 4-byte words.
  * taskHandler receives the opaque handle for later deletion.
  */
-int btblecontroller_task_new(void (*taskFunction)(void *), const char *name, int stack_size,
+int btblecontroller_task_new(void (*taskFunction)(void *arg), const char *name, int stack_size,
 			     void *arg, int prio, void *taskHandler)
 {
 	size_t stack_bytes = (size_t)stack_size * STACK_WORD_SIZE;

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_task.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_task.c
@@ -72,7 +72,7 @@ int rtos_sched_get_state(void)
 	return RTOS_SCHED_RUNNING;
 }
 
-int rtos_task_create(rtos_task_t *pp_handle, const char *p_name, void (*p_routine)(void *),
+int rtos_task_create(rtos_task_t *pp_handle, const char *p_name, void (*p_routine)(void *p_param),
 		     void *p_param, uint16_t stack_size_in_byte, uint16_t priority)
 {
 	k_tid_t p_thread;

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_timer.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_timer.c
@@ -16,7 +16,8 @@ typedef struct {
 } k_timer_wrapper_t;
 
 int rtos_timer_create(rtos_timer_t *pp_handle, const char *p_timer_name, uint32_t timer_id,
-		      uint32_t interval_ms, uint8_t reload, void (*p_timer_callback)(void *))
+		      uint32_t interval_ms, uint8_t reload,
+		      void (*p_timer_callback)(void *p_context))
 {
 	k_timer_wrapper_t *p_timer;
 
@@ -59,7 +60,8 @@ int rtos_timer_delete(rtos_timer_t p_handle, uint32_t wait_ms)
 }
 
 int rtos_timer_create_static(rtos_timer_t *pp_handle, const char *p_timer_name, uint32_t timer_id,
-			     uint32_t interval_ms, uint8_t reload, void (*p_timer_callback)(void *))
+			     uint32_t interval_ms, uint8_t reload,
+			     void (*p_timer_callback)(void *p_context))
 {
 	return rtos_timer_create(pp_handle, p_timer_name, timer_id, interval_ms, reload,
 				 p_timer_callback);

--- a/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
+++ b/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
@@ -207,7 +207,7 @@ bool os_sched_is_start_zephyr(void)
  ************************************************************/
 K_MEM_SLAB_DEFINE_TYPE(osif_task_slab, struct osif_task, CONFIG_REALTEK_BEE_OSIF_TASK_MAX_COUNT);
 
-bool os_task_create_zephyr(void **handle_ptr, const char *name, void (*routine)(void *),
+bool os_task_create_zephyr(void **handle_ptr, const char *name, void (*routine)(void *param),
 			   void *param, uint16_t stack_size, uint16_t priority)
 {
 	struct osif_task *task;

--- a/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.h
+++ b/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.h
@@ -116,7 +116,7 @@ bool os_sched_is_start_zephyr(void);
 /************************************************************
  * TASK MANAGEMENT - Internal APIs
  ************************************************************/
-bool os_task_create_zephyr(void **handle_ptr, const char *name, void (*routine)(void *),
+bool os_task_create_zephyr(void **handle_ptr, const char *name, void (*routine)(void *param),
 			   void *param, uint16_t stack_size, uint16_t priority);
 bool os_task_delete_zephyr(void *handle);
 bool os_task_suspend_zephyr(void *handle);

--- a/modules/hal_realtek/bee/osif/rtl8752h/osif_zephyr_patch.c
+++ b/modules/hal_realtek/bee/osif/rtl8752h/osif_zephyr_patch.c
@@ -301,8 +301,9 @@ static bool wrapper_os_mutex_give(void *p_handle, bool *p_result)
 /************************************************************
  * Task Management Wrapper Functions
  ************************************************************/
-static bool wrapper_os_task_create(void **pp_handle, const char *p_name, void (*p_routine)(void *),
-				   void *p_param, uint16_t stack_size, uint16_t priority,
+static bool wrapper_os_task_create(void **pp_handle, const char *p_name,
+				   void (*p_routine)(void *p_param), void *p_param,
+				   uint16_t stack_size, uint16_t priority,
 				   bool *p_is_create_success)
 {
 	*p_is_create_success =

--- a/modules/lvgl/lvgl_zephyr_osal.c
+++ b/modules/lvgl/lvgl_zephyr_osal.c
@@ -19,7 +19,7 @@ typedef void (*lv_thread_entry)(void *);
 static void thread_entry(void *thread, void *cb, void *user_data);
 
 lv_result_t lv_thread_init(lv_thread_t *thread, const char *const name, lv_thread_prio_t prio,
-			   void (*callback)(void *), size_t stack_size, void *user_data)
+			   void (*callback)(void *user_data), size_t stack_size, void *user_data)
 {
 	int thread_priority;
 

--- a/modules/openthread/platform/ble.c
+++ b/modules/openthread/platform/ble.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 /* Zephyr Kernel Objects */
 
-static void ot_plat_ble_thread(void *, void *, void *);
+static void ot_plat_ble_thread(void *unused1, void *unused2, void *unused3);
 static uint8_t ot_plat_ble_msg_buf[PLAT_BLE_MSG_DATA_MAX];
 
 static K_SEM_DEFINE(ot_plat_ble_init_semaphore, 0, 1);


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The in-tree glue for LVGL, OpenThread and the Realtek and Bouffalo Lab
HALs declared thread, timer and task entry callbacks with bare types.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
