### PR TITLE
drivers: ethernet: nxp_enet: mask the interrupt status with EIMR

### DIFF
--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -529,7 +529,10 @@ static void eth_nxp_enet_isr(const struct device *dev)
 	struct nxp_enet_mac_data *data = dev->data;
 	unsigned int irq_lock_key = irq_lock();
 
-	uint32_t eir = ENET_GetInterruptStatus(data->base);
+	/* EIR reflects each source even where EIMR masks it off, so branching
+	 * on it alone re-enters branches for events the driver has disabled
+	 */
+	uint32_t eir = ENET_GetInterruptStatus(data->base) & data->base->EIMR;
 
 	if (eir & (kENET_RxFrameInterrupt | kENET_RxBufferInterrupt)) {
 		ENET_ReceiveIRQHandler(ENET_IRQ_HANDLER_ARGS(data->base, &data->enet_handle));


### PR DESCRIPTION
eth_nxp_enet_isr() branches on the raw EIR. EIR reflects each source even
where EIMR has masked it off, so a branch is taken for events the driver
has deliberately disabled.

The receive path relies on masking: it disables kENET_RxFrameInterrupt,
submits work, and re-enables only once the handler has drained the ring.
Until then every transmit interrupt re-enters the receive branch and
resubmits work that is already queued. Masking the status loses nothing,
since the interrupt line is itself EIR qualified by EIMR.

Found on an i.MX RT1176 while measuring the receive path; 25817 of 25825
entries to the receive branch were spurious. The waste is present in any
configuration and grows with the delay between submitting the work and
running it.