### PR TITLE
dts: Add DT_BINDING_COMPAT_*

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -71,6 +71,12 @@ node-macro =/ %s"DT_N" path-id %s"_COMPAT_VENDOR_IDX_" DIGIT "_EXISTS"
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_VENDOR_IDX_" DIGIT
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_MODEL_IDX_" DIGIT "_EXISTS"
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_MODEL_IDX_" DIGIT
+; The binding compatible (the compatible that matched a binding) as a token,
+; uppercased token, or unquoted string. Only defined for nodes with a
+; matching binding.
+node-macro =/ %s"DT_N" path-id %s"_BINDING_COMPAT_TOKEN"
+node-macro =/ %s"DT_N" path-id %s"_BINDING_COMPAT_UPPER_TOKEN"
+node-macro =/ %s"DT_N" path-id %s"_BINDING_COMPAT_UNQUOTED"
 ; Every non-root node gets one of these macros, which expands to the node
 ; identifier for that node's parent in the devicetree.
 node-macro =/ %s"DT_N" path-id %s"_PARENT"

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4345,6 +4345,59 @@
 	IS_ENABLED(DT_CAT3(node_id, _COMPAT_MATCHES_, compat))
 
 /**
+ * @brief Get a node's binding compatible as a token.
+ *
+ * Expands to the compatible string (in token form, with special
+ * characters replaced by underscores) that matched this node's
+ * binding. Useful for token-pasting to dispatch to
+ * compat-namespaced symbols at compile time.
+ *
+ * Example, assuming the GPIO controller node matched "atmel,sam0-gpio":
+ *
+ * @code{.c}
+ *     DT_BINDING_COMPAT_TOKEN(DT_NODELABEL(gpio0))  // expands to: atmel_sam0_gpio
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @return The binding compatible as a C token.
+ */
+#define DT_BINDING_COMPAT_TOKEN(node_id) DT_CAT(node_id, _BINDING_COMPAT_TOKEN)
+
+/**
+ * @brief Get a node's binding compatible as an uppercased token.
+ *
+ * Like DT_BINDING_COMPAT_TOKEN(), but uppercased.
+ *
+ * Example, assuming the GPIO controller node matched "atmel,sam0-gpio":
+ *
+ * @code{.c}
+ *     DT_BINDING_COMPAT_UPPER_TOKEN(DT_NODELABEL(gpio0))  // expands to: ATMEL_SAM0_GPIO
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @return The binding compatible as an uppercased C token.
+ */
+#define DT_BINDING_COMPAT_UPPER_TOKEN(node_id) DT_CAT(node_id, _BINDING_COMPAT_UPPER_TOKEN)
+
+/**
+ * @brief Get a node's binding compatible as an unquoted sequence of tokens.
+ *
+ * Expands to the compatible string that matched this node's binding,
+ * as a sequence of tokens with no quotes. This can be used in macros
+ * that stringify their argument to produce a string literal.
+ *
+ * Example, assuming the GPIO controller node matched "atmel,sam0-gpio":
+ *
+ * @code{.c}
+ *     DT_BINDING_COMPAT_UNQUOTED(DT_NODELABEL(gpio0))  // expands to: atmel,sam0-gpio
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @return The binding compatible as an unquoted token sequence.
+ */
+#define DT_BINDING_COMPAT_UNQUOTED(node_id) DT_CAT(node_id, _BINDING_COMPAT_UNQUOTED)
+
+/**
  * @brief Does a devicetree node have a compatible and status?
  *
  * This is equivalent to:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -542,6 +542,14 @@ def write_compatibles(node: edtlib.Node) -> None:
     # about whether edtlib / Zephyr's binding language recognizes
     # them. The compatibles the node provides are what is important.
 
+    if node.matching_compat:
+        as_token = edtlib.str_as_token(node.matching_compat)
+        out_dt_define(f"{node.z_path_id}_BINDING_COMPAT_TOKEN", as_token)
+        out_dt_define(f"{node.z_path_id}_BINDING_COMPAT_UPPER_TOKEN", as_token.upper())
+        out_dt_define(
+            f"{node.z_path_id}_BINDING_COMPAT_UNQUOTED", escape_unquoted(node.matching_compat)
+        )
+
     for i, compat in enumerate(node.compats):
         out_dt_define(f"{node.z_path_id}_COMPAT_MATCHES_{str2ident(compat)}", 1)
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -573,6 +573,39 @@ ZTEST(devicetree_api, test_has_compat)
 	zassert_true(DT_INST_NODE_HAS_COMPAT(0, zephyr_model2));
 }
 
+ZTEST(devicetree_api, test_binding_compat)
+{
+	/* test_gpio_1 has compatible "vnd,gpio-device" with a matching binding */
+	const char *token = STRINGIFY(DT_BINDING_COMPAT_TOKEN(TEST_DEADBEEF));
+
+	zexpect_str_equal(token, "vnd_gpio_device");
+
+	const char *upper = STRINGIFY(DT_BINDING_COMPAT_UPPER_TOKEN(TEST_DEADBEEF));
+
+	zexpect_str_equal(upper, "VND_GPIO_DEVICE");
+
+	/* UNQUOTED contains a comma, so wrap in parentheses for STRINGIFY */
+	const char *unquoted = STRINGIFY((DT_BINDING_COMPAT_UNQUOTED(TEST_DEADBEEF)));
+
+	zexpect_str_equal(unquoted, "(vnd,gpio-device)");
+
+	/* TEST_ARRAYS has two compatibles: "vnd,array-holder" (has a binding)
+	 * and "vnd,undefined-compat" (no binding). Only the one with a
+	 * matching binding should be returned.
+	 */
+	const char *arrays_token = STRINGIFY(DT_BINDING_COMPAT_TOKEN(TEST_ARRAYS));
+
+	zexpect_str_equal(arrays_token, "vnd_array_holder");
+
+	const char *arrays_upper = STRINGIFY(DT_BINDING_COMPAT_UPPER_TOKEN(TEST_ARRAYS));
+
+	zexpect_str_equal(arrays_upper, "VND_ARRAY_HOLDER");
+
+	const char *arrays_unquoted = STRINGIFY((DT_BINDING_COMPAT_UNQUOTED(TEST_ARRAYS)));
+
+	zexpect_str_equal(arrays_unquoted, "(vnd,array-holder)");
+}
+
 ZTEST(devicetree_api, test_has_status)
 {
 	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(test_gpio_1), okay),


### PR DESCRIPTION
Add `DT_BINDING_COMPAT`, which allows for getting a node's compatible string at compile time.

This is required for #110787, which requires selecting a driver backend at compile time. This string can then be concatenated onto a function name (instead of using function overrides) to allow for multiple backends to provide distinct functions available at compile time. Please see #110787 for context; the compile time selection is a requirement of that PR.

Assisted-by: Claude:claude-opus-5