### PR TITLE
Bluetooth: CAP: add subprocedure callbacks for unicast start and stop

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -430,6 +430,14 @@ New APIs and options
     * :c:member:`bt_bap_unicast_group_info.c_to_p_ft`
     * :c:member:`bt_bap_unicast_group_info.p_to_c_ft`
     * :c:member:`bt_bap_unicast_group_info.iso_interval`
+    * :c:member:`bt_cap_initiator_cb.unicast_start_codec_configured`
+    * :c:member:`bt_cap_initiator_cb.unicast_start_qos_configured`
+    * :c:member:`bt_cap_initiator_cb.unicast_start_enabled`
+    * :c:member:`bt_cap_initiator_cb.unicast_start_connected`
+    * :c:member:`bt_cap_initiator_cb.unicast_start_started`
+    * :c:member:`bt_cap_initiator_cb.unicast_stop_disabled`
+    * :c:member:`bt_cap_initiator_cb.unicast_stop_stopped`
+    * :c:member:`bt_cap_initiator_cb.unicast_stop_released`
     * :c:func:`bt_vocs_client_free_instance`
 
   * Host

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -123,6 +123,69 @@ struct bt_cap_initiator_cb {
 	void (*unicast_start_complete)(int err, struct bt_conn *conn);
 
 	/**
+	 * @brief All streams have been codec configured
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
+	 * @ref BT_BAP_EP_STATE_CODEC_CONFIGURED state or higher, with the requested codec
+	 * configuration.
+	 *
+	 * This is only called if at least one Config Codec operation was sent to a CAP acceptor,
+	 * i.e. it is not called if all streams already had the requested codec configuration.
+	 *
+	 * The unicast group may be reconfigured with bt_cap_unicast_group_reconfig() from this
+	 * callback, as the QoS Configuration subprocedure has not been started yet. This is only
+	 * possible if none of the streams in the unicast group have been connected earlier, as the
+	 * unicast group cannot be reconfigured once a CIS has been established. It is not possible
+	 * to start a new CAP procedure from this callback, as the current procedure is still in
+	 * progress.
+	 */
+	void (*unicast_start_codec_configured)(void);
+
+	/**
+	 * @brief All streams have been QoS configured
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
+	 * @ref BT_BAP_EP_STATE_QOS_CONFIGURED state or higher, with the QoS configuration of the
+	 * unicast group.
+	 *
+	 * This is only called if at least one Config QoS operation was sent to a CAP acceptor, i.e.
+	 * it is not called if all streams already had the requested QoS configuration.
+	 */
+	void (*unicast_start_qos_configured)(void);
+
+	/**
+	 * @brief All streams have been enabled
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
+	 * @ref BT_BAP_EP_STATE_ENABLING state or higher, with the requested metadata.
+	 *
+	 * This is only called if at least one Enable operation was sent to a CAP acceptor, i.e. it
+	 * is not called if all streams were already enabled with the requested metadata.
+	 */
+	void (*unicast_start_enabled)(void);
+
+	/**
+	 * @brief All streams have their CIS connected
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_start() have an established CIS.
+	 *
+	 * This is only called if at least one CIS was established as part of the procedure, i.e. it
+	 * is not called if all CISes were already established.
+	 */
+	void (*unicast_start_connected)(void);
+
+	/**
+	 * @brief All streams have been started
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_start() are in the
+	 * @ref BT_BAP_EP_STATE_STREAMING state.
+	 *
+	 * This is only called if at least one Receiver Start Ready operation was sent to a CAP
+	 * acceptor, i.e. it is not called if all streams were started by the CAP acceptors.
+	 */
+	void (*unicast_start_started)(void);
+
+	/**
 	 * @brief Callback for bt_cap_initiator_unicast_audio_update().
 	 *
 	 * @param err
@@ -164,6 +227,39 @@ struct bt_cap_initiator_cb {
 	 *             cancelled by bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_stop_complete)(int err, struct bt_conn *conn);
+
+	/**
+	 * @brief All streams have been disabled
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_stop() are in the
+	 * @ref BT_BAP_EP_STATE_DISABLING or @ref BT_BAP_EP_STATE_QOS_CONFIGURED state.
+	 *
+	 * This is only called if at least one Disable operation was sent to a CAP acceptor, i.e. it
+	 * is not called if none of the streams were enabled or streaming.
+	 */
+	void (*unicast_stop_disabled)(void);
+
+	/**
+	 * @brief All streams have been stopped
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_stop() are in the
+	 * @ref BT_BAP_EP_STATE_QOS_CONFIGURED state.
+	 *
+	 * This is only called if at least one Receiver Stop Ready operation was sent to a CAP
+	 * acceptor, i.e. it is not called if none of the streams were in the
+	 * @ref BT_BAP_EP_STATE_DISABLING state.
+	 */
+	void (*unicast_stop_stopped)(void);
+
+	/**
+	 * @brief All streams have been released
+	 *
+	 * All streams supplied to bt_cap_initiator_unicast_audio_stop() have been released.
+	 *
+	 * This is only called if at least one Release operation was sent to a CAP acceptor, i.e. it
+	 * is not called if the streams were not requested to be released.
+	 */
+	void (*unicast_stop_released)(void);
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(__DOXYGEN__)
 	/**

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -63,6 +63,15 @@ void bt_cap_common_unlock_proc(void)
 	LOG_DBG("Released active_proc_mutex");
 }
 
+uint32_t bt_cap_common_get_active_proc_mutex_lock_count(const struct bt_cap_common_proc *proc)
+{
+	__ASSERT(proc == &active_proc, "Caller did not provide the active_proc");
+	__ASSERT(active_proc_mutex.lock_count > 0U, "Unexpected active_proc_mutex.lock_count: %u",
+		 active_proc_mutex.lock_count);
+
+	return active_proc_mutex.lock_count;
+}
+
 void bt_cap_common_clear_proc(struct bt_cap_common_proc *proc)
 {
 	(void)memset(proc, 0, sizeof(*proc));
@@ -88,6 +97,7 @@ void bt_cap_common_set_subproc(enum bt_cap_common_subproc_type subproc_type)
 	active_proc.proc_done_cnt = 0U;
 	active_proc.proc_initiated_cnt = 0U;
 	active_proc.subproc_type = subproc_type;
+	active_proc.subproc_initiated = false;
 }
 
 bool bt_cap_common_proc_is_type(enum bt_cap_common_proc_type proc_type)

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1365,6 +1365,89 @@ bool bt_cap_initiator_valid_unicast_audio_start_param(
 	return true;
 }
 
+static bool
+cap_initiator_unicast_subproc_complete_and_continue(const struct bt_cap_common_proc *active_proc)
+{
+	LOG_DBG("subproc %d for proc %d completed (%sinitiated)", active_proc->subproc_type,
+		active_proc->proc_type, !active_proc->subproc_initiated ? "not " : "");
+
+	if (!active_proc->subproc_initiated) {
+		/* The subprocedure was skipped as all streams were already in the requested state,
+		 * so we do not notify the application
+		 */
+		return true;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_active_proc_is_handover()) {
+		/* The procedure was not started by the application, so we do not notify the
+		 * application about the subprocedures
+		 */
+		return true;
+	}
+
+	if (cap_cb == NULL) {
+		return true;
+	}
+
+	switch (active_proc->subproc_type) {
+	case BT_CAP_COMMON_SUBPROC_TYPE_CODEC_CONFIG:
+		if (cap_cb->unicast_start_codec_configured != NULL) {
+			cap_cb->unicast_start_codec_configured();
+		}
+		break;
+	case BT_CAP_COMMON_SUBPROC_TYPE_QOS_CONFIG:
+		if (cap_cb->unicast_start_qos_configured != NULL) {
+			cap_cb->unicast_start_qos_configured();
+		}
+		break;
+	case BT_CAP_COMMON_SUBPROC_TYPE_ENABLE:
+		if (cap_cb->unicast_start_enabled != NULL) {
+			cap_cb->unicast_start_enabled();
+		}
+		break;
+	case BT_CAP_COMMON_SUBPROC_TYPE_CONNECT:
+		if (cap_cb->unicast_start_connected != NULL) {
+			cap_cb->unicast_start_connected();
+		}
+		break;
+	case BT_CAP_COMMON_SUBPROC_TYPE_START:
+		if (cap_cb->unicast_start_started != NULL) {
+			cap_cb->unicast_start_started();
+		}
+		break;
+	case BT_CAP_COMMON_SUBPROC_TYPE_DISABLE:
+		if (cap_cb->unicast_stop_disabled != NULL) {
+			cap_cb->unicast_stop_disabled();
+		}
+		break;
+	case BT_CAP_COMMON_SUBPROC_TYPE_STOP:
+		if (cap_cb->unicast_stop_stopped != NULL) {
+			cap_cb->unicast_stop_stopped();
+		}
+		break;
+	case BT_CAP_COMMON_SUBPROC_TYPE_RELEASE:
+		if (cap_cb->unicast_stop_released != NULL) {
+			cap_cb->unicast_stop_released();
+		}
+		break;
+	default:
+		__ASSERT(false, "Unexpected subproc %d for proc %d", active_proc->subproc_type,
+			 active_proc->proc_type);
+		break;
+	}
+
+	if (bt_cap_common_proc_is_aborted()) {
+		__ASSERT(bt_cap_common_proc_all_handled(),
+			 "CAP procedure is aborted but not all subprocs were handled after "
+			 "subproc_complete: %u != %u",
+			 active_proc->proc_done_cnt, active_proc->proc_cnt);
+
+		return false;
+	}
+
+	return true;
+}
+
 void cap_initiator_unicast_audio_proc_complete(struct bt_cap_common_proc *active_proc)
 {
 	enum bt_cap_common_proc_type proc_type;
@@ -1520,6 +1603,7 @@ cap_initiator_unicast_audio_configure(struct bt_cap_common_proc *active_proc,
 	active_proc->proc_initiated_cnt++;
 	proc_param->in_progress = true;
 
+	active_proc->subproc_initiated = true;
 	if (bap_stream->conn == NULL) {
 		/* Since BAP operations may require a write long or a read long on the notification,
 		 * we cannot assume that we can do multiple streams at once, thus do it one at a
@@ -1654,6 +1738,7 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		if (next_bap_stream->conn == NULL) {
 			err = bt_bap_stream_config(conn, next_bap_stream, ep, codec_cfg);
@@ -1706,6 +1791,12 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		}
 	}
 
+	if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
+		cap_initiator_unicast_audio_proc_complete(active_proc);
+
+		return;
+	}
+
 	/* All streams in the procedure share the same unicast group, so we just
 	 * use the reference from the first stream
 	 */
@@ -1740,6 +1831,7 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		}
 
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_qos(conns[i], unicast_group);
 		if (err != 0) {
@@ -1815,6 +1907,12 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 			return;
 		}
 
+		if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+
+			return;
+		}
+
 		bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_ENABLE);
 		proc_param = get_next_proc_param(active_proc);
 		if (proc_param == NULL) {
@@ -1832,6 +1930,7 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 		bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		codec_cfg = proc_param->start.codec_cfg;
 
@@ -1857,6 +1956,7 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_release(next_bap_stream);
 		if (err != 0) {
@@ -1924,6 +2024,7 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 
 		proc_param->in_progress = true;
 		codec_cfg = proc_param->start.codec_cfg;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_enable(next_bap_stream, codec_cfg->meta, codec_cfg->meta_len);
 		if (err != 0) {
@@ -1934,6 +2035,12 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		} else {
 			bt_cap_common_unlock_proc();
 		}
+
+		return;
+	}
+
+	if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
+		cap_initiator_unicast_audio_proc_complete(active_proc);
 
 		return;
 	}
