### PR TITLE
net: dsa: Add driver for the Microchip KSZ8463 3-port 10/100 Ethernet switch

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1240,6 +1240,10 @@ New Drivers
   * :dtcompatible:`ti,mspm0-dma` (:github:`91502`)
   * :dtcompatible:`xlnx,zynqmp-dma-1.0` (:github:`101685`)
 
+* :abbr:`DSA (Distributed Switch Architecture)`
+
+  * :dtcompatible:`microchip,ksz8463` (:github:`116253`)
+
 * :abbr:`DSP (Digital Signal Processor)`
 
   * :dtcompatible:`nxp,powerquad` (:github:`110745`)

--- a/drivers/ethernet/dsa/CMakeLists.txt
+++ b/drivers/ethernet/dsa/CMakeLists.txt
@@ -5,3 +5,4 @@ zephyr_library_sources_ifdef(CONFIG_DSA_MICROCHIP_KSZ8463 dsa_ksz8463.c)
 
 # DSA tag protocol drivers
 zephyr_library_sources_ifdef(CONFIG_DSA_TAG_PROTOCOL_NETC dsa_tag_netc.c)
+zephyr_library_sources_ifdef(CONFIG_DSA_TAG_PROTOCOL_KSZ8463 dsa_tag_ksz8463.c)

--- a/drivers/ethernet/dsa/CMakeLists.txt
+++ b/drivers/ethernet/dsa/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library_sources_ifdef(CONFIG_DSA_NXP_IMX_NETC dsa_nxp_imx_netc.c)
+zephyr_library_sources_ifdef(CONFIG_DSA_MICROCHIP_KSZ8463 dsa_ksz8463.c)
 
 # DSA tag protocol drivers
 zephyr_library_sources_ifdef(CONFIG_DSA_TAG_PROTOCOL_NETC dsa_tag_netc.c)

--- a/drivers/ethernet/dsa/Kconfig
+++ b/drivers/ethernet/dsa/Kconfig
@@ -16,6 +16,9 @@ if DSA_DRIVERS
 # Used by sourced files
 DSA_PORT_COMPAT := zephyr,dsa-port
 
+# zephyr-keep-sorted-start
+rsource "Kconfig.ksz8463"
 rsource "Kconfig.nxp_imx_netc"
+# zephyr-keep-sorted-stop
 
 endif # DSA_DRIVERS

--- a/drivers/ethernet/dsa/Kconfig
+++ b/drivers/ethernet/dsa/Kconfig
@@ -13,34 +13,9 @@ menuconfig DSA_DRIVERS
 
 if DSA_DRIVERS
 
-config DSA_NXP_IMX_NETC
-	bool "Support for NXP i.MX NETC"
-	default y
-	depends on DT_HAS_NXP_NETC_SWITCH_ENABLED
-	select NET_PKT_CONTROL_BLOCK if PTP_CLOCK_NXP_NETC
-	help
-	  Add support for NXP i.MX NETC DSA device driver.
-
-config DSA_NXP_IMX_NETC_GCL_LEN
-	int "Gate control list length for i.MX NETC switch"
-	default 64
-	range 1 256
-	depends on DSA_NXP_IMX_NETC && NET_QBV
-	help
-	  Amount of Gate control list to use. Small value saves RAM.
-	  The Max of the value can be 64, 128, or 256.
-
-# DSA tag protocol drivers
-#   Tag protocol ID found in <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
-
+# Used by sourced files
 DSA_PORT_COMPAT := zephyr,dsa-port
 
-config DSA_TAG_PROTOCOL_NETC
-	bool "Tag protocol - NETC"
-	default y
-	select NET_PKT_CONTROL_BLOCK
-	depends on $(dt_compat_any_has_prop,$(DSA_PORT_COMPAT),dsa-tag-protocol,1)
-	help
-	  NXP NETC tag protocol.
+rsource "Kconfig.nxp_imx_netc"
 
 endif # DSA_DRIVERS

--- a/drivers/ethernet/dsa/Kconfig.ksz8463
+++ b/drivers/ethernet/dsa/Kconfig.ksz8463
@@ -1,0 +1,55 @@
+# Microchip KSZ8463 DSA configuration options
+
+# Copyright (c) 2026 Vilhelm Engström
+#
+# SPDX-License-Identifier: Apache-2.0
+
+KSZ8463_COMPAT := microchip,ksz8463
+
+config DSA_MICROCHIP_KSZ8463
+	bool "Support for Microchip KSZ8463 Ethernet switch"
+	default y
+	depends on DT_HAS_MICROCHIP_KSZ8463_ENABLED
+	select GPIO if $(dt_compat_any_has_prop,$(KSZ8463_COMPAT),int-gpios,1) || \
+				$(dt_compat_any_has_prop,$(KSZ8463_COMPAT),reset-gpios,1)
+	select SPI
+	help
+	  Add support for the KSZ8463 3-port Ethernet switch family. Both MII and RMII models
+	  are supported.
+
+if DSA_MICROCHIP_KSZ8463
+
+config DSA_MICROCHIP_KSZ8463_SPI_OPERATIONAL_TIMEOUT
+	int "Maximum time to wait for initial SPI resopnse"
+	default 100
+	range 10 10000
+	help
+	  Number of milliseconds to wait for the chip to respond over SPI during initialization.
+
+config DSA_MICROCHIP_KSZ8463_LINK_STATE_POLL_INTERVAL
+	int "Interval at which the link state is polled"
+	default 1000
+	range 10 60000
+	help
+	  Interval at which the link state is polled should no int-gpios property be provided.
+	  Given in ms.
+
+config DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_POLL_INTERVAL
+	int "Interval at which the PHY is polled for auto-negotiation completion"
+	default 100
+	help
+	  During auto-negotiation, the PHY is periodically polled to determine whether or
+	  not the negotiation has completed. This setting determines how often said state is
+	  polled. Given in ms.
+
+config DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_TIMEOUT
+	int "Auto-negotiation timeout"
+	default 5000
+	help
+	  Number of milliseconds after which auto-negotiation is assumed to have failed. On failure,
+	  the PHY falls back on whatever speed is configured via its microchip,fixed-link-speed
+	  devicetree property.
+
+	  The value must be greater DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_POLL_INTERVAL.
+
+endif # DSA_MICROCHIP_KSZ8463

--- a/drivers/ethernet/dsa/Kconfig.ksz8463
+++ b/drivers/ethernet/dsa/Kconfig.ksz8463
@@ -52,4 +52,16 @@ config DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_TIMEOUT
 
 	  The value must be greater DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_POLL_INTERVAL.
 
+config DSA_TAG_PROTOCOL_KSZ8463
+	bool "Tag protocol - KSZ8463"
+	default y
+	depends on $(dt_compat_any_has_prop,$(DSA_PORT_COMPAT),dsa-tag-protocol,2)
+	help
+	  Enable support for the Microchip KSZ8463 tag protocol.
+
+	  The KSZ8463 Ethernet switch tag protocol uses a single byte just after the payload of
+	  each Ethernet frame sent to or from the CPU port to associate a packet with a user port.
+	  This option is automatically enabled by setting the dsa-tag-protocol property of the
+	  CPU port node to DSA_TAG_PROTO_KSZ8463.
+
 endif # DSA_MICROCHIP_KSZ8463

--- a/drivers/ethernet/dsa/Kconfig.nxp_imx_netc
+++ b/drivers/ethernet/dsa/Kconfig.nxp_imx_netc
@@ -1,0 +1,33 @@
+# NXP i.MX NETC DSA configuration options
+
+# Copyright (c) 2020 DENX Software Engineering GmbH
+#               Lukasz Majewski <lukma@denx.de>
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config DSA_NXP_IMX_NETC
+	bool "Support for NXP i.MX NETC"
+	default y
+	depends on DT_HAS_NXP_NETC_SWITCH_ENABLED
+	select NET_PKT_CONTROL_BLOCK if PTP_CLOCK_NXP_NETC
+	help
+	  Add support for NXP i.MX NETC DSA device driver.
+
+config DSA_NXP_IMX_NETC_GCL_LEN
+	int "Gate control list length for i.MX NETC switch"
+	default 64
+	range 1 256
+	depends on DSA_NXP_IMX_NETC && NET_QBV
+	help
+	  Amount of Gate control list to use. Small value saves RAM.
+	  The Max of the value can be 64, 128, or 256.
+
+# DSA tag protocol driver
+#   Tag protocol ID found in <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
+config DSA_TAG_PROTOCOL_NETC
+	bool "Tag protocol - NETC"
+	default y
+	select NET_PKT_CONTROL_BLOCK
+	depends on $(dt_compat_any_has_prop,$(DSA_PORT_COMPAT),dsa-tag-protocol,1)
+	help
+	  NXP NETC tag protocol.

