### PR TITLE
dts: intel_adsp: align boards to new CPU deferral config

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -26,6 +26,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -33,6 +34,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d3>;
+			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -26,6 +26,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -33,6 +34,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu3: cpu@3 {
@@ -40,6 +42,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu4: cpu@4 {
@@ -47,6 +50,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <4>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -26,6 +26,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -33,6 +34,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -13,6 +13,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu4: cpu@4 {
@@ -20,6 +21,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <4>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 	};
 

--- a/dts/xtensa/intel/intel_adsp_ace40.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace40.dtsi
@@ -26,6 +26,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace40_nvl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace40_nvl.dtsi
@@ -13,6 +13,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu3: cpu@3 {
@@ -20,6 +21,7 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
 			cpu-power-states = <&d0i3 &d3>;
+			zephyr,deferred-start;
 		};
 	};
 

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -26,6 +26,7 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 			cpu-power-states = <&d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -33,6 +34,7 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <2>;
 			cpu-power-states = <&d3>;
+			zephyr,deferred-start;
 		};
 
 		cpu3: cpu@3 {
@@ -40,6 +42,7 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <3>;
 			cpu-power-states = <&d3>;
+			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -26,6 +26,7 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 			cpu-power-states = <&d3>;
+			zephyr,deferred-start;
 		};
 
 		power-states {


### PR DESCRIPTION
On Intel ADSP platforms startup of secondary cores must be deferred till the IPC communication with the host driver. Previously this was achieved through SMP_BOOT_DELAY option. Recently this option has been removed. This change is aimed at maintaining legacy behavior by using new, more granular dts approach.

EDIT: This is the original patch that removed SMP_BOOT_DELAY option: 7a72151634e8062acf64e461587dd0d8736e2be6