### PR TITLE
dts: bindings: correct ti,ina7xx inatype documentation

### DIFF
--- a/dts/bindings/sensor/ti,ina7xx.yaml
+++ b/dts/bindings/sensor/ti,ina7xx.yaml
@@ -13,9 +13,9 @@ properties:
     required: true
     description: |
       select type of INA7xx device.
-      1 = INA700
-      2 = INA745/746
-      3 = INA780/781
+      0 = INA700
+      1 = INA745/746
+      2 = INA780/781
     enum:
       - 0
       - 1


### PR DESCRIPTION
The `inatype` binding descriptions use one-based values, while the binding enum and driver mapping are zero-based. Correct the descriptions so valid devicetree configurations select the expected device type.

Fixes #116194