### PR TITLE
tests: drivers: spi: spi_loopback: ship the loopback contract as a fixture

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/96b_carbon_stm32f401xe.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/96b_carbon_stm32f401xe.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi2 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/96b_stm32_sensor_mez.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/96b_stm32_sensor_mez.overlay
@@ -4,18 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi4 {
+spi_loopback: &spi4 {
 	cs-gpios = <&gpioe 11 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/adafruit_itsybitsy_m4_express.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/adafruit_itsybitsy_m4_express.overlay
@@ -4,18 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&sercom1 {
+spi_loopback: &sercom1 {
 	cs-gpios = <&porta 7 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/adp_xc7k_ae350.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/adp_xc7k_ae350.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/adp_xc7k_ae350_clic.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/adp_xc7k_ae350_clic.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/aik_ra8d1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/aik_ra8d1.overlay
@@ -4,18 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&pmod5_spi {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &pmod5_spi {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/aik_ra8d1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/aik_ra8d1_sci_b_spi.overlay
@@ -8,18 +8,11 @@
  * To run this test on AIK-RA8D1 board on PMOD 1, set S4-1 to UART/SPI position.
  */
 
-&pmod1_spi {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &pmod1_spi {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/am243x_evm_am2434_r5f0_0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/am243x_evm_am2434_r5f0_0.overlay
@@ -6,16 +6,9 @@
 
 #include <freq.h>
 
-&main_mcspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_K(500)>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_K(500)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(50)
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(50)>;
-	};
-};
+spi_loopback: &main_mcspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/apard32690_max32690_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/apard32690_max32690_m4.overlay
@@ -8,21 +8,14 @@
 	status = "okay";
 };
 
-arduino_spi: &spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	status = "okay";
 
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/arduino_uno_r4_r7fa4m1ab3cfm_minima.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/arduino_uno_r4_r7fa4m1ab3cfm_minima.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/arduino_uno_r4_r7fa4m1ab3cfm_wifi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/arduino_uno_r4_r7fa4m1ab3cfm_wifi.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/arduino_zero.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/arduino_zero.overlay
@@ -4,18 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&sercom4 {
+spi_loopback: &sercom4 {
 	cs-gpios = <&porta 3 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/arty_a7_designstart_fpga_cortex_m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/arty_a7_designstart_fpga_cortex_m1.overlay
@@ -4,18 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&daplink_single_spi0 {
+spi_loopback: &daplink_single_spi0 {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
@@ -8,21 +8,11 @@
 	apb2-prescaler = <2>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	st,fifo-threshold = <8>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/bg29_rb4420a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/bg29_rb4420a.overlay
@@ -10,7 +10,10 @@
  * Connect EXP4 (PC0) and EXP6 (PC1) of the Expansion Pin header
  */
 
-&eusart1 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &eusart1 {
 	dmas = <&dma0 DMA_REQSEL_EUSART1TXFL>,
 	       <&dma0 DMA_REQSEL_EUSART1RXFL>;
 	dma-names = "tx", "rx";
@@ -20,20 +23,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <10000000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -30,27 +30,20 @@
 
 /delete-node/ &mx25r64;
 
-&spi00 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(2)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi00 {
 	status = "okay";
 	pinctrl-0 = <&spi00_default>;
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(2)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
 
 &gpio2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -30,27 +30,20 @@
 
 /delete-node/ &mx25r64;
 
-&spi00 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(2)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi00 {
 	status = "okay";
 	pinctrl-0 = <&spi00_default>;
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(2)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
 
 &gpio2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/cc1352r1_launchxl.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/cc1352r1_launchxl.overlay
@@ -4,16 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/cy8ckit_041s_max.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/cy8ckit_041s_max.overlay
@@ -5,27 +5,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-spi: &scb1 {
+#define SPI_LOOPBACK_FAST_HZ 1000000
+
+spi_loopback: &scb1 {
 	compatible = "infineon,spi";
 	status = "okay";
 
 	pinctrl-0 = <&p2_0_scb1_spi_m_mosi &p2_1_scb1_spi_m_miso &p2_2_scb1_spi_m_clk>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio_prt2 3 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
 };
 
 &gpio_prt2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/cy8cproto_041tp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/cy8cproto_041tp.overlay
@@ -36,18 +36,11 @@ spi1: &scb1 {
 	status = "okay";
 };
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/cy8cproto_062_4343w.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/cy8cproto_062_4343w.overlay
@@ -1,22 +1,19 @@
-spi1: &scb3 {
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &scb3 {
 	compatible = "infineon,spi";
 	status = "okay";
 
 	pinctrl-0 = <&p6_0_scb3_spi_m_mosi &p6_1_scb3_spi_m_miso &p6_2_scb3_spi_m_clk>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio_prt6 3 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
 
 &gpio_prt6 {
@@ -40,3 +37,5 @@ spi1: &scb3 {
 		drive-push-pull;
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/cy8cproto_063_ble.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/cy8cproto_063_ble.overlay
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &pinctrl {
 	/* Configure pin control bias mode for SPI pins (MASTER) */
 	p10_0_scb1_spi_m_mosi: p10_0_scb1_spi_m_mosi {
@@ -16,27 +22,20 @@
 	};
 };
 
-spi: &scb1 {
+#define SPI_LOOPBACK_SLOW_HZ 200000
+#define SPI_LOOPBACK_FAST_HZ 1500000
+
+spi_loopback: &scb1 {
 	compatible = "infineon,spi";
 	status = "okay";
 
 	pinctrl-0 = <&p10_0_scb1_spi_m_mosi &p10_1_scb1_spi_m_miso &p10_2_scb1_spi_m_clk>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio_prt10 3 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <200000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <1500000>;
-	};
 };
 
 &gpio_prt10 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/disco_l475_iot1.overlay
@@ -4,21 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma1 3 1 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dma1 2 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra2a1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra2a1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra2l1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra2l1.overlay
@@ -1,24 +1,10 @@
 /*
- * Copyright (c) 2025 Renesas Electronics Corporation
+ * Copyright (c) 2024 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	rx-dtc;
-	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
 &pinctrl {
 	spi0_default: spi0_default {
@@ -31,7 +17,9 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
+	rx-dtc;
+	tx-dtc;
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&ioport1 3 GPIO_ACTIVE_LOW>;
@@ -43,3 +31,5 @@
 &ioport1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4c1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4c1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4e2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4e2.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4l1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4l1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4m1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4m2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4m2.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4m3.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4m3.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4w1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4w1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra6e2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra6e2.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra6m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra6m1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra6m2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra6m2.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra6m3.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra6m3.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra6m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra6m4.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra6m5.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra6m5.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8d1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8d1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8d1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8d1_sci_b_spi.overlay
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 2500000
+
 &pinctrl {
 	sci3_spi_default: sci3_spi_default {
 		group1 {
@@ -19,20 +22,8 @@
 	pinctrl-0 = <&sci3_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi_loopback: spi {
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <1000000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <2500000>;
-		};
 	};
 
 	uart {
@@ -43,3 +34,5 @@
 		status = "disabled";
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8d2_r7ka8d2kflcac_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8d2_r7ka8d2kflcac_cm33.overlay
@@ -3,20 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8d2_r7ka8d2kflcac_cm85.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8d2_r7ka8d2kflcac_cm85.overlay
@@ -3,20 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8m1.overlay
@@ -17,22 +17,15 @@
 	};
 };
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8m1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8m1_sci_b_spi.overlay
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 2500000
+
 &pinctrl {
 	sci2_spi_default: sci2_spi_default {
 		group1 {
@@ -19,20 +22,8 @@
 	pinctrl-0 = <&sci2_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi_loopback: spi {
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <1000000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <2500000>;
-		};
 	};
 
 	uart {
@@ -43,3 +34,5 @@
 		status = "disabled";
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8m2_r7ka8m2jflcac_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8m2_r7ka8m2jflcac_cm33.overlay
@@ -5,20 +5,13 @@
 
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8m2_r7ka8m2jflcac_cm85.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8m2_r7ka8m2jflcac_cm85.overlay
@@ -5,20 +5,13 @@
 
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
@@ -5,19 +5,12 @@
 
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -5,19 +5,12 @@
 
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8p1_r7ka8p1kflcac_cm85_sci_b_spi.overlay
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 2500000
+
 &pinctrl {
 	sci7_spi_default: sci7_spi_default {
 		group1 {
@@ -22,20 +25,8 @@
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 
-	spi {
+	spi_loopback: spi {
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <1000000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <2500000>;
-		};
 	};
 
 	uart {
@@ -46,3 +37,5 @@
 		status = "disabled";
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm33.overlay
@@ -5,20 +5,13 @@
 
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85.overlay
@@ -5,19 +5,12 @@
 
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 2500000
+
 &pinctrl {
 	sci4_spi_default: sci4_spi_default {
 		group1 {
@@ -22,20 +25,8 @@
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 
-	spi {
+	spi_loopback: spi {
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <1000000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <2500000>;
-		};
 	};
 
 	uart {
@@ -46,3 +37,5 @@
 		status = "disabled";
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ek_rx261.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_rx261.overlay
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&rspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+spi_loopback: &rspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/em_starterkit_emsk_em9d.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/em_starterkit_emsk_em9d.overlay
@@ -4,16 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 2500000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <2500000>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/emsdp_emsdp_em11d.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/emsdp_emsdp_em11d.overlay
@@ -4,16 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-};
+spi_loopback: &spi1 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/fpb_ra4e1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_ra4e1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_ra6e1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi1 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_ra6e2.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1.overlay
@@ -17,22 +17,15 @@
 	};
 };
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_ra8e1_sci_b_spi.overlay
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 2500000
+
 &pinctrl {
 	sci0_spi_default: sci0_spi_default {
 		group1 {
@@ -20,20 +23,8 @@
 	pinctrl-0 = <&sci0_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi_loopback: spi {
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <1000000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <2500000>;
-		};
 	};
 
 	uart {
@@ -44,3 +35,5 @@
 		status = "disabled";
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/fpb_rx140.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_rx140.overlay
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&rspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+spi_loopback: &rspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/fpb_rx261.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_rx261.overlay
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&rspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+spi_loopback: &rspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_flexio_spi.overlay
@@ -25,7 +25,7 @@
 &flexio2 {
 	status = "okay";
 
-	flexio2_spi: flexio2_spi {
+	spi_loopback: flexio2_spi: flexio2_spi {
 		compatible = "nxp,flexio-spi";
 		cs-gpios = <&gpio4 16 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
@@ -36,17 +36,7 @@
 		pinctrl-0 = <&pinmux_flexio2_spi>;
 		pinctrl-names = "default";
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <500000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <16000000>;
-		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -6,20 +6,10 @@
 
 /* To test this sample, connect J3-14 (LPSPI2_SOUT) <-> J3-16 (LPSPI2_SIN) */
 
-&lpspi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi2 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -6,20 +6,10 @@
 
 /* To test this sample, connect J3-14 (LPSPI2_SOUT) <-> J3-16 (LPSPI2_SIN) */
 
-&lpspi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi2 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_k64f.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_k64f.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_ke17z.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_ke17z.overlay
@@ -8,16 +8,8 @@
  * LPSPI0 SIN(J2-10)  -->  LPSPI0 SOUT(J2-8)
  */
 
-&lpspi0 {
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_REG 1
 
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <16000000>;
-	};
-};
+spi_loopback: &lpspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_ke17z512.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_ke17z512.overlay
@@ -8,16 +8,8 @@
  * LPSPI0 SIN(J2-10)  -->  LPSPI0 SOUT(J2-8)
  */
 
-&lpspi0 {
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_REG 2
 
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <16000000>;
-	};
-};
+spi_loopback: &lpspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_ke1xz_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_ke1xz_flexio_spi.overlay
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_FAST_HZ 4000000
 /* To test this sample, connect
  * SDO(J2-3)  -->  SDI(J2-4)
  */
@@ -24,7 +25,7 @@
 &flexio {
 	status = "okay";
 
-	flexio_spi0: flexio_spi0 {
+	spi_loopback: flexio_spi0: flexio_spi0 {
 		compatible = "nxp,flexio-spi";
 		status = "okay";
 		#address-cells = <1>;
@@ -35,22 +36,11 @@
 		sck-pin = <4>;
 		pinctrl-0 = <&pinmux_flexio_spi0>;
 		pinctrl-names = "default";
-
-		slow@0 {
-			status = "okay";
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <500000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <4000000>;
-		};
 	};
 };
 
 &gpioa {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_kl25z.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_kl25z.overlay
@@ -8,16 +8,8 @@
  * spi0 MOSI (J1-11, PTC6) --> spi0 MISO (J1-1, PTC7)
  */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_FAST_HZ 10000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_kw41z.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_kw41z.overlay
@@ -4,16 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <5000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 5000
+#define SPI_LOOPBACK_FAST_HZ 160000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <160000>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxa153.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI0 MOSI(J6-6, P1_0/LPSPI0_SDO)     -->        LPSPI0 MISO(J6-5, P1_2/LPSPI0_SDI)
  */
-&lpspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxa156.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxa156.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI0 MOSI(J6-6, P1_0/LPSPI0_SDO)     -->        LPSPI0 MISO(J6-5, P1_2/LPSPI0_SDI)
  */
-&lpspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxa266.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxa266.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI0 MOSI(J6-6, P1_0/LPSPI0_SDO)     -->        LPSPI0 MISO(J6-5, P1_2/LPSPI0_SDI)
  */
-&lpspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxa344.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxa344.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI1 MOSI(J2-8, P3_8/LPSPI1_SDO)     -->        LPSPI0 MISO(J2-10, P3_9/LPSPI1_SDI)
  */
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxa346.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxa346.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI0 MOSI(J6-6, P1_0/LPSPI0_SDO)     -->        LPSPI0 MISO(J6-5, P1_2/LPSPI0_SDI)
  */
-&lpspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxa366.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxa366.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI0 MOSI(J6-6, P1_0/LPSPI0_SDO)     -->        LPSPI0 MISO(J6-5, P1_2/LPSPI0_SDI)
  */
-&lpspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxa577.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxa577.overlay
@@ -7,16 +7,9 @@
 /* To test this sample, connect
  * LPSPI0 MOSI(J6-6, P4_4/LPSPI2_SDO)     -->        LPSPI0 MISO(J6-5, P4_5/LPSPI2_SDI)
  */
-&lpspi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <6000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 6000000
+#define SPI_LOOPBACK_FAST_HZ 12000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <12000000>;
-	};
-};
+spi_loopback: &lpspi2 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxe247.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxe247.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI1 MOSI(J2-8, LPSPI1_SOUT)     -->        LPSPI1 MISO(J2-10, LPSPI1_SIN)
  */
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxe31b.overlay
@@ -7,19 +7,13 @@
  * LPSPI0 MOSI (J2-8, D11, PTE2 LPSPI0_SOUT)
  * --> LPSPI0 MISO (J2-10, D12, PTE0 LPSPI0_SIN)
  */
-&lpspi_0 {
+
+#define SPI_LOOPBACK_FAST_HZ 4000000
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &lpspi_0 {
 	/* Guarantee SOUT data setup before the first capture edge in CPHA=0 */
 	pcs-sck-delay = <1000>;
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <4000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxe31b_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxe31b_flexio_spi.overlay
@@ -9,13 +9,15 @@
  * This is the same jumper as the LPSPI0 loopback (frdm_mcxe31b.overlay).
  */
 
+#define SPI_LOOPBACK_FAST_HZ 4000000
+
 /* FlexIO reuses the Arduino SPI pads, so LPSPI0 must release them. */
 &lpspi_0 {
 	status = "disabled";
 };
 
 &flexio {
-	flexio_spi: flexio_spi {
+	spi_loopback: flexio_spi: flexio_spi {
 		compatible = "nxp,flexio-spi";
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -26,21 +28,11 @@
 		pinctrl-0 = <&pinmux_flexio_spi>;
 		pinctrl-names = "default";
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <500000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <4000000>;
-		};
 	};
 };
 
 &gpioe_l {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxn236.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxn236.overlay
@@ -7,16 +7,6 @@
 /* To test this sample, connect
  * LPSPI3 MOSI(J2-8, P1_0/FC3_P0)     -->        LPSPI3 MISO(J2-10, P1_2/FC3_P2)
  */
-&flexcomm3_lpspi3 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm3_lpspi3 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -4,19 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&flexcomm1_lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &flexcomm1_lpspi1 {
 	transfer-delay = <100>;
 	sck-pcs-delay = <200>;
 	pcs-sck-delay = <200>;
@@ -25,3 +13,5 @@
 &flexcomm1 {
 	interrupts = <36 1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
@@ -5,16 +5,6 @@
  */
 
 /* Connect J2-10 and J2-8 */
-&flexcomm1_lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm1_lpspi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxw23.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxw23.overlay
@@ -5,16 +5,6 @@
  */
 
 /* Connect J2 pins 6-7 */
-&flexcomm2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm2 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxw71.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxw71.overlay
@@ -1,25 +1,24 @@
 /*
- * Copyright 2023 NXP
+ * Copyright (c) 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
+spi_loopback: &lpspi1 {
+	/* CS timing props kept here; the slow/fast devices are provided by the
+	 * spi-loopback snippet and merged onto these nodes.
+	 */
 	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		spi-interframe-delay-ns = <1000>;
 	};
 
 	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
 		spi-cs-setup-delay-ns = <200>;
 		spi-cs-hold-delay-ns = <200>;
 		spi-interframe-delay-ns = <100>;
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxw72.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxw72.overlay
@@ -8,16 +8,6 @@
  * This is a loopback setup for the frdm_mcxw72
  * To test this sample, connect J2.6 <-> J2.7
  */
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/frdm_rw612.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_rw612.overlay
@@ -5,16 +5,6 @@
  */
 
 /* Short MOSI and MISO externally using header J1 pins 2 and 4 */
-&flexcomm1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32f403z_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f403z_eval.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma0 1 0>, <&dma0 2 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32f407v_start.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f407v_start.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma1 0 3 0 0>, <&dma1 5 3 0 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32f450i_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f450i_eval.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma1 0 3 0 0>, <&dma1 5 3 0 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32f450v_start.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f450v_start.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma1 0 3 0 0>, <&dma1 5 3 0 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32f450z_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f450z_eval.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma1 0 3 0 0>, <&dma1 5 3 0 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32f470i_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f470i_eval.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma1 0 3 0 0>, <&dma1 5 3 0 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32vf103c_starter.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32vf103c_starter.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma0 1 0>, <&dma0 2 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/gd32vf103v_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32vf103v_eval.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma0 1 0>, <&dma0 2 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7.overlay
@@ -25,20 +25,10 @@
 	};
 };
 
-&ecspi1 {
+spi_loopback: &ecspi1 {
 	status = "okay";
 	pinctrl-0 = <&ecspi1_default>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7_ddr.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7_ddr.overlay
@@ -25,20 +25,10 @@
 	};
 };
 
-&ecspi1 {
+spi_loopback: &ecspi1 {
 	status = "okay";
 	pinctrl-0 = <&ecspi1_default>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/imx943_evk_mimx94398_a55.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/imx943_evk_mimx94398_a55.overlay
@@ -8,20 +8,12 @@
  * LPSPI3 MOSI(J47-8) --> LPSPI3 MISO(J47-10)
  */
 
-&lpspi3 {
+#define SPI_LOOPBACK_FAST_HZ 1000000
+
+spi_loopback: &lpspi3 {
 	status = "okay";
 	pinctrl-0 = <&lpspi3_default>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <1000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/imx95_evk_mimx9596_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/imx95_evk_mimx9596_m7.overlay
@@ -4,16 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_FAST_HZ 1000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
-};
+spi_loopback: &lpspi1 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/intel_adl_crb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/intel_adl_crb.overlay
@@ -6,16 +6,6 @@
 
 /* External Loopback: Short MOSI & MISO */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/intel_btl_s_crb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/intel_btl_s_crb.overlay
@@ -10,20 +10,10 @@
 	status = "okay";
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	pw,cs-mode = <0>;
 	pw,cs-output = <0>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/intel_nvl_s_rvp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/intel_nvl_s_rvp.overlay
@@ -4,24 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+spi_loopback: &spi0 {
 	pw,cs-mode = <0>;
 	pw,cs-output = <0>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpio_i {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/intel_rpl_p_crb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/intel_rpl_p_crb.overlay
@@ -6,20 +6,10 @@
 
 /* External Loopback: Short MOSI & MISO  */
 
-&spi0 {
+spi_loopback: &spi0 {
 	pw,cs-mode = <0>;
 	pw,cs-output = <0>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/intel_rpl_s_crb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/intel_rpl_s_crb.overlay
@@ -6,20 +6,10 @@
 
 /* External Loopback: Short MOSI (J7H4.3) & MISO (J7H4.5) */
 
-&spi0 {
+spi_loopback: &spi0 {
 	pw,cs-mode = <0>;
 	pw,cs-output = <0>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/intel_wcl_crb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/intel_wcl_crb.overlay
@@ -4,24 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+spi_loopback: &spi0 {
 	pw,cs-mode = <0>;
 	pw,cs-output = <0>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpio_e {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_psc3m5_evk.overlay
@@ -5,7 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-spi1: &scb4 {
+#define SPI_LOOPBACK_SLOW_HZ 3000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &scb4 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	compatible = "infineon,spi";
@@ -16,18 +19,6 @@ spi1: &scb4 {
 	cs-gpios = <&gpio_prt4 3 GPIO_ACTIVE_LOW>;
 
 	clocks = <&peri0_group4_16bit_0>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
 
 &gpio_prt4 {
@@ -52,3 +43,5 @@ spi1: &scb4 {
 &peri0_group4_16bit_0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_ai_common.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_ai_common.overlay
@@ -5,7 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-spi1: &scb10 {
+#define SPI_LOOPBACK_SLOW_HZ 3000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &scb10 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	compatible = "infineon,spi";
@@ -16,18 +19,6 @@ spi1: &scb10 {
 	cs-gpios = <&gpio_prt16 3 GPIO_ACTIVE_LOW>;
 
 	clocks = <&peri0_group1_16bit_2>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
 
 &peri0_group1_16bit_2 {
@@ -48,3 +39,5 @@ spi1: &scb10 {
 	drive-strength = "full";
 	drive-push-pull;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
@@ -5,7 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-spi1: &scb10 {
+#define SPI_LOOPBACK_SLOW_HZ 3000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &scb10 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	compatible = "infineon,spi";
@@ -16,18 +19,6 @@ spi1: &scb10 {
 	cs-gpios = <&gpio_prt16 3 GPIO_ACTIVE_LOW>;
 
 	clocks = <&peri0_group1_16bit_2>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 
 	dmas = <&dma0 0>, <&dma0 1>;
 	dma-names = "tx", "rx";
@@ -55,3 +46,5 @@ spi1: &scb10 {
 &dma0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/longan_nano.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/longan_nano.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma0 1 0>, <&dma0 2 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/longan_nano_gd32vf103_lite.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/longan_nano_gd32vf103_lite.overlay
@@ -19,7 +19,7 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
@@ -28,16 +28,6 @@
 
 	dmas = <&dma0 1 0>, <&dma0 2 0>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/lp_am243_am2434_r5f0_0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lp_am243_am2434_r5f0_0.overlay
@@ -7,6 +7,11 @@
 
 #include <freq.h>
 
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_K(500)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(50)
+/* CS1 is used so it's observable with a logic analyzer */
+#define SPI_LOOPBACK_REG 1
+
 &main_pinctrl {
 	spi0_cs1: spi0_cs1_default {
 		pinmux = <K3_PINMUX(0x20c, PIN_OUTPUT_PULLUP, MUX_MODE_0)>;
@@ -27,22 +32,11 @@
 	status = "okay";
 };
 
-/* CS1 is used so it's observable with a logic analyzer */
-&main_mcspi0 {
+spi_loopback: &main_mcspi0 {
 	pinctrl-0 = <&spi0_clk &spi0_cs1 &spi0_d0 &spi0_d1>;
 	pinctrl-names = "default";
 
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <DT_FREQ_K(500)>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <DT_FREQ_M(50)>;
-	};
-
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/lp_em_cc2340r5.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lp_em_cc2340r5.overlay
@@ -4,16 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3507.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3507.overlay
@@ -4,22 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 8000000
+
+spi_loopback: &spi0 {
 	cs-gpios = <&gpioa 6 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <8000000>;
-	};
 };
 
 &gpioa {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3519.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lp_mspm0g3519.overlay
@@ -4,16 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_FAST_HZ 8000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <8000000>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/lpcxpresso54114_lpc54114_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lpcxpresso54114_lpc54114_m4.overlay
@@ -4,16 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&flexcomm5 {
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_REG 2
 
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <16000000>;
-	};
-};
+spi_loopback: &flexcomm5 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/lpcxpresso55s16.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lpcxpresso55s16.overlay
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&hs_lspi {
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <5000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 5000
+#define SPI_LOOPBACK_FAST_HZ 160000
+#define SPI_LOOPBACK_REG 1
 
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <160000>;
-	};
-};
+spi_loopback: &hs_lspi {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
@@ -4,18 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&hs_lspi {
+#define SPI_LOOPBACK_SLOW_HZ 5000
+#define SPI_LOOPBACK_FAST_HZ 160000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &hs_lspi {
 	/delete-property/ cs-gpios;
-
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <5000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <160000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32650evkit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32650evkit.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi2 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI2_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI2_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32650fthr.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32650fthr.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32651evkit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32651evkit.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi2 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI2_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI2_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32655evkit_max32655_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32655evkit_max32655_m4.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi0 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32655fthr_max32655_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32655fthr_max32655_m4.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657.overlay
@@ -8,22 +8,14 @@
 	status = "okay";
 };
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &spi0 {
 	zephyr,pm-device-runtime-auto;
 	dmas = <&dma1 1 MAX32_DMA_SLOT_SPI_TX>, <&dma1 2 MAX32_DMA_SLOT_SPI_RX>;
 	dma-names = "tx", "rx";
-
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <500000>;
-	};
 };
 
 /*
@@ -34,3 +26,5 @@
 &sram0 {
 	adi,ram-bank-retained;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657_ns.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657_ns.overlay
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <128000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+#define SPI_LOOPBACK_REG 1
 
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <500000>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32658evkit_max32658.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32658evkit_max32658.overlay
@@ -8,22 +8,14 @@
 	status = "okay";
 };
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &spi0 {
 	zephyr,pm-device-runtime-auto;
 	dmas = <&dma1 1 MAX32_DMA_SLOT_SPI_TX>, <&dma1 2 MAX32_DMA_SLOT_SPI_RX>;
 	dma-names = "tx", "rx";
-
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <500000>;
-	};
 };
 
 /*
@@ -34,3 +26,5 @@
 &sram0 {
 	adi,ram-bank-retained;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32662evkit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32662evkit.overlay
@@ -9,19 +9,12 @@
 	reg = <20008000 DT_SIZE_K(32)>;
 };
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi0 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32666fthr_max32666_cpu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32666fthr_max32666_cpu0.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 150000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <150000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32670evkit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32670evkit.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi0 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32672evkit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32672evkit.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32672fthr.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32672fthr.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32675evkit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32675evkit.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 125000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI1_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI1_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <125000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32680evkit_max32680_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32680evkit_max32680_m4.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi0 {
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_m4.overlay
@@ -4,20 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 125000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi0 {
 	cs-gpios = <&gpio2 26 GPIO_ACTIVE_LOW>;
 	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <125000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_rv32.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_rv32.overlay
@@ -4,21 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 125000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0b_mosi_p2_28 &spi0b_miso_p2_27 &spi0b_sck_p2_29 &spi0b_ss1_p2_26>;
 	cs-gpios = <&gpio2 26 GPIO_ACTIVE_LOW>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <125000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max78000fthr_max78000_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max78000fthr_max78000_m4.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 128000
+#define SPI_LOOPBACK_FAST_HZ 400000
+
+spi_loopback: &spi0 {
 	dmas = <&dma0 1 MAX78_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX78_DMA_SLOT_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <128000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <400000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/max78002evkit_max78002_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max78002evkit_max78002_m4.overlay
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 125000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi0 {
 	dmas = <&dma0 1 MAX78_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX78_DMA_SLOT_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <125000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra4t1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra4t1.overlay
@@ -3,20 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t1.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t1_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t1_sci_b_spi.overlay
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 2500000
+
 &pinctrl {
 	sci0_spi_default: sci0_spi_default {
 		group1 {
@@ -19,20 +22,8 @@
 	pinctrl-0 = <&sci0_spi_default>;
 	pinctrl-names = "default";
 
-	spi {
+	spi_loopback: spi {
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <1000000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <2500000>;
-		};
 	};
 
 	uart {
@@ -43,3 +34,5 @@
 		status = "disabled";
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm33.overlay
@@ -3,20 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm85.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm85.overlay
@@ -3,19 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_SLOW_HZ 2000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
+
+spi_loopback: &spi0 {
 	rx-dtc;
 	tx-dtc;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <2000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mck_ra8t2_r7ka8t2lflcac_cm85_sci_b_spi.overlay
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 2500000
+
 &pinctrl {
 	sci7_spi_default: sci7_spi_default {
 		group1 {
@@ -22,20 +25,8 @@
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 
-	spi {
+	spi_loopback: spi {
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <1000000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <2500000>;
-		};
 	};
 
 	uart {
@@ -46,3 +37,5 @@
 		status = "disabled";
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -5,16 +5,6 @@
  */
 
 /* Connect J2-10 and J2-8 */
-&flexcomm1_lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm1_lpspi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
@@ -5,16 +5,6 @@
  */
 
 /* Connect J2-10 and J2-8 */
-&flexcomm1_lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm1_lpspi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mcxw23_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mcxw23_evk.overlay
@@ -5,16 +5,6 @@
  */
 
 /* Connect J21 pins 3-4 */
-&flexcomm2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm2 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mcxw72_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mcxw72_evk.overlay
@@ -1,25 +1,24 @@
 /*
- * Copyright 2024 NXP
+ * Copyright (c) 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
+spi_loopback: &lpspi1 {
+	/* CS timing props kept here; the slow/fast devices are provided by the
+	 * spi-loopback snippet and merged onto these nodes.
+	 */
 	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		spi-interframe-delay-ns = <1000>;
 	};
 
 	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
 		spi-cs-setup-delay-ns = <200>;
 		spi-cs-hold-delay-ns = <200>;
 		spi-interframe-delay-ns = <100>;
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mec172xevb_assy6906.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec172xevb_assy6906.overlay
@@ -10,20 +10,10 @@
 	};
 };
 
-&qspi0 {
+spi_loopback: &qspi0 {
 	status = "okay";
 	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qlj.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qlj.overlay
@@ -11,7 +11,7 @@
 
 /* Loopback requires wire connecting qspi_shd_io0_gpio223 to qspi_shd_io1_gpio224 */
 
-&qspi0 {
+spi_loopback: &qspi0 {
 	status = "okay";
 	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
@@ -19,16 +19,6 @@
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056
 		     &qspi_shd_io0_gpio223 &qspi_shd_io1_gpio224>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qsz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qsz.overlay
@@ -11,7 +11,7 @@
 
 /* Loopback requires wire connecting qspi_shd_io0_gpio223 to qspi_shd_io1_gpio224 */
 
-&qspi0 {
+spi_loopback: &qspi0 {
 	status = "okay";
 	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
@@ -19,16 +19,6 @@
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056
 		     &qspi_shd_io0_gpio223 &qspi_shd_io1_gpio224>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qlj.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qlj.overlay
@@ -11,7 +11,7 @@
 
 /* Loopback requires wire connecting qspi_shd_io0_gpio223 to qspi_shd_io1_gpio224 */
 
-&qspi0 {
+spi_loopback: &qspi0 {
 	status = "okay";
 	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
@@ -19,16 +19,6 @@
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056
 		     &qspi_shd_io0_gpio223 &qspi_shd_io1_gpio224>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qsz.overlay
@@ -11,7 +11,7 @@
 
 /* Loopback requires wire connecting qspi_shd_io0_gpio223 to qspi_shd_io1_gpio224 */
 
-&qspi0 {
+spi_loopback: &qspi0 {
 	status = "okay";
 	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
@@ -19,16 +19,6 @@
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056
 		     &qspi_shd_io0_gpio223 &qspi_shd_io1_gpio224>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimx8mm_phyboard_polis_mimx8mm6_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimx8mm_phyboard_polis_mimx8mm6_m4.overlay
@@ -4,20 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&ecspi1 {
+spi_loopback: &ecspi1 {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpio2 {
@@ -27,3 +15,5 @@
 &gpio5 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk_flexio_spi.overlay
@@ -36,7 +36,7 @@
 &flexio3 {
 	status = "okay";
 
-	flexio3_spi0: flexio3_spi0 {
+	spi_loopback: flexio3_spi0: flexio3_spi0 {
 		compatible = "nxp,flexio-spi";
 		status = "okay";
 		#address-cells = <1>;
@@ -81,3 +81,5 @@
 &lpspi3 {
 	status = "disabled";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -1,28 +1,24 @@
 /*
- * Copyright (c) 2022 Kumar Gala <galak@kernel.org>
+ * Copyright (c) 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
+spi_loopback: &lpspi1 {
+	transfer-delay = <100>;
+	sck-pcs-delay = <200>;
+	pcs-sck-delay = <200>;
+
 	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		spi-interframe-delay-ns = <1000>;
 	};
 
 	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
 		spi-cs-setup-delay-ns = <100>;
 		spi-cs-hold-delay-ns = <100>;
 	};
-
-	transfer-delay = <100>;
-	sck-pcs-delay = <200>;
-	pcs-sck-delay = <200>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -5,20 +5,10 @@
  */
 
 /* Short J17-pin4 and J17-pin5, populate R356, R350,R346, R362 to enable Pins for SPI1. */
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -5,23 +5,13 @@
  */
 
 /* Short J10-pin8 and J10-pin10. */
-&lpspi1 {
+spi_loopback: &lpspi1 {
 	dmas = <&edma0 0 36>, <&edma0 1 37>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi1 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_flexio_spi.overlay
@@ -26,7 +26,7 @@
 &flexio2 {
 	status = "okay";
 
-	flexio2spi1: flexio2spi1 {
+	spi_loopback: flexio2spi1: flexio2spi1 {
 		compatible = "nxp,flexio-spi";
 		cs-gpios = <&gpio9 28 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
@@ -37,17 +37,7 @@
 		pinctrl-0 = <&pinmux_flexio2spi1>;
 		pinctrl-names = "default";
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <500000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <16000000>;
-		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_flexio_spi.overlay
@@ -25,7 +25,7 @@
 &flexio2 {
 	status = "okay";
 
-	flexio2spi1: flexio2spi1 {
+	spi_loopback: flexio2spi1: flexio2spi1 {
 		compatible = "nxp,flexio-spi";
 		cs-gpios = <&gpio4 2 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
@@ -36,17 +36,7 @@
 		pinctrl-0 = <&pinmux_flexio2spi1>;
 		pinctrl-names = "default";
 		status = "okay";
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <500000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <16000000>;
-		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -6,20 +6,10 @@
 
 /* To test this sample, connect J44.8 <-> J44.10 */
 
-&lpspi3 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi3 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -18,20 +18,10 @@
 	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 };
 
-&lpspi3 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &lpspi3 {
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&hs_lspi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &hs_lspi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&flexcomm5 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm5 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
@@ -5,16 +5,6 @@
  */
 
 /* To test this sample, connect J20.3 <-> J20.5 */
-&lpspi14 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi14 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.overlay
@@ -4,21 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi1 {
+#define SPI_LOOPBACK_FAST_HZ 5000000
+
+spi_loopback: &lpspi1 {
 	status = "okay";
 	/* DMA channels 10 and 12, muxed to LPSPI1 TX and RX */
 	dmas = <&edma0 10 45>, <&edma0 12 46>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <5000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/npcx4m8f_evb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/npcx4m8f_evb.overlay
@@ -1,22 +1,15 @@
+/* SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-&spip0 {
+#define SPI_LOOPBACK_FAST_HZ 15000000
+
+spi_loopback: &spip0 {
 	status = "okay";
 	pinctrl-0 = <&spip_sclk_mosi_miso_gp95_gpa1_gpa3_gpa5_sl
 		     &spip_sclk_mosi_miso_gp95_gpa1_gpa3_gpa5_no_spip_inv>;
 	pinctrl-names = "default";
 
 	cs-gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <15000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/npcx7m6fb_evb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/npcx7m6fb_evb.overlay
@@ -1,22 +1,15 @@
+/* SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-&spip0 {
+#define SPI_LOOPBACK_FAST_HZ 15000000
+
+spi_loopback: &spip0 {
 	status = "okay";
 	pinctrl-0 = <&spip_sclk_mosi_miso_gp95_gpa1_gpa3_gpa5_sl
 		     &spip_sclk_mosi_miso_gp95_gpa1_gpa3_gpa5_no_spip_inv>;
 	pinctrl-names = "default";
 
 	cs-gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <15000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/npcx9m6f_evb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/npcx9m6f_evb.overlay
@@ -1,22 +1,15 @@
+/* SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-&spip0 {
+#define SPI_LOOPBACK_FAST_HZ 15000000
+
+spi_loopback: &spip0 {
 	status = "okay";
 	pinctrl-0 = <&spip_sclk_mosi_miso_gp95_gpa1_gpa3_gpa5_sl
 		     &spip_sclk_mosi_miso_gp95_gpa1_gpa3_gpa5_no_spip_inv>;
 	pinctrl-names = "default";
 
 	cs-gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <15000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf51dk_nrf51822.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf51dk_nrf51822.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf52840dk_nrf52840.overlay
@@ -4,21 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi3 {
+spi_loopback: &spi3 {
 	overrun-character = <0x00>;
 	rx-delay = <1>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf52dk_nrf52832.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf52dk_nrf52832.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -23,7 +23,7 @@
 	};
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	status = "okay";
 	overrun-character = <0x00>;
 	rx-delay = <1>;
@@ -31,20 +31,10 @@
 	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpio0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -33,25 +33,16 @@
 	};
 };
 
-&spi130 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_K(500)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(8)
+
+spi_loopback: &spi130 {
 	pinctrl-0 = <&spi130_default>;
 	pinctrl-1 = <&spi130_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_K(500)>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
-	};
 
 	cs-gpios = <&gpio0 10 0>;
 };
@@ -63,3 +54,5 @@
 &gpiote130 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -31,7 +31,10 @@
 	status = "okay";
 };
 
-&spi120 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(4)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(8)
+
+spi_loopback: &spi120 {
 	status = "okay";
 	pinctrl-0 = <&spi120_default>;
 	pinctrl-1 = <&spi120_sleep>;
@@ -39,16 +42,6 @@
 	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p2.overlay
@@ -40,7 +40,10 @@
 	status = "okay";
 };
 
-&spi121 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(4)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi121 {
 	status = "okay";
 	pinctrl-0 = <&spi121_default>;
 	pinctrl-1 = <&spi121_sleep>;
@@ -48,16 +51,6 @@
 	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -45,7 +45,10 @@
 	status = "okay";
 };
 
-&spi120 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(4)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(8)
+
+spi_loopback: &spi120 {
 	status = "okay";
 	pinctrl-0 = <&spi120_default>;
 	pinctrl-1 = <&spi120_sleep>;
@@ -53,20 +56,10 @@
 	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@1 {
-		compatible = "test-spi-loopback-slow";
-		reg = <1>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
-	};
 };
 
 &uart120 {
 	status = "disabled";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -37,7 +37,10 @@
 
 /delete-node/ &mx25r64;
 
-&spi00 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(2)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi00 {
 	status = "okay";
 	pinctrl-0 = <&spi00_default>;
 	pinctrl-1 = <&spi00_sleep>;
@@ -45,18 +48,6 @@
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
 	cs-gpios = <&gpio1 8 0>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(2)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
 
 &gpio1 {
@@ -66,3 +57,5 @@
 &gpio2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -27,27 +27,20 @@
 	};
 };
 
-&spi21 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(2)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi21 {
 	status = "okay";
 	pinctrl-0 = <&spi21_default>;
 	pinctrl-1 = <&spi21_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(2)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
 
 &gpio1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20a_cpuapp_spi00.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20a_cpuapp_spi00.overlay
@@ -31,27 +31,20 @@
 	};
 };
 
-&spi00 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(16)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(32)
+
+spi_loopback: &spi00 {
 	status = "okay";
 	pinctrl-0 = <&spi00_default>;
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(32)>;
-	};
 };
 
 &gpio2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -27,27 +27,20 @@
 	};
 };
 
-&spi21 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(2)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi21 {
 	status = "okay";
 	pinctrl-0 = <&spi21_default>;
 	pinctrl-1 = <&spi21_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(2)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
 
 &gpio1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi00.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi00.overlay
@@ -31,27 +31,20 @@
 	};
 };
 
-&spi00 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(16)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(32)
+
+spi_loopback: &spi00 {
 	status = "okay";
 	pinctrl-0 = <&spi00_default>;
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(32)>;
-	};
 };
 
 &gpio2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -37,7 +37,10 @@
 	};
 };
 
-&spi21 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(2)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi21 {
 	status = "okay";
 	pinctrl-0 = <&spi21_default>;
 	pinctrl-1 = <&spi21_sleep>;
@@ -45,20 +48,10 @@
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
 	cs-gpios = <&gpio1 14 0>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(2)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
 
 &gpio1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf9160dk_nrf9160.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi3 {
+spi_loopback: &spi3 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.overlay
@@ -4,23 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	pinctrl-0 = <&spi1_nss_pb0 &spi1_sck_pb3 &spi1_miso_pb4 &spi1_mosi_pb5>;
 	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -30,3 +18,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_c5a3zg.overlay
@@ -4,21 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&lpdma1 0 5 STM32_DMA_PERIPH_TX
 		&lpdma1 1 4 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	st,fifo-threshold = <8>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f091rc.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma1 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dma1 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f207zg.overlay
@@ -1,31 +1,18 @@
 /*
- * Copyright (c) 2021 STMicroelectronics
+ * Copyright (c) 2020 Erwin Rol <erwin@erwinrol.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma2 5 3 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
 	       <&dma2 2 3 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>;
 	dma-names = "tx", "rx";
-};
-
-&spi1 {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f302r8.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f302r8.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi2 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f411re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f411re.overlay
@@ -1,31 +1,18 @@
 /*
- * Copyright (c) 2020 STMicroelectronics
+ * Copyright (c) 2020 Erwin Rol <erwin@erwinrol.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma2 5 3 0x28440 0x03>,
 	       <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";
-};
-
-&spi1 {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f429zi.overlay
@@ -1,31 +1,18 @@
 /*
- * Copyright (c) 2020 STMicroelectronics
+ * Copyright (c) 2020 Erwin Rol <erwin@erwinrol.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma2 5 3 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
 	       <&dma2 2 3 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>;
 	dma-names = "tx", "rx";
-};
-
-&spi1 {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f746zg.overlay
@@ -5,24 +5,14 @@
  */
 
 /* Arduino Header pins: MOSI:D11, MISO:D12 */
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma2 5 3 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
 	       <&dma2 2 3 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f767zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f767zi.overlay
@@ -5,24 +5,14 @@
  */
 
 /* Arduino Header pins: MOSI:D11, MISO:D12 */
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma2 5 3 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
 	       <&dma2 2 3 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g071rb.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -29,3 +17,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g0b1re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g0b1re.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -29,3 +17,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g431rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g431rb.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -37,3 +25,5 @@
 	 */
 	apb2-prescaler = <2>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g474re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g474re.overlay
@@ -1,34 +1,18 @@
 /*
- * Copyright (c) 2020 Erwin Rol <erwin@erwinrol.com>
+ * Copyright (c) 2023 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 &rcc {
-	/*
-	 * Reduce bus clock speed to be able
-	 * to reach SPI_LOOPBACK_SLOW_FREQ = 500000
-	 * with max prescaler 256
-	 */
+	/* generate SPI clock of 21.25 MHz */
 	apb2-prescaler = <2>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 8 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -42,3 +26,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h723zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h723zg.overlay
@@ -11,20 +11,10 @@
 };
 
 /* Define PLL1_Q as SPI1 kernel clock source */
-&spi1 {
+spi_loopback: &spi1 {
 	/delete-property/ clocks;
 	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
 		 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
@@ -14,22 +14,10 @@
 	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -43,3 +31,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m4.overlay
@@ -14,22 +14,10 @@
 	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -43,3 +31,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
@@ -14,22 +14,10 @@
 	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -43,3 +31,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
@@ -14,23 +14,11 @@
 	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	st,fifo-threshold = <8>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -44,3 +32,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l152re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l152re.overlay
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_SLOW_HZ 150000
+#define SPI_LOOPBACK_FAST_HZ 500000
+
+spi_loopback: &spi1 {
 	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
 		     &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
@@ -12,20 +15,10 @@
 	       <&dma1 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <150000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
 };
 
 &dma1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l476rg.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dma1 3 1 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dma1 2 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -29,3 +17,5 @@
 &dma2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l4r5zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l4r5zi.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 7 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -33,3 +21,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l552ze_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l552ze_q.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX>,
 	       <&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -33,3 +21,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
@@ -4,24 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi5 {
+spi_loopback: &spi5 {
 	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpdma1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
@@ -4,25 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	st,fifo-threshold = <8>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpdma1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
@@ -8,20 +8,10 @@
 	apb2-prescaler = <2>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb09ke.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb09ke.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi3 {
+spi_loopback: &spi3 {
 	dmas = <&dmamux1 0 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -29,3 +17,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 11 7 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -33,3 +21,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
@@ -8,25 +8,15 @@
 	apb2-prescaler = <2>;
 };
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&gpdma1 0 2 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 1 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	st,fifo-threshold = <8>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpdma1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	dmas = <&dmamux1 11 8 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 7 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -33,3 +21,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m031ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m031ki.overlay
@@ -16,20 +16,13 @@
 	};
 };
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_K(500)>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_K(500)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(16)
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
-	};
-
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.overlay
@@ -1,3 +1,4 @@
+/* SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors */
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &pinctrl {
@@ -16,20 +17,10 @@
 	status = "okay";
 };
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.overlay
@@ -16,20 +16,13 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_K(500)>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_K(500)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(16)
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
-	};
-
+spi_loopback: &spi2 {
 	status = "okay";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-names = "default";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m3351ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m3351ki.overlay
@@ -16,20 +16,13 @@
 	};
 };
 
-&spi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_K(500)>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_K(500)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(16)
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
-	};
-
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.overlay
@@ -1,3 +1,4 @@
+/* SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors */
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &pinctrl {
@@ -12,20 +13,13 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_K(500)>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_K(500)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(16)
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
-	};
-
+spi_loopback: &spi2 {
 	status = "okay";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-names = "default";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/numaker_pfm_m467.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_pfm_m467.overlay
@@ -1,3 +1,4 @@
+/* SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors */
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &pinctrl {
@@ -16,20 +17,10 @@
 	status = "okay";
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-
+spi_loopback: &spi2 {
 	status = "okay";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-names = "default";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/olimex_esp32_evb_procpu.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/olimex_esp32_evb_procpu.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi2 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -27,7 +27,10 @@
 	};
 };
 
-&spi00 {
+#define SPI_LOOPBACK_SLOW_HZ DT_FREQ_M(2)
+#define SPI_LOOPBACK_FAST_HZ DT_FREQ_M(4)
+
+spi_loopback: &spi00 {
 	status = "okay";
 
 	pinctrl-0 = <&spi00_default>;
@@ -36,20 +39,10 @@
 
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(2)>;
-	};
-
-	dut_fast: fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(4)>;
-	};
 };
 
 &gpio2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/pic32cx_sg41_cult.overlay
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_FAST_HZ 24000000
+
 &sercom0 {
 	status = "disabled";
 };
 
-&sercom6 {
+spi_loopback: &sercom6 {
 	compatible = "microchip,sercom-g1-spi";
 	/* Internally connect MOSI to MISO for loop-back operation */
 	dipo = <3>;
@@ -18,18 +20,6 @@
 	/* Configure DMA */
 	dmas = <&dmac 0 0x10>, <&dmac 1 0x11>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <24000000>;
-	};
 
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -47,3 +37,5 @@
 		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rd_rw612_bga.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rd_rw612_bga.overlay
@@ -5,16 +5,6 @@
  */
 
 /* Connect JP19 and J5 pins 4-5 */
-&flexcomm0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &flexcomm0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/robokit1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/robokit1.overlay
@@ -4,18 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+spi_loopback: &spi0 {
 	loopback;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rpi_pico_pio.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rpi_pico_pio.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define SPI_LOOPBACK_FAST_HZ 14000000
+
 &pinctrl {
 	pio0_spi0_default: pio0_spi0_default {
 		/* gpio 17 is used for chip select, not assigned to the PIO */
@@ -21,7 +23,7 @@
 &pio0 {
 	status = "okay";
 
-	pio0_spi0: pio0_spi0 {
+	spi_loopback: pio0_spi0: pio0_spi0 {
 		pinctrl-0 = <&pio0_spi0_default>;
 		pinctrl-names = "default";
 
@@ -34,17 +36,7 @@
 		cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		clk-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
 		sdo-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
-
-		slow@0 {
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <500000>;
-		};
-
-		fast@0 {
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <14000000>;
-		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rpi_pico_pl022.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rpi_pico_pl022.overlay
@@ -4,18 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+spi_loopback: &spi0 {
 	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rpi_pico_pl022_dma.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rpi_pico_pl022_dma.overlay
@@ -10,21 +10,11 @@
 	status = "okay";
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 
 	dmas = <&dma 0 RPI_PICO_DMA_SLOT_SPI0_TX 0>, <&dma 1 RPI_PICO_DMA_SLOT_SPI0_RX 0>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rsk_rx130_512kb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rsk_rx130_512kb.overlay
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&rspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+spi_loopback: &rspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rsk_rx140.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rsk_rx140.overlay
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&rspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 3000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <3000000>;
-	};
-};
+spi_loopback: &rspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -14,25 +14,15 @@
 	status = "okay";
 };
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 1000000
+
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpioa 31 GPIO_ACTIVE_LOW>;
 	dmas = <&dma0 0 4 0x10021>, <&dma0 1 5 0xa>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
 };
 
 &pinctrl {
@@ -53,3 +43,5 @@
 		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -15,25 +15,15 @@
 	status = "okay";
 };
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 1000000
+
+spi_loopback: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
 	dmas = <&dma0 5 16 0x10021>, <&dma0 6 17 0xa>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
 };
 
 &pinctrl {
@@ -54,3 +44,5 @@
 		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rv32m1_vega_openisa_rv32m1_ri5cy.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rv32m1_vega_openisa_rv32m1_ri5cy.overlay
@@ -4,16 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi0 {
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_REG 2
 
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <16000000>;
-	};
-};
+spi_loopback: &lpspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rza3ul_smarc.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rza3ul_smarc.overlay
@@ -4,16 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_FAST_HZ 8333333
+#define SPI_LOOPBACK_REG 2
 
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <8333333>;
-	};
-};
+spi_loopback: &spi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rzg3s_smarc_r9a08g045s33gbg_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rzg3s_smarc_r9a08g045s33gbg_cm33.overlay
@@ -4,25 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 8333333
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &spi0 {
 	dmas = <&dma0 6 RZ_DMA_PERIPH_TO_MEM>,
 	       <&dma0 5 RZ_DMA_MEM_TO_PERIPH>;
 	dma-names = "rx", "tx";
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <8333333>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 	dma-buf-addr-alignment = <1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rzn2l_rsk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rzn2l_rsk.overlay
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
+#define SPI_LOOPBACK_FAST_HZ 2500000
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &spi2 {
 	pinctrl-0 = <&spi2_pins>;
 	pinctrl-names = "default";
 	status = "okay";
@@ -12,21 +15,11 @@
 	dmas = <&dma0 1 RZ_DMA_PERIPH_TO_MEM>,
 	       <&dma0 0 RZ_DMA_MEM_TO_PERIPH>;
 	dma-names = "rx", "tx";
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <2500000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 	dma-buf-addr-alignment = <1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rzt2l_rsk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rzt2l_rsk.overlay
@@ -17,7 +17,10 @@
 	};
 };
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 2500000
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &spi0 {
 	pinctrl-0 = <&spi0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
@@ -25,21 +28,11 @@
 	dmas = <&dma0 1 RZ_DMA_PERIPH_TO_MEM>,
 	       <&dma0 0 RZ_DMA_MEM_TO_PERIPH>;
 	dma-names = "rx", "tx";
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <2500000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 	dma-buf-addr-alignment = <1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rzt2m_rsk_r9a07g075m24gbg_cr520.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rzt2m_rsk_r9a07g075m24gbg_cr520.overlay
@@ -4,25 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
+#define SPI_LOOPBACK_FAST_HZ 2500000
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &spi2 {
 	dmas = <&dma0 1 RZ_DMA_PERIPH_TO_MEM>,
 	       <&dma0 0 RZ_DMA_MEM_TO_PERIPH>;
 	dma-names = "rx", "tx";
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <2500000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 	dma-buf-addr-alignment = <1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
@@ -4,22 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
+#define SPI_LOOPBACK_FAST_HZ 2500000
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &spi2 {
 	dmas = <&dma0 6 RZ_DMA_PERIPH_TO_MEM>,
 	       <&dma0 5 RZ_DMA_MEM_TO_PERIPH>;
 	dma-names = "rx", "tx";
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <2500000>;
-	};
 
 	pinctrl-0 = <&spi2_pins>;
 	pinctrl-names = "default";
@@ -30,3 +21,5 @@
 	status = "okay";
 	dma-buf-addr-alignment = <1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
@@ -4,25 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+#define SPI_LOOPBACK_FAST_HZ 8333333
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &spi1 {
 	dmas = <&dma0 6 RZ_DMA_PERIPH_TO_MEM>,
 	       <&dma0 5 RZ_DMA_MEM_TO_PERIPH>;
 	dma-names = "rx", "tx";
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <8333333>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 	dma-buf-addr-alignment = <1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
@@ -4,25 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi2 {
+#define SPI_LOOPBACK_FAST_HZ 2500000
+#define SPI_LOOPBACK_REG 2
+
+spi_loopback: &spi2 {
 	dmas = <&dma0 6 RZ_DMA_PERIPH_TO_MEM>,
 	       <&dma0 5 RZ_DMA_MEM_TO_PERIPH>;
 	dma-names = "rx", "tx";
-
-	slow@2 {
-		compatible = "test-spi-loopback-slow";
-		reg = <2>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@2 {
-		compatible = "test-spi-loopback-fast";
-		reg = <2>;
-		spi-max-frequency = <2500000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 	dma-buf-addr-alignment = <1>;
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/s32k5xxcvb_s32k566_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/s32k5xxcvb_s32k566_m7.overlay
@@ -18,23 +18,15 @@
 	};
 };
 
-&lpspi3 {
+#define SPI_LOOPBACK_FAST_HZ 5000000
+
+spi_loopback: &lpspi3 {
 	status = "okay";
 	pinctrl-0 = <&lpspi3_default>;
 	pinctrl-names = "default";
 	pcs-sck-delay = <1000>;
 	sck-pcs-delay = <1000>;
 	transfer-delay = <1000>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <5000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_dspi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_dspi.overlay
@@ -22,20 +22,10 @@
 	};
 };
 
-&dspi0 {
+spi_loopback: &dspi0 {
 	pinctrl-0 = <&dspi0_default>;
 	pinctrl-names = "default";
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -18,21 +18,11 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	clock-frequency = <100000000>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -18,21 +18,11 @@
 	};
 };
 
-&spi0 {
+spi_loopback: &spi0 {
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	clock-frequency = <100000000>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sam_e54_xpro.overlay
@@ -8,7 +8,9 @@
 	status = "disabled";
 };
 
-&sercom4 {
+#define SPI_LOOPBACK_FAST_HZ 24000000
+
+spi_loopback: &sercom4 {
 	compatible = "microchip,sercom-g1-spi";
 	/* Internally connect MOSI to MISO for loop-back operation */
 	dipo = <3>;
@@ -18,18 +20,6 @@
 	/* Configure DMA */
 	dmas = <&dmac 0 12>, <&dmac 1 13>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <24000000>;
-	};
 
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -47,3 +37,5 @@
 		};
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/sam_e70_xplained_same70q21.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sam_e70_xplained_same70q21.overlay
@@ -1,31 +1,19 @@
 /*
- * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2024 The Zephyr Project Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	loopback;
+#define SPI_LOOPBACK_FAST_HZ 1000000
 
+spi_loopback: &spi0 {
+	loopback;
 	dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
 };
 
 &spi1 {
 	loopback;
-
 	dmas = <&xdmac 3 DMA_PERID_SPI1_TX>, <&xdmac 4 DMA_PERID_SPI1_RX>;
 	dma-names = "tx", "rx";
 
@@ -41,3 +29,5 @@
 		spi-max-frequency = <1000000>;
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/sam_v71_xult_samv71q21.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sam_v71_xult_samv71q21.overlay
@@ -1,31 +1,19 @@
 /*
- * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2024 The Zephyr Project Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
-	loopback;
+#define SPI_LOOPBACK_FAST_HZ 1000000
 
+spi_loopback: &spi0 {
+	loopback;
 	dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
 };
 
 &spi1 {
 	loopback;
-
 	dmas = <&xdmac 3 DMA_PERID_SPI1_TX>, <&xdmac 4 DMA_PERID_SPI1_RX>;
 	dma-names = "tx", "rx";
 
@@ -41,3 +29,5 @@
 		spi-max-frequency = <1000000>;
 	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/sama7g54_ek.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sama7g54_ek.overlay
@@ -9,18 +9,11 @@
 	status = "okay";
 };
 
-&spi11 {
+#define SPI_LOOPBACK_SLOW_HZ 1000000
+#define SPI_LOOPBACK_FAST_HZ 10000000
+
+spi_loopback: &spi11 {
 	loopback;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/samd21_xpro.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/samd21_xpro.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&sercom5 {
+spi_loopback: &sercom5 {
 	/* Internally connect MOSI to MISO for loop-back operation */
 	dipo = <0>;
 	dopo = <0>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/same54_xpro.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/same54_xpro.overlay
@@ -9,7 +9,7 @@
 	status = "okay";
 };
 
-&sercom4 {
+spi_loopback: &sercom4 {
 	/* Internally connect MOSI to MISO for loop-back operation */
 	dipo = <3>;
 	dopo = <2>;
@@ -20,16 +20,6 @@
 	/* Configure DMA */
 	dmas = <&dmac 0 12>, <&dmac 1 13>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/samr21_xpro.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/samr21_xpro.overlay
@@ -4,20 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&sercom5 {
+spi_loopback: &sercom5 {
 	/* Internally connect MOSI to MISO for loop-back operation */
 	dipo = <0>;
 	dopo = <0>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/sf32lb52_devkit_lcd.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sf32lb52_devkit_lcd.overlay
@@ -3,18 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
+spi_loopback: &spi1 {
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
@@ -16,21 +16,14 @@
 	};
 };
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &spi0 {
 	status = "okay";
 	cs-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <10000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
@@ -16,21 +16,13 @@
 	};
 };
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+
+spi_loopback: &spi0 {
 	status = "okay";
 	cs-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_rb4342a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_rb4342a.overlay
@@ -16,21 +16,13 @@
 	};
 };
 
-&spi0 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+
+spi_loopback: &spi0 {
 	status = "okay";
 	cs-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/stm32f3_disco.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32f3_disco.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi1 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
@@ -8,23 +8,13 @@
 	apb1-prescaler = <2>;
 };
 
-&spi2 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+
+spi_loopback: &spi2 {
 	dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	st,fifo-threshold = <8>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-	};
 };
 
 &gpdma1 {
@@ -34,3 +24,5 @@
 &gpdma2 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
@@ -10,22 +10,10 @@
  * Short Pin PB4(D12) to PB5(D11) for the test to pass.
  */
 
-&spi3 {
+spi_loopback: &spi3 {
 	dmas = <&dmamux1 0 16 STM32_DMA_PERIPH_TX>,
 	       <&dmamux1 7 15 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -39,3 +27,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/stm32mp135f_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32mp135f_dk.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi5 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi5 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/stm32mp157c_dk2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32mp157c_dk2.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi4 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &spi4 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -4,25 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi5 {
+spi_loopback: &spi5 {
 	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX>,
 	       <&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	st,fifo-threshold = <4>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &gpdma1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.overlay
@@ -4,22 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi3 {
+spi_loopback: &spi3 {
 	dmas = <&dmamux1 2 41 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 40 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma1 {
@@ -33,3 +21,5 @@
 &dmamux1 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/tlsr9518adk80d.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/tlsr9518adk80d.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&pspi {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &pspi {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/twr_ke18f.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/twr_ke18f.overlay
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&lpspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+spi_loopback: &lpspi0 {};
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/ucans32k1sic.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ucans32k1sic.overlay
@@ -6,16 +6,8 @@
 
 /* Short P1.3 (SPI0/MISO) with P1.4 (SPI0/MOSI) */
 
-&lpspi0 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
+#define SPI_LOOPBACK_FAST_HZ 9000000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <9000000>;
-	};
-};
+spi_loopback: &lpspi0 {};
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/xg23_rb4210a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg23_rb4210a.overlay
@@ -6,7 +6,10 @@
 
 #include <zephyr/dt-bindings/pinctrl/silabs/xg23-pinctrl.h>
 
-&eusart1 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &eusart1 {
 	dmas = <&dma0 DMA_REQSEL_EUSART1TXFL>,
 	       <&dma0 DMA_REQSEL_EUSART1RXFL>;
 	dma-names = "tx", "rx";
@@ -16,20 +19,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <10000000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
@@ -21,7 +21,10 @@
 	};
 };
 
-&eusart1 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &eusart1 {
 	dmas = <&dma0 DMA_REQSEL_EUSART1TXFL>,
 	       <&dma0 DMA_REQSEL_EUSART1RXFL>;
 	dma-names = "tx", "rx";
@@ -31,20 +34,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <10000000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/xg29_rb4412a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg29_rb4412a.overlay
@@ -10,7 +10,10 @@
  * Connect EXP4 (PC0) and EXP6 (PC1) of the Expansion Pin header
  */
 
-&eusart1 {
+#define SPI_LOOPBACK_FAST_HZ 10000000
+#define SPI_LOOPBACK_REG 1
+
+spi_loopback: &eusart1 {
 	dmas = <&dma0 DMA_REQSEL_EUSART1TXFL>,
 	       <&dma0 DMA_REQSEL_EUSART1RXFL>;
 	dma-names = "tx", "rx";
@@ -20,20 +23,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <10000000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/xmc45_relax_kit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xmc45_relax_kit.overlay
@@ -21,7 +21,7 @@
 	hwctrl = "disabled";
 };
 
-&usic0ch0 {
+spi_loopback: &usic0ch0 {
 	compatible = "infineon,xmc4xxx-spi";
 	pinctrl-0 = <&spi_mosi_p1_5_u0c0 &spi_miso_p1_4_u0c0 &spi_sclk_p0_8_u0c0>;
 	pinctrl-names = "default";
@@ -34,20 +34,10 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma0 {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/boards/xmc47_relax_kit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xmc47_relax_kit.overlay
@@ -21,7 +21,7 @@
 	hwctrl = "disabled";
 };
 
-&usic2ch0 {
+spi_loopback: &usic2ch0 {
 	compatible = "infineon,xmc4xxx-spi";
 	pinctrl-0 = <&spi_mosi_p3_8_u2c0 &spi_miso_p3_7_u2c0 &spi_sclk_p3_9_u2c0>;
 	pinctrl-names = "default";
@@ -32,16 +32,6 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/overlay-mcux-flexio-spi.overlay
+++ b/tests/drivers/spi/spi_loopback/overlay-mcux-flexio-spi.overlay
@@ -26,7 +26,7 @@
 &flexio3 {
 	status = "okay";
 
-	flexio3_spi0: flexio3_spi0 {
+	spi_loopback: flexio3_spi0: flexio3_spi0 {
 		compatible = "nxp,flexio-spi";
 		status = "okay";
 		#address-cells = <1>;
@@ -37,19 +37,7 @@
 		sck-pin = <10>;
 		pinctrl-0 = <&pinmux_flexio3spi0>;
 		pinctrl-names = "default";
-
-		slow@0 {
-			status = "okay";
-			compatible = "test-spi-loopback-slow";
-			reg = <0>;
-			spi-max-frequency = <500000>;
-		};
-
-		fast@0 {
-			status = "okay";
-			compatible = "test-spi-loopback-fast";
-			reg = <0>;
-			spi-max-frequency = <16000000>;
-		};
 	};
 };
+
+#include "spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32_procpu.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32_procpu.overlay
@@ -23,6 +23,12 @@
 	};
 };
 
+/*
+ * Kept inline on purpose. An SoC overlay is applied in addition to the
+ * board overlay, and olimex_esp32_evb/esp32/procpu already puts the
+ * loopback contract on &spi2. Labelling &spi3 spi_loopback here as well
+ * would be a duplicate label and break that board's build.
+ */
 &spi3 {
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/socs/esp32c2.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32c2.overlay
@@ -23,21 +23,7 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -52,3 +38,5 @@
 &dma {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32c3.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32c3.overlay
@@ -23,21 +23,7 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -52,3 +38,5 @@
 &dma {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32c3_usb.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32c3_usb.overlay
@@ -23,21 +23,7 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -52,3 +38,5 @@
 &dma {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32c5_hpcore.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32c5_hpcore.overlay
@@ -23,24 +23,12 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	pinctrl-0 = <&spim2_loopback>;
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32c61.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32c61.overlay
@@ -23,21 +23,7 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -52,3 +38,5 @@
 &dma {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32c6_hpcore.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32c6_hpcore.overlay
@@ -23,21 +23,7 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -52,3 +38,5 @@
 &dma {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32h2.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32h2.overlay
@@ -23,21 +23,7 @@
 	};
 };
 
-&spi2 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -52,3 +38,5 @@
 &dma {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32p4_hpcore.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32p4_hpcore.overlay
@@ -23,22 +23,12 @@
 	};
 };
 
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	pinctrl-0 = <&spim2_loopback>;
 	pinctrl-names = "default";
 	status = "okay";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <16000000>;
-	};
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32p4_hpcore_dma.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32p4_hpcore_dma.overlay
@@ -23,7 +23,7 @@
 	};
 };
 
-&spi2 {
+spi_loopback: &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -33,20 +33,10 @@
 
 	dmas = <&dma_axi 0>, <&dma_axi 1>;
 	dma-names = "rx", "tx";
-
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <500000>;
-	};
-
-	fast@1 {
-		compatible = "test-spi-loopback-fast";
-		reg = <1>;
-		spi-max-frequency = <16000000>;
-	};
 };
 
 &dma_axi {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32s2.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32s2.overlay
@@ -23,21 +23,9 @@
 	};
 };
 
-&spi3 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <100000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 100000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi3 {
+spi_loopback: &spi3 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -45,3 +33,5 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/socs/esp32s3_procpu.overlay
+++ b/tests/drivers/spi/spi_loopback/socs/esp32s3_procpu.overlay
@@ -23,21 +23,9 @@
 	};
 };
 
-&spi3 {
-	slow@0 {
-		compatible = "test-spi-loopback-slow";
-		reg = <0>;
-		spi-max-frequency = <100000>;
-	};
+#define SPI_LOOPBACK_SLOW_HZ 100000
 
-	fast@0 {
-		compatible = "test-spi-loopback-fast";
-		reg = <0>;
-		spi-max-frequency = <16000000>;
-	};
-};
-
-&spi3 {
+spi_loopback: &spi3 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dma-enabled;
@@ -52,3 +40,5 @@
 &dma {
 	status = "okay";
 };
+
+#include "../spi-loopback.dtsi"

--- a/tests/drivers/spi/spi_loopback/spi-loopback.dtsi
+++ b/tests/drivers/spi/spi_loopback/spi-loopback.dtsi
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Shared SPI loopback test fixture. The board selects the loopback SPI
+ * controller with the `spi_loopback` node label:
+ *
+ *     spi_loopback: &<controller> { ... board-specific props ... };
+ *
+ * Defaults: 500 kHz (slow) / 16 MHz (fast), on chip-select 0. A board whose
+ * silicon differs overrides them by defining any of the following before
+ * selecting the controller (overlay files are preprocessed together, so the
+ * values reach this fragment):
+ *
+ *     #define SPI_LOOPBACK_SLOW_HZ  <hz>   (e.g. DT_FREQ_M(2))
+ *     #define SPI_LOOPBACK_FAST_HZ  <hz>
+ *     #define SPI_LOOPBACK_REG      <cs>   (chip-select index, default 0)
+ */
+
+#include <zephyr/dt-bindings/dt-util.h>
+
+#ifndef SPI_LOOPBACK_SLOW_HZ
+#define SPI_LOOPBACK_SLOW_HZ 500000
+#endif
+#ifndef SPI_LOOPBACK_FAST_HZ
+#define SPI_LOOPBACK_FAST_HZ 16000000
+#endif
+#ifndef SPI_LOOPBACK_REG
+#define SPI_LOOPBACK_REG 0
+#endif
+
+&spi_loopback {
+	dut_slow: slow@SPI_LOOPBACK_REG {
+		compatible = "test-spi-loopback-slow";
+		reg = <SPI_LOOPBACK_REG>;
+		spi-max-frequency = <SPI_LOOPBACK_SLOW_HZ>;
+	};
+
+	dut_fast: fast@SPI_LOOPBACK_REG {
+		compatible = "test-spi-loopback-fast";
+		reg = <SPI_LOOPBACK_REG>;
+		spi-max-frequency = <SPI_LOOPBACK_FAST_HZ>;
+	};
+};


### PR DESCRIPTION
- **tests: drivers: spi: spi_loopback: ship the loopback contract as a fixture**
- **tests: drivers: spi: spi_loopback: convert the SoC overlays**
