### PR TITLE
modules: hal_silabs: Fix bluetooth scheduler priority

### DIFF
--- a/modules/hal_silabs/simplicity_sdk/config/ll/sl_btctrl_scheduler_priority_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/ll/sl_btctrl_scheduler_priority_config.h
@@ -25,8 +25,8 @@
 #define SL_BT_CONTROLLER_SCHEDULER_PRI_INIT_MIN 55
 #define SL_BT_CONTROLLER_SCHEDULER_PRI_INIT_MAX 15
 
-#define SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MIN 16
-#define SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MAX 32
+#define SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MIN 32
+#define SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MAX 16
 
 #define SL_BT_CONTROLLER_SCHEDULER_PRI_PAWR_TX_MIN 15
 #define SL_BT_CONTROLLER_SCHEDULER_PRI_PAWR_TX_MAX 5
@@ -43,9 +43,9 @@
 	 .conn_max = SL_BT_CONTROLLER_SCHEDULER_PRI_CONN_MAX,                                      \
 	 .init_min = SL_BT_CONTROLLER_SCHEDULER_PRI_INIT_MIN,                                      \
 	 .init_max = SL_BT_CONTROLLER_SCHEDULER_PRI_INIT_MAX,                                      \
-	 .rail_mapping_offset = SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MIN,                    \
-	 .rail_mapping_range = (SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MAX -                   \
-				SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MIN),                   \
+	 .rail_mapping_offset = SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MAX,                    \
+	 .rail_mapping_range = (SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MIN -                   \
+				SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MAX),                   \
 	 0,                                                                                        \
 	 .adv_step = SL_BT_CONTROLLER_SCHEDULER_PRI_ADV_STEP,                                      \
 	 .scan_step = SL_BT_CONTROLLER_SCHEDULER_PRI_SCAN_STEP,                                    \


### PR DESCRIPTION
The definition of "min" and "max" scheduler priority was inverted in the latest HAL release. Swap the definitions to pass parameter validation in multiprotocol builds.

Fixes the following compiler error when `CONFIG_SILABS_SISDK_RAIL_MULTIPROTOCOL=y`:

```
modules/hal/silabs/simplicity_sdk/protocol/bluetooth/bgstack/ll/src/sl_btctrl_init.c:312:2: error: #error Invalid configuration: SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MIN < SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MAX
  312 | #error Invalid configuration: SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MIN < SL_BT_CONTROLLER_SCHEDULER_PRI_RAIL_WINDOW_MAX
      |  ^~~~~
```