### PR TITLE
doc: crc: fix the Kconfig option references on the driver page

### DIFF
--- a/doc/hardware/peripherals/crc.rst
+++ b/doc/hardware/peripherals/crc.rst
@@ -14,8 +14,8 @@ Configuration Options
 
 Related configuration options:
 
-* :kconfig:option:`CRC_HW`
-* :kconfig:option:`CRC_INIT_PRIORITY`
+* :kconfig:option:`CONFIG_CRC_DRIVER`
+* :kconfig:option:`CONFIG_CRC_DRIVER_INIT_PRIORITY`
 
 API Reference
 *************


### PR DESCRIPTION
## Description

The CRC driver page, `doc/hardware/peripherals/crc.rst`, lists two Kconfig
options that do not exist:

* `CRC_HW`
* `CRC_INIT_PRIORITY`

Neither symbol is declared anywhere in the tree, and no Kconfig template
generates them. The two occurrences on that page are the only ones in the
repository. The page has named them since it was added, in commit 3d99f6743,
which introduced the page and `drivers/crc/Kconfig` in the same change.

The page renders `.. doxygengroup:: crc_interface`, the group defined in
`include/zephyr/drivers/crc.h`, so the options that apply are the driver layer
ones declared in `drivers/crc/Kconfig`:

* `CRC_DRIVER` (line 5)
* `CRC_DRIVER_INIT_PRIORITY` (line 17)

`CRC_HW_HANDLER` belongs to the CRC subsystem rather than to the driver API,
and is already listed on the sister page `doc/services/crc/index.rst`, so it is
deliberately not added here.

The two names are written with the `CONFIG_` prefix because the Kconfig domain
registers option names prefixed (`doc/_extensions/zephyr/kconfig/__init__.py`)
and resolves cross references by exact match, so an unprefixed reference can
never resolve. `doc/services/crc/index.rst` already uses the prefixed form.

## What the defect actually is

It is a silent one, not a build failure. `nitpicky` is not enabled and
`:kconfig:option:` is a plain `XRefRole`, so an unresolved reference raises no
warning. **The documentation build does not break today.** The reference simply
renders as plain text instead of resolving to a link, and a reader who looks
either name up in the Kconfig search finds nothing.

## What was not done

**Nothing was built.** No board, no simulator, and no documentation build was
run for this change. It is a two line documentation text change that enters no
configuration expression and no generated code, so the reasoning above rests on
reading the tree and the doc extension, not on an execution. Stating that
plainly rather than implying more coverage than exists.

Checks that were run: `gitlint` with the in-tree rules, clean; and
`sphinx-lint` with the same flags the `SphinxLint` compliance check uses,
`No problems found`.
