### PR TITLE
Bluetooth: Classic: AVRCP: Clean up vendor dependent PDU state on disconnect

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -515,6 +515,7 @@ static void avrcp_disconnected(struct bt_avctp *session)
 	struct bt_avrcp *avrcp = AVRCP_AVCTP(session);
 	struct bt_avrcp_ct *ct = get_avrcp_ct(avrcp);
 	struct bt_avrcp_tg *tg = get_avrcp_tg(avrcp);
+	sys_snode_t *node;
 
 	if ((avrcp_ct_cb != NULL) && (avrcp_ct_cb->disconnected != NULL)) {
 		avrcp_ct_cb->disconnected(ct);
@@ -523,6 +524,24 @@ static void avrcp_disconnected(struct bt_avctp *session)
 	if ((avrcp_tg_cb != NULL) && (avrcp_tg_cb->disconnected != NULL)) {
 		avrcp_tg_cb->disconnected(tg);
 	}
+
+	/* Cancel the vendor dependent response TX machine and drop any
+	 * queued or partially sent responses. The TX state, including the
+	 * TX_ONGOING flag, lives in the buffer user data, so releasing the
+	 * buffers also resets the TX state. Without this, a disconnection
+	 * in the middle of a fragmented response leaks the buffer and
+	 * leaves the TX machine stalled on the stale list head when the
+	 * object is reused for a new connection.
+	 */
+	k_work_cancel_delayable(&tg->vd_rsp_tx_work);
+
+	avrcp_tg_lock(tg);
+	node = sys_slist_get(&tg->vd_rsp_tx_pending);
+	while (node != NULL) {
+		net_buf_unref(CONTAINER_OF(node, struct net_buf, node));
+		node = sys_slist_get(&tg->vd_rsp_tx_pending);
+	}
+	avrcp_tg_unlock(tg);
 
 	memset(&ct->ct_notify, 0, sizeof(ct->ct_notify));
 	memset(&tg->tg_notify, 0, sizeof(tg->tg_notify));

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -509,6 +509,8 @@ static void avrcp_connected(struct bt_avctp *session)
 	}
 }
 
+static void cleanup_fragmentation_context(struct bt_avrcp_ct *ct);
+
 /* The AVCTP L2CAP channel released */
 static void avrcp_disconnected(struct bt_avctp *session)
 {
@@ -542,6 +544,9 @@ static void avrcp_disconnected(struct bt_avctp *session)
 		node = sys_slist_get(&tg->vd_rsp_tx_pending);
 	}
 	avrcp_tg_unlock(tg);
+
+	/* Drop any partially reassembled vendor dependent response */
+	cleanup_fragmentation_context(ct);
 
 	memset(&ct->ct_notify, 0, sizeof(ct->ct_notify));
 	memset(&tg->tg_notify, 0, sizeof(tg->tg_notify));


### PR DESCRIPTION
avrcp_disconnected() leaves the vendor dependent PDU machinery holding buffer references when a connection drops mid-transfer, in both directions:

On the TG side, tg->vd_rsp_tx_work is not canceled and the buffers queued in tg->vd_rsp_tx_pending are not released. If the connection drops in the middle of a fragmented vendor dependent response, the pending buffer (from a pool that is only CONFIG_BT_MAX_CONN deep) is leaked with its TX_ONGOING flag still set in the buffer user data. Since the TG object is selected by connection index, a new connection on the same index finds the stale buffer at the head of the pending list, and the TX state machine remains permanently stalled with all new responses queued behind it and never sent.

On the CT side, a disconnect in the middle of reassembling a fragmented response leaves ct->reassembly_buf referenced, only reclaimed if the same connection index later starts a new reassembly — so repeated mid-reassembly disconnections can exhaust the RX pool.

Fix both by releasing the buffers (and canceling the TG TX work) on disconnection. One commit per direction.

Fixes: #118950