### PR TITLE
doc: doxygen: drop dead output and fix mis-set options

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -478,7 +478,7 @@ BUILTIN_STL_SUPPORT    = NO
 # enable parsing support.
 # The default value is: NO.
 
-CPP_CLI_SUPPORT        = YES
+CPP_CLI_SUPPORT        = NO
 
 # Set the SIP_SUPPORT tag to YES if your project consists of sip (see:
 # https://www.riverbankcomputing.com/software) sources only. Doxygen will parse
@@ -1603,7 +1603,7 @@ HTML_INDEX_NUM_ENTRIES = 100
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_DOCSET        = YES
+GENERATE_DOCSET        = NO
 
 # This tag determines the name of the docset feed. A documentation feed provides
 # an umbrella under which multiple documentation sets from a single provider
@@ -1669,7 +1669,7 @@ GENERATE_HTMLHELP      = NO
 # written to the html output directory.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_FILE               = NO
+CHM_FILE               =
 
 # The HHC_LOCATION tag can be used to specify the location (absolute path
 # including file name) of the HTML help compiler (hhc.exe). If non-empty,
@@ -2406,7 +2406,7 @@ XML_OUTPUT             = xml
 # The default value is: YES.
 # This tag requires that the tag GENERATE_XML is set to YES.
 
-XML_PROGRAMLISTING     = YES
+XML_PROGRAMLISTING     = NO
 
 # If the XML_NS_MEMB_FILE_SCOPE tag is set to YES, Doxygen will include
 # namespace members in file scope as well, matching the HTML output.
@@ -3039,15 +3039,6 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
-# files in one run (i.e. multiple -o and -T options on the command line). This
-# makes dot run faster, but since only newer versions of dot (>1.8.10) support
-# this, this feature is disabled by default.
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_MULTI_TARGETS      = NO
 
 # If the GENERATE_LEGEND tag is set to YES Doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated


### PR DESCRIPTION
A handful of things in `zephyr.doxyfile.in` that are either wrong or generating output nobody reads. Checked against Doxygen 1.17.0, the version CI pins.

The interesting one is `CPP_CLI_SUPPORT`. It was on, which puts Doxygen in Microsoft C++/CLI mode, and `internal` happens to be an access specifier there — so the `internal` bitfield of `struct dac_channel_cfg` has been quietly missing from our API docs. Turning it off brings it back:

    CPP_CLI_SUPPORT=YES -> dac_channel_cfg: channel_id resolution buffered
    CPP_CLI_SUPPORT=NO  -> dac_channel_cfg: channel_id resolution buffered internal

I diffed the full symbol set extracted from the XML before and after to be sure: that member is the only difference in the entire tree.

The rest:

- **`XML_PROGRAMLISTING` off.** Nothing reads the source dump — doxybridge, api_overview, coverxygen and `doxygen_toplevel_groups.py` all just want symbols. Saves 38% of the XML (221M → 138M) and halves the time doxmlparser spends walking it (72s → 32s), which Sphinx pays on every build. `@code` blocks in doc comments live in `<detaileddescription>` and are untouched.
- **`GENERATE_DOCSET` off.** We don't ship an Xcode docset, but it was adding `Info.plist`, `Makefile`, `Nodes.xml` and `Tokens.xml` — 51M — to the published HTML, with every `DOCSET_*` value still at its placeholder (`org.doxygen.Project`, `Publisher`, literally `FeedUrl`).
- **`DOT_MULTI_TARGETS` removed.** Gone since Doxygen 1.16, so it printed an obsolete-tag warning on every run.
- **`CHM_FILE` cleared.** It takes a filename, so `NO` never meant anything.

Two I deliberately left alone. `ABBREVIATE_BRIEF = YES` is a list of prefixes to strip, not a boolean, so today it strips the literal string "YES" — blanking it would switch on Doxygen's default list and reword briefs across the whole API, which needs a decision rather than a drive-by fix. And `WARN_IF_UNDOCUMENTED` / `WARN_IF_UNDOC_ENUM_VAL` are both no-ops under `EXTRACT_ALL` (Doxygen says so in the comments right above them) — misleading, but the coverxygen check covers that ground, so I didn't touch them.