### PR TITLE
tests: drivers: flash: common: Remove duplicated test

### DIFF
--- a/tests/drivers/flash/common/tests.yaml
+++ b/tests/drivers/flash/common/tests.yaml
@@ -303,6 +303,7 @@ tests:
       fixture: w25n01gv
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     extra_args:
       - FILE_SUFFIX="w25n01gv"
       - EXTRA_CONF_FILE="./boards/mikroe_flash_5_click.conf"
@@ -346,11 +347,3 @@ tests:
       - CONFIG_TEST_DRIVER_FLASH_SIZE=-1
     integration_platforms:
       - kit_pse84_eval/pse846gps2dbzc4a/m33
-  drivers.flash.common.spi_nand.w25n01gv:
-    platform_allow:
-      - nrf7120dk/nrf7120/cpuapp
-    harness_config:
-      fixture: w25n01gv
-    extra_args:
-      - FILE_SUFFIX="w25n01gv"
-      - EXTRA_CONF_FILE="./boards/mikroe_flash_5_click.conf"


### PR DESCRIPTION
Merge the duplicated spi_nand.w25n01gv test definitions in order to avoid errors by the compliance check when modifying this file.

see  #113817 