### PR TITLE
arch: arm: mpu: drop redundant RNR write in ARMv7-M region_init

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -29,11 +29,11 @@ static void mpu_init(void)
 static void region_init(const uint32_t index,
 	const struct arm_mpu_region *region_conf)
 {
+	/* Configure the region */
+#if defined(CONFIG_CPU_AARCH32_CORTEX_R)
 	/* Select the region you want to access */
 	set_region_number(index);
 
-	/* Configure the region */
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R)
 	/*
 	 * Clear size register, which disables the entry.  It cannot be
 	 * enabled as we reconfigure it.
@@ -44,6 +44,10 @@ static void region_init(const uint32_t index,
 	set_region_attributes(region_conf->attr.rasr);
 	set_region_size(region_conf->size | MPU_RASR_ENABLE_Msk);
 #else
+	/* Writing the region number in RBAR.REGION with RBAR.VALID set
+	 * also updates RNR, so the region does not need to be selected
+	 * with a separate RNR write first.
+	 */
 	MPU->RBAR = (region_conf->base & MPU_RBAR_ADDR_Msk)
 				| MPU_RBAR_VALID_Msk | index;
 	MPU->RASR = region_conf->attr.rasr | MPU_RASR_ENABLE_Msk;


### PR DESCRIPTION
Writing RBAR with the VALID bit and region number set also updates RNR (Arm v7-M ARM, B3.5.7), so the separate "select region via RNR" write beforehand is only needed on Cortex-R, whose RBAR variant has no VALID/REGION fields. Move the RNR write into the Cortex-R branch: one less MPU register write per programmed region on every context switch when `MPU_STACK_GUARD` or `USERSPACE` is enabled.

## Impact (standalone vs `main`)

Small by design (one register write per region). QEMU icount, which is instruction-exact, shows it cleanly; on real hardware it sits inside code-placement noise but throughput stays positive:

| | AZ3166 (STM32F412, M4 @ 96 MHz) | mps2/an385 (M3, QEMU icount) |
|---|---|---|
| latency Δ w/ stack guard (min/max/median) | −3.2/+2.4/+0.0% (placement noise) | mean −1.3% (−3.4/+0.0/−0.4%) |
| latency Δ w/ userspace (min/max/median) | mean −0.4% (−2.0/+3.6/−0.5%) | mean −1.1% (−2.9/+0.0/−0.6%) |
| thread_metric coop / preempt (guard) | +0.3% / +0.2% | +0.5% / +0.5% |
| flash Δ (az3166 guard image) | −8 B (−Os) / +8 B (−O2) | |

*Latency/cycles and flash: lower is better · thread_metric score: higher is better.*

## Testing

- Benchmarks above on both targets.
- twister, QEMU mps2/an385 + mps2/an521: `kernel/mem_protect/{mem_protect,userspace,stackprot,syscalls}` (an521 confirms the untouched ARMv8-M path is unaffected) — all pass.
- twister `--device-testing` on az3166_iotdevkit: `kernel/mem_protect/{userspace,stackprot,mem_protect}` — all pass.
