### PR TITLE
portability: posix: remove deprecated POSIX_READER_WRITER_LOCKS

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1668,6 +1668,12 @@ MCUmgr
   :ref:`mcumgr_os_application_info` command now always reports the board target as hardware
   platform; the pre-4.3 board and board revision output is no longer available.
 
+POSIX
+=====
+
+* ``CONFIG_POSIX_READER_WRITER_LOCKS`` has been removed. Use
+  :kconfig:option:`CONFIG_POSIX_RW_LOCKS` instead.
+
 Random
 ======
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -153,6 +153,10 @@ Removed APIs and options
       ``non-secure-callable`` properties of :dtcompatible:`nordic,owned-memory` and
       :dtcompatible:`nordic,owned-partitions`
 
+* POSIX
+
+    * ``CONFIG_POSIX_READER_WRITER_LOCKS``
+
 * Random
 
     * ``CONFIG_CTR_DRBG_CSPRNG_GENERATOR``

--- a/subsys/portability/posix/options/Kconfig.rwlock
+++ b/subsys/portability/posix/options/Kconfig.rwlock
@@ -25,10 +25,3 @@ module-str = POSIX Reader-Writer Locks
 source "subsys/logging/Kconfig.template.log_config"
 
 endif # POSIX_RW_LOCKS
-
-config POSIX_READER_WRITER_LOCKS
-	bool "POSIX reader-writer locks [DEPRECATED]"
-	select DEPRECATED
-	select POSIX_RW_LOCKS
-	help
-	  This option is deprecated. Use POSIX_RW_LOCKS instead.


### PR DESCRIPTION
Removes `CONFIG_POSIX_READER_WRITER_LOCKS`, deprecated in Zephyr 4.3 in favour of `CONFIG_POSIX_RW_LOCKS` (see release-notes-4.3.rst). Tracked by #94255. The deprecated symbol was a pure alias that did nothing but `select POSIX_RW_LOCKS`.