### PR TITLE
drivers: sensor: bmm150: restore preset on resume

### DIFF
--- a/drivers/sensor/bosch/bmm150/bmm150.c
+++ b/drivers/sensor/bosch/bmm150/bmm150.c
@@ -624,6 +624,7 @@ err_poweroff:
 
 static int pm_action(const struct device *dev, enum pm_device_action action)
 {
+	struct bmm150_preset preset = bmm150_presets_table[BMM150_DEFAULT_PRESET];
 	int ret = 0;
 
 	switch (action) {
@@ -641,6 +642,25 @@ static int pm_action(const struct device *dev, enum pm_device_action action)
 		}
 
 		k_sleep(BMM150_START_UP_TIME);
+
+		/* Suspend reset the registers, so reprogram the preset */
+		ret = bmm150_set_odr(dev, preset.odr);
+		if (ret != 0) {
+			LOG_ERR("failed to set ODR: %d", ret);
+			return ret;
+		}
+		ret = bmm150_reg_write(dev, BMM150_REG_REP_XY,
+					BMM150_REPXY_TO_REGVAL(preset.rep_xy));
+		if (ret != 0) {
+			LOG_ERR("failed to set REP XY: %d", ret);
+			return ret;
+		}
+		ret = bmm150_reg_write(dev, BMM150_REG_REP_Z,
+					BMM150_REPZ_TO_REGVAL(preset.rep_z));
+		if (ret != 0) {
+			LOG_ERR("failed to set REP Z: %d", ret);
+			return ret;
+		}
 
 		ret |= bmm150_opmode(dev, BMM150_MODE_NORMAL);
 		if (ret != 0) {


### PR DESCRIPTION
All four `CONFIG_BMM150_PRESET_*` options currently behave identically after resume. `bmm150_init_chip()` programs the selected preset and then suspends the device on the way out. Suspend resets the BMM150 registers, so the preset is lost. `PM_DEVICE_ACTION_RESUME` restores power and operating mode, but does not restore the preset.

Verified on hardware with a BMM150 connected through the BMI270 auxiliary interface on an nRF54L15. Using the regular preset, `REP_XY`/`REP_Z` read `0x04`/`0x07` before suspend and `0x00`/`0x00` after resume. With this change, they read back as `0x04`/`0x07` again after resume.

The same register loss occurs on every runtime suspend/resume cycle, so restore the configured preset from the resume path rather than only during initialization.