### PR TITLE
tests: kernel: mutex: clear owner before deadlock-test reinit

### DIFF
--- a/tests/kernel/mutex/mutex_deadlock/src/main.c
+++ b/tests/kernel/mutex/mutex_deadlock/src/main.c
@@ -62,6 +62,10 @@ void ztest_post_fatal_error_hook(unsigned int reason,
 	/* Abort t_low which is stuck pending on mutex_a */
 	k_thread_abort(&t_low);
 
+	/* Neither mutex was ever unlocked; clear owner before re-init. */
+	mutex_a.owner = NULL;
+	mutex_b.owner = NULL;
+
 	/* Reinitialize both mutexes to clear all stale state */
 	k_mutex_init(&mutex_a);
 	k_mutex_init(&mutex_b);


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/108619 introduced assertions on uninitialized/re-initialized mutexes, uncovering a gap in `mutex_deadlock`'s `ztest_post_fatal_error_hook()`: it unlinks `mutex_a` from the held-mutexes list but never clears `owner` on either mutex before calling `k_mutex_init()` again. Neither mutex was ever unlocked (that's the point of the deadlock test), so re-init trips the same assertions in `kernel.mutex.deadlock`.

Clear `owner` on both mutexes before re-init, so the recovery hook produces a clean, unheld mutex the same way an unlock would.