### PR TITLE
tests: sys_timer/timer_monotonic: fix fault w/ kernel coherence

### DIFF
--- a/tests/kernel/sys_timer/timer_monotonic/src/main.c
+++ b/tests/kernel/sys_timer/timer_monotonic/src/main.c
@@ -88,7 +88,7 @@ ZTEST(timer_fn, test_timer)
  */
 ZTEST(timer_fn, test_timer_monotonic_irq_locked)
 {
-	struct k_timer timer;
+	static struct k_timer timer;
 	uint32_t t_before, t_during, t_after;
 	unsigned int key;
 	int iter;


### PR DESCRIPTION
test_timer_monotonic_irq_locked declared its timer as stack local. On platforms with CONFIG_KERNEL_COHERENCE enabled, thread stacks live in cached, non-coherent memory. Kernel objects need to be in coherenet memory, or else kernel code will assert on these variables due to failing the sys_cache_is_mem_coherence() test.

So fix this by declaring the k_timer static so it will reside in coherent memory.

Fixes #116656