### PR TITLE
net: coap_client: fix observation with blockwise notifications

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -196,6 +196,8 @@ struct coap_client_internal_request {
 	/* For GETs with observe option set */
 	bool is_observe;
 	int last_response_id;
+	uint8_t observe_token[COAP_TOKEN_MAX_LEN]; /* registration token snapshot */
+	uint8_t observe_tkl;
 #if defined(CONFIG_COAP_CLIENT_MULTICAST)
 	bool is_mcast;
 	k_timepoint_t mcast_timeout;

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -279,10 +279,13 @@ static int coap_client_init_request(struct coap_client *client, struct coap_clie
 
 	/* Add extra options if any */
 	for (i = 0; i < req->num_options; i++) {
-		if (COAP_OPTION_BLOCK2 == req->options[i].code && block2) {
-			/* After the first request, ignore any block2 option added by the
-			 * application, since NUM (and possibly SZX) must be updated based on the
-			 * server response.
+		if (block2 && (req->options[i].code == COAP_OPTION_BLOCK2 ||
+			       req->options[i].code == COAP_OPTION_OBSERVE)) {
+			/* On Block2 continuation retrievals, drop the application's block2
+			 * option, since NUM (and possibly SZX) must be updated based on the
+			 * server response, and the Observe option, since RFC 7959 Section 3.4
+			 * requires that block retrievals of a notification body do not carry
+			 * Observe (only the block-0 notification does).
 			 */
 			continue;
 		}
@@ -430,6 +433,17 @@ static int coap_client_init_request(struct coap_client *client, struct coap_clie
 		if (internal_req->send_blk_ctx.total_size > 0) {
 			coap_next_block(&internal_req->request, &internal_req->send_blk_ctx);
 		}
+	}
+
+	/* Snapshot the registration token of an observe request (the initial request or
+	 * an Echo retry, both of which mint a new token). Block retrievals overwrite
+	 * request_token with fresh tokens, so the registration token is kept separately
+	 * for matching server-pushed notifications and for deregister.
+	 */
+	if (coap_request_is_observe(&internal_req->request)) {
+		memcpy(internal_req->observe_token, internal_req->request_token,
+		       internal_req->request_tkl);
+		internal_req->observe_tkl = internal_req->request_tkl;
 	}
 out:
 	return ret;
@@ -999,18 +1013,30 @@ static struct coap_client_internal_request *get_request_with_token(
 	response_tkl = coap_header_get_token(resp, response_token);
 
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
-		if (client->requests[i].request_ongoing ||
-		    !exchange_lifetime_exceeded(&client->requests[i])) {
-			if (client->requests[i].request_tkl == 0) {
-				continue;
-			}
-			if (client->requests[i].request_tkl != response_tkl) {
-				continue;
-			}
-			if (memcmp(&client->requests[i].request_token, &response_token,
-			    response_tkl) == 0) {
-				return &client->requests[i];
-			}
+		struct coap_client_internal_request *internal_req = &client->requests[i];
+
+		if (!internal_req->request_ongoing &&
+		    exchange_lifetime_exceeded(internal_req)) {
+			continue;
+		}
+
+		/* Current request token. For an observation mid-blockwise-notification
+		 * this is the block-retrieval (continuation) token.
+		 */
+		if (internal_req->request_tkl != 0 &&
+		    internal_req->request_tkl == response_tkl &&
+		    memcmp(&internal_req->request_token, &response_token, response_tkl) == 0) {
+			return internal_req;
+		}
+
+		/* Registration token of an active observation, so asynchronous
+		 * notifications stay matchable for the whole observation, including while
+		 * a blockwise notification body is being retrieved.
+		 */
+		if (internal_req->is_observe && internal_req->observe_tkl != 0 &&
+		    internal_req->observe_tkl == response_tkl &&
+		    memcmp(&internal_req->observe_token, &response_token, response_tkl) == 0) {
+			return internal_req;
 		}
 	}
 
@@ -1392,7 +1418,10 @@ fail:
 #endif
 
 	if (was_observe) {
-		/* Observer: keep request active until unobserve */
+		/* Observer: keep request active until unobserve. The registration token
+		 * stays matchable in get_request_with_token(), so no token restore is
+		 * needed here.
+		 */
 		return ret;
 	}
 
@@ -1539,10 +1568,13 @@ int coap_client_deregister_observe(struct coap_client *client, struct coap_clien
 		mid = coap_next_id();
 		memset(internal_req->send_buf, 0, sizeof(internal_req->send_buf));
 
+		/* Cancel using the registration token; request_token may currently hold a
+		 * block-retrieval token from an in-progress blockwise notification.
+		 */
 		err = coap_packet_init(
 			&pkt, internal_req->send_buf, sizeof(internal_req->send_buf), COAP_VERSION,
 			internal_req->coap_request.confirmable ? COAP_TYPE_CON : COAP_TYPE_NON_CON,
-			internal_req->request_tkl, internal_req->request_token, COAP_METHOD_GET,
+			internal_req->observe_tkl, internal_req->observe_token, COAP_METHOD_GET,
 			mid);
 
 		if (err == 0) {
@@ -1563,6 +1595,10 @@ int coap_client_deregister_observe(struct coap_client *client, struct coap_clien
 
 		internal_req->request = pkt;
 		internal_req->last_id = mid;
+		/* Match the deregister response via request_token once is_observe is cleared. */
+		memcpy(internal_req->request_token, internal_req->observe_token,
+		       internal_req->observe_tkl);
+		internal_req->request_tkl = internal_req->observe_tkl;
 		internal_req->is_observe = false;
 
 		if (internal_req->coap_request.confirmable) {

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -574,12 +574,359 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_observe(int sock, void *buf, si
 	return ret;
 }
 
+/* Token of the observe registration, captured from the first block-0 notification and reused
+ * when the server pushes the next notification.
+ */
+static uint8_t observe_reg_token[COAP_TOKEN_MAX_LEN];
+static int observe_block_step;
+
+/* Shared scratch for the interleaved-notification and mid-transfer deregister tests.
+ * ox_reg_token is the observe registration token; ox_last_token/ox_last_id track the most
+ * recently sent GET so the next block can echo it.
+ */
+static uint8_t ox_reg_token[COAP_TOKEN_MAX_LEN];
+static uint8_t ox_last_token[COAP_TOKEN_MAX_LEN];
+static uint16_t ox_last_id;
+static int ox_step;
+static int ox_dereg_count;
+static int ox_interleave_cb_idx;
+static int ox_blockwise_cb_count;
+static struct k_work ox_dereg_work;
+
+static void ox_dereg_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	(void)coap_client_deregister_observe(&client, &(struct coap_client_request){0});
+}
+
+static size_t build_block2_response(uint8_t *buf, size_t buf_len, uint8_t type,
+				    const uint8_t *token, uint16_t id, int observe_seq,
+				    int block_num, bool more)
+{
+	static uint8_t block_payload[CONFIG_COAP_CLIENT_BLOCK_SIZE];
+	struct coap_packet pkt;
+	uint16_t plen = more ? CONFIG_COAP_CLIENT_BLOCK_SIZE : 100;
+	int block2 = (block_num << 4) | (more ? 0x08 : 0) | COAP_BLOCK_256;
+
+	zassert_ok(coap_packet_init(&pkt, buf, buf_len, 1, type, COAP_TOKEN_MAX_LEN, token,
+				    COAP_RESPONSE_CODE_CONTENT, id));
+	if (observe_seq >= 0) {
+		zassert_ok(coap_append_option_int(&pkt, COAP_OPTION_OBSERVE, observe_seq));
+	}
+	zassert_ok(coap_append_option_int(&pkt, COAP_OPTION_BLOCK2, block2));
+	zassert_ok(coap_packet_append_payload_marker(&pkt));
+	zassert_true(coap_packet_append_payload(&pkt, block_payload, plen) >= 0);
+
+	return pkt.offset;
+}
+
+/* Minimal piggybacked 2.05 ACK (no payload), used for CON deregister responses. */
+static size_t build_content_ack(uint8_t *buf, size_t buf_len, const uint8_t *token, uint16_t id)
+{
+	struct coap_packet pkt;
+
+	zassert_ok(coap_packet_init(&pkt, buf, buf_len, 1, COAP_TYPE_ACK, COAP_TOKEN_MAX_LEN, token,
+				    COAP_RESPONSE_CODE_CONTENT, id));
+
+	return pkt.offset;
+}
+
+/* Deliver a resource that is transferred blockwise (two blocks) both for the initial
+ * notification and for a subsequent server-pushed notification.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_observe_block(int sock, void *buf, size_t max_len,
+							       int flags,
+							       struct net_sockaddr *src_addr,
+							       net_socklen_t *addrlen)
+{
+	uint8_t tokbuf[TOKEN_OFFSET + COAP_TOKEN_MAX_LEN] = {0};
+	size_t resp_len;
+	uint16_t id;
+
+	switch (observe_block_step) {
+	case 0: /* notification #1, block 0: carries Observe and the registration token */
+		id = get_next_pending_message_id();
+		restore_token(tokbuf);
+		memcpy(observe_reg_token, tokbuf + TOKEN_OFFSET, COAP_TOKEN_MAX_LEN);
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_ACK, observe_reg_token,
+						 id, 1, 0, true);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	case 1: /* notification #1, block 1: answers the continuation GET (token T1) */
+		id = get_next_pending_message_id();
+		restore_token(tokbuf);
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_ACK,
+						 tokbuf + TOKEN_OFFSET, id, -1, 1, false);
+		set_socket_events(sock, ZSOCK_POLLIN); /* push the next notification */
+		break;
+	case 2: /* notification #2, block 0: server push reusing the registration token */
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_NON_CON,
+						 observe_reg_token, 0xA000, 2, 0, true);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	case 3: /* notification #2, block 1: answers the continuation GET (token T2) */
+		id = get_next_pending_message_id();
+		restore_token(tokbuf);
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_ACK,
+						 tokbuf + TOKEN_OFFSET, id, -1, 1, false);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	default:
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		return 0;
+	}
+
+	observe_block_step++;
+	return resp_len;
+}
+
+/* Same as observe_block, but only the first two blocks (one notification). */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_observe_block_one(
+	int sock, void *buf, size_t max_len, int flags,
+	struct net_sockaddr *src_addr, net_socklen_t *addrlen)
+{
+	ssize_t ret;
+
+	if (observe_block_step >= 2) {
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		return 0;
+	}
+
+	ret = z_impl_zsock_recvfrom_custom_fake_observe_block(sock, buf, max_len, flags,
+							       src_addr, addrlen);
+	if (observe_block_step >= 2) {
+		clear_socket_events(sock, ZSOCK_POLLIN);
+	}
+
+	return ret;
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_observe_block(int sock, void *buf, size_t len,
+							     int flags,
+							     const struct net_sockaddr *dest_addr,
+							     net_socklen_t addrlen)
+{
+	struct coap_packet req = {0};
+	struct coap_option opt = {0};
+	uint16_t id = (((uint8_t *)buf)[2] << 8) | ((uint8_t *)buf)[3];
+	uint8_t type = (((uint8_t *)buf)[0] & 0x30) >> 4;
+
+	store_token(buf);
+	set_next_pending_message_id(id);
+
+	zassert_ok(coap_packet_parse(&req, buf, len, NULL, 0));
+
+	if (coap_get_option_int(&req, COAP_OPTION_OBSERVE) == 1) {
+		uint8_t token[COAP_TOKEN_MAX_LEN];
+
+		coap_header_get_token(&req, token);
+		zassert_mem_equal(token, observe_reg_token, COAP_TOKEN_MAX_LEN,
+				  "Deregister must use the observe registration token");
+		ox_dereg_count++;
+		return 1;
+	}
+
+	/* RFC 7959 Section 3.4: Block2 continuation GETs must not carry the Observe option. */
+	if (coap_get_option_int(&req, COAP_OPTION_BLOCK2) > 0) {
+		zassert_equal(coap_find_options(&req, COAP_OPTION_OBSERVE, &opt, 1), 0,
+			      "Observe must be absent on block retrievals");
+	}
+
+	if (type == 0) {
+		set_socket_events(sock, ZSOCK_POLLIN);
+	}
+
+	return 1;
+}
+
+/* Serve notification #1 block 0, then push notification #2 (block 0) WHILE the block-1
+ * retrieval of notification #1 is still outstanding. The pushed notification reuses the
+ * registration token, which must match via observe_token while request_token holds the
+ * block-retrieval token.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_observe_interleave(
+	int sock, void *buf, size_t max_len, int flags,
+	struct net_sockaddr *src_addr, net_socklen_t *addrlen)
+{
+	size_t resp_len;
+
+	switch (ox_step) {
+	case 0: /* notification #1, block 0: Observe + registration token, more to come */
+		memcpy(ox_reg_token, ox_last_token, COAP_TOKEN_MAX_LEN);
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_ACK, ox_reg_token,
+						 ox_last_id, 1, 0, true);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	case 1: /* notification #2, block 0: async push reusing the registration token,
+		 * arriving before the block-1 continuation GET is answered
+		 */
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_NON_CON, ox_reg_token,
+						 0xB000, 2, 0, true);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	case 2: /* notification #2, block 1: answer the latest continuation GET, last block */
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_ACK, ox_last_token,
+						 ox_last_id, -1, 1, false);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	default:
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		return 0;
+	}
+
+	ox_step++;
+	return resp_len;
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_observe_interleave(
+	int sock, void *buf, size_t len, int flags,
+	const struct net_sockaddr *dest_addr, net_socklen_t addrlen)
+{
+	struct coap_packet req = {0};
+	struct coap_option opt = {0};
+	uint8_t type = (((uint8_t *)buf)[0] & 0x30) >> 4;
+
+	zassert_ok(coap_packet_parse(&req, buf, len, NULL, 0));
+
+	/* The async notification must stay matchable: the client must never RST it. */
+	zassert_not_equal(type, COAP_TYPE_RESET,
+			  "Registration token unmatchable: client sent an RST");
+
+	if (coap_get_option_int(&req, COAP_OPTION_BLOCK2) > 0) {
+		zassert_equal(coap_find_options(&req, COAP_OPTION_OBSERVE, &opt, 1), 0,
+			      "Observe must be absent on block retrievals");
+	}
+
+	ox_last_id = (((uint8_t *)buf)[2] << 8) | ((uint8_t *)buf)[3];
+	memcpy(ox_last_token, (uint8_t *)buf + TOKEN_OFFSET, COAP_TOKEN_MAX_LEN);
+
+	if (type == COAP_TYPE_CON || type == COAP_TYPE_NON_CON) {
+		set_socket_events(sock, ZSOCK_POLLIN);
+	}
+
+	return 1;
+}
+
+/* Serve block 0 of a notification (more to come) so the client issues a block-1
+ * continuation GET, then deliver the CON deregister 2.05. Block 1 is never sent.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_observe_dereg(
+	int sock, void *buf, size_t max_len, int flags,
+	struct net_sockaddr *src_addr, net_socklen_t *addrlen)
+{
+	size_t resp_len;
+
+	switch (ox_step) {
+	case 0: /* notification block 0: Observe + registration token, more to come */
+		memcpy(ox_reg_token, ox_last_token, COAP_TOKEN_MAX_LEN);
+		resp_len = build_block2_response(buf, max_len, COAP_TYPE_ACK, ox_reg_token,
+						 ox_last_id, 1, 0, true);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	case 1: /* CON deregister response: 2.05 with the registration token */
+		resp_len = build_content_ack(buf, max_len, ox_reg_token, ox_last_id);
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		break;
+	default:
+		clear_socket_events(sock, ZSOCK_POLLIN);
+		return 0;
+	}
+
+	ox_step++;
+	fill_recv_src_addr(src_addr, addrlen);
+	return resp_len;
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_observe_dereg(
+	int sock, void *buf, size_t len, int flags,
+	const struct net_sockaddr *dest_addr, net_socklen_t addrlen)
+{
+	struct coap_packet req = {0};
+	struct coap_option opt = {0};
+	uint8_t type = (((uint8_t *)buf)[0] & 0x30) >> 4;
+	uint8_t tkl = ((uint8_t *)buf)[0] & 0x0f;
+
+	zassert_ok(coap_packet_parse(&req, buf, len, NULL, 0));
+
+	ox_last_id = (((uint8_t *)buf)[2] << 8) | ((uint8_t *)buf)[3];
+	memcpy(ox_last_token, (uint8_t *)buf + TOKEN_OFFSET, COAP_TOKEN_MAX_LEN);
+
+	if (coap_get_option_int(&req, COAP_OPTION_OBSERVE) == 1) {
+		/* Deregister GET: must reuse the registration token, even though request_token
+		 * currently holds the outstanding block-retrieval (continuation) token.
+		 */
+		zassert_equal(tkl, COAP_TOKEN_MAX_LEN, "Unexpected deregister token length");
+		zassert_mem_equal((uint8_t *)buf + TOKEN_OFFSET, ox_reg_token, COAP_TOKEN_MAX_LEN,
+				  "Deregister must use the observe registration token");
+		ox_dereg_count++;
+		if (type == COAP_TYPE_CON) {
+			set_socket_events(sock, ZSOCK_POLLIN);
+		}
+		return 1;
+	}
+
+	if (coap_get_option_int(&req, COAP_OPTION_BLOCK2) > 0) {
+		zassert_equal(coap_find_options(&req, COAP_OPTION_OBSERVE, &opt, 1), 0,
+			      "Observe must be absent on block retrievals");
+		/* Continuation GET is out, so request_token now holds the continuation token. */
+		k_sem_give(&sem2);
+		return 1;
+	}
+
+	/* Registration GET. */
+	set_socket_events(sock, ZSOCK_POLLIN);
+	return 1;
+}
+
 void coap_callback(const struct coap_client_response_data *data, void *user_data)
 {
 	LOG_INF("CoAP response callback, %d", data->result_code);
 	last_response_code = data->result_code;
 	if (user_data) {
 		k_sem_give((struct k_sem *) user_data);
+	}
+}
+
+static void coap_callback_interleave_observe(const struct coap_client_response_data *data,
+					     void *user_data)
+{
+	static const int expected_observe_seq[] = {1, 2};
+	int observe;
+
+	coap_callback(data, user_data);
+
+	if (data->packet == NULL || data->result_code != COAP_RESPONSE_CODE_CONTENT) {
+		return;
+	}
+
+	observe = coap_get_option_int(data->packet, COAP_OPTION_OBSERVE);
+	if (data->offset == 0 && !data->last_block) {
+		zassert_true(observe >= 0, "Observe missing on block-0 notification");
+		zassert_equal(observe, expected_observe_seq[ox_interleave_cb_idx],
+			      "Unexpected Observe sequence on interleaved notification");
+		ox_interleave_cb_idx++;
+	} else if (data->last_block) {
+		zassert_equal(observe, -ENOENT, "Observe must be absent on final block");
+	}
+}
+
+static void coap_callback_deregister_on_last_block(const struct coap_client_response_data *data,
+						 void *user_data)
+{
+	coap_callback(data, user_data);
+
+	if (data->result_code != COAP_RESPONSE_CODE_CONTENT) {
+		return;
+	}
+
+	ox_blockwise_cb_count++;
+	if (ox_blockwise_cb_count == 2) {
+		/* coap_client_deregister_observe() must not run synchronously from the
+		 * response callback: the recv path still holds the slot in_callback.
+		 * Post to the workqueue and run once the callback has returned.
+		 */
+		k_work_submit(&ox_dereg_work);
 	}
 }
 
