### PR TITLE
Bluetooth: CAP: INI: Check metadata before operation

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1099,6 +1099,9 @@ Bluetooth Audio
     :zephyr:code-sample:`bluetooth_cap_handover` and
     :zephyr:code-sample:`bluetooth_cap_initiator` have been moved from
     ``samples/bluetooth/`` to ``samples/bluetooth/audio``.
+  * :c:func:`bt_cap_initiator_unicast_audio_update` now rejects the API call if it would result in
+    no changed states (i.e. the metadata in the parameters are identical to the metadata the server
+    have reported to us), and will return ``-EALREADY``.
 
 * CCP
 

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -605,7 +605,10 @@ int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start
  *
  * @param param Update parameters.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 Success
+ * @retval -EBUSY CAP procedure is already in progress
+ * @retval -EINVAL @p param contains invalid parameters
+ * @retval -EALREADY Metadata is already set for all the streams
  */
 int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_update_param *param);
 

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -2270,12 +2270,34 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
 	struct bt_cap_initiator_proc_param *proc_param;
 	struct bt_cap_common_proc *active_proc;
 	struct bt_bap_stream *bap_stream;
+	bool metadata_is_set = true;
 	const uint8_t *meta;
 	size_t meta_len;
 	int err;
 
 	if (!valid_unicast_audio_update_param(param)) {
 		return -EINVAL;
+	}
+
+	for (size_t i = 0U; i < param->count; i++) {
+		const struct bt_cap_unicast_audio_update_stream_param *stream_param =
+			&param->stream_params[i];
+		const struct bt_cap_stream *cap_stream = stream_param->stream;
+
+		if (!util_eq(cap_stream->bap_stream.codec_cfg->meta,
+			     cap_stream->bap_stream.codec_cfg->meta_len, stream_param->meta,
+			     stream_param->meta_len)) {
+
+			metadata_is_set = false;
+			break;
+		}
+
+		LOG_DBG("param->stream_params[%zu].meta is already set for stream %p", i,
+			cap_stream);
+	}
+
+	if (metadata_is_set) {
+		return -EALREADY;
 	}
 
 	active_proc = bt_cap_common_get_active_proc();

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -790,6 +790,18 @@ static void unicast_audio_update_inval(void)
 		     "fail\n");
 		return;
 	}
+
+	/* Attempt to set identical metadata */
+	(void)memcpy(&invalid_codec.meta, stream_params[0].stream->bap_stream.codec_cfg->meta,
+		     stream_params[0].stream->bap_stream.codec_cfg->meta_len);
+	stream_params[0].meta = invalid_codec.meta;
+	stream_params[0].meta_len = stream_params[0].stream->bap_stream.codec_cfg->meta_len;
+
+	err = bt_cap_initiator_unicast_audio_update(&param);
+	if (err != -EALREADY) {
+		FAIL("bt_cap_initiator_unicast_audio_update with identical meta did not fail\n");
+		return;
+	}
 }
 
 static void unicast_audio_update(void)


### PR DESCRIPTION
Before initializing the metadata update procedure, we perform a check to see if there are any streams to update.