### PR TITLE
Bluetooth: Classic: HID: fix buffer tailroom in HID device

### DIFF
--- a/subsys/bluetooth/host/classic/hid_device.c
+++ b/subsys/bluetooth/host/classic/hid_device.c
@@ -115,7 +115,7 @@ static void hid_send_handshake(struct bt_hid_device *hid, uint8_t result_code)
 	struct bt_hid_hdr *hdr;
 	int err;
 
-	buf = bt_l2cap_create_pdu(&hid_hs_pool, sizeof(struct bt_hid_hdr));
+	buf = bt_l2cap_create_pdu(&hid_hs_pool, 0);
 	if (buf == NULL) {
 		LOG_ERR("Handshake buf alloc failed");
 		return;


### PR DESCRIPTION
The second argument of bt_l2cap_create_pdu() is the reserve (headroom), not the payload size. The code passed
sizeof(struct bt_hid_hdr), which consumed the whole buffer as headroom and left tailroom = 0. The following net_buf_add() then hits the __ASSERT() and hangs on debug builds, or writes out of bounds on release builds.