### PR TITLE
drivers: comparator: Add microchip pic32cmjh family

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.yaml
@@ -11,6 +11,7 @@ flash: 512
 ram: 64
 supported:
   - clock_control
+  - comparator
   - counter
   - gpio
   - pinctrl

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -12,6 +12,7 @@ ram: 64
 supported:
   - adc
   - clock_control
+  - comparator
   - counter
   - dac
   - dma

--- a/drivers/comparator/comparator_mchp_ac_g1.c
+++ b/drivers/comparator/comparator_mchp_ac_g1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -125,29 +125,6 @@ static void comparator_print_channel_cfg(const struct comparator_mchp_channel_cf
 	LOG_DBG("Event Output Enabled : %s", cfg->event_output_enable ? "Yes" : "No");
 	LOG_DBG("========================================");
 }
-
-/* Print all the comparator register values */
-static void comparator_print_reg(const struct device *dev)
-{
-	LOG_DBG("=============== Comparator Registers ===============");
-	LOG_DBG("%-20s: 0x%02x", "AC_CTRLA", AC_REG->AC_CTRLA);
-	LOG_DBG("%-20s: 0x%02x", "AC_CTRLB", AC_REG->AC_CTRLB);
-	LOG_DBG("%-20s: 0x%04x", "AC_EVCTRL", AC_REG->AC_EVCTRL);
-	LOG_DBG("%-20s: 0x%02x", "AC_INTENCLR", AC_REG->AC_INTENCLR);
-	LOG_DBG("%-20s: 0x%02x", "AC_INTENSET", AC_REG->AC_INTENSET);
-	LOG_DBG("%-20s: 0x%02x", "AC_INTFLAG", AC_REG->AC_INTFLAG);
-	LOG_DBG("%-20s: 0x%02x", "AC_STATUSA", AC_REG->AC_STATUSA);
-	LOG_DBG("%-20s: 0x%02x", "AC_STATUSB", AC_REG->AC_STATUSB);
-	LOG_DBG("%-20s: 0x%02x", "AC_DBGCTRL", AC_REG->AC_DBGCTRL);
-	LOG_DBG("%-20s: 0x%02x", "AC_WINCTRL", AC_REG->AC_WINCTRL);
-	LOG_DBG("%-20s: 0x%02x", "AC_SCALER[0]", AC_REG->AC_SCALER[0]);
-	LOG_DBG("%-20s: 0x%02x", "AC_SCALER[1]", AC_REG->AC_SCALER[1]);
-	LOG_DBG("%-20s: 0x%08x", "AC_COMPCTRL[0]", (uint32_t)AC_REG->AC_COMPCTRL[0]);
-	LOG_DBG("%-20s: 0x%08x", "AC_COMPCTRL[1]", (uint32_t)AC_REG->AC_COMPCTRL[1]);
-	LOG_DBG("%-20s: 0x%08x", "AC_SYNCBUSY", (uint32_t)AC_REG->AC_SYNCBUSY);
-	LOG_DBG("%-20s: 0x%04x", "AC_CALIB", AC_REG->AC_CALIB);
-	LOG_DBG("===================================================");
-}
 #endif /* CONFIG_COMPARATOR_LOG_LEVEL_DBG */
 
 /* Wait for synchronization */
@@ -269,11 +246,13 @@ static int ac_configure_channel(const struct device *dev)
 		AC_REG->AC_COMPCTRL[channel_id] |=
 			AC_COMPCTRL_HYSTEN(channel_config->hysteresis_enable ? 1 : 0);
 
+#if !defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
 		/* Set hysterisis */
 		if (channel_config->hysteresis_enable == true) {
 			AC_REG->AC_COMPCTRL[channel_id] |=
 				AC_COMPCTRL_HYST(channel_config->hysteresis_level);
 		}
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 	}
 
 	/* Set Comparator speed */
@@ -455,7 +434,6 @@ static int comparator_mchp_init(const struct device *dev)
 	struct comparator_mchp_dev_data *const dev_data = dev->data;
 	int ret;
 	uint8_t channel_id = dev_cfg->channel_config.channel_id;
-	uint32_t sw0_reg;
 
 	dev_data->interrupt_status = COMPARATOR_INT_STATUS_NONE;
 
