### PR TITLE
drivers: bee: claim peripheral DMA channels via dma_request_channel

### DIFF
--- a/drivers/serial/uart_bee.c
+++ b/drivers/serial/uart_bee.c
@@ -986,10 +986,34 @@ static int uart_bee_async_init(const struct device *dev)
 		return 0;
 	}
 
-	atomic_set_bit(((struct dma_context *)data->dma_rx.dma_dev->data)->atomic,
-		       data->dma_rx.dma_channel);
-	atomic_set_bit(((struct dma_context *)data->dma_tx.dma_dev->data)->atomic,
-		       data->dma_tx.dma_channel);
+	/*
+	 * Claim the devicetree-assigned channels through the DMA controller's
+	 * allocation bitmap so that dma_request_channel() (e.g. a memory-to-memory
+	 * user on the same controller) can never hand them out again. Using a
+	 * BIT(channel) filter forces exactly the DT channel and fails loudly if it
+	 * is already taken.
+	 */
+	if (data->dma_rx.dma_dev != NULL) {
+		uint32_t ch_filter = BIT(data->dma_rx.dma_channel);
+		int ch = dma_request_channel(data->dma_rx.dma_dev, &ch_filter);
+
+		if (ch < 0) {
+			LOG_ERR("UART RX DMA channel %u already in use",
+				data->dma_rx.dma_channel);
+			return ch;
+		}
+	}
+
+	if (data->dma_tx.dma_dev != NULL) {
+		uint32_t ch_filter = BIT(data->dma_tx.dma_channel);
+		int ch = dma_request_channel(data->dma_tx.dma_dev, &ch_filter);
+
+		if (ch < 0) {
+			LOG_ERR("UART TX DMA channel %u already in use",
+				data->dma_tx.dma_channel);
+			return ch;
+		}
+	}
 
 	/* Disable both UART TX and UART RX DMA requests */
 	uart_bee_dma_rx_disable(dev);

--- a/drivers/spi/spi_bee.c
+++ b/drivers/spi/spi_bee.c
@@ -698,6 +698,35 @@ static int spi_bee_dma_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	/*
+	 * Claim the devicetree-assigned channels through the DMA controller's
+	 * allocation bitmap so that dma_request_channel() (e.g. a memory-to-memory
+	 * user on the same controller) can never hand them out again. Using a
+	 * BIT(channel) filter forces exactly the DT channel and fails loudly if it
+	 * is already taken.
+	 */
+	if (data->dma_rx.dma_dev != NULL) {
+		uint32_t ch_filter = BIT(data->dma_rx.dma_channel);
+
+		ret = dma_request_channel(data->dma_rx.dma_dev, &ch_filter);
+		if (ret < 0) {
+			LOG_ERR("SPI RX DMA channel %u already in use",
+				data->dma_rx.dma_channel);
+			return ret;
+		}
+	}
+
+	if (data->dma_tx.dma_dev != NULL) {
+		uint32_t ch_filter = BIT(data->dma_tx.dma_channel);
+
+		ret = dma_request_channel(data->dma_tx.dma_dev, &ch_filter);
+		if (ret < 0) {
+			LOG_ERR("SPI TX DMA channel %u already in use",
+				data->dma_tx.dma_channel);
+			return ret;
+		}
+	}
+
 	/* Configure dma rx config */
 	memset(&data->dma_rx.blk_cfg, 0, sizeof(data->dma_rx.blk_cfg));
 


### PR DESCRIPTION
  ### Description

  The Bee UART and SPI drivers take their DMA channels statically from the
  devicetree (`dmas` / `dma-names`) and program them with `dma_config()`.
  Neither registered those channels in the DMA controller's allocation
  bitmap, so a `dma_request_channel(dev, NULL)` caller on the same
  controller (e.g. a memory-to-memory transfer) could be handed a channel
  already owned by UART/SPI, corrupting both transfers.

  Both drivers now claim their devicetree channel at init through
  `dma_request_channel()` with a `BIT(channel)` filter. The filter forces
  exactly the DT channel and registers it in the same atomic bitmap that
  dynamic allocation consults, so the two channel-allocation models can no
  longer collide. Init fails with an error if the channel is already in use.

  This also replaces a fragile `atomic_set_bit()` poke into the DMA
  controller's private `dma_context` in the UART driver, and fixes a latent
  NULL-pointer dereference there when only one DMA direction is configured.