### PR TITLE
shields: st: b_m2mem_pack1: fix LDO timeout; complete overlay ID configuration for MB1927_18BA; fix quad mode on MB1928-33LA

### DIFF
--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_18ba.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_18ba.overlay
@@ -35,6 +35,13 @@
 		/* TODO: Add jedec-id */
 
 		reset-gpios = <&m2mem_ldo_en M2MEM_CONNECTOR_GPIO_LDO_EN GPIO_ACTIVE_LOW>;
+		/* The reset line drives the module LDO enable, so a reset is a
+		 * power cycle. Keep the rail down long enough for the memory to
+		 * lose its volatile configuration, then let it start up before
+		 * the first command.
+		 */
+		t-reset-pulse = <5000000>;
+		t-reset-recovery = <10000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_18ba.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_18ba.overlay
@@ -25,14 +25,11 @@
 		read-command = <0xec13>;
 		write-command = <0x12ed>;
 		command-length = "INSTR_2_BYTE";
-
-		/* TODO:
-		 * mx25uw25645 datasheet: Confirm octal STR read dummy cycles.
-		 * placeholder value mirrors mx25lm51245 (33ba) - should be verified
+		/* The number of dummy cycles for the octal read is taken from
+		 * configuration register 2 of the memory itself, see the
+		 * mxicy,mx25u quirk, so rx-dummy is deliberately not set here.
 		 */
-		rx-dummy = <20>;
-
-		/* TODO: Add jedec-id */
+		jedec-id = [c2 81 39];
 
 		reset-gpios = <&m2mem_ldo_en M2MEM_CONNECTOR_GPIO_LDO_EN GPIO_ACTIVE_LOW>;
 		/* The reset line drives the module LDO enable, so a reset is a

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_33ba.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_33ba.overlay
@@ -29,6 +29,13 @@
 		jedec-id = [c2 85 3a];
 
 		reset-gpios = <&m2mem_ldo_en M2MEM_CONNECTOR_GPIO_LDO_EN GPIO_ACTIVE_LOW>;
+		/* The reset line drives the module LDO enable, so a reset is a
+		 * power cycle. Keep the rail down long enough for the memory to
+		 * lose its volatile configuration, then let it start up before
+		 * the first command.
+		 */
+		t-reset-pulse = <5000000>;
+		t-reset-recovery = <10000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33la.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33la.overlay
@@ -31,6 +31,13 @@
 		jedec-id = [9d 60 16];
 
 		reset-gpios = <&m2mem_ldo_en M2MEM_CONNECTOR_GPIO_LDO_EN GPIO_ACTIVE_LOW>;
+		/* The reset line drives the module LDO enable, so a reset is a
+		 * power cycle. Keep the rail down long enough for the memory to
+		 * lose its volatile configuration, then let it start up before
+		 * the first command.
+		 */
+		t-reset-pulse = <5000000>;
+		t-reset-recovery = <10000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33la.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33la.overlay
@@ -29,6 +29,11 @@
 		address-length = "ADDR_3_BYTE";
 		rx-dummy = <6>;
 		jedec-id = [9d 60 16];
+		/* QE is bit 6 of the status register and ships cleared, so the
+		 * quad commands do not work until the driver sets it. The
+		 * memory reports QER 010b in its SFDP, which is S1B6.
+		 */
+		quad-enable-requirements = "S1B6";
 
 		reset-gpios = <&m2mem_ldo_en M2MEM_CONNECTOR_GPIO_LDO_EN GPIO_ACTIVE_LOW>;
 		/* The reset line drives the module LDO enable, so a reset is a

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33lb.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33lb.overlay
@@ -31,6 +31,13 @@
 		jedec-id = [ef 40 15];
 
 		reset-gpios = <&m2mem_ldo_en M2MEM_CONNECTOR_GPIO_LDO_EN GPIO_ACTIVE_LOW>;
+		/* The reset line drives the module LDO enable, so a reset is a
+		 * power cycle. Keep the rail down long enough for the memory to
+		 * lose its volatile configuration, then let it start up before
+		 * the first command.
+		 */
+		t-reset-pulse = <5000000>;
+		t-reset-recovery = <10000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
## Problems

