### PR TITLE
soc: adi: max32: compute NUM_IRQS from devicetree

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -232,6 +232,26 @@ ADC
   condition. In-tree boards no longer enable it explicitly in their defconfigs since
   the default already covers them.
 
+Analog Devices
+==============
+
+* :kconfig:option:`CONFIG_NUM_IRQS` is now computed automatically for all MAX32 SoCs from the
+  devicetree, based on active (``status = "okay";``) devices, using the
+  ``dt_highest_controller_irq_number`` Kconfig preprocessor function. The hardcoded per-SoC values
+  have been removed, and the resulting IRQ table is typically considerably smaller than before.
+  Applications which register custom ISRs (using :c:macro:`IRQ_CONNECT()`) may encounter build
+  failures such as the following due to :kconfig:option:`CONFIG_NUM_IRQS` having a lower value:
+
+  .. code-block::
+
+    gen_isr_tables.py: error: IRQ 88 (offset=0) exceeds the maximum of 54
+
+  Explicitly set :kconfig:option:`CONFIG_NUM_IRQS` to an appropriate value to solve these issues.
+  (:ref:`The following documentation page <setting_configuration_values>` explains how to do it)
+
+  Applications that install ISRs at runtime with :c:func:`irq_connect_dynamic` are not covered by
+  this build-time check and must be reviewed manually.
+
 Audio Codec
 ===========
 

--- a/soc/adi/max32/Kconfig.defconfig
+++ b/soc/adi/max32/Kconfig.defconfig
@@ -5,6 +5,8 @@
 
 if SOC_FAMILY_MAX32
 
+# Source the per-SoC Kconfig files first, so that individual SoCs can override
+# the family-level defaults given below.
 rsource "Kconfig.defconfig.max*"
 rsource "sbt/Kconfig.defconfig"
 
@@ -12,6 +14,24 @@ choice PM_PREWAKEUP_CONV_MODE
 	default PM_PREWAKEUP_CONV_MODE_CEIL
 
 endchoice # PM_PREWAKEUP_CONV_MODE
+
+# Compute the IRQ table size automatically using DT.
+# dt_highest_controller_irq_number() returns a zero-based IRQn, increment it to
+# obtain the table size (= max IRQn + 1). Both cores are covered here: only one
+# of the two interrupt controllers is ever present in a given build's DT, so the
+# default for the other core is inert.
+
+# Cortex-M4 (ARMv7-M) and Cortex-M33 (ARMv8-M) cores: NVIC.
+DT_NVIC_PATH := /soc/interrupt-controller@e000e100
+DT_NVIC_MAX_IRQN := $(dt_highest_controller_irq_number,$(DT_NVIC_PATH),irq)
+
+# RV32 cores: MAX32 RISC-V core interrupt controller.
+DT_RV32_INTC_PATH := /soc/intc@e5070000
+DT_RV32_INTC_MAX_IRQN := $(dt_highest_controller_irq_number,$(DT_RV32_INTC_PATH),irq)
+
+configdefault NUM_IRQS
+	default $(inc,$(DT_NVIC_MAX_IRQN)) if $(dt_path_enabled,$(DT_NVIC_PATH))
+	default $(inc,$(DT_RV32_INTC_MAX_IRQN)) if $(dt_path_enabled,$(DT_RV32_INTC_PATH))
 
 if SOC_FAMILY_MAX32_RV32
 

--- a/soc/adi/max32/Kconfig.defconfig.max32650
+++ b/soc/adi/max32/Kconfig.defconfig.max32650
@@ -8,7 +8,4 @@ if SOC_MAX32650
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 80
-
 endif # SOC_MAX32650

--- a/soc/adi/max32/Kconfig.defconfig.max32651
+++ b/soc/adi/max32/Kconfig.defconfig.max32651
@@ -8,9 +8,6 @@ if SOC_MAX32651
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 80
-
 choice SOC_FAMILY_MAX32_SECURE_SOC_SIGNING_ALGO
 	default SOC_FAMILY_MAX32_SECURE_SOC_SIGNING_ALGO_RSA2048
 endchoice

--- a/soc/adi/max32/Kconfig.defconfig.max32655
+++ b/soc/adi/max32/Kconfig.defconfig.max32655
@@ -10,18 +10,12 @@ if SOC_MAX32655_M4
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 110
-
 endif
 
 if SOC_MAX32655_RV32
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_iso,clock-frequency)
-
-config NUM_IRQS
-	default 64
 
 config ISR_STACK_SIZE
 	default 1024

--- a/soc/adi/max32/Kconfig.defconfig.max32657
+++ b/soc/adi/max32/Kconfig.defconfig.max32657
@@ -9,9 +9,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if MAX32_WUT_TIMER
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 54
-
 # if PM_S2RAM selected, HAS_PM_S2RAM_CUSTOM_MARKING must be selected
 config PM_S2RAM
 	select HAS_PM_S2RAM_CUSTOM_MARKING

