### PR TITLE
drivers: i2c: dw: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -517,8 +517,8 @@ static inline void i2c_dw_transfer_complete(const struct device *dev)
 #ifdef CONFIG_I2C_TARGET
 static inline uint8_t i2c_dw_read_byte_non_blocking(const struct device *dev);
 static inline void i2c_dw_write_byte_non_blocking(const struct device *dev, uint8_t data);
-static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev,
-						union ic_interrupt_register intr_stat);
+static void i2c_dw_target_read_clear_intr_bits(const struct device *dev,
+					       union ic_interrupt_register intr_stat);
 #endif
 
 static void i2c_dw_isr(const struct device *port)
@@ -549,7 +549,7 @@ static void i2c_dw_isr(const struct device *port)
 
 	LOG_DBG("I2C: interrupt received");
 
-	/* Check if we are configured as a master device */
+	/* Check if we are configured as a controller device */
 	if (test_bit_con_master_mode(reg_base)) {
 #ifdef CONFIG_I2C_DW_LPSS_DMA
 		uint32_t stat = sys_read32(reg_base + IDMA_REG_INTR_STS);
@@ -616,43 +616,43 @@ static void i2c_dw_isr(const struct device *port)
 
 	} else {
 #ifdef CONFIG_I2C_TARGET
-		const struct i2c_target_callbacks *slave_cb = dw->slave_cfg->callbacks;
-		uint32_t slave_activity = test_bit_status_activity(reg_base);
+		const struct i2c_target_callbacks *target_cb = dw->target_cfg->callbacks;
+		uint32_t target_activity = test_bit_status_activity(reg_base);
 		uint8_t data;
 
-		i2c_dw_slave_read_clear_intr_bits(port, intr_stat);
+		i2c_dw_target_read_clear_intr_bits(port, intr_stat);
 
 		if (intr_stat.bits.rx_full) {
 			if (dw->state != I2C_DW_CMD_SEND) {
 				dw->state = I2C_DW_CMD_SEND;
 				dw->read_in_progress = false;
-				if (slave_cb->write_requested) {
-					slave_cb->write_requested(dw->slave_cfg);
+				if (target_cb->write_requested) {
+					target_cb->write_requested(dw->target_cfg);
 				}
 			}
 			/* FIFO needs to be drained here so we don't miss the next interrupt */
 			do {
 				data = i2c_dw_read_byte_non_blocking(port);
-				if (slave_cb->write_received) {
-					slave_cb->write_received(dw->slave_cfg, data);
+				if (target_cb->write_received) {
+					target_cb->write_received(dw->target_cfg, data);
 				}
 			} while (test_bit_status_rfne(reg_base));
 		}
 
 		if (intr_stat.bits.rd_req) {
-			if (slave_activity) {
+			if (target_activity) {
 				read_clr_rd_req(reg_base);
 				dw->state = I2C_DW_CMD_RECV;
 
 				if (!dw->read_in_progress) {
-					if (slave_cb->read_requested) {
-						slave_cb->read_requested(dw->slave_cfg, &data);
+					if (target_cb->read_requested) {
+						target_cb->read_requested(dw->target_cfg, &data);
 						i2c_dw_write_byte_non_blocking(port, data);
 					}
 					dw->read_in_progress = true;
 				} else {
-					if (slave_cb->read_processed) {
-						slave_cb->read_processed(dw->slave_cfg, &data);
+					if (target_cb->read_processed) {
+						target_cb->read_processed(dw->target_cfg, &data);
 						i2c_dw_write_byte_non_blocking(port, data);
 					}
 				}
@@ -661,8 +661,8 @@ static void i2c_dw_isr(const struct device *port)
 
 		if (intr_stat.bits.stop_det) {
 			read_clr_stop_det(reg_base);
-			if (slave_cb->stop) {
-				slave_cb->stop(dw->slave_cfg);
+			if (target_cb->stop) {
+				target_cb->stop(dw->target_cfg);
 			}
 			dw->state = I2C_DW_STATE_READY;
 			dw->read_in_progress = false;
@@ -676,7 +676,7 @@ done:
 	i2c_dw_transfer_complete(port);
 }
 
-static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
+static int i2c_dw_setup(const struct device *dev, uint16_t target_address)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t value;
@@ -686,9 +686,9 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 
 #if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
 	if (!dw->need_setup) {
-		/* If slave address changed setup is still needed */
+		/* If target address changed setup is still needed */
 		ic_tar.raw = read_tar(reg_base);
-		if (ic_tar.bits.ic_tar == slave_address) {
+		if (ic_tar.bits.ic_tar == target_address) {
 			return 0;
 		}
 	}
@@ -710,13 +710,13 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	/* Clear interrupts */
 	value = read_clr_intr(reg_base);
 
-	/* Set master or slave mode - (initialization = slave) */
+	/* Set controller or target mode - (initialization = target) */
 	if (I2C_MODE_CONTROLLER & dw->app_config) {
 		/*
 		 * Make sure to set both the master_mode and slave_disable_bit
 		 * to both 0 or both 1
 		 */
-		LOG_DBG("I2C: host configured as Master Device");
+		LOG_DBG("I2C: host configured as Controller Device");
 		ic_con.bits.master_mode = 1U;
 		ic_con.bits.slave_disable = 1U;
 	} else {
@@ -795,11 +795,11 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	ic_tar.raw = read_tar(reg_base);
 
 	if (test_bit_con_master_mode(reg_base)) {
-		/* Set address of target slave */
-		ic_tar.bits.ic_tar = slave_address;
+		/* Set address of target */
+		ic_tar.bits.ic_tar = target_address;
 	} else {
-		/* Set slave address for device */
-		write_sar(slave_address, reg_base);
+		/* Set target address for device */
+		write_sar(target_address, reg_base);
 	}
 
 	/* If I2C_DYNAMIC_TAR_UPDATE configuration parameter is set to Yes (1),
@@ -840,7 +840,7 @@ bool i2c_dw_is_busy(const struct device *dev)
 }
 
 static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
-			   uint16_t slave_address)
+			   uint16_t target_address)
 {
 	const struct i2c_dw_rom_config *const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
@@ -891,7 +891,7 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 
 	dw->state |= I2C_DW_BUSY;
 
-	ret = i2c_dw_setup(dev, slave_address);
+	ret = i2c_dw_setup(dev, target_address);
 	if (ret) {
 		goto error;
 	}
@@ -954,11 +954,12 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 		/* Enable interrupts to trigger ISR */
 		if (test_bit_con_master_mode(reg_base)) {
 			/* Enable necessary interrupts */
-			write_intr_mask((DW_ENABLE_TX_INT_I2C_MASTER | DW_ENABLE_RX_INT_I2C_MASTER),
+			write_intr_mask((DW_ENABLE_TX_INT_I2C_CONTROLLER |
+					 DW_ENABLE_RX_INT_I2C_CONTROLLER),
 					reg_base);
 		} else {
 			/* Enable necessary interrupts */
-			write_intr_mask(DW_ENABLE_TX_INT_I2C_SLAVE, reg_base);
+			write_intr_mask(DW_ENABLE_TX_INT_I2C_TARGET, reg_base);
 		}
 
 		/* Wait for transfer to be done */
@@ -1091,9 +1092,10 @@ static int i2c_dw_configure(const struct device *dev, uint32_t config)
 	value = read_clr_intr(reg_base);
 
 	/*
-	 * TEMPORARY HACK - The I2C does not work in any mode other than Master
-	 * currently.  This "hack" forces us to always be configured for master
-	 * mode, until we can verify that Slave mode works correctly.
+	 * TEMPORARY HACK - The I2C does not work in any mode other than
+	 * Controller currently.  This "hack" forces us to always be configured
+	 * for controller mode, until we can verify that Target mode works
+	 * correctly.
 	 */
 	dw->app_config |= I2C_MODE_CONTROLLER;
 
@@ -1139,7 +1141,7 @@ static inline void i2c_dw_write_byte_non_blocking(const struct device *dev, uint
 	write_cmd_data(data, reg_base);
 }
 
-static int i2c_dw_set_master_mode(const struct device *dev)
+static int i2c_dw_set_controller_mode(const struct device *dev)
 {
 	union ic_comp_param_1_register ic_comp_param_1;
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
@@ -1162,7 +1164,7 @@ static int i2c_dw_set_master_mode(const struct device *dev)
 	return 0;
 }
 
-static int i2c_dw_set_slave_mode(const struct device *dev, struct i2c_target_config *cfg)
+static int i2c_dw_set_target_mode(const struct device *dev, struct i2c_target_config *cfg)
 {
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
 	union ic_con_register ic_con;
@@ -1192,12 +1194,12 @@ static int i2c_dw_set_slave_mode(const struct device *dev, struct i2c_target_con
 	write_tx_tl(0, reg_base);
 	write_rx_tl(0, reg_base);
 
-	LOG_DBG("I2C: Host registered as Slave Device");
+	LOG_DBG("I2C: Host registered as Target Device");
 
 	return 0;
 }
 
-static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_config *cfg)
+static int i2c_dw_target_register(const struct device *dev, struct i2c_target_config *cfg)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
@@ -1209,8 +1211,8 @@ static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_con
 	}
 
 	dw->read_in_progress = false;
-	dw->slave_cfg = cfg;
-	ret = i2c_dw_set_slave_mode(dev, cfg);
+	dw->target_cfg = cfg;
+	ret = i2c_dw_set_target_mode(dev, cfg);
 	write_intr_mask(DW_INTR_MASK_RX_FULL | DW_INTR_MASK_RD_REQ |
 			DW_INTR_MASK_TX_ABRT | DW_INTR_MASK_STOP_DET |
 			DW_INTR_MASK_START_DET,
@@ -1219,21 +1221,21 @@ static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_con
 	return ret;
 }
 
-static int i2c_dw_slave_unregister(const struct device *dev, struct i2c_target_config *cfg)
+static int i2c_dw_target_unregister(const struct device *dev, struct i2c_target_config *cfg)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 	int ret;
 
 	dw->state = I2C_DW_STATE_READY;
-	ret = i2c_dw_set_master_mode(dev);
+	ret = i2c_dw_set_controller_mode(dev);
 
 	pm_device_runtime_put(dev);
 
 	return ret;
 }
 
-static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev,
-						union ic_interrupt_register intr_stat)
+static void i2c_dw_target_read_clear_intr_bits(const struct device *dev,
+					       union ic_interrupt_register intr_stat)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
@@ -1467,8 +1469,8 @@ static DEVICE_API(i2c, funcs) = {
 	.configure = i2c_dw_runtime_configure,
 	.transfer = i2c_dw_transfer,
 #ifdef CONFIG_I2C_TARGET
-	.target_register = i2c_dw_slave_register,
-	.target_unregister = i2c_dw_slave_unregister,
+	.target_register = i2c_dw_target_register,
+	.target_unregister = i2c_dw_target_unregister,
 #endif /* CONFIG_I2C_TARGET */
 #ifdef CONFIG_I2C_RTIO
 	.iodev_submit = i2c_iodev_submit_fallback,

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -54,21 +54,21 @@ typedef int (*i2c_api_check_bus_t)(const struct device *dev);
 #define I2C_DW_STUCK_ERR_MASK (I2C_DW_SCL_STUCK | I2C_DW_SDA_STUCK | I2C_DW_USER_ABRT)
 
 #ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
-#define DW_ENABLE_TX_INT_I2C_MASTER                                                                \
+#define DW_ENABLE_TX_INT_I2C_CONTROLLER                                                            \
 	(DW_INTR_STAT_TX_OVER | DW_INTR_STAT_TX_EMPTY | DW_INTR_STAT_TX_ABRT |                     \
 	 DW_INTR_STAT_STOP_DET | DW_INTR_STAT_SCL_STUCK_LOW)
 #else
-#define DW_ENABLE_TX_INT_I2C_MASTER                                                                \
+#define DW_ENABLE_TX_INT_I2C_CONTROLLER                                                            \
 	(DW_INTR_STAT_TX_OVER | DW_INTR_STAT_TX_EMPTY | DW_INTR_STAT_TX_ABRT |                     \
 	 DW_INTR_STAT_STOP_DET)
 #endif
-#define DW_ENABLE_RX_INT_I2C_MASTER                                                                \
+#define DW_ENABLE_RX_INT_I2C_CONTROLLER                                                            \
 	(DW_INTR_STAT_RX_UNDER | DW_INTR_STAT_RX_OVER | DW_INTR_STAT_RX_FULL |                     \
 	 DW_INTR_STAT_STOP_DET)
 
-#define DW_ENABLE_TX_INT_I2C_SLAVE                                                                 \
+#define DW_ENABLE_TX_INT_I2C_TARGET                                                                \
 	(DW_INTR_STAT_RD_REQ | DW_INTR_STAT_TX_ABRT | DW_INTR_STAT_STOP_DET)
-#define DW_ENABLE_RX_INT_I2C_SLAVE (DW_INTR_STAT_RX_FULL | DW_INTR_STAT_STOP_DET)
+#define DW_ENABLE_RX_INT_I2C_TARGET (DW_INTR_STAT_RX_FULL | DW_INTR_STAT_STOP_DET)
 
 #define DW_DISABLE_ALL_I2C_INT 0x00000000
 
@@ -210,7 +210,7 @@ struct i2c_dw_dev_config {
 	bool xfr_status;
 #endif
 
-	struct i2c_target_config *slave_cfg;
+	struct i2c_target_config *target_cfg;
 
 	i2c_api_recover_bus_t recover_bus_cb;
 	struct device *recover_bus_dev;


### PR DESCRIPTION
Update comments and driver-local identifiers to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

Identifiers mirroring the DesignWare databook (e.g. IC_CON union bitfields, IC_TAR union bitfield ic_10bitaddr_master, IC_TX_ABRT_SOURCE union bitfields) are kept unchanged.