### PR TITLE
Bluetooth: OTS: Fix reachable assert in OACP checksum responses

### DIFF
--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -648,7 +648,9 @@ static void oacp_ind_send(const struct bt_gatt_attr *oacp_attr,
 	oacp_res[oacp_res_len++] = oacp_proc.type;
 	oacp_res[oacp_res_len++] = oacp_status;
 
-	if (oacp_proc.type == BT_GATT_OTS_OACP_PROC_CHECKSUM_CALC) {
+	/* The Checksum Value field is only present when the procedure succeeded. */
+	if (oacp_proc.type == BT_GATT_OTS_OACP_PROC_CHECKSUM_CALC &&
+	    oacp_status == BT_GATT_OTS_OACP_RES_SUCCESS) {
 		sys_put_le32(net_buf_simple_pull_le32(resp_param), (oacp_res + oacp_res_len));
 		oacp_res_len += sizeof(uint32_t);
 	}

--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -395,6 +395,7 @@ static int oacp_command_decode(const uint8_t *buf, uint16_t len,
 
 		return 0;
 #endif
+#if defined(CONFIG_BT_OTS_OACP_CHECKSUM_SUPPORT)
 	case BT_GATT_OTS_OACP_PROC_CHECKSUM_CALC:
 		if (net_buf.len != BT_GATT_OTS_OACP_CS_CALC_PARAMS_SIZE) {
 			return -EBADMSG;
@@ -405,6 +406,7 @@ static int oacp_command_decode(const uint8_t *buf, uint16_t len,
 			net_buf_simple_pull_le32(&net_buf);
 
 		return 0;
+#endif
 	case BT_GATT_OTS_OACP_PROC_EXECUTE:
 		if (net_buf.len != 0) {
 			return -EBADMSG;


### PR DESCRIPTION
oacp_ind_send() appended the Checksum Value based on the op code alone, but
validation only fills the response buffer on success. Every error path then
pulled four bytes from an empty buffer: a panic with assertions on, a stale
stack read without. Reachable by any connected peer, unpaired.

Fixes: #117515