### PR TITLE
drivers: sdhc: esp32: fix sd card init hang on command write

### DIFF
--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -350,7 +350,11 @@ static int sdmmc_host_start_command(sdmmc_dev_t *sdio_hw, int slot, sdmmc_hw_cmd
 	sdmmc_ll_set_command_arg(sdio_hw, arg);
 	cmd.card_num = slot;
 	cmd.start_command = 1;
-	sdmmc_ll_set_command(sdio_hw, cmd);
+	/* Write the command register with a single 32-bit store. The low-level
+	 * helper copies through memcpy, which the compiler may expand into byte
+	 * stores, and the peripheral bus only accepts word accesses.
+	 */
+	sdio_hw->cmd = cmd;
 
 	return ESP_OK;
 }


### PR DESCRIPTION
The sdmmc_ll_set_command helper writes the command register through memcpy, which the compiler expands into four byte stores. The peripheral bus only accepts 32-bit accesses, so the command never reached the card interface unit and the driver spun forever waiting for it to be taken.

Restore the single word store to the command register. This is a regression from f4c7092ad64.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116306