### PR TITLE
twister: report unexpected faults as crashes, not timeouts

### DIFF
--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -43,6 +43,11 @@ SIM_PROGRAM_CMAKE_VARS = {
     'armfvp': 'ARMFVP',
 }
 
+# Failure reason reported when the console output contains an unexpected
+# fatal error (a crash), shared between the harness and the handlers so
+# every execution path reports such a crash the same way.
+FAULT_REASON = "Fault detected while running test"
+
 PYTEST_HARNESSES = ['pytest', 'shell', 'power', 'display_capture']
 
 SUPPORTED_HARNESSES = [

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 import psutil
 from domains import Domains
 from twisterlib import ZEPHYR_BASE
+from twisterlib.constants import FAULT_REASON
 from twisterlib.environment import strip_ansi_sequences
 from twisterlib.hardwaredata import CompoundHardwareData
 from twisterlib.platform import Platform
@@ -207,6 +208,12 @@ class Handler:
             # Depending on the failure type, we set the reason
             if self.options.enable_valgrind and self.returncode == 2:
                 self.instance.reason = "Valgrind error"
+            elif harness.fault:
+                # The console showed an unexpected fatal error: the test
+                # crashed. A crash typically also makes the run time out or
+                # the simulator exit with an error, so report the crash
+                # itself rather than those side effects.
+                self.instance.reason = FAULT_REASON
             elif failure_type == self.FailureType.TIMEOUT:
                 self.instance.reason = "Timeout"
             elif failure_type == self.FailureType.FLASH:
@@ -283,8 +290,12 @@ class BinaryHandler(Handler):
                     log_out_fp.write(strip_ansi_sequences(line_decoded))
                     log_out_fp.flush()
                     harness.handle(stripped_line)
+                    # A harness status means the run reached a verdict; a
+                    # fault means it crashed and no verdict is coming. In
+                    # both cases stop after a short grace period to catch
+                    # late output instead of waiting for the full timeout.
                     if (
-                        harness.status != TwisterStatus.NONE
+                        (harness.status != TwisterStatus.NONE or harness.fault)
                         and not timeout_extended
                         or harness.capture_coverage
                     ):
@@ -1125,7 +1136,10 @@ class QEMUHandler(QEMUHandlerBase):
 
                 if c == "":
                     # EOF, this shouldn't happen unless QEMU crashes
-                    if not ignore_unexpected_eof:
+                    # Don't overwrite an already-recorded failure (e.g. a
+                    # fault): that reason is more precise than the EOF that
+                    # follows it.
+                    if not ignore_unexpected_eof and _status != TwisterStatus.FAIL:
                         _status = TwisterStatus.FAIL
                         _reason = "unexpected eof"
                     break
@@ -1140,22 +1154,32 @@ class QEMUHandler(QEMUHandlerBase):
                 logger.debug(f"QEMU ({pid}): {line}")
 
                 harness.handle(line)
-                if harness.status != TwisterStatus.NONE:
+
+                if harness.fault and _status == TwisterStatus.NONE:
+                    # The console showed an unexpected fatal error: the test
+                    # crashed and usually halts right after, so no verdict is
+                    # coming. Record the crash as the failure now instead of
+                    # letting the run expire as a timeout.
+                    _status = TwisterStatus.FAIL
+                    _reason = FAULT_REASON
+
+                if harness.status != TwisterStatus.NONE and _status != TwisterStatus.FAIL:
                     # if we have registered a fail make sure the status is not
                     # overridden by a false success message coming from the
                     # testsuite
-                    if _status != TwisterStatus.FAIL:
-                        _status = harness.status
-                        _reason = harness.reason
+                    _status = harness.status
+                    _reason = harness.reason
 
-                    # if we get some status, that means test is doing well, we reset
-                    # the timeout and wait for 2 more seconds to catch anything
-                    # printed late. We wait much longer if code
-                    # coverage is enabled since dumping this information can
-                    # take some time.
-                    if not timeout_extended or harness.capture_coverage:
-                        timeout_extended = True
-                        timeout_time = QEMUHandler._extend_timeout_on_status(harness)
+                # once a verdict (or a crash) is known the test is done;
+                # reset the timeout and wait for 2 more seconds to catch
+                # anything printed late. We wait much longer if code
+                # coverage is enabled since dumping this information can
+                # take some time.
+                if _status != TwisterStatus.NONE and (
+                    not timeout_extended or harness.capture_coverage
+                ):
+                    timeout_extended = True
+                    timeout_time = QEMUHandler._extend_timeout_on_status(harness)
                 line = ""
 
             handler.execution_time = time.time() - start_time
@@ -1425,7 +1449,10 @@ class QEMUWinHandler(QEMUHandlerBase):
 
             if c == "":
                 # EOF, this shouldn't happen unless QEMU crashes
-                if not ignore_unexpected_eof:
+                # Don't overwrite an already-recorded failure (e.g. a
+                # fault): that reason is more precise than the EOF that
+                # follows it.
+                if not ignore_unexpected_eof and _status != TwisterStatus.FAIL:
                     _status = TwisterStatus.FAIL
                     _reason = "unexpected eof"
                 break
@@ -1440,22 +1467,32 @@ class QEMUWinHandler(QEMUHandlerBase):
             logger.debug(f"QEMU ({self.pid}): {line}")
 
             harness.handle(line)
-            if harness.status != TwisterStatus.NONE:
+
+            if harness.fault and _status == TwisterStatus.NONE:
+                # The console showed an unexpected fatal error: the test
+                # crashed and usually halts right after, so no verdict is
+                # coming. Record the crash as the failure now instead of
+                # letting the run expire as a timeout.
+                _status = TwisterStatus.FAIL
+                _reason = FAULT_REASON
+
+            if harness.status != TwisterStatus.NONE and _status != TwisterStatus.FAIL:
                 # if we have registered a fail make sure the status is not
                 # overridden by a false success message coming from the
                 # testsuite
-                if _status != TwisterStatus.FAIL:
-                    _status = harness.status
-                    _reason = harness.reason
+                _status = harness.status
+                _reason = harness.reason
 
-                # if we get some status, that means test is doing well, we reset
-                # the timeout and wait for 2 more seconds to catch anything
-                # printed late. We wait much longer if code
-                # coverage is enabled since dumping this information can
-                # take some time.
-                if not timeout_extended or harness.capture_coverage:
-                    timeout_extended = True
-                    timeout_time = self._extend_timeout_on_status(harness)
+            # once a verdict (or a crash) is known the test is done;
+            # reset the timeout and wait for 2 more seconds to catch
+            # anything printed late. We wait much longer if code
+            # coverage is enabled since dumping this information can
+            # take some time.
+            if _status != TwisterStatus.NONE and (
+                not timeout_extended or harness.capture_coverage
+            ):
+                timeout_extended = True
+                timeout_time = self._extend_timeout_on_status(harness)
             line = ""
 
         self.stop_thread = True

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -52,6 +52,11 @@ class Harness:
     GCOV_START = "GCOV_COVERAGE_DUMP_START"
     GCOV_END = "GCOV_COVERAGE_DUMP_END"
     FAULT = "ZEPHYR FATAL ERROR"
+    # Printed by Ztest's fatal-error/assert hooks
+    UNEXPECTED_FAULT_MARKERS = (
+        "fatal error was unexpected",
+        "assert failed was unexpected",
+    )
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
     run_id_pattern = r"RunID: (?P<run_id>[0-9A-Fa-f]+)"
@@ -185,9 +190,13 @@ class Harness:
             if run_id == str(self.run_id):
                 self.matched_run_id = True
 
-        # Faults are logged with a timestamp and module prefix, so the marker
-        # has to be matched as a substring rather than against the whole line.
-        if self.fail_on_fault and self.FAULT in line:
+        # Faults are logged with a timestamp and module prefix, so the markers
+        # have to be matched as substrings rather than against the whole line.
+        line_lower = line.lower()
+        unexpected_hook_fault = any(
+            marker in line_lower for marker in self.UNEXPECTED_FAULT_MARKERS
+        )
+        if (self.fail_on_fault and self.FAULT in line) or unexpected_hook_fault:
             self.fault = True
             # A fault can be reported after the test has already announced
             # success, for instance a stray interrupt taken once the test

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -22,7 +22,7 @@ from string import Template
 import junitparser.junitparser as junit
 import yaml
 from pytest import ExitCode
-from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
+from twisterlib.constants import FAULT_REASON, SUPPORTED_SIMS_IN_PYTEST
 from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
 from twisterlib.error import ConfigurationError, StatusAttributeError
 from twisterlib.handlers import DeviceHandler, Handler, terminate_process
@@ -195,12 +195,12 @@ class Harness:
             # that was recorded earlier in the output.
             if self.status == TwisterStatus.PASS:
                 self.status = TwisterStatus.FAIL
-                self.reason = "Fault detected while running test"
+                self.reason = FAULT_REASON
 
         if self.RUN_PASSED in line:
             if self.fault:
                 self.status = TwisterStatus.FAIL
-                self.reason = "Fault detected while running test"
+                self.reason = FAULT_REASON
             else:
                 self.status = TwisterStatus.PASS
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -284,7 +284,7 @@ def test_binaryhandler_try_kill_process_by_pid(mocked_instance):
 TESTDATA_3 = [
     (
         [b'This\\r\\n\n', b'is\r', b'some \x1B[31mANSI\x1B[39m in\n', b'a short\n', b'file.'],
-        mock.Mock(status=TwisterStatus.NONE, capture_coverage=False),
+        mock.Mock(status=TwisterStatus.NONE, capture_coverage=False, fault=False),
         [
             mock.call('This\\r\\n\n'),
             mock.call('is\r'),
@@ -304,7 +304,7 @@ TESTDATA_3 = [
     ),
     (
         [b'Too much.'] * 120,  # Should be more than the timeout
-        mock.Mock(status=TwisterStatus.PASS, capture_coverage=False),
+        mock.Mock(status=TwisterStatus.PASS, capture_coverage=False, fault=False),
         None,
         None,
         True,
@@ -312,7 +312,7 @@ TESTDATA_3 = [
     ),
     (
         [b'Too much.'] * 120,  # Should be more than the timeout
-        mock.Mock(status=TwisterStatus.PASS, capture_coverage=False),
+        mock.Mock(status=TwisterStatus.PASS, capture_coverage=False, fault=False),
         None,
         None,
         True,
@@ -320,7 +320,7 @@ TESTDATA_3 = [
     ),
     (
         [b'Too much.'] * 120,  # Should be more than the timeout
-        mock.Mock(status=TwisterStatus.PASS, capture_coverage=True),
+        mock.Mock(status=TwisterStatus.PASS, capture_coverage=True, fault=False),
         None,
         None,
         False,
@@ -495,22 +495,25 @@ def test_binaryhandler_create_env(
 
 
 TESTDATA_6 = [
-    (TwisterStatus.NONE, False, 2, True, TwisterStatus.FAIL, 'Valgrind error', False),
-    (TwisterStatus.NONE, False, 1, False, TwisterStatus.FAIL, 'Exited with 1', False),
-    (TwisterStatus.FAIL, False, 0, False, TwisterStatus.FAIL, "foobar", False),
-    ('success', False, 0, False, 'success', None, False),
-    (TwisterStatus.NONE, True, 1, True, TwisterStatus.FAIL, 'Exited with 1', True),
+    (TwisterStatus.NONE, False, False, 2, True, TwisterStatus.FAIL, 'Valgrind error', False),
+    (TwisterStatus.NONE, False, False, 1, False, TwisterStatus.FAIL, 'Exited with 1', False),
+    (TwisterStatus.NONE, True, False, 1, False, TwisterStatus.FAIL,
+     'Fault detected while running test', False),
+    (TwisterStatus.FAIL, False, False, 0, False, TwisterStatus.FAIL, "foobar", False),
+    ('success', False, False, 0, False, 'success', None, False),
+    (TwisterStatus.NONE, False, True, 1, True, TwisterStatus.FAIL, 'Exited with 1', True),
 ]
 
 @pytest.mark.parametrize(
-    'harness_status, terminated, returncode, enable_valgrind,' \
+    'harness_status, harness_fault, terminated, returncode, enable_valgrind,' \
     ' expected_status, expected_reason, do_add_missing',
     TESTDATA_6,
-    ids=['valgrind error', 'failed', 'harness failed', 'custom success', 'no status']
+    ids=['valgrind error', 'failed', 'crash', 'harness failed', 'custom success', 'no status']
 )
 def test_binaryhandler_update_instance_info(
     mocked_instance,
     harness_status,
+    harness_fault,
     terminated,
     returncode,
     enable_valgrind,
@@ -525,7 +528,7 @@ def test_binaryhandler_update_instance_info(
     handler.returncode = returncode
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
-    mocked_harness = mock.Mock(status=harness_status, reason="foobar")
+    mocked_harness = mock.Mock(status=harness_status, reason="foobar", fault=harness_fault)
 
     handler._update_instance_info(mocked_harness)
 
@@ -944,22 +947,26 @@ def test_devicehandler_create_command(
 
 
 TESTDATA_14 = [
-    ('success', Handler.FailureType.NONE, 'success', None, False),
-    (TwisterStatus.FAIL, Handler.FailureType.NONE, TwisterStatus.FAIL,
+    ('success', False, Handler.FailureType.NONE, 'success', None, False),
+    (TwisterStatus.FAIL, False, Handler.FailureType.NONE, TwisterStatus.FAIL,
         "foobar", True),
-    (TwisterStatus.ERROR, Handler.FailureType.NONE, TwisterStatus.ERROR, 'foobar', True),
-    (TwisterStatus.NONE, Handler.FailureType.NONE, TwisterStatus.FAIL, 'Unknown Error', True),
+    (TwisterStatus.ERROR, False, Handler.FailureType.NONE, TwisterStatus.ERROR, 'foobar', True),
+    (TwisterStatus.NONE, False, Handler.FailureType.NONE, TwisterStatus.FAIL,
+        'Unknown Error', True),
+    (TwisterStatus.NONE, True, Handler.FailureType.TIMEOUT, TwisterStatus.FAIL,
+        'Fault detected while running test', True),
 ]
 
 @pytest.mark.parametrize(
-    'harness_status, failure_type,' \
+    'harness_status, harness_fault, failure_type,' \
     ' expected_status, expected_reason, do_add_missing',
     TESTDATA_14,
-    ids=['custom success', 'failed', 'error', 'no status']
+    ids=['custom success', 'failed', 'error', 'no status', 'crash']
 )
 def test_devicehandler_update_instance_info(
         mocked_instance,
         harness_status,
+        harness_fault,
         failure_type,
         expected_status,
         expected_reason,
@@ -968,7 +975,7 @@ def test_devicehandler_update_instance_info(
     handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
-    mocked_harness = mock.Mock(status=harness_status, reason="foobar")
+    mocked_harness = mock.Mock(status=harness_status, reason="foobar", fault=harness_fault)
 
     handler._update_instance_info(mocked_harness, failure_type=failure_type)
 
@@ -1386,6 +1393,7 @@ TESTDATA_21 = [
         False,
         None,
         TwisterStatus.FAIL,
+        False,
         Handler.FailureType.NONE,
         TwisterStatus.FAIL,
         "foobar",
@@ -1396,6 +1404,7 @@ TESTDATA_21 = [
         True,
         None,
         TwisterStatus.FAIL,
+        False,
         Handler.FailureType.NONE,
         TwisterStatus.FAIL,
         "foobar",
@@ -1406,9 +1415,21 @@ TESTDATA_21 = [
         False,
         None,
         TwisterStatus.NONE,
+        False,
         Handler.FailureType.TIMEOUT,
         TwisterStatus.FAIL,
         'Timeout',
+        True
+    ),
+    (
+        0,
+        False,
+        None,
+        TwisterStatus.NONE,
+        True,
+        Handler.FailureType.TIMEOUT,
+        TwisterStatus.FAIL,
+        'Fault detected while running test',
         True
     ),
     (
@@ -1416,6 +1437,7 @@ TESTDATA_21 = [
         False,
         None,
         TwisterStatus.NONE,
+        False,
         Handler.FailureType.NONE,
         TwisterStatus.FAIL,
         'Exited with 1',
@@ -1426,6 +1448,7 @@ TESTDATA_21 = [
         False,
         'preexisting reason',
         'good dummy status',
+        False,
         Handler.FailureType.NONE,
         TwisterStatus.FAIL,
         'preexisting reason',
@@ -1435,10 +1458,10 @@ TESTDATA_21 = [
 
 @pytest.mark.parametrize(
     'self_returncode, self_ignore_qemu_crash,' \
-    ' self_instance_reason, harness_status, failure_type,' \
+    ' self_instance_reason, harness_status, harness_fault, failure_type,' \
     ' expected_status, expected_reason, expected_called_missing_case',
     TESTDATA_21,
-    ids=['not failed', 'qemu ignore', 'timeout', 'bad returncode', 'other fail']
+    ids=['not failed', 'qemu ignore', 'timeout', 'crash', 'bad returncode', 'other fail']
 )
 def test_qemuhandler_update_instance_info(
     mocked_instance,
@@ -1446,6 +1469,7 @@ def test_qemuhandler_update_instance_info(
     self_ignore_qemu_crash,
     self_instance_reason,
     harness_status,
+    harness_fault,
     failure_type,
     expected_status,
     expected_reason,
@@ -1453,7 +1477,7 @@ def test_qemuhandler_update_instance_info(
 ):
     mocked_instance.add_missing_case_status = mock.Mock()
     mocked_instance.reason = self_instance_reason
-    mocked_harness = mock.Mock(status=harness_status, reason="foobar")
+    mocked_harness = mock.Mock(status=harness_status, reason="foobar", fault=harness_fault)
 
     handler = QEMUHandler(mocked_instance, 'build', mock.Mock())
     handler.returncode = self_returncode
@@ -1518,6 +1542,7 @@ TESTDATA_25 = [
         [TwisterStatus.NONE] * 60 + [TwisterStatus.PASS] * 6,
         1000,
         False,
+        False,
         TwisterStatus.FAIL,
         'timeout',
         [mock.call('1\n'), mock.call('1\n')]
@@ -1528,6 +1553,7 @@ TESTDATA_25 = [
         -1,
         [TwisterStatus.NONE] * 60 + [TwisterStatus.PASS] * 30,
         100,
+        False,
         False,
         TwisterStatus.FAIL,
         None,
@@ -1540,6 +1566,7 @@ TESTDATA_25 = [
         [TwisterStatus.PASS] * 3,
         100,
         False,
+        False,
         TwisterStatus.FAIL,
         'unexpected eof',
         []
@@ -1551,6 +1578,7 @@ TESTDATA_25 = [
         [TwisterStatus.PASS] * 3,
         100,
         False,
+        False,
         TwisterStatus.FAIL,
         'unexpected byte',
         []
@@ -1561,6 +1589,7 @@ TESTDATA_25 = [
         1,
         [TwisterStatus.NONE] * 3 + [TwisterStatus.PASS] * 7,
         100,
+        False,
         False,
         TwisterStatus.PASS,
         None,
@@ -1573,6 +1602,7 @@ TESTDATA_25 = [
         [TwisterStatus.NONE] * 3 + [TwisterStatus.PASS] * 7,
         100,
         False,
+        False,
         TwisterStatus.FAIL,
         'timeout',
         [mock.call('1\n'), mock.call('2\n')]
@@ -1584,15 +1614,28 @@ TESTDATA_25 = [
         [TwisterStatus.NONE] * 3 + [TwisterStatus.PASS] * 7,
         (n for n in [100, 100, 10000]),
         True,
+        False,
         TwisterStatus.PASS,
         None,
         [mock.call('1\n'), mock.call('2\n'), mock.call('3\n'), mock.call('4\n')]
+    ),
+    (
+        '1\n2\n3\n4\n5\n'.encode('utf-8'),
+        60,
+        1,
+        [TwisterStatus.NONE] * 30,
+        100,
+        False,
+        True,
+        TwisterStatus.FAIL,
+        'Fault detected while running test',
+        [mock.call('1\n'), mock.call('2\n')]
     ),
 ]
 
 @pytest.mark.parametrize(
     'content, timeout, pid, harness_statuses, cputime, capture_coverage,' \
-    ' expected_status, expected_reason, expected_log_calls',
+    ' harness_fault, expected_status, expected_reason, expected_log_calls',
     TESTDATA_25,
     ids=[
         'timeout',
@@ -1601,7 +1644,8 @@ TESTDATA_25 = [
         'unexpected byte',
         'harness success',
         'timeout by pid=0',
-        'capture_coverage'
+        'capture_coverage',
+        'crash detected'
     ]
 )
 def test_qemuhandler_thread(
@@ -1613,6 +1657,7 @@ def test_qemuhandler_thread(
     harness_statuses,
     cputime,
     capture_coverage,
+    harness_fault,
     expected_status,
     expected_reason,
     expected_log_calls
@@ -1646,7 +1691,7 @@ def test_qemuhandler_thread(
 
         return file_object
 
-    harness = mock.Mock(capture_coverage=capture_coverage, handle=print)
+    harness = mock.Mock(capture_coverage=capture_coverage, handle=print, fault=harness_fault)
     type(harness).status = mock.PropertyMock(side_effect=harness_statuses)
 
     p = mock.Mock()
@@ -1687,7 +1732,7 @@ def test_qemuhandler_thread(
     mock_thread_update_instance_info.assert_called_once_with(
         handler,
         expected_status,
-        mock.ANY
+        expected_reason if expected_reason is not None else mock.ANY
     )
 
     file_objs[handler.log].write.assert_has_calls(expected_log_calls)
@@ -1746,7 +1791,7 @@ def test_qemuhandler_handle(
         handler.pid_fn = os.path.join(sysbuild_build_dir, 'qemu.pid')
         handler.log_fn = os.path.join('dummy', 'log')
 
-    harness = mock.Mock(status=harness_status)
+    harness = mock.Mock(status=harness_status, fault=False)
     handler_options_west_flash = []
 
     domain_build_dir = os.path.join('sysbuild', 'dummydir')

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -328,6 +328,41 @@ def test_harness_process_test_fault_after_run_passed_ignored():
     assert harness.status == TwisterStatus.PASS
 
 
+@pytest.mark.parametrize(
+    'line',
+    [
+        'Fatal error was unexpected, aborting...',
+        'fatal error was unexpected, aborting',
+        'Assert failed was unexpected, aborting...',
+    ],
+    ids=['ztest fatal hook', 'custom lowercase hook', 'ztest assert hook']
+)
+def test_harness_process_test_unexpected_hook_fault_overrides_ignore_faults(line):
+    """The Ztest error/assert hooks (and equivalent custom hooks) announce a
+    fault the test did not expect. That is a crash even for ignore_faults
+    tests, where the generic fatal-error banner is not acted upon."""
+    harness = Harness()
+    harness.status = TwisterStatus.NONE
+    harness.fail_on_fault = False
+
+    harness.process_test(line)
+
+    assert harness.fault
+
+
+def test_harness_process_test_expected_hook_fault_not_a_crash():
+    """The hooks' expected-fault messages must not trip crash detection."""
+    harness = Harness()
+    harness.status = TwisterStatus.NONE
+    harness.fail_on_fault = False
+
+    harness.process_test('Caught system error -- reason 3 1')
+    harness.process_test('Fatal error expected as part of test case.')
+    harness.process_test('Assert error expected as part of test case.')
+
+    assert not harness.fault
+
+
 def test_robot_configure(tmp_path):
     # Arrange
     mock_platform = mock.Mock()


### PR DESCRIPTION
When a test crashes with an unexpected fatal error the target halts
and never prints a verdict, so the QEMU monitor kept reading until
the full per-test timeout expired and the run was reported as
"Timeout". The timeout was a twister artifact, not the failure: the
console already contained the ">>> ZEPHYR FATAL ERROR" banner. Other
simulators exit on such a crash and got reported differently again
(e.g. "failed (rc=2)" on mps4 FVP), so the same crash produced
inconsistent results across platforms.

The harness already tracks unexpected fatal errors in harness.fault
(tests that fault on purpose opt out with ignore_faults), and any run
with a recorded fault is already doomed to fail once a verdict
arrives. Use that flag in the handlers:

- The QEMU monitor loops (POSIX and Windows) record the failure as
  "Fault detected while running test" as soon as the fault banner is
  seen and switch to the short post-status grace period, capturing
  the rest of the crash dump instead of waiting out the timeout. A
  subsequent EOF no longer overwrites the recorded fault reason with
  "unexpected eof".
- BinaryHandler's output loop stops after the same grace period once
  a fault is seen, covering simulators such as Arm FVP.
- Handler._update_instance_info() prefers the fault over the derived
  "Timeout" or "Exited with <rc>" reasons, so every handler
  (including device testing) reports such a crash the same way.

The reason string is shared as FAULT_REASON in constants.py so the
harness and the handlers cannot drift apart.


Before:
```
INFO    - Added initial list of jobs to queue
INFO    - 1/1 qemu_x86/atom             testing.ztest.error_hook                           FAILED unexpected eof (qemu 0.168s <zephyr/gnu>)
ERROR   - see: /home/nashif/zephyrproject/zephyr/twister-out/qemu_x86_atom/zephyr_gnu/tests/ztest/error_hook/testing.ztest.error_hook/handler.log

```

After:

```
INFO    - 12/39 qemu_or1k/qemu_or1k       testing.ztest.error_hook                           FILTERED (runtime filter)
INFO    - 13/39 qemu_x86/atom/nopae       testing.ztest.error_hook                           FAILED Fault detected while running test (qemu 1.655s <zephyr/gnu>)
ERROR   - see: /home/nashif/zephyrproject/zephyr/twister-out/qemu_x86_atom_nopae/zephyr_gnu/tests/ztest/error_hook/testing.ztest.error_hook/handler.log
INFO    - 14/39 qemu_riscv64/qemu_virt_riscv64/smp testing.ztest.error_hook                  FAILED Fault detected while running test (qemu 1.236s <zephyr/gnu>)
ERROR   - see: /home/nashif/zephyrproject/zephyr/twister-out/qemu_riscv64_qemu_virt_riscv64_smp/zephyr_gnu/tests/ztest/error_hook/testing.ztest.error_hook/handler.log
INFO    - 15/39 qemu_xtensa/dc233c/mmu    testing.ztest.error_hook                           FAILED Fault detected while running test (qemu 0.244s <zephyr/gnu>)
ERROR   - see: /home/nashif/zephyrproject/zephyr/twister-out/qemu_xtensa_dc233c_mmu/zephyr_gnu/tests/ztest/error_hook/testing.ztest.error_hook/handler.log

```
