### PR TITLE
task_wdt: relax the timeout Kconfig ranges

### DIFF
--- a/subsys/task_wdt/Kconfig
+++ b/subsys/task_wdt/Kconfig
@@ -41,7 +41,7 @@ config TASK_WDT_MIN_TIMEOUT
 	int "Minimum timeout for task watchdog (ms)"
 	depends on TASK_WDT_HW_FALLBACK
 	default 100
-	range 1 10000
+	range 1 2147483647
 	help
 	  The task watchdog uses a continuously restarted k_timer as its
 	  backend. This value specifies the minimum timeout in milliseconds
@@ -51,11 +51,15 @@ config TASK_WDT_MIN_TIMEOUT
 	  watchdog, its timeout is set to this value plus
 	  TASK_WDT_HW_FALLBACK_DELAY.
 
+	  The Kconfig range only bounds the value by what an int can hold. The
+	  timeout that can actually be installed is limited by the hardware
+	  watchdog, which rejects a window it cannot represent.
+
 config TASK_WDT_HW_FALLBACK_DELAY
 	int "Additional delay for hardware watchdog (ms)"
 	depends on TASK_WDT_HW_FALLBACK
 	default 20
-	range 1 10000
+	range 1 2147483647
 	help
 	  The timeout of the hardware watchdog fallback will be increased by
 	  this value to provide sufficient time for corrective actions in the

--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -134,8 +134,8 @@ int task_wdt_init(const struct device *hw_wdt)
 
 		wdt_config.flags = WDT_FLAG_RESET_SOC;
 		wdt_config.window.min = 0U;
-		wdt_config.window.max = CONFIG_TASK_WDT_MIN_TIMEOUT +
-			CONFIG_TASK_WDT_HW_FALLBACK_DELAY;
+		wdt_config.window.max = (uint32_t)CONFIG_TASK_WDT_MIN_TIMEOUT +
+					(uint32_t)CONFIG_TASK_WDT_HW_FALLBACK_DELAY;
 		wdt_config.callback = NULL;
 
 		hw_wdt_dev = hw_wdt;


### PR DESCRIPTION
Raises the upper Kconfig bound of `TASK_WDT_MIN_TIMEOUT` and
`TASK_WDT_HW_FALLBACK_DELAY` from 10 s to `INT_MAX` ms, and computes the
hardware fallback window as an unsigned value so that the wider range cannot
overflow it.

The 10 s cap prevents applications with long liveness intervals from
expressing their timeout at all, even though both the `k_timer` backend and
typical hardware watchdogs support far longer windows. On nRF devices the
watchdog accepts a window up to `NRF_WDT_RR_VALUE_MS` (`0x07CFFFFF` ms, more
than a day), so the Kconfig range was tighter than the hardware by four
orders of magnitude.

### Why `INT_MAX` and not a derived bound

`wdt_timeout_cfg.window.max` is a `uint32_t` and both symbols are Kconfig
`int`s, so the only bound Kconfig can state meaningfully is the range of an
`int`. Anything tighter would be as arbitrary as the 10 s it replaces, and it
would still not be the real limit: that belongs to the device, and
`wdt_install_timeout()` already rejects a window the hardware cannot
represent. The help text now says so.

The first commit is a prerequisite for the second. `window.max` was computed
as `CONFIG_TASK_WDT_MIN_TIMEOUT + CONFIG_TASK_WDT_HW_FALLBACK_DELAY`, an
addition of two `int`s, so the wider range would have made a signed overflow
reachable. Carrying the sum out in `uint32_t` keeps the largest pair the two
symbols allow representable.

### In-tree impact

No in-tree consumer depends on the old cap. `samples/subsys/task_wdt` sets
500 ms, five STM32 `Kconfig.defconfig` files raise
`TASK_WDT_HW_FALLBACK_DELAY` to at most 750 ms, and the `ti,tps382x` binding
mentions 850/750 ms in a comment. Raising the upper bound cannot invalidate
an existing configuration.

### Testing

There is no `tests/subsys/task_wdt` in tree, so `samples/subsys/task_wdt` is
the only coverage; its `tests.yaml` carries a `console` harness that twister
can run against hardware.

Verification on an nRF54L15 with `CONFIG_TASK_WDT_MIN_TIMEOUT=300000` is
still outstanding and will be added here before the draft is lifted.
