### PR TITLE
arch: add ARCH_HAS_DIRECT_INTERRUPTS capability symbol

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -26,6 +26,7 @@ config ARC
 	select ARCH_SUPPORTS_ROM_START
 	select ARCH_SUPPORTS_ROM_OFFSET
 	select ARCH_HAS_DIRECTED_IPIS
+	select ARCH_HAS_DIRECT_INTERRUPTS
 	help
 	  ARC architecture
 
@@ -44,6 +45,7 @@ config ARM
 	select ARCH_HAS_ISR_TABLES_LOCAL_DECLARATION
 	select ARCH_SUPPORTS_ROM_OFFSET
 	select ARCH_HAS_CPU_IDLE_HOOKS if CPU_CORTEX_M
+	select ARCH_HAS_DIRECT_INTERRUPTS
 	help
 	  ARM architecture
 
@@ -134,6 +136,8 @@ config X86
 	# Only the 32-bit (ia32) interrupt stub emits the ISR entry hook that
 	# closes the idle window; intel64 does not have one yet.
 	select ARCH_HAS_CPU_IDLE_HOOKS if !X86_64
+	# Only the 32-bit (ia32) variant implements the direct interrupt hooks.
+	select ARCH_HAS_DIRECT_INTERRUPTS if !X86_64
 	help
 	  x86 architecture
 
@@ -165,6 +169,7 @@ config RISCV
 	select ARCH_SUPPORTS_ROM_OFFSET
 	depends on DT_HAS_RISCV_ENABLED
 	select ARCH_HAS_CPU_IDLE_HOOKS
+	select ARCH_HAS_DIRECT_INTERRUPTS
 	help
 	  RISCV architecture
 
@@ -200,6 +205,9 @@ config ARCH_POSIX
 	select BARRIER_OPERATIONS_BUILTIN
 	# POSIX arch based targets get their memory cleared on entry by the host OS
 	select SKIP_BSS_CLEAR
+	# The direct interrupt hooks are provided by the board's board_irq.h
+	# (boards/native/common/irq/board_irq.h for the in-tree boards).
+	select ARCH_HAS_DIRECT_INTERRUPTS
 	help
 	  POSIX (native) architecture
 
@@ -870,6 +878,16 @@ config ARCH_HAS_IRQ_GET_ACTIVE
 	  therefore k_irq_get_active(). Some interrupt controllers expose
 	  this in a register; others record it in the interrupt dispatch
 	  path.
+
+config ARCH_HAS_DIRECT_INTERRUPTS
+	bool
+	help
+	  This option is selected by architectures that implement the direct
+	  interrupt hooks, i.e. ARCH_IRQ_DIRECT_CONNECT() and
+	  ARCH_ISR_DIRECT_DECLARE() together with the ARCH_ISR_DIRECT_HEADER(),
+	  ARCH_ISR_DIRECT_FOOTER() and ARCH_ISR_DIRECT_PM() hooks they expand
+	  to. It is a prerequisite for any code using IRQ_DIRECT_CONNECT() or
+	  ISR_DIRECT_DECLARE().
 
 config ARCH_HAS_SEMIHOST
 	bool

--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -343,6 +343,11 @@ Zephyr supports so-called 'direct' interrupts, which are installed via
 implementation requirements and a reduced feature set; see the definitions
 of :c:macro:`IRQ_DIRECT_CONNECT` and :c:macro:`ISR_DIRECT_DECLARE` for details.
 
+Direct interrupts are only available on architectures selecting
+:kconfig:option:`CONFIG_ARCH_HAS_DIRECT_INTERRUPTS`. Using
+:c:macro:`IRQ_DIRECT_CONNECT` or :c:macro:`ISR_DIRECT_DECLARE` on any other
+architecture fails the build.
+
 The following code demonstrates a direct ISR:
 
 .. code-block:: c

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -97,6 +97,36 @@ irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 					   parameter, flags);
 }
 
+/*
+ * Direct interrupts are optional; only architectures selecting
+ * CONFIG_ARCH_HAS_DIRECT_INTERRUPTS define the ARCH_*_DIRECT_* hooks used
+ * below. Without these fallbacks the undefined function-like macros survive
+ * preprocessing and misparse as K&R function definitions, which reports a
+ * missing return type rather than the missing feature.
+ *
+ * Only the two API entry points are stubbed: the HEADER/FOOTER/PM hooks are
+ * reachable solely from inside a direct ISR body, so the assertion on
+ * ARCH_ISR_DIRECT_DECLARE() already covers them, and RX defines the
+ * HEADER/FOOTER hooks for its internal ISR accounting without supporting
+ * direct interrupts, so stubbing those would collide.
+ *
+ * The guard cannot test the hooks themselves: the arch-level irq.h headers
+ * include this file before defining them. Doxygen is kept out so that the
+ * documented stubs in arch_interface.h remain the only visible definitions.
+ */
+#if !defined(CONFIG_ARCH_HAS_DIRECT_INTERRUPTS) && !defined(__DOXYGEN__)
+
+#define Z_ISR_DIRECT_UNSUPPORTED \
+	BUILD_ASSERT(0, "direct interrupts are not supported by this architecture")
+
+#define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
+	Z_ISR_DIRECT_UNSUPPORTED
+#define ARCH_ISR_DIRECT_DECLARE(name) \
+	Z_ISR_DIRECT_UNSUPPORTED; \
+	int name(void)
+
+#endif /* !CONFIG_ARCH_HAS_DIRECT_INTERRUPTS && !__DOXYGEN__ */
+
 /**
  * @brief Initialize a 'direct' interrupt handler.
  *

--- a/tests/arch/common/gen_isr_table/src/main.c
+++ b/tests/arch/common/gen_isr_table/src/main.c
@@ -18,7 +18,7 @@
 
 extern const uintptr_t _irq_vector_table[];
 
-#if defined(ARCH_IRQ_DIRECT_CONNECT) && defined(CONFIG_GEN_IRQ_VECTOR_TABLE)
+#if defined(CONFIG_ARCH_HAS_DIRECT_INTERRUPTS) && defined(CONFIG_GEN_IRQ_VECTOR_TABLE)
 #define HAS_DIRECT_IRQS
 #endif
 


### PR DESCRIPTION
Direct interrupts are an optional architecture feature: only ARC, ARM
(aarch32), RISC-V, x86 ia32 and the POSIX/native boards implement the
ARCH_IRQ_DIRECT_CONNECT() and ARCH_ISR_DIRECT_DECLARE() hooks. There was
no way to express that dependency in Kconfig, so a symbol enabling code
that uses IRQ_DIRECT_CONNECT() had to enumerate the supporting
architectures itself, and the only capability test available to C code
was probing whether the arch hook macro happened to be defined.

Add ARCH_HAS_DIRECT_INTERRUPTS, selected by the architectures that
implement the hooks, and switch the gen_isr_table test over to it. Note
that the capability is not uniform across an architecture: x86 provides
it only on the 32-bit (ia32) variant, and arm64, xtensa, MIPS, SPARC and
RX do not provide it at all.

No functional change: the symbol is selected exactly where the arch hooks
are defined today.
