### PR TITLE
Bluetooth: SMP: Unlock mutex on public key generation timeout

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -6050,8 +6050,14 @@ int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob)
 		err = k_condvar_wait(&pub_key_gen.condvar,
 				     &pub_key_gen.lock,
 				     K_SECONDS(30));
-		if (err) {
+		if (err != 0) {
 			LOG_WRN("Public key generation timeout");
+
+			__maybe_unused int mutex_err;
+
+			mutex_err = k_mutex_unlock(&pub_key_gen.lock);
+			__ASSERT_NO_MSG(mutex_err == 0);
+
 			return err;
 		}
 


### PR DESCRIPTION
bt_smp_le_oob_generate_sc_data() returns directly when k_condvar_wait() times out, without unlocking pub_key_gen.lock. k_condvar_wait() re-acquires the mutex before returning, on timeout as well as on signal, so the mutex is left locked forever.

Any subsequent public key generation callback then blocks whichever context runs it indefinitely, since pub_key_ready_notify() takes the same mutex with K_FOREVER.

Unlock the mutex before returning on the timeout path.