### PR TITLE
drivers: name the parameters in function declarations

### DIFF
--- a/drivers/cache/cache_nxp_lmem_cache.c
+++ b/drivers/cache/cache_nxp_lmem_cache.c
@@ -21,7 +21,7 @@ static inline int cache_data_require_enabled(void)
 }
 
 static int cache_data_manage_range(void *addr, size_t size,
-				   void (*operation)(uint32_t, uint32_t))
+				   void (*operation)(uint32_t addr, uint32_t size))
 {
 	int ret = cache_data_require_enabled();
 
@@ -119,7 +119,7 @@ static inline int cache_instr_require_enabled(void)
 }
 
 static int cache_instr_manage_range(void *addr, size_t size,
-				    void (*operation)(uint32_t, uint32_t))
+				    void (*operation)(uint32_t addr, uint32_t size))
 {
 	int ret = cache_instr_require_enabled();
 

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -210,7 +210,7 @@ static void ht_clean(const struct device *dev)
 }
 
 static int ht_wait_ready(const struct device *dev, uint16_t counts,
-			 int (*is_ready)(const struct device *))
+			 int (*is_ready)(const struct device *dev))
 {
 	const struct xec_pcr_config *drvcfg = dev->config;
 	mem_addr_t ht_base = drvcfg->htmr_base;
@@ -243,7 +243,7 @@ static int ht_wait_ready(const struct device *dev, uint16_t counts,
 }
 
 static int ht_wait_ready_ms(const struct device *dev, uint32_t ms,
-			    int (*is_ready)(const struct device *))
+			    int (*is_ready)(const struct device *dev))
 {
 	int ret = 0;
 	uint16_t ht_counts = 0;

--- a/drivers/comparator/comparator_renesas_rx_lvd.c
+++ b/drivers/comparator/comparator_renesas_rx_lvd.c
@@ -28,7 +28,7 @@ extern void lvd_ch1_isr(void);
 extern void lvd_ch2_isr(void);
 extern void lvd_start_lvd(lvd_channel_t ch, lvd_trigger_t trigger);
 extern void lvd_stop_lvd(lvd_channel_t ch);
-extern void lvd_start_int(lvd_channel_t ch, void (*p_callback)(void *));
+extern void lvd_start_int(lvd_channel_t ch, void (*p_callback)(void *p_args));
 extern void lvd_stop_int(lvd_channel_t ch);
 extern void lvd_hw_enable_reset_int(lvd_channel_t ch, bool enable);
 extern void lvd_hw_enable_reg_protect(bool enable);

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -40,7 +40,7 @@ static struct rv32m1_entropy_config entropy_rv32m1_config = {
 	.base = (TRNG_Type *)DT_INST_REG_ADDR(0)
 };
 
-static int entropy_rv32m1_trng_init(const struct device *);
+static int entropy_rv32m1_trng_init(const struct device *dev);
 
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_rv32m1_trng_init, NULL,

--- a/drivers/ethernet/eth_virtio_net.c
+++ b/drivers/ethernet/eth_virtio_net.c
@@ -114,8 +114,11 @@ struct virtnet_data {
 	uint8_t rxb[CONFIG_ETH_VIRTIO_NET_RX_BUFFERS][VIRTIO_NET_BUFLEN];
 };
 
-static uint16_t virtnet_enum_queues_cb(uint16_t q_index, uint16_t q_size_max, void *)
+static uint16_t virtnet_enum_queues_cb(uint16_t q_index, uint16_t q_size_max, void *priv)
 {
+	ARG_UNUSED(q_size_max);
+	ARG_UNUSED(priv);
+
 	if (q_index % 2 == 0) { /* receiving virtqueue (even-numbered) */
 		return CONFIG_ETH_VIRTIO_NET_RX_BUFFERS;
 	} else {

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -98,12 +98,14 @@ struct i2s_sam_dev_data {
 #define MODULO_INC(val, max) { val = (++val < max) ? val : 0; }
 
 static const struct device *get_dev_from_dma_channel(uint32_t dma_channel);
-static void dma_rx_callback(const struct device *, void *, uint32_t, int);
-static void dma_tx_callback(const struct device *, void *, uint32_t, int);
-static void rx_stream_disable(struct stream *, Ssc *const,
-			      const struct device *);
-static void tx_stream_disable(struct stream *, Ssc *const,
-			      const struct device *);
+static void dma_rx_callback(const struct device *dma_dev, void *user_data,
+			    uint32_t channel, int status);
+static void dma_tx_callback(const struct device *dma_dev, void *user_data,
+			    uint32_t channel, int status);
+static void rx_stream_disable(struct stream *stream, Ssc *ssc,
+			      const struct device *dev_dma);
+static void tx_stream_disable(struct stream *stream, Ssc *ssc,
+			      const struct device *dev_dma);
 
 /*
  * Get data from the queue

--- a/drivers/serial/uart_virtio_console.c
+++ b/drivers/serial/uart_virtio_console.c
@@ -136,8 +136,11 @@ struct virtconsole_data {
 };
 
 /* Return desired size for given virtqueue */
-static uint16_t virtconsole_enum_queues_cb(uint16_t q_index, uint16_t q_size_max, void *)
+static uint16_t virtconsole_enum_queues_cb(uint16_t q_index, uint16_t q_size_max, void *priv)
 {
+	ARG_UNUSED(q_size_max);
+	ARG_UNUSED(priv);
+
 	switch (q_index) {
 #ifdef CONFIG_UART_VIRTIO_CONSOLE_F_MULTIPORT
 	case VIRTQ_CONTROL_RX:
@@ -162,7 +165,8 @@ static void virtconsole_recv_cb(void *priv, uint32_t len)
 }
 
 static void virtconsole_recv_setup(const struct device *dev, uint16_t q_no, void *addr,
-				   uint32_t len, void (*recv_cb)(void *, uint32_t), void *cb_data)
+				   uint32_t len, void (*recv_cb)(void *priv, uint32_t rcv_len),
+				   void *cb_data)
 {
 	if (q_no % 2) {
 		return; /* This should not be called on tx queues (odd-numbered) */


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 requires every parameter in a function type to be
named, including the parameters of function pointer parameters.
The cache, clock control, comparator, entropy, Ethernet, I2S and serial
drivers left callback parameters unnamed, or carried forward
declarations that dropped the names the definitions already use. The two
virtio callbacks get ARG_UNUSED() for the arguments they deliberately
ignore.

Name them after the arguments the documentation or the
definitions already use. No functional change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
