### PR TITLE
drivers: charger: avoid leaking memroy in get_prop

### DIFF
--- a/drivers/charger/charger_handlers.c
+++ b/drivers/charger/charger_handlers.c
@@ -16,7 +16,9 @@ static inline int z_vrfy_charger_get_prop(const struct device *dev, const charge
 
 	int ret = z_impl_charger_get_prop(dev, prop, &k_val);
 
-	K_OOPS(k_usermode_to_copy(val, &k_val, sizeof(union charger_propval)));
+	if (ret == 0) {
+		K_OOPS(k_usermode_to_copy(val, &k_val, sizeof(union charger_propval)));
+	}
 
 	return ret;
 }


### PR DESCRIPTION
z_vrfy_charger_get_prop() declared an uninitialized union charger_propval on the kernel stack, passed it to the backend and then copied it back to the caller unconditionally, ignoring the return code.

Fixes: #117059