### PR TITLE
Bluetooth: L2CAP: Fix accept callback docs to require bt_l2cap_le_chan

### DIFF
--- a/doc/services/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/services/connectivity/bluetooth/api/l2cap.rst
@@ -29,7 +29,10 @@ Servers can be registered using :c:func:`bt_l2cap_server_register` API passing
 the :c:struct:`bt_l2cap_server` struct which informs what ``psm`` it should
 listen to, the required security level ``sec_level``, and the callback
 ``accept`` which is called to authorize incoming connection requests and
-allocate channel instances.
+allocate channel instances. The allocated objects must be of type
+:c:struct:`bt_l2cap_le_chan`, with the channel reference returned through the
+``accept`` callback pointing to the object's ``chan`` member, as shown in the
+example below.
 
 .. literalinclude:: ../../../../../samples/bluetooth/l2cap_coc_acceptor/src/main.c
    :language: c
@@ -44,12 +47,15 @@ Fixed Channels
 --------------
 
 The user can also define fixed channels using the :c:macro:`BT_L2CAP_FIXED_CHANNEL_DEFINE`
-macro. Fixed channels are initialized upon connection, and do not support segmentation. An example
-of how to define a fixed channel is shown below.
+macro. Fixed channels are initialized upon connection, and do not support segmentation. Note
+that even though the ``accept`` callback passes the channel reference as a
+:c:struct:`bt_l2cap_chan`, the allocated object must be of type :c:struct:`bt_l2cap_le_chan`,
+with the reference pointing to its ``chan`` member. An example of how to define a fixed
+channel is shown below.
 
 .. code-block:: c
 
-   static struct bt_l2cap_chan fixed_chan[CONFIG_BT_MAX_CONN];
+   static struct bt_l2cap_le_chan fixed_chan[CONFIG_BT_MAX_CONN];
 
    /* Callbacks are assumed to be defined prior. */
    static struct bt_l2cap_chan_ops ops = {
@@ -63,11 +69,11 @@ of how to define a fixed channel is shown below.
    {
        uint8_t conn_index = bt_conn_index(conn);
 
-       *chan = &fixed_chan[conn_index];
-
-       **chan = (struct bt_l2cap_chan){
-           .ops = &ops,
+       fixed_chan[conn_index] = (struct bt_l2cap_le_chan){
+           .chan.ops = &ops,
        };
+
+       *chan = &fixed_chan[conn_index].chan;
 
        return 0;
    }

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -353,25 +353,30 @@ struct bt_l2cap_fixed_chan {
 	 *
 	 *  This callback needs to be provided by the application, and is invoked when a new
 	 *  connection has been established. If accepting the connection, the user is expected to
-	 *  allocate memory with suitable alignment for the type @ref bt_l2cap_chan for the channel,
-	 *  and update the channel reference @p chan to point to the allocated memory. The channel
-	 *  should be initialized by assigning the callbacks to the @ref bt_l2cap_chan_ops field
-	 *  as follows:
+	 *  allocate memory for a zero-initialized object of type @ref bt_l2cap_le_chan, and update
+	 *  the channel reference @p chan to point to the @ref bt_l2cap_le_chan.chan member of the
+	 *  allocated object. The channel should be initialized by assigning the callbacks to the
+	 *  @ref bt_l2cap_chan_ops field as follows:
 	 *  @code
 	 *  static int accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	 *  {
 	 *      // Allocation of fixed_chan and definition of the ops are assumed done prior.
-	 *      *chan = &fixed_chan;
-	 *
-	 *      **chan = (struct bt_l2cap_chan){
-	 *          .ops = &ops,
+	 *      fixed_chan = (struct bt_l2cap_le_chan){
+	 *          .chan.ops = &ops,
 	 *      };
+	 *
+	 *      *chan = &fixed_chan.chan;
 	 *
 	 *      return 0;
 	 *  }
 	 *  @endcode
 	 *  The allocated context needs to be valid for the lifetime of the channel, i. e.
 	 *  freeing of the memory can be done in the @ref bt_l2cap_chan_ops.released callback.
+	 *
+	 *  @warning Even though the reference passed back through @p chan is a
+	 *           @ref bt_l2cap_chan, it must be the @ref bt_l2cap_le_chan.chan member of a
+	 *           @ref bt_l2cap_le_chan object. The stack uses the containing object, so
+	 *           returning a bare @ref bt_l2cap_chan would result in out-of-bounds access.
 	 *
 	 *  @param conn The connection that has been established.
 	 *  @param chan L2CAP channel reference.
@@ -831,10 +836,21 @@ struct bt_l2cap_server {
 	/** @brief Server accept callback
 	 *
 	 *  This callback is called whenever a new incoming connection requires
-	 *  authorization.
+	 *  authorization. If accepting the connection, the callback is expected
+	 *  to allocate a zero-initialized channel object and update the channel
+	 *  reference @p chan to point to its common member: for a server
+	 *  registered with bt_l2cap_server_register() the object must be of type
+	 *  @ref bt_l2cap_le_chan and @p chan set to its @ref bt_l2cap_le_chan.chan
+	 *  member, and for a server registered with bt_l2cap_br_server_register()
+	 *  the object must be of type @ref bt_l2cap_br_chan and @p chan set to its
+	 *  @ref bt_l2cap_br_chan.chan member.
 	 *
-	 *  @warning It is the responsibility of this callback to zero out the
-	 *  parent of the chan object.
+	 *  @warning Even though the reference passed back through @p chan is a
+	 *  @ref bt_l2cap_chan, it must be a member of a @ref bt_l2cap_le_chan or
+	 *  @ref bt_l2cap_br_chan object as described above. The stack uses the
+	 *  containing object, so returning a bare @ref bt_l2cap_chan would result in
+	 *  out-of-bounds access. It is the responsibility of this callback to
+	 *  zero out the containing object.
 	 *
 	 *  @param conn The connection that is requesting authorization
 	 *  @param server Pointer to the server structure this callback relates to


### PR DESCRIPTION
Both the fixed channel and the server accept callbacks pass the channel reference as a struct bt_l2cap_chan, but the stack immediately resolves the containing object with CONTAINER_OF() and initializes members that only exist beyond the end of the base struct: bt_l2cap_connected() and l2cap_chan_accept() both use BT_L2CAP_LE_CHAN() on the returned pointer, and BR/EDR servers get the equivalent treatment in l2cap_br.c. An application that allocates what the signature suggests gets out-of-bounds writes.

The documentation actively taught exactly that: the example in the bt_l2cap_fixed_chan accept callback documentation, as well as its expanded copy on the L2CAP documentation page, allocated an array of bare bt_l2cap_chan objects, and the bt_l2cap_server accept callback documentation only hinted at a containing object through a note about "the parent of the chan object" without saying what that parent is.

Fix both examples to allocate struct bt_l2cap_le_chan, and spell out the actual contract in the accept callback documentation: the object must be a bt_l2cap_le_chan (or bt_l2cap_br_chan for BR/EDR servers), with the channel reference pointing to its chan member. The equivalent requirement was already documented on the client side, on bt_l2cap_chan_connect().

Making the signatures type-safe is deliberately left out: the server callback is shared between LE and BR/EDR servers, which require different containing types, and the longer-term direction (issue #21000) is to move the members the stack needs into bt_l2cap_chan itself, after which the current signatures become genuinely correct. The l2cap_coc_acceptor sample and the send_on_connect bsim test used to make the same mistake as the documentation and have already been fixed in tree.

Fixes: #114692