### PR TITLE
video: buffer: fix NULL pointer dereference in video_buffer_release

### DIFF
--- a/subsys/video/buffer.c
+++ b/subsys/video/buffer.c
@@ -90,7 +90,12 @@ struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout)
 
 int video_buffer_release(struct video_buffer *vbuf)
 {
-	if (vbuf == NULL || vbuf->index >= ARRAY_SIZE(video_buf)) {
+	if (vbuf == NULL) {
+		LOG_ERR("NULL buffer");
+		return -EINVAL;
+	}
+
+	if (vbuf->index >= ARRAY_SIZE(video_buf)) {
 		LOG_ERR("Invalid buffer index: %u", vbuf->index);
 		return -EINVAL;
 	}

--- a/tests/subsys/video/api/src/video_common.c
+++ b/tests/subsys/video/api/src/video_common.c
@@ -150,4 +150,36 @@ ZTEST(video_common, test_video_closest_frmival_stepwise)
 	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&stepwise.max), "100 / 1");
 }
 
+ZTEST(video_common, test_video_buffer_release_null)
+{
+	int ret;
+
+	ret = video_buffer_release(NULL);
+	zassert_equal(ret, -EINVAL, "expecting -EINVAL when releasing a NULL buffer");
+}
+
+ZTEST(video_common, test_video_buffer_alloc_release)
+{
+	struct video_buffer *vbuf;
+	int ret;
+
+	vbuf = video_buffer_alloc(64, K_NO_WAIT);
+	zassert_not_null(vbuf, "expecting buffer allocation to succeed");
+
+	ret = video_buffer_release(vbuf);
+	zassert_ok(ret, "expecting buffer release to succeed");
+
+	ret = video_buffer_release(vbuf);
+	zassert_equal(ret, -EINVAL, "expecting -EINVAL when releasing a buffer twice");
+}
+
+ZTEST(video_common, test_video_buffer_release_bad_index)
+{
+	struct video_buffer vbuf = {.index = CONFIG_VIDEO_BUFFER_POOL_NUM_MAX};
+	int ret;
+
+	ret = video_buffer_release(&vbuf);
+	zassert_equal(ret, -EINVAL, "expecting -EINVAL for an out-of-range buffer index");
+}
+
 ZTEST_SUITE(video_common, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
### Issue

In `video_buffer_release()`, when `vbuf` is NULL, the combined check:

```c
if (vbuf == NULL || ...) {
        LOG_ERR(..., vbuf->index);
        ...
}
```
short-circuits into the error branch, but the `LOG_ERR` then unconditionally dereferences `vbuf->index`, causing a NULL pointer
dereference.

### Fix

Split the NULL check from the index bounds check.

### Testing

- test_video_buffer_release_null
- test_video_buffer_alloc_release
- test_video_buffer_release_bad_index

Verified with:
```
west twister -s video.api
```

Note: the null test faults reliably on native_sim, where dereferencing address 0 raises `SIGSEGV`. On some targets, address 0 mapped to real memory.