### PR TITLE
net: quic: initialize endpoint mutexes in test harness reset

### DIFF
--- a/tests/net/lib/quic/src/main.c
+++ b/tests/net/lib/quic/src/main.c
@@ -177,6 +177,8 @@ static struct quic_endpoint *reset_test_ep(struct quic_endpoint *ep)
 	memset(ep, 0, sizeof(*ep));
 	ep->sock = -1;
 	quic_recovery_init(ep);
+	k_mutex_init(&ep->pending.lock);
+	k_mutex_init(&ep->send_lock);
 
 	return ep;
 }


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/108619 introduced assertions on uninitialized mutexes, uncovering a gap in the QUIC test harness's `reset_test_ep()`, which only initializes `recovery.lock` and leaves `pending.lock` and `send_lock` zeroed. This trips the same assertions in `net.quic` and `net.quic.0rtt`.

Initialize both remaining mutexes in `reset_test_ep()`, matching production `quic_endpoint_init()`.