### PR TITLE
bluetooth: classic: bip: add required app param tag validation

### DIFF
--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -585,7 +585,7 @@ struct bip_function {
 	bool op_get;
 	uint8_t func_bit;
 	uint32_t supported_features;
-	uint32_t required_appl_param_tag_id;
+	uint32_t required_ap_tag_id;
 	struct bip_required_hdr hdr;
 	bt_bip_server_cb_t (*get_server_cb)(struct bt_bip_server *server);
 	bt_bip_client_cb_t (*get_client_cb)(struct bt_bip_client *client);
@@ -941,6 +941,19 @@ static bool has_required_hdrs(struct net_buf *buf, const struct bip_required_hdr
 	return true;
 }
 
+static bool has_required_ap_tag_id(struct net_buf *buf, uint32_t tag_mask)
+{
+	while (tag_mask != 0) {
+		uint8_t id = __builtin_ctz(tag_mask);
+
+		if (!bt_obex_has_app_param(buf, id)) {
+			return false;
+		}
+		tag_mask &= ~(1U << id);
+	}
+	return true;
+}
+
 static enum bt_obex_rsp_code bip_server_get_req_cb(struct bt_bip_server *server,
 						   struct net_buf *buf, bool is_get,
 						   bt_bip_server_cb_t *cb)
@@ -982,7 +995,9 @@ static enum bt_obex_rsp_code bip_server_get_req_cb(struct bt_bip_server *server,
 			continue;
 		}
 
-		/* Application parameter tag id is not checked. */
+		if (!has_required_ap_tag_id(buf, bip_functions[i].required_ap_tag_id)) {
+			continue;
+		}
 
 		if (bip_functions[i].get_server_cb == NULL) {
 			continue;
@@ -1799,7 +1814,9 @@ static int bip_client_get_req_cb(struct bt_bip_client *client, const char *type,
 			continue;
 		}
 
-		/* Application parameter tag id is not checked. */
+		if (!has_required_ap_tag_id(buf, bip_functions[i].required_ap_tag_id)) {
+			continue;
+		}
 
 		if (bip_functions[i].get_client_cb == NULL) {
 			continue;


### PR DESCRIPTION
The `required_appl_param_tag_id` bitmask in `struct bip_function` was unused; both `bip_server_get_req_cb()` and `bip_client_get_req_cb()` contained a placeholder comment noting that application parameter tag IDs were not checked.

Add `has_required_ap_tag_id()`, which iterates every set bit in the bitmask via `__builtin_ctz()` and verifies that the corresponding application parameter is present in the request buffer using `bt_obex_has_app_param()`. Invoke this helper in both the server and client request paths (GET and PUT) so BIP operations that require specific application parameters are correctly rejected when those parameters are absent, rather than being silently passed through.

Also rename the struct field from `required_appl_param_tag_id` to `required_ap_tag_id` to align with the shorter naming convention used elsewhere in the file.