### PR TITLE
kernel: fix kernel object tracking lifecycle issues

### DIFF
--- a/doc/kernel/object_cores/index.rst
+++ b/doc/kernel/object_cores/index.rst
@@ -39,6 +39,34 @@ Object cores have been integrated into following kernel objects:
 Developers are free to integrate them if desired into other objects within
 their projects.
 
+Object Lifetimes
+****************
+
+Kernel objects are only linked into their type's list when the object core
+framework (:kconfig:option:`CONFIG_OBJ_CORE`) and the respective object type
+integration option (see `Configuration Options`_) are enabled; otherwise the
+requirements below do not apply.
+
+An object that is linked into its type's list must remain valid for as long
+as it is linked. The kernel automatically unlinks objects at the natural end
+of their life cycle:
+
+* Threads are unlinked when they are aborted.
+* Dynamically allocated kernel objects (see
+  :kconfig:option:`CONFIG_DYNAMIC_OBJECTS`) are unlinked when they are freed
+  with :c:func:`k_object_free` or when automatically disposed of after their
+  last permission has been revoked.
+* Message queues, stacks and timers are unlinked by
+  :c:func:`k_msgq_cleanup`, :c:func:`k_stack_cleanup` and
+  :c:func:`k_timer_cleanup` respectively.
+
+Any other object passed to a kernel object ``*_init()`` function must remain
+valid forever (or until unlinked with :c:func:`k_obj_core_unlink`). In
+particular, a kernel object living on a thread's stack violates this
+requirement as soon as the stack frame holding it is left, and manually
+allocated memory holding a kernel object must not be freed while the object
+is linked.
+
 Object Core Statistics Concepts
 *******************************
 A variety of kernel objects allow for the gathering and reporting of statistics.

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -629,6 +629,14 @@ Other notable changes
 
 * Kernel
 
+  * Kernel object cores are now unlinked when a dynamic kernel object is
+    freed or an object is released with its ``*_cleanup()`` function.
+    Previously such objects left the :kconfig:option:`CONFIG_OBJ_CORE`
+    object type lists referencing freed memory. The object lifetime
+    requirements for :kconfig:option:`CONFIG_OBJ_CORE` and
+    :kconfig:option:`CONFIG_TRACING_OBJECT_TRACKING` are now documented in
+    :ref:`Object Cores <object_cores_api>`.
+
   * :kconfig:option:`CONFIG_SCHED_CPU_MASK` no longer depends on
     :kconfig:option:`CONFIG_SCHED_SIMPLE`.  CPU affinity masks are now
     supported on all three scheduler backends: ``SCHED_SIMPLE`` (O(N) list

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2174,6 +2174,9 @@ static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
  * function returns 0 the caller assumes responsibility for the
  * storage and there is no other consumer of the timer left.
  *
+ * On success the timer is also released from the kernel object tracking
+ * facilities; it must be initialized again before it can be used.
+ *
  * @param timer Address of the timer.
  * @retval 0 on success.
  * @retval -EAGAIN when threads are still pending on the timer's
@@ -3432,8 +3435,11 @@ __syscall int32_t k_stack_alloc_init(struct k_stack *stack,
  * @brief Release a stack's allocated buffer
  *
  * If a stack object was given a dynamically allocated buffer via
- * k_stack_alloc_init(), this will free it. This function does nothing
- * if the buffer wasn't dynamically allocated.
+ * k_stack_alloc_init(), this will free it. This function does not free
+ * the buffer if it wasn't dynamically allocated.
+ *
+ * On success the stack is also released from the kernel object tracking
+ * facilities; it must be initialized again before it can be used.
  *
  * @param stack Address of the stack.
  * @retval 0 on success
@@ -5477,6 +5483,10 @@ __syscall int k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
  * freed if it was allocated by k_msgq_alloc_init(); the call succeeds
  * but frees nothing for a caller-provided buffer. Any messages still
  * in the queue are discarded with the buffer.
+ *
+ * On success the message queue is also released from the kernel object
+ * tracking facilities; it must be initialized again before it can be
+ * used.
  *
  * @param msgq message queue to cleanup
  *

--- a/kernel/Kconfig.obj_core
+++ b/kernel/Kconfig.obj_core
@@ -11,6 +11,9 @@ menuconfig OBJ_CORE
 	  together and for that information to be easily retrieved by
 	  automated means.
 
+	  Linked objects must remain valid for as long as they are linked
+	  (see the Object Cores documentation for details).
+
 if OBJ_CORE
 config OBJ_CORE_CONDVAR
 	bool "Integrate condition variables into object core framework"

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -131,6 +131,18 @@ int z_msgq_cleanup(struct k_msgq *msgq, __maybe_unused bool locked)
 
 out:
 	k_spin_unlock(&msgq->lock, key);
+
+#ifdef CONFIG_OBJ_CORE_MSGQ
+	/* On success the message queue has reached the end of its life
+	 * cycle; the message queue object type list must not reference it
+	 * anymore. Unlink with the message queue lock released so that the
+	 * object core lock remains a leaf lock.
+	 */
+	if (ret == 0) {
+		k_obj_core_unlink(K_OBJ_CORE(msgq));
+	}
+#endif /* CONFIG_OBJ_CORE_MSGQ */
+
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, cleanup, msgq, ret);
 	return ret;
 }

