### PR TITLE
drivers: display: uc81xx: fix init and refresh handling

### DIFF
--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -642,22 +642,51 @@ static inline int uc81xx_set_ptl_16(const struct device *dev, uint16_t x, uint16
 }
 #endif
 
-#if DT_HAS_COMPAT_STATUS_OKAY(ultrachip_uc8175) || DT_HAS_COMPAT_STATUS_OKAY(ultrachip_uc8176)
+#if DT_HAS_COMPAT_STATUS_OKAY(ultrachip_uc8176)
 static int uc8176_set_cdi(const struct device *dev, bool border)
 {
 	const struct uc81xx_config *config = dev->config;
 	const struct uc81xx_data *data = dev->data;
 	const struct uc81xx_profile *p = config->profiles[data->profile];
-	uint8_t cdi = UC8176_CDI_VBD1 | UC8176_CDI_DDX0 |
-		(p ? (p->cdi & UC8176_CDI_CDI_MASK) : 0);
 
-	if (!p || !p->override_cdi) {
-		return 0;
+	uint8_t interval = UC8176_CDI_DEFAULT_INTERVAL;
+
+	if (p && p->override_cdi) {
+		interval = p->cdi & UC8176_CDI_CDI_MASK;
 	}
+
+	/* Border uses LUTKW */
+	uint8_t cdi = UC8176_CDI_VBD1 | UC8176_CDI_DDX0 | interval;
 
 	if (!border) {
 		/* Floating border */
 		cdi |= UC8176_CDI_VBD1 | UC8176_CDI_VBD0;
+	}
+
+	LOG_DBG("CDI: %#hhx", cdi);
+	return uc81xx_write_cmd_uint8(dev, UC81XX_CMD_CDI, cdi);
+}
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(ultrachip_uc8175)
+static int uc8175_set_cdi(const struct device *dev, bool border)
+{
+	const struct uc81xx_config *config = dev->config;
+	const struct uc81xx_data *data = dev->data;
+	const struct uc81xx_profile *p = config->profiles[data->profile];
+
+	uint8_t interval = UC8175_CDI_DEFAULT_INTERVAL;
+
+	if (p && p->override_cdi) {
+		interval = p->cdi & UC8175_CDI_CDI_MASK;
+	}
+
+	/* Border uses LUTW */
+	uint8_t cdi = UC8176_CDI_VBD1 | UC8176_CDI_DDX0 | interval;
+
+	if (!border) {
+		/* Floating border */
+		cdi &= GENMASK(5, 0);
 	}
 
 	LOG_DBG("CDI: %#hhx", cdi);
@@ -673,7 +702,7 @@ static const struct uc81xx_quirks uc8175_quirks = {
 	.auto_copy = false,
 	.pon_after_softstart = false,
 
-	.set_cdi = uc8176_set_cdi,
+	.set_cdi = uc8175_set_cdi,
 	.set_tres = uc81xx_set_tres_8,
 	.set_ptl = uc81xx_set_ptl_8,
 };
@@ -749,9 +778,9 @@ static int uc8151d_set_cdi(const struct device *dev, bool border)
 		      (p->cdi & UC8151D_CDI_MASK);
 	}
 
-	if (!border) {
-		/* Set VBD to floating for no border */
-		cdi = (cdi & ~UC8151D_CDI_VBD_MASK) | UC8151D_CDI_VBD_FLOATING;
+	if (border) {
+		/* Set VBD to LUTKW for border data */
+		cdi = (cdi & ~UC8151D_CDI_VBD_MASK) | UC8151D_CDI_VBD_LUTKW;
 	}
 
 	LOG_DBG("CDI: %#hhx", cdi);
@@ -793,16 +822,22 @@ static int uc8179_set_cdi(const struct device *dev, bool border)
 	const struct uc81xx_config *config = dev->config;
 	const struct uc81xx_data *data = dev->data;
 	const struct uc81xx_profile *p = config->profiles[data->profile];
-	uint8_t cdi[UC8179_CDI_REG_LENGTH] = {
-		UC8179_CDI_BDV1 | UC8179_CDI_N2OCP | UC8179_CDI_DDX0,
-		p ? p->cdi : 0,
-	};
 
-	if (!p || !p->override_cdi) {
-		return 0;
+	uint8_t interval = UC8179_CDI_DEFAULT_INTERVAL;
+
+	if (p && p->override_cdi) {
+		interval = p->cdi & UC8179_CDI_CDI_MASK;
 	}
 
-	cdi[UC8179_CDI_BDZ_DDX_IDX] |= border ? 0 : UC8179_CDI_BDZ;
+	/* Border uses LUTKW, force NEW->OLD auto-copy and NEW/OLD KW operation */
+	uint8_t cdi[UC8179_CDI_REG_LENGTH] = {
+		UC8179_CDI_BDV1 | UC8179_CDI_N2OCP | UC8179_CDI_DDX0,
+		interval,
+	};
+
+	if (!border) {
+		cdi[UC8179_CDI_BDZ_DDX_IDX] |= UC8179_CDI_BDZ;
+	}
 
 	LOG_HEXDUMP_DBG(cdi, sizeof(cdi), "CDI");
 	return uc81xx_write_cmd(dev, UC81XX_CMD_CDI, cdi, sizeof(cdi));

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -397,11 +397,13 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 	LOG_DBG("x %u, y %u, height %u, width %u, pitch %u",
 		x, y, desc->height, desc->width, desc->pitch);
 
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
+	__ASSERT(desc->width == desc->pitch, "Non-contiguous display buffers are not supported");
 	__ASSERT(buf != NULL, "Buffer is not available");
 	__ASSERT(desc->buf_size >= buf_len, "Buffer size too small");
-	__ASSERT(!(desc->width % UC81XX_PIXELS_PER_BYTE),
-		 "Buffer width not multiple of %d", UC81XX_PIXELS_PER_BYTE);
+	__ASSERT(!(desc->width % UC81XX_PIXELS_PER_BYTE), "Width must be aligned to %u pixels",
+		 UC81XX_PIXELS_PER_BYTE);
+	__ASSERT(!(x % UC81XX_PIXELS_PER_BYTE), "X must be aligned to %u pixels",
+		 UC81XX_PIXELS_PER_BYTE);
 
 	if ((y_end_idx > (config->height - 1)) ||
 	    (x_end_idx > (config->width - 1))) {

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -41,6 +41,11 @@ enum uc81xx_profile_type {
 	UC81XX_PROFILE_INVALID = UC81XX_NUM_PROFILES,
 };
 
+enum uc81xx_phase {
+	UC81XX_PHASE_NORMAL = 0,
+	UC81XX_PHASE_SWAPPED,
+};
+
 struct uc81xx_profile {
 	struct uc81xx_dt_array pwr;
 
@@ -67,6 +72,7 @@ struct uc81xx_quirks {
 
 	bool auto_copy;
 	bool pon_after_softstart;
+	bool dtm_swap;
 
 	int (*set_cdi)(const struct device *dev, bool border);
 	int (*set_tres)(const struct device *dev);
@@ -93,6 +99,7 @@ struct uc81xx_config {
 struct uc81xx_data {
 	bool blanking_on;
 	enum uc81xx_profile_type profile;
+	enum uc81xx_phase phase;
 };
 
 
@@ -349,6 +356,18 @@ static int uc81xx_update_display(const struct device *dev)
 		return -EIO;
 	}
 
+	const struct uc81xx_config *config = dev->config;
+	struct uc81xx_data *data = dev->data;
+
+	if (config->quirks->dtm_swap) {
+		/*
+		 * UC8253 has an undocumented quirk that swaps DTM1 with DTM2
+		 * on every refresh
+		 */
+		data->phase = (data->phase == UC81XX_PHASE_NORMAL) ? UC81XX_PHASE_SWAPPED
+								   : UC81XX_PHASE_NORMAL;
+	}
+
 	return 0;
 }
 
@@ -436,7 +455,9 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 		return -EIO;
 	}
 
-	if (uc81xx_write_cmd(dev, UC81XX_CMD_DTM2, (uint8_t *)buf, buf_len)) {
+	if (uc81xx_write_cmd(dev,
+			     data->phase == UC81XX_PHASE_NORMAL ? UC81XX_CMD_DTM2 : UC81XX_CMD_DTM1,
+			     (const uint8_t *)buf, buf_len)) {
 		return -EIO;
 	}
 
@@ -462,8 +483,10 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 		 * data buffer on refresh. Do that manually here if
 		 * needed.
 		 */
-		if (uc81xx_write_cmd(dev, UC81XX_CMD_DTM1,
-				     (uint8_t *)buf, buf_len)) {
+		if (uc81xx_write_cmd(dev,
+				     data->phase == UC81XX_PHASE_NORMAL ? UC81XX_CMD_DTM1
+									: UC81XX_CMD_DTM2,
+				     (const uint8_t *)buf, buf_len)) {
 			return -EIO;
 		}
 	}
@@ -537,6 +560,7 @@ static int uc81xx_controller_init(const struct device *dev)
 
 	data->blanking_on = true;
 	data->profile = UC81XX_PROFILE_INVALID;
+	data->phase = UC81XX_PHASE_NORMAL;
 
 	if (uc81xx_set_profile(dev, UC81XX_PROFILE_FULL)) {
 		return -EIO;
@@ -701,6 +725,7 @@ static const struct uc81xx_quirks uc8175_quirks = {
 
 	.auto_copy = false,
 	.pon_after_softstart = false,
+	.dtm_swap = false,
 
 	.set_cdi = uc8175_set_cdi,
 	.set_tres = uc81xx_set_tres_8,
@@ -715,6 +740,7 @@ static const struct uc81xx_quirks uc8176_quirks = {
 
 	.auto_copy = false,
 	.pon_after_softstart = false,
+	.dtm_swap = false,
 
 	.set_cdi = uc8176_set_cdi,
 	.set_tres = uc81xx_set_tres_16,
@@ -795,6 +821,7 @@ static const struct uc81xx_quirks uc8151d_quirks = {
 
 	.auto_copy = false,    /* Manual copy required */
 	.pon_after_softstart = true,
+	.dtm_swap = false,
 
 	.set_cdi = uc8151d_set_cdi,
 	.set_tres = uc81xx_set_tres_h8v16,
@@ -809,6 +836,7 @@ static const struct uc81xx_quirks uc8253_quirks = {
 
 	.auto_copy = false,
 	.pon_after_softstart = false,
+	.dtm_swap = true,
 
 	.set_cdi = uc8151d_set_cdi,
 	.set_tres = uc81xx_set_tres_h8v16,
@@ -849,6 +877,7 @@ static const struct uc81xx_quirks uc8179_quirks = {
 
 	.auto_copy = true,
 	.pon_after_softstart = false,
+	.dtm_swap = false,
 
 	.set_cdi = uc8179_set_cdi,
 	.set_tres = uc81xx_set_tres_16,

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -127,7 +127,7 @@ static inline int uc81xx_write_cmd_pattern(const struct device *dev,
 					   uint8_t pattern, size_t len)
 {
 	const struct uc81xx_config *config = dev->config;
-	struct display_buffer_descriptor mipi_desc;
+	struct display_buffer_descriptor mipi_desc = {0};
 	int err;
 	uint8_t data[64];
 
@@ -136,6 +136,7 @@ static inline int uc81xx_write_cmd_pattern(const struct device *dev,
 	err = mipi_dbi_command_write(config->mipi_dev, &config->dbi_config,
 				     cmd, NULL, 0);
 	if (err < 0) {
+		mipi_dbi_release(config->mipi_dev, &config->dbi_config);
 		return err;
 	}
 
@@ -155,13 +156,12 @@ static inline int uc81xx_write_cmd_pattern(const struct device *dev,
 					     data, &mipi_desc,
 					     PIXEL_FORMAT_MONO10);
 		if (err < 0) {
-			goto out;
+			break;
 		}
 
 		len -= mipi_desc.buf_size;
 	}
 
-out:
 	mipi_dbi_release(config->mipi_dev, &config->dbi_config);
 	return err;
 }
@@ -249,8 +249,8 @@ static int uc81xx_set_profile(const struct device *dev,
 		 * Enable LUT overrides if a LUT has been provided by
 		 * the user.
 		 */
-		if (p->lutc.len || p->lutww.len || p->lutkw.len ||
-		    p->lutwk.len || p->lutbd.len) {
+		if (p->lutc.len || p->lutww.len || p->lutkw.len || p->lutwk.len || p->lutkk.len ||
+		    p->lutbd.len) {
 			LOG_DBG("Using LUT from registers");
 			psr |= UC81XX_PSR_REG;
 		}
@@ -392,18 +392,14 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 
 	uint16_t x_end_idx = x + desc->width - 1;
 	uint16_t y_end_idx = y + desc->height - 1;
-	size_t buf_len;
-	const uint8_t back_buffer = data->blanking_on ?
-		UC81XX_CMD_DTM1 : UC81XX_CMD_DTM2;
+	size_t buf_len = desc->width * desc->height / UC81XX_PIXELS_PER_BYTE;
 
 	LOG_DBG("x %u, y %u, height %u, width %u, pitch %u",
 		x, y, desc->height, desc->width, desc->pitch);
 
-	buf_len = MIN(desc->buf_size,
-		      desc->height * desc->width / UC81XX_PIXELS_PER_BYTE);
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT(buf != NULL, "Buffer is not available");
-	__ASSERT(buf_len != 0U, "Buffer of length zero");
+	__ASSERT(desc->buf_size >= buf_len, "Buffer size too small");
 	__ASSERT(!(desc->width % UC81XX_PIXELS_PER_BYTE),
 		 "Buffer width not multiple of %d", UC81XX_PIXELS_PER_BYTE);
 
@@ -464,12 +460,7 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 		 * data buffer on refresh. Do that manually here if
 		 * needed.
 		 */
-
-		if (config->quirks->set_ptl(dev, x, y, x_end_idx, y_end_idx, desc)) {
-			return -EIO;
-		}
-
-		if (uc81xx_write_cmd(dev, back_buffer,
+		if (uc81xx_write_cmd(dev, UC81XX_CMD_DTM1,
 				     (uint8_t *)buf, buf_len)) {
 			return -EIO;
 		}
@@ -490,15 +481,15 @@ static void uc81xx_get_capabilities(const struct device *dev,
 	memset(caps, 0, sizeof(struct display_capabilities));
 	caps->x_resolution = config->width;
 	caps->y_resolution = config->height;
-	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10;
-	caps->current_pixel_format = PIXEL_FORMAT_MONO10;
+	caps->supported_pixel_formats = PIXEL_FORMAT_MONO01;
+	caps->current_pixel_format = PIXEL_FORMAT_MONO01;
 	caps->screen_info = SCREEN_INFO_MONO_MSB_FIRST | SCREEN_INFO_EPD;
 }
 
 static int uc81xx_set_pixel_format(const struct device *dev,
 				   const enum display_pixel_format pf)
 {
-	if (pf == PIXEL_FORMAT_MONO10) {
+	if (pf == PIXEL_FORMAT_MONO01) {
 		return 0;
 	}
 
@@ -610,7 +601,7 @@ static inline int uc81xx_set_ptl_8(const struct device *dev, uint16_t x, uint16_
 	};
 
 	/* Setup Partial Window and enable Partial Mode */
-	LOG_HEXDUMP_DBG(&ptl, sizeof(ptl), "ptl");
+	LOG_HEXDUMP_DBG(&ptl, sizeof(ptl), "PTL");
 
 	return uc81xx_write_cmd(dev, UC81XX_CMD_PTL, (const void *)&ptl, sizeof(ptl));
 }
@@ -643,7 +634,7 @@ static inline int uc81xx_set_ptl_16(const struct device *dev, uint16_t x, uint16
 	};
 
 	/* Setup Partial Window and enable Partial Mode */
-	LOG_HEXDUMP_DBG(&ptl, sizeof(ptl), "ptl");
+	LOG_HEXDUMP_DBG(&ptl, sizeof(ptl), "PTL");
 
 	return uc81xx_write_cmd(dev, UC81XX_CMD_PTL, (const void *)&ptl, sizeof(ptl));
 }
@@ -701,7 +692,7 @@ static const struct uc81xx_quirks uc8176_quirks = {
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(ultrachip_uc8151d) || DT_HAS_COMPAT_STATUS_OKAY(ultrachip_uc8253)
-static int uc8151d_set_tres(const struct device *dev)
+static int uc81xx_set_tres_h8v16(const struct device *dev)
 {
 	const struct uc81xx_config *config = dev->config;
 	/* Pass pixel coordinates directly; hardware interprets as byte+bit encoding
@@ -718,9 +709,9 @@ static int uc8151d_set_tres(const struct device *dev)
 			       (const void *)&tres, sizeof(tres));
 }
 
-static int uc8151d_set_ptl(const struct device *dev, uint16_t x, uint16_t y,
-			   uint16_t x_end_idx, uint16_t y_end_idx,
-			   const struct display_buffer_descriptor *desc)
+static int uc81xx_set_ptl_h8v16(const struct device *dev, uint16_t x, uint16_t y,
+				uint16_t x_end_idx, uint16_t y_end_idx,
+				const struct display_buffer_descriptor *desc)
 {
 	/* Pass pixel coordinates directly; hardware interprets as byte+bit encoding
 	 * See UC8151D datasheet page 26 (Partial Window command, R90h)
@@ -734,7 +725,7 @@ static int uc8151d_set_ptl(const struct device *dev, uint16_t x, uint16_t y,
 	};
 
 	/* Setup Partial Window and enable Partial Mode */
-	LOG_HEXDUMP_DBG(&ptl, sizeof(ptl), "ptl");
+	LOG_HEXDUMP_DBG(&ptl, sizeof(ptl), "PTL");
 
 	return uc81xx_write_cmd(dev, UC81XX_CMD_PTL,
 			       (const void *)&ptl, sizeof(ptl));
@@ -775,8 +766,8 @@ static const struct uc81xx_quirks uc8151d_quirks = {
 	.pon_after_softstart = true,
 
 	.set_cdi = uc8151d_set_cdi,
-	.set_tres = uc8151d_set_tres,
-	.set_ptl = uc8151d_set_ptl,
+	.set_tres = uc81xx_set_tres_h8v16,
+	.set_ptl = uc81xx_set_ptl_h8v16,
 };
 #endif
 
@@ -789,8 +780,8 @@ static const struct uc81xx_quirks uc8253_quirks = {
 	.pon_after_softstart = false,
 
 	.set_cdi = uc8151d_set_cdi,
-	.set_tres = uc8151d_set_tres,
-	.set_ptl = uc8151d_set_ptl,
+	.set_tres = uc81xx_set_tres_h8v16,
+	.set_ptl = uc81xx_set_ptl_h8v16,
 };
 #endif
 

--- a/drivers/display/uc81xx_regs.h
+++ b/drivers/display/uc81xx_regs.h
@@ -94,7 +94,12 @@
 #define UC8176_CDI_VBD1				BIT(7)
 #define UC8176_CDI_DDX1				BIT(5)
 #define UC8176_CDI_DDX0				BIT(4)
-#define UC8176_CDI_CDI_MASK			0x0f
+#define UC8176_CDI_CDI_MASK                     GENMASK(3, 0)
+#define UC8176_CDI_DEFAULT_INTERVAL             0x07
+
+/* UC8175 */
+#define UC8175_CDI_CDI_MASK         GENMASK(2, 0)
+#define UC8175_CDI_DEFAULT_INTERVAL 0x02
 
 #define UC8179_CDI_REG_LENGTH			2U
 #define UC8179_CDI_BDZ_DDX_IDX			0
@@ -105,6 +110,8 @@
 #define UC8179_CDI_N2OCP			BIT(3)
 #define UC8179_CDI_DDX1				BIT(1)
 #define UC8179_CDI_DDX0				BIT(0)
+#define UC8179_CDI_CDI_MASK                     GENMASK(3, 0)
+#define UC8179_CDI_DEFAULT_INTERVAL             0x07
 
 struct uc81xx_tres8 {
 	uint8_t hres;
@@ -169,10 +176,9 @@ BUILD_ASSERT(sizeof(struct uc8151d_ptl) == 7);
 #define UC8151D_CDI_DEFAULT			0xD7    /* Default value */
 
 /* UC8151D CDI VBD values for border control */
-#define UC8151D_CDI_VBD_FLOATING	0x00    /* Floating border */
-#define UC8151D_CDI_VBD_LUT1		0x40    /* LUT1 border */
-#define UC8151D_CDI_VBD_LUT2		0x80    /* LUT2 border */
-#define UC8151D_CDI_VBD_LUT3		0xC0    /* LUT3 border */
+#define UC8151D_CDI_VBD_FLOATING (BIT(7) | BIT(6))
+#define UC8151D_CDI_VBD_LUTWK    BIT(6)
+#define UC8151D_CDI_VBD_LUTKW    BIT(7)
 
 /* UC8151D CDI DDX values for data polarity */
 #define UC8151D_CDI_DDX_DEFAULT		0x10    /* Default DDX setting */

--- a/samples/drivers/display/Kconfig
+++ b/samples/drivers/display/Kconfig
@@ -15,6 +15,7 @@ config SAMPLE_BUFFER_ADDR_ALIGN
 
 config SAMPLE_PITCH_ALIGN
 	int "The update area pitch alignment"
+	default 8 if UC81XX
 	default 1
 
 config HEAP_MEM_POOL_ADD_SIZE_SAMPLE


### PR DESCRIPTION
This is little rework of uc81xx e-paper driver so it works as expected.
Changes include:
### Added handling for an undocumented UC8253 quirk that swaps DTM registers after refresh.

It is not mentioned in datasheet, but it is confirmed with Waveshare support. Basically after every refresh controller swaps writes to DTM1 and DTM2 representing OLD image (glass state) and NEW image. I don't know how it affects chip when in black/white/red mode, when OLD and NEW data registers are substituted with Black/White and Red data.
It is logically equal to swapping White2Black and Black2White LUT every refresh, but I opted out from this approach, since it would require calling profile change every refresh with additional logic that complicated when using LUT from OTP.
### Pixel alignment

Controller require continuous stream of data and there is no logic for width different from pitch, so pitch equal to width was added.
For partial refresh, area of interest need to be 8 pixel aligned in width and x position.
### Border refresh control

Driver expects border refresh for full update and no border refresh for partial update, but function returned early when no override in DT. By the way all the border control functions has been standardised to use Black2White LUT for border refresh. Driver assumed same border control for uc8176 and uc8175 which was fixed with adding proper uc8175_set_cdi logic.
### Minor fixes
- when setting profile Black2Black LUT was omitted
- when partial refresh added check for buffer being too small
- driver code forces 1=White on init, so for display API pixel format should be MONO01
- renamed uc8151d functions for more generic name, since the same logic is shared with uc8253
- driver assumed auto_copy enabled when available but it was not forced in init
### About OLD - NEW handling

Only NEW mode is not supported so we focus on OLD/NEW refresh logic. Now driver properly sets OLD and NEW registers when doing partial refresh, but when doing full refresh OLD information is lost when display_write exits. Only solution I see is to add frame buffer / shadow buffer to the driver. It is major change, so I settled on keeping OLD equal to NEW when doing full refresh. Functionally it makes inverted image jumpscare on refresh and uses only White2White and Black2Black LUTs. Usually LUTs for full refresh are long and strong with multiple transitions so overall image should be acceptable.

Thank you for letting me be small part of Zephyr. I look forward to your thoughts. Especially on frame buffer / shadow buffer since in future it would enable e-ink drivers to manage orientation changes from LVGL and other.