### PR TITLE
Bluetooth: remove options and macros deprecated in 4.1-4.3

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1427,6 +1427,14 @@ Bluetooth Host
   deprecated since Zephyr 4.2, and the number of pending TX buffers with a callback always
   follows :kconfig:option:`CONFIG_BT_BUF_ACL_TX_COUNT`.
 
+Bluetooth Mesh
+==============
+
+* The deprecated ``CONFIG_BT_MESH_BLOB_IO_FLASH_WITH_ERASE`` and
+  ``CONFIG_BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE`` Kconfig options have been removed, with no
+  replacement. They have been deprecated since Zephyr 4.3, where the BLOB IO Flash module
+  started querying the erase capability at runtime, and have had no effect since.
+
 Bluetooth Services
 ==================
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1423,6 +1423,10 @@ Bluetooth Host
   option: the central choice defaults to :kconfig:option:`CONFIG_BT_AUTO_PHY_CENTRAL_2M`, so
   both roles must be set to ``_NONE`` explicitly.
 
+* The deprecated ``CONFIG_BT_CONN_TX_MAX`` Kconfig option has been removed. It has been
+  deprecated since Zephyr 4.2, and the number of pending TX buffers with a callback always
+  follows :kconfig:option:`CONFIG_BT_BUF_ACL_TX_COUNT`.
+
 Bluetooth Services
 ==================
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -111,6 +111,11 @@ Removed APIs and options
     * ``CONFIG_BT_AUTO_PHY_UPDATE``, replaced by the ``BT_AUTO_PHY_CENTRAL`` and
       ``BT_AUTO_PHY_PERIPHERAL`` choices
 
+  * Services
+
+    * ``CONFIG_BT_DIS_MANUF``
+    * ``CONFIG_BT_DIS_MODEL``
+
 * Build system
 
     * ``CONFIG_BUILD_NO_GAP_FILL``

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -90,6 +90,10 @@ Removed APIs and options
 
 * Bluetooth
 
+  * Controller
+
+    * ``CONFIG_BT_CTRL_ADV_ADI_IN_SCAN_RSP``
+
   * Host
 
     * The ``CONFIG_BT_RECV_CONTEXT`` choice and its options ``CONFIG_BT_RECV_WORKQ_SYS``

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -118,6 +118,11 @@ Removed APIs and options
     * ``BT_GATT_CCC_INITIALIZER``
     * ``CONFIG_BT_CONN_TX_MAX``
 
+  * Mesh
+
+    * ``CONFIG_BT_MESH_BLOB_IO_FLASH_WITH_ERASE``
+    * ``CONFIG_BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE``
+
   * Services
 
     * ``CONFIG_BT_DIS_MANUF``

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -112,6 +112,7 @@ Removed APIs and options
       ``BT_AUTO_PHY_PERIPHERAL`` choices
     * ``_bt_gatt_ccc``
     * ``BT_GATT_CCC_INITIALIZER``
+    * ``CONFIG_BT_CONN_TX_MAX``
 
   * Services
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -110,6 +110,8 @@ Removed APIs and options
 
     * ``CONFIG_BT_AUTO_PHY_UPDATE``, replaced by the ``BT_AUTO_PHY_CENTRAL`` and
       ``BT_AUTO_PHY_PERIPHERAL`` choices
+    * ``_bt_gatt_ccc``
+    * ``BT_GATT_CCC_INITIALIZER``
 
   * Services
 

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1086,9 +1086,6 @@ struct bt_gatt_ccc_cfg {
 	uint16_t value;
 };
 
-/** Macro to keep old name for deprecation period. */
-#define _bt_gatt_ccc bt_gatt_ccc_managed_user_data __DEPRECATED_MACRO
-
 /** @brief Internal representation of CCC value.
  *
  * @note Only use this as an argument for @ref BT_GATT_CCC_MANAGED
@@ -1184,9 +1181,6 @@ ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn,
 ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, const void *buf,
 			       uint16_t len, uint16_t offset, uint8_t flags);
-
-/** Macro to keep old name for deprecation period. */
-#define BT_GATT_CCC_INITIALIZER BT_GATT_CCC_MANAGED_USER_DATA_INIT __DEPRECATED_MACRO
 
 /**
  *  @brief Initialize Client Characteristic Configuration Declaration Macro.

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -79,9 +79,6 @@ configdefault BT_BUF_ACL_TX_COUNT
 configdefault BT_BUF_EVT_RX_COUNT
 	default 20
 
-configdefault BT_CONN_TX_MAX
-	default 15
-
 endif
 
 rsource "*/Kconfig.defconfig"

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -533,16 +533,6 @@ config BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY
 	  must be synchronized with CTEInfo field in extended advertising header
 	  that is part of PDU data.
 
