### PR TITLE
ipc: ipc_service: icbmsg: Fix potential maybe-uninitialized warning

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -482,7 +482,7 @@ static int heap_alloc_tx_buffer(const struct device *instance, struct ept_data *
 	}
 
 	while (true) {
-		int off;
+		int off = 0;
 
 		K_SPINLOCK(&data->lock) {
 			off = bitmask_find_gap(data->tx_usage_mask, num_blocks,


### PR DESCRIPTION
off variable is always set in K_SPINLOCK block but still strict compiler may complain about potential use of uninitilized variable.