### PR TITLE
Bluetooth: Classic: HFP: Fix HF SLC work handling on disconnect

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4272,6 +4272,7 @@ static void hfp_hf_disconnected(struct bt_rfcomm_dlc *dlc)
 	atomic_clear_bit(hf->flags, BT_HFP_HF_FLAG_CONNECTED);
 
 	k_work_cancel(&hf->work);
+	k_work_cancel(&hf->slc_work);
 	k_work_cancel_delayable(&hf->deferred_work);
 
 	/* Drop queued TX buffers. Nothing will send them any more, and
@@ -4353,6 +4354,15 @@ static uint8_t bt_hfp_hf_discover_cb(struct bt_conn *conn, struct bt_sdp_client_
 	__ASSERT(index < ARRAY_SIZE(bt_hfp_hf_pool), "Index is out of bounds");
 
 	hf = &bt_hfp_hf_pool[index];
+
+	if (hf->acl == NULL) {
+		/* The HF object was released by hfp_hf_disconnected() while
+		 * the discovery was still ongoing. Do not touch the object
+		 * state or re-submit any work in that case.
+		 */
+		LOG_WRN("HF %p released before discovery completed", hf);
+		return BT_SDP_DISCOVER_UUID_STOP;
+	}
 
 	if ((result == NULL) || (result->resp_buf == NULL)) {
 		LOG_ERR("SDP discovery failed");
@@ -4454,12 +4464,13 @@ static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 	hf->sdp_param.pool = &hf_pool;
 	hf->sdp_param.ids  = &id_list;
 
+	hf->acl = conn;
+
 	err = bt_sdp_discover(conn, &hf->sdp_param);
 	if (err != 0) {
+		hf->acl = NULL;
 		return NULL;
 	}
-
-	hf->acl = conn;
 
 	hf->rfcomm_dlc.ops = &ops;
 	hf->rfcomm_dlc.mtu = BT_HFP_MAX_MTU;


### PR DESCRIPTION
hfp_hf_disconnected() cancels hf->work and hf->deferred_work, but not hf->slc_work, which is submitted to the system work queue both from hfp_hf_connected() and from the SDP discovery callback. Once the object has been marked as free (hf->acl == NULL), hfp_hf_create() wipes the whole object with memset() when the slot is reused. Wiping a work item that is still queued corrupts the work queue's pending list.

Additionally, an ongoing SDP discovery cannot be canceled (bt_sdp_discover_cancel() is declared but has no implementation), so the discovery callback may fire after the RFCOMM DLC has been disconnected and re-submit slc_work for an already released object.

Fix this by canceling slc_work in hfp_hf_disconnected(), and by making the discovery callback check that the object has not been released by hfp_hf_disconnected() while the discovery was still ongoing. To make that check reliable also on the connecting path, assign hf->acl before starting the discovery in hfp_hf_create(), since the callback may otherwise run before the assignment and treat the object as released.

The missing work item cancellation on the AG side was fixed in #115995; the equivalent AG-side discovery callback check is part of #116192.

Fixes: #117856