### PR TITLE
boards: nordic: nrf93m1dk: add missing `supported` tags

### DIFF
--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp.yaml
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp.yaml
@@ -8,7 +8,6 @@ arch: arm
 toolchain:
   - gnuarmemb
   - zephyr
-sysbuild: true
 ram: 256
 flash: 712
 supported:
@@ -22,3 +21,7 @@ supported:
   - spi
   - watchdog
   - i2s
+  - netif:modem
+  - ble
+vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_ns.yaml
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp_ns.yaml
@@ -19,5 +19,7 @@ supported:
   - watchdog
   - adc
   - i2s
+  - netif:modem
+  - ble
 vendor: nordic
 sysbuild: true


### PR DESCRIPTION
Add missing tags from the board for twister. `netif:modem` matches the nRF91 DK boards, and the nRF54L15 SoC supports Bluetooth.