### PR TITLE
manifest: tf-m: include fixes for STM32H5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -403,7 +403,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: e0b7b16a58d8f54a5833bd91f7227cf08742c8f3
+      revision: pull/225/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update trusted-firmware-m revision to include fixes for STM32H5.