### PR TITLE
samples: gpio: renesas: fix overlay

### DIFF
--- a/samples/basic/button/boards/rzg3s_smarc_r9a08g045s33gbg_cm33.overlay
+++ b/samples/basic/button/boards/rzg3s_smarc_r9a08g045s33gbg_cm33.overlay
@@ -7,6 +7,10 @@
 	status = "okay";
 };
 
+&tint16 {
+	status = "okay";
+};
+
 &gpio18 {
-	irqs = <0 16>;
+	irqs = <&tint16 0>;
 };

--- a/samples/drivers/gpio/button_interrupt/boards/rzg3s_smarc_r9a08g045s33gbg_cm33.overlay
+++ b/samples/drivers/gpio/button_interrupt/boards/rzg3s_smarc_r9a08g045s33gbg_cm33.overlay
@@ -7,6 +7,10 @@
 	status = "okay";
 };
 
+&tint16 {
+	status = "okay";
+};
+
 &gpio18 {
-	irqs = <0 16>;
+	irqs = <&tint16 0>;
 };


### PR DESCRIPTION
```
west twister -p rzg3s_smarc/r9a08g045s33gbg/cm33 -s sample.drivers.gpio.button_interrupt
west twister -p rzg3s_smarc/r9a08g045s33gbg/cm33 -s sample.basic.button
```
are failing without it.

CI fail in https://github.com/zephyrproject-rtos/zephyr/actions/runs/32126542106/job/95680207802?pr=110972

Probably missed in https://github.com/zephyrproject-rtos/zephyr/pull/101256