### PR TITLE
drivers: misc: neochrom_gpu2d: Change init log level from INF to DBG

### DIFF
--- a/drivers/misc/neochrom_gpu2d/st_neochrom_gpu2d.c
+++ b/drivers/misc/neochrom_gpu2d/st_neochrom_gpu2d.c
@@ -45,7 +45,7 @@ static int stm32_gpu2d_init(const struct device *dev)
 		return ret;
 	}
 
-	LOG_INF("GPU2D hardware enabled");
+	LOG_DBG("GPU2D hardware enabled");
 
 	return 0;
 }


### PR DESCRIPTION
The GPU2D driver initializes during POST_KERNEL and emits an INFO log message for successful initialization that interferes with logging tests that expect an empty queue.