### PR TITLE
boards: shields: nrf7002eb2: Remove unused overlay

### DIFF
--- a/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Nordic Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * nRF7002 EB-II board overlay for nrf54lm20dk/nrf54lm20a/cpuapp.
- * Includes common SoC overlay snippet.
- */
-#include "../nrf54lm20.overlay"

--- a/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Nordic Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * nRF7002 EB-II board overlay for nrf54lm20dk/nrf54lm20a/cpuapp/ns.
- * Includes common SoC overlay snippet.
- */
-#include "../nrf54lm20.overlay"

--- a/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Nordic Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * nRF7002 EB-II board overlay for nrf54lm20dk/nrf54lm20b/cpuapp/ns.
- * Includes common SoC overlay snippet.
- */
-#include "../nrf54lm20.overlay"


### PR DESCRIPTION
This overlays are not needed after #112474.
The workaround was removed.