### PR TITLE
subsys: kvss: zms: fix mutex concurrency issues

### DIFF
--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -66,6 +66,8 @@ struct zms_fs {
 	uint8_t sector_cycle;
 	/** Flag indicating if the file system is initialized */
 	bool ready;
+	/** Flag indicating that `zms_lock` has been initialized */
+	bool lock_initialized;
 	/** Mutex used to lock flash writes */
 	struct k_mutex zms_lock;
 	/** Flash device runtime structure */

--- a/subsys/kvss/zms/zms.c
+++ b/subsys/kvss/zms/zms.c
@@ -1635,7 +1635,12 @@ static int zms_mount_internal(struct zms_fs *fs, bool wipe_on_failure)
 		return -EINVAL;
 	}
 
-	k_mutex_init(&fs->zms_lock);
+	/* Initialize the mutex only on the first mount.
+	 */
+	if (!fs->lock_initialized) {
+		k_mutex_init(&fs->zms_lock);
+		fs->lock_initialized = true;
+	}
 
 	fs->flash_parameters = flash_get_parameters(fs->flash_device);
 	if (fs->flash_parameters == NULL) {
@@ -1743,6 +1748,8 @@ ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 		return -EINVAL;
 	}
 
+	k_mutex_lock(&fs->zms_lock, K_FOREVER);
+
 #ifdef CONFIG_ZMS_NO_DOUBLE_WRITE
 	uint64_t wlk_addr;
 
@@ -1755,7 +1762,8 @@ ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 			goto no_cached_entry;
 		} else {
 			/* skip delete entry for non-existing entry */
-			return 0;
+			rc = 0;
+			goto end;
 		}
 	}
 #else
@@ -1767,7 +1775,8 @@ ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 	struct zms_ate wlk_ate;
 	int prev_found = zms_find_ate_with_id(fs, id, wlk_addr, fs->ate_wra, &wlk_ate, &rd_addr);
 	if (prev_found < 0) {
-		return prev_found;
+		rc = prev_found;
+		goto end;
 	}
 
 	if (prev_found) {
@@ -1783,7 +1792,8 @@ ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 				/* skip delete entry as it is already the
 				 * last one
 				 */
-				return 0;
+				rc = 0;
+				goto end;
 			}
 		} else if (len == wlk_ate.len) {
 			/* do not try to compare if lengths are not equal */
@@ -1791,19 +1801,20 @@ ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 			if (len <= ZMS_DATA_IN_ATE_SIZE) {
 				rc = memcmp(&wlk_ate.data, data, len);
 				if (!rc) {
-					return 0;
+					goto end;
 				}
 			} else {
 				rc = zms_flash_block_cmp(fs, rd_addr, data, len);
 				if (rc <= 0) {
-					return rc;
+					goto end;
 				}
 			}
 		}
 	} else {
 		/* skip delete entry for non-existing entry */
 		if (len == 0) {
-			return 0;
+			rc = 0;
+			goto end;
 		}
 	}
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
@@ -1820,8 +1831,6 @@ no_cached_entry:
 			required_space = fs->ate_size;
 		}
 	}
-
-	k_mutex_lock(&fs->zms_lock, K_FOREVER);
 
 	gc_count = 0;
 	while (1) {
@@ -1895,6 +1904,14 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
 
 	cnt_his = 0U;
 
+	/* Lock the file system for the whole lookup. A concurrent write in
+	 * another thread can trigger garbage collection which relocates ATEs
+	 * and their data, updates fs->ate_wra and rebuilds the lookup cache.
+	 * Without this lock the walk below could follow stale addresses and
+	 * fail (-ENOENT/-EIO) or return corrupted data.
+	 */
+	k_mutex_lock(&fs->zms_lock, K_FOREVER);
+
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 	wlk_addr = zms_lookup_cache_addr(fs, id);
 
@@ -1912,7 +1929,8 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
 		prev_found = zms_find_ate_with_id(fs, id, wlk_addr, fs->ate_wra, &wlk_ate,
 						  &wlk_prev_addr);
 		if (prev_found < 0) {
-			return prev_found;
+			rc = prev_found;
+			goto err;
 		}
 		if (prev_found) {
 			cnt_his++;
@@ -1924,7 +1942,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
 			 */
 			rc = zms_compute_prev_addr(fs, &wlk_prev_addr);
 			if (rc) {
-				return rc;
+				goto err;
 			}
 			/* wlk_addr will be the start research address in the next loop */
 			wlk_addr = wlk_prev_addr;
@@ -1934,7 +1952,8 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
 	}
 
 	if (((!prev_found) || (wlk_ate.id != id)) || (wlk_ate.len == 0U) || (cnt_his < cnt)) {
-		return -ENOENT;
+		rc = -ENOENT;
+		goto err;
 	}
 
 	if (wlk_ate.len <= ZMS_DATA_IN_ATE_SIZE) {
@@ -1960,15 +1979,18 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
 				LOG_ERR("Invalid data CRC: ATE_CRC=0x%08X, "
 					"computed_data_crc=0x%08X",
 					wlk_ate.data_crc, computed_data_crc);
-				return -EIO;
+				rc = -EIO;
+				goto err;
 			}
 		}
 #endif
 	}
 
+	k_mutex_unlock(&fs->zms_lock);
 	return wlk_ate.len;
 
 err:
+	k_mutex_unlock(&fs->zms_lock);
 	return rc;
 }
 


### PR DESCRIPTION
Fix several concurrency issues in the ZMS locking.

- zms_mount() re-initialized fs->zms_lock on every mount. Since a re-mount is required after zms_clear(), remounting while another thread still holds the mutex silently discards the lock and breaks mutual exclusion. The mutex is now initialized only once.

- zms_read_hist() walked the ATEs and read the data without holding the mutex. A concurrent zms_write() in another thread could trigger garbage collection, which relocates ATEs and their data and updates fs->ate_wra. The read could then follow stale addresses and fail (-ENOENT/-EIO) or return corrupted data. The lookup and data read are now performed under fs->zms_lock.

- zms_write() searched for and compared against the latest entry with the same ID (if CONFIG_ZMS_NO_DOUBLE_WRITE is enabled) before taking the lock, reading fs->ate_wra and walking the ATEs unlocked. A concurrent write could trigger garbage collection and relocate the ATE being inspected, leading to a wrong comparison or a read of a stale address. The lock is now taken before that block.