### PR TITLE
drivers: ethernet: deprecate numaker ethernet driver

### DIFF
--- a/drivers/ethernet/Kconfig.numaker
+++ b/drivers/ethernet/Kconfig.numaker
@@ -10,6 +10,7 @@ config ETH_NUMAKER
 	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_ETHERNET_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
+	select DEPRECATED
 	help
 	  This option enables the Ethernet driver for Nuvoton NuMaker family of
 	  processors.


### PR DESCRIPTION
The numaker ethernet driver does not use
the separate  ethernet controller, mdio bus, phy structure. It does mdio inside the ethernet driver.

Until this is fixed this driver is going to be deprecated and if not fixed in 2 releases removed.
The better way would it be to replace it with the
existing vendor independent dwc_mac driver.

Porting to the dwc_mac driver is not difficult, I would do it myself, but i don't have a board to verify the results.