### PR TITLE
Bluetooth: Classic: HFP: Fix HF teardown and object reuse on disconnect

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4258,14 +4258,35 @@ static void hfp_hf_connected(struct bt_rfcomm_dlc *dlc)
 static void hfp_hf_disconnected(struct bt_rfcomm_dlc *dlc)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(dlc, struct bt_hfp_hf, rfcomm_dlc);
+	struct net_buf *buf;
 
 	LOG_DBG("hf disconnected!");
 	if (bt_hf->disconnected) {
 		bt_hf->disconnected(hf);
 	}
 
+	/* Stop the senders before draining the TX queue below: with the flag
+	 * cleared, command senders are rejected with -ENOTCONN instead of
+	 * queueing buffers that nothing will ever send.
+	 */
+	atomic_clear_bit(hf->flags, BT_HFP_HF_FLAG_CONNECTED);
+
 	k_work_cancel(&hf->work);
 	k_work_cancel_delayable(&hf->deferred_work);
+
+	/* Drop queued TX buffers. Nothing will send them any more, and
+	 * leaving them on the FIFO would leak them from hf_pool for good:
+	 * hfp_hf_create() wipes the FIFO with memset() when the slot is
+	 * reused. Freeing them also unblocks a work handler that is stuck
+	 * in the K_FOREVER allocation in hfp_hf_send_cmd() waiting for the
+	 * exhausted pool to be refilled.
+	 */
+	buf = k_fifo_get(&hf->tx_pending, K_NO_WAIT);
+	while (buf != NULL) {
+		net_buf_unref(buf);
+		buf = k_fifo_get(&hf->tx_pending, K_NO_WAIT);
+	}
+
 	hf->acl = NULL;
 }
 
@@ -4403,6 +4424,22 @@ static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 	hf = &bt_hfp_hf_pool[index];
 	if (hf->acl) {
 		LOG_ERR("HF connection (%p) is established", conn);
+		return NULL;
+	}
+
+	/* The work items are canceled on disconnect, but a handler that was
+	 * already running at that point may still be executing: cancellation
+	 * does not wait for a running handler, and the handlers can block for
+	 * a long time in the K_FOREVER buffer allocation in
+	 * hfp_hf_send_cmd(). Wiping the object under a running handler would
+	 * corrupt the work items and the TX FIFO, so refuse to reuse the
+	 * object until the handlers have finished. This is a transient
+	 * failure: retry once the pending work has drained.
+	 */
+	if ((k_work_busy_get(&hf->work) != 0) ||
+	    (k_work_busy_get(&hf->slc_work) != 0) ||
+	    (k_work_delayable_busy_get(&hf->deferred_work) != 0)) {
+		LOG_WRN("Work of HF %p is still pending or running", hf);
 		return NULL;
 	}
 


### PR DESCRIPTION
hfp_hf_disconnected() leaves the HF object in a state where reusing it is unsafe:

- The work items are canceled, but cancellation does not affect a handler that is already running, and the handlers can block for a long time in hfp_hf_send_cmd(), which allocates from hf_pool with K_FOREVER. hfp_hf_create() only checks hf->acl before wiping the object with memset(), so a new connection on the same index can wipe the work items, the TX FIFO and the AT client state under a still-running handler.

- Buffers still queued on tx_pending are never freed. Nothing sends them once the DLC is gone, and the memset() on reuse then loses them from hf_pool permanently. A fully parked pool also means a handler blocked in the hfp_hf_send_cmd() allocation never wakes up.

- The CONNECTED flag is never cleared (only the memset() on reuse does), so command senders keep queueing buffers for the dead DLC between disconnection and reuse instead of failing with -ENOTCONN.

Clear the CONNECTED flag and drain tx_pending in
hfp_hf_disconnected(), and make hfp_hf_create() refuse to reuse the object while any of the work items is still pending or running. The refusal is a transient condition: once the handlers have finished, the next connection attempt succeeds.

Fixes: #117056