### PR TITLE
drivers: i2c: max32: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_max32.c
+++ b/drivers/i2c/i2c_max32.c
@@ -708,14 +708,14 @@ static void i2c_max32_isr_target(const struct device *dev, mxc_i2c_regs_t *i2c)
 		if (int_fl0 & ADI_MAX32_I2C_INT_FL0_ADDR_MATCH) {
 			/* Address match occurred, prepare for transaction */
 			if (Wrap_MXC_I2C_GetReadWriteBitStatus(i2c)) {
-				/* Read request received from the master */
+				/* Read request received from the controller */
 				i2c_max32_target_callback(dev, i2c, MXC_I2C_EVT_MASTER_RD);
 				int_en0 = ADI_MAX32_I2C_INT_EN0_TX_THD |
 					  ADI_MAX32_I2C_INT_EN0_TX_LOCK_OUT |
 					  ADI_MAX32_I2C_INT_EN0_DONE | ADI_MAX32_I2C_INT_EN0_ERR;
 				int_en1 = ADI_MAX32_I2C_INT_EN1_TX_UNDERFLOW;
 			} else {
-				/* Write request received from the master */
+				/* Write request received from the controller */
 				i2c_max32_target_callback(dev, i2c, MXC_I2C_EVT_MASTER_WR);
 				int_en0 = ADI_MAX32_I2C_INT_EN0_RX_THD |
 					  ADI_MAX32_I2C_INT_EN0_DONE | ADI_MAX32_I2C_INT_EN0_ERR;
@@ -938,7 +938,7 @@ static int i2c_max32_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = MXC_I2C_Init(i2c, 1, 0); /* Configure as master */
+	ret = MXC_I2C_Init(i2c, 1, 0); /* Configure as controller */
 	if (ret) {
 		return ret;
 	}

--- a/drivers/i2c/i2c_max32_rtio.c
+++ b/drivers/i2c/i2c_max32_rtio.c
@@ -384,7 +384,7 @@ static int i2c_max32_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = MXC_I2C_Init(i2c, 1, 0); /* Configure as master */
+	ret = MXC_I2C_Init(i2c, 1, 0); /* Configure as controller */
 	if (ret) {
 		return ret;
 	}


### PR DESCRIPTION
Update comments, log messages, Kconfig prose, and driver-local identifiers to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

Identifiers mirroring the ADI MAX32 SDK and datasheet (e.g. MXC_I2C_SlaveTransactionAsync, mxc_i2c_slave_event_t, MXC_I2C_EVT_MASTER_WR) are kept unchanged.