### PR TITLE
boards: nxp: frdm_mcxl255: Enable MCUboot

### DIFF
--- a/boards/nxp/frdm_mcxl255/CMakeLists.txt
+++ b/boards/nxp/frdm_mcxl255/CMakeLists.txt
@@ -1,5 +1,10 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
 zephyr_library_sources(board.c)
+
+if(CONFIG_MCUBOOT_BOOTUTIL_LIB)
+  zephyr_library_sources(mcuboot_hooks/mcuboot_hooks.c)
+  zephyr_library_include_directories(mcuboot_hooks)
+endif()

--- a/boards/nxp/frdm_mcxl255/Kconfig.sysbuild
+++ b/boards/nxp/frdm_mcxl255/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# MCXL255 internal flash access control (FLASH_ACL) configuration
+# currently does not support SWAP modes
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_OVERWRITE_ONLY
+endchoice

--- a/boards/nxp/frdm_mcxl255/doc/index.rst
+++ b/boards/nxp/frdm_mcxl255/doc/index.rst
@@ -179,6 +179,49 @@ should see the following message in the terminal:
    *** Booting Zephyr OS build v4.3.0-2208-gcf34f44c1e18 ***
    Hello World! frdm_mcxl255/mcxl255/cpu0
 
+Flash Access Control
+********************
+
+The MCX L255 SoC uses a Memory Block Checker (MBC) unit to control access
+permissions to internal Flash. The MBC configuration applied at runtime is
+derived from the ``FLASH_ACL`` fields stored in the Customer Manufacturing
+Programming Area (CMPA) of the Flash IFR region. During ROM boot the boot
+ROM reads these fields and programs the MBC accordingly before handing
+control to application code.
+
+ROM-boot vs Debug-boot
+======================
+
+When an application is flashed through a debug probe (e.g. MCU-Link or
+J-Link) the debug session typically holds the MBC in a permissive state,
+so Flash erase and write operations succeed. However, after a hard reset
+(power-cycle or pressing the RESET button) the ROM boot reconfigures the
+MBC from the CMPA ``FLASH_ACL`` fields. If those fields restrict write or
+erase access to the Flash region where the application resides, any
+subsequent attempt to erase or program Flash will trigger a HardFault.
+
+Changing CMPA Configuration
+============================
+
+The CMPA ``FLASH_ACL`` fields can be updated with NXP's
+`MCUXpresso Secure Provisioning`_ tool. The tool provides a graphical
+interface to read, modify, and write back the CMPA page, allowing the user
+to grant the required Flash access permissions before deploying the
+application in a standalone (non-debug) scenario.
+
+Runtime MBC Setup Reference
+============================
+
+The ``mcuboot_hooks`` module located in the main board directory
+(``boards/nxp/frdm_mcxl255/mcuboot_hooks/``) contains a reference
+implementation that configures the MBC at runtime from application code.
+It can be used as a starting point for applications that need to adjust
+Flash access permissions dynamically without relying solely on the CMPA
+static configuration.
+
+.. _MCUXpresso Secure Provisioning:
+   https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-secure-provisioning-tool:MCUXPRESSO-SECURE-PROVISIONING
+
 .. _MCX L Series Website:
    https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/mcx-arm-cortex-m/mcx-l-series-microcontrollers:MCX-L-SERIES
 

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
@@ -12,3 +12,36 @@
 	model = "NXP FRDM_MCXL255 board";
 	compatible = "nxp,mcxl255", "nxp,mcx";
 };
+
+&flash {
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+			read-only;
+		};
+
+		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(160)>;
+		};
+
+		slot1_partition: partition@38000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x00038000 DT_SIZE_K(160)>;
+		};
+
+		storage_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x00060000 DT_SIZE_K(24)>;
+		};
+	};
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -18,6 +18,7 @@
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,crc = &crc;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -143,6 +143,10 @@
 	status = "okay";
 };
 
+&fmu {
+	status = "okay";
+};
+
 &wwdt0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -19,4 +19,5 @@ supported:
   - crc
   - watchdog
   - mbox
+  - flash
 vendor: nxp

