### PR TITLE
arch: arc: mpu: fix memory domain partition handling with holes

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_common_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_common_internal.h
@@ -132,6 +132,7 @@ void arc_core_mpu_configure_mem_domain(struct k_thread *thread)
 	uint32_t num_partitions;
 	struct k_mem_partition *pparts;
 	struct k_mem_domain *mem_domain = NULL;
+	uint32_t slot = 0U;
 
 	if (thread) {
 		mem_domain = thread->mem_domain_info.mem_domain;
@@ -148,16 +149,25 @@ void arc_core_mpu_configure_mem_domain(struct k_thread *thread)
 	}
 
 	for (; region_index >= 0; region_index--) {
-		if (num_partitions) {
-			LOG_DBG("set region 0x%x 0x%lx 0x%x", region_index, pparts->start,
-				pparts->size);
-			_region_init(region_index, pparts->start, pparts->size, pparts->attr);
+		/*
+		 * Skip zero-sized holes: they must not consume a region slot
+		 * or the remaining-partition counter
+		 */
+		while (num_partitions && slot < CONFIG_MAX_DOMAIN_PARTITIONS &&
+		       pparts[slot].size == 0U) {
+			slot++;
+		}
+		if (num_partitions && slot < CONFIG_MAX_DOMAIN_PARTITIONS) {
+			LOG_DBG("set region 0x%x 0x%lx 0x%x", region_index, pparts[slot].start,
+				pparts[slot].size);
+			_region_init(region_index, pparts[slot].start, pparts[slot].size,
+				     pparts[slot].attr);
 			num_partitions--;
+			slot++;
 		} else {
 			/* clear the left mpu entries */
 			_region_init(region_index, 0, 0, 0);
 		}
-		pparts++;
 	}
 }
 

