### PR TITLE
[Backport v3.7-branch] bluetooth: mesh: fix delayable msg race

### DIFF
--- a/subsys/bluetooth/mesh/delayable_msg.c
+++ b/subsys/bluetooth/mesh/delayable_msg.c
@@ -224,7 +224,7 @@ int bt_mesh_delayable_msg_manage(struct bt_mesh_msg_ctx *ctx, struct net_buf_sim
 	sys_snode_t *node;
 	struct delayable_msg_ctx *msg;
 	uint16_t random_delay;
-	int total_number = DIV_ROUND_UP(buf->size, CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_SIZE);
+	int total_number = DIV_ROUND_UP(buf->len, CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_SIZE);
 	int allocated_number = 0;
 	uint16_t len = buf->len;
 

--- a/subsys/bluetooth/mesh/delayable_msg.c
+++ b/subsys/bluetooth/mesh/delayable_msg.c
@@ -96,7 +96,7 @@ static struct delayable_msg_ctx *peek_pending_msg(void)
 
 static void reschedule_delayable_msg(struct delayable_msg_ctx *msg)
 {
-	uint32_t curr_time;
+	int32_t remaining;
 	k_timeout_t delay = K_NO_WAIT;
 	struct delayable_msg_ctx *pending_msg;
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -112,9 +112,9 @@ static void reschedule_delayable_msg(struct delayable_msg_ctx *msg)
 		return;
 	}
 
-	curr_time = k_uptime_get_32();
-	if (curr_time < pending_msg->fired_time) {
-		delay = K_MSEC(pending_msg->fired_time - curr_time);
+	remaining = (int32_t)(pending_msg->fired_time - k_uptime_get_32());
+	if (remaining > 0) {
+		delay = K_MSEC(remaining);
 	}
 
 	/* k_work_reschedule() is safe to call under our spinlock: it uses its own internal spinlock
@@ -218,28 +218,55 @@ static void complete_delayable_msg(struct delayable_msg_ctx *msg, int err)
 	}
 }
 
-static bool push_msg_from_delayable_msgs(void)
+/* Signed delta keeps this correct across the 32-bit uptime wrap. */
+static bool msg_expired(const struct delayable_msg_ctx *msg)
+{
+	return (int32_t)(k_uptime_get_32() - msg->fired_time) >= 0;
+}
+
+/* Takes the head off busy_ctx only if it is due. k_work_reschedule() cannot withdraw a submission
+ * that already happened, so the handler can run for an expiry another context has consumed; this
+ * leaves such an invocation with nothing to send.
+ */
+static struct delayable_msg_ctx *take_expired_msg(void)
+{
+	struct delayable_msg_ctx *msg;
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	msg = peek_pending_msg();
+	if (msg && !msg_expired(msg)) {
+		msg = NULL;
+	} else if (msg) {
+		(void)sys_slist_get(&access_delayable_msg.busy_ctx);
+	}
+	k_spin_unlock(&lock, key);
+
+	return msg;
+}
+
+/* Takes the head whatever its fired_time, so the purge path can force out the earliest msg. */
+static struct delayable_msg_ctx *take_earliest_msg(void)
 {
 	sys_snode_t *node;
-	struct delayable_msg_chunk *chunk;
-	struct delayable_msg_ctx *msg;
-	uint16_t len;
-	int err;
-	k_spinlock_key_t key;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	/* Detaching the head under the lock stops concurrent pushers from sending and releasing
-	 * the same msg twice.
+	/* Dequeueing under the lock stops concurrent callers from sending and releasing the same
+	 * msg twice.
 	 */
-	key = k_spin_lock(&lock);
 	node = sys_slist_get(&access_delayable_msg.busy_ctx);
 	k_spin_unlock(&lock, key);
 
-	if (!node) {
-		return false;
-	}
+	return node ? CONTAINER_OF(node, struct delayable_msg_ctx, node) : NULL;
+}
 
-	msg = CONTAINER_OF(node, struct delayable_msg_ctx, node);
-	len = msg->len;
+/* Sends `msg` and releases it. Returns false if a transient failure put it back on busy_ctx. */
+static bool send_delayable_msg(struct delayable_msg_ctx *msg)
+{
+	sys_snode_t *node;
+	struct delayable_msg_chunk *chunk;
+	uint16_t len = msg->len;
+	int err;
+	k_spinlock_key_t key;
 
 	/* bt_mesh_suspend() sets BT_MESH_SUSPENDED and bt_mesh_reset() clears BT_MESH_VALID before
 	 * the queue is drained, so either one means the stack is down. Never hand a message to the
@@ -253,8 +280,8 @@ static bool push_msg_from_delayable_msgs(void)
 
 	NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_TX_SDU_MAX);
 
-	/* sys_slist_get() removed msg from busy_ctx, so it is on no list and unreachable from other
-	 * contexts; its chunks can be walked unlocked.
+	/* msg is off busy_ctx, so it is unreachable from other contexts and its chunks can be
+	 * walked unlocked.
 	 */
 	SYS_SLIST_FOR_EACH_NODE(&msg->chunks, node) {
 		uint16_t tmp = MIN(CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_SIZE, len);
@@ -288,14 +315,27 @@ static bool push_msg_from_delayable_msgs(void)
 	return true;
 }
 
+static bool push_msg_from_delayable_msgs(void)
+{
+	struct delayable_msg_ctx *msg = take_earliest_msg();
+
+	if (!msg) {
+		return false;
+	}
+
+	return send_delayable_msg(msg);
+}
+
 static void delayable_msg_handler(struct k_work *w)
 {
-	/* push_msg_from_delayable_msgs() re-arms the timer itself on the transient-failure path,
-	 * so only the success path needs it here.
-	 */
-	if (push_msg_from_delayable_msgs()) {
-		reschedule_delayable_msg(NULL);
+	struct delayable_msg_ctx *msg = take_expired_msg();
+
+	if (msg) {
+		(void)send_delayable_msg(msg);
 	}
+
+	/* Re-arms for the next msg, immediately if one is already due. */
+	reschedule_delayable_msg(NULL);
 }
 
 int bt_mesh_delayable_msg_manage(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf,

--- a/subsys/bluetooth/mesh/delayable_msg.c
+++ b/subsys/bluetooth/mesh/delayable_msg.c
@@ -46,6 +46,13 @@ static struct {
 	struct k_work_delayable random_delay;
 } access_delayable_msg = {.random_delay = Z_WORK_DELAYABLE_INITIALIZER(delayable_msg_handler)};
 
+/* Serializes access to busy_ctx, free_ctx, free_chunks, and the fired_time field of any ctx
+ * currently on busy_ctx. Must never be held across a call that can block (bt_mesh_access_send(),
+ * bt_rand(), user callbacks).
+ */
+static struct k_spinlock lock;
+
+/* Caller must hold `lock`. */
 static void put_ctx_to_busy_list(struct delayable_msg_ctx *ctx)
 {
 	struct delayable_msg_ctx *curr_ctx;
@@ -92,6 +99,7 @@ static void reschedule_delayable_msg(struct delayable_msg_ctx *msg)
 	uint32_t curr_time;
 	k_timeout_t delay = K_NO_WAIT;
 	struct delayable_msg_ctx *pending_msg;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	if (msg) {
 		put_ctx_to_busy_list(msg);
@@ -100,6 +108,7 @@ static void reschedule_delayable_msg(struct delayable_msg_ctx *msg)
 	pending_msg = peek_pending_msg();
 
 	if (!pending_msg) {
+		k_spin_unlock(&lock, key);
 		return;
 	}
 
@@ -108,48 +117,73 @@ static void reschedule_delayable_msg(struct delayable_msg_ctx *msg)
 		delay = K_MSEC(pending_msg->fired_time - curr_time);
 	}
 
+	/* k_work_reschedule() is safe to call under our spinlock: it uses its own internal spinlock
+	 * and does not block. Holding the lock here makes the "select head + arm timer" step atomic
+	 * w.r.t. concurrent insertions.
+	 */
 	k_work_reschedule(&access_delayable_msg.random_delay, delay);
+	k_spin_unlock(&lock, key);
 }
 
 static int allocate_delayable_msg_chunks(struct delayable_msg_ctx *msg, int number)
 {
 	sys_snode_t *node;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	for (int i = 0; i < number; i++) {
 		node = sys_slist_get(&access_delayable_msg.free_chunks);
 		if (!node) {
+			k_spin_unlock(&lock, key);
 			LOG_WRN("Unable allocate %u chunks, allocated %u", number, i);
 			return i;
 		}
 		sys_slist_append(&msg->chunks, node);
 	}
 
+	k_spin_unlock(&lock, key);
 	return number;
 }
 
 static void release_delayable_msg_chunks(struct delayable_msg_ctx *msg)
 {
 	sys_snode_t *node;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	while ((node = sys_slist_get(&msg->chunks))) {
 		sys_slist_append(&access_delayable_msg.free_chunks, node);
 	}
+	k_spin_unlock(&lock, key);
 }
 
 static struct delayable_msg_ctx *allocate_delayable_msg_ctx(void)
 {
 	struct delayable_msg_ctx *msg;
 	sys_snode_t *node;
+	k_spinlock_key_t key;
 
-	if (sys_slist_is_empty(&access_delayable_msg.free_ctx)) {
+	key = k_spin_lock(&lock);
+	node = sys_slist_get(&access_delayable_msg.free_ctx);
+	k_spin_unlock(&lock, key);
+
+	if (!node) {
 		LOG_WRN("Purge pending delayable message.");
+		/* May block, so it must not be called with the lock held. */
 		if (!push_msg_from_delayable_msgs()) {
+			return NULL;
+		}
+
+		key = k_spin_lock(&lock);
+		node = sys_slist_get(&access_delayable_msg.free_ctx);
+		k_spin_unlock(&lock, key);
+
+		/* Another context may have taken the purged ctx before we retried. */
+		if (!node) {
 			return NULL;
 		}
 	}
 
-	node = sys_slist_get(&access_delayable_msg.free_ctx);
 	msg = CONTAINER_OF(node, struct delayable_msg_ctx, node);
+	/* msg is off every list here, so it is private to this caller. */
 	sys_slist_init(&msg->chunks);
 
 	return msg;
@@ -157,27 +191,71 @@ static struct delayable_msg_ctx *allocate_delayable_msg_ctx(void)
 
 static void release_delayable_msg_ctx(struct delayable_msg_ctx *ctx)
 {
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
 	/* Not on busy_ctx when called from the manage() error path. */
 	(void)sys_slist_find_and_remove(&access_delayable_msg.busy_ctx, &ctx->node);
 	sys_slist_append(&access_delayable_msg.free_ctx, &ctx->node);
+	k_spin_unlock(&lock, key);
+}
+
+/* Releases `msg` and reports `err` to its sender, which is skipped for a successful send because
+ * the transport owns the callback from then on. Must not be called with the lock held.
+ */
+static void complete_delayable_msg(struct delayable_msg_ctx *msg, int err)
+{
+	/* Capture the callback before releasing the ctx; another caller may take it immediately
+	 * and overwrite msg->cb / msg->cb_data.
+	 */
+	const struct bt_mesh_send_cb *cb = msg->cb;
+	void *cb_data = msg->cb_data;
+
+	release_delayable_msg_chunks(msg);
+	release_delayable_msg_ctx(msg);
+
+	if (err && cb && cb->start) {
+		cb->start(0, err, cb_data);
+	}
 }
 
 static bool push_msg_from_delayable_msgs(void)
 {
 	sys_snode_t *node;
 	struct delayable_msg_chunk *chunk;
-	struct delayable_msg_ctx *msg = peek_pending_msg();
+	struct delayable_msg_ctx *msg;
 	uint16_t len;
 	int err;
+	k_spinlock_key_t key;
 
-	if (!msg) {
+	/* Detaching the head under the lock stops concurrent pushers from sending and releasing
+	 * the same msg twice.
+	 */
+	key = k_spin_lock(&lock);
+	node = sys_slist_get(&access_delayable_msg.busy_ctx);
+	k_spin_unlock(&lock, key);
+
+	if (!node) {
 		return false;
 	}
 
+	msg = CONTAINER_OF(node, struct delayable_msg_ctx, node);
 	len = msg->len;
+
+	/* bt_mesh_suspend() sets BT_MESH_SUSPENDED and bt_mesh_reset() clears BT_MESH_VALID before
+	 * the queue is drained, so either one means the stack is down. Never hand a message to the
+	 * transport in that state, however it ended up on busy_ctx.
+	 */
+	if (atomic_test_bit(bt_mesh.flags, BT_MESH_SUSPENDED) ||
+	    !atomic_test_bit(bt_mesh.flags, BT_MESH_VALID)) {
+		complete_delayable_msg(msg, -ENODEV);
+		return true;
+	}
 
 	NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_TX_SDU_MAX);
 
+	/* sys_slist_get() removed msg from busy_ctx, so it is on no list and unreachable from other
+	 * contexts; its chunks can be walked unlocked.
+	 */
 	SYS_SLIST_FOR_EACH_NODE(&msg->chunks, node) {
 		uint16_t tmp = MIN(CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_SIZE, len);
 
@@ -187,33 +265,35 @@ static bool push_msg_from_delayable_msgs(void)
 	}
 
 	msg->ctx.rnd_delay = false;
+	/* Blocking call: must NOT hold the spinlock. */
 	err = bt_mesh_access_send(&msg->ctx, &buf, msg->src_addr, msg->cb, msg->cb_data);
 	msg->ctx.rnd_delay = true;
 
 	if (err == -EBUSY || err == -ENOBUFS) {
+		/* Transient failure: retry the msg 10 ms later, re-sorted into busy_ctx, and
+		 * re-arm the timer for whatever is now the head.
+		 */
+		key = k_spin_lock(&lock);
+		msg->fired_time += 10;
+		put_ctx_to_busy_list(msg);
+		k_spin_unlock(&lock, key);
+
+		reschedule_delayable_msg(NULL);
 		return false;
 	}
 
-	release_delayable_msg_chunks(msg);
-	release_delayable_msg_ctx(msg);
-
-	if (err && msg->cb && msg->cb->start) {
-		msg->cb->start(0, err, msg->cb_data);
-	}
+	/* User callback: must NOT hold the spinlock. */
+	complete_delayable_msg(msg, err);
 
 	return true;
 }
 
 static void delayable_msg_handler(struct k_work *w)
 {
-	if (!push_msg_from_delayable_msgs()) {
-		sys_snode_t *node = sys_slist_get(&access_delayable_msg.busy_ctx);
-		struct delayable_msg_ctx *pending_msg =
-			CONTAINER_OF(node, struct delayable_msg_ctx, node);
-
-		pending_msg->fired_time += 10;
-		reschedule_delayable_msg(pending_msg);
-	} else {
+	/* push_msg_from_delayable_msgs() re-arms the timer itself on the transient-failure path,
+	 * so only the success path needs it here.
+	 */
+	if (push_msg_from_delayable_msgs()) {
 		reschedule_delayable_msg(NULL);
 	}
 }
@@ -300,17 +380,19 @@ void bt_mesh_delayable_msg_init(void)
 void bt_mesh_delayable_msg_stop(void)
 {
 	sys_snode_t *node;
-	struct delayable_msg_ctx *ctx;
+	k_spinlock_key_t key;
 
 	k_work_cancel_delayable(&access_delayable_msg.random_delay);
 
-	while ((node = sys_slist_peek_head(&access_delayable_msg.busy_ctx))) {
-		ctx = CONTAINER_OF(node, struct delayable_msg_ctx, node);
-		release_delayable_msg_chunks(ctx);
-		release_delayable_msg_ctx(ctx);
+	for (;;) {
+		key = k_spin_lock(&lock);
+		node = sys_slist_get(&access_delayable_msg.busy_ctx);
+		k_spin_unlock(&lock, key);
 
-		if (ctx->cb && ctx->cb->start) {
-			ctx->cb->start(0, -ENODEV, ctx->cb_data);
+		if (!node) {
+			break;
 		}
+
+		complete_delayable_msg(CONTAINER_OF(node, struct delayable_msg_ctx, node), -ENODEV);
 	}
 }

--- a/subsys/bluetooth/mesh/delayable_msg.c
+++ b/subsys/bluetooth/mesh/delayable_msg.c
@@ -157,9 +157,9 @@ static struct delayable_msg_ctx *allocate_delayable_msg_ctx(void)
 
 static void release_delayable_msg_ctx(struct delayable_msg_ctx *ctx)
 {
-	if (sys_slist_find_and_remove(&access_delayable_msg.busy_ctx, &ctx->node)) {
-		sys_slist_append(&access_delayable_msg.free_ctx, &ctx->node);
-	}
+	/* Not on busy_ctx when called from the manage() error path. */
+	(void)sys_slist_find_and_remove(&access_delayable_msg.busy_ctx, &ctx->node);
+	sys_slist_append(&access_delayable_msg.free_ctx, &ctx->node);
 }
 
 static bool push_msg_from_delayable_msgs(void)

--- a/tests/bluetooth/mesh/delayable_msg/src/main.c
+++ b/tests/bluetooth/mesh/delayable_msg/src/main.c
@@ -168,13 +168,13 @@ ZTEST(bt_mesh_delayable_msg, test_self_sorting)
 	NET_BUF_SIMPLE_DEFINE(buf4, 20);
 
 	memset(tx_data, 1, 20);
-	memcpy(net_buf_simple_add(&buf1, 20), tx_data, 20);
+	net_buf_simple_add_mem(&buf1, tx_data, 20);
 	memset(tx_data, 2, 20);
-	memcpy(net_buf_simple_add(&buf2, 20), tx_data, 20);
+	net_buf_simple_add_mem(&buf2, tx_data, 20);
 	memset(tx_data, 3, 20);
-	memcpy(net_buf_simple_add(&buf3, 20), tx_data, 20);
+	net_buf_simple_add_mem(&buf3, tx_data, 20);
 	memset(tx_data, 4, 20);
-	memcpy(net_buf_simple_add(&buf4, 20), tx_data, 20);
+	net_buf_simple_add_mem(&buf4, tx_data, 20);
 
 	is_fake_random = true;
 	fake_random = 30;
@@ -216,7 +216,7 @@ ZTEST(bt_mesh_delayable_msg, test_ctx_reallocation)
 	NET_BUF_SIMPLE_DEFINE(buf, 20);
 
 	memset(tx_data, 1, 20);
-	memcpy(net_buf_simple_add(&buf, 20), tx_data, 20);
+	net_buf_simple_add_mem(&buf, tx_data, 20);
 
 	accum_mask = true;
 	is_fake_random = true;
@@ -250,12 +250,16 @@ ZTEST(bt_mesh_delayable_msg, test_chunk_reallocation)
 	NET_BUF_SIMPLE_DEFINE(buf2, BT_MESH_TX_SDU_MAX);
 
 	memset(tx_data, 1, BT_MESH_TX_SDU_MAX);
-	memcpy(net_buf_simple_add(&buf1, 20), tx_data, 20);
-	memcpy(net_buf_simple_add(&buf2, BT_MESH_TX_SDU_MAX), tx_data, BT_MESH_TX_SDU_MAX);
+	net_buf_simple_add_mem(&buf2, tx_data, BT_MESH_TX_SDU_MAX);
 
 	accum_mask = true;
+	net_buf_simple_add_mem(&buf1, tx_data, 20);
 	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf1, SRC_ADDR, &send_cb, &buf_id1));
+	net_buf_simple_reset(&buf1);
+	net_buf_simple_add_mem(&buf1, tx_data, 20);
 	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf1, SRC_ADDR, &send_cb, &buf_id2));
+	net_buf_simple_reset(&buf1);
+	net_buf_simple_add_mem(&buf1, tx_data, 20);
 	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf1, SRC_ADDR, &send_cb, &buf_id3));
 	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf2, SRC_ADDR, &send_cb, &buf_id4));
 	zassert_equal(id_mask, 0x0007, "Delayed message chunks reallocation was broken");
@@ -278,9 +282,9 @@ ZTEST(bt_mesh_delayable_msg, test_cb_error_status)
 	NET_BUF_SIMPLE_DEFINE(buf3, 20);
 
 	memset(tx_data, 1, BT_MESH_TX_SDU_MAX);
-	memcpy(net_buf_simple_add(&buf1, 20), tx_data, 20);
-	memcpy(net_buf_simple_add(&buf2, 20), tx_data, 20);
-	memcpy(net_buf_simple_add(&buf3, 20), tx_data, 20);
+	net_buf_simple_add_mem(&buf1, tx_data, 20);
+	net_buf_simple_add_mem(&buf2, tx_data, 20);
+	net_buf_simple_add_mem(&buf3, tx_data, 20);
 
 	cb_err_status = -ENOBUFS;
 	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf1, SRC_ADDR, &send_cb, &buf_id));
