### PR TITLE
Bluetooth: SMP: make the CTKD directions configurable

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -470,6 +470,11 @@ New APIs and options
     * :c:member:`bt_bap_unicast_group_info.iso_interval`
     * :c:func:`bt_vocs_client_free_instance`
 
+  * Classic
+
+    * :kconfig:option:`CONFIG_BT_SMP_DERIVE_LTK`
+    * :kconfig:option:`CONFIG_BT_SMP_DERIVE_LK`
+
   * Host
 
     * :c:func:`bt_conn_take`

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -609,6 +609,45 @@ config BT_SMP_ALLOW_UNAUTH_OVERWRITE
 	  to create a new bond the old bond has to be explicitly deleted with
 	  bt_unpair.
 
+config BT_SMP_DERIVE_LTK
+	bool "Derive the LE LTK from the BR/EDR link key"
+	depends on BT_CLASSIC
+	default y
+	help
+	  Accept the Security Manager procedure over BR/EDR, which derives the
+	  LE LTK from the BR/EDR link key as part of Cross-Transport Key
+	  Derivation (Core Specification 6.3, Vol 3, Part H, Section 2.4.2.5).
+
+	  Disabling this refuses that procedure as a whole rather than only the
+	  LTK: the IRK, the identity address and the CSRK are not distributed
+	  over BR/EDR either, so RPAs from a peer bonded only over BR/EDR can
+	  no longer be resolved. That is intended, because the identity
+	  information on its own already creates an LE bond entry. The BR/EDR
+	  Security Manager fixed channel is also left out of the L2CAP
+	  information response so that a peer does not start a procedure that
+	  would then be rejected.
+
+	  Disable this on a device that must not end up with an LE bond as a
+	  side effect of pairing over BR/EDR. Keys derived while it was enabled
+	  are kept.
+
+config BT_SMP_DERIVE_LK
+	bool "Derive the BR/EDR link key from the LE LTK"
+	depends on BT_CLASSIC
+	default y
+	help
+	  Ask for a BR/EDR link key to be derived from the LE LTK during Secure
+	  Connections pairing over LE, as part of Cross-Transport Key Derivation
+	  (Core Specification 6.3, Vol 3, Part H, Section 2.4.2.4).
+
+	  Disabling this clears the LinkKey bit from the key distribution of
+	  both the Pairing Request and the Pairing Response, so that the peer
+	  does not keep a link key that this device never derives.
+
+	  Disable this on a device that must not end up with a BR/EDR bond as a
+	  side effect of pairing over LE. Keys derived while it was enabled are
+	  kept.
+
 config BT_ID_UNPAIR_MATCHING_BONDS
 	bool "Delete bond with same peer with other local identity when bonding"
 	help

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1987,6 +1987,14 @@ static uint8_t get_fixed_channels_mask(void)
 
 	/* this needs to be enhanced if AMP Test Manager support is added */
 	STRUCT_SECTION_FOREACH(bt_l2cap_br_fixed_chan, fchan) {
+		if (!IS_ENABLED(CONFIG_BT_SMP_DERIVE_LTK) &&
+		    fchan->cid == BT_L2CAP_CID_BR_SMP) {
+			/* Nothing would be accepted on this channel, so do not
+			 * invite the peer to start a derivation on it.
+			 */
+			continue;
+		}
+
 		mask |= BIT(fchan->cid);
 	}
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -72,7 +72,7 @@ LOG_MODULE_REGISTER(bt_smp);
 #define ID_DIST 0
 #endif
 
-#if defined(CONFIG_BT_CLASSIC)
+#if defined(CONFIG_BT_SMP_DERIVE_LK)
 #define LINK_DIST BT_SMP_DIST_LINK_KEY
 #else
 #define LINK_DIST 0
@@ -773,6 +773,10 @@ static bool ltk_derive_link_key_allowed(struct bt_smp *smp)
 	struct bt_keys_link_key *link_key;
 	struct bt_keys *keys;
 
+	if (!IS_ENABLED(CONFIG_BT_SMP_DERIVE_LK)) {
+		return false;
+	}
+
 	if (!smp->chan.chan.conn) {
 		return false;
 	}
@@ -1270,6 +1274,10 @@ static bool smp_br_pairing_allowed(struct bt_smp_br *smp)
 	struct bt_conn *conn;
 	struct bt_keys_link_key *key;
 	struct bt_keys *le_keys;
