### PR TITLE
[Backport v3.7-branch] bluetooth: classic: rfcomm: improve error handling and buffer check

### DIFF
--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -731,8 +731,8 @@ static int rfcomm_send_rpn(struct bt_rfcomm_session *session, uint8_t cr,
 	return rfcomm_send(session, buf);
 }
 
-static int rfcomm_send_test(struct bt_rfcomm_session *session, uint8_t cr,
-			    uint8_t *pattern, uint8_t len)
+static int rfcomm_send_test(struct bt_rfcomm_session *session, uint8_t cr, uint8_t *pattern,
+			    uint8_t len)
 {
 	struct net_buf *buf;
 	uint8_t fcs;
@@ -1109,9 +1109,17 @@ static void rfcomm_handle_dm(struct bt_rfcomm_session *session, uint8_t dlci)
 static void rfcomm_handle_msc(struct bt_rfcomm_session *session,
 			      struct net_buf *buf, uint8_t cr)
 {
-	struct bt_rfcomm_msc *msc = (void *)buf->data;
+	struct bt_rfcomm_msc *msc;
 	struct bt_rfcomm_dlc *dlc;
-	uint8_t dlci = BT_RFCOMM_GET_DLCI(msc->dlci);
+	uint8_t dlci;
+
+	if (buf->len < sizeof(*msc)) {
+		LOG_WRN("Malformed MSC command %u < %zu", buf->len, sizeof(*msc));
+		return;
+	}
+
+	msc = net_buf_pull_mem(buf, sizeof(*msc));
+	dlci = BT_RFCOMM_GET_DLCI(msc->dlci);
 
 	LOG_DBG("dlci %d", dlci);
 
@@ -1149,9 +1157,17 @@ static void rfcomm_handle_msc(struct bt_rfcomm_session *session,
 static void rfcomm_handle_rls(struct bt_rfcomm_session *session,
 			      struct net_buf *buf, uint8_t cr)
 {
-	struct bt_rfcomm_rls *rls = (void *)buf->data;
-	uint8_t dlci = BT_RFCOMM_GET_DLCI(rls->dlci);
+	struct bt_rfcomm_rls *rls;
+	uint8_t dlci;
 	struct bt_rfcomm_dlc *dlc;
+
+	if (buf->len < sizeof(*rls)) {
+		LOG_WRN("Malformed RLS command %u < %zu", buf->len, sizeof(*rls));
+		return;
+	}
+
+	rls = net_buf_pull_mem(buf, sizeof(*rls));
+	dlci = BT_RFCOMM_GET_DLCI(rls->dlci);
 
 	LOG_DBG("dlci %d", dlci);
 
@@ -1172,29 +1188,37 @@ static void rfcomm_handle_rls(struct bt_rfcomm_session *session,
 static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 			      struct net_buf *buf, uint8_t cr)
 {
-	struct bt_rfcomm_rpn default_rpn, *rpn = (void *)buf->data;
-	uint8_t dlci = BT_RFCOMM_GET_DLCI(rpn->dlci);
+	struct bt_rfcomm_rpn default_rpn;
+	uint8_t dlci;
 	uint8_t data_bits, stop_bits, parity_bits;
-	/* Exclude fcs to get number of value bytes */
-	uint8_t value_len = buf->len - 1;
-
-	LOG_DBG("dlci %d", dlci);
 
 	if (!cr) {
 		/* Ignore if its a response */
 		return;
 	}
 
-	if (value_len == sizeof(*rpn)) {
+	if (buf->len == sizeof(struct bt_rfcomm_rpn)) {
+		struct bt_rfcomm_rpn *rpn;
+
+		rpn = net_buf_pull_mem(buf, sizeof(*rpn));
+		dlci = BT_RFCOMM_GET_DLCI(rpn->dlci);
+
+		LOG_DBG("Set RPN setting: dlci %d", dlci);
+
 		/* Accept all the values proposed by the sender */
 		rpn->param_mask = sys_cpu_to_le16(BT_RFCOMM_RPN_PARAM_MASK_ALL);
 		rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, rpn);
 		return;
 	}
 
-	if (value_len != 1U) {
+	if (buf->len != sizeof(dlci)) {
+		LOG_WRN("Invalid RPN command");
 		return;
 	}
+
+	dlci = BT_RFCOMM_GET_DLCI(net_buf_pull_u8(buf));
+
+	LOG_DBG("Get RPN setting: dlci %d", dlci);
 
 	/* If only one value byte then current port settings has to be returned
 	 * We will send default values
@@ -1218,9 +1242,15 @@ static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 			     struct net_buf *buf, uint8_t cr)
 {
-	struct bt_rfcomm_pn *pn = (void *)buf->data;
+	struct bt_rfcomm_pn *pn;
 	struct bt_rfcomm_dlc *dlc;
 
+	if (buf->len < sizeof(*pn)) {
+		LOG_WRN("Malformed PN command %u < %zu", buf->len, sizeof(*pn));
+		return;
+	}
+
+	pn = net_buf_pull_mem(buf, sizeof(*pn));
 	dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, pn->dlci);
 	if (!dlc) {
 		/*  Ignore if it is a response */
@@ -1319,8 +1349,7 @@ static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 	}
 }
 
-static void rfcomm_handle_msg(struct bt_rfcomm_session *session,
-			      struct net_buf *buf)
+static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf *buf)
 {
 	struct bt_rfcomm_msg_hdr *hdr;
 	uint8_t msg_type, len, cr;
@@ -1336,6 +1365,11 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session,
 	len = BT_RFCOMM_GET_LEN(hdr->len);
 
 	LOG_DBG("msg type %x cr %x", msg_type, cr);
+
+	if (buf->len < len) {
+		LOG_WRN("Invalid message length %u < %u", buf->len, len);
+		return;
+	}
 
 	switch (msg_type) {
 	case BT_RFCOMM_PN:
@@ -1354,8 +1388,13 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session,
 		if (!cr) {
 			break;
 		}
-		rfcomm_send_test(session, BT_RFCOMM_MSG_RESP_CR, buf->data,
-				 buf->len - 1);
+
+		if (buf->len > UINT8_MAX) {
+			LOG_WRN("TEST command too long %u > %u", buf->len, UINT8_MAX);
+			return;
+		}
+
+		rfcomm_send_test(session, BT_RFCOMM_MSG_RESP_CR, buf->data, buf->len);
 		break;
 	case BT_RFCOMM_FCON:
 		if (session->cfc == BT_RFCOMM_CFC_SUPPORTED) {
@@ -1421,9 +1460,8 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 	rfcomm_send_credit(dlc, credits);
 }
 
-static void rfcomm_handle_data(struct bt_rfcomm_session *session,
-			       struct net_buf *buf, uint8_t dlci, uint8_t pf)
-
+static void rfcomm_handle_data(struct bt_rfcomm_session *session, struct net_buf *buf, uint8_t dlci,
+			       uint8_t pf)
 {
 	struct bt_rfcomm_dlc *dlc;
 
@@ -1450,23 +1488,24 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session,
 		rfcomm_dlc_tx_give_credits(dlc, net_buf_pull_u8(buf));
 	}
 
-	if (buf->len > BT_RFCOMM_FCS_SIZE) {
-		if (dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED &&
-		    !dlc->rx_credit) {
-			LOG_ERR("Data recvd when rx credit is 0");
-			rfcomm_dlc_close(dlc);
-			return;
-		}
-
-		/* Remove FCS */
-		buf->len -= BT_RFCOMM_FCS_SIZE;
-		if (dlc->ops && dlc->ops->recv) {
-			dlc->ops->recv(dlc, buf);
-		}
-
-		dlc->rx_credit--;
-		rfcomm_dlc_update_credits(dlc);
+	if (buf->len == 0) {
+		LOG_DBG("Credit frame only, no payload");
+		return;
 	}
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED &&
+	    !dlc->rx_credit) {
+		LOG_ERR("Data recvd when rx credit is 0");
+		rfcomm_dlc_close(dlc);
+		return;
+	}
+
+	if (dlc->ops && dlc->ops->recv) {
+		dlc->ops->recv(dlc, buf);
+	}
+
+	dlc->rx_credit--;
+	rfcomm_dlc_update_credits(dlc);
 }
 
 int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
@@ -1552,6 +1591,7 @@ static int rfcomm_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	}
 
 	net_buf_pull(buf, hdr_len);
+	net_buf_remove_mem(buf, sizeof(fcs));
 
 	switch (frame_type) {
 	case BT_RFCOMM_SABM:

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -1188,7 +1188,7 @@ static void rfcomm_handle_rls(struct bt_rfcomm_session *session,
 static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 			      struct net_buf *buf, uint8_t cr)
 {
-	struct bt_rfcomm_rpn default_rpn;
+	struct bt_rfcomm_rpn rsp;
 	uint8_t dlci;
 	uint8_t data_bits, stop_bits, parity_bits;
 
@@ -1205,9 +1205,10 @@ static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 
 		LOG_DBG("Set RPN setting: dlci %d", dlci);
 
+		rsp = *rpn;
 		/* Accept all the values proposed by the sender */
-		rpn->param_mask = sys_cpu_to_le16(BT_RFCOMM_RPN_PARAM_MASK_ALL);
-		rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, rpn);
+		rsp.param_mask = sys_cpu_to_le16(BT_RFCOMM_RPN_PARAM_MASK_ALL);
+		rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, &rsp);
 		return;
 	}
 
@@ -1223,20 +1224,18 @@ static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 	/* If only one value byte then current port settings has to be returned
 	 * We will send default values
 	 */
-	default_rpn.dlci = BT_RFCOMM_SET_ADDR(dlci, 1);
-	default_rpn.baud_rate = BT_RFCOMM_RPN_BAUD_RATE_9600;
-	default_rpn.flow_control = BT_RFCOMM_RPN_FLOW_NONE;
-	default_rpn.xoff_char = BT_RFCOMM_RPN_XOFF_CHAR;
-	default_rpn.xon_char = BT_RFCOMM_RPN_XON_CHAR;
+	rsp.dlci = BT_RFCOMM_SET_ADDR(dlci, 1);
+	rsp.baud_rate = BT_RFCOMM_RPN_BAUD_RATE_9600;
+	rsp.flow_control = BT_RFCOMM_RPN_FLOW_NONE;
+	rsp.xoff_char = BT_RFCOMM_RPN_XOFF_CHAR;
+	rsp.xon_char = BT_RFCOMM_RPN_XON_CHAR;
 	data_bits = BT_RFCOMM_RPN_DATA_BITS_8;
 	stop_bits = BT_RFCOMM_RPN_STOP_BITS_1;
 	parity_bits = BT_RFCOMM_RPN_PARITY_NONE;
-	default_rpn.line_settings = BT_RFCOMM_SET_LINE_SETTINGS(data_bits,
-								stop_bits,
-								parity_bits);
-	default_rpn.param_mask = sys_cpu_to_le16(BT_RFCOMM_RPN_PARAM_MASK_ALL);
+	rsp.line_settings = BT_RFCOMM_SET_LINE_SETTINGS(data_bits, stop_bits, parity_bits);
+	rsp.param_mask = sys_cpu_to_le16(BT_RFCOMM_RPN_PARAM_MASK_ALL);
 
-	rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, &default_rpn);
+	rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, &rsp);
 }
 
 static void rfcomm_handle_pn(struct bt_rfcomm_session *session,


### PR DESCRIPTION
Backport of the fix from #115768 to `v3.7-branch`.

Fixes: #117045