### PR TITLE
cmake: west: read the topdir through west's Python API

### DIFF
--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -84,7 +84,10 @@ if(WEST_VERSION)
 
   if(NOT WEST_TOPDIR)
     execute_process(
-      COMMAND ${WEST} topdir
+      COMMAND
+      ${PYTHON_EXECUTABLE}
+      -c
+      "import west.util; from pathlib import PurePath; print(PurePath(west.util.west_topdir()).as_posix())"
       OUTPUT_VARIABLE WEST_TOPDIR
       ERROR_QUIET
       RESULT_VARIABLE west_topdir_result


### PR DESCRIPTION
`west topdir` boots west's entire CLI just to print one path. Calling `west.util.west_topdir()` directly does the same job without the CLI machinery. Saves **~100 ms per configure** (0.145 s → 0.035 s on macOS, 0.113 s → 0.022 s on Linux; isolated, min of 7 runs).

Note that `west build` already passes `-DWEST_TOPDIR`, which skips this block entirely — so the beneficiaries are plain `cmake` invocations and **twister**, where the saving is paid once per test case rather than once per session.

Output is unchanged (verified identical across runs on both platforms), and both failure paths are left alone: a west version import failure stays fatal, a missing topdir stays tolerated so a tree without a west workspace still configures.