### PR TITLE
boards: nxp: lpcxpresso54628: add SD card (SDIF) support

### DIFF
--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
@@ -6,6 +6,21 @@
 
 #include <nxp/lpc/LPC54628J512ET180-pinctrl.h>
 
+/*
+ * LPC546xx erratum SDIO.1 requires the four unused upper SD data functions
+ * (SD_D4-SD_D7) to be muxed with a pull-up even in 4-bit mode, or SD data
+ * transfers fail. This 180-ball package (ET180) does not bond a pad for these
+ * signals, so route them to the internal-only pads PIO4_29-31/PIO5_0 - the pads
+ * the NXP SDK uses for exactly this - which satisfies the controller without
+ * consuming a usable pin. These pads are not in the package pinctrl header (no
+ * ball), so their mux values are defined here (IOCON offset = port * 32 + pin,
+ * SDIF function = 2).
+ */
+#define SDIF_SD_D4_PIO4_29 IOCON_MUX(157, IOCON_TYPE_D, 2)
+#define SDIF_SD_D5_PIO4_30 IOCON_MUX(158, IOCON_TYPE_D, 2)
+#define SDIF_SD_D6_PIO4_31 IOCON_MUX(159, IOCON_TYPE_D, 2)
+#define SDIF_SD_D7_PIO5_0  IOCON_MUX(160, IOCON_TYPE_D, 2)
+
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {
 		group0 {
@@ -19,6 +34,40 @@
 		group0 {
 			pinmux = <USB0_VBUS_PIO0_22>;
 			slew-rate = "standard";
+		};
+	};
+
+	/* SD/MMC full-size card slot (J7): 4-bit data + native power-enable. */
+	pinmux_sdif: pinmux_sdif {
+		group0 {
+			pinmux = <SD_CLK_PIO2_3>,
+				 <SD_CMD_PIO2_4>,
+				 <SDIF_SD_D0_PIO2_6>,
+				 <SDIF_SD_D1_PIO2_7>,
+				 <SDIF_SD_D2_PIO2_8>,
+				 <SDIF_SD_D3_PIO2_9>,
+				 <SD_POW_EN_PIO2_5>;
+			slew-rate = "fast";
+		};
+
+		group1 {
+			pinmux = <SD_CARD_DET_N_PIO2_10>;
+			slew-rate = "standard";
+			bias-pull-up;
+		};
+
+		/*
+		 * Unused upper data lines, muxed to internal-only pads with
+		 * pull-ups to satisfy erratum SDIO.1 (see the note at the top of
+		 * this file) without consuming a usable pin.
+		 */
+		group2 {
+			pinmux = <SDIF_SD_D4_PIO4_29>,
+				 <SDIF_SD_D5_PIO4_30>,
+				 <SDIF_SD_D6_PIO4_31>,
+				 <SDIF_SD_D7_PIO5_0>;
+			slew-rate = "fast";
+			bias-pull-up;
 		};
 	};
 };

--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
@@ -94,3 +94,16 @@
 zephyr_udc0: &usbhs {
 	status = "okay";
 };
+
+/* Full-size SD card slot (J7), 4-bit SDIO. */
+&sdif {
+	status = "okay";
+	pinctrl-0 = <&pinmux_sdif>;
+	pinctrl-names = "default";
+
+	mmc {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
+	};
+};

--- a/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
@@ -328,6 +328,14 @@
 			num-bidir-endpoints = <6>;
 			status = "disabled";
 		};
+
+		sdif: sdif@4009b000 {
+			compatible = "nxp,lpc-sdif";
+			reg = <0x4009b000 0x1000>;
+			interrupts = <42 0>;
+			clocks = <&syscon MCUX_SDIF_CLK>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/soc/nxp/lpc/lpc54xxx/soc.c
+++ b/soc/nxp/lpc/lpc54xxx/soc.c
@@ -187,6 +187,16 @@ __weak void clock_init(void)
 #endif
 #endif
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(sdif), nxp_lpc_sdif, okay)
+	/*
+	 * SD/MMC host source clock: the main clock, divided to stay within the
+	 * controller's maximum source frequency.
+	 */
+	CLOCK_AttachClk(kMAIN_CLK_to_SDIO_CLK);
+	CLOCK_SetClkDiv(kCLOCK_DivSdioClk,
+			(CPU_FREQ / FSL_FEATURE_SDIF_MAX_SOURCE_CLOCK) + 1U, true);
+#endif
+
 	/*
 	 * The M_CAN functional clock is the core clock divided by CANnCLKDIV,
 	 * which is halted out of reset. Divide by 11 -> 20 MHz at a 220 MHz


### PR DESCRIPTION
## Summary

Enables the full-size SD card slot (J7) of the LPCXpresso54628 through the
LPC546xx SDIF host, using the existing in-tree `nxp,lpc-sdif` driver. No new
driver or binding is added.

1. **soc: nxp: lpc54xxx: add the SD/MMC (SDIF) host** — adds the SDIF node and
   sets up its source clock (the main clock, divided to stay within the
   controller's maximum source frequency).
2. **boards: nxp: lpcxpresso54628: enable the SD card slot** — enables `&sdif`
   in 4-bit mode with a `zephyr,sdmmc-disk` child, plus the pinctrl.

## Erratum SDIO.1

Per erratum SDIO.1 in the LPC546xx errata sheet (`ES_LPC546XX`), the four unused
upper data lines SD_D4-SD_D7 must have their SDIF function selected with a
pull-up enabled even when the slot is wired for 4-bit operation.

The ET180 package bonds no pad for these four signals, so they are muxed to the
internal-only pads PIO4_29-31/PIO5_0, which is what the NXP MCUXpresso SDK does
in `Board_InitSdifUnusedDataPin()`. This satisfies the controller without using
a pin that is otherwise available on the expansion headers. Those pads have no
ball and are therefore not in the package pinctrl header, so their mux values
are defined in the board pinctrl.

## Testing

Verified on an LPCXpresso54628 with `samples/subsys/fs/fs_sample` and a 16 GB
card: the card enumerates, the FAT filesystem mounts, and directory listing,
file creation and read back all work.
