### PR TITLE
XEC Counter driver bug fix

### DIFF
--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -313,7 +313,7 @@ static int counter_xec_init(const struct device *dev)
 			{                                                                          \
 				.max_top_value = DT_INST_PROP(inst, max_value),                    \
 				.freq = DT_INST_PROP(inst, clock_frequency) /                      \
-					DT_INST_PROP(inst, prescaler),                             \
+					(DT_INST_PROP(inst, prescaler) + 1),                       \
 				.flags = 0,                                                        \
 				.channels = 1,                                                     \
 			},                                                                         \

--- a/dts/arm/microchip/mec/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec/mec1501hsz.dtsi
@@ -330,10 +330,7 @@
 		};
 
 		/*
-		 * NOTE 1: timers 2 and 3 not implemented in MEC152x.
-		 * NOTE 2: When RTOS timer used as kernel timer, timer4 used
-		 * to provide high speed busy wait counter. Keep disabled to
-		 * prevent counter driver from claiming it.
+		 * NOTE: timers 2 and 3 not implemented in MEC152x.
 		 */
 		timer4: timer@40000c80 {
 			compatible = "microchip,xec-timer";
@@ -347,6 +344,11 @@
 			status = "disabled";
 		};
 
+		/*
+		 * NOTE: When RTOS timer used as kernel timer, timer5 used
+		 * to provide high speed busy wait counter. Keep disabled to
+		 * prevent counter driver from claiming it.
+		 */
 		timer5: timer@40000ca0 {
 			compatible = "microchip,xec-timer";
 			clock-frequency = <48000000>;
@@ -356,6 +358,7 @@
 			prescaler = <0>;
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(23, 5)>;
 			pcr-src = <MCHP_XEC_SCR_ENCODE(3, 24)>;
+			status = "disabled";
 		};
 
 		hibtimer0: timer@40009800 {

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -367,11 +367,6 @@ timer3: timer@40000c60 {
 	status = "disabled";
 };
 
-/*
- * NOTE: When RTOS timer used as kernel timer, timer4 used
- * to provide high speed busy wait counter. Keep disabled to
- * prevent counter driver from claiming it.
- */
 timer4: timer@40000c80 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;
@@ -384,6 +379,11 @@ timer4: timer@40000c80 {
 	status = "disabled";
 };
 
+/*
+ * NOTE: When RTOS timer used as kernel timer, timer5 used
+ * to provide high speed busy wait counter. Keep disabled to
+ * prevent counter driver from claiming it.
+ */
 timer5: timer@40000ca0 {
 	compatible = "microchip,xec-timer";
 	clock-frequency = <48000000>;

--- a/dts/bindings/rtc/microchip,xec-timer.yaml
+++ b/dts/bindings/rtc/microchip,xec-timer.yaml
@@ -23,7 +23,7 @@ properties:
   prescaler:
     type: int
     required: true
-    description: Timer frequency equals clock-frequency divided by the prescaler value
+    description: Timer frequency equals clock-frequency divided by (prescaler + 1)
 
   max-value:
     type: int

--- a/samples/drivers/counter/alarm/boards/mec15xxevb_assy6853.overlay
+++ b/samples/drivers/counter/alarm/boards/mec15xxevb_assy6853.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer4 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/mec172xevb_assy6906.overlay
+++ b/samples/drivers/counter/alarm/boards/mec172xevb_assy6906.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer4 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/samples/drivers/counter/alarm/boards/mec_assy6941_mec1753_qsz.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer4 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -96,6 +96,12 @@ struct counter_alarm_cfg alarm_cfg;
 #define SAMPLE_TIMER DT_ALIAS(counter)
 #elif defined(CONFIG_COUNTER_ITE_IT51XXX)
 #define SAMPLE_TIMER DT_NODELABEL(counter0)
+#elif defined(CONFIG_SOC_SERIES_MEC15XX)
+#define SAMPLE_TIMER DT_NODELABEL(timer4)
+#elif defined(CONFIG_SOC_SERIES_MEC172X)
+#define SAMPLE_TIMER DT_NODELABEL(timer4)
+#elif defined(CONFIG_SOC_MEC1753_QSZ)
+#define SAMPLE_TIMER DT_NODELABEL(timer4)
 #else
 #error Unable to find a counter device node in devicetree
 #endif

--- a/samples/drivers/counter/alarm/tests.yaml
+++ b/samples/drivers/counter/alarm/tests.yaml
@@ -57,6 +57,9 @@ tests:
       - xg24_rb4187c
       - xg27_rb4194a
       - xg29_rb4412a
+      - mec172xevb_assy6906
+      - mec15xxevb_assy6853
+      - mec_assy6941/mec1753_qsz
     integration_platforms:
       - nucleo_f746zg
   sample.drivers.counter.alarm.stm32_rtc:


### PR DESCRIPTION
Fixes a build-breaking divide-by-zero in the MEC XEC counter driver and a related devicetree bug, plus enables the alarm sample on 3 Microchip boards.

  - counter: mchp_xec: fix prescaler frequency divisor (clock_frequency / (prescaler + 1), was crashing on DT default prescaler=0)
  - samples: counter/alarm: enable for mec15xxevb_assy6853, mec172xevb_assy6906, mec_assy6941/mec1753_qsz
  - dts: fix busy-wait-timer comment (was on timer4, actually timer5)
  - dts: mec1501hsz: disable timer5 by default — was missing status, causing a spurious duplicate counter device

