### PR TITLE
boards: scobc_v1/versal_rpu: Add eMMC node

### DIFF
--- a/boards/sc/scobc_v1/scobc_v1_versal_rpu.dts
+++ b/boards/sc/scobc_v1/scobc_v1_versal_rpu.dts
@@ -44,3 +44,13 @@
 	status = "okay";
 	clock-frequency = <DT_FREQ_M(150)>;
 };
+
+&sdhci1 {
+	status = "disabled";
+
+	mmc {
+		compatible = "zephyr,mmc-disk";
+		bus-width = <8>;
+		disk-name = "mmc0";
+	};
+};

--- a/boards/sc/scobc_v1/scobc_v1_versal_rpu.yaml
+++ b/boards/sc/scobc_v1/scobc_v1_versal_rpu.yaml
@@ -6,3 +6,4 @@ toolchain:
 vendor: sc
 supported:
   - uart
+  - sdhc

--- a/dts/vendor/amd/versal.dtsi
+++ b/dts/vendor/amd/versal.dtsi
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <freq.h>
+
 / {
+	sdhci_ref_clk: sdhci-ref-clk {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(200)>;
+		#clock-cells = <0>;
+	};
+
 	soc: soc {
 		ocm: memory@fffc0000 {
 			compatible = "zephyr,memory-region";
@@ -283,6 +291,7 @@
 			compatible = "xlnx,versal-8.9a";
 			reg = <0xf1040000 0x10000>;
 			interrupts = <GIC_SPI 126 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&sdhci_ref_clk>;
 			status = "disabled";
 		};
 
@@ -290,6 +299,7 @@
 			compatible = "xlnx,versal-8.9a";
 			reg = <0xf1050000 0x10000>;
 			interrupts = <GIC_SPI 128 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&sdhci_ref_clk>;
 			status = "disabled";
 		};
 	};

--- a/tests/subsys/sd/mmc/boards/scobc_v1_versal_rpu.overlay
+++ b/tests/subsys/sd/mmc/boards/scobc_v1_versal_rpu.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &sdhci1;
+	};
+};
+
+&sdhci1 {
+	status = "okay";
+};


### PR DESCRIPTION
This PR enables eMMC support for `scobc_v1/versal_rpu`.