### PR TITLE
dts: riscv: wch: fix reset binding include for ch32h417

### DIFF
--- a/dts/riscv/wch/ch32h417/ch32h417.dtsi
+++ b/dts/riscv/wch/ch32h417/ch32h417.dtsi
@@ -9,7 +9,7 @@
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
-#include <zephyr/dt-bindings/reset/ch32_20x_30x-reset.h>
+#include <zephyr/dt-bindings/reset/ch32v20x_30x-reset.h>
 
 / {
 	#address-cells = <1>;


### PR DESCRIPTION
Commit a36a77e9b8d ("drivers: reset: add ch32 reset controller")
added reset-controller nodes to the WCH dtsi files, but the include
added to ch32h417.dtsi names the binding header ch32_20x_30x-reset.h
while the header introduced by that commit is ch32v20x_30x-reset.h.
This breaks devicetree preprocessing for every ch32h417evt build.

Fix the include to use the correct header name.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
