### PR TITLE
sys: assert: remove external use of internal assert helpers

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -425,14 +425,10 @@ static inline void tlb_shootdown(void)
 }
 #endif /* CONFIG_SMP */
 
-static inline void assert_addr_aligned(uintptr_t addr)
+static inline void assert_addr_aligned(uintptr_t addr __maybe_unused)
 {
-#if __ASSERT_ON
 	__ASSERT((addr & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
 		 "unaligned address 0x%" PRIxPTR, addr);
-#else
-	ARG_UNUSED(addr);
-#endif
 }
 
 static inline bool is_addr_aligned(uintptr_t addr)
@@ -454,14 +450,10 @@ static inline bool is_virt_addr_aligned(void *addr)
 	return is_addr_aligned((uintptr_t)addr);
 }
 
-static inline void assert_size_aligned(size_t size)
+static inline void assert_size_aligned(size_t size __maybe_unused)
 {
-#if __ASSERT_ON
 	__ASSERT((size & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
 		 "unaligned size %zu", size);
-#else
-	ARG_UNUSED(size);
-#endif
 }
 
 static inline bool is_size_aligned(size_t size)
@@ -1738,18 +1730,17 @@ int arch_mem_domain_init(struct k_mem_domain *domain)
 	k_spinlock_key_t key  = k_spin_lock(&x86_mmu_lock);
 
 	LOG_DBG("%s(%p)", __func__, domain);
-#if __ASSERT_ON
+
 	sys_snode_t *node;
 
 	/* Assert that we have not already initialized this domain */
 	SYS_SLIST_FOR_EACH_NODE(&x86_domain_list, node) {
-		struct arch_mem_domain *list_domain =
+		struct arch_mem_domain *list_domain __maybe_unused =
 			CONTAINER_OF(node, struct arch_mem_domain, node);
 
 		__ASSERT(list_domain != &domain->arch,
 			 "%s(%p) called multiple times", __func__, domain);
 	}
-#endif /* __ASSERT_ON */
 #ifndef CONFIG_X86_KPTI
 	/* If we're not using KPTI then we can use the build time page tables
 	 * (which are mutable) as the set of page tables for the default

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1633,6 +1633,11 @@ Other subsystems
   :c:func:`cpu_load_get_cpu`. Note that :c:func:`cpu_load_get_cpu` returns the load in per mille
   (0...1000) rather than percent; use :c:macro:`CPU_LOAD_PERMILLE_TO_PERCENT` to convert.
 
+* The internal ``__ASSERT_ON`` define has been removed. Out-of-tree code should invoke
+  ``__ASSERT()`` or ``__ASSERT_NO_MSG()`` directly, as these macros already compile out when
+  assertions are disabled.
+  Mark values used only by assertions with ``__maybe_unused`` or ``ARG_UNUSED()`` as appropriate.
+
 Logging
 =======
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -609,6 +609,11 @@ Libraries / Subsystems
     a dedicated pool on every channel (channels fall back to the shared pool until
     :c:func:`zbus_chan_set_msg_sub_pool` is called)
 
+* __assert
+
+   * ``__ASSERT_ON`` define has been removed.
+
+
 Devicetree
 **********
 * Nodes can now use phandles to refer to their children without causing a cycle in the

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -1195,7 +1195,7 @@ static int sdl_display_clear(const struct device *dev)
 		size = config->height * DIV_ROUND_UP(config->width, 2U);
 		break;
 	default:
-		__ASSERT_MSG_INFO("Pixel format not supported");
+		LOG_ERR("Pixel format not supported");
 		return -EINVAL;
 	}
 	LOG_DBG("size: %zu, bgcolor: %hhu", size, bgcolor);

--- a/drivers/rtc/rtc_smartbond.c
+++ b/drivers/rtc/rtc_smartbond.c
@@ -605,12 +605,12 @@ static void rtc_smartbond_100HZ_clock_cfg(void)
 	uint32_t clk_rtcdiv_reg;
 
 	if (!device_is_ready(dev)) {
-		__ASSERT_MSG_INFO("Clock device is not ready");
+		LOG_ERR("Clock device is not ready");
 	}
 
 	if (clock_control_get_rate(dev, (clock_control_subsys_t)SMARTBOND_CLK_LP_CLK,
 								&lp_clk_rate) < 0) {
-		__ASSERT_MSG_INFO("Cannot extract LP clock rate");
+		LOG_ERR("Cannot extract LP clock rate");
 	}
 
 	clk_rtcdiv_reg = CRG_TOP->CLK_RTCDIV_REG;

--- a/drivers/spi/spi_smartbond.c
+++ b/drivers/spi/spi_smartbond.c
@@ -583,7 +583,7 @@ static void spi_smartbond_isr_trigger(const struct device *dev)
 	case SPI_SMARTBOND_TRANSFER_NONE:
 		__fallthrough;
 	default:
-		__ASSERT_MSG_INFO("Invalid transfer mode");
+		LOG_ERR("Invalid transfer mode");
 		break;
 	}
 
@@ -664,7 +664,7 @@ static void spi_smartbond_isr(void *args)
 	case SPI_SMARTBOND_TRANSFER_NONE:
 		__fallthrough;
 	default:
-		__ASSERT_MSG_INFO("Invalid transfer mode");
+		LOG_ERR("Invalid transfer mode");
 		break;
 	}
 
@@ -1034,7 +1034,7 @@ static int spi_smartbond_dma_trigger(const struct device *dev)
 		case SPI_SMARTBOND_TRANSFER_NONE:
 			__fallthrough;
 		default:
-			__ASSERT_MSG_INFO("Invalid transfer mode");
+			LOG_ERR("Invalid transfer mode");
 			break;
 		}
 

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -514,27 +514,21 @@ ISR_DIRECT_DECLARE(nrfx_grtc_direct_irq_handler)
 
 void sys_clock_disable(void)
 {
+	int err __maybe_unused;
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
-	int err;
 	struct onoff_manager *mgr =
 		z_nrf_clock_control_get_onoff((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_LFCLK);
 
 	err = onoff_release(mgr);
-
 	__ASSERT_NO_MSG(err >= 0);
-#if !IS_ENABLED(__ASSERT_ON)
-	(void)err;
-#endif
+
 	nrfx_grtc_uninit();
 	nrfx_coredep_delay_us(1000);
 #elif defined(CONFIG_CLOCK_CONTROL_NRF_COMMON) &&                                                  \
 	!(defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF92))
-	int err = nrf_clock_control_release(DEVICE_DT_GET_ONE(nordic_nrf_clock_lfclk), NULL);
-
+	err = nrf_clock_control_release(DEVICE_DT_GET_ONE(nordic_nrf_clock_lfclk), NULL);
 	__ASSERT_NO_MSG(err >= 0);
-#if !IS_ENABLED(__ASSERT_ON)
-	(void)err;
-#endif
+
 	nrfx_grtc_uninit();
 	nrfx_coredep_delay_us(1000);
 #else

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -1422,7 +1422,7 @@ static inline int adc_raw_to_millivolts(int32_t ref_mv, enum adc_gain gain, uint
 	if (ret == 0) {
 		adc_mv = adc_mv >> resolution;
 		if (adc_mv > INT32_MAX || adc_mv < INT32_MIN) {
-			__ASSERT_MSG_INFO("conversion result is out of range");
+			__ASSERT(false, "conversion result is out of range");
 		}
 
 		*valp = (int32_t)adc_mv;

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -582,7 +582,7 @@ static inline int dac_millivolts_to_raw(uint32_t ref_mv, uint8_t resolution, uin
 	uint64_t dac_mv = (((uint64_t)*valp) << resolution) / (uint64_t)ref_mv;
 
 	if (dac_mv > (1UL << resolution)) {
-		__ASSERT_MSG_INFO("conversion result is out of range");
+		__ASSERT(false, "conversion result is out of range");
 		return -ERANGE;
 	}
 
@@ -601,7 +601,7 @@ static inline int dac_microvolts_to_raw(uint32_t ref_mv, uint8_t resolution, uin
 	uint64_t dac_uv = (((uint64_t)*valp) << resolution) / (uint64_t)ref_mv / (uint64_t)1000;
 
 	if (dac_uv > (1UL << resolution)) {
-		__ASSERT_MSG_INFO("conversion result is out of range");
+		__ASSERT(false, "conversion result is out of range");
 		return -ERANGE;
 	}
 

--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -10,23 +10,6 @@
 #include <stdbool.h>
 #include <zephyr/toolchain.h>
 
-#ifdef CONFIG_ASSERT
-#ifndef __ASSERT_ON
-#ifdef CONFIG_ASSERT_LEVEL
-#define __ASSERT_ON CONFIG_ASSERT_LEVEL
-#endif
-#endif
-#endif
-
-#ifdef CONFIG_FORCE_NO_ASSERT
-#undef __ASSERT_ON
-#define __ASSERT_ON 0
-#endif
-
-#ifndef __ASSERT_ON
-#define __ASSERT_ON 0
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -74,13 +57,15 @@ void __printf_like(1, 2) assert_print(const char *fmt, ...);
 	__ASSERT_PRINT("ASSERTION FAIL\n")
 #endif
 
-#ifdef __ASSERT_ON
-#if (__ASSERT_ON < 0) || (__ASSERT_ON > 2)
-#error "Invalid __ASSERT() level: must be between 0 and 2"
-#endif
+#if defined(CONFIG_ASSERT) && !defined(CONFIG_FORCE_NO_ASSERT) && \
+	defined(CONFIG_ASSERT_LEVEL) && (CONFIG_ASSERT_LEVEL > 0)
 
-#if __ASSERT_ON
+BUILD_ASSERT(CONFIG_ASSERT_LEVEL >= 0 && CONFIG_ASSERT_LEVEL <= 2,
+	     "Invalid CONFIG_ASSERT_LEVEL: must be between 0 and 2");
 
+#if CONFIG_ASSERT_LEVEL == 1
+#warning "__ASSERT() statements are ENABLED"
+#endif /* CONFIG_ASSERT_LEVEL == 1 */
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -133,20 +118,14 @@ void assert_post_action(const char *file, unsigned int line);
 		__ASSERT(test, fmt, ##__VA_ARGS__);                \
 	} while (false)
 
-#if (__ASSERT_ON == 1)
-#warning "__ASSERT() statements are ENABLED"
-#endif
+
 #else
+
 #define __ASSERT(test, fmt, ...) { }
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
 #define __ASSERT_POST_ACTION() { }
-#endif
-#else
-#define __ASSERT(test, fmt, ...) { }
-#define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
-#define __ASSERT_NO_MSG(test) { }
-#define __ASSERT_POST_ACTION() { }
+
 #endif
 
 #ifdef CONFIG_ASSERT_CUSTOM_HEADER

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -55,12 +55,12 @@ struct k_spinlock z_mm_lock;
 /* Database of all RAM page frames */
 struct k_mem_page_frame k_mem_page_frames[K_MEM_NUM_PAGE_FRAMES];
 
-#if __ASSERT_ON
+#ifdef CONFIG_ASSERT
 /* Indicator that k_mem_page_frames has been initialized, many of these APIs do
  * not work before POST_KERNEL
  */
 static bool page_frames_initialized;
-#endif
+#endif /* CONFIG_ASSERT */
 
 /* Add colors to page table dumps to indicate mapping type */
 #define COLOR_PAGE_FRAMES	1
@@ -1153,9 +1153,10 @@ void z_mem_manage_init(void)
 	z_paging_ondemand_section_map();
 #endif
 
-#if __ASSERT_ON
+#ifdef CONFIG_ASSERT
 	page_frames_initialized = true;
-#endif
+#endif /* CONFIG_ASSERT */
+
 	k_spin_unlock(&z_mm_lock, key);
 }
 

