### PR TITLE
lowrisc: opentitan: fix rv_timer base address

### DIFF
--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -46,10 +46,11 @@
 			reg = <0x10000000 0x10000>;
 		};
 
-		mtimer: timer@40100110 {
+		mtimer: timer@40100000 {
 			compatible = "riscv,machine-timer";
-			reg = <0x40100110 0x8 0x40100118 0x8>;
-			reg-names = "mtime", "mtimecmp";
+			/* "ctrl" holds the rv_timer regs the machine-timer binding doesn't cover */
+			reg = <0x40100000 0x104>, <0x40100110 0x8>, <0x40100118 0x8>;
+			reg-names = "ctrl", "mtime", "mtimecmp";
 			interrupts-extended = <&hlic 7>;
 		};
 


### PR DESCRIPTION
`RV_TIMER_BASE` is derived from the` mtimer` devicetree node but the register offsets used with it are relative to the `rv_timer` base at `0x40100000`

 Since commit f11f68eade4c that node describes only the `mtime `and `mtimecmp` registers, so `DT_REG_ADDR()` returns `0x40100110` rather than the timer's base. The function `soc_early_init_hook()` therefore writes `CTRL` to `0x40100114` and `INTR_ENABLE0` to `0x40100210`, instead of `0x40100004` and `0x40100100`.