### PR TITLE
soc: renesas: ra: Fix support of manual-configure DT property

### DIFF
--- a/soc/renesas/ra/Kconfig
+++ b/soc/renesas/ra/Kconfig
@@ -41,7 +41,8 @@ config SOC_RA_SECOND_CORE_BUILD
 config RENESAS_RA_BATTERY_BACKUP_MANUAL_CONFIGURE
 	bool "VBAT switching manual"
 	default y
-	depends on DT_HAS_RENESAS_RA_BATTERY_BACKUP_ENABLED && $(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_BATTERY_BACKUP),manual-configure)
+	depends on DT_HAS_RENESAS_RA_BATTERY_BACKUP_ENABLED && \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_RENESAS_RA_BATTERY_BACKUP),manual-configure,True)
 	help
 	  Enable if this SoC's battery backup domain allows switching to VBAT manually.
 	  Leave disabled if switching is automatic.


### PR DESCRIPTION
Fix `CONFIG_RENESAS_RA_BATTERY_BACKUP_MANUAL_CONFIGURE` default value.

Since `manual-configure` DT property is of boolean type, use of `dt_compat_any_has_prop(..., manual-configure)` always returns true. Set function argument `value` to `True` to get the expected behavior.