### PR TITLE
llext: remove unused variable in llext struct

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -125,9 +125,6 @@ struct llext {
 	/** Lookup table of memory regions */
 	void *mem[LLEXT_MEM_COUNT];
 
-	/** Address of text region in ELF buffer */
-	void *text_in_elf;
-
 	/** Is the memory for this region allocated on heap? */
 	bool mem_on_heap[LLEXT_MEM_COUNT];
 

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -135,10 +135,6 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 			/* Region has data in the file, check if peek() is supported */
 			ext->mem[mem_idx] = llext_peek(ldr, region->sh_offset);
 			if (ext->mem[mem_idx]) {
-				if (mem_idx == LLEXT_MEM_TEXT) {
-					ext->text_in_elf = ext->mem[mem_idx];
-				}
-
 				if ((IS_ALIGNED(ext->mem[mem_idx], region_align) ||
 				     ldr_parm->pre_located) &&
 				    ((mem_idx != LLEXT_MEM_TEXT) ||


### PR DESCRIPTION
Remove unused variable left in llext struct by #11409 due to CI errors.