### PR TITLE
bluetooth: classic: rfcomm: add asynchronous receive completion mechanism

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1426,6 +1426,11 @@ Bluetooth Classic
 * Renamed ``CONFIG_BT_DEVICE_VEDNOR_ID`` to :kconfig:option:`CONFIG_BT_DEVICE_VENDOR_ID`
   to fix a typo.
 
+* The :c:member:`bt_rfcomm_dlc_ops.recv` callback signature has changed from
+  ``void`` to ``int``. Existing implementations must be updated to return ``0``
+  to preserve previous synchronous behavior, or ``-EINPROGRESS`` to use the new
+  asynchronous completion path.
+
 Bluetooth HCI
 =============
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -408,6 +408,10 @@ New APIs and options
     * :c:member:`bt_conn_cb.le_param_update_rejected`
     * ``BT_HCI_QUIRK_NO_FLOW_CONTROL`` HCI device quirk for controllers that
       advertise but reject the controller to host flow control commands.
+    * :c:member:`bt_rfcomm_dlc.rx_credit_limit` to configure per-DLC initial RX credit count.
+    * :c:func:`bt_rfcomm_dlc_recv_complete` to return RX credits to the peer. Applications can
+      return ``-EINPROGRESS`` from the :c:member:`bt_rfcomm_dlc_ops.recv` callback to defer buffer
+      release and flow-control credit refill until processing is complete.
 
   * Mesh
 

--- a/doc/services/connectivity/bluetooth/shell/classic/spp.rst
+++ b/doc/services/connectivity/bluetooth/shell/classic/spp.rst
@@ -14,12 +14,18 @@ The :code:`spp` commands:
    uart:~$ spp
    spp - Bluetooth SPP sh commands
    Subcommands:
-     register_with_channel  : <channel>
-     register_with_uuid     : <bt-uuid16|bt-uuid32|bt-uuid128>
-     connect_by_channel     : <channel>
-     connect_by_uuid        : <bt-uuid16|bt-uuid32|bt-uuid128>
-     send                   : [length of packet(s)]
+     register_with_channel  : <channel> [limited credit value] [hold_credit]
+     register_with_uuid     : <bt-uuid16(e.g. 1101)|bt-uuid32|bt-uuid128(e.g.
+                              00001101-0000-1000-8000-00805F9B34FB)> [limited
+                              credit value] [hold_credit]
+     connect_by_channel     : <channel> [limited credit value] [hold_credit]
+     connect_by_uuid        : <bt-uuid16(e.g. 1101)|bt-uuid32|bt-uuid128(e.g.
+                              00001101-0000-1000-8000-00805F9B34FB)> [limited
+                              credit value] [hold_credit]
+     send                   : send [length of packet(s)]
+     rls                    : [overrun|parity|framing]
      disconnect             : [none]
+     recv_complete          : [none]
 
 Server Register
 ***************
@@ -88,3 +94,52 @@ Disconnect
    uart:~$ spp disconnect
    SPP: disconnecting...
    SPP: disconnected (ep=0x20000d20)
