### PR TITLE
tests: kernel: fatal: expect the fault printk_reentrancy provokes

### DIFF
--- a/tests/kernel/fatal/printk_reentrancy/tests.yaml
+++ b/tests/kernel/fatal/printk_reentrancy/tests.yaml
@@ -2,6 +2,9 @@ common:
   tags:
     - kernel
     - printk
+  # Taking the fault is the point of the test, so the fatal error report
+  # in the output is the expected outcome rather than a crash.
+  ignore_faults: true
   # A fault taken inside printk() must still be reported. Without a lock
   # free reporting path the fault handler blocks on the printk lock the
   # faulting context already holds, and the test times out rather than


### PR DESCRIPTION
`kernel.fatal.printk_reentrancy` and its `.logging` variant fail on all three allowed platforms in main's twister runs, e.g. [run 32285312782](https://github.com/zephyrproject-rtos/zephyr/actions/runs/32285312782/job/96173549745), with `Fault detected while running test`. The suite itself passes: the test faults on purpose from inside `printk()`, and twister reads the resulting fatal error banner as a crash.

Adding `ignore_faults: true`, as the other tests under `tests/kernel/fatal` already do, fixes all six configurations. Verified locally on mps2/an385, qemu_cortex_a53/smp and qemu_x86_64/atom: 6/6 fail before, 6/6 pass after.