### PR TITLE
Bluetooth: Classic: handle standard Inquiry Result event

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3207,6 +3207,22 @@ struct bt_hci_evt_inquiry_complete {
 	uint8_t status;
 } __packed;
 
+/** HCI Inquiry Result event. */
+#define BT_HCI_EVT_INQUIRY_RESULT                0x02
+/** HCI Inquiry Result event parameters, repeated per response. */
+struct bt_hci_evt_inquiry_result {
+	/** Address of the device that responded. */
+	bt_addr_t addr;
+	/** Page scan repetition mode of the device. */
+	uint8_t   pscan_rep_mode;
+	/** Reserved for future use. */
+	uint8_t   reserved[2];
+	/** Class of Device of the device. */
+	uint8_t   cod[3];
+	/** Clock offset of the device. */
+	uint16_t  clock_offset;
+} __packed;
+
 #define BT_HCI_EVT_CONN_COMPLETE                0x03
 struct bt_hci_evt_conn_complete {
 	uint8_t   status;
@@ -4532,6 +4548,8 @@ struct bt_hci_evt_le_conn_rate_change {
 #define BT_EVT_BIT(n) (1ULL << (n))
 
 #define BT_EVT_MASK_INQUIRY_COMPLETE             BT_EVT_BIT(0)
+/** Event mask bit for the Inquiry Result event. */
+#define BT_EVT_MASK_INQUIRY_RESULT               BT_EVT_BIT(1)
 #define BT_EVT_MASK_CONN_COMPLETE                BT_EVT_BIT(2)
 #define BT_EVT_MASK_CONN_REQUEST                 BT_EVT_BIT(3)
 #define BT_EVT_MASK_DISCONN_COMPLETE             BT_EVT_BIT(4)

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -497,6 +497,53 @@ static struct bt_br_discovery_result *get_result_slot(const bt_addr_t *addr, int
 	return result;
 }
 
+void bt_hci_inquiry_result(struct net_buf *buf)
+{
+	uint8_t num_reports = net_buf_pull_u8(buf);
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
+		return;
+	}
+
+	LOG_DBG("number of results: %u", num_reports);
+
+	while (num_reports--) {
+		struct bt_hci_evt_inquiry_result *evt;
+		struct bt_br_discovery_result *result;
+		struct bt_br_discovery_priv *priv;
+		struct bt_br_discovery_cb *listener, *next;
+
+		if (buf->len < sizeof(*evt)) {
+			LOG_ERR("Unexpected end to buffer");
+			return;
+		}
+
+		evt = net_buf_pull_mem(buf, sizeof(*evt));
+		LOG_DBG("%s", bt_addr_str(&evt->addr));
+
+		result = get_result_slot(&evt->addr, RSSI_INVALID);
+		if (!result) {
+			return;
+		}
+
+		priv = &result->_priv;
+		priv->pscan_rep_mode = evt->pscan_rep_mode;
+		priv->clock_offset = evt->clock_offset;
+
+		memcpy(result->cod, evt->cod, 3);
+		result->rssi = RSSI_INVALID;
+
+		/* we could reuse slot so make sure EIR is cleared */
+		(void)memset(result->eir, 0, sizeof(result->eir));
+
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&discovery_cbs, listener, next, node) {
+			if (listener->recv) {
+				listener->recv(result);
+			}
+		}
+	}
+}
+
 void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3195,6 +3195,8 @@ static const struct event_handler normal_events[] = {
 		      sizeof(struct bt_hci_evt_user_passkey_req)),
 	EVENT_HANDLER(BT_HCI_EVT_INQUIRY_COMPLETE, bt_hci_inquiry_complete,
 		      sizeof(struct bt_hci_evt_inquiry_complete)),
+	EVENT_HANDLER(BT_HCI_EVT_INQUIRY_RESULT, bt_hci_inquiry_result,
+		      sizeof(struct bt_hci_evt_inquiry_result)),
 	EVENT_HANDLER(BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI,
 		      bt_hci_inquiry_result_with_rssi,
 		      sizeof(struct bt_hci_evt_inquiry_result_with_rssi)),
@@ -4080,6 +4082,7 @@ static int set_event_mask(void)
 		 * Bluetooth 4.0 feature set
 		 */
 		mask |= BT_EVT_MASK_INQUIRY_COMPLETE;
+		mask |= BT_EVT_MASK_INQUIRY_RESULT;
 		mask |= BT_EVT_MASK_CONN_COMPLETE;
 		mask |= BT_EVT_MASK_CONN_REQUEST;
 		mask |= BT_EVT_MASK_AUTH_COMPLETE;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -554,6 +554,7 @@ void bt_hci_conn_complete(struct net_buf *buf);
 
 
 void bt_hci_inquiry_complete(struct net_buf *buf);
+void bt_hci_inquiry_result(struct net_buf *buf);
 void bt_hci_inquiry_result_with_rssi(struct net_buf *buf);
 void bt_hci_extended_inquiry_result(struct net_buf *buf);
 void bt_hci_remote_name_request_complete(struct net_buf *buf);


### PR DESCRIPTION
### Problem

The host masks out the standard `HCI_Inquiry_Result` event (0x02) and has no
handler for it, so devices are only discovered when the controller reports
results in the RSSI or extended format.

Core Spec v6.3 Vol 4, Part E, 7.7.2 says a controller reports in the standard
format whenever the last `HCI_Write_Inquiry_Mode` selected 0x00, or when that
command was never issued. In that case discovery silently yields no results:
the event is masked off, and even if it were unmasked it would fall through to
the unhandled event path.

### Change

- Add `BT_HCI_EVT_INQUIRY_RESULT` and its parameter struct. Field layout taken
  from 7.7.2: `BD_ADDR` 6, `Page_Scan_Repetition_Mode` 1, `Reserved` 2,
  `Class_Of_Device` 3, `Clock_Offset` 2.
- Add `BT_EVT_MASK_INQUIRY_RESULT` and unmask it alongside the other Classic
  events.
- Add `bt_hci_inquiry_result()`, reporting results the same way as the RSSI
  variant. The standard format carries no RSSI, so `RSSI_INVALID` is used;
  `get_result_slot()` already handles that for new slots.

### Verification

This is a rewrite rather than a port: the downstream tree only unmasked the
event, which is not useful on its own without the handler, so the handler and
the event definition are new here and have only been reviewed against the
spec. I do not have an upstream build set up yet, so this PR relies on CI for
the build.
