### PR TITLE
dts: bindings: retention: Add enum values to checksum

### DIFF
--- a/dts/bindings/retention/zephyr,retention.yaml
+++ b/dts/bindings/retention/zephyr,retention.yaml
@@ -40,6 +40,11 @@ properties:
       16-bit CRC, 4 for 32-bit CRC). Default is to not use a checksum.
     type: int
     default: 0
+    enum:
+      - 0
+      - 1
+      - 2
+      - 4
 
 examples:
   - |


### PR DESCRIPTION
Since only specific values are allowed, add those as enum values