### PR TITLE
boards: drivers: eth: microchip: Add Ethernet support for PIC32CX-SG series

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/Kconfig.defconfig
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/Kconfig.defconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_PIC32CX_SG41_CULT
+
+config EEPROM
+	default y if NVMEM
+
+configdefault NET_L2_ETHERNET
+	default y
+
+endif # BOARD_PIC32CX_SG41_CULT

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
@@ -69,4 +69,24 @@
 				 <PB25C_SERCOM0_PAD1>;
 		};
 	};
+
+	mdio_default: mdio_default {
+		group1 {
+			pinmux = <PC22L_GMAC_GMDC>,
+				 <PC23L_GMAC_GMDIO>;
+		};
+	};
+
+	gmac_rmii: gmac_rmii {
+		group1 {
+			pinmux = <PA14L_GMAC_GTXCK>,
+				 <PA17L_GMAC_GTXEN>,
+				 <PA18L_GMAC_GTX0>,
+				 <PA19L_GMAC_GTX1>,
+				 <PC20L_GMAC_GRXDV>,
+				 <PA13L_GMAC_GRX0>,
+				 <PA12L_GMAC_GRX1>,
+				 <PA15L_GMAC_GRXER>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -275,6 +275,26 @@
 	dmas = <&dmac 10 0x10>, <&dmac 11 0x11>;
 	dma-names = "rx", "tx";
 	status = "okay";
+
+	eeprom: eeprom@5e {
+		compatible = "atmel,at24", "atmel,24mac402";
+		reg = <0x5e>;
+		size = <256>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mac_address: mac-address@9a {
+				reg = <0x9a 6>;
+				#nvmem-cell-cells = <0>;
+			};
+		};
+	};
 };
 
 &tc5 {
@@ -328,5 +348,31 @@
 	cs-gpios = <&portc 24 GPIO_ACTIVE_LOW>;
 	dmas = <&dmac 3 0x4>, <&dmac 4 0x5>;
 	dma-names = "rx", "tx";
+	status = "okay";
+};
+
+&gmac {
+	pinctrl-0 = <&gmac_rmii>;
+	pinctrl-names = "default";
+
+	nvmem-cells = <&mac_address>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy>;
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&mdio_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		status = "okay";
+		reg = <0>;
+	};
+};
+
+&trng {
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -21,6 +21,7 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - netif:eth
   - interrupt_controller
   - pinctrl
   - pwm

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/Kconfig.defconfig
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/Kconfig.defconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_PIC32CX_SG61_CULT
+
+config EEPROM
+	default y if NVMEM
+
+configdefault NET_L2_ETHERNET
+	default y
+
+endif # BOARD_PIC32CX_SG61_CULT

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
@@ -69,4 +69,24 @@
 				 <PB25C_SERCOM0_PAD1>;
 		};
 	};
+
+	mdio_default: mdio_default {
+		group1 {
+			pinmux = <PC22L_GMAC_GMDC>,
+				 <PC23L_GMAC_GMDIO>;
+		};
+	};
+
+	gmac_rmii: gmac_rmii {
+		group1 {
+			pinmux = <PA14L_GMAC_GTXCK>,
+				 <PA17L_GMAC_GTXEN>,
+				 <PA18L_GMAC_GTX0>,
+				 <PA19L_GMAC_GTX1>,
+				 <PC20L_GMAC_GRXDV>,
+				 <PA13L_GMAC_GRX0>,
+				 <PA12L_GMAC_GRX1>,
+				 <PA15L_GMAC_GRXER>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -279,6 +279,26 @@
 	dmas = <&dmac 10 0x10>, <&dmac 11 0x11>;
 	dma-names = "rx", "tx";
 	status = "okay";
+
+	eeprom: eeprom@5e {
+		compatible = "atmel,at24", "atmel,24mac402";
+		reg = <0x5e>;
+		size = <256>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mac_address: mac-address@9a {
+				reg = <0x9a 6>;
+				#nvmem-cell-cells = <0>;
+			};
+		};
+	};
 };
 
 &tc5 {
@@ -332,5 +352,30 @@
 	cs-gpios = <&portc 24 GPIO_ACTIVE_LOW>;
 	dmas = <&dmac 3 0x4>, <&dmac 4 0x5>;
 	dma-names = "rx", "tx";
+};
+
+&gmac {
+	pinctrl-0 = <&gmac_rmii>;
+	pinctrl-names = "default";
+
+	nvmem-cells = <&mac_address>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy>;
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&mdio_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		status = "okay";
+		reg = <0>;
+	};
+};
+
+&trng {
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -21,6 +21,7 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - netif:eth
   - interrupt_controller
   - pinctrl
   - pwm

--- a/drivers/ethernet/mdio/mdio_mchp_gmac_g1.c
+++ b/drivers/ethernet/mdio/mdio_mchp_gmac_g1.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(mdio_mchp_gmac_g1, CONFIG_MDIO_LOG_LEVEL);
 
 #define DT_DRV_COMPAT microchip_gmac_g1_mdio
 
-#define MDIO_MCHP_OP_TIMEOUT 25
+#define MDIO_MCHP_OP_TIMEOUT 50
 
 struct mdio_dev_data {
 	struct k_mutex reg_mutex;

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -355,6 +355,25 @@
 			status = "disabled";
 		};
 
+		gmac: ethernet@42000800 {
+			compatible = "microchip,gmac-g1-eth";
+			reg = <0x42000800 0x400>;
+			interrupts = <84 0>;
+			interrupt-names = "gmac";
+			num-queues = <1>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_AHB_GMAC>,
+				 <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_GMAC>;
+			clock-names = "mclk-ahb", "mclk-apb";
+			status = "disabled";
+
+			mdio: mdio {
+				compatible = "microchip,gmac-g1-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
+
 		tcc2: tcc@42000c00 {
 			compatible = "microchip,tcc-g1";
 			reg = <0x42000c00 0x2000>;


### PR DESCRIPTION
This pull request adds Ethernet and MDIO driver support for the Microchip GMAC peripheral on PIC32CX-SG series.