### PR TITLE
soc: arm: beetle: describe the SoC in the arm SoC tree

### DIFF
--- a/soc/arm/beetle/soc.yml
+++ b/soc/arm/beetle/soc.yml
@@ -1,4 +1,0 @@
-series:
-- name: beetle
-  socs:
-  - name: beetle_r0

--- a/soc/arm/soc.yml
+++ b/soc/arm/soc.yml
@@ -30,6 +30,9 @@ family:
     socs:
     - name: designstart_fpga_cortex_m1
     - name: designstart_fpga_cortex_m3
+  - name: beetle
+    socs:
+    - name: beetle_r0
 - name: arm64
   series:
   - name: fvp_aem


### PR DESCRIPTION
soc/arm/beetle carried its own soc.yml, which made it a SoC tree of its
own even though it sits inside soc/arm and is already reached from there:
soc/arm/Kconfig.soc and soc/arm/Kconfig rsource */Kconfig.soc and
*/Kconfig, and soc/arm/CMakeLists.txt adds the series subdirectory.

The two trees therefore had to be loaded together for beetle to work,
as soc/arm/beetle/Kconfig.soc selects SOC_FAMILY_ARM from
soc/arm/Kconfig.soc, and beetle's Kconfig.soc ended up being sourced
twice, once through the generated Kconfig.soc and once through the
rsource glob.

Describe beetle as a series of the arm family in soc/arm/soc.yml and drop
the extra soc.yml. beetle_r0 now resolves to the soc/arm directory, which
is where its files are reached from anyway.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