-config BT_CTRL_ADV_ADI_IN_SCAN_RSP
-	bool "Include ADI in AUX_SCAN_RSP PDU [DEPRECATED]"
-	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
-	select BT_CTLR_ADV_ADI_IN_SCAN_RSP
-	select DEPRECATED
-	help
-	  DEPRECATED: Renamed as BT_CTLR_ADV_ADI_IN_SCAN_RSP.
-
-	  Enable ADI field in AUX_SCAN_RSP PDU.
-
 config BT_CTLR_ADV_ADI_IN_SCAN_RSP
 	bool "Include ADI in AUX_SCAN_RSP PDU"
 	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -312,15 +312,6 @@ config BT_CONN_FRAG_COUNT
 
 if BT_CONN
 
-config BT_CONN_TX_MAX
-	int "Maximum number of pending TX buffers with a callback [DEPRECATED]"
-	default BT_BUF_ACL_TX_COUNT
-	range BT_BUF_ACL_TX_COUNT $(UINT8_MAX)
-	help
-	  Maximum number of pending TX buffers that have an associated
-	  callback. Normally this can be left to the default value, which
-	  is equal to the number of TX buffers in the controller.
-
 config BT_CONN_PARAM_ANY
 	bool "Accept any values for connection parameters"
 	help

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1071,23 +1071,6 @@ config BT_MESH_BLOB_IO_FLASH
 
 if BT_MESH_BLOB_IO_FLASH
 
-config BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE
-	bool "BLOB flash support for devices without erase [DEPRECATED]"
-	default n
-	depends on FLASH_HAS_NO_EXPLICIT_ERASE
-	select DEPRECATED
-	help
-	  This option is deprecated and is no longer used by the BLOB IO Flash module.
-
-config BT_MESH_BLOB_IO_FLASH_WITH_ERASE
-	bool "BLOB flash support for devices with erase [DEPRECATED]"
-	default n
-	depends on FLASH_HAS_EXPLICIT_ERASE
-	depends on FLASH_PAGE_LAYOUT
-	select DEPRECATED
-	help
-	  This option is deprecated and is no longer used by the BLOB IO Flash module.
-
 config BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX
 	int "Maximum supported write block size"
 	default 4

--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -25,7 +25,6 @@ config BT_DIS_STR_MAX
 
 config BT_DIS_MODEL_NUMBER
 	bool "Model number characteristic"
-	depends on !BT_DIS_MODEL_DEPRECATED_USED
 	default y
 	help
 	  Enable model number characteristic in Device Information Service.
@@ -38,20 +37,8 @@ config BT_DIS_MODEL_NUMBER_STR
 	  Configure model number string that can be read with the model number characteristic
 	  in Device Information Service.
 
-config BT_DIS_MODEL
-	string "Model name [DEPRECATED]"
-	help
-	  The device model inside Device Information Service.
-	  This option is deprecated. Use BT_DIS_MODEL_NUMBER and BT_DIS_MODEL_NUMBER_STR instead.
-
-config BT_DIS_MODEL_DEPRECATED_USED
-	bool
-	default y if BT_DIS_MODEL != ""
-	select DEPRECATED
-
 config BT_DIS_MANUF_NAME
 	bool "Manufacturer name characteristic"
-	depends on !BT_DIS_MANUF_DEPRECATED_USED
 	default y
 	help
 	  Enable manufacturer name characteristic in Device Information Service.
@@ -63,17 +50,6 @@ config BT_DIS_MANUF_NAME_STR
 	help
 	  Configure manufacturer name string that can be read with the manufacturer name
 	  characteristic in Device Information Service.
