### PR TITLE
MAINTAINERS: defer vendor owned I3C drivers from generic area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2256,6 +2256,13 @@ Documentation Infrastructure:
     - include/zephyr/drivers/i3c/
     - doc/hardware/peripherals/i3c.rst
     - tests/drivers/build_all/i3c/
+  file-groups:
+    - name: I3C driver
+      defer-to-other-areas: true
+      files:
+        - drivers/i3c/i3c_*.c
+        - drivers/i3c/Kconfig.*
+        - dts/bindings/i3c/
   labels:
     - "area: I3C"
   tests:


### PR DESCRIPTION
I3C drivers from different vendors are best evaluated by the vendor maintainers and collaborator since they are more familiar with the hardward and are better equipped to evaluate the code. So use defer-to-other-areas such that the reviewer assignment script gives them higher priority.