### PR TITLE
testsuite: ztest: benchmark: make the headers usable from C++

### DIFF
--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -217,14 +217,14 @@ static __noinline void empty_function(void)
 
 static struct ztest_benchmark ctrl = {
 	.name = "ctrl",
-	.run = empty_function,
 	.iterations = 1000,
+	.run = empty_function,
 };
 
 static struct ztest_benchmark_timed ctrl_timed = {
+	.duration_ms = 100,
 	.name = "ctrl_timed",
 	.run = empty_function,
-	.duration_ms = 100,
 };
 
 void benchmark_main(void)

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -14,6 +14,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond INTERNAL_HIDDEN */
 /*
  * Identifier builders for the linker-visible symbols that the ZTEST_BENCHMARK*()
@@ -112,8 +116,8 @@ void benchmark_main(void);
 		.name = #benchmark,								\
 		.iterations = samples,								\
 		.setup = setup_fn,								\
-		.teardown = teardown_fn,							\
 		.run = Z_ZTEST_BENCHMARK_FN(suite_name, benchmark),				\
+		.teardown = teardown_fn,							\
 		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(suite_name),				\
 	};											\
 	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void)
@@ -133,8 +137,8 @@ void benchmark_main(void);
 	static const STRUCT_SECTION_ITERABLE(ztest_benchmark_timed,				\
 					Z_ZTEST_BENCHMARK_TIMED_NODE(testsuite, benchmark)) =	\
 	{											\
-		.name = #benchmark,								\
 		.duration_ms = duration,							\
+		.name = #benchmark,								\
 		.setup = setup_fn,								\
 		.run = Z_ZTEST_BENCHMARK_FN(testsuite, benchmark),				\
 		.teardown = teardown_fn,							\
@@ -145,4 +149,9 @@ void benchmark_main(void);
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZTEST_BENCHMARK_H */


### PR DESCRIPTION
The benchmarking framework cannot be used from a C++ translation unit.

C++ requires designated initialisers to appear in declaration order, and
two of the macros do not follow it: struct ztest_benchmark declares run
before teardown while ZTEST_BENCHMARK() initialises teardown first, and
struct ztest_benchmark_timed declares duration_ms before name while
ZTEST_BENCHMARK_TIMED() initialises name first. The two control
benchmarks in the runner have the same problem. C allows any order, so
none of it was noticed.

The header also lacks an extern "C" guard, so the declarations it makes
get C++ linkage and fail to resolve against the framework, which is
compiled as C.

A translation unit that includes the header and instantiates both macros
fails to compile as C++:

  benchmark.h: error: designator order for field 'ztest_benchmark::run'
  does not match declaration order in 'const ztest_benchmark'
  benchmark.h: error: designator order for field
  'ztest_benchmark_timed::duration_ms' does not match declaration order
  in 'const ztest_benchmark_timed'

Reorder the initialisers to match the structures and wrap the header in
extern "C". No behaviour changes for C.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
