### PR TITLE
drivers: i2c: b91: use inclusive terminology

### DIFF
--- a/drivers/i2c/i2c_b91.c
+++ b/drivers/i2c/i2c_b91.c
@@ -40,9 +40,9 @@ static int i2c_b91_configure(const struct device *dev, uint32_t dev_config)
 		return -ENOTSUP;
 	}
 
-	/* check I2C Master/Slave configuration */
+	/* check I2C Controller/Target configuration */
 	if (!(dev_config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("I2C slave is not implemented");
+		LOG_ERR("I2C target is not implemented");
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Update comments, log messages, Kconfig prose, and driver-local identifiers to use the controller/target terminology ratified by coding guideline A.2 and already used by the Zephyr I2C API.

Identifiers mirroring the Telink HAL (e.g. i2c_master_init, i2c_set_master_clk, i2c_master_send_stop) are kept unchanged.