### PR TITLE
tests: interrupt: honor NO_TRIGGER_FROM_SW in offload test

### DIFF
--- a/tests/arch/common/interrupt/src/interrupt_offload.c
+++ b/tests/arch/common/interrupt/src/interrupt_offload.c
@@ -131,7 +131,11 @@ static void trigger_offload_interrupt(const bool real_irq, void *work)
 	irq_param.work = work;
 
 	if (real_irq) {
+#ifdef NO_TRIGGER_FROM_SW
+		ztest_test_skip();
+#else
 		trigger_irq(vector_num);
+#endif
 	} else {
 		irq_offload((irq_offload_routine_t)&isr_handler, &irq_param);
 	}


### PR DESCRIPTION
This PR is a prerequisite for the initial m68k port discussed in RFC #114672.

## Summary

The m68k port supports `irq_offload()` and dynamic interrupts, but neither the CPU nor QEMU `virt` can raise an arbitrary hardware IRQ from software.

Zephyr already represents this capability with `NO_TRIGGER_FROM_SW`. However, `interrupt_offload.c` references `trigger_irq()` unconditionally, so the suite fails to compile when that function is intentionally unavailable.

## Why

`irq_offload()` support and software-triggerable hardware IRQs are independent capabilities. Excluding m68k would discard valid offload coverage, while providing a dummy `trigger_irq()` would claim unsupported hardware behavior.

The correct solution is to honor the existing architecture-independent capability marker.

## Change and impact

Skip only the real-IRQ test when `NO_TRIGGER_FROM_SW` is defined. The `irq_offload()` tests remain enabled.

This changes no production code, API, or ABI. Architectures providing `trigger_irq()` retain their existing behavior and coverage.

## Validation

The exact change was included in the [tested v3 integration candidate](https://github.com/dmvo/zephyr/releases/tag/m68k-rfc-tested-v3).

The full run selected all four existing `tests/arch/common/interrupt` configurations for both `qemu_m68k_m68000` and `qemu_m68k_m68010`: **8/8 configurations passed**, with **46 passed test cases, 24 expected skips, and 0 retries**.

As intended, the test requiring a software-triggered real IRQ was skipped under `NO_TRIGGER_FROM_SW`, while the `irq_offload()` test cases remained enabled and passed in every configuration.