@@ -323,7 +327,7 @@ ZTEST(bt_mesh_delayable_msg, test_stop_handler)
 	NET_BUF_SIMPLE_DEFINE(buf, 20);
 
 	memset(tx_data, 1, 20);
-	memcpy(net_buf_simple_add(&buf, 20), tx_data, 20);
+	net_buf_simple_add_mem(&buf, tx_data, 20);
 
 	accum_mask = true;
 	cb_err_status = -ENODEV;
@@ -335,4 +339,48 @@ ZTEST(bt_mesh_delayable_msg, test_stop_handler)
 	zexpect_not_ok(k_sem_take(&delayed_msg_sent, K_SECONDS(1)),
 		       "Delayed message has been sent after stopping.");
 	zassert_equal(id_mask, 0x000F, "Not all scheduled messages were handled after stopping");
+}
+
+/* The test checks that chunk allocation is based on actual data length (buf->len)
+ * and not on buffer capacity (buf->size). Four messages with small payloads in
+ * large-capacity buffers should consume exactly the full chunk pool without error
+ * or eviction.
+ *
+ * With CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_SIZE=20,
+ * CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_COUNT=20 and data_len=100:
+ *   DIV_ROUND_UP(100, 20) = 5 chunks per msg, 4 msgs * 5 = 20 chunks (full pool)
+ */
+ZTEST(bt_mesh_delayable_msg, test_chunk_alloc_by_data_len)
+{
+	uint8_t tx_data[100];
+	uint32_t buf_id1 = 0;
+	uint32_t buf_id2 = 1;
+	uint32_t buf_id3 = 2;
+	uint32_t buf_id4 = 3;
+
+	NET_BUF_SIMPLE_DEFINE(buf1, BT_MESH_TX_SDU_MAX);
+	NET_BUF_SIMPLE_DEFINE(buf2, BT_MESH_TX_SDU_MAX);
+	NET_BUF_SIMPLE_DEFINE(buf3, BT_MESH_TX_SDU_MAX);
+	NET_BUF_SIMPLE_DEFINE(buf4, BT_MESH_TX_SDU_MAX);
+
+	memset(tx_data, 1, sizeof(tx_data));
+	net_buf_simple_add_mem(&buf1, tx_data, sizeof(tx_data));
+	net_buf_simple_add_mem(&buf2, tx_data, sizeof(tx_data));
+	net_buf_simple_add_mem(&buf3, tx_data, sizeof(tx_data));
+	net_buf_simple_add_mem(&buf4, tx_data, sizeof(tx_data));
+
+	accum_mask = true;
+	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf1, SRC_ADDR, &send_cb, &buf_id1));
+	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf2, SRC_ADDR, &send_cb, &buf_id2));
+	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf3, SRC_ADDR, &send_cb, &buf_id3));
+	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf4, SRC_ADDR, &send_cb, &buf_id4));
+
+	/* All 4 messages should coexist using the full chunk pool (5 chunks each)
+	 * without any eviction.
+	 */
+	zassert_equal(id_mask, 0,
+		      "Messages were evicted unexpectedly (id_mask: 0x%04x)", id_mask);
+
+	k_sleep(K_MSEC(500));
+	zassert_equal(id_mask, 0x000F, "Not all messages were sent (id_mask: 0x%04x)", id_mask);
 }

