### PR TITLE
Bluetooth: Classic: AVDTP: Guard object reuse against pending release work

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -87,6 +87,15 @@ static struct bt_a2dp *a2dp_get_connection(struct bt_conn *conn)
 	a2dp = &connection[index];
 
 	if (a2dp->session.br_chan.chan.conn == NULL) {
+		/* The session release work submitted when the previous
+		 * connection was disconnected may still be pending. Wiping
+		 * a queued work item would corrupt the work queue, so
+		 * reject the object reuse until the work has completed.
+		 */
+		if (k_work_busy_get(&a2dp->session._release_work) != 0) {
+			return NULL;
+		}
+
 		/* Clean the memory area before returning */
 		(void)memset(a2dp, 0, sizeof(struct bt_a2dp));
 	}

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -2145,6 +2145,16 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 		return -ENOMEM;
 	}
 
+	/* The release work submitted when the previous connection was
+	 * disconnected may still be pending. Re-initializing a queued work
+	 * item would corrupt the work queue, so reject the session reuse
+	 * until the release work has completed.
+	 */
+	if (k_work_busy_get(&session->_release_work) != 0) {
+		k_sem_give(&avdtp_sem_lock);
+		return -EBUSY;
+	}
+
 	/* Locking semaphore initialized to 1 (unlocked). It has to be
 	 * initialized before the session is published, since the session
 	 * memory is owned and cleared by the upper layer.
@@ -2212,6 +2222,16 @@ int bt_avdtp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 	k_sem_take(&avdtp_sem_lock, K_FOREVER);
 
 	if (session->br_chan.chan.conn == NULL) {
+		/* The release work submitted when the previous connection
+		 * was disconnected may still be pending. Re-initializing a
+		 * queued work item would corrupt the work queue, so reject
+		 * the session reuse until the release work has completed.
+		 */
+		if (k_work_busy_get(&session->_release_work) != 0) {
+			k_sem_give(&avdtp_sem_lock);
+			return -ENOMEM;
+		}
+
 		/* Locking semaphore initialized to 1 (unlocked). It has to be
 		 * initialized before the session is published, since the
 		 * session memory is owned and cleared by the upper layer.


### PR DESCRIPTION
bt_avdtp_l2cap_disconnected() submits session->_release_work to defer the release of the session's endpoints. When the session object is reused for a new connection, both bt_avdtp_connect() and bt_avdtp_l2cap_accept() unconditionally k_work_init() that same work item, and a2dp_get_connection() goes further and wipes the whole containing bt_a2dp object with memset(). Doing either to a work item that is still queued corrupts the work queue's pending list — and since the remote can re-establish the AVDTP L2CAP channel immediately after a disconnect (no ACL re-establishment needed), the window is realistic whenever the system workqueue is backlogged.

The release work cannot simply be canceled on reuse, since the deferred endpoint release must always run. Instead, reject the reuse with an error while the release work is still pending: bt_avdtp_connect() returns -EBUSY, the accept path rejects with NO_RESOURCES (the remote retries), and a2dp_get_connection() returns NULL, which both its callers already handle. The rejection is transient — the release work completes on the system workqueue shortly after the disconnect. The checks are done under avdtp_sem_lock, and since the session has no L2CAP connection at that point, no new submission of the work can race with them.

One commit for the AVDTP session checks, one for the A2DP object-reuse check.

A similar lifecycle issue with session->timeout_work being re-initialized while potentially still scheduled is being addressed in #115996.

Fixes: #118952