### PR TITLE
MAINTAINERS: Add patterns to catch missed rpi_pico-related files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5373,6 +5373,8 @@ Raspberry Pi Pico Platforms:
     - drivers/*/*rpi_pico*/
     - drivers/*/*rpi_pico*.c
     - soc/raspberrypi/
+  files-regex:
+    - ^include/.*rpi[-_]pico.*
   labels:
     - "platform: Raspberry Pi Pico"
 


### PR DESCRIPTION
Add a pattern `^include/.*rpi[-_]pico.*` to catch missed rpi_pico　related headers.