### PR TITLE
ec_host_cmd: initialize thread field in context

### DIFF
--- a/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
+++ b/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
@@ -138,9 +138,8 @@ struct ec_host_cmd {
 	ec_host_cmd_user_cb_t user_cb;
 	void *user_data;
 	enum ec_host_cmd_state state;
-#ifdef CONFIG_EC_HOST_CMD_DEDICATED_THREAD
-	struct k_thread thread;
-#endif /* CONFIG_EC_HOST_CMD_DEDICATED_THREAD */
+	/** Thread running the host command handler loop. */
+	k_tid_t thread;
 };
 
 /**

--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -50,6 +50,7 @@ COND_CODE_1(CONFIG_EC_HOST_CMD_HANDLER_TX_BUFFER_DEF,
 
 #ifdef CONFIG_EC_HOST_CMD_DEDICATED_THREAD
 static K_KERNEL_STACK_DEFINE(hc_stack, CONFIG_EC_HOST_CMD_HANDLER_STACK_SIZE);
+static struct k_thread hc_thread;
 #endif /* CONFIG_EC_HOST_CMD_DEDICATED_THREAD */
 
 static struct ec_host_cmd ec_host_cmd = {
@@ -464,6 +465,7 @@ FUNC_NORETURN static void ec_host_cmd_thread(void *hc_handle, void *arg2, void *
 #ifndef CONFIG_EC_HOST_CMD_DEDICATED_THREAD
 FUNC_NORETURN void ec_host_cmd_task(void)
 {
+	ec_host_cmd.thread = k_current_get();
 	ec_host_cmd_thread(&ec_host_cmd, NULL, NULL);
 }
 #endif
@@ -518,10 +520,11 @@ int ec_host_cmd_init(struct ec_host_cmd_backend *backend)
 	}
 
 #ifdef CONFIG_EC_HOST_CMD_DEDICATED_THREAD
-	k_thread_create(&hc->thread, hc_stack, CONFIG_EC_HOST_CMD_HANDLER_STACK_SIZE,
-			ec_host_cmd_thread, (void *)hc, NULL, NULL, CONFIG_EC_HOST_CMD_HANDLER_PRIO,
-			0, K_NO_WAIT);
-	k_thread_name_set(&hc->thread, "ec_host_cmd");
+	hc->thread = k_thread_create(&hc_thread, hc_stack,
+				     CONFIG_EC_HOST_CMD_HANDLER_STACK_SIZE,
+				     ec_host_cmd_thread, (void *)hc, NULL, NULL,
+				     CONFIG_EC_HOST_CMD_HANDLER_PRIO, 0, K_NO_WAIT);
+	k_thread_name_set(hc->thread, "ec_host_cmd");
 #endif /* CONFIG_EC_HOST_CMD_DEDICATED_THREAD */
 
 	return 0;


### PR DESCRIPTION
Update struct ec_host_cmd to unconditionally store the k_tid_t of the thread executing host commands. When running with a dedicated thread, store the k_tid_t returned by k_thread_create. When running via ec_host_cmd_task, record k_current_get() upon entry.

This allows consumers to consistently query the host command thread via the ec_host_cmd context regardless of the threading configuration.