### PR TITLE
drivers: ipm: stm32_ipcc: use LL_IPCC_GetChannelNumber() on all series

### DIFF
--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -260,11 +260,7 @@ static int stm32_ipcc_mailbox_init(const struct device *dev)
 	IPCC_DisableIT_TXF(cfg->ipcc);
 	IPCC_DisableIT_RXO(cfg->ipcc);
 
-#if defined(CONFIG_SOC_SERIES_STM32MP2X)
 	data->num_ch = LL_IPCC_GetChannelNumber(cfg->ipcc);
-#else
-	data->num_ch = LL_IPCC_GetChannelConfig(cfg->ipcc);
-#endif
 
 	for (i = 0; i < data->num_ch; i++) {
 		/* Clear RX status */


### PR DESCRIPTION
The LL_IPCC_GetChannelConfig() function is Zephyr-specific and was added via a patch to hal_stm32 when STM32CubeMP1 v1.0.0 was in use, as this version of the package lacked a function to get the number of channels in the IPCC...

In STM32CubeMP1 v1.1.0, function LL_IPCC_GetChannelNumber() was added and should have replaced the custom one... but never did! Both the custom function and its user lingered in tree since then...

Since LL_IPCC_GetChannelNumber() exists in both MP1 and MP2 packages and is the *official* name, drop the #if series check and just use that function unconditionally on all series. This will allow removal of the custom LL_IPCC_GetChannelConfig() in the future.

References:
- https://github.com/zephyrproject-rtos/hal_stm32/commit/397208b41a2145390d9cab8a02dfca4c8c2c4911
- https://github.com/STMicroelectronics/STM32CubeMP1/blame/525d2499658d817a9e669eb17e66390906954895/Drivers/STM32MP1xx_HAL_Driver/Inc/stm32mp1xx_ll_ipcc.h#L697-L707
- https://github.com/zephyrproject-rtos/hal_stm32/blob/02baa06ccea3304d1f65ec6550c68e5e300fcc58/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_ipcc.h#L697-L717

