### PR TITLE
samples: net: zperf: Add per-function CPU profiling of the loopback run

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -12,6 +12,7 @@ on:
       - 'scripts/build/**'
       - 'scripts/cmake/**'
       - 'scripts/kconfig/**'
+      - 'samples/net/zperf/scripts/**'
       - '.github/workflows/scripts_tests.yml'
   pull_request:
     branches:
@@ -21,6 +22,7 @@ on:
       - 'scripts/build/**'
       - 'scripts/cmake/**'
       - 'scripts/kconfig/**'
+      - 'samples/net/zperf/scripts/**'
       - '.github/workflows/scripts_tests.yml'
 
 permissions:
@@ -77,4 +79,5 @@ jobs:
           ZEPHYR_BASE: ./
         run: |
           echo "Run script tests"
-          pytest ./scripts/build ./scripts/cmake ./scripts/kconfig
+          pytest ./scripts/build ./scripts/cmake ./scripts/kconfig \
+              ./samples/net/zperf/scripts

--- a/samples/net/zperf/Kconfig
+++ b/samples/net/zperf/Kconfig
@@ -90,6 +90,31 @@ config ZPERF_LOOPBACK_SELFTEST_PORT
 	int "Loopback selftest server port"
 	default 5001
 
+config ZPERF_LOOPBACK_SELFTEST_ONLY
+	string "Run only the named transfer"
+	default ""
+	help
+	  Run a single transfer instead of all of them. The value is one of
+	  the labels used in the ZPERF-RESULT output: udp4, udp4_frag, tcp4,
+	  tcp4_nodelay, udp6, udp6_frag, tcp6 or tcp6_nodelay. An empty
+	  value, the default, runs all of them and leaves the throughput
+	  scenario unchanged. A value matching no label runs no transfer at
+	  all, which yields a boot-only reference run.
+
+	  Profiling the run needs one transfer at a time: a profile collected
+	  over all eight blends UDP, TCP, fragmentation and both IP families
+	  into an average that is attributable to none of them, and the
+	  boot-only run gives the boot cost to subtract from the others.
+
+config ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE
+	bool "Halt the machine once the selftest is done"
+	help
+	  Halt the machine after printing ZPERF-DONE instead of returning
+	  from main() and idling forever. Under QEMU this leaves the emulator
+	  through the isa-debug-exit device, which matters when an external
+	  profiler is attached: QEMU writes an instrumentation report from an
+	  atexit handler, and that handler never runs while the guest idles.
+
 endif # ZPERF_LOOPBACK_SELFTEST
 
 source "Kconfig.zephyr"

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -36,6 +36,10 @@ backend that would otherwise break icount determinism.
    instructions-per-byte), not a real line rate. Only compare values captured
    with the same icount shift, packet size, and tick rate.
 
+This check reports one number per transfer, which is enough to notice a
+regression but not to locate it. To attribute the same run's cost to individual
+functions, see :ref:`zperf-loopback-profiling`.
+
 How it works
 ************
 

--- a/samples/net/zperf/README-loopback-profiling.rst
+++ b/samples/net/zperf/README-loopback-profiling.rst
@@ -1,0 +1,237 @@
+:orphan:
+
+.. _zperf-loopback-profiling:
+
+Per-function profiling of the zperf loopback run
+################################################
+
+Overview
+********
+
+:ref:`zperf-loopback-icount` measures the networking stack's throughput as a
+deterministic, host independent number. That number says whether the stack got
+slower, not where the cycles went.
+
+This describes how to break the same run down per function. The guest runs
+under a QEMU TCG plugin that counts executed instructions per translation
+block; the blocks are then mapped back onto the functions in the build's ELF
+file. The result is a table of instructions attributed to each function, one
+transfer type at a time.
+
+Under ``-icount shift=N`` one guest instruction is 2\ :sup:`N` ns of virtual
+time, so throughput is a closed form function of the instructions spent per
+payload byte:
+
+.. code-block:: none
+
+   Mbps = 8000 / (2**shift * ipb)          at shift=5:  Mbps = 250 / ipb
+
+A per-function breakdown of ``ipb`` is therefore a decomposition of the
+reported throughput rather than a correlated proxy for it. That is what makes
+the last column of the report, the throughput this transfer would reach if a
+given function cost nothing, meaningful.
+
+.. note::
+
+   The plugin is not part of Zephyr. QEMU's plugin interface header
+   :file:`include/qemu/qemu-plugin.h` is ``GPL-2.0-or-later``, so a plugin
+   built against it is a derivative work of QEMU, while this tree carries only
+   ``Apache-2.0`` and ``CC-BY-4.0`` (see :file:`LICENSES/`). Only the
+   Apache-2.0 driver, the setup recipe and this document are in the tree; the
+   plugin is fetched from QEMU and built outside the repository. Nothing GPL
+   licensed is redistributed with Zephyr, and neither the Zephyr build nor its
+   CI downloads or builds any of it.
+
+Relation to the in-guest perf tool
+**********************************
+
+Zephyr has a second, unrelated profiler. Pick whichever fits the question:
+
+* :ref:`profiling-perf` samples the guest's own call stacks from a timer
+  interrupt, so it gives call graphs and works on real hardware, but it
+  perturbs what it measures, needs a shell and only reports what it managed to
+  sample. Its output is post-processed with
+  :zephyr_file:`scripts/profiling/stackcollapse.py` into FlameGraph format.
+* This workflow counts every instruction from outside the guest, so it is
+  exact, reproducible and adds no guest overhead, but it is flat: a TCG plugin
+  sees translation blocks, not stack frames, so there are no call graphs and
+  only emulated targets are supported.
+
+Prerequisites
+*************
+
+Build the plugins once. The QEMU tag has to match the emulator that will load
+them, because the loader checks the plugin API version; check yours with
+``qemu-system-i386 --version``.
+
+.. code-block:: console
+
+   samples/net/zperf/scripts/qemu_plugin_setup.sh ../tools/qemu-plugins
+
+This downloads two plugins from QEMU, raises the report limit in one of them
+and compiles them with :command:`gcc`. It needs :command:`curl`,
+:command:`gcc` and the glib development files; all of QEMU does *not* have to
+be built, because a plugin resolves QEMU's symbols at load time.
+
+.. note::
+
+   Released QEMU versions print only the twenty hottest blocks: the limit is a
+   hardcoded constant in ``contrib/plugins/hotblocks.c`` and the plugin parses
+   no argument for it. The setup script raises it. If a report is ever
+   truncated anyway, :file:`scripts/zperf_profile.py` detects the mismatch
+   between the block count in the report header and the number of rows, and
+   warns instead of quietly understating the cost.
+
+Usage
+*****
+
+Profile every transfer, boot cost removed:
+
+.. code-block:: console
+
+   samples/net/zperf/scripts/zperf_profile.py run --base-dir .. \
+       --plugin ../tools/qemu-plugins/lib/libhotblocks.so \
+       --outdir ../build/zprof --save ../build/zprof/profile.json
+
+For each transfer this builds the sample with
+:kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_ONLY` set to that transfer and
+:kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE` enabled, then runs
+it twice: once to completion, and once stopped as it reaches :c:func:`main` to
+measure the boot cost. The second profile is subtracted from the first.
+
+Restrict the work with ``--transfers``, for example ``--transfers tcp4 udp4``.
+
+To re-report on an already collected run, or to use a plugin report produced by
+hand:
+
+.. code-block:: console
+
+   samples/net/zperf/scripts/zperf_profile.py report --base-dir .. \
+       --report ../build/zprof/tcp4.report \
+       --boot-report ../build/zprof/tcp4.boot.report \
+       --console ../build/zprof/tcp4.console \
+       --elf ../build/zprof/tcp4/zephyr/zephyr.elf --label tcp4 --top 25
+
+To compare two commits, save a profile on each and diff them. The comparison is
+on instructions per byte, so it is unaffected by how long each run happened to
+last:
+
+.. code-block:: console
+
+   samples/net/zperf/scripts/zperf_profile.py diff --base-dir .. \
+       --baseline ../build/zprof-base/profile.json \
+       --current ../build/zprof/profile.json --tolerance 1
+
+:file:`diff` exits non-zero when a transfer needs more than ``--tolerance``
+percent more instructions per byte than the baseline, which makes it usable as
+a follow-up to the throughput gate in
+:file:`samples/net/zperf/scripts/zperf_regression.py`: that one answers whether
+throughput dropped, this one answers which function caused it.
+
+Why one transfer per run
+========================
+
+The selftest normally runs eight transfers in one boot. A profile collected
+over all eight blends UDP, TCP, fragmentation and both IP families into an
+average that is attributable to none of them, so
+:kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_ONLY` restricts a build to one.
+Absolute numbers therefore differ slightly from a full eight transfer run,
+where earlier transfers warm caches and allocator state; compare profiles taken
+with the same setting.
+
+Interpreting the output
+***********************
+
+The header states how the run adds up (values are illustrative)::
+
+   === tcp4 (qemu_x86) ===
+   instructions      31,889,702   payload      791,780 B   ipb   40.276   boot subtracted 6,840,845
+   throughput   measured    6.325 Mbps   from profile    6.207 Mbps   cpu-bound  98.1%
+   attribution  exact 96.38%   inferred  3.62%   unattributed  0.00%
+
+``from profile`` is the throughput implied by the instruction count. Because
+``sleep=off`` lets halted time advance virtual time without executing
+instructions, the ratio to the measured value is the fraction of the run that
+was CPU bound; the remainder is time the guest spent waiting, which for TCP is
+mostly waiting for acknowledgements. A ratio above 100% means the accounting is
+wrong, not that the stack is fast.
+
+``unattributed`` should be essentially zero once the boot cost is subtracted.
+Before subtraction it is dominated by the BIOS the guest boots through.
+
+Then follows the per-function table, and a roll-up by subsystem group.
+
+Two limitations are worth keeping in mind when reading the table:
+
+* The sample is built with :kconfig:option:`CONFIG_SPEED_OPTIMIZATIONS`, so
+  small static helpers are inlined into their callers and are charged to them.
+  Lowering the optimisation level to separate them would change the code being
+  measured, so it is not done.
+* A translation block is attributed to the function containing its first
+  instruction. Blocks end at branches, so they rarely straddle two functions,
+  but hand written assembly without symbol sizes is attributed up to the next
+  entry point; the ``inferred`` share in the header says how much of the run
+  that covers.
+
+Correctness of the measurement
+******************************
+
+The plugin's callbacks run on the host and execute no guest instructions, so
+attaching it does not change what the guest does. This is worth re-checking
+after a QEMU or plugin upgrade: run the same build with and without
+``-plugin``, and every ``ZPERF-RESULT`` line must be identical.
+
+The instruction counts are reproducible but not bit-identical: repeated runs of
+the same binary agree to within about 0.03% of the total. The residual sits
+entirely in the logging subsystem (``cbprintf_package_convert``, the
+``mpsc_pbuf`` ring and the log message handlers), because the deferred log
+thread is scheduled independently of the traffic and does a slightly different
+amount of work per wakeup. The console output itself is identical. That
+variation is two orders of magnitude below the share of any function worth
+optimising, but it does mean a reported difference of a few hundredths of a
+percent is noise rather than a finding.
+
+The boot subtraction uses the same binary stopped at :c:func:`main` rather than
+a separate boot-only build, so the instruction stream it covers is identical to
+the full run's prefix and the subtraction is exact. :file:`zperf_profile.py`
+verifies this: if any block ran more often in the shorter run, the two runs did
+not share a prefix and it refuses to report a result.
+
+Two checks confirm that the attribution itself is meaningful rather than merely
+self-consistent. Both were run on ``udp4`` on ``qemu_x86``.
+
+Halving :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE` from 1220
+to 610 bytes doubles the number of packets carrying the same payload. Costs
+that scale with bytes must then stay flat per byte, and costs that scale with
+packets must double. Measured ratios of instructions per byte, 610 B against
+1220 B:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Function
+     - Ratio
+     - Scales with
+   * - ``memcpy``
+     - 1.02
+     - bytes
+   * - ``calc_chksum``
+     - 1.15
+     - bytes, plus a fixed per-packet part
+   * - ``net_pkt_get_contiguous_len``
+     - 2.00
+     - packets
+   * - ``z_impl_k_mutex_lock`` / ``_unlock``
+     - 2.00
+     - packets
+   * - ``rb_remove`` / ``rb_insert``
+     - 2.00
+     - packets
+   * - ``zvfs_poll_internal``
+     - 2.00
+     - packets
+
+Setting :kconfig:option:`CONFIG_NET_UDP_CHECKSUM` to ``n`` removes the receive
+side checksum verification, one of the two passes the loopback path makes over
+each datagram. ``calc_chksum`` loses 0.95 instructions per payload byte, which
+is one pass, and throughput rises from 13.353 to 14.396 Mbps.

--- a/samples/net/zperf/README-loopback-profiling.rst
+++ b/samples/net/zperf/README-loopback-profiling.rst
@@ -146,15 +146,33 @@ The header states how the run adds up (values are illustrative)::
 
    === tcp4 (qemu_x86) ===
    instructions      31,889,702   payload      791,780 B   ipb   40.276   boot subtracted 6,840,845
-   throughput   measured    6.325 Mbps   from profile    6.207 Mbps   cpu-bound  98.1%
+   throughput   measured    6.325 Mbps   from profile    6.207 Mbps   in-window  98.1%
+   virtual time profiled 1.020461 s of cpu   transfer window 1.001400 s   outside the window +0.019061 s
    attribution  exact 96.38%   inferred  3.62%   unattributed  0.00%
 
-``from profile`` is the throughput implied by the instruction count. Because
-``sleep=off`` lets halted time advance virtual time without executing
-instructions, the ratio to the measured value is the fraction of the run that
-was CPU bound; the remainder is time the guest spent waiting, which for TCP is
-mostly waiting for acknowledgements. A ratio above 100% means the accounting is
-wrong, not that the stack is fast.
+``from profile`` is the throughput implied by the instruction count. It is
+computed over everything the profile covers, from the boot boundary to the
+halt, while ``measured`` covers only the transfer the guest timed, so
+``in-window`` is the share of the profiled cost that the timed transfer
+accounts for. The rest is the network initialisation, the socket setup and the
+result reporting either side of it, and the line below states the same thing in
+seconds so the residual is a number rather than an inference.
+
+It is worth being clear about which way idle time moves that figure, because
+the obvious guess is the wrong one. ``sleep=off`` lets halted time advance
+virtual time without executing instructions, so time the guest spends waiting
+inside the timed window makes the window longer without adding a single
+instruction to the profile. Idle time therefore pushes ``in-window`` *above*
+100%, and a figure below it means the opposite thing: work was done outside the
+window.
+
+On loopback there is next to no waiting, and the measurements say so. The
+residual is 16.5 to 19.6 ms on every one of the eight transfers, and
+``in-window`` sits between 98.1% and 98.4% across UDP, TCP, fragmented UDP and
+builds with quite different code in them. A genuine idle fraction would not
+hold that still; a fixed block of setup and reporting work does. TCP's slightly
+lower figure is a slightly larger teardown, not time spent waiting for
+acknowledgements.
 
 ``unattributed`` should be essentially zero once the boot cost is subtracted.
 Before subtraction it is dominated by the BIOS the guest boots through.

--- a/samples/net/zperf/README-loopback-profiling.rst
+++ b/samples/net/zperf/README-loopback-profiling.rst
@@ -235,3 +235,96 @@ Setting :kconfig:option:`CONFIG_NET_UDP_CHECKSUM` to ``n`` removes the receive
 side checksum verification, one of the two passes the loopback path makes over
 each datagram. ``calc_chksum`` loses 0.95 instructions per payload byte, which
 is one pass, and throughput rises from 13.353 to 14.396 Mbps.
+
+Checking it automatically
+*************************
+
+The ``verify`` subcommand runs those checks, and several more, in one go. It
+needs QEMU and the plugins, so it is not part of CI; the unit tests next to the
+script are, and they cover the parsing, the symbol lookup and the arithmetic.
+What ``verify`` adds is everything that can only be established against
+something outside the script::
+
+   samples/net/zperf/scripts/zperf_profile.py verify --base-dir .. \
+       --plugin ../tools/qemu-plugins/lib/libhotblocks.so \
+       --outdir ../build/zprof-verify --board qemu_x86
+
+It builds one transfer, runs it several ways and reports:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Check
+     - What it establishes, and against what
+   * - instruction count
+     - QEMU's own ``libinsn.so`` is loaded alongside ``libhotblocks.so`` in the
+       same run. It counts once per instruction where hotblocks counts once per
+       translation block, so the two totals come from unrelated code inside
+       QEMU. See the note below on why they are close rather than equal.
+   * - conservation
+     - The per-function totals, the per-kind totals and the block sum are the
+       same number, so nothing is lost or invented between the report and the
+       table.
+   * - attribution
+     - Once the boot prefix is subtracted, essentially no instruction belongs
+       to no function. What is left is the BIOS, and there should be none of it.
+   * - symbol table
+     - Every sized function ``nm`` reports is the function this script names at
+       both its first and its last byte. binutils and pyelftools read the same
+       ELF through no shared code. On both boards all 1279 and 1267 sized
+       functions agree.
+   * - non-perturbation
+     - The guest reports the same throughput with the plugins loaded and
+       without them, so watching it does not change what it does.
+   * - determinism
+     - Two identical runs land on the same instruction count, within 0.001%.
+   * - prediction
+     - The one that matters, and the only one that tests the interpretation
+       rather than the plumbing. The build is repeated with
+       :kconfig:option:`CONFIG_NET_UDP_CHECKSUM` set to ``n``, and the
+       throughput change the profile implies is compared against the change the
+       guest measures.
+
+The prediction check is worth stating in full, because it is what makes
+"instructions per payload byte" a decomposition of the throughput rather than a
+quantity that merely correlates with it. Removing the receive side UDP checksum
+takes 1.37 instructions per byte out of ``udp4`` on ``qemu_x86``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Board
+     - Predicted from the profile
+     - Measured by the guest
+     - Difference
+   * - ``qemu_x86``
+     - +7.76%
+     - +7.81%
+     - 0.05 points
+   * - ``qemu_x86_64``
+     - +6.84%
+     - +6.86%
+     - 0.02 points
+
+Blocks are an upper bound
+=========================
+
+The instruction count check does not require the two plugins to agree exactly,
+and they do not: hotblocks comes out 0.62% high on ``qemu_x86`` and 0.22% high
+on ``qemu_x86_64``.
+
+The direction is not a coincidence. Counting per block charges a whole block as
+soon as execution enters it, while counting per instruction charges only what
+ran, so the two can part company only where a block is entered and not
+completed, and only in that direction. Every per-function figure here is
+therefore an upper bound, slightly overstating whatever code is left early.
+
+The gap is not the timer: raising the tick rate from 1 kHz to 10 kHz, which is a
+tenfold change in how often the clock driver runs, moves it from 0.635% to
+0.618%. It is essentially a constant.
+
+For comparing two builds it very largely cancels, which is what the prediction
+check above demonstrates: a systematic 0.62% bias on both sides still leaves the
+predicted and the measured change 0.05 points apart. For reading an absolute
+instructions-per-byte figure, treat it as a ceiling.

