### PR TITLE
boards: remove deprecated aliases and fix dangling ds3231 node

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -13,39 +13,6 @@
 # https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated,
 # so these aliases are eventually removed
 
-set(arduino_uno_r4_minima_DEPRECATED
-    arduino_uno_r4@minima
-)
-set(arduino_uno_r4_wifi_DEPRECATED
-    arduino_uno_r4@wifi
-)
-set(esp32c6_devkitc_DEPRECATED
-    esp32c6_devkitc/esp32c6/hpcore
-)
-set(neorv32_DEPRECATED
-    neorv32/neorv32/up5kdemo
-)
-set(panb511evb_DEPRECATED
-    panb611evb
-)
-set(xiao_esp32c6_DEPRECATED
-    xiao_esp32c6/esp32c6/hpcore
-)
-set(esp32_devkitc_wroom/esp32/procpu_DEPRECATED
-    esp32_devkitc/esp32/procpu
-)
-set(esp32_devkitc_wrover/esp32/procpu_DEPRECATED
-    esp32_devkitc/esp32/procpu
-)
-set(esp32_devkitc_wroom/esp32/appcpu_DEPRECATED
-    esp32_devkitc/esp32/appcpu
-)
-set(esp32_devkitc_wrover/esp32/appcpu_DEPRECATED
-    esp32_devkitc/esp32/appcpu
-)
-set(scobc_module1_DEPRECATED
-    scobc_a1
-)
 set(fvp_base_revc_2xaemv8a_DEPRECATED
     fvp_base_revc_2xaem/v8a
 )

--- a/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
+++ b/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
@@ -79,7 +79,7 @@
 			};
 
 			ds3231: rtc@68 {
-				compatible = "maxim,ds3231";
+				compatible = "maxim,ds3231-mfd";
 				reg = <0x68>;
 			};
 		};

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -217,6 +217,23 @@ Boards
   or :c:func:`spi_transceive_cb` without DMA) on an affected board must now explicitly enable
   :kconfig:option:`CONFIG_SPI_STM32_INTERRUPT` in their own configuration. (:github:`116218`)
 
+* The following board name aliases, deprecated in v4.3 or earlier, have been removed
+  (:github:`116657`, :github:`116750`). Build for the board target the alias used to
+  redirect to instead:
+
+  * ``arduino_uno_r4_minima`` → ``arduino_uno_r4@minima``
+  * ``arduino_uno_r4_wifi`` → ``arduino_uno_r4@wifi``
+  * ``esp32c6_devkitc`` → ``esp32c6_devkitc/esp32c6/hpcore``
+  * ``esp32_devkitc_wroom/esp32/procpu`` and ``esp32_devkitc_wrover/esp32/procpu`` →
+    ``esp32_devkitc/esp32/procpu``
+  * ``esp32_devkitc_wroom/esp32/appcpu`` and ``esp32_devkitc_wrover/esp32/appcpu`` →
+    ``esp32_devkitc/esp32/appcpu``
+  * ``neorv32`` → ``neorv32/neorv32/up5kdemo``
+  * ``panb511evb`` → ``panb611evb``
+  * ``raytac_an54l15q_db/nrf54l15/cpuapp`` → ``raytac_an54lq_db_15/nrf54l15/cpuapp``
+  * ``scobc_module1`` → ``scobc_a1``
+  * ``xiao_esp32c6`` → ``xiao_esp32c6/esp32c6/hpcore``
+
 Device Drivers and Devicetree
 *****************************
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -107,6 +107,23 @@ Removed APIs and options
     * ``CONFIG_BT_AUTO_PHY_UPDATE``, replaced by the ``BT_AUTO_PHY_CENTRAL`` and
       ``BT_AUTO_PHY_PERIPHERAL`` choices
 
+* Boards
+
+    * Dropped the following deprecated board aliases:
+
+      * ``arduino_uno_r4_minima``
+      * ``arduino_uno_r4_wifi``
+      * ``esp32c6_devkitc``
+      * ``esp32_devkitc_wroom/esp32/procpu``
+      * ``esp32_devkitc_wroom/esp32/appcpu``
+      * ``esp32_devkitc_wrover/esp32/procpu``
+      * ``esp32_devkitc_wrover/esp32/appcpu``
+      * ``neorv32``
+      * ``panb511evb``
+      * ``raytac_an54l15q_db/nrf54l15/cpuapp``
+      * ``scobc_module1``
+      * ``xiao_esp32c6``
+
 * Build system
 
     * ``CONFIG_BUILD_NO_GAP_FILL``


### PR DESCRIPTION
Removes eleven board name aliases from `boards/deprecated.cmake` that reached the end of their two-release deprecation period, plus a follow-up fix from the DS3231 removal. Not on tracker #94255.

- boards: remove board name aliases deprecated in 4.3 and earlier
- boards: intel: cyclonev_socdk: fix dangling ds3231 compatible

All but `panb511evb` were already present in `v4.2.0`, and `panb511evb` was added during the 4.3 cycle, so all eleven were deprecated in 4.3 or earlier. The board directories themselves are untouched — only the old-name redirection goes away. Aliases introduced in 4.4 or later stay.

This is also a follow-up to 5b51b03a4839 (#116657), which removed the `raytac_an54l15q_db/nrf54l15/cpuapp` alias without a release note or migration guide entry — both lists here cover it as well, so the 4.5 docs account for all twelve dropped aliases.

### Review note — the cyclonev commit is a bug fix, not a removal

The DS3231 removal (#111879) also dropped `dts/bindings/counter/maxim,ds3231.yaml`, but left this board declaring `compatible = "maxim,ds3231"`. No binding matches that compatible any more, so the node ends up unbound. It is re-pointed at `maxim,ds3231-mfd`, the binding that replaced it at the same I2C address.

Deliberately **no** `maxim,ds3231-rtc` child: that binding requires `isw-gpios`, which `rtc_ds3231.c` dereferences with `GPIO_DT_SPEC_INST_GET` rather than the `_OR` variant, and this board has never described such a GPIO. Adding the child would make `CONFIG_RTC_DS3231` default to `y` as soon as `CONFIG_RTC=y` and then fail to build. A board maintainer who wires the interrupt/square-wave pin can add the child together with its `isw-gpios` property.