+
+Flow Control
+************
+
+.. tabs::
+
+   .. group-tab:: Server
+
+      .. code-block:: console
+
+         uart:~$ spp register_with_channel 0 1 hold_credit
+         SPP: server registered (channel=6)
+         SPP: accepted incoming connection (conn=0x20005c70)
+         SPP: connected (ep=0x20006508, channel=6)
+         SPP: rx data (ep=0x20006508, len=10)
+         00000000: ff ff ff ff ff ff ff ff  ff ff                   |........ ..      |
+         uart:~$ spp recv_complete
+         SPP: rx data (ep=0x20006508, len=10)
+         00000000: ff ff ff ff ff ff ff ff  ff ff                   |........ ..      |
+         uart:~$ spp recv_complete
+         uart:~$ spp recv_complete
+         SPP: no inprogress buffer
+         uart:~$ spp send 10
+         SPP: tx data (len=10)
+         uart:~$ spp send 10
+         SPP: tx data (len=10)
+
+   .. group-tab:: Client
+
+      .. code-block:: console
+
+         uart:~$ spp connect_by_channel 6 1 hold_credit
+         SPP: connect started (channel=6)
+         Security changed: A0:CD:F3:77:F3:A0 level 2
+         SPP: connected (ep=0x20006448, channel=6)
+         uart:~$ spp send 10
+         SPP: tx data (len=10)
+         uart:~$ spp send 10
+         SPP: tx data (len=10)
+         uart:~$
+         uart:~$ spp recv_complete
+         SPP: rx data (ep=0x20006448, len=10)
+         00000000: ff ff ff ff ff ff ff ff  ff ff                   |........ ..      |
+         uart:~$ spp recv_complete
+         SPP: rx data (ep=0x20006448, len=10)
+         00000000: ff ff ff ff ff ff ff ff  ff ff                   |........ ..      |
+         uart:~$ spp recv_complete
+         uart:~$ spp recv_complete
+         SPP: no inprogress buffer

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -190,13 +190,35 @@ struct bt_rfcomm_dlc {
 
 	/** Number of receive credits remaining for this DLC.
 	 *
-	 *  Tracks how many additional UIH frames the local side may accept
-	 *  from the remote peer before flow control must be applied.
+	 *  Tracks how many additional UIH frames the local side may accept from the remote
+	 *  before flow control must be applied.
+	 *  Initialized from @p rx_credit_limit at connection setup and decremented as frames are
+	 *  received; refilled by sending credit grants to the remote.
+	 *
 	 *  Only meaningful when CFC is enabled.
 	 */
 	uint8_t rx_credit;
 
 	/** @endcond */
+
+	/** Requested initial number of receive credits for this DLC.
+	 *
+	 *  Sets how many UIH frames the local side is willing to accept from the remote after the
+	 *  DLC is established. The stack limits this value to MIN((BT_BUF_ACL_RX_COUNT - 1), 255)
+	 *  before use. If the field is 0, the stack uses the internal default
+	 *  MIN((BT_BUF_ACL_RX_COUNT - 1), 255). The result is written back to the field. Also
+	 *  the value of field will be limited to 7 when sending in Parameter Negotiation (PN)
+	 *  command/response.
+	 *
+	 *  @note If the value exceeds MIN((BT_BUF_ACL_RX_COUNT - 1), 255), it will be limited to
+	 *  MIN((BT_BUF_ACL_RX_COUNT - 1), 255).
+	 *  @note This field can only be modified when the DLC is in an unconnected state. This
+	 *  means that from the time @ref bt_rfcomm_server::accept returns until @ref
+	 *  bt_rfcomm_dlc_ops::disconnected is called, it cannot be modified any more.
+	 *
+	 *  Only meaningful when CFC is enabled.
+	 */
+	uint8_t rx_credit_limit;
 };
 
 struct bt_rfcomm_server {

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -112,31 +112,91 @@ typedef enum bt_rfcomm_role {
 
 /** @brief RFCOMM DLC structure. */
 struct bt_rfcomm_dlc {
-	/* Response Timeout eXpired (RTX) timer */
-	struct k_work_delayable    rtx_work;
+	/** @cond INTERNAL_HIDDEN */
 
-	/* Queue for outgoing data */
-	struct k_fifo              tx_queue;
+	/** Response Timeout eXpired (RTX) timer.
+	 *
+	 *  Used to detect when a peer fails to respond to an RFCOMM command
+	 *  (e.g. SABM, DISC) within the allowed time window.
+	 */
+	struct k_work_delayable rtx_work;
 
-	/* TX credits, Reuse as a binary sem for MSC FC if CFC is not enabled */
-	struct k_sem               tx_credits;
+	/** Queue for outgoing data.
+	 *
+	 *  Holds net_buf fragments waiting to be transmitted over this DLC.
+	 *  Frames are dequeued and sent by @p tx_work.
+	 */
+	struct k_fifo tx_queue;
 
-	/* Worker for RFCOMM TX */
-	struct k_work              tx_work;
+	/** TX credits semaphore.
+	 *
+	 *  When Credit-Based Flow Control (CFC) is active this semaphore counts
+	 *  the number of frames the remote peer is willing to receive. When CFC
+	 *  is not negotiated it is used as a binary semaphore to serialize
+	 *  transmissions under aggregate (MSC) flow control.
+	 */
+	struct k_sem tx_credits;
 
-	struct bt_rfcomm_session  *session;
-	struct bt_rfcomm_dlc_ops  *ops;
+	/** Worker for RFCOMM TX.
+	 *
+	 *  Submitted to the bt work queue whenever there are frames in
+	 *  @p tx_queue and credits are available, to drain the queue and push
+	 *  data to L2CAP.
+	 */
+	struct k_work tx_work;
 
-	/** @internal Internally used field for list handling */
-	sys_snode_t                _node;
+	/** Pointer to the RFCOMM session this DLC belongs to. */
+	struct bt_rfcomm_session *session;
 
-	bt_security_t              required_sec_level;
-	bt_rfcomm_role_t           role;
+	/** @endcond */
 
-	uint16_t                   mtu;
-	uint8_t                    dlci;
-	uint8_t                    state;
-	uint8_t                    rx_credit;
+	/** Pointer to the application callback operations for this DLC. */
+	struct bt_rfcomm_dlc_ops *ops;
+
+	/** @cond INTERNAL_HIDDEN */
+
+	/** Internally used field for list handling. */
+	sys_snode_t _node;
+
+	/** @endcond */
+
+	/** Minimum security level required before this DLC may be established. */
+	bt_security_t required_sec_level;
+
+	/** @cond INTERNAL_HIDDEN */
+
+	/** Role of this DLC: initiator or acceptor. */
+	bt_rfcomm_role_t role;
+
+	/** @endcond */
+
+	/** Maximum Transmission Unit for this DLC in bytes.
+	 *
+	 *  Negotiated during the Parameter Negotiation (PN) procedure.
+	 *  Outgoing @ref bt_rfcomm_dlc_send buffers must not exceed this value.
+	 */
+	uint16_t mtu;
+
+	/** @cond INTERNAL_HIDDEN */
+
+	/** Data Link Connection Identifier assigned to this DLC. */
+	uint8_t dlci;
+
+	/** Current connection state of this DLC.
+	 *
+	 *  One of the BT_RFCOMM_STATE_* values defined in rfcomm_internal.h.
+	 */
+	uint8_t state;
+
+	/** Number of receive credits remaining for this DLC.
+	 *
+	 *  Tracks how many additional UIH frames the local side may accept
+	 *  from the remote peer before flow control must be applied.
+	 *  Only meaningful when CFC is enabled.
+	 */
+	uint8_t rx_credit;
+
+	/** @endcond */
 };
 
 struct bt_rfcomm_server {

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -67,7 +67,18 @@ enum {
 
 struct bt_rfcomm_dlc;
 
-/** @brief RFCOMM DLC operations structure. */
+/** @brief RFCOMM DLC operations structure.
+ *
+ * The object has to stay valid and constant for the lifetime of the DLC.
+ *
+ *  @note The callbacks are invoked from a thread context, never from an
+ *        ISR. Whether a callback is invoked from a context internal to
+ *        the stack or synchronously from within the API call that
+ *        triggers it, and from which context, is not part of the API and
+ *        may change between releases. See
+ *        @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *        for the hazards of blocking in a callback and their mitigations.
+ */
 struct bt_rfcomm_dlc_ops {
 	/** DLC connected callback
 	 *
@@ -90,10 +101,33 @@ struct bt_rfcomm_dlc_ops {
 
 	/** DLC recv callback
 	 *
+	 *  Called whenever data is received on the DLC.
+	 *
+	 *  If processing @p buf requires work that cannot complete immediately (e.g. passing data
+	 *  to another thread or a work queue), return @c -EINPROGRESS to defer the completion. The
+	 *  callback must not block in this case. Then the stack will hold back RX flow-control
+	 *  credits (CFC) or assert FC=1 (non-CFC) until @ref bt_rfcomm_dlc_recv_complete is called
+	 *  for every outstanding buffer.
+	 *
+	 *  When @c -EINPROGRESS is returned, the application takes ownership of the @p buf
+	 *  reference and must eventually call @ref bt_rfcomm_dlc_recv_complete exactly once,
+	 *  passing back the same @p buf pointer. No @ref net_buf_ref or @ref net_buf_unref calls
+	 *  are needed around that hand-off.
+	 *
+	 *  @warning @ref bt_rfcomm_dlc_recv_complete must be called from a thread context
+	 *           <b>after this callback has returned</b>. Calling it from inside the recv
+	 *           callback (before it returns) will underflow the in-progress counter and
+	 *           cause @ref bt_rfcomm_dlc_recv_complete to fail with @c -EINVAL.
+	 *
 	 *  @param dlc The dlc receiving data.
 	 *  @param buf Buffer containing incoming data.
+	 *
+	 *  @retval 0 Data was fully consumed synchronously; the stack retains ownership of @p buf.
+	 *  @retval -EINPROGRESS Data processing is deferred; the application now owns @p buf and
+	 *                       must call @ref bt_rfcomm_dlc_recv_complete once processing is done.
+	 *  @return Other negative error code; the DLC will be actively disconnected by the stack.
 	 */
-	void (*recv)(struct bt_rfcomm_dlc *dlc, struct net_buf *buf);
+	int (*recv)(struct bt_rfcomm_dlc *dlc, struct net_buf *buf);
 
 	/** DLC sent callback
 	 *
@@ -219,6 +253,28 @@ struct bt_rfcomm_dlc {
 	 *  Only meaningful when CFC is enabled.
 	 */
 	uint8_t rx_credit_limit;
+
+	/** @cond INTERNAL_HIDDEN */
+
+	/** Number of in-progress receive operations for this DLC.
+	 *
+	 *  Counts how many @ref bt_rfcomm_dlc_ops::recv callbacks have returned @c -EINPROGRESS
+	 *  but have not yet been completed by calling @ref bt_rfcomm_dlc_recv_complete.
+	 *
+	 *  For CFC-supported sessions, this counter is used to delay RX credit refill:
+	 *  RX credits are not refilled until the in-progress bufs are completed, ensuring
+	 *  the remote peer cannot send more frames than the application can handle concurrently.
+	 *
+	 *  For non-CFC sessions, this counter gates the MSC flow-control commands:
+	 *  - MSC with FC=1 (pause) is sent only when the count is changing from 0 to 1
+	 *  - MSC with FC=0 (resume) is sent only when the count is changing from 1 to 0
+	 */
+	atomic_t rx_credit_inprogress;
+
+	/** DLC flags */
+	atomic_t flags;
+
+	/** @endcond */
 };
 
 struct bt_rfcomm_server {
@@ -378,6 +434,40 @@ int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf);
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_rfcomm_dlc_disconnect(struct bt_rfcomm_dlc *dlc);
+
+/**
+ * @brief Complete receiving RFCOMM channel data
+ *
+ * Must be called exactly once for each invocation of @ref bt_rfcomm_dlc_ops::recv that returned
+ * @c -EINPROGRESS. Pass back the same @p buf pointer that was received in that callback; no
+ * additional @ref net_buf_ref or @ref net_buf_unref calls are needed.
+ *
+ * @note This function must be called from a thread context only, never from an ISR.
+ *
+ * @note This function must be called only after @ref bt_rfcomm_dlc_ops::recv has returned.
+ *       Calling it from within the recv callback (before it returns) underflows the in-progress
+ *       counter and causes this function to return @c -EINVAL.
+ *
+ * When this function returns, the stack releases its reference to @p buf regardless of the return
+ * value, unless @p dlc or @p buf is @c NULL (in which case @c -EINVAL is returned immediately and
+ * @p buf is not touched).
+ *
+ * Flow-control behavior after a successful call:
+ * - CFC sessions: the stack may now send additional RX credits to the remote peer, allowing it
+ *   to send more frames.
+ * - Non-CFC sessions: an MSC command with FC=0 (resume) is sent to the remote peer only when
+ *   all in-progress buffers are completed.
+ *
+ * @param dlc Pointer to the RFCOMM DLC whose receive operation is being completed.
+ * @param buf The buffer that was passed to @ref bt_rfcomm_dlc_ops::recv when it returned
+ *            @c -EINPROGRESS.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ * @retval -EINVAL @p dlc or @p buf is @c NULL, the DLC's CFC state is unknown, or the
+ *                 in-progress counter would underflow (more completions than in-progress calls).
+ * @retval -ENOTCONN The DLC has no associated session or is not in the connected state.
+ */
+int bt_rfcomm_dlc_recv_complete(struct bt_rfcomm_dlc *dlc, struct net_buf *buf);
 
 /** @brief Allocate the buffer from pool after reserving head room for RFCOMM,
  *  L2CAP and ACL headers.

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -38,7 +38,7 @@ static sys_slist_t goep_rfcomm_server = SYS_SLIST_STATIC_INIT(&goep_rfcomm_serve
 
 #define GOEP_GET_TRANSPORT_V1(_dlc) CONTAINER_OF((_dlc), struct bt_goep_transport_v1, dlc)
 
-static void goep_rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
+static int goep_rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
 	struct bt_goep_transport_v1 *goep_transport_v1 = GOEP_GET_TRANSPORT_V1(dlc);
 	struct bt_goep *goep = goep_transport_v1->goep;
@@ -48,6 +48,8 @@ static void goep_rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	if (err != 0) {
 		LOG_WRN("Fail to handle OBEX packet (err %d)", err);
 	}
+
+	return 0;
 }
 
 static void goep_rfcomm_connected(struct bt_rfcomm_dlc *dlc)

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -3753,7 +3753,7 @@ static int hfp_ag_at_cmd_ack(struct bt_hfp_ag *ag, int err)
 	return err;
 }
 
-static void hfp_ag_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
+static int hfp_ag_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
 	struct bt_hfp_ag *ag = CONTAINER_OF(dlc, struct bt_hfp_ag, rfcomm_dlc);
 	uint8_t *data = buf->data;
@@ -3783,14 +3783,14 @@ static void hfp_ag_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 
 	if (err == -EINPROGRESS) {
 		LOG_DBG("OK code will be replied later");
-		return;
+		return 0;
 	}
 
 	if (!atomic_test_and_set_bit(ag->flags, BT_HFP_AG_1ST_AT_RECV)) {
 		LOG_DBG("First AT command ack will be replied later");
 		ag->ack_err = err;
 		bt_work_submit(&ag->slc_work);
-		return;
+		return 0;
 	}
 
 	err = hfp_ag_at_cmd_ack(ag, err);
@@ -3800,6 +3800,8 @@ static void hfp_ag_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	if (err != 0) {
 		LOG_ERR("HFP AG send response err :(%d)", err);
 	}
+
+	return 0;
 }
 
 static void hfp_ag_sent(struct bt_rfcomm_dlc *dlc, int err)

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4291,7 +4291,7 @@ static void hfp_hf_disconnected(struct bt_rfcomm_dlc *dlc)
 	hf->acl = NULL;
 }
 
-static void hfp_hf_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
+static int hfp_hf_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(dlc, struct bt_hfp_hf, rfcomm_dlc);
 
@@ -4301,6 +4301,8 @@ static void hfp_hf_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	}
 	atomic_clear_bit(hf->flags, BT_HFP_HF_FLAG_RX_ONGOING);
 	k_work_submit(&hf->work);
+
+	return 0;
 }
 
 static void hfp_hf_sent(struct bt_rfcomm_dlc *dlc, int err)

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -38,9 +38,14 @@ LOG_MODULE_REGISTER(bt_rfcomm);
 #define RFCOMM_MIN_MTU		BT_RFCOMM_SIG_MIN_MTU
 #define RFCOMM_DEFAULT_MTU	127
 
-#define RFCOMM_MAX_CREDITS		(BT_BUF_ACL_RX_COUNT - 1)
-#define RFCOMM_CREDITS_THRESHOLD	(RFCOMM_MAX_CREDITS / 2)
-#define RFCOMM_DEFAULT_CREDIT		RFCOMM_MAX_CREDITS
+#define RFCOMM_MAX_RX_CREDITS 255
+
+#define RFCOMM_MAX_CREDITS (MIN((BT_BUF_ACL_RX_COUNT - 1), RFCOMM_MAX_RX_CREDITS))
+
+#define RFCOMM_DLC_CREDITS_MAX(_dlc) ((_dlc)->rx_credit_limit)
+
+#define _RFCOMM_DLC_CREDITS_THRESHOLD(_dlc) (RFCOMM_DLC_CREDITS_MAX(_dlc) / 2)
+#define RFCOMM_DLC_CREDITS_THRESHOLD(_dlc) MAX(_RFCOMM_DLC_CREDITS_THRESHOLD(_dlc), 1)
 
 #define RFCOMM_CONN_TIMEOUT     K_SECONDS(60)
 #define RFCOMM_DISC_TIMEOUT     K_SECONDS(20)
@@ -487,7 +492,12 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 
 	dlc->dlci = dlci;
 	dlc->session = session;
-	dlc->rx_credit = RFCOMM_DEFAULT_CREDIT;
+	if (dlc->rx_credit_limit == 0) {
+		dlc->rx_credit_limit = RFCOMM_MAX_CREDITS;
+	} else {
+		dlc->rx_credit_limit = MIN(dlc->rx_credit_limit, RFCOMM_MAX_CREDITS);
+	}
+	dlc->rx_credit = dlc->rx_credit_limit;
 	dlc->state = BT_RFCOMM_STATE_INIT;
 	dlc->role = role;
 	k_work_init_delayable(&dlc->rtx_work, rfcomm_dlc_rtx_timeout);
@@ -1043,6 +1053,8 @@ static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 	}
 }
 
+#define RFCOMM_PN_MAX_RX_CREDITS 7
+
 static int rfcomm_send_pn(struct bt_rfcomm_dlc *dlc, uint8_t cr)
 {
 	struct bt_rfcomm_pn *pn;
@@ -1059,7 +1071,7 @@ static int rfcomm_send_pn(struct bt_rfcomm_dlc *dlc, uint8_t cr)
 	if (dlc->state == BT_RFCOMM_STATE_CONFIG &&
 	    (dlc->session->cfc == BT_RFCOMM_CFC_UNKNOWN ||
 	     dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED)) {
-		pn->credits = dlc->rx_credit;
+		pn->credits = MIN(dlc->rx_credit_limit, RFCOMM_PN_MAX_RX_CREDITS);
 		if (cr) {
 			pn->flow_ctrl = BT_RFCOMM_PN_CFC_CMD;
 		} else {
@@ -1539,15 +1551,16 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 	LOG_DBG("dlc %p credits %u", dlc, dlc->rx_credit);
 
 	/* Only give more credits if it went below the defined threshold */
-	if (dlc->rx_credit > RFCOMM_CREDITS_THRESHOLD) {
+	if (dlc->rx_credit > RFCOMM_DLC_CREDITS_THRESHOLD(dlc)) {
 		return;
 	}
 
 	/* Restore credits */
-	credits = RFCOMM_MAX_CREDITS - dlc->rx_credit;
-	dlc->rx_credit += credits;
-
-	rfcomm_send_credit(dlc, credits);
+	if (RFCOMM_DLC_CREDITS_MAX(dlc) > dlc->rx_credit) {
+		credits = RFCOMM_DLC_CREDITS_MAX(dlc) - dlc->rx_credit;
+		dlc->rx_credit += credits;
+		rfcomm_send_credit(dlc, credits);
+	}
 }
 
 static void rfcomm_handle_data(struct bt_rfcomm_session *session, struct net_buf *buf, uint8_t dlci,

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -498,6 +498,8 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 		dlc->rx_credit_limit = MIN(dlc->rx_credit_limit, RFCOMM_MAX_CREDITS);
 	}
 	dlc->rx_credit = dlc->rx_credit_limit;
+	atomic_clear(&dlc->rx_credit_inprogress);
+	atomic_clear(&dlc->flags);
 	dlc->state = BT_RFCOMM_STATE_INIT;
 	dlc->role = role;
 	k_work_init_delayable(&dlc->rtx_work, rfcomm_dlc_rtx_timeout);
@@ -629,6 +631,8 @@ static void rfcomm_sent(struct bt_conn *conn, void *user_data, int err)
 	}
 }
 
+static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc);
+
 static void rfcomm_dlc_tx_worker(struct k_work *work)
 {
 	struct bt_rfcomm_dlc *dlc = CONTAINER_OF(work, struct bt_rfcomm_dlc, tx_work);
@@ -671,6 +675,9 @@ user_disconnect:
 			LOG_DBG("Process user disconnect");
 			goto disconnect;
 		}
+
+		/* Update RX credits*/
+		rfcomm_dlc_update_credits(dlc);
 
 		return;
 	}
