### PR TITLE
arch: xtensa: only save EXCVADDR in the level 1 vector

### DIFF
--- a/arch/xtensa/include/xtensa_asm2.inc.S
+++ b/arch/xtensa/include/xtensa_asm2.inc.S
@@ -741,16 +741,19 @@ _not_triple_fault:
 	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
 	s32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
 
-#ifdef CONFIG_XTENSA_MMU
-.if \LVL != 1
-#endif
+#ifndef CONFIG_XTENSA_MMU
+.if \LVL == 1
 	/* Save register needed for handling the exception as
 	 * this register can be overwritten during nested
-	 * exceptions.
+	 * exceptions.  EXCVADDR describes exceptions, not
+	 * interrupts, so only the level 1 vector (which serves
+	 * both) needs it: nothing consumes it from the frames of
+	 * interrupt-only levels and nothing restores it on exit.
+	 * (With the MMU enabled, level 1 saved it on vector entry
+	 * already.)
 	 */
 	rsr.excvaddr a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_excvaddr_OFFSET
-#ifdef CONFIG_XTENSA_MMU
 .endif
 #endif
 


### PR DESCRIPTION
EXCVADDR describes exceptions, not interrupts, and only the level 1 vector serves exceptions. The frames built by interrupt-only vectors never have their excvaddr slot read (the C interrupt handlers do not look at it, and nothing restores it on exit), so stop saving it there. Fatal errors raised from ISRs still get a proper EXCVADDR: they trap through the level 1 exception vector, which keeps the save.

Benchmarks on qemu_xtensa/dc233c (QEMU icount shift=6, deterministic, 1 insn = 1 cycle) and ESP32-S3 (m5stack_stamps3 @ 240 MHz), exercising a level 3 software interrupt:

**thread_metric interrupt** (higher is better):

| Platform | Before | After | Delta |
|---|---|---|---|
| qemu_xtensa/dc233c | 759968 | 762439 | +0.3% |
| ESP32-S3 | 9281007 | 9304992 | +0.3% |

latency_measure is unchanged within ±1 cycle alignment noise (its ISR metrics start timing inside the ISR, after vector entry). Code size is unchanged (vector slots are fixed-size).