### PR TITLE
ISM330DHCX attr get + effective ODR reporting (reading INTERNAL_FREQ_FINE)

### DIFF
--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor/ism330dhcx.h>
 
 #include "ism330dhcx.h"
 
@@ -286,6 +287,90 @@ static int ism330dhcx_attr_set(const struct device *dev,
 	}
 
 	return 0;
+}
+
+/* Millionths of a unit, the resolution of sensor_value.val2. */
+#define ISM330DHCX_MICRO_PER_UNIT 1000000
+
+/* One INTERNAL_FREQ_FINE step is 0.15% of the rate, i.e. 1500 millionths. */
+#define ISM330DHCX_FREQ_FINE_STEP_MICRO 1500
+
+/*
+ * INTERNAL_FREQ_FINE holds the oscillator deviation as a signed count of 0.15%
+ * steps (datasheet chapter 9.24), scaling the configured rate to the real one.
+ */
+static void ism330dhcx_real_odr_get(const struct device *dev, uint16_t freq,
+				    struct sensor_value *val)
+{
+	struct ism330dhcx_data *data = dev->data;
+	int64_t freq_micro_hz =
+		(int64_t)freq * (ISM330DHCX_MICRO_PER_UNIT +
+				 ISM330DHCX_FREQ_FINE_STEP_MICRO * (int64_t)data->freq_fine);
+
+	val->val1 = (int32_t)(freq_micro_hz / ISM330DHCX_MICRO_PER_UNIT);
+	val->val2 = (int32_t)(freq_micro_hz % ISM330DHCX_MICRO_PER_UNIT);
+}
+
+static int ism330dhcx_accel_get_config(const struct device *dev,
+				       enum sensor_attribute attr,
+				       struct sensor_value *val)
+{
+	struct ism330dhcx_data *data = dev->data;
+
+	switch ((int)attr) {
+	case SENSOR_ATTR_FULL_SCALE:
+		sensor_g_to_ms2(ism330dhcx_accel_fs_map[data->accel_fs], val);
+		return 0;
+	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+		val->val1 = data->accel_freq;
+		val->val2 = 0;
+		return 0;
+	case SENSOR_ATTR_ISM330DHCX_REAL_ODR:
+		ism330dhcx_real_odr_get(dev, data->accel_freq, val);
+		return 0;
+	default:
+		LOG_DBG("Accel attribute not supported.");
+		return -ENOTSUP;
+	}
+}
+
+static int ism330dhcx_gyro_get_config(const struct device *dev,
+				      enum sensor_attribute attr,
+				      struct sensor_value *val)
+{
+	struct ism330dhcx_data *data = dev->data;
+
+	switch ((int)attr) {
+	case SENSOR_ATTR_FULL_SCALE:
+		sensor_degrees_to_rad(ism330dhcx_gyro_fs_map[data->gyro_fs], val);
+		return 0;
+	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+		val->val1 = data->gyro_freq;
+		val->val2 = 0;
+		return 0;
+	case SENSOR_ATTR_ISM330DHCX_REAL_ODR:
+		ism330dhcx_real_odr_get(dev, data->gyro_freq, val);
+		return 0;
+	default:
+		LOG_DBG("Gyro attribute not supported.");
+		return -ENOTSUP;
+	}
+}
+
+static int ism330dhcx_attr_get(const struct device *dev,
+			       enum sensor_channel chan,
+			       enum sensor_attribute attr,
+			       struct sensor_value *val)
+{
+	switch (chan) {
+	case SENSOR_CHAN_ACCEL_XYZ:
+		return ism330dhcx_accel_get_config(dev, attr, val);
+	case SENSOR_CHAN_GYRO_XYZ:
+		return ism330dhcx_gyro_get_config(dev, attr, val);
+	default:
+		LOG_WRN("attr_get() not supported on this channel.");
+		return -ENOTSUP;
+	}
 }
 
 static int ism330dhcx_sample_fetch_accel(const struct device *dev)
