### PR TITLE
net: lwm2m: Don't act on partial Package URI writes

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -1103,6 +1103,7 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm2m_eng
 		/* Get block_ctx for total_size (might be zero) */
 		total_size = msg->in.block_ctx->ctx.total_size;
 		offset = msg->in.block_ctx->opaque.offset;
+		last_block = msg->in.block_ctx->last_block;
 
 		LOG_DBG("BLOCK1: total:%zu current:%zu"
 			" last:%u",

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -305,8 +305,20 @@ static int package_uri_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 	LOG_DBG("PACKAGE_URI WRITE: %s", package_uri[obj_inst_id]);
 
 #ifdef CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
-	uint8_t state = lwm2m_firmware_get_update_state_inst(obj_inst_id);
-	bool empty_uri = data_len == 0 || strnlen(data, data_len) == 0;
+	uint8_t state;
+	bool empty_uri;
+
+	/* writes every block of a block-wise transfer to the start of
+	 * the buffer, so it never holds the assembled URI. Reject the
+	 * write rather than act on whichever fragment happens to be present.
+	 */
+	if (!last_block) {
+		LOG_ERR("PACKAGE_URI: block-wise write is not supported");
+		return -EFBIG;
+	}
+
+	state = lwm2m_firmware_get_update_state_inst(obj_inst_id);
+	empty_uri = data_len == 0 || strnlen(data, data_len) == 0;
 
 	if (state == STATE_IDLE) {
 		if (!empty_uri) {

--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -656,7 +656,20 @@ static int package_uri_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 	int error_code;
 	struct lwm2m_swmgmt_data *instance = NULL;
 
+	/* writes every block of a block-wise transfer to the start of
+	 * the buffer, so it never holds the assembled URI. Reject the
+	 * write rather than act on whichever fragment happens to be present.
+	 */
+	if (!last_block) {
+		LOG_ERR("PACKAGE_URI: block-wise write is not supported");
+		return -EFBIG;
+	}
+
 	instance = find_index(obj_inst_id);
+	if (instance == NULL) {
+		LOG_ERR("Instance %u not found", obj_inst_id);
+		return -ENOENT;
+	}
 
 	struct requesting_object req = { .obj_inst_id = obj_inst_id,
 					 .is_firmware_uri = false,


### PR DESCRIPTION
lwm2m_write_handler() declared last_block as true and never assigned it, so every non-opaque post-write callback was told the write had completed on every block of a block-wise transfer. Neither package_uri_write_cb() checked the flag anyway, so a Package URI written block-wise started a firmware download from the first non-empty block, using whatever fragment sat in the resource buffer instead of the intended URI.