### PR TITLE
drivers: display: Add Analog Devices ADV7535 bridge

### DIFF
--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_AC057TC1	display_ac057tc1.c)
+zephyr_library_sources_ifdef(CONFIG_ADV7535 display_adv7535.c)
 zephyr_library_sources_ifdef(CONFIG_CO5300 display_co5300.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_CHARLIEPLEX_LED_MATRIX display_charlieplex_led_matrix.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_COLOR_DITHER color_dither.c)

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -36,6 +36,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 # zephyr-keep-sorted-start
 source "drivers/display/Kconfig.ac057tc1"
+source "drivers/display/Kconfig.adv7535"
 source "drivers/display/Kconfig.charlieplex_led_matrix"
 source "drivers/display/Kconfig.co5300"
 source "drivers/display/Kconfig.dummy"

--- a/drivers/display/Kconfig.adv7535
+++ b/drivers/display/Kconfig.adv7535
@@ -1,0 +1,22 @@
+# Copyright (C) 2026, Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config ADV7535
+	bool "Analog Devices ADV7535 DSI-to-HDMI bridge"
+	default y
+	select I2C
+	select MIPI_DSI
+	depends on DT_HAS_ADI_ADV7535_ENABLED
+	help
+	  Initialize an ADV7535 for an RGB888 video mode and attach it to a
+	  MIPI DSI host. Runtime mode selection and HDMI services are not supported.
+
+if ADV7535
+
+config ADV7535_INIT_PRIORITY
+	int "ADV7535 initialization priority"
+	default 90
+	help
+	  Must be later than the MIPI DSI host initialization priority.
+
+endif

