### PR TITLE
net: dns: prevent dispatcher stuck by using non-blocking recvfrom

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -188,7 +188,7 @@ static int recv_data(struct net_socket_service_event *pev)
 	}
 
 	ret = zsock_recvfrom(pev->event.fd, dns_data->data,
-			     net_buf_max_len(dns_data), 0,
+			     net_buf_max_len(dns_data), ZSOCK_MSG_DONTWAIT,
 			     net_sad(&addr), &addrlen);
 	if (ret < 0) {
 		ret = -errno;


### PR DESCRIPTION
I am initiating this pull request with the intention to start the discussion on a problem of network packet starvation, due to the sockets_service thread being stuck on a zsock_recvfrom call with flags '0' (wait forever).

I can reproduce this issue about 1/10 or 1/20 times when rebooting my device and connecting via Wi-Fi. We have MDNS and DNS_SD enabled. The sockets service thread is woken up and 'revents' is set for a specific socket, which results in 'trigger_work' and 'call_work' functions. This results in 'recv_data' in dispatcher.c being called. However, when trying to read from the socket, the task hangs forever. In the next seconds and minutes, more packets are dispatched to this socket but the thread never wakes up, until no more packets are free.

Replacing the blocking wait fixes the issue for me, but apparently the error handling code is called more often than I would expect. It seems to me though that the system is still working fine with that fix. So it means that my system is certainly not 'corrupted' in any way. I can't say if a packet eventually was never handled, or not.

The reproduction is easiest on my home network, which I'm not on right now. My next steps are to verify which 'pev->event.revents' are set for the socket, maybe it's not at all ZSOCK_POLLIN. But even then, I would expect the zsock_recvfrom call to return once a next packet is inserted in the socket?

AI also pointed out that maybe another instance has read from the same socket, but that seems unlikely to me. Alternatively, might there be some race conditions in the socket implementation that can cause the thread to wake up but where the socket does not have the data ready for readout?

I'll post my next observations in this thread but I already wanted to create the PR to initiate the discussion.