### PR TITLE
tests: logging: align remaining cbprintf package buffers

### DIFF
--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -47,7 +47,7 @@ LOG_OUTPUT_DEFINE(log_output, mock_output_func,
 
 ZTEST(test_log_output, test_no_flags)
 {
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *exp_str = SNAME ": " TEST_STR "\r\n";
 	int err;
 
@@ -63,7 +63,7 @@ ZTEST(test_log_output, test_no_flags)
 
 ZTEST(test_log_output, test_raw)
 {
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *exp_str = TEST_STR;
 	int err;
 
@@ -79,7 +79,7 @@ ZTEST(test_log_output, test_raw)
 
 ZTEST(test_log_output, test_no_flags_dname)
 {
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *exp_str = DNAME "/" SNAME ": " TEST_STR "\r\n";
 	int err;
 
@@ -95,7 +95,7 @@ ZTEST(test_log_output, test_no_flags_dname)
 
 ZTEST(test_log_output, test_level_flag)
 {
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *exp_str = "<inf> " DNAME "/" SNAME ": " TEST_STR "\r\n";
 	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL;
 	int err;
@@ -112,7 +112,7 @@ ZTEST(test_log_output, test_level_flag)
 
 ZTEST(test_log_output, test_ts_flag)
 {
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *exp_str = IS_ENABLED(CONFIG_LOG_TIMESTAMP_64BIT) ?
 		"[00000000000000000000] " DNAME "/" SNAME ": " TEST_STR "\r\n" :
 		"[0000000000] " DNAME "/" SNAME ": " TEST_STR "\r\n";
@@ -138,7 +138,7 @@ ZTEST(test_log_output, test_format_ts)
 #else
 #define TIMESTAMP_STR "[00:00:01.000,000] "
 #endif
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *exp_str = TIMESTAMP_STR DNAME "/" SNAME ": " TEST_STR "\r\n";
 	uint32_t flags = LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	int err;
@@ -185,7 +185,7 @@ static bool use_func_prefix(uint8_t level)
 
 ZTEST(test_log_output, test_levels)
 {
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *const level_strs[] = {
 		"<err>",
 		"<wrn>",
@@ -242,7 +242,7 @@ ZTEST(test_log_output, test_colors)
 #define LOG_COLOR_DBG          LOG_COLOR_CODE_DEFAULT
 #endif /* CONFIG_LOG_BACKEND_SHOW_COLOR */
 
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	static const char *const color_strs[] = {
 		LOG_COLOR_ERR,
 		LOG_COLOR_WRN,
@@ -295,7 +295,7 @@ ZTEST(test_log_output, test_thread_id)
 	}
 
 	char exp_str[256];
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 
 	k_tid_t tid = k_current_get();
 	const char *name = k_thread_name_get(tid);
@@ -323,7 +323,7 @@ ZTEST(test_log_output, test_thread_id)
 
 ZTEST(test_log_output, test_skip_src)
 {
-	char __aligned(sizeof(void *)) package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	const char exp_str[] = TEST_STR "\r\n";
 	uint32_t flags = LOG_OUTPUT_FLAG_SKIP_SOURCE;
 	int err;

--- a/tests/subsys/logging/log_output_net/src/log_output_test.c
+++ b/tests/subsys/logging/log_output_net/src/log_output_test.c
@@ -49,7 +49,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_LOG_BACKEND_NET), "syslog backend not enabled");
 
 ZTEST(test_log_output_net, test_format)
 {
-	char package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 
 	static const char *exp_str =
 		"<134>1 1970-01-01T00:00:01.000000Z zephyr - - - - " DNAME "/" SNAME ": " TEST_STR;

--- a/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
+++ b/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
@@ -64,7 +64,7 @@ ZTEST(test_timestamp, test_custom_timestamp)
 			"custom-timestamp: " DNAME "/" SNAME ": " TEST_STR "\r\n" :
 			"[0000000001] " DNAME "/" SNAME ": " TEST_STR "\r\n";
 
-	char package[256];
+	char __aligned(Z_LOG_MSG_ALIGNMENT) package[256];
 	uint32_t flags = LOG_OUTPUT_FLAG_TIMESTAMP;
 	int err;
 


### PR DESCRIPTION
Use `Z_LOG_MSG_ALIGNMENT` for the package buffers in the `log_output`, `log_output_net`, and `log_timestamp` tests.

This follows up on commit [118c9c136362](https://github.com/zephyrproject-rtos/zephyr/commit/118c9c136362fa7fed5f392981e630c18e90483d), which aligned ten buffers in `log_output` to `sizeof(void *)` but left the timestamp and network-output buffers unaligned. This PR aligns the two missed buffers and replaces pointer-size alignment at the ten existing sites with the package alignment required by the logging code.

## Why

`cbprintf_package()` requires its output buffer to satisfy `CBPRINTF_PACKAGE_ALIGNMENT` and returns `-EFAULT` when that requirement is not met. `Z_LOG_MSG_ALIGNMENT` aliases this alignment requirement.

`sizeof(void *)` is not sufficient in general because a package may contain 64-bit arguments and the required alignment can vary between platforms.

The missing timestamp alignment surfaced while testing the m68k code proposed in [RFC #114672](https://github.com/zephyrproject-rtos/zephyr/issues/114672). On m68k, the stack buffer could be only 2-byte aligned, causing `cbprintf_package()` to fail before timestamp processing began. An audit found the same missing alignment in `log_output_net`.

## Validation

Applied to the m68k RFC preview and tested with QEMU:

| Test                               |   m68000   |   m68010     |
| ---------------------------------- | ---------- | ------------ |
| `logging.output`                   | PASS 11/11  | PASS 11/11  |
| `logging.output.default_timestamp` | PASS 1/1    | PASS 1/1    |
| `logging.output.custom_timestamp`  | PASS 1/1    | PASS 1/1    |

Before the fix, both timestamp configurations failed in `test_custom_timestamp()` at `cbprintf_package()` on both targets. They pass after the change.
