### PR TITLE
sysbuild: support using CMake defined variables in values

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3483,6 +3483,21 @@ function(zephyr_get variable)
       get_property(sysbuild_main_app TARGET sysbuild_cache PROPERTY SYSBUILD_MAIN_APP)
       get_property(sysbuild_local_${var} TARGET sysbuild_cache PROPERTY ${sysbuild_name}_${var})
       get_property(sysbuild_global_${var} TARGET sysbuild_cache PROPERTY ${var})
+
+      foreach(scope sysbuild_local sysbuild_global)
+        string(CONFIGURE "${${scope}_${var}}" test_expansion_value)
+        if(NOT "${${scope}_${var}}" STREQUAL "${test_expansion_value}")
+          # variable contains an unresolved or undefined variable.
+          # Check if it is sysbuild or globally defined, and resolve it.
+          string(REGEX MATCHALL "\\\${[^\\\$]*}" var_references "${${scope}_${var}}")
+          foreach(var ${var_references})
+            # Var name exists in the match pattern `(<pattern>)` and not the out var `ignore`.
+            string(REGEX MATCH "^\\\${\([^}]*\)}$" ignore "${var}")
+            zephyr_get(${CMAKE_MATCH_1} SYSBUILD)
+          endforeach()
+        endif()
+      endforeach()
+
       if(NOT DEFINED sysbuild_local_${var} AND sysbuild_main_app)
         set(sysbuild_local_${var} ${sysbuild_global_${var}})
       endif()


### PR DESCRIPTION
Zephyr build system supports the use of CMake variables on command line invocation for settings such as CONF_FILE, like
`-DCONF_FILE="\${<var>}/foo.conf"`.

However this principle only works for variables existing in the current CMake scope, for example cache variables or already resolved sysbuild variables where `zephyr_get(<var>)` has already been called.

This means that when using sysbuild, then the use of `-D<var>="\${APP_DIR}/file.txt"` results in different behavior depending on whether `zephyr_get(APP_DIR)` has been called previously in CMake or not.

Support the use of `${<var>}` for vars already defined through sysbuild by looking up `<var>` if it haven't been resolved yet.

Fixes: #74051 