### PR TITLE
drivers: can: do not use a stack-allocated semaphore in can_send

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -67,6 +67,7 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 		}
 
 		k_sem_take(&ctx.done, K_FOREVER);
+		k_sem_deinit(&ctx.done);
 
 		return ctx.status;
 	}

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3817,6 +3817,40 @@ __syscall int k_sem_init(struct k_sem *sem, unsigned int initial_count,
 			  unsigned int limit);
 
 /**
+ * @brief Deinitialize a semaphore.
+ *
+ * This routine releases @a sem from the kernel object tracking facilities
+ * (see @kconfig{CONFIG_OBJ_CORE_SEM} and
+ * @kconfig{CONFIG_TRACING_OBJECT_TRACKING}). It is required for semaphores
+ * without a permanent lifetime, such as semaphores living on a thread's
+ * stack, before the memory holding the semaphore is reused. It compiles to a
+ * no-op when no tracking facility is enabled.
+ *
+ * The semaphore must not be in use: no thread may be waiting on it. The
+ * semaphore must be initialized again with k_sem_init() before it can be
+ * used.
+ *
+ * @note This routine is intentionally not available from user mode. User
+ * mode cannot initialize semaphores that are not registered kernel objects,
+ * so it cannot create the transient semaphores this routine exists for, and
+ * dynamically allocated semaphores are instead released with
+ * k_object_free() or by revoking their permissions.
+ *
+ * @funcprops \supervisor
+ *
+ * @param sem Address of the semaphore.
+ */
+#if defined(CONFIG_OBJ_CORE_SEM) || defined(CONFIG_TRACING_OBJECT_TRACKING) || \
+	defined(CONFIG_USERSPACE)
+void k_sem_deinit(struct k_sem *sem);
+#else
+static inline void k_sem_deinit(struct k_sem *sem)
+{
+	ARG_UNUSED(sem);
+}
+#endif
+
+/**
  * @brief Take a semaphore.
  *
  * This routine takes @a sem.

--- a/include/zephyr/tracing/tracking.h
+++ b/include/zephyr/tracing/tracking.h
@@ -121,6 +121,7 @@ extern struct k_event *_track_list_k_event;
 void sys_track_k_timer_init(struct k_timer *timer);
 void sys_track_k_mem_slab_init(struct k_mem_slab *slab);
 void sys_track_k_sem_init(struct k_sem *sem);
+void sys_track_k_sem_deinit(struct k_sem *sem);
 void sys_track_k_mutex_init(struct k_mutex *mutex);
 void sys_track_k_stack_init(struct k_stack *stack);
 void sys_track_k_msgq_init(struct k_msgq *msgq);

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -27,6 +27,7 @@
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/tracing/tracing.h>
+#include <zephyr/tracing/tracking.h>
 #include <zephyr/sys/check.h>
 
 /* We use a system-wide lock to synchronize semaphores, which has
@@ -81,6 +82,27 @@ int z_vrfy_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 }
 #include <zephyr/syscalls/k_sem_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
+
+#if defined(CONFIG_OBJ_CORE_SEM) || defined(CONFIG_TRACING_OBJECT_TRACKING) || \
+	defined(CONFIG_USERSPACE)
+void k_sem_deinit(struct k_sem *sem)
+{
+	__ASSERT(z_waitq_head(&sem->wait_q) == NULL,
+		 "deinit of a semaphore with waiters");
+
+#ifdef CONFIG_USERSPACE
+	k_object_uninit(sem);
+#endif /* CONFIG_USERSPACE */
+
+#ifdef CONFIG_OBJ_CORE_SEM
+	k_obj_core_unlink(K_OBJ_CORE(sem));
+#endif /* CONFIG_OBJ_CORE_SEM */
+
+#ifdef CONFIG_TRACING_OBJECT_TRACKING
+	sys_track_k_sem_deinit(sem);
+#endif /* CONFIG_TRACING_OBJECT_TRACKING */
+}
+#endif
 
 static inline bool sem_handle_poll_events(struct k_sem *sem)
 {

--- a/subsys/tracing/tracing_tracking.c
+++ b/subsys/tracing/tracing_tracking.c
@@ -62,6 +62,21 @@ struct k_spinlock _track_list_k_event_lock;
 		k_spin_unlock(&list##_lock, key);                                                  \
 	} while (false)
 
+/* Iterates in the tracking list and removes an object when found */
+#define SYS_TRACK_LIST_REMOVE(list, obj)                                                           \
+	do {                                                                                       \
+		k_spinlock_key_t key = k_spin_lock(&list##_lock);                                  \
+		__typeof__(list) *_prev = &(list);                                                 \
+		while (*_prev != NULL) {                                                           \
+			if (*_prev == (obj)) {                                                     \
+				*_prev = (obj)->_obj_track_next;                                   \
+				break;                                                             \
+			}                                                                          \
+			_prev = &(*_prev)->_obj_track_next;                                        \
+		}                                                                                  \
+		k_spin_unlock(&list##_lock, key);                                                  \
+	} while (false)
+
 #define SYS_TRACK_STATIC_INIT(type, ...) \
 	do { \
 		STRUCT_SECTION_FOREACH(type, obj) \
@@ -86,6 +101,14 @@ void sys_track_k_sem_init(struct k_sem *sem)
 	if (sem) {
 		SYS_PORT_TRACING_TYPE_MASK(k_sem,
 				SYS_TRACK_LIST_PREPEND(_track_list_k_sem, sem));
+	}
+}
+
+void sys_track_k_sem_deinit(struct k_sem *sem)
+{
+	if (sem) {
+		SYS_PORT_TRACING_TYPE_MASK(k_sem,
+				SYS_TRACK_LIST_REMOVE(_track_list_k_sem, sem));
 	}
 }
 

--- a/tests/kernel/semaphore/deinit/CMakeLists.txt
+++ b/tests/kernel/semaphore/deinit/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sem_deinit)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/semaphore/deinit/prj.conf
+++ b/tests/kernel/semaphore/deinit/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/semaphore/deinit/src/main.c
+++ b/tests/kernel/semaphore/deinit/src/main.c
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Basalte bv
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/tracing/tracking.h>
+
+#ifdef CONFIG_OBJ_CORE_SEM
+struct obj_core_count_data {
+	/* Object core to count occurrences of */
+	struct k_obj_core *target;
+	/* Number of occurrences found */
+	size_t count;
+};
+
+static int obj_core_count_op(struct k_obj_core *obj_core, void *data)
+{
+	struct obj_core_count_data *count_data = data;
+
+	if (obj_core == count_data->target) {
+		count_data->count++;
+	}
+
+	return 0;
+}
+
+static size_t obj_core_count(struct k_sem *sem)
+{
+	struct k_obj_type *obj_type = k_obj_type_find(K_OBJ_TYPE_SEM_ID);
+	struct obj_core_count_data count_data = {
+		.target = K_OBJ_CORE(sem),
+		.count = 0,
+	};
+
+	zassert_not_null(obj_type, "semaphore object type not found");
+	k_obj_type_walk_locked(obj_type, obj_core_count_op, &count_data);
+
+	return count_data.count;
+}
+#endif /* CONFIG_OBJ_CORE_SEM */
+
+#ifdef CONFIG_TRACING_OBJECT_TRACKING
+static bool track_list_contains(struct k_sem *sem)
+{
+	for (struct k_sem *cur = _track_list_k_sem; cur != NULL;
+	     cur = SYS_PORT_TRACK_NEXT(cur)) {
+		if (cur == sem) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif /* CONFIG_TRACING_OBJECT_TRACKING */
+
+static void check_tracked(struct k_sem *sem, bool tracked)
+{
+#ifdef CONFIG_OBJ_CORE_SEM
+	zassert_equal(obj_core_count(sem), tracked ? 1 : 0,
+		      "unexpected semaphore object core link state");
+#endif /* CONFIG_OBJ_CORE_SEM */
+
+#ifdef CONFIG_TRACING_OBJECT_TRACKING
+	zassert_equal(track_list_contains(sem), tracked,
+		      "unexpected semaphore object tracking state");
+#endif /* CONFIG_TRACING_OBJECT_TRACKING */
+
+	ARG_UNUSED(sem);
+	ARG_UNUSED(tracked);
+}
+
+ZTEST(sem_deinit, test_sem_deinit)
+{
+	struct k_sem sem;
+
+	zassert_ok(k_sem_init(&sem, 0, 1));
+	check_tracked(&sem, true);
+
+	k_sem_give(&sem);
+	zassert_ok(k_sem_take(&sem, K_NO_WAIT));
+
+	/* Deinitializing releases the semaphore from the tracking
+	 * facilities; its memory (here, this stack frame) may be reused
+	 * afterwards.
+	 */
+	k_sem_deinit(&sem);
+	check_tracked(&sem, false);
+
+	/* The semaphore can be initialized and used again */
+	zassert_ok(k_sem_init(&sem, 1, 1));
+	check_tracked(&sem, true);
+
+	zassert_ok(k_sem_take(&sem, K_NO_WAIT));
+
+	k_sem_deinit(&sem);
+	check_tracked(&sem, false);
+}
+
+ZTEST_SUITE(sem_deinit, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/semaphore/deinit/tests.yaml
+++ b/tests/kernel/semaphore/deinit/tests.yaml
@@ -1,0 +1,25 @@
+tests:
+  kernel.semaphore.deinit:
+    tags:
+      - kernel
+      - semaphore
+    integration_platforms:
+      - qemu_x86
+  kernel.semaphore.deinit.obj_core:
+    tags:
+      - kernel
+      - semaphore
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_OBJ_CORE=y
+  kernel.semaphore.deinit.tracking:
+    tags:
+      - kernel
+      - semaphore
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_NONE=y
+      - CONFIG_TRACING_OBJECT_TRACKING=y


### PR DESCRIPTION
The blocking `can_send()` path (`callback == NULL`) used a semaphore living on the caller's stack to wait for TX completion. Kernel object tracking (`CONFIG_OBJ_CORE_SEM`, object tracking) registers semaphores passed to `k_sem_init()`, leaving the tracking lists referencing dead memory once `can_send()` returns.

Call `k_sem_deinit` to cleanup any tracking reference.

Ref: https://github.com/zephyrproject-rtos/zephyr/issues/114856