### PR TITLE
drivers: auxdisplay: add US2066 support

### DIFF
--- a/drivers/auxdisplay/CMakeLists.txt
+++ b/drivers/auxdisplay/CMakeLists.txt
@@ -15,4 +15,5 @@ zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_NXP_SLCD auxdisplay_nxp_slcd.c)
 zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_PT6314 auxdisplay_pt6314.c)
 zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_SERLCD auxdisplay_serlcd.c)
 zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_TM1637 auxdisplay_tm1637.c)
+zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_US2066 auxdisplay_us2066.c)
 # zephyr-keep-sorted-stop

--- a/drivers/auxdisplay/Kconfig
+++ b/drivers/auxdisplay/Kconfig
@@ -29,6 +29,7 @@ source "drivers/auxdisplay/Kconfig.nxp_slcd"
 source "drivers/auxdisplay/Kconfig.pt6314"
 source "drivers/auxdisplay/Kconfig.serlcd"
 source "drivers/auxdisplay/Kconfig.tm1637"
+source "drivers/auxdisplay/Kconfig.us2066"
 # zephyr-keep-sorted-stop
 
 endif # AUXDISPLAY

--- a/drivers/auxdisplay/Kconfig.us2066
+++ b/drivers/auxdisplay/Kconfig.us2066
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Jasper Jonker
+# SPDX-License-Identifier: Apache-2.0
+
+config AUXDISPLAY_US2066
+	bool "Newhaven Display US2066 LCD driver"
+	default y
+	select GPIO
+	select I2C if DT_HAS_NEWHAVEN_US2066_I2C_ENABLED
+	select SPI if DT_HAS_NEWHAVEN_US2066_SPI_ENABLED
+	depends on DT_HAS_NEWHAVEN_US2066_I2C_ENABLED || DT_HAS_NEWHAVEN_US2066_SPI_ENABLED
+	help
+	  Enable driver for Newhaven Display US2066 character LCDs.

