### PR TITLE
drivers: timer: xtensa_sys_timer: write the compare under the clock lock

### DIFF
--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -81,6 +81,8 @@ static void ccompare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
+	k_spinlock_key_t key = sys_clock_lock();
+
 	/* Disarm the IRQ. Writing CCOMPARE is what clears the pending timer
 	 * interrupt, and the match is on equality, so a compare one behind the
 	 * current count both acknowledges it and puts the next match a whole
@@ -90,7 +92,7 @@ static void ccompare_isr(const void *arg)
 	 */
 	set_ccompare(ccount_raw() - 1);
 
-	timer_core_announce();
+	timer_core_announce_from(key);
 }
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
Follow-up to 2f017912e25d.

The core reaches every comparator write through `sys_clock_set_timeout()`,
which asserts the clock lock is held. The disarm added to the ISR is the one
write outside it, and an interrupt arming a deadline in that window has it
discarded.

Build-tested on esp32_devkitc and esp32s3_devkitm; no emulated Xtensa platform
to run it on.
