### PR TITLE
storage: stream_flash: remove deprecated stream_flash_erase_page()

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1510,6 +1510,12 @@ Random
 
 * ``CONFIG_CS_CTR_DRBG_PERSONALIZATION`` has been removed. It did not have any effect.
 
+Stream Flash
+============
+
+* ``stream_flash_erase_page()`` has been removed. Use :c:func:`flash_area_erase` or
+  :c:func:`flash_erase` instead; there is no Stream Flash API equivalent.
+
 Tools
 *****
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -126,6 +126,10 @@ Removed APIs and options
     * ``CONFIG_CTR_DRBG_CSPRNG_GENERATOR``
     * ``CONFIG_CS_CTR_DRBG_PERSONALIZATION``
 
+* Stream Flash
+
+    * ``stream_flash_erase_page()``
+
 * West sign support for imgtool, which was deprecated in Zephyr 4.0, has been removed.
 
 Deprecated APIs and options

--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -142,23 +142,6 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
 				size_t len, bool flush);
 
 /**
- * @brief Erase the flash page to which a given offset belongs.
- *
- * @deprecated Use @a flash_area_erase() or flash_erase(). Note that there
- * is no Stream Flash API equivalent for that.
- *
- * This function erases a flash page to which an offset belongs if this page
- * is not the page previously erased by the provided ctx
- * (ctx->last_erased_page_start_offset).
- *
- * @param ctx context
- * @param off offset from the base address of the flash device
- *
- * @return non-negative on success, negative errno code on fail
- */
-__deprecated int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off);
-
-/**
  * @brief Load persistent stream write progress stored with key
  *        @p settings_key .
  *

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -129,61 +129,6 @@ static int stream_flash_erase_to_append(struct stream_flash_ctx *ctx, size_t siz
 	return rc;
 }
 
-#if defined(CONFIG_STREAM_FLASH_ERASE)
-
-int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
-{
-#if defined(CONFIG_FLASH_HAS_EXPLICIT_ERASE)
-	int rc;
-	struct flash_pages_info page;
-
-	if (off < ctx->offset || (off - ctx->offset) >= ctx->available) {
-		LOG_ERR("Offset out of designated range");
-		return -ERANGE;
-	}
-
-	/* Do not allow pages that have already been erased */
-	if ((off - ctx->offset) < ctx->erased_up_to) {
-		return -EINVAL;
-	}
-
-#if defined(CONFIG_FLASH_HAS_NO_EXPLICIT_ERASE)
-	/* There are both types of devices */
-	const struct flash_parameters *fparams = flash_get_parameters(ctx->fdev);
-
-	/* Stream flash does not rely on erase, it does it when device needs it */
-	if (!(flash_params_get_erase_cap(fparams) & FLASH_ERASE_C_EXPLICIT)) {
-		return 0;
-	}
-#endif
-	rc = flash_get_page_info_by_offs(ctx->fdev, off, &page);
-	if (rc != 0) {
-		LOG_ERR("Error %d while getting page info", rc);
-		return rc;
-	}
-
-	if (ctx->erased_up_to >= page.start_offset + page.size) {
-		return 0;
-	}
-
-	LOG_DBG("Erasing page at offset 0x%08lx", (long)page.start_offset);
-
-	rc = flash_erase(ctx->fdev, page.start_offset, page.size);
-
-	if (rc != 0) {
-		LOG_ERR("Error %d while erasing page", rc);
-	} else {
-		ctx->erased_up_to = page.start_offset + page.size;
-	}
-
-	return rc;
-#else
-	return 0;
-#endif
-}
-
-#endif /* CONFIG_STREAM_FLASH_ERASE */
-
 static int flash_sync(struct stream_flash_ctx *ctx)
 {
 	int rc = 0;


### PR DESCRIPTION
Removes `stream_flash_erase_page()`, deprecated in Zephyr 4.1.

There is no Stream Flash replacement by design; callers needing an explicit erase should use `flash_area_erase()` or `flash_erase()` directly.

The `ctx->erased_up_to` field stays: it still drives the progressive erase performed from `stream_flash_buffered_write()`.
