### PR TITLE
modules: tf-m: add MCUboot image encryption support

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -53,6 +53,23 @@ if(CONFIG_BUILD_WITH_TFM)
     list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_IMAGE_VERSION_NS=${CONFIG_TFM_IMAGE_VERSION_NS})
     list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_SIGNATURE_TYPE=${CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE})
 
+    if(CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+      list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENC_IMAGES:BOOL=OFF)
+      list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENCRYPT_RSA:BOOL=OFF)
+      list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENCRYPT_KW:BOOL=OFF)
+    else()
+      list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENC_IMAGES:BOOL=ON)
+      if(CONFIG_TFM_MCUBOOT_ENCRYPTION_RSA_OAEP)
+        list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENCRYPT_RSA:BOOL=ON)
+      else()
+        list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENCRYPT_RSA:BOOL=OFF)
+      endif()
+      # AES-KW is not supported in Zephyr's version of MCUboot but might be
+      # the platform default, turn it off
+      list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENCRYPT_KW:BOOL=OFF)
+      list(APPEND TFM_CMAKE_ARGS -DMCUBOOT_ENC_KEY_LEN=${CONFIG_TFM_MCUBOOT_ENC_KEY_LEN})
+    endif()
+
     # Configure which format to include the public key in the image manifest.
     #
     # Note: we disable MCUBOOT_BUILTIN_KEY because starting from TF-M v2.3
@@ -400,9 +417,16 @@ if(CONFIG_BUILD_WITH_TFM)
     TFM_S_HEX_FILE ${TFM_S_HEX_FILE} # TFM Secure FW (unsigned)
     TFM_NS_BIN_FILE ${TFM_NS_BIN_FILE} # TFM Nonsecure FW (unsigned)
     TFM_NS_HEX_FILE ${TFM_NS_HEX_FILE} # TFM Nonsecure FW (unsigned)
-    TFM_S_SIGNED_BIN_FILE ${TFM_S_SIGNED_BIN_FILE} # TFM Secure FW (signed)
-    TFM_NS_SIGNED_BIN_FILE ${TFM_NS_SIGNED_BIN_FILE} # TFM Nonsecure FW (signed)
-    TFM_S_NS_SIGNED_BIN_FILE ${TFM_S_NS_SIGNED_BIN_FILE} # Merged TFM Secure/Nonsecure FW (signed)
+    # The below signed files are not produced by a regular Zephyr build. Zephyr
+    # signs images itself through the post-build commands (with
+    # PLATFORM_DEFAULT_IMAGE_SIGNING=OFF), so TF-M only generates them when it
+    # performs the signing, e.g. in the tfm_psa_test sample.
+    # TFM Secure FW (signed or signed+encrypted)
+    TFM_S_SIGNED_BIN_FILE ${TFM_S_SIGNED_BIN_FILE}
+    # TFM Nonsecure FW (signed or signed+encrypted)
+    TFM_NS_SIGNED_BIN_FILE ${TFM_NS_SIGNED_BIN_FILE}
+    # Merged TFM Secure/Nonsecure FW (signed or signed+encrypted)
+    TFM_S_NS_SIGNED_BIN_FILE ${TFM_S_NS_SIGNED_BIN_FILE}
     )
 
   if(NOT CONFIG_TFM_USE_NS_APP)
@@ -528,7 +552,7 @@ if(CONFIG_BUILD_WITH_TFM)
   endif()
 
   function(tfm_sign OUT_ARG)
-    set(options HEADER TRAILER CONFIRM)
+    set(options HEADER TRAILER CONFIRM ENCRYPT)
     set(oneValueArgs SUFFIX MAX_SECTORS INPUT_FILE OUTPUT_FILE)
     set(multiValueArgs "")
 
@@ -567,6 +591,12 @@ if(CONFIG_BUILD_WITH_TFM)
       set(TFM_SIGN_ARG_SUFFIX "S")
     endif()
 
