### PR TITLE
drivers: entropy: psa_crypto: Get entropy from an interrupt context

### DIFF
--- a/drivers/entropy/Kconfig.psa_crypto
+++ b/drivers/entropy/Kconfig.psa_crypto
@@ -49,6 +49,26 @@ config ENTROPY_PSA_CRYPTO_RNG_ISR_REFILL_SIZE
 	  Special value 0 (default value) means the pool is refilled
 	  using the biggest possible chunks.
 
+config ENTROPY_PSA_CRYPTO_RNG_ISR_WORKQUEUE
+	bool "Dedicated worqueue to refill the ISR random bytes pool"
+	default y if BUILD_WITH_TFM
+	help
+	  When enabled, a dedicated workqueue is used to refill the ISR
+	  random bytes pool. When disabled, Zephyr's system workqueue
+	  is used.
+
+if ENTROPY_PSA_CRYPTO_RNG_ISR_WORKQUEUE
+
+config ENTROPY_PSA_CRYPTO_RNG_ISR_WQ_STACK_SIZE
+	int "Dedicated workqueue stack size"
+	default 384
+
+config ENTROPY_PSA_CRYPTO_RNG_ISR_WQ_PRIO
+	int "Dedicated workqueue priority"
+	default 1
+
+endif # ENTROPY_PSA_CRYPTO_RNG_ISR_WORKQUEUE
+
 endif # ENTROPY_PSA_CRYPTO_RNG_ISR
 
 endif # ENTROPY_PSA_CRYPTO_RNG

--- a/drivers/entropy/Kconfig.psa_crypto
+++ b/drivers/entropy/Kconfig.psa_crypto
@@ -10,3 +10,45 @@ config ENTROPY_PSA_CRYPTO_RNG
 	default y
 	help
 	  Enable the PSA Crypto source Entropy driver.
+
+if ENTROPY_PSA_CRYPTO_RNG
+
+config ENTROPY_PSA_CRYPTO_RNG_ISR
+	bool "Get random bytes from an interrupt context"
+	depends on MULTITHREADING
+	help
+	  Implement .get_entropy_isr handler to allow interrupt context
+	  to get random bytes from a pool filled with regular PSA Crypto
+	  calls from a thread context.
+
+if ENTROPY_PSA_CRYPTO_RNG_ISR
+
+config ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE
+	int "Size of the ISR random pool in bytes"
+	range 1 32767
+	default 32
+
+config ENTROPY_PSA_CRYPTO_RNG_ISR_REFILL_THRESHOLD
+	int "Byte size threshold for refilling the ISR random bytes pool"
+	range 0 ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE
+	default ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE
+	help
+	  A thread context is requested for filling the ISR random bytes
+	  pool when the number of available bytes is equal to or lower
+	  than this threshold.
+
+config ENTROPY_PSA_CRYPTO_RNG_ISR_REFILL_SIZE
+	int "Chunk byte size for refilling ISR random bytes pool"
+	range 0 ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE
+	default 0
+	help
+	  Bytes size of the buffer chunks used to refill the ISR
+	  random bytes pool. Bigger values may add latency to other
+	  PSA Crypto services.
+
+	  Special value 0 (default value) means the pool is refilled
+	  using the biggest possible chunks.
+
+endif # ENTROPY_PSA_CRYPTO_RNG_ISR
+
+endif # ENTROPY_PSA_CRYPTO_RNG

--- a/drivers/entropy/entropy_psa_crypto.c
+++ b/drivers/entropy/entropy_psa_crypto.c
@@ -9,21 +9,6 @@
 #include <zephyr/drivers/entropy.h>
 #include <psa/crypto.h>
 
-/* API implementation: PSA Crypto initialization */
-static int entropy_psa_crypto_rng_init(const struct device *dev)
-{
-	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-
-	ARG_UNUSED(dev);
-
-	status = psa_crypto_init();
-	if (status != PSA_SUCCESS) {
-		return -EIO;
-	}
-
-	return 0;
-}
-
 /* API implementation: get_entropy */
 static int entropy_psa_crypto_rng_get_entropy(const struct device *dev,
 					      uint8_t *buffer, uint16_t length)
