### PR TITLE
docs: migration-guide: remove part about nxp,enet-qos-ptp-clock

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -456,10 +456,8 @@ Ethernet
   flattened to match other similar controllers. The clocks, interrupts, ``pinctrl-0``,
   ``pinctrl-names``, ``phy-handle`` and MAC address properties now live directly on the parent
   ``nxp,enet-qos`` node instead of a separate child MAC node. The ``nxp,enet-qos-mac`` compatible
-  and its ``enet_mac`` node have been removed and the :dtcompatible:`nxp,enet-qos-mdio` and
-  :dtcompatible:`nxp,enet-qos-ptp-clock` nodes are now direct children of the controller node. The
-  PTP reference clock has moved onto the parent node's ``clocks`` property using the ``ptp``
-  ``clock-names`` entry. Out-of-tree boards using this controller must move the properties from the
+  and its ``enet_mac`` node have been removed.
+  Out-of-tree boards using this controller must move the properties from the
   old ``enet_mac`` node up to the ``enet`` node. (:github:`115952`)
 
 * The Kconfig option ``CONFIG_ETH_NXP_ENET_QOS_MAC_UNIQUE_MAC_ADDRESS`` has been renamed to


### PR DESCRIPTION
nxp,enet-qos-ptp-clock was only added after the
last release, so we don't need to mention it.

The mdio node was not moved, so no need
to mention it.