--- a/drivers/display/display_adv7535.c
+++ b/drivers/display/display_adv7535.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (C) 2026, Savoir-faire Linux, Inc.
+ * Author: Paolo Wattebled <paolo.wattebled@savoirfairelinux.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT adi_adv7535
+
+#include <errno.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/mipi_dsi.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(adv7535, CONFIG_DISPLAY_LOG_LEVEL);
+
+BUILD_ASSERT(CONFIG_ADV7535_INIT_PRIORITY > CONFIG_MIPI_DSI_INIT_PRIORITY,
+	     "ADV7535 must initialize after the MIPI DSI host");
+
+#define ADV7535_MAIN_POWER            0x41
+#define ADV7535_MAIN_POWER_DOWN       BIT(6)
+#define ADV7535_MAIN_CEC_ADDR         0xe1
+#define ADV7535_MAIN_POWER2           0xd6
+#define ADV7535_MAIN_HPD_OVERRIDE     BIT(6)
+#define ADV7535_CEC_OUTPUT            0x03
+#define ADV7535_CEC_OUTPUT_DISABLE    0x0b
+#define ADV7535_CEC_OUTPUT_ENABLE     0x89
+#define ADV7535_CEC_TIMING_GEN        0x27
+#define ADV7535_CEC_TIMING_GEN_RESET  0xcb
+#define ADV7535_CEC_TIMING_GEN_RUN    0x8b
+#define ADV7535_CEC_TEST_MODE         0x55
+#define ADV7535_CEC_DSI_RESET         0x26
+#define ADV7535_CEC_DSI_RESET_ASSERT  0x18
+#define ADV7535_CEC_DSI_RESET_RELEASE 0x38
+#define ADV7535_TIMING_MAX            0xfff
+
+struct adv7535_config {
+	struct i2c_dt_spec main;
+	struct i2c_dt_spec cec;
+	const struct device *mipi_dsi;
+	uint8_t data_lanes;
+	uint8_t pixel_format;
+	struct mipi_dsi_timings timings;
+};
+
+struct adv7535_reg {
+	bool cec;
+	uint8_t reg;
+	uint8_t value;
+};
+
+static const struct adv7535_reg adv7535_fixed_init[] = {
+	{false, 0x16, 0x20}, {false, 0x9a, 0xe0}, {false, 0xba, 0x70}, {false, 0xde, 0x82},
+	{false, 0xe4, 0x40}, {false, 0xe5, 0x80}, {true, 0x15, 0xd0},  {true, 0x17, 0xd0},
+	{true, 0x24, 0x20},  {true, 0x57, 0x11},  {true, 0x05, 0xc8},
+};
+
+static const struct adv7535_reg adv7535_video_init[] = {
+	{false, 0xaf, 0x16}, {false, 0x55, 0x10}, {false, 0x56, 0x28}, {false, 0x40, 0x80},
+	{false, 0x4c, 0x04}, {false, 0x49, 0x00}, {false, 0x4a, 0x80}, {true, 0xbe, 0x3d},
+};
+
+static int adv7535_write(const struct i2c_dt_spec *map, uint8_t reg, uint8_t value)
+{
+	int ret = i2c_reg_write_byte_dt(map, reg, value);
+
+	if (ret < 0) {
+		LOG_ERR("I2C 0x%02x reg 0x%02x write failed: %d", map->addr, reg, ret);
+	}
+
+	return ret;
+}
+
+static int adv7535_update(const struct i2c_dt_spec *map, uint8_t reg, uint8_t mask, uint8_t value)
+{
+	int ret = i2c_reg_update_byte_dt(map, reg, mask, value);
+
+	if (ret < 0) {
+		LOG_ERR("I2C 0x%02x reg 0x%02x update failed: %d", map->addr, reg, ret);
+	}
+
+	return ret;
+}
+
+static int adv7535_write_regs(const struct adv7535_config *cfg, const struct adv7535_reg *regs,
+			      size_t count)
+{
+	for (size_t i = 0; i < count; i++) {
+		const struct i2c_dt_spec *map = regs[i].cec ? &cfg->cec : &cfg->main;
+		int ret = adv7535_write(map, regs[i].reg, regs[i].value);
+
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int adv7535_write_timing(const struct i2c_dt_spec *cec, uint8_t reg, uint16_t value)
+{
+	uint16_t encoded = value << 4;
+	int ret;
+
+	ret = adv7535_write(cec, reg, encoded >> 8);
+	if (ret == 0) {
+		ret = adv7535_write(cec, reg + 1, encoded & 0xff);
+	}
+
+	return ret;
+}
+
+static void adv7535_disable(const struct adv7535_config *cfg)
+{
+	(void)adv7535_write(&cfg->cec, ADV7535_CEC_OUTPUT, ADV7535_CEC_OUTPUT_DISABLE);
+	(void)adv7535_update(&cfg->main, ADV7535_MAIN_POWER, ADV7535_MAIN_POWER_DOWN,
+			     ADV7535_MAIN_POWER_DOWN);
+}
+
+static int adv7535_program(const struct adv7535_config *cfg)
+{
+	const struct mipi_dsi_timings *t = &cfg->timings;
+	const struct {
+		uint8_t reg;
+		uint16_t value;
+	} timings[] = {
+		{0x28, t->hactive + t->hfp + t->hsync + t->hbp},
+		{0x2a, t->hsync},
+		{0x2c, t->hfp},
+		{0x2e, t->hbp},
+		{0x30, t->vactive + t->vfp + t->vsync + t->vbp},
+		{0x32, t->vsync},
+		{0x34, t->vfp},
+		{0x36, t->vbp},
+	};
+	int ret;
+
+	ret = adv7535_write(&cfg->main, ADV7535_MAIN_CEC_ADDR, cfg->cec.addr << 1);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_write(&cfg->cec, ADV7535_CEC_OUTPUT, ADV7535_CEC_OUTPUT_DISABLE);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_update(&cfg->main, ADV7535_MAIN_POWER, ADV7535_MAIN_POWER_DOWN, 0);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_update(&cfg->main, ADV7535_MAIN_POWER2, ADV7535_MAIN_HPD_OVERRIDE,
+			     ADV7535_MAIN_HPD_OVERRIDE);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_write_regs(cfg, adv7535_fixed_init, ARRAY_SIZE(adv7535_fixed_init));
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_write(&cfg->cec, 0x1c, cfg->data_lanes << 4);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_write_regs(cfg, adv7535_video_init, ARRAY_SIZE(adv7535_video_init));
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_write(&cfg->cec, ADV7535_CEC_DSI_RESET, ADV7535_CEC_DSI_RESET_ASSERT);
+	if (ret < 0) {
+		return ret;
+	}
+	k_msleep(200);
+	ret = adv7535_write(&cfg->cec, ADV7535_CEC_DSI_RESET, ADV7535_CEC_DSI_RESET_RELEASE);
+
+	if (ret < 0) {
+		return ret;
+	}
+	ret = adv7535_write(&cfg->cec, 0x16, 0x18);
+	if (ret < 0) {
+		return ret;
+	}
+	for (size_t i = 0; i < ARRAY_SIZE(timings); i++) {
+		ret = adv7535_write_timing(&cfg->cec, timings[i].reg, timings[i].value);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	ret = adv7535_write(&cfg->cec, ADV7535_CEC_TIMING_GEN, ADV7535_CEC_TIMING_GEN_RESET);
+	ret = ret ?: adv7535_write(&cfg->cec, ADV7535_CEC_TIMING_GEN, ADV7535_CEC_TIMING_GEN_RUN);
+	return ret
+		       ?: adv7535_write(&cfg->cec, ADV7535_CEC_TIMING_GEN,
+					ADV7535_CEC_TIMING_GEN_RESET);
+}
+
+static int adv7535_init(const struct device *dev)
+{
+	const struct adv7535_config *cfg = dev->config;
+	struct mipi_dsi_device mdev = {
+		.data_lanes = cfg->data_lanes,
+		.timings = cfg->timings,
+		.pixfmt = cfg->pixel_format,
+		.mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
+			      MIPI_DSI_MODE_VIDEO_HSE,
+	};
+	uint8_t id_msb;
+	uint8_t id_lsb;
+	uint16_t id;
+	int ret;
+
+	if (!i2c_is_ready_dt(&cfg->main) || !device_is_ready(cfg->mipi_dsi)) {
+		LOG_ERR("I2C bus or MIPI DSI host not ready");
+		return -ENODEV;
+	}
+
+	ret = adv7535_write(&cfg->main, ADV7535_MAIN_CEC_ADDR, cfg->cec.addr << 1);
+	ret = ret ?: i2c_reg_read_byte_dt(&cfg->cec, 0x00, &id_msb);
+	ret = ret ?: i2c_reg_read_byte_dt(&cfg->cec, 0x01, &id_lsb);
+	if (ret < 0) {
+		LOG_ERR("chip identification failed: %d", ret);
+		return ret;
+	}
+
+	id = ((uint16_t)id_msb << 8) | id_lsb;
+	if (id != 0x7533 && id != 0x7535) {
+		LOG_ERR("unexpected chip ID 0x%04x", id);
+		return -ENODEV;
+	}
+
+	ret = adv7535_program(cfg);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	ret = adv7535_write(&cfg->cec, ADV7535_CEC_OUTPUT, ADV7535_CEC_OUTPUT_ENABLE);
+	ret = ret ?: adv7535_write(&cfg->cec, ADV7535_CEC_TEST_MODE, 0x00);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	ret = mipi_dsi_attach(cfg->mipi_dsi, 0U, &mdev);
+	if (ret < 0) {
+		LOG_ERR("MIPI DSI attach failed: %d", ret);
+		goto fail;
+	}
+	LOG_INF("ADV753x ID 0x%04x, %ux%u RGB888, %u lanes", id, cfg->timings.hactive,
+		cfg->timings.vactive, cfg->data_lanes);
+	return 0;
+
+fail:
+	adv7535_disable(cfg);
+	return ret;
+}
+
+#define ADV7535_DEFINE(inst)                                                                       \
+	BUILD_ASSERT(DT_INST_PROP(inst, data_lanes) == 4, "ADV7535 requires 4 lanes");             \
+	BUILD_ASSERT(DT_INST_PROP(inst, pixel_format) == MIPI_DSI_PIXFMT_RGB888,                   \
+		     "ADV7535 requires RGB888");                                                   \
+	BUILD_ASSERT(DT_PROP(DT_PARENT(DT_INST_PHANDLE(inst, display_timing)), width) * 9U ==      \
+			     DT_PROP(DT_PARENT(DT_INST_PHANDLE(inst, display_timing)), height) *   \
+				     16U,                                                          \
+		     "ADV7535 requires a 16:9 active area");                                       \
+	BUILD_ASSERT(DT_INST_PROP(inst, adi_addr_cec) <= 0x7f,                                     \
+		     "ADV7535 CEC address must be seven-bit");                                     \
+	BUILD_ASSERT(DT_INST_PROP(inst, adi_addr_cec) != DT_INST_REG_ADDR(inst),                   \
+		     "ADV7535 main and CEC addresses must differ");                                \
+	BUILD_ASSERT(                                                                              \
+		DT_PROP(DT_PARENT(DT_INST_PHANDLE(inst, display_timing)), width) +                 \
+				DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing, hsync_len) + \
+				DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,              \
+						   hfront_porch) +                                 \
+				DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,              \
+						   hback_porch) <=                                 \
+			ADV7535_TIMING_MAX,                                                        \
+		"ADV7535 horizontal total exceeds 12 bits");                                       \
+	BUILD_ASSERT(                                                                              \
+		DT_PROP(DT_PARENT(DT_INST_PHANDLE(inst, display_timing)), height) +                \
+				DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing, vsync_len) + \
+				DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,              \
+						   vfront_porch) +                                 \
+				DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,              \
+						   vback_porch) <=                                 \
+			ADV7535_TIMING_MAX,                                                        \
+		"ADV7535 vertical total exceeds 12 bits");                                         \
+	static const struct adv7535_config adv7535_config_##inst = {                               \
+		.main = I2C_DT_SPEC_INST_GET(inst),                                                \
+		.cec = {.bus = DEVICE_DT_GET(DT_BUS(DT_DRV_INST(inst))),                           \
+			.addr = DT_INST_PROP(inst, adi_addr_cec)},                                 \
+		.mipi_dsi = DEVICE_DT_GET(DT_INST_PHANDLE(inst, mipi_dsi)),                        \
+		.data_lanes = DT_INST_PROP(inst, data_lanes),                                      \
+		.pixel_format = DT_INST_PROP(inst, pixel_format),                                  \
+		.timings =                                                                         \
+			{                                                                          \
+				.hactive = DT_PROP(                                                \
+					DT_PARENT(DT_INST_PHANDLE(inst, display_timing)), width),  \
+				.hfp = DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,       \
+							  hfront_porch),                           \
+				.hbp = DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,       \
+							  hback_porch),                            \
+				.hsync = DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,     \
+							    hsync_len),                            \
+				.vactive = DT_PROP(                                                \
+					DT_PARENT(DT_INST_PHANDLE(inst, display_timing)), height), \
+				.vfp = DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,       \
+							  vfront_porch),                           \
+				.vbp = DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,       \
+							  vback_porch),                            \
+				.vsync = DT_PROP_BY_PHANDLE(DT_DRV_INST(inst), display_timing,     \
+							    vsync_len),                            \
+			},                                                                         \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, adv7535_init, NULL, NULL, &adv7535_config_##inst, POST_KERNEL, \
+			      CONFIG_ADV7535_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(ADV7535_DEFINE)

