### PR TITLE
Kconfig: disable macro expansion tracking by default

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -565,7 +565,6 @@ config COMPILER_SAVE_TEMPS
 
 config COMPILER_TRACK_MACRO_EXPANSION
 	bool "Track macro expansion"
-	default y
 	help
 	  When enabled, locations of tokens across macro expansions will be
 	  tracked. Disabling this option may be useful to debug long macro


### PR DESCRIPTION
Disable compiler macro expansion tracking by default to reduce diagnostic output for deeply nested macros.
This can heavily reduce the amount of output generated by the compiler.