### PR TITLE
kernel: fix leak of memory mapped thread stack on abort

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1453,6 +1453,13 @@ static struct k_spinlock thread_cleanup_lock;
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
 static void *thread_cleanup_stack_addr;
 static size_t thread_cleanup_stack_sz;
+
+static void unmap_thread_stack(void *addr, size_t sz)
+{
+	if (addr != NULL) {
+		k_mem_unmap_phys_guard(addr, sz, false);
+	}
+}
 #endif /* CONFIG_THREAD_STACK_MEM_MAPPED */
 
 void defer_thread_cleanup(struct k_thread *thread)
@@ -1487,21 +1494,42 @@ void defer_thread_cleanup(struct k_thread *thread)
 #endif /* CONFIG_THREAD_STACK_MEM_MAPPED */
 }
 
-void do_thread_cleanup(struct k_thread *thread)
+void do_deferred_thread_cleanup(void)
 {
 	/* Note when adding new actual cleanup steps:
 	 * - The thread object may have been overwritten when this is
-	 *   called. So avoid using any data from the thread object.
+	 *   called. So only data stashed by defer_thread_cleanup() can
+	 *   be used here, never anything from the thread object.
 	 */
-	ARG_UNUSED(thread);
 
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
-	if (thread_cleanup_stack_addr != NULL) {
-		k_mem_unmap_phys_guard(thread_cleanup_stack_addr,
-				       thread_cleanup_stack_sz, false);
+	unmap_thread_stack(thread_cleanup_stack_addr, thread_cleanup_stack_sz);
 
-		thread_cleanup_stack_addr = NULL;
-	}
+	thread_cleanup_stack_addr = NULL;
+	thread_cleanup_stack_sz = 0;
+#endif /* CONFIG_THREAD_STACK_MEM_MAPPED */
+}
+
+void do_thread_cleanup(struct k_thread *thread)
+{
+	/* This is only for threads which are no longer running and are not
+	 * the current thread, so the thread object is still valid here and
+	 * the cleanup can be driven from it directly.
+	 */
+
+#ifdef CONFIG_THREAD_STACK_MEM_MAPPED
+	unmap_thread_stack(thread->stack_info.mapped.addr,
+			   thread->stack_info.mapped.sz);
+
+	/* The stack is now unmapped and thus un-usable. Clear the mapping
+	 * info so nothing looks into the stack afterwards, and so that
+	 * a repeated cleanup of the same thread object is a no-op,
+	 * e.g., z_stack_space_get().
+	 */
+	thread->stack_info.mapped.addr = NULL;
+	thread->stack_info.mapped.sz = 0;
+#else /* CONFIG_THREAD_STACK_MEM_MAPPED */
+	ARG_UNUSED(thread);
 #endif /* CONFIG_THREAD_STACK_MEM_MAPPED */
 }
 
@@ -1510,7 +1538,7 @@ void k_thread_abort_cleanup(struct k_thread *thread)
 	K_SPINLOCK(&thread_cleanup_lock) {
 		if (thread_to_cleanup != NULL) {
 			/* Finish the pending one first. */
-			do_thread_cleanup(thread_to_cleanup);
+			do_deferred_thread_cleanup();
 			thread_to_cleanup = NULL;
 		}
 
@@ -1545,7 +1573,7 @@ void k_thread_abort_cleanup_check_reuse(struct k_thread *thread)
 		 * object can be reused.
 		 */
 		if (thread_to_cleanup == thread) {
-			do_thread_cleanup(thread_to_cleanup);
+			do_deferred_thread_cleanup();
 			thread_to_cleanup = NULL;
 		}
 	}

--- a/tests/kernel/mem_protect/stackprot/src/mapped_stack.c
+++ b/tests/kernel/mem_protect/stackprot/src/mapped_stack.c
@@ -56,6 +56,21 @@ void mapped_thread(void *p1, void *p2, void *p3)
 	ztest_test_fail();
 }
 
+/* Number of create/abort cycles done by test_mapped_stack_abort_reuse().
+ * A leaked mapping is caught within the first two cycles, so this only needs
+ * to be big enough to also cover repeated reuse of the same stack object.
+ */
+#define ABORT_REUSE_CYCLES 32
+
+static void mapped_stack_sleeper(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_sleep(K_FOREVER);
+}
+
 /**
  * @brief To create thread to fault on guard pages.
  *
@@ -147,5 +162,52 @@ ZTEST(stackprot_mapped_stack, test_guard_page_rear_user)
 #endif
 }
 
+/**
+ * @brief Test that aborting a thread releases its mapped stack
+ *
+ * Repeatedly create a thread on the same stack object and abort it from
+ * another thread, which takes the immediate cleanup path in
+ * k_thread_abort_cleanup(). Each cycle must return the virtual address
+ * region of the stack to the pool, so every cycle maps the stack object
+ * at the same address again. If the mapping is leaked instead, the address
+ * walks away from the first one and the address space is eventually
+ * exhausted.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+ZTEST(stackprot_mapped_stack, test_mapped_stack_abort_reuse)
+{
+#ifdef CONFIG_THREAD_STACK_MEM_MAPPED
+	void *first_addr = NULL;
+
+	for (unsigned int i = 0; i < ABORT_REUSE_CYCLES; i++) {
+		k_tid_t tid = k_thread_create(&mapped_thread_data, mapped_thread_stack_area,
+					      STACK_SIZE, mapped_stack_sleeper,
+					      NULL, NULL, NULL,
+					      K_PRIO_COOP(1), 0, K_NO_WAIT);
+		void *addr = mapped_thread_data.stack_info.mapped.addr;
+
+		zassert_not_null(addr, "cycle %u: stack could not be mapped", i);
+
+		if (first_addr == NULL) {
+			first_addr = addr;
+		}
+
+		zassert_equal(addr, first_addr,
+			      "cycle %u: stack mapped at %p, expected %p to be reused",
+			      i, addr, first_addr);
+
+		/* Needed on SMP platforms where the thread runs asynchronously. */
+		k_msleep(1);
+
+		k_thread_abort(tid);
+
+		zassert_is_null(mapped_thread_data.stack_info.mapped.addr,
+				"cycle %u: stack still reported as mapped after abort", i);
+	}
+#else
+	ztest_test_skip();
+#endif
+}
 
 ZTEST_SUITE(stackprot_mapped_stack, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
k_thread_abort() on a thread which is not the current thread takes the
immediate cleanup path in k_thread_abort_cleanup(), which calls
do_thread_cleanup(). That function ignored its thread argument and only
ever unmapped the address stashed in thread_cleanup_stack_addr, which is
populated exclusively by defer_thread_cleanup() on the self-abort path.
The mapped stack of a thread aborted by another thread was therefore
never unmapped, leaking its virtual address region plus the two guard
pages on every create/abort cycle until the virtual address space was
exhausted.

Split the two paths so each releases what it owns:
do_deferred_thread_cleanup() unmaps the stashed region, while
do_thread_cleanup() unmaps the region recorded in the thread object,
which is still valid there as the thread is neither running nor the
current thread. The latter also clears stack_info.mapped so the now
unmapped stack is no longer reachable through e.g.
k_thread_stack_space_get(), and so that a repeated cleanup of the same
thread object is a no-op.

Add a regression test which creates and aborts a thread on the same
stack object 32 times and checks that the stack is released and its
virtual address region reused on every cycle. It fails on the first
cycle without the fix.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #119098