### PR TITLE
drivers: ethernet: nxp_enet: allow a preemptible RX thread

### DIFF
--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -61,11 +61,36 @@ config ETH_NXP_ENET_RX_THREAD_STACK_SIZE
 	help
 	  ENET RX thread stack size in bytes.
 
+choice ETH_NXP_ENET_RX_THREAD_TYPE
+	prompt "How the ENET RX thread should work"
+	default ETH_NXP_ENET_RX_THREAD_PREEMPTIVE if NET_TC_THREAD_PREEMPTIVE
+	default ETH_NXP_ENET_RX_THREAD_COOPERATIVE
+	help
+	  Please select the RX thread to be either pre-emptive or
+	  co-operative. The default follows NET_TC_THREAD_TYPE, so that the
+	  driver thread and the traffic class threads are of the same kind
+	  unless asked otherwise.
+
+config ETH_NXP_ENET_RX_THREAD_COOPERATIVE
+	bool "Use a co-operative RX thread"
+	depends on COOP_ENABLED
+	help
+	  With a co-operative thread, the thread cannot be pre-empted.
+
+config ETH_NXP_ENET_RX_THREAD_PREEMPTIVE
+	bool "Use a pre-emptive RX thread"
+	depends on PREEMPT_ENABLED
+	help
+	  With a pre-emptive thread, the thread can be pre-empted. This
+	  might reduce receive throughput.
+
+endchoice
+
 config ETH_NXP_ENET_RX_THREAD_PRIORITY
-	int "NXP ENET driver RX cooperative thread priority"
+	int "NXP ENET driver RX thread priority"
 	default 2
 	help
-	  ENET MAC Driver handles RX in cooperative workqueue thread.
+	  ENET MAC Driver handles RX in a workqueue thread.
 	  This options sets the priority of that thread.
 
 config ETH_NXP_ENET_RMII_EXT_CLK

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -116,6 +116,12 @@ struct nxp_enet_mac_data {
 static K_THREAD_STACK_DEFINE(enet_rx_stack, CONFIG_ETH_NXP_ENET_RX_THREAD_STACK_SIZE);
 static struct k_work_q rx_work_queue;
 
+#if defined(CONFIG_ETH_NXP_ENET_RX_THREAD_PREEMPTIVE)
+#define ENET_RX_THREAD_PRIORITY K_PRIO_PREEMPT(CONFIG_ETH_NXP_ENET_RX_THREAD_PRIORITY)
+#else
+#define ENET_RX_THREAD_PRIORITY K_PRIO_COOP(CONFIG_ETH_NXP_ENET_RX_THREAD_PRIORITY)
+#endif
+
 static int rx_queue_init(void)
 {
 	struct k_work_queue_config cfg = {.name = "ENET_RX"};
@@ -123,7 +129,7 @@ static int rx_queue_init(void)
 	k_work_queue_init(&rx_work_queue);
 	k_work_queue_start(&rx_work_queue, enet_rx_stack,
 			   K_THREAD_STACK_SIZEOF(enet_rx_stack),
-			   K_PRIO_COOP(CONFIG_ETH_NXP_ENET_RX_THREAD_PRIORITY),
+			   ENET_RX_THREAD_PRIORITY,
 			   &cfg);
 
 	return 0;


### PR DESCRIPTION
The RX workqueue thread is started with K_PRIO_COOP() and there is no
way to ask for anything else. A cooperative thread is never preempted,
so an application thread cannot be scheduled ahead of packet reception
whatever priority it is given: should_preempt() returns true only if the
current thread is itself preemptible, is already off the CPU, or the
incoming thread is a meta-IRQ.

This came up on an i.MX RT1170-EVK driving an SPI display, where the
application needs the display refresh to win over networking. A frame
write held at K_PRIO_PREEMPT(2) still lost to the RX thread at
K_PRIO_COOP(2), and no application-side priority could recover it.

The networking subsystem already offers this choice through
NET_TC_THREAD_TYPE. This adds the same one for the ENET RX thread, with
the same naming and the same COOP_ENABLED / PREEMPT_ENABLED
dependencies. The default stays cooperative, so existing configurations
are unaffected.

Selecting the preemptible class costs receive throughput while a higher
priority thread runs: on the same board a TCP stream that carried 30 MB
in 60 s carried 16-19 MB. Whether that is frames dropped at the MAC or
TCP backing off was not established.

Touches the same driver as #116382 but a different part of it; the two
are independent and do not conflict.