### PR TITLE
drivers: i2c: sam: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_mchp_sercom_g1.c
+++ b/drivers/i2c/i2c_mchp_sercom_g1.c
@@ -215,7 +215,7 @@ static inline void i2c_set_ack(const struct device *dev, bool ack)
 	}
 }
 
-/* Checks if NACK was received from I2C slave */
+/* Checks if NACK was received from I2C target */
 static inline bool i2c_got_nack(const struct device *dev)
 {
 	return (I2CM(dev).SERCOM_STATUS & SERCOM_I2CM_STATUS_RXNACK_Msk) != 0;

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -10,7 +10,7 @@
 /** @file
  * @brief I2C bus (TWIM) driver for Atmel SAM4L MCU family.
  *
- * I2C Master Mode with 7/10 bit addressing is currently supported.
+ * I2C Controller Mode with 7/10 bit addressing is currently supported.
  * Very long transfers are allowed using NCMDR register. DMA is not
  * yet supported.
  */
@@ -170,7 +170,7 @@ static int i2c_sam_twim_configure(const struct device *dev, uint32_t config)
 	int ret;
 
 	if (!(config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Master Mode is not enabled");
+		LOG_ERR("Controller Mode is not enabled");
 		return -EIO;
 	}
 
@@ -331,8 +331,8 @@ static void i2c_start_xfer(const struct device *dev, uint16_t daddr)
 		twim->CMDR = cmdr_reg | TWIM_CMDR_START;
 
 		/* Fill next transfer command. REPSAME performs a repeated
-		 * start to the same slave address as addressed in the
-		 * previous transfer in order to enter master receiver mode.
+		 * start to the same target address as addressed in the
+		 * previous transfer in order to enter controller receiver mode.
 		 */
 		cmdr_reg |= TWIM_CMDR_REPSAME;
 
@@ -368,7 +368,7 @@ static void i2c_start_xfer(const struct device *dev, uint16_t daddr)
 	cmdr_reg = twim->CMDR;
 	cur_is_read = (cmdr_reg & TWIM_CMDR_READ);
 
-	/* Enable master transfer */
+	/* Enable controller transfer */
 	twim->CR = TWIM_CR_MEN;
 
 	twim->IER = TWIM_IER_STD_MASK |

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -11,7 +11,7 @@
  * @brief I2C bus (TWI) driver for Atmel SAM MCU family.
  *
  * Limitations:
- * - Only I2C Master Mode with 7 bit addressing is currently supported.
+ * - Only I2C Controller Mode with 7 bit addressing is currently supported.
  * - No reentrancy support.
  */
 
@@ -127,7 +127,7 @@ static int i2c_sam_twi_configure(const struct device *dev, uint32_t config)
 	int ret;
 
 	if (!(config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Master Mode is not enabled");
+		LOG_ERR("Controller Mode is not enabled");
 		return -EIO;
 	}
 
@@ -158,10 +158,10 @@ static int i2c_sam_twi_configure(const struct device *dev, uint32_t config)
 		goto unlock;
 	}
 
-	/* Disable Slave Mode */
+	/* Disable Target Mode */
 	twi->TWI_CR = TWI_CR_SVDIS;
 
-	/* Enable Master Mode */
+	/* Enable Controller Mode */
 	twi->TWI_CR = TWI_CR_MSEN;
 
 	ret = 0;
@@ -173,7 +173,7 @@ unlock:
 
 static void write_msg_start(Twi *const twi, struct twi_msg *msg, uint8_t daddr)
 {
-	/* Set slave address and number of internal address bytes. */
+	/* Set target address and number of internal address bytes. */
 	twi->TWI_MMR = TWI_MMR_DADR(daddr);
 
 	/* Write first data byte on I2C bus */
@@ -187,7 +187,7 @@ static void read_msg_start(Twi *const twi, struct twi_msg *msg, uint8_t daddr)
 {
 	uint32_t twi_cr_stop;
 
-	/* Set slave address and number of internal address bytes */
+	/* Set target address and number of internal address bytes */
 	twi->TWI_MMR = TWI_MMR_MREAD | TWI_MMR_DADR(daddr);
 
 	/* In single data byte read the START and STOP must both be set */
@@ -229,7 +229,7 @@ static int i2c_sam_twi_transfer(const struct device *dev,
 		 * REMARK: Dirty workaround:
 		 *
 		 * The controller does not have a documented, generic way to
-		 * issue RESTART when changing transfer direction as master.
+		 * issue RESTART when changing transfer direction as controller.
 		 * Send a stop condition in such a case.
 		 */
 		if (num_msgs > 1) {

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -10,7 +10,7 @@
 /** @file
  * @brief I2C bus (TWIHS) driver for Atmel SAM MCU family.
  *
- * Only I2C Master Mode with 7 bit addressing is currently supported.
+ * Only I2C Controller Mode with 7 bit addressing is currently supported.
  */
 
 
@@ -111,7 +111,7 @@ static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
 	int ret;
 
 	if (!(config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Master Mode is not enabled");
+		LOG_ERR("Controller Mode is not enabled");
 		return -EIO;
 	}
 
@@ -142,10 +142,10 @@ static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
 		goto unlock;
 	}
 
-	/* Disable Slave Mode */
+	/* Disable Target Mode */
 	twihs->TWIHS_CR = TWIHS_CR_SVDIS;
 
-	/* Enable Master Mode */
+	/* Enable Controller Mode */
 	twihs->TWIHS_CR = TWIHS_CR_MSEN;
 
 	ret = 0;
@@ -158,7 +158,7 @@ unlock:
 static void write_msg_start(Twihs *const twihs, struct twihs_msg *msg,
 			    uint8_t daddr)
 {
-	/* Set slave address. */
+	/* Set target address. */
 	twihs->TWIHS_MMR = TWIHS_MMR_DADR(daddr);
 
 	/* Write first data byte on I2C bus */
@@ -173,7 +173,7 @@ static void read_msg_start(Twihs *const twihs, struct twihs_msg *msg,
 {
 	uint32_t twihs_cr_stop;
 
-	/* Set slave address and number of internal address bytes */
+	/* Set target address and number of internal address bytes */
 	twihs->TWIHS_MMR = TWIHS_MMR_MREAD | TWIHS_MMR_DADR(daddr);
 
 	/* In single data byte read the START and STOP must both be set */

--- a/drivers/i2c/i2c_sam_twihs_rtio.c
+++ b/drivers/i2c/i2c_sam_twihs_rtio.c
@@ -97,7 +97,7 @@ static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
 	int ret;
 
 	if (!(config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Master Mode is not enabled");
+		LOG_ERR("Controller Mode is not enabled");
 		return -EIO;
 	}
 


### PR DESCRIPTION
Update comments to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

