### PR TITLE
drivers: dma: microchip: Update G2 DMA support for PIC32CM SG/GC devices

### DIFF
--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.dts
@@ -202,3 +202,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&dmac {
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.dts
@@ -200,6 +200,8 @@
 	txpo = <0>;
 	pinctrl-0 = <&sercom4_uart_default>;
 	pinctrl-names = "default";
+	dmas = <&dmac 0 24>, <&dmac 1 25>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };
 

--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
@@ -11,6 +11,7 @@ flash: 512
 ram: 128
 supported:
   - clock_control
+  - dma
   - gpio
   - pinctrl
   - uart

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.dts
@@ -200,5 +200,7 @@
 	txpo = <0>;
 	pinctrl-0 = <&sercom4_uart_default>;
 	pinctrl-names = "default";
+	dmas = <&dmac 0 24>, <&dmac 1 25>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.dts
@@ -204,3 +204,7 @@
 	dma-names = "rx", "tx";
 	status = "okay";
 };
+
+&dmac {
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
@@ -11,6 +11,7 @@ flash: 512
 ram: 128
 supported:
   - clock_control
+  - dma
   - gpio
   - pinctrl
   - uart

--- a/drivers/dma/dma_mchp_dmac_g2.c
+++ b/drivers/dma/dma_mchp_dmac_g2.c
@@ -355,34 +355,83 @@ static int dma_mchp_desc_setup(struct dma_mchp_dev_data *dev_data, struct dma_co
 	return ret;
 }
 
-static void dma_mchp_isr(const struct device *dev)
+/* Channel Interrupt handling function */
+static __always_inline void dma_mchp_handle_channel_int(const struct device *dev, uint32_t channel,
+					uint8_t ch_int_flag)
 {
 	struct dma_mchp_dev_data *dev_data = dev->data;
-	uint16_t pend = DMAC_REG->DMAC_INTPEND;
-	uint32_t channel = (pend & DMAC_INTPEND_ID_Msk) >> DMAC_INTPEND_ID_Pos;
+	struct dma_mchp_channel_config *ch_cfg = &dev_data->dma_channel_config[channel];
 
-	/* Acknowledge interrupt immediately */
-	DMAC_REG->DMAC_INTPEND = pend;
-
-	/* Ignore non TC / ERR interrupts */
-	if ((pend & (DMAC_INTPEND_TERR_Msk | DMAC_INTPEND_TCMPL_Msk)) == 0) {
+	if (ch_cfg->cb == NULL) {
 		return;
 	}
 
-	struct dma_mchp_channel_config *cfg = &dev_data->dma_channel_config[channel];
-
-	if (cfg->cb == NULL) {
-		return;
-	}
-
-	if (pend & DMAC_INTPEND_TERR_Msk) {
+	if ((ch_int_flag & DMAC_CHINTFLAG_TERR_Msk) != 0U) {
 		/* Invoke error callback only if it is not disabled */
-		if (cfg->is_err_cb_dis == false) {
-			cfg->cb(dev, cfg->user_data, channel, -EIO);
+		if (ch_cfg->is_err_cb_dis == false) {
+			ch_cfg->cb(dev, ch_cfg->user_data, channel, -EIO);
 		}
 	} else {
-		cfg->cb(dev, cfg->user_data, channel, DMA_STATUS_COMPLETE);
+		ch_cfg->cb(dev, ch_cfg->user_data, channel, DMA_STATUS_COMPLETE);
 	}
+}
+
+/* ISR for dedicated IRQ line - one IRQ per channel */
+static __always_inline void dma_mchp_isr_dedicated(const struct device *dev, uint32_t channel)
+{
+	uint8_t ch_int_flag;
+	uint8_t saved_ch_id;
+
+	/* Save current channel ID to restore later */
+	saved_ch_id = DMAC_REG->DMAC_CHID;
+
+	/* Select the channel */
+	DMAC_REG->DMAC_CHID = channel;
+
+	/* Read and clear channel interrupt flags */
+	ch_int_flag = DMAC_REG->DMAC_CHINTFLAG & DMAC_REG->DMAC_CHINTENSET;
+	ch_int_flag &= (uint8_t)(DMAC_CHINTFLAG_TERR_Msk | DMAC_CHINTFLAG_TCMPL_Msk);
+
+	if (ch_int_flag != 0) {
+		DMAC_REG->DMAC_CHINTFLAG = ch_int_flag;
+		dma_mchp_handle_channel_int(dev, channel, ch_int_flag);
+	}
+
+	/* Restore the original channel ID */
+	DMAC_REG->DMAC_CHID = saved_ch_id;
+}
+
+/* ISR for shared IRQ line - multiple channels share one IRQ */
+static __always_inline void dma_mchp_isr_shared(const struct device *dev)
+{
+	uint16_t int_pend;
+	uint32_t channel;
+	uint8_t ch_int_flag;
+
+	/* Read INTPEND to get channel ID and interrupt flags */
+	int_pend = DMAC_REG->DMAC_INTPEND;
+
+	/* Acknowledge interrupt immediately */
+	DMAC_REG->DMAC_INTPEND = int_pend;
+
+	/* Extract channel from INTPEND */
+	channel = (int_pend & DMAC_INTPEND_ID_Msk) >> DMAC_INTPEND_ID_Pos;
+
+	/*
+	 * Extract interrupt flags from INTPEND bits [10:8] (SUSP, TCMPL, TERR).
+	 * These bits map directly to CHINTFLAG format and only show enabled
+	 * interrupts that triggered this ISR.
+	 */
+	ch_int_flag = (int_pend >> DMAC_INTPEND_TERR_Pos) &
+		      (DMAC_CHINTFLAG_TERR_Msk | DMAC_CHINTFLAG_TCMPL_Msk |
+		       DMAC_CHINTFLAG_SUSP_Msk);
+
+	/* Ignore if no TERR/TCMPL flags (e.g., only SUSP) */
+	if ((ch_int_flag & (DMAC_CHINTFLAG_TERR_Msk | DMAC_CHINTFLAG_TCMPL_Msk)) == 0) {
+		return;
+	}
+
+	dma_mchp_handle_channel_int(dev, channel, ch_int_flag);
 }
 
 static int dma_mchp_config(const struct device *dev, uint32_t channel, struct dma_config *config)
@@ -758,30 +807,39 @@ static DEVICE_API(dma, dma_mchp_api) = {
 	.get_attribute = dma_mchp_get_attribute,
 };
 
+/* Number of dedicated IRQs */
+#define NUM_DEDICATED_IRQS(n) DT_INST_PROP(n, num_dedicated_irqs)
+
+/* Generate ISR function for each IRQ index */
+#define DMA_MCHP_ISR_FUNC(idx, n)                                                                  \
+	static void dma_mchp_isr_##n##_##idx(const struct device *dev)                             \
+	{                                                                                          \
+		if ((idx) < NUM_DEDICATED_IRQS(n)) {                                               \
+			dma_mchp_isr_dedicated(dev, idx);                                          \
+		} else {                                                                           \
+			dma_mchp_isr_shared(dev);                                                  \
+		}                                                                                  \
+	}
+
 /* Declare the DMA IRQ connection handler for a specific instance. */
 #define DMA_MCHP_IRQ_HANDLER_DECL(n) static void mchp_dma_irq_connect_##n(void)
 
-/* Enable IRQ lines for the DMA controller. */
+/* Connect and enable a single IRQ */
 #define DMA_MCHP_IRQ_CONNECT(idx, n)                                                               \
-	IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, idx), (                                                  \
-		/** Connect the IRQ to the DMA ISR */                                              \
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),                                       \
-			DT_INST_IRQ_BY_IDX(n, idx, priority),                                      \
-			dma_mchp_isr,                                                              \
-			DEVICE_DT_INST_GET(n), 0);                                                 \
-		/** Enable the IRQ */                                                              \
-		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));                                       \
-	))
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),                                               \
+		    DT_INST_IRQ_BY_IDX(n, idx, priority),                                          \
+		    dma_mchp_isr_##n##_##idx,                                                      \
+		    DEVICE_DT_INST_GET(n), 0);                                                     \
+	irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));
 
 /* Define the DMA IRQ handler function for a given instance. */
 #define DMA_MCHP_IRQ_HANDLER(n)                                                                    \
