### PR TITLE
bluetooth: host: remove deprecated CONFIG_BT_AUTO_PHY_UPDATE

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1413,6 +1413,11 @@ Bluetooth Host
   should review their synchronization and callback stack requirements. See
   pull request :github:`93033` for details.
 
+* ``CONFIG_BT_AUTO_PHY_UPDATE`` has been removed. Use the per-role ``BT_AUTO_PHY_CENTRAL``
+  and ``BT_AUTO_PHY_PERIPHERAL`` choices instead. ``=n`` does not translate to dropping the
+  option: the central choice defaults to :kconfig:option:`CONFIG_BT_AUTO_PHY_CENTRAL_2M`, so
+  both roles must be set to ``_NONE`` explicitly.
+
 Bluetooth Services
 ==================
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -104,6 +104,9 @@ Removed APIs and options
       buffers unconditionally. Applications still setting these options can
       simply drop them.
 
+    * ``CONFIG_BT_AUTO_PHY_UPDATE``, replaced by the ``BT_AUTO_PHY_CENTRAL`` and
+      ``BT_AUTO_PHY_PERIPHERAL`` choices
+
 * Build system
 
     * ``CONFIG_BUILD_NO_GAP_FILL``

--- a/soc/st/stm32/stm32wb0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wb0x/Kconfig.defconfig
@@ -20,9 +20,6 @@ if BT
 configdefault SYSTEM_WORKQUEUE_STACK_SIZE
 	default 1152
 
-config BT_AUTO_PHY_UPDATE
-	default n
-
 config BT_AUTO_DATA_LEN_UPDATE
 	default n
 

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -173,8 +173,9 @@ config BT_BUF_CMD_TX_COUNT
 
 	  HCI Controllers may not support Num_HCI_Command_Packets > 1, hence they default to 1 when
 	  not enabling Controller to Host data flow control (BT_HCI_ACL_FLOW_CONTROL), Read Remote
-	  Version Information (BT_REMOTE_VERSION), Auto-Initiate PHY update (BT_AUTO_PHY_UPDATE), or
-	  Auto-Initiate Data Length Update (BT_AUTO_DATA_LEN_UPDATE).
+	  Version Information (BT_REMOTE_VERSION), Auto-Initiate PHY update
+	  (BT_AUTO_PHY_CENTRAL and BT_AUTO_PHY_PERIPHERAL choices), or Auto-Initiate Data Length
+	  Update (BT_AUTO_DATA_LEN_UPDATE).
 
 	  Normal HCI commands follow the HCI command flow control using Num_HCI_Command_Packets
 	  return in HCI command complete and status.

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -1092,7 +1092,7 @@ config BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM
 
 config BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM
 	int "Number of local control procedure contexts to be available across all connections"
-	default 6 if (BT_AUTO_PHY_UPDATE=y || BT_AUTO_DATA_LEN_UPDATE=y) && BT_CTLR_LLCP_CONN < 4
+	default 6 if BT_AUTO_DATA_LEN_UPDATE=y && BT_CTLR_LLCP_CONN < 4
 	default 2 if BT_CTLR_LLCP_CONN = 1
 	default BT_CTLR_LLCP_CONN if BT_CTLR_LLCP_CONN > 1
 	range 2 $(UINT8_MAX)

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -354,22 +354,9 @@ config BT_USER_PHY_UPDATE
 	  changes on the connection. The current PHY info is available in the
 	  connection info.
 
-config BT_AUTO_PHY_UPDATE
-	bool "Auto-initiate PHY Update Procedure [DEPRECATED]"
-	select DEPRECATED
-	help
-	  Initiate PHY Update Procedure on connection establishment. This will attempt
-	  to update the connection to use 2M PHY, however it doesn't actually guarantee
-	  that this is what will be used in the end.
-
-	  This option has been deprecated in favor of role specific options. The equivalent
-	  behavior can be accomplished by enabling BT_AUTO_PHY_PERIPHERAL_2M and
-	  BT_AUTO_PHY_CENTRAL_2M.
-
 choice BT_AUTO_PHY_PERIPHERAL
 	prompt "Auto PHY update for peripheral role"
 	depends on BT_PERIPHERAL
-	default BT_AUTO_PHY_PERIPHERAL_2M if BT_AUTO_PHY_UPDATE
 	default BT_AUTO_PHY_PERIPHERAL_NONE
 
 config BT_AUTO_PHY_PERIPHERAL_NONE


### PR DESCRIPTION
Removes `CONFIG_BT_AUTO_PHY_UPDATE`, deprecated in Zephyr 4.3 in favour of the role-specific `BT_AUTO_PHY_CENTRAL` and `BT_AUTO_PHY_PERIPHERAL` choices (see release-notes-4.3.rst).

The symbol lost its `default y if !BT_USER_PHY_UPDATE` in 4.3, so it has been unset in every in-tree configuration since, making each remaining reference dead code:

- The `BT_AUTO_PHY_PERIPHERAL` choice loses its `default BT_AUTO_PHY_PERIPHERAL_2M if BT_AUTO_PHY_UPDATE` entry and keeps falling through to `_NONE`, as it already did.
- `BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM` loses the always-false `BT_AUTO_PHY_UPDATE=y` disjunct of its `default 6` condition, which now reads as it already evaluated.
- The STM32WB0 SoC defconfig set `BT_AUTO_PHY_UPDATE=n`, which had no effect on either role, and is dropped.

**Deliberately behaviour-neutral.** Two pre-existing quirks are left alone, since they are policy calls for their maintainers rather than part of removing a deprecated symbol:

1. The local procedure context count no longer reaches 6 via automatic PHY update.
2. STM32WB0 follows the `BT_AUTO_PHY_CENTRAL` default of `_2M` for central-role connections — the SoC's old `BT_AUTO_PHY_UPDATE=n` never disabled this, since the central choice defaults to `_2M` unconditionally.

If ST would prefer central-role auto PHY update off on STM32WB0, that deserves a separate PR.
