### PR TITLE
scripts: kconfig: exempt unsplittable lines from the length check

### DIFF
--- a/scripts/kconfig/kconfig_style.py
+++ b/scripts/kconfig/kconfig_style.py
@@ -10,8 +10,9 @@ Checks the given files against the "Basic Formatting Rules" documented in
 doc/contribute/style/kconfig.rst:
 
   1. Line length: keep lines to 100 columns or fewer. Lines containing a
-     Kconfig macro expansion '$(...)' are exempt, as such calls cannot be
-     wrapped across lines.
+     Kconfig macro expansion '$(...)' or a quoted string are exempt, as
+     neither can be split across continuation lines. Comments and 'help' text
+     are prose that can be re-wrapped, so they are not exempt.
   2. Indentation: use a flat layout with tabs - entries at column 0, properties
      at a single tab, and 'help' entry text at one tab plus two extra spaces.
      Continuation lines may use any number of tabs but must not mix in spaces.
@@ -89,6 +90,23 @@ def _leading_ws(line: str) -> str:
 def _columns(line: str) -> int:
     """Return the display width of 'line', expanding tabs."""
     return len(line.expandtabs(TAB_WIDTH))
+
+
+def _length_exempt(line: str, in_help: bool) -> bool:
+    """
+    Rule 1 exemptions: True if 'line' contains a Kconfig macro expansion
+    '$(...)' or a quoted string, neither of which can be split - kconfiglib
+    joins backslash continuations by raw concatenation, so the continuation's
+    leading whitespace would be injected into the value, corrupting it.
+    Comments and help body text are prose that can always be re-wrapped, so
+    they earn no exemption (except a macro call quoted in help text, which
+    still cannot be split).
+    """
+    if in_help:
+        return "$(" in line
+    c = _comment_start(line)
+    code = line if c == -1 else line[:c]
+    return "$(" in code or '"' in code or "'" in code
 
 
 def _continues(line: str) -> bool:
@@ -233,13 +251,9 @@ def lint(lines: list[str]) -> list[Issue]:
         if in_help:
             help_body.add(i)
 
-        # Rule 1: line length. Lines containing a Kconfig macro expansion
-        # '$(...)' are exempt: such calls cannot be wrapped, as kconfiglib
-        # joins backslash continuations by raw concatenation and the
-        # continuation's leading whitespace would be injected into the macro
-        # arguments, corrupting them.
+        # Rule 1: line length.
         cols = _columns(line)
-        if cols > MAX_COLUMNS and "$(" not in line:
+        if cols > MAX_COLUMNS and not _length_exempt(line, in_help):
             issues.append(
                 Issue(
                     lineno,

--- a/scripts/kconfig/kconfig_style_test.py
+++ b/scripts/kconfig/kconfig_style_test.py
@@ -21,13 +21,43 @@ def _file_rules(tmp_path, text):
     return {issue.rule for issue in kconfig_style.check_file(path)}
 
 
-# Rule 1: line length, with the $(...) macro exemption.
+# Rule 1: line length, with exemptions for lines that cannot be wrapped.
 def test_line_too_long_flagged():
     assert _rules("config " + "A" * 110 + "\n") == {"line-too-long"}
 
 
 def test_line_too_long_macro_exempt():
-    assert not _rules('config X\n\tdefault "$(' + "y" * 110 + ')"\n')
+    # An unquoted macro call, so the exemption is not down to the quotes.
+    assert not _rules("config X\n\tdepends on $(" + "y" * 110 + ")\n")
+
+
+def test_line_too_long_string_exempt():
+    # Quoted strings cannot be split across continuation lines.
+    assert not _rules('config X\n\tdefault "' + "y" * 110 + '" if Z\n')
+    assert not _rules("config X\n\tdefault '" + "y" * 110 + "' if Z\n")
+
+
+def test_line_too_long_expression_flagged():
+    # Expressions can be wrapped, so lines without a string are still flagged.
+    assert _rules("config X\n\tdepends on A" + " && B" * 25 + "\n") == {"line-too-long"}
+
+
+def test_line_too_long_comment_flagged():
+    # Comments are prose that can be re-wrapped; quotes inside them are not an
+    # exemption, whether the comment fills the line or trails an expression.
+    assert _rules('# See "docs" ' + "y " * 60 + "\n") == {"line-too-long"}
+    assert _rules('config X\n\tdepends on A # see "docs" ' + "y " * 50 + "\n") == {"line-too-long"}
+
+
+def test_line_too_long_help_text_flagged():
+    # Help body text is prose that can be re-wrapped, even when it quotes
+    # something.
+    assert _rules('config X\n\thelp\n\t  Set to "y" ' + "y " * 60 + "\n") == {"line-too-long"}
+
+
+def test_line_too_long_help_macro_exempt():
+    # A macro call cited in help text still cannot be split.
+    assert not _rules("config X\n\thelp\n\t  Uses $(" + "y" * 110 + ").\n")
 
 
 # Rule 2: indentation (tabs, flat layout, help body, continuations).


### PR DESCRIPTION
A long quoted value (e.g. a path) or '$(...)' macro cannot be brought
under the 100-column limit: kconfiglib joins backslash continuations by
raw concatenation, so splitting the value injects the continuation's
leading whitespace into it. Exempt lines containing a quoted string
(single or double) too, not just macros. Comments and 'help' text are
re-wrappable prose and stay subject to the limit (a macro cited in help
text stays exempt, as it still cannot be split).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116922