### PR TITLE
soc/cdns: discard executable stack information sections

### DIFF
--- a/soc/cdns/dc233c/include/xtensa-dc233c.ld
+++ b/soc/cdns/dc233c/include/xtensa-dc233c.ld
@@ -369,4 +369,6 @@ SECTIONS
   {
     KEEP (*(.debug.xt.callgraph .debug.xt.callgraph.* .gnu.linkonce.xt.callgraph.*))
   }
+
+  /DISCARD/ : { *(.note.GNU-stack) }
 }

--- a/soc/cdns/sample_controller32/include/xtensa-sample-controller32.ld
+++ b/soc/cdns/sample_controller32/include/xtensa-sample-controller32.ld
@@ -585,4 +585,6 @@ SECTIONS
   {
     KEEP (*(.debug.xt.callgraph .debug.xt.callgraph.* .gnu.linkonce.xt.callgraph.*))
   }
+
+  /DISCARD/ : { *(.note.GNU-stack) }
 }


### PR DESCRIPTION
This commit adds missing DISCARDs for the `.note.GNU-stack` section, which carries information about whether the ELF requires an executable stack.

Since Zephyr largely operates without an ELF loader, this section can be safely discarded, and already is for the vast majority of platforms:

```
% grep -R ".note.GNU-stack" * | wc -l
51
```