### PR TITLE
drivers: i2c: ameba: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_ameba.c
+++ b/drivers/i2c/i2c_ameba.c
@@ -38,9 +38,9 @@ struct i2c_dma_stream {
 #endif
 
 struct i2c_ameba_data {
-	uint32_t master_mode;
+	uint32_t controller_mode;
 	uint32_t addr_mode;
-	uint32_t slave_address;
+	uint32_t target_address;
 	uint32_t dev_config;
 	struct i2c_msg *current;
 	volatile int flag_done;
@@ -273,7 +273,7 @@ static int i2c_rx_dma_config(const struct device *dev, uint8_t *pdata, uint32_t 
 	return dma_config(i2c_dma->dma_dev, i2c_dma->dma_channel, &i2c_dma->dma_cfg);
 }
 
-static int i2c_send_dma_master(const struct device *dev, uint8_t *pdata, uint32_t length)
+static int i2c_send_dma_controller(const struct device *dev, uint8_t *pdata, uint32_t length)
 {
 	struct i2c_ameba_data *data = dev->data;
 	const struct i2c_ameba_config *cfg = dev->config;
@@ -292,7 +292,7 @@ static int i2c_send_dma_master(const struct device *dev, uint8_t *pdata, uint32_
 	return 0;
 }
 
-static int i2c_send_dma_slave(const struct device *dev, uint8_t *pdata, uint32_t length)
+static int i2c_send_dma_target(const struct device *dev, uint8_t *pdata, uint32_t length)
 {
 	struct i2c_ameba_data *data = dev->data;
 	const struct i2c_ameba_config *cfg = dev->config;
@@ -313,7 +313,7 @@ static int i2c_send_dma_slave(const struct device *dev, uint8_t *pdata, uint32_t
 	return 0;
 }
 
-static int i2c_receive_dma_master(const struct device *dev, uint8_t *pdata, uint32_t length)
+static int i2c_receive_dma_controller(const struct device *dev, uint8_t *pdata, uint32_t length)
 {
 	struct i2c_ameba_data *data = dev->data;
 	const struct i2c_ameba_config *cfg = dev->config;
@@ -332,7 +332,7 @@ static int i2c_receive_dma_master(const struct device *dev, uint8_t *pdata, uint
 	return 0;
 }
 
-static int i2c_receive_dma_slave(const struct device *dev, uint8_t *pdata, uint32_t length)
+static int i2c_receive_dma_target(const struct device *dev, uint8_t *pdata, uint32_t length)
 {
 	struct i2c_ameba_data *data = dev->data;
 	const struct i2c_ameba_config *cfg = dev->config;
@@ -396,7 +396,7 @@ static int i2c_ameba_configure(const struct device *dev, uint32_t dev_config)
 		goto error;
 	}
 
-	data->master_mode = I2C_InitStruct.I2CMaster;
+	data->controller_mode = I2C_InitStruct.I2CMaster;
 	data->addr_mode = I2C_InitStruct.I2CAddrMod;
 	data->dev_config = dev_config;
 
@@ -476,7 +476,7 @@ static int i2c_ameba_transfer(const struct device *dev, struct i2c_msg *msgs,
 	I2C_SetSlaveAddress(i2c, addr);
 	/* Enable i2c device */
 	I2C_Cmd(i2c, ENABLE);
-	data->slave_address = addr;
+	data->target_address = addr;
 
 	/* 3. Execute Transfer */
 #if defined(CONFIG_I2C_AMEBA_INTERRUPT)
@@ -484,7 +484,7 @@ static int i2c_ameba_transfer(const struct device *dev, struct i2c_msg *msgs,
 	for (uint8_t i = 0; i < num_msgs; ++i) {
 		data->current = &msgs[i];
 
-		if (data->master_mode == 1) {
+		if (data->controller_mode == 1) {
 			data->flag_done = 0;
 			I2C_INTConfig(i2c, I2C_BIT_R_STOP_DET, ENABLE);
 
@@ -509,23 +509,25 @@ static int i2c_ameba_transfer(const struct device *dev, struct i2c_msg *msgs,
 		data->current = &msgs[i];
 		data->flag_dma_done = 0;
 		I2C_Cmd(i2c, ENABLE);
-		if (data->master_mode == 1) {
+		if (data->controller_mode == 1) {
 			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
-				i2c_send_dma_master(dev, data->current->buf, data->current->len);
+				i2c_send_dma_controller(dev, data->current->buf,
+							data->current->len);
 				while (data->flag_dma_done == 0) {
 				}
 			} else {
-				i2c_receive_dma_master(dev, data->current->buf, data->current->len);
+				i2c_receive_dma_controller(dev, data->current->buf,
+							   data->current->len);
 				while (data->flag_dma_done == 0) {
 				}
 			}
 		} else {
 			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
-				i2c_send_dma_slave(dev, data->current->buf, data->current->len);
+				i2c_send_dma_target(dev, data->current->buf, data->current->len);
 				while (data->flag_dma_done == 0) {
 				}
 			} else {
-				i2c_receive_dma_slave(dev, data->current->buf, data->current->len);
+				i2c_receive_dma_target(dev, data->current->buf, data->current->len);
 				while (data->flag_dma_done == 0) {
 				}
 			}
@@ -535,7 +537,7 @@ static int i2c_ameba_transfer(const struct device *dev, struct i2c_msg *msgs,
 	for (uint8_t i = 0; i < num_msgs; ++i) {
 		k_sleep(K_MSEC(5));
 		data->current = &msgs[i];
-		if (data->master_mode == 1) {
+		if (data->controller_mode == 1) {
 			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
 				I2C_MasterWrite(i2c, data->current->buf, data->current->len);
 			} else {


### PR DESCRIPTION
Update comments, log messages and driver-local identifiers to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

Identifiers mirroring the Realtek Ameba HAL (e.g. I2CMaster, I2C_MASTER_MODE, I2C_SLAVE_MODE) are kept unchanged.
