### PR TITLE
drivers: spi: spi_ambiq_spid: fix runtime PM defects in transceive path

### DIFF
--- a/drivers/spi/spi_ambiq_spid.c
+++ b/drivers/spi/spi_ambiq_spid.c
@@ -174,11 +174,16 @@ static int spi_config(const struct device *dev, const struct spi_config *config)
 	data->ios_cfg.pui8SRAMBuffer = ambiq_spid_sram_buffer,
 	data->ios_cfg.ui32SRAMBufferCap = AMBIQ_SPID_TX_BUFSIZE_MAX,
 
-	ctx->config = config;
+	ctx->config = NULL;
 
 	ret = am_hal_ios_configure(data->ios_handler, &data->ios_cfg);
+	if (ret != AM_HAL_STATUS_SUCCESS) {
+		return -EIO;
+	}
 
-	return ret;
+	ctx->config = config;
+
+	return 0;
 }
 
 static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *config)

--- a/drivers/spi/spi_ambiq_spid.c
+++ b/drivers/spi/spi_ambiq_spid.c
@@ -276,6 +276,7 @@ static int spi_ambiq_transceive(const struct device *dev, const struct spi_confi
 				const struct spi_buf_set *rx_bufs)
 {
 	struct spi_ambiq_data *data = dev->data;
+	int pm_ret;
 	int ret;
 
 	if (!tx_bufs && !rx_bufs) {
@@ -285,6 +286,7 @@ static int spi_ambiq_transceive(const struct device *dev, const struct spi_confi
 	ret = pm_device_runtime_get(dev);
 	if (ret < 0) {
 		LOG_ERR_PM_DEVICE_RUNTIME_GET(dev, ret);
+		return ret;
 	}
 
 	/* context setup */
@@ -292,22 +294,22 @@ static int spi_ambiq_transceive(const struct device *dev, const struct spi_confi
 
 	ret = spi_config(dev, config);
 	if (ret) {
-		spi_context_release(&data->ctx, ret);
-		return ret;
+		goto end;
 	}
 
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
 	ret = spi_ambiq_xfer(dev, config);
 
+end:
 	spi_context_release(&data->ctx, ret);
 
 	/* Use async put to avoid useless device suspension/resumption
 	 * when doing consecutive transmission.
 	 */
-	ret = pm_device_runtime_put_async(dev, K_MSEC(2));
-	if (ret < 0) {
-		LOG_ERR_PM_DEVICE_RUNTIME_PUT(dev, ret);
+	pm_ret = pm_device_runtime_put_async(dev, K_MSEC(2));
+	if (pm_ret < 0) {
+		LOG_ERR_PM_DEVICE_RUNTIME_PUT(dev, pm_ret);
 	}
 
 	return ret;


### PR DESCRIPTION
Fixes the runtime PM defects in the SPID transceive path reported in #116324:

- `spi_ambiq_transceive()` returned early when `spi_config()` failed, skipping the runtime PM put and leaking the usage count taken by the get, so the device could never runtime-suspend again. The config-failure path now routes through the common exit.
- The transfer status was overwritten by the return of `pm_device_runtime_put_async()`, hiding transfer errors from the caller. The put status now lives in its own variable.
- A failed `pm_device_runtime_get()` was logged but execution continued into the HAL; it now bails out.

Also fixes the config-caching defect noted in the same issue: `spi_config()` published the config into the SPI context before `am_hal_ios_configure()` ran, so one HAL configure failure left the context looking configured and the next transceive ran on unconfigured hardware. The config is now published only after the HAL accepts it, and a configure failure maps to `-EIO` instead of leaking a positive HAL status through the SPI API.

Fixes #116324