--- a/tests/bluetooth/mesh/delayable_msg/src/main.c
+++ b/tests/bluetooth/mesh/delayable_msg/src/main.c
@@ -111,6 +111,9 @@ static void tc_setup(void *fixture)
 	do_not_call_cb = false;
 	cb_err_status = 0;
 	k_sem_reset(&delayed_msg_sent);
+	/* The module only queues messages for a provisioned, running node. */
+	atomic_clear_bit(bt_mesh.flags, BT_MESH_SUSPENDED);
+	atomic_set_bit(bt_mesh.flags, BT_MESH_VALID);
 	bt_mesh_delayable_msg_init();
 }
 

--- a/tests/bluetooth/mesh/delayable_msg/src/main.c
+++ b/tests/bluetooth/mesh/delayable_msg/src/main.c
@@ -739,3 +739,68 @@ ZTEST(bt_mesh_delayable_msg, test_stop_during_in_flight_send)
 			      stop_race_slots[i].err);
 	}
 }
+
+#define STALE_BUF_LEN 20
+
+/* Regression test for a stale work invocation sending the next message before it is due.
+ *
+ * k_work_reschedule() does not withdraw a submission that already happened, so the handler can run
+ * for an expiry that another context has already consumed. Popping the head unconditionally then
+ * transmits a message that is not due, truncating the random delay the Access layer transmission
+ * rules require.
+ *
+ * The interleaving is built from a cooperative thread above the sysworkq priority: k_busy_wait()
+ * lets the first deadline expire and its work be submitted without giving the sysworkq a chance to
+ * run, and the purge path then consumes that same message, leaving the submission stale.
+ */
+ZTEST(bt_mesh_delayable_msg, test_stale_handler_no_early_send)
+{
+	/* bt_rand() is mocked, so these become delays of 20, 420, 430 and 440 ms. */
+	static const uint16_t fake_delays[] = {0, 400, 410, 420};
+	uint8_t tx_data[STALE_BUF_LEN];
+	int orig_prio;
+	int sends_after_purge;
+	int sends_at_end;
+
+	NET_BUF_SIMPLE_DEFINE(buf, STALE_BUF_LEN);
+
+	memset(tx_data, 3, sizeof(tx_data));
+
+	orig_prio = k_thread_priority_get(k_current_get());
+	k_thread_priority_set(k_current_get(), STRESS_COOP_PRIO);
+	is_fake_random = true;
+
+	for (int i = 0; i < ARRAY_SIZE(fake_delays); i++) {
+		fake_random = fake_delays[i];
+		net_buf_simple_reset(&buf);
+		net_buf_simple_add_mem(&buf, tx_data, sizeof(tx_data));
+		zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, NULL, NULL));
+	}
+
+	/* Let the first deadline expire and its work be submitted. Busy-waiting keeps the CPU, so
+	 * the cooperative sysworkq cannot run the handler yet.
+	 */
+	k_busy_wait(40 * USEC_PER_MSEC);
+
+	/* The ctx pool is full, so this call purges the first message itself. The submission made
+	 * on its behalf is now stale.
+	 */
+	fake_random = 440;
+	net_buf_simple_reset(&buf);
+	net_buf_simple_add_mem(&buf, tx_data, sizeof(tx_data));
+	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, NULL, NULL));
+
+	/* Hand the CPU over so the stale invocation runs while nothing is due. */
+	k_sleep(K_MSEC(50));
+	sends_after_purge = atomic_get(&send_call_count);
+
+	k_sleep(K_MSEC(600));
+	sends_at_end = atomic_get(&send_call_count);
+
+	k_thread_priority_set(k_current_get(), orig_prio);
+	is_fake_random = false;
+
+	zassert_equal(sends_after_purge, 1, "Message sent before it was due (%d sends, expected 1)",
+		      sends_after_purge);
+	zassert_equal(sends_at_end, 5, "Not every message was sent (%d of 5)", sends_at_end);
+}

