### PR TITLE
net: wifi: Report why an access point refused the connection

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1400,6 +1400,12 @@ WiFi
   rather than ``sizeof(int)`` for the event payload length. Event handlers that only read the
   status value are unaffected, as it remains the first member. (:github:`116704`)
 
+* A Wi-Fi connect request that runs past its timeout now reports
+  :c:enumerator:`WIFI_STATUS_CONN_TIMEOUT` in :c:enumerator:`NET_EVENT_WIFI_CONNECT_RESULT`
+  instead of a raw ``-ETIMEDOUT``. This only concerns the connections handled by the
+  supplicant. Applications that matched on the errno value have to match on the status
+  value instead. (:github:`116704`)
+
 Xen
 ===
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1389,6 +1389,17 @@ WiFi
   that previously disabled the Espressif-specific option must now disable the generic option
   to retain manual DHCPv4 or static IP behavior after STA connection.
 
+* :c:struct:`wifi_status` gained ``status_code`` and ``reason_code`` members carrying the raw
+  IEEE 802.11 codes, so the struct is larger than the ``int`` it used to be. Code that raises
+  or receives :c:enumerator:`NET_EVENT_WIFI_SCAN_DONE`,
+  :c:enumerator:`NET_EVENT_WIFI_CONNECT_RESULT`,
+  :c:enumerator:`NET_EVENT_WIFI_DISCONNECT_RESULT`,
+  :c:enumerator:`NET_EVENT_WIFI_DISCONNECT_COMPLETE`,
+  :c:enumerator:`NET_EVENT_WIFI_AP_ENABLE_RESULT` or
+  :c:enumerator:`NET_EVENT_WIFI_AP_DISABLE_RESULT` must use ``sizeof(struct wifi_status)``
+  rather than ``sizeof(int)`` for the event payload length. Event handlers that only read the
+  status value are unaffected, as it remains the first member. (:github:`116704`)
+
 Xen
 ===
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1874,6 +1874,14 @@ Other notable changes
   * Removed the ``samples/net/wifi/test_certs/rsa2k`` enterprise test
     certificates (DES-encrypted private keys). Use ``rsa2k_no_des`` instead.
 
+  * The connection result event can now say that the access point rejected the
+    authentication or the association, through the new
+    :c:enumerator:`WIFI_STATUS_CONN_AUTH_REJECT` and
+    :c:enumerator:`WIFI_STATUS_CONN_ASSOC_REJECT` values, and
+    :c:struct:`wifi_status` carries the raw IEEE 802.11 status and reason codes
+    behind the failure. The supplicant fills these in, and the Wi-Fi shell prints
+    them with the connection and disconnection results. (:github:`116704`)
+
   * The transmit power ceiling properties in ``wifi-tx-power-2g.yaml`` and
     ``wifi-tx-power-5g.yaml`` are no longer ``required`` and now carry
     conservative defaults, so a board that has not been characterised errs on

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -60,6 +60,16 @@ enum wifi_conn_status {
 	WIFI_STATUS_CONN_TIMEOUT,
 	/** Connection failed - AP not found */
 	WIFI_STATUS_CONN_AP_NOT_FOUND,
+	/** Connection failed - the AP rejected the authentication.
+	 * The IEEE 802.11 status code from the Authentication frame is reported in
+	 * the status_code field of \ref wifi_status.
+	 */
+	WIFI_STATUS_CONN_AUTH_REJECT,
+	/** Connection failed - the AP rejected the association.
+	 * The IEEE 802.11 status code from the (Re)Association Response frame is
+	 * reported in the status_code field of \ref wifi_status.
+	 */
+	WIFI_STATUS_CONN_ASSOC_REJECT,
 	/** Last connection status */
 	WIFI_STATUS_CONN_LAST_STATUS,
 	/** Connection disconnected status */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -930,6 +930,14 @@ struct wifi_status {
 		/** Access point status */
 		enum wifi_ap_status ap_status;
 	};
+	/** IEEE 802.11 status code from the last Authentication or (Re)Association
+	 * Response frame, 0 if not available. See IEEE Std 802.11-2020, Table 9-50.
+	 */
+	uint16_t status_code;
+	/** IEEE 802.11 reason code from the last Deauthentication or Disassociation
+	 * frame, 0 if not available. See IEEE Std 802.11-2020, Table 9-90.
+	 */
+	uint16_t reason_code;
 };
 
 /** @brief Wi-Fi interface status */
