### PR TITLE
arch: remove deprecated x86 and Arm Kconfig options

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -191,15 +191,6 @@ config RUNTIME_NMI
 	  NMI handler installed when the CPU boots. If a custom handler is
 	  needed, enable this option and attach it via z_arm_nmi_set_handler().
 
-config PLATFORM_SPECIFIC_INIT
-	bool "Platform (SOC) specific startup hook [DEPRECATED]"
-	select DEPRECATED
-	help
-	  The platform specific initialization code (z_arm_platform_init) is
-	  executed at the beginning of the startup code (__start).
-
-	  This option is deprecated, use SOC_RESET_HOOK instead.
-
 config FAULT_DUMP
 	int "Fault dump level"
 	default 2

--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -98,20 +98,6 @@ menu "Architecture Floating Point Options"
 
 if CPU_HAS_FPU
 
-config SSE
-	bool "SSE registers"
-	depends on FPU
-	select X86_SSE
-	help
-	  This option is deprecated. Please use CONFIG_X86_SSE instead.
-
-config SSE_FP_MATH
-	bool "Compiler-generated SSEx instructions"
-	depends on X86_SSE
-	select X86_SSE_FP_MATH
-	help
-	  This option is deprecated. Please use CONFIG_X86_SSE_FP_MATH instead.
-
 config EAGER_FPU_SHARING
 	bool
 	depends on FPU

--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -940,7 +940,7 @@ function(symbol_to_string)
             "${${STRING_STRING}}define image symbol ${symbol} = ${expr};\n"
             )
         else()
-          # Treatmen of "zephyr_linker_symbol(SYMBOL z_arm_platform_init EXPR "@SystemInit@")"
+          # Treatmen of "zephyr_linker_symbol(SYMBOL soc_reset_hook EXPR "@SystemInit@")"
           set_property(GLOBAL APPEND PROPERTY SYMBOL_STEERING_FILE
             "--redirect ${symbol}=${expr}\n"
             )

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1626,6 +1626,12 @@ Architectures
   :kconfig:option:`CONFIG_X86_SSE` and :kconfig:option:`CONFIG_X86_SSE_FP_MATH`
   instead.
 
+* ``CONFIG_PLATFORM_SPECIFIC_INIT`` and its ``z_arm_platform_init()`` hook have
+  been removed. Enable :kconfig:option:`CONFIG_SOC_RESET_HOOK` and rename the
+  hook to :c:func:`soc_reset_hook`. The new hook runs later in the reset path,
+  after the stack pointers have been set up, and is skipped on resume from
+  suspend-to-RAM.
+
 Video
 =====
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1622,6 +1622,10 @@ Architectures
   replacing their previous hand-rolled ``UNMAPPED`` MPU region table entry with
   identical runtime behavior.
 
+* ``CONFIG_SSE`` and ``CONFIG_SSE_FP_MATH`` have been removed. Use
+  :kconfig:option:`CONFIG_X86_SSE` and :kconfig:option:`CONFIG_X86_SSE_FP_MATH`
+  instead.
+
 Video
 =====
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -70,6 +70,11 @@ Removed APIs and options
 
 * Architectures
 
+   * x86
+
+      * ``CONFIG_SSE``
+      * ``CONFIG_SSE_FP_MATH``
+
    * Xtensa
 
       * ``CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK``

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -70,6 +70,11 @@ Removed APIs and options
 
 * Architectures
 
+   * ARM
+
+      * ``CONFIG_PLATFORM_SPECIFIC_INIT``
+      * ``z_arm_platform_init()``
+
    * x86
 
       * ``CONFIG_SSE``

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -381,7 +381,7 @@ extern struct task_state_segment _main_tss;
  * cases a 4 byte boundary is sufficient.
  */
 #if defined(CONFIG_EAGER_FPU_SHARING) || defined(CONFIG_LAZY_FPU_SHARING)
-#ifdef CONFIG_SSE
+#ifdef CONFIG_X86_SSE
 #define ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT	16
 #else
 #define ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT	(sizeof(void *))

--- a/soc/renode/cortex_r8_virtual/Kconfig
+++ b/soc/renode/cortex_r8_virtual/Kconfig
@@ -4,6 +4,6 @@
 config SOC_CORTEX_R8_VIRTUAL
 	select ARM
 	select CPU_CORTEX_R8
-	select PLATFORM_SPECIFIC_INIT
+	select SOC_RESET_HOOK
 	select CPU_HAS_ARM_MPU
 	select VFP_DP_D16

--- a/soc/renode/cortex_r8_virtual/soc.c
+++ b/soc/renode/cortex_r8_virtual/soc.c
@@ -8,10 +8,11 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/platform/hooks.h>
 
 #include <cmsis_core.h>
 
-void z_arm_platform_init(void)
+void soc_reset_hook(void)
 {
 	/*
 	 * Use normal exception vectors address range (0x0-0x1C).


### PR DESCRIPTION
Removes two deprecated arch Kconfig options, both deprecated well before Zephyr 4.2 and therefore due for removal in 4.5.

- x86: ia32: remove deprecated `CONFIG_SSE` and `CONFIG_SSE_FP_MATH`
- arch: arm: remove deprecated `CONFIG_PLATFORM_SPECIFIC_INIT`

Both were aliases that only selected their replacement. On x86, `include/zephyr/arch/x86/ia32/arch.h` was the last in-tree reader and tested `CONFIG_SSE` while every other consumer (`crt0.S`, `float.c`, `swap.S`, `ia32/thread.h`) already keys off `CONFIG_X86_SSE`. It now tests `CONFIG_X86_SSE` too, so a configuration enabling `X86_SSE` directly gets the 16-byte dynamic thread object alignment that `fxsave`/`fxrstor` require, instead of pointer alignment.

### Review note

The Arm removal turns previously **dead** code into live boot code on `soc/renode/cortex_r8_virtual`, the option's single in-tree selector. `z_arm_platform_init()` had no caller anywhere — neither `cortex_m/reset.S` nor `cortex_a_r/reset.S` tests the option, both only branch to `soc_reset_hook()` — so this SoC has not been clearing `SCTLR.V`. Migrating it to `SOC_RESET_HOOK` (body unchanged, hook renamed) re-activates that, selecting the low exception vector base as originally intended.

That is almost certainly the original intent, stranded when the deprecation landed, but it is a behaviour change and it now runs slightly later in the reset sequence, after the per-mode stack pointers are set up.