@@ -899,9 +906,14 @@ static int rfcomm_send_fcoff(struct bt_rfcomm_session *session, uint8_t cr)
 
 static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 {
+	int err;
+
 	dlc->state = BT_RFCOMM_STATE_CONNECTED;
 
-	rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
+	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
+	if (err == 0) {
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
+	}
 
 	if (dlc->session->cfc == BT_RFCOMM_CFC_UNKNOWN) {
 		/* This means PN negotiation is not done for this session and
@@ -1236,7 +1248,7 @@ static void rfcomm_handle_msc(struct bt_rfcomm_session *session,
 
 	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
 		/* Only FC bit affects the flow on RFCOMM level */
-		if (BT_RFCOMM_GET_FC(msc->v24_signal)) {
+		if (BT_RFCOMM_V24_SIGNALS_GET_FC(msc->v24_signal)) {
 			/* If FC bit is 1 the device is unable to accept frames.
 			 * Take the semaphore with timeout K_NO_WAIT so that
 			 * dlc thread will be blocked when it tries sem_take
@@ -1540,11 +1552,55 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 	}
 }
 
+static inline uint8_t rfcomm_dlc_get_available_credits(struct bt_rfcomm_dlc *dlc)
+{
+	uint8_t max_credits = RFCOMM_DLC_CREDITS_MAX(dlc);
+	atomic_val_t inprogress_credits = atomic_get(&dlc->rx_credit_inprogress);
+
+	__ASSERT(inprogress_credits >= 0, "Negative inprogress credits");
+	__ASSERT(inprogress_credits <= max_credits, "Inprogress credits exceeds max");
+
+	/* The case only occurs when there is no inprogress receiving buffer, but the app calls
+	 * bt_rfcomm_dlc_recv_complete().
+	 */
+	if (inprogress_credits < 0) {
+		/* In this case, treat as if there is no inprogress receiving buffer */
+		LOG_ERR("rx_credit_inprogress of %p is underflow", dlc);
+		inprogress_credits = 0;
+	}
+
+	return max_credits - inprogress_credits;
+}
+
+static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+
+	if (!atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ)) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED)) {
+		return;
+	}
+
+	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
+	if (err != 0) {
+		atomic_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
+		LOG_ERR("Failed to send MSC with FC cleared (%d)", err);
+	}
+}
+
 static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 {
 	uint8_t credits;
+	uint8_t credit_available;
+	int err;
 
 	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		/* FC Check and on if required */
+		rfcomm_dlc_fc_check_and_on(dlc);
 		return;
 	}
 
