### PR TITLE
tests: drivers: comparator: enable hysteresis on pse84 lpcomp loopback

### DIFF
--- a/tests/drivers/comparator/gpio_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/kit_pse84_eval_common.overlay
@@ -28,6 +28,8 @@
 	status = "okay";
 	output-mode = "direct";
 	power = "ulp";
+	/* Reject glitches when the slow ULP comparator crosses local_vref. */
+	hysteresis;
 	intr-type = "both";
 	input-p = "gpio";
 	input-n = "local_vref";


### PR DESCRIPTION
The kit_pse84_eval low-power comparator loopback test drives the comparator in
ULP mode against the local VREF with hysteresis disabled. On some boards the
slow ULP comparator glitches as the GPIO loopback edge crosses VREF, latching a
spurious falling-edge event and intermittently failing
`test_trigger_falling_edge_pending`.

Enable hysteresis on the comparator channel to reject the near-threshold
glitches. Verified on kit_pse84_eval/m55 hardware: the previously failing
`drivers.infineon_lpcomp` scenario now passes reliably (full suite 6/6 plus a
20x reset soak), with no regression on boards that already passed.