### PR TITLE
drivers: i2c_dw: Fix HOLD_TIME_TO_TICKS divider

### DIFF
--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -145,7 +145,7 @@ typedef int (*i2c_api_check_bus_t)(const struct device *dev);
 /* convert sda hold time in nanoseconds to DW I2C clock ticks at build time */
 #define HOLD_TIME_TO_TICKS(i2c_sda_hold_time_ns)                                                \
 	   ((uint32_t)DIV_ROUND_UP((uint64_t)(CONFIG_I2C_DW_CLOCK_SPEED) * (i2c_sda_hold_time_ns), \
-							   1000000000ULL))
+							   1000ULL))
 
 struct i2c_dw_rom_config {
 	DEVICE_MMIO_ROM;


### PR DESCRIPTION
CONFIG_I2C_DW_CLOCK_SPEED is defined in MHz in Kconfig.dw however the HOLD_TIME_TO_TICKS macro is assuming it is in Hz resulting in any configuration of i2c_sda_hold_time_ns defaulting to 1 tick.