### PR TITLE
dts: bindings: can: remove deprecated bus-speed properties

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -290,6 +290,9 @@ Controller Area Network (CAN)
   are processed in the order received on the bus. Out-of-tree users may want to update any
   ``bosch,mram-cfg`` devicetree property overrides to allocate all FIFO elements to RX FIFO0.
 
+* The deprecated ``bus-speed`` and ``bus-speed-data`` CAN controller devicetree properties have
+  been removed. Use ``bitrate`` and ``bitrate-data`` instead.
+
 Counter
 =======
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -115,6 +115,11 @@ Removed APIs and options
       ``<board>_<revision>_defconfig``
     * Pattern expansion in ``zephyr_code_relocate(FILES ...)``, replaced by ``file(GLOB ...)``
 
+* CAN
+
+    * ``bus-speed``
+    * ``bus-speed-data``
+
 * Comparator
 
     * ``nxp,enable-output-pin``, ``nxp,use-unfiltered-output``, ``nxp,high-speed-mode``,

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -3,14 +3,6 @@
 include: base.yaml
 
 properties:
-  bus-speed:
-    type: int
-    deprecated: true
-    description: |
-      Deprecated. This property has been renamed to bitrate.
-
-      Initial bitrate in bit/s. If this is unset, the initial bitrate is set to
-      CONFIG_CAN_DEFAULT_BITRATE.
   bitrate:
     type: int
     description: |

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -3,14 +3,6 @@
 include: can-controller.yaml
 
 properties:
-  bus-speed-data:
-    type: int
-    deprecated: true
-    description: |
-      Deprecated. This property has been renamed to bitrate-data.
-
-      Initial data phase bitrate in bit/s.  If this is unset, the initial data phase bitrate is set
-      to CONFIG_CAN_DEFAULT_BITRATE_DATA.
   bitrate-data:
     type: int
     description: |

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -370,12 +370,11 @@ struct can_driver_config {
 		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),			\
 		.min_bitrate = DT_CAN_TRANSCEIVER_MIN_BITRATE(node_id, _min_bitrate),		\
 		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, _max_bitrate),		\
-		.bitrate = DT_PROP_OR(node_id, bitrate,						\
-			DT_PROP_OR(node_id, bus_speed, CONFIG_CAN_DEFAULT_BITRATE)),            \
+		.bitrate = DT_PROP_OR(node_id, bitrate, CONFIG_CAN_DEFAULT_BITRATE),		\
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),				\
 		IF_ENABLED(CONFIG_CAN_FD_MODE,							\
-			(.bitrate_data = DT_PROP_OR(node_id, bitrate_data,                      \
-			 DT_PROP_OR(node_id, bus_speed_data, CONFIG_CAN_DEFAULT_BITRATE_DATA)), \
+			(.bitrate_data = DT_PROP_OR(node_id, bitrate_data,			\
+						    CONFIG_CAN_DEFAULT_BITRATE_DATA),		\
 			 .sample_point_data = DT_PROP_OR(node_id, sample_point_data, 0),))	\
 	}
 


### PR DESCRIPTION
Removes the `bus-speed` and `bus-speed-data` CAN controller devicetree properties, deprecated in Zephyr 3.7 when they were renamed to `bitrate` and `bitrate-data` (#73654).
