### PR TITLE
net: Initialize net_sockaddr_storage to silence uninitialized warnings

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -2081,7 +2081,7 @@ int net_dhcpv4_init(void)
 	uint64_t events =
 		IS_ENABLED(CONFIG_NET_DHCPV4_RESTART_ON_IF_UP) ?
 		(NET_EVENT_IF_UP | NET_EVENT_IF_DOWN) : NET_EVENT_IF_DOWN;
-	struct net_sockaddr_storage local_addr_storage;
+	struct net_sockaddr_storage local_addr_storage = { 0 };
 	struct net_sockaddr *local_addr = net_sad(&local_addr_storage);
 	int ret;
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -2368,7 +2368,7 @@ int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 	k_timeout_t tout;
 	struct net_buf *dns_data = NULL;
 	struct net_buf *dns_qname = NULL;
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = { 0 };
 	struct net_sockaddr *sa = net_sad(&addr);
 	int ret, i = -1;
 	bool mdns_query = false;
@@ -2811,7 +2811,7 @@ static bool dns_servers_exists(struct dns_resolve_context *ctx,
 {
 	if (servers) {
 		for (int i = 0; i < SERVER_COUNT && servers[i]; i++) {
-			struct net_sockaddr_storage addr;
+			struct net_sockaddr_storage addr = { 0 };
 			struct net_sockaddr *sa = net_sad(&addr);
 
 			if (!net_ipaddr_parse(servers[i], strlen(servers[i]), sa)) {

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -126,7 +126,7 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 	int i, ret = 0;
 	int family, sock, sock_error = 0;
 	int default_error = EIO;
-	struct net_sockaddr_storage addr_incoming_conn;
+	struct net_sockaddr_storage addr_incoming_conn = { 0 };
 	net_socklen_t optlen = sizeof(int);
 	net_socklen_t addrlen = sizeof(addr_incoming_conn);
 

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -352,7 +352,7 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 	int ret = 1;
 	int family, sock_error = 0;
 	int default_error = EIO;
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = { 0 };
 	struct net_sockaddr *sa = net_sad(&addr);
 	net_socklen_t optlen = sizeof(int);
 	net_socklen_t addrlen = sizeof(addr);


### PR DESCRIPTION
When building with CONFIG_NO_OPTIMIZATIONS=y, GCC reports
-Wmaybe-uninitialized warnings for net_sockaddr_storage variables
that are passed to net_sad() before being explicitly initialized.

With optimizations enabled, the compiler inlines net_sad() (a simple
cast) and can track that the variable is written before being read
(e.g., via zsock_accept or net_ipaddr_parse). At -O0, the cast
indirection prevents this analysis.

Zero-initialize the affected variables to silence the warnings.
The cost is negligible (memset of a small struct) and there is no
behavioral change since the variables are always written before use.