### PR TITLE
kernel: add k_sem_deinit()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3817,6 +3817,28 @@ __syscall int k_sem_init(struct k_sem *sem, unsigned int initial_count,
 			  unsigned int limit);
 
 /**
+ * @brief Deinitialize a semaphore.
+ *
+ * This routine invalidates @a sem. It is the developer's responsibility to
+ * deinitialize transient semaphores (such as those defined on a thread's
+ * stack or in dynamically allocated memory) prior to that semaphore's memory
+ * being reclaimed. Failure to deinitialize such semaphores may result in
+ * corruption if the semaphore continues to be used after reclamation; this
+ * may happen if there were threads waiting on the semaphore or if it was
+ * involved in any kernel object tracking (see
+ * @kconfig{CONFIG_OBJ_CORE_SEM} and @kconfig{CONFIG_TRACING_OBJECT_TRACKING}).
+ *
+ * Any threads waiting on @a sem are released as if the semaphore was reset,
+ * with their k_sem_take() calls returning -EAGAIN.
+ *
+ * A deinitialized semaphore must be initialized again with k_sem_init()
+ * before it can be used.
+ *
+ * @param sem Address of the semaphore.
+ */
+__syscall void k_sem_deinit(struct k_sem *sem);
+
+/**
  * @brief Take a semaphore.
  *
  * This routine takes @a sem.

--- a/include/zephyr/tracing/tracking.h
+++ b/include/zephyr/tracing/tracking.h
@@ -121,6 +121,7 @@ extern struct k_event *_track_list_k_event;
 void sys_track_k_timer_init(struct k_timer *timer);
 void sys_track_k_mem_slab_init(struct k_mem_slab *slab);
 void sys_track_k_sem_init(struct k_sem *sem);
+void sys_track_k_sem_deinit(struct k_sem *sem);
 void sys_track_k_mutex_init(struct k_mutex *mutex);
 void sys_track_k_stack_init(struct k_stack *stack);
 void sys_track_k_msgq_init(struct k_msgq *msgq);

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -27,6 +27,7 @@
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/tracing/tracing.h>
+#include <zephyr/tracing/tracking.h>
 #include <zephyr/sys/check.h>
 
 /* We use a system-wide lock to synchronize semaphores, which has
@@ -91,6 +92,50 @@ static inline bool sem_handle_poll_events(struct k_sem *sem)
 	return false;
 #endif /* CONFIG_POLL */
 }
