### PR TITLE
kernel: queue: skip blocking trace for no-wait get

### DIFF
--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -338,8 +338,6 @@ void *z_impl_k_queue_get(struct k_queue *queue, k_timeout_t timeout)
 		return data;
 	}
 
-	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_queue, get, queue, timeout);
-
 	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		k_spin_unlock(&queue->lock, key);
 
@@ -347,6 +345,8 @@ void *z_impl_k_queue_get(struct k_queue *queue, k_timeout_t timeout)
 
 		return NULL;
 	}
+
+	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_queue, get, queue, timeout);
 
 	int ret = z_pend_curr(&queue->lock, key, &queue->wait_q, timeout);
 

--- a/tests/subsys/tracing/ctf_trace/pytest/test_ctf_trace.py
+++ b/tests/subsys/tracing/ctf_trace/pytest/test_ctf_trace.py
@@ -75,6 +75,8 @@ def test_ctf_trace(dut):
     missing = [e for e in EXPECTED_EVENTS if e not in seen]
     assert not missing, f"missing expected CTF events {missing}; decoded types: {sorted(seen)}"
 
+    assert "queue_get_blocking" not in names, "K_NO_WAIT queue get emitted a blocking event"
+
     # Field sanity: queue_get_exit must carry the object id, timeout and return value.
     get_exit = next(e for e in tr.events if e.name == "queue_get_exit")
     for field in ("id", "timeout", "ret"):

--- a/tests/subsys/tracing/ctf_trace/src/main.c
+++ b/tests/subsys/tracing/ctf_trace/src/main.c
@@ -57,6 +57,8 @@ int main(void)
 	k_queue_init(&queue);
 	k_queue_append(&queue, &item);
 	(void)k_queue_get(&queue, K_NO_WAIT);
+	/* Exercise the empty no-wait path without emitting a blocking event. */
+	(void)k_queue_get(&queue, K_NO_WAIT);
 
 	k_fifo_init(&fifo);
 	k_fifo_put(&fifo, &item);


### PR DESCRIPTION
## Problem

When `k_queue_get()` is called on an empty queue with `K_NO_WAIT`, it emits the blocking tracepoint before immediately returning `NULL`.
This records blocking behaviour that did not occur and invokes the tracing backend on a non-blocking polling path.

## Root cause

`z_impl_k_queue_get()` emitted `SYS_PORT_TRACING_OBJ_FUNC_BLOCKING()` before checking whether the timeout was `K_NO_WAIT`.

## Change

Move the blocking tracepoint below the no-wait return so it is emitted only when the calling thread can actually pend.
Extend the CTF tracing test with an empty no-wait queue get and verify that it does not produce `queue_get_blocking`.

Non-empty gets and genuinely blocking gets are unchanged.

## Performance

A deterministic CTF comparison produced:

| Metric | Baseline | Patched |
|---|---:|---:|
| Events | 70 | 69 |
| Distinct event types | 53 | 52 |
| Trace stream | 1519 bytes | 1501 bytes |

This removes one tracing-backend invocation and one false event per empty `K_NO_WAIT` poll. No physical-target timing is claimed.

## Footprint

The host-GNU `z_impl_k_queue_get` text section remained 215 bytes, and the complete `queue.c` object size was unchanged. No state or allocation was added.

## Testing

- `kernel.queue` on `native_sim/native/64`: 21/21 test cases passed with no warnings
- CTF pytest harness on `native_sim/native/64`: passed
- Zephyr checkpatch: 0 errors and 0 warnings
- Gitlint and DCO validation: passed
- Changed-line clang-format, Ruff, Pylint, Python compatibility, licence, encoding, and diff-integrity checks: passed