### PR TITLE
module: Kconfig: extend WIFI_RECOVERY support to IW61X and IW416

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -917,7 +917,7 @@ config NXP_WIFI_UNII4_BAND_SUPPORT
 
 config NXP_WIFI_RECOVERY
 	bool "RECOVERY"
-	depends on NXP_RW610 || NXP_IW610
+	depends on NXP_RW610 || NXP_IW610 || NXP_IW61X || NXP_IW416
 	help
 	  This option is used to enable wifi recovery support.
 


### PR DESCRIPTION
WIFI_RECOVERY was only available for RW610 and IW610, extend the depends to also support IW61X and IW416 which use SDIO interface and can leverage the same command-timeout-based recovery mechanism.