### PR TITLE
drivers: lora: shell: fix bandwidth, spreading factor and frequency handling

### DIFF
--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -25,12 +25,6 @@ static struct lora_modem_config modem_config = {
 	.tx_power = 4,
 };
 
-static const int bw_table[] = {
-	[BW_125_KHZ] = 125,
-	[BW_250_KHZ] = 250,
-	[BW_500_KHZ] = 500,
-};
-
 static int parse_long(long *out, const struct shell *sh, const char *arg)
 {
 	char *eptr;
@@ -133,7 +127,7 @@ static int lora_conf_dump(const struct shell *sh)
 	shell_print(sh, "  TX power: %" PRIi8 " dBm",
 		    modem_config.tx_power);
 	shell_print(sh, "  Bandwidth: %i kHz",
-		    bw_table[modem_config.bandwidth]);
+		    (int)modem_config.bandwidth);
 	shell_print(sh, "  Spreading factor: SF%i",
 		    (int)modem_config.datarate);
 	shell_print(sh, "  Coding rate: 4/%i",
@@ -165,24 +159,32 @@ static int lora_conf_set(const struct shell *sh, const char *param,
 			return -EINVAL;
 		}
 		switch (lval) {
-		case 125:
-			modem_config.bandwidth = BW_125_KHZ;
-			break;
-		case 250:
-			modem_config.bandwidth = BW_250_KHZ;
-			break;
-		case 500:
-			modem_config.bandwidth = BW_500_KHZ;
+		case BW_7_KHZ:
+		case BW_10_KHZ:
+		case BW_15_KHZ:
+		case BW_20_KHZ:
+		case BW_31_KHZ:
+		case BW_41_KHZ:
+		case BW_62_KHZ:
+		case BW_125_KHZ:
+		case BW_200_KHZ:
+		case BW_250_KHZ:
+		case BW_400_KHZ:
+		case BW_500_KHZ:
+		case BW_800_KHZ:
+		case BW_1000_KHZ:
+		case BW_1600_KHZ:
+			modem_config.bandwidth = lval;
 			break;
 		default:
 			shell_error(sh, "Invalid bandwidth: %ld", lval);
 			return -EINVAL;
 		}
 	} else if (!strcmp("sf", param)) {
-		if (parse_long_range(&lval, sh, value, "sf", 6, 12) < 0) {
+		if (parse_long_range(&lval, sh, value, "sf", SF_5, SF_12) < 0) {
 			return -EINVAL;
 		}
-		modem_config.datarate = SF_6 + (unsigned int)lval - 6;
+		modem_config.datarate = lval;
 	} else if (!strcmp("cr", param)) {
 		if (parse_long_range(&lval, sh, value, "cr", 5, 8) < 0) {
 			return -EINVAL;

--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/drivers/lora.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
@@ -66,6 +67,7 @@ static int parse_freq(uint32_t *out, const struct shell *sh, const char *arg)
 	char *eptr;
 	unsigned long val;
 
+	errno = 0;
 	val = strtoul(arg, &eptr, 0);
 	if (*eptr != '\0') {
 		shell_error(sh, "Invalid frequency, '%s' is not an integer",
@@ -73,7 +75,7 @@ static int parse_freq(uint32_t *out, const struct shell *sh, const char *arg)
 		return -EINVAL;
 	}
 
-	if (val == ULONG_MAX) {
+	if (errno == ERANGE || val > UINT32_MAX) {
 		shell_error(sh, "Frequency %s out of range", arg);
 		return -EINVAL;
 	}

--- a/tests/drivers/build_all/lora/sx1262.overlay
+++ b/tests/drivers/build_all/lora/sx1262.overlay
@@ -4,6 +4,10 @@
  */
 
 / {
+	aliases {
+		lora0 = &test_semtech_sx1262;
+	};
+
 	test {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/tests/drivers/build_all/lora/tests.yaml
+++ b/tests/drivers/build_all/lora/tests.yaml
@@ -19,6 +19,16 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+  sample.drivers.lora.build.sx1262.shell:
+    build_only: true
+    extra_args: DTC_OVERLAY_FILE="sx1262.overlay"
+    extra_configs:
+      - CONFIG_SPI=y
+      - CONFIG_SHELL=y
+      - CONFIG_LORA_SHELL=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
   sample.drivers.lora.build.sx1262.native:
     build_only: true
     extra_args: DTC_OVERLAY_FILE="sx1262.overlay"


### PR DESCRIPTION
Fixes #116611

The `lora` shell went stale when `enum lora_signal_bandwidth` and `enum lora_datarate` were renumbered in 6b2f1c19aca to carry their kHz and spreading factor values directly.

- Restores access to all 15 bandwidths and to SF5, and drops the sparse 501 entry `bw_table` that the renumbering created.
- Fixes `parse_freq()` accepting out of range frequencies that were then truncated to 0 Hz on 64-bit hosts.
- Enables `CONFIG_LORA_SHELL=y` in `tests/drivers/build_all/lora`, which had no shell coverage at all. This is a build check only, but the shell was previously never compiled in CI, which is how the breakage went unnoticed.

Both fixes were verified at runtime on `native_sim` and `native_sim/native/64`; the frequency truncation was confirmed against a pre-fix binary.

Please consider for backport to `v4.4-branch` — both defects are present in v4.4.x.