### PR TITLE
drivers: counter: max32_rtc: Add square wave output support

### DIFF
--- a/drivers/counter/counter_max32_rtc.c
+++ b/drivers/counter/counter_max32_rtc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,6 +27,11 @@ LOG_MODULE_REGISTER(max32_counter_rtc, CONFIG_COUNTER_LOG_LEVEL);
 #define MAX32_RTC_COUNTER_INT_FL MXC_RTC_INT_FL_LONG
 #define MAX32_RTC_COUNTER_INT_EN MXC_RTC_INT_EN_LONG
 
+#define MAX32_RTC_COUNTER_SQW_1HZ 1
+#define MAX32_RTC_COUNTER_SQW_512HZ 512
+#define MAX32_RTC_COUNTER_SQW_4KHZ 4096
+#define MAX32_RTC_COUNTER_SQW_32KHZ 32768
+
 struct max32_rtc_data {
 	counter_alarm_callback_t alarm_callback;
 	counter_top_callback_t top_callback;
@@ -37,6 +42,8 @@ struct max32_rtc_data {
 struct max32_rtc_config {
 	struct counter_config_info info;
 	mxc_rtc_regs_t *regs;
+	const struct pinctrl_dev_config *pctrl;
+	uint16_t sqw_freq;
 	void (*irq_func)(void);
 	struct max32_perclk perclk;
 };
@@ -210,6 +217,36 @@ static void rtc_max32_isr(const struct device *dev)
 	MXC_RTC_ClearFlags(flags);
 }
 
+static int configure_sqw(uint16_t sqw_freq)
+{
+	mxc_rtc_freq_sel_t freq_sel;
+
+	switch (sqw_freq) {
+	case MAX32_RTC_COUNTER_SQW_1HZ:
+		freq_sel = MXC_RTC_F_1HZ;
+		break;
+	case MAX32_RTC_COUNTER_SQW_512HZ:
+		freq_sel = MXC_RTC_F_512HZ;
+		break;
+	case MAX32_RTC_COUNTER_SQW_4KHZ:
+		freq_sel = MXC_RTC_F_4KHZ;
+		break;
+	case MAX32_RTC_COUNTER_SQW_32KHZ:
+		freq_sel = MXC_RTC_F_32KHZ;
+		break;
+	default:
+		LOG_ERR("Unsupported square wave frequency: %d", sqw_freq);
+		return -ENOTSUP;
+	}
+
+	if (MXC_RTC_SquareWaveStart(freq_sel) != E_SUCCESS) {
+		LOG_ERR("Failed to start square wave output");
+		return -EIO;
+	}
+
+	return 0;
+}
+
 static int rtc_max32_init(const struct device *dev)
 {
 	int ret;
@@ -219,6 +256,20 @@ static int rtc_max32_init(const struct device *dev)
 		if (ret < 0) {
 			LOG_ERR("RTC does not support this clock source.");
 			return -ENOTSUP;
+		}
+	}
+
+	if (cfg->sqw_freq != 0) {
+		ret = pinctrl_apply_state(cfg->pctrl, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			LOG_ERR("Failed to apply pinctrl state: %d", ret);
+			return ret;
+		}
+
+		ret = configure_sqw(cfg->sqw_freq);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure square wave output: %d", ret);
+			return ret;
 		}
 	}
 
