### PR TITLE
drivers: mbox: nrf_vevif_event_rx: Start driver just after the vpr launcher

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_event_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_rx.c
@@ -193,6 +193,7 @@ static int vevif_event_rx_init(const struct device *dev)
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, vevif_event_rx_init, NULL, &data##inst, &conf##inst,           \
-			      POST_KERNEL, CONFIG_MBOX_INIT_PRIORITY, &vevif_event_rx_driver_api);
+			      POST_KERNEL, UTIL_INC(CONFIG_NORDIC_VPR_LAUNCHER_INIT_PRIORITY),     \
+			      &vevif_event_rx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VEVIF_EVENT_RX_DEFINE)

--- a/drivers/misc/nordic_vpr_launcher/Kconfig
+++ b/drivers/misc/nordic_vpr_launcher/Kconfig
@@ -19,6 +19,12 @@ source "subsys/logging/Kconfig.template.log_config"
 config NORDIC_VPR_LAUNCHER_INIT_PRIORITY
 	int "Nordic VPR coprocessor launcher init priority"
 	default 44 if DT_HAS_NORDIC_CORESIGHT_NRF_ENABLED
+	# If errata 16 is enabled Mailbox driver need to be started as soon as possible
+	# after VPR launcher to minimize a chance of losing an event from FLPR.
+	# Mailbox starts one level later than the VPR launcher and as many modules
+	# may start on level 0 there might be a significant delay. Need to use less common
+	# level. It's not bullet proof but there is nothing better.
+	default 11 if MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16
 	default 0
 	help
 	  The init priority of the VPR coprocessor launcher.


### PR DESCRIPTION
When Nordic Errata 16 is present (for example on nRF54L15) then events from VPR are lost if they are sent before mailbox driver (VEVIF RX) is not yet initialized. On the other hand, mailbox driver cannot be initialized before lauching (powering up) the VPR core because it's accessing VPR registers and fault is triggered if it is accessed before VPR is running. In order to not loose any events we need to minimize the time between VPR launching and initializing the mailbox driver. It is done by:
- changing mailbox priority to be `CONFIG_NORDIC_VPR_LAUNCHER_INIT_PRIORITY+1`
- changing CONFIG_NORDIC_VPR_LAUNCHER_INIT_PRIORITY to something else than 0 (because many modules use 0 level and it then delays initialization of level 1)

It is fixing `tests/subsys/shell/shell_remote` which started to fail on nrf54l15dk after #111878 due to different timing.