### PR TITLE
arch: xtensa: don't save dead registers in xtensa_switch

### DIFF
--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -301,16 +301,32 @@ __switch_swap_same_domain:
 	SPILL_ALL_WINDOWS
 	addi a1, a1, -___xtensa_irq_bsa_t_SIZEOF
 
-	/* Stash our A0/2/3 and the shift/loop registers into the base
-	 * save area so they get restored as they are now.  A2/A3
-	 * don't actually get used post-restore, but they need to be
-	 * stashed across the xtensa_save_high_regs call and this is a
-	 * convenient place.
+	/* Stash our A0/2/3 into the base save area so they get
+	 * restored as they are now.  A2/A3 don't actually get used
+	 * post-restore, but they need to be stashed across the HiFi
+	 * save call and this is a convenient place.
 	 */
 	s32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
 	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
 	s32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
-	ODD_REG_SAVE a0, a1
+
+	/* Synchronous switch: SAR, EXCCAUSE and SCOMPARE1 are
+	 * caller-saved scratch, so _restore_context may reload their
+	 * uninitialized save slots.  The loop registers' slots must be
+	 * zeroed, though: restoring a nonzero LCOUNT with stale
+	 * LBEG/LEND could trigger a spurious loopback.
+	 */
+#if XCHAL_HAVE_LOOPS
+	movi a0, 0
+	s32i a0, a1, ___xtensa_irq_bsa_t_lbeg_OFFSET
+	s32i a0, a1, ___xtensa_irq_bsa_t_lend_OFFSET
+	s32i a0, a1, ___xtensa_irq_bsa_t_lcount_OFFSET
+#endif
+#if XCHAL_HAVE_THREADPTR && \
+	(defined(CONFIG_USERSPACE) || defined(CONFIG_THREAD_LOCAL_STORAGE))
+	rur.THREADPTR a0
+	s32i a0, a1, ___xtensa_irq_bsa_t_threadptr_OFFSET
+#endif
 
 #if XCHAL_HAVE_FP && defined(CONFIG_CPU_HAS_FPU) && defined(CONFIG_FPU_SHARING)
 	FPU_REG_SAVE
@@ -344,8 +360,14 @@ __switch_swap_same_domain:
 	wsr a6, CPENABLE
 #endif
 
-	/* Now the high registers */
-	call0 xtensa_save_high_regs
+	/* SPILL_ALL_WINDOWS above spilled every caller frame, so
+	 * A4-A15 only hold dead copies: instead of calling
+	 * xtensa_save_high_regs, push the "no high registers saved"
+	 * marker that xtensa_restore_high_regs expects.
+	 */
+	mov a0, a1
+	addi a1, a1, -4
+	s32i a0, a1, 0
 
 #if defined(CONFIG_KERNEL_COHERENCE)
 	/* Flush the stack.  The top of stack was stored for us by


### PR DESCRIPTION
xtensa_switch() runs SPILL_ALL_WINDOWS before building its save frame, so by the time xtensa_save_high_regs() is called WINDOWSTART has a single bit set and A4-A15 only hold dead copies of values that were just spilled to the caller frames: the call unconditionally stores, and the restore path later reloads, twelve dead registers. Push only the "no high registers saved" marker instead.

Similarly, a synchronous switch does not need to preserve caller-saved special registers, so replace ODD_REG_SAVE with zeroing the loop registers' save slots (restoring a nonzero LCOUNT with stale LBEG/LEND could trigger a spurious loopback) while keeping the THREADPTR save.

Benchmarks on qemu_xtensa/dc233c under QEMU icount shift=6 (deterministic, 1 insn = 1 cycle, so the saved loads/stores are understated relative to real hardware) and on ESP32-S3 (m5stack_stamps3, LX7 @ 240 MHz):

**thread_metric cooperative** (higher is better):

| Platform | Before | After | Delta |
|---|---|---|---|
| qemu_xtensa/dc233c | 1668647 | 2047554 | +22.7% |
| ESP32-S3 | 18003375 | 20994899 | +16.6% (median of 3 periods) |

**latency_measure** (cycles, lower is better):

| Metric | dc233c | ESP32-S3 |
|---|---|---|
| thread.yield.(coop\|preempt).ctx.k_to_k | 208 → 175 (−15.9%) | 468 → 411 (−12.2%) |
| semaphore.take.blocking.k_to_k | 273 → 240 (−12.1%) | 596 → 539 (−9.6%) |
| fifo.get.blocking.k_to_k | 282 → 248 (−12.1%) | 624 → 567 (−9.1%) |
| isr.resume.interrupted.thread.kernel | 119 → 119 | unchanged |

thread_metric interrupt is unchanged on both platforms, and code size shrinks slightly (−20 to −24 bytes of text across the benchmark images).