### PR TITLE
MAINTAINERS: defer vendor owned UART drivers from generic area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2862,6 +2862,15 @@ Documentation Infrastructure:
     - doc/hardware/peripherals/uart.rst
     - include/zephyr/drivers/serial/
     - include/zephyr/drivers/uart_pipe.h
+  file-groups:
+    - name: Serial/UART driver
+      defer-to-other-areas: true
+      files:
+        - drivers/serial/uart_*.c
+        - drivers/serial/uart_*.h
+        - drivers/serial/Kconfig.*
+        - dts/bindings/serial/
+        - include/zephyr/dt-bindings/uart/
   labels:
     - "area: UART"
   tests:


### PR DESCRIPTION
UART drivers from different vendors are best evaluated by the vendor maintainers and collaborator since they are more familiar with the hardward and are better equipped to evaluate the code. So use defer-to-other-areas such that the reviewer assignment script gives them higher priority.