### PR TITLE
bluetooth: mesh: add frend request scan time

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -244,6 +244,7 @@ New APIs and options
     * :c:struct:`bt_mesh_lpn_timing`
     * :c:func:`bt_mesh_stat_lpn_timing_get`
     * :c:func:`bt_mesh_stat_lpn_timing_reset`
+    * :kconfig:option:`CONFIG_BT_MESH_LPN_OFFER_WAIT_TIMEOUT`
 
 * Crypto
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1617,6 +1617,19 @@ config BT_MESH_LPN_ESTABLISHMENT
 	  until it has successfully set up Friendship with a Friend
 	  node.
 
+config BT_MESH_LPN_OFFER_WAIT_TIMEOUT
+	int "Time to wait for Friend Offers after a Friend Request"
+	default 1000
+	range 100 10000
+	help
+	  Time in milliseconds that the Low Power node waits for Friend Offer
+	  messages, starting 100 ms after the Friend Request was sent. The
+	  Bluetooth Mesh Protocol specification recommends listening for up to
+	  1 second. When BT_MESH_LPN_ESTABLISHMENT is enabled, this is also the
+	  duration for which the scanner is kept enabled. If no acceptable
+	  Friend Offer is received, the next Friend Request is sent after
+	  BT_MESH_LPN_RETRY_TIMEOUT.
+
 config BT_MESH_LPN_AUTO
 	bool "Automatically start looking for Friend nodes once provisioned"
 	default y

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -56,7 +56,7 @@ LOG_MODULE_REGISTER(bt_mesh_lpn);
 #define FRIEND_REQ_RETRY_TIMEOUT  K_SECONDS(CONFIG_BT_MESH_LPN_RETRY_TIMEOUT)
 
 #define FRIEND_REQ_WAIT           100
-#define FRIEND_REQ_SCAN           (1 * MSEC_PER_SEC)
+#define FRIEND_REQ_SCAN           CONFIG_BT_MESH_LPN_OFFER_WAIT_TIMEOUT
 #define FRIEND_REQ_TIMEOUT        (FRIEND_REQ_WAIT + FRIEND_REQ_SCAN)
 
 #define POLL_RETRY_TIMEOUT        100
@@ -76,6 +76,9 @@ LOG_MODULE_REGISTER(bt_mesh_lpn);
 			  (REQ_ATTEMPTS(lpn) * REQ_RETRY_DURATION(lpn)))
 
 #define CLEAR_ATTEMPTS            3
+
+/* The specification defines no Friend Clear Confirm timeout for the Low Power node. */
+#define FRIEND_CLEAR_TIMEOUT      (1 * MSEC_PER_SEC)
 
 #define LPN_CRITERIA ((CONFIG_BT_MESH_LPN_MIN_QUEUE_SIZE) | \
 		      (CONFIG_BT_MESH_LPN_RSSI_FACTOR << 3) | \
@@ -199,7 +202,7 @@ static void friend_clear_sent(int err, void *user_data)
 	}
 
 	lpn_set_state(BT_MESH_LPN_CLEAR);
-	k_work_reschedule(&lpn->timer, K_MSEC(FRIEND_REQ_TIMEOUT));
+	k_work_reschedule(&lpn->timer, K_MSEC(FRIEND_CLEAR_TIMEOUT));
 }
 
 static const struct bt_mesh_send_cb clear_sent_cb = {


### PR DESCRIPTION
 Add BT_MESH_LPN_OFFER_WAIT_TIMEOUT to configure how long the Low
    Power node listens for Friend Offer messages after sending a Friend
    Request. The Mesh Protocol specification section 3.6.6.4.1
    recommends up to 1 second, but the optimal value depends on the
    deployment, so keep 1000 ms as the default and allow tuning it.
    
 Also introduce a separate FRIEND_CLEAR_TIMEOUT for the Friend Clear
    Confirm wait. The specification defines no timeout for it, so it
    must not change when the Friend Offer window is tuned.