### PR TITLE
modules: nuvoton: declare the BPWM, ECAP, I2S and DMA HAL symbols

### DIFF
--- a/modules/Kconfig.nuvoton
+++ b/modules/Kconfig.nuvoton
@@ -51,6 +51,22 @@ menu "Nuvoton NuMaker drivers"
 		bool "NuMaker PWM"
 		help
 		  Enable Nuvoton PWM HAL module driver
+	config HAS_NUMAKER_BPWM
+		bool "NuMaker BPWM"
+		help
+		  Enable Nuvoton Basic PWM (BPWM) HAL module driver
+	config HAS_NUMAKER_ECAP
+		bool "NuMaker ECAP"
+		help
+		  Enable Nuvoton Enhanced Input Capture (ECAP) HAL module driver
+	config HAS_NUMAKER_I2S
+		bool "NuMaker I2S"
+		help
+		  Enable Nuvoton I2S HAL module driver
+	config HAS_NUMAKER_DMA
+		bool "NuMaker PDMA"
+		help
+		  Enable Nuvoton Peripheral DMA (PDMA) HAL module driver
 	config HAS_NUMAKER_USBD
 		bool "NuMaker USB 1.1 device controller"
 		help


### PR DESCRIPTION
`hal_nuvoton` ships `src/bpwm.c`, `src/ecap.c`, `src/i2s.c` and `src/pdma.c` but has no Kconfig symbol to gate them on, so no driver can reach the 59 functions they define.

`m335x/StdDriver/CMakeLists.txt:19` already gates `src/pdma.c` on `CONFIG_HAS_NUMAKER_DMA` — a symbol this file never declares, so **that line has never been able to fire either**.

These four follow the existing entries exactly, and a driver opts in the same way the in-tree ones do (`select HAS_NUMAKER_PWM`, `select HAS_NUMAKER_TMR`).

### Companion PR

zephyrproject-rtos/hal_nuvoton#37 adds the source lines for `m55m1x`. **The two are independently mergeable in either order**, since an undeclared symbol makes a CMake gate false rather than an error.

### Testing

Built for a Cortex-M55 (M55M1) with all four symbols set: the four vendor objects compile clean and `zephyr.elf` came out byte-for-byte the same size as without them, because `--gc-sections` drops what nothing calls.