### PR TITLE
drivers: ethernet: adin2111: drop packets when allocation fails

### DIFF
--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -325,21 +325,21 @@ int eth_adin2111_oa_data_read(const struct device *dev, const uint16_t port_idx)
 							   K_MSEC(CONFIG_ETH_ADIN2111_TIMEOUT));
 			if (!pkt) {
 				LOG_ERR("OA RX: cannot allocate packet space, skipping.");
-				return -ENOMEM;
+				goto update_pos;
 			}
 			/* Skipping CRC32 */
 			ret = net_pkt_write(pkt, ctx->buf, ctx->scur - sizeof(uint32_t));
 			if (ret < 0) {
 				net_pkt_unref(pkt);
 				LOG_ERR("Failed to write pkt, scur %d, err %d", ctx->scur, ret);
-				return ret;
+				goto update_pos;
 			}
 			ret = net_recv_data(iface, pkt);
 			if (ret < 0) {
 				net_pkt_unref(pkt);
 				LOG_ERR("Port %u failed to enqueue frame to RX queue, %d",
 					port_idx, ret);
-				return ret;
+				goto update_pos;
 			}
 		}
 update_pos:


### PR DESCRIPTION
158df8d088316cdae20816fc07703892280b2acb was a hotfix for an out-of-bounds write security issue. At the time I didn't understand the root cause and addressed the symptom instead.

The root cause is, that the Zephyr network stack runs out of memory and net_pkt_rx_alloc_with_buffer returns NULL. This made the function return with an error without updating any of the state variables or processing the remaining chunks that were received via spi. This caused the first chunks(s) of the next frame to be dropped - including its start-of-frame flag which informs us, that the previous frame has ended. The result of that was, that the rest of the new frame was appended to the previous frame
- resulting in a single frame that's bigger than expected.

When that happens, you see this error message: OA RX: cannot allcate packet space, skipping.

This commit addresses this by dropping the packet and continuing to process the remaining chunks. The state will be reset as soon as the SV flag is seen.