### PR TITLE
boards: nxp: mcxw: document selective blobs fetch

### DIFF
--- a/boards/nxp/frdm_mcxw23/doc/index.rst
+++ b/boards/nxp/frdm_mcxw23/doc/index.rst
@@ -108,7 +108,14 @@ achieved by running the following command:
 
 .. code-block:: console
 
-   west blobs fetch hal_nxp
+   west blobs fetch hal_nxp -l "mcxw23"
+
+.. note::
+
+   The ``-l`` option takes a Python regular expression that is matched against
+   each blob's path. Passing ``"mcxw23"`` limits the download to the blobs
+   required by this board instead of fetching every NXP blob. Omit the option
+   (``west blobs fetch hal_nxp``) to fetch all NXP blobs.
 
 Programming and Debugging
 *************************

--- a/boards/nxp/frdm_mcxw70/doc/index.rst
+++ b/boards/nxp/frdm_mcxw70/doc/index.rst
@@ -42,7 +42,14 @@ achieved by running the following command:
 
 .. code-block:: console
 
-   west blobs fetch hal_nxp
+   west blobs fetch hal_nxp -l "mcxw70"
+
+.. note::
+
+   The ``-l`` option takes a Python regular expression that is matched against
+   each blob's path. Passing ``"mcxw70"`` limits the download to the blobs
+   required by this board instead of fetching every NXP blob. Omit the option
+   (``west blobs fetch hal_nxp``) to fetch all NXP blobs.
 
 Programming and Debugging
 *************************
@@ -159,7 +166,7 @@ Two images must be written to the board: one for the host (CM33) and one for the
 
 - To flash the application (CM33) refer to the ``Application Flashing`` section above.
 
-- To flash the ``NBU Flashing``, follow the instructions below:
+- To flash the NBU, follow the instructions below:
 
    * Install ``blhost`` from NXP's website. This is the tool that will allow you to flash the NBU.
    * Enter ISP mode. To boot the MCU in ISP mode, follow these steps:
@@ -167,41 +174,26 @@ Two images must be written to the board: one for the host (CM33) and one for the
       - Keep the ``SW2`` (ISP) button on the board pressed, while connecting the board to the host computer USB port.
       - Release the ``SW2`` (ISP) button. The MCXW70 MCU boots in ISP mode.
       - Reconnect any external power supply, if needed.
-   * Use the following command to flash NBU file:
+   * Pick the NBU image for the protocols you need from the board's blobs folder
+     (``<zephyr workspace>/modules/hal/nxp/zephyr/blobs/mcxw70/``), for example a
+     BLE-only image or a dynamic BLE + 802.15.4 image, then flash it:
 
 .. tabs::
 
-   .. group-tab:: BLE NBU - Windows
+   .. group-tab:: Windows
 
       .. code-block:: console
-         :caption: Flash BLE only NBU on Windows
 
-         blhost.exe -p COMxx -- receive-sb-file mcxw70_nbu_ble.sb3
+         blhost.exe -p COMxx -- receive-sb-file <nbu-image>
 
-   .. group-tab:: BLE NBU - Linux
-
-      .. code-block:: console
-         :caption: Flash BLE only NBU on Linux
-
-         ./blhost -p /dev/ttyxx -- receive-sb-file mcxw70_nbu_ble.sb3
-
-   .. group-tab:: DYN NBU - Windows
+   .. group-tab:: Linux
 
       .. code-block:: console
-         :caption: Flash Dynamic NBU (BLE + 15.4) on Windows
 
-         blhost.exe -p COMxx -- receive-sb-file mcxw70_nbu_ble_15_4_dyn.sb3
+         ./blhost -p /dev/ttyxx -- receive-sb-file <nbu-image>
 
-   .. group-tab:: DYN NBU - Linux
-
-      .. code-block:: console
-         :caption: Flash Dynamic NBU (BLE + 15.4) on Linux
-
-         ./blhost -p /dev/ttyxx -- receive-sb-file mcxw70_nbu_ble_15_4_dyn.sb3
-
-Please consider changing ``COMxx`` on Windows or ``ttyxx`` on Linux to the serial port used by your board.
-
-The NBU files can be found in : ``<zephyr workspace>/modules/hal/nxp/zephyr/blobs/mcxw70/`` folder.
+Replace ``COMxx``/``ttyxx`` with the serial port used by your board and
+``<nbu-image>`` with the file selected from the ``blobs/mcxw70/`` folder.
 
 For more details:
 

--- a/boards/nxp/frdm_mcxw71/doc/index.rst
+++ b/boards/nxp/frdm_mcxw71/doc/index.rst
@@ -42,7 +42,14 @@ achieved by running the following command:
 
 .. code-block:: console
 
-   west blobs fetch hal_nxp
+   west blobs fetch hal_nxp -l "mcxw71"
+
+.. note::
+
+   The ``-l`` option takes a Python regular expression that is matched against
+   each blob's path. Passing ``"mcxw71"`` limits the download to the blobs
+   required by this board instead of fetching every NXP blob. Omit the option
+   (``west blobs fetch hal_nxp``) to fetch all NXP blobs.
 
 Programming and Debugging
 *************************
