### PR TITLE
  drivers: nsos: fix use-after-free on close of a polled socket

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -279,21 +279,37 @@ static int nsos_close(void *obj)
 	k_spinlock_key_t key;
 	int ret;
 
-	ret = nsi_host_close(sock->poll.mid.fd);
-	if (ret < 0) {
-		errno = nsos_adapt_get_zephyr_errno();
-	}
-
 	key = k_spin_lock(&nsos_polls_lock);
 
 	SYS_DLIST_FOR_EACH_CONTAINER(&nsos_polls, poll, node) {
 		if (poll == &sock->poll) {
+			/* Wake up a thread blocked polling this socket. */
 			poll->mid.revents = ZSOCK_POLLHUP;
 			poll->mid.cb(&poll->mid);
+
+			/* The poll node is embedded in the socket object that is
+			 * about to be freed. Unlink it from the global poll list
+			 * and drop the adapter registration while holding the
+			 * lock, so neither the list, the adapter, nor a
+			 * concurrent poll's sys_dlist_append() is left pointing
+			 * into freed memory. This must happen before the host fd
+			 * is closed, as closing it implicitly removes it from the
+			 * adapter's poll set.
+			 */
+			poll->mid.cb = NULL;
+			poll->cond = NULL;
+			nsos_adapt_poll_remove(&poll->mid);
+			sys_dlist_remove(&poll->node);
+			break;
 		}
 	}
 
 	k_spin_unlock(&nsos_polls_lock, key);
+
+	ret = nsi_host_close(sock->poll.mid.fd);
+	if (ret < 0) {
+		errno = nsos_adapt_get_zephyr_errno();
+	}
 
 	nsi_host_free(sock);
 

--- a/tests/net/socket/nsos/CMakeLists.txt
+++ b/tests/net/socket/nsos/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test_nsos)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/net/socket/nsos/prj.conf
+++ b/tests/net/socket/nsos/prj.conf
@@ -1,0 +1,23 @@
+CONFIG_ZTEST=y
+
+CONFIG_NETWORKING=y
+CONFIG_NET_TEST=y
+CONFIG_NET_IPV4=y
+CONFIG_NET_DRIVERS=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_SOCKETS_OFFLOAD=y
+CONFIG_NET_NATIVE_OFFLOADED_SOCKETS=y
+
+CONFIG_ETH_NATIVE_TAP=n
+
+CONFIG_HEAP_MEM_POOL_SIZE=4096
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_ZTEST_STACK_SIZE=4096
+
+# The race is a use-after-free of the offloaded socket object. Build with
+# AddressSanitizer so the invalid access aborts the run (test fails) as long
+# as the bug is present, and passes once nsos_close() no longer leaves a
+# dangling poll node behind. ASAN_RECOVER=n makes the first error fatal
+# instead of relying on ASAN_OPTIONS=halt_on_error at runtime.
+CONFIG_ASAN=y
+CONFIG_ASAN_RECOVER=n

--- a/tests/net/socket/nsos/prj.conf
+++ b/tests/net/socket/nsos/prj.conf
@@ -14,10 +14,5 @@ CONFIG_HEAP_MEM_POOL_SIZE=4096
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_ZTEST_STACK_SIZE=4096
 
-# The race is a use-after-free of the offloaded socket object. Build with
-# AddressSanitizer so the invalid access aborts the run (test fails) as long
-# as the bug is present, and passes once nsos_close() no longer leaves a
-# dangling poll node behind. ASAN_RECOVER=n makes the first error fatal
-# instead of relying on ASAN_OPTIONS=halt_on_error at runtime.
 CONFIG_ASAN=y
 CONFIG_ASAN_RECOVER=n

