### PR TITLE
boards: alif: add DesignWare I2C and mikroBUS Click support

### DIFF
--- a/boards/alif/balletto_b1_dk/Kconfig.defconfig
+++ b/boards/alif/balletto_b1_dk/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright Alif Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Default configurations applied to the B1 DK boards
+
+if BOARD_BALLETTO_B1_DK
+
+configdefault I2C_DW_CLOCK_SPEED
+	default 40
+
+endif # BOARD_BALLETTO_B1_DK

--- a/boards/alif/balletto_b1_dk/balletto_b1_dk-pinctrl.dtsi
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk-pinctrl.dtsi
@@ -16,4 +16,22 @@
 			pinmux = <PIN_P5_3__UART2_TX_B>;
 		};
 	};
+
+	pinctrl_i2c0: pinctrl_i2c0 {
+		group0 {
+			pinmux = <PIN_P7_0__I2C0_SDA_C>,
+				 <PIN_P7_1__I2C0_SCL_C>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
+
+	pinctrl_i2c1: pinctrl_i2c1 {
+		group0 {
+			pinmux = <PIN_P7_2__I2C1_SDA_C>,
+				 <PIN_P7_3__I2C1_SCL_C>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
 };

--- a/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
@@ -24,3 +24,11 @@
 	pinctrl-0 = <&pinctrl_uart2>;
 	pinctrl-names = "default";
 };
+
+&i2c1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	pinctrl-names = "default";
+};
+
+mikrobus_i2c: &i2c1 {};

--- a/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.yaml
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.yaml
@@ -8,3 +8,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e1c_dk/Kconfig.defconfig
+++ b/boards/alif/ensemble_e1c_dk/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright Alif Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Default configurations applied to the E1C DK boards
+
+if BOARD_ENSEMBLE_E1C_DK
+
+configdefault I2C_DW_CLOCK_SPEED
+	default 40
+
+endif # BOARD_ENSEMBLE_E1C_DK

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk-pinctrl.dtsi
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk-pinctrl.dtsi
@@ -16,4 +16,22 @@
 			pinmux = <PIN_P5_3__UART2_TX_B>;
 		};
 	};
+
+	pinctrl_i2c0: pinctrl_i2c0 {
+		group0 {
+			pinmux = <PIN_P7_0__I2C0_SDA_C>,
+				 <PIN_P7_1__I2C0_SCL_C>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
+
+	pinctrl_i2c1: pinctrl_i2c1 {
+		group0 {
+			pinmux = <PIN_P7_2__I2C1_SDA_C>,
+				 <PIN_P7_3__I2C1_SCL_C>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
 };

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
@@ -25,3 +25,11 @@
 	pinctrl-0 = <&pinctrl_uart2>;
 	pinctrl-names = "default";
 };
+
+&i2c1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	pinctrl-names = "default";
+};
+
+mikrobus_i2c: &i2c1 {};

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.yaml
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.yaml
@@ -8,3 +8,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/Kconfig.defconfig
+++ b/boards/alif/ensemble_e8_dk/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright Alif Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Default configurations applied to the E8 DK boards
+
+if BOARD_ENSEMBLE_E8_DK
+
+configdefault I2C_DW_CLOCK_SPEED
+	default 100
+
+endif # BOARD_ENSEMBLE_E8_DK

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
@@ -94,4 +94,40 @@
 			pinmux = <PIN_P9_4__UART7_TX_B>;
 		};
 	};
