### PR TITLE
tests: kernel: memorty protection: overhaul documentation

### DIFF
--- a/tests/kernel/mem_protect/demand_paging/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/mem_map/src/main.c
@@ -83,6 +83,27 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 #define HALF_BYTES	(HALF_PAGES * CONFIG_MMU_PAGE_SIZE)
 static const char *nums = "0123456789";
 
+/**
+ * @brief Verify that more anonymous memory than free RAM can be mapped.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Demand paging is what lets a mapping exceed physical memory: the arena
+ * requested here is deliberately larger than the free RAM by half the backing
+ * store, so it can only be satisfied if the kernel is prepared to page. The
+ * arena created here is the fixture every later case in the suite works on.
+ *
+ * Test steps:
+ * - Query the free memory and request an arena that much plus half the
+ *   spare backing-store capacity.
+ * - Map it with k_mem_map().
+ *
+ * Expected result:
+ * - The over-committed mapping succeeds and returns a usable arena.
+ *
+ * @see k_mem_map()
+ */
 ZTEST(demand_paging, test_map_anon_pages)
 {
 	arena_size = k_mem_free_get() + HALF_BYTES;
@@ -200,21 +221,108 @@ static void touch_anon_pages(bool zig, bool zag)
 	}
 }
 
+/**
+ * @brief Verify that touching the whole arena pages in, evicts and preserves
+ *        data.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Walking an arena larger than RAM forces the full demand paging cycle:
+ * never-touched pages arrive zeroed, writes fault pages in and push dirty
+ * pages out to the backing store, and everything written must read back
+ * intact after having been evicted and restored. The page fault counter and
+ * the paging statistics -- global and per thread -- confirm the machinery
+ * actually ran instead of the arena silently fitting in RAM.
+ *
+ * Test steps:
+ * - Read the whole arena and check every byte is zero.
+ * - Write each location's own address into it, then read it all back.
+ * - Check the fault count is non-zero and dirty evictions occurred.
+ * - Read the (now unmodified) arena again and check clean evictions occurred.
+ * - Check the same counters in the current thread's statistics.
+ *
+ * Expected result:
+ * - All data survives eviction and page-in, and the fault and eviction
+ *   statistics show the paging happened.
+ *
+ * @see k_mem_paging_stats_get()
+ * @see k_mem_paging_thread_stats_get()
+ * @see k_mem_num_pagefaults_get()
+ */
 ZTEST(demand_paging, test_touch_anon_pages)
 {
 	touch_anon_pages(false, false);
 }
 
+/**
+ * @brief Verify demand paging with reads and writes in opposing directions.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The same full-arena walk as the linear case, but reading the arena
+ * backwards while writing it forwards. Traversal direction changes which
+ * pages are resident when each access lands, so an eviction policy that only
+ * survives sequential access is caught here.
+ *
+ * Test steps:
+ * - Run the arena walk with reads descending and writes ascending.
+ *
+ * Expected result:
+ * - Identical to the linear case: data survives and the paging statistics
+ *   show faults and evictions.
+ *
+ * @see k_mem_paging_stats_get()
+ */
 ZTEST(demand_paging, test_touch_anon_pages_zigzag1)
 {
 	touch_anon_pages(true, false);
 }
 
+/**
+ * @brief Verify demand paging with the opposite zig-zag pattern.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The mirror of the first zig-zag case: reads ascend while writes descend,
+ * covering the remaining combination of traversal directions.
+ *
+ * Test steps:
+ * - Run the arena walk with reads ascending and writes descending.
+ *
+ * Expected result:
+ * - Identical to the linear case: data survives and the paging statistics
+ *   show faults and evictions.
+ *
+ * @see k_mem_paging_stats_get()
+ */
 ZTEST(demand_paging, test_touch_anon_pages_zigzag2)
 {
 	touch_anon_pages(false, true);
 }
 
+/**
+ * @brief Verify that unmapping a demand-paged region revokes access.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * k_mem_unmap() on a demand-paged arena has to tear down the whole region,
+ * including pages currently paged out, so any later access faults rather than
+ * resurrecting stale data. The suite's fatal error handler converts the
+ * expected fault into a pass.
+ *
+ * Test steps:
+ * - Unmap the arena with k_mem_unmap().
+ * - Write to the first byte of the former arena.
+ *
+ * Expected result:
+ * - The access faults; the code after it is never reached.
+ *
+ * @see k_mem_unmap()
+ */
 ZTEST(demand_paging, test_unmap_anon_pages)
 {
 	 k_mem_unmap(arena, arena_size);
@@ -259,6 +367,28 @@ static void test_k_mem_page_out(void)
 
 }
 
+/**
+ * @brief Verify that k_mem_page_in() makes a region resident.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Preemptively paging a region in must leave every page resident, so
+ * touching it afterwards causes no faults at all -- that absence, measured
+ * with interrupts locked so nothing else can fault in between, is the
+ * observable effect of the call.
+ *
+ * Test steps:
+ * - Page half the arena out with k_mem_page_out().
+ * - Page the same range back in with k_mem_page_in().
+ * - With interrupts locked, write the whole range and count the faults.
+ *
+ * Expected result:
+ * - Zero page faults are taken while writing the paged-in range.
+ *
+ * @see k_mem_page_in()
+ * @see k_mem_page_out()
+ */
 ZTEST(demand_paging_api, test_k_mem_page_in)
 {
 	unsigned long faults;
@@ -286,6 +416,28 @@ ZTEST(demand_paging_api, test_k_mem_page_in)
 		      faults);
 }
 
+/**
+ * @brief Verify that k_mem_pin() keeps a region resident under pressure.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A pinned region must stay resident no matter how much paging traffic the
+ * rest of the arena generates. The rest of the arena, which is larger than
+ * RAM, is written first to force evictions; the pinned range must then be
+ * writable without a single fault.
+ *
+ * Test steps:
+ * - Pin half the arena with k_mem_pin().
+ * - Write the rest of the over-committed arena to force eviction pressure.
+ * - With interrupts locked, write the pinned range and count the faults.
+ * - Unpin the range.
+ *
+ * Expected result:
+ * - Zero page faults are taken in the pinned range despite the pressure.
+ *
+ * @see k_mem_pin()
+ */
 ZTEST(demand_paging_api, test_k_mem_pin)
 {
 	unsigned long faults;
@@ -314,6 +466,30 @@ ZTEST(demand_paging_api, test_k_mem_pin)
 	k_mem_unpin(arena, HALF_BYTES);
 }
 
+/**
+ * @brief Verify that k_mem_unpin() makes a region evictable again.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Unpinning must fully undo the pin: the region becomes an ordinary evictable
+ * range again. That is shown by re-running the page-out scenario on it --
+ * evicting the range succeeds, writing it back faults once per page, and
+ * paging out more than the backing store can hold still fails with -ENOMEM.
+ *
+ * Test steps:
+ * - Pin and then unpin half the arena.
+ * - Page the range out and check it succeeds.
+ * - With interrupts locked, write the range and count one fault per page.
+ * - Attempt to page out the whole over-committed arena.
+ *
+ * Expected result:
+ * - The unpinned range pages out and faults back in normally, and the
+ *   oversized page-out fails with -ENOMEM.
+ *
+ * @see k_mem_unpin()
+ * @see k_mem_page_out()
+ */
 ZTEST(demand_paging_api, test_k_mem_unpin)
 {
 	/* Pin the memory (which we know works from prior test) */
@@ -326,9 +502,31 @@ ZTEST(demand_paging_api, test_k_mem_unpin)
 	test_k_mem_page_out();
 }
 
-/* Show that even if we map enough anonymous memory to fill the backing
- * store, we can still handle pagefaults.
- * This eats up memory so should be last in the suite.
+/**
+ * @brief Verify that paging still works with the backing store nearly full.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Filling almost the entire backing store must not wedge the paging
+ * machinery: page faults have to keep being served even when eviction has
+ * nowhere spare to go. Without CONFIG_DEMAND_MAPPING a further mapping must
+ * be refused outright; with it, the mapping succeeds because pages are only
+ * committed when touched. This case consumes the remaining memory, so it
+ * runs in the suite that executes last.
+ *
+ * Test steps:
+ * - Map enough anonymous memory to fill the backing store except one page.
+ * - Attempt one more page mapping and check the configuration-dependent
+ *   outcome.
+ * - With interrupts locked, write both the old arena and the new mapping and
+ *   count the faults.
+ *
+ * Expected result:
+ * - The writes complete with page faults still being handled at capacity.
+ *
+ * @see k_mem_map()
+ * @see k_mem_num_pagefaults_get()
  */
 ZTEST(demand_paging_stat, test_backing_store_capacity)
 {
@@ -367,7 +565,31 @@ ZTEST(demand_paging_stat, test_backing_store_capacity)
 	zassert_not_equal(faults, 0, "should have had some pagefaults");
 }
 
-/* Test if we can get paging statistics under usermode */
+/**
+ * @brief Verify that paging statistics are readable from user mode.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The statistics queries are system calls, so a user thread must be able to
+ * read both the global and its own per-thread paging counters, and the values
+ * seen through the syscall path must reflect the paging activity earlier
+ * cases generated rather than coming back empty.
+ *
+ * Test steps:
+ * - From a user thread, read the global statistics with
+ *   k_mem_paging_stats_get().
+ * - Read the calling thread's statistics with
+ *   k_mem_paging_thread_stats_get().
+ * - Check the fault and eviction counters in both are non-zero.
+ *
+ * Expected result:
+ * - Both queries succeed from user mode and report the paging activity that
+ *   already took place.
+ *
+ * @see k_mem_paging_stats_get()
+ * @see k_mem_paging_thread_stats_get()
+ */
 ZTEST_USER(demand_paging_stat, test_user_get_stats)
 {
 	struct k_mem_paging_stats_t stats;
@@ -425,7 +647,28 @@ static bool print_histogram(struct k_mem_paging_histogram_t *hist)
 	return has_non_zero;
 }
 
-/* Test if we can get paging timing histograms */
+/**
+ * @brief Verify that paging timing histograms are readable from user mode.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * With CONFIG_DEMAND_PAGING_TIMING_HISTOGRAM the kernel bins the time spent
+ * evicting, paging in and paging out. Each histogram query is a system call,
+ * and after the paging traffic of the earlier cases every histogram must
+ * contain samples.
+ *
+ * Test steps:
+ * - From a user thread, read the eviction, page-in and page-out histograms.
+ * - Check each histogram has at least one non-zero bin.
+ *
+ * Expected result:
+ * - All three histograms are readable from user mode and carry samples.
+ *
+ * @see k_mem_paging_histogram_eviction_get()
+ * @see k_mem_paging_histogram_backing_store_page_in_get()
+ * @see k_mem_paging_histogram_backing_store_page_out_get()
+ */
 ZTEST_USER(demand_paging_stat, test_user_get_hist)
 {
 	struct k_mem_paging_histogram_t hist;

--- a/tests/kernel/mem_protect/demand_paging/ondemand_section/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/ondemand_section/src/main.c
@@ -19,6 +19,34 @@ static void __ondemand_func evictable_function(void)
 	printk("This %s code, count=%d\n", message, ++count);
 }
 
