### PR TITLE
boards: fanke/weact: Fix back flash size in board YAML file

### DIFF
--- a/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.yaml
+++ b/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 1376
-flash: 8192
+flash: 128
 supported:
   - uart
   - gpio

--- a/boards/weact/mini_stm32h743/mini_stm32h743.yaml
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 512
-flash: 8192
+flash: 2048
 supported:
   - gpio
   - counter

--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0.yaml
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 512
-flash: 8192
+flash: 2048
 supported:
   - gpio
   - counter


### PR DESCRIPTION
boards: fanke: fk7b0m1_vbt6: Fix back flash size in board YAML file

Commits 0d35e7b9d6b3 and  39b5bf31cf63 wrongly changed the flash size declared to Twister tool in the boards YAML file.
Despite a flash partition labeled `slot0_partition` exists in the boards DTS file, it is not referenced by a chosen `zephyr,code-partition` DT property and the application is located by default in the flash referenced by DT chosen `zephyr,flash` property.

Restore the expected flash size accordingly.