--- a/dts/bindings/display/adi,adv7535.yaml
+++ b/dts/bindings/display/adi,adv7535.yaml
@@ -1,0 +1,60 @@
+# Copyright (C) 2026, Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+title: Analog Devices ADV7535 MIPI DSI to HDMI bridge
+
+description: |
+  The ADV7535 is an I2C-controlled bridge that converts MIPI DSI video to HDMI.
+  Its CEC/DSI register map uses a secondary I2C address, and the bridge attaches
+  to a MIPI DSI host selected by phandle.
+
+compatible: "adi,adv7535"
+
+include: i2c-device.yaml
+
+properties:
+  adi,addr-cec:
+    type: int
+    required: true
+    description: Seven-bit address of the CEC/DSI register map.
+
+  mipi-dsi:
+    type: phandle
+    required: true
+    description: MIPI DSI host controller connected to the bridge.
+
+  data-lanes:
+    type: int
+    required: true
+    const: 4
+    description: Number of MIPI DSI data lanes.
+
+  pixel-format:
+    type: int
+    required: true
+    const: 0
+    description: Pixel format from dt-bindings/mipi_dsi/mipi_dsi.h.
+
+  display-timing:
+    type: phandle
+    required: true
+    description: Timing node owned by the upstream display controller.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
+
+    i2c {
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      hdmi-bridge@3d {
+        compatible = "adi,adv7535";
+        reg = <0x3d>;
+        adi,addr-cec = <0x3b>;
+        mipi-dsi = <&mipi_dsi>;
+        data-lanes = <4>;
+        pixel-format = <MIPI_DSI_PIXFMT_RGB888>;
+        display-timing = <&hdmi_timing>;
+      };
+    };

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -12,6 +12,7 @@
 
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+#include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
 #include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
