### PR TITLE
Bluetooth: SMP: clear LinkKey distribution bits after legacy pairing

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5059,13 +5059,17 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 			 */
 			atomic_set_bit(smp->flags, SMP_FLAG_DERIVE_LK);
 		}
-		/*
-		 * Those are used as pairing finished indicator so generated
-		 * but not distributed keys must be cleared here.
-		 */
-		smp->local_dist &= ~BT_SMP_DIST_LINK_KEY;
-		smp->remote_dist &= ~BT_SMP_DIST_LINK_KEY;
 	}
+
+	/*
+	 * Those are used as pairing finished indicator so generated
+	 * but not distributed keys must be cleared here. This applies to legacy
+	 * pairing too: a link key can only be derived from a Secure Connections
+	 * LTK, so the bit is never consumed there and would otherwise keep the
+	 * distribution set non-empty forever.
+	 */
+	smp->local_dist &= ~BT_SMP_DIST_LINK_KEY;
+	smp->remote_dist &= ~BT_SMP_DIST_LINK_KEY;
 
 	if (smp->remote_dist & BT_SMP_DIST_ENC_KEY) {
 		atomic_set_bit(smp->allowed_cmds, BT_SMP_CMD_ENCRYPT_INFO);


### PR DESCRIPTION
Legacy LE pairing times out on a build with `CONFIG_BT_CLASSIC` enabled.

`smp->local_dist` / `smp->remote_dist` double as the pairing-finished indicator,
and the only place that clears the LinkKey bit sits inside the
`if (SMP_FLAG_SC)` branch of `bt_smp_encrypt_change()`. `RECV_KEYS_SC` /
`SEND_KEYS_SC` deliberately keep `LINK_DIST` for CTKD and only mask out EncKey,
so on the legacy path nothing clears it: the
`!smp->local_dist && !smp->remote_dist` checks never pass, the 30 s SMP timer
fires, and the application is told the pairing failed even though the link is
encrypted and the keys were exchanged.

`SMP_FLAG_KEYS_DISTR` is set by the time the timeout fires, so
`smp_pairing_complete()` also clears the exchanged keys and the bond is lost.
`SMP_FLAG_TIMEOUT` stays latched, which blocks further pairing on that
connection.

This moves the clearing out of the SC branch and leaves only
`SMP_FLAG_DERIVE_LK` inside it. That flag is latched before the clearing, so SC
and CTKD behaviour is unchanged and nothing changes on air.

Preconditions to reproduce: `CONFIG_BT_CLASSIC=y`,
`CONFIG_BT_SMP_SC_PAIR_ONLY=n` (it is `default y`, which is why this has gone
unnoticed), and a peer that sets the LinkKey bit while SC is not selected. Two
Zephyr devices with `CONFIG_BT_SMP_LEGACY_PAIR_ONLY=y` on one side reproduce it
in both roles.

Not covered here: keeping the LinkKey bit out of the Pairing Response on the
legacy path, so that an unpatched peer does not retain it either. That is a
separate change.