+
+	if (!IS_ENABLED(CONFIG_BT_SMP_DERIVE_LTK)) {
+		return false;
+	}
 
 	if (!smp->chan.chan.conn) {
 		return false;
@@ -1825,7 +1833,7 @@ int bt_smp_br_send_pairing_req(struct bt_conn *conn)
 
 	/* check if we are allowed to start SMP over BR/EDR */
 	if (!smp_br_pairing_allowed(smp)) {
-		return 0;
+		return -ENOTSUP;
 	}
 
 	/* Channel not yet connected, will start pairing once connected */

--- a/tests/bluetooth/classic/smp_general/tests.yaml
+++ b/tests/bluetooth/classic/smp_general/tests.yaml
@@ -12,6 +12,28 @@ tests:
       pytest_dut_scope: session
       fixture: usb_hci
     timeout: 900
+  bluetooth.classic.smp.general.no_derive_ltk:
+    platform_allow:
+    - native_sim
+    integration_platforms:
+    - native_sim
+    tags:
+    - bluetooth
+    - smp
+    extra_configs:
+    - CONFIG_BT_SMP_DERIVE_LTK=n
+    build_only: true
+  bluetooth.classic.smp.general.no_derive_lk:
+    platform_allow:
+    - native_sim
+    integration_platforms:
+    - native_sim
+    tags:
+    - bluetooth
+    - smp
+    extra_configs:
+    - CONFIG_BT_SMP_DERIVE_LK=n
+    build_only: true
   bluetooth.classic.smp.general.no_blobs:
     platform_allow:
     - mimxrt1170_evk@B/mimxrt1176/cm7


### PR DESCRIPTION
Cross-Transport Key Derivation is unconditional today. With `CONFIG_BT_CLASSIC`
enabled, Secure Connections pairing over LE always asks for a derived BR/EDR
link key, and the Security Manager over BR/EDR always accepts deriving the LE
LTK from the link key. A device that must not end up with a bond on the other
transport as a side effect of pairing has no way to say so.

Two Kconfig options, both `default y`, so behaviour is unchanged unless a build
opts out:

- `BT_SMP_DERIVE_LTK` — derive the LE LTK from the BR/EDR link key
  (Core Specification 6.3, Vol 3, Part H, Section 2.4.2.5).
- `BT_SMP_DERIVE_LK` — derive the BR/EDR link key from the LE LTK
  (Section 2.4.2.4).

Kconfig rather than an API, because both decisions are device global. The
responder negotiates the key distribution in `smp_pairing_req()`, where
`required_sec_level` is still `BT_SECURITY_L1` because `bt_conn_set_security()`
was never called on a peer-initiated pairing. And `get_fixed_channels_mask()` is
reached from `l2cap_br_info_req()` during ACL setup, long before any security
call. Neither has a connection-scoped policy to read.

With `BT_SMP_DERIVE_LK` off, `LINK_DIST` expands to 0. That covers every
consumer of `SEND_KEYS` / `RECV_KEYS` in one place, so the negotiated
distribution and what goes on air stay consistent in both roles without touching
the PDU construction sites, and `SMP_FLAG_DERIVE_LK` can no longer be latched.
`ltk_derive_link_key_allowed()` refuses the derivation as a second line of
defence, mirroring how the other direction is gated in
`smp_br_pairing_allowed()`. The `BR_*_KEYS_SC` macros already mask `LINK_DIST`
out, so the Security Manager over BR/EDR is unaffected.

With `BT_SMP_DERIVE_LTK` off, `smp_br_pairing_allowed()` refuses the procedure.
`bt_smp_br_send_pairing_req()` returns `-ENOTSUP` in that case, like the fixed
channel check at the top of the same function. The BR/EDR Security Manager fixed
channel is left out of the L2CAP information response so that a peer does not
start a procedure that would then be rejected; the channel stays registered, so
a Pairing Request that arrives anyway still gets the 0x0E failure. Disabling
this refuses the procedure as a whole rather than only the LTK — the IRK,
identity address and CSRK are not distributed over BR/EDR either. That is
intended, since the identity information on its own already creates an LE bond
entry. The Kconfig help says so, and that neither option touches keys that were
derived while it was enabled.

Coverage: two build configurations in `tests/bluetooth/classic/smp_general`, one
per option turned off. Functional coverage of the 0x0E rejection and the
information response mask needs a Classic-capable controller on the runner, so
it cannot run in PR CI.

Release note entry added.
