### PR TITLE
samples: drivers: memc: mspi_stm32: Add missing st,mem-type property

### DIFF
--- a/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.overlay
+++ b/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.overlay
@@ -39,6 +39,7 @@
 				compatible = "st,psram-device", "aps-z8";
 				reg = <0>;
 				size = <DT_SIZE_M(128)>;
+				st,mem-type = "apmem";
 				mspi-max-frequency = <DT_FREQ_M(133)>;
 				mspi-io-mode = "MSPI_IO_MODE_HEX_8_8_16";
 				mspi-data-rate = "MSPI_DATA_RATE_S_D_D";


### PR DESCRIPTION
Following 27d8d897074df102e57b59d3db3e33e4cb9f48f0, st,mem-type is now a required property in devices declaring "st,psram-device" compatible.

Leftover from #114756