@@ -2461,12 +2469,34 @@ BUILD_ASSERT(offsetof(struct net_wifi_mgmt_offload, wifi_iface) == 0);
  */
 void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status);
 
+/** Wi-Fi management connect result event with the IEEE 802.11 codes
+ *
+ * Use this instead of wifi_mgmt_raise_connect_result_event() when the raw
+ * IEEE 802.11 status or reason code behind the failure is known.
+ *
+ * @param iface Network interface
+ * @param status Connect result status and codes
+ */
+void wifi_mgmt_raise_connect_result_status_event(struct net_if *iface,
+						 const struct wifi_status *status);
+
 /** Wi-Fi management disconnect result event
  *
  * @param iface Network interface
  * @param status Disconnect result status
  */
 void wifi_mgmt_raise_disconnect_result_event(struct net_if *iface, int status);
+
+/** Wi-Fi management disconnect result event with the IEEE 802.11 codes
+ *
+ * Use this instead of wifi_mgmt_raise_disconnect_result_event() when the raw
+ * IEEE 802.11 reason code behind the disconnection is known.
+ *
+ * @param iface Network interface
+ * @param status Disconnect result status and codes
+ */
+void wifi_mgmt_raise_disconnect_result_status_event(struct net_if *iface,
+						    const struct wifi_status *status);
 
 /** Wi-Fi management interface status event
  *

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -164,7 +164,6 @@ static void supp_shell_connect_status(struct k_work *work)
 {
 	static int seconds_counter;
 	int status = CONNECTION_SUCCESS;
-	int conn_result = CONNECTION_FAILURE;
 	struct wpa_supplicant *wpa_s;
 	struct wpa_supp_api_ctrl *ctrl = &wpas_api_ctrl;
 
@@ -188,10 +187,8 @@ static void supp_shell_connect_status(struct k_work *work)
 				goto out;
 			}
 
-			conn_result = -ETIMEDOUT;
-			supplicant_send_wifi_mgmt_event(wpa_s->ifname,
-							NET_EVENT_WIFI_CMD_CONNECT_RESULT,
-							(void *)&conn_result, sizeof(int));
+			supplicant_send_wifi_mgmt_conn_status(wpa_s,
+							      WIFI_STATUS_CONN_TIMEOUT);
 			status = CONNECTION_FAILURE;
 			goto out;
 		}

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1510,6 +1510,14 @@ int supplicant_connect(const struct device *dev __unused, struct net_if *iface,
 		goto out;
 	}
 
+	/* The supplicant only clears these once it associates, so drop the codes of
+	 * the previous request to keep them from being reported against this one.
+	 * Configuring the network ends with select_network, which already starts
+	 * the attempt, so this has to happen before that.
+	 */
+	wpa_s->auth_status_code = WLAN_STATUS_SUCCESS;
+	wpa_s->assoc_status_code = WLAN_STATUS_SUCCESS;
+
 	ret = wpas_add_and_config_network(wpa_s, params, false);
 	if (ret) {
 		wpa_printf(MSG_ERROR, "Failed to add and configure network for STA mode: %d", ret);

--- a/modules/hostap/src/supp_events.c
+++ b/modules/hostap/src/supp_events.c
@@ -292,6 +292,25 @@ int supplicant_send_wifi_mgmt_conn_event(void *ctx, int status_code)
 					       sizeof(status));
 }
 
+int supplicant_send_wifi_mgmt_conn_status(void *ctx, enum wifi_conn_status conn_status)
+{
+	struct wpa_supplicant *wpa_s = ctx;
+	struct wifi_status status = {
+		.conn_status = conn_status,
+	};
+
+	if (wpa_s == NULL) {
+		return -EINVAL;
+	}
+
+	supplicant_fill_reject(wpa_s, &status);
+
+	return supplicant_send_wifi_mgmt_event(wpa_s->ifname,
+					       NET_EVENT_WIFI_CMD_CONNECT_RESULT,
+					       (void *)&status,
+					       sizeof(status));
+}
+
 int supplicant_send_wifi_mgmt_disc_event(void *ctx, int reason_code)
 {
 	struct wpa_supplicant *wpa_s = ctx;

--- a/modules/hostap/src/supp_events.c
+++ b/modules/hostap/src/supp_events.c
@@ -89,6 +89,21 @@ static enum wifi_disconn_reason wpas_to_wifi_mgmt_disconn_status(int status)
 	}
 }
 
