### PR TITLE
tests: bsim: run_parallel: fix `unbound variable`

### DIFF
--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -64,6 +64,8 @@ tmp_res_file=tmp.xml
 
 if [[ -v BOARD ]]; then
 	export FAILURE_EXTRA_INFO=" on ${BOARD}"
+else
+  export FAILURE_EXTRA_INFO=""
 fi
 
 all_cases_a=( $all_cases )


### PR DESCRIPTION
Fix `run_parallel.sh: line 112: FAILURE_EXTRA_INFO: unbound variable`.

The `set -u` at the top of the file causes failures if an unbound variable is used.