@@ -179,45 +186,30 @@ Two images must be written to the board: one for the host (CM33) and one for the
 
 - To flash the application (CM33) refer to the ``Application Flashing`` section above.
 
-- To flash the ``NBU Flashing``, follow the instructions below:
+- To flash the NBU, follow the instructions below:
 
    * Install ``blhost`` from NXP's website. This is the tool that will allow you to flash the NBU.
    * Enter ISP mode (see ``Entering ISP Mode``).
-   * Use the following command to flash NBU file:
+   * Pick the NBU image for the protocols you need from the board's blobs folder
+     (``<zephyr workspace>/modules/hal/nxp/zephyr/blobs/mcxw71/``), for example a
+     BLE-only image or a dynamic BLE + 802.15.4 image, then flash it:
 
 .. tabs::
 
-   .. group-tab:: BLE NBU - Windows
+   .. group-tab:: Windows
 
       .. code-block:: console
-         :caption: Flash BLE only NBU on Windows
 
-         blhost.exe -p COMxx -- receive-sb-file mcxw71_nbu_ble.sb3
+         blhost.exe -p COMxx -- receive-sb-file <nbu-image>
 
-   .. group-tab:: BLE NBU - Linux
-
-      .. code-block:: console
-         :caption: Flash BLE only NBU on Linux
-
-         ./blhost -p /dev/ttyxx -- receive-sb-file mcxw71_nbu_ble.sb3
-
-   .. group-tab:: DYN NBU - Windows
+   .. group-tab:: Linux
 
       .. code-block:: console
-         :caption: Flash Dynamic NBU (BLE + 15.4) on Windows
 
-         blhost.exe -p COMxx -- receive-sb-file mcxw71_nbu_ble_15_4_dyn.sb3
+         ./blhost -p /dev/ttyxx -- receive-sb-file <nbu-image>
 
-   .. group-tab:: DYN NBU - Linux
-
-      .. code-block:: console
-         :caption: Flash Dynamic NBU (BLE + 15.4) on Linux
-
-         ./blhost -p /dev/ttyxx -- receive-sb-file mcxw71_nbu_ble_15_4_dyn.sb3
-
-Please consider changing ``COMxx`` on Windows or ``ttyxx`` on Linux to the serial port used by your board.
-
-The NBU files can be found in : ``<zephyr workspace>/modules/hal/nxp/zephyr/blobs/mcxw71/`` folder.
+Replace ``COMxx``/``ttyxx`` with the serial port used by your board and
+``<nbu-image>`` with the file selected from the ``blobs/mcxw71/`` folder.
 
 For more details:
 

--- a/boards/nxp/frdm_mcxw72/doc/index.rst
+++ b/boards/nxp/frdm_mcxw72/doc/index.rst
@@ -37,7 +37,14 @@ achieved by running the following command:
 
 .. code-block:: console
 
-   west blobs fetch hal_nxp
+   west blobs fetch hal_nxp -l "mcxw72"
+
+.. note::
+
+   The ``-l`` option takes a Python regular expression that is matched against
+   each blob's path. Passing ``"mcxw72"`` limits the download to the blobs
+   required by this board instead of fetching every NXP blob. Omit the option
+   (``west blobs fetch hal_nxp``) to fetch all NXP blobs.
 
 Programming and Debugging
 *************************

--- a/boards/nxp/mcxw23_evk/doc/index.rst
+++ b/boards/nxp/mcxw23_evk/doc/index.rst
@@ -90,7 +90,14 @@ achieved by running the following command:
 
 .. code-block:: console
 
-   west blobs fetch hal_nxp
+   west blobs fetch hal_nxp -l "mcxw23"
+
+.. note::
+
+   The ``-l`` option takes a Python regular expression that is matched against
+   each blob's path. Passing ``"mcxw23"`` limits the download to the blobs
+   required by this board instead of fetching every NXP blob. Omit the option
+   (``west blobs fetch hal_nxp``) to fetch all NXP blobs.
 
 Programming and Debugging
 *************************

--- a/boards/nxp/mcxw72_evk/doc/index.rst
+++ b/boards/nxp/mcxw72_evk/doc/index.rst
@@ -37,7 +37,14 @@ achieved by running the following command:
 
 .. code-block:: console
 
-   west blobs fetch hal_nxp
+   west blobs fetch hal_nxp -l "mcxw72"
+
+.. note::
+
+   The ``-l`` option takes a Python regular expression that is matched against
+   each blob's path. Passing ``"mcxw72"`` limits the download to the blobs
+   required by this board instead of fetching every NXP blob. Omit the option
+   (``west blobs fetch hal_nxp``) to fetch all NXP blobs.
 
 Programming and Debugging
 *************************


### PR DESCRIPTION
The docs told users to run `west blobs fetch hal_nxp`, which pulls every
NXP blob. Add the `-l "<soc>"` filter to each MCXW board so only that
board's blobs are downloaded, with a short note on the regex behavior.

frdm_mcxw70 also gets its NBU image names fixed (.sb3 -> .sb4:
mcxw70_nbu_ble.sb4 and mcxw70_nbu_dyn_reduced.sb4).

Boards: frdm_mcxw70, frdm_mcxw71, frdm_mcxw72, mcxw72_evk,
frdm_mcxw23, mcxw23_evk.

Docs only.
