### PR TITLE
drivers: timer: infineon_lp_timer_pdl: Add buffer for MCWDT reset

### DIFF
--- a/drivers/timer/infineon_lp_timer_pdl.c
+++ b/drivers/timer/infineon_lp_timer_pdl.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -83,6 +83,7 @@ static void lptimer_delay(uint32_t cycles)
 	 * This actually means we delay 210us here to reset in total.
 	 */
 	Cy_MCWDT_ResetCounters(lptimer, CY_MCWDT_CTR0 | CY_MCWDT_CTR1, 105);
+	WAIT_FOR(MCWDT_CNTLOW(lptimer) == 0, 100, NULL);
 	__ASSERT(MCWDT_CNTLOW(lptimer) == 0, "Issue with Cy_MCWDT_ResetCounters function call.");
 
 	MCWDT_MATCH(lptimer) = cycles;


### PR DESCRIPTION
In lptimer_delay, we reset the MCWDT counters using the PDL-recommended 210us.  On some devices during CPU-intensive processes, this is slightly too short for the counter to reset, causing the following ASSERT(counter = 0) to rarely trigger.

Adding a WAITFOR prior to the assert to offer up to 100us for MCWDT to finish resetting.  Using a WAITFOR instead of upping the ResetCounters delay so this extra wait is optional and only used when necessary.



In the future, I'd like to rework this driver to not depend on ResetCounters, expanding what is done in https://github.com/zephyrproject-rtos/zephyr/pull/114892 to cover this driver implementation too