### PR TITLE
Add Support to Run QEMU using ELF Entry Point

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -134,6 +134,17 @@ config QEMU_EXTRA_FLAGS
 	  to setup devices, for example to allocate interface for Zephyr
 	  GDBstub over serial with `-serial tcp:127.0.0.1:5678,server`
 
+config QEMU_DEVICE_LOADER
+	bool "QEMU device loader"
+	depends on QEMU_TARGET
+	help
+	  When enabled, QEMU will use the device loader functionality to load
+	  the ELF file instead of the "-kernel" option. On certain architectures,
+	  such as RISC-V, QEMU is designed to load the lowest address of
+	  the ELF rather than the entry point within the ELF. This option is
+	  used to enable logic at the board.cmake level that uses "-device,loader"
+	  rather than "-kernel" for loading
+
 config QEMU_VIRTIO_BLK_LOGICAL_BLOCK_SIZE
 	int "QEMU virtio-blk logical block size"
 	depends on QEMU_TARGET && DISK_DRIVER_VIRTIO_BLK

--- a/boards/qemu/riscv32/board.cmake
+++ b/boards/qemu/riscv32/board.cmake
@@ -25,4 +25,14 @@ set(QEMU_BOARD_FLAGS
   -cpu ${qemu_riscv_cpu}
   )
 
+if(CONFIG_QEMU_DEVICE_LOADER)
+  set(QEMU_KERNEL_OPTION "")
+  math(EXPR max_cpu_index "${CONFIG_MP_MAX_NUM_CPUS} - 1")
+  foreach(cpu_num RANGE 0 ${max_cpu_index})
+    list(APPEND QEMU_KERNEL_OPTION
+      "-device;loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>,cpu-num=${cpu_num}"
+    )
+  endforeach()
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv32/doc/index.rst
+++ b/boards/qemu/riscv32/doc/index.rst
@@ -5,6 +5,46 @@ Overview
 
 The RISCV32 QEMU board configuration is used to emulate the RISCV32 architecture.
 
+ELF Loading Convention
+***********************
+
+QEMU's RISC-V ``virt`` machine mirrors the boot behavior of OpenSBI's
+``fw_dynamic``, ``fw_jump`` and ``fw_payload`` firmware, as well as the
+Berkeley Boot Loader (BBL):
+
+.. code-block:: c
+
+   /*
+    * NB: Use low address not ELF entry point to ensure that the fw_dynamic
+    * behaviour when loading an ELF matches the fw_payload, fw_jump and BBL
+    * behaviour, as well as fw_dynamic with a raw binary, all of which jump to
+    * the (expected) load address load address. This allows kernels to have
+    * separate SBI and ELF entry points (used by FreeBSD, for example).
+    */
+
+In other words, when an ELF is passed to QEMU via ``-kernel``, the vCPU's
+program counter is set to the *lowest address the image is loaded at*, not
+to the address recorded in the ELF header's ``e_entry`` field. This keeps
+boot behavior consistent between raw binaries and ELF images and lets a
+kernel expose an SBI entry point that differs from its ELF entry point.
+
+This convention is normally invisible to Zephyr because the linker script
+places the image's entry point (``CONFIG_KERNEL_ENTRY``) at the very start
+of the ROM region, so the load address and the entry point happen to
+coincide. It becomes a problem the moment the two addresses diverge such
+as if the ROM region reserves space in front of ``rom_start`` for a
+header or padding, because QEMU will then jump to the beginning of that
+reserved space instead of to ``CONFIG_KERNEL_ENTRY`` and Zephyr will never
+run.
+
+:kconfig:option:`CONFIG_QEMU_DEVICE_LOADER` works around this by
+replacing the ``-kernel`` option with one ``-device loader,file=<elf>``
+entry per CPU (one for each of the :kconfig:option:`CONFIG_MP_MAX_NUM_CPUS`
+cores configured). Unlike ``-kernel``, QEMU's generic loader device honors
+the ELF's actual entry point, so every vCPU starts execution at
+``CONFIG_KERNEL_ENTRY`` regardless of where it sits relative to the base of
+ROM.
+
 Programming and Debugging
 *************************
 

