### PR TITLE
drivers: adc_max32: fix kernel panic in ADC stream mode

### DIFF
--- a/drivers/adc/Kconfig.max32
+++ b/drivers/adc/Kconfig.max32
@@ -14,6 +14,7 @@ config ADC_MAX32
 config ADC_MAX32_STREAM
 	bool "Use FIFO to stream data"
 	select ADC_ASYNC
+	select RTIO_WORKQ
 	depends on ADC_MAX32
 	depends on DT_HAS_ADI_MAX32_ADC_B_ME18_ENABLED
 	help

--- a/drivers/adc/adc_max32.c
+++ b/drivers/adc/adc_max32.c
@@ -15,6 +15,9 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 
+#ifdef CONFIG_ADC_MAX32_STREAM
+#include <zephyr/rtio/work.h>
+#endif
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_max32, CONFIG_ADC_LOG_LEVEL);
 
@@ -245,26 +248,42 @@ static int start_read_stream(const struct device *dev, const struct adc_sequence
 	return adc_context_wait_for_completion(&data->ctx);
 }
 
-void adc_max32_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+static void adc_max32_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
 {
-	struct max32_adc_data *data = (struct max32_adc_data *)dev->data;
 	const struct adc_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
+	const struct device *dev = read_cfg->adc;
+	struct max32_adc_data *data = (struct max32_adc_data *)dev->data;
 	int rc;
 
-	if (data->no_mem == 1) {
-		data->no_mem = 0;
-		return;
-	}
 	data->sqe = iodev_sqe;
 
 	adc_context_lock(&data->ctx, false, NULL);
 	rc = start_read_stream(dev, read_cfg->sequence);
-
 	adc_context_release(&data->ctx, rc);
 
 	if (rc < 0) {
 		LOG_ERR("Error starting conversion (%d)", rc);
 	}
+}
+
+void adc_max32_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct max32_adc_data *data = (struct max32_adc_data *)dev->data;
+	struct rtio_work_req *req;
+
+	if (data->no_mem == 1) {
+		data->no_mem = 0;
+		return;
+	}
+
+	req = rtio_work_req_alloc();
+	if (req == NULL) {
+		LOG_ERR("No RTIO work items available");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	rtio_work_req_submit(req, iodev_sqe, adc_max32_submit_fetch);
 }
 
 static const uint32_t adc_max32_resolution[] = {


### PR DESCRIPTION
Same ISR-context bug as #116767: `adc_max32_submit_stream()` calls `adc_context_lock()` (`k_sem_take(K_FOREVER)`) when RTIO re-submits from the conversion-complete ISR, which panics.

Defer the lock and conversion start to the RTIO workqueue via `rtio_work_req_submit()`, matching the STM32 change. `ADC_MAX32_STREAM` now selects `RTIO_WORKQ`.

I do not have MAX32 hardware, so this has **not** been tested on a board.
