### PR TITLE
modem: cellular: `CELLULAR_EVENT_MODEM_SUSPENDED`

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -848,6 +848,7 @@ static int modem_cellular_on_idle_state_enter(struct modem_cellular_data *data)
 	modem_cmux_release(&data->cmux);
 	modem_pipe_close_async(data->uart_pipe);
 	k_sem_give(&data->suspended_sem);
+	modem_cellular_emit_event(data, CELLULAR_EVENT_MODEM_SUSPENDED, NULL);
 	return 0;
 }
 

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -149,6 +149,8 @@ enum cellular_event {
 	CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT = BIT(2),
 	/** Cellular network status changed */
 	CELLULAR_EVENT_NETWORK_STATUS_CHANGED = BIT(3),
+	/** Cellular modem suspension callback */
+	CELLULAR_EVENT_MODEM_SUSPENDED = BIT(4),
 };
 
 /* Opaque bit-mask large enough for all current & future events */

--- a/samples/net/cellular_modem/src/main.c
+++ b/samples/net/cellular_modem/src/main.c
@@ -168,17 +168,9 @@ static int modem_cellular_find_apn(char *dst, size_t dst_sz, const char *key)
 	return -ENOENT;
 }
 
-static void modem_event_cb(const struct device *dev, enum cellular_event evt, const void *payload,
-			   void *user_data)
+static void auto_apn_modem_info_cb(const struct device *dev,
+				   const struct cellular_evt_modem_info *mi)
 {
-	ARG_UNUSED(user_data);
-
-	if (evt != CELLULAR_EVENT_MODEM_INFO_CHANGED) {
-		return;
-	}
-
-	const struct cellular_evt_modem_info *mi = payload;
-
 	if (!mi || mi->field != CELLULAR_MODEM_INFO_SIM_IMSI) {
 		return; /* not the IMSI notification */
 	}
@@ -227,6 +219,21 @@ static void modem_event_cb(const struct device *dev, enum cellular_event evt, co
 }
 
 #endif
+
+static void modem_event_cb(const struct device *dev, enum cellular_event evt, const void *payload,
+			   void *user_data)
+{
+	switch (evt) {
+	case CELLULAR_EVENT_MODEM_INFO_CHANGED:
+#ifdef CONFIG_SAMPLE_CELLULAR_MODEM_AUTO_APN
+		auto_apn_modem_info_cb(dev, payload);
+#endif
+		break;
+	default:
+		printk("Unhandled event: %d\n", evt);
+		break;
+	}
+}
 
 static void sample_dns_request_result(enum dns_resolve_status status, struct dns_addrinfo *info,
 				      void *user_data)
@@ -459,10 +466,11 @@ int main(void)
 	uint16_t *port;
 	int ret;
 
-#ifdef CONFIG_SAMPLE_CELLULAR_MODEM_AUTO_APN
-	/* subscribe before powering the modem so we catch the IMSI event */
-	cellular_set_callback(modem, CELLULAR_EVENT_MODEM_INFO_CHANGED, modem_event_cb, NULL);
-#endif
+	/* Subscribe before powering the modem so we catch all events */
+	ret = cellular_set_callback(modem, CELLULAR_EVENT_MODEM_INFO_CHANGED, modem_event_cb, NULL);
+	if (ret < 0) {
+		printk("Failed to subscribe to modem events (%d)\n", ret);
+	}
 
 	init_sample_test_packet();
 

--- a/samples/net/cellular_modem/src/main.c
+++ b/samples/net/cellular_modem/src/main.c
@@ -220,14 +220,60 @@ static void auto_apn_modem_info_cb(const struct device *dev,
 
 #endif
 
+static void modem_registration_changed(const struct device *dev,
+				       const struct cellular_evt_registration_status *rs)
+{
+	ARG_UNUSED(dev);
+
+	printk("Registration status: %d\n", rs->status);
+}
+
+static void comms_check_result(const struct device *dev,
+			       const struct cellular_evt_modem_comms_check_result *ccr)
+{
+	ARG_UNUSED(dev);
+
+	printk("Comms check %s\n", ccr->success ? "succeeded" : "failed");
+}
+
+static void network_status_changed(const struct device *dev,
+				   const struct cellular_evt_network_status *ns)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ns);
+
+	printk("Network status changed\n");
+}
+
+static void modem_suspended(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	printk("Modem suspended\n");
+}
+
 static void modem_event_cb(const struct device *dev, enum cellular_event evt, const void *payload,
 			   void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	switch (evt) {
 	case CELLULAR_EVENT_MODEM_INFO_CHANGED:
 #ifdef CONFIG_SAMPLE_CELLULAR_MODEM_AUTO_APN
 		auto_apn_modem_info_cb(dev, payload);
 #endif
+		break;
+	case CELLULAR_EVENT_REGISTRATION_STATUS_CHANGED:
+		modem_registration_changed(dev, payload);
+		break;
+	case CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT:
+		comms_check_result(dev, payload);
+		break;
+	case CELLULAR_EVENT_NETWORK_STATUS_CHANGED:
+		network_status_changed(dev, payload);
+		break;
+	case CELLULAR_EVENT_MODEM_SUSPENDED:
+		modem_suspended(dev);
 		break;
 	default:
 		printk("Unhandled event: %d\n", evt);
@@ -462,12 +508,16 @@ NET_MGMT_REGISTER_EVENT_HANDLER(l4_events, L4_EVENT_MASK, l4_event_handler, NULL
 
 int main(void)
 {
+	const cellular_event_mask_t all_events =
+		CELLULAR_EVENT_MODEM_INFO_CHANGED | CELLULAR_EVENT_REGISTRATION_STATUS_CHANGED |
+		CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT | CELLULAR_EVENT_NETWORK_STATUS_CHANGED |
+		CELLULAR_EVENT_MODEM_SUSPENDED;
 	bool valid_dns = false;
 	uint16_t *port;
 	int ret;
 
 	/* Subscribe before powering the modem so we catch all events */
-	ret = cellular_set_callback(modem, CELLULAR_EVENT_MODEM_INFO_CHANGED, modem_event_cb, NULL);
+	ret = cellular_set_callback(modem, all_events, modem_event_cb, NULL);
 	if (ret < 0) {
 		printk("Failed to subscribe to modem events (%d)\n", ret);
 	}


### PR DESCRIPTION
Add a modem event that is output when the modem transitions back to the idle state. This can be used by higher level application code to monitor unexpected transitions from the `modem_cellular` state machine.

Handle all events in the sample to demonstrate what can be monitored at the application level.