### PR TITLE
Add NXP MCXW23 board to peripheral app testcase 

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bluetooth_controller.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bluetooth_controller.cmake
@@ -3,35 +3,41 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_NXP_SNPS_BLE_CTRL)
-    set(CONFIG_MCUX_COMPONENT_middleware.wireless.snps_ll ON)
+  set(CONFIG_MCUX_COMPONENT_middleware.wireless.snps_ll ON)
+
+  zephyr_compile_definitions(
+    gUseHciTransportDownward_d=1
+    OSA_USED
+  )
+
+  if(CONFIG_BUILD_ONLY_NO_BLOBS)
+    set(CONFIG_MCUX_COMPONENT_middleware.wireless.snps_ll_ble_controller_if ON)
+    zephyr_library_sources(middleware/bt_controller/snps_controller_stub.c)
+  else()
     set(CONFIG_MCUX_COMPONENT_middleware.wireless.snps_ll_os ON)
 
     if(CONFIG_SOC_SERIES_MCXW2XX)
-        set(BLE_LIBS_PATH ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/mcxw23)
+      set(BLE_LIBS_PATH ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/mcxw23)
     endif()
 
     set(BLELIBOS_PATH       ${BLE_LIBS_PATH}/libble_ll_os.a)
     set(BLELIBUTILS_PATH    ${BLE_LIBS_PATH}/libble_ll_utils_os.a)
 
-    zephyr_compile_definitions(
-        gUseHciTransportDownward_d=1
-        OSA_USED
-    )
-
     zephyr_blobs_verify(FILES
-        ${BLELIBOS_PATH}
-        ${BLELIBUTILS_PATH}
+      ${BLELIBOS_PATH}
+      ${BLELIBUTILS_PATH}
     )
     zephyr_library_import(ble_lib_os ${BLELIBOS_PATH})
     zephyr_library_import(ble_lib_utils ${BLELIBUTILS_PATH})
+  endif()
 endif()
 
 if(CONFIG_NXP_MCXW7X_BLE_CTRL)
-    set(CONFIG_MCUX_COMPONENT_middleware.wireless.controller_api_minimal ON)
+  set(CONFIG_MCUX_COMPONENT_middleware.wireless.controller_api_minimal ON)
 endif()
 
 if(CONFIG_NXP_SNPS_BLE_CTRL OR CONFIG_NXP_MCXW7X_BLE_CTRL)
-    add_subdirectory(${MCUX_SDK_NG_DIR}/middleware/mcuxsdk-middleware-bluetooth-controller
-        ${CMAKE_CURRENT_BINARY_DIR}/mcuxsdk-middleware-bluetooth-controller
-    )
+  add_subdirectory(${MCUX_SDK_NG_DIR}/middleware/mcuxsdk-middleware-bluetooth-controller
+    ${CMAKE_CURRENT_BINARY_DIR}/mcuxsdk-middleware-bluetooth-controller
+  )
 endif()

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bt_controller/snps_controller_stub.c
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bt_controller/snps_controller_stub.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ble_controller.h"
+
+blec_result_t BLEController_SetConnectionInitialTxPowerDbm(int8_t level_dbm)
+{
+	return kBLEC_CommandDisallowed;
+}
+
+blec_result_t BLEController_SetTxPowerDbm(int8_t level_dbm)
+{
+	return kBLEC_CommandDisallowed;
+}
+
+blec_result_t BLEController_Init(blecHostHciRecvCallback_t callback, int8_t requested_max_power_dBm,
+				 power_range_dbm_t *selected_power_range)
+{
+	return kBLEC_CommandDisallowed;
+}
+
+blec_result_t BLEController_ProcessHciPacket(blec_hciPacketType_t packetType, void *pPacket,
+					     uint16_t packetSize)
+{
+	return kBLEC_CommandDisallowed;
+}
+
+void BLE_LL_IRQHandler(void)
+{
+}

--- a/samples/bluetooth/peripheral/tests.yaml
+++ b/samples/bluetooth/peripheral/tests.yaml
@@ -35,5 +35,6 @@ tests:
       - xg29_rb4412a/efr32mg29b140f1024im40
       - frdm_mcxw71
       - frdm_mcxw72
+      - frdm_mcxw23
       - frdm_rw612
     build_only: true

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 411d799dc9eaee5050604f56a9c53c821c0c129b
+      revision: 5218647eea21dee20def3cac103898101bf71bbf
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Adding the platforms here helps maintain build coverage for mcxw23 BLE upstream.

Add a CONFIG_BUILD_ONLY_NO_BLOBS path so the BLE applications can be
built in CI without fetching mcxw23 ll blobs.