### PR TITLE
kernel: work: do not track transient k_work_sync semaphores

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -224,6 +224,23 @@ void z_mem_manage_boot_finish(void);
 
 bool z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
 
+/**
+ * @brief Initialize a semaphore without registering it for object tracking
+ *
+ * Transient kernel-internal semaphores that live on a caller's stack (such
+ * as those embedded in k_work_sync) must not be registered with the kernel
+ * object tracking facilities as they go out of scope without notice: the
+ * object core type list and the tracing object tracking list would keep
+ * referencing dead memory. Unlike k_sem_init() this initializer performs no
+ * such registration.
+ *
+ * @param sem Address of the semaphore.
+ * @param initial_count Initial semaphore count.
+ * @param limit Maximum permitted semaphore count, must be non-zero and
+ *              greater than or equal to the initial count.
+ */
+void z_sem_init_untracked(struct k_sem *sem, unsigned int initial_count, unsigned int limit);
+
 #ifdef CONFIG_PM
 
 /* When the kernel is about to go idle, it calls this function to notify the

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -20,6 +20,7 @@
 #include <zephyr/kernel.h>
 
 #include <zephyr/toolchain.h>
+#include <kernel_internal.h>
 #include <wait_q.h>
 #include <zephyr/sys/dlist.h>
 #include <ksched.h>
@@ -42,6 +43,17 @@ static struct k_spinlock sem_lock;
 static struct k_obj_type obj_type_sem;
 #endif /* CONFIG_OBJ_CORE_SEM */
 
+void z_sem_init_untracked(struct k_sem *sem, unsigned int initial_count, unsigned int limit)
+{
+	sem->count = initial_count;
+	sem->limit = limit;
+
+	z_waitq_init(&sem->wait_q);
+#if defined(CONFIG_POLL)
+	sys_dlist_init(&sem->poll_events);
+#endif /* CONFIG_POLL */
+}
+
 int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 		      unsigned int limit)
 {
@@ -54,15 +66,10 @@ int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 		return -EINVAL;
 	}
 
-	sem->count = initial_count;
-	sem->limit = limit;
+	z_sem_init_untracked(sem, initial_count, limit);
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_sem, init, sem, 0);
 
-	z_waitq_init(&sem->wait_q);
-#if defined(CONFIG_POLL)
-	sys_dlist_init(&sem->poll_events);
-#endif /* CONFIG_POLL */
 	k_object_init(sem);
 
 #ifdef CONFIG_OBJ_CORE_SEM

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -11,6 +11,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <kernel_internal.h>
 #include <wait_q.h>
 #include <zephyr/spinlock.h>
 #include <errno.h>
@@ -71,7 +72,12 @@ static void handle_flush(struct k_work *work) { }
 static inline void init_flusher(struct z_work_flusher *flusher)
 {
 	struct k_work *work = &flusher->work;
-	k_sem_init(&flusher->sem, 0, 1);
+
+	/* The flusher lives on the flushing caller's stack (inside
+	 * k_work_sync); its semaphore must not be registered for object
+	 * tracking.
+	 */
+	z_sem_init_untracked(&flusher->sem, 0, 1);
 	k_work_init(&flusher->work, handle_flush);
 	flag_set(&work->flags, K_WORK_FLUSHING_BIT);
 }
@@ -90,7 +96,11 @@ static sys_slist_t pending_cancels;
 static inline void init_work_cancel(struct z_work_canceller *canceler,
 				    struct k_work *work)
 {
-	k_sem_init(&canceler->sem, 0, 1);
+	/* The canceller lives on the cancelling caller's stack (inside
+	 * k_work_sync); its semaphore must not be registered for object
+	 * tracking.
+	 */
+	z_sem_init_untracked(&canceler->sem, 0, 1);
 	canceler->work = work;
 	sys_slist_append(&pending_cancels, &canceler->node);
 }

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -149,7 +149,7 @@ static struct cpuhold_pool_item cpuhold_pool_items[MAX_NUM_CPUHOLD + 1];
 
 K_KERNEL_STACK_ARRAY_DEFINE(cpuhold_stacks, MAX_NUM_CPUHOLD + 1, CPUHOLD_STACK_SZ);
 
-static struct k_sem cpuhold_sem;
+static K_SEM_DEFINE(cpuhold_sem, 0, 999);
 
 volatile int cpuhold_active;
 volatile bool cpuhold_spawned;
