### PR TITLE
soc: stm32: Use dt_nodelabel_bool_prop for boolean properties

### DIFF
--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -224,7 +224,7 @@ if CRYPTO_STM32
 # AES CCM with up to 14 bytes of Additional Data (AD)
 config HEAP_MEM_POOL_ADD_SIZE_CRYPTO_STM32
 	int
-	default 16 if $(dt_nodelabel_enabled,cryp) && $(dt_nodelabel_has_prop,cryp,gcm-ccm-supported)
+	default 16 if $(dt_nodelabel_enabled,cryp) && $(dt_nodelabel_bool_prop,cryp,gcm-ccm-supported)
 
 endif # CRYPTO_STM32
 


### PR DESCRIPTION
dt_nodelabel_has_prop only checks for the existence of a property. bool properties always exist if they are defined in the binding and have a value of either true or false.

This caused these configs to always default to true - even if the properties weren't enabled in the device tree.