+    set(encrypt "")
+    if(TFM_SIGN_ARG_ENCRYPT)
+      set(encrypt -E ${CONFIG_TFM_MCUBOOT_ENCRYPTION_KEY_FILE_${TFM_SIGN_ARG_SUFFIX}}
+                  -L ${CONFIG_TFM_MCUBOOT_ENC_KEY_LEN})
+    endif()
+
     set(${OUT_ARG}
       # Add the MCUBoot script to the path so that if there is a version of imgtool in there then
       # it gets used over the system imgtool. Used so that imgtool from upstream
@@ -575,6 +605,7 @@ if(CONFIG_BUILD_WITH_TFM)
       ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper.py
       --layout ${layout_file}
       -k ${CONFIG_TFM_KEY_FILE_${TFM_SIGN_ARG_SUFFIX}}
+      ${encrypt}
       --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
       --align ${image_alignment}
       --max-sectors ${TFM_SIGN_ARG_MAX_SECTORS}
@@ -597,10 +628,18 @@ if(CONFIG_BUILD_WITH_TFM)
   set(S_NS_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns.hex)
   set(S_NS_SIGNED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed.hex)
   set(S_NS_SIGNED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed.bin)
+  set(S_NS_SIGNED_ENCRYPTED_HEX_FILE
+    ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed_encrypted.hex)
+  set(S_NS_SIGNED_ENCRYPTED_BIN_FILE
+    ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed_encrypted.bin)
   set(NS_SIGNED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/zephyr_ns_signed.hex)
   set(S_SIGNED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_signed.hex)
   set(NS_SIGNED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/zephyr_ns_signed.bin)
   set(S_SIGNED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_signed.bin)
+  set(NS_SIGNED_ENCRYPTED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/zephyr_ns_signed_encrypted.hex)
+  set(S_SIGNED_ENCRYPTED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_signed_encrypted.hex)
+  set(NS_SIGNED_ENCRYPTED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/zephyr_ns_signed_encrypted.bin)
+  set(S_SIGNED_ENCRYPTED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_signed_encrypted.bin)
 
   if(CONFIG_TFM_USE_NS_APP)
     # Use the TF-M NS binary as the Non-Secure application firmware image
@@ -640,6 +679,11 @@ if(CONFIG_BUILD_WITH_TFM)
     tfm_sign(sign_cmd_s_ns_hex SUFFIX "S_NS"
       HEADER MAX_SECTORS ${S_NS_MAX_SECTORS}
       INPUT_FILE ${S_NS_HEX_FILE} OUTPUT_FILE ${S_NS_SIGNED_HEX_FILE})
+    if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+      tfm_sign(sign_cmd_s_ns_encrypted_hex SUFFIX "S_NS"
+        HEADER ENCRYPT MAX_SECTORS ${S_NS_MAX_SECTORS}
+        INPUT_FILE ${S_NS_HEX_FILE} OUTPUT_FILE ${S_NS_SIGNED_ENCRYPTED_HEX_FILE})
+    endif()
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
@@ -664,6 +708,18 @@ if(CONFIG_BUILD_WITH_TFM)
       COMMAND ${CMAKE_OBJCOPY} --input-target=ihex --output-target=binary ${S_NS_SIGNED_HEX_FILE} ${S_NS_SIGNED_BIN_FILE}
     )
 
+    if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND ${sign_cmd_s_ns_encrypted_hex}
+
+        COMMAND ${CMAKE_OBJCOPY}
+          --input-target=ihex
+          --output-target=binary
+          ${S_NS_SIGNED_ENCRYPTED_HEX_FILE}
+          ${S_NS_SIGNED_ENCRYPTED_BIN_FILE}
+      )
+    endif()
+
     set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
       ${S_NS_SIGNED_CONFIRMED_HEX_FILE}
       ${S_NS_HEX_FILE}
@@ -672,6 +728,13 @@ if(CONFIG_BUILD_WITH_TFM)
       ${MERGED_HEX_FILE}
       ${MERGED_BIN_FILE}
     )
+
+    if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+        ${S_NS_SIGNED_ENCRYPTED_HEX_FILE}
+        ${S_NS_SIGNED_ENCRYPTED_BIN_FILE}
+      )
+    endif()
 
   else()
     if(CONFIG_TFM_USE_NS_APP)
