### PR TITLE
Bluetooth: Classic: L2CAP: initialise psm on the acceptor channel

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2871,6 +2871,7 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 	}
 
 	BR_CHAN(chan)->tx.cid = scid;
+	BR_CHAN(chan)->psm = psm;
 	br_chan->ident = ident;
 	bt_l2cap_br_chan_set_state(chan, BT_L2CAP_CONNECTING);
 	atomic_set_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_ACCEPTOR);


### PR DESCRIPTION
### Problem

`l2cap_br_conn_req()` sets up the channel for an incoming connection but never
stores the requested PSM in the `bt_l2cap_br_chan`, so `chan->psm` stays zero
for every channel created on the acceptor side. Code that looks a channel up
by PSM therefore fails to find channels that were accepted rather than
initiated locally.

### Change

Store the PSM when the acceptor channel is added, next to the existing
`tx.cid` assignment.

### Verification

The equivalent change is running in a downstream Zephyr based host on
production hardware. I do not have an upstream build set up yet, so this PR
relies on CI for the build.
