### PR TITLE
Ztest: Benchmarks: adapt and improve for new benchmarks

### DIFF
--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -92,6 +92,58 @@ functions only once allowing the test function to run hot within a dedicated tim
 This will give a more realistic measurements as it includes the overhead of the system as it would
 be in a real-world scenario, such as interrupts, context switches, and other background tasks.
 
+Manual Benchmarks
+=================
+
+Standard and timed benchmarks are timed by the framework itself, which takes both timestamps in
+thread context around each invocation of the benchmark body. Some measurements cannot be expressed
+that way because their endpoints are captured in different execution contexts: for example the
+latency from raising an interrupt to the first instruction of its ISR, or from the end of an ISR to
+a woken thread running.
+
+Manual benchmarks keep the loop, the setup and the teardown in the framework and hand the body
+only the choice of what is measured, by bracketing it with :c:func:`ztest_benchmark_start` and
+:c:func:`ztest_benchmark_end`. The framework computes and reports the same statistics as for
+standard benchmarks.
+
+.. code-block:: c
+
+   ZTEST_BENCHMARK_MANUAL(<suite name>, <benchmark name>, <samples>, <setup_fn>, <teardown_fn>)
+   {
+         prepare();
+
+         ztest_benchmark_start();
+         operation_under_test();
+         ztest_benchmark_end();
+   }
+
+When the span does not begin and end in the same execution context, the endpoint captured
+elsewhere is handed over instead, with :c:func:`ztest_benchmark_start_at` or
+:c:func:`ztest_benchmark_end_at`. An ISR captures ``timing_counter_get()`` into a variable and the
+body passes it in once it runs:
+
+.. code-block:: c
+
+   static volatile timing_t isr_timestamp;
+
+   static void my_isr(const void *arg)
+   {
+         isr_timestamp = timing_counter_get();
+   }
+
+   ZTEST_BENCHMARK_MANUAL(<suite name>, isr_exit_latency, 1000, NULL, NULL)
+   {
+         trigger_the_interrupt();
+
+         ztest_benchmark_start_at(isr_timestamp);
+         ztest_benchmark_end();
+   }
+
+The framework applies the same control-measurement noise correction as for standard benchmarks
+when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
+and leave the recording to the body. An iteration whose body records no span contributes no
+sample.
+
 Understanding Results
 *********************
 

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -180,6 +180,36 @@ Statistical Metrics
 * **Min/Max**: The minimum and maximum cycle counts observed, along with which
   sample they occurred on.
 
+Latency percentiles
+"""""""""""""""""""
+
+The mean and the standard error describe how precisely the average was
+estimated. That is the right question for throughput, but not for latency: a
+real-time system is characterised by how bad an individual operation can be,
+and that lives in the tail of the distribution rather than near the mean.
+
+Enable :kconfig:option:`CONFIG_ZTEST_BENCHMARK_PERCENTILES` to retain the
+individual samples and report ``min``, ``p50``, ``p90``, ``p99``, ``p99.9``,
+``p99.99`` and ``max`` alongside the usual statistics. In CSV mode each
+sampled and manual benchmark emits an additional ``P`` row; see
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV` for the columns.
+
+The difference this makes is clearest on a distribution with a tail. Measuring
+interrupt entry latency on a loaded system gives a mean of 1264 cycles with a
+standard error of 34, which describes no interrupt that actually occurred: the
+percentiles show 1216 cycles all the way out to p99, and 25184 beyond it.
+
+A percentile has to be resolvable by the number of samples taken. p99 needs at
+least 100 samples, p99.9 at least 1000 and p99.99 at least 10000; with fewer,
+the reported value degenerates to the maximum. Samples are retained in a
+buffer of :kconfig:option:`CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES` entries of
+8 bytes each, which has to be at least as large as the sample count of the
+largest benchmark. The retained samples are the first ones taken rather than a
+sample of the whole run, so percentiles over a truncated prefix would miss
+whatever happened after the buffer filled, which is where the tail tends to
+live. A benchmark that overruns the buffer therefore reports no percentiles at
+all, and says how many samples did not fit.
+
 Plainly speaking, lower values are better for all metrics.
 Lower mean, min, and max values indicates better raw performance.
 Lower standard deviation and standard error values indicate more consistent and

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -17,7 +17,9 @@ providing:
 * **Statistical Analysis**: Calculations of Mean, Standard Deviation, Standard
   Error, and Min/Max values.
 * **Overhead Compensation**: Inclusion of a control test to account for the
-  benchmarking frameworks own execution time.
+  benchmarking frameworks own execution time. The control is subtracted from
+  every reported statistic identically, so the corrected values are real
+  numbers that generally do not coincide with any single measurement.
 
 Configuration
 *************
@@ -143,6 +145,13 @@ The framework applies the same control-measurement noise correction as for stand
 when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
 and leave the recording to the body. An iteration whose body records no span contributes no
 sample.
+
+A benchmark that wants a warmup phase should run it through the full measurement loop, recording
+included, and then call :c:func:`ztest_benchmark_discard_samples` to throw the results away.
+Skipping the recording during warmup instead leaves the first measured iteration as the only one
+not preceded by the bookkeeping that :c:func:`ztest_benchmark_record_sample` performs, which is
+enough to make it measurably faster than every iteration after it and to leave the reported
+minimum describing a state the benchmark is never in again.
 
 Understanding Results
 *********************

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -173,6 +173,16 @@ Standard Benchmarking Results
 Statistical Metrics
 """""""""""""""""""
 
+.. note::
+
+   :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIERS` replaces the standard error line with the
+   number of samples slower than the median, and that number as a percentage. A latency
+   distribution is usually a baseline plus a handful of disturbed runs rather than samples of
+   one stochastic population, and a standard error over the two suggests an average that no
+   single execution ever produced -- ten thousand runs of 760 cycles and one of 1240 give a
+   standard error of 0.048, which reads as precision and is not, where ``1 / 10000 (0.010%)``
+   says what happened. Only the report changes; the standard error keeps its CSV column.
+
 * **Mean (u)**: The average number of cycles taken per sample. It provides a
   central value representing the expected cost of execution.
 
@@ -261,6 +271,7 @@ Timed Benchmarking Results
 
 Statistical Metrics
 """""""""""""""""""
+
 * **Total Time**: The total time taken for all samples of the benchmark, including overhead.
 
 * **Work Time**: The total time taken for the code under test, excluding the overhead of the

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -176,7 +176,10 @@ Statistical Metrics
 .. note::
 
    :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIERS` replaces the standard error line with the
-   number of samples slower than the median, and that number as a percentage. A latency
+   number of samples that exceed the median by more than
+   :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV` allows, and that number as a
+   percentage. The margin matters because the counter resolution spreads the baseline over a
+   few counts; without it about half of any distribution would be reported. A latency
    distribution is usually a baseline plus a handful of disturbed runs rather than samples of
    one stochastic population, and a standard error over the two suggests an average that no
    single execution ever produced -- ten thousand runs of 760 cycles and one of 1240 give a

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -119,39 +119,38 @@ standard benchmarks.
          ztest_benchmark_end();
    }
 
-When the span does not begin and end in the same execution context, the endpoint captured
-elsewhere is handed over instead, with :c:func:`ztest_benchmark_start_at` or
-:c:func:`ztest_benchmark_end_at`. An ISR captures ``timing_counter_get()`` into a variable and the
-body passes it in once it runs:
+Both hooks only take a timestamp, so either may be called from an ISR and the span need not begin
+and end in the same execution context. For the latency from an interrupt to the thread it wakes,
+the ISR marks the start and the thread ends the span:
 
 .. code-block:: c
 
