### PR TITLE
sys: sflist: make flag capacity ABI-dependent

### DIFF
--- a/doc/kernel/services/data_passing/fifos.rst
+++ b/doc/kernel/services/data_passing/fifos.rst
@@ -24,11 +24,11 @@ A FIFO has the following key properties:
 
 A FIFO must be initialized before it can be used. This sets its queue to empty.
 
-FIFO data items must be aligned on a word boundary, as the kernel reserves
-the first word of an item for use as a pointer to the next data item in
-the queue. Consequently, a data item that holds N bytes of application
-data requires N+4 (or N+8) bytes of memory. There are no alignment or
-reserved space requirements for data items if they are added with
+FIFO data items must be aligned as required for a pointer, as the kernel
+reserves the first pointer-sized field of an item for use as a pointer to the
+next data item in the queue. Consequently, a data item that holds N bytes of
+application data requires N+4 (or N+8) bytes of memory. There are no alignment
+or reserved space requirements for data items if they are added with
 :c:func:`k_fifo_alloc_put`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 

--- a/doc/kernel/services/data_passing/lifos.rst
+++ b/doc/kernel/services/data_passing/lifos.rst
@@ -24,11 +24,11 @@ A LIFO has the following key properties:
 
 A LIFO must be initialized before it can be used. This sets its queue to empty.
 
-LIFO data items must be aligned on a word boundary, as the kernel reserves
-the first word of an item for use as a pointer to the next data item in the
-queue. Consequently, a data item that holds N bytes of application data
-requires N+4 (or N+8) bytes of memory. There are no alignment or reserved
-space requirements for data items if they are added with
+LIFO data items must be aligned as required for a pointer, as the kernel
+reserves the first pointer-sized field of an item for use as a pointer to the
+next data item in the queue. Consequently, a data item that holds N bytes of
+application data requires N+4 (or N+8) bytes of memory. There are no alignment
+or reserved space requirements for data items if they are added with
 :c:func:`k_lifo_alloc_put`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2388,8 +2388,8 @@ __syscall void k_queue_cancel_wait(struct k_queue *queue);
  * @brief Append an element to the end of a queue.
  *
  * This routine appends a data item to @a queue. A queue data item must be
- * aligned on a word boundary, and the first word of the item is reserved
- * for the kernel's use.
+ * aligned as required for a pointer, and its first pointer-sized field is
+ * reserved for the kernel's use.
  *
  * @isr_ok
  *
@@ -2420,8 +2420,8 @@ __syscall int32_t k_queue_alloc_append(struct k_queue *queue, void *data);
  * @brief Prepend an element to a queue.
  *
  * This routine prepends a data item to @a queue. A queue data item must be
- * aligned on a word boundary, and the first word of the item is reserved
- * for the kernel's use.
+ * aligned as required for a pointer, and its first pointer-sized field is
+ * reserved for the kernel's use.
  *
  * @isr_ok
  *
@@ -2452,8 +2452,8 @@ __syscall int32_t k_queue_alloc_prepend(struct k_queue *queue, void *data);
  * @brief Inserts an element to a queue.
  *
  * This routine inserts a data item to @a queue after previous item. A queue
- * data item must be aligned on a word boundary, and the first word of
- * the item is reserved for the kernel's use.
+ * data item must be aligned as required for a pointer, and its first
+ * pointer-sized field is reserved for the kernel's use.
  *
  * @isr_ok
  *
@@ -2467,8 +2467,8 @@ void k_queue_insert(struct k_queue *queue, void *prev, void *data);
  * @brief Atomically append a list of elements to a queue.
  *
  * This routine adds a list of data items to @a queue in one operation.
- * The data items must be in a singly-linked list, with the first word
- * in each data item pointing to the next data item; the list must be
+ * The data items must be in a singly-linked list, with the first pointer-sized
+ * field in each data item pointing to the next data item; the list must be
  * NULL-terminated.
  *
  * @isr_ok