@@ -283,7 +283,12 @@ void z_impl_z_test_1cpu_start(void)
 
 	cpuhold_active = 1;
 
-	k_sem_init(&cpuhold_sem, 0, 999);
+	/* The semaphore is statically defined; only reset the count here.
+	 * Re-initializing it on every test would repeatedly register it with
+	 * the kernel object tracking facilities (CONFIG_OBJ_CORE_SEM, object
+	 * tracking).
+	 */
+	k_sem_reset(&cpuhold_sem);
 
 	/* Spawn N-1 threads to "hold" the other CPUs, waiting for
 	 * each to signal us that it's locked and spinning.

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -582,6 +582,69 @@ ZTEST(work_1cpu, test_1cpu_running_flush)
 	zassert_equal(rc, 0);
 }
 
+#ifdef CONFIG_OBJ_CORE_SEM
+static int obj_core_count_op(struct k_obj_core *obj_core, void *data)
+{
+	size_t *count = data;
+
+	(*count)++;
+
+	return 0;
+}
+
+static size_t sem_obj_core_count(void)
+{
+	size_t count = 0;
+	struct k_obj_type *obj_type = k_obj_type_find(K_OBJ_TYPE_SEM_ID);
+
+	zassert_not_null(obj_type, "semaphore object type not found");
+	k_obj_type_walk_locked(obj_type, obj_core_count_op, &count);
+
+	return count;
+}
+#endif /* CONFIG_OBJ_CORE_SEM */
+
+/* Single CPU verify the semaphore embedded in a caller-provided (and
+ * typically stack-allocated) k_work_sync is not registered for kernel
+ * object tracking by the flush and cancel paths.
+ */
+ZTEST(work_1cpu, test_1cpu_sync_no_obj_tracking)
+{
+#ifdef CONFIG_OBJ_CORE_SEM
+	int rc;
+	size_t count;
+	struct k_work_sync sync;
+
+	/* Reset state and use the delaying handler */
+	reset_counters();
+	k_work_init(&common_work, delay_handler);
+
+	count = sem_obj_core_count();
+
+	/* Submit to the cooperative queue and flush. */
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
+	zassert_equal(rc, 1);
+	zassert_true(k_work_flush(&common_work, &sync));
+	rc = k_sem_take(&sync_sem, K_NO_WAIT);
+	zassert_equal(rc, 0);
+
+	zassert_equal(sem_obj_core_count(), count,
+		      "k_work_sync flusher semaphore linked in type list");
+
+	/* Same check for the cancellation path; the work item has not
+	 * started yet when it is cancelled.
+	 */
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
+	zassert_equal(rc, 1);
+	zassert_true(k_work_cancel_sync(&common_work, &sync));
+
+	zassert_equal(sem_obj_core_count(), count,
+		      "k_work_sync canceller semaphore linked in type list");
+#else
+	ztest_test_skip();
+#endif /* CONFIG_OBJ_CORE_SEM */
+}
+
 /* Single CPU schedule a work item and wait for flush. */
 ZTEST(work_1cpu, test_1cpu_delayed_flush)
 {

--- a/tests/kernel/workq/work/tests.yaml
+++ b/tests/kernel/workq/work/tests.yaml
@@ -10,3 +10,14 @@ tests:
       - hifive1
       - qemu_rx
     timeout: 80
+  kernel.workqueue.api.obj_core:
+    min_flash: 34
+    tags: kernel
+    integration_platforms:
+      - qemu_x86
+    platform_exclude:
+      - hifive1
+      - qemu_rx
+    timeout: 80
+    extra_configs:
+      - CONFIG_OBJ_CORE=y


### PR DESCRIPTION
The semaphores embedded in the caller-provided `k_work_sync` structure, used by `k_work_flush()`, `k_work_cancel_sync()` and siblings, typically live on the caller's stack and go out of scope when the call returns.
Initializing them with `k_sem_init()` registered them with the kernel object tracking facilities (`CONFIG_OBJ_CORE_SEM` and object tracking lists), which then reference dead memory.

Split the semaphore field initialization out of `k_sem_init()` into an internal `z_sem_init_untracked()` and use it for the flusher and canceller semaphores.

Ref: https://github.com/zephyrproject-rtos/zephyr/issues/114856