### PR TITLE
Bluetooth: BAP: UC: Unify callback order for sink and source

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1219,19 +1219,6 @@ static void unicast_client_ep_notify_app(struct bt_bap_stream *stream, bool stat
 		return;
 	}
 
-	/* Call the `stopped` callback if we leave the BT_BAP_EP_STATE_STREAMING state for any
-	 * reason, except if the new state is BT_BAP_EP_STATE_IDLE as that indicates a disconnect
-	 * that is handled by unicast_client_ep_set_status
-	 */
-	if (state_changed && new_state != BT_BAP_EP_STATE_IDLE &&
-	    old_state == BT_BAP_EP_STATE_STREAMING) {
-		if (ops->stopped != NULL) {
-			ops->stopped(stream, reason);
-		} else {
-			LOG_WRN("No callback for stopped set");
-		}
-	}
-
 	switch (new_state) {
 	case BT_BAP_EP_STATE_IDLE:
 		if (ops->released != NULL) {
@@ -1251,16 +1238,20 @@ static void unicast_client_ep_notify_app(struct bt_bap_stream *stream, bool stat
 		break;
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 		if (dir == BT_AUDIO_DIR_SINK) {
-			if (ops->disabled != NULL) {
-				/* If the old state was enabling or streaming, then the sink
-				 * ASE has been disabled. Since the sink ASE does not have a
-				 * disabling state, we can check if by comparing the old_state
-				 */
-				const bool disabled = old_state == BT_BAP_EP_STATE_ENABLING ||
-						      old_state == BT_BAP_EP_STATE_STREAMING;
+			/* If the old state was enabling or streaming, then the sink
+			 * ASE has been disabled. Since the sink ASE does not have a
+			 * disabling state, we can check if by comparing the old_state
+			 */
+			const bool disabled = old_state == BT_BAP_EP_STATE_ENABLING ||
+					      old_state == BT_BAP_EP_STATE_STREAMING;
 
-				if (disabled) {
+			if (disabled) {
+				if (ops->disabled != NULL) {
 					ops->disabled(stream);
+				}
+
+				if (ops->stopped != NULL) {
+					ops->stopped(stream, reason);
 				}
 			}
 		} else if (dir == BT_AUDIO_DIR_SOURCE) {
@@ -1321,7 +1312,18 @@ static void unicast_client_ep_notify_app(struct bt_bap_stream *stream, bool stat
 		}
 		break;
 	case BT_BAP_EP_STATE_RELEASING:
-		/* no callback for releasing state */
+		/* Call the `disable` `stopped` callback if we leave the BT_BAP_EP_STATE_STREAMING
+		 * state for any reason
+		 */
+		if (state_changed && old_state == BT_BAP_EP_STATE_STREAMING) {
+			if (ops->disabled != NULL) {
+				ops->disabled(stream);
+			}
+
+			if (ops->stopped != NULL) {
+				ops->stopped(stream, reason);
+			}
+		}
 		break;
 	default:
 		LOG_WRN("Unexpected new_state: %d", new_state);

--- a/tests/bsim/bluetooth/audio/src/bap_stream_tx.h
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_tx.h
@@ -46,8 +46,7 @@ int bap_stream_tx_register(struct bt_bap_stream *bap_stream);
  *
  * @retval 0 on success
  * @retval -EINVAL @p bap_stream is NULL
- * @retval -EINVAL @p bap_stream is not configured for TX
- * @retval -EALREADY @p bap_stream is currently not registered
+ * @retval -ENODATA @p bap_stream is currently not registered
  */
 int bap_stream_tx_unregister(struct bt_bap_stream *bap_stream);
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -190,7 +190,7 @@ static void unicast_stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 		int err;
 
 		err = bap_stream_tx_unregister(stream);
-		if (err != 0) {
+		if (err != 0 && err != -ENODATA) {
 			FAIL("Failed to unregister stream %p for TX: %d\n", stream, err);
 			return;
 		}


### PR DESCRIPTION
The BAP stream callbacks does not mirror the ASCS states 1:1 so there are a few cases where the callbacks are called without matching the ASCS state.

BAP stream ops are intended to be the same for sink and source ASEs, even though they have different state machine, but sink streams did
stopped()
disabled()
qos_configured()

when exiting the streaming state (without a release), and source streams did
disabled()
stopped()
qos_configured()

Refactor unicast_client_ep_notify_app a bit to have the same callbacks in the same order for sinks and sources.