--- a/samples/net/zperf/scripts/qemu_plugin_setup.sh
+++ b/samples/net/zperf/scripts/qemu_plugin_setup.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# Fetch and build the QEMU TCG plugins that zperf_profile.py drives.
+#
+# The plugins themselves are QEMU's own, and they are deliberately NOT carried
+# in the Zephyr tree: they are built against a QEMU header, which makes them
+# derivative works of QEMU, and QEMU's terms are not among those this tree
+# carries (the LICENSES directory lists what it does). This script contains no
+# QEMU code. It downloads the sources, adjusts one constant and compiles them
+# into a directory outside the repository. Nothing it produces is redistributed
+# with Zephyr, and neither the Zephyr build nor its CI runs it. See
+# samples/net/zperf/README-loopback-profiling.rst for the full reasoning.
+#
+# Two plugins are built:
+#
+#   libhotblocks.so    counts executed instructions per translation block
+#   libstoptrigger.so  stops the guest at an address, used to measure the boot
+#                      cost that is subtracted from each transfer profile
+#
+# Usage:
+#   samples/net/zperf/scripts/qemu_plugin_setup.sh [output-directory]
+#
+# The QEMU tag must match the emulator that will load the plugins, because the
+# loader checks the plugin API version. Check yours with:
+#
+#   qemu-system-i386 --version
+
+set -eu
+
+QEMU_TAG="${QEMU_TAG:-v10.0.2}"
+DIR="${1:-$(pwd)/../tools/qemu-plugins}"
+RAW="https://gitlab.com/qemu-project/qemu/-/raw/${QEMU_TAG}"
+
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
+command -v gcc >/dev/null 2>&1 || { echo "gcc is required" >&2; exit 1; }
+pkg-config --exists glib-2.0 || {
+	echo "glib-2.0 development files are required (libglib2.0-dev)" >&2
+	exit 1
+}
+
+mkdir -p "$DIR/include" "$DIR/src" "$DIR/lib"
+
+echo "Fetching QEMU $QEMU_TAG plugin sources into $DIR"
+curl -fsSL -o "$DIR/include/qemu-plugin.h" "$RAW/include/qemu/qemu-plugin.h"
+curl -fsSL -o "$DIR/src/hotblocks.c" "$RAW/contrib/plugins/hotblocks.c"
+curl -fsSL -o "$DIR/src/stoptrigger.c" "$RAW/contrib/plugins/stoptrigger.c"
+
+# Released QEMU versions print only the 20 hottest blocks: the report limit is
+# a hardcoded constant and the plugin parses no argument for it. A profile of a
+# whole network stack needs every block, so raise it. Fail loudly if the
+# constant ever changes shape rather than silently producing a truncated
+# profile that looks plausible.
+if grep -q '^static guint64 limit = 20;$' "$DIR/src/hotblocks.c"; then
+	sed -i 's/^static guint64 limit = 20;$/static guint64 limit = G_MAXUINT64;/' \
+		"$DIR/src/hotblocks.c"
+elif grep -q 'limit' "$DIR/src/hotblocks.c"; then
+	echo "note: hotblocks.c no longer has the expected output limit constant," >&2
+	echo "      so it is built as upstream ships it. zperf_profile.py warns" >&2
+	echo "      when a report looks truncated; if it does, raise the limit in" >&2
+	echo "      $DIR/src/hotblocks.c by hand and rebuild the plugin." >&2
+fi
+
+for plugin in hotblocks stoptrigger; do
+	echo "Building lib$plugin.so"
+	# The plugin resolves qemu_plugin_* from the QEMU executable at load time,
+	# so it links against nothing but glib. Building all of QEMU is not needed.
+	gcc -O2 -g -fPIC -shared -Wall \
+		-I "$DIR/include" \
+		$(pkg-config --cflags glib-2.0) \
+		-o "$DIR/lib/lib$plugin.so" "$DIR/src/$plugin.c" \
+		$(pkg-config --libs glib-2.0)
+
+	for symbol in qemu_plugin_version qemu_plugin_install; do
+		nm -D "$DIR/lib/lib$plugin.so" | grep -q " $symbol\$" || {
+			echo "lib$plugin.so does not export $symbol; QEMU would reject it" >&2
+			exit 1
+		}
+	done
+done
+
+echo "$QEMU_TAG" > "$DIR/VERSION"
+
+cat <<EOF
+
+Built against QEMU $QEMU_TAG in $DIR/lib:
+  libhotblocks.so
+  libstoptrigger.so
+
+Profile the zperf loopback run with:
+  samples/net/zperf/scripts/zperf_profile.py run --base-dir .. \\
+      --plugin $DIR/lib/libhotblocks.so --outdir ../build/zprof
+EOF

--- a/samples/net/zperf/scripts/qemu_plugin_setup.sh
+++ b/samples/net/zperf/scripts/qemu_plugin_setup.sh
@@ -18,6 +18,12 @@
 #   libhotblocks.so    counts executed instructions per translation block
 #   libstoptrigger.so  stops the guest at an address, used to measure the boot
 #                      cost that is subtracted from each transfer profile
+#   libinsn.so         counts executed instructions, full stop. It is an
+#                      independent check: it counts per instruction where
+#                      hotblocks counts per translation block, so if the two
+#                      disagree the block accounting is wrong. "zperf_profile.py
+#                      verify" loads it alongside hotblocks and requires an
+#                      exact match.
 #
 # Usage:
 #   samples/net/zperf/scripts/qemu_plugin_setup.sh [output-directory]
@@ -46,6 +52,9 @@ echo "Fetching QEMU $QEMU_TAG plugin sources into $DIR"
 curl -fsSL -o "$DIR/include/qemu-plugin.h" "$RAW/include/qemu/qemu-plugin.h"
 curl -fsSL -o "$DIR/src/hotblocks.c" "$RAW/contrib/plugins/hotblocks.c"
 curl -fsSL -o "$DIR/src/stoptrigger.c" "$RAW/contrib/plugins/stoptrigger.c"
+# insn.c lives under tests/ rather than contrib/, but it is built the same way
+# and the licensing position is the same: nothing is added to the Zephyr tree.
+curl -fsSL -o "$DIR/src/insn.c" "$RAW/tests/tcg/plugins/insn.c"
 
 # Released QEMU versions print only the 20 hottest blocks: the report limit is
 # a hardcoded constant and the plugin parses no argument for it. A profile of a
@@ -62,7 +71,7 @@ elif grep -q 'limit' "$DIR/src/hotblocks.c"; then
 	echo "      $DIR/src/hotblocks.c by hand and rebuild the plugin." >&2
 fi
 
-for plugin in hotblocks stoptrigger; do
+for plugin in hotblocks stoptrigger insn; do
 	echo "Building lib$plugin.so"
 	# The plugin resolves qemu_plugin_* from the QEMU executable at load time,
 	# so it links against nothing but glib. Building all of QEMU is not needed.
@@ -87,8 +96,13 @@ cat <<EOF
 Built against QEMU $QEMU_TAG in $DIR/lib:
   libhotblocks.so
   libstoptrigger.so
+  libinsn.so
 
 Profile the zperf loopback run with:
   samples/net/zperf/scripts/zperf_profile.py run --base-dir .. \\
       --plugin $DIR/lib/libhotblocks.so --outdir ../build/zprof
+
+Check that the profile is telling the truth with:
+  samples/net/zperf/scripts/zperf_profile.py verify --base-dir .. \\
+      --plugin $DIR/lib/libhotblocks.so --outdir ../build/zprof-verify
 EOF

