### PR TITLE
drivers: gpio: cyw43 driver should use two parameters in 'iovar' call

### DIFF
--- a/drivers/gpio/gpio_cyw43.c
+++ b/drivers/gpio/gpio_cyw43.c
@@ -19,6 +19,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <whd.h>
+#include <whd_endian.h>
+#include <whd_types_int.h>
 
 LOG_MODULE_REGISTER(gpio_cyw43, CONFIG_GPIO_LOG_LEVEL);
 
@@ -27,9 +29,6 @@ LOG_MODULE_REGISTER(gpio_cyw43, CONFIG_GPIO_LOG_LEVEL);
 /* Provided by the AIROC WiFi driver */
 extern whd_interface_t airoc_wifi_get_whd_interface(void);
 
-/* WHD internal API for setting iovar values */
-extern uint32_t whd_wifi_set_iovar_value(whd_interface_t ifp, const char *iovar, uint32_t value);
-
 struct gpio_cyw43_config {
 	struct gpio_driver_config common;
 };
@@ -37,13 +36,19 @@ struct gpio_cyw43_config {
 struct gpio_cyw43_data {
 	struct gpio_driver_data common;
 	struct k_mutex lock;
+	uint32_t pin_mask;
 	uint32_t pin_state;
 };
 
-static int gpio_cyw43_write_state(const struct device *dev)
+static int gpio_cyw43_port_set_whd(const struct device *dev, gpio_port_pins_t mask,
+				   gpio_port_value_t value)
 {
 	struct gpio_cyw43_data *data = dev->data;
 	whd_interface_t ifp = airoc_wifi_get_whd_interface();
+
+	gpio_port_pins_t real_mask;
+	gpio_port_value_t real_value;
+	uint32_t buffer[2];
 	uint32_t ret;
 
 	if (ifp == NULL) {
@@ -51,16 +56,37 @@ static int gpio_cyw43_write_state(const struct device *dev)
 		return 0;
 	}
 
+	/* Make data change atomic */
 	k_mutex_lock(&data->lock, K_FOREVER);
-	ret = whd_wifi_set_iovar_value(ifp, "gpioout", data->pin_state);
+
+	real_mask = data->pin_mask & mask;
+	real_value = real_mask & value;
+
+	data->pin_state = (data->pin_state & ~real_mask) | real_value;
+
+	buffer[0] = htod32(real_mask);
+	buffer[1] = htod32(real_value);
+
+	ret = whd_wifi_set_iovar_buffer(ifp, "gpioout", buffer, (uint16_t)sizeof(buffer));
 	k_mutex_unlock(&data->lock);
 
+	if (ret != 0) {
+		LOG_ERR("Failed setting GPIO: %u", ret);
+	}
+
 	return (ret == 0) ? 0 : -EIO;
+}
+
+static int gpio_cyw43_port_set_masked_raw(const struct device *dev, gpio_port_pins_t mask,
+					  gpio_port_value_t value)
+{
+	return gpio_cyw43_port_set_whd(dev, mask, value);
 }
 
 static int gpio_cyw43_configure(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	struct gpio_cyw43_data *data = dev->data;
+	int res;
 
 	if (pin >= CYW43_GPIO_PINS) {
 		return -EINVAL;
@@ -78,13 +104,20 @@ static int gpio_cyw43_configure(const struct device *dev, gpio_pin_t pin, gpio_f
 		return -ENOTSUP;
 	}
 
+	/* Make data change atomic */
+	k_mutex_lock(&data->lock, K_FOREVER);
+	data->pin_mask |= BIT(pin);
+
 	if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0U) {
 		data->pin_state |= BIT(pin);
 	} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0U) {
 		data->pin_state &= ~BIT(pin);
 	}
 
-	return gpio_cyw43_write_state(dev);
+	res = gpio_cyw43_port_set_whd(dev, data->pin_mask, data->pin_state);
+	k_mutex_unlock(&data->lock);
+
+	return res;
 }
 
 static int gpio_cyw43_port_get_raw(const struct device *dev, uint32_t *value)
@@ -95,31 +128,29 @@ static int gpio_cyw43_port_get_raw(const struct device *dev, uint32_t *value)
 	return 0;
 }
 
-static int gpio_cyw43_port_set_masked_raw(const struct device *dev, gpio_port_pins_t mask,
-					  gpio_port_value_t value)
-{
-	struct gpio_cyw43_data *data = dev->data;
-
-	data->pin_state = (data->pin_state & ~mask) | (value & mask);
-	return gpio_cyw43_write_state(dev);
-}
-
 static int gpio_cyw43_port_set_bits_raw(const struct device *dev, gpio_port_pins_t pins)
 {
-	return gpio_cyw43_port_set_masked_raw(dev, pins, pins);
+	return gpio_cyw43_port_set_whd(dev, pins, pins);
 }
 
 static int gpio_cyw43_port_clear_bits_raw(const struct device *dev, gpio_port_pins_t pins)
 {
-	return gpio_cyw43_port_set_masked_raw(dev, pins, 0);
+	return gpio_cyw43_port_set_whd(dev, pins, 0);
 }
 
 static int gpio_cyw43_port_toggle_bits(const struct device *dev, gpio_port_pins_t pins)
 {
 	struct gpio_cyw43_data *data = dev->data;
+	gpio_port_pins_t new_value;
+	int res;
 
-	data->pin_state ^= pins;
-	return gpio_cyw43_write_state(dev);
+	/* Make data change atomic */
+	k_mutex_lock(&data->lock, K_FOREVER);
+	new_value = data->pin_state ^ (data->pin_mask & pins);
+	res = gpio_cyw43_port_set_whd(dev, pins, new_value);
+	k_mutex_unlock(&data->lock);
+
+	return res;
 }
 
 static DEVICE_API(gpio, gpio_cyw43_api) = {


### PR DESCRIPTION
#### Summary ####
The changes in this PR try to address issue #117115.

The CYW43439 firmware expects two parameters when the GPIO outputs are adjusted. This new code provides them by using the function 'whd_wifi_set_iovar_buffer()' and passing two 32-bit entries: The 'mask' and the 'state'.

Additionally, the lock is used to not only serialize the call to the WHD API function, but also tries to protect the status value in the driver's private data structure from race conditions.

#### Changes ####
- Add `pin_mask` to `gpio_cyw43_data` to passed to WHD function;
- Set `pin_mask` in `gpio_cyw43_configure()` function;
- Add function `gpio_cyw43_port_set_whd()` function accepting mask and pin values. It uses the function  `whd_wifi_set_iovar_buffer()` to set the GPIO pins of the chip;
- Call this new function from all driver functions, and use the lock to protect the call and any changes to `pin_state` from race conditions;
- Use headers `whd_endian.h` and `whd_types_int.h` to provide needed prototypes;

#### Tests ####
- Compiled for Pico2-W and flashed to device using the sample app `samples/boards/raspberrypi/pico_w_wifi_led`;
- Checked for correct LED behavior as discussed in issue;
- Confirmed compliance with `./scripts/ci/check_compliance.py -c HEAD...main`: Zero errors reported;
