### PR TITLE
dts: bindings: mspi: Rename compatible st,nor to st,nor-mspi

### DIFF
--- a/boards/shields/x_nucleo_pgeez1/boards/nucleo_u575zi_q.overlay
+++ b/boards/shields/x_nucleo_pgeez1/boards/nucleo_u575zi_q.overlay
@@ -19,7 +19,7 @@
 };
 
 &m95p32_x_nucleo_pgeez1 {
-	compatible = "st,nor", "jedec,nor";
+	compatible = "st,nor-mspi", "jedec,nor";
 	st,mem-type = "macronix";
 
 	partitions {

--- a/drivers/mspi/mspi_stm32.h
+++ b/drivers/mspi/mspi_stm32.h
@@ -34,7 +34,7 @@
 #define MSPI_STM32_WRITE_REG_MAX_TIME          40U
 
 #define MSPI_STM32_IS_SUPPORTED_CHILD(child) \
-DT_NODE_HAS_COMPAT(child, st_nor) || \
+DT_NODE_HAS_COMPAT(child, st_nor_mspi) || \
 DT_NODE_HAS_COMPAT(child, st_psram_device)
 
 #define MSPI_STM32_HAS_SUPPORTED_CHILD(index) \

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -1479,7 +1479,8 @@ static int mspi_stm32_ospi_pm_action(const struct device *dev, enum pm_device_ac
 		     "Unsupported OSPI instance: DTS node must be octospi1 or octospi2");          \
                                                                                                    \
 	BUILD_ASSERT(MSPI_STM32_HAS_SUPPORTED_CHILD(index),                                        \
-		     "MSPI controller must have a child with compatible st,nor/st,psram-device");  \
+		     "MSPI controller must have a child with compatible st,nor-mspi or "           \
+		     "st,psram-device");                                                           \
                                                                                                    \
 	MSPI_STM32_VALIDATE_MEMTYPE(MSPI_STM32_MEMTYPE_TOKEN(index));                              \
                                                                                                    \

--- a/dts/bindings/mspi/st,nor-mspi.yaml
+++ b/dts/bindings/mspi/st,nor-mspi.yaml
@@ -3,7 +3,7 @@
 
 description: STM32 memory device on mspi bus
 
-compatible: "st,nor"
+compatible: "st,nor-mspi"
 
 include: jedec,nor-mspi.yaml
 

--- a/samples/application_development/code_relocation_nocopy/boards/b_u585i_iot02a.overlay
+++ b/samples/application_development/code_relocation_nocopy/boards/b_u585i_iot02a.overlay
@@ -37,7 +37,7 @@
 			status = "okay";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "st,nor", "mxicy,mx25u", "jedec,nor";
+				compatible = "st,nor-mspi", "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Megabits */
 				mspi-max-frequency = <DT_FREQ_M(50)>;

--- a/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
@@ -39,7 +39,7 @@
 			status = "okay";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "st,nor", "mxicy,mx25u", "jedec,nor";
+				compatible = "st,nor-mspi", "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Megabits */
 				mspi-max-frequency = <DT_FREQ_M(50)>;

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
@@ -38,7 +38,7 @@
 			dma-names = "tx", "rx";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "st,nor", "mxicy,mx25u", "jedec,nor";
+				compatible = "st,nor-mspi", "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Mbits */
 				status = "okay";


### PR DESCRIPTION
Rename DT compatible ID `"st,nor"` to `"st,nor-mspi"` since this compatible applies to MSPI controlled NOR flashes device, as current DT bindings YAML file path shows: `dts/bindings/mspi/st,nor-mspi.yaml`.

Update the Zephyr file tree accordingly.