### PR TITLE
kernel: spinlock: add spinlock pool API

### DIFF
--- a/doc/kernel/data_structures/index.rst
+++ b/doc/kernel/data_structures/index.rst
@@ -40,3 +40,4 @@ structures are thread safe in specific usage scenarios (see
   spsc_lockfree.rst
   min_heap.rst
   ringq.rst
+  spinlocks.rst

--- a/doc/kernel/data_structures/spinlocks.rst
+++ b/doc/kernel/data_structures/spinlocks.rst
@@ -1,0 +1,166 @@
+.. _spinlocks:
+
+Spinlocks
+#########
+
+.. contents::
+  :local:
+  :depth: 2
+
+A spinlock is the lowest-level mutual-exclusion primitive in Zephyr.
+It guards a brief critical section so that only one execution context can access a shared resource
+at a time. A context that finds the lock already held "spins", busy waiting until the lock becomes
+available, rather than blocking and yielding the CPU. This is why spinlocks are only appropriate for
+short critical sections.
+
+Acquiring a spinlock also masks interrupts on the local CPU for as long as the lock is held. This is
+what makes a spinlock safe to share between threads and interrupt handlers: while a context holds
+the lock, no ISR on the same CPU can preempt it and no other CPU can enter the critical section, so
+neither can observe or corrupt the protected data mid-update.
+For these reasons, :c:struct:`k_spinlock` is the primary synchronization primitive used within the
+Zephyr kernel itself, protecting access to its core data structures.
+
+Application code may use it directly as well but it is generally recommended to use a higher-level
+synchronization primitive such as a ``k_mutex`` or ``k_sem`` instead.
+
+Usage
+*****
+
+Declare a :c:struct:`k_spinlock` for each independent resource you need to protect. Acquire it with
+:c:func:`k_spin_lock`, which returns a :c:type:`k_spinlock_key_t` that must be passed back to
+:c:func:`k_spin_unlock` to release the lock:
+
+.. code-block:: c
+
+   static struct k_spinlock lock;
+
+   void update_shared_state(void)
+   {
+           k_spinlock_key_t key = k_spin_lock(&lock);
+
+           /* critical section: exclusive access */
+
+           k_spin_unlock(&lock, key);
+   }
+
+The :c:macro:`K_SPINLOCK` helper acquires the lock for the duration of the
+enclosed block and releases it automatically on exiting the block.
+
+.. code-block:: c
+
+   static struct k_spinlock lock;
+
+   void update_shared_state(void)
+   {
+           K_SPINLOCK(&lock) {
+               /* critical section: exclusive access */
+           }
+   }
+
+Follow these rules when using a spinlock:
+
+* Keep the critical section as short as possible. Interrupts are masked on the
+  local CPU while the lock is held, and other CPUs may be spinning on it.
+* Never perform a blocking or sleeping operations while holding a spinlock.
+* Do not acquire a spinlock recursively. A context that already holds a lock
+  must not try to take it again, or it will deadlock. Nesting **distinct**
+  spinlocks is allowed, but must follow a consistent lock ordering to avoid
+  deadlock.
+
+.. _spinlocks_smp:
+
+Behavior on SMP systems
+***********************
+
+On multiprocessor systems the spinlock does more than mask local interrupts. It
+also atomically validates that a shared lock variable has been modified before
+returning to the caller, "spinning" on the check if needed to wait for another
+CPU to exit the lock. The default Zephyr implementation of :c:func:`k_spin_lock`
+and :c:func:`k_spin_unlock` is built on top of the pre-existing
+:c:struct:`atomic_` layer (itself usually implemented using compiler
+intrinsics), though facilities exist for architectures to define their own for
+performance reasons.
+
+This is the key difference from the legacy :c:func:`irq_lock` API. That API was
+naturally recursive: the lock was global, so it was legal to acquire a nested
+lock inside of a critical section. Spinlocks are separable: you can have many
+locks for separate subsystems or data structures, preventing CPUs from
+contending on a single global resource. But that means that spinlocks must not
+be used recursively. A validation layer is available to detect and report bugs
+like this.
+
+When used on a uniprocessor system, the data component of the spinlock (the
+atomic lock variable) is unnecessary and elided. Except for the recursive
+semantics above, spinlocks in single-CPU contexts produce identical code to
+legacy IRQ locks. In fact the entirety of the Zephyr core kernel has now been
+ported to use spinlocks exclusively.
+
+The default spinlock implementation is built on a single atomic variable and
+does not guarantee fairness between contending CPUs: it is possible for one CPU
+to repeatedly win the contention, in pathological cases starving the others.
+Where this matters, enabling :kconfig:option:`CONFIG_TICKET_SPINLOCKS` switches
+to a ticket-based implementation that grants a contended lock to requesting CPUs
+in first-come, first-served order, at the cost of a slightly larger lock object.
+
+.. _spinlock_pool_api:
+
+Spinlock pools
+**************
+
+A spinlock pool allows many objects to share a fixed number of spinlocks.
+This reduces the memory required compared with embedding one spinlock in every object, while
+permitting operations on objects assigned to different spinlocks to run concurrently. Inversely, it
+also increases throughput by reducing contention on a single lock when many objects are accessed
+concurrently.
+
+Define a pool at file scope with :c:macro:`SPINLOCK_POOL_DEFINE`.
+
+**How big should a pool be?**
+
+The larger the pool, the fewer collisions there will be between objects, but the more static memory is used.
+Given your applications runtime characteristics, you can tune the pool size to balance memory
+usage and concurrency.
+As peak concurrent locking entities are ,generally, bounded by the number of CPUs, a pool should be
+between 2 and 4 times the number of CPUs. This to maximize concurrency while keeping the memory
+footprint reasonable. After 2-4 times the number of CPUs, the drop off in collision rate will
+sharply become less significant, while the memory footprint will continue to grow linearly.
+
+**Note:**
+On a uniprocessor a spinlock only masks local interrupts, and no two
+contexts can ever be inside the pools critical sections at the same time, so a
+pool provides no concurrency benefit.
+
+
+Use :c:macro:`spinlock_find` to select the spinlock associated with an object identity:
+
+.. code-block:: c
+
+   SPINLOCK_POOL_DEFINE(device_locks, 16);
+
+   void update_device(struct device_data *data)
+   {
+           struct k_spinlock *lock = spinlock_find(device_locks, data);
+           k_spinlock_key_t key = k_spin_lock(lock);
+
+           update_device_state(data);
+
+           k_spin_unlock(lock, key);
+   }
+
+The lookup derives an index from the objects address. Different addresses can map to the same
+spinlock, this is an expected collision and only reduces concurrency. The identity should normally
+be a stable, naturally aligned object address.
+
+Spinlock pools should not be used for objects that may access another object in the same pool while
+holding a lock. This can lead to a deadlock if the two objects happen to map to the same spinlock.
+
+Increasing the pool size reduces collisions at the cost of static memory. It does not guarantee that
+each spinlock occupies a separate cache line, so adjacent spinlocks can still experience cache-line
+contention on SMP systems.
+
+See :ref:`smp_arch` for how spinlocks fit into Zephyr's SMP support.
+
+API Reference
+*************
+
+.. doxygengroup:: spinlock_apis

--- a/doc/kernel/services/smp/smp.rst
+++ b/doc/kernel/services/smp/smp.rst
@@ -45,81 +45,12 @@ data!
 Spinlocks
 =========
 
-SMP systems provide a more constrained :c:func:`k_spin_lock` primitive
-that not only masks interrupts locally, as done by :c:func:`irq_lock`, but
-also atomically validates that a shared lock variable has been
-modified before returning to the caller, "spinning" on the check if
-needed to wait for the other CPU to exit the lock.  The default Zephyr
-implementation of :c:func:`k_spin_lock` and :c:func:`k_spin_unlock` is built
-on top of the pre-existing :c:struct:`atomic_` layer (itself usually
-implemented using compiler intrinsics), though facilities exist for
-architectures to define their own for performance reasons.
-
-One important difference between IRQ locks and spinlocks is that the
-earlier API was naturally recursive: the lock was global, so it was
-legal to acquire a nested lock inside of a critical section.
-Spinlocks are separable: you can have many locks for separate
-subsystems or data structures, preventing CPUs from contending on a
-single global resource.  But that means that spinlocks must not be
-used recursively.  Code that holds a specific lock must not try to
-re-acquire it or it will deadlock (it is perfectly legal to nest
-**distinct** spinlocks, however).  A validation layer is available to
-detect and report bugs like this.
-
-When used on a uniprocessor system, the data component of the spinlock
-(the atomic lock variable) is unnecessary and elided.  Except for the
-recursive semantics above, spinlocks in single-CPU contexts produce
-identical code to legacy IRQ locks.  In fact the entirety of the
-Zephyr core kernel has now been ported to use spinlocks exclusively.
-
-The default spinlock implementation is built on a single atomic variable and
-does not guarantee fairness between contending CPUs: it is possible for one CPU
-to repeatedly win the contention, in pathological cases starving the others.
-Where this matters, enabling :kconfig:option:`CONFIG_TICKET_SPINLOCKS` switches
-to a ticket-based implementation that grants a contended lock to requesting CPUs
-in first-come, first-served order, at the cost of a slightly larger lock object.
-
-Spinlock pools
---------------
-
-A spinlock pool allows many objects to share a fixed number of spinlocks. This
-reduces the memory required compared with embedding one spinlock in every object,
-while permitting operations on objects assigned to different spinlocks to run
-concurrently.
-
-Define a pool at file scope with :c:macro:`SPINLOCK_POOL_DEFINE`. The number of
-spinlocks must be a nonzero power of two. Use :c:macro:`spinlock_find` to select
-the spinlock associated with an object identity:
-
-.. code-block:: c
-
-   SPINLOCK_POOL_DEFINE(device_locks, 16);
-
-   void update_device(struct device_data *data)
-   {
-           struct k_spinlock *lock = spinlock_find(device_locks, data);
-           k_spinlock_key_t key = k_spin_lock(lock);
-
-           update_device_state(data);
-
-           k_spin_unlock(lock, key);
-   }
-
-The lookup derives an index from the object identity. Repeated lookups using the
-same identity and pool return the same spinlock. Different identities can map to
-the same spinlock; this is an expected collision and only reduces concurrency.
-The identity should normally be a stable, naturally aligned object address.
-
-Spinlock pools do not make spinlocks recursive. Two logical locks from the same
-pool can resolve to the same physical spinlock. Acquiring one while holding the
-other can therefore deadlock. Do not use a shared pool for locks that may be
-nested unless their assigned spinlocks are guaranteed to be distinct. The same
-lock ordering requirements that apply to individual spinlocks also apply to
-spinlocks returned from a pool.
-
-Increasing the pool size reduces collisions at the cost of static memory. It
-does not guarantee that each spinlock occupies a separate cache line, so adjacent
-spinlocks can still experience cache-line contention on SMP systems.
+SMP systems provide a more constrained :c:func:`k_spin_lock` primitive that
+masks interrupts locally, like :c:func:`irq_lock`, while also atomically
+guarding a shared lock variable so that only one CPU enters the critical
+section at a time. Unlike the legacy IRQ locks, spinlocks are separable and
+must not be acquired recursively. See :ref:`spinlocks` for a full description,
+including ticket spinlocks, spinlock pools, and the API reference.
 
 Legacy irq_lock() emulation
 ===========================
@@ -516,8 +447,3 @@ system, it is moved to the back of the queue for its priority level. In
 contrast, on UP systems, a preempted thread does not move to the back of its
 priority queue; it simply waits to regain the CPU, preserving its original
 ordering relative to other threads of the same priority.
-
-API Reference
-**************
-
-.. doxygengroup:: spinlock_apis

--- a/doc/kernel/services/smp/smp.rst
+++ b/doc/kernel/services/smp/smp.rst
@@ -79,6 +79,48 @@ Where this matters, enabling :kconfig:option:`CONFIG_TICKET_SPINLOCKS` switches
 to a ticket-based implementation that grants a contended lock to requesting CPUs
 in first-come, first-served order, at the cost of a slightly larger lock object.
 
+Spinlock pools
+--------------
+
+A spinlock pool allows many objects to share a fixed number of spinlocks. This
+reduces the memory required compared with embedding one spinlock in every object,
+while permitting operations on objects assigned to different spinlocks to run
+concurrently.
+
+Define a pool at file scope with :c:macro:`SPINLOCK_POOL_DEFINE`. The number of
+spinlocks must be a nonzero power of two. Use :c:macro:`spinlock_find` to select
+the spinlock associated with an object identity:
+
+.. code-block:: c
+
+   SPINLOCK_POOL_DEFINE(device_locks, 16);
+
+   void update_device(struct device_data *data)
+   {
+           struct k_spinlock *lock = spinlock_find(device_locks, data);
+           k_spinlock_key_t key = k_spin_lock(lock);
+
+           update_device_state(data);
+
+           k_spin_unlock(lock, key);
+   }
+
+The lookup derives an index from the object identity. Repeated lookups using the
+same identity and pool return the same spinlock. Different identities can map to
+the same spinlock; this is an expected collision and only reduces concurrency.
+The identity should normally be a stable, naturally aligned object address.
+
+Spinlock pools do not make spinlocks recursive. Two logical locks from the same
+pool can resolve to the same physical spinlock. Acquiring one while holding the
+other can therefore deadlock. Do not use a shared pool for locks that may be
+nested unless their assigned spinlocks are guaranteed to be distinct. The same
+lock ordering requirements that apply to individual spinlocks also apply to
+spinlocks returned from a pool.
+
+Increasing the pool size reduces collisions at the cost of static memory. It
+does not guarantee that each spinlock occupies a separate cache line, so adjacent
+spinlocks can still experience cache-line contention on SMP systems.
+
 Legacy irq_lock() emulation
 ===========================
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5854,7 +5854,6 @@ struct k_pipe {
  */
 	size_t waiting;
 	struct ring_buf buf;
-	struct k_spinlock lock;
 	_wait_q_t data;
 	_wait_q_t space;
 	uint8_t flags;

--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -458,6 +458,38 @@ static ALWAYS_INLINE void z_spin_onexit(__maybe_unused k_spinlock_key_t *k)
 	for (k_spinlock_key_t __i K_SPINLOCK_ONEXIT = {}, __key = k_spin_lock(lck); !__i.key;      \
 	     k_spin_unlock((lck), __key), __i.key = 1)
 
+/**
+ * @brief Define a spinlock pool.
+ *
+ * Defines an array of zero-initialized spinlocks for use with spinlock_find().
+ * The pool size must be a nonzero power of two.
+ *
+ * @param name Name of the spinlock pool.
+ * @param num_spinlocks Number of spinlocks in the pool.
+ */
+#define SPINLOCK_POOL_DEFINE(name, num_spinlocks)					\
+	BUILD_ASSERT((num_spinlocks) > 0 && IS_POWER_OF_TWO(num_spinlocks),		\
+		     "spinlock pool count must be a power of two");			\
+	static struct k_spinlock name[num_spinlocks];					\
+	enum { z_##name##_spinlock_pool_size = (num_spinlocks) }
+
+/* @cond INTERNAL_HIDDEN */
+static ALWAYS_INLINE size_t z_spinlock_index(uintptr_t obj, size_t pool_size)
+{
+	return ((obj >> 2) & (pool_size - 1));
+}
+/* @endcond */
+
+/**
+ * @brief Find the spinlock associated with an object identity.
+ *
+ * @param pool Spinlock pool defined with SPINLOCK_POOL_DEFINE().
+ * @param obj Integer or pointer identifying the object.
+ *
+ * @return Pointer to the spinlock associated with @p obj.
+ */
+#define spinlock_find(pool, obj) \
+	(&(pool)[z_spinlock_index((uintptr_t)(obj), z_##pool##_spinlock_pool_size)])
 /** @} */
 
 #ifdef __cplusplus

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -390,6 +390,22 @@ config NONZERO_SPINLOCK_SIZE
 	  non-zero size (such as if used in an array). It is automatically
 	  selected when using C++.
 
+config PIPE_SPINLOCK_POOL_SHIFT
+	int "Pipe spinlock pool size (log2)"
+	default 0 if !SMP
+	default 3
+	range 0 8
+	help
+	  Log2 of the number of spinlocks in the pool shared by all
+	  pipes. The pool size is (1 << this value), always a power
+	  of two. Pipes are hashed onto the pool by address, so a
+	  larger pool reduces lock contention between unrelated
+	  pipes at the cost of static RAM.
+
+	  A pool provides no concurrency benefit on uniprocessor systems.
+	  On SMP, 2-4x the number of CPUs is recommended, the default of
+	  shift 3 (8 locks) suits typical 2-4 core systems.
+
 endmenu
 
 menu "Kernel Debugging and Metrics"

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -16,6 +16,8 @@
 static struct k_obj_type obj_type_pipe;
 #endif /* CONFIG_OBJ_CORE_PIPE */
 
+SPINLOCK_POOL_DEFINE(pipe_locks, BIT(CONFIG_PIPE_SPINLOCK_POOL_SHIFT));
+
 static inline bool pipe_closed(struct k_pipe *pipe)
 {
 	return (pipe->flags & PIPE_FLAG_OPEN) == 0;
@@ -62,8 +64,8 @@ static int wait_for(_wait_q_t *waitq, struct k_pipe *pipe, k_spinlock_key_t *key
 	} else {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_pipe, read, pipe, timeout);
 	}
-	rc = z_pend_curr(&pipe->lock, *key, waitq, timeout);
-	*key = k_spin_lock(&pipe->lock);
+	rc = z_pend_curr(spinlock_find(pipe_locks, pipe), *key, waitq, timeout);
+	*key = k_spin_lock(spinlock_find(pipe_locks, pipe));
 	pipe->waiting--;
 	if (unlikely(pipe_resetting(pipe))) {
 		if (pipe->waiting == 0) {
@@ -81,7 +83,6 @@ void z_impl_k_pipe_init(struct k_pipe *pipe, uint8_t *buffer, size_t buffer_size
 	pipe->flags = PIPE_FLAG_OPEN;
 	pipe->waiting = 0;
 
-	pipe->lock = (struct k_spinlock){};
 	z_waitq_init(&pipe->data);
 	z_waitq_init(&pipe->space);
 	k_object_init(pipe);
@@ -154,7 +155,8 @@ int z_impl_k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len, k_
 	int rc;
 	size_t written = 0;
 	k_timepoint_t end = sys_timepoint_calc(timeout);
-	k_spinlock_key_t key = k_spin_lock(&pipe->lock);
+	struct k_spinlock *lock = spinlock_find(pipe_locks, pipe);
+	k_spinlock_key_t key = k_spin_lock(lock);
 	bool need_resched = false;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, write, pipe, data, len, timeout);
@@ -215,9 +217,9 @@ int z_impl_k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len, k_
 out:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_pipe, write, pipe, rc);
 	if (need_resched) {
-		z_reschedule(&pipe->lock, key);
+		z_reschedule(lock, key);
 	} else {
-		k_spin_unlock(&pipe->lock, key);
+		k_spin_unlock(lock, key);
 	}
 	return rc;
 }
@@ -227,7 +229,8 @@ int z_impl_k_pipe_read(struct k_pipe *pipe, uint8_t *data, size_t len, k_timeout
 	struct pipe_buf_spec buf = { data, len, 0 };
 	int rc;
 	k_timepoint_t end = sys_timepoint_calc(timeout);
-	k_spinlock_key_t key = k_spin_lock(&pipe->lock);
+	struct k_spinlock *lock = spinlock_find(pipe_locks, pipe);
+	k_spinlock_key_t key = k_spin_lock(lock);
 	bool need_resched = false;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, read, pipe, data, len, timeout);
@@ -265,9 +268,9 @@ int z_impl_k_pipe_read(struct k_pipe *pipe, uint8_t *data, size_t len, k_timeout
 out:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_pipe, read, pipe, rc);
 	if (need_resched) {
-		z_reschedule(&pipe->lock, key);
+		z_reschedule(lock, key);
 	} else {
-		k_spin_unlock(&pipe->lock, key);
+		k_spin_unlock(lock, key);
 	}
 	return rc;
 }
@@ -275,7 +278,7 @@ out:
 void z_impl_k_pipe_reset(struct k_pipe *pipe)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, reset, pipe);
-	K_SPINLOCK(&pipe->lock) {
+	K_SPINLOCK(spinlock_find(pipe_locks, pipe)) {
 		ring_buf_reset(&pipe->buf);
 		if (likely(pipe->waiting != 0)) {
 			pipe->flags |= PIPE_FLAG_RESET;
@@ -289,7 +292,7 @@ void z_impl_k_pipe_reset(struct k_pipe *pipe)
 void z_impl_k_pipe_close(struct k_pipe *pipe)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, close, pipe);
-	K_SPINLOCK(&pipe->lock) {
+	K_SPINLOCK(spinlock_find(pipe_locks, pipe)) {
 		pipe->flags = 0;
 		z_sched_wake_all(&pipe->data, 0, NULL);
 		z_sched_wake_all(&pipe->space, 0, NULL);

--- a/tests/kernel/spinlock/spinlock_api/CMakeLists.txt
+++ b/tests/kernel/spinlock/spinlock_api/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spinlock_api)
 
-target_sources(app PRIVATE src/main.c)
-target_sources(app PRIVATE src/spinlock_error_case.c)
-target_sources(app PRIVATE src/spinlock_fairness.c)
+target_sources(app PRIVATE src/spinlock_pool.c)
+
+if(CONFIG_SMP)
+  target_sources(app PRIVATE src/main.c)
+  target_sources(app PRIVATE src/spinlock_error_case.c)
+  target_sources(app PRIVATE src/spinlock_fairness.c)
+endif()

--- a/tests/kernel/spinlock/spinlock_api/src/spinlock_pool.c
+++ b/tests/kernel/spinlock/spinlock_api/src/spinlock_pool.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/spinlock.h>
+#include <zephyr/ztest.h>
+
+#define NUMBER_OF_SPINLOCKS 8
+
+SPINLOCK_POOL_DEFINE(lonely_lock, 1);
+SPINLOCK_POOL_DEFINE(test_pool, NUMBER_OF_SPINLOCKS);
+
+ZTEST(spinlock_pool, test_spinlock_single)
+{
+	for (size_t i = 0; i < 128; i++) {
+		zassert_equal_ptr(spinlock_find(lonely_lock, i), &lonely_lock[0]);
+	}
+
+	zassert_equal_ptr(spinlock_find(lonely_lock, UINTPTR_MAX), &lonely_lock[0]);
+}
+
+ZTEST(spinlock_pool, test_spinlock_lookup)
+{
+	uintptr_t object = 0x1234U;
+	struct k_spinlock *lock = spinlock_find(test_pool, object);
+
+	zassume(sizeof(struct k_spinlock) != 0, "pool elements are zero-sized");
+
+	zassert_true(lock >= &test_pool[0]);
+	zassert_true(lock < &test_pool[NUMBER_OF_SPINLOCKS]);
+
+	zassert_equal_ptr(spinlock_find(test_pool, object), lock);
+}
+
+ZTEST(spinlock_pool, test_spinlock_distribution)
+{
+	bool seen[NUMBER_OF_SPINLOCKS] = { false };
+
+	zassume(sizeof(struct k_spinlock) != 0, "pool elements are zero-sized");
+
+	for (size_t i = 0; i < NUMBER_OF_SPINLOCKS; i++) {
+		struct k_spinlock *lock = spinlock_find(test_pool, i * 4U);
+		size_t index = z_spinlock_index(i * 4U, NUMBER_OF_SPINLOCKS);
+
+		zassert_equal_ptr(lock, &test_pool[index], "lock does not match computed slot");
+		zassert_false(seen[index], "pool %zu selected more than once", index);
+		seen[index] = true;
+	}
+
+	for (size_t i = 0; i < NUMBER_OF_SPINLOCKS; i++) {
+		zassert_true(seen[i], "pool %zu was not selected", i);
+	}
+}
+
+ZTEST(spinlock_pool, test_spinlock_lock)
+{
+	struct k_spinlock *lock = spinlock_find(test_pool, 4U);
+	k_spinlock_key_t key = k_spin_lock(lock);
+
+	zassert_true(z_spin_is_locked(lock));
+	k_spin_unlock(lock, key);
+	zassert_false(z_spin_is_locked(lock));
+}
+
+
+ZTEST(spinlock_pool, test_spinlock_dual_access)
+{
+	struct k_spinlock *lock1 = spinlock_find(test_pool, 4U);
+	struct k_spinlock *lock2 = spinlock_find(test_pool, 8U);
+
+	k_spinlock_key_t key1 = k_spin_lock(lock1);
+	k_spinlock_key_t key2 = k_spin_lock(lock2);
+
+	zassert_true(z_spin_is_locked(lock1));
+	zassert_true(z_spin_is_locked(lock2));
+
+	k_spin_unlock(lock2, key2);
+	k_spin_unlock(lock1, key1);
+
+	zassert_false(z_spin_is_locked(lock1));
+	zassert_false(z_spin_is_locked(lock2));
+}
+
+ZTEST_SUITE(spinlock_pool, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/spinlock/spinlock_api/tests.yaml
+++ b/tests/kernel/spinlock/spinlock_api/tests.yaml
@@ -31,3 +31,14 @@ tests:
       - CONFIG_SCHED_SIMPLE=y
       - CONFIG_SCHED_CPU_MASK=y
       - CONFIG_TICKET_SPINLOCKS=y
+  kernel.spinlock.stripe.up:
+    tags:
+      - kernel
+      - spinlock
+    filter: not CONFIG_SMP
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_SMP=n
+      - CONFIG_SPIN_VALIDATE=n
+      - CONFIG_NONZERO_SPINLOCK_SIZE=n


### PR DESCRIPTION
Add `SPINLOCK_POOL_DEFINE()` and `spinlock_find()`, letting many objects share a
fixed array of spinlocks instead of embedding a `k_spinlock`
in every object. `spinlock_find(pool, obj)` maps an object address to a pool
entry.

This trades a small, tunable amount of static memory for lower footprint while
preserving concurrency: objects that computes to different entries still lock in
parallel.

Original idea from https://github.com/zephyrproject-rtos/zephyr/pull/114888 and @wizard97.
This extends the idea so each object type can implement this while sharing the boilerplate.

Optionally extracts the general `k_spinlock` documentation out of the SMP page into a dedicated `spinlocks.rst` page.
https://builds.zephyrproject.io/zephyr/pr/116207/docs/kernel/data_structures/spinlocks.html