### PR TITLE
native_simulator: Get latest from upstream

### DIFF
--- a/scripts/native_simulator/native/src/include/nsi_timer_model.h
+++ b/scripts/native_simulator/native/src/include/nsi_timer_model.h
@@ -16,7 +16,10 @@ extern "C" {
 #endif
 
 void hwtimer_set_real_time_mode(bool new_rt);
-void hwtimer_timer_reached(void);
+void hwtimer_set_rt_period(uint64_t period);
+void hwtimer_set_rt_ratio(double ratio);
+void hwtimer_adjust_rt_ratio(double ratio_correction);
+
 void hwtimer_wake_in_time(uint64_t time);
 void hwtimer_set_silent_ticks(int64_t sys_ticks);
 void hwtimer_enable(uint64_t period);
@@ -24,10 +27,7 @@ int64_t hwtimer_get_pending_silent_ticks(void);
 
 void hwtimer_reset_rtc(void);
 void hwtimer_set_rtc_offset(int64_t offset);
-void hwtimer_set_rt_ratio(double ratio);
-
 void hwtimer_adjust_rtc_offset(int64_t offset_delta);
-void hwtimer_adjust_rt_ratio(double ratio_correction);
 int64_t hwtimer_get_simu_rtc_time(void);
 void hwtimer_get_pseudohost_rtc_time(uint32_t *nsec, uint64_t *sec);
 

--- a/scripts/native_simulator/native/src/timer_model.c
+++ b/scripts/native_simulator/native/src/timer_model.c
@@ -63,6 +63,7 @@ static char *us_time_to_str(char *dest, uint64_t time)
 static uint64_t hw_timer_timer; /* Event timer exposed to the HW scheduler */
 
 static uint64_t hw_timer_tick_timer;
+static uint64_t hw_timer_rt_timer;
 static uint64_t hw_timer_awake_timer;
 
 static uint64_t tick_p; /* Period of the ticker */
@@ -84,6 +85,7 @@ static uint64_t boot_time;
  * than real time
  */
 static double clock_ratio = 1.0;
+static uint64_t rt_period = 10e3; /* in microseconds */
 
 #if DEBUG_NP_TIMER
 /*
@@ -108,14 +110,25 @@ static uint64_t last_radj_rtime;
 /* Last simulated time when the ratio was adjusted */
 static uint64_t last_radj_stime;
 
+/* Set in real time mode. Note this can only be called before HW_INIT */
 void hwtimer_set_real_time_mode(bool new_rt)
 {
-	real_time_mode = new_rt;
+	if (hw_timer_rt_timer) {
+		nsi_print_warning("%s: can't be called after init. Ignored\n", __func__);
+	} else {
+		real_time_mode = new_rt;
+	}
+}
+
+void hwtimer_set_rt_period(uint64_t period)
+{
+	rt_period = period;
 }
 
 static void hwtimer_update_timer(void)
 {
 	hw_timer_timer = NSI_MIN(hw_timer_tick_timer, hw_timer_awake_timer);
+	hw_timer_timer = NSI_MIN(hw_timer_timer, hw_timer_rt_timer);
 }
 
 static inline void host_clock_gettime(struct timespec *tv)
@@ -140,17 +153,28 @@ uint64_t get_host_us_time(void)
 	return (uint64_t)tv.tv_sec * 1e6 + tv.tv_nsec / 1000;
 }
 
