### PR TITLE
doc: doxyxref: match how :kconfig:option: handles missing options

### DIFF
--- a/doc/_extensions/zephyr/doxyxref.py
+++ b/doc/_extensions/zephyr/doxyxref.py
@@ -21,7 +21,8 @@ remain valid wherever the documentation set is hosted (docs.zephyrproject.org/la
 copies, local builds, downstream distributions, ...).
 
 Placeholders that cannot be resolved are left untouched (they degrade to plain, code-styled text)
-and a Sphinx warning is emitted for each of them.
+and a Sphinx warning is emitted for each of them, except for Kconfig options that exist but are
+not part of the Kconfig reference.
 
 Configuration options
 =====================
@@ -188,6 +189,26 @@ def resolve(inventory: Inventory, stype: str, raw_target: str) -> Xref:
     return Xref(stype, target, item.uri, text)
 
 
+def degrades_silently(xref: Xref, kconfig_names: set[str] | None) -> bool:
+    """Whether an unresolved cross-reference is expected rather than a mistake.
+
+    Only documented Kconfig options are part of the object inventory, and none of them is when
+    Kconfig was not parsed at all.
+
+    Args:
+        xref: Cross-reference that could not be resolved.
+        kconfig_names: Names of all the Kconfig options that exist, or ``None`` if Kconfig was not
+            parsed in this build.
+
+    Returns:
+        Whether the reference may be left unresolved without warning.
+    """
+    if not xref.stype.startswith("kconfig:"):
+        return False
+
+    return kconfig_names is None or xref.target in kconfig_names
+
+
 def render_link(tag: str, xref: Xref, url_base: str) -> str:
     """Render a resolved :class:`Xref` as an HTML anchor.
 
@@ -300,6 +321,8 @@ def doxyxref_resolve(app, exception) -> None:
         logger.warning(f"doxyxref: could not read object inventory {inventory_file}: {e}")
         return
 
+    kconfig_names = getattr(app.env, "kconfig_all_names", None)
+
     for project, project_outdir in (app.config.doxyxref_projects or {}).items():
         html_dir = Path(project_outdir) / "html"
         if not html_dir.is_dir():
@@ -308,7 +331,8 @@ def doxyxref_resolve(app, exception) -> None:
 
         logger.info(f"doxyxref: resolving Sphinx cross-references for project '{project}'...")
         unresolved = process_html_dir(html_dir, inventory, docs_root=outdir)
-        for stype, target in sorted({(xref.stype, xref.target) for xref in unresolved}):
+        reportable = {xref for xref in unresolved if not degrades_silently(xref, kconfig_names)}
+        for stype, target in sorted({(xref.stype, xref.target) for xref in reportable}):
             logger.warning(
                 f"doxyxref: unresolved {stype} cross-reference: '{target}' (project '{project}')",
                 type="doxyxref",

--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -375,6 +375,8 @@ def kconfig_build_resources(app: Sphinx) -> None:
     """Build the Kconfig database and install HTML resources."""
 
     if not app.config.kconfig_generate_db:
+        # nothing was parsed, so no Kconfig reference can be resolved in this build
+        app.env.kconfig_all_names = None  # type: ignore
         return
 
     with progress_message("Building Kconfig database..."):
@@ -513,6 +515,15 @@ def kconfig_build_resources(app: Sphinx) -> None:
                     )
 
         app.env.kconfig_db = db  # type: ignore
+
+        # the database above only holds documented symbols; keep every name too, so that a
+        # reference to an undocumented option can be told apart from one to a nonexistent option
+        app.env.kconfig_all_names = {  # type: ignore
+            f"{kconfig_obj.config_prefix}{sc.name}"
+            for kconfig_obj in (kconfig, sysbuild_kconfig)
+            for sc in chain(kconfig_obj.unique_defined_syms, kconfig_obj.unique_choices)
+            if sc.name
+        }
 
         outdir = Path(app.outdir) / "kconfig"
         outdir.mkdir(exist_ok=True)


### PR DESCRIPTION
`@kconfig{CONFIG_FOO}` in a Doxygen comment is held to a stricter standard than `` :kconfig:option:`CONFIG_FOO` `` in an RST file, for the very same option. Options with neither prompt nor help are deliberately left out of the Kconfig reference and so never make it into `objects.inv`; where the role quietly renders plain text, `doxyxref` warns, which fails the build under `-W`.

The Kconfig extension now exports the names of all the options it parsed, and `doxyxref` only warns when the target is not one of them: typos and removed options are still caught. Same treatment when the Kconfig layer is skipped entirely (`make html-fast SKIP_KCONFIG=1`), where nothing Kconfig-related can resolve.

Unblocks #116397.
