### PR TITLE
modem: cmux: allow DLCI channels to process data

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1356,10 +1356,11 @@ static bool is_valid_type(uint8_t type)
 	}
 }
 
-static void modem_cmux_process_received_byte(struct modem_cmux *cmux, int idx)
+static bool modem_cmux_process_received_byte(struct modem_cmux *cmux, int idx)
 {
 	uint8_t fcs;
 	uint8_t byte = cmux->config.receive_buf[idx];
+	bool frame_processed = false;
 
 	switch (cmux->receive_state) {
 	case MODEM_CMUX_RECEIVE_STATE_SOF:
@@ -1546,6 +1547,7 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, int idx)
 
 		/* Process frame */
 		modem_cmux_on_frame(cmux);
+		frame_processed = true;
 
 		/* Await start of next frame */
 		cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_SOF;
@@ -1554,6 +1556,8 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, int idx)
 	default:
 		break;
 	}
+
+	return frame_processed;
 }
 
 /*
@@ -1593,6 +1597,7 @@ static void modem_cmux_receive_handler(struct k_work *item)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
 	struct modem_cmux *cmux = CONTAINER_OF(dwork, struct modem_cmux, receive_work);
+	bool frame_processed = false;
 	int ret;
 
 	runtime_pm_keepalive(cmux);
@@ -1607,9 +1612,26 @@ static void modem_cmux_receive_handler(struct k_work *item)
 
 		cmux->receive_buf_len += ret;
 		for (int i = parsed; i < cmux->receive_buf_len; i++) {
-			modem_cmux_process_received_byte(cmux, i);
+			frame_processed |= modem_cmux_process_received_byte(cmux, i);
 		}
 		move_incomplete_frame(cmux);
+
+		if (frame_processed) {
+			/* Processing this buffer resulted in a CMUX frame, which must be processed
+			 * by the same workqueue we are running from. The frame will be pending on
+			 * the DLCI ring buffer.
+			 * If a second frame is pending in our receive pipe and we continue
+			 * processing CMUX bytes without giving the DLCI handler a chance to run,
+			 * we can end up dropping bytes due to a full DLCI ring buffer.
+			 * Therefore, reschedule this work with no delay so that we resume
+			 * processing our buffer after the DLCI channel has a chance to drain.
+			 * Ideally we would only do this if we knew there were more bytes to be
+			 * retrieved in `modem_pipe_receive`, but the API does not expose that
+			 * information.
+			 */
+			modem_work_reschedule(dwork, K_NO_WAIT);
+			break;
+		}
 	}
 	if (ret < 0) {
 		LOG_ERR("Pipe receiving error: %d", ret);


### PR DESCRIPTION
When the CMUX byte handling has resulted in a valid CMUX frame, give that frames handling a chance to run before continuing to process additional pending bytes. This stops a large CMUX frame followed by a smaller frame resulting in buffer overruns.

The above error case was always observed on a `nRF93M1dk` running `samples/net/cellular_modem` when it attempted to perform a DNS query, as the result was a 127 byte cmux frame followed immediately by a 20 byte cmux frame.
```
Performing DNS lookup of test-endpoint.com
[00:00:08.217,048] <err> modem_cmux: DLCI 2 receive buffer overrun
                         (dropped 14 out of 20 bytes)
```

With this PR (and some additional debug logging), the PPP handling is now interleaved between the buffers:
```
Performing DNS lookup of test-endpoint.com
[00:00:08.162,020] <inf> modem_cmux: Processing 133 byte
[00:00:08.162,097] <dbg> modem_ppp.modem_ppp_pipe_callback: Submitting PPP process work
[00:00:08.162,105] <inf> modem_cmux: Rescheduling
[00:00:08.162,174] <dbg> modem_ppp.modem_ppp_process_received_byte: Receiving PPP frame
[00:00:08.162,438] <inf> modem_cmux: Processing 26 byte
[00:00:08.162,481] <dbg> modem_ppp.modem_ppp_pipe_callback: Submitting PPP process work
[00:00:08.162,570] <dbg> modem_ppp.modem_ppp_process_received_byte: Received PPP frame (len 143)
[00:00:08.162,494] <inf> modem_cmux: Rescheduling
```
This does result in an empty run of `modem_cmux_receive_handler` after each frame, since the modem pipe API doesn't expose a way to check if any bytes are still pending, but its better than frame being dropped.
