### PR TITLE
drivers: adc: lpadc: separate logical and physical channels

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -319,6 +319,18 @@ ADC
   condition. In-tree boards no longer enable it explicitly in their defconfigs since
   the default already covers them.
 
+* The ``CONFIG_LPADC_CHANNEL_COUNT`` Kconfig option has been removed. The NXP LPADC driver now
+  treats hardware command slots as logical ADC channels and derives the number of logical channels
+  per instance from the ``channel`` child nodes declared for that instance in devicetree, so unused
+  command slots no longer consume RAM. Applications that lowered the Kconfig option to save RAM
+  should simply drop it. An instance that declares no ``channel`` node keeps the full hardware
+  capacity available, so applications that only ever configure channels at runtime through
+  :c:func:`adc_channel_setup` are unaffected; applications that mix both must declare in
+  devicetree the highest channel identifier they set up at runtime. Declaring a channel identifier
+  beyond the number of ``CMD`` registers implemented by the SoC is now a build error instead of a
+  runtime HAL assertion, and :c:func:`adc_read` now rejects an empty channel mask, or one selecting
+  channels beyond that limit, with ``-EINVAL`` instead of silently ignoring it (:github:`116995`).
+
 Analog Devices
 ==============
 

--- a/drivers/adc/Kconfig.mcux
+++ b/drivers/adc/Kconfig.mcux
@@ -112,16 +112,6 @@ config LPADC_DO_OFFSET_CALIBRATION
 	help
 	  Do offset calibration
 
-config LPADC_CHANNEL_COUNT
-	int "LPADC channel count"
-	default 15
-	range 1 15
-	help
-	  Amount of hardware command channels to use, reduce to save RAM.
-	  The user can reduce this value if their application uses fewer than
-	  15 ADC channels. This value corresponds to how many of the CMD
-	  registers can be configured within the ADC.
-
 config ADC_MCUX_LPADC_DMA_DRIVEN
 	bool "Use DMA to transfer data"
 	select DMA

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -36,14 +36,6 @@
 #include <fsl_lpadc.h>
 LOG_MODULE_REGISTER(nxp_mcux_lpadc);
 
