### PR TITLE
dts: bindings: can: fix rx-timestamp-prescaler in realtek,bee-can

### DIFF
--- a/dts/bindings/can/realtek,bee-can.yaml
+++ b/dts/bindings/can/realtek,bee-can.yaml
@@ -30,5 +30,5 @@ properties:
       Prescaler value for computing the RX timestamps of received frames.
       The timestamp counter is derived from the CAN source clock divided by this value.
       A value of 1 means the timestamp counter runs at the CAN source clock rate.
-    min: 1
-    max: 256
+      min: 1
+      max: 256


### PR DESCRIPTION
The dt-binding schema does not support property-level `min`/`max` settings, so declaring them on `rx-timestamp-prescaler` broke the devicetree parse with "unknown setting 'min'". Fold the 1-256 range into the property `description` block instead, which keeps the range documented without tripping the binding validator.