+/**
+ * @brief Verify that code in an on-demand section is paged in and evictable.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Code and data placed in an on-demand linker section are not resident at
+ * boot: the first access has to fault them in, they stay resident until
+ * evicted, and they can be evicted and fetched back explicitly. The kernel's
+ * page fault counter is what makes each transition observable, since it is
+ * sampled either side of every call to the evictable function rather than
+ * inferred from the call succeeding.
+ *
+ * Test steps:
+ * - Call the on-demand function and confirm the fault count rose.
+ * - Call it again and confirm the count did not move, so it stayed resident.
+ * - Evict its page with k_mem_page_out() and call it again, expecting a fault.
+ * - Evict it once more, then fetch it back with k_mem_page_in().
+ * - Call it a final time and confirm no fault was taken.
+ *
+ * Expected result:
+ * - The first call and the call after each eviction fault; the call while
+ *   resident and the call after an explicit page-in do not.
+ *
+ * @see k_mem_page_out()
+ * @see k_mem_page_in()
+ * @see k_mem_num_pagefaults_get()
+ */
 ZTEST(ondemand_section, test_ondemand_basic)
 {
 	unsigned long faults_before, faults_after;

--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -165,7 +165,25 @@ static void futex_multiple_wait_wake_task(void *p1, void *p2, void *p3)
  */
 
 /**
- * @brief Test k_futex_wait() forever
+ * @brief Verify that k_futex_wait() with K_FOREVER blocks while the value
+ *        matches.
+ *
+ * @details
+ * A futex wait whose expected value matches the futex must put the caller to
+ * sleep indefinitely: nothing wakes it, so the waiter's post-wait code -- an
+ * atomic decrement of the futex value -- must never run. The value still
+ * being non-zero after the waiter had time to run is what shows it stayed
+ * blocked.
+ *
+ * Test steps:
+ * - Set the futex value and spawn a user thread that waits on it with
+ *   K_FOREVER and decrements the value after waking.
+ * - Yield so the waiter runs, then check the futex value.
+ *
+ * Expected result:
+ * - The value is unchanged: the waiter blocked and never woke.
+ *
+ * @see k_futex_wait()
  */
 ZTEST(futex, test_futex_wait_forever)
 {
@@ -187,6 +205,25 @@ ZTEST(futex, test_futex_wait_forever)
 	k_thread_abort(&futex_tid);
 }
 
+/**
+ * @brief Verify that k_futex_wait() returns control after a finite
+ *        timeout expires.
+ *
+ * @details
+ * With a finite timeout and no waker, the wait must end on its own once the
+ * timeout elapses, returning control to the waiter, which then decrements the
+ * futex value. The decrement having happened is what shows the timeout path
+ * completed.
+ *
+ * Test steps:
+ * - Set the futex value and spawn a user thread waiting with a 50 ms timeout.
+ * - Sleep past the timeout, then check the futex value.
+ *
+ * Expected result:
+ * - The waiter timed out and ran its post-wait code, so the value is zero.
+ *
+ * @see k_futex_wait()
+ */
 ZTEST(futex, test_futex_wait_timeout)
 {
 	timeout = k_ms_to_ticks_ceil32(50);
@@ -207,6 +244,23 @@ ZTEST(futex, test_futex_wait_timeout)
 	k_thread_abort(&futex_tid);
 }
 
+/**
+ * @brief Verify that k_futex_wait() with K_NO_WAIT returns immediately.
+ *
+ * @details
+ * A zero timeout turns the wait into a poll: the call must come back at once
+ * with -ETIMEDOUT instead of blocking. The waiter thread checks that return
+ * and then decrements the futex value, which is what the test observes.
+ *
+ * Test steps:
+ * - Set the futex value and spawn a user thread waiting with K_NO_WAIT.
+ * - Give it time to run, then check the futex value.
+ *
+ * Expected result:
+ * - The waiter returned immediately with -ETIMEDOUT and ran on.
+ *
+ * @see k_futex_wait()
+ */
 ZTEST(futex, test_futex_wait_nowait)
 {
 	timeout = 0;
@@ -227,7 +281,25 @@ ZTEST(futex, test_futex_wait_nowait)
 }
 
 /**
- * @brief Test k_futex_wait() and k_futex_wake()
+ * @brief Verify that k_futex_wake() wakes a waiter blocked with K_FOREVER.
+ *
+ * @details
+ * The basic handshake: one thread blocks on the futex forever, another calls
+ * k_futex_wake(), and the wake must both return the number of threads woken
+ * and actually unblock the waiter, whose post-wait decrement is what the test
+ * observes.
+ *
+ * Test steps:
+ * - Set the futex value and spawn a user thread waiting with K_FOREVER.
+ * - Spawn a second user thread that wakes one waiter and checks the count.
+ * - Yield, then check the futex value.
+ *
+ * Expected result:
+ * - The wake reports one thread woken and the waiter resumed, so the value
+ *   is zero.
+ *
+ * @see k_futex_wake()
+ * @see k_futex_wait()
  */
 ZTEST(futex, test_futex_wait_forever_wake)
 {
@@ -261,6 +333,27 @@ ZTEST(futex, test_futex_wait_forever_wake)
 	k_thread_abort(&futex_tid);
 }
 
+/**
+ * @brief Verify that a wake arriving before the timeout ends the wait early.
+ *
+ * @details
+ * When a waiter has a finite timeout and a wake arrives first, the wait must
+ * complete as a wake -- returning success to the waiter -- rather than
+ * waiting out the rest of the timeout.
+ *
+ * Test steps:
+ * - Set the futex value and spawn a user thread waiting with a 100 ms
+ *   timeout.
+ * - Spawn a waker before the timeout can expire and let both run.
+ * - Check the futex value.
+ *
+ * Expected result:
+ * - The waiter was woken (returning 0, not -ETIMEDOUT) and ran its post-wait
+ *   code before the timeout elapsed.
+ *
+ * @see k_futex_wake()
+ * @see k_futex_wait()
+ */
 ZTEST(futex, test_futex_wait_timeout_wake)
 {
 	woken = 1;
@@ -294,6 +387,24 @@ ZTEST(futex, test_futex_wait_timeout_wake)
 	k_thread_abort(&futex_tid);
 }
 
+/**
+ * @brief Verify that a wake finds no waiter after a K_NO_WAIT poll.
+ *
+ * @details
+ * A thread that polled with K_NO_WAIT is no longer waiting by the time a
+ * wake is issued, so the wake must report zero threads woken rather than
+ * counting the poller.
+ *
+ * Test steps:
+ * - Spawn a user thread that polls the futex with K_NO_WAIT and returns.
+ * - After it has finished, spawn a waker expecting to wake zero threads.
+ *
+ * Expected result:
+ * - The wake reports no threads woken.
+ *
+ * @see k_futex_wake()
+ * @see k_futex_wait()
+ */
 ZTEST(futex, test_futex_wait_nowait_wake)
 {
 	woken = 0;
@@ -321,6 +432,25 @@ ZTEST(futex, test_futex_wait_nowait_wake)
 	k_thread_abort(&futex_tid);
 }
 
+/**
+ * @brief Verify that k_futex_wake() works from interrupt context.
+ *
+ * @details
+ * Waking a futex is legal from an ISR, where the waker cannot block. A
+ * waiter blocked with K_FOREVER must be resumed by a wake issued through
+ * irq_offload() exactly as by one from a thread.
+ *
+ * Test steps:
+ * - Set the futex value and spawn a user thread waiting with K_FOREVER.
+ * - Issue k_futex_wake() from an ISR via irq_offload().
+ * - Yield, then check the futex value.
+ *
+ * Expected result:
+ * - The waiter is woken by the ISR and runs its post-wait code.
+ *
+ * @see k_futex_wake()
+ * @see irq_offload()
+ */
 ZTEST(futex, test_futex_wait_forever_wake_from_isr)
 {
 	timeout = K_TICKS_FOREVER;
@@ -346,6 +476,28 @@ ZTEST(futex, test_futex_wait_forever_wake_from_isr)
 	k_thread_abort(&futex_tid);
 }
 
+/**
+ * @brief Verify that a single wake-all resumes every waiter on one futex.
+ *
+ * @details
+ * k_futex_wake() with wake_all set must resume every thread blocked on the
+ * futex, and its return value must count them all. Each waiter decrements
+ * the futex value once resumed, so a value of zero at the end means none of
+ * them was left behind.
+ *
+ * Test steps:
+ * - Block a batch of user threads on one futex, incrementing the value once
+ *   per waiter.
+ * - Issue a single wake with wake_all from another thread and check it
+ *   reports the full count.
+ * - Yield, then check the futex value reached zero.
+ *
+ * Expected result:
+ * - All waiters resume off one wake and the reported count matches.
+ *
+ * @see k_futex_wake()
+ * @see k_futex_wait()
+ */
 ZTEST(futex, test_futex_multiple_threads_wait_wake)
 {
 	timeout = K_TICKS_FOREVER;
@@ -381,7 +533,27 @@ ZTEST(futex, test_futex_multiple_threads_wait_wake)
 	}
 }
 
-ZTEST(futex, test_multiple_futex_wait_wake)
+/**
+ * @brief Verify that independent futexes wake independently.
+ *
+ * @details
+ * Each futex has its own wait queue: a wake issued on one must resume only
+ * the thread waiting on that futex and not disturb waiters on any other.
+ * One waiter and one waker are paired per futex, and every futex's value
+ * must reach zero through its own pair.
+ *
+ * Test steps:
+ * - Block one user thread on each of several futexes.
+ * - Spawn one waker per futex, each waking only its own.
+ * - Yield, then check every futex's value.
+ *
+ * Expected result:
+ * - Every waiter is woken exactly by its own futex's wake.
+ *
+ * @see k_futex_wake()
+ * @see k_futex_wait()
+ */
+ZTEST(futex, test_futex_independent_wait_wake)
 {
 	woken = 1;
 	timeout = K_TICKS_FOREVER;
@@ -416,7 +588,29 @@ ZTEST(futex, test_multiple_futex_wait_wake)
 	}
 }
 
-ZTEST_USER(futex, test_user_futex_bad)
+/**
+ * @brief Verify that futex calls reject invalid objects, values and states.
+ *
+ * @details
+ * From user mode every futex argument is untrusted, so each way it can be
+ * wrong has its own error: memory the caller cannot access is -EACCES, an
+ * address that is not a futex kernel object is -EINVAL, a mismatched
+ * expected value is -EAGAIN, and a matching value with K_NO_WAIT times out
+ * with -ETIMEDOUT.
+ *
+ * Test steps:
+ * - Wait on and wake a futex the caller has no access to.
+ * - Wait on and wake two objects that are not futexes.
+ * - Wait with an expected value that does not match the futex.
+ * - Wait with the matching value and K_NO_WAIT.
+ *
+ * Expected result:
+ * - Each call fails with exactly the error its input deserves.
+ *
+ * @see k_futex_wait()
+ * @see k_futex_wake()
+ */
+ZTEST_USER(futex, test_futex_bad_inputs)
 {
 	int ret;
 

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -48,9 +48,30 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 }
 
 /**
- * Show that mapping an irregular size buffer works and RW flag is respected
+ * @brief Verify that k_mem_map_phys_bare() honours size, aliasing and the RW
+ *        flag.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Mapping the same unaligned physical buffer twice -- once writable, once
+ * read-only -- must produce two virtual aliases of the same memory: bytes
+ * written through the writable alias have to appear in the backing buffer and
+ * through the read-only alias, and a write through the read-only alias has to
+ * fault. The suite's fatal error handler passes the case when the expected
+ * fault arrives, so falling through the write is the failure.
+ *
+ * Test steps:
+ * - Map an unaligned buffer with K_MEM_PERM_RW and again with read-only
+ *   permissions.
+ * - Fill the writable alias and compare the backing buffer and the read-only
+ *   alias against what was written, with cache flushes where configured.
+ * - Write through the read-only alias.
+ *
+ * Expected result:
+ * - Both aliases show the written data and the read-only write faults.
+ *
+ * @see k_mem_map_phys_bare()
  */
 ZTEST(mem_map, test_k_mem_map_phys_bare_rw)
 {
@@ -139,9 +160,26 @@ static void transplanted_function(bool *executed)
 #endif
 
 /**
- * Show that mapping with/without K_MEM_PERM_EXEC works as expected
+ * @brief Verify that K_MEM_PERM_EXEC controls execution from a mapping.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The same function body is mapped twice: with execute permission, calling
+ * into the mapping must work, and without it, the call must fault. This is
+ * the mapping-level half of execute protection -- the region is the same, so
+ * only the permission decides. Skipped where the platform cannot fault
+ * execution.
+ *
+ * Test steps:
+ * - Map the page holding a transplanted function with K_MEM_PERM_EXEC and
+ *   call it through the mapping.
+ * - Map the same page without execute permission and call it again.
+ *
+ * Expected result:
+ * - The executable mapping runs the function; the non-executable one faults.
+ *
+ * @see k_mem_map_phys_bare()
  */
 ZTEST(mem_map, test_k_mem_map_phys_bare_exec)
 {
@@ -184,9 +222,25 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_exec)
 }
 
 /**
- * Show that memory mapping doesn't have unintended side effects
+ * @brief Verify that a new mapping leaves existing memory untouched.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Creating a mapping must not disturb anything already in memory: the data of
+ * this test, the page being mapped, and the kernel's own state have to be
+ * exactly as they were. The test seeds a buffer, maps it, and checks the
+ * contents through the original address rather than the new mapping.
+ *
+ * Test steps:
+ * - Fill the test page with a known pattern.
+ * - Map it read-only with k_mem_map_phys_bare().
+ * - Compare the buffer through its original address against the pattern.
+ *
+ * Expected result:
+ * - The buffer is unchanged by the act of mapping it.
+ *
+ * @see k_mem_map_phys_bare()
  */
 ZTEST(mem_map, test_k_mem_map_phys_bare_side_effect)
 {
@@ -212,10 +266,25 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_side_effect)
 }
 
 /**
- * Test that k_mem_unmap_phys_bare() unmaps the memory and it is no longer
- * accessible afterwards.
+ * @brief Verify that k_mem_unmap_phys_bare() revokes access to the mapping.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * After an unmap the virtual address must no longer reach the memory: a read
+ * through it has to fault rather than return stale data. The mapping is first
+ * exercised to show it worked, so the later fault can only come from the
+ * unmap.
+ *
+ * Test steps:
+ * - Map the test page read-only and read through the mapping.
+ * - Unmap it with k_mem_unmap_phys_bare().
+ * - Read through the now-stale virtual address.
+ *
+ * Expected result:
+ * - The read after the unmap faults; the code after it is never reached.
+ *
+ * @see k_mem_unmap_phys_bare()
  */
 ZTEST(mem_map, test_k_mem_unmap_phys_bare)
 {
@@ -241,9 +310,27 @@ ZTEST(mem_map, test_k_mem_unmap_phys_bare)
 }
 
 /**
- * Show that k_mem_unmap_phys_bare() can reclaim the virtual region correctly.
+ * @brief Verify that an unmapped virtual region can be mapped again.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Unmapping has to return the virtual region to the allocator, otherwise
+ * repeated map/unmap cycles leak address space. Mapping, unmapping and
+ * mapping again must eventually hand back the same virtual address, which is
+ * what shows the region was reclaimed rather than abandoned.
+ *
+ * Test steps:
+ * - Map the test page and record the virtual address.
+ * - Unmap it, then map the same page repeatedly, unmapping after each try,
+ *   until the recorded address comes back or an attempt limit is reached.
+ *
+ * Expected result:
+ * - The originally returned virtual address is handed out again, showing the
+ *   unmap reclaimed the region.
+ *
+ * @see k_mem_map_phys_bare()
+ * @see k_mem_unmap_phys_bare()
  */
 ZTEST(mem_map, test_k_mem_map_phys_bare_unmap_reclaim_addr)
 {
@@ -280,9 +367,30 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_unmap_reclaim_addr)
 }
 
 /**
- * Basic k_mem_map() and k_mem_unmap() functionality
+ * @brief Verify that k_mem_map() provides usable anonymous memory and
+ *        k_mem_unmap() takes it back.
  *
- * Does not exercise K_MEM_MAP_* control flags, just default behavior
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The anonymous mapping API must hand out zeroed, writable pages backed by
+ * real frames, and unmapping must release both the frames and the virtual
+ * region so a subsequent map can reuse them. Default behaviour only; the
+ * K_MEM_MAP_* control flags are not exercised here.
+ *
+ * Test steps:
+ * - Map a page with k_mem_map(), check it reads back as zeroes, and write a
+ *   pattern into it.
+ * - Check the number of free page frames dropped by the mapping's worth.
+ * - Unmap it, check the free frame count is restored, and map again to see
+ *   the region reused.
+ *
+ * Expected result:
+ * - The page is zero-filled and writable, and unmapping returns both the
+ *   frames and the virtual region.
+ *
+ * @see k_mem_map()
+ * @see k_mem_unmap()
  */
 ZTEST(mem_map_api, test_k_mem_map_unmap)
 {
@@ -354,7 +462,26 @@ ZTEST(mem_map_api, test_k_mem_map_unmap)
 }
 
 /**
- * Test that the "before" guard page is in place for k_mem_map().
+ * @brief Verify that k_mem_map() places a guard page before the mapping.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Anonymous mappings are bracketed by unmapped guard pages, so an underrun
+ * off the start of the region faults immediately instead of touching a
+ * neighbouring mapping. The fatal error handler passes the case when the
+ * expected fault arrives.
+ *
+ * Test steps:
+ * - Map a page with k_mem_map() and write to its first byte, which must
+ *   succeed.
+ * - Write just before the start of the mapping.
+ *
+ * Expected result:
+ * - The in-bounds write succeeds and the underrun faults in the guard page;
+ *   the code after it is never reached.
+ *
+ * @see k_mem_map()
  */
 ZTEST(mem_map_api, test_k_mem_map_guard_before)
 {
@@ -382,7 +509,25 @@ ZTEST(mem_map_api, test_k_mem_map_guard_before)
 }
 
 /**
- * Test that the "after" guard page is in place for k_mem_map().
+ * @brief Verify that k_mem_map() places a guard page after the mapping.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The counterpart of the "before" case: an overrun off the end of the region
+ * must fault in the trailing guard page rather than reach whatever is mapped
+ * next.
+ *
+ * Test steps:
+ * - Map a page with k_mem_map() and write to its last byte, which must
+ *   succeed.
+ * - Write just past the end of the mapping.
+ *
+ * Expected result:
+ * - The in-bounds write succeeds and the overrun faults in the guard page;
+ *   the code after it is never reached.
+ *
+ * @see k_mem_map()
  */
 ZTEST(mem_map_api, test_k_mem_map_guard_after)
 {
@@ -409,6 +554,33 @@ ZTEST(mem_map_api, test_k_mem_map_guard_after)
 	ztest_test_fail();
 }
 
