### PR TITLE
arch: arm64: reject SVCs from EL0 targeting kernel-only entries

### DIFF
--- a/arch/arm64/core/switch.S
+++ b/arch/arm64/core/switch.S
@@ -198,13 +198,20 @@ fpu_sve_trap:
 	/* Demux the SVC call */
 	and	x1, x0, #0xff
 
+	/*
+	 * The IRQ offload entry must never be reached from EL0: it jumps to a
+	 * caller-supplied address at EL1. The runtime-except entry stays
+	 * reachable from EL0 so user threads can raise kernel oopses and
+	 * stack-check failures (z_arm64_do_kernel_oops() sanitizes the
+	 * user-supplied reason), and the system call entry is the regular
+	 * syscall path. Verify which exception level the SVC was taken from.
+	 */
+	ldr	x2, [sp, ___esf_t_spsr_elr_OFFSET]
+	tst	x2, #SPSR_MODE_MASK
+	beq	svc_from_user
+
 	cmp	x1, #_SVC_CALL_RUNTIME_EXCEPT
 	beq	oops
-
-#ifdef CONFIG_USERSPACE
-	cmp	x1, #_SVC_CALL_SYSTEM_CALL
-	beq	z_arm64_do_syscall
-#endif
 
 #ifdef CONFIG_IRQ_OFFLOAD
 	cmp	x1, #_SVC_CALL_IRQ_OFFLOAD
@@ -242,6 +249,15 @@ offload:
 	/* Exit through regular IRQ exit path */
 	b	z_arm64_irq_done
 #endif
+	b	inv
+
+svc_from_user:
+#ifdef CONFIG_USERSPACE
+	cmp	x1, #_SVC_CALL_SYSTEM_CALL
+	beq	z_arm64_do_syscall
+#endif
+	cmp	x1, #_SVC_CALL_RUNTIME_EXCEPT
+	beq	oops
 	b	inv
 
 oops:

--- a/tests/arch/arm64/svc_el0_gate/CMakeLists.txt
+++ b/tests/arch/arm64/svc_el0_gate/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(svc_el0_gate)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/arch/arm64/svc_el0_gate/prj.conf
+++ b/tests/arch/arm64/svc_el0_gate/prj.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_USERSPACE=y
+CONFIG_IRQ_OFFLOAD=y

--- a/tests/arch/arm64/svc_el0_gate/src/main.c
+++ b/tests/arch/arm64/svc_el0_gate/src/main.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Process Mission
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+ZTEST_BMEM static volatile bool expect_fault;
+
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+{
+	ARG_UNUSED(esf);
+
+	printk("Caught system error -- reason %d\n", reason);
+
+	if (!expect_fault) {
+		printk("Unexpected fault during test\n");
+		TC_END_REPORT(TC_FAIL);
+		k_fatal_halt(reason);
+	}
+
+	expect_fault = false;
+	printk("System error was expected\n");
+}
+
+/* Kernel-only state that the EL0 SVC must never be able to touch. */
+static volatile uint32_t probe_called;
+
+/* Kernel function the user thread will try to invoke via svc #1. */
+static void probe(uint32_t value)
+{
+	probe_called = value;
+}
+
+K_THREAD_STACK_DEFINE(evil_stack, 2048);
+static struct k_thread evil_thread;
+
+static void evil_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	/* arch_irq_offload() passes the routine in x0 and the argument in x1. */
+	register uint64_t fn_reg __asm__("x0") = (uint64_t)(uintptr_t)probe;
+	register uint64_t arg_reg __asm__("x1") = 0x12345678ULL;
+
+	/* This is the raw SVC used by arch_irq_offload() from kernel mode. */
+	__asm__ volatile("svc #1\n" : : "r"(fn_reg), "r"(arg_reg) : "memory");
+
+	/* Reaching this point means the SVC was ignored instead of killing
+	 * the thread. Return so the join below succeeds at once and the
+	 * probe_called check fails immediately, rather than timing out.
+	 */
+}
+
+ZTEST(svc_el0_gate, test_el0_cannot_trigger_irq_offload)
+{
+	probe_called = 0;
+	expect_fault = true;
+
+	k_tid_t tid =
+		k_thread_create(&evil_thread, evil_stack, K_THREAD_STACK_SIZEOF(evil_stack),
+				evil_entry, NULL, NULL, NULL, K_PRIO_PREEMPT(1), K_USER, K_NO_WAIT);
+
+	/* The thread must fault and be aborted by the fatal handler. */
+	zassert_ok(k_thread_join(tid, K_SECONDS(10)), "EL0 svc #1 was not rejected");
+
+	zassert_equal(probe_called, 0, "svc #1 from EL0 invoked kernel code at EL1");
+}
+
+ZTEST_SUITE(svc_el0_gate, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/arm64/svc_el0_gate/tests.yaml
+++ b/tests/arch/arm64/svc_el0_gate/tests.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  arch.arm64.svc_el0_gate:
+    tags: kernel userspace arm64
+    platform_allow:
+      - qemu_cortex_a53
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+    integration_platforms:
+      - qemu_cortex_a53
+      - qemu_cortex_a53/qemu_cortex_a53/smp


### PR DESCRIPTION
`z_arm64_sync_exc()` demuxed SVC exceptions solely by the SVC immediate
(`svc #1` IRQ offload, `svc #2` runtime except, `svc #3` syscall) without
checking the exception level the SVC was taken from. Since SVC from EL0 and
EL1 both report ESR EC 0x15, a user thread could execute a raw `svc #1` with
an arbitrary function pointer in `x0`, causing the kernel to branch to it at
EL1 — privilege escalation from userspace (`CONFIG_USERSPACE=y` +
`CONFIG_IRQ_OFFLOAD=y`).

The fix reads the saved SPSR from the ESF and routes any SVC taken from EL0
to a user-only path that accepts just the system call immediate; all other
EL0 SVCs raise a fatal CPU exception. This mirrors the RISC-V port, which
distinguishes `ECALLU`/`ECALLM` via `mcause`.

Fixes #116254