### PR TITLE
boards: deprecated: remove raytac_an54l15q_db/nrf54l15/cpuapp entry

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -46,9 +46,6 @@ set(esp32_devkitc_wrover/esp32/appcpu_DEPRECATED
 set(scobc_module1_DEPRECATED
     scobc_a1
 )
-set(raytac_an54l15q_db/nrf54l15/cpuapp_DEPRECATED
-    raytac_an54lq_db_15/nrf54l15/cpuapp
-)
 set(fvp_base_revc_2xaemv8a_DEPRECATED
     fvp_base_revc_2xaem/v8a
 )


### PR DESCRIPTION
Remove the raytac_an54l15q_db/nrf54l15/cpuapp entry as this has been there for two releases already.