### PR TITLE
Bluetooth: AVDTP: Do not block the workqueue on buffer allocation

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -359,14 +359,15 @@ static int avdtp_media_connect(struct bt_avdtp *session, struct bt_avdtp_sep *se
 				     BT_L2CAP_PSM_AVDTP);
 }
 
-static struct net_buf *avdtp_create_pdu(uint8_t msg_type, uint8_t sig_id, uint8_t tid)
+static struct net_buf *avdtp_create_pdu_timeout(uint8_t msg_type, uint8_t sig_id, uint8_t tid,
+						k_timeout_t timeout)
 {
 	struct net_buf *buf;
 	struct bt_avdtp_single_sig_hdr *hdr;
 
 	LOG_DBG("");
 
-	buf = bt_l2cap_create_pdu(&avdtp_pool, 0);
+	buf = bt_l2cap_create_pdu_timeout(&avdtp_pool, 0, timeout);
 	if (!buf) {
 		LOG_ERR("Error: No Buff available");
 		return NULL;
@@ -381,6 +382,22 @@ static struct net_buf *avdtp_create_pdu(uint8_t msg_type, uint8_t sig_id, uint8_
 
 	LOG_DBG("hdr = 0x%02X, Signal_ID = 0x%02X", hdr->hdr, hdr->signal_id);
 	return buf;
+}
+
+static struct net_buf *avdtp_create_pdu(uint8_t msg_type, uint8_t sig_id, uint8_t tid)
+{
+	return avdtp_create_pdu_timeout(msg_type, sig_id, tid, K_FOREVER);
+}
+
+static struct net_buf *avdtp_create_rsp(uint8_t msg_type, uint8_t sig_id, uint8_t tid)
+{
+	/* Responses are built in the Bluetooth workqueue context, which is also
+	 * the context that returns the transmitted buffers to the same pool, and
+	 * some of the command handlers do this while holding the endpoint lock.
+	 * Waiting for a buffer here would therefore block the workqueue instead
+	 * of making progress. Let the remote side time out instead.
+	 */
+	return avdtp_create_pdu_timeout(msg_type, sig_id, tid, K_NO_WAIT);
 }
 
 static void avdtp_tx_raise(void)
@@ -666,7 +683,7 @@ static void avdtp_discover_cmd(struct bt_avdtp *session, struct net_buf *buf, ui
 		err = session->ops->discovery_ind(session, &avdtp_err_code);
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_DISCOVER, tid);
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_DISCOVER, tid);
 	if (!rsp_buf) {
 		return;
 	}
@@ -771,7 +788,7 @@ static void avdtp_get_caps_cmd_internal(struct bt_avdtp *session, struct net_buf
 	} else if (session->ops->get_capabilities_ind == NULL) {
 		err = -ENOTSUP;
 	} else {
-		rsp_buf = avdtp_create_pdu(BT_AVDTP_ACCEPT, get_all_caps ?
+		rsp_buf = avdtp_create_rsp(BT_AVDTP_ACCEPT, get_all_caps ?
 					   BT_AVDTP_GET_ALL_CAPABILITIES :
 					   BT_AVDTP_GET_CAPABILITIES, tid);
 		if (!rsp_buf) {
@@ -786,7 +803,7 @@ static void avdtp_get_caps_cmd_internal(struct bt_avdtp *session, struct net_buf
 	}
 
 	if (err) {
-		rsp_buf = avdtp_create_pdu(BT_AVDTP_REJECT, get_all_caps ?
+		rsp_buf = avdtp_create_rsp(BT_AVDTP_REJECT, get_all_caps ?
 					   BT_AVDTP_GET_ALL_CAPABILITIES :
 					   BT_AVDTP_GET_CAPABILITIES, tid);
 		if (!rsp_buf) {
@@ -991,7 +1008,7 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 		}
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, reconfig ?
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, reconfig ?
 				   BT_AVDTP_RECONFIGURE : BT_AVDTP_SET_CONFIGURATION, tid);
 	if (!rsp_buf) {
 		avdtp_sep_unlock(sep);
@@ -1106,7 +1123,7 @@ static void avdtp_open_cmd(struct bt_avdtp *session, struct net_buf *buf, uint8_
 		}
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_OPEN, tid);
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_OPEN, tid);
 	if (!rsp_buf) {
 		avdtp_sep_unlock(sep);
 		return;
@@ -1202,7 +1219,7 @@ static void avdtp_start_cmd(struct bt_avdtp *session, struct net_buf *buf, uint8
 		}
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_START, tid);
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_START, tid);
 	if (!rsp_buf) {
 		avdtp_sep_unlock(sep);
 		return;
@@ -1289,7 +1306,7 @@ static void avdtp_close_cmd(struct bt_avdtp *session, struct net_buf *buf, uint8
 		}
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_CLOSE, tid);
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_CLOSE, tid);
 	if (!rsp_buf) {
 		avdtp_sep_unlock(sep);
 		return;
@@ -1403,7 +1420,7 @@ static void avdtp_suspend_cmd(struct bt_avdtp *session, struct net_buf *buf, uin
 		}
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_SUSPEND, tid);
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_SUSPEND, tid);
 	if (!rsp_buf) {
 		avdtp_sep_unlock(sep);
 		return;
@@ -1479,7 +1496,7 @@ static void avdtp_abort_cmd(struct bt_avdtp *session, struct net_buf *buf, uint8
 		err = session->ops->abort_ind(session, sep, &avdtp_err_code);
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_ABORT, tid);
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_ABORT, tid);
 	if (!rsp_buf) {
 		avdtp_sep_unlock(sep);
 		return;
@@ -1587,7 +1604,7 @@ static void avdtp_delay_report_cmd(struct bt_avdtp *session, struct net_buf *buf
 		}
 	}
 
-	rsp_buf = avdtp_create_pdu(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_DELAYREPORT,
+	rsp_buf = avdtp_create_rsp(err ? BT_AVDTP_REJECT : BT_AVDTP_ACCEPT, BT_AVDTP_DELAYREPORT,
 				   tid);
 	if (rsp_buf == NULL) {
 		return;
@@ -1643,7 +1660,7 @@ static void avdtp_get_configuration_cmd(struct bt_avdtp *session, struct net_buf
 		 */
 		err = -EACCES;
 	} else {
-		rsp_buf = avdtp_create_pdu(BT_AVDTP_ACCEPT, BT_AVDTP_GET_CONFIGURATION, tid);
+		rsp_buf = avdtp_create_rsp(BT_AVDTP_ACCEPT, BT_AVDTP_GET_CONFIGURATION, tid);
 		if (rsp_buf == NULL) {
 			return;
 		}
@@ -1655,7 +1672,7 @@ static void avdtp_get_configuration_cmd(struct bt_avdtp *session, struct net_buf
 	}
 
 	if (err != 0) {
-		rsp_buf = avdtp_create_pdu(BT_AVDTP_REJECT, BT_AVDTP_GET_CONFIGURATION, tid);
+		rsp_buf = avdtp_create_rsp(BT_AVDTP_REJECT, BT_AVDTP_GET_CONFIGURATION, tid);
 		if (rsp_buf == NULL) {
 			return;
 		}
@@ -1942,7 +1959,7 @@ static int bt_avdtp_l2cap_frags_recv(struct bt_avdtp *session, struct net_buf *b
 			return avdtp_rel_and_return(session);
 		}
 
-		session->reasm_buf = net_buf_alloc(&avdtp_pool, K_FOREVER);
+		session->reasm_buf = net_buf_alloc(&avdtp_pool, K_NO_WAIT);
 		if (session->reasm_buf == NULL) {
 			LOG_ERR("fail to alloc reasm buf");
 			return 0;
@@ -2039,7 +2056,7 @@ static int avdtp_rel_and_rej(struct bt_avdtp *session, uint8_t sigid, uint8_t ti
 
 	net_buf_drop(&session->reasm_buf);
 
-	rsp_buf = avdtp_create_pdu(BT_AVDTP_GEN_REJECT, sigid, tid);
+	rsp_buf = avdtp_create_rsp(BT_AVDTP_GEN_REJECT, sigid, tid);
 	if (!rsp_buf) {
 		LOG_ERR("Error: No Buff available");
 		return 0;


### PR DESCRIPTION
The signalling response PDUs are allocated with K_FOREVER from the AVDTP buffer pool. The command handlers run in the Bluetooth workqueue, which is also the context that runs the AVDTP TX processing that returns the buffers to that same pool, so waiting for a buffer there cannot make progress. Most of the handlers wait with the endpoint lock held, which additionally blocks any other user of the endpoint.

The same applies to the reassembly buffer allocated on the receive path, which already has an unreachable allocation failure path.

Allocate both without waiting. All the response allocations already handle the failure by not responding, leaving the remote side to time out, which is preferable to blocking the whole host.