### PR TITLE
sys: printk: keep the user mode path in the unlocked variants

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -128,8 +128,39 @@ static void vprintk_core(const char *fmt, va_list ap)
 #endif
 }
 
+/*
+ * Format from user mode. The character output hook lives in kernel memory
+ * and cannot be reached from a user thread, so buffer here and hand the
+ * result to the kernel through k_str_out().
+ */
+static void vprintk_user(const char *fmt, va_list ap)
+{
+	struct buf_out_context ctx = {
+#ifdef CONFIG_PICOLIBC
+		.file = FDEV_SETUP_STREAM((int(*)(char, FILE *))buf_char_out,
+					  NULL, NULL, _FDEV_SETUP_WRITE),
+#else
+		0
+#endif
+	};
+
+#ifdef CONFIG_PICOLIBC
+	(void) vfprintf(&ctx.file, fmt, ap);
+#else
+	cbvprintf(buf_char_out, &ctx, fmt, ap);
+#endif
+	if (ctx.buf_count) {
+		buf_flush(&ctx);
+	}
+}
+
 void vprintk_unlocked(const char *fmt, va_list ap)
 {
+	if (k_is_user_context()) {
+		vprintk_user(fmt, ap);
+		return;
+	}
+
 	vprintk_core(fmt, ap);
 }
 EXPORT_SYMBOL(vprintk_unlocked);
@@ -140,7 +171,7 @@ void printk_unlocked(const char *fmt, ...)
 
 	va_start(ap, fmt);
 
-	vprintk_core(fmt, ap);
+	vprintk_unlocked(fmt, ap);
 
 	va_end(ap);
 }
@@ -154,23 +185,7 @@ void vprintk(const char *fmt, va_list ap)
 	}
 
 	if (k_is_user_context()) {
-		struct buf_out_context ctx = {
-#ifdef CONFIG_PICOLIBC
-			.file = FDEV_SETUP_STREAM((int(*)(char, FILE *))buf_char_out,
-						  NULL, NULL, _FDEV_SETUP_WRITE),
-#else
-			0
-#endif
-		};
-
-#ifdef CONFIG_PICOLIBC
-		(void) vfprintf(&ctx.file, fmt, ap);
-#else
-		cbvprintf(buf_char_out, &ctx, fmt, ap);
-#endif
-		if (ctx.buf_count) {
-			buf_flush(&ctx);
-		}
+		vprintk_user(fmt, ap);
 	} else {
 		compiler_barrier();
 #ifdef CONFIG_PRINTK_SYNC


### PR DESCRIPTION
`vprintk_unlocked()` formats straight to the character output hook, which
lives in kernel memory and is unreachable from a user thread, so an assert
taken in user mode faults instead of printing. Reported by @nashif on #114814.

Without this, `testing.ztest.error_hook` times out on qemu_arc/qemu_arc_em and
dies on qemu_x86/atom. With it, `tests/ztest/error_hook`, `tests/kernel/fatal`
and `tests/kernel/mem_protect/userspace` pass on qemu_arc/qemu_arc_em,
qemu_x86, qemu_cortex_m3, qemu_cortex_a53 and qemu_riscv32.