@@ -683,6 +746,16 @@ if(CONFIG_BUILD_WITH_TFM)
         HEADER TRAILER MAX_SECTORS ${S_NS_MAX_SECTORS}
         INPUT_FILE ${NS_BIN_APP_FILE}
         OUTPUT_FILE ${NS_SIGNED_BIN_FILE})
+      if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+        tfm_sign(sign_cmd_ns_encrypted_hex SUFFIX "NS"
+          HEADER TRAILER CONFIRM ENCRYPT MAX_SECTORS ${S_NS_MAX_SECTORS}
+          INPUT_FILE ${NS_HEX_APP_FILE}
+          OUTPUT_FILE ${NS_SIGNED_ENCRYPTED_HEX_FILE})
+        tfm_sign(sign_cmd_ns_encrypted_bin SUFFIX "NS"
+          HEADER TRAILER ENCRYPT MAX_SECTORS ${S_NS_MAX_SECTORS}
+          INPUT_FILE ${NS_BIN_APP_FILE}
+          OUTPUT_FILE ${NS_SIGNED_ENCRYPTED_BIN_FILE})
+      endif()
     else()
       tfm_sign(sign_cmd_ns_hex SUFFIX "NS"
         TRAILER CONFIRM MAX_SECTORS ${S_NS_MAX_SECTORS}
@@ -692,6 +765,16 @@ if(CONFIG_BUILD_WITH_TFM)
         MAX_SECTORS ${S_NS_MAX_SECTORS}
         INPUT_FILE ${NS_BIN_APP_FILE}
         OUTPUT_FILE ${NS_SIGNED_BIN_FILE})
+      if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+        tfm_sign(sign_cmd_ns_encrypted_hex SUFFIX "NS"
+          TRAILER CONFIRM ENCRYPT MAX_SECTORS ${S_NS_MAX_SECTORS}
+          INPUT_FILE ${NS_HEX_APP_FILE}
+          OUTPUT_FILE ${NS_SIGNED_ENCRYPTED_HEX_FILE})
+        tfm_sign(sign_cmd_ns_encrypted_bin SUFFIX "NS"
+          ENCRYPT MAX_SECTORS ${S_NS_MAX_SECTORS}
+          INPUT_FILE ${NS_BIN_APP_FILE}
+          OUTPUT_FILE ${NS_SIGNED_ENCRYPTED_BIN_FILE})
+      endif()
     endif()
 
     tfm_sign(sign_cmd_s_hex SUFFIX "S"
@@ -702,6 +785,16 @@ if(CONFIG_BUILD_WITH_TFM)
       HEADER TRAILER MAX_SECTORS ${S_NS_MAX_SECTORS}
       INPUT_FILE $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
       OUTPUT_FILE ${S_SIGNED_BIN_FILE})
+    if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+      tfm_sign(sign_cmd_s_encrypted_hex SUFFIX "S"
+        HEADER TRAILER CONFIRM ENCRYPT MAX_SECTORS ${S_NS_MAX_SECTORS}
+        INPUT_FILE $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
+        OUTPUT_FILE ${S_SIGNED_ENCRYPTED_HEX_FILE})
+      tfm_sign(sign_cmd_s_encrypted_bin SUFFIX "S"
+        HEADER TRAILER ENCRYPT MAX_SECTORS ${S_NS_MAX_SECTORS}
+        INPUT_FILE $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
+        OUTPUT_FILE ${S_SIGNED_ENCRYPTED_BIN_FILE})
+    endif()
 
     #Create and sign for concatenated binary image, should align with the TF-M BL2
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
@@ -718,6 +811,15 @@ if(CONFIG_BUILD_WITH_TFM)
         ${NS_SIGNED_HEX_FILE}
     )
 
+    if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND ${sign_cmd_ns_encrypted_hex}
+        COMMAND ${sign_cmd_ns_encrypted_bin}
+        COMMAND ${sign_cmd_s_encrypted_hex}
+        COMMAND ${sign_cmd_s_encrypted_bin}
+      )
+    endif()
+
     set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
       ${S_SIGNED_HEX_FILE}
       ${S_SIGNED_BIN_FILE}
