### PR TITLE
drivers: i2c: migrate driver internals to inclusive terminology

### DIFF
--- a/drivers/i2c/Kconfig.renesas_rx
+++ b/drivers/i2c/Kconfig.renesas_rx
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config I2C_RENESAS_RX_RIIC
-	bool "Renesas RX I2C Master"
+	bool "Renesas RX I2C Controller"
 	default y
 	depends on DT_HAS_RENESAS_RX_I2C_ENABLED
 	select USE_RX_RDP_I2C

--- a/drivers/i2c/i2c_andes_atciic100.h
+++ b/drivers/i2c/i2c_andes_atciic100.h
@@ -214,7 +214,7 @@ enum _i2c_driver_state {
 
 /* brief I2C Status */
 struct _i2c_status {
-/* /< Mode: 0=Slave, 1=Master */
+/* /< Mode: 0=Target, 1=Controller */
 	uint32_t mode:1;
 	uint32_t general_call: 1;
 	uint32_t arbitration_lost : 1;

--- a/drivers/i2c/i2c_bcm2711.c
+++ b/drivers/i2c/i2c_bcm2711.c
@@ -190,7 +190,7 @@ static void bcm2711_i2c_transaction(const struct device *dev, bool repeated_star
 		ctrl |= BCM2711_I2C_CR_INTD;
 	}
 
-	/* Set slave address and message length */
+	/* Set target address and message length */
 	bcm2711_i2c_write_reg(dev, BCM2711_I2C_ADDR, data->i2c_addr);
 	bcm2711_i2c_write_reg(dev, BCM2711_I2C_DLEN, segment_len);
 

--- a/drivers/i2c/i2c_bcm_iproc.c
+++ b/drivers/i2c/i2c_bcm_iproc.c
@@ -259,7 +259,7 @@ static int iproc_i2c_target_init(const struct device *dev, bool need_reset)
 	val = BIT(IE_S_RX_EVENT_SHIFT);
 	/* Enable interrupt register to indicate target Rx FIFO Full */
 	val |= BIT(IE_S_RX_FIFO_FULL_SHIFT);
-	/* Enable interrupt register to indicate a Master read transaction */
+	/* Enable interrupt register to indicate a controller read transaction */
 	val |= BIT(IE_S_RD_EN_SHIFT);
 	/* Enable interrupt register for the target BUSY command */
 	val |= BIT(IE_S_START_BUSY_SHIFT);
@@ -285,7 +285,7 @@ static int iproc_i2c_check_target_status(const struct device *dev)
 		if (val == S_CMD_STATUS_TIMEOUT) {
 			LOG_ERR("target random stretch time timeout");
 		} else if (val == S_CMD_STATUS_MASTER_ABORT) {
-			LOG_ERR("Master aborted read transaction");
+			LOG_ERR("Controller aborted read transaction");
 		}
 
 		/* re-initialize i2c for recovery */
@@ -314,15 +314,15 @@ static void iproc_i2c_target_read(const struct device *dev)
 		rx_data = ((val >> S_RX_DATA_SHIFT) & S_RX_DATA_MASK);
 
 		if (rx_status == I2C_TARGET_RX_START) {
-			/* Start of SMBUS Master write */
+			/* Start of SMBUS controller write */
 			target_cfg->callbacks->write_requested(target_cfg);
 			dd->rx_start_rcvd = true;
 			dd->target_read_complete = false;
 		} else if ((rx_status == I2C_TARGET_RX_DATA) && dd->rx_start_rcvd) {
-			/* Middle of SMBUS Master write */
+			/* Middle of SMBUS controller write */
 			target_cfg->callbacks->write_received(target_cfg, rx_data);
 		} else if ((rx_status == I2C_TARGET_RX_END) && dd->rx_start_rcvd) {
-			/* End of SMBUS Master write */
+			/* End of SMBUS controller write */
 			if (dd->target_rx_only) {
 				target_cfg->callbacks->write_received(target_cfg, rx_data);
 			}
@@ -346,7 +346,7 @@ static void iproc_i2c_target_rx(const struct device *dev)
 
 	if (!dd->target_rx_only && dd->target_read_complete) {
 		/*
-		 * In case of single byte master-read request,
+		 * In case of single byte controller-read request,
 		 * IS_S_TX_UNDERRUN_SHIFT event is generated before
 		 * IS_S_START_BUSY_SHIFT event. Hence start target data send
 		 * from first IS_S_TX_UNDERRUN_SHIFT event.
@@ -384,10 +384,10 @@ static void iproc_i2c_target_isr(const struct device *dev, uint32_t status)
 		sys_write32(val, base + IE_OFFSET);
 
 		if (status & BIT(IS_S_RD_EN_SHIFT)) {
-			/* Master-write-read request */
+			/* Controller-write-read request */
 			dd->target_rx_only = false;
 		} else {
-			/* Master-write request only */
+			/* Controller-write request only */
 			dd->target_rx_only = true;
 		}
 
@@ -407,10 +407,10 @@ static void iproc_i2c_target_isr(const struct device *dev, uint32_t status)
 	if (status & BIT(IS_S_TX_UNDERRUN_SHIFT)) {
 		dd->tx_underrun++;
 		if (dd->tx_underrun == 1) {
-			/* Start of SMBUS for Master Read */
+			/* Start of SMBUS for controller read */
 			target_cfg->callbacks->read_requested(target_cfg, &data);
 		} else {
-			/* Master read other than start */
+			/* Controller read other than start */
 			target_cfg->callbacks->read_processed(target_cfg, &data);
 		}
 
@@ -422,7 +422,7 @@ static void iproc_i2c_target_isr(const struct device *dev, uint32_t status)
 		sys_write32(BIT(IS_S_TX_UNDERRUN_SHIFT), base + IS_OFFSET);
 	}
 
-	/* Stop received from master in case of master read transaction */
+	/* Stop received from controller in case of controller read transaction */
 	if (status & BIT(IS_S_START_BUSY_SHIFT)) {
 		/*
 		 * Disable interrupt for TX FIFO becomes empty and
@@ -431,7 +431,7 @@ static void iproc_i2c_target_isr(const struct device *dev, uint32_t status)
 		dd->target_int_mask &= ~BIT(IE_S_TX_UNDERRUN_SHIFT);
 		sys_write32(dd->target_int_mask, base + IE_OFFSET);
 
-		/* End of SMBUS for Master Read */
+		/* End of SMBUS for controller read */
 		val = BIT(S_TX_WR_STATUS_SHIFT);
 		sys_write32(val, base + S_TX_OFFSET);
 
@@ -576,7 +576,7 @@ static int iproc_i2c_check_status(const struct device *dev, uint16_t dev_addr, s
 	}
 
 	if (rc < 0) {
-		/* flush both Master TX/RX FIFOs */
+		/* flush both controller TX/RX FIFOs */
 		val = BIT(M_FIFO_RX_FLUSH_SHIFT) | BIT(M_FIFO_TX_FLUSH_SHIFT);
 		sys_write32(val, base + M_FIFO_CTRL_OFFSET);
 	}
@@ -681,7 +681,7 @@ static int iproc_i2c_transfer_one(const struct device *dev, struct i2c_msg *msg,
 
 	tx_bytes = MIN(msg->len, (TX_RX_FIFO_SIZE - 1));
 	if (!(msg->flags & I2C_MSG_READ)) {
-		/* Fill master TX fifo */
+		/* Fill controller TX fifo */
 		for (uint32_t i = 0; i < tx_bytes; i++) {
 			val = msg->buf[i];
 			/* For the last byte, set MASTER_WR_STATUS bit */
@@ -706,7 +706,7 @@ static int iproc_i2c_transfer_one(const struct device *dev, struct i2c_msg *msg,
 	}
 
 	/*
-	 * Program master command register (0x30) with protocol type and set
+	 * Program controller command register (0x30) with protocol type and set
 	 * start_busy_command bit to initiate the write transaction
 	 */
 	val = BIT(M_CMD_START_BUSY_SHIFT);
@@ -752,13 +752,13 @@ static int iproc_i2c_transfer_one(const struct device *dev, struct i2c_msg *msg,
 	sys_write32(0, base + IE_OFFSET);
 
 	if (rc != 0) {
-		/* flush both Master TX/RX FIFOs */
+		/* flush both controller TX/RX FIFOs */
 		val = BIT(M_FIFO_RX_FLUSH_SHIFT) | BIT(M_FIFO_TX_FLUSH_SHIFT);
 		sys_write32(val, base + M_FIFO_CTRL_OFFSET);
 		return rc;
 	}
 
-	/* Check for Master Xfer status */
+	/* Check for controller Xfer status */
 	rc = iproc_i2c_check_status(dev, dev_addr, msg);
 
 	return rc;
@@ -835,7 +835,7 @@ static void iproc_i2c_send_data(const struct device *dev)
 	dd->tx_bytes += tx_bytes;
 }
 
-static void iproc_i2c_master_isr(const struct device *dev, uint32_t status)
+static void iproc_i2c_controller_isr(const struct device *dev, uint32_t status)
 {
 	struct iproc_i2c_data *dd = DEV_DATA(dev);
 
@@ -879,9 +879,9 @@ static void iproc_i2c_isr(void *arg)
 #endif
 
 	status &= ISR_MASK;
-	/* master events */
+	/* controller events */
 	if (status) {
-		iproc_i2c_master_isr(dev, status);
+		iproc_i2c_controller_isr(dev, status);
 		sys_write32(status, base + IS_OFFSET);
 	}
 }

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -177,9 +177,9 @@ static int i2c_cc13xx_cc26xx_configure(const struct device *dev,
 		return -EIO;
 	}
 
-	/* Support for slave mode has not been implemented */
+	/* Support for target mode has not been implemented */
 	if (!(dev_config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Slave mode is not supported");
+		LOG_ERR("Target mode is not supported");
 		return -EIO;
 	}
 
@@ -189,7 +189,7 @@ static int i2c_cc13xx_cc26xx_configure(const struct device *dev,
 		return -EIO;
 	}
 
-	/* Enables and configures I2C master */
+	/* Enables and configures I2C controller */
 	I2CMasterInitExpClk(config->base, CPU_FREQ, fast);
 
 #ifdef CONFIG_PM

--- a/drivers/i2c/i2c_cc23x0.c
+++ b/drivers/i2c/i2c_cc23x0.c
@@ -230,9 +230,9 @@ static int i2c_cc23x0_configure(const struct device *dev, uint32_t dev_config)
 		return -EIO;
 	}
 
-	/* Support for slave mode has not been implemented */
+	/* Support for target mode has not been implemented */
 	if (!(dev_config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Slave mode is not supported");
+		LOG_ERR("Target mode is not supported");
 		return -EIO;
 	}
 
@@ -242,7 +242,7 @@ static int i2c_cc23x0_configure(const struct device *dev, uint32_t dev_config)
 		return -EIO;
 	}
 
-	/* Enables and configures I2C master */
+	/* Enables and configures I2C controller */
 	I2CControllerInitExpClk(config->base, fast);
 
 	CLKCTLEnable(CLKCTL_BASE, CLKCTL_I2C0);

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -75,7 +75,7 @@ struct i2c_cc32xx_data {
 	volatile enum i2c_cc32xx_state state;
 
 	struct i2c_msg msg; /* Cache msg for transfer state machine */
-	uint16_t  slave_addr; /* Cache slave address for ISR use */
+	uint16_t  target_addr; /* Cache target address for ISR use */
 };
 
 static void configure_i2c_irq(const struct i2c_cc32xx_config *config);
@@ -120,12 +120,12 @@ static void i2c_cc32xx_prime_transfer(const struct device *dev,
 
 	/* Initialize internal counters and buf pointers: */
 	data->msg = *msg;
-	data->slave_addr = addr;
+	data->target_addr = addr;
 
 	/* Start transfer in Transmit mode */
 	if (IS_I2C_MSG_WRITE(data->msg.flags)) {
 
-		/* Specify the I2C slave address */
+		/* Specify the I2C target address */
 		MAP_I2CMasterSlaveAddrSet(base, addr, false);
 
 		/* Update the I2C state */
@@ -134,19 +134,19 @@ static void i2c_cc32xx_prime_transfer(const struct device *dev,
 		/* Write data contents into data register */
 		MAP_I2CMasterDataPut(base, *((data->msg.buf)++));
 
-		/* Start the I2C transfer in master transmit mode */
+		/* Start the I2C transfer in controller transmit mode */
 		MAP_I2CMasterControl(base, I2C_MASTER_CMD_BURST_SEND_START);
 
 	} else {
 		/* Start transfer in Receive mode */
-		/* Specify the I2C slave address */
+		/* Specify the I2C target address */
 		MAP_I2CMasterSlaveAddrSet(base, addr, true);
 
 		/* Update the I2C mode */
 		data->state = I2C_CC32XX_READ_MODE;
 
 		if (data->msg.len < 2) {
-			/* Start the I2C transfer in master receive mode */
+			/* Start the I2C transfer in controller receive mode */
 			MAP_I2CMasterControl(base,
 				       I2C_MASTER_CMD_BURST_RECEIVE_START_NACK);
 		} else {
@@ -370,7 +370,7 @@ static int i2c_cc32xx_init(const struct device *dev)
 	/* Clear any pending interrupts */
 	MAP_I2CMasterIntClear(base);
 
-	/* Enable the I2C Master for operation */
+	/* Enable the I2C controller for operation */
 	MAP_I2CMasterEnable(base);
 
 	/* Unmask I2C interrupts */

--- a/drivers/i2c/i2c_ene_kb106x.c
+++ b/drivers/i2c/i2c_ene_kb106x.c
@@ -32,7 +32,7 @@ struct i2c_kb106x_data {
 	volatile int err_code;
 };
 
-/* I2C Master local functions */
+/* I2C Controller local functions */
 static void i2c_kb106x_isr(const struct device *dev)
 {
 	const struct i2c_kb106x_config *config = dev->config;
@@ -231,7 +231,7 @@ static int i2c_kb106x_poll_read(const struct device *dev, struct i2c_msg *msg, u
 	return 0;
 }
 
-/* I2C Master api functions */
+/* I2C Controller api functions */
 static int i2c_kb106x_configure(const struct device *dev, uint32_t dev_config)
 {
 	const struct i2c_kb106x_config *config = dev->config;
@@ -324,7 +324,7 @@ static int i2c_kb106x_transfer(const struct device *dev, struct i2c_msg *msgs, u
 	return ret;
 }
 
-/* I2C Master driver registration */
+/* I2C Controller driver registration */
 static DEVICE_API(i2c, i2c_kb106x_api) = {
 	.configure = i2c_kb106x_configure,
 	.get_config = i2c_kb106x_get_config,

--- a/drivers/i2c/i2c_ene_kb1200.c
+++ b/drivers/i2c/i2c_ene_kb1200.c
@@ -34,7 +34,7 @@ struct i2c_kb1200_data {
 	volatile int err_code;
 };
 
-/* I2C Master local functions */
+/* I2C Controller local functions */
 static void i2c_kb1200_isr(const struct device *dev)
 {
 	const struct i2c_kb1200_config *config = dev->config;
@@ -229,7 +229,7 @@ static int i2c_kb1200_poll_read(const struct device *dev, struct i2c_msg msg, ui
 	return 0;
 }
 
-/* I2C Master api functions */
+/* I2C Controller api functions */
 static int i2c_kb1200_configure(const struct device *dev, uint32_t dev_config)
 {
 	const struct i2c_kb1200_config *config = dev->config;
@@ -324,7 +324,7 @@ static int i2c_kb1200_transfer(const struct device *dev, struct i2c_msg *msgs, u
 	return ret;
 }
 
-/* I2C Master driver registration */
+/* I2C Controller driver registration */
 static DEVICE_API(i2c, i2c_kb1200_api) = {
 	.configure = i2c_kb1200_configure,
 	.get_config = i2c_kb1200_get_config,

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -64,9 +64,9 @@ struct i2c_xec_data {
 	uint32_t timeout_seen;
 	uint32_t previously_in_read;
 	uint32_t speed_id;
-	struct i2c_target_config *slave_cfg;
-	bool slave_attached;
-	bool slave_read;
+	struct i2c_target_config *target_cfg;
+	bool target_attached;
+	bool target_read;
 };
 
 /* Recommended programming values based on 16MHz
@@ -173,7 +173,7 @@ static void cleanup_registers(uint32_t ba)
 }
 
 #ifdef CONFIG_I2C_TARGET
-static void restart_slave(uint32_t ba)
+static void restart_target(uint32_t ba)
 {
 	MCHP_I2C_SMB_CTRL_WO(ba) = MCHP_I2C_SMB_CTRL_PIN |
 				   MCHP_I2C_SMB_CTRL_ESO |
@@ -361,7 +361,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 	int ret;
 
 	if (data->timeout_seen == 1) {
-		/* Wait to see if the slave has released the CLK */
+		/* Wait to see if the target has released the CLK */
 		ret = wait_completion(dev);
 		if (ret) {
 			data->timeout_seen = 1;
@@ -371,8 +371,8 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 		}
 		data->timeout_seen = 0;
 
-		/* If we are here, it means the slave has finally released
-		 * the CLK. The master needs to end that transaction
+		/* If we are here, it means the target has finally released
+		 * the CLK. The controller needs to end that transaction
 		 * gracefully by sending a STOP on the bus.
 		 */
 		LOG_DBG("%s: %s Force Stop", __func__, dev->name);
@@ -384,8 +384,8 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 		k_busy_wait(BUS_IDLE_US_DFLT);
 		data->pending_stop = 0;
 
-		/* If the timeout had occurred while the master was reading
-		 * something from the slave, that read needs to be completed
+		/* If the timeout had occurred while the controller was reading
+		 * something from the target, that read needs to be completed
 		 * to clear the bus.
 		 */
 		if (data->previously_in_read == 1) {
@@ -424,7 +424,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 			return ret;
 		}
 
-		/* Send slave address */
+		/* Send target address */
 		MCHP_I2C_SMB_DATA(ba) = (addr & ~BIT(0));
 
 		/* Send start and ack bits */
@@ -438,7 +438,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 			break;
 
 		case -EIO:
-			LOG_WRN("%s: No Addr ACK from Slave 0x%x on %s",
+			LOG_WRN("%s: No Addr ACK from Target 0x%x on %s",
 				__func__, addr >> 1, dev->name);
 			return ret;
 
@@ -460,13 +460,13 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 			break;
 
 		case -EIO:
-			LOG_ERR("%s: No Data ACK from Slave 0x%x on %s",
+			LOG_ERR("%s: No Data ACK from Target 0x%x on %s",
 				__func__, addr >> 1, dev->name);
 			return ret;
 
 		case -ETIMEDOUT:
 			data->timeout_seen = 1;
-			LOG_ERR("%s: Clk stretch Timeout - Slave 0x%x on %s",
+			LOG_ERR("%s: Clk stretch Timeout - Target 0x%x on %s",
 				__func__, addr >> 1, dev->name);
 			return ret;
 
@@ -506,7 +506,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 	int ret;
 
 	if (data->timeout_seen == 1) {
-		/* Wait to see if the slave has released the CLK */
+		/* Wait to see if the target has released the CLK */
 		ret = wait_completion(dev);
 		if (ret) {
 			data->timeout_seen = 1;
@@ -516,8 +516,8 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 		}
 		data->timeout_seen = 0;
 
-		/* If we are here, it means the slave has finally released
-		 * the CLK. The master needs to end that transaction
+		/* If we are here, it means the target has finally released
+		 * the CLK. The controller needs to end that transaction
 		 * gracefully by sending a STOP on the bus.
 		 */
 		LOG_DBG("%s: %s Force Stop", __func__, dev->name);
@@ -566,7 +566,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 	MCHP_I2C_SMB_CTRL_WO(ba) = MCHP_I2C_SMB_CTRL_ESO |
 		MCHP_I2C_SMB_CTRL_STA | MCHP_I2C_SMB_CTRL_ACK;
 
-	/* Send slave address */
+	/* Send target address */
 	MCHP_I2C_SMB_DATA(ba) = (addr | BIT(0));
 
 	ret = wait_completion(dev);
@@ -576,14 +576,14 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 
 	case -EIO:
 		data->error_seen = 1;
-		LOG_WRN("%s: No Addr ACK from Slave 0x%x on %s",
+		LOG_WRN("%s: No Addr ACK from Target 0x%x on %s",
 			__func__, addr >> 1, dev->name);
 		return ret;
 
 	case -ETIMEDOUT:
 		data->previously_in_read = 1;
 		data->timeout_seen = 1;
-		LOG_ERR("%s: Clk stretch Timeout - Slave 0x%x on %s",
+		LOG_ERR("%s: Clk stretch Timeout - Target 0x%x on %s",
 			__func__, addr >> 1, dev->name);
 		return ret;
 
@@ -609,14 +609,14 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 			break;
 
 		case -EIO:
-			LOG_ERR("%s: No Data ACK from Slave 0x%x on %s",
+			LOG_ERR("%s: No Data ACK from Target 0x%x on %s",
 				__func__, addr >> 1, dev->name);
 			return ret;
 
 		case -ETIMEDOUT:
 			data->previously_in_read = 1;
 			data->timeout_seen = 1;
-			LOG_ERR("%s: Clk stretch Timeout - Slave 0x%x on %s",
+			LOG_ERR("%s: Clk stretch Timeout - Target 0x%x on %s",
 				__func__, addr >> 1, dev->name);
 			return ret;
 
@@ -655,8 +655,8 @@ static int i2c_xec_transfer(const struct device *dev, struct i2c_msg *msgs,
 #ifdef CONFIG_I2C_TARGET
 	struct i2c_xec_data *data = dev->data;
 
-	if (data->slave_attached) {
-		LOG_ERR("%s Device is registered as slave", dev->name);
+	if (data->target_attached) {
+		LOG_ERR("%s Device is registered as target", dev->name);
 		return -EBUSY;
 	}
 #endif
@@ -687,7 +687,7 @@ static void i2c_xec_bus_isr(const struct device *dev)
 	const struct i2c_xec_config *config =
 		(const struct i2c_xec_config *const) (dev->config);
 	struct i2c_xec_data *data = dev->data;
-	const struct i2c_target_callbacks *slave_cb = data->slave_cfg->callbacks;
+	const struct i2c_target_callbacks *target_cb = data->target_cfg->callbacks;
 	uint32_t ba = config->base_addr;
 
 	uint32_t status;
@@ -695,7 +695,7 @@ static void i2c_xec_bus_isr(const struct device *dev)
 
 	uint8_t dummy = 0U;
 
-	if (!data->slave_attached) {
+	if (!data->target_attached) {
 		return;
 	}
 
@@ -704,20 +704,20 @@ static void i2c_xec_bus_isr(const struct device *dev)
 
 	/* Bus Error */
 	if (status & MCHP_I2C_SMB_STS_BER) {
-		if (slave_cb->stop) {
-			slave_cb->stop(data->slave_cfg);
+		if (target_cb->stop) {
+			target_cb->stop(data->target_cfg);
 		}
-		restart_slave(ba);
+		restart_target(ba);
 		goto clear_iag;
 	}
 
 	/* External stop */
 	if (status & MCHP_I2C_SMB_STS_EXT_STOP) {
-		if (slave_cb->stop) {
-			slave_cb->stop(data->slave_cfg);
+		if (target_cb->stop) {
+			target_cb->stop(data->target_cfg);
 		}
 		dummy = MCHP_I2C_SMB_DATA(ba);
-		restart_slave(ba);
+		restart_target(ba);
 		goto clear_iag;
 	}
 
@@ -726,39 +726,39 @@ static void i2c_xec_bus_isr(const struct device *dev)
 		uint8_t slv_data = MCHP_I2C_SMB_DATA(ba);
 
 		if (!(slv_data & BIT(I2C_READ_WRITE_POS))) {
-			/* Slave receive  */
-			data->slave_read = false;
-			if (slave_cb->write_requested) {
-				slave_cb->write_requested(data->slave_cfg);
+			/* Target receive  */
+			data->target_read = false;
+			if (target_cb->write_requested) {
+				target_cb->write_requested(data->target_cfg);
 			}
 			goto clear_iag;
 		} else {
-			/* Slave transmit */
-			data->slave_read = true;
-			if (slave_cb->read_requested) {
-				slave_cb->read_requested(data->slave_cfg, &val);
+			/* Target transmit */
+			data->target_read = true;
+			if (target_cb->read_requested) {
+				target_cb->read_requested(data->target_cfg, &val);
 			}
 			MCHP_I2C_SMB_DATA(ba) = val;
 			goto clear_iag;
 		}
 	}
 
-	/* Slave transmit */
-	if (data->slave_read) {
-		/* Master has Nacked, then just write a dummy byte */
+	/* Target transmit */
+	if (data->target_read) {
+		/* Controller has Nacked, then just write a dummy byte */
 		if (MCHP_I2C_SMB_STS_RO(ba) & MCHP_I2C_SMB_STS_LRB_AD0) {
 			MCHP_I2C_SMB_DATA(ba) = dummy;
 		} else {
-			if (slave_cb->read_processed) {
-				slave_cb->read_processed(data->slave_cfg, &val);
+			if (target_cb->read_processed) {
+				target_cb->read_processed(data->target_cfg, &val);
 			}
 			MCHP_I2C_SMB_DATA(ba) = val;
 		}
 	} else {
 		val = MCHP_I2C_SMB_DATA(ba);
-		/* TODO NACK Master */
-		if (slave_cb->write_received) {
-			slave_cb->write_received(data->slave_cfg, val);
+		/* TODO NACK Controller */
+		if (target_cb->write_received) {
+			target_cb->write_received(data->target_cfg, val);
 		}
 	}
 
@@ -781,7 +781,7 @@ static int i2c_xec_target_register(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (data->slave_attached) {
+	if (data->target_attached) {
 		return -EBUSY;
 	}
 
@@ -796,13 +796,13 @@ static int i2c_xec_target_register(const struct device *dev,
 		}
 	}
 
-	data->slave_cfg = config;
+	data->target_cfg = config;
 
 	/* Set own address */
-	MCHP_I2C_SMB_OWN_ADDR(ba) = data->slave_cfg->address;
-	restart_slave(ba);
+	MCHP_I2C_SMB_OWN_ADDR(ba) = data->target_cfg->address;
+	restart_target(ba);
 
-	data->slave_attached = true;
+	data->target_attached = true;
 
 	/* Clear before enabling girq bit */
 	MCHP_GIRQ_SRC(cfg->girq_id) = BIT(cfg->girq_bit);
@@ -817,11 +817,11 @@ static int i2c_xec_target_unregister(const struct device *dev,
 	const struct i2c_xec_config *cfg = dev->config;
 	struct i2c_xec_data *data = dev->data;
 
-	if (!data->slave_attached) {
+	if (!data->target_attached) {
 		return -EINVAL;
 	}
 
-	data->slave_attached = false;
+	data->target_attached = false;
 
 	MCHP_GIRQ_ENCLR(cfg->girq_id) = BIT(cfg->girq_bit);
 
@@ -849,7 +849,7 @@ static int i2c_xec_init(const struct device *dev)
 	int ret;
 
 	data->pending_stop = 0;
-	data->slave_attached = false;
+	data->target_attached = false;
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret != 0) {

--- a/drivers/i2c/i2c_mchp_xec_v2.c
+++ b/drivers/i2c/i2c_mchp_xec_v2.c
@@ -302,7 +302,7 @@ static uint8_t i2c_sr_read(const struct device *dev)
  * released (high) for a certain number of the controller's 16 MHz BAUD clock.
  * Too many ways for I2C to malfunction:
  * Bus Error
- * Lost Arbitration in multi-master scenario.
+ * Lost Arbitration in multi-controller scenario.
  * NOTE: WAIT_FOR macro uses kernel timer granularity. Most projects using XEC are configured
  * to use 32KHz for the kernel timer. Granularity is 30.5 microseconds.
  */
@@ -1345,7 +1345,7 @@ static int i2c_xec_v2_pm_action(const struct device *dev, enum pm_device_action 
 			 * Turn on the clock so the block can complete the in-flight
 			 * AAT (auto-stretching SCL since the wake-up START), then
 			 * disarm the wake hardware. The regular GIRQ13 ISR will
-			 * service the AAT match once the master proceeds.
+			 * service the AAT match once the controller proceeds.
 			 */
 			soc_ecia_girq_ctrl(XEC_I2C_SMB_WK_GIRQ, cfg->wake_girq_pos, 0);
 			sys_write8(0, rb + XEC_I2C_WKCR_OFS);

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -90,7 +90,7 @@ static int i2c_nios2_transfer(const struct device *dev, struct i2c_msg *msgs,
 			stop = ALT_AVALON_I2C_NO_STOP;
 		}
 
-		/* Set the slave device address */
+		/* Set the target device address */
 		alt_avalon_i2c_master_target_set(&data->i2c_dev, addr);
 
 		/* Start the transfer */

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -85,7 +85,7 @@ LOG_MODULE_REGISTER(i2c_npcx, CONFIG_I2C_LOG_LEVEL);
 /* Timeout for device should be available after reset (SMBus spec. unit:ms) */
 #define I2C_MAX_TIMEOUT 35
 
-/* Timeout for SCL held to low by slave device . (SMBus spec. unit:ms). */
+/* Timeout for SCL held to low by target device . (SMBus spec. unit:ms). */
 #define I2C_MIN_TIMEOUT 25
 
 /* Valid bit fields in SMBST register */
@@ -541,7 +541,7 @@ static void i2c_ctrl_target_isr(const struct device *dev, uint8_t status)
 		return;
 	}
 
-	/* A 'Slave Stop' Condition has been identified */
+	/* A 'Target Stop' Condition has been identified */
 	if (IS_BIT_SET(status, NPCX_SMBST_SLVSTP)) {
 		/* Clear SLVSTP Bit */
 		inst->SMBST = BIT(NPCX_SMBST_SLVSTP);
@@ -666,7 +666,7 @@ static void i2c_ctrl_isr(const struct device *dev)
 		/* Clear BER Bit */
 		inst->SMBST = BIT(NPCX_SMBST_BER);
 
-		/* Make sure slave doesn't hold bus by reading FIFO again */
+		/* Make sure target doesn't hold bus by reading FIFO again */
 		tmp = i2c_ctrl_data_read(dev);
 
 		LOG_ERR("Bus error occurred on i2c %s::%02x!", dev->name, data->port);

--- a/drivers/i2c/i2c_npcx_controller.h
+++ b/drivers/i2c/i2c_npcx_controller.h
@@ -88,7 +88,7 @@ struct i2c_ctrl_data {
 	struct i2c_msg *msg_head;
 	int is_write;     /* direction of current msg */
 	uint8_t *ptr_msg; /* current msg pointer for FIFO read/write */
-	uint16_t addr;    /* slave address of transaction */
+	uint16_t addr;    /* target address of transaction */
 	uint8_t msg_max_num;
 	uint8_t msg_curr_idx;
 	uint8_t port;       /* current port used the controller */
@@ -265,7 +265,7 @@ int npcx_i2c_ctrl_get_speed(const struct device *i2c_dev, uint32_t *speed);
  *
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
- * @retval -ENXIO No slave address match.
+ * @retval -ENXIO No target address match.
  * @retval -ETIMEDOUT Timeout occurred for a i2c transaction.
  */
 int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,

--- a/drivers/i2c/i2c_npcx_controller_dma.c
+++ b/drivers/i2c/i2c_npcx_controller_dma.c
@@ -159,7 +159,7 @@ void i2c_ctrl_handle_write_int_event(const struct device *dev)
 
 	/* START condition is issued */
 	if (data->oper_state == NPCX_I2C_WAIT_START) {
-		/* Write slave address with W bit */
+		/* Write target address with W bit */
 		i2c_ctrl_data_write(dev, ((data->addr << 1) & ~BIT(0)));
 
 		/* Start first DMA transmitted transaction */
@@ -180,7 +180,7 @@ void i2c_ctrl_handle_read_int_event(const struct device *dev)
 		/* Configure first DMA received transaction before sending address */
 		i2c_ctrl_dma_proceed_read(dev);
 
-		/* Write slave address with R bit */
+		/* Write target address with R bit */
 		i2c_ctrl_data_write(dev, ((data->addr << 1) | BIT(0)));
 
 		/* Start to proceed read process */

--- a/drivers/i2c/i2c_npcx_controller_fifo.c
+++ b/drivers/i2c/i2c_npcx_controller_fifo.c
@@ -35,7 +35,7 @@ static inline void i2c_ctrl_fifo_free_scl(const struct device *dev)
 	inst->SMBCTL4 |= BIT(NPCX_SMBCTL4_LVL_WE);
 	/*
 	 * Release SCL bus. Then it might be still driven by module itself or
-	 * slave device.
+	 * target device.
 	 */
 	inst->SMBCTL3 |= BIT(NPCX_SMBCTL3_SCL_LVL) | BIT(NPCX_SMBCTL3_SDA_LVL);
 	/* Disable writing to them */
@@ -62,7 +62,7 @@ static inline void i2c_ctrl_fifo_free_sda(const struct device *dev)
 	inst->SMBCTL4 |= BIT(NPCX_SMBCTL4_LVL_WE);
 	/*
 	 * Release SDA bus. Then it might be still driven by module itself or
-	 * slave device.
+	 * target device.
 	 */
 	inst->SMBCTL3 |= BIT(NPCX_SMBCTL3_SDA_LVL) | BIT(NPCX_SMBCTL3_SCL_LVL);
 	/* Disable writing to them */
@@ -155,7 +155,7 @@ void i2c_ctrl_handle_write_int_event(const struct device *dev)
 
 	/* START condition is issued */
 	if (data->oper_state == NPCX_I2C_WAIT_START || data->oper_state == NPCX_I2C_WAIT_RESTART) {
-		/* Write slave address with W bit */
+		/* Write target address with W bit */
 		i2c_ctrl_data_write(dev, ((data->addr << 1) & ~BIT(0)));
 		/* Start to proceed write process */
 		data->oper_state = NPCX_I2C_WRITE_DATA;
@@ -233,7 +233,7 @@ void i2c_ctrl_handle_read_int_event(const struct device *dev)
 		/* Setup threshold of rx FIFO before sending address byte */
 		i2c_ctrl_fifo_rx_setup_threshold_nack(dev, data->msg->len,
 						      (data->msg->flags & I2C_MSG_STOP) != 0);
-		/* Write slave address with R bit */
+		/* Write target address with R bit */
 		i2c_ctrl_data_write(dev, ((data->addr << 1) | BIT(0)));
 		/* Start to proceed read process */
 		data->oper_state = NPCX_I2C_READ_DATA;

--- a/drivers/i2c/i2c_realtek_rts5912.c
+++ b/drivers/i2c/i2c_realtek_rts5912.c
@@ -100,7 +100,7 @@ static inline int i2c_rts5912_reset_sda_stuck(const struct device *dev)
 	 * SDA line) and then this bit gets auto clear
 	 */
 	LOG_DBG("CLK Recovery Start");
-	/* initiate the Master Clock Reset */
+	/* initiate the Controller Clock Reset */
 	set_bit_enable_clk_reset(reg_base);
 	if (!WAIT_FOR(!test_bit_enable_clk_reset(reg_base), RECOVERY_TIME_US, NULL)) {
 		LOG_ERR("ERROR: CLK recovery Fail");

--- a/drivers/i2c/i2c_renesas_rx_riic.c
+++ b/drivers/i2c/i2c_renesas_rx_riic.c
@@ -66,7 +66,7 @@ struct i2c_rx_data {
 
 	/* Msgs to send and receive */
 	struct i2c_msg *msgs;
-	uint8_t slv_addr;
+	uint8_t target_addr;
 	uint8_t num_msgs;
 	uint8_t num_processed_msgs;
 #endif
@@ -200,7 +200,7 @@ static void riic_eei_isr(const struct device *dev)
 
 		static uint8_t first_byte;
 
-		first_byte = data->slv_addr << 1;
+		first_byte = data->target_addr << 1;
 		if ((data->msgs[data->num_processed_msgs].flags & I2C_MSG_RW_MASK) ==
 		    I2C_MSG_WRITE) {
 			first_byte &= W_CODE;
@@ -538,7 +538,7 @@ static int run_rx_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 	while (data->p_regs->ICCR2.BIT.BBSY == 1) {
 	}
 	/** Store msgs info */
-	data->slv_addr = addr;
+	data->target_addr = addr;
 	data->msgs = msgs;
 	data->num_msgs = num_msgs;
 	data->num_processed_msgs = 0;
@@ -555,7 +555,7 @@ static int run_rx_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 #else
 	if (addr == 0x00) {
 		/* Enter transmission pattern 4 */
-		LOG_DBG("RDP RX I2C master transmit pattern 4\n");
+		LOG_DBG("RDP RX I2C controller transmit pattern 4\n");
 		setup_rdp_info(data, NULL, 0, NULL, 0, NULL);
 		rdp_ret = R_RIIC_MasterSend(&data->rdp_info);
 		goto transfer_blocking;
@@ -563,14 +563,14 @@ static int run_rx_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 
 	if (num_msgs == 1) {
 		if (msgs[0].flags & I2C_MSG_READ) {
-			/* Enter master reception pattern 1 */
-			LOG_DBG("RDP RX I2C master reception pattern 1\n");
+			/* Enter controller reception pattern 1 */
+			LOG_DBG("RDP RX I2C controller reception pattern 1\n");
 			setup_rdp_info(data, NULL, 0, msgs[0].buf, msgs[0].len, &addr);
 			rdp_ret = R_RIIC_MasterReceive(&data->rdp_info);
 			goto transfer_blocking;
 		} else {
-			/* Enter master transmission pattern 2/3 */
-			LOG_DBG("RDP RX I2C master transmit pattern 2/3\n");
+			/* Enter controller transmission pattern 2/3 */
+			LOG_DBG("RDP RX I2C controller transmit pattern 2/3\n");
 			setup_rdp_info(data, NULL, 0, msgs[0].len ? msgs[0].buf : NULL, msgs[0].len,
 				       &addr);
 			rdp_ret = R_RIIC_MasterSend(&data->rdp_info);
@@ -582,15 +582,15 @@ static int run_rx_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 		}
 
 		if (msgs[1].flags & I2C_MSG_READ) {
-			/* Enter master reception pattern 2 */
-			LOG_DBG("RDP RX I2C master reception pattern 2\n");
+			/* Enter controller reception pattern 2 */
+			LOG_DBG("RDP RX I2C controller reception pattern 2\n");
 			setup_rdp_info(data, msgs[0].buf, msgs[0].len, msgs[1].buf, msgs[1].len,
 				       &addr);
 			rdp_ret = R_RIIC_MasterReceive(&data->rdp_info);
 			goto transfer_blocking;
 		} else {
-			/* Enter master transmission pattern 1 */
-			LOG_DBG("RDP RX I2C master transmit pattern 1\n");
+			/* Enter controller transmission pattern 1 */
+			LOG_DBG("RDP RX I2C controller transmit pattern 1\n");
 			setup_rdp_info(data, msgs[0].buf, msgs[0].len, msgs[1].buf, msgs[1].len,
 				       &addr);
 			rdp_ret = R_RIIC_MasterSend(&data->rdp_info);
@@ -603,13 +603,13 @@ unsupport_pattern:
 	LOG_DBG("%s: \"Not a generic pattern ...\" !\n", __func__);
 	for (uint8_t i = 0; i < num_msgs; i++) {
 		if (msgs[i].flags & I2C_MSG_READ) {
-			/* Enter master reception pattern 1 */
-			LOG_DBG("RDP RX I2C master reception pattern 1\n");
+			/* Enter controller reception pattern 1 */
+			LOG_DBG("RDP RX I2C controller reception pattern 1\n");
 			setup_rdp_info(data, NULL, 0, msgs[i].buf, msgs[i].len, &addr);
 			rdp_ret = R_RIIC_MasterReceive(&data->rdp_info);
 		} else {
-			/* Enter master transmission pattern 2 */
-			LOG_DBG("RDP RX I2C master transmit pattern 2/3\n");
+			/* Enter controller transmission pattern 2 */
+			LOG_DBG("RDP RX I2C controller transmit pattern 2/3\n");
 			setup_rdp_info(data, NULL, 0, (msgs[i].len) ? msgs[i].buf : NULL,
 				       msgs[i].len, &addr);
 			rdp_ret = R_RIIC_MasterSend(&data->rdp_info);
@@ -664,7 +664,7 @@ static int i2c_rx_init(const struct device *dev)
 	ret = R_RIIC_Open(&data->rdp_info);
 
 	if (ret) {
-		LOG_ERR("Open i2c master failed.");
+		LOG_ERR("Open i2c controller failed.");
 		return -EIO;
 	}
 
@@ -682,7 +682,7 @@ static int i2c_rx_configure(const struct device *dev, uint32_t dev_config)
 
 	/* Validate input */
 	if (!(dev_config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Only I2C Master mode supported.");
+		LOG_ERR("Only I2C Controller mode supported.");
 		return -ENOTSUP;
 	}
 	if (dev_config & I2C_ADDR_10_BITS) {
@@ -862,7 +862,7 @@ static DEVICE_API(i2c, i2c_rx_driver_api) = {
 			.num_blocks = 0,                                                           \
 			.length = 0,                                                               \
 	},                                                                                         \
-	.slv_addr = 0x00,                                                                          \
+	.target_addr = 0x00,                                                                       \
 	.msgs = NULL,                                                                              \
 	.num_msgs = 0,                                                                             \
 	.num_processed_msgs = 0,

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -100,12 +100,12 @@ static int i2c_sbcon_get_config(const struct device *dev, uint32_t *config)
 }
 
 static int i2c_sbcon_transfer(const struct device *dev, struct i2c_msg *msgs,
-				uint8_t num_msgs, uint16_t slave_address)
+				uint8_t num_msgs, uint16_t target_address)
 {
 	struct i2c_sbcon_context *context = dev->data;
 
 	return i2c_bitbang_transfer(&context->bitbang, msgs, num_msgs,
-							slave_address);
+							target_address);
 }
 
 static int i2c_sbcon_recover_bus(const struct device *dev)

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -242,9 +242,9 @@ static int i2c_sifive_configure(const struct device *dev, uint32_t dev_config)
 	sys_write8((uint8_t) (0xFF & (prescale >> 8)),
 		   I2C_REG(config, REG_PRESCALE_HIGH));
 
-	/* Support I2C Master mode only */
+	/* Support I2C Controller mode only */
 	if (!(dev_config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("I2C only supports operation as master");
+		LOG_ERR("I2C only supports operation as controller");
 		return -ENOTSUP;
 	}
 

--- a/drivers/i2c/i2c_sy1xx.c
+++ b/drivers/i2c/i2c_sy1xx.c
@@ -109,7 +109,7 @@ static int sy1xx_i2c_configure(const struct device *dev, uint32_t flags)
 	struct sy1xx_i2c_dev_data *const data = dev->data;
 
 	if (!(flags & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Master Mode is required");
+		LOG_ERR("Controller Mode is required");
 		return -EIO;
 	}
 

--- a/dts/bindings/i2c/ambiq,ios-i2c.yaml
+++ b/dts/bindings/i2c/ambiq,ios-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Ambiq Micro Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Ambiq IOS I2C target (slave) peripheral
+description: Ambiq IOS I2C target peripheral
 
 compatible: "ambiq,ios-i2c"
 

--- a/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
@@ -7,8 +7,8 @@ description: |
   The Atmel Two-wire Master Interface (TWIM) interconnects components on a
   unique two-wire bus, made up of one clock line and one data line with speeds
   of up to 3.4 Mbit/s, based on a byte-oriented transfer format.  The TWIM is
-  always a bus master and can transfer sequential or single bytes.  Multiple
-  master capability is supported.  Arbitration of the bus is performed
+  always a bus controller and can transfer sequential or single bytes.  Multiple
+  controller capability is supported.  Arbitration of the bus is performed
   internally and relinquishes the bus automatically if the bus arbitration is
   lost.
 
@@ -191,7 +191,7 @@ properties:
     required: true
     description: |
       3-bit code to be prefixed with 0b00001 to form a unique
-      8-bit HS-mode master code (0000 1XXX)
+      8-bit HS-mode controller code (0000 1XXX)
     enum:
       - 0   # 000
       - 1   # 001

--- a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
@@ -53,8 +53,8 @@ properties:
     description: |
       Set this property if the I2C controller is used as a wake source for
       the SoC. When set, the driver arms the SMB block's native START-bit
-      wake detector during PM suspend so an external master initiating a
+      wake detector during PM suspend so an external controller initiating a
       transaction wakes the EC. The hardware auto clock-stretches SCL
       until clocks are restored, so no data is lost. Only effective for
-      target-mode use (a controller-only master initiates STARTs and does
+      target-mode use (a controller-only device initiates STARTs and does
       not need wake).

--- a/dts/bindings/i2c/renesas,rx-i2c.yaml
+++ b/dts/bindings/i2c/renesas,rx-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Renesas RX I2C Master controller
+description: Renesas RX I2C controller
 
 compatible: "renesas,rx-i2c"
 


### PR DESCRIPTION
This PR migrates the internals of the I2C drivers to inclusive terminology, following coding guideline [Rule A.2](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#inclusive-language): master/slave becomes controller/target, the replacement pair ratified for I2C by the I2C specification rev 7 (NXP UM10204) and already used by Zephyr's public I2C API (`I2C_MODE_CONTROLLER`, `i2c_target_config`, `i2c_target_register`, ...).

The public API migrated long ago; this series completes the job inside `drivers/i2c`, where comments, log messages, Kconfig prose, and driver-local identifiers still used the former terminology. There are no functional changes, no public API changes, and no deprecations — every commit is limited to one driver (or vendor family) and the tree builds identically at every point of the series.

## What changed

- **Driver-local identifiers**: functions, struct members, and driver-composed macros defined within each driver are renamed (e.g. `i2c_mcux_master_transfer_callback` → `i2c_mcux_controller_transfer_callback`, `RCAR_I2C_ICMCR_MASTER` → `RCAR_I2C_ICMCR_CONTROLLER` for the driver-composed convenience mask).
- **Comments, doxygen prose, and log/shell strings** throughout the drivers.
- **Kconfig prompts and help text** (e.g. "Renesas RX I2C Master" → "Renesas RX I2C Controller", target clock-stretching wording in the GPIO bitbang driver).
- **Binding descriptions** in `dts/bindings/i2c` (including the HS-mode controller code wording, which rev 7 of the I2C specification also renamed).

## Not changed (vendor and specification naming)

- Vendor HAL/SDK identifiers referenced by the drivers: NXP MCUX (`I2C_Master*`, `kI2C_Slave*`), Renesas FSP (`i2c_master_cfg_t`, `R_IIC_MASTER_*`), ESP-IDF (`i2c_ll_master_*`, `I2C_SLAVE_*`), Cypress/Infineon PDL (`CY_SCB_I2C_SLAVE_*`), TI driverlib (`I2CMaster*`, `I2C_MASTER_CMD_*`), ST LL (`LL_I2C_SetMasterAddressingMode`), Nuvoton, Telink, Ambiq, and others, as noted in the respective commit messages.
- Register, bitfield, and status-code names mirroring chip datasheets and IP databooks — DesignWare `IC_CON` bitfields, R-Car `ICMCR`/`ICMSR` mnemonics, Atmel TWI/SERCOM mode bits, ITE/NPCX/LPC register maps, LiteX CSR names — along with the comments that spell out their datasheet names, so the mnemonics remain traceable to vendor documentation.
- Devicetree compatibles and property names (e.g. `hs-master-code`), Kconfig symbol names, and vendor documentation URLs.