### PR TITLE
drivers: pwm: microchip: tcc g1: Fix duty cycle, polarity and SYNCBUSY

### DIFF
--- a/drivers/pwm/pwm_mchp_tcc_g1.c
+++ b/drivers/pwm/pwm_mchp_tcc_g1.c
@@ -209,8 +209,10 @@ static inline void tcc_enable(void *pwm_reg, bool enable)
 static inline void tcc_sync_wait(void *pwm_reg)
 {
 
-	if (!WAIT_FOR(((PWM_REG(pwm_reg)->TCC_SYNCBUSY) != 0), TIMEOUT_VALUE_US,
-		      k_busy_wait(DELAY_US))) {
+	bool sync_done = WAIT_FOR(((PWM_REG(pwm_reg)->TCC_SYNCBUSY) == 0), TIMEOUT_VALUE_US,
+				  k_busy_wait(DELAY_US));
+
+	if (sync_done == false) {
 		LOG_ERR("TCC_SYNCBUSY wait timed out");
 	}
 	LOG_DBG("%s invoked", __func__);

--- a/drivers/pwm/pwm_mchp_tcc_g1.c
+++ b/drivers/pwm/pwm_mchp_tcc_g1.c
@@ -105,6 +105,14 @@ typedef enum {
 } pwm_mchp_flags_t;
 
 /**
+ * @brief Output polarity of a PWM channel.
+ */
+typedef enum {
+	PWM_MCHP_POLARITY_NORMAL,
+	PWM_MCHP_POLARITY_INVERTED,
+} pwm_mchp_polarity_t;
+
+/**
  * @brief Structure to hold PWM data specific to Microchip hardware.
  */
 typedef struct {
@@ -209,18 +217,22 @@ static inline void tcc_sync_wait(void *pwm_reg)
 }
 
 /**
- *Set the output inversion for a specific PWM channel.
+ *Set the output polarity for a specific PWM channel.
  */
-static int32_t tcc_set_invert(void *pwm_reg, uint32_t channel)
+static int32_t tcc_set_polarity(void *pwm_reg, uint32_t channel, pwm_mchp_polarity_t polarity)
 {
 	uint32_t invert_mask = 1 << (channel + TCC_DRVCTRL_INVEN0_Pos);
 
 	tcc_enable(pwm_reg, false);
 	tcc_sync_wait(pwm_reg);
-	PWM_REG(pwm_reg)->TCC_DRVCTRL |= invert_mask;
+	if (polarity == PWM_MCHP_POLARITY_INVERTED) {
+		PWM_REG(pwm_reg)->TCC_DRVCTRL |= invert_mask;
+	} else {
+		PWM_REG(pwm_reg)->TCC_DRVCTRL &= ~invert_mask;
+	}
 	tcc_enable(pwm_reg, true);
 	tcc_sync_wait(pwm_reg);
-	LOG_DBG("tcc set invert 0x%x invoked", invert_mask);
+	LOG_DBG("tcc set invert 0x%x to %d invoked", invert_mask, (int)polarity);
 
 	return MCHP_PWM_SUCCESS;
 }
@@ -240,9 +252,9 @@ void tcc_init(void *pwm_reg, uint32_t prescaler)
 }
 
 /**
- *Get the output inversion status for a specific PWM channel.
+ *Get the output polarity for a specific PWM channel.
  */
-static inline bool tcc_get_invert_status(void *pwm_reg, uint32_t channel)
+static inline pwm_mchp_polarity_t tcc_get_polarity(void *pwm_reg, uint32_t channel)
 {
 	uint32_t invert_status = 0;
 	uint32_t invert_mask = 1 << (channel + TCC_DRVCTRL_INVEN0_Pos);
@@ -250,7 +262,7 @@ static inline bool tcc_get_invert_status(void *pwm_reg, uint32_t channel)
 	LOG_DBG("tcc get invert status 0x%x invoked", invert_mask);
 	invert_status = PWM_REG(pwm_reg)->TCC_DRVCTRL & invert_mask;
 
-	return (invert_status == 0) ? true : false;
+	return (invert_status == 0) ? PWM_MCHP_POLARITY_NORMAL : PWM_MCHP_POLARITY_INVERTED;
 }
 
 /***********************************
@@ -275,32 +287,33 @@ static int pwm_mchp_set_cycles(const struct device *pwm_dev, uint32_t channel, u
 {
 	const pwm_mchp_config_t *const mchp_pwm_cfg = pwm_dev->config;
 	pwm_mchp_data_t *mchp_pwm_data = pwm_dev->data;
-	int ret_val = -EINVAL;
 	uint32_t top = (BIT(mchp_pwm_cfg->max_bit_width) - 1);
-
-	MCHP_PWM_DATA_LOCK(&mchp_pwm_data->lock);
+	pwm_mchp_polarity_t requested_polarity = ((flags & PWM_POLARITY_INVERTED) != 0)
+							 ? PWM_MCHP_POLARITY_INVERTED
+							 : PWM_MCHP_POLARITY_NORMAL;
 
 	if (channel >= mchp_pwm_cfg->channels) {
 		LOG_ERR("channel %d is invalid", channel);
-	} else if ((period > top) || (pulse > top)) {
-		LOG_ERR("period or pulse is out of range");
-	} else {
-
-		bool invert_flag_set = ((flags & PWM_POLARITY_INVERTED) != 0);
-		bool not_inverted = tcc_get_invert_status(mchp_pwm_cfg->regs, channel);
-
-		if ((invert_flag_set == true) && (not_inverted == true)) {
-			tcc_set_invert(mchp_pwm_cfg->regs, channel);
-		}
-
-		PWM_REG(mchp_pwm_cfg->regs)->TCC_CCBUF[channel] = TCC_CCBUF_CCBUF(pulse);
-		PWM_REG(mchp_pwm_cfg->regs)->TCC_PER = TCC_PER_PER(period);
-		ret_val = MCHP_PWM_SUCCESS;
+		return -EINVAL;
 	}
+
+	if ((period > top) || (pulse > top)) {
+		LOG_ERR("period or pulse is out of range");
+		return -EINVAL;
+	}
+
+	MCHP_PWM_DATA_LOCK(&mchp_pwm_data->lock);
+
+	if (tcc_get_polarity(mchp_pwm_cfg->regs, channel) != requested_polarity) {
+		tcc_set_polarity(mchp_pwm_cfg->regs, channel, requested_polarity);
+	}
+
+	PWM_REG(mchp_pwm_cfg->regs)->TCC_CCBUF[channel] = TCC_CCBUF_CCBUF(pulse);
+	PWM_REG(mchp_pwm_cfg->regs)->TCC_PER = TCC_PER_PER(period);
 
 	MCHP_PWM_DATA_UNLOCK(&mchp_pwm_data->lock);
 
-	return ret_val;
+	return MCHP_PWM_SUCCESS;
 }
 
 /**

--- a/drivers/pwm/pwm_mchp_tcc_g1.c
+++ b/drivers/pwm/pwm_mchp_tcc_g1.c
@@ -290,6 +290,7 @@ static int pwm_mchp_set_cycles(const struct device *pwm_dev, uint32_t channel, u
 	const pwm_mchp_config_t *const mchp_pwm_cfg = pwm_dev->config;
 	pwm_mchp_data_t *mchp_pwm_data = pwm_dev->data;
 	uint32_t top = (BIT(mchp_pwm_cfg->max_bit_width) - 1);
+	uint32_t ccbuf_val = pulse;
 	pwm_mchp_polarity_t requested_polarity = ((flags & PWM_POLARITY_INVERTED) != 0)
 							 ? PWM_MCHP_POLARITY_INVERTED
 							 : PWM_MCHP_POLARITY_NORMAL;
@@ -310,7 +311,11 @@ static int pwm_mchp_set_cycles(const struct device *pwm_dev, uint32_t channel, u
 		tcc_set_polarity(mchp_pwm_cfg->regs, channel, requested_polarity);
 	}
 
-	PWM_REG(mchp_pwm_cfg->regs)->TCC_CCBUF[channel] = TCC_CCBUF_CCBUF(pulse);
+	if (pulse >= period) {
+		ccbuf_val = (period < top) ? (period + 1) : period;
+	}
+
+	PWM_REG(mchp_pwm_cfg->regs)->TCC_CCBUF[channel] = TCC_CCBUF_CCBUF(ccbuf_val);
 	PWM_REG(mchp_pwm_cfg->regs)->TCC_PER = TCC_PER_PER(period);
 
 	MCHP_PWM_DATA_UNLOCK(&mchp_pwm_data->lock);


### PR DESCRIPTION
Three defects in the TCC G1 PWM driver we hit on this board: an inverted SYNCBUSY wait, a polarity bit that is set and never cleared, and a one-tick glitch at full duty measured on hardware.

## Three defects in one driver

Separate commits, one subject: the TCC G1 PWM driver on a part where all
three are reachable from the PWM API.

**1. The synchronization wait is inverted.** `tcc_sync_wait()` waits for
`TCC_SYNCBUSY != 0`, so it returns immediately when a write is pending -
exactly when waiting was needed - and spins the whole timeout, logging an
error, when none is. This board printed two of those per boot. The watchdog
driver's equivalent has the comparison the right way round.

**2. Inverted polarity is set and never cleared.** `pwm_mchp_set_cycles()`
sets `DRVCTRL.INVEN` for `PWM_POLARITY_INVERTED` and has no path back, so a
channel that has once been inverted stays inverted until a reset.

**3. Full duty glitches once per period.** `CCBUF = pulse`, and in
single-slope mode the output is active while `COUNT < CC`, so `pulse ==
period` leaves one counter tick per period at the inactive level. The PWM API
requires `pulse == period` to mean a constant active level. Writing
`period + 1` restores that; when `period` is already the counter maximum,
`period + 1` would wrap the field to 0 and turn the output fully off, so that
corner keeps the single-tick glitch as the lesser defect.

## Evidence

Polarity, TCC3 WO0 on Arduino D3, captured with a logic analyzer:

|                       | unpatched | patched |
| --- | --- | --- |
| flags = 0 (start)     | 25.1%     | 25.1%   |
| flags = 1 (inverted)  | 74.9%     | 74.9%   |
| flags = 0 (back)      | 74.9%     | 25.0%   |

Full duty, TCC3 WO1 on Arduino D6 jumpered to A3 and watched by the analog
comparator as a glitch detector, threshold at DAC step 64, both edges, 100 Hz:

|              | unpatched | patched |
| --- | --- | --- |
| edges in 3 s | 350       | 0       |
| get_output   | 1         | 1       |

350 edges in 3 s at 100 Hz is one glitch per PWM period. The glitch is one
tick out of 45000, which is why sampling it with the ADC practically never
catches it.

The waveform is unchanged by the synchronization fix (1000.6 Hz at 25.0%), so
that one costs nothing but the error message.

## Testing

`tests/drivers/pwm/pwm_api` on hardware, with the board overlay this PR
carries.

Run on the board: `pwm_basic` pass = 3, fail = 0, skip = 0, total = 3
(`test_pwm_cycle`, `test_pwm_nsec`, `test_pwm_invalid_port`).

## Verification

Measured on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A), in a west
workspace at Zephyr 0d65ce46dda0 with this repository's patch queue
applied. The commits here are cut from current `main` and carry no other
patch.
