### PR TITLE
lorawan: native: do not use a stack-allocated semaphore

### DIFF
--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -6,6 +6,7 @@
 menuconfig LORAWAN
 	bool "LoRaWAN support [EXPERIMENTAL]"
 	depends on LORA
+	select POLL
 	select REQUIRES_FULL_LIBC
 	select EXPERIMENTAL
 	help

--- a/subsys/lorawan/native/engine.c
+++ b/subsys/lorawan/native/engine.c
@@ -80,13 +80,18 @@ void engine_init(struct lwan_ctx *ctx)
 
 int engine_post_req_wait(struct lwan_req *req)
 {
-	struct k_sem done;
+	struct k_poll_signal done;
+	struct k_poll_event event;
+	unsigned int signaled;
 	int result;
 	int ret;
 
-	k_sem_init(&done, 0, 1);
+	/* A poll signal is used rather than a semaphore as it, unlike kernel
+	 * objects, may live on the stack.
+	 */
+	k_poll_signal_init(&done);
+	k_poll_event_init(&event, K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &done);
 	req->done = &done;
-	req->result = &result;
 
 	ret = k_msgq_put(&engine_msgq, req, K_NO_WAIT);
 	if (ret != 0) {
@@ -94,13 +99,13 @@ int engine_post_req_wait(struct lwan_req *req)
 		return ret;
 	}
 
-	k_sem_take(&done, K_FOREVER);
+	(void)k_poll(&event, 1, K_FOREVER);
+	k_poll_signal_check(&done, &signaled, &result);
 
 	return result;
 }
 
 void engine_signal_result(const struct lwan_req *req, int result)
 {
-	*req->result = result;
-	k_sem_give(req->done);
+	k_poll_signal_raise(req->done, result);
 }

--- a/subsys/lorawan/native/engine.h
+++ b/subsys/lorawan/native/engine.h
@@ -76,10 +76,10 @@ struct lwan_req {
 	enum lwan_req_type type;
 	/* Pointer to request payload for @p type */
 	void *data;
-	/* Caller-owned completion for synchronous requests */
-	struct k_sem *done;
-	/* Caller-owned result storage */
-	int *result;
+	/* Caller-owned completion signal for synchronous requests, also
+	 * carries the request result.
+	 */
+	struct k_poll_signal *done;
 };
 
 #define LWAN_REQ(_type, _data) \

--- a/subsys/lorawan/native/mac/mac.c
+++ b/subsys/lorawan/native/mac/mac.c
@@ -255,7 +255,6 @@ static void mac_do_link_check(struct lwan_ctx *ctx,
 		.type = LWAN_REQ_SEND,
 		.data = &send_req,
 		.done = req->done,
-		.result = req->result,
 	};
 
 	mac_do_send(ctx, &send_msg);


### PR DESCRIPTION
`engine_post_req_wait()` used a semaphore living on its stack to wait for the engine thread to complete the request. Kernel object tracking (`CONFIG_OBJ_CORE_SEM`, object tracking) registers semaphores passed to `k_sem_init()`, leaving the tracking lists referencing dead memory once the function returns.

Use a `k_poll_signal` instead, which may live on the stack by design and whose result also carries the request result, removing the separate caller-owned result pointer.

Ref: https://github.com/zephyrproject-rtos/zephyr/issues/114856