### PR TITLE
tests: bsim: host: security: cover unreachable security levels

### DIFF
--- a/tests/bsim/bluetooth/host/security/level_enforced/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/security/level_enforced/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS "$ENV{ZEPHYR_BASE}")
+project(bsim_test_security_level_enforced)
+
+add_subdirectory("${ZEPHYR_BASE}/tests/bsim/babblekit" babblekit)
+target_link_libraries(app PRIVATE babblekit)
+
+target_sources(app PRIVATE
+  src/central.c
+  src/common.c
+  src/main.c
+  src/peripheral.c
+)
+
+zephyr_include_directories(
+  "${BSIM_COMPONENTS_PATH}/libUtilv1/src/"
+  "${BSIM_COMPONENTS_PATH}/libPhyComv1/src/"
+)

--- a/tests/bsim/bluetooth/host/security/level_enforced/prj.conf
+++ b/tests/bsim/bluetooth/host/security/level_enforced/prj.conf
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BT=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=y
+
+CONFIG_BT_SMP=y
+
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_MAX_PAIRED=1
+
+CONFIG_ASSERT=y
+CONFIG_LOG=y

--- a/tests/bsim/bluetooth/host/security/level_enforced/src/central.c
+++ b/tests/bsim/bluetooth/host/security/level_enforced/src/central.c
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+#include <zephyr/logging/log.h>
+
+#include "babblekit/testcase.h"
+
+LOG_MODULE_REGISTER(central, LOG_LEVEL_DBG);
+
+/* No bt_conn_auth_cb is registered on either side, which is what leaves both
+ * peers with no input and no output and pins the pairing method to Just Works.
+ */
+void central(void)
+{
+	test_setup();
+	scan_connect_to_first_result();
+	wait_connected();
+
+	/* First round is the peripheral's. Confirming the link reached L2 here
+	 * is what makes the peripheral's own control a two-sided fact.
+	 */
+	expect_observed_elevation(BT_SECURITY_L2);
+
+	wait_disconnected();
+	clear_g_conn();
+
+	/* Second round is the central's. The roles do not share a code path:
+	 * `bt_smp_start_security()` sends a security request as peripheral but a
+	 * pairing request as central, so the guard has to hold on both. Dropping
+	 * the bond first keeps the stored key from answering in its place.
+	 */
+	forget_bonds();
+	forget_security_result();
+
+	scan_connect_to_first_result();
+	wait_connected();
+
+	expect_refused_elevation(BT_SECURITY_L4);
+	expect_refused_elevation(BT_SECURITY_L3);
+	expect_granted_elevation(BT_SECURITY_L2);
+
+	disconnect_and_wait();
+
+	TEST_PASS("Central done");
+}

