### PR TITLE
net: mdns: fix mon_if array size

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -269,7 +269,7 @@ struct mdns_monitor_iface_addr {
 };
 
 static struct mdns_monitor_iface_addr mon_if[
-	MAX(MAX_IPV4_IFACE_COUNT, MAX_IPV4_IFACE_COUNT) *
+	MDNS_MAX_IFACE_COUNT *
 	(NET_IF_MAX_IPV4_ADDR + NET_IF_MAX_IPV6_ADDR)];
 #endif
 


### PR DESCRIPTION
Use the configured IPv6 interface count when sizing the mDNS interface address monitor array. The previous expression used the IPv4 interface count twice.