### PR TITLE
tests: net: mqtt: add a libFuzzer harness for the receive path

### DIFF
--- a/tests/net/lib/mqtt/fuzz/CMakeLists.txt
+++ b/tests/net/lib/mqtt/fuzz/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mqtt_fuzz)
+
+target_sources(app PRIVATE src/main.c)
+
+# UBSan reports and continues by default, so an input that triggers
+# undefined behaviour would be recorded by libFuzzer as a clean run.
+zephyr_compile_options(-fno-sanitize-recover=all)

--- a/tests/net/lib/mqtt/fuzz/README.rst
+++ b/tests/net/lib/mqtt/fuzz/README.rst
@@ -1,0 +1,176 @@
+.. SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+.. SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+.. SPDX-License-Identifier: Apache-2.0
+
+MQTT receive-path fuzz harness
+##############################
+
+What it covers
+**************
+
+Everything an MQTT client decodes comes from the broker it is connected
+to, so every byte reaching :c:func:`mqtt_input` is chosen by whoever
+holds the other end of the connection. The harness hands the fuzz case
+to the client as that byte stream, through a custom transport, and then
+drives :c:func:`mqtt_input` the way an application's poll loop does
+until the client rejects the stream or the peer runs out of data.
+
+Driving the real entry point rather than a decoder is what keeps a
+finding meaningful. The length fields worth aiming at are read in
+:file:`mqtt_rx.c` before any decoder sees them:
+
+* the fixed header's variable-length remaining length, which decides how
+  much of the stream is buffered,
+* the PUBLISH topic length and, under 5.0, the property length, which
+  :c:func:`mqtt_read_publish_var_header` adds up to decide how much of
+  the variable header to read before handing it on,
+* the UTF-8 string, binary-data and variable-integer lengths inside the
+  packet, which the decoders convert into offsets into the receive
+  buffer,
+* the 5.0 property length, which is a second budget the property walk
+  spends alongside the buffer end.
+
+Past the decoder the harness does what an application does with the
+result: it reads both ends of the PUBLISH topic, so a topic that escaped
+the receive buffer - or that was resolved out of the client's 5.0
+topic-alias store - is reported here rather than in the application that
+would have copied it out, and it drains the payload with
+:c:func:`mqtt_read_publish_payload`, which is the only thing that moves
+the client's remaining-payload accounting.
+
+A connection reaches the packet types worth fuzzing only once the broker
+has accepted it, so the transport serves a CONNACK of its own before the
+fuzz case and the fuzz case is the stream that follows it. The same
+stream is offered twice, to a client speaking 3.1.1 and to one speaking
+5.0, because the version is settled when the client connects and the two
+decoders diverge from the CONNACK onwards.
+
+Building and running
+********************
+
+libFuzzer needs clang, and the fuzzing support in the POSIX
+architecture is available on ``native_sim`` and
+``native_sim/native/64``. The harness is restricted to the 64-bit
+variant, as :file:`samples/subsys/debug/fuzz` is:
+
+.. code-block:: console
+
+   python3 tests/net/lib/mqtt/fuzz/gen_corpus.py /tmp/mqtt-corpus
+   export ZEPHYR_TOOLCHAIN_VARIANT=host/llvm
+   west build -p -b native_sim/native/64 tests/net/lib/mqtt/fuzz
+   ./build/zephyr/zephyr.exe /tmp/mqtt-corpus \
+       -dict=tests/net/lib/mqtt/fuzz/mqtt.dict -max_len=256 \
+       -max_total_time=300
+
+``CONFIG_ASAN`` and ``CONFIG_UBSAN`` are set by the harness's
+:file:`prj.conf`, and the build turns off sanitizer recovery: UBSan
+reports and continues by default, which would let libFuzzer record a
+clean run over an input that triggered undefined behaviour.
+
+The harness gives the client a 256-byte receive buffer and skips an
+input longer than that. In-tree the buffer an application hands the
+client is anything from 64 bytes, in the MQTT shell backend, to 1024
+in the Azure sample; 256 is the size the 5.0 packet test uses. The
+buffer is what bounds a single packet - a message the client cannot
+buffer is refused rather than parsed - so ``-max_len=256`` keeps the
+mutator inside the range that is executed at all.
+
+Replaying the corpus alone, without fuzzing, is a fast regression check:
+
+.. code-block:: console
+
+   ./build/zephyr/zephyr.exe -runs=0 /tmp/mqtt-corpus
+
+Proof the harness can fail
+**************************
+
+A clean run says nothing until the harness has been shown to report a
+defect it is aimed at. Deleting the bounds check on the 5.0 topic alias
+in :c:func:`publish_topic_alias_check` - the check that keeps a value
+taken from the wire from indexing the client's own array of aliases -
+makes the corpus abort on the seed written for it:
+
+.. code-block:: console
+
+   $ ./build/zephyr/zephyr.exe -runs=0 \
+         /tmp/mqtt-corpus/publish_topic_alias_out_of_range.bin
+   mqtt_decoder.c:783:18: runtime error: index 65534 out of bounds for
+   type 'struct mqtt_topic_alias[5]'
+   SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
+   $ echo $?
+   1
+
+With the check in place the same seed is parsed and rejected without a
+sanitizer report. The client and its buffers are allocated per run
+rather than kept as globals for the same reason: an index or an offset
+that leaves one of them lands in guarded memory and is reported, instead
+of reaching whatever the linker placed next.
+
+What it does not cover
+**********************
+
+The transport hands the client a short read when the rest of a message
+has not arrived, which is what a stream socket does, so the
+``-EAGAIN`` that :c:func:`mqtt_read_message_chunk` returns for a
+partial message is reached. What is not reached is a transport that
+fails: the harness's read never returns a negative value, so the
+branch in :c:func:`mqtt_read_message_chunk` that forwards a transport
+error, and the non-blocking early return in the publish payload
+reader, are both dead here. Nothing else in the receive path depends
+on them, so this is a coverage gap rather than a source of false
+findings.
+
+The other gap is the size regime above the harness's own buffer. The
+client is given 256 bytes and an input longer than that is skipped, so
+the 257 to 1024 byte packets an application with a larger buffer would
+accept are never parsed. Raising ``FUZZ_RX_BUF_SIZE`` and
+``-max_len`` together is what covers them.
+
+Seed corpus
+***********
+
+An MQTT packet is dense with zero bytes: every string length, every
+short remaining length and every success reason code is one. Git calls a
+file binary as soon as it contains a NUL and the tree takes no binary
+files, so the seeds are kept as hex in :file:`seeds.txt` and
+:file:`gen_corpus.py` writes the directory of binary seeds libFuzzer
+wants. Each seed is the stream a broker sends after the connection has
+been accepted.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Seed
+     - Stream
+   * - ``publish_qos0``
+     - The shortest PUBLISH carrying a topic and a payload.
+   * - ``publish_topic_alias``
+     - A QoS 1 PUBLISH that sets a 5.0 topic alias, followed by one that
+       carries no topic and resolves it from the alias, which is the
+       only path that reads a topic out of the client's own store.
+   * - ``publish_user_property``
+     - A user property, whose name and value lengths are spent against
+       the property-length budget rather than the buffer end.
+   * - ``connack_properties``
+     - A CONNACK with properties, decoded on an already connected
+       client. A conformant broker never sends a second one; the
+       decoder takes it without checking the connection state.
+   * - ``suback_reason_codes``
+     - A message id, an empty property list and three reason codes,
+       where the packet length decides how many codes are read.
+   * - ``disconnect_reason``
+     - A DISCONNECT with a reason code and no properties.
+   * - ``auth_method``
+     - An AUTH continuing authentication, with an authentication method
+       string.
+   * - ``publish_topic_alias_out_of_range``
+     - A topic alias past the configured maximum, which is the input the
+       alias bounds check exists for.
+   * - ``truncated_remaining_length``
+     - A fixed header announcing the largest remaining length the
+       encoding allows, with nothing behind it.
+
+The corpus is a seed set, not an accumulating one: a new seed belongs in
+it only when it reaches code the existing ones do not, and it is
+minimised (``-minimize_crash=1``, then ``-merge=1``) before its hex is
+added to :file:`seeds.txt`.

