### PR TITLE
Bluetooth: Audio: expand bt_bap_unicast_group_info

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -250,6 +250,16 @@ New APIs and options
     * :c:func:`bt_ascs_unregister`
     * :c:func:`bt_bap_unicast_client_qos_from_group`
     * :c:func:`bt_bap_qos_cfg_eq`
+    * :c:member:`bt_bap_unicast_group_info.c_to_p_interval`
+    * :c:member:`bt_bap_unicast_group_info.p_to_c_interval`
+    * :c:member:`bt_bap_unicast_group_info.c_to_p_latency`
+    * :c:member:`bt_bap_unicast_group_info.p_to_c_latency`
+    * :c:member:`bt_bap_unicast_group_info.framing`
+    * :c:member:`bt_bap_unicast_group_info.packing`
+    * :c:member:`bt_bap_unicast_group_info.has_been_connected`
+    * :c:member:`bt_bap_unicast_group_info.c_to_p_ft`
+    * :c:member:`bt_bap_unicast_group_info.p_to_c_ft`
+    * :c:member:`bt_bap_unicast_group_info.iso_interval`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1573,9 +1573,10 @@ int bt_bap_unicast_group_foreach_stream(struct bt_bap_unicast_group *unicast_gro
 					bt_bap_unicast_group_foreach_stream_func_t func,
 					void *user_data);
 
-/** Structure holding information of audio stream endpoint */
+/** Structure holding information of a unicast group */
 struct bt_bap_unicast_group_info {
-	/** Presentation delay for sink ASEs
+	/**
+	 * @brief Presentation delay for sink ASEs (central to peripheral audio direction)
 	 *
 	 * Will be @ref BT_BAP_PD_UNSET if no sink streams have been added to group.
 	 * The value does not reflect what has been configured on any remote ASEs, but only the
@@ -1583,13 +1584,79 @@ struct bt_bap_unicast_group_info {
 	 */
 	uint32_t sink_pd;
 
-	/** Presentation delay for source ASEs
+	/**
+	 * @brief Presentation delay for source ASEs (peripheral to central audio direction)
 	 *
 	 * Will be @ref BT_BAP_PD_UNSET if no source streams have been added to group.
 	 * The value does not reflect what has been configured on any remote ASEs, but only the
 	 * local value from when the group was created or reconfigured.
 	 */
 	uint32_t source_pd;
+
+	/**
+	 * @brief Central to Peripheral SDU interval in microseconds
+	 *
+	 * Will be 0 if no sink streams have been added to the group.
+	 */
+	uint32_t c_to_p_interval;
+
+	/**
+	 * @brief Peripheral to Central SDU interval in microseconds
+	 *
+	 * Will be 0 if no source streams have been added to the group.
+	 */
+	uint32_t p_to_c_interval;
+
+	/**
+	 * @brief Central to Peripheral maximum transport latency in milliseconds
+	 *
+	 * Will be 0 if no sink streams have been added to the group.
+	 */
+	uint16_t c_to_p_latency;
+
+	/**
+	 * @brief Peripheral to Central maximum transport latency in milliseconds
+	 *
+	 * Will be 0 if no source streams have been added to the group.
+	 */
+	uint16_t p_to_c_latency;
+
+	/** @brief The framing of the streams in the group */
+	enum bt_bap_qos_cfg_framing framing;
+
+	/**
+	 * @brief The packing of the group
+	 *
+	 * @ref BT_ISO_PACKING_SEQUENTIAL or @ref BT_ISO_PACKING_INTERLEAVED.
+	 */
+	uint8_t packing;
+
+	/**
+	 * @brief Whether any stream in the group has been connected
+	 *
+	 * If this is true, then the group can no longer be modified with e.g.
+	 * bt_bap_unicast_group_reconfig() or bt_bap_unicast_group_add_streams().
+	 */
+	bool has_been_connected;
+
+#if defined(CONFIG_BT_ISO_TEST_PARAMS) || defined(__DOXYGEN__)
+	/**
+	 * @brief Central to Peripheral flush timeout in multiples of the ISO interval
+	 *
+	 * Will be 0 if no sink streams have been added to the group.
+	 */
+	uint8_t c_to_p_ft;
+
+	/**
+	 * @brief Peripheral to Central flush timeout in multiples of the ISO interval
+	 *
+	 * Will be 0 if no source streams have been added to the group.
+	 */
+	uint8_t p_to_c_ft;
+
+	/** @brief ISO interval in 1.25 ms units */
+	uint16_t iso_interval;
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
 };
 
 /**

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -387,7 +387,6 @@ broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
 	bt_bap_stream_attach(NULL, stream, ep);
 	stream->qos = &ep->qos;
 	stream->group = source;
-	ep->broadcast_source = source;
 
 	return 0;
 }
@@ -538,7 +537,6 @@ static void broadcast_source_cleanup(struct bt_bap_broadcast_source *source)
 			bt_bap_iso_unbind_ep(stream->ep->iso, stream->ep);
 			stream->iso = NULL;
 			stream->ep->stream = NULL;
-			stream->ep->broadcast_source = NULL;
 			stream->ep = NULL;
 			stream->codec_cfg = NULL;
 			stream->qos = NULL;

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -58,10 +58,6 @@ struct bt_bap_ep {
 
 	/* Used by the unicast server and client */
 	bool receiver_ready;