--- a/kernel/obj_core.c
+++ b/kernel/obj_core.c
@@ -25,7 +25,12 @@ struct k_obj_type *z_obj_type_init(struct k_obj_type *type,
 
 void k_obj_core_init(struct k_obj_core *obj_core, struct k_obj_type *type)
 {
-	obj_core->node.next = NULL;
+	/* The link node is not touched here: it is owned by
+	 * k_obj_core_link() and k_obj_core_unlink(). Resetting the node of
+	 * a linked object (an object being re-initialized) would corrupt
+	 * its type's list; sys_slist_append() initializes the node of a new
+	 * object when it is linked.
+	 */
 	obj_core->type = type;
 #ifdef CONFIG_OBJ_CORE_STATS
 	obj_core->stats = NULL;
@@ -34,9 +39,18 @@ void k_obj_core_init(struct k_obj_core *obj_core, struct k_obj_type *type)
 
 void k_obj_core_link(struct k_obj_core *obj_core)
 {
+	sys_slist_t *list = &obj_core->type->list;
 	k_spinlock_key_t  key = k_spin_lock(&obj_core_lock);
 
-	sys_slist_append(&obj_core->type->list, &obj_core->node);
+	/* Unlink the object if it is already linked--linking is part of
+	 * (re-)initializing an object, and appending an already linked node
+	 * would corrupt the list. The removal walk only compares node
+	 * addresses, so it never reads the possibly indeterminate link node
+	 * of an object that was never linked before.
+	 */
+	(void)sys_slist_find_and_remove(list, &obj_core->node);
+
+	sys_slist_append(list, &obj_core->node);
 
 	k_spin_unlock(&obj_core_lock, key);
 }

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -109,6 +109,16 @@ int z_stack_cleanup(struct k_stack *stack, __maybe_unused bool locked)
 
 out:
 	k_spin_unlock(&stack->lock, key);
+
+#ifdef CONFIG_OBJ_CORE_STACK
+	/* On success the stack has reached the end of its life cycle; the
+	 * stack object type list must not reference it anymore.
+	 */
+	if (ret == 0) {
+		k_obj_core_unlink(K_OBJ_CORE(stack));
+	}
+#endif /* CONFIG_OBJ_CORE_STACK */
+
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, ret);
 
 	return ret;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -204,6 +204,15 @@ retry:
 out:
 	k_spin_unlock(&timer_lock, key);
 
+#ifdef CONFIG_OBJ_CORE_TIMER
+	/* On success the caller is about to free the storage; the timer
+	 * object type list must not reference it anymore.
+	 */
+	if (ret == 0) {
+		k_obj_core_unlink(K_OBJ_CORE(timer));
+	}
+#endif /* CONFIG_OBJ_CORE_TIMER */
+
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, ret);
 
 	return ret;

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -523,6 +523,75 @@ void *z_impl_k_object_alloc_size(enum k_objects otype, size_t size)
 	return z_object_alloc(otype, size);
 }
 
