### PR TITLE
Bluetooth: Host: Lock the scanner state in bt_le_scan_stop()

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2643,6 +2643,7 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb);
  *
  * @return Zero on success or error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
+ * @retval -EBUSY The scanner is being started or stopped in a different thread.
  */
 int bt_le_scan_stop(void);
 

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1862,6 +1862,17 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb)
 
 int bt_le_scan_stop(void)
 {
+	__maybe_unused int unlock_err;
+	int err;
+
+	/* Take the same lock as bt_le_scan_start(), so that the state it sets
+	 * up is not cleared while it is still being set up.
+	 */
+	err = k_mutex_lock(&scan_state.scan_explicit_params_mutex, K_NO_WAIT);
+	if (err != 0) {
+		return err;
+	}
+
 	bt_scan_softreset();
 	scan_dev_found_cb = NULL;
 
@@ -1874,7 +1885,12 @@ int bt_le_scan_stop(void)
 #endif
 	}
 
-	return bt_le_scan_user_remove(BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	err = bt_le_scan_user_remove(BT_LE_SCAN_USER_EXPLICIT_SCAN);
+
+	unlock_err = k_mutex_unlock(&scan_state.scan_explicit_params_mutex);
+	__ASSERT_NO_MSG(unlock_err == 0);
+
+	return err;
 }
 
 int bt_le_scan_cb_register(struct bt_le_scan_cb *cb)


### PR DESCRIPTION
bt_le_scan_start() sets up the explicit scan parameters and the scan callback with scan_explicit_params_mutex held, but bt_le_scan_stop() clears the callback and removes the scanner user without taking it, so a stop running concurrently with a start can tear down the state the start is in the middle of setting up.

Take the same lock in bt_le_scan_stop(). As in bt_le_scan_start(), the lock is taken without waiting, so that a stop from the Bluetooth workqueue cannot block on a start that is waiting for a command completion.