--- a/tests/bsim/bluetooth/host/security/level_enforced/src/common.c
+++ b/tests/bsim/bluetooth/host/security/level_enforced/src/common.c
@@ -1,0 +1,244 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/logging/log.h>
+
+#include "babblekit/flags.h"
+#include "babblekit/testcase.h"
+
+LOG_MODULE_REGISTER(common, LOG_LEVEL_DBG);
+
+/* Long enough for a security request, a pairing exchange and an encryption
+ * change to have travelled the link, so that a refusal that leaked onto the
+ * link is observed rather than merely outrun.
+ */
+#define SETTLE_TIME K_MSEC(500)
+
+/* All of the test's state lives here and is reached only through the calls
+ * common.h declares, so neither role can read a flag or a reported level
+ * without going through the check that is supposed to interpret it.
+ */
+DEFINE_FLAG_STATIC(flag_is_connected);
+DEFINE_FLAG_STATIC(flag_security_result);
+DEFINE_FLAG_STATIC(flag_pairing_completed);
+
+static struct bt_conn *g_conn;
+
+/* The outcome of the elevation attempt, as reported to the application. */
+static bt_security_t g_reported_level;
+static enum bt_security_err g_reported_err;
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	TEST_ASSERT(g_conn == NULL || conn == g_conn, "Unexpected new connection.");
+
+	if (g_conn == NULL) {
+		g_conn = bt_conn_ref(conn);
+	}
+
+	if (err != 0) {
+		clear_g_conn();
+		return;
+	}
+
+	SET_FLAG(flag_is_connected);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	UNSET_FLAG(flag_is_connected);
+}
+
+/* Both outcomes of an elevation attempt arrive here: a level that was reached,
+ * and an error that says it was not. Recording the level alongside the error is
+ * the whole point of the test, since a host that reports success at a lower
+ * level than the one asked for is the failure being guarded against.
+ */
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
+{
+	LOG_INF("Security changed: level %d, err %d", level, err);
+
+	g_reported_level = level;
+	g_reported_err = err;
+
+	SET_FLAG(flag_security_result);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+	.security_changed = security_changed,
+};
+
+static void pairing_complete(struct bt_conn *conn, bool bonded)
+{
+	LOG_INF("Pairing complete, bonded %d", bonded);
+
+	SET_FLAG(flag_pairing_completed);
+}
+
+static void pairing_failed(struct bt_conn *conn, enum bt_security_err err)
+{
+	LOG_INF("Pairing failed, err %d", err);
+
+	g_reported_err = err;
+
+	SET_FLAG(flag_security_result);
+}
+
+static struct bt_conn_auth_info_cb auth_info_cb = {
+	.pairing_complete = pairing_complete,
+	.pairing_failed = pairing_failed,
+};
+
+void test_setup(void)
+{
+	int err;
+
+	err = bt_enable(NULL);
+	TEST_ASSERT(err == 0, "bt_enable failed (err %d)", err);
+
+	err = bt_conn_auth_info_cb_register(&auth_info_cb);
+	TEST_ASSERT(err == 0, "bt_conn_auth_info_cb_register failed (err %d)", err);
+}
+
+void wait_connected(void)
+{
+	WAIT_FOR_FLAG(flag_is_connected);
+}
+
+void wait_disconnected(void)
+{
+	WAIT_FOR_FLAG_UNSET(flag_is_connected);
+}
+
+void clear_g_conn(void)
+{
+	struct bt_conn *conn = bt_conn_take(&g_conn);
+
+	TEST_ASSERT(conn, "Test error: no g_conn");
+	bt_conn_unref(conn);
+}
+
+void disconnect_and_wait(void)
+{
+	int err;
+
+	err = bt_conn_disconnect(g_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	TEST_ASSERT(err == 0, "bt_conn_disconnect failed (err %d)", err);
+
+	wait_disconnected();
+	clear_g_conn();
+}
+
+/* The second round has to start from an unpaired link. A stored key would let
+ * the host satisfy the request from `smp_keys_check()` and never reach the
+ * reachability guard the round is there to exercise.
+ */
+void forget_bonds(void)
+{
+	int err;
+
+	err = bt_unpair(BT_ID_DEFAULT, NULL);
+	TEST_ASSERT(err == 0, "bt_unpair failed (err %d)", err);
+}
+
+void forget_security_result(void)
+{
+	UNSET_FLAG(flag_security_result);
+	UNSET_FLAG(flag_pairing_completed);
+
+	g_reported_level = BT_SECURITY_L1;
+	g_reported_err = BT_SECURITY_ERR_SUCCESS;
+}
+
+/* An unreachable level must be refused locally: the call fails, nothing is put
+ * on the link, and the link stays where it was. Both roles owe this behaviour,
+ * and each reaches it through a different SMP path.
+ */
+void expect_refused_elevation(bt_security_t level)
+{
+	int err;
+
+	err = bt_conn_set_security(g_conn, level);
+	TEST_ASSERT(err < 0, "Elevation to an unreachable L%d was accepted (err %d)", level, err);
+
+	/* Nothing may have happened on the link as a result of the refusal. */
+	k_sleep(SETTLE_TIME);
+	TEST_ASSERT(!IS_FLAG_SET(flag_security_result),
+		    "Refused elevation to L%d still produced a security result", level);
+	TEST_ASSERT(!IS_FLAG_SET(flag_pairing_completed),
+		    "Refused elevation to L%d still paired", level);
+	TEST_ASSERT(bt_conn_get_security(g_conn) == BT_SECURITY_L1,
+		    "Link reports level %d after a refused elevation to L%d",
+		    bt_conn_get_security(g_conn), level);
+}
+
+/* The control for the refusals above: the same link does pair when asked for a
+ * level the pairing method can actually deliver. Without it the refusals would
+ * also hold on a build that cannot pair at all, which would make the whole test
+ * a confident lie.
+ */
+void expect_granted_elevation(bt_security_t level)
+{
+	int err;
+
+	err = bt_conn_set_security(g_conn, level);
+	TEST_ASSERT(err == 0, "Elevation to a reachable L%d was refused (err %d)", level, err);
+
+	expect_observed_elevation(level);
+}
+
+/* The same outcome seen from the peer that did not ask for it. The granted
+ * round is only a two-sided fact if both ends observe the level being reached,
+ * and this is the half a role cannot get from its own return value.
+ */
+void expect_observed_elevation(bt_security_t level)
+{
+	WAIT_FOR_FLAG(flag_security_result);
+	TEST_ASSERT(g_reported_err == BT_SECURITY_ERR_SUCCESS, "Elevation to L%d failed (err %d)",
+		    level, g_reported_err);
+	TEST_ASSERT(g_reported_level >= level,
+		    "Link settled at level %d after a successful elevation to L%d",
+		    g_reported_level, level);
+}
+
+static void stop_scan_and_connect(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+				  struct net_buf_simple *ad)
+{
+	int err;
+
+	if (g_conn != NULL) {
+		return;
+	}
+
+	err = bt_le_scan_stop();
+	TEST_ASSERT(err == 0, "bt_le_scan_stop failed (err %d)", err);
+
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &g_conn);
+	TEST_ASSERT(err == 0, "bt_conn_le_create failed (err %d)", err);
+}
+
+void scan_connect_to_first_result(void)
+{
+	int err;
+
+	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, stop_scan_and_connect);
+	TEST_ASSERT(err == 0, "bt_le_scan_start failed (err %d)", err);
+}
+
+void advertise_connectable(void)
+{
+	int err;
+
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
+	TEST_ASSERT(err == 0, "bt_le_adv_start failed (err %d)", err);
+}