+/* The supplicant keeps the status code of the last Authentication frame and the last
+ * (Re)Association Response it saw, so a rejection that never produced an event of its
+ * own can still be reported when the connection request finally gives up.
+ */
+static void supplicant_fill_reject(struct wpa_supplicant *wpa_s, struct wifi_status *status)
+{
+	if (wpa_s->assoc_status_code != WLAN_STATUS_SUCCESS) {
+		status->conn_status = WIFI_STATUS_CONN_ASSOC_REJECT;
+		status->status_code = wpa_s->assoc_status_code;
+	} else if (wpa_s->auth_status_code != WLAN_STATUS_SUCCESS) {
+		status->conn_status = WIFI_STATUS_CONN_AUTH_REJECT;
+		status->status_code = wpa_s->auth_status_code;
+	}
+}
+
 static int supplicant_process_status(struct supplicant_int_event_data *event_data,
 				     char *supplicant_status)
 {
@@ -243,7 +258,9 @@ static int supplicant_process_status(struct supplicant_int_event_data *event_dat
 int supplicant_send_wifi_mgmt_conn_event(void *ctx, int status_code)
 {
 	struct wpa_supplicant *wpa_s = ctx;
-	int status = wpas_to_wifi_mgmt_conn_status(status_code);
+	struct wifi_status status = {
+		.conn_status = wpas_to_wifi_mgmt_conn_status(status_code),
+	};
 	enum net_event_wifi_cmd event;
 
 	if (!wpa_s || !wpa_s->current_ssid) {
@@ -256,25 +273,42 @@ int supplicant_send_wifi_mgmt_conn_event(void *ctx, int status_code)
 		event = NET_EVENT_WIFI_CMD_CONNECT_RESULT;
 	}
 
+	if (event == NET_EVENT_WIFI_CMD_CONNECT_RESULT &&
+	    status.conn_status != WIFI_STATUS_CONN_SUCCESS) {
+		/* Anything positive reaching here is an IEEE 802.11 reason code */
+		if (status_code > 0) {
+			status.reason_code = status_code;
+		}
+
+		if (status.conn_status == WIFI_STATUS_CONN_FAIL ||
+		    status.conn_status == WIFI_STATUS_CONN_TIMEOUT) {
+			supplicant_fill_reject(wpa_s, &status);
+		}
+	}
+
 	return supplicant_send_wifi_mgmt_event(wpa_s->ifname,
 					       event,
 					       (void *)&status,
-					       sizeof(int));
+					       sizeof(status));
 }
 
 int supplicant_send_wifi_mgmt_disc_event(void *ctx, int reason_code)
 {
 	struct wpa_supplicant *wpa_s = ctx;
+	struct wifi_status status = { 0 };
 	enum net_event_wifi_cmd event;
-	int status;
 
 	if (!wpa_s || !wpa_s->current_ssid) {
 		return -EINVAL;
 	}
 
+	if (reason_code > 0) {
+		status.reason_code = reason_code;
+	}
+
 	if (wpa_s->wpa_state >= WPA_COMPLETED) {
 		/* Disconnect event code & status */
-		status = wpas_to_wifi_mgmt_disconn_status(reason_code);
+		status.disconn_reason = wpas_to_wifi_mgmt_disconn_status(reason_code);
 		if (wpa_s->current_ssid->mode == WPAS_MODE_AP) {
 			event = NET_EVENT_WIFI_CMD_AP_DISABLE_RESULT;
 		} else {
@@ -282,18 +316,19 @@ int supplicant_send_wifi_mgmt_disc_event(void *ctx, int reason_code)
 		}
 	} else {
 		/* Connect event code & status */
-		status = WIFI_STATUS_CONN_FAIL;
+		status.conn_status = WIFI_STATUS_CONN_FAIL;
 		if (wpa_s->current_ssid->mode == WPAS_MODE_AP) {
 			event = NET_EVENT_WIFI_CMD_AP_ENABLE_RESULT;
 		} else {
 			event = NET_EVENT_WIFI_CMD_CONNECT_RESULT;
+			supplicant_fill_reject(wpa_s, &status);
 		}
 	}
 
 	return supplicant_send_wifi_mgmt_event(wpa_s->ifname,
 					       event,
 					       (void *)&status,
-					       sizeof(int));
+					       sizeof(status));
 }
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
@@ -666,14 +701,29 @@ int supplicant_send_wifi_mgmt_event(const char *ifname, enum net_event_wifi_cmd 
 
 	switch (event) {
 	case NET_EVENT_WIFI_CMD_CONNECT_RESULT:
-		wifi_mgmt_raise_connect_result_event(
-			iface,
-			*(int *)supplicant_status);
+		/* The supplicant sends a bare status value from places that have no
+		 * IEEE 802.11 code to report.
+		 */
+		if (len == sizeof(struct wifi_status)) {
+			wifi_mgmt_raise_connect_result_status_event(
+				iface,
+				(struct wifi_status *)supplicant_status);
+		} else {
+			wifi_mgmt_raise_connect_result_event(
+				iface,
+				*(int *)supplicant_status);
+		}
 		break;
 	case NET_EVENT_WIFI_CMD_DISCONNECT_RESULT:
-		wifi_mgmt_raise_disconnect_result_event(
-			iface,
-			*(int *)supplicant_status);
+		if (len == sizeof(struct wifi_status)) {
+			wifi_mgmt_raise_disconnect_result_status_event(
+				iface,
+				(struct wifi_status *)supplicant_status);
+		} else {
+			wifi_mgmt_raise_disconnect_result_event(
+				iface,
+				*(int *)supplicant_status);
+		}
 		break;
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
 	case NET_EVENT_WIFI_CMD_SIGNAL_CHANGE:

--- a/modules/hostap/src/supp_events.h
+++ b/modules/hostap/src/supp_events.h
@@ -66,6 +66,7 @@ int supplicant_generate_state_event(const char *ifname,
 				    enum net_event_supplicant_cmd event,
 				    int status);
 int supplicant_send_wifi_mgmt_conn_event(void *ctx, int status_code);
+int supplicant_send_wifi_mgmt_conn_status(void *ctx, enum wifi_conn_status conn_status);
 int supplicant_send_wifi_mgmt_disc_event(void *ctx, int reason_code);
 
 #ifdef CONFIG_AP

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -377,6 +377,10 @@ const char *wifi_conn_status_txt(enum wifi_conn_status status)
 		return "Connection timeout";
 	case WIFI_STATUS_CONN_AP_NOT_FOUND:
 		return "AP not found";
+	case WIFI_STATUS_CONN_AUTH_REJECT:
+		return "Authentication rejected";
+	case WIFI_STATUS_CONN_ASSOC_REJECT:
+		return "Association rejected";
 	default:
 		return "UNKNOWN";
 	}

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -615,20 +615,34 @@ static int wifi_disconnect(uint64_t mgmt_request, struct net_if *iface,
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_DISCONNECT, wifi_disconnect);
 
+void wifi_mgmt_raise_connect_result_status_event(struct net_if *iface,
+						 const struct wifi_status *status)
+{
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
+	if (status->status == 0) {
+		roaming_params.roaming_cnt_11k = 0;
+		roaming_params.roaming_cnt_11v = 0;
+	}
+#endif
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_CONNECT_RESULT,
+					iface, status,
+					sizeof(struct wifi_status));
+}
+
 void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status)
 {
 	struct wifi_status cnx_status = {
 		.status = status,
 	};
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
-	if (status == 0) {
-		roaming_params.roaming_cnt_11k = 0;
-		roaming_params.roaming_cnt_11v = 0;
-	}
-#endif
-	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_CONNECT_RESULT,
-					iface, &cnx_status,
+	wifi_mgmt_raise_connect_result_status_event(iface, &cnx_status);
+}
+
+void wifi_mgmt_raise_disconnect_result_status_event(struct net_if *iface,
+						    const struct wifi_status *status)
+{
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_DISCONNECT_RESULT,
+					iface, status,
 					sizeof(struct wifi_status));
 }
 