+	/* Generate ISR functions for each IRQ */                                                  \
+	LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), DMA_MCHP_ISR_FUNC, (), n)                             \
 	static void mchp_dma_irq_connect_##n(void)                                                 \
 	{                                                                                          \
-		/** Connect all IRQs for this instance */                                          \
-		LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)),          \
-			DMA_MCHP_IRQ_CONNECT,                 \
-			(),                                   \
-			n)                                    \
+		/* Connect all IRQs for this instance */                                           \
+		LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), DMA_MCHP_IRQ_CONNECT, (), n)                  \
 	}
 
 /* DMA runtime data structure. */

--- a/dts/arm/microchip/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_sg_gc/common/pic32cm_sg_gc.dtsi
@@ -157,6 +157,19 @@
 			};
 		};
 
+		dmac: dmac@44802000 {
+			compatible = "microchip,dmac-g2-dma";
+			reg = <0x44802000 0x50>;
+			interrupts = <42 0>, <43 0>, <44 0>, <45 0>, <46 0>;
+			interrupt-names = "ch0", "ch1", "ch2", "ch3", "ch4-7";
+			num-dedicated-irqs = <4>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_DMAC_AHB>;
+			clock-names = "mclk";
+			dma-channels = <8>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		sercom0: sercom@44808000 {
 			compatible = "microchip,sercom-g1";
 			reg = <0x44808000 0x38>;

--- a/dts/bindings/dma/microchip,dmac-g2-dma.yaml
+++ b/dts/bindings/dma/microchip,dmac-g2-dma.yaml
@@ -29,6 +29,17 @@ properties:
   dma-channels:
     required: true
 
+  num-dedicated-irqs:
+    type: int
+    default: 0
+    description: |
+      Number of dedicated IRQ lines (1:1 mapping to channels).
+
+      IRQs 0 to (num-dedicated-irqs - 1) are dedicated to channels 0 to (num-dedicated-irqs - 1).
+      Remaining IRQs are shared among the other channels.
+      Example: num-dedicated-irqs = <4> means ch0-ch3 have dedicated IRQs,
+      and ch4+ share the remaining IRQ(s).
+
   "#dma-cells":
     type: int
     const: 2

--- a/soc/microchip/pic32c/pic32cm_sg_gc/common/mchp_dt_helper.h
+++ b/soc/microchip/pic32c/pic32cm_sg_gc/common/mchp_dt_helper.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file mchp_dt_helper.h
+ * @brief device tree helper macros.
+ *
+ * This file contains the device tree helper macros.
+ */
+
+#ifndef SOC_MICROCHIP_PIC32CM_SG_GC_COMMON_MCHP_DT_HELPER_H_
+#define SOC_MICROCHIP_PIC32CM_SG_GC_COMMON_MCHP_DT_HELPER_H_
+
+/* clang-format off */
+/* Helper macros for use with DMAC controller
+ * return 0xff as default value if there is no 'dmas' property
+ */
+#define MCHP_DT_INST_DMA_CELL(n, name, cell)						\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),					\
+			(DT_INST_DMAS_CELL_BY_NAME(n, name, cell)),			\
+			(0xff))
+#define MCHP_DT_INST_DMA_TRIGSRC(n, name) MCHP_DT_INST_DMA_CELL(n, name, trigsrc)
+#define MCHP_DT_INST_DMA_CHANNEL(n, name) MCHP_DT_INST_DMA_CELL(n, name, channel)
+#define MCHP_DT_INST_DMA_CTLR(n, name)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),					\
+			(DT_INST_DMAS_CTLR_BY_NAME(n, name)),				\
+			(DT_INVALID_NODE))
+/* clang-format on */
+
+#endif /* SOC_MICROCHIP_PIC32CM_SG_GC_COMMON_MCHP_DT_HELPER_H_ */

