### PR TITLE
drivers: timer: renesas_rx_cmt: use the generic timer core

### DIFF
--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -19,23 +19,14 @@
 #define CMT0_NODE DT_NODELABEL(cmt0)
 #define CMT1_NODE DT_NODELABEL(cmt1)
 
-#define CMT1_IRQN DT_IRQN(CMT1_NODE)
+#define CMT0_IRQ_NUM DT_IRQ_BY_NAME(CMT0_NODE, cmi, irq)
+#define CMT1_IRQN    DT_IRQN(CMT1_NODE)
 
 #define ICU_NODE DT_NODELABEL(icu)
-
-#define ICU_IR_ADDR DT_REG_ADDR_BY_NAME(ICU_NODE, IR)
-#define ICU_IR      ((volatile uint8_t *)ICU_IR_ADDR)
-
-#define CMT0_IRQ_NUM DT_IRQ_BY_NAME(CMT0_NODE, cmi, irq)
-#define CMT1_IRQ_NUM DT_IRQ_BY_NAME(CMT1_NODE, cmi, irq)
+#define ICU_IR   ((volatile uint8_t *)DT_REG_ADDR_BY_NAME(ICU_NODE, IR))
 
 #define COUNTER_MAX 0x0000ffff
-
-#define CYCLES_PER_SEC  (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)
-#define TICKS_PER_SEC   (CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#define CYCLES_PER_TICK (CYCLES_PER_SEC / TICKS_PER_SEC)
-#define MAX_TICKS       ((k_ticks_t)(COUNTER_MAX / CYCLES_PER_TICK) - 1)
-
+/* CMT1 counts 0..CMCOR then resets, so a whole period is one more than that. */
 #define CYCLES_CYCLE_TIMER (COUNTER_MAX + 1)
 
 static const struct clock_control_rx_subsys_cfg cmt_clk_cfg = {
@@ -62,120 +53,76 @@ static const struct timer_rx_cfg cycle_timer_cfg = {
 	.cmcnt = (uint16_t *)DT_REG_ADDR_BY_NAME(CMT1_NODE, CMCNT),
 	.cmcor = (uint16_t *)DT_REG_ADDR_BY_NAME(CMT1_NODE, CMCOR)};
 
-#ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
-typedef uint64_t cycle_t;
-#define CYCLE_COUNT_MAX (0xffffffffffffffff)
-#else
-typedef uint32_t cycle_t;
-#define CYCLE_COUNT_MAX (0xffffffff)
-#endif
-static cycle_t cycle_count;
-
-static uint16_t clock_cycles_per_tick;
-
-static volatile cycle_t announced_cycle_count;
-
-static struct k_spinlock lock;
-
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = CMT0_IRQ_NUM;
 #endif
 
-static cycle_t cmt1_elapsed(void)
+/*
+ * Two timers: CMT1 free-runs as the cycle source, widened by the core from the
+ * announce baseline, while CMT0 raises the tick interrupt. CMT0's CMCOR is a
+ * period rather than a deadline, since a match resets CMCNT, so this is the
+ * RELOAD backend.
+ */
+#define TIMER_CORE_BACKEND_RELOAD
+
+/* CMCNT is only 16 bits, which is 10.9 ms at 6 MHz, too short to be read
+ * straight: k_busy_wait() with interrupts masked has to keep working for well
+ * over a second, poor practice though that is, and the core's masked delta
+ * aliases past one period. So the count is extended in software here, and the
+ * core is handed 32 bits. Each read folds a wrap in, which is what keeps the
+ * extension alive while interrupts are masked and no ISR can run. Reading
+ * mutates that state, hence TIMER_CORE_COUNTER_NONATOMIC.
+ *
+ * The alarm is unaffected: CMT0's CMCOR is still 16 bits, so
+ * TIMER_CORE_ALARM_MAX_CYCLES below keeps the armed delay inside one period.
+ */
+#define TIMER_CORE_COUNTER_WIDTH 32
+#define TIMER_CORE_COUNTER_NONATOMIC
+
+/* One reload cannot express more than CMT0's 16-bit CMCOR holds. */
+#define TIMER_CORE_ALARM_MAX_CYCLES COUNTER_MAX
+
+/* A reload of one would program CMCOR == 0 against a just-cleared CMCNT, which
+ * matches on every count. Keep the floor one above that.
+ */
+#define TIMER_CORE_ALARM_MIN_CYCLES 2
+
+/* Whole CMT1 periods consumed, the upper bits of the extended count. */
+static uint32_t cycle_count;
+
+static uint32_t timer_driver_cycle_get(void)
 {
-	uint32_t val1 = (uint32_t)(*cycle_timer_cfg.cmcnt);
-	uint8_t cmt_ir = ICU_IR[CMT1_IRQN];
-	uint32_t val2 = (uint32_t)(*cycle_timer_cfg.cmcnt);
+	uint16_t val1 = *cycle_timer_cfg.cmcnt;
+	bool matched = ICU_IR[CMT1_IRQN] != 0;
+	uint16_t val2 = *cycle_timer_cfg.cmcnt;
 
-	if ((1 == cmt_ir) || (val1 > val2)) {
+	/* The compare-match flag catches a wrap that happened before this read,
+	 * and val1 > val2 one that happened during it.
+	 */
+	if (matched || (val1 > val2)) {
 		cycle_count += CYCLES_CYCLE_TIMER;
-
 		ICU_IR[CMT1_IRQN] = 0;
 	}
 
-	return (val2 + cycle_count);
+	return cycle_count + val2;
 }
 
-uint32_t sys_clock_cycle_get_32(void)
+static inline void timer_driver_set_reload(uint32_t cycles)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	uint32_t ret = (uint32_t)cmt1_elapsed();
-
-	k_spin_unlock(&lock, key);
-
-	return ret;
+	/* CMT0 exists only to raise the tick interrupt: the cycle domain is
+	 * CMT1, so nothing reads CMT0's count and it can be restarted here.
+	 * That makes CMCOR the plain relative delay the core asks for, with no
+	 * need to bias it by the count in flight.
+	 */
+	*tick_timer_cfg.cmcnt = 0;
+	*tick_timer_cfg.cmcor = (uint16_t)(cycles - 1U);
 }
 
-#ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
-uint64_t sys_clock_cycle_get_64(void)
-{
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	uint64_t ret = (uint64_t)cmt1_elapsed();
-
-	k_spin_unlock(&lock, key);
-
-	return ret;
-}
-#endif /* CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER */
-
-uint32_t sys_clock_elapsed(void)
-{
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		/* Always return 0 for tickful operation */
-		return 0;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	uint32_t ret;
-	cycle_t current_cycle_count;
-
-	current_cycle_count = cmt1_elapsed();
-
-	if (current_cycle_count < announced_cycle_count) {
-		/* cycle_count overflowed */
-		ret = (uint32_t)((current_cycle_count +
-				  (CYCLE_COUNT_MAX - announced_cycle_count + 1)) /
-				 CYCLES_PER_TICK);
-	} else {
-		ret = (uint32_t)((current_cycle_count - announced_cycle_count) / CYCLES_PER_TICK);
-	}
-
-	k_spin_unlock(&lock, key);
-
-	return ret;
-}
+#include "system_timer_generic.h"
 
 static void cmt0_isr(void)
 {
-	k_ticks_t dticks;
-	cycle_t current_cycle_count;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	current_cycle_count = cmt1_elapsed();
-
-	if (current_cycle_count < announced_cycle_count) {
-		/* cycle_count overflowed */
-		dticks = (k_ticks_t)((current_cycle_count +
-				      (CYCLE_COUNT_MAX - announced_cycle_count + 1)) /
-				     CYCLES_PER_TICK);
-	} else {
-		dticks = (k_ticks_t)((current_cycle_count - announced_cycle_count) /
-				     CYCLES_PER_TICK);
-	}
-
-	announced_cycle_count = (current_cycle_count / CYCLES_PER_TICK) * CYCLES_PER_TICK;
-
-	k_spin_unlock(&lock, key);
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		sys_clock_announce(1);
-	} else {
-		sys_clock_announce(dticks);
-	}
+	timer_core_announce();
 }
 
 static int sys_clock_driver_init(void)
