### PR TITLE
boards: *: remove non-standard and unused Zephyr chosens

### DIFF
--- a/boards/aithinker/esp32_cam/esp32_cam_procpu.dts
+++ b/boards/aithinker/esp32_cam/esp32_cam_procpu.dts
@@ -43,7 +43,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
-		zephyr,sdhc = &sdhc1;
 	};
 };
 

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
@@ -34,7 +34,6 @@
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,display = &st7789v;
 		zephyr,camera = &lcd_cam_dvp;
-		zephyr,sdhc = &sdhc0;
 	};
 
 	buttons {

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.dts
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.dts
@@ -36,7 +36,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ili9341;
-		zephyr,sdhc = &sdhc1;
 		zephyr,bt-hci = &esp32_bt_hci;
 	};
 

--- a/boards/lilygo/tdongle_s3/tdongle_s3_procpu.dts
+++ b/boards/lilygo/tdongle_s3/tdongle_s3_procpu.dts
@@ -36,7 +36,6 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,display = &st7735r;
-		zephyr,sdhc = &sdhc0;
 	};
 
 	buttons {

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.dts
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.dts
@@ -30,7 +30,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ssd1306_128x64;
-		zephyr,sdhc = &sdhc1;
 	};
 
 	leds {

--- a/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
@@ -27,7 +27,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
-		zephyr,sdhc = &sdcard0;
 		zephyr,display = &epd_ed2208_gca;
 	};
 

--- a/boards/seeed/reterminal_e1003/reterminal_e1003_procpu.dts
+++ b/boards/seeed/reterminal_e1003/reterminal_e1003_procpu.dts
@@ -26,7 +26,6 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,rtc = &pcf8563_rtc;
-		zephyr,sdhc = &sdcard0;
 		zephyr,display = &it8951_epd;
 	};
 

--- a/boards/sparkfun/samd21_dev_breakout/sparkfun_samd21_breakout.dts
+++ b/boards/sparkfun/samd21_dev_breakout/sparkfun_samd21_breakout.dts
@@ -19,7 +19,6 @@
 		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,i2c = &sercom3;
 		zephyr,code-partition = &code_partition;
 	};
 

--- a/boards/viewe/uedx24320028e_wb_a/uedx24320028e_wb_a_procpu.dts
+++ b/boards/viewe/uedx24320028e_wb_a/uedx24320028e_wb_a_procpu.dts
@@ -35,7 +35,6 @@
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,display = &gc9307n;
 		zephyr,touch = &chsc6x;
-		zephyr,sdhc = &sdhc0;
 	};
 
 	buzzer: buzzer {

--- a/boards/viewe/uedx32480035e_wb_a/uedx32480035e_wb_a_procpu.dts
+++ b/boards/viewe/uedx32480035e_wb_a/uedx32480035e_wb_a_procpu.dts
@@ -29,7 +29,6 @@
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,display = &st7796s;
 		zephyr,touch = &chsc6x;
-		zephyr,sdhc = &sdhc0;
 	};
 
 	aliases {

--- a/boards/waveshare/esp32s3_rlcd_4_2/esp32s3_rlcd_4_2_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_rlcd_4_2/esp32s3_rlcd_4_2_esp32s3_procpu.dts
@@ -35,7 +35,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &st7306;
-		zephyr,sdhc = &sdhc0;
 		zephyr,bt-hci = &esp32_bt_hci;
 	};
 


### PR DESCRIPTION
Drop two `zephyr,`-prefixed chosens found in a few boards around tree:
- `zephyr,sdhc`
- `zephyr,i2c` (one board: Sparkfun `samd21_dev_breakout`)

These chosens appear unused - no code in tree makes any reference to them, and they are not documented on [the appropriate page](https://docs.zephyrproject.org/latest/build/dts/api/api.html#zephyr-specific-chosen-nodes). I'm not aware of any out-of-tree usage either (unlike `zephyr,wifi`, which is undocumented but used downstream in NCS).

cc @kartben who introduced a `zephyr,sdhc` chosen most recently (https://github.com/zephyrproject-rtos/zephyr/pull/104226) - please make it known if the chosen has a usage

cc @ricfehr3 who introduced the `zephyr,i2c` chosen in https://github.com/zephyrproject-rtos/zephyr/pull/95971 - please make it known if the chosen has a usage