### PR TITLE
arch: x86: Unused arguments cleanup

### DIFF
--- a/arch/x86/core/ia32/soft_float_stubs.c
+++ b/arch/x86/core/ia32/soft_float_stubs.c
@@ -21,260 +21,330 @@ extern void abort(void);
 
 __weak void __addtf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __addxf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __subtf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __subxf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __multf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __mulxf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __divtf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __divxf3(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __negtf2(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __negxf2(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __extendsftf2(float a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __extendsfxf2(float a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __extenddftf2(double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __extenddfxf2(double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __truncxfdf2(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __trunctfdf2(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __truncxfsf2(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __trunctfsf2(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixtfsi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixxfsi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixtfdi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixxfdi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixtfti(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixxfti(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixunstfsi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixunsxfsi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixunstfdi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixunsxfdi(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixunstfti(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __fixunsxfti(long double a)
 {
+	ARG_UNUSED(a);
 	k_oops();
 }
 
 __weak void __floatsitf(int i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatsixf(int i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatditf(long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatdixf(long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floattitf(long long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floattixf(long long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatunsitf(unsigned int i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatunsixf(unsigned int i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatunditf(unsigned long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatundixf(unsigned long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatuntitf(unsigned long long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __floatuntixf(unsigned long long i)
 {
+	ARG_UNUSED(i);
 	k_oops();
 }
 
 __weak void __cmptf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __unordtf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __eqtf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __netf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __getf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __lttf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __letf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __gttf2(long double a, long double b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __powitf2(long double a, int b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }
 
 __weak void __powixf2(long double a, int b)
 {
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
 	k_oops();
 }

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -55,6 +55,7 @@ int arch_float_disable(struct k_thread *thread)
 #if defined(CONFIG_LAZY_FPU_SHARING)
 	return z_float_disable(thread);
 #else
+	ARG_UNUSED(thread);
 	return -ENOTSUP;
 #endif /* CONFIG_LAZY_FPU_SHARING */
 }
@@ -66,6 +67,8 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 #if defined(CONFIG_LAZY_FPU_SHARING)
 	return z_float_enable(thread, options);
 #else
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
 	return -ENOTSUP;
 #endif /* CONFIG_LAZY_FPU_SHARING */
 }
@@ -76,6 +79,7 @@ int arch_coprocessors_disable(struct k_thread *thread)
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	return arch_float_disable(thread);
 #else
+	ARG_UNUSED(thread);
 	return -ENOTSUP;
 #endif
 }
@@ -92,6 +96,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 * which is only needed if the stack is not memory mapped.
 	 */
 	z_x86_set_stack_guard(stack);
+#else
+	ARG_UNUSED(stack);
 #endif
 
 #ifdef CONFIG_USERSPACE

--- a/arch/x86/core/intel64/irq_offload.c
+++ b/arch/x86/core/intel64/irq_offload.c
@@ -23,6 +23,7 @@ static const void *irq_offload_args[CONFIG_MP_MAX_NUM_CPUS];
 
 static void dispatcher(const void *arg)
 {
+	ARG_UNUSED(arg);
 	uint8_t cpu_id = _current_cpu->id;
 
 	if (irq_offload_funcs[cpu_id] != NULL) {


### PR DESCRIPTION
Applies the ARG_UNUSED() macro to unused arguments on the x86 architecture. This helps clean up the "unused parameter" warnings should a developer build a project for x86 using the "-Wextra" option.

Related to #30914