### PR TITLE
net: http: fix a signed overflow decoding an HPACK integer

### DIFF
--- a/subsys/net/lib/http/http_hpack.c
+++ b/subsys/net/lib/http/http_hpack.c
@@ -184,12 +184,12 @@ static int hpack_integer_decode(const uint8_t *buf, size_t datalen,
 			return -EAGAIN;
 		}
 
-		if (m > sizeof(uint32_t) * 8) {
+		if (m >= sizeof(uint32_t) * 8) {
 			/* Can't handle integer that large. */
 			return -EBADMSG;
 		}
 
-		*value += (*buf & ~HPACK_INTEGER_CONTINUATION_FLAG) * (1 << m);
+		*value += (uint32_t)(*buf & ~HPACK_INTEGER_CONTINUATION_FLAG) << m;
 		m += 7;
 
 	} while (*buf & HPACK_INTEGER_CONTINUATION_FLAG);


### PR DESCRIPTION
`hpack_integer_decode()` accumulates the continuation octets of an HPACK variable-length integer with a multiplication done in `int`, and the guard above it stops at `m > 32`, which lets `m` reach 28. An octet with any value above 7 then overflows: for the last octet of `ff 80 80 80 80 7f` the product is `127 * 268435456`, which does not fit in an `int`. The bytes come from a HEADERS frame, which an HTTP/2 client sends before anything has authenticated it.

The commit message carries a reproduction that runs on this tree: two Kconfig lines in the decoder's own test suite, one case, and a clang build. The unmodified decoder dies in that case; with this commit the suite passes.

No test is added, and the message says why: both forms compute the same value and the decoder returns `-EBADMSG` for that input either way, so a ztest asserting the return value passes before the fix as well. The regression anchor is a libFuzzer harness over this decoder, which found this defect on its first session. It is a separate contribution and depends on this one, so it follows once this lands.

One thing this does not close, and I would rather raise it than fold it in: the decoded value can still wrap, which is defined for an unsigned type and is refused by all three places that consume it, but RFC 7541 section 5.1 says an integer encoding that exceeds implementation limits in value MUST be treated as a decoding error. Rejecting a wrapped value is a behaviour change worth making on its own rather than inside a fix for undefined behaviour. I am happy to send it as a follow-up if you would like it.
