### PR TITLE
boards: replace "ble" supported tag with "bluetooth"

### DIFF
--- a/boards/96boards/carbon/96b_carbon_nrf51822.yaml
+++ b/boards/96boards/carbon/96b_carbon_nrf51822.yaml
@@ -8,5 +8,5 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
 vendor: seeed

--- a/boards/96boards/carbon/96b_carbon_stm32f401xe.yaml
+++ b/boards/96boards/carbon/96b_carbon_stm32f401xe.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - gpio
-  - ble
+  - bluetooth
   - i2c
   - counter
   - spi

--- a/boards/96boards/nitrogen/96b_nitrogen.yaml
+++ b/boards/96boards/nitrogen/96b_nitrogen.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - gpio
   - i2c
   - spi

--- a/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840.yaml
+++ b/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - watchdog
   - counter
   - feather_serial

--- a/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense.yaml
+++ b/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - watchdog
   - counter
   - feather_serial

--- a/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense_uf2.yaml
+++ b/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense_uf2.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - watchdog
   - counter
   - feather_serial

--- a/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_uf2.yaml
+++ b/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_uf2.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - watchdog
   - counter
   - feather_serial

--- a/boards/adafruit/itsybitsy/adafruit_itsybitsy_nrf52840.yaml
+++ b/boards/adafruit/itsybitsy/adafruit_itsybitsy_nrf52840.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
@@ -17,7 +17,7 @@ supported:
   - i2c
   - i2c_target
   - clock_control
-  - ble
+  - bluetooth
   - usbd
 testing:
   ignore_tags:

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev1.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev1.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - i2c
   - pwm
   - serial

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - i2c
   - pwm
   - serial

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev1.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev1.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - i2c
   - pwm
   - serial

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - i2c
   - pwm
   - serial

--- a/boards/bbc/microbit/bbc_microbit.yaml
+++ b/boards/bbc/microbit/bbc_microbit.yaml
@@ -10,7 +10,7 @@ testing:
   ignore_tags:
     - net
 supported:
-  - ble
+  - bluetooth
   - i2c
   - gpio
   - pwm

--- a/boards/bbc/microbit_v2/bbc_microbit_v2.yaml
+++ b/boards/bbc/microbit_v2/bbc_microbit_v2.yaml
@@ -10,6 +10,6 @@ testing:
   ignore_tags:
     - net
 supported:
-  - ble
+  - bluetooth
   - i2c
   - gpio

--- a/boards/bcdevices/plt_demo_v2/blueclover_plt_demo_v2_nrf52832.yaml
+++ b/boards/bcdevices/plt_demo_v2/blueclover_plt_demo_v2_nrf52832.yaml
@@ -9,7 +9,7 @@ toolchain:
 ram: 64
 flash: 512
 supported:
-  - ble
+  - bluetooth
   - counter
   - nvs
   - i2c

--- a/boards/bytesatwork/bytesensi_l/bytesensi_l.yaml
+++ b/boards/bytesatwork/bytesensi_l/bytesensi_l.yaml
@@ -10,7 +10,7 @@ toolchain:
 ram: 64
 flash: 512
 supported:
-  - ble
+  - bluetooth
   - gpio
   - i2c
   - lora

--- a/boards/coredevices/p2d/p2d.yaml
+++ b/boards/coredevices/p2d/p2d.yaml
@@ -11,7 +11,7 @@ toolchain:
 ram: 256
 flash: 1024
 supported:
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.yaml
+++ b/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.yaml
@@ -8,7 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/ct/ctcc/ctcc_nrf52840.yaml
+++ b/boards/ct/ctcc/ctcc_nrf52840.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - gpio
   - usbd
   - watchdog

--- a/boards/electronut/nrf52840_blip/nrf52840_blip.yaml
+++ b/boards/electronut/nrf52840_blip/nrf52840_blip.yaml
@@ -9,5 +9,5 @@ supported:
   - adc
   - i2c
   - usb_device
-  - ble
+  - bluetooth
 vendor: electronutlabs

