### PR TITLE
tests: net: dns: add a libFuzzer harness for the message parser

### DIFF
--- a/tests/net/lib/dns/fuzz/CMakeLists.txt
+++ b/tests/net/lib/dns/fuzz/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(dns_fuzz)
+
+target_sources(app PRIVATE src/main.c)
+
+# UBSan reports and continues by default, so an input that triggers
+# undefined behaviour would be recorded by libFuzzer as a clean run.
+zephyr_compile_options(-fno-sanitize-recover=all)

--- a/tests/net/lib/dns/fuzz/README.rst
+++ b/tests/net/lib/dns/fuzz/README.rst
@@ -1,0 +1,138 @@
+.. SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+.. SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+.. SPDX-License-Identifier: Apache-2.0
+
+DNS parser fuzz harness
+#######################
+
+What it covers
+**************
+
+The harness feeds the fuzz case in as a received datagram and drives it
+through both consumers the tree has for one, each following the call
+sequence of the code that owns it.
+
+The responder path, as :file:`subsys/net/lib/dns/mdns_responder.c` and
+:file:`subsys/net/lib/dns/llmnr_responder.c` run it:
+
+* :c:func:`mdns_unpack_query_header`, then one
+  :c:func:`dns_unpack_query` per announced question, which walks the
+  name through :c:func:`dns_unpack_name` and unpacks the query type and
+  class after it
+* the step the responder takes on the unpacked name, the ``.local``
+  suffix test, so a name that reached the buffer is read back out here
+  rather than only in the responder
+
+The resolver path, as :c:func:`dns_read` in
+:file:`subsys/net/lib/dns/resolve.c` runs it: :c:func:`dns_validate_msg`,
+which re-reads the header, walks the question, walks every answer record
+through :c:func:`dns_unpack_answer`, converts each record's rdata to an
+address, a name, a text record or an SRV target, and copies a CNAME out
+with :c:func:`dns_copy_qname`.
+
+A resolver reply is accepted from whoever wins the race to the socket, and
+an mDNS or LLMNR query is accepted from anyone on the link, so every byte
+either path sees is attacker chosen.
+
+Reaching the answer walk
+************************
+
+:c:func:`dns_validate_msg` only looks at a reply that matches a query the
+resolver has outstanding: it hashes the question the reply carries and
+looks for a pending query with that hash and that DNS id. A harness that
+left the pending query fixed would have every fuzz case rejected at that
+comparison, and the answer walk would never be reached.
+
+So the harness sets the pending query up from the question the fuzz case
+carries, computing the hash the way :c:func:`update_query_idx` does, on a
+copy, so the bytes handed to the parser are untouched. That is the state a
+spoofer produces by echoing the question back at the resolver, which is
+what an off-path attacker sends, so a record reached this way is reached
+by a packet a peer can send and not by a state the resolver cannot be in.
+
+Building and running
+********************
+
+libFuzzer needs clang, and the fuzzing support in the POSIX architecture
+is available on ``native_sim/native/64`` only:
+
+.. code-block:: console
+
+   export ZEPHYR_TOOLCHAIN_VARIANT=host/llvm
+   west build -p -b native_sim/native/64 tests/net/lib/dns/fuzz
+   ./build/zephyr/zephyr.exe corpus \
+       -dict=tests/net/lib/dns/fuzz/dns.dict -max_len=512
+
+``CONFIG_ASAN`` and ``CONFIG_UBSAN`` are set by the harness's
+:file:`prj.conf`, and the build turns off sanitizer recovery: UBSan
+reports and continues by default, which would let libFuzzer record a
+clean run over an input that triggered undefined behaviour.
+
+The harness rejects an input longer than ``DNS_RESOLVER_MAX_BUF_SIZE``,
+which is what both consumers clamp a received datagram to before the
+parser sees it, so pass ``-max_len=512`` and let the mutator spend its
+executions inside the range that is executed at all.
+
+No seed corpus
+**************
+
+The tree accepts no binary files, and git calls a file binary as soon as
+it contains a NUL byte. Every DNS message contains one: a name ends in
+the zero octet of the root label, the class of a record that parses at
+all is ``0x0001``, and the counts in the header are small. Unlike the
+CoAP harness next door, there is no useful seed that avoids one, so no
+corpus is committed.
+
+The structure lives in :file:`dns.dict` instead, which is a text file and
+takes escapes: whole 12-byte headers, label runs, compression pointers,
+question trailers and record trailers. Point the run at an empty
+directory and libFuzzer builds its own corpus there, which is worth
+keeping between runs.
+
+.. code-block:: console
+
+   mkdir -p /tmp/dns-corpus
+   ./build/zephyr/zephyr.exe /tmp/dns-corpus \
+       -dict=tests/net/lib/dns/fuzz/dns.dict -max_len=512 \
+       -max_total_time=300
+
+Where the message is placed
+***************************
+
+The harness copies the fuzz case flush against the end of its buffer
+rather than to the start of it. A record whose declared rdata length runs
+past the end of the message is the defect class this parser has had
+before, and read into the slack of an oversized receive buffer it is
+silent: the bytes are whatever the previous datagram left there, which
+is a leak rather than a fault. Ending the copy on the last byte of the
+object puts the sanitizer's red zone immediately after the message, so a
+read past the end of the packet is reported instead of quietly resolving
+to stale data.
+
+Proof the harness finds what it targets
+***************************************
+
+commit 58b46c81c679 ("net: dns: validate rdata length in
+dns_unpack_answer") fixed exactly that: an RR whose ``rdlength``
+extended past the packet, which the TXT and SRV consumers in
+:file:`resolve.c` then read out. Drop that check again and replaying the
+corpus stops on it:
+
+.. code-block:: console
+
+   $ ./build/zephyr/zephyr.exe /tmp/dns-corpus -runs=0
+   ==3335765==ERROR: AddressSanitizer: global-buffer-overflow
+   SUMMARY: AddressSanitizer: global-buffer-overflow in __asan_memcpy
+   ==3335765==ABORTING
+
+With the check in place the same corpus replays clean.
+
+What the parser survived
+************************
+
+2556236 executions over 901 seconds in a single process produced no
+ASan or UBSan report. The corpus reaches :c:func:`dns_unpack_name`,
+:c:func:`dns_unpack_answer`, :c:func:`dns_unpack_query`,
+:c:func:`dns_copy_qname`, :c:func:`dns_unpack_response_query` and
+:c:func:`dns_validate_record`, which ``-print_coverage=1`` will confirm
+on a fresh checkout.

--- a/tests/net/lib/dns/fuzz/dns.dict
+++ b/tests/net/lib/dns/fuzz/dns.dict
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+#
+# libFuzzer dictionary for the DNS message parser. A DNS message is not
+# reachable by mutation from nothing: the header has to pass the flag and
+# opcode checks, a name has to be a run of length-prefixed labels ending
+# in a zero octet, and a record only parses with a class of IN. The
+# tokens below are those fixed shapes, so the executions go into the name
+# walk and the record walk instead of into rediscovering the framing.
+#
+# The tree accepts no binary files, so this dictionary, not a seed
+# corpus, is where the structure of a DNS message is kept. See
+# README.rst.
+
+# Whole 12-byte headers. Anything shorter than one of these is rejected
+# before a name is looked at.
+hdr_query_1q="\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00"
+hdr_mdns_query="\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00"
+hdr_response_1a="\x12\x34\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00"
+hdr_response_2a="\x12\x34\x81\x80\x00\x01\x00\x02\x00\x00\x00\x00"
+hdr_mdns_response="\x00\x00\x84\x00\x00\x00\x00\x01\x00\x00\x00\x00"
+hdr_response_additional="\x12\x34\x81\x80\x00\x01\x00\x01\x00\x01\x00\x01"
+
+# Name pieces: a label is a length octet and that many bytes, and the
+# name ends in the zero octet of the root label.
+label_local="\x05local"
+label_www="\x03www"
+label_arpa="\x04arpa"
+label_max63="\x3f"
+label_root="\x00"
+name_zephyr_local="\x06zephyr\x05local\x00"
+
+# Compression pointers. The top two bits mark the octet as a pointer and
+# the remaining 14 bits are an offset into the message, so these are the
+# tokens that send the name walk somewhere else in the packet.
+ptr_to_header="\xc0\x0c"
+ptr_to_self="\xc0\x00"
+ptr_high="\xff\xff"
+ptr_reserved_bits="\x80\x0c"
+ptr_40="\x40\x0c"
+
+# Question trailer: query type and class IN.
+qtype_a_in="\x00\x01\x00\x01"
+qtype_aaaa_in="\x00\x1c\x00\x01"
+qtype_ptr_in="\x00\x0c\x00\x01"
+qtype_srv_in="\x00\x21\x00\x01"
+qtype_txt_in="\x00\x10\x00\x01"
+qtype_any_in="\x00\xff\x00\x01"
+qclass_cache_flush="\x80\x01"
+
+# Record trailers: type, class, TTL and rdlength, the four fields
+# dns_unpack_answer() reads before it trusts the rdata length.
+rr_a="\x00\x01\x00\x01\x00\x00\x00\x3c\x00\x04"
+rr_aaaa="\x00\x1c\x00\x01\x00\x00\x00\x3c\x00\x10"
+rr_cname="\x00\x05\x00\x01\x00\x00\x00\x3c\x00\x02"
+rr_srv="\x00\x21\x00\x01\x00\x00\x00\x3c\x00\x08"
+rr_txt="\x00\x10\x00\x01\x00\x00\x00\x3c\x00\x01"
+rr_ptr="\x00\x0c\x00\x01\x00\x00\x00\x3c\x00\x02"
+rdlength_max="\xff\xff"
+ttl_max="\x7f\xff\xff\xff"

--- a/tests/net/lib/dns/fuzz/prj.conf
+++ b/tests/net/lib/dns/fuzz/prj.conf
@@ -11,7 +11,15 @@ CONFIG_UBSAN=y
 CONFIG_NETWORKING=y
 CONFIG_NET_L2_ETHERNET=n
 CONFIG_DNS_RESOLVER=y
+CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT=y
+CONFIG_DNS_SD=y
 CONFIG_CRC=y
+
+# Only CONFIG_MDNS_RESOLVER_BUF_SIZE is needed, to size the harness's own
+# buffer pool like the responder's; its sources aren't exercised. Pulls in
+# NET_HOSTNAME_ENABLE, an MDNS_RESPONDER dependency.
+CONFIG_NET_HOSTNAME_ENABLE=y
+CONFIG_MDNS_RESPONDER=y
 
 # dns_validate_msg() is the resolver's entry point for a received reply
 # and is only exported to a test build, the same way the dns_packet test

--- a/tests/net/lib/dns/fuzz/prj.conf
+++ b/tests/net/lib/dns/fuzz/prj.conf
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARCH_POSIX_LIBFUZZER=y
+
+CONFIG_ASAN=y
+CONFIG_ASAN_RECOVER=n
+CONFIG_UBSAN=y
+
+CONFIG_NETWORKING=y
+CONFIG_NET_L2_ETHERNET=n
+CONFIG_DNS_RESOLVER=y
+CONFIG_CRC=y
+
+# dns_validate_msg() is the resolver's entry point for a received reply
+# and is only exported to a test build, the same way the dns_packet test
+# reaches it.
+CONFIG_NET_TEST=y
+
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+# The parsers are driven directly from the fuzz entry point, outside the
+# OS, so nothing may take a lock or defer work to a logging thread.
+CONFIG_LOG=n

--- a/tests/net/lib/dns/fuzz/src/main.c
+++ b/tests/net/lib/dns/fuzz/src/main.c
@@ -1,0 +1,247 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * libFuzzer harness for the DNS message parser. Every byte arrives in an
+ * unauthenticated datagram, so the fuzz case is fed as that datagram
+ * through both consumers:
+ *
+ * - responder path: mdns_unpack_query_header() + dns_unpack_query() per
+ *   question, mirroring dns_read() in mdns_responder.c/llmnr_responder.c
+ * - resolver path: dns_validate_msg(), what dns_read() in resolve.c calls
+ *   on a reply
+ *
+ * dns_validate_msg() only accepts a reply matching an outstanding query,
+ * so the harness sets the pending query from the fuzz case's own question -
+ * the state an off-path spoofer reaches by echoing it back.
+ *
+ * See README.rst for build/run instructions.
+ */
+
+#include <ctype.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/toolchain.h>
+
+#include <dns_internal.h>
+#include <dns_pack.h>
+
+#if defined(CONFIG_BOARD_NATIVE_SIM)
+#include <nsi_cpu_if.h>
+#include <nsi_main_semipublic.h>
+#else
+#error "Platform not supported"
+#endif
+
+/* Both consumers clamp the datagram to their receive buffer before the
+ * parser sees it, so a longer input is never parsed as one message.
+ */
+#define FUZZ_MAX_PACKET DNS_RESOLVER_MAX_BUF_SIZE
+
+/* The responders unpack a name into a buffer of this size and the
+ * resolver copies a CNAME into one, so the tail-room checks in
+ * dns_unpack_name() and dns_copy_qname() are exercised against the
+ * length a name is allowed to reach on the wire.
+ */
+#define FUZZ_NAME_BUF_SIZE DNS_NAME_MAX_SIZE
+
+NET_BUF_POOL_DEFINE(fuzz_name_pool, 2, FUZZ_NAME_BUF_SIZE, 0, NULL);
+
+/* Each consumer gets its own copy: parsers keep the buffer pointer, and
+ * update_query_idx() lower-cases the question in place.
+ *
+ * The copy sits flush against the end of packet_buf, not its start, so
+ * the sanitizer's red zone follows the message immediately. A record
+ * whose declared length runs past the message end - this parser's known
+ * defect class - is caught here instead of silently reading stale bytes
+ * from receive-buffer slack.
+ */
+static uint8_t packet_buf[FUZZ_MAX_PACKET];
+
+static uint8_t *fuzz_packet(const uint8_t *data, size_t size)
+{
+	uint8_t *msg = packet_buf + sizeof(packet_buf) - size;
+
+	return memcpy(msg, data, size);
+}
+
+int main(void)
+{
+	/* Fuzz cases are executed from LLVMFuzzerTestOneInput(), outside
+	 * the OS. Nothing is left for the application thread to do.
+	 */
+	return 0;
+}
+
+static void fuzz_resolve_cb(enum dns_resolve_status status, struct dns_addrinfo *info,
+			    void *user_data)
+{
+	ARG_UNUSED(status);
+	ARG_UNUSED(info);
+	ARG_UNUSED(user_data);
+}
+
+/* Responder side: mirrors mdns_responder.c/llmnr_responder.c - unpack
+ * header, unpack each question, then read the name back out as the
+ * responder does to match it against its own hostname.
+ */
+static void consume_query(uint8_t *buf, uint16_t size)
+{
+	struct dns_msg_t dns_msg = { .msg = buf, .msg_size = size };
+	struct net_buf *result;
+	uint16_t src_id;
+	int queries;
+
+	queries = mdns_unpack_query_header(&dns_msg, &src_id);
+	if (queries < 0) {
+		return;
+	}
+
+	result = net_buf_alloc(&fuzz_name_pool, K_NO_WAIT);
+	if (result == NULL) {
+		return;
+	}
+
+	do {
+		enum dns_rr_type qtype;
+		enum dns_class qclass;
+		const char *lquery;
+
+		(void)memset(result->data, 0, net_buf_tailroom(result));
+		result->len = 0U;
+
+		if (dns_unpack_query(&dns_msg, result, &qtype, &qclass) < 0) {
+			break;
+		}
+
+		/* Mirrors the responder's ".local" suffix check that
+		 * decides whether the query is answered.
+		 */
+		lquery = strrchr((const char *)result->data, '.');
+		if (lquery == NULL) {
+			continue;
+		}
+
+		if (memcmp(lquery, (const void *){ ".local" }, 7) != 0) {
+			continue;
+		}
+	} while (--queries);
+
+	net_buf_unref(result);
+}
+
+/* Resolver side: mirrors dns_read() in resolve.c calling dns_validate_msg().
+ * The pending query is set up from the message's own question, so a reply
+ * that echoes it reaches the records like a real one would.
+ */
+static void consume_response(uint8_t *buf, uint16_t size)
+{
+	static struct dns_resolve_context ctx;
+	static uint8_t question[FUZZ_MAX_PACKET];
+	struct dns_msg_t dns_msg = { .msg = buf, .msg_size = size };
+	struct net_buf *cname;
+	uint16_t query_hash = 0U;
+	uint16_t dns_id;
+	int query_idx = -1;
+	size_t name_len;
+
+	if (size < DNS_MSG_HEADER_SIZE) {
+		return;
+	}
+
+	(void)memset(&ctx, 0, sizeof(ctx));
+	ctx.state = DNS_RESOLVE_CONTEXT_ACTIVE;
+	ctx.queries[0].cb = fuzz_resolve_cb;
+	ctx.queries[0].query = "fuzz";
+	ctx.queries[0].query_type = DNS_QUERY_TYPE_A;
+	ctx.queries[0].id = dns_unpack_header_id(buf);
+
+	/* Reproduces update_query_idx()'s hash (lower-cased question + type)
+	 * on a copy, so the pending query matches without touching the
+	 * bytes handed to the parser.
+	 */
+	(void)memcpy(question, buf, size);
+
+	for (name_len = DNS_MSG_HEADER_SIZE; name_len < size; name_len++) {
+		if (question[name_len] == 0U) {
+			break;
+		}
+	}
+
+	if (name_len + DNS_QTYPE_LEN < size) {
+		uint8_t *name = question + DNS_MSG_HEADER_SIZE;
+		size_t label_len = name_len - DNS_MSG_HEADER_SIZE;
+
+		for (size_t i = 0; i < label_len; i++) {
+			name[i] = tolower(name[i]);
+		}
+
+		query_hash = crc16_ansi(name, label_len + 1 + DNS_QTYPE_LEN);
+
+		switch (sys_get_be16(&question[name_len + 1])) {
+		case DNS_RR_TYPE_AAAA:
+			ctx.queries[0].query_type = DNS_QUERY_TYPE_AAAA;
+			break;
+		case DNS_RR_TYPE_PTR:
+			ctx.queries[0].query_type = DNS_QUERY_TYPE_PTR;
+			break;
+		case DNS_RR_TYPE_ANY:
+			ctx.queries[0].query_type = DNS_QUERY_TYPE_ANY;
+			break;
+		default:
+			break;
+		}
+	}
+
+	ctx.queries[0].query_hash = query_hash;
+
+	cname = net_buf_alloc(&fuzz_name_pool, K_NO_WAIT);
+	if (cname == NULL) {
+		return;
+	}
+
+	dns_id = ctx.queries[0].id;
+
+	(void)dns_validate_msg(&ctx, &dns_msg, &dns_id, &query_idx, cname, &query_hash, -1);
+
+	net_buf_unref(cname);
+}
+
+/**
+ * Fuzzing entry point. The simulator boots once for an initialised
+ * runtime; each case runs directly, no Zephyr thread needed.
+ */
+#if defined(CONFIG_BOARD_NATIVE_SIM)
+NATIVE_SIMULATOR_IF /* We expose this function to the final runner link stage */
+#endif
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	static bool runner_initialized;
+
+	if (!runner_initialized) {
+		nsi_init(0, NULL);
+		runner_initialized = true;
+	}
+
+	if (size > sizeof(packet_buf)) {
+		/* Skip rather than truncate, so a case the corpus keeps is
+		 * the case that was executed. Pass -max_len=512 to keep the
+		 * mutator inside the range that is executed at all.
+		 */
+		return 0;
+	}
+
+	consume_query(fuzz_packet(data, size), (uint16_t)size);
+	consume_response(fuzz_packet(data, size), (uint16_t)size);
+
+	return 0;
+}