--- a/boards/nxp/frdm_mcxl255/mcuboot_hooks/mcuboot_hooks.c
+++ b/boards/nxp/frdm_mcxl255/mcuboot_hooks/mcuboot_hooks.c
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * MCUboot hook example for FRDM-MCXL255 - MBC0 flash access control management.
+ *
+ * This module demonstrates the BOOT_GO_HOOKS and MCUBOOT_ACTION_HOOKS interfaces
+ * to configure MBC0 (TRDC) flash memory block permissions based on the MCUboot
+ * partition layout defined in the device tree.
+ * Partition offsets and sizes are read from the DT nodes boot_partition,
+ * slot0_partition, and slot1_partition at compile time via DT_REG_ADDR() and
+ * DT_REG_SIZE().
+ *
+ * Permission policy:
+ *   ACP slot 0 - RW  : used for writable regions (primary slot before boot, secondary slot)
+ *   ACP slot 4 - RX  : used for executable regions (MCUboot, primary slot before jump)
+ *
+ * Lifecycle:
+ *   boot_go_hook()
+ *       Sets up ACP slots 0 and 4, then assigns:
+ *           MCUboot   -> RX (slot 4)
+ *           primary   -> RW (slot 0)  [writable for potential update]
+ *           secondary -> RW (slot 0)
+ *
+ *   mcuboot_status_change(MCUBOOT_STATUS_BOOTABLE_IMAGE_FOUND)
+ *       Switches the primary slot to RX just before MCUboot jumps to the app,
+ *       covering both the update and no-update boot paths.
+ *
+ */
+
+/*
+ * Build-time guard: this hook implementation relies on the assumption that
+ * MCUboot never needs to write swap-state metadata (magic, swap type, copy
+ * done, image OK) into the primary slot after an image has been installed.
+ * That assumption holds only for overwrite-only mode and plain direct-XIP
+ * (without revert).
+ *
+ * In every swap mode (scratch, move, offset) and in direct-XIP-with-revert
+ * mode, MCUboot writes the trailer / magic into the primary slot AFTER copying
+ * the image, so switching the primary slot to RX at copy-completion time would
+ * block that write when trying to set the image as accepted.
+ *
+ * To extend this ACL handling to also cover these modes would require reserving
+ * one extra 8kB block at the end of the image that would be set as RW.
+ * Or alternatively the MCUboot API that takes care of accepting an image
+ * (modifying the image OK status) would have to adjust the ACL setup to allow for
+ * the write.
+ *
+ */
+#if !defined(CONFIG_BOOT_UPGRADE_ONLY)                && \
+	!defined(CONFIG_BOOT_DIRECT_XIP)              && \
+	!defined(CONFIG_SINGLE_APPLICATION_SLOT)
+#error "mcuboot_hooks.c: incompatible MCUboot mode selected"
+#endif
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+
+#include <bootutil/bootutil.h>
+#include <bootutil/bootutil_log.h>
+#include <bootutil/image.h>
+#include <bootutil/fault_injection_hardening.h>
+#include <bootutil/boot_hooks.h>
+#include <bootutil/mcuboot_status.h>
+
+
+/* NXP device register header - includes PERI_TRDC.h for MCXL255. */
+#include "fsl_device_registers.h"
+
+LOG_MODULE_DECLARE(mcuboot, CONFIG_MCUBOOT_LOG_LEVEL);
+
+/*
+ * MBC0 flash block size for MCXL255.
+ * The internal flash is organised in 8 KB erase/protect blocks.
+ */
+#define HOOKS_FLASH_BLOCK_SIZE  (0x2000U)  /* 8 KB */
+
+/*
+ * MBC0 MEM0 block count: 8 BLK_CFG_W words x 8 blocks/word = 64 blocks.
+ * At 8 KB per block this covers the full 512 KB internal flash.
+ */
+#define HOOKS_MEM0_BLOCK_COUNT  (64U)
+
+/*
+ * Access control policy (ACP) slot assignments:
+ *   slot 0 -> RW  (read + write, no execute)
+ *   slot 4 -> RX  (read + execute, no write)
+ *
+ * GLBAC register bit layout (1 = allow):
+ *   bit 0  NUX  non-secure user execute
+ *   bit 1  NUW  non-secure user write
+ *   bit 2  NUR  non-secure user read
+ *   bit 4  NPX  non-secure privileged execute
+ *   bit 5  NPW  non-secure privileged write
+ *   bit 6  NPR  non-secure privileged read
+ *   bit 8  SUX  secure user execute
+ *   bit 9  SUW  secure user write
+ *   bit 10 SUR  secure user read
+ *   bit 12 SPX  secure privileged execute
+ *   bit 13 SPW  secure privileged write
+ *   bit 14 SPR  secure privileged read
+ *
+ * RW = NUW|NUR|NPW|NPR|SUW|SUR|SPW|SPR = 0x6666
+ * RX = NUX|NUR|NPX|NPR|SUX|SUR|SPX|SPR = 0x5555
+ */
+#define HOOKS_ACP_RW     (0U)
+#define HOOKS_ACP_RX     (4U)
+
+/* GLBAC value that grants read+write (no execute) to all privilege levels. */
+#define HOOKS_GLBAC_RW_VAL  (0x6666U)
+/* GLBAC value that grants read+execute (no write) to all privilege levels. */
+#define HOOKS_GLBAC_RX_VAL  (0x5555U)
+
+/*
+ * Block configuration word layout (MBC_DOMx_MEMy_BLK_CFG_W):
+ *   Each 32-bit word encodes 8 consecutive blocks at 4 bits each:
+ *     bits [3:0]   block 0: NSE | MBACSEL[2:0]
+ *     bits [7:4]   block 1: NSE | MBACSEL[2:0]
+ *     ...
+ *     bits [31:28] block 7: NSE | MBACSEL[2:0]
+ *   NSE=1 enables non-secure access via the selected GLBAC slot.
+ */
+#define HOOKS_BLOCKS_PER_CFG_WORD  (8U)
+#define HOOKS_BITS_PER_BLOCK       (4U)
+#define HOOKS_MBACSEL_MASK         (0x7U)
+#define HOOKS_NSE_BIT              (0x8U)
+
+/*
+ * Partition base offsets and sizes sourced from the device tree at
+ * compile time.
+ */
+#define BOOT_PARTITION_OFFSET  PARTITION_ADDRESS(boot_partition)
+#define BOOT_PARTITION_SIZE    PARTITION_SIZE(boot_partition)
+
+#define SLOT0_PARTITION_OFFSET PARTITION_ADDRESS(slot0_partition)
+#define SLOT0_PARTITION_SIZE   PARTITION_SIZE(slot0_partition)
+
+#define SLOT1_PARTITION_OFFSET PARTITION_ADDRESS(slot1_partition)
+#define SLOT1_PARTITION_SIZE   PARTITION_SIZE(slot1_partition)
+
+/* --------------------------------------------------------------------------
+ * Internal helpers
+ * --------------------------------------------------------------------------
+ */
+
+static void mbc0_glikey_write_enable(void)
+{
+	/* Enable MBC register written with GLIKEY index 15 */
+	GLIKEY0->CTRL_0 = 0x00060000U;
+	GLIKEY0->CTRL_0 = 0x0002000FU;
+	GLIKEY0->CTRL_0 = 0x0001000FU;
+	GLIKEY0->CTRL_1 = 0x00290000U;
+	GLIKEY0->CTRL_0 = 0x0002000FU;
+	GLIKEY0->CTRL_1 = 0x00280000U;
+	GLIKEY0->CTRL_0 = 0x0000000FU;
+}
+
+static void mbc0_glikey_write_disable(void)
+{
+	GLIKEY0->CTRL_0 = 0x0002000FU;
+}
+
+/*
+ * mbc0_configure_acp_slot - program one of the eight GLBAC policy registers.
+ *
+ * @slot : ACP slot index (0-7)
+ * @val  : GLBAC register value encoding the desired permissions
+ */
+static void mbc0_configure_acp_slot(uint8_t slot, uint32_t val)
+{
+	MBC0->MBC_INDEX[0].MBC_MEMN_GLBAC[slot] = val;
+}
+
+/*
+ * mbc0_set_mem0_block - set the ACP slot for a single block in MEM0.
+ *
+ * MEM0 BLK_CFG_W covers blocks 0-63.  Blocks outside this range are silently
+ * skipped.
+ *
+ * @block    : absolute block index (0-based within MBC0)
+ * @acp_slot : ACP policy slot to assign (0-7)
+ */
+static void mbc0_set_mem0_block(uint32_t block, uint8_t acp_slot)
+{
+	uint32_t word;
+	uint32_t bit_off;
+	uint32_t field_mask;
+	uint32_t reg_val;
+	uint32_t field_val;
+
+	if (block >= HOOKS_MEM0_BLOCK_COUNT) {
+		return;
+	}
+
+	field_val = ((uint32_t)acp_slot & HOOKS_MBACSEL_MASK) | HOOKS_NSE_BIT;
+	word = block / HOOKS_BLOCKS_PER_CFG_WORD;
+	bit_off = (block % HOOKS_BLOCKS_PER_CFG_WORD) * HOOKS_BITS_PER_BLOCK;
+	field_mask = 0xFU << bit_off;
+
+	reg_val = MBC0->MBC_INDEX[0].MBC_DOM0_MEM0_BLK_CFG_W[word];
+	reg_val &= ~field_mask;
+	reg_val |= (field_val << bit_off) & field_mask;
+	MBC0->MBC_INDEX[0].MBC_DOM0_MEM0_BLK_CFG_W[word] = reg_val;
+}
+
+/*
+ * mbc0_set_partition_blocks - apply an ACP slot to every block that covers the
+ * given flash partition.
+ *
+ * @offset     : partition start offset within flash (bytes)
+ * @size       : partition size (bytes)
+ * @acp_slot   : ACP policy slot to assign (0-7)
+ */
+static void mbc0_set_partition_blocks(uint32_t offset, uint32_t size,
+				      uint8_t acp_slot)
+{
+	uint32_t first_blk = offset / HOOKS_FLASH_BLOCK_SIZE;
+	uint32_t num_blks  = (size + HOOKS_FLASH_BLOCK_SIZE - 1U) / HOOKS_FLASH_BLOCK_SIZE;
+
+	for (uint32_t i = 0U; i < num_blks; i++) {
+		mbc0_set_mem0_block(first_blk + i, acp_slot);
+	}
+}
+
+/*
+ * mbc0_switch_primary_to_rx - change the primary-slot blocks to RX
+ * (read + execute, no write) so the image can be executed but not modified.
+ */
+static void mbc0_switch_primary_to_rx(void)
+{
+	LOG_DBG("mcuboot_hooks: switching primary slot to RX");
+	mbc0_set_partition_blocks(SLOT0_PARTITION_OFFSET, SLOT0_PARTITION_SIZE, HOOKS_ACP_RX);
+}
+
+/* --------------------------------------------------------------------------
+ * MCUboot hooks
+ * --------------------------------------------------------------------------
+ */
+
+/*
+ * boot_go_hook - called by MCUboot before image selection begins.
+ *
+ * Configures MBC0 ACP slots and assigns flash-partition block permissions:
+ *   - ACP slot 0: RW  (read + write)
+ *   - ACP slot 4: RX  (read + execute)
+ *   - MCUboot partition  -> RX
+ *   - Primary slot       -> RW  (may need to be written during update)
+ *   - Secondary slot     -> RW  (always writable for incoming updates)
+ *
+ * Returns FIH_BOOT_HOOK_REGULAR to let MCUboot continue normally.
+ */
+fih_ret boot_go_hook(struct boot_rsp *rsp)
+{
+	ARG_UNUSED(rsp);
+
+	LOG_DBG("%s: configuring MBC0 flash permissions", __func__);
+
+	mbc0_glikey_write_enable();
+
+	LOG_DBG("%s: flash block size = %u bytes", __func__,
+		(unsigned int)HOOKS_FLASH_BLOCK_SIZE);
+
+	/* ACP slot 0: RW - full read/write access, no execute. */
+	mbc0_configure_acp_slot(HOOKS_ACP_RW, HOOKS_GLBAC_RW_VAL);
+	LOG_DBG("%s: ACP slot 0 (RW) = 0x%04x", __func__, HOOKS_GLBAC_RW_VAL);
+
+	/* ACP slot 4: RX - read and execute, no write. */
+	mbc0_configure_acp_slot(HOOKS_ACP_RX, HOOKS_GLBAC_RX_VAL);
+	LOG_DBG("%s: ACP slot 4 (RX) = 0x%04x", __func__, HOOKS_GLBAC_RX_VAL);
+
+	/* MCUboot partition: RX - MCUboot code must not be overwritten. */
+	mbc0_set_partition_blocks(BOOT_PARTITION_OFFSET, BOOT_PARTITION_SIZE,
+				  HOOKS_ACP_RX);
+	LOG_DBG("%s: MCUboot  0x%05x +%u KB -> RX", __func__,
+		(unsigned int)BOOT_PARTITION_OFFSET,
+		(unsigned int)(BOOT_PARTITION_SIZE / 1024U));
+
+	/* Primary slot: RW - writable so an incoming image can be copied here. */
+	mbc0_set_partition_blocks(SLOT0_PARTITION_OFFSET, SLOT0_PARTITION_SIZE,
+				  HOOKS_ACP_RW);
+	LOG_DBG("%s: primary  0x%05x +%u KB -> RW", __func__,
+		(unsigned int)SLOT0_PARTITION_OFFSET,
+		(unsigned int)(SLOT0_PARTITION_SIZE / 1024U));
+
+	/* Secondary slot: always RW - this is where new images are uploaded. */
+	mbc0_set_partition_blocks(SLOT1_PARTITION_OFFSET, SLOT1_PARTITION_SIZE,
+				  HOOKS_ACP_RW);
+	LOG_DBG("%s: secondary 0x%05x +%u KB -> RW", __func__,
+		(unsigned int)SLOT1_PARTITION_OFFSET,
+		(unsigned int)(SLOT1_PARTITION_SIZE / 1024U));
+
+	LOG_DBG("%s: MBC0 permissions configured", __func__);
+
+	/* Let MCUboot continue with normal image selection. */
+	FIH_RET(FIH_BOOT_HOOK_REGULAR);
+}
+
+/*
+ * mcuboot_status_change - action hook called when MCUboot's internal status
+ * changes.
+ *
+ * On MCUBOOT_STATUS_BOOTABLE_IMAGE_FOUND MCUboot has validated the primary
+ * image and is about to jump to it.  Switch the primary slot to RX here so
+ * the image cannot be modified after the permission change but before the
+ * actual jump.  This covers both the normal boot path (no update) and the
+ * post-update path.
+ */
+void mcuboot_status_change(mcuboot_status_type_t status)
+{
+	if (status == MCUBOOT_STATUS_BOOTABLE_IMAGE_FOUND) {
+		LOG_DBG("%s: BOOTABLE_IMAGE_FOUND - switching primary slot to RX",
+			__func__);
+		mbc0_switch_primary_to_rx();
+		mbc0_glikey_write_disable();
+	}
+}

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -54,6 +54,10 @@ LOG_MODULE_REGISTER(flash_mcux);
 #endif
 #define FLASH_Erase   FLASH_EraseSector
 #define FLASH_Program FLASH_ProgramPhrase
