### PR TITLE
drivers: i2c: infineon: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_infineon.c
+++ b/drivers/i2c/i2c_infineon.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
 #define I2C_CAT1_EVENTS_MASK  (CYHAL_I2C_MASTER_WR_CMPLT_EVENT | CYHAL_I2C_MASTER_RD_CMPLT_EVENT | \
 			       CYHAL_I2C_MASTER_ERR_EVENT)
 
-#define I2C_CAT1_SLAVE_EVENTS_MASK                                                                 \
+#define I2C_CAT1_TARGET_EVENTS_MASK                                                                \
 	(CYHAL_I2C_SLAVE_READ_EVENT | CYHAL_I2C_SLAVE_WRITE_EVENT |                                \
 	 CYHAL_I2C_SLAVE_RD_BUF_EMPTY_EVENT | CYHAL_I2C_SLAVE_RD_CMPLT_EVENT |                     \
 	 CYHAL_I2C_SLAVE_WR_CMPLT_EVENT | CYHAL_I2C_SLAVE_RD_BUF_EMPTY_EVENT |                     \
@@ -57,7 +57,7 @@ struct ifx_cat1_i2c_data {
 
 /* Device config structure */
 struct ifx_cat1_i2c_config {
-	uint32_t master_frequency;
+	uint32_t controller_frequency;
 	CySCB_Type *reg_addr;
 	const struct pinctrl_dev_config *pcfg;
 	uint8_t irq_priority;
@@ -94,7 +94,7 @@ static int32_t _get_hw_block_num(CySCB_Type *reg_addr)
 	return -ENOMEM;
 }
 
-static void ifx_master_event_handler(void *callback_arg, cyhal_i2c_event_t event)
+static void ifx_controller_event_handler(void *callback_arg, cyhal_i2c_event_t event)
 {
 	const struct device *dev = (const struct device *) callback_arg;
 	struct ifx_cat1_i2c_data *data = dev->data;
@@ -201,7 +201,7 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 		return -EIO;
 	}
 
-	/* Configure the I2C resource to be master */
+	/* Configure the I2C resource to be controller */
 	rslt = cyhal_i2c_configure(&data->obj, &data->cfg);
 	if (rslt != CY_RSLT_SUCCESS) {
 		LOG_ERR("cyhal_i2c_configure failed with err 0x%x", rslt);
@@ -210,7 +210,7 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 	}
 
 	/* Register an I2C event callback handler */
-	cyhal_i2c_register_callback(&data->obj, ifx_master_event_handler, (void *)dev);
+	cyhal_i2c_register_callback(&data->obj, ifx_controller_event_handler, (void *)dev);
 
 	/* Release semaphore */
 	k_sem_give(&data->operation_sem);
@@ -307,7 +307,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 			data->async_pending = CAT1_I2C_PENDING_TX_RX;
 		}
 
-		/* Initiate master write and read transfer
+		/* Initiate controller write and read transfer
 		 * using tx_buff and rx_buff respectively
 		 */
 		rslt = cyhal_i2c_master_transfer_async(&data->obj, addr,
@@ -329,7 +329,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		}
 
 		/* If error_status != 1 we have error during transfer async.
-		 * error_status is handling in master_event_handler function.
+		 * error_status is handling in controller_event_handler function.
 		 */
 		if (data->error_status != 0) {
 			/* Release semaphore */
@@ -405,10 +405,10 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	}
 	data->obj.is_clock_owned = true;
 
-	/* Store Master initial configuration */
+	/* Store Controller initial configuration */
 	data->cfg.is_slave = false;
 	data->cfg.address = 0;
-	data->cfg.frequencyhal_hz = config->master_frequency;
+	data->cfg.frequencyhal_hz = config->controller_frequency;
 
 	if (ifx_cat1_i2c_configure(dev, 0) != 0) {
 		/* Free I2C resource */
@@ -443,7 +443,7 @@ static int ifx_cat1_i2c_target_register(const struct device *dev, struct i2c_tar
 		return -EIO;
 	}
 
-	cyhal_i2c_enable_event(&data->obj, (cyhal_i2c_event_t)I2C_CAT1_SLAVE_EVENTS_MASK,
+	cyhal_i2c_enable_event(&data->obj, (cyhal_i2c_event_t)I2C_CAT1_TARGET_EVENTS_MASK,
 			       config->irq_priority, true);
 	return 0;
 }
@@ -458,7 +458,7 @@ static int ifx_cat1_i2c_target_unregister(const struct device *dev, struct i2c_t
 
 	cyhal_i2c_free(&data->obj);
 	data->p_target_config = NULL;
-	cyhal_i2c_enable_event(&data->obj, (cyhal_i2c_event_t)I2C_CAT1_SLAVE_EVENTS_MASK,
+	cyhal_i2c_enable_event(&data->obj, (cyhal_i2c_event_t)I2C_CAT1_TARGET_EVENTS_MASK,
 			       config->irq_priority, false);
 
 	/* Release semaphore */
@@ -486,7 +486,7 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
                                                                                                    \
 	static const struct ifx_cat1_i2c_config i2c_cat1_cfg_##n = {                               \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
-		.master_frequency = DT_INST_PROP_OR(n, clock_frequency, 100000),                   \
+		.controller_frequency = DT_INST_PROP_OR(n, clock_frequency, 100000),               \
 		.reg_addr = (CySCB_Type *)DT_INST_REG_ADDR(n),                                     \
 		.irq_priority = DT_INST_IRQ(n, priority),                                          \
 	};                                                                                         \

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -34,7 +34,7 @@ LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
 	(CY_SCB_I2C_MASTER_WR_CMPLT_EVENT | CY_SCB_I2C_MASTER_RD_CMPLT_EVENT |                     \
 	 CY_SCB_I2C_MASTER_ERR_EVENT)
 
-#define I2C_CAT1_SLAVE_EVENTS_MASK                                                                 \
+#define I2C_CAT1_TARGET_EVENTS_MASK                                                                \
 	(CY_SCB_I2C_SLAVE_READ_EVENT | CY_SCB_I2C_SLAVE_WRITE_EVENT |                              \
 	 CY_SCB_I2C_SLAVE_RD_BUF_EMPTY_EVENT | CY_SCB_I2C_SLAVE_RD_CMPLT_EVENT |                   \
 	 CY_SCB_I2C_SLAVE_WR_CMPLT_EVENT | CY_SCB_I2C_SLAVE_RD_BUF_EMPTY_EVENT |                   \
@@ -73,7 +73,7 @@ struct ifx_cat1_i2c_data {
 	struct i2c_target_config *p_target_config;
 	uint8_t i2c_target_wr_byte;
 	uint8_t target_wr_buffer[CONFIG_I2C_INFINEON_CAT1_TARGET_BUF];
-	uint8_t slave_address;
+	uint8_t target_address;
 	uint32_t frequencyhal_hz;
 	cy_stc_syspm_callback_t i2c_deep_sleep;
 	cy_stc_syspm_callback_params_t i2c_deep_sleep_param;
@@ -81,7 +81,7 @@ struct ifx_cat1_i2c_data {
 
 /* Device config structure */
 struct ifx_cat1_i2c_config {
-	uint32_t master_frequency;
+	uint32_t controller_frequency;
 	CySCB_Type *base;
 	const struct pinctrl_dev_config *pcfg;
 	uint8_t irq_priority;
@@ -232,7 +232,7 @@ static void ifx_cat1_i2c_event_handler(void *callback_arg, uint32_t event)
 	if (((CY_SCB_I2C_MASTER_ERR_EVENT | CY_SCB_I2C_SLAVE_ERR_EVENT) & event) != 0) {
 		(void)_i2c_abort_async(dev);
 		/*
-		 * Abort does not confirm the master went idle when it times out,
+		 * Abort does not confirm the controller went idle when it times out,
 		 * so clear the async state unconditionally. This stops the
 		 * interrupt handler from starting a spurious read after a failed
 		 * write and leaving a stale completion for the next transfer.
@@ -486,13 +486,13 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 		return -EIO;
 	}
 
-	data->scb_config.slaveAddress = data->slave_address;
+	data->scb_config.slaveAddress = data->target_address;
 
 	if (is_target_mode) {
 		data->scb_config.slaveAddressMask = 0xFE;
 		data->scb_config.ackGeneralAddr = false;
 	} else {
-		/* Controller mode: the PDL consults these slave-only fields only in
+		/* Controller mode: the PDL consults these target-only fields only in
 		 * target mode, but scb_config is a persistent per-instance copy, so
 		 * reset them to their defaults to avoid carrying stale target state
 		 * across a target-to-controller reconfiguration.
@@ -579,9 +579,9 @@ static int ifx_cat1_i2c_msg_validate(struct i2c_msg *msg, uint8_t num_msgs)
 	return 0;
 }
 
-static int _i2c_master_transfer_async(const struct device *dev, uint16_t address,
-					    const void *tx, size_t tx_size, void *rx,
-					    size_t rx_size)
+static int _i2c_controller_transfer_async(const struct device *dev, uint16_t address,
+					  const void *tx, size_t tx_size, void *rx,
+					  size_t rx_size)
 {
 	struct ifx_cat1_i2c_data *data = dev->data;
 	const struct ifx_cat1_i2c_config *const config = dev->config;
@@ -665,11 +665,14 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 			}
 		}
 
-		/* Initiate master write and read transfer using tx_buff and rx_buff respectively */
-		ret = _i2c_master_transfer_async(dev, addr, (tx_msg == NULL) ? NULL : tx_msg->buf,
-						 (tx_msg == NULL) ? 0 : tx_msg->len,
-						 (rx_msg == NULL) ? NULL : rx_msg->buf,
-						 (rx_msg == NULL) ? 0 : rx_msg->len);
+		/* Initiate controller write and read transfer using tx_buff and rx_buff
+		 * respectively
+		 */
+		ret = _i2c_controller_transfer_async(dev, addr,
+						     (tx_msg == NULL) ? NULL : tx_msg->buf,
+						     (tx_msg == NULL) ? 0 : tx_msg->len,
+						     (rx_msg == NULL) ? NULL : rx_msg->buf,
+						     (rx_msg == NULL) ? 0 : rx_msg->len);
 
 		if (ret < 0) {
 			k_sem_give(&data->operation_sem);
@@ -691,7 +694,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 			 */
 			abort_status = _i2c_abort_async(dev);
 			if (abort_status != CY_RSLT_SUCCESS) {
-				LOG_WRN("I2C abort did not confirm master idle "
+				LOG_WRN("I2C abort did not confirm controller idle "
 					"(0x%x); bus may be stuck", abort_status);
 			}
 
@@ -766,7 +769,7 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	 */
 	return ifx_cat1_i2c_configure(dev,
 				      I2C_MODE_CONTROLLER |
-					      i2c_map_dt_bitrate(config->master_frequency));
+					      i2c_map_dt_bitrate(config->controller_frequency));
 }
 
 void _i2c_free(const struct device *dev)
@@ -793,7 +796,7 @@ static int ifx_cat1_i2c_target_register(const struct device *dev, struct i2c_tar
 	}
 
 	data->p_target_config = cfg;
-	data->slave_address = (uint8_t)cfg->address;
+	data->target_address = (uint8_t)cfg->address;
 
 	/* Restore pinctrl to SCB mode after unregister released pins */
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
@@ -816,7 +819,7 @@ static int ifx_cat1_i2c_target_register(const struct device *dev, struct i2c_tar
 	Cy_SCB_I2C_SlaveConfigWriteBuf(config->base, (uint8_t *)data->target_wr_buffer,
 				       CONFIG_I2C_INFINEON_CAT1_TARGET_BUF, &data->context);
 
-	data->irq_cause |= I2C_CAT1_SLAVE_EVENTS_MASK;
+	data->irq_cause |= I2C_CAT1_TARGET_EVENTS_MASK;
 
 	return 0;
 }
@@ -833,7 +836,7 @@ static int ifx_cat1_i2c_target_unregister(const struct device *dev, struct i2c_t
 	_i2c_free(dev);
 	data->p_target_config = NULL;
 
-	data->irq_cause &= ~I2C_CAT1_SLAVE_EVENTS_MASK;
+	data->irq_cause &= ~I2C_CAT1_TARGET_EVENTS_MASK;
 
 	/* Disable NVIC to prevent ISR loops from stale INTR_S bits. */
 	irq_disable(config->irq_num);
@@ -857,9 +860,9 @@ static void i2c_isr_handler(const struct device *dev)
 	Cy_SCB_I2C_Interrupt(config->base, &data->context);
 
 	if (data->pending != CAT1_I2C_PENDING_NONE) {
-		/* The write-read read phase is chained from the master
+		/* The write-read read phase is chained from the controller
 		 * WR_CMPLT event, so only the single TX or RX phase needs to be
-		 * cleared once the master goes idle.
+		 * cleared once the controller goes idle.
 		 */
 		if (0 == (Cy_SCB_I2C_MasterGetStatus(config->base, &data->context) &
 			  CY_SCB_I2C_MASTER_BUSY)) {
@@ -942,7 +945,7 @@ static int ifx_cat1_i2c_recover_bus(const struct device *dev)
 
 	i2c_bitbang_init(&bitbang_ctx, &bitbang_io, (void *)config);
 
-	bitrate_cfg = i2c_map_dt_bitrate(config->master_frequency) | I2C_MODE_CONTROLLER;
+	bitrate_cfg = i2c_map_dt_bitrate(config->controller_frequency) | I2C_MODE_CONTROLLER;
 	error = i2c_bitbang_configure(&bitbang_ctx, bitrate_cfg);
 	if (error != 0) {
 		LOG_ERR("failed to configure I2C bitbang (err %d)", error);
@@ -1030,7 +1033,7 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
                                                                                                    \
 	static const struct ifx_cat1_i2c_config i2c_cat1_cfg_##n = {                               \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
-		.master_frequency = DT_INST_PROP_OR(n, clock_frequency, 100000),                   \
+		.controller_frequency = DT_INST_PROP_OR(n, clock_frequency, 100000),               \
 		.base = (CySCB_Type *)DT_INST_REG_ADDR(n),                                         \
 		.irq_priority = DT_INST_IRQ(n, priority),                                          \
 		.irq_num = DT_INST_IRQN(n),                                                        \

--- a/drivers/i2c/i2c_infineon_xmc4.c
+++ b/drivers/i2c/i2c_infineon_xmc4.c
@@ -62,7 +62,7 @@ struct ifx_xmc4_i2c_data {
 	uint32_t dev_config;
 	uint8_t target_wr_byte;
 	uint8_t target_wr_buffer[CONFIG_I2C_INFINEON_XMC4_TARGET_BUF];
-	bool ignore_slave_select;
+	bool ignore_target_select;
 	bool is_configured;
 };
 
@@ -203,7 +203,7 @@ static int ifx_xmc4_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 			/* Wait for acknowledge */
 			while ((XMC_I2C_CH_GetStatusFlag(config->i2c) &
 				XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U) {
-				/* wait for ACK from slave */
+				/* wait for ACK from target */
 				if (XMC_I2C_CH_GetStatusFlag(config->i2c) &
 				    I2C_XMC_STATUS_FLAG_ERROR_MASK) {
 					k_sem_give(&data->operation_sem);
@@ -216,14 +216,14 @@ static int ifx_xmc4_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 
 		for (uint32_t buf_index = 0u; buf_index < msg[msg_index].len; buf_index++) {
 			if (cmd_type == XMC_I2C_CH_CMD_WRITE) {
-				/* Transmit next command from I2C master to I2C slave */
+				/* Transmit next command from I2C controller to I2C target */
 				XMC_I2C_CH_MasterTransmit(config->i2c,
 							  msg[msg_index].buf[buf_index]);
 
 				/* Wait for acknowledge */
 				while ((XMC_I2C_CH_GetStatusFlag(config->i2c) &
 					XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U) {
-					/* wait for ACK from slave */
+					/* wait for ACK from target */
 					if (XMC_I2C_CH_GetStatusFlag(config->i2c) &
 					    I2C_XMC_STATUS_FLAG_ERROR_MASK) {
 						k_sem_give(&data->operation_sem);
@@ -252,7 +252,7 @@ static int ifx_xmc4_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 				while ((XMC_I2C_CH_GetStatusFlag(config->i2c) &
 				       (XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION |
 					XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION)) == 0U) {
-					/* wait for data byte from slave */
+					/* wait for data byte from target */
 					if (XMC_I2C_CH_GetStatusFlag(config->i2c) &
 					    I2C_XMC_STATUS_FLAG_ERROR_MASK) {
 						k_sem_give(&data->operation_sem);
@@ -384,10 +384,11 @@ static void i2c_xmc4_isr(const struct device *dev)
 			break;
 		}
 
-		if (!data->ignore_slave_select && (status & XMC_I2C_CH_STATUS_FLAG_SLAVE_SELECT)) {
-			data->ignore_slave_select = true;
+		if (!data->ignore_target_select &&
+		    (status & XMC_I2C_CH_STATUS_FLAG_SLAVE_SELECT)) {
+			data->ignore_target_select = true;
 
-			/* Start a slave read */
+			/* Start a target read */
 			if (status & XMC_I2C_CH_STATUS_FLAG_SLAVE_READ_REQUESTED) {
 				callbacks->read_requested(data->p_target_config,
 							  &data->target_wr_byte);
@@ -397,13 +398,13 @@ static void i2c_xmc4_isr(const struct device *dev)
 			}
 		}
 
-		/* Continue a slave read */
+		/* Continue a target read */
 		if (status & XMC_I2C_CH_STATUS_FLAG_TRANSMIT_SHIFT_INDICATION) {
 			callbacks->read_processed(data->p_target_config, &data->target_wr_byte);
 			XMC_I2C_CH_SlaveTransmit(config->i2c, data->target_wr_byte);
 		}
 
-		/* Start/Continue a slave write */
+		/* Start/Continue a target write */
 		if (status & (XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |
 		    XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION)) {
 			callbacks->write_received(data->p_target_config,
@@ -412,7 +413,7 @@ static void i2c_xmc4_isr(const struct device *dev)
 
 		if ((status & XMC_I2C_CH_STATUS_FLAG_START_CONDITION_RECEIVED) ||
 		    (status & XMC_I2C_CH_STATUS_FLAG_REPEATED_START_CONDITION_RECEIVED)) {
-			data->ignore_slave_select = false;
+			data->ignore_target_select = false;
 		}
 
 		status = XMC_I2C_CH_GetStatusFlag(config->i2c);


### PR DESCRIPTION
Update comments, log messages, Kconfig prose, and driver-local identifiers to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

Identifiers mirroring the Cypress/Infineon PDL and HAL (e.g. CYHAL_I2C_MASTER_*/CYHAL_I2C_SLAVE_* event macros, cyhal_i2c_master_transfer_async, cyhal_i2c_slave_config_write_buffer) are kept unchanged.
