### PR TITLE
doc: dts: clarify that status "reserved" maps to disabled

### DIFF
--- a/doc/build/dts/intro-syntax-structure.rst
+++ b/doc/build/dts/intro-syntax-structure.rst
@@ -277,8 +277,12 @@ status
 
     The devicetree specification allows this property to have values
     ``"okay"``, ``"disabled"``, ``"reserved"``, ``"fail"``, and ``"fail-sss"``.
-    Only the values ``"okay"`` and ``"disabled"`` are currently relevant to
-    Zephyr; use of other values currently results in undefined behavior.
+    Zephyr treats any value other than ``"okay"`` as disabled. In particular,
+    ``"reserved"`` is used to document that a node exists but is enabled
+    elsewhere (e.g. by another core or domain in a multi-domain application);
+    it is handled the same as ``"disabled"`` by ``edtlib``. Use of the
+    remaining values (``"fail"`` and ``"fail-sss"``) is not currently
+    supported by Zephyr.
 
     A node is considered enabled if its status property is either ``"okay"`` or
     not defined (i.e. does not exist in the devicetree source). Nodes with

--- a/doc/build/dts/intro-syntax-structure.rst
+++ b/doc/build/dts/intro-syntax-structure.rst
@@ -282,7 +282,7 @@ status
     elsewhere (e.g. by another core or domain in a multi-domain application);
     it is handled the same as ``"disabled"`` by ``edtlib``. Use of the
     remaining values (``"fail"`` and ``"fail-sss"``) is not currently
-    supported by Zephyr.
+    used by Zephyr.
 
     A node is considered enabled if its status property is either ``"okay"`` or
     not defined (i.e. does not exist in the devicetree source). Nodes with


### PR DESCRIPTION
Fixes: #116295

The `status` section of Important Properties stated that values other than `"okay"`/`"disabled"` result in undefined behavior. In practice `edtlib` treats `"reserved"` as disabled (any value other than `"okay"` is not enabled), and the tree already uses `status = "reserved"` in 51 files to document nodes that exist but are enabled elsewhere (e.g. another core/domain in multi-domain applications).

Update the docs to state that non-`"okay"` values are treated as disabled, describe the conventional use of `"reserved"`, and note that `"fail"`/`"fail-sss"` are not currently supported.

No code change; docs only.