+/**
+ * @brief Verify that k_mem_map() fails cleanly when memory is exhausted.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Whichever runs out first -- page frames or virtual address space -- the
+ * mapping call has to return NULL rather than fault or hand out a partial
+ * region, and everything mapped before the failure must still be released
+ * cleanly. The test maps pages until failure, then unmaps them all, which
+ * also demonstrates the exhaustion is recoverable.
+ *
+ * Test steps:
+ * - Record the free memory figure, then map pages one at a time until
+ *   k_mem_map() returns NULL, writing into each mapped page.
+ * - Compare the number of pages obtained and the free memory remaining
+ *   against what the initial figure predicted.
+ * - Unmap every page and compare the free memory against the starting
+ *   figure.
+ *
+ * Expected result:
+ * - Exhaustion is reported as NULL after exactly the predicted number of
+ *   pages, and unmapping restores the free memory to its initial value.
+ *
+ * @see k_mem_map()
+ * @see k_mem_unmap()
+ */
 ZTEST(mem_map_api, test_k_mem_map_exhaustion)
 {
 	/* With demand paging enabled, there is backing store
@@ -518,8 +690,29 @@ static void user_function(void *p1, void *p2, void *p3)
 #endif /* CONFIG_USERSPACE */
 
 /**
- * Test that the allocated region will be only accessible to userspace when
- * K_MEM_PERM_USER is used.
+ * @brief Verify that K_MEM_PERM_USER controls user access to a mapping.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A mapping created without K_MEM_PERM_USER must be invisible to user
+ * threads, and one created with it must be usable from user mode. The same
+ * physical page is mapped each way in turn and a user thread is spawned to
+ * touch it; the access to the kernel-only mapping has to fault, which the
+ * suite's fatal error handler accepts as the expected outcome. Skipped
+ * without userspace.
+ *
+ * Test steps:
+ * - Map the test page with K_MEM_PERM_USER, spawn a user thread to access it
+ *   and join it.
+ * - Unmap, then map the same page without K_MEM_PERM_USER.
+ * - Spawn the user thread again to access the new mapping.
+ *
+ * Expected result:
+ * - The access to the user-permitted mapping succeeds; the access to the
+ *   kernel-only mapping faults.
+ *
+ * @see k_mem_map_phys_bare()
  */
 ZTEST(mem_map_api, test_k_mem_map_user)
 {

--- a/tests/kernel/mem_protect/mem_protect/src/check_access.c
+++ b/tests/kernel/mem_protect/mem_protect/src/check_access.c
@@ -10,7 +10,29 @@ K_SEM_DEFINE(obj_access, 0, 1);
 K_SEM_DEFINE(obj_no_access, 0, 1);
 int no_obj;
 
-ZTEST_USER(userspace_access_check, test_access)
+/**
+ * @brief Verify that k_object_access_check() reports the caller's rights.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The check call lets a user thread ask, without side effects, whether it may
+ * use an object. Each answer must match the actual state: granted object,
+ * object never granted, address that is no kernel object, and the thread's
+ * own thread object, which every thread implicitly owns.
+ *
+ * Test steps:
+ * - Check a semaphore granted during suite setup.
+ * - Check a semaphore that was never granted.
+ * - Check an address that is not a kernel object.
+ * - Check the calling thread's own thread object.
+ *
+ * Expected result:
+ * - The calls return 0, -EPERM, -EBADF and 0 respectively.
+ *
+ * @see k_object_access_check()
+ */
+ZTEST_USER(userspace_access_check, test_kobject_access_check)
 {
 	zexpect_equal(k_object_access_check(&obj_access), 0, "should have access but doesn't");
 	zexpect_equal(k_object_access_check(&obj_no_access), -EPERM,

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -33,11 +33,27 @@ static void kobject_access_grant_user_part(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test access to a invalid semaphore who's address is NULL
+ * @brief Verify that a grant covers only properly initialized objects.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_thread_access_grant(), k_thread_user_mode_enter()
+ * @details
+ * k_thread_access_grant() records permission per object, but permission alone
+ * is not enough: the object must also be a valid, initialized kernel object
+ * of the right type. The granted set here includes a semaphore pointer of the
+ * wrong provenance; using it from user mode must fault even though it was
+ * granted alongside two genuine objects.
+ *
+ * Test steps:
+ * - Grant the current thread a semaphore, a mutex and the bogus semaphore
+ *   pointer.
+ * - Drop to user mode and take the bogus semaphore.
+ *
+ * Expected result:
+ * - The take faults rather than operating on the invalid object.
+ *
+ * @see k_thread_access_grant()
+ * @see k_thread_user_mode_enter()
  */
 ZTEST(mem_protect_kobj, test_kobject_access_grant)
 {
@@ -212,11 +228,26 @@ static void kobject_revoke_access_user_part(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test access revoke
+ * @brief Verify that revoking an object stops inheriting threads using it.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_thread_access_grant(), k_object_access_revoke()
+ * @details
+ * A child created with K_INHERIT_PERMS receives the parent's grants at
+ * creation time. After the parent revokes its own access to the semaphore, a
+ * second child created the same way must no longer receive it: the same
+ * operation that succeeded in the first child has to fault in the second.
+ *
+ * Test steps:
+ * - Grant the semaphore and spawn a child that uses it successfully.
+ * - Revoke the parent's access with k_object_access_revoke().
+ * - Spawn a second child that attempts the same use.
+ *
+ * Expected result:
+ * - The first child succeeds; the second faults on the revoked object.
+ *
+ * @see k_object_access_revoke()
+ * @see k_thread_access_grant()
  */
 ZTEST(mem_protect_kobj, test_kobject_revoke_access)
 {
@@ -259,11 +290,26 @@ static void kobject_grant_access_extra_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test access revoke
+ * @brief Verify that one user thread can grant an object to another.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_thread_access_grant(), k_object_access_revoke()
+ * @details
+ * A user thread holding permission on an object and on another thread may
+ * pass the object on: the child grants the semaphore to a second thread,
+ * which must then be able to use it. Granting requires permission on both
+ * the object and the receiving thread, so a pass shows the user-mode grant
+ * path checks and propagates correctly.
+ *
+ * Test steps:
+ * - Grant the parent the semaphore and the extra thread object.
+ * - Spawn a child that grants the semaphore to the extra thread.
+ * - Spawn the extra thread and have it use the semaphore.
+ *
+ * Expected result:
+ * - The extra thread uses the semaphore granted to it by the child.
+ *
+ * @see k_object_access_grant()
  */
 ZTEST(mem_protect_kobj, test_kobject_grant_access_kobj)
 {
@@ -339,11 +385,23 @@ static void release_from_user_child(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test revoke permission of a k_object from userspace
+ * @brief Verify that a user thread can release its own object permission.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_thread_access_grant(), k_object_release()
+ * @details
+ * k_object_release() is the user-mode self-revocation: after the child drops
+ * its permission on the semaphore, its next use of the object must fault,
+ * within the same thread that just used it successfully.
+ *
+ * Test steps:
+ * - Grant the semaphore and spawn a child that uses it.
+ * - Have the child release the semaphore and try to use it again.
+ *
+ * Expected result:
+ * - The use before the release succeeds and the one after it faults.
+ *
+ * @see k_object_release()
  */
 ZTEST(mem_protect_kobj, test_kobject_release_from_user)
 {
@@ -527,12 +585,25 @@ ZTEST(mem_protect_kobj, test_thread_has_residual_permissions)
 
 /****************************************************************************/
 /**
- * @brief Test grant access to a valid kobject but invalid thread id
+ * @brief Verify that grants to an uninitialized thread object are inert.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_object_access_grant(), k_object_access_revoke(),
- * k_object_find()
+ * @details
+ * Granting or revoking an object for a thread structure that was never
+ * initialized as a thread must not blow up, and must not turn that structure
+ * into a valid thread object either: validating it afterwards still fails.
+ *
+ * Test steps:
+ * - Grant and then revoke the semaphore for an uninitialized k_thread.
+ * - Validate the structure as a thread object with K_SYSCALL_OBJ().
+ *
+ * Expected result:
+ * - The calls complete without side effects and the structure still fails
+ *   validation.
+ *
+ * @see k_object_access_grant()
+ * @see k_object_access_revoke()
  */
 ZTEST(mem_protect_kobj, test_kobject_access_grant_to_invalid_thread)
 {
@@ -592,9 +663,22 @@ static void without_init_with_access_child(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test syscall on a kobject which is not initialized and has access
+ * @brief Verify that permission does not substitute for initialization.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The counterpart of the without-access case: here the child holds a valid
+ * grant on the semaphore, but the object was never initialized. The syscall
+ * boundary checks initialization separately from permission, so the use must
+ * still fault.
+ *
+ * Test steps:
+ * - Grant the never-initialized semaphore to the current thread.
+ * - Spawn a child that inherits the grant and takes the semaphore.
+ *
+ * Expected result:
+ * - The take faults on the uninitialized object despite the valid grant.
  *
  * @see k_thread_access_grant()
  */
@@ -637,9 +721,24 @@ static void reinitialize_thread_kobj_child(void *p1, void *p2, void *p3)
 
 }
 /**
- * @brief Test to reinitialize the k_thread object
+ * @brief Verify that a user thread cannot reinitialize a running thread.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * k_thread_create() on a thread object that is already alive would rewrite
+ * live kernel state. From user mode the syscall boundary must refuse it: the
+ * child attempts to create a thread over an object that is currently running
+ * and has to fault.
+ *
+ * Test steps:
+ * - Spawn a child user thread.
+ * - Have it call k_thread_create() on an in-use thread object.
+ *
+ * Expected result:
+ * - The attempt faults instead of reinitializing the live thread.
+ *
+ * @see k_thread_create()
  */
 ZTEST(mem_protect_kobj, test_kobject_reinitialize_thread_kobj)
 {
@@ -967,9 +1066,24 @@ static void essential_thread_from_user_child(void *p1, void *p2, void *p3)
 	zassert_unreachable("k_object validation failure in k thread create");
 }
 /**
- * @brief Create a new essential thread from user.
+ * @brief Verify that a user thread cannot create an essential thread.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Aborting an essential thread panics the kernel, so minting one from user
+ * mode would let unprivileged code plant a landmine. The child's attempt to
+ * create a thread with K_ESSENTIAL must fault at the syscall boundary.
+ *
+ * Test steps:
+ * - Spawn a child user thread granted a spare thread object and stack.
+ * - Have it call k_thread_create() with the K_ESSENTIAL option.
+ *
+ * Expected result:
+ * - The attempt faults instead of creating an essential thread.
+ *
+ * @see k_thread_create()
+ * @see K_ESSENTIAL
  */
 ZTEST(mem_protect_kobj, test_create_new_essential_thread_from_user)
 {

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -159,13 +159,25 @@ static void ro_write_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Check if the mem_domain is configured and accessible for userspace
- *
- * Join a memory domain with a read-write memory partition and a read-only
- * partition within it, and show that the data in the partition is accessible
- * as expected by the permissions provided.
+ * @brief Verify that partitions in a thread's domain are accessible as
+ *        declared.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A user thread that is a member of a domain must reach the data in that
+ * domain's partitions with exactly the declared permissions: read-write data
+ * is writable, read-only data is readable.
+ *
+ * Test steps:
+ * - Spawn a user thread in the test domain that reads and writes the
+ *   read-write partition.
+ * - Spawn another that reads the read-only partition.
+ *
+ * Expected result:
+ * - Both accesses succeed with no fault.
+ *
+ * @see k_mem_domain_add_thread()
  */
 ZTEST(mem_protect_domain, test_mem_domain_valid_access)
 {
@@ -174,9 +186,23 @@ ZTEST(mem_protect_domain, test_mem_domain_valid_access)
 }
 
 /**
- * @brief Show that a user thread can't touch partitions not in its domain
+ * @brief Verify that partitions outside a thread's domain are unreachable.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The same accesses as the valid case, made by a thread that was never added
+ * to the test domain, must fault: domain membership is what grants access,
+ * not the existence of the partition. The suite's fault hook marks the
+ * faults as expected.
+ *
+ * Test steps:
+ * - Spawn a user thread outside the test domain that touches the read-write
+ *   partition.
+ * - Spawn another that touches the read-only partition.
+ *
+ * Expected result:
+ * - Both accesses fault.
  */
 ZTEST(mem_protect_domain, test_mem_domain_invalid_access)
 {
@@ -186,9 +212,22 @@ ZTEST(mem_protect_domain, test_mem_domain_invalid_access)
 }
 
 /**
- * @brief Show that a read-only partition can't be written to
+ * @brief Verify that a read-only partition rejects writes from its own
+ *        domain.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Being inside the domain grants the declared permission, not more: a member
+ * thread writing data in the read-only partition must fault even though it
+ * can read it freely.
+ *
+ * Test steps:
+ * - Spawn a user thread in the test domain that writes a variable in the
+ *   read-only partition.
+ *
+ * Expected result:
+ * - The write faults.
  */
 ZTEST(mem_protect_domain, test_mem_domain_no_writes_to_ro)
 {
@@ -197,13 +236,26 @@ ZTEST(mem_protect_domain, test_mem_domain_no_writes_to_ro)
 }
 
 /**
- * @brief Show that adding/removing partitions works
- *
- * Show that removing a partition doesn't affect access to other partitions.
- * Show that removing a partition generates a fault if its data is accessed.
- * Show that adding a partition back restores access from a user thread.
+ * @brief Verify that partition removal and re-addition track access rights.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Removing a partition from a domain must revoke exactly that partition:
+ * other partitions stay reachable, the removed one faults, and adding it
+ * back restores access. All three transitions are observed from member user
+ * threads.
+ *
+ * Test steps:
+ * - Remove one read-write partition and show another is still accessible.
+ * - Access the removed partition and expect a fault.
+ * - Add the partition back and access it again.
+ *
+ * Expected result:
+ * - Access follows the domain's current partition set at each step.
+ *
+ * @see k_mem_domain_remove_partition()
+ * @see k_mem_domain_add_partition()
  */
 ZTEST(mem_protect_domain, test_mem_domain_remove_add_partition)
 {
@@ -267,15 +319,26 @@ static void mem_domain_add_thread_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test access memory domain APIs allowed to supervisor threads only
- *
- * Show that invoking any of the memory domain APIs from user mode leads to
- * a fault.
+ * @brief Verify that the memory domain APIs are supervisor-only.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_mem_domain_init(), k_mem_domain_add_partition(),
- *	k_mem_domain_remove_partition(), k_mem_domain_add_thread()
+ * @details
+ * The domain configuration calls have no syscall wrappers: they reshape the
+ * protection landscape and must be unreachable from user mode. A user thread
+ * invoking any of them has to fault on the attempt.
+ *
+ * Test steps:
+ * - From a user thread, call k_mem_domain_init(), add_partition,
+ *   remove_partition and add_thread in turn.
+ *
+ * Expected result:
+ * - Each call faults before doing anything.
+ *
+ * @see k_mem_domain_init()
+ * @see k_mem_domain_add_partition()
+ * @see k_mem_domain_remove_partition()
+ * @see k_mem_domain_add_thread()
  */
 ZTEST(mem_protect_domain, test_mem_domain_api_supervisor_only)
 {
@@ -287,13 +350,22 @@ ZTEST(mem_protect_domain, test_mem_domain_api_supervisor_only)
 }
 
 /**
- * @brief Show that boot threads belong to the default memory domain
- *
- * Static threads and the main thread are supposed to start as members of
- * the default memory domain. Prove this is the case by examining the
- * memory domain membership of z_main_thread and a static thread.
+ * @brief Verify that boot-time threads start in the default memory domain.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Threads that exist before the application configures anything -- the main
+ * thread and statically defined threads -- must be members of the default
+ * domain, or they would run with no defined memory view at all. Membership
+ * is read directly from the thread structures.
+ *
+ * Test steps:
+ * - Check z_main_thread's domain membership.
+ * - Start a static thread and check its membership.
+ *
+ * Expected result:
+ * - Both belong to k_mem_domain_default.
  */
 ZTEST(mem_protect_domain, test_mem_domain_boot_threads)
 {
@@ -325,16 +397,26 @@ static void spin_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Show that moving a thread from one domain to another works
- *
- * Start a thread and have it spin. Then while it is spinning, show that
- * adding it to another memory domain doesn't cause any faults.
- *
- * This test is of particular importance on SMP systems where the child
- * thread is spinning on a different CPU concurrently with the migration
- * operation.
+ * @brief Verify that a running thread can be migrated between domains.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * k_mem_domain_add_thread() may be applied to a thread that is actively
+ * running, and the migration must not fault it -- the destination domain
+ * also carries the partitions the thread is using. On SMP the thread spins
+ * on another CPU while the migration happens, which is the racy path this
+ * case exists for. Re-adding the thread to the domain it is already in must
+ * be a no-op.
+ *
+ * Test steps:
+ * - Start a user thread that spins on shared state.
+ * - While it runs, add it to the test domain, then add it again.
+ * - Release the spin and join the thread.
+ *
+ * Expected result:
+ * - The thread keeps running through the migration and the repeated add
+ *   changes nothing.
  *
  * @see k_mem_domain_add_thread()
  */

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -69,19 +69,40 @@ void object_permission_checks(struct k_sem *sem, bool skip_init)
 }
 
 /**
- * @brief Test to verify object permission
- *
- * @details
- * - The kernel must be able to associate kernel object memory addresses
- *   with whether the calling thread has access to that object, the object is
- *   of the expected type, and the object is of the expected init state.
- * - Test support freeing kernel objects allocated at runtime manually.
+ * @brief Verify that kernel object validation reports address, permission,
+ *        type and init state.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see k_object_alloc(), k_object_access_grant()
+ * @details
+ * Every system call that takes a kernel object has to answer three questions
+ * about it before trusting it: is this address a kernel object at all, does
+ * the calling thread have access to it, and is it initialized and of the
+ * expected type. Each answer has its own error code, so the test drives an
+ * address through every state in turn -- unknown to the table, known but not
+ * granted, granted but uninitialized, and fully usable -- and checks the code
+ * that comes back. Dynamically allocated objects are put through the same
+ * sequence and then freed, which also covers an object leaving the table.
+ *
+ * Test steps:
+ * - Validate a stack variable, a bad address and a wild pointer, none of
+ *   which are in the object table.
+ * - Validate static objects with and without permission granted, before and
+ *   after initialization.
+ * - Allocate objects at run time, granting an extra reference so they survive
+ *   revocation, and validate them through the same states.
+ * - Free each dynamic object and validate it once more.
+ *
+ * Expected result:
+ * - Addresses outside the table report -EBADF, objects without permission or
+ *   not yet initialized report -EINVAL, usable objects validate successfully,
+ *   and a freed object goes back to reporting -EBADF.
+ *
+ * @see k_object_alloc()
+ * @see k_object_access_grant()
+ * @see k_object_free()
  */
-ZTEST(object_validation, test_generic_object)
+ZTEST(object_validation, test_kobj_validate_states)
 {
 	struct k_sem stack_sem = {};
 
@@ -115,19 +136,29 @@ ZTEST(object_validation, test_generic_object)
 }
 
 /**
- * @brief Test requestor thread will implicitly be assigned permission on the
- * dynamically allocated object
- *
- * @details
- * - Create kernel object semaphore, dynamically allocate it from the calling
- *   thread's resource pool.
- * - Check that object's address is in bounds of that memory pool.
- * - Then check the requestor thread will implicitly be assigned permission on
- *   the allocated object by using semaphore API k_sem_init()
+ * @brief Verify that allocating an object grants the caller permission on it.
  *
  * @ingroup kernel_memprotect_tests
  *
+ * @details
+ * A thread that allocates a kernel object must be able to use it straight
+ * away, without a separate grant: the allocation implicitly gives the
+ * requesting thread permission. The object also has to come out of that
+ * thread's own resource pool, so its address is checked against the pool
+ * bounds, and it is then used through an ordinary API call, which would fail
+ * the permission check if the implicit grant were missing.
+ *
+ * Test steps:
+ * - Allocate a semaphore object with k_object_alloc().
+ * - Check its address lies within the calling thread's resource pool.
+ * - Call k_sem_init() on it from the same thread.
+ *
+ * Expected result:
+ * - The allocation succeeds, the object lies in the thread's pool, and the
+ *   thread can initialize it without being granted access explicitly.
+ *
  * @see k_object_alloc()
+ * @see k_sem_init()
  */
 ZTEST(object_validation, test_kobj_assign_perms_on_alloc_obj)
 {
@@ -154,17 +185,30 @@ ZTEST(object_validation, test_kobj_assign_perms_on_alloc_obj)
 }
 
 /**
- * @brief Test dynamically allocated kernel object release memory
- *
- * @details Dynamically allocated kernel objects whose access is controlled by
- * the permission system will use object permission as a reference count.
- * If no threads have access to an object, the object's memory released.
+ * @brief Verify that a kernel object is freed once nothing references it.
  *
  * @ingroup kernel_memprotect_tests
  *
+ * @details
+ * For a dynamically allocated object the set of threads holding permission on
+ * it doubles as its reference count, so revoking the last permission has to
+ * release the memory rather than leak it. The object is looked up again
+ * afterwards, and its disappearance from the object table is what shows the
+ * release happened.
+ *
+ * Test steps:
+ * - Allocate a mutex object with k_object_alloc().
+ * - Revoke the allocating thread's access, leaving no thread with permission.
+ * - Look the object up and validate it.
+ *
+ * Expected result:
+ * - The object is no longer in the table, reported as -EBADF, so its memory
+ *   was released.
+ *
  * @see k_object_alloc()
+ * @see k_object_access_revoke()
  */
-ZTEST(object_validation, test_no_ref_dyn_kobj_release_mem)
+ZTEST(object_validation, test_kobj_freed_when_unreferenced)
 {
 	int ret;
 

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -84,11 +84,26 @@ static void execute_from_buffer(uint8_t *dst)
 #endif /* SKIP_EXECUTE_TESTS */
 
 /**
- * @brief Test write to read only section
+ * @brief Verify that writing to .rodata faults.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Read-only data must be mapped without write permission, so an attempt to
+ * modify it has to trap rather than silently succeed.
+ *
+ * The suite installs a fatal error handler that reports the case as passed
+ * and moves on, so a caught fault is the success path: reaching the
+ * zassert_unreachable() after the access means the region was not protected.
+ *
+ * Test steps:
+ * - Take a pointer to a variable in .rodata.
+ * - Write the inverse of its value through that pointer.
+ *
+ * Expected result:
+ * - The write raises a fatal error; the code after it is never reached.
  */
-ZTEST(protection, test_write_ro)
+ZTEST(protection, test_protection_write_rodata)
 {
 	volatile uint32_t *ptr = (volatile uint32_t *)&rodata_var;
 
@@ -113,11 +128,27 @@ ZTEST(protection, test_write_ro)
 }
 
 /**
- * @brief Test to execute on text section
+ * @brief Verify that writing to .text faults.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Executable code must be mapped without write permission, otherwise running
+ * code could be rewritten in place. The test copies one function over
+ * another, which is the shape a real code-injection attempt would take.
+ *
+ * The suite installs a fatal error handler that reports the case as passed
+ * and moves on, so a caught fault is the success path: reaching the
+ * zassert_unreachable() after the access means the region was not protected.
+ *
+ * Test steps:
+ * - Copy the body of one function over another function in .text.
+ * - Call the overwritten function.
+ *
+ * Expected result:
+ * - The write raises a fatal error; the code after it is never reached.
  */
-ZTEST(protection, test_write_text)
+ZTEST(protection, test_protection_write_text)
 {
 	void *src = FUNC_TO_PTR(add_one);
 	void *dst = FUNC_TO_PTR(overwrite_target);
@@ -144,11 +175,27 @@ ZTEST(protection, test_write_text)
 }
 
 /**
- * @brief Test execution from data section
+ * @brief Verify that executing from .data faults.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Writable data must be mapped without execute permission, so code copied
+ * into a data buffer cannot be run. Skipped on configurations without data
+ * execution prevention, where the hardware cannot enforce this.
+ *
+ * The suite installs a fatal error handler that reports the case as passed
+ * and moves on, so a caught fault is the success path: reaching the
+ * zassert_unreachable() after the access means the region was not protected.
+ *
+ * Test steps:
+ * - Copy a small function into a buffer in .data.
+ * - Call into that buffer.
+ *
+ * Expected result:
+ * - The call raises a fatal error; the code after it is never reached.
  */
-ZTEST(protection, test_exec_data)
+ZTEST(protection, test_protection_exec_data)
 {
 #ifdef SKIP_EXECUTE_TESTS
 	ztest_test_skip();
@@ -159,11 +206,27 @@ ZTEST(protection, test_exec_data)
 }
 
 /**
- * @brief Test execution from stack section
+ * @brief Verify that executing from the stack faults.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A thread stack must be mapped without execute permission, which is what
+ * stops a stack overflow from being turned into code execution. Skipped on
+ * configurations without data execution prevention.
+ *
+ * The suite installs a fatal error handler that reports the case as passed
+ * and moves on, so a caught fault is the success path: reaching the
+ * zassert_unreachable() after the access means the region was not protected.
+ *
+ * Test steps:
+ * - Copy a small function into a buffer on the current thread's stack.
+ * - Call into that buffer.
+ *
+ * Expected result:
+ * - The call raises a fatal error; the code after it is never reached.
  */
-ZTEST(protection, test_exec_stack)
+ZTEST(protection, test_protection_exec_stack)
 {
 #ifdef SKIP_EXECUTE_TESTS
 	ztest_test_skip();
@@ -176,11 +239,29 @@ ZTEST(protection, test_exec_stack)
 }
 
 /**
- * @brief Test execution from heap
+ * @brief Verify that executing from the heap faults.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Heap memory must be mapped without execute permission, for the same reason
+ * as the stack and data cases. Skipped when there is no heap configured or
+ * the platform has no data execution prevention.
+ *
+ * The suite installs a fatal error handler that reports the case as passed
+ * and moves on, so a caught fault is the success path: reaching the
+ * zassert_unreachable() after the access means the region was not protected.
+ *
+ * Test steps:
+ * - Allocate a buffer with k_malloc() and copy a small function into it.
+ * - Call into that buffer.
+ *
+ * Expected result:
+ * - The call raises a fatal error; the code after it is never reached.
+ *
+ * @see k_malloc()
  */
-ZTEST(protection, test_exec_heap)
+ZTEST(protection, test_protection_exec_heap)
 {
 #if (CONFIG_HEAP_MEM_POOL_SIZE > 0) && !defined(SKIP_EXECUTE_TESTS)
 	uint8_t *heap_buf = k_malloc(BUF_SIZE);

--- a/tests/kernel/mem_protect/stack_random/src/main.c
+++ b/tests/kernel/mem_protect/stack_random/src/main.c
@@ -49,10 +49,32 @@ K_THREAD_STACK_DEFINE(alt_thread_stack_area, STACKSIZE);
 static struct k_thread alt_thread_data;
 
 /**
- * @brief Test stack pointer randomization
+ * @brief Verify that thread stack pointers are randomized between threads.
  *
  * @ingroup kernel_memprotect_tests
  *
+ * @details
+ * With stack pointer randomization the kernel offsets each thread's initial
+ * stack pointer by a random amount, so an attacker cannot predict where a
+ * thread's stack begins. The same stack area is reused by many short-lived
+ * threads in turn; each one records the address of a local variable, which
+ * tracks its initial stack pointer, and compares it against the address the
+ * previous thread saw. Without randomization every thread would start at the
+ * same offset and the address would never change.
+ *
+ * Test steps:
+ * - Lower the test thread to a preemptible priority so each spawned thread
+ *   runs to completion.
+ * - Create 64 threads in turn on one stack area, at the highest priority.
+ * - In each thread, take the address of a local variable and compare it with
+ *   the address recorded by the previous thread, counting the differences.
+ * - Restore the test thread's priority.
+ *
+ * Expected result:
+ * - The observed stack pointer differs between threads at least once, so the
+ *   initial stack pointer is not fixed.
+ *
+ * @see k_thread_create()
  */
 ZTEST(stack_pointer_randomness, test_stack_pt_randomization)
 {

--- a/tests/kernel/mem_protect/stackprot/README.txt
+++ b/tests/kernel/mem_protect/stackprot/README.txt
@@ -1,3 +1,6 @@
+SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+SPDX-License-Identifier: Apache-2.0
+
 Title: Stack Protection Support
 
 Description:
@@ -6,16 +9,20 @@ This test verifies that stack canaries and stack guard pages operate as
 expected. It runs two Ztest suites:
 
 1. stackprot
-   - test_stackprot (a user-mode case) overflows a thread stack and
-     confirms the stack-canary check detects the corruption and aborts
-     the offending thread while the rest of the system keeps running.
-   - test_create_alt_thread and test_canary_value exercise creating the
-     alternate thread and inspecting the canary value.
+   - test_stackprot_canary_overflow spawns a thread that overflows a
+     stack buffer and confirms the stack-canary check detects the
+     corruption and aborts the offending thread while the rest of the
+     system keeps running.
+   - test_stackprot_no_false_positive (a user-mode case) runs the same
+     buffer handling with input that fits and confirms the overflowing
+     thread never ran past its canary check.
+   - test_stackprot_canary_scope confirms the canary value is per thread
+     with CONFIG_STACK_CANARIES_TLS and global without it.
 
 2. stackprot_mapped_stack
-   - test_guard_page_front and test_guard_page_rear (plus their _user
-     variants) confirm that the guard pages placed in front of and behind
-     a mapped stack fault on overflow.
+   - test_stackprot_guard_page_front and test_stackprot_guard_page_rear
+     (plus their _user variants) confirm that the guard pages placed in
+     front of and behind a mapped stack fault on overflow.
 
 Because the test deliberately triggers faults, it is run with
 ignore_faults enabled in twister.
@@ -43,25 +50,25 @@ Sample Output:
 
 Running TESTSUITE stackprot
 ===================================================================
-START - test_canary_value
- PASS - test_canary_value
-===================================================================
-START - test_create_alt_thread
- PASS - test_create_alt_thread
-===================================================================
-START - test_stackprot
+START - test_stackprot_canary_overflow
 alternate_thread: Input string is too long and stack overflowed!
 *** Stack Check Fail! ***
- PASS - test_stackprot
+ PASS - test_stackprot_canary_overflow
+===================================================================
+START - test_stackprot_canary_scope
+ PASS - test_stackprot_canary_scope
+===================================================================
+START - test_stackprot_no_false_positive
+ PASS - test_stackprot_no_false_positive
 ===================================================================
 TESTSUITE stackprot succeeded
 
 Running TESTSUITE stackprot_mapped_stack
 ===================================================================
-START - test_guard_page_front
- PASS - test_guard_page_front
+START - test_stackprot_guard_page_front
+ PASS - test_stackprot_guard_page_front
 ===================================================================
-START - test_guard_page_rear
- PASS - test_guard_page_rear
+START - test_stackprot_guard_page_rear
+ PASS - test_stackprot_guard_page_rear
 ===================================================================
 TESTSUITE stackprot_mapped_stack succeeded

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -110,34 +110,56 @@ K_THREAD_STACK_DEFINE(alt_thread_stack_area, STACKSIZE);
 static struct k_thread alt_thread_data;
 
 /**
- * @brief test Stack Protector feature using canary
- *
- * @details This is the test program to test stack protection using canary.
- * The main thread starts a second thread, which generates a stack check
- * failure.
- * By design, the second thread will not complete its execution and
- * will not set ret to TC_FAIL.
- * This is the entry point to the test stack protection feature.
- * It starts the thread that tests stack protection, then prints out
- * a few messages before terminating.
+ * @brief Verify that legitimate stack use does not trip the canary.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The stack protector must be silent for well-behaved code: only an actual
+ * overflow may trigger it. This case runs the same buffer-handling function
+ * the overflow case uses, but with input that fits, and also checks that the
+ * overflow case's failure flag was never set -- the overflowing thread must
+ * have been stopped by the canary before it could reach the code that sets
+ * the flag. Ztest orders a suite alphabetically, so the overflow case
+ * (test_stackprot_canary_overflow) has already run when this check is made.
+ *
+ * Test steps:
+ * - Check that the shared failure flag is still clear.
+ * - Call the buffer-copying function repeatedly with input that fits.
+ *
+ * Expected result:
+ * - The calls complete normally and no stack check failure is raised.
  */
-ZTEST_USER(stackprot, test_stackprot)
+ZTEST_USER(stackprot, test_stackprot_no_false_positive)
 {
 	zassert_true(ret == TC_PASS);
 	print_loop(__func__);
 }
 
 /**
- * @brief Test optional mechanism to detect stack overflow
- *
- * @details Test that the system provides an optional mechanism to detect
- * when supervisor threads overflow stack memory buffer.
+ * @brief Verify that a stack buffer overflow is caught by the canary.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * With CONFIG_STACK_CANARIES a function whose local buffer is overrun must be
+ * stopped when it returns, raising K_ERR_STACK_CHK_FAIL rather than letting
+ * corrupted stack contents be used. The overflowing thread would set a shared
+ * failure flag if it survived, and the suite's fatal error handler accepts
+ * only the stack-check reason, so both a missed overflow and a wrong error
+ * type are detected.
+ *
+ * Test steps:
+ * - Spawn a thread that copies an over-long string into a 16-byte stack
+ *   buffer.
+ * - Let it run; the canary check fails when the overflowed function returns.
+ * - The fatal error handler verifies the reason is K_ERR_STACK_CHK_FAIL.
+ *
+ * Expected result:
+ * - The thread is terminated by the stack check and never reaches the code
+ *   that would flag a failure.
  */
-ZTEST(stackprot, test_create_alt_thread)
+ZTEST(stackprot, test_stackprot_canary_overflow)
 {
 	/* Start thread */
 	k_thread_create(&alt_thread_data, alt_thread_stack_area, STACKSIZE,
@@ -177,14 +199,27 @@ void alternate_thread_canary(void *arg1, void *arg2, void *arg3)
 }
 
 /**
- * @brief Test stack canaries behavior
- *
- * @details Test that canaries value are different between threads when
- * CONFIG_STACK_CANARIES_TLS is enabled.
+ * @brief Verify the scope of the stack canary value.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * With CONFIG_STACK_CANARIES_TLS every thread gets its own canary value, so
+ * leaking one thread's canary does not help overflow another's; without it
+ * there is a single global canary shared by all threads. The spawned thread
+ * compares its own canary against its parent's, and which relation is correct
+ * depends on the configuration under test.
+ *
+ * Test steps:
+ * - Read the current thread's canary value.
+ * - Spawn a thread, passing it that value, and have it compare against its
+ *   own canary.
+ *
+ * Expected result:
+ * - With per-thread canaries the values differ; with a global canary they are
+ *   identical.
  */
-ZTEST(stackprot, test_canary_value)
+ZTEST(stackprot, test_stackprot_canary_scope)
 {
 	/* Start thread */
 	k_thread_create(&alt_thread_data, alt_thread_stack_area, STACKSIZE,

--- a/tests/kernel/mem_protect/stackprot/src/mapped_stack.c
+++ b/tests/kernel/mem_protect/stackprot/src/mapped_stack.c
@@ -92,11 +92,27 @@ void create_thread(bool is_front, bool is_user)
 #endif /* CONFIG_THREAD_STACK_MEM_MAPPED */
 
 /**
- * @brief Test faulting on front guard page
+ * @brief Verify that the front guard page of a mapped stack faults.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A memory-mapped thread stack is surrounded by unmapped guard pages, so an
+ * access that runs off either end of the stack faults immediately instead of
+ * corrupting whatever happens to be adjacent. The spawned thread deliberately
+ * touches the middle of the front guard page; the fault is the expected outcome,
+ * and running past the access fails the test. Skipped when
+ * CONFIG_THREAD_STACK_MEM_MAPPED is not enabled.
+ * Test steps:
+ * - Create a kernel thread on a memory-mapped stack and record the mapped
+ *   stack's address and size.
+ * - In the thread, write to the middle of the front guard page.
+ *
+ * Expected result:
+ * - The write faults on the guard page and the thread is terminated; the code
+ *   after the write is never reached.
  */
-ZTEST(stackprot_mapped_stack, test_guard_page_front)
+ZTEST(stackprot_mapped_stack, test_stackprot_guard_page_front)
 {
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
 	create_thread(true, false);
@@ -106,11 +122,27 @@ ZTEST(stackprot_mapped_stack, test_guard_page_front)
 }
 
 /**
- * @brief Test faulting on rear guard page
+ * @brief Verify that the rear guard page of a mapped stack faults.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A memory-mapped thread stack is surrounded by unmapped guard pages, so an
+ * access that runs off either end of the stack faults immediately instead of
+ * corrupting whatever happens to be adjacent. The spawned thread deliberately
+ * touches the middle of the rear guard page; the fault is the expected outcome,
+ * and running past the access fails the test. Skipped when
+ * CONFIG_THREAD_STACK_MEM_MAPPED is not enabled.
+ * Test steps:
+ * - Create a kernel thread on a memory-mapped stack and record the mapped
+ *   stack's address and size.
+ * - In the thread, write to the middle of the rear guard page.
+ *
+ * Expected result:
+ * - The write faults on the guard page and the thread is terminated; the code
+ *   after the write is never reached.
  */
-ZTEST(stackprot_mapped_stack, test_guard_page_rear)
+ZTEST(stackprot_mapped_stack, test_stackprot_guard_page_rear)
 {
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
 	create_thread(false, false);
@@ -120,11 +152,27 @@ ZTEST(stackprot_mapped_stack, test_guard_page_rear)
 }
 
 /**
- * @brief Test faulting on front guard page in user mode
+ * @brief Verify that the front guard page faults for a user thread.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A memory-mapped thread stack is surrounded by unmapped guard pages, so an
+ * access that runs off either end of the stack faults immediately instead of
+ * corrupting whatever happens to be adjacent. The spawned thread deliberately
+ * touches the middle of the front guard page; the fault is the expected outcome,
+ * and running past the access fails the test. Skipped when
+ * CONFIG_THREAD_STACK_MEM_MAPPED is not enabled.
+ * Test steps:
+ * - Create a user thread on a memory-mapped stack and record the mapped
+ *   stack's address and size.
+ * - In the thread, write to the middle of the front guard page.
+ *
+ * Expected result:
+ * - The write faults on the guard page and the thread is terminated; the code
+ *   after the write is never reached.
  */
-ZTEST(stackprot_mapped_stack, test_guard_page_front_user)
+ZTEST(stackprot_mapped_stack, test_stackprot_guard_page_front_user)
 {
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
 	create_thread(true, true);
@@ -134,11 +182,27 @@ ZTEST(stackprot_mapped_stack, test_guard_page_front_user)
 }
 
 /**
- * @brief Test faulting on rear guard page in user mode
+ * @brief Verify that the rear guard page faults for a user thread.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A memory-mapped thread stack is surrounded by unmapped guard pages, so an
+ * access that runs off either end of the stack faults immediately instead of
+ * corrupting whatever happens to be adjacent. The spawned thread deliberately
+ * touches the middle of the rear guard page; the fault is the expected outcome,
+ * and running past the access fails the test. Skipped when
+ * CONFIG_THREAD_STACK_MEM_MAPPED is not enabled.
+ * Test steps:
+ * - Create a user thread on a memory-mapped stack and record the mapped
+ *   stack's address and size.
+ * - In the thread, write to the middle of the rear guard page.
+ *
+ * Expected result:
+ * - The write faults on the guard page and the thread is terminated; the code
+ *   after the write is never reached.
  */
-ZTEST(stackprot_mapped_stack, test_guard_page_rear_user)
+ZTEST(stackprot_mapped_stack, test_stackprot_guard_page_rear_user)
 {
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
 	create_thread(false, true);

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -249,16 +249,34 @@ static inline uint32_t z_vrfy_more_args(uint32_t arg1, uint32_t arg2,
 #include <zephyr/syscalls/more_args_mrsh.c>
 
 /**
- * @brief Test to demonstrate usage of k_usermode_string_nlen()
- *
- * @details The test will be called from user mode and kernel
- * mode to check the behavior of k_usermode_string_nlen()
+ * @brief Verify that k_usermode_string_nlen() measures only memory the caller
+ *        may read.
  *
  * @ingroup kernel_memprotect_tests
  *
+ * @details
+ * String lengths handed to the kernel come from untrusted callers, so the
+ * measuring helper has to respect the caller's permissions: from user mode a
+ * kernel-owned string or a wild address must fault into the error argument
+ * rather than being read, while a string the caller owns measures normally.
+ * The same call from supervisor mode may read everything. The case runs in
+ * both modes via ZTEST_USER, so both sides of that contract are covered by
+ * one body.
+ *
+ * Test steps:
+ * - Measure a kernel-owned string; expect a fault in user mode and a correct
+ *   length in supervisor mode.
+ * - Measure a user-owned string; expect the correct length in both modes.
+ * - Measure a known-faulty address; expect a fault (skipped on platforms
+ *   whose emulation cannot fault it).
+ *
+ * Expected result:
+ * - Lengths are returned only for memory the caller is allowed to read, and
+ *   every forbidden access is reported through the error argument.
+ *
  * @see k_usermode_string_nlen()
  */
-ZTEST_USER(syscalls, test_string_nlen)
+ZTEST_USER(syscalls, test_syscall_string_nlen)
 {
 	int err;
 	size_t ret;
@@ -312,7 +330,7 @@ ZTEST_USER(syscalls, test_string_nlen)
  *
  * @see k_usermode_string_nlen()
  */
-ZTEST(syscalls, test_string_nlen_maxsize_zero)
+ZTEST(syscalls, test_syscall_string_nlen_maxsize_zero)
 {
 	int err = 0;
 	size_t ret;
@@ -330,14 +348,32 @@ ZTEST(syscalls, test_string_nlen_maxsize_zero)
 }
 
 /**
- * @brief Test to verify syscall for string alloc copy
+ * @brief Verify that k_usermode_string_alloc_copy() copies only readable,
+ *        fitting strings.
  *
  * @ingroup kernel_memprotect_tests
  *
+ * @details
+ * The allocating copy helper brings a user string into kernel memory before
+ * the kernel looks at it, so it must reject a string that does not match the
+ * expectation, one that exceeds the destination size, and one the caller has
+ * no right to read -- the kernel_string case, where the copy itself must
+ * fault. Only a readable string of acceptable length may be copied and
+ * compared successfully.
+ *
+ * Test steps:
+ * - Pass a valid but unexpected string and check the comparison fails.
+ * - Pass an over-long string and check the copy is rejected.
+ * - Pass a kernel-owned string and check the copy faults.
+ * - Pass the expected string and check it copies and matches.
+ *
+ * Expected result:
+ * - Each invalid input is rejected with its own error and only the readable,
+ *   fitting string succeeds.
+ *
  * @see k_usermode_string_alloc_copy()
- * @see strcmp()
  */
-ZTEST_USER(syscalls, test_user_string_alloc_copy)
+ZTEST_USER(syscalls, test_syscall_string_alloc_copy)
 {
 	int ret;
 
@@ -356,14 +392,29 @@ ZTEST_USER(syscalls, test_user_string_alloc_copy)
 }
 
 /**
- * @brief Test sys_call for string copy
+ * @brief Verify that k_usermode_string_copy() copies only readable, fitting
+ *        strings.
  *
  * @ingroup kernel_memprotect_tests
  *
+ * @details
+ * The fixed-buffer counterpart of the allocating copy: same contract, but
+ * into a caller-provided buffer, with EINVAL for a string that does not fit
+ * and EFAULT for one the caller cannot read.
+ *
+ * Test steps:
+ * - Pass a valid but unexpected string and check the comparison fails.
+ * - Pass an over-long string and check EINVAL is returned.
+ * - Pass a kernel-owned string and check EFAULT is returned.
+ * - Pass the expected string and check it copies and matches.
+ *
+ * Expected result:
+ * - Each invalid input is rejected with its own error and only the readable,
+ *   fitting string succeeds.
+ *
  * @see k_usermode_string_copy()
- * @see strcmp()
  */
-ZTEST_USER(syscalls, test_user_string_copy)
+ZTEST_USER(syscalls, test_syscall_string_copy)
 {
 	int ret;
 
@@ -381,14 +432,29 @@ ZTEST_USER(syscalls, test_user_string_copy)
 }
 
 /**
- * @brief Test to demonstrate system call for copy
+ * @brief Verify that k_usermode_to_copy() writes only to caller-writable
+ *        memory.
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see memcpy()
+ * @details
+ * Copying data out of the kernel back to the caller must validate the
+ * destination the same way inbound copies validate the source: a buffer the
+ * user thread cannot write has to be refused with EFAULT, and a writable
+ * buffer receives the data intact.
+ *
+ * Test steps:
+ * - Ask the kernel to copy into a kernel-owned buffer; expect EFAULT.
+ * - Ask it to copy into a stack buffer of the calling user thread.
+ * - Compare the received data with what the kernel was asked to send.
+ *
+ * Expected result:
+ * - The unwritable destination is rejected and the writable one receives the
+ *   exact data.
+ *
  * @see k_usermode_to_copy()
  */
-ZTEST_USER(syscalls, test_to_copy)
+ZTEST_USER(syscalls, test_syscall_to_copy)
 {
 	char buf[BUF_SIZE];
 	int ret;
@@ -424,7 +490,7 @@ void run_test_arg64(void)
  * @ingroup kernel_memprotect_tests
  * @see syscall_arg64()
  */
-ZTEST_USER(syscalls, test_arg64)
+ZTEST_USER(syscalls, test_syscall_arg64)
 {
 	run_test_arg64();
 }
@@ -439,7 +505,7 @@ ZTEST_USER(syscalls, test_arg64)
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST_USER(syscalls, test_more_args)
+ZTEST_USER(syscalls, test_syscall_more_args)
 {
 	zassert_equal(more_args(1, 2, 3, 4, 5, 6, 7),
 		      z_impl_more_args(1, 2, 3, 4, 5, 6, 7),
@@ -499,13 +565,26 @@ void syscall_switch_stress(void *arg1, void *arg2, void *arg3)
 }
 
 /**
- * @brief Stress test system calls under concurrency
- *
- * @details Spawn many user threads that hammer the test system calls in a tight
- * loop across all CPUs, smoking out concurrency problems in the system call
- * path used by user threads to perform privileged operations.
+ * @brief Stress the system call path with many concurrent user threads.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The entry and exit paths of a system call touch per-CPU and per-thread
+ * state that has to hold up when every CPU is crossing the privilege boundary
+ * at once. Four user threads per CPU hammer the string-handling test calls in
+ * a tight loop, yielding periodically so the schedulers on all CPUs keep
+ * moving threads around; corruption anywhere in the path shows up as a failed
+ * validation inside one of the calls.
+ *
+ * Test steps:
+ * - Spawn four user threads per CPU running the string system calls in a
+ *   loop.
+ * - Let them run for the configured iteration count and join them all.
+ *
+ * Expected result:
+ * - Every thread completes every iteration without a validation failure or
+ *   fault.
  */
 ZTEST(syscalls_extended, test_syscall_switch_stress)
 {
@@ -561,13 +640,27 @@ void test_syscall_context_user(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test detection of user system call context
+ * @brief Verify that k_is_in_user_syscall() identifies user-invoked calls.
  *
- * @details Show that k_is_in_user_syscall() correctly reports whether execution
- * is inside a system call invoked from user mode: false in a supervisor thread
- * and in a supervisor-mode call, true when invoked from a user thread. This
- * exercises the system call mechanism that lets user threads perform privileged
- * operations.
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Some kernel code behaves differently depending on whether it was entered
+ * through a system call from user mode, so the predicate has to be true
+ * exactly then: not in an ordinary supervisor thread, not when the same
+ * function is invoked directly in supervisor mode, only inside a system call
+ * made by a user thread.
+ *
+ * Test steps:
+ * - Check the predicate is false in the supervisor-mode test thread.
+ * - Invoke the test system call from supervisor mode and check it reports
+ *   false inside.
+ * - Enter user mode and invoke the same call, checking it reports true.
+ *
+ * Expected result:
+ * - The predicate is true only inside a system call invoked from user mode.
+ *
+ * @see k_is_in_user_syscall()
  */
 ZTEST(syscalls, test_syscall_context)
 {

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -97,11 +97,24 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 }
 
 /**
- * @brief Test to check if the thread is in user mode
+ * @brief Verify that a ZTEST_USER case really runs unprivileged.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Every negative case in this suite relies on the test thread being
+ * unprivileged, so this case anchors that assumption by asking the kernel
+ * directly.
+ *
+ * Test steps:
+ * - From the test thread, call k_is_user_context().
+ *
+ * Expected result:
+ * - The thread reports user context.
+ *
+ * @see k_is_user_context()
  */
-ZTEST_USER(userspace, test_is_usermode)
+ZTEST_USER(userspace, test_userspace_is_usermode)
 {
 	/* Confirm that we are in fact running in user mode. */
 	clear_fault();
@@ -110,11 +123,23 @@ ZTEST_USER(userspace, test_is_usermode)
 }
 
 /**
- * @brief Test to check if k_is_pre_kernel works from user mode
+ * @brief Verify that k_is_pre_kernel() is callable and false in user mode.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The predicate reads kernel state, so calling it from an unprivileged
+ * thread must neither fault nor claim the kernel is still initializing.
+ *
+ * Test steps:
+ * - From the user-mode test thread, call k_is_pre_kernel().
+ *
+ * Expected result:
+ * - The call succeeds and returns false.
+ *
+ * @see k_is_pre_kernel()
  */
-ZTEST_USER(userspace, test_is_post_kernel)
+ZTEST_USER(userspace, test_userspace_is_post_kernel)
 {
 	clear_fault();
 
@@ -122,11 +147,28 @@ ZTEST_USER(userspace, test_is_post_kernel)
 }
 
 /**
- * @brief Test to write to a control register
+ * @brief Verify that user mode cannot write CPU control registers.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Privileged CPU state -- control, status or protection registers,
+ * whichever the architecture exposes -- must be out of reach: an
+ * unprivileged write has to trap instead of taking effect. On Cortex-M the
+ * write is silently ignored, so the register is read back unchanged instead
+ * of expecting a fault.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Attempt the architecture's privileged register access from user mode.
+ * - On Cortex-M, read the register back instead.
+ *
+ * Expected result:
+ * - The access faults with K_ERR_CPU_EXCEPTION (or is proven ineffective on Cortex-M).
  */
-ZTEST_USER(userspace, test_write_control)
+ZTEST_USER(userspace, test_userspace_write_control)
 {
 	/* Try to write to a control register. */
 #if defined(CONFIG_X86)
@@ -212,11 +254,26 @@ ZTEST_USER(userspace, test_write_control)
 }
 
 /**
- * @brief Test to disable memory protection
+ * @brief Verify that user mode cannot disable the MMU or MPU.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Turning off memory protection from user mode would defeat every other
+ * guarantee in this suite, so the attempt itself must trap, whatever form
+ * it takes on the architecture: clearing enable bits, rewriting protection
+ * entries or remapping regions.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Attempt the architecture's MMU/MPU disable sequence from user mode.
+ *
+ * Expected result:
+ * - The attempt faults with K_ERR_CPU_EXCEPTION; the code after it is never reached.
  */
-ZTEST_USER(userspace, test_disable_mmu_mpu)
+ZTEST_USER(userspace, test_userspace_disable_mmu_mpu)
 {
 	/* Try to disable memory protections. */
 #if defined(CONFIG_X86)
@@ -312,11 +369,24 @@ ZTEST_USER(userspace, test_disable_mmu_mpu)
 }
 
 /**
- * @brief Test to read from kernel RAM
+ * @brief Verify that user mode cannot read kernel RAM.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The kernel's own data -- here a field of the current thread's kernel
+ * structure -- must be unreadable from user mode.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Read a member of the current thread's kernel object from user mode.
+ *
+ * Expected result:
+ * - The read faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_read_kernram)
+ZTEST_USER(userspace, test_userspace_read_kernram)
 {
 	/* Try to read from kernel RAM. */
 	void *p;
@@ -329,11 +399,24 @@ ZTEST_USER(userspace, test_read_kernram)
 }
 
 /**
- * @brief Test to write to kernel RAM
+ * @brief Verify that user mode cannot write kernel RAM.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The write counterpart of the kernel RAM read: storing to a field of the
+ * current thread's kernel structure must trap.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Write a member of the current thread's kernel object from user mode.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_write_kernram)
+ZTEST_USER(userspace, test_userspace_write_kernram)
 {
 	/* Try to write to kernel RAM. */
 	set_fault(K_ERR_CPU_EXCEPTION);
@@ -347,11 +430,26 @@ extern int _errno_neg_eagain;
 #include <zephyr/linker/linker-defs.h>
 
 /**
- * @brief Test to write kernel RO
+ * @brief Verify that user mode cannot write the kernel's read-only data.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A kernel variable placed in .rodata must reject user-mode writes. The
+ * case first proves the chosen symbol really lives in the rodata region, so
+ * the fault genuinely exercises read-only protection.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Check the target symbol's address lies inside the rodata region.
+ * - Write to it from user mode.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_write_kernro)
+ZTEST_USER(userspace, test_userspace_write_kernro)
 {
 	bool in_rodata;
 
@@ -371,11 +469,24 @@ ZTEST_USER(userspace, test_write_kernro)
 }
 
 /**
- * @brief Test to write to kernel text section
+ * @brief Verify that user mode cannot write kernel code.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Patching kernel text from user mode is the classic privilege escalation,
+ * so overwriting the body of a kernel function must trap.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - memset() over a kernel function from user mode.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_write_kerntext)
+ZTEST_USER(userspace, test_userspace_write_kerntext)
 {
 	/* Try to write to kernel text. */
 	set_fault(K_ERR_CPU_EXCEPTION);
@@ -387,11 +498,24 @@ ZTEST_USER(userspace, test_write_kerntext)
 static int kernel_data;
 
 /**
- * @brief Test to read from kernel data section
+ * @brief Verify that user mode cannot read a kernel static variable.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A file-scope kernel variable is not in any partition granted to the
+ * test thread, so even a read of it must trap.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Read a kernel static variable from user mode.
+ *
+ * Expected result:
+ * - The read faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_read_kernel_data)
+ZTEST_USER(userspace, test_userspace_read_kernel_data)
 {
 	set_fault(K_ERR_CPU_EXCEPTION);
 
@@ -400,11 +524,23 @@ ZTEST_USER(userspace, test_read_kernel_data)
 }
 
 /**
- * @brief Test to write to kernel data section
+ * @brief Verify that user mode cannot write a kernel static variable.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The write counterpart of the kernel data read.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Write a kernel static variable from user mode.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_write_kernel_data)
+ZTEST_USER(userspace, test_userspace_write_kernel_data)
 {
 	set_fault(K_ERR_CPU_EXCEPTION);
 
@@ -422,11 +558,26 @@ K_APP_DMEM(default_part) int32_t size = (0 - CONFIG_PRIVILEGED_STACK_SIZE -
 #endif
 
 /**
- * @brief Test to read privileged stack
+ * @brief Verify that user mode cannot read its own privileged stack.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Each user thread has a privileged stack used while it executes system
+ * calls; its contents are kernel state and must be unreadable from user
+ * mode even though the stack belongs to this very thread.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Locate the current thread's privileged stack.
+ * - Read one byte of it from user mode.
+ *
+ * Expected result:
+ * - The read faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_read_priv_stack)
+ZTEST_USER(userspace, test_userspace_read_priv_stack)
 {
 	/* Try to read from privileged stack. */
 #if defined(CONFIG_ARC)
@@ -447,11 +598,26 @@ ZTEST_USER(userspace, test_read_priv_stack)
 }
 
 /**
- * @brief Test to write to privilege stack
+ * @brief Verify that user mode cannot write its own privileged stack.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The write counterpart of the privileged stack read: corrupting the
+ * stack the kernel will use for this thread's next system call must be
+ * impossible.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Locate the current thread's privileged stack.
+ * - Write one byte of it from user mode.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_write_priv_stack)
+ZTEST_USER(userspace, test_userspace_write_priv_stack)
 {
 	/* Try to write to privileged stack. */
 #if defined(CONFIG_ARC)
@@ -475,11 +641,28 @@ ZTEST_USER(userspace, test_write_priv_stack)
 K_APP_BMEM(default_part) static struct k_sem sem;
 
 /**
- * @brief Test to pass a user object to system call
+ * @brief Verify that a system call rejects an object in user memory.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Kernel objects live in kernel memory; a structure in a user partition
+ * cannot be one, however plausible it looks. Passing it to a system call
+ * must oops rather than let the kernel initialize user-controlled memory
+ * as an object.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Call k_sem_init() on a semaphore structure in user memory.
+ *
+ * Expected result:
+ * - The call oopses with K_ERR_KERNEL_OOPS.
+ *
+ * @see k_sem_init()
  */
-ZTEST_USER(userspace, test_pass_user_object)
+ZTEST_USER(userspace, test_userspace_pass_user_object)
 {
 	/* Try to pass a user object to a system call. */
 	set_fault(K_ERR_KERNEL_OOPS);
@@ -491,11 +674,26 @@ ZTEST_USER(userspace, test_pass_user_object)
 static struct k_sem ksem;
 
 /**
- * @brief Test to pass object to a system call without permissions
+ * @brief Verify that a system call rejects an object the caller lacks permission on.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A genuine kernel object the calling thread was never granted must be
+ * refused the same way as a fake one.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Call k_sem_init() on a kernel semaphore never granted to the thread.
+ *
+ * Expected result:
+ * - The call oopses with K_ERR_KERNEL_OOPS.
+ *
+ * @see k_sem_init()
  */
-ZTEST_USER(userspace, test_pass_noperms_object)
+ZTEST_USER(userspace, test_userspace_pass_noperms_object)
 {
 	/* Try to pass a object to a system call w/o permissions. */
 	set_fault(K_ERR_KERNEL_OOPS);
@@ -514,11 +712,26 @@ void thread_body(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test to start kernel thread from usermode
+ * @brief Verify that user mode cannot create a supervisor thread.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Creating a thread without K_USER from user mode would mint privileged
+ * execution out of unprivileged code, so the create call must oops.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Call k_thread_create() from user mode without the K_USER option.
+ *
+ * Expected result:
+ * - The call oopses with K_ERR_KERNEL_OOPS.
+ *
+ * @see k_thread_create()
  */
-ZTEST_USER(userspace, test_start_kernel_thread)
+ZTEST_USER(userspace, test_userspace_start_kernel_thread)
 {
 	/* Try to start a kernel thread from a usermode thread */
 	set_fault(K_ERR_KERNEL_OOPS);
@@ -548,11 +761,28 @@ static void uthread_write_body(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test to read from another thread's stack
+ * @brief Verify that one user thread cannot read another's stack.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * With CONFIG_MEM_DOMAIN_ISOLATED_STACKS the stacks of threads in the same
+ * memory domain are isolated from each other, so a spawned thread reading a
+ * stack variable of its parent must fault. Skipped where that isolation is
+ * not configured, since the baseline memory domain model permits the
+ * access.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Spawn a user thread and hand it the address of a parent stack variable.
+ * - Have it read through that pointer.
+ *
+ * Expected result:
+ * - The read faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_read_other_stack)
+ZTEST_USER(userspace, test_userspace_read_other_stack)
 {
 	/* Try to read from another thread's stack. */
 	unsigned int val;
@@ -575,13 +805,26 @@ ZTEST_USER(userspace, test_read_other_stack)
 	k_thread_join(&test_thread, K_FOREVER);
 }
 
-
 /**
- * @brief Test to write to other thread's stack
+ * @brief Verify that one user thread cannot write another's stack.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The write counterpart of the cross-stack read, under the same
+ * CONFIG_MEM_DOMAIN_ISOLATED_STACKS condition.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Spawn a user thread and hand it the address of a parent stack variable.
+ * - Have it write through that pointer.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
  */
-ZTEST_USER(userspace, test_write_other_stack)
+ZTEST_USER(userspace, test_userspace_write_other_stack)
 {
 	/* Try to write to another thread's stack. */
 	unsigned int val;
@@ -612,7 +855,7 @@ ZTEST_USER(userspace, test_write_other_stack)
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST_USER(userspace, test_revoke_noperms_object)
+ZTEST_USER(userspace, test_userspace_revoke_noperms_object)
 {
 	/* Attempt to revoke access to kobject w/o permissions*/
 	set_fault(K_ERR_KERNEL_OOPS);
@@ -624,11 +867,29 @@ ZTEST_USER(userspace, test_revoke_noperms_object)
 }
 
 /**
- * @brief Test to access object after revoking access
+ * @brief Verify that a thread's own revocation of an object is enforced.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * k_object_release() drops the calling thread's permission on an object.
+ * After releasing a semaphore it was granted, using that semaphore must
+ * oops exactly as if it had never been granted.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Release the granted semaphore with k_object_release().
+ * - Call k_sem_take() on it.
+ *
+ * Expected result:
+ * - The take oopses with K_ERR_KERNEL_OOPS.
+ *
+ * @see k_object_release()
+ * @see k_sem_take()
  */
-ZTEST_USER(userspace, test_access_after_revoke)
+ZTEST_USER(userspace, test_userspace_access_after_revoke)
 {
 	k_object_release(&test_revoke_sem);
 
@@ -658,7 +919,7 @@ static void umode_enter_func(void *p1, void *p2, void *p3)
 *
 * @ingroup kernel_memprotect_tests
 */
-ZTEST(userspace, test_user_mode_enter)
+ZTEST(userspace, test_userspace_user_mode_enter)
 {
 	clear_fault();
 
@@ -669,11 +930,28 @@ ZTEST(userspace, test_user_mode_enter)
 /* Define and initialize pipe. */
 K_PIPE_DEFINE(kpipe, PIPE_LEN, BYTES_TO_READ_WRITE);
 /**
- * @brief Test to write to kobject using pipe
+ * @brief Verify that a syscall output buffer cannot overlay a kernel object.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * k_pipe_read() writes into a caller-supplied buffer, so pointing that
+ * buffer at a kernel object would let the kernel overwrite its own state on
+ * the user's behalf. The write-validation of the syscall boundary has to
+ * refuse it.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Call k_pipe_read() with a kernel semaphore's address as the buffer.
+ *
+ * Expected result:
+ * - The call oopses with K_ERR_KERNEL_OOPS.
+ *
+ * @see k_pipe_read()
  */
-ZTEST_USER(userspace, test_write_kobject_user_pipe)
+ZTEST_USER(userspace, test_userspace_write_kobject_user_pipe)
 {
 	/*
 	 * Attempt to use system call from k_pipe_read to write over
@@ -688,11 +966,27 @@ ZTEST_USER(userspace, test_write_kobject_user_pipe)
 }
 
 /**
- * @brief Test to read from kobject using pipe
+ * @brief Verify that a syscall input buffer cannot leak a kernel object.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * k_pipe_write() reads from a caller-supplied buffer, so pointing it at a
+ * kernel object would exfiltrate kernel memory through the pipe. The
+ * read-validation of the syscall boundary has to refuse it.
+ * The suite's fatal error handler compares the fault reason against the
+ * one the case armed and converts the expected fault into a pass;
+ * running past the access fails the case.
+ *
+ * Test steps:
+ * - Call k_pipe_write() with a kernel semaphore's address as the buffer.
+ *
+ * Expected result:
+ * - The call oopses with K_ERR_KERNEL_OOPS.
+ *
+ * @see k_pipe_write()
  */
-ZTEST_USER(userspace, test_read_kobject_user_pipe)
+ZTEST_USER(userspace, test_userspace_read_kobject_user_pipe)
 {
 	/*
 	 * Attempt to use system call from k_pipe_write to read a
@@ -736,20 +1030,32 @@ static void drop_user(volatile bool *to_modify)
 }
 
 /**
- * @brief Test creation of new memory domains
- *
- * We initialize a new memory domain and show that its partition configuration
- * is correct. This new domain has "alt_part" in it, but not "default_part".
- * We then try to modify data in "default_part" and show it produces an
- * exception since that partition is not in the new domain.
- *
- * This caught a bug once where an MMU system copied page tables for the new
- * domain and accidentally copied memory partition permissions from the source
- * page tables, allowing the write to "default_part" to work.
+ * @brief Verify that a new memory domain grants only its own partitions.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A freshly initialized domain containing "alt_part" but not "default_part"
+ * must deny access to the latter: a member thread writing data in
+ * "default_part" has to fault. This once caught an MMU port that copied the
+ * source page tables' partition permissions into the new domain, which made
+ * the forbidden write succeed. The "1st" in the name makes ztest's
+ * alphabetical ordering run this case first, as it initializes the alternate
+ * domain the other domain cases reuse. The suite's fatal error handler
+ * converts the expected fault into a pass.
+ *
+ * Test steps:
+ * - Initialize the alternate domain with the alternate partition only.
+ * - Move the current thread into it and spawn a user thread that writes a
+ *   variable in the default partition.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
+ *
+ * @see k_mem_domain_init()
+ * @see k_mem_domain_add_thread()
  */
-ZTEST(userspace_domain, test_1st_init_and_access_other_memdomain)
+ZTEST(userspace_domain, test_userspace_1st_init_and_access_other_memdomain)
 {
 	struct k_mem_partition *parts[] = {
 #if Z_LIBC_PARTITION_EXISTS
@@ -775,12 +1081,27 @@ extern uint8_t *z_priv_stack_find(void *obj);
 #endif
 
 /**
- * Show that changing between memory domains and dropping to user mode works
- * as expected.
+ * @brief Verify domain reassignment applies when dropping to user mode.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Moving the calling thread into the alternate domain and then entering
+ * user mode must apply that domain's partitions: the user half writes a
+ * variable in a partition only the alternate domain carries, which succeeds
+ * only if the switch took effect.
+ *
+ * Test steps:
+ * - Add the current thread to the alternate domain.
+ * - Drop to user mode and write a variable in the alternate partition.
+ *
+ * Expected result:
+ * - The write succeeds with no fault.
+ *
+ * @see k_mem_domain_add_thread()
+ * @see k_thread_user_mode_enter()
  */
-ZTEST(userspace_domain, test_domain_add_thread_drop_to_user)
+ZTEST(userspace_domain, test_userspace_domain_add_thread_drop_to_user)
 {
 	clear_fault();
 	k_mem_domain_add_thread(&alternate_domain, k_current_get());
@@ -788,14 +1109,25 @@ ZTEST(userspace_domain, test_domain_add_thread_drop_to_user)
 }
 
 /**
- * @brief Test adding application memory partition to memory domain
- *
- * @details Show that adding a partition to a domain and then dropping to user
- * mode works as expected.
+ * @brief Verify a partition added to a domain is visible after dropping to user.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Adding a partition to the default domain must grant its member threads
+ * access as soon as they run in user mode.
+ *
+ * Test steps:
+ * - Add the alternate partition to the default domain.
+ * - Drop to user mode and write a variable in that partition.
+ *
+ * Expected result:
+ * - The write succeeds with no fault.
+ *
+ * @see k_mem_domain_add_partition()
+ * @see k_thread_user_mode_enter()
  */
-ZTEST(userspace_domain, test_domain_add_part_drop_to_user)
+ZTEST(userspace_domain, test_userspace_domain_add_part_drop_to_user)
 {
 	clear_fault();
 
@@ -807,12 +1139,26 @@ ZTEST(userspace_domain, test_domain_add_part_drop_to_user)
 }
 
 /**
- * Show that self-removing a partition from a domain we are a member of,
- * and then dropping to user mode faults as expected.
+ * @brief Verify a partition removed from a domain is revoked on entering user.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The inverse of the add case: after the partition added by the previous
+ * case is removed again, a user-mode access to it must fault. Ztest runs
+ * the suite alphabetically, so the add_part case has already run.
+ * The suite's fatal error handler converts the expected fault into a pass.
+ *
+ * Test steps:
+ * - Remove the alternate partition from the default domain.
+ * - Drop to user mode and write a variable in that partition.
+ *
+ * Expected result:
+ * - The write faults with K_ERR_CPU_EXCEPTION.
+ *
+ * @see k_mem_domain_remove_partition()
  */
-ZTEST(userspace_domain, test_domain_remove_part_drop_to_user)
+ZTEST(userspace_domain, test_userspace_domain_remove_part_drop_to_user)
 {
 	/* We added alt_part to the default domain in the previous test,
 	 * remove it, and then try to access again.
@@ -827,12 +1173,26 @@ ZTEST(userspace_domain, test_domain_remove_part_drop_to_user)
 }
 
 /**
- * Show that changing between memory domains and then switching to another
- * thread in the same domain works as expected.
+ * @brief Verify domain reassignment applies across a context switch.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The same domain-move check as the drop-to-user variant, but observed
+ * from a freshly spawned user thread, so the domain configuration is
+ * applied on a context switch rather than a privilege drop.
+ *
+ * Test steps:
+ * - Add the current thread to the alternate domain.
+ * - Spawn a user thread that writes a variable in the alternate partition
+ *   and join it.
+ *
+ * Expected result:
+ * - The spawned thread's write succeeds with no fault.
+ *
+ * @see k_mem_domain_add_thread()
  */
-ZTEST(userspace_domain_ctx, test_domain_add_thread_context_switch)
+ZTEST(userspace_domain_ctx, test_userspace_domain_add_thread_context_switch)
 {
 	clear_fault();
 	k_mem_domain_add_thread(&alternate_domain, k_current_get());
@@ -840,12 +1200,24 @@ ZTEST(userspace_domain_ctx, test_domain_add_thread_context_switch)
 }
 
 /**
- * Show that adding a partition to a domain and then switching to another
- * user thread in the same domain works as expected.
+ * @brief Verify a partition added to a domain is visible across a context switch.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The context-switch counterpart of the add_part drop-to-user case.
+ *
+ * Test steps:
+ * - Add the alternate partition to the default domain.
+ * - Spawn a user thread that writes a variable in that partition and join
+ *   it.
+ *
+ * Expected result:
+ * - The spawned thread's write succeeds with no fault.
+ *
+ * @see k_mem_domain_add_partition()
  */
-ZTEST(userspace_domain_ctx, test_domain_add_part_context_switch)
+ZTEST(userspace_domain_ctx, test_userspace_domain_add_part_context_switch)
 {
 	clear_fault();
 
@@ -857,13 +1229,26 @@ ZTEST(userspace_domain_ctx, test_domain_add_part_context_switch)
 }
 
 /**
- * Show that self-removing a partition from a domain we are a member of,
- * and then switching to another user thread in the same domain faults as
- * expected.
+ * @brief Verify a removed partition is revoked across a context switch.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The context-switch counterpart of the remove_part drop-to-user case;
+ * the partition added by the preceding add_part case is removed and the
+ * next user thread to touch it must fault. The suite's fatal error handler
+ * converts the expected fault into a pass.
+ *
+ * Test steps:
+ * - Remove the alternate partition from the default domain.
+ * - Spawn a user thread that writes a variable in that partition.
+ *
+ * Expected result:
+ * - The spawned thread's write faults with K_ERR_CPU_EXCEPTION.
+ *
+ * @see k_mem_domain_remove_partition()
  */
-ZTEST(userspace_domain_ctx, test_domain_remove_part_context_switch)
+ZTEST(userspace_domain_ctx, test_userspace_domain_remove_part_context_switch)
 {
 	/* We added alt_part to the default domain in the previous test,
 	 * remove it, and then try to access again.
@@ -892,7 +1277,7 @@ void z_impl_missing_syscall(void)
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST_USER(userspace, test_unimplemented_syscall)
+ZTEST_USER(userspace, test_userspace_unimplemented_syscall)
 {
 	set_fault(K_ERR_KERNEL_OOPS);
 
@@ -908,7 +1293,7 @@ ZTEST_USER(userspace, test_unimplemented_syscall)
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST_USER(userspace, test_bad_syscall)
+ZTEST_USER(userspace, test_userspace_bad_syscall)
 {
 	set_fault(K_ERR_KERNEL_OOPS);
 
@@ -932,7 +1317,7 @@ static struct k_sem recycle_sem;
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST(userspace, test_object_recycle)
+ZTEST(userspace, test_userspace_object_recycle)
 {
 	struct k_object *ko;
 	int perms_count = 0;
@@ -967,27 +1352,107 @@ ZTEST(userspace, test_object_recycle)
 	z_except_reason(provided); \
 } while (false)
 
-ZTEST_USER(userspace, test_oops_panic)
+/**
+ * @brief Verify that k_panic() from user mode lands as an oops.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A user thread must not be able to force a kernel panic: the panic
+ * reason is downgraded so only the offending thread dies. The suite's
+ * fatal error handler checks the delivered reason.
+ *
+ * Test steps:
+ * - Invoke z_except_reason() with K_ERR_KERNEL_PANIC from user mode.
+ *
+ * Expected result:
+ * - The fault arrives as K_ERR_KERNEL_OOPS.
+ *
+ * @see k_panic()
+ */
+ZTEST_USER(userspace, test_userspace_oops_panic)
 {
 	test_oops(K_ERR_KERNEL_PANIC, K_ERR_KERNEL_OOPS);
 }
 
-ZTEST_USER(userspace, test_oops_oops)
+/**
+ * @brief Verify that k_oops() from user mode is delivered as an oops.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The straightforward case: a user-raised oops arrives with its own
+ * reason.
+ *
+ * Test steps:
+ * - Invoke z_except_reason() with K_ERR_KERNEL_OOPS from user mode.
+ *
+ * Expected result:
+ * - The fault arrives as K_ERR_KERNEL_OOPS.
+ *
+ * @see k_oops()
+ */
+ZTEST_USER(userspace, test_userspace_oops_oops)
 {
 	test_oops(K_ERR_KERNEL_OOPS, K_ERR_KERNEL_OOPS);
 }
 
-ZTEST_USER(userspace, test_oops_exception)
+/**
+ * @brief Verify that a user-raised CPU-exception reason is downgraded to oops.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * User code must not be able to forge fault reasons reserved for the
+ * kernel: requesting K_ERR_CPU_EXCEPTION arrives as an ordinary oops.
+ *
+ * Test steps:
+ * - Invoke z_except_reason() with K_ERR_CPU_EXCEPTION from user mode.
+ *
+ * Expected result:
+ * - The fault arrives as K_ERR_KERNEL_OOPS.
+ */
+ZTEST_USER(userspace, test_userspace_oops_exception)
 {
 	test_oops(K_ERR_CPU_EXCEPTION, K_ERR_KERNEL_OOPS);
 }
 
-ZTEST_USER(userspace, test_oops_maxint)
+/**
+ * @brief Verify that an out-of-range oops reason is downgraded to oops.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A nonsense reason value from user mode must not reach the fatal error
+ * handler unfiltered.
+ *
+ * Test steps:
+ * - Invoke z_except_reason() with INT_MAX from user mode.
+ *
+ * Expected result:
+ * - The fault arrives as K_ERR_KERNEL_OOPS.
+ */
+ZTEST_USER(userspace, test_userspace_oops_maxint)
 {
 	test_oops(INT_MAX, K_ERR_KERNEL_OOPS);
 }
 
-ZTEST_USER(userspace, test_oops_stackcheck)
+/**
+ * @brief Verify that a user-raised stack-check failure keeps its reason.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * K_ERR_STACK_CHK_FAIL is a legitimate reason for user code to raise,
+ * so unlike the forged kernel reasons it must be delivered unchanged.
+ *
+ * Test steps:
+ * - Invoke z_except_reason() with K_ERR_STACK_CHK_FAIL from user mode.
+ *
+ * Expected result:
+ * - The fault arrives as K_ERR_STACK_CHK_FAIL.
+ */
+ZTEST_USER(userspace, test_userspace_oops_stackcheck)
 {
 	test_oops(K_ERR_STACK_CHK_FAIL, K_ERR_STACK_CHK_FAIL);
 }
@@ -1013,6 +1478,26 @@ static inline void z_vrfy_check_syscall_context(void)
 }
 #include <zephyr/syscalls/check_syscall_context_mrsh.c>
 
+/**
+ * @brief Verify the kernel context in which system calls execute.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * While handling a system call from user mode the kernel must run with
+ * interrupts unlocked and must not consider itself in ISR context; either
+ * would distort every syscall that checks or manipulates that state.
+ *
+ * Test steps:
+ * - Invoke a test system call whose implementation checks the IRQ lock
+ *   state and k_is_in_isr().
+ *
+ * Expected result:
+ * - Interrupts are unlocked and no ISR context is reported inside the
+ *   call.
+ *
+ * @see k_is_in_isr()
+ */
 ZTEST_USER(userspace, test_userspace_syscall_context)
 {
 	check_syscall_context();
@@ -1030,7 +1515,28 @@ static void tls_leakage_user_part(void *p1, void *p2, void *p3)
 }
 #endif
 
-ZTEST(userspace, test_tls_leakage)
+/**
+ * @brief Verify that supervisor TLS contents do not leak into user mode.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The thread's userspace-local-data area is written with a marker while
+ * still in supervisor mode; after dropping to user mode none of the marker
+ * must remain readable, while the area itself stays fully accessible to
+ * the user thread. Skipped without CONFIG_THREAD_USERSPACE_LOCAL_DATA.
+ *
+ * Test steps:
+ * - Fill the thread's userspace local data with a marker in supervisor
+ *   mode.
+ * - Drop to user mode and scan the area.
+ *
+ * Expected result:
+ * - No byte of the supervisor-written marker survives into user mode.
+ *
+ * @see k_thread_user_mode_enter()
+ */
+ZTEST(userspace, test_userspace_tls_leakage)
 {
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 	/* Tests two assertions:
@@ -1057,7 +1563,25 @@ void tls_entry(void *p1, void *p2, void *p3)
 }
 #endif
 
-ZTEST(userspace, test_tls_pointer)
+/**
+ * @brief Verify that a user thread's TLS area lies within its stack object.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The userspace local data of a thread lives inside that thread's own
+ * stack allocation; a TLS pointer outside those bounds would alias other
+ * memory. Skipped without CONFIG_THREAD_USERSPACE_LOCAL_DATA.
+ *
+ * Test steps:
+ * - Create a user thread without starting it.
+ * - Compare its userspace_local_data range against its stack object
+ *   bounds.
+ *
+ * Expected result:
+ * - The TLS area lies entirely within the thread's stack object.
+ */
+ZTEST(userspace, test_userspace_tls_pointer)
 {
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 	char *stack_obj_ptr;
@@ -1143,7 +1667,30 @@ static K_KERNEL_THREAD_DEFINE(kernel_only_thread,
 			      kernel_only_thread_entry, NULL, NULL, NULL,
 			      0, 0, 0);
 
-ZTEST(userspace, test_kernel_only_thread)
+/**
+ * @brief Verify that a K_KERNEL_THREAD-defined thread cannot enter user mode.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A thread defined with K_KERNEL_THREAD_DEFINE has no privilege-drop
+ * setup, so attempting k_thread_user_mode_enter() from it must raise a
+ * fatal error (panic, or oops on architectures that report it so) instead
+ * of reaching user mode.
+ *
+ * Test steps:
+ * - Release the statically defined kernel-only thread.
+ * - Have it attempt k_thread_user_mode_enter().
+ * - Check which parts of it ran.
+ *
+ * Expected result:
+ * - The kernel-mode half runs, the fatal error fires, and the user-mode
+ *   entry point never executes.
+ *
+ * @see K_KERNEL_THREAD_DEFINE
+ * @see k_thread_user_mode_enter()
+ */
+ZTEST(userspace, test_userspace_kernel_only_thread)
 {
 	kernel_only_thread_ran = false;
 	kernel_only_thread_user_ran = false;

--- a/tests/kernel/mem_protect/userspace/src/switching.c
+++ b/tests/kernel/mem_protect/userspace/src/switching.c
@@ -158,7 +158,32 @@ static void run_switching(int num_kernel_threads)
 #endif /* CONFIG_USERSPACE_SWITCHING_TESTS */
 }
 
-ZTEST(userspace_domain_switching, test_kernel_only_switching)
+/**
+ * @brief Verify the switching scenario with kernel threads as a baseline.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Threads pinned to one CPU alternate through the scheduler while belonging
+ * to two disjoint memory domains -- even-numbered threads in domain A, odd in
+ * domain B. Every reschedule must swap in the incoming thread's domain: each
+ * thread increments a counter in its own partition every loop, and the
+ * counter in the other domain's partition must stay untouched, so a stale
+ * domain after a switch shows up as a fault or a stray count. Skipped without
+ * CONFIG_USERSPACE_SWITCHING_TESTS.
+ *
+ * This variant runs every thread as a kernel thread, which has access to all
+ * memory regardless of domains, proving the scenario itself is sound before
+ * the user-mode variants rely on it.
+ *
+ * Test steps:
+ * - Run the switching scenario with all threads created as kernel threads.
+ *
+ * Expected result:
+ * - Every thread completes its loops and the cross-partition counters stay
+ *   zero.
+ */
+ZTEST(userspace_domain_switching, test_userspace_kernel_only_switching)
 {
 	/*
 	 * Run with all kernel threads.
@@ -170,13 +195,69 @@ ZTEST(userspace_domain_switching, test_kernel_only_switching)
 	run_switching(NUM_THREADS);
 }
 
-ZTEST(userspace_domain_switching, test_user_only_switching)
+/**
+ * @brief Verify domain isolation while switching among user threads.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Threads pinned to one CPU alternate through the scheduler while belonging
+ * to two disjoint memory domains -- even-numbered threads in domain A, odd in
+ * domain B. Every reschedule must swap in the incoming thread's domain: each
+ * thread increments a counter in its own partition every loop, and the
+ * counter in the other domain's partition must stay untouched, so a stale
+ * domain after a switch shows up as a fault or a stray count. Skipped without
+ * CONFIG_USERSPACE_SWITCHING_TESTS.
+ *
+ * This is the full test: every thread is a user thread confined to its
+ * domain, so each context switch has to reprogram the protection hardware.
+ *
+ * Test steps:
+ * - Run the switching scenario with all threads created as user threads,
+ *   assigned alternately to the two domains.
+ *
+ * Expected result:
+ * - Every thread completes its loops and the cross-partition counters stay
+ *   zero.
+ *
+ * @see k_mem_domain_add_thread()
+ */
+ZTEST(userspace_domain_switching, test_userspace_user_only_switching)
 {
 	/* Run with all user threads. */
 	run_switching(0);
 }
 
-ZTEST(userspace_domain_switching, test_kernel_user_mix_switching)
+/**
+ * @brief Verify domain isolation with kernel and user threads interleaved.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * Threads pinned to one CPU alternate through the scheduler while belonging
+ * to two disjoint memory domains -- even-numbered threads in domain A, odd in
+ * domain B. Every reschedule must swap in the incoming thread's domain: each
+ * thread increments a counter in its own partition every loop, and the
+ * counter in the other domain's partition must stay untouched, so a stale
+ * domain after a switch shows up as a fault or a stray count. Skipped without
+ * CONFIG_USERSPACE_SWITCHING_TESTS.
+ *
+ * One thread stays a kernel thread while the rest run in user mode, so the
+ * scheduler alternates between threads that bypass the domains and threads
+ * confined by them -- the transition each direction must restore the right
+ * protection view.
+ *
+ * Test steps:
+ * - Run the switching scenario with one kernel thread and the rest user
+ *   threads.
+ *
+ * Expected result:
+ * - Every thread completes its loops and the cross-partition counters stay
+ *   zero.
+ *
+ * @see k_mem_domain_add_thread()
+ */
+ZTEST(userspace_domain_switching, test_userspace_kernel_user_mix_switching)
 {
 	/* Run with one kernel thread while others are all user threads. */
 	run_switching(1);


### PR DESCRIPTION
- **tests: kernel: mem_protect: stack_random: document the test case**
- **tests: kernel: mem_protect: ondemand_section: document the test case**
- **tests: kernel: mem_protect: protection: document the test cases**
- **tests: kernel: mem_protect: obj_validation: document the test cases**
- **tests: kernel: mem_protect: stackprot: document the test cases**
- **tests: kernel: mem_protect: syscalls: document the test cases**
- **tests: kernel: mem_protect: mem_map: document the test cases**
- **tests: kernel: mem_protect: demand_paging: document the test cases**
- **tests: kernel: mem_protect: futex: document the test cases**
- **tests: kernel: mem_protect: userspace: document the test cases**
- **tests: kernel: mem_protect: document the test cases**