@@ -725,6 +827,15 @@ if(CONFIG_BUILD_WITH_TFM)
       ${NS_SIGNED_BIN_FILE}
       ${MERGED_HEX_FILE}
     )
+
+    if(NOT CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+        ${S_SIGNED_ENCRYPTED_HEX_FILE}
+        ${S_SIGNED_ENCRYPTED_BIN_FILE}
+        ${NS_SIGNED_ENCRYPTED_HEX_FILE}
+        ${NS_SIGNED_ENCRYPTED_BIN_FILE}
+      )
+    endif()
   endif()
 
   if(CONFIG_TFM_DUMMY_PROVISIONING)

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -355,6 +355,71 @@ config TFM_PUBLIC_KEY_FORMAT_HASH
 
 endchoice
 
+choice TFM_MCUBOOT_ENCRYPTION
+	prompt "Image encryption key-wrapping scheme in BL2"
+	default TFM_MCUBOOT_ENCRYPTION_NONE
+	help
+	  Selects whether MCUboot (BL2) expects encrypted images and, if so,
+	  which algorithm wraps the per-image AES content-encryption key that
+	  is stored in the image TLV area. Maps to the TF-M options
+	  MCUBOOT_ENC_IMAGES and MCUBOOT_ENCRYPT_RSA/MCUBOOT_ENCRYPT_KW.
+
+config TFM_MCUBOOT_ENCRYPTION_NONE
+	bool "Disabled"
+	help
+	  Image encryption is disabled. Images are signed but not encrypted.
+
+config TFM_MCUBOOT_ENCRYPTION_RSA_OAEP
+	bool "RSA-OAEP"
+	help
+	  Wrap the AES content-encryption key using RSA-OAEP.
+	  Corresponds to TF-M MCUBOOT_ENCRYPT_RSA option.
+
+endchoice
+
+choice TFM_MCUBOOT_ENCRYPTION_KEY_LEN
+	prompt "Image encryption AES key length"
+	depends on !TFM_MCUBOOT_ENCRYPTION_NONE
+	default TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128
+	help
+	  Length of the AES content-encryption key used to encrypt the image
+	  payload. Maps to TF-M MCUBOOT_ENC_KEY_LEN option.
+
+config TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128
+	bool "128-bit"
+
+config TFM_MCUBOOT_ENCRYPTION_KEY_LEN_256
+	bool "256-bit"
+
+endchoice
+
+config TFM_MCUBOOT_ENC_KEY_LEN
+	int
+	default 128 if TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128
+	default 256 if TFM_MCUBOOT_ENCRYPTION_KEY_LEN_256
+
+config TFM_MCUBOOT_ENCRYPTION_KEY_FILE_S
+	string "Path to key used to encrypt secure firmware images"
+	depends on !TFM_MCUBOOT_ENCRYPTION_NONE
+	default "$(ZEPHYR_MCUBOOT_MODULE_DIR)/enc-rsa2048-pub.pem" if TFM_MCUBOOT_ENCRYPTION_RSA_OAEP
+	default ""
+	help
+	  The path and filename for the key file that should be used by the BL2
+	  bootloader when encrypting secure firmware images. For RSA-OAEP this is
+	  the RSA public key that wraps the AES content-encryption key. This key
+	  file is also used for merged secure + non-secure builds
+	  (TFM_MCUBOOT_IMAGE_NUMBER == 1).
+
+config TFM_MCUBOOT_ENCRYPTION_KEY_FILE_NS
+	string "Path to key used to encrypt non-secure firmware images"
+	depends on !TFM_MCUBOOT_ENCRYPTION_NONE
+	default "$(ZEPHYR_MCUBOOT_MODULE_DIR)/enc-rsa2048-pub.pem" if TFM_MCUBOOT_ENCRYPTION_RSA_OAEP
+	default ""
+	help
+	  The path and filename for the key file that should be used by the BL2
+	  bootloader when encrypting non-secure firmware images. For RSA-OAEP this
+	  is the RSA public key that wraps the AES content-encryption key.
+
 config TFM_MCUBOOT_IMAGE_NUMBER
 	int "Granularity of FW updates of TFM and app"
 	range 1 2