-
-	/* TODO: Create a union to reduce memory usage */
-	struct bt_bap_unicast_group *unicast_group;
-	struct bt_bap_broadcast_source *broadcast_source;
 };
 
 struct bt_bap_unicast_group_cig_param {

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3079,6 +3079,13 @@ int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
 		struct bt_bap_unicast_group_stream_param *rx_param = stream_param->rx_param;
 		struct bt_bap_unicast_group_stream_param *tx_param = stream_param->tx_param;
 
+		unicast_group->cig_param.packing = param->packing;
+		IF_ENABLED(CONFIG_BT_ISO_TEST_PARAMS, ({
+			unicast_group->cig_param.c_to_p_ft = param->c_to_p_ft;
+			unicast_group->cig_param.p_to_c_ft = param->p_to_c_ft;
+			unicast_group->cig_param.iso_interval = param->iso_interval;
+		}));
+
 		if (rx_param != NULL) {
 			struct bt_bap_iso *bap_iso =
 				CONTAINER_OF(rx_param->stream->iso, struct bt_bap_iso, chan);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -326,20 +326,22 @@ static void unicast_client_ep_iso_sent(struct bt_iso_chan *chan)
 static void unicast_client_ep_iso_connected(struct bt_bap_ep *ep)
 {
 	const struct bt_bap_stream_ops *stream_ops;
-	struct bt_bap_stream *stream;
+	struct bt_bap_stream *stream = ep->stream;
 
-	if (ep->unicast_group != NULL) {
-		ep->unicast_group->has_been_connected = true;
-	}
-
-	if (ep->state != BT_BAP_EP_STATE_QOS_CONFIGURED && ep->state != BT_BAP_EP_STATE_ENABLING) {
-		LOG_DBG("endpoint in invalid state: %s", bt_bap_ep_state_str(ep->state));
+	if (stream == NULL) {
+		LOG_ERR("No stream for ep %p", ep);
 		return;
 	}
 
-	stream = ep->stream;
-	if (stream == NULL) {
-		LOG_ERR("No stream for ep %p", ep);
+	if (stream->group == NULL) {
+		LOG_ERR("No group for stream %p for ep %p", stream, ep);
+		return;
+	}
+
+	((struct bt_bap_unicast_group *)stream->group)->has_been_connected = true;
+
+	if (ep->state != BT_BAP_EP_STATE_QOS_CONFIGURED && ep->state != BT_BAP_EP_STATE_ENABLING) {
+		LOG_DBG("endpoint in invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return;
 	}
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3292,6 +3292,23 @@ int bt_bap_unicast_group_get_info(const struct bt_bap_unicast_group *unicast_gro
 
 	info->sink_pd = unicast_group->sink_pd;
 	info->source_pd = unicast_group->source_pd;
+	info->c_to_p_interval = unicast_group->cig_param.c_to_p_interval;
+	info->p_to_c_interval = unicast_group->cig_param.p_to_c_interval;
+	info->c_to_p_latency = unicast_group->cig_param.c_to_p_latency;
+	info->p_to_c_latency = unicast_group->cig_param.p_to_c_latency;
+	/* The framing is stored as the ISO value, so it is converted back to the BAP value */
+	if (unicast_group->cig_param.framing == BT_ISO_FRAMING_FRAMED) {
+		info->framing = BT_BAP_QOS_CFG_FRAMING_FRAMED;
+	} else {
+		info->framing = BT_BAP_QOS_CFG_FRAMING_UNFRAMED;
+	}
+	info->packing = unicast_group->cig_param.packing;
+	info->has_been_connected = unicast_group->has_been_connected;
+	IF_ENABLED(CONFIG_BT_ISO_TEST_PARAMS, ({
+		info->c_to_p_ft = unicast_group->cig_param.c_to_p_ft;
+		info->p_to_c_ft = unicast_group->cig_param.p_to_c_ft;
+		info->iso_interval = unicast_group->cig_param.iso_interval;
+	}));
 
 	return 0;
 }

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -44,6 +44,8 @@ LOG_MODULE_REGISTER(bap_unicast_client_test);
 
 extern enum bst_result_t bst_result;
 
+#define CIG_PACKING BT_ISO_PACKING_SEQUENTIAL
+
 static struct audio_test_stream test_streams[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
 static struct bt_bap_ep *g_sinks[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
 static struct bt_bap_ep *g_sources[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
@@ -712,10 +714,74 @@ static void codec_configure_streams(size_t stream_cnt)
 	}
 }
 
+static void check_unicast_group_info(struct bt_bap_unicast_group *unicast_group,
+				     const struct bt_bap_qos_cfg *rx_qos,
+				     const struct bt_bap_qos_cfg *tx_qos,
+				     bool expected_has_been_connected)
+{
+	struct bt_bap_unicast_group_info info;
+	int err;
+
+	err = bt_bap_unicast_group_get_info(unicast_group, &info);
+	if (err != 0) {
+		FAIL("Unable to get unicast group info: %d\n", err);
+		return;
+	}
+
+	if (info.sink_pd != tx_qos->pd) {
+		FAIL("Unexpected sink PD %u (expected %u)\n", info.sink_pd, tx_qos->pd);
+		return;
+	}
+
+	if (info.source_pd != rx_qos->pd) {
+		FAIL("Unexpected source PD %u (expected %u)\n", info.source_pd, rx_qos->pd);
+		return;
+	}
+
+	if (info.c_to_p_interval != tx_qos->interval) {
+		FAIL("Unexpected C to P interval %u (expected %u)\n", info.c_to_p_interval,
+		     tx_qos->interval);
+		return;
+	}
+
+	if (info.p_to_c_interval != rx_qos->interval) {
+		FAIL("Unexpected P to C interval %u (expected %u)\n", info.p_to_c_interval,
+		     rx_qos->interval);
+		return;
+	}
+
+	if (info.c_to_p_latency != tx_qos->latency) {
+		FAIL("Unexpected C to P latency %u (expected %u)\n", info.c_to_p_latency,
+		     tx_qos->latency);
+		return;
+	}
+
+	if (info.p_to_c_latency != rx_qos->latency) {
+		FAIL("Unexpected P to C latency %u (expected %u)\n", info.p_to_c_latency,
+		     rx_qos->latency);
+		return;
+	}
+
+	if (info.framing != tx_qos->framing) {
+		FAIL("Unexpected framing %u (expected %u)\n", info.framing, tx_qos->framing);
+		return;
+	}
+
+	if (info.packing != CIG_PACKING) {
+		FAIL("Unexpected packing %u (expected %u)\n", info.packing, CIG_PACKING);
+		return;
+	}
+
+	if (info.has_been_connected != expected_has_been_connected) {
+		FAIL("Unexpected has_been_connected %d (expected %d)\n", info.has_been_connected,
+		     expected_has_been_connected);
+		return;
+	}
+}
+
 static void qos_configure_streams(struct bt_bap_unicast_group *unicast_group,
 				  size_t stream_cnt)
 {
-	struct bt_bap_unicast_group_info info;
 	int err;
 
 	UNSET_FLAG(flag_stream_qos_configured);
@@ -734,22 +800,7 @@ static void qos_configure_streams(struct bt_bap_unicast_group *unicast_group,
 		(void)k_sleep(K_MSEC(1U));
 	}
 
-	err = bt_bap_unicast_group_get_info(unicast_group, &info);
-	if (err != 0) {
-		FAIL("Unable to QoS configure streams: %d\n", err);
-		return;
-	}
-
-	if (info.sink_pd != preset_16_2_1.qos.pd) {
-		FAIL("Unexpected sink PD %u (expected %u)\n", info.sink_pd, preset_16_2_1.qos.pd);
-		return;
-	}
-
-	if (info.source_pd != preset_16_2_1.qos.pd) {
-		FAIL("Unexpected source PD %u (expected %u)\n", info.source_pd,
-		     preset_16_2_1.qos.pd);
-		return;
-	}
+	check_unicast_group_info(unicast_group, &preset_16_2_1.qos, &preset_16_2_1.qos, false);
 }
 
 static int enable_stream(struct bt_bap_stream *stream)
@@ -1092,7 +1143,7 @@ static size_t create_unicast_group(struct bt_bap_unicast_group **unicast_group)
 
 	param.params = pair_params;
 	param.params_count = pair_cnt;
-	param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	param.packing = CIG_PACKING;
 
 	/* Require controller support for CIGs */
 	err = bt_bap_unicast_group_create(&param, unicast_group);
@@ -1278,7 +1329,7 @@ static void test_main_async_group(void)
 	struct bt_bap_unicast_group_param param = {
 		.params = &pair_param,
 		.params_count = 1U,
-		.packing = BT_ISO_PACKING_SEQUENTIAL,
+		.packing = CIG_PACKING,
 	};
 	struct bt_bap_unicast_group *unicast_group;
 	int err;
@@ -1291,6 +1342,8 @@ static void test_main_async_group(void)
 
 		return;
 	}
+
+	check_unicast_group_info(unicast_group, &rx_qos, &tx_qos, false);
 
 	deinit();
 
@@ -1318,7 +1371,7 @@ static void test_main_reconf_group(void)
 	struct bt_bap_unicast_group_param param = {
 		.params = &pair_param,
 		.params_count = 1U,
-		.packing = BT_ISO_PACKING_SEQUENTIAL,
+		.packing = CIG_PACKING,
 	};
 	struct bt_bap_unicast_group *unicast_group;
 	int err;
@@ -1332,6 +1385,8 @@ static void test_main_reconf_group(void)
 		return;
 	}
 
+	check_unicast_group_info(unicast_group, &preset_16_2_1.qos, &preset_16_2_1.qos, false);
+
 	rx_param.qos = &preset_16_2_2.qos;
 	tx_param.qos = &preset_16_2_2.qos;
 	err = bt_bap_unicast_group_reconfig(unicast_group, &param);
@@ -1340,6 +1395,8 @@ static void test_main_reconf_group(void)
 
 		return;
 	}
+
+	check_unicast_group_info(unicast_group, &preset_16_2_2.qos, &preset_16_2_2.qos, false);
 
 	deinit();
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -641,7 +641,8 @@ static void unicast_group_create(struct bt_cap_unicast_group **out_unicast_group
 
 static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, void *user_data)
 {
-	const uint32_t expected_pd = cap_stream->bap_stream.qos->pd;
+	const struct bt_bap_qos_cfg *qos = cap_stream->bap_stream.qos;
+	const uint32_t expected_pd = qos->pd;
 	struct bt_cap_unicast_group *unicast_group = user_data;
 	struct bt_bap_unicast_group_info bap_info;
 	struct bt_cap_unicast_group_info cap_info;
@@ -672,12 +673,52 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 			     expected_pd);
 			return false;
 		}
+
+		if (bap_info.c_to_p_interval != qos->interval) {
+			FAIL("Unexpected C to P interval %u (expected %u)\n",
+			     bap_info.c_to_p_interval, qos->interval);
+			return false;
+		}
+
+		if (bap_info.c_to_p_latency != qos->latency) {
+			FAIL("Unexpected C to P latency %u (expected %u)\n",
+			     bap_info.c_to_p_latency, qos->latency);
+			return false;
+		}
 	} else {
 		if (bap_info.source_pd != expected_pd) {
 			FAIL("Unexpected source PD %u (expected %u)\n", bap_info.source_pd,
 			     expected_pd);
 			return false;
 		}
+
+		if (bap_info.p_to_c_interval != qos->interval) {
+			FAIL("Unexpected P to C interval %u (expected %u)\n",
+			     bap_info.p_to_c_interval, qos->interval);
+			return false;
+		}
+
+		if (bap_info.p_to_c_latency != qos->latency) {
+			FAIL("Unexpected P to C latency %u (expected %u)\n",
+			     bap_info.p_to_c_latency, qos->latency);
+			return false;
+		}
+	}
+
+	if (bap_info.framing != qos->framing) {
+		FAIL("Unexpected framing %u (expected %u)\n", bap_info.framing, qos->framing);
+		return false;
+	}
+
+	if (bap_info.packing != BT_ISO_PACKING_SEQUENTIAL) {
+		FAIL("Unexpected packing %u (expected %u)\n", bap_info.packing,
+		     BT_ISO_PACKING_SEQUENTIAL);
+		return false;
+	}
+
+	if (!bap_info.has_been_connected) {
+		FAIL("Expected has_been_connected to be true after start\n");
+		return false;
 	}
 
 	return true;


### PR DESCRIPTION
Add the CIG parameters of the unicast group (SDU intervals, transport
latencies, framing, packing and, when CONFIG_BT_ISO_TEST_PARAMS is
enabled, the flush timeouts and the ISO interval) as well as the
has_been_connected state to struct bt_bap_unicast_group_info, so that
applications can retrieve all relevant information about a group.

The framing is stored internally using the ISO values, and is converted
back to the BAP QoS configuration values when reported.

The existing bsim tests for bt_bap_unicast_group_get_info have been
expanded to verify the new values, including for a group with
asymmetric parameters and for a reconfigured group.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/103567