-static void hwtimer_init(void)
+static void hwtimer_rt_init(void)
 {
-	silent_ticks = 0;
-	hw_timer_tick_timer = NSI_NEVER;
-	hw_timer_awake_timer = NSI_NEVER;
-	hwtimer_update_timer();
 	if (real_time_mode) {
 		boot_time = get_host_us_time();
 		last_radj_rtime = boot_time;
 		last_radj_stime = 0U;
+
+		hw_timer_rt_timer = rt_period;
+	} else {
+		hw_timer_rt_timer = NSI_NEVER;
 	}
+}
+
+static void hwtimer_init(void)
+{
+	hwtimer_rt_init();
+
+	silent_ticks = 0;
+	hw_timer_tick_timer = NSI_NEVER;
+	hw_timer_awake_timer = NSI_NEVER;
+	hwtimer_update_timer();
+
 	if (!reset_rtc) {
 		struct timespec tv;
 		uint64_t realhosttime;
@@ -186,39 +210,44 @@ void hwtimer_enable(uint64_t period)
 	nsi_hws_find_next_event();
 }
 
-static void hwtimer_tick_timer_reached(void)
+static void hwtimer_rt_timer_reached(void)
 {
-	if (real_time_mode) {
-		uint64_t expected_rt = (hw_timer_tick_timer - last_radj_stime)
-				    / clock_ratio
-				    + last_radj_rtime;
-		uint64_t real_time = get_host_us_time();
+	uint64_t expected_rt = (hw_timer_rt_timer - last_radj_stime) / clock_ratio
+				+ last_radj_rtime;
+	uint64_t real_time = get_host_us_time();
 
-		int64_t diff = expected_rt - real_time;
+	int64_t diff = expected_rt - real_time;
 
 #if DEBUG_NP_TIMER
-		char es[30];
-		char rs[30];
+	char es[30];
+	char rs[30];
 
-		us_time_to_str(es, expected_rt - boot_time);
-		us_time_to_str(rs, real_time - boot_time);
-		printf("tick @%5"PRIu64"ms: diff = expected_rt - real_time = "
-			"%5"PRIi64" = %s - %s\n",
-			hw_timer_tick_timer/1000U, diff, es, rs);
+	us_time_to_str(es, expected_rt - boot_time);
+	us_time_to_str(rs, real_time - boot_time);
+	printf("rt sync @%5"PRIu64"ms: diff = expected_rt - real_time = "
+		"%5"PRIi64" = %s - %s\n",
+		hw_timer_rt_timer/1000U, diff, es, rs);
 #endif
 
-		if (diff > 0) { /* we need to slow down */
-			struct timespec requested_time;
-			struct timespec remaining;
+	if (diff > 0) { /* we need to slow down */
+		struct timespec requested_time;
+		struct timespec remaining;
 
-			requested_time.tv_sec  = diff / 1e6;
-			requested_time.tv_nsec = (diff -
-						 requested_time.tv_sec*1e6)*1e3;
+		requested_time.tv_sec  = diff / 1e6;
+		requested_time.tv_nsec = (diff - requested_time.tv_sec*1e6)*1e3;
 
-			(void) nanosleep(&requested_time, &remaining);
-		}
+		(void) nanosleep(&requested_time, &remaining);
 	}
 
+	hw_timer_rt_timer += rt_period;
+	if (hw_timer_rt_timer < nsi_hws_get_time()) { /* wrapped around the end of time */
+		hw_timer_rt_timer = NSI_NEVER;
+	}
+	hwtimer_update_timer();
+}
+
+static void hwtimer_tick_timer_reached(void)
+{
 	if (tick_p > NSI_NEVER - hw_timer_tick_timer) { /* We'd wrap around the end of time */
 		hw_timer_tick_timer = NSI_NEVER;
 	} else {
@@ -246,6 +275,10 @@ static void hwtimer_timer_reached(void)
 
 	if (hw_timer_awake_timer == Now) {
 		hwtimer_awake_timer_reached();
+	}
+
+	if (hw_timer_rt_timer == Now) {
+		hwtimer_rt_timer_reached();
 	}
 
 	if (hw_timer_tick_timer == Now) {
@@ -428,6 +461,7 @@ static struct {
 	double stop_at;
 	double rtc_offset;
 	double rt_drift;
+	double rt_period;
 	double rt_ratio;
 } args;
 
@@ -485,6 +519,24 @@ static void cmd_rt_ratio_found(char *argv, int offset)
 	hwtimer_set_rt_ratio(args.rt_ratio);
 }
 
+static void cmd_rt_period_found(char *argv, int offset)
+{
+	NSI_ARG_UNUSED(argv);
+	NSI_ARG_UNUSED(offset);
+
+	if (args.rt_period < 1e-6) {
+		nsi_print_error_and_exit("The rt-period (%le) needs to be >= 1e-6. "
+					  "Please use --help for more info\n", args.rt_period);
+	}
+	if ((args.rt_period < 1e-3) || (args.rt_period > 60)) {
+		nsi_print_warning("rt-period has a weird value (%le). "
+				  "Are you sure this is what you want?\n",
+				  args.rt_period);
+	}
+	hwtimer_set_rt_period(args.rt_period * 1e6);
+	hwtimer_set_real_time_mode(true);
+}
+
 static void cmd_rtcreset_found(char *argv, int offset)
 {
 	(void) argv;
@@ -535,6 +587,19 @@ static void nsi_add_time_options(void)
 				    "speed, and therefore it does not make sense to use them "
 				    "simultaneously. "
 				    "This option has no effect in non real time mode"
+		},
+		{
+			.option = "rt-period",
+			.name = "period",
+			.type = 'd',
+			.dest = (void *)&args.rt_period,
+			.call_when_found = cmd_rt_period_found,
+			.descript = "In seconds, periodicity at which real time and simulated time "
+				    "will be sync'ed. "
+				    "For ex. set to 50e-3 to have the simulation held every 50ms "
+				    "until the real time catches up. By default it is 10ms. "
+				    "This option has no effect in non real time mode, but setting "
+				    "it implies `-rt`"
 		},
 		{
 			.option = "rtc-offset",


### PR DESCRIPTION
Align with native_simulator's upstream main
0d3eafc13a7bf37ef146da540986f99356ac48bd

Which includes:
0d3eafc native: hw_timer: split real time pacing from tick logic

-------

    native: hw_timer: split real time pacing from tick logic
    
    These two are independent. It should be possible to configure
    the tick period independently of the real time pacing periodicity,
    and a kernel changing or disabling the tick should not affect
    the real time adjustments.
    
    A new command line option `-rt-period` allows configuring this periodicity
    
    Note: This commit also removes hwtimer_timer_reached() from the header
    which should never have been there.

-----

With this change https://github.com/zephyrproject-rtos/zephyr/commit/0342c930d238270309469fbf7d7972c9b5ba4347 /  https://github.com/zephyrproject-rtos/zephyr/pull/116240 can be reapplied.