### PR TITLE
scripts: ci: fix BoilerplateFilter line matching

### DIFF
--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -3444,10 +3444,13 @@ class BoilerplateFilter(SelectionStrategy):
     # Applied to the line content after stripping the leading ``+`` / ``-``.
     _BOILERPLATE_LINE_RE = re.compile(
         r"^\s*(?:"
+        r"(?:[/*#]+\s*)?"
+        r"(?:"
         r"SPDX-License-Identifier:"
         r"|SPDX-FileCopyrightText:"
         r"|Copyright\b"
-        r"|[/*#]+\s*"  # comment delimiters only (e.g. bare ``*`` or ``//``)
+        r").*"
+        r"|[/*#]+"  # comment delimiters only (e.g. bare ``*`` or ``//``)
         r")\s*",
         re.IGNORECASE,
     )
@@ -3565,7 +3568,7 @@ class BoilerplateFilter(SelectionStrategy):
             content = raw_line[1:]  # strip leading + or -
             if not content.strip():
                 continue  # blank / whitespace-only line
-            if self._BOILERPLATE_LINE_RE.search(content):
+            if self._BOILERPLATE_LINE_RE.fullmatch(content):
                 continue  # boilerplate content
             return False  # substantive change found
         return True

--- a/scripts/tests/ci/test_test_plan_v2.py
+++ b/scripts/tests/ci/test_test_plan_v2.py
@@ -478,6 +478,25 @@ class TestBoilerplateFilter:
         s = tp.BoilerplateFilter()
         assert s._all_changes_boilerplate(diff) is False
 
+    def test_delimiter_prefixed_substantive_changes_detected(self):
+        changes = [
+            ("#define FOO_TIMEOUT 100", "#define FOO_TIMEOUT 200"),
+            ("#include <zephyr/foo.h>", "#include <zephyr/bar.h>"),
+            ("*ptr = 1;", "*ptr = 0;"),
+        ]
+
+        s = tp.BoilerplateFilter()
+
+        for old, new in changes:
+            diff = textwrap.dedent(f"""\
+                --- a/drivers/foo/foo.c
+                +++ b/drivers/foo/foo.c
+                @@ -20 +20 @@
+                -{old}
+                +{new}
+            """)
+            assert s._all_changes_boilerplate(diff) is False
+
     def test_mixed_boilerplate_and_code_not_boilerplate(self):
         diff = textwrap.dedent("""\
             --- a/drivers/foo/foo.c
@@ -535,6 +554,18 @@ class TestBoilerplateFilter:
             @@ -20 +20 @@
             -\treturn 0;
             +\treturn -EIO;
+        """)
+        s = self._strategy({"drivers/foo/foo.c": (code_diff, code_diff)})
+        _, handled = s.analyze(["drivers/foo/foo.c"])
+        assert "drivers/foo/foo.c" not in handled
+
+    def test_preprocessor_change_not_consumed(self):
+        code_diff = textwrap.dedent("""\
+            --- a/drivers/foo/foo.c
+            +++ b/drivers/foo/foo.c
+            @@ -20 +20 @@
+            -#define FOO_TIMEOUT 100
+            +#define FOO_TIMEOUT 200
         """)
         s = self._strategy({"drivers/foo/foo.c": (code_diff, code_diff)})
         _, handled = s.analyze(["drivers/foo/foo.c"])


### PR DESCRIPTION
## Summary

Fix `BoilerplateFilter` incorrectly treating substantive changed lines as
boilerplate and consuming the affected files.

The filter currently uses a partial regular expression match when classifying
changed lines. As a result, the comment-delimiter pattern can match only
the leading `#` or `*` in substantive lines such as `#define`, `#include`, or 
pointer assignments, causing the entire line to be treated as boilerplate.

Use a full-line match instead, while preserving the existing handling of SPDX
and copyright lines.

Add regression tests to verify that delimiter-prefixed substantive changes are
detected and that affected files are not consumed by `BoilerplateFilter`.

## Testing
- `python -m pytest scripts/tests/ci/test_test_plan_v2.py::TestBoilerplateFilter -v`
- `python -m pytest scripts/tests/ci/test_test_plan_v2.py -v`