@@ -1952,6 +2059,7 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 
 	bap_stream = &proc_param->stream->bap_stream;
 	proc_param->in_progress = true;
+	active_proc->subproc_initiated = true;
 
 	err = bt_bap_stream_connect(bap_stream);
 	if (err == -EALREADY) {
@@ -1973,7 +2081,6 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		bt_cap_common_abort_proc(bap_stream->conn, err);
 		cap_initiator_unicast_audio_proc_complete(active_proc);
 	} else {
-
 		bt_cap_common_unlock_proc();
 	}
 }
@@ -2036,6 +2143,7 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 
 			active_proc->proc_initiated_cnt++;
 			proc_param->in_progress = true;
+			active_proc->subproc_initiated = true;
 
 			err = bt_bap_stream_connect(next_bap_stream);
 			if (err == 0 || err == -EALREADY) {
@@ -2058,6 +2166,12 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 		return;
 	}
 
+	if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
+		cap_initiator_unicast_audio_proc_complete(active_proc);
+
+		return;
+	}
+
 	/* All streams connected - Start sending the receiver start ready for all source
 	 * ASEs. For sink ASEs it is the responsibility of the unicast server to do the
 	 * receiver start ready operation. If there are no source ASEs then we just wait.
@@ -2065,11 +2179,13 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 	bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_START);
 	proc_param = get_next_proc_param(active_proc);
 	if (proc_param == NULL) {
-		bt_cap_common_unlock_proc();
-
-		/* If proc_param is NULL then this step is a no-op and we can skip to the next step
+		/* If proc_param is NULL then this step is a no-op.
+		 * May happen if we have sink streams only, mark subproc_initiated to treat
+		 * this similar to sources and then just wait for notification from server
 		 */
