### PR TITLE
[Backport v4.4-branch] drivers: bluetooth: hci: ipm_stm32: Get interrupts from the DT

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -21,6 +21,14 @@
 #include "shci.h"
 #include "shci_tl.h"
 
+#define STM32_IPCC_RX_IRQ	DT_INST_IRQ_BY_NAME(0, rx, irq)
+#define STM32_IPCC_RX_IRQ_PRIO	DT_INST_IRQ_BY_NAME(0, rx, priority)
+#define STM32_IPCC_TX_IRQ	DT_INST_IRQ_BY_NAME(0, tx, irq)
+#define STM32_IPCC_TX_IRQ_PRIO	DT_INST_IRQ_BY_NAME(0, tx, priority)
+
+BUILD_ASSERT(STM32_IPCC_RX_IRQ == IPCC_C1_RX_IRQn, "Unexpected IRQ number for IPCC Rx");
+BUILD_ASSERT(STM32_IPCC_TX_IRQ == IPCC_C1_TX_IRQn, "Unexpected IRQ number for IPCC Tx");
+
 struct hci_data {
 	bt_hci_recv_t recv;
 };
@@ -396,8 +404,8 @@ void ipcc_reset(void)
 		LL_IPCC_CHANNEL_4 | LL_IPCC_CHANNEL_5 | LL_IPCC_CHANNEL_6);
 
 	/* Set IPCC default IRQ handlers */
-	IRQ_CONNECT(IPCC_C1_RX_IRQn, 0, HW_IPCC_Rx_Handler, NULL, 0);
-	IRQ_CONNECT(IPCC_C1_TX_IRQn, 0, HW_IPCC_Tx_Handler, NULL, 0);
+	IRQ_CONNECT(STM32_IPCC_RX_IRQ, STM32_IPCC_RX_IRQ_PRIO, HW_IPCC_Rx_Handler, NULL, 0);
+	IRQ_CONNECT(STM32_IPCC_TX_IRQ, STM32_IPCC_TX_IRQ_PRIO, HW_IPCC_Tx_Handler, NULL, 0);
 }
 
 void transport_init(void)

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -649,6 +649,9 @@
 		compatible = "st,stm32wb-rf";
 		clocks = <&rcc STM32_CLOCK(AHB3, 20)>,
 			 <&rcc STM32_SRC_LSE RFWKP_SEL(1)>;
+		interrupt-parent = <&nvic>;
+		interrupts = <44 0>, <45 0>;
+		interrupt-names = "rx", "tx";
 	};
 
 	smbus1: smbus1 {

--- a/dts/bindings/bluetooth/st,stm32wb-rf.yaml
+++ b/dts/bindings/bluetooth/st,stm32wb-rf.yaml
@@ -11,9 +11,19 @@ include: bt-hci.yaml
 properties:
   clocks:
     required: true
+
   bt-hci-name:
     default: "BT IPM"
+
   bt-hci-bus:
     default: "ipc"
+
   bt-hci-quirks:
     default: ["no-reset"]
+
+  interrupts:
+    required: true
+
+  interrupt-names:
+    required: true
+    enum: ["rx", "tx"]


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/pull/115380 to v4.4-branch.

Fixes: #114857
Fixes: #115944
