### PR TITLE
drivers: i3c: dw: honor i2c-scl-hz and add i2c_configure()

### DIFF
--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -1739,7 +1739,7 @@ static int dw_i3c_init_scl_timing(const struct device *dev, struct i3c_config_co
 	hcnt = DIV_ROUND_UP(I3C_BUS_THIGH_MAX_NS * (uint64_t)core_rate, I3C_PERIOD_NS) - 1;
 	hcnt = CLAMP(hcnt, SCL_I3C_TIMING_CNT_MIN, SCL_I3C_TIMING_CNT_MAX);
 
-	lcnt = DIV_ROUND_UP(core_rate, data->common.ctrl_config.scl.i3c) - hcnt;
+	lcnt = DIV_ROUND_UP(core_rate, ctrl_cfg->scl.i3c) - hcnt;
 	lcnt = CLAMP(lcnt, SCL_I3C_TIMING_CNT_MIN, SCL_I3C_TIMING_CNT_MAX);
 
 	scl_timing = SCL_I3C_TIMING_HCNT(hcnt) | SCL_I3C_TIMING_LCNT(lcnt);

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -1192,6 +1192,50 @@ static int dw_i3c_i2c_api_transfer(const struct device *dev, struct i2c_msg *msg
 
 	return dw_i3c_i2c_transfer(dev, i2c_dev, msgs, num_msgs);
 }
+
+static int dw_i3c_init_scl_timing(const struct device *dev, struct i3c_config_controller *ctrl_cfg);
+
+/**
+ * @brief Configure I2C operation of a host controller.
+ *
+ * @see i2c_configure
+ *
+ * @param dev        Pointer to device driver instance.
+ * @param dev_config @see i2c_configure
+ *
+ * @return @see i2c_configure
+ */
+static int dw_i3c_i2c_api_configure(const struct device *dev, uint32_t dev_config)
+{
+	struct dw_i3c_data *data = dev->data;
+	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
+	uint32_t i2c_scl_hz;
+	int ret;
+
+	/* Note: this only affects devices configured for FM in the device tree. */
+	switch (I2C_SPEED_GET(dev_config)) {
+	case I2C_SPEED_STANDARD:
+		i2c_scl_hz = 100000;
+		break;
+	case I2C_SPEED_FAST:
+		i2c_scl_hz = 400000;
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		i2c_scl_hz = 1000000;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->mt, K_FOREVER);
+
+	ctrl_config->scl.i2c = i2c_scl_hz;
+	ret = dw_i3c_init_scl_timing(dev, ctrl_config);
+
+	k_mutex_unlock(&data->mt);
+
+	return ret;
+}
 #endif /* CONFIG_I3C_CONTROLLER */
 #ifdef CONFIG_I3C_USE_IBI
 #ifdef CONFIG_I3C_CONTROLLER
@@ -2918,6 +2962,7 @@ static int dw_i3c_pm_ctrl(const struct device *dev, enum pm_device_action action
 
 static DEVICE_API(i3c, dw_i3c_api) = {
 #ifdef CONFIG_I3C_CONTROLLER
+	.i2c_api.configure = dw_i3c_i2c_api_configure,
 	.i2c_api.transfer = dw_i3c_i2c_api_transfer,
 	.i2c_api.recover_bus = dw_i3c_recover_bus,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2418,6 +2418,8 @@ static int dw_i3c_configure(const struct device *dev, enum i3c_config_type type,
 	const struct dw_i3c_config *dev_config = dev->config;
 #endif /* CONFIG_I3C_TARGET */
 
+	__ASSERT((config != NULL), "Configuration should not be NULL");
+
 	if (type == I3C_CONFIG_CONTROLLER) {
 #ifdef CONFIG_I3C_CONTROLLER
 		ret = dw_i3c_init_scl_timing(dev, config);

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -284,6 +284,7 @@ LOG_MODULE_REGISTER(i3c_dw, CONFIG_I3C_DW_LOG_LEVEL);
 #define SCL_I2C_FM_TIMING         0xbc
 #define SCL_I2C_FM_TIMING_HCNT(x) (((x) << 16) & GENMASK(31, 16))
 #define SCL_I2C_FM_TIMING_LCNT(x) ((x) & GENMASK(15, 0))
+#define SCL_I2C_FM_TIMING_CNT_MAX 0xffff
 
 #define SCL_I2C_FMP_TIMING         0xc0
 #define SCL_I2C_FMP_TIMING_HCNT(x) (((x) << 16) & GENMASK(23, 16))
@@ -350,6 +351,7 @@ LOG_MODULE_REGISTER(i3c_dw, CONFIG_I3C_DW_LOG_LEVEL);
 #define I3C_BUS_SDR2_SCL_RATE       6000000
 #define I3C_BUS_SDR3_SCL_RATE       4000000
 #define I3C_BUS_SDR4_SCL_RATE       2000000
+#define I3C_BUS_I2C_SM_TLOW_MIN_NS  4700
 #define I3C_BUS_I2C_FM_TLOW_MIN_NS  1300
 #define I3C_BUS_I2C_FMP_TLOW_MIN_NS 500
 #define I3C_BUS_THIGH_MAX_NS        41
@@ -361,6 +363,7 @@ LOG_MODULE_REGISTER(i3c_dw, CONFIG_I3C_DW_LOG_LEVEL);
 #define I3C_BUS_TYP_I3C_SCL_RATE     12500000
 #define I3C_BUS_I2C_FM_PLUS_SCL_RATE 1000000
 #define I3C_BUS_I2C_FM_SCL_RATE      400000
+#define I3C_BUS_I2C_SM_SCL_RATE      100000
 #define I3C_BUS_TLOW_OD_MIN_NS       200
 
 #define I3C_HOT_JOIN_ADDR 0x02
@@ -1708,7 +1711,7 @@ static int dw_i3c_init_scl_timing(const struct device *dev, struct i3c_config_co
 	struct dw_i3c_data *data = dev->data;
 	uint32_t core_rate, scl_timing;
 #ifdef CONFIG_I3C_CONTROLLER
-	uint32_t hcnt, lcnt, fmlcnt, fmplcnt, free_cnt;
+	uint32_t hcnt, lcnt, fmlcnt, fmplcnt, free_cnt, i2c_scl_hz, tlow_min_ns;
 #endif /* CONFIG_I3C_CONTROLLER */
 
 	if (clock_control_get_rate(config->clock, config->clock_subsys, &core_rate) != 0) {
@@ -1763,8 +1766,24 @@ static int dw_i3c_init_scl_timing(const struct device *dev, struct i3c_config_co
 	sys_write32(scl_timing, config->regs + SCL_I2C_FMP_TIMING);
 
 	/* I2C FM */
-	fmlcnt = DIV_ROUND_UP(I3C_BUS_I2C_FM_TLOW_MIN_NS * (uint64_t)core_rate, I3C_PERIOD_NS);
-	hcnt = DIV_ROUND_UP(core_rate, I3C_BUS_I2C_FM_SCL_RATE) - fmlcnt;
+	i2c_scl_hz = ctrl_cfg->scl.i2c;
+	if (i2c_scl_hz == 0) {
+		/* Not set in devicetree: derive from the LVRs of the attached I2C devices. */
+		i2c_scl_hz = i3c_any_i2c_fast_mode(&config->common.dev_list)
+				     ? I3C_BUS_I2C_FM_SCL_RATE
+				     : I3C_BUS_I2C_FM_PLUS_SCL_RATE;
+	}
+	i2c_scl_hz = MIN(i2c_scl_hz, I3C_BUS_I2C_FM_SCL_RATE);
+
+	if (i2c_scl_hz <= I3C_BUS_I2C_SM_SCL_RATE) {
+		tlow_min_ns = I3C_BUS_I2C_SM_TLOW_MIN_NS;
+	} else {
+		tlow_min_ns = I3C_BUS_I2C_FM_TLOW_MIN_NS;
+	}
+
+	fmlcnt = DIV_ROUND_UP(tlow_min_ns * (uint64_t)core_rate, I3C_PERIOD_NS);
+	fmlcnt = MIN(fmlcnt, SCL_I2C_FM_TIMING_CNT_MAX);
+	hcnt = MIN(DIV_ROUND_UP(core_rate, i2c_scl_hz) - fmlcnt, SCL_I2C_FM_TIMING_CNT_MAX);
 	scl_timing = SCL_I2C_FM_TIMING_HCNT(hcnt) | SCL_I2C_FM_TIMING_LCNT(fmlcnt);
 	sys_write32(scl_timing, config->regs + SCL_I2C_FM_TIMING);
 


### PR DESCRIPTION
The driver provided no .i2c_api.configure hook, so the I2C bus speed could only be set from devicetree and i2c_configure() faulted on the unset function pointer. Map the standard speed selectors onto ctrl_config.scl.i2c and reprogram the SCL timing, following cdns_i3c_i2c_api_configure(). Speeds above fast mode plus are rejected; the IP has no timing register beyond SCL_I2C_FMP_TIMING.

The i2c-scl-hz property was parsed into ctrl_config.scl.i2c and never read; SCL_I2C_FM_TIMING was always computed for the fixed I3C_BUS_I2C_FM_SCL_RATE. Derive it from the configured rate, holding tLOW at the spec floor for the mode that rate falls in, 4.7us at or below 100 kHz and 1.3us above. Fall back to the attached devices' LVRs when unset, and clamp HCNT and LCNT to their 16-bit fields, which the register macros otherwise mask silently.

This PR also fixes a few bugs in the I2C/I3C configuration code.