### PR TITLE
drivers: i2c: Fix CONFIG_I2C_MCUX_*_BUS_RECOVERY default values

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -259,7 +259,7 @@ config I2C_MCUX_LPI2C
 config I2C_MCUX_LPI2C_BUS_RECOVERY
 	bool "Bus recovery support"
 	default y if I2C_BUS_RECOVERY
-	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPI2C),recover-bus-on-init)
+	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPI2C),recover-bus-on-init,True)
 	depends on I2C_MCUX_LPI2C && PINCTRL
 	select I2C_BITBANG
 	help

--- a/drivers/i2c/Kconfig.mcux
+++ b/drivers/i2c/Kconfig.mcux
@@ -15,7 +15,7 @@ menuconfig I2C_MCUX_FLEXCOMM
 config I2C_MCUX_FLEXCOMM_BUS_RECOVERY
 	bool "Bus recovery support"
 	default y if I2C_BUS_RECOVERY
-	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPC_I2C),recover-bus-on-init)
+	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPC_I2C),recover-bus-on-init,True)
 	depends on I2C_MCUX_FLEXCOMM && PINCTRL
 	select I2C_BITBANG
 	help


### PR DESCRIPTION
Since `recover-bus-on-init` DT property if of boolean type, use of `dt_compat_any_has_prop()` without an explicit value argument of `True` makes that function to always return true and
`CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY` and
`CONFIG_I2C_MCUX_FLEXCOMM_BUS_RECOVERY` configuration options always enabled (when their dependencies are met).

Set function argument `value` to `True` to get the expected behavior.