### PR TITLE
Bluetooth: Host: Clean up variables only used by asserts

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -344,7 +344,7 @@ void bt_conn_tx_notify(struct bt_conn *conn, bool wait_for_completion)
 		tx_notify_process(conn);
 	} else {
 		struct k_work_sync sync;
-		int err;
+		__maybe_unused int err;
 
 		err = k_work_submit_to_queue(tx_notify_workqueue_get(), &conn->tx_complete_work);
 		__ASSERT(err >= 0, "couldn't submit (err %d)", err);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -777,7 +777,6 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	bool use_filter = false;
 	struct net_buf *buf;
 	uint8_t own_addr_type;
-	uint8_t num_phys;
 	int err;
 
 	if (IS_ENABLED(CONFIG_BT_FILTER_ACCEPT_LIST)) {
@@ -788,11 +787,6 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	if (err) {
 		return err;
 	}
-
-	num_phys = (!(bt_dev.create_param.options &
-		      BT_CONN_LE_OPT_NO_1M) ? 1 : 0) +
-		   ((bt_dev.create_param.options &
-		      BT_CONN_LE_OPT_CODED) ? 1 : 0);
 
 	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -583,8 +583,8 @@ static int l2cap_ecred_conn_req(struct bt_l2cap_chan **chan, int channels)
 	struct bt_l2cap_le_chan *ch;
 	int i;
 	uint8_t ident;
-	uint16_t req_psm;
-	uint16_t req_mtu;
+	__maybe_unused uint16_t req_psm;
+	__maybe_unused uint16_t req_mtu;
 
 	if (!chan || !channels) {
 		return -EINVAL;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -926,7 +926,7 @@ static void smp_br_id_add_replace(struct bt_keys *keys)
 
 	conflict = bt_id_find_conflict(keys);
 	if (conflict != NULL) {
-		int err;
+		__maybe_unused int err;
 
 		LOG_DBG("Un-pairing old conflicting bond and finalizing new.");
 
@@ -4140,7 +4140,7 @@ static uint8_t smp_id_add_replace(struct bt_smp *smp, struct bt_keys *new_bond)
 
 	if (conflict && IS_ENABLED(CONFIG_BT_ID_UNPAIR_MATCHING_BONDS)) {
 		bool trust_ok;
-		int unpair_err;
+		__maybe_unused int unpair_err;
 
 		trust_ok = update_keys_check(smp, conflict);
 		if (!trust_ok) {
@@ -6036,7 +6036,7 @@ int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob)
 		if (err && err != -EALREADY) {
 			LOG_WRN("Public key re-generation request failed (%d)", err);
 
-			int mutex_err;
+			__maybe_unused int mutex_err;
 
 			mutex_err = k_mutex_unlock(&pub_key_gen.lock);
 			__ASSERT_NO_MSG(mutex_err == 0);


### PR DESCRIPTION
Building with CONFIG_ASSERT=n and -Wunused-but-set-variable shows a number of variables in the host that are set but never read. Zephyr passes -Wno-unused-but-set-variable for GCC, so the default build is silent, but clang and arcmwdt enable the warning at warning level 1.

Most of them are only ever read by an __ASSERT(), which compiles out when CONFIG_ASSERT is disabled. Those are marked __maybe_unused: three in smp.c, one in conn.c and two in l2cap.c.

num_phys in bt_le_create_conn_ext() is a different case: it is not used at all, not even by an assert. It sized the command buffer until commit 2ea960538074 ("Bluetooth: Host: core: Use bt_hci_cmd_alloc()") made the buffer be allocated without a length, so it is removed rather than annotated.

Verified with tests/bluetooth/shell on native_sim, LE and prj_br.conf, both with and without CONFIG_ASSERT: no remaining warnings in these files, and no change to the generated code with asserts enabled.

The same warning also fires in the Classic sources; those are left for a separate PR since some of them look like dead code rather than assert-only variables.