### PR TITLE
arch: riscv: skip the reschedule call on the IRQ exit fast path

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -109,6 +109,7 @@
 
 /* imports */
 GDATA(_sw_isr_table)
+GDATA(_kernel)
 GTEXT(__soc_handle_irq)
 GTEXT(z_riscv_fault)
 GTEXT(z_irq_spurious)
@@ -796,6 +797,20 @@ check_reschedule:
 
 	/* Get pointer to current thread on this CPU */
 	lr a1, ___cpu_t_current_OFFSET(s0)
+
+#if !defined(CONFIG_SMP) && !defined(CONFIG_SCHED_THREAD_USAGE)
+	/*
+	 * Fast path: when the scheduler's ready queue cache still designates
+	 * the current thread, no reschedule is needed.  In that case all of
+	 * the bookkeeping in z_get_next_switch_handle() reduces to no-ops on
+	 * uniprocessor builds (and the stack sentinel, when enabled, was
+	 * already checked above), so the call can be skipped altogether.
+	 * This is the common case when returning from an interrupt.
+	 */
+	la t0, _kernel
+	lr t0, _kernel_offset_to_ready_q_cache(t0)
+	beq t0, a1, no_reschedule
+#endif /* !CONFIG_SMP && !CONFIG_SCHED_THREAD_USAGE */
 
 	/*
 	 * Get next thread to schedule with z_get_next_switch_handle().


### PR DESCRIPTION
On every non-nested interrupt exit, the RISC-V ISR wrapper called `z_get_next_switch_handle()` to ask the scheduler whether a context switch is needed — including the stack juggling around the call and a second stack-sentinel check inside the callee (isr.S already performs one on this path). For the vast majority of interrupts no reschedule is needed and all of that work amounts to nothing.

On uniprocessor builds the scheduler's decision is fully captured by `_kernel.ready_q.cache`: when it still designates the current thread, `z_get_next_switch_handle()` reduces to no-op bookkeeping. This adds a short inline comparison (four instructions) to the interrupt exit path and skips the call entirely in that case — the same way the Arm Cortex-M exception exit decides whether to pend PendSV. The fast path is disabled on SMP (where the decision requires the scheduler lock) and when `CONFIG_SCHED_THREAD_USAGE` accounting must run on every switch decision.

## Results

A/B: base commit vs. base + this patch, identical configs. latency_measure: lower is better; thread_metric: higher is better.

### M5Stack NanoC6 — ESP32-C6 HP core @ 160 MHz (`m5stack_nanoc6/esp32c6/hpcore`)

| Metric | Before | After | Δ |
|---|---|---|---|
| latency_measure: ISR → interrupted thread | 464 ns | 401 ns | **−14%** |
| latency_measure: ISR → different thread | 1099 ns | 1124 ns | +2.3% (fast-path check, taken only when a switch follows) |
| thread_metric: interrupt processing | 10,303,330 | 10,645,986 | **+3.3%** |
| thread_metric: interrupt preemption | 5,027,551 | 5,001,353 | −0.5% |
| thread_metric: preemptive / cooperative scheduling | — | — | unchanged (<0.01%) |
| all 45 other latency_measure metrics | — | — | unchanged (within ±1 tick of the 16 MHz timebase) |

thread_metric values are the median of 3 consecutive 30 s periods; period-to-period spread was below 0.005%. The interrupt-preemption workload reschedules on every interrupt, so it never takes the fast path and only pays the added check — that −0.5% is the expected worst case.

The ISR → different-thread regression is a constant four instructions, paid only when a full context switch (~1.1 µs here) follows anyway — so it adds no jitter and is dwarfed by the switch itself. Against the 63 ns saved on every non-rescheduling interrupt, the change nets out positive whenever more than ~28% of interrupt exits return to the interrupted thread (~10% on qemu_riscv32) — tick and device interrupts overwhelmingly do, which is also why Cortex-M has long used [the same trade-off on exception exit](https://github.com/zephyrproject-rtos/zephyr/blob/161f758ba363ec90cd9b727a5d82e6c86efa85ad/arch/arm/core/cortex_m/exc_exit.c#L57-L61).

### qemu_riscv32 (deterministic QEMU icount)

| Metric | Before | After | Δ |
|---|---|---|---|
| latency_measure: ISR → interrupted thread | 50 cyc | 31 cyc | **−38%** |
| latency_measure: ISR → different thread | 63 cyc | 65 cyc | +3.2% |
| thread_metric: interrupt processing | 1,420,879 | 1,557,774 | **+9.6%** |
| thread_metric: interrupt preemption | 713,682 | 710,438 | −0.45% |

### Code size

Text size delta: +12 B (+0.03% at `-Os`, +0.02% at `-O2`) on qemu_riscv32; +16 B (+0.02%, `-Os`) on ESP32-C6.

## Validation

All passing under QEMU: kernel common/context/sched/workq on qemu_riscv32; mem_protect userspace + stackprot on qemu_riscv32 (exercises every isr.S path including user syscall exits); kernel common/context on qemu_riscv64; kernel common on the 2-CPU SMP variant (fast path compiled out there). Checkpatch: 0 errors, 0 warnings.
