### PR TITLE
include: dt-bindings: clock: stm32: Doxygen fix and common include

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
+++ b/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
@@ -6,20 +6,25 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_
 
-/** System clock */
+/** ID for system clock as source clock */
 #define STM32_SRC_SYSCLK	0x001
-/** Fixed clocks  */
+/** ID for LSE clock as source clock */
 #define STM32_SRC_LSE		0x002
+/** ID for LSI clock as source clock */
 #define STM32_SRC_LSI		0x003
 
 /** Dummy: Add a specifier when no selection is possible */
 #define NO_SEL			0xFF
 
+/** @cond INTERNAL_HIDDEN */
+/** Helper macros to pack RCC clock source division info in the DT */
 #define STM32_CLOCK_DIV_SHIFT	12
+/** @endcond */
 
 /** Clock divider */
 #define STM32_CLOCK_DIV(div)	(((div) - 1) << STM32_CLOCK_DIV_SHIFT)
 
+/** @cond INTERNAL_HIDDEN */
 /** Helper macros to pack RCC clock source selection register info in the DT */
 #define STM32_DT_CLKSEL_REG_MASK	0xFFFFU
 #define STM32_DT_CLKSEL_REG_SHIFT	0U
@@ -29,6 +34,7 @@
 #define STM32_DT_CLKSEL_WIDTH_SHIFT	21U
 #define STM32_DT_CLKSEL_VAL_MASK	0xFFU
 #define STM32_DT_CLKSEL_VAL_SHIFT	24U
+/** @endcond */
 
 /**
  * @brief Pack STM32 source clock selection RCC register bit fields for the DT

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C0_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C0_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_IOP     0x034
@@ -71,5 +73,7 @@
 #define MCO_PRE_DIV_32  5
 #define MCO_PRE_DIV_64  6
 #define MCO_PRE_DIV_128 7
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32c5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c5_clock.h
@@ -11,9 +11,10 @@
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_
-/** @cond INTERNAL_HIDDEN */
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 
@@ -140,4 +141,5 @@
 #define MCO2_SEL_HSIDIV3	7
 
 /** @endcond */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x014
@@ -52,5 +54,7 @@
 /** CFGR1 devices */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
@@ -7,9 +7,10 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_
 
-#include "stm32_common_clocks.h"
 /* Ensure correct order by including generic F1 definitions first. */
-#include "stm32f1_clock.h"
+#include <zephyr/dt-bindings/clock/stm32f1_clock.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
@@ -21,5 +22,7 @@
 #undef MCO1_SEL /* Need to redefine generic F1 MCO_SEL for connectivity line devices. */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
 /* No MCO prescaler support on STM32F1 series. */
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 
@@ -55,5 +57,7 @@
 #define ADC_PRE_DIV_4		1
 #define ADC_PRE_DIV_6		2
 #define ADC_PRE_DIV_8		3
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f37x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f37x_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F37X_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F37X_CLOCK_H_
 
-#include "stm32f3_clock.h"
+#include <zephyr/dt-bindings/clock/stm32f3_clock.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /* On STM32F37x, the ADC prescaler is located in CFGR1 and the prescaler values are more limited */
 #undef ADC12_PRE
@@ -34,5 +36,7 @@
 #define ADC_PRE_DIV_4		1
 #define ADC_PRE_DIV_6		2
 #define ADC_PRE_DIV_8		3
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F37X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f3_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F3_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F3_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x014
@@ -84,5 +86,7 @@
 #define ADC_PRE_DIV_64		0x19
 #define ADC_PRE_DIV_128		0x1A
 #define ADC_PRE_DIV_256		0x1B
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f410_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f410_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F410_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F410_CLOCK_H_
 
-#include "stm32f4_clock.h"
+#include <zephyr/dt-bindings/clock/stm32f4_clock.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** @brief RCC_DCKCFGR register offset */
 #define DCKCFGR_REG		0x8C
@@ -32,5 +34,7 @@
 #ifdef I2S_SEL
 #undef I2S_SEL
 #endif
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F410_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f427_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f427_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_
 
-#include "stm32f4_clock.h"
+#include <zephyr/dt-bindings/clock/stm32f4_clock.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** @brief RCC_DCKCFGR register offset */
 #define DCKCFGR_REG		0x8C
@@ -20,5 +22,7 @@
 #define CK48M_SEL(val)		STM32_DT_CLOCK_SELECT((val), 27, 27, DCKCFGR_REG)
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 28, 28, DCKCFGR_REG)
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 29, DCKCFGR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 
@@ -78,5 +80,7 @@
 #define MCO_PRE_DIV_3 5
 #define MCO_PRE_DIV_4 6
 #define MCO_PRE_DIV_5 7
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -12,9 +12,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_
 
-/** @cond INTERNAL_HIDDEN */
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
 
-#include "stm32_common_clocks.h"
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 

--- a/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_
 
+/** @cond INTERNAL_HIDDEN */
+
 /* MCO prescaler : division factor */
 #define MCO_PRE_DIV_256  8
 #define MCO_PRE_DIV_512  9
@@ -18,5 +20,7 @@
 #define MCO_SEL_PLLQCLK   9
 #define MCO_SEL_RTCCLK    10
 #define MCO_SEL_RTCWAKEUP 11
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_IOP     0x034
@@ -92,5 +94,7 @@
 #define MCO_SEL_PLLRCLK 5
 #define MCO_SEL_LSI     6
 #define MCO_SEL_LSE     7
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G4_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G4_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
@@ -71,5 +73,7 @@
 #define QSPI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR2_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h5_clock.h
