### PR TITLE
drivers: sensor: adxl355: fix is_fifo offset mismatch in decoder routing

### DIFF
--- a/drivers/sensor/adi/adxl355/adxl355.c
+++ b/drivers/sensor/adi/adxl355/adxl355.c
@@ -623,6 +623,7 @@ static int adxl355_read_sample(const struct device *dev)
 	sample->y = combine_bytes_to_int20(buf[3], buf[4], buf[5]);
 	sample->z = combine_bytes_to_int20(buf[6], buf[7], buf[8]);
 	sample->range = data->range;
+	sample->is_fifo = 0;
 	return 0;
 }
 

--- a/drivers/sensor/adi/adxl355/adxl355.h
+++ b/drivers/sensor/adi/adxl355/adxl355.h
@@ -269,11 +269,11 @@ struct adxl355_extra_attr {
  *
  */
 struct adxl355_sample {
+	uint8_t is_fifo: 1;
 	int32_t x;
 	int32_t y;
 	int32_t z;
 	enum adxl355_range range;
-	uint8_t is_fifo: 1;
 };
 
 /**


### PR DESCRIPTION
adxl355_decoder_decode() reinterprets a raw sample buffer as struct adxl355_fifo_data first, 
checking is_fifo at byte offset 0 to decide whether to route to adxl355_decode_stream(). 
struct adxl355_sample declared is_fifo last (after x/y/z/range), so offset 0 of a one-shot 
sample buffer was actually the low byte of x - real accelerometer data, not a flag.

With CONFIG_ADXL355_STREAM=y, roughly half of all one-shot reads (whenever bit 0 of 
the raw X LSB happened to be set) were misrouted into adxl355_decode_stream(), which
 then reads fifo_byte_count and sample_set_size at offsets 20-22 - past the 
20-byte (sizeof(struct adxl355_sample)) buffer - causing an out-of-bounds read.

Fix this by giving adxl355_sample an is_fifo field at offset 0, matching 
adxl355_fifo_data's layout, and have adxl355_read_sample() explicitly clear it rather than 
relying on zero-initialization.

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>