### PR TITLE
MAX32666FTHR: usb and feather SPI/I2C support

### DIFF
--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
@@ -134,6 +134,19 @@
 	pinctrl-names = "default";
 };
 
+feather_spi: &spi2 {
+	status = "okay";
+	pinctrl-0 = <&spi2_mosi_p0_25 &spi2_miso_p0_26 &spi2_sck_p0_27>;
+	cs-gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+	pinctrl-names = "default";
+};
+
+feather_i2c: &i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0_scl_p0_6 &i2c0_sda_p0_7>;
+	pinctrl-names = "default";
+};
+
 &w1 {
 	pinctrl-0 = <&owm_io_p0_12>;
 	pinctrl-names = "default";

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -196,4 +196,8 @@ feather_i2c: &i2c0 {
 &sdhc_cdn_p1_7 {
 	power-source = <MAX32_VSEL_VDDIOH>;
 	drive-strength = <1>;
+};
+
+zephyr_udc0: &usbhs {
+	status = "okay";
 };

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
@@ -21,6 +21,8 @@ supported:
   - w1
   - feather_spi
   - feather_i2c
+  - usbd
+  - usb_device
   - flash
 ram: 128
 flash: 1024

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
@@ -19,6 +19,8 @@ supported:
   - rtc_counter
   - pwm
   - w1
+  - feather_spi
+  - feather_i2c
   - flash
 ram: 128
 flash: 1024


### PR DESCRIPTION
Round out the hardware support on the MAX32666FTHR by adding USB support, and properly exposing feather I2C/SPI pins.