@@ -242,6 +293,7 @@ static DEVICE_API(counter, counter_rtc_max32_driver_api) = {
 
 #define COUNTER_RTC_MAX32_INIT(_num)                                                               \
 	static struct max32_rtc_data rtc_max32_data_##_num;                                        \
+	PINCTRL_DT_INST_DEFINE(_num);                                                              \
 	static void max32_rtc_irq_init_##_num(void)                                                \
 	{                                                                                          \
 		IRQ_CONNECT(DT_INST_IRQN(_num), DT_INST_IRQ(_num, priority), rtc_max32_isr,        \
@@ -260,6 +312,8 @@ static DEVICE_API(counter, counter_rtc_max32_driver_api) = {
 				.channels = 1,                                                     \
 			},                                                                         \
 		.regs = (mxc_rtc_regs_t *)DT_INST_REG_ADDR(_num),                                  \
+		.pctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(_num),                                     \
+		.sqw_freq = DT_INST_PROP(_num, sqw_frequency),                               \
 		.irq_func = max32_rtc_irq_init_##_num,                                             \
 		.perclk.clk_src =                                                                  \
 			DT_INST_PROP_OR(_num, clock_source, ADI_MAX32_PRPH_CLK_SRC_ERTCO),         \

--- a/dts/arm/adi/max32/max32666-pinctrl.dtsi
+++ b/dts/arm/adi/max32/max32666-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -269,6 +269,10 @@
 				pinmux = <MAX32_PINMUX(0, 18, AF4)>;
 			};
 
+			/omit-if-no-ref/ sqwout_p0_19: sqwout_p0_19 {
+				pinmux = <MAX32_PINMUX(0, 19, GPIO)>;
+			};
+
 			/omit-if-no-ref/ ain1p_p0_19: ain1p_p0_19 {
 				pinmux = <MAX32_PINMUX(0, 19, AF1)>;
 			};
@@ -387,6 +391,10 @@
 
 			/omit-if-no-ref/ tmr2_p0_26: tmr2_p0_26 {
 				pinmux = <MAX32_PINMUX(0, 26, AF4)>;
+			};
+
+			/omit-if-no-ref/ sqw_out_p0_27: sqw_out_p0_27 {
+				pinmux = <MAX32_PINMUX(0, 27, GPIO)>;
 			};
 
 			/omit-if-no-ref/ pcm_bclk_p0_27: pcm_bclk_p0_27 {
@@ -975,6 +983,11 @@
 		low-power-enable;
 	};
 
+	/omit-if-no-ref/ sqw_out_p0_19_sleep: sqw_out_p0_19_sleep {
+		pinmux = <MAX32_PINMUX(0, 19, GPIO)>;
+		low-power-enable;
+	};
+
 	/omit-if-no-ref/ ain1p_p0_19_sleep: ain1p_p0_19_sleep {
 		pinmux = <MAX32_PINMUX(0, 19, AF1)>;
 		low-power-enable;
@@ -1122,6 +1135,11 @@
 
 	/omit-if-no-ref/ tmr2_p0_26_sleep: tmr2_p0_26_sleep {
 		pinmux = <MAX32_PINMUX(0, 26, AF4)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ sqw_out_p0_27_sleep: sqw_out_p0_27_sleep {
+		pinmux = <MAX32_PINMUX(0, 27, GPIO)>;
 		low-power-enable;
 	};
 

--- a/dts/bindings/counter/adi,max32-rtc-counter.yaml
+++ b/dts/bindings/counter/adi,max32-rtc-counter.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,7 +6,7 @@ description: ADI MAX32 compatible Counter RTC
 
 compatible: "adi,max32-rtc-counter"
 
-include: [base.yaml]
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
@@ -22,3 +22,35 @@ properties:
       - 5: "ADI_MAX32_PRPH_CLK_SRC_INRO" Internal Ring Oscillator
       The target device might not support all option please take a look on
       target device user guide
+
+  sqw-frequency:
+    type: int
+    description: |
+      Square wave output frequency value in Hz. Default is 0, which means that
+      the square wave output is disabled.
+    default: 0
+    enum:
+      - 0
+      - 1
+      - 512
+      - 4096
+      - 32768
+
+examples:
+  - |
+    /*
+     * Enable RTC counter.
+     */
+    &rtc_counter {
+        status = "okay";
+    };
+  - |
+    /*
+     * Enable 32kHz square wave output on P3.1.
+     */
+    &rtc_counter {
+        status = "okay";
+        pinctrl-0 = <&sqwout_p3_1>;
+        pinctrl-names = "default";
+        sqw-frequency = <32768>;
+    };

--- a/dts/vendor/adi/max32/max32690-pinctrl.dtsi
+++ b/dts/vendor/adi/max32/max32690-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -763,6 +763,10 @@
 
 			/omit-if-no-ref/ lptmr1b_ioa_p3_7: lptmr1b_ioa_p3_7 {
 				pinmux = <MAX32_PINMUX(3, 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sqwout_p4_1: sqwout_p4_1 {
+				pinmux = <MAX32_PINMUX(4, 1, AF1)>;
 			};
 		};
 	};
@@ -1716,6 +1720,11 @@
 
 	/omit-if-no-ref/ lptmr1b_ioa_p3_7_sleep: lptmr1b_ioa_p3_7_sleep {
 		pinmux = <MAX32_PINMUX(3, 7, AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ sqwout_p4_1_sleep: sqwout_p4_1_sleep {
+		pinmux = <MAX32_PINMUX(4, 1, AF1)>;
 		low-power-enable;
 	};
 };

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: ab16e67b49cfe45826e70d68b720ee5751e77664
+      revision: 1a5d9748b680adf0669739f37d05cb985f39b7b8
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Add square wave output support to the MAX32 RTC counter driver.