### PR TITLE
boards: st: Fix boards that use BlueNRG-x BLE module

### DIFF
--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -166,6 +166,8 @@
 		irq-gpios = <&gpioe 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
 		spi-hold-cs;
+		reset-event;
+		req-ll-only;
 	};
 
 	wifi0: ism43362@1 {

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -218,6 +218,8 @@
 		irq-gpios = <&gpioe 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
 		spi-hold-cs;
+		reset-event;
+		req-ll-only;
 	};
 
 	wifi0: ism43362@1 {

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -184,6 +184,8 @@
 		spi-max-frequency = <DT_FREQ_M(1)>;
 		spi-cpha;
 		spi-hold-cs;
+		reset-event;
+		req-ll-only;
 		reset-assert-duration-ms = <6>;
 	};
 };

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -168,6 +168,7 @@
 		spi-cpha;
 		spi-hold-cs;
 		spi-max-frequency = <DT_FREQ_M(8)>;
+		reset-event;
 		controller-data-delay-us = <0>;
 		reset-assert-duration-ms = <6>;
 	};

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -210,6 +210,8 @@
 		reset-gpios = <&gpiog 8 GPIO_ACTIVE_LOW>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
 		spi-hold-cs;
+		reset-event;
+		req-ll-only;
 	};
 };
 


### PR DESCRIPTION
Utilize properties introduced in commit
[dts: bindings: bluetooth: Introduce new properties for ST HCI SPI](https://github.com/zephyrproject-rtos/zephyr/commit/df4869fb60f49fe60e6595bf85b0448c46e8f3ab) to comply with the new changes of ST HCI-SPI BLE driver.