### PR TITLE
kernel: usage: fix unused-variable warning when THREAD_USAGE_ALL=n

### DIFF
--- a/kernel/usage.c
+++ b/kernel/usage.c
@@ -260,9 +260,8 @@ int k_thread_runtime_stats_enable(k_tid_t  thread)
 
 		if (thread == cpu->current) {
 			uint32_t now = usage_now();
-			uint32_t cycles = now - cpu->usage0;
 
-			sched_cpu_update_usage(cpu, cycles);
+			sched_cpu_update_usage(cpu, now - cpu->usage0);
 
 			cpu->usage0 = now;
 		}
@@ -436,9 +435,8 @@ int z_thread_stats_reset(struct k_obj_core *obj_core)
 	/* Update the current CPU stats. */
 
 	uint32_t now = usage_now();
-	uint32_t cycles = now - _current_cpu->usage0;
 
-	sched_cpu_update_usage(_current_cpu, cycles);
+	sched_cpu_update_usage(_current_cpu, now - _current_cpu->usage0);
 
 	_current_cpu->usage0 = now;
 


### PR DESCRIPTION
Fixes 2 potential compiler warnings in `usage.c` as discussed in pr #115983. @npitre 

### Issue

With `CONFIG_SCHED_THREAD_USAGE_ANALYSIS=y` and `CONFIG_SCHED_THREAD_USAGE_ALL=n`, sched_cpu_update_usage() expands to a no-op macro, so the `cycles` local in k_thread_runtime_stats_enable() is set but never read, triggering an unused-variable warning.

The same pattern exists in z_thread_stats_reset()

### Fix

Drop the temporary and pass the `now - cpu->usage0` straight to the macro. 

### Verification

```
CONFIG_COMPILER_WARNINGS_AS_ERRORS=y

# CONFIG_SCHED_THREAD_USAGE_ALL=n makes sched_cpu_update_usage() a no-op macro
CONFIG_THREAD_RUNTIME_STATS=y
CONFIG_SCHED_THREAD_USAGE=y
CONFIG_SCHED_THREAD_USAGE_ANALYSIS=y
CONFIG_SCHED_THREAD_USAGE_ALL=n

# pull z_thread_stats_reset() into the build
CONFIG_OBJ_CORE=y
CONFIG_OBJ_CORE_THREAD=y
CONFIG_OBJ_CORE_STATS=y
CONFIG_OBJ_CORE_STATS_SYSTEM=n
CONFIG_OBJ_CORE_STATS_THREAD=y
```

Verified now builds without warning/error