### PR TITLE
.gitignore: Ignore MPLAB IPE runner log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ ZephyrModuleFile.txt
 
 # Node dependecies
 node_modules
+
+# Log file from mplab_ipe runner
+MPLABXLog.xml


### PR DESCRIPTION
This PR adds a .gitignore entry for MPLABXLog.xml, which is generated by the MPLAB IPE runner when running west flash.