### PR TITLE
arch: xtensa: skip reschedule call on ISR exit when no switch needed

### DIFF
--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -293,8 +293,26 @@ static ALWAYS_INLINE void isr_enter_hook(void)
 static inline void *return_to(void *interrupted)
 {
 #ifdef CONFIG_MULTITHREADING
-	return _current_cpu->nested <= 1 ?
-		z_get_next_switch_handle(interrupted) : interrupted;
+	if (_current_cpu->nested > 1) {
+		return interrupted;
+	}
+
+#if !defined(CONFIG_SMP) && !defined(CONFIG_SCHED_THREAD_USAGE)
+	/* Fast path for the common case of an ISR that did not make a
+	 * higher-priority thread runnable: when the interrupted thread
+	 * is still the next thread to run, z_get_next_switch_handle()
+	 * would return "interrupted" unchanged, so skip the call.  Not
+	 * valid on SMP (the handle swap must happen under the scheduler
+	 * lock) nor with thread runtime stats (usage accounting must be
+	 * switched even when resuming the same thread).
+	 */
+	if (_kernel.ready_q.cache == _current) {
+		z_check_stack_sentinel();
+		return interrupted;
+	}
+#endif
+
+	return z_get_next_switch_handle(interrupted);
 #else
 	return interrupted;
 #endif /* CONFIG_MULTITHREADING */


### PR DESCRIPTION
On uniprocessor builds, when an ISR did not make a higher-priority thread runnable, z_get_next_switch_handle() just returns the interrupted context after re-selecting the current thread. Check _kernel.ready_q.cache against _current in return_to() and skip the call entirely in that case, keeping the stack sentinel check that would otherwise run inside it.

The fast path is disabled on SMP (the handle swap must happen under the scheduler lock) and with CONFIG_SCHED_THREAD_USAGE (usage accounting must be switched even when resuming the same thread).

Benchmarks on qemu_xtensa/dc233c (QEMU icount shift=6, deterministic, 1 insn = 1 cycle) and ESP32-S3 (m5stack_stamps3 @ 240 MHz):

**latency_measure** (cycles, lower is better):

| Metric | dc233c | ESP32-S3 |
|---|---|---|
| isr.resume.interrupted.thread.kernel | 119 → 101 (−15.1%) | 160 → 151 (−5.6%) |
| isr.resume.different.thread.kernel | 140 → 143 (+2.1%) | 237 → 242 (+2.1%) |

The isr.resume.different rows are the expected **worst case**: an ISR that always preempts never takes the fast path and only pays the added check. Those +3/+5 cycles are spent only when a full context switch follows anyway, so they add no jitter and are dwarfed by the switch itself. Against the 18 (dc233c) / 9 (ESP32-S3) cycles saved on every non-rescheduling exit, the change nets out positive whenever more than ~14% / ~36% of interrupt exits return to the interrupted thread — tick and device interrupts overwhelmingly do. Cortex-M has long made [the same trade-off on exception exit](https://github.com/zephyrproject-rtos/zephyr/blob/161f758ba363ec90cd9b727a5d82e6c86efa85ad/arch/arm/core/cortex_m/exc_exit.c#L57-L61), and RISC-V change on the way as well in #116606.

**thread_metric interrupt** (higher is better):

| Platform | Before | After | Delta |
|---|---|---|---|
| qemu_xtensa/dc233c | 751442 | 759968 | +1.1% |
| ESP32-S3 | 9162979 | 9281007 | +1.3% |

thread_metric cooperative is unchanged on both.

## Code size trade-off

This costs **+124 to +128 bytes of text** on the dc233c benchmark images: `return_to()` is inlined into every per-level C interrupt handler (`xtensa_int1_c` … `xtensa_int6_c`, NMI), so the ~18-byte check is duplicated once per interrupt level the core implements. Cores with fewer levels pay proportionally less.

I believe it is worth it: the fast path hits on every ISR exit that does *not* preempt — the overwhelmingly common case (timer ticks that expire nothing, RX interrupts that only queue data, etc.) — and turns a call through the scheduler into a two-load compare. That is a measured 15% cut in ISR-to-thread resume latency on dc233c (5.6% on ESP32-S3, where memory is faster relative to the pipeline) and a ~1% whole-benchmark gain on interrupt-heavy workloads, for about a hundred bytes. For comparison, the companion switch-path PR #116645 *saves* 20–24 bytes, so the two together net out around +100 bytes for double-digit latency improvements on both paths. If the size cost is a concern for the smallest targets, the fast path could maybe be gated (e.g. on `!CONFIG_SIZE_OPTIMIZATIONS`?).
