### PR TITLE
[Backport v4.3-branch] drivers: entropy: mcux_trng: fix buffer overflow on odd lengths

### DIFF
--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -7,11 +7,14 @@
 
 #define DT_DRV_COMPAT nxp_kinetis_trng
 
+#include <string.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/random/random.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/util.h>
 
 #include "fsl_trng.h"
 
@@ -26,8 +29,48 @@ static int entropy_mcux_trng_get_entropy(const struct device *dev,
 	const struct mcux_entropy_config *config = dev->config;
 	status_t status;
 
-	status = TRNG_GetRandomData(config->base, buffer, length);
-	__ASSERT_NO_MSG(!status);
+	/*
+	 * TRNG_GetRandomData() writes random data in 32-bit word
+	 * granularity. With TRNG_SW_HEALTH_TESTS enabled the SDK always
+	 * copies full words, which overflows a caller buffer whose length
+	 * is not a multiple of 4 bytes.
+	 *
+	 * Process an unaligned prefix through a bounce word, followed by
+	 * the aligned bulk directly, and finally a non-word-size tail
+	 * through the bounce word. This keeps the number of SDK calls low
+	 * without allowing an unaligned store or an overrun of the caller
+	 * buffer.
+	 */
+	if ((length > 0U) &&
+	    ((uintptr_t)buffer % sizeof(uint32_t) != 0U)) {
+		uint32_t word;
+		uint16_t leading = sizeof(word) -
+			((uintptr_t)buffer % sizeof(word));
+
+		leading = MIN(length, leading);
+		status = TRNG_GetRandomData(config->base, &word, sizeof(word));
+		__ASSERT_NO_MSG(!status);
+		memcpy(buffer, &word, leading);
+		buffer += leading;
+		length -= leading;
+	}
+
+	if (length >= sizeof(uint32_t)) {
+		uint16_t aligned = length & ~0x3U;
+
+		status = TRNG_GetRandomData(config->base, buffer, aligned);
+		__ASSERT_NO_MSG(!status);
+		buffer += aligned;
+		length -= aligned;
+	}
+
+	if (length > 0U) {
+		uint32_t word;
+
+		status = TRNG_GetRandomData(config->base, &word, sizeof(word));
+		__ASSERT_NO_MSG(!status);
+		memcpy(buffer, &word, length);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Backport of the fix from #115767 to `v4.3-branch`.

Fixes: #115591