### PR TITLE
tests: ipc: ipc_sessions: Remove partition manager bits

### DIFF
--- a/tests/subsys/ipc/ipc_sessions/sysbuild.cmake
+++ b/tests/subsys/ipc/ipc_sessions/sysbuild.cmake
@@ -15,11 +15,6 @@ ExternalZephyrProject_Add(
   BOARD ${SB_CONFIG_REMOTE_BOARD}
   BOARD_REVISION ${BOARD_REVISION}
 )
-set_property(GLOBAL APPEND PROPERTY PM_DOMAINS CPUNET)
-set_property(GLOBAL APPEND PROPERTY PM_CPUNET_IMAGES remote)
-set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
-set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
-
 # Add a dependency so that the remote sample will be built and flashed first
 sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.


### PR DESCRIPTION
This code should never have been added and has no relevance to zephyr at all