### PR TITLE
samples: infineon soc low power modes demo (psc3)

### DIFF
--- a/samples/boards/infineon/low_power_modes/CMakeLists.txt
+++ b/samples/boards/infineon/low_power_modes/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(low_power_modes)
+
+target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE src/main_dut.c)
+target_sources(app PRIVATE src/peripherals.c)

--- a/samples/boards/infineon/low_power_modes/Kconfig
+++ b/samples/boards/infineon/low_power_modes/Kconfig
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Infineon low-power modes sample"
+
+# The sample builds a single device-under-test (DUT) image that drives the
+# power-management sequence and exercises each peripheral's pm_action.
+# APP_DEEP_MODES gates the deeper phases.
+
+config APP_ROLE_DUT
+	bool "Build the device-under-test application"
+	default y
+	help
+	  Build main_dut.c: the application that drives the power-management test
+	  sequence and exercises each peripheral's pm_action callback.
+
+config APP_DEEP_MODES
+	bool "Exercise the retained and power-down deep sleep modes"
+	depends on APP_ROLE_DUT
+	help
+	  Run the DeepSleep-RAM, DeepSleep-OFF and hibernate phases in addition to
+	  regular DeepSleep. Leave disabled on targets whose SoC power management
+	  only implements regular DeepSleep.
+
+source "Kconfig.zephyr"

--- a/samples/boards/infineon/low_power_modes/README.rst
+++ b/samples/boards/infineon/low_power_modes/README.rst
@@ -1,0 +1,125 @@
+.. _ifx_low_power_modes:
+
+Infineon Low-Power Modes
+########################
+
+Overview
+********
+
+This sample exercises the low-power (DeepSleep) modes of an Infineon SoC and
+confirms that on-board peripherals recover after each transition.  In DeepSleep
+the high-frequency clocks are gated, so peripheral blocks stop; every driver
+implements a device ``pm_action`` callback that re-arms its hardware on wake, so
+the application does not reconfigure anything itself.
+
+The power modes exercised, from shallowest to deepest, are:
+
+* **Runtime idle** - CPU WFI sleep with the clocks still running.
+* **DeepSleep** (suspend-to-idle) - high-frequency clocks gated; SRAM and
+  peripheral state retained; wake resumes in-session.
+* **DeepSleep-RAM** (suspend-to-ram) - deeper retention with a warm boot on wake;
+  drivers are re-initialized from their ``pm_action`` callbacks.
+* **DeepSleep-OFF / hibernate** - the terminal power-down modes; wake is a cold
+  boot triggered by the wake button, so they end the run.
+
+A set of on-board peripherals (PWM, counter, and, depending on the board,
+communication and analog blocks) is self-tested at startup and again after each
+wake. The set is defined by the board devicetree, so it varies per silicon; a
+peripheral absent from the devicetree is compiled out and skipped. A matching
+result after wake confirms that peripheral's ``pm_action`` restored it.
+
+On the ``kit_psc3m5_evk`` the self-tested peripherals are a PWM LED (P4.0), a
+free-running counter, an SPI loopback (SCB2), an I2C probe (SCB0) and a second
+UART loopback (SCB4).  The SPI and UART loopbacks need jumper wires:
+
+* **SPI loopback** - bridge P7.1 (MOSI) to P7.2 (MISO).
+* **UART loopback** - bridge P3.3 (TX) to P3.2 (RX).
+
+The I2C probe uses the kit's I2C header (P9.0 SCL / P9.2 SDA, with board
+pull-ups) and reads a register at address ``0x68``; with no device on the bus it
+reports no-response consistently, which still exercises the block across
+DeepSleep.  The PSC3M5 has no SDHC, DMIC (PDM) or I2S hardware block, so those
+peripherals are absent from the devicetree and are not exercised.
+
+Configuration
+*************
+
+The sample builds a single device-under-test image (``src/main_dut.c``) that
+drives the power-mode sequence and the peripheral self-tests.  One capability
+option gates the deeper behavior:
+
+* ``CONFIG_APP_DEEP_MODES`` - run DeepSleep-RAM and the terminal power-down modes
+  (DeepSleep-OFF / hibernate) in addition to regular DeepSleep.  Leave it
+  disabled on a target whose power management only implements regular DeepSleep.
+
+Sequence
+********
+
+* **Phase 1 - runtime idle only.** DeepSleep is locked out via the PM policy, so
+  the core only enters WFI sleep with clocks running.
+* **Phase 2 - deep sleep.** The PM policy is allowed to select DeepSleep, then
+  (when supported) DeepSleep-RAM, and finally the terminal power-down mode.  The
+  LED thread is suspended so idle periods are long enough for the policy to
+  choose the mode; after each in-session wake the sample re-tests every
+  peripheral and reports the result.
+
+UART output and deepsleep entry
+*******************************
+
+The UART output (printk) in this sample can block the device from entering
+DeepSleep. ``printk`` is synchronous and the console UART driver refuses to
+suspend while a transmission is in flight, so pending output reaches the wire
+before the clocks are gated. The output generated on a USER button press can be
+used to illustrate this; it may take several presses to observe.
+
+Supported SoCs
+**************
+
+The following SoCs are supported by this sample code:
+
+* infineon/cat1b/psc3
+
+Building and Running
+********************
+
+Make sure to reset the board after programming (XRES) to ensure that the
+debugger is not attached, as this prevents the device from entering deep sleep.
+
+.. code-block:: console
+
+   west build -p auto -b kit_psc3m5_evk/psc3m5fds2afq1 \
+     samples/boards/infineon/low_power_modes
+   west flash
+
+Sample Output
+=============
+
+To check output of this sample, open a serial console, and select the proper COM port
+(i.e. on Linux minicom, putty, screen, etc).
+
+The console output should look approximately like this:
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build ***
+   PWM blue LED started at 2 Hz
+   Free-running counter started
+   Phase 1: runtime-idle only
+   Sleep: 5 | Deepsleep: 0
+   Phase 2: run each low-power mode in sequence
+   Phase 2: exercising DeepSleep
+   Phase 2: enter DeepSleep (counter=12345, watch blue LED freeze)
+   Phase 2: woke after 2000 ms
+   Sleep: 5 | Deepsleep: 1
+   Phase 2: exercising DeepSleep-RAM
+   Phase 2: enter DeepSleep-RAM (counter=23456, watch blue LED freeze)
+   Phase 2: woke after 2000 ms
+   Sleep: 5 | Deepsleep: 1
+   Phase 2: exercising DeepSleep-OFF
+   Phase 2: entering DeepSleep-OFF. Press the button to wake/reset.
+   Sequence complete
+
+The per-mode peripheral self-test lines between the wake messages depend on the
+board devicetree and are omitted here.  When ``CONFIG_APP_DEEP_MODES`` is
+disabled, the DeepSleep-RAM and terminal power-down lines are replaced by a
+single ``regular DeepSleep only`` notice.

--- a/samples/boards/infineon/low_power_modes/boards/kit_psc3m5_evk_psc3m5fds2afq1.conf
+++ b/samples/boards/infineon/low_power_modes/boards/kit_psc3m5_evk_psc3m5fds2afq1.conf
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Single-core (CM33) DUT configuration for the low-power modes sample on the
+# PSC3M5 EVK, a single-core part that owns all power-management registers.
+CONFIG_COUNTER=y
+
+# PWM LED (P4.0): stops during DeepSleep and resumes on wake via pm_action.
+CONFIG_PWM=y
+
+# SCB blocks self-tested across DeepSleep (pins and loopback jumpers in the
+# board overlay). SDHC, DMIC and I2S have no block on the PSC3M5, so they are
+# absent from the devicetree and compiled out.
+CONFIG_SPI=y
+CONFIG_I2C=y
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# DataWire DMA0, exercised by a software-triggered memory-to-memory copy.
+CONFIG_DMA=y
+
+# CAN FD channel (can1) self-tested in internal loopback, so no transceiver or
+# bus wiring is required. A DeepSleep-RAM warm boot re-powers the Message RAM
+# and re-initializes the channel.
+CONFIG_CAN=y
+
+# Run each peripheral's SUSPEND/RESUME pm_action around a regular DeepSleep.
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_SYSTEM_MANAGED=y
+
+# Let the I2C, SPI and UART drivers block states that gate their SCB
+# mid-transfer via each node's zephyr,disabling-power-states (board overlay).
+# The UART locks only for a TX drain, so RX can still act as a wake source.
+CONFIG_PM_POLICY_DEVICE_CONSTRAINTS=y
+
+# The second UART (uart-test) opts into device runtime PM via
+# zephyr,pm-device-runtime-auto, balancing a get/put around each transfer.
+CONFIG_PM_DEVICE_RUNTIME=y
+
+# System-managed device PM runs SUSPEND/RESUME on the idle thread; enlarge its
+# stack so a driver re-init there does not overflow the default idle stack.
+CONFIG_IDLE_STACK_SIZE=2048
+
+# Run the DeepSleep-RAM, DeepSleep-OFF and Hibernate phases too. Enabling the
+# DeepSleep-RAM devicetree state (board overlay) auto-selects CONFIG_PM_S2RAM.
+CONFIG_APP_DEEP_MODES=y

