### PR TITLE
arch: arm: mpu: flatten the region programming hot path

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -85,11 +85,18 @@ static const struct arm_mpu_region unmapped_region =
 #include "arm_mpu_v7_internal.h"
 #endif
 
-static int region_allocate_and_init(const uint8_t index,
+/* Cached number of MPU regions, a fixed hardware property.  Reading it
+ * out of the MPU type register costs an MMIO/system register access, and
+ * region_allocate_and_init() runs several times per context switch when
+ * MPU_STACK_GUARD or USERSPACE is enabled, so cache it once at init.
+ */
+static uint8_t num_mpu_regions;
+
+static ALWAYS_INLINE int region_allocate_and_init(const uint8_t index,
 	const struct arm_mpu_region *region_conf)
 {
 	/* Attempt to allocate new region index. */
-	if (index > (get_num_regions() - 1U)) {
+	if (index >= num_mpu_regions) {
 
 		/* No available MPU region index. */
 		LOG_ERR("Failed to allocate new MPU region %u\n", index);
@@ -468,6 +475,8 @@ void z_arm_restore_mpu_context(const struct z_mpu_context_retained *ctx)
 int z_arm_mpu_init(void)
 {
 	uint32_t r_index;
+
+	num_mpu_regions = get_num_regions();
 
 	if (mpu_config.num_regions + MPU_UNMAPPED_REGIONS_NUM > get_num_regions()) {
 		/* Attempt to configure more MPU regions than

--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -26,7 +26,7 @@ static void mpu_init(void)
  * Note:
  *   The caller must provide a valid region index.
  */
-static void region_init(const uint32_t index,
+static ALWAYS_INLINE void region_init(const uint32_t index,
 	const struct arm_mpu_region *region_conf)
 {
 	/* Select the region you want to access */
@@ -85,7 +85,7 @@ static int mpu_partition_is_valid(const struct z_arm_mpu_partition *part)
  * power-of-two value, and the returned SIZE field value corresponds
  * to that power-of-two value.
  */
-static inline uint32_t size_to_mpu_rasr_size(uint32_t size)
+static ALWAYS_INLINE uint32_t size_to_mpu_rasr_size(uint32_t size)
 {
 	/* The minimal supported region size is 32 bytes */
 	if (size <= 32U) {
@@ -110,7 +110,7 @@ static inline uint32_t size_to_mpu_rasr_size(uint32_t size)
  * region attribute configuration and size and fill-in a driver-specific
  * structure with the correct MPU region configuration.
  */
-static inline void get_region_attr_from_mpu_partition_info(
+static ALWAYS_INLINE void get_region_attr_from_mpu_partition_info(
 	arm_mpu_region_attr_t *p_attr,
 	const k_mem_partition_attr_t *attr, uint32_t base, uint32_t size)
 {


### PR DESCRIPTION
Programming one MPU region goes through three nested calls (`mpu_configure_region()` → `region_allocate_and_init()` → `region_init()`), bounces register values through a stack struct, and re-reads the MPU type register (a fixed hardware property) via `get_num_regions()` for every region. With `MPU_STACK_GUARD`/`USERSPACE` this runs several times per context switch, and at the default `-Os` the compiler keeps these helpers out of line.

Cache the region count once at `z_arm_mpu_init()` and force-inline the encode chain, so programming a region reduces to computing the RASR value and storing the MPU registers.

## Impact (standalone vs `main`, `-Os` builds)

| | AZ3166 (STM32F412, M4 @ 96 MHz) | mps2/an385 (M3, QEMU icount) |
|---|---|---|
| userspace: latency Δ, 124 ops (min/max/median) | mean **−4.6%** (−11.7/+10.2/−5.6%)¹ | mean −4.5% (−9.2/+0.2/−5.5%) |
| userspace: k_yield k-to-k | 638 → 569 cycles (−10.8%) | 521 → 479 (−8.1%) |
| userspace: k_yield u-to-u | 989 → 892 (−9.8%) | 774 → 712 (−8.0%) |
| stack guard: k_yield | 472 → 452 (−4.2%) | 364 → 342 (−6.0%) |
| flash Δ (az3166 guard image) | +184 B (−Os) / **−80 B** (−O2) | |

*Latency/cycles and flash: lower is better.* ¹ The +10.2% max is a single placement-outlier op (`thread.start.user`), +0.2% under icount.

Scope notes, measured: default builds (no per-switch MPU work) are unchanged; with `CONFIG_SPEED_OPTIMIZATIONS` the compiler already inlines this chain — QEMU icount shows an instruction-count delta of exactly 0 for the `-O2` thread_metric builds (the same runs move −2.4% on STM32F412 from code placement), and the `-O2` image actually shrinks 80 B since forced inlining drops the out-of-line helper copies.

## Testing

- Benchmarks above; latency_measure in default / stack-guard / userspace configs on both targets.
- twister, QEMU mps2/an385 + mps2/an521: `kernel/mem_protect/{mem_protect,userspace,stackprot,syscalls}` — all pass.
- twister `--device-testing` on az3166_iotdevkit: `kernel/mem_protect/{userspace,stackprot,mem_protect}` — all pass.
