### PR TITLE
scripts: kconfig: kconfiglib: keep the GC out of the way while parsing

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -540,6 +540,7 @@ Feedback
 Send bug reports, suggestions, and questions to the GitHub page.
 """
 import errno
+import gc
 import importlib
 import os
 import re
@@ -932,8 +933,19 @@ class Kconfig(object):
           Other exceptions besides EnvironmentError and KconfigError are still
           propagated when suppress_traceback is True.
         """
+        # Parsing builds a big graph of long-lived objects, and the cyclic
+        # garbage collector responds by running ever more expensive full
+        # collections over it, hunting for cycles that are hardly ever there.
+        # Reference counting handles the temporary objects by itself, so keep
+        # the collector away until the tree is built, then let it look at
+        # everything once. That single pass keeps the next collection cheap.
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+
         try:
             self._init(filename, warn, warn_to_stderr, encoding)
+            if gc_was_enabled:
+                gc.collect()
         except (EnvironmentError, KconfigError) as e:
             if suppress_traceback:
                 cmd = sys.argv[0]  # Empty string if missing
@@ -944,6 +956,9 @@ class Kconfig(object):
                 # them here.
                 sys.exit(cmd + str(e).strip())
             raise
+        finally:
+            if gc_was_enabled:
+                gc.enable()
 
     def _init(self, filename, warn, warn_to_stderr, encoding):
         # See __init__()


### PR DESCRIPTION
## Summary

`scripts/kconfig/kconfiglib.py` builds a graph of ~680,000 GC-tracked objects while parsing, and it all stays alive for as long as the `Kconfig` instance does. CPython's cyclic collector reacts to a growing long-lived graph by running progressively more expensive collections, each walking all of it for cycles that are essentially never there — parsing Zephyr's full Kconfig tree runs 1138 collections that free 35 objects between them, and spends 15-18% of the parse doing it.

Reference counting already handles the short-lived objects, so this disables the collector for the parse and runs a single collection at the end, restoring the previous state in a `finally`. That one pass is also what keeps the first collection *after* parsing cheap, rather than leaving a backlog for the caller's next allocations to pay off.

## Performance

Measured against a real Zephyr workspace (macOS/arm64, all west modules checked out), variants interleaved in fresh processes, median CPU time. Lower is better; an A-vs-A control puts the noise floor at ±0.5%.

- **Full-tree parse** — `Kconfig()` over every board, SoC, arch and module, i.e. exactly the tree `scripts/ci/check_compliance.py` builds (31,875 symbols, 47,369 menu nodes, 7,893 files), n=9.
- **Real board build** — `scripts/kconfig/kconfig.py` invoked exactly as `cmake/modules/kconfig.cmake` does at configure time, for `m5stack_stamps3/esp32s3/procpu` + `samples/drivers/display` + the `m5stack_cardputer` shield. Whole process, including `.config`, `autoconf.h` and the trace output, n=16.

| Python | Full-tree parse | Real board build |
|---|---|---|
| 3.12.14 | 0.931 s → 0.838 s (**−10.0%**) | 1.161 s → 1.059 s (**−8.8%**) |
| 3.13.15 | 0.882 s → 0.821 s (**−6.9%**) | 1.114 s → 1.101 s (−1.1%) |
| 3.14.7 | 0.901 s → 0.826 s (**−8.3%**) | 1.095 s → 1.049 s (−4.2%) |

Collector activity during the full-tree parse:

| Python | Collections gen0/gen1/gen2 | Time in GC |
|---|---|---|
| 3.12.14 | 1036/95/7 → 2/0/1 | 0.167 s (17.9%) → 0.080 s (9.7%) |
| 3.13.15 | 362/33/3 → 1/0/1 | 0.131 s (14.8%) → 0.074 s (9.1%) |
| 3.14.7 | 361/33/3 → 1/0/1 | 0.132 s (14.7%) → 0.056 s (6.7%) |

What is left after the change is the single full collection the patch runs itself. Peak RSS is unchanged (+0.2% on 3.12, +0.7% on 3.13, both under 1 MB).

The gain is biggest on Python 3.12, the version Zephyr requires as a minimum and strongly recommends. 3.13 raised the young-generation threshold from 700 to 2000 and reworked old-generation collection, which already removes part of the overhead — the board-build figure there sits close to the noise floor, while the parse itself still gains ~7%.

## Correctness

Same workspace, before vs after:

| Check | Result |
|---|---|
| `.config`, `autoconf.h`, `sources.txt` and `.config-trace.json` produced by the board build above | byte-identical |
| 131 MB canonical dump of the parsed full tree — every menu node with its prompt, dependencies and type, every symbol's value, visibility and direct dependencies, every choice, plus the warning list | byte-identical |
| `Kconfig`, `KconfigBasic`, `KconfigBasicNoModules`, `KconfigHWMv2`, `SysbuildKconfig`, `SysbuildKconfigBasic` and `SysbuildKconfigBasicNoModules` compliance checks | 7/7 pass, identical reports |

The upstream Kconfiglib version of this change was additionally verified against Linux v5.4, where `alldefconfig`, `allnoconfig`, `allyesconfig` and `allmodconfig` produce identical output across 26 architectures, and the Kconfiglib selftests pass.

## Upstream

The same change is being submitted to https://github.com/zephyrproject-rtos/Kconfiglib - zephyrproject-rtos/Kconfiglib#43
