### PR TITLE
drivers: spi: remove deprecated delay argument in DT macros

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -913,6 +913,12 @@ SPI
   FIFO is now always used in polling and interrupt mode to enhance performance. A new property
   ``st,fifo-threshold`` can be used to configure the FIFO threshold (default = 1). (:github:`110265`)
 
+* The optional delay argument of :c:macro:`SPI_CONFIG_DT`, :c:macro:`SPI_CONFIG_DT_INST`,
+  :c:macro:`SPI_DT_SPEC_GET`, :c:macro:`SPI_DT_SPEC_INST_GET`, :c:macro:`SPI_DT_IODEV_DEFINE`,
+  :c:macro:`SPI_DT_INST_IODEV_DEFINE` and :c:macro:`SPI_CS_CONTROL_INIT` has been removed; drop
+  it from every invocation. Use the ``spi-cs-setup-delay-ns`` and ``spi-cs-hold-delay-ns``
+  devicetree properties instead (note that they are in nanoseconds rather than microseconds).
+
 Stepper
 =======
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -151,6 +151,12 @@ Removed APIs and options
     * ``CONFIG_CTR_DRBG_CSPRNG_GENERATOR``
     * ``CONFIG_CS_CTR_DRBG_PERSONALIZATION``
 
+* SPI
+
+    * The optional delay argument of :c:macro:`SPI_CONFIG_DT`, :c:macro:`SPI_CONFIG_DT_INST`,
+      :c:macro:`SPI_DT_SPEC_GET`, :c:macro:`SPI_DT_SPEC_INST_GET`, :c:macro:`SPI_DT_IODEV_DEFINE`,
+      :c:macro:`SPI_DT_INST_IODEV_DEFINE` and :c:macro:`SPI_CS_CONTROL_INIT` has been removed.
+
 * Stream Flash
 
     * ``stream_flash_erase_page()``

--- a/drivers/mfd/mfd_max2221x.c
+++ b/drivers/mfd/mfd_max2221x.c
@@ -126,7 +126,7 @@ static int max2221x_init(const struct device *dev)
 
 #define MAX2221X_DEFINE(inst)                                                                      \
 	static const struct mfd_max2221x_config mfd_max2221x_config_##inst = {                     \
-		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8) | SPI_TRANSFER_MSB, 0),          \
+		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8) | SPI_TRANSFER_MSB),             \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, max2221x_init, NULL, NULL, &mfd_max2221x_config_##inst,        \

