### PR TITLE
soc: nxp: imxrt: add DWARF 5 sections to the DSP linker scripts

### DIFF
--- a/soc/nxp/imxrt/imxrt6xx/hifi4/linker.ld
+++ b/soc/nxp/imxrt/imxrt6xx/hifi4/linker.ld
@@ -498,6 +498,14 @@ SECTIONS
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
   .debug_ranges  0 :  { *(.debug_ranges) }
+  .debug_addr  0 :  { *(.debug_addr) }
+  .debug_line_str  0 :  { *(.debug_line_str) }
+  .debug_loclists  0 :  { *(.debug_loclists) }
+  .debug_macro  0 :  { *(.debug_macro) }
+  .debug_names  0 :  { *(.debug_names) }
+  .debug_rnglists  0 :  { *(.debug_rnglists) }
+  .debug_str_offsets  0 :  { *(.debug_str_offsets) }
+  .debug_sup  0 :  { *(.debug_sup) }
   .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {

--- a/soc/nxp/imxrt/imxrt7xx/hifi1/linker.ld
+++ b/soc/nxp/imxrt/imxrt7xx/hifi1/linker.ld
@@ -451,6 +451,14 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_addr  0 :  { *(.debug_addr) }
+  .debug_line_str  0 :  { *(.debug_line_str) }
+  .debug_loclists  0 :  { *(.debug_loclists) }
+  .debug_macro  0 :  { *(.debug_macro) }
+  .debug_names  0 :  { *(.debug_names) }
+  .debug_rnglists  0 :  { *(.debug_rnglists) }
+  .debug_str_offsets  0 :  { *(.debug_str_offsets) }
+  .debug_sup  0 :  { *(.debug_sup) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/nxp/imxrt/imxrt7xx/hifi4/linker.ld
+++ b/soc/nxp/imxrt/imxrt7xx/hifi4/linker.ld
@@ -427,6 +427,14 @@ SECTIONS
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
   .debug_ranges  0 :  { *(.debug_ranges) }
+  .debug_addr  0 :  { *(.debug_addr) }
+  .debug_line_str  0 :  { *(.debug_line_str) }
+  .debug_loclists  0 :  { *(.debug_loclists) }
+  .debug_macro  0 :  { *(.debug_macro) }
+  .debug_names  0 :  { *(.debug_names) }
+  .debug_rnglists  0 :  { *(.debug_rnglists) }
+  .debug_str_offsets  0 :  { *(.debug_str_offsets) }
+  .debug_sup  0 :  { *(.debug_sup) }
   .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {


### PR DESCRIPTION
Fixes `samples.boards.nxp.adsp.rtxxx.amp_talk` failing to link on `mimxrt700_evk/mimxrt798s/hifi4` in upstream CI.

Since #113770 dropped `-gdwarf-4`, GCC emits DWARF 5, which adds `.debug_rnglists`, `.debug_loclists` and `.debug_line_str`. The RT6xx/RT7xx HiFi linker scripts only listed the DWARF 1-3 sections, so those became orphan sections and `--orphan-handling=warn` + `--fatal-warnings` turned them into a link error:

```
ld.bfd: warning: orphan section `.debug_rnglists` from `app/libapp.a(main.c.obj)` being placed in section `.debug_rnglists`
collect2: error: ld returned 1 exit status
```

Adds the missing DWARF 5 sections, matching [`include/zephyr/linker/debug-sections.ld`](https://github.com/zephyrproject-rtos/zephyr/blob/39065c6ee6eb2874849c675e06c74094c962a1d7/include/zephyr/linker/debug-sections.ld#L43-L51) and the other Xtensa SoC scripts (e.g. [`imxrt5xx/f1`](https://github.com/zephyrproject-rtos/zephyr/blob/39065c6ee6eb2874849c675e06c74094c962a1d7/soc/nxp/imxrt/imxrt5xx/f1/linker.ld#L436-L443)). Three scripts were affected — these were the only `.ld` files in the tree defining `.debug_info` without `.debug_rnglists`:

| Linker script | Board target |
| --- | --- |
| `imxrt7xx/hifi4` | `mimxrt700_evk/mimxrt798s/hifi4` (the CI failure) |
| `imxrt6xx/hifi4` | `mimxrt685_evk/mimxrt685s/hifi4` — sysbuild remote for the other `adsp/rtxxx` samples |
| `imxrt7xx/hifi1` | `mimxrt700_evk/mimxrt798s/hifi1` |
