### PR TITLE
dts: nxp: restructure SoC pinctrl into family/series layout

### DIFF
--- a/boards/96boards/meerkat96/96b_meerkat96-pinctrl.dtsi
+++ b/boards/96boards/meerkat96/96b_meerkat96-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx7d-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx7d-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/element14/warp7/warp7-pinctrl.dtsi
+++ b/boards/element14/warp7/warp7-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <nxp/imx/nxp_imx7d_m4.dtsi>
-#include <nxp/nxp_imx/mimx7d-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx7d-pinctrl.dtsi>
 
 &pinctrl {
 	uart2_default: uart2_default {

--- a/boards/madmachine/mm_feather/mm_feather-pinctrl.dtsi
+++ b/boards/madmachine/mm_feather/mm_feather-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mm_feather.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1062dvl6a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1062dvl6a-pinctrl.dtsi>
 
 &pinctrl {
 	pinmux_lpi2c1: pinmux_lpi2c1 {

--- a/boards/madmachine/mm_swiftio/mm_swiftio-pinctrl.dtsi
+++ b/boards/madmachine/mm_swiftio/mm_swiftio-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mm_swiftio.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1052dvl6b-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1052dvl6b-pinctrl.dtsi>
 
 &pinctrl {
 	pinmux_csi: pinmux_csi {

--- a/boards/mikroe/hexiwear/hexiwear_mk64f12-pinctrl.dtsi
+++ b/boards/mikroe/hexiwear/hexiwear_mk64f12-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MK64FN1M0VDC12-pinctrl.h>
+#include <nxp/kinetis/k6x/pinctrl/MK64FN1M0VDC12-pinctrl.h>
 
 &pinctrl {
 	ftm3_default: ftm3_default {

--- a/boards/mikroe/hexiwear/hexiwear_mkw40z4-pinctrl.dtsi
+++ b/boards/mikroe/hexiwear/hexiwear_mkw40z4-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKW40Z160VHT4-pinctrl.h>
+#include <nxp/kinetis/kwx/pinctrl/MKW40Z160VHT4-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_imx91/frdm_imx91-pinctrl.dtsi
+++ b/boards/nxp/frdm_imx91/frdm_imx91-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx9131cvvxj-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9131cvvxj-pinctrl.dtsi>
 
 &pinctrl {
 	sai3_default: sai3_default {

--- a/boards/nxp/frdm_imx93/frdm_imx93-pinctrl.dtsi
+++ b/boards/nxp/frdm_imx93/frdm_imx93-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx9352cvuxk-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9352cvuxk-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/nxp/frdm_imxrt1152/frdm_imxrt1152-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt1152/frdm_imxrt1152-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1152xhm8b-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt11xx/pinctrl/mimxrt1152xhm8b-pinctrl.dtsi>
 
 &pinctrl {
 	pinmux_lpuart1: pinmux_lpuart1 {

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1186cvj8c-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt118x/pinctrl/mimxrt1186cvj8c-pinctrl.dtsi>
 
 &pinctrl {
 	pinmux_lpspi2: pinmux_lpspi2 {

--- a/boards/nxp/frdm_imxrt700/frdm_imxrt700-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt700/frdm_imxrt700-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/MIMXRT798SGFOB-pinctrl.h>
+#include <nxp/imxrt/imxrt7xx/pinctrl/MIMXRT798SGFOB-pinctrl.h>
 
 &pinctrl {
 	/* CPU0 debug console (MCU-Link), FLEXCOMM0 LPUART - same pins as MIMXRT700-EVK */

--- a/boards/nxp/frdm_k22f/frdm_k22f-pinctrl.dtsi
+++ b/boards/nxp/frdm_k22f/frdm_k22f-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MK22FN512VLH12-pinctrl.h>
+#include <nxp/kinetis/k2x/pinctrl/MK22FN512VLH12-pinctrl.h>
 
 &pinctrl {
 	ftm0_default: ftm0_default {

--- a/boards/nxp/frdm_k32l2b3/frdm_k32l2b3-pinctrl.dtsi
+++ b/boards/nxp/frdm_k32l2b3/frdm_k32l2b3-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/K32L2B31VLH0A-pinctrl.h>
+#include <nxp/kinetis/k32lx/pinctrl/K32L2B31VLH0A-pinctrl.h>
 
 &pinctrl {
 	lpuart0_default: lpuart0_default {

--- a/boards/nxp/frdm_k64f/frdm_k64f-pinctrl.dtsi
+++ b/boards/nxp/frdm_k64f/frdm_k64f-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MK64FN1M0VLL12-pinctrl.h>
+#include <nxp/kinetis/k6x/pinctrl/MK64FN1M0VLL12-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_k82f/frdm_k82f-pinctrl.dtsi
+++ b/boards/nxp/frdm_k82f/frdm_k82f-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MK82FN256VLL15-pinctrl.h>
+#include <nxp/kinetis/k8x/pinctrl/MK82FN256VLL15-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE15Z256VLL7-pinctrl.h>
+#include <nxp/kinetis/ke1xz/pinctrl/MKE15Z256VLL7-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_ke16z/frdm_ke16z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke16z/frdm_ke16z-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE16Z64VLF4-pinctrl.h>
+#include <nxp/kinetis/ke1xz/pinctrl/MKE16Z64VLF4-pinctrl.h>
 
 &pinctrl {
 	lpuart0_default: lpuart0_default {

--- a/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE17Z256VLL7-pinctrl.h>
+#include <nxp/kinetis/ke1xz/pinctrl/MKE17Z256VLL7-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE17Z512VLL9-pinctrl.h>
+#include <nxp/kinetis/ke1xz/pinctrl/MKE17Z512VLL9-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_kl25z/frdm_kl25z-pinctrl.dtsi
+++ b/boards/nxp/frdm_kl25z/frdm_kl25z-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKL25Z128VLK4-pinctrl.h>
+#include <nxp/kinetis/kl2x/pinctrl/MKL25Z128VLK4-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_kw41z/frdm_kw41z-pinctrl.dtsi
+++ b/boards/nxp/frdm_kw41z/frdm_kw41z-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKW41Z512VHT4-pinctrl.h>
+#include <nxp/kinetis/kwx/pinctrl/MKW41Z512VHT4-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXA153VLH-pinctrl.h>
+#include <nxp/mcx/mcxa/pinctrl/MCXA153VLH-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexpwm0_pwm0: pinmux_flexpwm0_pwm0 {

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXA156VLL-pinctrl.h>
+#include <nxp/mcx/mcxa/pinctrl/MCXA156VLL-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXA344VLL-pinctrl.h>
+#include <nxp/mcx/mcxa/pinctrl/MCXA344VLL-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcan0: pinmux_flexcan0 {

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXA577VPN-pinctrl.h>
+#include <nxp/mcx/mcxa/pinctrl/MCXA577VPN-pinctrl.h>
 
 /* P2_30 and P2_31 exist on the MCXA577VPN 169-ball BGA (balls L7 and L8)
  * but are not yet present in the upstream hal/nxp pinctrl header.

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXA266VLQ-pinctrl.h>
+#include <nxp/mcx/mcxa/pinctrl/MCXA266VLQ-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart2: pinmux_lpuart2 {

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa346-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa346-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXA346VLQ-pinctrl.h>
+#include <nxp/mcx/mcxa/pinctrl/MCXA346VLQ-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart2: pinmux_lpuart2 {

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXA366VLQ-pinctrl.h>
+#include <nxp/mcx/mcxa/pinctrl/MCXA366VLQ-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart2: pinmux_lpuart2 {

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXC242VLH-pinctrl.h>
+#include <nxp/mcx/mcxc/pinctrl/MCXC242VLH-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXC444VLH-pinctrl.h>
+#include <nxp/mcx/mcxc/pinctrl/MCXC444VLH-pinctrl.h>
 
 &pinctrl {
 	pinmux_adc0: pinmux_adc0 {

--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXE247VLQ-pinctrl.h>
+#include <nxp/mcx/mcxe/pinctrl/MCXE247VLQ-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart1: pinmux_lpuart1 {

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXE31BMPB-pinctrl.h>
+#include <nxp/mcx/mcxe/pinctrl/MCXE31BMPB-pinctrl.h>
 
 &pinctrl {
 	eirq0_default: eirq0_default {

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXL255VDF-pinctrl.h>
+#include <nxp/mcx/mcxl/pinctrl/MCXL255VDF-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXN236VDF-pinctrl.h>
+#include <nxp/mcx/mcxn/pinctrl/MCXN236VDF-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_lpuart: pinmux_flexcomm0_lpuart {

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXN947VDF-pinctrl.h>
+#include <nxp/mcx/mcxn/pinctrl/MCXN947VDF-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm1_lpspi: pinmux_flexcomm1_lpspi {

--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXW236BIHNAR-pinctrl.h>
+#include <nxp/mcx/mcxw/pinctrl/MCXW236BIHNAR-pinctrl.h>
 
 &pinctrl {
 	/* Configures pin routing and optionally pin electrical features. */

--- a/boards/nxp/frdm_mcxw70/frdm_mcxw70-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxw70/frdm_mcxw70-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXW70ACMFT-pinctrl.h>
+#include <nxp/mcx/mcxw/pinctrl/MCXW70ACMFT-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXW716CMFTA-pinctrl.h>
+#include <nxp/mcx/mcxw/pinctrl/MCXW716CMFTA-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXW727CMFTA-pinctrl.h>
+#include <nxp/mcx/mcxw/pinctrl/MCXW727CMFTA-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/rw/RW612-pinctrl.h>
+#include <nxp/rw/pinctrl/RW612-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm3_usart: pinmux_flexcomm3_usart {

--- a/boards/nxp/imx8mm_evk/imx8mm_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx8mm6dvtlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8mm6dvtlz-pinctrl.dtsi>
 
 &pinctrl {
 	uart2_default: uart2_default {

--- a/boards/nxp/imx8mn_evk/imx8mn_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx8mn6dvtjz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8mn6dvtjz-pinctrl.dtsi>
 
 &pinctrl {
 	uart2_default: uart2_default {

--- a/boards/nxp/imx8mp_evk/imx8mp_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
 
 &pinctrl {
 	flexcan1_default: flexcan1_default {

--- a/boards/nxp/imx8mq_evk/imx8mq_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mq_evk/imx8mq_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from fsl-imx8mq-evk.mex
  */
 
-#include <nxp/nxp_imx/mimx8mq6dvajz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8mq6dvajz-pinctrl.dtsi>
 
 &pinctrl {
 	uart2_default: uart2_default {

--- a/boards/nxp/imx91_evk/imx91_evk-pinctrl.dtsi
+++ b/boards/nxp/imx91_evk/imx91_evk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx9131cvvxj-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9131cvvxj-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/nxp/imx91_qsb/imx91_qsb-pinctrl.dtsi
+++ b/boards/nxp/imx91_qsb/imx91_qsb-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx9111cvxxj-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9111cvxxj-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
+++ b/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx9352cvuxk-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9352cvuxk-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
+++ b/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx94398avkm-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx94398avkm-pinctrl.dtsi>
 
 &pinctrl {
 	emdio_default: emdio_default {

--- a/boards/nxp/imx952_evk/imx952_evk-pinctrl.dtsi
+++ b/boards/nxp/imx952_evk/imx952_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx95294avzm-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx95294avzm-pinctrl.dtsi>
 
 &pinctrl {
 	emdio_default: emdio_default {

--- a/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx9596avzxn-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9596avzxn-pinctrl.dtsi>
 
 &pinctrl {
 	emdio_default: emdio_default {

--- a/boards/nxp/imx95_evk_15x15/imx95_evk_15x15-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk_15x15/imx95_evk_15x15-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx9596cvtxn-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9596cvtxn-pinctrl.dtsi>
 #include "../imx95_evk/imx95_evk-pinctrl.dtsi"
 
 &pinctrl {

--- a/boards/nxp/lpcxpresso51u68/lpcxpresso51u68-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso51u68/lpcxpresso51u68-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * from LPCXpresso51U68.mex
  */
 
-#include <nxp/lpc/LPC51U68JBD64-pinctrl.h>
+#include <nxp/lpc/lpc51u68/pinctrl/LPC51U68JBD64-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_uart: pinmux_flexcomm0_uart {

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/lpc/LPC54114J256BD64-pinctrl.h>
+#include <nxp/lpc/lpc54xxx/pinctrl/LPC54114J256BD64-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {

--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/lpc/LPC54628J512ET180-pinctrl.h>
+#include <nxp/lpc/lpc54xxx/pinctrl/LPC54628J512ET180-pinctrl.h>
 
 /*
  * LPC546xx erratum SDIO.1 requires the four unused upper SD data functions

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/lpc/LPC55S06JBD64-pinctrl.h>
+#include <nxp/lpc/lpc55xxx/pinctrl/LPC55S06JBD64-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/lpc/LPC55S16JBD100-pinctrl.h>
+#include <nxp/lpc/lpc55xxx/pinctrl/LPC55S16JBD100-pinctrl.h>
 
 &pinctrl {
 	pinmux_can0: pinmux_can0 {

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/lpc/LPC55S28JBD100-pinctrl.h>
+#include <nxp/lpc/lpc55xxx/pinctrl/LPC55S28JBD100-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/lpc/LPC55S36JBD100-pinctrl.h>
+#include <nxp/lpc/lpc55xxx/pinctrl/LPC55S36JBD100-pinctrl.h>
 
 &pinctrl {
 	/* Configures pin routing and optionally pin electrical features. */

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/lpc/LPC55S69JBD100-pinctrl.h>
+#include <nxp/lpc/lpc55xxx/pinctrl/LPC55S69JBD100-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {

--- a/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk-pinctrl.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk-pinctrl.dtsi
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXN547VDF-pinctrl.h>
+#include <nxp/mcx/mcxn/pinctrl/MCXN547VDF-pinctrl.h>
 #include "mcx_nx4x_evk-pinctrl.dtsi"

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk-pinctrl.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXN947VDF-pinctrl.h>
+#include <nxp/mcx/mcxn/pinctrl/MCXN947VDF-pinctrl.h>
 #include "mcx_nx4x_evk-pinctrl.dtsi"
 
 &pinctrl {

--- a/boards/nxp/mcxw23_evk/mcxw23_evk-pinctrl.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXW236BIHNAR-pinctrl.h>
+#include <nxp/mcx/mcxw/pinctrl/MCXW236BIHNAR-pinctrl.h>
 
 &pinctrl {
 	/* Configures pin routing and optionally pin electrical features. */

--- a/boards/nxp/mcxw72_evk/mcxw72_evk-pinctrl.dtsi
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXW727CMFTA-pinctrl.h>
+#include <nxp/mcx/mcxw/pinctrl/MCXW727CMFTA-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1010_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1011dae5a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1011dae5a-pinctrl.dtsi>
 
 &pinctrl {
 	/* ADC Channels 1 and 2, exposed as pins 10 and 12 on J26 of EVK */

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1015_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1015daf5a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1015daf5a-pinctrl.dtsi>
 
 &pinctrl {
 	/* adc1 inputs 1 and 13 */

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1020_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1021dag5a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1021dag5a-pinctrl.dtsi>
 
 &pinctrl {
 	/* ADC1 inputs 10 and 11 */

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1024_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1024dag5a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1024dag5a-pinctrl.dtsi>
 
 &pinctrl {
 	/* ADC1 inputs 10 and 11 */

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1040_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1042xjm5b-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1042xjm5b-pinctrl.dtsi>
 
 &pinctrl {
 	/* Route ADC1 IN3 and IN4 to J33 pins 1 and 2 */

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1050_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1052dvl6b-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1052dvl6b-pinctrl.dtsi>
 
 &pinctrl {
 	/* ADC1 inputs 0 and 15 */

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1060_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1062dvl6a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1062dvl6a-pinctrl.dtsi>
 
 &pinctrl {
 	/* ADC1 inputs 0 and 15 */

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1062dvl6a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1062dvl6a-pinctrl.dtsi>
 
 /* Flash RESET pin is DNP here unlike RT1050 */
 

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1064_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1064dvl6a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1064dvl6a-pinctrl.dtsi>
 
 &pinctrl {
 	/* ADC1 inputs 0 and 15 */

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1160_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1166dvm6a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt11xx/pinctrl/mimxrt1166dvm6a-pinctrl.dtsi>
 
 &pinctrl {
 	/* conflicts with fxos8700 sensor */

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from mimxrt1170_evk.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1176dvmaa-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt11xx/pinctrl/mimxrt1176dvmaa-pinctrl.dtsi>
 
 &pinctrl {
 	/* conflicts with fxos8700 sensor */

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  *
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1189cvm8c-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt118x/pinctrl/mimxrt1189cvm8c-pinctrl.dtsi>
 
 &pinctrl {
 	emdio_default: emdio_default {

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33-pinctrl.dtsi
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/MIMXRT595SFFOC-pinctrl.h>
+#include <nxp/imxrt/imxrt5xx/pinctrl/MIMXRT595SFFOC-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {

--- a/boards/nxp/mimxrt685_aud_evk/mimxrt685_aud_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt685_aud_evk/mimxrt685_aud_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/MIMXRT685SFVKB-pinctrl.h>
+#include <nxp/imxrt/imxrt6xx/pinctrl/MIMXRT685SFVKB-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/MIMXRT685SFVKB-pinctrl.h>
+#include <nxp/imxrt/imxrt6xx/pinctrl/MIMXRT685SFVKB-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_usart: pinmux_flexcomm0_usart {

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/MIMXRT798SGFOB-pinctrl.h>
+#include <nxp/imxrt/imxrt7xx/pinctrl/MIMXRT798SGFOB-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_lpuart: pinmux_flexcomm0_lpuart {

--- a/boards/nxp/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32K344_K324_K314_172HDQFP-pinctrl.h>
+#include <nxp/s32/pinctrl/S32K344_K324_K314_172HDQFP-pinctrl.h>
 
 &pinctrl {
 	eirq0_default: eirq0_default {

--- a/boards/nxp/mr_navq95b/mr_navq95b-pinctrl.dtsi
+++ b/boards/nxp/mr_navq95b/mr_navq95b-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx9596avzxn-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9596avzxn-pinctrl.dtsi>
 
 &pinctrl {
 	flexspi_default: flexspi_default {

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga-pinctrl.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/rw/RW612-pinctrl.h>
+#include <nxp/rw/pinctrl/RW612-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm3_usart: pinmux_flexcomm3_usart {

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66-pinctrl.dtsi
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MK66FN2M0VMD18-pinctrl.h>
+#include <nxp/kinetis/k6x/pinctrl/MK66FN2M0VMD18-pinctrl.h>
 
 &pinctrl {
 	mdio_default: mdio_default {

--- a/boards/nxp/s32k148_evb/s32k148_evb-pinctrl.dtsi
+++ b/boards/nxp/s32k148_evb/s32k148_evb-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32K148_LQFP176-pinctrl.h>
+#include <nxp/s32/pinctrl/S32K148_LQFP176-pinctrl.h>
 
 &pinctrl {
 	lpuart0_default: lpuart0_default {

--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566-pinctrl.dtsi
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32K56X-437BGA-pinctrl.h>
+#include <nxp/s32/pinctrl/S32K56X-437BGA-pinctrl.h>
 
 &pinctrl {
 	eirq1_default: eirq1_default {

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+#include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nxp/twr_ke18f/twr_ke18f-pinctrl.dtsi
+++ b/boards/nxp/twr_ke18f/twr_ke18f-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE18F512VLL16-pinctrl.h>
+#include <nxp/kinetis/ke1xf/pinctrl/MKE18F512VLL16-pinctrl.h>
 
 &pinctrl {
 	adc0_default: adc0_default {

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m-pinctrl.dtsi
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKV58F1M0VLQ24-pinctrl.h>
+#include <nxp/kinetis/kv5x/pinctrl/MKV58F1M0VLQ24-pinctrl.h>
 
 &pinctrl {
 	i2c1_default: i2c1_default {

--- a/boards/nxp/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32K146_LQFP64-pinctrl.h>
+#include <nxp/s32/pinctrl/S32K146_LQFP64-pinctrl.h>
 
 &pinctrl {
 	lpuart0_default: lpuart0_default {

--- a/boards/nxp/usb_kw24d512/usb_kw24d512-pinctrl.dtsi
+++ b/boards/nxp/usb_kw24d512/usb_kw24d512-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKW24D512VHA5-pinctrl.h>
+#include <nxp/kinetis/kwx/pinctrl/MKW24D512VHA5-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * from vmu_rt1170.mex, then updated manually
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1176dvmaa-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt11xx/pinctrl/mimxrt1176dvmaa-pinctrl.dtsi>
 
 &pinctrl {
 	pinmux_enet1g: pinmux_enet1g {

--- a/boards/phytec/phyboard_nash/phyboard_nash-pinctrl.dtsi
+++ b/boards/phytec/phyboard_nash/phyboard_nash-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx9352cvuxk-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9352cvuxk-pinctrl.dtsi>
 
 &pinctrl {
 	uart2_default: uart2_default {

--- a/boards/phytec/phyboard_polis/phyboard_polis-pinctrl.dtsi
+++ b/boards/phytec/phyboard_polis/phyboard_polis-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx8mm6dvtlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8mm6dvtlz-pinctrl.dtsi>
 
 &pinctrl {
 	uart4_default: uart4_default {

--- a/boards/phytec/phyboard_pollux/phyboard_pollux-pinctrl.dtsi
+++ b/boards/phytec/phyboard_pollux/phyboard_pollux-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/pjrc/teensy4/teensy4-pinctrl.dtsi
+++ b/boards/pjrc/teensy4/teensy4-pinctrl.dtsi
@@ -7,7 +7,7 @@
  * from teensy4.mex
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1062dvl6a-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt10xx/pinctrl/mimxrt1062dvl6a-pinctrl.dtsi>
 
 &pinctrl {
 	/* Mode Straps configuration DP83825 */

--- a/boards/segger/ip_k66f/ip_k66f-pinctrl.dtsi
+++ b/boards/segger/ip_k66f/ip_k66f-pinctrl.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MK66FN2M0VMD18-pinctrl.h>
+#include <nxp/kinetis/k6x/pinctrl/MK66FN2M0VMD18-pinctrl.h>
 
 &pinctrl {
 	enet_default: enet_default {

--- a/boards/shields/lcd_par_s035/boards/frdm_mcxe31b.overlay
+++ b/boards/shields/lcd_par_s035/boards/frdm_mcxe31b.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXE31BMPB-pinctrl.h>
+#include <nxp/mcx/mcxe/pinctrl/MCXE31BMPB-pinctrl.h>
 
 &pinctrl {
 	eirq0_default {

--- a/boards/shields/nxp_m2_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXN947VDF-pinctrl.h>
+#include <nxp/mcx/mcxn/pinctrl/MCXN947VDF-pinctrl.h>
 
 / {
 	chosen {

--- a/boards/shields/nxp_s32k5xx_mb/nxp_s32k5xx_mb_pinctrl.dtsi
+++ b/boards/shields/nxp_s32k5xx_mb/nxp_s32k5xx_mb_pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32K56X-437BGA-pinctrl.h>
+#include <nxp/s32/pinctrl/S32K56X-437BGA-pinctrl.h>
 
 &pinctrl {
 	lpuart3_default: lpuart3_default {

--- a/boards/technexion/pico_pi/pico_pi-pinctrl.dtsi
+++ b/boards/technexion/pico_pi/pico_pi-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <nxp/imx/nxp_imx7d_m4.dtsi>
-#include <nxp/nxp_imx/mimx7d-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx7d-pinctrl.dtsi>
 
 &pinctrl {
 	uart2_default: uart2_default {

--- a/boards/toradex/colibri_imx7d/colibri_imx7d-pinctrl.dtsi
+++ b/boards/toradex/colibri_imx7d/colibri_imx7d-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx7d-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx7d-pinctrl.dtsi>
 
 &pinctrl {
 	uart2_default: uart2_default {

--- a/boards/toradex/verdin_imx8mm/verdin_imx8mm-pinctrl.dtsi
+++ b/boards/toradex/verdin_imx8mm/verdin_imx8mm-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx8mm6dvtlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8mm6dvtlz-pinctrl.dtsi>
 
 &pinctrl {
 	uart4_default: uart4_default {

--- a/boards/toradex/verdin_imx8mp/verdin_imx8mp-pinctrl.dtsi
+++ b/boards/toradex/verdin_imx8mp/verdin_imx8mp-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/u-blox/ubx_evk_iris_w1/ubx_evk_iris_w1_rw612-pinctrl.dtsi
+++ b/boards/u-blox/ubx_evk_iris_w1/ubx_evk_iris_w1_rw612-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/rw/RW612-pinctrl.h>
+#include <nxp/rw/pinctrl/RW612-pinctrl.h>
 
 &pinctrl {
 	// default-UART

--- a/boards/u-blox/ubx_evkninab5/ubx_evkninab5_mcxw716c-pinctrl.dtsi
+++ b/boards/u-blox/ubx_evkninab5/ubx_evkninab5_mcxw716c-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXW716CMFTA-pinctrl.h>
+#include <nxp/mcx/mcxw/pinctrl/MCXW716CMFTA-pinctrl.h>
 
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {

--- a/boards/udoo/udoo_neo_full/udoo_neo_full-pinctrl.dtsi
+++ b/boards/udoo/udoo_neo_full/udoo_neo_full-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx6sx-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx6sx-pinctrl.dtsi>
 
 &pinctrl {
 	uart5_default: uart5_default {

--- a/boards/variscite/imx8mp_var_dart/imx8mp_var_dart-pinctrl.dtsi
+++ b/boards/variscite/imx8mp_var_dart/imx8mp_var_dart-pinctrl.dtsi
@@ -5,7 +5,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/variscite/imx8mp_var_som/imx8mp_var_som-pinctrl.dtsi
+++ b/boards/variscite/imx8mp_var_som/imx8mp_var_som-pinctrl.dtsi
@@ -5,7 +5,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/variscite/imx93_var_dart/imx93_var_dart-pinctrl.dtsi
+++ b/boards/variscite/imx93_var_dart/imx93_var_dart-pinctrl.dtsi
@@ -5,7 +5,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx9352cvuxk-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9352cvuxk-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/variscite/imx93_var_som/imx93_var_som-pinctrl.dtsi
+++ b/boards/variscite/imx93_var_som/imx93_var_som-pinctrl.dtsi
@@ -5,7 +5,7 @@
  *
  */
 
-#include <nxp/nxp_imx/mimx9352cvuxk-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx9352cvuxk-pinctrl.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -906,6 +906,34 @@ NXP
     /* After */
     #include <nxp/imxrt/imxrt118x/nxp_rt1186_cm7.dtsi>
 
+* The NXP SoC pin control headers under the ``hal_nxp`` ``dts/nxp/`` tree were
+  reorganized to mirror the ``dts/arm/nxp/<family>/<series>/`` layout: every
+  SoC ``*-pinctrl.h`` / ``*-pinctrl.dtsi`` file moved into a ``pinctrl/``
+  subdirectory. Out-of-tree boards that include these SoC pin control headers
+  directly must update their includes.
+
+  The families that are series-organized (i.MX RT, Kinetis, LPC, MCX) place
+  their headers in ``<family>/<series>/pinctrl/``; the families that are flat
+  (i.MX, S32, RW) place theirs in a family-level ``<family>/pinctrl/``
+  directory. Kinetis additionally adds new series directories (``k0x``,
+  ``km3x``, ``kv3x``) for parts that had none. In addition the former
+  ``nxp_imx`` directory was split: ``nxp_imx/rt/`` became the ``imxrt/`` family
+  and the remaining i.MX application processors became the flat ``imx/`` family.
+
+  Examples:
+
+  .. code-block:: dts
+
+    /* Before */
+    #include <nxp/nxp_imx/rt/mimxrt1151dvm8b-pinctrl.dtsi>
+    #include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+    #include <nxp/kinetis/MK64FN1M0VLL12-pinctrl.h>
+
+    /* After */
+    #include <nxp/imxrt/imxrt11xx/pinctrl/mimxrt1151dvm8b-pinctrl.dtsi>
+    #include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
+    #include <nxp/kinetis/k6x/pinctrl/MK64FN1M0VLL12-pinctrl.h>
+
 PWM
 ===
 

--- a/dts/arm/nxp/kinetis/kwx/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/kinetis/kwx/nxp_kw2xd.dtsi
@@ -14,7 +14,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 /* Include package pinmux file for the spi modem settings */
-#include <nxp/kinetis/MKW24D512VHA5-pinctrl.h>
+#include <nxp/kinetis/kwx/pinctrl/MKW24D512VHA5-pinctrl.h>
 
 / {
 	aliases {

--- a/dts/arm/phytec/phycore_rt1170-pinctrl.dtsi
+++ b/dts/arm/phytec/phycore_rt1170-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/mimxrt1176dvmaa-pinctrl.dtsi>
+#include <nxp/imxrt/imxrt11xx/pinctrl/mimxrt1176dvmaa-pinctrl.dtsi>
 
 &pinctrl {
 	pinmux_enet1g: pinmux_enet1g {

--- a/dts/bindings/pinctrl/nxp,mcxe31x-siul2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,mcxe31x-siul2-pinctrl.yaml
@@ -17,7 +17,7 @@ description: |
   board or application devicetree overlay as follows:
 
     /* Include the SoC package header containing the predefined pins definitions */
-    #include <nxp/mcx/MCXE31BMPB-pinctrl.h>
+    #include <nxp/mcx/mcxe/pinctrl/MCXE31BMPB-pinctrl.h>
 
     &pinctrl {
       uart0_default: uart0_default {

--- a/dts/bindings/pinctrl/nxp,s32k3-siul2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,s32k3-siul2-pinctrl.yaml
@@ -17,7 +17,7 @@ description: |
   board or application devicetree overlay as follows:
 
     /* Include the SoC package header containing the predefined pins definitions */
-    #include <nxp/s32/S32K344-257BGA-pinctrl.h>
+    #include <nxp/s32/pinctrl/S32K344-257BGA-pinctrl.h>
 
     &pinctrl {
       uart0_default: uart0_default {

--- a/dts/bindings/pinctrl/nxp,s32k5-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,s32k5-pinctrl.yaml
@@ -17,7 +17,7 @@ description: |
   board or application devicetree overlay as follows:
 
     /* Include the SoC package header containing the predefined pins definitions */
-    #include <nxp/s32/S32K566-437BGA-pinctrl.h>
+    #include <nxp/s32/pinctrl/S32K566-437BGA-pinctrl.h>
 
     &pinctrl {
       lpuart3_default: lpuart3_default {

--- a/dts/bindings/pinctrl/nxp,s32ze-siul2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,s32ze-siul2-pinctrl.yaml
@@ -17,7 +17,7 @@ description: |
   board or application devicetree overlay as follows:
 
     /* Include the SoC package header containing the predefined pins definitions */
-    #include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+    #include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 
     &pinctrl {
       uart0_default: uart0_default {

--- a/tests/drivers/build_all/comparator/mcux_acmp/mke15z7_pinctrl.dtsi
+++ b/tests/drivers/build_all/comparator/mcux_acmp/mke15z7_pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE17Z256VLL7-pinctrl.h>
+#include <nxp/kinetis/ke1xz/pinctrl/MKE17Z256VLL7-pinctrl.h>
 
 &pinctrl {
 	cmp0_default: cmp0_default {

--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_ke15z.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_ke15z.overlay
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE15Z256VLL7-pinctrl.h>
+#include <nxp/kinetis/ke1xz/pinctrl/MKE15Z256VLL7-pinctrl.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 /*

--- a/tests/drivers/comparator/gpio_loopback/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/MIMXRT685SFVKB-pinctrl.h>
+#include <nxp/imxrt/imxrt6xx/pinctrl/MIMXRT685SFVKB-pinctrl.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 /*

--- a/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+#include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {

--- a/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+#include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {

--- a/tests/drivers/gpio/gpio_basic_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+#include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 
 / {
 	/* Pin 1 and 3 of J69 must be connected on the board */

--- a/tests/drivers/gpio/gpio_basic_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+#include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 
 / {
 	/* Pin 1 and 3 of J69 must be connected on the board */

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxc242.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxc242.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/mcx/MCXC242VLH-pinctrl.h>
+#include <nxp/mcx/mcxc/pinctrl/MCXC242VLH-pinctrl.h>
 
 &pinctrl {
 	pinmux_i2c0: pinmux_i2c0 {

--- a/tests/drivers/pwm/pwm_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+#include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 
 / {
 	aliases {

--- a/tests/drivers/pwm/pwm_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+#include <nxp/s32/pinctrl/S32Z27-BGA594-pinctrl.h>
 
 / {
 	aliases {

--- a/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
 
 &pinctrl {
 	ecspi1_default: ecspi1_default {

--- a/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7_ddr.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/imx8mp_evk_mimx8ml8_m7_ddr.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+#include <nxp/imx/pinctrl/mimx8ml8dvnlz-pinctrl.dtsi>
 
 &pinctrl {
 	ecspi1_default: ecspi1_default {

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 8723557b8d1b1629941cd2697a59d71bee0538b8
+      revision: 14d44be6e81e0e98582f9bf3eb202e055309badf
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
## Summary

Restructure the NXP SoC pin control headers under `hal_nxp` `dts/nxp/` to
mirror the zephyr DTS-side `dts/arm/nxp/<family>/<series>/` layout, and update
all in-tree includes accordingly.

Every SoC `*-pinctrl.{h,dtsi}` file now lives in a `pinctrl/` sub-directory:

- Series-organized families (i.MX RT, Kinetis, LPC, MCX): `<family>/<series>/pinctrl/`
- Flat families (i.MX, S32, RW): `<family>/pinctrl/`

Keeping a `pinctrl/` layer for *all* families (including the flat ones) leaves
room for a sibling `clock/` directory in a future change (reserved, not created
here). The former `nxp_imx` directory is split: `nxp_imx/rt/*` becomes the
`imxrt/` family and the remaining i.MX application processors become the flat
`imx/` family.

The hal_nxp pinctrl generator (`gen_soc_headers.py`) is updated so regeneration
writes into the new layout instead of re-flattening the tree; a new shared
module `shared/pinctrl_layout.py` is the single source of truth for the
part-number-to-directory mapping.

## Zephyr-side changes in this PR

- Rewrite every in-tree SoC pinctrl `#include` to the new `pinctrl/` paths
  (boards, dts, test overlays, and pinctrl binding-doc examples).
- Add a migration guide entry (`migration-guide-4.5.rst`) with before/after
  include examples.
- Pin the `hal_nxp` manifest revision to the dependency PR pull ref so CI
  builds against the exact change under review.
