### PR TITLE
Bluetooth: Classic: SCO: Fix dangling chan->sco on accept failure

### DIFF
--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -382,7 +382,21 @@ uint8_t bt_esco_conn_req(struct bt_hci_evt_conn_request *evt)
 	sco_conn->sco.link_type = evt->link_type;
 
 	if (accept_sco_conn(&evt->bdaddr, sco_conn)) {
+		struct bt_sco_chan *chan = sco_conn->sco.chan;
+
 		LOG_ERR("Error accepting connection from %s", bt_addr_str(&evt->bdaddr));
+
+		/* If the server accepted the connection request, a channel was
+		 * attached in sco_accept(). Detach it before releasing the
+		 * connection object so that the channel does not keep a
+		 * dangling reference to it. The disconnected callback is not
+		 * called since the connection was never established.
+		 */
+		if (chan != NULL) {
+			bt_sco_chan_set_state(chan, BT_SCO_STATE_DISCONNECTED);
+			chan->sco = NULL;
+		}
+
 		bt_sco_cleanup(sco_conn);
 		return BT_HCI_ERR_UNSPECIFIED;
 	}


### PR DESCRIPTION
If sending the HCI Accept Synchronous Connection Request command fails in accept_sco_conn(), bt_esco_conn_req() releases the SCO connection object with bt_sco_cleanup(), but the channel that was attached by sco_accept() is left with chan->sco pointing to the released connection object and with its state stuck at BT_SCO_STATE_CONNECTING.

For HFP AG this means that bt_hfp_ag_sco_accept() rejects all subsequent incoming SCO connections for the session, since ag->sco_chan.sco is never cleared, and hfp_ag_close_sco() may call bt_conn_disconnect() with a stale pointer which can alias an unrelated connection once the object is recycled.

Detach the channel and reset its state before releasing the connection object. The disconnected callback is intentionally not called since the connection was never established and the connected callback never ran.