### PR TITLE
tests: arch: arm: Use get_available_nvic_line() helper function

### DIFF
--- a/tests/arch/arm/arm_custom_interrupt/src/arm_custom_interrupt.c
+++ b/tests/arch/arm/arm_custom_interrupt/src/arm_custom_interrupt.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <cmsis_core.h>
+#include <zephyr/interrupt_util.h>
 #include <zephyr/sys/barrier.h>
 
 unsigned int sw_irq_number = (unsigned int)(-1);
@@ -18,9 +19,9 @@ static volatile bool custom_eoi_called;
 static volatile bool irq_handler_called;
 
 #if CONFIG_2ND_LVL_ISR_TBL_OFFSET > 0
-#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX CONFIG_2ND_LVL_ISR_TBL_OFFSET
 #else
-#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_NUM_IRQS - 1)
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX CONFIG_NUM_IRQS
 #endif
 
 /* Define out custom SoC interrupt controller interface methods.
@@ -35,7 +36,7 @@ void z_soc_irq_init(void)
 {
 	int irq = 0;
 
-	for (; irq <= TEST_1ST_LEVEL_INTERRUPTS_MAX; irq++) {
+	for (; irq < TEST_1ST_LEVEL_INTERRUPTS_MAX; irq++) {
 		NVIC_SetPriority((IRQn_Type)irq, _IRQ_PRIO_OFFSET);
 	}
 
@@ -131,51 +132,14 @@ ZTEST(arm_custom_interrupt, test_arm_custom_interrupt)
 	zassert_true(custom_init_called, "Custom IRQ init not called\n");
 
 	/* Determine an NVIC IRQ line that is not currently in use. */
-	int i;
-
-	for (i = TEST_1ST_LEVEL_INTERRUPTS_MAX; i >= 0; i--) {
-		if (NVIC_GetEnableIRQ(i) == 0) {
-			/*
-			 * Interrupts configured statically with IRQ_CONNECT(.)
-			 * are automatically enabled. NVIC_GetEnableIRQ()
-			 * returning false, here, implies that the IRQ line is
-			 * either not implemented or it is not enabled, thus,
-			 * currently not in use by Zephyr.
-			 */
-
-			/* Set the NVIC line to pending. */
-			NVIC_SetPendingIRQ(i);
-
-			if (NVIC_GetPendingIRQ(i)) {
-				/* If the NVIC line is pending, it is
-				 * guaranteed that it is implemented; clear the
-				 * line.
-				 */
-				NVIC_ClearPendingIRQ(i);
-
-				if (!NVIC_GetPendingIRQ(i)) {
-					/*
-					 * If the NVIC line can be successfully
-					 * un-pended, it is guaranteed that it
-					 * can be used for software interrupt
-					 * triggering.
-					 */
-					break;
-				}
-			}
-		}
-	}
-
-	zassert_true(i >= 0, "No available IRQ line to use in the test\n");
-
-	TC_PRINT("Available IRQ line: %u\n", i);
-	sw_irq_number = i;
+	sw_irq_number = get_available_nvic_line(TEST_1ST_LEVEL_INTERRUPTS_MAX);
+	TC_PRINT("Available IRQ line: %u\n", sw_irq_number);
 
 	zassert_false(custom_set_priority_called, "Custom set priority flag set\n");
 	arch_irq_connect_dynamic(sw_irq_number, 0 /* highest priority */, arm_isr_handler, NULL, 0);
 	zassert_true(custom_set_priority_called, "Custom set priority not called\n");
 
-	NVIC_ClearPendingIRQ(i);
+	NVIC_ClearPendingIRQ(sw_irq_number);
 
 	zassert_false(arch_irq_is_enabled(sw_irq_number), "SW IRQ already enabled\n");
 	zassert_false(custom_enable_called, "Custom IRQ enable flag is set\n");
@@ -189,7 +153,7 @@ ZTEST(arm_custom_interrupt, test_arm_custom_interrupt)
 		custom_set_priority_called = false;
 
 		/* Set the dynamic IRQ to pending state. */
