### PR TITLE
drivers: pcie: guard capability walkers against cycles

### DIFF
--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -52,10 +52,15 @@ void pcie_set_cmd(pcie_bdf_t bdf, uint32_t bits, bool on)
 	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT, cmdstat);
 }
 
+/* Maximum number of DWORD-aligned capability slots in each configuration-space region. */
+#define PCIE_CAP_MAX_ENTRIES 48U
+#define PCIE_EXT_CAP_MAX_ENTRIES 960U
+
 uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id)
 {
 	uint32_t reg = 0U;
 	uint32_t data;
+	unsigned int ttl = PCIE_CAP_MAX_ENTRIES;
 
 	data = pcie_conf_read(bdf, PCIE_CONF_CMDSTAT);
 	if ((data & PCIE_CONF_CMDSTAT_CAPS) != 0U) {
@@ -63,32 +68,33 @@ uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id)
 		reg = PCIE_CONF_CAPPTR_FIRST(data);
 	}
 
-	while (reg != 0U) {
+	while ((reg != 0U) && (ttl-- > 0U)) {
 		data = pcie_conf_read(bdf, reg);
 
 		if (PCIE_CONF_CAP_ID(data) == cap_id) {
-			break;
+			return reg;
 		}
 
 		reg = PCIE_CONF_CAP_NEXT(data);
 	}
 
-	return reg;
+	return 0U;
 }
 
 uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id)
 {
 	unsigned int reg = PCIE_CONF_EXT_CAPPTR; /* Start at end of the PCI configuration space */
+	unsigned int ttl = PCIE_EXT_CAP_MAX_ENTRIES;
 	uint32_t data;
 
-	while (reg != 0U) {
+	while ((reg != 0U) && (ttl-- > 0U)) {
 		data = pcie_conf_read(bdf, reg);
 		if (!data || data == 0xffffffffU) {
 			return 0;
 		}
 
 		if (PCIE_CONF_EXT_CAP_ID(data) == cap_id) {
-			break;
+			return reg;
 		}
 
 		reg = PCIE_CONF_EXT_CAP_NEXT(data) >> 2;
@@ -98,7 +104,7 @@ uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id)
 		}
 	}
 
