### PR TITLE
boards: st: stm32h573i_dk: enable TF-M firmware update support

### DIFF
--- a/boards/st/stm32h573i_dk/Kconfig
+++ b/boards/st/stm32h573i_dk/Kconfig
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_STM32H573I_DK
+	select TFM_PARTITION_FIRMWARE_UPDATE_SUPPORTED if BOARD_STM32H573I_DK_STM32H573XX_NS

--- a/samples/tfm_integration/tfm_fwu/sysbuild.conf
+++ b/samples/tfm_integration/tfm_fwu/sysbuild.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# TF-M provides its own BL2 bootloader, so MCUboot must not be built by
+# sysbuild. Some boards default the sysbuild bootloader choice to MCUboot,
+# which conflicts with the TF-M build.
+SB_CONFIG_BOOTLOADER_NONE=y

--- a/samples/tfm_integration/tfm_fwu/tests.yaml
+++ b/samples/tfm_integration/tfm_fwu/tests.yaml
@@ -7,7 +7,7 @@ common:
   tags:
     - trusted-firmware-m
     - mcuboot
-  filter: CONFIG_TFM_PARTITION_FIRMWARE_UPDATE
+  filter: CONFIG_TFM_PARTITION_FIRMWARE_UPDATE and CONFIG_TFM_BL2
   integration_platforms:
     - mps2/an521/cpu0/ns
   harness: console


### PR DESCRIPTION
Select `TFM_PARTITION_FIRMWARE_UPDATE_SUPPORTED` for `stm32h573i_dk/stm32h573xx/ns` so the TF-M firmware update (FWU) partition is available and the FWU sample can be built and run on this board.

```
[INF] Starting bootloader
[WRN] This device was provisioned with dummy keys. This device is NOT SECURE
[INF] PSA Crypto init done, sig_type: EC-P256
[INF] Primary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x1
[INF] Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
[INF] Boot source: primary slot
[INF] Image index: 1, Swap type: none
[INF] Primary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x1
[INF] Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
[INF] Boot source: primary slot
[INF] Image index: 0, Swap type: none
[INF] Bootloader chainload address offset: 0x38000
[INF] Image version: v0.0.0
[INF] Jumping to the first image slot
[NOT] Booting TF-M v2.3.0+gd87b0151a
[NOT] Built Mon 17 Aug 2026 07:27:32 UTC
[WRN] This device was provisioned with dummy keys. This device is NOT SECURE
Creating an empty ITS flash layout.
Creating an empty PS flash layout.
[INF] [PS] Encryption alg: 0x5500200
*** Booting Zephyr OS build v4.4.0-11887-gc346929ea91d ***
TF-M FWU on stm32h573i_dk
Installing new firmware for component 1
Starting FWU
Writing 20773 bytes
Finishing FWU
Installing FWU
FWU installed, reboot required
Rebooting to apply the new firmware...[INF] Starting bootloader
[WRN] This device was provisioned with dummy keys. This device is NOT SECURE
[INF] PSA Crypto init done, sig_type: EC-P256
[INF] Primary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x1
[INF] Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
[INF] Boot source: primary slot
[INF] Image index: 1, Swap type: test
[INF] Starting swap using scratch algorithm.
[INF] Primary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x1
[INF] Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
[INF] Boot source: primary slot
[INF] Image index: 0, Swap type: none
[INF] Bootloader chainload address offset: 0x38000
[INF] Image version: v0.0.0
[INF] Jumping to the first image slot
[NOT] Booting TF-M v2.3.0+gd87b0151a
[NOT] Built Mon 17 Aug 2026 07:27:32 UTC
[WRN] This device was provisioned with dummy keys. This device is NOT SECURE
[INF] [PS] Encryption alg: 0x5500200
*** Booting Zephyr OS build v4.4.0-11887-gc346929ea91d ***
Swapped application booted on stm32h573i_dk
Component is in TRIAL state, accepting FWU
Cleaning up FWU
FWU completed successfully
```