--- a/drivers/ethernet/dsa/dsa_ksz8463.c
+++ b/drivers/ethernet/dsa/dsa_ksz8463.c
@@ -1,0 +1,1892 @@
+/*
+ * Copyright (c) 2026 Vilhelm Engström
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/dsa_core.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/phy.h>
+#include <zephyr/sys/atomic.h>
+
+#include "dsa_ksz8463.h"
+
+LOG_MODULE_REGISTER(ksz8463, CONFIG_ETHERNET_LOG_LEVEL);
+
+/* The driver should adhere to the following conventions
+ *
+ * - Variables/fields named dev always refer to the switch device
+ * - Variables/fields named portdev, or variations thereof, refer to switch ports
+ * - Variables/fields named phydev refer to PHYs
+ *
+ * The above implies that
+ *
+ * dev->data        is always a struct ksz8463_data *
+ * dev->config      is always a const struct ksz8463_config *
+ * portdev->data    is always a struct dsa_switch_context *
+ * portdev->config  is always a const struct dsa_port_config *
+ * phydev->data     is always a struct ksz8463_phy_data *
+ * phydev->config   is always a const struct ksz8463_phy_config *
+ */
+
+/* compatible = "microchip,ksz8463" */
+#define DT_DRV_COMPAT microchip_ksz8463
+
+/* Maximum time to wait for initial reply from the chip, in ms */
+#define KSZ8463_SPI_OPERATIONAL_TIMEOUT_MS CONFIG_DSA_MICROCHIP_KSZ8463_SPI_OPERATIONAL_TIMEOUT
+
+/* Maximum time to wait for initial reply from the chip as a k_timeout_t */
+#define KSZ8463_SPI_OPERATIONAL_TIMEOUT K_MSEC(KSZ8463_SPI_OPERATIONAL_TIMEOUT_MS)
+
+/* Interval at which link state is to be polled if no int-gpios is available */
+#define KSZ8463_LINK_POLL_INTVL K_MSEC(CONFIG_DSA_MICROCHIP_KSZ8463_LINK_STATE_POLL_INTERVAL)
+
+/* Interval at which to poll for auto-negotiation completion */
+#define KSZ8463_PHY_AUTONEG_POLL_INTVL                                                             \
+	K_MSEC(CONFIG_DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_POLL_INTERVAL)
+
+/* Maximum time to wait for auto-negotiation completion */
+#define KSZ8463_PHY_AUTONEG_TIMEOUT K_MSEC(CONFIG_DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_TIMEOUT)
+
+BUILD_ASSERT(CONFIG_DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_POLL_INTERVAL <
+	     CONFIG_DSA_MICROCHIP_KSZ8463_PHY_AUTONEG_TIMEOUT);
+
+/* Switch mutable state */
+struct ksz8463_data {
+	/* Chip ID, 0x04 for MII, 0x05 for RMII */
+	uint8_t chip_id;
+
+	/* Work scheduled on chip IRQ */
+	struct k_work_delayable chip_isr_dwork;
+
+	/* Mutex protecting SPI transactions */
+	struct k_mutex spi_mutex;
+
+	/* Callback invoked on chip IRQ */
+	struct gpio_callback chip_cb;
+
+	/* Array of port devices. Disabled ports are left as NULL */
+	const struct device **const portdevs;
+};
+
+/* Switch configuration */
+struct ksz8463_config {
+
+	/* Whether or not MLD snooping should be enabled */
+	bool mld_snoop_en;
+
+	/* Whether or not IGMP snooping should be enabled */
+	bool igmp_snoop_en;
+
+	/* Whether or not to enable legal max packet size check */
+	bool pkt_sz_chk_en;
+
+	/* Number of port devices in the data portdevs array */
+	uint8_t num_portdevs;
+
+	/* Port LED mode */
+	uint8_t led_mode;
+
+	/* Reset GPIO. NULL if not set in the dts */
+	struct gpio_dt_spec *rst_gpio;
+
+	/* IRQ GPIO. NULL if not set in the dts */
+	struct gpio_dt_spec *irq_gpio;
+
+	/* For SPI bus access */
+	struct spi_dt_spec spi;
+
+	/* Associated switch device */
+	const struct device *dev;
+};
+
+/* Private data available in the dsa_switch_context */
+struct ksz8463_prv_data {
+
+	/* Associated switch device */
+	const struct device *const dev;
+};
+
+/* Per-port configuration */
+struct ksz8463_port_config {
+
+	/* Whether or not to disable EEE */
+	const bool disable_eee;
+
+	/* Whether or not EEE is currently enabled */
+	bool eee_enabled;
+
+	/* Associated switch device */
+	const struct device *const dev;
+};
+
+/* PHY mutable state */
+struct ksz8463_phy_data {
+
+	/* Whether or not auto-negotiation is currently enabled */
+	bool autoneg_en;
+
+	/* Whether or not auto-negotiation is allowed */
+	bool use_fixed_link;
+
+	/* Fixed link speed */
+	uint8_t fixed_link_speed;
+
+	/* Atomically assessible struct phy_link_state */
+	atomic_t link_state;
+
+	/* Auto-negotiation expiration point */
+	k_timepoint_t autoneg_expiry;
+
+	/* Auto-negotiation work */
+	struct k_work_delayable dwork;
+
+	/* Mutex protecting API-related state */
+	struct k_mutex api_mutex;
+
+	/* Callback to invoke on link state change */
+	phy_callback_t phy_cb;
+
+	/* Data to include in link state change callback */
+	void *phy_cb_data;
+
+	/* Associated PHY device */
+	const struct device *const phydev;
+};
+
+/* PHY configuration */
+struct ksz8463_phy_config {
+
+	/* Associated port device */
+	const struct device *portdev;
+};
+
+static inline const struct device *ksz8463_port_to_switch_dev(const struct device *portdev)
+{
+	const struct dsa_port_config *dsacfg = portdev->config;
+	const struct ksz8463_port_config *portcfg = dsacfg->prv_config;
+
+	return portcfg->dev;
+}
+
+static inline const struct device *ksz8463_phy_to_port_dev(const struct device *phydev)
+{
+	const struct ksz8463_phy_config *phycfg = phydev->config;
+
+	return phycfg->portdev;
+}
+
+static inline const struct device *ksz8463_phy_to_switch_dev(const struct device *phydev)
+{
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	return ksz8463_port_to_switch_dev(portdev);
+}
+
+static inline const struct device *ksz8463_port_to_phy_dev(const struct device *portdev)
+{
+	const struct dsa_port_config *dsacfg = portdev->config;
+
+	return dsacfg->phy_dev;
+}
+
+static inline const struct device *ksz8463_spi_to_switch_dev(const struct spi_dt_spec *spi)
+{
+	const struct ksz8463_config *cfg = CONTAINER_OF(spi, struct ksz8463_config, spi);
+
+	return cfg->dev;
+}
+
+static inline const struct device *
+ksz8463_switch_ctx_to_switch_dev(const struct dsa_switch_context *dsa_switch_ctx)
+{
+	const struct ksz8463_prv_data *prv_data = dsa_switch_ctx->prv_data;
+
+	return prv_data->dev;
+}
+
+static inline atomic_val_t ksz8463_link_state(enum phy_link_speed speed, bool is_up)
+{
+	return (speed << 1) | !!is_up;
+}
+
+static inline enum phy_link_speed ksz8463_link_state_speed(atomic_val_t state)
+{
+	return state >> 1;
+}
+
+static inline bool ksz8463_link_state_up(atomic_val_t state)
+{
+	return state & 1;
+}
+
+static inline bool ksz8463_have_hard_reset(const struct device *dev)
+{
+	const struct ksz8463_config *cfg = dev->config;
+
+	return !!cfg->rst_gpio;
+}
+
+static inline bool ksz8463_have_irq_gpio(const struct device *dev)
+{
+	const struct ksz8463_config *cfg = dev->config;
+
+	return !!cfg->irq_gpio;
+}
+
+static int ksz8463_spi_lock(const struct spi_dt_spec *spi)
+{
+	struct ksz8463_data *data;
+	const struct device *dev = ksz8463_spi_to_switch_dev(spi);
+
+	data = dev->data;
+
+	return k_mutex_lock(&data->spi_mutex, K_MSEC(50));
+}
+
+static void ksz8463_spi_unlock(const struct spi_dt_spec *spi)
+{
+	struct ksz8463_data *data;
+	const struct device *dev = ksz8463_spi_to_switch_dev(spi);
+
+	data = dev->data;
+	k_mutex_unlock(&data->spi_mutex);
+}
+
+static uint16_t ksz8463_spi_cmd(uint16_t reg, size_t size)
+{
+	/* Chip employs a 4-byte aligned, 11 bit address. Accessing unaligned addresses
+	 * requires a wider read at the nearest, aligned address.
+	 *
+	 * Address is sent in bits 6:0 of the first byte in the command phase and bits
+	 * 7:5 of the second.
+	 *
+	 * See Table 3-14 in the data sheet.
+	 */
+	reg = (reg >> 2u) << 4u;
+	switch (size) {
+	case 1u:
+		reg |= (1u << (reg & 0x03u));
+		break;
+	case 2u:
+		reg |= (0x03 << (reg & 0x02));
+		break;
+	default:
+		reg |= 0x0fu;
+		break;
+	}
+
+	return reg << 2u;
+}
+
+/* Read n bytes over SPI. The SPI mutex should be held */
+static int ksz8463_spi_read_raw(const struct spi_dt_spec *spi, uint16_t addr, void *dst, size_t n)
+{
+	int ret;
+	uint8_t cmd[sizeof(addr)];
+
+	const struct spi_buf tx_buf[] = {
+		/* clang-format and checkpatch disagree */
+		/* clang-format off */
+		[0] = {
+			.buf = cmd,
+			.len = sizeof(cmd),
+		},
+		/* clang-format on */
+	};
+
+	const struct spi_buf rx_buf[] = {
+		/* clang-format off */
+		[0] = {
+			.buf = cmd,
+			.len = sizeof(cmd),
+		},
+		[1] = {
+			.buf = dst,
+			.len = n
+		},
+		/* clang-format on */
+	};
+
+	const struct spi_buf_set tx = {
+		.buffers = tx_buf,
+		.count = ARRAY_SIZE(tx_buf),
+	};
+
+	const struct spi_buf_set rx = {
+		.buffers = rx_buf,
+		.count = ARRAY_SIZE(rx_buf),
+	};
+
+	if (unlikely(n > KSZ8463_SPI_CMD_MAX_DATA_PH_SIZE)) {
+		return -ENOBUFS;
+	}
+
+	addr = ksz8463_spi_cmd(addr, n);
+	sys_put_be16(addr, cmd);
+
+	ret = spi_transceive_dt(spi, &tx, &rx);
+
+	return ret < 0 ? ret : 0;
+}
+
+/* Read 4 bytes over SPI. The SPI lock should be held */
+static int ksz8463_spi_read32_raw(const struct spi_dt_spec *spi, uint16_t addr, uint32_t *out)
+{
+	int ret;
+
+	/* Address must be 4-byte aligned */
+	if (unlikely(addr & 0x03)) {
+		return -EFAULT;
+	}
+
+	ret = ksz8463_spi_read_raw(spi, addr, out, sizeof(*out));
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_DBG("Read 0x%04" PRIx16 " (0x%04" PRIx16 "): 0x%08" PRIx32, addr,
+		ksz8463_spi_cmd(addr, sizeof(*out)), *out);
+	return 0;
+}
+
+/* Like ksz8463_spi_read32_raw but with automatic lock acquisition */
+static inline int ksz8463_spi_read32(const struct spi_dt_spec *spi, uint16_t addr, uint32_t *out)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_read32_raw(spi, addr, out);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+/* Read 16 bits from register, aligning addr if required. The SPI mutex should be held */
+static int ksz8463_spi_read16_raw(const struct spi_dt_spec *spi, uint16_t addr, uint16_t *out)
+{
+	int ret;
+	uint32_t be32;
+
+	/* Must be 2-byte aligned */
+	if (unlikely(addr & 0x01u)) {
+		return -EFAULT;
+	}
+
+	/* Driver supports access only at 4 byte boundaries */
+	if (addr & 0x02u) {
+		ret = ksz8463_spi_read32_raw(spi, addr & ~0x02u, &be32);
+		if (ret != 0) {
+			return ret;
+		}
+
+		*out = (uint16_t)(be32 >> 16u);
+		return 0;
+	}
+
+	ret = ksz8463_spi_read_raw(spi, addr, out, sizeof(*out));
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_DBG("Read 0x%04" PRIx16 " (0x%04" PRIx16 "): 0x%04" PRIx16, addr,
+		ksz8463_spi_cmd(addr, sizeof(*out)), *out);
+	return 0;
+}
+
+/* Like ksz8463_spi_read16_raw but with automatic lock acquisition */
+static inline int ksz8463_spi_read16(const struct spi_dt_spec *spi, uint16_t addr, uint16_t *out)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_read16_raw(spi, addr, out);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+/* Read 8 bytes from register, aligning addr if required. The SPI mutex should be held */
+static int ksz8463_spi_read8_raw(const struct spi_dt_spec *spi, uint16_t addr, uint8_t *out)
+{
+	int ret;
+	uint16_t be16;
+
+	/* Device supports accesses only at 4 byte boundaries */
+	if (addr & 0x03u) {
+		ret = ksz8463_spi_read16_raw(spi, addr & ~0x01u, &be16);
+		if (ret != 0) {
+			return ret;
+		}
+
+		*out = (uint8_t)(be16 >> ((addr & 0x01) << 0x03u));
+		return 0;
+	}
+
+	ret = ksz8463_spi_read_raw(spi, addr, out, sizeof(*out));
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_DBG("Read 0x%04" PRIx16 "(0x%04" PRIx16 "): 0x%02" PRIx8, addr,
+		ksz8463_spi_cmd(addr, sizeof(*out)), *out);
+	return 0;
+}
+
+/* Like ksz8463_spi_read8_raw but with automatic acquisition of the SPI mutex */
+static inline int ksz8463_spi_read8(const struct spi_dt_spec *spi, uint16_t addr, uint8_t *out)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_read8_raw(spi, addr, out);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+/* Write n bytes over SPI. The SPI mutex should be held */
+static int ksz8463_spi_write_raw(const struct spi_dt_spec *spi, uint16_t addr, void *value,
+				 size_t n)
+{
+	int ret;
+	uint8_t cmd[sizeof(addr)];
+	const struct spi_buf spibuf[] = {
+		/* clang-format and checkpatch disagree */
+		/* clang-format off */
+		[0] = {
+			.buf = cmd,
+			.len = sizeof(cmd)
+		},
+		[1] = {
+			.buf = value,
+			.len = n
+		}
+		/* clang-format on */
+	};
+
+	struct spi_buf_set tx = {
+		.buffers = spibuf,
+		.count = ARRAY_SIZE(spibuf),
+	};
+
+	if (unlikely(n > KSZ8463_SPI_CMD_MAX_DATA_PH_SIZE)) {
+		return -ENOTSUP;
+	}
+
+	addr = ksz8463_spi_cmd(addr, n);
+	sys_put_be16(addr, cmd);
+	cmd[0] |= KSZ8463_SPI_CMD_WR;
+
+	ret = spi_write_dt(spi, &tx);
+
+	return ret < 0 ? ret : 0;
+}
+
+/* Write 32 bits over SPI. The SPI mutex should be held */
+static int ksz8463_spi_write32_raw(const struct spi_dt_spec *spi, uint16_t addr, uint32_t value)
+{
+	/* Must be 4-byte aligned */
+	if (unlikely(addr & 0x03u)) {
+		return -EFAULT;
+	}
+
+	LOG_DBG("Write 0x%04" PRIx16 "(0x%04" PRIx16 "): 0x%08" PRIx32, addr,
+		ksz8463_spi_cmd(addr, sizeof(value)), value);
+	return ksz8463_spi_write_raw(spi, addr, &value, sizeof(value));
+}
+
+/* Like ksz8463_spi_write32_raw but acquires the SPI mutex */
+static inline int ksz8463_spi_write32(const struct spi_dt_spec *spi, uint16_t addr, uint32_t value)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_write32_raw(spi, addr, value);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+/* Update bits in 32 bit register. The new value is passed in the bits parameter
+ * whereas the mask determines which bits are to be updated. The SPI mutex
+ * should be held
+ */
+static int ksz8463_spi_update_bits32_raw(const struct spi_dt_spec *spi, uint16_t addr,
+					 uint32_t bits, uint32_t mask)
+{
+	int ret;
+	uint32_t be32;
+
+	/* Mask must cover all set bits */
+	if (unlikely(bits & ~mask)) {
+		return -EINVAL;
+	}
+
+	ret = ksz8463_spi_read32_raw(spi, addr, &be32);
+	if (ret != 0) {
+		return ret;
+	}
+
+	be32 &= ~mask;
+	be32 |= bits;
+
+	return ksz8463_spi_write32_raw(spi, addr, be32);
+}
+
+/* Write 16 bit register over SPI, aligning accesses as required. The SPI mutex should be held */
+static int ksz8463_spi_write16_raw(const struct spi_dt_spec *spi, uint16_t addr, uint16_t value)
+{
+	/* Access supported only at 4 byte boundaries */
+	if (addr & 0x02) {
+		return ksz8463_spi_update_bits32_raw(spi, addr & ~0x02u, value << 16u, 0xffff0000u);
+	}
+
+	LOG_DBG("Write 0x%04" PRIx16 "(0x%04" PRIx16 "): 0x%04" PRIx16, addr,
+		ksz8463_spi_cmd(addr, sizeof(value)), value);
+	return ksz8463_spi_write_raw(spi, addr, &value, sizeof(value));
+}
+
+/* Like ksz8463_spi_write16_raw but with acquisition of the SPI mutex */
+static inline int ksz8463_spi_write16(const struct spi_dt_spec *spi, uint16_t addr, uint16_t value)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_write16_raw(spi, addr, value);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+/* Like ksz8463_spi_update_bits32_raw but with 16 bit registers */
+static int ksz8463_spi_update_bits16_raw(const struct spi_dt_spec *spi, uint16_t addr,
+					 uint16_t bits, uint16_t mask)
+{
+	int ret;
+	uint16_t be16;
+
+	if (unlikely(bits & ~mask)) {
+		return -EINVAL;
+	}
+
+	ret = ksz8463_spi_read16_raw(spi, addr, &be16);
+	if (ret != 0) {
+		return ret;
+	}
+
+	be16 &= ~mask;
+	be16 |= bits;
+
+	return ksz8463_spi_write16_raw(spi, addr, be16);
+}
+
+/* Like ksz8463_spi_update_bits16_raw but with automatic SPI lock acquisition */
+static inline int ksz8463_spi_update_bits16(const struct spi_dt_spec *spi, uint16_t addr,
+					    uint16_t bits, uint16_t mask)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_update_bits16_raw(spi, addr, bits, mask);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+/* Write 8 bits over SPI, aligning access as required. The SPI mutex should be held */
+static int ksz8463_spi_write8_raw(const struct spi_dt_spec *spi, uint16_t addr, uint8_t value)
+{
+	if (addr & 0x03u) {
+		return ksz8463_spi_update_bits16_raw(spi, addr & ~0x01u,
+						     value << ((addr & 0x01u) << 3u),
+						     0xff << ((addr & 0x01u) << 3u));
+	}
+
+	LOG_DBG("Write 0x%04" PRIx16 "(0x%04" PRIx16 "): 0x%02" PRIx8, addr,
+		ksz8463_spi_cmd(addr, sizeof(value)), value);
+	return ksz8463_spi_write_raw(spi, addr, &value, sizeof(value));
+}
+
+/* Like ksz8463_spi_write8_raw but with automatic SPI lock acquisition */
+static inline int ksz8463_spi_write8(const struct spi_dt_spec *spi, uint16_t addr, uint8_t value)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_write8_raw(spi, addr, value);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+/* Like ksz8463_spi_update_bits16_raw but with 8 bit registers */
+static int ksz8463_spi_update_bits8_raw(const struct spi_dt_spec *spi, uint16_t addr, uint8_t bits,
+					uint8_t mask)
+{
+	int ret;
+	uint8_t b;
+
+	if (unlikely(bits & ~mask)) {
+		return -EINVAL;
+	}
+
+	ret = ksz8463_spi_read8_raw(spi, addr, &b);
+	if (ret != 0) {
+		return ret;
+	}
+
+	b &= ~mask;
+	b |= bits;
+
+	return ksz8463_spi_write8_raw(spi, addr, b);
+}
+
+/* Lock the SPI mutex and invoke ksz8463_spi_update_bits8_raw */
+static inline int ksz8463_spi_update_bits8(const struct spi_dt_spec *spi, uint16_t addr,
+					   uint8_t bits, uint8_t mask)
+{
+	int ret = ksz8463_spi_lock(spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_update_bits8_raw(spi, addr, bits, mask);
+	ksz8463_spi_unlock(spi);
+	return ret;
+}
+
+static bool ksz8463_is_cpu_port(const struct device *portdev)
+{
+	struct ethernet_context *eth_ctx;
+	struct net_if *iface = net_if_lookup_by_dev(portdev);
+
+	if (unlikely(!iface)) {
+		return false;
+	}
+
+	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
+		return false;
+	}
+
+	eth_ctx = net_if_l2_data(iface);
+	return eth_ctx->dsa_port == DSA_CPU_PORT;
+}
+
+static int ksz8463_eee_on_off(const struct device *portdev, bool enable, bool lock_spi)
+{
+	int ret;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg = portdev->config;
+	struct ksz8463_port_config *portcfg = dsacfg->prv_config;
+	const struct device *dev = ksz8463_port_to_switch_dev(portdev);
+
+	cfg = dev->config;
+
+	if (unlikely(dsacfg->port_idx >= cfg->num_portdevs)) {
+		return -EINVAL;
+	}
+
+	if (lock_spi) {
+		ret = ksz8463_spi_lock(&cfg->spi);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+	if (portcfg->eee_enabled != enable) {
+		BUILD_ASSERT(KSZ8463_PCSEEEC_P1_NEXT_PG_EN == BIT(0));
+		BUILD_ASSERT(KSZ8463_PCSEEEC_P2_NEXT_PG_EN == BIT(1));
+
+		ret = ksz8463_spi_update_bits8_raw(&cfg->spi, KSZ8463_REG_PCSEEEC,
+						   enable ? BIT(dsacfg->port_idx) : 0,
+						   BIT(dsacfg->port_idx));
+		if (ret == 0) {
+			portcfg->eee_enabled = enable;
+		}
+	}
+	if (lock_spi) {
+		ksz8463_spi_unlock(&cfg->spi);
+	}
+
+	return ret;
+}
+
+static inline int ksz8463_eee_disable(const struct device *portdev)
+{
+	return ksz8463_eee_on_off(portdev, false, true);
+}
+
+static inline int ksz8463_eee_disable_raw(const struct device *portdev)
+{
+	return ksz8463_eee_on_off(portdev, false, false);
+}
+
+static inline int ksz8463_eee_enable_raw(const struct device *portdev)
+{
+	return ksz8463_eee_on_off(portdev, true, false);
+}
+
+static int ksz8463_phy_validate_mode(const struct device *phydev)
+{
+	char const *modes = "rmii";
+	const struct ksz8463_data *data;
+	const struct dsa_port_config *dsacfg;
+	const struct ksz8463_port_config *portcfg;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	data = dev->data;
+	dsacfg = portdev->config;
+	portcfg = dsacfg->prv_config;
+
+	if (!ksz8463_is_cpu_port(portdev)) {
+		/* User ports use internal PHYs */
+		return strcmp(dsacfg->phy_mode, "internal") ? -EINVAL : 0;
+	}
+
+	switch (data->chip_id) {
+	case KSZ8463_MII_CHIP_ID:
+		/* "rmii" -> "mii" */
+		++modes;
+		break;
+	case KSZ8463_RMII_CHIP_ID:
+		break;
+	default:
+		LOG_ERR("Unexpected chip ID: 0x%x", (unsigned int)data->chip_id);
+		return -ENOTSUP;
+	}
+
+	return strcmp(dsacfg->phy_mode, modes) ? -EINVAL : 0;
+}
+
+static int ksz8463_phy_link_is_up(const struct device *phydev, bool *is_up)
+{
+	int ret;
+	uint8_t pxsr;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	dsacfg = portdev->config;
+	cfg = dev->config;
+
+	if (unlikely(ksz8463_is_cpu_port(portdev))) {
+		/* CPU link should always be up */
+		*is_up = true;
+		return 0;
+	}
+
+	ret = ksz8463_spi_read8(&cfg->spi, KSZ8463_REG_PxSR_LO(dsacfg->port_idx), &pxsr);
+	if (ret != 0) {
+		return ret;
+	}
+
+	*is_up = !!(pxsr & KSZ8463_PxSR_LO_LINK_STATUS);
+	return 0;
+}
+
+static int ksz8463_phy_partner_auto_negotiation_capable(const struct device *phydev, bool *capable)
+{
+	int ret;
+	uint8_t pxeeecs;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	cfg = dev->config;
+	dsacfg = portdev->config;
+
+	if (unlikely(ksz8463_is_cpu_port(portdev))) {
+		/* CPU port should use fix link */
+		*capable = false;
+		return 0;
+	}
+
+	ret = ksz8463_spi_read8(&cfg->spi, KSZ8463_REG_PxEEECS_LO(dsacfg->port_idx), &pxeeecs);
+	if (ret != 0) {
+		return ret;
+	}
+
+	*capable = !!(pxeeecs & KSZ8463_PxEEECS_LO_LNK_AUTONEG_CPBL);
+	return 0;
+}
+
+static int ksz8463_phy_link_configured(const struct device *phydev)
+{
+	uint8_t pxsr;
+	struct phy_link_state state;
+	int ret, base100, full_duplex;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	struct ksz8463_phy_data *phydata = phydev->data;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	cfg = dev->config;
+	dsacfg = portdev->config;
+
+	ret = ksz8463_spi_read8(&cfg->spi, KSZ8463_REG_PxSR_HI(dsacfg->port_idx), &pxsr);
+	if (ret != 0) {
+		return ret;
+	}
+
+	base100 = !!(pxsr & KSZ8463_PxSR_HI_OPER_SPEED_100MBPS);
+	full_duplex = !!(pxsr & KSZ8463_PxSR_HI_OPER_FULL_DUPLEX);
+
+	state.speed = 0;
+	switch ((base100 << 1) | full_duplex) {
+	case KSZ8463_SPEED_100BASE_FULL_DUPLEX:
+		state.speed = LINK_FULL_100BASE;
+		break;
+	case KSZ8463_SPEED_100BASE_HALF_DUPLEX:
+		state.speed = LINK_HALF_100BASE;
+		break;
+	case KSZ8463_SPEED_10BASE_FULL_DUPLEX:
+		state.speed = LINK_FULL_10BASE;
+		break;
+	case KSZ8463_SPEED_10BASE_HALF_DUPLEX:
+		state.speed = LINK_HALF_10BASE;
+		break;
+	default:
+		CODE_UNREACHABLE;
+	}
+
+	LOG_INF("Speed 10%sMbps, %s-duplex", PHY_LINK_IS_SPEED_100M(state.speed) ? "0" : "",
+		PHY_LINK_IS_FULL_DUPLEX(state.speed) ? "full" : "half");
+
+	ret = k_mutex_lock(&phydata->api_mutex, K_FOREVER);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Writes require locks to ensure assignments and callback invocations
+	 * are not mixed on concurrent PHY state changes
+	 */
+	atomic_set(&phydata->link_state, ksz8463_link_state(state.speed, true));
+
+	state.is_up = true;
+	if (phydata->phy_cb) {
+		phydata->phy_cb(phydev, &state, phydata->phy_cb_data);
+	}
+
+	k_mutex_unlock(&phydata->api_mutex);
+	return ret;
+}
+
+static int ksz8463_phy_auto_negotiation_on_off(const struct device *phydev, bool enable)
+{
+	int ret, rr;
+	bool disable_eee;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	const struct ksz8463_port_config *portcfg;
+	struct ksz8463_phy_data *phydata = phydev->data;
+	const uint8_t bit = KSZ8463_PxCR4_LO_AUTONEG_EN;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	cfg = dev->config;
+	dsacfg = portdev->config;
+	portcfg = dsacfg->prv_config;
+
+	if (enable && phydata->use_fixed_link) {
+		return -ENOTSUP;
+	}
+
+	if (phydata->autoneg_en == enable) {
+		return 0;
+	}
+
+	ret = ksz8463_spi_lock(&cfg->spi);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Errata 4 fromKZ8463_MLI_FMLI_PROD_0.3_errata. Temporarily disable EEE when disabling
+	 * auto-negotiation
+	 */
+	disable_eee = portcfg->eee_enabled && !enable;
+	if (disable_eee) {
+		ret = ksz8463_eee_disable_raw(portdev);
+	}
+
+	if (ret == 0) {
+		ret = ksz8463_spi_update_bits8_raw(
+			&cfg->spi, KSZ8463_REG_PxCR4_LO(dsacfg->port_idx), enable ? bit : 0, bit);
+
+		if (disable_eee) {
+			rr = ksz8463_eee_enable_raw(portdev);
+
+			if (rr != 0) {
+				LOG_ERR("Error reenabling EEE on port %d: %d", dsacfg->port_idx,
+					-rr);
+			}
+		}
+	}
+	if (ret == 0) {
+		phydata->autoneg_en = enable;
+	}
+
+	ksz8463_spi_unlock(&cfg->spi);
+	return ret;
+}
+
+static inline int ksz8463_phy_enable_auto_negotiation(const struct device *phydev)
+{
+	return ksz8463_phy_auto_negotiation_on_off(phydev, true);
+}
+
+static inline int ksz8463_phy_disable_auto_negotiation(const struct device *phydev)
+{
+	return ksz8463_phy_auto_negotiation_on_off(phydev, false);
+}
+
+static int ksz8463_phy_restart_auto_negotiation(const struct device *phydev)
+{
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	cfg = dev->config;
+	dsacfg = portdev->config;
+
+	return ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_PxCR4_HI(dsacfg->port_idx),
+					KSZ8463_PxCR4_HI_AUTONEG_RESTART,
+					KSZ8463_PxCR4_HI_AUTONEG_RESTART);
+}
+
+static int ksz8463_phy_configure_fixed_link(const struct device *phydev)
+{
+	int ret;
+	uint8_t bits;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	const struct ksz8463_phy_data *phydata = phydev->data;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+	const uint8_t mask =
+		KSZ8463_PxMBCR_HI_FORCE_100BASE_TX | KSZ8463_PxMBCR_HI_FORCE_FULL_DUPLEX;
+
+	dsacfg = portdev->config;
+	cfg = dev->config;
+	bits = 0;
+
+	ret = ksz8463_phy_disable_auto_negotiation(phydev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (phydata->fixed_link_speed & KSZ8463_SPEED_FULL_DUPLEX_BIT) {
+		bits |= KSZ8463_PxMBCR_HI_FORCE_FULL_DUPLEX;
+	}
+
+	if (phydata->fixed_link_speed & KSZ8463_SPEED_100BASE_BIT) {
+		bits |= KSZ8463_PxMBCR_HI_FORCE_100BASE_TX;
+	}
+
+	ret = ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_PxMBCR_HI(dsacfg->port_idx), bits,
+				       mask);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return ksz8463_phy_link_configured(phydev);
+}
+
+static int ksz8463_phy_start_auto_negotiation(const struct device *phydev)
+{
+	int ret;
+	const struct dsa_port_config *dsacfg;
+	struct ksz8463_phy_data *phydata = phydev->data;
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+
+	dsacfg = portdev->config;
+
+	ret = ksz8463_phy_enable_auto_negotiation(phydev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_phy_restart_auto_negotiation(phydev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	phydata->autoneg_expiry = sys_timepoint_calc(KSZ8463_PHY_AUTONEG_TIMEOUT);
+	k_work_reschedule(&phydata->dwork, KSZ8463_PHY_AUTONEG_POLL_INTVL);
+	return 0;
+}
+
+static void ksz8463_phy_dwork(struct k_work *work)
+{
+	int ret;
+	bool link_up;
+	uint8_t pxmbsr;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	const struct device *dev, *portdev, *phydev;
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct ksz8463_phy_data *phydata = CONTAINER_OF(dwork, struct ksz8463_phy_data, dwork);
+
+	phydev = phydata->phydev;
+	dev = ksz8463_phy_to_switch_dev(phydev);
+	portdev = ksz8463_phy_to_port_dev(phydev);
+
+	cfg = dev->config;
+	dsacfg = portdev->config;
+
+	ret = ksz8463_spi_read8(&cfg->spi, KSZ8463_REG_PxMBSR_LO(dsacfg->port_idx), &pxmbsr);
+	if (ret == 0 && (pxmbsr & KSZ8463_PxMBSR_AUTONEG_CPLT)) {
+		LOG_DBG("Auto-negotiation completed on port %d", dsacfg->port_idx);
+
+		phydata->autoneg_expiry = sys_timepoint_calc(K_NO_WAIT);
+		ret = ksz8463_phy_link_configured(phydev);
+	} else if (sys_timepoint_expired(phydata->autoneg_expiry)) {
+		LOG_INF("Auto-negotiation timed out");
+
+		ret = ksz8463_phy_link_is_up(phydev, &link_up);
+
+		if (ret == 0) {
+			if (link_up) {
+				/* Fall back on fixed link */
+				ret = ksz8463_phy_configure_fixed_link(phydev);
+			} else {
+				LOG_DBG("Link severed during auto-negotiation");
+			}
+		}
+	} else {
+		if (ret != 0) {
+			LOG_ERR("Could not read P%dMBSR: %d", dsacfg->port_idx, -ret);
+		} else {
+			LOG_DBG("Auto-negotiation in process, rescheduling");
+		}
+		ret = k_work_reschedule(&phydata->dwork, KSZ8463_PHY_AUTONEG_POLL_INTVL);
+	}
+
+	if (ret < 0) {
+		LOG_ERR("Error when pulling for auto-negotiation completion: %d", -ret);
+	}
+}
+
+static int ksz8463_phy_configure_link(const struct device *phydev)
+{
+	int ret;
+	bool autoneg_capable;
+	const struct ksz8463_phy_data *phydata = phydev->data;
+
+	autoneg_capable = false;
+	if (!phydata->use_fixed_link) {
+		ret = ksz8463_phy_partner_auto_negotiation_capable(phydev, &autoneg_capable);
+		if (ret != 0) {
+			return ret;
+		}
+
+		if (!autoneg_capable) {
+			LOG_INF("Link partner does not support auto-negotiation");
+		}
+	}
+
+	if (autoneg_capable) {
+		ret = ksz8463_phy_start_auto_negotiation(phydev);
+	} else {
+		ret = ksz8463_phy_configure_fixed_link(phydev);
+	}
+
+	return ret;
+}
+
+static int ksz8463_phy_init(const struct device *phydev)
+{
+	int ret;
+	bool link_up;
+	struct ksz8463_phy_data *phydata = phydev->data;
+
+	k_work_init_delayable(&phydata->dwork, ksz8463_phy_dwork);
+	phydata->autoneg_expiry = sys_timepoint_calc(K_NO_WAIT);
+
+	ret = k_mutex_init(&phydata->api_mutex);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_phy_validate_mode(phydev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_phy_link_is_up(phydev, &link_up);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (link_up) {
+		atomic_set(&phydata->link_state, ksz8463_link_state(0, true));
+		ret = ksz8463_phy_configure_link(phydev);
+	}
+
+	return ret;
+}
+
+static int ksz8463_phy_link_down(const struct device *phydev)
+{
+	int ret;
+	atomic_val_t state;
+	struct phy_link_state link_state;
+	struct ksz8463_phy_data *phydata = phydev->data;
+
+	ret = k_mutex_lock(&phydata->api_mutex, K_FOREVER);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Assignments must be done in critical sections despite atomicity to ensure CPU
+	 * doesn't preempt before callback
+	 */
+	state = atomic_get(&phydata->link_state);
+	if (state) {
+		atomic_set(&phydata->link_state, ksz8463_link_state(0, false));
+
+		link_state.is_up = false;
+		link_state.speed = 0;
+
+		if (phydata->phy_cb) {
+			phydata->phy_cb(phydev, &link_state, phydata->phy_cb_data);
+		}
+	}
+
+	k_mutex_unlock(&phydata->api_mutex);
+
+	k_work_cancel_delayable(&phydata->dwork);
+	phydata->autoneg_expiry = sys_timepoint_calc(K_NO_WAIT);
+
+	return 0;
+}
+
+static inline int ksz8463_phy_link_up(const struct device *phydev)
+{
+	struct ksz8463_phy_data *phydata = phydev->data;
+
+	atomic_set(&phydata->link_state, ksz8463_link_state(0, true));
+	return ksz8463_phy_configure_link(phydev);
+}
+
+static int ksz8463_phy_get_link(const struct device *phydev, struct phy_link_state *state)
+{
+	atomic_val_t link_state;
+	const struct ksz8463_phy_data *phydata = phydev->data;
+
+	link_state = atomic_get(&phydata->link_state);
+	state->is_up = ksz8463_link_state_up(link_state);
+	state->speed = ksz8463_link_state_speed(link_state);
+
+	return 0;
+}
+
+static void ksz8463_phy_fixed_link_from_advertise(const struct device *phydev,
+						  enum phy_link_speed adv_speeds)
+{
+	struct ksz8463_phy_data *phydata = phydev->data;
+
+	phydata->fixed_link_speed = 0;
+	/* Use highest advertised speed */
+	if (adv_speeds & (LINK_FULL_10BASE | LINK_FULL_100BASE)) {
+		phydata->fixed_link_speed |= KSZ8463_SPEED_FULL_DUPLEX_BIT;
+	}
+
+	if (adv_speeds & (LINK_HALF_100BASE | LINK_FULL_100BASE)) {
+		phydata->fixed_link_speed |= KSZ8463_SPEED_100BASE_BIT;
+	}
+}
+
+static int ksz8463_phy_configure_advertise(const struct device *phydev,
+					   enum phy_link_speed adv_speeds)
+{
+	uint16_t bits;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg;
+	const struct device *dev = ksz8463_phy_to_switch_dev(phydev);
+	const struct device *portdev = ksz8463_phy_to_port_dev(phydev);
+	const uint16_t mask = KSZ8463_PxANAR_ADV_100BASE_TX_FULL_DUPLEX |
+			      KSZ8463_PxANAR_ADV_100BASE_TX_HALF_DUPLEX |
+			      KSZ8463_PxANAR_ADV_10BASE_T_FULL_DUPLEX |
+			      KSZ8463_PxANAR_ADV_10BASE_T_HALF_DUPLEX;
+
+	cfg = dev->config;
+	dsacfg = portdev->config;
+
+	bits = 0;
+	if (adv_speeds & LINK_HALF_10BASE) {
+		bits |= KSZ8463_PxANAR_ADV_10BASE_T_HALF_DUPLEX;
+	}
+
+	if (adv_speeds & LINK_FULL_10BASE) {
+		bits |= KSZ8463_PxANAR_ADV_10BASE_T_FULL_DUPLEX;
+	}
+
+	if (adv_speeds & LINK_HALF_100BASE) {
+		bits |= KSZ8463_PxANAR_ADV_100BASE_TX_HALF_DUPLEX;
+	}
+
+	if (adv_speeds & LINK_FULL_100BASE) {
+		bits |= KSZ8463_PxANAR_ADV_100BASE_TX_FULL_DUPLEX;
+	}
+
+	return ksz8463_spi_update_bits16(&cfg->spi, KSZ8463_REG_PxANAR(dsacfg->port_idx), bits,
+					 mask);
+}
+
+static int ksz8463_phy_cfg_link(const struct device *phydev, enum phy_link_speed adv_speeds,
+				enum phy_cfg_link_flag flags)
+{
+	int ret;
+	struct ksz8463_phy_data *phydata = phydev->data;
+	const uint8_t speedmask =
+		LINK_HALF_10BASE | LINK_FULL_10BASE | LINK_HALF_100BASE | LINK_FULL_100BASE;
+
+	if (!(adv_speeds & speedmask)) {
+		return -EINVAL;
+	}
+
+	ret = k_mutex_lock(&phydata->api_mutex, K_FOREVER);
+	if (ret != 0) {
+		return ret;
+	}
+
+	phydata->use_fixed_link = !!(flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED);
+
+	ksz8463_phy_fixed_link_from_advertise(phydev, adv_speeds);
+
+	ret = ksz8463_phy_configure_advertise(phydev, adv_speeds);
+	if (ret == 0) {
+		ret = ksz8463_phy_configure_link(phydev);
+	}
+
+	k_mutex_unlock(&phydata->api_mutex);
+	return ret;
+}
+
+static int ksz8463_phy_link_cb_set(const struct device *phydev, phy_callback_t cb, void *user_data)
+{
+	int ret;
+	atomic_val_t encoded;
+	struct phy_link_state state;
+	struct ksz8463_phy_data *phydata = phydev->data;
+
+	ret = k_mutex_lock(&phydata->api_mutex, K_FOREVER);
+	if (ret != 0) {
+		return ret;
+	}
+
+	phydata->phy_cb = cb;
+	phydata->phy_cb_data = user_data;
+
+	encoded = atomic_get(&phydata->link_state);
+
+	/* Must invoke after setting */
+
+	state.is_up = ksz8463_link_state_up(encoded);
+	state.speed = ksz8463_link_state_speed(encoded);
+	cb(phydev, &state, user_data);
+
+	k_mutex_unlock(&phydata->api_mutex);
+
+	return 0;
+}
+
+static DEVICE_API(ethphy, ksz8463_phy_driver_api) = {
+	.get_link = ksz8463_phy_get_link,
+	.cfg_link = ksz8463_phy_cfg_link,
+	.link_cb_set = ksz8463_phy_link_cb_set,
+};
+
+static int ksz8463_link_changed(const struct device *dev)
+{
+	int ret;
+	bool was_up, is_up;
+	atomic_val_t link_state;
+	const struct dsa_port_config *dsacfg;
+	const struct device *portdev, *phydev;
+	struct ksz8463_data *data = dev->data;
+	const struct ksz8463_phy_data *phydata;
+	const struct ksz8463_config *cfg = dev->config;
+
+	ret = 0;
+	for (unsigned int i = 0u; ret == 0 && i < cfg->num_portdevs; ++i) {
+		portdev = data->portdevs[i];
+
+		/* CPU port's link status won't change, nor will that of disabled ports */
+		if (!portdev || ksz8463_is_cpu_port(portdev)) {
+			continue;
+		}
+
+		dsacfg = portdev->config;
+		phydev = ksz8463_port_to_phy_dev(portdev);
+		phydata = phydev->data;
+		link_state = atomic_get(&phydata->link_state);
+		was_up = ksz8463_link_state_up(link_state);
+
+		ret = ksz8463_phy_link_is_up(phydev, &is_up);
+		if (ret != 0) {
+			break;
+		}
+
+		if (was_up && !is_up) {
+			/* Chip indicates that the link is bad during auto-negotiation.
+			 * Defer potential link down event until auto-negotiation timer has
+			 * expired
+			 */
+			if (sys_timepoint_expired(phydata->autoneg_expiry)) {
+				ret = ksz8463_phy_link_down(phydev);
+			}
+		} else if (!was_up && is_up) {
+			ret = ksz8463_phy_link_up(phydev);
+		}
+	}
+
+	return ret;
+}
+
+static void ksz8463_chip_isr(const struct device *gpiodev, struct gpio_callback *cb,
+			     gpio_port_pins_t pins)
+{
+	struct ksz8463_data *data = CONTAINER_OF(cb, struct ksz8463_data, chip_cb);
+
+	k_work_schedule(&data->chip_isr_dwork, K_NO_WAIT);
+}
+
+static int ksz8463_handle_chip_isr(const struct device *dev)
+{
+	int ret;
+	uint8_t isr;
+	unsigned int key;
+	bool lcis_cleared;
+	const struct ksz8463_config *cfg = dev->config;
+
+	key = irq_lock();
+
+	/* Chip's internal state may change despite IRQs being disabled */
+	do {
+		ret = ksz8463_spi_read8(&cfg->spi, KSZ8463_REG_ISR_HI, &isr);
+		if (ret != 0) {
+			LOG_ERR("Could not read interrupt status: %d", -ret);
+			break;
+		}
+
+		if (unlikely(!(isr & KSZ8463_ISR_HI_LCIS))) {
+			ret = 0;
+			break;
+		}
+
+		/* Bit is W1C */
+		ret = ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_ISR_HI, KSZ8463_ISR_HI_LCIS,
+					       KSZ8463_ISR_HI_LCIS);
+		lcis_cleared = !ret;
+		if (!lcis_cleared) {
+			LOG_ERR("Error clearing LCIS: %d", -ret);
+		}
+
+		ret = ksz8463_link_changed(dev);
+		if (ret != 0) {
+			LOG_ERR("Error processing link state change: %d", -ret);
+			break;
+		}
+
+		/* Assuming LCIS was successfully cleared, loop and read the register. If the chip
+		 * has set the bit again, there is a new change to act on
+		 */
+	} while (lcis_cleared);
+
+	irq_unlock(key);
+
+	return ret;
+}
+
+static void ksz8463_chip_isr_dwork(struct k_work *work)
+{
+	int ret;
+	const struct ksz8463_config *cfg;
+	const struct device *dev, *portdev;
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct ksz8463_data *data = CONTAINER_OF(dwork, struct ksz8463_data, chip_isr_dwork);
+
+	/* There is at least one non-NULL entry in the portdevs array. Find it */
+	for (portdev = data->portdevs[0]; !portdev; ++portdev) {
+	}
+
+	dev = ksz8463_port_to_switch_dev(portdev);
+	cfg = dev->config;
+
+	(void)ksz8463_handle_chip_isr(dev);
+
+	if (!ksz8463_have_irq_gpio(dev)) {
+		ret = k_work_reschedule(&data->chip_isr_dwork, KSZ8463_LINK_POLL_INTVL);
+
+		if (ret < 0) {
+			LOG_ERR("Could not reschedule link poll: %d", ret);
+		}
+	}
+}
+
+static int ksz8463_port_enable(const struct device *portdev)
+{
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg = portdev->config;
+	const struct device *dev = ksz8463_port_to_switch_dev(portdev);
+	const uint8_t bits = KSZ8463_PxCR2_HI_TX_EN | KSZ8463_PxCR2_HI_RX_EN;
+	const uint8_t mask = bits | KSZ8463_PxCR2_HI_LEARN_DIS;
+
+	cfg = dev->config;
+
+	return ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_PxCR2_HI(dsacfg->port_idx), bits,
+					mask);
+}
+
+static int ksz8463_port_init(const struct device *portdev)
+{
+	int ret;
+	struct ksz8463_data *data;
+	const struct ksz8463_config *cfg;
+	const struct dsa_port_config *dsacfg = portdev->config;
+	const struct device *dev = ksz8463_port_to_switch_dev(portdev);
+	const struct device *phydev = ksz8463_port_to_phy_dev(portdev);
+	const struct ksz8463_port_config *portcfg = dsacfg->prv_config;
+
+	data = dev->data;
+	cfg = dev->config;
+
+	if (unlikely(dsacfg->port_idx >= cfg->num_portdevs)) {
+		return -EINVAL;
+	}
+
+	ret = ksz8463_port_enable(portdev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (!ksz8463_is_cpu_port(portdev)) {
+		if (portcfg->disable_eee) {
+			ret = ksz8463_eee_disable(portdev);
+
+			if (ret != 0) {
+				return ret;
+			}
+		}
+
+		ret = ksz8463_phy_init(phydev);
+	}
+
+	return ret;
+}
+
+static int ksz8463_configure_irq(const struct device *dev)
+{
+	int ret;
+	struct ksz8463_data *data = dev->data;
+	const struct ksz8463_config *cfg = dev->config;
+
+	if (unlikely(!cfg->irq_gpio)) {
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(cfg->irq_gpio, GPIO_INPUT);
+	if (ret != 0) {
+		return ret;
+	}
+
+	gpio_init_callback(&data->chip_cb, ksz8463_chip_isr, BIT(cfg->irq_gpio->pin));
+	gpio_add_callback(cfg->irq_gpio->port, &data->chip_cb);
+	ret = gpio_pin_interrupt_configure_dt(cfg->irq_gpio, GPIO_INT_EDGE_FALLING);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_write8(&cfg->spi, KSZ8463_REG_IER_HI, KSZ8463_IER_HI_LCIE);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Handle potential interrupt occurring before configuration */
+	ret = ksz8463_handle_chip_isr(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_INF("Link-change interrupt configured");
+	return 0;
+}
+
+static int ksz8463_configure_link_state_poll(const struct device *dev)
+{
+	int ret;
+	struct ksz8463_data *data = dev->data;
+
+	LOG_DBG("No IRQ pin provided, falling back on polling");
+
+	ret = k_work_reschedule(&data->chip_isr_dwork, KSZ8463_LINK_POLL_INTVL);
+	return ret < 0 ? ret : 0;
+}
+
+static inline int ksz8463_configure_leds(const struct device *dev)
+{
+	const struct ksz8463_config *cfg = dev->config;
+
+	return ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_SGCR7_HI, cfg->led_mode,
+					KSZ8463_SGCR7_HI_PORT_LED_MODE_MASK);
+}
+
+static inline int ksz8463_configure_legal_packet_size_check(const struct device *dev)
+{
+	const struct ksz8463_config *cfg = dev->config;
+	const uint8_t bit = KSZ8463_SGCR2_LO_LEGAL_PKT_SZ_CHK_EN;
+
+	return ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_SGCR2_LO,
+					cfg->pkt_sz_chk_en ? bit : 0, bit);
+}
+
+static int ksz8463_configure_snooping(const struct device *dev)
+{
+	uint8_t bits;
+	const struct ksz8463_config *cfg = dev->config;
+	const uint8_t mask = KSZ8463_SGCR2_HI_MLD_SNOOP_EN | KSZ8463_SGCR2_HI_IGMP_SNOOP_EN;
+
+	bits = 0;
+	if (cfg->mld_snoop_en) {
+		bits |= KSZ8463_SGCR2_HI_MLD_SNOOP_EN;
+	}
+	if (cfg->igmp_snoop_en) {
+		bits |= KSZ8463_SGCR2_HI_IGMP_SNOOP_EN;
+	}
+
+	return ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_SGCR2_HI, bits, mask);
+}
+
+static int ksz8463_switch_setup(const struct dsa_switch_context *dsa_switch_ctx)
+{
+	int ret;
+	struct ksz8463_data *data;
+	const struct device *dev = ksz8463_switch_ctx_to_switch_dev(dsa_switch_ctx);
+
+	data = dev->data;
+
+	k_work_init_delayable(&data->chip_isr_dwork, ksz8463_chip_isr_dwork);
+	if (ksz8463_have_irq_gpio(dev)) {
+		ret = ksz8463_configure_irq(dev);
+	} else {
+		ret = ksz8463_configure_link_state_poll(dev);
+	}
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_configure_leds(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_configure_legal_packet_size_check(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return ksz8463_configure_snooping(dev);
+}
+
+static enum ethernet_hw_caps ksz8463_get_capabilities(const struct device *portdev)
+{
+	ARG_UNUSED(portdev);
+
+	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
+}
+
+struct dsa_api ksz8463_dsa_api = {
+	.port_init = ksz8463_port_init,
+	.switch_setup = ksz8463_switch_setup,
+	.get_capabilities = ksz8463_get_capabilities,
+};
+
+static int ksz8463_hard_reset(const struct device *dev)
+{
+	int ret;
+	const struct ksz8463_config *cfg = dev->config;
+
+	if (unlikely(!cfg->rst_gpio || !gpio_is_ready_dt(cfg->rst_gpio))) {
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(cfg->rst_gpio, GPIO_OUTPUT_ACTIVE);
+	if (ret != 0) {
+		return ret;
+	}
+
+	k_sleep(K_MSEC(10));
+	ret = gpio_pin_set_dt(cfg->rst_gpio, 0);
+	if (ret != 0) {
+		return ret;
+	}
+
+	k_sleep(K_MSEC(10));
+	LOG_DBG("Hard reset complete");
+	return 0;
+}
+
+static int ksz8463_read_chip_id(const struct device *dev)
+{
+	int ret;
+	uint16_t cider;
+	k_timepoint_t expiry;
+	unsigned int interval;
+	struct ksz8463_data *data = dev->data;
+	const struct ksz8463_config *cfg = dev->config;
+
+	if (!spi_is_ready_dt(&cfg->spi)) {
+		return -ENODEV;
+	}
+
+	expiry = sys_timepoint_calc(KSZ8463_SPI_OPERATIONAL_TIMEOUT);
+	interval = MIN(5, KSZ8463_SPI_OPERATIONAL_TIMEOUT_MS >> 1u);
+
+	do {
+		ret = ksz8463_spi_read16(&cfg->spi, KSZ8463_REG_CIDER, &cider);
+		if (ret != 0) {
+			return ret;
+		}
+
+		if (cider >> 8 == KSZ8463_FAMILY_ID) {
+			break;
+		}
+
+		if (sys_timepoint_expired(expiry)) {
+			LOG_ERR("Timed out waiting for SPI");
+			return -ETIMEDOUT;
+		}
+
+		k_sleep(K_MSEC(interval));
+	} while (1);
+
+	LOG_DBG("SPI response received");
+
+	/* Chip ID in bits 7-4 */
+	data->chip_id = (uint8_t)cider >> 4;
+	LOG_DBG("Chip ID: 0x%x", (unsigned int)data->chip_id);
+	return 0;
+}
+
+static int ksz8463_soft_reset(const struct device *dev)
+{
+	int ret;
+	const struct ksz8463_config *cfg = dev->config;
+
+	ret = ksz8463_spi_lock(&cfg->spi);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = ksz8463_spi_write8_raw(&cfg->spi, KSZ8463_REG_GRR_LO, KSZ8463_GRR_GBL_SOFT_RST);
+	if (ret == 0) {
+		k_sleep(K_MSEC(10));
+		ret = ksz8463_spi_write8_raw(&cfg->spi, KSZ8463_REG_GRR_LO, 0);
+	}
+
+	ksz8463_spi_unlock(&cfg->spi);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_DBG("Soft reset complete");
+	return 0;
+}
+
+static int ksz8463_init(const struct device *dev)
+{
+	int ret;
+	struct ksz8463_data *data = dev->data;
+
+	ret = k_mutex_init(&data->spi_mutex);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (ksz8463_have_hard_reset(dev)) {
+		ret = ksz8463_hard_reset(dev);
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	ret = ksz8463_read_chip_id(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (!ksz8463_have_hard_reset(dev)) {
+		ret = ksz8463_soft_reset(dev);
+	}
+
+	return ret;
+}
+
+#define KSZ8463_PHY_INIT(phy_id, port_id)                                                          \
+	static struct ksz8463_phy_data ksz8463_phy_data_##port_id = {                              \
+		.autoneg_en = true,                                                                \
+		.use_fixed_link = DT_PROP(phy_id, microchip_fixed_link),                           \
+		.fixed_link_speed = DT_ENUM_IDX(phy_id, microchip_fixed_link_speed),               \
+		.phydev = DEVICE_DT_GET(phy_id),                                                   \
+	};                                                                                         \
+                                                                                                   \
+	static const struct ksz8463_phy_config ksz8463_phy_config_##port_id = {                    \
+		.portdev = DEVICE_DT_GET(port_id),                                                 \
+	};                                                                                         \
+                                                                                                   \
+	/* PHY device */                                                                           \
+	DEVICE_DT_DEFINE(phy_id, NULL, NULL, &ksz8463_phy_data_##port_id,                          \
+			 &ksz8463_phy_config_##port_id, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY,     \
+			 &ksz8463_phy_driver_api)
+
+#define KSZ8463_PORT_INIT_PHY(port_id)                                                             \
+	COND_CODE_0(DT_NODE_HAS_PROP(port_id, ethernet),                                           \
+		(KSZ8463_PHY_INIT(DT_CHILD(port_id, phy), port_id)),                               \
+		(EMPTY)                                                                            \
+	)
+
+#define KSZ8463_PORT_VERIFY_CHILD_NODE_COUNT(port_id)                                              \
+	COND_CODE_1(DT_NODE_HAS_PROP(port_id, ethernet),                                           \
+		(BUILD_ASSERT(!DT_CHILD_NUM_STATUS_OKAY(port_id),                                  \
+				"CPU port should have no children")),                              \
+		(BUILD_ASSERT(DT_CHILD_NUM_STATUS_OKAY(port_id) == 1,                              \
+				"Non-CPU ports should have 1 child"))                              \
+	)
+
+#define KSZ8463_PORT_GET_PHY_OR_NULL(port_id)                                                      \
+	COND_CODE_0(DT_NODE_HAS_PROP(port_id, ethernet),                                           \
+		(DEVICE_DT_GET(DT_CHILD(port_id, phy))),                                           \
+		(NULL)                                                                             \
+	)
+
+#define KSZ8463_PORT_INIT(port_id, inst)                                                           \
+	KSZ8463_PORT_VERIFY_CHILD_NODE_COUNT(port_id);                                             \
+                                                                                                   \
+	KSZ8463_PORT_INIT_PHY(port_id);                                                            \
+                                                                                                   \
+	static struct ksz8463_port_config ksz8463_##inst##port_id = {                              \
+		.disable_eee = DT_PROP(port_id, microchip_disable_eee),                            \
+		.eee_enabled = true,                                                               \
+		.dev = DEVICE_DT_INST_GET(inst),                                                   \
+	};                                                                                         \
+                                                                                                   \
+	static const struct dsa_port_config ksz8463_port_config##inst##port_id = {                 \
+		.mcfg = NET_ETH_MAC_DT_CONFIG_INIT(port_id),                                       \
+		.port_idx = DT_REG_ADDR(port_id),                                                  \
+		.phy_dev = KSZ8463_PORT_GET_PHY_OR_NULL(port_id),                                  \
+		.phy_mode = DT_PROP_OR(port_id, phy_connection_type, "internal"),                  \
+		.ethernet_connection = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(port_id, ethernet)),       \
+		.prv_config = &ksz8463_##inst##port_id,                                            \
+	};                                                                                         \
+                                                                                                   \
+	/* Port device */                                                                          \
+	DSA_PORT_INST_INIT(port_id, inst, &ksz8463_port_config##inst##port_id);
+
+/* clang-format and checkpatch disagree on spacing */
+/* clang-format off */
+#define KSZ8463_INST_PTDEV_ARRAY(inst)								   \
+	(const struct device * [DT_INST_CHILD_NUM(inst)]) { 0 }
+
+/* clang-format on */
+
+#define KSZ8463_GPIO_DT_SPEC_OR_NULL(inst, prop)                                                   \
+	COND_CODE_1(DT_INST_PROP_HAS_IDX(inst, prop, 0),					   \
+		(&(struct gpio_dt_spec) GPIO_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), prop, 0)),	   \
+		(NULL))
+
+#define KSZ8463_PORT_GET(port_id) [DT_REG_ADDR(port_id)] = DEVICE_DT_GET(port_id),
+
+/* clang-format off */
+#define KSZ8463_INST_PORT_ARRAY_INITIALIZER(inst)                                                  \
+	(const struct device * [DT_INST_CHILD_NUM(inst)]) {                                        \
+			DT_INST_FOREACH_CHILD_STATUS_OKAY(inst, KSZ8463_PORT_GET)                  \
+	}
+
+/* clang-format on */
+
+#define KSZ8463_INIT(inst)                                                                         \
+	BUILD_ASSERT(DT_INST_CHILD_NUM(inst) == KSZ8463_NUM_PORTS, "Switch has 3 ports");          \
+                                                                                                   \
+	/* Only the CPU port should set the ethernet phandle */                                    \
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(DT_INST_CHILD_BY_UNIT_ADDR_INT(inst, 0), ethernet),         \
+		     "Port 1 must not have an ethernet phandle");                                  \
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(DT_INST_CHILD_BY_UNIT_ADDR_INT(inst, 1), ethernet),         \
+		     "Port 2 must not have an ethernet phandle");                                  \
+	BUILD_ASSERT(DT_NODE_HAS_PROP(DT_INST_CHILD_BY_UNIT_ADDR_INT(inst, 2), ethernet),          \
+		     "Port 3 requires an ethernet phandle");                                       \
+                                                                                                   \
+	/* CPU port should set phy-connection-type */                                              \
+	BUILD_ASSERT(                                                                              \
+		DT_NODE_HAS_PROP(DT_INST_CHILD_BY_UNIT_ADDR_INT(inst, 2), phy_connection_type),    \
+		"Port 3 requires a PHY connection type");                                          \
+                                                                                                   \
+	BUILD_ASSERT(DT_INST_ENUM_IDX(inst, microchip_port_led_mode) <= BIT_MASK(2),               \
+		     "Invalid LED mode");                                                          \
+                                                                                                   \
+	static struct ksz8463_data ksz8463_data_##inst = {                                         \
+		.portdevs = KSZ8463_INST_PORT_ARRAY_INITIALIZER(inst),                             \
+	};                                                                                         \
+                                                                                                   \
+	static const struct ksz8463_config ksz8463_config_##inst = {                               \
+		.mld_snoop_en = DT_INST_PROP(inst, microchip_mld_snoop_en),                        \
+		.igmp_snoop_en = DT_INST_PROP(inst, microchip_igmp_snoop_en),                      \
+		.pkt_sz_chk_en = DT_INST_PROP(inst, microchip_legal_packet_size_check_en),         \
+		.num_portdevs = DT_INST_CHILD_NUM(inst),                                           \
+		.led_mode = DT_INST_ENUM_IDX(inst, microchip_port_led_mode),                       \
+		.rst_gpio = KSZ8463_GPIO_DT_SPEC_OR_NULL(inst, reset_gpios),                       \
+		.irq_gpio = KSZ8463_GPIO_DT_SPEC_OR_NULL(inst, int_gpios),                         \
+		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8)),                                \
+		.dev = DEVICE_DT_INST_GET(inst),                                                   \
+	};                                                                                         \
+                                                                                                   \
+	/* Switch device */                                                                        \
+	DEVICE_DT_INST_DEFINE(inst, ksz8463_init, NULL, &ksz8463_data_##inst,                      \
+			      &ksz8463_config_##inst, POST_KERNEL, CONFIG_ETH_INIT_PRIORITY,       \
+			      NULL);                                                               \
+                                                                                                   \
+	struct ksz8463_prv_data ksz8463_prv_data_##inst = {                                        \
+		.dev = DEVICE_DT_INST_GET(inst),                                                   \
+	};                                                                                         \
+                                                                                                   \
+	BUILD_ASSERT(DT_INST_CHILD_NUM_STATUS_OKAY(inst), "No ports enabled");                     \
+                                                                                                   \
+	DSA_SWITCH_INST_INIT(inst, &ksz8463_dsa_api, &ksz8463_prv_data_##inst, KSZ8463_PORT_INIT)
+
+DT_INST_FOREACH_STATUS_OKAY(KSZ8463_INIT)

--- a/drivers/ethernet/dsa/dsa_ksz8463.c
+++ b/drivers/ethernet/dsa/dsa_ksz8463.c
@@ -13,6 +13,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -1630,10 +1631,37 @@ static enum ethernet_hw_caps ksz8463_get_capabilities(const struct device *portd
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
 
+static inline int ksz8463_enable_tail_tagging(const struct device *dev)
+{
+	const struct ksz8463_config *cfg = dev->config;
+
+	return ksz8463_spi_update_bits8(&cfg->spi, KSZ8463_REG_SGCR8_HI,
+					KSZ8463_SGCR8_HI_TAIL_TAG_EN, KSZ8463_SGCR8_HI_TAIL_TAG_EN);
+}
+
+static int ksz8463_connect_tag_protocol(struct dsa_switch_context *dsa_switch_ctx, int tag_proto)
+{
+	const struct device *dev = ksz8463_switch_ctx_to_switch_dev(dsa_switch_ctx);
+
+	switch (tag_proto) {
+	case DSA_TAG_PROTO_NOTAG:
+		/* Tail-tagging disabled by default, nothing to do */
+		return 0;
+	case DSA_TAG_PROTO_KSZ8463:
+		break;
+	default:
+		LOG_ERR("Unsupported tag protocol 0x%x", (unsigned int)tag_proto);
+		return -ENOTSUP;
+	}
+
+	return ksz8463_enable_tail_tagging(dev);
+}
+
 struct dsa_api ksz8463_dsa_api = {
 	.port_init = ksz8463_port_init,
 	.switch_setup = ksz8463_switch_setup,
 	.get_capabilities = ksz8463_get_capabilities,
+	.connect_tag_protocol = ksz8463_connect_tag_protocol,
 };
 
 static int ksz8463_hard_reset(const struct device *dev)
@@ -1790,6 +1818,17 @@ static int ksz8463_init(const struct device *dev)
 				"Non-CPU ports should have 1 child"))                              \
 	)
 