--- a/drivers/auxdisplay/auxdisplay_us2066.c
+++ b/drivers/auxdisplay/auxdisplay_us2066.c
@@ -1,0 +1,1195 @@
+/*
+ * Copyright (c) 2026 Jasper Jonker
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT newhaven_us2066_spi
+
+#include "auxdisplay_us2066.h"
+
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/auxdisplay.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(auxdisplay_us2066, CONFIG_AUXDISPLAY_LOG_LEVEL);
+
+/* The serial write path cannot read the busy flag, so every byte is paced. */
+#define US2066_SHORT_DELAY         K_MSEC(1)
+#define US2066_CLEAR_HOME_DELAY    K_MSEC(2)
+#define US2066_I2C_CONTROL_COMMAND 0x00
+#define US2066_I2C_CONTROL_DATA    0x40
+#define US2066_SPI_CONTROL_COMMAND 0xf8
+#define US2066_SPI_CONTROL_DATA    0xfa
+
+struct auxdisplay_us2066_bus {
+	int (*init)(const struct device *dev);
+	int (*write)(const struct device *dev, bool data, uint8_t value);
+};
+
+struct auxdisplay_us2066_data {
+	bool power;
+	bool cursor;
+	bool blinking;
+	uint8_t brightness;
+	uint16_t cursor_x;
+	uint16_t cursor_y;
+};
+
+struct auxdisplay_us2066_config {
+	const struct auxdisplay_us2066_bus *bus;
+	struct gpio_dt_spec reset_gpio;
+	struct i2c_dt_spec i2c;
+	struct spi_dt_spec spi;
+	struct auxdisplay_capabilities capabilities;
+	uint16_t io_voltage_mv;
+	uint8_t contrast;
+	uint8_t clock_divider;
+	uint8_t clock_freq;
+	uint8_t phase1_period;
+	uint8_t phase2_period;
+	uint8_t vcomh_level;
+	uint8_t func_n_bit;          /* Pre-calculated N bit for line configuration */
+	uint8_t func_nw_bit;         /* Pre-calculated NW bit for line configuration */
+	uint8_t font_width;          /* Pre-calculated font width bit (5 or 6 dot) */
+	uint8_t cursor_invert;       /* Pre-calculated cursor invert bit */
+	uint8_t entry_mode;          /* Pre-calculated entry mode flags (I/D and S bits) */
+	uint8_t display_orientation; /* Pre-calculated BDC/BDS orientation flags */
+};
+
+/* Get DDRAM row addresses based on row count */
+static const uint8_t *get_row_addresses(uint8_t rows)
+{
+	static const uint8_t addr_1_line[]  = {0x00};
+	static const uint8_t addr_2_lines[] = {0x00, 0x20};
+	static const uint8_t addr_3_lines[] = {0x00, 0x10, 0x20};
+	static const uint8_t addr_4_lines[] = {0x00, 0x20, 0x40, 0x60};
+
+	switch (rows) {
+	case 1:
+		return addr_1_line;
+	case 2:
+		return addr_2_lines;
+	case 3:
+		return addr_3_lines;
+	case 4:
+	default:
+		return addr_4_lines;
+	}
+}
+
+#if DT_HAS_COMPAT_STATUS_OKAY(newhaven_us2066_i2c)
+static int auxdisplay_us2066_write_i2c(const struct device *dev, bool data, uint8_t value)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	uint8_t tx_data[] = {
+		data ? US2066_I2C_CONTROL_DATA : US2066_I2C_CONTROL_COMMAND,
+		value,
+	};
+	int rc;
+
+	rc = i2c_write_dt(&cfg->i2c, tx_data, sizeof(tx_data));
+	if (rc < 0) {
+		LOG_ERR("Failed to send %s byte 0x%02x over I2C [%d]", data ? "data" : "command",
+			value, rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_init_i2c(const struct device *dev)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+
+	if (!i2c_is_ready_dt(&cfg->i2c)) {
+		LOG_ERR("I2C bus is not ready");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static const struct auxdisplay_us2066_bus auxdisplay_us2066_i2c_bus = {
+	.init = auxdisplay_us2066_init_i2c,
+	.write = auxdisplay_us2066_write_i2c,
+};
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(newhaven_us2066_i2c) */
+
+#if DT_HAS_COMPAT_STATUS_OKAY(newhaven_us2066_spi)
+/* Reverse the bit order within one nibble for the US2066 serial transfer format. */
+static uint8_t auxdisplay_us2066_reverse_nibble(uint8_t value)
+{
+	value &= 0x0f;
+
+	return ((value & BIT(0)) << 3) | ((value & BIT(1)) << 1) |
+	       ((value & BIT(2)) >> 1) | ((value & BIT(3)) >> 3);
+}
+
+/*
+ * Write one command or data byte using the US2066 SPI-compatible serial format.
+ * The first byte is the start/control byte, followed by the low and high nibbles
+ * with each nibble bit-reversed and shifted into the upper half of the byte.
+ */
+static int auxdisplay_us2066_write_spi(const struct device *dev, bool data, uint8_t value)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	uint8_t tx_data[] = {
+		data ? US2066_SPI_CONTROL_DATA : US2066_SPI_CONTROL_COMMAND,
+		auxdisplay_us2066_reverse_nibble(value) << 4,
+		auxdisplay_us2066_reverse_nibble(value >> 4) << 4,
+	};
+	const struct spi_buf tx_buf = {
+		.buf = tx_data,
+		.len = sizeof(tx_data),
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1,
+	};
+	int rc;
+
+	rc = spi_write_dt(&cfg->spi, &tx);
+	if (rc < 0) {
+		LOG_ERR("Failed to send %s byte 0x%02x over SPI [%d]",
+			data ? "data" : "command", value, rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_init_spi(const struct device *dev)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+
+	if (!spi_is_ready_dt(&cfg->spi)) {
+		LOG_ERR("SPI bus is not ready");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static const struct auxdisplay_us2066_bus auxdisplay_us2066_spi_bus = {
+	.init = auxdisplay_us2066_init_spi,
+	.write = auxdisplay_us2066_write_spi,
+};
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(newhaven_us2066_i2c) */
+
+static int auxdisplay_us2066_write_bus(const struct device *dev, bool data, uint8_t value)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+
+	return cfg->bus->write(dev, data, value);
+}
+
+static int auxdisplay_us2066_command(const struct device *dev, uint8_t cmd)
+{
+	int rc;
+
+	rc = auxdisplay_us2066_write_bus(dev, false, cmd);
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (cmd == US2066_CMD_CLEAR_DISPLAY || cmd == US2066_CMD_RETURN_HOME) {
+		k_sleep(US2066_CLEAR_HOME_DELAY);
+	} else {
+		k_sleep(US2066_SHORT_DELAY);
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_data(const struct device *dev, uint8_t data)
+{
+	int rc;
+
+	rc = auxdisplay_us2066_write_bus(dev, true, data);
+	if (rc < 0) {
+		return rc;
+	}
+
+	k_sleep(US2066_SHORT_DELAY);
+	return 0;
+}
+
+static int auxdisplay_us2066_apply_display_control(const struct device *dev)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+	uint8_t cmd;
+
+	cmd = (data->power ? US2066_DISPLAY_ON : 0) |
+	      (data->cursor ? US2066_DISPLAY_CURSOR_ON : 0) |
+	      (data->blinking ? US2066_DISPLAY_BLINK_ON : 0);
+
+	return auxdisplay_us2066_command(dev, US2066_CMD_DISPLAY_CTRL | cmd);
+}
+
+static int auxdisplay_us2066_display_on(const struct device *dev)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+
+	data->power = true;
+
+	return auxdisplay_us2066_apply_display_control(dev);
+}
+
+static int auxdisplay_us2066_display_off(const struct device *dev)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+
+	data->power = false;
+
+	return auxdisplay_us2066_apply_display_control(dev);
+}
+
+static int auxdisplay_us2066_cursor_set_enabled(const struct device *dev, bool enable)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+
+	data->cursor = enable;
+
+	return auxdisplay_us2066_apply_display_control(dev);
+}
+
+static int auxdisplay_us2066_position_blinking_set_enabled(const struct device *dev, bool enable)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+
+	data->blinking = enable;
+
+	return auxdisplay_us2066_apply_display_control(dev);
+}
+
+static int auxdisplay_us2066_cursor_position_set(const struct device *dev,
+						 enum auxdisplay_position type, int16_t x,
+						 int16_t y)
+{
+	const struct auxdisplay_us2066_config *config = dev->config;
+	struct auxdisplay_us2066_data *data = dev->data;
+	const uint8_t *row_addr = get_row_addresses(config->capabilities.rows);
+	uint8_t addr;
+	int rc;
+
+	if (type == AUXDISPLAY_POSITION_RELATIVE) {
+		x += data->cursor_x;
+		y += data->cursor_y;
+	} else if (type == AUXDISPLAY_POSITION_RELATIVE_DIRECTION) {
+		return -EINVAL;
+	}
+
+	if (x < 0 || y < 0) {
+		return -EINVAL;
+	} else if (x >= config->capabilities.columns || y >= config->capabilities.rows) {
+		return -EINVAL;
+	}
+
+	/* Send hardware command first, only update tracking if successful */
+	addr = US2066_CMD_SET_DDRAM_ADDR | (row_addr[y] + x);
+	rc = auxdisplay_us2066_command(dev, addr);
+	if (rc) {
+		return rc;
+	}
+
+	/* Update software cursor tracking after successful hardware update */
+	data->cursor_x = (uint16_t)x;
+	data->cursor_y = (uint16_t)y;
+
+	return 0;
+}
+
+static int auxdisplay_us2066_cursor_position_get(const struct device *dev, int16_t *x, int16_t *y)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+
+	*x = (int16_t)data->cursor_x;
+	*y = (int16_t)data->cursor_y;
+
+	return 0;
+}
+
+static int auxdisplay_us2066_capabilities_get(const struct device *dev,
+					      struct auxdisplay_capabilities *capabilities)
+{
+	const struct auxdisplay_us2066_config *config = dev->config;
+
+	memcpy(capabilities, &config->capabilities, sizeof(struct auxdisplay_capabilities));
+
+	return 0;
+}
+
+static int auxdisplay_us2066_brightness_get(const struct device *dev, uint8_t *brightness)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+
+	*brightness = data->brightness;
+
+	return 0;
+}
+
+static int auxdisplay_us2066_brightness_set(const struct device *dev, uint8_t brightness)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	struct auxdisplay_us2066_data *data = dev->data;
+	int rc;
+
+	/* Enter extended mode (RE=1) before using OLED commands */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_RE_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to enter extended mode [%d]", rc);
+		return rc;
+	}
+
+	/* Enter OLED command set */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_ENABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Set contrast */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_SET_CONTRAST);
+	if (rc < 0) {
+		LOG_ERR("Failed to send set contrast command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, brightness);
+	if (rc < 0) {
+		LOG_ERR("Failed to send brightness value [%d]", rc);
+		return rc;
+	}
+
+	/* Exit OLED command set */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_DISABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to disable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Return to fundamental mode (RE=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to return to fundamental mode [%d]", rc);
+		return rc;
+	}
+
+	data->brightness = brightness;
+
+	return 0;
+}
+
+/* Write text */
+static int auxdisplay_us2066_write(const struct device *dev, const uint8_t *text, uint16_t len)
+{
+	const struct auxdisplay_us2066_config *config = dev->config;
+	struct auxdisplay_us2066_data *data = dev->data;
+	const uint8_t *row_addr = get_row_addresses(config->capabilities.rows);
+	int rc;
+
+	for (uint16_t i = 0; i < len; i++) {
+		/* Check if we need to wrap to next line before writing */
+		if (data->cursor_x >= config->capabilities.columns) {
+			data->cursor_x = 0;
+			data->cursor_y++;
+
+			if (data->cursor_y >= config->capabilities.rows) {
+				data->cursor_y = 0;
+			}
+
+			rc = auxdisplay_us2066_cursor_position_set(
+				dev, AUXDISPLAY_POSITION_ABSOLUTE, data->cursor_x, data->cursor_y);
+			if (rc < 0) {
+				LOG_ERR("Failed to set cursor position [%d]", rc);
+				return rc;
+			}
+		}
+
+		/* Write the character */
+		rc = auxdisplay_us2066_data(dev, text[i]);
+		if (rc < 0) {
+			LOG_ERR("Failed to write character 0x%02x [%d]", text[i], rc);
+			return rc;
+		}
+
+		/* Update cursor position tracking */
+		data->cursor_x++;
+
+		/* After writing to last column, explicitly set hardware cursor for next row
+		 * This prevents hardware DDRAM auto-increment from going to invalid addresses
+		 */
+		if (data->cursor_x >= config->capabilities.columns) {
+			uint16_t next_x = 0;
+			uint16_t next_y = data->cursor_y + 1;
+			uint8_t addr;
+
+			if (next_y >= config->capabilities.rows) {
+				next_y = 0;
+			}
+
+			/* Update hardware cursor position to start of next line */
+			addr = US2066_CMD_SET_DDRAM_ADDR | (row_addr[next_y] + next_x);
+			rc = auxdisplay_us2066_command(dev, addr);
+			if (rc < 0) {
+				LOG_ERR("Failed to set DDRAM address [%d]", rc);
+				return rc;
+			}
+
+			/* Update software tracking */
+			data->cursor_x = next_x;
+			data->cursor_y = next_y;
+		}
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_clear(const struct device *dev)
+{
+	struct auxdisplay_us2066_data *data = dev->data;
+	int rc;
+
+	data->cursor_x = 0;
+	data->cursor_y = 0;
+
+	/* Clear Display */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_CLEAR_DISPLAY);
+	if (rc < 0) {
+		LOG_ERR("Failed to clear display [%d]", rc);
+		return rc;
+	}
+
+	/* Return Home */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_RETURN_HOME);
+	if (rc < 0) {
+		LOG_ERR("Failed to return home [%d]", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_set_scroll_enable(const struct device *dev, uint8_t lines)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	int rc;
+
+	/* Select IS=1 while RE=0, then RE=1 to access shift/scroll enable commands. */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_IS_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to select special registers for scroll [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_RE_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to enter extended mode for scroll [%d]", rc);
+		return rc;
+	}
+
+	/* Set extended function set: 5-dot font, scroll enable (DH'=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET_EXTENDED | cfg->font_width |
+						    cfg->func_nw_bit | US2066_DH_DOT_SHIFT);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable scroll mode [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_SCROLL_ENABLE | (lines & 0x0f));
+	if (rc < 0) {
+		LOG_ERR("Failed to set scroll lines [%d]", rc);
+		return rc;
+	}
+
+	/* Return to fundamental mode (RE=0, IS=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to return to fundamental mode [%d]", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_set_scroll_quantity(const struct device *dev, uint8_t quantity)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	int rc;
+
+	if (quantity > US2066_SCROLL_QUANTITY_MAX) {
+		LOG_ERR("Invalid scroll quantity: %d", quantity);
+		return -EINVAL;
+	}
+
+	/* Enter extended mode (RE=1) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_RE_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to enter extended mode [%d]", rc);
+		return rc;
+	}
+
+	/* Set scroll quantity */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_SET_SCROLL_QTY | (quantity & 0x3F));
+	if (rc < 0) {
+		LOG_ERR("Failed to set scroll quantity [%d]", rc);
+		return rc;
+	}
+
+	/* Return to fundamental mode (RE=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to return to fundamental mode [%d]", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_set_shift_enable(const struct device *dev, uint8_t lines)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	int rc;
+
+	/* Select IS=1 while RE=0, then RE=1 to access shift/scroll enable commands. */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_IS_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to select special registers for shift [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_RE_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to enter extended mode [%d]", rc);
+		return rc;
+	}
+
+	/* Set extended function set to enable shift mode (DH'=1) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET_EXTENDED | cfg->font_width |
+						    cfg->func_nw_bit | US2066_DH_DISPLAY_SHIFT);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable shift mode [%d]", rc);
+		return rc;
+	}
+
+	/* Enable shift for specified lines */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_SHIFT_ENABLE | (lines & 0x0F));
+	if (rc < 0) {
+		LOG_ERR("Failed to set shift lines [%d]", rc);
+		return rc;
+	}
+
+	/* Return to fundamental mode (RE=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to return to fundamental mode [%d]", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_display_shift(const struct device *dev, bool right)
+{
+	/* Use cursor/display shift command in fundamental mode (RE=0) */
+	return auxdisplay_us2066_command(dev,
+					 US2066_CMD_CURSOR_SHIFT | US2066_SHIFT_DISPLAY |
+						 (right ? US2066_SHIFT_RIGHT : US2066_SHIFT_LEFT));
+}
+
+static int auxdisplay_us2066_set_fade_blink(const struct device *dev, uint8_t mode,
+					    uint8_t interval)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	int rc;
+
+	/* Validate mode */
+	if (mode != US2066_FADE_BLINK_DISABLE && mode != US2066_FADE_OUT_ENABLE &&
+	    mode != US2066_BLINK_ENABLE) {
+		LOG_ERR("Invalid fade/blink mode: %d", mode);
+		return -EINVAL;
+	}
+
+	/* Validate interval */
+	if (interval > US2066_FADE_INTERVAL_MAX) {
+		LOG_ERR("Invalid fade/blink interval: %d", interval);
+		return -EINVAL;
+	}
+
+	/* Enter extended mode (RE=1) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_RE_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to enter extended mode [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_ENABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Set fade/blink: OLED command followed by its command-parameter byte. */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_SET_FADE_BLINK);
+	if (rc < 0) {
+		LOG_ERR("Failed to send fade/blink command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, mode | US2066_FADE_INTERVAL(interval));
+	if (rc < 0) {
+		LOG_ERR("Failed to set fade/blink mode [%d]", rc);
+		return rc;
+	}
+
+	/* Disable OLED command set */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_DISABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to disable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Return to fundamental mode (RE=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to return to fundamental mode [%d]", rc);
+		return rc;
+	}
+
+	/* Small delay to ensure command is processed */
+	k_usleep(100);
+
+	return 0;
+}
+
+static int auxdisplay_us2066_set_double_height(const struct device *dev, uint8_t upper_lines,
+					       uint8_t lower_lines)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	int rc;
+
+	/* Enable double height in function set (RE=0, DH=1) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit |
+						    US2066_FUNC_DOUBLE_HEIGHT_ENABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable double height [%d]", rc);
+		return rc;
+	}
+
+	/* Enter extended mode (RE=1) to set which lines show upper/lower parts */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_RE_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to enter extended mode [%d]", rc);
+		return rc;
+	}
+
+	/* Set which line pairs show upper/lower halves */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_DH_DOT_SHIFT | upper_lines | lower_lines);
+	if (rc < 0) {
+		LOG_ERR("Failed to set double height lines [%d]", rc);
+		return rc;
+	}
+
+	/* Return to fundamental mode (RE=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit |
+						    US2066_FUNC_DOUBLE_HEIGHT_ENABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to return to fundamental mode [%d]", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int auxdisplay_us2066_clear_double_height(const struct device *dev)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+
+	/* Disable double height in function set (RE=0, DH=0) and return to normal height */
+	return auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+}
+
+static int auxdisplay_us2066_custom_command(const struct device *dev,
+					    struct auxdisplay_custom_data *command)
+{
+	if (command == NULL) {
+		return -EINVAL;
+	}
+
+	switch (command->options) {
+	case AUXDISPLAY_US2066_CUSTOM_SET_SCROLL_ENABLE:
+		if (command->data == NULL || command->len != 1) {
+			return -EINVAL;
+		}
+
+		return auxdisplay_us2066_set_scroll_enable(dev, command->data[0]);
+
+	case AUXDISPLAY_US2066_CUSTOM_SET_SCROLL_QUANTITY:
+		if (command->data == NULL || command->len != 1) {
+			return -EINVAL;
+		}
+
+		return auxdisplay_us2066_set_scroll_quantity(dev, command->data[0]);
+
+	case AUXDISPLAY_US2066_CUSTOM_SET_SHIFT_ENABLE:
+		if (command->data == NULL || command->len != 1) {
+			return -EINVAL;
+		}
+
+		return auxdisplay_us2066_set_shift_enable(dev, command->data[0]);
+
+	case AUXDISPLAY_US2066_CUSTOM_DISPLAY_SHIFT:
+		if (command->data == NULL || command->len != 1 ||
+		    command->data[0] > AUXDISPLAY_US2066_DISPLAY_SHIFT_RIGHT) {
+			return -EINVAL;
+		}
+
+		return auxdisplay_us2066_display_shift(
+			dev, command->data[0] == AUXDISPLAY_US2066_DISPLAY_SHIFT_RIGHT);
+
+	case AUXDISPLAY_US2066_CUSTOM_SET_FADE_BLINK:
+		if (command->data == NULL || command->len != 2) {
+			return -EINVAL;
+		}
+
+		return auxdisplay_us2066_set_fade_blink(dev, command->data[0], command->data[1]);
+
+	case AUXDISPLAY_US2066_CUSTOM_SET_DOUBLE_HEIGHT:
+		if (command->data == NULL || command->len != 2) {
+			return -EINVAL;
+		}
+
+		return auxdisplay_us2066_set_double_height(dev, command->data[0], command->data[1]);
+
+	case AUXDISPLAY_US2066_CUSTOM_CLEAR_DOUBLE_HEIGHT:
+		if (command->len != 0) {
+			return -EINVAL;
+		}
+
+		return auxdisplay_us2066_clear_double_height(dev);
+
+	default:
+		return -EINVAL;
+	}
+}
+
+static int auxdisplay_us2066_init(const struct device *dev)
+{
+	const struct auxdisplay_us2066_config *cfg = dev->config;
+	struct auxdisplay_us2066_data *data = dev->data;
+	int rc;
+
+	rc = cfg->bus->init(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (cfg->reset_gpio.port) {
+		rc = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_INACTIVE);
+		if (rc < 0) {
+			LOG_ERR("Failed to configure reset GPIO [%d]", rc);
+			return rc;
+		}
+		k_msleep(1);
+
+		/* Assert reset */
+		rc = gpio_pin_set_dt(&cfg->reset_gpio, 1);
+		if (rc < 0) {
+			LOG_ERR("Failed to assert reset [%d]", rc);
+			return rc;
+		}
+		k_msleep(20);
+
+		/* Release reset */
+		rc = gpio_pin_set_dt(&cfg->reset_gpio, 0);
+		if (rc < 0) {
+			LOG_ERR("Failed to release reset [%d]", rc);
+			return rc;
+		}
+		k_msleep(150);
+	}
+
+	k_msleep(10);
+
+	/* Convert VCOMH level to register value */
+	const uint8_t vcomh_values[] = {US2066_VCOMH_0_65_VCC, US2066_VCOMH_0_71_VCC,
+					US2066_VCOMH_0_77_VCC, US2066_VCOMH_0_83_VCC,
+					US2066_VCOMH_1_00_VCC};
+	uint8_t vcomh_level = cfg->vcomh_level;
+	uint8_t vcomh;
+
+	if (vcomh_level >= ARRAY_SIZE(vcomh_values)) {
+		/* Clamp to the highest supported VCOMH level */
+		vcomh_level = ARRAY_SIZE(vcomh_values) - 1;
+	}
+	vcomh = vcomh_values[vcomh_level];
+
+	/* Initialization sequence per datasheet (Table 11) */
+
+	/* Function set: extended command set (RE=1) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit |
+						    US2066_FUNC_RE_EXTENDED);
+	if (rc < 0) {
+		LOG_ERR("Failed to set extended function set [%d]", rc);
+		return rc;
+	}
+
+	/* Function selection A: Set VDD regulator based on I/O voltage */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNC_SELECTION_A);
+	if (rc < 0) {
+		LOG_ERR("Failed to send function selection A command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_data(dev, (cfg->io_voltage_mv == 5000) ? US2066_FSA_VDD_5V
+								      : US2066_FSA_VDD_3V3);
+	if (rc < 0) {
+		LOG_ERR("Failed to set VDD regulator [%d]", rc);
+		return rc;
+	}
+
+	/* Function set: fundamental command set (RE=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to set fundamental function set [%d]", rc);
+		return rc;
+	}
+
+	/* Display off */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_DISPLAY_CTRL);
+	if (rc < 0) {
+		LOG_ERR("Failed to turn display off [%d]", rc);
+		return rc;
+	}
+
+	/* Function set: extended command set (RE=1) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit |
+						    US2066_FUNC_RE_EXTENDED);
+	if (rc < 0) {
+		LOG_ERR("Failed to set extended function set [%d]", rc);
+		return rc;
+	}
+
+	/* OLED command set enabled */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_ENABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Set display clock divide ratio/oscillator frequency */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_SET_DISPLAY_CLK);
+	if (rc < 0) {
+		LOG_ERR("Failed to set display clock command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, US2066_CLK_DIVIDER(cfg->clock_divider) |
+						    US2066_CLK_FREQ(cfg->clock_freq));
+	if (rc < 0) {
+		LOG_ERR("Failed to set clock divider/frequency [%d]", rc);
+		return rc;
+	}
+
+	/* OLED command set disabled */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_DISABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to disable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Extended function set: 5-dot font */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET_EXTENDED | cfg->font_width |
+						    cfg->cursor_invert | cfg->func_nw_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to set extended function set [%d]", rc);
+		return rc;
+	}
+
+	/* COM-SEG direction */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_ENTRY_MODE_SET | cfg->display_orientation);
+	if (rc < 0) {
+		LOG_ERR("Failed to set COM-SEG direction [%d]", rc);
+		return rc;
+	}
+
+	/* Function selection B: ROM selection */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNC_SELECTION_B);
+	if (rc < 0) {
+		LOG_ERR("Failed to send function selection B command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_data(
+		dev,
+		US2066_FSB_ROM_A | US2066_FSB_CGRAM_8_A); /* ROM CGRAM selection per datasheet */
+	if (rc < 0) {
+		LOG_ERR("Failed to set ROM selection [%d]", rc);
+		return rc;
+	}
+
+	/* Switch to fundamental mode (RE=0) for cursor/shift entry mode */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to set fundamental function set [%d]", rc);
+		return rc;
+	}
+
+	/* Entry mode: cursor direction and shift (I/D, S bits in RE=0 mode) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_ENTRY_MODE_SET | cfg->entry_mode);
+	if (rc < 0) {
+		LOG_ERR("Failed to set entry mode [%d]", rc);
+		return rc;
+	}
+
+	/* Function set: extended command set (RE=1) for OLED config */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | US2066_FUNC_RE_EXTENDED |
+						    cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to set extended function set [%d]", rc);
+		return rc;
+	}
+
+	/* OLED command set enabled */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_ENABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to enable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Set SEG pins hardware configuration */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_SET_SEG_PINS);
+	if (rc < 0) {
+		LOG_ERR("Failed to send set SEG pins command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, US2066_SEG_PINS_ALTERNATIVE);
+	if (rc < 0) {
+		LOG_ERR("Failed to set SEG pins alternative [%d]", rc);
+		return rc;
+	}
+
+	/* Function selection C: Internal VSL, GPIO input disable */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_FUNC_SELECTION_C);
+	if (rc < 0) {
+		LOG_ERR("Failed to send function selection C command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev,
+				       US2066_FSC_VSL_INTERNAL | US2066_FSC_GPIO_HIZ_INPUT_OFF);
+	if (rc < 0) {
+		LOG_ERR("Failed to set VSL and GPIO config [%d]", rc);
+		return rc;
+	}
+
+	/* Set contrast control */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_SET_CONTRAST);
+	if (rc < 0) {
+		LOG_ERR("Failed to send set contrast command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, cfg->contrast);
+	if (rc < 0) {
+		LOG_ERR("Failed to set contrast value [%d]", rc);
+		return rc;
+	}
+
+	/* Set phase length */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_SET_PHASE_LENGTH);
+	if (rc < 0) {
+		LOG_ERR("Failed to send set phase length command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, US2066_PHASE1(cfg->phase1_period) |
+						    US2066_PHASE2(cfg->phase2_period));
+	if (rc < 0) {
+		LOG_ERR("Failed to set phase periods [%d]", rc);
+		return rc;
+	}
+
+	/* Set VCOMH deselect level */
+	rc = auxdisplay_us2066_command(dev, US2066_OLED_SET_VCOMH);
+	if (rc < 0) {
+		LOG_ERR("Failed to send set VCOMH command [%d]", rc);
+		return rc;
+	}
+
+	rc = auxdisplay_us2066_command(dev, vcomh);
+	if (rc < 0) {
+		LOG_ERR("Failed to set VCOMH level [%d]", rc);
+		return rc;
+	}
+
+	/* OLED command set disabled */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_OLED_DISABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to disable OLED command set [%d]", rc);
+		return rc;
+	}
+
+	/* Function set: fundamental command set (RE=0) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_FUNCTION_SET | cfg->func_n_bit);
+	if (rc < 0) {
+		LOG_ERR("Failed to set fundamental function set [%d]", rc);
+		return rc;
+	}
+
+	/* Clear display */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_CLEAR_DISPLAY);
+	if (rc < 0) {
+		LOG_ERR("Failed to clear display [%d]", rc);
+		return rc;
+	}
+	k_msleep(2); /* Required pause after clear display */
+
+	/* Set DDRAM address 0x00 (cursor home) */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_SET_DDRAM_ADDR);
+	if (rc < 0) {
+		LOG_ERR("Failed to set DDRAM address [%d]", rc);
+		return rc;
+	}
+
+	/* Display ON, cursor off, blink off */
+	rc = auxdisplay_us2066_command(dev, US2066_CMD_DISPLAY_CTRL | US2066_DISPLAY_ON);
+	if (rc < 0) {
+		LOG_ERR("Failed to turn display on [%d]", rc);
+		return rc;
+	}
+
+	data->power = true;
+	data->cursor = false;
+	data->blinking = false;
+	data->brightness = cfg->contrast;
+
+	k_msleep(100); /* Wait for stabilization after display on */
+
+	return 0;
+}
+
+/* API struct */
+static DEVICE_API(auxdisplay, auxdisplay_us2066_auxdisplay_api) = {
+	.display_on = auxdisplay_us2066_display_on,
+	.display_off = auxdisplay_us2066_display_off,
+	.cursor_set_enabled = auxdisplay_us2066_cursor_set_enabled,
+	.position_blinking_set_enabled = auxdisplay_us2066_position_blinking_set_enabled,
+	.cursor_position_set = auxdisplay_us2066_cursor_position_set,
+	.cursor_position_get = auxdisplay_us2066_cursor_position_get,
+	.capabilities_get = auxdisplay_us2066_capabilities_get,
+	.clear = auxdisplay_us2066_clear,
+	.brightness_get = auxdisplay_us2066_brightness_get,
+	.brightness_set = auxdisplay_us2066_brightness_set,
+	.write = auxdisplay_us2066_write,
+	.custom_command = auxdisplay_us2066_custom_command,
+};
+
+/* Device instantiation macros */
+#define AUXDISPLAY_US2066_COMMON_CONFIG(n)                                             \
+	.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),                   \
+	.io_voltage_mv = DT_INST_PROP(n, io_voltage_mv),                               \
+	.contrast = DT_INST_PROP(n, contrast),                                         \
+	.clock_divider = DT_INST_PROP(n, clock_divider),                               \
+	.clock_freq = DT_INST_PROP(n, clock_freq),                                     \
+	.phase1_period = DT_INST_PROP(n, phase1_period),                               \
+	.phase2_period = DT_INST_PROP(n, phase2_period),                               \
+	.vcomh_level = DT_INST_PROP(n, vcomh_level),                                   \
+	.func_n_bit = ((DT_INST_PROP(n, rows) == 2 || DT_INST_PROP(n, rows) == 4)      \
+			       ? US2066_FUNC_2_4_LINES                                     \
+			       : US2066_FUNC_1_3_LINES),                                   \
+	.func_nw_bit = ((DT_INST_PROP(n, rows) == 3 || DT_INST_PROP(n, rows) == 4)     \
+				? US2066_FUNC_EXT_LINES_3_4                                \
+				: US2066_FUNC_EXT_LINES_1_2),                              \
+	.font_width = (DT_INST_PROP(n, font_width) == 6)                               \
+			      ? US2066_FUNC_EXT_FONT_WIDTH_6                               \
+			      : US2066_FUNC_EXT_FONT_WIDTH_5,                              \
+	.cursor_invert = DT_INST_PROP_OR(n, cursor_invert, false)                      \
+				 ? US2066_FUNC_EXT_INVERT_ENABLE                       \
+				 : US2066_FUNC_EXT_INVERT_DISABLE,                     \
+	.entry_mode = ((DT_INST_PROP_OR(n, cursor_direction_left, false)               \
+				? US2066_ENTRY_DEC                                       \
+				: US2066_ENTRY_INC) |                                    \
+		       (DT_INST_PROP_OR(n, display_shift_on_write, false)                  \
+				? US2066_ENTRY_SHIFT                                     \
+				: US2066_ENTRY_NO_SHIFT)),                               \
+	.display_orientation = ((DT_INST_PROP_OR(n, display_rotate_180, false)         \
+					 ? US2066_ENTRY_BDS                            \
+					 : US2066_ENTRY_BDC) |                         \
+				(DT_INST_PROP_OR(n, display_mirror_horizontal, false)     \
+					 ? (US2066_ENTRY_BDC | US2066_ENTRY_BDS)       \
+					 : 0)),                                        \
+	.capabilities =                                                                \
+		{                                                                      \
+			.columns = DT_INST_PROP(n, columns),                           \
+			.rows = DT_INST_PROP(n, rows),                                 \
+			.mode = 0,                                                     \
+			.brightness.minimum = 0,                                       \
+			.brightness.maximum = 255,                                     \
+			.backlight.minimum = AUXDISPLAY_LIGHT_NOT_SUPPORTED,           \
+			.backlight.maximum = AUXDISPLAY_LIGHT_NOT_SUPPORTED,           \
+			.custom_characters = 0,                                        \
+			.custom_character_width = 0,                                   \
+			.custom_character_height = 0,                                  \
+		}
+
+#define AUXDISPLAY_US2066_DATA(name)                                                   \
+	static struct auxdisplay_us2066_data auxdisplay_us2066_data_##name = {         \
+		.power = true,                                                         \
+		.cursor = false,                                                       \
+		.blinking = false,                                                     \
+		.brightness = 0,                                                       \
+		.cursor_x = 0,                                                         \
+		.cursor_y = 0,                                                         \
+	}
+
+#define AUXDISPLAY_US2066_I2C_INST(n)                                                  \
+	static const struct auxdisplay_us2066_config auxdisplay_us2066_i2c_config_##n = {  \
+		.bus = &auxdisplay_us2066_i2c_bus,                                         \
+		.i2c = I2C_DT_SPEC_INST_GET(n),                                            \
+		AUXDISPLAY_US2066_COMMON_CONFIG(n),                                        \
+	};                                                                                 \
+	AUXDISPLAY_US2066_DATA(i2c_##n);                                                   \
+	DEVICE_DT_INST_DEFINE(n, &auxdisplay_us2066_init, NULL,                           \
+			      &auxdisplay_us2066_data_i2c_##n,                             \
+			      &auxdisplay_us2066_i2c_config_##n, POST_KERNEL,              \
+			      CONFIG_AUXDISPLAY_INIT_PRIORITY, &auxdisplay_us2066_auxdisplay_api);
+
+#define AUXDISPLAY_US2066_SPI_INST(n)                                                  \
+	static const struct auxdisplay_us2066_config auxdisplay_us2066_spi_config_##n = {  \
+		.bus = &auxdisplay_us2066_spi_bus,                                         \
+		.spi = SPI_DT_SPEC_INST_GET(                                               \
+			n, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8)),       \
+		AUXDISPLAY_US2066_COMMON_CONFIG(n),                                        \
+	};                                                                                 \
+	AUXDISPLAY_US2066_DATA(spi_##n);                                                   \
+	DEVICE_DT_INST_DEFINE(n, &auxdisplay_us2066_init, NULL,                           \
+			      &auxdisplay_us2066_data_spi_##n,                             \
+			      &auxdisplay_us2066_spi_config_##n, POST_KERNEL,              \
+			      CONFIG_AUXDISPLAY_INIT_PRIORITY, &auxdisplay_us2066_auxdisplay_api);
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT newhaven_us2066_i2c
+DT_INST_FOREACH_STATUS_OKAY(AUXDISPLAY_US2066_I2C_INST)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT newhaven_us2066_spi
+DT_INST_FOREACH_STATUS_OKAY(AUXDISPLAY_US2066_SPI_INST)

--- a/drivers/auxdisplay/auxdisplay_us2066.h
+++ b/drivers/auxdisplay/auxdisplay_us2066.h
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 Jasper Jonker
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_DRIVERS_AUXDISPLAY_AUXDISPLAY_US2066_H_
+#define ZEPHYR_DRIVERS_AUXDISPLAY_AUXDISPLAY_US2066_H_
+
+#include <stdint.h>
+
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * US2066 commands for auxdisplay_custom_command().
+ *
+ * The command is selected with auxdisplay_custom_data.options. The data payload
+ * is one byte for scroll enable, scroll quantity, shift enable, and display
+ * shift; two bytes for fade/blink and double-height; and empty for clear
+ * double-height.
+ */
+enum auxdisplay_us2066_custom_command {
+	AUXDISPLAY_US2066_CUSTOM_SET_SCROLL_ENABLE = 0,
+	AUXDISPLAY_US2066_CUSTOM_SET_SCROLL_QUANTITY = 1,
+	AUXDISPLAY_US2066_CUSTOM_SET_SHIFT_ENABLE = 2,
+	AUXDISPLAY_US2066_CUSTOM_DISPLAY_SHIFT = 3,
+	AUXDISPLAY_US2066_CUSTOM_SET_FADE_BLINK = 4,
+	AUXDISPLAY_US2066_CUSTOM_SET_DOUBLE_HEIGHT = 5,
+	AUXDISPLAY_US2066_CUSTOM_CLEAR_DOUBLE_HEIGHT = 6,
+};
+
+#define AUXDISPLAY_US2066_LINE_1                 BIT(0)
+#define AUXDISPLAY_US2066_LINE_2                 BIT(1)
+#define AUXDISPLAY_US2066_LINE_3                 BIT(2)
+#define AUXDISPLAY_US2066_LINE_4                 BIT(3)
+
+#define AUXDISPLAY_US2066_SCROLL_QUANTITY_MAX    48
+
+#define AUXDISPLAY_US2066_DISPLAY_SHIFT_LEFT     0
+#define AUXDISPLAY_US2066_DISPLAY_SHIFT_RIGHT    1
+
+#define AUXDISPLAY_US2066_DOUBLE_HEIGHT_LOWER    BIT(2)
+#define AUXDISPLAY_US2066_DOUBLE_HEIGHT_UPPER    BIT(3)
+
+#define AUXDISPLAY_US2066_FADE_BLINK_DISABLE     0x00
+#define AUXDISPLAY_US2066_FADE_OUT_ENABLE        0x20
+#define AUXDISPLAY_US2066_BLINK_ENABLE           0x30
+
+#define AUXDISPLAY_US2066_FADE_INTERVAL(n)       ((n) & 0x0F)
+#define AUXDISPLAY_US2066_FADE_INTERVAL_MAX      15
+
+#define AUXDISPLAY_US2066_FADE_8_FRAMES          0x00
+#define AUXDISPLAY_US2066_FADE_64_FRAMES         0x07
+#define AUXDISPLAY_US2066_FADE_128_FRAMES        0x0F
+
+/* --- Function Set to enable/disable RE and IS bits + extra --- */
+#define US2066_CMD_FUNCTION_SET          0x20   /* Base command */
+#define US2066_FUNC_IS_BASIC             0x00   /* Only when RE=0. IS=0: Fundamental command set */
+#define US2066_FUNC_IS_EXTENDED          BIT(0) /* Only when RE=0. IS=1: Extended command set */
+#define US2066_FUNC_RE_BASIC             0x00   /* Set RE=0: Basic instruction set */
+#define US2066_FUNC_RE_EXTENDED          BIT(1) /* Set RE=1: Extended instruction set */
+#define US2066_FUNC_1_3_LINES            0x00   /* Both RE=0 and RE=1 */
+#define US2066_FUNC_2_4_LINES            BIT(3) /* Both RE=0 and RE=1 */
+#define US2066_FUNC_DOUBLE_HEIGHT_ENABLE BIT(2) /* Only when RE=0 */
+#define US2066_FUNC_CGRAM_BLINK_ENABLE   BIT(2) /* Only when RE=1 */
+#define US2066_FUNC_REVERSE_DISPLAY      BIT(0) /* Only when RE=1 */
+
+/* --- Extended Function Set (RE=1 Required) --- */
+#define US2066_CMD_FUNCTION_SET_EXTENDED BIT(3) /* Base command */
+#define US2066_FUNC_EXT_FONT_WIDTH_6     BIT(2) /* 6-dot font width */
+#define US2066_FUNC_EXT_FONT_WIDTH_5     0x00   /* 5-dot font width */
+#define US2066_FUNC_EXT_INVERT_ENABLE    BIT(1) /* black/white inverting of cursor enable */
+#define US2066_FUNC_EXT_INVERT_DISABLE   0x00   /* black/white inverting of cursor disable */
+#define US2066_FUNC_EXT_LINES_3_4        BIT(0) /* 3/4 lines Display */
+#define US2066_FUNC_EXT_LINES_1_2        0x00   /* 1/2 lines Display */
+
+/* --- Function Selection A (RE=1) --- */
+#define US2066_CMD_FUNC_SELECTION_A      0x71 /* Command */
+#define US2066_FSA_VDD_5V                0x5C /* Enable internal regulator (5V I/O) */
+#define US2066_FSA_VDD_3V3               0x00 /* Disable internal VDD regulator (3V3 I/O) */
+
+/* --- Function Selection B (RE=1) --- */
+#define US2066_CMD_FUNC_SELECTION_B      0x72 /* Command */
+#define US2066_FSB_CGRAM_8_A             0x00 /* 240 CGROM, 8 CGRAM */
+#define US2066_FSB_CGRAM_8_B             0x01 /* 248 CGROM, 8 CGRAM */
+#define US2066_FSB_CGRAM_6               0x02 /* 250 CGROM, 6 CGRAM */
+#define US2066_FSB_CGRAM_0               0x03 /* 256 CGROM, 0 CGRAM (all ROM) */
+#define US2066_FSB_CGRAM_MASK            0x03
+
+#define US2066_FSB_ROM_A                 0x00 << 2 /* ROM A - Standard ASCII character set */
+#define US2066_FSB_ROM_B                 0x01 << 2 /* ROM B - Alternate character set */
+#define US2066_FSB_ROM_C                 0x02 << 2 /* ROM C - Alternate character set */
+#define US2066_FSB_ROM_MASK              0x03 << 2
+
+/* --- Function Selection C (RE=1) --- */
+#define US2066_OLED_FUNC_SELECTION_C     0xDC
+#define US2066_FSC_VSL_INTERNAL          0x00   /* Internal VSL (POR) */
+#define US2066_FSC_VSL_EXTERNAL          BIT(7) /* External VSL */
+
+#define US2066_FSC_GPIO_HIZ_INPUT_OFF    0x00 /* High-Z, input disabled (reads low) (POR) */
+#define US2066_FSC_GPIO_HIZ_INPUT_ON     0x01 /* High-Z, input enabled */
+#define US2066_FSC_GPIO_OUTPUT_LOW       0x02 /* GPIO outputs LOW */
+#define US2066_FSC_GPIO_OUTPUT_HIGH      0x03 /* GPIO outputs HIGH */
+
+/* --- Clear Display --- */
+#define US2066_CMD_CLEAR_DISPLAY         BIT(0)
+
+/* --- Return Home (RE=0) --- */
+#define US2066_CMD_RETURN_HOME           BIT(1)
+
+/* --- Entry Mode Set --- */
+#define US2066_CMD_ENTRY_MODE_SET        0x04 /* Base command */
+
+/* Entry Mode Flags (RE=0, Fundamental Command Set) - Controls cursor/text flow */
+#define US2066_ENTRY_INC                 BIT(1) /* Cursor moves right, DDRAM address increments */
+#define US2066_ENTRY_DEC                 0x00   /* Cursor moves left, DDRAM address decrements */
+#define US2066_ENTRY_SHIFT               BIT(0) /* Display shifts on character write */
+#define US2066_ENTRY_NO_SHIFT            0x00   /* Display stays still */
+
+/* Entry Mode Flags (RE=1, Extended Command Set) - Controls physical display orientation */
+#define US2066_ENTRY_BDC                 BIT(1) /* BDC=1: COM0->COM31, BDC=0: COM31->COM0 */
+#define US2066_ENTRY_BDS                 BIT(0) /* BDS=1: SEG0->SEG99, BDS=0: SEG99->SEG0 */
+
+/* --- Display ON/OFF Control (RE=0) --- */
+#define US2066_CMD_DISPLAY_CTRL          BIT(3) /* Base command */
+#define US2066_DISPLAY_BLINK_ON          BIT(0)
+#define US2066_DISPLAY_CURSOR_ON         BIT(1)
+#define US2066_DISPLAY_ON                BIT(2)
+
+/* --- Cursor or Display Shift (RE=0, IS=0) --- */
+#define US2066_CMD_CURSOR_SHIFT          BIT(4) /* Base command */
+#define US2066_SHIFT_DISPLAY             BIT(3) /* S/C=1: shift display */
+#define US2066_SHIFT_CURSOR              0x00   /* S/C=0: shift cursor */
+#define US2066_SHIFT_RIGHT               BIT(2) /* R/L=1: shift right */
+#define US2066_SHIFT_LEFT                0x00   /* R/L=0: shift left */
+
+/* --- Double Height (4- Line)/ Display-dot Shift (RE=1) --- */
+#define US2066_CMD_DH_DOT_SHIFT          BIT(4) /* Base command */
+#define US2066_DH_UD2                    BIT(3) /* UD2=1: upper part double height */
+#define US2066_DH_UD1                    BIT(2) /* UD1=1: lower part double height */
+#define US2066_DH_DISPLAY_SHIFT          BIT(0) /* DH’=1: display shift enable */
+#define US2066_DH_DOT_SHIFT              0x00   /* DH’=0: dot scroll enable (POR) */
+
+/* --- Shift Enable when DH'=1 (IS=1, RE=1) --- */
+#define US2066_CMD_SHIFT_ENABLE          BIT(4) /* Base command */
+#define US2066_SHIFT_DS4                 BIT(3) /* DS4=1 4th line display shift enable. */
+#define US2066_SHIFT_DS3                 BIT(2) /* DS3=1 3rd line display shift enable. */
+#define US2066_SHIFT_DS2                 BIT(1) /* DS2=1 2nd line display shift enable. */
+#define US2066_SHIFT_DS1                 BIT(0) /* DS1=1 1st line display shift enable. */
+
+/* --- Scroll Enable when DH'=0 (IS=1, RE=1) --- */
+#define US2066_CMD_SCROLL_ENABLE         BIT(5) /* Base command */
+#define US2066_SCROLL_HS4                BIT(3) /* HS4=1 4th line horizontal scroll enable. */
+#define US2066_SCROLL_HS3                BIT(2) /* HS3=1 3rd line horizontal scroll enable. */
+#define US2066_SCROLL_HS2                BIT(1) /* HS2=1 2nd line horizontal scroll enable. */
+#define US2066_SCROLL_HS1                BIT(0) /* HS1=1 1st line horizontal scroll enable. */
+#define US2066_SCROLL_QUANTITY_MAX       48     /* Max scroll quantity in pixels */
+
+/* --- Set CGRAM Address (IS=0, RE=0) --- */
+#define US2066_CMD_SET_CGRAM_ADDR        BIT(6)
+
+/* --- Set DDRAM Address (IS=0, RE=0) --- */
+#define US2066_CMD_SET_DDRAM_ADDR        BIT(7)
+
+/* --- Set Scroll Quantity (RE=1) --- */
+#define US2066_CMD_SET_SCROLL_QTY        BIT(7) /* Base command */
+
+/* --- OLED Characterization (RE=1) --- */
+#define US2066_CMD_OLED_DISABLE          0x78 /* SD=0 */
+#define US2066_CMD_OLED_ENABLE           0x79 /* SD=1 */
+
+/* --- Set Contrast Control (RE=1) --- */
+/*
+ * Double byte command to select 1 out of 256 contrast steps.
+ * Contrast increases as the value increases.  (POR = 7Fh )
+ */
+#define US2066_OLED_SET_CONTRAST         0x81
+
+/* --- Set Display Clock Divide Ratio / Oscillator Frequency (RE=1) --- */
+#define US2066_OLED_SET_DISPLAY_CLK      0xD5
+#define US2066_CLK_DIVIDER(div)          (((div) - 1) & 0x0F)   /* 1-16 as 0-15 */
+#define US2066_CLK_FREQ(freq)            (((freq) & 0x0F) << 4) /* 0-15 (POR=0111b) */
+
+/* --- Set Phase Length (RE=1) --- */
+#define US2066_OLED_SET_PHASE_LENGTH     0xD9
+#define US2066_PHASE1(val)               ((val) & 0x0F) /* Phase 1: 0-15 */
+#define US2066_PHASE2(val)               (((val) & 0x0F) << 4) /* Phase 2: 1-15 DCLKs (0 invalid) */
+
+/* --- Set SEG Pins Hardware Configuration (RE=1) --- */
+#define US2066_OLED_SET_SEG_PINS         0xDA
+
+/* SEG Pins Configuration Data Byte */
+#define US2066_SEG_PINS_SEQUENTIAL       0x00   /* Sequential COM pin configuration */
+#define US2066_SEG_PINS_ALTERNATIVE      BIT(4) /* Alternative COM pin configuration (0x10) */
+#define US2066_SEG_PINS_REMAP_OFF        0x00   /* Disable COM Left/Right remap (POR) */
+#define US2066_SEG_PINS_REMAP_ON         BIT(5) /* Enable COM Left/Right remap (0x20) */
+
+/* --- Set VCOMH Deselect Level (RE=1) --- */
+#define US2066_OLED_SET_VCOMH            0xDB
+#define US2066_VCOMH_0_65_VCC            0x00
+#define US2066_VCOMH_0_71_VCC            0x10
+#define US2066_VCOMH_0_77_VCC            0x20
+#define US2066_VCOMH_0_83_VCC            0x30
+#define US2066_VCOMH_1_00_VCC            0x40
+
+/* --- Set Fade Out and Blinking (RE=1) --- */
+#define US2066_OLED_SET_FADE_BLINK       0x23
+
+/* Fade/Blink Mode */
+#define US2066_FADE_BLINK_DISABLE        0x00 /* Normal display (POR) */
+#define US2066_FADE_OUT_ENABLE           0x20 /* Fade out to black */
+#define US2066_BLINK_ENABLE              0x30 /* Fade out then in, loop */
+
+/* Fade/Blink Interval (bits 3-0) - Frames per fade step */
+#define US2066_FADE_INTERVAL(n)          ((n) & 0x0F) /* n=0-15: (n+1)*8 frames */
+#define US2066_FADE_INTERVAL_MAX         15
+
+/* Common intervals */
+#define US2066_FADE_8_FRAMES             0x00 /* Fastest: 8 frames/step */
+#define US2066_FADE_64_FRAMES            0x07 /* Medium: 64 frames/step */
+#define US2066_FADE_128_FRAMES           0x0F /* Slowest: 128 frames/step */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_AUXDISPLAY_AUXDISPLAY_US2066_H_ */

--- a/dts/bindings/auxdisplay/newhaven,us2066-i2c.yaml
+++ b/dts/bindings/auxdisplay/newhaven,us2066-i2c.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2026 Jasper Jonker
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: Newhaven Display US2066 LCD (I2C)
+
+description: |
+  Newhaven Display US2066 character LCD using its I2C interface.
+
+compatible: "newhaven,us2066-i2c"
+
+include:
+  - name: i2c-device.yaml
+  - name: newhaven,us2066.yaml

--- a/dts/bindings/auxdisplay/newhaven,us2066-spi.yaml
+++ b/dts/bindings/auxdisplay/newhaven,us2066-spi.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2026 Jasper Jonker
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: Newhaven Display US2066 LCD (SPI)
+
+description: |
+  Newhaven Display US2066 character LCD using its SPI interface.
+
+compatible: "newhaven,us2066-spi"
+
+include:
+  - name: spi-device.yaml
+  - name: newhaven,us2066.yaml

--- a/dts/bindings/auxdisplay/newhaven,us2066.yaml
+++ b/dts/bindings/auxdisplay/newhaven,us2066.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2026 Jasper Jonker
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: Newhaven Display US2066 LCD common properties
+
+compatible: "newhaven,us2066"
+
+include: [auxdisplay-device.yaml]
+
+properties:
+  reset-gpios:
+    type: phandle-array
+    description: Optional GPIO connected to Reset (RST) of display
+
+  columns:
+    type: int
+    required: true
+    description: Number of character columns
+
+  rows:
+    type: int
+    required: true
+    description: |
+      Number of character rows (1, 2, 3, or 4 lines).
+    enum:
+      - 1
+      - 2
+      - 3
+      - 4
+
+  io-voltage-mv:
+    type: int
+    description: I/O voltage level in millivolts (3300 or 5000)
+    default: 3300
+    enum:
+      - 3300
+      - 5000
+
+  contrast:
+    type: int
+    description: Display contrast level (0-255)
+    default: 127
+
+  clock-divider:
+    type: int
+    description: Display clock divide ratio (1-16)
+    default: 1
+
+  clock-freq:
+    type: int
+    description: Oscillator frequency setting (0-15)
+    default: 7
+
+  phase1-period:
+    type: int
+    description: Phase 1 period in DCLKs (0=2 DCLKs, 1-15=1-15 DCLKs, up to 32 total)
+    default: 1
+
+  phase2-period:
+    type: int
+    description: Phase 2 period in DCLKs (1-15, 0 is invalid)
+    default: 15
+
+  vcomh-level:
+    type: int
+    description: VCOMH deselect level (0=0.65Vcc, 1=0.71Vcc, 2=0.77Vcc, 3=0.83Vcc, 4=1.0Vcc)
+    default: 4
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+
+  font-width:
+    type: int
+    description: Character font width in dots (5 or 6)
+    default: 5
+    enum:
+      - 5
+      - 6
+
+  cursor-invert:
+    type: boolean
+    description: Enable black/white inverting of cursor position
+
+  display-rotate-180:
+    type: boolean
+    description: |
+      Rotate display 180 degrees (hardware limitation: uses BDS bit only).
+      Useful when display is mounted upside down.
+      Note: This sets BDS which empirically produces a 180-degree rotation.
+
+  display-mirror-horizontal:
+    type: boolean
+    description: |
+      Mirror display horizontally (left-right flip only).
+      Hardware note: Sets both BDS and BDC bits to achieve horizontal mirroring.
+      This is a hardware quirk - single BDC bit has no effect on this display.
+
+  cursor-direction-left:
+    type: boolean
+    description: |
+      Cursor movement direction after writing a character (RE=0, I/D bit).
+      true: cursor moves left, DDRAM address decrements
+      false: cursor moves right, DDRAM address increments (default)
+
+  display-shift-on-write:
+    type: boolean
+    description: |
+      Enable automatic display shift when writing characters (RE=0, S bit).
+      true: entire display shifts on each character write (marquee effect)
+      false: only cursor moves, display content stays in place (default)

--- a/tests/drivers/build_all/auxdisplay/i2c_devices.overlay
+++ b/tests/drivers/build_all/auxdisplay/i2c_devices.overlay
@@ -41,6 +41,14 @@
 				columns = <16>;
 				rows = <2>;
 			};
