### PR TITLE
dap: report a connect failure when the port cannot be enabled

### DIFF
--- a/subsys/dap/cmsis_dap.c
+++ b/subsys/dap/cmsis_dap.c
@@ -194,7 +194,12 @@ static uint16_t dap_connect(struct dap_link_context *const ctx,
 			break;
 		}
 
-		(void)swdp_port_on(ctx->dev);
+		if (swdp_port_on(ctx->dev) != 0) {
+			LOG_ERR("failed to enable debug port");
+			atomic_clear_bit(&ctx->state, DAP_STATE_CONNECTED);
+			ctx->debug_port = DAP_PORT_DISABLED;
+			port = DAP_PORT_DISABLED;
+		}
 		break;
 	case DAP_PORT_JTAG:
 		LOG_ERR("port unsupported");


### PR DESCRIPTION
## Why this change

`swdp_port_on()` returns an error code, but `dap_connect()` ignores it and always answers `DAP_PORT_SWD`. So when the debug port cannot be enabled — for example the driver fails to configure its pins, or the port is not available at that moment — the host is told the connect worked. It then starts a debug session in which every transfer fails, and nothing on the wire explains why.

The CMSIS-DAP protocol already defines the correct answer: the `DAP_Connect` response byte is the port that was actually initialized, and `0` (`DAP_PORT_DISABLED`) means the connect failed. Hosts handle this today — pyOCD and OpenOCD both check the response byte and abort cleanly when it is 0.

The stale state left behind is a problem of its own, in two ways:

- a later `DAP_Disconnect` calls `swdp_port_off()` for a port that was never turned on — an unbalanced release the driver can only report as an error on an already-failed path;
- a retried `DAP_Connect` returns early on the still-set `DAP_STATE_CONNECTED` bit instead of attempting the port again, so a single failed enable wedges the connect path until reset.

## What changed

Check the return of `swdp_port_on()`. On failure, answer `DAP_PORT_DISABLED` and clear `DAP_STATE_CONNECTED` and `ctx->debug_port`, so both a disconnect and a retried connect behave correctly afterwards.

## Testing

Verified on hardware with a probe firmware whose swdp driver can refuse `port_on()` (shared pins held by another interface): with the fix, the failed connect answers 0, no unbalanced `port_off` follows, and a later `DAP_Connect` succeeds once the pins are free; without the fix, the same situation answers 1 and the host proceeds into a dead session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