@@ -553,7 +554,7 @@
 			};
 		};
 
-		test_mipi_dsi {
+		test_mipi_dsi: test_mipi_dsi {
 			compatible = "vnd,mipi-dsi";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -826,6 +827,16 @@
 			status = "okay";
 			clock-frequency = <100000>;
 
+			test_adv7535: hdmi-bridge@3d {
+				compatible = "adi,adv7535";
+				reg = <0x3d>;
+				adi,addr-cec = <0x3b>;
+				mipi-dsi = <&test_mipi_dsi>;
+				data-lanes = <4>;
+				pixel-format = <MIPI_DSI_PIXFMT_RGB888>;
+				display-timing = <&test_adv7535_timing>;
+			};
+
 			test_ist3931: ist3931@0 {
 				reg = <0x0>;
 				width = <64>;
@@ -940,6 +951,26 @@
 				multiplex-ratio = <0x3f>;
 				phase-length = <0x22>;
 				vcomh-voltage = <0x2>;
+			};
+		};
+
+		test_adv7535_timing_source {
+			compatible = "zephyr,dummy-dc";
+			width = <1920>;
+			height = <1080>;
+
+			test_adv7535_timing: display-timings {
+				compatible = "zephyr,panel-timing";
+				hsync-active = <0>;
+				vsync-active = <0>;
+				de-active = <0>;
+				pixelclk-active = <0>;
+				hsync-len = <44>;
+				hfront-porch = <88>;
+				hback-porch = <148>;
+				vsync-len = <5>;
+				vfront-porch = <4>;
+				vback-porch = <36>;
 			};
 		};
 	};