+
+			test_us2066: us2066@3c {
+				compatible = "newhaven,us2066-i2c";
+				reg = <0x3c>;
+				status = "okay";
+				columns = <20>;
+				rows = <4>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
Add US2066 auxdisplay support over SPI and I2C.

Tested it with this [Newhaven Display NHD-0420CW-AB3](https://www.digikey.ch/en/products/detail/newhaven-display-intl/NHD-0420CW-AB3/5022951)

Example devicetree for i2c:
```dts
&i2c2 {
	status = "okay";
	clock-frequency = <I2C_BITRATE_FAST>;
	auxdisplay_0: us2066@3c {
		compatible = "newhaven,us2066-i2c";
		reg = <0x3c>;
		status = "okay";
		columns = <20>;
		rows = <4>;
		reset-gpios = <&gpioe 15 GPIO_ACTIVE_LOW>;
	};
};
```

Example devicetree for spi:
```dts
  &spi2 {
  	status = "okay";
  	cs-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;

  	auxdisplay_0: us2066@0 {
  		compatible = "newhaven,us2066-spi";
  		reg = <0>;
  		spi-max-frequency = <500000>;
  		columns = <20>;
  		rows = <4>;
  		reset-gpios = <&gpioe 15 GPIO_ACTIVE_LOW>;
  	};
  };
```

Small sample video:

https://github.com/user-attachments/assets/2a90ff87-7eef-4a25-ae19-e833a4832b3d