-		bt_cap_initiator_started(active_proc->proc_param.initiator[0].stream);
+		active_proc->subproc_initiated = true;
+
+		bt_cap_common_unlock_proc();
 
 		return;
 	}
@@ -2077,6 +2193,7 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 	bap_stream = &proc_param->stream->bap_stream;
 	if (stream_is_dir(bap_stream, BT_AUDIO_DIR_SOURCE)) {
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_start(bap_stream);
 		if (err != 0) {
@@ -2141,37 +2258,49 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 		struct bt_bap_stream *next_bap_stream;
 
 		proc_param = get_next_proc_param(active_proc);
-		if (proc_param != NULL) {
-			next_cap_stream = proc_param->stream;
-			next_bap_stream = &next_cap_stream->bap_stream;
+		if (proc_param == NULL) {
+			/* If proc_param is NULL then this step is a no-op.
+			 * May happen if we have sink streams only, mark subproc_initiated to treat
+			 * this similar to sources and then just wait for notification from server
+			 */
+			active_proc->subproc_initiated = true;
 
-			if (stream_is_dir(next_bap_stream, BT_AUDIO_DIR_SOURCE)) {
-				int err;
+			bt_cap_common_unlock_proc();
 
-				proc_param->in_progress = true;
+			return;
+		}
 
-				err = bt_bap_stream_start(next_bap_stream);
-				if (err != 0) {
-					LOG_DBG("Failed to start stream %p: %d", next_cap_stream,
-						err);
+		next_cap_stream = proc_param->stream;
+		next_bap_stream = &next_cap_stream->bap_stream;
 
-					/* End and mark procedure as aborted.
-					 * If we have sent any requests over air, we will abort
-					 * once all sent requests has completed
-					 */
-					bt_cap_common_abort_proc(next_bap_stream->conn, err);
-					cap_initiator_unicast_audio_proc_complete(active_proc);
+		if (stream_is_dir(next_bap_stream, BT_AUDIO_DIR_SOURCE)) {
+			int err;
 
-					return;
-				}
+			proc_param->in_progress = true;
+			active_proc->subproc_initiated = true;
+
+			err = bt_bap_stream_start(next_bap_stream);
+			if (err != 0) {
+				LOG_DBG("Failed to start stream %p: %d", next_cap_stream, err);
+
+				/* End and mark procedure as aborted.
+				 * If we have sent any requests over air, we will abort
+				 * once all sent requests has completed
+				 */
+				bt_cap_common_abort_proc(next_bap_stream->conn, err);
+				cap_initiator_unicast_audio_proc_complete(active_proc);
+
+				return;
 			}
-		} /* else await notifications from server */
+		}
 
 		bt_cap_common_unlock_proc();
 
 		/* Return to await for response from server */
 		return;
 	}
+
+	(void)cap_initiator_unicast_subproc_complete_and_continue(active_proc);
 
 	cap_initiator_unicast_audio_proc_complete(active_proc);
 }
@@ -2377,7 +2506,17 @@ int bt_cap_initiator_unicast_audio_cancel(void)
 	}
 
 	bt_cap_common_abort_proc(NULL, -ECANCELED);
-	cap_initiator_unicast_audio_proc_complete(active_proc);
+
+	if (bt_cap_common_get_active_proc_mutex_lock_count(active_proc) == 1U) {
+		/* Since this may be called in a CAP callback, check if we hold the only mutex lock,
+		 * and if we do, then we complete it, else
+		 * cap_initiator_unicast_subproc_complete_and_continue is responsible for handling
+		 * that
+		 */
+		cap_initiator_unicast_audio_proc_complete(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
+	}
 
 	return 0;
 }