+#define KSZ8463_PORT_VERIFY_TAG_PROTO(port_id)                                                     \
+	COND_CODE_1(DT_NODE_HAS_PROP(port_id, ethernet),                                           \
+		(BUILD_ASSERT(                                                                     \
+			DT_PROP_OR(port_id, dsa_tag_protocol, DSA_TAG_PROTO_NOTAG) ==              \
+				DSA_TAG_PROTO_NOTAG ||                                             \
+			DT_PROP_OR(port_id, dsa_tag_protocol, DSA_TAG_PROTO_NOTAG) ==              \
+				DSA_TAG_PROTO_KSZ8463, "Unsupported tag protocol")),               \
+		(BUILD_ASSERT(!DT_NODE_HAS_PROP(port_id, dsa_tag_protocol),                        \
+			"dsa-tag-protocol is meaningless for non-CPU ports"))                      \
+	)
+
 #define KSZ8463_PORT_GET_PHY_OR_NULL(port_id)                                                      \
 	COND_CODE_0(DT_NODE_HAS_PROP(port_id, ethernet),                                           \
 		(DEVICE_DT_GET(DT_CHILD(port_id, phy))),                                           \
@@ -1807,11 +1846,14 @@ static int ksz8463_init(const struct device *dev)
 		.dev = DEVICE_DT_INST_GET(inst),                                                   \
 	};                                                                                         \
                                                                                                    \
