### PR TITLE
boards: rpi_pico: Clarify single-core support

### DIFF
--- a/boards/raspberrypi/rpi_pico/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico/doc/index.rst
@@ -9,6 +9,9 @@ a USB connector, and an SWD interface.
 
 The Pico W additionally contains an `Infineon CYW43439`_ 2.4 GHz Wi-Fi/Bluetooth module.
 
+The RP2040 has two Cortex-M0+ cores. Zephyr currently runs on one core only;
+running code on the second core is not supported.
+
 The USB bootloader allows the ability to flash without any adapter,
 in a drag-and-drop manner.
 It is also possible to flash and debug the boards with their SWD interface,

--- a/boards/raspberrypi/rpi_pico2/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico2/doc/index.rst
@@ -6,10 +6,9 @@ Overview
 The Raspberry Pi Pico 2 and Pico 2W are second-generation products in the Raspberry Pi
 Pico family. From the `Raspberry Pi website <https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html>`_ is referred to as Pico 2.
 
-The Pico 2 supports running code on either a single Cortex-M33 or a Hazard3
-(RISC-V) core.
-
-As with the Pico 1, there's no support for running any code on the second core.
+The RP2350 SoC has two Cortex-M33 cores and two Hazard3 (RISC-V) cores. Zephyr
+supports builds targeting either CPU architecture, but currently runs on one
+core only; running code on the second core is not supported.
 
 Hardware
 ********


### PR DESCRIPTION
## Description

Clarify that RP2040 and RP2350 hardware is dual-core while Zephyr currently runs on one core only. The Pico 2 documentation also now states that builds can target either the Cortex-M33 or Hazard3 CPU architecture.

Fixes #114349

## Testing

- `perl scripts/checkpatch.pl -g HEAD^..HEAD`
- `git diff --check`

The standalone Sphinx invocation requires Zephyr's CMake-generated `OUTPUT_DIR` configuration, so documentation rendering is left to CI.