@@ -5,9 +5,10 @@
  */
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_
-/** @cond INTERNAL_HIDDEN */
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 
@@ -40,7 +41,6 @@
 #define STM32_SRC_PLL3_R	(STM32_SRC_PLL3_Q + 1)
 /** Clock muxes */
 #define STM32_SRC_CKPER		(STM32_SRC_PLL3_R + 1)
-
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x088
@@ -154,4 +154,5 @@
 #define MCO_PRE_DIV_15 15
 
 /** @endcond */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
 
 /** @cond INTERNAL_HIDDEN */
 
@@ -41,7 +41,6 @@
 /** Others: Not yet supported */
 /* #define STM32_SRC_I2SCKIN	TBD */
 /* #define STM32_SRC_SPDIFRX	TBD */
-
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB3    0x0D4

--- a/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
@@ -6,9 +6,10 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7RS_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7RS_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
 
 /** @cond INTERNAL_HIDDEN */
+
 /** Domain clocks */
 
 /* RM0477  */

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L0_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L0_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_IOP     0x02c
@@ -50,5 +52,7 @@
 #define HSI48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 26, CCIPR_REG)
 /** CSR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CSR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l1_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L1_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L1_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x01c
@@ -33,5 +35,7 @@
 #define CSR_REG		0x34
 
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CSR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
@@ -117,5 +119,7 @@
 #define MCO_SEL_LSI	6
 #define MCO_SEL_LSE	7
 #define MCO_SEL_HSI48	8
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4plus_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4plus_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4PLUS_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4PLUS_CLOCK_H_
 
-#include "stm32l4_clock.h"
+#include <zephyr/dt-bindings/clock/stm32l4_clock.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /*
  * On STM32L4+ series, the SAI1 / SAI2 input clock selection fields
@@ -18,5 +20,7 @@
 /** CCIPR2 devices */
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 5, CCIPR2_REG)
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR2_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4PLUS_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l5_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L5_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L5_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
@@ -89,5 +91,7 @@
 /** CFGR devices */
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR_REG)
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
@@ -6,9 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_
 
-/** @cond INTERNAL_HIDDEN */
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
 
-#include "stm32_common_clocks.h"
+/** @cond INTERNAL_HIDDEN */
 
 /** System clock */
 /* defined in stm32_common_clocks.h */

--- a/include/zephyr/dt-bindings/clock/stm32mp2_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp2_clock.h
@@ -6,9 +6,10 @@
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP2_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP2_CLOCK_H_
-/** @cond INTERNAL_HIDDEN */
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Undefine the common clocks macro */
 #undef STM32_CLOCK
@@ -90,4 +91,5 @@
 #define STM32_CLOCK_PERIPH_MAX	STM32_CLOCK_PERIPH_I3C4
 
 /** @endcond */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP2_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32n6_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32n6_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32N6_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32N6_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 
@@ -222,5 +224,7 @@
 
 /* ADC prescaler division factor helper */
 #define ADC_PRE_DIV(pres)	((pres - 1) & 0xFFU)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32N6_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u0_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U0_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U0_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x48
@@ -61,5 +63,7 @@
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 28, CCIPR_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u3_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U3_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U3_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 
@@ -114,5 +116,7 @@
 #define ADCDAC_PRE_DIV_128	0xD
 #define ADCDAC_PRE_DIV_256	0xE
 #define ADCDAC_PRE_DIV_512	0xF
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -7,7 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Domain clocks */
 
@@ -143,5 +145,7 @@
 #define MCO_PRE_DIV_4  2
 #define MCO_PRE_DIV_8  3
 #define MCO_PRE_DIV_16 4
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb0_clock.h
@@ -6,8 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB0_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB0_CLOCK_H_
 
-/** Define system & low-speed clocks */
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Other fixed clocks.
  * - CLKSLOWMUX: used to query slow clock tree frequency
@@ -41,5 +42,7 @@
 #define SPI2_I2S2_SEL(val)	STM32_DT_CLOCK_SELECT((val), 22, 22, CFGR_REG)
 /* `msb` is only 22 for WB06/WB07, but a single definition with msb=23 is acceptable */
 #define SPI3_I2S3_SEL(val)	STM32_DT_CLOCK_SELECT((val), 23, 22, CFGR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
@@ -65,5 +67,7 @@
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 /** CSR devices */
 #define RFWKP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CSR_REG)
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wba_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wba_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WBA_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WBA_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Peripheral clock sources */
 
@@ -104,5 +106,6 @@
 #define MCO_SEL_PLL1QCLK 9
 #define MCO_SEL_HCLK5 10
 
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WBA_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_
 
-#include "stm32_common_clocks.h"
+#include <zephyr/dt-bindings/clock/stm32_common_clocks.h>
+
+/** @cond INTERNAL_HIDDEN */
 
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
@@ -23,7 +25,6 @@
 
 /** Domain clocks */
 /* RM0461, §6.4.29 Clock configuration register (RCC_CFGR3) */
-
 
 /** System clock */
 /* defined in stm32_common_clocks.h */
@@ -88,5 +89,7 @@
 #define MCO_SEL_LSE       8
 #define MCO_SEL_PLL1PCLK  13
 #define MCO_SEL_PLL1QCLK  14
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_ */


### PR DESCRIPTION
Add Doxygen INTERNAL_HIDDEN tags in stm32 clock DT bindings header files that are not well formatted regarding Doxygen and Zephyr requirements.

Explicit inclusion of other DT bindings header files using the generic `#include <zephyr/dt-bindings/clock/...>` format.

Document common clock source IDs in `stm32_common_clock.h`.

Remove inclusion of `stm32_common_clocks.h` from `stm32f10x_clock.h` since it includes `stm32f1_clock.h` that already include `stm32_common_clock.h`.

Add or remove empty lines where applicable.