### PR TITLE
tests: Add TF-PSA-Crypto dispatch include directory

### DIFF
--- a/tests/bluetooth/host/crypto/CMakeLists.txt
+++ b/tests/bluetooth/host/crypto/CMakeLists.txt
@@ -27,6 +27,7 @@ target_include_directories(mocks PUBLIC
   ${ZEPHYR_BASE}/tests/bluetooth/host/crypto/mocks
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
+  ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/dispatch/include/
 )
 
 target_link_libraries(mocks PRIVATE test_interface)

--- a/tests/bluetooth/mesh/brg/CMakeLists.txt
+++ b/tests/bluetooth/mesh/brg/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(app
     ${ZEPHYR_BASE}/subsys/bluetooth/mesh
     ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
     ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
+    ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/dispatch/include/
 )
 
 target_compile_options(app

--- a/tests/bluetooth/mesh/delayable_msg/CMakeLists.txt
+++ b/tests/bluetooth/mesh/delayable_msg/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(app
   ${ZEPHYR_BASE}/subsys/bluetooth/mesh
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
+  ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/dispatch/include/
 )
 
 target_compile_options(app

--- a/tests/bluetooth/mesh/net/CMakeLists.txt
+++ b/tests/bluetooth/mesh/net/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(app
   ${ZEPHYR_BASE}/subsys/bluetooth
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
+  ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/dispatch/include/
 )
 
 target_compile_options(app

--- a/tests/bluetooth/mesh/rpl/CMakeLists.txt
+++ b/tests/bluetooth/mesh/rpl/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(app
   ${ZEPHYR_BASE}/subsys/bluetooth/mesh
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
+  ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/dispatch/include/
 )
 
 target_compile_options(app

--- a/tests/net/lib/lwm2m/lwm2m_engine/CMakeLists.txt
+++ b/tests/net/lib/lwm2m/lwm2m_engine/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/lib/lwm2m/)
 target_include_directories(app PRIVATE ${ZEPHYR_MBEDTLS_MODULE_DIR}/include/)
 target_include_directories(app PRIVATE ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include/)
 target_include_directories(app PRIVATE ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/)
+target_include_directories(app PRIVATE ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/dispatch/include/)
 
 add_compile_definitions(CONFIG_LWM2M_ENGINE_MAX_PENDING=2)
 add_compile_definitions(CONFIG_LWM2M_ENGINE_MAX_REPLIES=2)

--- a/tests/net/lib/wifi_credentials_backend_psa/CMakeLists.txt
+++ b/tests/net/lib/wifi_credentials_backend_psa/CMakeLists.txt
@@ -21,6 +21,7 @@ zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
 zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/)
 zephyr_include_directories(${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/include)
 zephyr_include_directories(${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include)
+zephyr_include_directories(${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/dispatch/include)
 
 target_compile_options(app
   PRIVATE


### PR DESCRIPTION
The TF-PSA-Crypto revision bump in commit e603d04fa7c5 ("modules: mbedtls: Allow custom TF-PSA-Crypto dispatch directory", from #110328) moved the driver dispatch headers (`psa/crypto_driver_contexts_primitives.h`, `psa/crypto_driver_contexts_composites.h`) from `include/psa/` to a dedicated `dispatch/include/psa/` directory. Normal builds pick that up from the `tfpsacrypto` CMake target's interface include directories, but tests that mock crypto and hardcode the TF-PSA-Crypto include paths instead of linking the library must add it explicitly.

This currently breaks 12 test configurations on `main`, all failing with:

```
tf-psa-crypto/include/psa/crypto_struct.h:61:10: fatal error: psa/crypto_driver_contexts_primitives.h: No such file or directory
```

- `bluetooth.mesh.rpl`, `bluetooth.mesh.net`, `bluetooth.mesh.brg`, `bluetooth.mesh.delayable_msg` (gnu + llvm)
- `bluetooth.host.bt_rand.*`, `bluetooth.host.bt_encrypt_le.*`, `bluetooth.host.bt_encrypt_be.*`
- `net.lwm2m.lwm2m_engine`

Example failing run: https://github.com/zephyrproject-rtos/zephyr/actions/runs/32010483618

`tests/net/lib/wifi_credentials_backend_psa` hardcodes the same include paths and includes `psa/crypto.h`, so it is fixed here as well.

The literal `dispatch/include` path is used rather than the new `CONFIG_TF_PSA_CRYPTO_DISPATCH_DIR` symbol, because that symbol is defined inside `if MBEDTLS` and none of these tests enable `MBEDTLS` — it would expand to an empty string. This matches how these files already hardcode `drivers/builtin/include`.
