### PR TITLE
drivers: wifi: esp32: report mixed-mode psk security

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -412,6 +412,13 @@ static void scan_done_handler(void)
 		case WIFI_AUTH_WPA3_PSK:
 			res.security = WIFI_SECURITY_TYPE_SAE;
 			break;
+		case WIFI_AUTH_WPA_WPA2_PSK:
+		case WIFI_AUTH_WPA2_WPA3_PSK:
+			res.security = WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL;
+			break;
+		case WIFI_AUTH_DPP:
+			res.security = WIFI_SECURITY_TYPE_DPP;
+			break;
 		case WIFI_AUTH_WAPI_PSK:
 			res.security = WIFI_SECURITY_TYPE_WAPI;
 			break;
@@ -1676,6 +1683,13 @@ static int esp32_wifi_status(const struct device *dev __unused,
 		break;
 	case WIFI_AUTH_WPA3_PSK:
 		status->security = WIFI_SECURITY_TYPE_SAE;
+		break;
+	case WIFI_AUTH_WPA_WPA2_PSK:
+	case WIFI_AUTH_WPA2_WPA3_PSK:
+		status->security = WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL;
+		break;
+	case WIFI_AUTH_DPP:
+		status->security = WIFI_SECURITY_TYPE_DPP;
 		break;
 	case WIFI_AUTH_WPA_ENTERPRISE:
 	case WIFI_AUTH_WPA2_ENTERPRISE:


### PR DESCRIPTION
The scan and status handlers had no case for the WPA/WPA2 and WPA2/WPA3 transition authmodes, so mixed-mode access points were reported as UNKNOWN. Feeding such a result back into a connect request was then rejected. Map both to WPA_AUTO_PERSONAL, which is how other Wi-Fi drivers group these modes, and map the DPP authmode to its own security type.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116038