### PR TITLE
boards: openocd: add runner for stm32n6 board

### DIFF
--- a/boards/common/openocd-stm32.board.cmake
+++ b/boards/common/openocd-stm32.board.cmake
@@ -17,6 +17,8 @@ elseif(CONFIG_SOC_SERIES_STM32F2X OR
        CONFIG_SOC_SERIES_STM32F4X OR
        CONFIG_SOC_SERIES_STM32F7X)
   board_runner_args(openocd "--cmd-erase=stm32f2x mass_erase 0")
+elseif(CONFIG_SOC_SERIES_STM32N6X)
+  board_runner_args(openocd "--cmd-erase=stm32n6x mass_erase 0")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/st/stm32n6570_dk/board.cmake
+++ b/boards/st/stm32n6570_dk/board.cmake
@@ -25,4 +25,5 @@ board_runner_args(stlink_gdbserver "--extload=MX66UW1G45G_STM32N6570-DK.stldr")
 
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)

--- a/boards/st/stm32n6570_dk/support/openocd.cfg
+++ b/boards/st/stm32n6570_dk/support/openocd.cfg
@@ -1,0 +1,18 @@
+source [find interface/stlink-dap.cfg]
+
+transport select dapdirect_swd
+
+source [find target/stm32n6x.cfg]
+
+reset_config srst_only
+
+$_TARGETNAME configure -event gdb-attach {
+	echo "Debugger attaching: halting execution"
+	reset init
+	gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+	echo "Debugger detaching: resuming execution"
+	resume
+}


### PR DESCRIPTION
OpenOCD supports STM32N6 SoC series natively.  Add an OpenOCD runner for STM32N6 SoC series.