### PR TITLE
drivers: counter: microchip: tcc g1: Fix the alarm race and the clock check

### DIFF
--- a/drivers/counter/counter_mchp_tcc_g1.c
+++ b/drivers/counter/counter_mchp_tcc_g1.c
@@ -356,6 +356,7 @@ static int32_t counter_mchp_set_alarm(const struct device *const dev, const uint
 	int32_t count_diff = 0u;
 	uint32_t top_value = 0u;
 	uint32_t ticks = alarm_cfg->ticks;
+	uint32_t remaining;
 
 	struct counter_mchp_dev_data *const data = dev->data;
 	const struct counter_mchp_dev_config *const cfg = dev->config;
@@ -434,8 +435,22 @@ static int32_t counter_mchp_set_alarm(const struct device *const dev, const uint
 		data->channel_data[chan_id].compare_value = ticks;
 		tcc_counter_set_compare(cfg->regs, chan_id, ticks);
 
-		/* Enable interrupt at compare match */
-		tcc_counter_alarm_irq_enable(cfg->regs, max_channels, chan_id);
+		(void)tcc_counter_get_count(cfg->regs, &count_value);
+		remaining = tcc_counter_ticks_sub(ticks, count_value, top_value);
+
+		if ((remaining == 0U) || (remaining > alarm_cfg->ticks)) {
+			tcc_counter_alarm_irq_clear(cfg->regs, max_channels, chan_id);
+
+			data->late_alarm_flag = true;
+			data->late_alarm_channel = chan_id;
+#if defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
+			k_irq_set_pending(cfg->irq_line);
+#else
+			k_irq_set_pending(cfg->channel_irq_map->comp_irq_line[chan_id]);
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
+		} else {
+			tcc_counter_alarm_irq_enable(cfg->regs, max_channels, chan_id);
+		}
 	}
 
 	return ret_val;

--- a/drivers/counter/counter_mchp_tcc_g1.c
+++ b/drivers/counter/counter_mchp_tcc_g1.c
@@ -617,7 +617,7 @@ static int32_t counter_mchp_init(const struct device *const dev)
 	tcc_counter_init(cfg->regs, cfg->prescaler, cfg->max_channels, cfg->max_bit_width);
 	cfg->irq_config_func(dev);
 
-	return ret_val;
+	return (ret_val == -EALREADY) ? 0 : ret_val;
 }
 
 static inline void counter_mchp_channel_irq_handle(const struct device *const dev, uint8_t channel)


### PR DESCRIPTION
The TCC G1 counter fails to initialise whenever another driver already turned its shared GCLK channel on - which is every boot here, since TCC0 and TCC1 share GCLK_ID_TCC01 - and arms short relative alarms for a count the counter has already passed.

## Two defects in one driver

**1. A relative alarm races the counter.** `counter_mchp_set_alarm()` adds
the requested ticks to a COUNT sampled before the compare register is
written, and writing it costs a read synchronization, a write and a wait on
`TCC_SYNCBUSY`. On a counter clocked fast enough that is more than one tick,
so a short relative alarm can be armed for a count the counter has already
gone past - and a missed compare does not match again until a whole period
later.

The fix re-reads COUNT after arming. The distance still to run can only have
shrunk, so a value larger than the one requested means the target went by
while the alarm was being armed; that is reported the way an absolute alarm
in the past is reported, rather than a period late.

**2. An already-running clock aborts initialization.** init returns whatever
the last `clock_control_on()` answered, and the clock driver answers
`-EALREADY` for a clock that is already on. The device model reads that
negative return as a failed initialization, so the counter is simply absent
from the system with nothing logged. `pwm_mchp_tcc_g1.c` normalizes the same
value on its last line; this is that line.

It is not hypothetical on this part: TCC0 and TCC1 share one GCLK peripheral
channel (`GCLK_ID_TCC01`), so whichever of the PWM and counter drivers
initializes second sees it.

## Evidence

`tests/drivers/counter/counter_basic_api` failed `test_short_relative_alarm`
on the fourth iteration of a hundred, and is green with the first commit.

The second commit deletes two workarounds in this board's own tree: TCC0 and
TCC1 were kept out of `&gclkperiph` so the channel stayed off until a driver
asked for it, and `CONFIG_COUNTER_INIT_PRIORITY` was forced below the PWM's
so the counter would be the one to ask.

## Testing

`tests/drivers/counter/counter_basic_api` on hardware.

Run on the board: `counter_basic` pass = 10, fail = 0, skip = 1, total = 11.
`test_short_relative_alarm` and `test_late_alarm` are among the passes;
`test_cancelled_alarm_does_not_expire` skips because the driver reports no
cancel support.

## Verification

Measured on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A), in a west
workspace at Zephyr 0d65ce46dda0 with this repository's patch queue
applied. The commits here are cut from current `main` and carry no other
patch.
