### PR TITLE
Bluetooth: Classic: AVRCP: Fix dangling conn in cover art disconnect

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp_cover_art.c
+++ b/subsys/bluetooth/host/classic/avrcp_cover_art.c
@@ -175,9 +175,7 @@ static void tg_bip_transport_disconnected(struct bt_bip *bip)
 
 	LOG_DBG("BIP %p transport disconnected", bip);
 
-	if (tg->conn != NULL) {
-		bt_conn_unref(tg->conn);
-	}
+	bt_conn_drop(&tg->conn);
 
 	err = bt_bip_server_unregister(&tg->server);
 	if (err != 0) {
@@ -563,9 +561,7 @@ static void ct_bip_transport_disconnected(struct bt_bip *bip)
 
 	LOG_DBG("Cover Art CT %p  transport disconnected", ct);
 
-	if (ct->conn != NULL) {
-		bt_conn_unref(ct->conn);
-	}
+	bt_conn_drop(&ct->conn);
 
 	if ((cover_art_ct_cb != NULL) && (cover_art_ct_cb->l2cap_disconnected != NULL)) {
 		cover_art_ct_cb->l2cap_disconnected(ct);


### PR DESCRIPTION
The BIP transport disconnected callbacks for the Cover Art Target and Controller unreference tg->conn and ct->conn without clearing the pointers. The API functions in this file rely on a conn == NULL check to detect that the Cover Art channel is not connected, so after a transport disconnect these checks pass with a dangling pointer. Since connection objects are recycled, the stale pointer may also end up aliasing an unrelated live connection.

Use bt_conn_drop(), which unreferences the connection and clears the pointer, keeping the not-connected checks in the API functions sound.