### PR TITLE
tests: benchmarks: add kernel latency benchmark using ztest benchmark framework

### DIFF
--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -92,6 +92,58 @@ functions only once allowing the test function to run hot within a dedicated tim
 This will give a more realistic measurements as it includes the overhead of the system as it would
 be in a real-world scenario, such as interrupts, context switches, and other background tasks.
 
+Manual Benchmarks
+=================
+
+Standard and timed benchmarks are timed by the framework itself, which takes both timestamps in
+thread context around each invocation of the benchmark body. Some measurements cannot be expressed
+that way because their endpoints are captured in different execution contexts: for example the
+latency from raising an interrupt to the first instruction of its ISR, or from the end of an ISR to
+a woken thread running.
+
+Manual benchmarks keep the loop, the setup and the teardown in the framework and hand the body
+only the choice of what is measured, by bracketing it with :c:func:`ztest_benchmark_start` and
+:c:func:`ztest_benchmark_end`. The framework computes and reports the same statistics as for
+standard benchmarks.
+
+.. code-block:: c
+
+   ZTEST_BENCHMARK_MANUAL(<suite name>, <benchmark name>, <samples>, <setup_fn>, <teardown_fn>)
+   {
+         prepare();
+
+         ztest_benchmark_start();
+         operation_under_test();
+         ztest_benchmark_end();
+   }
+
+When the span does not begin and end in the same execution context, the endpoint captured
+elsewhere is handed over instead, with :c:func:`ztest_benchmark_start_at` or
+:c:func:`ztest_benchmark_end_at`. An ISR captures ``timing_counter_get()`` into a variable and the
+body passes it in once it runs:
+
+.. code-block:: c
+
+   static volatile timing_t isr_timestamp;
+
+   static void my_isr(const void *arg)
+   {
+         isr_timestamp = timing_counter_get();
+   }
+
+   ZTEST_BENCHMARK_MANUAL(<suite name>, isr_exit_latency, 1000, NULL, NULL)
+   {
+         trigger_the_interrupt();
+
+         ztest_benchmark_start_at(isr_timestamp);
+         ztest_benchmark_end();
+   }
+
+The framework applies the same control-measurement noise correction as for standard benchmarks
+when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
+and leave the recording to the body. An iteration whose body records no span contributes no
+sample.
+
 Understanding Results
 *********************
 

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -180,6 +180,36 @@ Statistical Metrics
 * **Min/Max**: The minimum and maximum cycle counts observed, along with which
   sample they occurred on.
 
+Latency percentiles
+"""""""""""""""""""
+
+The mean and the standard error describe how precisely the average was
+estimated. That is the right question for throughput, but not for latency: a
+real-time system is characterised by how bad an individual operation can be,
+and that lives in the tail of the distribution rather than near the mean.
+
+Enable :kconfig:option:`CONFIG_ZTEST_BENCHMARK_PERCENTILES` to retain the
+individual samples and report ``min``, ``p50``, ``p90``, ``p99``, ``p99.9``,
+``p99.99`` and ``max`` alongside the usual statistics. In CSV mode each
+sampled and manual benchmark emits an additional ``P`` row; see
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV` for the columns.
+
+The difference this makes is clearest on a distribution with a tail. Measuring
+interrupt entry latency on a loaded system gives a mean of 1264 cycles with a
+standard error of 34, which describes no interrupt that actually occurred: the
+percentiles show 1216 cycles all the way out to p99, and 25184 beyond it.
+
+A percentile has to be resolvable by the number of samples taken. p99 needs at
+least 100 samples, p99.9 at least 1000 and p99.99 at least 10000; with fewer,
+the reported value degenerates to the maximum. Samples are retained in a
+buffer of :kconfig:option:`CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES` entries of
+8 bytes each, which has to be at least as large as the sample count of the
+largest benchmark. The retained samples are the first ones taken rather than a
+sample of the whole run, so percentiles over a truncated prefix would miss
+whatever happened after the buffer filled, which is where the tail tends to
+live. A benchmark that overruns the buffer therefore reports no percentiles at
+all, and says how many samples did not fit.
+
 Plainly speaking, lower values are better for all metrics.
 Lower mean, min, and max values indicates better raw performance.
 Lower standard deviation and standard error values indicate more consistent and

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -17,7 +17,9 @@ providing:
 * **Statistical Analysis**: Calculations of Mean, Standard Deviation, Standard
   Error, and Min/Max values.
 * **Overhead Compensation**: Inclusion of a control test to account for the
-  benchmarking frameworks own execution time.
+  benchmarking frameworks own execution time. The control is subtracted from
+  every reported statistic identically, so the corrected values are real
+  numbers that generally do not coincide with any single measurement.
 
 Configuration
 *************
@@ -143,6 +145,13 @@ The framework applies the same control-measurement noise correction as for stand
 when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
 and leave the recording to the body. An iteration whose body records no span contributes no
 sample.
+
+A benchmark that wants a warmup phase should run it through the full measurement loop, recording
+included, and then call :c:func:`ztest_benchmark_discard_samples` to throw the results away.
+Skipping the recording during warmup instead leaves the first measured iteration as the only one
+not preceded by the bookkeeping that :c:func:`ztest_benchmark_record_sample` performs, which is
+enough to make it measurably faster than every iteration after it and to leave the reported
+minimum describing a state the benchmark is never in again.
 
 Understanding Results
 *********************

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -175,7 +175,10 @@ Statistical Metrics
 .. note::
 
    :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIERS` replaces the standard error line with the
-   number of samples slower than the median, and that number as a percentage. A latency
+   number of samples that exceed the median by more than
+   :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV` allows, and that number as a
+   percentage. The margin matters because the counter resolution spreads the baseline over a
+   few counts; without it about half of any distribution would be reported. A latency
    distribution is usually a baseline plus a handful of disturbed runs rather than samples of
    one stochastic population, and a standard error over the two suggests an average that no
    single execution ever produced -- ten thousand runs of 760 cycles and one of 1240 give a

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -172,6 +172,16 @@ Standard Benchmarking Results
 Statistical Metrics
 """""""""""""""""""
 
+.. note::
+
+   :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIERS` replaces the standard error line with the
+   number of samples slower than the median, and that number as a percentage. A latency
+   distribution is usually a baseline plus a handful of disturbed runs rather than samples of
+   one stochastic population, and a standard error over the two suggests an average that no
+   single execution ever produced -- ten thousand runs of 760 cycles and one of 1240 give a
+   standard error of 0.048, which reads as precision and is not, where ``1 / 10000 (0.010%)``
+   says what happened. Only the report changes; the standard error keeps its CSV column.
+
 * **Mean (u)**: The average number of cycles taken per sample. It provides a
   central value representing the expected cost of execution.
 
@@ -257,6 +267,7 @@ Timed Benchmarking Results
 
 Statistical Metrics
 """""""""""""""""""
+
 * **Total Time**: The total time taken for all samples of the benchmark, including overhead.
 
 * **Work Time**: The total time taken for the code under test, excluding the overhead of the

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -146,12 +146,10 @@ when reporting. The span is closed from thread context, so an ISR should only ca
 and leave the recording to the body. An iteration whose body records no span contributes no
 sample.
 
-A benchmark that wants a warmup phase should run it through the full measurement loop, recording
-included, and then call :c:func:`ztest_benchmark_discard_samples` to throw the results away.
-Skipping the recording during warmup instead leaves the first measured iteration as the only one
-not preceded by the bookkeeping that :c:func:`ztest_benchmark_record_sample` performs, which is
-enough to make it measurably faster than every iteration after it and to leave the reported
-minimum describing a state the benchmark is never in again.
+The warmup applies here exactly as it does to a sampled benchmark: the framework runs the body
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` extra times and discards those spans, keeping the
+first as the cold cost. The body never has to distinguish between the two phases, and every
+measured iteration is preceded by exactly the same work as the one before it.
 
 Understanding Results
 *********************
@@ -188,6 +186,27 @@ Statistical Metrics
 
 * **Min/Max**: The minimum and maximum cycle counts observed, along with which
   sample they occurred on.
+
+Warmup and the cold cost
+""""""""""""""""""""""""
+
+A benchmark is defined as three phases: the setup, then
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` iterations that are executed but not recorded,
+then the measured samples. The warmup applies to every benchmark in the image and defaults to
+zero, so by default sampling starts at the first iteration.
+
+Raising it matters when the steady state is what you are after, because a first execution runs
+with cold caches, branch predictors and TLBs and can be an order of magnitude slower. Left in
+the sample set it moves the maximum and the standard deviation while describing a state the
+benchmark is never in again. It is not free either: on a micro benchmark whose whole cost is
+comparable to a cache miss, discarding iterations costs accuracy, and with a large enough sample
+count the first iteration has no measurable effect on the mean.
+
+Rather than discard that information, the framework keeps it: the duration of the very first
+execution is reported separately as the **cold cost**, alongside the steady-state distribution.
+The two answer different questions — what an operation costs the first time it is reached, and
+what it costs thereafter — and an application that runs a path once at startup cares about the
+first.
 
 Latency percentiles
 """""""""""""""""""

