### PR TITLE
drivers: mspi: stm32: fix XSPI commands without an address phase

### DIFF
--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -381,7 +381,8 @@ static int mspi_stm32_ospi_access(const struct device *dev, const struct mspi_xf
 		cmd.DataMode = HAL_OSPI_DATA_NONE;
 	}
 
-	if ((cmd.Instruction == MSPI_NOR_CMD_WREN) || (cmd.Instruction == MSPI_NOR_OCMD_WREN)) {
+	if (dev_data->ctx.xfer.addr_length == 0) {
+		/* Commands without an address phase, e.g. RDID or WREN */
 		cmd.AddressMode = HAL_OSPI_ADDRESS_NONE;
 	}
 

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -508,7 +508,8 @@ static int mspi_stm32_qspi_access(const struct device *dev, const struct mspi_xf
 		cmd.DataMode = QSPI_DATA_NONE;
 	}
 
-	if (cmd.Instruction == MSPI_NOR_CMD_WREN) {
+	if (dev_data->ctx.xfer.addr_length == 0) {
+		/* Commands without an address phase, e.g. RDID or WREN */
 		cmd.AddressMode = QSPI_ADDRESS_NONE;
 	}
 

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -466,8 +466,8 @@ indirect:
 		cmd.DataMode = HAL_XSPI_DATA_NONE;
 	}
 
-	if ((cmd.Instruction == MSPI_NOR_CMD_WREN) || (cmd.Instruction == MSPI_NOR_OCMD_WREN)) {
-		/* Write Enable only accepts HAL_XSPI_ADDRESS_NONE */
+	if (dev_data->ctx.xfer.addr_length == 0) {
+		/* Commands without an address phase, e.g. RDID or WREN */
 		cmd.AddressMode = HAL_XSPI_ADDRESS_NONE;
 	}
 


### PR DESCRIPTION
## The problem
The STM32 XSPI MSPI driver sends an address phase with every command except WREN. The most visible consequence is that Read JEDEC ID (`0x9F`) returns zeros, so any flash node that carries a `jedec-id` property fails to initialize: `flash_mspi_nor` compares the ID it read against the devicetree value, does not match, and returns `-ENODEV`. Problem occured when I tested the **mspi_flash** demo on **nucleo_u3c5zi_q** + **b_m2mem_pack1** shield (card **MB1928-33LB** with Winbond **W25Q16JVSNIQ** flash memory)

## The fix
Replace the opcode-specific special case
```
if ((cmd.Instruction == MSPI_NOR_CMD_WREN) || (cmd.Instruction == MSPI_NOR_OCMD_WREN)) {
    /* Write Enable only accepts HAL_XSPI_ADDRESS_NONE */
    cmd.AddressMode = HAL_XSPI_ADDRESS_NONE;
}
```
 with the general rule: 
```
if (dev_data->ctx.xfer.addr_length == 0) {
	/* Commands without an address phase, e.g. RDID or WREN */
	cmd.AddressMode = HAL_XSPI_ADDRESS_NONE;
}

```
## The verification
*Tested on nucleo_u3c5zi_q + b_m2mem_pack1 hardware*

###  Console log before fix
```
[00:00:00.000,000] <dbg> flash_stm32.stm32_flash_init: Flash @0x8000000 initialized. BS: 16
[00:00:00.000,000] <dbg> flash_stm32.stm32_flash_init: Block 0: bs: 4096 count: 512
[00:00:00.000,000] <dbg> mspi_stm32_xspi.mspi_hal_init: MSPI Init'd
[00:00:00.000,000] <dbg> mspi_stm32_xspi.mspi_configure_delay_block: Delay Block Init
[00:00:00.000,000] <inf> mspi_stm32_xspi: MSPI configured
[00:00:00.000,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x9f
[00:00:00.000,000] <err> flash_mspi_nor: JEDEC ID mismatch, read: 00 00 00, expected: ef 40 15
*** Booting Zephyr OS build v4.4.0-12054-gf1a387bf2917 ***
mspi-nor-flash@0: device not ready.
```

### Console log after fix

```
mspi-nor-flash@0 SPI flash testing
==========================

Perform test on single sector
Test 1: Flash erase
[00:00:00.000,000] <dbg> flash_stm32.stm32_flash_init: Flash @0x8000000 initialized. BS: 16
[00:00:00.000,000] <dbg> flash_stm32.stm32_flash_init: Block 0: bs: 4096 count: 512
[00:00:00.000,000] <dbg> mspi_stm32_xspi.mspi_hal_init: MSPI Init'd
[00:00:00.000,000] <dbg> mspi_stm32_xspi.mspi_coFlash erase succeeded!

Test 2: Flash write
Attempting to write 4 bytes
Data read matches data written. Good!!

Perform test on multiple consecutive sectors
Test 1: Flash erase
nfigure_delay_block: Delay Block Init
[00:00:00.000,000] <inf> mspi_stm32_xspi: MSPI configured
[00:00:00.000,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x9f
[00:00:00.000,000] <dbg> flash_mspi_nor.drv_init: mspi-nor-flash@0 - size: 2097152, page 256
[00:00:00.000,000] <dbg> flash_mspi_nor.drv_init: - read command: 0xEB with 0 mode bit and 8 dummy cycles
[00:00:00.000,000] <dbg> flash_mspi_nor.drv_init: - page program command: 0x32
[00:00:00.000,000] <dbg> flash_mspi_nor.drv_init: - erase types:
[00:00:00.000,000] <dbg> flash_mspi_nor.drv_init:   - command: 0x20, size: 4096Flash erase succeeded!

Test 2: Flash write
Attempting to write 4 bytes at offset 0xff000
Data read matches data written. Good!!
Attempting to write 4 bytes at offset 0x100000
Data read matches data written. Good!!
==========================

*** Booting Zephyr OS build v4.4.0-12054-gf1a387bf2917 ***
[00:00:00.010,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x6
[00:00:00.010,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x20
[00:00:00.010,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_status_reg: MSPI poll status reg
[00:00:00.045,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x6
[00:00:00.045,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x32
[00:00:00.045,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_status_reg: MSPI poll status reg
[00:00:00.045,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0xeb
[00:00:00.054,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x6
[00:00:00.054,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x20
[00:00:00.054,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_status_reg: MSPI poll status reg
[00:00:00.085,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x6
[00:00:00.085,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x20
[00:00:00.085,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_status_reg: MSPI poll status reg
[00:00:00.114,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0xeb
[00:00:00.114,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0xeb
[00:00:00.122,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x6
[00:00:00.122,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x32
[00:00:00.122,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_status_reg: MSPI poll status reg
[00:00:00.122,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0xeb
[00:00:00.129,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x6
[00:00:00.129,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0x32
[00:00:00.129,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_status_reg: MSPI poll status reg
[00:00:00.129,000] <dbg> mspi_stm32_xspi.mspi_stm32_xspi_access: MSPI access Instruction 0xeb
```