### PR TITLE
drivers: ethernet: numaker: two link and descriptor fixes

### DIFF
--- a/drivers/ethernet/Kconfig.numaker
+++ b/drivers/ethernet/Kconfig.numaker
@@ -7,6 +7,7 @@ config ETH_NUMAKER
 	bool "Nuvoton NUMAKER MCU Ethernet driver"
 	default y
 	select HAS_NUMAKER_ETH
+	select HAS_NUMAKER_FMC
 	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_ETHERNET_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT

--- a/drivers/ethernet/eth_numaker.c
+++ b/drivers/ethernet/eth_numaker.c
@@ -632,7 +632,8 @@ static void eth_numaker_isr(const struct device *dev)
 		synopGMAC_reset(gmacdev); /* reset the DMA engine and the GMAC ip */
 		synopGMAC_set_mac_address(NUMAKER_GMAC_INTF, data->mac_addr);
 		synopGMAC_dma_bus_mode_init(gmacdev, DmaFixedBurstEnable | DmaBurstLength8 |
-							     DmaDescriptorSkip0);
+							     DmaDescriptorSkip0 |
+							     DmaDescriptor8Words);
 		synopGMAC_dma_control_init(gmacdev, DmaStoreAndForward);
 		synopGMAC_init_rx_desc_base(gmacdev);
 		synopGMAC_init_tx_desc_base(gmacdev);


### PR DESCRIPTION
Two independent bugs in `eth_numaker`, one commit each. Neither is a feature — both are cases where the driver is wrong today for anyone using it.

### 1. The driver links only by accident

`eth_numaker.c` derives the MAC address from the chip UID: `FMC_Open()`, `FMC_ReadUID()` ×3, `FMC_Close()`. `FMC_ReadUID` is a static inline in the HAL's `fmc.h` that references the global `g_FMC_i32ErrCode`, defined in `StdDriver/src/fmc.c` — which `hal_nuvoton` compiles only under `CONFIG_HAS_NUMAKER_FMC`.

`ETH_NUMAKER` does not select it. Only `drivers/flash/Kconfig.numaker` and `drivers/hwinfo/Kconfig.numaker` do, so **the Ethernet driver links only when an application happens to enable one of those**. An application with networking and nothing else fails at link with

```
fmc.h: undefined reference to `g_FMC_i32ErrCode'
dangerous relocation: unsupported relocation
```

which names neither the Ethernet driver nor FMC.

### 2. Bus-error recovery halves the descriptor stride

The rings are `DmaDesc`, the 8-word enhanced form, and `eth_numaker_init()` programs the bus mode with `DmaDescriptor8Words` to match. The fatal-bus-error path in `eth_numaker_isr()` re-programs the bus mode and **omits it**.

The rings are `RINGMODE` with a descriptor skip of 0, so the MAC strides by the descriptor size it has been told to use. After recovery it is told 4 words while the ring is still 32-byte entries, so it walks the ring at half stride and reads the wrong descriptors from that point on — silently, since nothing re-validates the ring. It also loses the extended words, so a build using the descriptor timestamps stops receiving them after any bus error.

### Testing

Both reproduced on M55M1 (Cortex-M55). The first with `CONFIG_NETWORKING`, `CONFIG_NET_L2_ETHERNET` and `CONFIG_ETH_NUMAKER` set and no flash or hwinfo driver — the one-line `select` fixes it and costs nothing where FMC was already selected. `checkpatch` clean.