### PR TITLE
drivers: dai: allow bespoke config blobs larger than the stack buffer

### DIFF
--- a/drivers/dai/Kconfig
+++ b/drivers/dai/Kconfig
@@ -27,13 +27,15 @@ config DAI_USERSPACE
 
 config DAI_MAX_BESPOKE_CFG_SIZE
 	int "Maximum bespoke configuration blob size"
-	default 1024
+	default 8192
 	depends on DAI_USERSPACE
-	range 256 4096
+	range 256 65536
 	help
 	  Maximum size of bespoke configuration objects passed to the DAI
-	  driver via syscalls. The objects are temporarily allocated on the
-	  stack for validation when copied from user-space to kernel memory.
+	  driver via syscalls. The objects are copied from user-space to
+	  kernel memory for validation. Small objects are validated on the
+	  stack; larger objects are copied into a temporary heap allocation,
+	  so this limit is not bounded by the available stack size.
 
 module = DAI
 module-str = dai

--- a/drivers/dai/dai_handlers.c
+++ b/drivers/dai/dai_handlers.c
@@ -6,8 +6,17 @@
 
 #include <zephyr/drivers/dai.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/kernel.h>
 
+/* Overall upper bound for bespoke config blobs copied from user-space. */
 #define DAI_MAX_BESPOKE_CFG_SIZE CONFIG_DAI_MAX_BESPOKE_CFG_SIZE
+
+/*
+ * Bespoke config objects up to this size are validated on the stack;
+ * larger objects (up to DAI_MAX_BESPOKE_CFG_SIZE) are copied into a
+ * temporary heap allocation instead.
+ */
+#define DAI_BESPOKE_CFG_STACK_SIZE 1024
 
 static inline int z_vrfy_dai_probe(const struct device *dev)
 {
@@ -30,8 +39,10 @@ static inline int z_vrfy_dai_config_set(const struct device *dev,
 					const void *bespoke_cfg,
 					size_t size)
 {
-	uint8_t bespoke_cfg_kernel[DAI_MAX_BESPOKE_CFG_SIZE];
+	uint8_t bespoke_cfg_stack[DAI_BESPOKE_CFG_STACK_SIZE];
+	uint8_t *bespoke_cfg_kernel = NULL;
 	struct dai_config cfg_kernel;
+	int ret;
 
 	if (size > DAI_MAX_BESPOKE_CFG_SIZE) {
 		return -EINVAL;
@@ -41,11 +52,32 @@ static inline int z_vrfy_dai_config_set(const struct device *dev,
 	K_OOPS(k_usermode_from_copy(&cfg_kernel, cfg, sizeof(cfg_kernel)));
 
 	if (bespoke_cfg) {
-		K_OOPS(k_usermode_from_copy(bespoke_cfg_kernel, bespoke_cfg, size));
+		/* Small blobs use the stack, larger ones the kernel heap. */
+		if (size > DAI_BESPOKE_CFG_STACK_SIZE) {
+			bespoke_cfg_kernel = k_malloc(size);
+			if (!bespoke_cfg_kernel) {
+				return -ENOMEM;
+			}
+		} else {
+			bespoke_cfg_kernel = bespoke_cfg_stack;
+		}
+
+		ret = k_usermode_from_copy(bespoke_cfg_kernel, bespoke_cfg, size);
+		if (ret) {
+			if (bespoke_cfg_kernel != bespoke_cfg_stack) {
+				k_free(bespoke_cfg_kernel);
+			}
+			K_OOPS(ret);
+		}
 	}
 
-	return z_impl_dai_config_set(dev, &cfg_kernel,
-				     bespoke_cfg ? bespoke_cfg_kernel : NULL, size);
+	ret = z_impl_dai_config_set(dev, &cfg_kernel, bespoke_cfg_kernel, size);
+
+	if (bespoke_cfg_kernel && bespoke_cfg_kernel != bespoke_cfg_stack) {
+		k_free(bespoke_cfg_kernel);
+	}
+
+	return ret;
 }
 #include <zephyr/syscalls/dai_config_set_mrsh.c>
 
@@ -132,15 +164,40 @@ static inline int z_vrfy_dai_config_update(const struct device *dev,
 					   const void *bespoke_cfg,
 					   size_t size)
 {
-	uint8_t bespoke_cfg_kernel[DAI_MAX_BESPOKE_CFG_SIZE];
+	uint8_t bespoke_cfg_stack[DAI_BESPOKE_CFG_STACK_SIZE];
+	uint8_t *bespoke_cfg_kernel;
+	int ret;
 
 	if (!bespoke_cfg || size > DAI_MAX_BESPOKE_CFG_SIZE) {
 		return -EINVAL;
 	}
 
 	K_OOPS(K_SYSCALL_DRIVER_DAI(dev, config_update));
-	K_OOPS(k_usermode_from_copy(bespoke_cfg_kernel, bespoke_cfg, size));
 
-	return z_impl_dai_config_update(dev, bespoke_cfg_kernel, size);
+	/* Small blobs use the stack, larger ones the kernel heap. */
+	if (size > DAI_BESPOKE_CFG_STACK_SIZE) {
+		bespoke_cfg_kernel = k_malloc(size);
+		if (!bespoke_cfg_kernel) {
+			return -ENOMEM;
+		}
+	} else {
+		bespoke_cfg_kernel = bespoke_cfg_stack;
+	}
+
+	ret = k_usermode_from_copy(bespoke_cfg_kernel, bespoke_cfg, size);
+	if (ret) {
+		if (bespoke_cfg_kernel != bespoke_cfg_stack) {
+			k_free(bespoke_cfg_kernel);
+		}
+		K_OOPS(ret);
+	}
+
+	ret = z_impl_dai_config_update(dev, bespoke_cfg_kernel, size);
+
+	if (bespoke_cfg_kernel != bespoke_cfg_stack) {
+		k_free(bespoke_cfg_kernel);
+	}
+
+	return ret;
 }
 #include <zephyr/syscalls/dai_config_update_mrsh.c>


### PR DESCRIPTION
The dai_config_set()/dai_config_update() syscall verifiers copied the user-space bespoke configuration blob into a fixed stack buffer of CONFIG_DAI_MAX_BESPOKE_CFG_SIZE bytes and rejected anything larger with -EINVAL. This turns out to be too limiting and we need to support larger configuration objects.

Decouple the stack buffer size from the maximum allowed blob size and change implementation such that objects up to DAI_BESPOKE_CFG_STACK_SIZE are validated on the stack as before, but for larger objects, k_malloc'ed kernel buffer is used instead.