### PR TITLE
scripts: west: build: retain quotes for SB_CONFIG_ in extra_args

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -418,9 +418,13 @@ class Build(Forceable):
                                 args.append("-D{}".format(entry.replace('"', '\"')))
                     elif data == 'extra_args':
                         # Retain quotes around config options
-                        config_options = [arg for arg in arg_list if arg.startswith("CONFIG_")]
+                        config_options = [
+                            arg for arg in arg_list
+                            if arg.startswith(("CONFIG_", "SB_CONFIG_"))
+                        ]
                         non_config_option_candidates = [
-                            arg for arg in arg_list if not arg.startswith("CONFIG_")
+                            arg for arg in arg_list
+                            if not arg.startswith(("CONFIG_", "SB_CONFIG_"))
                         ]
                         args = ["-D{}".format(a.replace('"', '\"')) for a in config_options]
 


### PR DESCRIPTION
The extra_args parsing only treated arguments starting with "CONFIG_" as config options whose surrounding quotes must be preserved. Sysbuild config options prefixed with "SB_CONFIG_" were classified as non-config candidates, which stripped their quotes and could mangle values.

Extend the prefix check to also match "SB_CONFIG_" so sysbuild config options are handled identically to regular config options.