### PR TITLE
dts: bindings: cpu: Add vendor defined cpu enable-method

### DIFF
--- a/drivers/pm_cpu_ops/pm_cpu_ops_spin_table.c
+++ b/drivers/pm_cpu_ops/pm_cpu_ops_spin_table.c
@@ -13,8 +13,11 @@ LOG_MODULE_REGISTER(spin_table, CONFIG_PM_CPU_OPS_LOG_LEVEL);
 
 #define NUM_CPUS  ARRAY_SIZE(mpid_table)
 
-#define CPU_IS_SPIN_TABLE(node_id)                                                 \
-	DT_ENUM_HAS_VALUE(node_id, enable_method, spin_table)
+/* Sentinel to detect a "spin-table" enable-method */
+#define Z_ENABLE_METHOD_spin_table 1
+
+#define CPU_IS_SPIN_TABLE(node_id)                                                                 \
+	IS_ENABLED(UTIL_CAT(Z_ENABLE_METHOD_, DT_STRING_TOKEN(node_id, enable_method)))
 
 #define SPIN_TABLE_RELEASE_ADDR(node_id)                                           \
 	COND_CODE_1(CPU_IS_SPIN_TABLE(node_id),                                    \

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -13,7 +13,6 @@ properties:
       Standard device_type identifying this node as a cpu. Required to maintain compatibility
       with the IEEE 1275 standard as well as for DT_FOREACH_CPU family of devicetree macros to
       identify cpu nodes within the "/cpus" parent node
-
   zephyr,deferred-start:
     type: boolean
     description: |
@@ -36,10 +35,17 @@ properties:
     description: d-cache line size
   enable-method:
     type: string
-    enum:
-      - "psci"
-      - "spin-table"
-    description: Enable method for cpu, either it is "psci" or "spin-table"
+    description: |
+      Method by which a CPU in a disabled state is enabled. This property is
+      required for CPUs with a status property with a value of disabled. The
+      value may be one of the following:
+      - "psci": ARM Power State Coordination Interface.
+      - "spin-table": Standard DTSpec spin-table; requires cpu-release-addr.
+      - "[vendor],[method]": Vendor-defined method which describes the method a
+        CPU is released from a disabled state.
+
+      For details, see "3.8.1 General Properties of /cpus/cpu* nodes" in
+      Devicetree Specification v0.4.
   cpu-release-addr:
     type: array
     description: Address of the release mailbox used by the spin-table enable-method.


### PR DESCRIPTION
There is no standard way to launch a secondary CPU out of its quiescent state. While ARM Cortex-A cores use standardized secondary cpu launch methods like PSCI or spin-tables, other multi-core SoC's (eg. raspberrypi rp2350, nxp lpc55s69, etc) enable-methods are entirely vendor-specific.

The [devicetree specification section 3.8.1](https://devicetree-specification.readthedocs.io/en/latest/chapter3-devicenodes.html#general-properties-of-cpus-cpu-nodes) describes the `enable-method` property of a `cpus/cpu*` node. It may have the value `"[vendor],[method]"` which describes the vendors-specific method by which a CPU is released from a disabled state.

Remove `enum` from `enable-method` binding and update DT macros that relied on `enable-method` being an `enum` type property.

Document the `[vendor],[method]` value in the `enable-method` property of `cpu.yaml`.