### PR TITLE
logging: align stack packages when stack alignment is insufficient

### DIFF
--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -23,6 +23,20 @@ BUILD_ASSERT(sizeof(struct log_msg_desc) == sizeof(uint32_t),
 
 #define CBPRINTF_DESC_SIZE32 (sizeof(struct cbprintf_package_desc) / sizeof(uint32_t))
 
+/*
+ * cbvprintf_package() requires its buffer to be aligned at least to the size
+ * of a pointer. Avoid alignment arithmetic when the stack already provides
+ * that guarantee.
+ *
+ * Use the logging alignment for the fallback so the package address matches
+ * the alignment assumed when its size was calculated.
+ */
+#define LOG_MSG_ALIGNED_ALLOCA(_size)                                                              \
+	(IS_ALIGNED(ARCH_STACK_PTR_ALIGN, sizeof(void *))                                          \
+		 ? alloca(_size)                                                                   \
+		 : (void *)ROUND_UP((uintptr_t)alloca((_size) + Z_LOG_MSG_ALIGNMENT - 1U),         \
+				    Z_LOG_MSG_ALIGNMENT))
+
 /* For simplified message handling cprintf package must have only 1 word. */
 BUILD_ASSERT(!IS_ENABLED(CONFIG_LOG_SIMPLE_MSG_OPTIMIZE) ||
 	     (IS_ENABLED(CONFIG_LOG_SIMPLE_MSG_OPTIMIZE) && (CBPRINTF_DESC_SIZE32 == 1)));
@@ -398,19 +412,19 @@ void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 		Z_LOG_MSG_DESC_INITIALIZER(domain_id, level, plen, dlen);
 
 	if (k_is_user_context()) {
-		pkg = alloca(plen);
+		pkg = LOG_MSG_ALIGNED_ALLOCA(plen);
 		msg = NULL;
 	} else if (IS_ENABLED(CONFIG_LOG_MODE_DEFERRED) && BACKENDS_IN_USE()) {
 		compiler_barrier();
 		msg = z_log_msg_alloc(msg_wlen);
 		if (IS_ENABLED(CONFIG_LOG_FRONTEND) && msg == NULL) {
-			pkg = alloca(plen);
+			pkg = LOG_MSG_ALIGNED_ALLOCA(plen);
 		} else {
 			pkg = msg ? msg->data : NULL;
 		}
 	} else {
 		compiler_barrier();
-		msg = alloca(msg_wlen * sizeof(int));
+		msg = LOG_MSG_ALIGNED_ALLOCA(msg_wlen * sizeof(int));
 		pkg = msg->data;
 	}
 


### PR DESCRIPTION
This change is a prerequisite for the m68k port proposed in RFC #114672.

Runtime logging sometimes builds a temporary `cbprintf` package on the current thread's stack using `alloca()`. `cbvprintf_package()` explicitly comments that its buffer “must be aligned at least to size of a pointer” and returns `-EFAULT` otherwise.

That requirement usually follows from the architecture's stack alignment. m68k is the counterexample: its ABI permits 2-byte stack alignment while pointers are 4 bytes. A legal stack can therefore make `alloca()` return an address at `2 mod 4`. Packaging then fails, and runtime logging panics on its `plen >= 0` assertion.

The fix selects the allocation path at compile time. Architectures whose stack already guarantees pointer alignment retain plain `alloca()` and unchanged generated code. Otherwise, all three stack-backed paths reserve alignment slack and round the allocation to `Z_LOG_MSG_ALIGNMENT`. Pointer alignment determines whether the fallback is needed; when it is, aligning to `Z_LOG_MSG_ALIGNMENT` makes the real package match the alignment assumed by logging’s preceding size calculation.