+#ifdef CONFIG_OBJ_CORE
+/* Unlink the object core (if any) of a dynamic kernel object that is about
+ * to be freed so that its type's list does not point into freed memory.
+ */
+static void dyn_obj_core_unlink(struct k_object *ko)
+{
+	struct k_obj_type *type;
+	uint32_t type_id;
+
+	/* An object that was never initialized was never linked and has an
+	 * uninitialized object core.
+	 */
+	if ((ko->flags & K_OBJ_FLAG_INITIALIZED) == 0U) {
+		return;
+	}
+
+	switch (ko->type) {
+	case K_OBJ_CONDVAR:
+		type_id = K_OBJ_TYPE_CONDVAR_ID;
+		break;
+#ifdef CONFIG_EVENTS
+	case K_OBJ_EVENT:
+		type_id = K_OBJ_TYPE_EVENT_ID;
+		break;
+#endif /* CONFIG_EVENTS */
+	case K_OBJ_MEM_SLAB:
+		type_id = K_OBJ_TYPE_MEM_SLAB_ID;
+		break;
+	case K_OBJ_MSGQ:
+		type_id = K_OBJ_TYPE_MSGQ_ID;
+		break;
+	case K_OBJ_MUTEX:
+		type_id = K_OBJ_TYPE_MUTEX_ID;
+		break;
+	case K_OBJ_PIPE:
+		type_id = K_OBJ_TYPE_PIPE_ID;
+		break;
+	case K_OBJ_SEM:
+		type_id = K_OBJ_TYPE_SEM_ID;
+		break;
+	case K_OBJ_STACK:
+		type_id = K_OBJ_TYPE_STACK_ID;
+		break;
+	case K_OBJ_THREAD:
+		type_id = K_OBJ_TYPE_THREAD_ID;
+		break;
+	case K_OBJ_TIMER:
+		type_id = K_OBJ_TYPE_TIMER_ID;
+		break;
+	default:
+		return;
+	}
+
+	/* The object type is not registered if its object core integration
+	 * is disabled (CONFIG_OBJ_CORE_*).
+	 */
+	type = k_obj_type_find(type_id);
+	if (type != NULL) {
+		k_obj_core_unlink(
+			(struct k_obj_core *)((uint8_t *)ko->name + type->obj_core_offset));
+	}
+}
+#else
+static void dyn_obj_core_unlink(struct k_object *ko)
+{
+	ARG_UNUSED(ko);
+}
+#endif /* CONFIG_OBJ_CORE */
+
 void k_object_free(void *obj)
 {
 	struct dyn_obj *dyn = NULL;
@@ -561,6 +630,7 @@ void k_object_free(void *obj)
 	}
 
 	if (dyn != NULL) {
+		dyn_obj_core_unlink(&dyn->kobj);
 #ifdef CONFIG_DYNAMIC_OBJECTS_FORCE_STACK_CACHED
 		/* We may have nudged the pointer to point to the cached area
 		 * in dynamic_object_create() when we first created the thread
@@ -720,6 +790,8 @@ static void unref_check(struct k_object *ko, uintptr_t index, bool locked)
 		/* Nothing to do */
 		break;
 	}
+
+	dyn_obj_core_unlink(ko);
 
 	sys_dlist_remove(&dyn->dobj_list);
 	k_free(dyn->data);

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -282,6 +282,10 @@ config TRACING_OBJECT_TRACKING
 	help
 	  Keep lists to track kernel objects.
 
+	  Tracked objects are never removed from the tracking lists, so any
+	  object passed to a kernel object *_init() function must remain
+	  valid forever.
+
 config TRACING_SHELL
 	bool "Tracing shell commands"
 	depends on TRACING_CORE && SHELL

--- a/tests/kernel/obj_core/obj_core/src/main.c
+++ b/tests/kernel/obj_core/obj_core/src/main.c
@@ -352,5 +352,37 @@ ZTEST(obj_core, test_obj_core_reinit)
 		      "FIFO list truncated by re-initialization\n");
 }
 