--- a/samples/net/zperf/scripts/zperf_profile.py
+++ b/samples/net/zperf/scripts/zperf_profile.py
@@ -1,0 +1,1035 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+"""Attribute the zperf loopback run's CPU cost to individual functions.
+
+The ``sample.net.zperf.loopback_icount`` setup runs a deterministic throughput
+test under QEMU icount mode and reports one throughput number per transfer.
+That says whether the stack got slower, not where the cycles went. This script
+answers the second question by running the same guest under a QEMU TCG plugin
+that counts executed instructions per translation block, and mapping those
+blocks back onto the functions in the build's ELF file.
+
+Under ``-icount shift=N`` one guest instruction is 2^N ns of virtual time, so
+throughput is a closed-form function of the instructions spent per payload
+byte::
+
+    Mbps = 8000 / (2**shift * ipb)      (at shift=5:  Mbps = 250 / ipb)
+
+A per-function breakdown of ``ipb`` is therefore a decomposition of the
+reported throughput rather than a correlated proxy for it, which is what makes
+the "instructions per byte" column and the "Mbps if this function were free"
+column meaningful.
+
+The plugin is *not* shipped with Zephyr, and cannot be: it is built against a
+QEMU header, which makes it a derivative work of QEMU, and QEMU's terms are not
+among those this tree carries. Use
+:file:`samples/net/zperf/scripts/qemu_plugin_setup.sh` to fetch and build one
+outside the repository; :file:`samples/net/zperf/README-loopback-profiling.rst`
+sets out the split in full. This script only parses the plugin's textual
+report:
+
+    collected <N> entries in the hash table
+    pc, tcount, icount, ecount
+    0x0000000000100238, 1, 1, 9341782
+    ...
+
+where ``icount`` is the number of instructions in the block and ``ecount`` how
+often the block ran, so the block contributes ``icount * ecount``
+instructions. Any plugin emitting that format works.
+
+Typical usage::
+
+    # One-shot: build, run and profile every transfer, boot cost removed.
+    samples/net/zperf/scripts/zperf_profile.py run --base-dir .. \\
+        --plugin ../tools/qemu-plugins/lib/libhotblocks.so \\
+        --outdir ../build/zprof --save ../build/zprof/profile.json
+
+    # Report again from an already collected run.
+    samples/net/zperf/scripts/zperf_profile.py report --base-dir .. \\
+        --report ../build/zprof/tcp4.hb.log \\
+        --elf ../build/zprof/tcp4/zephyr/zephyr.elf --top 25
+
+    # What changed between two commits.
+    samples/net/zperf/scripts/zperf_profile.py diff --base-dir .. \\
+        --baseline ../build/zprof-base/profile.json \\
+        --current ../build/zprof/profile.json
+
+By default all files read or written must live under the current directory;
+pass --base-dir to widen that.
+"""
+
+import argparse
+import bisect
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+
+from elftools.elf.constants import SH_FLAGS
+from elftools.elf.elffile import ELFFile
+
+# The labels the selftest reports, i.e. the accepted values of
+# CONFIG_ZPERF_LOOPBACK_SELFTEST_ONLY.
+TRANSFERS = (
+    "udp4",
+    "udp4_frag",
+    "tcp4",
+    "tcp4_nodelay",
+    "udp6",
+    "udp6_frag",
+    "tcp6",
+    "tcp6_nodelay",
+)
+
+SAMPLE = "samples/net/zperf"
+OVERLAYS = "overlay-loopback.conf;overlay-loopback-icount.conf"
+
+# Buckets for instructions that belong to no Zephyr function.
+UNKNOWN = "[unknown]"
+FIRMWARE = "[firmware]"
+
+# Ordered (regex on the source path, group) rules; first match wins. Functions
+# whose source file is unknown fall back to SYMBOL_GROUPS below.
+FILE_GROUPS = (
+    (r"^drivers/net/loopback\.c$", "driver"),
+    (r"^subsys/net/lib/zperf/", "harness"),
+    (r"^samples/", "harness"),
+    (r"^subsys/net/ip/net_pkt\.c$", "pktbuf"),
+    (r"^lib/net_buf/", "pktbuf"),
+    (r"^subsys/net/ip/utils\.c$", "checksum"),
+    (r"^subsys/net/ip/net_tc\.c$", "tc"),
+    (r"^subsys/net/ip/(net_core|net_if)\.c$", "core"),
+    (r"^subsys/net/ip/tcp\.c$", "tcp"),
+    (r"^subsys/net/ip/udp\.c$", "udp"),
+    (r"^subsys/net/ip/(connection|net_context)\.c$", "conn"),
+    (r"^subsys/net/ip/(ipv4|ipv6|icmp)", "ip"),
+    (r"^subsys/net/lib/sockets/", "sockets"),
+    (r"^subsys/net/", "net-other"),
+    (r"^(kernel|arch)/", "kernel"),
+    # rb.c is the scheduler's and the timeout queue's red-black tree, and the
+    # timer driver is charged on every tick, so both are kernel overhead.
+    (r"^lib/utils/", "kernel"),
+    (r"^drivers/timer/", "kernel"),
+    (r"^(lib/libc|lib/os|modules/lib/picolibc|modules/picolibc)", "libc"),
+)
+
+# Fallback classification by symbol name, used when DWARF gives no source file
+# (assembly, or a stripped build).
+SYMBOL_GROUPS = (
+    (r"^(calc_chksum|net_calc_chksum)", "checksum"),
+    (r"^(net_pkt_|pkt_alloc|net_buf_)", "pktbuf"),
+    (r"^tcp_", "tcp"),
+    (r"^(zsock_|zvfs_)", "sockets"),
+    (r"^net_", "net-other"),
+    (r"^(z_|k_|arch_|_interrupt|_exception|sys_clock|rb_|queue_)", "kernel"),
+    (r"^(mem|str|__udiv|__umod)", "libc"),
+)
+
+GROUP_ORDER = (
+    "checksum",
+    "pktbuf",
+    "tcp",
+    "udp",
+    "ip",
+    "conn",
+    "sockets",
+    "core",
+    "tc",
+    "driver",
+    "net-other",
+    "kernel",
+    "libc",
+    "harness",
+    "other",
+)
+
+
+def validate_path(path: str, base_dir: str, *, for_write: bool) -> str:
+    """Resolve *path* and ensure it stays inside *base_dir*.
+
+    All files this script reads or writes are taken from CLI arguments. To
+    avoid path-traversal or absolute-path escapes when the script is driven
+    with untrusted or faulty arguments, every such path is resolved (following
+    symlinks and ``..``) and rejected unless it lives under the resolved base
+    directory. The validated absolute path is returned for use with ``open()``.
+    """
+    if not path or "\x00" in path:
+        sys.exit(f"Invalid path: {path!r}")
+
+    base_real = os.path.realpath(base_dir)
+    if not os.path.isdir(base_real):
+        sys.exit(f"Base directory '{base_dir}' does not exist.")
+
+    # Resolve the path as the user means it (relative paths against the current
+    # directory, absolute paths as-is, following symlinks and ".."), then
+    # require the result to stay under the resolved base directory.
+    target_real = os.path.realpath(path)
+
+    if os.path.commonpath([base_real, target_real]) != base_real:
+        sys.exit(
+            f"Refusing to access '{path}': resolved path '{target_real}' is "
+            f"outside the permitted base directory '{base_real}'. Use "
+            f"--base-dir to widen the allowed location."
+        )
+
+    if for_write:
+        parent = os.path.dirname(target_real)
+        if not os.path.isdir(parent):
+            sys.exit(f"Cannot write '{path}': '{parent}' is not a directory.")
+        if os.path.isdir(target_real):
+            sys.exit(f"Cannot write '{path}': it is a directory.")
+
+    return target_real
+
+
+def validate_qemu_arg_path(path: str, base_dir: str, *, for_write: bool) -> str:
+    """Like validate_path(), for a path that ends up on the QEMU command line.
+
+    CMake splits QEMU_EXTRA_FLAGS with separate_arguments(), and the plugin
+    argument syntax is itself comma separated, so a path containing whitespace
+    or a comma would be silently torn apart into several arguments.
+    """
+    resolved = validate_path(path, base_dir, for_write=for_write)
+    bad = [c for c in (" ", "\t", ",") if c in resolved]
+    if bad:
+        sys.exit(
+            f"Refusing to use '{resolved}' on the QEMU command line: it "
+            f"contains {bad!r}, which QEMU argument splitting would break."
+        )
+    return resolved
+
+
+class SymbolTable:
+    """Interval lookup from a guest PC to the function containing it."""
+
+    def __init__(self, elf_path: str):
+        self._fp = open(elf_path, "rb")  # noqa: SIM115 - kept open for DWARF
+        elf = ELFFile(self._fp)
+
+        symtab = elf.get_section_by_name(".symtab")
+        if symtab is None:
+            sys.exit(f"{elf_path} has no .symtab; a stripped build cannot be profiled.")
+
+        exec_sections = {
+            idx
+            for idx, sec in enumerate(elf.iter_sections())
+            if sec["sh_flags"] & SH_FLAGS.SHF_EXECINSTR
+        }
+
+        # Two views of the symbol table.
+        #
+        # "ranges" holds sized STT_FUNC symbols. Those are authoritative: a PC
+        # inside one belongs to that function, full stop.
+        #
+        # "bounds" holds entry points with no usable size, which have to be
+        # delimited by whatever symbol comes next. Zero-sized STT_FUNC covers
+        # hand written assembly such as _interrupt_enter and arch_swap, which
+        # is exactly where a network benchmark spends interrupt and context
+        # switch time. Global STT_NOTYPE covers assembly entry points that were
+        # never given a .type directive - picolibc's memcpy is one, and without
+        # it every byte memcpy moves is misattributed to whichever symbol
+        # precedes it. Local NOTYPE symbols are excluded: they are internal
+        # labels inside a function, and treating them as boundaries would split
+        # that function's cost in two.
+        ranges: dict[int, tuple[int, int, str]] = {}
+        bounds: dict[int, tuple[int, str]] = {}
+
+        for sym in symtab.iter_symbols():
+            entry = sym.entry
+            shndx = entry.st_shndx
+            if not isinstance(shndx, int) or shndx not in exec_sections:
+                continue
+
+            kind = entry.st_info.type
+            binding = entry.st_info.bind
+            addr = entry.st_value
+            size = entry.st_size
+
+            if kind == "STT_FUNC" and size:
+                rank = 1 if binding == "STB_GLOBAL" else 0
+                if addr not in ranges or rank > ranges[addr][0]:
+                    ranges[addr] = (rank, size, sym.name)
+            elif kind == "STT_FUNC" or (
+                kind == "STT_NOTYPE" and binding in ("STB_GLOBAL", "STB_WEAK")
+            ):
+                rank = 1 if kind == "STT_FUNC" else 0
+                if addr not in bounds or rank > bounds[addr][0]:
+                    bounds[addr] = (rank, sym.name)
+
+        self._ranges = sorted((a, v[1], v[2]) for a, v in ranges.items())
+        self._range_starts = [r[0] for r in self._ranges]
+
+        # Every sized function also acts as a boundary for the unsized ones.
+        for addr, (_rank, size, name) in ranges.items():
+            bounds.setdefault(addr, (1, name))
+            bounds.setdefault(addr + size, (1, UNKNOWN))
+        self._bounds = sorted((a, v[1]) for a, v in bounds.items())
+        self._bound_starts = [b[0] for b in self._bounds]
+
+        if not self._ranges and not self._bounds:
+            sys.exit(f"{elf_path} contains no function symbols.")
+
+        # Loadable ranges, used to tell "not a Zephyr function" apart from
+        # "not Zephyr at all" (the BIOS the guest boots through).
+        self._load = [
+            (seg["p_vaddr"], seg["p_vaddr"] + seg["p_memsz"])
+            for seg in elf.iter_segments()
+            if seg["p_type"] == "PT_LOAD" and seg["p_memsz"]
+        ]
+
+        self._dwarf = elf.get_dwarf_info() if elf.has_dwarf_info() else None
+        self._aranges = None
+        if self._dwarf is not None:
+            try:
+                self._aranges = self._dwarf.get_aranges()
+            except Exception:  # noqa: BLE001 - DWARF is best effort
+                self._aranges = None
+        self._file_cache: dict[str, str | None] = {}
+        self._sym_cache: dict[int, tuple[str, str]] = {}
+
+    def in_image(self, pc: int) -> bool:
+        return any(lo <= pc < hi for lo, hi in self._load)
+
+    def lookup(self, pc: int) -> tuple[str, str]:
+        """Return (function name, kind) where kind is exact/inferred/bucket."""
+        hit = self._sym_cache.get(pc)
+        if hit is not None:
+            return hit
+
+        result = self._lookup_uncached(pc)
+        self._sym_cache[pc] = result
+        return result
+
+    def _lookup_uncached(self, pc: int) -> tuple[str, str]:
+        if not self.in_image(pc):
+            return FIRMWARE, "bucket"
+
+        # A sized function wins outright.
+        idx = bisect.bisect_right(self._range_starts, pc) - 1
+        if idx >= 0:
+            addr, size, name = self._ranges[idx]
+            if pc < addr + size:
+                return name, "exact"
+
+        # Otherwise fall back to the nearest preceding entry point.
+        idx = bisect.bisect_right(self._bound_starts, pc) - 1
+        if idx >= 0:
+            name = self._bounds[idx][1]
+            if name != UNKNOWN:
+                return name, "inferred"
+
+        return UNKNOWN, "bucket"
+
+    def source_file(self, pc: int, zephyr_base: str, topdir: str) -> str | None:
+        """Best-effort source file for *pc*, relative to the west topdir."""
+        if self._aranges is None:
+            return None
+
+        try:
+            cu_offset = self._aranges.cu_offset_at_addr(pc)
+            if cu_offset is None:
+                return None
+            cu = self._dwarf.get_CU_at(cu_offset)
+            top = cu.get_top_DIE()
+            name = top.attributes["DW_AT_name"].value.decode()
+            comp_dir = top.attributes.get("DW_AT_comp_dir")
+            if not os.path.isabs(name) and comp_dir is not None:
+                name = os.path.join(comp_dir.value.decode(), name)
+        except Exception:  # noqa: BLE001 - DWARF is best effort
+            return None
+
+        return _relativise(os.path.normpath(name), zephyr_base, topdir)
+
+
+def _relativise(path: str, zephyr_base: str, topdir: str) -> str:
+    """Trim an absolute source path down to a repo relative one."""
+    for root in (zephyr_base, topdir):
+        if root and path.startswith(root.rstrip("/") + "/"):
+            return path[len(root.rstrip("/")) + 1 :]
+    return path
+
+
+def classify(func: str, source: str | None) -> str:
+    if source is not None:
+        for pattern, group in FILE_GROUPS:
+            if re.search(pattern, source):
+                return group
+    for pattern, group in SYMBOL_GROUPS:
+        if re.match(pattern, func):
+            return group
+    return "other"
+
+
+def parse_report(path: str) -> tuple[dict[tuple[int, int], int], int]:
+    """Parse a plugin report into {(pc, insns_per_block): exec_count}.
+
+    Also returns the block count from the header line, so a truncated report
+    (released QEMU versions cap contrib/plugins/hotblocks.c output at the 20
+    hottest blocks) can be detected instead of being silently believed.
+    """
+    blocks: dict[tuple[int, int], int] = {}
+    collected = -1
+    seen_header = False
+
+    with open(path) as fp:
+        for line in fp:
+            line = line.strip()
+            if not line:
+                continue
+            match = re.match(r"collected (\d+) entries", line)
+            if match:
+                collected = int(match.group(1))
+                continue
+            if line.startswith("pc,"):
+                seen_header = True
+                continue
+            if not line.startswith("0x"):
+                continue
+            # Plugins share the report stream, so skip anything that is not a
+            # 4 column data row (the stop plugin prints "0x... reached, exiting").
+            fields = [f.strip() for f in line.split(",")]
+            if len(fields) != 4:
+                continue
+            pc, _tcount, insns, ecount = fields
+            blocks[(int(pc, 16), int(insns))] = blocks.get((int(pc, 16), int(insns)), 0) + int(
+                ecount
+            )
+
+    if not seen_header or not blocks:
+        sys.exit(
+            f"{path} does not look like a QEMU plugin block report. Was the "
+            f"plugin loaded, and was '-d plugin' passed? Without '-d plugin' "
+            f"QEMU discards the report."
+        )
+
+    if collected >= 0 and len(blocks) < collected - 1:
+        print(
+            f"warning: {os.path.basename(path)}: the plugin reported "
+            f"{collected} blocks but emitted only {len(blocks)} rows. The "
+            f"profile is truncated to the hottest blocks and every total "
+            f"below understates the real cost. Rebuild the plugin with an "
+            f"unlimited output limit (see qemu_plugin_setup.sh).",
+            file=sys.stderr,
+        )
+
+    return blocks, collected
+
+
+def subtract(full: dict[tuple[int, int], int], boot: dict[tuple[int, int], int]) -> dict:
+    """Remove the boot-only cost from a transfer run, block by block.
+
+    The guest is deterministic under icount and the instruction stream before
+    the first transfer is identical in both runs, so this is exact rather than
+    approximate. A block that ran *fewer* times in the longer run means the two
+    runs diverged and the result must not be trusted.
+    """
+    out = dict(full)
+    bad = []
+    for key, count in boot.items():
+        have = out.get(key, 0)
+        if have < count:
+            bad.append((key, have, count))
+            continue
+        remaining = have - count
+        if remaining:
+            out[key] = remaining
+        else:
+            out.pop(key, None)
+
+    if bad:
+        detail = ", ".join(f"0x{pc:x}(+{n}): {h} < {c}" for (pc, n), h, c in bad[:5])
+        sys.exit(
+            f"Boot baseline subtraction failed for {len(bad)} block(s) "
+            f"[{detail}]: the boot-only run executed blocks more often than "
+            f"the transfer run, so the two runs did not share a boot prefix. "
+            f"Rebuild both from the same tree and rerun."
+        )
+
+    return out
+
+
+def attribute(
+    blocks: dict[tuple[int, int], int], table: SymbolTable, zephyr_base: str, topdir: str
+) -> tuple[dict[str, dict], int, dict[str, int]]:
+    """Fold blocks into per-function instruction totals."""
+    funcs: dict[str, dict] = {}
+    total = 0
+    kinds: dict[str, int] = defaultdict(int)
+
+    for (pc, insns), ecount in blocks.items():
+        cost = insns * ecount
+        total += cost
+        name, kind = table.lookup(pc)
+        kinds[kind] += cost
+
+        entry = funcs.get(name)
+        if entry is None:
+            source = table.source_file(pc, zephyr_base, topdir) if kind != "bucket" else None
+            entry = {"insns": 0, "file": source, "group": classify(name, source)}
+            funcs[name] = entry
+        entry["insns"] += cost
+
+    return funcs, total, dict(kinds)
+
+
+def render(profile: dict, top: int) -> None:
+    """Print the header, the per-function table and the group roll-up."""
+    label = profile["label"]
+    total = profile["total_insns"]
+    byts = profile.get("bytes") or 0
+    shift = profile.get("icount_shift", 5)
+    measured = profile.get("measured_mbps")
+
+    ipb = (total / byts) if byts else 0.0
+    # Mbps = 8 bits/byte * 1e9 ns/s / (2**shift ns/insn * ipb insn/byte) / 1e6
+    reconstructed = (8000.0 / (2**shift * ipb)) if ipb else 0.0
+
+    print(f"\n=== {label} ({profile.get('platform', '?')}) ===")
+    line = f"instructions {total:>15,}   payload {byts:>12,} B   ipb {ipb:8.3f}"
+    if profile.get("boot_insns"):
+        line += f"   boot subtracted {profile['boot_insns']:,}"
+    print(line)
+
+    if measured:
+        # With icount sleep=off, halted time advances virtual time without
+        # executing instructions, so this ratio is the CPU-bound fraction of
+        # the run. Below 1 means the guest waited (TCP on ACKs, for example);
+        # above 1 means the accounting is wrong.
+        ratio = reconstructed / measured if measured else 0.0
+        print(
+            f"throughput   measured {measured:8.3f} Mbps   "
+            f"from profile {reconstructed:8.3f} Mbps   cpu-bound {ratio * 100:5.1f}%"
+        )
+
+    kinds = profile.get("kinds") or {}
+    if total:
+        bucketed = kinds.get("bucket", 0)
+        inferred = kinds.get("inferred", 0)
+        print(
+            f"attribution  exact {100 * kinds.get('exact', 0) / total:5.2f}%   "
+            f"inferred {100 * inferred / total:5.2f}%   "
+            f"unattributed {100 * bucketed / total:5.2f}%"
+        )
+
+    funcs = profile["functions"]
+    ranked = sorted(funcs.items(), key=lambda kv: -kv[1]["insns"])
+
+    print(
+        f"\n{'#':>3}  {'function':<34}{'group':<10}{'instructions':>14}"
+        f"{'ipb':>8}{'%':>7}{'cum%':>7}{'+Mbps':>8}  file"
+    )
+    cum = 0
+    for rank, (name, info) in enumerate(ranked[:top], start=1):
+        insns = info["insns"]
+        cum += insns
+        share = 100.0 * insns / total if total else 0.0
+        f_ipb = insns / byts if byts else 0.0
+        # What the throughput would become if this function cost nothing.
+        gain = ((8000.0 / (2**shift * (ipb - f_ipb))) - reconstructed) if ipb > f_ipb else 0.0
+        print(
+            f"{rank:>3}  {name[:33]:<34}{info['group']:<10}{insns:>14,}"
+            f"{f_ipb:>8.3f}{share:>6.2f}%{100 * cum / total if total else 0:>6.1f}%"
+            f"{gain:>+8.2f}  {info['file'] or ''}"
+        )
+
+    groups: dict[str, int] = defaultdict(int)
+    for info in funcs.values():
+        groups[info["group"]] += info["insns"]
+
+    print(f"\n{'group':<12}{'instructions':>14}{'ipb':>9}{'%':>8}")
+    ordered = sorted(
+        groups.items(), key=lambda kv: (GROUP_ORDER.index(kv[0]) if kv[0] in GROUP_ORDER else 99)
+    )
+    for group, insns in ordered:
+        print(
+            f"{group:<12}{insns:>14,}{insns / byts if byts else 0:>9.3f}"
+            f"{100.0 * insns / total if total else 0:>7.2f}%"
+        )
+
+
+def render_diff(baseline: dict, current: dict, tolerance_pct: float, top: int) -> bool:
+    """Print per-function and per-group deltas; return True if within tolerance."""
+    ok = True
+    for label in sorted(set(baseline) | set(current)):
+        base = baseline.get(label)
+        cur = current.get(label)
+        if base is None or cur is None:
+            print(
+                f"\n=== {label} ===\n  only present in {'current' if base is None else 'baseline'}"
+            )
+            ok = False
+            continue
+
+        b_bytes = base.get("bytes") or 0
+        c_bytes = cur.get("bytes") or 0
+        b_ipb = base["total_insns"] / b_bytes if b_bytes else 0.0
+        c_ipb = cur["total_insns"] / c_bytes if c_bytes else 0.0
+        change = ((c_ipb - b_ipb) / b_ipb * 100.0) if b_ipb else 0.0
+        # More instructions per byte is slower, so a positive change is bad.
+        status = "OK" if change <= tolerance_pct else "REGRESSION"
+        if status != "OK":
+            ok = False
+
+        print(f"\n=== {label} ===")
+        print(f"ipb {b_ipb:.3f} -> {c_ipb:.3f}  ({change:+.2f}%)  {status}")
+
+        deltas: dict[str, int] = defaultdict(int)
+        for name, info in base["functions"].items():
+            deltas[name] -= info["insns"]
+        for name, info in cur["functions"].items():
+            deltas[name] += info["insns"]
+
+        moved = sorted(deltas.items(), key=lambda kv: -abs(kv[1]))[:top]
+        moved = [(n, d) for n, d in moved if d]
+        if moved:
+            print(f"  {'function':<36}{'delta insns':>14}  note")
+            for name, delta in moved:
+                note = ""
+                if name not in base["functions"]:
+                    note = "NEW"
+                elif name not in cur["functions"]:
+                    note = "GONE"
+                print(f"  {name[:35]:<36}{delta:>+14,}  {note}")
+
+    return ok
+
+
+def _group_totals(profile: dict) -> dict[str, int]:
+    groups: dict[str, int] = defaultdict(int)
+    for info in profile["functions"].values():
+        groups[info["group"]] += info["insns"]
+    return dict(groups)
+
+
+def qemu_command(build_dir: str) -> list[str]:
+    """Recover the QEMU command line the build system would use.
+
+    Taking it from the build keeps the board flags, the icount settings and
+    the QEMU binary owned by the build system, and lets one build serve several
+    runs with different plugin arguments. QEMU_EXTRA_FLAGS cannot do the
+    latter: cmake/emu/qemu.cmake consumes it at configure time, so it is baked
+    into the run target.
+    """
+    ninja = shutil.which("ninja")
+    if ninja is None:
+        sys.exit("ninja not found in PATH; it is needed to recover the QEMU command line.")
+
+    out = (
+        subprocess.run(
+            [ninja, "-C", build_dir, "-t", "commands", "zephyr/run_qemu"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        .stdout.strip()
+        .splitlines()
+    )
+    if not out:
+        sys.exit(f"No run_qemu target in {build_dir}; is it a QEMU board build?")
+
+    # The recipe is "cd <dir> && <qemu> <args...>", written as the shell would
+    # run it, so a build path containing a space arrives quoted. Split it the
+    # same way the shell would: shlex keeps such a path in one token and strips
+    # the quotes, which is what execve() needs, and it leaves "&&" as a plain
+    # token because it parses words rather than shell grammar.
+    words = shlex.split(out[-1])
+    argv = words[words.index("&&") + 1 :] if "&&" in words else words
+    if not argv or "qemu-system" not in argv[0]:
+        sys.exit(f"Unexpected run_qemu recipe in {build_dir}: {out[-1]!r}")
+
+    # Some boards do not boot zephyr.elf directly. qemu_x86_64 splits the image
+    # into zephyr-qemu-locore.elf and zephyr-qemu-main.elf, which are produced
+    # by a target the run target depends on. Running QEMU ourselves skips that
+    # dependency, so build it when a referenced image is missing.
+    missing = [path for path in _kernel_images(argv) if not os.path.exists(path)]
+    if missing:
+        subprocess.run([ninja, "-C", build_dir, "qemu_kernel_target"], check=True)
+        still = [path for path in missing if not os.path.exists(path)]
+        if still:
+            sys.exit(f"Still missing after building qemu_kernel_target: {', '.join(still)}")
+
+    # Replace the interactive console with a log file: the profiling run is
+    # unattended and must not inherit a terminal.
+    cleaned: list[str] = []
+    skip_next = False
+    for arg in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in ("-chardev", "-serial", "-mon", "-monitor", "-pidfile"):
+            skip_next = True
+            continue
+        if arg == "-nographic":
+            continue
+        cleaned.append(arg)
+
+    return cleaned
+
+
+def _kernel_images(argv: list[str]) -> list[str]:
+    """Image files the QEMU command line loads into the guest."""
+    images = []
+    for i, arg in enumerate(argv):
+        if arg == "-kernel" and i + 1 < len(argv):
+            images.append(argv[i + 1])
+        elif arg.startswith("loader,"):
+            for field in arg.split(","):
+                if field.startswith("file="):
+                    images.append(field[len("file=") :])
+    return images
+
+
+def run_one(
+    build_dir: str,
+    plugin: str,
+    report_path: str,
+    console_path: str,
+    stop_plugin: str | None = None,
+    stop_addr: int | None = None,
+) -> None:
+    argv = qemu_command(build_dir)
+    argv += [
+        "-serial",
+        f"file:{console_path}",
+        "-display",
+        "none",
+        "-monitor",
+        "none",
+        "-plugin",
+        f"file={plugin},inline=on",
+    ]
+    if stop_plugin is not None and stop_addr is not None:
+        # Stop the guest the moment it reaches the address, so this run covers
+        # only the prefix shared with the full run.
+        argv += ["-plugin", f"file={stop_plugin},addr=0x{stop_addr:x}"]
+    argv += [
+        # qemu_plugin_outs() goes through qemu_log_mask(CPU_LOG_PLUGIN, ...),
+        # so without -d plugin the report is written nowhere.
+        "-d",
+        "plugin",
+        "-D",
+        report_path,
+    ]
+
+    for path in (report_path, console_path):
+        if os.path.exists(path):
+            os.unlink(path)
+
+    # The guest halts itself through isa-debug-exit, so QEMU's exit status is
+    # the guest's halt reason, not a failure indication.
+    subprocess.run(argv, cwd=build_dir, check=False, timeout=1800)
+
+    if not os.path.exists(report_path) or os.path.getsize(report_path) == 0:
+        sys.exit(
+            f"No plugin report at {report_path}. The guest most likely never "
+            f"exited, so QEMU's atexit handler never ran: build with "
+            f"CONFIG_ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE=y."
+        )
+
+
+def symbol_address(elf_path: str, name: str) -> int:
+    """Address of a defined function symbol, used as the boot/run boundary."""
+    with open(elf_path, "rb") as fp:
+        symtab = ELFFile(fp).get_section_by_name(".symtab")
+        if symtab is None:
+            sys.exit(f"{elf_path} has no .symtab; a stripped build cannot be profiled.")
+
+        for sym in symtab.iter_symbols():
+            if (
+                sym.name == name
+                and sym.entry.st_info.type == "STT_FUNC"
+                and sym.entry.st_shndx not in ("SHN_UNDEF", "SHN_ABS")
+            ):
+                return sym.entry.st_value
+    sys.exit(f"No function symbol '{name}' in {elf_path}.")
+
+
+def build_one(zephyr_base: str, board: str, build_dir: str, only: str) -> None:
+    west = shutil.which("west")
+    if west is None:
+        sys.exit("west not found in PATH; activate the workspace virtualenv first.")
+
+    argv = [
+        west,
+        "build",
+        "-p",
+        "-b",
+        board,
+        "-d",
+        build_dir,
+        os.path.join(zephyr_base, SAMPLE),
+        "--",
+        f"-DEXTRA_CONF_FILE={OVERLAYS}",
+        # A Kconfig string fragment carries its own quotes; they belong inside
+        # the value, not around the -D argument.
+        f'-DCONFIG_ZPERF_LOOPBACK_SELFTEST_ONLY="{only}"',
+        "-DCONFIG_ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE=y",
+    ]
+    subprocess.run(argv, check=True, cwd=zephyr_base)
+
+
+def parse_console(path: str) -> tuple[dict[str, float], dict[str, int]]:
+    """Extract the ZPERF-RESULT throughputs and ZPERF-INFO byte counts."""
+    mbps: dict[str, float] = {}
+    byts: dict[str, int] = {}
+    if not os.path.exists(path):
+        return mbps, byts
+
+    with open(path, errors="replace") as fp:
+        text = fp.read()
+    for label, value in re.findall(r"ZPERF-RESULT (\w+)_mbps=([0-9.]+)", text):
+        mbps[label] = float(value)
+    for label, value in re.findall(r"ZPERF-INFO (\w+)_bytes=(\d+)", text):
+        byts[label] = int(value)
+    return mbps, byts
+
+
+def build_profile(
+    label: str,
+    report: str,
+    elf: str,
+    boot_report: str | None,
+    console: str | None,
+    platform: str,
+    shift: int,
+    zephyr_base: str,
+    topdir: str,
+) -> dict:
+    blocks, _ = parse_report(report)
+    boot_insns = 0
+    if boot_report:
+        boot_blocks, _ = parse_report(boot_report)
+        boot_insns = sum(n * c for (_, n), c in boot_blocks.items())
+        blocks = subtract(blocks, boot_blocks)
+
+    table = SymbolTable(elf)
+    funcs, total, kinds = attribute(blocks, table, zephyr_base, topdir)
+
+    mbps, byts = parse_console(console) if console else ({}, {})
+
+    return {
+        "schema": 1,
+        "label": label,
+        "platform": platform,
+        "icount_shift": shift,
+        "bytes": byts.get(label, 0),
+        "measured_mbps": mbps.get(label),
+        "total_insns": total,
+        "boot_insns": boot_insns,
+        "kinds": kinds,
+        "functions": funcs,
+    }
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    zephyr_base = os.environ.get("ZEPHYR_BASE") or os.getcwd()
+    topdir = os.path.realpath(os.path.join(zephyr_base, ".."))
+    plugin = validate_qemu_arg_path(args.plugin, args.base_dir, for_write=False)
+    outdir = validate_path(args.outdir, args.base_dir, for_write=False)
+    os.makedirs(outdir, exist_ok=True)
+
+    stop_plugin = None
+    if not args.no_subtract_boot:
+        stop = args.stop_plugin or os.path.join(os.path.dirname(plugin), "libstoptrigger.so")
+        stop_plugin = validate_qemu_arg_path(stop, args.base_dir, for_write=False)
+        if not os.path.exists(stop_plugin):
+            sys.exit(
+                f"No stop plugin at {stop_plugin}. It is needed to measure the "
+                f"boot cost that is subtracted from every transfer; build it "
+                f"with qemu_plugin_setup.sh, point --stop-plugin at it, or "
+                f"pass --no-subtract-boot."
+            )
+
+    labels = args.transfers or list(TRANSFERS)
+    unknown = [label for label in labels if label not in TRANSFERS]
+    if unknown:
+        sys.exit(f"Unknown transfer label(s): {', '.join(unknown)}")
+
+    profiles: dict[str, dict] = {}
+    for label in labels:
+        build_dir = os.path.join(outdir, label)
+        report = os.path.join(outdir, f"{label}.report")
+        console = os.path.join(outdir, f"{label}.console")
+        boot_report = os.path.join(outdir, f"{label}.boot.report")
+        boot_console = os.path.join(outdir, f"{label}.boot.console")
+        elf = os.path.join(build_dir, "zephyr", "zephyr.elf")
+
+        print(f"--- {label}: building", flush=True)
+        build_one(zephyr_base, args.board, build_dir, label)
+
+        print(f"--- {label}: running", flush=True)
+        run_one(build_dir, plugin, report, console)
+
+        used_boot = None
+        if stop_plugin is not None:
+            # The boot baseline is the *same binary* stopped as it enters the
+            # measurement boundary, so the instruction stream it covers is
+            # bit-identical to the full run's prefix and the subtraction is
+            # exact. A separate boot-only build would not be: a guest that
+            # runs no transfer diverges after boot.
+            print(f"--- {label}: boot baseline", flush=True)
+            run_one(
+                build_dir,
+                plugin,
+                boot_report,
+                boot_console,
+                stop_plugin,
+                symbol_address(elf, args.boot_boundary),
+            )
+            used_boot = boot_report
+
+        profiles[label] = build_profile(
+            label,
+            report,
+            elf,
+            used_boot,
+            console,
+            args.board,
+            args.icount_shift,
+            zephyr_base,
+            topdir,
+        )
+        render(profiles[label], args.top)
+
+    if args.save:
+        out = validate_path(args.save, args.base_dir, for_write=True)
+        with open(out, "w") as fp:
+            json.dump(profiles, fp, indent=1, sort_keys=True)
+        print(f"\nSaved {len(profiles)} profile(s) to {out}")
+
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    zephyr_base = os.environ.get("ZEPHYR_BASE") or os.getcwd()
+    topdir = os.path.realpath(os.path.join(zephyr_base, ".."))
+
+    report = validate_path(args.report, args.base_dir, for_write=False)
+    elf = validate_path(args.elf, args.base_dir, for_write=False)
+    boot = (
+        validate_path(args.boot_report, args.base_dir, for_write=False)
+        if args.boot_report
+        else None
+    )
+    console = validate_path(args.console, args.base_dir, for_write=False) if args.console else None
+
+    profile = build_profile(
+        args.label,
+        report,
+        elf,
+        boot,
+        console,
+        args.platform,
+        args.icount_shift,
+        zephyr_base,
+        topdir,
+    )
+    render(profile, args.top)
+
+    if args.save:
+        out = validate_path(args.save, args.base_dir, for_write=True)
+        with open(out, "w") as fp:
+            json.dump({args.label: profile}, fp, indent=1, sort_keys=True)
+        print(f"\nSaved profile to {out}")
+
+    return 0
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    with open(validate_path(args.baseline, args.base_dir, for_write=False)) as fp:
+        baseline = json.load(fp)
+    with open(validate_path(args.current, args.base_dir, for_write=False)) as fp:
+        current = json.load(fp)
+
+    ok = render_diff(baseline, current, args.tolerance, args.top)
+    if not ok:
+        print("\nAt least one transfer regressed beyond the tolerance.")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    # --base-dir is shared by every subcommand and accepted on either side of
+    # the subcommand name, so it goes on a parent parser rather than the root.
+    common = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    common.add_argument(
+        "--base-dir",
+        default=".",
+        help="every file read or written must resolve under this directory",
+    )
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[common],
+        allow_abbrev=False,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common_top = dict(type=int, default=25, help="how many rows to show")
+
+    run = sub.add_parser(
+        "run",
+        help="build, run and profile the loopback selftest",
+        parents=[common],
+        allow_abbrev=False,
+    )
+    run.add_argument("--plugin", required=True, help="path to the QEMU TCG plugin")
+    run.add_argument("--outdir", required=True, help="directory for builds and reports")
+    run.add_argument("--board", default="qemu_x86")
+    run.add_argument("--transfers", nargs="*", help=f"defaults to all of: {' '.join(TRANSFERS)}")
+    run.add_argument("--icount-shift", type=int, default=5)
+    run.add_argument(
+        "--no-subtract-boot", action="store_true", help="keep the boot cost in each profile"
+    )
+    run.add_argument(
+        "--stop-plugin",
+        help="QEMU stop-on-address plugin used for the boot "
+        "baseline (default: libstoptrigger.so next to --plugin)",
+    )
+    run.add_argument(
+        "--boot-boundary", default="main", help="symbol separating boot from the measured work"
+    )
+    run.add_argument("--save", help="write the profiles as JSON")
+    run.add_argument("--top", **common_top)
+    run.set_defaults(func=cmd_run)
+
+    rep = sub.add_parser(
+        "report", help="report on an already collected run", parents=[common], allow_abbrev=False
+    )
+    rep.add_argument("--report", required=True, help="plugin block report")
+    rep.add_argument("--elf", required=True, help="zephyr.elf of the same build")
+    rep.add_argument("--boot-report", help="boot baseline report to subtract")
+    rep.add_argument("--console", help="console log, for the throughput and byte counts")
+    rep.add_argument("--label", default="run")
+    rep.add_argument("--platform", default="?")
+    rep.add_argument("--icount-shift", type=int, default=5)
+    rep.add_argument("--save", help="write the profile as JSON")
+    rep.add_argument("--top", **common_top)
+    rep.set_defaults(func=cmd_report)
+
+    dif = sub.add_parser(
+        "diff", help="compare two saved profile sets", parents=[common], allow_abbrev=False
+    )
+    dif.add_argument("--baseline", required=True)
+    dif.add_argument("--current", required=True)
+    dif.add_argument(
+        "--tolerance",
+        type=float,
+        default=1.0,
+        help="allowed increase in instructions per byte, in percent",
+    )
+    dif.add_argument("--top", **common_top)
+    dif.set_defaults(func=cmd_diff)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/samples/net/zperf/scripts/zperf_profile.py
+++ b/samples/net/zperf/scripts/zperf_profile.py
@@ -208,20 +208,20 @@ def validate_qemu_arg_path(path: str, base_dir: str, *, for_write: bool) -> str:
 class SymbolTable:
     """Interval lookup from a guest PC to the function containing it."""
 
-    def __init__(self, elf_path: str):
-        self._fp = open(elf_path, "rb")  # noqa: SIM115 - kept open for DWARF
-        elf = ELFFile(self._fp)
+    def __init__(
+        self,
+        symbols: list[tuple[str, int, int, str, str]],
+        load: list[tuple[int, int]],
+        source: str = "<symbols>",
+    ):
+        """Build the lookup tables from raw symbol tuples.
 
-        symtab = elf.get_section_by_name(".symtab")
-        if symtab is None:
-            sys.exit(f"{elf_path} has no .symtab; a stripped build cannot be profiled.")
-
-        exec_sections = {
-            idx
-            for idx, sec in enumerate(elf.iter_sections())
-            if sec["sh_flags"] & SH_FLAGS.SHF_EXECINSTR
-        }
-
+        *symbols* is (name, address, size, st_info.type, st_info.bind) for
+        every symbol defined in an executable section, and *load* is the
+        (start, end) of every non-empty PT_LOAD segment. Taking an ELF file
+        apart is from_elf()'s job; keeping it out of here lets the interval
+        logic be exercised without a binary to hand.
+        """
         # Two views of the symbol table.
         #
         # "ranges" holds sized STT_FUNC symbols. Those are authoritative: a PC
@@ -240,27 +240,17 @@ class SymbolTable:
         ranges: dict[int, tuple[int, int, str]] = {}
         bounds: dict[int, tuple[int, str]] = {}
 
-        for sym in symtab.iter_symbols():
-            entry = sym.entry
-            shndx = entry.st_shndx
-            if not isinstance(shndx, int) or shndx not in exec_sections:
-                continue
-
-            kind = entry.st_info.type
-            binding = entry.st_info.bind
-            addr = entry.st_value
-            size = entry.st_size
-
+        for name, addr, size, kind, binding in symbols:
             if kind == "STT_FUNC" and size:
                 rank = 1 if binding == "STB_GLOBAL" else 0
                 if addr not in ranges or rank > ranges[addr][0]:
-                    ranges[addr] = (rank, size, sym.name)
+                    ranges[addr] = (rank, size, name)
             elif kind == "STT_FUNC" or (
                 kind == "STT_NOTYPE" and binding in ("STB_GLOBAL", "STB_WEAK")
             ):
                 rank = 1 if kind == "STT_FUNC" else 0
                 if addr not in bounds or rank > bounds[addr][0]:
-                    bounds[addr] = (rank, sym.name)
+                    bounds[addr] = (rank, name)
 
         self._ranges = sorted((a, v[1], v[2]) for a, v in ranges.items())
         self._range_starts = [r[0] for r in self._ranges]
@@ -273,25 +263,62 @@ class SymbolTable:
         self._bound_starts = [b[0] for b in self._bounds]
 
         if not self._ranges and not self._bounds:
-            sys.exit(f"{elf_path} contains no function symbols.")
+            sys.exit(f"{source} contains no function symbols.")
 
         # Loadable ranges, used to tell "not a Zephyr function" apart from
         # "not Zephyr at all" (the BIOS the guest boots through).
-        self._load = [
+        self._load = list(load)
+
+        # Filled in by from_elf(); a table built from bare symbols has no
+        # DWARF, so source_file() returns None for every address.
+        self._fp = None
+        self._dwarf = None
+        self._aranges = None
+        self._file_cache: dict[str, str | None] = {}
+        self._sym_cache: dict[int, tuple[str, str]] = {}
+
+    @classmethod
+    def from_elf(cls, elf_path: str) -> "SymbolTable":
+        """Build the table from a build's ELF, DWARF included when present."""
+        fp = open(elf_path, "rb")  # noqa: SIM115 - kept open for DWARF
+        elf = ELFFile(fp)
+
+        symtab = elf.get_section_by_name(".symtab")
+        if symtab is None:
+            sys.exit(f"{elf_path} has no .symtab; a stripped build cannot be profiled.")
+
+        exec_sections = {
+            idx
+            for idx, sec in enumerate(elf.iter_sections())
+            if sec["sh_flags"] & SH_FLAGS.SHF_EXECINSTR
+        }
+
+        symbols = [
+            (
+                sym.name,
+                sym.entry.st_value,
+                sym.entry.st_size,
+                sym.entry.st_info.type,
+                sym.entry.st_info.bind,
+            )
+            for sym in symtab.iter_symbols()
+            if isinstance(sym.entry.st_shndx, int) and sym.entry.st_shndx in exec_sections
+        ]
+        load = [
             (seg["p_vaddr"], seg["p_vaddr"] + seg["p_memsz"])
             for seg in elf.iter_segments()
             if seg["p_type"] == "PT_LOAD" and seg["p_memsz"]
         ]
 
-        self._dwarf = elf.get_dwarf_info() if elf.has_dwarf_info() else None
-        self._aranges = None
-        if self._dwarf is not None:
+        table = cls(symbols, load, elf_path)
+        table._fp = fp
+        table._dwarf = elf.get_dwarf_info() if elf.has_dwarf_info() else None
+        if table._dwarf is not None:
             try:
-                self._aranges = self._dwarf.get_aranges()
+                table._aranges = table._dwarf.get_aranges()
             except Exception:  # noqa: BLE001 - DWARF is best effort
-                self._aranges = None
-        self._file_cache: dict[str, str | None] = {}
-        self._sym_cache: dict[int, tuple[str, str]] = {}
+                table._aranges = None
+        return table
 
     def in_image(self, pc: int) -> bool:
         return any(lo <= pc < hi for lo, hi in self._load)
@@ -478,6 +505,32 @@ def attribute(
     return funcs, total, dict(kinds)
 
 
+def _ipb(insns: int, byts: int) -> float:
+    """Instructions per payload byte; 0.0 when nothing was transferred."""
+    return (insns / byts) if byts else 0.0
+
+
+def _mbps(ipb: float, shift: int) -> float:
+    """Throughput implied by *ipb* under ``-icount shift=<shift>``.
+
+    8 bits/byte * 1e9 ns/s / (2**shift ns/insn * ipb insn/byte) / 1e6, which
+    at the default shift of 5 is 250/ipb.
+    """
+    return (8000.0 / (2**shift * ipb)) if ipb else 0.0
+
+
+def _mbps_gain(ipb: float, f_ipb: float, shift: int) -> float:
+    """What the throughput would gain if a function costing *f_ipb* were free."""
+    if ipb <= f_ipb:
+        return 0.0
+    return _mbps(ipb - f_ipb, shift) - _mbps(ipb, shift)
+
+
+def _pct(part: float, whole: float) -> float:
+    """*part* as a percentage of *whole*; 0.0 when *whole* is zero."""
+    return (100.0 * part / whole) if whole else 0.0
+
+
 def render(profile: dict, top: int) -> None:
     """Print the header, the per-function table and the group roll-up."""
     label = profile["label"]
@@ -486,9 +539,8 @@ def render(profile: dict, top: int) -> None:
     shift = profile.get("icount_shift", 5)
     measured = profile.get("measured_mbps")
 
-    ipb = (total / byts) if byts else 0.0
-    # Mbps = 8 bits/byte * 1e9 ns/s / (2**shift ns/insn * ipb insn/byte) / 1e6
-    reconstructed = (8000.0 / (2**shift * ipb)) if ipb else 0.0
+    ipb = _ipb(total, byts)
+    reconstructed = _mbps(ipb, shift)
 
     print(f"\n=== {label} ({profile.get('platform', '?')}) ===")
     line = f"instructions {total:>15,}   payload {byts:>12,} B   ipb {ipb:8.3f}"
@@ -512,9 +564,9 @@ def render(profile: dict, top: int) -> None:
         bucketed = kinds.get("bucket", 0)
         inferred = kinds.get("inferred", 0)
         print(
-            f"attribution  exact {100 * kinds.get('exact', 0) / total:5.2f}%   "
-            f"inferred {100 * inferred / total:5.2f}%   "
-            f"unattributed {100 * bucketed / total:5.2f}%"
+            f"attribution  exact {_pct(kinds.get('exact', 0), total):5.2f}%   "
+            f"inferred {_pct(inferred, total):5.2f}%   "
+            f"unattributed {_pct(bucketed, total):5.2f}%"
         )
 
     funcs = profile["functions"]
@@ -528,29 +580,24 @@ def render(profile: dict, top: int) -> None:
     for rank, (name, info) in enumerate(ranked[:top], start=1):
         insns = info["insns"]
         cum += insns
-        share = 100.0 * insns / total if total else 0.0
-        f_ipb = insns / byts if byts else 0.0
+        share = _pct(insns, total)
+        f_ipb = _ipb(insns, byts)
         # What the throughput would become if this function cost nothing.
-        gain = ((8000.0 / (2**shift * (ipb - f_ipb))) - reconstructed) if ipb > f_ipb else 0.0
+        gain = _mbps_gain(ipb, f_ipb, shift)
         print(
             f"{rank:>3}  {name[:33]:<34}{info['group']:<10}{insns:>14,}"
-            f"{f_ipb:>8.3f}{share:>6.2f}%{100 * cum / total if total else 0:>6.1f}%"
+            f"{f_ipb:>8.3f}{share:>6.2f}%{_pct(cum, total):>6.1f}%"
             f"{gain:>+8.2f}  {info['file'] or ''}"
         )
 
-    groups: dict[str, int] = defaultdict(int)
-    for info in funcs.values():
-        groups[info["group"]] += info["insns"]
+    groups = _group_totals(profile)
 
     print(f"\n{'group':<12}{'instructions':>14}{'ipb':>9}{'%':>8}")
     ordered = sorted(
         groups.items(), key=lambda kv: (GROUP_ORDER.index(kv[0]) if kv[0] in GROUP_ORDER else 99)
     )
     for group, insns in ordered:
-        print(
-            f"{group:<12}{insns:>14,}{insns / byts if byts else 0:>9.3f}"
-            f"{100.0 * insns / total if total else 0:>7.2f}%"
-        )
+        print(f"{group:<12}{insns:>14,}{_ipb(insns, byts):>9.3f}{_pct(insns, total):>7.2f}%")
 
 
 def render_diff(baseline: dict, current: dict, tolerance_pct: float, top: int) -> bool:
@@ -568,9 +615,9 @@ def render_diff(baseline: dict, current: dict, tolerance_pct: float, top: int) -
 
         b_bytes = base.get("bytes") or 0
         c_bytes = cur.get("bytes") or 0
-        b_ipb = base["total_insns"] / b_bytes if b_bytes else 0.0
-        c_ipb = cur["total_insns"] / c_bytes if c_bytes else 0.0
-        change = ((c_ipb - b_ipb) / b_ipb * 100.0) if b_ipb else 0.0
+        b_ipb = _ipb(base["total_insns"], b_bytes)
+        c_ipb = _ipb(cur["total_insns"], c_bytes)
+        change = _pct(c_ipb - b_ipb, b_ipb)
         # More instructions per byte is slower, so a positive change is bad.
         status = "OK" if change <= tolerance_pct else "REGRESSION"
         if status != "OK":
@@ -808,7 +855,7 @@ def build_profile(
         boot_insns = sum(n * c for (_, n), c in boot_blocks.items())
         blocks = subtract(blocks, boot_blocks)
 
-    table = SymbolTable(elf)
+    table = SymbolTable.from_elf(elf)
     funcs, total, kinds = attribute(blocks, table, zephyr_base, topdir)
 
     mbps, byts = parse_console(console) if console else ({}, {})

--- a/samples/net/zperf/scripts/zperf_profile.py
+++ b/samples/net/zperf/scripts/zperf_profile.py
@@ -555,14 +555,35 @@ def render(profile: dict, top: int) -> None:
     print(line)
 
     if measured:
+        # The profile covers everything from the boot boundary to the halt,
+        # while the measured throughput covers only the timed transfer, so
+        # this ratio is the share of the profiled cost the transfer accounts
+        # for. The rest is the network initialisation, the socket setup and
+        # the result reporting either side of it.
+        #
+        # It is not a CPU-bound fraction, and it moves the other way from one.
         # With icount sleep=off, halted time advances virtual time without
-        # executing instructions, so this ratio is the CPU-bound fraction of
-        # the run. Below 1 means the guest waited (TCP on ACKs, for example);
-        # above 1 means the accounting is wrong.
-        ratio = reconstructed / measured if measured else 0.0
+        # executing instructions, so time the guest spends idle inside the
+        # window makes the window longer without adding instructions, which
+        # pushes this figure *above* 100%. On loopback there is next to no
+        # such time, and what is seen instead is a steady few percent of work
+        # outside the window.
         print(
             f"throughput   measured {measured:8.3f} Mbps   "
-            f"from profile {reconstructed:8.3f} Mbps   cpu-bound {ratio * 100:5.1f}%"
+            f"from profile {reconstructed:8.3f} Mbps   "
+            f"in-window {_pct(reconstructed, measured):5.1f}%"
+        )
+
+    window_us = profile.get("window_us")
+    if window_us:
+        # The accounting behind the line above, in seconds, so the residual is
+        # a number rather than an inference.
+        cpu_s = total * (2**shift) / 1e9
+        window_s = window_us / 1e6
+        print(
+            f"virtual time profiled {cpu_s:.6f} s of cpu   "
+            f"transfer window {window_s:.6f} s   "
+            f"outside the window {cpu_s - window_s:+.6f} s"
         )
 
     kinds = profile.get("kinds") or {}
@@ -838,20 +859,32 @@ def build_one(
     subprocess.run(argv, check=True, cwd=zephyr_base)
 
 
-def parse_console(path: str) -> tuple[dict[str, float], dict[str, int]]:
-    """Extract the ZPERF-RESULT throughputs and ZPERF-INFO byte counts."""
+def parse_console(path: str) -> tuple[dict[str, float], dict[str, int], dict[str, int]]:
+    """Extract the ZPERF-RESULT throughputs and the ZPERF-INFO byte counts and
+    transfer durations.
+
+    The duration is the guest's own view of how long the timed transfer took,
+    in virtual microseconds. It is what makes the profile's virtual time
+    accounting checkable rather than merely plausible.
+    """
     mbps: dict[str, float] = {}
     byts: dict[str, int] = {}
+    window: dict[str, int] = {}
     if not os.path.exists(path):
-        return mbps, byts
+        return mbps, byts, window
 
     with open(path, errors="replace") as fp:
         text = fp.read()
     for label, value in re.findall(r"ZPERF-RESULT (\w+)_mbps=([0-9.]+)", text):
         mbps[label] = float(value)
-    for label, value in re.findall(r"ZPERF-INFO (\w+)_bytes=(\d+)", text):
-        byts[label] = int(value)
-    return mbps, byts
+    # One ZPERF-INFO line carries several fields, so scope to the line first
+    # rather than anchoring each field on the prefix.
+    for info in re.findall(r"ZPERF-INFO ([^\n]*)", text):
+        for label, value in re.findall(r"(\w+)_bytes=(\d+)", info):
+            byts[label] = int(value)
+        for label, value in re.findall(r"(\w+)_us=(\d+)", info):
+            window[label] = int(value)
+    return mbps, byts, window
 
 
 def build_profile(
@@ -875,7 +908,7 @@ def build_profile(
     table = SymbolTable.from_elf(elf)
     funcs, total, kinds = attribute(blocks, table, zephyr_base, topdir)
 
-    mbps, byts = parse_console(console) if console else ({}, {})
+    mbps, byts, window = parse_console(console) if console else ({}, {}, {})
 
     return {
         "schema": 1,
@@ -884,6 +917,7 @@ def build_profile(
         "icount_shift": shift,
         "bytes": byts.get(label, 0),
         "measured_mbps": mbps.get(label),
+        "window_us": window.get(label),
         "total_insns": total,
         "boot_insns": boot_insns,
         "kinds": kinds,
@@ -1267,8 +1301,8 @@ def cmd_verify(args: argparse.Namespace) -> int:
     # guest reports has to be identical with and without them.
     bare_console = os.path.join(outdir, f"{label}.noplugin.console")
     run_one(build_dir, None, os.path.join(outdir, f"{label}.noplugin.report"), bare_console)
-    bare_mbps, _ = parse_console(bare_console)
-    watched_mbps, _ = parse_console(os.path.join(outdir, f"{label}.console"))
+    bare_mbps, _bytes, _window = parse_console(bare_console)
+    watched_mbps, _bytes, _window = parse_console(os.path.join(outdir, f"{label}.console"))
     _report(
         results,
         "non-perturbation",

--- a/samples/net/zperf/scripts/zperf_profile.py
+++ b/samples/net/zperf/scripts/zperf_profile.py
@@ -56,6 +56,12 @@ Typical usage::
         --baseline ../build/zprof-base/profile.json \\
         --current ../build/zprof/profile.json
 
+    # Check the profile against QEMU's own instruction counter, against
+    # binutils, and against a code change whose effect it has to predict.
+    samples/net/zperf/scripts/zperf_profile.py verify --base-dir .. \\
+        --plugin ../tools/qemu-plugins/lib/libhotblocks.so \\
+        --outdir ../build/zprof-verify
+
 By default all files read or written must live under the current directory;
 pass --base-dir to widen that.
 """
@@ -734,11 +740,12 @@ def _kernel_images(argv: list[str]) -> list[str]:
 
 def run_one(
     build_dir: str,
-    plugin: str,
+    plugin: str | None,
     report_path: str,
     console_path: str,
     stop_plugin: str | None = None,
     stop_addr: int | None = None,
+    extra_plugins: tuple[str, ...] = (),
 ) -> None:
     argv = qemu_command(build_dir)
     argv += [
@@ -748,9 +755,13 @@ def run_one(
         "none",
         "-monitor",
         "none",
-        "-plugin",
-        f"file={plugin},inline=on",
     ]
+    # No plugin at all is how the run is checked for not being disturbed by
+    # being watched: the guest must report the same throughput either way.
+    if plugin is not None:
+        argv += ["-plugin", f"file={plugin},inline=on"]
+    for extra in extra_plugins:
+        argv += ["-plugin", extra]
     if stop_plugin is not None and stop_addr is not None:
         # Stop the guest the moment it reaches the address, so this run covers
         # only the prefix shared with the full run.
@@ -771,6 +782,9 @@ def run_one(
     # The guest halts itself through isa-debug-exit, so QEMU's exit status is
     # the guest's halt reason, not a failure indication.
     subprocess.run(argv, cwd=build_dir, check=False, timeout=1800)
+
+    if plugin is None:
+        return
 
     if not os.path.exists(report_path) or os.path.getsize(report_path) == 0:
         sys.exit(
@@ -797,7 +811,9 @@ def symbol_address(elf_path: str, name: str) -> int:
     sys.exit(f"No function symbol '{name}' in {elf_path}.")
 
 
-def build_one(zephyr_base: str, board: str, build_dir: str, only: str) -> None:
+def build_one(
+    zephyr_base: str, board: str, build_dir: str, only: str, extra: tuple[str, ...] = ()
+) -> None:
     west = shutil.which("west")
     if west is None:
         sys.exit("west not found in PATH; activate the workspace virtualenv first.")
@@ -817,6 +833,7 @@ def build_one(zephyr_base: str, board: str, build_dir: str, only: str) -> None:
         # the value, not around the -D argument.
         f'-DCONFIG_ZPERF_LOOPBACK_SELFTEST_ONLY="{only}"',
         "-DCONFIG_ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE=y",
+        *extra,
     ]
     subprocess.run(argv, check=True, cwd=zephyr_base)
 
@@ -1000,6 +1017,337 @@ def cmd_diff(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def parse_insn_total(path: str) -> int | None:
+    """The instruction count QEMU's own insn plugin reported, if it was loaded.
+
+    That plugin counts once per instruction, where hotblocks counts once per
+    translation block and multiplies by the block length. The two numbers come
+    from different code in QEMU and have to agree exactly; if they do not, the
+    block accounting every per-function figure is built on is wrong.
+    """
+    with open(path, errors="replace") as fp:
+        for line in fp:
+            match = re.match(r"total insns:\s*(\d+)", line.strip())
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def cache_tool(build_dir: str, key: str) -> str | None:
+    """A toolchain binary the build recorded, e.g. CMAKE_NM."""
+    cache = os.path.join(build_dir, "CMakeCache.txt")
+    if not os.path.exists(cache):
+        return None
+
+    with open(cache, errors="replace") as fp:
+        for line in fp:
+            name, _, value = line.partition("=")
+            if name.split(":")[0] == key:
+                return value.strip() or None
+    return None
+
+
+# GCC splits a function into several symbols: a cold partition, a cloned
+# constant-propagated body, an interprocedural-scalar-replacement variant. They
+# are the same function under decorated names, and nm's size for the parent can
+# run into the child, so compare the undecorated stems.
+GCC_PARTITION = re.compile(r"\.(cold|hot|part|isra|constprop|lto_priv)(\.[0-9]+)*$")
+
+
+def base_symbol(name: str) -> str:
+    """A symbol name with GCC's per-partition decoration removed."""
+    while True:
+        stripped = GCC_PARTITION.sub("", name)
+        if stripped == name:
+            return name
+        name = stripped
+
+
+def nm_functions(nm: str, elf_path: str) -> dict[tuple[int, int], set[str]]:
+    """Sized functions as binutils sees them, keyed by (address, size).
+
+    The sysv format is used rather than the default because it names the
+    symbol type outright. The single letter codes do not: a constant placed in
+    a text section is a "T" like any function, and comparing against those
+    would report a difference wherever the profiler is right to ignore one.
+
+    Aliases share an address, so the value is a set of undecorated names: the
+    profiler picks one name per address and any of the aliases is a correct
+    answer.
+    """
+    out = subprocess.run(
+        [nm, "--format=sysv", "--defined-only", elf_path],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    functions: dict[tuple[int, int], set[str]] = defaultdict(set)
+    for line in out.splitlines():
+        fields = [f.strip() for f in line.split("|")]
+        # Name | Value | Class | Type | Size | Line | Section
+        if len(fields) != 7 or fields[3] != "FUNC":
+            continue
+        try:
+            addr, size = int(fields[1], 16), int(fields[4], 16)
+        except ValueError:
+            # An unsized symbol leaves the column blank. Those are exactly the
+            # ones the profiler has to infer bounds for, so nm has nothing to
+            # check them against.
+            continue
+        if size:
+            functions[(addr, size)].add(base_symbol(fields[0]))
+    return dict(functions)
+
+
+def _report(results: list[tuple[str, str, str]], name: str, verdict: str, detail: str) -> None:
+    results.append((name, verdict, detail))
+    print(f"{verdict:<5} {name:<24} {detail}", flush=True)
+
+
+def _profile_one(
+    label: str,
+    build_dir: str,
+    outdir: str,
+    prefix: str,
+    plugin: str,
+    stop_plugin: str,
+    board: str,
+    shift: int,
+    zephyr_base: str,
+    topdir: str,
+    extra_plugins: tuple[str, ...] = (),
+) -> tuple[dict, str]:
+    """One full run plus its boot baseline, folded into a profile."""
+    elf = os.path.join(build_dir, "zephyr", "zephyr.elf")
+    report = os.path.join(outdir, f"{prefix}.report")
+    console = os.path.join(outdir, f"{prefix}.console")
+    boot_report = os.path.join(outdir, f"{prefix}.boot.report")
+    boot_console = os.path.join(outdir, f"{prefix}.boot.console")
+
+    run_one(build_dir, plugin, report, console, extra_plugins=extra_plugins)
+    run_one(build_dir, plugin, boot_report, boot_console, stop_plugin, symbol_address(elf, "main"))
+    profile = build_profile(
+        label, report, elf, boot_report, console, board, shift, zephyr_base, topdir
+    )
+    return profile, report
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    """Check the profile against things that are not this script.
+
+    The unit tests establish that the script does what its author meant. They
+    cannot establish that what it means is true of the guest, because they
+    never run one. These checks compare its output against QEMU's own
+    instruction counter, against binutils' view of the same ELF, against the
+    guest running unobserved, and against a code change whose effect the
+    profile has to predict before it is measured.
+    """
+    zephyr_base = os.environ.get("ZEPHYR_BASE") or os.getcwd()
+    topdir = os.path.realpath(os.path.join(zephyr_base, ".."))
+    plugin = validate_qemu_arg_path(args.plugin, args.base_dir, for_write=False)
+    plugin_dir = os.path.dirname(plugin)
+    stop_plugin = validate_qemu_arg_path(
+        args.stop_plugin or os.path.join(plugin_dir, "libstoptrigger.so"),
+        args.base_dir,
+        for_write=False,
+    )
+    insn_plugin = validate_qemu_arg_path(
+        args.insn_plugin or os.path.join(plugin_dir, "libinsn.so"), args.base_dir, for_write=False
+    )
+    outdir = validate_path(args.outdir, args.base_dir, for_write=False)
+    os.makedirs(outdir, exist_ok=True)
+
+    label = args.transfer
+    if label not in TRANSFERS:
+        sys.exit(f"Unknown transfer '{label}'. One of: {', '.join(TRANSFERS)}")
+
+    build_dir = os.path.join(outdir, label)
+    elf = os.path.join(build_dir, "zephyr", "zephyr.elf")
+    results: list[tuple[str, str, str]] = []
+
+    print(f"--- {label}: building", flush=True)
+    build_one(zephyr_base, args.board, build_dir, label)
+
+    print(f"\n=== Verifying the profile ({label}, {args.board}) ===\n", flush=True)
+
+    # 1. QEMU's own instruction counter against the block accounting. Both
+    # plugins go into one run, so this costs nothing and compares the very
+    # same execution rather than two runs that merely ought to match.
+    profile, report = _profile_one(
+        label,
+        build_dir,
+        outdir,
+        label,
+        plugin,
+        stop_plugin,
+        args.board,
+        args.icount_shift,
+        zephyr_base,
+        topdir,
+        extra_plugins=(f"file={insn_plugin}",),
+    )
+    blocks, _ = parse_report(report)
+    block_total = sum(insns * count for (_, insns), count in blocks.items())
+    insn_total = parse_insn_total(report)
+    if insn_total is None:
+        _report(
+            results,
+            "instruction count",
+            "SKIP",
+            f"no insn plugin output in {os.path.basename(report)}; build libinsn.so "
+            f"with qemu_plugin_setup.sh",
+        )
+    else:
+        # These do not have to be equal, and knowing why is the point of
+        # running both. Counting per block charges a whole block whenever
+        # execution enters it, while counting per instruction charges only
+        # what ran; the two part company wherever a block is left early,
+        # which on this guest is the emulated timer and UART. So the block
+        # count is an upper bound, and what is checked is that the gap is
+        # small and in the direction it has to be. A block count *below* the
+        # instruction count would mean blocks are being missed entirely.
+        gap = _pct(block_total - insn_total, insn_total)
+        _report(
+            results,
+            "instruction count",
+            "PASS" if 0 <= gap <= args.block_bias else "FAIL",
+            f"hotblocks {block_total:,}, insn plugin {insn_total:,}, blocks high by {gap:.3f}%",
+        )
+
+    # 2. Nothing is lost or invented between the blocks and the table.
+    func_total = sum(info["insns"] for info in profile["functions"].values())
+    kind_total = sum(profile["kinds"].values())
+    _report(
+        results,
+        "conservation",
+        "PASS" if func_total == kind_total == profile["total_insns"] else "FAIL",
+        f"functions {func_total:,}, kinds {kind_total:,}, total {profile['total_insns']:,}",
+    )
+
+    # 3. After the boot prefix comes off, every instruction left belongs to a
+    # function in this image. Anything in the bucket is the BIOS, which means
+    # the subtraction did not do its job.
+    bucket = profile["kinds"].get("bucket", 0)
+    share = _pct(bucket, profile["total_insns"])
+    _report(
+        results,
+        "attribution",
+        "PASS" if share <= args.unattributed else "FAIL",
+        f"{bucket:,} instructions ({share:.4f}%) unattributed after boot subtraction",
+    )
+
+    # 4. binutils reading the same ELF has to agree about which function owns
+    # which address. This checks the symbol extraction and the interval
+    # construction against an implementation that shares no code with it.
+    nm = args.nm or cache_tool(build_dir, "CMAKE_NM")
+    if nm is None or shutil.which(nm) is None:
+        _report(results, "symbol table", "SKIP", "no nm found; pass --nm")
+    else:
+        table = SymbolTable.from_elf(elf)
+        functions = nm_functions(nm, elf)
+        bad = [
+            (addr, size, names)
+            for (addr, size), names in functions.items()
+            if base_symbol(table.lookup(addr)[0]) not in names
+            or base_symbol(table.lookup(addr + size - 1)[0]) not in names
+        ]
+        detail = f"{len(functions)} sized functions, {len(bad)} disagreeing with nm"
+        if bad:
+            addr, size, names = bad[0]
+            detail += (
+                f" (first: 0x{addr:x}+0x{size:x} is {sorted(names)}, profiler says "
+                f"{table.lookup(addr)[0]} at the start and "
+                f"{table.lookup(addr + size - 1)[0]} at the end)"
+            )
+        _report(results, "symbol table", "PASS" if not bad else "FAIL", detail)
+
+    # 5. Watching the guest must not change what it does. The plugin callbacks
+    # run on the host and execute no guest instructions, so the throughput the
+    # guest reports has to be identical with and without them.
+    bare_console = os.path.join(outdir, f"{label}.noplugin.console")
+    run_one(build_dir, None, os.path.join(outdir, f"{label}.noplugin.report"), bare_console)
+    bare_mbps, _ = parse_console(bare_console)
+    watched_mbps, _ = parse_console(os.path.join(outdir, f"{label}.console"))
+    _report(
+        results,
+        "non-perturbation",
+        "PASS" if bare_mbps == watched_mbps and bare_mbps else "FAIL",
+        f"unwatched {bare_mbps}, watched {watched_mbps}",
+    )
+
+    # 6. Under icount the same binary executes the same instructions, so a
+    # repeat run should land on the same total. The logging thread is
+    # scheduled independently of the traffic, which is what the tolerance is
+    # for; anything larger means the measurement is not repeatable.
+    repeat, _ = _profile_one(
+        label,
+        build_dir,
+        outdir,
+        f"{label}.repeat",
+        plugin,
+        stop_plugin,
+        args.board,
+        args.icount_shift,
+        zephyr_base,
+        topdir,
+    )
+    drift = abs(_pct(repeat["total_insns"] - profile["total_insns"], profile["total_insns"]))
+    _report(
+        results,
+        "determinism",
+        "PASS" if drift < args.drift else "FAIL",
+        f"{profile['total_insns']:,} then {repeat['total_insns']:,}, {drift:.4f}% apart",
+    )
+
+    # 7. The one that matters. If instructions per byte really is the
+    # throughput in different units, then removing known work from the stack
+    # must move the measured throughput by the amount the profile says. Take
+    # the receive side UDP checksum out, which is one of the two passes the
+    # loopback path makes over every datagram, and compare.
+    if not label.startswith("udp"):
+        _report(results, "prediction", "SKIP", f"needs a UDP transfer, not {label}")
+    else:
+        mod_dir = os.path.join(outdir, f"{label}-nocksum")
+        print(f"\n--- {label}: building without the UDP checksum", flush=True)
+        build_one(zephyr_base, args.board, mod_dir, label, extra=("-DCONFIG_NET_UDP_CHECKSUM=n",))
+        modified, _ = _profile_one(
+            label,
+            mod_dir,
+            outdir,
+            f"{label}.nocksum",
+            plugin,
+            stop_plugin,
+            args.board,
+            args.icount_shift,
+            zephyr_base,
+            topdir,
+        )
+        base_ipb = _ipb(profile["total_insns"], profile["bytes"])
+        mod_ipb = _ipb(modified["total_insns"], modified["bytes"])
+        predicted = _pct(base_ipb - mod_ipb, mod_ipb)
+        measured = _pct(
+            modified["measured_mbps"] - profile["measured_mbps"], profile["measured_mbps"]
+        )
+        _report(
+            results,
+            "prediction",
+            "PASS" if abs(predicted - measured) <= args.prediction else "FAIL",
+            f"profile said {predicted:+.2f}%, guest measured {measured:+.2f}%, "
+            f"{abs(predicted - measured):.2f} points apart",
+        )
+
+    failed = [name for name, verdict, _ in results if verdict == "FAIL"]
+    skipped = [name for name, verdict, _ in results if verdict == "SKIP"]
+    print(
+        f"\n{len(results) - len(failed) - len(skipped)} passed, "
+        f"{len(failed)} failed, {len(skipped)} skipped"
+    )
+    if failed:
+        print(f"Failed: {', '.join(failed)}", file=sys.stderr)
+    return 1 if failed else 0
+
+
 def main() -> int:
     # --base-dir is shared by every subcommand and accepted on either side of
     # the subcommand name, so it goes on a parent parser rather than the root.
@@ -1073,6 +1421,48 @@ def main() -> int:
     )
     dif.add_argument("--top", **common_top)
     dif.set_defaults(func=cmd_diff)
+
+    ver = sub.add_parser(
+        "verify",
+        help="check the profile against QEMU, binutils and a measured code change",
+        parents=[common],
+        allow_abbrev=False,
+    )
+    ver.add_argument("--plugin", required=True, help="path to the QEMU TCG plugin")
+    ver.add_argument("--outdir", required=True, help="directory for builds and reports")
+    ver.add_argument("--board", default="qemu_x86")
+    ver.add_argument("--transfer", default="udp4", help=f"one of: {' '.join(TRANSFERS)}")
+    ver.add_argument("--icount-shift", type=int, default=5)
+    ver.add_argument("--stop-plugin", help="default: libstoptrigger.so next to --plugin")
+    ver.add_argument("--insn-plugin", help="default: libinsn.so next to --plugin")
+    ver.add_argument("--nm", help="default: the nm the build used")
+    ver.add_argument(
+        "--drift",
+        type=float,
+        default=0.1,
+        help="allowed instruction count drift between two runs, in percent",
+    )
+    ver.add_argument(
+        "--block-bias",
+        type=float,
+        default=1.0,
+        help="how far the per-block instruction count may exceed the "
+        "per-instruction one, in percent",
+    )
+    ver.add_argument(
+        "--unattributed",
+        type=float,
+        default=0.01,
+        help="allowed share of instructions belonging to no function, in percent",
+    )
+    ver.add_argument(
+        "--prediction",
+        type=float,
+        default=0.5,
+        help="allowed gap between the predicted and the measured throughput "
+        "change, in percentage points",
+    )
+    ver.set_defaults(func=cmd_verify)
 
     args = parser.parse_args()
     return args.func(args)

--- a/samples/net/zperf/scripts/zperf_profile_test.py
+++ b/samples/net/zperf/scripts/zperf_profile_test.py
@@ -690,6 +690,7 @@ def test_parse_console_extracts_results_and_byte_counts(tmp_path):
     assert zperf_profile.parse_console(path) == (
         {"tcp4": 91.25, "udp4": 120.5},
         {"tcp4": 1048576, "udp4": 2097152},
+        {"tcp4": 1001300, "udp4": 1000800},
     )
 
 
@@ -705,11 +706,11 @@ def test_parse_console_tolerates_undecodable_bytes(tmp_path):
     path = tmp_path / "c.log"
     path.write_bytes(b"\xff\xfe \x1b[1;32muart:~$ ZPERF-RESULT tcp4_mbps=5.0\n")
 
-    assert zperf_profile.parse_console(str(path)) == ({"tcp4": 5.0}, {})
+    assert zperf_profile.parse_console(str(path)) == ({"tcp4": 5.0}, {}, {})
 
 
 def test_parse_console_without_a_file():
-    assert zperf_profile.parse_console("/nonexistent/console.log") == ({}, {})
+    assert zperf_profile.parse_console("/nonexistent/console.log") == ({}, {}, {})
 
 
 #
@@ -933,14 +934,14 @@ def test_validate_qemu_arg_path_accepts_an_ordinary_path(tmp_path):
 
 GOLDEN_REPORT = (
     HEADER.format(n=4)
-    + "0x0000000000001000, 1, 4, 20\n"
-    + "0x0000000000002000, 1, 3, 10\n"
-    + "0x0000000000003000, 1, 2, 5\n"
-    + "0x0000000000000500, 1, 1, 8\n"
+    + "0x0000000000001000, 1, 4, 200\n"
+    + "0x0000000000002000, 1, 3, 100\n"
+    + "0x0000000000003000, 1, 2, 50\n"
+    + "0x0000000000000500, 1, 1, 80\n"
 )
-GOLDEN_BOOT = HEADER.format(n=2) + "0x0000000000001000, 1, 4, 5\n0x0000000000000500, 1, 1, 8\n"
+GOLDEN_BOOT = HEADER.format(n=2) + "0x0000000000001000, 1, 4, 50\n0x0000000000000500, 1, 1, 80\n"
 GOLDEN_CONSOLE = (
-    "*** Booting Zephyr OS ***\nZPERF-INFO tcp4_bytes=25\nZPERF-RESULT tcp4_mbps=62.5\n"
+    "*** Booting Zephyr OS ***\nZPERF-INFO tcp4_bytes=250 tcp4_us=32\nZPERF-RESULT tcp4_mbps=62.5\n"
 )
 
 
@@ -957,25 +958,28 @@ def _golden(tmp_path, boot=True, console=True):
 def test_build_profile_golden(tmp_path):
     """A report, its boot baseline and the console, end to end.
 
-    The numbers are chosen so the profile is self consistent: after the boot
-    prefix comes off, 100 instructions carried 25 payload bytes, which is 4.0
-    instructions per byte, which at shift 5 is exactly the 62.5 Mbps the guest
-    itself reported.
+    The numbers are chosen so the profile is self consistent in both
+    directions: after the boot prefix comes off, 1000 instructions carried 250
+    payload bytes, which is 4.0 instructions per byte, which at shift 5 is
+    exactly the 62.5 Mbps the guest itself reported; and those 1000
+    instructions are 32 us of virtual time, which is exactly the transfer
+    window the guest timed, so nothing was spent outside it.
     """
     assert _golden(tmp_path) == {
         "schema": 1,
         "label": "tcp4",
         "platform": "qemu_x86",
         "icount_shift": 5,
-        "bytes": 25,
+        "bytes": 250,
         "measured_mbps": 62.5,
-        "total_insns": 100,
-        "boot_insns": 28,
-        "kinds": {"exact": 60, "inferred": 40},
+        "window_us": 32,
+        "total_insns": 1000,
+        "boot_insns": 280,
+        "kinds": {"exact": 600, "inferred": 400},
         "functions": {
-            "net_pkt_alloc": {"insns": 60, "file": None, "group": "pktbuf"},
-            "arch_swap": {"insns": 30, "file": None, "group": "kernel"},
-            "memcpy": {"insns": 10, "file": None, "group": "libc"},
+            "net_pkt_alloc": {"insns": 600, "file": None, "group": "pktbuf"},
+            "arch_swap": {"insns": 300, "file": None, "group": "kernel"},
+            "memcpy": {"insns": 100, "file": None, "group": "libc"},
         },
     }
 
@@ -995,10 +999,10 @@ def test_build_profile_boot_subtraction_removes_the_firmware(tmp_path):
     with_boot = _golden(tmp_path)
     without_boot = _golden(tmp_path, boot=False)
 
-    assert without_boot["kinds"]["bucket"] == 8
+    assert without_boot["kinds"]["bucket"] == 80
     assert "bucket" not in with_boot["kinds"]
-    assert without_boot["total_insns"] == 128
-    assert with_boot["boot_insns"] == 28
+    assert without_boot["total_insns"] == 1280
+    assert with_boot["boot_insns"] == 280
 
 
 def test_build_profile_without_a_console(tmp_path):
@@ -1006,6 +1010,7 @@ def test_build_profile_without_a_console(tmp_path):
 
     assert profile["bytes"] == 0
     assert profile["measured_mbps"] is None
+    assert profile["window_us"] is None
 
 
 def test_build_profile_round_trips_through_json(tmp_path):
@@ -1026,9 +1031,14 @@ def test_render_reports_the_reconstructed_throughput(tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "=== tcp4 (qemu_x86) ===" in out
-    assert "payload           25 B   ipb    4.000" in out
-    assert "boot subtracted 28" in out
+    assert "payload          250 B   ipb    4.000" in out
+    assert "boot subtracted 280" in out
     assert "measured   62.500 Mbps   from profile   62.500 Mbps" in out
+    assert "in-window 100.0%" in out
+    # 1000 instructions at 32 ns each is 32 us of cpu, which is the whole of
+    # the 32 us window: nothing was spent outside it.
+    assert "profiled 0.000032 s of cpu   transfer window 0.000032 s" in out
+    assert "outside the window +0.000000 s" in out
     assert "attribution  exact 60.00%   inferred 40.00%   unattributed  0.00%" in out
     for group in ("pktbuf", "kernel", "libc"):
         assert group in out

--- a/samples/net/zperf/scripts/zperf_profile_test.py
+++ b/samples/net/zperf/scripts/zperf_profile_test.py
@@ -21,6 +21,7 @@ import argparse
 import contextlib
 import json
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -939,9 +940,7 @@ GOLDEN_REPORT = (
 )
 GOLDEN_BOOT = HEADER.format(n=2) + "0x0000000000001000, 1, 4, 5\n0x0000000000000500, 1, 1, 8\n"
 GOLDEN_CONSOLE = (
-    "*** Booting Zephyr OS ***\n"
-    "ZPERF-INFO tcp4_bytes=25 tcp4_us=3200\n"
-    "ZPERF-RESULT tcp4_mbps=62.5\n"
+    "*** Booting Zephyr OS ***\nZPERF-INFO tcp4_bytes=25\nZPERF-RESULT tcp4_mbps=62.5\n"
 )
 
 
@@ -1079,3 +1078,145 @@ def test_cmd_diff_exits_non_zero_on_a_regression(tmp_path, capsys):
 
     assert zperf_profile.cmd_diff(args) == 1
     assert "At least one transfer regressed beyond the tolerance." in capsys.readouterr().out
+
+
+#
+# The pieces the verify subcommand is built from
+#
+
+
+def test_parse_insn_total(tmp_path):
+    """QEMU's insn plugin appends its own totals to the same report file, so
+    the block table and this number come out of one run."""
+    path = _write(
+        tmp_path,
+        "r.log",
+        HEADER.format(n=1)
+        + "0x0000000000100238, 1, 4, 10\n"
+        + "cpu 0 insns: 38410031\n"
+        + "total insns: 38410031\n",
+    )
+
+    assert zperf_profile.parse_insn_total(path) == 38410031
+    # And the block table is unharmed by the extra lines.
+    assert zperf_profile.parse_report(path)[0] == {(0x100238, 4): 10}
+
+
+def test_parse_insn_total_without_the_plugin(tmp_path):
+    path = _write(tmp_path, "r.log", HEADER.format(n=1) + "0x0000000000100238, 1, 4, 10\n")
+
+    assert zperf_profile.parse_insn_total(path) is None
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("net_pkt_alloc", "net_pkt_alloc"),
+        # GCC splits a function across partitions and clones it for constant
+        # arguments. Those are the same function under decorated names, and
+        # nm's size for the parent can run into the child.
+        ("dummy_recv.cold", "dummy_recv"),
+        ("net_ipv6_send_ns.cold", "net_ipv6_send_ns"),
+        ("foo.constprop.0", "foo"),
+        ("foo.isra.12", "foo"),
+        ("foo.part.3.cold", "foo"),
+        ("foo.lto_priv.0", "foo"),
+        # A dot that is not one of GCC's suffixes is part of the name.
+        ("foo.bar", "foo.bar"),
+    ],
+)
+def test_base_symbol(name, expected):
+    assert zperf_profile.base_symbol(name) == expected
+
+
+def test_nm_functions_keeps_only_sized_functions(tmp_path):
+    out = (
+        "Symbols from zephyr.elf:\n"
+        "\n"
+        "Name                  Value   Class        Type         Size     Line  Section\n"
+        "\n"
+        "net_pkt_alloc       |00100000|   T  |              FUNC|00000040|     |text\n"
+        "static_helper       |00100040|   t  |              FUNC|00000010|     |text\n"
+        # An alias: either name is a correct answer for that address.
+        "net_pkt_alloc_alias |00100000|   T  |              FUNC|00000040|     |text\n"
+        # A partition of a function, which is the same function.
+        "outer.cold          |00100100|   t  |              FUNC|00000020|     |text\n"
+        # Unsized: the profiler infers this one's bounds, so there is nothing
+        # to compare it against.
+        "arch_swap           |00100050|   T  |              FUNC|        |     |text\n"
+        # Data, including data that lives in a text section and so carries the
+        # same single letter code a function would.
+        "a_variable          |00200000|   B  |            OBJECT|00000004|     |bss\n"
+        "a_constant          |00100200|   T  |            OBJECT|00000008|     |text\n"
+    )
+    run = mock.Mock(return_value=mock.Mock(stdout=out))
+    with mock.patch("zperf_profile.subprocess.run", run):
+        functions = zperf_profile.nm_functions("nm", "zephyr.elf")
+
+    assert functions == {
+        (0x100000, 0x40): {"net_pkt_alloc", "net_pkt_alloc_alias"},
+        (0x100040, 0x10): {"static_helper"},
+        (0x100100, 0x20): {"outer"},
+    }
+    assert run.call_args.args[0] == ["nm", "--format=sysv", "--defined-only", "zephyr.elf"]
+
+
+def test_cache_tool(tmp_path):
+    (tmp_path / "CMakeCache.txt").write_text(
+        "//The nm to use\n"
+        "CMAKE_NM:FILEPATH=/opt/sdk/bin/x86_64-zephyr-elf-nm\n"
+        "CMAKE_ADDR2LINE:FILEPATH=/opt/sdk/bin/x86_64-zephyr-elf-addr2line\n"
+        "EMPTY_ONE:FILEPATH=\n"
+    )
+
+    assert (
+        zperf_profile.cache_tool(str(tmp_path), "CMAKE_NM") == "/opt/sdk/bin/x86_64-zephyr-elf-nm"
+    )
+    assert zperf_profile.cache_tool(str(tmp_path), "EMPTY_ONE") is None
+    assert zperf_profile.cache_tool(str(tmp_path), "NOT_THERE") is None
+
+
+def test_cache_tool_without_a_build():
+    assert zperf_profile.cache_tool("/nonexistent/build", "CMAKE_NM") is None
+
+
+def test_run_one_without_a_plugin_does_not_demand_a_report(tmp_path):
+    """The unwatched run exists precisely to produce no plugin output, so the
+    empty report it leaves behind must not be treated as a failure."""
+    report = str(tmp_path / "empty.report")
+    console = str(tmp_path / "c.log")
+    with (
+        mock.patch("zperf_profile.qemu_command", return_value=["qemu-system-i386"]),
+        mock.patch("zperf_profile.subprocess.run") as run,
+    ):
+        zperf_profile.run_one("/b", None, report, console)
+
+    argv = run.call_args.args[0]
+    assert "-plugin" not in argv
+    assert argv[argv.index("-D") + 1] == report
+
+
+def test_run_one_loads_every_plugin_it_is_given(tmp_path):
+    report = _write(tmp_path, "r.report", "collected 0 entries\n")
+    with (
+        mock.patch("zperf_profile.qemu_command", return_value=["qemu-system-i386"]),
+        mock.patch("zperf_profile.subprocess.run") as run,
+    ):
+        # The guest would write the report; stand in for it, because run_one
+        # treats a missing one as the guest never having exited.
+        run.side_effect = lambda *a, **k: Path(report).write_text("x")
+        zperf_profile.run_one(
+            "/b",
+            "/p/libhotblocks.so",
+            report,
+            str(tmp_path / "c.log"),
+            "/p/libstoptrigger.so",
+            0x1234,
+            extra_plugins=("file=/p/libinsn.so",),
+        )
+    argv = run.call_args.args[0]
+
+    assert argv.count("-plugin") == 3
+    assert "file=/p/libhotblocks.so,inline=on" in argv
+    assert "file=/p/libinsn.so" in argv
+    assert "file=/p/libstoptrigger.so,addr=0x1234" in argv

--- a/samples/net/zperf/scripts/zperf_profile_test.py
+++ b/samples/net/zperf/scripts/zperf_profile_test.py
@@ -1,0 +1,1081 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+"""Unit tests for zperf_profile.py.
+
+These cover the parts of the profiler that turn a QEMU plugin report into
+numbers: parsing, boot subtraction, the PC to function mapping, the
+classification rules and the throughput arithmetic. They need no QEMU, no
+plugin and no build.
+
+What they deliberately do not cover is everything that drives an emulator:
+run_one(), build_one() and cmd_run() are a QEMU command line, a west build and
+the loop around them. Asserting a mocked argv against itself would say nothing
+about whether the plugin loaded, whether '-d plugin' produced a report or
+whether the guest halted, which are the ways those actually fail. The 'verify'
+subcommand checks those against QEMU and binutils instead.
+"""
+
+import argparse
+import contextlib
+import json
+import os
+from unittest import mock
+
+import pytest
+import zperf_profile
+
+# A synthetic symbol table covering all three lookup paths: a sized function
+# (exact), a zero-sized assembly entry point (inferred through the bounds
+# list), and a global STT_NOTYPE such as picolibc's memcpy (also inferred).
+# The names are chosen so SYMBOL_GROUPS puts each one in a different group.
+SYMS = [
+    ("net_pkt_alloc", 0x1000, 0x40, "STT_FUNC", "STB_GLOBAL"),
+    ("arch_swap", 0x2000, 0, "STT_FUNC", "STB_LOCAL"),
+    ("memcpy", 0x3000, 0, "STT_NOTYPE", "STB_GLOBAL"),
+]
+LOAD = [(0x1000, 0x4000)]
+
+HEADER = "collected {n} entries in the hash table\npc, tcount, icount, ecount\n"
+
+
+def _table(symbols=None, load=None, source="<symbols>"):
+    return zperf_profile.SymbolTable(
+        SYMS if symbols is None else symbols,
+        LOAD if load is None else load,
+        source,
+    )
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+#
+# parse_report()
+#
+
+
+def test_parse_report_well_formed(tmp_path):
+    path = _write(
+        tmp_path,
+        "r.log",
+        HEADER.format(n=3)
+        + "0x0000000000100238, 1, 4, 10\n"
+        + "0x0000000000100250, 2, 3, 7\n"
+        + "0x0000000000100260, 1, 1, 1\n",
+    )
+    blocks, collected = zperf_profile.parse_report(path)
+
+    assert blocks == {(0x100238, 4): 10, (0x100250, 3): 7, (0x100260, 1): 1}
+    assert collected == 3
+
+
+def test_parse_report_duplicate_keys_accumulate(tmp_path):
+    path = _write(
+        tmp_path,
+        "r.log",
+        "pc, tcount, icount, ecount\n0x0000000000100238, 1, 4, 10\n0x100238, 1, 4, 5\n",
+    )
+    blocks, collected = zperf_profile.parse_report(path)
+
+    assert blocks == {(0x100238, 4): 15}
+    assert collected == -1
+
+
+def test_parse_report_keeps_one_pc_with_two_block_sizes_apart(tmp_path):
+    """A block may be re-translated at a different length; that is not the same
+    block and its cost per execution differs."""
+    path = _write(
+        tmp_path,
+        "r.log",
+        HEADER.format(n=2) + "0x0000000000100238, 1, 4, 10\n0x0000000000100238, 1, 2, 3\n",
+    )
+    blocks, _ = zperf_profile.parse_report(path)
+
+    assert blocks == {(0x100238, 4): 10, (0x100238, 2): 3}
+
+
+def test_parse_report_skips_stoptrigger_lines(tmp_path):
+    """Plugins share one report stream, so the stop plugin's own output turns up
+    in the middle of the block table."""
+    path = _write(
+        tmp_path,
+        "r.log",
+        HEADER.format(n=2)
+        + "0x0000000000100238, 1, 4, 10\n"
+        + "0x0000000000101f00 reached, exiting\n"
+        + "stoptrigger: watching 0x101f00\n"
+        + "0x0000000000100250, 1, 3, 7\n",
+    )
+    blocks, _ = zperf_profile.parse_report(path)
+
+    assert blocks == {(0x100238, 4): 10, (0x100250, 3): 7}
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "0x0000000000100250, 1, 3\n",
+        "0x0000000000100250, 1, 3, 7, 9\n",
+        "0x0000000000100250\n",
+    ],
+)
+def test_parse_report_skips_rows_with_the_wrong_field_count(tmp_path, row):
+    path = _write(tmp_path, "r.log", HEADER.format(n=2) + "0x0000000000100238, 1, 4, 10\n" + row)
+    blocks, _ = zperf_profile.parse_report(path)
+
+    assert blocks == {(0x100238, 4): 10}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # No "pc," header: not a block report, whatever else it holds.
+        "collected 1 entries in the hash table\n0x0000000000100238, 1, 4, 10\n",
+        # Header but no rows: the plugin ran and found nothing, or -d plugin
+        # was missing and this is somebody else's output.
+        HEADER.format(n=0),
+        "",
+    ],
+)
+def test_parse_report_rejects_a_non_report(tmp_path, text):
+    path = _write(tmp_path, "r.log", text)
+
+    with pytest.raises(SystemExit, match="does not look like a QEMU plugin block report"):
+        zperf_profile.parse_report(path)
+
+
+def test_parse_report_warns_when_truncated(tmp_path, capsys):
+    """A stock QEMU plugin caps its output at the 20 hottest blocks. Believing
+    such a report silently would understate every total in the profile."""
+    path = _write(
+        tmp_path,
+        "r.log",
+        HEADER.format(n=25) + "0x100238, 1, 4, 10\n0x100250, 1, 3, 7\n0x100260, 1, 1, 1\n",
+    )
+    blocks, collected = zperf_profile.parse_report(path)
+
+    assert len(blocks) == 3
+    assert collected == 25
+    captured = capsys.readouterr()
+    assert "the plugin reported 25 blocks but emitted only 3 rows" in captured.err
+    assert captured.out == ""
+
+
+def test_parse_report_does_not_warn_within_one_row(tmp_path, capsys):
+    """The check allows one row of slack, so an off-by-one in the plugin's own
+    bookkeeping does not produce a false alarm on every run."""
+    path = _write(
+        tmp_path,
+        "r.log",
+        HEADER.format(n=4) + "0x100238, 1, 4, 10\n0x100250, 1, 3, 7\n0x100260, 1, 1, 1\n",
+    )
+    zperf_profile.parse_report(path)
+
+    assert capsys.readouterr().err == ""
+
+
+#
+# subtract()
+#
+
+
+def test_subtract_per_block():
+    full = {(0x10, 4): 10, (0x20, 2): 5, (0x30, 1): 3}
+    out = zperf_profile.subtract(full, {(0x10, 4): 4})
+
+    assert out == {(0x10, 4): 6, (0x20, 2): 5, (0x30, 1): 3}
+
+
+def test_subtract_removes_a_block_that_reaches_zero():
+    full = {(0x10, 4): 10, (0x20, 2): 5}
+    out = zperf_profile.subtract(full, {(0x20, 2): 5})
+
+    assert (0x20, 2) not in out
+    assert out == {(0x10, 4): 10}
+
+
+def test_subtract_does_not_mutate_its_input():
+    full = {(0x10, 4): 10, (0x20, 2): 5}
+    zperf_profile.subtract(full, {(0x10, 4): 4, (0x20, 2): 5})
+
+    assert full == {(0x10, 4): 10, (0x20, 2): 5}
+
+
+def test_subtract_rejects_a_boot_run_that_ran_a_block_more_often():
+    """The boot baseline is a prefix of the full run, so it can never execute a
+    block more times. If it did, the two runs diverged and nothing downstream
+    means anything."""
+    with pytest.raises(SystemExit) as excinfo:
+        zperf_profile.subtract({(0x10, 4): 3}, {(0x10, 4): 5})
+
+    assert "0x10(+4): 3 < 5" in str(excinfo.value)
+    assert "failed for 1 block(s)" in str(excinfo.value)
+
+
+def test_subtract_rejects_a_boot_block_absent_from_the_full_run():
+    with pytest.raises(SystemExit) as excinfo:
+        zperf_profile.subtract({}, {(0x99, 1): 1})
+
+    assert "0x99(+1): 0 < 1" in str(excinfo.value)
+
+
+#
+# SymbolTable
+#
+
+
+@pytest.mark.parametrize("pc", [0x1000, 0x1020, 0x103F])
+def test_lookup_inside_a_sized_function_is_exact(pc):
+    assert _table().lookup(pc) == ("net_pkt_alloc", "exact")
+
+
+@pytest.mark.parametrize("pc", [0x2000, 0x2FFF])
+def test_lookup_in_a_zero_sized_function_is_inferred(pc):
+    assert _table().lookup(pc) == ("arch_swap", "inferred")
+
+
+@pytest.mark.parametrize("pc", [0x3000, 0x3FFF])
+def test_lookup_in_a_global_notype_symbol_is_inferred(pc):
+    """picolibc's memcpy has no .type directive. Without STT_NOTYPE entry points
+    every byte it moves would be charged to whichever symbol precedes it."""
+    assert _table().lookup(pc) == ("memcpy", "inferred")
+
+
+@pytest.mark.parametrize("pc", [0x1040, 0x2000])
+def test_lookup_past_a_sized_function_is_unattributed(pc):
+    table = _table(symbols=[("net_pkt_alloc", 0x1000, 0x40, "STT_FUNC", "STB_GLOBAL")])
+
+    assert table.lookup(pc) == (zperf_profile.UNKNOWN, "bucket")
+
+
+@pytest.mark.parametrize("pc", [0x0, 0xFFF, 0x4000, 0xFFFFFFF0])
+def test_lookup_outside_the_image_is_firmware(pc):
+    """The guest boots through a BIOS that is not in the ELF at all. Charging
+    that to the nearest Zephyr symbol would be a lie; it is a separate bucket
+    so the boot subtraction can be seen to remove it."""
+    assert _table().lookup(pc) == (zperf_profile.FIRMWARE, "bucket")
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_lookup_prefers_a_global_symbol_over_a_local_one(reverse):
+    symbols = [
+        ("local_fn", 0x1000, 0x10, "STT_FUNC", "STB_LOCAL"),
+        ("global_fn", 0x1000, 0x10, "STT_FUNC", "STB_GLOBAL"),
+    ]
+    if reverse:
+        symbols.reverse()
+
+    assert _table(symbols=symbols).lookup(0x1004) == ("global_fn", "exact")
+
+
+@pytest.mark.parametrize(
+    ("binding", "expected"),
+    [
+        # A local .L label lives inside a function; treating it as a boundary
+        # would split that function's cost across two names.
+        ("STB_LOCAL", "asm_fn"),
+        # A global or weak entry point without a .type directive is a real
+        # function and must delimit the one before it.
+        ("STB_GLOBAL", "label"),
+        ("STB_WEAK", "label"),
+    ],
+)
+def test_a_notype_symbol_is_a_boundary_only_when_it_is_not_local(binding, expected):
+    table = _table(
+        symbols=[
+            ("asm_fn", 0x1000, 0, "STT_FUNC", "STB_GLOBAL"),
+            ("label", 0x1080, 0, "STT_NOTYPE", binding),
+        ]
+    )
+
+    assert table.lookup(0x1090) == (expected, "inferred")
+
+
+def test_a_sized_function_bounds_an_unsized_neighbour():
+    table = _table(
+        symbols=[
+            ("asm_fn", 0x1000, 0, "STT_FUNC", "STB_GLOBAL"),
+            ("sized", 0x1100, 0x20, "STT_FUNC", "STB_GLOBAL"),
+        ]
+    )
+
+    assert table.lookup(0x10F0) == ("asm_fn", "inferred")
+    assert table.lookup(0x1100) == ("sized", "exact")
+    assert table.lookup(0x1120) == (zperf_profile.UNKNOWN, "bucket")
+
+
+@pytest.mark.parametrize(
+    ("pc", "expected"), [(0xFFF, False), (0x1000, True), (0x1FFF, True), (0x2000, False)]
+)
+def test_in_image(pc, expected):
+    assert _table(load=[(0x1000, 0x2000)]).in_image(pc) is expected
+
+
+def test_a_table_with_no_function_symbols_exits():
+    with pytest.raises(SystemExit, match="fake.elf contains no function symbols"):
+        _table(symbols=[], source="fake.elf")
+
+
+def test_a_table_built_from_symbols_has_no_source_files():
+    """Without DWARF the file column is empty and classification falls back to
+    the symbol name rules, rather than guessing."""
+    assert _table().source_file(0x1000, "/z", "/") is None
+
+
+#
+# attribute()
+#
+
+BLOCKS = {(0x1000, 4): 10, (0x1010, 2): 5, (0x2000, 3): 2, (0x0500, 1): 7}
+
+
+def test_attribute_folds_blocks_into_functions():
+    funcs, total, kinds = zperf_profile.attribute(BLOCKS, _table(), "/z", "/")
+
+    assert funcs == {
+        "net_pkt_alloc": {"insns": 50, "file": None, "group": "pktbuf"},
+        "arch_swap": {"insns": 6, "file": None, "group": "kernel"},
+        zperf_profile.FIRMWARE: {"insns": 7, "file": None, "group": "other"},
+    }
+    assert total == 63
+    assert kinds == {"exact": 50, "inferred": 6, "bucket": 7}
+
+
+def test_attribute_kinds_account_for_every_instruction():
+    _funcs, total, kinds = zperf_profile.attribute(BLOCKS, _table(), "/z", "/")
+
+    assert sum(kinds.values()) == total
+
+
+def test_attribute_accumulates_one_function_seen_at_two_pcs():
+    funcs, total, _kinds = zperf_profile.attribute(
+        {(0x1000, 4): 10, (0x1010, 2): 5}, _table(), "/z", "/"
+    )
+
+    assert list(funcs) == ["net_pkt_alloc"]
+    assert funcs["net_pkt_alloc"]["insns"] == 50
+    assert total == 50
+
+
+def test_attribute_charges_a_whole_block_to_the_function_it_starts_in():
+    """A translation block ends at a branch, so it rarely straddles two
+    functions, and its whole cost goes to the function containing its first
+    instruction. Pin that, because it is the approximation the per-function
+    numbers rest on."""
+    funcs, total, _kinds = zperf_profile.attribute({(0x1030, 8): 1}, _table(), "/z", "/")
+
+    assert list(funcs) == ["net_pkt_alloc"]
+    assert total == 8
+
+
+#
+# classify() and _relativise()
+#
+
+
+@pytest.mark.parametrize(
+    ("func", "source", "expected"),
+    [
+        # FILE_GROUPS is first match wins: this path matches the zperf rule and
+        # the catch-all "^subsys/net/" rule, and the earlier one must win.
+        ("zperf_udp_recv", "subsys/net/lib/zperf/zperf_udp_receiver.c", "harness"),
+        ("net_pkt_alloc", "subsys/net/ip/net_pkt.c", "pktbuf"),
+        ("calc_chksum", "subsys/net/ip/utils.c", "checksum"),
+        ("tcp_in", "subsys/net/ip/tcp.c", "tcp"),
+        ("net_eth_send", "subsys/net/l2/ethernet/ethernet.c", "net-other"),
+        ("rb_insert", "lib/utils/rb.c", "kernel"),
+        # A known source matching no file rule falls through to the symbol
+        # rules rather than landing in "other".
+        ("net_if_send", "boards/x86/qemu_x86/board.c", "net-other"),
+        # No source at all: symbol rules only.
+        ("memcpy", None, "libc"),
+        ("z_swap", None, "kernel"),
+        ("calc_chksum", None, "checksum"),
+        # The symbol rules are anchored, so a mid-name match does not count.
+        ("my_tcp_helper", None, "other"),
+        ("do_thing", "boards/x86/qemu_x86/board.c", "other"),
+    ],
+)
+def test_classify(func, source, expected):
+    assert zperf_profile.classify(func, source) == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "zephyr_base", "topdir", "expected"),
+    [
+        (
+            "/home/u/zp/zephyr/subsys/net/ip/tcp.c",
+            "/home/u/zp/zephyr",
+            "/home/u/zp",
+            "subsys/net/ip/tcp.c",
+        ),
+        (
+            "/home/u/zp/modules/hal/nordic/f.c",
+            "/home/u/zp/zephyr",
+            "/home/u/zp",
+            "modules/hal/nordic/f.c",
+        ),
+        ("/opt/sdk/lib/gcc/x.c", "/home/u/zp/zephyr", "/home/u/zp", "/opt/sdk/lib/gcc/x.c"),
+        # A sibling directory sharing a prefix must not be truncated: the guard
+        # is a separator, not a string prefix.
+        ("/home/u/zp/zephyr-extra/f.c", "/home/u/zp/zephyr", "/home/u/zp", "zephyr-extra/f.c"),
+        # A trailing slash on ZEPHYR_BASE is a realistic environment value and
+        # must not defeat the match, or the path keeps a "zephyr/" prefix and
+        # stops matching the anchored rules in FILE_GROUPS.
+        ("/home/u/zp/zephyr/subsys/x.c", "/home/u/zp/zephyr/", "/home/u/zp", "subsys/x.c"),
+        # An empty root must be skipped rather than treated as "/", which would
+        # match every absolute path and eat its leading separator.
+        ("/opt/sdk/x.c", "", "", "/opt/sdk/x.c"),
+    ],
+)
+def test_relativise(path, zephyr_base, topdir, expected):
+    assert zperf_profile._relativise(path, zephyr_base, topdir) == expected
+
+
+#
+# The throughput arithmetic
+#
+
+
+def test_ipb():
+    assert zperf_profile._ipb(1000, 250) == 4.0
+    assert zperf_profile._ipb(1000, 0) == 0.0
+    assert zperf_profile._ipb(0, 250) == 0.0
+
+
+@pytest.mark.parametrize("ipb", [1.0, 4.0, 12.5, 19.03])
+def test_mbps_matches_the_documented_closed_form(ipb):
+    """At shift 5 one instruction is 32 ns, so Mbps is exactly 250/ipb. This is
+    the identity the whole method rests on."""
+    assert zperf_profile._mbps(ipb, 5) == pytest.approx(250.0 / ipb)
+
+
+@pytest.mark.parametrize(("shift", "expected"), [(0, 2000.0), (4, 125.0), (5, 62.5), (6, 31.25)])
+def test_mbps_scales_with_the_icount_shift(shift, expected):
+    assert zperf_profile._mbps(4.0, shift) == pytest.approx(expected)
+
+
+def test_mbps_of_a_run_that_moved_no_payload():
+    assert zperf_profile._mbps(0.0, 5) == 0.0
+
+
+def test_mbps_gain():
+    # Removing a quarter of the cost per byte.
+    assert zperf_profile._mbps_gain(4.0, 1.0, 5) == pytest.approx(250.0 / 3.0 - 62.5)
+    # Removing half of it doubles the throughput, so the gain equals the
+    # original figure.
+    assert zperf_profile._mbps_gain(4.0, 2.0, 5) == pytest.approx(62.5)
+
+
+@pytest.mark.parametrize(
+    ("ipb", "f_ipb"),
+    [
+        # A function accounting for the entire run: "free" means infinite
+        # throughput, which is not a number worth printing.
+        (4.0, 4.0),
+        (4.0, 5.0),
+        (4.0, 0.0),
+        (0.0, 0.0),
+    ],
+)
+def test_mbps_gain_degenerate_cases_are_zero_not_an_exception(ipb, f_ipb):
+    assert zperf_profile._mbps_gain(ipb, f_ipb, 5) == 0.0
+
+
+def test_pct():
+    assert zperf_profile._pct(50, 200) == 25.0
+    assert zperf_profile._pct(1, 0) == 0.0
+    assert zperf_profile._pct(-5.0, 100.0) == -5.0
+
+
+def test_group_totals():
+    profile = {
+        "functions": {
+            "a": {"insns": 10, "group": "tcp"},
+            "b": {"insns": 5, "group": "tcp"},
+            "c": {"insns": 2, "group": "libc"},
+        }
+    }
+
+    assert zperf_profile._group_totals(profile) == {"tcp": 15, "libc": 2}
+
+
+#
+# qemu_command() and _kernel_images()
+#
+
+
+@contextlib.contextmanager
+def _fake_ninja(recipe, *, exists=True):
+    """Make qemu_command() see *recipe* as ninja's run_qemu command line."""
+    run = mock.Mock(return_value=mock.Mock(stdout=recipe))
+    # A bool answers every existence check the same way; a list answers them in
+    # order, which is how the "missing, then built" path is reached.
+    seen = {"return_value": exists} if isinstance(exists, bool) else {"side_effect": exists}
+    with (
+        mock.patch("zperf_profile.shutil.which", return_value="/usr/bin/ninja"),
+        mock.patch("zperf_profile.subprocess.run", run),
+        mock.patch("zperf_profile.os.path.exists", **seen),
+    ):
+        yield run
+
+
+def test_qemu_command_splits_the_recipe():
+    recipe = (
+        "cd /b/dir && qemu-system-i386 -m 8 -cpu qemu32 -nographic -no-reboot "
+        "-serial mon:stdio -machine q35 -kernel /b/dir/zephyr/zephyr.elf"
+    )
+    with _fake_ninja(recipe):
+        argv = zperf_profile.qemu_command("/b/dir")
+
+    assert argv == [
+        "qemu-system-i386",
+        "-m",
+        "8",
+        "-cpu",
+        "qemu32",
+        "-no-reboot",
+        "-machine",
+        "q35",
+        "-kernel",
+        "/b/dir/zephyr/zephyr.elf",
+    ]
+
+
+def test_qemu_command_asks_ninja_for_the_run_target():
+    with _fake_ninja("cd /b && qemu-system-i386 -kernel k.elf") as run:
+        zperf_profile.qemu_command("/b")
+
+    assert run.call_args_list[0].args[0] == [
+        "/usr/bin/ninja",
+        "-C",
+        "/b",
+        "-t",
+        "commands",
+        "zephyr/run_qemu",
+    ]
+    assert run.call_args_list[0].kwargs["check"] is True
+
+
+def test_qemu_command_uses_the_last_recipe_line():
+    """The run target is the last of the recipes ninja prints for it."""
+    recipe = "cd /b && cmake -E echo building\ncd /b && qemu-system-i386 -kernel k.elf"
+    with _fake_ninja(recipe):
+        assert zperf_profile.qemu_command("/b") == ["qemu-system-i386", "-kernel", "k.elf"]
+
+
+@pytest.mark.parametrize("quote", ["'", '"'])
+def test_qemu_command_keeps_a_quoted_space_in_one_token(quote):
+    """A build directory containing a space arrives quoted, because the recipe
+    is written the way a shell would run it. Splitting on whitespace would tear
+    the path in two and QEMU would not find the kernel."""
+    image = "/b/my builds/x/zephyr/zephyr.elf"
+    recipe = f"cd {quote}/b/my builds/x{quote} && qemu-system-i386 -kernel {quote}{image}{quote}"
+    with _fake_ninja(recipe):
+        argv = zperf_profile.qemu_command("/b/my builds/x")
+
+    assert argv == ["qemu-system-i386", "-kernel", image]
+
+
+def test_qemu_command_without_a_cd_prefix():
+    with _fake_ninja("qemu-system-arm -M mps2-an385 -kernel z.elf"):
+        assert zperf_profile.qemu_command("/b") == [
+            "qemu-system-arm",
+            "-M",
+            "mps2-an385",
+            "-kernel",
+            "z.elf",
+        ]
+
+
+@pytest.mark.parametrize(
+    "recipe", ["cd /b && echo nothing", "cd /b &&", "python3 foo.py", "cd /b && /usr/bin/gdb"]
+)
+def test_qemu_command_rejects_a_recipe_that_does_not_run_qemu(recipe):
+    with _fake_ninja(recipe), pytest.raises(SystemExit, match="Unexpected run_qemu recipe"):
+        zperf_profile.qemu_command("/b")
+
+
+def test_qemu_command_rejects_a_build_without_a_run_target():
+    with _fake_ninja(""), pytest.raises(SystemExit, match="No run_qemu target"):
+        zperf_profile.qemu_command("/b")
+
+
+def test_qemu_command_requires_ninja():
+    with (
+        mock.patch("zperf_profile.shutil.which", return_value=None),
+        pytest.raises(SystemExit, match="ninja not found"),
+    ):
+        zperf_profile.qemu_command("/b")
+
+
+@pytest.mark.parametrize("flag", ["-serial", "-chardev", "-mon", "-monitor", "-pidfile"])
+def test_qemu_command_drops_a_console_flag_and_its_argument(flag):
+    """The profiling run is unattended and writes the console to a file, so
+    anything that would attach it to a terminal has to go, argument included."""
+    with _fake_ninja(f"cd /b && qemu-system-i386 {flag} VALUE -kernel k.elf"):
+        argv = zperf_profile.qemu_command("/b")
+
+    assert argv == ["qemu-system-i386", "-kernel", "k.elf"]
+
+
+def test_qemu_command_drops_nographic_without_eating_the_next_argument():
+    with _fake_ninja("cd /b && qemu-system-i386 -nographic -kernel k.elf"):
+        assert zperf_profile.qemu_command("/b") == ["qemu-system-i386", "-kernel", "k.elf"]
+
+
+def test_qemu_command_builds_a_missing_kernel_image():
+    """qemu_x86_64 splits the image in two, produced by a target the run target
+    depends on. Running QEMU directly skips that dependency."""
+    recipe = "cd /b && qemu-system-x86_64 -device loader,file=/b/locore.elf -kernel /b/main.elf"
+    with _fake_ninja(recipe, exists=[False, False, True, True]) as run:
+        zperf_profile.qemu_command("/b")
+
+    assert run.call_args_list[1].args[0] == ["/usr/bin/ninja", "-C", "/b", "qemu_kernel_target"]
+
+
+def test_qemu_command_gives_up_when_the_image_is_still_missing():
+    with (
+        _fake_ninja("cd /b && qemu-system-i386 -kernel k.elf", exists=False),
+        pytest.raises(SystemExit, match="Still missing after building qemu_kernel_target"),
+    ):
+        zperf_profile.qemu_command("/b")
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["-kernel", "/a/zephyr.elf"], ["/a/zephyr.elf"]),
+        (["-device", "loader,file=/a/locore.elf,addr=0x1000"], ["/a/locore.elf"]),
+        (
+            ["-device", "loader,file=/a/locore.elf", "-device", "loader,file=/a/main.elf"],
+            ["/a/locore.elf", "/a/main.elf"],
+        ),
+        (["-kernel", "/a/z.elf", "-device", "loader,file=/a/b.elf"], ["/a/z.elf", "/a/b.elf"]),
+        (["-nographic", "-m", "8"], []),
+        (["-device", "loader,addr=0x100"], []),
+        # A trailing -kernel with no value must not index past the end.
+        (["-m", "8", "-kernel"], []),
+    ],
+)
+def test_kernel_images(argv, expected):
+    assert zperf_profile._kernel_images(argv) == expected
+
+
+#
+# parse_console()
+#
+
+
+def test_parse_console_extracts_results_and_byte_counts(tmp_path):
+    path = _write(
+        tmp_path,
+        "c.log",
+        "*** Booting Zephyr OS build v4.4.0 ***\n"
+        "[00:00:00.017,000] <inf> net_zperf: Binding to 127.0.0.1\n"
+        "ZPERF-RESULT tcp4_mbps=91.25\n"
+        "ZPERF-INFO tcp4_bytes=1048576 tcp4_us=1001300\n"
+        "ZPERF-RESULT udp4_mbps=120.5\n"
+        "ZPERF-INFO udp4_bytes=2097152 udp4_us=1000800\n"
+        "ZPERF-RESULT ignored\n"
+        "ZPERF-DONE\n",
+    )
+
+    assert zperf_profile.parse_console(path) == (
+        {"tcp4": 91.25, "udp4": 120.5},
+        {"tcp4": 1048576, "udp4": 2097152},
+    )
+
+
+def test_parse_console_takes_the_last_value_for_a_label(tmp_path):
+    path = _write(tmp_path, "c.log", "ZPERF-RESULT tcp4_mbps=1.0\nZPERF-RESULT tcp4_mbps=2.0\n")
+
+    assert zperf_profile.parse_console(path)[0] == {"tcp4": 2.0}
+
+
+def test_parse_console_tolerates_undecodable_bytes(tmp_path):
+    """The console log carries the shell's escape sequences and whatever the
+    guest emitted before the UART settled."""
+    path = tmp_path / "c.log"
+    path.write_bytes(b"\xff\xfe \x1b[1;32muart:~$ ZPERF-RESULT tcp4_mbps=5.0\n")
+
+    assert zperf_profile.parse_console(str(path)) == ({"tcp4": 5.0}, {})
+
+
+def test_parse_console_without_a_file():
+    assert zperf_profile.parse_console("/nonexistent/console.log") == ({}, {})
+
+
+#
+# render_diff()
+#
+
+
+def _profile(total, byts, funcs):
+    return {
+        "total_insns": total,
+        "bytes": byts,
+        "functions": {n: {"insns": i, "group": "other", "file": None} for n, i in funcs.items()},
+    }
+
+
+def test_render_diff_reports_more_instructions_per_byte_as_a_regression(capsys):
+    ok = zperf_profile.render_diff(
+        {"udp4": _profile(1000, 250, {"f": 1000})},
+        {"udp4": _profile(1100, 250, {"f": 1100})},
+        1.0,
+        5,
+    )
+
+    assert ok is False
+    out = capsys.readouterr().out
+    assert "ipb 4.000 -> 4.400  (+10.00%)  REGRESSION" in out
+
+
+def test_render_diff_reports_fewer_instructions_per_byte_as_an_improvement(capsys):
+    ok = zperf_profile.render_diff(
+        {"udp4": _profile(1000, 250, {"f": 1000})},
+        {"udp4": _profile(900, 250, {"f": 900})},
+        1.0,
+        5,
+    )
+
+    assert ok is True
+    out = capsys.readouterr().out
+    assert "(-10.00%)  OK" in out
+    assert "REGRESSION" not in out
+
+
+def test_render_diff_accepts_a_change_within_tolerance(capsys):
+    ok = zperf_profile.render_diff(
+        {"udp4": _profile(1000, 250, {"f": 1000})},
+        {"udp4": _profile(1005, 250, {"f": 1005})},
+        1.0,
+        5,
+    )
+
+    assert ok is True
+    assert "(+0.50%)  OK" in capsys.readouterr().out
+
+
+def test_render_diff_accepts_an_identical_profile_at_zero_tolerance(capsys):
+    profile = {"udp4": _profile(1000, 250, {"f": 1000})}
+    ok = zperf_profile.render_diff(profile, profile, 0.0, 5)
+
+    assert ok is True
+    assert "(+0.00%)  OK" in capsys.readouterr().out
+
+
+def test_render_diff_annotates_functions_that_appeared_and_vanished(capsys):
+    zperf_profile.render_diff(
+        {"udp4": _profile(150, 250, {"stays": 100, "removed_fn": 50})},
+        {"udp4": _profile(170, 250, {"stays": 100, "brand_new": 70})},
+        100.0,
+        5,
+    )
+
+    out = capsys.readouterr().out
+    assert "brand_new" in out
+    assert "+70  NEW" in out
+    assert "-50  GONE" in out
+
+
+def test_render_diff_omits_functions_that_did_not_move(capsys):
+    zperf_profile.render_diff(
+        {"udp4": _profile(150, 250, {"unchanged_fn": 100, "moved_fn": 50})},
+        {"udp4": _profile(170, 250, {"unchanged_fn": 100, "moved_fn": 70})},
+        100.0,
+        5,
+    )
+
+    out = capsys.readouterr().out
+    assert "moved_fn" in out
+    assert "unchanged_fn" not in out
+
+
+def test_render_diff_honours_top(capsys):
+    base = _profile(0, 250, {f"f{i}": 0 for i in range(5)})
+    cur = _profile(0, 250, {f"f{i}": (i + 1) * 100 for i in range(5)})
+    zperf_profile.render_diff({"udp4": base}, {"udp4": cur}, 100.0, 2)
+
+    out = capsys.readouterr().out
+    assert "f4" in out
+    assert "f3" in out
+    assert "f2" not in out
+
+
+@pytest.mark.parametrize(
+    ("missing_from", "expected"), [("current", "baseline"), ("baseline", "current")]
+)
+def test_render_diff_flags_a_transfer_present_on_only_one_side(capsys, missing_from, expected):
+    both = {"tcp4": _profile(1000, 250, {"f": 1000}), "udp6": _profile(1000, 250, {"f": 1000})}
+    one = {"tcp4": _profile(1000, 250, {"f": 1000})}
+    baseline, current = (both, one) if missing_from == "current" else (one, both)
+
+    ok = zperf_profile.render_diff(baseline, current, 1.0, 5)
+
+    assert ok is False
+    out = capsys.readouterr().out
+    assert "=== udp6 ===" in out
+    assert f"only present in {expected}" in out
+
+
+def test_render_diff_with_no_payload_does_not_divide_by_zero(capsys):
+    ok = zperf_profile.render_diff(
+        {"udp4": _profile(1000, 0, {"f": 1000})},
+        {"udp4": _profile(1000, 0, {"f": 1000})},
+        1.0,
+        5,
+    )
+
+    assert ok is True
+    assert "(+0.00%)" in capsys.readouterr().out
+
+
+#
+# validate_path() and validate_qemu_arg_path()
+#
+
+
+def test_validate_path_accepts_a_relative_path_inside_the_base(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "f.txt").write_text("x")
+
+    resolved = zperf_profile.validate_path("sub/f.txt", str(tmp_path), for_write=False)
+
+    assert resolved == os.path.realpath(tmp_path / "sub" / "f.txt")
+
+
+def test_validate_path_accepts_an_absolute_path_inside_the_base(tmp_path):
+    (tmp_path / "f.txt").write_text("x")
+
+    resolved = zperf_profile.validate_path(str(tmp_path / "f.txt"), str(tmp_path), for_write=False)
+
+    assert resolved == os.path.realpath(tmp_path / "f.txt")
+
+
+@pytest.mark.parametrize("path", ["../outside", "/etc/passwd", "sub/../../outside"])
+def test_validate_path_rejects_an_escape(tmp_path, monkeypatch, path):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit, match="outside the permitted base directory"):
+        zperf_profile.validate_path(path, str(tmp_path), for_write=False)
+
+
+def test_validate_path_rejects_an_escape_through_a_symlink(tmp_path, monkeypatch):
+    """Resolution follows symlinks, so a link out of the tree is not a way past
+    the check."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "link").symlink_to(tmp_path.parent)
+
+    with pytest.raises(SystemExit, match="outside the permitted base directory"):
+        zperf_profile.validate_path("link/x", str(tmp_path), for_write=False)
+
+
+@pytest.mark.parametrize("path", ["a\x00b", ""])
+def test_validate_path_rejects_an_unusable_path(tmp_path, path):
+    with pytest.raises(SystemExit, match="Invalid path"):
+        zperf_profile.validate_path(path, str(tmp_path), for_write=False)
+
+
+def test_validate_path_rejects_a_base_directory_that_is_not_there(tmp_path):
+    with pytest.raises(SystemExit, match="does not exist"):
+        zperf_profile.validate_path("f.txt", str(tmp_path / "nope"), for_write=False)
+
+
+def test_validate_path_for_write_accepts_a_file_that_does_not_exist_yet(tmp_path):
+    resolved = zperf_profile.validate_path(
+        str(tmp_path / "new.json"), str(tmp_path), for_write=True
+    )
+
+    assert resolved == os.path.realpath(tmp_path / "new.json")
+
+
+def test_validate_path_for_write_rejects_a_missing_parent(tmp_path):
+    with pytest.raises(SystemExit, match="is not a directory"):
+        zperf_profile.validate_path(str(tmp_path / "a/b/c.json"), str(tmp_path), for_write=True)
+
+
+def test_validate_path_for_write_rejects_a_directory(tmp_path):
+    (tmp_path / "d").mkdir()
+
+    with pytest.raises(SystemExit, match="it is a directory"):
+        zperf_profile.validate_path(str(tmp_path / "d"), str(tmp_path), for_write=True)
+
+
+@pytest.mark.parametrize("name", ["lib plugin.so", "lib,plugin.so", "lib\tplugin.so"])
+def test_validate_qemu_arg_path_rejects_a_path_qemu_would_split(tmp_path, name):
+    """The plugin argument is comma separated and CMake splits QEMU_EXTRA_FLAGS
+    on whitespace, so such a path would be silently torn into several
+    arguments rather than failing."""
+    with pytest.raises(SystemExit, match="QEMU argument splitting would break"):
+        zperf_profile.validate_qemu_arg_path(str(tmp_path / name), str(tmp_path), for_write=False)
+
+
+def test_validate_qemu_arg_path_accepts_an_ordinary_path(tmp_path):
+    resolved = zperf_profile.validate_qemu_arg_path(
+        str(tmp_path / "libhotblocks.so"), str(tmp_path), for_write=False
+    )
+
+    assert resolved == os.path.realpath(tmp_path / "libhotblocks.so")
+
+
+#
+# build_profile(): everything above, wired together
+#
+
+GOLDEN_REPORT = (
+    HEADER.format(n=4)
+    + "0x0000000000001000, 1, 4, 20\n"
+    + "0x0000000000002000, 1, 3, 10\n"
+    + "0x0000000000003000, 1, 2, 5\n"
+    + "0x0000000000000500, 1, 1, 8\n"
+)
+GOLDEN_BOOT = HEADER.format(n=2) + "0x0000000000001000, 1, 4, 5\n0x0000000000000500, 1, 1, 8\n"
+GOLDEN_CONSOLE = (
+    "*** Booting Zephyr OS ***\n"
+    "ZPERF-INFO tcp4_bytes=25 tcp4_us=3200\n"
+    "ZPERF-RESULT tcp4_mbps=62.5\n"
+)
+
+
+def _golden(tmp_path, boot=True, console=True):
+    report = _write(tmp_path, "tcp4.report", GOLDEN_REPORT)
+    boot_path = _write(tmp_path, "tcp4.boot.report", GOLDEN_BOOT) if boot else None
+    console_path = _write(tmp_path, "tcp4.console", GOLDEN_CONSOLE) if console else None
+    with mock.patch.object(zperf_profile.SymbolTable, "from_elf", return_value=_table()):
+        return zperf_profile.build_profile(
+            "tcp4", report, "zephyr.elf", boot_path, console_path, "qemu_x86", 5, "/z", "/"
+        )
+
+
+def test_build_profile_golden(tmp_path):
+    """A report, its boot baseline and the console, end to end.
+
+    The numbers are chosen so the profile is self consistent: after the boot
+    prefix comes off, 100 instructions carried 25 payload bytes, which is 4.0
+    instructions per byte, which at shift 5 is exactly the 62.5 Mbps the guest
+    itself reported.
+    """
+    assert _golden(tmp_path) == {
+        "schema": 1,
+        "label": "tcp4",
+        "platform": "qemu_x86",
+        "icount_shift": 5,
+        "bytes": 25,
+        "measured_mbps": 62.5,
+        "total_insns": 100,
+        "boot_insns": 28,
+        "kinds": {"exact": 60, "inferred": 40},
+        "functions": {
+            "net_pkt_alloc": {"insns": 60, "file": None, "group": "pktbuf"},
+            "arch_swap": {"insns": 30, "file": None, "group": "kernel"},
+            "memcpy": {"insns": 10, "file": None, "group": "libc"},
+        },
+    }
+
+
+def test_build_profile_reconstructs_the_measured_throughput(tmp_path):
+    """The claim the whole method rests on: the instruction count and the
+    throughput the guest measured are the same number in different units."""
+    profile = _golden(tmp_path)
+    ipb = zperf_profile._ipb(profile["total_insns"], profile["bytes"])
+
+    assert zperf_profile._mbps(ipb, profile["icount_shift"]) == profile["measured_mbps"]
+
+
+def test_build_profile_boot_subtraction_removes_the_firmware(tmp_path):
+    """Before subtraction the BIOS the guest boots through dominates the
+    unattributed bucket; after it, nothing should be left there."""
+    with_boot = _golden(tmp_path)
+    without_boot = _golden(tmp_path, boot=False)
+
+    assert without_boot["kinds"]["bucket"] == 8
+    assert "bucket" not in with_boot["kinds"]
+    assert without_boot["total_insns"] == 128
+    assert with_boot["boot_insns"] == 28
+
+
+def test_build_profile_without_a_console(tmp_path):
+    profile = _golden(tmp_path, console=False)
+
+    assert profile["bytes"] == 0
+    assert profile["measured_mbps"] is None
+
+
+def test_build_profile_round_trips_through_json(tmp_path):
+    """The diff subcommand reads back exactly what run saved, so the profile
+    has to survive a JSON round trip unchanged."""
+    profile = _golden(tmp_path)
+
+    assert json.loads(json.dumps(profile, sort_keys=True)) == profile
+
+
+#
+# render() and cmd_diff()
+#
+
+
+def test_render_reports_the_reconstructed_throughput(tmp_path, capsys):
+    zperf_profile.render(_golden(tmp_path), 25)
+
+    out = capsys.readouterr().out
+    assert "=== tcp4 (qemu_x86) ===" in out
+    assert "payload           25 B   ipb    4.000" in out
+    assert "boot subtracted 28" in out
+    assert "measured   62.500 Mbps   from profile   62.500 Mbps" in out
+    assert "attribution  exact 60.00%   inferred 40.00%   unattributed  0.00%" in out
+    for group in ("pktbuf", "kernel", "libc"):
+        assert group in out
+
+
+def test_render_honours_top(tmp_path, capsys):
+    zperf_profile.render(_golden(tmp_path), 1)
+
+    out = capsys.readouterr().out
+    assert "net_pkt_alloc" in out
+    # arch_swap is out of the per-function table; only its group is rolled up.
+    assert "arch_swap" not in out
+
+
+def test_render_survives_a_run_that_measured_nothing(capsys):
+    zperf_profile.render(
+        {"label": "x", "total_insns": 0, "bytes": 0, "functions": {}, "kinds": {}}, 5
+    )
+
+    assert "=== x" in capsys.readouterr().out
+
+
+def _diff_args(tmp_path, baseline, current, tolerance=1.0):
+    for name, profiles in (("base.json", baseline), ("cur.json", current)):
+        (tmp_path / name).write_text(json.dumps(profiles))
+    return argparse.Namespace(
+        baseline=str(tmp_path / "base.json"),
+        current=str(tmp_path / "cur.json"),
+        base_dir=str(tmp_path),
+        tolerance=tolerance,
+        top=5,
+    )
+
+
+def test_cmd_diff_exits_zero_when_nothing_moved(tmp_path):
+    profiles = {"udp4": _profile(1000, 250, {"f": 1000})}
+
+    assert zperf_profile.cmd_diff(_diff_args(tmp_path, profiles, profiles)) == 0
+
+
+def test_cmd_diff_exits_non_zero_on_a_regression(tmp_path, capsys):
+    args = _diff_args(
+        tmp_path,
+        {"udp4": _profile(1000, 250, {"f": 1000})},
+        {"udp4": _profile(1100, 250, {"f": 1100})},
+    )
+
+    assert zperf_profile.cmd_diff(args) == 1
+    assert "At least one transfer regressed beyond the tolerance." in capsys.readouterr().out

--- a/samples/net/zperf/src/main.c
+++ b/samples/net/zperf/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #endif
 
 #if defined(CONFIG_ZPERF_LOOPBACK_SELFTEST)
+#include <zephyr/fatal.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/zperf.h>
 
@@ -33,6 +34,7 @@ LOG_MODULE_REGISTER(zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #define SELFTEST_PACKET_SIZE CONFIG_ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE
 #define SELFTEST_RATE_KBPS   CONFIG_ZPERF_LOOPBACK_SELFTEST_RATE_KBPS
 #define SELFTEST_FRAG_PACKET_SIZE CONFIG_ZPERF_LOOPBACK_SELFTEST_FRAG_PACKET_SIZE
+#define SELFTEST_ONLY        CONFIG_ZPERF_LOOPBACK_SELFTEST_ONLY
 
 /* Non-default socket priority applied to every upload so that, when more than
  * one traffic class is configured, traffic is routed through the per-traffic-
@@ -134,6 +136,42 @@ static void selftest_report(const char *proto, struct zperf_results *res)
 
 	printk("ZPERF-RESULT %s_mbps=%u.%03u\n", proto,
 	       (uint32_t)(kbps / 1000U), (uint32_t)(kbps % 1000U));
+
+	/* The payload byte count and the elapsed time behind the throughput
+	 * figure above, which a profiler needs to normalise a run into
+	 * instructions per byte.
+	 *
+	 * Only the single-transfer builds a profiler drives print it. printk()
+	 * is routed through the deferred logging subsystem here
+	 * (CONFIG_LOG_PRINTK), and its buffer is small enough that one more
+	 * message per transfer can push an earlier ZPERF-RESULT line out of it,
+	 * losing a metric from the throughput recording. SELFTEST_ONLY is a
+	 * string literal, so this whole block folds away when no single
+	 * transfer is selected, leaving the default build untouched.
+	 *
+	 * The separate ZPERF-INFO prefix matters too: the regression helper
+	 * reports a key present on only one side of a comparison as missing and
+	 * fails, so these must stay out of the recorded ZPERF-RESULT namespace.
+	 */
+	if (SELFTEST_ONLY[0] != '\0') {
+		printk("ZPERF-INFO %s_bytes=%llu %s_us=%llu\n", proto,
+		       (unsigned long long)res->nb_packets_sent *
+		       (unsigned long long)res->packet_size,
+		       proto, (unsigned long long)res->client_time_in_us);
+	}
+}
+
+/* Whether the transfer reported under the given label is selected by
+ * CONFIG_ZPERF_LOOPBACK_SELFTEST_ONLY. An empty setting selects every transfer,
+ * a setting matching no label selects none, which gives a boot-only run.
+ */
+static bool selftest_selected(const char *label)
+{
+	if (SELFTEST_ONLY[0] == '\0') {
+		return true;
+	}
+
+	return strcmp(SELFTEST_ONLY, label) == 0;
 }
 
 static int selftest_run_udp(int family, const char *label, uint32_t packet_size)
@@ -142,6 +180,10 @@ static int selftest_run_udp(int family, const char *label, uint32_t packet_size)
 	struct zperf_upload_params ul;
 	struct zperf_results res = { 0 };
 	int ret;
+
+	if (!selftest_selected(label)) {
+		return 0;
+	}
 
 	/* Bind the receiver to the loopback address so the client can reach it
 	 * (in particular ::1, which is not the interface's default address).
@@ -171,6 +213,10 @@ static int selftest_run_tcp(int family, const char *label, bool tcp_nodelay)
 	struct zperf_upload_params ul;
 	struct zperf_results res = { 0 };
 	int ret;
+
+	if (!selftest_selected(label)) {
+		return 0;
+	}
 
 	selftest_fill_addr(&dl.addr, family);
 
@@ -253,6 +299,15 @@ static void run_loopback_selftest(void)
 	}
 
 	printk("ZPERF-DONE\n");
+
+	if (IS_ENABLED(CONFIG_ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE)) {
+		/* Let the console drain before the machine goes away. The sleep
+		 * costs no instructions: the CPU halts and, under QEMU icount,
+		 * virtual time warps to the next timer event.
+		 */
+		k_sleep(K_MSEC(50));
+		k_fatal_halt(K_ERR_KERNEL_PANIC);
+	}
 }
 #endif /* CONFIG_ZPERF_LOOPBACK_SELFTEST */
 


### PR DESCRIPTION
The `sample.net.zperf.loopback_icount` check added in #114388 reports one
deterministic throughput number per transfer. That is enough to notice a
regression but not to locate it. This series attributes the same run's cost to
individual functions.

The guest runs under a QEMU TCG plugin that counts executed instructions per
translation block; the blocks are mapped back onto the functions in the build's
ELF. Under `-icount shift=N` one guest instruction is 2^N ns of virtual time, so

    Mbps = 8000 / (2**shift * ipb)        at shift=5:  Mbps = 250 / ipb

where `ipb` is instructions per payload byte. A per-function breakdown of `ipb`
is therefore an algebraic decomposition of the number the existing check already
reports, not a proxy for it, which also gives the throughput a transfer would
reach if a given function were free.

### What is added

| file | |
|---|---|
| `Kconfig`, `src/main.c` | `ZPERF_LOOPBACK_SELFTEST_ONLY`, `ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE` |
| `scripts/qemu_plugin_setup.sh` | fetches and builds the QEMU plugins, outside the repo |
| `scripts/zperf_profile.py` | `run` / `report` / `diff` |
| `README-loopback-profiling.rst` | method, limits, reproduction |

`ZPERF_LOOPBACK_SELFTEST_ONLY` restricts a build to one transfer: a profile
collected over all eight blends UDP, TCP, fragmentation and both IP families
into an average attributable to none of them. Empty is the default and leaves
the existing scenario and any recorded baseline unchanged.

`ZPERF_LOOPBACK_SELFTEST_HALT_ON_DONE` halts the machine through the
`isa-debug-exit` device the board already configures. Without it the guest
returns from `main()` and idles forever, and QEMU writes its instrumentation
report from an `atexit` handler that then never runs.

### Why the plugin is not in this tree

QEMU's plugin interface header `include/qemu/qemu-plugin.h` is
`GPL-2.0-or-later`, so a plugin built against it is a derivative work of QEMU.
This tree carries only `Apache-2.0` and `CC-BY-4.0`, and `check_compliance.py`
rejects a license with no file under `LICENSES/`. That applies to a patch of the
plugin sources as much as to the sources themselves, since a patch carries their
context.

So no plugin source is added. `qemu_plugin_setup.sh` contains only URLs, one
`sed` expression and a `gcc` invocation; it fetches QEMU's own plugins and
builds them into a directory outside the repository. The in-tree driver consumes
a text report format, nothing more. Zephyr never downloads, builds,
redistributes or links GPL code, and neither the build nor CI runs the setup
script. Building all of QEMU is not needed either: a plugin resolves QEMU's
symbols at load time, so it links against nothing but glib.

The `sed` raises the plugin's report limit. Released QEMU versions print only
the twenty hottest blocks, because the limit is a hardcoded constant and the
plugin parses no argument for it.

### Example output

    === udp4 (qemu_x86) ===
    instructions      31,806,331   payload    1,671,400 B   ipb   19.030   boot subtracted 6,840,845
    throughput   measured   13.353 Mbps   from profile   13.137 Mbps   cpu-bound  98.4%
    attribution  exact 94.70%   inferred  5.30%   unattributed  0.00%

      #  function                     group       instructions     ipb      %   cum%   +Mbps  file
      1  calc_chksum                  checksum       3,779,335   2.261 11.88%  11.9%   +1.77  subsys/net/ip/utils.c
      2  net_pkt_cursor_operate       pktbuf         1,715,758   1.027  5.39%  17.3%   +0.75  subsys/net/ip/net_pkt.c
      3  memcpy                       libc           1,497,451   0.896  4.71%  22.0%   +0.65  .../memcpy-32.S

followed by a roll-up per source file and per subsystem group.

`from profile` is the throughput implied by the instruction count; because
`sleep=off` lets halted time advance virtual time without executing
instructions, its ratio to the measured value is the fraction of the run that
was CPU bound.

### What it found

Instructions per payload byte, `qemu_x86` and `qemu_x86_64`:

| | udp4 | udp6 | udp4_frag | udp6_frag | tcp4 | tcp6 |
|---|---|---|---|---|---|---|
| `qemu_x86` | 19.03 | 18.98 | 12.47 | 12.44 | 40.28 | 39.82 |
| `qemu_x86_64` | 14.63 | 14.43 | 9.64 | 9.56 | 30.98 | 30.19 |

- TCP costs 2.1x per byte on both, and the gap is kernel and `net_pkt` work
  rather than `tcp.c`, which is only 3.74. For UDP, protocol code proper is
  about 1.8 of 19.03; most of the rest is per-packet overhead a throughput-only
  metric cannot point at.
- `calc_chksum` is the largest single function on both platforms, 2.26 / 2.75
  on 32-bit and 1.52 / 1.86 on 64-bit. It costs ~0.95 instructions per payload
  byte per pass and `subsys/net/ip/utils.c` walks the fragment chain two bytes
  at a time.
- `net_pkt` cursor walking 1.79 / 4.51; its share more than doubles for TCP.
- `__udivdi3` 0.50 / 1.02 on 32-bit, absent on 64-bit as expected.

The first thing it turned up is not a networking issue at all.
`boards/qemu/x86/qemu_x86_defconfig` sets `CONFIG_SCHED_SCALABLE=y` and
`CONFIG_WAITQ_SCALABLE=y` (all seven `qemu_x86_*` defconfigs do), putting the
ready queue and every wait queue in a red-black tree, while `qemu_x86_64` takes
the `SIMPLE` defaults. Zephyr's own Kconfig help for `SCHED_SCALABLE` says it
is for platforms with "more than 20 or so" runnable threads and that "most
applications don't want this". Rebuilding `qemu_x86` with `SCHED_SIMPLE` and
`WAITQ_SIMPLE`, changing nothing else:

| | SCALABLE | SIMPLE | |
|---|---|---|---|
| udp4 | 13.353 Mbps | 15.306 Mbps | +14.6% |
| tcp4 | 6.325 Mbps | 7.268 Mbps | +14.9% |

Every function moving by more than 0.05 ipb is red-black tree code, so the whole
14% is the data structure. Worth raising separately; the figures above keep the
board default so they stay comparable with existing baselines.

### Decisions that may draw questions

- No twister scenario, `tests.yaml` untouched. `QEMU_EXTRA_FLAGS` is consumed at
  CMake configure time and has no per-scenario injection path short of a twister
  sidecar; without the plugin the scenario would be a duplicate of
  `sample.net.zperf.loopback_icount` and double its CI cost to measure nothing;
  and a profiling session is eight builds and sixteen runs. This is a developer
  workflow reached for after the existing gate fires, not a test.
- Not under `scripts/profiling/`. That path belongs to the Debugging area, and
  the driver is zperf-specific: it knows the overlay names, the `ZPERF-RESULT`
  protocol and the new Kconfig. If the symbolize core later proves reusable it
  can be lifted there in a follow-up.
- `-O2` kept, so inlined static helpers are charged to their callers. Lowering
  the optimisation level would change the code being measured.
- No flame graphs. A TCG plugin sees translation blocks, not stack frames.
  `CONFIG_PROFILING_PERF` remains the tool for call stacks; the new document
  contrasts the two.

### Reproducing

    samples/net/zperf/scripts/qemu_plugin_setup.sh ../tools/qemu-plugins
    samples/net/zperf/scripts/zperf_profile.py run --base-dir .. \
        --plugin ../tools/qemu-plugins/lib/libhotblocks.so \
        --outdir ../build/zprof --save ../build/zprof/profile.json

Tested on `qemu_x86` and `qemu_x86_64`; all eight transfers on both give 0.00%
unattributed instructions and 98.1-99.0% cpu-bound. Baselines are per-platform,
as for the existing throughput check.
