### PR TITLE
drivers: entropy: silabs: Remove unused include

### DIFF
--- a/drivers/entropy/entropy_gecko_se.c
+++ b/drivers/entropy/entropy_gecko_se.c
@@ -8,7 +8,6 @@
 
  #include <zephyr/drivers/entropy.h>
  #include <soc.h>
- #include "em_cmu.h"
  #include "sl_se_manager.h"
  #include "sl_se_manager_entropy.h"
 


### PR DESCRIPTION
Remove unused include from the entropy_gecko_se driver.