### PR TITLE
boards: infineon: kit_xmc72_evk: select debug adapter by serial

### DIFF
--- a/boards/infineon/kit_xmc72_evk/support/openocd.cfg
+++ b/boards/infineon/kit_xmc72_evk/support/openocd.cfg
@@ -12,4 +12,12 @@ source [find interface/$INTERFACE.cfg]
 
 transport select swd
 
+# Optional: specify a particular KitProg3/CMSIS-DAP debugger if multiple are
+# connected. west's openocd runner passes --serial/--dev-id as
+# _ZEPHYR_BOARD_SERIAL; honor it so the correct probe is selected on hosts
+# with more than one adapter attached.
+if { [info exists _ZEPHYR_BOARD_SERIAL] } {
+    adapter serial $_ZEPHYR_BOARD_SERIAL
+}
+
 source [find target/cat1c.cfg]


### PR DESCRIPTION
boards: infineon: kit_xmc72_evk: select debug adapter by serial

The kit_xmc72_evk OpenOCD configuration sourced the CMSIS-DAP interface
without ever selecting a specific adapter. On a host with more than one
CMSIS-DAP probe connected, OpenOCD binds whichever probe enumerates
first, which can be the wrong board and leads to connection failures
such as "Error connecting DP: cannot read IDR".

west's openocd runner already passes `--serial`/`--dev-id` to the board
configuration as the Tcl variable `_ZEPHYR_BOARD_SERIAL`, but this board
never consumed it. Honor the variable and issue an `adapter serial`
command when it is set, so probe selection is deterministic when
multiple adapters are attached to the same host.

This matches the pattern already used by several other Infineon board
configurations (cy8cproto_041tp, kit_psc3m5_evk, kit_pse84_eval, and
others). Behavior is unchanged when a single probe is connected or when
no serial is supplied.
