### PR TITLE
drivers: i2c: ite: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -53,7 +53,7 @@ LOG_MODULE_REGISTER(i2c_ite_enhance, CONFIG_I2C_LOG_LEVEL);
 #define I2C_CQ_CMD_L_P  BIT(5)
 /* E (End) is this device end flag. */
 #define I2C_CQ_CMD_L_E  BIT(4)
-/* LA (Last ACK) is Last ACK in master receiver. */
+/* LA (Last ACK) is Last ACK in controller receiver. */
 #define I2C_CQ_CMD_L_LA BIT(3)
 /* bit[2:0] are number of transfer out or receive data which depends on R/W. */
 #define I2C_CQ_CMD_L_NUM_BIT_2_0 GENMASK(2, 0)
@@ -194,7 +194,7 @@ enum enhanced_i2c_ctl {
 	E_RX_MODE = 0x80,
 	/* State reset and hardware reset */
 	E_STS_AND_HW_RST = (E_STS_RST | E_HW_RST),
-	/* Generate start condition and transmit slave address */
+	/* Generate start condition and transmit target address */
 	E_START_ID = (E_INT_EN | E_MODE_SEL | E_ACK | E_START | E_HW_RST),
 	/* Generate stop condition */
 	E_FINISH = (E_INT_EN | E_MODE_SEL | E_ACK | E_STOP | E_HW_RST),
@@ -468,7 +468,7 @@ static void i2c_pio_trans_data(const struct device *dev,
 	uint32_t nack = 0;
 
 	if (first_byte) {
-		/* First byte must be slave address. */
+		/* First byte must be target address. */
 		IT8XXX2_I2C_DTR(base) = trans_data |
 					(direct == RX_DIRECT ? BIT(0) : 0);
 		/* start or repeat start signal. */

--- a/drivers/i2c/i2c_ite_it51xxx.c
+++ b/drivers/i2c/i2c_ite_it51xxx.c
@@ -1956,7 +1956,7 @@ static int i2c_it51xxx_init(const struct device *dev)
 
 	/* Enable SMBus function */
 	sys_write8(SMB_SMD_TO_EN | SMB_SMH_EN, config->host_base + SMB_HOCTL2);
-	/* Kill SMBus host transaction. And enable the interrupt for the master interface */
+	/* Kill SMBus host transaction. And enable the interrupt for the controller interface */
 	sys_write8(SMB_KILL | SMB_INTREN, config->host_base + SMB_HOCTL);
 	sys_write8(SMB_INTREN, config->host_base + SMB_HOCTL);
 	/* W/C host status register */

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -766,7 +766,7 @@ int __soc_ram_code i2c_tran_read(const struct device *dev)
 					   IT8XXX2_SMB_SMHEN;
 		/*
 		 * bit0, Direction of the host transfer.
-		 * bit[1:7}, Address of the targeted slave.
+		 * bit[1:7}, Address of the target.
 		 */
 		IT8XXX2_SMB_TRASLA(base) = (uint8_t)(data->addr_16bit << 1) |
 					   IT8XXX2_SMB_DIR;
@@ -848,7 +848,7 @@ int __soc_ram_code i2c_tran_write(const struct device *dev)
 					   IT8XXX2_SMB_SMHEN;
 		/*
 		 * bit0, Direction of the host transfer.
-		 * bit[1:7}, Address of the targeted slave.
+		 * bit[1:7}, Address of the target.
 		 */
 		IT8XXX2_SMB_TRASLA(base) = (uint8_t)data->addr_16bit << 1;
 		/* Send first byte */
@@ -1123,13 +1123,13 @@ static int i2c_it8xxx2_init(const struct device *dev)
 	 * bit1, Enable to communicate with I2C device
 	 *		  and support I2C-compatible cycles.
 	 * bit4, This bit controls the reset mechanism
-	 *		  of SMBus master to handle the SMDAT
+	 *		  of SMBus controller to handle the SMDAT
 	 *		  line low if 25ms reg timeout.
 	 */
 	IT8XXX2_SMB_HOCTL2(base) = IT8XXX2_SMB_SMD_TO_EN | IT8XXX2_SMB_SMHEN;
 	/*
 	 * bit1, Kill SMBus host transaction.
-	 * bit0, Enable the interrupt for the master interface.
+	 * bit0, Enable the interrupt for the controller interface.
 	 */
 	IT8XXX2_SMB_HOCTL(base) = IT8XXX2_SMB_KILL | IT8XXX2_SMB_SMHEN;
 	IT8XXX2_SMB_HOCTL(base) = IT8XXX2_SMB_SMHEN;


### PR DESCRIPTION
Update comments to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

Identifiers mirroring the ITE datasheet (e.g. ITE SMBus host/target register mnemonics SMB_* and their verbatim datasheet register-title comments, ITE IT8XXX2_SMB_* / IT8XXX2_I2C_* register accessor macros, ITE command-queue datasheet bit names) are kept unchanged.