### PR TITLE
Revert "Bluetooth: CAP: add subprocedure callbacks for unicast start and stop"

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -250,14 +250,6 @@ New APIs and options
     * :c:func:`bt_ascs_unregister`
     * :c:func:`bt_bap_unicast_client_qos_from_group`
     * :c:func:`bt_bap_qos_cfg_eq`
-    * :c:member:`bt_cap_initiator_cb.unicast_start_codec_configured`
-    * :c:member:`bt_cap_initiator_cb.unicast_start_qos_configured`
-    * :c:member:`bt_cap_initiator_cb.unicast_start_enabled`
-    * :c:member:`bt_cap_initiator_cb.unicast_start_connected`
-    * :c:member:`bt_cap_initiator_cb.unicast_start_started`
-    * :c:member:`bt_cap_initiator_cb.unicast_stop_disabled`
-    * :c:member:`bt_cap_initiator_cb.unicast_stop_stopped`
-    * :c:member:`bt_cap_initiator_cb.unicast_stop_released`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -123,73 +123,6 @@ struct bt_cap_initiator_cb {
 	void (*unicast_start_complete)(int err, struct bt_conn *conn);
 
 	/**
-	 * @brief The Codec Configuration subprocedure of
-	 * bt_cap_initiator_unicast_audio_start() has completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
-	 * @ref BT_BAP_EP_STATE_CODEC_CONFIGURED state or higher, with the requested codec
-	 * configuration.
-	 *
-	 * This is only called if at least one Config Codec operation was sent to a CAP acceptor,
-	 * i.e. it is not called if all streams already had the requested codec configuration.
-	 *
-	 * The unicast group may be reconfigured with bt_cap_unicast_group_reconfig() from this
-	 * callback, as the QoS Configuration subprocedure has not been started yet. This is only
-	 * possible if none of the streams in the unicast group have been connected earlier, as the
-	 * unicast group cannot be reconfigured once a CIS has been established. It is not possible
-	 * to start a new CAP procedure from this callback, as the current procedure is still in
-	 * progress.
-	 */
-	void (*unicast_start_codec_configured)(void);
-
-	/**
-	 * @brief The QoS Configuration subprocedure of bt_cap_initiator_unicast_audio_start() has
-	 * completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
-	 * @ref BT_BAP_EP_STATE_QOS_CONFIGURED state or higher, with the QoS configuration of the
-	 * unicast group.
-	 *
-	 * This is only called if at least one Config QoS operation was sent to a CAP acceptor, i.e.
-	 * it is not called if all streams already had the requested QoS configuration.
-	 */
-	void (*unicast_start_qos_configured)(void);
-
-	/**
-	 * @brief The Enable subprocedure of bt_cap_initiator_unicast_audio_start() has completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
-	 * @ref BT_BAP_EP_STATE_ENABLING state or higher, with the requested metadata.
-	 *
-	 * This is only called if at least one Enable operation was sent to a CAP acceptor, i.e. it
-	 * is not called if all streams were already enabled with the requested metadata.
-	 */
-	void (*unicast_start_enabled)(void);
-
-	/**
-	 * @brief The CIS establishment subprocedure of bt_cap_initiator_unicast_audio_start() has
-	 * completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_start() have an established CIS.
-	 *
-	 * This is only called if at least one CIS was established as part of the procedure, i.e. it
-	 * is not called if all CISes were already established.
-	 */
-	void (*unicast_start_connected)(void);
-
-	/**
-	 * @brief The Receiver Start Ready subprocedure of
-	 * bt_cap_initiator_unicast_audio_start() has completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
-	 * @ref BT_BAP_EP_STATE_STREAMING state.
-	 *
-	 * This is only called if at least one Receiver Start Ready operation was sent to a CAP
-	 * acceptor, i.e. it is not called if all streams were started by the CAP acceptors.
-	 */
-	void (*unicast_start_started)(void);
-
-	/**
 	 * @brief Callback for bt_cap_initiator_unicast_audio_update().
 	 *
 	 * @param err
@@ -231,40 +164,6 @@ struct bt_cap_initiator_cb {
 	 *             cancelled by bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_stop_complete)(int err, struct bt_conn *conn);
-
-	/**
-	 * @brief The Disable subprocedure of bt_cap_initiator_unicast_audio_stop() has completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_stop() are in the
-	 * @ref BT_BAP_EP_STATE_DISABLING or @ref BT_BAP_EP_STATE_QOS_CONFIGURED state.
-	 *
-	 * This is only called if at least one Disable operation was sent to a CAP acceptor, i.e. it
-	 * is not called if none of the streams were enabled or streaming.
-	 */
-	void (*unicast_stop_disabled)(void);
-
-	/**
-	 * @brief The Receiver Stop Ready subprocedure of bt_cap_initiator_unicast_audio_stop() has
-	 * completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_stop() are in the
-	 * @ref BT_BAP_EP_STATE_QOS_CONFIGURED state.
-	 *
-	 * This is only called if at least one Receiver Stop Ready operation was sent to a CAP
-	 * acceptor, i.e. it is not called if none of the streams were in the
-	 * @ref BT_BAP_EP_STATE_DISABLING state.
-	 */
-	void (*unicast_stop_stopped)(void);
-
-	/**
-	 * @brief The Release subprocedure of bt_cap_initiator_unicast_audio_stop() has completed.
-	 *
-	 * All streams supplied to bt_cap_initiator_unicast_audio_stop() have been released.
-	 *
-	 * This is only called if at least one Release operation was sent to a CAP acceptor, i.e. it
-	 * is not called if the streams were not requested to be released.
-	 */
-	void (*unicast_stop_released)(void);
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(__DOXYGEN__)
 	/**

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -88,7 +88,6 @@ void bt_cap_common_set_subproc(enum bt_cap_common_subproc_type subproc_type)
 	active_proc.proc_done_cnt = 0U;
 	active_proc.proc_initiated_cnt = 0U;
 	active_proc.subproc_type = subproc_type;
-	active_proc.subproc_initiated = false;
 }
 
 bool bt_cap_common_proc_is_type(enum bt_cap_common_proc_type proc_type)

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1366,87 +1366,6 @@ bool bt_cap_initiator_valid_unicast_audio_start_param(
 	return true;
 }
 
-static bool
-cap_initiator_unicast_subproc_complete_and_continue(const struct bt_cap_common_proc *active_proc)
-{
-	LOG_DBG("subproc %d for proc %d completed (%sinitiated)", active_proc->subproc_type,
-		active_proc->proc_type, !active_proc->subproc_initiated ? "not " : "");
-
-	if (!active_proc->subproc_initiated) {
-		/* The subprocedure was skipped as all streams were already in the requested state,
-		 * so we do not notify the application
-		 */
-		return true;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_active_proc_is_handover()) {
-		/* The procedure was not started by the application, so we do not notify the
-		 * application about the subprocedures
-		 */
-		return true;
-	}
-
-	if (cap_cb == NULL) {
-		return true;
-	}
-
-	switch (active_proc->subproc_type) {
-	case BT_CAP_COMMON_SUBPROC_TYPE_CODEC_CONFIG:
-		if (cap_cb->unicast_start_codec_configured != NULL) {
-			cap_cb->unicast_start_codec_configured();
-		}
-		break;
-	case BT_CAP_COMMON_SUBPROC_TYPE_QOS_CONFIG:
-		if (cap_cb->unicast_start_qos_configured != NULL) {
-			cap_cb->unicast_start_qos_configured();
-		}
-		break;
-	case BT_CAP_COMMON_SUBPROC_TYPE_ENABLE:
-		if (cap_cb->unicast_start_enabled != NULL) {
-			cap_cb->unicast_start_enabled();
-		}
-		break;
-	case BT_CAP_COMMON_SUBPROC_TYPE_CONNECT:
-		if (cap_cb->unicast_start_connected != NULL) {
-			cap_cb->unicast_start_connected();
-		}
-		break;
-	case BT_CAP_COMMON_SUBPROC_TYPE_START:
-		if (cap_cb->unicast_start_started != NULL) {
-			cap_cb->unicast_start_started();
-		}
-		break;
-	case BT_CAP_COMMON_SUBPROC_TYPE_DISABLE:
-		if (cap_cb->unicast_stop_disabled != NULL) {
-			cap_cb->unicast_stop_disabled();
-		}
-		break;
-	case BT_CAP_COMMON_SUBPROC_TYPE_STOP:
-		if (cap_cb->unicast_stop_stopped != NULL) {
-			cap_cb->unicast_stop_stopped();
-		}
-		break;
-	case BT_CAP_COMMON_SUBPROC_TYPE_RELEASE:
-		if (cap_cb->unicast_stop_released != NULL) {
-			cap_cb->unicast_stop_released();
-		}
-		break;
-	default:
-		break;
-	}
-
-	if (bt_cap_common_proc_is_aborted()) {
-		__ASSERT(bt_cap_common_proc_all_handled(),
-			 "CAP procedure is aborted but not all subprocs were handled after "
-			 "subproc_complete: %u != %u",
-			 active_proc->proc_done_cnt, active_proc->proc_cnt);
-
-		return false;
-	}
-
-	return true;
-}
-
 void cap_initiator_unicast_audio_proc_complete(struct bt_cap_common_proc *active_proc)
 {
 	enum bt_cap_common_proc_type proc_type;
@@ -1602,7 +1521,6 @@ cap_initiator_unicast_audio_configure(struct bt_cap_common_proc *active_proc,
 	active_proc->proc_initiated_cnt++;
 	proc_param->in_progress = true;
 
-	active_proc->subproc_initiated = true;
 	if (bap_stream->conn == NULL) {
 		/* Since BAP operations may require a write long or a read long on the notification,
 		 * we cannot assume that we can do multiple streams at once, thus do it one at a
@@ -1737,7 +1655,6 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		if (next_bap_stream->conn == NULL) {
 			err = bt_bap_stream_config(conn, next_bap_stream, ep, codec_cfg);
@@ -1790,12 +1707,6 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		}
 	}
 
-	if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
-		cap_initiator_unicast_audio_proc_complete(active_proc);
-
-		return;
-	}
-
 	/* All streams in the procedure share the same unicast group, so we just
 	 * use the reference from the first stream
 	 */
@@ -1830,7 +1741,6 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		}
 
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_qos(conns[i], unicast_group);
 		if (err != 0) {
@@ -1906,12 +1816,6 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 			return;
 		}
 
-		if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
-			cap_initiator_unicast_audio_proc_complete(active_proc);
-
-			return;
-		}
-
 		bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_ENABLE);
 		proc_param = get_next_proc_param(active_proc);
 		if (proc_param == NULL) {
@@ -1929,7 +1833,6 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 		bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		codec_cfg = proc_param->start.codec_cfg;
 
@@ -1955,7 +1858,6 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_release(next_bap_stream);
 		if (err != 0) {
@@ -2023,7 +1925,6 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 
 		proc_param->in_progress = true;
 		codec_cfg = proc_param->start.codec_cfg;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_enable(next_bap_stream, codec_cfg->meta, codec_cfg->meta_len);
 		if (err != 0) {
@@ -2034,12 +1935,6 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		} else {
 			bt_cap_common_unlock_proc();
 		}
-
-		return;
-	}
-
-	if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
-		cap_initiator_unicast_audio_proc_complete(active_proc);
 
 		return;
 	}
