### PR TITLE
MAINTAINERS: add NUCODE Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4225,6 +4225,15 @@ NEORV32 platform:
   tests:
     - boards.neorv32
 
+NUCODE Platforms:
+  status: maintained
+  maintainers:
+    - manjae-cho
+  files:
+    - boards/nucode/
+  labels:
+    - "platform: NUCODE"
+
 NVMEM:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add a dedicated `NUCODE Platforms` area covering `boards/nucode/` and
nominate @manjae-cho as its maintainer.

I am the original author of the NU40 (#107151) and NU32 (#110171) board
ports. Since their introduction, I have continued maintaining and validating
both boards on physical hardware, including #110041, #114185, and #114573.

I also participate in review and validation outside the proposed area,
including #114480 and #114355.

The scope is intentionally limited to `boards/nucode/`. I will maintain the
NU32 and NU40 board support, review NUCODE board changes, validate mainline
and releases on physical hardware, and respond to regressions in this directory.

Note: `platform: NUCODE` is a new label and will need to be created.

Approval is requested from the MAINTAINERS file representatives,
@MaureenHelm and @nashif. @kartben, Boards/SoCs context and feedback would
also be appreciated.
