### PR TITLE
drivers: can: sam0: enforce MRAM allocation within lower 64KB SRAM

### DIFF
--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -643,6 +643,23 @@ enum can_mcan_psr_lec {
 	static char __nocache_noinit __aligned(4) _name[CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id)];
 
 /**
+ * @brief Define a RAM buffer for Bosch M_CAN Message RAM in a specific section
+ *
+ * For devicetree nodes without dedicated Message RAM area, this macro defines a suitable RAM buffer
+ * to hold the Message RAM elements. The buffer will be placed in the specified section. Since this
+ * buffer cannot be shared between multiple Bosch M_CAN instances, the Message RAM offset must be
+ * set to 0x0.
+ *
+ * @param node_id node identifier
+ * @param _name buffer variable name
+ * @param _section_name Name of the linker section to place the buffer in
+ */
+#define CAN_MCAN_DT_MRAM_DEFINE_SECTION(node_id, _name, _section_name)                             \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_OFFSET(node_id) == 0, "offset must be 0");                   \
+	static char __aligned(4) _name[CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id)] Z_GENERIC_SECTION( \
+		_section_name);
+
+/**
  * @brief Assert that the Message RAM configuration meets the Bosch M_CAN IP core restrictions
  *
  * @param node_id node identifier
@@ -844,6 +861,15 @@ enum can_mcan_psr_lec {
  * @see CAN_MCAN_DT_MRAM_DEFINE()
  */
 #define CAN_MCAN_DT_INST_MRAM_DEFINE(inst, _name) CAN_MCAN_DT_MRAM_DEFINE(DT_DRV_INST(inst), _name)
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_DEFINE_SECTION(DT_DRV_INST(inst), _name, _section_name)
+ * @param inst DT_DRV_COMPAT instance number
+ * @param _name buffer variable name
+ * @param _section_name Name of the linker section to place the buffer in
+ */
+#define CAN_MCAN_DT_INST_MRAM_DEFINE_SECTION(inst, _name, _section_name)                           \
+	CAN_MCAN_DT_MRAM_DEFINE_SECTION(DT_DRV_INST(inst), _name, _section_name)
 
 /**
  * @brief Bosch M_CAN specific static initializer for a minimum nominal @p can_timing struct

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -211,9 +211,23 @@ static void config_can_##inst##_irq(void)						\
 #define ASSIGNED_CLOCKS_CELL_BY_NAME							\
 	ATMEL_SAM0_DT_INST_ASSIGNED_CLOCKS_CELL_BY_NAME
 
+/*
+ * On devices with more than 64 KB SRAM, place the MCAN Message RAM buffers
+ * in a dedicated section to ensure they are located in the first 64 KB of
+ * SRAM, as required by section 39.9.1 of the SAM D5x/E5x Family Data Sheet
+ * (DS60001507N).
+ */
+#if CONFIG_SRAM_SIZE > 64
+#define CAN_SAM0_DT_INST_MRAM_DEFINE(inst, _name)                                       \
+	CAN_MCAN_DT_INST_MRAM_DEFINE_SECTION(inst, _name, ".can_message_ram")
+
+#else
+#define CAN_SAM0_DT_INST_MRAM_DEFINE(inst, _name) CAN_MCAN_DT_INST_MRAM_DEFINE(inst, _name)
+#endif
+
 #define CAN_SAM0_CFG_INST(inst)								\
 	CAN_MCAN_DT_INST_CALLBACKS_DEFINE(inst, can_sam0_cbs_##inst);			\
-	CAN_MCAN_DT_INST_MRAM_DEFINE(inst, can_sam0_mram_##inst);			\
+	CAN_SAM0_DT_INST_MRAM_DEFINE(inst, can_sam0_mram_##inst);			\
 											\
 	static const struct can_sam0_config can_sam0_cfg_##inst = {			\
 		.base = CAN_MCAN_DT_INST_MCAN_ADDR(inst),				\

--- a/soc/atmel/sam0/common/CMakeLists.txt
+++ b/soc/atmel/sam0/common/CMakeLists.txt
@@ -25,3 +25,7 @@ zephyr_sources_ifdef(CONFIG_SOC_SERIES_SAME54 soc_samd5x.c)
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+
+if(CONFIG_CAN_SAM0 AND (CONFIG_SRAM_SIZE GREATER 64))
+  zephyr_linker_sources(RAM_SECTIONS can_message_ram.ld)
+endif()

--- a/soc/atmel/sam0/common/can_message_ram.ld
+++ b/soc/atmel/sam0/common/can_message_ram.ld
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Place the MCAN Message RAM buffers in a dedicated section to ensure they are
+ * located in the first 64 KB of SRAM, as required by section 39.9.1 of the SAM
+ * D5x/E5x Family Data Sheet (DS60001507N).
+ */
+
+SECTION_PROLOGUE(.can_message_ram,(NOLOAD),)
+{
+    . = ALIGN(4);
+    *(.can_message_ram)
+    . = ALIGN(4);
+} GROUP_LINK_IN(RAMABLE_REGION)
+
+ASSERT((. - RAM_ADDR) <= KB(64), "Error: SAM0 MCAN MRAM buffers exceed 64 KB SRAM boundary!")


### PR DESCRIPTION
On Microchip SAM0/SAMx54 family SoCs, the MCAN peripheral uses a 16-bit Message RAM Base Address (MRBA) register relative to 0x20000000. If MRAM buffers are placed above 0x20010000, the address truncates and DMA operations access invalid memory locations.

This change introduces a dedicated .mram_noinit section via zephyr_linker_sources_ifdef in SAM0 common CMake scripts to guarantee that MRAM buffers are allocated at the start of RAM, staying strictly within the 64 KB offset limit.