### PR TITLE
mgmt: mcumgr: transport: serial: Fix unaligned frame header read

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/serial_util.c
+++ b/subsys/mgmt/mcumgr/transport/src/serial_util.c
@@ -158,7 +158,7 @@ struct net_buf *mcumgr_serial_process_frag(struct mcumgr_serial_rx_ctxt *rx_ctxt
 			return NULL;
 		}
 
-		op = sys_be16_to_cpu(*(uint16_t *)frag);
+		op = sys_get_be16(frag);
 		switch (op) {
 		case MCUMGR_SERIAL_HDR_PKT:
 			net_buf_reset(rx_ctxt->nb);


### PR DESCRIPTION
The mcumgr serial transport reads the frame header through an unaligned pointer, which faults on an ARMv8-M Baseline core - this die is a Cortex-M23 - and leaves DFU over the console unusable.

## What breaks

An MCUmgr image upload over the shell transport hard faults the device: a
fault in the `shell_uart` thread, then a watchdog reset. It reads as a silent
transport, because the board is back and answering before a host retries.

`image state read` worked every time, which is what made this look like a
configuration problem for five wrong hypotheses. A request that fits one
framing line uses the first buffer of the pool, which is aligned. An upload
cannot fit one line - its first request carries `image`, `len`, `off` and a
32-byte `sha` before any image data - so it reaches the second buffer, which
starts on an odd address, and faults.

## Why the second buffer is odd

`frag` points into a `net_buf` from the pool `subsys/shell/backends/
shell_uart.c` defines with a data size of `SMP_SHELL_RX_BUF_SIZE` = 127.
`NET_BUF_POOL_FIXED_DEFINE` aligns the array but strides its rows by the data
size, so an odd stride puts every other buffer on an odd address.

ARMv7-M fixes an unaligned 16-bit load up in hardware, which is why this has
gone unnoticed on Cortex-M3, M4 and M33. ARMv8-M Baseline does not, and this
is a Cortex-M23.

## Scope

`sys_get_be16()` is the alignment-safe read the rest of the tree uses for
exactly this. The fix is deliberately independent of the buffer size:
`SMP_SHELL_RX_BUF_SIZE` is a hardcoded macro rather than a Kconfig symbol, so
no application can round the stride up to avoid the fault. It makes the
MCUmgr serial and shell transports work on every ARMv8-M Baseline part, not
only this one.

## Testing

Faulting PC resolves to `serial_util.c:161`, called from `smp_shell_process`
at `smp_shell.c:213`, thread `shell_uart`. With the fix a 163260-byte image
uploads in 32 s at 115200 baud, MCUboot swaps it, an unconfirmed image
reverts on the next reset and a confirmed one stays.

Re-run on 2026-08-18 with an MCUboot plus signed blinky pair programmed as
one merged hex, driven from the host by `smpclient` over the board's virtual
COM port: the image list answers slot 0, version 0.1.0, confirmed and active,
and an upload of `zephyr.signed.bin` moved 163239 bytes into slot 1 in 31.1 s
with no fault. Every one of those frames goes through
`mcumgr_serial_process_frag`, which is the function this changes.

## Verification

Measured on a PIC32CM5112GC00100 Curiosity Pro (EV17V75A), in a west
workspace at Zephyr 0d65ce46dda0 with this repository's patch queue
applied. The commits here are cut from current `main` and carry no other
patch.

Fixes #117014