### PR TITLE
net: mdns: Answer a legacy unicast query the way RFC 6762 asks

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -56,6 +56,11 @@ extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 
 #define MDNS_TTL CONFIG_MDNS_RESPONDER_TTL /* In seconds */
 
+/* RFC 6762 6.7: an answer to a legacy unicast query may be cached by something
+ * that knows nothing about multicast DNS, so it is given a short life.
+ */
+#define MDNS_LEGACY_TTL 10 /* In seconds */
+
 #if defined(CONFIG_NET_INTERFACE_NAME_LEN)
 #define INTERFACE_NAME_LEN CONFIG_NET_INTERFACE_NAME_LEN
 #else
@@ -353,6 +358,31 @@ static int set_ttl_hop_limit(int sock, int level, int option, int new_limit)
 	return zsock_setsockopt(sock, level, option, &new_limit, sizeof(new_limit));
 }
 
+/* A querier that did not ask from port 5353 is not another multicast DNS
+ * responder but something making a one-off lookup, a resolver library or a
+ * command line tool. RFC 6762 6.7 calls that a legacy unicast query and asks
+ * for an answer such a querier can understand: sent back to it alone, with the
+ * question repeated and the identifier it used, without the cache flush bit,
+ * and with a short time to live so that whatever caches it does not hold the
+ * answer long.
+ */
+static bool is_legacy_query(const struct net_sockaddr *src)
+{
+	if (src == NULL) {
+		return false;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && src->sa_family == NET_AF_INET) {
+		return net_sin(src)->sin_port != net_htons(MDNS_LISTEN_PORT);
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) && src->sa_family == NET_AF_INET6) {
+		return net_sin6(src)->sin6_port != net_htons(MDNS_LISTEN_PORT);
+	}
+
+	return false;
+}
+
 int setup_dst_addr(int sock, net_sa_family_t family,
 		   struct net_sockaddr *src, net_socklen_t src_len,
 		   struct net_sockaddr *dst, net_socklen_t *dst_len)
