### PR TITLE
soc: nordic: remove Kconfig options deprecated in 3.5-4.1

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -243,6 +243,9 @@ Boards
   instead: ``regulator-initial-mode = <NRF5X_REG_MODE_DCDC>`` on ``&reg1``/``&vregmain``/
   ``&vregradio``, and ``status = "okay"`` on ``&reg0``/``&vregh``.
 
+* The Nordic nRF53 Kconfig option ``CONFIG_BOARD_ENABLE_CPUNET`` has been removed. Use
+  :kconfig:option:`CONFIG_SOC_NRF53_CPUNET_ENABLE` instead.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -237,6 +237,12 @@ Boards
 * The Nordic nRF52 Kconfig option ``CONFIG_GPIO_AS_PINRESET`` has been removed. Set the
   ``gpio-as-nreset`` property on the ``&uicr`` devicetree node instead.
 
+* The Nordic Kconfig options ``CONFIG_SOC_DCDC_NRF52X``, ``CONFIG_SOC_DCDC_NRF52X_HV``,
+  ``CONFIG_SOC_DCDC_NRF53X_APP``, ``CONFIG_SOC_DCDC_NRF53X_NET`` and
+  ``CONFIG_SOC_DCDC_NRF53X_HV`` have been removed. Configure the regulators in devicetree
+  instead: ``regulator-initial-mode = <NRF5X_REG_MODE_DCDC>`` on ``&reg1``/``&vregmain``/
+  ``&vregradio``, and ``status = "okay"`` on ``&reg0``/``&vregh``.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -234,6 +234,9 @@ Boards
   * ``scobc_module1`` → ``scobc_a1``
   * ``xiao_esp32c6`` → ``xiao_esp32c6/esp32c6/hpcore``
 
+* The Nordic nRF52 Kconfig option ``CONFIG_GPIO_AS_PINRESET`` has been removed. Set the
+  ``gpio-as-nreset`` property on the ``&uicr`` devicetree node instead.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -295,6 +295,9 @@ Audio Codec
 Clock Control
 =============
 
+* The Nordic Kconfig option ``CONFIG_NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT`` has been
+  removed. Use :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_HSFLL_LOCAL_REQ_LOW_FREQ` instead.
+
 * The :dtcompatible:`nxp,imxrt11xx-arm-pll` binding now uses ``loop-div`` and
   ``post-div`` for ARM PLL configuration. The legacy ``clock-mult`` and
   ``clock-div`` properties remain supported but are deprecated. Existing

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -219,6 +219,8 @@ Removed APIs and options
       :dtcompatible:`nordic,owned-partitions`
     * ``CONFIG_BOARD_ENABLE_CPUNET``, replaced by :kconfig:option:`CONFIG_SOC_NRF53_CPUNET_ENABLE`
     * ``CONFIG_GPIO_AS_PINRESET``
+    * ``CONFIG_NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT``, replaced by
+      :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_HSFLL_LOCAL_REQ_LOW_FREQ`
     * ``CONFIG_SOC_DCDC_NRF52X``
     * ``CONFIG_SOC_DCDC_NRF52X_HV``
     * ``CONFIG_SOC_DCDC_NRF53X_APP``

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -217,6 +217,7 @@ Removed APIs and options
     * ``owner-id``, ``perm-read``, ``perm-write``, ``perm-execute``, ``perm-secure`` and
       ``non-secure-callable`` properties of :dtcompatible:`nordic,owned-memory` and
       :dtcompatible:`nordic,owned-partitions`
+    * ``CONFIG_BOARD_ENABLE_CPUNET``, replaced by :kconfig:option:`CONFIG_SOC_NRF53_CPUNET_ENABLE`
     * ``CONFIG_GPIO_AS_PINRESET``
     * ``CONFIG_SOC_DCDC_NRF52X``
     * ``CONFIG_SOC_DCDC_NRF52X_HV``

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -217,6 +217,7 @@ Removed APIs and options
     * ``owner-id``, ``perm-read``, ``perm-write``, ``perm-execute``, ``perm-secure`` and
       ``non-secure-callable`` properties of :dtcompatible:`nordic,owned-memory` and
       :dtcompatible:`nordic,owned-partitions`
+    * ``CONFIG_GPIO_AS_PINRESET``
 
 * Random
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -218,6 +218,11 @@ Removed APIs and options
       ``non-secure-callable`` properties of :dtcompatible:`nordic,owned-memory` and
       :dtcompatible:`nordic,owned-partitions`
     * ``CONFIG_GPIO_AS_PINRESET``