--- a/tests/bluetooth/mesh/delayable_msg/src/main.c
+++ b/tests/bluetooth/mesh/delayable_msg/src/main.c
@@ -39,11 +39,13 @@ static bool is_fake_random;
 static bool check_expectations;
 static bool accum_mask;
 static bool do_not_call_cb;
+static bool yield_in_send;
 static uint16_t fake_random;
 static uint8_t *buf_data;
 static size_t buf_data_size;
 static uint16_t id_mask;
 static int cb_err_status;
+static atomic_t send_call_count;
 
 K_SEM_DEFINE(delayed_msg_sent, 0, 1);
 
@@ -51,6 +53,8 @@ K_SEM_DEFINE(delayed_msg_sent, 0, 1);
 int bt_mesh_access_send(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf, uint16_t src_addr,
 			const struct bt_mesh_send_cb *cb, void *cb_data)
 {
+	atomic_inc(&send_call_count);
+
 	if (check_expectations) {
 		gctx.rnd_delay = false;
 		ztest_check_expected_data(ctx, sizeof(struct bt_mesh_msg_ctx));
@@ -63,6 +67,13 @@ int bt_mesh_access_send(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf,
 
 	if (cb && !do_not_call_cb) {
 		cb->start(0x0, cb_err_status, cb_data);
+	}
+
+	/* Models the caller blocking inside the transport: the delayable msg has already been
+	 * detached from busy_ctx at this point.
+	 */
+	if (yield_in_send) {
+		k_yield();
 	}
 
 	return cb_err_status;
@@ -109,7 +120,9 @@ static void tc_setup(void *fixture)
 	accum_mask = false;
 	id_mask = 0;
 	do_not_call_cb = false;
+	yield_in_send = false;
 	cb_err_status = 0;
+	atomic_set(&send_call_count, 0);
 	k_sem_reset(&delayed_msg_sent);
 	/* The module only queues messages for a provisioned, running node. */
 	atomic_clear_bit(bt_mesh.flags, BT_MESH_SUSPENDED);
@@ -339,8 +352,10 @@ ZTEST(bt_mesh_delayable_msg, test_stop_handler)
 	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, &send_cb, &buf_id3));
 	zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, &send_cb, &buf_id4));
 	bt_mesh_delayable_msg_stop();
