### PR TITLE
haptics: Introduce API for triggered effects

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -235,9 +235,9 @@ New APIs and options
 
 * Haptics
 
-  * :c:enumerator:`haptics_monitor`
-  * :c:enumerator:`haptics_monitor_type`
-  * :c:enumerator:`haptics_source`
+  * :c:enum:`haptics_monitor`
+  * :c:enum:`haptics_monitor_type`
+  * :c:enum:`haptics_source`
   * :c:enum:`haptics_trigger_type`
   * :c:union:`haptics_config`
   * :c:func:`haptics_calibrate`

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -238,13 +238,16 @@ New APIs and options
   * :c:enumerator:`haptics_monitor`
   * :c:enumerator:`haptics_monitor_type`
   * :c:enumerator:`haptics_source`
+  * :c:enum:`haptics_trigger_type`
   * :c:union:`haptics_config`
   * :c:func:`haptics_calibrate`
   * :c:func:`haptics_monitor_get`
   * :c:func:`haptics_monitor_set`
   * :c:func:`haptics_select_source`
   * :c:func:`haptics_set_level`
+  * :c:func:`haptics_set_trigger`
   * :c:func:`haptics_stream_samples`
+  * :c:func:`haptics_trigger`
 
 * HWSPINLOCK
 

--- a/drivers/haptics/haptics_handlers.c
+++ b/drivers/haptics/haptics_handlers.c
@@ -70,6 +70,22 @@ static inline int z_vrfy_haptics_set_level(const struct device *dev, const enum 
 
 #include <zephyr/syscalls/haptics_set_level_mrsh.c>
 
+static inline int z_vrfy_haptics_set_trigger(const struct device *dev, const uint32_t trigger,
+					     const uint32_t types, const enum haptics_source src,
+					     const union haptics_config *const cfg,
+					     const uint32_t level)
+{
+	K_OOPS(K_SYSCALL_DRIVER_HAPTICS(dev, set_trigger));
+
+	if (cfg != NULL) {
+		K_OOPS(K_SYSCALL_MEMORY_READ(cfg, sizeof(*cfg)));
+	}
+
+	return z_impl_haptics_set_trigger(dev, trigger, types, src, cfg, level);
+}
+
+#include <zephyr/syscalls/haptics_set_trigger_mrsh.c>
+
 static inline int z_vrfy_haptics_start_output(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_HAPTICS(dev, start_output));
@@ -99,3 +115,13 @@ static inline int z_vrfy_haptics_stream_samples(const struct device *dev,
 }
 
 #include <zephyr/syscalls/haptics_stream_samples_mrsh.c>
+
+static inline int z_vrfy_haptics_trigger(const struct device *dev, const uint32_t trigger,
+					 const enum haptics_trigger_type type)
+{
+	K_OOPS(K_SYSCALL_DRIVER_HAPTICS(dev, trigger));
+
+	return z_impl_haptics_trigger(dev, trigger, type);
+}
+
+#include <zephyr/syscalls/haptics_trigger_mrsh.c>

--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -44,6 +44,9 @@ extern "C" {
  * Applications can register a callback function (see @ref haptics_register_error_callback()) to
  * handle or recover from error states. The following error types are used to construct a bitmask
  * provided to the application layer at run-time (see @ref haptics_error_callback_t).
+ *
+ * @attention Device-specific error codes must be distinct bit flags continuing from
+ * HAPTICS_ERROR_PRIV_START, e.g., BIT(5), BIT(6), and so forth.
  */
 enum haptics_error_type {
 	HAPTICS_ERROR_OVERCURRENT = BIT(0),     /**< Output overcurrent error */

--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -17,7 +17,7 @@
  * @brief Interfaces for haptic drivers.
  * @defgroup haptics_interface Haptics
  * @since 4.0
- * @version 0.3.0
+ * @version 0.4.0
  * @ingroup io_interfaces
  * @{
  *
@@ -127,6 +127,29 @@ enum haptics_source {
 };
 
 /**
+ * @brief Options for GPIO-triggered effects
+ *
+ * Trigger options for haptic drivers that support edge- or level-triggered effects. A value of zero
+ * is reserved for @ref HAPTICS_TRIGGER_NONE to indicate that haptic effects should be disabled for
+ * the specified trigger. Refer to device drivers for implementation details.
+ *
+ * @attention Device-specific error codes must be distinct bit flags continuing from
+ * HAPTICS_TRIGGER_PRIV_START, e.g., BIT(4), BIT(5), and so forth.
+ */
+enum haptics_trigger_type {
+	HAPTICS_TRIGGER_NONE,             /**< Disable triggered effects */
+	HAPTICS_TRIGGER_RISING = BIT(0),  /**< Rising-edge (low to high) GPIO event */
+	HAPTICS_TRIGGER_FALLING = BIT(1), /**< Falling-edge (high to low) GPIO event */
+	HAPTICS_TRIGGER_HIGH = BIT(2),    /**< Level-triggered (high) GPIO condition */
+	HAPTICS_TRIGGER_LOW = BIT(3),     /**< Level-triggered (low) GPIO condition */
+
+	/* Device-specific GPIO trigger options can follow, refer to the device’s header file */
+	/** @cond INTERNAL_HIDDEN */
+	HAPTICS_TRIGGER_PRIV_START = BIT(4),
+	/** @endcond */
+};
+
+/**
  * @brief Haptics source configuration
  *
  * Most haptic drivers provide pre-programmed effects or expose methods for programming new effects
@@ -202,6 +225,14 @@ typedef int (*haptics_set_level_t)(const struct device *dev, const enum haptics_
 				   const union haptics_config *const cfg, const uint32_t level);
 
 /**
+ * @brief Assign a haptic effect to a specified GPIO event or condition.
+ * See haptics_set_trigger() for argument description.
+ */
+typedef int (*haptics_set_trigger_t)(const struct device *dev, const uint32_t trigger,
+				     const uint32_t types, const enum haptics_source src,
+				     const union haptics_config *const cfg, const uint32_t level);
+
+/**
  * @brief Start playback for a haptic effect.
  * See haptics_start_output() for argument description.
  */
@@ -219,6 +250,13 @@ typedef int (*haptics_stop_output_t)(const struct device *dev);
  */
 typedef int (*haptics_stream_samples_t)(const struct device *dev, const uint8_t *const samples,
 					const size_t len);
+
+/**
+ * @brief Trigger a haptic effect.
+ * See haptics_trigger() for argument description.
+ */
+typedef int (*haptics_trigger_t)(const struct device *dev, const uint32_t trigger,
+				 const enum haptics_trigger_type type);
 
 /**
  * @driver_ops{Haptics}
@@ -249,6 +287,10 @@ __subsystem struct haptics_driver_api {
 	 */
 	haptics_set_level_t set_level;
 	/**
+	 * @driver_ops_optional @copybrief haptics_set_trigger
+	 */
+	haptics_set_trigger_t set_trigger;
+	/**
 	 * @driver_ops_mandatory @copybrief haptics_start_output
 	 */
 	haptics_start_output_t start_output;
@@ -260,6 +302,10 @@ __subsystem struct haptics_driver_api {
 	 * @driver_ops_optional @copybrief haptics_stream_samples
 	 */
 	haptics_stream_samples_t stream_samples;
+	/**
+	 * @driver_ops_optional @copybrief haptics_trigger
+	 */
+	haptics_trigger_t trigger;
 };
 
 /**
@@ -454,6 +500,45 @@ static inline int z_impl_haptics_set_level(const struct device *dev, const enum 
 }
 
 /**
+ * @brief Assign a haptic effect to a specified GPIO event or condition
+ *
+ * Most haptic drivers support edge- or level-triggered effects to reduce latency for time-critical
+ * or rapid effects. Triggered effects are typically @ref HAPTICS_SOURCE_ROM or
+ * @ref HAPTICS_SOURCE_RAM waveforms.
+ *
+ * @attention @p level can specify gain or attenuation for the triggered-effect. The interaction
+ * between @p level and @ref haptics_set_level() is driver-specific. Refer to device drivers for
+ * implementation details.
+ *
+ * @param[in] dev Pointer to the device structure for the haptic device instance
+ * @param[in] trigger Identifier for the desired trigger
+ * @param[in] types Bitmask of trigger types (of type @ref haptics_trigger_type)
+ * @param[in] src Playback source (of type @ref haptics_source)
+ * @param[in] cfg Source configuration (of type @ref haptics_config) or NULL
+ * @param[in] level Device-specific output level value, refer to device drivers for details
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS if not implemented
+ */
+__syscall int haptics_set_trigger(const struct device *dev, const uint32_t trigger,
+				  const uint32_t types, const enum haptics_source src,
+				  const union haptics_config *const cfg, const uint32_t level);
+
+static inline int z_impl_haptics_set_trigger(const struct device *dev, const uint32_t trigger,
+					     const uint32_t types, const enum haptics_source src,
+					     const union haptics_config *const cfg,
+					     const uint32_t level)
+{
+	const struct haptics_driver_api *api = DEVICE_API_GET(haptics, dev);
+
+	if (api->set_trigger == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_trigger(dev, trigger, types, src, cfg, level);
+}
+
+/**
  * @brief Start playback for a haptic effect
  *
  * Start playback for a haptic effect specified using @ref haptics_select_source(). If no source is
@@ -528,6 +613,40 @@ static inline int z_impl_haptics_stream_samples(const struct device *dev,
 	__ASSERT_NO_MSG(samples != NULL);
 
 	return api->stream_samples(dev, samples, len);
+}
+
+/**
+ * @brief Trigger a haptic effect
+ *
+ * Performs action required to produce the specified haptic effect. For example, if a rising-edge
+ * effect is set using @ref haptics_set_trigger() and this function is called with @p type set to
+ * @ref HAPTICS_TRIGGER_RISING, then a device driver may drive the specified pin high. Refer to
+ * device drivers for implementation details.
+ *
+ * @attention The application is responsible for managing the physical line level. For example,
+ * calling this function with @p type set to @ref HAPTICS_TRIGGER_RISING when the physical level is
+ * already high may result in a no-op.
+ *
+ * @param[in] dev Pointer to the device structure for the haptic device instance
+ * @param[in] trigger Identifier for the desired trigger
+ * @param[in] type Trigger type (of type @ref haptics_trigger_type)
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS if not implemented
+ */
+__syscall int haptics_trigger(const struct device *dev, const uint32_t trigger,
+			      const enum haptics_trigger_type type);
+
+static inline int z_impl_haptics_trigger(const struct device *dev, const uint32_t trigger,
+					 const enum haptics_trigger_type type)
+{
+	const struct haptics_driver_api *api = DEVICE_API_GET(haptics, dev);
+
+	if (api->trigger == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->trigger(dev, trigger, type);
 }
 
 /**


### PR DESCRIPTION
Please refer to #116344 for details.

See #116277 for related updates to the haptics shell and #116275 for an example implementation of this new API for the CS40L26/27 driver.