### PR TITLE
Rcar gen5 xen support

### DIFF
--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -6,7 +6,7 @@
 config XEN
 	bool
 	default y
-	depends on ARMV8_A
+	depends on ARMV8_A || ARMV9_A
 	depends on DT_HAS_XEN_XEN_ENABLED
 	select GNU_C_EXTENSIONS
 	help

--- a/snippets/xen-dom0/boards/rcar_ironhide_x5h_r8a78000_a720.conf
+++ b/snippets/xen-dom0/boards/rcar_ironhide_x5h_r8a78000_a720.conf
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Renesas Electronics Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CLOCK_CONTROL=n
+CONFIG_MBOX=n
+CONFIG_ARM_SCMI=n
+
+# Xen starts Dom0 at EL1 Non-secure; configure GIC interrupts as Group 1.
+CONFIG_ARMV8_A_NS=y

--- a/snippets/xen-dom0/boards/rcar_ironhide_x5h_r8a78000_a720.overlay
+++ b/snippets/xen-dom0/boards/rcar_ironhide_x5h_r8a78000_a720.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &ram;
+/delete-node/ &hscif0;
+/delete-node/ &scmi_res0;
+
+#include <mem.h>
+
+&mfis {
+	status = "disabled";
+};
+
+/ {
+	firmware {
+		/delete-node/ scmi;
+	};
+
+	hypervisor: hypervisor@58200000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x58200000 0x0 0x40000
+		       0x0 0x39a00000 0x0 0x6600000>;
+		interrupts = <GIC_PPI 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * Xen Dom0 BANK[0] 0x40000000-0x48000000 (128M); mapped 96M only.
+	 * DTB is at 0x47e00000, outside this node.
+	 */
+	ram: memory@40000000 {
+		device_type = "mmio-sram";
+		reg = <0x0 0x40000000 0x0 DT_SIZE_M(96)>;
+	};
+};

--- a/snippets/xen-dom0/snippet.yml
+++ b/snippets/xen-dom0/snippet.yml
@@ -21,6 +21,10 @@ boards:
   rcar_spider_s4/r8a779f0/a55:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/rcar_spider_s4_r8a779f0_a55.overlay
+  rcar_ironhide_x5h/r8a78000/a720:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/rcar_ironhide_x5h_r8a78000_a720.overlay
+      EXTRA_CONF_FILE: boards/rcar_ironhide_x5h_r8a78000_a720.conf
   rpi_5/bcm2712:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/rpi_5.overlay


### PR DESCRIPTION
Hi everybody,

This series adds support for running Zephyr as Xen Dom0 on the Renesas R-Car X5H platform.
It adds the required Xen configuration, memory layout, interrupt settings, and board-specific device-tree overlay.

Thank you for your time and review. Any feedback is appreciated.