@@ -33,6 +18,21 @@ static int entropy_psa_crypto_rng_get_entropy(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	status = psa_generate_random(buffer, length);
+	if (status != PSA_SUCCESS) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/* API implementation: PSA Crypto initialization */
+static int entropy_psa_crypto_rng_init(const struct device *dev)
+{
+	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+
+	ARG_UNUSED(dev);
+
+	status = psa_crypto_init();
 	if (status != PSA_SUCCESS) {
 		return -EIO;
 	}

--- a/drivers/entropy/entropy_psa_crypto.c
+++ b/drivers/entropy/entropy_psa_crypto.c
@@ -20,10 +20,17 @@ struct entropy_psa_crypto_context {
 	struct ring_buf isr_rbuf;
 	struct k_spinlock isr_lock;
 	struct k_work isr_refill_work;
+	struct k_work_q *isr_wq;
 };
 
 static struct entropy_psa_crypto_context entropy_psa_crypto_ctx;
 static uint8_t __noinit entropy_psa_crypto_isr_pool[CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE];
+
+#ifdef CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_WORKQUEUE
+static K_THREAD_STACK_DEFINE(entropy_psa_crypto_isr_wq_stack,
+			     CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_WQ_STACK_SIZE);
+static struct k_work_q entropy_psa_crypto_isr_wq;
+#endif /* CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_WORKQUEUE */
 
 /* API implementation: get_entropy_isr */
 static int entropy_psa_crypto_rng_get_entropy_isr(const struct device *dev,
@@ -49,8 +56,8 @@ static int entropy_psa_crypto_rng_get_entropy_isr(const struct device *dev,
 
 	k_spin_unlock(&ctx->isr_lock, key);
 
-	if (refill) {
-		ret = k_work_submit(&ctx->isr_refill_work);
+	if (refill && ctx->isr_wq != NULL) {
+		ret = k_work_submit_to_queue(ctx->isr_wq, &ctx->isr_refill_work);
 		if (ret < 0 && ret != -ENODEV) {
 			LOG_ERR("Failed to launch RNG pool refill: %d", ret);
 		}
@@ -107,12 +114,26 @@ static void entropy_psa_crypto_isr_refill_work_fn(struct k_work *work)
 	LOG_DBG("Refilled %zu bytes", total);
 }
 
-static int entropy_psa_crypto_init_refill_isr_pool(void)
+static int entropy_psa_crypto_init_post_kernel(void)
 {
+	struct entropy_psa_crypto_context *ctx = &entropy_psa_crypto_ctx;
 	int ret;
 
-	/* Refill the pool in case it was used prio system work was started */
-	ret = k_work_submit(&entropy_psa_crypto_ctx.isr_refill_work);
+#ifdef CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_WORKQUEUE
+	k_work_queue_init(&entropy_psa_crypto_isr_wq);
+	k_work_queue_start(&entropy_psa_crypto_isr_wq,
+			   ((k_thread_stack_t *)&entropy_psa_crypto_isr_wq_stack),
+			   K_THREAD_STACK_SIZEOF(entropy_psa_crypto_isr_wq_stack),
+			   CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_WQ_PRIO, NULL);
+	k_thread_name_set(entropy_psa_crypto_isr_wq.thread_id, "psa-rng-isr-pool");
+
+	ctx->isr_wq = &entropy_psa_crypto_isr_wq;
+#else
+	ctx->isr_wq = &k_sys_work_q;
+#endif /* CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_WORKQUEUE */
+
+	/* Refill the pool in case it was used before the workqueue got started */
+	ret = k_work_submit_to_queue(ctx->isr_wq, &ctx->isr_refill_work);
 	if (ret < 0) {
 		LOG_ERR("Failed to launch RNG pool refill: %d", ret);
 	}
@@ -120,7 +141,7 @@ static int entropy_psa_crypto_init_refill_isr_pool(void)
 	return ret;
 }
 
-SYS_INIT(entropy_psa_crypto_init_refill_isr_pool, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(entropy_psa_crypto_init_post_kernel, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 static int entropy_psa_crypto_init_isr_pool(void)
 {

--- a/drivers/entropy/entropy_psa_crypto.c
+++ b/drivers/entropy/entropy_psa_crypto.c
@@ -7,7 +7,148 @@
 #define DT_DRV_COMPAT zephyr_psa_crypto_rng
 
 #include <zephyr/drivers/entropy.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/minmax.h>
+#include <zephyr/sys/ring_buffer.h>
 #include <psa/crypto.h>
+
+LOG_MODULE_REGISTER(entropy_psa_crypto, CONFIG_ENTROPY_LOG_LEVEL);
+
+#ifdef CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR
+struct entropy_psa_crypto_context {
+	struct ring_buf isr_rbuf;
+	struct k_spinlock isr_lock;
+	struct k_work isr_refill_work;
+};
+
+static struct entropy_psa_crypto_context entropy_psa_crypto_ctx;
+static uint8_t __noinit entropy_psa_crypto_isr_pool[CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE];
+
+/* API implementation: get_entropy_isr */
+static int entropy_psa_crypto_rng_get_entropy_isr(const struct device *dev,
+						  uint8_t *buffer, uint16_t length,
+						  uint32_t flags)
+{
+	struct entropy_psa_crypto_context *ctx = &entropy_psa_crypto_ctx;
+	k_spinlock_key_t key;
+	uint32_t rand_size;
+	bool refill;
+	int ret;
+
+	key = k_spin_lock(&ctx->isr_lock);
+
+	rand_size = ring_buf_size_get(&ctx->isr_rbuf);
+
+	if (likely((flags & ENTROPY_BUSYWAIT) == 0U) || rand_size >= length) {
+		rand_size = ring_buf_get(&ctx->isr_rbuf, buffer, min(rand_size, length));
+	}
+
+	refill = (ring_buf_size_get(&ctx->isr_rbuf) <=
+		  CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_REFILL_THRESHOLD);
+
+	k_spin_unlock(&ctx->isr_lock, key);
+
+	if (refill) {
+		ret = k_work_submit(&ctx->isr_refill_work);
+		if (ret < 0 && ret != -ENODEV) {
+			LOG_ERR("Failed to launch RNG pool refill: %d", ret);
+		}
+	}
+
+	if (unlikely((flags & ENTROPY_BUSYWAIT) != 0U) && rand_size < length) {
+		LOG_WRN_RATELIMIT("ISR random bytes underflow: %u/%u", rand_size, length);
+		return -EBUSY;
+	}
+
+	return (int)rand_size;
+}
+
+static void entropy_psa_crypto_isr_refill_work_fn(struct k_work *work)
+{
+	struct entropy_psa_crypto_context *ctx = &entropy_psa_crypto_ctx;
+	__maybe_unused size_t total = 0;
+	k_spinlock_key_t key;
+	bool done = false;
+	uint32_t size;
+	uint8_t *ptr;
+
+	/* Get random byte per small chunks to lower latency to TF-M services */
+	do {
+		if (CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_REFILL_SIZE == 0) {
+			size = UINT32_MAX;
+		} else {
+			size = CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_REFILL_SIZE;
+		}
+
+		key = k_spin_lock(&ctx->isr_lock);
+		size = ring_buf_put_claim(&ctx->isr_rbuf, &ptr, size);
+		k_spin_unlock(&ctx->isr_lock, key);
+
+		if (psa_generate_random(ptr, size) != PSA_SUCCESS) {
+			(void)ring_buf_put_finish(&ctx->isr_rbuf, 0);
+			LOG_ERR("psa_generate_random() failed");
+			break;
+		}
+
+		key = k_spin_lock(&ctx->isr_lock);
+
+		if (unlikely(ring_buf_put_finish(&ctx->isr_rbuf, size) < 0)) {
+			LOG_ERR("Failed to finish ring buffer update");
+			done = true;
+		} else {
+			total += size;
+			done = (ring_buf_space_get(&ctx->isr_rbuf) == 0);
+		}
+
+		k_spin_unlock(&ctx->isr_lock, key);
+	} while (!done);
+
+	LOG_DBG("Refilled %zu bytes", total);
+}
+
+static int entropy_psa_crypto_init_refill_isr_pool(void)
+{
+	int ret;
+
+	/* Refill the pool in case it was used prio system work was started */
+	ret = k_work_submit(&entropy_psa_crypto_ctx.isr_refill_work);
+	if (ret < 0) {
+		LOG_ERR("Failed to launch RNG pool refill: %d", ret);
+	}
+
+	return ret;
+}
+
+SYS_INIT(entropy_psa_crypto_init_refill_isr_pool, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+static int entropy_psa_crypto_init_isr_pool(void)
+{
+	struct entropy_psa_crypto_context *ctx = &entropy_psa_crypto_ctx;
+	k_spinlock_key_t key;
+	uint32_t filled_size;
+
+	ring_buf_init(&ctx->isr_rbuf, sizeof(entropy_psa_crypto_isr_pool),
+		      entropy_psa_crypto_isr_pool);
+
+	/* Start with a fully filled pool of random bytes */
+	entropy_psa_crypto_isr_refill_work_fn(&ctx->isr_refill_work);
+
+	key = k_spin_lock(&ctx->isr_lock);
+	filled_size = ring_buf_size_get(&ctx->isr_rbuf);
+	k_spin_unlock(&ctx->isr_lock, key);
+
+	k_work_init(&ctx->isr_refill_work, entropy_psa_crypto_isr_refill_work_fn);
+
+	if (filled_size < CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE) {
+		LOG_ERR("Failed to fully fill the ISR pool: %u/%u bytes",
+			filled_size, CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE);
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR */
 
 /* API implementation: get_entropy */
 static int entropy_psa_crypto_rng_get_entropy(const struct device *dev,
@@ -37,12 +178,19 @@ static int entropy_psa_crypto_rng_init(const struct device *dev)
 		return -EIO;
 	}
 
+#ifdef CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR
+	return entropy_psa_crypto_init_isr_pool();
+#else
 	return 0;
+#endif /* CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR */
 }
 
 /* Entropy driver APIs structure */
 static DEVICE_API(entropy, entropy_psa_crypto_rng_api) = {
 	.get_entropy = entropy_psa_crypto_rng_get_entropy,
+#ifdef CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR
+	.get_entropy_isr = entropy_psa_crypto_rng_get_entropy_isr,
+#endif /* CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR */
 };
 
 /* Entropy driver registration */

--- a/tests/drivers/entropy/api/entropy_psa_crypto.conf
+++ b/tests/drivers/entropy/api/entropy_psa_crypto.conf
@@ -5,6 +5,8 @@ CONFIG_HARDWARE_DEVICE_CS_GENERATOR=y
 # (9 bytes) to check it's refilled.
 CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR=y
 CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE=5
-# Refilling entropy_psa_crypto ISR random sample pool requires a thread
-# to execute aside the Ztest thread hence make it preemptible.
-CONFIG_ZTEST_THREAD_PRIORITY=0
+# Refilling entropy_psa_crypto ISR random sample pool with TF-M requires
+# the driver ISR refill thread to preempt the Ztest thread.
+# Use equal preemptive thread priorities to achieve that.
+CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_WQ_PRIO=1
+CONFIG_ZTEST_THREAD_PRIORITY=1

--- a/tests/drivers/entropy/api/entropy_psa_crypto.conf
+++ b/tests/drivers/entropy/api/entropy_psa_crypto.conf
@@ -1,3 +1,10 @@
 CONFIG_PSA_CRYPTO=y
 CONFIG_TFM_CRYPTO_RNG_MODULE_ENABLED=y
 CONFIG_HARDWARE_DEVICE_CS_GENERATOR=y
+# Enable ISR test with a pool smaller (5 bytes) than the test buffer size
+# (9 bytes) to check it's refilled.
+CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR=y
+CONFIG_ENTROPY_PSA_CRYPTO_RNG_ISR_BUFFER_SIZE=5
+# Refilling entropy_psa_crypto ISR random sample pool requires a thread
+# to execute aside the Ztest thread hence make it preemptible.
+CONFIG_ZTEST_THREAD_PRIORITY=0

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -33,7 +33,7 @@ static uint8_t entropy_buffer[BUFFER_LENGTH] = {0};
 static uint8_t entropy_buffer[BUFFER_LENGTH] = {0};
 #endif
 
-static int random_entropy(const struct device *dev, uint8_t *buffer, char num)
+static int random_entropy(const struct device *dev, uint8_t *buffer, char num, bool test_isr)
 {
 	int ret, i;
 	int count = 0;
@@ -46,13 +46,42 @@ static int random_entropy(const struct device *dev, uint8_t *buffer, char num)
 	 * outside the passed buffer, and that should never
 	 * happen.
 	 */
-	ret = entropy_get_entropy(dev, buffer, BUFFER_LENGTH - 1);
-	if (ret) {
-		TC_PRINT("Error: entropy_get_entropy failed: %d\n", ret);
-		return TC_FAIL;
+	if (test_isr) {
+		/* 1 sec should be enough to get the samples */
+		k_timepoint_t tp = sys_timepoint_calc(Z_TIMEOUT_MS(1000));
+		int remaining = BUFFER_LENGTH - 1;
+
+		/* Get the random bytes possibly in several calls */
+		do {
+			uint32_t offset = BUFFER_LENGTH - 1 - remaining;
+
+			ret = entropy_get_entropy_isr(dev, buffer + offset, remaining, 0);
+			if (ret < 0) {
+				if (ret ==  -ENOSYS) {
+					TC_PRINT("Skip ISR test: .get_entropy_isr not supported\n");
+					return TC_PASS;
+				}
+
+				TC_PRINT("Error: entropy_get_entropy_isr failed: %d\n", ret);
+				return TC_FAIL;
+			}
+			remaining -= ret;
+
+			if (ret == 0 && sys_timepoint_expired(tp)) {
+				TC_PRINT("Error: Timeout on entropy_get_entropy_isr\n");
+				return TC_FAIL;
+			}
+		} while (remaining > 0);
+	} else {
+		ret = entropy_get_entropy(dev, buffer, BUFFER_LENGTH - 1);
+		if (ret) {
+			TC_PRINT("Error: entropy_get_entropy failed: %d\n", ret);
+			return TC_FAIL;
+		}
 	}
+
 	if (buffer[BUFFER_LENGTH - 1] != num) {
-		TC_PRINT("Error: entropy_get_entropy buffer overflow\n");
+		TC_PRINT("Error: buffer overflow\n");
 		return TC_FAIL;
 	}
 
@@ -74,7 +103,7 @@ static int random_entropy(const struct device *dev, uint8_t *buffer, char num)
  * Function invokes the get_entropy callback in driver
  * to get the random data and fill to passed buffer
  */
-static int get_entropy(void)
+static int get_entropy(bool test_isr)
 {
 	const struct device *const dev = entropy_get_default_device();
 	int ret;
@@ -87,7 +116,7 @@ static int get_entropy(void)
 	TC_PRINT("random device is %p, name is %s\n",
 		 dev, dev->name);
 
-	ret = random_entropy(dev, entropy_buffer, 0);
+	ret = random_entropy(dev, entropy_buffer, 0, test_isr);
 
 	/* Check whether 20% or more of buffer still filled with default
 	 * value(0), if yes then recheck again by filling nonzero value(0xa5)
@@ -95,19 +124,25 @@ static int get_entropy(void)
 	 * of buffer filled with value(0xa5) or not.
 	 */
 	if (ret == RECHECK_RANDOM_ENTROPY) {
-		ret = random_entropy(dev, entropy_buffer, 0xa5);
+		ret = random_entropy(dev, entropy_buffer, 0xa5, test_isr);
 		if (ret == RECHECK_RANDOM_ENTROPY) {
 			return TC_FAIL;
 		} else {
 			return ret;
 		}
 	}
+
 	return ret;
 }
 
 ZTEST(entropy_api, test_entropy_get_entropy)
 {
-	zassert_true(get_entropy() == TC_PASS);
+	zassert_true(get_entropy(false) == TC_PASS);
+}
+
+ZTEST(entropy_api, test_entropy_get_entropy_isr)
+{
+	zassert_true(get_entropy(true) == TC_PASS);
 }
 
 void *entropy_api_setup(void)


### PR DESCRIPTION
Implement `.get_entropy_isr` handler in **entropy_psa_crypto** driver using a random bytes pool filled from a workqueue whose bytes can be consumed from a interrupt handler.

Configuration set the pool size, the threshold to trigger its refilling and the size of the buffer chunk use to refill it.

This added support is useful for example when the entropy PSA Crypto service is implemented in TF-M which has re-entrance constraints preventing reliable calls from a Zephyr interrupt context, notably for example, considering a wireless stack execution constraints.

Add a test for `entropy_get_entropy_isr()` in **tests/drivers/entropy/api/**.