@@ -2058,7 +1953,6 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 
 	bap_stream = &proc_param->stream->bap_stream;
 	proc_param->in_progress = true;
-	active_proc->subproc_initiated = true;
 
 	err = bt_bap_stream_connect(bap_stream);
 	if (err == -EALREADY) {
@@ -2067,7 +1961,6 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		 * calling this
 		 */
 		proc_param->in_progress = false;
-		active_proc->subproc_initiated = false;
 		bt_cap_initiator_connected(proc_param->stream);
 
 		bt_cap_common_unlock_proc();
@@ -2081,6 +1974,7 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		bt_cap_common_abort_proc(bap_stream->conn, err);
 		cap_initiator_unicast_audio_proc_complete(active_proc);
 	} else {
+
 		bt_cap_common_unlock_proc();
 	}
 }
@@ -2143,7 +2037,6 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 
 			active_proc->proc_initiated_cnt++;
 			proc_param->in_progress = true;
-			active_proc->subproc_initiated = true;
 
 			err = bt_bap_stream_connect(next_bap_stream);
 			if (err == 0 || err == -EALREADY) {
@@ -2162,12 +2055,6 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 		} /* else pending connection - wait for connected callback */
 
 		bt_cap_common_unlock_proc();
-
-		return;
-	}
-
-	if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
-		cap_initiator_unicast_audio_proc_complete(active_proc);
 
 		return;
 	}