1. The B-M2MEM-PACK1 modules are powered through an LDO whose enable pin is wired to the M.2 connector, and the devicetree describes that pin as the memory reset line. A reset of the memory is therefore a power cycle.

   This breaks the octal modules. The MCU boots, talks to the memory over single-line SPI, and configures it into OPI mode. When the MCU is reset, the module keeps its supply, so the memory stays in OPI while the firmware starts over and talks single-line SPI to it. Nothing answers, and initialization fails. The only way out was to unplug the board, which is not something the driver can rely on.

2. When I added B-M2MEM-PACK1 support I could not find the datasheet for the Macronix MX25UW25645GXDI00 anywhere, it does not appear to be public. I needed it for the `jedec-id` and `rx-dummy` properties, so I left TODO markers instead.

3. The IS25LP032D on MB1928-33LA never worked in quad mode. The JEDEC ID was read correctly, so single-line communication with the memory was fine, but every read-back returned `0x88` on every byte and the multi sector test failed its erase check. The reason is that this memory ships with the Quad Enable bit cleared: the datasheet describes it as a non-volatile bit 6 of the status register with `0` as the factory default, and while it is `0` the quad read `0xEB` and the quad page program `0x32` are simply not honored by the memory.

## Fixes

1. Add the reset timing properties, which the flash driver uses in `gpio_reset()`:

```dts
   t-reset-pulse = <5000000>;
   t-reset-recovery = <10000000>;
```
`t-reset-pulse` is how long the driver holds the LDO enable pin low, so the rail actually collapses and the memory loses its volatile configuration. Without it the value defaults to 0, the regulator is switched off and on again in the same breath, and the memory never notices. t-reset-recovery is a fixed delay after the supply is restored, before the first command is sent.

The values cover all four memories with margin, from their datasheets: MX25LM51245G asks for 300 us below 0.9 V for the initialization to happen and 3 ms until it operates, W25Q16JV for 20 us until chip select may go low and 5 ms until a write instruction is accepted, and IS25LP032D for 300 us until chip select may go low. What no datasheet can tell is how long the rail needs to collapse on this particular module, hence the margin on the pulse.


2. Both properties are resolved from the hardware instead. The memory answers c2 81 39, the Macronix octal 256 Mbit part the module is documented to carry. The dummy cycle count does not belong in the devicetree at all: the mxicy,mx25u quirk reads it from configuration register 2 of the memory, and the driver only overrides that when rx-dummy is present, so the property is dropped rather than filled in with a number. The value the memory reports is 20, which happens to match the placeholder, but it is now read rather than guessed.

3. Add the property that tells the driver how to enable quad mode on this memory:

   ```dts
   quad-enable-requirements = "S1B6";
   ```
The value is not a guess: the memory reports a Quad Enable Requirement of 010b in its SFDP, and that encoding is S1B6 in JESD216, meaning the bit lives in status register 1 at position 6. With the property present, the driver reads the status register with 0x05 during initialization, sets bit 6 if it is not already set, and writes it back with 0x01 after a Write Enable. The log confirms it: a 0x01 command appears where there was none before, and the erase, write and read-back tests pass.

The other three variants do not need this. The W25Q16JV on MB1928-33LB is an SNIQ ordering option, whose Quad Enable bit is fixed to 1 in the factory, and the two MB1927 modules are octal, where the mode is enabled through configuration register 2 by the mxicy,mx25u quirk instead.

## Testing
*Hardware test are performed on nucleo_u3c5zi_q + b_m2mem_pack1* *

`samples/drivers/mspi/mspi_flash` on `nucleo_u3c5zi_q`, all four modules, single and multi sector erase, write and read-back:

| Shield variant | Module | Memory | Bus mode | Result |
|---|---|---|---|---|
| `b_m2mem_pack1_mb1927_18ba` | MB1927-18BA | Macronix MX25UW25645GXDI00 | Octal STR | pass |
| `b_m2mem_pack1_mb1927_33ba` | MB1927-33BA | Macronix MX25LM51245GXDI00 | Octal STR | pass |
| `b_m2mem_pack1_mb1928_33la` | MB1928-33LA | ISSI IS25LP032DJNLE-TR | Quad STR | pass |
| `b_m2mem_pack1_mb1928_33lb` | MB1928-33LB | Winbond W25Q16JVSNIQ | Quad STR | pass |

On MB1927-18BA the memory is now recognized as 32 MB with 4-byte addressing, and the driver takes 20 dummy cycles for the octal read from the memory itself rather than from the devicetree.

## Relation to other PR-s

Depends on #116855 
