### PR TITLE
include: storage: flash_map: fix `fic` param name in sha256 check

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -103,7 +103,7 @@ struct flash_area_check {
  * point is indicated by an offset value.
  *
  * @param[in] fa	Flash area
- * @param[in] fic	Flash area check integrity data
+ * @param[in] fac	Flash area check integrity data
  *
  * @return  0 on success, negative errno code on fail
  */


### PR DESCRIPTION
The struct next to it is `flash_area_check`, so `fic` reads like it predates the parameter being named `fac`.