@@ -360,7 +390,7 @@ int setup_dst_addr(int sock, net_sa_family_t family,
 	int ret;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
-		if ((src != NULL) && (net_sin(src)->sin_port != net_htons(MDNS_LISTEN_PORT))) {
+		if (is_legacy_query(src)) {
 			memcpy(dst, src, src_len);
 			*dst_len = src_len;
 		} else {
@@ -373,7 +403,7 @@ int setup_dst_addr(int sock, net_sa_family_t family,
 			}
 		}
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
-		if ((src != NULL) && (net_sin6(src)->sin6_port != net_htons(MDNS_LISTEN_PORT))) {
+		if (is_legacy_query(src)) {
 			memcpy(dst, src, src_len);
 			*dst_len = src_len;
 		} else {
@@ -405,7 +435,12 @@ static int get_socket(net_sa_family_t family)
 	return ret;
 }
 
-static void setup_dns_hdr(uint8_t *buf, uint16_t answers)
+/* dns_id and questions are zero for a multicast answer, which carries neither
+ * an identifier nor the question, RFC 6762 18.1. An answer to a legacy unicast
+ * query carries both, RFC 6762 6.7.
+ */
+static void setup_dns_hdr(uint8_t *buf, uint16_t answers, uint16_t dns_id,
+			  uint16_t questions)
 {
 	struct dns_header *hdr = (struct dns_header *)buf;
 	uint16_t flags;
@@ -415,9 +450,9 @@ static void setup_dns_hdr(uint8_t *buf, uint16_t answers)
 	flags = BIT(15);  /* This is response */
 	flags |= BIT(10); /* Authoritative Answer */
 
-	UNALIGNED_PUT(0, UNALIGNED_MEMBER_ADDR(hdr, id)); /* Identifier, RFC 6762 ch 18.1 */
+	UNALIGNED_PUT(net_htons(dns_id), UNALIGNED_MEMBER_ADDR(hdr, id));
 	UNALIGNED_PUT(net_htons(flags), UNALIGNED_MEMBER_ADDR(hdr, flags));
-	UNALIGNED_PUT(0, UNALIGNED_MEMBER_ADDR(hdr, qdcount));
+	UNALIGNED_PUT(net_htons(questions), UNALIGNED_MEMBER_ADDR(hdr, qdcount));
 	UNALIGNED_PUT(net_htons(answers), UNALIGNED_MEMBER_ADDR(hdr, ancount));
 	UNALIGNED_PUT(0, UNALIGNED_MEMBER_ADDR(hdr, nscount));
 	UNALIGNED_PUT(0, UNALIGNED_MEMBER_ADDR(hdr, arcount));
@@ -429,9 +464,12 @@ static int init_name_labels(struct net_buf *query)
 	char *prev = query->data + DNS_MSG_HEADER_SIZE;
 
 	/* Verify the buffer has enough space to store header and query name
-	 * + 2 for the length of the first label and the terminator byte
+	 * + 2 for the length of the first label and the terminator byte,
+	 * + the type and class of an echoed question, which an answer to a
+	 * legacy unicast query appends straight after the name.
 	 */
-	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE + 2)) {
+	if ((net_buf_max_len(query) - query->len) <
+	    (DNS_MSG_HEADER_SIZE + 2 + DNS_QTYPE_LEN + DNS_QCLASS_LEN)) {
 		return -ENOBUFS;
 	}
 
@@ -462,6 +500,7 @@ struct answer_ctx {
 	enum dns_rr_type qtype;
 	int answer_count;
 	uint16_t name_offset;
+	bool legacy;
 };
 
 static void add_a_aaaa_answer(struct answer_ctx *ctx, uint32_t ttl,
@@ -486,8 +525,16 @@ static void add_a_aaaa_answer(struct answer_ctx *ctx, uint32_t ttl,
 	}
 
 	net_buf_add_be16(ctx->query, ctx->qtype);
-	/* Bit 15 tells to flush the cache */
-	net_buf_add_be16(ctx->query, DNS_CLASS_IN | BIT(15));
+
+	/* The cache flush bit tells a multicast DNS cache to drop what it
+	 * held for this name. It must not be set in an answer to a legacy
+	 * unicast query, RFC 6762 10.2, because whatever cached that answer
+	 * is not a multicast DNS cache and would read bit 15 as part of the
+	 * class.
+	 */
+	net_buf_add_be16(ctx->query,
+			 ctx->legacy ? DNS_CLASS_IN
+				     : (DNS_CLASS_IN | DNS_CLASS_FLUSH));
 	net_buf_add_be32(ctx->query, ttl);
 	net_buf_add_be16(ctx->query, addr_len);
 	net_buf_add_mem(ctx->query, addr, addr_len);
@@ -518,27 +565,44 @@ static void answer_addr_cb(struct net_if *iface, struct net_if_addr *ifaddr,
 
 	/* First answer contains full DNS name (already encoded). Consecutive
 	 * answers use label compression and encode label pointers.
+	 *
+	 * When the question is echoed, the name at that offset belongs to the
+	 * question rather than to the first answer, so every answer points at
+	 * it, the first one included.
 	 */
-	if (ctx->answer_count == 0) {
+	if (ctx->answer_count == 0 && !ctx->legacy) {
 		include_name_ptr = false;
 	}
 
-	add_a_aaaa_answer(ctx, MDNS_TTL, addr_len, addr, include_name_ptr);
+	add_a_aaaa_answer(ctx, ctx->legacy ? MDNS_LEGACY_TTL : MDNS_TTL,
+			  addr_len, addr, include_name_ptr);
 }
 
 static int create_answer(struct net_buf *query, enum dns_rr_type qtype,
-			 struct net_if *iface)
+			 struct net_if *iface, bool legacy, uint16_t dns_id)
 {
 	struct answer_ctx ctx = {
 		.query = query,
 		.qtype = qtype,
 		.name_offset = DNS_MSG_HEADER_SIZE,
+		.legacy = legacy,
 	};
 	int ret;
 
 	ret = init_name_labels(query);
 	if (ret < 0) {
 		return ret;
+	}
+
+	if (legacy) {
+		/* Repeat the question, RFC 6762 6.7. The name is already
+		 * there, written by init_name_labels() at the offset the
+		 * answers point back to, so only its type and class are
+		 * missing. The class is written plain: the unicast response
+		 * bit a querier may have set in it has no meaning coming back.
+		 */
+		net_buf_add_be16(query, qtype);
+		net_buf_add_be16(query, DNS_CLASS_IN);
 	}
 
 	if ((qtype == DNS_RR_TYPE_A) && IS_ENABLED(CONFIG_NET_IPV4)) {
@@ -554,7 +618,12 @@ static int create_answer(struct net_buf *query, enum dns_rr_type qtype,
 		return -ENOMEM;
 	}
 
-	setup_dns_hdr(query->data, ctx.answer_count);
+	/* A multicast answer carries neither an identifier nor the question:
+	 * RFC 6762 18.1 has the identifier zero on transmission and ignored on
+	 * reception, because there is no one querier it belongs to.
+	 */
+	setup_dns_hdr(query->data, ctx.answer_count, legacy ? dns_id : 0U,
+		      legacy ? 1U : 0U);
 
 	return 0;
 }
@@ -565,7 +634,8 @@ static int send_response(int sock,
 			 size_t addrlen,
 			 struct net_buf *query,
 			 enum dns_rr_type qtype,
-			 struct net_if *recv_if)
+			 struct net_if *recv_if,
+			 uint16_t dns_id)
 {
 	struct net_if *iface;
 	net_socklen_t dst_len;
@@ -596,7 +666,7 @@ static int send_response(int sock,
 		return -EINVAL;
 	}
 
-	ret = create_answer(query, qtype, iface);
+	ret = create_answer(query, qtype, iface, is_legacy_query(src_addr), dns_id);
 	if (ret != 0) {
 		return -ENOMEM;
 	}
@@ -797,6 +867,7 @@ static int dns_read(int sock,
 	int family = src_addr->sa_family;
 	struct net_buf *result;
 	struct dns_msg_t dns_msg;
+	uint16_t dns_id = 0U;
 	int data_len;
 	int queries;
 	int ret;
@@ -815,7 +886,7 @@ static int dns_read(int sock,
 	dns_msg.msg = dns_data->data;
 	dns_msg.msg_size = data_len;
 
-	ret = mdns_unpack_query_header(&dns_msg, NULL);
+	ret = mdns_unpack_query_header(&dns_msg, &dns_id);
 	if (ret < 0) {
 		goto quit;
 	}
@@ -866,7 +937,7 @@ static int dns_read(int sock,
 				family == NET_AF_INET ? "IPv4" : "IPv6", "query",
 				hostname, ".local");
 			send_response(sock, family, src_addr, addrlen,
-				      result, qtype, recv_if);
+				      result, qtype, recv_if, dns_id);
 		} else if (IS_ENABLED(CONFIG_MDNS_RESPONDER_DNS_SD)
 			&& qtype == DNS_RR_TYPE_PTR) {
 			send_sd_response(sock, family, src_addr, addrlen, result, recv_if);
@@ -2112,7 +2183,7 @@ static struct net_buf *create_unsolicited_mdns_answer(struct net_if *iface,
 		return NULL;
 	}
 
-	setup_dns_hdr(answer->data, 1);
+	setup_dns_hdr(answer->data, 1, 0, 0);
 	net_buf_add(answer, DNS_MSG_HEADER_SIZE);
 
 	answer_count = 0U;

--- a/tests/net/lib/mdns_responder/src/main.c
+++ b/tests/net/lib/mdns_responder/src/main.c
@@ -234,7 +234,12 @@ static int sender_iface(const struct device *dev, struct net_pkt *pkt)
 	if (test_started) {
 		hdr = NET_IPV6_HDR(pkt);
 
-		if (net_ipv6_addr_cmp_raw(hdr->dst, mdns_server_ipv6_addr)) {
+		/* Answers to a query from port 5353 go to the group; an answer
+		 * to a one-off lookup goes back to the querier alone, so both
+		 * destinations have to be picked up here.
+		 */
+		if (net_ipv6_addr_cmp_raw(hdr->dst, mdns_server_ipv6_addr) ||
+		    net_ipv6_addr_cmp_raw(hdr->dst, (const uint8_t *)&sender_ll_addr)) {
 			/* Multi-homed test: grab the outgoing mDNS response separately. */
 			if (mh_capture_active && mh_response_pkt == NULL &&
 			    mh_mdns_udp_pkt(pkt)) {
@@ -430,7 +435,11 @@ static void cleanup(void *d)
 	mh_reset_capture();
 }
 
-static void send_msg(const uint8_t *data, size_t len)
+/* A query from port 5353 is one multicast DNS responder talking to another; a
+ * query from anywhere else is a one-off lookup, which RFC 6762 6.7 answers
+ * differently. Tests that care say which they are sending.
+ */
+static void send_msg_from_port(const uint8_t *data, size_t len, uint16_t src_port)
 {
 	struct net_pkt *pkt;
 	int res;
@@ -448,7 +457,7 @@ static void send_msg(const uint8_t *data, size_t len)
 	res = net_pkt_write(pkt, ipv6_hdr_rest, sizeof(ipv6_hdr_rest));
 	zassert_equal(res, 0, "pkt write for rest of the header failed");
 
-	res = net_pkt_write_be16(pkt, 5353);
+	res = net_pkt_write_be16(pkt, src_port);
 	zassert_equal(res, 0, "pkt write for UDP src port failed");
 
 	res = net_pkt_write_be16(pkt, 5353);
@@ -466,6 +475,11 @@ static void send_msg(const uint8_t *data, size_t len)
 
 	res = net_recv_data(iface1, pkt);
 	zassert_equal(res, 0, "net_recv_data() failed");
+}
+
+static void send_msg(const uint8_t *data, size_t len)
+{
+	send_msg_from_port(data, len, 5353);
 }
 
 static struct dns_sd_rec *alloc_ext_record(const char *instance, const char *service,
@@ -679,6 +693,67 @@ ZTEST(test_mdns_responder, test_basic_query)
 	zassert_ok(res, "Did not receive a response");
 
 	check_basic_query_resp(response_pkts[0]);
+}
+
+/* RFC 6762 6.7: a query that did not come from port 5353 is a one-off lookup,
+ * and the answer to it has to be one a conventional resolver understands. It
+ * repeats the identifier and the question, leaves the cache flush bit clear,
+ * and carries a short time to live, because whatever caches it is not a
+ * multicast DNS cache.
+ */
+ZTEST(test_mdns_responder, test_legacy_unicast_query)
+{
+	static const uint16_t query_id = 0x1234;
+	static uint8_t zephyr_local_query[] = {
+		/* Header, with an identifier the answer has to repeat */
+		0x12, 0x34, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		/* zephyr.local */
+		0x06, 0x7a, 0x65, 0x70, 0x68, 0x79, 0x72, 0x05, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x00,
+		/* AAAA record */
+		0x00, 0x1c, 0x00, 0x01
+	};
+	struct dns_header resp_header;
+	struct dns_rr resp_record;
+	uint16_t qtype;
+	uint16_t qclass;
+	struct net_pkt *pkt;
+
+	/* Anything other than 5353 makes this a one-off lookup */
+	send_msg_from_port(zephyr_local_query, sizeof(zephyr_local_query), 45678);
+
+	zassert_ok(k_sem_take(&wait_data, RESPONSE_TIMEOUT), "Did not receive a response");
+
+	pkt = response_pkts[0];
+	net_pkt_cursor_init(pkt);
+	net_pkt_set_overwrite(pkt, true);
+	zassert_ok(net_pkt_skip(pkt, NET_IPV6UDPH_LEN), "net_pkt skip failed");
+
+	zassert_ok(net_pkt_read(pkt, &resp_header, sizeof(resp_header)), "net_pkt read failed");
+	zassert_equal(net_ntohs(resp_header.id), query_id,
+		      "Answer carries id 0x%04x, the query used 0x%04x",
+		      net_ntohs(resp_header.id), query_id);
+	zassert_equal(net_ntohs(resp_header.qdcount), 1,
+		      "Answer does not repeat the question");
+	zassert_true(net_ntohs(resp_header.ancount) >= 1, "Answer carries no records");
+
+	/* The repeated question */
+	validate_label(pkt, "zephyr", false);
+	validate_label(pkt, "local", true);
+	zassert_ok(net_pkt_read_be16(pkt, &qtype), "net_pkt read failed");
+	zassert_equal(qtype, DNS_RR_TYPE_AAAA, "Repeated question has the wrong type");
+	zassert_ok(net_pkt_read_be16(pkt, &qclass), "net_pkt read failed");
+	zassert_equal(qclass, DNS_CLASS_IN, "Repeated question has the wrong class");
+
+	/* The first answer, which names the question rather than repeating it */
+	skip_labels(pkt);
+	zassert_ok(net_pkt_read(pkt, &resp_record, sizeof(resp_record)), "net_pkt read failed");
+	zassert_equal(net_ntohs(resp_record.type), DNS_RR_TYPE_AAAA, "Invalid record type");
+	zassert_equal(net_ntohs(resp_record.class_), DNS_CLASS_IN,
+		      "Answer class is 0x%04x; the cache flush bit does not belong here",
+		      net_ntohs(resp_record.class_));
+	zassert_true(net_ntohl(resp_record.ttl) <= 10,
+		     "Answer TTL is %u, which is too long to hand to a cache that "
+		     "knows nothing of multicast DNS", net_ntohl(resp_record.ttl));
 }
 
 static void check_basic_dns_sd_query_resp(struct net_pkt *pkt)


### PR DESCRIPTION
A query that did not come from port 5353 is not another multicast DNS responder but something making a one-off lookup: a resolver library, or a command line tool. RFC 6762 6.7 calls that a legacy unicast query and asks for an answer such a querier can understand.

The responder already sent those answers back to the querier alone, and the test that decides so has sat in setup_dst_addr() all along. It was simply never passed to the code that builds the answer, so the answer itself stayed in multicast form: identifier zero, no question section, the cache flush bit set, and the full ten minute time to live.

For a querier that speaks multicast DNS none of that matters, because RFC 6762 18.1 has it ignore the identifier and it knows what it asked. For anything else all four matter. A conventional resolver matches an answer to its question by the identifier and the question coming back, and has neither here. Bit 15 of the class means "flush your cache" only to a multicast DNS cache; to anything else it is part of the class, and the answer is for a class nobody uses. And a ten minute lifetime is far too long to hand to a cache that will not hear the announcements that would correct it.

So propagate the test, and give an answer to such a query the shape a conventional one has. Answers to a querier on port 5353 are unchanged, identifier included: 18.1 requires that one to be zero.

The DNS-SD side of the responder builds its own messages in dns_sd.c and still answers in multicast form. Doing the same there means reworking the compression offsets those encoders compute from a fixed header size, and is left for its own change.

Assisted-by: Claude:claude-opus-5