### PR TITLE
drivers: i2c: stm32: factorize runtime config and a few minor cleaning

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -61,65 +61,6 @@ int i2c_stm32_get_config(const struct device *dev, uint32_t *config)
 	return 0;
 }
 
-int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
-{
-	const struct i2c_stm32_config *cfg = dev->config;
-	struct i2c_stm32_data *data = dev->data;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	I2C_TypeDef *i2c = cfg->i2c;
-	uint32_t i2c_clock = 0U;
-	int ret;
-
-	__ASSERT(k_sem_count_get(&data->bus_mutex) == 0, "Bus is not locked");
-
-	if (cfg->pclk_len > 1) {
-		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[1],
-					   &i2c_clock) < 0) {
-			LOG_ERR("Failed call clock_control_get_rate(pclken[1])");
-			return -EIO;
-		}
-	} else {
-		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[0],
-					   &i2c_clock) < 0) {
-			LOG_ERR("Failed call clock_control_get_rate(pclken[0])");
-			return -EIO;
-		}
-	}
-
-	data->dev_config = config;
-
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
-	if (ret < 0) {
-		LOG_ERR("failure Enabling I2C clock");
-		return ret;
-	}
-#endif
-
-	LL_I2C_Disable(i2c);
-#if defined(I2C_CR1_SMBUS) || defined(I2C_CR1_SMBDEN) || defined(I2C_CR1_SMBHEN)
-	i2c_stm32_set_smbus_mode(dev, data->mode);
-#endif
-	ret = i2c_stm32_configure_timing(dev, i2c_clock);
-	if (ret < 0) {
-		return ret;
-	}
-
-	if (data->smbalert_active) {
-		LL_I2C_Enable(i2c);
-	}
-
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	ret = clock_control_off(clk, (clock_control_subsys_t)&cfg->pclken[0]);
-	if (ret < 0) {
-		LOG_ERR("failure disabling I2C clock");
-		return ret;
-	}
-#endif
-
-	return 0;
-}
-
 #define OPERATION(msg) (((struct i2c_msg *) msg)->flags & I2C_MSG_RW_MASK)
 
 static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,

--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -7,25 +7,24 @@
 
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/kernel.h>
+
 #include <soc.h>
 #include <stm32_ll_i2c.h>
 #include <stm32_ll_rcc.h>
 #include <errno.h>
-#include <zephyr/drivers/i2c.h>
-#include <zephyr/drivers/pinctrl.h>
-#include <zephyr/irq.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_stm32);
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
 
+LOG_MODULE_REGISTER(i2c_stm32, CONFIG_I2C_LOG_LEVEL);
 
 int i2c_stm32_get_config(const struct device *dev, uint32_t *config)
 {

--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -60,8 +60,6 @@ int i2c_stm32_get_config(const struct device *dev, uint32_t *config)
 	return 0;
 }
 