@@ -195,8 +142,10 @@ static int sys_clock_driver_init(void)
 	*tick_timer_cfg.cmcr = 0x00C0;  /* enable CMT0 interrupt */
 	*cycle_timer_cfg.cmcr = 0x00C0; /* enable CMT1 interrupt */
 
-	clock_cycles_per_tick = (uint16_t)(CYCLES_PER_TICK);
-	*tick_timer_cfg.cmcor = clock_cycles_per_tick - 1;
+	/* A tickful kernel leaves the period alone after this, so set it here.
+	 * A tickless one gets it from timer_core_init() below.
+	 */
+	*tick_timer_cfg.cmcor = (uint16_t)TIMER_CORE_CYC_PER_TICK - 1;
 	*cycle_timer_cfg.cmcor = (uint16_t)COUNTER_MAX;
 
 	IRQ_CONNECT(CMT0_IRQ_NUM, 0x01, cmt0_isr, NULL, 0);
@@ -204,54 +153,9 @@ static int sys_clock_driver_init(void)
 
 	*tick_timer_cfg.cmstr = 0x0003; /* start cmt0,1 */
 
+	timer_core_init();
+
 	return 0;
-}
-
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
-{
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	/* Nothing to do when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		return;
-	}
-
-	/* Preserve the original behavior even though it looks wrong; to be
-	 * revisited.
-	 */
-	if (ticks >= 1) {
-		ticks -= 1;
-	}
-	if (ticks > MAX_TICKS) {
-		ticks = MAX_TICKS;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	cycle_t now = cmt1_elapsed();
-	cycle_t elapsed;
-
-	if (now < announced_cycle_count) {
-		/* cycle_count overflowed */
-		elapsed = (cycle_t)(now + (CYCLE_COUNT_MAX - announced_cycle_count + 1));
-	} else {
-		elapsed = (now - announced_cycle_count);
-	}
-
-	cycle_t delay = (cycle_t)ticks * CYCLES_PER_TICK;
-
-	delay += elapsed;
-	delay = DIV_ROUND_UP(delay, CYCLES_PER_TICK) * CYCLES_PER_TICK;
-	delay -= elapsed;
-
-	uint16_t current = *tick_timer_cfg.cmcnt;
-	uint16_t new_cmcor = (uint16_t)(current + delay - 1U);
-
-	*tick_timer_cfg.cmcor = new_cmcor;
-
-	k_spin_unlock(&lock, key);
 }
 
 SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);


### PR DESCRIPTION
Converts the renesas_rx_cmt system-timer driver to the generic tickless timer core
that landed in #115844. The core takes over the tick accounting, and what is
left here is the cycle-domain primitives for this hardware. The commit log says
which shape the hardware is and which `TIMER_CORE_*` knobs that implies.
