### PR TITLE
[Backport v4.4-branch] drivers: i3c: validate nested CCC buffers in do_ccc syscall handler

### DIFF
--- a/drivers/i3c/i3c_handlers.c
+++ b/drivers/i3c/i3c_handlers.c
@@ -8,6 +8,80 @@
 #include <string.h>
 #include <zephyr/internal/syscall_handler.h>
 
+static int copy_ccc_and_do(const struct device *dev,
+			   struct i3c_ccc_payload *payload)
+{
+	struct i3c_ccc_payload copy;
+	struct i3c_ccc_target_payload *user_payloads;
+	struct i3c_ccc_target_payload *kernel_payloads = NULL;
+	size_t i;
+	int ret;
+
+	/* Work from a local copy rather than the caller's live structure. */
+	memcpy(&copy, payload, sizeof(copy));
+
+	if (copy.ccc.data != NULL) {
+		K_OOPS(K_SYSCALL_MEMORY_ARRAY_WRITE(copy.ccc.data,
+						    copy.ccc.data_len,
+						    sizeof(*copy.ccc.data)));
+	}
+
+	user_payloads = copy.targets.payloads;
+
+	if (user_payloads != NULL) {
+		K_OOPS(K_SYSCALL_VERIFY(copy.targets.num_targets >= 1 &&
+					copy.targets.num_targets < 32));
+		K_OOPS(K_SYSCALL_MEMORY_ARRAY_WRITE(user_payloads,
+						    copy.targets.num_targets,
+						    sizeof(*user_payloads)));
+
+		/* Allocate a private copy of the target array rather than
+		 * working directly off the caller-supplied pointer.
+		 */
+		kernel_payloads = k_usermode_alloc_from_copy(
+			user_payloads,
+			copy.targets.num_targets * sizeof(*user_payloads));
+		K_OOPS(K_SYSCALL_VERIFY(kernel_payloads != NULL));
+
+		copy.targets.payloads = kernel_payloads;
+
+		for (i = 0; i < copy.targets.num_targets; i++) {
+			if (kernel_payloads[i].data == NULL) {
+				continue;
+			}
+			/* rnw=1: Read (driver writes buffer); rnw=0: Write (driver reads). */
+			if (K_SYSCALL_MEMORY(kernel_payloads[i].data,
+					     kernel_payloads[i].data_len,
+					     kernel_payloads[i].rnw)) {
+				k_free(kernel_payloads);
+				K_OOPS(K_SYSCALL_VERIFY(false));
+			}
+		}
+
+		ret = z_impl_i3c_do_ccc(dev, &copy);
+
+		/*
+		 * Propagate driver-written results back to the caller. Data
+		 * buffers are written through directly (the pointers still
+		 * reference user memory); only the scalar fields living in the
+		 * snapshot need to be copied out.
+		 */
+		for (i = 0; i < copy.targets.num_targets; i++) {
+			user_payloads[i].num_xfer = kernel_payloads[i].num_xfer;
+			user_payloads[i].err = kernel_payloads[i].err;
+		}
+
+		k_free(kernel_payloads);
+	} else {
+		ret = z_impl_i3c_do_ccc(dev, &copy);
+	}
+
+	payload->ccc.num_xfer = copy.ccc.num_xfer;
+	payload->ccc.err = copy.ccc.err;
+
+	return ret;
+}
+
 static inline int z_vrfy_i3c_do_ccc(const struct device *dev,
 				    struct i3c_ccc_payload *payload)
 {
@@ -15,25 +89,7 @@ static inline int z_vrfy_i3c_do_ccc(const struct device *dev,
 	K_OOPS(K_SYSCALL_MEMORY_READ(payload, sizeof(*payload)));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(payload, sizeof(*payload)));
 
-	if (payload->ccc.data != NULL) {
-		K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(payload->ccc.data,
-						   payload->ccc.data_len,
-						   sizeof(*payload->ccc.data)));
-		K_OOPS(K_SYSCALL_MEMORY_ARRAY_WRITE(payload->ccc.data,
-						    payload->ccc.data_len,
-						    sizeof(*payload->ccc.data)));
-	}
-
-	if (payload->targets.payloads != NULL) {
-		K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(payload->targets.payloads,
-						   payload->targets.num_targets,
-						   sizeof(*payload->targets.payloads)));
-		K_OOPS(K_SYSCALL_MEMORY_ARRAY_WRITE(payload->targets.payloads,
-						    payload->targets.num_targets,
-						    sizeof(*payload->targets.payloads)));
-	}
-
-	return z_impl_i3c_do_ccc(dev, payload);
+	return copy_ccc_and_do(dev, payload);
 }
 #include <zephyr/syscalls/i3c_do_ccc_mrsh.c>
 


### PR DESCRIPTION
Backport of the fix from #110170 to `v4.4-branch`.

Fixes: #115575