### PR TITLE
drivers: udc_mcux_ehci: cancel primed transfer on dequeue

### DIFF
--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -543,7 +543,17 @@ static int udc_mcux_ep_enqueue(const struct device *dev,
 static int udc_mcux_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
+	const struct udc_mcux_config *config = dev->config;
+	const usb_device_controller_interface_struct_t *mcux_if = config->mcux_if;
+	struct udc_mcux_data *priv = udc_get_private(dev);
+
 	cfg->stat.halted = false;
+
+	/* Cancel the primed transfer, it would otherwise still reach the host
+	 * although the buffer is reported to the class as aborted.
+	 */
+	(void)mcux_if->deviceCancel(priv->mcux_device.controllerHandle, cfg->addr);
+
 	udc_ep_cancel_queued(dev, cfg);
 
 	udc_mcux_lock(dev);

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -666,6 +666,10 @@ bool udc_ep_queue_is_empty(const struct device *dev, const uint8_t ep);
  * all requests in the queue will passed as chained list of
  * the event variable buf. The endpoint queue is empty after that.
  *
+ * A transfer that the controller is already processing is cancelled as
+ * well, the data of a request released with -ECONNABORTED is not
+ * transferred.
+ *
  * @param[in] dev    Pointer to device struct of the driver instance
  * @param[in] ep     Endpoint address
  *


### PR DESCRIPTION
`udc_mcux_ep_dequeue()` only releases the buffers still waiting in the software queue, via `udc_ep_cancel_queued()`. It never tells the controller to drop the transfer it was already primed with, so that transfer still reaches the host even though the buffer comes back to the class as `-ECONNABORTED`.

Cancel it first, using the `deviceCancel` entry of the MCUX controller interface the driver already holds. Second commit documents the expectation on `udc_ep_dequeue()`.

### Why the status matters

USB 2.0, 5.8.3:

> A bulk transfer is complete when the endpoint has transferred exactly the amount of data expected, or transfers a packet with a payload size less than wMaxPacketSize, or transfers a zero-length packet.

A class aborting a Bulk-IN transfer has to make sure a short packet ends it, but only if one hasn't already gone out, and the completion status is all it has to tell those apart.

USBTMC 1.0, 4.2.1.4:

> A Host may use the INITIATE_ABORT_BULK_IN request to abort a Bulk-IN transfer and restore Bulk-IN synchronization.

The host reads until it gets a short packet, then stops. If the aborted response went out anyway, that response is the short packet, and the one the class queues afterwards is never read. It turns up at the head of the next Bulk-IN transfer, and from then on every query returns the previous response. No error, and nothing resynchronizes on its own.

### Why it surfaced now

Nothing else dequeues a live endpoint. `ec_host_cmd_backend_usb.c` dequeues right after moving the backend to `DISABLED`, and `usbd_ep_disable()` dequeues after `udc_ep_disable()` has already stopped the endpoint. A stray packet is invisible in both. The USBTMC class in #116986 is the first caller where it isn't.

### Testing

frdm_rw612 at high speed, with the host receiving all 86 bytes of the response:

```
<dbg> usbd_usbtmc: Transfer ep 0x81, len 86, err -113
<dbg> usbd_usbtmc: Transfer ep 0x81, len 0, err 0     <- spurious
```

After the fix the response is cancelled and only the terminating short packet arrives. A 16-case USBTMC suite over libusb goes from 15/16 to 16/16.

wio_terminal (full speed, `udc_sam0`) passes all 16 with an unmodified class, and the aborted response never reaches the host there. That is what points at the driver rather than the class.

### Other drivers

Every other UDC driver cancels in hardware before releasing the queued buffers: `udc_stm32` flushes the endpoint, `udc_nrf` aborts it, `udc_kinetis` clears the buffer descriptor, `udc_sam0` clears `BK1RDY`, `udc_it82xx2` forces the FIFO empty, `udc_ambiq` resets the endpoint state, `udc_bflb_v1` NAKs and clears the FIFOs, `udc_sam_usbhs` disables the bank.

`udc_mcux_ip3511.c` has an identical `udc_mcux_ep_dequeue()`, and `udc_max32.c` also only calls `udc_ep_cancel_queued()`. Both probably need the same treatment, but I have no hardware for either so I left them alone.

The second commit writes this expectation into the `udc_ep_dequeue()` documentation, which so far only said the endpoint queue is emptied.
