### PR TITLE
drivers: serial: stm32: declare few lock functions as maybe unused

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -215,7 +215,7 @@ static void uart_stm32_pm_policy_state_lock_put(const struct device *dev)
 }
 
 #ifdef CONFIG_UART_ASYNC_API
-static void uart_stm32_rx_wakeup_lock_get(const struct device *dev)
+static __maybe_unused void uart_stm32_rx_wakeup_lock_get(const struct device *dev)
 {
 	struct uart_stm32_data *data = dev->data;
 
@@ -225,7 +225,7 @@ static void uart_stm32_rx_wakeup_lock_get(const struct device *dev)
 	}
 }
 
-static void uart_stm32_rx_wakeup_lock_put(const struct device *dev)
+static __maybe_unused void uart_stm32_rx_wakeup_lock_put(const struct device *dev)
 {
 	struct uart_stm32_data *data = dev->data;
 


### PR DESCRIPTION
This fixes a potential build warning introduced in 7b2a3c0cca0, where the static functions would get declard but not used if the board has:
- CONFIG_PM=y
- CONFIG_UART_ASYNC_API=y
- CONFIG_DMA=y
- the dma node enabled in devicetree

Reproduced with:

west build -p -b stm32f4_disco samples/hello_world -DCONFIG_PM=y -DCONFIG_UART_ASYNC_API=y -DCONFIG_DMA=y

zephyrproject/zephyr/drivers/serial/uart_stm32.c:218:13: warning: 'uart_stm32_rx_wakeup_lock_get' defined but not used

Found this downstream, finding the specific combination of option and dt override to reproduce this was a big mess, there's no benefit chasing down the specific combination of ifdeffery here so let's just mark them as maybe unused and if that combo hits the compiler can just drop them. Between ifdefs form Kconfig and the HAL this driver is already VERY hard to follow.