### PR TITLE
Bluetooth: HCI: psoc6_bless: Make the TX packet info a local variable

### DIFF
--- a/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
@@ -42,7 +42,6 @@ static K_SEM_DEFINE(psoc6_bless_rx_sem, 0, 1);
 static K_SEM_DEFINE(psoc6_bless_operation_sem, 1, 1);
 static K_KERNEL_STACK_DEFINE(psoc6_bless_rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 static struct k_thread psoc6_bless_rx_thread_data;
-static cy_stc_ble_hci_tx_packet_info_t hci_tx_pkt;
 
 extern void Cy_BLE_EnableLowPowerMode(void);
 
@@ -151,11 +150,10 @@ static int psoc6_bless_open(const struct device *dev)
 
 static int psoc6_bless_send(const struct device *dev, struct net_buf *buf)
 {
+	cy_stc_ble_hci_tx_packet_info_t hci_tx_pkt = {0};
 	cy_en_ble_api_result_t result;
 
 	ARG_UNUSED(dev);
-
-	memset(&hci_tx_pkt, 0, sizeof(cy_stc_ble_hci_tx_packet_info_t));
 
 	hci_tx_pkt.packetType = net_buf_pull_u8(buf);
 	hci_tx_pkt.dataLength = buf->len;


### PR DESCRIPTION
hci_tx_pkt is a file-scope variable, but psoc6_bless_send() clears and populates it before taking psoc6_bless_operation_sem, so two senders can overwrite each other's packet information, and the one holding the semaphore can end up handing the controller a packet that describes the other buffer.

Nothing else uses the variable, and it does not need to outlive the call: Cy_BLE_SoftHciSendAppPkt() copies the packet into the controller's buffer before returning, as documented in cy_ble_stack.h. Make it a local variable, which removes the shared state instead of locking it.

Compile tested only (no hardware): samples/bluetooth/peripheral_hr for cy8cproto_063_ble.

Fixes: #117347