### PR TITLE
drivers: stm32: sdhc: fix R2 response data order

### DIFF
--- a/drivers/sdhc/sdhc_stm32.c
+++ b/drivers/sdhc/sdhc_stm32.c
@@ -611,10 +611,11 @@ static int sdhc_stm32_set_response(struct sdhc_stm32_data *dev_data, SDMMC_TypeD
 	__SDMMC_CLEAR_FLAG(instance, SDMMC_STATIC_CMD_FLAGS);
 	switch (resp) {
 	case SDMMC_RESPONSE_LONG:
-		cmd->response[0] = SDMMC_GetResponse(instance, SDMMC_RESP1);
-		cmd->response[1] = SDMMC_GetResponse(instance, SDMMC_RESP2);
-		cmd->response[2] = SDMMC_GetResponse(instance, SDMMC_RESP3);
-		cmd->response[3] = SDMMC_GetResponse(instance, SDMMC_RESP4);
+		/* NOTE: RESPn registers are in "reverse order" for R2 response */
+		cmd->response[0] = SDMMC_GetResponse(instance, SDMMC_RESP4);
+		cmd->response[1] = SDMMC_GetResponse(instance, SDMMC_RESP3);
+		cmd->response[2] = SDMMC_GetResponse(instance, SDMMC_RESP2);
+		cmd->response[3] = SDMMC_GetResponse(instance, SDMMC_RESP1);
 		break;
 	case SDMMC_RESPONSE_SHORT:
 		cmd->response[0] = SDMMC_GetResponse(instance, SDMMC_RESP1);


### PR DESCRIPTION
~~When calculating the device Size of a SD card from the CSD register, the device size field depends on the SD card standard or High Capacity. The sdmmc_decode_csd function must know if the card is standard or high capacity (given by the OCR).~~
~~For standard capacity SDSC memory cards, refer to CSD Version 1.0.~~
~~For high capacity SDHC and SDXC memory cards, refer to CSD Version 2.0.~~

The STM32 driver reads R2 response data in reverse order from what Zephyr expects: `RESP1` to `RESP4` contain bits in 127 -> 0 order, but Zephyr expects `response[0]` to `response[3]` to be filled in 0 -> 127 order.

Reverse read order in STM32 driver to match Zephyr's expectations.