### PR TITLE
kernel: stack: fix allocation size overflow

### DIFF
--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -44,17 +44,23 @@ void k_stack_init(struct k_stack *stack, stack_data_t *buffer,
 int32_t z_impl_k_stack_alloc_init(struct k_stack *stack, uint32_t num_entries)
 {
 	void *buffer;
+	size_t total_size;
 	int32_t ret;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, alloc_init, stack);
 
-	buffer = z_thread_malloc(num_entries * sizeof(stack_data_t));
-	if (buffer != NULL) {
-		k_stack_init(stack, buffer, num_entries);
-		stack->flags = K_STACK_FLAG_ALLOC;
-		ret = 0;
-	} else {
+	/* Reject allocation sizes that cannot be represented. */
+	if (size_mul_overflow(num_entries, sizeof(stack_data_t), &total_size)) {
 		ret = -ENOMEM;
+	} else {
+		buffer = z_thread_malloc(total_size);
+		if (buffer != NULL) {
+			k_stack_init(stack, buffer, num_entries);
+			stack->flags = K_STACK_FLAG_ALLOC;
+			ret = 0;
+		} else {
+			ret = -ENOMEM;
+		}
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, alloc_init, stack, ret);

--- a/tests/kernel/stack/stack/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack/src/test_stack_contexts.c
@@ -379,5 +379,24 @@ ZTEST(stack_contexts, test_stack_alloc_null)
 }
 
 /**
+ * @brief Reject stack entry counts that overflow the allocation size.
+ */
+ZTEST(stack_contexts, test_stack_alloc_size_overflow)
+{
+	struct k_stack overflow_stack;
+	uint32_t num_entries;
+	int ret;
+
+	if (sizeof(size_t) > sizeof(uint32_t)) {
+		ztest_test_skip();
+	}
+
+	num_entries = (UINT32_MAX / sizeof(stack_data_t)) + 1U;
+	ret = k_stack_alloc_init(&overflow_stack, num_entries);
+	zassert_equal(ret, -ENOMEM,
+		      "overflowing stack allocation must be rejected");
+}
+
+/**
  * @}
  */


### PR DESCRIPTION
k_stack_alloc_init() calculates the allocation size as num_entries * sizeof(stack_data_t). On targets where size_t is 32 bits, a sufficiently large entry count can overflow the multiplication and result in an allocation much smaller than the capacity recorded in the stack object.

The userspace verifier already checks this multiplication, but supervisor callers invoke z_impl_k_stack_alloc_init() directly and bypass that check.

Check the multiplication in the implementation before allocating the buffer. Treat an overflowing request as an allocation failure and return -ENOMEM.

Add regression coverage for the supervisor allocation path. The complete qemu_cortex_m3 stack validation passed after the fix:

    16 tests passed, 0 failed
    PROJECT EXECUTION SUCCESSFUL

Fixes: be3d4232c223 ("kernel: fix k_stack_alloc_init()")