### PR TITLE
dts: bindings: comparator: drop deprecated nxp,kinetis-acmp props

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -231,6 +231,13 @@ Clock Control
   RT11xx overlays should be updated using the mapping
   ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
 
+Comparator
+==========
+
+* The deprecated ``nxp,``-prefixed :dtcompatible:`nxp,kinetis-acmp` properties have been removed:
+  use ``enable-pin-out``, ``use-unfiltered-output``, ``enable-high-speed-mode``,
+  ``filter-enable-sample``, ``filter-count``, ``filter-period`` and ``enable-window-mode``.
+
 Controller Area Network (CAN)
 =============================
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -94,6 +94,12 @@ Removed APIs and options
       buffers unconditionally. Applications still setting these options can
       simply drop them.
 
+* Comparator
+
+    * ``nxp,enable-output-pin``, ``nxp,use-unfiltered-output``, ``nxp,high-speed-mode``,
+      ``nxp,enable-sample``, ``nxp,filter-count``, ``nxp,filter-period`` and ``nxp,window-mode``
+      properties of :dtcompatible:`nxp,kinetis-acmp`
+
 * Counter
 
     * ``CONFIG_COUNTER_MAXIM_DS3231``

--- a/drivers/sensor/nxp/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/nxp/mcux_acmp/mcux_acmp.c
@@ -41,49 +41,6 @@ BUILD_ASSERT(kACMP_PortInputFromDAC == 0);
 BUILD_ASSERT(kACMP_PortInputFromMux == 1);
 #endif /* MCUX_ACMP_HAS_INPSEL || MCUX_ACMP_HAS_INNSEL */
 
-/*
- * prop New property name
- * depr Deprecated property name
- */
-#define MCUX_ACMP_DT_INST_PROP(inst, prop, depr)						\
-	COND_CODE_1(										\
-		DT_INST_NODE_HAS_PROP(inst, prop),						\
-		(DT_INST_PROP(inst, prop)),							\
-		(DT_INST_PROP(inst, depr))							\
-	)
-
-/*
- * prop New property name
- * depr Deprecated property name
- */
-#define MCUX_ACMP_DT_INST_PROP_OR(inst, prop, depr, default_value)				\
-	COND_CODE_1(										\
-		DT_INST_NODE_HAS_PROP(inst, prop) || DT_INST_NODE_HAS_PROP(inst, depr),		\
-		(MCUX_ACMP_DT_INST_PROP(inst, prop, depr)),					\
-		(default_value)									\
-	)
-
-#define MCUX_ACMP_DT_INST_ENABLE_SAMPLE(inst) \
-	MCUX_ACMP_DT_INST_PROP(inst, filter_enable_sample, nxp_enable_sample)
-
-#define MCUX_ACMP_DT_INST_FILTER_COUNT(inst) \
-	MCUX_ACMP_DT_INST_PROP_OR(inst, filter_count, nxp_filter_count, 0)
-
-#define MCUX_ACMP_DT_INST_FILTER_PERIOD(inst) \
-	MCUX_ACMP_DT_INST_PROP_OR(inst, filter_period, nxp_filter_period, 0)
-
-#define MCUX_ACMP_DT_INST_HIGH_SPEED(inst) \
-	MCUX_ACMP_DT_INST_PROP(inst, enable_high_speed_mode, nxp_high_speed_mode)
-
-#define MCUX_ACMP_DT_INST_USE_UNFILTERED_MODE(inst) \
-	MCUX_ACMP_DT_INST_PROP(inst, use_unfiltered_output, nxp_use_unfiltered_output)
-
-#define MCUX_ACMP_DT_INST_USE_ENABLE_PIN_OUT(inst) \
-	MCUX_ACMP_DT_INST_PROP(inst, enable_pin_out, nxp_enable_output_pin)
-
-#define MCUX_ACMP_DT_INST_ENABLE_WINDOW_MODE(inst) \
-	MCUX_ACMP_DT_INST_PROP(inst, enable_window_mode, nxp_window_mode)
-
 struct mcux_acmp_config {
 	CMP_Type *base;
 	acmp_filter_config_t filter;
@@ -535,15 +492,16 @@ static const struct mcux_acmp_config mcux_acmp_config_##n = {		\
 	.base = (CMP_Type *)DT_INST_REG_ADDR(n),			\
 	.filter = {							\
 		COND_CODE_1(MCUX_ACMP_HAS_SAMPLE_CLOCK_SELECTION,	\
-		(.enableSample = MCUX_ACMP_DT_INST_ENABLE_SAMPLE(n),),	\
+		(.enableSample =					\
+		DT_INST_PROP(n, filter_enable_sample),),		\
 		())							\
-		.filterCount = MCUX_ACMP_DT_INST_FILTER_COUNT(n),	\
-		.filterPeriod = MCUX_ACMP_DT_INST_FILTER_PERIOD(n),	\
+		.filterCount = DT_INST_PROP_OR(n, filter_count, 0),	\
+		.filterPeriod = DT_INST_PROP_OR(n, filter_period, 0),	\
 	},								\
-	.high_speed = MCUX_ACMP_DT_INST_HIGH_SPEED(n),			\
-	.unfiltered = MCUX_ACMP_DT_INST_USE_UNFILTERED_MODE(n),		\
-	.output = MCUX_ACMP_DT_INST_USE_ENABLE_PIN_OUT(n),		\
-	.window = MCUX_ACMP_DT_INST_ENABLE_WINDOW_MODE(n),		\
+	.high_speed = DT_INST_PROP(n, enable_high_speed_mode),		\
+	.unfiltered = DT_INST_PROP(n, use_unfiltered_output),		\
+	.output = DT_INST_PROP(n, enable_pin_out),			\
+	.window = DT_INST_PROP(n, enable_window_mode),			\
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	config_func_init						\
 }

--- a/dts/bindings/comparator/nxp,kinetis-acmp.yaml
+++ b/dts/bindings/comparator/nxp,kinetis-acmp.yaml
@@ -53,41 +53,6 @@ properties:
   reg:
     required: true
 
-  nxp,enable-output-pin:
-    type: boolean
-    deprecated: true
-    description: Deprecated. Please use enable-pin-out instead
-
-  nxp,use-unfiltered-output:
-    type: boolean
-    deprecated: true
-    description: Deprecated. Please use use-unfiltered-output instead
-
-  nxp,high-speed-mode:
-    type: boolean
-    deprecated: true
-    description: Deprecated. Please use enable-high-speed-mode instead
-
-  nxp,enable-sample:
-    type: boolean
-    deprecated: true
-    description: Deprecated. Please use filter-enable-sample instead
-
-  nxp,filter-count:
-    type: int
-    deprecated: true
-    description: Deprecated. Please use filter-count instead
-
-  nxp,filter-period:
-    type: int
-    deprecated: true
-    description: Deprecated. Please use filter-period instead
-
-  nxp,window-mode:
-    type: boolean
-    deprecated: true
-    description: Deprecated. Please use enable-window-mode instead
-
   offset-mode:
     type: string
     enum:


### PR DESCRIPTION
Removes the `nxp,`-prefixed `nxp,kinetis-acmp` properties (`nxp,enable-output-pin`, `nxp,use-unfiltered-output`, `nxp,high-speed-mode`, `nxp,enable-sample`, `nxp,filter-count`, `nxp,filter-period` and `nxp,window-mode`), deprecated in Zephyr 4.0 in favor of unprefixed names (#76087).
