### PR TITLE
[Backport v4.3-branch] drivers: input: gt911: clamp reported touch point count

### DIFF
--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/input/input.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/pm/pm.h>
 
 #include <zephyr/logging/log.h>
@@ -134,9 +135,10 @@ static int gt911_process(const struct device *dev)
 	/*
 	 * Note- since we program the max number of touch inputs during init,
 	 * the controller won't report more than the maximum number of touch
-	 * points we are configured to support
+	 * points we are configured to support. Clamp anyway so that corrupted
+	 * data on the bus cannot overflow the point array.
 	 */
-	points = status & TOUCH_POINTS_MSK;
+	points = min(status & TOUCH_POINTS_MSK, CONFIG_INPUT_GT911_MAX_TOUCH_POINTS);
 
 	/* need to clear the status */
 	uint8_t clear_buffer[3] = {(uint8_t)REG_STATUS, (uint8_t)(REG_STATUS >> 8), 0};


### PR DESCRIPTION
Backport of the fix from #115605 to `v4.3-branch`.

Fixes: #116414