+
+	pinctrl_i2c0: pinctrl_i2c0 {
+		group0 {
+			pinmux = <PIN_P3_5__I2C0_SDA_B>,
+				 <PIN_P3_4__I2C0_SCL_B>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
+
+	pinctrl_i2c1: pinctrl_i2c1 {
+		group0 {
+			pinmux = <PIN_P7_2__I2C1_SDA_C>,
+				 <PIN_P7_3__I2C1_SCL_C>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
+
+	pinctrl_i2c2: pinctrl_i2c2 {
+		group0 {
+			pinmux = <PIN_P0_7__I2C2_SDA_A>,
+				 <PIN_P0_6__I2C2_SCL_A>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
+
+	pinctrl_i2c3: pinctrl_i2c3 {
+		group0 {
+			pinmux = <PIN_P9_6__I2C3_SDA_B>,
+				 <PIN_P9_7__I2C3_SCL_B>;
+			input-enable;
+			drive-strength = <12>;
+		};
+	};
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
@@ -9,6 +9,7 @@
 #include <alif/ensemble/ae402fa0e5597le0_nvic_irq.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_he.dtsi>
 #include "ensemble_e8_dk-pinctrl.dtsi"
+#include "ensemble_e8_dk_common.dtsi"
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae402fa0e5597le0-rtss-he";

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.yaml
@@ -8,3 +8,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
@@ -9,6 +9,7 @@
 #include <alif/ensemble/ae402fa0e5597le0_nvic_irq.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_hp.dtsi>
 #include "ensemble_e8_dk-pinctrl.dtsi"
+#include "ensemble_e8_dk_common.dtsi"
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae402fa0e5597le0-rtss-hp";

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.yaml
@@ -8,3 +8,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
@@ -9,6 +9,7 @@
 #include <alif/ensemble/ae612fa0e5597ls0_nvic_irq.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_he.dtsi>
 #include "ensemble_e8_dk-pinctrl.dtsi"
+#include "ensemble_e8_dk_common.dtsi"
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae612fa0e5597ls0-rtss-he";

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.yaml
@@ -8,3 +8,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
@@ -9,6 +9,7 @@
 #include <alif/ensemble/ae612fa0e5597ls0_nvic_irq.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_hp.dtsi>
 #include "ensemble_e8_dk-pinctrl.dtsi"
+#include "ensemble_e8_dk_common.dtsi"
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae612fa0e5597ls0-rtss-hp";

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.yaml
@@ -8,3 +8,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.dts
@@ -9,6 +9,7 @@
 #include <alif/ensemble/ae822fa0e5597ls0_gic_irq.dtsi>
 #include <alif/ensemble/common/ensemble_apss.dtsi>
 #include "ensemble_e8_dk-pinctrl.dtsi"
+#include "ensemble_e8_dk_common.dtsi"
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae822fa0e5597ls0-apss";

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.yaml
@@ -8,3 +8,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
@@ -10,6 +10,7 @@
 #include <alif/ensemble/ae822fa0e5597ls0_nvic_irq.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_he.dtsi>
 #include "ensemble_e8_dk-pinctrl.dtsi"
+#include "ensemble_e8_dk_common.dtsi"
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae822fa0e5597ls0-rtss-he";

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.yaml
@@ -9,3 +9,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
@@ -10,6 +10,7 @@
 #include <alif/ensemble/ae822fa0e5597ls0_nvic_irq.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_hp.dtsi>
 #include "ensemble_e8_dk-pinctrl.dtsi"
+#include "ensemble_e8_dk_common.dtsi"
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae822fa0e5597ls0-rtss-hp";

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.yaml
@@ -9,3 +9,5 @@ arch: arm
 vendor: alif
 toolchain:
   - zephyr
+supported:
+  - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_common.dtsi
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_common.dtsi
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * On-board peripherals shared by every ensemble_e8_dk board target. Include
+ * this after the SoC dtsi, the cluster dtsi and the board pinctrl dtsi: every
+ * node referenced below comes from one of those.
+ */
+
+&i2c0 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_i2c0>;
+	pinctrl-names = "default";
+};
+
+mikrobus_i2c: &i2c0 {};

--- a/dts/arm/alif/balletto/common/balletto_common.dtsi
+++ b/dts/arm/alif/balletto/common/balletto_common.dtsi
@@ -8,6 +8,7 @@
 #include <mem.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/clock/alif-balletto-clocks.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -149,6 +150,42 @@
 			interrupts = <129 0>;
 			reg-shift = <2>;
 			current-speed = <115200>;
+			status = "disabled";
+		};
+
+		/*
+		 * DesignWare I2C controllers.
+		 * hcnt-offset / lcnt-offset are the tuning offsets applied on top
+		 * of the values computed from the input clock and target speed.
+		 * Verify against the target board layout and adjust per instance if needed.
+		 */
+		i2c0: i2c@49010000 {
+			compatible = "snps,designware-i2c";
+			clocks = <&clockctrl ALIF_I2C0_SYST_PCLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			hcnt-offset = <0>;
+			lcnt-offset = <0>;
+			fs-spike-len = <5>;
+			hs-spike-len = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <132 0>;
+			reg = <0x49010000 0x1000>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@49011000 {
+			compatible = "snps,designware-i2c";
+			clocks = <&clockctrl ALIF_I2C1_SYST_PCLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			hcnt-offset = <0>;
+			lcnt-offset = <0>;
+			fs-spike-len = <5>;
+			hs-spike-len = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <133 0>;
+			reg = <0x49011000 0x1000>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/alif/ensemble/common/ensemble_common.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_common.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/clock/alif-ensemble-clocks.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 /*
  * Interrupt routing for the peripherals defined here is intentionally kept
@@ -216,6 +217,40 @@
 			ngpios = <2>;
 			gpio-controller;
 			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		/*
+		 * DesignWare I2C controllers.
+		 * hcnt-offset / lcnt-offset are the tuning offsets applied on top
+		 * of the values computed from the input clock and target speed.
+		 * Verify against the target board layout and adjust per instance if needed.
+		 */
+		i2c0: i2c@49010000 {
+			compatible = "snps,designware-i2c";
+			clocks = <&clockctrl ALIF_I2C0_SYST_PCLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			hcnt-offset = <0>;
+			lcnt-offset = <0>;
+			fs-spike-len = <5>;
+			hs-spike-len = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x49010000 0x1000>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@49011000 {
+			compatible = "snps,designware-i2c";
+			clocks = <&clockctrl ALIF_I2C1_SYST_PCLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			hcnt-offset = <0>;
+			lcnt-offset = <0>;
+			fs-spike-len = <5>;
+			hs-spike-len = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x49011000 0x1000>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/alif/ensemble/common/ensemble_common_gic_irq.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_common_gic_irq.dtsi
@@ -154,3 +154,13 @@
 		     <GIC_SPI 238 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 		     <GIC_SPI 239 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 };
+
+&i2c0 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 121 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};
+
+&i2c1 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 122 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};

--- a/dts/arm/alif/ensemble/common/ensemble_common_nvic_irq.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_common_nvic_irq.dtsi
@@ -151,3 +151,13 @@
 		     <249 0>,
 		     <250 0>;
 };
+
+&i2c0 {
+	interrupt-parent = <&nvic>;
+	interrupts = <132 0>;
+};
+
+&i2c1 {
+	interrupt-parent = <&nvic>;
+	interrupts = <133 0>;
+};

--- a/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8.dtsi
@@ -84,6 +84,40 @@
 		#gpio-cells = <2>;
 		status = "disabled";
 	};
+
+	/*
+	 * DesignWare I2C controllers.
+	 * hcnt-offset / lcnt-offset are the tuning offsets applied on top
+	 * of the values computed from the input clock and target speed.
+	 * Verify against the target board layout and adjust per instance if needed.
+	 */
+	i2c2: i2c@49012000 {
+		compatible = "snps,designware-i2c";
+		clocks = <&clockctrl ALIF_I2C2_SYST_PCLK>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		hcnt-offset = <0>;
+		lcnt-offset = <0>;
+		fs-spike-len = <5>;
+		hs-spike-len = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x49012000 0x1000>;
+		status = "disabled";
+	};
+
+	i2c3: i2c@49013000 {
+		compatible = "snps,designware-i2c";
+		clocks = <&clockctrl ALIF_I2C3_SYST_PCLK>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		hcnt-offset = <0>;
+		lcnt-offset = <0>;
+		fs-spike-len = <5>;
+		hs-spike-len = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x49013000 0x1000>;
+		status = "disabled";
+	};
 };
 
 /* These devices carry the full eight pin wide LPGPIO. */

--- a/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_gic_irq.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_gic_irq.dtsi
@@ -103,3 +103,13 @@
 		     <GIC_SPI 286 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 		     <GIC_SPI 287 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 };
+
+&i2c2 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 123 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};
+
+&i2c3 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 124 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};

