### PR TITLE
drivers: pcie: fix PTM register access

### DIFF
--- a/drivers/pcie/host/ptm.c
+++ b/drivers/pcie/host/ptm.c
@@ -21,22 +21,31 @@ LOG_MODULE_REGISTER(pcie);
 #include <zephyr/drivers/pcie/pcie.h>
 #include "ptm.h"
 
+static void pcie_ptm_control_enable(pcie_bdf_t bdf, uint32_t base, bool root)
+{
+	uint32_t ctrl;
+
+	ctrl = pcie_conf_read(bdf, base + PTM_CTRL_REG_OFFSET);
+	ctrl |= PTM_CTRL_ENABLE;
+	if (root) {
+		ctrl |= PTM_CTRL_ROOT;
+	}
+
+	pcie_conf_write(bdf, base + PTM_CTRL_REG_OFFSET, ctrl);
+}
+
 static int pcie_ptm_root_setup(const struct device *dev, uint32_t base)
 {
 	const struct pcie_ptm_root_config *config = dev->config;
-	union ptm_cap_reg cap;
-	union ptm_ctrl_reg ctrl;
+	uint32_t cap;
 
-	cap.raw = pcie_conf_read(config->pcie->bdf, base + PTM_CAP_REG_OFFSET);
-	if ((cap.root == 0) || ((cap.root == 1) && (cap.responder == 0))) {
+	cap = pcie_conf_read(config->pcie->bdf, base + PTM_CAP_REG_OFFSET);
+	if ((cap & PTM_CAP_ROOT) == 0 || (cap & PTM_CAP_RESPONDER) == 0) {
 		LOG_ERR("PTM root not supported on 0x%x", config->pcie->bdf);
 		return -ENOTSUP;
 	}
 
-	ctrl.ptm_enable = 1;
-	ctrl.root_select = 1;
-
-	pcie_conf_write(config->pcie->bdf, base + PTM_CTRL_REG_OFFSET, ctrl.raw);
+	pcie_ptm_control_enable(config->pcie->bdf, base, true);
 
 	LOG_DBG("PTM root 0x%x enabled", config->pcie->bdf);
 
@@ -72,8 +81,7 @@ DT_INST_FOREACH_STATUS_OKAY(PCIE_PTM_ROOT_INIT)
 bool pcie_ptm_enable(pcie_bdf_t bdf)
 {
 	uint32_t base;
-	union ptm_cap_reg cap;
-	union ptm_ctrl_reg ctrl;
+	uint32_t cap;
 
 	base = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_ID_PTM);
 	if (base == 0) {
@@ -81,15 +89,13 @@ bool pcie_ptm_enable(pcie_bdf_t bdf)
 		return false;
 	}
 
-	cap.raw = pcie_conf_read(bdf, base + PTM_CAP_REG_OFFSET);
-	if (cap.requester == 0) {
+	cap = pcie_conf_read(bdf, base + PTM_CAP_REG_OFFSET);
+	if ((cap & PTM_CAP_REQUESTER) == 0) {
 		LOG_ERR("PTM requester not supported on 0x%x", bdf);
 		return false;
 	}
 
-	ctrl.ptm_enable = 1;
-
-	pcie_conf_write(bdf, base + PTM_CTRL_REG_OFFSET, ctrl.raw);
+	pcie_ptm_control_enable(bdf, base, false);
 
 	LOG_DBG("PTM requester 0x%x enabled", bdf);
 

--- a/drivers/pcie/host/ptm.h
+++ b/drivers/pcie/host/ptm.h
@@ -9,33 +9,21 @@
 
 #include <zephyr/drivers/pcie/pcie.h>
 #include <zephyr/drivers/pcie/cap.h>
+#include <zephyr/sys/util.h>
 
-#define PTM_CAP_REG_OFFSET 0x04U
+/* pcie_conf_read()/pcie_conf_write() use DWORD indices, not byte offsets. */
+#define PTM_REG_OFFSET(_offset) ((_offset) / sizeof(uint32_t))
 
-union ptm_cap_reg {
-	struct {
-		uint32_t requester               : 1;
-		uint32_t responder               : 1;
-		uint32_t root                    : 1;
-		uint32_t _reserved1              : 5;
-		uint32_t local_clock_granularity : 8;
-		uint32_t _reserved2              : 16;
-	};
-	uint32_t raw;
-};
+#define PTM_CAP_REG_OFFSET PTM_REG_OFFSET(0x04U)
+#define PTM_CAP_REQUESTER  BIT(0)
+#define PTM_CAP_RESPONDER  BIT(1)
+#define PTM_CAP_ROOT                    BIT(2)
+#define PTM_CAP_LOCAL_CLOCK_GRANULARITY GENMASK(15, 8)
 
-#define PTM_CTRL_REG_OFFSET 0x08U
-
-union ptm_ctrl_reg {
-	struct {
-		uint32_t ptm_enable            : 1;
-		uint32_t root_select           : 1;
-		uint32_t _reserved1            : 6;
-		uint32_t effective_granularity : 8;
-		uint32_t _reserved2            : 16;
-	};
-	uint32_t raw;
-};
+#define PTM_CTRL_REG_OFFSET PTM_REG_OFFSET(0x08U)
+#define PTM_CTRL_ENABLE     BIT(0)
+#define PTM_CTRL_ROOT                  BIT(1)
+#define PTM_CTRL_EFFECTIVE_GRANULARITY GENMASK(15, 8)
 
 struct pcie_ptm_root_config {
 	struct pcie_dev *pcie;

--- a/tests/drivers/pcie/ptm/CMakeLists.txt
+++ b/tests/drivers/pcie/ptm/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(pcie_ptm)
+
+target_sources(app PRIVATE src/main.c)
+target_compile_definitions(app PRIVATE CONFIG_PCIE_LOG_LEVEL=0)

--- a/tests/drivers/pcie/ptm/prj.conf
+++ b/tests/drivers/pcie/ptm/prj.conf
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y

--- a/tests/drivers/pcie/ptm/src/main.c
+++ b/tests/drivers/pcie/ptm/src/main.c
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+
+#include <zephyr/drivers/pcie/cap.h>
+#include <zephyr/drivers/pcie/pcie.h>
+#include <zephyr/drivers/pcie/ptm.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/ztest.h>
+
+#define TEST_BDF PCIE_BDF(0, 1, 0)
+#define TEST_PTM_BASE PCIE_CONF_EXT_CAPPTR
+
+#define TEST_PTM_CAP_REG  (TEST_PTM_BASE + (0x04U / sizeof(uint32_t)))
+#define TEST_PTM_CTRL_REG (TEST_PTM_BASE + (0x08U / sizeof(uint32_t)))
+
+#define TEST_PTM_CAP_REQUESTER BIT(0)
+#define TEST_PTM_CAP_RESPONDER BIT(1)
+#define TEST_PTM_CAP_ROOT      BIT(2)
+#define TEST_PTM_CTRL_ENABLE   BIT(0)
+#define TEST_PTM_CTRL_ROOT     BIT(1)
+
+#define TEST_CTRL_PATTERN 0xA5C35A5CU
+#define TEST_CFG_DWORDS   128U
+#define TEST_READ_HISTORY 8U
+#define TEST_WRITE_HISTORY 4U
+
+static uint32_t config_space[TEST_CFG_DWORDS];
+static unsigned int read_regs[TEST_READ_HISTORY];
+static unsigned int write_regs[TEST_WRITE_HISTORY];
+static uint32_t write_values[TEST_WRITE_HISTORY];
+static size_t read_count;
+static size_t write_count;
+static bool cap_present;
+
+uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id)
+{
+	zassert_equal(bdf, TEST_BDF);
+	zassert_equal(cap_id, PCIE_EXT_CAP_ID_PTM);
+
+	return cap_present ? TEST_PTM_BASE : 0U;
+}
+
+uint32_t pcie_conf_read(pcie_bdf_t bdf, unsigned int reg)
+{
+	zassert_equal(bdf, TEST_BDF);
+	zassert_true(reg < ARRAY_SIZE(config_space),
+		     "configuration register %u is out of range", reg);
+	zassert_true(read_count < ARRAY_SIZE(read_regs), "read history overflow");
+
+	read_regs[read_count++] = reg;
+	return config_space[reg];
+}
+
+void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
+{
+	zassert_equal(bdf, TEST_BDF);
+	zassert_true(reg < ARRAY_SIZE(config_space),
+		     "configuration register %u is out of range", reg);
+	zassert_true(write_count < ARRAY_SIZE(write_regs), "write history overflow");
+
+	config_space[reg] = data;
+	write_regs[write_count] = reg;
+	write_values[write_count] = data;
+	write_count++;
+}
+
+/* Include the real PTM implementation so the static root init path is testable. */
+#include "../../../../../drivers/pcie/host/ptm.c"
+
+static struct pcie_dev root_pcie = {
+	.bdf = TEST_BDF,
+};
+
+static const struct pcie_ptm_root_config root_config = {
+	.pcie = &root_pcie,
+};
+
+static struct device root_device = {
+	.name = "pcie-ptm-root-test",
+	.config = &root_config,
+};
+
+static void reset_config_space(void)
+{
+	memset(config_space, 0, sizeof(config_space));
+	memset(read_regs, 0, sizeof(read_regs));
+	memset(write_regs, 0, sizeof(write_regs));
+	memset(write_values, 0, sizeof(write_values));
+
+	read_count = 0U;
+	write_count = 0U;
+	cap_present = true;
+
+	config_space[TEST_PTM_CAP_REG] = TEST_PTM_CAP_REQUESTER;
+	config_space[TEST_PTM_CTRL_REG] = TEST_CTRL_PATTERN;
+}
+
+static void before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	reset_config_space();
+}
+
+ZTEST(pcie_ptm, test_enable_uses_dword_offsets_and_preserves_control)
+{
+	zassert_true(pcie_ptm_enable(TEST_BDF));
+
+	zassert_equal(read_count, 2U);
+	zassert_equal(read_regs[0], TEST_PTM_CAP_REG);
+	zassert_equal(read_regs[1], TEST_PTM_CTRL_REG);
+	zassert_equal(write_count, 1U);
+	zassert_equal(write_regs[0], TEST_PTM_CTRL_REG);
+	zassert_equal(write_values[0], TEST_CTRL_PATTERN | TEST_PTM_CTRL_ENABLE);
+	zassert_equal(config_space[TEST_PTM_CTRL_REG], TEST_CTRL_PATTERN | TEST_PTM_CTRL_ENABLE);
+	zassert_false(write_values[0] & TEST_PTM_CTRL_ROOT);
+}
+
+ZTEST(pcie_ptm, test_root_enable_uses_dword_offsets_and_preserves_control)
+{
+	config_space[TEST_PTM_CAP_REG] = TEST_PTM_CAP_RESPONDER | TEST_PTM_CAP_ROOT;
+
+	zassert_equal(pcie_ptm_root_init(&root_device), 0);
+
+	zassert_equal(read_count, 2U);
+	zassert_equal(read_regs[0], TEST_PTM_CAP_REG);
+	zassert_equal(read_regs[1], TEST_PTM_CTRL_REG);
+	zassert_equal(write_count, 1U);
+	zassert_equal(write_regs[0], TEST_PTM_CTRL_REG);
+	zassert_equal(write_values[0],
+		      TEST_CTRL_PATTERN | TEST_PTM_CTRL_ENABLE | TEST_PTM_CTRL_ROOT);
+	zassert_equal(config_space[TEST_PTM_CTRL_REG],
+		      TEST_CTRL_PATTERN | TEST_PTM_CTRL_ENABLE | TEST_PTM_CTRL_ROOT);
+}
+
+ZTEST(pcie_ptm, test_root_requires_responder_capability)
+{
+	config_space[TEST_PTM_CAP_REG] = TEST_PTM_CAP_ROOT;
+
+	zassert_equal(pcie_ptm_root_init(&root_device), -ENOTSUP);
+
+	zassert_equal(read_count, 1U);
+	zassert_equal(read_regs[0], TEST_PTM_CAP_REG);
+	zassert_equal(write_count, 0U);
+	zassert_equal(config_space[TEST_PTM_CTRL_REG], TEST_CTRL_PATTERN);
+}
+
+ZTEST(pcie_ptm, test_root_requires_root_capability)
+{
+	config_space[TEST_PTM_CAP_REG] = TEST_PTM_CAP_RESPONDER;
+
+	zassert_equal(pcie_ptm_root_init(&root_device), -ENOTSUP);
+
+	zassert_equal(read_count, 1U);
+	zassert_equal(read_regs[0], TEST_PTM_CAP_REG);
+	zassert_equal(write_count, 0U);
+	zassert_equal(config_space[TEST_PTM_CTRL_REG], TEST_CTRL_PATTERN);
+}
+
+ZTEST(pcie_ptm, test_missing_requester_capability_does_not_write)
+{
+	config_space[TEST_PTM_CAP_REG] = TEST_PTM_CAP_RESPONDER;
+
+	zassert_false(pcie_ptm_enable(TEST_BDF));
+
+	zassert_equal(read_count, 1U);
+	zassert_equal(read_regs[0], TEST_PTM_CAP_REG);
+	zassert_equal(write_count, 0U);
+	zassert_equal(config_space[TEST_PTM_CTRL_REG], TEST_CTRL_PATTERN);
+}
+
+ZTEST(pcie_ptm, test_missing_ptm_capability_does_not_access_config_space)
+{
+	cap_present = false;
+
+	zassert_false(pcie_ptm_enable(TEST_BDF));
+
+	zassert_equal(read_count, 0U);
+	zassert_equal(write_count, 0U);
+	zassert_equal(config_space[TEST_PTM_CTRL_REG], TEST_CTRL_PATTERN);
+}
+
+ZTEST_SUITE(pcie_ptm, NULL, NULL, before, NULL, NULL);

--- a/tests/drivers/pcie/ptm/tests.yaml
+++ b/tests/drivers/pcie/ptm/tests.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.pcie.ptm:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - drivers
+      - pcie


### PR DESCRIPTION
## Summary

Fix PCIe Precision Time Management register access and control updates.

Zephyr's PCIe configuration helpers use DWORD indices, but the PTM code added the capability register byte offsets (`0x04` and `0x08`) directly to the extended capability base. This made it access the wrong configuration registers.

The enable paths also built the PTM Control DWORD from an uninitialized bitfield union and wrote the whole value, which could set indeterminate bits and overwrite existing control fields.

This change:
- converts PTM register offsets to DWORD indices;
- replaces the PTM bitfield unions with explicit masks;
- uses read-modify-write for PTM Control so existing bits are preserved;
- adds simulated PCIe configuration-space tests for exact register addressing, requester enable, control preservation, and missing-capability cases.

Validation:
- `native_sim`: PASS
- `native_sim/native/64`: PASS
- 2/2 configurations: PASS
- 12/12 ztest cases: PASS
- `checkpatch.pl --strict`: 0 errors, 0 warnings
- `git diff --check`: PASS
- GitHub Actions run: https://github.com/alesanGreat/zephyr/actions/runs/33026104083
