### PR TITLE
drivers: hwinfo: microchip: g1: add PIC32CM SG/GC support

### DIFF
--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
@@ -15,5 +15,6 @@ supported:
   - gpio
   - i2c
   - pinctrl
+  - reset
   - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - dma
   - gpio
+  - hwinfo
   - i2c
   - pinctrl
   - reset

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
@@ -15,5 +15,6 @@ supported:
   - gpio
   - i2c
   - pinctrl
+  - reset
   - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - dma
   - gpio
+  - hwinfo
   - i2c
   - pinctrl
   - reset

--- a/drivers/hwinfo/hwinfo_mchp_g1.c
+++ b/drivers/hwinfo/hwinfo_mchp_g1.c
@@ -56,8 +56,7 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 
 int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
-	volatile uint8_t *rcause_reg = (uint8_t *)(DT_REG_ADDR(RSTC_INST));
-	uint8_t rcause = *rcause_reg;
+	uint32_t rcause = ((rstc_registers_t *)DT_REG_ADDR(RSTC_INST))->RSTC_RCAUSE;
 	uint32_t result = 0;
 
 	if (cause == NULL) {
@@ -68,10 +67,7 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	if ((rcause & BIT(RSTC_G1_RCAUSE_POR)) != 0) {
 		result |= RESET_POR;
 	}
-	if ((rcause & BIT(RSTC_G1_RCAUSE_BOD12)) != 0) {
-		result |= RESET_BROWNOUT;
-	}
-	if ((rcause & BIT(RSTC_G1_RCAUSE_BOD33)) != 0) {
+	if ((rcause & RSTC_G1_RCAUSE_BROWNOUT_MASK) != 0) {
 		result |= RESET_BROWNOUT;
 	}
 	if ((rcause & BIT(RSTC_G1_RCAUSE_EXT)) != 0) {

--- a/drivers/hwinfo/hwinfo_mchp_g1.c
+++ b/drivers/hwinfo/hwinfo_mchp_g1.c
@@ -51,6 +51,10 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 	*supported = RESET_POR | RESET_BROWNOUT | RESET_PIN | RESET_WATCHDOG | RESET_SOFTWARE |
 		     RESET_USER | RESET_LOW_POWER_WAKE;
 
+#ifdef RSTC_G1_RCAUSE_HAS_LOCKUP
+	*supported |= RESET_CPU_LOCKUP;
+#endif
+
 	return 0;
 }
 
@@ -82,6 +86,11 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	if ((rcause & BIT(RSTC_G1_RCAUSE_BACKUP)) != 0) {
 		result |= RESET_LOW_POWER_WAKE;
 	}
+#ifdef RSTC_G1_RCAUSE_HAS_LOCKUP
+	if ((rcause & BIT(RSTC_G1_RCAUSE_LOCKUP)) != 0) {
+		result |= RESET_CPU_LOCKUP;
+	}
+#endif
 
 	*cause = result;
 

--- a/dts/arm/microchip/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.dtsi
@@ -31,6 +31,14 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		hwinfo: device_id@a0071e0 {
+			compatible = "microchip,hwinfo-g1";
+			reg = <0x0a0071e0 0x4>,
+			      <0x0a0071e4 0x4>,
+			      <0x0a0071e8 0x4>,
+			      <0x0a0071ec 0x4>;
+		};
+
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
 			#address-cells = <1>;

--- a/dts/arm/microchip/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.dtsi
@@ -235,6 +235,11 @@
 			clock-names = "mclk", "gclk";
 			status = "disabled";
 		};
+
+		rstc: rstc@45004000 {
+			compatible = "microchip,rstc-g1-reset";
+			reg = <0x45004000 0x8>;
+		};
 	};
 };
 

--- a/include/zephyr/drivers/reset/mchp_rstc_g1.h
+++ b/include/zephyr/drivers/reset/mchp_rstc_g1.h
@@ -32,6 +32,9 @@ enum rstc_g1_rcause {
 	RSTC_G1_RCAUSE_BACKUP = 7 /* Backup Reset */
 };
 
+/** Reset-cause bits that all report through RESET_BROWNOUT. */
+#define RSTC_G1_RCAUSE_BROWNOUT_MASK (BIT(RSTC_G1_RCAUSE_BOD12) | BIT(RSTC_G1_RCAUSE_BOD33))
+
 #ifdef CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH
 /* Reserved reset-cause bits on PIC32CM JH */
 #define RSTC_RESERVED_BIT_3     BIT(3)

--- a/include/zephyr/drivers/reset/mchp_rstc_g1.h
+++ b/include/zephyr/drivers/reset/mchp_rstc_g1.h
@@ -21,6 +21,28 @@
  * This enumeration defines the possible reset causes as indicated by the
  * RSTC_RCAUSE register in the Microchip RSTC G1 reset controller.
  */
