### PR TITLE
Bluetooth: AVDTP: Fix locking in endpoint registration and session setup

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -2145,12 +2145,15 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 		return -ENOMEM;
 	}
 
+	/* Locking semaphore initialized to 1 (unlocked). It has to be
+	 * initialized before the session is published, since the session
+	 * memory is owned and cleared by the upper layer.
+	 */
+	k_sem_init(&session->sem_lock, 1, 1);
 	session->br_chan.chan.conn = conn;
 	bt_avdtp_clear_tx(session);
 	k_sem_give(&avdtp_sem_lock);
 
-	/* Locking semaphore initialized to 1 (unlocked) */
-	k_sem_init(&session->sem_lock, 1, 1);
 	k_work_init(&session->_release_work, avdtp_release_work);
 	k_work_init_delayable(&session->timeout_work, avdtp_timeout);
 	session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
@@ -2209,11 +2212,15 @@ int bt_avdtp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 	k_sem_take(&avdtp_sem_lock, K_FOREVER);
 
 	if (session->br_chan.chan.conn == NULL) {
+		/* Locking semaphore initialized to 1 (unlocked). It has to be
+		 * initialized before the session is published, since the
+		 * session memory is owned and cleared by the upper layer.
+		 */
+		k_sem_init(&session->sem_lock, 1, 1);
 		session->br_chan.chan.conn = conn;
 		bt_avdtp_clear_tx(session);
 		k_sem_give(&avdtp_sem_lock);
-		/* Locking semaphore initialized to 1 (unlocked) */
-		k_sem_init(&session->sem_lock, 1, 1);
+
 		k_work_init(&session->_release_work, avdtp_release_work);
 		k_work_init_delayable(&session->timeout_work, avdtp_timeout);
 		session->br_chan.chan.ops = &signal_chan_ops;

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -2285,7 +2285,11 @@ int bt_avdtp_register_sep(uint8_t media_type, uint8_t sep_type, struct bt_avdtp_
 	/* Locking semaphore initialized to 1 (unlocked) */
 	k_sem_init(&sep->sem_lock, 1, 1);
 	k_work_init_delayable(&sep->_delay_work, avdtp_media_disconnect_work);
-	bt_avdtp_set_state_lock(sep, AVDTP_IDLE);
+	/* The endpoint is not in the `seps` list yet, so it cannot be accessed
+	 * by any other context. Set the state without taking `sep->sem_lock`,
+	 * which would invert the lock order used by the command handlers.
+	 */
+	bt_avdtp_set_state(sep, AVDTP_IDLE);
 
 	sys_slist_append(&seps, &sep->_node);
 	k_sem_give(&avdtp_sem_lock);


### PR DESCRIPTION
Two locking fixes in the AVDTP signalling layer, found by review.

bt_avdtp_register_sep() takes the global avdtp_sem_lock and then the endpoint lock, whereas the command handlers hold the endpoint lock and take avdtp_sem_lock when queuing the response, so registering an endpoint while signalling is in progress can deadlock. The endpoint is not in the `seps` list yet at that point, so the state can be set without its lock.

bt_avdtp_connect() and bt_avdtp_l2cap_accept() initialize the session lock only after storing the connection pointer, which is what makes the session visible to other contexts. Since the upper layer clears the whole session structure when it is reused, the session can be reached with a zero-initialized semaphore in between. The initialization now happens before the session is published, while the global lock is held.

Compile tested only: tests/bluetooth/shell with prj_br.conf on native_sim. There is no AVDTP simulation coverage to run these paths.