@@ -1556,17 +1612,51 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 	}
 
 	/* Restore credits */
-	if (RFCOMM_DLC_CREDITS_MAX(dlc) > dlc->rx_credit) {
-		credits = RFCOMM_DLC_CREDITS_MAX(dlc) - dlc->rx_credit;
+	credit_available = rfcomm_dlc_get_available_credits(dlc);
+	if (credit_available > dlc->rx_credit) {
+		credits = credit_available - dlc->rx_credit;
 		dlc->rx_credit += credits;
-		rfcomm_send_credit(dlc, credits);
+		err = rfcomm_send_credit(dlc, credits);
+		if (err != 0) {
+			LOG_ERR("Failed to send credit (%d)", err);
+			dlc->rx_credit -= credits;
+		}
 	}
+}
+
+static int rfcomm_handle_recv_inprogress(struct bt_rfcomm_dlc *dlc)
+{
+	int err = 0;
+	atomic_val_t old_rx_credit_inprogress;
+	uint8_t v24_signals = BT_RFCOMM_DEFAULT_V24_SIG;
+
+	old_rx_credit_inprogress = atomic_inc(&dlc->rx_credit_inprogress);
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED) {
+		return 0;
+	}
+
+	if (old_rx_credit_inprogress != 0) {
+		LOG_DBG("Only set FC bit at the first time for DLC %p", dlc);
+		return 0;
+	}
+
+	if (atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED)) {
+		v24_signals = BT_RFCOMM_V24_SIGNALS_SET_FC(v24_signals);
+		err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, v24_signals);
+		if (err != 0) {
+			atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
+			LOG_ERR("Failed to send MSC with FC set (%d)", err);
+		}
+	}
+	return err;
 }
 
 static void rfcomm_handle_data(struct bt_rfcomm_session *session, struct net_buf *buf, uint8_t dlci,
 			       uint8_t pf)
 {
 	struct bt_rfcomm_dlc *dlc;
+	int err = 0;
 
 	LOG_DBG("dlci %d, pf %d", dlci, pf);
 
@@ -1577,7 +1667,7 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session, struct net_buf
 		return;
 	}
 
-	LOG_DBG("dlc %p rx credit %d", dlc, dlc->rx_credit);
+	LOG_DBG("dlc %p rx credit %u", dlc, dlc->rx_credit);
 
 	if (dlc->state != BT_RFCOMM_STATE_CONNECTED) {
 		return;
@@ -1596,18 +1686,39 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session, struct net_buf
 		return;
 	}
 
-	if (dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED &&
-	    !dlc->rx_credit) {
+	if (dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED && dlc->rx_credit == 0) {
 		LOG_ERR("Data recvd when rx credit is 0");
 		rfcomm_dlc_close(dlc);
 		return;
 	}
 
-	if (dlc->ops && dlc->ops->recv) {
-		dlc->ops->recv(dlc, buf);
+	if (dlc->ops != NULL && dlc->ops->recv != NULL) {
+		err = dlc->ops->recv(dlc, net_buf_ref(buf));
+		if (err != -EINPROGRESS) {
+			net_buf_unref(buf);
+		}
 	}
 
-	dlc->rx_credit--;
+	if (err != 0 && err != -EINPROGRESS) {
+		LOG_ERR("DLC data recvd error (%d)", err);
+		rfcomm_dlc_close(dlc);
+		return;
+	}
+
+	if (err == -EINPROGRESS) {
+		err = rfcomm_handle_recv_inprogress(dlc);
+		if (err != 0) {
+			/* The buffer should not be released here, because the rfcomm does not
+			 * own the buffer reference any more.
+			 */
+			rfcomm_dlc_close(dlc);
+			return;
+		}
+	}
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED) {
+		dlc->rx_credit--;
+	}
 	rfcomm_dlc_update_credits(dlc);
 }
 
@@ -1962,4 +2073,53 @@ void bt_rfcomm_init(void)
 	}
 
 	initialized = true;
+}
+
+int bt_rfcomm_dlc_recv_complete(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
+{
+	struct bt_rfcomm_session *session;
+	atomic_val_t old_rx_credit_inprogress;
+
+	if (dlc == NULL || buf == NULL) {
+		return -EINVAL;
+	}
+
+	net_buf_unref(buf);
+
+	session = dlc->session;
+	if (session == NULL) {
+		LOG_ERR("Invalid session of dlc %p", dlc);
+		return -ENOTCONN;
+	}
+
+	if (dlc->state != BT_RFCOMM_STATE_CONNECTED) {
+		LOG_ERR("Invalid state %u for dlc %p", dlc->state, dlc);
+		return -ENOTCONN;
+	}
+
+	if (session->cfc != BT_RFCOMM_CFC_NOT_SUPPORTED &&
+	    session->cfc != BT_RFCOMM_CFC_SUPPORTED) {
+		LOG_ERR("Invalid CFC state UNKNOWN for dlc %p", dlc);
+		return -EINVAL;
+	}
+
+	old_rx_credit_inprogress = atomic_dec(&dlc->rx_credit_inprogress);
+	if (old_rx_credit_inprogress <= 0) {
+		atomic_inc(&dlc->rx_credit_inprogress);
+		LOG_ERR("rx_credit_inprogress underflow for dlc %p", dlc);
+		return -EINVAL;
+	}
+
+	if (session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		if (old_rx_credit_inprogress > 1) {
+			LOG_DBG("Only clear FC bit at the last time for DLC %p", dlc);
+			return 0;
+		}
+
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
+	}
+
+	rfcomm_dlc_tx_trigger(dlc);
+
+	return 0;
 }

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -631,80 +631,6 @@ static void rfcomm_sent(struct bt_conn *conn, void *user_data, int err)
 	}
 }
 
