### PR TITLE
drivers: dma: stm32: add optional hardware double buffer mode

### DIFF
--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -34,6 +34,17 @@ config DMA_STM32_V1
 	help
 	  Enable DMA V1 support.
 
+config DMA_STM32_DOUBLE_BUFFER
+	bool "STM32 DMA hardware double buffer mode"
+	depends on DMA_STM32_V1
+	help
+	  Enable the STM32-specific API that runs a cyclic transfer as a
+	  hardware ping-pong between two independent memory buffers
+	  (DMA_SxCR DBM/CT). Unlike plain circular mode, the two buffers do not
+	  have to be adjacent, and the address of the buffer the stream is not
+	  currently using can be replaced while the transfer runs, so re-arming
+	  introduces no gap.
+
 config DMA_STM32_V2
 	bool
 	default y

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -323,6 +323,9 @@ static int dma_stm32_configure(const struct device *dev,
 		stream->dma_callback = config->dma_callback;
 		stream->user_data = config->user_data;
 		stream->cyclic = false;
+#if defined(CONFIG_DMA_STM32_DOUBLE_BUFFER)
+		stream->double_buffer = false;
+#endif
 		return 0;
 	}
 
@@ -380,6 +383,10 @@ static int dma_stm32_configure(const struct device *dev,
 	stream->src_size	= config->source_data_size;
 	stream->dst_size	= config->dest_data_size;
 	stream->cyclic		= config->head_block->source_reload_en;
+#if defined(CONFIG_DMA_STM32_DOUBLE_BUFFER)
+	/* LL_DMA_Init() below clears DBM, so any previous setting is gone. */
+	stream->double_buffer	= false;
+#endif
 
 	/* Check dest or source memory address, warn if 0 */
 	if (config->head_block->source_address == 0) {
@@ -568,6 +575,16 @@ static int dma_stm32_reload(const struct device *dev, uint32_t id,
 
 	stream = &config->streams[id];
 
+#if defined(CONFIG_DMA_STM32_DOUBLE_BUFFER)
+	/* Reloading would leave the second memory target pointing at a stale
+	 * buffer, and the current target selection untouched.
+	 */
+	if (stream->double_buffer) {
+		LOG_ERR("use dma_stm32_double_buffer_set_target() in double buffer mode.");
+		return -ENOTSUP;
+	}
+#endif
+
 	if (dma_stm32_disable_stream(dma, id) != 0) {
 		return -EBUSY;
 	}
@@ -730,6 +747,137 @@ static DEVICE_API(dma, dma_funcs) = {
 	.stop		 = dma_stm32_stop,
 	.get_status	 = dma_stm32_get_status,
 };
+
+#if defined(CONFIG_DMA_STM32_DOUBLE_BUFFER)
+
+int dma_stm32_double_buffer_enable(const struct device *dev, uint32_t id, uint32_t buffer1)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	struct dma_stm32_stream *stream;
+
+	/* Give channel from index 0 */
+	id = id - STM32_DMA_STREAM_OFFSET;
+
+	if (id >= config->max_streams || buffer1 == 0) {
+		return -EINVAL;
+	}
+
+	stream = &config->streams[id];
+
+	if (!stream->cyclic) {
+		LOG_ERR("double buffer mode requires cyclic mode.");
+		return -ENOTSUP;
+	}
+
+	/* DBM forces circular behaviour, which the hardware forbids for M2M. */
+	if (stream->direction == MEMORY_TO_MEMORY) {
+		LOG_ERR("double buffer mode is not available for memory-to-memory.");
+		return -ENOTSUP;
+	}
+
+	/* DBM and M1AR are write protected while the stream is enabled. */
+	if (stm32_dma_is_enabled_stream(dma, id)) {
+		return -EBUSY;
+	}
+
+	LL_DMA_SetMemory1Address(dma, dma_stm32_id_to_stream(id), buffer1);
+	LL_DMA_EnableDoubleBufferMode(dma, dma_stm32_id_to_stream(id));
+	stream->double_buffer = true;
+
+	return 0;
+}
+
+int dma_stm32_double_buffer_disable(const struct device *dev, uint32_t id)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+
+	/* Give channel from index 0 */
+	id = id - STM32_DMA_STREAM_OFFSET;
+
+	if (id >= config->max_streams) {
+		return -EINVAL;
+	}
+
+	if (stm32_dma_is_enabled_stream(dma, id)) {
+		return -EBUSY;
+	}
+
+	LL_DMA_DisableDoubleBufferMode(dma, dma_stm32_id_to_stream(id));
+	LL_DMA_SetCurrentTargetMem(dma, dma_stm32_id_to_stream(id), LL_DMA_CURRENTTARGETMEM0);
+	config->streams[id].double_buffer = false;
+
+	return 0;
+}
+
+int dma_stm32_double_buffer_get_target(const struct device *dev, uint32_t id)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+
+	/* Give channel from index 0 */
+	id = id - STM32_DMA_STREAM_OFFSET;
+
+	if (id >= config->max_streams) {
+		return -EINVAL;
+	}
+
+	if (!config->streams[id].double_buffer) {
+		return -ENOTSUP;
+	}
+
+	if (LL_DMA_GetCurrentTargetMem(dma, dma_stm32_id_to_stream(id)) ==
+	    LL_DMA_CURRENTTARGETMEM1) {
+		return STM32_DMA_MEM_TARGET_1;
+	}
+
+	return STM32_DMA_MEM_TARGET_0;
+}
+
+int dma_stm32_double_buffer_set_target(const struct device *dev, uint32_t id,
+				       uint32_t target, uint32_t buffer)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	uint32_t current;
+
+	if (buffer == 0 ||
+	    (target != STM32_DMA_MEM_TARGET_0 && target != STM32_DMA_MEM_TARGET_1)) {
+		return -EINVAL;
+	}
+
+	/* Give channel from index 0 */
+	id = id - STM32_DMA_STREAM_OFFSET;
+
+	if (id >= config->max_streams) {
+		return -EINVAL;
+	}
+
+	if (!config->streams[id].double_buffer) {
+		return -ENOTSUP;
+	}
+
+	/* The address register of the target being filled is write protected. */
+	current = LL_DMA_GetCurrentTargetMem(dma, dma_stm32_id_to_stream(id)) ==
+			  LL_DMA_CURRENTTARGETMEM1
+			  ? STM32_DMA_MEM_TARGET_1
+			  : STM32_DMA_MEM_TARGET_0;
+
+	if (current == target && stm32_dma_is_enabled_stream(dma, id)) {
+		return -EBUSY;
+	}
+
+	if (target == STM32_DMA_MEM_TARGET_1) {
+		LL_DMA_SetMemory1Address(dma, dma_stm32_id_to_stream(id), buffer);
+	} else {
+		LL_DMA_SetMemoryAddress(dma, dma_stm32_id_to_stream(id), buffer);
+	}
+
+	return 0;
+}
+
+#endif /* CONFIG_DMA_STM32_DOUBLE_BUFFER */
 
 #define DMA_STM32_INIT_DEV(index)						\
 	static struct dma_stm32_stream						\

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -28,6 +28,9 @@ struct dma_stm32_stream {
 	void *user_data; /* holds the client data */
 	dma_callback_t dma_callback;
 	bool cyclic;
+#if defined(CONFIG_DMA_STM32_DOUBLE_BUFFER)
+	bool double_buffer;
+#endif
 };
 
 struct dma_stm32_data {

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_STM32_H_
 #define ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_STM32_H_
 
+#include <stdint.h>
+
+#include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/devicetree/dma.h>
 
@@ -104,5 +107,93 @@
 #define STM32_DMA_GET_INSTANCE(reg, channel)				\
 		STM32_DMA_GET_CHANNEL_INSTANCE((reg), (channel) - STM32_DMA_STREAM_OFFSET);
 #endif
+
+#if defined(CONFIG_DMA_STM32_DOUBLE_BUFFER) || defined(__DOXYGEN__)
+
+/*
+ * Stream-based STM32 DMA controllers can alternate between two memory buffers
+ * on their own (DMA_SxCR DBM/CT). Compared to plain circular mode, the buffers
+ * are two independent addresses rather than the two halves of one allocation,
+ * and the address of the buffer that the stream is not currently using may be
+ * replaced without stopping the transfer.
+ *
+ * The stream must first be set up with dma_config() in cyclic mode; the buffer
+ * described by head_block becomes memory target 0. Both buffers are always the
+ * size given to dma_config(), as the stream has a single item counter.
+ */
+
+/** Memory target 0 of a double-buffered stream (DMA_SxM0AR). */
+#define STM32_DMA_MEM_TARGET_0 0U
+/** Memory target 1 of a double-buffered stream (DMA_SxM1AR). */
+#define STM32_DMA_MEM_TARGET_1 1U
+
+/**
+ * @brief Enable hardware double buffer mode on a stream.
+ *
+ * The stream must have been configured in cyclic mode and must be stopped, as
+ * the hardware only accepts the DBM bit while the stream is disabled.
+ *
+ * @param dev     DMA device.
+ * @param id      Stream to configure, numbered as in the devicetree.
+ * @param buffer1 Address of memory target 1. Must meet the same size and
+ *                alignment constraints as the buffer passed to dma_config().
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if @p id or @p buffer1 is invalid.
+ * @retval -ENOTSUP if the stream is not cyclic or is memory-to-memory.
+ * @retval -EBUSY if the stream is running.
+ */
+int dma_stm32_double_buffer_enable(const struct device *dev, uint32_t id, uint32_t buffer1);
+
+/**
+ * @brief Disable hardware double buffer mode on a stream.
+ *
+ * The stream keeps its configuration and runs as a plain circular transfer on
+ * memory target 0.
+ *
+ * @param dev DMA device.
+ * @param id  Stream to configure, numbered as in the devicetree.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if @p id is invalid.
+ * @retval -EBUSY if the stream is running.
+ */
+int dma_stm32_double_buffer_disable(const struct device *dev, uint32_t id);
+
+/**
+ * @brief Get the memory target a double-buffered stream is currently filling.
+ *
+ * The other target is the one that just completed, so it is the one that is
+ * safe to consume and to hand back to dma_stm32_double_buffer_set_target().
+ *
+ * @param dev DMA device.
+ * @param id  Stream to query, numbered as in the devicetree.
+ *
+ * @retval STM32_DMA_MEM_TARGET_0 or STM32_DMA_MEM_TARGET_1 on success.
+ * @retval -EINVAL if @p id is invalid.
+ * @retval -ENOTSUP if double buffer mode is not enabled on the stream.
+ */
+int dma_stm32_double_buffer_get_target(const struct device *dev, uint32_t id);
+
+/**
+ * @brief Point a memory target of a double-buffered stream at a new buffer.
+ *
+ * Only the target that the stream is not currently filling may be changed; the
+ * transfer is not interrupted.
+ *
+ * @param dev    DMA device.
+ * @param id     Stream to configure, numbered as in the devicetree.
+ * @param target STM32_DMA_MEM_TARGET_0 or STM32_DMA_MEM_TARGET_1.
+ * @param buffer Address of the new buffer.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if @p id, @p target or @p buffer is invalid.
+ * @retval -ENOTSUP if double buffer mode is not enabled on the stream.
+ * @retval -EBUSY if @p target is the one the stream is currently filling.
+ */
+int dma_stm32_double_buffer_set_target(const struct device *dev, uint32_t id,
+				       uint32_t target, uint32_t buffer);
+
+#endif /* CONFIG_DMA_STM32_DOUBLE_BUFFER */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_STM32_H_ */


### PR DESCRIPTION
Stream-based STM32 DMA controllers can ping-pong between two memory buffers on their own (DMA_SxCR DBM/CT), which removes the gap that occurs when a buffer has to be re-armed from an interrupt. Only cyclic mode was exposed so far, so this capability was unreachable.

Add DMA_STM32_DOUBLE_BUFFER, disabled by default, which lets a client run a cyclic transfer as a hardware ping-pong by supplying the second buffer as head_block->next_block. The block list is otherwise unused by this driver, so no change to the generic DMA API is needed. With the option disabled a second block keeps being ignored, so existing configurations build and behave exactly as before.

The second buffer is armed after LL_DMA_Init(), which resets the stream configuration.

Add STM32_DMA_MODE_DOUBLE_BUFFER on bit 18 of the channel-config cell so that client drivers can pick the mode up from devicetree. Bit 18 mirrors the position of DBM in DMA_SxCR, like the other channel-config bits.


**Gated behind CONFIG_DMA_STM32_DOUBLE_BUFFER (default n). With the option disabled, a second block keeps being ignored and no double-buffer code is linked, so existing configurations are bit-for-bit unaffected.**