--- a/boards/qemu/riscv32_xip/board.cmake
+++ b/boards/qemu/riscv32_xip/board.cmake
@@ -8,4 +8,14 @@ set(QEMU_BOARD_FLAGS
   -machine sifive_e
 )
 
+if(CONFIG_QEMU_DEVICE_LOADER)
+  set(QEMU_KERNEL_OPTION "")
+  math(EXPR max_cpu_index "${CONFIG_MP_MAX_NUM_CPUS} - 1")
+  foreach(cpu_num RANGE 0 ${max_cpu_index})
+    list(APPEND QEMU_KERNEL_OPTION
+      "-device;loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>,cpu-num=${cpu_num}"
+    )
+  endforeach()
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv32_xip/doc/index.rst
+++ b/boards/qemu/riscv32_xip/doc/index.rst
@@ -5,6 +5,46 @@ Overview
 
 The RISCV32 XIP QEMU board configuration is used to emulate the RISCV32 architecture.
 
+ELF Loading Convention
+***********************
+
+QEMU's RISC-V ``virt`` machine mirrors the boot behavior of OpenSBI's
+``fw_dynamic``, ``fw_jump`` and ``fw_payload`` firmware, as well as the
+Berkeley Boot Loader (BBL):
+
+.. code-block:: c
+
+   /*
+    * NB: Use low address not ELF entry point to ensure that the fw_dynamic
+    * behaviour when loading an ELF matches the fw_payload, fw_jump and BBL
+    * behaviour, as well as fw_dynamic with a raw binary, all of which jump to
+    * the (expected) load address load address. This allows kernels to have
+    * separate SBI and ELF entry points (used by FreeBSD, for example).
+    */
+
+In other words, when an ELF is passed to QEMU via ``-kernel``, the vCPU's
+program counter is set to the *lowest address the image is loaded at*, not
+to the address recorded in the ELF header's ``e_entry`` field. This keeps
+boot behavior consistent between raw binaries and ELF images and lets a
+kernel expose an SBI entry point that differs from its ELF entry point.
+
+This convention is normally invisible to Zephyr because the linker script
+places the image's entry point (``CONFIG_KERNEL_ENTRY``) at the very start
+of the ROM region, so the load address and the entry point happen to
+coincide. It becomes a problem the moment the two addresses diverge such
+as if the ROM region reserves space in front of ``rom_start`` for a
+header or padding, because QEMU will then jump to the beginning of that
+reserved space instead of to ``CONFIG_KERNEL_ENTRY`` and Zephyr will never
+run.
+
+:kconfig:option:`CONFIG_QEMU_DEVICE_LOADER` works around this by
+replacing the ``-kernel`` option with one ``-device loader,file=<elf>``
+entry per CPU (one for each of the :kconfig:option:`CONFIG_MP_MAX_NUM_CPUS`
+cores configured). Unlike ``-kernel``, QEMU's generic loader device honors
+the ELF's actual entry point, so every vCPU starts execution at
+``CONFIG_KERNEL_ENTRY`` regardless of where it sits relative to the base of
+ROM.
+
 Programming and Debugging
 *************************
 

--- a/boards/qemu/riscv32e/board.cmake
+++ b/boards/qemu/riscv32e/board.cmake
@@ -17,4 +17,14 @@ set(QEMU_BOARD_FLAGS
   -cpu ${qemu_riscv_cpu}
   )
 
+if(CONFIG_QEMU_DEVICE_LOADER)
+  set(QEMU_KERNEL_OPTION "")
+  math(EXPR max_cpu_index "${CONFIG_MP_MAX_NUM_CPUS} - 1")
+  foreach(cpu_num RANGE 0 ${max_cpu_index})
+    list(APPEND QEMU_KERNEL_OPTION
+      "-device;loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>,cpu-num=${cpu_num}"
+    )
+  endforeach()
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv32e/doc/index.rst
+++ b/boards/qemu/riscv32e/doc/index.rst
@@ -5,6 +5,46 @@ Overview
 
 The RISCV32E QEMU board configuration is used to emulate the RISCV32 (RV32E) architecture.
 
