### PR TITLE
[Backport v3.7-branch] Bluetooth: ISO: Add SDU len checks before recv cb

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -165,6 +165,8 @@ struct bt_conn_iso {
 		/* BIS ID within the BIG*/
 		uint8_t			bis_id;
 	};
+	/* Expected SDU size of current parsing data `conn->rx` */
+	uint16_t sdu_len;
 
 	/** Stored information about the ISO stream */
 	struct bt_iso_info info;
@@ -222,7 +224,6 @@ struct bt_conn {
 	uint8_t			err;
 
 	bt_conn_state_t		state;
-	uint16_t rx_len;
 	struct net_buf		*rx;
 
 	/* Pending TX that are awaiting the NCP event. len(tx_pending) == in_ll */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -678,18 +678,30 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		}
 
 		iso->rx = buf;
-		iso->rx_len = len - buf->len;
-		if (iso->rx_len) {
-			/* if iso->rx_len then package is longer than the
-			 * buf->len and cannot fit in a SINGLE package
-			 */
-			if (pb == BT_ISO_SINGLE) {
-				LOG_ERR("Unexpected ISO single fragment");
+		iso->iso.sdu_len = len;
+
+		if (pb == BT_ISO_SINGLE) {
+			/* For single fragments the packet length shall match the `buf->len` */
+			if (len != buf->len) {
+				LOG_ERR("Unexpected ISO single fragment length %u != %u", len,
+					buf->len);
+				bt_conn_reset_rx_state(iso);
+				return;
+			}
+
+			break;
+		} else if (pb == BT_ISO_START) {
+			/* For start fragments the packet length shall be larger than `buf->len` */
+			if (len <= buf->len) {
+				LOG_ERR("Unexpected ISO start fragment length %u <= %u", len,
+					buf->len);
 				bt_conn_reset_rx_state(iso);
 			}
+
 			return;
+		} else {
+			CODE_UNREACHABLE;
 		}
-		break;
 
 	case BT_ISO_CONT:
 		/* The ISO_Data_Load field contains a continuation fragment of
@@ -701,8 +713,7 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 			return;
 		}
 
-		BT_ISO_DATA_DBG("Cont, len %u rx_len %u",
-				buf->len, iso->rx_len);
+		BT_ISO_DATA_DBG("Cont, len %u sdu_len %u", buf->len, iso->iso.sdu_len);
 
 		if (buf->len > net_buf_tailroom(iso->rx)) {
 			LOG_ERR("Not enough buffer space for ISO data");
@@ -712,7 +723,6 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		}
 
 		net_buf_add_mem(iso->rx, buf->data, buf->len);
-		iso->rx_len -= buf->len;
 		net_buf_unref(buf);
 		return;
 
@@ -720,7 +730,7 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		/* The ISO_Data_Load field contains the last fragment of an
 		 * SDU.
 		 */
-		BT_ISO_DATA_DBG("End, len %u rx_len %u", buf->len, iso->rx_len);
+		BT_ISO_DATA_DBG("End, len %u sdu_len %u", buf->len, iso->iso.sdu_len);
 
 		if (iso->rx == NULL) {
 			LOG_ERR("Unexpected ISO end fragment");
@@ -736,7 +746,6 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		}
 
 		(void)net_buf_add_mem(iso->rx, buf->data, buf->len);
-		iso->rx_len -= buf->len;
 		net_buf_unref(buf);
 
 		break;
@@ -744,6 +753,12 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		LOG_ERR("Unexpected ISO pb flags (0x%02x)", pb);
 		bt_conn_reset_rx_state(iso);
 		net_buf_unref(buf);
+		return;
+	}
+
+	if (iso->rx->len != iso->iso.sdu_len) {
+		LOG_ERR("ISO SDU len mismatch (%u != %u)", iso->rx->len, iso->iso.sdu_len);
+		bt_conn_reset_rx_state(iso);
 		return;
 	}
 


### PR DESCRIPTION
ISO now verifies that the data received has the same length as the length field in the BT_ISO_SINGLE or BT_ISO_START fragment. If it does not, it is dropped in the same way that ACL drops data.

`bt_conn.rx_len` was only used by ISO, so the field was moved to `bt_conn_iso` instead. Unlike ACL where the buffer contains the L2CAP header, the ISO `conn->rx` only contains the data without the header, so we need to store this information somewhere, and cannot just rely on the header within conn->rx.

Lastly, there was also a check added for BT_ISO_START to check if it should have been a BT_ISO_SINGLE instead, effectively disallowing BT_ISO_CONT or BT_ISO_END with length = 0.


(cherry picked from commit 8b54caf0d84612490e47b17e3dcb86eec95ef934) from https://github.com/zephyrproject-rtos/zephyr/pull/115798

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116631 
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116617