### PR TITLE
net: tcp: Derive the received TCP header once per packet

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -215,20 +215,18 @@ static size_t tcp_endpoint_len(net_sa_family_t af)
 }
 
 static int tcp_endpoint_set(union tcp_endpoint *ep, struct net_pkt *pkt,
-			    enum pkt_addr src)
+			    struct tcphdr *th, enum pkt_addr src)
 {
 	int ret = 0;
+
+	if (th == NULL) {
+		return -ENOBUFS;
+	}
 
 	switch (net_pkt_family(pkt)) {
 	case NET_AF_INET:
 		if (IS_ENABLED(CONFIG_NET_IPV4)) {
 			struct net_ipv4_hdr *ip = NET_IPV4_HDR(pkt);
-			struct tcphdr *th;
-
-			th = th_get(pkt);
-			if (!th) {
-				return -ENOBUFS;
-			}
 
 			memset(ep, 0, sizeof(*ep));
 
@@ -247,12 +245,6 @@ static int tcp_endpoint_set(union tcp_endpoint *ep, struct net_pkt *pkt,
 	case NET_AF_INET6:
 		if (IS_ENABLED(CONFIG_NET_IPV6)) {
 			struct net_ipv6_hdr *ip = NET_IPV6_HDR(pkt);
-			struct tcphdr *th;
-
-			th = th_get(pkt);
-			if (!th) {
-				return -ENOBUFS;
-			}
 
 			memset(ep, 0, sizeof(*ep));
 
@@ -2309,7 +2301,7 @@ static bool tcp_endpoint_cmp(union tcp_endpoint *ep, struct net_pkt *pkt,
 {
 	union tcp_endpoint ep_tmp;
 
-	if (tcp_endpoint_set(&ep_tmp, pkt, which) < 0) {
+	if (tcp_endpoint_set(&ep_tmp, pkt, th_get(pkt), which) < 0) {
 		return false;
 	}
 
@@ -2342,7 +2334,7 @@ static struct tcp *tcp_conn_search(struct net_pkt *pkt)
 	return found ? conn : NULL;
 }
 
-static struct tcp *tcp_conn_new(struct net_pkt *pkt);
+static struct tcp *tcp_conn_new(struct net_pkt *pkt, struct tcphdr *th);
 
 static enum net_verdict tcp_recv(struct net_conn *net_conn,
 				 struct net_pkt *pkt,
@@ -2379,7 +2371,7 @@ static enum net_verdict tcp_recv(struct net_conn *net_conn,
 			goto out;
 		}
 
-		conn = tcp_conn_new(pkt);
+		conn = tcp_conn_new(pkt, th);
 		if (!conn) {
 			NET_ERR("Cannot allocate a new TCP connection");
 			goto in;
@@ -2521,7 +2513,7 @@ static uint32_t tcp_init_isn(struct net_sockaddr *saddr, struct net_sockaddr *da
 /* Create a new tcp connection, as a part of it, create and register
  * net_context
  */
-static struct tcp *tcp_conn_new(struct net_pkt *pkt)
+static struct tcp *tcp_conn_new(struct net_pkt *pkt, struct tcphdr *th)
 {
 	struct tcp *conn = NULL;
 	struct net_context *context = NULL;
@@ -2542,13 +2534,13 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 
 	net_context_set_family(conn->context, net_pkt_family(pkt));
 
-	if (tcp_endpoint_set(&conn->dst, pkt, TCP_EP_SRC) < 0) {
+	if (tcp_endpoint_set(&conn->dst, pkt, th, TCP_EP_SRC) < 0) {
 		net_context_put(context);
 		conn = NULL;
 		goto err;
 	}
 
-	if (tcp_endpoint_set(&conn->src, pkt, TCP_EP_DST) < 0) {
+	if (tcp_endpoint_set(&conn->src, pkt, th, TCP_EP_DST) < 0) {
 		net_context_put(context);
 		conn = NULL;
 		goto err;
@@ -4388,8 +4380,8 @@ static enum net_verdict tcp_input(struct net_conn *net_conn,
 			net_tcp_get(context);
 			net_context_set_family(context, net_pkt_family(pkt));
 			conn = context->tcp;
-			tcp_endpoint_set(&conn->dst, pkt, TCP_EP_SRC);
-			tcp_endpoint_set(&conn->src, pkt, TCP_EP_DST);
+			tcp_endpoint_set(&conn->dst, pkt, th, TCP_EP_SRC);
+			tcp_endpoint_set(&conn->src, pkt, th, TCP_EP_DST);
 			/* Make an extra reference, the sanity check suite
 			 * will delete the connection explicitly
 			 */
@@ -4518,8 +4510,14 @@ enum net_verdict tp_input(struct net_conn *net_conn,
 				net_context_set_family(context,
 						       net_pkt_family(pkt));
 				conn = context->tcp;
-				tcp_endpoint_set(&conn->dst, pkt, TCP_EP_SRC);
-				tcp_endpoint_set(&conn->src, pkt, TCP_EP_DST);
+				/* This is a UDP packet carrying the test
+				 * protocol; only the port fields are read,
+				 * and those alias the TCP header layout.
+				 */
+				tcp_endpoint_set(&conn->dst, pkt, th_get(pkt),
+						 TCP_EP_SRC);
+				tcp_endpoint_set(&conn->src, pkt, th_get(pkt),
+						 TCP_EP_DST);
 				conn->iface = pkt->iface;
 				tcp_conn_ref(conn);
 			}

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -361,12 +361,12 @@ static size_t tcp_data_len(struct net_pkt *pkt, struct tcphdr *th)
 	return len > 0 ? (size_t)len : 0;
 }
 
-static const char *tcp_th(struct net_pkt *pkt, uint32_t *seq_ptr, uint32_t *ack_ptr)
+static const char *tcp_th(struct net_pkt *pkt, struct tcphdr *th,
+			  uint32_t *seq_ptr, uint32_t *ack_ptr)
 {
 #define BUF_SIZE 80
 	static char buf[BUF_SIZE];
 	int len = 0;
-	struct tcphdr *th = th_get(pkt);
 	uint32_t seq, ack;
 
 	buf[0] = '\0';
@@ -1062,14 +1062,15 @@ out:
 	return prefix ? s : (s + 4);
 }
 
-static const char *tcp_conn_state(struct tcp *conn, struct net_pkt *pkt)
+static const char *tcp_conn_state(struct tcp *conn, struct net_pkt *pkt,
+				  struct tcphdr *th)
 {
 #define BUF_SIZE 160
 	static char buf[BUF_SIZE];
 	uint32_t seq = conn->isn, ack = conn->isn_peer;
 
 	snprintk(buf, BUF_SIZE, "%s [%s Seq=%u{%u} Ack=%u{%u}]",
-		 pkt ? tcp_th(pkt, &seq, &ack) : "",
+		 pkt ? tcp_th(pkt, th, &seq, &ack) : "",
 		 tcp_state_to_str(conn->state, false),
 		 conn->seq - seq, conn->seq,
 		 conn->ack - ack, conn->ack);
@@ -1569,7 +1570,7 @@ void net_tcp_reply_rst(struct net_pkt *pkt)
 		goto err;
 	}
 
-	NET_DBG("%s", tcp_th(rst, NULL, NULL));
+	NET_DBG("%s", tcp_th(rst, th_get(rst), NULL, NULL));
 
 	tcp_send(rst);
 
@@ -2038,7 +2039,7 @@ static void tcp_timewait_timeout(struct k_work *work)
 	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, timewait_timer);
 
 	/* no need to acquire the conn->lock as there is nothing scheduled here */
-	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL));
+	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL, NULL));
 
 	(void)tcp_conn_close(conn, -ETIMEDOUT);
 }
@@ -2046,7 +2047,7 @@ static void tcp_timewait_timeout(struct k_work *work)
 static void tcp_establish_timeout(struct tcp *conn)
 {
 	NET_DBG("[%p] Did not receive %s in %dms", conn, "ACK", ACK_TIMEOUT_MS);
-	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL));
+	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL, NULL));
 
 	(void)tcp_conn_close(conn, -ETIMEDOUT);
 }
@@ -2063,7 +2064,7 @@ static void tcp_fin_timeout(struct k_work *work)
 	}
 
 	NET_DBG("[%p] Did not receive %s in %dms", conn, "FIN", tcp_max_timeout_ms);
-	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL));
+	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL, NULL));
 
 	(void)tcp_conn_close(conn, -ETIMEDOUT);
 }