+ELF Loading Convention
+***********************
+
+QEMU's RISC-V ``virt`` machine mirrors the boot behavior of OpenSBI's
+``fw_dynamic``, ``fw_jump`` and ``fw_payload`` firmware, as well as the
+Berkeley Boot Loader (BBL):
+
+.. code-block:: c
+
+   /*
+    * NB: Use low address not ELF entry point to ensure that the fw_dynamic
+    * behaviour when loading an ELF matches the fw_payload, fw_jump and BBL
+    * behaviour, as well as fw_dynamic with a raw binary, all of which jump to
+    * the (expected) load address load address. This allows kernels to have
+    * separate SBI and ELF entry points (used by FreeBSD, for example).
+    */
+
+In other words, when an ELF is passed to QEMU via ``-kernel``, the vCPU's
+program counter is set to the *lowest address the image is loaded at*, not
+to the address recorded in the ELF header's ``e_entry`` field. This keeps
+boot behavior consistent between raw binaries and ELF images and lets a
+kernel expose an SBI entry point that differs from its ELF entry point.
+
+This convention is normally invisible to Zephyr because the linker script
+places the image's entry point (``CONFIG_KERNEL_ENTRY``) at the very start
+of the ROM region, so the load address and the entry point happen to
+coincide. It becomes a problem the moment the two addresses diverge such
+as if the ROM region reserves space in front of ``rom_start`` for a
+header or padding, because QEMU will then jump to the beginning of that
+reserved space instead of to ``CONFIG_KERNEL_ENTRY`` and Zephyr will never
+run.
+
+:kconfig:option:`CONFIG_QEMU_DEVICE_LOADER` works around this by
+replacing the ``-kernel`` option with one ``-device loader,file=<elf>``
+entry per CPU (one for each of the :kconfig:option:`CONFIG_MP_MAX_NUM_CPUS`
+cores configured). Unlike ``-kernel``, QEMU's generic loader device honors
+the ELF's actual entry point, so every vCPU starts execution at
+``CONFIG_KERNEL_ENTRY`` regardless of where it sits relative to the base of
+ROM.
+
 Programming and Debugging
 *************************
 

--- a/boards/qemu/riscv64/board.cmake
+++ b/boards/qemu/riscv64/board.cmake
@@ -38,4 +38,14 @@ set(QEMU_BOARD_FLAGS
   ${QEMU_VIRTIO_INPUT_FLAGS}
   )
 
+if(CONFIG_QEMU_DEVICE_LOADER)
+  set(QEMU_KERNEL_OPTION "")
+  math(EXPR max_cpu_index "${CONFIG_MP_MAX_NUM_CPUS} - 1")
+  foreach(cpu_num RANGE 0 ${max_cpu_index})
+    list(APPEND QEMU_KERNEL_OPTION
+      "-device;loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>,cpu-num=${cpu_num}"
+    )
+  endforeach()
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv64/doc/index.rst
+++ b/boards/qemu/riscv64/doc/index.rst
@@ -14,6 +14,46 @@ with toolchain and QEMU support for the RISCV64 architecture is v0.10.2.
 Please see the :ref:`installation instructions <install-required-tools>`
 for more details.
 