@@ -2639,6 +2778,7 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 		bap_stream = &proc_param->stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_disable(bap_stream);
 		if (err != 0) {
@@ -2656,6 +2796,7 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 		bap_stream = &proc_param->stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_stop(bap_stream);
 		if (err != 0) {
@@ -2673,6 +2814,7 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 		bap_stream = &proc_param->stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_release(bap_stream);
 		if (err != 0) {
@@ -2757,6 +2899,7 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_disable(next_bap_stream);
 		if (err != 0) {
@@ -2764,8 +2907,6 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
 			cap_initiator_unicast_audio_proc_complete(active_proc);
-		} else {
-			bt_cap_common_unlock_proc();
 		}
 	} else {
 		struct bt_cap_initiator_proc_param *proc_param;
@@ -2773,16 +2914,24 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		struct bt_bap_stream *next_bap_stream;
 		int err;
 
+		if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+
+			return;
+		}
+
 		bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_STOP);
 
 		proc_param = get_next_proc_param(active_proc);
 		if (proc_param == NULL) {
-			bt_cap_common_unlock_proc();
-
-			/* If proc_param is NULL then this step is a no-op and we can skip to the
-			 * next step
+			/* If proc_param is NULL then this step is a no-op.
+			 * May happen if we have sink streams only, mark subproc_initiated to treat
+			 * this similar to sources.
+			 * BAP will call ops->stopped for the sink stream after this
 			 */
-			bt_cap_initiator_stopped(active_proc->proc_param.initiator[0].stream);
+			active_proc->subproc_initiated = true;
+
+			bt_cap_common_unlock_proc();
 
 			return;
 		}
@@ -2791,6 +2940,7 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_stop(next_bap_stream);
 		if (err != 0) {
@@ -2798,11 +2948,14 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
 			cap_initiator_unicast_audio_proc_complete(active_proc);
+
+			return;
 		} else {
 			/* else wait for server notification*/
-			bt_cap_common_unlock_proc();
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
@@ -2854,23 +3007,35 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 		int err;
 
 		proc_param = get_next_proc_param(active_proc);
-		if (proc_param != NULL) {
-			next_cap_stream = proc_param->stream;
-			next_bap_stream = &next_cap_stream->bap_stream;
+		if (proc_param == NULL) {
+			bt_cap_common_unlock_proc();
 
-			active_proc->proc_initiated_cnt++;
-			proc_param->in_progress = true;
+			/* If proc_param is NULL then this step is a no-op.
+			 * May happen if we have sink streams only, mark subproc_initiated to treat
+			 * this similar to sources.
+			 * BAP will call ops->qos_configured for the sink stream after this
+			 */
+			active_proc->subproc_initiated = true;
 
-			err = bt_bap_stream_stop(next_bap_stream);
-			if (err != 0) {
-				LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
+			return;
+		}
 
-				bt_cap_common_abort_proc(next_bap_stream->conn, err);
-				cap_initiator_unicast_audio_proc_complete(active_proc);
+		next_cap_stream = proc_param->stream;
+		next_bap_stream = &next_cap_stream->bap_stream;
 
-				return;
-			}
-		} /* else await notification from server */
+		active_proc->proc_initiated_cnt++;
+		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
+
+		err = bt_bap_stream_stop(next_bap_stream);
+		if (err != 0) {
+			LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
+
+			bt_cap_common_abort_proc(next_bap_stream->conn, err);
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+
+			return;
+		} /* else wait for server notification*/
 	} else {
 		/* We are done stopping streams now - We mark the next subproc. If
 		 * get_next_proc_param returns a NULL value it means that we are complete done. If
@@ -2880,9 +3045,8 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 		 */
 		struct bt_cap_initiator_proc_param *proc_param;
 
-		if (!bt_cap_common_proc_is_done()) {
-			/* We are still disabling or stopping some */
-			bt_cap_common_unlock_proc();
+		if (!cap_initiator_unicast_subproc_complete_and_continue(active_proc)) {
+			cap_initiator_unicast_audio_proc_complete(active_proc);
 
 			return;
 		}
@@ -2956,6 +3120,7 @@ void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
+		active_proc->subproc_initiated = true;
 
 		err = bt_bap_stream_release(next_bap_stream);
 		if (err != 0) {
@@ -2967,6 +3132,8 @@ void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
 			bt_cap_common_unlock_proc();
 		}
 	} else {
+
+		(void)cap_initiator_unicast_subproc_complete_and_continue(active_proc);
 		cap_initiator_unicast_audio_proc_complete(active_proc);
 	}
 }

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -282,6 +282,8 @@ struct bt_cap_common_proc {
 	struct bt_cap_common_proc_param proc_param;
 #if defined(CONFIG_BT_CAP_SUBPROC_SUPPORT)
 	enum bt_cap_common_subproc_type subproc_type;
+	/* Whether any request has been sent to a peer device for the current subprocedure */
+	bool subproc_initiated;
 #endif /* CONFIG_BT_CAP_SUBPROC_SUPPORT */
 };
 
@@ -306,6 +308,7 @@ void bt_cap_common_unlock_proc(void);
  * @param proc The procedure to unlock and clear
  */
 void bt_cap_common_clear_proc(struct bt_cap_common_proc *proc);
+uint32_t bt_cap_common_get_active_proc_mutex_lock_count(const struct bt_cap_common_proc *proc);
 void bt_cap_common_set_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt);
 void bt_cap_common_set_subproc(enum bt_cap_common_subproc_type subproc_type);
 void bt_cap_common_set_handover_active(void);

--- a/tests/bluetooth/audio/cap_initiator/include/cap_initiator.h
+++ b/tests/bluetooth/audio/cap_initiator/include/cap_initiator.h
@@ -22,8 +22,16 @@ DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_discovery_complete_cb, struct 
 		       const struct bt_csip_set_coordinator_set_member *,
 		       const struct bt_csip_set_coordinator_csis_inst *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_complete_cb, int, struct bt_conn *);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_codec_configured_cb);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_qos_configured_cb);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_enabled_cb);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_connected_cb);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_started_cb);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_update_complete_cb, int, struct bt_conn *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_complete_cb, int, struct bt_conn *);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_disabled_cb);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_stopped_cb);
+DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_released_cb);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_started_cb, struct bt_cap_broadcast_source *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_stopped_cb, struct bt_cap_broadcast_source *,
 		       uint8_t);

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -228,6 +228,18 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start)
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
+	/* All streams started from the idle state, so all subprocedures were performed */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 1,
+			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 1,
+			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_enabled", 1,
+			   mock_cap_initiator_unicast_start_enabled_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_connected", 1,
+			   mock_cap_initiator_unicast_start_connected_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_started", 1,
+			   mock_cap_initiator_unicast_start_started_cb_fake.call_count);
+
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
 
@@ -421,8 +433,17 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
+	/* The streams had a different codec configuration, so the Codec Configuration
+	 * subprocedure was performed
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 1,
+			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 1,
+			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
+
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
+
 	zassert_equal(0, mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0], "%d",
 		      mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0]);
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
@@ -445,9 +466,7 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_qos_configured)
 {
-	/* Use a different preset than fixture->preset to also verify that the codec_cfg data is
-	 * updated
-	 */
+	/* Use a different preset than fixture->preset to also verify that the QoS is updated */
 	struct bt_bap_lc3_preset preset =
 		(struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_48_2_1(
 			BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
@@ -486,8 +505,17 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
+	/* The streams were already codec configured, so that subprocedure was skipped, but the
+	 * QoS configuration was different so that subprocedure was performed
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 0,
+			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 1,
+			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
+
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
+
 	zassert_equal(0, mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0], "%d",
 		      mock_cap_initiator_unicast_start_complete_cb_fake.arg0_history[0]);
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
@@ -527,6 +555,16 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	/* The streams were already enabled with the requested configuration and metadata, so the
+	 * Codec Configuration, QoS Configuration and Enable subprocedures were all skipped
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_codec_configured", 0,
+			   mock_cap_initiator_unicast_start_codec_configured_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_qos_configured", 0,
+			   mock_cap_initiator_unicast_start_qos_configured_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_enabled", 0,
+			   mock_cap_initiator_unicast_start_enabled_cb_fake.call_count);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -284,6 +284,16 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
+	/* The streams were streaming or enabling, so both the Disable and the Receiver Stop Ready
+	 * subprocedures were performed, but the streams were not released
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
+			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
+			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 0,
+			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
+
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
@@ -308,6 +318,16 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
+
+	/* The streams were streaming or enabling, so both the Disable and the Receiver Stop Ready
+	 * subprocedures were performed, but the streams were not released
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
+			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
+			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 0,
+			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
@@ -337,6 +357,16 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
+	/* The streams were not streaming or enabling, so only the Release subprocedure was
+	 * performed
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 0,
+			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 0,
+			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
+			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
+
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 
@@ -364,6 +394,16 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
+	/* The streams were not streaming or enabling, so only the Release subprocedure was
+	 * performed
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 0,
+			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 0,
+			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
+			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
+
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 
@@ -390,6 +430,16 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
+	/* The streams were streaming or enabling and were requested to be released, so all
+	 * subprocedures were performed
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
+			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
+			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
+			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
+
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 
@@ -415,6 +465,16 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
+
+	/* The streams were streaming or enabling and were requested to be released, so all
+	 * subprocedures were performed
+	 */
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_disabled", 1,
+			   mock_cap_initiator_unicast_stop_disabled_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_stopped", 1,
+			   mock_cap_initiator_unicast_stop_stopped_cb_fake.call_count);
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_released", 1,
+			   mock_cap_initiator_unicast_stop_released_cb_fake.call_count);
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 

--- a/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
@@ -16,16 +16,32 @@
 #define FFF_FAKES_LIST(FAKE)                                                                       \
 	FAKE(mock_cap_initiator_unicast_discovery_complete_cb)                                     \
 	FAKE(mock_cap_initiator_unicast_start_complete_cb)                                         \
+	FAKE(mock_cap_initiator_unicast_start_codec_configured_cb)                                 \
+	FAKE(mock_cap_initiator_unicast_start_qos_configured_cb)                                   \
+	FAKE(mock_cap_initiator_unicast_start_enabled_cb)                                          \
+	FAKE(mock_cap_initiator_unicast_start_connected_cb)                                        \
+	FAKE(mock_cap_initiator_unicast_start_started_cb)                                          \
 	FAKE(mock_cap_initiator_unicast_update_complete_cb)                                        \
-	FAKE(mock_cap_initiator_unicast_stop_complete_cb)
+	FAKE(mock_cap_initiator_unicast_stop_complete_cb)                                          \
+	FAKE(mock_cap_initiator_unicast_stop_disabled_cb)                                          \
+	FAKE(mock_cap_initiator_unicast_stop_stopped_cb)                                           \
+	FAKE(mock_cap_initiator_unicast_stop_released_cb)
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_discovery_complete_cb, struct bt_conn *, int,
 		      const struct bt_csip_set_coordinator_set_member *,
 		      const struct bt_csip_set_coordinator_csis_inst *);
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_complete_cb, int, struct bt_conn *);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_codec_configured_cb);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_qos_configured_cb);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_enabled_cb);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_connected_cb);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_start_started_cb);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_update_complete_cb, int, struct bt_conn *);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_complete_cb, int, struct bt_conn *);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_disabled_cb);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_stopped_cb);
+DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_unicast_stop_released_cb);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_started_cb, struct bt_cap_broadcast_source *);
 DEFINE_FAKE_VOID_FUNC(mock_cap_initiator_broadcast_stopped_cb, struct bt_cap_broadcast_source *,
 		      uint8_t);
