### PR TITLE
mgmt: mcumgr: os: refuse an echo request that carries no data

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -180,7 +180,10 @@ static int os_mgmt_echo(struct smp_streamer *ctxt)
 
 	ok = zcbor_map_decode_bulk(zsd, echo_decode, ARRAY_SIZE(echo_decode), &decoded) == 0;
 
-	if (!ok) {
+	/* No "d" key leaves data a zero-length string with no buffer;
+	 * echoing it back would hand zcbor_tstr_encode() a NULL pointer.
+	 */
+	if (!ok || decoded == 0) {
 		return MGMT_ERR_EINVAL;
 	}
 

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_echo/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_echo/src/main.c
@@ -63,4 +63,41 @@ ZTEST(os_mgmt_echo, test_echo)
 			  "Expected received data mismatch");
 }
 
+/* Echo request with an empty map: the "d" key is absent. */
+static const uint8_t command_no_data[] = {
+	0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x01, 0x00,
+	0xbf, 0xff,
+};
+
+/* Expected response: rc = MGMT_ERR_EINVAL. */
+static const uint8_t expected_response_no_data[] = {
+	0x03, 0x00, 0x00, 0x06, 0x00, 0x00, 0x01, 0x00,
+	0xbf, 0x62, 0x72, 0x63, 0x03, 0xff,
+};
+
+ZTEST(os_mgmt_echo, test_echo_no_data)
+{
+	struct net_buf *nb;
+
+	smp_dummy_enable();
+	smp_dummy_clear_state();
+
+	(void)smp_dummy_tx_pkt(command_no_data, sizeof(command_no_data));
+	smp_dummy_add_data();
+
+	bool received = smp_dummy_wait_for_data(SMP_RESPONSE_WAIT_TIME);
+
+	zassert_true(received, "Expected to receive data but timed out\n");
+
+	nb = smp_dummy_get_outgoing();
+	smp_dummy_disable();
+
+	zassert_equal(sizeof(expected_response_no_data), nb->len,
+		      "Expected to receive %zu bytes but got %d\n",
+		      sizeof(expected_response_no_data), nb->len);
+
+	zassert_mem_equal(expected_response_no_data, nb->data, nb->len,
+			  "Expected received data mismatch");
+}
+
 ZTEST_SUITE(os_mgmt_echo, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
`os_mgmt_echo()` decodes into `struct zcbor_string data = { 0 }` with `zcbor_map_decode_bulk()`, which reports success when the map holds none of the keys it was given. A request whose payload is an empty map therefore reaches the encoder with `data` still holding a NULL pointer and a length of zero, and the device answers with a successful echo of a string the peer never sent. Getting there costs ten bytes, and MCUmgr parses them before anything has authenticated the peer:

```
02 00 00 02 00 00 01 00 bf ff
```

Encoding that string is undefined behaviour rather than a harmless no-op: `zcbor_tstr_encode()` reaches `memmove(dst, NULL, 0)`. Under the address and undefined behaviour sanitizers an unmodified tree reports `zcbor_encode.c:283:31: runtime error: null pointer passed as argument 2`, and does not with this commit applied.

The fix requires the key the command is defined around. `smp_group_0.rst` documents the request as `{"d": (str)}` with no optional marker, so this refuses something the protocol never allowed, and a request carrying `"d"` is unaffected, including `"d": ""`, which still decodes and still echoes.

Testing: `tests/subsys/mgmt/mcumgr/os_mgmt_echo` on `native_sim`, 2 of 2 pass. Watched it fail: on an unmodified tree the new case fails, the reply being `03 00 00 05 00 00 01 00 bf 61 72 60 ff`, an echo of the empty string.

One question for the reviewer. I used `decoded == 0`, which for this single-key struct is exactly equivalent to the key not being found. `transport_mgmt.c` uses `decoded == 0 || !zcbor_map_decode_bulk_key_found(...)` for the same job, which stays correct if the struct ever grows a second key. Say the word and I will switch to that form.

This was found with a libFuzzer harness over `smp_process_request_packet()`. That harness is a separate contribution and is not ready to submit yet, for a reason worth naming here: on unmodified source it also trips `-fsanitize=function` inside `zcbor_map_decode_bulk()`, because `ZCBOR_MAP_DECODE_KEY_DECODER` casts each decoder to a differently-typed function pointer. That affects every command group that matches a key, and I will report it separately rather than fold it into this patch.

Fixes #117207