### PR TITLE
drivers: gpio: pcf857x: add support for MAX7321

### DIFF
--- a/drivers/gpio/Kconfig.pcf857x
+++ b/drivers/gpio/Kconfig.pcf857x
@@ -3,15 +3,18 @@
 # Copyright (c) 2022 Ithinx
 # Copyright (c) 2023 Mr Beam Lasers GmbH
 # Copyright (c) 2023 Amrith Venkat Kesavamoorthi <amrith@mr-beam.org>
+# Copyright (c) 2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig GPIO_PCF857X
 	bool "PCF857X I2C GPIO chip"
 	default y
-	depends on DT_HAS_NXP_PCF857X_ENABLED
+	depends on DT_HAS_NXP_PCF857X_ENABLED || DT_HAS_ADI_MAX7321_ENABLED
 	select I2C
 	help
 	  Enable driver for PCF857X I2C GPIO chip.
+	  This driver also supports the Analog Devices MAX7321 I2C port
+	  expander, which uses a compatible communication protocol.
 
 config GPIO_PCF857X_INIT_PRIORITY
 	int "Init priority"

--- a/drivers/gpio/gpio_pcf857x.c
+++ b/drivers/gpio/gpio_pcf857x.c
@@ -3,14 +3,14 @@
  * 2022 Ithinx GmbH
  * 2023 Amrith Venkat Kesavamoorthi <amrith@mr-beam.org>
  * 2023 Mr Beam Lasers GmbH.
+ * 2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
  * @see https://www.nxp.com/docs/en/data-sheet/PCF8575.pdf
  * @see https://www.nxp.com/docs/en/data-sheet/PCF8574_PCF8574A.pdf
+ * @see https://www.analog.com/media/en/technical-documentation/data-sheets/MAX7321.pdf
  */
-
-#define DT_DRV_COMPAT nxp_pcf857x
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
@@ -227,8 +227,8 @@ static int pcf857x_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_
 		return -ENOTSUP;
 	}
 	/*
-	 * These parts are open-drain, so open-drain is the natural output mode
-	 * and is accepted. Open-source is not supported.
+	 * The PCF857x and MAX7321 are open-drain parts, so open-drain is the
+	 * natural output mode and is accepted. Open-source is not supported.
 	 */
 	if ((flags & GPIO_SINGLE_ENDED) && !(flags & GPIO_LINE_OPEN_DRAIN)) {
 		return -ENOTSUP;
@@ -424,19 +424,24 @@ static DEVICE_API(gpio, pcf857x_drv_api) = {
 	.manage_callback = pcf857x_manage_callback,
 };
 
-#define GPIO_PCF857X_INST(idx)                                                                     \
-	static const struct pcf857x_drv_cfg pcf857x_cfg##idx = {                                   \
+#define GPIO_PCF857X_INST(idx, pfx)                                                                \
+	static const struct pcf857x_drv_cfg pfx##_cfg##idx = {                                     \
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(idx),                                    \
 		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(idx, int_gpios, {0}),                         \
 		.i2c = I2C_DT_SPEC_INST_GET(idx),                                                  \
 	};                                                                                         \