--- a/boards/electronut/nrf52840_papyr/nrf52840_papyr.yaml
+++ b/boards/electronut/nrf52840_papyr/nrf52840_papyr.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - ble
+  - bluetooth
   - pwm
   - watchdog
 vendor: electronutlabs

--- a/boards/ezurio/bl653_dvk/bl653_dvk.yaml
+++ b/boards/ezurio/bl653_dvk/bl653_dvk.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - ble
+  - bluetooth
   - pwm
   - watchdog
   - gpio

--- a/boards/ezurio/bl654_dvk/bl654_dvk.yaml
+++ b/boards/ezurio/bl654_dvk/bl654_dvk.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - ble
+  - bluetooth
   - pwm
   - watchdog
 vendor: ezurio

--- a/boards/ezurio/bl654_dvk/bl654_dvk_nrf52840_pa.yaml
+++ b/boards/ezurio/bl654_dvk/bl654_dvk_nrf52840_pa.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - ble
+  - bluetooth
   - pwm
   - watchdog
 vendor: ezurio

--- a/boards/ezurio/bl654_sensor_board/bl654_sensor_board.yaml
+++ b/boards/ezurio/bl654_sensor_board/bl654_sensor_board.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/ezurio/bl654_usb/bl654_usb.yaml
+++ b/boards/ezurio/bl654_usb/bl654_usb.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - watchdog
   - counter

--- a/boards/ezurio/bl654_usb/bl654_usb_nrf52840_bare.yaml
+++ b/boards/ezurio/bl654_usb/bl654_usb_nrf52840_bare.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - watchdog
   - counter

--- a/boards/ezurio/bt510/bt510.yaml
+++ b/boards/ezurio/bt510/bt510.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - pwm
   - watchdog
   - i2c

--- a/boards/ezurio/bt610/bt610.yaml
+++ b/boards/ezurio/bt610/bt610.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - gpio
   - i2c
   - pwm

--- a/boards/ezurio/mg100/mg100.yaml
+++ b/boards/ezurio/mg100/mg100.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/ezurio/pinnacle_100_dvk/pinnacle_100_dvk.yaml
+++ b/boards/ezurio/pinnacle_100_dvk/pinnacle_100_dvk.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/ezurio/rm1xx_dvk/rm1xx_dvk.yaml
+++ b/boards/ezurio/rm1xx_dvk/rm1xx_dvk.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 ram: 32
 supported:
-  - ble
+  - bluetooth
   - i2c
   - spi
   - lora

--- a/boards/fobe/quill_nrf52840_mesh/quill_nrf52840_mesh.yaml
+++ b/boards/fobe/quill_nrf52840_mesh/quill_nrf52840_mesh.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - lora

--- a/boards/heltec/heltec_t114_v2/heltec_t114_v2.yaml
+++ b/boards/heltec/heltec_t114_v2/heltec_t114_v2.yaml
@@ -10,7 +10,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - spi
   - watchdog

--- a/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_uf2.yaml
+++ b/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_uf2.yaml
@@ -10,7 +10,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - spi
   - watchdog

--- a/boards/holyiot/yj16019/holyiot_yj16019.yaml
+++ b/boards/holyiot/yj16019/holyiot_yj16019.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - pwm
   - watchdog
 ram: 64

--- a/boards/holyiot/yj17095/holyiot_yj17095.yaml
+++ b/boards/holyiot/yj17095/holyiot_yj17095.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - pwm
   - watchdog
 ram: 64

--- a/boards/makerdiary/nrf52840_mdk/nrf52840_mdk.yaml
+++ b/boards/makerdiary/nrf52840_mdk/nrf52840_mdk.yaml
@@ -7,6 +7,6 @@ toolchain:
   - gnuarmemb
 supported:
   - usb_device
-  - ble
+  - bluetooth
   - pwm
 vendor: makerdiary

--- a/boards/makerdiary/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.yaml
+++ b/boards/makerdiary/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.yaml
@@ -9,6 +9,6 @@ toolchain:
   - gnuarmemb
 supported:
   - usbd
-  - ble
+  - bluetooth
   - watchdog
   - counter

--- a/boards/mikroe/hexiwear/hexiwear_mk64f12.yaml
+++ b/boards/mikroe/hexiwear/hexiwear_mk64f12.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - flash
   - gpio
   - i2c

