### PR TITLE
Bluetooth: Classic: HFP: Fix connect failure cleanup

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -4073,6 +4073,15 @@ static uint8_t bt_hfp_ag_discover_cb(struct bt_conn *conn, struct bt_sdp_client_
 
 	ag = &bt_hfp_ag_pool[index];
 
+	if (ag->acl_conn == NULL) {
+		/* The AG object was released by hfp_ag_disconnected() while
+		 * the discovery was still ongoing. Do not touch the object
+		 * state or re-submit any work in that case.
+		 */
+		LOG_WRN("AG %p released before discovery completed", ag);
+		return BT_SDP_DISCOVER_UUID_STOP;
+	}
+
 	if ((result == NULL) || (result->resp_buf == NULL)) {
 		LOG_ERR("SDP discovery failed");
 		goto failed;
@@ -4117,6 +4126,15 @@ static uint8_t bt_hfp_ag_discover_cb(struct bt_conn *conn, struct bt_sdp_client_
 	atomic_set_bit(ag->flags, BT_HFP_AG_RECORD_FOUND);
 failed:
 	atomic_set_bit(ag->flags, BT_HFP_AG_DISCOVER_DONE);
+	if (atomic_test_bit(ag->flags, BT_HFP_AG_RELEASING)) {
+		/* The RFCOMM connection creation failed and the object was
+		 * kept allocated only to keep the SDP discovery request
+		 * valid. Release the object now that the discovery has
+		 * completed.
+		 */
+		ag->acl_conn = NULL;
+		return BT_SDP_DISCOVER_UUID_STOP;
+	}
 	bt_work_submit(&ag->slc_work);
 
 	return BT_SDP_DISCOVER_UUID_STOP;
@@ -4167,8 +4185,11 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 	ag->sdp_param.pool = &ag_pool;
 	ag->sdp_param.ids  = &id_list;
 
+	ag->acl_conn = conn;
+
 	err = bt_sdp_discover(conn, &ag->sdp_param);
 	if (err != 0) {
+		ag->acl_conn = NULL;
 		return NULL;
 	}
 
@@ -4206,8 +4227,6 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 
 	ag->hf_features = 0;
 	ag->hf_codec_ids = 0;
-
-	ag->acl_conn = conn;
 
 	/* Set AG indicator value */
 	ag->indicator_value[BT_HFP_AG_SERVICE_IND] = 0;
@@ -4262,7 +4281,17 @@ int bt_hfp_ag_connect(struct bt_conn *conn, struct bt_hfp_ag **ag, uint8_t chann
 
 	err = bt_rfcomm_dlc_connect(conn, &new_ag->rfcomm_dlc, channel);
 	if (err != 0) {
-		(void)memset(new_ag, 0, sizeof(*new_ag));
+		/* The SDP discovery request started by hfp_ag_create() is
+		 * linked in the SDP client's request list, so the object
+		 * cannot be wiped here. Mark the object for release and let
+		 * the SDP discovery callback release it. If the discovery
+		 * has already completed, release the object immediately.
+		 */
+		atomic_set_bit(new_ag->flags, BT_HFP_AG_RELEASING);
+		if (atomic_test_bit(new_ag->flags, BT_HFP_AG_DISCOVER_DONE)) {
+			k_work_cancel(&new_ag->slc_work);
+			new_ag->acl_conn = NULL;
+		}
 		*ag = NULL;
 	} else {
 		*ag = new_ag;

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -185,6 +185,7 @@ enum {
 	BT_HFP_AG_RECORD_FOUND,  /* SDP HF Record found */
 	BT_HFP_AG_1ST_AT_RECV,   /* 1st AT is received */
 	BT_HFP_AG_FEAT_UPDATED,  /* Remote feature has been updated */
+	BT_HFP_AG_RELEASING,     /* Release object when SDP discovery completes */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_NUM_FLAGS,

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4388,6 +4388,15 @@ static uint8_t bt_hfp_hf_discover_cb(struct bt_conn *conn, struct bt_sdp_client_
 	atomic_set_bit(hf->flags, BT_HFP_HF_FLAG_RECORD_FOUND);
 failed:
 	atomic_set_bit(hf->flags, BT_HFP_HF_FLAG_DISCOVER_DONE);
+	if (atomic_test_bit(hf->flags, BT_HFP_HF_FLAG_RELEASING)) {
+		/* The RFCOMM connection creation failed and the object was
+		 * kept allocated only to keep the SDP discovery request
+		 * valid. Release the object now that the discovery has
+		 * completed.
+		 */
+		hf->acl = NULL;
+		return BT_SDP_DISCOVER_UUID_STOP;
+	}
 	k_work_submit(&hf->slc_work);
 
 	return BT_SDP_DISCOVER_UUID_STOP;
@@ -4625,7 +4634,17 @@ int bt_hfp_hf_connect(struct bt_conn *conn, struct bt_hfp_hf **hf, uint8_t chann
 
 	err = bt_rfcomm_dlc_connect(conn, &new_hf->rfcomm_dlc, channel);
 	if (err != 0) {
-		(void)memset(new_hf, 0, sizeof(*new_hf));
+		/* The SDP discovery request started by hfp_hf_create() is
+		 * linked in the SDP client's request list, so the object
+		 * cannot be wiped here. Mark the object for release and let
+		 * the SDP discovery callback release it. If the discovery
+		 * has already completed, release the object immediately.
+		 */
+		atomic_set_bit(new_hf->flags, BT_HFP_HF_FLAG_RELEASING);
+		if (atomic_test_bit(new_hf->flags, BT_HFP_HF_FLAG_DISCOVER_DONE)) {
+			k_work_cancel(&new_hf->slc_work);
+			new_hf->acl = NULL;
+		}
 		*hf = NULL;
 	} else {
 		*hf = new_hf;

--- a/subsys/bluetooth/host/classic/hfp_hf_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_hf_internal.h
@@ -165,6 +165,7 @@ enum {
 	BT_HFP_HF_FLAG_RECORD_FOUND,  /* SDP AG Record found */
 	BT_HFP_HF_FLAG_DLC_CONNECTED, /* HFP HF DLC is connected */
 	BT_HFP_HF_FLAG_FEAT_UPDATED,  /* Remote feature has been updated */
+	BT_HFP_HF_FLAG_RELEASING,     /* Release object when SDP discovery completes */
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_HF_NUM_FLAGS,
 };


### PR DESCRIPTION
Both bt_hfp_hf_connect() and bt_hfp_ag_connect() wipe the whole HF/AG object with memset() when bt_rfcomm_dlc_connect() fails. At that point the SDP discovery started when the object was created is still ongoing, and the embedded sdp_param._node is deterministically linked in the SDP client's request list, so the memset() corrupts that list in place. It can also wipe a queued slc_work item, corrupting the work queue's pending list.

An ongoing SDP discovery cannot be canceled (bt_sdp_discover_cancel() is declared in the public header but has no implementation), so the object cannot be safely torn down synchronously on this path. Instead, keep the object allocated and mark it with a new RELEASING flag, making the SDP discovery callback release it once the discovery has completed, rather than proceeding with SLC establishment. If the discovery has already completed when the RFCOMM connection creation fails, the object is released immediately.

One commit per role (HF and AG); the bug is identical on both sides. The AG commit additionally makes the discovery callback bail out if hfp_ag_disconnected() has already released the object while the discovery was still ongoing, which the AG side was missing (the HF-side counterpart is in #116191).

Related fixes: #116191 (HF disconnect path), #115995 (AG disconnect path). Implementing the missing bt_sdp_discover_cancel() would allow simplifying this in the future and is a candidate for separate follow-up work.

Fixes: #117860