### PR TITLE
drivers: mfd: nxp sc18is606s GPIO and SPI bugfixes

### DIFF
--- a/drivers/gpio/gpio_sc18is606.c
+++ b/drivers/gpio/gpio_sc18is606.c
@@ -19,20 +19,6 @@
 
 LOG_MODULE_REGISTER(nxp_sc18is606_gpio, CONFIG_GPIO_LOG_LEVEL);
 
-#define SC18IS606_GPIO_MAX_PINS 3
-
-#define SC18IS606_GPIO_WRITE  0xF4
-#define SC18IS606_GPIO_READ   0xF5
-#define SC18IS606_GPIO_ENABLE 0xF6
-#define SC18IS606_GPIO_CONF   0xF7
-
-#define SC18IS606_GPIO_CONF_INPUT      0x00
-#define SC18IS606_GPIO_CONF_PUSH_PULL  0x01
-#define SC18IS606_GPIO_CONF_OPEN_DRAIN 0x03
-#define SC18IS606_GPIO_CONF_MASK       0x03
-
-#define SC18IS606_GPIO_ENABLE_MASK GENMASK(2, 0)
-
 struct gpio_sc18is606_config {
 	struct gpio_driver_config common;
 	const struct device *bridge;
@@ -43,9 +29,6 @@ struct gpio_sc18is606_data {
 
 	/* current port state */
 	uint8_t output_state;
-
-	/* current port pin config */
-	uint8_t conf;
 };
 
 static int gpio_sc18is606_port_set_raw(const struct device *port, uint8_t mask, uint8_t value,
@@ -84,20 +67,8 @@ static int gpio_sc18is606_pin_configure(const struct device *port, gpio_pin_t pi
 					gpio_flags_t flags)
 {
 	const struct gpio_sc18is606_config *cfg = port->config;
-	struct gpio_sc18is606_data *data = port->data;
 	uint8_t pin_conf;
-	uint8_t pin_enable;
 	int ret;
-
-	uint8_t buf[] = {
-		SC18IS606_GPIO_CONF,
-		0x00,
-	};
-
-	uint8_t enable_buf[] = {
-		SC18IS606_GPIO_ENABLE,
-		0x00,
-	};
 
 	if (pin >= SC18IS606_GPIO_MAX_PINS) {
 		return -EINVAL;
@@ -124,22 +95,9 @@ static int gpio_sc18is606_pin_configure(const struct device *port, gpio_pin_t pi
 		return -ENOTSUP;
 	}
 
-	pin_enable = FIELD_PREP(SC18IS606_GPIO_ENABLE_MASK, (1 << pin));
-
-	enable_buf[1] = pin_enable;
-
-	ret = nxp_sc18is606_transfer(cfg->bridge, enable_buf, sizeof(enable_buf), NULL, 0, NULL);
+	ret = nxp_sc18is606_set_pin_mode(cfg->bridge, pin, true, pin_conf);
 	if (ret < 0) {
-		LOG_ERR("Failed to enable GPIO (%d)", ret);
-	}
-
-	data->conf &= ~(SC18IS606_GPIO_CONF_MASK << (pin * 2));
-	data->conf |= (pin_conf & SC18IS606_GPIO_CONF_MASK) << (pin * 2);
-	buf[1] = data->conf;
-
-	ret = nxp_sc18is606_transfer(cfg->bridge, buf, sizeof(buf), NULL, 0, NULL);
-	if (ret < 0) {
-		LOG_ERR("Failed to configure GPIO (%d)", ret);
+		LOG_ERR("Failed to set pin mode (%d)", ret);
 	}
 
 	if (ret == 0 && flags & GPIO_OUTPUT) {
@@ -224,9 +182,8 @@ static DEVICE_API(gpio, gpio_sc18is606_driver_api) = {
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(inst),                                   \
 		.bridge = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                     \
 	};                                                                                         \
-	static struct gpio_sc18is606_data gpio_sc18is606_data##inst = {                            \
-		.conf = 0x00,                                                                      \
-	};                                                                                         \
+                                                                                                   \
+	static struct gpio_sc18is606_data gpio_sc18is606_data##inst = {0};                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, gpio_sc18is606_init, NULL, &gpio_sc18is606_data##inst,         \
 			      &gpio_sc18is606_config##inst, POST_KERNEL,                           \

--- a/drivers/mfd/mfd_sc18is606.c
+++ b/drivers/mfd/mfd_sc18is606.c
@@ -10,11 +10,16 @@
 #include "mfd_sc18is606.h"
 LOG_MODULE_REGISTER(nxp_sc18is606, CONFIG_MFD_LOG_LEVEL);
 
+/* Avoid making CS outputs by default */
+#define SC18IS606_GPIO_DEFAULT                                                                     \
+	(SC18IS606_GPIO_CS_CONF | (SC18IS606_GPIO_CS_CONF << 2) | (SC18IS606_GPIO_CS_CONF << 4))
+
 int nxp_sc18is606_transfer(const struct device *dev, const uint8_t *tx_data, uint8_t tx_len,
 			   uint8_t *rx_data, uint8_t rx_len, uint8_t *id_buf)
 {
 	struct sc18is606_data *data = dev->data;
 	const struct sc18is606_config *info = dev->config;
+	k_timepoint_t end = sys_timepoint_calc(K_MSEC(1000));
 	int ret;
 
 	ret = k_mutex_lock(&data->bridge_lock, K_FOREVER);
@@ -23,30 +28,27 @@ int nxp_sc18is606_transfer(const struct device *dev, const uint8_t *tx_data, uin
 	}
 
 	if (tx_data != NULL) {
-		if (id_buf != NULL) {
-			struct i2c_msg tx_msg[2] = {
-				{
-					.buf = id_buf,
-					.len = 1,
-					.flags = I2C_MSG_WRITE,
-				},
-				{
-					.buf = (uint8_t *)tx_data,
-					.len = tx_len,
-					.flags = I2C_MSG_WRITE,
-				},
-			};
+		do {
+			if (id_buf != NULL) {
+				struct i2c_msg tx_msg[2] = {
+					{
+						.buf = id_buf,
+						.len = 1,
+						.flags = I2C_MSG_WRITE,
+					},
+					{
+						.buf = (uint8_t *)tx_data,
+						.len = tx_len,
+						.flags = I2C_MSG_WRITE,
+					},
+				};
 
-			ret = i2c_transfer_dt(&info->i2c_controller, tx_msg, 2);
-		} else {
-			struct i2c_msg tx_msg[1] = {{
-				.buf = (uint8_t *)tx_data,
-				.len = tx_len,
-				.flags = I2C_MSG_WRITE,
-			}};
+				ret = i2c_transfer_dt(&info->i2c_controller, tx_msg, 2);
+			} else {
 
-			ret = i2c_transfer_dt(&info->i2c_controller, tx_msg, 1);
-		}
+				ret = i2c_write_dt(&info->i2c_controller, tx_data, 1);
+			}
+		} while (ret != 0 && !sys_timepoint_expired(end));
 
 		if (ret != 0) {
 			LOG_ERR("SPI write failed: %d", ret);
@@ -63,12 +65,6 @@ int nxp_sc18is606_transfer(const struct device *dev, const uint8_t *tx_data, uin
 	}
 
 	if (rx_data != NULL) {
-		/*What is the time*/
-		k_timepoint_t end;
-
-		/*Set a deadline in a second*/
-		end = sys_timepoint_calc(K_MSEC(1));
-
 		do {
 			ret = i2c_read(info->i2c_controller.bus, rx_data, rx_len,
 				       info->i2c_controller.addr);
@@ -137,6 +133,32 @@ static int int_gpios_setup(const struct device *dev)
 	return ret;
 }
 
+int nxp_sc18is606_set_pin_mode(const struct device *dev, const uint8_t pin, const bool is_gpio,
+			       const uint8_t mode)
+{
+	struct sc18is606_data *data = dev->data;
+
+	uint8_t enable_buf[] = {
+		SC18IS606_GPIO_ENABLE,
+		0x0,
+	};
+
+	uint8_t conf_buf[] = {
+		SC18IS606_GPIO_CONF,
+		0x00,
+	};
+
+	data->gpio_enable |= FIELD_PREP(SC18IS606_GPIO_ENABLE_MASK, (1 << pin));
+
+	enable_buf[1] = data->gpio_enable;
+
+	data->pin_conf &= ~(SC18IS606_GPIO_CONF_MASK << (pin * 2));
+	data->pin_conf |= (mode & SC18IS606_GPIO_CONF_MASK) << (pin * 2);
+	conf_buf[1] = data->pin_conf;
+
+	return nxp_sc18is606_transfer(dev, conf_buf, sizeof(conf_buf), NULL, 0, NULL);
+}
+
 static int sc18is606_init(const struct device *dev)
 {
 	const struct sc18is606_config *cfg = dev->config;
@@ -186,7 +208,9 @@ static int sc18is606_init(const struct device *dev)
 		.int_gpios = GPIO_DT_SPEC_GET_OR(DT_DRV_INST(inst), int_gpios, {0}),               \
 	};                                                                                         \
                                                                                                    \
-	static struct sc18is606_data data##inst;                                                   \
+	static struct sc18is606_data data##inst = {                                                \
+		.pin_conf = SC18IS606_GPIO_DEFAULT,                                                \
+	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, sc18is606_init, NULL, &data##inst, &sc18is606_config_##inst,   \
 			      POST_KERNEL, CONFIG_MFD_INIT_PRIORITY, NULL);

--- a/drivers/mfd/mfd_sc18is606.h
+++ b/drivers/mfd/mfd_sc18is606.h
@@ -22,17 +22,17 @@
 extern "C" {
 #endif
 
-
-
 /**
  * SC18IS606 Data Struct
  *
  * Contains the mutex, interrupt callback and semaphore
  */
 struct sc18is606_data {
-	struct k_mutex bridge_lock;	/**< Mutex for the mfd device base */
-	struct gpio_callback int_cb;	/**< Gpio call back for gpio functions */
-	struct k_sem int_sem;		/**< Semaphore to  gate access	*/
+	struct k_mutex bridge_lock;  /**< Mutex for the mfd device base */
+	struct gpio_callback int_cb; /**< Gpio call back for gpio functions */
+	struct k_sem int_sem;        /**< Semaphore to  gate access	*/
+	uint8_t gpio_enable;
+	uint8_t pin_conf;
 };
 
 /**
@@ -41,9 +41,9 @@ struct sc18is606_data {
  * Contains the i2c controller, reset and interrupt gpios
  */
 struct sc18is606_config {
-	const struct i2c_dt_spec i2c_controller;	/**< I2C controller for the device */
-	const struct gpio_dt_spec reset_gpios;		/**< Device reset gpio */
-	const struct gpio_dt_spec int_gpios;		/**< Device interrupt gpio */
+	const struct i2c_dt_spec i2c_controller; /**< I2C controller for the device */
+	const struct gpio_dt_spec reset_gpios;   /**< Device reset gpio */
+	const struct gpio_dt_spec int_gpios;     /**< Device interrupt gpio */
 };
 
 /**
@@ -100,6 +100,60 @@ static inline int nxp_sc18is606_release(const struct device *dev)
  */
 int nxp_sc18is606_transfer(const struct device *dev, const uint8_t *tx_data, uint8_t tx_len,
 			   uint8_t *rx_data, uint8_t rx_len, uint8_t *id_buf);
+
+/**
+ * Configure a pin on the bridge
+ *
+ * This routine implements the synchronization between the SPI controller and GPIO cntroller
+ *
+ * @param dev SC18IS606 bridge
+ * @param pin pin to configure
+ * @param is_gpio whether it is to be used as a GPIO or CS pin
+ * @param mode pin mode, SC18IS606_GPIO_CS_CONF for a CS pin
+ *
+ * @retval 0 pin mode set successfully
+ */
+int nxp_sc18is606_set_pin_mode(const struct device *dev, const uint8_t pin, const bool is_gpio,
+			       const uint8_t mode);
+
+/** How many pins the bridge has */
+#define SC18IS606_GPIO_MAX_PINS 3
+
+/** SPI configuration register */
+#define SC18IS606_CONFIG_SPI      0xF0
+/** Clear interrupt command */
+#define SC18IS606_CLEAR_INTERRUPT 0xF1
+/** Idle sleep command */
+#define SC18IS606_IDLE_MODE       0xF2
+/** GPIO output value register */
+#define SC18IS606_GPIO_WRITE      0xF4
+/** GPIO input value register  */
+#define SC18IS606_GPIO_READ       0xF5
+/** GPIO mode register */
+#define SC18IS606_GPIO_ENABLE     0xF6
+/** GPIO I/O mode configuration register */
+#define SC18IS606_GPIO_CONF       0xF7
+
+/** Input I/O mode */
+#define SC18IS606_GPIO_CONF_INPUT      0x00
+/** Output I/O mode */
+#define SC18IS606_GPIO_CONF_PUSH_PULL  0x01
+/** Hi-Z I/O mode */
+#define SC18IS606_GPIO_CONF_OPEN_DRAIN 0x03
+
+/** SPI LSB/MSB switch bit */
+#define SC18IS606_LSB_MASK         GENMASK(5, 5)
+/** SPI mode selection bits */
+#define SC18IS606_MODE_MASK        GENMASK(3, 2)
+/** SPI frequency selection bits */
+#define SC18IS606_FREQ_MASK        GENMASK(1, 0)
+/** GPIO I/O mode configuration bits */
+#define SC18IS606_GPIO_CONF_MASK   GENMASK(1, 0)
+/** GPIO mode register bits */
+#define SC18IS606_GPIO_ENABLE_MASK GENMASK(2, 0)
+
+/** 'GPIO' Push-Pull mode that must be set for a CS pin */
+#define SC18IS606_GPIO_CS_CONF SC18IS606_GPIO_CONF_PUSH_PULL
 
 #ifdef __cplusplus
 }

--- a/drivers/spi/spi_sc18is606.c
+++ b/drivers/spi/spi_sc18is606.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, tinyvision.ai
+ * Copyright (c) 2026, tinyvision.ai
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,13 +20,6 @@ LOG_MODULE_REGISTER(spi_sc18is606, CONFIG_SPI_LOG_LEVEL);
 #include "spi_context.h"
 #include <mfd_sc18is606.h>
 
-#define SC18IS606_CONFIG_SPI 0xF0
-#define CLEAR_INTERRUPT      0xF1
-#define IDLE_MODE            0xF2
-#define SC18IS606_LSB_MASK   GENMASK(5, 5)
-#define SC18IS606_MODE_MASK  GENMASK(3, 2)
-#define SC18IS606_FREQ_MASK  GENMASK(1, 0)
-
 struct spi_sc18is606_data {
 	struct spi_context ctx;
 	uint8_t frequency_idx;
@@ -37,12 +30,21 @@ struct spi_sc18is606_config {
 	const struct device *bridge;
 };
 
+#define SC18IS606_SPI_FREQUENCY_CNT  4
+#define SC18IS606_SPI_FREQUENCY_1875 0
+#define SC18IS606_SPI_FREQUENCY_455  1
+#define SC18IS606_SPI_FREQUENCY_115  2
+#define SC18IS606_SPI_FREQUENCY_58   3
+
+
 static int sc18is606_spi_configure(const struct device *dev, const struct spi_config *config)
 {
 	const struct spi_sc18is606_config *cfg = dev->config;
 	struct spi_sc18is606_data *data = dev->data;
 	uint8_t cfg_byte = 0;
 	uint8_t buffer[2];
+	uint8_t freq_idx;
+	int ret;
 
 	if ((config->operation & SPI_OP_MODE_SLAVE) != 0U) {
 		LOG_ERR("SC18IS606 does not support Slave mode");
@@ -61,12 +63,28 @@ static int sc18is606_spi_configure(const struct device *dev, const struct spi_co
 		return -ENOTSUP;
 	}
 
+	ret = nxp_sc18is606_set_pin_mode(cfg->bridge, config->slave, false, SC18IS606_GPIO_CS_CONF);
+
+	if (ret < 0) {
+		LOG_ERR("Failed to set pin mode (%d)", ret);
+	}
+
 	/* Build SC18IS606  configuration byte*/
 	cfg_byte |= FIELD_PREP(SC18IS606_LSB_MASK, (config->operation & SPI_TRANSFER_LSB) >> 4);
 
 	cfg_byte |= FIELD_PREP(SC18IS606_MODE_MASK, (SPI_MODE_GET(config->operation) >> 1));
 
-	cfg_byte |= FIELD_PREP(SC18IS606_FREQ_MASK, config->frequency);
+	if (config->frequency >= KHZ(1875)) {
+		freq_idx = SC18IS606_SPI_FREQUENCY_1875;
+	} else if (config->frequency >= KHZ(455)) {
+		freq_idx = SC18IS606_SPI_FREQUENCY_455;
+	} else if (config->frequency >= KHZ(115)) {
+		freq_idx = SC18IS606_SPI_FREQUENCY_115;
+	} else {
+		freq_idx = SC18IS606_SPI_FREQUENCY_58;
+	}
+
+	cfg_byte |= FIELD_PREP(SC18IS606_FREQ_MASK, freq_idx);
 
 	data->ctx.config = config;
 
@@ -82,6 +100,8 @@ static int sc18is606_spi_transceive(const struct device *dev, const struct spi_c
 				    const struct spi_buf_set *rx_buffer_set)
 {
 	const struct spi_sc18is606_config *cfg = dev->config;
+	struct spi_sc18is606_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
 	int ret;
 
 	ret = sc18is606_spi_configure(dev, spi_cfg);
@@ -104,39 +124,63 @@ static int sc18is606_spi_transceive(const struct device *dev, const struct spi_c
 
 	uint8_t function_id = (1 << ss_idx) & 0x07;
 
-	if (tx_buffer_set && tx_buffer_set->buffers && tx_buffer_set->count > 0) {
+	spi_context_cs_control(ctx, true);
+
+	if (tx_buffer_set && tx_buffer_set->buffers && rx_buffer_set && rx_buffer_set->buffers) {
 		for (size_t i = 0; i < tx_buffer_set->count; i++) {
 			const struct spi_buf *tx_buf = &tx_buffer_set->buffers[i];
+			const struct spi_buf *rx_buf = &rx_buffer_set->buffers[i];
 
 			uint8_t id_buf[1] = {function_id};
 
-			ret = nxp_sc18is606_transfer(cfg->bridge, tx_buf->buf, tx_buf->len, NULL, 0,
-						     id_buf);
+			ret = nxp_sc18is606_transfer(cfg->bridge, tx_buf->buf, tx_buf->len,
+						     rx_buf->buf, rx_buf->len, id_buf);
 			if (ret < 0) {
 				LOG_ERR("SC18IS606: TX of size: %d failed %s", tx_buf->len,
 					dev->name);
 				return ret;
 			}
 		}
-	}
+	} else {
+		if (tx_buffer_set && tx_buffer_set->buffers && tx_buffer_set->count > 0) {
+			for (size_t i = 0; i < tx_buffer_set->count; i++) {
+				const struct spi_buf *tx_buf = &tx_buffer_set->buffers[i];
 
-	if (rx_buffer_set && rx_buffer_set->buffers && rx_buffer_set->count > 0) {
-		for (size_t i = 0; i < rx_buffer_set->count; i++) {
-			/* Function ID first to select the device */
-			uint8_t cmd_buf[1] = {function_id};
+				uint8_t id_buf[1] = {function_id};
 
-			const struct spi_buf *rx_buf = &rx_buffer_set->buffers[i];
+				ret = nxp_sc18is606_transfer(cfg->bridge, tx_buf->buf, tx_buf->len,
+							     NULL, 0, id_buf);
 
-			ret = nxp_sc18is606_transfer(cfg->bridge, cmd_buf, sizeof(cmd_buf),
-						     rx_buf->buf, rx_buf->len, NULL);
+				if (ret < 0) {
+					LOG_ERR("SC18IS606: TX of size: %d failed on  (%s)",
+						tx_buf->len, dev->name);
+					return ret;
+				}
+			}
+		}
 
-			if (ret < 0) {
-				LOG_ERR("SC18IS606: RX of size: %d failed on  (%s)", rx_buf->len,
-					dev->name);
-				return ret;
+		if (rx_buffer_set && rx_buffer_set->buffers && rx_buffer_set->count > 0) {
+			for (size_t i = 0; i < rx_buffer_set->count; i++) {
+				/* Function ID to select the device */
+				uint8_t cmd_buf[1] = {function_id};
+
+				const struct spi_buf *rx_buf = &rx_buffer_set->buffers[i];
+
+				ret = nxp_sc18is606_transfer(cfg->bridge, cmd_buf, sizeof(cmd_buf),
+							     rx_buf->buf, rx_buf->len, NULL);
+
+				if (ret < 0) {
+					LOG_ERR("SC18IS606: Rx of size: %d failed on (%s)",
+						rx_buf->len, dev->name);
+					return ret;
+				}
 			}
 		}
 	}
+
+	spi_context_cs_control(ctx, false);
+
+	spi_context_complete(ctx, dev, 0);
 
 	return ret;
 }
@@ -174,6 +218,12 @@ static int sc18is606_spi_init(const struct device *dev)
 		return ret;
 	}
 
+	ret = spi_context_cs_configure_all(&data->ctx);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure CS pins: %d", ret);
+		return ret;
+	}
+
 	LOG_DBG("SC18IS606 SPI initialized");
 	return 0;
 }
@@ -182,7 +232,7 @@ static int sc18is606_spi_init(const struct device *dev)
 	static struct spi_sc18is606_data spi_sc18is606_data_##inst = {                             \
 		.frequency_idx = DT_INST_ENUM_IDX(inst, frequency),                                \
 		.spi_mode = DT_INST_PROP(inst, spi_mode),                                          \
-	};                                                                                         \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx)};                          \
 	static const struct spi_sc18is606_config spi_sc18is606_config##inst = {                    \
 		.bridge = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                     \
 	};                                                                                         \


### PR DESCRIPTION
- Fix handling of busy behavior and timeout for sc18is606 by doing transfers before the deadline.
- The pin settings as were would cause the pins to be in a default state that wasn't conducive to scenarios such as CS and GPIO on the same device. Managing this from mfd proved much more effective.
- Handle state in such a way that SPI reads with the device are much more stable.

Thanks @VynDragon for all the help!