--- a/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_nvic_irq.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_e4_e6_e8_nvic_irq.dtsi
@@ -103,3 +103,13 @@
 		     <297 0>,
 		     <298 0>;
 };
+
+&i2c2 {
+	interrupt-parent = <&nvic>;
+	interrupts = <134 0>;
+};
+
+&i2c3 {
+	interrupt-parent = <&nvic>;
+	interrupts = <135 0>;
+};

--- a/include/zephyr/dt-bindings/clock/alif-balletto-clocks.h
+++ b/include/zephyr/dt-bindings/clock/alif-balletto-clocks.h
@@ -24,6 +24,12 @@
 /** UART control register offset in CLKCTL_PER_SLV */
 #define ALIF_UART_CTRL_REG		0x08U
 
+/** I2C0 control register offset in CLKCTL_PER_SLV */
+#define ALIF_I2C0_CTRL_REG		0x50U
+
+/** I2C1 control register offset in CLKCTL_PER_SLV */
+#define ALIF_I2C1_CTRL_REG		0x54U
+
 /** @} */
 
 /**
@@ -50,6 +56,12 @@
 #define ALIF_UART5_SYST_PCLK        \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, UART_CTRL, 5U, 1U, 1U, 1U, 13U, ALIF_PARENT_CLK_SYST_PCLK)
 
+/** I2C0 clock sourced from system PCLK */
+#define ALIF_I2C0_SYST_PCLK         \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C0_CTRL, 0U, 1U, 0U, 0U, 0U, ALIF_PARENT_CLK_SYST_PCLK)
+/** I2C1 clock sourced from system PCLK */
+#define ALIF_I2C1_SYST_PCLK         \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C1_CTRL, 0U, 1U, 0U, 0U, 0U, ALIF_PARENT_CLK_SYST_PCLK)
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ALIF_BALLETTO_CLOCKS_H_ */