-static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc);
-
-static void rfcomm_dlc_tx_worker(struct k_work *work)
-{
-	struct bt_rfcomm_dlc *dlc = CONTAINER_OF(work, struct bt_rfcomm_dlc, tx_work);
-	struct net_buf *buf;
-
-	LOG_DBG("Work for dlc %p state %u", dlc, dlc->state);
-
-	if (dlc->state < BT_RFCOMM_STATE_CONNECTED) {
-		return;
-	}
-
-	if (dlc->state == BT_RFCOMM_STATE_CONNECTED ||
-	    dlc->state == BT_RFCOMM_STATE_USER_DISCONNECT) {
-		if (k_fifo_is_empty(&dlc->tx_queue) == true) {
-			goto user_disconnect;
-		}
-
-		if (rfcomm_check_fc(dlc) == false) {
-			LOG_DBG("FC or credit not available");
-			goto user_disconnect;
-		}
-
-		buf = k_fifo_get(&dlc->tx_queue, K_NO_WAIT);
-		LOG_DBG("Tx buf %p", buf);
-		if (rfcomm_send_cb(dlc->session, buf, rfcomm_sent, dlc) < 0) {
-			/* This fails only if channel is disconnected */
-			dlc->state = BT_RFCOMM_STATE_DISCONNECTED;
-			bt_rfcomm_tx_destroy(dlc, buf);
-			LOG_ERR("Failed to send buffer, disconnected");
-			goto disconnect;
-		}
-
-		if (k_fifo_is_empty(&dlc->tx_queue) == false) {
-			rfcomm_dlc_tx_trigger(dlc);
-			return;
-		}
-
-user_disconnect:
-		if (dlc->state == BT_RFCOMM_STATE_USER_DISCONNECT) {
-			LOG_DBG("Process user disconnect");
-			goto disconnect;
-		}
-
-		/* Update RX credits*/
-		rfcomm_dlc_update_credits(dlc);
-
-		return;
-	}
-
-disconnect:
-	LOG_DBG("dlc %p disconnected - cleaning up", dlc);
-
-	/* Give back any allocated buffers */
-	while ((buf = k_fifo_get(&dlc->tx_queue, K_NO_WAIT))) {
-		bt_rfcomm_tx_destroy(dlc, buf);
-		net_buf_unref(buf);
-	}
-
-	if (dlc->state == BT_RFCOMM_STATE_USER_DISCONNECT) {
-		dlc->state = BT_RFCOMM_STATE_DISCONNECTING;
-	}
-
-	if (dlc->state == BT_RFCOMM_STATE_DISCONNECTING) {
-		rfcomm_send_disc(dlc->session, dlc->dlci);
-		bt_work_reschedule(&dlc->rtx_work, RFCOMM_DISC_TIMEOUT);
-	} else {
-		rfcomm_dlc_destroy(dlc);
-	}
-
-	LOG_DBG("dlc %p exiting", dlc);
-}
-
 static int rfcomm_send_ua(struct bt_rfcomm_session *session, uint8_t dlci)
 {
 	struct bt_rfcomm_hdr *hdr;
@@ -904,42 +830,6 @@ static int rfcomm_send_fcoff(struct bt_rfcomm_session *session, uint8_t cr)
 	return rfcomm_send(session, buf);
 }
 
-static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
-{
-	int err;
-
-	dlc->state = BT_RFCOMM_STATE_CONNECTED;
-
-	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
-	if (err == 0) {
-		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
-	}
-
-	if (dlc->session->cfc == BT_RFCOMM_CFC_UNKNOWN) {
-		/* This means PN negotiation is not done for this session and
-		 * can happen only for 1.0b device.
-		 */
-		dlc->session->cfc = BT_RFCOMM_CFC_NOT_SUPPORTED;
-	}
-
-	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
-		LOG_DBG("CFC not supported %p", dlc);
-		rfcomm_send_fcon(dlc->session, BT_RFCOMM_MSG_CMD_CR);
-		/* Use tx_credits as binary sem for MSC FC */
-		k_sem_init(&dlc->tx_credits, 0, 1);
-	}
-
-	/* Cancel conn timer */
-	k_work_cancel_delayable(&dlc->rtx_work);
-
-	k_fifo_init(&dlc->tx_queue);
-	k_work_init(&dlc->tx_work, rfcomm_dlc_tx_worker);
-
-	if (dlc->ops && dlc->ops->connected) {
-		dlc->ops->connected(dlc);
-	}
-}
-
 enum security_result {
 	RFCOMM_SECURITY_PASSED,
 	RFCOMM_SECURITY_REJECT,
@@ -1017,52 +907,6 @@ static int rfcomm_dlc_close(struct bt_rfcomm_dlc *dlc)
 	}
 
 	return 0;
-}
-
-static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
-{
-	if (!dlci) {
-		if (rfcomm_send_ua(session, dlci) < 0) {
-			return;
-		}
-
-		session->state = BT_RFCOMM_STATE_CONNECTED;
-	} else {
-		struct bt_rfcomm_dlc *dlc;
-		enum security_result result;
-
-		dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
-		if (dlc == NULL) {
-			dlc = rfcomm_dlc_accept(session, dlci);
-			if (dlc == NULL) {
-				rfcomm_send_dm(session, dlci);
-				return;
-			}
-		}
-
-		result = rfcomm_dlc_security(dlc);
-		switch (result) {
-		case RFCOMM_SECURITY_PENDING:
-			dlc->state = BT_RFCOMM_STATE_SECURITY_PENDING;
-			return;
-		case RFCOMM_SECURITY_PASSED:
-			break;
-		case RFCOMM_SECURITY_REJECT:
-		default:
-			rfcomm_send_dm(session, dlci);
-			rfcomm_dlc_drop(dlc);
-			return;
-		}
-
-		if (rfcomm_send_ua(session, dlci) < 0) {
-			return;
-		}
-
-		/* Cancel idle timer if any */
-		k_work_cancel_delayable(&session->rtx_work);
-
-		rfcomm_dlc_connected(dlc);
-	}
 }
 
 #define RFCOMM_PN_MAX_RX_CREDITS 7
@@ -1151,6 +995,232 @@ static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)
 	}
 
 	return 0;
+}
+
+static inline uint8_t rfcomm_dlc_get_available_credits(struct bt_rfcomm_dlc *dlc)
+{
+	uint8_t max_credits = RFCOMM_DLC_CREDITS_MAX(dlc);
+	atomic_val_t inprogress_credits = atomic_get(&dlc->rx_credit_inprogress);
+
+	__ASSERT(inprogress_credits >= 0, "Negative inprogress credits");
+	__ASSERT(inprogress_credits <= max_credits, "Inprogress credits exceeds max");
+
+	/* The case only occurs when there is no inprogress receiving buffer, but the app calls
+	 * bt_rfcomm_dlc_recv_complete().
+	 */
+	if (inprogress_credits < 0) {
+		/* In this case, treat as if there is no inprogress receiving buffer */
+		LOG_ERR("rx_credit_inprogress of %p is underflow", dlc);
+		inprogress_credits = 0;
+	}
+
+	return max_credits - inprogress_credits;
+}
+
+static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+
+	if (!atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ)) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED)) {
+		return;
+	}
+
+	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
+	if (err != 0) {
+		atomic_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
+		LOG_ERR("Failed to send MSC with FC cleared (%d)", err);
+	}
+}
+
+static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
+{
+	uint8_t credits;
+	uint8_t credit_available;
+	int err;
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		/* FC Check and on if required */
+		rfcomm_dlc_fc_check_and_on(dlc);
+		return;
+	}
+
+	LOG_DBG("dlc %p credits %u", dlc, dlc->rx_credit);
+
+	/* Only give more credits if it went below the defined threshold */
+	if (dlc->rx_credit > RFCOMM_DLC_CREDITS_THRESHOLD(dlc)) {
+		return;
+	}
+
+	/* Restore credits */
+	credit_available = rfcomm_dlc_get_available_credits(dlc);
+	if (credit_available > dlc->rx_credit) {
+		credits = credit_available - dlc->rx_credit;
+		dlc->rx_credit += credits;
+		err = rfcomm_send_credit(dlc, credits);
+		if (err != 0) {
+			LOG_ERR("Failed to send credit (%d)", err);
+			dlc->rx_credit -= credits;
+		}
+	}
+}
+
+static void rfcomm_dlc_tx_worker(struct k_work *work)
+{
+	struct bt_rfcomm_dlc *dlc = CONTAINER_OF(work, struct bt_rfcomm_dlc, tx_work);
+	struct net_buf *buf;
+
+	LOG_DBG("Work for dlc %p state %u", dlc, dlc->state);
+
+	if (dlc->state < BT_RFCOMM_STATE_CONNECTED) {
+		return;
+	}
+
+	if (dlc->state == BT_RFCOMM_STATE_CONNECTED ||
+	    dlc->state == BT_RFCOMM_STATE_USER_DISCONNECT) {
+		if (k_fifo_is_empty(&dlc->tx_queue) == true) {
+			goto user_disconnect;
+		}
+
+		if (rfcomm_check_fc(dlc) == false) {
+			LOG_DBG("FC or credit not available");
+			goto user_disconnect;
+		}
+
+		buf = k_fifo_get(&dlc->tx_queue, K_NO_WAIT);
+		LOG_DBG("Tx buf %p", buf);
+		if (rfcomm_send_cb(dlc->session, buf, rfcomm_sent, dlc) < 0) {
+			/* This fails only if channel is disconnected */
+			dlc->state = BT_RFCOMM_STATE_DISCONNECTED;
+			bt_rfcomm_tx_destroy(dlc, buf);
+			LOG_ERR("Failed to send buffer, disconnected");
+			goto disconnect;
+		}
+
+		if (k_fifo_is_empty(&dlc->tx_queue) == false) {
+			rfcomm_dlc_tx_trigger(dlc);
+			return;
+		}
+
+user_disconnect:
+		if (dlc->state == BT_RFCOMM_STATE_USER_DISCONNECT) {
+			LOG_DBG("Process user disconnect");
+			goto disconnect;
+		}
+
+		/* Update RX credits*/
+		rfcomm_dlc_update_credits(dlc);
+
+		return;
+	}
+
+disconnect:
+	LOG_DBG("dlc %p disconnected - cleaning up", dlc);
+
+	/* Give back any allocated buffers */
+	while ((buf = k_fifo_get(&dlc->tx_queue, K_NO_WAIT))) {
+		bt_rfcomm_tx_destroy(dlc, buf);
+		net_buf_unref(buf);
+	}
+
+	if (dlc->state == BT_RFCOMM_STATE_USER_DISCONNECT) {
+		dlc->state = BT_RFCOMM_STATE_DISCONNECTING;
+	}
+
+	if (dlc->state == BT_RFCOMM_STATE_DISCONNECTING) {
+		rfcomm_send_disc(dlc->session, dlc->dlci);
+		bt_work_reschedule(&dlc->rtx_work, RFCOMM_DISC_TIMEOUT);
+	} else {
+		rfcomm_dlc_destroy(dlc);
+	}
+
+	LOG_DBG("dlc %p exiting", dlc);
+}
+
+static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+
+	dlc->state = BT_RFCOMM_STATE_CONNECTED;
+
+	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
+	if (err == 0) {
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
+	}
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_UNKNOWN) {
+		/* This means PN negotiation is not done for this session and
+		 * can happen only for 1.0b device.
+		 */
+		dlc->session->cfc = BT_RFCOMM_CFC_NOT_SUPPORTED;
+	}
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		LOG_DBG("CFC not supported %p", dlc);
+		rfcomm_send_fcon(dlc->session, BT_RFCOMM_MSG_CMD_CR);
+		/* Use tx_credits as binary sem for MSC FC */
+		k_sem_init(&dlc->tx_credits, 0, 1);
+	}
+
+	/* Cancel conn timer */
+	k_work_cancel_delayable(&dlc->rtx_work);
+
+	k_fifo_init(&dlc->tx_queue);
+	k_work_init(&dlc->tx_work, rfcomm_dlc_tx_worker);
+
+	if (dlc->ops && dlc->ops->connected) {
+		dlc->ops->connected(dlc);
+	}
+}
+
+static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
+{
+	if (!dlci) {
+		if (rfcomm_send_ua(session, dlci) < 0) {
+			return;
+		}
+
+		session->state = BT_RFCOMM_STATE_CONNECTED;
+	} else {
+		struct bt_rfcomm_dlc *dlc;
+		enum security_result result;
+
+		dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
+		if (dlc == NULL) {
+			dlc = rfcomm_dlc_accept(session, dlci);
+			if (dlc == NULL) {
+				rfcomm_send_dm(session, dlci);
+				return;
+			}
+		}
+
+		result = rfcomm_dlc_security(dlc);
+		switch (result) {
+		case RFCOMM_SECURITY_PENDING:
+			dlc->state = BT_RFCOMM_STATE_SECURITY_PENDING;
+			return;
+		case RFCOMM_SECURITY_PASSED:
+			break;
+		case RFCOMM_SECURITY_REJECT:
+		default:
+			rfcomm_send_dm(session, dlci);
+			rfcomm_dlc_drop(dlc);
+			return;
+		}
+
+		if (rfcomm_send_ua(session, dlci) < 0) {
+			return;
+		}
+
+		/* Cancel idle timer if any */
+		k_work_cancel_delayable(&session->rtx_work);
+
+		rfcomm_dlc_connected(dlc);
+	}
 }
 
 static void rfcomm_handle_ua(struct bt_rfcomm_session *session, uint8_t dlci)