@@ -34,8 +50,16 @@ const struct bt_cap_initiator_cb mock_cap_initiator_cb = {
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 	.unicast_discovery_complete = mock_cap_initiator_unicast_discovery_complete_cb,
 	.unicast_start_complete = mock_cap_initiator_unicast_start_complete_cb,
+	.unicast_start_codec_configured = mock_cap_initiator_unicast_start_codec_configured_cb,
+	.unicast_start_qos_configured = mock_cap_initiator_unicast_start_qos_configured_cb,
+	.unicast_start_enabled = mock_cap_initiator_unicast_start_enabled_cb,
+	.unicast_start_connected = mock_cap_initiator_unicast_start_connected_cb,
+	.unicast_start_started = mock_cap_initiator_unicast_start_started_cb,
 	.unicast_update_complete = mock_cap_initiator_unicast_update_complete_cb,
 	.unicast_stop_complete = mock_cap_initiator_unicast_stop_complete_cb,
+	.unicast_stop_disabled = mock_cap_initiator_unicast_stop_disabled_cb,
+	.unicast_stop_stopped = mock_cap_initiator_unicast_stop_stopped_cb,
+	.unicast_stop_released = mock_cap_initiator_unicast_stop_released_cb,
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 	.broadcast_started = mock_cap_initiator_broadcast_started_cb,

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -1230,6 +1230,31 @@ static void test_cap_acceptor_unicast_disconnect(void)
 	PASS("CAP acceptor unicast disconnect passed\n");
 }
 
+static void test_cap_acceptor_unicast_cancel_in_subproc(void)
+{
+	init();
+
+	test_start_adv();
+
+	auto_start_sink_streams = true;
+
+	WAIT_FOR_FLAG(flag_connected);
+
+	/* Wait until initiator is done starting streams */
+	backchannel_sync_wait(CAP_INITIATOR_DEV_ID);
+
+	if (expect_rx) {
+		wait_for_data();
+	}
+
+	/* let initiator know we have received what we wanted */
+	backchannel_sync_send(CAP_INITIATOR_DEV_ID);
+
+	WAIT_FOR_UNSET_FLAG(flag_connected);
+
+	PASS("CAP acceptor unicast cancel in subproc passed\n");
+}
+
 static void pa_sync_to_broadcaster(void)
 {
 	int err;
@@ -1411,6 +1436,12 @@ static const struct bst_test_instance test_cap_acceptor[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_cap_acceptor_unicast_disconnect,
+	},
+	{
+		.test_id = "cap_acceptor_unicast_cancel_in_subproc",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_cap_acceptor_unicast_cancel_in_subproc,
 	},
 	{
 		.test_id = "cap_acceptor_broadcast",

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -95,7 +95,7 @@ CREATE_FLAG(flag_codec_found);
 CREATE_FLAG(flag_endpoint_found);
 CREATE_FLAG(flag_started);
 CREATE_FLAG(flag_start_failed);
-CREATE_FLAG(flag_start_timeout);
+CREATE_FLAG(flag_start_cancelled);
 CREATE_FLAG(flag_start_codec_configured_subproc);
 CREATE_FLAG(flag_start_qos_configured_subproc);
 CREATE_FLAG(flag_start_enabled_subproc);
@@ -109,6 +109,7 @@ CREATE_FLAG(flag_stop_released_subproc);
 CREATE_FLAG(flag_mtu_exchanged);
 CREATE_FLAG(flag_sink_discovered);
 CREATE_FLAG(flag_source_discovered);
+CREATE_FLAG(flag_cancel_in_enabled);
 
 static const struct named_lc3_preset lc3_unicast_presets[] = {
 	{"8_1_1", BT_BAP_LC3_UNICAST_PRESET_8_1_1(LOCATION, CONTEXT)},
@@ -266,8 +267,10 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 
 static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 {
+	LOG_INF("Unicast start completed with err: %d (%p)", err, conn);
+
 	if (err == -ECANCELED) {
-		SET_FLAG(flag_start_timeout);
+		SET_FLAG(flag_start_cancelled);
 	} else if (err != 0) {
 		LOG_ERR("Failed to start (failing conn %p): %d", conn, err);
 		SET_FLAG(flag_start_failed);
@@ -295,6 +298,16 @@ static void unicast_start_enabled_cb(void)
 	LOG_INF("All streams enabled");
 
 	SET_FLAG(flag_start_enabled_subproc);
+
+	if (TEST_FLAG(flag_cancel_in_enabled)) {
+		int err;
+
+		err = bt_cap_initiator_unicast_audio_cancel();
+		if (err != 0) {
+			FAIL("Failed to cancel unicast audio: %d\n", err);
+			return;
+		}
+	}
 }
 
 static void unicast_start_connected_cb(void)
@@ -1122,6 +1135,19 @@ static void wait_for_data(void)
 	LOG_INF("Data received");
 }
 
+static void disconnect_default_conn(void)
+{
+	int err;
+
+	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
+	if (err != 0) {
+		FAIL("Failed to disconnect: %d\n", err);
+	}
+
+	bt_conn_drop(&default_conn);
+}
+
 static void test_main_cap_initiator_unicast(void)
 {
 	struct bt_cap_unicast_group *unicast_group;
@@ -1249,7 +1275,7 @@ static void test_cap_initiator_unicast_timeout(void)
 			unicast_audio_cancel();
 		}
 
-		WAIT_FOR_FLAG(flag_start_timeout);
+		WAIT_FOR_FLAG(flag_start_cancelled);
 
 		cap_initiator_unicast_audio_stop(unicast_group);
 	}
@@ -1258,6 +1284,60 @@ static void test_cap_initiator_unicast_timeout(void)
 	unicast_group = NULL;
 
 	PASS("CAP initiator unicast timeout passed\n");
+}
+
+static void test_cap_initiator_unicast_cancel_in_subproc(void)
+{
+	struct bt_cap_unicast_group *unicast_group;
+
+	SET_FLAG(flag_cancel_in_enabled);
+
+	init();
+
+	scan_and_connect();
+
+	WAIT_FOR_FLAG(flag_mtu_exchanged);
+
+	update_security(default_conn);
+
+	discover_cas(default_conn);
+
+	discover_sink(default_conn);
+	discover_source(default_conn);
+
+	unicast_group_create(&unicast_group);
+
+	unicast_audio_start(unicast_group, false);
+
+	WAIT_FOR_FLAG(flag_start_codec_configured_subproc);
+	WAIT_FOR_FLAG(flag_start_qos_configured_subproc);
+	WAIT_FOR_FLAG(flag_start_enabled_subproc);
+
+	WAIT_FOR_FLAG(flag_start_cancelled);
+
+	if (TEST_FLAG(flag_start_connected_subproc)) {
+		FAIL("Cancel in enabled did not prevent connected from being completed");
+	}
+
+	if (TEST_FLAG(flag_start_started_subproc)) {
+		FAIL("Cancel in enabled did not prevent started from being completed");
+	}
+
+	/* Resume the procedure */
+	UNSET_FLAG(flag_cancel_in_enabled);
+	unicast_audio_start(unicast_group, true);
+
+	/* Wait until acceptors have received expected data */
+	backchannel_sync_wait_all();
+
+	cap_initiator_unicast_audio_stop(unicast_group);
+
+	unicast_group_delete(unicast_group);
+	unicast_group = NULL;
+
+	disconnect_default_conn();
+
+	PASS("CAP initiator unicast cancel in subproc passed\n");
 }
 
 static void set_invalid_metadata_type(uint8_t type)
@@ -2082,6 +2162,12 @@ static const struct bst_test_instance test_cap_initiator_unicast[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_main_cap_initiator_unicast_inval,
+	},
+	{
+		.test_id = "cap_initiator_unicast_cancel_in_subproc",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_cap_initiator_unicast_cancel_in_subproc,
 	},
 	{
 		.test_id = "cap_initiator_ac_1",

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -96,8 +96,16 @@ CREATE_FLAG(flag_endpoint_found);
 CREATE_FLAG(flag_started);
 CREATE_FLAG(flag_start_failed);
 CREATE_FLAG(flag_start_timeout);
+CREATE_FLAG(flag_start_codec_configured_subproc);
+CREATE_FLAG(flag_start_qos_configured_subproc);
+CREATE_FLAG(flag_start_enabled_subproc);
+CREATE_FLAG(flag_start_connected_subproc);
+CREATE_FLAG(flag_start_started_subproc);
 CREATE_FLAG(flag_updated);
 CREATE_FLAG(flag_stopped);
+CREATE_FLAG(flag_stop_disabled_subproc);
+CREATE_FLAG(flag_stop_stopped_subproc);
+CREATE_FLAG(flag_stop_released_subproc);
 CREATE_FLAG(flag_mtu_exchanged);
 CREATE_FLAG(flag_sink_discovered);
 CREATE_FLAG(flag_source_discovered);
@@ -268,6 +276,41 @@ static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 	}
 }
 
