### PR TITLE
tests: drivers: reset: mmio: keep the fake registers out of kernel RAM

### DIFF
--- a/tests/drivers/reset/mmio/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/reset/mmio/boards/qemu_cortex_m3.overlay
@@ -1,13 +1,22 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram0 {
+	reg = <0x20000000 0xfc00>;
+};
+
 / {
-	reset0: reset@20000004 {
+	reset0: reset@2000fc00 {
 		compatible = "reset-mmio";
-		reg = <0x20000004 0x4>;
+		reg = <0x2000fc00 0x4>;
 		num-resets = <16>;
 	};
 
-	reset1: reset@20000008 {
+	reset1: reset@2000fc04 {
 		compatible = "reset-mmio";
-		reg = <0x20000008 0x4>;
+		reg = <0x2000fc04 0x4>;
 		num-resets = <16>;
 		active-low;
 	};


### PR DESCRIPTION
The qemu_cortex_m3 overlay placed the fake reset-mmio registers at
0x20000004/0x20000008, inside the SRAM the kernel links into. The
words they occupy are owned by whatever .data the linker places at
the start of RAM, so every write through the reset driver corrupts
live kernel state, and the test only ever passed by layout luck.

A recent timer-core change added an 8-byte .data variable that landed
at 0x20000000, which pushed libc's _char_out console output function
pointer to exactly 0x20000008: the active-low test case then wrote
its register patterns over the pointer, console output jumped through
the corrupted value into a HardFault, the fault handler's own print
re-took the fault, and QEMU stopped with "Lockup: can't escalate 3 to
HardFault". Any future .data layout change could break this test the
same way.

Shrink the kernel's view of the 64 KiB SRAM by one KiB in the overlay
and move the fake registers into the carved-out tail, so no linker
layout can ever place kernel data under them.

