### PR TITLE
Bluetooth: GATT: Persist Service Changed state on pairing complete

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1081,6 +1081,19 @@ static void bt_gatt_pairing_complete(struct bt_conn *conn, bool bonded)
 		/* Store the ccc and cf data */
 		gatt_store_ccc(conn->id, &(conn->le.dst));
 		bt_gatt_store_cf(conn->id, &conn->le.dst);
+
+		if (IS_ENABLED(CONFIG_BT_GATT_SERVICE_CHANGED)) {
+			struct gatt_sc_cfg *cfg = find_sc_cfg(conn->id, &conn->le.dst);
+
+			/* A client may subscribe to Service Changed before it
+			 * bonds, in which case sc_save() created the entry but
+			 * had no bond to persist it against. Store it now that
+			 * there is one.
+			 */
+			if (cfg != NULL) {
+				sc_store(cfg);
+			}
+		}
 	}
 }
 #endif /* CONFIG_BT_SETTINGS && CONFIG_BT_SMP */

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -140,6 +141,96 @@ static void gatt_discover(void)
 
 	LOG_DBG("sc handle: %d", gatt_handles[SC]);
 	LOG_DBG("ccc handle: %d", gatt_handles[CCC]);
+}
+
+void central_reboot_subscribe_bond(void)
+{
+	int err;
+	struct bt_conn_auth_info_cb bt_conn_auth_info_cb = {
+		.pairing_failed = pairing_failed,
+		.pairing_complete = pairing_complete,
+	};
+
+	err = bt_enable(NULL);
+	TEST_ASSERT(!err, "bt_enable failed (%d)", err);
+
+	err = bt_conn_auth_info_cb_register(&bt_conn_auth_info_cb);
+	TEST_ASSERT(!err, "bt_conn_auth_info_cb_register failed.");
+
+	err = settings_load();
+	TEST_ASSERT(!err, "settings_load failed (%d)", err);
+
+	scan_connect_to_first_result();
+	wait_connected();
+
+	/* Subscribe before there is a bond to persist the configuration
+	 * against.
+	 */
+	gatt_discover();
+	subscribe();
+
+	set_security(BT_SECURITY_L2);
+
+	TAKE_FLAG(flag_pairing_complete);
+	TAKE_FLAG(flag_bonded);
+
+	disconnect();
+	wait_disconnected();
+	clear_g_conn();
+
+	TEST_PASS("PASS");
+}
+
+/* Attribute handles of the Service Changed characteristic value and its CCC.
+ * The GATT service is the first service in the attribute table, so these are
+ * fixed and can be used without a new discovery after the reboot.
+ */
+#define SC_VALUE_HANDLE 0x0003
+#define SC_CCC_HANDLE   0x0004
+
+static void bond_addr_cb(const struct bt_bond_info *info, void *user_data)
+{
+	bt_addr_le_t *addr = user_data;
+
+	bt_addr_le_copy(addr, &info->addr);
+}
+
+void central_reboot_resubscribe(void)
+{
+	int err;
+	bt_addr_le_t peer = *BT_ADDR_LE_ANY;
+
+	err = bt_enable(NULL);
+	TEST_ASSERT(!err, "bt_enable failed (%d)", err);
+
+	err = settings_load();
+	TEST_ASSERT(!err, "settings_load failed (%d)", err);
+
+	bt_foreach_bond(BT_ID_DEFAULT, bond_addr_cb, &peer);
+	TEST_ASSERT(!bt_addr_le_eq(&peer, BT_ADDR_LE_ANY), "no bond restored");
+
+	/* Re-arm the subscription without writing the CCC, like a client that
+	 * believes it is still subscribed. This must happen before connecting,
+	 * since the server sends the Service Changed indication as soon as the
+	 * connection is established.
+	 */
+	subscribe_params.ccc_handle = SC_CCC_HANDLE;
+	subscribe_params.value_handle = SC_VALUE_HANDLE;
+	subscribe_params.value = BT_GATT_CCC_INDICATE;
+	subscribe_params.notify = sc_indicated;
+
+	err = bt_gatt_resubscribe(BT_ID_DEFAULT, &peer, &subscribe_params);
+	TEST_ASSERT(!err, "bt_gatt_resubscribe failed (%d)", err);
+
+	scan_connect_to_first_result();
+	wait_connected();
+
+	set_security(BT_SECURITY_L2);
+
+	/* wait for service change indication */
+	WAIT_FOR_FLAG(flag_indicated);
+
+	TEST_PASS("PASS");
 }
 
 void central(void)

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +10,10 @@
 
 extern void central(void);
 extern void peripheral(void);