-/*
- * Currently, no instance of the ADC IP has more than
- * 8 channels present. Therefore, we treat channels
- * with an index 8 or higher as a side b channel, with
- * the channel index given by channel_num % 8
- */
-#define CHANNELS_PER_SIDE 0x8
-
 #if defined(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS)
 #define ADC_CONTEXT_ENABLE_ON_COMPLETE
 #endif

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -92,7 +92,12 @@ struct mcux_lpadc_data {
 	uint16_t *buffer;
 	uint16_t *repeat_buffer;
 	uint32_t channels;
-	lpadc_conv_command_config_t cmd_config[CONFIG_LPADC_CHANNEL_COUNT];
+	/* Map each logical channel to its physical input configuration.
+	 * Sized per instance from the channel nodes present in devicetree.
+	 */
+	lpadc_conv_command_config_t *logic_to_physical;
+	/* Number of logical channels (command slots) usable on this instance. */
+	uint8_t max_channels;
 	/* OPAMP gain control context */
 	uint8_t current_gain_index;
 	int desired_gain_index;
@@ -111,7 +116,7 @@ struct mcux_lpadc_data {
 	struct dma_config dma_cfg;
 	struct dma_block_config dma_block;
 	/* Staging buffer for 32-bit RESFIFO words (max channels per round) */
-	uint32_t dma_results[CONFIG_LPADC_CHANNEL_COUNT];
+	uint32_t *dma_results;
 #endif
 };
 
@@ -207,14 +212,12 @@ static int mcux_lpadc_channel_setup(const struct device *dev,
 	uint8_t channel_num;
 	int err;
 
-	/* User may configure maximum number of active channels */
-	if (channel_cfg->channel_id >= CONFIG_LPADC_CHANNEL_COUNT) {
+	if (channel_cfg->channel_id >= data->max_channels) {
 		LOG_ERR("Channel %d is not valid", channel_cfg->channel_id);
 		return -EINVAL;
 	}
 
-	/* Select ADC CMD register to configure based off channel ID */
-	cmd = &data->cmd_config[channel_cfg->channel_id];
+	cmd = &data->logic_to_physical[channel_cfg->channel_id];
 
 	/* If bit 5 of input_positive is set, then channel side B is used */
 	channel_side = 0x20 & channel_cfg->input_positive;
@@ -344,6 +347,7 @@ static int mcux_lpadc_start_read(const struct device *dev,
 	struct mcux_lpadc_data *data = dev->data;
 	lpadc_hardware_average_mode_t hardware_average_mode;
 	uint8_t channel, last_enabled;
+	uint8_t channel_count = POPCOUNT(sequence->channels);
 	int ret;
 #if defined(FSL_FEATURE_LPADC_HAS_CMDL_MODE) && FSL_FEATURE_LPADC_HAS_CMDL_MODE
 	lpadc_conversion_resolution_mode_t resolution_mode;
@@ -400,8 +404,14 @@ static int mcux_lpadc_start_read(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	ret = adc_sequence_validate_buffer(sequence,
-					   POPCOUNT(sequence->channels), sizeof(uint16_t));
+	if (channel_count == 0U ||
+	    (sequence->channels & ~BIT_MASK(data->max_channels)) != 0U) {
+		LOG_ERR("Invalid channel mask 0x%08x", sequence->channels);
+		return -EINVAL;
+	}
+
+	ret = adc_sequence_validate_buffer(sequence, channel_count,
+					   sizeof(uint16_t));
 	if (ret < 0) {
 		return ret;
 	}
@@ -410,36 +420,29 @@ static int mcux_lpadc_start_read(const struct device *dev,
 	 * Now, look at the selected channels to determine which ADC channels
 	 * we need to configure, and set those channels up.
 	 *
-	 * Since this ADC supports chaining channels in hardware, we will
-	 * start with the highest channel ID and work downwards, chaining
-	 * channels as we go.
+	 * Since this ADC supports chaining channels in hardware, start with
+	 * the highest logical channel and work downwards, chaining as we go.
 	 */
-	channel = CONFIG_LPADC_CHANNEL_COUNT;
-	last_enabled = 0;
-	while (channel-- > 0) {
+	channel = data->max_channels;
+	last_enabled = 0U;
+	while (channel-- > 0U) {
 		if (sequence->channels & BIT(channel)) {
-			/* Setup this channel command */
+			lpadc_conv_command_config_t *physical_config =
+				&data->logic_to_physical[channel];
+
 #if defined(FSL_FEATURE_LPADC_HAS_CMDL_MODE) && FSL_FEATURE_LPADC_HAS_CMDL_MODE
-			data->cmd_config[channel].conversionResolutionMode =
+			physical_config->conversionResolutionMode =
 				resolution_mode;
 #endif
-			data->cmd_config[channel].hardwareAverageMode =
+			physical_config->hardwareAverageMode =
 				hardware_average_mode;
-			if (last_enabled) {
-				/* Chain channel */
-				data->cmd_config[channel].chainedNextCommandNumber =
-					last_enabled + 1;
-				LOG_DBG("Chaining channel %u to %u",
-					channel, last_enabled);
-			} else {
-				/* End of chain */
-				data->cmd_config[channel].chainedNextCommandNumber = 0;
-			}
+			physical_config->chainedNextCommandNumber =
+				(last_enabled == 0U) ? 0U : last_enabled + 1U;
 			last_enabled = channel;
 			LPADC_SetConvCommandConfig(config->base,
-				channel + 1, &data->cmd_config[channel]);
+				channel + 1U, physical_config);
 		}
-	};
+	}
 
 	data->buffer = sequence->buffer;
 
@@ -538,12 +541,10 @@ static void mcux_lpadc_start_channel(const struct device *dev)
 	const struct mcux_lpadc_config *config = dev->config;
 	struct mcux_lpadc_data *data = dev->data;
 	lpadc_conv_trigger_config_t trigger_config;
-	uint8_t first_channel;
-
-	first_channel = find_lsb_set(data->channels) - 1;
+	uint8_t first_channel = find_lsb_set(data->channels) - 1U;
 
 	LOG_DBG("Starting channel %d, input %d", first_channel,
-		data->cmd_config[first_channel].channelNumber);
+		data->logic_to_physical[first_channel].channelNumber);
 
 	/* Apply any pending OPAMP gain change synchronously at the start of
 	 * the next sampling round, so the adjustment takes effect immediately.
@@ -566,7 +567,7 @@ static void mcux_lpadc_start_channel(const struct device *dev)
 
 	LPADC_GetDefaultConvTriggerConfig(&trigger_config);
 
-	trigger_config.targetCommandId = first_channel + 1;
+	trigger_config.targetCommandId = first_channel + 1U;
 
 	/* configures trigger0. */
 	LPADC_SetConvTriggerConfig(config->base, 0, &trigger_config);
@@ -611,7 +612,7 @@ static void mcux_lpadc_dma_callback(const struct device *dma_dev, void *user_dat
 	uint32_t written = 0U;
 
 	for (uint8_t ch = 0U;
-		ch < CONFIG_LPADC_CHANNEL_COUNT && written < data->channels_count; ch++) {
+	     ch < data->max_channels && written < data->channels_count; ch++) {
 		/* Skip channels not requested in this sequence. */
 		if (!(data->ctx.sequence.channels & BIT(ch))) {
 			continue;
@@ -623,7 +624,8 @@ static void mcux_lpadc_dma_callback(const struct device *dma_dev, void *user_dat
 		bool is_diff = false;
 
 #if defined(FSL_FEATURE_LPADC_HAS_B_SIDE_CHANNELS) && (FSL_FEATURE_LPADC_HAS_B_SIDE_CHANNELS)
-		lpadc_sample_channel_mode_t conv_mode = data->cmd_config[ch].sampleChannelMode;
+		lpadc_sample_channel_mode_t conv_mode =
+			data->logic_to_physical[ch].sampleChannelMode;
 #if defined(FSL_FEATURE_LPADC_HAS_CMDL_DIFF) && (FSL_FEATURE_LPADC_HAS_CMDL_DIFF)
 		is_diff = (conv_mode == kLPADC_SampleChannelDiffBothSideAB ||
 			   conv_mode == kLPADC_SampleChannelDiffBothSideBA);
@@ -774,7 +776,7 @@ static void mcux_lpadc_isr(const struct device *dev)
 	LPADC_GetConvResult(base, &conv_result);
 #endif /* FSL_FEATURE_LPADC_FIFO_COUNT */
 
-	channel = conv_result.commandIdSource - 1;
+	channel = conv_result.commandIdSource - 1U;
 	LOG_DBG("Finished channel %d. Raw result is 0x%04x",
 		channel, conv_result.convValue);
 	/*
@@ -786,7 +788,7 @@ static void mcux_lpadc_isr(const struct device *dev)
 	 * API should treat the value as signed if the channel is
 	 * in differential mode
 	 */
-	conv_mode = data->cmd_config[channel].sampleChannelMode;
+	conv_mode = data->logic_to_physical[channel].sampleChannelMode;
 	if (data->ctx.sequence.resolution < 15) {
 		result = ((conv_result.convValue >> 3) & 0xFFF);
 #if !(defined(FSL_FEATURE_LPADC_HAS_B_SIDE_CHANNELS) && \
@@ -1067,6 +1069,22 @@ static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 #define OPAMP_CH_ID(n) DT_PHA_BY_IDX(DT_DRV_INST(n), nxp_opamps, 0, channel_id)
 #define OPAMP_CH_NODE(n) DT_FOREACH_CHILD_VARGS(DT_DRV_INST(n),	\
 	LPADC_FOREACH_INPUT, OPAMP_CH_ID(n))
+
+/*
+ * Logical channels are hardware command slots. Size the per-instance command
+ * table from the channel nodes declared in devicetree, so slots the application
+ * does not describe cost no RAM. An instance without any channel node keeps the
+ * full hardware capacity available, since its channels can only be set up at
+ * runtime through adc_channel_setup().
+ */
+#define LPADC_CHANNEL_ID_BIT(node) \
+	IF_ENABLED(DT_NODE_HAS_PROP(node, reg), (BIT(DT_REG_ADDR_RAW(node)) |))
+#define LPADC_CHANNEL_ID_MASK(n) \
+	(DT_INST_FOREACH_CHILD_STATUS_OKAY(n, LPADC_CHANNEL_ID_BIT) 0)
+#define LPADC_MAX_CHANNELS(n)								\
+	(LPADC_CHANNEL_ID_MASK(n) == 0U						\
+		 ? ADC_CMDL_COUNT						\
+		 : LOG2(LPADC_CHANNEL_ID_MASK(n)) + 1)
 #define OPAMP_GAINS_INIT(n)								\
 	.opamp_gains = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, nxp_opamps),		\
 		(COND_CODE_1(DT_NODE_HAS_PROP(OPAMP_NODE(n), programmable_gain),	\
@@ -1085,8 +1103,14 @@ static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 			(DT_INST_DMAS_CELL_BY_NAME(n, fifoa, mux)), (0)),		\
 	.dma_slot = COND_CODE_1(DT_INST_DMAS_HAS_NAME(n, fifoa),			\
 			(DT_INST_DMAS_CELL_BY_NAME(n, fifoa, source)), (0)),
+#define DMA_RESULTS_DEFINE(n)								\
+	static uint32_t mcux_lpadc_dma_results_##n[LPADC_MAX_CHANNELS(n)];
+#define DMA_RESULTS_INIT(n)								\
+	.dma_results = mcux_lpadc_dma_results_##n,
 #else
 #define DMA_INIT(n)
+#define DMA_RESULTS_DEFINE(n)
+#define DMA_RESULTS_INIT(n)
 #endif
 
 #if defined(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS)
@@ -1150,10 +1174,17 @@ static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 		DMA_INIT(n)									\
 	};											\
 												\
+	static lpadc_conv_command_config_t							\
+		mcux_lpadc_cmd_config_##n[LPADC_MAX_CHANNELS(n)];				\
+	DMA_RESULTS_DEFINE(n)									\
+												\
 	static struct mcux_lpadc_data mcux_lpadc_data_##n = {					\
 		ADC_CONTEXT_INIT_TIMER(mcux_lpadc_data_##n, ctx),				\
 		ADC_CONTEXT_INIT_LOCK(mcux_lpadc_data_##n, ctx),				\
 		ADC_CONTEXT_INIT_SYNC(mcux_lpadc_data_##n, ctx),				\
+		.logic_to_physical = mcux_lpadc_cmd_config_##n,					\
+		.max_channels = LPADC_MAX_CHANNELS(n),						\
+		DMA_RESULTS_INIT(n)								\
 	};											\
 												\
 	LPADC_PM_DEVICE_DEFINE									\
@@ -1173,6 +1204,9 @@ static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 	BUILD_ASSERT((DT_INST_PROP_OR(n, power_level, 0) >= 0) &&				\
 		     (DT_INST_PROP_OR(n, power_level, 0) <= 3), "power_level: wrong value");	\
 	BUILD_ASSERT((0 DT_FOREACH_CHILD(DT_DRV_INST(n), LPADC_BANDGAP_SUPPLY_COUNT)) <= 1,	\
-		     "Only one LPADC channel may define bandgap-supply");
+		     "Only one LPADC channel may define bandgap-supply");			\
+												\
+	BUILD_ASSERT(LPADC_MAX_CHANNELS(n) <= ADC_CMDL_COUNT,					\
+		     "channel id exceeds the CMD registers implemented by this SoC");
 
 DT_INST_FOREACH_STATUS_OKAY(LPADC_MCUX_INIT)


### PR DESCRIPTION
Refactor the LPADC driver so hardware command slots represent logical ADC channels, while each slot independently selects a physical input. This architecture matches both the ADC API and LPADC hardware model, keeps hardware capacity in the HAL as a single source of truth, avoids invalid command access, and supports physical inputs beyond the number of command slots.

Fixes #115563.