+#ifdef CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_SG_GC
+enum rstc_g1_rcause {
+	RSTC_G1_RCAUSE_POR = 0,       /* Power-on Reset */
+	RSTC_G1_RCAUSE_PORCORE = 1,   /* Core Power-on Reset */
+	RSTC_G1_RCAUSE_BORVDDREG = 2, /* Brown-Out VDDREG Detector Reset */
+	RSTC_G1_RCAUSE_BORVDDA = 3,   /* Brown-Out VDDA Detector Reset */
+	RSTC_G1_RCAUSE_BORVDDIO = 4,  /* Brown-Out VDDIO Detector Reset */
+	RSTC_G1_RCAUSE_EXT = 5,       /* External Reset */
+	RSTC_G1_RCAUSE_WDT = 6,       /* Watchdog Reset */
+	RSTC_G1_RCAUSE_SYST = 7,      /* System Reset Request */
+	RSTC_G1_RCAUSE_BACKUP = 8,    /* Backup Reset */
+	RSTC_G1_RCAUSE_LOCKUP = 9     /* CPU Lockup Reset */
+};
+
+/** This family resets the device when the core locks up and reports it. */
+#define RSTC_G1_RCAUSE_HAS_LOCKUP 1
+
+/** Reset-cause bits that all report through RESET_BROWNOUT. */
+#define RSTC_G1_RCAUSE_BROWNOUT_MASK                                                               \
+	(BIT(RSTC_G1_RCAUSE_PORCORE) | BIT(RSTC_G1_RCAUSE_BORVDDREG) |                             \
+	 BIT(RSTC_G1_RCAUSE_BORVDDA) | BIT(RSTC_G1_RCAUSE_BORVDDIO))
+#else
 enum rstc_g1_rcause {
 	RSTC_G1_RCAUSE_POR = 0,   /* Power-on Reset */
 	RSTC_G1_RCAUSE_BOD12 = 1, /* Brown-Out 1.2V Detector Reset */
@@ -34,6 +56,7 @@ enum rstc_g1_rcause {
 
 /** Reset-cause bits that all report through RESET_BROWNOUT. */
 #define RSTC_G1_RCAUSE_BROWNOUT_MASK (BIT(RSTC_G1_RCAUSE_BOD12) | BIT(RSTC_G1_RCAUSE_BOD33))
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_SG_GC */
 
 #ifdef CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH
 /* Reserved reset-cause bits on PIC32CM JH */


### PR DESCRIPTION
PIC32CM SG/GC had no rstc or hwinfo devicetree node, so the G1 hwinfo driver never selected on the family; and the shared RCAUSE bit map is not the one this family uses, so enabling it without that map reports an external reset as a watchdog reset.

## What this adds

`HWINFO_MCHP_G1` depends on `DT_HAS_MICROCHIP_HWINFO_G1_ENABLED` or
`DT_HAS_MICROCHIP_RSTC_G1_RESET_ENABLED`, and the SG/GC SoC dtsi carried
neither node, so the condition was never true on any board of the family.

Adding the two nodes is not enough on its own, because the RCAUSE bit
assignment in the shared `mchp_rstc_g1.h` is not the one this family uses.
Enabling the driver without the map would report an external reset as a
watchdog reset. Hence three commits, in the order that keeps each of them
correct on its own:

1. the RCAUSE map for this family in the shared header
2. the `rstc` and `hwinfo` nodes in the SG/GC SoC dtsi
3. the `hwinfo` label on pic32cm_gc00_cpro

## The bit map

The header carried one assignment for every G1 part: POR=0, BOD12=1,
BOD33=2, NVM=3, EXT=4, WDT=5, SYST=6, BACKUP=7, read as a byte. PIC32CM
SG/GC has four brown-out detectors where that has two, so it reads POR=0,
PORCORE=1, BORVDDREG=2, BORVDDA=3, BORVDDIO=4, EXT=5, WDT=6, SYST=7,
BACKUP=8, LOCKUP=9, on a register the family makes 16 bits wide. Every cause
above the brown-outs is shifted by one, and BACKUP falls outside a byte
access entirely.

The header gains a `CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_SG_GC` branch with
those positions, a four-bit brown-out mask, and an `RSTC_G1_RCAUSE_READ()`
that is 16-bit there and 8-bit elsewhere. The `#else` keeps the existing map
byte for byte, and the two existing brown-out tests become one mask with the
same result. No other family changes behaviour.

## Devicetree

RSTC is at 0x45004000 on both SG00 and GC00, so both nodes go in the shared
`common/pic32cm_sg_gc.dtsi`. The device identifier is the 128-bit value of
data sheet table 11-3, which this family keeps in the CAL-OTP region at
0x0a0071e0 rather than in the NVM software calibration row the other G1
parts read.

pic32cm_sg00_cpro picks up the same nodes from that shared dtsi, but is left
out of the board yaml change: the suite has not been run on that part.

## Testing

Every commit of the branch builds on its own: the header commit for
pic32cm_jh01_cpro, the two after it for pic32cm_gc00_cpro. At the tip the
generated config carries `CONFIG_HWINFO_MCHP_G1=y` and the generated
devicetree carries `microchip,rstc-g1-reset` at 0x45004000 and
`microchip,hwinfo-g1` at 0x0a0071e0, so the driver is selected rather than
silently absent.

`tests/drivers/hwinfo/api` on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A),
built from this branch and flashed over J-Link: `hwinfo_device_id_api`
pass = 3, fail = 0, skip = 1, total = 4, `PROJECT EXECUTION SUCCESSFUL`.
`test_device_id_get`, `test_get_reset_cause` and
`test_get_supported_reset_cause` pass; `test_clear_reset_cause` skips
because the driver reports no clear support. The image on the part is this
branch and not a stale install: the boot banner reads
`v4.4.0-12089-g1aa7d2d36c01`, the branch tip.

Only the power-on cause was provoked in that run. The external reset and
lockup cases were provoked separately, in an earlier session on the same
part: the same external reset reads `watchdog` before the map change and
`pin` after, and a shell command that sets MSP to address 4 locks the core
up, the silicon resets, and hwinfo returns "CPU lockup" with the watchdog
armed throughout.
title: drivers: hwinfo: microchip: g1: add PIC32CM SG/GC support
sha256: 19061c5f2f2a413a7cc00c7c03d745ab71734dfe71633ecaf558d110e73c9437
