### PR TITLE
drivers: wifi: nrf_wifi: off_raw_tx: Add operating band selection

### DIFF
--- a/drivers/wifi/nrf_wifi/off_raw_tx/src/off_raw_tx_api.c
+++ b/drivers/wifi/nrf_wifi/off_raw_tx/src/off_raw_tx_api.c
@@ -308,6 +308,39 @@ static bool validate_rate(enum nrf_wifi_off_raw_tx_tput_mode tput_mode,
 	return true;
 }
 
+static bool validate_chan_band(enum nrf_wifi_off_raw_tx_band band, unsigned int chan)
+{
+	switch (band) {
+	case NRF_WIFI_OFF_RAW_TX_BAND_2GHZ:
+		if (chan < 1 || chan > 14) {
+			LOG_ERR("%s: Channel %u is not a valid 2.4 GHz channel",
+				__func__, chan);
+			return false;
+		}
+		break;
+	case NRF_WIFI_OFF_RAW_TX_BAND_5GHZ:
+		if (chan < 32 || chan > 177) {
+			LOG_ERR("%s: Channel %u is not a valid 5 GHz channel",
+				__func__, chan);
+			return false;
+		}
+		break;
+	case NRF_WIFI_OFF_RAW_TX_BAND_6GHZ:
+		LOG_ERR("%s: 6 GHz band is not supported on nRF70", __func__);
+		return false;
+	case NRF_WIFI_OFF_RAW_TX_BAND_AUTO:
+	default:
+		if ((chan >= 1 && chan <= 14) || (chan >= 32 && chan <= 177)) {
+			break;
+		}
+		LOG_ERR("%s: Channel %u is not valid for AUTO band selection",
+			__func__, chan);
+		return false;
+	}
+
+	return true;
+}
+
 int nrf_wifi_off_raw_tx_conf_update(struct nrf_wifi_off_raw_tx_conf *conf)
 {
 	int ret = -1;
@@ -346,6 +379,11 @@ int nrf_wifi_off_raw_tx_conf_update(struct nrf_wifi_off_raw_tx_conf *conf)
 	if (!validate_rate(conf->tput_mode, conf->rate)) {
 		LOG_ERR("%s Invalid rate. Throughput mode: %d, rate: %d\n", __func__,
 				      conf->tput_mode, conf->rate);
+		goto out;
+	}
+
+	if (!validate_chan_band(conf->band, conf->chan)) {
+		LOG_ERR("%s: Invalid channel or band", __func__);
 		goto out;
 	}
 

--- a/drivers/wifi/nrf_wifi/src/wifi_util.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_util.c
@@ -1112,7 +1112,7 @@ static int nrf_wifi_util_req_extended_sleep(const struct shell *sh,
 
 	val = strtoul(argv[1], &ptr, 10);
 
-	if ((val < 0) || (val > UINT_MAX)) {
+	if (val > UINT_MAX) {
 		shell_fprintf(sh,
 			      SHELL_ERROR,
 			      "Invalid value(%lu).\n",

--- a/include/zephyr/drivers/wifi/nrf_wifi/off_raw_tx/off_raw_tx_api.h
+++ b/include/zephyr/drivers/wifi/nrf_wifi/off_raw_tx/off_raw_tx_api.h
@@ -105,6 +105,22 @@ enum nrf_wifi_off_raw_tx_he_ltf {
 };
 
 /**
+ * @brief- Operating band
+ * Band on which the channel resides. Needed because channel numbers overlap
+ * across bands (e.g. channel 1 exists in both 2.4 GHz and 6 GHz).
+ */
+enum nrf_wifi_off_raw_tx_band {
+	/** Infer the band from the channel number (2.4 GHz: 1-14, 5 GHz: 32-177) */
+	NRF_WIFI_OFF_RAW_TX_BAND_AUTO,
+	/** 2.4 GHz band */
+	NRF_WIFI_OFF_RAW_TX_BAND_2GHZ,
+	/** 5 GHz band */
+	NRF_WIFI_OFF_RAW_TX_BAND_5GHZ,
+	/** 6 GHz band (nRF71 series only) */
+	NRF_WIFI_OFF_RAW_TX_BAND_6GHZ,
+};
+
+/**
  * @brief- Throughput mode
  * Throughput mode to be used for transmitting the packet.
  */
@@ -145,6 +161,7 @@ struct nrf_wifi_off_raw_tx_conf {
 	unsigned int tx_pwr;
 	/** Channel number on which to transmit */
 	unsigned int chan;
+	enum nrf_wifi_off_raw_tx_band band;
 	/** Set to TRUE to use short preamble for FALSE to disable short preamble */
 	bool short_preamble;
 	/* Number of times a packet should be retried at each possible rate */


### PR DESCRIPTION
Channel numbers overlap across the 2.4 GHz, 5 GHz and 6 GHz bands (e.g. channel 1 exists in both 2.4 GHz and 6 GHz), so the channel number alone is not enough to select a band on nRF71.

Add a nrf_wifi_off_raw_tx_band enum and a band field to struct nrf_wifi_off_raw_tx_conf so the caller can specify the band explicitly, defaulting to AUTO (inferred from the channel number).

Drop dead check in extended sleep shell cmd