### PR TITLE
settings: nvs: delete a settings item whose value fails its CRC

### DIFF
--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -26,6 +26,10 @@ LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 struct settings_nvs_read_fn_arg {
 	struct nvs_fs *fs;
 	uint16_t id;
+	/* First read failure, so the loader can tell a value that failed
+	 * to read from one the handler simply ignored.
+	 */
+	ssize_t rd_rc;
 };
 
 static int settings_nvs_load(struct settings_store *cs,
@@ -48,6 +52,10 @@ static ssize_t settings_nvs_read_fn(void *back_end, void *data, size_t len)
 	rd_fn_arg = (struct settings_nvs_read_fn_arg *)back_end;
 
 	rc = nvs_read(rd_fn_arg->fs, rd_fn_arg->id, data, len);
+	if ((rc < 0) && (rd_fn_arg->rd_rc >= 0)) {
+		rd_fn_arg->rd_rc = rc;
+	}
+
 	if (rc > (ssize_t)len) {
 		/* nvs_read signals that not all bytes were read
 		 * align read len to what was requested
@@ -203,6 +211,7 @@ static int settings_nvs_load(struct settings_store *cs,
 		name[rc1] = '\0';
 		read_fn_arg.fs = &cf->cf_nvs;
 		read_fn_arg.id = name_id + NVS_NAME_ID_OFFSET;
+		read_fn_arg.rd_rc = 0;
 
 #if CONFIG_SETTINGS_NVS_NAME_CACHE
 		settings_nvs_cache_add(cf, name, name_id);
@@ -215,6 +224,33 @@ static int settings_nvs_load(struct settings_store *cs,
 			(void *)arg);
 		if (ret) {
 			break;
+		}
+
+		if (read_fn_arg.rd_rc < 0) {
+			/* Value entry failed to read back (e.g. NVS data CRC
+			 * rejected it). The probe above can't catch this - NVS
+			 * only checks the CRC on a full read, so it surfaces
+			 * only once a handler reads the value itself.
+			 */
+			LOG_ERR("Settings entry %u did not read back (%zd), deleting", name_id,
+				read_fn_arg.rd_rc);
+
+			nvs_delete(&cf->cf_nvs, name_id);
+			nvs_delete(&cf->cf_nvs, name_id + NVS_NAME_ID_OFFSET);
+
+			if (name_id == cf->last_name_id) {
+				cf->last_name_id--;
+				nvs_write(&cf->cf_nvs, NVS_NAMECNT_ID, &cf->last_name_id,
+					  sizeof(uint16_t));
+			}
+
+			/* Cache count is left alone: the deleted name already
+			 * took a cache slot, possibly evicting another, which
+			 * can't be undone. Lowering the count would let
+			 * SETTINGS_NVS_CACHE_OVFL() claim full coverage while
+			 * an evicted name is missing, turning a miss into a
+			 * false absence proof. Overcounting only costs a scan.
+			 */
 		}
 	}
 	return ret;

--- a/tests/subsys/settings/nvs_data_crc/CMakeLists.txt
+++ b/tests/subsys/settings/nvs_data_crc/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test_settings_nvs_data_crc)
+
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/settings/include)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/settings/nvs_data_crc/prj.conf
+++ b/tests/subsys/settings/nvs_data_crc/prj.conf
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
+CONFIG_NVS_DATA_CRC=y
+
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_NVS=y
+
+# The corruption is injected by writing over an already programmed byte.
+CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
+
+# The interaction this change perturbs is deleting an item after it has
+# been cached, so the cache is on.
+CONFIG_SETTINGS_NVS_NAME_CACHE=y