-		NVIC_SetPendingIRQ(i);
+		NVIC_SetPendingIRQ(sw_irq_number);
 
 		/*
 		 * Instruction barriers to make sure the NVIC IRQ is

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -9,6 +9,7 @@
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 #include <cmsis_core.h>
 #endif
+#include <zephyr/interrupt_util.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/barrier.h>
 
@@ -674,41 +675,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 	TC_PRINT("Using SGI %u for Cortex-R\n", i);
 #else
 
-	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
-		if (irq_controller_get_enable(i) == 0) {
-			/*
-			 * Interrupts configured statically with IRQ_CONNECT(.)
-			 * are automatically enabled. irq_controller_get_enable()
-			 * returning false, here, implies that the IRQ line is
-			 * either not implemented or it is not enabled, thus,
-			 * currently not in use by Zephyr.
-			 */
-
-			/* Set the NVIC line to pending. */
-			irq_controller_set_pending(i);
-
-			if (irq_controller_get_pending(i)) {
-				/* If the NVIC line is pending, it is
-				 * guaranteed that it is implemented; clear the
-				 * line.
-				 */
-				irq_controller_clear_pending(i);
-
-				if (!irq_controller_get_pending(i)) {
-					/*
-					 * If the NVIC line can be successfully
-					 * un-pended, it is guaranteed that it
-					 * can be used for software interrupt
-					 * triggering.
-					 */
-					break;
-				}
-			}
-		}
-	}
-
-	zassert_true(i >= 0, "No available IRQ line to use in the test\n");
-
+	i = get_available_nvic_line(CONFIG_NUM_IRQS);
 	TC_PRINT("Available IRQ line: %u\n", i);
 #endif
 

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
@@ -5,14 +5,15 @@
  */
 
 #include <zephyr/ztest.h>
+#include <zephyr/interrupt_util.h>
 #include <zephyr/arch/cpu.h>
 #include <cmsis_core.h>
 
 #if defined(CONFIG_ARM_SECURE_FIRMWARE) && defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 #if CONFIG_2ND_LVL_ISR_TBL_OFFSET > 0
-#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX CONFIG_2ND_LVL_ISR_TBL_OFFSET
 #else
-#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_NUM_IRQS - 1)
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX CONFIG_NUM_IRQS
 #endif
 
 extern irq_target_state_t irq_target_state_set(unsigned int irq, irq_target_state_t target_state);
@@ -27,41 +28,7 @@ ZTEST(arm_irq_advanced_features, test_arm_irq_target_state)
 	/* Determine an NVIC IRQ line that is implemented
 	 * but not currently in use.
 	 */
-	int i;
-
-	for (i = TEST_1ST_LEVEL_INTERRUPTS_MAX; i >= 0; i--) {
-		if (NVIC_GetEnableIRQ(i) == 0) {
-			/*
-			 * In-use interrupts are automatically enabled by
-			 * virtue of IRQ_CONNECT(.). NVIC_GetEnableIRQ()
-			 * returning false, here, implies that the IRQ line is
-			 * either not implemented or it is not enabled, thus,
-			 * currently not in use by Zephyr.
-			 */
-
-			/* Set the NVIC line to pending. */
-			NVIC_SetPendingIRQ(i);
-
-			if (NVIC_GetPendingIRQ(i)) {
-				/* If the NVIC line is pending, it is
-				 * guaranteed that it is implemented.
-				 */
-				NVIC_ClearPendingIRQ(i);
-
-				if (!NVIC_GetPendingIRQ(i)) {
-					/*
-					 * If the NVIC line can be successfully
-					 * un-pended, it is guaranteed that it
-					 * can be used for software interrupt
-					 * triggering.
-					 */
-					break;
-				}
-			}
-		}
-	}
-
-	zassert_true(i >= 0, "No available IRQ line to configure as zero-latency\n");
+	int i = get_available_nvic_line(TEST_1ST_LEVEL_INTERRUPTS_MAX);
 
 	TC_PRINT("Available IRQ line: %u\n", i);
 

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
@@ -7,12 +7,13 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <cmsis_core.h>
+#include <zephyr/interrupt_util.h>
 #include <zephyr/sys/barrier.h>
 
 #if CONFIG_2ND_LVL_ISR_TBL_OFFSET > 0
-#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX CONFIG_2ND_LVL_ISR_TBL_OFFSET
 #else
-#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_NUM_IRQS - 1)
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX CONFIG_NUM_IRQS
 #endif
 
 static volatile int test_flag;
@@ -45,43 +46,7 @@ ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 
 	zassert_false(init_flag, "Test flag not initialized to zero\n");
 
