### PR TITLE
[v3.7-branch] Bluetooth: L2CAP: Cancel dynamic channel rx_work on channel destroy

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1280,6 +1280,20 @@ static void l2cap_chan_destroy(struct bt_l2cap_chan *chan)
 		k_work_cancel_delayable(&le_chan->rtx_work);
 	}
 
+	/* The rx_work item also references the channel and may be pending or
+	 * running on another workqueue, so it needs the same guarded sync
+	 * cancellation as rtx_work above.
+	 */
+	struct k_work_q *rx_work_queue = le_chan->rx_work.queue;
+
+	if (rx_work_queue == NULL || k_current_get() != &rx_work_queue->thread) {
+		struct k_work_sync sync;
+
+		k_work_cancel_sync(&le_chan->rx_work, &sync);
+	} else {
+		k_work_cancel(&le_chan->rx_work);
+	}
+
 	/* Remove buffers on the SDU RX queue */
 	while ((buf = net_buf_get(&le_chan->rx_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);


### PR DESCRIPTION
l2cap_chan_destroy() cancels the RTX work and drains the RX queue, but leaves the rx_work item untouched. The work item is submitted to the system workqueue, while channel teardown may run in a different context (e.g. the Bluetooth RX workqueue processing an L2CAP Disconnect Request), so a queued or running rx_work item can outlive the channel object, even though the released() callback tells the application that the object may be freed or re-used at that point.

Cancel rx_work using the same guarded synchronous cancellation pattern that the function already uses for rtx_work: sync when running in a different context than the work item's workqueue, and a plain cancel when running on that workqueue itself, where syncing would deadlock and where a pending item cannot be running.

On the main branch this was fixed as part of commit 22896cb8d6f2 ("Bluetooth: Host: Route LE host work items to the Bluetooth workqueue"), which depends on infrastructure that is not suitable for backporting; this is a self-contained equivalent for the stable branch.

Fixes #116523