### PR TITLE
drivers: timer: mchp_xec_rtos_timer: use the generic timer core

### DIFF
--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -90,9 +90,6 @@ BUILD_ASSERT(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 32768,
 #define TIMER_ADJUST_LIMIT  2
 #define TIMER_ADJUST_CYCLES 1
 
-/* max number of ticks we can load into the timer in one shot */
-#define MAX_TICKS (TIMER_MAX / CYCLES_PER_TICK)
-
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
 BUILD_ASSERT(DT_INST_NODE_HAS_PROP(0, busy_wait_timer),
 	     "Driver does not not have busy-wait-timer property!");
@@ -123,15 +120,11 @@ BUILD_ASSERT(DT_PROP(BTMR_NODE, max_value) == UINT32_MAX, "Custom busy wait time
 #endif
 
 /*
- * The spinlock protects all access to the RTMR registers, as well as
- * 'total_cycles', 'last_announcement', and 'cached_icr'.
- *
- * One important invariant that must be observed: `total_cycles` + `cached_icr`
- * is always an integral multiple of CYCLE_PER_TICK; this is, timer interrupts
- * are only ever scheduled to occur at tick boundaries.
+ * The system clock lock protects all access to the RTMR registers, as well as
+ * 'total_cycles' and 'cached_icr'.
  */
 
-static struct k_spinlock lock;
+/* Whole reloads consumed so far, the low bits of the synthesized count */
 static uint32_t total_cycles;
 static uint32_t cached_icr = CYCLES_PER_TICK;
 
@@ -166,168 +159,81 @@ static inline uint32_t timer_count(void)
 	return ccr;
 }
 
-#ifdef CONFIG_TICKLESS_KERNEL
-
-static uint32_t last_announcement; /* last time we called sys_clock_announce() */
-
 /*
- * Request a timeout n Zephyr ticks in the future from now.
- * Requested number of ticks in the future of n <= 1 means the kernel wants
- * the tick announced as soon as possible, ideally no more than one tick
- * in the future.
- *
- * Per comment below we don't clear RTMR pending interrupt.
- * RTMR counter register is read-only and is loaded from the preload
- * register by a 0->1 transition of the control register start bit.
- * Writing a new value to preload only takes effect once the count
- * register reaches 0.
+ * A down-counter reloaded from the preload register, which interrupts at zero
+ * and does not free-run: a RELOAD backend. The counter the core reads is
+ * synthesized, the reloads consumed so far plus what the one in flight has
+ * counted down, and it is 28 bits wide like the hardware. That read touches
+ * state the ISR and the reload path also write, hence
+ * TIMER_CORE_COUNTER_NONATOMIC.
  */
-void sys_clock_set_timeout(uint32_t n, bool idle)
+#define TIMER_CORE_BACKEND_RELOAD
+#define TIMER_CORE_COUNTER_WIDTH 28
+#define TIMER_CORE_COUNTER_NONATOMIC
+
+/* One reload cannot express more than the preload register holds. */
+#define TIMER_CORE_ALARM_MAX_CYCLES TIMER_MAX
+
+static inline uint32_t timer_driver_cycle_get(void)
 {
-	ARG_UNUSED(idle);
+	return (total_cycles + (cached_icr - timer_count())) & TIMER_COUNT_MASK;
+}
 
-	uint32_t ccr, temp;
-	int full_ticks;          /* number of complete ticks we'll wait */
-	uint32_t full_cycles;    /* full_ticks represented as cycles */
-	uint32_t partial_cycles; /* number of cycles to first tick boundary */
+static void timer_driver_set_reload(uint32_t cycles)
+{
+	uint32_t ccr = timer_count();
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (n == SYS_CLOCK_MAX_WAIT)) {
-		/*
-		 * We are not in a locked section. Are writes to two
-		 * global objects safe from pre-emption?
-		 */
-		sys_write32(0, TIMER_BASE + TIMER_CR_OFS); /* stop timer */
-		cached_icr = TIMER_STOPPED;
+	/* Fold what the reload in flight has already counted down into the
+	 * synthesized count before replacing it.
+	 */
+	total_cycles = (total_cycles + (cached_icr - ccr)) & TIMER_COUNT_MASK;
+	cached_icr = cycles;
+
+	/* Adjust cycle count programmed into timer for HW restart latency */
+	if (cycles > TIMER_ADJUST_LIMIT) {
+		cycles -= TIMER_ADJUST_CYCLES;
+	}
+
+	timer_restart(cycles);
+}
+
+#include "system_timer_generic.h"
+
+static void xec_rtos_timer_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	k_spinlock_key_t key = sys_clock_lock();
+
+	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_SRC_OFS);
+
+	/* Restart as early as possible to minimise drift, and account the
+	 * reload just consumed. A tickless kernel gets the next deadline from
+	 * the core right after the announce, so this reload only has to keep the
+	 * counter running; a ticked one leaves the period to the driver.
+	 */
+	total_cycles = (total_cycles + cached_icr) & TIMER_COUNT_MASK;
+	cached_icr = IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? TIMER_MAX : CYCLES_PER_TICK;
+	timer_restart(cached_icr);
+
+	timer_core_announce_from(key);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	if (ticks != SYS_CLOCK_IDLE_FOREVER) {
+		sys_clock_set_timeout(ticks, false);
 		return;
 	}
 
