### PR TITLE
drivers: timer: infineon_lp: use the generic timer core

### DIFF
--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -44,103 +44,64 @@ LOG_MODULE_REGISTER(ifx_cat1_lp_timer, CONFIG_KERNEL_LOG_LEVEL);
 #endif
 
 cyhal_lptimer_t lptimer_obj;
-static uint32_t last_lptimer_value;
-static struct k_spinlock lock;
+
+/* Set while sys_clock_no_timeout() holds the match interrupt masked. */
+static bool lptimer_event_masked;
+
+static void lptimer_event_set(bool enable)
+{
+	cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
+				   LPTIMER_INTR_PRIORITY, enable);
+}
+
+/*
+ * A free-running 32-bit counter at the low-frequency clock rate, matched by a
+ * comparator that fires on equality alone, so a COMPARE_EXACT backend. The HAL
+ * turns the absolute match back into a delay from the current count and clamps
+ * that delay, so a target already behind would be programmed some 36 hours out
+ * rather than fire; the core's verify loop is what catches it.
+ *
+ * The kernel counts in these same cycles, so the core emits both cycle getters
+ * and nothing here needs to scale.
+ */
+#define TIMER_CORE_BACKEND_COMPARE_EXACT
+
+BUILD_ASSERT(LPTIMER_FREQ == CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+	     "the lp-timer counts clk_lf, so CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC must be "
+	     "that rate; see the SoC Kconfig.defconfig");
+
+static inline uint32_t timer_driver_cycle_get(void)
+{
+	return cyhal_lptimer_read(&lptimer_obj);
+}
+
+static inline void timer_driver_set_compare(uint32_t cycles)
+{
+	if (lptimer_event_masked) {
+		lptimer_event_masked = false;
+		lptimer_event_set(true);
+	}
+	cyhal_lptimer_set_match(&lptimer_obj, cycles);
+}
+
+#include "system_timer_generic.h"
 
 static void lptimer_interrupt_handler(void *handler_arg, cyhal_lptimer_event_t event)
 {
 	CY_UNUSED_PARAMETER(handler_arg);
 	CY_UNUSED_PARAMETER(event);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	/* announce the elapsed time in ms */
-	uint32_t lptimer_value = cyhal_lptimer_read(&lptimer_obj);
-	uint32_t delta_ticks =
-		((uint64_t)(lptimer_value - last_lptimer_value) * CONFIG_SYS_CLOCK_TICKS_PER_SEC) /
-		LPTIMER_FREQ;
-	last_lptimer_value += (delta_ticks * LPTIMER_FREQ) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-	k_spin_unlock(&lock, key);
-
-	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
+	timer_core_announce();
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_no_timeout(void)
 {
-	ARG_UNUSED(idle);
-
-	k_spinlock_key_t key = {0};
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		key = k_spin_lock(&lock);
-		/* Disable the LPTIMER events */
-		cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
-					   LPTIMER_INTR_PRIORITY, false);
-		k_spin_unlock(&lock, key);
-		return;
-	}
-
-	/* passing ticks==1 means "announce the next tick", ticks value of zero
-	 * is legal and treated identically: it simply indicates the kernel would like the next
-	 * tick announcement as soon as possible.
+	/* No announcement is wanted, so mask the match interrupt. The counter
+	 * keeps running, which is what sys_clock_cycle_get_32() reads, and the
+	 * next arming unmasks it.
 	 */
-	if (ticks < 1) {
-		ticks = 1;
-	}
-
-	uint32_t set_ticks = ((uint32_t)(ticks)*LPTIMER_FREQ) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-	key = k_spin_lock(&lock);
-
-	/* Configure and Enable the LPTIMER events */
-	cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH, LPTIMER_INTR_PRIORITY,
-				   true);
-	/* Set the delay value for the next wakeup interrupt */
-	cyhal_lptimer_set_delay(&lptimer_obj, set_ticks);
-
-	k_spin_unlock(&lock, key);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	uint32_t lptimer_value = cyhal_lptimer_read(&lptimer_obj);
-
-	k_spin_unlock(&lock, key);
-
-	/* gives the value of LPTIM counter (ms) since the previous 'announce' */
-	uint64_t ret = (((uint64_t)(lptimer_value - last_lptimer_value)) *
-			CONFIG_SYS_CLOCK_TICKS_PER_SEC) /
-		       LPTIMER_FREQ;
-
-	return (uint32_t)ret;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	/* just gives the accumulated count in a number of hw cycles */
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	uint32_t lp_time = cyhal_lptimer_read(&lptimer_obj);
-
-	k_spin_unlock(&lock, key);
-
-	/* convert lptim count in a nb of hw cycles with precision */
-	uint64_t ret = ((uint64_t)lp_time * sys_clock_hw_cycles_per_sec()) / LPTIMER_FREQ;
-
-	/* convert in hw cycles (keeping 32bit value) */
-	return (uint32_t)ret;
+	lptimer_event_masked = true;
+	lptimer_event_set(false);
 }
 
 static int sys_clock_driver_init(void)
@@ -180,6 +141,13 @@ static int sys_clock_driver_init(void)
 		LOG_ERR("Sys Clock initialization failed. Error: 0x%08X\n", (unsigned int)result);
 		return -EIO;
 	}
+
+	/* Unmask the match interrupt once here rather than on every arming.
+	 * Only sys_clock_no_timeout() masks it again.
+	 */
+	lptimer_event_set(true);
+
+	timer_core_init();
 
 	return 0;
 }

--- a/soc/infineon/cat1b/cyw20829/Kconfig.defconfig
+++ b/soc/infineon/cat1b/cyw20829/Kconfig.defconfig
@@ -16,8 +16,17 @@ config CORTEX_M_SYSTICK
 config NUM_IRQS
 	default 70
 
+# The lp-timer counts at clk_lf, sourced from the PILO, and CORTEX_M_SYSTICK is
+# turned off above when it is the kernel timer. The kernel cycle rate is then
+# that counter's, not the CPU's.
 config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/clocks/clk_pilo,clock-frequency) if INFINEON_LP_TIMER_HAL
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+# A tick must be a whole number of counter cycles. The tickless default of 10000
+# does not divide 32768, so pick a quarter of the counter rate.
+config SYS_CLOCK_TICKS_PER_SEC
+	default $(div,$(dt_node_int_prop_int,/clocks/clk_pilo,clock-frequency),4) if INFINEON_LP_TIMER_HAL
 
 config BUILD_OUTPUT_ADJUST_LMA
 	depends on XIP


### PR DESCRIPTION
Converts the infineon_lp_timer system-timer driver to the generic tickless timer core
that landed in #115844. The core takes over the tick accounting, and what is
left here is the cycle-domain primitives for this hardware. The commit log says
which shape the hardware is and which `TIMER_CORE_*` knobs that implies.
