### PR TITLE
Bluetooth: conn: drop the unused user data on the fragment pool

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -139,10 +139,11 @@ static struct bt_conn sco_conns[CONFIG_BT_MAX_SCO_CONN];
 #if defined(CONFIG_BT_CONN_TX)
 static void frag_destroy(struct net_buf *buf);
 
-/* Storage for fragments (views) into the upper layers' PDUs. */
-/* TODO: remove user-data requirements */
-NET_BUF_POOL_FIXED_DEFINE(fragments, CONFIG_BT_CONN_FRAG_COUNT, 0,
-			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, frag_destroy);
+/* Storage for fragments (views) into the upper layers' PDUs. No user data:
+ * the HCI driver may use a sent fragment's user data, so the view metadata
+ * lives in frag_md_pool below instead.
+ */
+NET_BUF_POOL_FIXED_DEFINE(fragments, CONFIG_BT_CONN_FRAG_COUNT, 0, 0, frag_destroy);
 
 struct frag_md {
 	struct bt_buf_view_meta view_meta;


### PR DESCRIPTION
The ACL fragment pool declares `CONFIG_BT_CONN_TX_USER_DATA_SIZE` bytes of user
data that nothing reads. The requirement came from `bt_buf_set_type()` and went
away with 26d97164be2, so the `TODO` next to it is stale.

This sizes the user data zero and keeps the view metadata in the side table, per
@jhedberg's review: an HCI driver may use a sent fragment's user data, so
metadata that `frag_destroy()` dereferences does not belong there.

The first revision moved the metadata into the fragment's user data instead. That
relied on no driver touching it, which `bt_hci_send()` has never promised.

Verified against `origin/main` 3f6e4b89aa6, same counts as a baseline run on that
commit:

- `tests/bsim/bluetooth/host` on `nrf52_bsim/native`: 100 built, 0 failed, 0 errored
- `tests/bluetooth` on `native_sim`: 145 configurations executed, 0 failed, 0 errored
- `tests/bluetooth` on `qemu_cortex_m3`: 36 built, 0 failed, 0 errored