+ZTEST(obj_core, test_obj_core_dyn_free)
+{
+#ifdef CONFIG_DYNAMIC_OBJECTS
+	struct k_obj_type *obj_type;
+	struct k_obj_core *obj_core;
+	struct k_sem *sem;
+
+	obj_type = k_obj_type_find(K_OBJ_TYPE_SEM_ID);
+	zassert_not_null(obj_type, "semaphore object type not found\n");
+
+	k_thread_system_pool_assign(k_current_get());
+
+	sem = k_object_alloc(K_OBJ_SEM);
+	zassert_not_null(sem, "unable to allocate semaphore\n");
+
+	k_sem_init(sem, 0, 1);
+	obj_core = K_OBJ_CORE(sem);
+
+	zassert_equal(obj_core_count(obj_type, obj_core), 1, "allocated semaphore not linked\n");
+
+	/* Freeing the semaphore must unlink it from the semaphore type
+	 * list, which would otherwise point into freed memory.
+	 */
+
+	k_object_free(sem);
+
+	zassert_equal(obj_core_count(obj_type, obj_core), 0, "freed semaphore still linked\n");
+#else
+	ztest_test_skip();
+#endif /* CONFIG_DYNAMIC_OBJECTS */
+}
+
 ZTEST_SUITE(obj_core, NULL, NULL,
 	    ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);

--- a/tests/kernel/obj_core/obj_core/src/main.c
+++ b/tests/kernel/obj_core/obj_core/src/main.c
@@ -352,6 +352,75 @@ ZTEST(obj_core, test_obj_core_reinit)
 		      "FIFO list truncated by re-initialization\n");
 }
 
+static struct k_thread cleanup_thread;
+static K_THREAD_STACK_DEFINE(cleanup_thread_stack, 512 + CONFIG_TEST_EXTRA_STACK_SIZE);
+
+static void stack_pop_entry(void *p1, void *p2, void *p3)
+{
+	stack_data_t data;
+
+	(void)k_stack_pop(&stack2, &data, K_FOREVER);
+}
+
+ZTEST(obj_core, test_obj_core_cleanup)
+{
+	struct k_obj_type *obj_type;
+
+	/* Objects that reached the end of their life cycle via their
+	 * *_cleanup() function must be unlinked from their type's list.
+	 */
+
+	obj_type = k_obj_type_find(K_OBJ_TYPE_MSGQ_ID);
+	zassert_not_null(obj_type, "message queue object type not found\n");
+
+	k_msgq_init(&msgq2, msgq2_buffer, 4, 4);
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&msgq2)), 1,
+		      "message queue not linked\n");
+	zassert_equal(k_msgq_cleanup(&msgq2), 0, "msgq cleanup failed\n");
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&msgq2)), 0,
+		      "cleaned up message queue still linked\n");
+
+	obj_type = k_obj_type_find(K_OBJ_TYPE_STACK_ID);
+	zassert_not_null(obj_type, "stack object type not found\n");
+
+	k_stack_init(&stack2, stack2_buffer, 8);
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&stack2)), 1, "stack not linked\n");
+
+	/* A cleanup refused because the object is still in use must leave
+	 * the object linked.
+	 */
+
+	k_thread_create(&cleanup_thread, cleanup_thread_stack,
+			K_THREAD_STACK_SIZEOF(cleanup_thread_stack),
+			stack_pop_entry, NULL, NULL, NULL,
+			K_HIGHEST_THREAD_PRIO, 0, K_NO_WAIT);
+
+	/* Wait until the thread is pending on the stack */
+	k_msleep(50);
+
+	zassert_equal(k_stack_cleanup(&stack2), -EAGAIN,
+		      "stack cleanup did not refuse with a waiter\n");
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&stack2)), 1,
+		      "refused stack cleanup unlinked the stack\n");
+
+	/* Release the waiter and try again */
+	zassert_ok(k_stack_push(&stack2, 1));
+	zassert_ok(k_thread_join(&cleanup_thread, K_SECONDS(1)));
+
+	zassert_equal(k_stack_cleanup(&stack2), 0, "stack cleanup failed\n");
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&stack2)), 0,
+		      "cleaned up stack still linked\n");
+
+	obj_type = k_obj_type_find(K_OBJ_TYPE_TIMER_ID);
+	zassert_not_null(obj_type, "timer object type not found\n");
+
+	k_timer_init(&timer2, NULL, NULL);
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&timer2)), 1, "timer not linked\n");
+	zassert_equal(k_timer_cleanup(&timer2), 0, "timer cleanup failed\n");
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&timer2)), 0,
+		      "cleaned up timer still linked\n");
+}
+
 ZTEST(obj_core, test_obj_core_dyn_free)
 {
 #ifdef CONFIG_DYNAMIC_OBJECTS

--- a/tests/kernel/obj_core/obj_core/src/main.c
+++ b/tests/kernel/obj_core/obj_core/src/main.c
@@ -283,5 +283,74 @@ ZTEST(obj_core, test_obj_core_sem)
 			     K_OBJ_CORE(&sem1), K_OBJ_CORE(&sem2));
 }
 
