### PR TITLE
STM32U0: add poweroff and wakeup pins support

### DIFF
--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -36,7 +36,7 @@
 
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/reset/stm32u0_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
@@ -250,6 +251,51 @@
 				#gpio-cells = <2>;
 				reg = <0x50001400 0x400>;
 				clocks = <&rcc STM32_CLOCK(IOP, 5)>;
+			};
+		};
+
+		pwr: power@40007000 {
+			compatible = "st,stm32-pwr";
+			reg = <0x40007000 0x400>;
+
+			wakeup-controller {
+				compatible = "st,stm32-pwr-wkupctrl";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+
+				st,max-wkup-line-idx = <7>;
+				st,has-pwr-full-pupd;
+
+				wkup@1 {
+					reg = <0x1>;
+					wkup-gpios = <&gpioa 0 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+				};
+
+				wkup@2 {
+					reg = <0x2>;
+					wkup-gpios = <&gpioc 13 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+				};
+
+				wkup@3 {
+					reg = <0x3>;
+					wkup-gpios = <&gpioa 1 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+				};
+
+				wkup@4 {
+					reg = <0x4>;
+					wkup-gpios = <&gpioa 2 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+				};
+
+				wkup@5 {
+					reg = <0x5>;
+					wkup-gpios = <&gpioc 5 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+				};
+
+				wkup@7 {
+					reg = <0x7>;
+					wkup-gpios = <&gpiob 15 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+				};
 			};
 		};
 

--- a/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_u083rc.overlay
+++ b/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_u083rc.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		wkup-src = &user_button;
+	};
+};
+
+&pwr {
+	wakeup-controller {
+		status = "okay";
+	};
+};

--- a/samples/boards/st/power_mgmt/wkup_pins/tests.yaml
+++ b/samples/boards/st/power_mgmt/wkup_pins/tests.yaml
@@ -11,6 +11,7 @@ tests:
       - nucleo_g031k8
       - nucleo_l152re
       - nucleo_l4r5zi
+      - nucleo_u083rc
       - nucleo_u575zi_q
       - nucleo_u5a5zj_q
       - nucleo_wba55cg

--- a/soc/st/stm32/stm32u0x/CMakeLists.txt
+++ b/soc/st/stm32/stm32u0x/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_sources(
   )
 
 zephyr_sources_ifdef(CONFIG_PM power.c)
+zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 
 zephyr_include_directories(.)
 

--- a/soc/st/stm32/stm32u0x/Kconfig
+++ b/soc/st/stm32/stm32u0x/Kconfig
@@ -13,6 +13,7 @@ config SOC_SERIES_STM32U0X
 	select CPU_HAS_ARM_MPU
 	# Software options
 	select HAS_PM
+	select HAS_POWEROFF
 	select PM_STATE_SET_IRQ_UNLOCKED
 	select SOC_EARLY_INIT_HOOK
 	# STM32-specific options

--- a/soc/st/stm32/stm32u0x/poweroff.c
+++ b/soc/st/stm32/stm32u0x/poweroff.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/toolchain.h>
+
+#include <stm32_bitops.h>
+#include <stm32_common.h>
+#include <stm32_ll_pwr.h>
+
+void z_sys_poweroff(void)
+{
+	if (IS_ENABLED(CONFIG_STM32_WKUP_PINS)) {
+		LL_PWR_EnablePUPDCfg();
+	}
+
+	/* No LL function to clear all flags at once; do it ourselves */
+	stm32_reg_set_bits(&PWR->SCR,
+			   PWR_SCR_CWUF1 | PWR_SCR_CWUF2 | PWR_SCR_CWUF3 |
+			   PWR_SCR_CWUF4 | PWR_SCR_CWUF5 | PWR_SCR_CWUF7);
+	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
+
+	stm32_enter_poweroff();
+}


### PR DESCRIPTION
This PR adds the support for poweroff and wakeup pins on STM32U0.
Tested on Nucleo-U083RC.