--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.yaml
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.yaml
@@ -11,7 +11,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_i2c
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/nordic/nrf51dk/nrf51dk_nrf51822.yaml
+++ b/boards/nordic/nrf51dk/nrf51dk_nrf51822.yaml
@@ -9,7 +9,7 @@ ram: 32
 flash: 256
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/nordic/nrf51dongle/nrf51dongle_nrf51822.yaml
+++ b/boards/nordic/nrf51dongle/nrf51dongle_nrf51822.yaml
@@ -8,6 +8,6 @@ toolchain:
 ram: 32
 flash: 256
 supported:
-  - ble
+  - bluetooth
   - nvs
 vendor: nordic

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52820.yaml
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52820.yaml
@@ -10,7 +10,7 @@ flash: 256
 supported:
   - usb_device
   - usbd
-  - ble
+  - bluetooth
   - gpio
   - watchdog
   - counter

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.yaml
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.yaml
@@ -14,7 +14,7 @@ supported:
   - arduino_spi
   - usb_device
   - usbd
-  - ble
+  - bluetooth
   - gpio
   - pwm
   - watchdog

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.yaml
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.yaml
@@ -13,7 +13,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.yaml
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.yaml
@@ -10,7 +10,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - spi
   - watchdog

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840_bare.yaml
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840_bare.yaml
@@ -10,7 +10,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - spi
   - watchdog

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf52840_0_14_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf52840_0_14_0.yaml
@@ -8,7 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - netif:openthread
   - gpio
 vendor: nordic

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf52840_0_7_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf52840_0_7_0.yaml
@@ -8,7 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - netif:openthread
   - gpio
 vendor: nordic

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.yaml
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.yaml
@@ -8,7 +8,7 @@ toolchain:
 ram: 448
 flash: 1024
 supported:
-  - ble
+  - bluetooth
   - gpio
   - i2c
   - pwm

--- a/boards/nucode/nucode_nu32/nucode_nu32_nrf52832.yaml
+++ b/boards/nucode/nucode_nu32/nucode_nu32_nrf52832.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - nfc

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.yaml
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.yaml
@@ -13,7 +13,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - usbd
-  - ble
+  - bluetooth
   - i2c
   - pwm
   - spi

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.yaml
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.yaml
@@ -13,7 +13,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - usbd
-  - ble
+  - bluetooth
   - i2c
   - pwm
   - spi

--- a/boards/others/promicro_nrf52840/promicro_nrf52840.yaml
+++ b/boards/others/promicro_nrf52840/promicro_nrf52840.yaml
@@ -10,7 +10,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - spi
   - watchdog

--- a/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_uf2.yaml
+++ b/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_uf2.yaml
@@ -10,7 +10,7 @@ toolchain:
 supported:
   - adc
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - spi
   - watchdog

--- a/boards/panasonic/pan1770_evb/pan1770_evb.yaml
+++ b/boards/panasonic/pan1770_evb/pan1770_evb.yaml
@@ -17,7 +17,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/panasonic/pan1780_evb/pan1780_evb.yaml
+++ b/boards/panasonic/pan1780_evb/pan1780_evb.yaml
@@ -17,7 +17,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/panasonic/pan1781_evb/pan1781_evb.yaml
+++ b/boards/panasonic/pan1781_evb/pan1781_evb.yaml
@@ -15,7 +15,7 @@ toolchain:
 supported:
   - arduino_i2c
   - arduino_spi
-  - ble
+  - bluetooth
   - gpio
   - i2c
   - spi

--- a/boards/panasonic/pan1782_evb/pan1782_evb.yaml
+++ b/boards/panasonic/pan1782_evb/pan1782_evb.yaml
@@ -17,7 +17,7 @@ supported:
   - arduino_i2c
   - arduino_spi
   - usb_device
-  - ble
+  - bluetooth
   - gpio
   - i2c
   - spi

--- a/boards/particle/argon/particle_argon.yaml
+++ b/boards/particle/argon/particle_argon.yaml
@@ -12,7 +12,7 @@ supported:
   - spi
   - gpio
   - usb_device
