### PR TITLE
include: net: hdlc_rcp_if: drop `@param none` from void callbacks

### DIFF
--- a/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
+++ b/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
@@ -62,8 +62,6 @@ struct hdlc_api {
 	/**
 	 * @brief Deinitialize the device.
 	 *
-	 * @param none
-	 *
 	 * @retval 0 The interface was successfully stopped.
 	 * @retval -EIO The interface could not be stopped.
 	 */
@@ -72,8 +70,6 @@ struct hdlc_api {
 	/**
 	 * @brief Optional: complete the RCP interface initialization in deferred init mode.
 	 * If NULL, the interface is started automatically at init.
-	 *
-	 * @param none
 	 *
 	 * @retval 0 The interface was successfully started.
 	 * @retval -EIO The interface could not be started.


### PR DESCRIPTION
Doxygen reads `@param none` as a parameter literally named "none", so both blocks document an argument that isn't there. Found it while checking `@param` names against declarations across the tree, and these two are the only `@param none` in all of `include/`, so it looks like a slip rather than a convention you use.

Left the `@retval` blocks alone, they're fine as they are.
