### PR TITLE
drivers: i2c: smartbond: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_smartbond.c
+++ b/drivers/i2c/i2c_smartbond.c
@@ -140,7 +140,7 @@ static int i2c_smartbond_apply_configure(const struct device *dev, uint32_t dev_
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	/* Enable sending RESTART as master */
+	/* Enable sending RESTART as controller */
 	con_reg |= I2C_I2C_CON_REG_I2C_RESTART_EN_Msk;
 
 	i2c_smartbond_disable_when_inactive(dev);


### PR DESCRIPTION
Use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

Identifiers mirroring the Renesas Smartbond datasheet (e.g. I2C_I2C_CON_REG_I2C_MASTER_MODE_Msk, I2C_I2C_CON_REG_I2C_SLAVE_DISABLE_Msk, I2C_I2C_CON_REG_I2C_10BITADDR_MASTER_Msk) are kept unchanged.