### PR TITLE
drivers: watchdog: microchip: g1: Fix the synchronization wait and the properties

### DIFF
--- a/drivers/watchdog/wdt_mchp_g1.c
+++ b/drivers/watchdog/wdt_mchp_g1.c
@@ -16,10 +16,15 @@
 LOG_MODULE_REGISTER(wdt_mchp_g1, CONFIG_WDT_LOG_LEVEL);
 
 #define WDT_LOCK_TIMEOUT              K_MSEC(10)
-#define MAX_INSTALLABLE_TIMEOUT_COUNT (DT_PROP(DT_NODELABEL(wdt), max_installable_timeout_count))
-#define MAX_TIMEOUT_WINDOW            (DT_PROP(DT_NODELABEL(wdt), max_timeout_window))
-#define MAX_TIMEOUT_WINDOW_MODE       (DT_PROP(DT_NODELABEL(wdt), max_timeout_window_mode))
-#define MIN_WINDOW_LIMIT              (DT_PROP(DT_NODELABEL(wdt), min_window_limit))
+/*
+ * DT_INST_PROP, not DT_NODELABEL(wdt): the label is only a convention, not
+ * guaranteed by the binding. only_one_timeout_val_supported_flag below still
+ * relies on the label and is left alone.
+ */
+#define MAX_INSTALLABLE_TIMEOUT_COUNT (DT_INST_PROP(0, max_installable_timeout_count))
+#define MAX_TIMEOUT_WINDOW            (DT_INST_PROP(0, max_timeout_window))
+#define MAX_TIMEOUT_WINDOW_MODE       (DT_INST_PROP(0, max_timeout_window_mode))
+#define MIN_WINDOW_LIMIT              (DT_INST_PROP(0, min_window_limit))
 #define WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED                                                  \
 	(DT_PROP(DT_NODELABEL(wdog), only_one_timeout_val_supported_flag))
 

--- a/drivers/watchdog/wdt_mchp_g1.c
+++ b/drivers/watchdog/wdt_mchp_g1.c
@@ -38,7 +38,11 @@ LOG_MODULE_REGISTER(wdt_mchp_g1, CONFIG_WDT_LOG_LEVEL);
  * left-shifting the number 8 by `n` positions. The result of this macro is 8 * 2^n.
  */
 #define PERIOD_VALUE(n)  (8 << n)
-#define TIMEOUT_VALUE_US 1000
+/* Clocked from the ~1.024 kHz internal ULP oscillator: synchronization takes
+ * milliseconds, measured at 1.12 ms on PIC32CM GC00. A shorter timeout lets
+ * register writes race a still-syncing peripheral and get discarded.
+ */
+#define TIMEOUT_VALUE_US 5000
 #define DELAY_US         2
 
 typedef enum {

--- a/drivers/watchdog/wdt_mchp_g1.c
+++ b/drivers/watchdog/wdt_mchp_g1.c
@@ -465,8 +465,12 @@ static int wdt_mchp_install_timeout(const struct device *wdt_dev, const struct w
 	channel_data[mchp_wdt_data->installed_timeout_cnt].window.min =
 		actual_set_timeout.window.min;
 
-	LOG_ERR("Rounded off timeout min to %d\nRounded off timeout max to %d",
-		actual_set_timeout.window.min, actual_set_timeout.window.max);
+	if ((actual_set_timeout.window.min != cfg->window.min) ||
+	    (actual_set_timeout.window.max != cfg->window.max)) {
+		LOG_WRN("timeout rounded: min %u to %u ms, max %u to %u ms", cfg->window.min,
+			actual_set_timeout.window.min, cfg->window.max,
+			actual_set_timeout.window.max);
+	}
 
 	/* this will return the channel id and then increment the
 	 * count which will then be used for the next channel.


### PR DESCRIPTION
The G1 watchdog driver only compiles against a devicetree that labels its node exactly 'wdt', waits one millisecond for a synchronization that takes 1.12 ms, and reports a by-design rounding as an error.

## Three defects in one driver

**1. Four properties are read through a hardcoded node label.**
`DT_PROP(DT_NODELABEL(wdt), ...)` compiles only against a devicetree that
labels the node exactly `wdt`. Nothing in the binding says so, and a board
that picks another label gets an unknown-node error out of the devicetree
macros rather than anything pointing at the cause. They become
`DT_INST_PROP(0, ...)`: the four size a structure and bound a loop at compile
time, so they cannot vary per instance without a larger change, and index 0
keeps that restriction exactly as it is.

**2. The synchronization timeout is shorter than one synchronization.**
`TIMEOUT_VALUE_US` is 1000 while the watchdog is clocked from the internal
ultra low power oscillator at about 1.024 kHz. Measured with an instrumented
build: the two CONFIG writes complete in under 2 us because the register is
not yet busy, and the enable takes 1120 us - just over the timeout, on every
boot. The wait then returns while the peripheral is still synchronizing and
the driver carries on writing registers the hardware discards, so the
configuration that ends up in the watchdog is not the one that was asked for.
5 ms covers the measured value with margin and costs nothing on a part that
synchronizes faster, because the wait ends on the flag.

**3. A rounded timeout is reported as an error.** The message is `LOG_ERR`,
fires whether or not anything was rounded, and embeds a newline mid-line.
Rounding is by design; it now warns only when a value really changed, and
names what was asked for beside what was installed.

## Left alone deliberately

The neighbouring `WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED` reads
`only_one_timeout_val_supported_flag` from `DT_NODELABEL(wdog)`, a label no
devicetree in the tree defines, and the property appears in no binding. It
survives only because it is tested with `#if defined()`, which is true for
any object-like macro, so the code it guards is compiled unconditionally and
the macro itself is never expanded. Making that guard honest would change
behaviour on every part this driver serves, which is not a change to make
from one board - but a maintainer should look at it.

## Testing

`tests/drivers/watchdog/wdt_basic_api` on hardware. Note the suite keeps its
progress in `.noinit`, and on this family the Boot ROM clears the bottom of
SRAM, so it is run with `CONFIG_TEST_WDT_NOINIT_SECTION` pointed at a
retained region.

Run on the board with `-S retained-ram` and
`CONFIG_TEST_WDT_NOINIT_SECTION="RETAINED_RAM"` (16 B used of a 4 KB
region): `wdt_basic_test_suite` pass = 1, fail = 0, skip = 0, total = 1.
`test_wdt_no_callback` resets the part and completes across the reset;
`test_wdt_callback_1` reports the interrupt path as unsupported, which is
what this family's WDT offers.

## Verification

Measured on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A), in a west
workspace at Zephyr 0d65ce46dda0 with this repository's patch queue
applied. The commits here are cut from current `main` and carry no other
patch.
