### PR TITLE
drivers: virtio: fix PCI capability parsing

### DIFF
--- a/drivers/virtio/virtio_pci.c
+++ b/drivers/virtio/virtio_pci.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/device.h>
+#include <zephyr/drivers/pcie/cap.h>
 #include <zephyr/drivers/pcie/pcie.h>
 #include <zephyr/kernel/mm.h>
 #include <zephyr/logging/log.h>
@@ -74,6 +75,7 @@ struct virtio_pci_common_cfg {
 #define VIRTIO_PCI_CAP_PCI_CFG 5
 #define VIRTIO_PCI_CAP_SHARED_MEMORY_CFG 8
 #define VIRTIO_PCI_CAP_VENDOR_CFG 9
+#define VIRTIO_PCI_BAR_MAX 5U
 
 #define CABABILITY_LIST_VALID_BIT 4
 #define STATUS_COMMAND_REG 0x1
@@ -142,15 +144,20 @@ static bool virtio_pci_read_cap(
 		for (int i = 0; i < sizeof(struct virtio_pci_cap) / sizeof(uint32_t); i++) {
 			((uint32_t *)&tmp)[i] = pcie_conf_read(bdf, cap_off + i);
 		}
-		if (tmp.cfg_type == cfg_type) {
-			if (tmp.cap_len < sizeof(struct virtio_pci_cap) ||
-			    tmp.cap_len > cap_struct_size) {
+		if (tmp.cap_vndr == PCI_CAP_ID_VNDR && tmp.cfg_type == cfg_type &&
+		    tmp.bar <= VIRTIO_PCI_BAR_MAX) {
+			/*
+			 * cap_len may include padding or fields unused by this driver.
+			 * Require the bytes we consume, then copy only that many.
+			 */
+			if (tmp.cap_len < cap_struct_size) {
 				LOG_ERR("invalid virtio pci cap_len %u for bdf 0x%x",
 					tmp.cap_len, bdf);
 				return false;
 			}
 			size_t extra_data_words =
-				(tmp.cap_len - sizeof(struct virtio_pci_cap)) / sizeof(uint32_t);
+				(cap_struct_size - sizeof(struct virtio_pci_cap)) /
+				sizeof(uint32_t);
 			size_t extra_data_offset =
 				cap_off + sizeof(struct virtio_pci_cap) / sizeof(uint32_t);
 			uint32_t *extra_data =
@@ -425,7 +432,7 @@ static int virtio_pci_init_common(const struct device *dev)
 
 	if (conf->pcie->bdf == PCIE_BDF_NONE) {
 		LOG_ERR("no virtio pci device with id 0x%x on the bus", conf->pcie->id);
-		return 1;
+		return -ENODEV;
 	}
 	LOG_INF(
 		"found virtio pci device with id 0x%x and bdf 0x%x", conf->pcie->id, conf->pcie->bdf
@@ -433,7 +440,7 @@ static int virtio_pci_init_common(const struct device *dev)
 
 	if (virtio_pci_read_cap(conf->pcie->bdf, VIRTIO_PCI_CAP_COMMON_CFG, &vpc, sizeof(vpc))) {
 		if (!virtio_pci_map_cap(conf->pcie->bdf, &vpc, (void **)&data->common_cfg)) {
-			return 1;
+			return -EINVAL;
 		}
 	} else {
 		LOG_ERR(
@@ -441,12 +448,12 @@ static int virtio_pci_init_common(const struct device *dev)
 			conf->pcie->id,
 			conf->pcie->bdf
 		);
-		return 1;
+		return -EINVAL;
 	}
 
 	if (virtio_pci_read_cap(conf->pcie->bdf, VIRTIO_PCI_CAP_ISR_CFG, &vpc, sizeof(vpc))) {
 		if (!virtio_pci_map_cap(conf->pcie->bdf, &vpc, (void **)&data->isr_status)) {
-			return 1;
+			return -EINVAL;
 		}
 	} else {
 		LOG_ERR(
@@ -454,14 +461,14 @@ static int virtio_pci_init_common(const struct device *dev)
 			conf->pcie->id,
 			conf->pcie->bdf
 		);
-		return 1;
+		return -EINVAL;
 	}
 
 	if (virtio_pci_read_cap(conf->pcie->bdf, VIRTIO_PCI_CAP_NOTIFY_CFG, &vpnc, sizeof(vpnc))) {
 		if (!virtio_pci_map_cap(
 				conf->pcie->bdf, (struct virtio_pci_cap *)&vpnc,
 				(void **)&data->notify_cfg)) {
-			return 1;
+			return -EINVAL;
 		}
 		data->notify_off_multiplier = sys_le32_to_cpu(vpnc.notify_off_multiplier);
 	} else {
@@ -470,7 +477,7 @@ static int virtio_pci_init_common(const struct device *dev)
 			conf->pcie->id,
 			conf->pcie->bdf
 		);
-		return 1;
+		return -EINVAL;
 	}
 
 	/*
@@ -483,7 +490,7 @@ static int virtio_pci_init_common(const struct device *dev)
 	if (virtio_pci_read_cap(conf->pcie->bdf, VIRTIO_PCI_CAP_DEVICE_CFG, &vpc, sizeof(vpc))) {
 		if (!virtio_pci_map_cap(
 				conf->pcie->bdf, &vpc, (void **)&data->device_specific_cfg)) {
-			return 1;
+			return -EINVAL;
 		}
 	} else {
 		data->device_specific_cfg = NULL;
@@ -536,7 +543,7 @@ static int virtio_pci_init_common(const struct device *dev)
 			conf->pcie->id,
 			conf->pcie->bdf
 		);
-		return 1;
+		return -EINVAL;
 	}
 
 	virtio_pci_write_driver_feature_bit(dev, VIRTIO_F_VERSION_1, 1);

--- a/tests/drivers/virtio/pci/CMakeLists.txt
+++ b/tests/drivers/virtio/pci/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(virtio_pci)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/virtio/pci/app.overlay
+++ b/tests/drivers/virtio/pci/app.overlay
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,pcie-controller = &pcie_test;
+	};
+
+	test_intc: test-intc {
+		compatible = "zephyr,test-irq-controller";
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	pcie_test: pcie-test {
+		compatible = "pcie-controller";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		virtio_pci_non_vendor: virtio-pci-non-vendor {
+			compatible = "virtio,pci";
+			vendor-id = <0x1af4>;
+			device-id = <0x1070>;
+			interrupts = <0 0>;
+			interrupt-parent = <&test_intc>;
+			zephyr,deferred-init;
+			status = "okay";
+		};
+
+		virtio_pci_reserved_bar: virtio-pci-reserved-bar {
+			compatible = "virtio,pci";
+			vendor-id = <0x1af4>;
+			device-id = <0x1071>;
+			interrupts = <1 0>;
+			interrupt-parent = <&test_intc>;
+			zephyr,deferred-init;
+			status = "okay";
+		};
+
+		virtio_pci_long_notify: virtio-pci-long-notify {
+			compatible = "virtio,pci";
+			vendor-id = <0x1af4>;
+			device-id = <0x1072>;
+			interrupts = <2 0>;
+			interrupt-parent = <&test_intc>;
+			zephyr,deferred-init;
+			status = "okay";
+		};
+
+		virtio_pci_truncated_notify: virtio-pci-truncated-notify {
+			compatible = "virtio,pci";
+			vendor-id = <0x1af4>;
+			device-id = <0x1073>;
+			interrupts = <3 0>;
+			interrupt-parent = <&test_intc>;
+			zephyr,deferred-init;
+			status = "okay";
+		};
+
+		virtio_pci_short_common: virtio-pci-short-common {
+			compatible = "virtio,pci";
+			vendor-id = <0x1af4>;
+			device-id = <0x1074>;
+			interrupts = <5 0>;
+			interrupt-parent = <&test_intc>;
+			zephyr,deferred-init;
+			status = "okay";
+		};
+
+		virtio_pci_no_caps: virtio-pci-no-caps {
+			compatible = "virtio,pci";
+			vendor-id = <0x1af4>;
+			device-id = <0x1075>;
+			interrupts = <6 0>;
+			interrupt-parent = <&test_intc>;
+			zephyr,deferred-init;
+			status = "okay";
+		};
+	};
+};

--- a/tests/drivers/virtio/pci/dts/bindings/interrupt-controller/zephyr,test-irq-controller.yaml
+++ b/tests/drivers/virtio/pci/dts/bindings/interrupt-controller/zephyr,test-irq-controller.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test interrupt controller for VirtIO PCI
+
+compatible: "zephyr,test-irq-controller"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  "#interrupt-cells":
+    const: 2
+
+interrupt-cells:
+  - irq
+  - priority

--- a/tests/drivers/virtio/pci/prj.conf
+++ b/tests/drivers/virtio/pci/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_PCI=y
+CONFIG_VIRTIO_LOG_LEVEL_OFF=y

--- a/tests/drivers/virtio/pci/src/main.c
+++ b/tests/drivers/virtio/pci/src/main.c
@@ -1,0 +1,372 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pcie/cap.h>
+#include <zephyr/drivers/pcie/controller.h>
+#include <zephyr/drivers/pcie/pcie.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/ztest.h>
+
+#define TEST_CTRL_NODE        DT_NODELABEL(pcie_test)
+#define NON_VENDOR_NODE       DT_NODELABEL(virtio_pci_non_vendor)
+#define RESERVED_BAR_NODE     DT_NODELABEL(virtio_pci_reserved_bar)
+#define LONG_NOTIFY_NODE      DT_NODELABEL(virtio_pci_long_notify)
+#define TRUNCATED_NOTIFY_NODE DT_NODELABEL(virtio_pci_truncated_notify)
+#define SHORT_COMMON_NODE     DT_NODELABEL(virtio_pci_short_common)
+#define NO_CAPS_NODE          DT_NODELABEL(virtio_pci_no_caps)
+
+#define TEST_FIRST_DEVICE 20U
+#define TEST_ENDPOINTS    6U
+#define TEST_PAGE_SIZE    4096U
+#define TEST_CONFIG_SIZE  256U
+
+#define TEST_FIRST_CAP  0x40U
+#define TEST_SECOND_CAP 0x50U
+#define TEST_THIRD_CAP  0x60U
+#define TEST_FOURTH_CAP 0x70U
+
+#define TEST_CAP_COMMON_CFG 1U
+#define TEST_CAP_NOTIFY_CFG 2U
+#define TEST_CAP_ISR_CFG    3U
+#define TEST_BAR_MAX        5U
+
+#define TEST_COMMON_OFFSET         0x000U
+#define TEST_ISR_OFFSET            0x100U
+#define TEST_NOTIFY_OFFSET         0x200U
+#define TEST_COMMON_LENGTH         0x100U
+#define TEST_ISR_LENGTH            0x002U
+#define TEST_NOTIFY_LENGTH         0x100U
+#define TEST_DEVICE_FEATURE_OFFSET 0x004U
+
+struct test_virtio_pci_cap {
+	uint8_t cap_vndr;
+	uint8_t cap_next;
+	uint8_t cap_len;
+	uint8_t cfg_type;
+	uint8_t bar;
+	uint8_t padding[3];
+	uint32_t offset;
+	uint32_t length;
+};
+
+struct test_virtio_pci_notify_cap {
+	struct test_virtio_pci_cap cap;
+	uint32_t notify_off_multiplier;
+};
+
+enum test_endpoint {
+	ENDPOINT_NON_VENDOR,
+	ENDPOINT_RESERVED_BAR,
+	ENDPOINT_LONG_NOTIFY,
+	ENDPOINT_TRUNCATED_NOTIFY,
+	ENDPOINT_SHORT_COMMON,
+	ENDPOINT_NO_CAPS,
+};
+
+static const pcie_id_t endpoint_ids[TEST_ENDPOINTS] = {
+	PCIE_DT_ID(NON_VENDOR_NODE),
+	PCIE_DT_ID(RESERVED_BAR_NODE),
+	PCIE_DT_ID(LONG_NOTIFY_NODE),
+	PCIE_DT_ID(TRUNCATED_NOTIFY_NODE),
+	PCIE_DT_ID(SHORT_COMMON_NODE),
+	PCIE_DT_ID(NO_CAPS_NODE),
+};
+
+static uint8_t config_space[TEST_ENDPOINTS][TEST_CONFIG_SIZE];
+static uint8_t bar_pages[TEST_ENDPOINTS][TEST_PAGE_SIZE] __aligned(TEST_PAGE_SIZE);
+static uint32_t command_status[TEST_ENDPOINTS];
+static bool bar_probe[TEST_ENDPOINTS];
+
+static pcie_bdf_t endpoint_bdf(enum test_endpoint endpoint)
+{
+	return PCIE_BDF(0, TEST_FIRST_DEVICE + endpoint, 0);
+}
+
+static int endpoint_from_bdf(pcie_bdf_t bdf)
+{
+	for (int endpoint = 0; endpoint < TEST_ENDPOINTS; endpoint++) {
+		if (bdf == endpoint_bdf(endpoint)) {
+			return endpoint;
+		}
+	}
+
+	return -1;
+}
+
+static struct test_virtio_pci_cap make_cap(uint8_t cfg_type, uint8_t cap_next,
+					   uint8_t bar, uint32_t offset, uint32_t length)
+{
+	return (struct test_virtio_pci_cap){
+		.cap_vndr = PCI_CAP_ID_VNDR,
+		.cap_next = cap_next,
+		.cap_len = sizeof(struct test_virtio_pci_cap),
+		.cfg_type = cfg_type,
+		.bar = bar,
+		.offset = sys_cpu_to_le32(offset),
+		.length = sys_cpu_to_le32(length),
+	};
+}
+
+static void set_capability(enum test_endpoint endpoint, uint32_t byte_offset,
+			   const void *capability, size_t size)
+{
+	zassert_equal(byte_offset % sizeof(uint32_t), 0U);
+	zassert_true(byte_offset + size <= TEST_CONFIG_SIZE);
+	memcpy(&config_space[endpoint][byte_offset], capability, size);
+}
+
+static void set_valid_common_and_isr(enum test_endpoint endpoint, uint8_t common_offset,
+				     uint8_t common_next, uint8_t isr_next)
+{
+	struct test_virtio_pci_cap common_cap =
+		make_cap(TEST_CAP_COMMON_CFG, common_next, 0U, TEST_COMMON_OFFSET,
+			 TEST_COMMON_LENGTH);
+	struct test_virtio_pci_cap isr_cap =
+		make_cap(TEST_CAP_ISR_CFG, isr_next, 0U, TEST_ISR_OFFSET, TEST_ISR_LENGTH);
+
+	set_capability(endpoint, common_offset, &common_cap, sizeof(common_cap));
+	set_capability(endpoint, common_next, &isr_cap, sizeof(isr_cap));
+}
+
+static void set_notify(enum test_endpoint endpoint, uint8_t notify_offset, uint8_t cap_len)
+{
+	struct test_virtio_pci_notify_cap notify_cap = {
+		.cap = make_cap(TEST_CAP_NOTIFY_CFG, 0U, 0U, TEST_NOTIFY_OFFSET,
+				TEST_NOTIFY_LENGTH),
+		.notify_off_multiplier = sys_cpu_to_le32(0U),
+	};
+
+	notify_cap.cap.cap_len = cap_len;
+	set_capability(endpoint, notify_offset, &notify_cap, sizeof(notify_cap));
+}
+
+static void build_capabilities(void)
+{
+	struct test_virtio_pci_cap fake_cap;
+	uint32_t ignored_extra = 0xa5c35a5cU;
+
+	memset(config_space, 0, sizeof(config_space));
+
+	fake_cap = make_cap(TEST_CAP_COMMON_CFG, TEST_SECOND_CAP, 1U, 0U,
+			    TEST_COMMON_LENGTH);
+	fake_cap.cap_vndr = 0x05U;
+	set_capability(ENDPOINT_NON_VENDOR, TEST_FIRST_CAP, &fake_cap, sizeof(fake_cap));
+	set_valid_common_and_isr(ENDPOINT_NON_VENDOR, TEST_SECOND_CAP, TEST_THIRD_CAP,
+				 TEST_FOURTH_CAP);
+	set_notify(ENDPOINT_NON_VENDOR, TEST_FOURTH_CAP,
+		   sizeof(struct test_virtio_pci_notify_cap));
+
+	fake_cap = make_cap(TEST_CAP_COMMON_CFG, TEST_SECOND_CAP, TEST_BAR_MAX + 1U,
+			    0U, TEST_COMMON_LENGTH);
+	set_capability(ENDPOINT_RESERVED_BAR, TEST_FIRST_CAP, &fake_cap, sizeof(fake_cap));
+	set_valid_common_and_isr(ENDPOINT_RESERVED_BAR, TEST_SECOND_CAP, TEST_THIRD_CAP,
+				 TEST_FOURTH_CAP);
+	set_notify(ENDPOINT_RESERVED_BAR, TEST_FOURTH_CAP,
+		   sizeof(struct test_virtio_pci_notify_cap));
+
+	set_valid_common_and_isr(ENDPOINT_LONG_NOTIFY, TEST_FIRST_CAP, TEST_SECOND_CAP,
+				 TEST_THIRD_CAP);
+	set_notify(ENDPOINT_LONG_NOTIFY, TEST_THIRD_CAP,
+		   sizeof(struct test_virtio_pci_notify_cap) + sizeof(ignored_extra));
+	set_capability(ENDPOINT_LONG_NOTIFY,
+		       TEST_THIRD_CAP + sizeof(struct test_virtio_pci_notify_cap),
+		       &ignored_extra, sizeof(ignored_extra));
+
+	set_valid_common_and_isr(ENDPOINT_TRUNCATED_NOTIFY, TEST_FIRST_CAP, TEST_SECOND_CAP,
+				 TEST_THIRD_CAP);
+	set_notify(ENDPOINT_TRUNCATED_NOTIFY, TEST_THIRD_CAP,
+		   sizeof(struct test_virtio_pci_cap));
+
+	fake_cap = make_cap(TEST_CAP_COMMON_CFG, 0U, 0U, TEST_COMMON_OFFSET,
+			    TEST_COMMON_LENGTH);
+	fake_cap.cap_len = sizeof(fake_cap) - sizeof(uint32_t);
+	set_capability(ENDPOINT_SHORT_COMMON, TEST_FIRST_CAP, &fake_cap, sizeof(fake_cap));
+}
+
+static uint32_t test_pcie_conf_read(const struct device *dev, pcie_bdf_t bdf, unsigned int reg)
+{
+	int endpoint = endpoint_from_bdf(bdf);
+	uint32_t byte_offset = reg * sizeof(uint32_t);
+	uint32_t word;
+
+	ARG_UNUSED(dev);
+
+	if (endpoint < 0) {
+		return reg == PCIE_CONF_ID ? PCIE_ID_NONE : 0U;
+	}
+
+	switch (reg) {
+	case PCIE_CONF_ID:
+		return endpoint_ids[endpoint];
+	case PCIE_CONF_TYPE:
+	case PCIE_CONF_CLASSREV:
+		return 0U;
+	case PCIE_CONF_CMDSTAT:
+		return command_status[endpoint];
+	case PCIE_CONF_CAPPTR:
+		return TEST_FIRST_CAP;
+	case PCIE_CONF_BAR0:
+		if (bar_probe[endpoint]) {
+			return ~(TEST_PAGE_SIZE - 1U);
+		}
+		return (uint32_t)k_mem_phys_addr(bar_pages[endpoint]);
+	default:
+		break;
+	}
+
+	if (byte_offset >= TEST_FIRST_CAP && byte_offset + sizeof(word) <= TEST_CONFIG_SIZE) {
+		memcpy(&word, &config_space[endpoint][byte_offset], sizeof(word));
+		return word;
+	}
+
+	return 0U;
+}
+
+static void test_pcie_conf_write(const struct device *dev, pcie_bdf_t bdf, unsigned int reg,
+				 uint32_t data)
+{
+	int endpoint = endpoint_from_bdf(bdf);
+
+	ARG_UNUSED(dev);
+
+	if (endpoint < 0) {
+		return;
+	}
+
+	if (reg == PCIE_CONF_CMDSTAT) {
+		command_status[endpoint] = data;
+	} else if (reg == PCIE_CONF_BAR0) {
+		bar_probe[endpoint] = data == UINT32_MAX;
+	}
+}
+
+static bool test_pcie_region_allocate(const struct device *dev, pcie_bdf_t bdf, bool mem,
+				      bool mem64, size_t bar_size, uintptr_t *bar_bus_addr)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(bdf);
+	ARG_UNUSED(mem);
+	ARG_UNUSED(mem64);
+	ARG_UNUSED(bar_size);
+	ARG_UNUSED(bar_bus_addr);
+
+	return false;
+}
+
+static bool test_pcie_region_get_allocate_base(const struct device *dev, pcie_bdf_t bdf,
+					       bool mem, bool mem64, size_t align,
+					       uintptr_t *bar_base_addr)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(bdf);
+	ARG_UNUSED(mem);
+	ARG_UNUSED(mem64);
+	ARG_UNUSED(align);
+	ARG_UNUSED(bar_base_addr);
+
+	return false;
+}
+
+static DEVICE_API(pcie_ctrl, test_pcie_ctrl_api) = {
+	.conf_read = test_pcie_conf_read,
+	.conf_write = test_pcie_conf_write,
+	.region_allocate = test_pcie_region_allocate,
+	.region_get_allocate_base = test_pcie_region_get_allocate_base,
+};
+
+DEVICE_DT_DEFINE(TEST_CTRL_NODE, NULL, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_PCIE_INIT_PRIORITY,
+		 &test_pcie_ctrl_api);
+
+static void before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	memset(bar_pages, 0, sizeof(bar_pages));
+	memset(bar_probe, 0, sizeof(bar_probe));
+	for (int endpoint = 0; endpoint < TEST_ENDPOINTS; endpoint++) {
+		command_status[endpoint] = PCIE_CONF_CMDSTAT_CAPS;
+		sys_put_le32(BIT(0),
+			     &bar_pages[endpoint][TEST_COMMON_OFFSET + TEST_DEVICE_FEATURE_OFFSET]);
+	}
+	command_status[ENDPOINT_NO_CAPS] = 0U;
+	build_capabilities();
+}
+
+static pcie_bdf_t discovered_bdf(pcie_id_t id)
+{
+	STRUCT_SECTION_FOREACH(pcie_dev, dev) {
+		if (dev->id == id) {
+			return dev->bdf;
+		}
+	}
+
+	return PCIE_BDF_NONE;
+}
+
+static void assert_endpoint(const struct device *dev, pcie_id_t id,
+			    enum test_endpoint endpoint, bool should_initialize)
+{
+	int ret;
+
+	zassert_equal(discovered_bdf(id), endpoint_bdf(endpoint),
+		      "synthetic PCI endpoint %d was not discovered", endpoint);
+	zassert_false(device_is_ready(dev), "deferred VirtIO PCI device unexpectedly ready");
+
+	ret = device_init(dev);
+	if (should_initialize) {
+		zassert_ok(ret, "VirtIO PCI transport rejected capability scenario %d", endpoint);
+		zassert_true(device_is_ready(dev), "VirtIO PCI transport did not become ready");
+	} else {
+		zassert_equal(ret, -EINVAL,
+			      "VirtIO PCI transport accepted invalid scenario %d", endpoint);
+		zassert_false(device_is_ready(dev), "failed VirtIO PCI transport became ready");
+	}
+}
+
+ZTEST(virtio_pci_cap, test_non_vendor_capability_is_skipped)
+{
+	assert_endpoint(DEVICE_DT_GET(NON_VENDOR_NODE), PCIE_DT_ID(NON_VENDOR_NODE),
+			ENDPOINT_NON_VENDOR, true);
+}
+
+ZTEST(virtio_pci_cap, test_reserved_bar_capability_is_skipped)
+{
+	assert_endpoint(DEVICE_DT_GET(RESERVED_BAR_NODE), PCIE_DT_ID(RESERVED_BAR_NODE),
+			ENDPOINT_RESERVED_BAR, true);
+}
+
+ZTEST(virtio_pci_cap, test_longer_capability_is_accepted)
+{
+	assert_endpoint(DEVICE_DT_GET(LONG_NOTIFY_NODE), PCIE_DT_ID(LONG_NOTIFY_NODE),
+			ENDPOINT_LONG_NOTIFY, true);
+}
+
+ZTEST(virtio_pci_cap, test_truncated_notify_capability_is_rejected)
+{
+	assert_endpoint(DEVICE_DT_GET(TRUNCATED_NOTIFY_NODE),
+			PCIE_DT_ID(TRUNCATED_NOTIFY_NODE), ENDPOINT_TRUNCATED_NOTIFY,
+			false);
+}
+
+ZTEST(virtio_pci_cap, test_short_base_capability_is_rejected)
+{
+	assert_endpoint(DEVICE_DT_GET(SHORT_COMMON_NODE), PCIE_DT_ID(SHORT_COMMON_NODE),
+			ENDPOINT_SHORT_COMMON, false);
+}
+
+ZTEST(virtio_pci_cap, test_missing_capability_list_is_rejected)
+{
+	assert_endpoint(DEVICE_DT_GET(NO_CAPS_NODE), PCIE_DT_ID(NO_CAPS_NODE),
+			ENDPOINT_NO_CAPS, false);
+}
+
+ZTEST_SUITE(virtio_pci_cap, NULL, NULL, before, NULL, NULL);

--- a/tests/drivers/virtio/pci/tests.yaml
+++ b/tests/drivers/virtio/pci/tests.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.virtio.pci:
+    platform_allow:
+      - qemu_malta
+    tags:
+      - drivers
+      - pcie
+      - virtio


### PR DESCRIPTION
## Summary

Fix parsing of VirtIO PCI capabilities in `virtio_pci_read_cap()`.

VirtIO PCI configuration structures are carried in PCI vendor-specific capabilities, but the parser matched every conventional PCI capability by `cfg_type` alone. An unrelated capability whose following bytes happened to match a VirtIO `cfg_type` could therefore be selected instead of a later real VirtIO capability.

The parser also treated `cap_len` as both a minimum and a maximum. VirtIO 1.3 requires drivers to accept capabilities longer than the specified structure, because they may contain padding or fields the driver does not use. At the same time, the existing check could accept a truncated notify capability without reading `notify_off_multiplier`.

This change:
- requires `cap_vndr == PCI_CAP_ID_VNDR` before matching `cfg_type`;
- skips reserved BAR numbers greater than 5 and continues walking the list;
- treats the caller's structure size as the minimum required `cap_len`;
- copies only the caller's structure size, so longer capabilities cannot overflow the destination;
- preserves rejection of truncated capabilities introduced by the bounds hardening in #111289.

VirtIO 1.3 PCI transport requirements:
https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html#x1-1290001

## Tests

Adds a simulated PCI configuration-space ztest covering:
- a non-vendor capability that mimics a VirtIO Common CFG before the real capability;
- a VirtIO capability with a reserved BAR followed by a valid one;
- a longer notify capability accepted without overwriting a guard value;
- a truncated notify capability rejected;
- a short base capability rejected;
- a missing PCI capability list.

Validation run:
https://github.com/alesanGreat/zephyr/actions/runs/32454165956

- `native_sim`: PASS
- `native_sim/native/64`: PASS
- 2/2 configurations: PASS
- 12/12 ztest cases: PASS
- 0 Twister warnings
- `checkpatch.pl --strict`: 0 errors, 0 warnings
- `git diff --check`: PASS