-	for (i = TEST_1ST_LEVEL_INTERRUPTS_MAX; i >= 0; i--) {
-		if (NVIC_GetEnableIRQ(i) == 0) {
-			/*
-			 * Interrupts configured statically with IRQ_CONNECT(.)
-			 * are automatically enabled. NVIC_GetEnableIRQ()
-			 * returning false, here, implies that the IRQ line is
-			 * either not implemented or it is not enabled, thus,
-			 * currently not in use by Zephyr.
-			 */
-
-			/* Set the NVIC line to pending. */
-			NVIC_SetPendingIRQ(i);
-
-			if (NVIC_GetPendingIRQ(i)) {
-				/*
-				 * If the NVIC line is pending, it is
-				 * guaranteed that it is implemented; clear the
-				 * line.
-				 */
-				NVIC_ClearPendingIRQ(i);
-
-				if (!NVIC_GetPendingIRQ(i)) {
-					/*
-					 * If the NVIC line can be successfully
-					 * un-pended, it is guaranteed that it
-					 * can be used for software interrupt
-					 * triggering. Return the NVIC line
-					 * number.
-					 */
-					break;
-				}
-			}
-		}
-	}
-
-	zassert_true(i >= 0, "No available IRQ line to configure as zero-latency\n");
-
+	i = get_available_nvic_line(TEST_1ST_LEVEL_INTERRUPTS_MAX);
 	TC_PRINT("Available IRQ line: %u\n", i);
 
 	/* Configure the available IRQ line as zero-latency. */
@@ -89,7 +54,6 @@ ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 	arch_irq_connect_dynamic(i, 0 /* Unused */, arm_zero_latency_isr_handler, NULL,
 				 IRQ_ZERO_LATENCY);
 
-	NVIC_ClearPendingIRQ(i);
 	NVIC_EnableIRQ(i);
 
 	/* Lock interrupts */

--- a/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <cmsis_core.h>
+#include <zephyr/interrupt_util.h>
 #include <zephyr/sys/barrier.h>
 
 #define EXECUTION_TRACE_LENGTH 6
@@ -89,51 +90,6 @@ void isr_b_handler(const void *args)
 	execution_trace_add(STEP_ISR_B_END);
 }
 
-static int find_unused_irq(int start)
-{
-	int i;
-
-	for (i = start - 1; i >= 0; i--) {
-		if (NVIC_GetEnableIRQ(i) == 0) {
-			/*
-			 * Interrupts configured statically with IRQ_CONNECT(.)
-			 * are automatically enabled. NVIC_GetEnableIRQ()
-			 * returning false, here, implies that the IRQ line is
-			 * either not implemented or it is not enabled, thus,
-			 * currently not in use by Zephyr.
-			 */
-
-			/* Set the NVIC line to pending. */
-			NVIC_SetPendingIRQ(i);
-
-			if (NVIC_GetPendingIRQ(i)) {
-				/*
-				 * If the NVIC line is pending, it is
-				 * guaranteed that it is implemented; clear the
-				 * line.
-				 */
-				NVIC_ClearPendingIRQ(i);
-
-				if (!NVIC_GetPendingIRQ(i)) {
-					/*
-					 * If the NVIC line can be successfully
-					 * un-pended, it is guaranteed that it
-					 * can be used for software interrupt
-					 * triggering. Return the NVIC line
-					 * number.
-					 */
-					break;
-				}
-			}
-		}
-	}
-
-	zassert_true(i >= 0, "No available IRQ line to configure as zero-latency\n");
-
-	TC_PRINT("Available IRQ line: %u\n", i);
-	return i;
-}
-
 ZTEST(arm_irq_zero_latency_levels, test_arm_zero_latency_levels)
 {
 	/*
@@ -147,8 +103,8 @@ ZTEST(arm_irq_zero_latency_levels, test_arm_zero_latency_levels)
 	}
 
 	/* Determine two NVIC IRQ lines that are not currently in use. */
-	irq_a = find_unused_irq(CONFIG_NUM_IRQS);
-	irq_b = find_unused_irq(irq_a);
+	irq_a = get_available_nvic_line(CONFIG_NUM_IRQS);
+	irq_b = get_available_nvic_line(irq_a);
 
 	/* Configure IRQ A as zero-latency interrupt with prio 1 */
 	arch_irq_connect_dynamic(irq_a, IRQ_A_PRIO, isr_a_handler, NULL, IRQ_ZERO_LATENCY);

--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -87,57 +87,21 @@ void test_main(void)
 
 	__ASSERT(flag == 0, "Test flag not initialized to 0\n");
 
-	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
-		if (NVIC_GetEnableIRQ(i) == 0) {
-			/*
-			 * Interrupts configured statically with IRQ_CONNECT(.)
-			 * are automatically enabled. NVIC_GetEnableIRQ()
-			 * returning false, here, implies that the IRQ line is
-			 * either not implemented or it is not enabled, thus,
-			 * currently not in use by Zephyr.
-			 */
+	i = get_available_nvic_line(CONFIG_NUM_IRQS);
+	printk("Available IRQ line: %u\n", i);
 
-			/* Set the NVIC line to pending. */
-			NVIC_SetPendingIRQ(i);
+	NVIC_SetPendingIRQ(i);
 
-			if (NVIC_GetPendingIRQ(i)) {
-				/* If the NVIC line is pending, it is
-				 * guaranteed that it is implemented; clear the
-				 * line.
-				 */
-				NVIC_ClearPendingIRQ(i);
+	arch_irq_connect_dynamic(i, 0 /* highest priority */, arm_isr_handler, NULL, 0);
 
-				if (!NVIC_GetPendingIRQ(i)) {
-					/*
-					 * If the NVIC line can be successfully
-					 * un-pended, it is guaranteed that it
-					 * can be used for software interrupt
-					 * triggering. Trigger it.
-					 */
-					NVIC_SetPendingIRQ(i);
-					break;
-				}
-			}
-		}
-	}
+	NVIC_EnableIRQ(i);
 