--- a/tests/bsim/bluetooth/host/security/level_enforced/src/common.h
+++ b/tests/bsim/bluetooth/host/security/level_enforced/src/common.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TESTS_BSIM_BLUETOOTH_HOST_SECURITY_LEVEL_ENFORCED_COMMON_H_
+#define TESTS_BSIM_BLUETOOTH_HOST_SECURITY_LEVEL_ENFORCED_COMMON_H_
+
+#include <zephyr/bluetooth/conn.h>
+
+/* The connection, the flags and the reported outcome are private to common.c.
+ * Both roles reach them only through the calls below, so there is one place
+ * that decides what an elevation attempt is supposed to look like.
+ */
+
+void test_setup(void);
+void wait_connected(void);
+void wait_disconnected(void);
+void clear_g_conn(void);
+void scan_connect_to_first_result(void);
+void advertise_connectable(void);
+void disconnect_and_wait(void);
+void forget_bonds(void);
+void forget_security_result(void);
+void expect_refused_elevation(bt_security_t level);
+void expect_granted_elevation(bt_security_t level);
+void expect_observed_elevation(bt_security_t level);
+
+#endif /* TESTS_BSIM_BLUETOOTH_HOST_SECURITY_LEVEL_ENFORCED_COMMON_H_ */

--- a/tests/bsim/bluetooth/host/security/level_enforced/src/main.c
+++ b/tests/bsim/bluetooth/host/security/level_enforced/src/main.c
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bstests.h"
+
+void central(void);
+void peripheral(void);
+
+static const struct bst_test_instance test_to_add[] = {
+	{
+		.test_id = "central",
+		.test_main_f = central,
+	},
+	{
+		.test_id = "peripheral",
+		.test_main_f = peripheral,
+	},
+	BSTEST_END_MARKER,
+};
+
+static struct bst_test_list *install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_to_add);
+};
+
+bst_test_install_t test_installers[] = {install, NULL};
+
+int main(void)
+{
+	bst_main();
+	return 0;
+}

--- a/tests/bsim/bluetooth/host/security/level_enforced/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/level_enforced/src/peripheral.c
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+#include <zephyr/logging/log.h>
+
+#include "babblekit/testcase.h"
+
+LOG_MODULE_REGISTER(peripheral, LOG_LEVEL_DBG);
+
+void peripheral(void)
+{
+	test_setup();
+	advertise_connectable();
+	wait_connected();
+
+	/* Neither peer registers authentication callbacks, so both have no
+	 * input and no output and the only available pairing method is Just
+	 * Works, which produces an unauthenticated key. L3 and L4 are both
+	 * unreachable on this link by construction.
+	 *
+	 * The host must say so instead of pairing anyway and reporting a lower
+	 * level as success: an application that asks for L4 and is told the
+	 * request was accepted has no other signal to act on.
+	 *
+	 * A peripheral request travels `smp_send_security_req()`.
+	 */
+	expect_refused_elevation(BT_SECURITY_L4);
+	expect_refused_elevation(BT_SECURITY_L3);
+	expect_granted_elevation(BT_SECURITY_L2);
+
+	disconnect_and_wait();
+
+	/* Second round: the central drives the same three attempts, over a link
+	 * that carries no key from the first round.
+	 */
+	forget_bonds();
+	forget_security_result();
+
+	advertise_connectable();
+	wait_connected();
+	wait_disconnected();
+	clear_g_conn();
+
+	TEST_PASS("Unreachable security levels refused, reachable one granted");
+}

--- a/tests/bsim/bluetooth/host/security/level_enforced/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/level_enforced/tests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  bluetooth.host.security.level_enforced:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_host_security_level_enforced_prj_conf
+      fixture: bsim_multi_test

--- a/tests/bsim/bluetooth/host/security/level_enforced/tests_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/level_enforced/tests_scripts/run_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="${BOARD_TS}_security_level_enforced"
+verbosity_level=2
+
+test_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "${test_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
+
+Execute "${test_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+    -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Nothing in the tree checks what happens when an application asks for a security
level the link's pairing method cannot deliver. The host refuses it in
`smp_send_security_req()` and `smp_send_pairing_req()` through
`sec_level_reachable()`, and that refusal is the only signal the caller gets: a
host that instead paired anyway and reported a lower level as success would
leave an application believing it has authentication the link does not carry.

This adds a two-device bsim scenario pinning both halves of that behaviour.
Neither peer registers authentication callbacks, so both are NoInputNoOutput and
Just Works is the only method available. The peripheral asks for L4, which is
unreachable on such a link, and asserts that the request is refused, that no
pairing happened, and that the reported level did not move. It then asks for L2
and asserts that one is granted, so the test cannot pass on a build that simply
never pairs.

Testing: `nrf52_bsim`, both devices report `Test end: PASS`. Watched it fail as
well: removing the `sec_level_reachable()` guard in `smp_send_security_req()`
makes the scenario fail on its first assertion, and it passes again once the
guard is restored.
