### PR TITLE
drivers: video: fix Kconfig help reference to the region name option

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -36,7 +36,7 @@ config VIDEO_BUFFER_POOL_ZEPHYR_REGION
 	help
 	  Place video buffer pool in a region, automatically
 	  created from a 'zephyr,memory-region' compatible node,
-	  whose name is specified in CONFIG_VIDEO_BUFFER_ZEPHYR_REGION_NAME.
+	  whose name is specified in CONFIG_VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME.
 
 config VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME
 	string "Name of the zephyr memory-region for video buffer pool"


### PR DESCRIPTION
The help text of `VIDEO_BUFFER_POOL_ZEPHYR_REGION` (drivers/video/Kconfig:39)
tells the user the memory-region name is set by
`CONFIG_VIDEO_BUFFER_ZEPHYR_REGION_NAME`. No such option exists.

The option is declared two lines below, at drivers/video/Kconfig:41, as
`VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME`, and that is the name the rest of the
tree uses:

- subsys/video/buffer.c:25 —
  `Z_GENERIC_SECTION(CONFIG_VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME)`
- boards/st/stm32n6570_dk/Kconfig.defconfig:29 — sets
  `VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME`

The typo dates back to 9788cedcf, which introduced both symbols in the same
hunk. Help text only; no functional change.
