### PR TITLE
arch/x86: x86_64: Fix generated include

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -15,7 +15,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/kernel/mm.h>
 #ifdef CONFIG_HW_SHADOW_STACK
-#include <x86_shstk.h>
+#include <zephyr/x86_shstk.h>
 #endif
 
 /*


### PR DESCRIPTION
Commit d78bf6c16580 ("kconfig: Deprecate LEGACY_GENERATED_INCLUDE_PATH") made it mandatory that generated includes need to include the "zephyr" namespace, which was missed for a shadow stack related include on `locore.S`.