### PR TITLE
soc: nordic: flpr: ppr: Keep CBPRINTF_CONVERT_CHECK_PTR disabled

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuflpr
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuflpr
@@ -10,4 +10,8 @@ config NUM_IRQS
 config ASSERT
 	default n
 
+# This check takes more than 650 bytes.
+config CBPRINTF_CONVERT_CHECK_PTR
+	default n if !XIP
+
 endif # SOC_NRF54H20_CPUFLPR

--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
@@ -11,4 +11,8 @@ config NUM_IRQS
 config ASSERT
 	default n
 
+# This check takes more than 650 bytes.
+config CBPRINTF_CONVERT_CHECK_PTR
+	default n if !XIP
+
 endif # SOC_NRF54H20_CPUPPR

--- a/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l_05_10_15_cpuflpr
+++ b/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l_05_10_15_cpuflpr
@@ -12,4 +12,8 @@ config NUM_IRQS
 config ASSERT
 	default n
 
+# This check takes more than 650 bytes.
+config CBPRINTF_CONVERT_CHECK_PTR
+	default n if !XIP
+
 endif # SOC_NRF54L05_CPUFLPR || SOC_NRF54L10_CPUFLPR || SOC_NRF54L15_CPUFLPR

--- a/soc/nordic/nrf54l/Kconfig.defconfig.nrf54lm20_a_b_cpuflpr
+++ b/soc/nordic/nrf54l/Kconfig.defconfig.nrf54lm20_a_b_cpuflpr
@@ -8,4 +8,8 @@ if SOC_NRF54LM20A_CPUFLPR || SOC_NRF54LM20B_CPUFLPR
 config NUM_IRQS
 	default 287
 
+# This check takes more than 650 bytes.
+config CBPRINTF_CONVERT_CHECK_PTR
+	default n if !XIP
+
 endif # SOC_NRF54LM20A_CPUFLPR || SOC_NRF54LM20B_CPUFLPR

--- a/soc/nordic/nrf71/Kconfig.defconfig.nrf7120_enga_cpuflpr
+++ b/soc/nordic/nrf71/Kconfig.defconfig.nrf7120_enga_cpuflpr
@@ -14,4 +14,8 @@ config NUM_IRQS
 config ASSERT
 	default n
 
+# This check takes more than 650 bytes.
+config CBPRINTF_CONVERT_CHECK_PTR
+	default n if !XIP
+
 endif # SOC_NRF7120_ENGA_CPUFLPR || SOC_NRF7120E_ENGA_CPUFLPR


### PR DESCRIPTION
CONFIG_CBPRINTF_CONVERT_CHECK_PTR is by default enabled and allows to detect use of %p with char pointer in logging macros. It's benefitial but takes
>650 bytes of code and VPR cores have little memory.