### PR TITLE
manifest: littlefs: update west revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -313,7 +313,7 @@ manifest:
       path: modules/fs/littlefs
       groups:
         - fs
-      revision: 7b969efe9ecf2942e811aeaaa3f2782623642ccf
+      revision: e9a8638fc228e43a3156ed3ac602229af3e3c1d5
     - name: lora-basics-modem
       revision: a8ddc544043e72807cf7db532478e1dda734ae7c
       path: modules/lib/lora-basics-modem


### PR DESCRIPTION
Point the littlefs module at zephyrproject-rtos/littlefs#21, which removes littlefs dependency on __ASSERT_ON.

Zephyr no longer defines` __ASSERT_ON` when asserts are enabled, so the module must suppress the relevant compiler warnings by a different method.

Prerequisite for: #112756