### PR TITLE
drivers: interrupt_controller: microchip: eic g1: Fix the PORTB line mapping

### DIFF
--- a/drivers/interrupt_controller/intc_mchp_eic_g1.c
+++ b/drivers/interrupt_controller/intc_mchp_eic_g1.c
@@ -44,8 +44,10 @@ LOG_MODULE_REGISTER(intc_mchp_eic_g1, CONFIG_INTC_LOG_LEVEL);
 /* Port B */
 #define PORTB_UNSUPPORTED_PINS    DT_INST_PROP(0, portb_unsupported_pins)
 /* The special pins need an offset when calculating the eic line */
-#define PORTB_SPECIAL_PINS        DT_INST_PROP_BY_IDX(0, portb_special_pins_1, 0)
-#define PORTB_SPECIAL_PINS_OFFSET DT_INST_PROP_BY_IDX(0, portb_special_pins_1, 1)
+#define PORTB_SPECIAL_PINS          DT_INST_PROP_BY_IDX(0, portb_special_pins_1, 0)
+#define PORTB_SPECIAL_PINS_OFFSET   DT_INST_PROP_BY_IDX(0, portb_special_pins_1, 1)
+#define PORTB_SPECIAL_PINS_2        DT_INST_PROP_BY_IDX(0, portb_special_pins_2, 0)
+#define PORTB_SPECIAL_PINS_2_OFFSET DT_INST_PROP_BY_IDX(0, portb_special_pins_2, 1)
 
 /* Port C */
 #define PORTC_SUPPORTED_PINS        DT_INST_PROP(0, portc_supported_pins)
@@ -135,7 +137,7 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 		if ((PORTA_UNSUPPORTED_PINS & pin_mask) != 0) {
 			eic_line = INTC_LINE_FREE;
 		} else if ((PORTA_SPECIAL_PINS_1 & pin_mask) != 0) {
-			eic_line += PORTA_SPECIAL_PINS_1_OFFSET;
+			eic_line = (eic_line + PORTA_SPECIAL_PINS_1_OFFSET) % EIC_LINES_PER_PORT;
 		} else {
 			/* Nothing to be done */
 		}
