### PR TITLE
drivers: i2c: dw: correct 10-bit addressing in controller

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -731,9 +731,12 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	ic_con.bits.restart_en = 1U;
 
 	/* Set addressing mode - (initialization = 7 bit) */
-	if (I2C_ADDR_10_BITS & dw->app_config) {
+	if (I2C_MSG_ADDR_10_BITS & dw->app_config) {
 		LOG_DBG("I2C: using 10-bit address");
 		ic_con.bits.addr_master_10bit = 1U;
+	} else {
+		LOG_DBG("I2C: using 7-bit address");
+		ic_con.bits.addr_master_10bit = 0U;
 	}
 
 	/* Setup the clock frequency and speed mode */
@@ -804,19 +807,15 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 		write_sar(slave_address, reg_base);
 	}
 
-	/* If I2C is being operated in master mode and I2C_DYNAMIC_TAR_UPDATE
-	 * configuration parameter is set to Yes (1), the ic_10bitaddr_master
-	 * bit in ic_tar register would control whether the DW_apb_i2c starts
-	 * its transfers in 7-bit or 10-bit addressing mode.
+	/* If I2C_DYNAMIC_TAR_UPDATE configuration parameter is set to Yes (1),
+	 * the ic_10bitaddr_master bit in ic_tar register would control whether
+	 * the DW_apb_i2c starts its transfers in 7-bit or 10-bit addressing mode.
 	 */
-	if (I2C_MODE_CONTROLLER & dw->app_config) {
-		if (I2C_ADDR_10_BITS & dw->app_config) {
-			ic_tar.bits.ic_10bitaddr_master = 1U;
-		} else {
-			ic_tar.bits.ic_10bitaddr_master = 0U;
-		}
+	if (I2C_MSG_ADDR_10_BITS & dw->app_config) {
+		ic_tar.bits.ic_10bitaddr_master = 1U;
+	} else {
+		ic_tar.bits.ic_10bitaddr_master = 0U;
 	}
-
 	write_tar(ic_tar.raw, reg_base);
 
 #if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS


### PR DESCRIPTION
The controller path in i2c_dw_setup() had three issues around 10-bit addressing:

* addr_master_10bit was only ever set on the 10-bit branch and never cleared, so once a 10-bit configuration had been programmed the controller stayed latched in 10-bit mode for subsequent 7-bit transfers.

* Both check sites used the deprecated I2C_ADDR_10_BITS macro instead of the current I2C_MSG_ADDR_10_BITS definition.

* The ic_10bitaddr_master programming (dynamic TAR path) was guarded by an additional I2C_MODE_CONTROLLER check that is already asserted earlier in the same function, making the outer branch redundant.

Fix all three by adding an explicit 7-bit clear branch, replacing I2C_ADDR_10_BITS with I2C_MSG_ADDR_10_BITS, and collapsing the dynamic TAR block to a straight if/else. No functional change to the 7-bit default behavior.