@@ -2191,7 +2078,6 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 	bap_stream = &proc_param->stream->bap_stream;
 	if (stream_is_dir(bap_stream, BT_AUDIO_DIR_SOURCE)) {
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_start(bap_stream);
 		if (err != 0) {
@@ -2264,7 +2150,6 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 				int err;
 
 				proc_param->in_progress = true;
-				active_proc->subproc_initiated = true;
 
 				err = bt_bap_stream_start(next_bap_stream);
 				if (err != 0) {
@@ -2288,8 +2173,6 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 		/* Return to await for response from server */
 		return;
 	}
-
-	(void)cap_initiator_unicast_subproc_complete_and_continue(active_proc);
 
 	cap_initiator_unicast_audio_proc_complete(active_proc);
 }
@@ -2757,7 +2640,6 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 		bap_stream = &proc_param->stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_disable(bap_stream);
 		if (err != 0) {
@@ -2775,7 +2657,6 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 		bap_stream = &proc_param->stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_stop(bap_stream);
 		if (err != 0) {
@@ -2793,7 +2674,6 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 		bap_stream = &proc_param->stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_release(bap_stream);
 		if (err != 0) {
@@ -2878,7 +2758,6 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_disable(next_bap_stream);
 		if (err != 0) {
@@ -2894,12 +2773,6 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		struct bt_cap_stream *next_cap_stream;
 		struct bt_bap_stream *next_bap_stream;
 		int err;
-
-		if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
-			cap_initiator_unicast_audio_proc_complete(active_proc);
-
-			return;
-		}
 
 		bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_STOP);
 
@@ -2919,7 +2792,6 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_stop(next_bap_stream);
 		if (err != 0) {
@@ -2989,7 +2861,6 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 
 			active_proc->proc_initiated_cnt++;
 			proc_param->in_progress = true;
-			active_proc->subproc_initiated = true;
 
 			err = bt_bap_stream_stop(next_bap_stream);
 			if (err != 0) {
@@ -3013,12 +2884,6 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 		if (!bt_cap_common_proc_is_done()) {
 			/* We are still disabling or stopping some */
 			bt_cap_common_unlock_proc();
-
-			return;
-		}
-
-		if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
-			cap_initiator_unicast_audio_proc_complete(active_proc);
 
 			return;
 		}
@@ -3092,7 +2957,6 @@ void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
-		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_release(next_bap_stream);
 		if (err != 0) {
@@ -3104,8 +2968,6 @@ void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
 			bt_cap_common_unlock_proc();
 		}
 	} else {
-
-		(void)cap_initiator_unicast_subproc_complete_and_continue(active_proc);
 		cap_initiator_unicast_audio_proc_complete(active_proc);
 	}
 }

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -282,8 +282,6 @@ struct bt_cap_common_proc {
 	struct bt_cap_common_proc_param proc_param;
 #if defined(CONFIG_BT_CAP_SUBPROC_SUPPORT)
 	enum bt_cap_common_subproc_type subproc_type;
-	/* Whether any request has been sent to a peer device for the current subprocedure */
-	bool subproc_initiated;
 #endif /* CONFIG_BT_CAP_SUBPROC_SUPPORT */
 };
 

--- a/tests/bluetooth/audio/cap_initiator/include/cap_initiator.h
+++ b/tests/bluetooth/audio/cap_initiator/include/cap_initiator.h
@@ -22,16 +22,8 @@ DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_discovery_complete_cb, struct 
 		       const struct bt_csip_set_coordinator_set_member *,
 		       const struct bt_csip_set_coordinator_csis_inst *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_complete_cb, int, struct bt_conn *);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_codec_configured_cb);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_qos_configured_cb);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_enabled_cb);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_connected_cb);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_started_cb);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_update_complete_cb, int, struct bt_conn *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_complete_cb, int, struct bt_conn *);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_disabled_cb);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_stopped_cb);
-DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_released_cb);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_started_cb, struct bt_cap_broadcast_source *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_stopped_cb, struct bt_cap_broadcast_source *,
 		       uint8_t);

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -228,18 +228,6 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start)
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	/* All streams started from the idle state, so all subprocedures were performed */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 1,
-			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 1,
-			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_enabled", 1,
-			   mock_cap_initiator_unicast_start_enabled_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_connected", 1,
-			   mock_cap_initiator_unicast_start_connected_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_started", 1,
-			   mock_cap_initiator_unicast_start_started_cb_fake.call_count);
-
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
 
@@ -433,17 +421,8 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	/* The streams had a different codec configuration, so the Codec Configuration
-	 * subprocedure was performed
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 1,
-			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 1,
-			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
-
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
-
 	zassert_equal(0, mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0], "%d",
 		      mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0]);
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
@@ -466,7 +445,9 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_qos_configured)
 {
-	/* Use a different preset than fixture->preset to also verify that the qos is updated */
+	/* Use a different preset than fixture->preset to also verify that the codec_cfg data is
+	 * updated
+	 */
 	struct bt_bap_lc3_preset preset =
 		(struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_48_2_1(
 			BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
@@ -505,17 +486,8 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	/* The streams were already codec configured, so that subprocedure was skipped, but the
-	 * QoS configuration was different so that subprocedure was performed
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 0,
-			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 1,
-			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
-
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
-
 	zassert_equal(0, mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0], "%d",
 		      mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0]);
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
@@ -555,16 +527,6 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
-
-	/* The streams were already enabled with the requested configuration and metadata, so the
-	 * Codec Configuration, QoS Configuration and Enable subprocedures were all skipped
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 0,
-			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 0,
-			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_start_enabled", 0,
-			   mock_cap_initiator_unicast_start_enabled_cb_fake.call_count);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -284,16 +284,6 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	/* The streams were streaming or enabling, so both the Disable and the Receiver Stop Ready
-	 * subprocedures were performed, but the streams were not released
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
-			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
-			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 0,
-			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
-
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
@@ -318,16 +308,6 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
-
-	/* The streams were streaming or enabling, so both the Disable and the Receiver Stop Ready
-	 * subprocedures were performed, but the streams were not released
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
-			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
-			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 0,
-			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
@@ -357,16 +337,6 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	/* The streams were not streaming or enabling, so only the Release subprocedure was
-	 * performed
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 0,
-			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 0,
-			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
-			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
-
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 
@@ -394,16 +364,6 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	/* The streams were not streaming or enabling, so only the Release subprocedure was
-	 * performed
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 0,
-			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 0,
-			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
-			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
-
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 
@@ -430,16 +390,6 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	/* The streams were streaming or enabling and were requested to be released, so all
-	 * subprocedures were performed
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
-			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
-			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
-			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
-
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 
@@ -465,16 +415,6 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
-
-	/* The streams were streaming or enabling and were requested to be released, so all
-	 * subprocedures were performed
-	 */
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
-			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
-			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
-			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 

--- a/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
@@ -16,32 +16,16 @@
 #define FFF_FAKES_LIST(FAKE)                                                                       \
 	FAKE(mock_cap_initiator_unicast_discovery_complete_cb)                                     \
 	FAKE(mock_cap_initiator_unicast_start_complete_cb)                                         \
-	FAKE(mock_cap_initiator_unicast_start_codec_configured_cb)                                 \
-	FAKE(mock_cap_initiator_unicast_start_qos_configured_cb)                                   \
-	FAKE(mock_cap_initiator_unicast_start_enabled_cb)                                          \
-	FAKE(mock_cap_initiator_unicast_start_connected_cb)                                        \
-	FAKE(mock_cap_initiator_unicast_start_started_cb)                                          \
 	FAKE(mock_cap_initiator_unicast_update_complete_cb)                                        \
-	FAKE(mock_cap_initiator_unicast_stop_complete_cb)                                          \
-	FAKE(mock_cap_initiator_unicast_stop_disabled_cb)                                          \
-	FAKE(mock_cap_initiator_unicast_stop_stopped_cb)                                           \
-	FAKE(mock_cap_initiator_unicast_stop_released_cb)
+	FAKE(mock_cap_initiator_unicast_stop_complete_cb)
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_discovery_complete_cb, struct bt_conn *, int,
 		      const struct bt_csip_set_coordinator_set_member *,
 		      const struct bt_csip_set_coordinator_csis_inst *);
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_complete_cb, int, struct bt_conn *);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_codec_configured_cb);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_qos_configured_cb);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_enabled_cb);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_connected_cb);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_started_cb);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_update_complete_cb, int, struct bt_conn *);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_complete_cb, int, struct bt_conn *);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_disabled_cb);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_stopped_cb);
-DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_released_cb);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_started_cb, struct bt_cap_broadcast_source *);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_stopped_cb, struct bt_cap_broadcast_source *,
 		      uint8_t);
