### PR TITLE
logging: log_mgmt: Fix link name buffer types

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -229,7 +229,7 @@ static const char *link_source_name_get(uint8_t domain_id, uint32_t source_id)
 		__ASSERT_NO_MSG(link != NULL);
 
 		err = log_link_get_source_name(link, rel_domain_id, source_id,
-					       cached, &cache_size);
+					       (char *)cached, &cache_size);
 		if (err < 0) {
 			log_cache_release(&sname_cache, cached);
 			return NULL;
@@ -277,7 +277,8 @@ static const char *link_domain_name_get(uint8_t domain_id)
 
 		__ASSERT_NO_MSG(link != NULL);
 
-		err = log_link_get_domain_name(link, rel_domain_id, cached, &cache_size);
+		err = log_link_get_domain_name(link, rel_domain_id, (char *)cached,
+					       &cache_size);
 		if (err < 0) {
 			log_cache_release(&dname_cache, cached);
 			return invalid_domain;


### PR DESCRIPTION
## Description

Cast the cache byte buffers at the `log_link_get_source_name()` and `log_link_get_domain_name()` text API boundaries. This preserves the `uint8_t *` cache interface while satisfying the `char *` text API contract and removes the related pointer-sign warnings.

Part of #8921

## Testing

- `perl scripts/checkpatch.pl -g HEAD^..HEAD`
- `git diff --check`

A target build was not run because `west` is not installed in this checkout.