-	if (n < 1) {
-		full_ticks = 0;
-	} else if (n > MAX_TICKS) {
-		full_ticks = MAX_TICKS - 1;
-	} else {
-		full_ticks = n - 1;
-	}
-
-	full_cycles = full_ticks * CYCLES_PER_TICK;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	ccr = timer_count();
-
-	/* turn off to clear any pending interrupt status */
+	/* Nothing to wake up for and the uptime accounting may drift: stop the
+	 * timer. Only this path may, and only because the CPU is on its way to
+	 * sleep, so nothing is left to read a synthesized count that stops with
+	 * it. sys_clock_idle_exit() starts it again.
+	 */
 	sys_write32(0, TIMER_BASE + TIMER_CR_OFS);
-	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_SRC_OFS);
-	NVIC_ClearPendingIRQ(TIMER_NVIC_NO);
-
-	temp = total_cycles;
-	temp += (cached_icr - ccr);
-	temp &= TIMER_COUNT_MASK;
-	total_cycles = temp;
-
-	partial_cycles = CYCLES_PER_TICK - (total_cycles % CYCLES_PER_TICK);
-	cached_icr = full_cycles + partial_cycles;
-	/* adjust for up to one 32KHz cycle startup time */
-	temp = cached_icr;
-	if (temp > TIMER_ADJUST_LIMIT) {
-		temp -= TIMER_ADJUST_CYCLES;
-	}
-
-	timer_restart(temp);
-
-	k_spin_unlock(&lock, key);
+	cached_icr = TIMER_STOPPED;
 }
-
-/*
- * Return the number of Zephyr ticks elapsed from last call to
- * sys_clock_announce in the ISR. The caller casts uint32_t to int32_t.
- * We must make sure bit[31] is 0 in the return value.
- */
-uint32_t sys_clock_elapsed(void)
-{
-	uint32_t ccr;
-	uint32_t ticks;
-	int32_t elapsed;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	ccr = timer_count();
-
-	/* It may not look efficient but the compiler does a good job */
-	elapsed = (int32_t)total_cycles - (int32_t)last_announcement;
-	if (elapsed < 0) {
-		elapsed = -1 * elapsed;
-	}
-	ticks = (uint32_t)elapsed;
-	ticks += cached_icr - ccr;
-	ticks /= CYCLES_PER_TICK;
-	ticks &= TIMER_COUNT_MASK;
-
-	k_spin_unlock(&lock, key);
-
-	return ticks;
-}
-
-static void xec_rtos_timer_isr(const void *arg)
-{
-	ARG_UNUSED(arg);
-
-	uint32_t cycles;
-	int32_t ticks;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_SRC_OFS);
-
-	/* Restart the timer as early as possible to minimize drift... */
-	timer_restart(MAX_TICKS * CYCLES_PER_TICK);
-
-	cycles = cached_icr;
-	cached_icr = MAX_TICKS * CYCLES_PER_TICK;
-
-	total_cycles += cycles;
-	total_cycles &= TIMER_COUNT_MASK;
-
-	/* handle wrap by using (power of 2) - 1 mask */
-	ticks = total_cycles - last_announcement;
-	ticks &= TIMER_COUNT_MASK;
-	ticks /= CYCLES_PER_TICK;
-
-	last_announcement = total_cycles;
-
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(ticks);
-}
-
-#else
-
-/* Non-tickless kernel build. */
-
-static void xec_rtos_timer_isr(const void *arg)
-{
-	ARG_UNUSED(arg);
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_SRC_OFS);
-
-	/* Restart the timer as early as possible to minimize drift... */
-	timer_restart(cached_icr);
-
-	uint32_t temp = total_cycles + CYCLES_PER_TICK;
-
-	total_cycles = temp & TIMER_COUNT_MASK;
-	k_spin_unlock(&lock, key);
-
-	sys_clock_announce(1);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	return 0U;
-}
-
-#endif /* CONFIG_TICKLESS_KERNEL */
 
 /*
  * Warning RTOS timer resolution is 30.5 us.
@@ -339,21 +245,6 @@ uint32_t sys_clock_elapsed(void)
  *    z_impl_k_busy_wait calls here. This code path uses the value as uint32_t.
  *
  */
-uint32_t sys_clock_cycle_get_32(void)
-{
-	uint32_t ret;
-	uint32_t ccr;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	ccr = timer_count();
-	ret = (total_cycles + (cached_icr - ccr)) & TIMER_COUNT_MASK;
-
-	k_spin_unlock(&lock, key);
-
-	return ret;
-}
-
 void sys_clock_idle_exit(void)
 {
 	if (cached_icr == TIMER_STOPPED) {
@@ -399,10 +290,6 @@ void arch_busy_wait(uint32_t usec_to_wait)
 
 static int sys_clock_driver_init(void)
 {
-#ifdef CONFIG_TICKLESS_KERNEL
-	cached_icr = MAX_TICKS;
-#endif
-
 	sys_write32(0, TIMER_BASE + TIMER_CR_OFS);
 	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_ENCLR_OFS);
 	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_SRC_OFS);
@@ -429,6 +316,9 @@ static int sys_clock_driver_init(void)
 #else
 	timer_restart(cached_icr);
 #endif
+
+	/* Seed the announce baseline and arm the first tick. */
+	timer_core_init();
 
 	return 0;
 }


### PR DESCRIPTION
Converts the mchp_xec_rtos_timer system-timer driver to the generic tickless timer core
that landed in #115844. The core takes over the tick accounting, and what is
left here is the cycle-domain primitives for this hardware. The commit log says
which shape the hardware is and which `TIMER_CORE_*` knobs that implies.
