### PR TITLE
net: dns: Use a fresh source port for each query

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -475,6 +475,26 @@ source "subsys/net/Kconfig.template.log_config.net"
 
 endif # DNS_SD
 
+config DNS_RESOLVER_RANDOMIZE_SOURCE_PORT
+	bool "Use a fresh source port for each query"
+	depends on DNS_RESOLVER
+	default y
+	help
+	  Ask the system for a new local port before sending a query to a
+	  server that has nothing outstanding, so that consecutive queries do
+	  not leave from the same one.
+
+	  RFC 5452 section 9.2 asks for this. An attacker who cannot see a
+	  query has to guess both the 16 bit identifier and the source port to
+	  forge an answer to it; a port that never changes is one of the two
+	  given away, and it is learned from any single query.
+
+	  This costs a socket being closed and reopened, and its dispatcher
+	  re-registered, before a query that follows an idle period. Turn it
+	  off where that matters more than the hardening does. Queries to
+	  multicast DNS and LLMNR are unaffected either way: those protocols
+	  fix the port.
+
 config DNS_RESOLVER_MAX_SERVERS_LIMIT
 	int
 	depends on (DNS_RESOLVER || MDNS_RESPONDER)

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -2043,6 +2043,147 @@ static int set_ttl_hop_limit(int sock, int level, int option, int new_limit)
 	return zsock_setsockopt(sock, level, option, &new_limit, sizeof(new_limit));
 }
 