@@ -638,9 +652,7 @@ void wifi_mgmt_raise_disconnect_result_event(struct net_if *iface, int status)
 		.status = status,
 	};
 
-	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_DISCONNECT_RESULT,
-					iface, &cnx_status,
-					sizeof(struct wifi_status));
+	wifi_mgmt_raise_disconnect_result_status_event(iface, &cnx_status);
 }
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -1681,7 +1681,7 @@ void wifi_mgmt_raise_ap_enable_result_event(struct net_if *iface,
 
 	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_AP_ENABLE_RESULT,
 					iface, &cnx_status,
-					sizeof(enum wifi_ap_status));
+					sizeof(struct wifi_status));
 }
 
 void wifi_mgmt_raise_ap_disable_result_event(struct net_if *iface,
@@ -1693,7 +1693,7 @@ void wifi_mgmt_raise_ap_disable_result_event(struct net_if *iface,
 
 	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_AP_DISABLE_RESULT,
 					iface, &cnx_status,
-					sizeof(enum wifi_ap_status));
+					sizeof(struct wifi_status));
 }
 
 void wifi_mgmt_raise_ap_sta_connected_event(struct net_if *iface,

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -402,6 +402,25 @@ static void handle_wifi_scan_done(struct net_mgmt_event_callback *cb)
 	context.scan_result = 0U;
 }
 