-#define OPERATION(msg) (((struct i2c_msg *) msg)->flags & I2C_MSG_RW_MASK)
-
 static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 			      uint8_t num_msgs, uint16_t target)
 {
@@ -90,7 +88,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 			 * Restart condition between messages
 			 * of different directions is required
 			 */
-			if (OPERATION(current) != OPERATION(next)) {
+			if ((current->flags & I2C_MSG_RW_MASK) != (next->flags & I2C_MSG_RW_MASK)) {
 				if (!(next->flags & I2C_MSG_RESTART)) {
 					ret = -EINVAL;
 					break;

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -223,14 +223,16 @@ void i2c_stm32_error_isr(void *arg);
 #endif /* CONFIG_I2C_STM32_COMBINED_INTERRUPT */
 
 #define I2C_STM32_IRQ_HANDLER_DECL(index)							\
-static void i2c_stm32_irq_config_func_##index(const struct device *dev)
+	static void i2c_stm32_irq_config_func_##index(const struct device *dev)
+
 #define I2C_STM32_IRQ_HANDLER_FUNCTION(index)							\
 	.irq_config_func = i2c_stm32_irq_config_func_##index,
+
 #define I2C_STM32_IRQ_HANDLER(index)								\
-static void i2c_stm32_irq_config_func_##index(const struct device *dev)				\
-{												\
-	I2C_STM32_IRQ_CONNECT_AND_ENABLE(index);						\
-}
+	static void i2c_stm32_irq_config_func_##index(const struct device *dev __unused)	\
+	{											\
+		I2C_STM32_IRQ_CONNECT_AND_ENABLE(index);					\
+	}
 
 #else /* CONFIG_I2C_STM32_INTERRUPT */
 #define I2C_STM32_IRQ_HANDLER_DECL(index)
@@ -238,4 +240,4 @@ static void i2c_stm32_irq_config_func_##index(const struct device *dev)				\
 #define I2C_STM32_IRQ_HANDLER(index)
 #endif /* CONFIG_I2C_STM32_INTERRUPT */
 
-#endif	/* ZEPHYR_DRIVERS_I2C_I2C_STM32_H_ */
+#endif /* ZEPHYR_DRIVERS_I2C_I2C_STM32_H_ */

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -9,18 +9,12 @@
 #ifndef ZEPHYR_DRIVERS_I2C_I2C_STM32_H_
 #define ZEPHYR_DRIVERS_I2C_I2C_STM32_H_
 
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c/stm32.h>
 #include <zephyr/kernel.h>
-#include <zephyr/devicetree.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
-#include <zephyr/logging/log.h>
-
-#ifdef CONFIG_I2C_STM32_BUS_RECOVERY
-#include <zephyr/drivers/gpio.h>
-#endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
-
-#include <zephyr/drivers/dma.h>
 
 typedef void (*irq_config_func_t)(const struct device *port);
 

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -17,6 +17,7 @@
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/policy.h>
 #include <stm32_cache.h>
+#include <stm32_ll_i2c.h>
 
 #ifdef CONFIG_I2C_STM32_BUS_RECOVERY
 #include "i2c_bitbang.h"
@@ -187,6 +188,69 @@ void i2c_stm32_pm_put(const struct device *dev)
 		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 	}
 	(void)pm_device_runtime_put(dev);
+}
+
+int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	I2C_TypeDef *i2c = cfg->i2c;
+	uint32_t i2c_clock = 0U;
+	int ret;
+
+	if (cfg->pclk_len > 1) {
+		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[1],
+					   &i2c_clock) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclken[1])");
+			return -EIO;
+		}
+	} else {
+		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[0],
+					   &i2c_clock) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclken[0])");
+			return -EIO;
+		}
+	}
+
+	data->dev_config = config;
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
+	if (ret < 0) {
+		LOG_ERR("failure Enabling I2C clock");
+		return ret;
+	}
+#endif
+
+	LL_I2C_Disable(i2c);
+
+#ifndef CONFIG_I2C_RTIO
+#if defined(I2C_CR1_SMBUS) || defined(I2C_CR1_SMBDEN) || defined(I2C_CR1_SMBHEN)
+	i2c_stm32_set_smbus_mode(dev, data->mode);
+#endif
+#endif /* CONFIG_I2C_RTIO */
+
+	ret = i2c_stm32_configure_timing(dev, i2c_clock);
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifndef CONFIG_I2C_RTIO
+	if (data->smbalert_active) {
+		LL_I2C_Enable(i2c);
+	}
+#endif /* CONFIG_I2C_RTIO */
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	ret = clock_control_off(clk, (clock_control_subsys_t)&cfg->pclken[0]);
+	if (ret < 0) {
+		LOG_ERR("failure disabling I2C clock");
+		return ret;
+	}
+#endif
+
+	return 0;
 }
 
 #ifdef CONFIG_I2C_STM32_BUS_RECOVERY

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -14,19 +14,17 @@
 #include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/i2c/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/policy.h>
+
 #include <stm32_cache.h>
 #include <stm32_ll_i2c.h>
 
-#ifdef CONFIG_I2C_STM32_BUS_RECOVERY
 #include "i2c_bitbang.h"
 #include "i2c-priv.h"
-#endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_common);
+LOG_MODULE_REGISTER(i2c_ll_stm32_common, CONFIG_I2C_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
 #define DT_DRV_COMPAT st_stm32_i2c_v2

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -27,58 +27,6 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_rtio);
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
 
-
-int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
-{
-	const struct i2c_stm32_config *cfg = dev->config;
-	struct i2c_stm32_data *data = dev->data;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	I2C_TypeDef *i2c = cfg->i2c;
-	uint32_t i2c_clock = 0U;
-	int ret;
-
-	if (cfg->pclk_len > 1) {
-		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[1],
-					   &i2c_clock) < 0) {
-			LOG_ERR("Failed call clock_control_get_rate(pclken[1])");
-			return -EIO;
-		}
-	} else {
-		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[0],
-					   &i2c_clock) < 0) {
-			LOG_ERR("Failed call clock_control_get_rate(pclken[0])");
-			return -EIO;
-		}
-	}
-
-	data->dev_config = config;
-
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
-	if (ret < 0) {
-		LOG_ERR("Failed enabling I2C clock");
-		return ret;
-	}
-#endif
-
-	LL_I2C_Disable(i2c);
-	ret = i2c_stm32_configure_timing(dev, i2c_clock);
-	if (ret < 0) {
-		LOG_ERR("Failed configuring I2C timing");
-		return ret;
-	}
-
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	ret = clock_control_off(clk, (clock_control_subsys_t)&cfg->pclken[0]);
-	if (ret < 0) {
-		LOG_ERR("Failed disabling I2C clock");
-		return ret;
-	}
-#endif
-
-	return ret;
-}
-
 static bool i2c_stm32_start(const struct device *dev, int *status)
 {
 	struct i2c_stm32_data *data = dev->data;

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -108,8 +108,6 @@ static int i2c_stm32_configure(const struct device *dev,
 	return i2c_rtio_configure(ctx, dev_config_raw);
 }
 
-#define OPERATION(msg)	((msg)->flags & I2C_MSG_RW_MASK)
-
 static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr)
 {
@@ -142,7 +140,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msgs,
 		}
 #endif
 