@@ -50,16 +34,8 @@ const struct bt_cap_initiator_cb mock_cap_initiator_cb = {
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 	.unicast_discovery_complete = mock_cap_initiator_unicast_discovery_complete_cb,
 	.unicast_start_complete = mock_cap_initiator_unicast_start_complete_cb,
-	.unicast_start_codec_configured = mock_cap_initiator_unicast_start_codec_configured_cb,
-	.unicast_start_qos_configured = mock_cap_initiator_unicast_start_qos_configured_cb,
-	.unicast_start_enabled = mock_cap_initiator_unicast_start_enabled_cb,
-	.unicast_start_connected = mock_cap_initiator_unicast_start_connected_cb,
-	.unicast_start_started = mock_cap_initiator_unicast_start_started_cb,
 	.unicast_update_complete = mock_cap_initiator_unicast_update_complete_cb,
 	.unicast_stop_complete = mock_cap_initiator_unicast_stop_complete_cb,
-	.unicast_stop_disabled = mock_cap_initiator_unicast_stop_disabled_cb,
-	.unicast_stop_stopped = mock_cap_initiator_unicast_stop_stopped_cb,
-	.unicast_stop_released = mock_cap_initiator_unicast_stop_released_cb,
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 	.broadcast_started = mock_cap_initiator_broadcast_started_cb,

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -96,16 +96,8 @@ CREATE_FLAG(flag_endpoint_found);
 CREATE_FLAG(flag_started);
 CREATE_FLAG(flag_start_failed);
 CREATE_FLAG(flag_start_timeout);
-CREATE_FLAG(flag_start_codec_configured_subproc);
-CREATE_FLAG(flag_start_qos_configured_subproc);
-CREATE_FLAG(flag_start_enabled_subproc);
-CREATE_FLAG(flag_start_connected_subproc);
-CREATE_FLAG(flag_start_started_subproc);
 CREATE_FLAG(flag_updated);
 CREATE_FLAG(flag_stopped);
-CREATE_FLAG(flag_stop_disabled_subproc);
-CREATE_FLAG(flag_stop_stopped_subproc);
-CREATE_FLAG(flag_stop_released_subproc);
 CREATE_FLAG(flag_mtu_exchanged);
 CREATE_FLAG(flag_sink_discovered);
 CREATE_FLAG(flag_source_discovered);
@@ -276,41 +268,6 @@ static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 	}
 }
 
