### PR TITLE
drivers: timer: openrisc_tick_timer: use the generic timer core

### DIFF
--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -12,14 +12,7 @@
 
 #include <openrisc/openriscregs.h>
 
-#define MAX_CYC   SPR_TTMR_TP
-#define MIN_DELAY 1000
-
-static struct k_spinlock lock;
-static uint32_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
-static uint32_t cyc_per_tick;
+#define MAX_CYC SPR_TTMR_TP
 
 static ALWAYS_INLINE void set_compare(uint32_t time)
 {
@@ -36,38 +29,26 @@ static ALWAYS_INLINE uint32_t get_count(void)
 	return openrisc_read_spr(SPR_TTCR);
 }
 
-/* Signed distance between two counts in the 28-bit compare domain: mask to
- * the TP field width, then shift the top bit to bit 31 so the arithmetic
- * shift sign-extends it back.
+/*
+ * A 28-bit free-running count with a compare that matches only TTCR[27:0] == TP,
+ * so a target written at or behind the count is missed until the count wraps,
+ * 13.4 s at 20 MHz. That is the COMPARE_EXACT backend: the core writes the
+ * register through its verify loop.
  */
-static ALWAYS_INLINE int32_t cyc_diff(uint32_t a, uint32_t b)
+#define TIMER_CORE_COUNTER_WIDTH 28
+#define TIMER_CORE_BACKEND_COMPARE_EXACT
+
+static inline uint32_t timer_driver_cycle_get(void)
 {
-	return (int32_t)(((a - b) & MAX_CYC) << 4) >> 4;
+	return get_count();
 }
 
-/* TTMR matches only TTCR[27:0] == TP: a target at or behind the count when
- * TTMR is written is missed until the 28-bit count wraps (13.4 s at 20 MHz),
- * so a deadline armed close to "now" (e.g. a timeout landing just before a
- * tick boundary) must be pushed ahead of the count until it is strictly in
- * the future. A post-write count read still behind the target proves the
- * match is armed; the exit check must accept any strictly-future target
- * rather than demand MIN_DELAY of remaining headroom, which the moving
- * count could never satisfy.
- */
-static ALWAYS_INLINE void set_compare_safe(uint32_t time)
+static inline void timer_driver_set_compare(uint64_t cycles)
 {
-	uint32_t next = time & MAX_CYC;
-
-	set_compare(next);
-
-	uint32_t now = get_count() & MAX_CYC;
-
-	while (cyc_diff(next, now) <= 0) {
-		next = (now + MIN_DELAY) & MAX_CYC;
-		set_compare(next);
-		now = get_count() & MAX_CYC;
-	}
+	set_compare((uint32_t)cycles & MAX_CYC);
 }
+
+#include "system_timer_generic.h"
 
 void z_openrisc_timer_isr(void)
 {
@@ -75,86 +56,22 @@ void z_openrisc_timer_isr(void)
 		sys_trace_isr_enter();
 	}
 
-	const k_spinlock_key_t key = k_spin_lock(&lock);
-
-	const uint32_t current_count = get_count();
-	const uint32_t delta_count = current_count - last_count;
-	const uint32_t delta_ticks = delta_count / cyc_per_tick;
-
-	last_count += delta_ticks * cyc_per_tick;
-	last_ticks += delta_ticks;
-	last_elapsed = 0;
+	const k_spinlock_key_t key = sys_clock_lock();
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		clear_compare();
-	} else {
-		set_compare_safe(last_count + cyc_per_tick);
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(delta_ticks);
+	timer_core_announce_from(key);
 
 	if (IS_ENABLED(CONFIG_TRACING_ISR)) {
 		sys_trace_isr_exit();
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
-{
-#if defined(CONFIG_TICKLESS_KERNEL)
-	/*
-	 * Clamp the max period length to a number of cycles that can fit
-	 * in half the range of a cycle_diff_t for native width divisions
-	 * to be usable elsewhere. The half range gives us extra room to cope
-	 * with the unavoidable IRQ servicing latency.
-	 */
-	ticks = MIN(ticks, MAX_CYC / 2 / cyc_per_tick);
-
-	const uint32_t compare =
-		((last_ticks + last_elapsed + (uint32_t)ticks) * cyc_per_tick) & MAX_CYC;
-	const k_spinlock_key_t key = k_spin_lock(&lock);
-
-	set_compare_safe(compare);
-	k_spin_unlock(&lock, key);
-
-#else  /* CONFIG_TICKLESS_KERNEL */
-	ARG_UNUSED(ticks);
-	ARG_UNUSED(idle);
-#endif
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	const k_spinlock_key_t key = k_spin_lock(&lock);
-
-	const uint32_t current_count = get_count();
-	const uint32_t delta_count = current_count - last_count;
-	const uint32_t delta_ticks = delta_count / cyc_per_tick;
-
-	last_elapsed = delta_ticks;
-	k_spin_unlock(&lock, key);
-	return delta_ticks;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return get_count();
-}
-
 static int sys_clock_driver_init(void)
 {
-	cyc_per_tick = (uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() /
-		(uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC);
-
-	last_ticks = get_count() / cyc_per_tick;
-	last_count = last_ticks * cyc_per_tick;
-	last_elapsed = 0;
-
-	set_compare_safe(last_count + cyc_per_tick);
+	timer_core_init();
 
 	return 0;
 }


### PR DESCRIPTION
Converts the openrisc_tick_timer system-timer driver to the generic tickless timer core
that landed in #115844. The core takes over the tick accounting, and what is
left here is the cycle-domain primitives for this hardware. The commit log says
which shape the hardware is and which `TIMER_CORE_*` knobs that implies.