-  - ble
+  - bluetooth
   - feather_serial
   - feather_i2c
   - feather_spi

--- a/boards/particle/boron/particle_boron.yaml
+++ b/boards/particle/boron/particle_boron.yaml
@@ -12,7 +12,7 @@ supported:
   - spi
   - gpio
   - usb_device
-  - ble
+  - bluetooth
   - feather_serial
   - feather_i2c
   - feather_spi

--- a/boards/particle/nrf51_blenano/nrf51_blenano.yaml
+++ b/boards/particle/nrf51_blenano/nrf51_blenano.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 ram: 16
 supported:
-  - ble
+  - bluetooth
 testing:
   ignore_tags:
     - net

--- a/boards/particle/xenon/particle_xenon.yaml
+++ b/boards/particle/xenon/particle_xenon.yaml
@@ -17,7 +17,7 @@ supported:
   - spi
   - gpio
   - usb_device
-  - ble
+  - bluetooth
   - feather_serial
   - feather_i2c
   - feather_spi

--- a/boards/phytec/reel_board/reel_board_1.yaml
+++ b/boards/phytec/reel_board/reel_board_1.yaml
@@ -12,7 +12,7 @@ supported:
   - spi
   - gpio
   - usb_device
-  - ble
+  - bluetooth
   - pwm
   - arduino_i2c
   - arduino_spi

--- a/boards/phytec/reel_board/reel_board_nrf52840_2.yaml
+++ b/boards/phytec/reel_board/reel_board_nrf52840_2.yaml
@@ -12,7 +12,7 @@ supported:
   - spi
   - gpio
   - usb_device
-  - ble
+  - bluetooth
   - pwm
   - arduino_i2c
   - arduino_spi

--- a/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk.yaml
+++ b/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk.yaml
@@ -11,7 +11,7 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - ble
+  - bluetooth
   - gpio
   - pwm
   - watchdog

--- a/boards/rakwireless/rak4631/rak4631_nrf52840.yaml
+++ b/boards/rakwireless/rak4631/rak4631_nrf52840.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/rakwireless/rak5010/rak5010_nrf52840.yaml
+++ b/boards/rakwireless/rak5010/rak5010_nrf52840.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/raytac/mdbt50q_cx_40_dongle/raytac_mdbt50q_cx_40_dongle_nrf52840.yaml
+++ b/boards/raytac/mdbt50q_cx_40_dongle/raytac_mdbt50q_cx_40_dongle_nrf52840.yaml
@@ -13,7 +13,7 @@ toolchain:
   - gnuarmemb
 supported:
   - usbd
-  - ble
+  - bluetooth
   - pwm
   - watchdog
   - counter

--- a/boards/raytac/mdbt50q_db_33/raytac_mdbt50q_db_33_nrf52833.yaml
+++ b/boards/raytac/mdbt50q_db_33/raytac_mdbt50q_db_33_nrf52833.yaml
@@ -12,7 +12,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/raytac/mdbt50q_db_40/raytac_mdbt50q_db_40_nrf52840.yaml
+++ b/boards/raytac/mdbt50q_db_40/raytac_mdbt50q_db_40_nrf52840.yaml
@@ -14,7 +14,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/ruuvi/ruuvitag/ruuvi_ruuvitag.yaml
+++ b/boards/ruuvi/ruuvitag/ruuvi_ruuvitag.yaml
@@ -8,7 +8,7 @@ toolchain:
 ram: 64
 flash: 512
 supported:
-  - ble
+  - bluetooth
   - adc
   - gpio
   - spi

--- a/boards/seeed/wio_tracker_l1/wio_tracker_l1.yaml
+++ b/boards/seeed/wio_tracker_l1/wio_tracker_l1.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - display
   - flash

--- a/boards/seeed/xiao_ble/xiao_ble.yaml
+++ b/boards/seeed/xiao_ble/xiao_ble.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/seeed/xiao_ble/xiao_ble_nrf52840_sense.yaml
+++ b/boards/seeed/xiao_ble/xiao_ble_nrf52840_sense.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/sparkfun/micromod/micromod_nrf52840.yaml
+++ b/boards/sparkfun/micromod/micromod_nrf52840.yaml
@@ -8,7 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - ble
+  - bluetooth
   - gpio
   - spi
   - qspi

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
@@ -16,7 +16,7 @@ supported:
   - lsm6dsl
   - pwm
   - gpio