--- a/tests/drivers/dma/chan_blen_transfer/boards/pic32cm_gc00_cpro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/pic32cm_gc00_cpro.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};

--- a/tests/drivers/dma/chan_blen_transfer/boards/pic32cm_sg00_cpro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/pic32cm_sg00_cpro.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};

--- a/tests/drivers/dma/chan_blen_transfer/tests.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/tests.yaml
@@ -21,6 +21,7 @@ tests:
       - sam_e54_xpro
       - pic32cm_jh01_cpro
       - pic32cm_pl10_cnano
+      - pic32cm_gc00_cpro
   drivers.dma.ifx_axidmac.chan_blen_transfer:
     tags:
       - dma

--- a/tests/drivers/dma/loop_transfer/boards/pic32cm_gc00_cpro.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/pic32cm_gc00_cpro.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};

--- a/tests/drivers/dma/loop_transfer/boards/pic32cm_sg00_cpro.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/pic32cm_sg00_cpro.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};


### PR DESCRIPTION
Update DMA (G2) support for PIC32CM SG/GC family, including devicetree binding, SoC DT helpers, and Zephyr DMA driver update.
Enable DMA controller and supported features for pic32cm_gc00_cpro and pic32cm_sg00_cpro board.
Add Twister test overlays to validate DMA functionality on the board.