--- a/tests/subsys/settings/nvs_data_crc/src/main.c
+++ b/tests/subsys/settings/nvs_data_crc/src/main.c
@@ -1,0 +1,189 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+
+#include <zephyr/kvss/nvs.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/ztest.h>
+
+#include <settings/settings_nvs.h>
+
+#define TEST_SUBTREE  "crc"
+#define TEST_KEY_NAME TEST_SUBTREE "/name"
+#define TEST_KEY_LONG TEST_SUBTREE "/long"
+
+/* Long enough that the loader's one-byte probe cannot verify it: NVS only
+ * checks the data CRC when the whole element is read.
+ */
+static const uint8_t long_value[] = {0x5a, 0xa5, 0x3c, 0xc3, 0x69, 0x96, 0x0f, 0xf0};
+
+/* Scoped to one key: settings_load() walks every entry, including a
+ * corrupt one left by an earlier test.
+ */
+static const char *watched_key;
+static int handler_calls;
+static ssize_t handler_read_rc;
+
+static int test_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg)
+{
+	uint8_t buf[sizeof(long_value)];
+	ssize_t rc;
+
+	rc = read_cb(cb_arg, buf, MIN(len, sizeof(buf)));
+
+	/* The handler is given the key without its subtree prefix. */
+	if ((watched_key == NULL) || (strcmp(name, watched_key + strlen(TEST_SUBTREE) + 1) != 0)) {
+		return 0;
+	}
+
+	handler_calls++;
+	handler_read_rc = rc;
+
+	return 0;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(test_crc, TEST_SUBTREE, NULL, test_set, NULL, NULL);
+
+static struct nvs_fs *test_storage(void)
+{
+	void *storage = NULL;
+
+	zassert_ok(settings_storage_get(&storage), "no settings storage");
+	zassert_not_null(storage, "no settings storage");
+
+	return (struct nvs_fs *)storage;
+}
+
+static uint16_t test_name_id(struct nvs_fs *fs, const char *key)
+{
+	char name[SETTINGS_MAX_NAME_LEN + 1];
+
+	for (uint16_t id = NVS_NAMECNT_ID + 1; id < NVS_NAMECNT_ID + NVS_NAME_ID_OFFSET; id++) {
+		ssize_t rc = nvs_read(fs, id, name, sizeof(name) - 1);
+
+		if (rc <= 0) {
+			continue;
+		}
+
+		name[rc] = '\0';
+		if (strcmp(name, key) == 0) {
+			return id;
+		}
+	}
+
+	zassert_unreachable("stored name entry not found");
+
+	return 0;
+}
+
+/* Clears one bit of the given pattern on the partition, so NVS data CRC
+ * rejects it on the next read. No erase needed - flash writes only clear bits.
+ */
+static void corrupt_stored_bytes(const void *pattern, size_t pattern_len)
+{
+	static uint8_t partition[PARTITION_SIZE(storage_partition)];
+	const struct flash_area *fa;
+	const uint8_t zero = 0;
+	size_t hit;
+	bool found = false;
+
+	zassert_ok(flash_area_open(PARTITION_ID(storage_partition), &fa));
+	zassert_ok(flash_area_read(fa, 0, partition, sizeof(partition)));
+
+	for (hit = 0; hit + pattern_len <= sizeof(partition); hit++) {
+		if (memcmp(&partition[hit], pattern, pattern_len) == 0) {
+			found = true;
+			break;
+		}
+	}
+	zassert_true(found, "stored bytes not found on the partition");
+
+	zassert_ok(flash_area_write(fa, hit, &zero, sizeof(zero)));
+	flash_area_close(fa);
+}
+
+/* A corrupt name entry is dropped by settings_load(), along with its
+ * value entry.
+ */
+ZTEST(settings_nvs_data_crc, test_corrupt_name_is_deleted)
+{
+	struct nvs_fs *fs;
+	uint16_t name_id;
+	char name[SETTINGS_MAX_NAME_LEN + 1];
+	uint8_t value = 0;
+	const uint8_t stored = 0x42;
+
+	zassert_ok(settings_save_one(TEST_KEY_NAME, &stored, sizeof(stored)));
+
+	fs = test_storage();
+	name_id = test_name_id(fs, TEST_KEY_NAME);
+
+	corrupt_stored_bytes(TEST_KEY_NAME, strlen(TEST_KEY_NAME));
+
+	/* The injection took effect: the name no longer reads back. */
+	zassert_equal(nvs_read(fs, name_id, name, sizeof(name) - 1), -EIO,
+		      "corruption was not injected");
+
+	watched_key = TEST_KEY_NAME;
+	handler_calls = 0;
+	zassert_ok(settings_load());
+	zassert_equal(handler_calls, 0, "corrupted entry was handed to a handler");
+
+	zassert_equal(nvs_read(fs, name_id, name, sizeof(name) - 1), -ENOENT,
+		      "corrupted name entry survived settings_load()");
+	zassert_equal(nvs_read(fs, name_id + NVS_NAME_ID_OFFSET, &value, sizeof(value)), -ENOENT,
+		      "orphaned value entry survived settings_load()");
+}
+
+/* Same but for a value longer than one byte: the loader's one-byte probe
+ * succeeds without a CRC check, so the failure surfaces only when the
+ * handler reads the value; both entries must still be dropped.
+ */
+ZTEST(settings_nvs_data_crc, test_corrupt_long_value_is_deleted)
+{
+	struct nvs_fs *fs;
+	uint16_t name_id;
+	char name[SETTINGS_MAX_NAME_LEN + 1];
+	uint8_t value[sizeof(long_value)];
+
+	zassert_ok(settings_save_one(TEST_KEY_LONG, long_value, sizeof(long_value)));
+
+	fs = test_storage();
+	name_id = test_name_id(fs, TEST_KEY_LONG);
+
+	corrupt_stored_bytes(long_value, sizeof(long_value));
+
+	/* Full read fails but the loader's one-byte probe still succeeds -
+	 * that gap is what this test targets.
+	 */
+	zassert_equal(nvs_read(fs, name_id + NVS_NAME_ID_OFFSET, value, sizeof(value)), -EIO,
+		      "corruption was not injected");
+	zassert_equal(nvs_read(fs, name_id + NVS_NAME_ID_OFFSET, value, 1),
+		      (ssize_t)sizeof(long_value), "the one-byte probe did not stay silent");
+
+	watched_key = TEST_KEY_LONG;
+	handler_calls = 0;
+	handler_read_rc = 0;
+	zassert_ok(settings_load());
+	zassert_equal(handler_calls, 1, "handler was not called for a readable name");
+	zassert_equal(handler_read_rc, -EIO, "the handler's read did not fail");
+
+	zassert_equal(nvs_read(fs, name_id, name, sizeof(name) - 1), -ENOENT,
+		      "name entry of a corrupt value survived settings_load()");
+	zassert_equal(nvs_read(fs, name_id + NVS_NAME_ID_OFFSET, value, sizeof(value)), -ENOENT,
+		      "corrupted value entry survived settings_load()");
+}
+
+static void *setup(void)
+{
+	zassert_ok(settings_subsys_init());
+
+	return NULL;
+}
+
+ZTEST_SUITE(settings_nvs_data_crc, NULL, setup, NULL, NULL, NULL);

--- a/tests/subsys/settings/nvs_data_crc/tests.yaml
+++ b/tests/subsys/settings/nvs_data_crc/tests.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  settings.nvs_data_crc:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - settings
+      - nvs


### PR DESCRIPTION
`settings_nvs_load()` drops a settings item whose name or value entry does not read back, on the assumption that it is the leftover of an interrupted write. With `CONFIG_NVS_DATA_CRC` enabled a read also fails when the entry is intact but its stored bytes no longer match their CRC-32, and that case is meant to end the same way.

Today it does not, and which way it ends depends on the length of the value. The loader probes the value entry with a one byte buffer, and `nvs_read_hist()` only verifies the data CRC when the whole element was read, so for any value longer than one byte the probe succeeds and the item is handed to its handler as sound. The `-EIO` then surfaces inside the read callback, after the loader has moved on, and both entries stay on the storage. A corrupt name, or a corrupt one byte value, is deleted; a corrupt longer value is not.

This reports the failure the handler's read hit back to the loader and deletes both entries there.

What it does not do, because the same rule about whole elements applies to the handler's read: a handler that reads less than the whole value still gets a prefix without a CRC check, an item nobody has registered a handler for is never read in full at all, and a handler that does not read the value leaves nothing for the loader to see. Making the check unconditional means verifying the element inside NVS, without a caller-sized buffer, which is a change to NVS rather than to settings and is not attempted here.

The count of cached names is deliberately not lowered when an item is deleted. The name was added to the cache before the handler ran, that add may already have evicted whatever shared its slot, and that cannot be undone. Counting one name too many only costs a scan; counting one too few would let a cache miss be taken as proof that a name is absent, and `settings_nvs_save()` would then write a second name entry for a key that already exists.

Testing: `native_sim`, `settings.nvs_data_crc`, 2 of 2 passing, with the name cache enabled so that deleting an item after it has been cached is covered. Watched it fail as well: on an unmodified tree the corrupt name case passes, since that path already deletes, and the corrupt eight byte value case fails with the name entry still readable after `settings_load()`. Each case asserts that its injection took effect before asserting the outcome, and the value case also asserts that the one byte probe still succeeds, which is the asymmetry being fixed.

This replaces the earlier version of this pull request, which kept such entries instead of deleting them. @Laczen, this is the direction you asked for.
