### PR TITLE
nxp: imxrt: fix dtsi include paths after reorg

### DIFF
--- a/boards/nxp/frdm_imxrt1152/frdm_imxrt1152.dts
+++ b/boards/nxp/frdm_imxrt1152/frdm_imxrt1152.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/imxrt/nxp_rt1152.dtsi>
+#include <nxp/imxrt/imxrt11xx/nxp_rt1152.dtsi>
 #include "frdm_imxrt1152-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 

--- a/boards/nxp/frdm_imxrt700/frdm_imxrt700_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/frdm_imxrt700/frdm_imxrt700_mimxrt798s_cm33_cpu0.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi>
+#include <nxp/imxrt/imxrt7xx/nxp_rt7xx_cm33_cpu0.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "frdm_imxrt700-pinctrl.dtsi"
 

--- a/boards/nxp/frdm_imxrt700/frdm_imxrt700_mimxrt798s_cm33_cpu1.dts
+++ b/boards/nxp/frdm_imxrt700/frdm_imxrt700_mimxrt798s_cm33_cpu1.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi>
+#include <nxp/imxrt/imxrt7xx/nxp_rt7xx_cm33_cpu1.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "frdm_imxrt700-pinctrl.dtsi"
 

--- a/dts/arm/nxp/imxrt/imxrt11xx/nxp_rt1151.dtsi
+++ b/dts/arm/nxp/imxrt/imxrt11xx/nxp_rt1151.dtsi
@@ -7,10 +7,10 @@
 /* SOC DTS for the single Cortex-M7 core i.MX RT1151 */
 
 /* Include the shared RT11xx series devicetree for the Cortex-M7 core */
-#include <nxp/imxrt/nxp_rt11xx_cm7.dtsi>
+#include <nxp/imxrt/imxrt11xx/nxp_rt11xx_cm7.dtsi>
 
 /* Includes the specifics for the RT1150 family */
-#include <nxp/imxrt/nxp_rt115x.dtsi>
+#include <nxp/imxrt/imxrt11xx/nxp_rt115x.dtsi>
 
 /*
  * The RT1151 additionally has no parallel camera interface (CSI),

--- a/dts/arm/nxp/imxrt/imxrt11xx/nxp_rt1152.dtsi
+++ b/dts/arm/nxp/imxrt/imxrt11xx/nxp_rt1152.dtsi
@@ -7,7 +7,7 @@
 /* SOC DTS for the single Cortex-M7 core i.MX RT1152 */
 
 /* Include the shared RT11xx series devicetree for the Cortex-M7 core */
-#include <nxp/imxrt/nxp_rt11xx_cm7.dtsi>
+#include <nxp/imxrt/imxrt11xx/nxp_rt11xx_cm7.dtsi>
 
 /* Includes the specifics for the RT1150 family */
-#include <nxp/imxrt/nxp_rt115x.dtsi>
+#include <nxp/imxrt/imxrt11xx/nxp_rt115x.dtsi>

--- a/dts/arm/nxp/imxrt/imxrt11xx/nxp_rt115x.dtsi
+++ b/dts/arm/nxp/imxrt/imxrt11xx/nxp_rt115x.dtsi
@@ -11,7 +11,7 @@
  * nxp_rt1151.dtsi and nxp_rt1152.dtsi.
  */
 
-#include <nxp/imxrt/nxp_rt11xx.dtsi>
+#include <nxp/imxrt/imxrt11xx/nxp_rt11xx.dtsi>
 
 /* Configure ARM PLL to 798MHz (24MHz * 133 / (2 * 2)) */
 &arm_pll {


### PR DESCRIPTION
- **dts: nxp: imxrt: move imxrt115x dtsi files into imxrt11xx/ subdirectory**
- **boards: nxp: frdm_imxrt700: fix dtsi include paths after reorg**
