### PR TITLE
dts: bindings: remove deprecated vendor prefixes

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -261,6 +261,9 @@ Devicetree
   unsigned comparisons or ``BUILD_ASSERT(DT_PROP(node, foo) > 0, ...)`` checks, must be updated
   to use signed types or signed-aware checks (:github:`107271`).
 
+* The deprecated ``facebook``, ``powervr`` and ``toppoly`` devicetree vendor prefixes have been
+  removed. Use ``meta``, ``img`` and ``tpo`` respectively.
+
 Digital Microphone
 ==================
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -98,6 +98,10 @@ Removed APIs and options
 
     * ``CONFIG_COUNTER_MAXIM_DS3231``
 
+* Devicetree
+
+    * ``facebook``, ``powervr`` and ``toppoly`` devicetree vendor prefixes
+
 * LLEXT
 
     * ``llext_get_fn_table``, replaced by ``llext_get_fn_table_entry``

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -252,7 +252,6 @@ exar	Exar Corporation
 excito	Excito
 ezchip	EZchip Semiconductor
 ezurio	Ezurio
-facebook	Facebook (deprecated, use meta)
 fairphone	Fairphone B.V.
 fanke	FANKE Technology Co., Ltd.
 faraday	Faraday Technology Corporation
@@ -579,7 +578,6 @@ portwell	Portwell Inc.
 poslab	Poslab Technology Co., Ltd.
 pov	Point of View International B.V.
 powertip	Powertip Tech. Corp.
-powervr	PowerVR (deprecated, use img)
 primux	Primux Trading, S.L.
 probox2	PROBOX2 (by W2COMP Co., Ltd.)
 prt	Protonic Holland
@@ -741,7 +739,6 @@ titanmec	Shenzhen Titan Micro Electronics Co., Ltd.
 tlm	Trusted Logic Mobility
 tmt	Tecon Microprocessor Technologies, LLC.
 topeet	Topeet
-toppoly	TPO (deprecated, use tpo)
 topwise	Topwise Communication Co., Ltd.
 toradex	Toradex AG
 torex	Torex Semiconductor Ltd.


### PR DESCRIPTION
Removes the `facebook`, `powervr` and `toppoly` devicetree vendor prefixes, in favor of `meta`, `img` and `tpo`.

`facebook` was deprecated in Zephyr 3.5 (#61351). `powervr` and `toppoly` have carried the deprecation marker since they were imported from the Linux kernel, in Zephyr 2.0 (#16309) and 2.7 (#35422) respectively.

### Out-of-tree impact, hence the migration guide entry

`vendor-prefixes.txt` is also checked against out-of-tree bindings, so downstream compatibles still using the old prefixes will now fail compliance.
