### PR TITLE
net: wireguard: Do not learn endpoint from unauthenticated data

### DIFF
--- a/subsys/net/lib/wireguard/wg.c
+++ b/subsys/net/lib/wireguard/wg.c
@@ -689,11 +689,11 @@ static int handle_cookie_reply(struct wg_peer *peer,
 	return 0;
 }
 
-static int handle_transport_data(struct wg_peer *peer,
-				 struct net_sockaddr *peer_addr,
-				 struct net_pkt *pkt,
-				 size_t ip_udp_hdr_len,
-				 size_t data_len)
+ZTESTABLE_STATIC int handle_transport_data(struct wg_peer *peer,
+					   struct net_sockaddr *peer_addr,
+					   struct net_pkt *pkt,
+					   size_t ip_udp_hdr_len,
+					   size_t data_len)
 {
 	NET_PKT_DATA_ACCESS_DEFINE(access, struct msg_transport_data);
 	struct msg_transport_data *msg;

--- a/subsys/net/lib/wireguard/wg.c
+++ b/subsys/net/lib/wireguard/wg.c
@@ -709,10 +709,32 @@ static int handle_transport_data(struct wg_peer *peer,
 		/* No valid session for this receiver index. The remote peer
 		 * might have a stale session. Trigger a new handshake if we
 		 * haven't done so recently.
+		 *
+		 * Note that this message is not authenticated in any way. As
+		 * the receiver index is unknown, there is no key to verify it
+		 * with, so anyone able to send an UDP packet to our port can
+		 * craft one. It must therefore never be allowed to change the
+		 * peer endpoint, as that would let an off-path attacker steer
+		 * our handshake initiations, and thus the tunnel, to an
+		 * address of their choosing. Send the handshake only to the
+		 * endpoint that we have learnt from authenticated messages,
+		 * or to the configured one if we have none yet.
 		 */
 		if (!peer->handshake.is_valid && !peer->session.keypair.current.is_valid) {
+			if (peer->endpoint.ss_family == NET_AF_UNSPEC) {
+				memcpy(&peer->endpoint, &peer->cfg_endpoint,
+				       sizeof(peer->endpoint));
+			}
+
+			if (peer->endpoint.ss_family == NET_AF_UNSPEC) {
+				/* No known endpoint to initiate to. This peer
+				 * can only be reached after it has contacted
+				 * us with a valid handshake initiation.
+				 */
+				return -ENOENT;
+			}
+
 			peer->send_handshake = true;
-			memcpy(&peer->endpoint, peer_addr, sizeof(peer->endpoint));
 			(void)k_work_schedule(&peer->ctx->wg_ctx->wg_periodic_timer,
 					      K_NO_WAIT);
 		}

--- a/subsys/net/lib/wireguard/wg_internal.h
+++ b/subsys/net/lib/wireguard/wg_internal.h
@@ -375,6 +375,11 @@ ZTESTABLE_STATIC int wg_process_data_message(struct wg_iface_context *ctx,
 					     struct net_pkt *pkt,
 					     size_t ip_udp_hdr_len,
 					     struct net_sockaddr *addr);
+ZTESTABLE_STATIC int handle_transport_data(struct wg_peer *peer,
+					   struct net_sockaddr *peer_addr,
+					   struct net_pkt *pkt,
+					   size_t ip_udp_hdr_len,
+					   size_t data_len);
 ZTESTABLE_STATIC void keypair_destroy(struct wg_keypair *keypair);
 static void wg_encrypt_packet(uint8_t *dst, const uint8_t *src, size_t src_len,
 			      struct wg_keypair *keypair);

--- a/tests/net/lib/wireguard/src/transport_test.c
+++ b/tests/net/lib/wireguard/src/transport_test.c
@@ -185,4 +185,40 @@ ZTEST(wireguard_transport, test_valid_keepalive_accepted)
 	zassert_equal(stats_after.valid_rx, stats_before.valid_rx);
 }
 
+ZTEST(wireguard_transport, test_unknown_session_does_not_move_endpoint)
+{
+	struct net_sockaddr_storage endpoint_before;
+	struct net_sockaddr_storage endpoint_after;
+	struct net_sockaddr_storage attacker;
+	int ret;
+
+	/* Neither a session nor a handshake in progress, which is the state at
+	 * boot and after the session has expired.
+	 */
+	ret = wireguard_test_clear_session(test_peer_id);
+	zassert_equal(ret, 0, "session clear failed (%d)", ret);
+
+	ret = wireguard_test_peer_endpoint(test_peer_id, &endpoint_before);
+	zassert_equal(ret, 0);
+
+	attacker = make_addr(net_htonl(0xC000022A), 40000); /* 192.0.2.42 */
+
+	ret = wireguard_test_inject_stale_session(test_peer_id,
+						  (struct net_sockaddr *)&attacker,
+						  0xdeadbeef);
+	zexpect_true(ret < 0, "unauthenticated message should be dropped (%d)", ret);
+
+	ret = wireguard_test_peer_endpoint(test_peer_id, &endpoint_after);
+	zassert_equal(ret, 0);
+
+	zexpect_mem_equal(&endpoint_after, &endpoint_before, sizeof(endpoint_after),
+			  "endpoint moved by unauthenticated message");
+
+	/* Recovery from a stale session is still attempted, but only towards
+	 * the endpoint we already trust.
+	 */
+	zexpect_true(wireguard_test_peer_send_handshake(test_peer_id),
+		     "handshake not triggered for stale session");
+}
+
 ZTEST_SUITE(wireguard_transport, NULL, transport_setup, transport_before, NULL, NULL);

--- a/tests/net/lib/wireguard/src/wg_test_helpers.c
+++ b/tests/net/lib/wireguard/src/wg_test_helpers.c
@@ -39,6 +39,8 @@ int wg_psa_aead_encrypt(uint8_t *dst, const uint8_t *src, size_t src_len,
 int wg_process_data_message(struct wg_iface_context *ctx, struct wg_peer *peer,
 			    struct msg_transport_data *data_hdr, struct net_pkt *pkt,
 			    size_t ip_udp_hdr_len, struct net_sockaddr *addr);
+int handle_transport_data(struct wg_peer *peer, struct net_sockaddr *peer_addr,
+			  struct net_pkt *pkt, size_t ip_udp_hdr_len, size_t data_len);
 
 /* Preallocated peer pool / active list, exported via ZTESTABLE_STATIC. */
 extern sys_slist_t peer_list;
@@ -276,6 +278,76 @@ out:
 	net_pkt_unref(pkt);
 
 	return ret;
+}
+
+int wireguard_test_clear_session(int peer_id)
+{
+	struct wg_peer *peer;
+
+	peer = peer_lookup_by_id(peer_id);
+	if (peer == NULL) {
+		return -ENOENT;
+	}
+
+	keypair_destroy(&peer->session.keypair.prev);
+	keypair_destroy(&peer->session.keypair.current);
+	keypair_destroy(&peer->session.keypair.next);
+
+	peer->handshake.is_valid = false;
+	peer->send_handshake = false;
+	peer->first_valid = false;
+
+	return 0;
+}
+
+int wireguard_test_inject_stale_session(int peer_id, const struct net_sockaddr *src,
+					uint32_t receiver)
+{
+	struct msg_transport_data hdr;
+	struct net_pkt *pkt = NULL;
+	struct wg_peer *peer;
+	int ret;
+
+	if (src == NULL) {
+		return -EINVAL;
+	}
+
+	peer = peer_lookup_by_id(peer_id);
+	if (peer == NULL) {
+		return -ENOENT;
+	}
+
+	pkt = net_pkt_alloc_with_buffer(peer->iface, sizeof(hdr), NET_AF_UNSPEC, 0,
+					PKT_ALLOC_WAIT_TIME);
+	if (pkt == NULL) {
+		return -ENOMEM;
+	}
+
+	hdr.type = MESSAGE_TRANSPORT_DATA;
+	hdr.reserved[0] = hdr.reserved[1] = hdr.reserved[2] = 0;
+	hdr.receiver = receiver;
+	sys_put_le64(0ULL, hdr.counter);
+
+	ret = net_pkt_write(pkt, &hdr, sizeof(hdr));
+	if (ret < 0) {
+		goto out;
+	}
+
+	net_pkt_cursor_init(pkt);
+
+	ret = handle_transport_data(peer, (struct net_sockaddr *)src, pkt, 0, 0);
+
+out:
+	net_pkt_unref(pkt);
+
+	return ret;
+}
+
+bool wireguard_test_peer_send_handshake(int peer_id)
+{
+	struct wg_peer *peer = peer_lookup_by_id(peer_id);
+
+	return peer != NULL ? peer->send_handshake : false;
 }
 
 int wireguard_test_get_stats(int peer_id, struct net_stats_vpn *stats)

--- a/tests/net/lib/wireguard/src/wg_test_helpers.h
+++ b/tests/net/lib/wireguard/src/wg_test_helpers.h
@@ -113,6 +113,35 @@ int wireguard_test_inject_transport(int peer_id,
 				    size_t ciphertext_len);
 
 /**
+ * @brief Drop any session and handshake state from a test peer.
+ *
+ * Leaves the peer in the state it has at boot or after a session has expired.
+ *
+ * @param peer_id Peer id from wireguard_test_peer_add().
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int wireguard_test_clear_session(int peer_id);
+
+/**
+ * @brief Inject a transport-data message for an unknown session.
+ *
+ * Drives the receive path with a message whose receiver index matches no
+ * session, i.e. a message that cannot be authenticated.
+ *
+ * @param peer_id Peer id from wireguard_test_peer_add().
+ * @param src Source UDP/IP address of the outer packet.
+ * @param receiver Receiver index to put into the message.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int wireguard_test_inject_stale_session(int peer_id, const struct net_sockaddr *src,
+					uint32_t receiver);
+
+/** @brief Query whether a peer is scheduled to send a handshake initiation. */
+bool wireguard_test_peer_send_handshake(int peer_id);
+
+/**
  * @brief Read accumulated VPN statistics for a peer interface.
  *
  * @param peer_id Peer id from wireguard_test_peer_add().


### PR DESCRIPTION
When a transport data message arrives for a receiver index that matches
no session, the peer might have a stale session, so we trigger a new
handshake. That path also copied the source address of the message into
the peer endpoint.

That message cannot be authenticated. As the receiver index is unknown,
there is no key to verify it with, so anyone able to send an UDP packet
to our port can craft one: a 16 byte datagram with the transport data
type and an arbitrary receiver index is enough. Because the trigger only
runs when we have neither a handshake nor a current keypair, which is
the state at boot and after the session has expired, a single spoofed
datagram permanently redirects our handshake initiations to an address
of the attacker choosing. The legitimate peer never answers them, so
nothing ever re-authenticates and the endpoint stays poisoned. The
attacker can also relay the initiations to the real peer and place
itself in the middle of the tunnel without being on the path.

Every other endpoint update is done only after the message has been
authenticated, either by the Noise handshake or by an AEAD decrypt
followed by the anti-replay check. Do the same here and never move the
endpoint based on this message. Keep the stale session recovery, but
send the handshake to the endpoint we already trust, falling back to the
configured one if we have not learnt any yet. If neither is known, the
peer can only be reached after it has contacted us with a valid
handshake initiation, so just drop the message.

Fixes: #118013