--- a/samples/tfm_integration/tfm_fwu/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_fwu/CMakeLists.txt
@@ -9,10 +9,16 @@ project(tfm_fwu)
 
 set(SWAPPED_APP_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/../swapped_app/zephyr")
 
+if(CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE)
+  set(SWAPPED_APP_IMAGE "${SWAPPED_APP_BUILD_DIR}/zephyr_ns_signed.bin")
+else()
+  set(SWAPPED_APP_IMAGE "${SWAPPED_APP_BUILD_DIR}/zephyr_ns_signed_encrypted.bin")
+endif()
+
 generate_inc_file_for_target(
     app
-    ${SWAPPED_APP_BUILD_DIR}/zephyr_ns_signed.bin
-    ${ZEPHYR_BINARY_DIR}/include/generated/zephyr_ns_signed.inc
+    ${SWAPPED_APP_IMAGE}
+    ${ZEPHYR_BINARY_DIR}/include/generated/swapped_app_image.inc
 )
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/tfm_integration/tfm_fwu/Kconfig.sysbuild
+++ b/samples/tfm_integration/tfm_fwu/Kconfig.sysbuild
@@ -9,3 +9,40 @@ config SAMPLE_TFM_FWU_COMPONENT_ID
 	help
 	  The PSA Firmware Update component ID that the application
 	  operates on.
+
+config SAMPLE_TFM_MCUBOOT_SIGNATURE_TYPE
+	string "The signature type used to sign the secure and non-secure firmware images."
+	default "EC-P256"
+	help
+	  The signature type used for TF-M MCUboot.
+
+choice SAMPLE_TFM_MCUBOOT_ENCRYPTION
+	prompt "Image encryption key-wrapping scheme in BL2"
+	default SAMPLE_TFM_MCUBOOT_ENCRYPTION_NONE
+	help
+	  Selects whether MCUboot (BL2) expects encrypted images and, if so,
+	  which algorithm wraps the per-image AES content-encryption key.
+
+config SAMPLE_TFM_MCUBOOT_ENCRYPTION_NONE
+	bool "Disabled"
+
+config SAMPLE_TFM_MCUBOOT_ENCRYPTION_RSA_OAEP
+	bool "RSA-OAEP"
+
+endchoice
+
+choice SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN
+	prompt "Image encryption AES key length"
+	depends on !SAMPLE_TFM_MCUBOOT_ENCRYPTION_NONE
+	default SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128
+	help
+	  Length of the AES content-encryption key used to encrypt the image
+	  payload.
+
+config SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128
+	bool "128-bit"
+
+config SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_256
+	bool "256-bit"
+
+endchoice

--- a/samples/tfm_integration/tfm_fwu/check_string_presence.cmake
+++ b/samples/tfm_integration/tfm_fwu/check_string_presence.cmake
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify that SEARCH_STRING is present or absent (per EXPECT) in BIN_FILE. Used
+# to confirm whether the embedded swapped application is stored encrypted.
+
+if(NOT DEFINED BIN_FILE OR NOT DEFINED SEARCH_STRING OR NOT DEFINED EXPECT)
+  message(FATAL_ERROR "BIN_FILE, SEARCH_STRING and EXPECT must be defined")
+endif()
+
+file(STRINGS "${BIN_FILE}" matches REGEX "${SEARCH_STRING}")
+
+if(EXPECT STREQUAL "absent" AND matches)
+  message(FATAL_ERROR
+    "Found plaintext string '${SEARCH_STRING}' in ${BIN_FILE}; the embedded "
+    "swapped application does not appear to be encrypted")
+elseif(EXPECT STREQUAL "present" AND NOT matches)
+  message(FATAL_ERROR
+    "Did not find string '${SEARCH_STRING}' in ${BIN_FILE}; the embedded "
+    "unencrypted swapped application is missing")
+endif()

--- a/samples/tfm_integration/tfm_fwu/src/main.c
+++ b/samples/tfm_integration/tfm_fwu/src/main.c
@@ -9,7 +9,7 @@
 #include <psa/update.h>
 
 static const uint8_t swapped_ns_firmware[] = {
-#include "zephyr_ns_signed.inc"
+#include "swapped_app_image.inc"
 };
 
 int main(void)

--- a/samples/tfm_integration/tfm_fwu/sysbuild.cmake
+++ b/samples/tfm_integration/tfm_fwu/sysbuild.cmake
@@ -15,3 +15,36 @@ set_config_int(${DEFAULT_IMAGE} CONFIG_SAMPLE_TFM_FWU_COMPONENT_ID
   ${SB_CONFIG_SAMPLE_TFM_FWU_COMPONENT_ID})
 set_config_int(swapped_app CONFIG_SAMPLE_TFM_FWU_COMPONENT_ID
   ${SB_CONFIG_SAMPLE_TFM_FWU_COMPONENT_ID})
+
+# Forward the image encryption/signature configuration
+foreach(image ${DEFAULT_IMAGE} swapped_app)
+  set_config_string(${image} CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE
+    "${SB_CONFIG_SAMPLE_TFM_MCUBOOT_SIGNATURE_TYPE}")
+  set_config_bool(${image} CONFIG_TFM_MCUBOOT_ENCRYPTION_NONE
+    "${SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_NONE}")
+  set_config_bool(${image} CONFIG_TFM_MCUBOOT_ENCRYPTION_RSA_OAEP
+    "${SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_RSA_OAEP}")
+  set_config_bool(${image} CONFIG_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128
+    "${SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128}")
+  set_config_bool(${image} CONFIG_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_256
+    "${SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_256}")
+endforeach()
+
+# Validate how the embedded swapped application is stored: encrypted images must
+# not contain its plaintext strings, unencrypted images must contain them.
+if(SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_NONE)
+  set(swapped_app_expect present)
+else()
+  set(swapped_app_expect absent)
+endif()
+
+ExternalProject_Get_Property(${DEFAULT_IMAGE} BINARY_DIR)
+add_custom_target(check_swapped_app_encryption ALL
+  COMMAND ${CMAKE_COMMAND}
+    -DBIN_FILE=${BINARY_DIR}/zephyr/zephyr.elf
+    "-DSEARCH_STRING=Swapped application booted"
+    -DEXPECT=${swapped_app_expect}
+    -P ${CMAKE_CURRENT_LIST_DIR}/check_string_presence.cmake
+  VERBATIM
+)
+add_dependencies(check_swapped_app_encryption ${DEFAULT_IMAGE})

--- a/samples/tfm_integration/tfm_fwu/tests.yaml
+++ b/samples/tfm_integration/tfm_fwu/tests.yaml
@@ -19,4 +19,16 @@ common:
       - "Swapped application booted on .*"
       - "FWU completed successfully"
 tests:
-  sample.tfm.fwu: {}
+  sample.tfm.fwu:
+    extra_args:
+      - SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_NONE=y
+  sample.tfm.fwu.enc.rsa2048.aes128:
+    extra_args:
+      - SB_CONFIG_SAMPLE_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-2048"
+      - SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_RSA_OAEP=y
+      - SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_128=y
+  sample.tfm.fwu.enc.rsa2048.aes256:
+    extra_args:
+      - SB_CONFIG_SAMPLE_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-2048"
+      - SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_RSA_OAEP=y
+      - SB_CONFIG_SAMPLE_TFM_MCUBOOT_ENCRYPTION_KEY_LEN_256=y

--- a/west.yml
+++ b/west.yml
@@ -403,7 +403,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: ef35073337e66e3117a6ef33fc60f69596d2afbc
+      revision: d5fd891769580b32bb374b8c554dc3c35c2dacd0
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Add Kconfig options and build logic to support encrypting the TF-M secure and non-secure firmware images for BL2. Additional encrypted hex/bin files are generated alongside the existing signed images.

While BL2 supports RSA-OAEP and AES-KW, support for AES-KW is not included as this requires additional patches that are not part of the mcuboot version zephyr uses.

The firmware update sample is extended to also cover image encryption. It has been tested on `stm32h573i_dk/stm32h573xx/ns` and `mps2/an521/cpu0/ns`.