### PR TITLE
sys: printk: restore the API in the Doxygen output

### DIFF
--- a/include/zephyr/sys/printk.h
+++ b/include/zephyr/sys/printk.h
@@ -46,7 +46,7 @@ extern "C" {
  * @param fmt Format string.
  * @param ... Optional list of format arguments.
  */
-#ifdef CONFIG_PRINTK
+#if defined(CONFIG_PRINTK) || defined(__DOXYGEN__)
 
 #ifdef CONFIG_LOG_PRINTK_STATIC
 /* If printk is redirected to the logging use the macro which allow build time
@@ -58,6 +58,14 @@ extern "C" {
 __printf_like(1, 2) void printk(const char *fmt, ...);
 #endif /* CONFIG_LOG_PRINTK_STATIC */
 
+/**
+ * @brief Print kernel debugging message, va_list version
+ *
+ * See printk() for the output format.
+ *
+ * @param fmt Format string.
+ * @param ap Format arguments.
+ */
 __printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
 
 /**
@@ -105,10 +113,6 @@ __printf_like(1, 0) void vprintk_unlocked(const char *fmt, va_list ap);
 void printk_panic(void);
 
 #else
-/** @cond INTERNAL_HIDDEN */
-/* Stubs for CONFIG_PRINTK=n. The API is documented above; these carry no
- * documentation of their own so that Doxygen describes each function once.
- */
 static inline __printf_like(1, 2) void printk(const char *fmt, ...)
 {
 	ARG_UNUSED(fmt);
@@ -134,8 +138,7 @@ static inline __printf_like(1, 0) void vprintk_unlocked(const char *fmt, va_list
 static inline void printk_panic(void)
 {
 }
-/** @endcond */
-#endif
+#endif /* defined(CONFIG_PRINTK) || defined(__DOXYGEN__) */
 
 #ifdef CONFIG_PICOLIBC
 
@@ -146,8 +149,38 @@ static inline void printk_panic(void)
 
 #else
 
+/**
+ * @brief Print a kernel debugging message to a buffer.
+ *
+ * Formats as printk() does, but writes to @p str instead of the console.
+ * The output is truncated if it does not fit, and is NUL terminated as
+ * long as @p size is not zero.
+ *
+ * @param str Buffer to write to.
+ * @param size Size of the buffer, in bytes.
+ * @param fmt Format string.
+ * @param ... Optional list of format arguments.
+ *
+ * @return Number of characters that would have been written, not counting
+ * the terminating NUL. A value of @p size or more means the output was
+ * truncated.
+ */
 __printf_like(3, 4) int snprintk(char *str, size_t size,
 					const char *fmt, ...);
+
+/**
+ * @brief Print a kernel debugging message to a buffer, va_list version
+ *
+ * See snprintk() for the formatting and the buffer handling.
+ *
+ * @param str Buffer to write to.
+ * @param size Size of the buffer, in bytes.
+ * @param fmt Format string.
+ * @param ap Format arguments.
+ *
+ * @return Number of characters that would have been written, not counting
+ * the terminating NUL.
+ */
 __printf_like(3, 0) int vsnprintk(char *str, size_t size,
 					  const char *fmt, va_list ap);
 


### PR DESCRIPTION
Doxygen does not define `CONFIG_PRINTK`, so it only ever sees the `CONFIG_PRINTK=n` stubs. #114814 hid those behind `@cond`, which left the `printk()` documentation block with nothing to attach to: it landed on `snprintk()` instead — that is the `parameters ... are not documented` warning in the doc build — and the rest of the header dropped out of the API documentation entirely 🥲 

Add `__DOXYGEN__` to the condition so the real prototypes are what gets documented, and document `snprintk()`, `vsnprintk()` and `vprintk()`, which never had documentation of their own while at it.

### Why CI didn't catch it

As of a few weeks back doc CI workflow does not build Sphinx website when not needed so a PR only touching header files only has Doxygen being built, and in that case Doxygen warnings are not considered an error. It's only when Doxygen build is wrapped  in a "full" Sphinx build that warnings get promoted as errors... I'll try to improve this in a follow-up fix.