### PR TITLE
tests: net: coap_oscore: Select salt-only source via Kconfig

### DIFF
--- a/tests/net/lib/coap_oscore/CMakeLists.txt
+++ b/tests/net/lib/coap_oscore/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(coap_oscore)
 
-if(COAP_OSCORE_SALT_ONLY)
+if(CONFIG_TEST_OSCORE_SALT_ONLY)
   target_sources(app PRIVATE src/salt.c)
 else()
   target_sources(app PRIVATE src/main.c)

--- a/tests/net/lib/coap_oscore/Kconfig
+++ b/tests/net/lib/coap_oscore/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_OSCORE_SALT_ONLY
+	bool "Build only the master-salt-zero OSCORE test"
+	help
+	  Select the minimal salt-only test source (src/salt.c) instead of the
+	  full OSCORE test suite (src/main.c).
+
+source "Kconfig.zephyr"

--- a/tests/net/lib/coap_oscore/tests.yaml
+++ b/tests/net/lib/coap_oscore/tests.yaml
@@ -23,9 +23,8 @@ tests:
     min_flash: 192
     tags: net
     depends_on: netif
-    extra_args:
-      - COAP_OSCORE_SALT_ONLY=ON
     extra_configs:
+      - CONFIG_TEST_OSCORE_SALT_ONLY=y
       - CONFIG_COAP_OSCORE_MASTER_SALT_MAX_LEN=0
       - CONFIG_COAP_OSCORE_MAX_CONTEXTS=2
 


### PR DESCRIPTION
Drive the salt-only test source selection from CONFIG_TEST_OSCORE_SALT_ONLY instead of a bare CMake cache variable so it reaches the application image under sysbuild, where the previous -D only affected the top-level build and left the /ns targets building main.c and failing to link nvm_read/write_ssn.

Fixes #116479