### PR TITLE
bluetooth: tester: fix BIS_Sync in receive state event

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -1313,7 +1313,7 @@ btp_send_broadcast_receive_state_ev(struct bt_conn *conn,
 	for (uint8_t i = 0U; i < ev->num_subgroups; i++) {
 		const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
 
-		sys_put_le32(subgroup->bis_sync >> 1, ptr);
+		sys_put_le32(subgroup->bis_sync, ptr);
 		ptr += sizeof(subgroup->bis_sync);
 		*ptr = subgroup->metadata_len;
 		ptr += sizeof(subgroup->metadata_len);


### PR DESCRIPTION
btp_send_broadcast_receive_state_ev() right-shifted
subgroup->bis_sync by one before packing it into the
BTP event. BIS_Sync is a bitfield in which bit 0
represents BIS index 1, not an index, so the shift
silently corrupted the value: 0x00000001 (BIS 1 synced)
was reported as 0, and 0xFFFFFFFF was reported as 0x7FFFFFFF.

The following conformance tests now pass:
BAP/BA/BASS/BV-05-C
BAP/BA/BASS/BV-06-C
BAP/BA/BASS/BV-07-C

Testing
nRF5340 Audio DK
nRF54L15 DK