--- a/subsys/testsuite/ztest/benchmark/CMakeLists.txt
+++ b/subsys/testsuite/ztest/benchmark/CMakeLists.txt
@@ -8,5 +8,6 @@ zephyr_library_sources_ifdef(CONFIG_ZTEST_BENCHMARK
 
 zephyr_linker_sources(DATA_SECTIONS benchmark.ld)
 zephyr_iterable_section(NAME ztest_benchmark GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
+zephyr_iterable_section(NAME ztest_benchmark_manual GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
 zephyr_iterable_section(NAME ztest_benchmark_timed GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
 zephyr_iterable_section(NAME ztest_benchmark_suite GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -13,6 +13,30 @@ config ZTEST_BENCHMARK
 
 if ZTEST_BENCHMARK
 
+config ZTEST_BENCHMARK_WARMUP
+	int "Iterations run before sampling starts"
+	default 0
+	help
+	  Iterations every benchmark executes, in full, before it begins
+	  recording. They are not part of the reported distribution.
+
+	  A benchmark's first execution runs with cold caches, branch
+	  predictors and TLBs and can be an order of magnitude slower
+	  than its steady state. Left in the sample set it moves the
+	  maximum and the standard deviation while describing a state the
+	  benchmark is never in again.
+
+	  The default of zero samples from the first iteration, which is
+	  what the framework has always done: with a large enough sample
+	  count the first iteration has no measurable effect on the mean,
+	  and discarding iterations costs accuracy on micro benchmarks
+	  whose whole cost is comparable to a cache miss. Raise it only
+	  when the steady state is what you are after.
+
+	  The first iteration is reported separately as the cold cost
+	  either way, so the effect of a cold start stays visible without
+	  having to discard anything.
+
 config ZTEST_BENCHMARK_PERCENTILES
 	bool "Report latency percentiles"
 	help
@@ -85,6 +109,14 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 	  - std_error: standard error of the mean
 	  - min / max: extreme cycle values
 	  - min_sample / max_sample: iteration at which each extreme occurred
+
+	  Every benchmark that ran at least one iteration also emits a "C" row carrying its cold
+	  cost, the duration of its very first execution, which is excluded from the distribution:
+
+	    C, suite, name, warmup, cold
+
+	  - warmup: iterations executed before sampling started
+	  - cold: cycles taken by the first execution, noise-corrected
 
 	  Manually sampled benchmarks (created with ZTEST_BENCHMARK_MANUAL()) emit "M" rows with
 	  the same column layout as "S" rows, where samples is the number of iterations that

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -50,8 +50,8 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  characterised by how bad an individual operation can be, and
 	  that lives in the tail of the distribution.
 
-	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples slower
-	  than the median.
+	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples that sit
+	  clear of the median.
 
 	  A percentile needs enough samples to be resolved at all. p99
 	  needs at least 100, p99.9 at least 1000 and p99.99 at least
@@ -65,8 +65,9 @@ config ZTEST_BENCHMARK_OUTLIERS
 	depends on ZTEST_BENCHMARK_PERCENTILES
 	help
 	  Replace the standard error line of the report with the number
-	  of samples slower than the median, and that number as a
-	  percentage of the samples taken.
+	  of samples that sit clear of the median, and that number as a
+	  percentage of the samples taken. How far clear is set by
+	  CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV.
 
 	  The standard error describes how precisely the mean of one
 	  stochastic population has been estimated. A latency
@@ -79,6 +80,29 @@ config ZTEST_BENCHMARK_OUTLIERS
 
 	  Only the human-readable report changes. The standard error
 	  keeps its column in the CSV output.
+
+config ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV
+	int "Outlier margin above the median, as a divisor"
+	depends on ZTEST_BENCHMARK_OUTLIERS
+	default 16
+	range 1 1000
+	help
+	  How far above the median a sample has to sit before it counts as
+	  an outlier, expressed as a divisor of the median: the default of
+	  16 sets the margin at a sixteenth of the median, so a baseline of
+	  400 counts a sample from 426 upwards. The margin is never less
+	  than two counts, so that a distribution spanning only adjacent
+	  counts of a coarse timer never registers.
+
+	  Without a margin every sample above the median counts, and the
+	  baseline of a benchmark is not one exact value: the resolution of
+	  the timing counter spreads it over a few counts, and where that
+	  counter is coarse relative to the operation being measured the
+	  whole distribution can span as little as two values. Half the
+	  samples then land above the median and are reported as outliers
+	  although nothing disturbed them. Lower this to count smaller
+	  disturbances, raise it on a platform whose baseline is noisy by
+	  nature.
 
 config ZTEST_BENCHMARK_MAX_SAMPLES
 	int "Number of samples retained for percentiles"

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -13,6 +13,41 @@ config ZTEST_BENCHMARK
 
 if ZTEST_BENCHMARK
 
+config ZTEST_BENCHMARK_PERCENTILES
+	bool "Report latency percentiles"
+	help
+	  Retain the individual samples of each benchmark and report
+	  min, p50, p90, p99, p99.9, p99.99 and max alongside the usual
+	  statistics.
+
+	  The mean and the standard error describe how precisely the
+	  average was estimated, which is the right question for
+	  throughput but not for latency: a real-time system is
+	  characterised by how bad an individual operation can be, and
+	  that lives in the tail of the distribution.
+
+	  A percentile needs enough samples to be resolved at all. p99
+	  needs at least 100, p99.9 at least 1000 and p99.99 at least
+	  10000; below that the reported value degenerates to the
+	  maximum. Retaining samples costs 8 bytes each, so the buffer
+	  has to be sized for the number of iterations the benchmarks
+	  run.
+
+config ZTEST_BENCHMARK_MAX_SAMPLES
+	int "Number of samples retained for percentiles"
+	depends on ZTEST_BENCHMARK_PERCENTILES
+	default 1024
+	help
+	  Size of the sample buffer, in samples of 8 bytes each. Only one
+	  benchmark runs at a time, so a single buffer of this size is
+	  allocated for all of them. It has to be at least as large as
+	  the sample count of the largest benchmark: the retained samples
+	  are the first ones taken rather than a sample of the whole run,
+	  so percentiles over a truncated prefix would miss whatever
+	  happened after the buffer filled, which is where the tail tends
+	  to live. A benchmark that overruns the buffer reports no
+	  percentiles at all and says how many samples did not fit.
+
 choice ZTEST_BENCHMARK_OUTPUT_FORMAT
 	prompt "Ztest benchmark output format"
 	default ZTEST_BENCHMARK_OUTPUT_VERBOSE
@@ -71,6 +106,17 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 
 	  If measured overhead exceeds the total time, the row contains INCONCLUSIVE instead of
 	  numeric results (e.g. "T, my_suite, my_benchmark, INCONCLUSIVE").
+
+	  With CONFIG_ZTEST_BENCHMARK_PERCENTILES, every sampled and manual benchmark emits an
+	  additional row of the form:
+
+	    P, suite, name, samples, min, p50, p90, p99, p999, p9999, max
+
+	  - samples: number of retained samples the percentiles were taken over
+	  - min / max: extreme cycle values
+	  - p50 ... p9999: nearest-rank percentiles, p9999 being the 99.99th
+
+	  All values are noise-corrected against the control measurement.
 endchoice
 
 endif

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -51,6 +51,11 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 	  - min / max: extreme cycle values
 	  - min_sample / max_sample: iteration at which each extreme occurred
 
+	  Manually sampled benchmarks (created with ZTEST_BENCHMARK_MANUAL()) emit "M" rows with
+	  the same column layout as "S" rows, where samples is the number of iterations that
+	  recorded a span. A manual benchmark that records no samples emits
+	  "M, suite, name, INCONCLUSIVE" instead.
+
 	  Timed benchmarks (created with ZTEST_BENCHMARK_TIMED() or
 	  ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN()) emit rows of the form:
 

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -50,12 +50,35 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  characterised by how bad an individual operation can be, and
 	  that lives in the tail of the distribution.
 
+	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples slower
+	  than the median.
+
 	  A percentile needs enough samples to be resolved at all. p99
 	  needs at least 100, p99.9 at least 1000 and p99.99 at least
 	  10000; below that the reported value degenerates to the
 	  maximum. Retaining samples costs 8 bytes each, so the buffer
 	  has to be sized for the number of iterations the benchmarks
 	  run.
+
+config ZTEST_BENCHMARK_OUTLIERS
+	bool "Report the outlier count in place of the standard error"
+	depends on ZTEST_BENCHMARK_PERCENTILES
+	help
+	  Replace the standard error line of the report with the number
+	  of samples slower than the median, and that number as a
+	  percentage of the samples taken.
+
+	  The standard error describes how precisely the mean of one
+	  stochastic population has been estimated. A latency
+	  distribution is usually not that: it is a baseline the
+	  operation hits on almost every run plus a handful of runs that
+	  something interrupted. Ten thousand samples of 760 cycles and
+	  one of 1240 give a standard error of 0.048, which reads as
+	  precision about an average no execution ever produced, where
+	  "1 / 10000 (0.010%)" says what happened.
+
+	  Only the human-readable report changes. The standard error
+	  keeps its column in the CSV output.
 
 config ZTEST_BENCHMARK_MAX_SAMPLES
 	int "Number of samples retained for percentiles"

--- a/subsys/testsuite/ztest/benchmark/benchmark.ld
+++ b/subsys/testsuite/ztest/benchmark/benchmark.ld
@@ -6,5 +6,6 @@
 #include <zephyr/linker/iterable_sections.h>
 
 ITERABLE_SECTION_RAM(ztest_benchmark, Z_LINK_ITERABLE_SUBALIGN)
+ITERABLE_SECTION_RAM(ztest_benchmark_manual, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_RAM(ztest_benchmark_timed, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_RAM(ztest_benchmark_suite, Z_LINK_ITERABLE_SUBALIGN)

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -133,11 +133,41 @@ static uint64_t percentile(uint32_t hundredths)
 	return retained[rank - 1U];
 }
 
-static void percentiles_report(const char *suite_name, const char *bench_name,
-			       struct ztest_benchmark_stats *ctrl_stats)
+#if defined(CONFIG_ZTEST_BENCHMARK_OUTLIERS) && defined(CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE)
+/*
+ * Samples slower than the median.
+ *
+ * For a kernel latency distribution the median is the baseline: the
+ * operation costs the same on almost every run, and what matters is how
+ * many runs were disturbed and by how much. Counting them says that
+ * directly, where a standard error would only describe how precisely an
+ * average of two different populations had been estimated.
+ */
+static size_t percentiles_outliers(void)
 {
-	double ctrl = (double)ctrl_stats->mean;
+	uint64_t median = percentile(5000);
+	size_t count = 0;
 
+	while ((count < retained_count) && (retained[retained_count - 1 - count] > median)) {
+		count++;
+	}
+
+	return count;
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTLIERS && CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+
+static bool percentiles_available(void)
+{
+	/*
+	 * Samples that did not fit make the retained ones a prefix rather
+	 * than a sample of the run, which percentiles_prepare() refuses
+	 * to sort or report.
+	 */
+	return (retained_count != 0) && (dropped_count == 0);
+}
+
+static void percentiles_prepare(const char *suite_name, const char *bench_name)
+{
 	if (retained_count == 0) {
 		return;
 	}
@@ -158,72 +188,38 @@ static void percentiles_report(const char *suite_name, const char *bench_name,
 	}
 
 	percentiles_sort();
-
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
-		suite_name, bench_name, retained_count,
-		noise_correction((double)retained[0], ctrl),
-		noise_correction((double)percentile(5000), ctrl),
-		noise_correction((double)percentile(9000), ctrl),
-		noise_correction((double)percentile(9900), ctrl),
-		noise_correction((double)percentile(9990), ctrl),
-		noise_correction((double)percentile(9999), ctrl),
-		noise_correction((double)retained[retained_count - 1], ctrl));
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
-	printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
-	printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
-	printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
-	printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 }
 #else
-static inline void percentiles_reset(void)
+/*
+ * Only the two hooks the runner calls unconditionally need a stub. The
+ * rest are referenced solely from code that this option compiles out,
+ * and a stub for them would be an unused function, which both
+ * compilers reject under the warning flags Zephyr builds with.
+ */
+static void percentiles_reset(void)
 {
 }
 
-static inline void percentiles_record(uint64_t cycles)
+static void percentiles_record(uint64_t cycles)
 {
 	ARG_UNUSED(cycles);
-}
-
-static inline void percentiles_report(const char *suite_name, const char *bench_name,
-				      struct ztest_benchmark_stats *ctrl_stats)
-{
-	ARG_UNUSED(suite_name);
-	ARG_UNUSED(bench_name);
-	ARG_UNUSED(ctrl_stats);
 }
 #endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
 
 /*
- * The very first execution of a benchmark, before anything is warm.
- * Reported separately rather than folded into the distribution, where a
- * single cold sample would move the maximum and tell the reader nothing
- * about the steady state.
+ * Report one benchmark.
+ *
+ * The layout is the one the framework has always printed. The optional
+ * additions extend it rather than rearrange it: percentiles and the
+ * cold cost are extra lines, and CONFIG_ZTEST_BENCHMARK_OUTLIERS
+ * swaps the standard error for the outlier count in place.
+ *
+ * The CSV output keeps every column it had, including the standard
+ * error, so that existing parsers are unaffected whatever is enabled.
  */
-static void ztest_benchmark_print_cold(const char *suite_name, const char *bench_name,
-				       struct ztest_benchmark_stats *stats,
-				       struct ztest_benchmark_stats *ctrl_stats)
-{
-	double value = noise_correction((double)stats->cold, (double)ctrl_stats->mean);
-
-	if (stats->cold == 0) {
-		return;
-	}
-
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("C,%s,%s,%d,%.3f\n", suite_name, bench_name, CONFIG_ZTEST_BENCHMARK_WARMUP, value);
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk("\tCold (first run): %.3f\n", value);
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
-}
-
-static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
-					char record_type, struct ztest_benchmark_stats *stats,
-					struct ztest_benchmark_stats *ctrl_stats)
+static void ztest_benchmark_report(const char *suite_name, const char *bench_name,
+				   char record_type, struct ztest_benchmark_stats *stats,
+				   struct ztest_benchmark_stats *ctrl_stats)
 {
 	double ctrl = (double)ctrl_stats->mean;
 	double stddev = 0.0;
@@ -247,6 +243,10 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 		std_error = stddev / sqrt(stats->samples);
 	}
 
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	percentiles_prepare(suite_name, bench_name);
+#endif
+
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
 	printk("%c,%s,%s,%lld,%.3f,%.3f,%.3f,%.3f,%.3f,%lld,%.3f,%lld\n",
 		record_type, suite_name, bench_name,
@@ -255,7 +255,37 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 		noise_correction(stats->mean, ctrl), stddev, std_error,
 		noise_correction((double)stats->min.value, ctrl), stats->min.sample,
 		noise_correction((double)stats->max.value, ctrl), stats->max.sample);
+
+	if (stats->cold != 0) {
+		printk("C,%s,%s,%d,%.3f\n", suite_name, bench_name,
+			CONFIG_ZTEST_BENCHMARK_WARMUP,
+			noise_correction((double)stats->cold, ctrl));
+	}
+
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	/*
+	 * The percentiles go in a row of their own rather than as extra
+	 * columns on the row above, so that a parser written against the
+	 * original column layout keeps working.
+	 *
+	 * The extremes come from the retained samples the percentiles were
+	 * taken over, which is not the same set as the min and max on the
+	 * row above once samples have been dropped.
+	 */
+	if (percentiles_available()) {
+		printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
+			suite_name, bench_name, retained_count,
+			noise_correction((double)retained[0], ctrl),
+			noise_correction((double)percentile(5000), ctrl),
+			noise_correction((double)percentile(9000), ctrl),
+			noise_correction((double)percentile(9900), ctrl),
+			noise_correction((double)percentile(9990), ctrl),
+			noise_correction((double)percentile(9999), ctrl),
+			noise_correction((double)retained[retained_count - 1], ctrl));
+	}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
 	printk_line(bench_name, '=');
 	printk("\tSample size:%lld, total cycles: %.3f\n", stats->samples,
@@ -263,16 +293,43 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 
 	printk("\tMean(u): %.3f\n", noise_correction(stats->mean, ctrl));
 	printk("\tStandard deviation(s): %.3f\n", stddev);
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTLIERS
+	/*
+	 * The standard error describes how precisely the mean of one
+	 * stochastic population was estimated. A latency distribution is
+	 * usually a baseline plus a few disturbed runs instead, so the
+	 * count of samples slower than the median says more about it.
+	 */
+	if (percentiles_available()) {
+		size_t outliers = percentiles_outliers();
+
+		printk("\tOutliers: %zu / %zu (%.3f%%)\n", outliers, retained_count,
+			(100.0 * (double)outliers) / (double)retained_count);
+	}
+#else
 	printk("\tStandard Error(SE): %.3f\n", std_error);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTLIERS */
 	printk("\tMin: %lld (run #%llu)\n", noise_corrected_floor(stats->min.value, ctrl),
 		stats->min.sample);
 	printk("\tMax: %lld (run #%llu)\n", noise_corrected_ceil(stats->max.value, ctrl),
 		stats->max.sample);
+
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	if (percentiles_available()) {
+		printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
+		printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
+		printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
+		printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
+		printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
+	}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
+
+	if (stats->cold != 0) {
+		printk("\tCold (first run): %.3f\n",
+			noise_correction((double)stats->cold, ctrl));
+	}
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
-
-	percentiles_report(suite_name, bench_name, ctrl_stats);
 }
-
 
 static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 {
@@ -560,10 +617,8 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_run(benchmark);
-			ztest_benchmark_print_stats(suite->name, benchmark->name, 'S',
-						    &benchmark->stats, &ctrl.stats);
-			ztest_benchmark_print_cold(suite->name, benchmark->name,
-						   &benchmark->stats, &ctrl.stats);
+			ztest_benchmark_report(suite->name, benchmark->name, 'S',
+					       &benchmark->stats, &ctrl.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_manual, benchmark) {
@@ -571,10 +626,8 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_manual_run(benchmark);
-			ztest_benchmark_print_stats(suite->name, benchmark->name, 'M',
-						    &benchmark->stats, &ctrl.stats);
-			ztest_benchmark_print_cold(suite->name, benchmark->name,
-						   &benchmark->stats, &ctrl.stats);
+			ztest_benchmark_report(suite->name, benchmark->name, 'M',
+					       &benchmark->stats, &ctrl.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_timed, benchmark) {

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -42,6 +42,131 @@ static int64_t discrete_noise_correction(uint64_t value, double ctrl)
 	return (int64_t)value - (int64_t)trunc(ctrl);
 }
 
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+/*
+ * Retained samples, for the percentile report. Only one benchmark runs
+ * at a time, so a single buffer serves all of them.
+ */
+static uint64_t retained[CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES];
+static size_t retained_count;
+static size_t dropped_count;
+
+static void percentiles_reset(void)
+{
+	retained_count = 0;
+	dropped_count = 0;
+}
+
+static void percentiles_record(uint64_t cycles)
+{
+	if (retained_count < ARRAY_SIZE(retained)) {
+		retained[retained_count++] = cycles;
+	} else {
+		dropped_count++;
+	}
+}
+
+static void percentiles_sort(void)
+{
+	/* Shell sort: no allocation, no recursion, good enough here */
+	for (size_t gap = retained_count / 2; gap > 0; gap /= 2) {
+		for (size_t i = gap; i < retained_count; i++) {
+			uint64_t value = retained[i];
+			size_t j = i;
+
+			while ((j >= gap) && (retained[j - gap] > value)) {
+				retained[j] = retained[j - gap];
+				j -= gap;
+			}
+			retained[j] = value;
+		}
+	}
+}
+
+/*
+ * Nearest-rank percentile, with the percentile given in hundredths of a
+ * percent so that 99.99 can be expressed: 5000 is the median, 9999 is
+ * the 99.99th percentile.
+ */
+static uint64_t percentile(uint32_t hundredths)
+{
+	uint64_t rank = ((uint64_t)hundredths * retained_count + 9999U) / 10000U;
+
+	if (rank == 0U) {
+		rank = 1U;
+	}
+
+	if (rank > retained_count) {
+		rank = retained_count;
+	}
+
+	return retained[rank - 1U];
+}
+
+static void percentiles_report(const char *suite_name, const char *bench_name,
+			       struct ztest_benchmark_stats *ctrl_stats)
+{
+	double ctrl = (double)ctrl_stats->mean;
+
+	if (retained_count == 0) {
+		return;
+	}
+
+	/*
+	 * The retained samples are the first ones taken, not a sample of
+	 * the whole run, so percentiles over them are not percentiles of
+	 * the distribution: whatever happened after the buffer filled is
+	 * missing entirely, and the tail is exactly where it tends to
+	 * live. Report nothing rather than something misleading.
+	 */
+	if (dropped_count != 0) {
+		printk("%s %s: no percentiles, %zu of %zu samples did not fit; "
+		       "raise CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES\n",
+		       suite_name, bench_name, dropped_count,
+		       retained_count + dropped_count);
+		return;
+	}
+
+	percentiles_sort();
+
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
+	printk("P,%s,%s,%zu,%lld,%lld,%lld,%lld,%lld,%lld,%lld\n",
+		suite_name, bench_name, retained_count,
+		discrete_noise_correction(retained[0], ctrl),
+		discrete_noise_correction(percentile(5000), ctrl),
+		discrete_noise_correction(percentile(9000), ctrl),
+		discrete_noise_correction(percentile(9900), ctrl),
+		discrete_noise_correction(percentile(9990), ctrl),
+		discrete_noise_correction(percentile(9999), ctrl),
+		discrete_noise_correction(retained[retained_count - 1], ctrl));
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+	printk("\tp50: %lld\n", discrete_noise_correction(percentile(5000), ctrl));
+	printk("\tp90: %lld\n", discrete_noise_correction(percentile(9000), ctrl));
+	printk("\tp99: %lld\n", discrete_noise_correction(percentile(9900), ctrl));
+	printk("\tp99.9: %lld\n", discrete_noise_correction(percentile(9990), ctrl));
+	printk("\tp99.99: %lld\n", discrete_noise_correction(percentile(9999), ctrl));
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+}
+#else
+static inline void percentiles_reset(void)
+{
+}
+
+static inline void percentiles_record(uint64_t cycles)
+{
+	ARG_UNUSED(cycles);
+}
+
+static inline void percentiles_report(const char *suite_name, const char *bench_name,
+				      struct ztest_benchmark_stats *ctrl_stats)
+{
+	ARG_UNUSED(suite_name);
+	ARG_UNUSED(bench_name);
+	ARG_UNUSED(ctrl_stats);
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
+
 static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
 					char record_type, struct ztest_benchmark_stats *stats,
 					struct ztest_benchmark_stats *ctrl_stats)
@@ -90,11 +215,16 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 	printk("\tMax: %lld (run #%llu)\n", discrete_noise_correction(stats->max.value, ctrl),
 		stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+
+	percentiles_report(suite_name, bench_name, ctrl_stats);
 }
+
 
 static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 {
 	double delta, delta2;
+
+	percentiles_record(cycles);
 
 	/* Welfords method */
 	stats->samples += 1;
@@ -122,6 +252,7 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
+	percentiles_reset();
 
 	for (size_t i = 0; i < benchmark->iterations; i++) {
 		if (benchmark->setup) {
@@ -201,6 +332,7 @@ static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
 {
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
+	percentiles_reset();
 
 	/*
 	 * The loop, the setup and the teardown are the framework's, exactly

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -197,6 +197,30 @@ static inline void percentiles_report(const char *suite_name, const char *bench_
 }
 #endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
 
+/*
+ * The very first execution of a benchmark, before anything is warm.
+ * Reported separately rather than folded into the distribution, where a
+ * single cold sample would move the maximum and tell the reader nothing
+ * about the steady state.
+ */
+static void ztest_benchmark_print_cold(const char *suite_name, const char *bench_name,
+				       struct ztest_benchmark_stats *stats,
+				       struct ztest_benchmark_stats *ctrl_stats)
+{
+	double value = noise_correction((double)stats->cold, (double)ctrl_stats->mean);
+
+	if (stats->cold == 0) {
+		return;
+	}
+
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
+	printk("C,%s,%s,%d,%.3f\n", suite_name, bench_name, CONFIG_ZTEST_BENCHMARK_WARMUP, value);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+	printk("\tCold (first run): %.3f\n", value);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+}
+
 static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
 					char record_type, struct ztest_benchmark_stats *stats,
 					struct ztest_benchmark_stats *ctrl_stats)
@@ -284,7 +308,14 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 	benchmark->stats.min.value = UINT64_MAX;
 	percentiles_reset();
 
-	for (size_t i = 0; i < benchmark->iterations; i++) {
+	/*
+	 * The warmup iterations run the whole loop, setup and teardown
+	 * included, and are simply not recorded. Only the very first is
+	 * kept, as the cold cost.
+	 */
+	for (size_t i = 0; i < CONFIG_ZTEST_BENCHMARK_WARMUP + benchmark->iterations; i++) {
+		uint64_t cycles;
+
 		if (benchmark->setup) {
 			benchmark->setup();
 		}
@@ -295,7 +326,15 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 		benchmark->run();
 		end = timing_counter_get();
 
-		update_metrics(&benchmark->stats, timing_cycles_get(&start, &end));
+		cycles = timing_cycles_get(&start, &end);
+
+		if (i == 0) {
+			benchmark->stats.cold = cycles;
+		}
+
+		if (i >= CONFIG_ZTEST_BENCHMARK_WARMUP) {
+			update_metrics(&benchmark->stats, cycles);
+		}
 
 		if (benchmark->teardown) {
 			benchmark->teardown();
@@ -304,15 +343,17 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 }
 
 /*
- * The benchmark whose body is running, and the span it has open.
+ * The benchmark whose body is running, the span it has open, and which
+ * iteration it is on.
  *
  * Only one benchmark runs at a time, so a single set of these serves all
- * of them. manual_started separates "no span open" from a span that
+ * of them. manual_span_open separates "no span open" from a span that
  * legitimately began at timestamp zero.
  */
 static struct ztest_benchmark_stats *manual_active_stats;
 static timing_t manual_span_start;
 static bool manual_span_open;
+static size_t manual_iteration;
 
 void ztest_benchmark_start_at(timing_t start)
 {
@@ -337,6 +378,8 @@ void ztest_benchmark_start(void)
 
 void ztest_benchmark_end_at(timing_t end)
 {
+	uint64_t cycles;
+
 	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
 
 	if ((manual_active_stats == NULL) || !manual_span_open) {
@@ -344,7 +387,19 @@ void ztest_benchmark_end_at(timing_t end)
 	}
 
 	manual_span_open = false;
-	update_metrics(manual_active_stats, timing_cycles_get(&manual_span_start, &end));
+	cycles = timing_cycles_get(&manual_span_start, &end);
+
+	if (manual_iteration == 0) {
+		manual_active_stats->cold = cycles;
+	}
+
+	/*
+	 * The warmup iterations run the body in full and are simply not
+	 * recorded, exactly as for a sampled benchmark.
+	 */
+	if (manual_iteration >= CONFIG_ZTEST_BENCHMARK_WARMUP) {
+		update_metrics(manual_active_stats, cycles);
+	}
 }
 
 void ztest_benchmark_end(void)
@@ -358,17 +413,6 @@ void ztest_benchmark_end(void)
 	ztest_benchmark_end_at(timing_counter_get());
 }
 
-void ztest_benchmark_discard_samples(void)
-{
-	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
-
-	if (manual_active_stats != NULL) {
-		memset(manual_active_stats, 0, sizeof(*manual_active_stats));
-		manual_active_stats->min.value = UINT64_MAX;
-		percentiles_reset();
-	}
-}
-
 static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
 {
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
@@ -380,13 +424,14 @@ static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
 	 * as for a sampled benchmark. All the body decides is which part of
 	 * itself the timestamps go around.
 	 */
-	for (size_t i = 0; i < benchmark->iterations; i++) {
+	for (size_t i = 0; i < CONFIG_ZTEST_BENCHMARK_WARMUP + benchmark->iterations; i++) {
 		if (benchmark->setup) {
 			benchmark->setup();
 		}
 
 		manual_active_stats = &benchmark->stats;
 		manual_span_open = false;
+		manual_iteration = i;
 		benchmark->run();
 		manual_active_stats = NULL;
 
@@ -517,6 +562,8 @@ void benchmark_main(void)
 			ztest_benchmark_run(benchmark);
 			ztest_benchmark_print_stats(suite->name, benchmark->name, 'S',
 						    &benchmark->stats, &ctrl.stats);
+			ztest_benchmark_print_cold(suite->name, benchmark->name,
+						   &benchmark->stats, &ctrl.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_manual, benchmark) {
@@ -526,6 +573,8 @@ void benchmark_main(void)
 			ztest_benchmark_manual_run(benchmark);
 			ztest_benchmark_print_stats(suite->name, benchmark->name, 'M',
 						    &benchmark->stats, &ctrl.stats);
+			ztest_benchmark_print_cold(suite->name, benchmark->name,
+						   &benchmark->stats, &ctrl.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_timed, benchmark) {

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -32,15 +32,45 @@ static void printk_line(const char *fn, char sep_char)
 }
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
+/*
+ * Subtract the control measurement from a reported statistic.
+ *
+ * Every statistic has to be corrected by the same amount, or they stop
+ * describing one set of samples: truncating the control to an integer
+ * for the discrete statistics, as this used to do, left a benchmark
+ * whose samples were all identical reporting a mean below its own
+ * minimum whenever the control was under one cycle.
+ *
+ * The correction is a real number, so the corrected values are real
+ * numbers too, and generally do not coincide with any single
+ * measurement.
+ */
 static double noise_correction(double value, double ctrl)
 {
 	return value - ctrl;
 }
 
-static int64_t discrete_noise_correction(uint64_t value, double ctrl)
+/*
+ * Render a corrected extreme as a whole number of cycles.
+ *
+ * The extremes are single measurements and a cycle is a discrete thing,
+ * so printing them with a fraction reads oddly. The correction is still
+ * a real number, so rounding has to be directional: the minimum rounds
+ * down and the maximum rounds up, which keeps each of them outside the
+ * statistics computed from the same samples instead of letting a
+ * rounded extreme cross the mean.
+ */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+static int64_t noise_corrected_floor(uint64_t value, double ctrl)
 {
-	return (int64_t)value - (int64_t)trunc(ctrl);
+	return (int64_t)floor(noise_correction((double)value, ctrl));
 }
+
+static int64_t noise_corrected_ceil(uint64_t value, double ctrl)
+{
+	return (int64_t)ceil(noise_correction((double)value, ctrl));
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
 #ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
 /*
@@ -130,22 +160,22 @@ static void percentiles_report(const char *suite_name, const char *bench_name,
 	percentiles_sort();
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("P,%s,%s,%zu,%lld,%lld,%lld,%lld,%lld,%lld,%lld\n",
+	printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
 		suite_name, bench_name, retained_count,
-		discrete_noise_correction(retained[0], ctrl),
-		discrete_noise_correction(percentile(5000), ctrl),
-		discrete_noise_correction(percentile(9000), ctrl),
-		discrete_noise_correction(percentile(9900), ctrl),
-		discrete_noise_correction(percentile(9990), ctrl),
-		discrete_noise_correction(percentile(9999), ctrl),
-		discrete_noise_correction(retained[retained_count - 1], ctrl));
+		noise_correction((double)retained[0], ctrl),
+		noise_correction((double)percentile(5000), ctrl),
+		noise_correction((double)percentile(9000), ctrl),
+		noise_correction((double)percentile(9900), ctrl),
+		noise_correction((double)percentile(9990), ctrl),
+		noise_correction((double)percentile(9999), ctrl),
+		noise_correction((double)retained[retained_count - 1], ctrl));
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk("\tp50: %lld\n", discrete_noise_correction(percentile(5000), ctrl));
-	printk("\tp90: %lld\n", discrete_noise_correction(percentile(9000), ctrl));
-	printk("\tp99: %lld\n", discrete_noise_correction(percentile(9900), ctrl));
-	printk("\tp99.9: %lld\n", discrete_noise_correction(percentile(9990), ctrl));
-	printk("\tp99.99: %lld\n", discrete_noise_correction(percentile(9999), ctrl));
+	printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
+	printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
+	printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
+	printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
+	printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 }
 #else
@@ -194,25 +224,25 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 	}
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("%c,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
+	printk("%c,%s,%s,%lld,%.3f,%.3f,%.3f,%.3f,%.3f,%lld,%.3f,%lld\n",
 		record_type, suite_name, bench_name,
 		stats->samples,
-		discrete_noise_correction(stats->total, ctrl * stats->samples),
+		noise_correction((double)stats->total, ctrl * (double)stats->samples),
 		noise_correction(stats->mean, ctrl), stddev, std_error,
-		discrete_noise_correction(stats->min.value, ctrl), stats->min.sample,
-		discrete_noise_correction(stats->max.value, ctrl), stats->max.sample);
+		noise_correction((double)stats->min.value, ctrl), stats->min.sample,
+		noise_correction((double)stats->max.value, ctrl), stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
 	printk_line(bench_name, '=');
-	printk("\tSample size:%lld, total cycles: %lld\n", stats->samples,
-			discrete_noise_correction(stats->total, ctrl * stats->samples));
+	printk("\tSample size:%lld, total cycles: %.3f\n", stats->samples,
+			noise_correction((double)stats->total, ctrl * (double)stats->samples));
 
 	printk("\tMean(u): %.3f\n", noise_correction(stats->mean, ctrl));
 	printk("\tStandard deviation(s): %.3f\n", stddev);
 	printk("\tStandard Error(SE): %.3f\n", std_error);
-	printk("\tMin: %lld (run #%llu)\n", discrete_noise_correction(stats->min.value, ctrl),
+	printk("\tMin: %lld (run #%llu)\n", noise_corrected_floor(stats->min.value, ctrl),
 		stats->min.sample);
-	printk("\tMax: %lld (run #%llu)\n", discrete_noise_correction(stats->max.value, ctrl),
+	printk("\tMax: %lld (run #%llu)\n", noise_corrected_ceil(stats->max.value, ctrl),
 		stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
@@ -326,6 +356,17 @@ void ztest_benchmark_end(void)
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
 	ztest_benchmark_end_at(timing_counter_get());
+}
+
+void ztest_benchmark_discard_samples(void)
+{
+	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
+
+	if (manual_active_stats != NULL) {
+		memset(manual_active_stats, 0, sizeof(*manual_active_stats));
+		manual_active_stats->min.value = UINT64_MAX;
+		percentiles_reset();
+	}
 }
 
 static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -44,6 +44,10 @@ static void printk_line(const char *fn, char sep_char)
  * The correction is a real number, so the corrected values are real
  * numbers too, and generally do not coincide with any single
  * measurement.
+ *
+ * A negative result is not clamped: it means the operation costs less
+ * than the control loop bracketing it, so the counter is too coarse to
+ * measure it. Clamping would hide that behind a plausible number.
  */
 static double noise_correction(double value, double ctrl)
 {
@@ -135,20 +139,33 @@ static uint64_t percentile(uint32_t hundredths)
 
 #if defined(CONFIG_ZTEST_BENCHMARK_OUTLIERS) && defined(CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE)
 /*
- * Samples slower than the median.
+ * Samples disturbed enough to sit clear of the baseline, which for a
+ * kernel latency distribution is the median.
  *
- * For a kernel latency distribution the median is the baseline: the
- * operation costs the same on almost every run, and what matters is how
- * many runs were disturbed and by how much. Counting them says that
- * directly, where a standard error would only describe how precisely an
- * average of two different populations had been estimated.
+ * Merely exceeding the median is not enough: the counter resolution
+ * spreads the baseline over a few counts, so that would report about
+ * half the samples as outliers. Require a margin instead, relative so
+ * it holds across platforms, floored below for quantized distributions.
  */
 static size_t percentiles_outliers(void)
 {
 	uint64_t median = percentile(5000);
+	uint64_t margin = median / CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV;
+	uint64_t threshold;
 	size_t count = 0;
 
-	while ((count < retained_count) && (retained[retained_count - 1 - count] > median)) {
+	/*
+	 * A distribution spanning a couple of counts is at the counter
+	 * resolution, not above it. One count is not enough to exclude
+	 * it: the neighbouring count is exactly one away.
+	 */
+	if (margin < 2U) {
+		margin = 2U;
+	}
+
+	threshold = median + margin;
+
+	while ((count < retained_count) && (retained[retained_count - 1 - count] > threshold)) {
 		count++;
 	}
 

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -42,14 +42,25 @@ static int64_t discrete_noise_correction(uint64_t value, double ctrl)
 	return (int64_t)value - (int64_t)trunc(ctrl);
 }
 
-static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
-					  struct ztest_benchmark_stats *ctrl_stats)
+static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
+					char record_type, struct ztest_benchmark_stats *stats,
+					struct ztest_benchmark_stats *ctrl_stats)
 {
 	double ctrl = (double)ctrl_stats->mean;
 	double stddev = 0.0;
 	double sample_variance;
 	double std_error = 0.0;
-	struct ztest_benchmark_stats *stats = &benchmark->stats;
+
+	if (stats->samples == 0) {
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
+		printk("%c,%s,%s\tINCONCLUSIVE\n", record_type, suite_name, bench_name);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+		printk_line(bench_name, '=');
+		printk("\tTest inconclusive (no samples recorded)\n");
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+		return;
+	}
 
 	if (stats->samples > 1) {
 		sample_variance = stats->m2 / (double)(stats->samples - 1);
@@ -58,8 +69,8 @@ static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
 	}
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("S,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
-		benchmark->suite->name, benchmark->name,
+	printk("%c,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
+		record_type, suite_name, bench_name,
 		stats->samples,
 		discrete_noise_correction(stats->total, ctrl * stats->samples),
 		noise_correction(stats->mean, ctrl), stddev, std_error,
@@ -67,7 +78,7 @@ static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
 		discrete_noise_correction(stats->max.value, ctrl), stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk_line(benchmark->name, '=');
+	printk_line(bench_name, '=');
 	printk("\tSample size:%lld, total cycles: %lld\n", stats->samples,
 			discrete_noise_correction(stats->total, ctrl * stats->samples));
 
@@ -124,6 +135,87 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 		end = timing_counter_get();
 
 		update_metrics(&benchmark->stats, timing_cycles_get(&start, &end));
+
+		if (benchmark->teardown) {
+			benchmark->teardown();
+		}
+	}
+}
+
+/*
+ * The benchmark whose body is running, and the span it has open.
+ *
+ * Only one benchmark runs at a time, so a single set of these serves all
+ * of them. manual_started separates "no span open" from a span that
+ * legitimately began at timestamp zero.
+ */
+static struct ztest_benchmark_stats *manual_active_stats;
+static timing_t manual_span_start;
+static bool manual_span_open;
+
+void ztest_benchmark_start_at(timing_t start)
+{
+	if (manual_active_stats == NULL) {
+		return;
+	}
+
+	manual_span_start = start;
+	manual_span_open = true;
+}
+
+void ztest_benchmark_start(void)
+{
+	if (manual_active_stats == NULL) {
+		return;
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	ztest_benchmark_start_at(timing_counter_get());
+}
+
+void ztest_benchmark_end_at(timing_t end)
+{
+	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
+
+	if ((manual_active_stats == NULL) || !manual_span_open) {
+		return;
+	}
+
+	manual_span_open = false;
+	update_metrics(manual_active_stats, timing_cycles_get(&manual_span_start, &end));
+}
+
+void ztest_benchmark_end(void)
+{
+	if ((manual_active_stats == NULL) || !manual_span_open) {
+		return;
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	ztest_benchmark_end_at(timing_counter_get());
+}
+
+static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
+{
+	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
+	benchmark->stats.min.value = UINT64_MAX;
+
+	/*
+	 * The loop, the setup and the teardown are the framework's, exactly
+	 * as for a sampled benchmark. All the body decides is which part of
+	 * itself the timestamps go around.
+	 */
+	for (size_t i = 0; i < benchmark->iterations; i++) {
+		if (benchmark->setup) {
+			benchmark->setup();
+		}
+
+		manual_active_stats = &benchmark->stats;
+		manual_span_open = false;
+		benchmark->run();
+		manual_active_stats = NULL;
 
 		if (benchmark->teardown) {
 			benchmark->teardown();
@@ -250,7 +342,17 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_run(benchmark);
-			ztest_benchmark_print_results(benchmark, &ctrl.stats);
+			ztest_benchmark_print_stats(suite->name, benchmark->name, 'S',
+						    &benchmark->stats, &ctrl.stats);
+		}
+
+		STRUCT_SECTION_FOREACH(ztest_benchmark_manual, benchmark) {
+			if (benchmark->suite != suite) {
+				continue;
+			}
+			ztest_benchmark_manual_run(benchmark);
+			ztest_benchmark_print_stats(suite->name, benchmark->name, 'M',
+						    &benchmark->stats, &ctrl.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_timed, benchmark) {

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -49,6 +49,8 @@ struct ztest_benchmark_stats {
 	uint64_t samples;
 	struct ztest_extreme_value min;
 	struct ztest_extreme_value max;
+	/* First iteration, measured before the steady state is reached. */
+	uint64_t cold;
 };
 
 struct ztest_benchmark {

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -13,6 +13,7 @@
 #define ZTEST_BENCHMARK_H
 #include <stdint.h>
 #include <stddef.h>
+#include <zephyr/timing/timing.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,10 +24,11 @@ extern "C" {
  * Identifier builders for the linker-visible symbols that the ZTEST_BENCHMARK*()
  * macros generate. Use when defining a symbol or when taking its reference.
  */
-#define Z_ZTEST_BENCHMARK_SUITE_NODE(suite)        z_ztest_benchmark_suite_##suite
-#define Z_ZTEST_BENCHMARK_NODE(suite, bench)       z_ztest_benchmark_##suite##_##bench
-#define Z_ZTEST_BENCHMARK_TIMED_NODE(suite, bench) z_ztest_benchmark_timed_##suite##_##bench
-#define Z_ZTEST_BENCHMARK_FN(suite, bench)         z_ztest_benchmark_##suite##_##bench##_fn
+#define Z_ZTEST_BENCHMARK_SUITE_NODE(suite)         z_ztest_benchmark_suite_##suite
+#define Z_ZTEST_BENCHMARK_NODE(suite, bench)        z_ztest_benchmark_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_TIMED_NODE(suite, bench)  z_ztest_benchmark_timed_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_MANUAL_NODE(suite, bench) z_ztest_benchmark_manual_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_FN(suite, bench)          z_ztest_benchmark_##suite##_##bench##_fn
 
 typedef void (*ztest_benchmark_fn_t)(void);
 struct ztest_benchmark_suite {
@@ -50,6 +52,16 @@ struct ztest_benchmark_stats {
 };
 
 struct ztest_benchmark {
+	const char *name;
+	size_t iterations;
+	ztest_benchmark_fn_t setup;
+	ztest_benchmark_fn_t run;
+	ztest_benchmark_fn_t teardown;
+	struct ztest_benchmark_stats stats;
+	const struct ztest_benchmark_suite *suite;
+};
+
+struct ztest_benchmark_manual {
 	const char *name;
 	size_t iterations;
 	ztest_benchmark_fn_t setup;
@@ -145,6 +157,98 @@ void benchmark_main(void);
 		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(testsuite),				\
 	};											\
 	static __noinline void Z_ZTEST_BENCHMARK_FN(testsuite, benchmark)(void)
+
+/**
+ * @brief Define a manually sampled benchmark
+ *
+ * The framework runs the body once per iteration exactly as it does for
+ * ZTEST_BENCHMARK(), but the body decides which part of itself is measured
+ * by bracketing it with ztest_benchmark_start() and
+ * ztest_benchmark_end():
+ *
+ * @code
+ * ZTEST_BENCHMARK_MANUAL(my_suite, my_benchmark, 1000, NULL, NULL)
+ * {
+ *         prepare();
+ *         ztest_benchmark_start();
+ *         operation_under_test();
+ *         ztest_benchmark_end();
+ * }
+ * @endcode
+ *
+ * That covers a span the framework cannot time by itself because it does
+ * not start and end where the body does. When the span does not even begin
+ * and end in the same execution context - the latency from an interrupt to
+ * the thread it wakes, say - the endpoint captured elsewhere is handed over
+ * with ztest_benchmark_start_at() or ztest_benchmark_end_at().
+ *
+ * A body that records no span contributes no sample for that iteration.
+ *
+ * @param suite_name Name of the suite the benchmark belongs to
+ * @param benchmark Name of the benchmark
+ * @param samples Number of iterations to run the benchmark
+ * @param setup_fn Function to run before each iteration
+ * @param teardown_fn Function to run after each iteration
+ */
+#define ZTEST_BENCHMARK_MANUAL(suite_name, benchmark, samples, setup_fn, teardown_fn)		\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void);		\
+	static STRUCT_SECTION_ITERABLE(ztest_benchmark_manual,					\
+				       Z_ZTEST_BENCHMARK_MANUAL_NODE(suite_name, benchmark)) =	\
+	{											\
+		.name = #benchmark,								\
+		.iterations = samples,								\
+		.setup = setup_fn,								\
+		.run = Z_ZTEST_BENCHMARK_FN(suite_name, benchmark),				\
+		.teardown = teardown_fn,							\
+		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(suite_name),				\
+	};											\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void)
+
+/**
+ * @brief Begin the measured span of a manual benchmark iteration
+ *
+ * Timestamps now. Anything the body did before this call is excluded from
+ * the measurement.
+ *
+ * Calls made outside a ZTEST_BENCHMARK_MANUAL() body are ignored.
+ */
+void ztest_benchmark_start(void);
+
+/**
+ * @brief End the measured span of a manual benchmark iteration
+ *
+ * Timestamps now and hands the span to the framework as one sample.
+ * Without a preceding ztest_benchmark_start() there is no span, and the
+ * call is ignored.
+ *
+ * Must be called from thread context: recording a sample performs floating
+ * point math, which is not safe in ISRs on all architectures.
+ */
+void ztest_benchmark_end(void);
+
+/**
+ * @brief Begin the measured span at a timestamp taken elsewhere
+ *
+ * As ztest_benchmark_start(), for a span that began in another execution
+ * context. An ISR captures timing_counter_get() and the body hands the
+ * result over once it runs.
+ *
+ * @param start Timestamp the measured span began at
+ */
+void ztest_benchmark_start_at(timing_t start);
+
+/**
+ * @brief End the measured span at a timestamp taken elsewhere
+ *
+ * As ztest_benchmark_end(), for a span whose end was captured in another
+ * execution context.
+ *
+ * Must be called from thread context, for the same reason as
+ * ztest_benchmark_end().
+ *
+ * @param end Timestamp the measured span ended at
+ */
+void ztest_benchmark_end_at(timing_t end);
 
 /**
  * @}

--- a/tests/benchmarks/kernel_latency/CMakeLists.txt
+++ b/tests/benchmarks/kernel_latency/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(kernel_latency)
+
+target_sources(app PRIVATE
+  src/thread.c
+  src/semaphore.c
+  src/mutex.c
+  src/fifo.c
+  src/lifo.c
+  src/stack.c
+  src/heap.c
+  src/condvar.c
+)
+
+target_sources_ifdef(CONFIG_EVENTS app PRIVATE src/events.c)

--- a/tests/benchmarks/kernel_latency/Kconfig
+++ b/tests/benchmarks/kernel_latency/Kconfig
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Kernel Latency Benchmark"
+
+config KERNEL_BENCH_NUM_SAMPLES
+	int "Number of samples per benchmark"
+	default 1000
+	help
+	  Samples recorded for each benchmark. Percentiles need enough of
+	  them to resolve: p99 needs a hundred, p99.9 a thousand. Raise
+	  CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES to match.
+
+source "Kconfig.zephyr"

--- a/tests/benchmarks/kernel_latency/README.rst
+++ b/tests/benchmarks/kernel_latency/README.rst
@@ -1,0 +1,132 @@
+Kernel Latency Benchmark
+########################
+
+This benchmark measures the cost of the kernel operations an application
+uses constantly: creating and switching threads, taking and giving
+synchronisation objects, moving items through queues, and allocating from
+the heap.
+
+It covers the same ground as ``tests/benchmarks/latency_measure``, which
+remains in place, but is built on the :ref:`ztest benchmarking framework
+<ztest_benchmarking>` rather than on its own harness. What that buys is
+percentile reporting, control-measurement correction and twister-recordable
+output for free, and one benchmark per operation rather than one number per
+printed line.
+
+Structure
+*********
+
+Each kernel object gets a suite of its own in a file of its own, because
+``ZTEST_BENCHMARK_SUITE()`` defines the suite object static and a benchmark
+has to live in the same translation unit as its suite.
+
+Operations that begin and end in the calling thread are plain
+``ZTEST_BENCHMARK()`` bodies, which the framework times itself. Where an
+operation has a natural pair -- lock and unlock, put and get, malloc and
+free -- the two are separate benchmarks rather than one round trip: the
+setup and teardown hooks are not timed, so whichever half is not being
+measured can be done there. That is how ``mutex.lock`` and ``mutex.unlock``
+come out as separate numbers.
+
+Operations that end in a *different* thread are
+``ZTEST_BENCHMARK_MANUAL()`` bodies. The waking thread takes the first
+timestamp and the woken thread takes the second, which framework-timed
+benchmarks cannot express. These are the ``*_wake_switch`` benchmarks and
+the two context switch measurements.
+
+What is measured
+****************
+
+===================================  ==========================================
+Suite / benchmark                    Operation
+===================================  ==========================================
+``thread.create``                    ``k_thread_create()`` without starting
+``thread.start``                     ``k_thread_start()`` on a lower priority
+                                     thread, so no switch occurs
+``thread.suspend`` / ``resume``      suspend and resume a started thread
+``thread.abort``                     abort a started thread
+``thread.yield_preemptive``          context switch between preemptible
+                                     threads of equal priority
+``thread.yield_cooperative``         the same between cooperative threads
+``semaphore.give`` / ``take``        uncontended, no waiter
+``semaphore.give_wake_switch``       give to a blocked higher priority thread,
+                                     until that thread runs
+``mutex.lock`` / ``unlock``          uncontended
+``fifo.put`` / ``get``               uncontended
+``fifo.alloc_put``                   ``k_fifo_alloc_put()``, which takes memory
+                                     from the thread resource pool
+``fifo.put_wake_switch``             put to a blocked higher priority thread
+``lifo.put`` / ``get``               uncontended, for comparison with the FIFO
+``stack.push`` / ``pop``             uncontended
+``heap.malloc`` / ``free``           64 byte block from the kernel heap
+``events.post`` / ``wait_satisfied`` post, and a wait that is already satisfied
+``events.post_wake_switch``          post to a blocked higher priority thread
+``condvar.signal_wake_switch``       signal a waiting thread; necessarily
+                                     includes the mutex handoff
+===================================  ==========================================
+
+Running
+*******
+
+.. code-block:: console
+
+   west build -p -b <board> tests/benchmarks/kernel_latency -t run -- \
+       -DCONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE=y
+
+Without the override the application selects CSV output, which is what
+twister records:
+
+.. code-block:: console
+
+   scripts/twister -p qemu_x86 -T tests/benchmarks/kernel_latency
+
+Warmup and the cold cost
+************************
+
+Each benchmark is setup, then
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` iterations that execute but
+are not recorded, then the measured samples. The framework runs the warmup
+and reports the very first execution separately as the **cold cost**, so
+the two are never mixed. The framework does not warm up by default, so
+:file:`prj.conf` asks for it here.
+
+That separation is not academic. On an FRDM-MCXN947 the first execution
+costs between 1.1 and 1.8 times the steady state: ``thread.suspend`` is 343
+cycles cold against 196 hot, ``mutex.lock`` 231 against 137. Folded into
+the distribution a single sample like that moves the maximum and the
+standard deviation while describing a state the benchmark never returns to;
+reported on its own it answers a question an application actually has,
+which is what a path costs the first time it is reached.
+
+Reading the results
+*******************
+
+Percentiles are enabled, so each benchmark reports ``min``, ``p50``,
+``p90``, ``p99``, ``p99.9``, ``p99.99`` and ``max`` as well as the mean and
+standard deviation. For kernel operations the median is usually the number
+of interest -- these are short, uncontended paths -- but the tail is what
+shows when an operation is occasionally interrupted, and the two differ by
+more than the mean suggests.
+
+At the default thousand samples p99.9 is the last percentile with enough
+samples behind it. Raise :kconfig:option:`CONFIG_KERNEL_BENCH_NUM_SAMPLES`
+and :kconfig:option:`CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES` together to go
+further out.
+
+The cold cost is reported for every benchmark, and in CSV output it is a
+row of its own.
+
+Notes
+*****
+
+* Memory mapped thread stacks are disabled. The thread benchmarks create and
+  destroy a thread on the same stack once per sample, and each cycle consumes
+  virtual address space that is not handed back, so a few hundred iterations
+  exhaust the mapping pool and ``k_thread_create()`` asserts. Disabling it
+  also keeps thread creation comparable with platforms that have no MMU.
+* Absolute cycle counts under emulation say little. QEMU advances its cycle
+  counter with host time rather than with emulated instructions, so numbers
+  taken there are useful for comparing operations against each other and
+  useless as absolute figures. Take them on hardware.
+* Userspace variants of these operations, which ``latency_measure``
+  reports, are not covered yet.

--- a/tests/benchmarks/kernel_latency/prj.conf
+++ b/tests/benchmarks/kernel_latency/prj.conf
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_BENCHMARK=y
+CONFIG_ZTEST_BENCHMARK_PERCENTILES=y
+CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES=1024
+
+# The framework does not warm up by default. These benchmarks want the
+# steady state, and the first execution of one of them costs up to 1.8
+# times the rest, so discard a few iterations before sampling. Only the
+# measured samples are retained, so this stays inside MAX_SAMPLES above.
+CONFIG_ZTEST_BENCHMARK_WARMUP=10
+
+# Formatting the statistics uses more stack than the 1KB some
+# platforms default to.
+CONFIG_MAIN_STACK_SIZE=4096
+
+# Keep timer interrupts out of the measurements
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=100
+
+# The thread benchmarks create and destroy a thread on the same stack
+# once per sample. Where stacks are memory mapped, each cycle consumes
+# virtual address space that is not handed back, so a few hundred
+# iterations exhaust the mapping pool and k_thread_create() asserts.
+# Turning the mapping off also keeps thread creation comparable with
+# the platforms that have no MMU at all.
+CONFIG_THREAD_STACK_MEM_MAPPED=n
+
+CONFIG_TIMESLICING=n
+CONFIG_PM=n
+CONFIG_EVENTS=y
+CONFIG_HEAP_MEM_POOL_SIZE=4096

--- a/tests/benchmarks/kernel_latency/src/bench.h
+++ b/tests/benchmarks/kernel_latency/src/bench.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTS_BENCHMARKS_KERNEL_LATENCY_SRC_BENCH_H_
+#define ZEPHYR_TESTS_BENCHMARKS_KERNEL_LATENCY_SRC_BENCH_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/timing/timing.h>
+
+/*
+ * Shared helpers for the manually sampled benchmarks.
+ *
+ * Operations that begin and end in the same thread are plain
+ * ZTEST_BENCHMARK() bodies, which the framework times itself. The ones
+ * here span a context switch, so one thread takes the first timestamp
+ * and the partner thread takes the second, which only
+ * ZTEST_BENCHMARK_MANUAL() can express.
+ *
+ * The framework runs the body once per iteration and handles the warmup
+ * either way, so a body performs a single handshake: the partner is
+ * created by the setup function, does its half, and is joined by the
+ * teardown function.
+ */
+
+#define BENCH_SAMPLES CONFIG_KERNEL_BENCH_NUM_SAMPLES
+
+#define BENCH_PARTNER_STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+/*
+ * Hand the framework a span whose endpoints were taken in two different
+ * threads. Called from the benchmark body once the handshake has
+ * completed, so both timestamps are settled by then.
+ */
+static inline void bench_span(timing_t start, timing_t finish)
+{
+	ztest_benchmark_start_at(start);
+	ztest_benchmark_end_at(finish);
+}
+
+#endif /* ZEPHYR_TESTS_BENCHMARKS_KERNEL_LATENCY_SRC_BENCH_H_ */

--- a/tests/benchmarks/kernel_latency/src/condvar.c
+++ b/tests/benchmarks/kernel_latency/src/condvar.c
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Condition variable signalling. There is no uncontended variant worth
+ * timing: signalling with nobody waiting does almost nothing, so the
+ * measurement is the wake of a waiting thread.
+ *
+ * The span is necessarily larger than the equivalent semaphore or FIFO
+ * wake. k_condvar_wait() cannot return without the mutex, so the
+ * waiter only reaches its timestamp after the signaller has released
+ * it, and the measurement therefore contains the mutex handoff as well
+ * as the wake. That is inherent to the primitive rather than an
+ * artefact of the benchmark.
+ */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(condvar, NULL, NULL);
+
+static K_MUTEX_DEFINE(mutex);
+static K_CONDVAR_DEFINE(condvar);
+static K_SEM_DEFINE(ready_sem, 0, 1);
+static K_SEM_DEFINE(done_sem, 0, 1);
+static K_THREAD_STACK_DEFINE(waiter_stack, BENCH_PARTNER_STACK_SIZE);
+static struct k_thread waiter_thread;
+static volatile timing_t wake_start;
+static volatile timing_t wake_finish;
+
+static void waiter_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	(void)k_mutex_lock(&mutex, K_FOREVER);
+	k_sem_give(&ready_sem);
+	(void)k_condvar_wait(&condvar, &mutex, K_FOREVER);
+
+	wake_finish = timing_counter_get();
+
+	(void)k_mutex_unlock(&mutex);
+	k_sem_give(&done_sem);
+}
+
+static void waiter_create(void)
+{
+	int priority = k_thread_priority_get(k_current_get()) - 1;
+
+	k_thread_create(&waiter_thread, waiter_stack, BENCH_PARTNER_STACK_SIZE, waiter_entry,
+			NULL, NULL, NULL, priority, 0, K_NO_WAIT);
+}
+
+static void waiter_join(void)
+{
+	(void)k_thread_join(&waiter_thread, K_FOREVER);
+}
+
+ZTEST_BENCHMARK_MANUAL(condvar, signal_wake_switch, BENCH_SAMPLES, waiter_create, waiter_join)
+{
+	/*
+	 * Wait until the partner is inside k_condvar_wait() and has
+	 * released the mutex, so that the signal always has somebody to
+	 * wake.
+	 */
+	(void)k_sem_take(&ready_sem, K_FOREVER);
+	(void)k_mutex_lock(&mutex, K_FOREVER);
+
+	wake_start = timing_counter_get();
+	(void)k_condvar_signal(&condvar);
+
+	(void)k_mutex_unlock(&mutex);
+	(void)k_sem_take(&done_sem, K_FOREVER);
+
+	bench_span(wake_start, wake_finish);
+}

--- a/tests/benchmarks/kernel_latency/src/events.c
+++ b/tests/benchmarks/kernel_latency/src/events.c
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* k_event post and wait, and the wake of a thread blocked in wait. */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(events, NULL, NULL);
+
+#define EVENT_BIT BIT(0)
+
+static K_EVENT_DEFINE(event);
+
+static void event_clear(void)
+{
+	k_event_clear(&event, EVENT_BIT);
+}
+
+static void event_set(void)
+{
+	k_event_post(&event, EVENT_BIT);
+}
+
+ZTEST_BENCHMARK(events, post, BENCH_SAMPLES, NULL, event_clear)
+{
+	k_event_post(&event, EVENT_BIT);
+}
+
+ZTEST_BENCHMARK(events, wait_satisfied, BENCH_SAMPLES, event_set, event_clear)
+{
+	(void)k_event_wait(&event, EVENT_BIT, false, K_NO_WAIT);
+}
+
+/*
+ * Time from k_event_post() to the higher priority thread blocked in
+ * k_event_wait() running.
+ */
+static K_EVENT_DEFINE(wake_event);
+static K_SEM_DEFINE(done_sem, 0, 1);
+static K_THREAD_STACK_DEFINE(waiter_stack, BENCH_PARTNER_STACK_SIZE);
+static struct k_thread waiter_thread;
+static volatile timing_t wake_start;
+static volatile timing_t wake_finish;
+
+static void waiter_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	(void)k_event_wait(&wake_event, EVENT_BIT, false, K_FOREVER);
+	wake_finish = timing_counter_get();
+	k_event_clear(&wake_event, EVENT_BIT);
+	k_sem_give(&done_sem);
+}
+
+static void waiter_create(void)
+{
+	int priority = k_thread_priority_get(k_current_get()) - 1;
+
+	k_thread_create(&waiter_thread, waiter_stack, BENCH_PARTNER_STACK_SIZE, waiter_entry,
+			NULL, NULL, NULL, priority, 0, K_NO_WAIT);
+}
+
+static void waiter_join(void)
+{
+	(void)k_thread_join(&waiter_thread, K_FOREVER);
+}
+
+ZTEST_BENCHMARK_MANUAL(events, post_wake_switch, BENCH_SAMPLES, waiter_create, waiter_join)
+{
+	wake_start = timing_counter_get();
+	k_event_post(&wake_event, EVENT_BIT);
+	(void)k_sem_take(&done_sem, K_FOREVER);
+
+	bench_span(wake_start, wake_finish);
+}

--- a/tests/benchmarks/kernel_latency/src/fifo.c
+++ b/tests/benchmarks/kernel_latency/src/fifo.c
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * FIFO operations, including the allocating variants that take memory
+ * from the calling thread's resource pool, and the wake of a thread
+ * blocked in k_fifo_get().
+ */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(fifo, NULL, NULL);
+
+static K_FIFO_DEFINE(fifo);
+
+static struct {
+	intptr_t reserved;
+	uint32_t payload;
+} item;
+
+static void fifo_fill(void)
+{
+	k_fifo_put(&fifo, &item);
+}
+
+static void fifo_drain(void)
+{
+	(void)k_fifo_get(&fifo, K_NO_WAIT);
+}
+
+ZTEST_BENCHMARK(fifo, put, BENCH_SAMPLES, NULL, fifo_drain)
+{
+	k_fifo_put(&fifo, &item);
+}
+
+ZTEST_BENCHMARK(fifo, get, BENCH_SAMPLES, fifo_fill, NULL)
+{
+	(void)k_fifo_get(&fifo, K_NO_WAIT);
+}
+
+static void fifo_alloc_fill(void)
+{
+	(void)k_fifo_alloc_put(&fifo, &item);
+}
+
+ZTEST_BENCHMARK(fifo, alloc_put, BENCH_SAMPLES, NULL, fifo_drain)
+{
+	(void)k_fifo_alloc_put(&fifo, &item);
+}
+
+ZTEST_BENCHMARK(fifo, get_after_alloc_put, BENCH_SAMPLES, fifo_alloc_fill, NULL)
+{
+	(void)k_fifo_get(&fifo, K_NO_WAIT);
+}
+
+/*
+ * Time from k_fifo_put() to the higher priority thread blocked in
+ * k_fifo_get() running with the item.
+ */
+static K_FIFO_DEFINE(wake_fifo);
+static K_SEM_DEFINE(done_sem, 0, 1);
+static K_THREAD_STACK_DEFINE(waiter_stack, BENCH_PARTNER_STACK_SIZE);
+static struct k_thread waiter_thread;
+static volatile timing_t wake_start;
+static volatile timing_t wake_finish;
+
+static struct {
+	intptr_t reserved;
+	uint32_t payload;
+} wake_item;
+
+static void waiter_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	(void)k_fifo_get(&wake_fifo, K_FOREVER);
+	wake_finish = timing_counter_get();
+	k_sem_give(&done_sem);
+}
+
+static void waiter_create(void)
+{
+	int priority = k_thread_priority_get(k_current_get()) - 1;
+
+	k_thread_create(&waiter_thread, waiter_stack, BENCH_PARTNER_STACK_SIZE, waiter_entry,
+			NULL, NULL, NULL, priority, 0, K_NO_WAIT);
+}
+
+static void waiter_join(void)
+{
+	(void)k_thread_join(&waiter_thread, K_FOREVER);
+}
+
+ZTEST_BENCHMARK_MANUAL(fifo, put_wake_switch, BENCH_SAMPLES, waiter_create, waiter_join)
+{
+	wake_start = timing_counter_get();
+	k_fifo_put(&wake_fifo, &wake_item);
+	(void)k_sem_take(&done_sem, K_FOREVER);
+
+	bench_span(wake_start, wake_finish);
+}

--- a/tests/benchmarks/kernel_latency/src/heap.c
+++ b/tests/benchmarks/kernel_latency/src/heap.c
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Kernel heap allocation. Allocating and freeing are separate
+ * benchmarks so that the two costs, which differ, do not hide inside
+ * one number.
+ */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(heap, NULL, NULL);
+
+#define BLOCK_SIZE 64
+
+static void *block;
+
+static void heap_alloc(void)
+{
+	block = k_malloc(BLOCK_SIZE);
+	__ASSERT(block != NULL, "k_malloc failed; raise CONFIG_HEAP_MEM_POOL_SIZE");
+}
+
+static void heap_free(void)
+{
+	k_free(block);
+	block = NULL;
+}
+
+ZTEST_BENCHMARK(heap, malloc, BENCH_SAMPLES, NULL, heap_free)
+{
+	block = k_malloc(BLOCK_SIZE);
+}
+
+ZTEST_BENCHMARK(heap, free, BENCH_SAMPLES, heap_alloc, NULL)
+{
+	k_free(block);
+}

--- a/tests/benchmarks/kernel_latency/src/lifo.c
+++ b/tests/benchmarks/kernel_latency/src/lifo.c
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* LIFO operations, for comparison against the FIFO of the same shape. */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(lifo, NULL, NULL);
+
+static K_LIFO_DEFINE(lifo);
+
+static struct {
+	intptr_t reserved;
+	uint32_t payload;
+} item;
+
+static void lifo_fill(void)
+{
+	k_lifo_put(&lifo, &item);
+}
+
+static void lifo_drain(void)
+{
+	(void)k_lifo_get(&lifo, K_NO_WAIT);
+}
+
+ZTEST_BENCHMARK(lifo, put, BENCH_SAMPLES, NULL, lifo_drain)
+{
+	k_lifo_put(&lifo, &item);
+}
+
+ZTEST_BENCHMARK(lifo, get, BENCH_SAMPLES, lifo_fill, NULL)
+{
+	(void)k_lifo_get(&lifo, K_NO_WAIT);
+}

--- a/tests/benchmarks/kernel_latency/src/mutex.c
+++ b/tests/benchmarks/kernel_latency/src/mutex.c
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Uncontended mutex operations. Splitting lock from unlock is what the
+ * setup and teardown hooks are for: neither is timed, so each
+ * benchmark reports one operation rather than the pair.
+ */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(mutex, NULL, NULL);
+
+static K_MUTEX_DEFINE(mutex);
+
+static void mutex_acquire(void)
+{
+	(void)k_mutex_lock(&mutex, K_FOREVER);
+}
+
+static void mutex_release(void)
+{
+	(void)k_mutex_unlock(&mutex);
+}
+
+ZTEST_BENCHMARK(mutex, lock, BENCH_SAMPLES, NULL, mutex_release)
+{
+	(void)k_mutex_lock(&mutex, K_FOREVER);
+}
+
+ZTEST_BENCHMARK(mutex, unlock, BENCH_SAMPLES, mutex_acquire, NULL)
+{
+	(void)k_mutex_unlock(&mutex);
+}

--- a/tests/benchmarks/kernel_latency/src/semaphore.c
+++ b/tests/benchmarks/kernel_latency/src/semaphore.c
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Semaphore operations. The uncontended give and take are timed by the
+ * framework; waking a waiting thread is measured manually, because the
+ * span ends in that thread.
+ */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(semaphore, NULL, NULL);
+
+static K_SEM_DEFINE(sem, 0, 1);
+
+static void sem_drain(void)
+{
+	(void)k_sem_take(&sem, K_NO_WAIT);
+}
+
+static void sem_fill(void)
+{
+	k_sem_give(&sem);
+}
+
+ZTEST_BENCHMARK(semaphore, give, BENCH_SAMPLES, NULL, sem_drain)
+{
+	k_sem_give(&sem);
+}
+
+ZTEST_BENCHMARK(semaphore, take, BENCH_SAMPLES, sem_fill, NULL)
+{
+	(void)k_sem_take(&sem, K_NO_WAIT);
+}
+
+/*
+ * Time from k_sem_give() to the higher priority thread that was
+ * blocked on the semaphore running again: the wake plus the context
+ * switch it forces.
+ */
+static K_SEM_DEFINE(wake_sem, 0, 1);
+static K_SEM_DEFINE(done_sem, 0, 1);
+static K_THREAD_STACK_DEFINE(waiter_stack, BENCH_PARTNER_STACK_SIZE);
+static struct k_thread waiter_thread;
+static volatile timing_t wake_start;
+static volatile timing_t wake_finish;
+
+static void waiter_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	(void)k_sem_take(&wake_sem, K_FOREVER);
+	wake_finish = timing_counter_get();
+	k_sem_give(&done_sem);
+}
+
+static void waiter_create(void)
+{
+	int priority = k_thread_priority_get(k_current_get()) - 1;
+
+	k_thread_create(&waiter_thread, waiter_stack, BENCH_PARTNER_STACK_SIZE, waiter_entry,
+			NULL, NULL, NULL, priority, 0, K_NO_WAIT);
+}
+
+static void waiter_join(void)
+{
+	(void)k_thread_join(&waiter_thread, K_FOREVER);
+}
+
+ZTEST_BENCHMARK_MANUAL(semaphore, give_wake_switch, BENCH_SAMPLES, waiter_create, waiter_join)
+{
+	wake_start = timing_counter_get();
+	k_sem_give(&wake_sem);
+	(void)k_sem_take(&done_sem, K_FOREVER);
+
+	bench_span(wake_start, wake_finish);
+}

--- a/tests/benchmarks/kernel_latency/src/stack.c
+++ b/tests/benchmarks/kernel_latency/src/stack.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* k_stack push and pop, uncontended. */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(stack, NULL, NULL);
+
+#define STACK_DEPTH 4
+
+K_STACK_DEFINE(stack, STACK_DEPTH);
+
+static void stack_fill(void)
+{
+	(void)k_stack_push(&stack, (stack_data_t)0xbeef);
+}
+
+static void stack_drain(void)
+{
+	stack_data_t value;
+
+	(void)k_stack_pop(&stack, &value, K_NO_WAIT);
+}
+
+ZTEST_BENCHMARK(stack, push, BENCH_SAMPLES, NULL, stack_drain)
+{
+	(void)k_stack_push(&stack, (stack_data_t)0xbeef);
+}
+
+ZTEST_BENCHMARK(stack, pop, BENCH_SAMPLES, stack_fill, NULL)
+{
+	stack_data_t value;
+
+	(void)k_stack_pop(&stack, &value, K_NO_WAIT);
+}

--- a/tests/benchmarks/kernel_latency/src/thread.c
+++ b/tests/benchmarks/kernel_latency/src/thread.c
@@ -1,0 +1,172 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Thread lifecycle operations, and the context switch itself.
+ *
+ * The lifecycle operations are timed by the framework: each one is the
+ * body, and whatever has to happen around it to make the operation
+ * legal is the setup or the teardown, which are not timed. The context
+ * switch is measured manually, because it ends in a different thread
+ * from the one it starts in.
+ */
+
+#include "bench.h"
+
+ZTEST_BENCHMARK_SUITE(thread, NULL, NULL);
+
+static K_THREAD_STACK_DEFINE(target_stack, BENCH_PARTNER_STACK_SIZE);
+static struct k_thread target_thread;
+
+/* Never runs: created below the benchmark's priority and left parked */
+static void target_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_sleep(K_FOREVER);
+}
+
+static int target_priority(void)
+{
+	return k_thread_priority_get(k_current_get()) + 1;
+}
+
+static void target_create(void)
+{
+	k_thread_create(&target_thread, target_stack, BENCH_PARTNER_STACK_SIZE, target_entry,
+			NULL, NULL, NULL, target_priority(), 0, K_FOREVER);
+}
+
+static void target_create_and_start(void)
+{
+	target_create();
+	k_thread_start(&target_thread);
+}
+
+static void target_create_start_suspend(void)
+{
+	target_create_and_start();
+	k_thread_suspend(&target_thread);
+}
+
+/*
+ * Abort and then wait for the thread to be reaped. Where thread stacks
+ * are memory mapped, the mapping is only released once the terminated
+ * thread has been cleaned up, and a thousand create/abort cycles that
+ * do not wait exhaust the mapping pool.
+ */
+static void target_abort(void)
+{
+	k_thread_abort(&target_thread);
+	(void)k_thread_join(&target_thread, K_FOREVER);
+}
+
+static void target_join(void)
+{
+	(void)k_thread_join(&target_thread, K_FOREVER);
+}
+
+ZTEST_BENCHMARK(thread, create, BENCH_SAMPLES, NULL, target_abort)
+{
+	target_create();
+}
+
+ZTEST_BENCHMARK(thread, start, BENCH_SAMPLES, target_create, target_abort)
+{
+	k_thread_start(&target_thread);
+}
+
+ZTEST_BENCHMARK(thread, suspend, BENCH_SAMPLES, target_create_and_start, target_abort)
+{
+	k_thread_suspend(&target_thread);
+}
+
+ZTEST_BENCHMARK(thread, resume, BENCH_SAMPLES, target_create_start_suspend, target_abort)
+{
+	k_thread_resume(&target_thread);
+}
+
+ZTEST_BENCHMARK(thread, abort, BENCH_SAMPLES, target_create_and_start, target_join)
+{
+	k_thread_abort(&target_thread);
+}
+
+/*
+ * Context switch through k_yield(), measured between two threads of
+ * equal priority that hand the CPU back and forth. The partner takes
+ * the second timestamp, so the span covers the switch itself rather
+ * than the cost of calling k_yield().
+ */
+static K_THREAD_STACK_DEFINE(yield_stack, BENCH_PARTNER_STACK_SIZE);
+static struct k_thread yield_thread;
+static volatile timing_t yield_start;
+static volatile timing_t yield_finish;
+static int yield_saved_priority;
+
+static void yield_partner(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	yield_finish = timing_counter_get();
+}
+
+/*
+ * The partner runs at the measuring thread's own priority so that
+ * k_yield() actually switches. For the cooperative variant both are
+ * moved into the cooperative range first, and put back afterwards.
+ */
+static void yield_create(bool cooperative)
+{
+	int priority;
+
+	yield_saved_priority = k_thread_priority_get(k_current_get());
+
+	if (cooperative) {
+		k_thread_priority_set(k_current_get(), K_PRIO_COOP(2));
+	}
+
+	priority = k_thread_priority_get(k_current_get());
+
+	k_thread_create(&yield_thread, yield_stack, BENCH_PARTNER_STACK_SIZE, yield_partner,
+			NULL, NULL, NULL, priority, 0, K_NO_WAIT);
+}
+
+static void yield_create_preemptive(void)
+{
+	yield_create(false);
+}
+
+static void yield_create_cooperative(void)
+{
+	yield_create(true);
+}
+
+static void yield_join(void)
+{
+	(void)k_thread_join(&yield_thread, K_FOREVER);
+	k_thread_priority_set(k_current_get(), yield_saved_priority);
+}
+
+ZTEST_BENCHMARK_MANUAL(thread, yield_preemptive, BENCH_SAMPLES, yield_create_preemptive,
+		       yield_join)
+{
+	yield_start = timing_counter_get();
+	k_yield();
+
+	bench_span(yield_start, yield_finish);
+}
+
+ZTEST_BENCHMARK_MANUAL(thread, yield_cooperative, BENCH_SAMPLES, yield_create_cooperative,
+		       yield_join)
+{
+	yield_start = timing_counter_get();
+	k_yield();
+
+	bench_span(yield_start, yield_finish);
+}

--- a/tests/benchmarks/kernel_latency/tests.yaml
+++ b/tests/benchmarks/kernel_latency/tests.yaml
@@ -1,0 +1,22 @@
+common:
+  tags:
+    - kernel
+    - benchmark
+tests:
+  benchmark.kernel.latency.objects:
+    min_ram: 32
+    timeout: 300
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    harness: console
+    integration_platforms:
+      - qemu_x86
+      - qemu_cortex_a53
+      - qemu_riscv32
+    harness_config:
+      type: one_line
+      record:
+        regex:
+          - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"

--- a/tests/ztest/benchmark_manual/CMakeLists.txt
+++ b/tests/ztest/benchmark_manual/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(benchmark_manual)
+
+target_sources(app PRIVATE
+  src/main.c
+)

--- a/tests/ztest/benchmark_manual/prj.conf
+++ b/tests/ztest/benchmark_manual/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_BENCHMARK=y
+CONFIG_IRQ_OFFLOAD=y
+CONFIG_MAIN_STACK_SIZE=2048

--- a/tests/ztest/benchmark_manual/src/main.c
+++ b/tests/ztest/benchmark_manual/src/main.c
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Validation for ZTEST_BENCHMARK_MANUAL(): one benchmark measuring a
+ * span of a known duration (k_busy_wait) that is only part of the body,
+ * and one measuring a span whose starting timestamp is captured in a
+ * different execution context (an ISR entered via irq_offload), which
+ * framework-timed benchmarks cannot express.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/irq_offload.h>
+#include <zephyr/timing/timing.h>
+
+#define NUM_SAMPLES  100
+#define BUSY_WAIT_US 100
+
+ZTEST_BENCHMARK_SUITE(benchmark_manual, NULL, NULL);
+
+ZTEST_BENCHMARK_MANUAL(benchmark_manual, busy_wait_span, NUM_SAMPLES, NULL, NULL)
+{
+	/* Excluded from the measurement, to show that the brackets pick
+	 * out part of the body rather than all of it.
+	 */
+	k_busy_wait(BUSY_WAIT_US);
+
+	ztest_benchmark_start();
+	k_busy_wait(BUSY_WAIT_US);
+	ztest_benchmark_end();
+}
+
+static volatile timing_t isr_timestamp;
+
+static void offload_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	isr_timestamp = timing_counter_get();
+}
+
+ZTEST_BENCHMARK_MANUAL(benchmark_manual, isr_exit_span, NUM_SAMPLES, NULL, NULL)
+{
+	irq_offload(offload_isr, NULL);
+
+	ztest_benchmark_start_at(isr_timestamp);
+	ztest_benchmark_end();
+}

--- a/tests/ztest/benchmark_manual/tests.yaml
+++ b/tests/ztest/benchmark_manual/tests.yaml
@@ -1,0 +1,20 @@
+common:
+  tags:
+    - test_framework
+    - benchmark
+  # The framework's timed control benchmark spins until a deadline
+  # expires, and on a simulated target time does not advance while the
+  # CPU is busy, so it never returns. tests/benchmarks/memory_allocators
+  # excludes posix for the same reason.
+  arch_exclude:
+    - posix
+tests:
+  testing.ztest.benchmark_manual:
+    integration_platforms:
+      - qemu_x86
+      - qemu_cortex_a53
+  testing.ztest.benchmark_manual.csv:
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    integration_platforms:
+      - qemu_x86


### PR DESCRIPTION
Add a benchmark for the kernel operations an application uses
constantly: thread lifecycle and context switches, semaphores,
mutexes, FIFOs, LIFOs, stacks, events, condition variables and the
heap. It covers the same ground as latency_measure, which stays where
it is, but is built on the ztest benchmark framework rather than on a
harness of its own, so it gets percentiles, control-measurement
correction and twister-recordable output without providing them
itself.

output:


```
*** Booting Zephy�*** Booting Zephyr OS build v4.4.0-11887-gc7180db33540 ***
condvar ####################################################
signal_wake_switch =========================================
        Sample size:10000, total cycles: 19530059.000
        Mean(u): 1953.006
        Standard deviation(s): 0.604
        Outliers: 3 / 10000 (0.030%)
        Min: 1952.996 (run #1)
        Max: 2001.996 (run #7020)
        p50: 1952.996
        p90: 1952.996
        p99: 1952.996
        p99.9: 1952.996
        p99.99: 1977.996
        Cold: 2142.996, after 10 warmup iterations
events #####################################################
post =======================================================
        Sample size:10000, total cycles: 2869960.000
        Mean(u): 286.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 286.996 (run #1)
        Max: 286.996 (run #1)
        p50: 286.996
        p90: 286.996
        p99: 286.996
        p99.9: 286.996
        p99.99: 286.996
        Cold: 476.996, after 10 warmup iterations
wait_satisfied =============================================
        Sample size:10000, total cycles: 1729960.000
        Mean(u): 172.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 172.996 (run #1)
        Max: 172.996 (run #1)
        p50: 172.996
        p90: 172.996
        p99: 172.996
        p99.9: 172.996
        p99.99: 172.996
        Cold: 254.996, after 10 warmup iterations
post_wake_switch ===========================================
        Sample size:10000, total cycles: 7390619.000
        Mean(u): 739.062
        Standard deviation(s): 6.590
        Outliers: 1 / 10000 (0.010%)
        Min: 738.996 (run #1)
        Max: 1397.996 (run #6245)
        p50: 738.996
        p90: 738.996
        p99: 738.996
        p99.9: 738.996
        p99.99: 738.996
        Cold: 847.996, after 10 warmup iterations
fifo #######################################################
alloc_put ==================================================
        Sample size:10000, total cycles: 9621157.000
        Mean(u): 962.116
        Standard deviation(s): 8.625
        Outliers: 2 / 10000 (0.020%)
        Min: 961.996 (run #1)
        Max: 1677.996 (run #4226)
        p50: 961.996
        p90: 961.996
        p99: 961.996
        p99.9: 961.996
        p99.99: 1442.996
        Cold: 1335.996, after 10 warmup iterations
get ========================================================
        Sample size:10000, total cycles: 1329960.000
        Mean(u): 132.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 132.996 (run #1)
        Max: 132.996 (run #1)
        p50: 132.996
        p90: 132.996
        p99: 132.996
        p99.9: 132.996
        p99.99: 132.996
        Cold: 155.996, after 10 warmup iterations
get_after_alloc_put ========================================
        Sample size:10000, total cycles: 10670441.000
        Mean(u): 1067.044
        Standard deviation(s): 4.810
        Outliers: 1 / 10000 (0.010%)
        Min: 1066.996 (run #1)
        Max: 1547.996 (run #7697)
        p50: 1066.996
        p90: 1066.996
        p99: 1066.996
        p99.9: 1066.996
        p99.99: 1066.996
        Cold: 1226.996, after 10 warmup iterations
put ========================================================
        Sample size:10000, total cycles: 1749960.000
        Mean(u): 174.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 174.996 (run #1)
        Max: 174.996 (run #1)
        p50: 174.996
        p90: 174.996
        p99: 174.996
        p99.9: 174.996
        p99.99: 174.996
        Cold: 262.996, after 10 warmup iterations
put_wake_switch ============================================
        Sample size:10000, total cycles: 5590627.000
        Mean(u): 559.063
        Standard deviation(s): 6.670
        Outliers: 1 / 10000 (0.010%)
        Min: 558.996 (run #1)
        Max: 1225.996 (run #7552)
        p50: 558.996
        p90: 558.996
        p99: 558.996
        p99.9: 558.996
        p99.99: 558.996
        Cold: 639.996, after 10 warmup iterations
heap #######################################################
free =======================================================
        Sample size:10000, total cycles: 9350462.000
        Mean(u): 935.046
        Standard deviation(s): 5.020
        Outliers: 1 / 10000 (0.010%)
        Min: 934.996 (run #1)
        Max: 1436.996 (run #7297)
        p50: 934.996
        p90: 934.996
        p99: 934.996
        p99.9: 934.996
        p99.99: 934.996
        Cold: 1064.996, after 10 warmup iterations
malloc =====================================================
        Sample size:10000, total cycles: 7599960.000
        Mean(u): 759.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 759.996 (run #1)
        Max: 759.996 (run #1)
        p50: 759.996
        p90: 759.996
        p99: 759.996
        p99.9: 759.996
        p99.99: 759.996
        Cold: 999.996, after 10 warmup iterations
lifo #######################################################
get ========================================================
        Sample size:10000, total cycles: 1329960.000
        Mean(u): 132.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 132.996 (run #1)
        Max: 132.996 (run #1)
        p50: 132.996
        p90: 132.996
        p99: 132.996
        p99.9: 132.996
        p99.99: 132.996
        Cold: 174.996, after 10 warmup iterations
put ========================================================
        Sample size:10000, total cycles: 1739960.000
        Mean(u): 173.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 173.996 (run #1)
        Max: 173.996 (run #1)
        p50: 173.996
        p90: 173.996
        p99: 173.996
        p99.9: 173.996
        p99.99: 173.996
        Cold: 262.996, after 10 warmup iterations
mutex ######################################################
lock =======================================================
        Sample size:10000, total cycles: 1339960.000
        Mean(u): 133.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 133.996 (run #1)
        Max: 133.996 (run #1)
        p50: 133.996
        p90: 133.996
        p99: 133.996
        p99.9: 133.996
        p99.99: 133.996
        Cold: 213.996, after 10 warmup iterations
unlock =====================================================
        Sample size:10000, total cycles: 1509960.000
        Mean(u): 150.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 150.996 (run #1)
        Max: 150.996 (run #1)
        p50: 150.996
        p90: 150.996
        p99: 150.996
        p99.9: 150.996
        p99.99: 150.996
        Cold: 204.996, after 10 warmup iterations
semaphore ##################################################
give =======================================================
        Sample size:10000, total cycles: 1129960.000
        Mean(u): 112.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 112.996 (run #1)
        Max: 112.996 (run #1)
        p50: 112.996
        p90: 112.996
        p99: 112.996
        p99.9: 112.996
        p99.99: 112.996
        Cold: 168.996, after 10 warmup iterations
take =======================================================
        Sample size:10000, total cycles: 1229960.000
        Mean(u): 122.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 122.996 (run #1)
        Max: 122.996 (run #1)
        p50: 122.996
        p90: 122.996
        p99: 122.996
        p99.9: 122.996
        p99.99: 122.996
        Cold: 176.996, after 10 warmup iterations
give_wake_switch ===========================================
        Sample size:10000, total cycles: 5230675.000
        Mean(u): 523.068
        Standard deviation(s): 7.150
        Outliers: 1 / 10000 (0.010%)
        Min: 522.996 (run #1)
        Max: 1237.996 (run #4605)
        p50: 522.996
        p90: 522.996
        p99: 522.996
        p99.9: 522.996
        p99.99: 522.996
        Cold: 573.996, after 10 warmup iterations
stack ######################################################
pop ========================================================
        Sample size:10000, total cycles: 1399960.000
        Mean(u): 139.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 139.996 (run #1)
        Max: 139.996 (run #1)
        p50: 139.996
        p90: 139.996
        p99: 139.996
        p99.9: 139.996
        p99.99: 139.996
        Cold: 196.996, after 10 warmup iterations
push =======================================================
        Sample size:10000, total cycles: 1269960.000
        Mean(u): 126.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 126.996 (run #1)
        Max: 126.996 (run #1)
        p50: 126.996
        p90: 126.996
        p99: 126.996
        p99.9: 126.996
        p99.99: 126.996
        Cold: 180.996, after 10 warmup iterations
thread #####################################################
abort ======================================================
        Sample size:10000, total cycles: 3559960.000
        Mean(u): 355.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 355.996 (run #1)
        Max: 355.996 (run #1)
        p50: 355.996
        p90: 355.996
        p99: 355.996
        p99.9: 355.996
        p99.99: 355.996
        Cold: 529.996, after 10 warmup iterations
create =====================================================
        Sample size:10000, total cycles: 3029960.000
        Mean(u): 302.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 302.996 (run #1)
        Max: 302.996 (run #1)
        p50: 302.996
        p90: 302.996
        p99: 302.996
        p99.9: 302.996
        p99.99: 302.996
        Cold: 511.996, after 10 warmup iterations
resume =====================================================
        Sample size:10000, total cycles: 2059960.000
        Mean(u): 205.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 205.996 (run #1)
        Max: 205.996 (run #1)
        p50: 205.996
        p90: 205.996
        p99: 205.996
        p99.9: 205.996
        p99.99: 205.996
        Cold: 234.996, after 10 warmup iterations
start ======================================================
        Sample size:10000, total cycles: 3299960.000
        Mean(u): 329.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 329.996 (run #1)
        Max: 329.996 (run #1)
        p50: 329.996
        p90: 329.996
        p99: 329.996
        p99.9: 329.996
        p99.99: 329.996
        Cold: 529.996, after 10 warmup iterations
suspend ====================================================
        Sample size:10000, total cycles: 1929960.000
        Mean(u): 192.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 192.996 (run #1)
        Max: 192.996 (run #1)
        p50: 192.996
        p90: 192.996
        p99: 192.996
        p99.9: 192.996
        p99.99: 192.996
        Cold: 319.996, after 10 warmup iterations
yield_cooperative ==========================================
        Sample size:10000, total cycles: 3250692.000
        Mean(u): 325.069
        Standard deviation(s): 7.320
        Outliers: 1 / 10000 (0.010%)
        Min: 324.996 (run #1)
        Max: 1056.996 (run #5433)
        p50: 324.996
        p90: 324.996
        p99: 324.996
        p99.9: 324.996
        p99.99: 324.996
        Cold: 548.996, after 10 warmup iterations
yield_preemptive ===========================================
        Sample size:10000, total cycles: 3249960.000
        Mean(u): 324.996
        Standard deviation(s): 0.000
        Outliers: 0 / 10000 (0.000%)
        Min: 324.996 (run #1)
        Max: 324.996 (run #1)
        p50: 324.996
        p90: 324.996
        p99: 324.996
        p99.9: 324.996
        p99.99: 324.996
        Cold: 548.996, after 10 warmup iterations

------ TESTSUITE SUMMARY START ------

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

This PR is on top of https://github.com/zephyrproject-rtos/zephyr/pull/116347