-	return reg;
+	return 0U;
 }
 
 /**

--- a/tests/drivers/pcie/capability_walkers/CMakeLists.txt
+++ b/tests/drivers/pcie/capability_walkers/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(pcie_capability_walkers)
+
+target_sources(app PRIVATE src/main.c)
+target_compile_options(app PRIVATE -Wno-unused-function)

--- a/tests/drivers/pcie/capability_walkers/prj.conf
+++ b/tests/drivers/pcie/capability_walkers/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+# The test includes pcie.c directly with fake config-space access, so keep
+# the normal PCIe library out of the build to avoid duplicate symbols.
+CONFIG_PCIE=n

--- a/tests/drivers/pcie/capability_walkers/src/main.c
+++ b/tests/drivers/pcie/capability_walkers/src/main.c
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+
+#include <zephyr/drivers/pcie/pcie.h>
+#include <zephyr/ztest.h>
+
+#define CONF_WORDS BIT(10)
+#define FAKE_READ_LIMIT (CONF_WORDS + 16U)
+
+static uint32_t config_space[CONF_WORDS];
+static size_t read_count;
+static bool read_limit_hit;
+
+uint32_t pcie_conf_read(pcie_bdf_t bdf, unsigned int reg)
+{
+	ARG_UNUSED(bdf);
+
+	read_count++;
+	if (read_count > FAKE_READ_LIMIT) {
+		read_limit_hit = true;
+		return 0U;
+	}
+
+	if (reg >= ARRAY_SIZE(config_space)) {
+		return 0xffffffffU;
+	}
+
+	return config_space[reg];
+}
+
+void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
+{
+	ARG_UNUSED(bdf);
+	ARG_UNUSED(reg);
+	ARG_UNUSED(data);
+}
+
+/* Keep the included driver from registering its unrelated PCIe bus init hook. */
+#undef SYS_INIT
+#define SYS_INIT(...)
+
+#include "../../../../../drivers/pcie/host/pcie.c"
+
+static void set_standard_head(unsigned int reg)
+{
+	config_space[PCIE_CONF_CMDSTAT] = PCIE_CONF_CMDSTAT_CAPS;
+	config_space[PCIE_CONF_CAPPTR] = reg << 2;
+}
+
+static void set_standard_cap(unsigned int reg, uint32_t id, unsigned int next)
+{
+	config_space[reg] = id | (next << 10);
+}
+
+static void set_extended_cap(unsigned int reg, uint32_t id, unsigned int next)
+{
+	config_space[reg] = id | BIT(16) | ((next << 2) << 20);
+}
+
+static void before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	memset(config_space, 0, sizeof(config_space));
+	read_count = 0U;
+	read_limit_hit = false;
+}
+
+ZTEST(pcie_capability_walkers, test_standard_self_loop_terminates)
+{
+	set_standard_head(16U);
+	set_standard_cap(16U, 0x01U, 16U);
+
+	zassert_equal(pcie_get_cap(PCIE_BDF(0, 0, 0), 0xfeU), 0U);
+	zassert_false(read_limit_hit, "standard capability walker exceeded defensive read limit");
+}
+
+ZTEST(pcie_capability_walkers, test_standard_two_node_cycle_terminates)
+{
+	set_standard_head(16U);
+	set_standard_cap(16U, 0x01U, 20U);
+	set_standard_cap(20U, 0x05U, 16U);
+
+	zassert_equal(pcie_get_cap(PCIE_BDF(0, 0, 0), 0xfeU), 0U);
+	zassert_false(read_limit_hit, "standard capability walker exceeded defensive read limit");
+}
+
+ZTEST(pcie_capability_walkers, test_standard_valid_capability_is_found)
+{
+	set_standard_head(16U);
+	set_standard_cap(16U, 0x01U, 20U);
+	set_standard_cap(20U, 0x05U, 0U);
+
+	zassert_equal(pcie_get_cap(PCIE_BDF(0, 0, 0), 0x05U), 20U);
+	zassert_false(read_limit_hit);
+}
+
+ZTEST(pcie_capability_walkers, test_extended_self_loop_terminates)
+{
+	set_extended_cap(PCIE_CONF_EXT_CAPPTR, 0x0001U, PCIE_CONF_EXT_CAPPTR);
+
+	zassert_equal(pcie_get_ext_cap(PCIE_BDF(0, 0, 0), 0x1234U), 0U);
+	zassert_false(read_limit_hit, "extended capability walker exceeded defensive read limit");
+}
+
+ZTEST(pcie_capability_walkers, test_extended_two_node_cycle_terminates)
+{
+	set_extended_cap(PCIE_CONF_EXT_CAPPTR, 0x0001U, 72U);
+	set_extended_cap(72U, 0x0010U, PCIE_CONF_EXT_CAPPTR);
+
+	zassert_equal(pcie_get_ext_cap(PCIE_BDF(0, 0, 0), 0x1234U), 0U);
+	zassert_false(read_limit_hit, "extended capability walker exceeded defensive read limit");
+}
+
+ZTEST(pcie_capability_walkers, test_extended_valid_capability_is_found)
+{
+	set_extended_cap(PCIE_CONF_EXT_CAPPTR, 0x0001U, 72U);
+	set_extended_cap(72U, 0x1234U, 0U);
+
+	zassert_equal(pcie_get_ext_cap(PCIE_BDF(0, 0, 0), 0x1234U), 72U);
+	zassert_false(read_limit_hit);
+}
+
+ZTEST(pcie_capability_walkers, test_extended_zero_header_stops_walk)
+{
+	config_space[PCIE_CONF_EXT_CAPPTR] = 0U;
+
+	zassert_equal(pcie_get_ext_cap(PCIE_BDF(0, 0, 0), 0x1234U), 0U);
+	zassert_equal(read_count, 1U);
+}
+
+ZTEST(pcie_capability_walkers, test_extended_all_ones_header_stops_walk)
+{
+	config_space[PCIE_CONF_EXT_CAPPTR] = 0xffffffffU;
+
+	zassert_equal(pcie_get_ext_cap(PCIE_BDF(0, 0, 0), 0x1234U), 0U);
+	zassert_equal(read_count, 1U);
+}
+
+ZTEST_SUITE(pcie_capability_walkers, NULL, NULL, before, NULL, NULL);

--- a/tests/drivers/pcie/capability_walkers/tests.yaml
+++ b/tests/drivers/pcie/capability_walkers/tests.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.pcie.capability_walkers:
+    platform_allow:
+      - qemu_x86
+    tags:
+      - drivers
+      - pcie


### PR DESCRIPTION
Malformed PCI and PCIe capability lists can contain self-loops or multi-node cycles. Both `pcie_get_cap()` and `pcie_get_ext_cap()` currently follow the next pointer until it reaches zero, so a cyclic list can make either walker spin forever.

Bound traversal by the number of DWORD-aligned capability slots that can physically exist in each configuration-space region: 48 standard capability slots and 960 extended capability slots. If the budget is exhausted without a match, return 0. Valid chains and the existing extended-capability terminal headers remain unchanged.

Add regression coverage with a fake configuration-space reader and a defensive read limit for:

- standard capability self-loop
- standard two-node cycle
- extended capability self-loop
- extended two-node cycle
- valid standard and extended capability chains
- extended header values 0 and 0xffffffff

Validation:

- `qemu_x86`: 8/8 test cases pass with the fix
- the same suite with only `drivers/pcie/host/pcie.c` restored to the unpatched parent fails exactly the four cyclic cases via the defensive read limit, without hanging CI; all non-cycle cases still pass
- `checkpatch.pl --strict`: 0 errors, 0 warnings
- `git diff --check`: pass

Validation run: https://github.com/alesanGreat/zephyr/actions/runs/32461131031
