### PR TITLE
kernel: dynamic: fix kernel stack size overflow

### DIFF
--- a/kernel/dynamic.c
+++ b/kernel/dynamic.c
@@ -58,6 +58,8 @@ static k_thread_stack_t *z_thread_stack_alloc_pool(size_t size, int flags)
 
 static k_thread_stack_t *z_thread_stack_alloc_dyn(size_t size, int flags)
 {
+	size_t stack_len;
+
 	if ((flags & K_USER) == K_USER) {
 #ifdef CONFIG_DYNAMIC_OBJECTS
 		return k_object_alloc_size(K_OBJ_THREAD_STACK_ELEMENT, size);
@@ -69,7 +71,12 @@ static k_thread_stack_t *z_thread_stack_alloc_dyn(size_t size, int flags)
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 	}
 
-	return z_thread_aligned_alloc(Z_KERNEL_STACK_OBJ_ALIGN, K_KERNEL_STACK_LEN(size));
+	stack_len = K_KERNEL_STACK_LEN(size);
+	if (stack_len < size) {
+		return NULL;
+	}
+
+	return z_thread_aligned_alloc(Z_KERNEL_STACK_OBJ_ALIGN, stack_len);
 }
 
 k_thread_stack_t *z_impl_k_thread_stack_alloc(size_t size, int flags)

--- a/tests/kernel/threads/dynamic_thread_stack/src/main.c
+++ b/tests/kernel/threads/dynamic_thread_stack/src/main.c
@@ -168,6 +168,19 @@ ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_alloc)
 	}
 }
 
+/** @brief Reject dynamically allocated kernel stacks with overflowing sizes. */
+ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_size_overflow)
+{
+	k_thread_stack_t *stack;
+
+	if (!IS_ENABLED(CONFIG_DYNAMIC_THREAD_ALLOC)) {
+		ztest_test_skip();
+	}
+
+	stack = k_thread_stack_alloc(SIZE_MAX, 0);
+	zassert_is_null(stack, "overflowing stack size must be rejected");
+}
+
 K_SEM_DEFINE(perm_sem, 0, 1);
 ZTEST_BMEM static volatile bool expect_fault;
 ZTEST_BMEM static volatile unsigned int expected_reason;


### PR DESCRIPTION
k_thread_stack_alloc() passed K_KERNEL_STACK_LEN(size) directly to the allocator. The alignment and reserved-size arithmetic could wrap for an oversized request, causing it to be turned into a much smaller allocation instead of being rejected.

Before the fix, the regression test accepted SIZE_MAX and reported:

    Assertion failed ... (stack is not NULL)
    overflowing stack size must be rejected
    FAIL - test_dynamic_thread_stack_size_overflow

Reject the allocation when K_KERNEL_STACK_LEN(size) is smaller than the requested size, which indicates that the size calculation wrapped. The existing userspace dynamic-object overflow check remains unchanged.

Fixes: 7b1b2576ac9a ("kernel: support dynamic thread stack allocation")