### PR TITLE
drivers: adc: stm32: Fix ADC_HAS_SEQUENCE_PRIORITY selection

### DIFF
--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -17,7 +17,7 @@ config ADC_STM32
 	select PINCTRL
 	select ADC_ASYNC if ADC_STREAM
 	select ADC_HAS_SEQUENCE_PRIORITY if \
-		$(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_ADC),$(ADC_STM32_INJECTED_SUPPORT))
+		$(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_ADC),$(ADC_STM32_INJECTED_SUPPORT),True)
 	help
 	  Enable the driver implementation for the stm32xx ADC
 


### PR DESCRIPTION
Fix `CONFIG_ADC_HAS_SEQUENCE_PRIORITY` select by `CONFIG_ADC_STM32`.

Since `st,adc-has-injected-support` DT property is of boolean type, use of `dt_compat_any_has_prop(..., st,adc-has-injected-support)` always returns true. Set function argument `value` to `True` to get the expected behavior.