@@ -486,10 +464,12 @@ static int comparator_mchp_init(const struct device *dev)
 	AC_REG->AC_CTRLA = AC_CTRLA_SWRST_Msk;
 	ac_wait_sync(AC_REG, AC_SYNCBUSY_SWRST_Msk);
 
+#if !defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
 	/* Configure calibration */
-	sw0_reg = ((fuses_sw0_fuses_registers_t *)SW0_ADDR)->FUSES_SW0_WORD_0;
+	uint32_t sw0_reg = ((fuses_sw0_fuses_registers_t *)SW0_ADDR)->FUSES_SW0_WORD_0;
 	dev_cfg->regs->AC_CALIB =
 		(sw0_reg & FUSES_SW0_WORD_0_AC_BIAS0_Msk) >> FUSES_SW0_WORD_0_AC_BIAS0_Pos;
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 
 	/* Configure ISR */
 	dev_cfg->config_func(dev);

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -341,6 +341,17 @@
 			calib-mapping-names = "BIASREFBUF", "BIASCOMP";
 			status = "disabled";
 		};
+
+		ac: ac@42004c00 {
+			compatible = "microchip,ac-g1-comparator";
+			reg = <0x42004c00 0x24>;
+			interrupts = <27 0>;
+			interrupt-names = "win0-1";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_AC>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_AC>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/comparator/microchip,ac-g1-comparator.yaml
+++ b/dts/bindings/comparator/microchip,ac-g1-comparator.yaml
@@ -1,10 +1,14 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 title: Microchip G1 Analog Comparator
 
 description: |
   Binding for the Microchip Comparator driver supporting AC G1 peripherals.
+
+  Group g1 AC driver supports following hardware peripherals:
+    - module name="AC" id="U2501" version="1.0.0"
+    - module name="AC" id="U2245" version="1.1.1"
 
 compatible: "microchip,ac-g1-comparator"
 
@@ -126,3 +130,14 @@ properties:
     type: boolean
     description: |
       Enable the event output path for the comparator.
+
+examples:
+  - |
+    ac: ac@42004c00 {
+      compatible = "microchip,ac-g1-comparator";
+      reg = <0x42004c00 0x24>;
+      interrupts = <27 0>;
+      interrupt-names = "win0-1";
+      comparator-channel = <0>;
+      status = "disabled";
+    };

--- a/tests/drivers/comparator/gpio_loopback/boards/pic32cm_jh01_cnano.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/pic32cm_jh01_cnano.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* connect the PA04 to PA05 for the test */
+
+/ {
+	aliases {
+		test-comp = &ac;
+	};
+
+	zephyr,user {
+		test-gpios = <&porta 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ac {
+	comparator-channel = <0>;
+	positive-mux-input = "pin0";
+	negative-mux-input = "bandgap";
+	pinctrl-0 = <&pinctrl_ac>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_ac: ac_pins {
+		group1 {
+			pinmux = <PA4B_AC_AIN0>;
+		};
+	};
+};

--- a/tests/drivers/comparator/gpio_loopback/boards/pic32cm_jh01_cpro.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/pic32cm_jh01_cpro.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* connect the PA04 to PA05 for the test */
+
+/ {
+	aliases {
+		test-comp = &ac;
+	};
+
+	zephyr,user {
+		test-gpios = <&porta 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ac {
+	comparator-channel = <0>;
+	positive-mux-input = "pin0";
+	negative-mux-input = "bandgap";
+	pinctrl-0 = <&pinctrl_ac>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_ac: ac_pins {
+		group1 {
+			pinmux = <PA4B_AC_AIN0>;
+		};
+	};
+};

--- a/tests/drivers/comparator/gpio_loopback/tests.yaml
+++ b/tests/drivers/comparator/gpio_loopback/tests.yaml
@@ -81,6 +81,7 @@ tests:
     platform_allow:
       - sam_e54_xpro
       - pic32cx_sg41_cult
+      - pic32cm_jh01_cpro
   drivers.comparator.gpio_loopback.ite:
     platform_allow:
       - it51xxx_evb/it51526aw


### PR DESCRIPTION
- Adds node in dts
- Updates the binding yaml of comparator driver with the supported ac ip version
- Update AC G1 driver implementation to support PIC32CM_JH
- Update pic32cm_jh01_cpro.yaml to reflect G1 AC support on the board.
- Adds pic32cm_jh01_cpro.overlay file for gpio_loopback test.