### PR TITLE
Bluetooth: CAP: fix function names in disconnect handling

### DIFF
--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -280,7 +280,7 @@ static void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
 		bt_cap_common_abort_proc(conn, -ECONNRESET);
 
 #if defined(CONFIG_BT_CAP_INITIATOR_UNICAST)
-		if (active_proc_is_initiator()) {
+		if (bt_cap_common_active_proc_is_initiator()) {
 			/* For Initiator procedures, we may have multiple procedures per connection,
 			 * so loop through and count the ones that we consider "done"
 			 */
@@ -303,7 +303,7 @@ static void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
 		}
 #endif /* CONFIG_BT_CAP_INITIATOR_UNICAST */
 #if defined(CONFIG_BT_CAP_COMMANDER)
-		if (active_proc_is_commander()) {
+		if (bt_cap_common_active_proc_is_commander()) {
 			/* For Commander procedures there is a 1:1 between number of procedures and
 			 * connections, so we always just increment by 1
 			 */


### PR DESCRIPTION
Commit 6c461f291f7 ("Bluetooth: CAP: Handle disconnects during
procedures") added calls to active_proc_is_initiator() and
active_proc_is_commander() in bt_cap_common_disconnected(), but no
such functions exist; the actual helpers are prefixed with
bt_cap_common_. This fails the build with an implicit function
declaration error (-Werror) whenever CONFIG_BT_CAP_INITIATOR_UNICAST
or CONFIG_BT_CAP_COMMANDER is enabled, breaking the bsim audio tests
in push CI on main.

Use the correctly prefixed function names.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
