### PR TITLE
arch: arm: cortex_m: pend PendSV with a plain ICSR store

### DIFF
--- a/arch/arm/core/cortex_m/exc_exit.c
+++ b/arch/arm/core/cortex_m/exc_exit.c
@@ -56,7 +56,12 @@ Z_GENERIC_SECTION(.text._HandlerModeExit) void z_arm_exc_exit(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
 	if (_kernel.ready_q.cache != _kernel.cpus->current) {
-		SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
+		/* PENDSVSET is write-one-to-set and writing zero to the
+		 * other ICSR bits has no effect, so a plain store is
+		 * sufficient (and avoids a read-modify-write that could
+		 * write back stale state bits).
+		 */
+		SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
 	}
 #endif /* CONFIG_PREEMPT_ENABLED */
 

--- a/arch/arm/core/cortex_m/thread_abort.c
+++ b/arch/arm/core/cortex_m/thread_abort.c
@@ -39,7 +39,7 @@ void z_impl_k_thread_abort(k_tid_t thread)
 			 * situations where the isr check is true but there
 			 * is not an implicit scheduler invocation.
 			 */
-			SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
+			SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
 			/* Clear any system calls that may be pending
 			 * as they have a higher priority than the PendSV
 			 * handler and will check the stack of the thread

--- a/arch/arm/include/cortex_m/kernel_arch_func.h
+++ b/arch/arm/include/cortex_m/kernel_arch_func.h
@@ -90,8 +90,12 @@ static ALWAYS_INLINE int arch_swap(unsigned int key)
 	_current->arch.basepri = key;
 	_current->arch.swap_return_value = -EAGAIN;
 
-	/* set pending bit to make sure we will take a PendSV exception */
-	SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
+	/* Set the pending bit to make sure we will take a PendSV exception.
+	 * PENDSVSET is write-one-to-set and writing zero to the other ICSR
+	 * bits has no effect, so a plain store is sufficient (and avoids a
+	 * read-modify-write that could write back stale state bits).
+	 */
+	SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
 
 	/* clear mask or enable all irqs to take a pendsv */
 	irq_unlock(0);


### PR DESCRIPTION
`arch_swap()`, `z_arm_exc_exit()` and `k_thread_abort()` pend PendSV with `SCB->ICSR |= PENDSVSET`. ICSR's writable bits are all write-one-to-set/write-one-to-clear and writing zero is a no-op, so the read-modify-write is pointless: a plain store is equivalent and one memory access shorter on the two hottest exception paths. It also stops writing back a stale snapshot of the other write-one bits (e.g. re-pending a SysTick whose pend bit got cleared between the read and the write, were the sequence ever preempted mid-RMW).

## Impact (standalone vs `main`)

| | AZ3166 (STM32F412, M4 @ 96 MHz) | mps2/an385 (M3, QEMU icount) |
|---|---|---|
| thread_metric preemptive | **+2.0%** | +1.1% |
| thread_metric cooperative | +1.1% | +1.1% |
| thread_metric interrupt preemption | +0.8% | +0.3% |
| latency_measure Δ, 47 ops (min/max/median) | −2.0/+2.2/+0.0% (placement noise) | mean −1.8% (−5.0/+0.0/−1.1%) |
| k_yield context switch | 241 → 239 cycles | 182 → 180 |
| flash Δ (az3166 image) | −8 B (−Os and −O2) | |

*Latency/cycles and flash: lower is better · thread_metric score: higher is better.*

QEMU icount is instruction-exact: worst-case op is +0.0%. On real M4 hardware individual latency ops move ±2 cycles either way from code placement; the throughput benchmarks stay positive.

## Testing

- Benchmarks above on both targets.
- twister, QEMU mps2/an385 + mps2/an521: `arch/arm/arm_thread_swap` (validates swap return values), `kernel/sched/schedule_api`, `kernel/context` — all pass.
- twister `--device-testing` on az3166_iotdevkit: `arch/arm/arm_thread_swap`, `kernel/sched/schedule_api` — all pass.

