### PR TITLE
doc: build the coverage Doxygen run with XML output only

### DIFF
--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -114,4 +114,4 @@ jobs:
       - name: Check for new top-level Doxygen groups
         if: ${{ !cancelled() }}
         run: |
-          python3 scripts/ci/doxygen_toplevel_groups.py --xml-dir doc/_build/doxygen/xml
+          python3 scripts/ci/doxygen_toplevel_groups.py --xml-dir doc/_build/doxygen-xml/xml

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -191,12 +191,44 @@ set_target_properties(
 )
 
 #-------------------------------------------------------------------------------
+# Doxygen (XML only)
+#
+# Same configuration as 'doxygen' -- overlays included, since the generated
+# Doxyfile is pulled in with @INCLUDE -- with the HTML and the tag file turned
+# off. Writes to its own directory so that it cannot race with 'doxygen'.
+
+set(DOXY_XML_OUT ${CMAKE_CURRENT_BINARY_DIR}/doxygen-xml)
+set(DOXYFILE_XML_OUT ${CMAKE_CURRENT_BINARY_DIR}/zephyr-xml.doxyfile)
+
+file(WRITE ${DOXYFILE_XML_OUT}
+"@INCLUDE = ${DOXYFILE_OUT}
+OUTPUT_DIRECTORY = ${DOXY_XML_OUT}
+GENERATE_HTML = NO
+GENERATE_TAGFILE =
+")
+
+add_custom_target(
+  doxygen-xml
+  COMMAND
+    ${DOXYGEN_EXECUTABLE} ${DOXYFILE_XML_OUT}
+  COMMENT "Running Doxygen (XML only)..."
+)
+
+add_dependencies(doxygen-xml requirements)
+
+set_target_properties(
+  doxygen-xml
+  PROPERTIES
+    ADDITIONAL_CLEAN_FILES "${DOXY_XML_OUT}"
+)
+
+#-------------------------------------------------------------------------------
 # Doxygen Coverage
 
 add_custom_target(
   doxygen-coverage
   COMMAND ${PYTHON_EXECUTABLE} -m coverxygen
-    --xml-dir ${CMAKE_CURRENT_BINARY_DIR}/doxygen/xml/
+    --xml-dir ${DOXY_XML_OUT}/xml/
     --src-dir ${ZEPHYR_BASE}/include/
     --output ${CMAKE_CURRENT_BINARY_DIR}/doc-coverage.info
   COMMAND lcov
@@ -207,18 +239,18 @@ add_custom_target(
     --no-branch-coverage
     ${CMAKE_CURRENT_BINARY_DIR}/new.info
     -o ${CMAKE_CURRENT_BINARY_DIR}/coverage-report
-  DEPENDS doxygen
+  DEPENDS doxygen-xml
   COMMENT "Generating Doxygen coverage info and HTML report..."
 )
 
 add_custom_target(
   doxygen-coverage-json
   COMMAND ${PYTHON_EXECUTABLE} -m coverxygen
-    --xml-dir ${CMAKE_CURRENT_BINARY_DIR}/doxygen/xml/
+    --xml-dir ${DOXY_XML_OUT}/xml/
     --src-dir ${ZEPHYR_BASE}/include/
     --format json-v3
     --output ${CMAKE_CURRENT_BINARY_DIR}/doc-coverage.json
-  DEPENDS doxygen
+  DEPENDS doxygen-xml
   COMMENT "Generating Doxygen coverage info in JSON format..."
 )
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -30,7 +30,7 @@ SKIP_TAGS = \
 # ------------------------------------------------------------------------------
 # Documentation targets
 
-.PHONY: configure clean html html-fast html-minimal html-live html-live-fast latex pdf doxygen doxygen-coverage doxygen-coverage-json
+.PHONY: configure clean html html-fast html-minimal html-live html-live-fast latex pdf doxygen doxygen-xml doxygen-coverage doxygen-coverage-json
 
 html-fast:
 	${MAKE} html DT_TURBO_MODE=1 HW_FEATURES_TURBO_MODE=1
@@ -49,7 +49,7 @@ doxygen-coverage doxygen-coverage-json:
 	${MAKE} configure DOXYGEN_FORCE_SINGLE_THREAD=1
 	cmake --build ${BUILDDIR} --target $@
 
-html html-live latex pdf linkcheck doxygen: configure
+html html-live latex pdf linkcheck doxygen doxygen-xml: configure
 	cmake --build ${BUILDDIR} --target $@
 
 configure:

--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -350,6 +350,9 @@ much faster than building the full documentation set::
 
 The output can be found in ``_build/doxygen/html``.
 
+The ``doxygen-xml`` target builds the same documentation with only the XML output enabled, in
+``_build/doxygen-xml/xml``.
+
 In the regular documentation build, references made from Doxygen comments to the main
 documentation (e.g. ``@kconfig{}``, ``@dtcompatible{}`` or ``@rstref{}``, see
 :ref:`doxygen_sphinx_xrefs`) are automatically resolved into hyperlinks. In a standalone Doxygen


### PR DESCRIPTION
The documentation coverage targets and the top-level group check only read the Doxygen XML tree. Both went through the `doxygen` target, which also renders the complete API HTML and writes the tag file — so every run paid for output that nothing then looked at. The Doxygen Checks workflow pays it *twice* per pull request, once for the branch and once for its base, and configures the build with `DOXYGEN_FORCE_SINGLE_THREAD=1` on top of that.

This adds a `doxygen-xml` target that pulls in the generated Doxyfile with `@INCLUDE` and switches off the outputs that are not needed, then points `doxygen-coverage` and `doxygen-coverage-json` at it.

### Measurements (full tree, Doxygen 1.17.0, single-threaded as CI runs it)

| | Time | Output |
|---|---|---|
| Before | 34s | 642M |
| After | 20s | 221M |

**−41% time, −66% disk, and the Doxygen Checks job pays it twice per PR.**

The generated XML is byte-for-byte identical to the full run apart from `xml/Doxyfile.xml`, which is Doxygen's dump of its own configuration and which neither `coverxygen` nor `doxygen_toplevel_groups.py` reads.

Also in here: `--xml-dir` updated in `doxygen-checks.yml`, and `doxygen-xml` wired into `doc/Makefile` so it is reachable as `make doxygen-xml`.