### PR TITLE
tests: kernel: threads: overhaul test documentation

### DIFF
--- a/tests/benchmarks/pmu/src/main.c
+++ b/tests/benchmarks/pmu/src/main.c
@@ -151,7 +151,7 @@ static void pmu_bench_suite_setup(void)
 #ifdef CONFIG_SMP
 	bench_cpu = arch_curr_cpu()->id;
 	/*
-	 * CPU mask APIs cannot pin a running thread (see test_threads_cpu_mask).
+	 * CPU mask APIs cannot pin a running thread (see test_thread_cpu_mask).
 	 * Record the boot CPU and verify it in pmu_bench_begin(); pin helper
 	 * threads to bench_cpu before k_thread_start().
 	 */

--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -106,14 +106,33 @@ static void permission_test(void)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test object permission on dynamic user thread when index is reused
+ * @brief Verify that object permissions do not survive a reused thread index.
  *
- * @details This creates one dynamic thread with permissions to both
- * semaphores so there is no fault. Then a new thread is created and will be
- * re-using the thread index in first pass. Except the second thread does
- * not have permission to one of the semaphore. If permissions are cleared
- * correctly when thread is destroyed, the second should raise kernel oops.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * Thread indexes are recycled, so a newly allocated dynamic thread may occupy
+ * the index a destroyed one used. Its permission bits must be cleared when the
+ * old thread is destroyed, otherwise the new thread silently inherits access
+ * to objects that were granted to its predecessor. The dynamic creation cases
+ * of this suite run before this one and leave behind destroyed threads that
+ * had access to both semaphores; this case then creates a thread granted
+ * access to only one of them and has it touch the other, which must fault
+ * rather than succeed.
+ *
+ * Test steps:
+ * - Allocate a dynamic thread object and create a user thread from it,
+ *   granting access to the start semaphore only.
+ * - Start the thread and release it, so it attempts to give the end semaphore
+ *   it was not granted.
+ * - Take the end semaphore with a timeout from the test thread.
+ *
+ * Expected result:
+ * - The thread raises a kernel oops on the object it was not granted, and the
+ *   end semaphore is never given, so the take times out.
+ *
+ * @see k_object_alloc()
+ * @see k_object_access_grant()
  */
 ZTEST(thread_dynamic, test_dyn_thread_perms)
 {
@@ -126,7 +145,30 @@ ZTEST(thread_dynamic, test_dyn_thread_perms)
 	TC_PRINT("===== must have access denied on k_sem %p\n", &end_sem);
 }
 
-ZTEST(thread_dynamic, test_thread_index_management)
+/**
+ * @brief Verify dynamic thread object indexes are exhausted and recycled.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * Allocates kernel thread objects until allocation fails, then proves the
+ * failure is caused by thread-index exhaustion rather than lack of heap by
+ * allocating an equally-sized plain kernel object. Freeing one thread object
+ * must make its index available for a subsequent allocation.
+ *
+ * Test steps:
+ * - Allocate K_OBJ_THREAD objects until k_object_alloc() returns NULL.
+ * - Allocate a same-size dynamic kernel object to show heap remains.
+ * - Free one thread object and allocate a new one.
+ *
+ * Expected result:
+ * - At least one thread object is created, the heap allocation succeeds,
+ *   and the freed thread index is reused for the new allocation.
+ *
+ * @see k_object_alloc()
+ * @see k_object_free()
+ */
+ZTEST(thread_dynamic, test_dyn_thread_index_recycle)
 {
 	int i, ctr = 0;
 
@@ -186,13 +228,34 @@ ZTEST(thread_dynamic, test_thread_index_management)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test creation of dynamic user thread under kernel thread
+ * @brief Verify that a kernel thread can create a dynamic user thread.
  *
- * @details This is a simple test to create a user thread
- * dynamically via k_object_alloc() under a kernel thread.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread object obtained from k_object_alloc() must be usable as the target
+ * of k_thread_create() exactly like a statically defined one, and the thread
+ * created from it must be able to run and use the objects it was granted. The
+ * created thread runs to completion through a pair of semaphores, so a
+ * dynamic object that is mis-initialized shows up as the handshake failing
+ * rather than as a silent no-op. Skipped without userspace, where dynamic
+ * kernel objects do not exist.
+ *
+ * Test steps:
+ * - Allocate a thread object with k_object_alloc() from the kernel-mode test
+ *   thread.
+ * - Create a user thread from it and grant it both semaphores.
+ * - Start the thread, give the start semaphore and wait on the end semaphore.
+ * - Abort the thread and release the object.
+ *
+ * Expected result:
+ * - The allocation succeeds and the dynamic user thread completes the
+ *   handshake within the timeout.
+ *
+ * @see k_object_alloc()
+ * @see k_thread_create()
  */
-ZTEST(thread_dynamic, test_kernel_create_dyn_user_thread)
+ZTEST(thread_dynamic, test_dyn_thread_create_from_kernel)
 {
 	if (!(IS_ENABLED(CONFIG_USERSPACE))) {
 		ztest_test_skip();
@@ -202,13 +265,31 @@ ZTEST(thread_dynamic, test_kernel_create_dyn_user_thread)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test creation of dynamic user thread under user thread
+ * @brief Verify that a user thread can create a dynamic user thread.
  *
- * @details This is a simple test to create a user thread
- * dynamically via k_object_alloc() under a user thread.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The same dynamic creation path has to work when the caller is itself a user
+ * thread, where k_object_alloc() and the grants that follow it are reached
+ * through system calls and are subject to the caller's own permissions. The
+ * check is therefore repeated with the test case running in user mode.
+ *
+ * Test steps:
+ * - Allocate a thread object with k_object_alloc() from a user-mode test
+ *   thread.
+ * - Create a user thread from it and grant it both semaphores.
+ * - Start the thread, give the start semaphore and wait on the end semaphore.
+ * - Abort the thread and release the object.
+ *
+ * Expected result:
+ * - The allocation succeeds and the dynamic user thread completes the
+ *   handshake within the timeout.
+ *
+ * @see k_object_alloc()
+ * @see k_thread_create()
  */
-ZTEST_USER(thread_dynamic, test_user_create_dyn_user_thread)
+ZTEST_USER(thread_dynamic, test_dyn_thread_create_from_user)
 {
 	create_dynamic_thread();
 }

--- a/tests/kernel/threads/dynamic_thread_stack/src/main.c
+++ b/tests/kernel/threads/dynamic_thread_stack/src/main.c
@@ -35,7 +35,33 @@ static void func(void *arg1, void *arg2, void *arg3)
 	*flag = true;
 }
 
-/** @brief Check we can create a thread from userspace, using dynamic objects */
+/**
+ * @brief Verify that a user thread can create a thread from dynamic objects.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A user thread has no statically defined thread object or stack to hand to
+ * k_thread_create(), so both have to come from the dynamic allocators: the
+ * thread object from k_object_alloc() and the stack from
+ * k_thread_stack_alloc() with K_USER. The spawned thread raises a flag, so a
+ * pass proves the pair of dynamic objects really produced a runnable user
+ * thread. Skipped when userspace is not enabled.
+ *
+ * Test steps:
+ * - Allocate a thread object and a user-mode thread stack.
+ * - Create and start a user thread on them.
+ * - Join the thread with a timeout and check its flag.
+ * - Free the stack.
+ *
+ * Expected result:
+ * - Both allocations succeed, the thread runs and sets its flag, and the
+ *   stack is freed without error.
+ *
+ * @see k_thread_stack_alloc()
+ * @see k_object_alloc()
+ * @see k_thread_create()
+ */
 ZTEST_USER(dynamic_thread_stack, test_dynamic_thread_stack_userspace_dyn_obj)
 {
 	k_tid_t tid;
@@ -71,7 +97,32 @@ ZTEST_USER(dynamic_thread_stack, test_dynamic_thread_stack_userspace_dyn_obj)
 	zassert_ok(k_thread_stack_free(stack));
 }
 
-/** @brief Exercise the pool-based thread stack allocator */
+/**
+ * @brief Verify that the thread stack pool serves and reclaims every slot.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * With CONFIG_DYNAMIC_THREAD_PREFER_POOL the allocator hands out stacks from a
+ * fixed pool of CONFIG_DYNAMIC_THREAD_POOL_SIZE entries. Allocating exactly
+ * that many stacks must succeed, and each one has to be usable as a real
+ * thread stack rather than merely being a non-NULL pointer, which is why a
+ * thread is run on every one of them. Skipped when the pool is not the
+ * preferred allocator.
+ *
+ * Test steps:
+ * - Allocate one stack per pool entry.
+ * - Create and start a thread on each stack.
+ * - Join every thread and check the flag it raised.
+ * - Free all stacks back to the pool.
+ *
+ * Expected result:
+ * - The pool satisfies every allocation, all threads run, and all stacks are
+ *   freed without error.
+ *
+ * @see k_thread_stack_alloc()
+ * @see k_thread_stack_free()
+ */
 ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_pool)
 {
 	static k_tid_t tid[CONFIG_DYNAMIC_THREAD_POOL_SIZE];
@@ -122,7 +173,32 @@ ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_pool)
 	}
 }
 
-/** @brief Exercise the heap-based thread stack allocator */
+/**
+ * @brief Verify that thread stacks can be allocated from the heap.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * With CONFIG_DYNAMIC_THREAD_PREFER_ALLOC the stacks come from the heap
+ * instead of the fixed pool, so the number available is bounded by memory
+ * rather than by a compile-time count. Each allocated stack has to carry a
+ * running thread, and freeing them has to return the memory so the sequence
+ * can be repeated. Skipped when heap allocation is not the preferred
+ * allocator.
+ *
+ * Test steps:
+ * - Allocate stacks from the heap up to the test's limit.
+ * - Create and start a thread on each stack.
+ * - Join every thread and check the flag it raised.
+ * - Free all stacks.
+ *
+ * Expected result:
+ * - Every allocation succeeds, all threads run, and all stacks are freed
+ *   without error.
+ *
+ * @see k_thread_stack_alloc()
+ * @see k_thread_stack_free()
+ */
 ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_alloc)
 {
 	size_t N;
@@ -210,7 +286,32 @@ static void perm_func_violator(void *arg1, void *arg2, void *arg3)
 	zassert_unreachable("should not reach here");
 }
 
