### PR TITLE
drivers: serial: Fix UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER dependency

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -73,7 +73,7 @@ config UARTE_NRFX_UARTE_HAS_DMAEND
 config UARTE_NRFX_UARTE_COUNT_BYTES_WITH_TIMER
 	bool "Use TIMER to count RX bytes"
 	depends on UART_ASYNC_API
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_UARTE),frame-timeout-supported)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_UARTE),frame-timeout-supported,True)
 	depends on !UARTE_NRFX_UARTE_HAS_DMAEND
 	depends on !ARCH_POSIX # Mode not supported on BSIM target
 	select NRFX_GPPI


### PR DESCRIPTION
Since `frame-timeout-supported` DT property if of boolean type, use of `dt_compat_any_has_prop()` without an explicit `value` argument of `True` makes that function to always return true. Set function argument `value` to `True` to get the expected behavior.