### PR TITLE
flash: andes_qspi_nor_xip: add support for volatile SR write

### DIFF
--- a/drivers/flash/flash_andes_qspi.h
+++ b/drivers/flash/flash_andes_qspi.h
@@ -14,6 +14,7 @@
 #define FLASH_ANDES_CMD_PP	0x02    /* Page program */
 #define FLASH_ANDES_CMD_4PP	0x38    /* Quad mode page program*/
 #define FLASH_ANDES_CMD_SE	0x20    /* Sector erase */
+#define FLASH_ANDES_CMD_VOL_SR	0x50    /* Volatile SR Write Enable */
 #define FLASH_ANDES_CMD_BE_32K	0x52    /* Block erase 32KB */
 #define FLASH_ANDES_CMD_BE	0xD8    /* Block erase */
 #define FLASH_ANDES_CMD_CE	0xC7    /* Chip erase */

--- a/drivers/flash/flash_andes_qspi_xip.c
+++ b/drivers/flash/flash_andes_qspi_xip.c
@@ -577,7 +577,7 @@ cleanup:
 }
 
 static __ramfunc int write_status_register(const struct device *dev, uint8_t sr, uint8_t mask,
-					   uint8_t op_read, uint8_t op_write)
+					   uint8_t op_read, uint8_t op_write, bool volatile_write)
 {
 	uint8_t sr_curr;
 	uint8_t sr_new;
@@ -593,7 +593,11 @@ static __ramfunc int write_status_register(const struct device *dev, uint8_t sr,
 	}
 	sr_new = (sr_curr & ~mask) | sr;
 	if (sr_new != sr_curr) {
-		ret = write_protection_set(dev, false);
+		if (volatile_write) {
+			ret = flash_andes_qspi_xip_cmd_write(dev, FLASH_ANDES_CMD_VOL_SR);
+		} else {
+			ret = write_protection_set(dev, false);
+		}
 		if (ret != 0) {
 			return ret;
 		}
@@ -621,19 +625,19 @@ static __ramfunc int flash_andes_qspi_xip_set_status(const struct device *dev,
 	prepare_for_flashing(dev);
 
 	ret = write_status_register(dev, op_out->regs[0], op_out->masks[0], SPI_NOR_CMD_RDSR,
-				    SPI_NOR_CMD_WRSR);
+				    SPI_NOR_CMD_WRSR, op_out->volatile_write);
 	if (ret) {
 		goto cleanup;
 	}
 
 	ret = write_status_register(dev, op_out->regs[1], op_out->masks[1], SPI_NOR_CMD_RDSR2,
-				    SPI_NOR_CMD_WRSR2);
+				    SPI_NOR_CMD_WRSR2, op_out->volatile_write);
 	if (ret) {
 		goto cleanup;
 	}
 
 	ret = write_status_register(dev, op_out->regs[2], op_out->masks[2], SPI_NOR_CMD_RDSR3,
-				    SPI_NOR_CMD_WRSR3);
+				    SPI_NOR_CMD_WRSR3, op_out->volatile_write);
 
 cleanup:
 	cleanup_after_flashing(dev, 0, 0);

--- a/include/zephyr/drivers/flash/andes_flash_xip_api_ex.h
+++ b/include/zephyr/drivers/flash/andes_flash_xip_api_ex.h
@@ -118,6 +118,8 @@ struct andes_xip_ex_ops_set_in {
 	uint8_t regs[3];
 	/** Mask of status registers to change. */
 	uint8_t masks[3];
+	/** Use the volatile write. */
+	bool volatile_write;
 };
 
 /**


### PR DESCRIPTION
Add support for enabling the volatile SR write.

It gives more flexibility how to deal with the flash chip.