### PR TITLE
tests: llext: fix integration platform errors on the userspace scenario

### DIFF
--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -73,7 +73,16 @@ struct llext_test {
 };
 
 
-K_THREAD_STACK_DEFINE(llext_stack, 1024);
+/* Extensions run in a user thread on this stack. 64-bit targets need
+ * more room: pointers, saved registers and stack slots all double.
+ */
+#ifdef CONFIG_64BIT
+#define LLEXT_STACK_SIZE 4096
+#else
+#define LLEXT_STACK_SIZE 1024
+#endif
+
+K_THREAD_STACK_DEFINE(llext_stack, LLEXT_STACK_SIZE);
 struct k_thread llext_thread;
 
 

--- a/tests/subsys/llext/tests.yaml
+++ b/tests/subsys/llext/tests.yaml
@@ -97,17 +97,15 @@ tests:
       - CONFIG_LLEXT_HEAP_MEMBLK=y
       - CONFIG_LLEXT_EXT_HEAP_SIZE=64
       - CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=8192
-  # RISC-V userspace: exercises calling syscalls from an extension and running
-  # it in a user-mode thread. Every syscall stub inlines arch_is_user_context();
-  # on RISC-V that check used to read a thread-local symbol a loaded extension
-  # cannot relocate, so any such extension failed to link. RISC-V runs the
-  # extension from RAM and needs writable storage, so it is covered here rather
-  # than by the readonly_mpu cases above.
-  llext.userspace:
-    arch_allow:
-      - riscv
-    platform_allow:
-      - qemu_riscv32
+  # Writable storage under an MPU, running the extension in a user-mode
+  # thread: the counterpart of the readonly_mpu cases above for targets
+  # that copy the extension into RAM instead of running it in place.
+  #
+  # Only RISC-V does that today, but the restriction is expressed as a
+  # filter rather than arch_allow so the arm integration platforms
+  # inherited from common are filtered at build time instead of
+  # erroring the integration test plan.
+  llext.writable_mpu:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_RISCV_PMP
     integration_platforms:
       - qemu_riscv32


### PR DESCRIPTION
The `llext.userspace` scenario restricted itself with `arch_allow: riscv` and `platform_allow: qemu_riscv32`. Those produce `Filters.TESTSUITE` exclusions, which `change_skip_to_error_if_integration()` converts into errors for any platform listed in `integration_platforms`. Since `integration_platforms` merges additively from the `common:` block and cannot be narrowed per scenario, the five arm platforms inherited from `common:` each became an error in `testplan.json`, and `test_plan_v2.py` returns the number of error-status suites as its exit code.

Express the RISC-V restriction through the Kconfig `filter:` the scenario already carries instead. A Kconfig filter is evaluated at CMake-run time rather than in the allow-list pass, so it never adds a `Filters.TESTSUITE` entry and the arm platforms are filtered at build time instead of erroring the plan. `CONFIG_RISCV_PMP` in the existing filter expression already excludes them, so no coverage changes: arm is still never built for this scenario.

This mirrors what `llext.tls` in the same file already does for the identical arm64-only case, and its comment explaining why.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/115660