### PR TITLE
lib: hash: fix sys_hash32_murmur3() prototype mismatch

### DIFF
--- a/lib/hash/hash_func32_murmur3.c
+++ b/lib/hash/hash_func32_murmur3.c
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/sys/hash_function.h>
 #include <zephyr/sys/util.h>
 
 static inline uint32_t murmur_32_scramble(uint32_t k)
@@ -26,8 +27,9 @@ static inline uint32_t murmur_32_scramble(uint32_t k)
 		h = h * 5 + 0xe6546b64; \
 	}
 
-uint32_t sys_hash32_murmur3(const char *str, size_t n)
+uint32_t sys_hash32_murmur3(const void *data, size_t n)
 {
+	const char *str = data;
 	uint32_t k;
 	/* seed of 0 */
 	uint32_t h = 0;


### PR DESCRIPTION
`sys_hash32_murmur3()` is declared in `<zephyr/sys/hash_function.h>` as taking a `const void *`:

```c
uint32_t sys_hash32_murmur3(const void *str, size_t n);
```

but `lib/hash/hash_func32_murmur3.c` defines it taking a `const char *`:

```c
uint32_t sys_hash32_murmur3(const char *str, size_t n)
```

The mismatch goes unnoticed today because the implementation does not include the header that declares the function, so the compiler never sees the two declarations in the same translation unit. It surfaces as a hard error as soon as it does — for instance when `hash_func32_djb2.c` (which does include the header) and `hash_func32_murmur3.c` end up in one translation unit:

```
lib/hash/hash_func32_murmur3.c:29:10: error: conflicting types for 'sys_hash32_murmur3';
    have 'uint32_t(const char *, size_t)'
include/zephyr/sys/hash_function.h:115:10: note: previous declaration of 'sys_hash32_murmur3'
    with type 'uint32_t(const void *, size_t)'
```

Include `<zephyr/sys/hash_function.h>` and match the declared prototype, keeping a local `const char *` for the byte-wise arithmetic in the body. No functional change; callers already go through the header's declaration.