### PR TITLE
doc: build: dts: indicate that `compatible` is for top-level only

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -184,6 +184,15 @@ vendor. In these cases, there is no vendor prefix. One example is the
 :dtcompatible:`gpio-leds` compatible which is commonly used to describe board
 LEDs connected to GPIOs.
 
+.. note::
+
+    The ``compatible`` key should not be used inside a ``child-binding``.
+
+    To enforce a specific value as the ``compatible`` of a node's children,
+    use the :ref:`const key <dt-bindings-properties>` on the ``compatible``
+    *property* in the ``child-binding`` and describe the properties of that
+    compatible in a distinct binding file instead.
+
 .. _dt-bindings-properties:
 
 Properties

--- a/doc/build/dts/dt-vs-kconfig.rst
+++ b/doc/build/dts/dt-vs-kconfig.rst
@@ -80,7 +80,7 @@ During the devicetree processing step, CMake runs
 :ref:`DTS root <dts_root>` directories, including :zephyr_file:`dts/bindings` and
 writes ``Kconfig.dts`` into the build's ``KCONFIG_BINARY_DIR`` (for example
 ``<build>/zephyr`` or ``<build>/<image>/zephyr`` in case of :ref:`sysbuild`).
-For each ``compatible = "vendor,chip"`` that appears in a binding, the generated
+For each ``compatible: "vendor,chip"`` key that appears in bindings, the generated
 file contains:
 
 .. code-block:: kconfig
@@ -113,3 +113,18 @@ Because these symbols are generated automatically, adding a new binding with
 a ``compatible`` property is all that is required to make the corresponding
 ``DT_HAS_<compatible>_ENABLED`` and ``DT_COMPAT_<compatible>`` constructs
 available to Kconfig.
+
+  .. warning::
+
+    Only the *top-level* ``compatible`` key found in binding files is taken
+    into account by :zephyr_file:`scripts/dts/gen_driver_kconfig_dts.py`.
+    ``compatible`` keys present in a ``child-binding`` will be ignored and
+    no Kconfig symbols will be generated for these compatibles.
+
+    In general, the ``compatible`` key should not be present in a ``child-binding``.
+    Refer to :ref:`the following page <dt-bindings-compatible>` for more information.
+
+    If the ``compatible`` property is important, create a distinct binding file and
+    declared properties in it instead. This distinct binding file will be picked up
+    properly by :zephyr_file:`scripts/dts/gen_driver_kconfig_dts.py` and Kconfig
+    options will be generated for it.


### PR DESCRIPTION
The `compatible` key should only be used at top-level in a binding. On paper, it *can* be used inside a `child-binding` but this causes issues with gen_driver_kconfig_dts.py and is usually an antipattern.

Add a note in the documentation to make this usage forbidden and indicate the alternative: create a distinct binding for the child nodes, and make the `compatible` *property* required on the parent (instead of using the `compatible` **key** on the `child-binding`).

Related: https://github.com/zephyrproject-rtos/zephyr/pull/116605