### PR TITLE
dts: bindings: counter: remove deprecated nxp,lptmr prescaler

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -252,6 +252,10 @@ Counter
   ``inputmux-connections = <&inputmux0 0 0x06000024>;`` becomes
   ``mux-states = <&inputmux0 0 0x06000024>;`` (:github:`112088`)
 
+* The ``prescaler`` property of :dtcompatible:`nxp,lptmr` has been removed. Use
+  ``prescale-glitch-filter`` and ``prescale-glitch-filter-bypass`` instead. The new property is
+  an exponent, not a divisor: the prescaler divides by ``2^(prescale-glitch-filter + 1)``.
+
 Devicetree
 ==========
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -97,6 +97,7 @@ Removed APIs and options
 * Counter
 
     * ``CONFIG_COUNTER_MAXIM_DS3231``
+    * ``prescaler`` property of :dtcompatible:`nxp,lptmr`
 
 * LLEXT
 

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -15,14 +15,6 @@ properties:
     required: true
     description: Counter clock frequency
 
-  prescaler:
-    type: int
-    deprecated: true
-    description: |
-      This property has been deprecated and replaced by prescale-glitch-filter.
-      It no longer has any functional impact. Any value assigned to this property
-      will be disregarded. Consequently, the prescaler will be bypassed.
-
   clk-source:
     type: int
     required: true


### PR DESCRIPTION
Removes the `prescaler` property of `nxp,lptmr`, deprecated in Zephyr 4.3 in favor of `prescale-glitch-filter` and `prescale-glitch-filter-bypass` (#95263).

### Out-of-tree impact, hence the migration guide entry

`prescaler` was `required: true` as recently as `v4.2.0`, so downstream board devicetrees are likely to still carry it. This is the first written notice they get — the driver never read it, so it has been inert since 4.3. The replacement is also an exponent rather than a divisor, so a mechanical rename would be wrong.
