### PR TITLE
modem: cellular: handle modem busy in periodic script

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1799,6 +1799,7 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 {
 	const struct modem_cellular_config *config = data->dev->config;
 	struct cellular_evt_modem_comms_check_result result;
+	int ret;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
@@ -1830,7 +1831,12 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 			data->periodic_timeout_skipped = true;
 			break;
 		}
-		modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
+		ret = modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
+		if (ret < 0) {
+			LOG_WRN("periodic %s %s, rearming timer", "timer",
+				ret == -EBUSY ? "busy" : "failed");
+			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
+		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_PERIODIC_KICK:
@@ -1842,9 +1848,10 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 			break;
 		}
 		data->periodic_timeout_skipped = false;
-		if (modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic) <
-		    0) {
-			LOG_WRN("periodic kick busy, rearming timer");
+		ret = modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
+		if (ret < 0) {
+			LOG_WRN("periodic %s %s, rearming timer", "kick",
+				ret == -EBUSY ? "busy" : "failed");
 			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
 		}
 		break;


### PR DESCRIPTION
If the periodic script failed to start, reschedule the timer so it doesn't permanently stop.