+	KSZ8463_PORT_VERIFY_TAG_PROTO(port_id);                                                    \
+                                                                                                   \
 	static const struct dsa_port_config ksz8463_port_config##inst##port_id = {                 \
 		.mcfg = NET_ETH_MAC_DT_CONFIG_INIT(port_id),                                       \
 		.port_idx = DT_REG_ADDR(port_id),                                                  \
 		.phy_dev = KSZ8463_PORT_GET_PHY_OR_NULL(port_id),                                  \
 		.phy_mode = DT_PROP_OR(port_id, phy_connection_type, "internal"),                  \
+		.tag_proto = DT_PROP_OR(port_id, dsa_tag_protocol, DSA_TAG_PROTO_NOTAG),           \
 		.ethernet_connection = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(port_id, ethernet)),       \
 		.prv_config = &ksz8463_##inst##port_id,                                            \
 	};                                                                                         \

--- a/drivers/ethernet/dsa/dsa_ksz8463.h
+++ b/drivers/ethernet/dsa/dsa_ksz8463.h
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2026 Vilhelm Engström
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_ETHERNET_DSA_KSZ8463_H_
+#define ZEPHYR_DRIVERS_ETHERNET_DSA_KSZ8463_H_
+
+#include <stdint.h>
+
+#include <zephyr/sys/util.h>
+
+/* KSZ8463 family identifier */
+#define KSZ8463_FAMILY_ID    0x84
+/* Chip ID for KSZ8463ML and KSZ8463FML */
+#define KSZ8463_MII_CHIP_ID  0x04
+/* Chip ID for KSz8463RL and KSZ8463FRL */
+#define KSZ8463_RMII_CHIP_ID 0x05
+
+/* Number of ports */
+#define KSZ8463_NUM_PORTS 3
+
+/* Number of user ports */
+#define KSZ8463_NUM_USER_PORTS (KSZ8463_NUM_PORTS - 1)
+
+#define KSZ8463_SPEED_FULL_DUPLEX_BIT BIT(0)
+#define KSZ8463_SPEED_100BASE_BIT     BIT(1)
+
+/* Speeds supported by the KSZ8463, T4 omitted.
+ *
+ * Order should match the enum list for the
+ * microchip,fixed-link-speed property
+ */
+enum ksz8463_speed {
+
+	/* 10Mbps, half-duplex */
+	KSZ8463_SPEED_10BASE_HALF_DUPLEX,
+
+	/* 10Mbps, full-duplex */
+	KSZ8463_SPEED_10BASE_FULL_DUPLEX = KSZ8463_SPEED_FULL_DUPLEX_BIT,
+
+	/* 100Mbps, half-duplex */
+	KSZ8463_SPEED_100BASE_HALF_DUPLEX = KSZ8463_SPEED_100BASE_BIT,
+
+	/* 100Mbpx, full-duplex */
+	KSZ8463_SPEED_100BASE_FULL_DUPLEX =
+		KSZ8463_SPEED_FULL_DUPLEX_BIT | KSZ8463_SPEED_100BASE_BIT,
+
+	KSZ8463_SPEED_AFTER_LAST_,
+	KSZ8463_SPEED_MAX = KSZ8463_SPEED_AFTER_LAST_ - 1
+};
+
+/*
+ * Most significant bit in the first byte of an SPI transaction is
+ * read/write desginator
+ */
+
+/* Bit not set when reading */
+#define KSZ8463_SPI_CMD_RD 0
+
+/* Bit set when writing */
+#define KSZ8463_SPI_CMD_WR BIT(7)
+
+/*
+ * SPI phases are described in Table 3-14 in data sheet
+ */
+/* Size of command phase, in bytes */
+#define KSZ8463_SPI_CMD_PH_SIZE          2
+/* Offset of the data phase, in bytes */
+#define KSZ8463_SPI_CMD_DATA_PH_OFF      KSZ8463_SPI_CMD_PH_SIZE
+/* Maximum size of the data phase */
+#define KSZ8463_SPI_CMD_MAX_DATA_PH_SIZE 4
+/* Max size of a complete SPI command */
+#define KSZ8463_SPI_CMD_MAX_SIZE (KSZ8463_SPI_CMD_PH_SIZE + KSZ8463_SPI_CMD_MAX_DATA_PH_SIZE)
+
+/* PHY x and MII basic control register. 16-bit accesses */
+#define KSZ8463_REG_PxMBCR(x) (0x4c + ((x) * 0x0c))
+
+/* PHY x and MII basic control register, low byte. 8-bit access */
+#define KSZ8463_REG_PxMBCR_LO(x) KSZ8463_REG_PxMBCR(x)
+
+/* PHY x and MII basic control register, high byte. 8-bit access */
+#define KSZ8463_REG_PxMBCR_HI(x) (KSZ8463_REG_PxMBCR_LO(x) + 1)
+
+/* PHY x and MII basic status register. 16-bit access */
+#define KSZ8463_REG_PxMBSR(x) (0x4e + ((x) * 0x0c))
+
+/* PHY x and MII basic status register, low byte. 8-bit access */
+#define KSZ8463_REG_PxMBSR_LO(x) KSZ8463_REG_PxMBSR(x)
+
+/* PHY x and MII basic status register, high byte. 8-bit access */
+#define KSZ8463_REG_PxMBSR_HI(x) (KSZ8463_REG_PxMBSR_LO(x) + 1)
+
+/* PHY x auto-negotiation advertisement register, 16-bit access */
+#define KSZ8463_REG_PxANAR(x) (0x54 + ((x) * 0x0c))
+
+/* PHY x auto-negotiation advertisement register, low byte. 8-bit access */
+#define KSZ8463_REG_PxANAR_LO(x) KSZ8463_REG_PxANAR(x)
+
+/* PHY x auto-negotiation advertisement register,highlow byte. 8-bit access */
+#define KSZ8463_REG_PxANAR_HI(x) (KSZ8463_REG_PxANAR_LO(x) + 1)
+
+/* Port x control register 2. 16-bit access */
+#define KSZ8463_REG_PxCR2(x) (0x6e + ((x) * 0x18))
+
+/* Port x control register 2, low byte. 8-bit access */
+#define KSZ8463_REG_PxCR2_LO(x) KSZ8463_REG_PxCR2(x)
+
+/* Port x control register 2, high byte. 8-bit access */
+#define KSZ8463_REG_PxCR2_HI(x) (KSZ8463_REG_PxCR2_LO(x) + 1)
+
+/* Port x control register 4. 16-bit access */
+#define KSZ8463_REG_PxCR4(x) (0x7e + ((x) * 0x18))
+
+/* Port x control register 4, low byte. 8-bit access */
+#define KSZ8463_REG_PxCR4_LO(x) KSZ8463_REG_PxCR4(x)
+
+/* Port x control register 4, high byte. 8-bit access */
+#define KSZ8463_REG_PxCR4_HI(x) (KSZ8463_REG_PxCR4_LO(x) + 1)
+
+/* Port x status register. 16-bit access */
+#define KSZ8463_REG_PxSR(x) (0x80 + ((x) * 0x18))
+
+/* Port x status register, low byte. 8-bit access */
+#define KSZ8463_REG_PxSR_LO(x) KSZ8463_REG_PxSR(x)
+
+/* Port x status register, high byte. 8-bit access */
+#define KSZ8463_REG_PxSR_HI(x) (KSZ8463_REG_PxSR_LO(x) + 1)
+
+/* Port x EEE control/status and auto-negotiation expansion register. 16-bit
+ * access
+ */
+#define KSZ8463_REG_PxEEECS(x) (0xe4 + ((x) * 0x0c))
+
+/* Port x EEE contrl/status and auto-negotiation expansion register, low byte.
+ * 8-bit access
+ */
+#define KSZ8463_REG_PxEEECS_LO(x) KSZ8463_REG_PxEEECS(x)
+
+/* Port x EEE contrl/status and auto-negotiation expansion register, high byte.
+ * 8-bit access
+ */
+#define KSZ8463_REG_PxEEECS_HI(x) (KSZ8463_REG_PxEEECS_LO(x) + 1)
+
+/*
+ * Fixed-address registers used by the driver
+ */
+/* Chip ID and enable register. 16-bit access */
+#define KSZ8463_REG_CIDER 0x000
+
+/* Switch global control register 2. 16-bit access */
+#define KSZ8463_REG_SGCR2    0x004
+/* Switch global control register 2, low byte. 8-bit access */
+#define KSZ8463_REG_SGCR2_LO KSZ8463_REG_SGCR2
+/* Switch global control register 2, high byte. 8-bit access */
+#define KSZ8463_REG_SGCR2_HI (KSZ8463_REG_SGCR2_LO + 1)
+
+/* Switch global control register 7. 16-bit access */
+#define KSZ8463_REG_SGCR7    0x00e
+/* Switch global control register 7, low byte. 8-bit access */
+#define KSZ8463_REG_SGCR7_LO KSZ8463_REG_SGCR7
+/* Switch global control register 7, high byte. 8-bit access */
+#define KSZ8463_REG_SGCR7_HI (KSZ8463_REG_SGCR7_LO + 1)
+
+/* Switch global control register 8. 16-bit access */
+#define KSZ8463_REG_SGCR8    0x0ac
+/* Switch global control register 8, low byte. 8-bit access */
+#define KSZ8463_REG_SGCR8_LO KSZ8463_REG_SGCR8
+/* Switch global control register 8, high byte. 8-bit access */
+#define KSZ8463_REG_SGCR8_HI (KSZ8463_REG_SGCR8_LO + 1)
+
+/* PCS EEE control register. 8-bit access*/
+#define KSZ8463_REG_PCSEEEC 0x0f3
+
+/* Global reset register. 16-bit access */
+#define KSZ8463_REG_GRR    0x126
+/* Global reset register, low byte. 8-bit access */
+#define KSZ8463_REG_GRR_LO KSZ8463_REG_GRR
+
+/* Interrupt enable register. 16-bit access */
+#define KSZ8463_REG_IER    0x190
+/* Interrupt enable register, low byte. 8-bit access*/
+#define KSZ8463_REG_IER_LO KSZ8463_REG_IER
+/* Interrupt enable register, high byte. 8-bit access */
+#define KSZ8463_REG_IER_HI (KSZ8463_REG_IER_LO + 1)
+
+/* Interrupt status register. 16-bit access */
+#define KSZ8463_REG_ISR    0x192
+/* Interrupt status register, low byte. 8-bit access */
+#define KSZ8463_REG_ISR_LO KSZ8463_REG_ISR
+/* Interrupt status register, high byte. 8-bit access */
+#define KSZ8463_REG_ISR_HI (KSZ8463_REG_ISR_LO + 1)
+
+/*
+ * Global reset register
+ */
+/* Set to enable global software reset */
+#define KSZ8463_GRR_GBL_SOFT_RST BIT(0)
+
+/*
+ * Interrupt enable register
+ */
+
+/* Link change iterrupt enable */
+#define KSZ8463_IER_LCIE BIT(15)
+
+/* Link change interrupt enable, index in high IER byte */
+#define KSZ8463_IER_HI_LCIE (KSZ8463_IER_LCIE >> 8)
+
+/*
+ * Interrupt status register
+ */
+
+/* Set if link status has changed. Write 1 to clear */
+#define KSZ8463_ISR_LCIS BIT(15)
+
+/* Link change interrupt status, index in high byte. Write 1 to clear */
+#define KSZ8463_ISR_HI_LCIS (KSZ8463_ISR_LCIS >> 8)
+
+/*
+ * PCS EEE control register
+ */
+
+/* Port 2 next page enable */
+#define KSZ8463_PCSEEEC_P2_NEXT_PG_EN BIT(1)
+
+/* Port 1 next page enable */
+#define KSZ8463_PCSEEEC_P1_NEXT_PG_EN BIT(0)
+
+/*
+ * Port x control register 2
+ */
+
+/* Set to enable packet transmission */
+#define KSZ8463_PxCR2_TX_EN BIT(10)
+
+/* Set to enable packet reception */
+#define KSZ8463_PxCR2_RX_EN BIT(9)
+
+/* Set to disable switch address learning */
+#define KSZ8463_PxCR2_LEARN_DIS BIT(8)
+
+/* Set to enable packet transmission, index in high byte */
+#define KSZ8463_PxCR2_HI_TX_EN (KSZ8463_PxCR2_TX_EN >> 8)
+
+/* Set to enable packet reception, index in high byte */
+#define KSZ8463_PxCR2_HI_RX_EN (KSZ8463_PxCR2_RX_EN >> 8)
+
+/* Set to disable address learning, index in high byte */
+#define KSZ8463_PxCR2_HI_LEARN_DIS (KSZ8463_PxCR2_LEARN_DIS >> 8)
+
+/*
+ * Port x control register 4
+ */
+
+/* Set to restart auto-negotiation */
+#define KSZ8463_PxCR4_AUTONEG_RESTART BIT(13)
+
+/* Set to enable auto-negotiation */
+#define KSZ8463_PxCR4_AUTONEG_EN BIT(7)
+
+/* Set to restart auto-negotiation. Index in high byte */
+#define KSZ8463_PxCR4_HI_AUTONEG_RESTART (KSZ8463_PxCR4_AUTONEG_RESTART >> 8)
+
+/* Set to enable auto-negotiation, index in low byte */
+#define KSZ8463_PxCR4_LO_AUTONEG_EN KSZ8463_PxCR4_AUTONEG_EN
+
+/*
+ * Switch global control register 2
+ */
+
+/* Set to enable IGMP snooping */
+#define KSZ8463_SGCR2_IGMP_SNOOP_EN BIT(14)
+
+/* Set to enable MLD snooping */
+#define KSZ8463_SGCR2_MLD_SNOOP_EN BIT(13)
+
+/* Set to enable legal max packet size check */
+#define KSZ8463_SGCR2_LEGAL_PKT_SZ_CHK_EN BIT(1)
+
+/* Set to enable IGMP snooping. Index in high byte */
+#define KSZ8463_SGCR2_HI_IGMP_SNOOP_EN (KSZ8463_SGCR2_IGMP_SNOOP_EN >> 8)
+
+/* Set to enable MLD snooping. Index in high byte */
+#define KSZ8463_SGCR2_HI_MLD_SNOOP_EN (KSZ8463_SGCR2_MLD_SNOOP_EN >> 8)
+
+/* Set to enable legal max packet size check. Index in low byte */
+#define KSZ8463_SGCR2_LO_LEGAL_PKT_SZ_CHK_EN KSZ8463_SGCR2_LEGAL_PKT_SZ_CHK_EN
+
+/*
+ * Switch global control register 7
+ */
+
+/* LED1: speed, LED0: link and activity */
+#define KSZ8463_SGCR7_LED_MODE_SPD1_LNKACT0 (0 << 8)
+
+/* LED1: activity, LED0: link */
+#define KSZ8463_SGCR7_LED_MODE_ACT1_LNK0 (1 << 8)
+
+/* LED1: FUll-Duplex, LED0: link and activity */
+#define KSZ8463_SGCR7_LED_MODE_FDPLX1_LNKACT0 (2 << 8)
+
+/* LED1: FUll-Duplex, LED0: link */
+#define KSZ8463_SGCR7_LED_MODE_FDPLX1_LNK0 (3 << 8)
+
+/* LED mode bitmask */
+#define KSZ8463_SGCR7_PORT_LED_MODE_MASK (BIT_MASK(2) << 8)
+
+/* LED1: speed, LED0: link and activity. Index in high byte */
+#define KSZ8463_SGCR7_HI_LED_MODE_SPD1_LNKACT0 (KSZ8463_SGCR7_LED_MODE_SPD1_LNKACT0 >> 8)
+
+/* LED1: activity, LED0: link. Index in high byte */
+#define KSZ8463_SGCR7_HI_LED_MODE_ACT1_LNK0 (KSZ8463_SGCR7_LED_MODE_ACT1_LNK0 >> 8)
+
+/* LED1: FUll-Duplex, LED0: link and activity. Index in high byte */
+#define KSZ8463_SGCR7_HI_LED_MODE_FDPLX1_LNKACT0 (KSZ8463_SGCR7_LED_MODE_FDPLX1_LNKACT0 >> 8)
+
+/* LED1: FUll-Duplex, LED0: link. Index in high byte */
+#define KSZ8463_SGCR7_HI_LED_MODE_FDPLX1_LNK0 (KSZ8463_SGCR7_LED_MODE_FDPLX1_LNK0 >> 8)
+
+/* LED mode bitmask, bits in high byte */
+#define KSZ8463_SGCR7_HI_PORT_LED_MODE_MASK (KSZ8463_SGCR7_PORT_LED_MODE_MASK >> 8)
+
+/*
+ * Switch global control register 8
+ */
+
+/* Set to enable tail tagging on port 3 */
+#define KSZ8463_SGCR8_TAIL_TAG_EN BIT(8)
+
+/* Set to enable tail tagging on port 3, index in high byte */
+#define KSZ8463_SGCR8_HI_TAIL_TAG_EN (KSZ8463_SGCR8_TAIL_TAG_EN >> 8)
+
+/*
+ * Port x status register
+ */
+
+/* Set when link speed is 100Mbps, unset when 10Mbps */
+#define KSZ8463_PxSR_OPER_SPEED_100MBPS BIT(10)
+
+/* Set then link duplex is full, unset when it's half */
+#define KSZ8463_PxSR_OPER_FULL_DUPLEX BIT(9)
+
+/* Set when auto-negotiation has completed */
+#define KSZ8463_PxSR_AUTONEG_CPLT BIT(6)
+
+/* Set when link status is good */
+#define KSZ8463_PxSR_LINK_STATUS BIT(5)
+
+/* Set when link speed is 100Mbps, unset when 10Mbps. High byte index */
+#define KSZ8463_PxSR_HI_OPER_SPEED_100MBPS (KSZ8463_PxSR_OPER_SPEED_100MBPS >> 8)
+
+/* Set when link duplex is full, unset when half. Index in high byte */
+#define KSZ8463_PxSR_HI_OPER_FULL_DUPLEX (KSZ8463_PxSR_OPER_FULL_DUPLEX >> 8)
+
+/* Set when auto-negotiation has completed, index in low byte */
+#define KSZ8463_PxSR_LO_AUTONEG_CPLT KSZ8463_PxSR_AUTONEG_CPLT
+
+/* Set if link status is good, index in low byte */
+#define KSZ8463_PxSR_LO_LINK_STATUS KSZ8463_PxSR_LINK_STATUS
+
+/*
+ * Port x EEE contrl/status and auto-negotiation expansion register
+ */
+
+/* Set when link partner is auto-negotiation able */
+#define KSZ8463_PxEEECS_LNK_AUTONEG_CPBL BIT(0)
+
+/* Set when link partner is auto-negotiation able, index in low byte */
+#define KSZ8463_PxEEECS_LO_LNK_AUTONEG_CPBL KSZ8463_PxEEECS_LNK_AUTONEG_CPBL
+
+/*
+ * PHY x and MII basic control register
+ */
+
+/* Set to force 100Mbps when auto-negotiation is disabled */
+#define KSZ8463_PxMBCR_FORCE_100BASE_TX BIT(13)
+
+/* Set to force full-duplex when auto-negotiation is disabled */
+#define KSZ8463_PxMBCR_FORCE_FULL_DUPLEX BIT(8)
+
+/* Force 100Mbps when auto-negotiation is disabled. High byte index */
+#define KSZ8463_PxMBCR_HI_FORCE_100BASE_TX (KSZ8463_PxMBCR_FORCE_100BASE_TX >> 8)
+
+/* Force full-duplex when auto-negotiation is disabled. High byte index */
+#define KSZ8463_PxMBCR_HI_FORCE_FULL_DUPLEX (KSZ8463_PxMBCR_FORCE_FULL_DUPLEX >> 8)
+
+/*
+ * PHY x and MII basic status register
+ */
+
+/* Set when auto-negotiation has completed */
+#define KSZ8463_PxMBSR_AUTONEG_CPLT BIT(5)
+
+/* Link status, mirrored from KSZ8463_PxSR_LINK_STATUS */
+#define KSZ8463_PxMBSR_LINK_STATUS BIT(2)
+
+/* Auto-negotiation complete, index in low byte */
+#define KSZ8463_PxMBSR_LO_AUTONEG_CPLT KSZ8463_PxMBSR_AUTONEG_CPLT
+
+/* Link status, index in low byte */
+#define KSZ8463_PxMBSR_LO_LINK_STATUS KSZ8463_PxMBSR_LINK_STATUS
+
+/*
+ * PHY x auto-negotiation advertisement register
+ */
+
+/* Advertise 100BASE-TX full-duplex */
+#define KSZ8463_PxANAR_ADV_100BASE_TX_FULL_DUPLEX BIT(8)
+
+/* Advertise 100BASE-TX half-duplex */
+#define KSZ8463_PxANAR_ADV_100BASE_TX_HALF_DUPLEX BIT(7)
+
+/* Advertise 10BASE-T full-duplex */
+#define KSZ8463_PxANAR_ADV_10BASE_T_FULL_DUPLEX BIT(6)
+
+/* Advertise 10BASE-T half-duplex */
+#define KSZ8463_PxANAR_ADV_10BASE_T_HALF_DUPLEX BIT(5)
+
+#endif /* ZEPHYR_DRIVERS_ETHERNET_DSA_KSZ8463_H_ */

