### PR TITLE
Bluetooth: HCI: stm32wba: Use a mutex to serialize controller access

### DIFF
--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -34,7 +34,11 @@ LOG_MODULE_REGISTER(hci_wba);
 
 #define DT_DRV_COMPAT st_hci_stm32wba
 
-static K_SEM_DEFINE(hci_sem, 1, 1);
+/* Serializes the accesses to the controller. It is a mutex, and not a
+ * semaphore, because the controller can indicate an event from within
+ * BleStack_Request(), i.e. from the thread that is already holding it.
+ */
+static K_MUTEX_DEFINE(hci_lock);
 
 #if defined(CONFIG_BT_HCI_SETUP)
 /* Bluetooth LE public STM32WBA default device address (if udn not available) */
@@ -270,6 +274,7 @@ uint8_t BLECB_Indication(const uint8_t *data, uint16_t length,
 			 const uint8_t *ext_data, uint16_t ext_length)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
+	__maybe_unused int unlock_err;
 	int ret = 0;
 	int err;
 
@@ -278,12 +283,17 @@ uint8_t BLECB_Indication(const uint8_t *data, uint16_t length,
 		LOG_DBG("ext_length: %d", ext_length);
 	}
 
-	k_sem_take(&hci_sem, K_FOREVER);
+	err = k_mutex_lock(&hci_lock, K_FOREVER);
+	if (err != 0) {
+		LOG_ERR("Failed to lock the controller (%d)", err);
+		return 1;
+	}
 
 	err = receive_data(dev, data, (size_t)length,
 			   ext_data, (size_t)ext_length);
 
-	k_sem_give(&hci_sem);
+	unlock_err = k_mutex_unlock(&hci_lock);
+	__ASSERT_NO_MSG(unlock_err == 0);
 
 	HostStack_Process();
 
@@ -300,9 +310,14 @@ static int bt_hci_stm32wba_send(const struct device *dev, struct net_buf *buf)
 	struct net_buf *evt_buf = NULL;
 	uint16_t event_length;
 	uint8_t *data;
+	__maybe_unused int unlock_err;
 	int err = 0;
 
-	k_sem_take(&hci_sem, K_FOREVER);
+	err = k_mutex_lock(&hci_lock, K_FOREVER);
+	if (err != 0) {
+		LOG_ERR("Failed to lock the controller (%d)", err);
+		return err;
+	}
 
 	if (buf->data[0] == BT_HCI_H4_CMD) {
 		/*
@@ -351,7 +366,8 @@ static int bt_hci_stm32wba_send(const struct device *dev, struct net_buf *buf)
 	}
 
 done:
-	k_sem_give(&hci_sem);
+	unlock_err = k_mutex_unlock(&hci_lock);
+	__ASSERT_NO_MSG(unlock_err == 0);
 
 	net_buf_unref(buf);
 


### PR DESCRIPTION
bt_hci_stm32wba_send() calls BleStack_Request() while holding hci_sem. If the controller indicates an event from within that call, the resulting BLECB_Indication() takes the same semaphore from the same thread and blocks forever, since a semaphore has no notion of an owner.

Use a mutex instead, which the owning thread is allowed to lock recursively.