### PR TITLE
[backport v4.4-branch] mgmt: mcumgr: transport: serial: Fix unaligned frame header read

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/serial_util.c
+++ b/subsys/mgmt/mcumgr/transport/src/serial_util.c
@@ -158,7 +158,7 @@ struct net_buf *mcumgr_serial_process_frag(struct mcumgr_serial_rx_ctxt *rx_ctxt
 			return NULL;
 		}
 
-		op = sys_be16_to_cpu(*(uint16_t *)frag);
+		op = sys_get_be16(frag);
 		switch (op) {
 		case MCUMGR_SERIAL_HDR_PKT:
 			net_buf_reset(rx_ctxt->nb);


### PR DESCRIPTION
Manual backport of #116813 to `v4.4-branch`. The automated Backport job on that pull request failed, so this is the hand-made one. The cherry-pick is clean; the commit is unchanged apart from the `(cherry picked from commit ...)` line the pick adds.

What it fixes: `mcumgr_serial_process_frag()` reads the two framing bytes with a cast to `uint16_t *`. The shell transport's net_buf pool strides its rows by 127 bytes, so every other buffer starts on an odd address, and the read is unaligned. ARMv7-M fixes that up in hardware; ARMv8-M Baseline does not, so on a Cortex-M23 an MCUmgr image upload is a HardFault followed by a watchdog reset. Requests that fit one framing line use the first, aligned buffer and keep working, which is why `image state read` succeeds while `image upload` never does.

Verified here by building `samples/subsys/mgmt/mcumgr/smp_svr` with `shell.conf` and `shell-mgmt.conf` for `nrf52840dk/nrf52840` against this branch: the changed translation unit compiles and the image links. The original fix was measured on hardware, a PIC32CM5112GC00100 Cortex-M23, on main.

Fixes #117129
