### PR TITLE
drivers: counter: max32_rtc: Support external clock input

### DIFF
--- a/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
@@ -102,13 +102,8 @@
 	};
 };
 
-&wut0 {
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
-};
-
 &wut1 {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 	wakeup-source;
 
 	counter_wut1: counter {

--- a/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
@@ -56,8 +56,17 @@
 	status = "okay";
 };
 
+&clk_inro {
+	status = "okay";
+};
+
 &clk_ipo {
 	status = "okay";
+};
+
+&clk_32k {
+	status = "okay";
+	clocks = <&clk_inro>;
 };
 
 &gpio0 {
@@ -76,7 +85,6 @@
 
 &rtc_counter {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 };
 
 &i3c0 {

--- a/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
@@ -102,13 +102,8 @@
 	};
 };
 
-&wut0 {
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
-};
-
 &wut1 {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 	wakeup-source;
 
 	counter_wut1: counter {

--- a/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
@@ -56,8 +56,17 @@
 	status = "okay";
 };
 
+&clk_inro {
+	status = "okay";
+};
+
 &clk_ipo {
 	status = "okay";
+};
+
+&clk_32k {
+	status = "okay";
+	clocks = <&clk_inro>;
 };
 
 &gpio0 {
@@ -76,7 +85,6 @@
 
 &rtc_counter {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 };
 
 &i3c0 {

--- a/drivers/clock_control/clock_control_max32.c
+++ b/drivers/clock_control/clock_control_max32.c
@@ -1,15 +1,22 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/adi_max32_clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #include <wrap_max32_sys.h>
 
 #define DT_DRV_COMPAT adi_max32_gcr
+
+#define MAX32_32K_CLK_CTLR DT_CLOCKS_CTLR_BY_IDX(DT_NODELABEL(clk_32k), 0)
+
+struct max32_clock_config {
+	const struct pinctrl_dev_config *pctrl_rtc_in;
+};
 
 static inline int api_on(const struct device *dev, clock_control_subsys_t clkcfg)
 {
@@ -141,14 +148,30 @@ static void setup_fixed_clocks(void)
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_extclk), fixed_clock, okay)
 	MXC_SYS_ClockSourceEnable(ADI_MAX32_CLK_EXTCLK);
 #endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(clk_32k))
+#if DT_SAME_NODE(MAX32_32K_CLK_CTLR, DT_NODELABEL(clk_ertco))
+	Wrap_MXC_SYS_Select32KClockSource(ADI_MAX32_PRPH_CLK_SRC_ERTCO);
+#elif DT_SAME_NODE(MAX32_32K_CLK_CTLR, DT_NODELABEL(clk_inro))
+	Wrap_MXC_SYS_Select32KClockSource(ADI_MAX32_PRPH_CLK_SRC_INRO);
+#elif DT_SAME_NODE(MAX32_32K_CLK_CTLR, DT_NODELABEL(clk_rtc_in))
+	Wrap_MXC_SYS_Select32KClockSource(ADI_MAX32_PRPH_CLK_SRC_EXTCLK);
+#else
+#error "32K clock source is not supported by this SoC"
+#endif
+#endif
 }
 
 static int max32_clkctrl_init(const struct device *dev)
 {
-	ARG_UNUSED(dev);
+	const struct max32_clock_config *cfg = dev->config;
 
 	/* Setup fixed clocks if enabled */
 	setup_fixed_clocks();
+
+	if (cfg->pctrl_rtc_in) {
+		pinctrl_apply_state(cfg->pctrl_rtc_in, PINCTRL_STATE_DEFAULT);
+	}
 
 	/* Setup device clock source */
 	MXC_SYS_Clock_Select(ADI_MAX32_SYSCLK_SRC);
@@ -161,5 +184,16 @@ static int max32_clkctrl_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, max32_clkctrl_init, NULL, NULL, NULL, PRE_KERNEL_1,
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(clk_rtc_in))
+PINCTRL_DT_DEFINE(DT_NODELABEL(clk_rtc_in));
+#define PINCTRL_RTC_IN PINCTRL_DT_DEV_CONFIG_GET(DT_NODELABEL(clk_rtc_in))
+#else
+#define PINCTRL_RTC_IN NULL
+#endif
+
+static const struct max32_clock_config max32_clkctrl_config = {
+	.pctrl_rtc_in = PINCTRL_RTC_IN,
+};
+
+DEVICE_DT_INST_DEFINE(0, max32_clkctrl_init, NULL, NULL, &max32_clkctrl_config, PRE_KERNEL_1,
 		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &max32_clkctrl_api);

--- a/drivers/counter/counter_max32_rtc.c
+++ b/drivers/counter/counter_max32_rtc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -215,7 +215,7 @@ static int rtc_max32_init(const struct device *dev)
 	int ret;
 	const struct max32_rtc_config *cfg = dev->config;
 
-	while ((ret = Wrap_MXC_RTC_Init(0, 0, cfg->perclk.clk_src)) != E_SUCCESS) {
+	while ((ret = Wrap_MXC_RTC_Init(0, 0, 0)) != E_SUCCESS) {
 		if (ret < 0) {
 			LOG_ERR("RTC does not support this clock source.");
 			return -ENOTSUP;
@@ -261,8 +261,6 @@ static DEVICE_API(counter, counter_rtc_max32_driver_api) = {
 			},                                                                         \
 		.regs = (mxc_rtc_regs_t *)DT_INST_REG_ADDR(_num),                                  \
 		.irq_func = max32_rtc_irq_init_##_num,                                             \
-		.perclk.clk_src =                                                                  \
-			DT_INST_PROP_OR(_num, clock_source, ADI_MAX32_PRPH_CLK_SRC_ERTCO),         \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(_num, &rtc_max32_init, NULL, &rtc_max32_data_##_num,                 \

--- a/drivers/counter/counter_max32_wut.c
+++ b/drivers/counter/counter_max32_wut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,7 +33,6 @@ struct max32_wut_data {
 struct max32_wut_config {
 	struct counter_config_info info;
 	mxc_wut_regs_t *regs;
-	int clock_source;
 	int prescaler;
 	void (*irq_config)(const struct device *dev);
 	uint32_t irq_number;
@@ -234,8 +233,6 @@ static int counter_max32_wut_init(const struct device *dev)
 	mxc_wut_pres_t pres;
 	mxc_wut_cfg_t wut_cfg;
 
-	Wrap_MXC_SYS_Select32KClockSource(cfg->clock_source);
-
 	counter_max32_wut_hw_init(dev);
 
 	prescaler_lo = FIELD_GET(GENMASK(2, 0), LOG2(cfg->prescaler));
@@ -288,8 +285,6 @@ static DEVICE_API(counter, counter_max32_wut_driver_api) = {
 				.channels = 1,                                                     \
 			},                                                                         \
 		.regs = (mxc_wut_regs_t *)DT_REG_ADDR(TIMER(_num)),                                \
-		.clock_source =                                                                    \
-			DT_PROP_OR(TIMER(_num), clock_source, ADI_MAX32_PRPH_CLK_SRC_ERTCO),       \
 		.prescaler = DT_PROP(TIMER(_num), prescaler),                                      \
 		.irq_config = max32_wut_irq_init_##_num,                                           \
 		.irq_number = DT_IRQN(TIMER(_num)),                                                \

--- a/dts/arm/adi/max32/max32657-pinctrl.dtsi
+++ b/dts/arm/adi/max32/max32657-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,6 +45,11 @@
 
 	/omit-if-no-ref/ uart0_tx_p0_9: uart0_tx_p0_9 {
 		pinmux = <MAX32_PINMUX(0, 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ rtc_clk_in_p0_12: rtc_clk_in_p0_12 {
+		pinmux = <MAX32_PINMUX(0, 12, GPIO)>;
+		input-enable;
 	};
 
 	/omit-if-no-ref/ sqwout_p0_13: sqwout_p0_13 {
@@ -153,6 +158,12 @@
 
 	/omit-if-no-ref/ uart0_tx_p0_9_sleep: uart0_tx_p0_9_sleep {
 		pinmux = <MAX32_PINMUX(0, 9, AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ rtc_clk_in_p0_12_sleep: rtc_clk_in_p0_12_sleep {
+		pinmux = <MAX32_PINMUX(0, 12, GPIO)>;
+		input-enable;
 		low-power-enable;
 	};
 

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -80,7 +80,7 @@
 		clk_inro: clk_inro {
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(8)>;
+			clock-frequency = <DT_FREQ_K(131)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -102,6 +102,21 @@
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(32)>;
+			status = "disabled";
+		};
+
+		clk_rtc_in: clk_rtc_in {
+			compatible = "adi,max32-extclk";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_K(32768)>;
+			status = "disabled";
+		};
+
+		clk_32k: clk_32k {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <32768>;
+			clocks = <&clk_ertco>;
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/clock/adi,max32-extclk.yaml
+++ b/dts/bindings/clock/adi,max32-extclk.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Analog Device MAX32 External Clock
+
+compatible: "adi,max32-extclk"
+
+include: [fixed-clock.yaml, pinctrl-device.yaml]

--- a/dts/bindings/counter/adi,max32-rtc-counter.yaml
+++ b/dts/bindings/counter/adi,max32-rtc-counter.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,14 +11,3 @@ include: [base.yaml]
 properties:
   reg:
     required: true
-
-  clock-source:
-    type: int
-    enum: [4, 5]
-    description: |
-      Clock source to be used by the RTC peripheral. The following options
-      are available:
-      - 4: "ADI_MAX32_PRPH_CLK_SRC_ERTCO" External Real-Time Clock Oscillator
-      - 5: "ADI_MAX32_PRPH_CLK_SRC_INRO" Internal Ring Oscillator
-      The target device might not support all option please take a look on
-      target device user guide


### PR DESCRIPTION
Support for external clock input to 32kHz clock source.