### PR TITLE
arch: common: name the parameters in function declarations

### DIFF
--- a/arch/common/dynamic_isr.c
+++ b/arch/common/dynamic_isr.c
@@ -9,7 +9,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys/__assert.h>
 
-void __weak z_isr_install(unsigned int irq, void (*routine)(const void *),
+void __weak z_isr_install(unsigned int irq, void (*routine)(const void *parameter),
 			  const void *param)
 {
 	unsigned int table_idx;
@@ -37,7 +37,7 @@ void __weak z_isr_install(unsigned int irq, void (*routine)(const void *),
  */
 int __weak arch_irq_connect_dynamic(unsigned int irq,
 				    unsigned int priority,
-				    void (*routine)(const void *),
+				    void (*routine)(const void *arg),
 				    const void *parameter,
 				    uint32_t flags)
 {

--- a/arch/common/shared_irq.c
+++ b/arch/common/shared_irq.c
@@ -37,7 +37,7 @@ void z_shared_isr(const void *data)
 
 static struct k_spinlock lock;
 
-void z_isr_install(unsigned int irq, void (*routine)(const void *),
+void z_isr_install(unsigned int irq, void (*routine)(const void *parameter),
 		   const void *param)
 {
 	struct z_shared_isr_table_entry *shared_entry;
@@ -157,7 +157,7 @@ int __weak arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 }
 
 int z_isr_uninstall(unsigned int irq,
-		    void (*routine)(const void *),
+		    void (*routine)(const void *arg),
 		    const void *parameter)
 {
 	struct z_shared_isr_table_entry *shared_entry;

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -299,11 +299,11 @@ struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 #define IRQ_TABLE_SIZE (CONFIG_NUM_IRQS - CONFIG_GEN_IRQ_START_VECTOR)
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
-void z_isr_install(unsigned int irq, void (*routine)(const void *),
+void z_isr_install(unsigned int irq, void (*routine)(const void *parameter),
 		   const void *param);
 
 #ifdef CONFIG_SHARED_INTERRUPTS
-int z_isr_uninstall(unsigned int irq, void (*routine)(const void *),
+int z_isr_uninstall(unsigned int irq, void (*routine)(const void *parameter),
 		    const void *param);
 #endif /* CONFIG_SHARED_INTERRUPTS */
 #endif


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
z_isr_install(), z_isr_uninstall() and the generic
arch_irq_connect_dynamic() fallback left the ISR they take unnamed, in
the header and in the definitions.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
