### PR TITLE
debug: coredump: Avoid taking mutex in isr with in memory coredump ba…

### DIFF
--- a/subsys/debug/coredump/coredump_backend_in_memory.c
+++ b/subsys/debug/coredump/coredump_backend_in_memory.c
@@ -100,10 +100,6 @@ static void coredump_in_memory_backend_start(void)
 
 	*coredump_size = 0;
 
-	while (LOG_PROCESS()) {
-		;
-	}
-
 	LOG_PANIC();
 	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_BEGIN_STR);
 }


### PR DESCRIPTION
# Prerequisite
- Log fs backend enabled
- Coredump in memory backend enabled

# Issue description
When a coredump occur with in memory backend, it ties to process all pending logs. When fs log backend is enable, it use a mutex which is not possible in ISR context. This raise a kernel_panic.

# Fix description
The `LOG_PANIC` macro calls `z_impl_log_panic` which does:
1. `log_backend_panic` for all log backends. The fs implementation disable the fs log backend (this avoid the use of mutex in ISR context).
2. Runs a loop of `log_process`

The proposed fix is to removed the `LOG_PROCESS` loop as it's already done internally by `LOG_PANIC`. This allow to disable fs log backend and continue to log on others backend.