--- a/drivers/ethernet/dsa/dsa_tag_ksz8463.c
+++ b/drivers/ethernet/dsa/dsa_tag_ksz8463.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Vilhelm Engström
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/dsa_core.h>
+#include <zephyr/net/dsa_tag.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/net_log.h>
+#include <zephyr/toolchain.h>
+
+#include "dsa_ksz8463.h"
+
+LOG_MODULE_REGISTER(dsa_tag_ksz8463, CONFIG_ETHERNET_LOG_LEVEL);
+
+/*
+ * The KSZ8463 supports inserting a single-byte tag following the
+ * payload in each Ethernet frame. Thus, a tagged VLAN frame would
+ * look something akin to
+ *                                             Inserted
+ *                                                 v
+ * +------+------+------+-----+-------+---------+-----+-----+
+ * | DMAC | SMAC | VPID | TCI | PTYPE | Payload | Tag | FCS |
+ * +------+------+------+-----+-------+---------+-----+-----+
+ *
+ * The figure is obviously not to scale.
+ *
+ * The tag byte is used slightly differently for ingress and egress packets.
+ * In ingress packets - i.e. packets sent from the DSA conduit port on the host
+ * to the CPU port on the switch - the two least significant bits of the
+ * tag encode the destination port. The values are interpreted as follows
+ *
+ *   00b - Destination looked up via DMAC
+ *   01b - Packet to be sent on user port 1.
+ *   10b - Packet to be sent on user port 2.
+ *   11b - Packet to be sent on both user port 1 and user port 2.
+ *
+ * Additionally, the ingress tag includes 802.1p priorities 0-3 encoded in
+ * zero-indexed bits 3:2. These are all left set to 0, indicating priority 0.
+ *
+ * Egress packets - that is, packets from the KSZ8463 to the host - are simpler.
+ * These encode the zero-based port index in bit 0. If said bit is cleared, the
+ * packet was received on user port 1. If the bit is set, the packet was
+ * received on user port 2.
+ *
+ * Refer to Section 3.3.4 of the data sheet for more information.
+ */
+
+static struct net_if *dsa_tag_ksz8463_recv(struct net_if *iface, struct net_pkt *pkt)
+{
+	size_t len;
+	uint8_t tag;
+	enum ethernet_hw_caps caps;
+	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
+	struct dsa_switch_context *dsa_switch_ctx = eth_ctx->dsa_switch_ctx;
+
+	caps = net_eth_get_hw_capabilities(iface);
+	if (!(caps & ETHERNET_DSA_CONDUIT_PORT)) {
+		NET_WARN("Packet received on non-conduit port");
+		return iface;
+	}
+
+	/* Extract the tag following the payload. Note that the FCS is
+	 * not part of the frame here, meaning the tag is the very last
+	 * byte in the net_pkt
+	 */
+	net_pkt_set_overwrite(pkt, true);
+	net_pkt_cursor_init(pkt);
+	len = net_pkt_get_len(pkt);
+	net_pkt_skip(pkt, len - sizeof(tag));
+	net_pkt_read_u8(pkt, &tag);
+	net_pkt_update_length(pkt, len - sizeof(tag));
+
+	/* Port index encoded in least significant bit */
+	tag &= BIT_MASK(1);
+
+	if (unlikely(tag >= dsa_switch_ctx->num_ports)) {
+		NET_ERR("Ingress packet tagged for port %d/%d dropped", (int)tag,
+			dsa_switch_ctx->num_ports);
+		return iface;
+	}
+
+	NET_DBG("Redirecting packet to port %d", (int)tag);
+	return dsa_switch_ctx->iface_user[tag];
+}
+
+static struct net_pkt *dsa_tag_ksz8463_xmit(struct net_if *iface, struct net_pkt *pkt)
+{
+	uint8_t *tag;
+	struct net_buf *frag;
+	struct net_buf_pool *pool;
+	const struct dsa_port_config *dsa_cfg;
+	const struct device *ptdev = net_if_get_device(iface);
+
+	dsa_cfg = ptdev->config;
+
+	if (unlikely(dsa_cfg->port_idx >= KSZ8463_NUM_USER_PORTS)) {
+		NET_ERR("Invalid user port index %d", dsa_cfg->port_idx);
+		/* DSA core does not allow NULL to be returned here. Return
+		 * the unaltered packet and allow the switch to discard it
+		 */
+		return pkt;
+	}
+
+	frag = net_buf_frag_last(pkt->frags);
+	if (!net_buf_tailroom(frag)) {
+		pool = net_buf_pool_get(pkt->buffer->pool_id);
+		frag = net_buf_alloc_len(pool, sizeof(*tag), K_NO_WAIT);
+		if (!frag) {
+			NET_WARN("Could not allocate room for tag byte");
+			return pkt;
+		}
+	}
+
+	tag = net_buf_tail(frag);
+	*tag = dsa_cfg->port_idx + 1;
+
+	net_buf_add(frag, sizeof(*tag));
+	net_buf_frag_add(pkt->buffer, frag);
+
+	NET_DBG("Packet tagged for port %d", dsa_cfg->port_idx);
+	return pkt;
+}
+
+DSA_TAG_REGISTER(DSA_TAG_PROTO_KSZ8463, dsa_tag_ksz8463_recv, dsa_tag_ksz8463_xmit);

