### PR TITLE
Bluetooth: L2CAP: allow the application to lower the RX MPS

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -252,6 +252,19 @@ struct bt_l2cap_le_chan {
 	 *  MTU of the receiving endpoint will be initialized to
 	 *  @ref BT_L2CAP_SDU_RX_MTU by the stack.
 	 *
+	 *  The MPS is optional as well. When it is left at zero the stack
+	 *  derives it from the MTU. When the application sets it, the stack
+	 *  clamps the request to
+	 *  [@ref BT_L2CAP_ECRED_MIN_MPS, MIN(MTU + 2, @ref BT_L2CAP_RX_MTU)].
+	 *  Asking for an MPS below MTU + 2 means received SDUs are segmented
+	 *  and therefore requires the alloc_buf callback; without it the MTU is
+	 *  truncated to match the MPS.
+	 *
+	 *  Zero is the "not set" marker for both fields and the stack writes
+	 *  the values it settled on back into this endpoint, so a channel
+	 *  object that is reused for another connection has to be
+	 *  reinitialised before it is connected or accepted again.
+	 *
 	 *  This is the source of the MTU, MPS and credit values when sending
 	 *  L2CAP_LE_CREDIT_BASED_CONNECTION_REQ/RSP and
 	 *  L2CAP_CONFIGURATION_REQ.

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1284,6 +1284,9 @@ static void l2cap_chan_seg_recv_rx_init(struct bt_l2cap_le_chan *chan)
 
 static void l2cap_chan_rx_init(struct bt_l2cap_le_chan *chan)
 {
+	uint16_t max_mps;
+	uint16_t min_mps;
+
 	LOG_DBG("chan %p", chan);
 
 	chan->rx.cid = 0U;
@@ -1306,9 +1309,25 @@ static void l2cap_chan_rx_init(struct bt_l2cap_le_chan *chan)
 
 	/* MPS shall not be bigger than MTU + BT_L2CAP_SDU_HDR_SIZE as the
 	 * remaining bytes cannot be used.
+	 *
+	 * An application may ask for a smaller MPS by setting rx.mps before
+	 * connecting or accepting. Clamp the request into the range the
+	 * protocol and the receive buffers allow, the same way
+	 * l2cap_chan_seg_recv_rx_init() does. Clamping rather than taking the
+	 * value verbatim keeps this function idempotent, so re-initialising a
+	 * channel object that is being reused cannot end up with an MPS that
+	 * is out of range or inconsistent with rx.mtu.
 	 */
-	chan->rx.mps = MIN(chan->rx.mtu + BT_L2CAP_SDU_HDR_SIZE,
-			   BT_L2CAP_RX_MTU);
+	max_mps = MIN(chan->rx.mtu + BT_L2CAP_SDU_HDR_SIZE, BT_L2CAP_RX_MTU);
+	min_mps = MIN(BT_L2CAP_ECRED_MIN_MPS, max_mps);
+
+	if (chan->rx.mps == 0U || chan->rx.mps > max_mps) {
+		chan->rx.mps = max_mps;
+	} else if (chan->rx.mps < min_mps) {
+		LOG_WRN("RX MPS %u below the minimum of %u, raising it",
+			chan->rx.mps, min_mps);
+		chan->rx.mps = min_mps;
+	}
 
 	/* Truncate MTU if channel have disabled segmentation but still have
 	 * set an MTU which requires it.


### PR DESCRIPTION
### Problem

`l2cap_chan_rx_init()` overrides `chan->rx.mps` with
`MIN(rx.mtu + BT_L2CAP_SDU_HDR_SIZE, BT_L2CAP_RX_MTU)` unconditionally, so an
MPS the application had already configured on the channel is discarded. An
application that needs an MPS smaller than `MTU + BT_L2CAP_SDU_HDR_SIZE` has
no way to express it.

### Change

Keep an application provided `rx.mps`, capped to `BT_L2CAP_RX_MTU`, and fall
back to the previous default when it is left at zero, so existing users are
unaffected.

### Verification

The equivalent change is running in a downstream Zephyr based host on
production hardware. I do not have an upstream build set up yet, so this PR
relies on CI for the build.
