### PR TITLE
boards: shields: nrf7002eb2: Remove defunct overlays

### DIFF
--- a/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Nordic Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * nRF7002 EB-II board overlay for nrf54lm20dk/nrf54lm20a/cpuapp.
- * Includes common SoC overlay snippet.
- */
-#include "../nrf54lm20.overlay"

--- a/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Nordic Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * nRF7002 EB-II board overlay for nrf54lm20dk/nrf54lm20a/cpuapp/ns.
- * Includes common SoC overlay snippet.
- */
-#include "../nrf54lm20.overlay"

--- a/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Nordic Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * nRF7002 EB-II board overlay for nrf54lm20dk/nrf54lm20b/cpuapp/ns.
- * Includes common SoC overlay snippet.
- */
-#include "../nrf54lm20.overlay"


### PR DESCRIPTION
Commit 893eb7a3c5ccd14d9768fbb5fcaf8c3114d89938 removed common nrf54lm20.overlay, rendering the board-specific overlays (sourcing that file) broken. As they contain no other contents, just remove them.

Fixes #116632