@@ -2505,8 +2505,8 @@ int k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
 /**
  * @brief Get an element from a queue.
  *
- * This routine removes first data item from @a queue. The first word of the
- * data item is reserved for the kernel's use.
+ * This routine removes first data item from @a queue. The first pointer-sized
+ * field of the data item is reserved for the kernel's use.
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
@@ -2524,9 +2524,9 @@ __syscall void *k_queue_get(struct k_queue *queue, k_timeout_t timeout);
 /**
  * @brief Remove an element from a queue.
  *
- * This routine removes data item from @a queue. The first word of the
- * data item is reserved for the kernel's use. Removing elements from k_queue
- * rely on sys_slist_find_and_remove which is not a constant time operation.
+ * This routine removes data item from @a queue. The first pointer-sized field
+ * of the data item is reserved for the kernel's use. Removing elements from
+ * k_queue rely on sys_slist_find_and_remove which is not a constant time operation.
  *
  * @isr_ok
  *
@@ -2540,9 +2540,9 @@ bool k_queue_remove(struct k_queue *queue, void *data);
 /**
  * @brief Append an element to a queue only if it's not present already.
  *
- * This routine appends data item to @a queue. The first word of the data
- * item is reserved for the kernel's use. Appending elements to k_queue
- * relies on sys_slist_is_node_in_list which is not a constant time operation.
+ * This routine appends data item to @a queue. The first pointer-sized field of
+ * the data item is reserved for the kernel's use. Appending elements to
+ * k_queue relies on sys_slist_is_node_in_list which is not a constant time operation.
  *
  * @isr_ok
  *
@@ -3038,8 +3038,8 @@ struct k_fifo {
 /**
  * @brief Add an element to a FIFO queue.
  *
- * This routine adds a data item to @a fifo. A FIFO data item must be
- * aligned on a word boundary, and the first word of the item is reserved
+ * This routine adds a data item to @a fifo. A FIFO data item must be aligned
+ * as required for a pointer, and its first pointer-sized field is reserved
  * for the kernel's use.
  *
  * @isr_ok
@@ -3084,8 +3084,8 @@ struct k_fifo {
  * @brief Atomically add a list of elements to a FIFO.
  *
  * This routine adds a list of data items to @a fifo in one operation.
- * The data items must be in a singly-linked list, with the first word of
- * each data item pointing to the next data item; the list must be
+ * The data items must be in a singly-linked list, with the first pointer-sized
+ * field in each data item pointing to the next data item; the list must be
  * NULL-terminated.
  *
  * @isr_ok
@@ -3131,7 +3131,8 @@ struct k_fifo {
  * @brief Get an element from a FIFO queue.
  *
  * This routine removes a data item from @a fifo in a "first in, first out"
- * manner. The first word of the data item is reserved for the kernel's use.
+ * manner. The first pointer-sized field of the data item is reserved for the
+ * kernel's use.
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
@@ -3278,7 +3279,7 @@ struct k_lifo {
  * @brief Add an element to a LIFO queue.
  *
  * This routine adds a data item to @a lifo. A LIFO queue data item must be
- * aligned on a word boundary, and the first word of the item is
+ * aligned as required for a pointer, and its first pointer-sized field is
  * reserved for the kernel's use.
  *
  * @isr_ok
@@ -3323,7 +3324,8 @@ struct k_lifo {
  * @brief Get an element from a LIFO queue.
  *
  * This routine removes a data item from @a LIFO in a "last in, first out"
- * manner. The first word of the data item is reserved for the kernel's use.
+ * manner. The first pointer-sized field of the data item is reserved for the
+ * kernel's use.
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *

--- a/include/zephyr/sys/sflist.h
+++ b/include/zephyr/sys/sflist.h
@@ -38,14 +38,9 @@ extern "C" {
 #endif
 
 /** @cond INTERNAL_HIDDEN */
-/*
- * Flag bits are stored in the low bits of the node address, so a node must be
- * aligned to at least 4 bytes. Not every ABI gives uintptr_t that alignment
- * naturally, so require it explicitly. See SYS_SFLIST_FLAGS_MASK below.
- */
 struct _sfnode {
 	uintptr_t next_and_flags;
-} __aligned(sizeof(void *));
+};
 /** @endcond */
 
 /** Flagged single-linked list node structure. */
@@ -221,10 +216,11 @@ static inline void sys_sflist_init(sys_sflist_t *list)
  */
 #define SYS_SFLIST_STATIC_INIT(ptr_to_list) {NULL, NULL}
 