+#if defined(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT)
+/* True when no query is still waiting to hear from this server, so its socket
+ * can be replaced without losing an answer that is on its way.
+ */
+static bool dns_server_is_idle(struct dns_resolve_context *ctx, int server_idx,
+			       int except_query_idx)
+{
+	for (int i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
+		/* The query about to be sent is already marked as awaiting a
+		 * reply by the time it gets here, so it does not count.
+		 */
+		if (i == except_query_idx) {
+			continue;
+		}
+
+		if (dns_server_awaiting_reply(&ctx->queries[i], server_idx)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/* Give the server's socket a new local port.
+ *
+ * RFC 5452 9.2: an attacker who cannot see a query has to guess the identifier
+ * and the source port together to forge an answer to it. The identifier is
+ * already drawn afresh for every query; the port was chosen once, when the
+ * socket was opened, and then reused for the life of the resolver, so a single
+ * observed query gave it away for good.
+ *
+ * The socket is closed and opened again rather than rebound, because a bound
+ * UDP socket cannot be rebound. The port itself is left to the system: binding
+ * to zero is what the resolver already does at startup, and the dispatcher
+ * reads back the port that was chosen.
+ *
+ * A server whose socket cannot be replaced is left without one, which the
+ * resolver already treats as unavailable: the query goes to the next server
+ * instead. Getting here means the system is out of sockets, in which case the
+ * old one could not have been kept either.
+ */
+static void dns_randomize_source_port(struct dns_resolve_context *ctx,
+				      int server_idx, int query_idx)
+{
+	struct dns_server_info *server = &ctx->servers[server_idx];
+	struct net_sockaddr_storage local;
+	net_socklen_t local_len;
+	int old_sock = server->sock;
+	int sock;
+	int ret;
+
+	/* Multicast DNS and LLMNR are spoken on a fixed port, and the
+	 * dispatcher pairs a resolver with a responder by that port.
+	 */
+	if (server->is_mdns || server->is_llmnr) {
+		return;
+	}
+
+	if (old_sock < 0 || !dns_server_is_idle(ctx, server_idx, query_idx)) {
+		return;
+	}
+
+	/* Keep the address the dispatcher was bound to, drop the port. */
+	memcpy(&local, &server->dispatcher.local_addr_storage, sizeof(local));
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) && local.ss_family == NET_AF_INET6) {
+		net_sin6(net_sad(&local))->sin6_port = 0;
+		local_len = sizeof(struct net_sockaddr_in6);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && local.ss_family == NET_AF_INET) {
+		net_sin(net_sad(&local))->sin_port = 0;
+		local_len = sizeof(struct net_sockaddr_in);
+	} else {
+		return;
+	}
+
+	/* Give the old socket up first. Its descriptor is then free for the
+	 * replacement, which matters where the descriptor budget is sized for
+	 * exactly the sockets the resolver holds.
+	 */
+	(void)dns_dispatcher_unregister(&server->dispatcher);
+
+	ARRAY_FOR_EACH(ctx->fds, j) {
+		if (ctx->fds[j].fd == old_sock) {
+			ctx->fds[j].fd = -1;
+			break;
+		}
+	}
+
+	zsock_close(old_sock);
+	server->sock = -1;
+
+	sock = zsock_socket(server->dns_server_addr.ss_family, NET_SOCK_DGRAM,
+			    NET_IPPROTO_UDP);
+	if (sock < 0) {
+		NET_ERR("Cannot get a socket to renew the source port (%d)", -errno);
+		return;
+	}
+
+	if (server->if_index > 0) {
+		ret = bind_to_iface(sock, net_sad(&server->dns_server_addr),
+				    server->if_index);
+		if (ret < 0) {
+			zsock_close(sock);
+			return;
+		}
+	}
+
+	ARRAY_FOR_EACH(ctx->fds, j) {
+		if (ctx->fds[j].fd < 0) {
+			ctx->fds[j].fd = sock;
+			ctx->fds[j].events = ZSOCK_POLLIN;
+			break;
+		}
+	}
+
+	server->sock = sock;
+
+	ret = register_dispatcher(ctx, server->dispatcher.svc, server,
+				  net_sad(&local), local_len, NULL, NULL);
+	if (ret < 0) {
+		/* The old socket is gone and the new one is not dispatched, so
+		 * an answer arriving on it would not be seen. Give the socket
+		 * up: the resolver treats a server without one as unavailable
+		 * and moves on to the next.
+		 */
+		NET_ERR("Cannot dispatch the renewed socket for server %d (%d)",
+			server_idx, ret);
+
+		ARRAY_FOR_EACH(ctx->fds, j) {
+			if (ctx->fds[j].fd == sock) {
+				ctx->fds[j].fd = -1;
+				break;
+			}
+		}
+
+		zsock_close(sock);
+		server->sock = -1;
+	}
+}
+#endif /* CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT */
+
 /* Must be invoked with context lock held */
 static int dns_write(struct dns_resolve_context *ctx,
 		     int server_idx,
@@ -2058,7 +2199,15 @@ static int dns_write(struct dns_resolve_context *ctx,
 	int ret, sock, family;
 	char *query_name;
 
+	if (IS_ENABLED(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT)) {
+		dns_randomize_source_port(ctx, server_idx, query_idx);
+	}
+
 	sock = ctx->servers[server_idx].sock;
+	if (sock < 0) {
+		return -ENOTCONN;
+	}
+
 	family = ctx->servers[server_idx].dns_server_addr.ss_family;
 	server = net_sad(&ctx->servers[server_idx].dns_server_addr);
 	dns_id = ctx->queries[query_idx].id;

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -168,6 +168,12 @@ static inline int get_slot_by_id(struct dns_resolve_context *ctx,
 	return -1;
 }
 
+/* The source port the last two queries left from, so that a test can see
+ * whether it moves. RFC 5452 9.2 asks that it does.
+ */
+static uint16_t query_src_port;
+static uint16_t last_query_src_port;
+
 static bool is_dns_query_packet(struct net_pkt *pkt)
 {
 	struct net_udp_hdr *udp;
@@ -208,6 +214,18 @@ static int sender_iface(const struct device *dev, struct net_pkt *pkt)
 	}
 
 	send_count++;
+
+	if (IS_ENABLED(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT)) {
+		struct net_udp_hdr *udp = net_udp_get_hdr(pkt, NULL);
+
+		/* Only ordinary queries. Multicast DNS and LLMNR are spoken
+		 * from a fixed port on purpose, so theirs does not move.
+		 */
+		if (udp != NULL && net_ntohs(udp->dst_port) == 53U) {
+			last_query_src_port = query_src_port;
+			query_src_port = net_ntohs(udp->src_port);
+		}
+	}
 
 	if (!timeout_query) {
 		struct net_if_test *data = dev->data;
@@ -992,6 +1010,50 @@ ZTEST(dns_resolve, test_dns_query_ipv4)
 	if (k_sem_take(&wait_data2, WAIT_TIME)) {
 		zassert_true(false, "Timeout while waiting data");
 	}
+}
+
+/* RFC 5452 9.2: an off path attacker forging an answer has to guess the
+ * identifier and the source port together. A port that never moves is learned
+ * from any single query, leaving only the identifier to guess.
+ */
+ZTEST(dns_resolve, test_dns_query_source_port_varies)
+{
+	struct observed_status observed;
+	int ret;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT);
+
+	timeout_query = false;
+	query_src_port = 0U;
+	last_query_src_port = 0U;
+
+	/* The port is only renewed for a server with nothing outstanding, so
+	 * each lookup has to be seen through to the end before the next.
+	 */
+	for (int i = 0; i < 2; i++) {
+		observed = (struct observed_status){ 0 };
+
+		ret = dns_get_addr_info(NAME4, DNS_QUERY_TYPE_A, &current_dns_id,
+					dns_result_record_cb, &observed, DNS_TIMEOUT);
+		zassert_equal(ret, 0, "Cannot create IPv4 query");
+
+		k_msleep(THREAD_SLEEP);
+
+		while (observed.status != DNS_EAI_ALLDONE) {
+			if (k_sem_take(&wait_data2, WAIT_TIME)) {
+				zassert_true(false, "Timeout while waiting data");
+			}
+		}
+
+		if (i == 0) {
+			zassert_not_equal(query_src_port, 0U, "No query was seen");
+		}
+	}
+
+	zassert_not_equal(query_src_port, last_query_src_port,
+			  "Both queries left from port %u; an observer learns it "
+			  "from the first and need only guess the identifier",
+			  query_src_port);
 }
 
 ZTEST(dns_resolve, test_dns_query_ipv4_timeout_fallback)


### PR DESCRIPTION
RFC 5452 9.2 asks a resolver to vary the source port of its queries as well as the identifier. Both together are what an off path attacker has to guess to forge an answer to a query it cannot see. The identifier was already drawn afresh each time; the port was chosen once, when the socket was opened, and reused for the life of the resolver, so a single observed query gave it away for good and halved what an attacker had to guess.

Give the socket a new port before a query goes to a server that has nothing outstanding. It is closed and opened again rather than rebound, because a bound UDP socket cannot be rebound, and the port is left to the system exactly as it is at startup: binding to zero, with the dispatcher reading back what was chosen.

One socket per server is kept, so the poll arrays, the descriptor budget and the build assertions that size them are all as they were. What that costs is that queries which overlap on one server share a port; only a server with nothing in flight gets a new one. With the default of one query at a time that is every query.

Multicast DNS and LLMNR are left alone. Both are spoken from a fixed port, and the dispatcher paths a resolver to a responder by that port.

The old socket is given up before the replacement is asked for, so that its descriptor is free when the new one is opened. Systems that size the descriptor budget for exactly the sockets the resolver holds have no spare one to lend.

CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT turns this off where the churn matters more than the hardening.

Assisted-by: Claude:claude-opus-5

Fixes: #117501