### PR TITLE
arch: arm: mpu: only clear dynamic MPU regions still in use

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -249,6 +249,23 @@ static int mpu_configure_static_mpu_regions(const struct z_arm_mpu_partition
 static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 	dynamic_regions[], uint8_t regions_num)
 {
+#if defined(CONFIG_CPU_CORTEX_M)
+	/* Index one past the highest dynamic MPU region ever programmed.
+	 * All regions at or above this index are known to be disabled, so
+	 * they do not need to be cleared again on every reconfiguration
+	 * (i.e. on every context switch).  UINT8_MAX marks the initial,
+	 * unknown hardware state, making the first call clear all regions
+	 * above the static ones.  A single instance is sufficient: on
+	 * uniprocessor Cortex-M all callers are serialized (context
+	 * switches cannot nest and user-mode entry runs with IRQs locked),
+	 * as the caller's static dynamic_regions[] buffer already assumes.
+	 */
+	static uint8_t dyn_regions_end = UINT8_MAX;
+
+	if (dyn_regions_end == UINT8_MAX) {
+		dyn_regions_end = get_num_regions();
+	}
+#endif
 	int mpu_reg_index = static_regions_num;
 
 	/* In ARMv7-M architecture the dynamic regions are
@@ -258,6 +275,22 @@ static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 	mpu_reg_index = mpu_configure_regions(dynamic_regions,
 		regions_num, mpu_reg_index, false);
 
+#if defined(CONFIG_CPU_CORTEX_M)
+	if (mpu_reg_index == -EINVAL) {
+		/* A partial failure may have left regions enabled above the
+		 * mark: mark the hardware state unknown again so that the
+		 * next call clears everything above the static regions.
+		 */
+		dyn_regions_end = UINT8_MAX;
+		return -EINVAL;
+	}
+
+	/* Disable the non-programmed MPU regions. */
+	for (int i = mpu_reg_index; i < dyn_regions_end; i++) {
+		ARM_MPU_ClrRegion(i);
+	}
+	dyn_regions_end = (uint8_t)mpu_reg_index;
+#else
 	if (mpu_reg_index != -EINVAL) {
 
 		/* Disable the non-programmed MPU regions. */
@@ -265,6 +298,7 @@ static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 			ARM_MPU_ClrRegion(i);
 		}
 	}
+#endif
 
 	return mpu_reg_index;
 }

--- a/arch/arm/core/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v8_internal.h
@@ -743,10 +743,35 @@ static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 {
 	int mpu_reg_index = static_regions_num;
 
+#if defined(CONFIG_CPU_CORTEX_M)
+	/* Index one past the highest dynamic MPU region ever programmed.
+	 * All regions at or above this index are known to be disabled, so
+	 * they do not need to be cleared again on every reconfiguration
+	 * (i.e. on every context switch).  UINT8_MAX marks the initial,
+	 * unknown hardware state, making the first call clear all regions
+	 * above the static ones.  A single instance is sufficient: on
+	 * uniprocessor Cortex-M all callers are serialized (context
+	 * switches cannot nest and user-mode entry runs with IRQs locked),
+	 * as the caller's static dynamic_regions[] buffer already assumes.
+	 */
+	static uint8_t dyn_regions_end = UINT8_MAX;
+
+	if (dyn_regions_end == UINT8_MAX) {
+		dyn_regions_end = get_num_regions();
+	}
+
+	/* Disable the dynamic MPU regions programmed by the previous call
+	 * that are not about to be reprogrammed below.
+	 */
+	for (int i = mpu_reg_index; i < dyn_regions_end; i++) {
+		mpu_clear_region(i);
+	}
+#else
 	/* Disable all MPU regions except for the static ones. */
 	for (int i = mpu_reg_index; i < get_num_regions(); i++) {
 		mpu_clear_region(i);
 	}
+#endif
 
 #if defined(CONFIG_MPU_GAP_FILLING)
 	/* Reset MPU regions inside which dynamic memory regions may
@@ -780,6 +805,19 @@ static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 		regions_num, mpu_reg_index, true);
 
 #endif /* CONFIG_MPU_GAP_FILLING */
+
+#if defined(CONFIG_CPU_CORTEX_M)
+	if (mpu_reg_index == -EINVAL) {
+		/* A partial failure may have left regions enabled above the
+		 * mark: mark the hardware state unknown again so that the
+		 * next call clears everything above the static regions.
+		 */
+		dyn_regions_end = UINT8_MAX;
+	} else {
+		dyn_regions_end = (uint8_t)mpu_reg_index;
+	}
+#endif
+
 	return mpu_reg_index;
 }
 


