### PR TITLE
boards: renesas: rza3m_ek: extend J-Link commands to TFA IPL

### DIFF
--- a/boards/renesas/rza3m_ek/board.cmake
+++ b/boards/renesas/rza3m_ek/board.cmake
@@ -2,8 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=R9A07G066M04")
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 
 if(CONFIG_BUILD_WITH_TFA)
   set(TFA_PLAT "rza3m_ek_nor")
+  if(CONFIG_TFA_MAKE_BUILD_TYPE_DEBUG)
+    set(BUILD_FOLDER "debug")
+  else()
+    set(BUILD_FOLDER "release")
+  endif()
+  set(TFA_BL2_PATH ${PROJECT_BINARY_DIR}/../tfa/${TFA_PLAT}/${BUILD_FOLDER}/${TFA_PLAT}_ipl.srec)
+
+  board_runner_args(jlink "--pre-script-cmd=r")
+  board_runner_args(jlink "--pre-script-cmd=loadfile ${TFA_BL2_PATH}")
 endif()
+
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/renesas/rza3m_ek/doc/index.rst
+++ b/boards/renesas/rza3m_ek/doc/index.rst
@@ -73,40 +73,31 @@ Supported Features
 Programming and Debugging
 *************************
 
-EK-RZ/A3M uses Initial Program Loader (IPL) to perform initial settings and copy the Zephyr image from flash to DDR SRAM for execution.
-It only needs to be written to flash at lease once before running Zephyr.
+.. zephyr:board-supported-runners::
+
+Applications for the ``rza3m_ek`` board can be built, flashed, and debugged in the usual way.
+See :ref:`build_an_application` and :ref:`application_run` for more details on building and running.
+
+The ``rza3m_ek`` board uses Initial Program Loader (IPL) to perform initial settings and
+copy the Zephyr image from flash to DDR DRAM for execution.
+The board is shipped with the Renesas IPL already programmed, so the IPL build and flash step
+below, enabled with ``-DCONFIG_BUILD_WITH_TFA=y``, is optional.
+It only needs to be written to flash once, so perform it only if the IPL is corrupted or has to be rewritten.
 
 1. For the board setup and connections, follow "3.2 Board Setup" of `Getting Started with RZ/A Flexible Software Package`_.
 
 2. Enable the IPL build with ``-DCONFIG_BUILD_WITH_TFA=y``.
-   The IPL image ``rza3m_ek_nor_ipl.bin`` is generated under zephyr/build/tfa/rza3m_ek_nor/release
+   The IPL image ``rza3m_ek_nor_ipl.srec`` is generated under zephyr/build/tfa/rza3m_ek_nor/release
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: rza3m_ek
-   :goals: build
+   :goals: build flash
    :gen-args: -DCONFIG_BUILD_WITH_TFA=y
 
 .. note::
    Currently, the IPL source code can built on Linux environment only.
    For Windows, please follow `Initial Program Loader Application Note`_
-
-3. Flash it onto the board at address 0x20000000 by Jlink command `Segger JLink Renesas R9A07G066`_
-
-.. code-block:: console
-
-   $ JLinkExe
-   J-Link> connect
-   Device> R9A07G066M04
-   TIF> s
-   Speed> [Enter]
-   J-Link> h
-   J-Link> loadfile <ipl_bin_path> 0x20000000
-
-Where ``<ipl_bin_path>`` is the path to the ``rza3m_ek_nor_ipl.bin`` in the output directory.
-
-Applications for the ``rza3m_ek`` board can be built in the usual way as
-documented in :ref:`build_an_application`.
 
 Console
 =======


### PR DESCRIPTION
Leverage the J-Link runner's `--pre-script-cmd` option to extend the flash command to IPL, so a build with `-DCONFIG_BUILD_WITH_TFA=y` writes the IPL and the Zephyr image in a single `west flash` and the user no longer types any J-Link command by hand.

Update the board documentation accordingly.