### PR TITLE
logging: log_output: fix NULL pointer dereference in syslog formatting for ISR logs

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -488,14 +488,13 @@ static int syslog_print(const struct log_output *output,
 	 */
 	if (*thread_on) {
 		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-			if (strstr(k_thread_name_get(tid), " ") != NULL) {
+			const char *tname = (tid == NULL) ? "irq" : k_thread_name_get(tid);
+
+			if (strstr(tname, " ") != NULL) {
 				goto do_not_print_name;
 			}
 
-			len += print_formatted(output, "%s ",
-					       tid == NULL ?
-					       "irq" :
-					       k_thread_name_get(tid));
+			len += print_formatted(output, "%s ", tname);
 		} else {
 do_not_print_name:
 			len += print_formatted(output, "%p ", tid);


### PR DESCRIPTION
Hi maintainers,

While reviewing the logging output formatting, I noticed a reproducible NULL pointer dereference edge-case. When syslog formatting is enabled and an ISR generates a log message, `tid` evaluates to `NULL`. Currently, the `strstr` validation check on line 492 evaluates `k_thread_name_get(tid)` blindly, crashing the kernel before it can reach the safety fallback on line 496. 

This PR addresses the issue by safely evaluating the thread name (or utilizing the `"irq"` fallback) *before* performing any string validation. 

Please let me know if you need any adjustments or if you'd like additional Ztest coverage explicitly for this syslog edge case!
