### PR TITLE
drivers: sensor: qst: qmi8658a: use Kconfig trigger template

### DIFF
--- a/drivers/sensor/qst/qmi8658a/Kconfig
+++ b/drivers/sensor/qst/qmi8658a/Kconfig
@@ -8,49 +8,21 @@ menuconfig QMI8658A
 	default y
 	depends on DT_HAS_QST_QMI8658A_ENABLED
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_QST_QMI8658A),int-gpios)
 	help
 	  Enable driver for the QST QMI8658A six-axis IMU.
 
 if QMI8658A
 
-choice
-	prompt "Trigger mode"
-	default QMI8658A_TRIGGER_NONE
-	help
-	  Specify the type of triggering to be used by the driver.
-
-config QMI8658A_TRIGGER_NONE
-	bool "No trigger"
+module = QMI8658A
+thread_priority = 10
+thread_stack_size = 1024
+source "drivers/sensor/Kconfig.trigger_template"
 
 config QMI8658A_TRIGGER_GLOBAL_THREAD
-	bool "Use global thread"
-	depends on GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_QST_QMI8658A),int-gpios)
-	select QMI8658A_TRIGGER
 
 config QMI8658A_TRIGGER_OWN_THREAD
-	bool "Use own thread"
-	depends on GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_QST_QMI8658A),int-gpios)
-	select QMI8658A_TRIGGER
-
-endchoice
-
-config QMI8658A_TRIGGER
-	bool
-
-config QMI8658A_THREAD_PRIORITY
-	int "Thread priority"
-	depends on QMI8658A_TRIGGER_OWN_THREAD
-	default 10
-	help
-	  Priority of thread used by the driver to handle interrupts.
-
-config QMI8658A_THREAD_STACK_SIZE
-	int "Thread stack size"
-	depends on QMI8658A_TRIGGER_OWN_THREAD
-	default 1024
-	help
-	  Stack size of thread used by the driver to handle interrupts.
 
 endif # QMI8658A


### PR DESCRIPTION
Following the standard pattern for sensor Kconfig files and allows access to the named choice symbol QMI8658A_TRIGGER_MODE from out-of-tree Kconfig files. Also add conditional GPIO select when any binded DTS node expose a int-gpios property.

Fixes #116404