### PR TITLE
drivers: timer: mchp_pit_g1: use zephyr/sys/clock.h

### DIFF
--- a/drivers/timer/mchp_pit_g1_timer.c
+++ b/drivers/timer/mchp_pit_g1_timer.c
@@ -13,7 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 BUILD_ASSERT(0, "PIT driver for tickless kernel support DOES NOT implemented yet!");


### PR DESCRIPTION
The PIT driver (d8e551cee2c) includes the deprecated
zephyr/sys_clock.h header, which since 5b2fd0761d8 emits a
deprecation warning. With -Werror=cpp in CI this fails the build of
every configuration for the sama5d27 boards, which are the only
users of this driver.

Include zephyr/sys/clock.h instead, which is where the sys_clock
API lives since the headers were merged in c08544a87bb.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
