### PR TITLE
[Backport v3.7-branch] net: Fix generation of IPv6 IID and TCP ISN secret keys

### DIFF
--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -167,6 +167,7 @@ config NET_IPV6_RA_RDNSS
 
 config NET_IPV6_PE
 	bool "Privacy extension (RFC 8981) support [EXPERIMENTAL]"
+	depends on CSPRNG_ENABLED
 	select MBEDTLS
 	select MBEDTLS_MD
 	select EXPERIMENTAL

--- a/subsys/net/ip/ipv6_pe.c
+++ b/subsys/net/ip/ipv6_pe.c
@@ -251,7 +251,16 @@ static int gen_temporary_iid(struct net_if *iface,
 	       MIN(sizeof(buf.mac), net_if_get_link_addr(iface)->len));
 
 	if (!once) {
-		sys_rand_get(&secret_key, sizeof(secret_key));
+		/* The secret key must not be guessable, otherwise the
+		 * generated temporary IIDs could be predicted and the
+		 * privacy extension would not provide any protection.
+		 * RFC 8981 ch 3.3.2
+		 */
+		if (sys_csrand_get(secret_key, sizeof(secret_key)) != 0) {
+			NET_ERR("Cannot generate secret key for temporary IID");
+			return -EIO;
+		}
+
 		once = true;
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2292,6 +2292,30 @@ static uint32_t seq_scale(uint32_t seq)
 }
 
 static uint8_t unique_key[16]; /* MD5 128 bits as described in RFC6528 */
+static bool unique_key_valid;
+
+/* The secret key must not be known to an off-path attacker, otherwise the
+ * ISN can be computed from the four-tuple alone. RFC 6528 ch 3
+ */
+static int tcp_init_isn_key(void)
+{
+	int ret = 0;
+
+	k_mutex_lock(&tcp_lock, K_FOREVER);
+
+	if (!unique_key_valid) {
+		ret = sys_csrand_get(unique_key, sizeof(unique_key));
+		if (ret == 0) {
+			unique_key_valid = true;
+		} else {
+			NET_ERR("Cannot generate secret key for TCP ISN");
+		}
+	}
+
+	k_mutex_unlock(&tcp_lock);
+
+	return ret;
+}
 
 static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 			       struct in6_addr *daddr,
@@ -2313,12 +2337,6 @@ static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 
 	uint8_t hash[16];
 	size_t hash_len;
-	static bool once;
-
-	if (!once) {
-		sys_csrand_get(unique_key, sizeof(unique_key));
-		once = true;
-	}
 
 	memcpy(buf.key, unique_key, sizeof(buf.key));
 
@@ -2348,15 +2366,8 @@ static uint32_t tcpv4_init_isn(struct in_addr *saddr,
 
 	uint8_t hash[16];
 	size_t hash_len;
-	static bool once;
-
-	if (!once) {
-		sys_csrand_get(unique_key, sizeof(unique_key));
-		once = true;
-	}
 
 	memcpy(buf.key, unique_key, sizeof(unique_key));
-
 
 	psa_hash_compute(PSA_ALG_SHA_256, (const unsigned char *)&buf, sizeof(buf),
 			 hash, sizeof(hash), &hash_len);
@@ -2368,12 +2379,13 @@ static uint32_t tcpv4_init_isn(struct in_addr *saddr,
 
 #define tcpv6_init_isn(...) (0UL)
 #define tcpv4_init_isn(...) (0UL)
+#define tcp_init_isn_key() (-ENOTSUP)
 
 #endif /* CONFIG_NET_TCP_ISN_RFC6528 */
 
 static uint32_t tcp_init_isn(struct sockaddr *saddr, struct sockaddr *daddr)
 {
-	if (IS_ENABLED(CONFIG_NET_TCP_ISN_RFC6528)) {
+	if (IS_ENABLED(CONFIG_NET_TCP_ISN_RFC6528) && tcp_init_isn_key() == 0) {
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    saddr->sa_family == AF_INET6) {
 			return tcpv6_init_isn(&net_sin6(saddr)->sin6_addr,


### PR DESCRIPTION
Backport 700888e3ecff8474f4fe7dfa8782b8869053222b~3..700888e3ecff8474f4fe7dfa8782b8869053222b from #115807.

_Original PR description:_

---

- Generate the RFC 7217 stable IID and RFC 8981 privacy extension secret keys
  with `sys_csrand_get()` instead of `sys_rand_get()`, and fail IID generation
  rather than deriving addresses from a predictable key.
- Check the result of the RFC 6528 TCP ISN key generation, which previously left
  the key zeroed on failure, and generate it once from a single guarded helper
  instead of two independent flags sharing one key.

https://github.com/zephyrproject-rtos/zephyr/commit/f8b05ede94226b3f749547f46034cd87706dff2e doesn't apply for `v3.7-branch` as `net_ipv6_addr_generate_iid()` didn't exist back then.

Fixes: #116527