### PR TITLE
boards: lpcxpresso55s36: Enable I3C support

### DIFF
--- a/boards/nxp/lpcxpresso55s36/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s36/doc/index.rst
@@ -118,6 +118,13 @@ The LPC55S36 SoC has 8 FLEXCOMM interfaces for serial
 communication. One is configured as USART for the console and the
 remaining are not used.
 
+I3C
+===
+
+The LPC55S36 SoC has one I3C module.
+Mind that the I3C and SWD signals/pins going to the on-board MCU-Link are shared.
+It is recommended to short jumper JP27 to isolate MCU-Link from driving the shared signals.
+
 Programming and Debugging
 *************************
 

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36-pinctrl.dtsi
@@ -143,4 +143,30 @@
 			nxp,analog-mode;
 		};
 	};
+
+	pinmux_i3c0_alt0: pinmux_i3c0_alt0 {
+		group0 {
+			pinmux = <I3C0_SDA_PIO0_24>,
+				 <I3C0_SCL_PIO0_9>;
+			slew-rate = "fast";
+		};
+
+		group1 {
+			pinmux = <I3C0_PUR_PIO0_28>;
+			slew-rate = "fast";
+		};
+	};
+
+	pinmux_i3c0_alt1: pinmux_i3c0_alt1 {
+		group0 {
+			pinmux = <I3C0_SDA_PIO2_1>,
+				 <I3C0_SCL_PIO0_9>;
+			slew-rate = "fast";
+		};
+
+		group1 {
+			pinmux = <I3C0_PUR_PIO2_0>;
+			slew-rate = "fast";
+		};
+	};
 };

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -261,3 +261,10 @@ zephyr_udc0: &usbfs {
 &ctimer4 {
 	status = "okay";
 };
+
+&i3c0 {
+	status = "okay";
+
+	pinctrl-0 = <&pinmux_i3c0_alt0>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -28,4 +28,5 @@ supported:
   - usbd
   - watchdog
   - crc
+  - i3c
 vendor: nxp

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S3x_common.dtsi
@@ -667,6 +667,19 @@
 		clocks = <&syscon MCUX_POWERQUAD_CLK>;
 		status = "disabled";
 	};
+
+	i3c0: i3c@16000 {
+		compatible = "nxp,mcux-i3c";
+		reg = <0x16000 0x1000>;
+		interrupts = <62 0>;
+		clocks = <&syscon MCUX_I3C_CLK>;
+		clk-divider = <6>;
+		clk-divider-slow = <1>;
+		clk-divider-tc = <1>;
+		status = "disabled";
+		#address-cells = <3>;
+		#size-cells = <0>;
+	};
 };
 
 &nvic {

--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -453,6 +453,20 @@ DT_FOREACH_STATUS_OKAY(nxp_ctimer_pwm, CTIMER_CLOCK_SETUP)
 	CLOCK_SetClkDiv(kCLOCK_DivArmTrClkDiv, 1U, true);
 #endif
 
+#if defined(CONFIG_I3C)
+
+#if defined(CONFIG_SOC_LPC55S36)
+	CLOCK_AttachClk(kMAIN_CLK_to_I3CFCLK);
+	CLOCK_SetClkDiv(kCLOCK_DivI3cFclk, 0U, true);
+	CLOCK_SetClkDiv(kCLOCK_DivI3cFclk, DT_PROP(DT_NODELABEL(i3c0), clk_divider), false);
+
+	/* Enable FCLKS for I3C slave event. */
+	CLOCK_SetClkDiv(kCLOCK_DivI3cFclkS, 0U, true);
+	CLOCK_SetClkDiv(kCLOCK_DivI3cFclkS, 1U, false);
+#endif
+
+#endif /* I3C */
+
 #if CONFIG_AUDIO_CODEC_WM8904
 	CLOCK_AttachClk(kPLL0_to_MCLK);
 	SYSCON->MCLKDIV = SYSCON_MCLKDIV_DIV(0U);


### PR DESCRIPTION
The lpcxpresso55s36 has an I3C module.
This change adds the necessary pinmux settings (both possibilities of the EVK board) and devicetree descriptions to allow users to use the I3C module.

Also added docs on the caveat of using the I3C on the board due to the signal sharing with SWD.
This info was taken from the NXP website/docs:
https://docs.nxp.com/bundle/LPCXpresso55S36UM/page/topics/i3c_interface.html