### PR TITLE
drivers: pinctrl: silabs: Use sl_hal_gpio instead of emlib

### DIFF
--- a/drivers/pinctrl/pinctrl_silabs_dbus.c
+++ b/drivers/pinctrl/pinctrl_silabs_dbus.c
@@ -7,7 +7,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/arch/cpu.h>
 
-#include <em_gpio.h>
+#include <sl_hal_gpio.h>
 
 #define DT_DRV_COMPAT silabs_dbus_pinctrl
 #define PIN_MASK      0xF0000UL
@@ -19,6 +19,10 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 
 	for (uint8_t i = 0U; i < pin_cnt; i++) {
 		mem_addr_t enable_reg, route_reg;
+		sl_gpio_t gpio = {
+			.port = pins[i].port,
+			.pin = pins[i].pin,
+		};
 
 		/* Configure ABUS */
 		if (pins[i].en_bit == SILABS_PINCTRL_ANALOG) {
@@ -34,7 +38,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		}
 
 		/* Configure GPIO */
-		GPIO_PinModeSet(pins[i].port, pins[i].pin, pins[i].mode, pins[i].dout);
+		sl_hal_gpio_set_pin_mode(&gpio, pins[i].mode, pins[i].dout);
 
 		/* Configure DBUS */
 		enable_reg = DT_INST_REG_ADDR_BY_NAME(0, dbus) +
@@ -46,7 +50,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		}
 
 		if (pins[i].en_bit != SILABS_PINCTRL_UNUSED) {
-			if (pins[i].mode == gpioModeDisabled) {
+			if (pins[i].mode == SL_GPIO_MODE_DISABLED) {
 				sys_clear_bit(enable_reg, pins[i].en_bit);
 			} else {
 				sys_set_bit(enable_reg, pins[i].en_bit);

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -318,13 +318,14 @@ endif()
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_ACMP      ${EMLIB_DIR}/src/em_acmp.c)
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_EMU       ${EMLIB_DIR}/src/em_emu.c)
 if(CONFIG_SILABS_SISDK_GPIO)
+  zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_SILABS_S2  ${EMLIB_DIR}/src/em_gpio.c)
   zephyr_library_sources(
-    ${EMLIB_DIR}/src/em_gpio.c
     ${DRIVER_DIR}/gpio/src/sl_gpio.c
     ${PERIPHERAL_DIR}/src/sl_hal_gpio.c
   )
   zephyr_library_compile_definitions(
     SL_CATALOG_GPIO_PRESENT
+    SL_CODE_COMPONENT_GPIO=gpio
     SL_CODE_COMPONENT_HAL_GPIO=hal_gpio
   )
 endif()


### PR DESCRIPTION
Update driver to use new HAL library that supports both Series 2 and Series 3 SoCs.

The GPIO driver already uses the new HAL library, update pinctrl to match. Leave the legacy HAL file available for other users, pending full deprecation of emlib.