### PR TITLE
tests: bluetooth: Add PSA Crypto dispatch include directory

### DIFF
--- a/tests/bluetooth/host/crypto/CMakeLists.txt
+++ b/tests/bluetooth/host/crypto/CMakeLists.txt
@@ -26,6 +26,7 @@ target_include_directories(mocks PUBLIC
   ${ZEPHYR_BASE}/tests/bluetooth/host
   ${ZEPHYR_BASE}/tests/bluetooth/host/crypto/mocks
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
+  ${CONFIG_TF_PSA_CRYPTO_DISPATCH_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )
 

--- a/tests/bluetooth/mesh/brg/CMakeLists.txt
+++ b/tests/bluetooth/mesh/brg/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(app
   PRIVATE
     ${ZEPHYR_BASE}/subsys/bluetooth/mesh
     ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
+    ${CONFIG_TF_PSA_CRYPTO_DISPATCH_DIR}/include
     ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )
 

--- a/tests/bluetooth/mesh/delayable_msg/CMakeLists.txt
+++ b/tests/bluetooth/mesh/delayable_msg/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(app
   PRIVATE
   ${ZEPHYR_BASE}/subsys/bluetooth/mesh
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
+  ${CONFIG_TF_PSA_CRYPTO_DISPATCH_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )
 

--- a/tests/bluetooth/mesh/net/CMakeLists.txt
+++ b/tests/bluetooth/mesh/net/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(app
   ${ZEPHYR_BASE}/subsys/bluetooth/mesh
   ${ZEPHYR_BASE}/subsys/bluetooth
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
+  ${CONFIG_TF_PSA_CRYPTO_DISPATCH_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )
 

--- a/tests/bluetooth/mesh/rpl/CMakeLists.txt
+++ b/tests/bluetooth/mesh/rpl/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(app
   PRIVATE
   ${ZEPHYR_BASE}/subsys/bluetooth/mesh
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
+  ${CONFIG_TF_PSA_CRYPTO_DISPATCH_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )
 

--- a/tests/net/lib/lwm2m/lwm2m_engine/CMakeLists.txt
+++ b/tests/net/lib/lwm2m/lwm2m_engine/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/)
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/lib/lwm2m/)
 target_include_directories(app PRIVATE ${ZEPHYR_MBEDTLS_MODULE_DIR}/include/)
 target_include_directories(app PRIVATE ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include/)
+target_include_directories(app PRIVATE ${CONFIG_TF_PSA_CRYPTO_DISPATCH_DIR}/include/)
 target_include_directories(app PRIVATE ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/)
 
 add_compile_definitions(CONFIG_LWM2M_ENGINE_MAX_PENDING=2)


### PR DESCRIPTION
Several test apps hard-code the include paths of PSA Crypto. Add the public include path of the dispatch directory wherever the public include path of the core is used.