### PR TITLE
samples: Bluetooth: Explain ACL TX fragmentation in mtu_update

### DIFF
--- a/samples/bluetooth/mtu_update/README.rst
+++ b/samples/bluetooth/mtu_update/README.rst
@@ -24,6 +24,30 @@ Q&A:
 
 Answer: Yes. [#mtu_exchange]_ The Bluetooth specification mandates a symmetric MTU for ATT.
 
+  Question: I raised the MTU, but the data is still sent to the controller in
+  27-octet chunks. Is the MTU update not working?
+
+| Answer: It is working. The MTU and the size of the HCI ACL data packets are
+  configured separately.
+| :kconfig:option:`CONFIG_BT_L2CAP_TX_MTU` sets the largest SDU the L2CAP layer
+  accepts from ATT, which is what the MTU exchange communicates to the peer.
+| :kconfig:option:`CONFIG_BT_BUF_ACL_TX_SIZE` sets the largest ACL data packet
+  the host hands to the controller, and defaults to the 27 octets that every
+  controller is required to support. An SDU larger than that is fragmented over
+  several HCI ACL packets, and the receiving side recombines them into the
+  original L2CAP PDU. The peer still receives one notification of the full
+  size.
+| Set :kconfig:option:`CONFIG_BT_BUF_ACL_TX_SIZE` to at least the MTU plus the
+  L2CAP header size (4 octets) if you want each SDU to reach the controller in
+  a single HCI ACL packet, and make sure the controller reports at least that
+  much in its ACL data packet length.
+
+This sample deliberately leaves :kconfig:option:`CONFIG_BT_BUF_ACL_TX_SIZE` at
+its default, so that it demonstrates a large L2CAP MTU while using the default
+data packet size, keeps working with controllers that only support 27-octet
+data packets, and shows that the RX buffer size requirement follows the L2CAP
+MTU rather than the ACL packet size.
+
 Overview:
 *********
 


### PR DESCRIPTION
The sample raises CONFIG_BT_L2CAP_TX_MTU to 247 but leaves CONFIG_BT_BUF_ACL_TX_SIZE at its default of 27, so the 100 octet notification reaches the controller as a series of 27 octet HCI ACL fragments. The controller reassembles them and the peer still receives a single notification of the full size, but anyone watching the HCI traffic sees fragmentation and reasonably concludes the MTU update did not work.

The README documents the MTU side thoroughly and never mentions the ACL data packet size, which makes the two easy to conflate. Add a Q&A entry separating them, and record why the sample keeps the default: it demonstrates a large L2CAP MTU with the default data packet size, works with controllers that only support 27 octet packets, and shows that the RX buffer requirement follows the L2CAP MTU rather than the ACL packet size.

Fixes: #96436