### PR TITLE
cmake: only set CMAKE_SYSTEM_PROCESSOR when cross-compiling

### DIFF
--- a/cmake/modules/FindTargetTools.cmake
+++ b/cmake/modules/FindTargetTools.cmake
@@ -66,7 +66,9 @@ set(CMAKE_SYSTEM_NAME Generic)
 #   CMAKE_SYSTEM_NAME-compiler-CMAKE_SYSTEM_PROCESSOR.cmake file,
 #   which can be used to modify settings like compiler flags etc. for
 #   the target
-set(CMAKE_SYSTEM_PROCESSOR ${ARCH})
+if(NOT ARCH STREQUAL "posix")
+  set(CMAKE_SYSTEM_PROCESSOR ${ARCH})
+endif()
 
 # https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_VERSION.html:
 #   When the CMAKE_SYSTEM_NAME variable is set explicitly to enable cross

--- a/west.yml
+++ b/west.yml
@@ -370,7 +370,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 01254932e8e81085817ed61fd858648584ffe37c
+      revision: pull/14/head
     - name: psa-arch-tests
       revision: 588572c0ebd835c7e0929eaf3007d4fbadb47b5b
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
CMAKE_SYSTEM_PROCESSOR is intended for cross compilation. Only set CMAKE_SYSTEM_PROCESSOR when cross compiling. The `posix` arch is in principle not cross-compiling Zephyr but is generally intended to run natively on the OS.

Alternative to #116571