### PR TITLE
boards: arm: v2m_musca_b1: fix typo in Code Partition chosen name

### DIFF
--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
@@ -19,7 +19,7 @@
 		zephyr,console = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partitions = &slot0_ns_partition;
+		zephyr,code-partition = &slot0_ns_partition;
 		zephyr,shell-uart = &uart1;
 	};
 


### PR DESCRIPTION
The standardized Code Partition chosen is `zephyr,code-partition`, but this board defines `zephyr,code-partitions` (note final `s`) instead. This seems to be a typo/mistake as nothing in tree consumes this chosen.

Adjust the chosen property's name to match the standardized name.