+#elif defined(CONFIG_SOC_FAMILY_MCXL)
+#include "fsl_romapi.h"
+#define FLASH_Erase   FLASH_EraseSector
+#define FLASH_Program FLASH_ProgramPhrase
 #elif defined(CONFIG_MCUX_FLASH_K4_API)
 #include "fsl_k4_flash.h"
 #else
@@ -156,10 +160,13 @@ static void clear_flash_caches(void)
 	/* this bit clears the code cache */
 	*lpcac_ctrl |= BIT(1);
 }
-#elif CONFIG_SOC_FAMILY_MCXA
+#elif defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)
 static void clear_flash_caches(void)
 {
-	SYSCON->LPCAC_CTRL |= SYSCON_LPCAC_CTRL_DIS_LPCAC(1U);
+	/* Clear L1 low power cache. */
+	if ((SYSCON->LPCAC_CTRL & SYSCON_LPCAC_CTRL_DIS_LPCAC_MASK) == 0U) {
+		SYSCON->LPCAC_CTRL |= SYSCON_LPCAC_CTRL_CLR_LPCAC_MASK;
+	}
 }
 #elif defined(CONFIG_CACHE_NXP_LMEM_CACHE)
 static void clear_flash_caches(void)

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl.dtsi
@@ -65,6 +65,19 @@
 	};
 };
 