-
-config BT_DIS_MANUF
-	string "Manufacturer name [DEPRECATED]"
-	help
-	  The device manufacturer inside Device Information Service.
-	  This option is deprecated. Use BT_DIS_MANUF_NAME and BT_DIS_MANUF_NAME_STR instead.
-
-config BT_DIS_MANUF_DEPRECATED_USED
-	bool
-	default y if BT_DIS_MANUF != ""
-	select DEPRECATED
 
 config BT_DIS_PNP
 	bool "PnP_ID characteristic"

--- a/subsys/bluetooth/services/dis.c
+++ b/subsys/bluetooth/services/dis.c
@@ -61,16 +61,10 @@ static uint8_t dis_system_id[8] = {BT_BYTES_LIST_LE40((uint64_t)CONFIG_BT_DIS_SY
 #if defined(CONFIG_BT_DIS_MODEL_NUMBER)
 BUILD_ASSERT(sizeof(CONFIG_BT_DIS_MODEL_NUMBER_STR) <= CONFIG_BT_DIS_STR_MAX + 1);
 static uint8_t dis_model[CONFIG_BT_DIS_STR_MAX + 1] = CONFIG_BT_DIS_MODEL_NUMBER_STR;
-#elif defined(CONFIG_BT_DIS_MODEL_DEPRECATED_USED)
-BUILD_ASSERT(sizeof(CONFIG_BT_DIS_MODEL) <= CONFIG_BT_DIS_STR_MAX + 1);
-static uint8_t dis_model[CONFIG_BT_DIS_STR_MAX + 1] = CONFIG_BT_DIS_MODEL;
 #endif
 #if defined(CONFIG_BT_DIS_MANUF_NAME)
 BUILD_ASSERT(sizeof(CONFIG_BT_DIS_MANUF_NAME_STR) <= CONFIG_BT_DIS_STR_MAX + 1);
 static uint8_t dis_manuf[CONFIG_BT_DIS_STR_MAX + 1] = CONFIG_BT_DIS_MANUF_NAME_STR;
-#elif defined(CONFIG_BT_DIS_MANUF_DEPRECATED_USED)
-BUILD_ASSERT(sizeof(CONFIG_BT_DIS_MANUF) <= CONFIG_BT_DIS_STR_MAX + 1);
-static uint8_t dis_manuf[CONFIG_BT_DIS_STR_MAX + 1] = CONFIG_BT_DIS_MANUF;
 #endif
 #if defined(CONFIG_BT_DIS_SERIAL_NUMBER)
 BUILD_ASSERT(sizeof(CONFIG_BT_DIS_SERIAL_NUMBER_STR) <= CONFIG_BT_DIS_STR_MAX + 1);
@@ -126,13 +120,9 @@ static uint8_t dis_ieee_rcdl[CONFIG_BT_DIS_STR_MAX + 1] = CONFIG_BT_DIS_IEEE_RCD
 
 #if defined(CONFIG_BT_DIS_MODEL_NUMBER)
 #define BT_DIS_MODEL_REF             CONFIG_BT_DIS_MODEL_NUMBER_STR
-#elif defined(CONFIG_BT_DIS_MODEL_DEPRECATED_USED)
-#define BT_DIS_MODEL_REF             CONFIG_BT_DIS_MODEL
 #endif
 #if defined(CONFIG_BT_DIS_MANUF_NAME)
 #define BT_DIS_MANUF_REF             CONFIG_BT_DIS_MANUF_NAME_STR
-#elif defined(CONFIG_BT_DIS_MANUF_DEPRECATED_USED)
-#define BT_DIS_MANUF_REF             CONFIG_BT_DIS_MANUF
 #endif
 #define BT_DIS_SERIAL_NUMBER_STR_REF CONFIG_BT_DIS_SERIAL_NUMBER_STR
 #define BT_DIS_FW_REV_STR_REF        CONFIG_BT_DIS_FW_REV_STR
@@ -147,8 +137,7 @@ static uint8_t dis_ieee_rcdl[CONFIG_BT_DIS_STR_MAX + 1] = CONFIG_BT_DIS_IEEE_RCD
 #endif /* CONFIG_BT_DIS_SETTINGS */
 
 #define BT_DIS_READ_STR_USED \
-	(CONFIG_BT_DIS_MODEL_NUMBER || CONFIG_BT_DIS_MODEL_DEPRECATED_USED || \
-	 CONFIG_BT_DIS_MANUF_NAME || CONFIG_BT_DIS_MANUF_DEPRECATED_USED || \
+	(CONFIG_BT_DIS_MODEL_NUMBER || CONFIG_BT_DIS_MANUF_NAME || \
 	 CONFIG_BT_DIS_SERIAL_NUMBER || CONFIG_BT_DIS_FW_REV || CONFIG_BT_DIS_HW_REV || \
 	 CONFIG_BT_DIS_SW_REV || CONFIG_BT_DIS_IEEE_RCDL)
 
@@ -252,12 +241,12 @@ static ssize_t read_udi(struct bt_conn *conn, const struct bt_gatt_attr *attr, v
 BT_GATT_SERVICE_DEFINE(
 	dis_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_DIS),
 
-#if defined(CONFIG_BT_DIS_MODEL_NUMBER) || defined(CONFIG_BT_DIS_MODEL_DEPRECATED_USED)
+#if defined(CONFIG_BT_DIS_MODEL_NUMBER)
 	BT_GATT_CHARACTERISTIC(BT_UUID_DIS_MODEL_NUMBER, BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
 			       read_str, NULL, BT_DIS_MODEL_REF),
 #endif
 
-#if defined(CONFIG_BT_DIS_MANUF_NAME) || defined(CONFIG_BT_DIS_MANUF_DEPRECATED_USED)
+#if defined(CONFIG_BT_DIS_MANUF_NAME)
 	BT_GATT_CHARACTERISTIC(BT_UUID_DIS_MANUFACTURER_NAME, BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
 			       read_str, NULL, BT_DIS_MANUF_REF),
 #endif
@@ -344,7 +333,7 @@ static int dis_set(const char *name, size_t len_rd, settings_read_cb read_cb, vo
 	ARG_UNUSED(len);
 
 	nlen = settings_name_next(name, &next);
-#if defined(CONFIG_BT_DIS_MANUF_NAME) || defined(CONFIG_BT_DIS_MANUF_DEPRECATED_USED)
+#if defined(CONFIG_BT_DIS_MANUF_NAME)
 	if (!strncmp(name, "manuf", nlen)) {
 		len = read_cb(store, &dis_manuf, sizeof(dis_manuf) - 1);
 		if (len < 0) {
@@ -357,7 +346,7 @@ static int dis_set(const char *name, size_t len_rd, settings_read_cb read_cb, vo
 		return 0;
 	}
 #endif
-#if defined(CONFIG_BT_DIS_MODEL_NUMBER) || defined(CONFIG_BT_DIS_MODEL_DEPRECATED_USED)
+#if defined(CONFIG_BT_DIS_MODEL_NUMBER)
 	if (!strncmp(name, "model", nlen)) {
 		len = read_cb(store, &dis_model, sizeof(dis_model) - 1);
 		if (len < 0) {


### PR DESCRIPTION
Removes five Bluetooth options and macros deprecated between Zephyr 4.1 and 4.3, all past the two-release window.

- bluetooth: dis: remove deprecated `BT_DIS_MANUF` and `BT_DIS_MODEL` (4.1)
- bluetooth: gatt: remove deprecated CCC name compatibility macros (4.2)
- bluetooth: host: remove deprecated `BT_CONN_TX_MAX` (4.2)
- bluetooth: controller: remove deprecated `BT_CTRL_ADV_ADI_IN_SCAN_RSP` (4.3)
- bluetooth: mesh: remove deprecated BLOB IO flash erase options (4.3)

Each is either a pure alias or already inert. `BT_CTRL_ADV_ADI_IN_SCAN_RSP` only selected the CTLR-spelled option. No C code has read `BT_CONN_TX_MAX` since its deprecation — the pending TX buffer count follows `BT_BUF_ACL_TX_COUNT`, already both the default and the range floor of the removed option. The BLOB IO Flash module has queried the erase capability at runtime through `flash_params_get_erase_cap()` since 4.3, so both mesh options have been no-ops.

The DIS commit also drops the `*_DEPRECATED_USED` detection symbols, which lets the two characteristic bools return to unconditional `default y` and collapses the `#if`/`#elif` ladders in `dis.c`.
