### PR TITLE
drivers: ptp_clock: nxp: qos: use common compatible

### DIFF
--- a/drivers/ptp_clock/Kconfig.nxp_enet_qos
+++ b/drivers/ptp_clock/Kconfig.nxp_enet_qos
@@ -4,7 +4,7 @@
 config PTP_CLOCK_NXP_ENET_QOS
 	bool "NXP ENET QoS PTP Clock driver"
 	default y
-	depends on DT_HAS_NXP_ENET_QOS_PTP_CLOCK_ENABLED
+	depends on DT_HAS_SNPS_DWMAC_PTP_CLOCK_ENABLED
 	depends on ETH_NXP_ENET_QOS
 	select NET_L2_PTP_TIMESTAMPING
 	help

--- a/drivers/ptp_clock/ptp_clock_nxp_enet_qos.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet_qos.c
@@ -18,7 +18,7 @@
  * The fsl_enet_qos SDK HAL is intentionally NOT used here.
  */
 
-#define DT_DRV_COMPAT nxp_enet_qos_ptp_clock
+#define DT_DRV_COMPAT snps_dwmac_ptp_clock
 
 #include <zephyr/drivers/ptp_clock.h>
 #include <zephyr/kernel.h>

--- a/dts/arm/nxp/mcx/mcxn/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxn/nxp_mcxnx4x_common.dtsi
@@ -964,7 +964,7 @@
 		status = "disabled";
 
 		enet_ptp_clock: ptp_clock {
-			compatible = "nxp,enet-qos-ptp-clock";
+			compatible = "snps,dwmac-ptp-clock";
 			status = "disabled";
 		};
 

--- a/dts/bindings/ethernet/nxp,enet-qos-ptp-clock.yaml
+++ b/dts/bindings/ethernet/nxp,enet-qos-ptp-clock.yaml
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: Copyright 2026 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-description: NXP ENET QoS PTP (Precision Time Protocol) Clock
-
-compatible: "nxp,enet-qos-ptp-clock"
-
-include: ["base.yaml"]


### PR DESCRIPTION
use the common "snps,dwmac-ptp-clock" compatible
for the ptp clock.