+&fmu {
+	compatible = "nxp,msf1";
+	interrupts = <12 0>;
+	#address-cells = <1>;
+	#size-cells = <1>;
+	status = "disabled";
+
+	uuid: uuid@1100800 {
+		compatible = "nxp,lpc-uid";
+		reg = <0x1100800 0x10>;
+	};
+};
+
 &peripheral {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -152,20 +165,6 @@
 			tar-clk-in1 {
 				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_CLK_IN1>;
 			};
-		};
-	};
-
-	fmu: flash-controller@95000 {
-		compatible = "nxp,msf1";
-		reg = <0x95000 0x1000>;
-		interrupts = <12 0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-		status = "disabled";
-
-		uuid: uuid@1100800 {
-			compatible = "nxp,lpc-uid";
-			reg = <0x1100800 0x10>;
 		};
 	};
 

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl253_cm33.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl253_cm33.dtsi
@@ -20,6 +20,11 @@
 		aon_peripheral: aon_peripheral@b0000000 {
 			ranges = <0x0 0xb0000000 0x10000000>;
 		};
+
+		fmu: flash-controller@50095000 {
+			reg = <0x50095000 0x1000>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+		};
 	};
 };
 

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl253_cm33_ns.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl253_cm33_ns.dtsi
@@ -20,6 +20,11 @@
 		aon_peripheral: aon_peripheral@a0000000 {
 			ranges = <0x0 0xa0000000 0x10000000>;
 		};
