### PR TITLE
scripts: process_gperf: update allowed version

### DIFF
--- a/scripts/build/process_gperf.py
+++ b/scripts/build/process_gperf.py
@@ -89,7 +89,7 @@ def process_line(line, fp):
     if m:
         v = version.parse(m.groups()[0])
         v_lo = version.parse("3.0")
-        v_hi = version.parse("3.1")
+        v_hi = version.parse("3.3")
         if v < v_lo or v > v_hi:
             warn(f"gperf {v} is not tested, versions {v_lo} through {v_hi} supported")
 


### PR DESCRIPTION
Update the allowed upper version limit to 3.3. This removes the warning about outdated gperf version.

Skimming through the changelog from v3.1 to v3.3 and most of the changes are doc and tool related.