-/** @brief Exercise stack permissions */
+/**
+ * @brief Verify that a thread cannot free a stack it does not own.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A dynamically allocated stack is owned by the thread it was granted to, so
+ * k_thread_stack_free() must refuse a caller that was never given access to
+ * it. Two threads are started on two separately allocated stacks and one of
+ * them attempts to free the other's, which must fault rather than release
+ * memory still in use. Skipped when heap allocation is not the preferred
+ * allocator.
+ *
+ * Test steps:
+ * - Allocate two thread stacks and start a thread on each.
+ * - Have the second thread call k_thread_stack_free() on the first thread's
+ *   stack, which it was not granted.
+ * - Observe that the violating thread does not run past that call.
+ *
+ * Expected result:
+ * - The attempt faults instead of freeing the stack, and the code after it is
+ *   never reached.
+ *
+ * @see k_thread_stack_free()
+ * @see k_thread_stack_alloc()
+ */
 ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_permission)
 {
 	static k_tid_t tid[2];

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -8,7 +8,33 @@
 #include <zephyr/device.h>
 #include <zephyr/ztest.h>
 
-ZTEST(no_multithreading, test_k_busy_wait)
+/**
+ * @brief Verify that k_busy_wait() delays for the requested time when
+ *        multithreading is disabled.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * With CONFIG_MULTITHREADING=n there is no scheduler and no other thread to
+ * switch to, so a busy wait has to be served entirely by the caller spinning
+ * while the system clock keeps advancing. Uptime is sampled around a busy wait
+ * of a known length to confirm both that the clock runs and that the delay is
+ * of the requested duration.
+ *
+ * Test steps:
+ * - Spin until the uptime changes, so the measurement starts on a tick
+ *   boundary, failing if it never does.
+ * - Sample the uptime, call k_busy_wait() for 10 ms and sample it again.
+ * - Compare the elapsed uptime against the requested delay.
+ *
+ * Expected result:
+ * - The uptime advances, and the elapsed time is within 2 ms of the 10 ms
+ *   that were requested.
+ *
+ * @see k_busy_wait()
+ * @see k_uptime_get()
+ */
+ZTEST(no_multithreading, test_no_multithreading_busy_wait)
 {
 	int64_t now = k_uptime_get();
 	uint32_t watchdog = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
@@ -39,7 +65,35 @@ static void timeout_handler(struct k_timer *timer)
 
 K_TIMER_DEFINE(timer, timeout_handler, NULL);
 
-ZTEST(no_multithreading, test_irq_locking)
+/**
+ * @brief Verify that locking interrupts defers a timer expiry handler.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * Interrupt locking is the only mutual exclusion mechanism left once
+ * multithreading is disabled, so it has to hold off the timer ISR: a timer
+ * that expires while interrupts are locked must not run its handler until
+ * they are unlocked. The handler sets a flag through the timer user data,
+ * which is sampled on both sides of the unlock.
+ *
+ * Test steps:
+ * - Start a 10 ms timer whose handler raises a flag.
+ * - Lock interrupts, busy-wait past the timer deadline with a tick of slack
+ *   and check the flag is still clear.
+ * - Unlock interrupts, allowing the pending timer interrupt to be delivered.
+ * - On a tickful kernel, busy-wait one more tick so a second announce reaches
+ *   the timer deadline, then check the flag.
+ *
+ * Expected result:
+ * - The handler does not run while interrupts are locked.
+ * - The handler runs once interrupts are unlocked.
+ *
+ * @see irq_lock()
+ * @see irq_unlock()
+ * @see k_timer_start()
+ */
+ZTEST(no_multithreading, test_no_multithreading_irq_lock)
 {
 	volatile bool timeout_run = false;
 
@@ -75,7 +129,32 @@ ZTEST(no_multithreading, test_irq_locking)
 	zassert_true(timeout_run, "Timeout should expire because irq got unlocked");
 }
 
-ZTEST(no_multithreading, test_cpu_idle)
+/**
+ * @brief Verify that k_cpu_idle() sleeps until a timer interrupt wakes it.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * Without multithreading there is no idle thread, so the application itself
+ * calls k_cpu_idle() to wait. The CPU must suspend until an interrupt arrives
+ * and must resume with the timer's expiry handler having run, which is how a
+ * single-threaded application waits for time to pass without spinning.
+ *
+ * Test steps:
+ * - Start a 10 ms timer whose handler raises a flag, sampling the uptime.
+ * - Call k_cpu_idle(); on a tickful kernel, where every tick wakes the CPU,
+ *   idle again until the handler has actually run.
+ * - Check the flag and measure the elapsed uptime.
+ *
+ * Expected result:
+ * - The CPU resumes with the timer handler having run.
+ * - At least the requested 10 ms elapsed, and no more than one tick plus a
+ *   small measurement margin beyond it.
+ *
+ * @see k_cpu_idle()
+ * @see k_timer_start()
+ */
+ZTEST(no_multithreading, test_no_multithreading_cpu_idle)
 {
 	volatile bool timeout_run = false;
 	int64_t now, diff;
@@ -122,7 +201,29 @@ ZTEST(no_multithreading, test_cpu_idle)
  * See https://github.com/zephyrproject-rtos/zephyr/issues/114503
  */
 #if defined(CONFIG_ARM)
-ZTEST(no_multithreading, test_tls)
+/**
+ * @brief Verify that thread-local storage is initialized without
+ *        multithreading.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * Thread-local variables are set up from their initializers as part of
+ * starting a thread. With CONFIG_MULTITHREADING=n there is only the main
+ * thread of control, and its TLS block still has to be established before the
+ * application runs, so a thread-local variable must read back its initializer
+ * rather than zero or garbage.
+ *
+ * Test steps:
+ * - Declare a thread-local variable with a non-zero initializer.
+ * - Read it back from the single thread of control.
+ *
+ * Expected result:
+ * - The variable holds the value it was initialized with.
+ *
+ * @see Z_THREAD_LOCAL
+ */
+ZTEST(no_multithreading, test_no_multithreading_tls)
 {
 	static volatile Z_THREAD_LOCAL int i = 42;
 
@@ -151,7 +252,29 @@ static int sys_init_result;
 
 FOR_EACH(SYS_INIT_CREATE, (;), PRE_KERNEL_1, PRE_KERNEL_2, POST_KERNEL);
 
-ZTEST(no_multithreading, test_sys_init)
+/**
+ * @brief Verify that SYS_INIT functions run in order without multithreading.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The initialization levels are a property of the boot sequence rather than of
+ * the scheduler, so disabling multithreading must not change them. Each
+ * registered init function checks that it is entered at its own position in
+ * the sequence and then advances a counter, so a wrong order is recorded as it
+ * happens rather than being inferred afterwards.
+ *
+ * Test steps:
+ * - Register one init function at PRE_KERNEL_1, PRE_KERNEL_2 and POST_KERNEL,
+ *   each asserting its position and incrementing a shared counter.
+ * - After boot, read the counter.
+ *
+ * Expected result:
+ * - All three init functions ran, in level order, leaving the counter at 3.
+ *
+ * @see SYS_INIT()
+ */
+ZTEST(no_multithreading, test_no_multithreading_sys_init)
 {
 	zassert_equal(init_order, 3, "SYS_INIT failed: %d", init_order);
 }

--- a/tests/kernel/threads/runtime_stack_safety/src/main.c
+++ b/tests/kernel/threads/runtime_stack_safety/src/main.c
@@ -98,7 +98,7 @@ static void suite_teardown(void *fixture)
 
 /**
  * @brief Thread runtime stack safety tests
- * @defgroup tests_kernel_runtime_stack_safety Thread runtime stack safety
+ * @defgroup kernel_runtime_stack_safety_tests Thread runtime stack safety
  * @ingroup all_tests
  * @{
  */
@@ -125,7 +125,7 @@ static void suite_teardown(void *fixture)
  * @see k_thread_runtime_stack_unused_threshold_pct_set()
  * @see k_thread_runtime_stack_unused_threshold_get()
  */
-ZTEST(runtime_stack_safety, test_threshold_pct_set_get)
+ZTEST(runtime_stack_safety, test_stack_safety_threshold_pct_set_get)
 {
 	size_t size = child_thread.stack_info.size;
 
@@ -166,7 +166,7 @@ ZTEST(runtime_stack_safety, test_threshold_pct_set_get)
  * @see k_thread_runtime_stack_unused_threshold_set()
  * @see k_thread_runtime_stack_unused_threshold_get()
  */
-ZTEST(runtime_stack_safety, test_threshold_bytes_set_get)
+ZTEST(runtime_stack_safety, test_stack_safety_threshold_bytes_set_get)
 {
 	size_t size = child_thread.stack_info.size;
 
@@ -208,7 +208,7 @@ ZTEST(runtime_stack_safety, test_threshold_bytes_set_get)
  *
  * @see k_thread_runtime_stack_safety_full_check()
  */
-ZTEST(runtime_stack_safety, test_full_check)
+ZTEST(runtime_stack_safety, test_stack_safety_full_check)
 {
 	size_t size = child_thread.stack_info.size;
 	size_t unused = 0;
@@ -269,7 +269,7 @@ ZTEST(runtime_stack_safety, test_full_check)
  *
  * @see k_thread_runtime_stack_safety_full_check()
  */
-ZTEST(runtime_stack_safety, test_full_check_null_handler)
+ZTEST(runtime_stack_safety, test_stack_safety_full_check_null_handler)
 {
 	size_t size = child_thread.stack_info.size;
 	size_t unused = 0;
@@ -304,7 +304,7 @@ ZTEST(runtime_stack_safety, test_full_check_null_handler)
  * @see k_thread_runtime_stack_safety_threshold_check()
  * @see k_thread_runtime_stack_safety_full_check()
  */
-ZTEST(runtime_stack_safety, test_threshold_check)
+ZTEST(runtime_stack_safety, test_stack_safety_threshold_check)
 {
 	size_t unused_full = 0;
 	size_t unused_abbrev = 0;
@@ -360,7 +360,7 @@ ZTEST(runtime_stack_safety, test_threshold_check)
  * @see k_thread_runtime_stack_unused_threshold_get()
  * @see k_thread_runtime_stack_unused_threshold_pct_set()
  */
-ZTEST_USER(runtime_stack_safety, test_threshold_syscalls)
+ZTEST_USER(runtime_stack_safety, test_stack_safety_threshold_syscalls)
 {
 	struct k_thread *self = k_current_get();
 

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -40,19 +40,51 @@ static int main_prio;
 static ZTEST_DMEM int tp = 10;
 
 /**
+ * @brief Verify that the main thread runs at its configured priority.
+ *
  * @ingroup kernel_thread_tests
- * @brief Verify main thread
+ *
+ * @details
+ * The thread that runs main() has to be started at the priority named by
+ * CONFIG_MAIN_THREAD_PRIORITY, since applications rely on it to sit at a known
+ * point in the scheduling order. The priority is sampled during suite setup,
+ * before any case has had a chance to change it.
+ *
+ * Test steps:
+ * - Record the main thread's priority in the suite setup function.
+ * - Compare it against CONFIG_MAIN_THREAD_PRIORITY.
+ *
+ * Expected result:
+ * - The main thread runs at the configured priority.
+ *
+ * @see k_thread_priority_get()
  */
-ZTEST(threads_lifecycle, test_systhreads_main)
+ZTEST(threads_lifecycle, test_thread_main_priority)
 {
 	zassert_true(main_prio == CONFIG_MAIN_THREAD_PRIORITY, "%d", CONFIG_MAIN_THREAD_PRIORITY);
 }
 
 /**
+ * @brief Verify that the idle thread runs below every application thread.
+ *
  * @ingroup kernel_thread_tests
- * @brief Verify idle thread
+ *
+ * @details
+ * The idle thread must be the lowest priority thread in the system, so that it
+ * only ever runs when nothing else can. Rather than inspecting the idle thread
+ * directly, the test sleeps to let it run and then checks that its own
+ * priority is still above K_IDLE_PRIO.
+ *
+ * Test steps:
+ * - Sleep so the idle thread gets a chance to run on each CPU.
+ * - Compare the current thread's priority against K_IDLE_PRIO.
+ *
+ * Expected result:
+ * - The running thread's priority is higher than the idle priority.
+ *
+ * @see k_thread_priority_get()
  */
-ZTEST(threads_lifecycle, test_systhreads_idle)
+ZTEST(threads_lifecycle, test_thread_idle_priority)
 {
 	k_msleep(100);
 	/** TESTPOINT: check working thread priority should */
@@ -76,13 +108,28 @@ static void customdata_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test thread custom data get/set from coop thread
+ * @brief Verify that custom data is per thread, from a cooperative thread.
  *
- * @see k_thread_custom_data_get()
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The custom data slot belongs to the thread that set it, so a value written
+ * by one thread must be readable by that same thread and must not be seen by
+ * another. The cooperative case writes and reads the slot repeatedly across
+ * yields, so a slot that is global rather than per thread shows up as a
+ * mismatch.
+ *
+ * Test steps:
+ * - Set the custom data of the current thread and read it back.
+ * - Yield, then repeat several times with changing values.
+ *
+ * Expected result:
+ * - Each read returns the value this thread most recently set.
+ *
  * @see k_thread_custom_data_set()
+ * @see k_thread_custom_data_get()
  */
-ZTEST(threads_lifecycle_1cpu, test_customdata_get_set_coop)
+ZTEST(threads_lifecycle_1cpu, test_thread_custom_data_coop)
 {
 	k_tid_t tid = k_thread_create(&tdata_custom, tstack_custom, STACK_SIZE,
 				      customdata_entry, NULL, NULL, NULL,
@@ -100,11 +147,30 @@ static void thread_name_entry(void *p1, void *p2, void *p3)
 }
 
 /**
+ * @brief Verify that a thread name can be set and read back.
+ *
  * @ingroup kernel_thread_tests
- * @brief Test thread name get/set from supervisor thread
+ *
+ * @details
+ * A thread's name is what identifies it in logs and debug output, so setting
+ * it has to be reflected by both accessors: k_thread_name_get(), which returns
+ * the kernel's own string, and k_thread_name_copy(), which copies it into a
+ * caller buffer. Too small a buffer must be reported rather than truncated
+ * silently.
+ *
+ * Test steps:
+ * - Set a name on the current thread and on a spawned thread.
+ * - Read them back with k_thread_name_get() and compare.
+ * - Copy them out with k_thread_name_copy() and compare.
+ * - Attempt a copy into a buffer that is too small.
+ *
+ * Expected result:
+ * - Both accessors report the name that was set, and the undersized copy
+ *   fails rather than truncating.
+ *
+ * @see k_thread_name_set()
  * @see k_thread_name_get()
  * @see k_thread_name_copy()
- * @see k_thread_name_set()
  */
 ZTEST(threads_lifecycle, test_thread_name_get_set)
 {
@@ -143,10 +209,29 @@ struct k_sem sem;
 #endif /* CONFIG_USERSPACE */
 
 /**
+ * @brief Verify that thread names are handled safely from user mode.
+ *
  * @ingroup kernel_thread_tests
- * @brief Test thread name get/set from user thread
- * @see k_thread_name_copy()
+ *
+ * @details
+ * Reached from user mode, the name calls become system calls that must
+ * validate every pointer they are handed instead of trusting the caller: an
+ * unreadable source string, a buffer the caller does not own, and a thread
+ * object it has no permission for all have to be rejected rather than
+ * faulting the kernel. Skipped when userspace is not enabled.
+ *
+ * Test steps:
+ * - Set and read back the current thread's name from user mode.
+ * - Attempt to set a name from a string the thread cannot read.
+ * - Attempt to copy a name into a buffer the thread does not own.
+ * - Attempt to name a thread the caller has no access to.
+ *
+ * Expected result:
+ * - The legitimate calls succeed and every invalid pointer or permission is
+ *   rejected with an error instead of a fault.
+ *
  * @see k_thread_name_set()
+ * @see k_thread_name_copy()
  */
 ZTEST_USER(threads_lifecycle, test_thread_name_user_get_set)
 {
@@ -213,12 +298,28 @@ ZTEST_USER(threads_lifecycle, test_thread_name_user_get_set)
 }
 
 /**
+ * @brief Verify that custom data is per thread, from a preemptible user
+ *        thread.
+ *
  * @ingroup kernel_thread_tests
- * @brief Test thread custom data get/set from preempt thread
- * @see k_thread_custom_data_get()
+ *
+ * @details
+ * The preemptible, user-mode counterpart of the cooperative custom data case.
+ * Here the accessors are reached as system calls and the thread can be
+ * preempted between the write and the read, so the slot has to survive
+ * arbitrary scheduling rather than only cooperative yields.
+ *
+ * Test steps:
+ * - Set the custom data of the current user thread and read it back.
+ * - Yield, then repeat several times with changing values.
+ *
+ * Expected result:
+ * - Each read returns the value this thread most recently set.
+ *
  * @see k_thread_custom_data_set()
+ * @see k_thread_custom_data_get()
  */
-ZTEST_USER(threads_lifecycle_1cpu, test_customdata_get_set_preempt)
+ZTEST_USER(threads_lifecycle_1cpu, test_thread_custom_data_preempt)
 {
 	/** TESTPOINT: custom data of preempt thread */
 	k_tid_t tid = k_thread_create(&tdata_custom, tstack_custom, STACK_SIZE,
@@ -263,17 +364,28 @@ static void enter_user_mode_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Verify a thread can run with user-mode (unprivileged) privileges.
- *
- * @details
- * Create a thread that calls k_thread_user_mode_enter() so it transitions to
- * user mode, confirming the kernel can create threads with a defined privilege
- * level.
+ * @brief Verify that a thread can drop into user mode.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_user_mode_enter() converts the calling supervisor thread into an
+ * unprivileged one and does not return. The thread checks
+ * k_is_user_context() on the far side of the transition, so a pass proves the
+ * privilege level really changed rather than that the call merely returned.
+ *
+ * Test steps:
+ * - Confirm the test thread is already running in user mode.
+ * - Create a supervisor thread that calls k_thread_user_mode_enter().
+ * - In its user-mode entry point, check k_is_user_context() and signal.
+ *
+ * Expected result:
+ * - The thread continues in user mode and reports unprivileged context.
+ *
  * @see k_thread_user_mode_enter()
+ * @see k_is_user_context()
  */
-ZTEST_USER(threads_lifecycle, test_user_mode)
+ZTEST_USER(threads_lifecycle, test_thread_user_mode)
 {
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 			      enter_user_mode_entry, NULL, NULL,
@@ -408,9 +520,27 @@ static inline int join_scenario(enum control_method m)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test thread join
+ * @brief Verify that k_thread_join() waits for a thread in every end state.
  *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A join has to return only once the target thread is really finished,
+ * whichever way it got there, and it has to behave the same when the thread
+ * has already ended before the join is issued. Each way a thread can reach
+ * its end is driven in turn so no single path can hide a join that returns
+ * early.
+ *
+ * Test steps:
+ * - Join a thread that exits on its own.
+ * - Join a thread that is aborted while running.
+ * - Join a thread that is still waiting out a start delay.
+ * - Join a thread that had already exited before the join.
+ *
+ * Expected result:
+ * - Every join returns success only after the target thread has ended.
+ *
+ * @see k_thread_join()
  */
 ZTEST_USER(threads_lifecycle, test_thread_join)
 {
@@ -436,11 +566,26 @@ ZTEST_USER(threads_lifecycle, test_thread_join)
 }
 
 /**
+ * @brief Verify that k_thread_join() from an ISR cannot block.
+ *
  * @ingroup kernel_thread_tests
- * @brief Test thread join from ISR
+ *
+ * @details
+ * Interrupt context must never block, so a join issued from an ISR can only
+ * be attempted without waiting. Joining a still-running thread has to be
+ * refused with -EBUSY, while joining one that has already finished can be
+ * satisfied immediately.
+ *
+ * Test steps:
+ * - Spawn a thread and, from an ISR, join it with K_NO_WAIT while it runs.
+ * - Let the thread finish, then join it again from an ISR.
+ *
+ * Expected result:
+ * - The join of the running thread returns -EBUSY, and the join of the
+ *   finished thread succeeds.
  *
  * @see k_thread_join()
- * @see k_thread_abort()
+ * @see irq_offload()
  */
 ZTEST(threads_lifecycle, test_thread_join_isr)
 {
@@ -477,17 +622,25 @@ static void deadlock2_entry(void *p1, void *p2, void *p3)
 
 
 /**
- * @brief Test case for thread join deadlock scenarios.
- *
- * This test verifies the behavior of the `k_thread_join` API in scenarios
- * that could lead to deadlocks. It includes the following checks:
- *
- * - Ensures that a thread cannot join itself, which would result in a
- *   self-deadlock. The API should return `-EDEADLK` in this case.
- * - Creates two threads (`deadlock1_thread` and `deadlock2_thread`) and
- *   verifies that they can be joined successfully without causing a deadlock.
+ * @brief Verify that k_thread_join() refuses to deadlock.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread joining itself would wait forever for its own exit, so the kernel
+ * has to detect that and refuse rather than hang. Joins that only look
+ * circular must still be allowed, which is why two threads that join each
+ * other in a legal order are exercised alongside the self-join.
+ *
+ * Test steps:
+ * - Call k_thread_join() on the calling thread itself.
+ * - Create two threads that join one another and join them from the test.
+ *
+ * Expected result:
+ * - The self-join is rejected with -EDEADLK, and the two-thread joins all
+ *   succeed.
+ *
+ * @see k_thread_join()
  */
 ZTEST_USER(threads_lifecycle, test_thread_join_deadlock)
 {
@@ -519,9 +672,31 @@ static void user_start_thread(void *p1, void *p2, void *p3)
 	/* do nothing */
 }
 /**
- * @brief Test case for verifying thread timeout expiration and remaining time.
+ * @brief Verify that a thread's pending timeout can be queried.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread waiting out its start delay has a timeout pending, and the kernel
+ * can report it two ways: as the absolute tick the thread becomes ready, and
+ * as the ticks still to go. The absolute view must not fall before the
+ * deadline computed at creation, and the relative view has to keep shrinking
+ * as time passes, which is what sampling it repeatedly checks.
+ *
+ * Test steps:
+ * - Compute the expected expiry tick and create a thread with that start
+ *   delay.
+ * - Read the thread's expiry tick and compare it against the expected one.
+ * - Read its remaining ticks and confirm they are below the full delay.
+ * - Sleep and read the remaining ticks again.
+ * - Abort the thread before it starts.
+ *
+ * Expected result:
+ * - The expiry tick is no earlier than the deadline set at creation, and each
+ *   reading of the remaining ticks is smaller than the one before.
+ *
+ * @see k_thread_timeout_remaining_ticks()
+ * @see k_thread_timeout_expires_ticks()
  */
 
 ZTEST_USER(threads_lifecycle, test_thread_timeout_remaining_expires)
@@ -576,15 +751,27 @@ static void foreach_callback(const struct k_thread *thread, void *user_data)
 }
 
 /**
- * @brief Test case for thread runtime statistics retrieval in Zephyr kernel
- *
- * This case accumulates every thread's execution_cycles first, then
- * get the total execution_cycles from a global
- * k_thread_runtime_stats_t to see that all time is reflected in the
- * total.
+ * @brief Verify that per-thread runtime statistics add up to the system total.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The kernel accounts execution time both per thread and system wide, and the
+ * two views have to describe the same time: no thread's cycles may be missing
+ * from the total. Summing every thread's execution cycles and comparing
+ * against the global figure is what makes a dropped or double-counted thread
+ * visible.
+ *
+ * Test steps:
+ * - Walk every thread and accumulate its execution cycles.
+ * - Read the system-wide runtime statistics.
+ * - Compare the accumulated sum against the reported total.
+ *
+ * Expected result:
+ * - Every thread's execution time is reflected in the system total.
+ *
  * @see k_thread_runtime_stats_get()
+ * @see k_thread_runtime_stats_all_get()
  */
 ZTEST(threads_lifecycle, test_thread_runtime_stats_get)
 {
@@ -606,12 +793,29 @@ ZTEST(threads_lifecycle, test_thread_runtime_stats_get)
 
 
 /**
- * @brief Test the behavior of k_busy_wait with thread runtime statistics.
+ * @brief Verify that busy waiting is accounted as execution time.
  *
- * This test verifies the accuracy of the `k_busy_wait` function by checking
- * the thread's execution cycle statistics before and after calling the function.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_busy_wait() spins on the CPU rather than blocking, so the time it takes
+ * must show up as the calling thread's own execution cycles. Sampling the
+ * thread's runtime statistics on both sides of a busy wait of known length is
+ * what ties the accounting to real elapsed time.
+ *
+ * Test steps:
+ * - Read the current thread's runtime statistics.
+ * - Call k_busy_wait() for a known duration.
+ * - Read the statistics again and compare the difference.
+ *
+ * Expected result:
+ * - The thread's execution cycles grow by at least the time spent busy
+ *   waiting.
+ *
+ * @see k_busy_wait()
+ * @see k_thread_runtime_stats_get()
  */
-ZTEST(threads_lifecycle, test_k_busy_wait)
+ZTEST(threads_lifecycle, test_thread_busy_wait)
 {
 	uint64_t cycles, dt;
 	k_thread_runtime_stats_t test_stats;
@@ -650,12 +854,29 @@ static void tp_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test the behavior of k_busy_wait with thread runtime statistics
- *        in user mode.
+ * @brief Verify that busy waiting is accounted for a user thread.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The same accounting has to hold when the busy wait is performed by a user
+ * thread, where both the wait and the statistics query are system calls. The
+ * case runs on a single CPU so the measurement is not disturbed by the thread
+ * migrating.
+ *
+ * Test steps:
+ * - From a user thread, read its runtime statistics.
+ * - Call k_busy_wait() for a known duration.
+ * - Read the statistics again and compare the difference.
+ *
+ * Expected result:
+ * - The user thread's execution cycles grow by at least the time spent busy
+ *   waiting.
+ *
+ * @see k_busy_wait()
+ * @see k_thread_runtime_stats_get()
  */
-ZTEST_USER(threads_lifecycle_1cpu, test_k_busy_wait_user)
+ZTEST_USER(threads_lifecycle_1cpu, test_thread_busy_wait_user)
 {
 
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
@@ -691,15 +912,28 @@ static int small_stack(size_t *space)
 }
 
 /**
- * @brief Test k_thread_stack_sapce_get
- *
- * Test k_thread_stack_sapce_get unused stack space in large_stack_space()
- * is smaller than that in small_stack() because the former function has a
- * large local variable
+ * @brief Verify that reported unused stack space tracks actual stack use.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_stack_space_get() reports how much of a thread's stack has never
+ * been touched, so the figure has to fall as the thread uses more of it.
+ * Calling it from a function with a large local variable and again from one
+ * with a small local gives two points whose order is known in advance,
+ * regardless of the absolute numbers, which vary by architecture.
+ *
+ * Test steps:
+ * - Query the unused stack space from a function with a small local variable.
+ * - Query it again from a function with a large local variable.
+ * - Compare the two figures.
+ *
+ * Expected result:
+ * - The deeper call reports less unused stack space than the shallow one.
+ *
+ * @see k_thread_stack_space_get()
  */
-ZTEST_USER(threads_lifecycle, test_k_thread_stack_space_get_user)
+ZTEST_USER(threads_lifecycle, test_thread_stack_space_get_user)
 {
 	size_t a, b;
 

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -42,13 +42,32 @@ static void thread_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test to validate essential flag set/clear
+ * @brief Verify that a thread can mark itself essential and clear it again.
  *
  * @ingroup kernel_thread_tests
  *
- * @see #K_ESSENTIAL(x)
+ * @details
+ * The essential flag is part of a thread's own state and can be turned on and
+ * off at run time, not only at creation. The spawned thread sets the flag,
+ * checks that it reads back as set, clears it and checks again, so what is
+ * validated is the flag the kernel actually recorded. Clearing it also lets
+ * the thread be aborted afterwards without panicking the kernel.
+ *
+ * Test steps:
+ * - Create a thread that calls k_thread_essential_set() and confirms
+ *   k_is_essential() reports it.
+ * - Have the thread clear the flag and confirm it no longer reports.
+ * - Signal the test thread, which then aborts the worker.
+ *
+ * Expected result:
+ * - The flag reads back as set after being set and clear after being cleared,
+ *   and the thread aborts without raising a fatal error.
+ *
+ * @see k_thread_essential_set()
+ * @see k_thread_essential_clear()
+ * @see k_is_essential()
  */
-ZTEST(threads_lifecycle, test_essential_thread_operation)
+ZTEST(threads_lifecycle, test_thread_essential_set_clear)
 {
 	k_tid_t tid = k_thread_create(&kthread_thread, kthread_stack,
 				      STACKSIZE, thread_entry, NULL,
@@ -90,17 +109,30 @@ static void abort_thread_self(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Abort an essential thread
- *
- * @details The kernel shall raise a fatal system error if an essential thread
- *          aborts, implement k_sys_fatal_error_handler to handle this error.
+ * @brief Verify that aborting an essential thread raises a fatal error.
  *
  * @ingroup kernel_thread_tests
  *
- * @see #K_ESSENTIAL(x)
+ * @details
+ * An essential thread is one the system cannot continue without, so the kernel
+ * must treat its termination as a fatal system error rather than reclaiming it
+ * quietly. The test installs a fatal error handler that records the event and
+ * lets the system continue, so the abort can be observed instead of halting
+ * the run.
+ *
+ * Test steps:
+ * - Create a thread with the K_ESSENTIAL option and let it start.
+ * - Abort it from the test thread.
+ * - Check the flag recorded by the fatal error handler.
+ *
+ * Expected result:
+ * - The kernel raises a fatal error for the aborted essential thread.
+ *
+ * @see K_ESSENTIAL
+ * @see k_thread_abort()
+ * @see k_sys_fatal_error_handler()
  */
-
-ZTEST(threads_lifecycle, test_essential_thread_abort)
+ZTEST(threads_lifecycle, test_thread_essential_abort_panics)
 {
 	fatal_error_signaled = false;
 	k_thread_create(&kthread_thread1, kthread_stack, STACKSIZE,
@@ -114,16 +146,28 @@ ZTEST(threads_lifecycle, test_essential_thread_abort)
 }
 
 /**
- * @brief Abort an essential thread from itself
- *
- * @details The kernel shall raise a fatal system error if an essential thread
- *          aborts, implement k_sys_fatal_error_handler to handle this error.
+ * @brief Verify that an essential thread aborting itself raises a fatal error.
  *
  * @ingroup kernel_thread_tests
  *
- * @see #K_ESSENTIAL(x)
+ * @details
+ * The same rule has to hold when the essential thread ends itself rather than
+ * being aborted by someone else, which is the harder path: the panic is raised
+ * on the very thread that is going away, so the architecture layer has to
+ * unwind a thread that aborts inside its own fatal error handling.
+ *
+ * Test steps:
+ * - Create a thread with the K_ESSENTIAL option whose entry point returns,
+ *   ending the thread from within itself.
+ * - Wait for the fatal error handler to record the event.
+ *
+ * Expected result:
+ * - The kernel raises a fatal error for the self-terminating essential thread.
+ *
+ * @see K_ESSENTIAL
+ * @see k_sys_fatal_error_handler()
  */
-ZTEST(threads_lifecycle, test_essential_thread_abort_self)
+ZTEST(threads_lifecycle, test_thread_essential_abort_self_panics)
 {
 	/* This test case needs to be able to handle a k_panic() call
 	 * that aborts the current thread inside of the panic handler

--- a/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
+++ b/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
@@ -76,17 +76,30 @@ void thread_callback_unlocked(const struct k_thread *thread, void *user_data)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test k_thread_foreach API
+ * @brief Verify that k_thread_foreach() visits every thread, including new
+ *        ones.
  *
- * @details Call k_thread_foreach() at the beginning of the test and
- * call it again after creating a thread, See k_thread_foreach()
- * iterates over the newly created thread and calls the user passed
- * callback function.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The iterator has to walk the kernel's whole thread list and invoke the
+ * caller's callback once per thread, picking up threads created since a
+ * previous walk. Counting the callbacks before and after creating a thread
+ * makes that growth observable. The iteration runs with the scheduler locked,
+ * so the callback must not create or abort threads.
+ *
+ * Test steps:
+ * - Call k_thread_foreach() and record how many threads were visited.
+ * - Create an additional thread.
+ * - Call k_thread_foreach() again and compare the new count.
+ *
+ * Expected result:
+ * - The first walk visits at least one thread, and the second visits exactly
+ *   one more than the first.
  *
  * @see k_thread_foreach()
  */
-ZTEST(threads_lifecycle_1cpu, test_k_thread_foreach)
+ZTEST(threads_lifecycle_1cpu, test_thread_foreach)
 {
 	int count;
 
@@ -120,19 +133,31 @@ ZTEST(threads_lifecycle_1cpu, test_k_thread_foreach)
 }
 
 /**
- * @brief Test k_thread_foreach_unlock API
+ * @brief Verify that k_thread_foreach_unlocked() iterates without holding the
+ *        scheduler lock.
  *
- * @details Call k_thread_foreach_unlocked() at the beginning of the test and
- * call it again after creating a thread, See k_thread_foreach_unlocked()
- * iterates over the newly created thread and calls the user passed
- * callback function.
- * In contrast to k_thread_foreach(), k_thread_foreach_unlocked() allow
- * callback function created or abort threads
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The unlocked iterator visits the same threads as the locked one but leaves
+ * the scheduler unlocked between callbacks, which is what makes it legal for
+ * the callback to create or abort threads. The callback used here aborts a
+ * thread while the walk is in progress, so a pass shows the iteration
+ * tolerates the list changing underneath it.
+ *
+ * Test steps:
+ * - Call k_thread_foreach_unlocked() and record how many threads were visited.
+ * - Create an additional thread.
+ * - Call it again with a callback that aborts a thread mid-iteration.
+ * - Compare the counts.
+ *
+ * Expected result:
+ * - The first walk visits at least one thread, the second visits exactly one
+ *   more, and aborting from the callback does not disturb the walk.
  *
  * @see k_thread_foreach_unlocked()
- * @ingroup kernel_thread_tests
  */
-ZTEST(threads_lifecycle_1cpu, test_k_thread_foreach_unlocked)
+ZTEST(threads_lifecycle_1cpu, test_thread_foreach_unlocked)
 {
 	int count;
 
@@ -182,45 +207,75 @@ ZTEST(threads_lifecycle_1cpu, test_k_thread_foreach_unlocked)
 }
 
 /**
- * @brief Test k_thread_foreach API with null callback
+ * @brief Verify that k_thread_foreach() rejects a NULL callback.
  *
- * @details Call k_thread_foreach() with null callback will trigger __ASSERT()
- * and this test thread will be aborted by z_fatal_error()
- * @see k_thread_foreach()
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * There is nothing sensible to do with a NULL callback, so the iterator
+ * asserts on it rather than walking the thread list and dereferencing it. The
+ * assertion aborts this thread through the fatal error path, which the test
+ * harness expects.
+ *
+ * Test steps:
+ * - Call k_thread_foreach() with a NULL callback.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and does not return.
+ *
+ * @see k_thread_foreach()
  */
-ZTEST(threads_lifecycle_1cpu, test_k_thread_foreach_null_cb)
+ZTEST(threads_lifecycle_1cpu, test_thread_foreach_null_cb)
 {
 	k_thread_foreach(NULL, TEST_STRING);
 }
 
 /**
- * @brief Test k_thread_foreach_unlocked API with null callback
+ * @brief Verify that k_thread_foreach_unlocked() rejects a NULL callback.
  *
- * @details Call k_thread_foreach_unlocked() with null callback will trigger
- * __ASSERT() and this test thread will be aborted by z_fatal_error()
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The unlocked iterator has to reject a NULL callback exactly as the locked
+ * one does, asserting instead of walking the thread list and dereferencing it.
+ *
+ * Test steps:
+ * - Call k_thread_foreach_unlocked() with a NULL callback.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and does not return.
  *
  * @see k_thread_foreach_unlocked()
- * @ingroup kernel_thread_tests
  */
-
-ZTEST(threads_lifecycle_1cpu, test_k_thread_foreach_unlocked_null_cb)
+ZTEST(threads_lifecycle_1cpu, test_thread_foreach_unlocked_null_cb)
 {
 	k_thread_foreach_unlocked(NULL, TEST_STRING_UNLOCKED);
 }
 
 /**
- * @brief Test k_thread_state_str API with null callback
+ * @brief Verify that k_thread_state_str() names every thread state.
  *
- * @details It's impossible to sched a thread step by step manually to
- * experience each state from initialization to _THREAD_DEAD. To cover each
- * line of function k_thread_state_str(), set thread_state of tdata1 and check
- * the string this function returns
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_state_str() renders a thread's state bits as text for logs and
+ * shell output, so every state and combination it knows about has to produce
+ * the right string. Driving a real thread through each state in turn is not
+ * possible, so the state field of a spare thread object is set directly and
+ * the rendered string is compared against the expected name.
+ *
+ * Test steps:
+ * - For each thread state, write it into a spare thread object's state field.
+ * - Call k_thread_state_str() with a caller-provided buffer.
+ * - Compare the returned string with the expected text.
+ *
+ * Expected result:
+ * - Every state, including combinations and the empty state, renders as its
+ *   documented name.
  *
  * @see k_thread_state_str()
- * @ingroup kernel_thread_tests
  */
-ZTEST(threads_lifecycle_1cpu, test_k_thread_state_str)
+ZTEST(threads_lifecycle_1cpu, test_thread_state_str)
 {
 	char state_str[32];
 	const char *str;

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -31,16 +31,28 @@ static void thread_entry_abort(void *p1, void *p2, void *p3)
 	zassert_true(1 == 0);
 }
 /**
- * @ingroup kernel_thread_tests
- * @brief Validate aborting a thread when called by current thread
+ * @brief Verify that a thread can abort itself.
  *
- * @details Create a user thread and let the thread execute.
- * Then call k_thread_abort() and check if the thread is terminated.
- * Here the main thread is also a user thread.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread calling k_thread_abort() on itself must not return from the call:
+ * it has to terminate at that point. The spawned thread raises a flag, aborts
+ * itself, and would raise a second value on the line after the call, so the
+ * flag distinguishes "ran and stopped there" from "ran past the abort".
+ *
+ * Test steps:
+ * - Create a user thread that flags that it ran and then aborts itself.
+ * - Sleep long enough for it to run.
+ * - Read the flag back.
+ *
+ * Expected result:
+ * - The thread ran and stopped inside the abort, never reaching the code
+ *   after it.
  *
  * @see k_thread_abort()
  */
-ZTEST_USER(threads_lifecycle, test_threads_abort_self)
+ZTEST_USER(threads_lifecycle, test_thread_abort_self)
 {
 	execute_flag = 0;
 	k_thread_create(&tdata, tstack, STACK_SIZE, thread_entry_abort,
@@ -51,16 +63,28 @@ ZTEST_USER(threads_lifecycle, test_threads_abort_self)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Validate aborting a thread when called by other thread
+ * @brief Verify that a thread can be aborted by another thread.
  *
- * @details Create a user thread and abort the thread before its
- * execution. Create a another user thread and abort the thread
- * after it has started.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * Aborting another thread has to work both before that thread has had a
+ * chance to run and after it has started, since the two take different paths:
+ * one removes a ready thread that was never scheduled, the other terminates
+ * one that is already executing. Both are covered here from user mode.
+ *
+ * Test steps:
+ * - Create a user thread and abort it immediately, before it can run.
+ * - Sleep past the point it would have run and check its flag.
+ * - Create a second user thread, let it start, then abort it.
+ *
+ * Expected result:
+ * - The thread aborted before starting never runs, and the one aborted after
+ *   starting is terminated.
  *
  * @see k_thread_abort()
  */
-ZTEST_USER(threads_lifecycle, test_threads_abort_others)
+ZTEST_USER(threads_lifecycle, test_thread_abort_others)
 {
 	execute_flag = 0;
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
@@ -84,12 +108,25 @@ ZTEST_USER(threads_lifecycle, test_threads_abort_others)
 }
 
 /**
+ * @brief Verify that aborting an already terminated thread is harmless.
+ *
  * @ingroup kernel_thread_tests
- * @brief Test abort on an already terminated thread
+ *
+ * @details
+ * A thread that has already been aborted may still be referenced by code that
+ * does not know it is gone, so a second k_thread_abort() on it has to be
+ * accepted quietly rather than corrupting the scheduler or faulting.
+ *
+ * Test steps:
+ * - Create a thread and abort it.
+ * - Call k_thread_abort() on the same thread again, twice.
+ *
+ * Expected result:
+ * - The repeated aborts complete without error and the system keeps running.
  *
  * @see k_thread_abort()
  */
-ZTEST(threads_lifecycle_1cpu, test_threads_abort_repeat)
+ZTEST(threads_lifecycle_1cpu, test_thread_abort_repeat)
 {
 	execute_flag = 0;
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
@@ -121,14 +158,24 @@ static void delayed_thread_entry(void *p1, void *p2, void *p3)
  * @brief Test abort on delayed thread before it has started
  * execution
  *
- * @details Create a thread with a 100ms start delay and abort it while
- * it is still waiting to start. Sleep past the original start deadline
- * and verify the thread never ran: a broken abort would have let the
- * thread start and set execute_flag.
+ * @details
+ * A thread that is still waiting out its start delay is not yet on any ready
+ * queue, so aborting it has to cancel the pending start rather than leave a
+ * timeout that would launch a dead thread later. Sleeping past the original
+ * deadline is what makes a surviving timeout visible.
+ *
+ * Test steps:
+ * - Create a thread with a 100 ms start delay.
+ * - Abort it while it is still waiting to start.
+ * - Sleep past the original start deadline.
+ * - Check the flag the thread would have set had it run.
+ *
+ * Expected result:
+ * - The thread never runs, so its flag stays clear.
  *
  * @see k_thread_abort()
  */
-ZTEST(threads_lifecycle_1cpu, test_delayed_thread_abort)
+ZTEST(threads_lifecycle_1cpu, test_thread_abort_delayed)
 {
 	int current_prio = k_thread_priority_get(k_current_get());
 
@@ -195,16 +242,29 @@ static void entry_abort_isr(void *p1, void *p2, void *p3)
 extern struct k_sem offload_sem;
 
 /**
+ * @brief Verify that a thread can be aborted from an ISR interrupting it.
+ *
  * @ingroup kernel_thread_tests
  *
- * @brief Show that threads can be aborted from interrupt context by itself
+ * @details
+ * k_thread_abort() is callable from interrupt context, including on the very
+ * thread the ISR interrupted. The kernel has to let the ISR run to completion
+ * and only then drop the aborted thread, rather than switching away inside
+ * the handler. The ISR sets a flag as its last act, so the test can tell that
+ * it finished as well as that the thread died.
  *
- * @details Spawn a thread, then enter ISR context in child thread and abort
- * the child thread. Check if ISR completed and target thread was aborted.
+ * Test steps:
+ * - Spawn a thread that enters an ISR and aborts itself from there.
+ * - Join the spawned thread.
+ * - Check the flag the ISR sets before returning.
+ *
+ * Expected result:
+ * - The ISR completes and the interrupted thread is terminated.
  *
  * @see k_thread_abort()
+ * @see irq_offload()
  */
-ZTEST(threads_lifecycle, test_abort_from_isr)
+ZTEST(threads_lifecycle, test_thread_abort_from_isr)
 {
 	isr_finished = false;
 	k_thread_create(&tdata, tstack, STACK_SIZE, entry_abort_isr,
@@ -249,16 +309,29 @@ static void entry_aborted_thread(void *p1, void *p2, void *p3)
 }
 
 /**
+ * @brief Verify that a thread can be aborted from an ISR on another thread.
+ *
  * @ingroup kernel_thread_tests
  *
- * @brief Show that threads can be aborted from interrupt context
+ * @details
+ * The counterpart of aborting the interrupted thread: here the ISR runs on
+ * the test thread and aborts a different, already running thread. That target
+ * may be executing on another CPU or merely be ready, so the abort has to
+ * complete from interrupt context without waiting on the target to reach a
+ * scheduling point.
  *
- * @details Spawn a thread, then enter ISR context in main thread and abort
- * the child thread. Check if ISR completed and target thread was aborted.
+ * Test steps:
+ * - Spawn a thread and let it start running.
+ * - From the test thread, enter an ISR and abort the spawned thread there.
+ * - Join the spawned thread and check the flag the ISR sets.
+ *
+ * Expected result:
+ * - The ISR completes and the target thread is terminated.
  *
  * @see k_thread_abort()
+ * @see irq_offload()
  */
-ZTEST(threads_lifecycle, test_abort_from_isr_not_self)
+ZTEST(threads_lifecycle, test_thread_abort_from_isr_not_self)
 {
 	k_tid_t tid;
 

--- a/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
@@ -24,18 +24,36 @@ void child_fn(void *a, void *b, void *c)
 
 
 /**
- * @brief Test the CPU mask APIs for thread lifecycle management
- *
- * This test verifies the behavior of the CPU mask APIs in the Zephyr kernel
- * for thread lifecycle management. It ensures that the APIs behave as expected
- * when operating on both running and non-running threads.
- *
- * @note This test is only executed if `CONFIG_SCHED_CPU_MASK` is enabled.
- *       Otherwise, the test is skipped.
+ * @brief Verify that a thread's CPU mask decides whether it can be scheduled.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The affinity APIs may only be applied to a thread that is prevented from
+ * running, and the resulting mask decides whether the scheduler may dispatch
+ * it at all. Both halves are checked: the calls are first refused on the
+ * running caller, then a not-yet-started high priority thread is given each
+ * shape of mask in turn and the test observes whether it runs when yielded to.
+ * Skipped unless CONFIG_SCHED_CPU_MASK is enabled.
+ *
+ * Test steps:
+ * - Call each mask API on the running thread itself and check the return.
+ * - For each pass, create a higher priority thread in the K_FOREVER state and
+ *   give it a mask: cleared, all enabled, CPU 0 disabled, or pinned to CPU 0.
+ * - Start the thread, yield, and record whether it ran.
+ * - Skip the pass that enables more than one CPU when PIN_ONLY is configured.
+ *
+ * Expected result:
+ * - Every mask API returns -EINVAL for the running thread.
+ * - The thread runs only for the masks that leave it eligible for this CPU.
+ *
+ * @see k_thread_cpu_mask_clear()
+ * @see k_thread_cpu_mask_enable_all()
+ * @see k_thread_cpu_mask_enable()
+ * @see k_thread_cpu_mask_disable()
+ * @see k_thread_cpu_pin()
  */
-ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
+ZTEST(threads_lifecycle_1cpu, test_thread_cpu_mask)
 {
 #ifdef CONFIG_SCHED_CPU_MASK
 	k_tid_t thread;

--- a/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
@@ -59,17 +59,31 @@ void thread2_set_prio_test(void *p1, void *p2, void *p3)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test setting and verifying thread priorities
+ * @brief Verify that a thread's priority can be changed and read back.
  *
- * @details This test creates a thread with a lower priority than the
- * current thread. It then sets the priority of the thread to a
- * higher value, and checks that the priority has been set correctly.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_priority_set() must take effect on both the calling thread and
+ * another thread, and the new value has to be what k_thread_priority_get()
+ * subsequently reports. The second thread reads its own priority back and
+ * hands the result to the test through a semaphore, so what is checked is the
+ * priority the scheduler actually recorded rather than the value that was
+ * requested.
+ *
+ * Test steps:
+ * - Lower the current thread's own priority and read it back.
+ * - Create a second thread and change its priority from the test thread.
+ * - Have the second thread read its own priority and report it.
+ * - Compare the reported priority against the requested one and join.
+ *
+ * Expected result:
+ * - Both threads report exactly the priorities that were set for them.
  *
  * @see k_thread_priority_set()
  * @see k_thread_priority_get()
  */
-ZTEST(threads_lifecycle, test_threads_priority_set)
+ZTEST(threads_lifecycle, test_thread_priority_set)
 {
 	int rv;
 	int prio = k_thread_priority_get(k_current_get());
@@ -131,16 +145,32 @@ ZTEST(threads_lifecycle, test_threads_priority_set)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Test changing thread priorities from an ISR
+ * @brief Verify that a thread's priority can be changed from an ISR.
  *
- * @details This test verifies that thread priorities can be changed
- * correctly when invoked from an interrupt service routine (ISR).
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_priority_set() is callable from interrupt context, where it must
+ * apply the same change without needing to reschedule inside the ISR. The
+ * same priority changes as the thread-context case are therefore driven
+ * through an offloaded interrupt, and the results are read back afterwards
+ * from thread context.
+ *
+ * Test steps:
+ * - Lower the current thread's own priority from an ISR via irq_offload().
+ * - Read the priority back and compare it with the requested value.
+ * - Change a second thread's priority from an ISR the same way.
+ * - Have the second thread report its own priority and compare.
+ *
+ * Expected result:
+ * - Both priority changes made from interrupt context take effect and are
+ *   reported back.
  *
  * @see k_thread_priority_set()
  * @see k_thread_priority_get()
+ * @see irq_offload()
  */
-ZTEST(threads_lifecycle, test_isr_threads_priority_set_)
+ZTEST(threads_lifecycle, test_thread_priority_set_from_isr)
 {
 	int rv;
 	int prio = k_thread_priority_get(k_current_get());

--- a/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
@@ -36,16 +36,27 @@ static void thread_entry_delay(void *p1, void *p2, void *p3)
 /* test cases */
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Check the parameters passed to thread entry function
+ * @brief Verify that a spawned thread receives the parameters it was given.
  *
- * @details Create an user thread and pass 2 variables and a
- * semaphore to a thread entry function. Check for the correctness
- * of the parameters passed.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The three parameters handed to k_thread_create() have to arrive unchanged
+ * at the thread's entry point. The spawned thread compares them itself and
+ * signals through a semaphore it was passed as one of them, so a pass proves
+ * both that the values survived and that a passed kernel object is usable.
+ *
+ * Test steps:
+ * - Create a user thread, passing two values and a semaphore.
+ * - In the thread, compare the three parameters against what was passed.
+ * - Sleep long enough for the thread to run.
+ *
+ * Expected result:
+ * - The thread observes exactly the parameters that were passed to it.
  *
  * @see k_thread_create()
  */
-ZTEST_USER(threads_lifecycle, test_threads_spawn_params)
+ZTEST_USER(threads_lifecycle, test_thread_spawn_params)
 {
 	k_thread_create(&tdata, tstack, STACK_SIZE, thread_entry_params,
 			tp1, INT_TO_POINTER(tp2), tp3, 0,
@@ -54,15 +65,29 @@ ZTEST_USER(threads_lifecycle, test_threads_spawn_params)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Spawn thread with higher priority
+ * @brief Verify that a thread spawned at a higher priority preempts its
+ *        creator.
  *
- * @details Create an user thread with priority greater than
- * current thread and check its behavior.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * Creating a thread at a priority above the caller's must make it runnable at
+ * once and preempt the caller, rather than waiting for the caller to block.
+ * The spawned thread records the priority it observes so the placement can be
+ * checked as well as the fact that it ran.
+ *
+ * Test steps:
+ * - Compute a priority one step higher than the current thread's.
+ * - Create a user thread at that priority.
+ * - Sleep, then check what the thread recorded.
+ *
+ * Expected result:
+ * - The thread runs and reports the priority it was created with.
  *
  * @see k_thread_create()
+ * @see k_thread_priority_get()
  */
-ZTEST(threads_lifecycle, test_threads_spawn_priority)
+ZTEST(threads_lifecycle, test_thread_spawn_priority)
 {
 	/* spawn thread with higher priority */
 	spawn_prio = k_thread_priority_get(k_current_get()) - 1;
@@ -72,15 +97,27 @@ ZTEST(threads_lifecycle, test_threads_spawn_priority)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Spawn thread with a delay
+ * @brief Verify that a spawn delay defers the thread's first execution.
  *
- * @details Create a user thread with delay and check if the
- * thread entry function is executed only after the timeout occurs.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread created with a start delay must not run before that delay has
+ * elapsed. The check is made at a point in time deliberately shorter than the
+ * delay, so a thread that started early is caught rather than merely being
+ * late.
+ *
+ * Test steps:
+ * - Set a sentinel value that the thread would overwrite.
+ * - Create a user thread with a 120 ms start delay.
+ * - Sleep only 100 ms and read the sentinel back.
+ *
+ * Expected result:
+ * - The sentinel is untouched, so the thread had not run yet.
  *
  * @see k_thread_create()
  */
-ZTEST_USER(threads_lifecycle, test_threads_spawn_delay)
+ZTEST_USER(threads_lifecycle, test_thread_spawn_delay)
 {
 	/* spawn thread with higher priority */
 	tp2 = 10;
@@ -96,18 +133,29 @@ ZTEST_USER(threads_lifecycle, test_threads_spawn_delay)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Spawn thread with forever delay and highest priority
+ * @brief Verify that a K_FOREVER thread stays inactive until started.
  *
- * @details Create an user thread with forever delay and yield
- * the current thread. Even though the current thread has yielded,
- * the thread will not be put in ready queue since it has forever delay,
- * the thread is explicitly started using k_thread_start() and checked
- * if thread has started executing.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread created with K_FOREVER is never made ready by the passage of time,
+ * only by an explicit k_thread_start(). It is created at the highest priority
+ * so that, once started, it runs immediately: that makes the difference
+ * between "not yet started" and "started" unambiguous even after the creator
+ * yields.
+ *
+ * Test steps:
+ * - Create a user thread with K_FOREVER at the highest priority.
+ * - Yield, then confirm the thread has still not run.
+ * - Call k_thread_start() and check again.
+ *
+ * Expected result:
+ * - Yielding does not run the thread; k_thread_start() does.
  *
  * @see k_thread_create()
+ * @see k_thread_start()
  */
-ZTEST(threads_lifecycle, test_threads_spawn_forever)
+ZTEST(threads_lifecycle, test_thread_spawn_forever)
 {
 	/* spawn thread with highest priority. It will run immediately once
 	 * started.
@@ -128,10 +176,23 @@ ZTEST(threads_lifecycle, test_threads_spawn_forever)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Validate behavior of multiple calls to k_thread_start
+ * @brief Verify that starting an already terminated thread has no effect.
  *
- * @details Call k_thread_start() on an already terminated thread
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_start() on a thread that has already run to completion must be
+ * ignored rather than resurrecting it. The thread writes a value when it
+ * runs, so the test can reset that value after the thread has finished and
+ * see whether a second start would run the body again.
+ *
+ * Test steps:
+ * - Create a K_FOREVER thread and start it, letting it run to completion.
+ * - Reset the value its body writes.
+ * - Call k_thread_start() on the terminated thread again.
+ *
+ * Expected result:
+ * - The second start does nothing, so the value stays as it was reset.
  *
  * @see k_thread_start()
  */
@@ -162,6 +223,29 @@ static void user_start_thread(void *p1, void *p2, void *p3)
 {
 	*(int *)p1 = 100;
 }
+
+/**
+ * @brief Verify that a user thread can start an inactive thread.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_start() is reachable from user mode through its system call, so a
+ * user thread must be able to start a thread it was granted, and that thread
+ * must then actually run. The started thread writes a value its creator reads
+ * back.
+ *
+ * Test steps:
+ * - From a user thread, create a thread with a K_FOREVER start delay.
+ * - Call k_thread_start() on it.
+ * - Sleep, then read back the value the thread writes.
+ *
+ * Expected result:
+ * - The started thread runs and writes its value.
+ *
+ * @see k_thread_start()
+ * @see k_thread_create()
+ */
 ZTEST_USER(threads_lifecycle, test_thread_start_user)
 {
 	tp2 = 5;

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -41,33 +41,59 @@ static void threads_suspend_resume(int prio)
 /*test cases*/
 
 /**
+ * @brief Verify that suspend and resume work on a cooperative thread.
+ *
  * @ingroup kernel_thread_tests
- * @brief Check the suspend and resume functionality in
- * a cooperative thread
  *
- * @details Create a thread with the priority lower than the current
- * thread which is cooperative and suspend it, make sure it doesn't
- * gets scheduled, and resume and check if the entry function is executed.
+ * @details
+ * A suspended thread must not be dispatched no matter what its priority
+ * would otherwise allow, and resuming it must make it runnable again. The
+ * worker is created at a cooperative priority and records that it ran, so
+ * the check is on observed execution rather than on a state flag.
  *
- * @see k_thread_suspend(), k_thread_resume()
+ * Test steps:
+ * - Create a cooperative thread and suspend it before it can run.
+ * - Sleep long enough that it would have run, and confirm it did not.
+ * - Resume it and sleep again.
+ * - Check that the entry function executed and that the thread kept the
+ *   priority it was created with.
+ *
+ * Expected result:
+ * - The thread does not run while suspended and does run once resumed.
+ *
+ * @see k_thread_suspend()
+ * @see k_thread_resume()
  */
-ZTEST(threads_lifecycle_1cpu, test_threads_suspend_resume_cooperative)
+ZTEST(threads_lifecycle_1cpu, test_thread_suspend_resume_coop)
 {
 	threads_suspend_resume(-2);
 }
 
 /**
+ * @brief Verify that suspend and resume work on a preemptible thread.
+ *
  * @ingroup kernel_thread_tests
- * @brief Check the suspend and resume functionality in
- * preemptive thread
  *
- * @details Create a thread with the priority lower than the current
- * thread which is preemptive and suspend it, make sure it doesn't gets
- * scheduled, and resume and check if the entry function is executed.
+ * @details
+ * The preemptible counterpart of the cooperative case, run from user mode so
+ * suspend and resume are reached through their system calls. A preemptible
+ * thread is eligible to be scheduled as soon as it is ready, which makes
+ * "did not run while suspended" the meaningful part of the check.
  *
- * @see k_thread_suspend(), k_thread_resume()
+ * Test steps:
+ * - Create a preemptible thread and suspend it before it can run.
+ * - Sleep long enough that it would have run, and confirm it did not.
+ * - Resume it and sleep again.
+ * - Check that the entry function executed and that the thread kept the
+ *   priority it was created with.
+ *
+ * Expected result:
+ * - The thread does not run while suspended and does run once resumed.
+ *
+ * @see k_thread_suspend()
+ * @see k_thread_resume()
  */
-ZTEST_USER(threads_lifecycle, test_threads_suspend_resume_preemptible)
+ZTEST_USER(threads_lifecycle, test_thread_suspend_resume_preempt)
 {
 	threads_suspend_resume(1);
 }
@@ -84,12 +110,28 @@ void suspend_myself(void *arg0, void *arg1, void *arg2)
 }
 
 /**
+ * @brief Verify that a thread suspending itself reschedules immediately.
+ *
  * @ingroup kernel_thread_tests
  *
- * @brief Check that suspending a thread is a schedule point when
- * called on the current thread.
+ * @details
+ * k_thread_suspend() called on the current thread has to act as a scheduling
+ * point: the thread must give up the CPU inside the call rather than running
+ * on to the next statement. The worker sets a flag on the line after the
+ * call, so that flag being clear is what proves the switch happened there.
+ *
+ * Test steps:
+ * - Create a user thread that suspends itself and then sets a flag.
+ * - Give it time to start and run into the suspend.
+ * - Check the flag, then resume the thread and check it again.
+ *
+ * Expected result:
+ * - The flag stays clear while the thread is suspended and is set once it is
+ *   resumed, so the suspend switched away before the following statement.
+ *
+ * @see k_thread_suspend()
  */
-ZTEST(threads_lifecycle, test_threads_suspend)
+ZTEST(threads_lifecycle, test_thread_suspend)
 {
 	after_suspend = false;
 
@@ -120,13 +162,29 @@ void sleep_suspended(void *arg0, void *arg1, void *arg2)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Check that suspending a thread cancels a preexisting thread timeout
+ * @brief Verify that suspending a sleeping thread cancels its timeout.
  *
- * @details Suspended threads should not wake up unexpectedly if they
- * happened to have been sleeping when suspended.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread that is suspended while it happens to be sleeping must not be
+ * woken by the timeout it had pending. If the timeout survived the suspend,
+ * the thread would come back on its own, which is exactly what a suspended
+ * thread must never do.
+ *
+ * Test steps:
+ * - Create a user thread that sleeps and then sets a flag on waking.
+ * - Suspend it part-way through its sleep.
+ * - Wait well past the point its sleep would have expired.
+ * - Check the flag.
+ *
+ * Expected result:
+ * - The thread does not wake up, so the flag stays clear.
+ *
+ * @see k_thread_suspend()
+ * @see k_sleep()
  */
-ZTEST(threads_lifecycle, test_threads_suspend_timeout)
+ZTEST(threads_lifecycle, test_thread_suspend_timeout)
 {
 	after_suspend = false;
 
@@ -148,13 +206,29 @@ ZTEST(threads_lifecycle, test_threads_suspend_timeout)
 }
 
 /**
- * @ingroup kernel_thread_tests
- * @brief Check resuming a thread that is not suspended
+ * @brief Verify that resuming a thread that is not suspended does nothing.
  *
- * @details Use k_thread_state_str() to get thread state.
- * Resume an unsuspend thread will not change the thread state.
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * k_thread_resume() on a thread that was never suspended has to be a no-op
+ * rather than disturbing whatever the thread is currently doing. The thread's
+ * state string is sampled before and after the call, so an unwanted change of
+ * state is visible rather than merely assumed absent.
+ *
+ * Test steps:
+ * - Create a thread and let it reach a known state.
+ * - Read its state with k_thread_state_str().
+ * - Call k_thread_resume() on it, which was never suspended.
+ * - Read the state again and compare.
+ *
+ * Expected result:
+ * - The thread state is unchanged by the resume.
+ *
+ * @see k_thread_resume()
+ * @see k_thread_state_str()
  */
-ZTEST(threads_lifecycle, test_resume_unsuspend_thread)
+ZTEST(threads_lifecycle, test_thread_resume_not_suspended)
 {
 	char buffer[32];
 	const char *str;

--- a/tests/kernel/threads/thread_error_case/src/main.c
+++ b/tests/kernel/threads/thread_error_case/src/main.c
@@ -178,123 +178,231 @@ static void create_negative_test_thread(int choice)
 }
 
 /**
- * @brief Test that k_thread_start() rejects a NULL thread pointer
- *
- * Verifies that passing a NULL pointer to k_thread_start() triggers
- * the expected fatal error in the syscall validation layer.
+ * @brief Verify that k_thread_start() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_start()
  */
-ZTEST_USER(thread_error_case, test_thread_start_error)
+ZTEST_USER(thread_error_case, test_thread_start_null)
 {
 	create_negative_test_thread(THREAD_START);
 }
 
 /**
- * @brief Test that k_float_disable() rejects a NULL thread pointer
- *
- * Verifies that passing a NULL pointer to k_float_disable() triggers
- * the expected fatal error in the syscall validation layer.
+ * @brief Verify that k_float_disable() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_float_disable()
  */
-ZTEST_USER(thread_error_case, test_float_disable)
+ZTEST_USER(thread_error_case, test_thread_float_disable_null)
 {
 	create_negative_test_thread(FLOAT_DISABLE);
 }
 
 /**
- * @brief Test that k_thread_timeout_remaining_ticks() rejects a NULL pointer
- *
- * Verifies that passing a NULL thread pointer to
- * k_thread_timeout_remaining_ticks() triggers the expected fatal error
- * in the syscall validation layer.
+ * @brief Verify that k_thread_timeout_remaining_ticks() rejects a NULL thread
+ *        pointer.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_timeout_remaining_ticks()
  */
-ZTEST_USER(thread_error_case, test_timeout_remaining_ticks)
+ZTEST_USER(thread_error_case, test_thread_timeout_remaining_ticks_null)
 {
 	create_negative_test_thread(TIMEOUT_REMAINING_TICKS);
 }
 
 /**
- * @brief Test that k_thread_timeout_expires_ticks() rejects a NULL pointer
- *
- * Verifies that passing a NULL thread pointer to
- * k_thread_timeout_expires_ticks() triggers the expected fatal error
- * in the syscall validation layer.
+ * @brief Verify that k_thread_timeout_expires_ticks() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_timeout_expires_ticks()
  */
-ZTEST_USER(thread_error_case, test_timeout_expires_ticks)
+ZTEST_USER(thread_error_case, test_thread_timeout_expires_ticks_null)
 {
 	create_negative_test_thread(TIMEOUT_EXPIRES_TICKS);
 }
 
 /**
- * @brief Test that k_thread_create() rejects a NULL new-thread pointer
- *
- * Verifies that passing NULL as the new thread object to k_thread_create()
- * triggers the expected fatal error. The syscall verifier requires the
- * thread object to be a valid, uninitialized kernel object.
+ * @brief Verify that k_thread_create() rejects a NULL new-thread object.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * The verifier requires the new thread to be a valid, uninitialized kernel
+ * object, so a NULL pointer must be refused rather than initialized.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_create()
  */
-ZTEST_USER(thread_error_case, test_thread_create_uninit)
+ZTEST_USER(thread_error_case, test_thread_create_null_thread)
 {
 	create_negative_test_thread(THREAD_CREATE_NEWTHREAD_NULL);
 }
 
 /**
- * @brief Test that k_thread_create() rejects a NULL stack pointer
- *
- * Verifies that passing NULL as the stack argument to k_thread_create()
- * triggers the expected fatal error. The syscall verifier requires the
- * stack to be a valid, uninitialized kernel stack object.
+ * @brief Verify that k_thread_create() rejects a NULL stack object.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * The verifier requires the stack to be a valid, uninitialized kernel stack
+ * object, so a NULL pointer must be refused rather than used as a stack.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_create()
  */
-ZTEST_USER(thread_error_case, test_thread_create_stack_null)
+ZTEST_USER(thread_error_case, test_thread_create_null_stack)
 {
 	create_negative_test_thread(THREAD_CREATE_STACK_NULL);
 }
 
 /**
- * @brief Test that k_thread_create() rejects an overflowing stack size
- *
- * Verifies that passing SIZE_MAX (-1 cast to size_t) as the stack size
- * to k_thread_create() triggers the expected fatal error. The syscall
- * verifier detects the overflow when computing
- * K_THREAD_STACK_RESERVED + stack_size.
+ * @brief Verify that k_thread_create() rejects a stack size that overflows.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * The verifier adds K_THREAD_STACK_RESERVED to the requested size, so a size
+ * of SIZE_MAX wraps around; the overflow has to be detected instead of
+ * yielding a small, bogus stack.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_create()
  */
-ZTEST_USER(thread_error_case, test_thread_create_stack_overflow)
+ZTEST_USER(thread_error_case, test_thread_create_stack_size_overflow)
 {
 	create_negative_test_thread(THREAD_CREATE_STACK_SIZE_OVERFLOW);
 }
 
 /**
- * @brief Test that k_thread_suspend() rejects a NULL thread pointer
- *
- * Verifies that passing a NULL pointer to k_thread_suspend() triggers
- * the expected fatal error in the syscall validation layer.
+ * @brief Verify that k_thread_suspend() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
  *
  * @see k_thread_suspend()
  */
@@ -304,12 +412,26 @@ ZTEST_USER(thread_error_case, test_thread_suspend_null)
 }
 
 /**
- * @brief Test that k_thread_resume() rejects a NULL thread pointer
- *
- * Verifies that passing a NULL pointer to k_thread_resume() triggers
- * the expected fatal error in the syscall validation layer.
+ * @brief Verify that k_thread_resume() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
  *
  * @see k_thread_resume()
  */
@@ -319,12 +441,26 @@ ZTEST_USER(thread_error_case, test_thread_resume_null)
 }
 
 /**
- * @brief Test that k_thread_priority_set() rejects a NULL thread pointer
- *
- * Verifies that passing a NULL pointer to k_thread_priority_set() triggers
- * the expected fatal error in the syscall validation layer.
+ * @brief Verify that k_thread_priority_set() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
  *
  * @see k_thread_priority_set()
  */
@@ -334,12 +470,26 @@ ZTEST_USER(thread_error_case, test_thread_priority_set_null)
 }
 
 /**
- * @brief Test that k_thread_priority_get() rejects a NULL thread pointer
- *
- * Verifies that passing a NULL pointer to k_thread_priority_get() triggers
- * the expected fatal error in the syscall validation layer.
+ * @brief Verify that k_thread_priority_get() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
  *
  * @see k_thread_priority_get()
  */
@@ -349,12 +499,26 @@ ZTEST_USER(thread_error_case, test_thread_priority_get_null)
 }
 
 /**
- * @brief Test that k_wakeup() rejects a NULL thread pointer
- *
- * Verifies that passing a NULL pointer to k_wakeup() triggers the
- * expected fatal error in the syscall validation layer.
+ * @brief Verify that k_wakeup() rejects a NULL thread pointer.
  *
  * @ingroup kernel_thread_tests
+ *
+ * @details
+ * The syscall verification layer must reject a NULL thread object before it
+ * reaches the kernel, where it would be dereferenced.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
  *
  * @see k_wakeup()
  */
@@ -364,37 +528,60 @@ ZTEST_USER(thread_error_case, test_thread_wakeup_null)
 }
 
 /**
- * @brief Test that k_thread_create() forbids creating supervisor threads
- *        from user context
- *
- * Verifies that a user thread cannot create a supervisor thread by omitting
- * the K_USER option flag. The syscall verifier in z_vrfy_k_thread_create()
- * enforces that the K_USER flag must be set for all threads spawned from
- * user context.
+ * @brief Verify that a user thread cannot create a supervisor thread.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * Omitting K_USER from a thread created in user context would hand
+ * unprivileged code a privileged thread, so the verifier must require the
+ * flag on every thread spawned from user mode.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_create()
  */
-ZTEST_USER(thread_error_case, test_thread_create_supervisor)
+ZTEST_USER(thread_error_case, test_thread_create_supervisor_denied)
 {
 	create_negative_test_thread(THREAD_CREATE_SUPERVISOR);
 }
 
 /**
- * @brief Test that k_thread_create() forbids creating essential threads
- *        from user context
- *
- * Verifies that a user thread cannot create an essential thread by setting
- * the K_ESSENTIAL option flag. The syscall verifier in
- * z_vrfy_k_thread_create() rejects this to prevent unprivileged code from
- * creating threads whose abort would trigger a kernel panic.
+ * @brief Verify that a user thread cannot create an essential thread.
  *
  * @ingroup kernel_thread_tests
  *
+ * @details
+ * Aborting an essential thread panics the kernel, so unprivileged code must
+ * not be able to set K_ESSENTIAL on a thread it creates.
+ *
+ * All cases in this suite share one mechanism: a worker thread, running in
+ * user mode when the test case does, arms the ztest fatal-error hook and then
+ * makes the offending call. The call must not return -- reaching the code
+ * after it fails the test -- so a pass means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Make the offending call from that thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
  * @see k_thread_create()
  */
-ZTEST_USER(thread_error_case, test_thread_create_essential)
+ZTEST_USER(thread_error_case, test_thread_create_essential_denied)
 {
 	create_negative_test_thread(THREAD_CREATE_ESSENTIAL);
 }

--- a/tests/kernel/threads/thread_init/src/main.c
+++ b/tests/kernel/threads/thread_init/src/main.c
@@ -62,14 +62,27 @@ static ZTEST_BMEM struct thread_data {
 /*entry routines*/
 static void thread_entry(void *p1, void *p2, void *p3)
 {
+	/* Sample the moment this thread was first scheduled before
+	 * synchronising, so the start delay is still measured from creation to
+	 * first execution rather than from the release of the semaphore.
+	 */
+	uint64_t t_start = k_uptime_get();
+
+	/* Wait to be released by the test case that owns this thread before
+	 * looking at any of the shared expectations. A statically defined
+	 * thread becomes ready at boot, or once its own start delay expires,
+	 * and is then scheduled during whichever test case happens to block
+	 * first, which need not be its own, so reading them earlier would race
+	 * with that case.
+	 */
+	k_sem_take(p3, K_FOREVER);
+
 	if (t_create) {
-		uint64_t t_delay = k_uptime_get() - t_create;
+		uint64_t t_delay = t_start - t_create;
 		/**TESTPOINT: check delay start*/
 		zassert_true(t_delay >= expected.init_delay,
 			     "k_thread_create delay start failed");
 	}
-
-	k_sem_take(p3, K_FOREVER);
 
 	k_tid_t tid = k_current_get();
 	/**TESTPOINT: check priority and params*/
@@ -88,13 +101,33 @@ static void thread_entry(void *p1, void *p2, void *p3)
  */
 
 /**
- * @brief test preempt thread initialization via K_THREAD_DEFINE
+ * @brief Verify that K_THREAD_DEFINE() initializes a preemptible thread with
+ *        the values it was given.
  *
- * @see #K_THREAD_DEFINE(x)
+ * @details
+ * A statically defined thread has to reach its entry point with exactly the
+ * priority and the three parameters named in its definition, the same way a
+ * thread created at run time does. The thread itself performs the checks, so
+ * what is validated is the state the kernel actually handed it rather than
+ * what the definition asked for. The start delay is not checked here because
+ * a statically defined thread has no observable creation timestamp.
  *
- * @ingroup kernel_thread_tests
+ * Test steps:
+ * - Record the priority and parameters the thread was defined with.
+ * - Release the statically defined preemptible thread from its start
+ *   semaphore.
+ * - In the thread, compare its own priority and its p1, p2 and p3 against the
+ *   recorded values, then signal completion.
+ * - Wait for the completion semaphore.
+ *
+ * Expected result:
+ * - The thread runs at the defined priority and receives the defined
+ *   parameters.
+ *
+ * @see K_THREAD_DEFINE()
+ * @see k_thread_priority_get()
  */
-ZTEST_USER(thread_init, test_kdefine_preempt_thread)
+ZTEST_USER(thread_init, test_thread_init_kdefine_preempt)
 {
 	/*static thread created time unknown, skip it*/
 	t_create = 0U;
@@ -112,13 +145,30 @@ ZTEST_USER(thread_init, test_kdefine_preempt_thread)
 }
 
 /**
- * @brief test coop thread initialization via K_THREAD_DEFINE
+ * @brief Verify that K_THREAD_DEFINE() initializes a cooperative thread with
+ *        the values it was given.
  *
- * @ingroup kernel_thread_tests
+ * @details
+ * The cooperative counterpart of the preemptible case: a negative priority
+ * must survive static definition just as a positive one does, so the same
+ * checks are repeated against a thread defined at a cooperative priority.
  *
- * @see #K_THREAD_DEFINE(x)
+ * Test steps:
+ * - Record the priority and parameters the thread was defined with.
+ * - Release the statically defined cooperative thread from its start
+ *   semaphore.
+ * - In the thread, compare its own priority and its p1, p2 and p3 against the
+ *   recorded values, then signal completion.
+ * - Wait for the completion semaphore.
+ *
+ * Expected result:
+ * - The thread runs at the defined cooperative priority and receives the
+ *   defined parameters.
+ *
+ * @see K_THREAD_DEFINE()
+ * @see k_thread_priority_get()
  */
-ZTEST_USER(thread_init, test_kdefine_coop_thread)
+ZTEST_USER(thread_init, test_thread_init_kdefine_coop)
 {
 	/*static thread creation time unknown, skip it*/
 	t_create = 0U;
@@ -136,14 +186,36 @@ ZTEST_USER(thread_init, test_kdefine_coop_thread)
 }
 
 /**
- * @brief test preempt thread initialization via k_thread_create
+ * @brief Verify that k_thread_create() honours priority, parameters and start
+ *        delay for a preemptible thread.
  *
- * @ingroup kernel_thread_tests
+ * @details
+ * Creating a thread at run time must apply everything the call specifies: the
+ * priority, the three parameters and the delay before the thread is made
+ * ready. This case creates the thread with a delay of zero, so it covers
+ * immediate start; the cooperative case below carries the non-zero delay.
+ *
+ * Test steps:
+ * - Record the creation timestamp, then create a preemptible thread with a
+ *   zero start delay.
+ * - Release it from its start semaphore.
+ * - In the thread, check that the time from creation to its first execution
+ *   is at least the requested delay, then compare its priority and its p1, p2
+ *   and p3 against the requested values and signal completion.
+ * - Wait for the completion semaphore.
+ *
+ * Expected result:
+ * - Creation succeeds and the thread runs at the requested priority with the
+ *   requested parameters.
  *
  * @see k_thread_create()
+ * @see k_thread_priority_get()
  */
-ZTEST_USER(thread_init, test_kinit_preempt_thread)
+ZTEST_USER(thread_init, test_thread_init_create_preempt)
 {
+	/*record time stamp before thread creation*/
+	t_create = k_uptime_get();
+
 	/*create preempt thread*/
 	k_tid_t pthread = k_thread_create(&thread_preempt, stack_preempt,
 					  INIT_PREEMPT_STACK_SIZE, thread_entry, INIT_PREEMPT_P1,
@@ -151,8 +223,6 @@ ZTEST_USER(thread_init, test_kinit_preempt_thread)
 					  INIT_PREEMPT_OPTION,
 					  K_MSEC(INIT_PREEMPT_DELAY));
 
-	/*record time stamp of thread creation*/
-	t_create = k_uptime_get();
 	zassert_not_null(pthread, "thread creation failed");
 
 	expected.init_p1 = INIT_PREEMPT_P1;
@@ -169,17 +239,42 @@ ZTEST_USER(thread_init, test_kinit_preempt_thread)
 }
 
 /**
- * @brief test coop thread initialization via k_thread_create
+ * @brief Verify that k_thread_create() honours priority, parameters and start
+ *        delay for a cooperative thread.
  *
- * @ingroup kernel_thread_tests
+ * @details
+ * The cooperative counterpart of the run-time creation case, covering a
+ * negative priority and the K_USER option. It is also the case that exercises
+ * the start delay: the thread is created with a two second delay and knows
+ * when it was created, so it can confirm it was not made ready early. Skipped
+ * when userspace is not enabled, as the thread is created with the user option
+ * that configuration does not provide.
+ *
+ * Test steps:
+ * - Record the creation timestamp, then create a cooperative thread with a
+ *   two second start delay.
+ * - Release it from its start semaphore.
+ * - In the thread, check that the time from creation to its first execution
+ *   is at least the requested delay, then compare its priority and its p1, p2
+ *   and p3 against the requested values and signal completion.
+ * - Wait for the completion semaphore.
+ *
+ * Expected result:
+ * - Creation succeeds, the thread starts no earlier than the requested delay,
+ *   and it runs at the requested cooperative priority with the requested
+ *   parameters.
  *
  * @see k_thread_create()
+ * @see k_thread_priority_get()
  */
-ZTEST(thread_init, test_kinit_coop_thread)
+ZTEST(thread_init, test_thread_init_create_coop)
 {
 	if (!(IS_ENABLED(CONFIG_USERSPACE))) {
 		ztest_test_skip();
 	}
+
+	/*record time stamp before thread creation*/
+	t_create = k_uptime_get();
 
 	/*create coop thread*/
 	k_tid_t pthread = k_thread_create(&thread_coop, stack_coop,
@@ -187,8 +282,6 @@ ZTEST(thread_init, test_kinit_coop_thread)
 			  INIT_COOP_P2, INIT_COOP_P3, INIT_COOP_PRIO,
 			  INIT_COOP_OPTION, K_MSEC(INIT_COOP_DELAY));
 
-	/*record time stamp of thread creation*/
-	t_create = k_uptime_get();
 	zassert_not_null(pthread, "thread spawn failed");
 
 	expected.init_p1 = INIT_COOP_P1;

--- a/tests/kernel/threads/thread_stack/src/main.c
+++ b/tests/kernel/threads/thread_stack/src/main.c
@@ -405,15 +405,38 @@ void scenario_entry(void *stack_obj, size_t obj_size, size_t reported_size,
 }
 
 /**
- * @brief Test kernel provides user thread read/write access to its own stack
- * memory buffer
- *
- * @details Thread can access its own stack memory buffer and perform
- * read/write operations.
+ * @brief Verify that every kind of declared stack is sized, aligned and
+ *        writable as its macros promise.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * A thread must be able to read and write the whole stack buffer it was given,
+ * and the size and alignment reported by the K_THREAD_STACK and K_KERNEL_STACK
+ * macros have to agree with what the object actually occupies. Getting this
+ * wrong is what turns a stack into an overlapping or under-sized region, so
+ * each form a stack can be declared in is checked in turn: a single stack, an
+ * element of a stack array, and a stack embedded in a struct, for both thread
+ * and kernel stacks.
+ *
+ * Test steps:
+ * - Report the reserved space and interrupt stack sizes for the record.
+ * - For each declared stack, spawn a thread on it and have that thread check
+ *   its reported bounds, alignment and reserved space, then write over the
+ *   full usable extent of its own stack.
+ * - Repeat for user stacks, user stack arrays, kernel stacks, kernel stack
+ *   arrays and a struct-embedded stack.
+ *
+ * Expected result:
+ * - Every stack reports the size and alignment its declaration implies, and a
+ *   thread can write the whole buffer without faulting.
+ *
+ * @see K_THREAD_STACK_DEFINE()
+ * @see K_KERNEL_STACK_DEFINE()
+ * @see K_THREAD_STACK_SIZEOF()
+ * @see k_thread_stack_space_get()
  */
-ZTEST(userspace_thread_stack, test_stack_buffer)
+ZTEST(userspace_thread_stack, test_thread_stack_buffer_access)
 {
 	printk("Reserved space (thread stacks): %zu\n",
 	       K_THREAD_STACK_RESERVED);
@@ -480,15 +503,34 @@ void no_op_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Show that the idle thread stack size is correct
- *
- * The idle thread has to occasionally clean up self-exiting threads.
- * Exercise this and show that we didn't overflow, reporting out stack
- * usage.
+ * @brief Verify that cleaning up an exited thread does not overflow the idle
+ *        thread stack.
  *
  * @ingroup kernel_memprotect_tests
+ *
+ * @details
+ * The idle thread is where a self-exiting thread's resources are reclaimed,
+ * including any dynamic kernel objects whose last reference it held. That
+ * cleanup runs on the idle thread's own stack, which is sized by
+ * CONFIG_IDLE_STACK_SIZE, so it has to fit. The test drives that path and then
+ * reads back how much of the idle stack was left, which also reports the
+ * headroom for the record. Skipped on coherence platforms, where the idle
+ * stack may have been initialized on another CPU and cannot be inspected from
+ * this one.
+ *
+ * Test steps:
+ * - Spawn a thread that allocates a dynamic kernel object and self-exits, so
+ *   the idle thread has to clean up after it.
+ * - Join the thread and sleep briefly so the idle thread runs.
+ * - Query the unused space of the idle thread's stack.
+ *
+ * Expected result:
+ * - The query succeeds and the idle thread stack still has unused space, so
+ *   the cleanup did not overflow it.
+ *
+ * @see k_thread_stack_space_get()
  */
-ZTEST(userspace_thread_stack, test_idle_stack)
+ZTEST(userspace_thread_stack, test_thread_stack_idle_no_overflow)
 {
 	if (IS_ENABLED(CONFIG_KERNEL_COHERENCE)) {
 		/* Stacks on coherence platforms aren't coherent, and

--- a/tests/kernel/threads/tls/src/main.c
+++ b/tests/kernel/threads/tls/src/main.c
@@ -182,7 +182,32 @@ static void start_tls_test(uint32_t thread_options)
 	zassert_true(passed, "Test failed");
 }
 
-ZTEST(thread_tls, test_tls)
+/**
+ * @brief Verify that thread-local variables are private to each thread.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A variable declared thread-local must resolve to a separate instance per
+ * thread, so writes made by one thread are invisible to every other one.
+ * Several threads run the same body concurrently, each writing a value derived
+ * from its own identity and then checking that what it reads back is still its
+ * own; a shared instance would show up as a thread observing a neighbour's
+ * value. Skipped when userspace is enabled, as the user-mode case below covers
+ * that configuration.
+ *
+ * Test steps:
+ * - Spawn the worker threads in supervisor mode.
+ * - In each thread, write to the thread-local variables, yield to let the
+ *   others run, and read them back.
+ * - Collect the per-thread results once every thread has finished.
+ *
+ * Expected result:
+ * - Every thread reads back only the values it wrote itself.
+ *
+ * @see Z_THREAD_LOCAL
+ */
+ZTEST(thread_tls, test_tls_vars_are_per_thread)
 {
 	if (IS_ENABLED(CONFIG_USERSPACE)) {
 		ztest_test_skip();
@@ -192,9 +217,33 @@ ZTEST(thread_tls, test_tls)
 	start_tls_test(0);
 }
 
-ZTEST_USER(thread_tls, test_tls_userspace)
+/**
+ * @brief Verify that thread-local variables stay private in user mode.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * User threads reach their thread-local storage through the same mechanism as
+ * supervisor threads but under memory protection, where the TLS block has to
+ * be mapped into the thread's own domain. The same isolation check is
+ * therefore repeated with the workers spawned as user threads, so a TLS block
+ * that is shared or unreachable under userspace is caught.
+ *
+ * Test steps:
+ * - Spawn the worker threads with K_USER, inheriting the caller's permissions.
+ * - In each thread, write to the thread-local variables, yield to let the
+ *   others run, and read them back.
+ * - Collect the per-thread results once every thread has finished.
+ *
+ * Expected result:
+ * - Every user thread reads back only the values it wrote itself.
+ *
+ * @see Z_THREAD_LOCAL
+ * @see k_thread_create()
+ */
+ZTEST_USER(thread_tls, test_tls_vars_are_per_thread_user)
 {
-	/* TLS test in supervisor mode */
+	/* TLS test in user mode */
 	start_tls_test(K_USER | K_INHERIT_PERMS);
 }
 


### PR DESCRIPTION
- **tests: kernel: threads: tls: document the test cases**
- **tests: kernel: threads: no-multithreading: document the test cases**
- **tests: kernel: threads: thread_init: document the test cases**
- **tests: kernel: threads: runtime_stack_safety: fix the doc group name**
- **tests: kernel: threads: dynamic_thread: document the test cases**
- **tests: kernel: threads: dynamic_thread_stack: document the test cases**
- **tests: kernel: threads: thread_stack: document the test cases**
- **tests: kernel: threads: thread_error_case: document the test cases**
- **tests: kernel: threads: thread_apis: document the test cases**