-	static struct pcf857x_drv_data pcf857x_data##idx = {                                       \
-		.lock = Z_SEM_INITIALIZER(pcf857x_data##idx.lock, 1, 1),                           \
+	static struct pcf857x_drv_data pfx##_data##idx = {                                         \
+		.lock = Z_SEM_INITIALIZER(pfx##_data##idx.lock, 1, 1),                             \
 		.work = Z_WORK_INITIALIZER(pcf857x_work_handler),                                  \
 		.dev = DEVICE_DT_INST_GET(idx),                                                    \
-		.num_bytes = DT_INST_ENUM_IDX(idx, ngpios) + 1,                                    \
+		.num_bytes = DT_INST_PROP(idx, ngpios) / 8,                                        \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(idx, pcf857x_init, NULL, &pcf857x_data##idx, &pcf857x_cfg##idx,      \
+	DEVICE_DT_INST_DEFINE(idx, pcf857x_init, NULL, &pfx##_data##idx, &pfx##_cfg##idx,          \
 			      POST_KERNEL, CONFIG_GPIO_PCF857X_INIT_PRIORITY, &pcf857x_drv_api);
 
-DT_INST_FOREACH_STATUS_OKAY(GPIO_PCF857X_INST);
+#define DT_DRV_COMPAT nxp_pcf857x
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_PCF857X_INST, pcf857x)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT adi_max7321
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_PCF857X_INST, max7321)

--- a/drivers/gpio/gpio_pcf857x.c
+++ b/drivers/gpio/gpio_pcf857x.c
@@ -357,6 +357,30 @@ static int pcf857x_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	/*
+	 * Put the device into a known state: all pins released high
+	 * (high-impedance / input with pull-up on these open-drain parts).
+	 * This also primes input_port_last with the initial pin state.
+	 */
+	drv_data->pins_cfg.configured_as_outputs = 0U;
+	drv_data->pins_cfg.outputs_state = 0xFFFFU;
+
+	uint8_t init_buf[2] = {0xFFU, 0xFFU};
+
+	rc = i2c_write_dt(&drv_cfg->i2c, init_buf, drv_data->num_bytes);
+	if (rc != 0) {
+		LOG_ERR("%s: failed to initialize output port: %d", dev->name, rc);
+		return -EIO;
+	}
+
+	k_sem_take(&drv_data->lock, K_FOREVER);
+	rc = pcf857x_process_input(dev, NULL);
+	k_sem_give(&drv_data->lock);
+	if (rc != 0) {
+		LOG_ERR("%s: failed to read initial state: %d", dev->name, rc);
+		return -EIO;
+	}
+
 	/* If the INT line is available, configure the callback for it. */
 	if (drv_cfg->gpio_int.port) {
 		if (!gpio_is_ready_dt(&drv_cfg->gpio_int)) {

--- a/drivers/gpio/gpio_pcf857x.c
+++ b/drivers/gpio/gpio_pcf857x.c
@@ -172,7 +172,15 @@ static int pcf857x_port_set_raw(const struct device *dev, uint16_t mask, uint16_
 		return -EWOULDBLOCK;
 	}
 
-	if ((drv_data->pins_cfg.configured_as_outputs & value) != value) {
+	/*
+	 * These parts are quasi-bidirectional open-drain: writing a 1 releases
+	 * the pin to high-impedance (its input/pulled-up state) while writing a
+	 * 0 actively pulls it low. Releasing a pin high is therefore always
+	 * safe, so only reject attempts to actively drive a pin that is not
+	 * configured as an output low. The set of pins being pulled low is
+	 * mask & ~value.
+	 */
+	if (((mask & ~value) & ~drv_data->pins_cfg.configured_as_outputs) != 0U) {
 		LOG_ERR("Pin(s) is/are configured as input which should be output.");
 		return -EOPNOTSUPP;
 	}
@@ -215,7 +223,14 @@ static int pcf857x_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_
 	uint16_t temp_pins = drv_data->pins_cfg.outputs_state;
 	uint16_t temp_outputs = drv_data->pins_cfg.configured_as_outputs;
 
-	if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN | GPIO_DISCONNECTED | GPIO_SINGLE_ENDED)) {
+	if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN | GPIO_DISCONNECTED)) {
+		return -ENOTSUP;
+	}
+	/*
+	 * These parts are open-drain, so open-drain is the natural output mode
+	 * and is accepted. Open-source is not supported.
+	 */
+	if ((flags & GPIO_SINGLE_ENDED) && !(flags & GPIO_LINE_OPEN_DRAIN)) {
 		return -ENOTSUP;
 	}
 	if (flags & GPIO_INPUT) {

--- a/drivers/gpio/gpio_pcf857x.c
+++ b/drivers/gpio/gpio_pcf857x.c
@@ -323,7 +323,8 @@ static int pcf857x_pin_interrupt_configure(const struct device *dev, gpio_pin_t 
 {
 	const struct pcf857x_drv_cfg *drv_cfg = dev->config;
 
-	if (!drv_cfg->gpio_int.port) {
+	/* Disabling interrupts is always allowed, even without an INT line. */
+	if (mode != GPIO_INT_MODE_DISABLED && !drv_cfg->gpio_int.port) {
 		return -ENOTSUP;
 	}
 

--- a/dts/bindings/gpio/adi,max7321.yaml
+++ b/dts/bindings/gpio/adi,max7321.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  MAX7321 I2C port expander with 8 open-drain I/Os.
+  The internal pull-up selection is not configurable through this driver.
+  Writing a 1 to a port makes it high-impedance (input with pull-up).
+  Writing a 0 to a port pulls it low (output driven low).
+
+compatible: "adi,max7321"
+
+include: [i2c-device.yaml, gpio-controller.yaml]
+
+properties:
+  ngpios:
+    required: true
+    const: 8
+    description: Number of GPIOs. MAX7321 always has 8 I/O pins.
+
+  int-gpios:
+    type: phandle-array
+    description: |
+      GPIO connected to the controller INT pin. This pin is active-low,
+      open-drain. Asserted when any input pin changes state.
+
+  "#gpio-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -524,6 +524,15 @@
 				#gpio-cells = <2>;
 				gpio-controller;
 			};
+
+			test_i2c_max7321: max7321@22 {
+				compatible = "adi,max7321";
+				reg = <0x22>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				int-gpios = <&test_gpio 0 0>;
+			};
 		};
 
 		nct3807_alert_1 {


### PR DESCRIPTION
Add support for the Analog Devices MAX7321 to the existing PCF857x driver.

The MAX7321 is an 8-bit open-drain I2C expander that uses the same single-byte read/write protocol as the NXP PCF8574. Rather than duplicating the driver, this adds `adi,max7321` as a second compatible with its own binding and enables the driver for either.

Supersedes zephyrproject-rtos/zephyr#109143 -- per @msalau's review there, the MAX7321 is added as a compatible to the existing PCF857x driver instead of a standalone driver.

### Testing
- `tests/drivers/build_all/gpio` builds on `native_sim`.
- Verified on `nucleo_g474re` with a MAX7321 at `0x68` on `I2C1`.