+static void unicast_start_codec_configured_cb(void)
+{
+	LOG_INF("All streams codec configured");
+
+	SET_FLAG(flag_start_codec_configured_subproc);
+}
+
+static void unicast_start_qos_configured_cb(void)
+{
+	LOG_INF("All streams QoS configured");
+
+	SET_FLAG(flag_start_qos_configured_subproc);
+}
+
+static void unicast_start_enabled_cb(void)
+{
+	LOG_INF("All streams enabled");
+
+	SET_FLAG(flag_start_enabled_subproc);
+}
+
+static void unicast_start_connected_cb(void)
+{
+	LOG_INF("All streams connected");
+
+	SET_FLAG(flag_start_connected_subproc);
+}
+
+static void unicast_start_started_cb(void)
+{
+	LOG_INF("All streams started");
+
+	SET_FLAG(flag_start_started_subproc);
+}
+
 static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 {
 	if (err != 0) {
@@ -290,11 +333,40 @@ static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 	SET_FLAG(flag_stopped);
 }
 
+static void unicast_stop_disabled_cb(void)
+{
+	LOG_INF("All streams disabled");
+
+	SET_FLAG(flag_stop_disabled_subproc);
+}
+
+static void unicast_stop_stopped_cb(void)
+{
+	LOG_INF("All streams stopped");
+
+	SET_FLAG(flag_stop_stopped_subproc);
+}
+
+static void unicast_stop_released_cb(void)
+{
+	LOG_INF("All streams released");
+
+	SET_FLAG(flag_stop_released_subproc);
+}
+
 static struct bt_cap_initiator_cb cap_cb = {
 	.unicast_discovery_complete = cap_discovery_complete_cb,
 	.unicast_start_complete = unicast_start_complete_cb,
+	.unicast_start_codec_configured = unicast_start_codec_configured_cb,
+	.unicast_start_qos_configured = unicast_start_qos_configured_cb,
+	.unicast_start_enabled = unicast_start_enabled_cb,
+	.unicast_start_connected = unicast_start_connected_cb,
+	.unicast_start_started = unicast_start_started_cb,
 	.unicast_update_complete = unicast_update_complete_cb,
 	.unicast_stop_complete = unicast_stop_complete_cb,
+	.unicast_stop_disabled = unicast_stop_disabled_cb,
+	.unicast_stop_stopped = unicast_stop_stopped_cb,
+	.unicast_stop_released = unicast_stop_released_cb,
 };
 
 static void add_remote_sink(const struct bt_conn *conn, struct bt_bap_ep *ep)
@@ -724,6 +796,25 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 	return true;
 }
 
