### PR TITLE
drivers: i2c: dw: guard need_setup write with its Kconfig

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1027,10 +1027,12 @@ error:
 	k_sem_give(&dw->bus_sem);
 
 	pm_device_runtime_put(dev);
+#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
 	if (ret != 0) {
 		/* Failed/aborted transaction is no longer active, require setup */
 		dw->need_setup = true;
 	}
+#endif
 
 	return ret;
 }


### PR DESCRIPTION
The need_setup member of struct i2c_dw_dev_config only exists when
CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS is enabled, and every other
access to it in the driver is wrapped in a matching #if. The write
added in i2c_dw_transfer() to require a re-setup after a failed or
aborted transaction was left unguarded, so the driver fails to build
whenever that option is off:

  drivers/i2c/i2c_dw.c:1032:19: error: 'struct i2c_dw_dev_config'
  has no member named 'need_setup'

Wrap the write in the same #if used by the rest of the driver.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
