### PR TITLE
drivers: reset: fix Kconfig prompts for mchp, focaltech, nxp_rstctl

### DIFF
--- a/drivers/reset/Kconfig.focaltech
+++ b/drivers/reset/Kconfig.focaltech
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_FOCALTECH_FT9001
-	bool "FocalTech FT9001 Reset Control Module driver"
+	bool "FocalTech FT9001 reset driver"
 	default y
 	depends on DT_HAS_FOCALTECH_FT9001_CPM_RCTL_ENABLED
 	help

--- a/drivers/reset/Kconfig.mchp
+++ b/drivers/reset/Kconfig.mchp
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_MCHP_RSTC_G1
-	bool "Microchip Reset Controller g1 peripheral driver"
+	bool "Microchip RSTC G1 reset driver"
 	default y
 	depends on DT_HAS_MICROCHIP_RSTC_G1_RESET_ENABLED
 	help

--- a/drivers/reset/Kconfig.nxp_rstctl
+++ b/drivers/reset/Kconfig.nxp_rstctl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config RESET_NXP_RSTCTL
-	bool "NXP RSTCTL driver"
+	bool "NXP RSTCTL reset driver"
 	default y
 	depends on DT_HAS_NXP_RSTCTL_ENABLED
 	help


### PR DESCRIPTION
Follow up of #115694
Part of #7272

Align reset driver prompts with the Kconfig style guide (doc/contribute/style/kconfig.rst), which specifies for /drivers:

  "{Driver Name} {Driver Type} driver" for prompts.

These drivers were left as-is in #115694 because "reset" is embedded into their IP block name (RSTC, RSTCTL) or spelled out in the original prompt ("Reset Control Module"). Use the vendor abbreviation and apply the standard format.

- RESET_MCHP_RSTC_G1: "Microchip RSTC G1 reset driver"
- RESET_NXP_RSTCTL: "NXP RSTCTL reset driver"
- RESET_FOCALTECH_FT9001: "FocalTech FT9001 reset driver"