-   static volatile timing_t isr_timestamp;
-
    static void my_isr(const void *arg)
    {
-         isr_timestamp = timing_counter_get();
+         ztest_benchmark_start();
    }
 
    ZTEST_BENCHMARK_MANUAL(<suite name>, isr_exit_latency, 1000, NULL, NULL)
    {
          trigger_the_interrupt();
 
-         ztest_benchmark_start_at(isr_timestamp);
          ztest_benchmark_end();
    }
 
-The framework applies the same control-measurement noise correction as for standard benchmarks
-when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
-and leave the recording to the body. An iteration whose body records no span contributes no
-sample.
+The sample itself is computed once the body has returned, which is what keeps the statistics out
+of interrupt context: updating them uses floating point, which is not allowed in an ISR on every
+architecture. An iteration whose body marks no span contributes no sample.
 
-A benchmark that wants a warmup phase should run it through the full measurement loop, recording
-included, and then call :c:func:`ztest_benchmark_discard_samples` to throw the results away.
-Skipping the recording during warmup instead leaves the first measured iteration as the only one
-not preceded by the bookkeeping that :c:func:`ztest_benchmark_record_sample` performs, which is
-enough to make it measurably faster than every iteration after it and to leave the reported
-minimum describing a state the benchmark is never in again.
+Manual benchmarks are corrected against a control of their own rather than the one the sampled
+benchmarks use. A manual span costs the two timestamps that bracket it and nothing else, where the
+sampled control also measures the indirect call to the benchmark body, which is not part of a
+manual span. A span whose ends are captured in two different contexts pays neither exactly, and no
+control can express that.
+
+The warmup applies here exactly as it does to a sampled benchmark: the framework runs the body
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` extra times and discards those spans, keeping the
+first as the cold cost. The body never has to distinguish between the two phases, and every
+measured iteration is preceded by exactly the same work as the one before it.
 
 Understanding Results
 *********************
@@ -188,6 +187,30 @@ Statistical Metrics
 
 * **Min/Max**: The minimum and maximum cycle counts observed, along with which
   sample they occurred on.
+
+Warmup and the cold cost
+""""""""""""""""""""""""
+
+A benchmark is defined as three phases: the setup, then
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` iterations that are executed but not recorded,
+then the measured samples. The warmup applies to every benchmark in the image.
+
+The very first execution is always unrecorded, whatever the warmup is set to. It runs with cold
+caches, branch predictors and TLBs and can be an order of magnitude slower than the steady state,
+and rather than discard that information the framework reports it on its own as the **cold cost**.
+The two answer different questions — what an operation costs the first time it is reached, and
+what it costs thereafter — and an application that runs a path once at startup cares about the
+first.
+
+Keeping it out of the distribution is what makes the distribution mean anything at the tail. A
+benchmark that reported the cold start in both places would have it decide the far percentiles:
+at ten thousand samples the nearest-rank p99.99 is the second largest value, so one cold start
+would be read as the steady-state tail.
+
+Raising the warmup beyond that costs accuracy on a micro benchmark whose whole cost is comparable
+to a cache miss, and with a large enough sample count the early iterations have no measurable
+effect on the mean, so the default of zero is the right starting point. Raise it when the
+benchmark is large enough for cache state to matter and the steady state is what you are after.
 
 Latency percentiles
 """""""""""""""""""

