### PR TITLE
arch: arm: cortex_m: drop redundant ISBs from IRQ lock and unlock

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -506,6 +506,23 @@ config CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE
 
 endif # CORTEX_M_NULL_POINTER_EXCEPTION
 
+config CORTEX_M_ERRATUM_440977_WORKAROUND
+	bool "Workaround for Cortex-M7 erratum 440977"
+	default y if CPU_CORTEX_M7
+	depends on ARMV7_M_ARMV8_M_MAINLINE
+	help
+	  On Cortex-M7 r0p0/r0p1, a priority-raising BASEPRI/BASEPRI_MAX
+	  write can leave the following instruction open to preemption
+	  (Arm erratum 440977, formerly 837070, fixed in r0p2).
+	  Keep the existing ISB as that instruction, so the critical region
+	  starts after the window closes. An interrupt can still preempt
+	  the ISB, which retains its pipeline-serialization cost.
+	  Unlike Arm's CPSID i/MSR/CPSIE i workaround, this does not
+	  temporarily mask higher-priority interrupts, including zero-latency
+	  interrupts, or change PRIMASK.
+	  Other cores need no barrier after priority-raising writes. This
+	  option may also be disabled on Cortex-M7 r0p2 and newer.
+
 config ARM_FP_CLOBBER_WORKAROUND
 	bool "Frame pointer clobber workaround"
 	depends on USE_SWITCH

--- a/arch/arm/core/cortex_m/swap_helper.S
+++ b/arch/arm/core/cortex_m/swap_helper.S
@@ -121,7 +121,13 @@ SECTION_FUNC(TEXT, z_arm_pendsv)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     movs.n r0, #_EXC_IRQ_DEFAULT_PRIO
     msr BASEPRI_MAX, r0
-    isb /* Make the effect of disabling interrupts be realized immediately */
+#if defined(CONFIG_CORTEX_M_ERRATUM_440977_WORKAROUND)
+    /* Arm erratum 440977 (formerly 837070): the next instruction can
+     * still be preempted. Keep the ISB before the critical region
+     * without masking higher-priority interrupts through PRIMASK.
+     */
+    isb
+#endif
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */

--- a/arch/arm/include/cortex_m/kernel_arch_func.h
+++ b/arch/arm/include/cortex_m/kernel_arch_func.h
@@ -96,6 +96,13 @@ static ALWAYS_INLINE int arch_swap(unsigned int key)
 	/* clear mask or enable all irqs to take a pendsv */
 	irq_unlock(0);
 
+	/* The ISB guarantees the now-unmasked PendSV is recognized here,
+	 * and not a couple of instructions later, which could otherwise
+	 * let the return value load below execute before the context
+	 * switch and read a stale -EAGAIN when the thread resumes.
+	 */
+	__ISB();
+
 	/* Context switch is performed here. Returning implies the
 	 * thread has been context-switched-in again.
 	 */

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -447,6 +447,10 @@ New APIs and options
 
   * :kconfig:option:`CONFIG_ARM_MPU_CM7_UNMAPPED_REGION` (Arm Cortex-M7 catch-all MPU region
     for unmapped addresses, erratum 1013783 workaround)
+  * :kconfig:option:`CONFIG_CORTEX_M_ERRATUM_440977_WORKAROUND` (keeps an ISB after
+    priority-raising BASEPRI writes; enabled by default on Arm Cortex-M7, where erratum
+    440977 applies to r0p0/r0p1 cores. Other Cortex-M cores no longer execute barriers in
+    the interrupt lock/unlock fast paths, speeding up kernel hot paths)
   * :kconfig:option:`CONFIG_EXCEPTION_DUMP` (enabled by default, can be disabled to compile
     out the fault handler output on size constrained builds)
 

--- a/include/zephyr/arch/arm/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/asm_inline_gcc.h
@@ -55,7 +55,17 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	key = __get_BASEPRI();
 	__set_BASEPRI_MAX(_EXC_IRQ_DEFAULT_PRIO);