+ELF Loading Convention
+***********************
+
+QEMU's RISC-V ``virt`` machine mirrors the boot behavior of OpenSBI's
+``fw_dynamic``, ``fw_jump`` and ``fw_payload`` firmware, as well as the
+Berkeley Boot Loader (BBL):
+
+.. code-block:: c
+
+   /*
+    * NB: Use low address not ELF entry point to ensure that the fw_dynamic
+    * behaviour when loading an ELF matches the fw_payload, fw_jump and BBL
+    * behaviour, as well as fw_dynamic with a raw binary, all of which jump to
+    * the (expected) load address load address. This allows kernels to have
+    * separate SBI and ELF entry points (used by FreeBSD, for example).
+    */
+
+In other words, when an ELF is passed to QEMU via ``-kernel``, the vCPU's
+program counter is set to the *lowest address the image is loaded at*, not
+to the address recorded in the ELF header's ``e_entry`` field. This keeps
+boot behavior consistent between raw binaries and ELF images and lets a
+kernel expose an SBI entry point that differs from its ELF entry point.
+
+This convention is normally invisible to Zephyr because the linker script
+places the image's entry point (``CONFIG_KERNEL_ENTRY``) at the very start
+of the ROM region, so the load address and the entry point happen to
+coincide. It becomes a problem the moment the two addresses diverge such
+as if the ROM region reserves space in front of ``rom_start`` for a
+header or padding, because QEMU will then jump to the beginning of that
+reserved space instead of to ``CONFIG_KERNEL_ENTRY`` and Zephyr will never
+run.
+
+:kconfig:option:`CONFIG_QEMU_DEVICE_LOADER` works around this by
+replacing the ``-kernel`` option with one ``-device loader,file=<elf>``
+entry per CPU (one for each of the :kconfig:option:`CONFIG_MP_MAX_NUM_CPUS`
+cores configured). Unlike ``-kernel``, QEMU's generic loader device honors
+the ELF's actual entry point, so every vCPU starts execution at
+``CONFIG_KERNEL_ENTRY`` regardless of where it sits relative to the base of
+ROM.
+
 Programming and Debugging
 *************************
 


### PR DESCRIPTION
On RISC-V based QEMU there is a convention in the platform where the ELF entry point is ignored in favor of using the low address of the ELF (https://raw.githubusercontent.com/qemu/qemu/v10.0.2/hw/riscv/boot.c):
> /*
     * NB: Use low address not ELF entry point to ensure that the fw_dynamic
     * behaviour when loading an ELF matches the fw_payload, fw_jump and BBL
     * behaviour, as well as fw_dynamic with a raw binary, all of which jump to
     * the (expected) load address load address. This allows kernels to have
     * separate SBI and ELF entry points (used by FreeBSD, for example).
     */

QEMU's ARM `virt` machine, by contrast, boots bare ELF images through a completely different code path (https://raw.githubusercontent.com/qemu/qemu/v10.0.2/hw/arm/boot.c) that ultimately obtains the ELF's entry point `e_entry` through the call chain `arm_setup_direct_kernel_boot()` --> `arm_load_elf()`.

The proposed script leverages QEMU's ability to [set a CPU's program counter](https://www.qemu.org/docs/master/system/generic-loader.html#setting-a-cpu-s-program-counter) by (**optionally**, depending on if `CONFIG_QEMU_ENTRY_WRAPPER` is set) extracting the `e_entry` point of the ELF and passing it to QEMU on invocation through Zephyr.

This was tested locally with a dynamic ELF that contained sections that lead to the resulting ELF's entry point and low address being mismatched. With the wrapper enabled QEMU runs from the appropriate address rather than starting from the first section in the ELF.

**ELF begins with `rom_start` (current configuration for qemu_riscv32)**
With `CONFIG_QEMU_ENTRY_WRAPPER` disabled:

<img width="869" height="86" alt="image" src="https://github.com/user-attachments/assets/65a8dc68-d69a-4ebb-a9be-bee4f82438e1" />

With `CONFIG_QEMU_ENTRY_WRAPPER` enabled:

<img width="874" height="142" alt="image" src="https://github.com/user-attachments/assets/eb859139-f3e5-4303-be15-8cc0f5b39a32" />

- single core

<img width="866" height="172" alt="image" src="https://github.com/user-attachments/assets/7fe9dae3-6626-458c-9d89-5feba53eb72e" />

- SMP enabled

**Adding a dummy pad section prior to `rom_start`**

<img width="642" height="110" alt="image" src="https://github.com/user-attachments/assets/7df0c161-c66d-4d48-b821-1944803570b8" />

With `CONFIG_QEMU_ENTRY_WRAPPER` disabled:

<img width="876" height="120" alt="image" src="https://github.com/user-attachments/assets/9b3ba9c5-d5c7-4a2d-8c8b-d2fdafb1395a" />

- Fails to successfully reach main

With `CONFIG_QEMU_ENTRY_WRAPPER` enabled:

<img width="874" height="173" alt="image" src="https://github.com/user-attachments/assets/a1f6a6b7-6973-46b3-800e-18b39fd09fe9" />