--- a/samples/boards/infineon/low_power_modes/boards/kit_psc3m5_evk_psc3m5fds2afq1.overlay
+++ b/samples/boards/infineon/low_power_modes/boards/kit_psc3m5_evk_psc3m5fds2afq1.overlay
@@ -1,0 +1,251 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/*
+ * Single-core (CM33) overlay for the low-power modes sample on the PSC3M5 EVK.
+ * Wires two observable probes:
+ *
+ *   - A free-running 32-bit counter on TCPWM (counter0_0) as the clock-gating
+ *     probe: it runs from CLK_HF2 (peri group 4), so it freezes during
+ *     DeepSleep and the counter pm_action restarts it on wake.
+ *   - A PWM LED on P4.0 (TCPWM1 line 4) blinking at 2 Hz. The on-chip LEDs have
+ *     no TCPWM route, so connect an LED or scope to P4.0.
+ *
+ * Three SCB blocks are self-tested across DeepSleep (SDHC, DMIC and I2S have no
+ * block on this SoC and are absent):
+ *
+ *   - SPI on SCB2: loopback, jumper P7.1 (MOSI) to P7.2 (MISO).
+ *   - I2C on SCB0: single-register probe on the kit's header P9.0 (SCL) /
+ *     P9.2 (SDA). With no target it reports no-response consistently.
+ *   - UART on SCB4: interrupt-driven loopback on P3.3 (TX) / P3.2 (RX),
+ *     separate from the console; jumper P3.3 to P3.2.
+ */
+
+/ {
+	aliases {
+		counter0 = &counter0_0;
+		pwm-led0 = &pwm_led0;
+		uart-test = &uart4;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		status = "okay";
+
+		pwm_led0: pwm_led0 {
+			pwms = <&pwm1_4 0 PWM_MSEC(500) PWM_POLARITY_NORMAL>;
+			label = "PWM LED (P4.0)";
+		};
+	};
+};
+
+/*
+ * Arm the Hibernate wake source declaratively: the SoC power management reads
+ * this node at init, enables the input buffer on the armed pad and programs the
+ * SRSS wake registers. PIN0 = P2.0 = SW2, pressed low. PIN1 = P9.0 is the I2C
+ * SCL header pin, so it is not armed (arming it would self-wake).
+ */
+&hibernate_wakeup {
+	status = "okay";
+	wakeup-pin0-trigger = "low";
+};
+
+/*
+ * DeepSleep-RAM is disabled by default in the SoC devicetree. Enabling it here
+ * selects it explicitly; its "suspend-to-ram" power-state-name auto-selects
+ * CONFIG_PM_S2RAM. The default min-residency (2 s) equals the sample's 2 s
+ * sleep window, so lower it here so the state reliably engages.
+ */
+&deepsleep_ram {
+	status = "okay";
+	min-residency-us = <500000>;
+};
+
+/* Free-running 32-bit counter used to observe clock gating across DeepSleep.
+ * peri group 4 is a CLK_HF2 divider (80 MHz); divide to a 1 MHz tick.
+ */
+&peri0_group4_16bit_0 {
+	status = "okay";
+	clock-div = <80>;
+};
+
+&tcpwm0_0 {
+	status = "okay";
+
+	counter0_0 {
+		status = "okay";
+		clocks = <&peri0_group4_16bit_0>;
+	};
+};
+
+/*
+ * PWM LED on P4.0 (TCPWM1 line 4). tcpwm1_4 is a 16-bit counter, so feed it a
+ * slow clock: divide peri group 5 by 2000 to keep the 500 ms (2 Hz) blink
+ * within range. The PWM is suspended across DeepSleep and re-armed on wake.
+ */
+&peri0_group5_16bit_0 {
+	status = "okay";
+	clock-div = <2000>;
+};
+
+&tcpwm1_4 {
+	status = "okay";
+
+	pwm1_4: pwm1_4 {
+		status = "okay";
+		clocks = <&peri0_group5_16bit_0>;
+		pinctrl-0 = <&p4_0_pwm1_4>;
+		pinctrl-names = "default";
+	};
+};
+
+&pinctrl {
+	p4_0_pwm1_4: p4_0_pwm1_4 {
+		drive-push-pull;
+	};
+};
+
+&gpio_prt4 {
+	status = "okay";
+};
+
+/*
+ * SPI loopback self-test on SCB2 (port 7). Jumper P7.1 (MOSI) to P7.2 (MISO);
+ * P7.0 is the clock and P7.3 the chip-select. SCB2 is on CLK_HF2 (peri group
+ * 4).
+ */
+spi2: &scb2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	compatible = "infineon,spi";
+	status = "okay";
+
+	/* Keep the SoC out of states that gate SCB2 while a transfer is active. */
+	zephyr,disabling-power-states = <&deepsleep &deepsleep_ram>;
+
+	clocks = <&peri0_group4_16_5bit_1>;
+	pinctrl-0 = <&p7_1_scb2_spi_m_mosi &p7_2_scb2_spi_m_miso &p7_0_scb2_spi_m_clk>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio_prt7 3 GPIO_ACTIVE_LOW>;
+
+	loopback_dev: loopback@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&peri0_group4_16_5bit_1 {
+	status = "okay";
+};
+
+&p7_1_scb2_spi_m_mosi {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p7_2_scb2_spi_m_miso {
+	drive-strength = "full";
+	input-enable;
+};
+
+&p7_0_scb2_spi_m_clk {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&gpio_prt7 {
+	status = "okay";
+};
+
+/*
+ * I2C controller on SCB0, on the kit's header P9.0 (SCL) / P9.2 (SDA) with
+ * board pull-ups. The sample reads a single register at 0x68; with no device it
+ * reports no-response consistently. SCB0 is on CLK_HF2 (peri group 4).
+ */
+i2c0: &scb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	compatible = "infineon,i2c";
+	status = "okay";
+
+	/* Keep the SoC out of states that gate SCB0 while a transfer is active. */
+	zephyr,disabling-power-states = <&deepsleep &deepsleep_ram>;
+
+	clocks = <&peri0_group4_16_5bit_2>;
+	pinctrl-0 = <&p9_0_scb0_i2c_scl &p9_2_scb0_i2c_sda>;
+	pinctrl-names = "default";
+};
+
+&peri0_group4_16_5bit_2 {
+	status = "okay";
+};
+
+&p9_0_scb0_i2c_scl {
+	drive-open-drain;
+	input-enable;
+};
+
+&p9_2_scb0_i2c_sda {
+	drive-open-drain;
+	input-enable;
+};
+
+/*
+ * Second UART on SCB4, on the kit's P3.3 (TX) / P3.2 (RX) header pins and
+ * separate from the console. The only peripheral wired for device runtime PM
+ * (zephyr,pm-device-runtime-auto). Loopback jumper: P3.3 (TX) to P3.2 (RX).
+ * SCB4 is on CLK_HF2 (peri group 4).
+ */
+uart4: &scb4 {
+	compatible = "infineon,uart";
+	status = "okay";
+	current-speed = <115200>;
+	zephyr,pm-device-runtime-auto;
+
+	/* Block SCB4-gating states during a TX drain; RX stays a wake candidate. */
+	zephyr,disabling-power-states = <&deepsleep &deepsleep_ram>;
+
+	clocks = <&peri0_group4_8bit_1>;
+	pinctrl-0 = <&p3_3_scb4_uart_tx &p3_2_scb4_uart_rx>;
+	pinctrl-names = "default";
+};
+
+&peri0_group4_8bit_1 {
+	status = "okay";
+};
+
+&p3_3_scb4_uart_tx {
+	drive-push-pull;
+};
+
+&p3_2_scb4_uart_rx {
+	input-enable;
+};
+
+/*
+ * DataWire DMA0, exercised by a software-triggered memory-to-memory copy (DMIC
+ * and I2S, the usual DMA consumers, have no block on this SoC). The channel is
+ * disabled again once the copy completes.
+ */
+&dma0 {
+	status = "okay";
+};
+
+/*
+ * CAN FD channel 1 (can1), already enabled, clocked and pinned by the board
+ * devicetree and selected as chosen zephyr,canbus. The sample picks it up via
+ * DT_CHOSEN(zephyr_canbus) and drives it in internal loopback (TX routed to RX
+ * on-chip, self-acknowledged), so no transceiver or bus is required. The
+ * reference is made explicit so the node is visibly part of this overlay.
+ */
+&can1 {
+	status = "okay";
+};

--- a/samples/boards/infineon/low_power_modes/prj.conf
+++ b/samples/boards/infineon/low_power_modes/prj.conf
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Common configuration shared by the DUT and the companion image built from
+# this sample.  Target-specific peripheral and stack settings live in the
+# per-board files under boards/.
+CONFIG_GPIO=y
+CONFIG_PM=y
+CONFIG_HWINFO=y

--- a/samples/boards/infineon/low_power_modes/src/main.c
+++ b/samples/boards/infineon/low_power_modes/src/main.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+/*
+ * app_main (from main_dut.c) runs in a dedicated worker thread: its deep DS-RAM
+ * entry path and large on-stack driver-config structs need more than the
+ * default main stack.
+ */
+#define APP_THREAD_STACK_SIZE 8192
+#define APP_THREAD_PRIORITY   5
+
+void app_main(void);
+
+K_THREAD_STACK_DEFINE(app_thread_stack, APP_THREAD_STACK_SIZE);
+static struct k_thread app_thread;
+
+static void app_thread_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	app_main();
+}
+
+int main(void)
+{
+	k_thread_create(&app_thread, app_thread_stack, K_THREAD_STACK_SIZEOF(app_thread_stack),
+			app_thread_entry, NULL, NULL, NULL, APP_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	return 0;
+}

--- a/samples/boards/infineon/low_power_modes/src/main_dut.c
+++ b/samples/boards/infineon/low_power_modes/src/main_dut.c
@@ -1,0 +1,351 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_APP_ROLE_DUT)
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys/poweroff.h>
+
+#include <soc.h>
+
+#include "peripherals.h"
+
+#define MAIN_SLEEP_TIME_MS 2000
+
+#define PM_MODE_DS     0
+#define PM_MODE_DS_RAM 1
+#define PM_MODE_DS_OFF 2
+#define PM_MODE_HIB    3
+
+/* Idle window after which the displayed terminal mode is entered; a button
+ * press toggles between DeepSleep-OFF and hibernate (see run_terminal_mode()).
+ */
+#define TERMINAL_SELECT_TIMEOUT_MS 2000
+
+/* CONFIG_APP_DEEP_MODES gates the Phase-2 deep modes (DeepSleep-RAM and the
+ * terminal power-down modes); leave it off on targets that implement regular
+ * DeepSleep only.
+ */
+
+#define LED0_NODE DT_ALIAS(led0)
+
+static const struct gpio_dt_spec red_led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+#define SW0_NODE DT_ALIAS(sw0)
+#if !DT_NODE_HAS_STATUS(SW0_NODE, okay)
+#error "Unsupported board: sw0 devicetree alias is not defined"
+#endif
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(SW0_NODE, gpios);
+static struct gpio_callback button_cb_data;
+
+/* Dedicated Hibernate wake pad (sw1 alias). Only dedicated wake pads can wake
+ * from Hibernate, and the pad must be a digital input so its buffer feeds the
+ * always-on wake detector. The SoC selects the wake source; the pad is
+ * configured here via the normal GPIO driver.
+ */
+#define SW1_NODE DT_ALIAS(sw1)
+#if DT_NODE_HAS_STATUS(SW1_NODE, okay)
+static const struct gpio_dt_spec hib_wake = GPIO_DT_SPEC_GET(SW1_NODE, gpios);
+#endif
+
+/* Signalled from the button ISR; used to toggle the terminal mode selection. */
+K_SEM_DEFINE(button_sem, 0, 1);
+
+static uint32_t sleep_count;
+static uint32_t deepsleep_count;
+static uint32_t deepsleep_ram_count;
+
+static void pm_notifier_entry(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		sleep_count++;
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		deepsleep_count++;
+		break;
+	case PM_STATE_SUSPEND_TO_RAM:
+		deepsleep_ram_count++;
+		break;
+	default:
+		break;
+	}
+}
+
+static struct pm_notifier pm_notif = {
+	.state_entry = pm_notifier_entry,
+};
+
+static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	printk("Button pressed at %" PRIu32 "\n", k_cycle_get_32());
+	k_sem_give(&button_sem);
+}
+
+static void print_pm_counts(void)
+{
+	printk("Sleep: %u | Deepsleep: %u\n", sleep_count, deepsleep_count);
+}
+
+/* PM entry count for a deep state, used to confirm it actually engaged. */
+static uint32_t pm_state_entry_count(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		return deepsleep_count;
+	case PM_STATE_SUSPEND_TO_RAM:
+		return deepsleep_ram_count;
+	default:
+		return 0;
+	}
+}
+
+/* Run one retained/warm-boot mode (DeepSleep or DeepSleep-RAM): unlock its PM
+ * policy state, sleep once, re-test every peripheral after wake, then restore
+ * the lock so the next mode starts from a known state.
+ */
+static void run_retained_mode_test(enum pm_state test_state, const char *name)
+{
+	printk("Phase 2: exercising %s\n", name);
+
+	pm_policy_state_lock_put(test_state, PM_ALL_SUBSTATES);
+
+	uint32_t cnt_before = peripherals_counter_read();
+	uint32_t entries_before = pm_state_entry_count(test_state);
+
+	printk("Phase 2: enter %s (counter=%u, watch blue LED freeze)\n", name, cnt_before);
+
+	uint32_t t0 = k_uptime_get_32();
+
+	k_msleep(MAIN_SLEEP_TIME_MS);
+
+	uint32_t t1 = k_uptime_get_32();
+
+	/*
+	 * No manual rebuild needed: the SoC restores every power-cycled peripheral
+	 * (including the console UART) from the DeepSleep-RAM resume path before
+	 * control returns here.
+	 */
+	printk("Phase 2: woke after %u ms\n", t1 - t0);
+	print_pm_counts();
+
+	/* Confirm the state engaged; on a platform that only supports a shallower
+	 * mode the policy falls back and the entry count does not advance.
+	 */
+	if (pm_state_entry_count(test_state) == entries_before) {
+		printk("Phase 2: WARNING - %s did not engage; platform fell back to a "
+		       "shallower state\n",
+		       name);
+	}
+
+	/* Re-test every present peripheral now that the clocks are back. */
+	peripherals_test_after_wake(name);
+
+	/* Re-lock the mode (HF clocks stay on) and hold. The blue LED blinking here
+	 * confirms the PWM channel was rebuilt after wake. Leave the lock held so
+	 * the next mode starts from a known state.
+	 */
+	pm_policy_state_lock_get(test_state, PM_ALL_SUBSTATES);
+	printk("Phase 2: watch blue LED blink (PWM resumed via pm_action)\n");
+	k_msleep(MAIN_SLEEP_TIME_MS);
+}
+
+#if defined(CONFIG_APP_DEEP_MODES)
+
+/* Runtime-selected terminal power-down mode; toggled by the button. */
+static uint32_t terminal_pm_mode = PM_MODE_DS_OFF;
+
+static const char *terminal_mode_name(uint32_t mode)
+{
+	return (mode == PM_MODE_HIB) ? "Hibernate" : "DeepSleep-OFF";
+}
+
+/* Terminal mode: DeepSleep-OFF. Powers the CPU domain down; wake is a cold
+ * boot, so this does not return on success.
+ */
+static void run_ds_off_mode(void)
+{
+	printk("Phase 2: exercising DeepSleep-OFF\n");
+
+	printk("Phase 2: entering DeepSleep-OFF. Press the button to wake/reset.\n");
+
+	pm_state_set(PM_STATE_SOFT_OFF, 1);
+
+	__enable_irq();
+	printk("Phase 2: DeepSleep-OFF did not engage\n");
+}
+
+/* Terminal mode: hibernate. Powers the whole chip down; wake is a button cold
+ * boot, so this does not return. The active-low wake source is armed by the SoC
+ * from the devicetree hibernate-wakeup node; the app only configures the pad as
+ * a GPIO input.
+ */
+static void run_hibernate_mode(void)
+{
+	int ret;
+
+	printk("Phase 2: exercising Hibernate\n");
+
+	if (!gpio_is_ready_dt(&button)) {
+		printk("Error: button device %s is not ready\n", button.port->name);
+		return;
+	}
+	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+	if (ret != 0) {
+		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
+		       button.pin);
+		return;
+	}
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
+		       button.port->name, button.pin);
+		return;
+	}
+
+	printk("Phase 2: entering hibernate. Press the wake button to wake/reset.\n");
+
+	/* Configure the wake pad as a digital input so its pull-up holds it inactive
+	 * and its buffer feeds the wake detector. Any second hibernate pad that is
+	 * unconnected on the board is left unarmed (it would self-wake).
+	 */
+#if DT_NODE_HAS_STATUS(SW1_NODE, okay)
+	if (gpio_is_ready_dt(&hib_wake)) {
+		ret = gpio_pin_configure_dt(&hib_wake, GPIO_INPUT);
+		if (ret != 0) {
+			printk("Error %d: failed to configure hibernate wake pin %d\n", ret,
+			       hib_wake.pin);
+		}
+	}
+#endif
+
+	pm_state_set(PM_STATE_SOFT_OFF, 0);
+
+	__enable_irq();
+	printk("Phase 2: Hibernate did not engage\n");
+}
+
+/* Let the operator pick the terminal mode: each button press toggles
+ * DeepSleep-OFF / hibernate; the displayed mode is entered after
+ * TERMINAL_SELECT_TIMEOUT_MS idle. Entering it powers the SoC down and ends
+ * the run.
+ */
+static void run_terminal_mode(void)
+{
+	printk("Phase 2: press the button to toggle the terminal mode "
+	       "(entered after %d ms idle)\n",
+	       TERMINAL_SELECT_TIMEOUT_MS);
+	printk("Phase 2: terminal mode = %s\n", terminal_mode_name(terminal_pm_mode));
+
+	/* Ignore any press latched during the earlier tests. */
+	k_sem_reset(&button_sem);
+
+	while (k_sem_take(&button_sem, K_MSEC(TERMINAL_SELECT_TIMEOUT_MS)) == 0) {
+		terminal_pm_mode =
+			(terminal_pm_mode == PM_MODE_DS_OFF) ? PM_MODE_HIB : PM_MODE_DS_OFF;
+		printk("Phase 2: terminal mode = %s\n", terminal_mode_name(terminal_pm_mode));
+	}
+
+	if (terminal_pm_mode == PM_MODE_HIB) {
+		run_hibernate_mode();
+	} else {
+		run_ds_off_mode();
+	}
+}
+
+#endif /* CONFIG_APP_DEEP_MODES */
+
+static int test_pm(void)
+{
+	int ret;
+
+	if (!gpio_is_ready_dt(&red_led)) {
+		return 0;
+	}
+	ret = gpio_pin_configure_dt(&red_led, GPIO_OUTPUT_INACTIVE);
+	if (ret < 0) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(&button)) {
+		printk("Error: button device %s is not ready\n", button.port->name);
+		return 0;
+	}
+	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+	if (ret != 0) {
+		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
+		       button.pin);
+		return 0;
+	}
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
+		       button.port->name, button.pin);
+		return 0;
+	}
+	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
+	gpio_add_callback(button.port, &button_cb_data);
+
+	/* Configure every present peripheral and run its baseline self-test; absent
+	 * peripherals are compiled out in peripherals.c.
+	 */
+	peripherals_setup();
+
+	/* Leave the DeepSleep mode selection to the SoC's pm_state_set(); do not
+	 * override it here.
+	 */
+
+	pm_notifier_register(&pm_notif);
+
+	/*
+	 * Phase 1: runtime-idle only (WFI, clocks running). DeepSleep is locked
+	 * out, so the LED keeps blinking and the counter keeps advancing.
+	 */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+
+	printk("Phase 1: runtime-idle only\n");
+	k_msleep(MAIN_SLEEP_TIME_MS);
+	print_pm_counts();
+
+	/*
+	 * Phase 2: exercise the deep sleep modes. Suspend long enough for the
+	 * policy to select the mode, then re-test every peripheral after wake.
+	 */
+	printk("Phase 2: run each low-power mode in sequence\n");
+
+	/* DeepSleep and DeepSleep-RAM return in-session, so run them back to back. */
+	run_retained_mode_test(PM_STATE_SUSPEND_TO_IDLE, "DeepSleep");
+
+#if defined(CONFIG_APP_DEEP_MODES)
+	run_retained_mode_test(PM_STATE_SUSPEND_TO_RAM, "DeepSleep-RAM");
+
+	/* The terminal mode powers the SoC down (button cold boot) and ends the
+	 * run; the button also selects DeepSleep-OFF vs hibernate.
+	 */
+	run_terminal_mode();
+#else
+	printk("Phase 2: DeepSleep-RAM and terminal power-down skipped "
+	       "(regular DeepSleep only)\n");
+#endif /* CONFIG_APP_DEEP_MODES */
+
+	printk("Sequence complete\n");
+
+	return 0;
+}
+
+/* DUT entry, invoked from the worker thread in main.c. */
+void app_main(void)
+{
+	(void)test_pm();
+}
+
+#endif /* CONFIG_APP_ROLE_DUT */

