### PR TITLE
drivers: timer: xtensa_sys_timer: use the generic timer core

### DIFF
--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -14,23 +14,17 @@
 #define TIMER_IRQ UTIL_CAT(XCHAL_TIMER,		\
 			   UTIL_CAT(CONFIG_XTENSA_TIMER_ID, _INTERRUPT))
 
-#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
-		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#define MAX_CYC 0xffffffffu
-#define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
-#define MIN_DELAY 1000
-
-static unsigned int last_count;
-
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = UTIL_CAT(XCHAL_TIMER,
 					 UTIL_CAT(CONFIG_XTENSA_TIMER_ID, _INTERRUPT));
 #endif
 
 static uint32_t ccount_compensation;
+#ifdef CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK
 static uint32_t ccount_pre_idle;
 static uint64_t lptim_pre_idle;
 static bool timeout_idle;
+#endif
 
 static uint32_t ccount_comp(void)
 {
@@ -60,14 +54,28 @@ static uint32_t ccount(void)
 	return ccount_raw() + ccount_comp();
 }
 
-static uint32_t sys_clock_elapsed_ticks(uint32_t curr)
+/*
+ * Free-running 32-bit CCOUNT plus a CCOMPARE register that fires only on
+ * CCOUNT == CCOMPARE, so an already-past target is missed until CCOUNT wraps.
+ * That is the COMPARE_EXACT backend: the core rewrites through its verify loop,
+ * replacing the MIN_DELAY floor this driver used to apply by hand. Writing
+ * CCOMPARE clears the pending interrupt. The cycle count carries the low-power
+ * compensation (ccount_comp), so the raw register value written is the target
+ * minus that offset.
+ */
+#define TIMER_CORE_BACKEND_COMPARE_EXACT
+
+static inline uint32_t timer_driver_cycle_get(void)
 {
-	uint32_t dticks = (curr - last_count) / CYC_PER_TICK;
-
-	last_count += dticks * CYC_PER_TICK;
-
-	return dticks;
+	return ccount();
 }
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	set_ccompare((uint32_t)cycles - ccount_comp());
+}
+
+#include "system_timer_generic.h"
 
 static void ccompare_isr(const void *arg)
 {
@@ -82,127 +90,74 @@ static void ccompare_isr(const void *arg)
 	 */
 	set_ccompare(ccount_raw() - 1);
 
-	k_spinlock_key_t key = sys_clock_lock();
-
-	uint32_t curr = ccount();
-	uint32_t dticks = sys_clock_elapsed_ticks(curr);
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint32_t next = last_count + CYC_PER_TICK;
-
-		if ((int32_t)(next - curr) < MIN_DELAY) {
-			next += CYC_PER_TICK;
-		}
-		set_ccompare(next - ccount_comp());
-	}
-
-	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
-}
-
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#if defined(CONFIG_TICKLESS_KERNEL)
-	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
-
-	uint32_t curr = ccount(), cyc, adj;
-
-	/* Round up to next tick boundary */
-	cyc = ticks * CYC_PER_TICK;
-	adj = (curr - last_count) + (CYC_PER_TICK - 1);
-	if (cyc <= MAX_CYC - adj) {
-		cyc += adj;
-	} else {
-		cyc = MAX_CYC;
-	}
-	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
-	cyc += last_count;
-
-	if ((cyc - curr) < MIN_DELAY) {
-		cyc += CYC_PER_TICK;
-	}
-
-	set_ccompare(cyc - ccount_comp());
-
-	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
-		if (idle) {
-			uint64_t timeout_us =
-				((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-			lptim_pre_idle = z_xtensa_lptim_hook_on_lpm_entry(timeout_us);
-			ccount_pre_idle = ccount();
-			timeout_idle = true;
-		}
-	} else {
-		ARG_UNUSED(idle);
-	}
-
-#endif
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	return (ccount() - last_count) / CYC_PER_TICK;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return ccount();
+	timer_core_announce();
 }
 
 #ifdef CONFIG_SMP
 void smp_timer_init(void)
 {
-	set_ccompare(ccount() + CYC_PER_TICK);
+	timer_core_smp_prime();
 	irq_enable(TIMER_IRQ);
 }
 #endif
 
