### PR TITLE
Bluetooth: HCI: Identify the controller in the startup banner

### DIFF
--- a/doc/services/connectivity/bluetooth/api/hci.txt
+++ b/doc/services/connectivity/bluetooth/api/hci.txt
@@ -215,7 +215,7 @@ additional counter for incremental builds.
 	| Value              | Parameter Description                |
 	+--------------------+--------------------------------------+
 	| 0x00               | Standard Bluetooth controller        |
-	| 0x01               | Vendor specific controller           |
+	| 0x01               | Vendor specific Bluetooth Controller |
 	| 0x02               | Firmware loader                      |
 	| 0x03               | Rescue image                         |
 	| All other values   | Reserved for future use              |

--- a/doc/services/connectivity/bluetooth/bluetooth-shell.rst
+++ b/doc/services/connectivity/bluetooth/bluetooth-shell.rst
@@ -64,7 +64,7 @@ message is printed to confirm Bluetooth has been initialized.
         [00:02:26.771,179] <inf> fs_nvs: nvs_mount: data wra: 0, 0
         [00:02:26.777,984] <inf> bt_hci_core: hci_vs_init: HW Platform: Nordic Semiconductor (0x0002)
         [00:02:26.778,015] <inf> bt_hci_core: hci_vs_init: HW Variant: nRF52x (0x0002)
-        [00:02:26.778,045] <inf> bt_hci_core: hci_vs_init: Firmware: Standard Bluetooth controller (0x00) Version 3.2 Build 99
+        [00:02:26.778,045] <inf> bt_hci_core: hci_vs_init: Controller: Zephyr Bluetooth Controller (0x00) manufacturer 0x05f1 Version 3.2 Build 99
         [00:02:26.778,656] <inf> bt_hci_core: bt_init: No ID address. App must call settings_load()
         [00:02:26.794,738] <inf> bt_hci_core: bt_dev_show_info: Identity: EB:BF:36:26:42:09 (random)
         [00:02:26.794,769] <inf> bt_hci_core: bt_dev_show_info: HCI: version 5.3 (0x0c) revision 0x0000, manufacturer 0x05f1

--- a/include/zephyr/bluetooth/hci_vs.h
+++ b/include/zephyr/bluetooth/hci_vs.h
@@ -65,10 +65,10 @@ extern "C" {
 #define BT_HCI_VS_HW_VAR_ESP32H2                0x0006
 #define BT_HCI_VS_HW_VAR_ESP32C5                0x0007 /**< ESP32-C5 hardware variant */
 
-#define BT_HCI_VS_FW_VAR_STANDARD_CTLR          0x0001
-#define BT_HCI_VS_FW_VAR_VS_CTLR                0x0002
-#define BT_HCI_VS_FW_VAR_FW_LOADER              0x0003
-#define BT_HCI_VS_FW_VAR_RESCUE_IMG             0x0004
+#define BT_HCI_VS_FW_VAR_STANDARD_CTLR          0x0000
+#define BT_HCI_VS_FW_VAR_VS_CTLR                0x0001
+#define BT_HCI_VS_FW_VAR_FW_LOADER              0x0002
+#define BT_HCI_VS_FW_VAR_RESCUE_IMG             0x0003
 #define BT_HCI_OP_VS_READ_VERSION_INFO		BT_OP(BT_OGF_VS, 0x0001)
 struct bt_hci_rp_vs_read_version_info {
 	uint8_t  status;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4215,10 +4215,17 @@ static const char *vs_fw_variant(uint8_t variant)
 {
 	static const char * const var_str[] = {
 		"Standard Bluetooth controller",
-		"Vendor specific controller",
+		"Vendor specific Bluetooth Controller",
 		"Firmware loader",
 		"Rescue image",
 	};
+
+	/* The Zephyr controller responds with the standard variant and The
+	 * Linux Foundation company identifier.
+	 */
+	if (variant == BT_HCI_VS_FW_VAR_STANDARD_CTLR && bt_dev.manufacturer == BT_COMP_ID_LF) {
+		return "Zephyr Bluetooth Controller";
+	}
 
 	if (variant < ARRAY_SIZE(var_str)) {
 		return var_str[variant];
@@ -4272,8 +4279,9 @@ static void hci_vs_init(void)
 		vs_hw_variant(sys_le16_to_cpu(rp.info->hw_platform),
 			      sys_le16_to_cpu(rp.info->hw_variant)),
 		sys_le16_to_cpu(rp.info->hw_variant));
-	LOG_INF("Firmware: %s (0x%02x) Version %u.%u Build %u", vs_fw_variant(rp.info->fw_variant),
-		rp.info->fw_variant, rp.info->fw_version, sys_le16_to_cpu(rp.info->fw_revision),
+	LOG_INF("Controller: %s (0x%02x) manufacturer 0x%04x Version %u.%u Build %u",
+		vs_fw_variant(rp.info->fw_variant), rp.info->fw_variant, bt_dev.manufacturer,
+		rp.info->fw_version, sys_le16_to_cpu(rp.info->fw_revision),
 		sys_le32_to_cpu(rp.info->fw_build));
 
 	net_buf_unref(rsp);


### PR DESCRIPTION
The startup banner made it hard to tell which controller an image is running against. The line was labelled "Firmware", the fw_variant 0x00 string was the generic "Standard Bluetooth controller", and the only manufacturer shown was the one on the "HCI: version" line, which is the Bluetooth company identifier of whoever wrote the controller and reads as if it identified the stack.

Label the line "Controller" and include the manufacturer on it. Print "Zephyr Bluetooth Controller" when the controller reports the standard variant together with The Linux Foundation company identifier, which is what the Zephyr controller responds with. The meaning of the fw_variant values is unchanged, since 0x00 is also reported by other conforming controllers, both in-tree (ESP32) and out of tree. Rename the fw_variant 0x01 string to "Vendor specific Bluetooth Controller" and update the sample output in the shell documentation to match.

Resulting output with the Zephyr controller (verified on nrf52dk):

```
<inf> bt_hci_core: Controller: Zephyr Bluetooth Controller (0x00) manufacturer 0x05f1 Version 4.4 Build 99
```

Fixes: #80679
