### PR TITLE
boards: nxp: frdm_imxrt1186: disable FlexSPI1 node on CM33

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -163,6 +163,18 @@ p3t1755dp_ard_i2c_interface: &lpi2c3 {};
 	status = "okay";
 };
 
+&flexspi {
+	/*
+	 * FlexSPI1 is configured by the Boot ROM for HyperRAM (via XMCD).
+	 * Reinitializing the controller overwrites the Boot ROM configuration
+	 * and makes HyperRAM inaccessible. Enable this node via an overlay only
+	 * when the application explicitly manages FlexSPI1 initialization, or
+	 * when CM7 executes XIP from HyperRAM (the XIP guard preserves the
+	 * Boot ROM configuration in that case).
+	 */
+	status = "disabled";
+};
+
 &flexspi2 {
 	/*
 	 * If booting with XIP from FlexSPI flash, the flash memory will be initialized by the

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.dts
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.dts
@@ -55,10 +55,6 @@
 	current-speed = <115200>;
 };
 
-&flexspi {
-	status = "okay";
-};
-
 &flexspi2 {
 	status = "okay";
 };


### PR DESCRIPTION
FlexSPI1 is configured by the Boot ROM for HyperRAM, that is the default SRAM for CM33. Enabling the flexspi node in the device tree is harmless in the default config, but any Kconfig that selects MEMC_MCUX_FLEXSPI (e.g. FLASH_MCUX_FLEXSPI_NOR or MEMC) will instantiate a driver for FlexSPI1, causing FLEXSPI_Init() to run during boot. This reinitializes the controller with driver defaults, overwriting the Boot ROM HyperRAM configuration and leading to access faults. The XIP guard does not protect FlexSPI1 because CM33 boots from FlexSPI2. Remove the flexspi status override from the default device tree.