### PR TITLE
drivers: serial: stm32: fix async RX teardown race

### DIFF
--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
@@ -15,6 +15,7 @@ supported:
   - uart
   - gpio
   - counter
+  - dma
   - i2c
   - pwm
   - netif:eth

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1722,6 +1722,11 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 	const struct device *uart_dev = user_data;
 	struct uart_stm32_data *data = uart_dev->data;
 
+	/* Drop DMA callbacks after RX is disabled */
+	if (!data->dma_rx.enabled) {
+		return;
+	}
+
 	if (status < 0) {
 		async_evt_rx_err(data, status);
 		return;

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	dmas = <&dmamux1 2 44 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 3 43 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};


### PR DESCRIPTION
When asynchronous RX is being disabled, a late DMA callback can still arrive while teardown is in progress and observe stale RX state. This can cause buffer handover calls to fail spuriously and introduces nondeterministic behavior during RX state transitions.

Prevent this race by ignoring late DMA RX callbacks once RX is disabled.

This keeps async RX state transitions deterministic and avoids processing callbacks against torn-down RX context.

This is a spinoff of #116122 and #102014, where my DMA patches surfaced a bug in the UART async API tests. My testing on `nucleo_h755zi_q` board with this specific test run was failing:
```
./scripts/twister --device-testing --device-serial /dev/ttyACM0 -p nucleo_h755zi_q/stm32h755xx/m7 -T tests/drivers/uart/uart_async_api -s drivers.uart.async_api --fixture gpio_loopback -v --west-flash --west-runner openocd --device-flash-timeout 120
```

I couldn't really identify which exact change caused this regression, which further points towards a timing related problem.