### PR TITLE
drivers: i3c: dw: fix PM device action callback name

### DIFF
--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2987,7 +2987,7 @@ static DEVICE_API(i3c, dw_i3c_api) = {
 				DT_INST_PROP_OR(n, primary_controller_da, 0x00),                   \
 			.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(n),))                  \
 		I3C_DW_PINCTRL_INIT(n)};                                                           \
-	PM_DEVICE_DT_INST_DEFINE(n, dw_i3c_pm_action);                                             \
+	PM_DEVICE_DT_INST_DEFINE(n, dw_i3c_pm_ctrl);                                               \
 	DEVICE_DT_INST_DEFINE(n, dw_i3c_init, PM_DEVICE_DT_INST_GET(n), &dw_i3c_data_##n,          \
 			      &dw_i3c_cfg_##n, POST_KERNEL, CONFIG_I3C_CONTROLLER_INIT_PRIORITY,   \
 			      &dw_i3c_api);
@@ -3070,7 +3070,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_HAS_MCHP_MEC_I3C),
 				DT_INST_PROP_OR(n, primary_controller_da, 0x00),                 \
 			.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(n),))                \
 		I3C_DW_PINCTRL_INIT(n)};                                                         \
-	PM_DEVICE_DT_INST_DEFINE(n, dw_i3c_pm_action);                                             \
+	PM_DEVICE_DT_INST_DEFINE(n, dw_i3c_pm_ctrl);                                               \
 	DEVICE_DT_INST_DEFINE(n, dw_i3c_init, PM_DEVICE_DT_INST_GET(n), &xec_i3c_data_##n,         \
 			      &xec_i3c_cfg_##n, POST_KERNEL, CONFIG_I3C_CONTROLLER_INIT_PRIORITY,  \
 			      &dw_i3c_api);

--- a/tests/drivers/build_all/i3c/tests.yaml
+++ b/tests/drivers/build_all/i3c/tests.yaml
@@ -46,6 +46,13 @@ tests:
       - nucleo_u385rg_q
     tags: i3c_cdns i3c_dw
     extra_args: "CONFIG_I3C_TARGET_ROLE_ONLY=y CONFIG_I3C_USE_IBI=n"
+  drivers.i3c.build.dual_role_pm:
+    # will cover drivers without in-tree boards
+    platform_allow:
+      - qemu_cortex_m3
+      - nucleo_u385rg_q
+    tags: i3c_cdns i3c_dw
+    extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y CONFIG_PM_DEVICE=y"
   drivers.i3c.build.stm32:
     platform_allow:
       - nucleo_c5a3zg


### PR DESCRIPTION
PM_DEVICE_DT_INST_DEFINE() references dw_i3c_pm_action, but the callback is named dw_i3c_pm_ctrl. The symbol does not exist anywhere in the tree, so building with CONFIG_PM_DEVICE=y fails with 'dw_i3c_pm_action' undeclared. Reference the actual name at both instantiation sites, snps,designware-i3c and microchip,xec-i3c.

No scenario enabled CONFIG_PM_DEVICE, so the i3c drivers' PM hooks were never compiled in CI. Add a dual role scenario with CONFIG_PM_DEVICE=y, covering both cdns,i3c and snps,designware-i3c through the existing qemu_cortex_m3 overlay.