### PR TITLE
drivers: sensor: adxl345: clear is_fifo in one-shot sample reads

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -370,6 +370,9 @@ int adxl345_read_sample(const struct device *dev,
 
 	sample->selected_range = data->selected_range;
 	sample->is_full_res = data->is_full_res;
+#ifdef CONFIG_ADXL345_STREAM
+	sample->is_fifo = 0;
+#endif /* CONFIG_ADXL345_STREAM */
 
 	return 0;
 }


### PR DESCRIPTION
adxl345_decoder_decode() routes on is_fifo at byte offset 0 to decide whether to call adxl345_decode_stream(). adxl345_submit_fetch() passes adxl345_read_sample() a raw RTIO mempool buffer, which is not zeroed, and adxl345_read_sample() never sets is_fifo, so the flag is whatever the previous user of that block left behind.

With CONFIG_ADXL345_STREAM=y, a one-shot sensor_read() can therefore be misrouted into adxl345_decode_stream(), which reads a 12-byte struct adxl345_fifo_data header out of a buffer sized for the 10-byte struct adxl345_sample and then iterates on an out-of-bounds fifo_byte_count.

Clear is_fifo explicitly, as adxl362, adxl367 and adxl372 already do.

Assisted-by: Claude:claude-opus-5