### PR TITLE
drivers: dac: Align Kconfig prompts with style guide

### DIFF
--- a/drivers/dac/Kconfig.ltc166x
+++ b/drivers/dac/Kconfig.ltc166x
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_LTC166X
-	bool "Linear Technology LTC166X DAC"
+	bool "Linear Technology LTC166X DAC driver"
 	default y
 	select SPI
 	depends on DT_HAS_LLTC_LTC1660_ENABLED || DT_HAS_LLTC_LTC1665_ENABLED

--- a/drivers/dac/Kconfig.max22017
+++ b/drivers/dac/Kconfig.max22017
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_MAX22017
-	bool "Analog Devices MAX22017 DAC"
+	bool "Analog Devices MAX22017 DAC driver"
 	default y
 	depends on DT_HAS_ADI_MAX22017_DAC_ENABLED
 	select MFD

--- a/drivers/dac/Kconfig.mchp
+++ b/drivers/dac/Kconfig.mchp
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_MCHP_G1
-	bool "Microchip G1 DAC Driver"
+	bool "Microchip G1 DAC driver"
 	depends on DT_HAS_MICROCHIP_DAC_G1_ENABLED
 	default y
 	select PINCTRL
@@ -40,7 +40,7 @@ config DAC_MCHP_G1_OVERSAMPLING_RATIO
 endif # DAC_MCHP_G1
 
 config DAC_MCHP_G2
-	bool "Microchip G2 DAC Driver"
+	bool "Microchip G2 DAC driver"
 	depends on DT_HAS_MICROCHIP_DAC_G2_ENABLED
 	default y
 	select PINCTRL

--- a/drivers/dac/Kconfig.mspm0
+++ b/drivers/dac/Kconfig.mspm0
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_MSPM0
-	bool "TI MSPM0 Digital To Analog Converter (DAC) Driver"
+	bool "TI MSPM0 DAC driver"
 	default y
 	depends on DT_HAS_TI_MSPM0_DAC_ENABLED
 	select USE_MSPM0_DL_DAC12

--- a/drivers/dac/Kconfig.renesas_ra
+++ b/drivers/dac/Kconfig.renesas_ra
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_RENESAS_RA
-	bool "Renesas RA DAC"
+	bool "Renesas RA DAC driver"
 	default y
 	depends on DT_HAS_RENESAS_RA_DAC_ENABLED
 	select USE_RA_FSP_DAC

--- a/drivers/dac/Kconfig.sam0
+++ b/drivers/dac/Kconfig.sam0
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_SAM0
-	bool "Atmel SAM0 series DAC Driver"
+	bool "Atmel SAM0 series DAC driver"
 	default y
 	depends on DT_HAS_ATMEL_SAM0_DAC_ENABLED
 	select PINCTRL

--- a/drivers/dac/Kconfig.samd5x
+++ b/drivers/dac/Kconfig.samd5x
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_SAMD5X
-	bool "Atmel SAMD5x series DAC Driver"
+	bool "Atmel SAMD5x series DAC driver"
 	default y
 	depends on DT_HAS_ATMEL_SAMD5X_DAC_ENABLED
 	select PINCTRL


### PR DESCRIPTION
## Description

Align seven DAC driver enabling prompts with the documented `{Driver Name} DAC driver` format. This is a prompt-only update; symbols, dependencies, defaults, and generated configuration behavior are unchanged.

Part of #7272

## Testing

- `perl scripts/checkpatch.pl -g HEAD^..HEAD`
- `git diff --check`
- `python3 scripts/kconfig/kconfig_style.py drivers/dac` (reported only six pre-existing violations in unchanged lines)

A target build was not run because `west` is not installed in this checkout.