+    * ``CONFIG_SOC_DCDC_NRF52X``
+    * ``CONFIG_SOC_DCDC_NRF52X_HV``
+    * ``CONFIG_SOC_DCDC_NRF53X_APP``
+    * ``CONFIG_SOC_DCDC_NRF53X_NET``
+    * ``CONFIG_SOC_DCDC_NRF53X_HV``
 
 * Random
 

--- a/modules/hal_nordic/nrfs/dvfs/Kconfig
+++ b/modules/hal_nordic/nrfs/dvfs/Kconfig
@@ -15,12 +15,6 @@ config NRFS_LOCAL_DOMAIN_DVFS_TEST
 	help
 	  Disable hw registers interaction for testing.
 
-config NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT
-	bool "Local domain scale down after init"
-	select DEPRECATED
-	help
-	  Request lowest oppoint after DVFS initialization.
-
 config NRFS_LOCAL_DOMAIN_DOWNSCALE_SAFETY_TIMEOUT_US
 	int "Voltage downscale procedure safety timeout in us"
 	range 1 10000000

--- a/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.c
+++ b/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.c
@@ -300,11 +300,6 @@ static void dvfs_service_handler_task(void *dummy0, void *dummy1, void *dummy2)
 
 	LOG_DBG("DVFS init done.");
 
-#if defined(CONFIG_NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT)
-	LOG_DBG("Requesting lowest frequency oppoint.");
-	dvfs_service_handler_change_freq_setting(DVFS_FREQ_LOW);
-#endif
-
 	while (1) {
 		k_sem_take(&dvfs_service_idle_sem, K_FOREVER);
 		/* perform background processing */

--- a/modules/hal_nordic/nrfx/mdk_config.h
+++ b/modules/hal_nordic/nrfx/mdk_config.h
@@ -450,8 +450,8 @@
 #include <zephyr/devicetree.h>
 
 /*
- * Inject HAL "NFCT_PINS_AS_GPIOS" definition if user requests to
- * configure the NFCT pins as GPIOS. Do the same with "CONFIG_GPIO_AS_PINRESET"
+ * Inject HAL "NRF_CONFIG_NFCT_PINS_AS_GPIOS" definition if user requests to
+ * configure the NFCT pins as GPIOS. Do the same with "NRF_CONFIG_GPIO_AS_PINRESET"
  * to configure the reset GPIO as nRESET. This way, the HAL will take care of
  * doing the proper configuration sequence during system init.
  */

--- a/soc/nordic/nrf52/Kconfig
+++ b/soc/nordic/nrf52/Kconfig
@@ -62,17 +62,6 @@ config SOC_DCDC_NRF52X_HV
 
 	  Enable nRF52 series System on Chip High Voltage DC/DC converter.
 
-config GPIO_AS_PINRESET
-	bool
-	select DEPRECATED
-	help
-	  This option is deprecated, use devicetree instead. Example
-	  configuration:
-
-	  &uicr {
-	      gpio-as-nreset;
-	  };
-
 config NRF_ENABLE_ICACHE
 	bool "The instruction cache (I-Cache)"
 	depends on SOC_NRF52832 || SOC_NRF52833 || SOC_NRF52840

--- a/soc/nordic/nrf52/Kconfig
+++ b/soc/nordic/nrf52/Kconfig
@@ -35,33 +35,6 @@ config SOC_NRF52840
 
 if SOC_SERIES_NRF52
 
-config SOC_DCDC_NRF52X
-	bool
-	select DEPRECATED
-	help
-	  This option is deprecated, use devicetree instead. Example
-	  configuration:
-
-	  &reg/reg1 {
-	    regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
-	  };
-
-	  Enable nRF52 series System on Chip DC/DC converter.
-
-config SOC_DCDC_NRF52X_HV
-	bool
-	depends on SOC_NRF52840_QIAA
-	select DEPRECATED
-	help
-	  This option is deprecated, use devicetree instead. Example
-	  configuration:
-
-	  &reg0 {
-	    status = "okay";
-	  };
-
-	  Enable nRF52 series System on Chip High Voltage DC/DC converter.
-
 config NRF_ENABLE_ICACHE
 	bool "The instruction cache (I-Cache)"
 	depends on SOC_NRF52832 || SOC_NRF52833 || SOC_NRF52840

--- a/soc/nordic/nrf52/soc.c
+++ b/soc/nordic/nrf52/soc.c
@@ -32,12 +32,10 @@ void soc_early_init_hook(void)
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
 #endif
 
-#if defined(CONFIG_SOC_DCDC_NRF52X) || (DT_PROP(DT_INST(0, nordic_nrf5x_regulator),                \
-						regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
+#if DT_PROP(DT_INST(0, nordic_nrf5x_regulator), regulator_initial_mode) == NRF5X_REG_MODE_DCDC
 	nrf_power_dcdcen_set(NRF_POWER, true);
 #endif
-#if NRF_POWER_HAS_DCDCEN_VDDH && (defined(CONFIG_SOC_DCDC_NRF52X_HV) || \
-	DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nordic_nrf52x_regulator_hv)))
+#if NRF_POWER_HAS_DCDCEN_VDDH && DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nordic_nrf52x_regulator_hv))
 	nrf_power_dcdcen_vddh_set(NRF_POWER, true);
 #endif
 }

