### PR TITLE
scripts: twister: let ccache reuse objects across test build directories

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1104,6 +1104,7 @@ class TwisterEnv:
         else:
             self.board_roots = options.board_root
         self.outdir = os.path.abspath(options.outdir)
+        self._setup_ccache()
 
         self.snippet_roots = [Path(ZEPHYR_BASE)]
         self.soc_roots = [Path(ZEPHYR_BASE), Path(ZEPHYR_BASE) / 'subsys' / 'testsuite']
@@ -1132,6 +1133,21 @@ class TwisterEnv:
         self.test_config = options.test_config
 
         self.alt_config_root = options.alt_config_root
+
+    def _setup_ccache(self) -> None:
+        """Let ccache reuse objects between the per-test build directories.
+
+        The build directory otherwise appears in the compiler command line and,
+        because Zephyr builds with -g, in the hash that separates debug info.
+        The trade-off is that a reused object carries the debug info of the
+        build directory it came from. That is of little consequence for test
+        builds, and is limited to files generated into the build directory, as
+        Zephyr refers to the rest by absolute path. Settings already in the
+        environment win.
+        """
+        os.environ.setdefault("CCACHE_BASEDIR", self.outdir)
+        if not {"CCACHE_HASHDIR", "CCACHE_NOHASHDIR"} & os.environ.keys():
+            os.environ["CCACHE_NOHASHDIR"] = "true"
 
     def non_default_options(self) -> dict:
         """Returns current command line options which are set to non-default values."""


### PR DESCRIPTION
Twister builds every test in its own directory, and ccache keys on that directory — it appears in the compiler command line, and in the debug-info hash because Zephyr builds with `-g`. So an object compiled for one test is never reused by another. Setting ccache's `base_dir` and `hash_dir` for the builds twister spawns fixes that.

Measured on `qemu_x86`, each run starting from an empty cache:

| test set | ccache hits | wall clock |
|---|---|---|
| 121 configurations | 1.5% → **70%** | 727 s → **488 s** (−33%) |
| 43 configurations | 1.4% → **35%** | 235 s → **198 s** (−16%) |

The benefit grows with the size of the run: the more tests get built, the more often one of them finds an object a sibling already compiled.

<details>
<summary>Reproducing the 121-configuration run</summary>

Run this once on `main` and once with the patch. `CCACHE_DIR` points at a throwaway directory so your real cache is neither used nor disturbed.

```sh
export CCACHE_DIR=$(mktemp -d)
./scripts/twister -p qemu_x86 --build-only -j 12 \
    -T tests/kernel/threads -T tests/kernel/mem_protect -T tests/kernel/timer \
    -T tests/kernel/workq -T tests/kernel/mutex -T tests/kernel/semaphore \
    -T tests/kernel/queue -T tests/kernel/fifo -T tests/subsys/settings \
    -T tests/subsys/logging/log_api
ccache -s
```
</details>

Anything already set in your environment is left alone. One trade-off worth knowing: a reused object records the build directory it was first compiled in, so its debug info points there. Zephyr passes absolute source paths, so in practice that only affects files generated into the build directory.

CI picks this up without a workflow change, though the gain is smaller wherever the cache is already warm: re-running work ccache has seen before reaches about 99% either way, in CI and locally alike. What this adds is reuse between *different* tests, which is what a first run, a new test selection, or a change that invalidates widely-included objects runs into. Changing the ccache key also invalidates the existing shared cache once, so the first run after this merges will be slower than usual.