+extern void central_reboot_subscribe_bond(void);
+extern void central_reboot_resubscribe(void);
+extern void peripheral_reboot_bond(void);
+extern void peripheral_reboot_indicate(void);
 
 static const struct bst_test_instance test_to_add[] = {
 	{
@@ -18,6 +23,33 @@ static const struct bst_test_instance test_to_add[] = {
 	{
 		.test_id = "peripheral",
 		.test_main_f = peripheral,
+	},
+	{
+		.test_id = "central_reboot_subscribe_bond",
+		.test_descr = "Subscribe to Service Changed, then bond and disconnect. The bond "
+			      "and the Service Changed configuration must survive a reboot.",
+		.test_main_f = central_reboot_subscribe_bond,
+	},
+	{
+		.test_id = "central_reboot_resubscribe",
+		.test_descr = "After a reboot, re-arm the subscription from bond data, reconnect "
+			      "and expect a Service Changed indication for a database change made "
+			      "while disconnected.",
+		.test_main_f = central_reboot_resubscribe,
+	},
+	{
+		.test_id = "peripheral_reboot_bond",
+		.test_descr = "Accept a connection from a client that subscribes to Service "
+			      "Changed before bonding, persisting the bond and the Service "
+			      "Changed configuration.",
+		.test_main_f = peripheral_reboot_bond,
+	},
+	{
+		.test_id = "peripheral_reboot_indicate",
+		.test_descr = "After a reboot, change the database while the bonded client is "
+			      "disconnected, then advertise so it can reconnect and receive the "
+			      "Service Changed indication.",
+		.test_main_f = peripheral_reboot_indicate,
 	},
 	BSTEST_END_MARKER,
 };

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/peripheral.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -46,6 +47,50 @@ static struct bt_gatt_service svc = {
 	.attrs = attrs,
 	.attr_count = ARRAY_SIZE(attrs),
 };
+
+void peripheral_reboot_bond(void)
+{
+	int err;
+	struct bt_le_ext_adv *adv = NULL;
+
+	err = bt_enable(NULL);
+	TEST_ASSERT(!err, "bt_enable failed (%d)", err);
+
+	err = settings_load();
+	TEST_ASSERT(!err, "settings_load failed (%d)", err);
+
+	create_adv(&adv);
+	start_adv(adv);
+	wait_connected();
+
+	wait_disconnected();
+	clear_g_conn();
+
+	TEST_PASS("PASS");
+}
+
+void peripheral_reboot_indicate(void)
+{
+	int err;
+	struct bt_le_ext_adv *adv = NULL;
+
+	err = bt_enable(NULL);
+	TEST_ASSERT(!err, "bt_enable failed (%d)", err);
+
+	err = settings_load();
+	TEST_ASSERT(!err, "settings_load failed (%d)", err);
+
+	/* add a new service to trigger the service changed indication */
+	err = bt_gatt_service_register(&svc);
+	TEST_ASSERT(!err, "bt_gatt_service_register failed (%d)", err);
+	LOG_DBG("New service added");
+
+	create_adv(&adv);
+	start_adv(adv);
+	wait_connected();
+
+	TEST_PASS("PASS");
+}
 
 void peripheral(void)
 {

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_reboot.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_reboot.sh
@@ -1,0 +1,46 @@
+#!/bin/env bash
+# Copyright (c) 2026 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that the Service Changed configuration of a client that subscribed
+# before bonding survives a reboot of both devices: the server database
+# changes after the reboot while the client is disconnected, and the
+# indication must still be delivered on reconnection.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_sc_indicate_prj_conf"
+simulation_id="${BOARD_TS}_sc_indicate_reboot"
+verbosity_level=2
+EXECUTE_TIMEOUT=120
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 \
+  -testid=central_reboot_subscribe_bond -RealEncryption=1 \
+  -flash="${simulation_id}_client.log.bin" -flash_erase
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_reboot_bond -RealEncryption=1 \
+  -flash="${simulation_id}_server.log.bin" -flash_erase
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=30e6
+
+wait_for_background_jobs
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id}.2 -d=0 \
+  -testid=central_reboot_resubscribe -RealEncryption=1 \
+  -flash="${simulation_id}_client.log.bin" -flash_rm
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id}.2 -d=1 \
+  -testid=peripheral_reboot_indicate -RealEncryption=1 \
+  -flash="${simulation_id}_server.log.bin" -flash_rm
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id}.2 \
+  -D=2 -sim_length=30e6
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_reboot_privacy.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_reboot_privacy.sh
@@ -1,0 +1,46 @@
+#!/bin/env bash
+# Copyright (c) 2026 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that the Service Changed configuration of a client that subscribed
+# before bonding survives a reboot of both devices: the server database
+# changes after the reboot while the client is disconnected, and the
+# indication must still be delivered on reconnection.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_sc_indicate_overlay-privacy_conf"
+simulation_id="${BOARD_TS}_sc_indicate_reboot_privacy"
+verbosity_level=2
+EXECUTE_TIMEOUT=120
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 \
+  -testid=central_reboot_subscribe_bond -RealEncryption=1 \
+  -flash="${simulation_id}_client.log.bin" -flash_erase
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_reboot_bond -RealEncryption=1 \
+  -flash="${simulation_id}_server.log.bin" -flash_erase
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=30e6
+
+wait_for_background_jobs
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id}.2 -d=0 \
+  -testid=central_reboot_resubscribe -RealEncryption=1 \
+  -flash="${simulation_id}_client.log.bin" -flash_rm
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id}.2 -d=1 \
+  -testid=peripheral_reboot_indicate -RealEncryption=1 \
+  -flash="${simulation_id}_server.log.bin" -flash_rm
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id}.2 \
+  -D=2 -sim_length=30e6
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/tests.yaml
@@ -13,6 +13,7 @@ tests:
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_sc_indicate_prj_conf
       tests_scripts:
         - test_scripts/sc_indicate.sh
+        - test_scripts/sc_indicate_reboot.sh
   bluetooth.host.gatt.sc_indicate_privacy:
     extra_args:
       - EXTRA_CONF_FILE=overlay-privacy.conf
@@ -21,3 +22,4 @@ tests:
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_sc_indicate_overlay-privacy_conf
       tests_scripts:
         - test_scripts/sc_indicate_privacy.sh
+        - test_scripts/sc_indicate_reboot_privacy.sh


### PR DESCRIPTION
sc_save() only calls sc_store() when a bond already exists for the peer, so a client that subscribes to Service Changed before it bonds gets an sc_cfg entry in RAM that is never written to settings. iOS does exactly this: it subscribes right after connecting and only pairs later, once the user accepts the dialog.

bt_gatt_identity_resolved() does not cover it either, since its sc_store() call is likewise conditional on the bond already existing, and identity resolution happens during key distribution rather than after the bond has been committed.

The result is that the subscription survives in RAM for the current connection but is lost across a reboot, so a characteristic change made while disconnected is never indicated and the client keeps a stale cache. Reconnecting papers over it, because the client subscribes again and by then the bond exists.

Store the Service Changed configuration from bt_gatt_pairing_complete(), where the ccc and cf data is already persisted for the same reason.

Fixes: #111078