--- a/include/zephyr/dt-bindings/clock/alif-ensemble-clocks.h
+++ b/include/zephyr/dt-bindings/clock/alif-ensemble-clocks.h
@@ -25,6 +25,15 @@
 /** UART control register offset in CLKCTL_PER_SLV */
 #define ALIF_UART_CTRL_REG		0x08U
 
+/** I2C0 control register offset in CLKCTL_PER_SLV */
+#define ALIF_I2C0_CTRL_REG		0x50U
+/** I2C1 control register offset in CLKCTL_PER_SLV */
+#define ALIF_I2C1_CTRL_REG		0x54U
+/** I2C2 control register offset in CLKCTL_PER_SLV */
+#define ALIF_I2C2_CTRL_REG		0x58U
+/** I2C3 control register offset in CLKCTL_PER_SLV */
+#define ALIF_I2C3_CTRL_REG		0x5CU
+
 /** @} */
 
 /**
@@ -56,7 +65,18 @@
 /** UART7 clock sourced from system PCLK */
 #define ALIF_UART7_SYST_PCLK        \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, UART_CTRL, 7U, 1U, 1U, 1U, 15U, ALIF_PARENT_CLK_SYST_PCLK)
-
+/** I2C0 clock sourced from system PCLK */
+#define ALIF_I2C0_SYST_PCLK         \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C0_CTRL, 0U, 1U, 0U, 0U, 0U, ALIF_PARENT_CLK_SYST_PCLK)
+/** I2C1 clock sourced from system PCLK */
+#define ALIF_I2C1_SYST_PCLK         \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C1_CTRL, 0U, 1U, 0U, 0U, 0U, ALIF_PARENT_CLK_SYST_PCLK)
+/** I2C2 clock sourced from system PCLK */
+#define ALIF_I2C2_SYST_PCLK         \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C2_CTRL, 0U, 1U, 0U, 0U, 0U, ALIF_PARENT_CLK_SYST_PCLK)
+/** I2C3 clock sourced from system PCLK */
+#define ALIF_I2C3_SYST_PCLK         \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C3_CTRL, 0U, 1U, 0U, 0U, 0U, ALIF_PARENT_CLK_SYST_PCLK)
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ALIF_ENSEMBLE_CLOCKS_H_ */

