### PR TITLE
Enable McSPI for AM62L.

### DIFF
--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
@@ -43,6 +43,22 @@
 		pinmux = <K3_PINMUX(0x01d8, PIN_INPUT_PULLUP, MUX_MODE_0)>; /* (A6) I2C1_SDA */
 	};
 
+	main_spi0_clk: spi0_clk_default {
+		pinmux = <K3_PINMUX(0x01a8, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_spi0_d0: spi0_d0_default {
+		pinmux = <K3_PINMUX(0x01ac, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_spi0_d1: spi0_d1_default {
+		pinmux = <K3_PINMUX(0x01b0, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_spi0_cs0: spi0_cs0_default {
+		pinmux = <K3_PINMUX(0x01a0, PIN_INPUT, MUX_MODE_0)>;
+	};
+
 	mmc0_cmd: mmc0_cmd_default {
 		pinmux = <K3_PINMUX(0x0214, PIN_INPUT_PULLUP, MUX_MODE_0)>; /* (D2) MMC0_CMD */
 	};

--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
@@ -223,3 +223,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&main_spi0 {
+	pinctrl-0 = <&main_spi0_clk &main_spi0_cs0 &main_spi0_d0 &main_spi0_d1>;
+	pinctrl-names = "default";
+	status = "okay";
+	power-domains = <&main_spi0_pd>;
+};

--- a/tests/drivers/spi/spi_loopback/boards/am62l_evm_am62l3_a53.conf
+++ b/tests/drivers/spi/spi_loopback/boards/am62l_evm_am62l3_a53.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Texas Instruments
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_LOOPBACK_MODE_LOOP=y
+CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=30

--- a/tests/drivers/spi/spi_loopback/boards/am62l_evm_am62l3_a53.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/am62l_evm_am62l3_a53.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+
+&main_spi0 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(50)>;
+	};
+};


### PR DESCRIPTION
  - Add pinctrl definitions for mcspi and enable the main_spi0 node.                                                             
  - Add board overlay and conf enabling the spi_loopback test on am62l_evm/am62l3/a53 via main_spi0.

- spi_loopback been tested on TI's AM62L SoC.