### PR TITLE
dts: arm: infineon: xmc7200: disable unused work flash node

### DIFF
--- a/dts/arm/infineon/cat1c/xmc7200/xmc7200.dtsi
+++ b/dts/arm/infineon/cat1c/xmc7200/xmc7200.dtsi
@@ -26,6 +26,7 @@
 			reg = <0x10080000 0x200000>;
 			write-block-size = <512>;
 			erase-block-size = <512>;
+			status = "disabled";
 		};
 	};
 


### PR DESCRIPTION
The xmc7200 `flash-controller@40240000` node declares two `soc-nv-flash` children (`flash0` and `flash1`). The Infineon CAT1 flash driver only supports a single `soc-nv-flash` child: it selects the first okay child via `SOC_NV_FLASH_NODE`. When the driver is built without fixed partitions (for example a minimal/footprint configuration), the presence of a second okay `soc-nv-flash` node breaks the build.

This mirrors the arrangement already applied to the psoc6 SoC devicetree in #114105, where the unused second work-flash node was disabled so the controller exposes a single active `soc-nv-flash` child.

Disable the unused second (work) flash node on xmc7200 to restore a single active `soc-nv-flash` child and fix the build.