--- a/lib/libc/picolibc/assert.c
+++ b/lib/libc/picolibc/assert.c
@@ -11,11 +11,9 @@
 FUNC_NORETURN void __assert_func(const char *file, int line,
 				 const char *function, const char *expression)
 {
-#if __ASSERT_ON
 	__ASSERT(0, "assertion \"%s\" failed: file \"%s\", line %d%s%s\n",
 		 expression, file, line,
 		 function ? ", function: " : "", function ? function : "");
-#endif
 	abort();
 }
 
@@ -23,9 +21,7 @@ FUNC_NORETURN void __assert_func(const char *file, int line,
 
 FUNC_NORETURN void __assert_no_args(void)
 {
-#if __ASSERT_ON
 	__ASSERT_NO_MSG(0);
-#endif
 	abort();
 }
 

--- a/subsys/crc/crc_hardware.c
+++ b/subsys/crc/crc_hardware.c
@@ -64,7 +64,7 @@ uint8_t crc4(const uint8_t *src, size_t len, uint8_t polynomial, uint8_t initial
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -86,7 +86,7 @@ uint8_t crc4_ti(uint8_t seed, const uint8_t *src, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -108,7 +108,7 @@ uint8_t crc7_be(uint8_t seed, const uint8_t *src, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -135,7 +135,7 @@ uint8_t crc8(const uint8_t *src, size_t len, uint8_t polynomial, uint8_t initial
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 	return ctx.result;
@@ -156,7 +156,7 @@ uint8_t crc8_rohc(uint8_t initial_value, const void *buf, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, buf, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -178,7 +178,7 @@ uint8_t crc8_ccitt(uint8_t initial_value, const void *buf, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, buf, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -200,7 +200,7 @@ uint16_t crc16(uint16_t poly, uint16_t seed, const uint8_t *src, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -222,7 +222,7 @@ uint16_t crc16_reflect(uint16_t poly, uint16_t seed, const uint8_t *src, size_t 
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 	return ctx.result;
@@ -243,7 +243,7 @@ uint16_t crc16_ccitt(uint16_t seed, const uint8_t *src, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -265,7 +265,7 @@ uint16_t crc16_itu_t(uint16_t seed, const uint8_t *src, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -287,7 +287,7 @@ uint32_t crc24_pgp_update(uint32_t crc, const uint8_t *data, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, data, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -318,7 +318,7 @@ uint32_t crc32_c(uint32_t crc, const uint8_t *buf, size_t len, bool first_pkt, b
 
 	ret = crc_operation(crc_dev, &ctx, buf, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -342,7 +342,7 @@ uint32_t crc32_ieee_update(uint32_t crc, const uint8_t *buf, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, buf, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -369,7 +369,7 @@ uint32_t crc32_k_4_2_update(uint32_t crc, const uint8_t *const data, const size_
 
 	ret = crc_operation(crc_dev, &ctx, data, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 
@@ -391,7 +391,7 @@ uint32_t crc32_mpeg2_update(uint32_t crc, const uint8_t *data, size_t len)
 
 	ret = crc_operation(crc_dev, &ctx, data, len);
 	if (ret != 0) {
-		__ASSERT_MSG_INFO("CRC operation failed: %d", ret);
+		LOG_ERR("CRC operation failed: %d", ret);
 		return 0;
 	}
 

--- a/subsys/random/random_arm64.c
+++ b/subsys/random/random_arm64.c
@@ -18,7 +18,7 @@ void z_impl_sys_rand_get(void *dst, size_t outlen)
 
 		if (__builtin_aarch64_rndr(&value) != 0) {
 			if (++failure_counter > CONFIG_ARM64_RANDOM_GENERATOR_MAX_RETRIES) {
-				__ASSERT_PRINT("ARM64 RNDR keeps failing\n");
+				__ASSERT(false, "ARM64 RNDR keeps failing");
 				k_panic();
 			}
 			k_usleep(CONFIG_ARM64_RANDOM_GENERATOR_RETRY_WAIT_USEC);

--- a/tests/bsim/bluetooth/host/att/long_read/main.c
+++ b/tests/bsim/bluetooth/host/att/long_read/main.c
@@ -21,7 +21,7 @@
 #include "testlib/security.h"
 
 /* This test uses system asserts to fail tests. */
-BUILD_ASSERT(__ASSERT_ON);
+BUILD_ASSERT(IS_ENABLED(CONFIG_ASSERT));
 
 #define CENTRAL_DEVICE_NBR    0
 #define PERIPHERAL_DEVICE_NBR 1

--- a/tests/bsim/bluetooth/host/att/open_close/src/main.c
+++ b/tests/bsim/bluetooth/host/att/open_close/src/main.c
@@ -21,7 +21,7 @@
 #include "testlib/security.h"
 
 /* This test uses system asserts to fail tests. */
-BUILD_ASSERT(__ASSERT_ON);
+BUILD_ASSERT(IS_ENABLED(CONFIG_ASSERT));
 
 #define CENTRAL_DEVICE_NBR    0
 #define PERIPHERAL_DEVICE_NBR 1

--- a/tests/bsim/bluetooth/host/att/timeout/main.c
+++ b/tests/bsim/bluetooth/host/att/timeout/main.c
@@ -23,7 +23,7 @@
 #include "testlib/security.h"
 
 /* This test uses system asserts to fail tests. */
-BUILD_ASSERT(__ASSERT_ON);
+BUILD_ASSERT(IS_ENABLED(CONFIG_ASSERT));
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 


### PR DESCRIPTION
This PR works as a precondition for #112756 .

This PR aims to remove usages of various `__assert.h` APIs that overlapped with the LOG_* APIs responsibility.
Furthermore it removes usages of `__ASSERT_ON` define and instead uses the Kconfig value. 