@@ -1549,78 +1619,6 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 		LOG_WRN("Unknown/Unsupported RFCOMM Msg type 0x%02x", msg_type);
 		rfcomm_send_nsc(session, hdr->type);
 		break;
-	}
-}
-
-static inline uint8_t rfcomm_dlc_get_available_credits(struct bt_rfcomm_dlc *dlc)
-{
-	uint8_t max_credits = RFCOMM_DLC_CREDITS_MAX(dlc);
-	atomic_val_t inprogress_credits = atomic_get(&dlc->rx_credit_inprogress);
-
-	__ASSERT(inprogress_credits >= 0, "Negative inprogress credits");
-	__ASSERT(inprogress_credits <= max_credits, "Inprogress credits exceeds max");
-
-	/* The case only occurs when there is no inprogress receiving buffer, but the app calls
-	 * bt_rfcomm_dlc_recv_complete().
-	 */
-	if (inprogress_credits < 0) {
-		/* In this case, treat as if there is no inprogress receiving buffer */
-		LOG_ERR("rx_credit_inprogress of %p is underflow", dlc);
-		inprogress_credits = 0;
-	}
-
-	return max_credits - inprogress_credits;
-}
-
-static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
-{
-	int err;
-
-	if (!atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ)) {
-		return;
-	}
-
-	if (atomic_test_and_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED)) {
-		return;
-	}
-
-	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
-	if (err != 0) {
-		atomic_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
-		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
-		LOG_ERR("Failed to send MSC with FC cleared (%d)", err);
-	}
-}
-
-static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
-{
-	uint8_t credits;
-	uint8_t credit_available;
-	int err;
-
-	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
-		/* FC Check and on if required */
-		rfcomm_dlc_fc_check_and_on(dlc);
-		return;
-	}
-
-	LOG_DBG("dlc %p credits %u", dlc, dlc->rx_credit);
-
-	/* Only give more credits if it went below the defined threshold */
-	if (dlc->rx_credit > RFCOMM_DLC_CREDITS_THRESHOLD(dlc)) {
-		return;
-	}
-
-	/* Restore credits */
-	credit_available = rfcomm_dlc_get_available_credits(dlc);
-	if (credit_available > dlc->rx_credit) {
-		credits = credit_available - dlc->rx_credit;
-		dlc->rx_credit += credits;
-		err = rfcomm_send_credit(dlc, credits);
-		if (err != 0) {
-			LOG_ERR("Failed to send credit (%d)", err);
-			dlc->rx_credit -= credits;
-		}
 	}
 }
 

--- a/subsys/bluetooth/host/classic/rfcomm_internal.h
+++ b/subsys/bluetooth/host/classic/rfcomm_internal.h
@@ -75,6 +75,37 @@ struct bt_rfcomm_pn {
 	uint8_t  credits;
 } __packed;
 
