### PR TITLE
soc: nxp: rw: enable HDLC_RCP_IF by default for OpenThread

### DIFF
--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -105,4 +105,11 @@ config POWER_DOMAIN
 
 endif # PM_DEVICE
 
+if NET_L2_OPENTHREAD
+
+config HDLC_RCP_IF
+	default y
+
+endif # NET_L2_OPENTHREAD
+
 endif # SOC_SERIES_RW6XX


### PR DESCRIPTION
On RW6xx, `CONFIG_HDLC_RCP_IF` is required when `NET_L2_OPENTHREAD` is selected, but no Kconfig default was set for this SoC family outside of the Matter chip-module.

Add `default y` for `HDLC_RCP_IF` under `NET_L2_OPENTHREAD` in `soc/nxp/rw/Kconfig.defconfig` to ensure a consistent Kconfig state for standalone OpenThread builds on RW612.

This is a Kconfig-only fix — no build output change.
