### PR TITLE
smp_shell: route SMP responses to the receiving shell backend

### DIFF
--- a/include/zephyr/mgmt/mcumgr/transport/smp_shell.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_shell.h
@@ -19,6 +19,7 @@
  * @{
  */
 
+#include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
@@ -34,6 +35,7 @@ struct smp_shell_data {
 	struct k_fifo buf_ready;
 	struct net_buf *buf;
 	atomic_t esc_state;
+	const struct shell_uart_common *uart;
 };
 
 /**

--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -188,6 +188,8 @@ void smp_shell_process(struct smp_shell_data *data)
 	struct net_buf *buf;
 	struct net_buf *nb;
 
+	shell_uart = data->uart;
+
 	while (true) {
 		buf = k_fifo_get(&data->buf_ready, K_NO_WAIT);
 		if (!buf) {
@@ -227,7 +229,6 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 {
 	int rc;
 
-	shell_uart = (struct shell_uart_common *)shell_backend_uart_get_ptr()->iface->ctx;
 	rc = mcumgr_serial_tx_pkt(nb->data, nb->len, smp_shell_tx_raw);
 	smp_packet_free(nb);
 

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -298,6 +298,7 @@ static int init(const struct shell_transport *transport,
 #ifdef CONFIG_MCUMGR_TRANSPORT_SHELL
 	common->smp.buf_pool = &smp_shell_rx_pool;
 	k_fifo_init(&common->smp.buf_ready);
+	common->smp.uart = common;
 #endif
 
 	ret = pm_device_runtime_get(common->dev);


### PR DESCRIPTION
The SMP shell transport hardcodes UART backend lookup in TX path, causing mcumgr responses to always go to UART regardless of which backend received the request.

Store a pointer to the shell_uart_common context in smp_shell_data during init and use it in smp_shell_process() to set the TX target. This allows SMP responses to route back to the correct backend (UART, CDC-ACM, etc.).

Co-Developed-by: qwen3.6:27b via llama.cpp <assistant@opencode.ai>