### PR TITLE
net: pkt: Keep the clock out of the packet allocation fast path

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1015,9 +1015,24 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 	do {
 		struct net_buf *new;
 
-		new = net_buf_alloc_fixed(pool, timeout);
-		if (!new) {
-			goto error;
+		/* An allocation that does not block cannot have consumed any
+		 * of the caller's timeout, so only work out how much of it is
+		 * left when the pool was empty and we actually have to wait.
+		 * That keeps the clock out of the common path: with K_NO_WAIT
+		 * the deadline handling in net_buf_alloc_len() short circuits
+		 * too, so nothing below here reads it either.
+		 */
+		new = net_buf_alloc_fixed(pool, K_NO_WAIT);
+		if (new == NULL) {
+			if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+				goto error;
+			}
+
+			new = net_buf_alloc_fixed(pool,
+						  sys_timepoint_timeout(end));
+			if (new == NULL) {
+				goto error;
+			}
 		}
 
 		if (!first && !current) {
@@ -1046,8 +1061,6 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 
 			size -= current->size;
 		}
-
-		timeout = sys_timepoint_timeout(end);
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 		NET_FRAG_CHECK_IF_NOT_IN_USE(new, new->ref + 1);

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1745,7 +1745,6 @@ pkt_alloc_with_buffer(struct k_mem_slab *slab,
 		      k_timeout_t timeout)
 #endif
 {
-	k_timepoint_t end = sys_timepoint_calc(timeout);
 	struct net_pkt *pkt;
 	int ret;
 
@@ -1756,19 +1755,40 @@ pkt_alloc_with_buffer(struct k_mem_slab *slab,
 	NET_DBG("On iface %d (%p) size %zu", net_if_get_by_iface(iface), iface, size);
 #endif /* CONFIG_NET_RAW_MODE */
 
+	/* As in pkt_alloc_buffer(), take the slab without waiting first. When
+	 * that works none of the caller's timeout has gone, so it can be
+	 * handed to the buffer allocation untouched and the clock stays out
+	 * of the common path entirely.
+	 */
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-	pkt = pkt_alloc_on_iface(slab, iface, timeout, caller, line);
+	pkt = pkt_alloc_on_iface(slab, iface, K_NO_WAIT, caller, line);
 #else
-	pkt = pkt_alloc_on_iface(slab, iface, timeout);
+	pkt = pkt_alloc_on_iface(slab, iface, K_NO_WAIT);
 #endif
 
-	if (!pkt) {
-		return NULL;
+	if (pkt == NULL) {
+		k_timepoint_t end;
+
+		if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+			return NULL;
+		}
+
+		end = sys_timepoint_calc(timeout);
+
+#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
+		pkt = pkt_alloc_on_iface(slab, iface, timeout, caller, line);
+#else
+		pkt = pkt_alloc_on_iface(slab, iface, timeout);
+#endif
+		if (pkt == NULL) {
+			return NULL;
+		}
+
+		/* Waiting for the slab used up part of the caller's budget. */
+		timeout = sys_timepoint_timeout(end);
 	}
 
 	net_pkt_set_family(pkt, family);
-
-	timeout = sys_timepoint_timeout(end);
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 	ret = net_pkt_alloc_buffer_debug(pkt, size, proto, timeout,
 					 caller, line);

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -1287,4 +1287,217 @@ ZTEST(net_pkt_test_suite, test_net_pkt_shallow_clone_append_buf_2)
 	test_net_pkt_shallow_clone_append_buf(2);
 }
 
+/* Buffers held to keep the data pool empty while a blocking allocation runs. */
+static struct net_buf *pool_hog;
+
+static struct net_buf *drain_data_pool(struct net_buf_pool *pool)
+{
+	struct net_buf *head = NULL;
+	struct net_buf *buf;
+
+	while ((buf = net_buf_alloc_len(pool, CONFIG_NET_BUF_DATA_SIZE,
+					K_NO_WAIT)) != NULL) {
+		buf->frags = head;
+		head = buf;
+	}
+
+	return head;
+}
+
+static void release_pool_hog(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	if (pool_hog != NULL) {
+		net_buf_unref(pool_hog);
+		pool_hog = NULL;
+	}
+}
+
+static K_WORK_DELAYABLE_DEFINE(pool_hog_work, release_pool_hog);
+
+/* The allocator tries a non-blocking allocation before waiting. Check that a
+ * caller which asked to wait still waits, and still gets its buffers once they
+ * are returned to the pool.
+ */
+ZTEST(net_pkt_test_suite, test_net_pkt_alloc_buffer_blocking_succeeds)
+{
+	struct net_buf_pool *tx_data;
+	struct net_pkt *pkt;
+	int64_t start;
+
+	net_pkt_get_info(NULL, NULL, NULL, &tx_data);
+
+	pool_hog = drain_data_pool(tx_data);
+	zassert_not_null(pool_hog, "Data pool was already empty");
+	zassert_equal(atomic_get(&tx_data->avail_count), 0,
+		      "Data pool not drained");
+
+	k_work_schedule(&pool_hog_work, K_MSEC(50));
+
+	start = k_uptime_get();
+	pkt = net_pkt_alloc_with_buffer(NULL, CONFIG_NET_BUF_DATA_SIZE * 3,
+					NET_AF_UNSPEC, 0, K_MSEC(2000));
+
+	zassert_not_null(pkt, "Blocking allocation failed even though the "
+			      "buffers were returned to the pool");
+	zassert_true(k_uptime_get() - start >= 50,
+		     "Allocation returned without waiting");
+
+	net_pkt_unref(pkt);
+	release_pool_hog(NULL);
+}
+
+/* A caller that asked to wait for a given time must not wait appreciably
+ * longer. The upper bound is the point of this test: it fails if the deadline
+ * is ever restarted per fragment instead of being held across the chain.
+ */
+ZTEST(net_pkt_test_suite, test_net_pkt_alloc_buffer_blocking_times_out)
+{
+	struct net_buf_pool *tx_data;
+	struct net_pkt *pkt;
+	int64_t elapsed;
+
+	net_pkt_get_info(NULL, NULL, NULL, &tx_data);
+
+	pool_hog = drain_data_pool(tx_data);
+	zassert_not_null(pool_hog, "Data pool was already empty");
+
+	elapsed = k_uptime_get();
+	pkt = net_pkt_alloc_with_buffer(NULL, CONFIG_NET_BUF_DATA_SIZE * 3,
+					NET_AF_UNSPEC, 0, K_MSEC(100));
+	elapsed = k_uptime_get() - elapsed;
+
+	zassert_is_null(pkt, "Allocation succeeded with an empty pool");
+	zassert_true(elapsed >= 100, "Allocation gave up after %lld ms",
+		     elapsed);
+	zassert_true(elapsed < 300, "Allocation waited %lld ms for a 100 ms "
+		     "timeout", elapsed);
+
+	release_pool_hog(NULL);
+}
+
+/* Buffers handed back one at a time, so that a multi fragment allocation has
+ * to wait more than once.
+ */
+static struct net_buf *trickle_hog;
+
+static void trickle_release(struct k_work *work)
+{
+	struct net_buf *buf = trickle_hog;
+
+	if (buf == NULL) {
+		return;
+	}
+
+	trickle_hog = buf->frags;
+	buf->frags = NULL;
+	net_buf_unref(buf);
+
+	if (trickle_hog != NULL) {
+		k_work_reschedule(k_work_delayable_from_work(work), K_MSEC(60));
+	}
+}
+
+static K_WORK_DELAYABLE_DEFINE(trickle_work, trickle_release);
+
+/* The timeout is a budget for the whole allocation, not for each fragment of
+ * it. With one buffer coming back every 60 ms, a three fragment allocation
+ * given 100 ms must give up: it can only ever get the first fragment. If the
+ * deadline were restarted for each fragment it would instead collect all
+ * three and return after about 180 ms.
+ */
+ZTEST(net_pkt_test_suite, test_net_pkt_alloc_buffer_deadline_spans_chain)
+{
+	struct net_buf_pool *tx_data;
+	struct net_pkt *pkt;
+	int64_t elapsed;
+
+	net_pkt_get_info(NULL, NULL, NULL, &tx_data);
+
+	trickle_hog = drain_data_pool(tx_data);
+	zassert_not_null(trickle_hog, "Data pool was already empty");
+
+	k_work_schedule(&trickle_work, K_MSEC(60));
+
+	elapsed = k_uptime_get();
+	pkt = net_pkt_alloc_with_buffer(NULL, CONFIG_NET_BUF_DATA_SIZE * 3,
+					NET_AF_UNSPEC, 0, K_MSEC(100));
+	elapsed = k_uptime_get() - elapsed;
+
+	if (pkt != NULL) {
+		net_pkt_unref(pkt);
+	}
+
+	(void)k_work_cancel_delayable(&trickle_work);
+	if (trickle_hog != NULL) {
+		net_buf_unref(trickle_hog);
+		trickle_hog = NULL;
+	}
+
+	zassert_is_null(pkt, "Allocation collected every fragment in %lld ms "
+			"despite a 100 ms timeout, so the deadline is being "
+			"restarted per fragment", elapsed);
+	zassert_true(elapsed < 150, "Allocation waited %lld ms for a 100 ms "
+		     "timeout", elapsed);
+}
+
+/* When only part of the chain can be allocated the buffers taken so far must
+ * go back to the pool.
+ */
+ZTEST(net_pkt_test_suite, test_net_pkt_alloc_buffer_partial_chain)
+{
+	struct net_buf_pool *tx_data;
+	struct net_buf *spare;
+	struct net_pkt *pkt;
+
+	net_pkt_get_info(NULL, NULL, NULL, &tx_data);
+
+	pool_hog = drain_data_pool(tx_data);
+	zassert_not_null(pool_hog, "Data pool was already empty");
+
+	/* Hand one buffer back, so the first fragment succeeds and the
+	 * second one has to give up.
+	 */
+	spare = pool_hog;
+	pool_hog = spare->frags;
+	spare->frags = NULL;
+	net_buf_unref(spare);
+
+	zassert_equal(atomic_get(&tx_data->avail_count), 1,
+		      "Expected exactly one buffer to be available");
+
+	pkt = net_pkt_alloc_with_buffer(NULL, CONFIG_NET_BUF_DATA_SIZE * 3,
+					NET_AF_UNSPEC, 0, K_MSEC(100));
+
+	zassert_is_null(pkt, "Allocation succeeded without enough buffers");
+	zassert_equal(atomic_get(&tx_data->avail_count), 1,
+		      "Partially allocated chain was not returned to the pool");
+
+	release_pool_hog(NULL);
+}
+
+/* A non-blocking caller must still fail immediately on an empty pool, and must
+ * not leak the buffer it probed for.
+ */
+ZTEST(net_pkt_test_suite, test_net_pkt_alloc_buffer_nowait_exhausted)
+{
+	struct net_buf_pool *tx_data;
+	struct net_pkt *pkt;
+
+	net_pkt_get_info(NULL, NULL, NULL, &tx_data);
+
+	pool_hog = drain_data_pool(tx_data);
+	zassert_not_null(pool_hog, "Data pool was already empty");
+
+	pkt = net_pkt_alloc_with_buffer(NULL, CONFIG_NET_BUF_DATA_SIZE,
+					NET_AF_UNSPEC, 0, K_NO_WAIT);
+
+	zassert_is_null(pkt, "Allocation succeeded with an empty pool");
+	zassert_equal(atomic_get(&tx_data->avail_count), 0,
+		      "A failed allocation returned a buffer to the pool");
+
+	release_pool_hog(NULL);
+}
+
 ZTEST_SUITE(net_pkt_test_suite, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Allocating a packet reads the clock far more often than its timeout needs, and
the reads are not cheap. This series removes the ones that cannot affect the
outcome, which is all of them whenever the pools are not empty.

### The finding

Building a packet's buffer chain allocates one `net_buf` per fragment, and every
fragment reads the clock three times:

| site | call |
|---|---|
| `net_pkt.c`, bottom of `pkt_alloc_buffer()`'s loop | `sys_timepoint_timeout(end)` |
| `lib/net_buf/buf.c`, entry to `net_buf_alloc_len()` | `sys_timepoint_calc(timeout)` |
| `lib/net_buf/buf.c`, before the data allocation | `sys_timepoint_timeout(end)` |

Each one goes through `sys_clock_tick_get()` into the timer driver. On a target
whose timer frequency is only known at runtime the divisor is a variable and the
dividend is 64-bit, so a 32-bit build gets a call to `__udivdi3` on top of the
driver read.

With the default `CONFIG_NET_BUF_DATA_SIZE=128` a 1280-byte frame is ten
fragments, so one packet paid for about thirty clock reads. Measured on a QEMU
icount profile of the zperf TCP loopback run (the tooling proposed in #116614):

| function | instructions per payload byte | share of run |
|---|---|---|
| `sys_clock_elapsed` | 4.399 | 7.03% |
| `sys_timepoint_timeout` | 3.249 | 5.19% |
| `__udivdi3` | 2.774 | 4.43% |
| `sys_timepoint_calc` | 1.615 | 2.58% |
| **total** | **12.04** | **19.2%** |

Two checks that the attribution is right. The measured `calc : timeout` ratio is
1.615 : 3.249, or 1 : 2.01, which is exactly one `calc` and two `timeout` per
fragment. And UDP measures the same proportion as TCP, so this is a cost of the
allocator rather than of either protocol.

### The change

An allocation that does not block cannot have consumed any of the caller's
timeout. So ask the pool without waiting first, and only work out how much time
is left when the pool turns out to be empty and the allocation really has to
wait.

Passing `K_NO_WAIT` also makes the deadline handling inside `net_buf_alloc_len()`
short circuit: it stores a zero deadline without reading the clock, and the
second site then returns `K_NO_WAIT` without reading it either. So the one change
in `net_pkt.c` removes all three reads, and `lib/net_buf/` needs no change.

The second commit does the same for the packet slab in
`pkt_alloc_with_buffer()`. That is a smaller effect, two reads per packet rather
than three per fragment, and it is independent of the first.

### Why the timeout still means what it did

The deadline is still taken on entry, and every allocation that waits is still
measured against that same absolute instant. The rewrite does not change the set
of instants at which the function can be waiting; it inserts a bounded,
non-blocking probe before each wait. An allocation therefore cannot take longer
than it did before.

A successful probe provably consumes nothing: it either takes the uninitialised
count path, which is pointer arithmetic, or a `k_lifo_get(K_NO_WAIT)` that pops
under a spinlock. A failed probe is side-effect free — it returns before the
success path, touching no reference count, no `uninit_count` and no pool usage
counter. And it cannot take a buffer from a thread already waiting for one,
because `k_lifo_put()` hands the buffer straight to the highest-priority waiter
rather than putting it on the queue.

Callers that asked not to wait at all keep making exactly one attempt, so every
ISR path and every existing `K_NO_WAIT` caller behaves as before.

The one visible difference: with `CONFIG_NET_BUF_LOG` enabled (`default n`), a
fragment that has to wait now also logs the failed probe that preceded the wait.

### Measured effect

qemu_x86, zperf loopback selftest under `-icount shift=5`:

| transfer | before | after | |
|---|---|---|---|
| tcp4, 128-byte fragments | 4.093 Mbps | **4.827 Mbps** | **+17.9%** |
| udp4, 128-byte fragments | 7.421 Mbps | **8.921 Mbps** | **+20.2%** |
| tcp4, 1100-byte fragments | 6.642 Mbps | **7.212 Mbps** | **+8.6%** |

`sys_clock_elapsed` drops by 89%, `__udivdi3` by 89% (it tracks it exactly, being
its child), `sys_timepoint_timeout` by 76%, and `sys_timepoint_calc` by 38% —
the last one still runs once per chain, by design.

The gain falls with fragment size because the cost was per fragment: at 1100
bytes a 1280-byte frame is two fragments instead of ten.

### Tests

The blocking allocation path had no coverage at all. Every allocation in
`tests/net/net_pkt` asked not to wait, which is precisely the path this series
leaves alone, so nothing would have caught a blocking allocation quietly turning
into a failing one. Four tests land with the first commit:

- a blocking allocation that succeeds once a cooperative thread frees buffers,
- one that times out, checked against both bounds,
- a partial chain that unwinds, checked against the pool's available count,
- a non-blocking allocation on an empty pool, pinning the single-attempt path.

The timeout bound is the one that matters, and it is worth saying how it is
built, because the obvious version of it does not work. Against a fully drained
pool only one wait ever happens, so a deadline wrongly restarted per fragment
cannot show up. This test instead hands a buffer back every 60 ms: a three
fragment allocation given 100 ms must then give up, having only ever obtained the
first fragment, where a per-fragment deadline would collect all three and return
after about 180 ms. Verified by injecting that bug: the test fails on it and
passes without it.

### Deliberately not touched

- **The variable-size `pkt_alloc_buffer()`.** It has no timepoint bookkeeping to
  remove, it is not the default, and a probe there could take a `net_buf` from
  the LIFO, fail the heap allocation and destroy it again, turning one wait into
  two for no measured gain.
- **`lib/net_buf/buf.c`.** Hoisting `sys_timepoint_calc()` out of
  `net_buf_alloc_len()`'s entry would be a bug: the `k_lifo_get()` between it and
  the data allocation can block, so the deadline has to be taken before it.