-/* Flag bits are stored in unused LSB of the sys_sfnode_t pointer */
+/** Mask of flag bits available in a node pointer on this ABI. */
 #define SYS_SFLIST_FLAGS_MASK	((uintptr_t)(__alignof__(sys_sfnode_t) - 1))
-/* At least 2 available flag bits are expected */
-BUILD_ASSERT(SYS_SFLIST_FLAGS_MASK >= 0x3);
+
+/** Number of flag bits available in a node pointer on this ABI. */
+#define SYS_SFLIST_FLAG_BITS LOG2(__alignof__(sys_sfnode_t))
 
 static inline sys_sfnode_t *z_sfnode_next_peek(const sys_sfnode_t *node)
 {
@@ -283,8 +279,7 @@ static inline sys_sfnode_t *sys_sflist_peek_tail(const sys_sflist_t *list)
  * @brief Fetch flags value for a particular sfnode
  *
  * @param node A pointer to the node to fetch flags from
- * @return The value of flags, which will be between 0 and 3 on 32-bit
- *         architectures, or between 0 and 7 on 64-bit architectures
+ * @return The flags value, between zero and @ref SYS_SFLIST_FLAGS_MASK.
  */
 static inline uint8_t sys_sfnode_flags_get(const sys_sfnode_t *node)
 {
@@ -294,10 +289,10 @@ static inline uint8_t sys_sfnode_flags_get(const sys_sfnode_t *node)
 /**
  * @brief Initialize an sflist node
  *
- * Set an initial flags value for this slist node, which can be a value between
- * 0 and 3 on 32-bit architectures, or between 0 and 7 on 64-bit architectures.
- * These flags will persist even if the node is moved around within a list,
- * removed, or transplanted to a different slist.
+ * Set an initial flags value for this slist node. The value must fit in the
+ * number of bits reported by @ref SYS_SFLIST_FLAG_BITS. These flags will
+ * persist even if the node is moved around within a list, removed, or
+ * transplanted to a different slist.
  *
  * This is ever so slightly faster than sys_sfnode_flags_set() and should
  * only be used on a node that hasn't been added to any list.
@@ -314,10 +309,10 @@ static inline void sys_sfnode_init(sys_sfnode_t *node, uint8_t flags)
 /**
  * @brief Set flags value for an sflist node
  *
- * Set a flags value for this slist node, which can be a value between
- * 0 and 3 on 32-bit architectures, or between 0 and 7 on 64-bit architectures.
- * These flags will persist even if the node is moved around within a list,
- * removed, or transplanted to a different slist.
+ * Set a flags value for this slist node. The value must fit in the number of
+ * bits reported by @ref SYS_SFLIST_FLAG_BITS. These flags will persist even if
+ * the node is moved around within a list, removed, or transplanted to a
+ * different slist.
  *
  * @param node A pointer to the node to set the flags on
  * @param flags The flags value to set

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -386,6 +386,8 @@ static void *virt_region_alloc(size_t size, size_t align)
  * This implies in the future there may be multiple slists managing physical
  * pages. Each page frame will still just have one snode link.
  */
+BUILD_ASSERT(SYS_SFLIST_FLAG_BITS >= 1, "MMU free-page list needs one sflist flag bit");
+
 static sys_sflist_t free_page_frame_list;
 
 /* Number of unused and available free page frames.

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -22,6 +22,8 @@
 #include <kernel_internal.h>
 #include <zephyr/sys/check.h>
 
+BUILD_ASSERT(SYS_SFLIST_FLAG_BITS >= 1, "k_queue needs one sflist flag bit");
+
 struct alloc_node {
 	sys_sfnode_t node;
 	void *data;

--- a/tests/unit/list/sflist.c
+++ b/tests/unit/list/sflist.c
@@ -304,6 +304,7 @@ ZTEST(dlist_api, test_sflist)
 	};
 	sys_sfnode_t *node = NULL;
 	int ii;
+	int max_test_flag = MIN((uintptr_t)0x7, SYS_SFLIST_FLAGS_MASK);
 
 	sys_sflist_init(&test_list);
 
@@ -398,22 +399,26 @@ ZTEST(dlist_api, test_sflist)
 	 * sys_sfnode_init()
 	 */
 	sys_sflist_init(&test_list);
-	/* Only iterating 0..3 due to limited range of flag values */
-	for (ii = 0; ii < 4; ii++) {
-		sys_sfnode_init(&data_node[ii].node, ii);
-		sys_sflist_append(&test_list, &data_node[ii].node);
+	struct data_node flag_node[8] = {
+		{.data = 0}, {.data = 1}, {.data = 2}, {.data = 3},
+		{.data = 4}, {.data = 5}, {.data = 6}, {.data = 7},
+	};
+	/* Test up to eight values within the flag capacity of this ABI. */
+	for (ii = 0; ii <= max_test_flag; ii++) {
+		sys_sfnode_init(&flag_node[ii].node, ii);
+		sys_sflist_append(&test_list, &flag_node[ii].node);
 	}
-	for (ii = 0; ii < 4; ii++) {
+	for (ii = 0; ii <= max_test_flag; ii++) {
 		node = sys_sflist_get(&test_list);
 		zassert_equal(sys_sfnode_flags_get(node), ii,
 			      "wrong flags value");
 		/* Place the nodes back on the list with the flags set
 		 * in reverse order for the next test
 		 */
-		sys_sfnode_flags_set(node, 3 - ii);
+		sys_sfnode_flags_set(node, max_test_flag - ii);
 		sys_sflist_append(&test_list, node);
 	}
-	for (ii = 3; ii >= 0; ii--) {
+	for (ii = max_test_flag; ii >= 0; ii--) {
 		node = sys_sflist_get(&test_list);
 		zassert_equal(sys_sfnode_flags_get(node), ii,
 			      "wrong flags value");


### PR DESCRIPTION
This change is a prerequisite for the m68k architecture port proposed in RFC #114672.

## Problem

`sys_sflist` stores flags in the unused low bits of node links. The number of bits available for this depends on the natural alignment guaranteed by the target ABI.

The generic implementation currently forces `sys_sfnode_t` to pointer-size alignment and globally requires at least two flag bits:

```c
BUILD_ASSERT(SYS_SFLIST_FLAGS_MASK >= 0x3);
```

That alignment applies to objects declared as `sys_sfnode_t`, but not to caller-owned intrusive objects borrowed by users such as `k_queue`. Those objects are only cast to `sys_sfnode_t *` and retain their original alignment.

On the m68k ABI used by the proposed port:

```text
sizeof(void *)  = 4
alignof(void *) = 2
```

A caller-owned queue item may therefore be validly aligned to two bytes. When the address of the next item has bit 1 set, the current two-bit mask interprets that address bit as a flag and clears it while decoding the link. This corrupts the pointer and can subsequently damage queues, wait queues, heap state, or spinlocks.

## Solution

Make the flag capacity reported by `sys_sflist` reflect the ABI's natural alignment:

* remove the artificial `__aligned(sizeof(void *))` from `sys_sfnode_t`;
* keep `SYS_SFLIST_FLAGS_MASK` derived from the natural alignment of the node;
* expose `SYS_SFLIST_FLAG_BITS`;
* move flag-capacity requirements to individual consumers.

The existing consumers each require only one flag bit:

* `k_queue` uses bit 0 to distinguish allocated wrapper nodes from caller-owned intrusive items;
* the MMU free-page list uses one bit for `K_MEM_PAGE_FRAME_FREE`.

Both consumers now enforce that requirement with a local build assertion. A future consumer that needs more bits can assert its own requirement without imposing it on every `sys_sflist` user.

This preserves the generic flagged-list implementation. ABIs with four-byte or eight-byte natural pointer alignment retain their existing two-bit or three-bit capacity, while m68k correctly reports one available bit.

## Additional changes

* Make the `sys_sflist` unit test exercise only flag values supported by the current ABI.
* Document the ABI-dependent flag range.
* Clarify that intrusive queue, FIFO, and LIFO items require natural pointer alignment and a pointer-sized reserved field.

There are no architecture-specific conditionals or public API signature changes. `k_queue` continues to use `sys_sflist`, and its storage layout and allocated-wrapper lifetime remain unchanged.

### Validation

`kernel.queue` passed on both m68k targets under QEMU 11.0.0:

* `qemu_virt_m68k_m68000`: 22/22 test cases
* `qemu_virt_m68k_m68010`: 22/22 test cases

This includes the affected allocated-wrapper and list append/merge paths. No retries were needed.