--- a/samples/boards/infineon/low_power_modes/src/peripherals.c
+++ b/samples/boards/infineon/low_power_modes/src/peripherals.c
@@ -1,0 +1,778 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_APP_ROLE_DUT)
+
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2s.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/sdhc.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/drivers/can.h>
+#include <zephyr/audio/dmic.h>
+#include <string.h>
+
+#include "peripherals.h"
+
+/*
+ * Per-peripheral presence guards: each peripheral compiles in only when its
+ * devicetree node is present, so this file adapts to boards with a different
+ * subset of peripherals.
+ */
+#define PERIPH_HAS_PWM     DT_NODE_HAS_STATUS(DT_ALIAS(pwm_led0), okay)
+#define PERIPH_HAS_COUNTER DT_NODE_HAS_STATUS(DT_ALIAS(counter0), okay)
+#define PERIPH_HAS_SPI     DT_NODE_HAS_STATUS(DT_NODELABEL(loopback_dev), okay)
+#define PERIPH_HAS_I2C     DT_NODE_HAS_STATUS(DT_NODELABEL(i2c0), okay)
+#define PERIPH_HAS_DMIC    DT_NODE_HAS_STATUS(DT_NODELABEL(dmic0), okay)
+#define PERIPH_HAS_I2S     DT_NODE_HAS_STATUS(DT_ALIAS(i2s_tx), okay)
+#define PERIPH_HAS_SDHC    DT_NODE_HAS_STATUS(DT_NODELABEL(sdhc1), okay)
+#define PERIPH_HAS_UART    DT_NODE_HAS_STATUS(DT_ALIAS(uart_test), okay)
+#define PERIPH_HAS_DMA     DT_NODE_HAS_STATUS(DT_NODELABEL(dma0), okay)
+#define PERIPH_HAS_CAN     DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_canbus), okay)
+
+#if PERIPH_HAS_PWM
+static const struct pwm_dt_spec pwm_led = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
+#endif
+
+#if PERIPH_HAS_COUNTER
+static const struct device *const counter_dev = DEVICE_DT_GET(DT_ALIAS(counter0));
+#endif
+
+#if PERIPH_HAS_SPI
+#define SPI_LOOPBACK_NODE DT_NODELABEL(loopback_dev)
+static const struct spi_dt_spec spi_loopback =
+	SPI_DT_SPEC_GET(SPI_LOOPBACK_NODE, SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB);
+
+/* SPI loopback self-test: sends a pattern over a MOSI-to-MISO jumper and checks
+ * it returns. Run before/after DeepSleep.
+ */
+static int spi_loopback_test(void)
+{
+	static const uint8_t tx_data[] = {0xA5, 0x5A, 0x00, 0xFF, 0x12, 0x34, 0x56, 0x78};
+	uint8_t rx_data[sizeof(tx_data)] = {0};
+	const struct spi_buf tx_buf = {.buf = (void *)tx_data, .len = sizeof(tx_data)};
+	const struct spi_buf rx_buf = {.buf = rx_data, .len = sizeof(rx_data)};
+	const struct spi_buf_set tx_set = {.buffers = &tx_buf, .count = 1};
+	const struct spi_buf_set rx_set = {.buffers = &rx_buf, .count = 1};
+	int ret;
+
+	ret = spi_transceive_dt(&spi_loopback, &tx_set, &rx_set);
+	if (ret < 0) {
+		printk("SPI: transceive failed (%d)\n", ret);
+		return ret;
+	}
+
+	if (memcmp(tx_data, rx_data, sizeof(tx_data)) != 0) {
+		printk("SPI loopback: MISMATCH (check the MOSI-to-MISO jumper)\n");
+		return -EIO;
+	}
+
+	printk("SPI loopback: OK (%u bytes matched)\n", (unsigned int)sizeof(tx_data));
+	return 0;
+}
+#endif /* PERIPH_HAS_SPI */
+
+#if PERIPH_HAS_I2C
+/* I2C single-register probe at a fixed address, repeated after each DeepSleep
+ * wake. If no device answers it reports no-response consistently.
+ */
+#define I2C_BUS_NODE DT_NODELABEL(i2c0)
+static const struct device *const i2c_dev = DEVICE_DT_GET(I2C_BUS_NODE);
+#define I2C_PROBE_ADDR 0x68U
+#define I2C_PROBE_REG  0x00U
+
+static int i2c_probe_test(void)
+{
+	uint8_t chip_id = 0;
+	int ret;
+
+	ret = i2c_reg_read_byte(i2c_dev, I2C_PROBE_ADDR, I2C_PROBE_REG, &chip_id);
+	if (ret < 0) {
+		printk("I2C probe: addr 0x%02x no response (%d)\n", I2C_PROBE_ADDR, ret);
+		return ret;
+	}
+
+	printk("I2C probe: addr 0x%02x reg 0x%02x = 0x%02x\n", I2C_PROBE_ADDR, I2C_PROBE_REG,
+	       chip_id);
+	return 0;
+}
+#endif /* PERIPH_HAS_I2C */
+
+#if PERIPH_HAS_DMIC
+/* PDM microphone stream via DMA. One mono stream is a liveness check run
+ * before/after each DeepSleep.
+ */
+#define DMIC_NODE DT_NODELABEL(dmic0)
+static const struct device *const dmic_dev = DEVICE_DT_GET(DMIC_NODE);
+#define DMIC_SAMPLE_RATE      16000U
+#define DMIC_SAMPLE_BITS      16U
+#define DMIC_HW_CHAN_IDX      1U
+#define DMIC_BYTES_PER_SAMPLE (DMIC_SAMPLE_BITS / 8U)
+/* One block holds 100 ms of mono audio. */
+#define DMIC_BLOCK_SIZE       (DMIC_BYTES_PER_SAMPLE * (DMIC_SAMPLE_RATE / 10U))
+#define DMIC_BLOCK_COUNT      4U
+#define DMIC_READ_TIMEOUT     1000
+K_MEM_SLAB_DEFINE_STATIC(dmic_mem_slab, DMIC_BLOCK_SIZE, DMIC_BLOCK_COUNT, 4);
+
+/* DMIC self-test: configure a mono stream, start it, read one 100 ms block,
+ * then stop. Liveness check: if configure+START are accepted the block and its
+ * DMA channel came up; a read that only times out still counts as alive.
+ */
+static int dmic_test(void)
+{
+	struct pcm_stream_cfg stream = {
+		.pcm_width = DMIC_SAMPLE_BITS,
+		.mem_slab = &dmic_mem_slab,
+	};
+	struct dmic_cfg cfg = {
+		.io = {
+			.min_pdm_clk_freq = 1000000,
+			.max_pdm_clk_freq = 3500000,
+			.min_pdm_clk_dc = 40,
+			.max_pdm_clk_dc = 60,
+		},
+		.streams = &stream,
+		.channel = {
+			.req_num_streams = 1,
+			.req_num_chan = 1,
+		},
+	};
+	void *buffer;
+	uint32_t size;
+	int ret;
+
+	cfg.channel.req_chan_map_lo = dmic_build_channel_map(0, DMIC_HW_CHAN_IDX, PDM_CHAN_LEFT);
+	cfg.streams[0].pcm_rate = DMIC_SAMPLE_RATE;
+	cfg.streams[0].block_size = DMIC_BLOCK_SIZE;
+
+	ret = dmic_configure(dmic_dev, &cfg);
+	if (ret < 0) {
+		printk("DMIC: configure failed (%d)\n", ret);
+		return ret;
+	}
+
+	ret = dmic_trigger(dmic_dev, DMIC_TRIGGER_START);
+	if (ret < 0) {
+		printk("DMIC: START trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	/* The block is alive from here: configure and START were accepted. */
+	ret = dmic_read(dmic_dev, 0, &buffer, &size, DMIC_READ_TIMEOUT);
+	if (ret == 0) {
+		printk("DMIC: alive, captured %u bytes\n", size);
+		k_mem_slab_free(&dmic_mem_slab, buffer);
+	} else if (ret == -EAGAIN) {
+		printk("DMIC: alive (configured + streaming), no block in %d ms\n",
+		       DMIC_READ_TIMEOUT);
+	} else {
+		printk("DMIC: read error (%d)\n", ret);
+	}
+
+	ret = dmic_trigger(dmic_dev, DMIC_TRIGGER_STOP);
+	if (ret < 0) {
+		printk("DMIC: STOP trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+#endif /* PERIPH_HAS_DMIC */
+
+#if PERIPH_HAS_I2S
+/* I2S transmitter via DMA in controller mode, so it self-clocks one block with
+ * no external codec. Run before/after each DeepSleep.
+ */
+#define I2S_NODE DT_ALIAS(i2s_tx)
+static const struct device *const i2s_dev = DEVICE_DT_GET(I2S_NODE);
+#define I2S_SAMPLE_RATE   44100U
+#define I2S_WORD_SIZE     16U
+#define I2S_CHANNELS      2U
+#define I2S_SAMPLES       64U
+/* One stereo block of 16-bit samples. */
+#define I2S_BLOCK_SIZE    (I2S_SAMPLES * I2S_CHANNELS * sizeof(int16_t))
+#define I2S_BLOCK_COUNT   4U
+#define I2S_WRITE_TIMEOUT 1000
+K_MEM_SLAB_DEFINE_STATIC(i2s_mem_slab, I2S_BLOCK_SIZE, I2S_BLOCK_COUNT, 4);
+
+/* I2S self-test: configure TX as controller, queue one block of silence, start,
+ * then DROP. DROP returns the stream to READY synchronously (unlike
+ * DRAIN/STOP), so it is never left RUNNING/STOPPING - which would veto every
+ * DeepSleep and reject the next i2s_configure().
+ */
+static int i2s_test(void)
+{
+	struct i2s_config i2s_cfg = {
+		.word_size = I2S_WORD_SIZE,
+		.channels = I2S_CHANNELS,
+		.format = I2S_FMT_DATA_FORMAT_I2S,
+		.options = I2S_OPT_FRAME_CLK_CONTROLLER | I2S_OPT_BIT_CLK_CONTROLLER,
+		.frame_clk_freq = I2S_SAMPLE_RATE,
+		.block_size = I2S_BLOCK_SIZE,
+		.mem_slab = &i2s_mem_slab,
+		.timeout = I2S_WRITE_TIMEOUT,
+	};
+	void *tx_block;
+	int ret;
+
+	ret = i2s_configure(i2s_dev, I2S_DIR_TX, &i2s_cfg);
+	if (ret < 0) {
+		printk("I2S: configure failed (%d)\n", ret);
+		return ret;
+	}
+
+	ret = k_mem_slab_alloc(&i2s_mem_slab, &tx_block, K_NO_WAIT);
+	if (ret < 0) {
+		printk("I2S: block alloc failed (%d)\n", ret);
+		return ret;
+	}
+	memset(tx_block, 0, I2S_BLOCK_SIZE);
+
+	ret = i2s_write(i2s_dev, tx_block, I2S_BLOCK_SIZE);
+	if (ret < 0) {
+		printk("I2S: write failed (%d)\n", ret);
+		k_mem_slab_free(&i2s_mem_slab, tx_block);
+		return ret;
+	}
+
+	ret = i2s_trigger(i2s_dev, I2S_DIR_TX, I2S_TRIGGER_START);
+	if (ret < 0) {
+		printk("I2S: START trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	/* Let the queued block clock out (one block is ~3 ms at 44.1 kHz). */
+	k_msleep(10);
+
+	/* DROP returns the stream to READY synchronously and frees queued buffers. */
+	ret = i2s_trigger(i2s_dev, I2S_DIR_TX, I2S_TRIGGER_DROP);
+	if (ret < 0) {
+		printk("I2S: DROP trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	printk("I2S transmit: OK (%u bytes)\n", (unsigned int)I2S_BLOCK_SIZE);
+	return 0;
+}
+#endif /* PERIPH_HAS_I2S */
+
+#if PERIPH_HAS_SDHC
+/* SD host controller self-test. Configures the block with no card required; run
+ * before/after each DeepSleep.
+ */
+#define SDHC_NODE DT_NODELABEL(sdhc1)
+static const struct device *const sdhc_dev = DEVICE_DT_GET(SDHC_NODE);
+
+/* SDHC self-test: read host properties and apply an I/O config (power on, min
+ * clock, 1-bit bus, 3.3 V), programming the block registers and clock divider.
+ */
+static int sdhc_test(void)
+{
+	struct sdhc_host_props props;
+	struct sdhc_io io = {0};
+	int present;
+	int ret;
+
+	ret = sdhc_get_host_props(sdhc_dev, &props);
+	if (ret < 0) {
+		printk("SDHC: get_host_props failed (%d)\n", ret);
+		return ret;
+	}
+
+	io.clock = props.f_min;
+	io.bus_mode = SDHC_BUSMODE_PUSHPULL;
+	io.power_mode = SDHC_POWER_ON;
+	io.bus_width = SDHC_BUS_WIDTH1BIT;
+	io.timing = SDHC_TIMING_LEGACY;
+	io.signal_voltage = SD_VOL_3_3_V;
+
+	ret = sdhc_set_io(sdhc_dev, &io);
+	if (ret < 0) {
+		printk("SDHC: set_io failed (%d)\n", ret);
+		return ret;
+	}
+
+	present = sdhc_card_present(sdhc_dev);
+	printk("SDHC host configured: OK (f_min %u Hz, card %s)\n", props.f_min,
+	       (present == 1) ? "present" : "absent");
+	return 0;
+}
+#endif /* PERIPH_HAS_SDHC */
+
+#if PERIPH_HAS_UART
+/* Second UART, separate from the console and the only peripheral using device
+ * runtime PM (zephyr,pm-device-runtime-auto): its interrupt-driven
+ * enable/disable paths take and drop a runtime reference. The loopback verifies
+ * a TX-to-RX jumper and drives the runtime PM get/put paths. Run before/after
+ * DeepSleep.
+ */
+#define UART_TEST_NODE DT_ALIAS(uart_test)
+static const struct device *const uart_test_dev = DEVICE_DT_GET(UART_TEST_NODE);
+
+static const uint8_t uart_test_tx[] = {0xC3, 0x3C, 0x00, 0xFF, 0xA5, 0x5A, 0x0F, 0xF0};
+static volatile uint8_t uart_test_rx[sizeof(uart_test_tx)];
+static volatile size_t uart_test_tx_idx;
+static volatile size_t uart_test_rx_idx;
+static K_SEM_DEFINE(uart_test_done, 0, 1);
+
+/* Interrupt-driven loopback ISR: fills TX from the pattern and drains RX. Each
+ * direction disables its own interrupt when done, dropping its runtime PM ref.
+ */
+static void uart_test_isr(const struct device *dev, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	uart_irq_update(dev);
+
+	while (uart_irq_is_pending(dev)) {
+		if (uart_irq_rx_ready(dev)) {
+			uint8_t c;
+
+			while ((uart_test_rx_idx < sizeof(uart_test_rx)) &&
+			       (uart_fifo_read(dev, &c, 1) == 1)) {
+				uart_test_rx[uart_test_rx_idx++] = c;
+			}
+
+			if (uart_test_rx_idx >= sizeof(uart_test_rx)) {
+				uart_irq_rx_disable(dev);
+				k_sem_give(&uart_test_done);
+			}
+		}
+
+		if (uart_irq_tx_ready(dev)) {
+			if (uart_test_tx_idx < sizeof(uart_test_tx)) {
+				uart_test_tx_idx += uart_fifo_fill(
+					dev, (const uint8_t *)&uart_test_tx[uart_test_tx_idx],
+					sizeof(uart_test_tx) - uart_test_tx_idx);
+			}
+
+			if ((uart_test_tx_idx >= sizeof(uart_test_tx)) &&
+			    uart_irq_tx_complete(dev)) {
+				uart_irq_tx_disable(dev);
+			}
+		}
+
+		uart_irq_update(dev);
+	}
+}
+
+/* UART loopback self-test: send the pattern (interrupt-driven) and check it
+ * returns. Requires a TX-to-RX jumper.
+ */
+static int uart_test(void)
+{
+	int ret;
+
+	uart_test_tx_idx = 0;
+	uart_test_rx_idx = 0;
+	memset((void *)uart_test_rx, 0, sizeof(uart_test_rx));
+	k_sem_reset(&uart_test_done);
+
+	ret = uart_irq_callback_user_data_set(uart_test_dev, uart_test_isr, NULL);
+	if (ret < 0) {
+		printk("UART: callback set failed (%d)\n", ret);
+		return ret;
+	}
+
+	uart_irq_rx_enable(uart_test_dev);
+	uart_irq_tx_enable(uart_test_dev);
+
+	if (k_sem_take(&uart_test_done, K_MSEC(100)) != 0) {
+		uart_irq_tx_disable(uart_test_dev);
+		uart_irq_rx_disable(uart_test_dev);
+		printk("UART loopback: TIMEOUT (check the TX-to-RX jumper)\n");
+		return -ETIMEDOUT;
+	}
+
+	if (memcmp((const void *)uart_test_rx, uart_test_tx, sizeof(uart_test_tx)) != 0) {
+		printk("UART loopback: MISMATCH (check the TX-to-RX jumper)\n");
+		return -EIO;
+	}
+
+	printk("UART loopback: OK (%u bytes matched)\n", (unsigned int)sizeof(uart_test_tx));
+	return 0;
+}
+#endif /* PERIPH_HAS_UART */
+
+#if PERIPH_HAS_DMA
+/* DMA memory-to-memory self-test: a software-triggered channel copies a pattern
+ * between two RAM buffers, so it needs no external wiring. Run before/after each
+ * DeepSleep.
+ */
+#define DMA_NODE DT_NODELABEL(dma0)
+static const struct device *const dma_dev = DEVICE_DT_GET(DMA_NODE);
+#define DMA_TEST_CHANNEL 0U
+#define DMA_XFER_SIZE    32U
+
+static K_SEM_DEFINE(dma_done, 0, 1);
+static volatile int dma_cb_status;
+
+static void dma_test_cb(const struct device *dev, void *user_data, uint32_t channel, int status)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(channel);
+
+	dma_cb_status = status;
+	k_sem_give(&dma_done);
+}
+
+static int dma_test(void)
+{
+	/* Source in RAM (.data) so the transfer is pure memory-to-memory. */
+	static uint8_t dma_src[DMA_XFER_SIZE] = {
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA,
+		0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x0F, 0x1E, 0x2D, 0x3C, 0x4B, 0x5A,
+		0x69, 0x78, 0x87, 0x96, 0xA5, 0xB4, 0xC3, 0xD2, 0xE1, 0xF0,
+	};
+	static uint8_t dma_dst[DMA_XFER_SIZE];
+	struct dma_block_config block = {
+		.source_address = (uint32_t)dma_src,
+		.dest_address = (uint32_t)dma_dst,
+		.block_size = DMA_XFER_SIZE,
+		.source_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
+	struct dma_config cfg = {
+		.channel_direction = MEMORY_TO_MEMORY,
+		.source_data_size = 1,
+		.dest_data_size = 1,
+		.block_count = 1,
+		.head_block = &block,
+		.dma_callback = dma_test_cb,
+	};
+	int ret;
+
+	memset(dma_dst, 0, sizeof(dma_dst));
+	k_sem_reset(&dma_done);
+
+	ret = dma_config(dma_dev, DMA_TEST_CHANNEL, &cfg);
+	if (ret < 0) {
+		printk("DMA: config failed (%d)\n", ret);
+		return ret;
+	}
+
+	ret = dma_start(dma_dev, DMA_TEST_CHANNEL);
+	if (ret < 0) {
+		printk("DMA: start failed (%d)\n", ret);
+		return ret;
+	}
+
+	if (k_sem_take(&dma_done, K_MSEC(100)) != 0) {
+		printk("DMA: TIMEOUT waiting for completion\n");
+		(void)dma_stop(dma_dev, DMA_TEST_CHANNEL);
+		return -ETIMEDOUT;
+	}
+
+	if (dma_cb_status < 0) {
+		printk("DMA: transfer error (%d)\n", dma_cb_status);
+		return dma_cb_status;
+	}
+
+	if (memcmp(dma_src, dma_dst, DMA_XFER_SIZE) != 0) {
+		printk("DMA mem-to-mem: MISMATCH\n");
+		return -EIO;
+	}
+
+	printk("DMA mem-to-mem: OK (%u bytes copied)\n", (unsigned int)DMA_XFER_SIZE);
+	return 0;
+}
+#endif /* PERIPH_HAS_DMA */
+
+#if PERIPH_HAS_CAN
+/* CAN FD in internal loopback, so no transceiver or bus wiring is needed. Sends
+ * one classic frame and receives it back through a msgq filter. Run before/after
+ * each DeepSleep; a DeepSleep-RAM warm boot re-powers the Message RAM and
+ * re-inits the channel.
+ */
+#define CAN_NODE DT_CHOSEN(zephyr_canbus)
+static const struct device *const can_dev = DEVICE_DT_GET(CAN_NODE);
+#define CAN_TEST_ID 0x123U
+CAN_MSGQ_DEFINE(can_test_msgq, 2);
+
+static int can_test(void)
+{
+	static const uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x23, 0x45, 0x67};
+	const struct can_filter filter = {
+		.id = CAN_TEST_ID,
+		.mask = CAN_STD_ID_MASK,
+		.flags = 0,
+	};
+	struct can_frame tx_frame = {
+		.id = CAN_TEST_ID,
+		.dlc = can_bytes_to_dlc(sizeof(payload)),
+		.flags = 0,
+	};
+	struct can_frame rx_frame;
+	int filter_id;
+	int ret;
+
+	memcpy(tx_frame.data, payload, sizeof(payload));
+
+	/* Internal loopback: TX is routed to RX on-chip with a self-generated ACK. */
+	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
+	if (ret < 0) {
+		printk("CAN: set_mode(LOOPBACK) failed (%d)\n", ret);
+		return ret;
+	}
+
+	ret = can_start(can_dev);
+	if (ret < 0) {
+		printk("CAN: start failed (%d)\n", ret);
+		return ret;
+	}
+
+	filter_id = can_add_rx_filter_msgq(can_dev, &can_test_msgq, &filter);
+	if (filter_id < 0) {
+		printk("CAN: add_rx_filter failed (%d)\n", filter_id);
+		(void)can_stop(can_dev);
+		return filter_id;
+	}
+
+	ret = can_send(can_dev, &tx_frame, K_MSEC(100), NULL, NULL);
+	if (ret < 0) {
+		printk("CAN: send failed (%d)\n", ret);
+		can_remove_rx_filter(can_dev, filter_id);
+		(void)can_stop(can_dev);
+		return ret;
+	}
+
+	ret = k_msgq_get(&can_test_msgq, &rx_frame, K_MSEC(100));
+	can_remove_rx_filter(can_dev, filter_id);
+	(void)can_stop(can_dev);
+	if (ret != 0) {
+		printk("CAN loopback: TIMEOUT (no frame received)\n");
+		return -ETIMEDOUT;
+	}
+
+	if ((rx_frame.id != tx_frame.id) || (rx_frame.dlc != tx_frame.dlc) ||
+	    (memcmp(rx_frame.data, payload, sizeof(payload)) != 0)) {
+		printk("CAN loopback: MISMATCH\n");
+		return -EIO;
+	}
+
+	printk("CAN loopback: OK (%u bytes matched)\n", (unsigned int)sizeof(payload));
+	return 0;
+}
+#endif /* PERIPH_HAS_CAN */
+
+void peripherals_setup(void)
+{
+#if PERIPH_HAS_PWM
+	/* PWM on blue LED at 2 Hz: it freezes during DeepSleep and resumes on wake
+	 * via the PWM pm_action.
+	 */
+	if (!pwm_is_ready_dt(&pwm_led)) {
+		printk("Error: PWM device not ready\n");
+	} else {
+		int ret = pwm_set_dt(&pwm_led, PWM_MSEC(500), PWM_MSEC(250));
+
+		if (ret < 0) {
+			printk("Error %d: failed to set PWM\n", ret);
+		} else {
+			printk("PWM blue LED started at 2 Hz\n");
+		}
+	}
+#endif
+
+#if PERIPH_HAS_COUNTER
+	/* Free-running counter: stops while HF clocks are gated, resumes on wake.
+	 * Reading the value across a sleep confirms it resumed.
+	 */
+	if (!device_is_ready(counter_dev)) {
+		printk("Error: counter device not ready\n");
+	} else {
+		int ret = counter_start(counter_dev);
+
+		if (ret < 0) {
+			printk("Error %d: failed to start counter\n", ret);
+		} else {
+			printk("Free-running counter started\n");
+		}
+	}
+#endif
+
+#if PERIPH_HAS_SPI
+	/* SPI loopback baseline. Requires a MOSI-to-MISO jumper. */
+	if (!spi_is_ready_dt(&spi_loopback)) {
+		printk("Error: SPI loopback device not ready\n");
+	} else {
+		printk("SPI loopback baseline:\n");
+		(void)spi_loopback_test();
+	}
+#endif
+
+#if PERIPH_HAS_I2C
+	/* I2C probe baseline. */
+	if (!device_is_ready(i2c_dev)) {
+		printk("Error: I2C bus %s not ready\n", i2c_dev->name);
+	} else {
+		printk("I2C probe baseline:\n");
+		(void)i2c_probe_test();
+	}
+#endif
+
+#if PERIPH_HAS_DMIC
+	/* DMIC capture baseline - captures one mono block from the PDM mic. */
+	if (!device_is_ready(dmic_dev)) {
+		printk("Error: DMIC device %s not ready\n", dmic_dev->name);
+	} else {
+		printk("DMIC capture baseline:\n");
+		(void)dmic_test();
+	}
+#endif
+
+#if PERIPH_HAS_I2S
+	/* I2S transmit baseline - streams one block out of the TDM block. */
+	if (!device_is_ready(i2s_dev)) {
+		printk("Error: I2S device %s not ready\n", i2s_dev->name);
+	} else {
+		printk("I2S transmit baseline:\n");
+		(void)i2s_test();
+	}
+#endif
+
+#if PERIPH_HAS_SDHC
+	/* SDHC baseline - configures the SD host block (no card required). */
+	if (!device_is_ready(sdhc_dev)) {
+		printk("Error: SDHC device %s not ready\n", sdhc_dev->name);
+	} else {
+		printk("SDHC baseline:\n");
+		(void)sdhc_test();
+	}
+#endif
+
+#if PERIPH_HAS_UART
+	/* UART loopback baseline. Requires a TX-to-RX jumper. */
+	if (!device_is_ready(uart_test_dev)) {
+		printk("Error: UART test device %s not ready\n", uart_test_dev->name);
+	} else {
+		printk("UART loopback baseline:\n");
+		(void)uart_test();
+	}
+#endif
+
+#if PERIPH_HAS_DMA
+	/* DMA baseline - a software-triggered memory-to-memory copy. */
+	if (!device_is_ready(dma_dev)) {
+		printk("Error: DMA device %s not ready\n", dma_dev->name);
+	} else {
+		printk("DMA mem-to-mem baseline:\n");
+		(void)dma_test();
+	}
+#endif
+
+#if PERIPH_HAS_CAN
+	/* CAN loopback baseline (internal loopback, no external wiring). */
+	if (!device_is_ready(can_dev)) {
+		printk("Error: CAN device %s not ready\n", can_dev->name);
+	} else {
+		printk("CAN loopback baseline:\n");
+		(void)can_test();
+	}
+#endif
+}
+
+uint32_t peripherals_counter_read(void)
+{
+#if PERIPH_HAS_COUNTER
+	uint32_t val = 0;
+
+	(void)counter_get_value(counter_dev, &val);
+	return val;
+#else
+	return 0U;
+#endif
+}
+
+void peripherals_test_after_wake(const char *phase)
+{
+#if PERIPH_HAS_PWM
+	/* The PWM free-runs and is never read back, so nothing else triggers its
+	 * lazy DeepSleep-RAM rebuild. Re-applying the setting runs the PWM
+	 * pm_action and restarts the 2 Hz blink.
+	 */
+	if (pwm_is_ready_dt(&pwm_led)) {
+		int ret = pwm_set_dt(&pwm_led, PWM_MSEC(500), PWM_MSEC(250));
+
+		printk("Phase 2: PWM blue LED re-armed after %s (%s)\n", phase,
+		       (ret < 0) ? "FAILED" : "blinking");
+	}
+#endif
+
+#if PERIPH_HAS_COUNTER
+	uint32_t cnt_wake = 0;
+	uint32_t cnt_after = 0;
+
+	/* Two reads with clocks on: a changing value proves the counter runs again. */
+	(void)counter_get_value(counter_dev, &cnt_wake);
+	k_busy_wait(1000);
+	(void)counter_get_value(counter_dev, &cnt_after);
+
+	printk("Phase 2: counter %u -> %u (%s)\n", cnt_wake, cnt_after,
+	       (cnt_after != cnt_wake) ? "running" : "STOPPED");
+#endif
+
+#if PERIPH_HAS_SPI
+	/* Re-run SPI loopback: a match proves the SPI pm_action restored the block. */
+	printk("Phase 2: SPI loopback after %s:\n", phase);
+	(void)spi_loopback_test();
+#endif
+
+#if PERIPH_HAS_I2C
+	/* Re-run the I2C probe: an identical result proves the block resumed. */
+	printk("Phase 2: I2C probe after %s:\n", phase);
+	(void)i2c_probe_test();
+#endif
+
+#if PERIPH_HAS_DMIC
+	/* Re-run DMIC capture: the stream coming back proves the audio path resumed. */
+	printk("Phase 2: DMIC capture after %s:\n", phase);
+	(void)dmic_test();
+#endif
+
+#if PERIPH_HAS_I2S
+	/* Re-run I2S transmit: a successful stream proves the TDM block resumed. */
+	printk("Phase 2: I2S transmit after %s:\n", phase);
+	(void)i2s_test();
+#endif
+
+#if PERIPH_HAS_SDHC
+	/* Re-run the SDHC config: an identical result proves the host block resumed. */
+	printk("Phase 2: SDHC after %s:\n", phase);
+	(void)sdhc_test();
+#endif
+
+#if PERIPH_HAS_UART
+	/* Re-run UART loopback: a match proves the block and its runtime PM
+	 * get/put paths still balance across the transition.
+	 */
+	printk("Phase 2: UART loopback after %s:\n", phase);
+	(void)uart_test();
+#endif
+
+#if PERIPH_HAS_DMA
+	/* Re-run the DMA copy: a match proves the DMA pm_action restored the block. */
+	printk("Phase 2: DMA mem-to-mem after %s:\n", phase);
+	(void)dma_test();
+#endif
+
+#if PERIPH_HAS_CAN
+	/* Re-run CAN loopback: a matching frame proves the Message RAM was
+	 * re-powered and the channel re-initialized.
+	 */
+	printk("Phase 2: CAN loopback after %s:\n", phase);
+	(void)can_test();
+#endif
+}
+
+#endif /* CONFIG_APP_ROLE_DUT */

--- a/samples/boards/infineon/low_power_modes/src/peripherals.h
+++ b/samples/boards/infineon/low_power_modes/src/peripherals.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PERIPHERALS_H_
+#define PERIPHERALS_H_
+
+#include <stdint.h>
+
+/*
+ * Optional peripheral self-tests for the DUT. Each peripheral is guarded by its
+ * devicetree presence in peripherals.c, so absent peripherals compile out and
+ * this sample can target other Infineon boards.
+ */
+
+/* Configure every present peripheral and run its baseline self-test. Call once
+ * before the low-power sequence.
+ */
+void peripherals_setup(void);
+
+/* Read the free-running counter used to observe clock gating; 0 if absent. */
+uint32_t peripherals_counter_read(void);
+
+/* Re-run every present peripheral's self-test after a wake. @p phase is the mode
+ * name printed with each result.
+ */
+void peripherals_test_after_wake(const char *phase);
+
+#endif /* PERIPHERALS_H_ */

--- a/samples/boards/infineon/low_power_modes/tests.yaml
+++ b/samples/boards/infineon/low_power_modes/tests.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: Infineon Low-Power Modes
+tests:
+  # Single-core PSC3M5 DUT: exercises the SoC power states (runtime-idle,
+  # DeepSleep, DeepSleep-RAM and the DeepSleep-OFF / Hibernate terminal modes).
+  infineon.low_power_modes.psc3m5:
+    build_only: true
+    platform_allow:
+      - kit_psc3m5_evk/psc3m5fds2afq1
+    integration_platforms:
+      - kit_psc3m5_evk/psc3m5fds2afq1
+    tags:
+      - pm
+      - counter
+      - gpio
+      - pwm
+      - dma
+      - can


### PR DESCRIPTION
Sample to demonstrate the low power modes of Infineon SoCs. Each power mode is verified by monitoring the console to verify deep sleep entry and exit processes.

Adds support for psc3 SoC.

This is a simplified version of https://github.com/zephyrproject-rtos/zephyr/pull/114224 without TF-M and SRF complexity.

Related PRs:
- https://github.com/zephyrproject-rtos/zephyr/pull/116691
- https://github.com/zephyrproject-rtos/zephyr/pull/114225
- https://github.com/zephyrproject-rtos/zephyr/pull/114224