### PR TITLE
bluetooth: host: bip: fix role validation in client connect

### DIFF
--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -1345,11 +1345,12 @@ static int bt_bip_client_connect(struct bt_bip *bip, struct bt_bip_client *clien
 		return -EINVAL;
 	}
 
+	if (bip->role == BT_BIP_ROLE_RESPONDER) {
+		LOG_ERR("Invalid role responder");
+		return -EINVAL;
+	}
+
 	if (is_bip_primary_connect(type)) {
-		if (bip->role == BT_BIP_ROLE_RESPONDER) {
-			LOG_ERR("Invalid role responder");
-			return -EINVAL;
-		}
 
 		if (primary_server != NULL) {
 			LOG_ERR("primary server should be NULL");
@@ -1363,11 +1364,6 @@ static int bt_bip_client_connect(struct bt_bip *bip, struct bt_bip_client *clien
 		}
 	} else {
 		struct bt_bip *primary_bip;
-
-		if (bip->role == BT_BIP_ROLE_INITIATOR) {
-			LOG_ERR("Invalid role initiator");
-			return -EINVAL;
-		}
 
 		if (primary_server == NULL || primary_server->_bip == NULL) {
 			LOG_ERR("Invalid primary client");


### PR DESCRIPTION
Move the responder role check outside the is_bip_primary_connect() conditional so it applies to all connection types. Remove the initiator role check from the secondary path since a responder role is valid for secondary connections initiated by the remote device.

This ensures that a BIP instance configured as responder cannot initiate any client connections, regardless of connection type.