### PR TITLE
arch: openrisc: fill the branch delay slot when entering main

### DIFF
--- a/arch/openrisc/core/thread.c
+++ b/arch/openrisc/core/thread.c
@@ -78,8 +78,10 @@ FUNC_NORETURN void z_openrisc_switch_to_main_no_multithreading(k_thread_entry_t 
 	__asm__ volatile (
 		"l.ori r1, %0, 0\n"
 		"l.jalr %1\n"
+		"l.nop\n"
 		:
-		: "r" (main_stack), "r" (main_entry));
+		: "r" (main_stack), "r" (main_entry)
+		: "memory");
 
 	/* infinite loop */
 	irq_lock();

--- a/tests/kernel/mem_slab/mslab_api/tests.yaml
+++ b/tests/kernel/mem_slab/mslab_api/tests.yaml
@@ -24,10 +24,6 @@ tests:
       - qemu_riscv64
       - qemu_leon3
       - qemu_or1k
-    # qemu_or1k takes a fatal I-TLB miss on the way out of main with
-    # CONFIG_MULTITHREADING=n. Drop this once #116733 is merged.
-    platform_exclude:
-      - qemu_or1k
     integration_platforms:
       - qemu_cortex_m3
       - qemu_arc/qemu_arc_hs


### PR DESCRIPTION
> [!NOTE]
> The second commit reverts #116736, the `platform_exclude` stopgap that keeps `kernel.memory_slabs.api.no-mt` off `qemu_or1k` until the arch fix lands. Both commits are meant to merge together.

Fixes the `I-TLB Miss` fatal error that hits `qemu_or1k` immediately *after* a `CONFIG_MULTITHREADING=n` test reports success — e.g. `kernel.memory_slabs.api.no-mt`:

```
RunID: c3f27577f1996450a441b1a9c1a8e540
PROJECT EXECUTION SUCCESSFUL
E:
E:  reason: 10, I-TLB Miss
E: epcr: 0x0000314c esr: 0x00008558
...
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Halting system
```

All subtests pass; the fault is in the return path out of `main`.

### Root cause

`z_openrisc_switch_to_main_no_multithreading()` jumps to `main` from an inline asm block that ends with a branch and no delay-slot instruction:

```c
__asm__ volatile (
	"l.ori r1, %0, 0\n"
	"l.jalr %1\n"
	:
	: "r" (main_stack), "r" (main_entry));
```

GCC cannot see into an asm block, so its delayed-branch pass never fills that slot. The first instruction the compiler emits *after* the block therefore executes in the delay slot, and `l.jalr` sets `r9` to the *second* one. The code that follows is `irq_lock()`, which compiles to roughly:

```
l.mfspr r17, r0, SPR_SR      <- runs in the delay slot, before main
l.movhi r19, 0xffff          <- r9 points here
l.ori   r19, r19, 0xfff9
l.and   r17, r17, r19
l.mtspr r0, r17, SPR_SR      <- writes whatever main left in r17
```

`r17` is caller-saved, so `main` clobbers it freely. When `main` returns it lands mid-sequence, past the `l.mfspr`, and a stale scratch value is masked and written straight into the Supervisor Register.

### Evidence from the register dump

| Value | Meaning |
| --- | --- |
| `r19 = 0xfffffff9` | `~SPR_SR_IRQ_MASK`, the `irq_lock()` mask constant |
| `r17 = 0x8558` | stale leftover from `main`, survives the `l.and` unchanged |
| `esr = 0x8558` | same value, now in SR: `SM` cleared (user mode), `IME` set (IMMU on) |
| `r27 = 0x1f` | `sr_init`, the value SR *should* have held |

With the IMMU suddenly enabled and no TLB entries, the very next instruction fetch takes an I-TLB miss. Nothing about this is specific to mem_slab — that test just happens to be one of the few `no-mt` suites `qemu_or1k` is in `platform_allow` for.

### Fix

Emit the `l.nop` explicitly. This is correct on both core variants:

- delay-slot cores: the nop executes in the slot, `r9 = PC + 8`
- `__OR1K_NODELAY__` cores: `r9 = PC + 4` points at the nop, which falls through

Either way `main` returns to a clean `l.mfspr` and `irq_lock()` runs as written. This also matches the convention already used throughout `arch/openrisc/core/*.S`, where every branch is followed by its delay-slot instruction.

The commit also adds the `"memory"` clobber that the RISC-V port already carries on the equivalent asm, since `main` observes the `_kernel.cpus[0]` stores made just above.

### Why this surfaced now

The fault is not new — it has been there since the initial OpenRISC port (76def70bed5, #98160) and is present in `v4.4.0`. What changed is that twister only recently learned to see it.

Before ac4666dac26 ("twister: detect faults reported after a test passes", in `main` since 2026-08-17), `Harness.process_test()` compared the console line for equality against the bare `ZEPHYR FATAL ERROR` marker. `z_fatal_error()` logs through `LOG_ERR`, so the line always arrives with a timestamp and an `<err> os:` prefix and never matched — meaning the Ztest harness could not fail on a fault at all. The check also sat after the `RUN_PASSED` branch, so a fault arriving once `PROJECT EXECUTION SUCCESSFUL` had been printed could not withdraw the PASS either way.

That commit matches the marker as a substring and downgrades an already-recorded PASS, which is exactly the `Fault detected while running test` reason in the failure above. Every `qemu_or1k` `no-mt` run has been crashing on exit all along; the harness was simply stopping at the success marker.

### Test coverage restored

The second commit reverts #116736, putting `kernel.memory_slabs.api.no-mt` back on `qemu_or1k` in the same PR as the fix, so the scenario never sits excluded on a `main` that already has the fix.

Two further scenarios run the same fatal path on `qemu_or1k` and are fixed here too, though neither is currently failing (whether the corrupted SR actually faults depends on what the test binary leaves in `r17`):

- `libraries.multi_heap.no_mt`
- `kernel.timer.no_multitheading`

