### PR TITLE
samples: net: cellular_modem: improve DNS handling

### DIFF
--- a/samples/net/cellular_modem/src/main.c
+++ b/samples/net/cellular_modem/src/main.c
@@ -443,6 +443,7 @@ NET_MGMT_REGISTER_EVENT_HANDLER(l4_events, L4_EVENT_MASK, l4_event_handler, NULL
 
 int main(void)
 {
+	bool valid_dns = false;
 	uint16_t *port;
 	int ret;
 
@@ -487,7 +488,9 @@ int main(void)
 	ret = sample_dns_request();
 	if (ret < 0) {
 		printk("DNS query failed\n");
-		return -1;
+		goto power_cycle;
+	} else {
+		valid_dns = true;
 	}
 
 	{
@@ -529,13 +532,15 @@ int main(void)
 		return -1;
 	}
 
-	printk("Restart modem\n");
+power_cycle:
+	printk("Shutting down modem\n");
 	ret = pm_device_action_run(modem, PM_DEVICE_ACTION_SUSPEND);
 	if (ret != 0) {
 		printk("Failed to power down modem\n");
 		return -1;
 	}
 
+	printk("Restarting modem\n");
 	pm_device_action_run(modem, PM_DEVICE_ACTION_RESUME);
 
 	printk("Waiting for L4 connected\n");
@@ -549,8 +554,11 @@ int main(void)
 	/* Wait a bit to avoid (unsuccessfully) trying to send the first echo packet too quickly. */
 	k_sleep(K_SECONDS(5));
 
-	ret = sample_echo_packet(net_sad(&sample_test_dns_addrinfo.ai_addr_storage),
-				 sample_test_dns_addrinfo.ai_addrlen, port);
+	if (valid_dns) {
+		/* Only run the second echo if the original DNS succeeded */
+		ret = sample_echo_packet(net_sad(&sample_test_dns_addrinfo.ai_addr_storage),
+					sample_test_dns_addrinfo.ai_addrlen, port);
+	}
 
 	if (ret < 0) {
 		printk("Failed to send echos after restart\n");

--- a/samples/net/cellular_modem/src/main.c
+++ b/samples/net/cellular_modem/src/main.c
@@ -36,7 +36,7 @@ const struct device *modem = DEVICE_DT_GET(DT_ALIAS(modem));
 
 static uint8_t sample_test_packet[SAMPLE_TEST_PACKET_SIZE];
 static uint8_t sample_recv_buffer[SAMPLE_TEST_PACKET_SIZE];
-static bool sample_test_dns_in_progress;
+static bool sample_test_dns_success;
 static struct dns_addrinfo sample_test_dns_addrinfo;
 struct net_if *ppp_iface;
 K_EVENT_DEFINE(l4_event);
@@ -231,17 +231,23 @@ static void modem_event_cb(const struct device *dev, enum cellular_event evt, co
 static void sample_dns_request_result(enum dns_resolve_status status, struct dns_addrinfo *info,
 				      void *user_data)
 {
-	if (sample_test_dns_in_progress == false) {
-		return;
+	switch (status) {
+	case DNS_EAI_INPROGRESS:
+		sample_test_dns_success = true;
+		sample_test_dns_addrinfo = *info;
+		break;
+	case DNS_EAI_ALLDONE:
+		k_sem_give(&dns_query_sem);
+		break;
+	case DNS_EAI_AGAIN:
+	case DNS_EAI_FAIL:
+	case DNS_EAI_NONAME:
+		printk("DNS query failed: %d\n", status);
+		k_sem_give(&dns_query_sem);
+		break;
+	default:
+		printk("Unhandled DNS status: %d\n", status);
 	}
-
-	if (status != DNS_EAI_INPROGRESS) {
-		return;
-	}
-
-	sample_test_dns_in_progress = false;
-	sample_test_dns_addrinfo = *info;
-	k_sem_give(&dns_query_sem);
 }
 
 static int sample_dns_request(void)
@@ -249,7 +255,6 @@ static int sample_dns_request(void)
 	static uint16_t dns_id;
 	int ret;
 
-	sample_test_dns_in_progress = true;
 	ret = dns_get_addr_info(SAMPLE_TEST_ENDPOINT_HOSTNAME,
 				DNS_QUERY_TYPE_A,
 				&dns_id,
@@ -260,7 +265,14 @@ static int sample_dns_request(void)
 		return -EAGAIN;
 	}
 
+	/* Wait for DNS query to complete */
 	if (k_sem_take(&dns_query_sem, K_SECONDS(20)) < 0) {
+		printk("DNS query timed out\n");
+		return -EAGAIN;
+	}
+
+	/* Validate whether the query succeeded */
+	if (!sample_test_dns_success) {
 		return -EAGAIN;
 	}
 
@@ -487,7 +499,6 @@ int main(void)
 	printk("Performing DNS lookup of %s\n", SAMPLE_TEST_ENDPOINT_HOSTNAME);
 	ret = sample_dns_request();
 	if (ret < 0) {
-		printk("DNS query failed\n");
 		goto power_cycle;
 	} else {
 		valid_dns = true;

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -64,17 +64,21 @@ static int dns_dispatch(struct dns_socket_dispatcher *dispatcher,
 
 	/* Make sure that we can read DNS id, flags and rcode */
 	if (dns_msg.msg_size < (sizeof(uint16_t) + sizeof(uint16_t))) {
+		NET_WARN("Invalid message size: %d < %zd", dns_msg.msg_size,
+			 (sizeof(uint16_t) + sizeof(uint16_t)));
 		ret = -EINVAL;
 		goto done;
 	}
 
 	if (dns_header_rcode(dns_msg.msg) == DNS_HEADER_REFUSED) {
+		NET_WARN("DNS_HEADER_REFUSED");
 		ret = -EINVAL;
 		goto done;
 	}
 
 	is_query = (dns_header_qr(dns_msg.msg) == DNS_QUERY);
 	if (is_query) {
+		NET_DBG("Received %d byte DNS query message", dns_msg.msg_size);
 		if (dispatcher->type == DNS_SOCKET_RESPONDER) {
 			/* Call the responder callback */
 			ret = dispatcher->cb(dispatcher, sock,
@@ -93,6 +97,7 @@ static int dns_dispatch(struct dns_socket_dispatcher *dispatcher,
 	} else {
 		/* So this was an answer to a query that was made by resolver.
 		 */
+		NET_DBG("Received %d byte DNS answer message", dns_msg.msg_size);
 		if (dispatcher->type == DNS_SOCKET_RESOLVER) {
 			/* Call the resolver callback */
 			ret = dispatcher->cb(dispatcher, sock,


### PR DESCRIPTION
Ensure that there is some form of logging from the DNS dispatcher module at `LOG_LEVEL_DBG` when a DNS message is received and processed. Failure to do so can lead to the misleading impression that no response was received at all.

Since the default configuration of the sample will always result in a DNS query failure (since `test-endpoint.com` is not a valid URL), continue with the rest of the sample when that happens, instead of leaving the modem powered up and idling

Instead of blocking for the maximum timeout until the DNS query returns a success, block until the DNS query completes and handle whether it succeeded immediately.