-	if (i >= 0) {
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
 
-		printk("Available IRQ line: %u\n", i);
+	flag = test_flag;
 
-		arch_irq_connect_dynamic(i, 0 /* highest priority */, arm_isr_handler, NULL, 0);
+	__ASSERT(flag > 0, "Test flag not set by IRQ\n");
 
-		NVIC_EnableIRQ(i);
-
-		barrier_dsync_fence_full();
-		barrier_isync_fence_full();
-
-		flag = test_flag;
-
-		__ASSERT(flag > 0, "Test flag not set by IRQ\n");
-
-		printk("ARM no multithreading test successful\n");
-	} else {
-		__ASSERT(0, "No available IRQ line to use in the test\n");
-	}
+	printk("ARM no multithreading test successful\n");
 }

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <cmsis_core.h>
+#include <zephyr/interrupt_util.h>
 #include <zephyr/kernel_structs.h>
 #include <zephyr/sys/barrier.h>
 #include <offsets_short_arch.h>
@@ -207,35 +208,11 @@ ZTEST(arm_thread_swap, test_arm_syscalls)
 #endif
 
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
-		if (NVIC_GetEnableIRQ(i) == 0) {
-			/*
-			 * Interrupts configured statically with IRQ_CONNECT(.)
-			 * are automatically enabled. NVIC_GetEnableIRQ()
-			 * returning false, here, implies that the IRQ line is
-			 * either not implemented or it is not enabled, thus,
-			 * currently not in use by Zephyr.
-			 */
-
-			/* Set the NVIC line to pending. */
-			NVIC_SetPendingIRQ(i);
-
-			if (NVIC_GetPendingIRQ(i)) {
-				/* If the NVIC line is pending, it is
-				 * guaranteed that it is implemented.
-				 */
-				break;
-			}
-		}
-	}
-
-	zassert_true(i >= 0, "No available IRQ line to use in the test\n");
-
+	i = get_available_nvic_line(CONFIG_NUM_IRQS);
 	TC_PRINT("Available IRQ line: %u\n", i);
 
 	arch_irq_connect_dynamic(i, 0 /* highest priority */, arm_isr_handler, (uint32_t *)i, 0);
 
-	NVIC_ClearPendingIRQ(i);
 	NVIC_EnableIRQ(i);
 
 	/* Allow the user thread to trigger an interrupt;


### PR DESCRIPTION
Use `get_available_nvic_line()` helper function in various Arm tests instead of re-implementing it.

'arm_thread_swap' test is slightly changed in that the interrupt used is tested to ensure it can be cleared, which was not tested before this change. This is not expected to affect the test and is worth it to leverage existing `get_available_nvic_line()` Ztest helper function.