### PR TITLE
cmake, scripts: Allow for command-scoped runner args

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -133,6 +133,30 @@ function(create_runners_yaml)
     endif()
   endforeach()
 
+  # Get runner-specific arguments that are scoped to a single command
+  # (flash, debug, attach, ...), set in the board files via the
+  # board_runner_args_<command>() helpers.
+  runners_yaml_append("# Runner specific arguments, scoped per command")
+  runners_yaml_append("command_args:")
+  foreach(runner ${runners})
+    string(MAKE_C_IDENTIFIER ${runner} runner_id)
+    set(have_cmd_args FALSE)
+    foreach(command flash debug debugserver attach rtt reset)
+      string(TOUPPER ${command} command_upper)
+      get_property(cmd_args GLOBAL PROPERTY "BOARD_RUNNER_ARGS_${command_upper}_${runner_id}")
+      if(cmd_args)
+        if(NOT have_cmd_args)
+          runners_yaml_append("  ${runner}:")
+          set(have_cmd_args TRUE)
+        endif()
+        runners_yaml_append("    ${command}:")
+        foreach(arg ${cmd_args})
+          runners_yaml_append("      - ${arg}")
+        endforeach()
+      endif()
+    endforeach()
+  endforeach()
+
   # Write the final contents.
   file(GENERATE OUTPUT "${runners_yaml}" CONTENT
     $<TARGET_PROPERTY:runners_yaml_props_target,yaml_contents>)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1313,6 +1313,53 @@ function(board_runner_args runner)
   set_property(GLOBAL APPEND PROPERTY BOARD_RUNNER_ARGS_EXPLICIT_${runner_id} ${ARGN})
 endfunction()
 
+# Command-scoped variants of board_runner_args().
+#
+# Usage from board.cmake files:
+#   board_runner_args_flash(runner "--device=SOME_FLASH_CORE")
+#   board_runner_args_debug(runner "--device=SOME_DEBUG_CORE")
+#
+# These behave exactly like board_runner_args(), except the arguments
+# only apply when the runner is invoked for the matching west command
+# (flash, debug, debugserver, attach, rtt or reset).
+#
+# board_runner_args() (with no command scope) remains the way to set
+# arguments common to every command and command-scoped arguments are
+# applied after the common ones (so they take precedence for options
+# where the last value wins).
+function(_board_runner_args_command command runner)
+  string(TOUPPER ${command} command_upper)
+  string(MAKE_C_IDENTIFIER ${runner} runner_id)
+  # Note the "_EXPLICIT_" here, and see board_finalize_runner_args().
+  set_property(GLOBAL APPEND PROPERTY
+    BOARD_RUNNER_ARGS_EXPLICIT_${command_upper}_${runner_id} ${ARGN})
+endfunction()
+
+function(board_runner_args_flash runner)
+  _board_runner_args_command(flash ${runner} ${ARGN})
+endfunction()
+
+function(board_runner_args_debug runner)
+  _board_runner_args_command(debug ${runner} ${ARGN})
+endfunction()
+
+function(board_runner_args_debugserver runner)
+  _board_runner_args_command(debugserver ${runner} ${ARGN})
+endfunction()
+
+function(board_runner_args_attach runner)
+  _board_runner_args_command(attach ${runner} ${ARGN})
+endfunction()
+
+function(board_runner_args_rtt runner)
+  _board_runner_args_command(rtt ${runner} ${ARGN})
+endfunction()
+
+function(board_runner_args_reset runner)
+  _board_runner_args_command(reset ${runner} ${ARGN})
+endfunction()
+
+
 # This function is intended for internal use by
 # boards/common/runner.board.cmake files.
 #
@@ -1353,9 +1400,28 @@ function(board_finalize_runner_args runner)
     ${BOARD_RUNNER_ARGS_${runner_id}}
     )
 
+  # Consolidate any command-scoped arguments set via
+  # board_runner_args_<command>() into their final per-command property.
+  foreach(command flash debug debugserver attach rtt reset)
+    string(TOUPPER ${command} command_upper)
+    get_property(cmd_explicit GLOBAL PROPERTY
+      "BOARD_RUNNER_ARGS_EXPLICIT_${command_upper}_${runner_id}")
+    if(cmd_explicit OR BOARD_RUNNER_ARGS_${command_upper}_${runner_id})
+      # Note no _EXPLICIT_ here. This property contains the final list.
+      set_property(GLOBAL APPEND PROPERTY
+        BOARD_RUNNER_ARGS_${command_upper}_${runner_id}
+        # Arguments explicitly given with board_runner_args_<command>().
+        ${cmd_explicit}
+        # Arguments given via the CMake cache come last of all.
+        ${BOARD_RUNNER_ARGS_${command_upper}_${runner_id}}
+        )
+    endif()
+  endforeach()
+
   # Add the finalized runner to the global property list.
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_RUNNERS ${runner})
 endfunction()
+
 
 #[=======================================================================[.rst:
 

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -393,9 +393,12 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
 
     # Arguments in this order to allow specific to override general:
     #
-    # - runner-specific runners.yaml arguments
+    # - runner-specific runners.yaml arguments (common to all commands)
+    # - runner-specific runners.yaml arguments scoped to this command
     # - user-provided command line arguments
-    final_argv = runners_yaml['args'][runner_name] + runner_args
+    command_args = runners_yaml.get('command_args') or {}
+    runner_args_cmd_specific = (command_args.get(runner_name) or {}).get(command_name) or []
+    final_argv = runners_yaml['args'][runner_name] + runner_args_cmd_specific + runner_args
 
     # If flashing multiple images, the runner supports reset after flashing and
     # the board has enabled this functionality, check if the board should be


### PR DESCRIPTION
This PR adds support command-scoped runner arguments, so that arguments specific for each board, runner and command can be specified. `board_runner_args` is retained and behaves the same, just with the change that the command-specific functions (`board_runner_args_flash`, `board_runner_args_debug`, ...) take precedence (they're put on the command line earlier than the now common ones), just like the user-specified arguments do.

The rationale behind this is that in https://github.com/zephyrproject-rtos/zephyr/pull/114666, I do have a sysbuild setup in which not all domains have a flash driver (in case of `mimxrt685s`, `/cm33` does but `/hifi4` does not), which implies that not all images can be flashed through their respective domains. Using a "primary" domain to flash all of the images works, so the idea is to use that for all of the images. Passing a device name belonging to the primary domain through runner arguments for all commands works with the `flash` command, but prohibits debugging other domains, as the wrong device is selected, so that leads to something that allows to specify a different device for the `debug`, `attach`, etc. commands.

I feel like this is a bit of a workaround but I can't think of anything else, if there's a cleaner way to make this work, I'm all ears.