### PR TITLE
dts: bindings: dsa: clean up organization

### DIFF
--- a/drivers/ethernet/dsa/Kconfig
+++ b/drivers/ethernet/dsa/Kconfig
@@ -33,13 +33,11 @@ config DSA_NXP_IMX_NETC_GCL_LEN
 # DSA tag protocol drivers
 #   Tag protocol ID found in <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
 
-DSA_PORT_COMPAT := zephyr,dsa-port
-
 config DSA_TAG_PROTOCOL_NETC
 	bool "Tag protocol - NETC"
 	default y
 	select NET_PKT_CONTROL_BLOCK
-	depends on $(dt_compat_any_has_prop,$(DSA_PORT_COMPAT),dsa-tag-protocol,1)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_DSA_PORT),dsa-tag-protocol,1)
 	help
 	  NXP NETC tag protocol.
 

--- a/dts/bindings/dsa/dsa.yaml
+++ b/dts/bindings/dsa/dsa.yaml
@@ -9,6 +9,7 @@ child-binding:
   compatible: "zephyr,dsa-port"
 
   include:
+    - name: base.yaml
     - name: pinctrl-device.yaml
     - name: ethernet-controller.yaml
       property-allowlist:
@@ -22,7 +23,6 @@ child-binding:
 
   properties:
     reg:
-      type: array
       required: true
       description: Port number
     ethernet:

--- a/dts/bindings/dsa/dsa.yaml
+++ b/dts/bindings/dsa/dsa.yaml
@@ -4,34 +4,8 @@
 description: DSA Device
 
 child-binding:
-  description: Properties of port
-
-  compatible: "zephyr,dsa-port"
-
-  include:
-    - name: base.yaml
-    - name: pinctrl-device.yaml
-    - name: ethernet-controller.yaml
-      property-allowlist:
-        - zephyr,random-mac-address
-        - zephyr,mac-address-prefix
-        - local-mac-address
-        - phy-handle
-        - phy-connection-type
-        - ptp-clock
-    - name: nvmem-consumer.yaml
+  include: base.yaml
 
   properties:
-    reg:
-      required: true
-      description: Port number
-    ethernet:
-      type: phandle
-      description:
-        A phandle to a valid Ethernet device node. This host
-        device is what the switch port is connected to.
-    dsa-tag-protocol:
-      type: int
-      description:
-        Tag protocol the switch using. The <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
-        which provides macros should be included to use.
+    compatible:
+      const: "zephyr,dsa-port"

--- a/dts/bindings/dsa/dsa.yaml
+++ b/dts/bindings/dsa/dsa.yaml
@@ -1,7 +1,9 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: DSA Device
+title: DSA Switch
+
+description: Distributed Switch Architecture (DSA) Network Switch
 
 child-binding:
   include: base.yaml

--- a/dts/bindings/dsa/zephyr,dsa-port.yaml
+++ b/dts/bindings/dsa/zephyr,dsa-port.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2025 NXP
+# SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: DSA Device Port
+
+compatible: "zephyr,dsa-port"
+
+include:
+  - name: base.yaml
+  - name: pinctrl-device.yaml
+  - name: ethernet-controller.yaml
+    property-allowlist:
+      - zephyr,random-mac-address
+      - zephyr,mac-address-prefix
+      - local-mac-address
+      - phy-handle
+      - phy-connection-type
+      - ptp-clock
+  - name: nvmem-consumer.yaml
+
+properties:
+  reg:
+    required: true
+    description: Port number
+  ethernet:
+    type: phandle
+    description:
+      A phandle to a valid Ethernet device node. This host
+      device is what the switch port is connected to.
+  dsa-tag-protocol:
+    type: int
+    description:
+      Tag protocol the switch using. The <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
+      which provides macros should be included to use.

--- a/dts/bindings/dsa/zephyr,dsa-port.yaml
+++ b/dts/bindings/dsa/zephyr,dsa-port.yaml
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: DSA Device Port
+title: DSA Switch Port
+
+description: Distributed Switch Architecture (DSA) Network Switch Port
 
 compatible: "zephyr,dsa-port"
 


### PR DESCRIPTION
This is mainly to get rid of the explicit compat variable definition:
```
DSA_PORT_COMPAT := zephyr,dsa-port
```

The core "issue" is that `gen_drivers_kconfig_dts.py` only searches for the `compatible` key on binding files' **top-level**: 
https://github.com/zephyrproject-rtos/zephyr/blob/86dd2f3b0295bd7e1d796ea26c4edfe9e8b0d8a0/scripts/dts/gen_driver_kconfig_dts.py#L82-L85

In this case, the property existed only in a `child-binding` so it was never seen by `gen_driver_kconfig_dts.py` and no options were generated for `zephyr,dsa-port`.

While one might argue that's a bug in `gen_driver_kconfig_dts.py` (our [documentation](https://docs.zephyrproject.org/latest/build/dts/dt-vs-kconfig.html#automatic-kconfig-symbols-from-devicetree) is not completely clear), the way this binding is declared is messy anyways and fixing it avoids the need to change `gen_driver_kconfig_dts.py`, so that's the way I went instead. While at it, gave a fresh coat of paint to the bindings :slightly_smiling_face: 

Note: I think the new approach is slightly more restrictive that before, as the DSA Port nodes must now have `compatible = "zephyr,dsa-port"` whereas *I think* `compatible = "whatever", "zephyr,dsa-port";` *might* have worked previously. I don't think a multi-compatible use case is intended for this so it shouldn't matter too much, and we can always get rid of this later in the future if necessary.