--- a/soc/alif/balletto/Kconfig.defconfig
+++ b/soc/alif/balletto/Kconfig.defconfig
@@ -15,4 +15,7 @@ configdefault CLOCK_CONTROL
 configdefault CACHE_MANAGEMENT
 	default y
 
+configdefault I2C_DW_IC_CLK_FREQ_OPTIMIZATION
+	default y
+
 endif # SOC_FAMILY_BALLETTO

--- a/soc/alif/ensemble/Kconfig.defconfig
+++ b/soc/alif/ensemble/Kconfig.defconfig
@@ -15,4 +15,7 @@ config CLOCK_CONTROL
 configdefault CACHE_MANAGEMENT
 	default y
 
+configdefault I2C_DW_IC_CLK_FREQ_OPTIMIZATION
+	default y
+
 endif # SOC_FAMILY_ENSEMBLE


### PR DESCRIPTION
## Summary
Enable I2C on Alif Balletto and Ensemble development kits by wiring
the existing upstream DesignWare I2C driver (`snps,designware-i2c` /
`I2C_DW`)

Also expose `mikrobus_i2c` on E8 DK, E1C DK, and Balletto B1 DK so
standard mikroBUS Click shields (e.g. Mikroe Weather Click / BME280)
work with `--shield` and without board-specific sample overlays.

## Commits breakdown:

1. **`include: dt-bindings: clock: alif: add i2c clock IDs`**
   Adds CLKCTL_PER_SLV I2C clock macros (`ALIF_I2Cx_SYST_PCLK`) for
   Balletto (I2C0/I2C1) and Ensemble (I2C0–I2C3), so DT nodes can
   reference the existing `alif,clockctrl` binding.

2. **`dts: arm: alif: add designWare i2c devicetree nodes`**
   Describes Alif I2C controllers as disabled `snps,designware-i2c`
   nodes (reg, clocks, IRQs for NVIC/GIC, timing defaults). Boards
   enable the instances they need; the upstream `I2C_DW` driver binds
   them.

3. **`soc: alif: enable designWare i2c clock optimization`**
   Defaults `I2C_DW_IC_CLK_FREQ_OPTIMIZATION` for Balletto and Ensemble
   so SCL timing is calculated correctly for these SYST_PCLK-fed I2C
   blocks.
4. **`boards: alif: wire i2c pinctrl and dw clock speed for devkits`**
   Adds board I2C pinmux (E8 / E1C / B1) and sets `I2C_DW_CLOCK_SPEED`
   to match each board’s controller input clock (100 MHz on E8 DK,
   40 MHz on E1C DK and Balletto B1 DK).
5. **`boards: alif: ensemble_e8_dk: add mikrobus i2c connector support`**
   Adds shared `ensemble_e8_dk_common.dtsi` with `mikrobus_i2c` →
   `i2c0` (click-header I2C) and includes it from all E8 DK targets.
6. **`boards: alif: ensemble_e1c_dk: add mikrobus i2c connector support`**
   Exposes `mikrobus_i2c` → `i2c1` on Ensemble E1C DK for Click
   shields.
7. **`boards: alif: balletto_b1_dk: add mikrobus i2c connector support`**
   Exposes `mikrobus_i2c` → `i2c1` on Balletto B1 DK for Click
   shields.

## Hardware notes (mikroBUS Click)
Click I/O voltage must be **3.3 V** on the devkits:

|          Board           | Jumper | Setting |
|---------------------|---------|---------|
| Ensemble E8 DK   | **JP7** | 3.3 V |
| Ensemble E1C DK | **JP9** | 3.3 V |
| Balletto B1 DK      | **JP9** | 3.3 V |

Incorrect voltage (Connector I/O Voltage) can prevent Click devices from enumerating or can
damage 3.3 V-only modules.

## Example usage

```bash
west build -b ensemble_e8_dk/ae822fa0e5597ls0/rtss_hp \
  samples/sensor/bme280 --shield mikroe_weather_click_i2c

west build -b ensemble_e1c_dk/ae1c1f4051920ph0/rtss_he \
  samples/sensor/bme280 --shield mikroe_weather_click_i2c

west build -b balletto_b1_dk/ab1c1f4m51820ph0 \
  samples/sensor/bme280 --shield mikroe_weather_click_i2c