-		if ((OPERATION(msgs + n - 1) != OPERATION(msgs + n)) &&
+		if (((msgs[n].flags & I2C_MSG_RW_MASK) != (msgs[n - 1].flags & I2C_MSG_RW_MASK)) &&
 		    ((msgs[n].flags & I2C_MSG_RESTART) == 0U)) {
 			LOG_ERR("Missing restart flag between message of different directions");
 			return -EINVAL;

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -4,28 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
-#include <soc.h>
-#include <stm32_ll_i2c.h>
-#include <stm32_ll_rcc.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/i2c/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/util.h>
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_rtio);
+#include <soc.h>
+#include <stm32_ll_i2c.h>
+#include <stm32_ll_rcc.h>
+#include <errno.h>
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
+
+LOG_MODULE_REGISTER(i2c_ll_stm32_rtio, CONFIG_I2C_LOG_LEVEL);
 
 static bool i2c_stm32_start(const struct device *dev, int *status)
 {

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -10,20 +10,22 @@
 
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/sys/util.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/sys/util.h>
+
 #include <soc.h>
 #include <stm32_bitops.h>
 #include <stm32_ll_i2c.h>
-#include <errno.h>
-#include <zephyr/drivers/i2c.h>
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_v1);
+#include <errno.h>
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
+
+LOG_MODULE_REGISTER(i2c_ll_stm32_v1, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_STM32_TIMEOUT_USEC  1000
 #define I2C_REQUEST_WRITE       0x00

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -4,27 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
-#include <soc.h>
-#include <stm32_bitops.h>
-#include <stm32_ll_i2c.h>
-#include <stm32_ll_rcc.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/i2c/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/util.h>
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_v1_rtio);
+#include <soc.h>
+#include <stm32_bitops.h>
+#include <stm32_ll_i2c.h>
+#include <stm32_ll_rcc.h>
+
+#include <errno.h>
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
+
+LOG_MODULE_REGISTER(i2c_ll_stm32_v1_rtio, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_REQUEST_WRITE       0x00
 #define I2C_REQUEST_READ        0x01

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -9,29 +9,30 @@
  *
  */
 
+#include <zephyr/cache.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/sys/util.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/kernel.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/mem_mgmt/mem_attr.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/sys/util.h>
+
 #include <soc.h>
 #include <stm32_bitops.h>
 #include <stm32_cache.h>
 #include <stm32_ll_i2c.h>
-#include <errno.h>
-#include <zephyr/drivers/i2c.h>
-#include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
-#include <zephyr/cache.h>
-#include <zephyr/linker/linker-defs.h>
-#include <zephyr/mem_mgmt/mem_attr.h>
-#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_v2);
+#include <errno.h>
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
+
+LOG_MODULE_REGISTER(i2c_ll_stm32_v2, CONFIG_I2C_LOG_LEVEL);
 
 #if CONFIG_STM32_HAL2
 #define STM32_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period) \

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -6,28 +6,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
-#include <soc.h>
-#include <stm32_ll_i2c.h>
-#include <stm32_ll_rcc.h>
-#include <stm32_cache.h>
+#include <zephyr/cache.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/i2c/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/cache.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/util.h>
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_v2_rtio);
+#include <soc.h>
+#include <stm32_cache.h>
+#include <stm32_ll_i2c.h>
+#include <stm32_ll_rcc.h>
+
+#include <errno.h>
 
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
+
+LOG_MODULE_REGISTER(i2c_ll_stm32_v2_rtio, CONFIG_I2C_LOG_LEVEL);
 
 #if CONFIG_STM32_HAL2
 #define STM32_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period) \


### PR DESCRIPTION
Factorize `i2c_stm32_runtime_configure()` between STM32 I2C non-RTIO and RTIO drivers that implements the same sequence but regarding SMBus support that is not yet available in the RTIO driver.

Improve consistency of some local helper macros definitions and in header files inclusions.

Remove a local helper macro that is not really needed.

No functional changes.