### PR TITLE
drivers: i2c: microchip: sercom g1: Reject an unreachable bitrate

### DIFF
--- a/drivers/i2c/i2c_mchp_sercom_g1.c
+++ b/drivers/i2c/i2c_mchp_sercom_g1.c
@@ -240,7 +240,10 @@ static void i2c_write_addr(const struct device *dev, uint16_t addr, bool is_read
 /* Calculates baud rate register values for requested I2C bitrate */
 static bool i2c_baudrate_calc(uint32_t bitrate, uint32_t sys_clock_rate, uint32_t *baud_val)
 {
-	uint32_t baud_value = 0U;
+	uint32_t baud_offset;
+	uint32_t baud_min;
+	uint32_t baud_max;
+	uint32_t baud_value;
 
 	/* Reference clock frequency must be at least two times the baud rate */
 	if (sys_clock_rate < (2U * bitrate)) {
@@ -251,54 +254,50 @@ static bool i2c_baudrate_calc(uint32_t bitrate, uint32_t sys_clock_rate, uint32_
 
 	if (bitrate > I2C_BITRATE_FAST_PLUS) {
 		/* HS mode baud calculation: BAUD = (f_ref / f_scl) - 2 */
-		baud_value = (sys_clock_rate / bitrate) - 2U;
+		baud_offset = 2U;
 	} else {
 		/* Standard, FM and FM+ baud calculation:
 		 * BAUD = (f_ref / f_scl) - ((f_ref * T_RISE_ns) / 1,000,000,000) - 10
 		 */
-		baud_value = (sys_clock_rate / bitrate) -
-			     ((sys_clock_rate * I2C_TRISE_DEFAULT_NS) / 1000000000U) - 10U;
+		baud_offset = ((sys_clock_rate * I2C_TRISE_DEFAULT_NS) / 1000000000U) + 10U;
 	}
 
 	if (bitrate <= I2C_BITRATE_FAST) {
 		/* For I2C clock speed up to 400 kHz, the value of BAUD<7:0>
 		 * determines both SCL_L and SCL_H with SCL_L = SCL_H
 		 */
-		if (baud_value > (I2C_BAUD_MAX * 2U)) {
-			/* Set baud rate to the maximum possible value */
-			baud_value = I2C_BAUD_MAX;
-		} else if (baud_value <= 1U) {
-			/* Baud value cannot be 0. Set baud rate to minimum possible */
-			baud_value = 1U;
-		} else {
-			baud_value /= 2U;
-		}
-
-		*baud_val = baud_value;
-
-		return true;
+		baud_min = 2U;
+		baud_max = I2C_BAUD_MAX * 2U;
+	} else {
+		/* To maintain the ratio of SCL_L:SCL_H to 2:1, the max value of
+		 * BAUD_LOW<15:8>:BAUD<7:0> can be 0xFF:0x7F. Hence BAUD_LOW + BAUD
+		 * can not exceed 255+127 = 382
+		 */
+		baud_min = 4U;
+		baud_max = I2C_BAUD_LOW_HIGH_MAX - 1U;
 	}
 
-	/* To maintain the ratio of SCL_L:SCL_H to 2:1, the max value of
-	 * BAUD_LOW<15:8>:BAUD<7:0> can be 0xFF:0x7F. Hence BAUD_LOW + BAUD
-	 * can not exceed 255+127 = 382
-	 */
-	if (baud_value >= I2C_BAUD_LOW_HIGH_MAX) {
-		/* Set baud rate to the maximum possible value while
-		 * maintaining SCL_L:SCL_H to 2:1
-		 */
-		baud_value = (0xFFUL << 8U) | (0x7FU);
-	} else if (baud_value <= 3U) {
-		/* Baud value cannot be 0. Set baud rate to minimum possible
-		 * value while maintaining SCL_L:SCL_H to 2:1
-		 */
-		baud_value = (2UL << 8U) | 1U;
+	/* Tested before the subtraction below, which would otherwise wrap */
+	if ((sys_clock_rate / bitrate) < (baud_offset + baud_min)) {
+		LOG_ERR("Reference clock %u Hz is too slow for I2C bitrate %u Hz", sys_clock_rate,
+			bitrate);
+		return false;
+	}
+
+	baud_value = (sys_clock_rate / bitrate) - baud_offset;
+
+	if (baud_value > baud_max) {
+		LOG_ERR("Reference clock %u Hz is too fast for I2C bitrate %u Hz", sys_clock_rate,
+			bitrate);
+		return false;
+	}
+
+	if (bitrate <= I2C_BITRATE_FAST) {
+		*baud_val = baud_value / 2U;
 	} else {
 		/* For Fm+ mode, I2C SCL_L:SCL_H to 2:1 */
-		baud_value = ((((baud_value * 2U) / 3U) << 8U) | (baud_value / 3U));
+		*baud_val = ((((baud_value * 2U) / 3U) << 8U) | (baud_value / 3U));
 	}
-
-	*baud_val = baud_value;
 
 	return true;
 }
@@ -383,7 +382,7 @@ static int i2c_apply_speed(const struct device *dev, uint32_t config)
 
 	if (!i2c_set_baudrate(dev, f_scl, f_ref)) {
 		LOG_ERR("Failed to set baudrate");
-		return -EIO;
+		return -EINVAL;
 	}
 
 	return 0;


### PR DESCRIPTION
The SERCOM G1 I2C driver clamps an unreachable bitrate and reports success: this board asked for 100 kHz and got 137.1 kHz on the wire, measured with a logic analyzer.

## What breaks

`i2c_baudrate_calc()` computes

    baud_value = (f_ref / bitrate) - (f_ref * T_RISE_ns / 1e9) - 10

and, when the result exceeds `2 * 255`, writes `BAUD = 255` and returns true.
That is not a fallback, it is the opposite of what was asked: `BAUD = 255` is
the slowest the register can express, so the bus runs as fast as the hardware
can get and the caller is told the configuration succeeded.

The same clamp swallows a second, opposite failure. The subtraction is
unsigned and the only guard in front of it is `sys_clock_rate < 2 * bitrate`,
while the formula needs roughly `f_ref >= 12 * bitrate`. Every reference
clock between 2x and about 12x the bitrate wraps the subtraction, trips the
same branch, and clamps to `BAUD = 255` again.

| request | f_ref | driver writes | SCL on the wire | error |
| --- | --- | --- | --- | --- |
| 100k | 72M | BAUD=255      | 137.7 kHz | +37.7% (measured 137.1 kHz) |
| 100k | 12M | BAUD=55       | 99.6 kHz  | -0.4% (measured 100.0 kHz) |
| 100k | 48M | BAUD=234      | 100.0 kHz | 0.0% |
| 400k | 72M | BAUD=84       | 398.1 kHz | -0.5% |
| 400k | 1M  | BAUD=255 wrap | 1.9 kHz   | -99.5% |

Standard-mode devices are specified to 100 kHz; the driver puts them 37%
over, with no diagnostic anywhere. Measured with a logic analyzer on EXT1
over 1044 SCL periods.

## This is a behaviour change, deliberately

Both saturating branches now log and return false, so a board asking for a
bitrate its reference clock cannot reach fails `i2c_configure()` instead of
running out of spec. Clamping downwards is left alone: a slower bus is always
within spec and a faster one is not.

The second commit is the follow-up that keeps the contract honest: the
refusal reached the caller as `-EIO`, which `i2c_configure()` reserves for a
transfer failure, and a caller that retries on `-EIO` would retry forever. A
configuration that cannot be satisfied is `-EINVAL`. The other `-EIO` in the
same function is left alone - a reference clock that reads back as zero
really is a failure to talk to the hardware.

## Testing

`tests/drivers/i2c/i2c_api` on hardware, plus an analyzer capture of the
clamped case. On the target the driver now prints "I2C bitrate 100000 Hz is
out of range for a 72000000 Hz reference clock" and the device comes up
DISABLED instead of silently running at 137 kHz.

Re-measured on the bench with a Saleae Logic Pro 8 on SDA and SCL, driving
the bus from the `i2c` shell on a `samples/hello_world` image, `i2c scan`
clocking all 128 addresses while the analyzer recorded at 50 MS/s:

| Asked for | SCL measured | SCL low |
|---|---|---|
| `I2C_SPEED_STANDARD`, 100 kHz | 100.00 kHz | 50% |
| `I2C_SPEED_FAST`, 400 kHz | 400.00 kHz | 51% |
| `I2C_SPEED_FAST_PLUS`, 1 MHz | 925.93 kHz | 56% |
| `I2C_SPEED_HIGH`, 3.4 MHz | 400.00 kHz | 51% |
| `I2C_SPEED_ULTRA`, 5 MHz | refused | - |

Fast plus lands below what was asked rather than above it, which is the safe
direction: the bitrate names a ceiling. High speed shows the fast-mode rate
because a scan never sends the master code that enters the high-speed phase,
and the driver keeps that rate in the low half of BAUD by design. Ultra is
answered "Unsupported speed: 5" and `i2c_configure()` fails.

The refusal was measured too, by putting SERCOM1's core clock back on GCLK0 at
72 MHz - the arrangement that produced the 137 kHz clamp - and rebuilding. The
device comes up `DISABLED` and the shell answers "Device driver
sercom@4480a000 not found", so the configuration that used to run 37% out of
spec now does not run at all. The 137.1 kHz figure itself is the earlier
capture against the unpatched driver and was not reproduced today.

`tests/drivers/i2c/i2c_api` still does not run here: it needs an `i2c-0` alias
with a device on the bus, and nothing is wired to this one.

## Verification

Measured on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A), in a west
workspace at Zephyr 0d65ce46dda0 with this repository's patch queue
applied. The commits here are cut from current `main` and carry no other
patch.