--- a/subsys/testsuite/ztest/benchmark/CMakeLists.txt
+++ b/subsys/testsuite/ztest/benchmark/CMakeLists.txt
@@ -8,5 +8,6 @@ zephyr_library_sources_ifdef(CONFIG_ZTEST_BENCHMARK
 
 zephyr_linker_sources(DATA_SECTIONS benchmark.ld)
 zephyr_iterable_section(NAME ztest_benchmark GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
+zephyr_iterable_section(NAME ztest_benchmark_manual GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
 zephyr_iterable_section(NAME ztest_benchmark_timed GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
 zephyr_iterable_section(NAME ztest_benchmark_suite GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -13,6 +13,41 @@ config ZTEST_BENCHMARK
 
 if ZTEST_BENCHMARK
 
+config ZTEST_BENCHMARK_PERCENTILES
+	bool "Report latency percentiles"
+	help
+	  Retain the individual samples of each benchmark and report
+	  min, p50, p90, p99, p99.9, p99.99 and max alongside the usual
+	  statistics.
+
+	  The mean and the standard error describe how precisely the
+	  average was estimated, which is the right question for
+	  throughput but not for latency: a real-time system is
+	  characterised by how bad an individual operation can be, and
+	  that lives in the tail of the distribution.
+
+	  A percentile needs enough samples to be resolved at all. p99
+	  needs at least 100, p99.9 at least 1000 and p99.99 at least
+	  10000; below that the reported value degenerates to the
+	  maximum. Retaining samples costs 8 bytes each, so the buffer
+	  has to be sized for the number of iterations the benchmarks
+	  run.
+
+config ZTEST_BENCHMARK_MAX_SAMPLES
+	int "Number of samples retained for percentiles"
+	depends on ZTEST_BENCHMARK_PERCENTILES
+	default 1024
+	help
+	  Size of the sample buffer, in samples of 8 bytes each. Only one
+	  benchmark runs at a time, so a single buffer of this size is
+	  allocated for all of them. It has to be at least as large as
+	  the sample count of the largest benchmark: the retained samples
+	  are the first ones taken rather than a sample of the whole run,
+	  so percentiles over a truncated prefix would miss whatever
+	  happened after the buffer filled, which is where the tail tends
+	  to live. A benchmark that overruns the buffer reports no
+	  percentiles at all and says how many samples did not fit.
+
 choice ZTEST_BENCHMARK_OUTPUT_FORMAT
 	prompt "Ztest benchmark output format"
 	default ZTEST_BENCHMARK_OUTPUT_VERBOSE
@@ -71,6 +106,17 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 
 	  If measured overhead exceeds the total time, the row contains INCONCLUSIVE instead of
 	  numeric results (e.g. "T, my_suite, my_benchmark, INCONCLUSIVE").
+
+	  With CONFIG_ZTEST_BENCHMARK_PERCENTILES, every sampled and manual benchmark emits an
+	  additional row of the form:
+
+	    P, suite, name, samples, min, p50, p90, p99, p999, p9999, max
+
+	  - samples: number of retained samples the percentiles were taken over
+	  - min / max: extreme cycle values
+	  - p50 ... p9999: nearest-rank percentiles, p9999 being the 99.99th
+
+	  All values are noise-corrected against the control measurement.
 endchoice
 
 endif

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -51,6 +51,11 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 	  - min / max: extreme cycle values
 	  - min_sample / max_sample: iteration at which each extreme occurred
 
+	  Manually sampled benchmarks (created with ZTEST_BENCHMARK_MANUAL()) emit "M" rows with
+	  the same column layout as "S" rows, where samples is the number of iterations that
+	  recorded a span. A manual benchmark that records no samples emits
+	  "M, suite, name, INCONCLUSIVE" instead.
+
 	  Timed benchmarks (created with ZTEST_BENCHMARK_TIMED() or
 	  ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN()) emit rows of the form:
 

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -49,8 +49,8 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  characterised by how bad an individual operation can be, and
 	  that lives in the tail of the distribution.
 
-	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples slower
-	  than the median.
+	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples that sit
+	  clear of the median.
 
 	  A percentile needs enough samples to be resolved at all. p99
 	  needs at least 100, p99.9 at least 1000 and p99.99 at least
@@ -64,8 +64,9 @@ config ZTEST_BENCHMARK_OUTLIERS
 	depends on ZTEST_BENCHMARK_PERCENTILES
 	help
 	  Replace the standard error line of the report with the number
-	  of samples slower than the median, and that number as a
-	  percentage of the samples taken.
+	  of samples that sit clear of the median, and that number as a
+	  percentage of the samples taken. How far clear is set by
+	  CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV.
 
 	  The standard error describes how precisely the mean of one
 	  stochastic population has been estimated. A latency
@@ -78,6 +79,29 @@ config ZTEST_BENCHMARK_OUTLIERS
 
 	  Only the human-readable report changes. The standard error
 	  keeps its column in the CSV output.
+
+config ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV
+	int "Outlier margin above the median, as a divisor"
+	depends on ZTEST_BENCHMARK_OUTLIERS
+	default 16
+	range 1 1000
+	help
+	  How far above the median a sample has to sit before it counts as
+	  an outlier, expressed as a divisor of the median: the default of
+	  16 sets the margin at a sixteenth of the median, so a baseline of
+	  400 counts a sample from 426 upwards. The margin is never less
+	  than two counts, so that a distribution spanning only adjacent
+	  counts of a coarse timer never registers.
+
+	  Without a margin every sample above the median counts, and the
+	  baseline of a benchmark is not one exact value: the resolution of
+	  the timing counter spreads it over a few counts, and where that
+	  counter is coarse relative to the operation being measured the
+	  whole distribution can span as little as two values. Half the
+	  samples then land above the median and are reported as outliers
+	  although nothing disturbed them. Lower this to count smaller
+	  disturbances, raise it on a platform whose baseline is noisy by
+	  nature.
 
 config ZTEST_BENCHMARK_MAX_SAMPLES
 	int "Number of samples retained for percentiles"

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -49,12 +49,35 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  characterised by how bad an individual operation can be, and
 	  that lives in the tail of the distribution.
 
+	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples slower
+	  than the median.
+
 	  A percentile needs enough samples to be resolved at all. p99
 	  needs at least 100, p99.9 at least 1000 and p99.99 at least
 	  10000; below that the reported value degenerates to the
 	  maximum. Retaining samples costs 8 bytes each, so the buffer
 	  has to be sized for the number of iterations the benchmarks
 	  run.
+
+config ZTEST_BENCHMARK_OUTLIERS
+	bool "Report the outlier count in place of the standard error"
+	depends on ZTEST_BENCHMARK_PERCENTILES
+	help
+	  Replace the standard error line of the report with the number
+	  of samples slower than the median, and that number as a
+	  percentage of the samples taken.
+
+	  The standard error describes how precisely the mean of one
+	  stochastic population has been estimated. A latency
+	  distribution is usually not that: it is a baseline the
+	  operation hits on almost every run plus a handful of runs that
+	  something interrupted. Ten thousand samples of 760 cycles and
+	  one of 1240 give a standard error of 0.048, which reads as
+	  precision about an average no execution ever produced, where
+	  "1 / 10000 (0.010%)" says what happened.
+
+	  Only the human-readable report changes. The standard error
+	  keeps its column in the CSV output.
 
 config ZTEST_BENCHMARK_MAX_SAMPLES
 	int "Number of samples retained for percentiles"

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -13,6 +13,29 @@ config ZTEST_BENCHMARK
 
 if ZTEST_BENCHMARK
 
+config ZTEST_BENCHMARK_WARMUP
+	int "Iterations run before sampling starts"
+	default 0
+	help
+	  Iterations every benchmark executes, in full, before it begins
+	  recording. They are not part of the reported distribution.
+
+	  The very first execution is always one of them, whatever this is
+	  set to: it runs with cold caches, branch predictors and TLBs and
+	  can be an order of magnitude slower than the steady state, and it
+	  is reported on its own as the cold cost rather than mixed into
+	  the samples. A benchmark that reported it in both places would
+	  have a single cold start decide its far percentiles, since at ten
+	  thousand samples the nearest-rank p99.99 is the second largest
+	  value.
+
+	  The default of zero therefore discards nothing beyond that one
+	  execution, which is not discarded so much as reported elsewhere.
+	  Further iterations cost accuracy on micro benchmarks whose whole
+	  cost is comparable to a cache miss, so raise this only when the
+	  steady state is what you are after and the benchmark is large
+	  enough for the cache state to matter.
+
 config ZTEST_BENCHMARK_PERCENTILES
 	bool "Report latency percentiles"
 	help
@@ -85,6 +108,14 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 	  - std_error: standard error of the mean
 	  - min / max: extreme cycle values
 	  - min_sample / max_sample: iteration at which each extreme occurred
+
+	  Every benchmark that ran at least one iteration also emits a "C" row carrying its cold
+	  cost, the duration of its very first execution, which is excluded from the distribution:
+
+	    C, suite, name, warmup, cold
+
+	  - warmup: iterations executed before sampling started
+	  - cold: cycles taken by the first execution, noise-corrected
 
 	  Manually sampled benchmarks (created with ZTEST_BENCHMARK_MANUAL()) emit "M" rows with
 	  the same column layout as "S" rows, where samples is the number of iterations that

--- a/subsys/testsuite/ztest/benchmark/benchmark.ld
+++ b/subsys/testsuite/ztest/benchmark/benchmark.ld
@@ -6,5 +6,6 @@
 #include <zephyr/linker/iterable_sections.h>
 
 ITERABLE_SECTION_RAM(ztest_benchmark, Z_LINK_ITERABLE_SUBALIGN)
+ITERABLE_SECTION_RAM(ztest_benchmark_manual, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_RAM(ztest_benchmark_timed, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_RAM(ztest_benchmark_suite, Z_LINK_ITERABLE_SUBALIGN)

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -44,6 +44,10 @@ static void printk_line(const char *fn, char sep_char)
  * The correction is a real number, so the corrected values are real
  * numbers too, and generally do not coincide with any single
  * measurement.
+ *
+ * A negative result is not clamped: it means the operation costs less
+ * than the control loop bracketing it, so the counter is too coarse to
+ * measure it. Clamping would hide that behind a plausible number.
  */
 static double noise_correction(double value, double ctrl)
 {
@@ -135,20 +139,33 @@ static uint64_t percentile(uint32_t hundredths)
 
 #if defined(CONFIG_ZTEST_BENCHMARK_OUTLIERS) && defined(CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE)
 /*
- * Samples slower than the median.
+ * Samples disturbed enough to sit clear of the baseline, which for a
+ * kernel latency distribution is the median.
  *
- * For a kernel latency distribution the median is the baseline: the
- * operation costs the same on almost every run, and what matters is how
- * many runs were disturbed and by how much. Counting them says that
- * directly, where a standard error would only describe how precisely an
- * average of two different populations had been estimated.
+ * Merely exceeding the median is not enough: the counter resolution
+ * spreads the baseline over a few counts, so that would report about
+ * half the samples as outliers. Require a margin instead, relative so
+ * it holds across platforms, floored below for quantized distributions.
  */
 static size_t percentiles_outliers(void)
 {
 	uint64_t median = percentile(5000);
+	uint64_t margin = median / CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV;
+	uint64_t threshold;
 	size_t count = 0;
 
-	while ((count < retained_count) && (retained[retained_count - 1 - count] > median)) {
+	/*
+	 * A distribution spanning a couple of counts is at the counter
+	 * resolution, not above it. One count is not enough to exclude
+	 * it: the neighbouring count is exactly one away.
+	 */
+	if (margin < 2U) {
+		margin = 2U;
+	}
+
+	threshold = median + margin;
+
+	while ((count < retained_count) && (retained[retained_count - 1 - count] > threshold)) {
 		count++;
 	}
 

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -32,15 +32,45 @@ static void printk_line(const char *fn, char sep_char)
 }
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
+/*
+ * Subtract the control measurement from a reported statistic.
+ *
+ * Every statistic has to be corrected by the same amount, or they stop
+ * describing one set of samples: truncating the control to an integer
+ * for the discrete statistics, as this used to do, left a benchmark
+ * whose samples were all identical reporting a mean below its own
+ * minimum whenever the control was under one cycle.
+ *
+ * The correction is a real number, so the corrected values are real
+ * numbers too, and generally do not coincide with any single
+ * measurement.
+ */
 static double noise_correction(double value, double ctrl)
 {
 	return value - ctrl;
 }
 
-static int64_t discrete_noise_correction(uint64_t value, double ctrl)
+/*
+ * Render a corrected extreme as a whole number of cycles.
+ *
+ * The extremes are single measurements and a cycle is a discrete thing,
+ * so printing them with a fraction reads oddly. The correction is still
+ * a real number, so rounding has to be directional: the minimum rounds
+ * down and the maximum rounds up, which keeps each of them outside the
+ * statistics computed from the same samples instead of letting a
+ * rounded extreme cross the mean.
+ */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+static int64_t noise_corrected_floor(uint64_t value, double ctrl)
 {
-	return (int64_t)value - (int64_t)trunc(ctrl);
+	return (int64_t)floor(noise_correction((double)value, ctrl));
 }
+
+static int64_t noise_corrected_ceil(uint64_t value, double ctrl)
+{
+	return (int64_t)ceil(noise_correction((double)value, ctrl));
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
 #ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
 /*
@@ -130,22 +160,22 @@ static void percentiles_report(const char *suite_name, const char *bench_name,
 	percentiles_sort();
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("P,%s,%s,%zu,%lld,%lld,%lld,%lld,%lld,%lld,%lld\n",
+	printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
 		suite_name, bench_name, retained_count,
-		discrete_noise_correction(retained[0], ctrl),
-		discrete_noise_correction(percentile(5000), ctrl),
-		discrete_noise_correction(percentile(9000), ctrl),
-		discrete_noise_correction(percentile(9900), ctrl),
-		discrete_noise_correction(percentile(9990), ctrl),
-		discrete_noise_correction(percentile(9999), ctrl),
-		discrete_noise_correction(retained[retained_count - 1], ctrl));
+		noise_correction((double)retained[0], ctrl),
+		noise_correction((double)percentile(5000), ctrl),
+		noise_correction((double)percentile(9000), ctrl),
+		noise_correction((double)percentile(9900), ctrl),
+		noise_correction((double)percentile(9990), ctrl),
+		noise_correction((double)percentile(9999), ctrl),
+		noise_correction((double)retained[retained_count - 1], ctrl));
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk("\tp50: %lld\n", discrete_noise_correction(percentile(5000), ctrl));
-	printk("\tp90: %lld\n", discrete_noise_correction(percentile(9000), ctrl));
-	printk("\tp99: %lld\n", discrete_noise_correction(percentile(9900), ctrl));
-	printk("\tp99.9: %lld\n", discrete_noise_correction(percentile(9990), ctrl));
-	printk("\tp99.99: %lld\n", discrete_noise_correction(percentile(9999), ctrl));
+	printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
+	printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
+	printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
+	printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
+	printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 }
 #else
@@ -194,25 +224,25 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 	}
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("%c,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
+	printk("%c,%s,%s,%lld,%.3f,%.3f,%.3f,%.3f,%.3f,%lld,%.3f,%lld\n",
 		record_type, suite_name, bench_name,
 		stats->samples,
-		discrete_noise_correction(stats->total, ctrl * stats->samples),
+		noise_correction((double)stats->total, ctrl * (double)stats->samples),
 		noise_correction(stats->mean, ctrl), stddev, std_error,
-		discrete_noise_correction(stats->min.value, ctrl), stats->min.sample,
-		discrete_noise_correction(stats->max.value, ctrl), stats->max.sample);
+		noise_correction((double)stats->min.value, ctrl), stats->min.sample,
+		noise_correction((double)stats->max.value, ctrl), stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
 	printk_line(bench_name, '=');
-	printk("\tSample size:%lld, total cycles: %lld\n", stats->samples,
-			discrete_noise_correction(stats->total, ctrl * stats->samples));
+	printk("\tSample size:%lld, total cycles: %.3f\n", stats->samples,
+			noise_correction((double)stats->total, ctrl * (double)stats->samples));
 
 	printk("\tMean(u): %.3f\n", noise_correction(stats->mean, ctrl));
 	printk("\tStandard deviation(s): %.3f\n", stddev);
 	printk("\tStandard Error(SE): %.3f\n", std_error);
-	printk("\tMin: %lld (run #%llu)\n", discrete_noise_correction(stats->min.value, ctrl),
+	printk("\tMin: %lld (run #%llu)\n", noise_corrected_floor(stats->min.value, ctrl),
 		stats->min.sample);
-	printk("\tMax: %lld (run #%llu)\n", discrete_noise_correction(stats->max.value, ctrl),
+	printk("\tMax: %lld (run #%llu)\n", noise_corrected_ceil(stats->max.value, ctrl),
 		stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
@@ -348,6 +378,17 @@ static bool manual_run_once(struct ztest_benchmark_manual *benchmark, uint64_t *
 	}
 
 	return measured;
+}
+
+void ztest_benchmark_discard_samples(void)
+{
+	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
+
+	if (manual_active_stats != NULL) {
+		memset(manual_active_stats, 0, sizeof(*manual_active_stats));
+		manual_active_stats->min.value = UINT64_MAX;
+		percentiles_reset();
+	}
 }
 
 static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -42,6 +42,131 @@ static int64_t discrete_noise_correction(uint64_t value, double ctrl)
 	return (int64_t)value - (int64_t)trunc(ctrl);
 }
 
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+/*
+ * Retained samples, for the percentile report. Only one benchmark runs
+ * at a time, so a single buffer serves all of them.
+ */
+static uint64_t retained[CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES];
+static size_t retained_count;
+static size_t dropped_count;
+
+static void percentiles_reset(void)
+{
+	retained_count = 0;
+	dropped_count = 0;
+}
+
+static void percentiles_record(uint64_t cycles)
+{
+	if (retained_count < ARRAY_SIZE(retained)) {
+		retained[retained_count++] = cycles;
+	} else {
+		dropped_count++;
+	}
+}
+
+static void percentiles_sort(void)
+{
+	/* Shell sort: no allocation, no recursion, good enough here */
+	for (size_t gap = retained_count / 2; gap > 0; gap /= 2) {
+		for (size_t i = gap; i < retained_count; i++) {
+			uint64_t value = retained[i];
+			size_t j = i;
+
+			while ((j >= gap) && (retained[j - gap] > value)) {
+				retained[j] = retained[j - gap];
+				j -= gap;
+			}
+			retained[j] = value;
+		}
+	}
+}
+
+/*
+ * Nearest-rank percentile, with the percentile given in hundredths of a
+ * percent so that 99.99 can be expressed: 5000 is the median, 9999 is
+ * the 99.99th percentile.
+ */
+static uint64_t percentile(uint32_t hundredths)
+{
+	uint64_t rank = ((uint64_t)hundredths * retained_count + 9999U) / 10000U;
+
+	if (rank == 0U) {
+		rank = 1U;
+	}
+
+	if (rank > retained_count) {
+		rank = retained_count;
+	}
+
+	return retained[rank - 1U];
+}
+
+static void percentiles_report(const char *suite_name, const char *bench_name,
+			       struct ztest_benchmark_stats *ctrl_stats)
+{
+	double ctrl = (double)ctrl_stats->mean;
+
+	if (retained_count == 0) {
+		return;
+	}
+
+	/*
+	 * The retained samples are the first ones taken, not a sample of
+	 * the whole run, so percentiles over them are not percentiles of
+	 * the distribution: whatever happened after the buffer filled is
+	 * missing entirely, and the tail is exactly where it tends to
+	 * live. Report nothing rather than something misleading.
+	 */
+	if (dropped_count != 0) {
+		printk("%s %s: no percentiles, %zu of %zu samples did not fit; "
+		       "raise CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES\n",
+		       suite_name, bench_name, dropped_count,
+		       retained_count + dropped_count);
+		return;
+	}
+
+	percentiles_sort();
+
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
+	printk("P,%s,%s,%zu,%lld,%lld,%lld,%lld,%lld,%lld,%lld\n",
+		suite_name, bench_name, retained_count,
+		discrete_noise_correction(retained[0], ctrl),
+		discrete_noise_correction(percentile(5000), ctrl),
+		discrete_noise_correction(percentile(9000), ctrl),
+		discrete_noise_correction(percentile(9900), ctrl),
+		discrete_noise_correction(percentile(9990), ctrl),
+		discrete_noise_correction(percentile(9999), ctrl),
+		discrete_noise_correction(retained[retained_count - 1], ctrl));
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+	printk("\tp50: %lld\n", discrete_noise_correction(percentile(5000), ctrl));
+	printk("\tp90: %lld\n", discrete_noise_correction(percentile(9000), ctrl));
+	printk("\tp99: %lld\n", discrete_noise_correction(percentile(9900), ctrl));
+	printk("\tp99.9: %lld\n", discrete_noise_correction(percentile(9990), ctrl));
+	printk("\tp99.99: %lld\n", discrete_noise_correction(percentile(9999), ctrl));
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+}
+#else
+static inline void percentiles_reset(void)
+{
+}
+
+static inline void percentiles_record(uint64_t cycles)
+{
+	ARG_UNUSED(cycles);
+}
+
+static inline void percentiles_report(const char *suite_name, const char *bench_name,
+				      struct ztest_benchmark_stats *ctrl_stats)
+{
+	ARG_UNUSED(suite_name);
+	ARG_UNUSED(bench_name);
+	ARG_UNUSED(ctrl_stats);
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
+
 static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
 					char record_type, struct ztest_benchmark_stats *stats,
 					struct ztest_benchmark_stats *ctrl_stats)
@@ -90,11 +215,16 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 	printk("\tMax: %lld (run #%llu)\n", discrete_noise_correction(stats->max.value, ctrl),
 		stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+
+	percentiles_report(suite_name, bench_name, ctrl_stats);
 }
+
 
 static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 {
 	double delta, delta2;
+
+	percentiles_record(cycles);
 
 	/* Welfords method */
 	stats->samples += 1;
@@ -122,6 +252,7 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
+	percentiles_reset();
 
 	for (size_t i = 0; i < benchmark->iterations; i++) {
 		if (benchmark->setup) {
@@ -223,6 +354,7 @@ static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
 {
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
+	percentiles_reset();
 
 	/*
 	 * The loop, the setup and the teardown are the framework's, exactly

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -276,30 +276,59 @@ static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 	stats->m2 += delta * delta2;
 }
 
-static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
+/* One iteration of a sampled benchmark, setup and teardown included. */
+static uint64_t sampled_run_once(struct ztest_benchmark *benchmark)
 {
 	timing_t start, end;
 
+	if (benchmark->setup) {
+		benchmark->setup();
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	start = timing_counter_get();
+	benchmark->run();
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	end = timing_counter_get();
+
+	if (benchmark->teardown) {
+		benchmark->teardown();
+	}
+
+	return timing_cycles_get(&start, &end);
+}
+
+static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
+{
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
 	percentiles_reset();
 
+	/*
+	 * The first execution is the cold cost and is never part of the
+	 * distribution. It is reported on its own, and a benchmark that
+	 * reported it in both places would have it decide the far
+	 * percentiles: at ten thousand samples the nearest-rank p99.99 is
+	 * the second largest value, so a single cold start describes the
+	 * tail instead of the steady state it is supposed to characterise.
+	 *
+	 * Warmup and measurement are then separate loops rather than one
+	 * loop with a test on the iteration number. Such a test flips
+	 * exactly once, on the first measured iteration, so the mispredict
+	 * lands on the one sample the warmup exists to protect. The loop
+	 * bounds fold at build time, the warmup count being a Kconfig
+	 * constant.
+	 */
+	benchmark->stats.cold = sampled_run_once(benchmark);
+
+	for (size_t i = 1; i < CONFIG_ZTEST_BENCHMARK_WARMUP; i++) {
+		(void)sampled_run_once(benchmark);
+	}
+
 	for (size_t i = 0; i < benchmark->iterations; i++) {
-		if (benchmark->setup) {
-			benchmark->setup();
-		}
-
-		barrier_dsync_fence_full();
-		barrier_isync_fence_full();
-		start = timing_counter_get();
-		benchmark->run();
-		end = timing_counter_get();
-
-		update_metrics(&benchmark->stats, timing_cycles_get(&start, &end));
-
-		if (benchmark->teardown) {
-			benchmark->teardown();
-		}
+		update_metrics(&benchmark->stats, sampled_run_once(benchmark));
 	}
 }
 
@@ -380,31 +409,24 @@ static bool manual_run_once(struct ztest_benchmark_manual *benchmark, uint64_t *
 	return measured;
 }
 
-void ztest_benchmark_discard_samples(void)
-{
-	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
-
-	if (manual_active_stats != NULL) {
-		memset(manual_active_stats, 0, sizeof(*manual_active_stats));
-		manual_active_stats->min.value = UINT64_MAX;
-		percentiles_reset();
-	}
-}
-
 static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
 {
+	uint64_t cycles;
+
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
 	percentiles_reset();
 
-	/*
-	 * The loop, the setup and the teardown are the framework's, exactly
-	 * as for a sampled benchmark. All the body decides is which part of
-	 * itself the timestamps go around.
-	 */
-	for (size_t i = 0; i < benchmark->iterations; i++) {
-		uint64_t cycles;
+	/* Cold first, then the two phases, as in ztest_benchmark_run(). */
+	if (manual_run_once(benchmark, &cycles)) {
+		benchmark->stats.cold = cycles;
+	}
 
+	for (size_t i = 1; i < CONFIG_ZTEST_BENCHMARK_WARMUP; i++) {
+		(void)manual_run_once(benchmark, &cycles);
+	}
+
+	for (size_t i = 0; i < benchmark->iterations; i++) {
 		if (manual_run_once(benchmark, &cycles)) {
 			update_metrics(&benchmark->stats, cycles);
 		}

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -42,14 +42,25 @@ static int64_t discrete_noise_correction(uint64_t value, double ctrl)
 	return (int64_t)value - (int64_t)trunc(ctrl);
 }
 
-static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
-					  struct ztest_benchmark_stats *ctrl_stats)
+static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
+					char record_type, struct ztest_benchmark_stats *stats,
+					struct ztest_benchmark_stats *ctrl_stats)
 {
 	double ctrl = (double)ctrl_stats->mean;
 	double stddev = 0.0;
 	double sample_variance;
 	double std_error = 0.0;
-	struct ztest_benchmark_stats *stats = &benchmark->stats;
+
+	if (stats->samples == 0) {
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
+		printk("%c,%s,%s\tINCONCLUSIVE\n", record_type, suite_name, bench_name);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+		printk_line(bench_name, '=');
+		printk("\tTest inconclusive (no samples recorded)\n");
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+		return;
+	}
 
 	if (stats->samples > 1) {
 		sample_variance = stats->m2 / (double)(stats->samples - 1);
@@ -58,8 +69,8 @@ static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
 	}
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("S,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
-		benchmark->suite->name, benchmark->name,
+	printk("%c,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
+		record_type, suite_name, bench_name,
 		stats->samples,
 		discrete_noise_correction(stats->total, ctrl * stats->samples),
 		noise_correction(stats->mean, ctrl), stddev, std_error,
@@ -67,7 +78,7 @@ static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
 		discrete_noise_correction(stats->max.value, ctrl), stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk_line(benchmark->name, '=');
+	printk_line(bench_name, '=');
 	printk("\tSample size:%lld, total cycles: %lld\n", stats->samples,
 			discrete_noise_correction(stats->total, ctrl * stats->samples));
 
@@ -127,6 +138,102 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 
 		if (benchmark->teardown) {
 			benchmark->teardown();
+		}
+	}
+}
+
+/*
+ * The benchmark whose body is running, and the span it has marked.
+ *
+ * Only one benchmark runs at a time, so a single set of these serves all
+ * of them. Neither hook records anything: they only take timestamps, so
+ * both are safe to call from an ISR, and the sample is computed by the
+ * runner once the body has returned and the thread is running again.
+ * That is what keeps the floating point of update_metrics() out of
+ * interrupt context, where it is not allowed on every architecture.
+ */
+static bool manual_active;
+static timing_t manual_span_start;
+static timing_t manual_span_end;
+static bool manual_span_open;
+static bool manual_span_closed;
+
+void ztest_benchmark_start(void)
+{
+	if (!manual_active) {
+		LOG_DBG("%s() outside a manual benchmark body, ignored", __func__);
+		return;
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	manual_span_start = timing_counter_get();
+	manual_span_open = true;
+}
+
+void ztest_benchmark_end(void)
+{
+	if (!manual_active) {
+		LOG_DBG("%s() outside a manual benchmark body, ignored", __func__);
+		return;
+	}
+
+	if (!manual_span_open) {
+		LOG_DBG("%s() without a matching start, ignored", __func__);
+		return;
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	manual_span_end = timing_counter_get();
+	manual_span_open = false;
+	manual_span_closed = true;
+}
+
+/* One iteration of a manual benchmark, returning its span or nothing. */
+static bool manual_run_once(struct ztest_benchmark_manual *benchmark, uint64_t *cycles)
+{
+	bool measured;
+
+	if (benchmark->setup) {
+		benchmark->setup();
+	}
+
+	manual_span_open = false;
+	manual_span_closed = false;
+	manual_active = true;
+	benchmark->run();
+	manual_active = false;
+
+	measured = manual_span_closed;
+	if (measured) {
+		*cycles = timing_cycles_get(&manual_span_start, &manual_span_end);
+	} else {
+		LOG_DBG("%s recorded no span this iteration", benchmark->name);
+	}
+
+	if (benchmark->teardown) {
+		benchmark->teardown();
+	}
+
+	return measured;
+}
+
+static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
+{
+	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
+	benchmark->stats.min.value = UINT64_MAX;
+
+	/*
+	 * The loop, the setup and the teardown are the framework's, exactly
+	 * as for a sampled benchmark. All the body decides is which part of
+	 * itself the timestamps go around.
+	 */
+	for (size_t i = 0; i < benchmark->iterations; i++) {
+		uint64_t cycles;
+
+		if (manual_run_once(benchmark, &cycles)) {
+			update_metrics(&benchmark->stats, cycles);
 		}
 	}
 }
@@ -221,6 +328,30 @@ static struct ztest_benchmark ctrl = {
 	.run = empty_function,
 };
 
+/*
+ * A manual span costs the two timestamps that bracket it and nothing
+ * else: the body is not called from inside the span, so the indirect
+ * call that the sampled control measures is not part of one. Correcting
+ * a manual sample against the sampled control would subtract an
+ * overhead it never paid, so it gets a control of its own, an empty
+ * span with the framework's own hooks around it.
+ *
+ * A span whose ends are captured in two different contexts pays neither
+ * of these exactly, and no control can express that; the correction is
+ * still the closest of the two.
+ */
+static void empty_span(void)
+{
+	ztest_benchmark_start();
+	ztest_benchmark_end();
+}
+
+static struct ztest_benchmark_manual ctrl_manual = {
+	.name = "ctrl_manual",
+	.iterations = 1000,
+	.run = empty_span,
+};
+
 static struct ztest_benchmark_timed ctrl_timed = {
 	.duration_ms = 100,
 	.name = "ctrl_timed",
@@ -234,6 +365,7 @@ void benchmark_main(void)
 
 	k_sched_lock();
 	ztest_benchmark_run(&ctrl);
+	ztest_benchmark_manual_run(&ctrl_manual);
 	ztest_benchmark_timed_run(&ctrl_timed);
 	k_sched_unlock();
 
@@ -250,7 +382,17 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_run(benchmark);
-			ztest_benchmark_print_results(benchmark, &ctrl.stats);
+			ztest_benchmark_print_stats(suite->name, benchmark->name, 'S',
+						    &benchmark->stats, &ctrl.stats);
+		}
+
+		STRUCT_SECTION_FOREACH(ztest_benchmark_manual, benchmark) {
+			if (benchmark->suite != suite) {
+				continue;
+			}
+			ztest_benchmark_manual_run(benchmark);
+			ztest_benchmark_print_stats(suite->name, benchmark->name, 'M',
+						    &benchmark->stats, &ctrl_manual.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_timed, benchmark) {

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -133,11 +133,41 @@ static uint64_t percentile(uint32_t hundredths)
 	return retained[rank - 1U];
 }
 
-static void percentiles_report(const char *suite_name, const char *bench_name,
-			       struct ztest_benchmark_stats *ctrl_stats)
+#if defined(CONFIG_ZTEST_BENCHMARK_OUTLIERS) && defined(CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE)
+/*
+ * Samples slower than the median.
+ *
+ * For a kernel latency distribution the median is the baseline: the
+ * operation costs the same on almost every run, and what matters is how
+ * many runs were disturbed and by how much. Counting them says that
+ * directly, where a standard error would only describe how precisely an
+ * average of two different populations had been estimated.
+ */
+static size_t percentiles_outliers(void)
 {
-	double ctrl = (double)ctrl_stats->mean;
+	uint64_t median = percentile(5000);
+	size_t count = 0;
 
+	while ((count < retained_count) && (retained[retained_count - 1 - count] > median)) {
+		count++;
+	}
+
+	return count;
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTLIERS && CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+
+static bool percentiles_available(void)
+{
+	/*
+	 * Samples that did not fit make the retained ones a prefix rather
+	 * than a sample of the run, which percentiles_prepare() refuses
+	 * to sort or report.
+	 */
+	return (retained_count != 0) && (dropped_count == 0);
+}
+
+static void percentiles_prepare(const char *suite_name, const char *bench_name)
+{
 	if (retained_count == 0) {
 		return;
 	}
@@ -158,48 +188,38 @@ static void percentiles_report(const char *suite_name, const char *bench_name,
 	}
 
 	percentiles_sort();
-
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
-		suite_name, bench_name, retained_count,
-		noise_correction((double)retained[0], ctrl),
-		noise_correction((double)percentile(5000), ctrl),
-		noise_correction((double)percentile(9000), ctrl),
-		noise_correction((double)percentile(9900), ctrl),
-		noise_correction((double)percentile(9990), ctrl),
-		noise_correction((double)percentile(9999), ctrl),
-		noise_correction((double)retained[retained_count - 1], ctrl));
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
-	printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
-	printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
-	printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
-	printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 }
 #else
-static inline void percentiles_reset(void)
+/*
+ * Only the two hooks the runner calls unconditionally need a stub. The
+ * rest are referenced solely from code that this option compiles out,
+ * and a stub for them would be an unused function, which both
+ * compilers reject under the warning flags Zephyr builds with.
+ */
+static void percentiles_reset(void)
 {
 }
 
-static inline void percentiles_record(uint64_t cycles)
+static void percentiles_record(uint64_t cycles)
 {
 	ARG_UNUSED(cycles);
 }
-
-static inline void percentiles_report(const char *suite_name, const char *bench_name,
-				      struct ztest_benchmark_stats *ctrl_stats)
-{
-	ARG_UNUSED(suite_name);
-	ARG_UNUSED(bench_name);
-	ARG_UNUSED(ctrl_stats);
-}
 #endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
 
-static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
-					char record_type, struct ztest_benchmark_stats *stats,
-					struct ztest_benchmark_stats *ctrl_stats)
+/*
+ * Report one benchmark.
+ *
+ * The layout is the one the framework has always printed. The optional
+ * additions extend it rather than rearrange it: percentiles and the
+ * cold cost are extra lines, and CONFIG_ZTEST_BENCHMARK_OUTLIERS
+ * swaps the standard error for the outlier count in place.
+ *
+ * The CSV output keeps every column it had, including the standard
+ * error, so that existing parsers are unaffected whatever is enabled.
+ */
+static void ztest_benchmark_report(const char *suite_name, const char *bench_name,
+				   char record_type, struct ztest_benchmark_stats *stats,
+				   struct ztest_benchmark_stats *ctrl_stats)
 {
 	double ctrl = (double)ctrl_stats->mean;
 	double stddev = 0.0;
@@ -223,6 +243,10 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 		std_error = stddev / sqrt(stats->samples);
 	}
 
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	percentiles_prepare(suite_name, bench_name);
+#endif
+
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
 	printk("%c,%s,%s,%lld,%.3f,%.3f,%.3f,%.3f,%.3f,%lld,%.3f,%lld\n",
 		record_type, suite_name, bench_name,
@@ -231,7 +255,37 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 		noise_correction(stats->mean, ctrl), stddev, std_error,
 		noise_correction((double)stats->min.value, ctrl), stats->min.sample,
 		noise_correction((double)stats->max.value, ctrl), stats->max.sample);
+
+	if (stats->cold != 0) {
+		printk("C,%s,%s,%d,%.3f\n", suite_name, bench_name,
+			CONFIG_ZTEST_BENCHMARK_WARMUP,
+			noise_correction((double)stats->cold, ctrl));
+	}
+
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	/*
+	 * The percentiles go in a row of their own rather than as extra
+	 * columns on the row above, so that a parser written against the
+	 * original column layout keeps working.
+	 *
+	 * The extremes come from the retained samples the percentiles were
+	 * taken over, which is not the same set as the min and max on the
+	 * row above once samples have been dropped.
+	 */
+	if (percentiles_available()) {
+		printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
+			suite_name, bench_name, retained_count,
+			noise_correction((double)retained[0], ctrl),
+			noise_correction((double)percentile(5000), ctrl),
+			noise_correction((double)percentile(9000), ctrl),
+			noise_correction((double)percentile(9900), ctrl),
+			noise_correction((double)percentile(9990), ctrl),
+			noise_correction((double)percentile(9999), ctrl),
+			noise_correction((double)retained[retained_count - 1], ctrl));
+	}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
 	printk_line(bench_name, '=');
 	printk("\tSample size:%lld, total cycles: %.3f\n", stats->samples,
@@ -239,16 +293,43 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 
 	printk("\tMean(u): %.3f\n", noise_correction(stats->mean, ctrl));
 	printk("\tStandard deviation(s): %.3f\n", stddev);
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTLIERS
+	/*
+	 * The standard error describes how precisely the mean of one
+	 * stochastic population was estimated. A latency distribution is
+	 * usually a baseline plus a few disturbed runs instead, so the
+	 * count of samples slower than the median says more about it.
+	 */
+	if (percentiles_available()) {
+		size_t outliers = percentiles_outliers();
+
+		printk("\tOutliers: %zu / %zu (%.3f%%)\n", outliers, retained_count,
+			(100.0 * (double)outliers) / (double)retained_count);
+	}
+#else
 	printk("\tStandard Error(SE): %.3f\n", std_error);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTLIERS */
 	printk("\tMin: %lld (run #%llu)\n", noise_corrected_floor(stats->min.value, ctrl),
 		stats->min.sample);
 	printk("\tMax: %lld (run #%llu)\n", noise_corrected_ceil(stats->max.value, ctrl),
 		stats->max.sample);
+
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	if (percentiles_available()) {
+		printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
+		printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
+		printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
+		printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
+		printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
+	}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
+
+	if (stats->cold != 0) {
+		printk("\tCold (first run): %.3f\n",
+			noise_correction((double)stats->cold, ctrl));
+	}
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
-
-	percentiles_report(suite_name, bench_name, ctrl_stats);
 }
-
 
 static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 {
@@ -577,8 +658,8 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_run(benchmark);
-			ztest_benchmark_print_stats(suite->name, benchmark->name, 'S',
-						    &benchmark->stats, &ctrl.stats);
+			ztest_benchmark_report(suite->name, benchmark->name, 'S',
+					       &benchmark->stats, &ctrl.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_manual, benchmark) {
@@ -586,8 +667,8 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_manual_run(benchmark);
-			ztest_benchmark_print_stats(suite->name, benchmark->name, 'M',
-						    &benchmark->stats, &ctrl_manual.stats);
+			ztest_benchmark_report(suite->name, benchmark->name, 'M',
+					       &benchmark->stats, &ctrl_manual.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_timed, benchmark) {

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -601,6 +601,8 @@ static void ztest_benchmark_timed_run(struct ztest_benchmark_timed *benchmark)
 		RUN_100(benchmark->run());
 		iterations += 100;
 	}
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
 	end = timing_counter_get();
 
 	benchmark->stats.duration_cycles = timing_cycles_get(&start, &end);

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -48,6 +48,8 @@ struct ztest_benchmark_stats {
 	uint64_t samples;
 	struct ztest_extreme_value min;
 	struct ztest_extreme_value max;
+	/* First iteration, measured before the steady state is reached. */
+	uint64_t cold;
 };
 
 struct ztest_benchmark {

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -23,10 +23,11 @@ extern "C" {
  * Identifier builders for the linker-visible symbols that the ZTEST_BENCHMARK*()
  * macros generate. Use when defining a symbol or when taking its reference.
  */
-#define Z_ZTEST_BENCHMARK_SUITE_NODE(suite)        z_ztest_benchmark_suite_##suite
-#define Z_ZTEST_BENCHMARK_NODE(suite, bench)       z_ztest_benchmark_##suite##_##bench
-#define Z_ZTEST_BENCHMARK_TIMED_NODE(suite, bench) z_ztest_benchmark_timed_##suite##_##bench
-#define Z_ZTEST_BENCHMARK_FN(suite, bench)         z_ztest_benchmark_##suite##_##bench##_fn
+#define Z_ZTEST_BENCHMARK_SUITE_NODE(suite)         z_ztest_benchmark_suite_##suite
+#define Z_ZTEST_BENCHMARK_NODE(suite, bench)        z_ztest_benchmark_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_TIMED_NODE(suite, bench)  z_ztest_benchmark_timed_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_MANUAL_NODE(suite, bench) z_ztest_benchmark_manual_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_FN(suite, bench)          z_ztest_benchmark_##suite##_##bench##_fn
 
 typedef void (*ztest_benchmark_fn_t)(void);
 struct ztest_benchmark_suite {
@@ -50,6 +51,16 @@ struct ztest_benchmark_stats {
 };
 
 struct ztest_benchmark {
+	const char *name;
+	size_t iterations;
+	ztest_benchmark_fn_t setup;
+	ztest_benchmark_fn_t run;
+	ztest_benchmark_fn_t teardown;
+	struct ztest_benchmark_stats stats;
+	const struct ztest_benchmark_suite *suite;
+};
+
+struct ztest_benchmark_manual {
 	const char *name;
 	size_t iterations;
 	ztest_benchmark_fn_t setup;
@@ -145,6 +156,79 @@ void benchmark_main(void);
 		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(testsuite),				\
 	};											\
 	static __noinline void Z_ZTEST_BENCHMARK_FN(testsuite, benchmark)(void)
+
+/**
+ * @brief Define a manually sampled benchmark
+ *
+ * The framework runs the body once per iteration exactly as it does for
+ * ZTEST_BENCHMARK(), but the body decides which part of itself is measured
+ * by bracketing it with ztest_benchmark_start() and
+ * ztest_benchmark_end():
+ *
+ * @code
+ * ZTEST_BENCHMARK_MANUAL(my_suite, my_benchmark, 1000, NULL, NULL)
+ * {
+ *         prepare();
+ *         ztest_benchmark_start();
+ *         operation_under_test();
+ *         ztest_benchmark_end();
+ * }
+ * @endcode
+ *
+ * That covers a span the framework cannot time by itself because it does
+ * not start and end where the body does. Both hooks are safe to call from
+ * an ISR, so a span need not even begin and end in the same execution
+ * context: for the latency from an interrupt to the thread it wakes, the
+ * ISR calls ztest_benchmark_start() and the woken thread calls
+ * ztest_benchmark_end().
+ *
+ * A body that records no span contributes no sample for that iteration.
+ *
+ * @param suite_name Name of the suite the benchmark belongs to
+ * @param benchmark Name of the benchmark
+ * @param samples Number of iterations to run the benchmark
+ * @param setup_fn Function to run before each iteration
+ * @param teardown_fn Function to run after each iteration
+ */
+#define ZTEST_BENCHMARK_MANUAL(suite_name, benchmark, samples, setup_fn, teardown_fn)		\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void);		\
+	static STRUCT_SECTION_ITERABLE(ztest_benchmark_manual,					\
+				       Z_ZTEST_BENCHMARK_MANUAL_NODE(suite_name, benchmark)) =	\
+	{											\
+		.name = #benchmark,								\
+		.iterations = samples,								\
+		.setup = setup_fn,								\
+		.run = Z_ZTEST_BENCHMARK_FN(suite_name, benchmark),				\
+		.teardown = teardown_fn,							\
+		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(suite_name),				\
+	};											\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void)
+
+/**
+ * @brief Begin the measured span of a manual benchmark iteration
+ *
+ * Timestamps now. Anything the body did before this call is excluded from
+ * the measurement.
+ *
+ * Safe to call from an ISR: it only takes a timestamp, so a span whose
+ * start belongs to interrupt context is marked from there directly. The
+ * sample itself is computed once the body has returned.
+ *
+ * Calls made outside a ZTEST_BENCHMARK_MANUAL() body are ignored.
+ */
+void ztest_benchmark_start(void);
+
+/**
+ * @brief End the measured span of a manual benchmark iteration
+ *
+ * Timestamps now. Without a preceding ztest_benchmark_start() there is no
+ * span, and the call is ignored.
+ *
+ * Safe to call from an ISR, for the same reason as
+ * ztest_benchmark_start(): the span is only handed to the statistics once
+ * the body has returned to thread context.
+ */
+void ztest_benchmark_end(void);
 
 /**
  * @}

--- a/tests/ztest/benchmark_manual/CMakeLists.txt
+++ b/tests/ztest/benchmark_manual/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(benchmark_manual)
+
+target_sources(app PRIVATE
+  src/main.c
+)

--- a/tests/ztest/benchmark_manual/prj.conf
+++ b/tests/ztest/benchmark_manual/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_BENCHMARK=y
+CONFIG_IRQ_OFFLOAD=y
+CONFIG_MAIN_STACK_SIZE=2048

--- a/tests/ztest/benchmark_manual/src/main.c
+++ b/tests/ztest/benchmark_manual/src/main.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Validation for ZTEST_BENCHMARK_MANUAL(): one benchmark measuring a
+ * span of a known duration (k_busy_wait) that is only part of the body,
+ * and one measuring a span that starts in a different execution context
+ * (an ISR entered via irq_offload marks it) and ends in the thread,
+ * which framework-timed benchmarks cannot express.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/irq_offload.h>
+
+#define NUM_SAMPLES  100
+#define BUSY_WAIT_US 100
+
+ZTEST_BENCHMARK_SUITE(benchmark_manual, NULL, NULL);
+
+ZTEST_BENCHMARK_MANUAL(benchmark_manual, busy_wait_span, NUM_SAMPLES, NULL, NULL)
+{
+	/* Excluded from the measurement, to show that the brackets pick
+	 * out part of the body rather than all of it.
+	 */
+	k_busy_wait(BUSY_WAIT_US);
+
+	ztest_benchmark_start();
+	k_busy_wait(BUSY_WAIT_US);
+	ztest_benchmark_end();
+}
+
+static void offload_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	/* Marking the span from interrupt context is the point here. */
+	ztest_benchmark_start();
+}
+
+ZTEST_BENCHMARK_MANUAL(benchmark_manual, isr_exit_span, NUM_SAMPLES, NULL, NULL)
+{
+	irq_offload(offload_isr, NULL);
+
+	ztest_benchmark_end();
+}

--- a/tests/ztest/benchmark_manual/tests.yaml
+++ b/tests/ztest/benchmark_manual/tests.yaml
@@ -1,0 +1,20 @@
+common:
+  tags:
+    - test_framework
+    - benchmark
+  # The framework's timed control benchmark spins until a deadline
+  # expires, and on a simulated target time does not advance while the
+  # CPU is busy, so it never returns. tests/benchmarks/memory_allocators
+  # excludes posix for the same reason.
+  arch_exclude:
+    - posix
+tests:
+  testing.ztest.benchmark_manual:
+    integration_platforms:
+      - qemu_x86
+      - qemu_cortex_a53
+  testing.ztest.benchmark_manual.csv:
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    integration_platforms:
+      - qemu_x86


### PR DESCRIPTION

All needed for few new benchmark conversions and new benchmark reporting
features targeting scheduler and interrupt latencies.


- **testsuite: ztest: benchmark: add manually sampled benchmarks**
- **tests: ztest: add manually sampled benchmark validation**
- **testsuite: ztest: benchmark: report latency percentiles**
- **testsuite: ztest: benchmark: correct every statistic identically**
- **testsuite: ztest: benchmark: declare warmup and report cold cost**
- **testsuite: ztest: benchmark: count outliers instead of standard error**