--- a/tests/net/lib/mqtt/fuzz/gen_corpus.py
+++ b/tests/net/lib/mqtt/fuzz/gen_corpus.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+"""Write the seed corpus of the MQTT fuzz harness as binary files.
+
+The seeds are kept as hex in seeds.txt because an MQTT packet is full of
+NUL bytes and the tree takes no binary files; libFuzzer wants a
+directory of them, so this produces one.
+"""
+
+import argparse
+import pathlib
+import sys
+
+SEEDS = pathlib.Path(__file__).with_name("seeds.txt")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("outdir", type=pathlib.Path, help="directory to write the seeds into")
+    args = parser.parse_args()
+
+    args.outdir.mkdir(parents=True, exist_ok=True)
+
+    for lineno, line in enumerate(SEEDS.read_text().splitlines(), 1):
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        name, _, payload = line.partition(" ")
+        try:
+            data = bytes.fromhex(payload)
+        except ValueError as err:
+            sys.exit(f"{SEEDS}:{lineno}: {err}")
+
+        if not data:
+            sys.exit(f"{SEEDS}:{lineno}: seed '{name}' is empty")
+
+        (args.outdir / f"{name}.bin").write_bytes(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/net/lib/mqtt/fuzz/mqtt.dict
+++ b/tests/net/lib/mqtt/fuzz/mqtt.dict
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+#
+# libFuzzer dictionary for the MQTT receive path. The tokens are the
+# byte sequences the encoding gives meaning to: the fixed-header byte
+# that selects the packet type, the continuation bytes that extend the
+# remaining length, and the 5.0 property identifiers. Reaching a
+# property identifier by mutation alone costs the fuzzer the executions
+# that should go into the property walk behind it.
+
+# Fixed header: packet type in the high nibble, flags in the low one.
+# A packet the client does not expect is dropped without being decoded,
+# so only the ones it decodes are listed.
+pkt_connack="\x20"
+pkt_publish_qos0="\x30"
+pkt_publish_qos1="\x32"
+pkt_publish_qos2="\x34"
+pkt_publish_dup_retain="\x3b"
+pkt_puback="\x40"
+pkt_pubrec="\x50"
+pkt_pubrel="\x62"
+pkt_pubcomp="\x70"
+pkt_suback="\x90"
+pkt_unsuback="\xb0"
+pkt_pingresp="\xd0"
+pkt_disconnect="\xe0"
+pkt_auth="\xf0"
+
+# Remaining length, and every other variable-length integer: the high
+# bit continues the field into the next byte, up to four of them.
+varint_cont="\x80"
+varint_max="\xff\xff\xff\x7f"
+varint_overlong="\xff\xff\xff\xff"
+
+# Property identifiers, 5.0 only. Each is followed by a value whose
+# width the identifier decides, which is where a length taken from the
+# wire becomes a read.
+prop_payload_format="\x01"
+prop_message_expiry="\x02"
+prop_content_type="\x03"
+prop_response_topic="\x08"
+prop_correlation_data="\x09"
+prop_subscription_id="\x0b"
+prop_session_expiry="\x11"
+prop_assigned_client_id="\x12"
+prop_server_keep_alive="\x13"
+prop_auth_method="\x15"
+prop_auth_data="\x16"
+prop_response_information="\x1a"
+prop_server_reference="\x1c"
+prop_reason_string="\x1f"
+prop_receive_maximum="\x21"
+prop_topic_alias_maximum="\x22"
+prop_topic_alias="\x23"
+prop_maximum_qos="\x24"
+prop_retain_available="\x25"
+prop_user_property="\x26"
+prop_maximum_packet_size="\x27"
+
+# A property list that announces more bytes than the packet carries is
+# the shape the length checks exist for.
+prop_len_empty="\x00"
+prop_len_overlong="\xff\x7f"
+
+# Reason codes a broker returns, which decide whether the client keeps
+# decoding the packet or gives up on the connection.
+reason_success="\x00"
+reason_topic_alias_invalid="\x94"
+reason_packet_too_large="\x95"
+reason_malformed_packet="\x81"

--- a/tests/net/lib/mqtt/fuzz/prj.conf
+++ b/tests/net/lib/mqtt/fuzz/prj.conf
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARCH_POSIX_LIBFUZZER=y
+
+CONFIG_ASAN=y
+CONFIG_ASAN_RECOVER=n
+CONFIG_UBSAN=y
+
+CONFIG_NETWORKING=y
+CONFIG_MQTT_LIB=y
+
+# The 5.0 decoder is a superset of the 3.1.1 one: the version the client
+# speaks is chosen per connection at run time, so building 5.0 lets the
+# harness drive both paths from the same image.
+CONFIG_MQTT_VERSION_5_0=y
+
+# The fuzz case is the byte stream a broker sends, so the transport under
+# the client is the harness itself rather than a socket.
+CONFIG_MQTT_LIB_CUSTOM_TRANSPORT=y
+
+# The decoder is driven from the fuzz entry point, outside the OS, so
+# nothing may defer work to a logging thread.
+CONFIG_LOG=n

--- a/tests/net/lib/mqtt/fuzz/seeds.txt
+++ b/tests/net/lib/mqtt/fuzz/seeds.txt
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+#
+# Seed corpus for the MQTT receive-path fuzz harness, one seed per line
+# as "<name> <hex>". gen_corpus.py turns this file into the directory of
+# binary seeds libFuzzer wants.
+#
+# The seeds are hex rather than files because an MQTT packet is dense
+# with zero bytes - every string length, every short remaining length,
+# every success reason code is one - and git calls a file binary as soon
+# as it contains a NUL, which the tree does not accept.
+#
+# Each seed is the stream a broker sends after the connection has been
+# accepted; the harness supplies the CONNACK itself.
+
+# Shortest PUBLISH that carries a topic and a payload. Under 5.0 the
+# empty property list is the byte between the two.
+publish_qos0 300a0005746f706963006869
+
+# QoS 1, so the message id is decoded, followed by a second PUBLISH that
+# carries no topic and resolves it from the alias the first one set.
+# This is the only path that reads a topic out of the client's own
+# alias store rather than out of the receive buffer.
+publish_topic_alias 320a00017400010323000178300700000323000179
+
+# One user property, whose name and value lengths are consumed against
+# the property-length counter rather than the buffer end.
+publish_user_property 300c000174072600016b0001767a
+
+# CONNACK carrying properties, decoded while the client is already
+# connected. A conformant broker never sends a second CONNACK; the
+# decoder takes one anyway, without checking the connection state, so
+# a hostile peer can put the client here.
+connack_properties 200b000008110000003c220005
+
+# SUBACK: message id, an empty property list and three reason codes,
+# which is where the packet length decides how many codes are read.
+suback_reason_codes 9006000100000102
+
+# DISCONNECT with a reason code and no properties.
+disconnect_reason e0028b00
+
+# AUTH continuing authentication, with an authentication method string.
+auth_method f00b18091500066d6574686f64
+
+# A topic alias past the configured maximum, which is the input the
+# alias bounds check exists for: without it the alias indexes the
+# client's own array of aliases from the wire.
+publish_topic_alias_out_of_range 30080001740323ffff78
+
+# A fixed header announcing the largest remaining length the encoding
+# allows, with nothing behind it: the length check is the only thing
+# between the client and the end of the buffer.
+truncated_remaining_length 30ffffff7f

--- a/tests/net/lib/mqtt/fuzz/src/main.c
+++ b/tests/net/lib/mqtt/fuzz/src/main.c
@@ -1,0 +1,294 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * libFuzzer harness for the MQTT client's receive path.
+ *
+ * A custom transport hands the fuzz case to the client as bytes from the
+ * broker, and mqtt_input() is driven the way an application's poll loop
+ * would. This exercises the real length parsing in mqtt_rx.c (remaining
+ * length, UTF-8 string lengths, 5.0 property length) instead of feeding a
+ * decoder a buffer of the harness's own choosing.
+ *
+ * A CONNACK is served before the fuzz case so the stream reaches the
+ * packet types worth fuzzing; see mqtt_client_custom_transport_read().
+ *
+ * See README.rst for how to build and run it.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/mqtt.h>
+#include <zephyr/toolchain.h>
+
+#if defined(CONFIG_BOARD_NATIVE_SIM)
+#include <nsi_cpu_if.h>
+#include <nsi_main_semipublic.h>
+#else
+#error "Platform not supported"
+#endif
+
+/* Bounds a single packet: a message the client cannot buffer is refused
+ * rather than parsed. In-tree buffers range from 64 (MQTT shell) to 1024
+ * (Azure sample); 256 is what a finding has to fit in here.
+ */
+#define FUZZ_RX_BUF_SIZE 256
+#define FUZZ_TX_BUF_SIZE 256
+
+/* Beyond the buffer the stream is only more packets, already reached by
+ * shorter cases, so the case length just follows the buffer size.
+ */
+#define FUZZ_MAX_INPUT FUZZ_RX_BUF_SIZE
+
+/* The peer running out of data ends every case (transport returns 0,
+ * mqtt_rx.c turns it into -ENOTCONN) well before this cap; it only
+ * guards against a future transport change turning the loop into a hang.
+ */
+#define FUZZ_MAX_INPUT_ITERATIONS FUZZ_MAX_INPUT
+
+/* Read back in the event callback the way an application does. */
+#define FUZZ_PAYLOAD_CHUNK 64
+
+/* The stream the peer sends: a CONNACK, then the fuzz case. */
+static const uint8_t *stream_prologue;
+static size_t stream_prologue_len;
+static size_t stream_prologue_pos;
+static const uint8_t *stream_case;
+static size_t stream_case_len;
+static size_t stream_case_pos;
+
+/* Connection accepted, no session present; 5.0 form has an empty property list. */
+static const uint8_t connack_3_1_1[] = {0x20, 0x02, 0x00, 0x00};
+static const uint8_t connack_5_0[] = {0x20, 0x03, 0x00, 0x00, 0x00};
+
+int main(void)
+{
+	/* Fuzz cases run from LLVMFuzzerTestOneInput(), outside the OS. */
+	return 0;
+}
+
+static size_t stream_read(uint8_t *data, size_t buflen)
+{
+	size_t taken = 0;
+
+	while (taken < buflen) {
+		const uint8_t *src;
+		size_t avail;
+
+		if (stream_prologue_pos < stream_prologue_len) {
+			src = stream_prologue + stream_prologue_pos;
+			avail = stream_prologue_len - stream_prologue_pos;
+		} else if (stream_case_pos < stream_case_len) {
+			src = stream_case + stream_case_pos;
+			avail = stream_case_len - stream_case_pos;
+		} else {
+			break;
+		}
+
+		if (avail > buflen - taken) {
+			avail = buflen - taken;
+		}
+
+		memcpy(data + taken, src, avail);
+		taken += avail;
+
+		if (stream_prologue_pos < stream_prologue_len) {
+			stream_prologue_pos += avail;
+		} else {
+			stream_case_pos += avail;
+		}
+	}
+
+	return taken;
+}
+
+int mqtt_client_custom_transport_connect(struct mqtt_client *c)
+{
+	ARG_UNUSED(c);
+
+	return 0;
+}
+
+int mqtt_client_custom_transport_write(struct mqtt_client *c, const uint8_t *data, uint32_t datalen)
+{
+	ARG_UNUSED(c);
+	ARG_UNUSED(data);
+
+	/* Not part of the fuzz surface: the harness controls what is sent. */
+	return (int)datalen;
+}
+
+int mqtt_client_custom_transport_write_msg(struct mqtt_client *c, const struct net_msghdr *message)
+{
+	ARG_UNUSED(c);
+	ARG_UNUSED(message);
+
+	return 0;
+}
+
+int mqtt_client_custom_transport_read(struct mqtt_client *c, uint8_t *data, uint32_t buflen,
+				      bool shall_block)
+{
+	size_t taken;
+
+	ARG_UNUSED(c);
+	ARG_UNUSED(shall_block);
+
+	taken = stream_read(data, buflen);
+	if (taken == 0U) {
+		/* Peer sent everything and closed: stream ended. */
+		return 0;
+	}
+
+	/* Short reads are served as-is, the way a stream socket would. */
+	return (int)taken;
+}
+
+int mqtt_client_custom_transport_disconnect(struct mqtt_client *c)
+{
+	ARG_UNUSED(c);
+
+	return 0;
+}
+
+static void consume_topic(const struct mqtt_utf8 *topic)
+{
+	if (topic->utf8 == NULL || topic->size == 0U) {
+		return;
+	}
+
+	/* Touch both ends: an overrun (or a bad 5.0 topic-alias
+	 * resolution) is reported here, not in the copying application.
+	 */
+	volatile uint8_t sink = topic->utf8[0];
+
+	sink = topic->utf8[topic->size - 1U];
+	(void)sink;
+}
+
+static void consume_publish(struct mqtt_client *c, const struct mqtt_publish_param *param)
+{
+	uint8_t payload[FUZZ_PAYLOAD_CHUNK];
+	uint32_t left = param->message.payload.len;
+
+	consume_topic(&param->message.topic.topic);
+
+	/* Reading from the event callback is what advances the client's
+	 * remaining-payload accounting, as a real application would.
+	 */
+	while (left > 0U) {
+		size_t chunk = left > sizeof(payload) ? sizeof(payload) : left;
+		int ret = mqtt_read_publish_payload(c, payload, chunk);
+
+		if (ret <= 0) {
+			break;
+		}
+
+		left -= (uint32_t)ret;
+	}
+}
+
+static void fuzz_evt_cb(struct mqtt_client *c, const struct mqtt_evt *evt)
+{
+	if (evt->result != 0) {
+		return;
+	}
+
+	if (evt->type == MQTT_EVT_PUBLISH) {
+		consume_publish(c, &evt->param.publish);
+	}
+}
+
+static void run_one(uint8_t protocol_version, const uint8_t *connack, size_t connack_len)
+{
+	/* Allocated per run, not kept as globals: an overrun lands in
+	 * guarded memory and is reported instead of the linker's next object.
+	 */
+	struct mqtt_client *client;
+	uint8_t *rx_buf;
+	uint8_t *tx_buf;
+
+	stream_prologue = connack;
+	stream_prologue_len = connack_len;
+	stream_prologue_pos = 0U;
+	stream_case_pos = 0U;
+
+	client = calloc(1, sizeof(*client));
+	rx_buf = calloc(1, FUZZ_RX_BUF_SIZE);
+	tx_buf = calloc(1, FUZZ_TX_BUF_SIZE);
+
+	if (client == NULL || rx_buf == NULL || tx_buf == NULL) {
+		goto out;
+	}
+
+	mqtt_client_init(client);
+
+	client->broker = NULL;
+	client->evt_cb = fuzz_evt_cb;
+	client->client_id.utf8 = (uint8_t *)"fuzz";
+	client->client_id.size = 4U;
+	client->protocol_version = protocol_version;
+	client->transport.type = MQTT_TRANSPORT_CUSTOM;
+	client->rx_buf = rx_buf;
+	client->rx_buf_size = FUZZ_RX_BUF_SIZE;
+	client->tx_buf = tx_buf;
+	client->tx_buf_size = FUZZ_TX_BUF_SIZE;
+
+	if (mqtt_connect(client) < 0) {
+		goto out;
+	}
+
+	for (int i = 0; i < FUZZ_MAX_INPUT_ITERATIONS; i++) {
+		if (mqtt_input(client) < 0) {
+			/* Client refused the stream and closed. */
+			goto out;
+		}
+	}
+
+out:
+	free(tx_buf);
+	free(rx_buf);
+	free(client);
+}
+
+/**
+ * Entry point for fuzzing. The native simulator boots once; each case
+ * then runs directly since the receive path needs no thread of its own.
+ */
+#if defined(CONFIG_BOARD_NATIVE_SIM)
+NATIVE_SIMULATOR_IF /* We expose this function to the final runner link stage */
+#endif
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	static bool runner_initialized;
+
+	if (!runner_initialized) {
+		nsi_init(0, NULL);
+		runner_initialized = true;
+	}
+
+	if (size > FUZZ_MAX_INPUT) {
+		/* Skip rather than truncate, so a kept case matches what
+		 * ran. Pass -max_len=256 to keep the mutator in range.
+		 */
+		return 0;
+	}
+
+	stream_case = data;
+	stream_case_len = size;
+
+	/* Protocol version is fixed at connect and the decoders diverge
+	 * from the CONNACK onward, so offer the same stream to both.
+	 */
+	run_one(MQTT_VERSION_3_1_1, connack_3_1_1, sizeof(connack_3_1_1));
+	run_one(MQTT_VERSION_5_0, connack_5_0, sizeof(connack_5_0));
+
+	return 0;
+}

