### PR TITLE
arch: riscv: remove deprecated EXTRA_EXCEPTION_INFO Kconfig option

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -360,12 +360,6 @@ config RISCV_HART_MASK
 	  i.e. 128, 129, ..(0x80, 8x81, ..), this can be configured to 63 (0x7f)
 	  such that we can extract the bits that start from 0.
 
-config EXTRA_EXCEPTION_INFO
-	bool "Collect extra exception info [DEPRECATED]"
-	select DEPRECATED
-	help
-	  This option is deprecated and should be replaced with CONFIG_EXCEPTION_DEBUG.
-
 config RISCV_PMP
 	bool "RISC-V PMP Support"
 	depends on !RISCV_S_MODE

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1776,6 +1776,9 @@ Architectures
   after the stack pointers have been set up, and is skipped on resume from
   suspend-to-RAM.
 
+* The RISC-V specific ``CONFIG_EXTRA_EXCEPTION_INFO`` has been removed. Use
+  :kconfig:option:`CONFIG_EXCEPTION_DEBUG` instead. The option is unchanged on Arm and SPARC.
+
 Video
 =====
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -75,6 +75,10 @@ Removed APIs and options
       * ``CONFIG_PLATFORM_SPECIFIC_INIT``
       * ``z_arm_platform_init()``
 
+   * RISC-V
+
+      * ``CONFIG_EXTRA_EXCEPTION_INFO``
+
    * x86
 
       * ``CONFIG_SSE``


### PR DESCRIPTION
Removes the RISC-V-local `CONFIG_EXTRA_EXCEPTION_INFO`, deprecated in Zephyr 4.3 in favour of `CONFIG_EXCEPTION_DEBUG` (see release-notes-4.3.rst). Tracked by #94255.

This symbol in `arch/riscv/Kconfig` shadowed the identically-named, **non-deprecated** option in `arch/Kconfig` (guarded by `ARCH_HAS_EXTRA_EXCEPTION_INFO`) that Arm and SPARC still use. Only the RISC-V block goes; the generic option and its Arm/SPARC/coredump/gdbstub/perf users are untouched.
