### PR TITLE
dts: bindings: remove deprecated zephyr,memory-region-mpu

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -39,13 +39,6 @@ LOG_MODULE_DECLARE(mpu);
 #define MPU_NODEID DT_INST(0, arm_armv6m_mpu)
 #endif
 
-#define NODE_HAS_PROP_AND_OR(node_id, prop) \
-	DT_NODE_HAS_PROP(node_id, prop) ||
-
-BUILD_ASSERT((DT_FOREACH_STATUS_OKAY_NODE_VARGS(
-	      NODE_HAS_PROP_AND_OR, zephyr_memory_region_mpu) false) == false,
-	      "`zephyr,memory-region-mpu` was deprecated in favor of `zephyr,memory-attr`");
-
 #define NULL_PAGE_DETECT_NODE_FINDER(node_id, prop)                                                \
 	(DT_NODE_HAS_PROP(node_id, prop) && (DT_REG_ADDR(node_id) == 0) &&                         \
 	 (DT_REG_SIZE(node_id) >= CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE)) ||

--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -20,13 +20,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(mpu);
 
-#define NODE_HAS_PROP_AND_OR(node_id, prop) \
-	DT_NODE_HAS_PROP(node_id, prop) ||
-
-BUILD_ASSERT((DT_FOREACH_STATUS_OKAY_NODE_VARGS(
-	      NODE_HAS_PROP_AND_OR, zephyr_memory_region_mpu) false) == false,
-	      "`zephyr,memory-region-mpu` was deprecated in favor of `zephyr,memory-attr`");
-
 /*
  * Global status variable holding the number of HW MPU region indices, which
  * have been reserved by the MPU driver to program the static (fixed) memory

--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -21,13 +21,6 @@
 
 LOG_MODULE_REGISTER(mpu, CONFIG_MPU_LOG_LEVEL);
 
-#define NODE_HAS_PROP_AND_OR(node_id, prop) \
-	DT_NODE_HAS_PROP(node_id, prop) ||
-
-BUILD_ASSERT((DT_FOREACH_STATUS_OKAY_NODE_VARGS(
-	      NODE_HAS_PROP_AND_OR, zephyr_memory_region_mpu) false) == false,
-	      "`zephyr,memory-region-mpu` was deprecated in favor of `zephyr,memory-attr`");
-
 #define MPU_DYNAMIC_REGION_AREAS_NUM	3
 
 #if defined(CONFIG_USERSPACE) || defined(CONFIG_ARM64_STACK_PROTECTION)

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -261,6 +261,18 @@ Devicetree
   unsigned comparisons or ``BUILD_ASSERT(DT_PROP(node, foo) > 0, ...)`` checks, must be updated
   to use signed types or signed-aware checks (:github:`107271`).
 
+* The ``zephyr,memory-region-mpu`` property has been removed. Use ``zephyr,memory-attr``
+  instead. It takes an integer bitmask, not a string:
+
+  .. code-block:: none
+
+     "RAM"         -> <DT_MEM_ARM_MPU_RAM>
+     "RAM_NOCACHE" -> <DT_MEM_ARM_MPU_RAM_NOCACHE>
+     "FLASH"       -> <DT_MEM_ARM_MPU_FLASH>
+     "PPB"         -> <DT_MEM_ARM_MPU_PPB>
+     "IO"          -> <DT_MEM_ARM_MPU_IO>
+     "EXTMEM"      -> <DT_MEM_ARM_MPU_EXTMEM>
+
 Digital Microphone
 ==================
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -98,6 +98,10 @@ Removed APIs and options
 
     * ``CONFIG_COUNTER_MAXIM_DS3231``
 
+* Devicetree
+
+    * ``zephyr,memory-region-mpu``
+
 * LLEXT
 
     * ``llext_get_fn_table``, replaced by ``llext_get_fn_table_entry``

--- a/doc/services/mem_mgmt/index.rst
+++ b/doc/services/mem_mgmt/index.rst
@@ -71,24 +71,6 @@ and act on regions and attributes (see next section for more details).
 A test for the ``mem-attr`` library and its usage is provided in
 ``tests/subsys/mem_mgmt/mem_attr/``.
 
-Migration guide from ``zephyr,memory-region-mpu``
-*************************************************
-
-When the ``zephyr,memory-attr`` property was introduced, the
-``zephyr,memory-region-mpu`` property was removed and deprecated.
-
-The developers that are still using the deprecated property can move to the new
-one by renaming the property and changing its value according to the following list:
-
-.. code-block:: none
-
-   "RAM"         -> <DT_MEM_ARM_MPU_RAM>
-   "RAM_NOCACHE" -> <DT_MEM_ARM_MPU_RAM_NOCACHE>
-   "FLASH"       -> <DT_MEM_ARM_MPU_FLASH>
-   "PPB"         -> <DT_MEM_ARM_MPU_PPB>
-   "IO"          -> <DT_MEM_ARM_MPU_IO>
-   "EXTMEM"      -> <DT_MEM_ARM_MPU_EXTMEM>
-
 Memory Attributes Heap Allocator
 ********************************
 

--- a/dts/bindings/base/zephyr,memory-common.yaml
+++ b/dts/bindings/base/zephyr,memory-common.yaml
@@ -19,13 +19,6 @@ properties:
       memory region. The string set here will be specified in parentheses
       after the area name in the linker script.
 
-  zephyr,memory-region-mpu:
-    type: string
-    deprecated: true
-    description: |
-      Signify that this node should result in a dedicated MPU region.
-      Deprecated in favor of 'zephyr,memory-attr'.
-
   zephyr,memory-attr:
     type: int
     description: |


### PR DESCRIPTION
Removes the `zephyr,memory-region-mpu` devicetree property, deprecated in Zephyr 3.5 in favor of the `zephyr,memory-attr` bitmask (#60049).

The three `BUILD_ASSERT` tripwires in the ARM/ARM64 MPU drivers already turned any remaining use into a build failure, so they go with it, along with the now-unused `NODE_HAS_PROP_AND_OR` helper.

The "Migration guide from `zephyr,memory-region-mpu`" section of `doc/services/mem_mgmt/index.rst` documented a property that no longer exists, so it is dropped and its value mapping table moved into the 4.5 migration guide entry.
