### PR TITLE
Bluetooth: CAP: Fix bug in cap_to_bap_unicast_params.stream_params

### DIFF
--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1006,8 +1006,7 @@ bool bt_cap_initiator_valid_unicast_group_param(const struct bt_cap_unicast_grou
 
 struct cap_to_bap_unicast_params {
 	struct bt_bap_unicast_group_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
-			      CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
+		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT * 2U];
 	struct bt_bap_unicast_group_stream_pair_param
 		pair_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_bap_unicast_group_param group_param;


### PR DESCRIPTION
BAP_UNICAST_CLIENT_ASE counts are per connection, and not reflect the actual number of streams that may exist in a group. Changed to use CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT which does reflect that exactly.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116732