### PR TITLE
Bluetooth: Controller: Use PHY flags for Coded PHY

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -720,6 +720,11 @@ static uint8_t sw_tifs_toggle;
  * PPIs related with the Radio operation switch.
  * Enable of end event compensation is controller by @p end_evt_delay_en.
  *
+ * On an RX-to-TX switch, flags for the received PHY are unused. For Coded
+ * PHY, the radio hardware determines whether the received PDU used S2 or S8
+ * and adjusts TIFS using the S2-event PPI/DPPI configuration. The flags for
+ * the following TX PHY select its coding scheme.
+ *
  * @param dir_curr         Current direction the Radio is working: SW_SWITCH_TX or SW_SWITCH_RX
  * @param dir_next         Next direction the Radio is preparing for: SW_SWITCH_TX or SW_SWITCH_RX
  * @param phy_curr         PHY the Radio is working on.
@@ -769,7 +774,7 @@ void sw_switch(uint8_t dir_curr, uint8_t dir_next, uint8_t phy_curr, uint8_t fla
 			delay = HAL_RADIO_NS2US_ROUND(
 			    hal_radio_tx_ready_delay_ns_get(phy_next,
 							    flags_next) +
-			    hal_radio_rx_chain_delay_ns_get(phy_curr, 1));
+			    hal_radio_rx_chain_delay_ns_get(phy_curr, PHY_FLAGS_S8));
 
 			hal_radio_txen_on_sw_switch(cc, ppi);
 		}
@@ -811,7 +816,7 @@ void sw_switch(uint8_t dir_curr, uint8_t dir_next, uint8_t phy_curr, uint8_t fla
 			delay_s2 = HAL_RADIO_NS2US_ROUND(
 				hal_radio_tx_ready_delay_ns_get(phy_next,
 								flags_next) +
-				hal_radio_rx_chain_delay_ns_get(phy_curr, 0));
+				hal_radio_rx_chain_delay_ns_get(phy_curr, PHY_FLAGS_S2));
 
 			new_cc_s2_value = SW_SWITCH_TIMER->CC[cc];
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1207,9 +1207,12 @@ static void isr_tx(void *param)
 	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US +
 	       (EVENT_CLOCK_JITTER_US << 1) + RANGE_DELAY_US +
 	       HAL_RADIO_TMR_START_DELAY_US;
-	hcto += radio_rx_chain_delay_get(phy_p, PHY_FLAGS_UNUSED);
+	/* RX delay uses the worst-case S8 coded reception; TX delay uses
+	 * the selected advertising coding scheme.
+	 */
+	hcto += radio_rx_chain_delay_get(phy_p, PHY_FLAGS_S8);
 	hcto += addr_us_get(phy_p);
-	hcto -= radio_tx_chain_delay_get(phy_p, PHY_FLAGS_UNUSED);
+	hcto -= radio_tx_chain_delay_get(phy_p, phy_flags);
 	radio_tmr_hcto_configure(hcto);
 
 	/* capture end of CONNECT_IND PDU, used for calculating first
@@ -1232,7 +1235,7 @@ static void isr_tx(void *param)
 
 	radio_gpio_lna_setup();
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
-				 radio_tx_chain_delay_get(phy_p, PHY_FLAGS_UNUSED) -
+				 radio_tx_chain_delay_get(phy_p, phy_flags) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1174,7 +1174,7 @@ static void isr_tx(void *param)
 
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
-	radio_switch_complete_and_tx(phy_p, 0, phy_p, phy_flags);
+	radio_switch_complete_and_tx(phy_p, PHY_FLAGS_UNUSED, phy_p, phy_flags);
 
 	/* setup Rx buffer */
 	node_rx = ull_pdu_rx_alloc_peek(1);
@@ -1207,9 +1207,9 @@ static void isr_tx(void *param)
 	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US +
 	       (EVENT_CLOCK_JITTER_US << 1) + RANGE_DELAY_US +
 	       HAL_RADIO_TMR_START_DELAY_US;
-	hcto += radio_rx_chain_delay_get(phy_p, 0);
+	hcto += radio_rx_chain_delay_get(phy_p, PHY_FLAGS_UNUSED);
 	hcto += addr_us_get(phy_p);