-	zexpect_not_ok(k_sem_take(&delayed_msg_sent, K_SECONDS(1)),
-		       "Delayed message has been sent after stopping.");
+	/* Long enough for any timer that survived the stop to fire. */
+	k_sleep(K_SECONDS(1));
+	zassert_equal(atomic_get(&send_call_count), 0,
+		      "Delayed message has been sent after stopping.");
 	zassert_equal(id_mask, 0x000F, "Not all scheduled messages were handled after stopping");
 }
 
@@ -386,4 +401,341 @@ ZTEST(bt_mesh_delayable_msg, test_chunk_alloc_by_data_len)
 
 	k_sleep(K_MSEC(500));
 	zassert_equal(id_mask, 0x000F, "Not all messages were sent (id_mask: 0x%04x)", id_mask);
+}
+
+#define STRESS_ITER    40
+#define STRESS_BUF_LEN 20
+
+/* Cooperative priority for the main test thread and the helper: strictly higher (more negative)
+ * than the sysworkq default of -1, mirroring the production model where the enqueuing contexts
+ * (BT RX WQ) run cooperatively above the sysworkq that runs delayable_msg_handler().
+ */
+#define STRESS_COOP_PRIO K_PRIO_COOP(6)
+
+K_THREAD_STACK_DEFINE(stress_helper_stack, 4096);
+static struct k_thread stress_helper_thread;
+
+/* Per-msg callback counters. Each manage() call passes a pointer to one entry as cb_data, and a
+ * correct implementation increments every scheduled entry exactly once. Counting per entry catches
+ * both a msg sent twice and a msg silently dropped, which the aggregate counters can hide.
+ */
+static atomic_t stress_main_cb_count[STRESS_ITER];
+static atomic_t stress_helper_cb_count[STRESS_ITER];
+
+/* Aggregate counts kept for a quick sanity check and diagnostic output. */
+static atomic_t stress_scheduled;
+static atomic_t stress_cb_count;
+
+/* cb_data pointers passed to manage(). Only the slots that were actually scheduled fire. */
+static atomic_t *stress_main_slot[STRESS_ITER];
+static atomic_t *stress_helper_slot[STRESS_ITER];
+
+static void stress_cb_start(uint16_t duration, int err, void *cb_data)
+{
+	ARG_UNUSED(duration);
+	ARG_UNUSED(err);
+
+	atomic_inc(&stress_cb_count);
+	/* cb_data points directly at the per-slot counter for this msg. */
+	atomic_inc((atomic_t *)cb_data);
+	/* The mock calls this synchronously from inside bt_mesh_access_send(), that is, while
+	 * push_msg_from_delayable_msgs() is still working on the detached msg. Yielding here hands
+	 * the CPU to the other cooperative enqueuer at exactly that point.
+	 */
+	k_yield();
+}
+
+static const struct bt_mesh_send_cb stress_send_cb = {
+	.start = stress_cb_start,
+};
+
+static void stress_helper_fn(void *a, void *b, void *c)
+{
+	uint8_t data[STRESS_BUF_LEN];
+
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
+	ARG_UNUSED(c);
+
+	memset(data, 0x5A, sizeof(data));
+
+	for (int i = 0; i < STRESS_ITER; i++) {
+		NET_BUF_SIMPLE_DEFINE(buf, STRESS_BUF_LEN);
+		int err;
+
+		net_buf_simple_add_mem(&buf, data, STRESS_BUF_LEN);
+		stress_helper_slot[i] = &stress_helper_cb_count[i];
+		err = bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, &stress_send_cb,
+						   stress_helper_slot[i]);
+		if (err == 0) {
+			atomic_inc(&stress_scheduled);
+		} else {
+			/* Not queued: mark this slot as "not expected". */
+			stress_helper_slot[i] = NULL;
+		}
+		/* Cooperative round-robin: hand the CPU to the other same-priority enqueuer.
+		 * Neither thread can be preempted, so the interleaving points are exactly the
+		 * yield sites.
+		 */
+		k_yield();
+	}
+}
+
+/* Regression test for unsynchronized cross-thread access to the delayable msg lists.
+ *
+ * Two cooperative threads at the same priority (the ZTEST main thread, temporarily raised, and a
+ * helper) call bt_mesh_delayable_msg_manage() alternately via k_yield(), and the mocked send yields
+ * as well, so a second enqueuer enters push_msg_from_delayable_msgs() while the first is still
+ * working on the head msg. The sysworkq handler drains the queue during the final k_sleep().
+ *
+ * Callbacks are counted per cb_data slot: a msg sent twice and a msg silently dropped cancel each
+ * other out in the aggregate counters, but not per slot.
+ */
+ZTEST(bt_mesh_delayable_msg, test_concurrent_manage)
+{
+	uint8_t data[STRESS_BUF_LEN];
+	atomic_t final_cb_slot = ATOMIC_INIT(0);
+	int orig_prio;
+	int join_result;
+	int post_manage_result;
+	int scheduled_snapshot;
+	int completed_snapshot;
+	int per_slot_failures = 0;
+	int final_completed;
+
+	memset(data, 0xA5, sizeof(data));
+
+	atomic_set(&stress_scheduled, 0);
+	atomic_set(&stress_cb_count, 0);
+	for (int i = 0; i < STRESS_ITER; i++) {
+		atomic_set(&stress_main_cb_count[i], 0);
+		atomic_set(&stress_helper_cb_count[i], 0);
+		stress_main_slot[i] = NULL;
+		stress_helper_slot[i] = NULL;
+	}
+
+	/* This thread and the helper run at the same cooperative priority, above the sysworkq, so
+	 * neither can be preempted and every scheduling transition happens at a k_yield()/k_sleep.
+	 */
+	orig_prio = k_thread_priority_get(k_current_get());
+	k_thread_priority_set(k_current_get(), STRESS_COOP_PRIO);
+
+	k_thread_create(&stress_helper_thread, stress_helper_stack,
+			K_THREAD_STACK_SIZEOF(stress_helper_stack), stress_helper_fn, NULL,
+			NULL, NULL, STRESS_COOP_PRIO, 0, K_NO_WAIT);
+	k_thread_name_set(&stress_helper_thread, "stress_helper");
+
+	for (int i = 0; i < STRESS_ITER; i++) {
+		NET_BUF_SIMPLE_DEFINE(buf, STRESS_BUF_LEN);
+		int err;
+
+		net_buf_simple_add_mem(&buf, data, STRESS_BUF_LEN);
+		stress_main_slot[i] = &stress_main_cb_count[i];
+		err = bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, &stress_send_cb,
+						   stress_main_slot[i]);
+		if (err == 0) {
+			atomic_inc(&stress_scheduled);
+		} else {
+			stress_main_slot[i] = NULL;
+		}
+		k_yield();
+	}
+
+	/* Capture the join result before touching the priority or asserting, as zassert may
+	 * long-jump out of the test.
+	 */
+	join_result = k_thread_join(&stress_helper_thread, K_SECONDS(5));
+
+	/* Drain: main blocks, so the sysworkq becomes the only runnable cooperative thread and
+	 * fires the handler until busy_ctx is empty. The random delay is up to ~500 ms per msg for
+	 * group addresses, so give a generous margin.
+	 */
+	k_sleep(K_SECONDS(2));
+
+	scheduled_snapshot = atomic_get(&stress_scheduled);
+	completed_snapshot = atomic_get(&stress_cb_count);
+
+	/* Every scheduled slot must have received exactly one callback, every unscheduled slot
+	 * none.
+	 */
+	for (int i = 0; i < STRESS_ITER; i++) {
+		int m = atomic_get(&stress_main_cb_count[i]);
+		int h = atomic_get(&stress_helper_cb_count[i]);
+		int m_expected = stress_main_slot[i] ? 1 : 0;
+		int h_expected = stress_helper_slot[i] ? 1 : 0;
+
+		if (m != m_expected || h != h_expected) {
+			per_slot_failures++;
+		}
+	}
+
+	/* Scheduling one more msg proves that the free and busy lists are consistent and that
+	 * nothing was leaked out of both of them.
+	 */
+	NET_BUF_SIMPLE_DEFINE(final_buf, STRESS_BUF_LEN);
+
+	net_buf_simple_add_mem(&final_buf, data, STRESS_BUF_LEN);
+	post_manage_result = bt_mesh_delayable_msg_manage(&gctx, &final_buf, SRC_ADDR,
+							  &stress_send_cb, &final_cb_slot);
+
+	k_sleep(K_MSEC(700));
+	final_completed = atomic_get(&stress_cb_count);
+
+	/* Restore the priority before any zassert that could long-jump out of the test, so the
+	 * remaining test cases run with the expected one.
+	 */
+	k_thread_priority_set(k_current_get(), orig_prio);
+
+	zassert_ok(join_result, "Helper thread did not terminate (join=%d)", join_result);
+	zassert_equal(per_slot_failures, 0,
+		      "Race detected: %d slots received a wrong callback count "
+		      "(exactly-once delivery contract violated). "
+		      "scheduled=%d completed=%d",
+		      per_slot_failures, scheduled_snapshot, completed_snapshot);
+	zassert_equal(scheduled_snapshot, completed_snapshot,
+		      "Race detected (aggregate): scheduled=%d completed=%d",
+		      scheduled_snapshot, completed_snapshot);
+	zassert_ok(post_manage_result,
+		   "Post-stress manage() failed (%d): indicates leak or list corruption",
+		   post_manage_result);
+	zassert_equal(atomic_get(&final_cb_slot), 1,
+		      "Post-stress callback did not fire exactly once (got %d)",
+		      (int)atomic_get(&final_cb_slot));
+	zassert_equal(final_completed, completed_snapshot + 1,
+		      "Post-stress aggregate cb count off: final=%d snapshot=%d",
+		      final_completed, completed_snapshot);
+}
+
+#define STOP_RACE_MSGS 4
+#define STOP_RACE_LEN  20
+
+struct stop_race_slot {
+	atomic_t count;
+	int err;
+};
+
+static struct stop_race_slot stop_race_slots[STOP_RACE_MSGS];
+static struct stop_race_slot stop_race_extra_slot;
+
+static void stop_race_cb_start(uint16_t duration, int err, void *cb_data)
+{
+	struct stop_race_slot *slot = cb_data;
+
+	ARG_UNUSED(duration);
+
+	slot->err = err;
+	atomic_inc(&slot->count);
+}
+
+static const struct bt_mesh_send_cb stop_race_send_cb = {
+	.start = stop_race_cb_start,
+};
+
+K_THREAD_STACK_DEFINE(stop_race_stack, 2048);
+static struct k_thread stop_race_thread;
+
+static void stop_race_stopper_fn(void *a, void *b, void *c)
+{
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
+	ARG_UNUSED(c);
+
+	/* Mirrors bt_mesh_suspend(): the flag is set before the queue is drained. */
+	atomic_set_bit(bt_mesh.flags, BT_MESH_SUSPENDED);
+	bt_mesh_delayable_msg_stop();
+}
+
+/* Regression test for a message left in flight across bt_mesh_delayable_msg_stop().
+ *
+ * push_msg_from_delayable_msgs() detaches the head from busy_ctx before the blocking send, so a
+ * concurrent stop() cannot see that context and cannot complete it. If the send then reports
+ * -EBUSY or -ENOBUFS, the context must not be queued again on the stopped stack.
+ *
+ * The interleaving is forced deterministically: the ctx pool is filled, so the next manage() takes
+ * the purge path and calls push_msg_from_delayable_msgs() itself; the mocked send yields, handing
+ * the CPU to a same-priority cooperative thread that suspends and stops the module; the send then
+ * reports -ENOBUFS, so the message is queued again behind the drain. It must not reach the
+ * transport after that, and the message that manage() was building must not be accepted either.
+ */
+ZTEST(bt_mesh_delayable_msg, test_stop_during_in_flight_send)
+{
+	uint8_t tx_data[STOP_RACE_LEN];
+	int orig_prio;
+	int join_result;
+	int manage_result;
+	int sends_after_stop;
+
+	NET_BUF_SIMPLE_DEFINE(buf, STOP_RACE_LEN);
+
+	memset(tx_data, 1, sizeof(tx_data));
+
+	for (int i = 0; i < STOP_RACE_MSGS; i++) {
+		atomic_set(&stop_race_slots[i].count, 0);
+		stop_race_slots[i].err = 0;
+	}
+	atomic_set(&stop_race_extra_slot.count, 0);
+	stop_race_extra_slot.err = 0;
+
+	/* Cooperative priority above the sysworkq, so every context switch happens at an explicit
+	 * yield site.
+	 */
+	orig_prio = k_thread_priority_get(k_current_get());
+	k_thread_priority_set(k_current_get(), STRESS_COOP_PRIO);
+
+	for (int i = 0; i < STOP_RACE_MSGS; i++) {
+		net_buf_simple_reset(&buf);
+		net_buf_simple_add_mem(&buf, tx_data, sizeof(tx_data));
+		zexpect_ok(bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, &stop_race_send_cb,
+							&stop_race_slots[i]));
+	}
+
+	k_thread_create(&stop_race_thread, stop_race_stack,
+			K_THREAD_STACK_SIZEOF(stop_race_stack), stop_race_stopper_fn, NULL, NULL,
+			NULL, STRESS_COOP_PRIO, 0, K_NO_WAIT);
+	k_thread_name_set(&stop_race_thread, "stop_race_stopper");
+
+	/* The transport reports no buffers and does not raise the callback itself, exactly as it
+	 * does while the advertiser is suspended.
+	 */
+	cb_err_status = -ENOBUFS;
+	do_not_call_cb = true;
+	yield_in_send = true;
+
+	net_buf_simple_reset(&buf);
+	net_buf_simple_add_mem(&buf, tx_data, sizeof(tx_data));
+	manage_result = bt_mesh_delayable_msg_manage(&gctx, &buf, SRC_ADDR, &stop_race_send_cb,
+						     &stop_race_extra_slot);
+
+	yield_in_send = false;
+	do_not_call_cb = false;
+	cb_err_status = 0;
+
+	join_result = k_thread_join(&stop_race_thread, K_SECONDS(5));
+
+	sends_after_stop = atomic_get(&send_call_count);
+	/* Long enough for a resurrected message to fire (backoff is 10 ms). */
+	k_sleep(K_SECONDS(1));
+
+	k_thread_priority_set(k_current_get(), orig_prio);
+	atomic_clear_bit(bt_mesh.flags, BT_MESH_SUSPENDED);
+
+	zassert_ok(join_result, "Stopper thread did not terminate (join=%d)", join_result);
+	zassert_equal(atomic_get(&send_call_count), sends_after_stop,
+		      "Message was sent after stopping (%d sends, expected %d)",
+		      (int)atomic_get(&send_call_count), sends_after_stop);
+	/* -ENODEV when the queueing itself is refused, -ENOMEM when no context can be freed for it;
+	 * either way a message built before the stop must not be accepted.
+	 */
+	zassert_not_ok(manage_result, "manage() accepted a message once stopped");
+	zassert_equal(atomic_get(&stop_race_extra_slot.count), 0,
+		      "Refused message must not raise the callback");
+
+	for (int i = 0; i < STOP_RACE_MSGS; i++) {
+		zassert_equal(atomic_get(&stop_race_slots[i].count), 1,
+			      "Message %d got %d callbacks, expected exactly one", i,
+			      (int)atomic_get(&stop_race_slots[i].count));
+		zassert_equal(stop_race_slots[i].err, -ENODEV,
+			      "Message %d completed with %d, expected -ENODEV", i,
+			      stop_race_slots[i].err);
+	}
 }


