### PR TITLE
MAINTAINERS: add utilities tests to kernel/base os

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -545,6 +545,7 @@ Base OS:
     - printk
     - libraries.fdtable.fdtable
     - libraries.p4wq
+    - utilities
 
 BeagleBoard Platforms:
   status: maintained
@@ -3681,6 +3682,7 @@ Kernel:
     - libraries.p4wq
     - sample.kernel
     - linker.linker_generator
+    - utilities
 
 Key-Value Storage Systems:
   status: maintained


### PR DESCRIPTION
Add utilities tests to kernel/base os.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
