### PR TITLE
kernel: mmu: fix wraparound assertion in k_mem_unmap_phys_bare()

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -906,7 +906,7 @@ void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32
 					 phys, size,
 					 CONFIG_MMU_PAGE_SIZE);
 	__ASSERT(aligned_size != 0U, "0-length mapping at 0x%lx", aligned_phys);
-	__ASSERT(aligned_phys < (aligned_phys + (aligned_size - 1)),
+	__ASSERT(aligned_size - 1 <= (UINTPTR_MAX - aligned_phys),
 		 "wraparound for physical address 0x%lx (size %zu)",
 		 aligned_phys, aligned_size);
 
@@ -988,7 +988,7 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size)
 					 POINTER_TO_UINT(virt), size,
 					 CONFIG_MMU_PAGE_SIZE);
 	__ASSERT(aligned_size != 0U, "0-length mapping at 0x%lx", aligned_virt);
-	__ASSERT(aligned_virt < (aligned_virt + (aligned_size - 1)),
+	__ASSERT(aligned_size - 1 <= (UINTPTR_MAX - aligned_virt),
 		 "wraparound for virtual address 0x%lx (size %zu)",
 		 aligned_virt, aligned_size);
 


### PR DESCRIPTION
The overflow check uses unsigned arithmetic to detect unsigned overflow:

    __ASSERT(aligned_virt < (aligned_virt + (aligned_size - 1)), ...)

The addition aligned_virt + (aligned_size - 1) can itself wrap, making the assertion unreliable. On AArch32, a mapping at the top of the 4 GB virtual address space is valid:

    aligned_virt = 0xFFFFF000, aligned_size = 0x1000

The exclusive end 0xFFFFF000 + 0x1000 = 0x100000000 wraps to 0 on 32-bit. The old check computes 0xFFFFF000 + 0x0FFF = 0xFFFFFFFF and passes silently allowing the overflow to reach downstream code.

Replace with the canonical overflow-free form:

    __ASSERT(aligned_size <= (UINTPTR_MAX - aligned_virt), ...)

UINTPTR_MAX - aligned_virt is always safe. The boundary case now correctly fires: 0x1000 <= 0xFFF is false.