### PR TITLE
drivers: timer: native_sim_timer: keep the model ticking at the tick period

### DIFF
--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys/clock.h>
+#include <zephyr/sys/util.h>
 #include "nsi_hw_scheduler.h"
 #include "nsi_timer_model.h"
 #include "soc.h"
@@ -26,13 +27,27 @@ static uint64_t timer_driver_cycle_get(void)
 	return nsi_hws_get_time();
 }
 
+/* Microseconds per kernel tick, the core's TIMER_CORE_CYC_PER_TICK, needed here
+ * before the core is included.
+ */
+#define NP_TICK_PERIOD_US (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
 /**
- * Program the next tick interrupt <cycles> microseconds from now.
- * hwtimer_enable() re-anchors the tick period at the current time.
+ * Program the next tick interrupt <cycles> microseconds from now, by passing over
+ * the tick expiries in between.
+ *
+ * Stretching the model's tick period with hwtimer_enable() instead would let it
+ * reach the deadline in a single step, which leaves CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME
+ * with nothing to pace simulated time against: that runs once per tick expiry.
+ *
+ * Skipping lands on the model's tick grid, so this can fire up to a tick early.
+ * The core announces what actually elapsed and the kernel re-arms.
  */
 static void timer_driver_set_reload(uint64_t cycles)
 {
-	hwtimer_enable(cycles);
+	int64_t silent_ticks = (int64_t)(cycles / NP_TICK_PERIOD_US) - 1;
+
+	hwtimer_set_silent_ticks(MAX(silent_ticks, 0));
 }
 
 /*
@@ -43,6 +58,9 @@ static void timer_driver_set_reload(uint64_t cycles)
 #define TIMER_CORE_ALARM_MAX_CYCLES NSI_NEVER
 
 #include "system_timer_generic.h"
+
+BUILD_ASSERT(NP_TICK_PERIOD_US == TIMER_CORE_CYC_PER_TICK,
+	     "the tick period used to arm the model must match the core's");
 
 /**
  * Interrupt handler for the timer interrupt
@@ -81,7 +99,7 @@ void sys_clock_disable(void)
  */
 static int sys_clock_driver_init(void)
 {
-	hwtimer_enable(TIMER_CORE_CYC_PER_TICK);
+	hwtimer_enable(NP_TICK_PERIOD_US);
 
 	IRQ_CONNECT(TIMER_TICK_IRQ, 1, np_timer_isr, 0, 0);
 	irq_enable(TIMER_TICK_IRQ);


### PR DESCRIPTION
Fixes the twister regression on `main` seen in https://github.com/zephyrproject-rtos/zephyr/actions/runs/32385137294.

## Root cause

0342c930d238 ("drivers: timer: native_sim_timer: use the generic timer core") arms the next announce with `hwtimer_enable(cycles)`. `hwtimer_enable()` sets the *period the timer model free-runs at*, so arming stretches the tick period out to the whole span and the model reaches the deadline in a single step.

The model paces simulated time against real time once per tick expiry, so a single step of the whole span leaves nothing to pace it. Under `CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME` (the default whenever `!CONFIG_TEST`, which covers both failing test directories) an idle with no timeout arms `0x7fffffff` ticks, simulated time leaves the wall clock ~248 days behind in one go, and the model then tries to sleep off the difference.

Simulated time on `samples/hello_world`, `native_sim/native/64`, after N seconds of wall clock:

```
0342c930d238^   2s -> Stopped at 2.010s          5s -> Stopped at 5.010s
0342c930d238    2s -> Stopped at 21474836.470s   (0x7fffffff ticks)
this PR         2s -> Stopped at 2.010s          5s -> Stopped at 5.010s
```

Only tests sharing the simulation with a real-world peer notice, which is why the native offloaded sockets talking to a host `openssl s_server` / `google.com` are the ones that broke. A small NSOS round-trip app against a local echo server reports `Test PASSED` at simulated `00:00:00.180` before the conversion and with this PR, versus `00:17:31.026` on current `main`.

## The fix

Arm through `hwtimer_set_silent_ticks()`, as the driver did before the conversion: the period stays at one tick, the model keeps stepping -- and pacing -- a tick at a time, and the ticks up to the deadline are passed over without raising an interrupt. `hwtimer_enable()` goes back to the single call at init that sets that period. The conversion to the generic timer core itself is kept.

Skipping ticks lands on the model's own tick grid rather than exactly `cycles` from now, so the interrupt can come up to a tick early; the core announces what actually elapsed and the kernel re-arms, so that costs one extra announce and nothing else.

A straight revert of 0342c930d238 might be a lower-risk alternative.