### PR TITLE
Bluetooth: Classic: SDP: Do not block the workqueue on buffer allocation

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -2352,7 +2352,10 @@ static int sdp_client_discover(struct bt_sdp_client *session)
 	}
 
 	if (param != NULL && session->rec_buf == NULL) {
-		session->rec_buf = net_buf_alloc(param->pool, K_FOREVER);
+		session->rec_buf = net_buf_alloc(param->pool, K_NO_WAIT);
+		if (session->rec_buf == NULL) {
+			LOG_WRN("Unable to allocate a receive buffer");
+		}
 	}
 
 	if (param == NULL || session->rec_buf == NULL) {
@@ -2701,8 +2704,10 @@ static struct net_buf *sdp_client_alloc_buf(struct bt_l2cap_chan *chan)
 
 	session->param = GET_PARAM(sys_slist_peek_head(&session->reqs));
 
-	buf = net_buf_alloc(session->param->pool, K_FOREVER);
-	__ASSERT_NO_MSG(buf);
+	buf = net_buf_alloc(session->param->pool, K_NO_WAIT);
+	if (buf == NULL) {
+		LOG_WRN("Unable to allocate a receive buffer");
+	}
 
 	return buf;
 }


### PR DESCRIPTION
The SDP client allocates the receive buffer from the application provided pool with K_FOREVER, in sdp_client_discover() while holding the session lock, and in the L2CAP alloc_buf callback which sdp_client_connected() also calls with the lock held.

Both run in the Bluetooth workqueue, which is the same context that releases these buffers once a discovery completes, so waiting for a buffer there cannot make progress. It also blocks any other user of the session for as long as the pool stays empty.

Allocate without waiting. Both call sites already handle the allocation failure by disconnecting the SDP channel, and the L2CAP layer handles alloc_buf() returning NULL, so the assert on the returned buffer is dropped.