### PR TITLE
TI_am3352_ehrpwm: fix uninitialized upper bits in cycles_per_sec

### DIFF
--- a/drivers/pwm/pwm_ti_am3352_ehrpwm.c
+++ b/drivers/pwm/pwm_ti_am3352_ehrpwm.c
@@ -413,6 +413,7 @@ static int ti_ehrpwm_get_cycles_per_sec(const struct device *dev, uint32_t chann
 	ARG_UNUSED(channel);
 	const struct ti_ehrpwm_cfg *cfg = DEV_CFG(dev);
 
+	*cycles = 0;
 	return clock_control_get_rate(cfg->clock_dev, cfg->clock_subsys, (uint32_t *)cycles);
 }
 


### PR DESCRIPTION
- ti_ehrpwm_get_cycles_per_sec() passes a 64-bit cycles pointer to clock_control_get_rate() cast down to uint32_t*, which only writes the lower 32 bits of the rate. The upper 32 bits of *cycles were left uninitialized, so callers computing cycles_per_sec as a 64-bit value could read garbage in the high word.

- Zero *cycles before the call so the unwritten upper bits are well-defined.