### PR TITLE
drivers: espi: microchip: xec: fix inverted boot-done acknowledge

### DIFF
--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -629,10 +629,10 @@ static int espi_xec_manage_callback(const struct device *dev, struct espi_callba
 static void send_slave_bootdone(const struct device *dev)
 {
 	int ret = 0;
-	uint8_t boot_done = false;
+	uint8_t boot_done = 0;
 
 	ret = espi_xec_receive_vwire(dev, ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE, &boot_done);
-	if ((ret == 0) && (boot_done == true)) {
+	if ((ret == 0) && (boot_done == 0U)) {
 		/* SLAVE_BOOT_DONE & SLAVE_LOAD_STS have to be sent together */
 		espi_xec_send_vwire(dev, ESPI_VWIRE_SIGNAL_TARGET_BOOT_STS, 1);
 		espi_xec_send_vwire(dev, ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE, 1);


### PR DESCRIPTION
Currently driver only acknowledged the boot handshake when TARGET_BOOT_DONE was already asserted.

On a cold boot the virtual wire reads back 0, so the condition never held and the EC never sent TARGET_BOOT_STS/TARGET_BOOT_DONE together, leaving the host stalled waiting for boot-load-done.

Fixes: c0c0ff702c93 ("drivers: espi: microchip: xec: Port V2 driver to MEC174x/5x/165xB")

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/117390