### PR TITLE
STM32H5: Add poweroff and wake-up pins support

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/reset/stm32h5_reset.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/power/stm32h5_iocell.h>
 #include <freq.h>
 #include <mem.h>
@@ -722,6 +723,60 @@
 			interrupt-names = "digi_temp";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 3)>;
 			status = "disabled";
+		};
+
+		pwr: power@44020800 {
+			compatible = "st,stm32-pwr";
+			reg = <0x44020800 0x400>;
+
+			wakeup-controller {
+				compatible = "st,stm32-pwr-wkupctrl";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+
+				st,max-wkup-line-idx = <8>;
+
+				wkup@1 {
+					reg = <0x1>;
+					wkup-gpios = <&gpioa 0 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@2 {
+					reg = <0x2>;
+					wkup-gpios = <&gpioa 2 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@3 {
+					reg = <0x3>;
+					/* Available only on STM32H503, H562 and higher */
+				};
+
+				wkup@4 {
+					reg = <0x4>;
+					wkup-gpios = <&gpioc 13 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@5 {
+					reg = <0x5>;
+					wkup-gpios = <&gpiob 7 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@6 {
+					reg = <0x6>;
+					/* Available only on STM32H523 and higher */
+				};
+
+				wkup@7 {
+					reg = <0x7>;
+					/* Available only on STM32H523 and higher */
+				};
+
+				wkup@8 {
+					reg = <0x8>;
+					/* Available only on STM32H523 and higher */
+				};
+			};
 		};
 
 		crc: crc@40023000 {

--- a/dts/arm/st/h5/stm32h503.dtsi
+++ b/dts/arm/st/h5/stm32h503.dtsi
@@ -9,5 +9,13 @@
 / {
 	soc {
 		compatible = "st,stm32h503", "st,stm32h5", "simple-bus";
+
+		pwr: power@44020800 {
+			wakeup-controller {
+				wkup@3 {
+					wkup-gpios = <&gpioc 1 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+			};
+		};
 	};
 };

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -98,6 +98,22 @@
 			st,has-sha384-algorithm;
 			st,has-sha512-algorithm;
 		};
+
+		pwr: power@44020800 {
+			wakeup-controller {
+				wkup@6 {
+					wkup-gpios = <&gpioc 1 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@7 {
+					wkup-gpios = <&gpiod 2 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@8 {
+					wkup-gpios = <&gpiod 3 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+			};
+		};
 	};
 };
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -591,6 +591,26 @@
 			ref-voltages = <2500000>, <2048000>, <1800000>;
 			status = "disabled";
 		};
+
+		pwr: power@44020800 {
+			wakeup-controller {
+				wkup@3 {
+					wkup-gpios = <&gpioi 8 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@6 {
+					wkup-gpios = <&gpioc 1 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@7 {
+					wkup-gpios = <&gpiod 2 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@8 {
+					wkup-gpios = <&gpiod 3 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+			};
+		};
 	};
 
 	smbus3: smbus3 {

--- a/samples/boards/st/power_mgmt/wkup_pins/boards/stm32h573i_dk.overlay
+++ b/samples/boards/st/power_mgmt/wkup_pins/boards/stm32h573i_dk.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		wkup-src = &user_button;
+	};
+};
+
+&pwr {
+	wakeup-controller {
+		status = "okay";
+	};
+};

--- a/soc/st/stm32/stm32h5x/CMakeLists.txt
+++ b/soc/st/stm32/stm32h5x/CMakeLists.txt
@@ -9,6 +9,8 @@ zephyr_sources_ifdef(CONFIG_PM
   power.c
   )
 
+zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)
+
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/st/stm32/stm32h5x/Kconfig
+++ b/soc/st/stm32/stm32h5x/Kconfig
@@ -19,6 +19,7 @@ config SOC_SERIES_STM32H5X
 	select HAS_SWO
 	# Software options
 	select HAS_PM
+	select HAS_POWEROFF
 	select PM_STATE_SET_IRQ_UNLOCKED
 	select SOC_EARLY_INIT_HOOK
 	# STM32-specific options

--- a/soc/st/stm32/stm32h5x/poweroff.c
+++ b/soc/st/stm32/stm32h5x/poweroff.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/toolchain.h>
+
+#include <stm32_common.h>
+#include <stm32_gpio_shared.h>
+#include <stm32_ll_pwr.h>
+
+void z_sys_poweroff(void)
+{
+	LL_PWR_ClearFlag_WU();
+	LL_PWR_SetPowerMode(LL_PWR_STANDBY_MODE);
+
+	stm32_enter_poweroff();
+}


### PR DESCRIPTION
This PR adds the support for poweroff and wake-up pins for STM32H5.