### PR TITLE
STM32C5: Add wake-up pins support

### DIFF
--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/reset/stm32c5_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
@@ -482,6 +483,55 @@
 			       <&lpdma1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			status = "disabled";
+		};
+
+		pwr: power@44020800 {
+			compatible = "st,stm32-pwr";
+			reg = <0x44020800 0x400>;
+
+			wakeup-controller {
+				compatible = "st,stm32-pwr-wkupctrl";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+
+				st,max-wkup-line-idx = <7>;
+
+				wkup@1 {
+					reg = <0x1>;
+					wkup-gpios = <&gpioa 0 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@2 {
+					reg = <0x2>;
+					wkup-gpios = <&gpioa 2 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@3 {
+					reg = <0x3>;
+					/* Available only on STM32C551 and higher */
+				};
+
+				wkup@4 {
+					reg = <0x4>;
+					wkup-gpios = <&gpioc 13 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@5 {
+					reg = <0x5>;
+					wkup-gpios = <&gpiob 7 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@6 {
+					reg = <0x6>;
+					/* Available only on STM32C551 and higher */
+				};
+
+				wkup@7 {
+					reg = <0x7>;
+					/* Available only on STM32C551 and higher */
+				};
+			};
 		};
 
 		spi1: spi@40013000 {

--- a/dts/arm/st/c5/stm32c551.dtsi
+++ b/dts/arm/st/c5/stm32c551.dtsi
@@ -59,6 +59,22 @@
 			status = "disabled";
 		};
 
+		pwr: power@44020800 {
+			wakeup-controller {
+				wkup@3 {
+					wkup-gpios = <&gpioe 6 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@6 {
+					wkup-gpios = <&gpioc 1 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+
+				wkup@7 {
+					wkup-gpios = <&gpiod 2 STM32_PWR_WKUP_EVT_SRC_0>;
+				};
+			};
+		};
+
 		spi3: spi@40003c00 {
 			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;

--- a/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_c5a3zg.overlay
+++ b/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		wkup-src = &user_button;
+	};
+};
+
+&pwr {
+	wakeup-controller {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
This PR adds the support of the wake-up pins for STM32C5.