+/** @brief Bitmask for the FC (Flow Control) field in the RFCOMM MSC V.24 signals octet. */
+#define BT_RFCOMM_V24_SIGNALS_FC_MASK GENMASK(1, 1)
+
+/**
+ * @brief Extract the FC (Flow Control) field from the RFCOMM MSC V.24 signals octet.
+ *
+ * @param _v  V.24 signals octet value.
+ *
+ * @return FC field value (0 = ready to accept frames, 1 = unable to accept frames).
+ */
+#define BT_RFCOMM_V24_SIGNALS_GET_FC(_v) FIELD_GET(BT_RFCOMM_V24_SIGNALS_FC_MASK, _v)
+
+/**
+ * @brief Clear the FC (Flow Control) field from the RFCOMM MSC V.24 signals octet.
+ *
+ * @param _v  V.24 signals octet value.
+ *
+ * @return V.24 signals octet with FC field cleared.
+ */
+#define BT_RFCOMM_V24_SIGNALS_CLR_FC(_v) ((_v) & (~BT_RFCOMM_V24_SIGNALS_FC_MASK))
+
+/**
+ * @brief Set the FC (Flow Control) field to the RFCOMM MSC V.24 signals octet.
+ *
+ * @param _v  V.24 signals octet value.
+ *
+ * @return V.24 signals octet with FC field set.
+ */
+#define BT_RFCOMM_V24_SIGNALS_SET_FC(_v) \
+	(BT_RFCOMM_V24_SIGNALS_CLR_FC(_v) | FIELD_PREP(BT_RFCOMM_V24_SIGNALS_FC_MASK, 1))
+
 #define BT_RFCOMM_MSC    0x38
 struct bt_rfcomm_msc {
 	uint8_t  dlci;
@@ -100,8 +131,6 @@ struct bt_rfcomm_rls {
 
 /* DV = 1 IC = 0 RTR = 1 RTC = 1 FC = 0 EXT = 0 */
 #define BT_RFCOMM_DEFAULT_V24_SIG 0x8d
-
-#define BT_RFCOMM_GET_FC(v24_signal) (((v24_signal) & 0x02) >> 1)
 
 #define BT_RFCOMM_SIG_MIN_MTU   23
 #define BT_RFCOMM_SIG_MAX_MTU   32767
@@ -183,3 +212,8 @@ struct bt_rfcomm_rls {
 
 /* Initialize RFCOMM signal layer */
 void bt_rfcomm_init(void);
+
+enum {
+	RFCOMM_FLAG_MSC_FC_CLEARED = 0,
+	RFCOMM_FLAG_MSC_FC_CLEAR_REQ = 1,
+};

--- a/subsys/bluetooth/host/classic/shell/spp.c
+++ b/subsys/bluetooth/host/classic/shell/spp.c
@@ -252,12 +252,14 @@ static void bt_spp_disconnected(struct bt_rfcomm_dlc *dlci)
 	bt_shell_print("SPP: disconnected (ep=%p)", ep);
 }
 
-static void bt_spp_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
+static int bt_spp_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
 {
 	struct bt_spp_endpoint *ep = SPP_EP_FROM_DLC(dlci);
 
 	bt_shell_print("SPP: rx data (ep=%p, len=%u)", ep, (unsigned int)buf->len);
 	bt_shell_hexdump(buf->data, buf->len);
+
+	return 0;
 }
 
 static int spp_sdp_set_uuid(const struct bt_uuid *uuid)

--- a/subsys/bluetooth/host/classic/shell/spp.c
+++ b/subsys/bluetooth/host/classic/shell/spp.c
@@ -80,6 +80,12 @@ struct bt_spp_endpoint {
 
 	/** Connection state (atomic) */
 	atomic_t state;
+
+	/** Hold the credit for incoming data */
+	bool hold_credit;
+
+	/** FIFO for storing received data if hold_credit is enabled */
+	struct k_fifo rx_fifo;
 };
 
 struct bt_spp_client {
@@ -247,9 +253,16 @@ static void bt_spp_connected(struct bt_rfcomm_dlc *dlci)
 static void bt_spp_disconnected(struct bt_rfcomm_dlc *dlci)
 {
 	struct bt_spp_endpoint *ep = SPP_EP_FROM_DLC(dlci);
+	struct net_buf *buf;
 
 	atomic_set(&ep->state, SPP_STATE_DISCONNECTED);
 	bt_shell_print("SPP: disconnected (ep=%p)", ep);
+
+	buf = k_fifo_get(&ep->rx_fifo, K_NO_WAIT);
+	while (buf != NULL) {
+		net_buf_unref(buf);
+		buf = k_fifo_get(&ep->rx_fifo, K_NO_WAIT);
+	}
 }
 
 static int bt_spp_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
@@ -259,7 +272,13 @@ static int bt_spp_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
 	bt_shell_print("SPP: rx data (ep=%p, len=%u)", ep, (unsigned int)buf->len);
 	bt_shell_hexdump(buf->data, buf->len);
 
-	return 0;
+	if (!ep->hold_credit) {
+		return 0;
+	}
+
+	k_fifo_put(&ep->rx_fifo, buf);
+
+	return -EINPROGRESS;
 }
 
 static int spp_sdp_set_uuid(const struct bt_uuid *uuid)
@@ -319,6 +338,7 @@ static int bt_spp_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
 	}
 
 	atomic_set(&spp->ep.state, SPP_STATE_CONNECTING);
+	k_fifo_init(&spp->ep.rx_fifo);
 	spp->ep.rfcomm_dlc.ops = &spp_rfcomm_ops;
 	spp->ep.rfcomm_dlc.mtu = SPP_RFCOMM_MTU;
 	spp->ep.rfcomm_dlc.required_sec_level = BT_SECURITY_L2;
@@ -350,11 +370,26 @@ static int bt_spp_server_register(struct bt_spp_server *server)
 	return 0;
 }
 
