### PR TITLE
net: http: fix empty http/2 content-encoding

### DIFF
--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -519,7 +519,9 @@ static int handle_http2_static_fs_resource(struct http_resource_detail_static_fs
 
 	/* send headers */
 	if (IS_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION)) {
-		res_detail.content_encoding = http_compression_text(chosen_compression);
+		if (chosen_compression != HTTP_NONE) {
+			res_detail.content_encoding = http_compression_text(chosen_compression);
+		}
 	}
 	ret = send_headers_frame(client, HTTP_200_OK, frame->stream_identifier, &res_detail, 0,
 				 NULL, 0);


### PR DESCRIPTION
When no compressed file variant is found, http_compression_text() returns an empty string. Previously this was unconditionally assigned to res_detail.content_encoding, causing send_headers_frame() to encode a content-encoding header with an empty value. HPACK rejects empty header values, resulting in an HTTP/2 protocol error on the client.

Guard the assignment so content_encoding is only set when a compression algorithm was actually selected.

Fixes: #117884