--- a/dts/bindings/dsa/microchip,ksz8463.yaml
+++ b/dts/bindings/dsa/microchip,ksz8463.yaml
@@ -1,0 +1,202 @@
+# Copyright (c) 2026 Vilhelm Engström
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip KSZ8463 3-Port Ethernet Switch
+
+compatible: "microchip,ksz8463"
+
+include:
+  - name: base.yaml
+    property-allowlist:
+      - reg
+  - name: dsa.yaml
+  - name: spi-device.yaml
+
+properties:
+  reset-gpios:
+    type: phandle-array
+    description: |
+      Optional reset GPIO. If provided, the pin is asserted 10ms during initialization. When
+      omitted, the chip subjected to a software reset instead.
+
+      If provided, the phandle array should specify exactly one GPIO.
+
+  int-gpios:
+    type: phandle-array
+    description: |
+      Optional GPIO to monitor for chip interrupts.
+
+      If provided, the phandle array should contain exactly one GPIO.
+
+  microchip,legal-packet-size-check-en:
+    type: boolean
+    description: |
+      Enable legal maximum packet size check.
+
+  microchip,igmp-snoop-en:
+    type: boolean
+    description: |
+      Enable IGMP snooping.
+
+  microchip,mld-snoop-en:
+    type: boolean
+    description: |
+      Enable MLD snooping.
+
+  microchip,port-led-mode:
+    type: string
+    default: "LED1: Activity, LED0: Link"
+    description: |
+      Configure behavior of the two LEDs
+    enum:
+      - "LED1: Speed, LED0: Link And Activity"
+      - "LED1: Activity, LED0: Link"
+      - "LED1: Full-Duplex, LED0: Link And Activity"
+      - "LED1: FUll-Duplex, LED0: Link"
+
+child-binding:
+
+  properties:
+    reg:
+      description: |
+        Single-cell reg specifying the zero-indexed port number. Physical port 1 should have value
+        0, physical port 2 value 1 and so on.
+
+    ethernet:
+      description: |
+        A phandle referring to the Ethernet node to which the CPU port, i.e. physical port 3, is
+        connected. Should be set for only the node with reg value 2.
+
+    microchip,disable-eee:
+      type: boolean
+      description: |
+        Permanently disable Energy-Efficient Ethernet.
+
+        Note that even should this property not be set, the driver disables EEE while disabling
+        auto-negotiation as a workaround for errata 4 in KSZ8463MLI_FMLI_Prod_0.3_errata.
+
+  child-binding:
+
+    description: |
+      User port integrated PHY. Note that the node must be named "phy" to allow the driver to find
+      it.
+
+    compatible: "microchip,ksz8463-phy"
+
+    properties:
+      microchip,fixed-link:
+        type: boolean
+        description: |
+          Disable auto-negotiation. The speed used is determined by the microchip,fixed-link-speed
+          property.
+
+          This property may be altered at runtime by calling phy_configure_link.
+
+      microchip,fixed-link-speed:
+        type: string
+        default: "10BASE Half-Duplex"
+        description: |
+          Speed to fall back on if link partner does not support auto-negotiation or when the latter
+          is disabled.
+        enum:
+          - "10BASE Half-Duplex"
+          - "10BASE Full-Duplex"
+          - "100BASE Half-Duplex"
+          - "100BASE Full-Duplex"
+
+examples:
+  - |
+    &mac {
+      /* For MII-based products */
+      phy-connection-type = "mii";
+
+      status = "okay";
+    };
+
+    &spi1 {
+      /* ... */
+
+      sw1: ethernet-switch@0 {
+        compatible = "microchip,ksz8463";
+
+        reg = <0>;
+
+        spi-max-frequency = <DT_FREQ_M(50)>;
+
+        #address-cells = <1>;
+        #address-cells = <0>;
+
+        /* Enable IGMP and MLD snooping */
+        microchip,igmp-snoop-en;
+        microchip,mld-snoop-en;
+
+        status = "okay";
+
+        /* User port 1 */
+        port1: port@0 {
+          compatible = zephyr,dsa-port";
+
+          /* Physical port 1 has address 0 */
+          reg = <0>;
+
+          /* Use random MAC */
+          zephyr,random-mac-address;
+
+          phy-connection-type = "internal";
+
+          status = "okay";
+
+          /* Internal PHY */
+          phy {
+            compatible = "microchip,ksz8463-phy";
+
+            /* Fall back on 100BASE Full-Duplex on auto-negotiation failure */
+            microchip,fixed-link-speed = "100BASE Full-Duplex";
+
+            status = "okay";
+          };
+        };
+
+        /* User port 2 */
+        port2: port@1 {
+          compatible = zephyr,dsa-port";
+
+          /* Physical port 2 has address 1 */
+          reg = <1>;
+
+          /* Use random MAC */
+          zephyr,random-mac-address;
+
+          phy-connection-type = "internal";
+
+          status = "okay";
+
+          /* Internal PHY */
+          phy {
+            compatible = "microchip,ksz8463-phy";
+
+            /* Fall back on 10BASE Half-Duplex on auto-negotiation failure */
+            microchip,fixed-link-speed = "10BASE Half-Duplex";
+
+            status = "okay";
+          };
+        };
+
+        /* CPU port */
+        port3: port@2 {
+          compatible = "zephyr,dsa-port";
+
+          reg = <2>;
+
+          /* Connected to the MAC */
+          ethernet = <&mac>;
+          /* Should match both the switch model and the MAC */
+          phy-connection-type = "mii";
+
+          /* No PHY node required on the CPU port */
+
+          status = "okay";
+        };
+      };
+    };

