### PR TITLE
modules: hal_bouffalolab: Fix printf usage

### DIFF
--- a/modules/hal_bouffalolab/cmake/blob_objcopy.cmake
+++ b/modules/hal_bouffalolab/cmake/blob_objcopy.cmake
@@ -1,0 +1,13 @@
+# Copyright 2026 MASSDRIVER EI (massdriver.space)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+function(blob_objcopy name library)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}
+    COMMAND ${CMAKE_OBJCOPY} ${ARGN} ${library} ${name}
+  )
+  add_custom_target(${name}_target DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${name})
+  add_dependencies(zephyr_interface ${name}_target)
+  zephyr_link_libraries(${CMAKE_CURRENT_BINARY_DIR}/${name})
+endfunction()

--- a/modules/hal_bouffalolab/src/bl616cl/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl616cl/CMakeLists.txt
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+include("../../cmake/blob_objcopy.cmake")
+
 set(BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES})
 
 if(CONFIG_BT_BFLB_BL616CL)
@@ -26,15 +28,19 @@ if(CONFIG_WIFI_BFLB)
     set(MACSW_CFG_LIB libmacsw_config_bl616cl_default.a)
   endif()
 
-  message(STATUS "BL61x WiFi MACSW: ${MACSW_LIB}")
+  message(STATUS "BL61x WiFi MACSW: ${MACSW_CFG_LIB}")
 endif()
 
 if((CONFIG_BT_BFLB_BL616CL OR CONFIG_WIFI_BFLB) AND NOT CONFIG_BUILD_ONLY_NO_BLOBS)
+
+  # Replace blob's printf with blob_printf
+  set(BLOBS_OBJCOPY_ARGS --redefine-sym printf=blob_printf)
+
   # phyrf is shared between BLE and WiFi
-  zephyr_link_libraries(${BLOBS_DIR}/libbl616cl_phyrf.a)
+  blob_objcopy(phyrf.a "${BLOBS_DIR}/libbl616cl_phyrf.a" ${BLOBS_OBJCOPY_ARGS})
 
   if(CONFIG_BT_BFLB_BL616CL)
-    zephyr_link_libraries(${BLOBS_DIR}/${BLE_VARIANT_LIB})
+    blob_objcopy(${BLE_VARIANT_LIB} "${BLOBS_DIR}/${BLE_VARIANT_LIB}" ${BLOBS_OBJCOPY_ARGS})
   endif()
 
   if(CONFIG_WIFI_BFLB)
@@ -45,12 +51,9 @@ if((CONFIG_BT_BFLB_BL616CL OR CONFIG_WIFI_BFLB) AND NOT CONFIG_BUILD_ONLY_NO_BLO
       ${ZEPHYR_BASE}/kernel/timeout.c
     LOCATION RAM NOKEEP)
 
-
-    zephyr_link_libraries(
-      ${BLOBS_DIR}/libwl80211_bl616cl.a
-      ${BLOBS_DIR}/libmacsw_bl616cl.a
-      ${BLOBS_DIR}/${MACSW_CFG_LIB}
-    )
+    blob_objcopy(libwl80211.a "${BLOBS_DIR}/libwl80211_bl616cl.a" ${BLOBS_OBJCOPY_ARGS})
+    blob_objcopy(libmacsw.a "${BLOBS_DIR}/libmacsw_bl616cl.a" ${BLOBS_OBJCOPY_ARGS})
+    blob_objcopy(${MACSW_CFG_LIB} "${BLOBS_DIR}/${MACSW_CFG_LIB}" ${BLOBS_OBJCOPY_ARGS})
   endif()
 
 endif()

--- a/modules/hal_bouffalolab/src/bl61x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl61x/CMakeLists.txt
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+include("../../cmake/blob_objcopy.cmake")
+
 set(BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES})
 
 if(CONFIG_BT_BFLB_BL61X)
@@ -32,26 +34,28 @@ if(CONFIG_WIFI_BFLB)
     set(MACSW_CFG_LIB libmacsw_config_bl616_coex.a)
   endif()
 
-  message(STATUS "BL61x WiFi MACSW: ${MACSW_LIB}")
+  message(STATUS "BL61x WiFi MACSW: ${MACSW_CFG_LIB}")
 endif()
 
 if((CONFIG_BT_BFLB_BL61X OR CONFIG_WIFI_BFLB) AND NOT CONFIG_BUILD_ONLY_NO_BLOBS)
+
+  # Replace blob's printf with blob_printf
+  set(BLOBS_OBJCOPY_ARGS --redefine-sym printf=blob_printf)
+
   # phyrf is shared between BLE and WiFi
-  zephyr_link_libraries(${BLOBS_DIR}/libbl616_phyrf.a)
+  blob_objcopy(phyrf.a "${BLOBS_DIR}/libbl616_phyrf.a" ${BLOBS_OBJCOPY_ARGS})
 
   if(CONFIG_BT_BFLB_BL61X)
-    zephyr_link_libraries(${BLOBS_DIR}/${BLE_VARIANT_LIB})
+    blob_objcopy(${BLE_VARIANT_LIB} "${BLOBS_DIR}/${BLE_VARIANT_LIB}" ${BLOBS_OBJCOPY_ARGS})
   endif()
 
   if(CONFIG_WIFI_BFLB)
     # WiFi blobs are fat LTO objects with incompatible IR; disable LTO at link time
     zephyr_link_libraries($<TARGET_PROPERTY:compiler,prohibit_lto>)
 
-    zephyr_link_libraries(
-      ${BLOBS_DIR}/libwl80211_bl616.a
-      ${BLOBS_DIR}/libmacsw_bl616.a
-      ${BLOBS_DIR}/${MACSW_CFG_LIB}
-    )
+    blob_objcopy(libwl80211.a "${BLOBS_DIR}/libwl80211_bl616.a" ${BLOBS_OBJCOPY_ARGS})
+    blob_objcopy(libmacsw.a "${BLOBS_DIR}/libmacsw_bl616.a" ${BLOBS_OBJCOPY_ARGS})
+    blob_objcopy(${MACSW_CFG_LIB} "${BLOBS_DIR}/${MACSW_CFG_LIB}" ${BLOBS_OBJCOPY_ARGS})
   endif()
 
 endif()

--- a/soc/bflb/common/rf/wifi6/platform.c
+++ b/soc/bflb/common/rf/wifi6/platform.c
@@ -169,3 +169,17 @@ int macsw_hook_evt_disconnected(const char *f, ...)
 	ARG_UNUSED(f);
 	return 0;
 }
+
+__printf_like(1, 2) int blob_printf(const char *format, ...)
+{
+#ifdef CONFIG_LOG
+	va_list argptr;
+
+	va_start(argptr, format);
+	log_generic(LOG_LEVEL_INF, format, argptr);
+	va_end(argptr);
+#else
+	ARG_UNUSED(format);
+#endif
+	return 0;
+}


### PR DESCRIPTION
The blob uses printf, this crashes in many cases and is often unwelcome.

Remove printf privilege from the blob, take each blob static lib and edit the printf symbol to be blob_printf.
Add blob_printf log stub.

example of problem case:

```
Breakpoint 3, printf (fmt=0xa011b340 "macsw features: \r\n") at /home/vdragon/dev/micropython_v/shared/libc/printf.c:62
62          va_start(ap, fmt);
(gdb) n
63          int ret = mp_vprintf(MICROPY_INTERNAL_PRINTF_PRINTER, fmt, ap);
```

Blob using micropython printf before miropython streams are setup, immediate crash.