--- a/soc/adi/max32/Kconfig.defconfig.max32660
+++ b/soc/adi/max32/Kconfig.defconfig.max32660
@@ -8,7 +8,4 @@ if SOC_MAX32660
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 55
-
 endif # SOC_MAX32660

--- a/soc/adi/max32/Kconfig.defconfig.max32662
+++ b/soc/adi/max32/Kconfig.defconfig.max32662
@@ -8,7 +8,4 @@ if SOC_MAX32662
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 108
-
 endif # SOC_MAX32662

--- a/soc/adi/max32/Kconfig.defconfig.max32666
+++ b/soc/adi/max32/Kconfig.defconfig.max32666
@@ -8,7 +8,4 @@ if SOC_MAX32666
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 95
-
 endif # SOC_MAX32666

--- a/soc/adi/max32/Kconfig.defconfig.max32670
+++ b/soc/adi/max32/Kconfig.defconfig.max32670
@@ -8,7 +8,4 @@ if SOC_MAX32670
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 100
-
 endif # SOC_MAX32670

--- a/soc/adi/max32/Kconfig.defconfig.max32672
+++ b/soc/adi/max32/Kconfig.defconfig.max32672
@@ -8,9 +8,6 @@ if SOC_MAX32672
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 108
-
 choice SOC_FAMILY_MAX32_SECURE_SOC_SIGNING_ALGO
 	default SOC_FAMILY_MAX32_SECURE_SOC_SIGNING_ALGO_ECDSA256
 endchoice

--- a/soc/adi/max32/Kconfig.defconfig.max32675
+++ b/soc/adi/max32/Kconfig.defconfig.max32675
@@ -8,7 +8,4 @@ if SOC_MAX32675
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 100
-
 endif # SOC_MAX32675

--- a/soc/adi/max32/Kconfig.defconfig.max32680
+++ b/soc/adi/max32/Kconfig.defconfig.max32680
@@ -8,8 +8,4 @@ if SOC_MAX32680
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 104 if SOC_MAX32680_M4
-	default 60 if SOC_MAX32680_RV32
-
 endif # SOC_MAX32680

--- a/soc/adi/max32/Kconfig.defconfig.max32690
+++ b/soc/adi/max32/Kconfig.defconfig.max32690
@@ -10,18 +10,12 @@ if SOC_MAX32690_M4
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 112
-
 endif
 
 if SOC_MAX32690_RV32
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_iso,clock-frequency)
-
-config NUM_IRQS
-	default 64
 
 endif
 

--- a/soc/adi/max32/Kconfig.defconfig.max78000
+++ b/soc/adi/max32/Kconfig.defconfig.max78000
@@ -10,18 +10,12 @@ if SOC_MAX78000_M4
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 119
-
 endif # SOC_MAX78000_M4
 
 if SOC_MAX78000_RV32
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_iso,clock-frequency)
-
-config NUM_IRQS
-	default 60
 
 endif # SOC_MAX78000_RV32
 

--- a/soc/adi/max32/Kconfig.defconfig.max78002
+++ b/soc/adi/max32/Kconfig.defconfig.max78002
@@ -10,18 +10,12 @@ if SOC_MAX78002_M4
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_ipo,clock-frequency)
 
-config NUM_IRQS
-	default 105
-
 endif # SOC_MAX78002_M4
 
 if SOC_MAX78002_RV32
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clk_iso,clock-frequency)
-
-config NUM_IRQS
-	default 60
 
 endif # SOC_MAX78002_RV32
 


### PR DESCRIPTION
Every MAX32 SoC carried a hardcoded CONFIG_NUM_IRQS sized to the full
hardware IRQ line count: 18 values spread over 14 Kconfig files in three
different syntactic styles. Each one had to be maintained by hand, was
easy to get wrong when a peripheral was added, and forced applications
to carry an ISR table sized for peripherals they never enable.
 
Replace them with a single family-level default derived from the
devicetree via dt_highest_controller_irq_number(). The helper only
considers nodes with status = "okay", so the table is now sized to what
the application actually uses. Both cores are covered: Cortex-M4 and
Cortex-M33 through the NVIC node, RV32 through the MAX32 RISC-V core
interrupt controller. Only one of those controllers is ever present in a
given build's devicetree, so the default for the other core is inert.

The default is declared with configdefault and placed after the per-SoC
rsource statements, so a SoC or a board can still pin an explicit value.

Measured with samples/hello_world, the derived values are at or below
the previous constants on all 32 buildable MAX32 board targets, for
example max78002/m4 105 -> 57, max32657 54 -> 26 and max32655/rv32
64 -> 28.

This mirrors the equivalent change made for STM32 in #104819

Assisted-by: Claude:claude-opus-5
Signed-off-by: Maureen Helm <maureen.helm@analog.com>