--- a/tests/net/lib/dns/fuzz/src/main.c
+++ b/tests/net/lib/dns/fuzz/src/main.c
@@ -47,14 +47,17 @@
  */
 #define FUZZ_MAX_PACKET DNS_RESOLVER_MAX_BUF_SIZE
 
-/* The responders unpack a name into a buffer of this size and the
- * resolver copies a CNAME into one, so the tail-room checks in
- * dns_unpack_name() and dns_copy_qname() are exercised against the
- * length a name is allowed to reach on the wire.
+/* Matches the buffer sizes the code under test actually uses (not
+ * DNS_NAME_MAX_SIZE), so tail-room checks in dns_unpack_name() and
+ * dns_copy_qname() are exercised against the real buffers. The two differ;
+ * CONFIG_DNS_RESOLVER_MAX_QUERY_LEN (255) matching the CNAME buffer is
+ * coincidental today.
  */
-#define FUZZ_NAME_BUF_SIZE DNS_NAME_MAX_SIZE
+#define FUZZ_QUERY_NAME_BUF_SIZE CONFIG_MDNS_RESOLVER_BUF_SIZE
+#define FUZZ_CNAME_BUF_SIZE CONFIG_DNS_RESOLVER_MAX_QUERY_LEN
 
-NET_BUF_POOL_DEFINE(fuzz_name_pool, 2, FUZZ_NAME_BUF_SIZE, 0, NULL);
+NET_BUF_POOL_DEFINE(fuzz_query_name_pool, 2, FUZZ_QUERY_NAME_BUF_SIZE, 0, NULL);
+NET_BUF_POOL_DEFINE(fuzz_cname_pool, 2, FUZZ_CNAME_BUF_SIZE, 0, NULL);
 
 /* Each consumer gets its own copy: parsers keep the buffer pointer, and
  * update_query_idx() lower-cases the question in place.
@@ -106,7 +109,7 @@ static void consume_query(uint8_t *buf, uint16_t size)
 		return;
 	}
 
-	result = net_buf_alloc(&fuzz_name_pool, K_NO_WAIT);
+	result = net_buf_alloc(&fuzz_query_name_pool, K_NO_WAIT);
 	if (result == NULL) {
 		return;
 	}
@@ -204,7 +207,7 @@ static void consume_response(uint8_t *buf, uint16_t size)
 
 	ctx.queries[0].query_hash = query_hash;
 
-	cname = net_buf_alloc(&fuzz_name_pool, K_NO_WAIT);
+	cname = net_buf_alloc(&fuzz_cname_pool, K_NO_WAIT);
 	if (cname == NULL) {
 		return;
 	}

--- a/tests/net/lib/dns/fuzz/tests.yaml
+++ b/tests/net/lib/dns/fuzz/tests.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - net
+    - dns
+  toolchain_allow: host/llvm
+  platform_allow:
+    - native_sim/native/64
+tests:
+  net.dns.fuzz:
+    # The harness is driven by libFuzzer, which runs until it is told to
+    # stop; Twister only keeps it compiling against the parser's API.
+    build_only: true


### PR DESCRIPTION
The DNS message parser decodes packets nobody authenticated. A resolver reply is taken from whoever wins the race to the socket, and an mDNS or LLMNR query is taken from anyone on the link, so every byte reaching `dns_unpack_name()`, `dns_unpack_answer()` and `dns_copy_qname()` is chosen by the sender.

This adds a libFuzzer harness that feeds the fuzz case in as that datagram and drives it through both consumers the tree has, each following the call sequence of the code that owns it: `mdns_unpack_query_header()` and one `dns_unpack_query()` per question, as `mdns_responder.c` and `llmnr_responder.c` run it, and `dns_validate_msg()`, as `resolve.c` runs it on a received reply.

`dns_validate_msg()` only looks at a reply matching a query the resolver has outstanding, so the harness sets the pending query up from the question the fuzz case carries, hashing it the way `update_query_idx()` does, on a copy so the parser still sees the bytes as they arrived. That is the state a spoofer produces by echoing the question back, so the records reached this way are reached by a packet a peer can send.

The message is copied flush against the end of its buffer rather than to the start of it. A record whose declared rdata length runs past the end of the packet is the defect class this parser has had before, and read into the slack of an oversized receive buffer it is silent: the bytes are whatever the previous datagram left there. Ending the copy on the last byte of the object puts the red zone right after the message, so that read is reported.

Proof the harness can fail, run against this branch rather than quoted from an earlier session: deleting the check added by 58b46c81c679 ("net: dns: validate rdata length in dns_unpack_answer") makes the stored case abort with an AddressSanitizer global-buffer-overflow in `__asan_memcpy`, exit 1, and restoring the check makes the same case replay clean, exit 0.

The tree accepts no binary files and every DNS message contains a zero octet, so no seed corpus is committed. The structure lives in the dictionary instead, which is a text file that takes escapes: whole headers, label runs, compression pointers, question trailers and record trailers.

Testing: builds on `native_sim/native/64` with clang 18.1.3. On the parser as it stands, 2556236 executions over 901 seconds in a single process produced no ASan or UBSan report and no crash artifact. Twister only keeps the harness compiling (`build_only`), since libFuzzer runs until it is told to stop and `tests.yaml` has no way to pass it runtime flags.