-  - ble
+  - bluetooth
   - spi
   - vl53l0x
   - watchdog

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.yaml
@@ -9,7 +9,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_i2c
-  - ble
+  - bluetooth
   - counter
   - crc
   - dac

--- a/boards/st/sensortile_box/sensortile_box.yaml
+++ b/boards/st/sensortile_box/sensortile_box.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - pwm
   - spi
-  - ble
+  - bluetooth
   - i2c
   - gpio
   - usbd

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.yaml
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.yaml
@@ -8,7 +8,7 @@ toolchain:
 supported:
   - pwm
   - spi
-  - ble
+  - bluetooth
   - i2c
   - gpio
   - usbd

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.yaml
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.yaml
@@ -12,5 +12,5 @@ supported:
   - gpio
   - pwm
   - watchdog
-  - ble
+  - bluetooth
 vendor: st

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
@@ -9,7 +9,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_spi
-  - ble
+  - bluetooth
   - counter
   - crc
   - dac

--- a/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.yaml
+++ b/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.yaml
@@ -12,7 +12,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.yaml
+++ b/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.yaml
@@ -11,7 +11,7 @@ supported:
   - adc
   - arduino_i2c
   - arduino_spi
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/u-blox/ubx_bmd380eval/ubx_bmd380eval_nrf52840.yaml
+++ b/boards/u-blox/ubx_bmd380eval/ubx_bmd380eval_nrf52840.yaml
@@ -9,7 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.yaml
+++ b/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.yaml
@@ -11,7 +11,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_i2c
-  - ble
+  - bluetooth
   - counter
   - gpio
   - i2c

--- a/boards/u-blox/ubx_evkninab4/ubx_evkninab4_nrf52833.yaml
+++ b/boards/u-blox/ubx_evkninab4/ubx_evkninab4_nrf52833.yaml
@@ -11,7 +11,7 @@ supported:
   - arduino_i2c
   - arduino_spi
   - usb_device
-  - ble
+  - bluetooth
   - gpio
   - pwm
   - watchdog

--- a/boards/waveshare/nrf51_ble400/nrf51_ble400.yaml
+++ b/boards/waveshare/nrf51_ble400/nrf51_ble400.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
 ram: 32
 supported:
-  - ble
+  - bluetooth
   - gpio
   - i2c
 testing:

--- a/boards/we/proteus3ev/we_proteus3ev_nrf52840.yaml
+++ b/boards/we/proteus3ev/we_proteus3ev_nrf52840.yaml
@@ -12,7 +12,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - ble
+  - bluetooth
   - gpio
   - i2c
   - spi

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/tests.yaml
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/tests.yaml
@@ -22,7 +22,7 @@ tests:
       - CONFIG_MCUMGR_GRP_OS_INFO_CUSTOM_HOOKS=n
       - CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS=n
   mgmt.mcumgr.os.info.bt:
-    depends_on: ble
+    depends_on: bluetooth
     extra_configs:
       - CONFIG_BT=y
       - CONFIG_BT_DEVICE_NAME="a_bt_name"


### PR DESCRIPTION
The "ble" board supported feature tag is replaced in favor of "bluetooth". Update all remaining board YAML files so tests using depends_on: bluetooth are correctly filtered in.

Before changes:

```
ceolin@debian-nuc:~/p/zephyrproject/zephyr$ git grep -e "\<ble\>"  "boards/*.yaml" | wc -l
91
ceolin@debian-nuc:~/p/zephyrproject/zephyr$ git grep -e "\<bluetooth\>"  "boards/*.yaml" | wc -l
386
```

after:

```
ceolin@debian-nuc:~/p/zephyrproject/zephyr$ git grep -e "\<ble\>"  "boards/*.yaml"  | wc -l
0
ceolin@debian-nuc:~/p/zephyrproject/zephyr$ git grep -e "\<bluetooth\>"  "boards/*.yaml"  | wc -l
477
```