### PR TITLE
Bluetooth: Classic: handle the standard Inquiry Result event

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -175,6 +175,7 @@ static inline void get_evt_hdr(const struct device *dev)
 			h4->rx.hdr_len++;
 			break;
 #if defined(CONFIG_BT_CLASSIC)
+		case BT_HCI_EVT_INQUIRY_RESULT:
 		case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 		case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 			h4->rx.discardable = true;

--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -42,6 +42,7 @@ static bool bt_hci_bee_check_hci_event_discardable(const uint8_t *event_data)
 
 	switch (event_type) {
 #if defined(CONFIG_BT_CLASSIC)
+	case BT_HCI_EVT_INQUIRY_RESULT:
 	case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 	case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 		return true;

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -522,6 +522,7 @@ static bool is_hci_event_discardable(uint8_t evt_code, const uint8_t *payload, s
 {
 	switch (evt_code) {
 #if defined(CONFIG_BT_CLASSIC)
+	case BT_HCI_EVT_INQUIRY_RESULT:
 	case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 	case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 		return true;

--- a/drivers/bluetooth/hci/hci_sf32lb.c
+++ b/drivers/bluetooth/hci/hci_sf32lb.c
@@ -256,6 +256,7 @@ static inline void get_evt_hdr(const struct device *dev)
 			hci->rx.hdr_len++;
 			break;
 #if defined(CONFIG_BT_CLASSIC)
+		case BT_HCI_EVT_INQUIRY_RESULT:
 		case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 		case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 			hci->rx.discardable = true;

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -73,6 +73,7 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 
 	switch (evt_type) {
 #if defined(CONFIG_BT_CLASSIC)
+	case BT_HCI_EVT_INQUIRY_RESULT:
 	case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 	case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 		return true;

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -55,6 +55,7 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 
 	switch (evt_type) {
 #if defined(CONFIG_BT_CLASSIC)
+	case BT_HCI_EVT_INQUIRY_RESULT:
 	case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 	case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 		return true;

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -63,6 +63,7 @@ static bool is_hci_event_discardable(const struct bt_hci_evt_hdr *evt)
 {
 	switch (evt->evt) {
 #if defined(CONFIG_BT_CLASSIC)
+	case BT_HCI_EVT_INQUIRY_RESULT:
 	case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 	case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 		return true;

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3207,6 +3207,22 @@ struct bt_hci_evt_inquiry_complete {
 	uint8_t status;
 } __packed;
 
+/** HCI Inquiry Result event. */
+#define BT_HCI_EVT_INQUIRY_RESULT                0x02
+/** HCI Inquiry Result event parameters, repeated per response. */
+struct bt_hci_evt_inquiry_result {
+	/** Address of the device that responded. */
+	bt_addr_t addr;
+	/** Page scan repetition mode of the device. */
+	uint8_t   pscan_rep_mode;
+	/** Reserved for future use. */
+	uint8_t   reserved[2];
+	/** Class of Device of the device. */
+	uint8_t   cod[3];
+	/** Clock offset of the device. */
+	uint16_t  clock_offset;
+} __packed;
+
 #define BT_HCI_EVT_CONN_COMPLETE                0x03
 struct bt_hci_evt_conn_complete {
 	uint8_t   status;
@@ -4532,6 +4548,8 @@ struct bt_hci_evt_le_conn_rate_change {
 #define BT_EVT_BIT(n) (1ULL << (n))
 
 #define BT_EVT_MASK_INQUIRY_COMPLETE             BT_EVT_BIT(0)
+/** Event mask bit for the Inquiry Result event. */
+#define BT_EVT_MASK_INQUIRY_RESULT               BT_EVT_BIT(1)
 #define BT_EVT_MASK_CONN_COMPLETE                BT_EVT_BIT(2)
 #define BT_EVT_MASK_CONN_REQUEST                 BT_EVT_BIT(3)
 #define BT_EVT_MASK_DISCONN_COMPLETE             BT_EVT_BIT(4)

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -540,6 +540,34 @@ static void inquiry_result_report(const bt_addr_t *addr, uint8_t pscan_rep_mode,
 	}
 }
 
+void bt_hci_inquiry_result(struct net_buf *buf)
+{
+	uint8_t num_reports = net_buf_pull_u8(buf);
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
+		return;
+	}
+
+	LOG_DBG("number of results: %u", num_reports);
+
+	while (num_reports--) {
+		struct bt_hci_evt_inquiry_result *evt;
+
+		if (buf->len < sizeof(*evt)) {
+			LOG_ERR("Unexpected end to buffer");
+			return;
+		}
+
+		evt = net_buf_pull_mem(buf, sizeof(*evt));
+		LOG_DBG("%s", bt_addr_str(&evt->addr));
+
+		/* The standard format carries no RSSI. */
+		inquiry_result_report(&evt->addr, evt->pscan_rep_mode,
+				      evt->clock_offset, evt->cod, RSSI_INVALID,
+				      NULL);
+	}
+}
+
 void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -497,6 +497,49 @@ static struct bt_br_discovery_result *get_result_slot(const bt_addr_t *addr, int
 	return result;
 }
 
+/* Report one inquiry response to the discovery listeners.
+ *
+ * @param addr           Address of the responding device.
+ * @param pscan_rep_mode Page scan repetition mode of the device.
+ * @param clock_offset   Clock offset of the device, little endian.
+ * @param cod            Class of Device, 3 octets.
+ * @param rssi           RSSI, or RSSI_INVALID when the event does not carry it.
+ * @param eir            EIR data, or NULL when the event does not carry it.
+ */
+static void inquiry_result_report(const bt_addr_t *addr, uint8_t pscan_rep_mode,
+				  uint16_t clock_offset, const uint8_t cod[3],
+				  int8_t rssi, const uint8_t *eir)
+{
+	struct bt_br_discovery_result *result;
+	struct bt_br_discovery_priv *priv;
+	struct bt_br_discovery_cb *listener, *next;
+
+	result = get_result_slot(addr, rssi);
+	if (!result) {
+		return;
+	}
+
+	priv = &result->_priv;
+	priv->pscan_rep_mode = pscan_rep_mode;
+	priv->clock_offset = clock_offset;
+
+	memcpy(result->cod, cod, 3);
+	result->rssi = rssi;
+
+	if (eir != NULL) {
+		memcpy(result->eir, eir, sizeof(result->eir));
+	} else {
+		/* we could reuse slot so make sure EIR is cleared */
+		(void)memset(result->eir, 0, sizeof(result->eir));
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&discovery_cbs, listener, next, node) {
+		if (listener->recv) {
+			listener->recv(result);
+		}
+	}
+}
+
 void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);
@@ -509,9 +552,6 @@ void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
 
 	while (num_reports--) {
 		struct bt_hci_evt_inquiry_result_with_rssi *evt;
-		struct bt_br_discovery_result *result;
-		struct bt_br_discovery_priv *priv;
-		struct bt_br_discovery_cb *listener, *next;
 
 		if (buf->len < sizeof(*evt)) {
 			LOG_ERR("Unexpected end to buffer");
@@ -521,35 +561,15 @@ void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
 		evt = net_buf_pull_mem(buf, sizeof(*evt));
 		LOG_DBG("%s rssi %d dBm", bt_addr_str(&evt->addr), evt->rssi);
 
-		result = get_result_slot(&evt->addr, evt->rssi);
-		if (!result) {
-			return;
-		}
-
-		priv = &result->_priv;
-		priv->pscan_rep_mode = evt->pscan_rep_mode;
-		priv->clock_offset = evt->clock_offset;
-
-		memcpy(result->cod, evt->cod, 3);
-		result->rssi = evt->rssi;
-
-		/* we could reuse slot so make sure EIR is cleared */
-		(void)memset(result->eir, 0, sizeof(result->eir));
-
-		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&discovery_cbs, listener, next, node) {
-			if (listener->recv) {
-				listener->recv(result);
-			}
-		}
+		inquiry_result_report(&evt->addr, evt->pscan_rep_mode,
+				      evt->clock_offset, evt->cod, evt->rssi,
+				      NULL);
 	}
 }
 
 void bt_hci_extended_inquiry_result(struct net_buf *buf)
 {
 	struct bt_hci_evt_extended_inquiry_result *evt = (void *)buf->data;
-	struct bt_br_discovery_result *result;
-	struct bt_br_discovery_priv *priv;
-	struct bt_br_discovery_cb *listener, *next;
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
 		return;
@@ -557,24 +577,8 @@ void bt_hci_extended_inquiry_result(struct net_buf *buf)
 
 	LOG_DBG("%s rssi %d dBm", bt_addr_str(&evt->addr), evt->rssi);
 
-	result = get_result_slot(&evt->addr, evt->rssi);
-	if (!result) {
-		return;
-	}
-
-	priv = &result->_priv;
-	priv->pscan_rep_mode = evt->pscan_rep_mode;
-	priv->clock_offset = evt->clock_offset;
-
-	result->rssi = evt->rssi;
-	memcpy(result->cod, evt->cod, 3);
-	memcpy(result->eir, evt->eir, sizeof(result->eir));
-
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&discovery_cbs, listener, next, node) {
-		if (listener->recv) {
-			listener->recv(result);
-		}
-	}
+	inquiry_result_report(&evt->addr, evt->pscan_rep_mode,
+			      evt->clock_offset, evt->cod, evt->rssi, evt->eir);
 }
 
 void bt_hci_remote_name_request_complete(struct net_buf *buf)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3195,6 +3195,8 @@ static const struct event_handler normal_events[] = {
 		      sizeof(struct bt_hci_evt_user_passkey_req)),
 	EVENT_HANDLER(BT_HCI_EVT_INQUIRY_COMPLETE, bt_hci_inquiry_complete,
 		      sizeof(struct bt_hci_evt_inquiry_complete)),
+	EVENT_HANDLER(BT_HCI_EVT_INQUIRY_RESULT, bt_hci_inquiry_result,
+		      sizeof(uint8_t) + sizeof(struct bt_hci_evt_inquiry_result)),
 	EVENT_HANDLER(BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI,
 		      bt_hci_inquiry_result_with_rssi,
 		      sizeof(struct bt_hci_evt_inquiry_result_with_rssi)),
@@ -4080,6 +4082,7 @@ static int set_event_mask(void)
 		 * Bluetooth 4.0 feature set
 		 */
 		mask |= BT_EVT_MASK_INQUIRY_COMPLETE;
+		mask |= BT_EVT_MASK_INQUIRY_RESULT;
 		mask |= BT_EVT_MASK_CONN_COMPLETE;
 		mask |= BT_EVT_MASK_CONN_REQUEST;
 		mask |= BT_EVT_MASK_AUTH_COMPLETE;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -554,6 +554,7 @@ void bt_hci_conn_complete(struct net_buf *buf);
 
 
 void bt_hci_inquiry_complete(struct net_buf *buf);
+void bt_hci_inquiry_result(struct net_buf *buf);
 void bt_hci_inquiry_result_with_rssi(struct net_buf *buf);
 void bt_hci_extended_inquiry_result(struct net_buf *buf);
 void bt_hci_remote_name_request_complete(struct net_buf *buf);


### PR DESCRIPTION
### Problem

The host cannot work with a controller that does not implement the optional
Inquiry Result formats, and it cannot even fall back to the standard one.

`bt_br_init()` always writes `Inquiry_Mode` 0x02, which requires the Extended
Inquiry Response feature. That feature and RSSI with inquiry results are both
optional (Core Spec v6.3 Vol 2, Part C, Table 3.4, features 48 and 30), so a
controller implementing neither rejects the command with Invalid HCI Command
Parameters, `bt_br_init()` returns that error and BR/EDR initialisation aborts
entirely.

Falling back is not enough on its own either: the standard
`HCI_Inquiry_Result` event (0x02) is masked out and has no handler, so it would
be dropped. Per Core Spec v6.3 Vol 4, Part E, 7.7.2 a controller reports in
that format whenever the last `HCI_Write_Inquiry_Mode` selected 0x00, or when
that command was never issued.

### Change

Two commits:

1. Handle the standard Inquiry Result event. Adds the event code and its
   parameter struct (field layout per 7.7.2: `BD_ADDR` 6,
   `Page_Scan_Repetition_Mode` 1, `Reserved` 2, `Class_Of_Device` 3,
   `Clock_Offset` 2), unmasks the event, and reports results the same way as the
   RSSI variant. The standard format carries no RSSI, so `RSSI_INVALID` is used;
   `get_result_slot()` already handles that for new slots.

2. Select the Inquiry Result format from the controller features: extended, then
   RSSI, then standard. Adds the two LMP feature macros for the optional
   features.

### Verification

Derived from analysis of the current upstream code rather than ported, so it has
been reviewed against the spec but not run on hardware. Relying on CI for the
build.