--- a/arch/arc/core/mpu/arc_mpu_common_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_common_internal.h
@@ -195,13 +195,36 @@ void arc_core_mpu_remove_mem_domain(struct k_mem_domain *mem_domain)
  */
 void arc_core_mpu_remove_mem_partition(struct k_mem_domain *domain, uint32_t part_id)
 {
-	ARG_UNUSED(domain);
-
 	int region_index = get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
+	uint32_t i;
 
-	LOG_DBG("disable region 0x%x", region_index + part_id);
+	if (part_id >= CONFIG_MAX_DOMAIN_PARTITIONS || domain->partitions[part_id].size == 0U) {
+		return;
+	}
+
+	/*
+	 * arc_core_mpu_configure_mem_domain() programs valid partitions in
+	 * array order into consecutive region slots counting down from the
+	 * domain-partition base region, skipping holes; count the valid
+	 * partitions before this one to derive its region slot.
+	 */
+	for (i = 0; i < part_id; i++) {
+		if (domain->partitions[i].size != 0U) {
+			region_index--;
+		}
+	}
+
+	/*
+	 * Defensive: unreachable while the kernel caps partitions at
+	 * base + 1 via arch_mem_domain_max_partitions_get().
+	 */
+	if (region_index < 0) {
+		return;
+	}
+
+	LOG_DBG("disable region 0x%x", region_index);
 	/* Disable region */
-	_region_init(region_index + part_id, 0, 0, 0);
+	_region_init(region_index, 0, 0, 0);
 }
 
 /**

--- a/arch/arc/core/mpu/arc_mpu_v4_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v4_internal.h
@@ -590,17 +590,15 @@ void arc_core_mpu_configure_thread(struct k_thread *thread)
 		pparts = NULL;
 	}
 
-	for (uint32_t i = 0; i < num_partitions; i++) {
-		if (pparts->size) {
-			if (_dynamic_region_allocate_and_init(pparts->start,
-				pparts->size, pparts->attr) < 0) {
-				LOG_ERR(
-				"thread %p's mem region: %p failed",
-				 thread, pparts);
+	for (uint32_t i = 0; i < CONFIG_MAX_DOMAIN_PARTITIONS && num_partitions; i++) {
+		if (pparts[i].size != 0U) {
+			if (_dynamic_region_allocate_and_init(pparts[i].start, pparts[i].size,
+							      pparts[i].attr) < 0) {
+				LOG_ERR("thread %p's mem region: %p failed", thread, pparts);
 				return;
 			}
+			num_partitions--;
 		}
-		pparts++;
 	}
 #else
 	arc_core_mpu_configure_mem_domain(thread);
@@ -681,16 +679,21 @@ void arc_core_mpu_configure_mem_domain(struct k_thread *thread)
 	num_regions = get_num_regions();
 	region_index = get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
 
-	while (num_partitions && region_index < num_regions) {
-		if (pparts->size > 0) {
-			LOG_DBG("set region 0x%x 0x%lx 0x%x",
-				region_index, pparts->start, pparts->size);
-			_region_init(region_index, pparts->start,
-				     pparts->size, pparts->attr);
+	/*
+	 * Scan the full partitions array: removed partitions leave zero-sized
+	 * holes, so num_partitions only counts the valid entries. The array
+	 * bound keeps the scan in range regardless.
+	 */
+	for (uint32_t i = 0; i < CONFIG_MAX_DOMAIN_PARTITIONS && num_partitions &&
+	     region_index < num_regions; i++) {
+		if (pparts[i].size != 0U) {
+			LOG_DBG("set region 0x%x 0x%lx 0x%x", region_index, pparts[i].start,
+				pparts[i].size);
+			_region_init(region_index, pparts[i].start, pparts[i].size,
+				     pparts[i].attr);
 			region_index++;
+			num_partitions--;
 		}
-		pparts++;
-		num_partitions--;
 	}
 
 	while (region_index < num_regions) {
@@ -708,34 +711,28 @@ void arc_core_mpu_configure_mem_domain(struct k_thread *thread)
  */
 void arc_core_mpu_remove_mem_domain(struct k_mem_domain *mem_domain)
 {
-	uint32_t num_partitions;
 	struct k_mem_partition *pparts;
 	int index;
 
-	if (mem_domain) {
-		LOG_DBG("configure domain: %p", mem_domain);
-		num_partitions = mem_domain->num_partitions;
-		pparts = mem_domain->partitions;
-	} else {
+	if (!mem_domain) {
 		LOG_DBG("disable domain partition regions");
-		num_partitions = 0U;
-		pparts = NULL;
+		return;
 	}
 
-	for (uint32_t i = 0; i < num_partitions; i++) {
-		if (pparts->size) {
-			index = _get_region_index(pparts->start,
-			 pparts->size);
+	LOG_DBG("configure domain: %p", mem_domain);
+	pparts = mem_domain->partitions;
+
+	for (uint32_t i = 0; i < CONFIG_MAX_DOMAIN_PARTITIONS; i++) {
+		if (pparts[i].size != 0U) {
+			index = _get_region_index(pparts[i].start, pparts[i].size);
 			if (index > 0) {
 #if defined(CONFIG_MPU_GAP_FILLING)
-				_region_set_attr(index,
-				REGION_KERNEL_RAM_ATTR);
+				_region_set_attr(index, REGION_KERNEL_RAM_ATTR);
 #else
 				_region_init(index, 0, 0, 0);
 #endif
 			}
 		}
-		pparts++;
 	}
 }
 


### PR DESCRIPTION
k_mem_domain_remove_partition() leaves a zero-sized hole in
domain->partitions[]. The ARC MPU domain region loops bounded their
iteration with num_partitions, so each hole consumed one iteration and
valid partitions behind it were never programmed into the MPU, faulting
user-mode accesses with EV_ProtV.

Commits:
- arch: arc: mpu: skip zero-sized holes without consuming the
  remaining-partition counter (v2/v3/v6 common path; v4/v8 gap-filling,
  non-gap-filling, and remove paths)
- arch: arc: mpu: fix remove_mem_partition() region index derivation to
  match the configure loop's downward slot mapping

Fixes: #116321