+
+		fmu: flash-controller@40095000 {
+			reg = <0x40095000 0x1000>;
+			ranges = <0x0 0x0 DT_SIZE_K(128)>;
+		};
 	};
 };
 

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl254_cm33.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl254_cm33.dtsi
@@ -20,6 +20,11 @@
 		aon_peripheral: aon_peripheral@b0000000 {
 			ranges = <0x0 0xb0000000 0x10000000>;
 		};
+
+		fmu: flash-controller@50095000 {
+			reg = <0x50095000 0x1000>;
+			ranges = <0x0 0x0 DT_SIZE_K(256)>;
+		};
 	};
 };
 

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl254_cm33_ns.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl254_cm33_ns.dtsi
@@ -20,6 +20,11 @@
 		aon_peripheral: aon_peripheral@a0000000 {
 			ranges = <0x0 0xa0000000 0x10000000>;
 		};
+
+		fmu: flash-controller@40095000 {
+			reg = <0x40095000 0x1000>;
+			ranges = <0x0 0x0 DT_SIZE_K(256)>;
+		};
 	};
 };
 

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33.dtsi
@@ -21,6 +21,11 @@
 		aon_peripheral: aon_peripheral@b0000000 {
 			ranges = <0x0 0xb0000000 0x10000000>;
 		};
