### PR TITLE
Bluetooth: Classic: fix discovery stop while resolving names

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1114,6 +1114,7 @@ int bt_br_discovery_start(const struct bt_br_discovery_param *param,
 
 int bt_br_discovery_stop(void)
 {
+	bool resolving_names = false;
 	int err;
 	int i;
 
@@ -1121,11 +1122,6 @@ int bt_br_discovery_stop(void)
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
 		return -EALREADY;
-	}
-
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_INQUIRY_CANCEL, NULL, NULL);
-	if (err) {
-		return err;
 	}
 
 	for (i = 0; i < discovery_results_count; i++) {
@@ -1139,6 +1135,8 @@ int bt_br_discovery_stop(void)
 			continue;
 		}
 
+		resolving_names = true;
+
 		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			continue;
@@ -1148,6 +1146,17 @@ int bt_br_discovery_stop(void)
 		bt_addr_copy(&cp->bdaddr, &discovery_results[i].addr);
 
 		bt_hci_cmd_send_sync(BT_HCI_OP_REMOTE_NAME_CANCEL, buf, NULL);
+	}
+
+	/* A remote name is only requested once the controller has reported
+	 * Inquiry Complete, and Inquiry Cancel is only defined before that
+	 * event (Core Specification 6.3, Vol 4, Part E, Section 7.1.2).
+	 */
+	if (!resolving_names) {
+		err = bt_hci_cmd_send_sync(BT_HCI_OP_INQUIRY_CANCEL, NULL, NULL);
+		if (err) {
+			return err;
+		}
 	}
 
 	atomic_clear_bit(bt_dev.flags, BT_DEV_INQUIRY);


### PR DESCRIPTION
`bt_br_discovery_stop()` sends Inquiry Cancel unconditionally. That command is
only defined between the Command Status for HCI_Inquiry and the Inquiry Complete
event (Core Specification 6.3, Vol 4, Part E, Section 7.1.2), and the
specification does not say what a controller returns outside that window, only
that any non-zero status means the command failed.

`BT_DEV_INQUIRY` covers the whole discovery — the inquiry and the remote name
resolution that follows it — and is only cleared once every name is resolved, in
`report_discovery_results()` or `bt_hci_remote_name_request_complete()`. So while
names are being resolved the flag is set, the controller has already reported
Inquiry Complete, and the cancel is rejected. `bt_br_discovery_stop()` returns
that error without doing anything else, `BT_DEV_INQUIRY` stays set, and every
later `bt_br_discovery_start()` returns `-EALREADY`.

The host already knows which phase it is in, without a second device flag. A
remote name is only ever requested from `report_discovery_results()`, which runs
on the Inquiry Complete event, so a result in `RESOLVE_REMOTE_NAME_RESOLVING` is
itself the record that the inquiry has finished — and `bt_br_discovery_stop()`
already walks that state to cancel the outstanding name request. Sending Inquiry
Cancel only when nothing is resolving costs one bool and touches one file.

A cancel that does get sent and fails still aborts the teardown, so the concern
about releasing `discovery_results` while the inquiry may still be running is
unchanged.

Deliberately not addressed: `report_discovery_results()` marks every result
`PENDING` and only then picks one to resolve, while `bt_br_discovery_stop()`
reads that state from the caller's thread with no lock. A stop landing inside
that window behaves as it does today. Closing it needs synchronisation across
the discovery state, which is a separate change.

Built on 65022a7560f: `tests/bluetooth` on `qemu_cortex_m3` is 36 built, 0
failed, 0 errored, same as the base, plus a native_sim Classic build.
