### PR TITLE
drivers: ethernet: dwc_mac: esp32: disable tx checksum offloading

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -139,6 +139,7 @@ config ETH_DWMAC_RX_REFILL_THREAD_PRIORITY
 config ETH_DWC_ETHER_TX_HW_CHECKSUM
 	bool "Use TX hardware checksum"
 	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET
+	depends on !SOC_SERIES_ESP32
 	depends on !SOC_SERIES_ESP32P4
 	default y
 	help


### PR DESCRIPTION
Deactive tx checksum offloading on the
esp32, while it has a big enough fifo,
the tx checksum is not correctly calculated
on every second packet.

Also noticed in https://github.com/jethub-iot/esp-emac-rs/pull/16