@@ -597,6 +944,7 @@ static void *suite_setup(void)
 	net_coap_init();
 	zassert_ok(coap_client_init(&client, NULL));
 	zassert_ok(coap_client_init(&client2, NULL));
+	k_work_init(&ox_dereg_work, ox_dereg_work_handler);
 
 	return NULL;
 }
@@ -626,6 +974,16 @@ static void test_setup(void *data)
 	last_response_code = 0;
 	k_sem_reset(&sem1);
 	k_sem_reset(&sem2);
+
+	observe_block_step = 0;
+	memset(observe_reg_token, 0, sizeof(observe_reg_token));
+	ox_step = 0;
+	ox_dereg_count = 0;
+	ox_interleave_cb_idx = 0;
+	ox_blockwise_cb_count = 0;
+	memset(ox_reg_token, 0, sizeof(ox_reg_token));
+	memset(ox_last_token, 0, sizeof(ox_last_token));
+	ox_last_id = 0;
 
 	k_mutex_unlock(&client.lock);
 }
@@ -971,7 +1329,7 @@ ZTEST(coap_client, test_observe)
 		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
 		.cb = coap_callback,
 		.payload = short_payload,
-		.len = strlen(short_payload),
+		.len = sizeof(short_payload) - 1,
 		.options = { {
 			.code = COAP_OPTION_OBSERVE,
 			.value[0] = 0,
@@ -982,7 +1340,6 @@ ZTEST(coap_client, test_observe)
 	};
 
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_observe;
-
 
 	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
 
@@ -1119,6 +1476,173 @@ ZTEST(coap_client, test_observe_deregister_non)
 	zassert_equal(last_response_code, -ECANCELED);
 
 	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+}
