### PR TITLE
Bluetooth: Classic: AVDTP: Clear conn marker on connect failure

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -2129,6 +2129,8 @@ static const struct bt_l2cap_chan_ops signal_chan_ops = {
 /*A2DP Layer interface */
 int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 {
+	int err;
+
 	if (!session) {
 		return -EINVAL;
 	}
@@ -2156,7 +2158,25 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 	session->br_chan.chan.ops = &signal_chan_ops;
 	session->br_chan.required_sec_level = BT_SECURITY_L2;
 
-	return bt_l2cap_chan_connect(conn, &session->br_chan.chan, BT_L2CAP_PSM_AVDTP);
+	err = bt_l2cap_chan_connect(conn, &session->br_chan.chan, BT_L2CAP_PSM_AVDTP);
+	if (err != 0) {
+		/* If the L2CAP connection creation failed before the channel
+		 * was added to the connection, no disconnected callback will
+		 * ever run to clear the connection marker set above, which
+		 * would prevent the session from ever being used again. Clear
+		 * the marker so that the session can be reused. If the
+		 * failure happened after the channel was added, the marker
+		 * has already been cleared by bt_l2cap_br_chan_del(), so only
+		 * clear it if it still holds the value set above.
+		 */
+		k_sem_take(&avdtp_sem_lock, K_FOREVER);
+		if (session->br_chan.chan.conn == conn) {
+			session->br_chan.chan.conn = NULL;
+		}
+		k_sem_give(&avdtp_sem_lock);
+	}
+
+	return err;
 }
 
 int bt_avdtp_disconnect(struct bt_avdtp *session)


### PR DESCRIPTION
bt_avdtp_connect() sets session->br_chan.chan.conn before calling bt_l2cap_chan_connect() in order to detect simultaneous local and remote AVDTP signaling connection attempts. If bt_l2cap_chan_connect() fails before the channel has been added to the connection, for example with -ENOTCONN when the ACL is no longer connected, or through one of the early argument and state checks in bt_l2cap_br_chan_connect(), no disconnected callback will ever run for the channel and the marker is never cleared. a2dp_get_connection() treats a non-NULL marker as a session in use, so every subsequent bt_a2dp_connect() for that connection index fails with -ENOMEM, including attempts on future ACL connections that reuse the same connection object.

Clear the marker on the error path of bt_l2cap_chan_connect(), holding avdtp_sem_lock like the other accesses to the marker. It is only cleared if it still holds the value set above, since a failure that occurs after the channel was added to the connection has already cleared it in bt_l2cap_br_chan_del().

The accept side sets the same marker in bt_avdtp_l2cap_accept(), but there the L2CAP server code owns the channel lifecycle after accept returns and deletes the channel with bt_l2cap_br_chan_del() on the failure paths, which clears the marker.