+#if defined(CONFIG_CORTEX_M_ERRATUM_440977_WORKAROUND)
+	/* Arm erratum 440977 (formerly 837070): the next instruction can
+	 * still be preempted. Keep the ISB before the critical region
+	 * without masking higher-priority interrupts through PRIMASK.
+	 */
 	__ISB();
+#endif
+	/* Priority-raising writes to PRIMASK/FAULTMASK/BASEPRI are
+	 * serialized to the instruction stream, so (other than the above
+	 * erratum) no ISB is needed here; see Arm DAI0321A, section 4.8.
+	 */
 #elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) ||                                \
 	defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	__asm__ volatile(
@@ -79,15 +89,20 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 
 static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 {
+	/* No barrier is used when unmasking: on Cortex-M an interrupt
+	 * that is (or becomes) pended is taken after at most a couple of
+	 * instructions; unlocking makes no promise that it is taken
+	 * *before* the next instruction (see Arm DAI0321A, section 4.7).
+	 * The one spot that does need synchronous recognition of a pended
+	 * exception, the Cortex-M arch_swap(), inserts its own ISB.
+	 */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	if (key != 0U) {
 		return;
 	}
 	__enable_irq();
-	__ISB();
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	__set_BASEPRI(key);
-	__ISB();
 #elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) ||                                \
 	defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	if (key != 0U) {


### PR DESCRIPTION
`arch_irq_lock()`/`arch_irq_unlock()` execute an ISB after every BASEPRI/PRIMASK write — two pipeline flushes per kernel critical section. Neither is architecturally required: priority-raising MSR writes are self-synchronizing (Arm DAI 0321A §4.8), and on unmask the core takes a pended interrupt within a couple of instructions (§4.7). The one place that needs synchronous recognition of the pended PendSV, `arch_swap()`, gets an explicit ISB instead.

Cortex-M7 r0p0/r0p1 (erratum 440977, formerly 837070) keeps the priority-raise ISB via new `CONFIG_CORTEX_M_ERRATUM_440977_WORKAROUND` (default `y` on M7), preserving today's behavior there. The ISB occupies the instruction that can still be preempted before the critical region begins. This retains its pipeline-serialization cost while avoiding the temporary masking of higher-priority interrupts, including zero-latency interrupts, that Arm's CPSID i/MSR/CPSIE i workaround introduces through PRIMASK.

## Impact (standalone vs `main`)

| | AZ3166 (STM32F412, M4 @ 96 MHz) | mps2/an385 (M3, QEMU icount) |
|---|---|---|
| latency_measure Δ, 47 ops (min/max/median) | mean **−3.3%** (−8.1/+0.6/−2.9%) | mean −3.8% (−6.8/+0.0/−3.8%) |
| k_yield context switch | 241 → 235 cycles | 182 → 179 |
| ISR return to interrupted thread | 243 → 233 | 176 → 169 |
| semaphore give, no waiter | 74 → 68 | 60 → 57 |
| thread_metric synchronization | **+15.4%** | +8.3% |
| thread_metric coop / preempt / interrupt | +3.3% / +4.6% / +2.9% | +2.1% / +2.2% / +2.3% |
| flash Δ (az3166 image) | **−400 B** (−Os) / −424 B (−O2) | |

*Latency/cycles and flash: lower is better · thread_metric score: higher is better.*

## Testing

- Benchmarks above: `tests/benchmarks/latency_measure`, `tests/benchmarks/thread_metric` on both targets.
- twister, QEMU mps2/an385 + mps2/an521: `arch/arm/arm_interrupt`, `arch/arm/arm_irq_advanced_features`, `kernel/context` — all pass.
- twister `--device-testing` on az3166_iotdevkit: `arch/arm/arm_interrupt`, `arch/arm/arm_irq_advanced_features` — all pass.