+
+ZTEST(coap_client, test_observe_blockwise)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = coap_callback,
+		.payload = short_payload,
+		.len = sizeof(short_payload) - 1,
+		.options = { {
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		} },
+		.num_options = 1,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_observe_block;
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_observe_block;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* Notification #1, transferred as two blocks. */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+
+	/* Notification #2 must still be delivered: observe_token keeps the registration
+	 * token matchable while block retrievals use fresh tokens in request_token.
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "");
+
+	coap_client_cancel_requests(&client);
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, -ECANCELED, "");
+}
+
+ZTEST(coap_client, test_observe_blockwise_async_notification)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = coap_callback_interleave_observe,
+		.payload = short_payload,
+		.len = sizeof(short_payload) - 1,
+		.options = { {
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		} },
+		.num_options = 1,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_recvfrom_fake.custom_fake =
+		z_impl_zsock_recvfrom_custom_fake_observe_interleave;
+	z_impl_zsock_sendto_fake.custom_fake =
+		z_impl_zsock_sendto_custom_fake_observe_interleave;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* Block 0 of notification #1, then notification #2 pushed mid-retrieval, then its
+	 * final block. All three deliveries must reach the callback and none must be RST'd
+	 * (asserted in the sendto fake).
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(ox_interleave_cb_idx, 2, "Expected two block-0 Observe notifications");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "");
+
+	coap_client_cancel_requests(&client);
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, -ECANCELED, "");
+}
+
+ZTEST(coap_client, test_observe_deregister_blockwise)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = coap_callback,
+		.payload = short_payload,
+		.len = sizeof(short_payload) - 1,
+		.options = { {
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		} },
+		.num_options = 1,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_recvfrom_fake.custom_fake =
+		z_impl_zsock_recvfrom_custom_fake_observe_dereg;
+	z_impl_zsock_sendto_fake.custom_fake =
+		z_impl_zsock_sendto_custom_fake_observe_dereg;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* Block 0 is delivered and the client issues the block-1 continuation GET, so
+	 * request_token now holds the continuation token, not the registration token.
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+
+	/* Deregister mid-transfer: outgoing GET must use the registration token (sendto
+	 * fake) and the CON 2.05 response must match after request_token is synced.
+	 */
+	zassert_ok(coap_client_deregister_observe(&client, &req));
+	zassert_equal(ox_dereg_count, 1, "Deregister GET was not sent");
+
+	/* Server 2.05 for the CON deregister. */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT,
+		      "Deregister CON response was not handled");
+
+	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+}
+
+ZTEST(coap_client, test_observe_deregister_blockwise_in_callback)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = coap_callback_deregister_on_last_block,
+		.payload = short_payload,
+		.len = sizeof(short_payload) - 1,
+		.options = { {
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		} },
+		.num_options = 1,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_recvfrom_fake.custom_fake =
+		z_impl_zsock_recvfrom_custom_fake_observe_block_one;
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_observe_block;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* Deregister posted from the last-block callback while request_token still holds
+	 * the continuation token; only verifies the deregister GET is sent.
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	/* Wait for the deregister work posted from the last-block callback. */
+	k_sleep(K_MSEC(10));
+	zassert_equal(ox_dereg_count, 1, "Deregister GET was not sent");
+
+	coap_client_cancel_requests(&client);
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, -ECANCELED, "");
 }
 
 ZTEST(coap_client, test_request_rst)


### PR DESCRIPTION
When observing a resource whose notification body is large enough to be transferred blockwise (RFC 7959), the client stopped receiving notifications after the first one.

The registration is made with an observe token T0. To retrieve the remaining blocks of a notification, coap_client issues Block2 GETs, and coap_client_init_request() generates a fresh token for each of them, overwriting internal_req->request_token. While a blockwise notification is in progress, and again after it completes, request_token therefore holds a block-retrieval token (T1, T2, ...), not T0. Server-pushed notifications always use T0, so get_request_with_token() no longer found the request: the notification was dropped and an RST was sent, which cancels the observation on the server.

The same overwrite broke coap_client_deregister_observe(), which built the unobserve GET from request_token and could send the continuation token instead of T0.

Block2 continuation GETs also re-appended the application's Observe option, violating RFC 7959 Section 3.4 (only the block-0 notification may carry Observe).

Fix this by:
- Saving the registration token in observe_token/observe_tkl when the observe request is created (including Echo retries).
- Matching responses on either request_token (block-retrieval replies) or observe_token (new notifications) for active observations.
- Building unobserve packets from observe_token rather than request_token.
- Dropping the Observe option (in addition to the already-dropped Block2 option) from Block2 continuation retrievals.

Add observe blockwise notification test cases.