### PR TITLE
drivers: sensor: bmp581: combine I2C register writes

### DIFF
--- a/drivers/sensor/bosch/bmp581/bmp581_bus.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_bus.c
@@ -94,6 +94,36 @@ int bmp581_prep_reg_write_rtio_async(const struct bmp581_bus *bus,
 		return size;
 	}
 
+	if (bus->rtio.type == BMP581_BUS_TYPE_I2C) {
+		struct rtio_sqe *write_sqe;
+		uint8_t write_buf[7] = {reg};
+
+		/* One byte is occupied by the register address. */
+		if (size > sizeof(write_buf) - 1) {
+			return -EINVAL;
+		}
+
+		for (size_t i = 0; i < size; i++) {
+			write_buf[i + 1] = buf[i];
+		}
+
+		write_sqe = rtio_sqe_acquire(ctx);
+		if (!write_sqe) {
+			rtio_sqe_drop_all(ctx);
+			return -ENOMEM;
+		}
+
+		rtio_sqe_prep_tiny_write(write_sqe, iodev, RTIO_PRIO_NORM, write_buf,
+					 size + 1, NULL);
+		write_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+
+		if (out) {
+			*out = write_sqe;
+		}
+
+		return 1;
+	}
+
 	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
 	struct rtio_sqe *write_buf_sqe = rtio_sqe_acquire(ctx);
 


### PR DESCRIPTION
## Summary

Combine the BMP581 I2C register address and payload into a single RTIO
tiny-write SQE.

This fixes BMP581 initialization on a custom nRF52840 board using the native
nrfx TWIM RTIO backend. The change has been verified on hardware with
`samples/sensor/sensor_shell`.

## Problem

The existing BMP581 I2C write path submits the register address and payload as
two RTIO SQEs. On the tested nRF52840 target, writing the soft-reset command in
this form does not produce the contiguous register write expected by the
BMP581. Both RTIO operations report success, but the reset-complete bit is not
set and `soft_reset()` returns `-EFAULT` (`-14`).

The failure is reproducible during initialization:

```console
[00:00:00.330,383] <err> bmp581: Failed to perform soft-reset: -14
uart:~$ sensor get bmp581@46
Sensor device unknown (bmp581@46)
```

The device is present on the bus and reports the expected chip ID:

```console
uart:~$ i2c read_byte i2c@40004000 46 01
Output: 0x50
```

Sending the same reset as one I2C register write from the shell succeeds. The
reset-complete bit is then visible in `INT_STATUS`:

```console
uart:~$ i2c write_byte i2c@40004000 46 7e b6
uart:~$ i2c read_byte i2c@40004000 46 27
Output: 0x10
```

Increasing the post-reset delay from the driver default to 10 ms did not change
the failure, which rules out insufficient reset settling time.

## Fix

For I2C, construct one buffer containing the register address followed by the
payload and submit it as one tiny-write SQE with `RTIO_IODEV_I2C_STOP`:

```text
START + device address + register address + payload + STOP
```

An RTIO tiny-write buffer holds seven bytes. One byte is used for the register
address, leaving up to six payload bytes. The BMP581 driver currently writes at
most two payload bytes, so all existing writes fit in the combined frame.

The SPI and I3C paths are unchanged.

## Hardware verification

Test configuration:

- Custom nRF52840 board
- BMP581 connected over I2C at address `0x46`
- Native nrfx TWIM RTIO backend (`CONFIG_I2C_NRFX_TWIM=y` and
  `CONFIG_I2C_RTIO=y`)
- `samples/sensor/sensor_shell`

After this change, initialization completes without the BMP581 soft-reset error
and the sensor returns valid temperature and pressure samples:

```console
uart:~$ sensor get bmp581@46
channel type=13(ambient_temp) index=0 shift=15 num_samples=1 value=6302642822ns (28.892364)
channel type=14(press) index=0 shift=15 num_samples=1 value=6302642822ns (99.884323)
```

## Validation

- Pristine `sensor_shell` build for the custom nRF52840 board: passed
- Hardware initialization and sensor sampling: passed
- `scripts/checkpatch.pl --git HEAD`: 0 errors, 0 warnings
- `drivers.sensor.bmp581` was selected with Twister, but `native_sim` was
  statically filtered on the local macOS host and was therefore not executed
  locally; the existing test is expected to run in upstream CI

Related issue: https://github.com/zephyrproject-rtos/zephyr/issues/103361