--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -132,47 +132,6 @@ config SOC_NRF53_ANOMALY_166_WORKAROUND
 	  The workaround applies only to application core and VREGMAIN in LDO mode.
 	  It is disabled by default as it increases power consumption noticeably.
 
-config SOC_DCDC_NRF53X_APP
-	bool
-	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
-	select DEPRECATED
-	help
-	  This option is deprecated, use devicetree instead. Example
-	  configuration:
-
-	  &vregmain {
-	    regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
-	  };
-
-	  Enable nRF53 series System on Chip Application MCU DC/DC converter.
-
-config SOC_DCDC_NRF53X_NET
-	bool
-	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
-	select DEPRECATED
-	help
-	  This option is deprecated, use devicetree instead. Example
-	  configuration:
-
-	  &vregradio {
-	    regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
-	  };
-
-	  Enable nRF53 series System on Chip Network MCU DC/DC converter.
-
-config SOC_DCDC_NRF53X_HV
-	bool
-	select DEPRECATED
-	help
-	  This option is deprecated, use devicetree instead. Example
-	  configuration:
-
-	  &vregh {
-	    status = "okay";
-	  };
-
-	  Enable nRF53 series System on Chip High Voltage DC/DC converter.
-
 config NRF_SPU_FLASH_REGION_SIZE
 	hex
 	default 0x4000

--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -172,13 +172,6 @@ config SOC_NRF53_CPUNET_ENABLE
 	  secure firmware image must already have configured GPIO allocation for the
 	  Network MCU.
 
-config BOARD_ENABLE_CPUNET
-	bool "[DEPRECATED] NRF53 Network MCU is enabled at boot time"
-	select SOC_NRF53_CPUNET_ENABLE
-	select DEPRECATED
-	help
-	  Use SOC_NRF53_CPUNET_ENABLE instead.
-
 if !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 
 choice SOC_HFXO_LOAD_CAPACITANCE

--- a/soc/nordic/nrf53/soc.c
+++ b/soc/nordic/nrf53/soc.c
@@ -555,8 +555,7 @@ void soc_early_init_hook(void)
 #endif
 #endif /* CONFIG_SOC_NRF5340_CPUAPP */
 
-#if defined(CONFIG_SOC_DCDC_NRF53X_APP) || \
-	(DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
+#if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #elif (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_LDO)
 	if (NRF_ERRATA_DYNAMIC_CHECK(53, 166)) {
@@ -565,11 +564,10 @@ void soc_early_init_hook(void)
 		*((volatile uint32_t *)0x50300C00) = 0x00009375ul;
 	}
 #endif
-#if defined(CONFIG_SOC_DCDC_NRF53X_NET) || \
-	(DT_PROP(DT_NODELABEL(vregradio), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
+#if (DT_PROP(DT_NODELABEL(vregradio), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_RADIO, true);
 #endif
-#if defined(CONFIG_SOC_DCDC_NRF53X_HV) || DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(vregh))
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(vregh))
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_HIGH, true);
 #endif
 


### PR DESCRIPTION
Removes four Nordic SoC and hal_nordic Kconfig options deprecated between Zephyr 3.5 and 4.1, all well past the two-release removal window. None of them appear on tracker #94255.

- soc: nordic: nrf52: remove deprecated `CONFIG_GPIO_AS_PINRESET`
- soc: nordic: remove deprecated `SOC_DCDC_NRF5X` Kconfig options
- soc: nordic: nrf53: remove deprecated `CONFIG_BOARD_ENABLE_CPUNET`
- modules: hal_nordic: remove deprecated nrfs DVFS scale down option

### Review note

The five `SOC_DCDC_NRF5X` symbols and `GPIO_AS_PINRESET` are hidden promptless bools that nothing in-tree selects, so their deprecation warning has never fired. Every C consumer was `#if defined(CONFIG_SOC_DCDC_*) || <DT condition>`; only the Kconfig disjunct was removed, and each DT condition is byte-identical.

Out-of-tree behaviour note: a config with `CONFIG_SOC_DCDC_NRF53X_APP=y` but vregmain in LDO mode previously skipped the anomaly-166 branch and now correctly takes it. No in-tree build can reach that state.