@@ -2096,7 +2097,7 @@ static void tcp_last_ack_timeout(struct k_work *work)
 	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, fin_timer);
 
 	NET_DBG("[%p] Did not receive %s in %dms", conn, "last ACK", LAST_ACK_TIMEOUT_MS);
-	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL));
+	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, NULL, NULL));
 
 	(void)tcp_conn_close(conn, -ETIMEDOUT);
 }
@@ -3003,7 +3004,7 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt,
 		return NET_DROP;
 	}
 
-	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, pkt));
+	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, pkt, th));
 
 	len = tcp_data_len(pkt, th);
 
@@ -3753,7 +3754,7 @@ int net_tcp_put(struct net_context *context, bool force_close)
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
-	NET_DBG("[%p] %s", conn, conn ? tcp_conn_state(conn, NULL) : "");
+	NET_DBG("[%p] %s", conn, conn ? tcp_conn_state(conn, NULL, NULL) : "");
 	NET_DBG("[%p] context %p %s", conn, context,
 		({ const char *state = net_context_state(context);
 					state ? state : "<unknown>"; }));

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -80,7 +80,8 @@ K_MEM_SLAB_DEFINE_STATIC_TYPE(tcp_conns_slab, struct tcp,
 static struct k_work_q tcp_work_q;
 static K_KERNEL_STACK_DEFINE(work_q_stack, CONFIG_NET_TCP_WORKQ_STACK_SIZE);
 
-static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt);
+static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt,
+			       struct tcphdr *th);
 static bool is_destination_local(struct net_pkt *pkt);
 static void tcp_out(struct tcp *conn, uint8_t flags);
 static const char *tcp_state_to_str(enum tcp_state state, bool prefix);
