### PR TITLE
dts: bindings: mcumgr: Add max length to data ready GPIO

### DIFF
--- a/dts/bindings/mcumgr/zephyr,smp-spi.yaml
+++ b/dts/bindings/mcumgr/zephyr,smp-spi.yaml
@@ -16,6 +16,8 @@ properties:
   data-ready-gpios:
     type: phandle-array
     required: true
+    min-len: 1
+    max-len: 1
     description: |
       GPIO driven by the SPI peripheral to signal the controller.
 


### PR DESCRIPTION
This field must be provided and it can only take a single GPIO