+
+void z_impl_k_sem_deinit(struct k_sem *sem)
+{
+	k_spinlock_key_t key = k_spin_lock(&sem_lock);
+	bool resched = false;
+
+	/* Release any waiters as if the semaphore was reset */
+	resched = z_sched_wake_all(&sem->wait_q, -EAGAIN, NULL);
+
+	/* Invalidate the semaphore. The zeroed limit makes a deinitialized
+	 * semaphore inert.
+	 */
+	sem->count = 0;
+	sem->limit = 0;
+
+	resched = sem_handle_poll_events(sem) || resched;
+
+	if (resched) {
+		z_reschedule(&sem_lock, key);
+	} else {
+		k_spin_unlock(&sem_lock, key);
+	}
+
+#ifdef CONFIG_USERSPACE
+	k_object_uninit(sem);
+#endif /* CONFIG_USERSPACE */
+
+#ifdef CONFIG_OBJ_CORE_SEM
+	k_obj_core_unlink(K_OBJ_CORE(sem));
+#endif /* CONFIG_OBJ_CORE_SEM */
+
+#ifdef CONFIG_TRACING_OBJECT_TRACKING
+	sys_track_k_sem_deinit(sem);
+#endif /* CONFIG_TRACING_OBJECT_TRACKING */
+}
+
+#ifdef CONFIG_USERSPACE
+static inline void z_vrfy_k_sem_deinit(struct k_sem *sem)
+{
+	K_OOPS(K_SYSCALL_OBJ(sem, K_OBJ_SEM));
+	z_impl_k_sem_deinit(sem);
+}
+#include <zephyr/syscalls/k_sem_deinit_mrsh.c>
+#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_sem_give(struct k_sem *sem)
 {

--- a/subsys/tracing/tracing_tracking.c
+++ b/subsys/tracing/tracing_tracking.c
@@ -62,6 +62,21 @@ struct k_spinlock _track_list_k_event_lock;
 		k_spin_unlock(&list##_lock, key);                                                  \
 	} while (false)
 
+/* Iterates in the tracking list and removes an object when found */
+#define SYS_TRACK_LIST_REMOVE(list, obj)                                                           \
+	do {                                                                                       \
+		k_spinlock_key_t key = k_spin_lock(&list##_lock);                                  \
+		__typeof__(list) *_prev = &(list);                                                 \
+		while (*_prev != NULL) {                                                           \
+			if (*_prev == (obj)) {                                                     \
+				*_prev = (obj)->_obj_track_next;                                   \
+				break;                                                             \
+			}                                                                          \
+			_prev = &(*_prev)->_obj_track_next;                                        \
+		}                                                                                  \
+		k_spin_unlock(&list##_lock, key);                                                  \
+	} while (false)
+
 #define SYS_TRACK_STATIC_INIT(type, ...) \
 	do { \
 		STRUCT_SECTION_FOREACH(type, obj) \
@@ -86,6 +101,14 @@ void sys_track_k_sem_init(struct k_sem *sem)
 	if (sem) {
 		SYS_PORT_TRACING_TYPE_MASK(k_sem,
 				SYS_TRACK_LIST_PREPEND(_track_list_k_sem, sem));
+	}
+}
+
+void sys_track_k_sem_deinit(struct k_sem *sem)
+{
+	if (sem) {
+		SYS_PORT_TRACING_TYPE_MASK(k_sem,
+				SYS_TRACK_LIST_REMOVE(_track_list_k_sem, sem));
 	}
 }
 

--- a/tests/kernel/semaphore/deinit/CMakeLists.txt
+++ b/tests/kernel/semaphore/deinit/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sem_deinit)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/semaphore/deinit/prj.conf
+++ b/tests/kernel/semaphore/deinit/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/semaphore/deinit/src/main.c
+++ b/tests/kernel/semaphore/deinit/src/main.c
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Basalte bv
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/tracing/tracking.h>
+
+#ifdef CONFIG_OBJ_CORE_SEM
+struct obj_core_count_data {
+	/* Object core to count occurrences of */
+	struct k_obj_core *target;
+	/* Number of occurrences found */
+	size_t count;
+};
+
+static int obj_core_count_op(struct k_obj_core *obj_core, void *data)
+{
+	struct obj_core_count_data *count_data = data;
+
+	if (obj_core == count_data->target) {
+		count_data->count++;
+	}
+
+	return 0;
+}
+
+static size_t obj_core_count(struct k_sem *sem)
+{
+	struct k_obj_type *obj_type = k_obj_type_find(K_OBJ_TYPE_SEM_ID);
+	struct obj_core_count_data count_data = {
+		.target = K_OBJ_CORE(sem),
+		.count = 0,
+	};
+
+	zassert_not_null(obj_type, "semaphore object type not found");
+	k_obj_type_walk_locked(obj_type, obj_core_count_op, &count_data);
+
+	return count_data.count;
+}
+#endif /* CONFIG_OBJ_CORE_SEM */
+
+#ifdef CONFIG_TRACING_OBJECT_TRACKING
+static bool track_list_contains(struct k_sem *sem)
+{
+	for (struct k_sem *cur = _track_list_k_sem; cur != NULL;
+	     cur = SYS_PORT_TRACK_NEXT(cur)) {
+		if (cur == sem) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif /* CONFIG_TRACING_OBJECT_TRACKING */
+
+static void check_tracked(struct k_sem *sem, bool tracked)
+{
+#ifdef CONFIG_OBJ_CORE_SEM
+	zassert_equal(obj_core_count(sem), tracked ? 1 : 0,
+		      "unexpected semaphore object core link state");
+#endif /* CONFIG_OBJ_CORE_SEM */
+
+#ifdef CONFIG_TRACING_OBJECT_TRACKING
+	zassert_equal(track_list_contains(sem), tracked,
+		      "unexpected semaphore object tracking state");
+#endif /* CONFIG_TRACING_OBJECT_TRACKING */
+
+	ARG_UNUSED(sem);
+	ARG_UNUSED(tracked);
+}
+
+ZTEST(sem_deinit, test_sem_deinit)
+{
+	struct k_sem sem;
+
+	zassert_ok(k_sem_init(&sem, 0, 1));
+	check_tracked(&sem, true);
+
+	k_sem_give(&sem);
+	zassert_ok(k_sem_take(&sem, K_NO_WAIT));
+
+	/* Deinitializing releases the semaphore from the tracking
+	 * facilities; its memory (here, this stack frame) may be reused
+	 * afterwards.
+	 */
+	k_sem_deinit(&sem);
+	check_tracked(&sem, false);
+
+	/* The semaphore can be initialized and used again */
+	zassert_ok(k_sem_init(&sem, 1, 1));
+	check_tracked(&sem, true);
+
+	zassert_ok(k_sem_take(&sem, K_NO_WAIT));
+
+	k_sem_deinit(&sem);
+	check_tracked(&sem, false);
+}
+
+static struct k_sem pending_sem;
+static struct k_thread pending_thread;
+static K_THREAD_STACK_DEFINE(pending_stack, 1024 + CONFIG_TEST_EXTRA_STACK_SIZE);
+
+static void pending_entry(void *p1, void *p2, void *p3)
+{
+	int *ret = p1;
+
+	*ret = k_sem_take(&pending_sem, K_FOREVER);
+}
+
+ZTEST(sem_deinit, test_sem_deinit_waiters)
+{
+	int take_ret = 0xb4d;
+
+	zassert_ok(k_sem_init(&pending_sem, 0, 1));
+
+	k_thread_create(&pending_thread, pending_stack,
+			K_THREAD_STACK_SIZEOF(pending_stack), pending_entry,
+			&take_ret, NULL, NULL,
+			k_thread_priority_get(k_current_get()) - 1, 0,
+			K_NO_WAIT);
+
+	/* Wait until the thread is pending on the semaphore */
+	k_msleep(50);
+
+	/* Deinitializing releases waiters as if the semaphore was reset */
+	k_sem_deinit(&pending_sem);
+	check_tracked(&pending_sem, false);
+
+	zassert_ok(k_thread_join(&pending_thread, K_SECONDS(1)));
+	zassert_equal(take_ret, -EAGAIN, "waiter not released with -EAGAIN");
+}
+
+static struct k_sem user_sem;
+
+ZTEST_USER(sem_deinit, test_sem_deinit_user)
+{
+	zassert_ok(k_sem_init(&user_sem, 0, 1));
+
+	k_sem_give(&user_sem);
+	zassert_ok(k_sem_take(&user_sem, K_NO_WAIT));
+
+	k_sem_deinit(&user_sem);
+
+	/* The semaphore can be initialized and used again */
+	zassert_ok(k_sem_init(&user_sem, 1, 1));
+	zassert_ok(k_sem_take(&user_sem, K_NO_WAIT));
+
+	k_sem_deinit(&user_sem);
+}
+
+static void *sem_deinit_setup(void)
+{
+#ifdef CONFIG_USERSPACE
+	k_thread_access_grant(k_current_get(), &user_sem);
+#endif /* CONFIG_USERSPACE */
+
+	return NULL;
+}
+
+ZTEST_SUITE(sem_deinit, NULL, sem_deinit_setup, NULL, NULL, NULL);

--- a/tests/kernel/semaphore/deinit/tests.yaml
+++ b/tests/kernel/semaphore/deinit/tests.yaml
@@ -1,0 +1,35 @@
+tests:
+  kernel.semaphore.deinit:
+    tags:
+      - kernel
+      - semaphore
+    integration_platforms:
+      - qemu_x86
+  kernel.semaphore.deinit.obj_core:
+    tags:
+      - kernel
+      - semaphore
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_OBJ_CORE=y
+  kernel.semaphore.deinit.tracking:
+    tags:
+      - kernel
+      - semaphore
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_NONE=y
+      - CONFIG_TRACING_OBJECT_TRACKING=y
+  kernel.semaphore.deinit.user:
+    tags:
+      - kernel
+      - semaphore
+      - userspace
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=y


### PR DESCRIPTION
Kernel object tracking (`CONFIG_OBJ_CORE_SEM`, object tracking) registers semaphores passed to `k_sem_init()`, but nothing releases them again: semaphores without a permanent lifetime (e.g. living on a thread's stack or in memory that is freed) leave the tracking lists referencing dead memory.

Add the `k_sem_deinit()` system call to invalidate a semaphore at the end of its life cycle. It releases any waiters as if the semaphore was reset, zeroes the count and limit so that a deinitialized semaphore is inert and misuse can be asserted on, marks the kernel object as uninitialized and releases it from the object core type list and the object tracking list (adding the previously missing tracking list removal).

Ref: https://github.com/zephyrproject-rtos/zephyr/issues/114856