### PR TITLE
drivers: gpio: npm10xx: use mfd pin config function

### DIFF
--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/gpio.h)
 zephyr_library()
 
 # zephyr-keep-sorted-start
+zephyr_library_include_directories_ifdef(CONFIG_GPIO_NPM10XX ${ZEPHYR_BASE}/drivers/mfd)
 zephyr_library_sources_ifdef(CONFIG_GPIO_AD559X gpio_ad559x.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_ADP5585 gpio_adp5585.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_ADS1X4S0X gpio_ads1x4s0x.c)

--- a/drivers/gpio/Kconfig.npm10xx
+++ b/drivers/gpio/Kconfig.npm10xx
@@ -4,7 +4,8 @@
 config GPIO_NPM10XX
 	bool "nPM10xx GPIO driver"
 	default y
-	depends on DT_HAS_NORDIC_NPM10XX_GPIO_ENABLED
+	depends on DT_HAS_NORDIC_NPM10XX_GPIO_ENABLED && DT_HAS_NORDIC_NPM10XX_ENABLED
+	select MFD
 	select I2C
 	help
 	  Enable the nPM10xx GPIO driver.
@@ -15,4 +16,4 @@ config GPIO_NPM10XX_INIT_PRIORITY
 	default 85
 	help
 	  Initialization priority for the nPM10xx GPIO driver. It must be
-	  greater than the I2C controller init priority.
+	  greater than the MFD init priority.

--- a/drivers/gpio/gpio_npm10xx.c
+++ b/drivers/gpio/gpio_npm10xx.c
@@ -11,29 +11,17 @@
 #include <zephyr/dt-bindings/gpio/nordic-npm10xx-gpio.h>
 #include <zephyr/logging/log.h>
 
+#include "mfd_npm10xx.h"
+
 LOG_MODULE_REGISTER(gpio_npm10xx, CONFIG_GPIO_LOG_LEVEL);
 
-#define NPM10XX_GPIO_PINS 3U
-
 /* Register Offsets */
-#define NPM10_GPIO_CONFIG0 0xA0U
 #define NPM10_GPIO_OUTPUT0 0xA6U
 #define NPM10_GPIO_READ    0xACU
 
-/* CONFIGx (0xA0–0xA2) */
-#define GPIO_CONFIG_INPUT     BIT(0)
-#define GPIO_CONFIG_OUTPUT    BIT(1)
-#define GPIO_CONFIG_OPENDRAIN BIT(2)
-#define GPIO_CONFIG_PULLDOWN  BIT(3)
-#define GPIO_CONFIG_PULLUP    BIT(4)
-#define GPIO_CONFIG_DRIVE     BIT(5)
-#define GPIO_CONFIG_DEBOUNCE  BIT(6)
-
-/* USAGEx (0xA3–0xA5) */
-#define GPIO_USAGE_POL_INVERT BIT(4)
-
 struct gpio_npm10xx_config {
 	struct gpio_driver_config common;
+	const struct device *mfd;
 	struct i2c_dt_spec i2c;
 };
 
@@ -41,29 +29,30 @@ struct gpio_npm10xx_data {
 	struct gpio_driver_data common;
 };
 
+int gpio_npm10xx_port_set_masked_raw(const struct device *dev, gpio_port_pins_t mask,
+				     gpio_port_value_t value);
+
 int gpio_npm10xx_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_npm10xx_config *config = dev->config;
-	uint8_t conf;
+	int ret;
 
 	if (k_is_in_isr()) {
 		return -EWOULDBLOCK;
 	}
 
-	if (pin >= NPM10XX_GPIO_PINS) {
-		LOG_ERR("pin number out of range %d", pin);
-		return -EINVAL;
+	ret = mfd_npm10xx_pin_configure(config->mfd, pin, NPM10_PIN_GPIO, flags);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure pin %u for GPIO usage", pin);
+		return ret;
 	}
 
-	conf = FIELD_PREP(GPIO_CONFIG_INPUT, !!(flags & GPIO_INPUT)) |
-	       FIELD_PREP(GPIO_CONFIG_OUTPUT, !!(flags & GPIO_OUTPUT)) |
-	       FIELD_PREP(GPIO_CONFIG_OPENDRAIN, (flags & GPIO_OPEN_DRAIN) == GPIO_OPEN_DRAIN) |
-	       FIELD_PREP(GPIO_CONFIG_PULLDOWN, !!(flags & GPIO_PULL_DOWN)) |
-	       FIELD_PREP(GPIO_CONFIG_PULLUP, !!(flags & GPIO_PULL_UP)) |
-	       FIELD_PREP(GPIO_CONFIG_DRIVE, !!(flags & NPM10XX_GPIO_DRIVE_HIGH)) |
-	       FIELD_PREP(GPIO_CONFIG_DEBOUNCE, !!(flags & NPM10XX_GPIO_DEBOUNCE_ON));
+	if (flags & (GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH)) {
+		return gpio_npm10xx_port_set_masked_raw(
+			dev, BIT(pin), flags & GPIO_OUTPUT_INIT_HIGH ? BIT(pin) : 0U);
+	}
 
-	return i2c_reg_write_byte_dt(&config->i2c, NPM10_GPIO_CONFIG0 + pin, conf);
+	return 0;
 }
 
 int gpio_npm10xx_port_get_raw(const struct device *dev, gpio_port_value_t *value)
@@ -83,7 +72,7 @@ int gpio_npm10xx_port_set_masked_raw(const struct device *dev, gpio_port_pins_t 
 	const struct gpio_npm10xx_config *config = dev->config;
 	int ret;
 
-	for (size_t i = 0; i < NPM10XX_GPIO_PINS; i++) {
+	for (size_t i = 0; i < NPM10_PIN_NUM; i++) {
 		if (IS_BIT_SET(mask, i)) {
 			ret = i2c_reg_write_byte_dt(&config->i2c, NPM10_GPIO_OUTPUT0 + i,
 						    IS_BIT_SET(value, i));
@@ -143,6 +132,7 @@ static DEVICE_API(gpio, gpio_npm10xx_api) = {
 #define GPIO_NPM10XX_DEFINE(n)                                                                     \
 	static const struct gpio_npm10xx_config gpio_npm10xx_config##n = {                         \
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(n),                                      \
+		.mfd = DEVICE_DT_GET(DT_INST_PARENT(n)),                                           \
 		.i2c = I2C_DT_SPEC_GET(DT_INST_PARENT(n)),                                         \
 	};                                                                                         \
                                                                                                    \

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -494,6 +494,7 @@
 
 			test_i2c_npm1012: pmic@1f {
 				reg = <0x1f>;
+				compatible = "nordic,npm10xx";
 
 				npm1012_gpio: gpio-controller {
 					compatible = "nordic,npm10xx-gpio";


### PR DESCRIPTION
use the gpio configuration function from the MFD driver introduced in #112620 