### PR TITLE
doc: net: dsa: Account for use of net_eth_mac_config

### DIFF
--- a/doc/services/connectivity/networking/dsa.rst
+++ b/doc/services/connectivity/networking/dsa.rst
@@ -83,8 +83,7 @@ of i.MX NETC.
                    .phy_mode = NETC_PHY_MODE(port),                                            \
            };                                                                                  \
            struct dsa_port_config dsa_##n##_##port##_config = {                                \
-                   .use_random_mac_addr = DT_PROP(port, zephyr_random_mac_address),            \
-                   .mac_addr = DT_PROP_OR(port, local_mac_address, {0}),                       \
+                   .mcfg = NET_ETH_MAC_DT_CONFIG_INIT(port),                                   \
                    .port_idx = DT_REG_ADDR(port),                                              \
                    .phy_dev = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(port, phy_handle)),             \
                    .phy_mode = DT_PROP_OR(port, phy_connection_type, ""),                      \


### PR DESCRIPTION
66b211e5a29a0b replaced the `use_random_mac_addr` and `mac_addr` fields in `struct dsa_port_config` with a `struct net_eth_mac_config`. Update the i.MX NETC example in the docs to account for this.

It might even be preferable to use a `literalinclude` here to avoid future deviations. LMK if you think that's the right way to go.