### PR DESCRIPTION
On every context switch with `MPU_STACK_GUARD` or `USERSPACE`, `mpu_configure_dynamic_mpu_regions()` disables *every* MPU region from the last dynamic one to the end of the MPU — even though those regions are almost always already disabled. On an 8-region MPU with stack guard only, that's 5 wasted region clears (RNR + RASR/RLAR writes) per switch; up to 13 on a 16-region M7. The loop bound also re-read the volatile MPU_TYPE register each iteration.

This tracks a high-water mark (one past the highest dynamic region programmed) and only clears regions the previous configuration actually left enabled. First call still clears everything above the static regions; regions being reprogrammed are handled exactly as before. If a configuration fails partway (`-EINVAL`; release builds continue past the `__ASSERT`), the mark is reset so the next call clears everything above the static regions again. Single static mark is safe: all callers are serialized on uniprocessor Cortex-M (context switches cannot nest, user-mode entry runs with IRQs locked) — the same assumption the static `dynamic_regions[]` buffer in `z_arm_configure_dynamic_mpu_regions()` already makes. Cortex-R keeps the old behavior (ARMv8-R can be SMP).

## Impact (standalone vs `main`, MPU stack guard enabled)

| | AZ3166 (STM32F412, M4 @ 96 MHz) | mps2/an385 (M3, QEMU icount) | mps2/an521 (M33, ARMv8-M, QEMU icount) |
|---|---|---|---|
| k_yield context switch | 419 → 375 cycles (**−10.5%**) | 646 → 579 (−10.4%) | 931 → 872 (−6.3%) |
| ISR return to different thread | 502 → 457 (−9.0%) | 681 → 614 (−9.8%) | 959 → 900 (−6.2%) |
| semaphore give w/ ctx switch | 556 → 508 (−8.6%) | 812 → 745 (−8.3%) | 1064 → 1005 (−5.5%) |
| latency_measure Δ, 47 ops, mean (min/max/median) | −4.6% (−11.0/+2.3/−6.6%) | −3.8% (−10.9/+0.9/−5.1%) | −2.6% (−6.5/+0.0/−4.1%) |
| thread_metric coop / preempt | **+11.0% / +10.5%** | +18.2% / +18.8% | +9.6% / +9.8% |
| flash Δ (az3166 guard image) | +32 B (−Os) / +40 B (−O2) | | |

*Latency/cycles and flash: lower is better · thread_metric score: higher is better.*
*an385/az3166: guard via `HW_STACK_PROTECTION=y`. an521: additionally `BUILTIN_STACK_GUARD=n` so the MPU guard is exercised (the default situation on ARMv8-M cores without PSPLIM); on v8-M the win scales with the number of unused regions the old code cleared through gap filling.*

With `USERSPACE=y`: context-switch-heavy ops improve 3–8% (k_to_k yield: az3166 −4.0%, an521 −7.9%; u_to_u −2.8%/−4.0%). Default builds: unchanged.

## Testing

- Benchmarks above; latency_measure additionally run with `USERSPACE=y` and in default config (no change) on all three targets. QEMU runs are icount-deterministic and byte-identical across repeats; az3166 runs repeat with 0-cycle deltas across full reflash cycles.
- twister, QEMU mps2/an385 + mps2/an521/cpu0 (covers the ARMv7-M and ARMv8-M implementations): `kernel/mem_protect` — 22/22 configurations, 326/326 test cases pass.
- twister `--device-testing` on az3166_iotdevkit: `kernel/mem_protect/{userspace,stackprot,mem_protect}` — all pass.