--- a/dts/bindings/dsa/microchip,ksz8463.yaml
+++ b/dts/bindings/dsa/microchip,ksz8463.yaml
@@ -68,6 +68,14 @@ child-binding:
         A phandle referring to the Ethernet node to which the CPU port, i.e. physical port 3, is
         connected. Should be set for only the node with reg value 2.
 
+    dsa-tag-protocol:
+      description: |
+        An integer identifying which DSA tag protocol to use. Must be either DSA_TAG_PROTO_NOTAG or
+        DSA_TAG_PROTO_KSZ8463. The former disables packet tagging, the latter uses the
+        KSZ8463-specific tagging scheme.
+
+        The property should be set for the CPU port. The default is DSA_TAG_PROTO_NOTAG.
+
     microchip,disable-eee:
       type: boolean
       description: |
@@ -196,7 +204,9 @@ examples:
 
           /* No PHY node required on the CPU port */
 
+          /* Use KSZ8463 tag protocol */
+          dsa-tag-protocol = <DSA_TAG_PROTO_KSZ8463>;
+
           status = "okay";
         };
       };
-    };

--- a/include/zephyr/dt-bindings/ethernet/dsa_tag_proto.h
+++ b/include/zephyr/dt-bindings/ethernet/dsa_tag_proto.h
@@ -10,5 +10,7 @@
 #define DSA_TAG_PROTO_NOTAG	0
 /* NXP NETC switch tag protocol */
 #define DSA_TAG_PROTO_NETC	1
