### PR TITLE
Bluetooth: L2CAP: add bt_l2cap_server_unregister()

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -482,6 +482,7 @@ New APIs and options
     * :c:member:`bt_conn_cb.le_param_update_rejected`
     * ``BT_HCI_QUIRK_NO_FLOW_CONTROL`` HCI device quirk for controllers that
       advertise but reject the controller to host flow control commands.
+    * :c:func:`bt_l2cap_server_unregister`
     * :c:member:`bt_rfcomm_dlc.rx_credit_limit` to configure per-DLC initial RX credit count.
     * :c:func:`bt_rfcomm_dlc_recv_complete` to return RX credits to the peer. Applications can
       return ``-EINPROGRESS`` from the :c:member:`bt_rfcomm_dlc_ops.recv` callback to defer buffer

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -314,6 +314,12 @@ struct bt_l2cap_le_chan {
 	uint8_t                         pending_req;
 	bt_security_t			required_sec_level;
 
+	/** @internal Server that accepted this channel, NULL when the channel
+	 *  was initiated locally. Blocks unregistering that server for as long
+	 *  as the channel lives.
+	 */
+	struct bt_l2cap_server		*_server;
+
 	/* Response Timeout eXpired (RTX) timer */
 	struct k_work_delayable		rtx_work;
 	struct k_work_sync		rtx_sync;
@@ -872,6 +878,11 @@ struct bt_l2cap_server {
 	int (*accept)(struct bt_conn *conn, struct bt_l2cap_server *server,
 		      struct bt_l2cap_chan **chan);
 
+	/** @internal Channels accepted by this server that are still
+	 *  connected.
+	 */
+	atomic_t _active_chans;
+
 	sys_snode_t node;
 };
 
@@ -890,11 +901,35 @@ struct bt_l2cap_server {
  *  a GATT service, and that's how L2CAP clients discover how to connect to
  *  the server.
  *
+ *  @note This may be called from any thread, but not from an interrupt
+ *  context.
+ *
  *  @param server Server structure.
  *
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_l2cap_server_register(struct bt_l2cap_server *server);
+
+/** @brief Unregister L2CAP server.
+ *
+ *  Unregister the L2CAP server for a PSM, making the PSM available for
+ *  registration again.
+ *
+ *  @note This may be called from any thread, but not from an interrupt
+ *  context. It blocks while an incoming connection request for this server is
+ *  being processed, so the server is no longer in use once it returns. It must
+ *  not be called from the server's own accept() callback: the list is locked
+ *  across that callback, and the RX path still uses the server after it
+ *  returns.
+ *
+ *  @param server Server structure.
+ *
+ *  @retval 0 Success.
+ *  @retval -EINVAL @p server is NULL.
+ *  @retval -EBUSY Channels accepted by @p server are still connected.
+ *  @retval -ENOENT @p server was not registered.
+ */
+int bt_l2cap_server_unregister(struct bt_l2cap_server *server);
 
 /** @brief Register L2CAP server on BR/EDR oriented connection.
  *

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3904,13 +3904,11 @@ static void bt_eatt_init(void)
 		.sec_level = BT_SECURITY_L2,
 		.accept = bt_eatt_accept,
 	};
-	struct bt_l2cap_server *registered_server;
 
 	LOG_DBG("");
 
 	/* Check if eatt_l2cap server has already been registered. */
-	registered_server = bt_l2cap_server_lookup_psm(eatt_l2cap.psm);
-	if (registered_server != &eatt_l2cap) {
+	if (!bt_l2cap_server_is_registered(&eatt_l2cap)) {
 		err = bt_l2cap_server_register(&eatt_l2cap);
 		if (err < 0) {
 			LOG_ERR("EATT Server registration failed %d", err);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -92,6 +92,11 @@ NET_BUF_POOL_FIXED_DEFINE(disc_pool, 1,
 	__l2cap_lookup_ident(conn, ident, req_opcode, true)
 
 static sys_slist_t servers = SYS_SLIST_STATIC_INIT(&servers);
+
+/* Guards @ref servers, and is held for as long as a server looked up from it
+ * is in use, so that the server object stays valid for its user.
+ */
+static K_MUTEX_DEFINE(servers_lock);
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
 /* L2CAP signalling channel specific context */
@@ -1214,7 +1219,8 @@ struct bt_l2cap_chan *bt_l2cap_le_lookup_rx_cid(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
-struct bt_l2cap_server *bt_l2cap_server_lookup_psm(uint16_t psm)
+/* Caller must hold @ref servers_lock for as long as the result is used. */
+static struct bt_l2cap_server *l2cap_server_lookup_psm(uint16_t psm)
 {
 	struct bt_l2cap_server *server;
 
@@ -1227,36 +1233,62 @@ struct bt_l2cap_server *bt_l2cap_server_lookup_psm(uint16_t psm)
 	return NULL;
 }
 
+bool bt_l2cap_server_is_registered(const struct bt_l2cap_server *server)
+{
+	struct bt_l2cap_server *registered;
+	bool found = false;
+
+	k_mutex_lock(&servers_lock, K_FOREVER);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&servers, registered, node) {
+		if (registered == server) {
+			found = true;
+			break;
+		}
+	}
+
+	k_mutex_unlock(&servers_lock);
+
+	return found;
+}
+
 int bt_l2cap_server_register(struct bt_l2cap_server *server)
 {
+	int err = 0;
+
 	if (!server->accept) {
 		return -EINVAL;
 	}
 
+	k_mutex_lock(&servers_lock, K_FOREVER);
+
 	if (server->psm) {
 		if (server->psm < L2CAP_LE_PSM_FIXED_START ||
 		    server->psm > L2CAP_LE_PSM_DYN_END) {
-			return -EINVAL;
+			err = -EINVAL;
+			goto unlock;
 		}
 
 		/* Check if given PSM is already in use */
-		if (bt_l2cap_server_lookup_psm(server->psm)) {
+		if (l2cap_server_lookup_psm(server->psm)) {
 			LOG_DBG("PSM already registered");
-			return -EADDRINUSE;
+			err = -EADDRINUSE;
+			goto unlock;
 		}
 	} else {
 		uint16_t psm;
 
 		for (psm = L2CAP_LE_PSM_DYN_START;
 		     psm <= L2CAP_LE_PSM_DYN_END; psm++) {
-			if (!bt_l2cap_server_lookup_psm(psm)) {
+			if (!l2cap_server_lookup_psm(psm)) {
 				break;
 			}
 		}
 
 		if (psm > L2CAP_LE_PSM_DYN_END) {
 			LOG_WRN("No free dynamic PSMs available");
-			return -EADDRNOTAVAIL;
+			err = -EADDRNOTAVAIL;
+			goto unlock;
 		}
 
 		LOG_DBG("Allocated PSM 0x%04x for new server", psm);
@@ -1264,7 +1296,8 @@ int bt_l2cap_server_register(struct bt_l2cap_server *server)
 	}
 
 	if (server->sec_level > BT_SECURITY_L4) {
-		return -EINVAL;
+		err = -EINVAL;
+		goto unlock;
 	} else if (server->sec_level < BT_SECURITY_L1) {
 		/* Level 0 is only applicable for BR/EDR */
 		server->sec_level = BT_SECURITY_L1;
@@ -1274,7 +1307,10 @@ int bt_l2cap_server_register(struct bt_l2cap_server *server)
 
 	sys_slist_append(&servers, &server->node);
 
-	return 0;
+unlock:
+	k_mutex_unlock(&servers_lock);
+
+	return err;
 }
 
 #if defined(CONFIG_BT_L2CAP_SEG_RECV)
@@ -1526,13 +1562,45 @@ static uint16_t l2cap_check_security(struct bt_conn *conn,
 	return BT_L2CAP_LE_ERR_AUTHENTICATION;
 }
 
+/* Look up the server for @p psm and let it accept the channel, with the server
+ * list held locked across accept() so that it cannot be unregistered meanwhile.
+ */
+static uint16_t l2cap_le_accept(struct bt_conn *conn, uint16_t psm, uint16_t scid,
+				uint16_t mtu, uint16_t mps, uint16_t credits,
+				struct bt_l2cap_chan **chan)
+{
+	struct bt_l2cap_server *server;
+	uint16_t result;
+
+	k_mutex_lock(&servers_lock, K_FOREVER);
+
+	/* Check if there is a server registered */
+	server = l2cap_server_lookup_psm(psm);
+	if (!server) {
+		result = BT_L2CAP_LE_ERR_PSM_NOT_SUPP;
+		goto unlock;
+	}
+
+	/* Check if connection has minimum required security level */
+	result = l2cap_check_security(conn, server);
+	if (result != BT_L2CAP_LE_SUCCESS) {
+		goto unlock;
+	}
+
+	result = l2cap_chan_accept(conn, server, scid, mtu, mps, credits, chan);
+
+unlock:
+	k_mutex_unlock(&servers_lock);
+
+	return result;
+}
+
 static void le_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 			struct net_buf *buf)
 {
 	struct bt_conn *conn = l2cap->chan.chan.conn;
 	struct bt_l2cap_chan *chan;
 	struct bt_l2cap_le_chan *le_chan;
-	struct bt_l2cap_server *server;
 	struct bt_l2cap_le_conn_req *req = (void *)buf->data;
 	struct bt_l2cap_le_conn_rsp *rsp;
 	uint16_t psm, scid, mtu, mps, credits;
@@ -1571,21 +1639,7 @@ static void le_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 		goto rsp;
 	}
 
-	/* Check if there is a server registered */
-	server = bt_l2cap_server_lookup_psm(psm);
-	if (!server) {
-		result = BT_L2CAP_LE_ERR_PSM_NOT_SUPP;
-		goto rsp;
-	}
-
-	/* Check if connection has minimum required security level */
-	result = l2cap_check_security(conn, server);
-	if (result != BT_L2CAP_LE_SUCCESS) {
-		goto rsp;
-	}
-
-	result = l2cap_chan_accept(conn, server, scid, mtu, mps, credits,
-				   &chan);
+	result = l2cap_le_accept(conn, psm, scid, mtu, mps, credits, &chan);
 	if (result != BT_L2CAP_LE_SUCCESS) {
 		goto rsp;
 	}
@@ -1666,16 +1720,20 @@ static void le_ecred_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 		goto response;
 	}
 
+	/* Locked until the last accept() has returned, as in l2cap_le_accept(). */
+	k_mutex_lock(&servers_lock, K_FOREVER);
+
 	/* Check if there is a server registered */
-	server = bt_l2cap_server_lookup_psm(psm);
+	server = l2cap_server_lookup_psm(psm);
 	if (!server) {
 		result = BT_L2CAP_LE_ERR_PSM_NOT_SUPP;
-		goto response;
+	} else {
+		/* Check if connection has minimum required security level */
+		result = l2cap_check_security(conn, server);
 	}
 
-	/* Check if connection has minimum required security level */
-	result = l2cap_check_security(conn, server);
 	if (result != BT_L2CAP_LE_SUCCESS) {
+		k_mutex_unlock(&servers_lock);
 		goto response;
 	}
 
@@ -1706,6 +1764,7 @@ static void le_ecred_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 			continue;
 		}
 	}
+	k_mutex_unlock(&servers_lock);
 
 response:
 	buf = l2cap_create_le_sig_pdu(BT_L2CAP_ECRED_CONN_RSP, ident,

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -273,6 +273,16 @@ static void l2cap_chan_del(struct bt_l2cap_chan *chan)
 
 	LOG_DBG("conn %p chan %p", chan->conn, chan);
 
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+	/* Release the channel from its server before the disconnected callback,
+	 * so that an application may unregister the server from there.
+	 */
+	if (le_chan->_server != NULL) {
+		atomic_dec(&le_chan->_server->_active_chans);
+		le_chan->_server = NULL;
+	}
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+
 	if (!chan->conn) {
 		goto destroy;
 	}
@@ -370,6 +380,7 @@ static void init_le_chan_private(struct bt_l2cap_le_chan *le_chan)
 #if defined(CONFIG_BT_L2CAP_SEG_RECV)
 	le_chan->_sdu_len_done = 0;
 #endif /* CONFIG_BT_L2CAP_SEG_RECV */
+	le_chan->_server = NULL;
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 	memset(&le_chan->_pdu_ready, 0, sizeof(le_chan->_pdu_ready));
 	le_chan->_pdu_remaining = 0;
@@ -1233,20 +1244,26 @@ static struct bt_l2cap_server *l2cap_server_lookup_psm(uint16_t psm)
 	return NULL;
 }
 
-bool bt_l2cap_server_is_registered(const struct bt_l2cap_server *server)
+/* Caller must hold @ref servers_lock. */
+static bool l2cap_server_is_registered(const struct bt_l2cap_server *server)
 {
 	struct bt_l2cap_server *registered;
-	bool found = false;
-
-	k_mutex_lock(&servers_lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&servers, registered, node) {
 		if (registered == server) {
-			found = true;
-			break;
+			return true;
 		}
 	}
 
+	return false;
+}
+
+bool bt_l2cap_server_is_registered(const struct bt_l2cap_server *server)
+{
+	bool found;
+
+	k_mutex_lock(&servers_lock, K_FOREVER);
+	found = l2cap_server_is_registered(server);
 	k_mutex_unlock(&servers_lock);
 
 	return found;
@@ -1305,7 +1322,43 @@ int bt_l2cap_server_register(struct bt_l2cap_server *server)
 
 	LOG_DBG("PSM 0x%04x", server->psm);
 
+	atomic_clear(&server->_active_chans);
+
 	sys_slist_append(&servers, &server->node);
+
+unlock:
+	k_mutex_unlock(&servers_lock);
+
+	return err;
+}
+
+int bt_l2cap_server_unregister(struct bt_l2cap_server *server)
+{
+	atomic_val_t active;
+	int err = 0;
+
+	if (server == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&servers_lock, K_FOREVER);
+
+	if (!l2cap_server_is_registered(server)) {
+		err = -ENOENT;
+		goto unlock;
+	}
+
+	/* The count cannot grow here, because accepting takes the same lock. */
+	active = atomic_get(&server->_active_chans);
+	if (active != 0) {
+		LOG_DBG("PSM 0x%04x still has %ld channel(s)", server->psm, active);
+		err = -EBUSY;
+		goto unlock;
+	}
+
+	(void)sys_slist_find_and_remove(&servers, &server->node);
+
+	LOG_DBG("PSM 0x%04x unregistered", server->psm);
 
 unlock:
 	k_mutex_unlock(&servers_lock);
@@ -1528,6 +1581,9 @@ static uint16_t l2cap_chan_accept(struct bt_conn *conn,
 
 	/* Set channel PSM */
 	le_chan->psm = server->psm;
+
+	le_chan->_server = server;
+	atomic_inc(&server->_active_chans);
 
 	/* Update state */
 	l2cap_chan_set_state(*chan, BT_L2CAP_CONNECTED);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -227,8 +227,8 @@ struct bt_l2cap_ecred_cb {
 /* Register callbacks for Enhanced Credit based Flow Control */
 void bt_l2cap_register_ecred_cb(const struct bt_l2cap_ecred_cb *cb);
 
-/* Returns a server if it exists for given psm. */
-struct bt_l2cap_server *bt_l2cap_server_lookup_psm(uint16_t psm);
+/* Returns true if the given server is currently registered. */
+bool bt_l2cap_server_is_registered(const struct bt_l2cap_server *server);
 
 /* Pull data from the L2CAP layer */
 struct net_buf *l2cap_data_pull(struct bt_conn *conn,

--- a/tests/bluetooth/l2cap/src/main.c
+++ b/tests/bluetooth/l2cap/src/main.c
@@ -39,6 +39,11 @@ static struct bt_l2cap_server test_inv_server = {
 	.psm		= 0xffff,
 };
 
+static struct bt_l2cap_server test_unreg_server = {
+	.accept		= l2cap_accept,
+	.psm		= 0x0071,
+};
+
 ZTEST_SUITE(test_l2cap, NULL, NULL, NULL, NULL, NULL);
 
 ZTEST(test_l2cap, test_l2cap_register)
@@ -70,4 +75,35 @@ ZTEST(test_l2cap, test_l2cap_register)
 	/* Attempt to re-register server with dynamic PSM */
 	zassert_true(bt_l2cap_server_register(&test_dyn_server),
 		     "Test dynamic PSM server duplicate succeeded");
+}
+
+ZTEST(test_l2cap, test_l2cap_unregister)
+{
+	/* Attempt to unregister a NULL server */
+	zassert_equal(bt_l2cap_server_unregister(NULL), -EINVAL,
+		      "Unregistering NULL did not fail with -EINVAL");
+
+	/* Attempt to unregister a server that was never registered */
+	zassert_equal(bt_l2cap_server_unregister(&test_unreg_server), -ENOENT,
+		      "Unregistering an unknown server did not fail with -ENOENT");
+
+	zassert_ok(bt_l2cap_server_register(&test_unreg_server),
+		   "Test unregister server registration failed");
+
+	/* The PSM is taken while the server is registered */
+	zassert_true(bt_l2cap_server_register(&test_unreg_server),
+		     "Test unregister server duplicate succeeded");
+
+	zassert_ok(bt_l2cap_server_unregister(&test_unreg_server),
+		   "Test unregister server unregistration failed");
+
+	/* Attempt to unregister the same server twice */
+	zassert_equal(bt_l2cap_server_unregister(&test_unreg_server), -ENOENT,
+		      "Double unregistration did not fail with -ENOENT");
+
+	/* The PSM is available again */
+	zassert_ok(bt_l2cap_server_register(&test_unreg_server),
+		   "Test unregister server re-registration failed");
+	zassert_ok(bt_l2cap_server_unregister(&test_unreg_server),
+		   "Test unregister server unregistration failed");
 }

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/CMakeLists.txt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(test_l2cap_server_unregister)
+
+add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/common/testlib testlib)
+target_link_libraries(app PRIVATE testlib)
+
+add_subdirectory(${ZEPHYR_BASE}/tests/bsim/babblekit babblekit)
+target_link_libraries(app PRIVATE babblekit)
+
+zephyr_include_directories(
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+)
+
+target_sources(app PRIVATE
+  src/main.c
+  src/dut.c
+  src/tester.c
+)

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/prj.conf
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/prj.conf
@@ -1,0 +1,22 @@
+CONFIG_LOG=y
+CONFIG_ASSERT=y
+CONFIG_THREAD_NAME=y
+CONFIG_LOG_THREAD_ID_PREFIX=y
+CONFIG_ARCH_POSIX_TRAP_ON_FATAL=y
+
+CONFIG_BT=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_PERIPHERAL=y
+
+# Dependency of testlib/adv and testlib/scan.
+CONFIG_BT_EXT_ADV=y
+
+# Dynamic channel depends on SMP
+CONFIG_BT_SMP=y
+CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y
+
+# Disable auto-initiated procedures so they don't
+# mess with the test's execution.
+CONFIG_BT_AUTO_PHY_CENTRAL_NONE=y
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=n
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/src/data.h
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/src/data.h
@@ -1,0 +1,14 @@
+/* Copyright (c) 2026 Xiaomi Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTS_BSIM_BLUETOOTH_HOST_L2CAP_SERVER_UNREGISTER_SRC_DATA_H_
+#define ZEPHYR_TESTS_BSIM_BLUETOOTH_HOST_L2CAP_SERVER_UNREGISTER_SRC_DATA_H_
+
+/* Both sides use the same PSM number, so that an outgoing channel on the DUT
+ * carries the PSM of the DUT's own server without having been accepted by it.
+ */
+#define TEST_DATA_L2CAP_PSM 0x0080
+#define TEST_DATA_DUT_ADDR  BT_TESTLIB_ADDR_LE_RANDOM_C0_00_00_00_00_(0x01)
+
+#endif /* ZEPHYR_TESTS_BSIM_BLUETOOTH_HOST_L2CAP_SERVER_UNREGISTER_SRC_DATA_H_ */

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/src/dut.c
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/src/dut.c
@@ -1,0 +1,126 @@
+/* Copyright (c) 2026 Xiaomi Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+
+#include <testlib/addr.h>
+#include <testlib/adv.h>
+#include <testlib/conn.h>
+
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
+
+#include "data.h"
+
+LOG_MODULE_REGISTER(dut, LOG_LEVEL_INF);
+
+DEFINE_FLAG(flag_accepted_connected);
+DEFINE_FLAG(flag_accepted_disconnected);
+
+static int chan_recv_cb(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	return 0;
+}
+
+static void accepted_connected_cb(struct bt_l2cap_chan *chan)
+{
+	SET_FLAG(flag_accepted_connected);
+}
+
+static void accepted_disconnected_cb(struct bt_l2cap_chan *chan)
+{
+	SET_FLAG(flag_accepted_disconnected);
+}
+
+static struct bt_l2cap_le_chan accepted_chan = {
+	.chan.ops =
+		&(const struct bt_l2cap_chan_ops){
+			.connected = accepted_connected_cb,
+			.disconnected = accepted_disconnected_cb,
+			.recv = chan_recv_cb,
+		},
+};
+
+static struct bt_l2cap_le_chan outgoing_chan = {
+	.chan.ops =
+		&(const struct bt_l2cap_chan_ops){
+			.recv = chan_recv_cb,
+		},
+};
+
+static int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_server *server,
+			    struct bt_l2cap_chan **chan)
+{
+	*chan = &accepted_chan.chan;
+
+	return 0;
+}
+
+static struct bt_l2cap_server test_server = {
+	.accept = server_accept_cb,
+	.psm = TEST_DATA_L2CAP_PSM,
+};
+
+void entrypoint_dut(void)
+{
+	struct bt_conn *conn = NULL;
+	int err;
+
+	TEST_START("dut");
+
+	err = bt_id_create(&TEST_DATA_DUT_ADDR, NULL);
+	__ASSERT_NO_MSG(!err);
+
+	err = bt_enable(NULL);
+	__ASSERT_NO_MSG(!err);
+
+	err = bt_l2cap_server_register(&test_server);
+	TEST_ASSERT(err == 0, "register: %d", err);
+
+	err = bt_testlib_adv_conn(&conn, BT_ID_DEFAULT, NULL);
+	__ASSERT_NO_MSG(!err);
+
+	/* The tester opens a channel that this server accepts. */
+	WAIT_FOR_FLAG(flag_accepted_connected);
+
+	err = bt_l2cap_server_unregister(&test_server);
+	TEST_ASSERT(err == -EBUSY, "unregister with an accepted channel: %d", err);
+
+	err = bt_l2cap_chan_disconnect(&accepted_chan.chan);
+	TEST_ASSERT(err == 0, "chan disconnect: %d", err);
+	WAIT_FOR_FLAG(flag_accepted_disconnected);
+
+	err = bt_l2cap_server_unregister(&test_server);
+	TEST_ASSERT(err == 0, "unregister once the channel is gone: %d", err);
+
+	err = bt_l2cap_server_unregister(&test_server);
+	TEST_ASSERT(err == -ENOENT, "unregister a second time: %d", err);
+
+	err = bt_l2cap_server_register(&test_server);
+	TEST_ASSERT(err == 0, "register again on the same PSM: %d", err);
+
+	/* An outgoing channel carries the same PSM number, but it is not a
+	 * channel this server accepted, so it must not block unregistering.
+	 */
+	err = bt_l2cap_chan_connect(conn, &outgoing_chan.chan, TEST_DATA_L2CAP_PSM);
+	TEST_ASSERT(err == 0, "chan connect: %d", err);
+
+	while (!atomic_test_bit(outgoing_chan.chan.status, BT_L2CAP_STATUS_OUT)) {
+		k_sleep(K_MSEC(10));
+	}
+
+	err = bt_l2cap_server_unregister(&test_server);
+	TEST_ASSERT(err == 0, "unregister with only an outgoing channel: %d", err);
+
+	TEST_PASS_AND_EXIT("dut");
+}

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/src/main.c
@@ -1,0 +1,47 @@
+/* Copyright (c) 2026 Xiaomi Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#include "bstests.h"
+#include "babblekit/testcase.h"
+
+extern void entrypoint_dut(void);
+extern void entrypoint_tester(void);
+extern enum bst_result_t bst_result;
+
+static void test_end_cb(void)
+{
+	if (bst_result != Passed) {
+		TEST_PRINT("Test has not passed.");
+	}
+}
+
+static const struct bst_test_instance entrypoints[] = {
+	{
+		.test_id = "l2cap/server_unregister/dut",
+		.test_delete_f = test_end_cb,
+		.test_main_f = entrypoint_dut,
+	},
+	{
+		.test_id = "l2cap/server_unregister/tester",
+		.test_delete_f = test_end_cb,
+		.test_main_f = entrypoint_tester,
+	},
+	BSTEST_END_MARKER,
+};
+
+static struct bst_test_list *install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, entrypoints);
+};
+
+bst_test_install_t test_installers[] = {install, NULL};
+
+int main(void)
+{
+	bst_main();
+
+	return 0;
+}

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/src/tester.c
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/src/tester.c
@@ -1,0 +1,84 @@
+/* Copyright (c) 2026 Xiaomi Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+
+#include <testlib/addr.h>
+#include <testlib/conn.h>
+#include <testlib/scan.h>
+
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
+
+#include "data.h"
+
+LOG_MODULE_REGISTER(tester, LOG_LEVEL_INF);
+
+static int chan_recv_cb(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	return 0;
+}
+
+static struct bt_l2cap_le_chan accepted_chan = {
+	.chan.ops =
+		&(const struct bt_l2cap_chan_ops){
+			.recv = chan_recv_cb,
+		},
+};
+
+static struct bt_l2cap_le_chan outgoing_chan = {
+	.chan.ops =
+		&(const struct bt_l2cap_chan_ops){
+			.recv = chan_recv_cb,
+		},
+};
+
+static int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_server *server,
+			    struct bt_l2cap_chan **chan)
+{
+	*chan = &accepted_chan.chan;
+
+	return 0;
+}
+
+static struct bt_l2cap_server test_server = {
+	.accept = server_accept_cb,
+	.psm = TEST_DATA_L2CAP_PSM,
+};
+
+void entrypoint_tester(void)
+{
+	struct bt_conn *conn = NULL;
+	int err;
+
+	TEST_START("tester");
+
+	err = bt_enable(NULL);
+	__ASSERT_NO_MSG(!err);
+
+	/* The DUT opens a channel to this server at the end of the test. */
+	err = bt_l2cap_server_register(&test_server);
+	TEST_ASSERT(err == 0, "register: %d", err);
+
+	err = bt_testlib_connect(&TEST_DATA_DUT_ADDR, &conn);
+	__ASSERT_NO_MSG(!err);
+
+	err = bt_l2cap_chan_connect(conn, &outgoing_chan.chan, TEST_DATA_L2CAP_PSM);
+	TEST_ASSERT(err == 0, "chan connect: %d", err);
+
+	while (!atomic_test_bit(outgoing_chan.chan.status, BT_L2CAP_STATUS_OUT)) {
+		k_sleep(K_MSEC(10));
+	}
+
+	TEST_PASS("tester");
+}

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/test_scripts/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Xiaomi Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+test_name="$(guess_test_long_name)"
+simulation_id="${BOARD_TS}_${test_name}"
+verbosity_level=2
+EXECUTE_TIMEOUT=120
+SIM_LEN_US=$((10 * 1000 * 1000))
+
+test_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_${test_name}_prj_conf"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "${test_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 \
+    -testid=l2cap/server_unregister/dut
+Execute "${test_exe}" -v=${verbosity_level} -s=${simulation_id} -d=1 \
+    -testid=l2cap/server_unregister/tester
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=${SIM_LEN_US} $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/l2cap/server_unregister/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/server_unregister/tests.yaml
@@ -1,0 +1,13 @@
+tests:
+  bluetooth.host.l2cap.server_unregister:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_host_l2cap_server_unregister_prj_conf
+      tests_scripts:
+        - test_scripts


### PR DESCRIPTION
`bt_l2cap_server_register()` appends the server to a list that nothing ever
removes from, so an application that stops a service cannot register the same PSM
again and gets `-EADDRINUSE`. The BR/EDR API already has
`bt_l2cap_br_server_unregister()`; this is the LE counterpart.

The first commit takes the thread safety part on its own, because
`bt_l2cap_server_register()` already needs it: it does a non-atomic
check-then-act over the PSM uniqueness scan and then appends to the list, while
the RX thread walks the same list on every incoming connection request. Two
threads registering concurrently can end up on the same PSM, and a walk
concurrent with an append can miss entries. The RX path now holds the mutex from
the lookup until `accept()` has returned, so a server obtained from the list
stays valid for as long as it is used. That means `accept()` runs with the lock
held, so an application must not register or unregister from inside it; the
header says so. The lookup that escaped the list to `att.c` becomes
`bt_l2cap_server_is_registered()`, so no unprotected server pointer leaves the
file.

Checked while doing that: `bt_conn_foreach()` only uses `bt_conn_ref`/`unref`, and
neither register nor unregister sends an HCI command while holding the lock, so
there is no path where the lock is held waiting for the RX thread.
`bt_eatt_accept()`, the only in-tree LE accept callback, neither registers nor
blocks.

The second commit adds the API. Removal takes the same mutex, so it waits for a
connection request that is already using the server, and it is refused with
`-EBUSY` while channels the server accepted are still connected, so the PSM
cannot be handed to a different server underneath them.
`bt_hid_device_unregister()` does the same `-EBUSY` check for its own
registration.

Channels are counted on the server as they are accepted and released rather than
looked for in `conn->channels` at unregister time. That list is not covered by
the server list mutex, and a locally initiated channel to the same PSM number on
a peer is not a channel this server accepted. The count is decremented before the
`disconnected` callback, so an application may unregister from there.

Coverage: `tests/bluetooth/l2cap` gets the API contract (NULL, unknown server,
PSM taken while registered, unregister, double unregister, re-registration), and
a new bsim scenario `tests/bsim/bluetooth/host/l2cap/server_unregister` covers
the rest against a real connection — `-EBUSY` while a channel the server accepted
is connected, success once it is gone, and success with only an outgoing channel
on the same PSM number. Verified locally that the last one fails if the decision
is made by scanning `conn->channels` for a matching PSM instead.

Release note entry added.