@@ -680,6 +765,7 @@ static int ism330dhcx_channel_get(const struct device *dev,
 
 static DEVICE_API(sensor, ism330dhcx_api_funcs) = {
 	.attr_set = ism330dhcx_attr_set,
+	.attr_get = ism330dhcx_attr_get,
 #if CONFIG_ISM330DHCX_TRIGGER
 	.trigger_set = ism330dhcx_trigger_set,
 #endif
@@ -746,6 +832,19 @@ static int ism330dhcx_init_chip(const struct device *dev)
 		LOG_DBG("failed to set gyroscope sampling rate");
 		return -EIO;
 	}
+
+	/* Factory trim, constant for the life of the part: read it once here so
+	 * that querying the effective output data rate costs no bus traffic.
+	 */
+	uint8_t freq_fine;
+
+	if (ism330dhcx_odr_cal_reg_get(ism330dhcx->ctx, &freq_fine) < 0) {
+		LOG_DBG("failed to read internal frequency trim");
+		return -EIO;
+	}
+
+	ism330dhcx->freq_fine = (int8_t)freq_fine;
+	LOG_DBG("internal frequency trim is %d", ism330dhcx->freq_fine);
 
 	/* Set FIFO bypass mode */
 	if (ism330dhcx_fifo_mode_set(ism330dhcx->ctx, ISM330DHCX_BYPASS_MODE) < 0) {

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -138,6 +138,8 @@ static int ism330dhcx_gyro_set_fs_raw(const struct device *dev, uint8_t fs)
 		return -EIO;
 	}
 
+	data->gyro_fs = fs;
+
 	return 0;
 }
 
@@ -148,6 +150,8 @@ static int ism330dhcx_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
 	if (ism330dhcx_gy_data_rate_set(data->ctx, odr) < 0) {
 		return -EIO;
 	}
+
+	data->gyro_freq = ism330dhcx_odr_to_freq_val(odr);
 
 	return 0;
 }
@@ -738,7 +742,6 @@ static int ism330dhcx_init_chip(const struct device *dev)
 	}
 
 	LOG_DBG("gyro odr is %d", cfg->gyro_odr);
-	ism330dhcx->gyro_freq = ism330dhcx_odr_to_freq_val(cfg->gyro_odr);
 	if (ism330dhcx_gyro_set_odr_raw(dev, cfg->gyro_odr) < 0) {
 		LOG_DBG("failed to set gyroscope sampling rate");
 		return -EIO;

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.h
@@ -90,6 +90,9 @@ struct ism330dhcx_data {
 	uint16_t gyro_freq;
 	uint8_t gyro_fs;
 
+	/* Factory trim of the internal oscillator, read once at init. */
+	int8_t freq_fine;
+
 #ifdef CONFIG_ISM330DHCX_TRIGGER
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler_drdy_acc;

--- a/include/zephyr/drivers/sensor/ism330dhcx.h
+++ b/include/zephyr/drivers/sensor/ism330dhcx.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Filics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of ISM330DHCX sensor
+ * @ingroup ism330dhcx_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_ISM330DHCX_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_ISM330DHCX_H_
+
+/**
+ * @defgroup ism330dhcx_interface ISM330DHCX
+ * @ingroup sensor_interface_ext_st
+ * @brief ST Microelectronics ISM330DHCX 6-axis IMU
+ * @{
+ */
+
+#include <zephyr/drivers/sensor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Custom sensor attributes for ISM330DHCX
+ */
+enum sensor_attribute_ism330dhcx {
+	/**
+	 * Real output data rate in Hz, the configured rate corrected by the
+	 * factory oscillator trim in INTERNAL_FREQ_FINE. Read-only.
+	 */
+	SENSOR_ATTR_ISM330DHCX_REAL_ODR = SENSOR_ATTR_PRIV_START,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ISM330DHCX_H_ */


### PR DESCRIPTION
The driver could not read its configuration back, nor reach INTERNAL_FREQ_FINE, which holds the factory-measured deviation of the internal oscillator in signed steps of 0.15%. The device therefore samples up to roughly 19% away from the configured rate: a part measured here reports 109.46 Hz when configured for 104 Hz.

Add attr_get() serving SENSOR_ATTR_FULL_SCALE and
SENSOR_ATTR_SAMPLING_FREQUENCY, which report the configured values as in the lsm6dsv16x driver, plus SENSOR_ATTR_ISM330DHCX_REAL_ODR for the trim-corrected rate. The trim is constant for the life of the part, so it is read once at init and applied with integer arithmetic.

Reading the configuration back also requires tracking it: the gyroscope setters never updated data->gyro_freq and data->gyro_fs. Update them as the accelerometer ones already do.