### PR TITLE
net: sockets: handle interface down case in multicast group join

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -2555,6 +2555,13 @@ static int ipv4_multicast_group(struct net_context *ctx, const void *optval,
 		ret = net_ipv4_igmp_leave(iface, &mreqn->imr_multiaddr);
 	}
 
+	if (ret == -ENETDOWN) {
+		/* If the interface is down, we can still return success as the
+		 * join will be performed when the interface comes up.
+		 */
+		return 0;
+	}
+
 	if (ret < 0) {
 		errno  = -ret;
 		return -1;
@@ -2605,6 +2612,13 @@ static int ipv6_multicast_group(struct net_context *ctx, const void *optval,
 		ret = net_ipv6_mld_join(iface, &mreq->ipv6mr_multiaddr);
 	} else {
 		ret = net_ipv6_mld_leave(iface, &mreq->ipv6mr_multiaddr);
+	}
+
+	if (ret == -ENETDOWN) {
+		/* If the interface is down, we can still return success as the
+		 * join will be performed when the interface comes up.
+		 */
+		return 0;
 	}
 
 	if (ret < 0) {


### PR DESCRIPTION
when the iface is down, the group will
be joined on up, so don't treat that as
a error.