@@ -149,7 +151,7 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 		if ((PORTC_SUPPORTED_PINS & pin_mask) == 0) {
 			eic_line = INTC_LINE_FREE;
 		} else if ((PORTC_SPECIAL_PINS_1 & pin_mask) != 0) {
-			eic_line += PORTC_SPECIAL_PINS_1_OFFSET;
+			eic_line = (eic_line + PORTC_SPECIAL_PINS_1_OFFSET) % EIC_LINES_PER_PORT;
 		} else if ((PORTC_SPECIAL_PINS_2 & pin_mask) != 0) {
 			eic_line -= PORTC_SPECIAL_PINS_2_OFFSET;
 		} else {
@@ -181,7 +183,9 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 		if ((PORTB_UNSUPPORTED_PINS & pin_mask) != 0) {
 			eic_line = INTC_LINE_FREE;
 		} else if ((PORTB_SPECIAL_PINS & pin_mask) != 0) {
-			eic_line += PORTB_SPECIAL_PINS_OFFSET;
+			eic_line = (eic_line + PORTB_SPECIAL_PINS_OFFSET) % EIC_LINES_PER_PORT;
+		} else if ((PORTB_SPECIAL_PINS_2 & pin_mask) != 0) {
+			eic_line = (eic_line + PORTB_SPECIAL_PINS_2_OFFSET) % EIC_LINES_PER_PORT;
 		} else {
 			/* Nothing to be done */
 		}
@@ -190,7 +194,7 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 		if ((PORTC_UNSUPPORTED_PINS & pin_mask) != 0) {
 			eic_line = INTC_LINE_FREE;
 		} else if ((PORTC_SPECIAL_PINS_1 & pin_mask) != 0) {
-			eic_line += PORTC_SPECIAL_PINS_1_OFFSET;
+			eic_line = (eic_line + PORTC_SPECIAL_PINS_1_OFFSET) % EIC_LINES_PER_PORT;
 		} else {
 			/* Nothing to be done */
 		}
@@ -199,7 +203,7 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 		if ((PORTD_SUPPORTED_PINS & pin_mask) == 0) {
 			eic_line = INTC_LINE_FREE;
 		} else if ((PORTD_SPECIAL_PINS_2 & pin_mask) != 0) {
-			eic_line += PORTD_SPECIAL_PINS_2_OFFSET;
+			eic_line = (eic_line + PORTD_SPECIAL_PINS_2_OFFSET) % EIC_LINES_PER_PORT;
 		} else if ((PORTD_SPECIAL_PINS_1 & pin_mask) != 0) {
 			eic_line -= PORTD_SPECIAL_PINS_1_OFFSET;
 		} else {

--- a/drivers/interrupt_controller/intc_mchp_eic_g1.c
+++ b/drivers/interrupt_controller/intc_mchp_eic_g1.c
@@ -178,8 +178,12 @@ uint8_t find_eic_line_from_pin(int port, int pin)
 		}
 		break;
 	case MCHP_PORT_ID1:
-		if ((PORTB_SPECIAL_PINS & pin_mask) != 0) {
+		if ((PORTB_UNSUPPORTED_PINS & pin_mask) != 0) {
+			eic_line = INTC_LINE_FREE;
+		} else if ((PORTB_SPECIAL_PINS & pin_mask) != 0) {
 			eic_line += PORTB_SPECIAL_PINS_OFFSET;
+		} else {
+			/* Nothing to be done */
 		}
 		break;
 	case MCHP_PORT_ID2:

--- a/drivers/interrupt_controller/intc_mchp_eic_g1.c
+++ b/drivers/interrupt_controller/intc_mchp_eic_g1.c
@@ -355,7 +355,12 @@ int eic_mchp_config_interrupt(struct eic_config_params *eic_pin_config)
 	}
 
 	eic_data->lock = irq_lock();
-	if ((eic_data->line_busy & BIT(eic_line)) != 0) {
+	/* Reconfiguring the trigger of the pin that already owns this line is allowed;
+	 * only a different pin claiming a busy line is rejected.
+	 */
+	if (((eic_data->line_busy & BIT(eic_line)) != 0) &&
+	    ((eic_data->lines[eic_line].port != eic_pin_config->port_id) ||
+	     (eic_data->lines[eic_line].pin != pin))) {
 		irq_unlock(eic_data->lock);
 		LOG_ERR("EIC Line for port %d : %d is busy", eic_pin_config->port_id, pin);
 		return -EBUSY;

--- a/drivers/interrupt_controller/intc_mchp_eic_g1.c
+++ b/drivers/interrupt_controller/intc_mchp_eic_g1.c
@@ -262,7 +262,9 @@ int eic_mchp_disable_interrupt(struct eic_config_params *eic_pin_config)
 	if ((eic_data->line_busy & BIT(eic_line)) != 0) {
 		disable_interrupt_line(eic_cfg->regs, eic_line);
 	} else {
-		LOG_ERR("EIC Line is already free");
+		/* GPIO_INT_DISABLE on an unarmed pin is a no-op per API contract. */
+		LOG_DBG("EIC line for port %d : %d is already free", eic_pin_config->port_id,
+			eic_pin_config->pin_num);
 		return 0;
 	}
 

--- a/dts/bindings/interrupt-controller/microchip,eic-g1-intc.yaml
+++ b/dts/bindings/interrupt-controller/microchip,eic-g1-intc.yaml
@@ -15,6 +15,11 @@ description: |
    - GPIO pins that do not support external interrupts.
    - GPIO pins whose EIC line mapping differs from the default mapping.
 
+  An offset given by a *-special-pins-* property is applied within the sixteen
+  EXTINT lines of a port, so a sum that passes line 15 wraps back to line 0.
+  A pad whose line is below its default mapping is therefore reachable through
+  the complement of the distance, and needs no separate sign.
+
   Group g1 EIC supports following hardware peripherals:
     - module name="EIC" id="U2254" version="3.0.0"
 
@@ -102,6 +107,20 @@ properties:
     description: |
       Number of cells in portb-special-pins-1 property
 
+  portb-special-pins-2:
+    type: array
+    default: [0, 0]
+    description: |
+      Each bit in this number denotes a pin number. These pins are derived from datasheet
+      by listing down the eic line and port-pin mapping.
+      The eic line mapping to the pin number requires a manipulation with an offset.
+
+  "#portb-special-pins-2-cells":
+    type: int
+    default: 2
+    description: |
+      Number of cells in portb-special-pins-2 property
+
   portc-special-pins-1:
     type: array
     default: [0, 0]
@@ -155,6 +174,10 @@ properties:
       Number of cells in portd-special-pins-2 property
 
 portb-special-pins-1-cells:
+  - pins_val
+  - offset
+
+portb-special-pins-2-cells:
   - pins_val
   - offset
 


### PR DESCRIPTION
The EIC G1 line mapping cannot describe a pad whose EXTINT line sits below its default mapping, so PB12 and PB15 on this part are silently armed on the wrong line instead of being refused or mapped correctly.

## Two defects in one function

`find_eic_line_from_pin()` maps a pin as `pin % 16` plus at most one offset
per port.

**1. Port B ignored its own unsupported-pins property.** Ports A, C and D
refuse a pad the mapping cannot describe; port B computed a line for it and
reported success. On this die that is PB15 - pad EXTINT0 against a computed
15 - and PB12 - EXTINT2 against a computed 12. PB12's `-EBUSY` looked like a
check and was not: line 12 happened to be taken by PB11.

**2. An offset cannot point downwards.** The offset is added and the sum is
never bounded, so a pad whose EXTINT line sits below the pin it is derived
from cannot be described - the number that would reach it runs past line 15.
The binding worked around that by growing a second, subtracting group for
ports C and D; ports A and B never got one, which is why five pins on this
die had no interrupt at all.

The fix is arithmetic rather than another property: the offset wraps within a
port's sixteen lines, so a downward move is the complement of an upward one
and needs no sign. PB15 stops being special - it becomes an ordinary member
of port B's existing +1 group, because 15 + 1 is 0. Only PB12 still needs a
group of its own, so port B gains the `portb-special-pins-2` property that
ports C and D already have, defaulting to `[0, 0]`.

## Nothing in the tree changes meaning

Every additive group in every devicetree using this binding was checked pin
by pin: SAM D5x/E5x and PIC32CX SG have port B 26..29 at +2, port C 7 at +2
and port D 20..21 at +6; PIC32CM JH has port A 24|25|27 at +4 and port C 0..7
at +8. Not one of them reaches line 15, so not one of them wraps. The two
subtracting groups are left untouched.

## Evidence

Measured rather than argued. A PORT output drives four rising edges into one
pad at a time while all five listen on the EIC, so a pin armed on someone
else's line shows up as a count on the wrong name:

| wire | PB15 | PB12 | PD07 | PD08 | PD09 |
| --- | --- | --- | --- | --- | --- |
| none            | 0 | 0 | 0 | 0 | 0 |
| D1 -> D0        | 4 | 0 | 0 | 0 | 0 |
| D1 -> D5        | 0 | 4 | 0 | 0 | 0 |
| D1 -> D9        | 0 | 0 | 4 | 0 | 0 |
| EXT2 13 -> 9    | 0 | 0 | 0 | 4 | 0 |
| EXT2 13 -> 10   | 0 | 0 | 0 | 0 | 4 |

Before the change these five answered `-ENOTSUP` or were absent from the
supported mask. The two buttons and the port A probe are unaffected in every
run.

## A pin cannot rearm the line it already holds

`eic_mchp_config_interrupt()` answers `-EBUSY` for any line whose busy bit is
set, without asking who set it. The GPIO API is specified the other way round:
`gpio_pin_interrupt_configure()` may be called again on a pin whose interrupt is
already configured, to change its trigger, and a driver is expected to
reconfigure rather than refuse.

Measured with a jumper from Arduino D1 to D0, which is PB16 driving PB15.
`tests/drivers/gpio/gpio_basic_api`:

| Testcase | Before | After |
|---|---|---|
| `gpio_port.test_gpio_port` | PASS | PASS |
| `gpio_port_cb_mgmt.test_gpio_callback_add_remove` | FAIL | PASS |
| `gpio_port_cb_mgmt.test_gpio_callback_enable_disable` | PASS | PASS |
| `gpio_port_cb_mgmt.test_gpio_callback_self_remove` | FAIL | PASS |
| `gpio_port_cb_vari.test_gpio_callback_variants` | PASS | PASS |
| `after_flash_gpio_config_trigger` (two) | 1 FAIL, 1 SKIP | both SKIP |

Each failure was the second `gpio_pin_interrupt_configure()` on the same pin,
with `EIC Line for port 1 : 15 is busy` logged immediately before the assertion.
The two skips are the open-drain testcases, which this PORT cannot do either
way. The refusal is kept for the case it was written for: one EXTINT line is
shared across ports, so a line held by a pin of another port is a real conflict.

The same run printed `E: EIC Line is already free` 24 times, from the disable
path, for the legal no-op of disabling an interrupt nobody armed. That is the
second commit, and it changes nothing but the log level.

## Testing

`tests/drivers/gpio/gpio_basic_api` on hardware, on a port B pin above the
wrap, with the overlay `tests/overlays/gpio-pic32cm_gc00_cpro.overlay`: 5 pass,
0 fail, 2 skip. The two skips are the open-drain cases, which this pad does not
support. Measured on the branch tip, so the log-level commit is in the image
too, and its effect is visible: not one `E:` line from the EIC driver in the
whole run. The same suite before these commits printed
`E: EIC Line for port 1 : 15 is busy` three times, failing
`test_gpio_config_twice_trigger`, `test_gpio_callback_add_remove` and
`test_gpio_callback_self_remove`, and printed `E: EIC Line is already free`
twenty-four times, once for every disable the API itself calls successful.

The five-pin line mapping table above is the earlier bench run, taken with the
board's test jumpers fitted one wire at a time.

## Verification

Measured on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A), in a west
workspace at Zephyr 0d65ce46dda0 with this repository's patch queue
applied. The commits here are cut from current `main` and carry no other
patch.
