### PR TITLE
arch: x86: Fix demand paging when KPTI is enabled

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -492,11 +492,11 @@ void z_x86_page_fault_handler(struct arch_esf *esf)
 		    !z_x86_kpti_is_access_ok(virt, get_ptables(esf))) {
 			was_valid_access = false;
 		} else
-#else
+#endif /* CONFIG_X86_KPTI */
 		{
 			was_valid_access = k_mem_page_fault(virt);
 		}
-#endif /* CONFIG_X86_KPTI */
+
 		if (was_valid_access) {
 			/* Page fault handled, re-try */
 			return;


### PR DESCRIPTION
With KPTI enabled, when a page fault happened, code would never load the page when it should due an `ifdef` confusion.

Fixes: #116502