-	hcto -= radio_tx_chain_delay_get(phy_p, 0);
+	hcto -= radio_tx_chain_delay_get(phy_p, PHY_FLAGS_UNUSED);
 	radio_tmr_hcto_configure(hcto);
 
 	/* capture end of CONNECT_IND PDU, used for calculating first
@@ -1232,7 +1232,7 @@ static void isr_tx(void *param)
 
 	radio_gpio_lna_setup();
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
-				 radio_tx_chain_delay_get(phy_p, 0) -
+				 radio_tx_chain_delay_get(phy_p, PHY_FLAGS_UNUSED) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -599,7 +599,8 @@ static void isr_tx_rx(void *param)
 
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
-	radio_switch_complete_and_tx(lll->phy_s, 0, lll->phy_s, lll->phy_flags);
+	radio_switch_complete_and_tx(lll->phy_s, PHY_FLAGS_UNUSED, lll->phy_s,
+				     lll->phy_flags);
 
 	/* setup Rx buffer */
 	node_rx = ull_pdu_rx_alloc_peek(1);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -599,6 +599,9 @@ static void isr_tx_rx(void *param)
 
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
+	/* The RX coding is determined by the radio; TX uses the selected
+	 * advertising coding scheme.
+	 */
 	radio_switch_complete_and_tx(lll->phy_s, PHY_FLAGS_UNUSED, lll->phy_s,
 				     lll->phy_flags);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -249,7 +249,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN)
 	radio_gpio_pa_setup();
 
