### PR TITLE
net: ethernet: Fix the broadcast destination MAC check

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -188,23 +188,41 @@ static inline bool eth_is_vlan_tag_stripped(struct net_if *iface)
 #if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
 /* Drop packet if it has broadcast destination MAC address but the IP
  * address is not multicast or broadcast address. See RFC 1122 ch 3.3.6
+ *
+ * This runs after the Ethernet header has been pulled off the packet, so the
+ * destination MAC address is read from the link address stored in the packet
+ * and the IPv4 header is fetched through the cursor.
  */
-static inline
-enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt,
-						struct net_eth_hdr *hdr)
+static enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt)
 {
+	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv4_access, struct net_ipv4_hdr);
+	struct net_linkaddr *lladdr = net_pkt_lladdr_dst(pkt);
+	enum net_verdict verdict = NET_OK;
+	struct net_pkt_cursor cur;
+	struct net_ipv4_hdr *hdr;
+
 	if (IS_ENABLED(CONFIG_NET_L2_ETHERNET_ACCEPT_MISMATCH_L3_L2_ADDR)) {
 		return NET_OK;
 	}
 
-	if (net_eth_is_addr_broadcast(&hdr->dst) &&
-	    !(net_ipv4_is_addr_mcast_raw(NET_IPV4_HDR(pkt)->dst) ||
-	      net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt),
-					 NET_IPV4_HDR(pkt)->dst))) {
-		return NET_DROP;
+	if (lladdr->len != sizeof(struct net_eth_addr) ||
+	    !net_eth_is_addr_broadcast((struct net_eth_addr *)lladdr->addr)) {
+		return NET_OK;
 	}
 
-	return NET_OK;
+	net_pkt_cursor_backup(pkt, &cur);
+	net_pkt_cursor_init(pkt);
+
+	hdr = (struct net_ipv4_hdr *)net_pkt_get_data(pkt, &ipv4_access);
+	if (hdr == NULL ||
+	    !(net_ipv4_is_addr_mcast_raw(hdr->dst) ||
+	      net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt), hdr->dst))) {
+		verdict = NET_DROP;
+	}
+
+	net_pkt_cursor_restore(pkt, &cur);
+
+	return verdict;
 }
 #endif
 
@@ -428,9 +446,7 @@ static enum net_verdict ethernet_ip_recv(struct net_if *iface,
 	ARG_UNUSED(iface);
 
 	if (ptype == NET_ETH_PTYPE_IP) {
-		struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
-
-		if (ethernet_check_ipv4_bcast_addr(pkt, hdr) == NET_DROP) {
+		if (ethernet_check_ipv4_bcast_addr(pkt) == NET_DROP) {
 			return NET_DROP;
 		}
 

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -692,4 +692,95 @@ ZTEST(arp_fn_tests, test_arp)
 	}
 }
 
+/* Feed an IPv4 frame to the Ethernet L2 and tell whether it was let through.
+ * The L2 sets the packet family only for a frame that it accepts, so a family
+ * that is still unspecified afterwards means the frame was dropped.
+ */
+static void recv_ipv4_frame(struct net_if *iface,
+			    const struct net_eth_addr *dst_hwaddr,
+			    const uint8_t *dst_ipaddr,
+			    bool expect_accepted)
+{
+	static const struct net_eth_addr peer_hwaddr = {
+		{ 0x00, 0x00, 0x5e, 0x00, 0x53, 0x01 } };
+	static const uint8_t peer_ipaddr[] = { 192, 0, 2, 2 };
+	struct net_ipv4_hdr *ipv4_hdr;
+	struct net_eth_hdr *eth_hdr;
+	struct net_pkt *pkt;
+	int ret;
+
+	pkt = net_pkt_rx_alloc_with_buffer(iface,
+					   sizeof(struct net_eth_hdr) +
+					   sizeof(struct net_ipv4_hdr),
+					   NET_AF_UNSPEC, 0, K_SECONDS(1));
+	zassert_not_null(pkt, "out of mem");
+
+	net_buf_add(pkt->buffer, sizeof(struct net_eth_hdr) +
+		    sizeof(struct net_ipv4_hdr));
+
+	setup_eth_header(iface, pkt, dst_hwaddr, NET_ETH_PTYPE_IP);
+
+	/* setup_eth_header() uses our own address as the source but the frame
+	 * is supposed to come from a peer.
+	 */
+	eth_hdr = (struct net_eth_hdr *)net_pkt_data(pkt);
+	memcpy(&eth_hdr->src.addr, &peer_hwaddr, sizeof(struct net_eth_addr));
+
+	ipv4_hdr = (struct net_ipv4_hdr *)(net_pkt_data(pkt) +
+					   sizeof(struct net_eth_hdr));
+	memset(ipv4_hdr, 0, sizeof(struct net_ipv4_hdr));
+	ipv4_hdr->vhl = 0x45;
+	ipv4_hdr->len = net_htons(sizeof(struct net_ipv4_hdr));
+	ipv4_hdr->ttl = 64;
+	ipv4_hdr->proto = NET_IPPROTO_UDP;
+	net_ipv4_addr_copy_raw(ipv4_hdr->src, peer_ipaddr);
+	net_ipv4_addr_copy_raw(ipv4_hdr->dst, dst_ipaddr);
+
+	/* Hold on to the packet so that the family can still be read after the
+	 * stack is done with it.
+	 */
+	net_pkt_ref(pkt);
+
+	ret = net_recv_data(iface, pkt);
+	zassert_equal(ret, 0, "Cannot receive data (%d)", ret);
+
+	/* Give the RX thread a chance to process the frame. */
+	k_msleep(10);
+
+	if (expect_accepted) {
+		zexpect_equal(net_pkt_family(pkt), NET_AF_INET,
+			      "Frame was dropped by the L2");
+	} else {
+		zexpect_equal(net_pkt_family(pkt), NET_AF_UNSPEC,
+			      "Frame was accepted by the L2");
+	}
+
+	net_pkt_unref(pkt);
+}
+
+/* RFC 1122 ch 3.3.6: a frame sent to the broadcast link layer address must not
+ * carry a unicast IPv4 destination address.
+ */
+ZTEST(arp_fn_tests, test_bcast_hwaddr_unicast_ipaddr)
+{
+	static const uint8_t unicast_ipaddr[] = { 192, 0, 2, 1 };
+	static const uint8_t bcast_ipaddr[] = { 255, 255, 255, 255 };
+	struct net_if *iface = net_if_get_first_by_type(
+					&NET_L2_GET_NAME(ETHERNET));
+
+	zassert_not_null(iface, "No Ethernet interface");
+
+	/* The mismatching frame must be dropped. */
+	recv_ipv4_frame(iface, net_eth_broadcast_addr(), unicast_ipaddr, false);
+
+	/* A broadcast IPv4 destination matches the broadcast MAC address, and
+	 * a unicast IPv4 destination matches our own MAC address, so both of
+	 * these must be accepted.
+	 */
+	recv_ipv4_frame(iface, net_eth_broadcast_addr(), bcast_ipaddr, true);
+	recv_ipv4_frame(iface,
+			(struct net_eth_addr *)net_if_get_link_addr(iface)->addr,
+			unicast_ipaddr, true);
+}
+
 ZTEST_SUITE(arp_fn_tests, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
RFC 1122 ch 3.3.6 says that a frame sent to the broadcast link layer
address must not carry a unicast IPv4 destination address, and
ethernet_check_ipv4_bcast_addr() is supposed to drop such a frame. The
check stopped working when the IPv4 handling was moved behind the
NET_L3_REGISTER() mechanism in commit "net: Extend the protocol handling in Ethernet".
