### PR TITLE
sys: printk: make printk_unlocked() usable from user mode

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -128,9 +128,39 @@ static void vprintk_core(const char *fmt, va_list ap)
 #endif
 }
 
+/*
+ * User mode has no access to the console hook: buffer locally and hand
+ * the output to the kernel through the k_str_out() syscall.
+ */
+static void vprintk_user(const char *fmt, va_list ap)
+{
+	struct buf_out_context ctx = {
+#ifdef CONFIG_PICOLIBC
+		.file = FDEV_SETUP_STREAM((int(*)(char, FILE *))buf_char_out,
+					  NULL, NULL, _FDEV_SETUP_WRITE),
+#else
+		0
+#endif
+	};
+
+#ifdef CONFIG_PICOLIBC
+	(void) vfprintf(&ctx.file, fmt, ap);
+#else
+	cbvprintf(buf_char_out, &ctx, fmt, ap);
+#endif
+	if (ctx.buf_count) {
+		buf_flush(&ctx);
+	}
+}
+
 void vprintk_unlocked(const char *fmt, va_list ap)
 {
-	vprintk_core(fmt, ap);
+	if (k_is_user_context()) {
+		/* A user thread cannot hold the printk lock anyway */
+		vprintk_user(fmt, ap);
+	} else {
+		vprintk_core(fmt, ap);
+	}
 }
 EXPORT_SYMBOL(vprintk_unlocked);
 
@@ -140,7 +170,7 @@ void printk_unlocked(const char *fmt, ...)
 
 	va_start(ap, fmt);
 
-	vprintk_core(fmt, ap);
+	vprintk_unlocked(fmt, ap);
 
 	va_end(ap);
 }
@@ -154,23 +184,7 @@ void vprintk(const char *fmt, va_list ap)
 	}
 
 	if (k_is_user_context()) {
-		struct buf_out_context ctx = {
-#ifdef CONFIG_PICOLIBC
-			.file = FDEV_SETUP_STREAM((int(*)(char, FILE *))buf_char_out,
-						  NULL, NULL, _FDEV_SETUP_WRITE),
-#else
-			0
-#endif
-		};
-
-#ifdef CONFIG_PICOLIBC
-		(void) vfprintf(&ctx.file, fmt, ap);
-#else
-		cbvprintf(buf_char_out, &ctx, fmt, ap);
-#endif
-		if (ctx.buf_count) {
-			buf_flush(&ctx);
-		}
+		vprintk_user(fmt, ap);
 	} else {
 		compiler_barrier();
 #ifdef CONFIG_PRINTK_SYNC


### PR DESCRIPTION
vprintk_unlocked() formatted straight to the console hook, which lives
in kernel memory. Since commit 0ecb6caf0f88 ("lib: os: assert: print
the assertion message unlocked") routed assert_print() through it, an
assertion firing in a user-mode thread faults on the first character
of the message: the thread takes an MPU/MMU protection violation
reading the hook, and the fatal error handler reports an unexpected
CPU exception instead of the assertion. Caught by
tests/ztest/error_hook (test_catch_assert_fail is a ZTEST_USER case)
on qemu_arc/qemu_arc_em in CI.

Route the user-context case through the same buffered k_str_out()
syscall path vprintk() already uses. A user thread cannot be holding
the printk spinlock, so skipping the lock only ever mattered for the
kernel-context path, which is unchanged.

Assisted-by: Claude:claude-fable-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