--- a/tests/net/socket/nsos/src/main.c
+++ b/tests/net/socket/nsos/src/main.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Draeger Safety AG & Co. KGaA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/socket.h>
+
+#define POLLER_STACK_SIZE 4096
+
+static K_THREAD_STACK_DEFINE(poller_stack, POLLER_STACK_SIZE);
+static struct k_thread poller_thread;
+
+/* Signalled by the poller right before it enters the blocking poll. */
+static K_SEM_DEFINE(poller_ready, 0, 1);
+
+static int poller_fd;
+static volatile int poller_poll_ret;
+
+static void poller_entry(void *p1, void *p2, void *p3)
+{
+	struct zsock_pollfd fds = {
+		.fd = poller_fd,
+		.events = ZSOCK_POLLIN,
+	};
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	/* Tell the test thread we are about to block in poll(). */
+	k_sem_give(&poller_ready);
+
+	/* Blocks forever (no data ever arrives) until the socket is closed
+	 * from the test thread, which delivers POLLHUP and wakes us.
+	 */
+	poller_poll_ret = zsock_poll(&fds, 1, SYS_FOREVER_MS);
+}
+
+/* ensure that closing a socket while it is being polled
+ * in another thread does not cause UB by using memory freed
+ * by zsock_close
+ */
+ZTEST(nsos, test_close_while_polling)
+{
+	int sock_a;
+	int sock_b;
+	int ret;
+	int prio = k_thread_priority_get(k_current_get());
+
+	sock_a = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(sock_a >= 0, "socket(sock_a) failed: %d", errno);
+
+	poller_fd = sock_a;
+
+	/* Poller runs at a strictly lower priority than this thread so it can
+	 * only execute while this thread is blocked. This guarantees the
+	 * ordering the reproducer relies on.
+	 */
+	k_thread_create(&poller_thread, poller_stack, POLLER_STACK_SIZE, poller_entry, NULL, NULL,
+			NULL, prio + 1, 0, K_NO_WAIT);
+
+	/* Wait until the poller is about to poll, then sleep so it actually
+	 * reaches and parks inside k_poll() with sock_a's node linked into
+	 * the global nsos_polls list.
+	 */
+	ret = k_sem_take(&poller_ready, K_SECONDS(1));
+	zassert_ok(ret, "poller did not start");
+	k_msleep(100);
+
+	/* Close sock_a while the poller is blocked on it. With the bug, this
+	 * frees the socket object but leaves its poll node linked in
+	 * nsos_polls, dangling into freed memory. The poller is woken (made
+	 * ready) but, being lower priority, does not run yet.
+	 */
+	ret = zsock_close(sock_a);
+	zassert_ok(ret, "close(sock_a) failed: %d", errno);
+
+	/* Still on this thread, with no blocking call in between: create and
+	 * poll another nsos socket. Its poll PREPARE does
+	 * sys_dlist_append(&nsos_polls, ...), writing through the dangling
+	 * tail left by the close above -> heap-use-after-free under ASAN.
+	 */
+	sock_b = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(sock_b >= 0, "socket(sock_b) failed: %d", errno);
+
+	struct zsock_pollfd fds = {
+		.fd = sock_b,
+		.events = ZSOCK_POLLIN,
+	};
+
+	/* K_NO_WAIT poll: exercises PREPARE (the faulting append) and UPDATE
+	 * without blocking, so the poller still cannot preempt us.
+	 */
+	ret = zsock_poll(&fds, 1, 0);
+	zassert_true(ret >= 0, "poll(sock_b) failed: %d", errno);
+
+	/* If we got here the bug is fixed. Let the woken poller run to
+	 * completion and clean up.
+	 */
+	ret = k_thread_join(&poller_thread, K_SECONDS(5));
+	zassert_ok(ret, "poller did not return after sock_a was closed");
+
+	zassert_ok(zsock_close(sock_b), "close(sock_b) failed: %d", errno);
+}
+
+ZTEST_SUITE(nsos, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/socket/nsos/src/main.c
+++ b/tests/net/socket/nsos/src/main.c
@@ -70,11 +70,7 @@ ZTEST(nsos, test_close_while_polling)
 	zassert_ok(ret, "poller did not start");
 	k_msleep(100);
 
-	/* Close sock_a while the poller is blocked on it. With the bug, this
-	 * frees the socket object but leaves its poll node linked in
-	 * nsos_polls, dangling into freed memory. The poller is woken (made
-	 * ready) but, being lower priority, does not run yet.
-	 */
+	/* Close sock_a while the poller is blocked on it. */
 	ret = zsock_close(sock_a);
 	zassert_ok(ret, "close(sock_a) failed: %d", errno);
 
@@ -97,9 +93,6 @@ ZTEST(nsos, test_close_while_polling)
 	ret = zsock_poll(&fds, 1, 0);
 	zassert_true(ret >= 0, "poll(sock_b) failed: %d", errno);
 
-	/* If we got here the bug is fixed. Let the woken poller run to
-	 * completion and clean up.
-	 */
 	ret = k_thread_join(&poller_thread, K_SECONDS(5));
 	zassert_ok(ret, "poller did not return after sock_a was closed");
 

--- a/tests/net/socket/nsos/tests.yaml
+++ b/tests/net/socket/nsos/tests.yaml
@@ -1,0 +1,13 @@
+common:
+  min_ram: 16
+  tags:
+    - net
+    - socket
+  # AddressSanitizer is only available on the POSIX architecture.
+  arch_allow:
+    - posix
+tests:
+  net.socket.nsos:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
  nsos_close() freed the socket object with nsi_host_free(sock) while its
  embedded poll node (&sock->poll.node) was still linked in the global
  nsos_polls list. When a socket is closed from one thread while another
  thread is blocked in zsock_poll()/epoll on it, the close leaves a node
  in nsos_polls that points into freed heap memory. The next poll of any
  nsos socket then calls sys_dlist_append(&nsos_polls, ...) and writes
  through the dangling tail (tail->next) into the freed object, and
  nsos_isr() would likewise walk into freed memory from IRQ context.

  Fix nsos_close() so that, when the socket being closed is still linked
  in nsos_polls, it wakes any blocked poller and then, under
  nsos_polls_lock, unlinks the node (sys_dlist_remove), drops the adapter
  registration (nsos_adapt_poll_remove) and clears poll->mid.cb /
  poll->cond before the object is freed. Nothing in the list or the
  adapter is left referencing the memory that is about to be released.

  The adapter unlink must run before nsi_host_close(): closing the host fd
  implicitly removes it from the adapter's epoll set, so calling
  nsos_adapt_poll_remove() afterwards fails with EBADF ("EPOLL_CTL_DEL:
  errno=9"). The close of the host fd is therefore moved after the
  list/adapter cleanup.

  Add tests/net/socket/nsos_close_race, a ztest reproducer built with
  CONFIG_ASAN=y (ASAN_RECOVER=n so the first error is fatal). A
  low-priority poller thread parks in zsock_poll(sock_a, FOREVER), the
  higher-priority test thread closes sock_a and then, without ever
  blocking, creates and polls sock_b so its poll's sys_dlist_append()
  faults on the dangling tail. The test fails (ASAN heap-use-after-free)
  without this fix and passes with it.
  
  
  >!  Please let me know where I should add this ASAN test, I have not found a suitable place for it yet! !<
  

  Known issues NOT addressed by this change:

  - Object lifetime across an in-flight wait. The generic zvfs poll path holds no reference on the driver object across the k_poll() wait and re-fetches it at POLL_UPDATE, while zvfs_close() frees the object via close2() before clearing the fd-table slot. A poller that re-fetches the object in the narrow window after close2() frees it but before zvfs_free_fd() clears the slot still dereferences freed memory in nsos_poll_update(). Closing this needs object-lifetime management (e.g. a refcount on struct nsos_socket taken in nsos_poll_prepare and released in nsos_poll_update, with nsos_close() deferring the free to the last releaser). The reproducer does not hit this window because the closing thread clears the fd slot before the lower-priority poller runs.

  - The same lifetime gap affects the blocking recv/send/connect path (nsos_wait_for_poll): a concurrent close frees the socket while the operation is parked, and the caller (nsos_recvfrom/nsos_sendto) dereferences the freed sock on return. Because that path polls a dup'd fd and nsos_close() only matches &sock->poll, the close does not even wake the waiter, so a K_FOREVER blocking recv can also hang and leak the dup fd.

Assisted-by: Claude:claude-opus-4.8