### PR TITLE
net: dns: dispatcher: wait for in-flight dispatch in unregister

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -429,5 +429,15 @@ int dns_dispatcher_unregister(struct dns_socket_dispatcher *ctx)
 out:
 	k_mutex_unlock(&lock);
 
+	/*
+	 * dispatch_table[sock] was already cleared above, so no new call into
+	 * recv_data() can pick up this ctx. But a call that already read the
+	 * (still non-NULL) pointer may still be in its critical section,
+	 * holding ctx->lock while it finishes dispatching. Wait for it here so
+	 * the caller can safely reuse/reinit ctx once we return.
+	 */
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	k_mutex_unlock(&ctx->lock);
+
 	return ret;
 }


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/108619 introduced assertions on uninitialized/re-initialized mutexes, uncovering a race in `dns_dispatcher_unregister()`: it clears the dispatch-table slot and returns immediately, even if a concurrent `recv_data()` call already holds `ctx->lock` and is mid-dispatch. A caller that reuses `ctx` right after can race with it, tripping the same assertions in `net.mdns.runtime_iface_allowlist`.

Take and release `ctx->lock` after clearing the table, so `unregister()` only returns once any in-flight dispatch has finished.