-static void unicast_start_codec_configured_cb(void)
-{
-	LOG_INF("All streams codec configured");
-
-	SET_FLAG(flag_start_codec_configured_subproc);
-}
-
-static void unicast_start_qos_configured_cb(void)
-{
-	LOG_INF("All streams QoS configured");
-
-	SET_FLAG(flag_start_qos_configured_subproc);
-}
-
-static void unicast_start_enabled_cb(void)
-{
-	LOG_INF("All streams enabled");
-
-	SET_FLAG(flag_start_enabled_subproc);
-}
-
-static void unicast_start_connected_cb(void)
-{
-	LOG_INF("All streams connected");
-
-	SET_FLAG(flag_start_connected_subproc);
-}
-
-static void unicast_start_started_cb(void)
-{
-	LOG_INF("All streams started");
-
-	SET_FLAG(flag_start_started_subproc);
-}
-
 static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 {
 	if (err != 0) {
@@ -333,40 +290,11 @@ static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 	SET_FLAG(flag_stopped);
 }
 
-static void unicast_stop_disabled_cb(void)
-{
-	LOG_INF("All streams disabled");
-
-	SET_FLAG(flag_stop_disabled_subproc);
-}
-
-static void unicast_stop_stopped_cb(void)
-{
-	LOG_INF("All streams stopped");
-
-	SET_FLAG(flag_stop_stopped_subproc);
-}
-
-static void unicast_stop_released_cb(void)
-{
-	LOG_INF("All streams released");
-
-	SET_FLAG(flag_stop_released_subproc);
-}
-
 static struct bt_cap_initiator_cb cap_cb = {
 	.unicast_discovery_complete = cap_discovery_complete_cb,
 	.unicast_start_complete = unicast_start_complete_cb,
-	.unicast_start_codec_configured = unicast_start_codec_configured_cb,
-	.unicast_start_qos_configured = unicast_start_qos_configured_cb,
-	.unicast_start_enabled = unicast_start_enabled_cb,
-	.unicast_start_connected = unicast_start_connected_cb,
-	.unicast_start_started = unicast_start_started_cb,
 	.unicast_update_complete = unicast_update_complete_cb,
 	.unicast_stop_complete = unicast_stop_complete_cb,
-	.unicast_stop_disabled = unicast_stop_disabled_cb,
-	.unicast_stop_stopped = unicast_stop_stopped_cb,
-	.unicast_stop_released = unicast_stop_released_cb,
 };
 
 static void add_remote_sink(const struct bt_conn *conn, struct bt_bap_ep *ep)
@@ -755,25 +683,6 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 	return true;
 }
 