+struct obj_core_count_data {
+	struct k_obj_core *obj_core;    /* Object core to count */
+	unsigned int count;             /* Number of occurrences found */
+};
+
+static int obj_core_count_op(struct k_obj_core *obj_core, void *data)
+{
+	struct obj_core_count_data *count_data = data;
+
+	if (count_data->obj_core == obj_core) {
+		count_data->count++;
+	}
+
+	return 0;
+}
+
+static unsigned int obj_core_count(struct k_obj_type *obj_type, struct k_obj_core *obj_core)
+{
+	struct obj_core_count_data walk_data = {
+		.obj_core = obj_core,
+		.count = 0,
+	};
+
+	k_obj_type_walk_locked(obj_type, obj_core_count_op, &walk_data);
+
+	return walk_data.count;
+}
+
+ZTEST(obj_core, test_obj_core_reinit)
+{
+	struct k_obj_type *obj_type;
+
+	obj_type = k_obj_type_find(K_OBJ_TYPE_MUTEX_ID);
+	zassert_not_null(obj_type, "mutex object type not found\n");
+
+	/*
+	 * mutex1 was statically defined and linked at boot; link mutex2
+	 * after it. Re-initializing mutex1 must neither truncate the mutex
+	 * type list (losing mutex2) nor link mutex1's node twice.
+	 */
+
+	k_mutex_init(&mutex2);
+	k_mutex_init(&mutex1);
+	k_mutex_init(&mutex1);
+
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&mutex1)), 1,
+		      "re-initialized mutex not linked exactly once\n");
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&mutex2)), 1,
+		      "mutex list truncated by re-initialization\n");
+
+	/*
+	 * k_fifo_init() links the object core via the split
+	 * K_OBJ_CORE_INIT()/K_OBJ_CORE_LINK() macros rather than
+	 * k_obj_core_init_and_link(); cover that path as well.
+	 */
+
+	obj_type = k_obj_type_find(K_OBJ_TYPE_FIFO_ID);
+	zassert_not_null(obj_type, "FIFO object type not found\n");
+
+	k_fifo_init(&fifo2);
+	k_fifo_init(&fifo1);
+	k_fifo_init(&fifo1);
+
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&fifo1)), 1,
+		      "re-initialized FIFO not linked exactly once\n");
+	zassert_equal(obj_core_count(obj_type, K_OBJ_CORE(&fifo2)), 1,
+		      "FIFO list truncated by re-initialization\n");
+}
+
 ZTEST_SUITE(obj_core, NULL, NULL,
 	    ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);

--- a/tests/kernel/obj_core/obj_core/tests.yaml
+++ b/tests/kernel/obj_core/obj_core/tests.yaml
@@ -6,3 +6,15 @@ tests:
       - qemu_x86
     platform_exclude:
       - qemu_x86_tiny
+  kernel.obj_core.dynamic:
+    tags: kernel
+    ignore_faults: true
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    integration_platforms:
+      - qemu_x86
+    platform_exclude:
+      - qemu_x86_tiny
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=y
+      - CONFIG_DYNAMIC_OBJECTS=y
+      - CONFIG_HEAP_MEM_POOL_SIZE=8192


### PR DESCRIPTION
`CONFIG_OBJ_CORE` links every kernel object into its type's list from `*_init()`, but except for aborted threads nothing ever unlinked them, leaving the lists corrupted or pointing into freed memory. This series fixes, each with a regression test:

- Re-initializing an already linked object (e.g. `k_sem_init()` on a `K_SEM_DEFINE`'d semaphore) truncated its type list.
- Freed dynamic kernel objects left dangling list entries.
- Objects released with `k_msgq_cleanup()`/`k_stack_cleanup()`/`k_timer_cleanup()` left dangling list entries.

The last commit documents the resulting object lifetime requirements.

Out of scope, to be addressed separately: kernel objects living on a thread's stack, and the lack of a removal API for the `TRACING_OBJECT_TRACKING` lists.