+static void print_ieee80211_codes(const struct shell *sh,
+				  struct net_mgmt_event_callback *cb)
+{
+	const struct wifi_status *status = cb->info;
+
+	/* Not every producer of these events fills in the codes */
+	if (cb->info_length < sizeof(struct wifi_status)) {
+		return;
+	}
+
+	if (status->status_code != 0) {
+		PR("IEEE 802.11 status code %u\n", status->status_code);
+	}
+
+	if (status->reason_code != 0) {
+		PR("IEEE 802.11 reason code %u\n", status->reason_code);
+	}
+}
+
 static void handle_wifi_connect_result(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_status *status =
@@ -421,6 +440,7 @@ static void handle_wifi_connect_result(struct net_mgmt_event_callback *cb)
 
 		PR_WARNING("Connection request failed (%s/%d)\n",
 			   wifi_conn_status_txt(st), st);
+		print_ieee80211_codes(sh, cb);
 	} else {
 		PR("Connected\n");
 	}
@@ -450,6 +470,8 @@ static void handle_wifi_disconnect_result(struct net_mgmt_event_callback *cb)
 			PR("Disconnected\n");
 		}
 	}
+
+	print_ieee80211_codes(sh, cb);
 }
 
 static void print_twt_params(uint8_t dialog_token, uint8_t flow_id,

--- a/tests/drivers/wifi/hwsim/src/main.c
+++ b/tests/drivers/wifi/hwsim/src/main.c
@@ -38,6 +38,10 @@ static struct wifi_connect_req_params default_ap_params = {
 static const uint8_t psk_ssid[] = "ZephyrPsk";
 static const uint8_t sae_ssid[] = "ZephyrSae";
 static const uint8_t secured_psk[] = "ZephyrPass123";
+static const uint8_t wrong_psk[] = "ZephyrPass456";
+
+/* IEEE Std 802.11-2020, Table 9-90 */
+#define IEEE80211_REASON_4WAY_HANDSHAKE_TIMEOUT 15
 
 static struct wifi_connect_req_params wpa2_psk_params = {
 	.ssid = psk_ssid,
@@ -71,6 +75,19 @@ struct hwsim_waiter {
 	uint64_t event_mask;
 	uint64_t last_event;
 	int status;
+	uint16_t status_code;
+	uint16_t reason_code;
+	/*
+	 * One request can produce several results, and the fields above only
+	 * keep the latest one. A waiter can name the status it is after, and
+	 * the result carrying it is then latched separately so that whatever
+	 * the supplicant reports next cannot hide it.
+	 */
+	bool wanted_valid;
+	bool wanted_seen;
+	int wanted_status;
+	uint16_t wanted_status_code;
+	uint16_t wanted_reason_code;
 };
 
 static void waiter_handler(struct net_mgmt_event_callback *cb, uint64_t event,
@@ -90,6 +107,18 @@ static void waiter_handler(struct net_mgmt_event_callback *cb, uint64_t event,
 		if (cb->info != NULL && cb->info_length >= sizeof(int)) {
 			w->status = *(int *)cb->info;
 		}
+		if (cb->info != NULL && cb->info_length >= sizeof(struct wifi_status)) {
+			const struct wifi_status *st = cb->info;
+
+			w->status_code = st->status_code;
+			w->reason_code = st->reason_code;
+		}
+
+		if (w->wanted_valid && !w->wanted_seen && w->status == w->wanted_status) {
+			w->wanted_seen = true;
+			w->wanted_status_code = w->status_code;
+			w->wanted_reason_code = w->reason_code;
+		}
 #endif
 		k_sem_give(&w->sem);
 	}
@@ -98,13 +127,33 @@ static void waiter_handler(struct net_mgmt_event_callback *cb, uint64_t event,
 static void hwsim_waiter_init(struct hwsim_waiter *w, struct net_if *iface,
 			     uint64_t event_mask)
 {
-	k_sem_init(&w->sem, 0, 1);
+	/*
+	 * Counting, as a single request can report more than one result and a
+	 * waiter that reads them in a loop must not lose any of them.
+	 */
+	k_sem_init(&w->sem, 0, K_SEM_MAX_LIMIT);
 	w->iface = iface;
 	w->event_mask = event_mask;
 	w->last_event = 0;
 	w->status = -1;
+	w->status_code = 0;
+	w->reason_code = 0;
+	w->wanted_valid = false;
+	w->wanted_seen = false;
+	w->wanted_status = 0;
+	w->wanted_status_code = 0;
+	w->wanted_reason_code = 0;
 	net_mgmt_init_event_callback(&w->cb, waiter_handler, event_mask);
 	net_mgmt_add_event_callback(&w->cb);
+}
+
+/* Latch the result carrying this status, see struct hwsim_waiter. Call before
+ * the request that produces the results is made.
+ */
+static void hwsim_waiter_expect_status(struct hwsim_waiter *w, int status)
+{
+	w->wanted_valid = true;
+	w->wanted_status = status;
 }
 
 static int hwsim_waiter_wait(struct hwsim_waiter *w, k_timeout_t timeout)
@@ -406,7 +455,7 @@ ZTEST(hwsim, test_05_ap_start_connect_ping_full)
  * succeeds. For a secured network a successful connect result means the real
  * 4-way handshake (EAPOL over the medium) completed.
  */
-static void secured_connect(struct wifi_connect_req_params *params)
+static void secured_ap_start(struct wifi_connect_req_params *params)
 {
 	struct hwsim_waiter w;
 
@@ -438,6 +487,13 @@ static void secured_connect(struct wifi_connect_req_params *params)
 	 */
 	net_if_up(iface_ap);
 	net_if_up(iface_sta);
+}
+
+static void secured_connect(struct wifi_connect_req_params *params)
+{
+	struct hwsim_waiter w;
+
+	secured_ap_start(params);
 
 	/* Connect the STA; success implies the 4-way handshake completed. */
 	hwsim_waiter_init(&w, iface_sta, NET_EVENT_WIFI_CONNECT_RESULT);
@@ -463,4 +519,51 @@ ZTEST(hwsim, test_07_connect_wpa3_sae)
 	secured_connect(&wpa3_sae_params);
 	sta_ping_ap();
 }
+
+ZTEST(hwsim, test_08_connect_wrong_password)
+{
+	k_timeout_t timeout = K_SECONDS(CONFIG_WIFI_HWSIM_CONNECT_TIMEOUT_SEC + 5);
+	struct wifi_connect_req_params params = wpa2_psk_params;
+	struct hwsim_waiter w;
+
+	secured_ap_start(&wpa2_psk_params);
+
+	params.psk = wrong_psk;
+	params.psk_length = sizeof(wrong_psk) - 1;
+
+	hwsim_waiter_init(&w, iface_sta, NET_EVENT_WIFI_CONNECT_RESULT);
+	hwsim_waiter_expect_status(&w, WIFI_STATUS_CONN_WRONG_PASSWORD);
+	zassert_equal(net_mgmt(NET_REQUEST_WIFI_CONNECT, iface_sta,
+			       &params, sizeof(params)), 0,
+		      "connect request with a wrong password failed");
+
+	/*
+	 * The supplicant reports the failed association before it concludes that
+	 * the key was wrong, so a single request can produce more than one
+	 * result. Keep reading until the verdict arrives.
+	 */
+	for (int i = 0; i < 4; i++) {
+		if (hwsim_waiter_wait(&w, timeout) != 0) {
+			break;
+		}
+
+		/* Once the first result is in, the rest follow immediately */
+		timeout = K_SECONDS(2);
+
+		zexpect_not_equal(w.status, WIFI_STATUS_CONN_SUCCESS,
+				  "connect with a wrong password succeeded");
+
+		if (w.wanted_seen) {
+			break;
+		}
+	}
+
+	zexpect_true(w.wanted_seen, "wrong password was never reported");
+	zexpect_equal(w.wanted_reason_code, IEEE80211_REASON_4WAY_HANDSHAKE_TIMEOUT,
+		      "expected the 4-way handshake reason code, got %u",
+		      w.wanted_reason_code);
+
+	hwsim_waiter_cleanup(&w);
+}
+
 #endif /* CONFIG_NET_IPV4 */


### PR DESCRIPTION
Fixes #116704. Note that this PR does not change any existing upstream drivers, that will be done in followup PRs.

### Problem

When a Wi-Fi connection fails, `NET_EVENT_WIFI_CONNECT_RESULT` can only say one of
five things, and `wpas_to_wifi_mgmt_conn_status()` recognises exactly two supplicant
codes. Everything else like MAC filtering, an AP at capacity, a security algorithm the
AP will not accept, arrives as the generic `WIFI_STATUS_CONN_FAIL`. A product in
the field cannot tell a transient failure worth retrying from a configuration error
the user has to fix.

Tracing the path turned up two things the issue does not mention:

- **An association reject raises no event at all today.** The supplicant has no
  Zephyr hook on that path, so a MAC-filtered station reports nothing until the
  connect request times out.
- **That timeout then reports a raw errno.** `supp_api.c` sends `-ETIMEDOUT` (-116)
  as the connection status, a value that means nothing in `enum wifi_conn_status`.
  The Wi-Fi shell has carried a workaround for it since the beginning; applications
  get no such help.

### Approach

The issue's title asks for raw IEEE 802.11 codes; its body proposes abstract enum
values instead. This does both, because neither alone is enough: two new enum values
keep the common cases legible without the enumeration having to grow forever, and
the raw code carries everything the abstraction drops.

- `WIFI_STATUS_CONN_AUTH_REJECT` and `WIFI_STATUS_CONN_ASSOC_REJECT` name which frame
  carried the rejection. Appended after `WIFI_STATUS_CONN_AP_NOT_FOUND`, so existing
  values keep their numbering.
- `struct wifi_status` gains `status_code` and `reason_code`. They are separate IEEE
  802.11 namespaces carried by different frames, so keeping them apart avoids needing
  a discriminator; 0 means "not available" in both. `status` stays the first member,
  so receivers that read the payload as an `int` are unaffected.
- The supplicant already tracks the status code of the last Authentication frame and
  the last (Re)Association Response. Reading those on the failure paths is what makes
  this a Zephyr-only change: **no hostap module patch and no manifest bump.** The
  event dispatcher accepts both the new struct and the bare status the supplicant
  still sends from places that have no code to report.
- The connect timeout now reports `WIFI_STATUS_CONN_TIMEOUT`, and if the AP was
  rejecting us while the request ran, it reports that rejection and its code instead.

What an application sees for an AP that denies the association changes from silence
followed by `-116` to `WIFI_STATUS_CONN_ASSOC_REJECT` with, say, status code 17
("AP unable to handle additional associated STAs").

### Testing

`tests/drivers/wifi/hwsim` runs hostapd and wpa_supplicant in one native_sim binary
over the simulated medium, so the whole path is testable without hardware. The new
test connects to the secured AP with the wrong passphrase and checks the result names
the wrong password and carries reason code 15, the 4-way handshake timeout that
produced that verdict.

**Not covered:** nothing available here produces a real association or authentication
reject, so `WIFI_STATUS_CONN_ASSOC_REJECT` and `_AUTH_REJECT` are verified by code
path only. Confirming them needs an AP with MAC filtering or a hostapd `deny_mac_file`.

### Known issue, not addressed here

A wrong passphrase produces **two** connect-result events: the supplicant emits
`CTRL-EVENT-DISCONNECTED` first, which lands as `WIFI_STATUS_CONN_FAIL`, and only
then diagnoses the key mismatch and emits `WIFI_STATUS_CONN_WRONG_PASSWORD`. An
application acting on the first result still sees a generic failure. The ordering is
in `wpa_supplicant/events.c` and predates this series; changing it means suppressing
or deferring an event, which is a behaviour change beyond what this issue asks for.
The new test loops over the results because of it.

### API impact

`struct wifi_status` grows from 4 to 8 bytes. It is by far the smallest member of
`union wifi_mgmt_events`, so `NET_EVENT_INFO_MAX_SIZE` does not move. Out-of-tree
code that hardcodes `sizeof(int)` as the payload length for these events must switch
to `sizeof(struct wifi_status)` is noted in the migration guide.