+
+		fmu: flash-controller@50095000 {
+			reg = <0x50095000 0x1000>;
+			ranges = <0x0 0x0 DT_SIZE_K(512)>;
+		};
 	};
 };
 
@@ -81,6 +86,9 @@
 		reg = <0 DT_SIZE_K(512)>;
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <128>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x0 DT_SIZE_K(512)>;
 	};
 };
 

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33_ns.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33_ns.dtsi
@@ -20,6 +20,11 @@
 		aon_peripheral: aon_peripheral@a0000000 {
 			ranges = <0x0 0xa0000000 0x10000000>;
 		};
+
+		fmu: flash-controller@40095000 {
+			reg = <0x40095000 0x1000>;
+			ranges = <0x0 0x0 DT_SIZE_K(512)>;
+		};
 	};
 };
 

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -394,6 +394,10 @@ if(CONFIG_SOC_FAMILY_MCXA)
   endif()
 endif()
 
+if(CONFIG_SOC_FAMILY_MCXL)
+  set_variable_ifdef(CONFIG_SOC_FLASH_MCUX CONFIG_MCUX_COMPONENT_driver.romapi)
+endif()
+
 if(CONFIG_SOC_FAMILY_MCXN AND (NOT CONFIG_SOC_MCXN947) AND (NOT CONFIG_SOC_MCXN547))
   set_variable_ifdef(CONFIG_SOC_FLASH_MCUX CONFIG_MCUX_COMPONENT_driver.romapi_flashiap)
 endif()

--- a/soc/nxp/mcx/mcxl/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig.defconfig
@@ -16,6 +16,10 @@ config NUM_IRQS
 	default 32 if SOC_MCXL255_CPU1 || SOC_MCXL254_CPU1 || SOC_MCXL253_CPU1
 	default 161 if SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || SOC_MCXL253_CPU0
 
+# Default offset 0x200 is not enough with higher ISR count
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if \
 		SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || SOC_MCXL253_CPU0


### PR DESCRIPTION
MCUboot enablement for frdm_mcxl255:

- flash_mcux driver adaptation for MCXL

- flash partitions definition in the Device Tree.

- adjusted MCUboot header offset at the SoC-level Kconfig to handle
  a higher number of ISR's.

- configured MCUboot hooks to manage restrictive flash access
  control (FLASH_ACL) by setting required Read-Execute and Read-Write
  permissions according to the boot state.

- refactoring of MCXL DT for mapped-partition support

PR for MCUboot - https://github.com/mcu-tools/mcuboot/pull/2846