-	radio_gpio_pa_lna_enable(start_us + radio_tx_ready_delay_get(phy_s, 1) -
+	radio_gpio_pa_lna_enable(start_us + radio_tx_ready_delay_get(phy_s, lll->adv->phy_flags) -
 				 HAL_RADIO_GPIO_PA_OFFSET);
 #else /* !HAL_RADIO_GPIO_HAVE_PA_PIN */
 	ARG_UNUSED(start_us);
@@ -432,7 +432,7 @@ static void isr_tx(void *param)
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
 				 EVENT_SYNC_B2B_MAFS_US -
 				 (EVENT_CLOCK_JITTER_US << 1) + cte_len_us -
-				 radio_tx_chain_delay_get(lll->phy_s, 0) -
+				 radio_tx_chain_delay_get(lll->phy_s, lll->adv->phy_flags) -
 				 HAL_RADIO_GPIO_PA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_PA_PIN */
 
@@ -532,11 +532,13 @@ static void switch_radio_complete_and_b2b_tx(const struct lll_adv_sync *lll,
 {
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 	if (lll->cte_started) {
-		radio_switch_complete_and_phy_end_b2b_tx(phy_s, 0, phy_s, 0);
+		radio_switch_complete_and_phy_end_b2b_tx(phy_s, lll->adv->phy_flags, phy_s,
+							 lll->adv->phy_flags);
 	} else
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 	{
-		radio_switch_complete_and_b2b_tx(phy_s, 0, phy_s, 0);
+		radio_switch_complete_and_b2b_tx(phy_s, lll->adv->phy_flags, phy_s,
+						 lll->adv->phy_flags);
 	}
 }
 #endif /* CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -708,7 +708,8 @@ void lll_conn_isr_tx(void *param)
 	/* Use special API for SOC that requires compensation for PHYEND event delay. */
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_with_delay_compensation_and_tx(lll->phy_rx, 0, lll->phy_tx,
+	radio_switch_complete_with_delay_compensation_and_tx(lll->phy_rx,
+							     PHY_FLAGS_UNUSED, lll->phy_tx,
 							     lll->phy_flags, end_evt_delay);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_switch_complete_with_delay_compensation_and_tx(0, 0, 0, 0, end_evt_delay);
@@ -723,9 +724,10 @@ void lll_conn_isr_tx(void *param)
  */
 #if !defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_and_tx(lll->phy_rx, 0, lll->phy_tx, lll->phy_flags);
+	radio_switch_complete_and_tx(lll->phy_rx, PHY_FLAGS_UNUSED, lll->phy_tx,
+				     lll->phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
-	radio_switch_complete_and_tx(0, 0, 0, 0);
+	radio_switch_complete_and_tx(PHY_LEGACY, PHY_FLAGS_UNUSED, PHY_LEGACY, PHY_FLAGS_UNUSED);
 #endif /* !CONFIG_BT_CTLR_PHY */
 #endif /* !CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
@@ -774,7 +776,7 @@ void lll_conn_isr_tx(void *param)
 	hcto += cte_len;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
 #if defined(CONFIG_BT_CTLR_PHY)
-	hcto += radio_rx_chain_delay_get(lll->phy_rx, 1);
+	hcto += radio_rx_chain_delay_get(lll->phy_rx, PHY_FLAGS_S8);
 	hcto += addr_us_get(lll->phy_rx);
 	hcto -= radio_tx_chain_delay_get(lll->phy_tx, lll->phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
@@ -864,7 +866,7 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	phy = 0U;
 #endif /* !CONFIG_BT_CTLR_PHY */
 
-	radio_phy_set(phy, 0);
+	radio_phy_set(phy, PHY_FLAGS_UNUSED);
 
 	if (0) {
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -866,7 +866,7 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	phy = 0U;
 #endif /* !CONFIG_BT_CTLR_PHY */
 
-	radio_phy_set(phy, PHY_FLAGS_UNUSED);
+	radio_phy_set(phy, PHY_FLAGS_S8);
 
 	if (0) {
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -245,7 +245,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 /* Use special API for SOC that requires compensation for PHYEND event delay. */
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_with_delay_compensation_and_tx(lll->phy_rx, 0, lll->phy_tx,
+	radio_switch_complete_with_delay_compensation_and_tx(lll->phy_rx,
+							     PHY_FLAGS_UNUSED, lll->phy_tx,
 							     lll->phy_flags, end_evt_delay);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_switch_complete_with_delay_compensation_and_tx(0, 0, 0, 0, end_evt_delay);
@@ -260,7 +261,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	 */
 	if (!IS_ENABLED(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)) {
 #if defined(CONFIG_BT_CTLR_PHY)
-		radio_switch_complete_and_tx(lll->phy_rx, 0, lll->phy_tx, lll->phy_flags);
+		radio_switch_complete_and_tx(lll->phy_rx, PHY_FLAGS_UNUSED, lll->phy_tx,
+					     lll->phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY && !CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 		radio_switch_complete_and_tx(0, 0, 0, 0);
 #endif /* !CONFIG_BT_CTLR_PHY */
@@ -290,9 +292,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	       lll->periph.window_size_event_us;
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	hcto += radio_rx_ready_delay_get(lll->phy_rx, 1);
+	hcto += radio_rx_ready_delay_get(lll->phy_rx, PHY_FLAGS_S8);
 	hcto += addr_us_get(lll->phy_rx);
-	hcto += radio_rx_chain_delay_get(lll->phy_rx, 1);
+	hcto += radio_rx_chain_delay_get(lll->phy_rx, PHY_FLAGS_S8);
 #else /* !CONFIG_BT_CTLR_PHY */
 	hcto += radio_rx_ready_delay_get(0, 0);
 	hcto += addr_us_get(0);
@@ -306,7 +308,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_gpio_pa_lna_enable(remainder_us +
-				 radio_rx_ready_delay_get(lll->phy_rx, 1) -
+				 radio_rx_ready_delay_get(lll->phy_rx, PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_gpio_pa_lna_enable(remainder_us +

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -275,7 +275,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_tmr_tifs_set(cis_lll->tifs_us);
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_and_tx(cis_lll->rx.phy, 0U, cis_lll->tx.phy,
+	radio_switch_complete_and_tx(cis_lll->rx.phy, PHY_FLAGS_UNUSED, cis_lll->tx.phy,
 				     cis_lll->tx.phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_switch_complete_and_tx(0U, 0U, 0U, 0U);
@@ -974,7 +974,7 @@ static void isr_tx(void *param)
 	radio_tmr_tifs_set(cis_lll->tifs_us);
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_and_tx(cis_lll->rx.phy, 0U, cis_lll->tx.phy,
+	radio_switch_complete_and_tx(cis_lll->rx.phy, PHY_FLAGS_UNUSED, cis_lll->tx.phy,
 				     cis_lll->tx.phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_switch_complete_and_tx(0U, 0U, 0U, 0U);
@@ -1207,7 +1207,7 @@ static void isr_prepare_subevent_common(void *param)
 	radio_tmr_tifs_set(cis_lll->tifs_us);
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_and_tx(cis_lll->rx.phy, 0U, cis_lll->tx.phy,
+	radio_switch_complete_and_tx(cis_lll->rx.phy, PHY_FLAGS_UNUSED, cis_lll->tx.phy,
 				     cis_lll->tx.phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_switch_complete_and_tx(0U, 0U, 0U, 0U);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -320,7 +320,7 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	/* TODO: for passive scanning use complete_and_disable */
-	radio_switch_complete_and_tx(phy_aux, 0, phy_aux, 1);
+	radio_switch_complete_and_tx(phy_aux, PHY_FLAGS_UNUSED, phy_aux, PHY_FLAGS_S8);
 
 	/* TODO: skip filtering if AdvA was already found in previous PDU */
 
@@ -524,7 +524,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	/* TODO: for passive scanning use complete_and_disable */
-	radio_switch_complete_and_tx(lll_aux->phy, 0, lll_aux->phy, 1);
+	radio_switch_complete_and_tx(lll_aux->phy, PHY_FLAGS_UNUSED, lll_aux->phy,
+				     PHY_FLAGS_S8);
 
 	/* TODO: skip filtering if AdvA was already found in previous PDU */
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -349,10 +349,10 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */
-	radio_phy_set(lll->phy_p, 1);
+	radio_phy_set(lll->phy_p, PHY_FLAGS_S8);
 	radio_pkt_configure(8, PDU_AC_LEG_PAYLOAD_SIZE_MAX, (lll->phy_p << 1));
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
-	radio_phy_set(0, 0);
+	radio_phy_set(PHY_LEGACY, PHY_FLAGS_UNUSED);
 	radio_pkt_configure(8, PDU_AC_LEG_PAYLOAD_SIZE_MAX, 0);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
@@ -259,7 +259,7 @@ void lll_conn_isr_rx(void *param)
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US -
-				 radio_rx_chain_delay_get(lll->phy_rx, 1) -
+				 radio_rx_chain_delay_get(lll->phy_rx, PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_PA_OFFSET);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US -
@@ -347,7 +347,7 @@ void lll_conn_isr_tx(void *param)
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_and_tx(lll->phy_rx, 0,
+	radio_switch_complete_and_tx(lll->phy_rx, PHY_FLAGS_UNUSED,
 				     lll->phy_tx,
 				     lll->phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
@@ -363,7 +363,7 @@ void lll_conn_isr_tx(void *param)
 	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 +
 		RANGE_DELAY_US + 1;
 #if defined(CONFIG_BT_CTLR_PHY)
-	hcto += radio_rx_chain_delay_get(lll->phy_rx, 1);
+	hcto += radio_rx_chain_delay_get(lll->phy_rx, PHY_FLAGS_S8);
 	hcto += addr_us_get(lll->phy_rx);
 	hcto -= radio_tx_chain_delay_get(lll->phy_tx, lll->phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
@@ -436,7 +436,7 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	phy = 0U;
 #endif /* !CONFIG_BT_CTLR_PHY */
 
-	radio_phy_set(phy, 0);
+	radio_phy_set(phy, PHY_FLAGS_UNUSED);
 
 	if (0) {
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
@@ -436,7 +436,7 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	phy = 0U;
 #endif /* !CONFIG_BT_CTLR_PHY */
 
-	radio_phy_set(phy, PHY_FLAGS_UNUSED);
+	radio_phy_set(phy, PHY_FLAGS_S8);
 
 	if (0) {
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
@@ -175,7 +175,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_tmr_tifs_set(EVENT_IFS_US);
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_switch_complete_and_tx(lll->phy_rx, 0, lll->phy_tx,
+	radio_switch_complete_and_tx(lll->phy_rx, PHY_FLAGS_UNUSED, lll->phy_tx,
 				     lll->phy_flags);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_switch_complete_and_tx(0, 0, 0, 0);
@@ -199,9 +199,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	       lll->periph.window_size_event_us;
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	hcto += radio_rx_ready_delay_get(lll->phy_rx, 1);
+	hcto += radio_rx_ready_delay_get(lll->phy_rx, PHY_FLAGS_S8);
 	hcto += addr_us_get(lll->phy_rx);
-	hcto += radio_rx_chain_delay_get(lll->phy_rx, 1);
+	hcto += radio_rx_chain_delay_get(lll->phy_rx, PHY_FLAGS_S8);
 #else /* !CONFIG_BT_CTLR_PHY */
 	hcto += radio_rx_ready_delay_get(0, 0);
 	hcto += addr_us_get(0);
@@ -215,7 +215,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_gpio_pa_lna_enable(remainder_us +
-				 radio_rx_ready_delay_get(lll->phy_rx, 1) -
+				 radio_rx_ready_delay_get(lll->phy_rx, PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_gpio_pa_lna_enable(remainder_us +

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -156,7 +156,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */
-	radio_phy_set(lll->phy, 1);
+	radio_phy_set(lll->phy, PHY_FLAGS_S8);
 	radio_pkt_configure(8, PDU_AC_LEG_PAYLOAD_SIZE_MAX, (lll->phy << 1));
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 	radio_phy_set(0, 0);

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -279,12 +279,12 @@
  * for packet formats and thus lengths
  */
 
-#define PHY_LEGACY       0
+#define PHY_LEGACY       0U
 #define PHY_1M           BIT(0)
 #define PHY_2M           BIT(1)
 #define PHY_CODED        BIT(2)
-#define PHY_FLAGS_UNUSED 0
-#define PHY_FLAGS_S2     0
+#define PHY_FLAGS_UNUSED 0U
+#define PHY_FLAGS_S2     0U
 #define PHY_FLAGS_S8     BIT(0)
 
 /* Macros for getting/setting did/sid from pdu_adv_adi */

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -279,12 +279,13 @@
  * for packet formats and thus lengths
  */
 
-#define PHY_LEGACY   0
-#define PHY_1M       BIT(0)
-#define PHY_2M       BIT(1)
-#define PHY_CODED    BIT(2)
-#define PHY_FLAGS_S2 0
-#define PHY_FLAGS_S8 BIT(0)
+#define PHY_LEGACY       0
+#define PHY_1M           BIT(0)
+#define PHY_2M           BIT(1)
+#define PHY_CODED        BIT(2)
+#define PHY_FLAGS_UNUSED 0
+#define PHY_FLAGS_S2     0
+#define PHY_FLAGS_S8     BIT(0)
 
 /* Macros for getting/setting did/sid from pdu_adv_adi */
 #define PDU_ADV_ADI_DID_GET(adi) ((adi)->did_sid_packed[0] | \


### PR DESCRIPTION
## Description

Replace literal Coded-PHY flag arguments with the existing `PHY_FLAGS_S2` and `PHY_FLAGS_S8` constants throughout the Nordic and OpenISA controller paths. Receiver-side switch arguments whose coding is determined by the radio hardware now use `PHY_FLAGS_UNUSED`, while Coded-PHY timing paths pass the selected coding flags where those flags drive timing.

The Nordic `sw_switch()` implementation is documented to explain why RX-to-TX switching ignores the received PHY flags, and the zero-valued PHY macros now use unsigned literals.

Part of #37458

## Testing

- `scripts/checkpatch.pl --git origin/main..HEAD`
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/ci/check_compliance.py -c origin/main..HEAD -m Gitlint -m ClangFormat -m Checkpatch -m GitDiffCheck`
- `.venv/bin/python scripts/ci/check_compliance.py -c origin/main..HEAD -e Ruff -p 0`
  - `Ruff` was excluded locally because the local toolchain reports unrelated existing Python issues outside this PR's Bluetooth changes.
- `.venv/bin/west build -p always -b nrf52840dk/nrf52840 samples/bluetooth/hci_uart -d /private/tmp/zephyr-build-hci-uart-nrf52840-coded -- -DEXTRA_CONF_FILE=overlay-all-bt_ll_sw_split.conf`