### PR TITLE
Bluetooth: Classic: L2CAP: Handle channel add failure in connection req

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2856,7 +2856,16 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 	br_chan->required_sec_level = server->sec_level;
 	br_chan->psm = psm;
 
-	l2cap_br_chan_add(conn, chan, l2cap_br_chan_destroy);
+	if (!l2cap_br_chan_add(conn, chan, l2cap_br_chan_destroy)) {
+		/* Give the channel the server just accepted back to it,
+		 * following the normal channel lifecycle so that the server
+		 * knows the channel object is no longer in use.
+		 */
+		bt_l2cap_br_chan_del(chan);
+		result = BT_L2CAP_BR_ERR_NO_RESOURCES;
+		goto no_chan;
+	}
+
 	BR_CHAN(chan)->tx.cid = scid;
 	br_chan->ident = ident;
 	bt_l2cap_br_chan_set_state(chan, BT_L2CAP_CONNECTING);


### PR DESCRIPTION
l2cap_br_conn_req() ignores the return value of l2cap_br_chan_add(), unlike both of its other callers. When the dynamic CID allocation fails, the code continues as if the channel was fully set up: it sends a connection response whose DCID is the CID that was never allocated (0), and the channel object that the server just accepted is never attached to the connection. Since the channel is not on the connection's channel list, no disconnected or released callback will ever be called for it, so the server considers the object in use forever and one of its channels is permanently leaked.

Check the return value, give the channel back to the server through the normal bt_l2cap_br_chan_del() lifecycle, and reply to the remote with "no resources available".