-static bool stream_is_in_state(const struct bt_cap_stream *cap_stream, enum bt_bap_ep_state state)
-{
-	struct bt_bap_ep_info ep_info;
-	int err;
-
-	if (cap_stream->bap_stream.ep == NULL) {
-		return BT_BAP_EP_STATE_IDLE;
-	}
-
-	err = bt_bap_ep_get_info(cap_stream->bap_stream.ep, &ep_info);
-	if (err != 0) {
-		LOG_DBG("Failed to get endpoint info %p: %d", cap_stream, err);
-
-		return BT_BAP_EP_STATE_IDLE;
-	}
-
-	return ep_info.state == state;
-}
-
 static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool wait)
 {
 	struct bt_cap_unicast_audio_start_stream_param stream_param[2];
@@ -794,32 +703,6 @@ static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool
 	stream_param[1].ep = unicast_source_eps[bt_conn_index(default_conn)][0];
 	stream_param[1].codec_cfg = &unicast_preset_16_2_1.codec_cfg;
 
-	/* Unset flags based on the stream EP and ISO states, as some subprocedures may be skipped
-	 * if all streams are already in that state
-	 */
-	for (size_t i = 0U; i < param.count; i++) {
-		if (stream_is_in_state(param.stream_params->stream, BT_BAP_EP_STATE_IDLE)) {
-			UNSET_FLAG(flag_start_codec_configured_subproc);
-		}
-
-		if (stream_is_in_state(param.stream_params->stream,
-				       BT_BAP_EP_STATE_CODEC_CONFIGURED)) {
-			UNSET_FLAG(flag_start_qos_configured_subproc);
-		}
-
-		if (stream_is_in_state(param.stream_params->stream,
-				       BT_BAP_EP_STATE_QOS_CONFIGURED)) {
-			UNSET_FLAG(flag_start_enabled_subproc);
-		}
-
-		if (stream_is_in_state(param.stream_params->stream, BT_BAP_EP_STATE_ENABLING)) {
-			UNSET_FLAG(flag_start_started_subproc);
-		}
-
-		if (param.stream_params->stream->bap_stream.iso == NULL) {
-			UNSET_FLAG(flag_start_connected_subproc);
-		}
-	}
 	UNSET_FLAG(flag_started);
 
 	err = bt_cap_initiator_unicast_audio_start(&param);
@@ -829,14 +712,6 @@ static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool
 	}
 
 	if (wait) {
-		/* The streams were all in the idle state, so all subprocedures shall have been
-		 * performed
-		 */
-		WAIT_FOR_FLAG(flag_start_codec_configured_subproc);
-		WAIT_FOR_FLAG(flag_start_qos_configured_subproc);
-		WAIT_FOR_FLAG(flag_start_enabled_subproc);
-		WAIT_FOR_FLAG(flag_start_connected_subproc);
-		WAIT_FOR_FLAG(flag_start_started_subproc);
 		WAIT_FOR_FLAG(flag_started);
 		/* let other devices know we have started what we wanted */
 		backchannel_sync_send_all();
@@ -958,9 +833,6 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 
 	/* Stop without release first to verify that we enter the QoS Configured state */
 	UNSET_FLAG(flag_stopped);
-	UNSET_FLAG(flag_stop_disabled_subproc);
-	UNSET_FLAG(flag_stop_stopped_subproc);
-	UNSET_FLAG(flag_stop_released_subproc);
 	LOG_INF("Stopping without releasing");
 
 	/* Mark streams as stopping to not treat lost SDUs as a failure condition */
@@ -978,15 +850,6 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 	}
 
 	WAIT_FOR_FLAG(flag_stopped);