### PR DESCRIPTION
## Overview

Add support for the Analog Devices ADV7535 MIPI DSI-to-HDMI bridge.

The driver configures the bridge through I2C and attaches it to a
MIPI DSI host using Zephyr's generic MIPI DSI API.

The initial implementation supports:
- 4 MIPI DSI data lanes
- RGB888
- 16:9 active video modes
- devicetree-provided display timings
- ADV7533 and ADV7535 device IDs

Runtime mode switching, audio, CEC services, EDID, HDCP, and power
management are not included.

## Devicetree

Add the `adi,adv7535` binding with properties for:
- the secondary CEC/DSI I2C register-map address
- the MIPI DSI host
- lane count
- pixel format
- display timing source

## Testing
- Built `tests/drivers/build_all/display` on `native_sim`
- Verified with `checkpatch.pl`
- Video attached to this PR

## Hardware validation
Tested on `imx8mp_evk/mimx8ml8/m7/ddr` with downstream MIPI DSIM,
LCDIFv3, clock, power-domain, and board-overlay support. Here is a
reference to the PRs made for the whole imx8mp evk display pipeline:
- #111446
- #111868
- NXP HAL LCDIFv3 compatibility patch  [754](https://github.com/zephyrproject-rtos/hal_nxp/pull/754)


https://github.com/user-attachments/assets/11867bba-5104-4de5-a3b3-8bc26890c2a0