+static int spp_credit_limit_parse(const char *argv)
+{
+	int err = 0;
+	unsigned long value;
+
+	value = shell_strtoul(argv, 0, &err);
+	if (err != 0 || value > UINT8_MAX) {
+		bt_shell_error("SPP: invalid credit limit:%s", argv);
+		return -EINVAL;
+	}
+
+	return value;
+}
+
 static int cmd_spp_register_with_uuid(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 	struct bt_uuid_any uuid_any;
 	const char *uuid = argv[1];
+	uint8_t credit_limit = 0;
 
 	if (default_spp_server.rfcomm_server.channel != 0) {
 		shell_error(sh, "SPP: server already registered");
@@ -371,6 +406,20 @@ static int cmd_spp_register_with_uuid(const struct shell *sh, size_t argc, char 
 		return -ENOEXEC;
 	}
 
+	if (argc > 2) {
+		err = spp_credit_limit_parse(argv[2]);
+		if (err < 0) {
+			return err;
+		}
+		credit_limit = (uint8_t)err;
+	}
+	default_spp_server.ep.rfcomm_dlc.rx_credit_limit = credit_limit;
+
+	if (argc > 3 && strcmp("hold_credit", argv[3]) == 0) {
+		default_spp_server.ep.hold_credit = true;
+	} else {
+		default_spp_server.ep.hold_credit = false;
+	}
 	default_spp_server.sdp_record = &spp_sdp_rec;
 
 	err = bt_spp_server_register(&default_spp_server);
@@ -390,6 +439,7 @@ static int cmd_spp_register_with_channel(const struct shell *sh, size_t argc, ch
 {
 	int err;
 	uint8_t channel = 0;
+	uint8_t credit_limit = 0;
 
 	if (default_spp_server.rfcomm_server.channel != 0) {
 		shell_error(sh, "SPP: server already registered");
@@ -400,6 +450,21 @@ static int cmd_spp_register_with_channel(const struct shell *sh, size_t argc, ch
 	if (err < 0) {
 		shell_error(sh, "SPP: invalid RFCOMM channel:%s", argv[1]);
 		return -EINVAL;
+	}
+
+	if (argc > 2) {
+		err = spp_credit_limit_parse(argv[2]);
+		if (err < 0) {
+			return err;
+		}
+		credit_limit = (uint8_t)err;
+	}
+	default_spp_server.ep.rfcomm_dlc.rx_credit_limit = credit_limit;
+
+	if (argc > 3 && strcmp("hold_credit", argv[3]) == 0) {
+		default_spp_server.ep.hold_credit = true;
+	} else {
+		default_spp_server.ep.hold_credit = false;
 	}
 
 	(void)spp_sdp_set_uuid(BT_UUID_DECLARE_16(BT_SDP_SERIAL_PORT_SVCLASS));
@@ -425,6 +490,7 @@ static int bt_spp_connect_rfcomm(struct bt_conn *conn, struct bt_spp_endpoint *e
 {
 	int err;
 
+	k_fifo_init(&ep->rx_fifo);
 	ep->rfcomm_dlc.ops = &spp_rfcomm_ops;
 	ep->rfcomm_dlc.mtu = SPP_RFCOMM_MTU;
 	ep->rfcomm_dlc.required_sec_level = BT_SECURITY_L2;
@@ -520,6 +586,7 @@ static int bt_spp_connect(struct bt_conn *conn, struct bt_spp_client *spp)
 static int cmd_spp_connect_by_uuid(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
+	uint8_t credit_limit = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "SPP: no default connection");
@@ -537,6 +604,20 @@ static int cmd_spp_connect_by_uuid(const struct shell *sh, size_t argc, char *ar
 		return -EALREADY;
 	}
 
+	if (argc > 2) {
+		err = spp_credit_limit_parse(argv[2]);
+		if (err < 0) {
+			return err;
+		}
+		credit_limit = (uint8_t)err;
+	}
+	default_spp_client.ep.rfcomm_dlc.rx_credit_limit = credit_limit;
+
+	if (argc > 3 && strcmp("hold_credit", argv[3]) == 0) {
+		default_spp_client.ep.hold_credit = true;
+	} else {
+		default_spp_client.ep.hold_credit = false;
+	}
 	default_spp_client.ep.mode = BT_SPP_MODE_UUID;
 	default_spp_client.ep.uuid = &spp_uuid.uuid;
 
@@ -557,6 +638,7 @@ static int cmd_spp_connect_by_channel(const struct shell *sh, size_t argc, char 
 {
 	int err;
 	uint8_t channel = 0;
+	uint8_t credit_limit = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "SPP: no default connection");
@@ -575,6 +657,20 @@ static int cmd_spp_connect_by_channel(const struct shell *sh, size_t argc, char 
 		return -EALREADY;
 	}
 
+	if (argc > 2) {
+		err = spp_credit_limit_parse(argv[2]);
+		if (err < 0) {
+			return err;
+		}
+		credit_limit = (uint8_t)err;
+	}
+	default_spp_client.ep.rfcomm_dlc.rx_credit_limit = credit_limit;
+
+	if (argc > 3 && strcmp("hold_credit", argv[3]) == 0) {
+		default_spp_client.ep.hold_credit = true;
+	} else {
+		default_spp_client.ep.hold_credit = false;
+	}
 	default_spp_client.ep.mode = BT_SPP_MODE_CHANNEL;
 	default_spp_client.ep.channel = channel;
 
@@ -716,21 +812,51 @@ static int cmd_spp_rls(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_spp_recv_complete(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	struct bt_spp_endpoint *ep;
+	struct net_buf *buf;
+
+	ep = bt_spp_get_active_ep();
+	if (ep == NULL) {
+		shell_error(sh, "SPP: no active connection");
+		return -ENOEXEC;
+	}
+
+	buf = k_fifo_get(&ep->rx_fifo, K_NO_WAIT);
+	if (buf == NULL) {
+		shell_error(sh, "SPP: no inprogress buffer");
+		return -ENOEXEC;
+	}
+
+	err = bt_rfcomm_dlc_recv_complete(&ep->rfcomm_dlc, buf);
+	if (err != 0) {
+		shell_error(sh, "SPP: fail to call recv_complete (%d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	spp_cmds,
-	SHELL_CMD_ARG(register_with_channel, NULL, "<channel>",
-		      cmd_spp_register_with_channel, 2, 0),
+	SHELL_CMD_ARG(register_with_channel, NULL, "<channel> [limited credit value] [hold_credit]",
+		      cmd_spp_register_with_channel, 2, 2),
 	SHELL_CMD_ARG(register_with_uuid, NULL,
-		      "<bt-uuid16|bt-uuid32|bt-uuid128> e.g. 1101 or 00001101-0000-1000-8000-00805F9B34FB",
-		      cmd_spp_register_with_uuid, 2, 0),
-	SHELL_CMD_ARG(connect_by_channel, NULL, "<channel>",
-		      cmd_spp_connect_by_channel, 2, 0),
+		      "<bt-uuid16(e.g. 1101)|bt-uuid32|bt-uuid128(e.g. "
+		      "00001101-0000-1000-8000-00805F9B34FB)> [limited credit value] [hold_credit]",
+		      cmd_spp_register_with_uuid, 2, 2),
+	SHELL_CMD_ARG(connect_by_channel, NULL, "<channel> [limited credit value] [hold_credit]",
+		      cmd_spp_connect_by_channel, 2, 2),
 	SHELL_CMD_ARG(connect_by_uuid, NULL,
-		      "<bt-uuid16|bt-uuid32|bt-uuid128> e.g. 1101 or 00001101-0000-1000-8000-00805F9B34FB",
-		      cmd_spp_connect_by_uuid, 2, 0),
+		      "<bt-uuid16(e.g. 1101)|bt-uuid32|bt-uuid128(e.g. "
+		      "00001101-0000-1000-8000-00805F9B34FB)> [limited credit value] [hold_credit]",
+		      cmd_spp_connect_by_uuid, 2, 2),
 	SHELL_CMD_ARG(send, NULL, "send [length of packet(s)]", cmd_spp_send, 1, 1),
 	SHELL_CMD_ARG(rls, NULL, "[overrun|parity|framing]", cmd_spp_rls, 1, 1),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_spp_disconnect, 1, 0),
+	SHELL_CMD_ARG(recv_complete, NULL, HELP_NONE, cmd_spp_recv_complete, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/tests/bluetooth/classic/rfcomm_c/src/rfcomm_c.c
+++ b/tests/bluetooth/classic/rfcomm_c/src/rfcomm_c.c
@@ -94,9 +94,10 @@ static struct bt_sdp_attribute spp_attrs[] = {
 static struct bt_sdp_record spp_rec = BT_SDP_RECORD(spp_attrs);
 
 /* DLC entity */
-static void rfcomm_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
+static int rfcomm_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
 {
 	bt_shell_print("Incoming data dlc %p. Data length: %u", dlci, buf->len);
+	return 0;
 }
 
 static void rfcomm_connected(struct bt_rfcomm_dlc *dlci)

--- a/tests/bluetooth/classic/rfcomm_s/src/rfcomm_s.c
+++ b/tests/bluetooth/classic/rfcomm_s/src/rfcomm_s.c
@@ -94,9 +94,10 @@ static struct bt_sdp_attribute spp_attrs[] = {
 static struct bt_sdp_record spp_rec = BT_SDP_RECORD(spp_attrs);
 
 /* DLC entity */
-static void rfcomm_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
+static int rfcomm_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
 {
 	bt_shell_print("Incoming data dlc %p len %u", dlci, buf->len);
+	return 0;
 }
 
 static void rfcomm_connected(struct bt_rfcomm_dlc *dlci)

--- a/tests/bluetooth/tester/src/btp_rfcomm.c
+++ b/tests/bluetooth/tester/src/btp_rfcomm.c
@@ -117,7 +117,7 @@ static void rfcomm_disconnected(struct bt_rfcomm_dlc *dlc)
 	free_channel(chan);
 }
 
-static void rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
+static int rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
 	struct rfcomm_channel *chan = CONTAINER_OF(dlc, struct rfcomm_channel, dlc);
 	struct btp_rfcomm_data_received_ev *ev;
@@ -128,7 +128,7 @@ static void rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 
 	if (chan->conn == NULL) {
 		LOG_ERR("No connection");
-		return;
+		return 0;
 	}
 
 	ev_len = sizeof(*ev) + buf->len;
@@ -139,7 +139,7 @@ static void rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	if (ev_data == NULL) {
 		LOG_ERR("Failed to allocate event buffer");
 		tester_rsp_buffer_unlock();
-		return;
+		return 0;
 	}
 
 	ev = (struct btp_rfcomm_data_received_ev *)ev_data;
@@ -153,6 +153,8 @@ static void rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 
 	tester_rsp_buffer_free();
 	tester_rsp_buffer_unlock();
+
+	return 0;
 }
 
 static void rfcomm_sent(struct bt_rfcomm_dlc *dlc, int err)


### PR DESCRIPTION
* bluetooth: classic: rfcomm: add comments to bt_rfcomm_dlc structure

Add doxygen comments to all fields of the structure `bt_rfcomm_dlc` to improve code readability and help developers understand the purpose and usage of each member.

Mark internal implementation fields with `@cond INTERNAL_HIDDEN` to exclude them from public API documentation, while documenting public fields like `mtu` and `required_sec_level` that applications may need to access.

* bluetooth: classic: rfcomm: add configurable default RX credits

Add support for configurable default RX credits per DLC through the new `rx_credit_limit` field in structure `bt_rfcomm_dlc` .

Previously, all DLCs used a fixed default credit value RFCOMM_MAX_CREDITS. This change allows applications to specify a custom initial RX credit count for each DLC, providing better control over credit based flow control behavior.

When `rx_credit_limit` is set to 0, the rfcomm driver uses the internal default value. Otherwise, the specified value (the upper limit is RFCOMM_MAX_CREDITS) is used as the maximum credit count for the specific DLC.

Also, limit the maximum value of RFCOMM_MAX_CREDITS to 255 to avoid overflow.

* bluetooth: classic: rfcomm: add asynchronous receive completion API

Add support for asynchronous receive completion to allow applications to control when RFCOMM data reception is considered complete.

Change the `recv` callback in `bt_rfcomm_dlc_ops` to return an `int` instead of void. Applications can now return `-EINPROGRESS` to indicate that data processing is asynchronous and will be completed later by calling the new `bt_rfcomm_dlc_recv_complete()` API.

When `-EINPROGRESS` is returned:
- The application takes ownership of the buffer reference
- Increment `rx_credit_inprogress` counter
- For non-CFC sessions, send MSC command with FC bit set
- RX credits are decremented immediately but not refilled until `bt_rfcomm_dlc_recv_complete()` is called

Update all existing RFCOMM recv callbacks (HFP AG, HFP HF, GOEP, SPP shell, etc) to return 0 to maintain current behavior.

* bluetooth: classic: shell: spp: add flow control testing support

Add support for testing RFCOMM credit-based flow control in the SPP shell commands.

Add new optional parameters to SPP shell commands:
- `credit_limit`: Configure custom RX credit limit per DLC
- `hold_credit`: Enable asynchronous receive completion mode

When `hold_credit` is enabled:
- Received buffers are stored in a FIFO queue
- The recv callback returns `-EINPROGRESS` to hold credits
- New `recv_complete` command allows manual completion of receive operations to test credit refill behavior

Update all SPP shell commands (register_with_channel, register_with_uuid, connect_by_channel, connect_by_uuid) to accept these optional parameters for flow control testing.

Add documentation with examples demonstrating flow control testing scenarios for both server and client roles.