--- a/drivers/mux/mux_adi_adgm3121.c
+++ b/drivers/mux/mux_adi_adgm3121.c
@@ -265,8 +265,7 @@ static int mux_adgm3121_init(const struct device *dev)
 	static const struct mux_adgm3121_config mux_adgm3121_spi_cfg_##inst = { \
 		.mode = ADGM3121_MODE_SPI,                                     \
 		.spi = SPI_DT_SPEC_INST_GET(inst,                              \
-			SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8),\
-			0),                                                    \
+			SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8)),\
 	};                                                                     \
 	DEVICE_DT_INST_DEFINE(inst, mux_adgm3121_init, NULL,                   \
 			      &mux_adgm3121_spi_data_##inst,                   \

--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -354,7 +354,7 @@ static DEVICE_API(sensor, bma4xx_driver_api) = {
 	RTIO_DEFINE(bma4xx_rtio_##inst, 8, 8);
 
 #define BMA4XX_RTIO_SPI_DEFINE(inst)                                                               \
-	SPI_DT_IODEV_DEFINE(bma4xx_iodev_##inst, DT_DRV_INST(inst));                               \
+	SPI_DT_IODEV_DEFINE(bma4xx_iodev_##inst, DT_DRV_INST(inst), 0);                            \
 	RTIO_DEFINE(bma4xx_rtio_##inst, 8, 8);
 
 #define BMA4XX_DEFINE_RTIO(inst)                                                                   \

--- a/drivers/sensor/tdk/tad2144/tad214x_drv.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_drv.c
@@ -337,7 +337,7 @@ static DEVICE_API(sensor, tad214x_api_funcs) = {
 		.if_mode = IF_SPI, \
 		.bus.spi = SPI_DT_SPEC_INST_GET(inst, \
 						SPI_WORD_SET(8) | \
-						SPI_TRANSFER_MSB, 0), \
+						SPI_TRANSFER_MSB), \
 		.bus_io = &tad214x_bus_io_spi, \
 		TAD214X_CONFIG(inst) \
 	}

--- a/drivers/sensor/wsen/wsen_pdms_25131308XXX05/wsen_pdms_25131308XXX05.c
+++ b/drivers/sensor/wsen/wsen_pdms_25131308XXX05/wsen_pdms_25131308XXX05.c
@@ -240,8 +240,7 @@ static DEVICE_API(sensor, pdms_25131308XXX05_driver_api) = {
 		(.bus_cfg = { \
 			.spi = SPI_DT_SPEC_INST_GET( \
 				inst, \
-				PDMS_25131308XXX05_SPI_OPERATION, \
-				0 \
+				PDMS_25131308XXX05_SPI_OPERATION \
 			) \
 		},), \
 		())

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -338,18 +338,13 @@ struct spi_cs_control {
 	    DT_PROP_OR(node_id, spi_cs_hold_delay_ns, 0))
 
 
-#define SPI_CS_CONTROL_INIT_GPIO(node_id, ...)						\
+#define SPI_CS_CONTROL_INIT_GPIO(node_id)						\
 	.gpio = SPI_CS_GPIOS_DT_SPEC_GET(node_id),					\
-	.delay = COND_CODE_1(IS_EMPTY(__VA_ARGS__),					\
-			(DIV_ROUND_UP(SPI_CS_CONTROL_MAX_DELAY(node_id), 1000)),	\
-			(__VA_ARGS__)),
+	.delay = DIV_ROUND_UP(SPI_CS_CONTROL_MAX_DELAY(node_id), 1000),
 
 #define SPI_CS_CONTROL_INIT_NATIVE(node_id)						\
 	.setup_ns = DT_PROP_OR(node_id, spi_cs_setup_delay_ns, 0),			\
 	.hold_ns = DT_PROP_OR(node_id, spi_cs_hold_delay_ns, 0),
-
-#define SPI_DEPRECATE_DELAY_WARN							\
-	__WARN("Delay parameter in SPI DT macros is deprecated, use DT prop instead")
 /** @endcond */
 
 /**
@@ -382,7 +377,9 @@ struct spi_cs_control {
  * @code{.c}
  *     struct spi_cs_control ctrl = {
  *             .gpio = SPI_CS_GPIOS_DT_SPEC_GET(DT_NODELABEL(spidev)),
- *             .delay = DT_PROP(node_id, cs_delay_ns) / 1000,
+ *             .delay = DIV_ROUND_UP(MAX(DT_PROP_OR(node_id, spi_cs_setup_delay_ns, 0),
+ *                                       DT_PROP_OR(node_id, spi_cs_hold_delay_ns, 0)),
+ *                                   1000),
  *             .cs_is_gpio = true,
  *     };
  * @endcode
@@ -394,11 +391,10 @@ struct spi_cs_control {
  *
  * @return a pointer to the @p spi_cs_control structure
  */
-#define SPI_CS_CONTROL_INIT(node_id, ...)					\
+#define SPI_CS_CONTROL_INIT(node_id)						\
 {										\
-	COND_CODE_0(IS_EMPTY(__VA_ARGS__), (SPI_DEPRECATE_DELAY_WARN), ())	\
 	COND_CODE_1(DT_SPI_DEV_HAS_CS_GPIOS(node_id),				\
-			(SPI_CS_CONTROL_INIT_GPIO(node_id, __VA_ARGS__)),	\
+			(SPI_CS_CONTROL_INIT_GPIO(node_id)),			\
 			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))			\
 	.cs_is_gpio = DT_SPI_DEV_HAS_CS_GPIOS(node_id),				\
 }
@@ -407,7 +403,7 @@ struct spi_cs_control {
  * @brief Get a pointer to a @p spi_cs_control from a devicetree node
  *
  * This is equivalent to
- * <tt>SPI_CS_CONTROL_INIT(DT_DRV_INST(inst), delay)</tt>.
+ * <tt>SPI_CS_CONTROL_INIT(DT_DRV_INST(inst))</tt>.
  *
  * Therefore, @c DT_DRV_COMPAT must already be defined before using
  * this macro.
@@ -509,7 +505,7 @@ static inline uint16_t spi_get_word_delay(const struct spi_config *cfg)
  *                struct spi_config to create an initializer for
  * @param operation_ the desired @p operation field in the struct spi_config
  */
-#define SPI_CONFIG_DT(node_id, operation_, ...)				\
+#define SPI_CONFIG_DT(node_id, operation_)				\
 	{								\
 		.frequency = DT_PROP(node_id, spi_max_frequency),	\
 		.operation = (operation_) |				\
@@ -521,7 +517,7 @@ static inline uint16_t spi_get_word_delay(const struct spi_config *cfg)
 			COND_CODE_1(DT_PROP(node_id, spi_lsb_first), SPI_TRANSFER_LSB, (0)) |	\
 			COND_CODE_1(DT_PROP(node_id, spi_cs_high), SPI_CS_ACTIVE_HIGH, (0)),	\
 		.slave = DT_REG_ADDR(node_id),				\
-		.cs = SPI_CS_CONTROL_INIT(node_id, __VA_ARGS__),	\
+		.cs = SPI_CS_CONTROL_INIT(node_id),			\
 		.word_delay = DT_PROP(node_id, spi_interframe_delay_ns),\
 	}
 
@@ -534,8 +530,8 @@ static inline uint16_t spi_get_word_delay(const struct spi_config *cfg)
  * @param inst Devicetree instance number
  * @param operation_ the desired @p operation field in the struct spi_config
  */
-#define SPI_CONFIG_DT_INST(inst, operation_, ...)		\
-	SPI_CONFIG_DT(DT_DRV_INST(inst), operation_, __VA_ARGS__)
+#define SPI_CONFIG_DT_INST(inst, operation_)			\
+	SPI_CONFIG_DT(DT_DRV_INST(inst), operation_)
 
 /**
  * @brief Complete SPI DT information
@@ -562,10 +558,10 @@ struct spi_dt_spec {
  *                struct spi_dt_spec to create an initializer for
  * @param operation_ the desired @p operation field in the struct spi_config
  */
-#define SPI_DT_SPEC_GET(node_id, operation_, ...)				\
+#define SPI_DT_SPEC_GET(node_id, operation_)					\
 	{									\
 		.bus = DEVICE_DT_GET(DT_BUS(node_id)),				\
-		.config = SPI_CONFIG_DT(node_id, operation_, __VA_ARGS__),	\
+		.config = SPI_CONFIG_DT(node_id, operation_),			\
 	}
 
 /**
@@ -577,8 +573,8 @@ struct spi_dt_spec {
  * @param inst Devicetree instance number
  * @param operation_ the desired @p operation field in the struct spi_config
  */
-#define SPI_DT_SPEC_INST_GET(inst, operation_, ...) \
-	SPI_DT_SPEC_GET(DT_DRV_INST(inst), operation_, __VA_ARGS__)
+#define SPI_DT_SPEC_INST_GET(inst, operation_) \
+	SPI_DT_SPEC_GET(DT_DRV_INST(inst), operation_)
 
 /**
  * @brief Value that will never compare true with any valid overrun character
@@ -1362,9 +1358,9 @@ extern const struct rtio_iodev_api spi_iodev_api;
  * @param node_id Devicetree node identifier
  * @param operation_ SPI operational mode
  */
-#define SPI_DT_IODEV_DEFINE(name, node_id, operation_, ...)			\
+#define SPI_DT_IODEV_DEFINE(name, node_id, operation_)				\
 	const struct spi_dt_spec _spi_dt_spec_##name =				\
-		SPI_DT_SPEC_GET(node_id, operation_, __VA_ARGS__);		\
+		SPI_DT_SPEC_GET(node_id, operation_);				\
 	RTIO_IODEV_DEFINE(name, &spi_iodev_api, (void *)&_spi_dt_spec_##name)
 
 /**
@@ -1377,8 +1373,8 @@ extern const struct rtio_iodev_api spi_iodev_api;
  * @param inst Devicetree instance number
  * @param operation_ SPI operational mode
  */
-#define SPI_DT_INST_IODEV_DEFINE(name, inst, operation_, ...)			\
-	SPI_DT_IODEV_DEFINE(name, DT_DRV_INST(inst), operation_, __VA_ARGS__)
+#define SPI_DT_INST_IODEV_DEFINE(name, inst, operation_)			\
+	SPI_DT_IODEV_DEFINE(name, DT_DRV_INST(inst), operation_)
 
 /**
  * @brief Validate that SPI bus (and CS gpio if defined) is ready.


### PR DESCRIPTION
Removes the optional delay argument of `SPI_CONFIG_DT`, `SPI_CONFIG_DT_INST`, `SPI_DT_SPEC_GET`, `SPI_DT_SPEC_INST_GET`, `SPI_DT_IODEV_DEFINE`, `SPI_DT_INST_IODEV_DEFINE` and `SPI_CS_CONTROL_INIT`, deprecated in Zephyr 4.3 (see release-notes-4.3.rst). Tracked by #94255.

These macros now take a fixed argument list, and the chip select delay always comes from the `spi-cs-setup-delay-ns` / `spi-cs-hold-delay-ns` devicetree properties. The `SPI_DEPRECATE_DELAY_WARN` helper and the `COND_CODE_0`/`IS_EMPTY(__VA_ARGS__)` plumbing that supported the deprecated form are gone.

Note for out-of-tree users: the removed argument was in **microseconds** while the devicetree properties are in **nanoseconds**, so a delay of `N` becomes `N * 1000`.

### Adjacent fix (second commit)

`drivers/sensor/bosch/bma4xx/bma4xx.c` called `SPI_DT_IODEV_DEFINE` with 2 arguments where 3 are required, so the macro could never expand for an instance on SPI. This is **pre-existing** — the old variadic form also required 3 named args — and went unnoticed because the definition sits behind a `COND_CODE_1(DT_INST_ON_BUS(inst, spi), ...)` and no in-tree devicetree describes a bma4xx on SPI. It now passes an operation of `0`, matching the `SPI_DT_SPEC_INST_GET(inst, 0)` used for the same node a few lines below.
