### PR TITLE
drivers: adc_stm32: fix kernel panic in ADC stream mode

### DIFF
--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -16,6 +16,7 @@ config ADC_STM32
 	depends on DT_HAS_ST_STM32_ADC_ENABLED
 	select PINCTRL
 	select ADC_ASYNC if ADC_STREAM
+	select RTIO_WORKQ if ADC_STREAM
 	select ADC_HAS_SEQUENCE_PRIORITY if \
 		$(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_ADC),$(ADC_STM32_INJECTED_SUPPORT))
 	help

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -15,6 +15,9 @@
 
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/pinctrl.h>
+#ifdef CONFIG_ADC_STREAM
+#include <zephyr/rtio/work.h>
+#endif
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
@@ -2122,10 +2125,11 @@ static int adc_stm32_pm_action(const struct device *dev,
 #endif /* CONFIG_PM_DEVICE */
 
 #ifdef CONFIG_ADC_STREAM
-static void adc_stm32_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+static void adc_stm32_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
 {
-	struct adc_stm32_data *data = dev->data;
 	const struct adc_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
+	const struct device *dev = read_cfg->adc;
+	struct adc_stm32_data *data = dev->data;
 	int rc;
 
 	data->sqe = iodev_sqe;
@@ -2137,6 +2141,19 @@ static void adc_stm32_submit_stream(const struct device *dev, struct rtio_iodev_
 	if (rc < 0) {
 		LOG_ERR("Error starting conversion (%d)", rc);
 	}
+}
+
+static void adc_stm32_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct rtio_work_req *req = rtio_work_req_alloc();
+
+	if (req == NULL) {
+		LOG_ERR("No RTIO work items available");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	rtio_work_req_submit(req, iodev_sqe, adc_stm32_submit_fetch);
 }
 
 static int adc_stm32_decoder_get_frame_count(const uint8_t *buffer, uint32_t channel,

--- a/samples/drivers/adc/adc_stream/boards/nucleo_g431kb.overlay
+++ b/samples/drivers/adc/adc_stream/boards/nucleo_g431kb.overlay
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Arduino-header analog inputs on the Nucleo-G431KB:
+ *   A0 — PA0 — ADC1_IN1
+ *   A1 — PA1 — ADC1_IN2
+ */
+
+/ {
+	aliases {
+		adc0 = &adc1;
+	};
+
+	zephyr,user {
+		io-channels = <&adc1 1>, <&adc1 2>;
+	};
+};
+
+&adc1 {
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	pinctrl-0 = <&adc1_in1_pa0 &adc1_in2_pa1>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* A0 — PA0 */
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	/* A1 — PA1 */
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_stream/tests.yaml
+++ b/samples/drivers/adc/adc_stream/tests.yaml
@@ -2,15 +2,19 @@ sample:
   name: ADC stream sample
 common:
   tags: adc
-  depends_on: adc
-  filter: dt_alias_exists("adc0") and dt_node_has_prop("/zephyr,user","io-channels")
   harness: console
   harness_config:
     type: one_line
     regex:
       - "^ADC data for [^@]+@\\d+ channel \\d+ \\([0-9.]+\\) \\d+ns$"
 tests:
-  sample.drivers.adc.adc_stream: {}
+  sample.drivers.adc.adc_stream:
+    depends_on: adc
+    filter: dt_alias_exists("adc0") and dt_node_has_prop("/zephyr,user","io-channels")
+  sample.drivers.adc.adc_stream.stm32:
+    platform_allow:
+      - nucleo_g431kb
+      - nucleo_h753zi
   sample.drivers.adc.adc_stream.ad4052-stream:
     extra_args:
       - SHIELD=eval_ad4052_ardz


### PR DESCRIPTION
### Problem

When using `CONFIG_ADC_STREAM` on STM32, continuous streaming causes a **kernel panic** ("Fault during interrupt handling") on the second and subsequent conversions.

The root cause is that `adc_stm32_submit_stream()` calls `adc_context_lock()`, which internally does `k_sem_take(K_FOREVER)`. This is fine for the initial submission from thread context, but RTIO re-submits the next SQE from CQE processing in **ISR context** (the ADC end-of-conversion interrupt).  `k_sem_take` with a non-zero timeout is illegal in ISR context, triggering an immediate fault.

### Fix

Split the stream submission into two functions:

- **`adc_stm32_submit_stream()`** — the RTIO entry point, now just allocates an `rtio_work_req` and defers to the RTIO shared workqueue.
- **`adc_stm32_submit_fetch()`** — runs in thread context on the RTIO workqueue, where it is safe to acquire `adc_context_lock`.

This follows the same pattern already used by `default_rtio_adc.c` (`adc_submit_fallback` → `rtio_work_req_submit`), so no new infrastructure is added.  `RTIO_WORKQ` is selected automatically when `ADC_STREAM` is enabled.

### Scope of the bug

The same pattern exists in `adc_max32.c`, which will need a similar fix.

https://github.com/zephyrproject-rtos/zephyr/blob/c0bba90c366a395d2b55f3637aac066ecfb7757d/drivers/adc/adc_max32.c#L248-L268

Drivers that don't override `.submit` use the default fallback in `default_rtio_adc.c`, which already defers via `rtio_work_req_submit` and are not affected.

### Sample board support

The second commit adds `nucleo_g431kb` to the `adc_stream` sample with a device tree overlay for the Arduino A0/A1 analog inputs (PA0, PA1). It also moves `depends_on` and `filter` from the `common:` section to the generic test entry, so that `platform_allow` boards whose overlays supply the required nodes are not filtered out before the overlay is applied.

### Testing

- Built and run on **Nucleo-G431KB** hardware.
- `adc_stream` sample produces correct, stable readings in continuous mode (previously faulted on the second conversion).
- Twister `sample.drivers.adc.adc_stream.stm32` passes with console harness.

<details>
<summary>Click to expand twister output</summary>

```console
$ west twister -T samples/drivers/adc/adc_stream -s sample.drivers.adc.adc_stream.stm32 -p nucleo_g431kb --device-testing --device-serial /dev/ttyACM0 --west-flash --west-runner=openocd -v
INFO    - Using Ninja..
INFO    - Zephyr version: 68ffc324e177
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - Writing JSON report /home/lasse/projects/zephyr-devel/deps/zephyr/twister-out/testplan.json

Device testing on:

| Platform                  | ID   | Serial device   |
|---------------------------|------|-----------------|
| nucleo_g431kb/stm32g431xx |      | /dev/ttyACM0    |

INFO    - JOBS: 16
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/1 nucleo_g431kb/stm32g431xx sample.drivers.adc.adc_stream.stm32                PASSED (device: None, 1.616s <zephyr/gnu>)

INFO    - 1 test scenarios (1 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 1 of 1 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 8.90 seconds.
INFO    - 1 of 1 executed test cases passed (100.00%) on 1 out of total 1685 platforms (0.06%).
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                     | ID   |   Counter |   Failures |
|---------------------------|------|-----------|------------|
| nucleo_g431kb/stm32g431xx |      |         1 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report /home/lasse/projects/zephyr-devel/deps/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/lasse/projects/zephyr-devel/deps/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/lasse/projects/zephyr-devel/deps/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

</details>
