### PR TITLE
soc: infineon: cat1c: place .cy_sharedmem SROM scratch section

### DIFF
--- a/soc/infineon/cat1c/common/CMakeLists.txt
+++ b/soc/infineon/cat1c/common/CMakeLists.txt
@@ -2,3 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(.)
+
+# Place the Infineon CAT1C SROM shared-memory scratch buffers. The PDL flash
+# driver (cy_flash_srom.c) tags them with CY_SECTION_SHAREDMEM (".cy_sharedmem").
+# Without explicit placement the section is an orphan; under the default
+# ORPHAN_SECTION_WARN the linker silently puts this must-be-SRAM scratch into
+# read-only flash, which faults at runtime. Anchor it in SRAM via NOINIT.
+zephyr_linker_sources(NOINIT noinit.ld)

--- a/soc/infineon/cat1c/common/noinit.ld
+++ b/soc/infineon/cat1c/common/noinit.ld
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+. = ALIGN(4);
+KEEP(*(.cy_sharedmem))


### PR DESCRIPTION
Place the Infineon CAT1C PDL SROM shared-memory scratch section.

The CAT1C PDL flash driver (`cy_flash_srom.c`) tags its SROM scratch buffers
with `CY_SECTION_SHAREDMEM`, which resolves to
`__attribute__((section(".cy_sharedmem")))`. The generic Cortex-M linker
script used by CAT1C (xmc7200) has no output section for `.cy_sharedmem`, so
once that source is built the section is an orphan. Under the default
`ORPHAN_SECTION_WARN` the link still succeeds, but the linker places this
must-be-SRAM scratch into read-only flash, so the first write faults at
runtime rather than producing a build error.

This anchors the section in the `noinit` (SRAM) region via
`zephyr_linker_sources(NOINIT)`, the same way `soc/infineon/cat1a` already
places its `.cy_sharedmem` buffers.

Building the flash driver source itself is handled separately by #118040;
this change is scoped to only the section placement that #118040 does not
cover.

Verified on `kit_xmc72_evk` (xmc7200, m7_0): the generated linker script
collects `KEEP(*(.cy_sharedmem))` into the `noinit (NOLOAD)` output section
mapped to RAM.
