### PR TITLE
driver: usb: uhc_dwc2: use generic base getter in suspend/resume

### DIFF
--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -609,8 +609,7 @@ static int port_reset(const struct device *dev)
 
 static int port_suspend(const struct device *const dev)
 {
-	const struct uhc_dwc2_config *const config = dev->config;
-	struct usb_dwc2_reg *const base = config->base;
+	struct usb_dwc2_reg *const base = uhc_dwc2_get_base(dev);
 	uint32_t hprt;
 
 	hprt = sys_read32((mem_addr_t)&base->hprt);
@@ -644,8 +643,7 @@ static int port_suspend(const struct device *const dev)
 
 static int port_resume(const struct device *const dev)
 {
-	const struct uhc_dwc2_config *const config = dev->config;
-	struct usb_dwc2_reg *const base = config->base;
+	struct usb_dwc2_reg *const base = uhc_dwc2_get_base(dev);
 	enum uhc_event_type type;
 	uint32_t hprt;
 	int ret;
@@ -1930,9 +1928,8 @@ static int uhc_dwc2_sof_enable(const struct device *const dev)
 
 static int uhc_dwc2_bus_suspend(const struct device *const dev)
 {
-	const struct uhc_dwc2_config *const config = dev->config;
 	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
-	struct usb_dwc2_reg *const base = config->base;
+	struct usb_dwc2_reg *const base = uhc_dwc2_get_base(dev);
 	uint32_t hprt;
 
 	hprt = sys_read32((mem_addr_t)&base->hprt);


### PR DESCRIPTION
### Description

The `uhc_dwc2_get_base()` was introduced during the MMIO introduction and the suspend/wakeup logic was not rebased on the last changes.
This PR changes the way of obtaining the dwc2 base in port suspend/wakeup from the helper function instead of direct `config->base` member access.

### Relates

- #112766
- #113597 