### PR TITLE
drivers: ethernet: w6300: fix TX corruption and permanent interrupt loss

### DIFF
--- a/drivers/ethernet/eth_w6300.c
+++ b/drivers/ethernet/eth_w6300.c
@@ -225,6 +225,7 @@ static int w6300_tx(const struct device *dev, struct net_pkt *pkt)
 {
 	struct w6300_runtime *ctx = dev->data;
 	uint16_t len = (uint16_t)net_pkt_get_len(pkt);
+	k_timepoint_t end = sys_timepoint_calc(K_MSEC(W6300_CMD_TIMEOUT_MS));
 	uint16_t offset;
 	uint8_t tmp[2];
 	int ret;
@@ -234,6 +235,24 @@ static int w6300_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 
 	k_sem_reset(&ctx->tx_sem);
+
+	while (true) {
+		ret = w6300_spi_read(dev, W6300_BSB_SOCK(0), W6300_Sn_TX_FSR,
+				     tmp, 2);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (sys_get_be16(tmp) >= len) {
+			break;
+		}
+
+		if (sys_timepoint_expired(end)) {
+			return -EIO;
+		}
+
+		k_busy_wait(W6300_CMD_POLL_US);
+	}
 
 	ret = w6300_spi_read(dev, W6300_BSB_SOCK(0), W6300_Sn_TX_WR, tmp, 2);
 	if (ret < 0) {

--- a/drivers/ethernet/eth_w6300.c
+++ b/drivers/ethernet/eth_w6300.c
@@ -483,7 +483,7 @@ static void w6300_thread(void *p1, void *p2, void *p3)
 			w6300_update_link_status(dev);
 		}
 
-		if (res == 0 && ctx->state.is_up) {
+		if (ctx->state.is_up) {
 			w6300_handle_interrupts(dev, &config->interrupt);
 		}
 	}


### PR DESCRIPTION
## Summary

Two fixes for the WIZnet W6300 ethernet driver, both for permanent
lock-ups observed on real hardware under sustained TCP traffic:

1. **TX: wait for `Sn_TX_FSR` free space before writing.**
   `w6300_tx()` resets `tx_sem` and takes it after issuing SEND. If the
   interrupt thread processes the *previous* send's SENDOK between the
   reset and the take, the take completes for the wrong send, and the
   next `w6300_tx()` rewrites the TX buffer and issues SEND while the
   chip is still transmitting. The chip's TX state is corrupted, SENDOK
   never fires again, and the board stops transmitting entirely
   (including ARP replies) until a power cycle. The sibling `eth_w5500`
   driver avoids the overlap with credit semantics (`tx_sem` initialized
   to 1, never reset); gating on the chip-reported free size also covers
   the semaphore-timeout path (the frame is already committed when the
   10 ms take times out, so its late SENDOK becomes a stale credit).

2. **RX: service interrupts from the monitor path.**
   The INT line is edge-triggered (`GPIO_INT_EDGE_FALLING`) and
   `w6300_handle_interrupts()` bails out when an `Sn_IR` read fails
   while INT may still be asserted. No new edge ever fires in that
   state, and the monitor timeout path only updates the link status, so
   interrupt handling stays disabled permanently. Running the handler on
   the monitor period as well is a no-op while INT is inactive and
   recovers a missed edge within `CONFIG_ETH_W6300_MONITOR_PERIOD`.
   The W5500 driver gained the same kind of protection in commit
   d61128427155 ("drivers: eth_w5500: Check W5500 int pin after
   processing interrupt").

## Reproduction / testing

Hardware: WIZnet W6300-EVB-Pico2 (RP2350), W6300 on the board's default
bit-banged SPI. Test application: a TCP server receiving a bulk upload
of 96 x 4000-byte frames with a 1-byte application-level ack per frame
(so the board TXes continuously while RXing).

A/B on the same board, same application, only the driver differing:

| driver | SPI clock | result |
| --- | --- | --- |
| unmodified | 500 kHz (board DT default) | dies on 1st upload (frame 10/96); unreachable until power cycle |
| unmodified | 8 MHz | dies on 1st upload (frame 14/96), again on 2nd (frame 3/96) after power cycle; unreachable until power cycle each time |
| with both fixes | 8 MHz | 10/10 consecutive uploads completed, no drops |

The failure signature without the fixes is always the same: mid-upload
the connection resets, and afterwards the board no longer answers ARP
until power-cycled - consistent with the chip's TX path being wedged
while RX still works.

## Notes

- No performance impact on the fast path: the FSR gate is one extra
  6-byte SPI read per packet when the buffer is free, and waiting when
  it is not free is required by the datasheet anyway (SENDOK before the
  next SEND). The monitor-path interrupt check is a single GPIO read
  per period when idle.
- Related: #115626 addresses the same family of INTn/TX robustness
  issues on the W5500 (this PR does not touch that driver).
- If #113315 (wiznet common code restructuring, moves this file to
  `drivers/ethernet/wiznet/`) merges first, happy to rebase.