### PR TITLE
soc: silabs_s2: Fix HW compat flags detection from DT

### DIFF
--- a/soc/silabs/silabs_s2/Kconfig
+++ b/soc/silabs/silabs_s2/Kconfig
@@ -51,24 +51,24 @@ config SILABS_DEVICE_IS_MODULE
 # Hardware capability flags (auto-detected from Device Tree)
 # Bluetooth 5.0
 config HAS_HW_EFR32_RADIO_BLE_2M
-	def_bool $(dt_nodelabel_has_prop,radio,ble-2mbps-supported)
+	def_bool $(dt_nodelabel_bool_prop,radio,ble-2mbps-supported)
 
 config HAS_HW_EFR32_RADIO_BLE_CODED
-	def_bool $(dt_nodelabel_has_prop,radio,ble-coded-phy-supported)
+	def_bool $(dt_nodelabel_bool_prop,radio,ble-coded-phy-supported)
 
 # Bluetooth 5.1
 config HAS_HW_EFR32_RADIO_CTE_TX
-	def_bool $(dt_nodelabel_has_prop,radio,ble-cte-tx-supported)
+	def_bool $(dt_nodelabel_bool_prop,radio,ble-cte-tx-supported)
 
 config HAS_HW_EFR32_RADIO_CTE_RX
-	def_bool $(dt_nodelabel_has_prop,radio,ble-cte-rx-supported) && HAS_HW_EFR32_RADIO_CTE_TX
+	def_bool $(dt_nodelabel_bool_prop,radio,ble-cte-rx-supported) && HAS_HW_EFR32_RADIO_CTE_TX
 
 # Bluetooth 6.0
 config HAS_HW_EFR32_RADIO_CS
-	def_bool $(dt_nodelabel_has_prop,radio,ble-cs-supported)
+	def_bool $(dt_nodelabel_bool_prop,radio,ble-cs-supported)
 
 # Vendor-specific
 config HAS_HW_EFR32_RADIO_TX_HIGH_POWER
-	def_bool $(dt_nodelabel_has_prop,radio,radio-tx-high-power-supported)
+	def_bool $(dt_nodelabel_bool_prop,radio,radio-tx-high-power-supported)
 
 endif


### PR DESCRIPTION
Replace use of `dt_nodelabel_has_prop()` with use of `dt_nodelabel_bool_prop()` on boolean properties since the former always return true when a property is defined which is the case for `"nordic,nrf-radio"` and `"silabs,series2-radio"` DT compatible nodes which both include **ble-radio.yaml** and **radio.yaml** bindings that defines these boolean properties.