### PR TITLE
drivers: timer: document the lock held on the idle hooks

### DIFF
--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -62,9 +62,9 @@ extern "C" {
  * which consumes it.  The lock is released when
  * sys_clock_announce_locked() returns.
  *
- * The driver-provided functions sys_clock_set_timeout() and
- * sys_clock_elapsed() are always called by the kernel with this lock
- * already held.
+ * The driver-provided functions sys_clock_set_timeout(),
+ * sys_clock_elapsed(), sys_clock_no_timeout() and sys_clock_idle_enter()
+ * are always called by the kernel with this lock already held.
  *
  * Example usage from a timer ISR:
  *
@@ -277,6 +277,8 @@ void sys_clock_disable(void);
  *
  * Unlike sys_clock_disable(), this is not a teardown.
  *
+ * @note Called with the system clock lock held.
+ *
  * The hook is optional.  Without it, sys_clock_set_timeout() is asked for the
  * longest wait it can express, UINT32_MAX ticks.  That is numerically what
  * K_TICKS_FOREVER was here, so a driver that has not migrated and still keys
@@ -305,6 +307,8 @@ void sys_clock_no_timeout(void);
  *        Only the calling CPU is going idle: a driver whose time base is
  *        shared between CPUs must ensure only the last CPU going idle stops
  *        the clock.
+ *
+ * @note Called with the system clock lock held.
  */
 void sys_clock_idle_enter(uint32_t ticks);
 


### PR DESCRIPTION
`sys_clock_no_timeout()` and `sys_clock_idle_enter()` are called with the system
clock lock held, from `reprogram_next()` and from the power management idle path
respectively. The contract paragraph named only `sys_clock_set_timeout()` and
`sys_clock_elapsed()`, so a driver implementing either hook had nothing telling
it the lock was already taken.

Found via #116236, where the mcux_os_timer conversion took the lock in
`sys_clock_no_timeout()`. That reduces to an interrupt lock on a uniprocessor
build without `CONFIG_SPIN_VALIDATE`, so it passes there and would deadlock on
SMP. Documentation only, no functional change.
