### PR TITLE
cmake: Properly set CMAKE_SYSTEM_PROCESSOR for the POSIX arch

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -39,19 +39,7 @@ set_property(TARGET native_simulator PROPERTY LOCALIZE_EXTRA_OPTIONS "")
 
 set(NSI_DIR ${ZEPHYR_BASE}/scripts/native_simulator CACHE PATH "Path to the native simulator")
 
-if(NATIVE_TARGET_HOST) # Allow users to manually select the target for cross-compiling use cases
-  set(TARGET_HOST ${NATIVE_TARGET_HOST})
-else()
-  if("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "arm.*")
-    # All 32bit arm variants
-    set(TARGET_HOST "arm")
-  elseif("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES ".*86.*")
-    # x86_64/i*86
-    set(TARGET_HOST "x86_64")
-  else()
-    set(TARGET_HOST ${CMAKE_HOST_SYSTEM_PROCESSOR})
-  endif()
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/target_arch.cmake)
 
 if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${TARGET_HOST}.cmake)
   # Set necessary compiler & linker options for this specific host architecture

--- a/arch/posix/target_arch.cmake
+++ b/arch/posix/target_arch.cmake
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT DEFINED TARGET_HOST)
+  if(NATIVE_TARGET_HOST) # Allow users to manually select the target for cross-compiling use cases
+    set(TARGET_HOST ${NATIVE_TARGET_HOST})
+  else()
+    # NOTE: As this is included before project(), CMAKE_HOST_SYSTEM_PROCESSOR is not yet set
+    # but this will produce the same result for Linux
+    cmake_host_system_information(RESULT host_processor QUERY OS_PLATFORM)
+    if(host_processor MATCHES "arm.*")
+      # All 32bit arm variants
+      set(TARGET_HOST "arm")
+    elseif(host_processor MATCHES ".*86.*")
+      # x86_64/i*86
+      set(TARGET_HOST "x86_64")
+    else()
+      set(TARGET_HOST ${host_processor})
+    endif()
+  endif()
+
+  if((TARGET_HOST STREQUAL "x86_64") AND (NOT CONFIG_64BIT))
+    set(NATIVE_TARGET_ARCH "i686")
+  else()
+    set(NATIVE_TARGET_ARCH ${TARGET_HOST})
+  endif()
+endif()

--- a/cmake/modules/FindTargetTools.cmake
+++ b/cmake/modules/FindTargetTools.cmake
@@ -66,7 +66,13 @@ set(CMAKE_SYSTEM_NAME Generic)
 #   CMAKE_SYSTEM_NAME-compiler-CMAKE_SYSTEM_PROCESSOR.cmake file,
 #   which can be used to modify settings like compiler flags etc. for
 #   the target
-set(CMAKE_SYSTEM_PROCESSOR ${ARCH})
+if("${ARCH}" STREQUAL "posix")
+  # For the POSIX architecture, let's set it to the actual target host architecture
+  include(${ARCH_DIR}/posix/target_arch.cmake)
+  set(CMAKE_SYSTEM_PROCESSOR ${NATIVE_TARGET_ARCH})
+else()
+  set(CMAKE_SYSTEM_PROCESSOR ${ARCH})
+endif()
 
 # https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_VERSION.html:
 #   When the CMAKE_SYSTEM_NAME variable is set explicitly to enable cross

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -61,3 +61,9 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
   endif()
 
 endif()
+
+if(CONFIG_ARCH_POSIX)
+  # Picolibs's assembler is not adding a .note.GNU-stack to tell the linker the stack is not
+  # executable. Let's tell the linker directly it is not.
+  zephyr_link_libraries("-z noexecstack")
+endif()


### PR DESCRIPTION
For the POSIX architecture, we were setting CMAKE_SYSTEM_PROCESSOR as "posix" which is quite bogus.
This resulted in picolibc skipping its assembler folders, and a bug due to this.
Let's set it to a proper value.

Note that for x86 (32bit builds in x86_64) we set it to i686 to be consistent with what cmake would set, instead of what Zephyr would set, as nothing in Zephyr is expected to use this, but external modules.

Fixes #116307

Note: With this PR commit a full twister run for both native_sim  native_sim/native/64  is clean.