### PR TITLE
toolchain: Fix concat in TOOLCHAIN_PRAGMA_UNROLL

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -359,7 +359,8 @@ do {                                                                    \
  * @param n Maximum iteration count (must be a literal integer).
  */
 #ifndef TOOLCHAIN_PRAGMA_UNROLL
-#define TOOLCHAIN_PRAGMA_UNROLL(n) _Pragma("GCC unroll " #n)
+#define _TOOLCHAIN_PRAGMA_UNROLL(x) _Pragma(#x)
+#define TOOLCHAIN_PRAGMA_UNROLL(n) _TOOLCHAIN_PRAGMA_UNROLL(GCC unroll n)
 #endif
 
 /*


### PR DESCRIPTION
This fixes a concatenation issue in TOOLCHAIN_PRAGMA_UNROLL when it is nested in another macro.

`_Pragma` seems to require exactly 1 argument and does not concatenate when nested in another macro. Instead of `_Pragma("GCC unroll 256")` it is `_Pragma("GCC unroll " "256")`, which does not work.

This is a hotfix for an error I just found in #114239. This is not yet used in any other drivers (was just merged). I have verified that this compiles and works on hardware with #110787/#111218.

Assisted-by: Claude:claude-opus-5