### PR TITLE
drivers: timer: esp32_sys_timer: use the generic timer core

### DIFF
--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -22,26 +22,15 @@
 
 #include "esp32_sys_timer.h"
 
-#define CYC_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec()	\
-			      / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
-#define MAX_CYC 0xffffffffu
-#define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
-#define MIN_DELAY 1
-
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = DT_IRQN(DT_NODELABEL(systimer0));
 #endif
-
-#define TICKLESS IS_ENABLED(CONFIG_TICKLESS_KERNEL)
 
 #if defined(CONFIG_PM)
 static uint64_t systimer_pre_idle;
 static uint64_t lptim_pre_idle;
 static bool timeout_idle;
 #endif
-
-static struct k_spinlock lock;
-static uint64_t last_count;
 
 /* Systimer HAL layer object */
 static systimer_hal_context_t systimer_hal;
@@ -65,131 +54,88 @@ static uint64_t get_systimer_alarm(void)
 	return systimer_hal_get_counter_value(&systimer_hal, SYSTIMER_COUNTER_OS_TICK);
 }
 
-static uint64_t sys_timer_elapsed_ticks(uint64_t now)
+/* Counter value sampled by sys_clock_disable(), reported by the read below
+ * once the hardware is gone.
+ */
+static uint64_t stopped_cycles;
+
+/*
+ * A free-running counter and a one-shot alarm: a COMPARE_ORDERED backend. The
+ * counter is 52 bits wide, read back as a 64-bit value. Every SoC this driver
+ * builds for defines SYSTIMER_LL_ALARM_MISS_COMPENSATE, so an alarm armed at or
+ * behind the counter is raised at once instead of being lost, and the target
+ * needs no minimum distance.
+ */
+#define TIMER_CORE_BACKEND_COMPARE_ORDERED
+#define TIMER_CORE_COUNTER_WIDTH 52
+
+static inline uint64_t timer_driver_cycle_get(void)
 {
-	uint64_t dticks = (uint64_t)((now - last_count) / CYC_PER_TICK);
-
-	last_count += dticks * CYC_PER_TICK;
-
-	return dticks;
+	/* sys_clock_disable() deinitializes the HAL and clears dev; a stray core
+	 * read afterwards must not dereference it. Report the value the counter
+	 * stopped at, so the elapsed span holds instead of stepping backwards.
+	 */
+	if (systimer_hal.dev == NULL) {
+		return stopped_cycles;
+	}
+	return get_systimer_alarm();
 }
+
+static void timer_driver_set_compare(uint64_t cycles)
+{
+	/* Same post-sys_clock_disable() guard as timer_driver_cycle_get(): once
+	 * the HAL is deinitialized and dev cleared, a stray arm must not
+	 * dereference it.
+	 */
+	if (systimer_hal.dev == NULL) {
+		return;
+	}
+
+	set_systimer_alarm(cycles);
+}
+
+#include "system_timer_generic.h"
 
 static void IRAM_ATTR sys_timer_isr(void *arg)
 {
 	ARG_UNUSED(arg);
 	systimer_ll_clear_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	uint64_t now = get_systimer_alarm();
-	uint64_t dticks = sys_timer_elapsed_ticks(now);
-
-	if (!TICKLESS) {
-		uint64_t next = last_count + CYC_PER_TICK;
-
-		if ((int64_t)(next - now) < MIN_DELAY) {
-			next += CYC_PER_TICK;
-		}
-		set_systimer_alarm(next);
-	}
-
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(dticks);
-}
-
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
-{
-#if defined(CONFIG_TICKLESS_KERNEL)
-	if (systimer_hal.dev == NULL) {
-		return;
-	}
-
-	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint64_t now = get_systimer_alarm();
-	uint32_t adj, cyc = ticks * CYC_PER_TICK;
-
-	/* Round up to next tick boundary. */
-	adj = (uint32_t)(now - last_count) + (CYC_PER_TICK - 1);
-	if (cyc <= MAX_CYC - adj) {
-		cyc += adj;
-	} else {
-		cyc = MAX_CYC;
-	}
-	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
-
-	if ((int32_t)(cyc + last_count - now) < MIN_DELAY) {
-		cyc += CYC_PER_TICK;
-	}
-
-	set_systimer_alarm(cyc + last_count);
-
-#if defined(CONFIG_PM)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
-		systimer_pre_idle = get_systimer_alarm();
-		timeout_idle = true;
-	}
-#else
-	ARG_UNUSED(idle);
-#endif
-
-	k_spin_unlock(&lock, key);
-#endif
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	if (systimer_hal.dev == NULL) {
-		return 0;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = ((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
-
-	k_spin_unlock(&lock, key);
-	return ret;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	if (systimer_hal.dev == NULL) {
-		return 0;
-	}
-	return (uint32_t)get_systimer_alarm();
-}
-
-uint64_t sys_clock_cycle_get_64(void)
-{
-	if (systimer_hal.dev == NULL) {
-		return 0;
-	}
-	return get_systimer_alarm();
+	timer_core_announce();
 }
 
 void sys_clock_disable(void)
 {
+	stopped_cycles = get_systimer_alarm();
+
 	systimer_ll_enable_alarm(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
 	systimer_ll_enable_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
 	systimer_hal_deinit(&systimer_hal);
 }
 
 #if defined(CONFIG_PM)
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	sys_clock_set_timeout(ticks, false);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || systimer_hal.dev == NULL) {
+		return;
+	}
+
+	uint64_t timeout_us = k_ticks_to_us_ceil64(ticks);
+
+	lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
+	systimer_pre_idle = get_systimer_alarm();
+	timeout_idle = true;
+}
+
 void sys_clock_idle_exit(void)
 {
 	if (!timeout_idle) {
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t lptim_now = esp32_lptim_hook_on_lpm_exit();
 	uint64_t systimer_now = get_systimer_alarm();
@@ -211,15 +157,10 @@ void sys_clock_idle_exit(void)
 	systimer_ll_set_counter_value(systimer_hal.dev, SYSTIMER_COUNTER_OS_TICK, new_value);
 	systimer_ll_apply_counter_value(systimer_hal.dev, SYSTIMER_COUNTER_OS_TICK);
 
-	systimer_now = get_systimer_alarm();
-	uint64_t dticks = sys_timer_elapsed_ticks(systimer_now);
-
 	timeout_idle = false;
 
-	k_spin_unlock(&lock, key);
-
 	/* Announce OS ticks as systimer remained stalled while in light sleep */
-	sys_clock_announce(dticks);
+	timer_core_announce_from(key);
 }
 #endif
 
@@ -247,8 +188,9 @@ static int sys_clock_driver_init(void)
 #if defined(CONFIG_SMP)
 	systimer_hal_counter_can_stall_by_cpu(&systimer_hal, SYSTIMER_COUNTER_OS_TICK, 1, true);
 #endif
-	last_count = get_systimer_alarm();
-	set_systimer_alarm(last_count + CYC_PER_TICK);
+
+	/* Seed the announce baseline from the systimer and arm the first tick. */
+	timer_core_init();
 	return 0;
 }
 


### PR DESCRIPTION
Converts the esp32_sys_timer system-timer driver to the generic tickless timer core
that landed in #115844. The core takes over the tick accounting, and what is
left here is the cycle-domain primitives for this hardware. The commit log says
which shape the hardware is and which `TIMER_CORE_*` knobs that implies.