-	/* The streams were all streaming, so both the disable and the receiver stop ready
-	 * subprocedures shall have been performed, but the streams shall not have been released
-	 */
-	WAIT_FOR_FLAG(flag_stop_disabled_subproc);
-	WAIT_FOR_FLAG(flag_stop_stopped_subproc);
-	if (TEST_FLAG(flag_stop_released_subproc)) {
-		FAIL("Streams released without being requested to\n");
-		return;
-	}
 
 	/* Verify that it cannot be stopped twice */
 	err = bt_cap_initiator_unicast_audio_stop(&param);
@@ -998,9 +861,6 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 
 	/* Stop with release first to verify that we enter the idle state */
 	UNSET_FLAG(flag_stopped);
-	UNSET_FLAG(flag_stop_disabled_subproc);
-	UNSET_FLAG(flag_stop_stopped_subproc);
-	UNSET_FLAG(flag_stop_released_subproc);
 	param.release = true;
 	LOG_INF("Releasing");
 
@@ -1011,14 +871,6 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 	}
 
 	WAIT_FOR_FLAG(flag_stopped);
-	/* The streams were already in the QoS Configured state, so only the release subprocedure
-	 * shall have been performed
-	 */
-	WAIT_FOR_FLAG(flag_stop_released_subproc);
-	if (TEST_FLAG(flag_stop_disabled_subproc) || TEST_FLAG(flag_stop_stopped_subproc)) {
-		FAIL("Streams disabled or stopped when they were already stopped\n");
-		return;
-	}
 
 	/* Verify that it cannot be stopped twice */
 	err = bt_cap_initiator_unicast_audio_stop(&param);


### PR DESCRIPTION
Reverts the last 2 commits of https://github.com/zephyrproject-rtos/zephyr/pull/116355

Hotfix for CI