### PR TITLE
drivers: dma: microchip: g2: Clear CHINTFLAG in the ISR

### DIFF
--- a/drivers/dma/dma_mchp_dmac_g2.c
+++ b/drivers/dma/dma_mchp_dmac_g2.c
@@ -358,31 +358,53 @@ static int dma_mchp_desc_setup(struct dma_mchp_dev_data *dev_data, struct dma_co
 static void dma_mchp_isr(const struct device *dev)
 {
 	struct dma_mchp_dev_data *dev_data = dev->data;
-	uint16_t pend = DMAC_REG->DMAC_INTPEND;
-	uint32_t channel = (pend & DMAC_INTPEND_ID_Msk) >> DMAC_INTPEND_ID_Pos;
+	uint8_t saved_chid = DMAC_REG->DMAC_CHID;
+	uint32_t channel;
 
-	/* Acknowledge interrupt immediately */
-	DMAC_REG->DMAC_INTPEND = pend;
+	/*
+	 * On PIC32CM GC00, INTPEND reads back zero even with a channel's
+	 * CHINTFLAG.TCMPL set, so the level-driven interrupt never clears and
+	 * starves other threads. Poll INTSTATUS (one bit per channel) instead,
+	 * and read each pending channel's CHINTFLAG through CHID.
+	 *
+	 * CHINTFLAG is write-one-to-clear; clear it before the callback runs
+	 * so a callback that queues the next transfer can't race its own
+	 * completion flag.
+	 */
+	for (channel = 0; channel < dev_data->dma_ctx.dma_channels; channel++) {
+		struct dma_mchp_channel_config *cfg;
+		uint8_t flags;
 
-	/* Ignore non TC / ERR interrupts */
-	if ((pend & (DMAC_INTPEND_TERR_Msk | DMAC_INTPEND_TCMPL_Msk)) == 0) {
-		return;
-	}
-
-	struct dma_mchp_channel_config *cfg = &dev_data->dma_channel_config[channel];
-
-	if (cfg->cb == NULL) {
-		return;
-	}
-
-	if (pend & DMAC_INTPEND_TERR_Msk) {
-		/* Invoke error callback only if it is not disabled */
-		if (cfg->is_err_cb_dis == false) {
-			cfg->cb(dev, cfg->user_data, channel, -EIO);
+		if ((DMAC_REG->DMAC_INTSTATUS & BIT(channel)) == 0U) {
+			continue;
 		}
-	} else {
-		cfg->cb(dev, cfg->user_data, channel, DMA_STATUS_COMPLETE);
+
+		DMAC_REG->DMAC_CHID = channel;
+		flags = DMAC_REG->DMAC_CHINTFLAG & DMAC_REG->DMAC_CHINTENSET;
+		flags &= (uint8_t)(DMAC_CHINTFLAG_TERR_Msk | DMAC_CHINTFLAG_TCMPL_Msk);
+
+		if (flags == 0U) {
+			continue;
+		}
+
+		DMAC_REG->DMAC_CHINTFLAG = flags;
+
+		cfg = &dev_data->dma_channel_config[channel];
+		if (cfg->cb == NULL) {
+			continue;
+		}
+
+		if ((flags & DMAC_CHINTFLAG_TERR_Msk) != 0U) {
+			/* Invoke error callback only if it is not disabled */
+			if (cfg->is_err_cb_dis == false) {
+				cfg->cb(dev, cfg->user_data, channel, -EIO);
+			}
+		} else {
+			cfg->cb(dev, cfg->user_data, channel, DMA_STATUS_COMPLETE);
+		}
 	}
+
+	DMAC_REG->DMAC_CHID = saved_chid;
 }
 
 static int dma_mchp_config(const struct device *dev, uint32_t channel, struct dma_config *config)


### PR DESCRIPTION
The G2 DMA ISR acknowledges through INTPEND, which reads back zero on this part while the channel's CHINTFLAG is still set: the level-driven interrupt then re-enters forever and dma_start() kills the console mid-boot.

## What breaks

`dma_mchp_isr()` reads the pending channel from `INTPEND` and acknowledges by
writing it back. On PIC32CM GC00 `INTPEND` reads back zero while the
channel's own `CHINTFLAG.TCMPL` is set, so the write acknowledged nothing.
The channel interrupt is level driven, so the handler was re-entered for as
long as the flag stayed set, and every other thread on the part starved -
`dma_start()` killed the console mid-boot.

## The fix

Walk the channels through the CHID window, mask `CHINTFLAG` with
`CHINTENSET`, and clear the write-one-to-clear flag before the callback runs,
so a callback that queues the next transfer cannot have its completion
cleared underneath it. `CHID` is saved and restored, because the ISR can
interrupt code that was using the window.

## Scope

Three families instantiate this driver: PIC32CM PL, PIC32CM JH and, with the
SoC devicetree we are upstreaming separately, PIC32CM SG/GC. All three
packs define `CHID` and the per-channel `CHINTFLAG`/`CHINTENSET` used here,
checked in `hal_microchip` rather than assumed. The change is a strict
improvement on a part where `INTPEND` does report the channel: the flags
are then read and cleared through the same channel the old code would have
picked.

## Testing

`tests/drivers/dma/chan_blen_transfer` and `tests/drivers/dma/loop_transfer`
on hardware, with board overlays kept in our own workspace, not in this PR.

Run on the board: `dma_m2m` pass = 4, fail = 0, skip = 0, total = 4 (both
channels at burst 8 and burst 16), and `dma_m2m_loop` pass = 3, fail = 0,
skip = 0, total = 3, including `test_dma0_m2m_loop_suspend_resume` and
`test_dma0_m2m_loop_repeated_start_stop`.

## Verification

Measured on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A), in a west
workspace at Zephyr 0d65ce46dda0 with this repository's patch queue
applied. The commits here are cut from current `main` and carry no other
patch.