--- a/tests/net/lib/mqtt/fuzz/tests.yaml
+++ b/tests/net/lib/mqtt/fuzz/tests.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - net
+    - mqtt
+  toolchain_allow: host/llvm
+  platform_allow:
+    - native_sim/native/64
+tests:
+  net.mqtt.fuzz:
+    # The harness is driven by libFuzzer, which runs until it is told to
+    # stop; Twister only keeps it compiling against the client's API.
+    build_only: true


### PR DESCRIPTION
Everything an MQTT client decodes arrives from the broker it is connected to, so every byte reaching `mqtt_input()` is chosen by whoever holds the other end of the connection. A device on somebody else's network decodes those bytes with no authentication behind them.

This adds a libFuzzer harness that hands the fuzz case to the client as the stream the peer sends, through a custom transport, and drives `mqtt_input()` the way an application's poll loop does, until the client rejects the stream or the peer runs out of data.

Driving the real entry point rather than a decoder is what keeps a finding meaningful. The fixed header's variable-length remaining length, the UTF-8 string lengths and the 5.0 property length are read in `mqtt_rx.c` before any decoder sees them, and `mqtt_rx.c` is also what decides how much of the stream is buffered, so a harness feeding a decoder a buffer of its own choosing would report states no broker can produce.

Past the decoder the harness does what an application does with the result: it reads both ends of the PUBLISH topic, so a topic that escaped the receive buffer or was resolved out of the 5.0 topic-alias store is reported here rather than in the application that would have copied it out, and it drains the payload with `mqtt_read_publish_payload()`, which is the only thing that moves the client's remaining-payload accounting. The client and its buffers are allocated per case, so an index that leaves one of them lands in guarded memory instead of whatever the linker placed next.

