### PR TITLE
drivers: i2c: nxp: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -30,7 +30,7 @@ struct i2c_imx_config {
 	const struct pinctrl_dev_config *pincfg;
 };
 
-struct i2c_master_transfer {
+struct i2c_controller_transfer {
 	const uint8_t     *txBuff;
 	volatile uint8_t  *rxBuff;
 	volatile uint32_t	cmdSize;
@@ -43,7 +43,7 @@ struct i2c_master_transfer {
 };
 
 struct i2c_imx_data {
-	struct i2c_master_transfer transfer;
+	struct i2c_controller_transfer transfer;
 	struct k_sem device_sync_sem;
 };
 
@@ -52,7 +52,7 @@ static bool i2c_imx_write(const struct device *dev, uint8_t *txBuffer,
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = dev->data;
-	struct i2c_master_transfer *transfer = &data->transfer;
+	struct i2c_controller_transfer *transfer = &data->transfer;
 
 	transfer->isBusy = true;
 
@@ -86,7 +86,7 @@ static void i2c_imx_read(const struct device *dev, uint8_t *rxBuffer,
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = dev->data;
-	struct i2c_master_transfer *transfer = &data->transfer;
+	struct i2c_controller_transfer *transfer = &data->transfer;
 
 	transfer->isBusy = true;
 
@@ -126,7 +126,7 @@ static int i2c_imx_configure(const struct device *dev,
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = dev->data;
-	struct i2c_master_transfer *transfer = &data->transfer;
+	struct i2c_controller_transfer *transfer = &data->transfer;
 	uint32_t baudrate;
 
 	if (!(I2C_MODE_CONTROLLER & dev_config_raw)) {
@@ -190,7 +190,7 @@ static int i2c_imx_transfer(const struct device *dev, struct i2c_msg *msgs,
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = dev->data;
-	struct i2c_master_transfer *transfer = &data->transfer;
+	struct i2c_controller_transfer *transfer = &data->transfer;
 	uint16_t timeout = UINT16_MAX;
 	int result = -EIO;
 
@@ -202,7 +202,7 @@ static int i2c_imx_transfer(const struct device *dev, struct i2c_msg *msgs,
 		return result;
 	}
 
-	/* Make sure we're in a good state so slave recognises the Start */
+	/* Make sure we're in a good state so target recognises the Start */
 	I2C_SetWorkMode(base, i2cModeSlave);
 	transfer->currentMode = i2cModeSlave;
 	/* Switch back to Rx direction. */
@@ -268,7 +268,7 @@ static void i2c_imx_isr(const struct device *dev)
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = dev->data;
-	struct i2c_master_transfer *transfer = &data->transfer;
+	struct i2c_controller_transfer *transfer = &data->transfer;
 
 	/* Clear interrupt flag. */
 	I2C_ClearStatusFlag(base, i2cStatusInterrupt);

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -102,8 +102,8 @@ static int lpc11u6x_i2c_transfer(const struct device *dev,
 	}
 	data->transfer.status = LPC11U6X_I2C_STATUS_INACTIVE;
 
-	/* If a slave is registered, put the controller in slave mode */
-	if (data->slave) {
+	/* If a target is registered, put the controller in target mode */
+	if (data->target) {
 		cfg->base->con_set = LPC11U6X_I2C_CONTROL_AA;
 	}
 
@@ -111,8 +111,8 @@ static int lpc11u6x_i2c_transfer(const struct device *dev,
 	return ret;
 }
 
-static int lpc11u6x_i2c_slave_register(const struct device *dev,
-				       struct i2c_target_config *cfg)
+static int lpc11u6x_i2c_target_register(const struct device *dev,
+					struct i2c_target_config *cfg)
 {
 	const struct lpc11u6x_i2c_config *dev_cfg = dev->config;
 	struct lpc11u6x_i2c_data *data = dev->data;
@@ -127,13 +127,13 @@ static int lpc11u6x_i2c_slave_register(const struct device *dev,
 	}
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
-	if (data->slave) {
+	if (data->target) {
 		ret = -EBUSY;
 		goto exit;
 	}
 
-	data->slave = cfg;
-	/* Configure controller to act as slave */
+	data->target = cfg;
+	/* Configure controller to act as target */
 	dev_cfg->base->addr0 = (cfg->address << 1);
 	dev_cfg->base->con_clr = LPC11U6X_I2C_CONTROL_START |
 		LPC11U6X_I2C_CONTROL_STOP | LPC11U6X_I2C_CONTROL_SI;
@@ -145,8 +145,8 @@ exit:
 }
 
 
-static int lpc11u6x_i2c_slave_unregister(const struct device *dev,
-					 struct i2c_target_config *cfg)
+static int lpc11u6x_i2c_target_unregister(const struct device *dev,
+					  struct i2c_target_config *cfg)
 {
 	const struct lpc11u6x_i2c_config *dev_cfg = dev->config;
 	struct lpc11u6x_i2c_data *data = dev->data;
@@ -154,12 +154,12 @@ static int lpc11u6x_i2c_slave_unregister(const struct device *dev,
 	if (!cfg) {
 		return -EINVAL;
 	}
-	if (data->slave != cfg) {
+	if (data->target != cfg) {
 		return -EINVAL;
 	}
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
-	data->slave = NULL;
+	data->target = NULL;
 	dev_cfg->base->con_clr = LPC11U6X_I2C_CONTROL_AA;
 	k_mutex_unlock(&data->mutex);
 
@@ -176,7 +176,7 @@ static void lpc11u6x_i2c_isr(const struct device *dev)
 	uint8_t val;
 
 	switch (i2c->stat) {
-		/* Master TX states */
+		/* Controller TX states */
 	case LPC11U6X_I2C_MASTER_TX_START:
 	case LPC11U6X_I2C_MASTER_TX_RESTART:
 		i2c->dat = (transfer->addr << 1) |
@@ -204,7 +204,7 @@ static void lpc11u6x_i2c_isr(const struct device *dev)
 		}
 		break;
 
-		/* Master RX states */
+		/* Controller RX states */
 	case LPC11U6X_I2C_MASTER_RX_DAT_NACK:
 		transfer->msgs++;
 		transfer->nr_msgs--;
@@ -227,12 +227,12 @@ static void lpc11u6x_i2c_isr(const struct device *dev)
 		}
 		break;
 
-		/* Slave States */
+		/* Target States */
 	case LPC11U6X_I2C_SLAVE_RX_ADR_ACK:
 	case LPC11U6X_I2C_SLAVE_RX_ARB_LOST_ADR_ACK:
 	case LPC11U6X_I2C_SLAVE_RX_GC_ACK:
 	case LPC11U6X_I2C_SLAVE_RX_ARB_LOST_GC_ACK:
-		if (data->slave->callbacks->write_requested(data->slave)) {
+		if (data->target->callbacks->write_requested(data->target)) {
 			clear |= LPC11U6X_I2C_CONTROL_AA;
 		}
 		break;
@@ -240,7 +240,7 @@ static void lpc11u6x_i2c_isr(const struct device *dev)
 	case LPC11U6X_I2C_SLAVE_RX_DAT_ACK:
 	case LPC11U6X_I2C_SLAVE_RX_GC_DAT_ACK:
 		val = i2c->dat;
-		if (data->slave->callbacks->write_received(data->slave, val)) {
+		if (data->target->callbacks->write_received(data->target, val)) {
 			clear |= LPC11U6X_I2C_CONTROL_AA;
 		}
 		break;
@@ -248,32 +248,32 @@ static void lpc11u6x_i2c_isr(const struct device *dev)
 	case LPC11U6X_I2C_SLAVE_RX_DAT_NACK:
 	case LPC11U6X_I2C_SLAVE_RX_GC_DAT_NACK:
 		val = i2c->dat;
-		data->slave->callbacks->write_received(data->slave, val);
-		data->slave->callbacks->stop(data->slave);
+		data->target->callbacks->write_received(data->target, val);
+		data->target->callbacks->stop(data->target);
 		set |= LPC11U6X_I2C_CONTROL_AA;
 		break;
 
 	case LPC11U6X_I2C_SLAVE_RX_STOP:
-		data->slave->callbacks->stop(data->slave);
+		data->target->callbacks->stop(data->target);
 		set |= LPC11U6X_I2C_CONTROL_AA;
 		break;
 
 	case LPC11U6X_I2C_SLAVE_TX_ADR_ACK:
 	case LPC11U6X_I2C_SLAVE_TX_ARB_LOST_ADR_ACK:
-		if (data->slave->callbacks->read_requested(data->slave, &val)) {
+		if (data->target->callbacks->read_requested(data->target, &val)) {
 			clear |= LPC11U6X_I2C_CONTROL_AA;
 		}
 		i2c->dat = val;
 		break;
 	case LPC11U6X_I2C_SLAVE_TX_DAT_ACK:
-		if (data->slave->callbacks->read_processed(data->slave, &val)) {
+		if (data->target->callbacks->read_processed(data->target, &val)) {
 			clear |= LPC11U6X_I2C_CONTROL_AA;
 		}
 		i2c->dat = val;
 		break;
 	case LPC11U6X_I2C_SLAVE_TX_DAT_NACK:
 	case LPC11U6X_I2C_SLAVE_TX_LAST_BYTE:
-		data->slave->callbacks->stop(data->slave);
+		data->target->callbacks->stop(data->target);
 		set |= LPC11U6X_I2C_CONTROL_AA;
 		break;
 
@@ -339,8 +339,8 @@ static int lpc11u6x_i2c_init(const struct device *dev)
 static DEVICE_API(i2c, i2c_api) = {
 	.configure = lpc11u6x_i2c_configure,
 	.transfer = lpc11u6x_i2c_transfer,
-	.target_register = lpc11u6x_i2c_slave_register,
-	.target_unregister = lpc11u6x_i2c_slave_unregister,
+	.target_register = lpc11u6x_i2c_target_register,
+	.target_unregister = lpc11u6x_i2c_target_unregister,
 #ifdef CONFIG_I2C_RTIO
 	.iodev_submit = i2c_iodev_submit_fallback,
 #endif

--- a/drivers/i2c/i2c_lpc11u6x.h
+++ b/drivers/i2c/i2c_lpc11u6x.h
@@ -57,14 +57,14 @@ struct lpc11u6x_i2c_regs {
 	volatile uint32_t con_set;           /* Control set */
 	volatile const uint32_t stat;        /* Status */
 	volatile uint32_t dat;               /* Data */
-	volatile uint32_t addr0;             /* Slave address 0 */
+	volatile uint32_t addr0;             /* Target address 0 */
 	volatile uint32_t sclh;              /* SCL Duty Cycle */
 	volatile uint32_t scll;              /* SCL Duty Cycle */
 	volatile uint32_t con_clr;           /* Control clear */
 	volatile uint32_t mm_ctrl;           /* Monitor mode control */
-	volatile uint32_t addr[3];           /* Slave address {1,2,3} */
+	volatile uint32_t addr[3];           /* Target address {1,2,3} */
 	volatile const uint32_t data_buffer; /* Data buffer */
-	volatile uint32_t mask[4];           /* Slave address mask */
+	volatile uint32_t mask[4];           /* Target address mask */
 };
 
 struct lpc11u6x_i2c_config {
@@ -86,7 +86,7 @@ struct lpc11u6x_i2c_current_transfer {
 
 struct lpc11u6x_i2c_data {
 	struct lpc11u6x_i2c_current_transfer transfer;
-	struct i2c_target_config *slave;
+	struct i2c_target_config *target;
 	struct k_sem completion;
 	struct k_mutex mutex;
 };

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -102,9 +102,9 @@ static void i2c_mcux_async_iter(const struct device *dev);
 
 #endif
 
-static void i2c_mcux_master_transfer_callback(I2C_Type *base,
-					      i2c_master_handle_t *handle,
-					      status_t status, void *userdata)
+static void i2c_mcux_controller_transfer_callback(I2C_Type *base,
+						  i2c_master_handle_t *handle,
+						  status_t status, void *userdata)
 {
 
 	ARG_UNUSED(handle);
@@ -449,7 +449,7 @@ static int i2c_mcux_target_register(const struct device *dev,
 	I2C_Type *base = DEV_BASE(dev);
 	const struct i2c_mcux_config *config = dev->config;
 	struct i2c_mcux_data *data = dev->data;
-	i2c_slave_config_t slave_config;
+	i2c_slave_config_t target_cfg;
 	uint32_t clock_freq;
 
 	if (!target_config || !target_config->callbacks) {
@@ -467,12 +467,12 @@ static int i2c_mcux_target_register(const struct device *dev,
 	data->target_first_rxtx = true;
 	data->target_receiving = false;
 
-	I2C_SlaveGetDefaultConfig(&slave_config);
-	slave_config.slaveAddress = target_config->address;
+	I2C_SlaveGetDefaultConfig(&target_cfg);
+	target_cfg.slaveAddress = target_config->address;
 
 	clock_freq = CLOCK_GetFreq(config->clock_source);
 
-	I2C_SlaveInit(base, &slave_config, clock_freq);
+	I2C_SlaveInit(base, &target_cfg, clock_freq);
 	I2C_SlaveClearStatusFlags(base, kClearFlags);
 	I2C_SlaveTransferCreateHandle(base, &data->target_handle, i2c_mcux_target_transfer_cb,
 				      (void *)dev);
@@ -525,17 +525,17 @@ static int i2c_mcux_init(const struct device *dev)
 	const struct i2c_mcux_config *config = dev->config;
 	struct i2c_mcux_data *data = dev->data;
 	uint32_t clock_freq, bitrate_cfg;
-	i2c_master_config_t master_config;
+	i2c_master_config_t controller_config;
 	int error;
 
 	k_sem_init(&data->lock, 1, 1);
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	clock_freq = CLOCK_GetFreq(config->clock_source);
-	I2C_MasterGetDefaultConfig(&master_config);
-	I2C_MasterInit(base, &master_config, clock_freq);
+	I2C_MasterGetDefaultConfig(&controller_config);
+	I2C_MasterInit(base, &controller_config, clock_freq);
 	I2C_MasterTransferCreateHandle(base, &data->handle,
-				       i2c_mcux_master_transfer_callback, (void *)dev);
+				       i2c_mcux_controller_transfer_callback, (void *)dev);
 
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -116,10 +116,10 @@ static int mcux_flexcomm_configure(const struct device *dev,
 	return 0;
 }
 
-static void mcux_flexcomm_master_transfer_callback(I2C_Type *base,
-						   i2c_master_handle_t *handle,
-						   status_t status,
-						   void *userData)
+static void mcux_flexcomm_controller_transfer_callback(I2C_Type *base,
+						       i2c_master_handle_t *handle,
+						       status_t status,
+						       void *userData)
 {
 	struct mcux_flexcomm_data *data = userData;
 
@@ -456,7 +456,7 @@ static void i2c_target_transfer_callback(I2C_Type *base,
 	}
 }
 
-static int mcux_flexcomm_setup_slave_config(const struct device *dev)
+static int mcux_flexcomm_setup_target_config(const struct device *dev)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
 	struct mcux_flexcomm_data *data = dev->data;
@@ -511,7 +511,7 @@ int mcux_flexcomm_target_register(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (mcux_flexcomm_setup_slave_config(dev) < 0) {
+	if (mcux_flexcomm_setup_target_config(dev) < 0) {
 		return -EINVAL;
 	}
 
@@ -542,8 +542,8 @@ int mcux_flexcomm_target_unregister(const struct device *dev,
 	data->nr_targets_attached--;
 
 	if (data->nr_targets_attached > 0) {
-		/* still slaves attached, reconfigure the I2C peripheral after address removal */
-		if (mcux_flexcomm_setup_slave_config(dev) < 0) {
+		/* still targets attached, reconfigure the I2C peripheral after address removal */
+		if (mcux_flexcomm_setup_target_config(dev) < 0) {
 			return -EINVAL;
 		}
 
@@ -577,7 +577,7 @@ static int mcux_flexcomm_init_common(const struct device *dev)
 	struct mcux_flexcomm_data *data = dev->data;
 	I2C_Type *base = config->base;
 	uint32_t clock_freq, bitrate_cfg;
-	i2c_master_config_t master_config;
+	i2c_master_config_t controller_config;
 	int error;
 
 	if (!device_is_ready(config->reset.dev)) {
@@ -615,11 +615,11 @@ static int mcux_flexcomm_init_common(const struct device *dev)
 		return -EINVAL;
 	}
 
-	I2C_MasterGetDefaultConfig(&master_config);
-	master_config.enableMaster = false;
-	I2C_MasterInit(base, &master_config, clock_freq);
+	I2C_MasterGetDefaultConfig(&controller_config);
+	controller_config.enableMaster = false;
+	I2C_MasterInit(base, &controller_config, clock_freq);
 	I2C_MasterTransferCreateHandle(base, &data->handle,
-				       mcux_flexcomm_master_transfer_callback,
+				       mcux_flexcomm_controller_transfer_callback,
 				       data);
 
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -123,9 +123,9 @@ static int mcux_lpi2c_configure(const struct device *dev,
 	return 0;
 }
 
-static void mcux_lpi2c_master_transfer_callback(LPI2C_Type *base,
-						lpi2c_master_handle_t *handle,
-						status_t status, void *userData)
+static void mcux_lpi2c_controller_transfer_callback(LPI2C_Type *base,
+						    lpi2c_master_handle_t *handle,
+						    status_t status, void *userData)
 {
 	struct mcux_lpi2c_data *data = userData;
 
@@ -316,7 +316,7 @@ restore:
 #endif /* CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY */
 
 #ifdef CONFIG_I2C_TARGET
-static void mcux_lpi2c_slave_irq_handler(const struct device *dev)
+static void mcux_lpi2c_target_irq_handler(const struct device *dev)
 {
 	struct mcux_lpi2c_data *data = dev->data;
 	LPI2C_Type *base = (LPI2C_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
@@ -325,7 +325,7 @@ static void mcux_lpi2c_slave_irq_handler(const struct device *dev)
 	uint32_t flags;
 	uint8_t i2c_data;
 
-	/* Note- the HAL provides a callback-based I2C slave API, but
+	/* Note- the HAL provides a callback-based I2C target API, but
 	 * the API expects the user to provide a transmit buffer of
 	 * a fixed length at the first byte received, and will not signal
 	 * the user callback until this buffer is exhausted. This does not
@@ -336,7 +336,7 @@ static void mcux_lpi2c_slave_irq_handler(const struct device *dev)
 	flags = LPI2C_SlaveGetStatusFlags(base);
 
 	if (flags & kLPI2C_SlaveAddressValidFlag) {
-		/* Read Slave address to clear flag */
+		/* Read target address to clear flag */
 		LPI2C_SlaveGetReceivedAddress(base);
 		data->first_tx = true;
 		/* Reset to sending ACK, in case we NAK'ed before */
@@ -415,7 +415,7 @@ static int mcux_lpi2c_target_register(const struct device *dev,
 	const struct mcux_lpi2c_config *config = dev->config;
 	struct mcux_lpi2c_data *data = dev->data;
 	LPI2C_Type *base = (LPI2C_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
-	lpi2c_slave_config_t slave_config;
+	lpi2c_slave_config_t target_cfg;
 	uint32_t clock_freq;
 
 	LPI2C_MasterDeinit(base);
@@ -438,14 +438,14 @@ static int mcux_lpi2c_target_register(const struct device *dev,
 	data->target_cfg = target_config;
 	data->first_tx = false;
 
-	LPI2C_SlaveGetDefaultConfig(&slave_config);
-	slave_config.address0 = target_config->address;
+	LPI2C_SlaveGetDefaultConfig(&target_cfg);
+	target_cfg.address0 = target_config->address;
 	/* Note- this setting enables clock stretching to allow the
-	 * slave to respond to each byte with an ACK/NAK.
+	 * target to respond to each byte with an ACK/NAK.
 	 * this behavior may cause issues with some I2C controllers.
 	 */
-	slave_config.sclStall.enableAck = true;
-	LPI2C_SlaveInit(base, &slave_config, clock_freq);
+	target_cfg.sclStall.enableAck = true;
+	LPI2C_SlaveInit(base, &target_cfg, clock_freq);
 	/* Clear all flags. */
 	LPI2C_SlaveClearStatusFlags(base, (uint32_t)kLPI2C_SlaveClearFlags);
 	/* Enable interrupt */
@@ -490,7 +490,7 @@ static void mcux_lpi2c_isr(const struct device *dev)
 
  #ifdef CONFIG_I2C_TARGET
 	if (data->target_attached) {
-		mcux_lpi2c_slave_irq_handler(dev);
+		mcux_lpi2c_target_irq_handler(dev);
 	}
 #endif /* CONFIG_I2C_TARGET */
 
@@ -549,7 +549,7 @@ static int mcux_lpi2c_init(const struct device *dev)
 	struct mcux_lpi2c_data *data = dev->data;
 	LPI2C_Type *base;
 	uint32_t clock_freq, bitrate_cfg;
-	lpi2c_master_config_t master_config;
+	lpi2c_master_config_t controller_config;
 	int error;
 
 	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
@@ -596,11 +596,11 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	LPI2C_MasterGetDefaultConfig(&master_config);
-	master_config.busIdleTimeout_ns = config->bus_idle_timeout_ns;
-	LPI2C_MasterInit(base, &master_config, clock_freq);
+	LPI2C_MasterGetDefaultConfig(&controller_config);
+	controller_config.busIdleTimeout_ns = config->bus_idle_timeout_ns;
+	LPI2C_MasterInit(base, &controller_config, clock_freq);
 	LPI2C_MasterTransferCreateHandle(base, &data->handle,
-					 mcux_lpi2c_master_transfer_callback,
+					 mcux_lpi2c_controller_transfer_callback,
 					 data);
 
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -261,9 +261,9 @@ static void mcux_lpi2c_submit(const struct device *dev, struct rtio_iodev_sqe *i
 	}
 }
 
-static void mcux_lpi2c_master_transfer_callback(LPI2C_Type *base,
-						lpi2c_master_handle_t *handle,
-						status_t status, void *userData)
+static void mcux_lpi2c_controller_transfer_callback(LPI2C_Type *base,
+						    lpi2c_master_handle_t *handle,
+						    status_t status, void *userData)
 {
 	ARG_UNUSED(handle);
 	ARG_UNUSED(base);
@@ -302,7 +302,7 @@ static int mcux_lpi2c_init(const struct device *dev)
 	struct mcux_lpi2c_data *data = dev->data;
 	LPI2C_Type *base;
 	uint32_t clock_freq, bitrate_cfg;
-	lpi2c_master_config_t master_config;
+	lpi2c_master_config_t controller_config;
 	int error;
 
 	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
@@ -324,11 +324,11 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	LPI2C_MasterGetDefaultConfig(&master_config);
-	master_config.busIdleTimeout_ns = config->bus_idle_timeout_ns;
-	LPI2C_MasterInit(base, &master_config, clock_freq);
+	LPI2C_MasterGetDefaultConfig(&controller_config);
+	controller_config.busIdleTimeout_ns = config->bus_idle_timeout_ns;
+	LPI2C_MasterInit(base, &controller_config, clock_freq);
 	LPI2C_MasterTransferCreateHandle(base, &data->handle,
-					 mcux_lpi2c_master_transfer_callback,
+					 mcux_lpi2c_controller_transfer_callback,
 					 (void *)dev);
 
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);

--- a/drivers/i2c/i2c_nxp_ii2c.c
+++ b/drivers/i2c/i2c_nxp_ii2c.c
@@ -105,9 +105,9 @@ static void nxp_ii2c_async_iter(const struct device *dev);
 
 #endif
 
-static void nxp_ii2c_master_transfer_callback(I2C_Type *base,
-					      i2c_master_handle_t *handle,
-					      status_t status, void *userdata)
+static void nxp_ii2c_controller_transfer_callback(I2C_Type *base,
+						  i2c_master_handle_t *handle,
+						  status_t status, void *userdata)
 {
 
 	ARG_UNUSED(handle);
@@ -324,7 +324,7 @@ static int nxp_ii2c_init(const struct device *dev)
 	const struct nxp_ii2c_config *config = dev->config;
 	struct nxp_ii2c_data *data = dev->data;
 	uint32_t clock_freq, bitrate_cfg;
-	i2c_master_config_t master_config;
+	i2c_master_config_t controller_config;
 	int error;
 
 	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
@@ -349,10 +349,10 @@ static int nxp_ii2c_init(const struct device *dev)
 	k_sem_init(&data->lock, 1, 1);
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
-	I2C_MasterGetDefaultConfig(&master_config);
-	I2C_MasterInit(base, &master_config, clock_freq);
+	I2C_MasterGetDefaultConfig(&controller_config);
+	I2C_MasterInit(base, &controller_config, clock_freq);
 	I2C_MasterTransferCreateHandle(base, &data->handle,
-				       nxp_ii2c_master_transfer_callback, (void *)dev);
+				       nxp_ii2c_controller_transfer_callback, (void *)dev);
 
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -49,8 +49,8 @@ static int rv32m1_lpi2c_configure(const struct device *dev,
 	int err;
 
 	if (!(I2C_MODE_CONTROLLER & dev_config)) {
-		/* Slave mode not supported - yet */
-		LOG_ERR("Slave mode not supported");
+		/* Target mode not supported - yet */
+		LOG_ERR("Target mode not supported");
 		return -ENOTSUP;
 	}
 
@@ -94,10 +94,10 @@ static int rv32m1_lpi2c_configure(const struct device *dev,
 	return 0;
 }
 
-static void rv32m1_lpi2c_master_transfer_callback(LPI2C_Type *base,
-						  lpi2c_master_handle_t *handle,
-						  status_t completionStatus,
-						  void *userData)
+static void rv32m1_lpi2c_controller_transfer_callback(LPI2C_Type *base,
+						      lpi2c_master_handle_t *handle,
+						      status_t completionStatus,
+						      void *userData)
 {
 	struct rv32m1_lpi2c_data *data = userData;
 
@@ -205,7 +205,7 @@ static int rv32m1_lpi2c_init(const struct device *dev)
 {
 	const struct rv32m1_lpi2c_config *config = dev->config;
 	struct rv32m1_lpi2c_data *data = dev->data;
-	lpi2c_master_config_t master_config;
+	lpi2c_master_config_t controller_config;
 	uint32_t clk_freq, dev_cfg;
 	int err;
 
@@ -228,10 +228,10 @@ static int rv32m1_lpi2c_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	LPI2C_MasterGetDefaultConfig(&master_config);
-	LPI2C_MasterInit(config->base, &master_config, clk_freq);
+	LPI2C_MasterGetDefaultConfig(&controller_config);
+	LPI2C_MasterInit(config->base, &controller_config, clk_freq);
 	LPI2C_MasterTransferCreateHandle(config->base, &data->handle,
-					 rv32m1_lpi2c_master_transfer_callback,
+					 rv32m1_lpi2c_controller_transfer_callback,
 					 data);
 
 	dev_cfg = i2c_map_dt_bitrate(config->bitrate);


### PR DESCRIPTION
Update comments, log messages, Kconfig prose, and driver-local identifiers to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.