### PR DESCRIPTION
Backport [#113282](https://github.com/zephyrproject-rtos/zephyr/pull/113282) and its
prerequisite [#111398](https://github.com/zephyrproject-rtos/zephyr/pull/111398) to `v3.7-branch`.

Original PR description:

## Summary

delayable_msg.c mutates three `sys_slist_t` pools from two different threads with no synchronization. This series serializes that state, fixes a context leak on an error path, and adds a regression test that reproduces the failure deterministically.

## Problem

Two contexts mutate the module's `free_ctx` / `busy_ctx` / `free_chunks` lists:

- `bt_mesh_delayable_msg_manage()` runs in the caller of the model response send. For messages received over GATT proxy or the advertising bearer this is the BT host RX workqueue (`CONFIG_BT_RECV_WORKQ_BT=y`, `K_PRIO_COOP(CONFIG_BT_RX_PRIO)` = -8).
- `delayable_msg_handler()` runs on the system workqueue (`SYSTEM_WORKQUEUE_PRIORITY` = -1).

Both are cooperative, so they cannot preempt each other arbitrarily — but the enqueuer path calls `bt_mesh_access_send()` and `bt_rand()`, which block. While the enqueuer is blocked mid-update, the sysworkq handler runs and interleaves on inconsistent list state. `push_msg_from_delayable_msgs()` compounded this by *peeking* the `busy_ctx` head rather than popping it, so both contexts could send and release the same context.

Observed symptom: `delayable_msg_handler()` used the result of `sys_slist_get()` without a NULL check. Once the other context had drained the busy list, `CONTAINER_OF()` yielded `NULL` and the following `pending_msg->fired_time += 10` read-modify-write faulted on a NULL-based address — a bus fault in the flash vector-table region on Cortex-M, ending with the CPU at `PC=0` (hard fault reported in the sysworkq context).

Separately, `release_delayable_msg_ctx()` only appended to `free_ctx` when `sys_slist_find_and_remove()` found the context on `busy_ctx`. The `-ENOMEM` path in `bt_mesh_delayable_msg_manage()` releases a context that was popped from `free_ctx` and never inserted on `busy_ctx`, so it was silently lost from both lists. This needs no race to trigger: it is reachable single-threaded whenever chunk allocation comes up short and the purge attempt hits `-EBUSY`/`-ENOBUFS` from the transport. Repeat it `CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG_COUNT` times and every delayable send fails with `-ENOMEM` until reboot.

## Changes

| Commit | Description |
|---|---|
| `bluetooth: mesh: delayable_msg: fix ctx leak on manage() ENOMEM path` | Append to `free_ctx` unconditionally. `find_and_remove()` is a no-op when the context is not on `busy_ctx`, so the normal release path is unaffected. |
| `bluetooth: mesh: delayable_msg: serialize list access with a spinlock` | Add a `k_spinlock` covering every list mutation and the `fired_time` field of any context on `busy_ctx`. The lock is dropped around all blocking calls. `push_msg_from_delayable_msgs()` now atomically detaches the head, so concurrent pushers cannot send the same message. On `-EBUSY`/`-ENOBUFS` the message is reinserted with the `fired_time += 10` backoff (moved out of the handler for atomicity) and the timer re-armed. The handler no longer touches `busy_ctx` directly, eliminating the NULL dereference by construction. |
| `tests: bluetooth: mesh: delayable_msg: add concurrency regression test` | New `test_concurrent_manage` in the existing suite. |

No API, Kconfig, or devicetree changes. Critical sections contain only list manipulation; every blocking call is made with the lock released. On non-SMP builds `k_spinlock` reduces to `irq_lock()`/`irq_unlock()` with no added RAM.

## Test

`test_concurrent_manage` runs two cooperative threads — the ZTEST main thread temporarily raised to `K_PRIO_COOP(6)` and a helper at the same priority — each calling `bt_mesh_delayable_msg_manage()` 40 times, alternating via `k_yield()`. The mocked send-completion callback also yields, landing control inside `push_msg_from_delayable_msgs()` while the caller is mid-critical-section. Because the interleaving points are explicit yield sites rather than preemption timing, a regression reproduces on the first run.

Assertions track callbacks **per `cb_data` slot** rather than in aggregate. This matters: the bug delivers two callbacks to one message and zero to another, so aggregate counters coincidentally balance and hide it. The per-slot check enforces the exactly-once delivery contract.

Results on `qemu_x86`:

- Reverting the fixes and keeping the test: `test_concurrent_manage` fails with 40 of 80 slots receiving a wrong callback count.
- With the fixes: `SUITE PASS - 100.00%`, 8/8 passing.

```
west build -b qemu_x86 tests/bluetooth/mesh/delayable_msg -t run
```

Fixes #113175 