+static bool stream_is_in_state(const struct bt_cap_stream *cap_stream, enum bt_bap_ep_state state)
+{
+	struct bt_bap_ep_info ep_info;
+	int err;
+
+	if (cap_stream->bap_stream.ep == NULL) {
+		return BT_BAP_EP_STATE_IDLE;
+	}
+
+	err = bt_bap_ep_get_info(cap_stream->bap_stream.ep, &ep_info);
+	if (err != 0) {
+		LOG_DBG("Failed to get endpoint info %p: %d", cap_stream, err);
+
+		return BT_BAP_EP_STATE_IDLE;
+	}
+
+	return ep_info.state == state;
+}
+
 static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool wait)
 {
 	struct bt_cap_unicast_audio_start_stream_param stream_param[2];
@@ -744,6 +835,32 @@ static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool
 	stream_param[1].ep = unicast_source_eps[bt_conn_index(default_conn)][0];
 	stream_param[1].codec_cfg = &unicast_preset_16_2_1.codec_cfg;
 
+	/* Unset flags based on the stream EP and ISO states, as some subprocedures may be skipped
+	 * if all streams are already in that state
+	 */
+	for (size_t i = 0U; i < param.count; i++) {
+		const struct bt_cap_stream *cap_stream = param.stream_params[i].stream;
+
+		if (stream_is_in_state(cap_stream, BT_BAP_EP_STATE_IDLE)) {
+			UNSET_FLAG(flag_start_codec_configured_subproc);
+		}
+
+		if (stream_is_in_state(cap_stream, BT_BAP_EP_STATE_CODEC_CONFIGURED)) {
+			UNSET_FLAG(flag_start_qos_configured_subproc);
+		}
+
+		if (stream_is_in_state(cap_stream, BT_BAP_EP_STATE_QOS_CONFIGURED)) {
+			UNSET_FLAG(flag_start_enabled_subproc);
+		}
+
+		if (stream_is_in_state(cap_stream, BT_BAP_EP_STATE_ENABLING)) {
+			UNSET_FLAG(flag_start_started_subproc);
+		}
+
+		if (cap_stream->bap_stream.iso == NULL) {
+			UNSET_FLAG(flag_start_connected_subproc);
+		}
+	}
 	UNSET_FLAG(flag_started);
 
 	err = bt_cap_initiator_unicast_audio_start(&param);
@@ -753,6 +870,14 @@ static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool
 	}
 
 	if (wait) {
+		/* The streams were all in the idle state, so all subprocedures shall have been
+		 * performed
+		 */
+		WAIT_FOR_FLAG(flag_start_codec_configured_subproc);
+		WAIT_FOR_FLAG(flag_start_qos_configured_subproc);
+		WAIT_FOR_FLAG(flag_start_enabled_subproc);
+		WAIT_FOR_FLAG(flag_start_connected_subproc);
+		WAIT_FOR_FLAG(flag_start_started_subproc);
 		WAIT_FOR_FLAG(flag_started);
 		/* let other devices know we have started what we wanted */
 		backchannel_sync_send_all();
@@ -873,6 +998,9 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 	param.release = false;
 
 	/* Stop without release first to verify that we enter the QoS Configured state */
+	UNSET_FLAG(flag_stop_disabled_subproc);
+	UNSET_FLAG(flag_stop_stopped_subproc);
+	UNSET_FLAG(flag_stop_released_subproc);
 	UNSET_FLAG(flag_stopped);
 	LOG_INF("Stopping without releasing");
 
@@ -890,6 +1018,15 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 		return;
 	}
 
+	/* The streams were all streaming, so both the disable and the receiver stop ready
+	 * subprocedures shall have been performed, but the streams shall not have been released
+	 */
+	WAIT_FOR_FLAG(flag_stop_disabled_subproc);
+	WAIT_FOR_FLAG(flag_stop_stopped_subproc);
+	if (TEST_FLAG(flag_stop_released_subproc)) {
+		FAIL("Streams released without being requested to\n");
+		return;
+	}
 	WAIT_FOR_FLAG(flag_stopped);
 
 	/* Verify that it cannot be stopped twice */
@@ -901,6 +1038,9 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 	}
 
 	/* Stop with release first to verify that we enter the idle state */
+	UNSET_FLAG(flag_stop_disabled_subproc);
+	UNSET_FLAG(flag_stop_stopped_subproc);
+	UNSET_FLAG(flag_stop_released_subproc);
 	UNSET_FLAG(flag_stopped);
 	param.release = true;
 	LOG_INF("Releasing");
@@ -911,6 +1051,14 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 		return;
 	}
 
+	/* The streams were already in the QoS Configured state, so only the release subprocedure
+	 * shall have been performed
+	 */
+	WAIT_FOR_FLAG(flag_stop_released_subproc);
+	if (TEST_FLAG(flag_stop_disabled_subproc) || TEST_FLAG(flag_stop_stopped_subproc)) {
+		FAIL("Streams disabled or stopped when they were already stopped\n");
+		return;
+	}
 	WAIT_FOR_FLAG(flag_stopped);
 
 	/* Verify that it cannot be stopped twice */

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_cancel_in_subproc.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_cancel_in_subproc.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_unicast_cancel_in_subproc"
+VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running CAP unicast cancel in subproc test =========\n\n"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_cancel_in_subproc \
+  -RealEncryption=1 -rs=46 -D=2
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast_cancel_in_subproc \
+  -RealEncryption=1 -rs=23 -D=2
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
The CAP unicast audio start and stop procedures consist of several
subprocedures, and applications may need to know when each of these have
completed, e.g. to reconfigure the unicast group after the streams have
been codec configured but before they are QoS configured.

Add new callbacks to bt_cap_initiator_cb for each subprocedure of the
unicast audio start and unicast audio stop procedures. The callbacks are
only called if at least one request was sent to a CAP acceptor as part of
the subprocedure, so that subprocedures that are skipped because all
streams are already in the requested state do not trigger a callback. To
support this a new subproc_initiated field has been added to the common
procedure struct, which is reset whenever a new subprocedure is set.

The unit tests have been extended to verify both that the callbacks are
called when the subprocedures are performed, and that they are not called
when the subprocedures are skipped, and the BSIM CAP initiator unicast
test now waits for the new callbacks as part of the start and stop
procedures.

depends on https://github.com/zephyrproject-rtos/zephyr/pull/116928
fixes https://github.com/zephyrproject-rtos/zephyr/issues/103425