### PR TITLE
Bluetooth: GATT: Document the consequence of BT_GATT_PERM_PREPARE_WRITE

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -94,6 +94,14 @@ enum bt_gatt_perm {
 	 *  not set, prepare writes are accepted by default (subject to normal
 	 *  write permissions).
 	 *
+	 *  @note Unlike the other values of this enum, this is not an access
+	 *  check: clearing it does not make the GATT layer reject prepare
+	 *  writes. Every value that gets queued is passed to the write
+	 *  callback when the client executes the write, so an attribute that
+	 *  cannot accept a prepared write has to reject it from its write
+	 *  callback: at prepare time if this permission is set, and otherwise
+	 *  at execution.
+	 *
 	 *  Do not confuse this with @ref BT_GATT_CEP_RELIABLE_WRITE, which is
 	 *  a Characteristic Extended Property bit from the specification.
 	 */
@@ -127,6 +135,10 @@ enum bt_gatt_attr_write_flag {
 	 *
 	 * If set, write callback should only check if the device is
 	 * authorized but no data shall be written.
+	 *
+	 * Only delivered for attributes that set
+	 * @ref BT_GATT_PERM_PREPARE_WRITE. See that permission for why its
+	 * absence does not mean prepared writes are rejected.
 	 */
 	BT_GATT_WRITE_FLAG_PREPARE = BIT(0),
 


### PR DESCRIPTION
The permission was recently documented in commit 0b4294a2bbd0 ("bluetooth: gatt: document BT_GATT_PERM_PREPARE_WRITE"), including that prepare writes are accepted by default when it is not set. What that leaves unsaid is the consequence for servers: since every other value of `bt_gatt_perm` is an access check that the GATT layer enforces on the client's behalf, it is easy to assume this one is too, and that clearing it protects the attribute from prepared writes. It does not: the queued value is still executed against the write callback, so an attribute that cannot accept a prepared write has to reject it from its write callback whether or not the permission is set.

Spell that consequence out in a note on the permission, and note on `BT_GATT_WRITE_FLAG_PREPARE` that it is only delivered for attributes that set the permission, with a pointer back to the permission for why its absence does not mean prepared writes are rejected. The behaviour itself is left alone: making this permission gate prepared writes would silently change how existing servers respond.

Fixes: #100962