@@ -2383,7 +2384,7 @@ static enum net_verdict tcp_recv(struct net_conn *net_conn,
 	}
 in:
 	if (conn) {
-		verdict = tcp_in(conn, pkt);
+		verdict = tcp_in(conn, pkt, th);
 	} else {
 		net_tcp_reply_rst(pkt);
 	}
@@ -2964,9 +2965,9 @@ static void tcp_check_sock_options(struct tcp *conn)
 }
 
 /* TCP state machine, everything happens here */
-static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
+static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt,
+			       struct tcphdr *th)
 {
-	struct tcphdr *th;
 	uint8_t next = 0, fl = 0;
 	bool do_close = false;
 	bool connection_ok = false;
@@ -2980,14 +2981,8 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 	int close_status = 0;
 	enum net_verdict verdict = NET_DROP;
 
-	if (conn == NULL || pkt == NULL) {
+	if (conn == NULL || pkt == NULL || th == NULL) {
 		NET_ERR("Invalid parameters");
-		return NET_DROP;
-	}
-
-	th = th_get(pkt);
-	if (th == NULL) {
-		NET_ERR("Failed to get TCP header");
 		return NET_DROP;
 	}
 
@@ -4392,7 +4387,7 @@ static enum net_verdict tcp_input(struct net_conn *net_conn,
 
 		if (conn) {
 			conn->iface = pkt->iface;
-			verdict = tcp_in(conn, pkt);
+			verdict = tcp_in(conn, pkt, th);
 		}
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -367,8 +367,19 @@ static const char *tcp_flags(uint8_t flags)
 
 static size_t tcp_data_len(struct net_pkt *pkt, struct tcphdr *th)
 {
-	size_t tcp_options_len = (th_off(th) - 5) * 4;
-	int len = net_pkt_get_len(pkt) - net_pkt_ip_hdr_len(pkt) -
+	size_t tcp_options_len;
+	int len;
+
+	/* An offset below the header size would make the option length
+	 * underflow, and the payload length derived from it is then whatever
+	 * the subtraction wraps to. Such a segment carries no usable data.
+	 */
+	if (th == NULL || th_off(th) < 5) {
+		return 0;
+	}
+
+	tcp_options_len = (th_off(th) - 5) * 4;
+	len = net_pkt_get_len(pkt) - net_pkt_ip_hdr_len(pkt) -
 		net_pkt_ip_opts_len(pkt) - sizeof(*th) - tcp_options_len;
 
 	return len > 0 ? (size_t)len : 0;
@@ -383,6 +394,11 @@ static const char *tcp_th(struct net_pkt *pkt, struct tcphdr *th,
 	uint32_t seq, ack;
 
 	buf[0] = '\0';
+
+	if (th == NULL) {
+		len += snprintk(buf + len, BUF_SIZE - len, "no header");
+		goto end;
+	}
 
 	if (th_off(th) < 5) {
 		len += snprintk(buf + len, BUF_SIZE - len,

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1695,9 +1695,8 @@ static void tcp_out(struct tcp *conn, uint8_t flags)
 	(void)tcp_out_ext(conn, flags, 0 /* no data */, conn->seq + conn->unacked_len);
 }
 
-static int tcp_pkt_pull(struct net_pkt *pkt, size_t len)
+static int tcp_pkt_pull(struct net_pkt *pkt, size_t len, size_t total)
 {
-	int total = net_pkt_get_len(pkt);
 	int ret = 0;
 
 	if (len > total) {
@@ -1744,7 +1743,7 @@ static int tcp_pkt_trim_data(struct tcp *conn, struct net_pkt *pkt, size_t data_
 	}
 
 	/* Last, append the valid data part to the new_pkt */
-	ret = tcp_pkt_pull(pkt, hdrlen + trim_len);
+	ret = tcp_pkt_pull(pkt, hdrlen + trim_len, total);
 	if (ret < 0) {
 		goto out;
 	}
@@ -2938,15 +2937,17 @@ static void tcp_out_of_order_data(struct tcp *conn, struct net_pkt *pkt,
 				  size_t data_len, uint32_t seq)
 {
 	size_t headers_len;
+	size_t total_len;
 
 	if (data_len == 0) {
 		return;
 	}
 
-	headers_len = net_pkt_get_len(pkt) - data_len;
+	total_len = net_pkt_get_len(pkt);
+	headers_len = total_len - data_len;
 
 	/* Get rid of protocol headers from the data */
-	if (tcp_pkt_pull(pkt, headers_len) < 0) {
+	if (tcp_pkt_pull(pkt, headers_len, total_len) < 0) {
 		return;
 	}
 
@@ -3381,8 +3382,8 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt,
 			NET_DBG("[%p] len_acked=%u", conn, len_acked);
 
 			if ((conn->send_data_total < len_acked) ||
-					(tcp_pkt_pull(&conn->send_data,
-						      len_acked) < 0)) {
+					(tcp_pkt_pull(&conn->send_data, len_acked,
+						      conn->send_data_total) < 0)) {
 				NET_ERR("[%p] Invalid len_acked=%u "
 					"(total=%zu)", conn, len_acked,
 					conn->send_data_total);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -352,9 +352,8 @@ static const char *tcp_flags(uint8_t flags)
 	return buf;
 }
 
-static size_t tcp_data_len(struct net_pkt *pkt)
+static size_t tcp_data_len(struct net_pkt *pkt, struct tcphdr *th)
 {
-	struct tcphdr *th = th_get(pkt);
 	size_t tcp_options_len = (th_off(th) - 5) * 4;
 	int len = net_pkt_get_len(pkt) - net_pkt_ip_hdr_len(pkt) -
 		net_pkt_ip_opts_len(pkt) - sizeof(*th) - tcp_options_len;
@@ -403,7 +402,7 @@ static const char *tcp_th(struct net_pkt *pkt, uint32_t *seq_ptr, uint32_t *ack_
 	}
 
 	len += snprintk(buf + len, BUF_SIZE - len,
-			" Len=%ld", (long)tcp_data_len(pkt));
+			" Len=%ld", (long)tcp_data_len(pkt, th));
 end:
 #undef BUF_SIZE
 	return buf;
@@ -1545,7 +1544,8 @@ void net_tcp_reply_rst(struct net_pkt *pkt)
 		UNALIGNED_PUT(RST, &th_rst->th_flags);
 		UNALIGNED_PUT(th_pkt->th_ack, UNALIGNED_MEMBER_ADDR(th_rst, th_seq));
 	} else {
-		uint32_t ack = net_ntohl(th_pkt->th_seq) + tcp_data_len(pkt);
+		uint32_t ack = net_ntohl(th_pkt->th_seq) +
+			tcp_data_len(pkt, th_pkt);
 
 		if (th_flags(th_pkt) & SYN) {
 			ack++;
@@ -3005,7 +3005,7 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt,
 
 	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, pkt));
 
-	len = tcp_data_len(pkt);
+	len = tcp_data_len(pkt, th);
 
 	/* first validate the seqnum */
 	if (!tcp_validate_seq(conn, th, len)) {
@@ -4396,7 +4396,7 @@ static enum net_verdict tcp_input(struct net_conn *net_conn,
 
 static size_t tp_tcp_recv_cb(struct tcp *conn, struct net_pkt *pkt)
 {
-	ssize_t len = tcp_data_len(pkt);
+	ssize_t len = tcp_data_len(pkt, th_get(pkt));
 	struct net_pkt *up = tcp_pkt_clone(pkt);
 
 	NET_DBG("[%p] pkt: %p, len: %zu", conn, pkt, net_pkt_get_len(pkt));

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2296,34 +2296,36 @@ int net_tcp_get(struct net_context *context)
 	return ret;
 }
 
-static bool tcp_endpoint_cmp(union tcp_endpoint *ep, struct net_pkt *pkt,
-			     enum pkt_addr which)
+static bool tcp_endpoint_cmp(const union tcp_endpoint *ep,
+			     const union tcp_endpoint *ep_pkt)
 {
-	union tcp_endpoint ep_tmp;
-
-	if (tcp_endpoint_set(&ep_tmp, pkt, th_get(pkt), which) < 0) {
-		return false;
-	}
-
-	return !memcmp(ep, &ep_tmp, tcp_endpoint_len(ep->sa.sa_family));
+	/* The length comes from the connection's endpoint, as before, so a
+	 * connection of one address family never matches a packet of another:
+	 * the family byte is part of the compared region.
+	 */
+	return !memcmp(ep, ep_pkt, tcp_endpoint_len(ep->sa.sa_family));
 }
 
-static bool tcp_conn_cmp(struct tcp *conn, struct net_pkt *pkt)
+static struct tcp *tcp_conn_search(struct net_pkt *pkt, struct tcphdr *th)
 {
-	return tcp_endpoint_cmp(&conn->src, pkt, TCP_EP_DST) &&
-		tcp_endpoint_cmp(&conn->dst, pkt, TCP_EP_SRC);
-}
-
-static struct tcp *tcp_conn_search(struct net_pkt *pkt)
-{
+	union tcp_endpoint src_ep, dst_ep;
 	bool found = false;
 	struct tcp *conn;
 	struct tcp *tmp;
 
+	/* Build the packet's endpoints once instead of rebuilding them for
+	 * every connection examined below.
+	 */
+	if (tcp_endpoint_set(&src_ep, pkt, th, TCP_EP_SRC) < 0 ||
+	    tcp_endpoint_set(&dst_ep, pkt, th, TCP_EP_DST) < 0) {
+		return NULL;
+	}
+
 	k_mutex_lock(&tcp_lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&tcp_conns, conn, tmp, next) {
-		found = tcp_conn_cmp(conn, pkt);
+		found = tcp_endpoint_cmp(&conn->src, &dst_ep) &&
+			tcp_endpoint_cmp(&conn->dst, &src_ep);
 		if (found) {
 			break;
 		}
@@ -2354,7 +2356,7 @@ static enum net_verdict tcp_recv(struct net_conn *net_conn,
 		goto out;
 	}
 
-	conn = tcp_conn_search(pkt);
+	conn = tcp_conn_search(pkt, th);
 	if (conn) {
 		goto in;
 	}
@@ -4372,7 +4374,7 @@ static enum net_verdict tcp_input(struct net_conn *net_conn,
 	enum net_verdict verdict = NET_DROP;
 
 	if (th && (th_off(th) >= 5)) {
-		struct tcp *conn = tcp_conn_search(pkt);
+		struct tcp *conn = tcp_conn_search(pkt, th);
 
 		if (conn == NULL && SYN == th_flags(th)) {
 			struct net_context *context =
@@ -4454,7 +4456,10 @@ enum net_verdict tp_input(struct net_conn *net_conn,
 {
 	struct net_udp_hdr *uh = net_udp_get_hdr(pkt, NULL);
 	size_t data_len = net_ntohs(uh->len) - sizeof(*uh);
-	struct tcp *conn = tcp_conn_search(pkt);
+	/* The test protocol rides on UDP; th_get() lands on the UDP header,
+	 * whose port fields alias the TCP ones, which is all that is read.
+	 */
+	struct tcp *conn = tcp_conn_search(pkt, th_get(pkt));
 	size_t json_len = 0;
 	struct tp *tp;
 	struct tp_new *tp_new;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -184,6 +184,19 @@ static int tcp_pkt_linearize(struct net_pkt *pkt, size_t pos, size_t len)
 	return ret;
 }
 
+/* Locate the TCP header inside a received packet.
+ *
+ * The returned pointer aims into pkt->buffer, at ip_hdr_len + ip_opts_len, and
+ * stays valid only while that fragment keeps its data pointer and its place in
+ * the chain. It does not survive anything that pulls, trims, splices or
+ * replaces buffers, nor handing the packet to another owner. In the receive
+ * path that means tcp_pkt_trim_data(), tcp_pkt_pull(), the k_fifo_put() in
+ * tcp_data_get() and the final net_pkt_unref(); re-derive after those rather
+ * than carrying the old pointer across.
+ *
+ * Note the packet is left in overwrite mode with the cursor parked on the TCP
+ * header, and neither is restored.
+ */
 static struct tcphdr *th_get(struct net_pkt *pkt)
 {
 	size_t ip_len = net_pkt_ip_hdr_len(pkt) + net_pkt_ip_opts_len(pkt);
@@ -3464,6 +3477,16 @@ data_recv:
 			int32_t new_len = tcp_compute_new_length(conn, th, len, false);
 
 			if (tcp_pkt_trim_data(conn, pkt, len, (size_t)(len - new_len)) == 0) {
+				/* Trimming replaces pkt->buffer, so the header
+				 * derived on entry no longer points into this
+				 * packet.
+				 */
+				th = th_get(pkt);
+				if (th == NULL) {
+					verdict = NET_DROP;
+					break;
+				}
+
 				len = new_len;
 				goto data_recv;
 			} else {


### PR DESCRIPTION
I used the PR #116614 to verify the performance improvements.

`th_get()` locates the TCP header in a received packet by rewinding the
packet cursor to the head of the buffer chain, walking the IP header
again, and checking the TCP header is contiguous. It caches nothing, so
every caller pays the full walk.

For one received in-order data segment it runs **five times**:

| | |
|---|---|
| `tcp_recv()` | derives it, then discards the pointer |
| `tcp_conn_search()` | **twice per connection examined** |
| `tcp_in()` | derives it again, identical result |
| `tcp_data_len()` | derives it again, to read one field |

The connection lookup is the worst of the four, and worse than the call
count suggests. `tcp_conn_cmp()` called `tcp_endpoint_cmp()` twice, and
each of those built a temporary `union tcp_endpoint` from the packet
before comparing it — so both the header derivation and the endpoint
construction ran 2*N times for N connections scanned. That temporary is
the same value every time: it depends only on the packet.

This series derives the header once in `tcp_recv()` and passes it down,
and builds the packet's two endpoints once before the lookup loop.
Everything touched is `static`; there is no API change.

Holding the pointer across calls is not a new practice in this file.
`tcp_in()` already derives it once and uses it about 40 times across the
whole state machine, including through `tcp_options_check()`,
`tcp_data_get()` and `tcp_pkt_trim_data()`. The series extends that
lifetime by one stack frame, over `tcp_conn_search()` and
`tcp_conn_new()`, neither of which alters the buffer chain.

### Result

Measured on `qemu_x86` with a zperf TCP loopback transfer under QEMU
icount, so the figures are instruction counts rather than wall clock and
repeat exactly:

| fragment size | before | after | |
|---|---|---|---|
| `CONFIG_NET_BUF_DATA_SIZE=1100` | 6.325 Mbps | 6.642 Mbps | **+5.01%** |
| `CONFIG_NET_BUF_DATA_SIZE=128` (default) | 3.970 Mbps | 4.093 Mbps | **+3.10%** |

Instructions per payload byte, showing where it comes from:

| | before | after | |
|---|---|---|---|
| total | 40.276 | 38.358 | −4.76% |
| `th_get` | 0.492 | 0.076 | **−84.6%** |
| `tcp_endpoint_set` | 0.342 | 0.180 | −47.4% |
| `net_pkt_skip` | 0.178 | 0.096 | −45.8% |
| `net_pkt_cursor_init` | 0.254 | 0.154 | −39.3% |
| `net_pkt_get_contiguous_len` | 1.228 | 0.857 | −30.2% |
| `net_pkt_cursor_operate` | 2.346 | 1.666 | −29.0% |
| `memcmp` | 0.214 | 0.214 | unchanged |

`memcmp` staying flat is the check that the lookup still does the same
comparisons; only the work of preparing them went away.

The absolute saving is **1.92 instructions per payload byte at both
fragment sizes**. It reads as 5% or 3% only because the totals differ
(40.3 vs 64.5 ipb). `th_get()` skips just the IP header, which sits in
the first fragment whatever the fragment size, so this path does not
scale with fragment count — unlike the payload traversal, which does.

### Note on the last commit

`tcp_pkt_trim_data()` builds a replacement buffer chain and swaps it into
the packet, which leaves the header pointer the state machine is holding
pointing into freed buffers. That is already true today and already
harmless, because the jump to the receive path does not use the header
again. It stops being harmless as soon as anything there does, and
nothing said so. The last commit re-derives after a trim and writes the
lifetime rule down next to `th_get()`.
