### PR TITLE
firmware: scmi: Distinguish oversized responses from malformed responses

### DIFF
--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -184,7 +184,7 @@ int scmi_send_message(struct scmi_protocol *proto, struct scmi_message *msg,
 	}
 
 	ret = scmi_transport_read_message(proto->transport, proto->tx, reply);
-	if (ret < 0) {
+	if ((ret < 0) && (ret != -EMSGSIZE)) {
 		LOG_ERR("failed to read message reply: %d", ret);
 		goto out_release_mutex;
 	}

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -64,7 +64,7 @@ static int scmi_mbox_read_message(const struct device *transport,
 	int ret;
 
 	ret = scmi_shmem_read_message(mbox_chan->shmem, msg);
-	if (ret < 0) {
+	if ((ret < 0) && (ret != -EMSGSIZE)) {
 		return ret;
 	}
 
@@ -75,7 +75,7 @@ static int scmi_mbox_read_message(const struct device *transport,
 		scmi_shmem_mark_channel_free(mbox_chan->shmem);
 	}
 
-	return 0;
+	return ret;
 }
 
 static bool scmi_mbox_channel_is_free(const struct device *transport,

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -98,10 +98,13 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg
 	struct scmi_shmem_layout *layout;
 	struct scmi_shmem_data *data;
 	const struct scmi_shmem_config *cfg;
+	uint32_t act_len;
+	int ret = 0;
 
 	data = shmem->data;
 	cfg = shmem->config;
 	layout = (struct scmi_shmem_layout *)data->regmap;
+	act_len = layout->len - sizeof(layout->msg_hdr);
 
 	/* some input validation first */
 	if (!msg) {
@@ -118,10 +121,11 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg
 	}
 
 	/* mismatch between expected reply size and actual size? */
-	if (msg->len != (layout->len - sizeof(layout->msg_hdr))) {
+	if (msg->len < act_len) {
+		ret = -EMSGSIZE;
+	} else if (msg->len > act_len) {
 		LOG_ERR("bad message len. Expected 0x%x, got 0x%x",
-			msg->len,
-			(uint32_t)(layout->len - sizeof(layout->msg_hdr)));
+			msg->len, act_len);
 		return -EINVAL;
 	}
 
@@ -142,7 +146,7 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg
 				  data->regmap + sizeof(*layout), msg->len);
 	}
 
-	return 0;
+	return ret;
 }
 
 int scmi_shmem_write_message(const struct device *shmem,


### PR DESCRIPTION
Currently SCMI transport reports all payload size mismatches as -EINVAL.

However, responses larger than expected are not necessarily malformed. Distinguishing oversized responses using -EMSGSIZE provides protocol  implementations with additional information while maintaining existing behavior for malformed messages.

This change does not alter protocol handling. It only exposes a more specific error condition to upper layers.

Return -EMSGSIZE when the received payload is larger than the expected size while preserving the received response data.

This allows callers to differentiate between malformed messages and oversized messages and make protocol-specific decisions where appropriate.