+/* Microchip KSZ8463 tag protocol */
+#define DSA_TAG_PROTO_KSZ8463   2
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ETHERNET_DSA_TAG_PROTO_H_ */

--- a/samples/net/ethernet/dsa/README.rst
+++ b/samples/net/ethernet/dsa/README.rst
@@ -28,3 +28,19 @@ Follow these steps to build the DSA sample application:
    :conf: prj.conf
    :goals: build
    :compact:
+
+Using the Nucleo H755ZI-Q With the KSZ8463ML Evaluation Board
+=============================================================
+
+The KSZ8463ML evaluation board uses a MII connector for connecting the MAC of port 3
+--- i.e. the host/CPU port --- to an external MAC. Using the evaluation board with
+the STM32 Nucleo H755ZI-Q, which comes with an integrated LAN8742A PHY connected via
+RMII, can therefore be done in one of two ways.
+
+#. Desolder the LAN8742A PHY from the Nucleo board and connect the respective MII lines
+   from the KSZ8463 directly to the extension connectors/through holes on the former
+#. Hook the KSZ8463ML evaluation board up to an external PHY and connect said PHY
+   to the Nucleo board via Ethernet (untested).
+
+Note that the strap-in configuration differs between the two options. See Section 3.1.1
+in the KSZ8463ML/RL user guide.

--- a/samples/net/ethernet/dsa/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
+++ b/samples/net/ethernet/dsa/boards/nucleo_h755zi_q_stm32h755xx_m7.conf
@@ -1,0 +1,1 @@
+CONFIG_SPI=y

--- a/samples/net/ethernet/dsa/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
+++ b/samples/net/ethernet/dsa/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 Vilhelm Engström
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Example of how to configure the Microchip KSZ8463 switch for use with
+ * STMicroelectronics's Nucleo H755ZI-Q board. This particular file assumes the
+ * switch is connected to spi1 and is written for the KSz8463ML evaluation kit,
+ * the host port of which uses MII. To use RMII, change the phy-connection-type
+ * property of the CPU port node to "rmii" and mux the appropriate pins.
+ *
+ * Note that the Nucleo board comes with a LAN8742A PHY that needs to be removed
+ * in order to connect said board to the KSZ8463ML evaluation kit via the MII
+ * lines. See the README for this sample for more information.
+ */
+
+#include <st/h7/stm32h755zitx-pinctrl.dtsi>
+#include <zephyr/dt-bindings/pinctrl/stm32-pinctrl.h>
+#include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
+
+&mac {
+	pinctrl-0 = <&eth_mii_col_pa3
+		     &eth_mii_crs_pa0
+		     &eth_mii_rx_clk_pa1
+		     &eth_mii_rx_dv_pa7
+		     &eth_mii_rx_er_pb10
+		     &eth_mii_rxd0_pc4
+		     &eth_mii_rxd1_pc5
+		     &eth_mii_rxd2_pb0
+		     &eth_mii_rxd3_pb1
+		     &eth_mii_tx_clk_pc3
+		     &eth_mii_tx_en_pb11
+		     &eth_mii_txd0_pb12
+		     &eth_mii_txd1_pb13
+		     &eth_mii_txd2_pc2
+		     &eth_mii_txd3_pb8
+		     &eth_mii_tx_er_pb2>;
+	pinctrl-names = "default";
+
+	phy-handle = <&phy0>;
+
+	/* KSZ8463ML uses MII */
+	phy-connection-type = "mii";
+
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&eth_mdc_pc1
+		     &eth_mdio_pa2>;
+	pinctrl-names = "default";
+
+	status = "okay";
+
+	/* PHY for CPU port */
+	phy0: ethernet-phy@0 {
+		/* Know the capabilities of both the MAC transceiver and
+		 * the switch, no sense attempting to negotiate speeds
+		 */
+		compatible = "ethernet-phy-fixed-link";
+
+		/* KSZ8463 capped at 100Mbps, Full-Duplex */
+		default-speeds = "100BASE Full-Duplex";
+
+		reg = <0>;
+		status = "okay";
+	};
+};
+
+&pinctrl {
+	eth_mdc_pc1: eth_mdc_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>; /* ETH_MDC */
+	};
+
+	eth_mdio_pa2: eth_mdio_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>; /* ETH_MDIO */
+	};
+
+	eth_mii_col_pa3: eth_mii_col_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>; /* ETH_MII_COL */
+	};
+
+	eth_mii_crs_pa0: eth_mii_crs_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>; /* ETH_MII_CRS */
+	};
+
+	eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>; /* ETH_MII_RX_CLK */
+	};
+
+	eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>; /* ETH_MII_RX_DV */
+	};
+
+	eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>; /* ETH_MII_RX_ER */
+	};
+
+	eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>; /* ETH_MII_RXD0 */
+	};
+
+	eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>; /* ETH_MII_RXD1 */
+	};
+
+	eth_mii_rxd2_pb0: eth_mii_rxd2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>; /* ETH_MII_RXD2 */
+	};
+
+	eth_mii_rxd3_pb1: eth_mii_rxd3_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>; /* ETH_MII_RXD3 */
+	};
+
+	eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>; /* ETH_MII_TX_CLK */
+	};
+
+	eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>; /* ETH_MII_TX_EN */
+	};
+
+	eth_mii_tx_er_pb2: eth_mii_tx_er_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>; /* ETH_TX_ER */
+	};
+
+	eth_mii_txd0_pb12: eth_mii_txd0_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>; /* ETH_MII_TXD0 */
+	};
+
+	eth_mii_txd1_pb13: eth_mii_txd1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>; /* ETH_MII_TXD1 */
+	};
+
+	eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>; /* ETH_MII_TXD2 */
+	};
+
+	eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>; /* ETH_MII_TXD3 */
+	};
+
+	spi1_nss_pa4: spi1_nss_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF5)>; /* SPI1_NSS */
+	};
+
+	spi1_sck_pa5: spi1_sck_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF5)>; /* SPI1_SCK */
+	};
+
+	spi1_miso_pa6: spi1_miso_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>; /* SPI1_MISO */
+	};
+
+	spi1_mosi_pa7: spi1_mosi_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>; /* SPI1_MOSI */
+	};
+
+	sw1_rst_pb3: sw1_rst_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, GPIO)>; /* GPIO */
+	};
+
+	sw1_irq_pb5: sw1_irq_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, GPIO)>; /* GPIO */
+	};
+};
+
+/* For sys_rand_get */
+&rng {
+	status = "okay";
+};
+
+/* Switch connected to SPI bus 1 */
+&spi1 {
+	cs-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
+
+	pinctrl-0 = <&spi1_nss_pa4
+		     &spi1_sck_pa5
+		     &spi1_miso_pa6
+		     &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+
+	status = "okay";
+
+	sw1: ethernet-switch@0 {
+		compatible = "microchip,ksz8463";
+
+		/* Chip-select 0 */
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		spi-max-frequency = <DT_FREQ_K(12500)>;
+
+		/* Hardware reset is active low */
+		reset-gpios = <&gpiob 3 GPIO_ACTIVE_LOW>;
+
+		/* Interrupt output is active low */
+		int-gpios = <&gpiob 5 GPIO_ACTIVE_LOW>;
+
+		/* Enable IGMP snooping */
+		microchip,igmp-snoop-en;
+
+		/* Enable MLD snooping */
+		microchip,mld-snoop-en;
+
+		status = "okay";
+
+		/* User port 1 */
+		sw1_port1: port@0 {
+			compatible = "zephyr,dsa-port";
+			reg = <0>;
+
+			/* Use random MAC */
+			zephyr,random-mac-address;
+
+			status = "okay";
+
+			/* Internal PHY */
+			phy {
+				compatible = "microchip,ksz8463-phy";
+
+				/* Fall back on 10BASE Half-Duplex on auto-negotiation failure */
+				microchip,fixed-link-speed = "10BASE Half-Duplex";
+
+				status = "okay";
+			};
+		};
+
+		/* User port 2 */
+		sw1_port2: port@1 {
+			compatible = "zephyr,dsa-port";
+			reg = <1>;
+
+			zephyr,random-mac-address;
+
+			status = "okay";
+
+			/* Internal PHY */
+			phy {
+				compatible = "microchip,ksz8463-phy";
+
+				/* Fall back on 100BASE Full-Duplex on auto-negotiation failure */
+				microchip,fixed-link-speed = "100BASE Full-Duplex";
+
+				status = "okay";
+			};
+		};
+
+		/* CPU port */
+		sw1_port3: port@2 {
+			compatible = "zephyr,dsa-port";
+			reg = <2>;
+
+			/* Port is connected to the STM MAC */
+			ethernet = <&mac>;
+
+			/* KSZ8463ML uses MII */
+			phy-connection-type = "mii";
+
+			/* Enable tail tagging */
+			dsa-tag-protocol = <DSA_TAG_PROTO_KSZ8463>;
+
+			status = "okay";
+		};
+	};
+};

--- a/samples/net/ethernet/dsa/tests.yaml
+++ b/samples/net/ethernet/dsa/tests.yaml
@@ -16,4 +16,5 @@ tests:
       - frdm_imxrt1186/mimxrt1186/cm7/extmem
       - imx943_evk/mimx94398/m33/ddr
       - imx943_evk/mimx94398/a55
+      - nucleo_h755zi_q/stm32h755xx/m7
     depends_on: eth


### PR DESCRIPTION
This PR introduces support for Microchip's KSZ8463 Ethernet switch, a 3-port switch featuring integrated PHYs in each of the two user ports. The driver supports the following features

- Both MII and RMII over the host port. Which of the two to use is ultimately determined by the switch model. KSZ8463ML and KSZ8463FML use MII whereas KSZ8463RL and KSZ8463FRL use RMII.
- Interrupt-driven hotplug detection, subject to the `INTRN` line being connected to the CPU.
- Poll-based hotplug detection automatically enabled should no `int-gpios` be specified in the devicetree.
- Auto-negotiation, assuming the link partner is capable.
- Support for the KSZ8463-specific tag protocol.

Hopefully, this will serve as a another example of how to employ the so far relatively sparingly used DSA API introduced in v4.4.

Given that most of the functionality introduced in this PR is entirely new, relatively few modifications are done to existing code. The only change is that Kconfig options for the NXP NETC driver are moved to a separate Kconfig file named Kconfig.netc to avoid cluttering the DSA top-level Kconfig.

The data sheet for the KSZ8463, along with other information, is available [here](https://www.microchip.com/en-us/product/ksz8463).

I apologize for this PR being as large as it is. It's difficult to introduce changes such as these in smaller pieces.

A special thanks to Microchip for providing the evaluation kit used to develop this.