### PR TITLE
drivers: sensors: bmp581: Prevent loss of 6 bit of precision

### DIFF
--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -457,15 +457,12 @@ static int bmp581_sample_fetch(const struct device *dev, enum sensor_channel cha
 			((int64_t)(raw_temp_signed % 65536) * 1000000) / 65536;
 
 		if (drv->osr_odr_press_config.press_en == BMP5_ENABLE) {
-			/* convert raw sensor data to sensor_value. Shift the decimal part by
-			 * 4 decimal places to compensate for the conversion in
-			 * sensor_value_to_double()
-			 */
-			uint32_t raw_pressure = (uint32_t)((uint32_t)(data[5] << 16) |
-							   (uint16_t)(data[4] << 8) | data[3]) >>
-						6;
-			drv->last_sample.pressure.val1 = raw_pressure / 1000;
-			drv->last_sample.pressure.val2 = (raw_pressure % 1000) * 1000;
+			/* raw_pressure has 6 fractional bits (unit: 1/64 Pa) */
+			uint32_t raw_pressure = ((uint32_t)data[5] << 16) |
+						((uint32_t)data[4] << 8) | data[3];
+
+			drv->last_sample.pressure.val1 = raw_pressure / (64 * 1000);
+			drv->last_sample.pressure.val2 = (raw_pressure % (64 * 1000)) * 1000 / 64;
 		} else {
 			drv->last_sample.pressure.val1 = 0;
 			drv->last_sample.pressure.val2 = 0;


### PR DESCRIPTION
The `bmp581` driver used a bitshift of 6 on the right when converting raw data, dropping the last 6 bit of precision.

This PR remove the bit shift and update the division performed during the conversion into `sensor_value` struct. 
This allow to use the full precision of 1/64Pa of the BMP581 instead of 1Pa.