### PR TITLE
drivers: counter: xec: implement low power mode

### DIFF
--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -28,6 +28,7 @@
 LOG_MODULE_REGISTER(counter_mchp_xec, CONFIG_COUNTER_LOG_LEVEL);
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/pm/device.h>
 #include <soc.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -46,6 +47,7 @@ struct counter_xec_data {
 	counter_alarm_callback_t alarm_cb;
 	counter_top_callback_t top_cb;
 	void *user_data;
+	uint32_t ctrl;
 };
 
 #define COUNTER_XEC_REG_BASE(_dev)                                                                 \
@@ -265,6 +267,39 @@ static void counter_xec_isr(const struct device *dev)
 	}
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int counter_xec_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
+	struct counter_xec_data *data = COUNTER_XEC_DATA(dev);
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		if (data->ctrl & MCHP_BTMR_CTRL_ENABLE) {
+			counter->CTRL |= MCHP_BTMR_CTRL_ENABLE;
+			if (data->ctrl & MCHP_BTMR_CTRL_START) {
+				counter->CTRL |= MCHP_BTMR_CTRL_START;
+			}
+
+			data->ctrl = 0;
+		}
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		if (counter->CTRL & MCHP_BTMR_CTRL_ENABLE) {
+			data->ctrl = counter->CTRL;
+
+			counter->CTRL &= ~(MCHP_BTMR_CTRL_START);
+			counter->CTRL &= ~(MCHP_BTMR_CTRL_ENABLE);
+		}
+		break;
+	default:
+		ret = -ENOTSUP;
+	}
+	return ret;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 static DEVICE_API(counter, counter_xec_api) = {
 	.start = counter_xec_start,
 	.stop = counter_xec_stop,
@@ -326,9 +361,10 @@ static int counter_xec_init(const struct device *dev)
 		.enc_pcr = DT_INST_PROP(0, pcr_src),                                               \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, counter_xec_init, NULL, &counter_xec_dev_data_##inst,          \
-			      &counter_xec_dev_config_##inst, POST_KERNEL,                         \
-			      CONFIG_COUNTER_INIT_PRIORITY, &counter_xec_api);                     \
+	PM_DEVICE_DT_INST_DEFINE(inst, counter_xec_pm_action);                                     \
+	DEVICE_DT_INST_DEFINE(inst, counter_xec_init, PM_DEVICE_DT_INST_GET(inst),                 \
+			      &counter_xec_dev_data_##inst, &counter_xec_dev_config_##inst,        \
+			      POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY, &counter_xec_api);        \
                                                                                                    \
 	static void counter_xec_irq_config_##inst(void)                                            \
 	{                                                                                          \

--- a/soc/microchip/mec/common/soc_pm_mgmt.c
+++ b/soc/microchip/mec/common/soc_pm_mgmt.c
@@ -19,11 +19,42 @@
 #define XEC_PCR_OSC_ID_OFS          0x0CU
 #define XEC_PCR_OSC_ID_PLL_LOCK_POS 8
 
-#define XEC_BASIC_TIMER_INSTANCES 6
-#define XEC_BASIC_TIMER_SPACING   0x20U
-#define XEC_BASIC_TIMER0_REG_BASE DT_REG_ADDR(DT_NODELABEL(timer0))
-#define XEC_BASIC_TIMER_CR_OFS    0x10U
-#define XEC_BASIC_TIMER_CR_EN_POS 0
+/*
+ * arch_busy_wait()'s free-running counter is not a Zephyr device (no
+ * PM_DEVICE hook), so it can't be stopped/restarted at the driver level.
+ * Derive its base address from the same "busy-wait-timer" DT phandle
+ * mchp_xec_rtos_timer.c uses to stop/restart. All other basic timers are
+ * Zephyr counter devices (drivers/counter/counter_mchp_xec.c) and are
+ * suspended/resumed via their own PM_DEVICE action.
+ */
+#if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT) &&                                                   \
+	DT_NODE_HAS_PROP(DT_NODELABEL(rtimer), busy_wait_timer)
+#define BUSY_WAIT_TMR_ADDR DT_REG_ADDR(DT_PHANDLE(DT_NODELABEL(rtimer), busy_wait_timer))
+
+static void deep_sleep_save_busy_wait_timer(void)
+{
+	uintptr_t ctrl_addr = BUSY_WAIT_TMR_ADDR + MCHP_BTMR_CTRL_OFS;
+
+	sys_write32(sys_read32(ctrl_addr) & ~(MCHP_BTMR_CTRL_START | MCHP_BTMR_CTRL_ENABLE),
+		    ctrl_addr);
+}
+
+static void deep_sleep_restore_busy_wait_timer(void)
+{
+	uintptr_t ctrl_addr = BUSY_WAIT_TMR_ADDR + MCHP_BTMR_CTRL_OFS;
+
+	sys_write32(sys_read32(ctrl_addr) | MCHP_BTMR_CTRL_ENABLE | MCHP_BTMR_CTRL_START,
+		    ctrl_addr);
+}
+#else
+static void deep_sleep_save_busy_wait_timer(void)
+{
+}
+
+static void deep_sleep_restore_busy_wait_timer(void)
+{
+}
+#endif
 
 #if DT_NODE_EXISTS(DT_NODELABEL(uart3))
 #define MEC165XB_UART_INSTANCES 4
@@ -35,33 +66,7 @@
 
 #define XEC_UART0_REG_BASE DT_REG_ADDR(DT_NODELABEL(uart0))
 
-static uint8_t basic_timer_cr_save[XEC_BASIC_TIMER_INSTANCES];
 static uint8_t uart_actv_save[MEC165XB_UART_INSTANCES];
-
-static void save_basic_timers(void)
-{
-	mm_reg_t rb = (mm_reg_t)(XEC_BASIC_TIMER0_REG_BASE);
-
-	for (uint32_t n = 0; n < XEC_BASIC_TIMER_INSTANCES; n++) {
-		uint32_t temp = sys_read32(rb + XEC_BASIC_TIMER_CR_OFS);
-
-		sys_write32(temp & ~BIT(XEC_BASIC_TIMER_CR_EN_POS), rb + XEC_BASIC_TIMER_CR_OFS);
-		basic_timer_cr_save[n] = (uint8_t)(temp & BIT(XEC_BASIC_TIMER_CR_EN_POS));
-		rb += XEC_BASIC_TIMER_SPACING;
-	}
-}
-
-static void restore_basic_timers(void)
-{
-	mm_reg_t rb = (mm_reg_t)(XEC_BASIC_TIMER0_REG_BASE);
-
-	for (uint32_t n = 0; n < XEC_BASIC_TIMER_INSTANCES; n++) {
-		if (basic_timer_cr_save[n] != 0) {
-			sys_set_bit(rb + XEC_BASIC_TIMER_CR_OFS, XEC_BASIC_TIMER_CR_EN_POS);
-		}
-		rb += XEC_BASIC_TIMER_SPACING;
-	}
-}
 
 static void save_uarts(void)
 {
@@ -89,13 +94,13 @@ static void restore_uarts(void)
  */
 static void soc_deep_sleep_periph_save(void)
 {
-	save_basic_timers();
+	deep_sleep_save_busy_wait_timer();
 	save_uarts();
 }
 
 static void soc_deep_sleep_periph_restore(void)
 {
-	restore_basic_timers();
+	deep_sleep_restore_busy_wait_timer();
 	restore_uarts();
 }
 

--- a/soc/microchip/mec/mec15xx/device_power.c
+++ b/soc/microchip/mec/mec15xx/device_power.c
@@ -32,6 +32,40 @@
  */
 #define DEEP_SLEEP_PERIPH_SAVE_RESTORE
 
+/*
+ * arch_busy_wait()'s free-running counter is not a Zephyr device (no
+ * PM_DEVICE hook), so it can't be stopped/restarted at the driver level.
+ * Derive its base address from the same "busy-wait-timer" DT phandle
+ * mchp_xec_rtos_timer.c uses to stop/restart.
+ */
+#if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT) &&                                                   \
+	DT_NODE_HAS_PROP(DT_NODELABEL(rtimer), busy_wait_timer)
+#define BUSY_WAIT_TMR_ADDR DT_REG_ADDR(DT_PHANDLE(DT_NODELABEL(rtimer), busy_wait_timer))
+
+static void deep_sleep_save_busy_wait_timer(void)
+{
+	uintptr_t ctrl_addr = BUSY_WAIT_TMR_ADDR + MCHP_BTMR_CTRL_OFS;
+
+	sys_write32(sys_read32(ctrl_addr) & ~(MCHP_BTMR_CTRL_START | MCHP_BTMR_CTRL_ENABLE),
+		    ctrl_addr);
+}
+
+static void deep_sleep_restore_busy_wait_timer(void)
+{
+	uintptr_t ctrl_addr = BUSY_WAIT_TMR_ADDR + MCHP_BTMR_CTRL_OFS;
+
+	sys_write32(sys_read32(ctrl_addr) | MCHP_BTMR_CTRL_ENABLE | MCHP_BTMR_CTRL_START,
+		    ctrl_addr);
+}
+#else
+static void deep_sleep_save_busy_wait_timer(void)
+{
+}
+
+static void deep_sleep_restore_busy_wait_timer(void)
+{
+}
+#endif
 
 /*
  * Light sleep: PLL remains on. Fastest wake latency.
@@ -124,18 +158,6 @@ struct ds_timer_info {
 
 const struct ds_timer_info ds_timer_tbl[] = {
 	{
-		(uintptr_t)&B16TMR0_REGS->CTRL, 0
-	},
-	{
-		(uintptr_t)&B16TMR1_REGS->CTRL, 0
-	},
-	{
-		(uintptr_t)&B32TMR0_REGS->CTRL, 0
-	},
-	{
-		(uintptr_t)&B32TMR1_REGS->CTRL, 0
-	},
-	{
 		(uintptr_t)&CCT_REGS->CTRL,
 		(MCHP_CCT_CTRL_COMP1_SET | MCHP_CCT_CTRL_COMP0_SET),
 	},
@@ -210,6 +232,7 @@ void soc_deep_sleep_periph_save(void)
 {
 	deep_sleep_save_uarts();
 	deep_sleep_save_ecs();
+	deep_sleep_save_busy_wait_timer();
 	deep_sleep_save_timers();
 }
 
@@ -217,6 +240,7 @@ void soc_deep_sleep_periph_restore(void)
 {
 	deep_sleep_restore_ecs();
 	deep_sleep_restore_uarts();
+	deep_sleep_restore_busy_wait_timer();
 	deep_sleep_restore_timers();
 }
 

--- a/soc/microchip/mec/mec172x/device_power.c
+++ b/soc/microchip/mec/mec172x/device_power.c
@@ -33,14 +33,6 @@
 #define VBATM_XEC_BASE_ADDR						\
 	((uintptr_t)(DT_REG_ADDR(DT_NODELABEL(bbram))))
 
-#define BTMR16_0_ADDR	DT_REG_ADDR(DT_NODELABEL(timer0))
-#define BTMR16_1_ADDR	DT_REG_ADDR(DT_NODELABEL(timer1))
-#define BTMR16_2_ADDR	DT_REG_ADDR(DT_NODELABEL(timer2))
-#define BTMR16_3_ADDR	DT_REG_ADDR(DT_NODELABEL(timer3))
-#define BTMR32_0_ADDR	DT_REG_ADDR(DT_NODELABEL(timer4))
-#define BTMR32_1_ADDR	DT_REG_ADDR(DT_NODELABEL(timer5))
-#define VBATM_XEC_ADDR	DT_REG_ADDR(DT_NODELABEL(vbr))
-
 #ifdef DEBUG_DEEP_SLEEP_CLK_REQ
 void soc_debug_sleep_clk_req(void)
 {
@@ -57,6 +49,41 @@ void soc_debug_sleep_clk_req(void)
 	sys_write32(pcr->SYS_SLP_CTRL, vbm_addr);
 	vbm_addr += 4;
 	sys_write32(ecs->SLP_STS_MIRROR, vbm_addr);
+}
+#endif
+
+/*
+ * arch_busy_wait()'s free-running counter is not a Zephyr device (no
+ * PM_DEVICE hook), so it can't be stopped/restarted at the driver level.
+ * Derive its base address from the same "busy-wait-timer" DT phandle
+ * mchp_xec_rtos_timer.c uses to stop/restart.
+ */
+#if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT) &&                                                   \
+	DT_NODE_HAS_PROP(DT_NODELABEL(rtimer), busy_wait_timer)
+#define BUSY_WAIT_TMR_ADDR DT_REG_ADDR(DT_PHANDLE(DT_NODELABEL(rtimer), busy_wait_timer))
+
+static void deep_sleep_save_busy_wait_timer(void)
+{
+	uintptr_t ctrl_addr = BUSY_WAIT_TMR_ADDR + MCHP_BTMR_CTRL_OFS;
+
+	sys_write32(sys_read32(ctrl_addr) & ~(MCHP_BTMR_CTRL_START | MCHP_BTMR_CTRL_ENABLE),
+		    ctrl_addr);
+}
+
+static void deep_sleep_restore_busy_wait_timer(void)
+{
+	uintptr_t ctrl_addr = BUSY_WAIT_TMR_ADDR + MCHP_BTMR_CTRL_OFS;
+
+	sys_write32(sys_read32(ctrl_addr) | MCHP_BTMR_CTRL_ENABLE | MCHP_BTMR_CTRL_START,
+		    ctrl_addr);
+}
+#else
+static void deep_sleep_save_busy_wait_timer(void)
+{
+}
+
+static void deep_sleep_restore_busy_wait_timer(void)
+{
 }
 #endif
 
@@ -123,33 +150,6 @@ void soc_deep_sleep_wake_dis(void)
 /* Variables used to save various HW state */
 #ifdef DEEP_SLEEP_PERIPH_SAVE_RESTORE
 
-const struct ds_timer_info ds_timer_tbl[NUM_DS_TIMER_ENTRIES] = {
-	{
-		(uintptr_t)(BTMR16_0_ADDR + MCHP_BTMR_CTRL_OFS),
-		MCHP_BTMR_CTRL_HALT, 0
-	},
-	{
-		(uintptr_t)(BTMR16_1_ADDR + MCHP_BTMR_CTRL_OFS),
-		MCHP_BTMR_CTRL_HALT, 0
-	},
-	{
-		(uintptr_t)(BTMR16_2_ADDR + MCHP_BTMR_CTRL_OFS),
-		MCHP_BTMR_CTRL_HALT, 0
-	},
-	{
-		(uintptr_t)(BTMR16_3_ADDR + MCHP_BTMR_CTRL_OFS),
-		MCHP_BTMR_CTRL_HALT, 0
-	},
-	{
-		(uintptr_t)(BTMR32_0_ADDR + MCHP_BTMR_CTRL_OFS),
-		MCHP_BTMR_CTRL_HALT, 0
-	},
-	{
-		(uintptr_t)(BTMR32_1_ADDR + MCHP_BTMR_CTRL_OFS),
-		MCHP_BTMR_CTRL_HALT, 0
-	},
-};
-
 static struct ds_dev_info ds_ctx;
 
 static void deep_sleep_save_ecs(void)
@@ -186,23 +186,6 @@ static void deep_sleep_save_uarts(void)
 }
 #endif
 
-static void deep_sleep_save_timers(void)
-{
-	const struct ds_timer_info *p;
-	uint32_t i;
-
-	p = &ds_timer_tbl[0];
-	for (i = 0; i < NUM_DS_TIMER_ENTRIES; i++) {
-		ds_ctx.timers[i] = sys_read32(p->addr);
-		if (p->stop_mask) {
-			sys_write32(ds_ctx.timers[i] | p->stop_mask, p->addr);
-		} else {
-			sys_write32(0, p->addr);
-		}
-		p++;
-	}
-}
-
 static void deep_sleep_restore_ecs(void)
 {
 #ifdef DEEP_SLEEP_JTAG
@@ -223,24 +206,6 @@ static void deep_sleep_restore_uarts(void)
 	regs1->ACTV = ds_ctx.uart_info[1];
 }
 #endif
-
-static void deep_sleep_restore_timers(void)
-{
-	const struct ds_timer_info *p;
-	uint32_t i, temp;
-
-	p = &ds_timer_tbl[0];
-	for (i = 0; i < NUM_DS_TIMER_ENTRIES; i++) {
-		if (p->stop_mask) {
-			temp = sys_read32(p->addr) & ~(p->stop_mask);
-			sys_write32(temp, p->addr);
-		} else {
-			sys_write32(ds_ctx.timers[i] & ~p->restore_mask,
-				    p->addr);
-		}
-		p++;
-	}
-}
 
 #ifdef DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED
 
@@ -365,7 +330,7 @@ void soc_deep_sleep_periph_save(void)
 	deep_sleep_save_blocks();
 #endif
 	deep_sleep_save_ecs();
-	deep_sleep_save_timers();
+	deep_sleep_save_busy_wait_timer();
 #ifdef DEEP_SLEEP_UART_SAVE_RESTORE
 	deep_sleep_save_uarts();
 #endif
@@ -377,7 +342,7 @@ void soc_deep_sleep_periph_restore(void)
 #ifdef DEEP_SLEEP_UART_SAVE_RESTORE
 	deep_sleep_restore_uarts();
 #endif
-	deep_sleep_restore_timers();
+	deep_sleep_restore_busy_wait_timer();
 #ifdef DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED
 	deep_sleep_restore_blocks();
 #endif

--- a/soc/microchip/mec/mec172x/device_power.h
+++ b/soc/microchip/mec/mec172x/device_power.h
@@ -48,8 +48,6 @@
  */
 #define DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED
 
-#define NUM_DS_TIMER_ENTRIES 6
-
 struct ds_timer_info {
 	uintptr_t addr;
 	uint32_t stop_mask;
@@ -63,7 +61,6 @@ struct ds_peci_info {
 
 struct ds_dev_info {
 	uint32_t ecs[2];
-	uint32_t timers[NUM_DS_TIMER_ENTRIES];
 #ifdef DEEP_SLEEP_UART_SAVE_RESTORE
 	uint8_t uart_info[MCHP_UART_INSTANCES];
 #endif


### PR DESCRIPTION
Relocate counter low power configuration from the SoC PM layer to the XEC counter driver.