### PR TITLE
tests: mem_slab: exclude qemu_or1k from the no-multithreading variant

### DIFF
--- a/tests/kernel/mem_slab/mslab_api/tests.yaml
+++ b/tests/kernel/mem_slab/mslab_api/tests.yaml
@@ -24,6 +24,10 @@ tests:
       - qemu_riscv64
       - qemu_leon3
       - qemu_or1k
+    # qemu_or1k takes a fatal I-TLB miss on the way out of main with
+    # CONFIG_MULTITHREADING=n. Drop this once #116733 is merged.
+    platform_exclude:
+      - qemu_or1k
     integration_platforms:
       - qemu_cortex_m3
       - qemu_arc/qemu_arc_hs


### PR DESCRIPTION
Hotfix to unblock CI. **The real fix is #116733 but it needs time for a proper review from OpenRISC maintainer ; revert this once that lands.**

`kernel.memory_slabs.api.no-mt` fails on `qemu_or1k` with a fatal I-TLB miss raised *after* the suite has already reported success:

```
RunID: c3f27577f1996450a441b1a9c1a8e540
PROJECT EXECUTION SUCCESSFUL
E:
E:  reason: 10, I-TLB Miss
E: epcr: 0x0000314c esr: 0x00008558
...
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
```

Every subtest passes; the crash is in the return path out of `main`. The OpenRISC `CONFIG_MULTITHREADING=n` entry point leaves the `l.jalr` branch delay slot unfilled, so `main` returns into the middle of the following `irq_lock()` and a stale scratch register is written straight into the Supervisor Register. #116733 has the full analysis and the one-line arch fix.

### Why now

The fault is not new — it dates to the initial OpenRISC port (76def70bed5, #98160) and is present in `v4.4.0`. ac4666dac26 ("twister: detect faults reported after a test passes", in `main` since 2026-08-17) is what made twister start seeing it: the marker is now matched as a substring and a fault arriving after `PROJECT EXECUTION SUCCESSFUL` withdraws the recorded PASS.

### Scope

Two other scenarios share the same fatal path and also allow `qemu_or1k`:

- `libraries.multi_heap.no_mt`
- `kernel.timer.no_multitheading`

They are left alone here because they are not currently failing — whether the corrupted SR value actually faults depends on what the test binary happens to leave in `r17`. If CI turns them red too, they need the same exclusion, and #116733 fixes all three at once.
