### PR TITLE
kernel: queue: fix k_queue_remove() for allocated items

### DIFF
--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -356,11 +356,27 @@ void *z_impl_k_queue_get(struct k_queue *queue, k_timeout_t timeout)
 	return (ret != 0) ? NULL : _current->base.swap_data;
 }
 
+/* Remove a queue item by its data pointer and free any wrapper node. */
 bool k_queue_remove(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, remove, queue);
 	k_spinlock_key_t key = k_spin_lock(&queue->lock);
-	bool ret = sys_sflist_find_and_remove(&queue->data_q, (sys_sfnode_t *)data);
+	sys_sfnode_t *prev = NULL;
+	sys_sfnode_t *node = sys_sflist_peek_head(&queue->data_q);
+	bool ret = false;
+
+	while (node != NULL) {
+		void *peeked = z_queue_node_peek(node, false);
+
+		if (peeked == data) {
+			sys_sflist_remove(&queue->data_q, prev, node);
+			(void)z_queue_node_peek(node, true);
+			ret = true;
+			break;
+		}
+		prev = node;
+		node = sys_sflist_peek_next(node);
+	}
 
 	k_spin_unlock(&queue->lock, key);
 

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -654,6 +654,48 @@ ZTEST(queue_api, test_queue_alloc)
 	tqueue_alloc(&queue);
 }
 
+/**
+ * @brief Verify k_queue_remove works with alloc_append/alloc_prepend data.
+ *
+ * @details
+ * k_queue_alloc_append() and k_queue_alloc_prepend() wrap the data in an
+ * internal alloc_node before inserting it into the queue. k_queue_remove()
+ * must locate and remove such entries by comparing against the original data
+ * pointer, not the alloc_node wrapper address.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_alloc_append()
+ * @see k_queue_alloc_prepend()
+ * @see k_queue_remove()
+ */
+ZTEST(queue_api, test_queue_alloc_remove)
+{
+	/* Verify both alloc append and alloc prepend entries can be removed. */
+	static qdata_t alloc_remove_data = { .data = 0x42, .allocated = false };
+	static qdata_t alloc_prepend_data = { .data = 0x43, .allocated = false };
+
+	k_queue_init(&queue);
+
+	k_thread_heap_assign(k_current_get(), &mem_pool_pass);
+
+	/* Append and remove an alloc append entry. */
+	zassert_ok(k_queue_alloc_append(&queue, &alloc_remove_data),
+		   "alloc_append failed");
+	zassert_true(k_queue_remove(&queue, &alloc_remove_data),
+		     "k_queue_remove failed after alloc_append");
+
+	/* Prepend and remove an alloc prepend entry. */
+	zassert_ok(k_queue_alloc_prepend(&queue, &alloc_prepend_data),
+		   "alloc_prepend failed");
+	zassert_true(k_queue_remove(&queue, &alloc_prepend_data),
+		     "k_queue_remove failed after alloc_prepend");
+
+	/* The queue must be empty after both removals. */
+	zassert_true(k_queue_is_empty(&queue),
+		     "Queue should be empty after removals");
+}
+
 
 /* Does nothing but read items out of the queue and verify that they
  * are non-null.  Two such threads will be created.


### PR DESCRIPTION
k_queue_alloc_append() and k_queue_alloc_prepend() wrap the caller's data in an internal alloc_node before inserting it into the queue. The old k_queue_remove() implementation searched for the caller data pointer as if it were the linked-list node, so removal returned false and left the allocated queue item in place.

Walk the queue and compare the unwrapped payload pointer instead. Free the alloc_node wrapper after removing a matching item, while preserving the existing behavior for directly inserted queue nodes.

Add coverage for removing items inserted through both alloc APIs.

Tested:
- ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb GNUARMEMB_TOOLCHAIN_PATH=/usr west build -d /tmp/zephyr-queue-gnuarmemb
- qemu_cortex_m3: queue_api 15/15 and queue_api_1cpu 7/7