+#ifdef CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	/* Arm the comparator for the wakeup, then hand off to the low-power
+	 * timer that keeps time while CCOUNT is stalled.
+	 */
+	sys_clock_set_timeout(ticks, false);
+
+	/* ticks may be SYS_CLOCK_IDLE_FOREVER, which would overflow the conversion.
+	 * The core has already clamped what it armed above, so clamp this the
+	 * same way.
+	 */
+	uint32_t lp_ticks = MIN(ticks, k_cyc_to_ticks_floor32(TIMER_CORE_ALARM_MAX_CYCLES));
+	uint64_t timeout_us = k_ticks_to_us_ceil64(lp_ticks);
+
+	lptim_pre_idle = z_xtensa_lptim_hook_on_lpm_entry(timeout_us);
+	ccount_pre_idle = ccount();
+	timeout_idle = true;
+}
+
 void sys_clock_idle_exit(void)
 {
-	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
-
-		if (!timeout_idle) {
-			return;
-		}
-
-		k_spinlock_key_t key = sys_clock_lock();
-
-		uint64_t lptim_now = z_xtensa_lptim_hook_on_lpm_exit();
-		uint64_t ccount_now = ccount();
-		uint64_t lptim_diff = lptim_now - lptim_pre_idle;
-		uint32_t ccount_diff = ccount_now - ccount_pre_idle;
-		uint64_t expected_cycles = (lptim_diff * sys_clock_hw_cycles_per_sec()) /
-					   z_xtensa_lptim_hook_get_freq();
-		uint32_t missed_cycles = 0;
-
-		if (expected_cycles > ccount_diff) {
-			missed_cycles = (uint32_t)(expected_cycles - ccount_diff);
-		}
-
-		ccount_compensation += missed_cycles;
-
-		ccount_now = ccount();
-		uint32_t dticks = sys_clock_elapsed_ticks(ccount_now);
-
-		timeout_idle = false;
-
-		/* Announce corrected ticks as CCOUNT remained stalled during LPM */
-		sys_clock_announce_locked(dticks, key);
+	if (!timeout_idle) {
+		return;
 	}
+
+	k_spinlock_key_t key = sys_clock_lock();
+
+	uint64_t lptim_now = z_xtensa_lptim_hook_on_lpm_exit();
+	uint32_t ccount_diff = (uint32_t)ccount() - ccount_pre_idle;
+	uint64_t lptim_diff = lptim_now - lptim_pre_idle;
+	uint64_t expected_cycles =
+		(lptim_diff * sys_clock_hw_cycles_per_sec()) / z_xtensa_lptim_hook_get_freq();
+
+	uint64_t missed_cycles = 0;
+
+	if (expected_cycles > ccount_diff) {
+		/* CCOUNT stalled during LPM. Fold the missed cycles into the
+		 * compensation so the cycle count picks up the real elapsed time,
+		 * and hand the span to the core directly: a sleep can outrun the
+		 * 32-bit CCOUNT, so the announce cannot come from the counter.
+		 * What CCOUNT did see stays there for the next announce.
+		 */
+		missed_cycles = expected_cycles - ccount_diff;
+		ccount_compensation += (uint32_t)missed_cycles;
+	}
+
+	timeout_idle = false;
+
+	timer_core_announce_cycles64_from(key, missed_cycles);
 }
+#endif /* CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK */
 
 static int sys_clock_driver_init(void)
 {
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
-	set_ccompare(ccount() + CYC_PER_TICK);
+	timer_core_init();
 	irq_enable(TIMER_IRQ);
 	return 0;
 }

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -47,12 +47,17 @@ static void set_ccompare(uint32_t val)
 			  :: "r"(val));
 }
 
-static uint32_t ccount(void)
+static uint32_t ccount_raw(void)
 {
 	uint32_t val;
 
 	__asm__ volatile ("rsr.CCOUNT %0" : "=r"(val));
-	return val + ccount_comp();
+	return val;
+}
+
+static uint32_t ccount(void)
+{
+	return ccount_raw() + ccount_comp();
 }
 
 static uint32_t sys_clock_elapsed_ticks(uint32_t curr)
@@ -67,6 +72,15 @@ static uint32_t sys_clock_elapsed_ticks(uint32_t curr)
 static void ccompare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
+
+	/* Disarm the IRQ. Writing CCOMPARE is what clears the pending timer
+	 * interrupt, and the match is on equality, so a compare one behind the
+	 * current count both acknowledges it and puts the next match a whole
+	 * counter period away, which is as far as a 32-bit comparator reaches.
+	 * This interrupt then fires once for the deadline it was armed with,
+	 * whether or not another one is programmed afterwards.
+	 */
+	set_ccompare(ccount_raw() - 1);
 
 	k_spinlock_key_t key = sys_clock_lock();
 


### PR DESCRIPTION
Converts the xtensa_sys_timer system-timer driver to the generic tickless timer core
that landed in #115844. The core takes over the tick accounting, and what is
left here is the cycle-domain primitives for this hardware. The commit log says
which shape the hardware is and which `TIMER_CORE_*` knobs that implies.