A connection only reaches the packet types worth fuzzing once the broker has accepted it, so the transport serves a CONNACK of its own before the fuzz case. The same stream is then offered to a client speaking 3.1.1 and to one speaking 5.0, because the version is settled when the client connects and the two decoders diverge from there.

The tree accepts no binary files and an MQTT packet is dense with zero octets, so the seeds are kept as hex in `seeds.txt` and `gen_corpus.py` writes the directory of binary seeds libFuzzer wants.

Proof the harness can fail, run against this branch rather than quoted from elsewhere: removing the bounds check on the 5.0 topic alias in `publish_topic_alias_check()` makes the corpus abort on the seed written for it, with UBSan reporting `index 65534 out of bounds for type 'struct mqtt_topic_alias[5]'` at `mqtt_decoder.c:783`, exit 1. Restoring the check makes the same corpus replay clean, exit 0.

The README is explicit about what the harness does not reach: the transport never fails, so the branch forwarding a transport error out of `mqtt_read_message_chunk()` and the non-blocking early return in the publish payload reader are dead here, and inputs above the harness's own 256-byte buffer are skipped, so the larger packets an application with a bigger buffer would accept are not parsed.

Testing: builds on `native_sim/native/64` with clang 18.1.3. 34271592 executions over 601 seconds, and a further 10035672 over 181 seconds after the last change, produced no ASan or UBSan report and no crash artifact. Twister only keeps the harness compiling (`build_only`), since libFuzzer runs until it is told to stop and `tests.yaml` has no way to pass it runtime flags.
