### PR TITLE
Add interrupt benchmark based on ztest benchmark framework

### DIFF
--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -92,6 +92,58 @@ functions only once allowing the test function to run hot within a dedicated tim
 This will give a more realistic measurements as it includes the overhead of the system as it would
 be in a real-world scenario, such as interrupts, context switches, and other background tasks.
 
+Manual Benchmarks
+=================
+
+Standard and timed benchmarks are timed by the framework itself, which takes both timestamps in
+thread context around each invocation of the benchmark body. Some measurements cannot be expressed
+that way because their endpoints are captured in different execution contexts: for example the
+latency from raising an interrupt to the first instruction of its ISR, or from the end of an ISR to
+a woken thread running.
+
+Manual benchmarks keep the loop, the setup and the teardown in the framework and hand the body
+only the choice of what is measured, by bracketing it with :c:func:`ztest_benchmark_start` and
+:c:func:`ztest_benchmark_end`. The framework computes and reports the same statistics as for
+standard benchmarks.
+
+.. code-block:: c
+
+   ZTEST_BENCHMARK_MANUAL(<suite name>, <benchmark name>, <samples>, <setup_fn>, <teardown_fn>)
+   {
+         prepare();
+
+         ztest_benchmark_start();
+         operation_under_test();
+         ztest_benchmark_end();
+   }
+
+When the span does not begin and end in the same execution context, the endpoint captured
+elsewhere is handed over instead, with :c:func:`ztest_benchmark_start_at` or
+:c:func:`ztest_benchmark_end_at`. An ISR captures ``timing_counter_get()`` into a variable and the
+body passes it in once it runs:
+
+.. code-block:: c
+
+   static volatile timing_t isr_timestamp;
+
+   static void my_isr(const void *arg)
+   {
+         isr_timestamp = timing_counter_get();
+   }
+
+   ZTEST_BENCHMARK_MANUAL(<suite name>, isr_exit_latency, 1000, NULL, NULL)
+   {
+         trigger_the_interrupt();
+
+         ztest_benchmark_start_at(isr_timestamp);
+         ztest_benchmark_end();
+   }
+
+The framework applies the same control-measurement noise correction as for standard benchmarks
+when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
+and leave the recording to the body. An iteration whose body records no span contributes no
+sample.
+
 Understanding Results
 *********************
 

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -180,6 +180,36 @@ Statistical Metrics
 * **Min/Max**: The minimum and maximum cycle counts observed, along with which
   sample they occurred on.
 
+Latency percentiles
+"""""""""""""""""""
+
+The mean and the standard error describe how precisely the average was
+estimated. That is the right question for throughput, but not for latency: a
+real-time system is characterised by how bad an individual operation can be,
+and that lives in the tail of the distribution rather than near the mean.
+
+Enable :kconfig:option:`CONFIG_ZTEST_BENCHMARK_PERCENTILES` to retain the
+individual samples and report ``min``, ``p50``, ``p90``, ``p99``, ``p99.9``,
+``p99.99`` and ``max`` alongside the usual statistics. In CSV mode each
+sampled and manual benchmark emits an additional ``P`` row; see
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV` for the columns.
+
+The difference this makes is clearest on a distribution with a tail. Measuring
+interrupt entry latency on a loaded system gives a mean of 1264 cycles with a
+standard error of 34, which describes no interrupt that actually occurred: the
+percentiles show 1216 cycles all the way out to p99, and 25184 beyond it.
+
+A percentile has to be resolvable by the number of samples taken. p99 needs at
+least 100 samples, p99.9 at least 1000 and p99.99 at least 10000; with fewer,
+the reported value degenerates to the maximum. Samples are retained in a
+buffer of :kconfig:option:`CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES` entries of
+8 bytes each, which has to be at least as large as the sample count of the
+largest benchmark. The retained samples are the first ones taken rather than a
+sample of the whole run, so percentiles over a truncated prefix would miss
+whatever happened after the buffer filled, which is where the tail tends to
+live. A benchmark that overruns the buffer therefore reports no percentiles at
+all, and says how many samples did not fit.
+
 Plainly speaking, lower values are better for all metrics.
 Lower mean, min, and max values indicates better raw performance.
 Lower standard deviation and standard error values indicate more consistent and

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -17,7 +17,9 @@ providing:
 * **Statistical Analysis**: Calculations of Mean, Standard Deviation, Standard
   Error, and Min/Max values.
 * **Overhead Compensation**: Inclusion of a control test to account for the
-  benchmarking frameworks own execution time.
+  benchmarking frameworks own execution time. The control is subtracted from
+  every reported statistic identically, so the corrected values are real
+  numbers that generally do not coincide with any single measurement.
 
 Configuration
 *************
@@ -143,6 +145,13 @@ The framework applies the same control-measurement noise correction as for stand
 when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
 and leave the recording to the body. An iteration whose body records no span contributes no
 sample.
+
+A benchmark that wants a warmup phase should run it through the full measurement loop, recording
+included, and then call :c:func:`ztest_benchmark_discard_samples` to throw the results away.
+Skipping the recording during warmup instead leaves the first measured iteration as the only one
+not preceded by the bookkeeping that :c:func:`ztest_benchmark_record_sample` performs, which is
+enough to make it measurably faster than every iteration after it and to leave the reported
+minimum describing a state the benchmark is never in again.
 
 Understanding Results
 *********************

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -173,6 +173,16 @@ Standard Benchmarking Results
 Statistical Metrics
 """""""""""""""""""
 
+.. note::
+
+   :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIERS` replaces the standard error line with the
+   number of samples slower than the median, and that number as a percentage. A latency
+   distribution is usually a baseline plus a handful of disturbed runs rather than samples of
+   one stochastic population, and a standard error over the two suggests an average that no
+   single execution ever produced -- ten thousand runs of 760 cycles and one of 1240 give a
+   standard error of 0.048, which reads as precision and is not, where ``1 / 10000 (0.010%)``
+   says what happened. Only the report changes; the standard error keeps its CSV column.
+
 * **Mean (u)**: The average number of cycles taken per sample. It provides a
   central value representing the expected cost of execution.
 
@@ -261,6 +271,7 @@ Timed Benchmarking Results
 
 Statistical Metrics
 """""""""""""""""""
+
 * **Total Time**: The total time taken for all samples of the benchmark, including overhead.
 
 * **Work Time**: The total time taken for the code under test, excluding the overhead of the

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -176,7 +176,10 @@ Statistical Metrics
 .. note::
 
    :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIERS` replaces the standard error line with the
-   number of samples slower than the median, and that number as a percentage. A latency
+   number of samples that exceed the median by more than
+   :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV` allows, and that number as a
+   percentage. The margin matters because the counter resolution spreads the baseline over a
+   few counts; without it about half of any distribution would be reported. A latency
    distribution is usually a baseline plus a handful of disturbed runs rather than samples of
    one stochastic population, and a standard error over the two suggests an average that no
    single execution ever produced -- ten thousand runs of 760 cycles and one of 1240 give a

--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -119,39 +119,38 @@ standard benchmarks.
          ztest_benchmark_end();
    }
 
-When the span does not begin and end in the same execution context, the endpoint captured
-elsewhere is handed over instead, with :c:func:`ztest_benchmark_start_at` or
-:c:func:`ztest_benchmark_end_at`. An ISR captures ``timing_counter_get()`` into a variable and the
-body passes it in once it runs:
+Both hooks only take a timestamp, so either may be called from an ISR and the span need not begin
+and end in the same execution context. For the latency from an interrupt to the thread it wakes,
+the ISR marks the start and the thread ends the span:
 
 .. code-block:: c
 
-   static volatile timing_t isr_timestamp;
-
    static void my_isr(const void *arg)
    {
-         isr_timestamp = timing_counter_get();
+         ztest_benchmark_start();
    }
 
    ZTEST_BENCHMARK_MANUAL(<suite name>, isr_exit_latency, 1000, NULL, NULL)
    {
          trigger_the_interrupt();
 
-         ztest_benchmark_start_at(isr_timestamp);
          ztest_benchmark_end();
    }
 
-The framework applies the same control-measurement noise correction as for standard benchmarks
-when reporting. The span is closed from thread context, so an ISR should only capture a timestamp
-and leave the recording to the body. An iteration whose body records no span contributes no
-sample.
+The sample itself is computed once the body has returned, which is what keeps the statistics out
+of interrupt context: updating them uses floating point, which is not allowed in an ISR on every
+architecture. An iteration whose body marks no span contributes no sample.
 
-A benchmark that wants a warmup phase should run it through the full measurement loop, recording
-included, and then call :c:func:`ztest_benchmark_discard_samples` to throw the results away.
-Skipping the recording during warmup instead leaves the first measured iteration as the only one
-not preceded by the bookkeeping that :c:func:`ztest_benchmark_record_sample` performs, which is
-enough to make it measurably faster than every iteration after it and to leave the reported
-minimum describing a state the benchmark is never in again.
+Manual benchmarks are corrected against a control of their own rather than the one the sampled
+benchmarks use. A manual span costs the two timestamps that bracket it and nothing else, where the
+sampled control also measures the indirect call to the benchmark body, which is not part of a
+manual span. A span whose ends are captured in two different contexts pays neither exactly, and no
+control can express that.
+
+The warmup applies here exactly as it does to a sampled benchmark: the framework runs the body
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` extra times and discards those spans, keeping the
+first as the cold cost. The body never has to distinguish between the two phases, and every
+measured iteration is preceded by exactly the same work as the one before it.
 
 Understanding Results
 *********************
@@ -188,6 +187,30 @@ Statistical Metrics
 
 * **Min/Max**: The minimum and maximum cycle counts observed, along with which
   sample they occurred on.
+
+Warmup and the cold cost
+""""""""""""""""""""""""
+
+A benchmark is defined as three phases: the setup, then
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` iterations that are executed but not recorded,
+then the measured samples. The warmup applies to every benchmark in the image.
+
+The very first execution is always unrecorded, whatever the warmup is set to. It runs with cold
+caches, branch predictors and TLBs and can be an order of magnitude slower than the steady state,
+and rather than discard that information the framework reports it on its own as the **cold cost**.
+The two answer different questions — what an operation costs the first time it is reached, and
+what it costs thereafter — and an application that runs a path once at startup cares about the
+first.
+
+Keeping it out of the distribution is what makes the distribution mean anything at the tail. A
+benchmark that reported the cold start in both places would have it decide the far percentiles:
+at ten thousand samples the nearest-rank p99.99 is the second largest value, so one cold start
+would be read as the steady-state tail.
+
+Raising the warmup beyond that costs accuracy on a micro benchmark whose whole cost is comparable
+to a cache miss, and with a large enough sample count the early iterations have no measurable
+effect on the mean, so the default of zero is the right starting point. Raise it when the
+benchmark is large enough for cache state to matter and the steady state is what you are after.
 
 Latency percentiles
 """""""""""""""""""

--- a/subsys/testsuite/ztest/benchmark/CMakeLists.txt
+++ b/subsys/testsuite/ztest/benchmark/CMakeLists.txt
@@ -8,5 +8,6 @@ zephyr_library_sources_ifdef(CONFIG_ZTEST_BENCHMARK
 
 zephyr_linker_sources(DATA_SECTIONS benchmark.ld)
 zephyr_iterable_section(NAME ztest_benchmark GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
+zephyr_iterable_section(NAME ztest_benchmark_manual GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
 zephyr_iterable_section(NAME ztest_benchmark_timed GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
 zephyr_iterable_section(NAME ztest_benchmark_suite GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -13,6 +13,41 @@ config ZTEST_BENCHMARK
 
 if ZTEST_BENCHMARK
 
+config ZTEST_BENCHMARK_PERCENTILES
+	bool "Report latency percentiles"
+	help
+	  Retain the individual samples of each benchmark and report
+	  min, p50, p90, p99, p99.9, p99.99 and max alongside the usual
+	  statistics.
+
+	  The mean and the standard error describe how precisely the
+	  average was estimated, which is the right question for
+	  throughput but not for latency: a real-time system is
+	  characterised by how bad an individual operation can be, and
+	  that lives in the tail of the distribution.
+
+	  A percentile needs enough samples to be resolved at all. p99
+	  needs at least 100, p99.9 at least 1000 and p99.99 at least
+	  10000; below that the reported value degenerates to the
+	  maximum. Retaining samples costs 8 bytes each, so the buffer
+	  has to be sized for the number of iterations the benchmarks
+	  run.
+
+config ZTEST_BENCHMARK_MAX_SAMPLES
+	int "Number of samples retained for percentiles"
+	depends on ZTEST_BENCHMARK_PERCENTILES
+	default 1024
+	help
+	  Size of the sample buffer, in samples of 8 bytes each. Only one
+	  benchmark runs at a time, so a single buffer of this size is
+	  allocated for all of them. It has to be at least as large as
+	  the sample count of the largest benchmark: the retained samples
+	  are the first ones taken rather than a sample of the whole run,
+	  so percentiles over a truncated prefix would miss whatever
+	  happened after the buffer filled, which is where the tail tends
+	  to live. A benchmark that overruns the buffer reports no
+	  percentiles at all and says how many samples did not fit.
+
 choice ZTEST_BENCHMARK_OUTPUT_FORMAT
 	prompt "Ztest benchmark output format"
 	default ZTEST_BENCHMARK_OUTPUT_VERBOSE
@@ -71,6 +106,17 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 
 	  If measured overhead exceeds the total time, the row contains INCONCLUSIVE instead of
 	  numeric results (e.g. "T, my_suite, my_benchmark, INCONCLUSIVE").
+
+	  With CONFIG_ZTEST_BENCHMARK_PERCENTILES, every sampled and manual benchmark emits an
+	  additional row of the form:
+
+	    P, suite, name, samples, min, p50, p90, p99, p999, p9999, max
+
+	  - samples: number of retained samples the percentiles were taken over
+	  - min / max: extreme cycle values
+	  - p50 ... p9999: nearest-rank percentiles, p9999 being the 99.99th
+
+	  All values are noise-corrected against the control measurement.
 endchoice
 
 endif

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -51,6 +51,11 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 	  - min / max: extreme cycle values
 	  - min_sample / max_sample: iteration at which each extreme occurred
 
+	  Manually sampled benchmarks (created with ZTEST_BENCHMARK_MANUAL()) emit "M" rows with
+	  the same column layout as "S" rows, where samples is the number of iterations that
+	  recorded a span. A manual benchmark that records no samples emits
+	  "M, suite, name, INCONCLUSIVE" instead.
+
 	  Timed benchmarks (created with ZTEST_BENCHMARK_TIMED() or
 	  ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN()) emit rows of the form:
 

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -49,8 +49,8 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  characterised by how bad an individual operation can be, and
 	  that lives in the tail of the distribution.
 
-	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples slower
-	  than the median.
+	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples that sit
+	  clear of the median.
 
 	  A percentile needs enough samples to be resolved at all. p99
 	  needs at least 100, p99.9 at least 1000 and p99.99 at least
@@ -64,8 +64,9 @@ config ZTEST_BENCHMARK_OUTLIERS
 	depends on ZTEST_BENCHMARK_PERCENTILES
 	help
 	  Replace the standard error line of the report with the number
-	  of samples slower than the median, and that number as a
-	  percentage of the samples taken.
+	  of samples that sit clear of the median, and that number as a
+	  percentage of the samples taken. How far clear is set by
+	  CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV.
 
 	  The standard error describes how precisely the mean of one
 	  stochastic population has been estimated. A latency
@@ -78,6 +79,29 @@ config ZTEST_BENCHMARK_OUTLIERS
 
 	  Only the human-readable report changes. The standard error
 	  keeps its column in the CSV output.
+
+config ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV
+	int "Outlier margin above the median, as a divisor"
+	depends on ZTEST_BENCHMARK_OUTLIERS
+	default 16
+	range 1 1000
+	help
+	  How far above the median a sample has to sit before it counts as
+	  an outlier, expressed as a divisor of the median: the default of
+	  16 sets the margin at a sixteenth of the median, so a baseline of
+	  400 counts a sample from 426 upwards. The margin is never less
+	  than two counts, so that a distribution spanning only adjacent
+	  counts of a coarse timer never registers.
+
+	  Without a margin every sample above the median counts, and the
+	  baseline of a benchmark is not one exact value: the resolution of
+	  the timing counter spreads it over a few counts, and where that
+	  counter is coarse relative to the operation being measured the
+	  whole distribution can span as little as two values. Half the
+	  samples then land above the median and are reported as outliers
+	  although nothing disturbed them. Lower this to count smaller
+	  disturbances, raise it on a platform whose baseline is noisy by
+	  nature.
 
 config ZTEST_BENCHMARK_MAX_SAMPLES
 	int "Number of samples retained for percentiles"

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -49,12 +49,35 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  characterised by how bad an individual operation can be, and
 	  that lives in the tail of the distribution.
 
+	  The percentiles also give CONFIG_ZTEST_BENCHMARK_OUTLIERS its count of samples slower
+	  than the median.
+
 	  A percentile needs enough samples to be resolved at all. p99
 	  needs at least 100, p99.9 at least 1000 and p99.99 at least
 	  10000; below that the reported value degenerates to the
 	  maximum. Retaining samples costs 8 bytes each, so the buffer
 	  has to be sized for the number of iterations the benchmarks
 	  run.
+
+config ZTEST_BENCHMARK_OUTLIERS
+	bool "Report the outlier count in place of the standard error"
+	depends on ZTEST_BENCHMARK_PERCENTILES
+	help
+	  Replace the standard error line of the report with the number
+	  of samples slower than the median, and that number as a
+	  percentage of the samples taken.
+
+	  The standard error describes how precisely the mean of one
+	  stochastic population has been estimated. A latency
+	  distribution is usually not that: it is a baseline the
+	  operation hits on almost every run plus a handful of runs that
+	  something interrupted. Ten thousand samples of 760 cycles and
+	  one of 1240 give a standard error of 0.048, which reads as
+	  precision about an average no execution ever produced, where
+	  "1 / 10000 (0.010%)" says what happened.
+
+	  Only the human-readable report changes. The standard error
+	  keeps its column in the CSV output.
 
 config ZTEST_BENCHMARK_MAX_SAMPLES
 	int "Number of samples retained for percentiles"

--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -13,6 +13,29 @@ config ZTEST_BENCHMARK
 
 if ZTEST_BENCHMARK
 
+config ZTEST_BENCHMARK_WARMUP
+	int "Iterations run before sampling starts"
+	default 0
+	help
+	  Iterations every benchmark executes, in full, before it begins
+	  recording. They are not part of the reported distribution.
+
+	  The very first execution is always one of them, whatever this is
+	  set to: it runs with cold caches, branch predictors and TLBs and
+	  can be an order of magnitude slower than the steady state, and it
+	  is reported on its own as the cold cost rather than mixed into
+	  the samples. A benchmark that reported it in both places would
+	  have a single cold start decide its far percentiles, since at ten
+	  thousand samples the nearest-rank p99.99 is the second largest
+	  value.
+
+	  The default of zero therefore discards nothing beyond that one
+	  execution, which is not discarded so much as reported elsewhere.
+	  Further iterations cost accuracy on micro benchmarks whose whole
+	  cost is comparable to a cache miss, so raise this only when the
+	  steady state is what you are after and the benchmark is large
+	  enough for the cache state to matter.
+
 config ZTEST_BENCHMARK_PERCENTILES
 	bool "Report latency percentiles"
 	help
@@ -85,6 +108,14 @@ config ZTEST_BENCHMARK_OUTPUT_CSV
 	  - std_error: standard error of the mean
 	  - min / max: extreme cycle values
 	  - min_sample / max_sample: iteration at which each extreme occurred
+
+	  Every benchmark that ran at least one iteration also emits a "C" row carrying its cold
+	  cost, the duration of its very first execution, which is excluded from the distribution:
+
+	    C, suite, name, warmup, cold
+
+	  - warmup: iterations executed before sampling started
+	  - cold: cycles taken by the first execution, noise-corrected
 
 	  Manually sampled benchmarks (created with ZTEST_BENCHMARK_MANUAL()) emit "M" rows with
 	  the same column layout as "S" rows, where samples is the number of iterations that

--- a/subsys/testsuite/ztest/benchmark/benchmark.ld
+++ b/subsys/testsuite/ztest/benchmark/benchmark.ld
@@ -6,5 +6,6 @@
 #include <zephyr/linker/iterable_sections.h>
 
 ITERABLE_SECTION_RAM(ztest_benchmark, Z_LINK_ITERABLE_SUBALIGN)
+ITERABLE_SECTION_RAM(ztest_benchmark_manual, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_RAM(ztest_benchmark_timed, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_RAM(ztest_benchmark_suite, Z_LINK_ITERABLE_SUBALIGN)

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -44,6 +44,10 @@ static void printk_line(const char *fn, char sep_char)
  * The correction is a real number, so the corrected values are real
  * numbers too, and generally do not coincide with any single
  * measurement.
+ *
+ * A negative result is not clamped: it means the operation costs less
+ * than the control loop bracketing it, so the counter is too coarse to
+ * measure it. Clamping would hide that behind a plausible number.
  */
 static double noise_correction(double value, double ctrl)
 {
@@ -135,20 +139,33 @@ static uint64_t percentile(uint32_t hundredths)
 
 #if defined(CONFIG_ZTEST_BENCHMARK_OUTLIERS) && defined(CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE)
 /*
- * Samples slower than the median.
+ * Samples disturbed enough to sit clear of the baseline, which for a
+ * kernel latency distribution is the median.
  *
- * For a kernel latency distribution the median is the baseline: the
- * operation costs the same on almost every run, and what matters is how
- * many runs were disturbed and by how much. Counting them says that
- * directly, where a standard error would only describe how precisely an
- * average of two different populations had been estimated.
+ * Merely exceeding the median is not enough: the counter resolution
+ * spreads the baseline over a few counts, so that would report about
+ * half the samples as outliers. Require a margin instead, relative so
+ * it holds across platforms, floored below for quantized distributions.
  */
 static size_t percentiles_outliers(void)
 {
 	uint64_t median = percentile(5000);
+	uint64_t margin = median / CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV;
+	uint64_t threshold;
 	size_t count = 0;
 
-	while ((count < retained_count) && (retained[retained_count - 1 - count] > median)) {
+	/*
+	 * A distribution spanning a couple of counts is at the counter
+	 * resolution, not above it. One count is not enough to exclude
+	 * it: the neighbouring count is exactly one away.
+	 */
+	if (margin < 2U) {
+		margin = 2U;
+	}
+
+	threshold = median + margin;
+
+	while ((count < retained_count) && (retained[retained_count - 1 - count] > threshold)) {
 		count++;
 	}
 

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -32,15 +32,45 @@ static void printk_line(const char *fn, char sep_char)
 }
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
+/*
+ * Subtract the control measurement from a reported statistic.
+ *
+ * Every statistic has to be corrected by the same amount, or they stop
+ * describing one set of samples: truncating the control to an integer
+ * for the discrete statistics, as this used to do, left a benchmark
+ * whose samples were all identical reporting a mean below its own
+ * minimum whenever the control was under one cycle.
+ *
+ * The correction is a real number, so the corrected values are real
+ * numbers too, and generally do not coincide with any single
+ * measurement.
+ */
 static double noise_correction(double value, double ctrl)
 {
 	return value - ctrl;
 }
 
-static int64_t discrete_noise_correction(uint64_t value, double ctrl)
+/*
+ * Render a corrected extreme as a whole number of cycles.
+ *
+ * The extremes are single measurements and a cycle is a discrete thing,
+ * so printing them with a fraction reads oddly. The correction is still
+ * a real number, so rounding has to be directional: the minimum rounds
+ * down and the maximum rounds up, which keeps each of them outside the
+ * statistics computed from the same samples instead of letting a
+ * rounded extreme cross the mean.
+ */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+static int64_t noise_corrected_floor(uint64_t value, double ctrl)
 {
-	return (int64_t)value - (int64_t)trunc(ctrl);
+	return (int64_t)floor(noise_correction((double)value, ctrl));
 }
+
+static int64_t noise_corrected_ceil(uint64_t value, double ctrl)
+{
+	return (int64_t)ceil(noise_correction((double)value, ctrl));
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
 #ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
 /*
@@ -130,22 +160,22 @@ static void percentiles_report(const char *suite_name, const char *bench_name,
 	percentiles_sort();
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("P,%s,%s,%zu,%lld,%lld,%lld,%lld,%lld,%lld,%lld\n",
+	printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
 		suite_name, bench_name, retained_count,
-		discrete_noise_correction(retained[0], ctrl),
-		discrete_noise_correction(percentile(5000), ctrl),
-		discrete_noise_correction(percentile(9000), ctrl),
-		discrete_noise_correction(percentile(9900), ctrl),
-		discrete_noise_correction(percentile(9990), ctrl),
-		discrete_noise_correction(percentile(9999), ctrl),
-		discrete_noise_correction(retained[retained_count - 1], ctrl));
+		noise_correction((double)retained[0], ctrl),
+		noise_correction((double)percentile(5000), ctrl),
+		noise_correction((double)percentile(9000), ctrl),
+		noise_correction((double)percentile(9900), ctrl),
+		noise_correction((double)percentile(9990), ctrl),
+		noise_correction((double)percentile(9999), ctrl),
+		noise_correction((double)retained[retained_count - 1], ctrl));
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk("\tp50: %lld\n", discrete_noise_correction(percentile(5000), ctrl));
-	printk("\tp90: %lld\n", discrete_noise_correction(percentile(9000), ctrl));
-	printk("\tp99: %lld\n", discrete_noise_correction(percentile(9900), ctrl));
-	printk("\tp99.9: %lld\n", discrete_noise_correction(percentile(9990), ctrl));
-	printk("\tp99.99: %lld\n", discrete_noise_correction(percentile(9999), ctrl));
+	printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
+	printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
+	printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
+	printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
+	printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 }
 #else
@@ -194,25 +224,25 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 	}
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("%c,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
+	printk("%c,%s,%s,%lld,%.3f,%.3f,%.3f,%.3f,%.3f,%lld,%.3f,%lld\n",
 		record_type, suite_name, bench_name,
 		stats->samples,
-		discrete_noise_correction(stats->total, ctrl * stats->samples),
+		noise_correction((double)stats->total, ctrl * (double)stats->samples),
 		noise_correction(stats->mean, ctrl), stddev, std_error,
-		discrete_noise_correction(stats->min.value, ctrl), stats->min.sample,
-		discrete_noise_correction(stats->max.value, ctrl), stats->max.sample);
+		noise_correction((double)stats->min.value, ctrl), stats->min.sample,
+		noise_correction((double)stats->max.value, ctrl), stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
 	printk_line(bench_name, '=');
-	printk("\tSample size:%lld, total cycles: %lld\n", stats->samples,
-			discrete_noise_correction(stats->total, ctrl * stats->samples));
+	printk("\tSample size:%lld, total cycles: %.3f\n", stats->samples,
+			noise_correction((double)stats->total, ctrl * (double)stats->samples));
 
 	printk("\tMean(u): %.3f\n", noise_correction(stats->mean, ctrl));
 	printk("\tStandard deviation(s): %.3f\n", stddev);
 	printk("\tStandard Error(SE): %.3f\n", std_error);
-	printk("\tMin: %lld (run #%llu)\n", discrete_noise_correction(stats->min.value, ctrl),
+	printk("\tMin: %lld (run #%llu)\n", noise_corrected_floor(stats->min.value, ctrl),
 		stats->min.sample);
-	printk("\tMax: %lld (run #%llu)\n", discrete_noise_correction(stats->max.value, ctrl),
+	printk("\tMax: %lld (run #%llu)\n", noise_corrected_ceil(stats->max.value, ctrl),
 		stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 
@@ -348,6 +378,17 @@ static bool manual_run_once(struct ztest_benchmark_manual *benchmark, uint64_t *
 	}
 
 	return measured;
+}
+
+void ztest_benchmark_discard_samples(void)
+{
+	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
+
+	if (manual_active_stats != NULL) {
+		memset(manual_active_stats, 0, sizeof(*manual_active_stats));
+		manual_active_stats->min.value = UINT64_MAX;
+		percentiles_reset();
+	}
 }
 
 static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -42,6 +42,131 @@ static int64_t discrete_noise_correction(uint64_t value, double ctrl)
 	return (int64_t)value - (int64_t)trunc(ctrl);
 }
 
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+/*
+ * Retained samples, for the percentile report. Only one benchmark runs
+ * at a time, so a single buffer serves all of them.
+ */
+static uint64_t retained[CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES];
+static size_t retained_count;
+static size_t dropped_count;
+
+static void percentiles_reset(void)
+{
+	retained_count = 0;
+	dropped_count = 0;
+}
+
+static void percentiles_record(uint64_t cycles)
+{
+	if (retained_count < ARRAY_SIZE(retained)) {
+		retained[retained_count++] = cycles;
+	} else {
+		dropped_count++;
+	}
+}
+
+static void percentiles_sort(void)
+{
+	/* Shell sort: no allocation, no recursion, good enough here */
+	for (size_t gap = retained_count / 2; gap > 0; gap /= 2) {
+		for (size_t i = gap; i < retained_count; i++) {
+			uint64_t value = retained[i];
+			size_t j = i;
+
+			while ((j >= gap) && (retained[j - gap] > value)) {
+				retained[j] = retained[j - gap];
+				j -= gap;
+			}
+			retained[j] = value;
+		}
+	}
+}
+
+/*
+ * Nearest-rank percentile, with the percentile given in hundredths of a
+ * percent so that 99.99 can be expressed: 5000 is the median, 9999 is
+ * the 99.99th percentile.
+ */
+static uint64_t percentile(uint32_t hundredths)
+{
+	uint64_t rank = ((uint64_t)hundredths * retained_count + 9999U) / 10000U;
+
+	if (rank == 0U) {
+		rank = 1U;
+	}
+
+	if (rank > retained_count) {
+		rank = retained_count;
+	}
+
+	return retained[rank - 1U];
+}
+
+static void percentiles_report(const char *suite_name, const char *bench_name,
+			       struct ztest_benchmark_stats *ctrl_stats)
+{
+	double ctrl = (double)ctrl_stats->mean;
+
+	if (retained_count == 0) {
+		return;
+	}
+
+	/*
+	 * The retained samples are the first ones taken, not a sample of
+	 * the whole run, so percentiles over them are not percentiles of
+	 * the distribution: whatever happened after the buffer filled is
+	 * missing entirely, and the tail is exactly where it tends to
+	 * live. Report nothing rather than something misleading.
+	 */
+	if (dropped_count != 0) {
+		printk("%s %s: no percentiles, %zu of %zu samples did not fit; "
+		       "raise CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES\n",
+		       suite_name, bench_name, dropped_count,
+		       retained_count + dropped_count);
+		return;
+	}
+
+	percentiles_sort();
+
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
+	printk("P,%s,%s,%zu,%lld,%lld,%lld,%lld,%lld,%lld,%lld\n",
+		suite_name, bench_name, retained_count,
+		discrete_noise_correction(retained[0], ctrl),
+		discrete_noise_correction(percentile(5000), ctrl),
+		discrete_noise_correction(percentile(9000), ctrl),
+		discrete_noise_correction(percentile(9900), ctrl),
+		discrete_noise_correction(percentile(9990), ctrl),
+		discrete_noise_correction(percentile(9999), ctrl),
+		discrete_noise_correction(retained[retained_count - 1], ctrl));
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+	printk("\tp50: %lld\n", discrete_noise_correction(percentile(5000), ctrl));
+	printk("\tp90: %lld\n", discrete_noise_correction(percentile(9000), ctrl));
+	printk("\tp99: %lld\n", discrete_noise_correction(percentile(9900), ctrl));
+	printk("\tp99.9: %lld\n", discrete_noise_correction(percentile(9990), ctrl));
+	printk("\tp99.99: %lld\n", discrete_noise_correction(percentile(9999), ctrl));
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+}
+#else
+static inline void percentiles_reset(void)
+{
+}
+
+static inline void percentiles_record(uint64_t cycles)
+{
+	ARG_UNUSED(cycles);
+}
+
+static inline void percentiles_report(const char *suite_name, const char *bench_name,
+				      struct ztest_benchmark_stats *ctrl_stats)
+{
+	ARG_UNUSED(suite_name);
+	ARG_UNUSED(bench_name);
+	ARG_UNUSED(ctrl_stats);
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
+
 static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
 					char record_type, struct ztest_benchmark_stats *stats,
 					struct ztest_benchmark_stats *ctrl_stats)
@@ -90,11 +215,16 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 	printk("\tMax: %lld (run #%llu)\n", discrete_noise_correction(stats->max.value, ctrl),
 		stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+
+	percentiles_report(suite_name, bench_name, ctrl_stats);
 }
+
 
 static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 {
 	double delta, delta2;
+
+	percentiles_record(cycles);
 
 	/* Welfords method */
 	stats->samples += 1;
@@ -122,6 +252,7 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
+	percentiles_reset();
 
 	for (size_t i = 0; i < benchmark->iterations; i++) {
 		if (benchmark->setup) {
@@ -223,6 +354,7 @@ static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
 {
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
+	percentiles_reset();
 
 	/*
 	 * The loop, the setup and the teardown are the framework's, exactly

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -276,30 +276,59 @@ static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 	stats->m2 += delta * delta2;
 }
 
-static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
+/* One iteration of a sampled benchmark, setup and teardown included. */
+static uint64_t sampled_run_once(struct ztest_benchmark *benchmark)
 {
 	timing_t start, end;
 
+	if (benchmark->setup) {
+		benchmark->setup();
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	start = timing_counter_get();
+	benchmark->run();
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	end = timing_counter_get();
+
+	if (benchmark->teardown) {
+		benchmark->teardown();
+	}
+
+	return timing_cycles_get(&start, &end);
+}
+
+static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
+{
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
 	percentiles_reset();
 
+	/*
+	 * The first execution is the cold cost and is never part of the
+	 * distribution. It is reported on its own, and a benchmark that
+	 * reported it in both places would have it decide the far
+	 * percentiles: at ten thousand samples the nearest-rank p99.99 is
+	 * the second largest value, so a single cold start describes the
+	 * tail instead of the steady state it is supposed to characterise.
+	 *
+	 * Warmup and measurement are then separate loops rather than one
+	 * loop with a test on the iteration number. Such a test flips
+	 * exactly once, on the first measured iteration, so the mispredict
+	 * lands on the one sample the warmup exists to protect. The loop
+	 * bounds fold at build time, the warmup count being a Kconfig
+	 * constant.
+	 */
+	benchmark->stats.cold = sampled_run_once(benchmark);
+
+	for (size_t i = 1; i < CONFIG_ZTEST_BENCHMARK_WARMUP; i++) {
+		(void)sampled_run_once(benchmark);
+	}
+
 	for (size_t i = 0; i < benchmark->iterations; i++) {
-		if (benchmark->setup) {
-			benchmark->setup();
-		}
-
-		barrier_dsync_fence_full();
-		barrier_isync_fence_full();
-		start = timing_counter_get();
-		benchmark->run();
-		end = timing_counter_get();
-
-		update_metrics(&benchmark->stats, timing_cycles_get(&start, &end));
-
-		if (benchmark->teardown) {
-			benchmark->teardown();
-		}
+		update_metrics(&benchmark->stats, sampled_run_once(benchmark));
 	}
 }
 
@@ -380,31 +409,24 @@ static bool manual_run_once(struct ztest_benchmark_manual *benchmark, uint64_t *
 	return measured;
 }
 
-void ztest_benchmark_discard_samples(void)
-{
-	__ASSERT(!k_is_in_isr(), "%s must be called from thread context", __func__);
-
-	if (manual_active_stats != NULL) {
-		memset(manual_active_stats, 0, sizeof(*manual_active_stats));
-		manual_active_stats->min.value = UINT64_MAX;
-		percentiles_reset();
-	}
-}
-
 static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
 {
+	uint64_t cycles;
+
 	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
 	benchmark->stats.min.value = UINT64_MAX;
 	percentiles_reset();
 
-	/*
-	 * The loop, the setup and the teardown are the framework's, exactly
-	 * as for a sampled benchmark. All the body decides is which part of
-	 * itself the timestamps go around.
-	 */
-	for (size_t i = 0; i < benchmark->iterations; i++) {
-		uint64_t cycles;
+	/* Cold first, then the two phases, as in ztest_benchmark_run(). */
+	if (manual_run_once(benchmark, &cycles)) {
+		benchmark->stats.cold = cycles;
+	}
 
+	for (size_t i = 1; i < CONFIG_ZTEST_BENCHMARK_WARMUP; i++) {
+		(void)manual_run_once(benchmark, &cycles);
+	}
+
+	for (size_t i = 0; i < benchmark->iterations; i++) {
 		if (manual_run_once(benchmark, &cycles)) {
 			update_metrics(&benchmark->stats, cycles);
 		}

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -42,14 +42,25 @@ static int64_t discrete_noise_correction(uint64_t value, double ctrl)
 	return (int64_t)value - (int64_t)trunc(ctrl);
 }
 
-static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
-					  struct ztest_benchmark_stats *ctrl_stats)
+static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
+					char record_type, struct ztest_benchmark_stats *stats,
+					struct ztest_benchmark_stats *ctrl_stats)
 {
 	double ctrl = (double)ctrl_stats->mean;
 	double stddev = 0.0;
 	double sample_variance;
 	double std_error = 0.0;
-	struct ztest_benchmark_stats *stats = &benchmark->stats;
+
+	if (stats->samples == 0) {
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
+		printk("%c,%s,%s\tINCONCLUSIVE\n", record_type, suite_name, bench_name);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
+		printk_line(bench_name, '=');
+		printk("\tTest inconclusive (no samples recorded)\n");
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+		return;
+	}
 
 	if (stats->samples > 1) {
 		sample_variance = stats->m2 / (double)(stats->samples - 1);
@@ -58,8 +69,8 @@ static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
 	}
 
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("S,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
-		benchmark->suite->name, benchmark->name,
+	printk("%c,%s,%s,%lld,%lld,%.3f,%.3f,%.3f,%lld,%lld,%lld,%lld\n",
+		record_type, suite_name, bench_name,
 		stats->samples,
 		discrete_noise_correction(stats->total, ctrl * stats->samples),
 		noise_correction(stats->mean, ctrl), stddev, std_error,
@@ -67,7 +78,7 @@ static void ztest_benchmark_print_results(struct ztest_benchmark *benchmark,
 		discrete_noise_correction(stats->max.value, ctrl), stats->max.sample);
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk_line(benchmark->name, '=');
+	printk_line(bench_name, '=');
 	printk("\tSample size:%lld, total cycles: %lld\n", stats->samples,
 			discrete_noise_correction(stats->total, ctrl * stats->samples));
 
@@ -127,6 +138,102 @@ static void ztest_benchmark_run(struct ztest_benchmark *benchmark)
 
 		if (benchmark->teardown) {
 			benchmark->teardown();
+		}
+	}
+}
+
+/*
+ * The benchmark whose body is running, and the span it has marked.
+ *
+ * Only one benchmark runs at a time, so a single set of these serves all
+ * of them. Neither hook records anything: they only take timestamps, so
+ * both are safe to call from an ISR, and the sample is computed by the
+ * runner once the body has returned and the thread is running again.
+ * That is what keeps the floating point of update_metrics() out of
+ * interrupt context, where it is not allowed on every architecture.
+ */
+static bool manual_active;
+static timing_t manual_span_start;
+static timing_t manual_span_end;
+static bool manual_span_open;
+static bool manual_span_closed;
+
+void ztest_benchmark_start(void)
+{
+	if (!manual_active) {
+		LOG_DBG("%s() outside a manual benchmark body, ignored", __func__);
+		return;
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	manual_span_start = timing_counter_get();
+	manual_span_open = true;
+}
+
+void ztest_benchmark_end(void)
+{
+	if (!manual_active) {
+		LOG_DBG("%s() outside a manual benchmark body, ignored", __func__);
+		return;
+	}
+
+	if (!manual_span_open) {
+		LOG_DBG("%s() without a matching start, ignored", __func__);
+		return;
+	}
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	manual_span_end = timing_counter_get();
+	manual_span_open = false;
+	manual_span_closed = true;
+}
+
+/* One iteration of a manual benchmark, returning its span or nothing. */
+static bool manual_run_once(struct ztest_benchmark_manual *benchmark, uint64_t *cycles)
+{
+	bool measured;
+
+	if (benchmark->setup) {
+		benchmark->setup();
+	}
+
+	manual_span_open = false;
+	manual_span_closed = false;
+	manual_active = true;
+	benchmark->run();
+	manual_active = false;
+
+	measured = manual_span_closed;
+	if (measured) {
+		*cycles = timing_cycles_get(&manual_span_start, &manual_span_end);
+	} else {
+		LOG_DBG("%s recorded no span this iteration", benchmark->name);
+	}
+
+	if (benchmark->teardown) {
+		benchmark->teardown();
+	}
+
+	return measured;
+}
+
+static void ztest_benchmark_manual_run(struct ztest_benchmark_manual *benchmark)
+{
+	memset(&benchmark->stats, 0, sizeof(benchmark->stats));
+	benchmark->stats.min.value = UINT64_MAX;
+
+	/*
+	 * The loop, the setup and the teardown are the framework's, exactly
+	 * as for a sampled benchmark. All the body decides is which part of
+	 * itself the timestamps go around.
+	 */
+	for (size_t i = 0; i < benchmark->iterations; i++) {
+		uint64_t cycles;
+
+		if (manual_run_once(benchmark, &cycles)) {
+			update_metrics(&benchmark->stats, cycles);
 		}
 	}
 }
@@ -221,6 +328,30 @@ static struct ztest_benchmark ctrl = {
 	.run = empty_function,
 };
 
+/*
+ * A manual span costs the two timestamps that bracket it and nothing
+ * else: the body is not called from inside the span, so the indirect
+ * call that the sampled control measures is not part of one. Correcting
+ * a manual sample against the sampled control would subtract an
+ * overhead it never paid, so it gets a control of its own, an empty
+ * span with the framework's own hooks around it.
+ *
+ * A span whose ends are captured in two different contexts pays neither
+ * of these exactly, and no control can express that; the correction is
+ * still the closest of the two.
+ */
+static void empty_span(void)
+{
+	ztest_benchmark_start();
+	ztest_benchmark_end();
+}
+
+static struct ztest_benchmark_manual ctrl_manual = {
+	.name = "ctrl_manual",
+	.iterations = 1000,
+	.run = empty_span,
+};
+
 static struct ztest_benchmark_timed ctrl_timed = {
 	.duration_ms = 100,
 	.name = "ctrl_timed",
@@ -234,6 +365,7 @@ void benchmark_main(void)
 
 	k_sched_lock();
 	ztest_benchmark_run(&ctrl);
+	ztest_benchmark_manual_run(&ctrl_manual);
 	ztest_benchmark_timed_run(&ctrl_timed);
 	k_sched_unlock();
 
@@ -250,7 +382,17 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_run(benchmark);
-			ztest_benchmark_print_results(benchmark, &ctrl.stats);
+			ztest_benchmark_print_stats(suite->name, benchmark->name, 'S',
+						    &benchmark->stats, &ctrl.stats);
+		}
+
+		STRUCT_SECTION_FOREACH(ztest_benchmark_manual, benchmark) {
+			if (benchmark->suite != suite) {
+				continue;
+			}
+			ztest_benchmark_manual_run(benchmark);
+			ztest_benchmark_print_stats(suite->name, benchmark->name, 'M',
+						    &benchmark->stats, &ctrl_manual.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_timed, benchmark) {

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -133,11 +133,41 @@ static uint64_t percentile(uint32_t hundredths)
 	return retained[rank - 1U];
 }
 
-static void percentiles_report(const char *suite_name, const char *bench_name,
-			       struct ztest_benchmark_stats *ctrl_stats)
+#if defined(CONFIG_ZTEST_BENCHMARK_OUTLIERS) && defined(CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE)
+/*
+ * Samples slower than the median.
+ *
+ * For a kernel latency distribution the median is the baseline: the
+ * operation costs the same on almost every run, and what matters is how
+ * many runs were disturbed and by how much. Counting them says that
+ * directly, where a standard error would only describe how precisely an
+ * average of two different populations had been estimated.
+ */
+static size_t percentiles_outliers(void)
 {
-	double ctrl = (double)ctrl_stats->mean;
+	uint64_t median = percentile(5000);
+	size_t count = 0;
 
+	while ((count < retained_count) && (retained[retained_count - 1 - count] > median)) {
+		count++;
+	}
+
+	return count;
+}
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTLIERS && CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
+
+static bool percentiles_available(void)
+{
+	/*
+	 * Samples that did not fit make the retained ones a prefix rather
+	 * than a sample of the run, which percentiles_prepare() refuses
+	 * to sort or report.
+	 */
+	return (retained_count != 0) && (dropped_count == 0);
+}
+
+static void percentiles_prepare(const char *suite_name, const char *bench_name)
+{
 	if (retained_count == 0) {
 		return;
 	}
@@ -158,48 +188,38 @@ static void percentiles_report(const char *suite_name, const char *bench_name,
 	}
 
 	percentiles_sort();
-
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
-	printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
-		suite_name, bench_name, retained_count,
-		noise_correction((double)retained[0], ctrl),
-		noise_correction((double)percentile(5000), ctrl),
-		noise_correction((double)percentile(9000), ctrl),
-		noise_correction((double)percentile(9900), ctrl),
-		noise_correction((double)percentile(9990), ctrl),
-		noise_correction((double)percentile(9999), ctrl),
-		noise_correction((double)retained[retained_count - 1], ctrl));
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
-#ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
-	printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
-	printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
-	printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
-	printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
-	printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
-#endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
 }
 #else
-static inline void percentiles_reset(void)
+/*
+ * Only the two hooks the runner calls unconditionally need a stub. The
+ * rest are referenced solely from code that this option compiles out,
+ * and a stub for them would be an unused function, which both
+ * compilers reject under the warning flags Zephyr builds with.
+ */
+static void percentiles_reset(void)
 {
 }
 
-static inline void percentiles_record(uint64_t cycles)
+static void percentiles_record(uint64_t cycles)
 {
 	ARG_UNUSED(cycles);
 }
-
-static inline void percentiles_report(const char *suite_name, const char *bench_name,
-				      struct ztest_benchmark_stats *ctrl_stats)
-{
-	ARG_UNUSED(suite_name);
-	ARG_UNUSED(bench_name);
-	ARG_UNUSED(ctrl_stats);
-}
 #endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
 
-static void ztest_benchmark_print_stats(const char *suite_name, const char *bench_name,
-					char record_type, struct ztest_benchmark_stats *stats,
-					struct ztest_benchmark_stats *ctrl_stats)
+/*
+ * Report one benchmark.
+ *
+ * The layout is the one the framework has always printed. The optional
+ * additions extend it rather than rearrange it: percentiles and the
+ * cold cost are extra lines, and CONFIG_ZTEST_BENCHMARK_OUTLIERS
+ * swaps the standard error for the outlier count in place.
+ *
+ * The CSV output keeps every column it had, including the standard
+ * error, so that existing parsers are unaffected whatever is enabled.
+ */
+static void ztest_benchmark_report(const char *suite_name, const char *bench_name,
+				   char record_type, struct ztest_benchmark_stats *stats,
+				   struct ztest_benchmark_stats *ctrl_stats)
 {
 	double ctrl = (double)ctrl_stats->mean;
 	double stddev = 0.0;
@@ -223,6 +243,10 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 		std_error = stddev / sqrt(stats->samples);
 	}
 
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	percentiles_prepare(suite_name, bench_name);
+#endif
+
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV
 	printk("%c,%s,%s,%lld,%.3f,%.3f,%.3f,%.3f,%.3f,%lld,%.3f,%lld\n",
 		record_type, suite_name, bench_name,
@@ -231,7 +255,37 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 		noise_correction(stats->mean, ctrl), stddev, std_error,
 		noise_correction((double)stats->min.value, ctrl), stats->min.sample,
 		noise_correction((double)stats->max.value, ctrl), stats->max.sample);
+
+	if (stats->cold != 0) {
+		printk("C,%s,%s,%d,%.3f\n", suite_name, bench_name,
+			CONFIG_ZTEST_BENCHMARK_WARMUP,
+			noise_correction((double)stats->cold, ctrl));
+	}
+
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	/*
+	 * The percentiles go in a row of their own rather than as extra
+	 * columns on the row above, so that a parser written against the
+	 * original column layout keeps working.
+	 *
+	 * The extremes come from the retained samples the percentiles were
+	 * taken over, which is not the same set as the min and max on the
+	 * row above once samples have been dropped.
+	 */
+	if (percentiles_available()) {
+		printk("P,%s,%s,%zu,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
+			suite_name, bench_name, retained_count,
+			noise_correction((double)retained[0], ctrl),
+			noise_correction((double)percentile(5000), ctrl),
+			noise_correction((double)percentile(9000), ctrl),
+			noise_correction((double)percentile(9900), ctrl),
+			noise_correction((double)percentile(9990), ctrl),
+			noise_correction((double)percentile(9999), ctrl),
+			noise_correction((double)retained[retained_count - 1], ctrl));
+	}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV */
+
 #ifdef CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE
 	printk_line(bench_name, '=');
 	printk("\tSample size:%lld, total cycles: %.3f\n", stats->samples,
@@ -239,16 +293,43 @@ static void ztest_benchmark_print_stats(const char *suite_name, const char *benc
 
 	printk("\tMean(u): %.3f\n", noise_correction(stats->mean, ctrl));
 	printk("\tStandard deviation(s): %.3f\n", stddev);
+#ifdef CONFIG_ZTEST_BENCHMARK_OUTLIERS
+	/*
+	 * The standard error describes how precisely the mean of one
+	 * stochastic population was estimated. A latency distribution is
+	 * usually a baseline plus a few disturbed runs instead, so the
+	 * count of samples slower than the median says more about it.
+	 */
+	if (percentiles_available()) {
+		size_t outliers = percentiles_outliers();
+
+		printk("\tOutliers: %zu / %zu (%.3f%%)\n", outliers, retained_count,
+			(100.0 * (double)outliers) / (double)retained_count);
+	}
+#else
 	printk("\tStandard Error(SE): %.3f\n", std_error);
+#endif /* CONFIG_ZTEST_BENCHMARK_OUTLIERS */
 	printk("\tMin: %lld (run #%llu)\n", noise_corrected_floor(stats->min.value, ctrl),
 		stats->min.sample);
 	printk("\tMax: %lld (run #%llu)\n", noise_corrected_ceil(stats->max.value, ctrl),
 		stats->max.sample);
+
+#ifdef CONFIG_ZTEST_BENCHMARK_PERCENTILES
+	if (percentiles_available()) {
+		printk("\tp50: %.3f\n", noise_correction((double)percentile(5000), ctrl));
+		printk("\tp90: %.3f\n", noise_correction((double)percentile(9000), ctrl));
+		printk("\tp99: %.3f\n", noise_correction((double)percentile(9900), ctrl));
+		printk("\tp99.9: %.3f\n", noise_correction((double)percentile(9990), ctrl));
+		printk("\tp99.99: %.3f\n", noise_correction((double)percentile(9999), ctrl));
+	}
+#endif /* CONFIG_ZTEST_BENCHMARK_PERCENTILES */
+
+	if (stats->cold != 0) {
+		printk("\tCold (first run): %.3f\n",
+			noise_correction((double)stats->cold, ctrl));
+	}
 #endif /* CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE */
-
-	percentiles_report(suite_name, bench_name, ctrl_stats);
 }
-
 
 static void update_metrics(struct ztest_benchmark_stats *stats, uint64_t cycles)
 {
@@ -577,8 +658,8 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_run(benchmark);
-			ztest_benchmark_print_stats(suite->name, benchmark->name, 'S',
-						    &benchmark->stats, &ctrl.stats);
+			ztest_benchmark_report(suite->name, benchmark->name, 'S',
+					       &benchmark->stats, &ctrl.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_manual, benchmark) {
@@ -586,8 +667,8 @@ void benchmark_main(void)
 				continue;
 			}
 			ztest_benchmark_manual_run(benchmark);
-			ztest_benchmark_print_stats(suite->name, benchmark->name, 'M',
-						    &benchmark->stats, &ctrl_manual.stats);
+			ztest_benchmark_report(suite->name, benchmark->name, 'M',
+					       &benchmark->stats, &ctrl_manual.stats);
 		}
 
 		STRUCT_SECTION_FOREACH(ztest_benchmark_timed, benchmark) {

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -601,6 +601,8 @@ static void ztest_benchmark_timed_run(struct ztest_benchmark_timed *benchmark)
 		RUN_100(benchmark->run());
 		iterations += 100;
 	}
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
 	end = timing_counter_get();
 
 	benchmark->stats.duration_cycles = timing_cycles_get(&start, &end);

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -48,6 +48,8 @@ struct ztest_benchmark_stats {
 	uint64_t samples;
 	struct ztest_extreme_value min;
 	struct ztest_extreme_value max;
+	/* First iteration, measured before the steady state is reached. */
+	uint64_t cold;
 };
 
 struct ztest_benchmark {

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -23,10 +23,11 @@ extern "C" {
  * Identifier builders for the linker-visible symbols that the ZTEST_BENCHMARK*()
  * macros generate. Use when defining a symbol or when taking its reference.
  */
-#define Z_ZTEST_BENCHMARK_SUITE_NODE(suite)        z_ztest_benchmark_suite_##suite
-#define Z_ZTEST_BENCHMARK_NODE(suite, bench)       z_ztest_benchmark_##suite##_##bench
-#define Z_ZTEST_BENCHMARK_TIMED_NODE(suite, bench) z_ztest_benchmark_timed_##suite##_##bench
-#define Z_ZTEST_BENCHMARK_FN(suite, bench)         z_ztest_benchmark_##suite##_##bench##_fn
+#define Z_ZTEST_BENCHMARK_SUITE_NODE(suite)         z_ztest_benchmark_suite_##suite
+#define Z_ZTEST_BENCHMARK_NODE(suite, bench)        z_ztest_benchmark_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_TIMED_NODE(suite, bench)  z_ztest_benchmark_timed_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_MANUAL_NODE(suite, bench) z_ztest_benchmark_manual_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_FN(suite, bench)          z_ztest_benchmark_##suite##_##bench##_fn
 
 typedef void (*ztest_benchmark_fn_t)(void);
 struct ztest_benchmark_suite {
@@ -50,6 +51,16 @@ struct ztest_benchmark_stats {
 };
 
 struct ztest_benchmark {
+	const char *name;
+	size_t iterations;
+	ztest_benchmark_fn_t setup;
+	ztest_benchmark_fn_t run;
+	ztest_benchmark_fn_t teardown;
+	struct ztest_benchmark_stats stats;
+	const struct ztest_benchmark_suite *suite;
+};
+
+struct ztest_benchmark_manual {
 	const char *name;
 	size_t iterations;
 	ztest_benchmark_fn_t setup;
@@ -145,6 +156,79 @@ void benchmark_main(void);
 		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(testsuite),				\
 	};											\
 	static __noinline void Z_ZTEST_BENCHMARK_FN(testsuite, benchmark)(void)
+
+/**
+ * @brief Define a manually sampled benchmark
+ *
+ * The framework runs the body once per iteration exactly as it does for
+ * ZTEST_BENCHMARK(), but the body decides which part of itself is measured
+ * by bracketing it with ztest_benchmark_start() and
+ * ztest_benchmark_end():
+ *
+ * @code
+ * ZTEST_BENCHMARK_MANUAL(my_suite, my_benchmark, 1000, NULL, NULL)
+ * {
+ *         prepare();
+ *         ztest_benchmark_start();
+ *         operation_under_test();
+ *         ztest_benchmark_end();
+ * }
+ * @endcode
+ *
+ * That covers a span the framework cannot time by itself because it does
+ * not start and end where the body does. Both hooks are safe to call from
+ * an ISR, so a span need not even begin and end in the same execution
+ * context: for the latency from an interrupt to the thread it wakes, the
+ * ISR calls ztest_benchmark_start() and the woken thread calls
+ * ztest_benchmark_end().
+ *
+ * A body that records no span contributes no sample for that iteration.
+ *
+ * @param suite_name Name of the suite the benchmark belongs to
+ * @param benchmark Name of the benchmark
+ * @param samples Number of iterations to run the benchmark
+ * @param setup_fn Function to run before each iteration
+ * @param teardown_fn Function to run after each iteration
+ */
+#define ZTEST_BENCHMARK_MANUAL(suite_name, benchmark, samples, setup_fn, teardown_fn)		\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void);		\
+	static STRUCT_SECTION_ITERABLE(ztest_benchmark_manual,					\
+				       Z_ZTEST_BENCHMARK_MANUAL_NODE(suite_name, benchmark)) =	\
+	{											\
+		.name = #benchmark,								\
+		.iterations = samples,								\
+		.setup = setup_fn,								\
+		.run = Z_ZTEST_BENCHMARK_FN(suite_name, benchmark),				\
+		.teardown = teardown_fn,							\
+		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(suite_name),				\
+	};											\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void)
+
+/**
+ * @brief Begin the measured span of a manual benchmark iteration
+ *
+ * Timestamps now. Anything the body did before this call is excluded from
+ * the measurement.
+ *
+ * Safe to call from an ISR: it only takes a timestamp, so a span whose
+ * start belongs to interrupt context is marked from there directly. The
+ * sample itself is computed once the body has returned.
+ *
+ * Calls made outside a ZTEST_BENCHMARK_MANUAL() body are ignored.
+ */
+void ztest_benchmark_start(void);
+
+/**
+ * @brief End the measured span of a manual benchmark iteration
+ *
+ * Timestamps now. Without a preceding ztest_benchmark_start() there is no
+ * span, and the call is ignored.
+ *
+ * Safe to call from an ISR, for the same reason as
+ * ztest_benchmark_start(): the span is only handed to the statistics once
+ * the body has returned to thread context.
+ */
+void ztest_benchmark_end(void);
 
 /**
  * @}

--- a/tests/benchmarks/interrupt_latency/CMakeLists.txt
+++ b/tests/benchmarks/interrupt_latency/CMakeLists.txt
@@ -9,5 +9,7 @@ target_sources(app PRIVATE
   src/benchmarks.c
 )
 
+target_sources_ifdef(CONFIG_INT_BENCH_LOAD app PRIVATE src/load.c)
+
 target_sources_ifdef(CONFIG_INT_BENCH_TRIGGER_SW_IRQ app PRIVATE src/trigger_sw_irq.c)
 target_sources_ifdef(CONFIG_INT_BENCH_TRIGGER_OFFLOAD app PRIVATE src/trigger_offload.c)

--- a/tests/benchmarks/interrupt_latency/CMakeLists.txt
+++ b/tests/benchmarks/interrupt_latency/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(interrupt_latency)
+
+target_sources(app PRIVATE
+  src/benchmarks.c
+)
+
+target_sources_ifdef(CONFIG_INT_BENCH_TRIGGER_SW_IRQ app PRIVATE src/trigger_sw_irq.c)
+target_sources_ifdef(CONFIG_INT_BENCH_TRIGGER_OFFLOAD app PRIVATE src/trigger_offload.c)

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -88,13 +88,21 @@ config INT_BENCH_IRQ_PRIO
 config INT_BENCH_IRQ_PRIO_ALT
 	int "Priority of the second benchmark IRQ"
 	depends on INT_BENCH_TRIGGER_SW_IRQ
-	default 0
+	# Zero-latency interrupts have to sit within the levels reserved
+	# for them, and the nested scenario needs to outrank the first
+	# line. Everything else wants the two lines at equal priority, so
+	# that comparing them measures only how they are connected.
+	default 0 if INT_BENCH_SCENARIO_ZLI
+	default 0 if INT_BENCH_SCENARIO_NESTED
+	default INT_BENCH_IRQ_PRIO
 	help
-	  Interrupt priority for the second benchmark IRQ line. It has to
-	  be a higher priority than CONFIG_INT_BENCH_IRQ_PRIO for the
-	  nested scenario to be able to preempt the first line, and on
-	  Cortex-M a zero-latency interrupt additionally has to be within
-	  the levels reserved for them.
+	  Interrupt priority for the second benchmark IRQ line, in the
+	  same convention as CONFIG_INT_BENCH_IRQ_PRIO.
+
+	  The default matches the first line, so that the entry latency
+	  of the two can be compared without the priority differing as
+	  well. The nested and zero-latency scenarios override it because
+	  they are about the second line outranking the first.
 
 config INT_BENCH_LOCK_HOLD_US
 	int "Critical section hold time (microseconds)"
@@ -321,9 +329,19 @@ config INT_BENCH_MASK_INJECT_US
 	  measured delay falls short of the injected one. Zero measures
 	  only the windows the kernel creates by itself.
 
+choice INT_BENCH_ALT_LINE_USE
+	prompt "Use of the second benchmark IRQ line"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default INT_BENCH_SCENARIO_DIRECT if CPU_CORTEX_M || ARC || (X86 && !X86_64)
+	default INT_BENCH_SCENARIO_NESTED if GIC
+	default INT_BENCH_ALT_LINE_NONE
+	help
+	  How an interrupt is connected and what priority it runs at are
+	  both fixed at build time, so the scenarios that need a second
+	  line cannot share one. Pick the one to build.
+
 config INT_BENCH_SCENARIO_DIRECT
 	bool "Direct ISR entry latency"
-	depends on INT_BENCH_TRIGGER_SW_IRQ
 	# Needs both a second triggerable line and IRQ_DIRECT_CONNECT().
 	# There is no capability symbol for the latter, so the
 	# architectures that implement ARCH_ISR_DIRECT_DECLARE() are
@@ -331,43 +349,46 @@ config INT_BENCH_SCENARIO_DIRECT
 	# only on IA32, and RISC-V without a CLIC has only the one
 	# interrupt a hart can raise on itself.
 	depends on CPU_CORTEX_M || ARC || (X86 && !X86_64)
-	depends on !INT_BENCH_SCENARIO_ZLI
-	default y
 	help
 	  Measure entry latency for an interrupt connected with
 	  IRQ_DIRECT_CONNECT(), which is dispatched straight from the
-	  vector table instead of through the software ISR table. Run
-	  alongside the regular entry latency scenario, the pair shows
-	  what the common interrupt entry code costs.
+	  vector table instead of through the software ISR table. The
+	  line runs at the same priority as the first one, so comparing
+	  the two measures only the dispatch.
 
 config INT_BENCH_SCENARIO_ZLI
-	bool "Zero-latency interrupt entry while interrupts are locked"
-	depends on INT_BENCH_TRIGGER_SW_IRQ
+	bool "Zero-latency interrupt"
 	depends on ZERO_LATENCY_IRQS
-	default n
 	help
-	  Connect the second line as a zero-latency interrupt and trigger
-	  it with interrupts locked. A zero-latency interrupt is not
-	  masked by irq_lock(), so it is served during the critical
-	  section rather than after it, which the regular critical
-	  section scenario can be compared against.
+	  Connect the second line as a zero-latency interrupt and measure
+	  it both with interrupts enabled and from inside a critical
+	  section. A zero-latency interrupt is not masked by irq_lock(),
+	  so it is served during the critical section rather than after
+	  it, which the regular critical section scenario can be compared
+	  against.
 
-	  This claims the same line as the direct ISR scenario, so only
-	  one of the two can be built at a time.
+	  The priority difference is inherent here: a zero-latency
+	  interrupt is one that runs above the level the kernel masks.
 
 config INT_BENCH_SCENARIO_NESTED
 	bool "Nested interrupt preemption latency"
-	depends on INT_BENCH_TRIGGER_SW_IRQ
 	# Same set of platforms whose nesting behaviour
 	# tests/arch/common/interrupt exercises.
 	depends on CPU_CORTEX_M || ARC || GIC
-	default y
 	help
 	  Raise the second, higher priority interrupt from inside the
 	  first one's ISR and measure how long it takes to preempt it.
 	  This is the latency a high priority interrupt suffers when a
 	  lower priority one is already being serviced, which for an
 	  interrupt-heavy application is often the dominant term.
+
+config INT_BENCH_ALT_LINE_NONE
+	bool "Unused"
+	help
+	  Leave the second line alone. This is the only option on
+	  platforms that have no second line to trigger.
+
+endchoice
 
 config INT_BENCH_SCENARIO_THROUGHPUT
 	bool "Sustained interrupt round-trip cost"

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -155,6 +155,33 @@ config INT_BENCH_LOAD_TIMER_PERIOD_US
 	  the system clock are rounded up, so raise
 	  CONFIG_SYS_CLOCK_TICKS_PER_SEC accordingly.
 
+config INT_BENCH_LOAD_KERNEL
+	bool "Kernel activity from interrupt context"
+	depends on INT_BENCH_LOAD_TIMER
+	default y
+	help
+	  Have the load timer handler exercise kernel primitives from
+	  interrupt context, so that the benchmark interrupt competes
+	  with the interrupt-disabled windows the kernel takes around its
+	  own data structures rather than only with an empty handler.
+
+	  Runs in the system clock ISR, so unlike a thread it takes
+	  effect regardless of priorities and on uniprocessors too.
+
+config INT_BENCH_LOAD_SCHED
+	bool "Scheduler churn between samples"
+	default y
+	help
+	  Wake a higher priority thread and let it block again before
+	  each sample, so that every measurement is taken on a system
+	  that has just context switched rather than one that has been
+	  spinning in the same thread.
+
+	  The churn happens between samples rather than during them on
+	  purpose. A thread that could preempt the benchmark while it is
+	  measuring would add its own scheduling delay to the result and
+	  be indistinguishable from interrupt latency.
+
 config INT_BENCH_LOAD_THREADS
 	bool "Background CPU and memory load threads"
 	default y

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -60,6 +60,16 @@ config INT_BENCH_IRQ_LINE
 	  this on SoCs where the automatic choice is not an implemented
 	  or free line.
 
+config INT_BENCH_IRQ_LINE_ALT
+	int "Second IRQ line used by the benchmark (-1 = auto-select)"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default -1
+	help
+	  Scenarios that compare how an interrupt is connected need a
+	  second line, because the connection method is fixed at build
+	  time. Selected the same way as CONFIG_INT_BENCH_IRQ_LINE, one
+	  line below it where that is derived from CONFIG_NUM_IRQS.
+
 config INT_BENCH_IRQ_PRIO
 	int "Priority of the benchmark IRQ"
 	depends on INT_BENCH_TRIGGER_SW_IRQ
@@ -239,6 +249,40 @@ config INT_BENCH_MASK_INJECT_US
 	  timer then re-anchors to when it was last serviced, so the
 	  measured delay falls short of the injected one. Zero measures
 	  only the windows the kernel creates by itself.
+
+config INT_BENCH_SCENARIO_DIRECT
+	bool "Direct ISR entry latency"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	# Needs both a second triggerable line and IRQ_DIRECT_CONNECT().
+	# There is no capability symbol for the latter, so the
+	# architectures that implement ARCH_ISR_DIRECT_DECLARE() are
+	# listed explicitly: Arm64 has no direct interrupts, x86 has them
+	# only on IA32, and RISC-V without a CLIC has only the one
+	# interrupt a hart can raise on itself.
+	depends on CPU_CORTEX_M || ARC || (X86 && !X86_64)
+	depends on !INT_BENCH_SCENARIO_ZLI
+	default y
+	help
+	  Measure entry latency for an interrupt connected with
+	  IRQ_DIRECT_CONNECT(), which is dispatched straight from the
+	  vector table instead of through the software ISR table. Run
+	  alongside the regular entry latency scenario, the pair shows
+	  what the common interrupt entry code costs.
+
+config INT_BENCH_SCENARIO_ZLI
+	bool "Zero-latency interrupt entry while interrupts are locked"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	depends on ZERO_LATENCY_IRQS
+	default n
+	help
+	  Connect the second line as a zero-latency interrupt and trigger
+	  it with interrupts locked. A zero-latency interrupt is not
+	  masked by irq_lock(), so it is served during the critical
+	  section rather than after it, which the regular critical
+	  section scenario can be compared against.
+
+	  This claims the same line as the direct ISR scenario, so only
+	  one of the two can be built at a time.
 
 config INT_BENCH_SCENARIO_THROUGHPUT
 	bool "Sustained interrupt round-trip cost"

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -78,6 +78,76 @@ config INT_BENCH_LOCK_HOLD_US
 	  with the benchmark interrupt pending before unlocking and
 	  measuring the unlock-to-ISR-entry latency.
 
+menuconfig INT_BENCH_LOAD
+	bool "Run the scenarios under background system load"
+	help
+	  Interrupt latency measured on an otherwise idle system is a
+	  best case: caches hold the benchmark's own working set, no
+	  other interrupt is in service and nothing else competes for the
+	  memory system. Enable background load so that the reported
+	  maximum and standard deviation describe something closer to
+	  what an application will see. The individual load sources are
+	  selected below.
+
+if INT_BENCH_LOAD
+
+config INT_BENCH_LOAD_CACHE
+	bool "Evict caches between samples"
+	default y
+	help
+	  Walk a working set larger than the benchmark's own between
+	  samples, outside the measured span, so that each measured
+	  interrupt is served with cold caches and TLBs. Runs in the
+	  benchmark thread and therefore affects every scenario on every
+	  platform.
+
+config INT_BENCH_LOAD_CACHE_KB
+	int "Working set size (KB)"
+	depends on INT_BENCH_LOAD_CACHE
+	default 8
+	help
+	  Size of the buffer walked between samples. To be effective this
+	  should exceed the size of the last level cache; to be usable it
+	  has to fit in RAM alongside the benchmark.
+
+config INT_BENCH_LOAD_TIMER
+	bool "Competing periodic timer interrupts"
+	default y
+	help
+	  Run a periodic timer whose handler executes in the system clock
+	  ISR, so that it competes with the benchmark interrupt for the
+	  interrupt controller and for the interrupt-disabled windows of
+	  the kernel timeout code. Affects every platform.
+
+config INT_BENCH_LOAD_TIMER_PERIOD_US
+	int "Timer load period (microseconds)"
+	depends on INT_BENCH_LOAD_TIMER
+	default 1000
+	help
+	  Period of the competing timer. Values below the tick period of
+	  the system clock are rounded up, so raise
+	  CONFIG_SYS_CLOCK_TICKS_PER_SEC accordingly.
+
+config INT_BENCH_LOAD_THREADS
+	bool "Background CPU and memory load threads"
+	default y
+	help
+	  Run threads of lower priority than the benchmark that
+	  continuously write to memory. On SMP these run on the other
+	  CPUs and contend for the memory system throughout. On a
+	  uniprocessor they only run while the benchmark blocks, so their
+	  effect is limited to the rescheduling scenario.
+
+config INT_BENCH_LOAD_NUM_THREADS
+	int "Number of background load threads"
+	depends on INT_BENCH_LOAD_THREADS
+	default 2
+	help
+	  On SMP this should be at least the number of CPUs other than
+	  the one running the benchmark.
+
+endif # INT_BENCH_LOAD
+
 comment "Scenarios"
 
 config INT_BENCH_SCENARIO_ENTRY

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -202,6 +202,20 @@ config INT_BENCH_LOAD_NUM_THREADS
 
 endif # INT_BENCH_LOAD
 
+config INT_BENCH_ISR_IN_RAM
+	bool "Place the benchmark ISR in RAM"
+	depends on ARCH_HAS_RAMFUNC_SUPPORT
+	depends on XIP
+	help
+	  Relocate the benchmark's interrupt handlers to RAM with
+	  __ramfunc, so that comparing a run against one built without
+	  this option shows what fetching the handler from flash costs.
+
+	  Only the benchmark's own handlers move. The vector table and
+	  the architecture's interrupt entry code stay where the build
+	  put them, so the difference is a lower bound on what fully
+	  relocating the interrupt path would save.
+
 comment "Scenarios"
 
 config INT_BENCH_SCENARIO_ENTRY

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Interrupt Handling Benchmark"
+
+menu "Interrupt benchmark options"
+
+config INT_BENCH_NUM_ITERATIONS
+	int "Number of iterations per scenario"
+	default 1000
+	help
+	  Number of samples collected for each measured scenario. Larger
+	  values give more stable statistics at the cost of runtime and of
+	  the RAM needed to record the individual samples (4 bytes each).
+
+choice INT_BENCH_TRIGGER
+	prompt "Interrupt trigger backend"
+	default INT_BENCH_TRIGGER_SW_IRQ if CPU_CORTEX_M || GIC || ARC
+	default INT_BENCH_TRIGGER_OFFLOAD
+
+config INT_BENCH_TRIGGER_SW_IRQ
+	bool "Software-triggered hardware interrupt"
+	depends on CPU_CORTEX_M || GIC || ARC
+	help
+	  Raise a real asynchronous interrupt through the platform
+	  interrupt controller (NVIC STIR/ISPR on Cortex-M, a GIC SGI on
+	  Arm GIC platforms, IRQ_HINT on ARC). This exercises the full
+	  hardware interrupt entry path and is required for the entry
+	  latency, critical section and throughput scenarios.
+
+config INT_BENCH_TRIGGER_OFFLOAD
+	bool "irq_offload() software trap"
+	depends on IRQ_OFFLOAD
+	help
+	  Run the benchmark ISRs synchronously via irq_offload(). This
+	  works on every architecture but does not go through the
+	  interrupt controller: only the interrupt *exit* paths are
+	  measured. Entry latency numbers are not available with this
+	  backend.
+
+endchoice
+
+config INT_BENCH_IRQ_LINE
+	int "IRQ line used by the benchmark (-1 = auto-select)"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default -1
+	help
+	  IRQ line the benchmark connects its ISR to and then triggers
+	  from software. The default of -1 selects a platform-appropriate
+	  line automatically: an SGI on GIC platforms, a line known to be
+	  free on selected QEMU boards, and the last available line
+	  (CONFIG_NUM_IRQS - 1) otherwise. Override this on SoCs where
+	  the automatic choice is not an implemented or free line.
+
+config INT_BENCH_IRQ_PRIO
+	int "Priority of the benchmark IRQ"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default 1
+	help
+	  Interrupt priority for the benchmark IRQ line, using the same
+	  convention as the priority argument of IRQ_CONNECT() on the
+	  target architecture.
+
+config INT_BENCH_LOCK_HOLD_US
+	int "Critical section hold time (microseconds)"
+	depends on INT_BENCH_SCENARIO_LOCKED
+	default 10
+	help
+	  How long the critical section scenario keeps interrupts locked
+	  with the benchmark interrupt pending before unlocking and
+	  measuring the unlock-to-ISR-entry latency.
+
+comment "Scenarios"
+
+config INT_BENCH_SCENARIO_ENTRY
+	bool "Interrupt entry latency"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default y
+	help
+	  Measure the time from the software trigger of a hardware
+	  interrupt to the first instruction of its ISR.
+
+config INT_BENCH_SCENARIO_EXIT
+	bool "Interrupt exit latency"
+	default y
+	help
+	  Measure the time from the end of the ISR body back to the
+	  interrupted thread, and the time from the end of an ISR that
+	  wakes a higher priority thread to that thread running.
+
+config INT_BENCH_SCENARIO_LOCKED
+	bool "Entry latency after a critical section"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	# ARC raises a software interrupt by writing the line number to
+	# the single IRQ_HINT register, and the system timer writes that
+	# same register from sys_clock_cycle_get_32() whenever it finds
+	# the timer already expired. The hold below busy waits on that
+	# function with interrupts locked, so the timer takes the
+	# register over from the benchmark and the two then fight for it
+	# for as long as the timer stays behind.
+	depends on !ARC
+	default y
+	help
+	  Trigger the benchmark interrupt while interrupts are locked,
+	  hold the lock for a configurable window, then measure the time
+	  from irq_unlock() to ISR entry. This approximates the latency
+	  an interrupt experiences when it arrives during a kernel or
+	  application critical section.
+
+	  Not available on ARC, where the benchmark trigger and the
+	  system timer share one hardware register.
+
+config INT_BENCH_SCENARIO_DYNAMIC
+	bool "Dynamic interrupt connect cost"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	depends on DYNAMIC_INTERRUPTS
+	depends on !SHARED_INTERRUPTS
+	default y
+	help
+	  Measure the cost of installing an ISR at runtime with
+	  irq_connect_dynamic().
+
+config INT_BENCH_SCENARIO_THROUGHPUT
+	bool "Sustained interrupt round-trip cost"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default y
+	help
+	  Re-trigger the benchmark interrupt from within its own ISR so
+	  interrupts are serviced back to back, and report the average
+	  cost of one full entry + ISR + exit round trip. The inverse of
+	  this number is the maximum sustainable interrupt rate.
+
+endmenu
+
+config SYS_CLOCK_TICKS_PER_SEC
+	int "Number of ticks per second"
+	default 20 if SOC_FAMILY_STM32
+	default 100
+	help
+	  A low tick rate keeps timer interrupts out of the measurements,
+	  but it cannot be lowered without limit: a tick has to be
+	  expressible in the timer's counter. A Cortex-M SysTick counter
+	  is 24 bits, so a tick longer than 16777215 cycles cannot be
+	  programmed, and the driver then falls back to its minimum delay
+	  of ten microseconds and interrupts continuously.
+
+	  The default of 100 is representable on any core up to 1.6GHz.
+	  Combined with a tickless kernel it is also quiet: with nothing
+	  scheduled the driver programs as far ahead as the counter
+	  allows, which on a 150MHz part is 110ms.
+
+source "Kconfig.zephyr"

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -73,11 +73,28 @@ config INT_BENCH_IRQ_LINE_ALT
 config INT_BENCH_IRQ_PRIO
 	int "Priority of the benchmark IRQ"
 	depends on INT_BENCH_TRIGGER_SW_IRQ
+	# On Arm GIC the priority is a raw eight bit value of which only
+	# the upper bits select the preemption group, so a line at
+	# priority 1 cannot be preempted by one at priority 0: they share
+	# a group. Use the platform default, which is both representative
+	# and far enough from the top for the second line to outrank it.
+	default 160 if GIC
 	default 1
 	help
 	  Interrupt priority for the benchmark IRQ line, using the same
 	  convention as the priority argument of IRQ_CONNECT() on the
 	  target architecture.
+
+config INT_BENCH_IRQ_PRIO_ALT
+	int "Priority of the second benchmark IRQ"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default 0
+	help
+	  Interrupt priority for the second benchmark IRQ line. It has to
+	  be a higher priority than CONFIG_INT_BENCH_IRQ_PRIO for the
+	  nested scenario to be able to preempt the first line, and on
+	  Cortex-M a zero-latency interrupt additionally has to be within
+	  the levels reserved for them.
 
 config INT_BENCH_LOCK_HOLD_US
 	int "Critical section hold time (microseconds)"
@@ -296,6 +313,20 @@ config INT_BENCH_SCENARIO_ZLI
 
 	  This claims the same line as the direct ISR scenario, so only
 	  one of the two can be built at a time.
+
+config INT_BENCH_SCENARIO_NESTED
+	bool "Nested interrupt preemption latency"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	# Same set of platforms whose nesting behaviour
+	# tests/arch/common/interrupt exercises.
+	depends on CPU_CORTEX_M || ARC || GIC
+	default y
+	help
+	  Raise the second, higher priority interrupt from inside the
+	  first one's ISR and measure how long it takes to preempt it.
+	  This is the latency a high priority interrupt suffers when a
+	  lower priority one is already being serviced, which for an
+	  interrupt-heavy application is often the dominant term.
 
 config INT_BENCH_SCENARIO_THROUGHPUT
 	bool "Sustained interrupt round-trip cost"

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -14,19 +14,25 @@ config INT_BENCH_NUM_ITERATIONS
 
 choice INT_BENCH_TRIGGER
 	prompt "Interrupt trigger backend"
-	default INT_BENCH_TRIGGER_SW_IRQ if CPU_CORTEX_M || GIC || ARC || X86
+	default INT_BENCH_TRIGGER_SW_IRQ if CPU_CORTEX_M || GIC || ARC || X86 || \
+		(RISCV && !SMP && !RISCV_S_MODE)
 	default INT_BENCH_TRIGGER_OFFLOAD
 
 config INT_BENCH_TRIGGER_SW_IRQ
 	bool "Software-triggered hardware interrupt"
-	depends on CPU_CORTEX_M || GIC || ARC || X86
+	depends on CPU_CORTEX_M || GIC || ARC || X86 || \
+		(RISCV && !SMP && !RISCV_S_MODE)
 	help
 	  Raise a real asynchronous interrupt through the platform
 	  interrupt controller (NVIC STIR/ISPR on Cortex-M, a GIC SGI on
 	  Arm GIC platforms, IRQ_HINT on ARC, a local APIC self IPI on
-	  x86). This exercises the full
-	  hardware interrupt entry path and is required for the entry
-	  latency, critical section and throughput scenarios.
+	  x86, and a CLIC pending bit or a CLINT machine software
+	  interrupt on RISC-V). This exercises the full hardware
+	  interrupt entry path and is required for the entry latency,
+	  critical section and throughput scenarios.
+
+	  Not available in RISC-V supervisor mode: both the CLINT and
+	  mhartid are machine mode only.
 
 config INT_BENCH_TRIGGER_OFFLOAD
 	bool "irq_offload() software trap"
@@ -47,10 +53,12 @@ config INT_BENCH_IRQ_LINE
 	help
 	  IRQ line the benchmark connects its ISR to and then triggers
 	  from software. The default of -1 selects a platform-appropriate
-	  line automatically: an SGI on GIC platforms, a line known to be
-	  free on selected QEMU boards and on x86, and the last
-	  available line (CONFIG_NUM_IRQS - 1) otherwise. Override this on SoCs where
-	  the automatic choice is not an implemented or free line.
+	  line automatically: an SGI on GIC platforms, the machine
+	  software interrupt on RISC-V platforms without a CLIC, a line
+	  known to be free on selected QEMU boards and on x86, and the
+	  last available line (CONFIG_NUM_IRQS - 1) otherwise. Override
+	  this on SoCs where the automatic choice is not an implemented
+	  or free line.
 
 config INT_BENCH_IRQ_PRIO
 	int "Priority of the benchmark IRQ"

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -10,21 +10,21 @@ config INT_BENCH_NUM_ITERATIONS
 	default 1000
 	help
 	  Number of samples collected for each measured scenario. Larger
-	  values give more stable statistics at the cost of runtime and of
-	  the RAM needed to record the individual samples (4 bytes each).
+	  values give more stable statistics at the cost of runtime.
 
 choice INT_BENCH_TRIGGER
 	prompt "Interrupt trigger backend"
-	default INT_BENCH_TRIGGER_SW_IRQ if CPU_CORTEX_M || GIC || ARC
+	default INT_BENCH_TRIGGER_SW_IRQ if CPU_CORTEX_M || GIC || ARC || X86
 	default INT_BENCH_TRIGGER_OFFLOAD
 
 config INT_BENCH_TRIGGER_SW_IRQ
 	bool "Software-triggered hardware interrupt"
-	depends on CPU_CORTEX_M || GIC || ARC
+	depends on CPU_CORTEX_M || GIC || ARC || X86
 	help
 	  Raise a real asynchronous interrupt through the platform
 	  interrupt controller (NVIC STIR/ISPR on Cortex-M, a GIC SGI on
-	  Arm GIC platforms, IRQ_HINT on ARC). This exercises the full
+	  Arm GIC platforms, IRQ_HINT on ARC, a local APIC self IPI on
+	  x86). This exercises the full
 	  hardware interrupt entry path and is required for the entry
 	  latency, critical section and throughput scenarios.
 
@@ -48,8 +48,8 @@ config INT_BENCH_IRQ_LINE
 	  IRQ line the benchmark connects its ISR to and then triggers
 	  from software. The default of -1 selects a platform-appropriate
 	  line automatically: an SGI on GIC platforms, a line known to be
-	  free on selected QEMU boards, and the last available line
-	  (CONFIG_NUM_IRQS - 1) otherwise. Override this on SoCs where
+	  free on selected QEMU boards and on x86, and the last
+	  available line (CONFIG_NUM_IRQS - 1) otherwise. Override this on SoCs where
 	  the automatic choice is not an implemented or free line.
 
 config INT_BENCH_IRQ_PRIO
@@ -115,10 +115,19 @@ config INT_BENCH_SCENARIO_DYNAMIC
 	depends on INT_BENCH_TRIGGER_SW_IRQ
 	depends on DYNAMIC_INTERRUPTS
 	depends on !SHARED_INTERRUPTS
+	# On x86, arch_irq_connect_dynamic() is a one shot allocation
+	# rather than a rebindable install: it allocates a new IDT vector
+	# and consumes an entry from a fixed pool of interrupt stubs on
+	# every call, and asserts that the line is not already
+	# configured. Repeatedly connecting the same line to gather
+	# samples exhausts that pool.
+	depends on !X86
 	default y
 	help
 	  Measure the cost of installing an ISR at runtime with
-	  irq_connect_dynamic().
+	  irq_connect_dynamic(), by repeatedly reinstalling the handler
+	  on the benchmark IRQ line. This requires the architecture to
+	  support rebinding a line that is already connected.
 
 config INT_BENCH_SCENARIO_THROUGHPUT
 	bool "Sustained interrupt round-trip cost"

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -15,21 +15,22 @@ config INT_BENCH_NUM_ITERATIONS
 choice INT_BENCH_TRIGGER
 	prompt "Interrupt trigger backend"
 	default INT_BENCH_TRIGGER_SW_IRQ if CPU_CORTEX_M || GIC || ARC || X86 || \
-		(RISCV && !SMP && !RISCV_S_MODE)
+		INTC_ESP32 || (RISCV && !SMP && !RISCV_S_MODE)
 	default INT_BENCH_TRIGGER_OFFLOAD
 
 config INT_BENCH_TRIGGER_SW_IRQ
 	bool "Software-triggered hardware interrupt"
-	depends on CPU_CORTEX_M || GIC || ARC || X86 || \
+	depends on CPU_CORTEX_M || GIC || ARC || X86 || INTC_ESP32 || \
 		(RISCV && !SMP && !RISCV_S_MODE)
 	help
 	  Raise a real asynchronous interrupt through the platform
 	  interrupt controller (NVIC STIR/ISPR on Cortex-M, a GIC SGI on
 	  Arm GIC platforms, IRQ_HINT on ARC, a local APIC self IPI on
-	  x86, and a CLIC pending bit or a CLINT machine software
-	  interrupt on RISC-V). This exercises the full hardware
-	  interrupt entry path and is required for the entry latency,
-	  critical section and throughput scenarios.
+	  x86, a CLIC pending bit or a CLINT machine software interrupt
+	  on RISC-V, and a software-raised interrupt matrix source on
+	  Espressif SoCs). This exercises the full hardware interrupt
+	  entry path and is required for the entry latency, critical
+	  section and throughput scenarios.
 
 	  Not available in RISC-V supervisor mode: both the CLINT and
 	  mhartid are machine mode only.

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -176,6 +176,19 @@ config INT_BENCH_SCENARIO_EXIT
 	  interrupted thread, and the time from the end of an ISR that
 	  wakes a higher priority thread to that thread running.
 
+config INT_BENCH_SCENARIO_END_TO_END
+	bool "Interrupt to awakened thread latency"
+	depends on INT_BENCH_TRIGGER_SW_IRQ
+	default y
+	help
+	  Measure the whole path an application waits on, from raising
+	  the interrupt to the high priority thread it wakes running.
+
+	  The entry and exit scenarios measure the pieces of this span,
+	  but they cannot be added together: they are measured in
+	  separate runs and neither covers the ISR body or the handoff
+	  between them.
+
 config INT_BENCH_SCENARIO_LOCKED
 	bool "Entry latency after a critical section"
 	depends on INT_BENCH_TRIGGER_SW_IRQ

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -224,6 +224,36 @@ config INT_BENCH_ISR_IN_RAM
 	  put them, so the difference is a lower bound on what fully
 	  relocating the interrupt path would save.
 
+config INT_BENCH_OUTLIER_TRACE
+	bool "Report what coincided with outlying samples"
+	help
+	  Print a line for each sample far above the smallest one seen,
+	  naming what else the system did while it was being taken: how
+	  many clock ticks were announced and how many times the load
+	  timer ran. An outlier that coincides with neither was caused by
+	  something the benchmark cannot see, such as the memory system
+	  or a debug probe.
+
+	  The witnesses are read once per sample, outside the measured
+	  span, so this changes the steady state slightly and is meant
+	  for diagnosis rather than for the numbers to be quoted.
+
+config INT_BENCH_OUTLIER_FACTOR
+	int "How far above the minimum counts as an outlier"
+	depends on INT_BENCH_OUTLIER_TRACE
+	default 4
+	help
+	  A sample is reported when it exceeds this many times the
+	  smallest sample seen so far in the same benchmark.
+
+config INT_BENCH_OUTLIER_LIMIT
+	int "Maximum outliers reported per benchmark"
+	depends on INT_BENCH_OUTLIER_TRACE
+	default 8
+	help
+	  Printing perturbs the samples that follow, so stop after this
+	  many. The count of the rest is still reported.
+
 comment "Scenarios"
 
 config INT_BENCH_SCENARIO_ENTRY

--- a/tests/benchmarks/interrupt_latency/Kconfig
+++ b/tests/benchmarks/interrupt_latency/Kconfig
@@ -207,6 +207,39 @@ config INT_BENCH_SCENARIO_DYNAMIC
 	  on the benchmark IRQ line. This requires the architecture to
 	  support rebinding a line that is already connected.
 
+config INT_BENCH_SCENARIO_MASKING
+	bool "Delay inflicted on a periodic interrupt"
+	# Two samples are taken per tick, so the tick has to be frequent
+	# enough both to sample the windows of interest and to finish in
+	# reasonable time. The base configuration runs far slower than
+	# that; the load overlay raises it to 1000.
+	depends on SYS_CLOCK_TICKS_PER_SEC >= 1000
+	default y
+	help
+	  Run a periodic timer at the tick rate while exercising kernel
+	  primitives, and measure how much later than its period each
+	  timer interrupt is actually served. This is the delay an
+	  application sees when the kernel or a driver masks interrupts.
+
+	  This is a sampling technique and cannot attribute the delay: a
+	  masked window that does not overlap a tick is never seen, and
+	  the measured delay also contains time spent in interrupts
+	  served earlier. The maximum is a sampled lower bound on the
+	  longest interrupt-disabled window, not proof of one.
+
+config INT_BENCH_MASK_INJECT_US
+	int "Inject a known interrupt-disabled window (microseconds)"
+	depends on INT_BENCH_SCENARIO_MASKING
+	default 0
+	help
+	  Mask interrupts for this long inside the scenario's work loop,
+	  to check on a new platform that the measurement responds to a
+	  known window. Keep the value well below the tick period: a
+	  window comparable to it masks nearly continuously, and the
+	  timer then re-anchors to when it was last serviced, so the
+	  measured delay falls short of the injected one. Zero measures
+	  only the windows the kernel creates by itself.
+
 config INT_BENCH_SCENARIO_THROUGHPUT
 	bool "Sustained interrupt round-trip cost"
 	depends on INT_BENCH_TRIGGER_SW_IRQ

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -108,7 +108,7 @@ Interrupt generation is abstracted behind a small backend API
    implemented for Cortex-M (NVIC STIR/ISPR), Arm GIC v2/v3 (SGI), ARC
    (IRQ_HINT), x86 (local APIC self IPI, both xAPIC and x2APIC) and RISC-V
    (CLIC pending bit, or the CLINT machine software interrupt where there
-   is no CLIC), largely using the same mechanisms as
+   is no CLIC) and Espressif SoCs, largely using the same mechanisms as
    ``tests/arch/common/interrupt``. The IRQ line is auto-selected and can
    be overridden with ``CONFIG_INT_BENCH_IRQ_LINE`` for SoCs where the
    automatic choice is not a free, implemented line.
@@ -122,6 +122,19 @@ Interrupt generation is abstracted behind a small backend API
    entry latency therefore includes one store to the CLINT. This backend
    is unavailable on SMP builds, where the machine software interrupt is
    already used for scheduler IPIs.
+
+   Espressif parts route every interrupt through an interrupt matrix rather
+   than exposing lines the CPU can pend, so neither the RISC-V nor the
+   Xtensa mechanism applies to them. They do have peripheral sources whose
+   only purpose is to be raised by software, meant for cross-core
+   signalling: writing the register asserts a real interrupt that arrives
+   through the matrix like any other. The benchmark takes source 2, leaving
+   0 and 1 to ESP-IDF and to Zephyr's own SMP code, and allocates it with
+   ``esp_intr_alloc()`` since the matrix picks the CPU interrupt and there
+   is no line to name in ``IRQ_CONNECT()``. The register moved peripheral
+   and name across the family, so the address is selected per SoC series;
+   the interrupt is level triggered, so the ISR clears it. Verified to
+   build on ESP32, ESP32-S3, ESP32-C3 and ESP32-C6.
 
 ``CONFIG_INT_BENCH_TRIGGER_OFFLOAD``
    Fallback for every other architecture, based on ``irq_offload()``. Since

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -180,7 +180,7 @@ overlay to re-run every scenario under background load:
    west build -p -b qemu_x86 tests/benchmarks/interrupt_latency -t run -- \
        -DEXTRA_CONF_FILE=prj.load.conf
 
-Three load sources are enabled independently
+Five load sources are enabled independently
 (:kconfig:option:`CONFIG_INT_BENCH_LOAD` and the options under it):
 
 ``CONFIG_INT_BENCH_LOAD_CACHE``
@@ -195,6 +195,22 @@ Three load sources are enabled independently
    with the benchmark interrupt for the interrupt controller and for the
    interrupt-disabled windows of the kernel timeout code. This is the load
    source that dominates under emulation.
+
+``CONFIG_INT_BENCH_LOAD_KERNEL``
+   Has the load timer handler exercise kernel primitives from interrupt
+   context, so the benchmark interrupt competes with the interrupt-disabled
+   windows the kernel takes around its own data structures rather than with
+   an empty handler. Running in the system clock ISR, it takes effect
+   regardless of thread priorities and on uniprocessors too.
+
+``CONFIG_INT_BENCH_LOAD_SCHED``
+   Wakes a higher priority thread and lets it block again before each
+   sample, so every measurement is taken on a system that has just context
+   switched rather than one that has been spinning in the same thread. The
+   churn happens between samples rather than during them on purpose: a
+   thread that could preempt the benchmark mid-measurement would add its
+   own scheduling delay to the result and be indistinguishable from
+   interrupt latency.
 
 ``CONFIG_INT_BENCH_LOAD_THREADS``
    Threads of lower priority than the benchmark that continuously write to

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -33,6 +33,12 @@ All benchmarks are in the ``interrupt`` suite:
   each sample runs from one ISR entry to the next and so covers a full
   ISR + exit + entry round trip under back-to-back service. Its inverse
   is the maximum sustainable interrupt rate.
+* ``periodic_isr_delay`` -- how much later than its period a periodic timer
+  interrupt is actually served while the kernel is busy, which is the delay
+  interrupt masking inflicts on an application. See `Masking windows`_ for
+  what this number does and does not prove. Needs a tick rate of at least
+  100 Hz, so it is enabled by the load overlay rather than the base
+  configuration.
 * ``dynamic_connect`` -- cost of installing an ISR at runtime with
   ``irq_connect_dynamic()`` (needs ``CONFIG_DYNAMIC_INTERRUPTS``). Not
   available on x86, where connecting an interrupt dynamically is a one
@@ -124,8 +130,8 @@ is only visible with the system doing something.
 The load configuration can be impractically slow on emulated targets. The
 critical section scenario busy waits with interrupts locked while the load
 timer keeps expiring, and under emulation that combination can cost orders
-of magnitude more wall clock than the nominal hold time; ARC is excluded
-from the load run in ``tests.yaml`` for that reason. On such targets, lower
+of magnitude more wall clock than the nominal hold time; ARC and
+Cortex-M3 are excluded from the load run in ``tests.yaml`` for that reason. On such targets, lower
 :kconfig:option:`CONFIG_INT_BENCH_NUM_ITERATIONS`, or disable
 :kconfig:option:`CONFIG_INT_BENCH_LOAD_TIMER`.
 
@@ -141,6 +147,55 @@ priorities rather than of the benchmark.
 ``throughput_round_trip`` barely moves anywhere. It saturates the interrupt
 path by design, so it measures a steady state that stays warm whatever else
 the system is doing.
+
+Masking windows
+***************
+
+``periodic_isr_delay`` addresses a question the other scenarios cannot: how
+long does the system keep interrupts masked? That is a property of the
+kernel and the drivers rather than something the benchmark can trigger, and
+Zephyr has no instrumentation of ``irq_lock()`` windows, so it is measured
+by its effect. A periodic timer runs at the tick rate while the benchmark
+exercises kernel primitives that take spinlocks, and each sample is how
+much later than its period a timer interrupt was served.
+
+Read the maximum as *the worst delay a periodic real-time event was
+actually made to suffer*, which is the number an application cares about.
+It is not a measurement of the longest ``irq_lock()`` in the tree, for
+three reasons: a sample is only taken at a tick boundary, so a masked
+window that does not overlap one is never seen; the measured delay also
+contains time spent in interrupts that were served first; and the framework
+subtracts its control measurement from every statistic, so samples with no
+delay are reported as a small negative number.
+
+:kconfig:option:`CONFIG_INT_BENCH_MASK_INJECT_US` masks interrupts for a
+known time in the work loop, to confirm the measurement responds on a new
+platform. On qemu_x86 with a 1 kHz tick, injecting 50us raises the reported
+maximum from roughly 700 cycles to 57568, or about 58us against a 50us
+window. Keep the injected value well below the tick period: a window
+comparable to it masks nearly continuously, the timer re-anchors to when it
+was last serviced, and the measured delay then falls well short of the
+injected one. The same effect limits what the scenario can report about a
+system that is genuinely saturated.
+
+The undelayed interval is established empirically, as the median of the
+observed intervals, rather than computed from the configured tick rate. The
+timing counter does not run at ``timing_freq_get()`` on every platform, and
+a baseline off by a constant would either hide every delay or turn every
+interval into one; on RISC-V the computed baseline exceeded every observed
+interval, so the scenario reported nothing at all until it was made
+self-calibrating.
+
+Where the periodic timer does not deliver at the tick rate at all, the
+scenario reports that it was skipped and records no samples, which the
+framework shows as inconclusive. That is the case on qemu_cortex_m3.
+
+This scenario is the most sensitive of all of them to being run under
+emulation, because it measures wall clock delay rather than a span of the
+guest's own execution. When the host deschedules the emulator, the guest
+sees it as a late interrupt: on qemu_x86_64 that shows up as isolated
+maxima of over a hundred million cycles, which say nothing about Zephyr.
+Read this scenario on hardware.
 
 Running
 *******

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -296,6 +296,28 @@ sees it as a late interrupt: on qemu_x86_64 that shows up as isolated
 maxima of over a hundred million cycles, which say nothing about Zephyr.
 Read this scenario on hardware.
 
+Handlers in RAM
+***************
+
+On a device that executes in place from flash, part of the interrupt entry
+latency is spent fetching the handler. Build with the ``prj.ramfunc.conf``
+overlay to relocate the benchmark's handlers to RAM with ``__ramfunc`` and
+compare against a run without it:
+
+.. code-block:: console
+
+   west build -p -b <board> tests/benchmarks/interrupt_latency -t run -- \
+       -DEXTRA_CONF_FILE=prj.ramfunc.conf
+
+Only the benchmark's own handlers move. The vector table and the
+architecture's interrupt entry code stay where the build put them, so the
+difference between the two runs is a lower bound on what relocating the
+whole interrupt path would save.
+
+This one needs real hardware to say anything: emulators do not model flash
+wait states, so under QEMU the two runs are identical apart from where the
+symbols landed.
+
 Running
 *******
 
@@ -344,6 +366,8 @@ Future work
 * Priority interference: how much a high priority ISR delays a lower
   priority one that is already pending.
 * Latency distribution histograms.
+* Relocating the vector table and the architecture entry code, not just
+  the benchmark's handlers, so the full flash contribution can be seen.
 * An external event trigger, for example a GPIO loopback described in
   devicetree, so that entry latency includes the pin and interrupt
   controller propagation delays that a software trigger skips.

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -353,6 +353,33 @@ for the column layout)::
    M,interrupt,entry_trigger_to_isr,1000,55000,55.000,0.000,0.000,55,1,55,1
    M,interrupt,exit_resume_interrupted,1000,56000,56.000,0.000,0.000,56,1,56,1
 
+Where the outliers come from
+****************************
+
+:kconfig:option:`CONFIG_INT_BENCH_OUTLIER_TRACE` prints a line for each
+sample far above the smallest one seen, naming what else happened while it
+was taken: how many clock ticks were announced and how many times the load
+timer ran. An outlier accompanied by neither was caused by something the
+benchmark cannot observe, such as the memory system or an attached debug
+probe.
+
+On an FRDM-MCXN947 under load this attributes the tail completely. Every
+outlier reports one tick and one load timer run, so the tail is the
+competing timer interrupt and nothing else, and its size, around 1200 to
+1350 cycles, is the cost of that interrupt being serviced first.
+
+It also explains why the scenarios differ in how often they are hit. The
+frequency is simply how much of the time each measurement is exposed:
+``irq_to_thread`` spans 2.2us against a 1ms timer period and sees 0.26% of
+its samples disturbed, while ``locked_unlock_to_isr`` holds interrupts
+masked for far longer and sees 2.1%, which is why its tail begins at p99
+rather than at p99.9.
+
+Idle outliers are a different matter. One run in three showed a single
+566 cycle sample out of 10000 and the other two showed none at all, so
+there is nothing periodic to find; with no load there is no tick or timer
+for the trace to point at either.
+
 Notes on methodology
 ********************
 

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -25,6 +25,11 @@ All benchmarks are in the ``interrupt`` suite:
   the interrupted thread.
 * ``exit_reschedule`` -- time from the end of an ISR that wakes a higher
   priority thread to that thread running (exit plus context switch).
+* ``irq_to_thread`` -- the whole path an application waits on, from raising
+  the interrupt to the woken high priority thread running. The other
+  scenarios measure the pieces of this span but they cannot be added: they
+  come from separate runs and neither covers the ISR body or the handoff.
+  On qemu_x86 the pieces total 3264 cycles while the span itself is 16800.
 * ``locked_unlock_to_isr`` -- the interrupt is raised while interrupts are
   locked and kept pending for a configurable window; measured is the time
   from ``irq_unlock()`` to ISR entry (latency after a critical section).
@@ -45,6 +50,10 @@ All benchmarks are in the ``interrupt`` suite:
   isolates the cost of the software ISR table dispatch and the common
   entry code: on qemu_x86 that is 1216 cycles regular against 576 direct,
   while on ARC the two are within a cycle of each other.
+* ``zli_entry_trigger_to_isr`` -- entry latency for a zero-latency
+  interrupt with interrupts enabled, the lowest latency Zephyr offers.
+  Measured the same way as the two entry scenarios above, so the three
+  connection kinds can be compared directly.
 * ``zli_entry_while_locked`` -- entry latency for a zero-latency interrupt
   raised *while interrupts are locked*. Cortex-M only, and built from the
   ``prj.zli.conf`` overlay because it claims the same line as

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -78,6 +78,70 @@ Interrupt generation is abstracted behind a small backend API
    backend; entry latency, critical section and throughput scenarios are
    not available.
 
+Background load
+***************
+
+Latency measured on an otherwise idle system is a best case: caches hold the
+benchmark's own working set, no other interrupt is in service and nothing
+else competes for the memory system. Build with the ``prj.load.conf``
+overlay to re-run every scenario under background load:
+
+.. code-block:: console
+
+   west build -p -b qemu_x86 tests/benchmarks/interrupt_latency -t run -- \
+       -DEXTRA_CONF_FILE=prj.load.conf
+
+Three load sources are enabled independently
+(:kconfig:option:`CONFIG_INT_BENCH_LOAD` and the options under it):
+
+``CONFIG_INT_BENCH_LOAD_CACHE``
+   Walks a working set larger than the benchmark's own between samples,
+   outside the measured span, so that each measured interrupt is served with
+   cold caches and TLBs. Runs in the benchmark thread, so it affects every
+   scenario. Note that this has little effect under emulation: QEMU does not
+   model caches, so the walk costs time but does not slow later accesses.
+
+``CONFIG_INT_BENCH_LOAD_TIMER``
+   A periodic timer whose handler runs in the system clock ISR, competing
+   with the benchmark interrupt for the interrupt controller and for the
+   interrupt-disabled windows of the kernel timeout code. This is the load
+   source that dominates under emulation.
+
+``CONFIG_INT_BENCH_LOAD_THREADS``
+   Threads of lower priority than the benchmark that continuously write to
+   memory. On SMP these run on the other CPUs and contend for the memory
+   system throughout; on a uniprocessor they only run while the benchmark
+   blocks, so their effect is limited to the rescheduling scenario. They are
+   deliberately kept below the benchmark's priority so that they cannot
+   preempt it and be mistaken for interrupt latency.
+
+Under load the mean stays close to the idle figure while the maximum and the
+standard deviation grow by an order of magnitude or more; on qemu_x86 the
+entry latency maximum rises from 1184 cycles idle to over 25000 under load.
+The maximum is the number that matters for a real-time application, and it
+is only visible with the system doing something.
+
+The load configuration can be impractically slow on emulated targets. The
+critical section scenario busy waits with interrupts locked while the load
+timer keeps expiring, and under emulation that combination can cost orders
+of magnitude more wall clock than the nominal hold time; ARC is excluded
+from the load run in ``tests.yaml`` for that reason. On such targets, lower
+:kconfig:option:`CONFIG_INT_BENCH_NUM_ITERATIONS`, or disable
+:kconfig:option:`CONFIG_INT_BENCH_LOAD_TIMER`.
+
+How much each scenario moves under load is itself informative. On Arm GIC
+the benchmark SGI is configured above the system timer, so
+``locked_unlock_to_isr`` does not move at all: whatever else is pending when
+interrupts are unmasked, the benchmark interrupt is serviced first. On x86
+the same scenario grows from 928 to 1726 cycles on average, because the
+competing timer interrupt outranks the benchmark vector and is serviced
+before it. That difference is a property of the platform's interrupt
+priorities rather than of the benchmark.
+
+``throughput_round_trip`` barely moves anywhere. It saturates the interrupt
+path by design, so it measures a steady state that stays warm whatever else
+the system is doing.
+
 Running
 *******
 
@@ -123,9 +187,15 @@ Future work
 ***********
 
 * sw-irq trigger backend for Xtensa (INTSET).
-* Nested interrupt preemption latency (two lines, two priorities).
+* Nested interrupt preemption latency and priority interference, both of
+  which need the trigger backend extended to a second line at a second
+  priority.
 * Direct ISR (``IRQ_DIRECT_CONNECT``) and zero-latency IRQ comparison
   scenarios.
-* Percentile (p99) reporting and latency distribution histograms.
-* Background-load variants and SMP scenarios (IPI latency, ISR on
-  non-boot CPU).
+* Percentile (p99) reporting and latency distribution histograms, which
+  the benchmark framework cannot express today because it keeps no
+  sample buffer.
+* An external event trigger, for example a GPIO loopback described in
+  devicetree, so that entry latency includes the pin and interrupt
+  controller propagation delays that a software trigger skips.
+* SMP scenarios (IPI latency, ISR on a non-boot CPU).

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -34,7 +34,10 @@ All benchmarks are in the ``interrupt`` suite:
   ISR + exit + entry round trip under back-to-back service. Its inverse
   is the maximum sustainable interrupt rate.
 * ``dynamic_connect`` -- cost of installing an ISR at runtime with
-  ``irq_connect_dynamic()`` (needs ``CONFIG_DYNAMIC_INTERRUPTS``).
+  ``irq_connect_dynamic()`` (needs ``CONFIG_DYNAMIC_INTERRUPTS``). Not
+  available on x86, where connecting an interrupt dynamically is a one
+  shot allocation of an IDT vector and an interrupt stub rather than a
+  rebindable install, so it cannot be repeated to gather samples.
 
 Each benchmark records ``CONFIG_INT_BENCH_NUM_ITERATIONS`` samples; the
 framework reports mean, standard deviation, standard error and min/max with
@@ -51,11 +54,12 @@ Interrupt generation is abstracted behind a small backend API
 
 ``CONFIG_INT_BENCH_TRIGGER_SW_IRQ``
    Raises a real interrupt through the interrupt controller. Currently
-   implemented for Cortex-M (NVIC STIR/ISPR), Arm GIC v2/v3 (SGI) and ARC
-   (IRQ_HINT), using the same mechanisms as ``tests/arch/common/interrupt``.
-   The IRQ line is auto-selected (an SGI on GIC, ``CONFIG_NUM_IRQS - 1``
-   otherwise) and can be overridden with ``CONFIG_INT_BENCH_IRQ_LINE`` for
-   SoCs where the automatic choice is not a free, implemented line.
+   implemented for Cortex-M (NVIC STIR/ISPR), Arm GIC v2/v3 (SGI), ARC
+   (IRQ_HINT) and x86 (local APIC self IPI, both xAPIC and x2APIC), using
+   the same mechanisms as ``tests/arch/common/interrupt``. The IRQ line is
+   auto-selected (an SGI on GIC, ``CONFIG_NUM_IRQS - 1`` otherwise) and can
+   be overridden with ``CONFIG_INT_BENCH_IRQ_LINE`` for SoCs where the
+   automatic choice is not a free, implemented line.
 
 ``CONFIG_INT_BENCH_TRIGGER_OFFLOAD``
    Fallback for every other architecture, based on ``irq_offload()``. Since
@@ -94,6 +98,11 @@ Notes on methodology
   tick per second on a 150MHz part makes the driver fall back to its
   ten microsecond minimum and interrupt 78000 times a second instead of
   once.
+* The first iteration of each scenario runs with cold caches, branch
+  predictors and TLBs and is typically an order of magnitude slower than
+  the steady state. The framework reports it separately as the cold cost,
+  and :kconfig:option:`CONFIG_ZTEST_BENCHMARK_WARMUP` discards further
+  iterations before sampling if the steady state is all that matters.
 * Entry latency includes the cost of the trigger write itself and, on some
   interrupt controllers, the propagation delay of the software-generated
   interrupt. Numbers are therefore comparable across Zephyr versions and
@@ -102,8 +111,7 @@ Notes on methodology
 Future work
 ***********
 
-* sw-irq trigger backends for x86 (LOAPIC self-IPI), RISC-V (CLIC/mip) and
-  Xtensa (INTSET).
+* sw-irq trigger backends for RISC-V (CLIC/mip) and Xtensa (INTSET).
 * Nested interrupt preemption latency (two lines, two priorities).
 * Direct ISR (``IRQ_DIRECT_CONNECT``) and zero-latency IRQ comparison
   scenarios.

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -33,6 +33,13 @@ All benchmarks are in the ``interrupt`` suite:
 * ``locked_unlock_to_isr`` -- the interrupt is raised while interrupts are
   locked and kept pending for a configurable window; measured is the time
   from ``irq_unlock()`` to ISR entry (latency after a critical section).
+* ``nested_preempt`` -- the second, higher priority interrupt is raised from
+  inside the first one's ISR; measured is how long it takes to preempt it.
+  For an interrupt-heavy application this is often a better description of
+  what a high priority handler sees than the plain entry latency, since the
+  CPU is rarely idle when the event arrives. On qemu_cortex_a53 preemption
+  takes 66 cycles against 74 for entry from thread context, the nested
+  entry having less state to save.
 * ``throughput_round_trip`` -- the ISR re-triggers itself so the next
   interrupt is already pending while the current one is being serviced;
   each sample runs from one ISR entry to the next and so covers a full
@@ -123,8 +130,9 @@ Interrupt generation is abstracted behind a small backend API
 Direct and zero-latency interrupts
 **********************************
 
-Two scenarios measure what a different kind of connection buys, and both
-need a second IRQ line, because how an interrupt is connected is fixed at
+Three scenarios need a second IRQ line -- two because how an interrupt is
+connected is fixed at build time, and the nested one because it needs a
+second priority, because how an interrupt is connected is fixed at
 build time. The second line is available on Cortex-M, Arm GIC, ARC and x86;
 RISC-V without a CLIC has only the one interrupt a hart can raise on
 itself, which the first line already uses.
@@ -317,9 +325,8 @@ Future work
 ***********
 
 * sw-irq trigger backend for Xtensa (INTSET).
-* Nested interrupt preemption latency and priority interference, both of
-  which need the trigger backend extended to a second line at a second
-  priority.
+* Priority interference: how much a high priority ISR delays a lower
+  priority one that is already pending.
 * Latency distribution histograms.
 * An external event trigger, for example a GPIO loopback described in
   devicetree, so that entry latency includes the pin and interrupt

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -55,11 +55,22 @@ Interrupt generation is abstracted behind a small backend API
 ``CONFIG_INT_BENCH_TRIGGER_SW_IRQ``
    Raises a real interrupt through the interrupt controller. Currently
    implemented for Cortex-M (NVIC STIR/ISPR), Arm GIC v2/v3 (SGI), ARC
-   (IRQ_HINT) and x86 (local APIC self IPI, both xAPIC and x2APIC), using
-   the same mechanisms as ``tests/arch/common/interrupt``. The IRQ line is
-   auto-selected (an SGI on GIC, ``CONFIG_NUM_IRQS - 1`` otherwise) and can
+   (IRQ_HINT), x86 (local APIC self IPI, both xAPIC and x2APIC) and RISC-V
+   (CLIC pending bit, or the CLINT machine software interrupt where there
+   is no CLIC), largely using the same mechanisms as
+   ``tests/arch/common/interrupt``. The IRQ line is auto-selected and can
    be overridden with ``CONFIG_INT_BENCH_IRQ_LINE`` for SoCs where the
    automatic choice is not a free, implemented line.
+
+   On RISC-V without a CLIC, a hart cannot make one of its own external
+   interrupts pending -- PLIC pending bits are driven by the interrupt
+   gateways and the ``mip`` software, timer and external bits are read
+   only -- so the machine software interrupt is asserted through the
+   CLINT, as the SMP IPI code does. That interrupt is level triggered, so
+   the ISR deasserts it before running the measurement handler; RISC-V
+   entry latency therefore includes one store to the CLINT. This backend
+   is unavailable on SMP builds, where the machine software interrupt is
+   already used for scheduler IPIs.
 
 ``CONFIG_INT_BENCH_TRIGGER_OFFLOAD``
    Fallback for every other architecture, based on ``irq_offload()``. Since
@@ -111,7 +122,7 @@ Notes on methodology
 Future work
 ***********
 
-* sw-irq trigger backends for RISC-V (CLIC/mip) and Xtensa (INTSET).
+* sw-irq trigger backend for Xtensa (INTSET).
 * Nested interrupt preemption latency (two lines, two priorities).
 * Direct ISR (``IRQ_DIRECT_CONNECT``) and zero-latency IRQ comparison
   scenarios.

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -39,6 +39,16 @@ All benchmarks are in the ``interrupt`` suite:
   what this number does and does not prove. Needs a tick rate of at least
   100 Hz, so it is enabled by the load overlay rather than the base
   configuration.
+* ``entry_direct_isr`` -- entry latency for an interrupt connected with
+  ``IRQ_DIRECT_CONNECT()``, dispatched straight from the vector table.
+  Compared against ``entry_trigger_to_isr`` in the same run, the pair
+  isolates the cost of the software ISR table dispatch and the common
+  entry code: on qemu_x86 that is 1216 cycles regular against 576 direct,
+  while on ARC the two are within a cycle of each other.
+* ``zli_entry_while_locked`` -- entry latency for a zero-latency interrupt
+  raised *while interrupts are locked*. Cortex-M only, and built from the
+  ``prj.zli.conf`` overlay because it claims the same line as
+  ``entry_direct_isr``. See `Direct and zero-latency interrupts`_.
 * ``dynamic_connect`` -- cost of installing an ISR at runtime with
   ``irq_connect_dynamic()`` (needs ``CONFIG_DYNAMIC_INTERRUPTS``). Not
   available on x86, where connecting an interrupt dynamically is a one
@@ -83,6 +93,45 @@ Interrupt generation is abstracted behind a small backend API
    this is a synchronous trap, only the exit-path scenarios run with this
    backend; entry latency, critical section and throughput scenarios are
    not available.
+
+Direct and zero-latency interrupts
+**********************************
+
+Two scenarios measure what a different kind of connection buys, and both
+need a second IRQ line, because how an interrupt is connected is fixed at
+build time. The second line is available on Cortex-M, Arm GIC, ARC and x86;
+RISC-V without a CLIC has only the one interrupt a hart can raise on
+itself, which the first line already uses.
+
+``entry_direct_isr`` connects the second line with ``IRQ_DIRECT_CONNECT()``
+and measures its entry latency exactly as ``entry_trigger_to_isr`` does for
+a regular ISR. The difference between the two is the common entry code and
+the software ISR table lookup that a regular interrupt goes through. How
+much that is worth is entirely a property of the architecture: on qemu_x86
+a direct ISR is entered in 576 cycles against 1216 for a regular one, while
+on ARC, whose regular entry path is already thin, the two are within a
+cycle of each other and the direct connection buys nothing.
+
+The scenario is enabled by default wherever the architecture implements
+direct interrupts. There is no capability symbol for that, so the Kconfig
+names the architectures: Arm64 has none, and on x86 only IA32 does, the
+64-bit ``ARCH_ISR_DIRECT_DECLARE()`` being an empty stub that silently
+produces a function with no return type.
+
+``zli_entry_while_locked`` connects the second line as a zero-latency
+interrupt and triggers it *inside* a critical section. Because a
+zero-latency interrupt runs above the priority the kernel masks with, it is
+served during the lock rather than after it, which is the whole point of
+the feature; ``locked_unlock_to_isr`` is the comparison, measuring an
+interrupt that has to wait for ``irq_unlock()``. On Arm a zero-latency
+interrupt must be registered with ``IRQ_DIRECT_CONNECT()``, so it is also a
+direct ISR, and it claims the same line: build it with the
+``prj.zli.conf`` overlay, which turns the direct scenario off.
+
+Both scenarios bound their wait for the ISR and report that they were
+skipped rather than hanging if it never arrives. That matters most for the
+zero-latency case, where the wait happens with interrupts locked and
+nothing else could break the deadlock.
 
 Background load
 ***************
@@ -245,8 +294,6 @@ Future work
 * Nested interrupt preemption latency and priority interference, both of
   which need the trigger backend extended to a second line at a second
   priority.
-* Direct ISR (``IRQ_DIRECT_CONNECT``) and zero-latency IRQ comparison
-  scenarios.
 * Percentile (p99) reporting and latency distribution histograms, which
   the benchmark framework cannot express today because it keeps no
   sample buffer.

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -1,0 +1,112 @@
+Interrupt Handling Benchmark
+############################
+
+This benchmark measures the individual components of interrupt handling in
+Zephyr, with the goal of characterizing a platform for interrupt-heavy
+applications. Where possible it uses a *real asynchronous interrupt* raised
+through the platform interrupt controller, rather than the synchronous
+``irq_offload()`` trap used by the ``latency_measure`` benchmark, so that the
+hardware interrupt entry path is part of what is measured.
+
+The benchmarks are built on the :ref:`ztest benchmarking framework
+<ztest_benchmarking>` as manually sampled benchmarks
+(``ZTEST_BENCHMARK_MANUAL``), because every measured span has at least one
+endpoint captured in a different execution context (inside the ISR, or in a
+woken thread) which framework-timed benchmarks cannot express.
+
+Scenarios
+*********
+
+All benchmarks are in the ``interrupt`` suite:
+
+* ``entry_trigger_to_isr`` -- time from the software write that raises the
+  interrupt to the first timestamp taken inside the ISR (entry latency).
+* ``exit_resume_interrupted`` -- time from the end of the ISR body back to
+  the interrupted thread.
+* ``exit_reschedule`` -- time from the end of an ISR that wakes a higher
+  priority thread to that thread running (exit plus context switch).
+* ``locked_unlock_to_isr`` -- the interrupt is raised while interrupts are
+  locked and kept pending for a configurable window; measured is the time
+  from ``irq_unlock()`` to ISR entry (latency after a critical section).
+* ``throughput_round_trip`` -- the ISR re-triggers itself so the next
+  interrupt is already pending while the current one is being serviced;
+  each sample runs from one ISR entry to the next and so covers a full
+  ISR + exit + entry round trip under back-to-back service. Its inverse
+  is the maximum sustainable interrupt rate.
+* ``dynamic_connect`` -- cost of installing an ISR at runtime with
+  ``irq_connect_dynamic()`` (needs ``CONFIG_DYNAMIC_INTERRUPTS``).
+
+Each benchmark records ``CONFIG_INT_BENCH_NUM_ITERATIONS`` samples; the
+framework reports mean, standard deviation, standard error and min/max with
+control-measurement noise correction. The default configuration selects the
+CSV output format so that twister records the values (``twister.json`` /
+``recording.csv``); build with ``CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE=y``
+for human readable output instead.
+
+Trigger backends
+****************
+
+Interrupt generation is abstracted behind a small backend API
+(``src/trigger.h``) selected with Kconfig:
+
+``CONFIG_INT_BENCH_TRIGGER_SW_IRQ``
+   Raises a real interrupt through the interrupt controller. Currently
+   implemented for Cortex-M (NVIC STIR/ISPR), Arm GIC v2/v3 (SGI) and ARC
+   (IRQ_HINT), using the same mechanisms as ``tests/arch/common/interrupt``.
+   The IRQ line is auto-selected (an SGI on GIC, ``CONFIG_NUM_IRQS - 1``
+   otherwise) and can be overridden with ``CONFIG_INT_BENCH_IRQ_LINE`` for
+   SoCs where the automatic choice is not a free, implemented line.
+
+``CONFIG_INT_BENCH_TRIGGER_OFFLOAD``
+   Fallback for every other architecture, based on ``irq_offload()``. Since
+   this is a synchronous trap, only the exit-path scenarios run with this
+   backend; entry latency, critical section and throughput scenarios are
+   not available.
+
+Running
+*******
+
+.. code-block:: console
+
+   west build -p -b qemu_cortex_m3 tests/benchmarks/interrupt_latency -t run
+
+or via twister, which also collects the metrics:
+
+.. code-block:: console
+
+   scripts/twister -p qemu_cortex_m3 -T tests/benchmarks/interrupt_latency
+
+Sample CSV output (see :kconfig:option:`CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV`
+for the column layout)::
+
+   M,interrupt,entry_trigger_to_isr,1000,55000,55.000,0.000,0.000,55,1,55,1
+   M,interrupt,exit_resume_interrupted,1000,56000,56.000,0.000,0.000,56,1,56,1
+
+Notes on methodology
+********************
+
+* Timestamps use the timing subsystem; the framework subtracts a control
+  measurement from every reported statistic.
+* The system tick rate is kept low so timer interrupts do not perturb
+  most samples; residual hits show up in the maximum and standard
+  deviation. It cannot be made arbitrarily low: a tick has to fit the
+  timer's counter, and a Cortex-M SysTick is 24 bits, so asking for one
+  tick per second on a 150MHz part makes the driver fall back to its
+  ten microsecond minimum and interrupt 78000 times a second instead of
+  once.
+* Entry latency includes the cost of the trigger write itself and, on some
+  interrupt controllers, the propagation delay of the software-generated
+  interrupt. Numbers are therefore comparable across Zephyr versions and
+  configurations on the same platform, and indicative across platforms.
+
+Future work
+***********
+
+* sw-irq trigger backends for x86 (LOAPIC self-IPI), RISC-V (CLIC/mip) and
+  Xtensa (INTSET).
+* Nested interrupt preemption latency (two lines, two priorities).
+* Direct ISR (``IRQ_DIRECT_CONNECT``) and zero-latency IRQ comparison
+  scenarios.
+* Percentile (p99) reporting and latency distribution histograms.
+* Background-load variants and SMP scenarios (IPI latency, ISR on
+  non-boot CPU).

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -39,7 +39,9 @@ All benchmarks are in the ``interrupt`` suite:
   what a high priority handler sees than the plain entry latency, since the
   CPU is rarely idle when the event arrives. On qemu_cortex_a53 preemption
   takes 66 cycles against 74 for entry from thread context, the nested
-  entry having less state to save.
+  entry having less state to save. Selecting this scenario connects the
+  second line as a regular ISR, so the number describes preemption into an
+  ordinary handler.
 * ``throughput_round_trip`` -- the ISR re-triggers itself so the next
   interrupt is already pending while the current one is being serviced;
   each sample runs from one ISR entry to the next and so covers a full
@@ -132,19 +134,33 @@ Direct and zero-latency interrupts
 
 Three scenarios need a second IRQ line -- two because how an interrupt is
 connected is fixed at build time, and the nested one because it needs a
-second priority, because how an interrupt is connected is fixed at
-build time. The second line is available on Cortex-M, Arm GIC, ARC and x86;
-RISC-V without a CLIC has only the one interrupt a hart can raise on
-itself, which the first line already uses.
+second priority. Only one of them can be built at a time, because they
+disagree about what priority that line should run at, so the
+``INT_BENCH_ALT_LINE_USE`` choice picks between them. The direct
+comparison is the default where the architecture supports direct
+interrupts, nesting where it does not, and ``prj.nested.conf`` and
+``prj.zli.conf`` select the other two. The second line is available on
+Cortex-M, Arm GIC, ARC and x86; RISC-V without a CLIC has only the one
+interrupt a hart can raise on itself, which the first line already uses.
 
 ``entry_direct_isr`` connects the second line with ``IRQ_DIRECT_CONNECT()``
 and measures its entry latency exactly as ``entry_trigger_to_isr`` does for
-a regular ISR. The difference between the two is the common entry code and
-the software ISR table lookup that a regular interrupt goes through. How
-much that is worth is entirely a property of the architecture: on qemu_x86
-a direct ISR is entered in 576 cycles against 1216 for a regular one, while
-on ARC, whose regular entry path is already thin, the two are within a
-cycle of each other and the direct connection buys nothing.
+a regular ISR, and at the same priority, so the difference between the two
+is the common entry code and the software ISR table lookup that a regular
+interrupt goes through and nothing else. How much that is worth is entirely
+a property of the architecture: on qemu_x86 a direct ISR is entered in 576
+cycles against 1216 for a regular one, while on ARC, whose regular entry
+path is already thin, the two are within a cycle of each other and the
+direct connection buys nothing.
+
+Equal priority matters for reading the result. On an FRDM-MCXN947 a direct
+ISR is entered in 19 cycles against 33 for a regular one, and under load
+both have the same tail, 1210 and 1236 cycles at p99.99. Direct dispatch
+saves a fixed amount on every interrupt and nothing at all in the tail,
+because what fills the tail is waiting behind other interrupts, which is a
+matter of priority. Running the second line at a higher priority instead
+made the direct ISR appear to have no tail whatsoever, which said nothing
+about direct dispatch.
 
 The scenario is enabled by default wherever the architecture implements
 direct interrupts. There is no capability symbol for that, so the Kconfig

--- a/tests/benchmarks/interrupt_latency/README.rst
+++ b/tests/benchmarks/interrupt_latency/README.rst
@@ -55,9 +55,26 @@ All benchmarks are in the ``interrupt`` suite:
   shot allocation of an IDT vector and an interrupt stub rather than a
   rebindable install, so it cannot be repeated to gather samples.
 
-Each benchmark records ``CONFIG_INT_BENCH_NUM_ITERATIONS`` samples; the
-framework reports mean, standard deviation, standard error and min/max with
-control-measurement noise correction. The default configuration selects the
+Each benchmark records ``CONFIG_INT_BENCH_NUM_ITERATIONS`` samples, all
+with control-measurement noise correction.
+
+The numbers to read are the percentiles, which the benchmark enables with
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_PERCENTILES`: ``min``, ``p50``,
+``p90``, ``p99``, ``p99.9``, ``p99.99`` and ``max``. What characterises a
+platform for interrupt-heavy work is how bad an individual interrupt can
+be, not how precisely the average was estimated, and the two can describe
+entirely different systems. Entry latency on a loaded qemu_x86 has a mean
+of 1264 cycles and a standard error of 34, yet no interrupt ever took
+1264 cycles: 99% of them took 1216 and the rest took 25184. The mean and
+standard deviation are still reported, for comparison against other
+benchmarks that use them.
+
+Resolving a percentile takes samples: p99 needs a hundred, p99.9 a
+thousand and p99.99 ten thousand. At the default thousand iterations
+p99.9 is the last meaningful one, so raise both
+:kconfig:option:`CONFIG_INT_BENCH_NUM_ITERATIONS` and
+:kconfig:option:`CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES` to characterise
+further out. The default configuration selects the
 CSV output format so that twister records the values (``twister.json`` /
 ``recording.csv``); build with ``CONFIG_ZTEST_BENCHMARK_OUTPUT_VERBOSE=y``
 for human readable output instead.
@@ -294,9 +311,7 @@ Future work
 * Nested interrupt preemption latency and priority interference, both of
   which need the trigger backend extended to a second line at a second
   priority.
-* Percentile (p99) reporting and latency distribution histograms, which
-  the benchmark framework cannot express today because it keeps no
-  sample buffer.
+* Latency distribution histograms.
 * An external event trigger, for example a GPIO loopback described in
   devicetree, so that entry latency includes the pin and interrupt
   controller propagation delays that a software trigger skips.

--- a/tests/benchmarks/interrupt_latency/prj.conf
+++ b/tests/benchmarks/interrupt_latency/prj.conf
@@ -3,8 +3,14 @@
 
 CONFIG_ZTEST=y
 CONFIG_ZTEST_BENCHMARK=y
-CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
 CONFIG_ASSERT=n
+#CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+
+# What matters for a real-time system is how bad an individual
+# interrupt can be, which lives in the tail of the distribution rather
+# than in the mean. Retain every sample so the tail can be reported.
+CONFIG_ZTEST_BENCHMARK_PERCENTILES=y
+CONFIG_ZTEST_BENCHMARK_MAX_SAMPLES=1024
 
 # The benchmark framework reports its statistics as doubles from the
 # thread running the benchmarks. Formatting them needs more stack than

--- a/tests/benchmarks/interrupt_latency/prj.conf
+++ b/tests/benchmarks/interrupt_latency/prj.conf
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_BENCHMARK=y
+CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+CONFIG_ASSERT=n
+
+# Fallback trigger backend for architectures without a sw-irq trigger
+CONFIG_IRQ_OFFLOAD=y
+
+# Every scenario measures one core: the trigger raises the interrupt on
+# whichever CPU the benchmark thread is running on, and each measured
+# span starts and ends there. Left multi-core, the thread migrates and
+# the interrupt is raised on a CPU that never enabled the line, since
+# enabling an SGI or a software interrupt is per-CPU, so the trigger is
+# simply lost.
+CONFIG_MP_MAX_NUM_CPUS=1
+
+# Reduce measurement noise
+CONFIG_FORCE_NO_ASSERT=y
+CONFIG_TEST_HW_STACK_PROTECTION=n
+CONFIG_HW_STACK_PROTECTION=n
+CONFIG_COVERAGE=n
+CONFIG_PM=n
+CONFIG_TIMESLICING=n
+CONFIG_BT=n

--- a/tests/benchmarks/interrupt_latency/prj.conf
+++ b/tests/benchmarks/interrupt_latency/prj.conf
@@ -6,6 +6,11 @@ CONFIG_ZTEST_BENCHMARK=y
 CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
 CONFIG_ASSERT=n
 
+# The benchmark framework reports its statistics as doubles from the
+# thread running the benchmarks. Formatting them needs more stack than
+# the 1KB default of some platforms provides.
+CONFIG_MAIN_STACK_SIZE=4096
+
 # Fallback trigger backend for architectures without a sw-irq trigger
 CONFIG_IRQ_OFFLOAD=y
 

--- a/tests/benchmarks/interrupt_latency/prj.load.conf
+++ b/tests/benchmarks/interrupt_latency/prj.load.conf
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run the benchmark scenarios under background system load. Use with
+# EXTRA_CONF_FILE="prj.load.conf".
+
+CONFIG_INT_BENCH_LOAD=y
+CONFIG_ASSERT=n
+
+# The base configuration keeps the tick rate low to keep timer
+# interrupts out of the measurements. Under load the
+# competing timer is part of the point, so give the system clock a
+# resolution the load period can actually use. Kept moderate so that
+# the benchmark stays practical on slow emulated targets.
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000

--- a/tests/benchmarks/interrupt_latency/prj.nested.conf
+++ b/tests/benchmarks/interrupt_latency/prj.nested.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Use the second IRQ line for the nested preemption scenario instead of
+# the direct ISR comparison; the two need the line at different
+# priorities, so only one can be built at a time. Use with
+# EXTRA_CONF_FILE="prj.nested.conf".
+
+CONFIG_INT_BENCH_SCENARIO_NESTED=y

--- a/tests/benchmarks/interrupt_latency/prj.ramfunc.conf
+++ b/tests/benchmarks/interrupt_latency/prj.ramfunc.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Relocate the benchmark's interrupt handlers to RAM, so that the run
+# can be compared against one built without this overlay to see what
+# fetching them from flash costs. Use with
+# EXTRA_CONF_FILE="prj.ramfunc.conf".
+
+CONFIG_INT_BENCH_ISR_IN_RAM=y

--- a/tests/benchmarks/interrupt_latency/prj.zli.conf
+++ b/tests/benchmarks/interrupt_latency/prj.zli.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Measure a zero-latency interrupt instead of a directly connected one;
+# the two scenarios share the second IRQ line. Cortex-M only. Use with
+# EXTRA_CONF_FILE="prj.zli.conf".
+
+CONFIG_ZERO_LATENCY_IRQS=y
+CONFIG_INT_BENCH_SCENARIO_ZLI=y

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -114,7 +114,7 @@ static volatile bool fired;
 
 #if defined(CONFIG_INT_BENCH_SCENARIO_ENTRY) || defined(CONFIG_INT_BENCH_SCENARIO_LOCKED)
 /* Timestamp as early as possible in the ISR: measures the entry path */
-static void entry_handler(void)
+static BENCH_ISR_FUNC void entry_handler(void)
 {
 	ztest_benchmark_end();
 	fired = true;
@@ -163,7 +163,7 @@ static struct k_thread waiter_thread;
 
 #ifdef CONFIG_INT_BENCH_SCENARIO_EXIT
 /* Timestamp as the last operation in the ISR: measures the exit path */
-static void exit_handler(void)
+static BENCH_ISR_FUNC void exit_handler(void)
 {
 	fired = true;
 	ztest_benchmark_start();

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -1,0 +1,297 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Interrupt handling benchmarks, built on the ztest benchmark
+ * framework. All scenarios are manually sampled benchmarks
+ * (ZTEST_BENCHMARK_MANUAL) because their measured spans have endpoints
+ * captured in different execution contexts (thread vs ISR), which
+ * framework-timed benchmarks cannot express.
+ *
+ * The suite and all benchmarks live in one translation unit because
+ * ZTEST_BENCHMARK_SUITE() defines the suite object static; individual
+ * scenarios are selected with the CONFIG_INT_BENCH_SCENARIO_* options.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/irq.h>
+#include <zephyr/timing/timing.h>
+
+#include "trigger.h"
+
+#define NUM_ITERATIONS CONFIG_INT_BENCH_NUM_ITERATIONS
+
+static void suite_setup(void)
+{
+#ifdef CONFIG_INT_BENCH_TRIGGER_SW_IRQ
+	printk("Interrupt benchmark: trigger=sw-irq (line %u), %u iterations\n",
+	       bench_trigger_irq_line(), NUM_ITERATIONS);
+#else
+	printk("Interrupt benchmark: trigger=irq_offload, %u iterations\n"
+	       "No sw-irq trigger for this architecture: only the exit path\n"
+	       "scenarios run (entry latency, critical section, throughput\n"
+	       "and dynamic connect need a real asynchronous interrupt)\n",
+	       NUM_ITERATIONS);
+#endif
+
+	(void)bench_trigger_init();
+}
+
+ZTEST_BENCHMARK_SUITE(interrupt, suite_setup, NULL);
+
+#if defined(CONFIG_INT_BENCH_SCENARIO_ENTRY) || defined(CONFIG_INT_BENCH_SCENARIO_EXIT) || \
+	defined(CONFIG_INT_BENCH_SCENARIO_LOCKED)
+static volatile bool fired;
+#endif
+
+#if defined(CONFIG_INT_BENCH_SCENARIO_ENTRY) || defined(CONFIG_INT_BENCH_SCENARIO_LOCKED)
+/* Timestamp as early as possible in the ISR: measures the entry path */
+static void entry_handler(void)
+{
+	ztest_benchmark_end();
+	fired = true;
+}
+#endif
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_ENTRY
+/*
+ * Interrupt entry latency: time from the software write that raises
+ * the interrupt to the first timestamp taken inside the ISR. Requires
+ * the sw-irq trigger backend (a real asynchronous interrupt).
+ */
+static void entry_setup(void)
+{
+	bench_trigger_set_handler(entry_handler);
+}
+
+static void entry_teardown(void)
+{
+	bench_trigger_set_handler(NULL);
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, entry_trigger_to_isr, NUM_ITERATIONS, entry_setup,
+		       entry_teardown)
+{
+	fired = false;
+
+	ztest_benchmark_start();
+	bench_trigger();
+
+	while (!fired) {
+	}
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_ENTRY */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_EXIT
+/* Timestamp as the last operation in the ISR: measures the exit path */
+static void exit_handler(void)
+{
+	fired = true;
+	ztest_benchmark_start();
+}
+
+/*
+ * Interrupt exit latency: time from the last instruction of the ISR
+ * body back to the interrupted thread. Works with both trigger
+ * backends; with irq_offload() it measures the offload trap exit path.
+ */
+static void exit_setup(void)
+{
+	bench_trigger_set_handler(exit_handler);
+}
+
+static void exit_teardown(void)
+{
+	bench_trigger_set_handler(NULL);
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, exit_resume_interrupted, NUM_ITERATIONS, exit_setup,
+		       exit_teardown)
+{
+	fired = false;
+
+	bench_trigger();
+
+	while (!fired) {
+	}
+
+	ztest_benchmark_end();
+}
+
+#define WAITER_STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+static K_SEM_DEFINE(wake_sem, 0, 1);
+static K_SEM_DEFINE(sync_sem, 0, 1);
+static K_THREAD_STACK_DEFINE(waiter_stack, WAITER_STACK_SIZE);
+static struct k_thread waiter_thread;
+
+static void resched_handler(void)
+{
+	k_sem_give(&wake_sem);
+	ztest_benchmark_start();
+}
+
+
+static void waiter_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_sem_take(&wake_sem, K_FOREVER);
+	ztest_benchmark_end();
+	k_sem_give(&sync_sem);
+}
+
+/*
+ * Interrupt exit with rescheduling: time from the last instruction of
+ * an ISR that wakes a higher priority thread to that thread running
+ * (interrupt exit plus context switch).
+ */
+static void resched_setup(void)
+{
+	int priority = k_thread_priority_get(k_current_get());
+
+	bench_trigger_set_handler(resched_handler);
+
+	k_thread_create(&waiter_thread, waiter_stack, K_THREAD_STACK_SIZEOF(waiter_stack),
+			waiter_entry, NULL, NULL, NULL, priority - 1, 0, K_NO_WAIT);
+}
+
+static void resched_teardown(void)
+{
+	(void)k_thread_join(&waiter_thread, K_FOREVER);
+	bench_trigger_set_handler(NULL);
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, exit_reschedule, NUM_ITERATIONS, resched_setup,
+		       resched_teardown)
+{
+	bench_trigger();
+	k_sem_take(&sync_sem, K_FOREVER);
+
+
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_EXIT */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_LOCKED
+/*
+ * Entry latency after a critical section: the interrupt is raised
+ * while interrupts are locked, kept pending for
+ * CONFIG_INT_BENCH_LOCK_HOLD_US, then the time from irq_unlock() to
+ * ISR entry is measured. Requires the sw-irq trigger backend.
+ */
+static void locked_setup(void)
+{
+	bench_trigger_set_handler(entry_handler);
+}
+
+static void locked_teardown(void)
+{
+	bench_trigger_set_handler(NULL);
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, locked_unlock_to_isr, NUM_ITERATIONS, locked_setup,
+		       locked_teardown)
+{
+	unsigned int key;
+
+	fired = false;
+
+	key = irq_lock();
+
+	bench_trigger();
+	k_busy_wait(CONFIG_INT_BENCH_LOCK_HOLD_US);
+
+	ztest_benchmark_start();
+	irq_unlock(key);
+
+	while (!fired) {
+	}
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_LOCKED */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_THROUGHPUT
+static volatile bool done;
+static volatile uint32_t isr_count;
+
+/*
+ * Re-trigger from the top of the handler, so the next interrupt is
+ * already pending while this one is still being serviced, and
+ * timestamp the entry of both.
+ */
+static void throughput_handler(void)
+{
+	if (isr_count == 0U) {
+		ztest_benchmark_start();
+		isr_count = 1U;
+		bench_trigger();
+	} else {
+		ztest_benchmark_end();
+		done = true;
+	}
+}
+
+static void throughput_setup(void)
+{
+	bench_trigger_set_handler(throughput_handler);
+}
+
+static void throughput_teardown(void)
+{
+	bench_trigger_set_handler(NULL);
+}
+
+/*
+ * Sustained interrupt round-trip cost. The span runs from the entry of
+ * one interrupt to the entry of the next, with the next already pending
+ * throughout, so it covers the handler body, the exit path and the
+ * entry path back to back (tail-chained where the hardware supports
+ * it). Its inverse is the maximum sustainable interrupt rate. Requires
+ * the sw-irq backend.
+ */
+ZTEST_BENCHMARK_MANUAL(interrupt, throughput_round_trip, NUM_ITERATIONS, throughput_setup,
+		       throughput_teardown)
+{
+	isr_count = 0U;
+	done = false;
+
+	bench_trigger();
+
+	while (!done) {
+	}
+
+
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_THROUGHPUT */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_DYNAMIC
+/*
+ * Cost of installing an interrupt handler at runtime with
+ * irq_connect_dynamic(). The line is disabled while the handler is
+ * (re)installed because z_isr_install() requires the line to be
+ * disabled on most architectures.
+ */
+static void dynamic_setup(void)
+{
+	irq_disable(bench_trigger_irq_line());
+}
+
+static void dynamic_teardown(void)
+{
+	irq_enable(bench_trigger_irq_line());
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, dynamic_connect, NUM_ITERATIONS, dynamic_setup,
+		       dynamic_teardown)
+{
+	unsigned int line = bench_trigger_irq_line();
+
+	ztest_benchmark_start();
+	(void)irq_connect_dynamic(line, CONFIG_INT_BENCH_IRQ_PRIO, bench_trigger_isr, NULL, 0);
+	ztest_benchmark_end();
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_DYNAMIC */

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -127,6 +127,15 @@ ZTEST_BENCHMARK_MANUAL(interrupt, entry_trigger_to_isr, NUM_ITERATIONS, entry_se
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_ENTRY */
 
+#if defined(CONFIG_INT_BENCH_SCENARIO_EXIT) || defined(CONFIG_INT_BENCH_SCENARIO_END_TO_END)
+#define WAITER_STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+static K_SEM_DEFINE(wake_sem, 0, 1);
+static K_SEM_DEFINE(sync_sem, 0, 1);
+static K_THREAD_STACK_DEFINE(waiter_stack, WAITER_STACK_SIZE);
+static struct k_thread waiter_thread;
+#endif
+
 #ifdef CONFIG_INT_BENCH_SCENARIO_EXIT
 /* Timestamp as the last operation in the ISR: measures the exit path */
 static void exit_handler(void)
@@ -163,13 +172,6 @@ ZTEST_BENCHMARK_MANUAL(interrupt, exit_resume_interrupted, NUM_ITERATIONS, exit_
 
 	ztest_benchmark_end();
 }
-
-#define WAITER_STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
-
-static K_SEM_DEFINE(wake_sem, 0, 1);
-static K_SEM_DEFINE(sync_sem, 0, 1);
-static K_THREAD_STACK_DEFINE(waiter_stack, WAITER_STACK_SIZE);
-static struct k_thread waiter_thread;
 
 static void resched_handler(void)
 {
@@ -482,14 +484,12 @@ static bool alt_wait(void)
 }
 #endif
 
-#ifdef CONFIG_INT_BENCH_SCENARIO_DIRECT
 /*
- * Entry latency of a directly connected ISR. Identical to
- * entry_trigger_to_isr apart from the line it uses, so the difference
- * between the two is the cost of the software ISR table dispatch and
- * the common entry code that a regular ISR goes through.
+ * Entry latency of the second line, measured exactly as
+ * entry_trigger_to_isr measures the first. What differs is only how
+ * the line is connected, so the two are directly comparable.
  */
-ZTEST_BENCHMARK_MANUAL(interrupt, entry_direct_isr, NUM_ITERATIONS, NULL, NULL)
+static void alt_entry_measure(const char *name)
 {
 	alt_fired = false;
 	bench_load_pollute();
@@ -498,9 +498,20 @@ ZTEST_BENCHMARK_MANUAL(interrupt, entry_direct_isr, NUM_ITERATIONS, NULL, NULL)
 	bench_trigger_alt();
 
 	if (!alt_wait()) {
-		printk("entry_direct_isr: direct ISR did not run, skipping\n");
+		printk("%s: ISR did not run, skipping\n", name);
 		return;
 	}
+}
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_DIRECT
+/*
+ * A directly connected ISR is dispatched from the vector table, so the
+ * difference from entry_trigger_to_isr is the software ISR table
+ * dispatch and the common entry code a regular ISR goes through.
+ */
+ZTEST_BENCHMARK_MANUAL(interrupt, entry_direct_isr, NUM_ITERATIONS, NULL, NULL)
+{
+	alt_entry_measure("entry_direct_isr");
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_DIRECT */
 
@@ -513,6 +524,18 @@ ZTEST_BENCHMARK_MANUAL(interrupt, entry_direct_isr, NUM_ITERATIONS, NULL, NULL)
  * two scenarios together show what a critical section costs an
  * interrupt, and what escaping it buys.
  */
+/*
+ * Entry latency of a zero-latency interrupt with interrupts enabled.
+ * This is the lowest latency Zephyr offers, and being measured the
+ * same way as entry_trigger_to_isr and entry_direct_isr it can be
+ * compared with them; zli_entry_while_locked below answers the
+ * different question of what happens inside a critical section.
+ */
+ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_trigger_to_isr, NUM_ITERATIONS, NULL, NULL)
+{
+	alt_entry_measure("zli_entry_trigger_to_isr");
+}
+
 ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, NULL)
 {
 	unsigned int key;
@@ -536,3 +559,57 @@ ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, 
 	}
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_ZLI */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_END_TO_END
+static void e2e_handler(void)
+{
+	k_sem_give(&wake_sem);
+}
+
+static void e2e_waiter_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_sem_take(&wake_sem, K_FOREVER);
+	ztest_benchmark_end();
+	k_sem_give(&sync_sem);
+}
+
+/*
+ * The whole path an application actually waits on: from raising the
+ * interrupt to the high priority thread it wakes being on the CPU.
+ *
+ * The other scenarios measure the pieces of this span, but the pieces
+ * cannot simply be added: entry latency and the rescheduling exit are
+ * measured in separate runs and neither includes the ISR body or the
+ * handoff between them. This is the figure to quote for how quickly an
+ * application can respond to an event.
+ */
+static void e2e_setup(void)
+{
+	int priority = k_thread_priority_get(k_current_get());
+
+	bench_trigger_set_handler(e2e_handler);
+
+	k_thread_create(&waiter_thread, waiter_stack, K_THREAD_STACK_SIZEOF(waiter_stack),
+			e2e_waiter_entry, NULL, NULL, NULL, priority - 1, 0, K_NO_WAIT);
+}
+
+static void e2e_teardown(void)
+{
+	(void)k_thread_join(&waiter_thread, K_FOREVER);
+	bench_trigger_set_handler(NULL);
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, irq_to_thread, NUM_ITERATIONS, e2e_setup, e2e_teardown)
+{
+	bench_load_pollute();
+
+	ztest_benchmark_start();
+	bench_trigger();
+
+	k_sem_take(&sync_sem, K_FOREVER);
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_END_TO_END */

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -141,6 +141,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, entry_trigger_to_isr, NUM_ITERATIONS, entry_se
 		       entry_teardown)
 {
 	fired = false;
+	bench_load_churn();
 	bench_load_pollute();
 
 	ztest_benchmark_start();
@@ -187,6 +188,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, exit_resume_interrupted, NUM_ITERATIONS, exit_
 		       exit_teardown)
 {
 	fired = false;
+	bench_load_churn();
 	bench_load_pollute();
 
 	bench_trigger();
@@ -239,6 +241,7 @@ static void resched_teardown(void)
 ZTEST_BENCHMARK_MANUAL(interrupt, exit_reschedule, NUM_ITERATIONS, resched_setup,
 		       resched_teardown)
 {
+	bench_load_churn();
 	bench_load_pollute();
 
 	bench_trigger();
@@ -271,6 +274,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, locked_unlock_to_isr, NUM_ITERATIONS, locked_s
 	unsigned int key;
 
 	fired = false;
+	bench_load_churn();
 
 	key = irq_lock();
 
@@ -281,7 +285,10 @@ ZTEST_BENCHMARK_MANUAL(interrupt, locked_unlock_to_isr, NUM_ITERATIONS, locked_s
 	 * Pollute from inside the critical section, so that the
 	 * interrupt is unmasked with the caches in the state a critical
 	 * section doing real work would leave them in. This lengthens
-	 * the hold time beyond the configured value.
+	 * the hold time beyond the configured value. Only the cache load
+	 * runs here: the kernel and scheduler churn make kernel calls,
+	 * which is not valid with interrupts locked, so they ran before
+	 * the lock was taken.
 	 */
 	bench_load_pollute();
 
@@ -337,6 +344,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, throughput_round_trip, NUM_ITERATIONS, through
 {
 	isr_count = 0U;
 	done = false;
+	bench_load_churn();
 	bench_load_pollute();
 
 	bench_trigger();
@@ -370,6 +378,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, dynamic_connect, NUM_ITERATIONS, dynamic_setup
 {
 	unsigned int line = bench_trigger_irq_line();
 
+	bench_load_churn();
 	bench_load_pollute();
 
 	ztest_benchmark_start();
@@ -518,6 +527,7 @@ static bool alt_wait(void)
 static void alt_entry_measure(const char *name)
 {
 	alt_fired = false;
+	bench_load_churn();
 	bench_load_pollute();
 
 	ztest_benchmark_start();
@@ -569,6 +579,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, 
 	bool served;
 
 	alt_fired = false;
+	bench_load_churn();
 	bench_load_pollute();
 
 	key = irq_lock();
@@ -632,6 +643,7 @@ static void e2e_teardown(void)
 
 ZTEST_BENCHMARK_MANUAL(interrupt, irq_to_thread, NUM_ITERATIONS, e2e_setup, e2e_teardown)
 {
+	bench_load_churn();
 	bench_load_pollute();
 
 	ztest_benchmark_start();
@@ -686,6 +698,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, nested_preempt, NUM_ITERATIONS, nested_setup,
 		       nested_teardown)
 {
 	nested_done = false;
+	bench_load_churn();
 	bench_load_pollute();
 
 	bench_trigger();

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -25,6 +25,24 @@
 
 #define NUM_ITERATIONS CONFIG_INT_BENCH_NUM_ITERATIONS
 
+#if defined(CONFIG_INT_BENCH_SCENARIO_DIRECT) || defined(CONFIG_INT_BENCH_SCENARIO_ZLI)
+static volatile bool alt_fired;
+
+/*
+ * Dispatched straight from the vector table: no software ISR table
+ * lookup and none of the common entry code that wraps a regular ISR.
+ * Returning zero tells the architecture layer that no reschedule is
+ * needed, which keeps the exit path out of the measurement.
+ */
+ISR_DIRECT_DECLARE(bench_alt_isr)
+{
+	ztest_benchmark_end();
+	alt_fired = true;
+
+	return 0;
+}
+#endif
+
 static void suite_setup(void)
 {
 #ifdef CONFIG_INT_BENCH_TRIGGER_SW_IRQ
@@ -39,6 +57,20 @@ static void suite_setup(void)
 #endif
 
 	(void)bench_trigger_init();
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_DIRECT
+	IRQ_DIRECT_CONNECT(BENCH_IRQ_LINE_ALT, CONFIG_INT_BENCH_IRQ_PRIO, bench_alt_isr, 0);
+	irq_enable(BENCH_IRQ_LINE_ALT);
+#endif
+#ifdef CONFIG_INT_BENCH_SCENARIO_ZLI
+	/*
+	 * Zero-latency interrupts have to be registered with
+	 * IRQ_DIRECT_CONNECT(), and at a priority within the levels
+	 * reserved for them.
+	 */
+	IRQ_DIRECT_CONNECT(BENCH_IRQ_LINE_ALT, 0, bench_alt_isr, IRQ_ZERO_LATENCY);
+	irq_enable(BENCH_IRQ_LINE_ALT);
+#endif
 
 	printk("Background load: %s\n", bench_load_description());
 	bench_load_start();
@@ -428,3 +460,79 @@ ZTEST_BENCHMARK_MANUAL(interrupt, periodic_isr_interval, NUM_ITERATIONS, mask_se
 	}
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_MASKING */
+
+#if defined(CONFIG_INT_BENCH_SCENARIO_DIRECT) || defined(CONFIG_INT_BENCH_SCENARIO_ZLI)
+/*
+ * Bound on the spin waiting for the second line's ISR. A direct or
+ * zero-latency interrupt that never arrives would otherwise hang the
+ * run, and in the zero-latency case the wait happens with interrupts
+ * locked, so nothing else could break the deadlock.
+ */
+#define ALT_SPIN_LIMIT 10000000U
+
+static bool alt_wait(void)
+{
+	for (uint32_t spin = 0U; spin < ALT_SPIN_LIMIT; spin++) {
+		if (alt_fired) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_DIRECT
+/*
+ * Entry latency of a directly connected ISR. Identical to
+ * entry_trigger_to_isr apart from the line it uses, so the difference
+ * between the two is the cost of the software ISR table dispatch and
+ * the common entry code that a regular ISR goes through.
+ */
+ZTEST_BENCHMARK_MANUAL(interrupt, entry_direct_isr, NUM_ITERATIONS, NULL, NULL)
+{
+	alt_fired = false;
+	bench_load_pollute();
+
+	ztest_benchmark_start();
+	bench_trigger_alt();
+
+	if (!alt_wait()) {
+		printk("entry_direct_isr: direct ISR did not run, skipping\n");
+		return;
+	}
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_DIRECT */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_ZLI
+/*
+ * Entry latency of a zero-latency interrupt raised while interrupts
+ * are locked. A zero-latency interrupt runs above the priority the
+ * kernel masks with, so unlike the interrupt in locked_unlock_to_isr
+ * it is served inside the critical section rather than after it. The
+ * two scenarios together show what a critical section costs an
+ * interrupt, and what escaping it buys.
+ */
+ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, NULL)
+{
+	unsigned int key;
+	bool served;
+
+	alt_fired = false;
+	bench_load_pollute();
+
+	key = irq_lock();
+
+	ztest_benchmark_start();
+	bench_trigger_alt();
+
+	served = alt_wait();
+
+	irq_unlock(key);
+
+	if (!served) {
+		printk("zli_entry_while_locked: not served while locked, skipping\n");
+		return;
+	}
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_ZLI */

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -319,3 +319,112 @@ ZTEST_BENCHMARK_MANUAL(interrupt, dynamic_connect, NUM_ITERATIONS, dynamic_setup
 	ztest_benchmark_end();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_DYNAMIC */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_MASKING
+/*
+ * How long the system keeps interrupts masked is a property of the
+ * kernel and its drivers rather than something the benchmark can
+ * trigger, and Zephyr does not instrument irq_lock() windows, so
+ * measure it by its effect: arm a one-shot timer for one tick, keep
+ * the kernel busy taking spinlocks until it fires, and measure from
+ * arming it to the first instruction of its ISR.
+ *
+ * The span is one nominal tick plus whatever delay the ISR suffered,
+ * so the distribution reads directly: the median is the undelayed
+ * period, and everything above it is delay that masking inflicted.
+ * Reporting the interval rather than a delay computed against an
+ * assumed period avoids having to know the counter frequency, which
+ * timing_freq_get() does not report correctly on every platform.
+ *
+ * The number is the worst delay a periodic real-time event was
+ * actually made to suffer, not the longest irq_lock() in the tree: a
+ * window that does not overlap a tick boundary is never seen, and the
+ * delay also contains time spent in interrupts served first.
+ * CONFIG_INT_BENCH_MASK_INJECT_US masks for a known time so the
+ * measurement can be checked on a new platform.
+ */
+static K_SEM_DEFINE(mask_sem, 0, 1);
+static K_MUTEX_DEFINE(mask_mutex);
+
+static volatile uint32_t mask_seq;
+
+/*
+ * The span is the interval between two expiries, so the first one opens
+ * it and the second closes it. Both hooks are safe here: they only take
+ * a timestamp, and the framework turns the span into a sample once the
+ * body has returned to thread context.
+ */
+static void mask_timer_handler(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+
+	if (mask_seq == 0U) {
+		ztest_benchmark_start();
+	} else if (mask_seq == 1U) {
+		ztest_benchmark_end();
+	}
+
+	mask_seq++;
+}
+
+static K_TIMER_DEFINE(mask_timer, mask_timer_handler, NULL);
+
+/* Kernel primitives that take spinlocks, and so mask interrupts */
+static void mask_kernel_work(void)
+{
+	k_sem_give(&mask_sem);
+	(void)k_sem_take(&mask_sem, K_NO_WAIT);
+	(void)k_mutex_lock(&mask_mutex, K_NO_WAIT);
+	(void)k_mutex_unlock(&mask_mutex);
+	(void)k_uptime_get();
+}
+
+static void mask_setup(void)
+{
+	mask_seq = 0U;
+	k_timer_start(&mask_timer, K_TICKS(1), K_TICKS(1));
+}
+
+static void mask_teardown(void)
+{
+	k_timer_stop(&mask_timer);
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, periodic_isr_interval, NUM_ITERATIONS, mask_setup,
+		       mask_teardown)
+{
+	int64_t deadline;
+
+	/*
+	 * Two expiries, so the span runs between consecutive periods of
+	 * a running periodic timer rather than from an arbitrary arming
+	 * point to the next tick boundary, which would carry up to a
+	 * whole tick of phase noise. Each sample therefore costs two
+	 * ticks, which is why this scenario needs the tick rate the load
+	 * overlay configures rather than the much slower one the base
+	 * configuration runs at.
+	 *
+	 * Give up rather than spin forever where the timer does not
+	 * deliver at the tick rate at all, which under emulation can
+	 * otherwise cost minutes of wall clock. Recording no sample
+	 * leaves the benchmark inconclusive, which is the honest
+	 * outcome.
+	 */
+	deadline = k_uptime_get() + 100;
+
+	while (mask_seq < 2U) {
+		if (k_uptime_get() > deadline) {
+			return;
+		}
+
+		mask_kernel_work();
+
+		if (CONFIG_INT_BENCH_MASK_INJECT_US > 0) {
+			unsigned int key = irq_lock();
+
+			k_busy_wait(CONFIG_INT_BENCH_MASK_INJECT_US);
+			irq_unlock(key);
+		}
+	}
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_MASKING */

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -768,6 +768,8 @@ ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, 
 #endif /* CONFIG_INT_BENCH_SCENARIO_ZLI */
 
 #ifdef CONFIG_INT_BENCH_SCENARIO_END_TO_END
+static volatile bool e2e_done;
+
 static void e2e_handler(void)
 {
 	k_sem_give(&wake_sem);
@@ -781,7 +783,7 @@ static void e2e_waiter_entry(void *p1, void *p2, void *p3)
 
 	k_sem_take(&wake_sem, K_FOREVER);
 	BENCH_SPAN_END();
-	k_sem_give(&sync_sem);
+	e2e_done = true;
 }
 
 /*
@@ -815,10 +817,19 @@ ZTEST_BENCHMARK_MANUAL(interrupt, irq_to_thread, NUM_ITERATIONS, e2e_setup, e2e_
 	bench_load_churn();
 	bench_load_pollute();
 
+	/*
+	 * Spin rather than block: blocking would race the interrupt,
+	 * which can arrive while this thread is still entering
+	 * k_sem_take(), charging the woken thread for a block that is
+	 * immediately unwound. The waiter runs at a higher priority, so
+	 * it preempts this loop as soon as the ISR wakes it.
+	 */
+	e2e_done = false;
 	BENCH_SPAN_START();
 	bench_trigger();
 
-	k_sem_take(&sync_sem, K_FOREVER);
+	while (!e2e_done) {
+	}
 
 	bench_trace();
 }

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -25,8 +25,14 @@
 
 #define NUM_ITERATIONS CONFIG_INT_BENCH_NUM_ITERATIONS
 
-#if defined(CONFIG_INT_BENCH_SCENARIO_DIRECT) || defined(CONFIG_INT_BENCH_SCENARIO_ZLI)
+#if defined(CONFIG_INT_BENCH_SCENARIO_DIRECT) || defined(CONFIG_INT_BENCH_SCENARIO_ZLI) || \
+	defined(CONFIG_INT_BENCH_SCENARIO_NESTED)
+#define BENCH_ALT_LINE_USED 1
 static volatile bool alt_fired;
+#endif
+
+#if defined(CONFIG_INT_BENCH_SCENARIO_DIRECT) || defined(CONFIG_INT_BENCH_SCENARIO_ZLI)
+#define BENCH_ALT_LINE_DIRECT 1
 
 /*
  * Dispatched straight from the vector table: no software ISR table
@@ -40,6 +46,14 @@ ISR_DIRECT_DECLARE(bench_alt_isr)
 	alt_fired = true;
 
 	return 0;
+}
+#elif defined(BENCH_ALT_LINE_USED)
+static void bench_alt_regular_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	ztest_benchmark_end();
+	alt_fired = true;
 }
 #endif
 
@@ -59,7 +73,17 @@ static void suite_setup(void)
 	(void)bench_trigger_init();
 
 #ifdef CONFIG_INT_BENCH_SCENARIO_DIRECT
-	IRQ_DIRECT_CONNECT(BENCH_IRQ_LINE_ALT, CONFIG_INT_BENCH_IRQ_PRIO, bench_alt_isr, 0);
+	IRQ_DIRECT_CONNECT(BENCH_IRQ_LINE_ALT, CONFIG_INT_BENCH_IRQ_PRIO_ALT, bench_alt_isr, 0);
+	irq_enable(BENCH_IRQ_LINE_ALT);
+#endif
+#if defined(BENCH_ALT_LINE_USED) && !defined(BENCH_ALT_LINE_DIRECT)
+	/*
+	 * Nothing claimed the line as a direct or zero-latency
+	 * interrupt, so connect it the ordinary way. This is the only
+	 * option on platforms without direct interrupts.
+	 */
+	IRQ_CONNECT(BENCH_IRQ_LINE_ALT, CONFIG_INT_BENCH_IRQ_PRIO_ALT, bench_alt_regular_isr,
+		    NULL, 0);
 	irq_enable(BENCH_IRQ_LINE_ALT);
 #endif
 #ifdef CONFIG_INT_BENCH_SCENARIO_ZLI
@@ -463,12 +487,13 @@ ZTEST_BENCHMARK_MANUAL(interrupt, periodic_isr_interval, NUM_ITERATIONS, mask_se
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_MASKING */
 
-#if defined(CONFIG_INT_BENCH_SCENARIO_DIRECT) || defined(CONFIG_INT_BENCH_SCENARIO_ZLI)
+#ifdef BENCH_ALT_LINE_USED
 /*
- * Bound on the spin waiting for the second line's ISR. A direct or
- * zero-latency interrupt that never arrives would otherwise hang the
- * run, and in the zero-latency case the wait happens with interrupts
- * locked, so nothing else could break the deadlock.
+ * Bound on the spin waiting for the second line's ISR. An interrupt
+ * that never arrives would otherwise hang the run, and in the
+ * zero-latency and nested cases the wait happens with the first
+ * interrupt masked or in service, so nothing else could break the
+ * deadlock.
  */
 #define ALT_SPIN_LIMIT 10000000U
 
@@ -484,6 +509,7 @@ static bool alt_wait(void)
 }
 #endif
 
+#ifdef BENCH_ALT_LINE_DIRECT
 /*
  * Entry latency of the second line, measured exactly as
  * entry_trigger_to_isr measures the first. What differs is only how
@@ -502,6 +528,7 @@ static void alt_entry_measure(const char *name)
 		return;
 	}
 }
+#endif /* BENCH_ALT_LINE_DIRECT */
 
 #ifdef CONFIG_INT_BENCH_SCENARIO_DIRECT
 /*
@@ -613,3 +640,64 @@ ZTEST_BENCHMARK_MANUAL(interrupt, irq_to_thread, NUM_ITERATIONS, e2e_setup, e2e_
 	k_sem_take(&sync_sem, K_FOREVER);
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_END_TO_END */
+
+#ifdef CONFIG_INT_BENCH_SCENARIO_NESTED
+static volatile bool nested_done;
+static volatile bool nested_preempted;
+
+/*
+ * Runs at the lower priority. Raises the higher priority interrupt and
+ * waits for it to preempt this ISR, which is what nesting means: the
+ * second interrupt is served while the first is still in progress.
+ *
+ * Both ends of the span are marked from interrupt context, this handler
+ * opening it and the preempting one closing it. The framework turns the
+ * pair into a sample once the body has returned to thread context.
+ */
+static void nested_low_handler(void)
+{
+	alt_fired = false;
+
+	ztest_benchmark_start();
+	bench_trigger_alt();
+
+	nested_preempted = alt_wait();
+
+	nested_done = true;
+}
+
+/*
+ * Latency of a high priority interrupt raised while a lower priority
+ * ISR is running. An interrupt-heavy application rarely has the CPU
+ * idle when an event arrives, so this is often a better description of
+ * what a high priority handler will see than the plain entry latency.
+ */
+static void nested_setup(void)
+{
+	bench_trigger_set_handler(nested_low_handler);
+}
+
+static void nested_teardown(void)
+{
+	bench_trigger_set_handler(NULL);
+}
+
+ZTEST_BENCHMARK_MANUAL(interrupt, nested_preempt, NUM_ITERATIONS, nested_setup,
+		       nested_teardown)
+{
+	nested_done = false;
+	bench_load_pollute();
+
+	bench_trigger();
+
+	while (!nested_done) {
+	}
+
+	if (!nested_preempted) {
+		printk("nested_preempt: the higher priority interrupt did not "
+		       "preempt the lower one, skipping\n");
+		return;
+	}
+
+}
+#endif /* CONFIG_INT_BENCH_SCENARIO_NESTED */

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -25,6 +25,159 @@
 
 #define NUM_ITERATIONS CONFIG_INT_BENCH_NUM_ITERATIONS
 
+#ifdef CONFIG_INT_BENCH_OUTLIER_TRACE
+/*
+ * Cortex-M counts the cycles it spends entering and leaving exceptions
+ * in DWT_EXCCNT, which is the one witness that distinguishes an
+ * interrupt from a stall in the memory system. It is only eight bits
+ * wide, but exception overhead is a few cycles at a time, so it does
+ * not wrap between consecutive samples.
+ */
+#if defined(CONFIG_CPU_CORTEX_M) && defined(CONFIG_CORTEX_M_DWT)
+#include <cmsis_core.h>
+#define OUTLIER_HAS_EXC_COUNT 1
+
+static inline void outlier_exc_init(void)
+{
+	DWT->CTRL |= DWT_CTRL_EXCEVTENA_Msk;
+	DWT->EXCCNT = 0;
+}
+
+static inline uint32_t outlier_exc_count(void)
+{
+	return DWT->EXCCNT & 0xFFU;
+}
+#else
+static inline void outlier_exc_init(void)
+{
+}
+
+static inline uint32_t outlier_exc_count(void)
+{
+	return 0;
+}
+#endif
+
+/*
+ * Report what else the system was doing when a sample came out far
+ * above the smallest one seen.
+ *
+ * The witnesses are sampled once per iteration rather than around the
+ * measured span itself, so what they cover is the interval between
+ * consecutive samples. That is enough to tell an outlier caused by a
+ * clock tick or by the load timer from one caused by something the
+ * benchmark cannot observe, which is the distinction worth having.
+ */
+static uint32_t outlier_min;
+static uint32_t outlier_reported;
+static uint32_t outlier_seen;
+static uint32_t outlier_prev_ticks;
+static uint32_t outlier_prev_timer;
+static uint32_t outlier_prev_exc;
+static timing_t outlier_prev_time;
+static uint32_t outlier_iteration;
+
+static void outlier_check(uint64_t cycles)
+{
+	uint32_t ticks = (uint32_t)sys_clock_tick_get_32();
+	uint32_t timer = bench_load_timer_runs();
+	uint32_t exc = outlier_exc_count();
+	uint32_t iteration = outlier_iteration++;
+
+	/*
+	 * The framework does not tell a scenario when it is starting, so
+	 * count the samples and wrap. A scenario that skips a sample
+	 * makes the wrap late, which only shifts the iteration numbers
+	 * in the trace.
+	 */
+	if (outlier_iteration >= NUM_ITERATIONS) {
+		outlier_iteration = 0U;
+	}
+
+	if (iteration == 0U) {
+		/*
+		 * A new benchmark is starting: close off the previous
+		 * one, since there is no hook for its end here.
+		 */
+		if (outlier_seen > outlier_reported) {
+			printk("\tprevious benchmark: %u outliers in total, %u reported\n",
+			       outlier_seen, outlier_reported);
+		}
+
+		outlier_min = UINT32_MAX;
+		outlier_reported = 0U;
+		outlier_seen = 0U;
+		outlier_exc_init();
+	} else if ((outlier_min != UINT32_MAX) &&
+		   (cycles > (uint64_t)outlier_min * CONFIG_INT_BENCH_OUTLIER_FACTOR)) {
+		outlier_seen++;
+
+		if (outlier_reported < CONFIG_INT_BENCH_OUTLIER_LIMIT) {
+			timing_t now = timing_counter_get();
+			timing_t prev = outlier_prev_time;
+			uint64_t since = (outlier_prev_time == 0) ? 0 :
+					 timing_cycles_get(&prev, &now);
+
+			outlier_prev_time = now;
+			outlier_reported++;
+			printk("\toutlier: iteration %u, %llu cycles against a minimum of %u, "
+			       "ticks +%u, load timer +%u, exception cycles +%u\n",
+			       iteration, cycles, outlier_min, ticks - outlier_prev_ticks,
+			       timer - outlier_prev_timer,
+			       (exc - outlier_prev_exc) & 0xFFU);
+			printk("\t          %llu cycles since the previous one\n", since);
+		}
+	}
+
+	if (cycles < outlier_min) {
+		outlier_min = (uint32_t)cycles;
+	}
+
+	outlier_prev_ticks = ticks;
+	outlier_prev_timer = timer;
+	outlier_prev_exc = exc;
+}
+#endif /* CONFIG_INT_BENCH_OUTLIER_TRACE */
+
+/*
+ * The trace needs the size of the sample, which the framework does not
+ * hand back. Take its own timestamps immediately outside the span, so
+ * that what it measures is the sample plus one counter read and the
+ * measurement itself pays nothing for being traced.
+ */
+#ifdef CONFIG_INT_BENCH_OUTLIER_TRACE
+static volatile timing_t trace_start;
+static volatile timing_t trace_end;
+
+#define BENCH_SPAN_START()						\
+	do {								\
+		trace_start = timing_counter_get();			\
+		ztest_benchmark_start();				\
+	} while (0)
+
+#define BENCH_SPAN_END()						\
+	do {								\
+		ztest_benchmark_end();					\
+		trace_end = timing_counter_get();			\
+	} while (0)
+
+static inline void bench_trace(void)
+{
+	timing_t s = trace_start;
+	timing_t e = trace_end;
+
+	outlier_check(timing_cycles_get(&s, &e));
+}
+#else
+#define BENCH_SPAN_START() ztest_benchmark_start()
+#define BENCH_SPAN_END()   ztest_benchmark_end()
+
+static inline void bench_trace(void)
+{
+}
+#endif /* CONFIG_INT_BENCH_OUTLIER_TRACE */
+
+
 #if defined(CONFIG_INT_BENCH_SCENARIO_DIRECT) || defined(CONFIG_INT_BENCH_SCENARIO_ZLI) || \
 	defined(CONFIG_INT_BENCH_SCENARIO_NESTED)
 #define BENCH_ALT_LINE_USED 1
@@ -42,7 +195,7 @@ static volatile bool alt_fired;
  */
 ISR_DIRECT_DECLARE(bench_alt_isr)
 {
-	ztest_benchmark_end();
+	BENCH_SPAN_END();
 	alt_fired = true;
 
 	return 0;
@@ -52,7 +205,7 @@ static void bench_alt_regular_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	ztest_benchmark_end();
+	BENCH_SPAN_END();
 	alt_fired = true;
 }
 #endif
@@ -116,7 +269,7 @@ static volatile bool fired;
 /* Timestamp as early as possible in the ISR: measures the entry path */
 static BENCH_ISR_FUNC void entry_handler(void)
 {
-	ztest_benchmark_end();
+	BENCH_SPAN_END();
 	fired = true;
 }
 #endif
@@ -144,11 +297,13 @@ ZTEST_BENCHMARK_MANUAL(interrupt, entry_trigger_to_isr, NUM_ITERATIONS, entry_se
 	bench_load_churn();
 	bench_load_pollute();
 
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 	bench_trigger();
 
 	while (!fired) {
 	}
+
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_ENTRY */
 
@@ -166,7 +321,7 @@ static struct k_thread waiter_thread;
 static BENCH_ISR_FUNC void exit_handler(void)
 {
 	fired = true;
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 }
 
 /*
@@ -196,13 +351,15 @@ ZTEST_BENCHMARK_MANUAL(interrupt, exit_resume_interrupted, NUM_ITERATIONS, exit_
 	while (!fired) {
 	}
 
-	ztest_benchmark_end();
+	BENCH_SPAN_END();
+
+	bench_trace();
 }
 
 static void resched_handler(void)
 {
 	k_sem_give(&wake_sem);
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 }
 
 
@@ -213,7 +370,7 @@ static void waiter_entry(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p3);
 
 	k_sem_take(&wake_sem, K_FOREVER);
-	ztest_benchmark_end();
+	BENCH_SPAN_END();
 	k_sem_give(&sync_sem);
 }
 
@@ -247,7 +404,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, exit_reschedule, NUM_ITERATIONS, resched_setup
 	bench_trigger();
 	k_sem_take(&sync_sem, K_FOREVER);
 
-
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_EXIT */
 
@@ -292,11 +449,13 @@ ZTEST_BENCHMARK_MANUAL(interrupt, locked_unlock_to_isr, NUM_ITERATIONS, locked_s
 	 */
 	bench_load_pollute();
 
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 	irq_unlock(key);
 
 	while (!fired) {
 	}
+
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_LOCKED */
 
@@ -312,11 +471,11 @@ static volatile uint32_t isr_count;
 static void throughput_handler(void)
 {
 	if (isr_count == 0U) {
-		ztest_benchmark_start();
+		BENCH_SPAN_START();
 		isr_count = 1U;
 		bench_trigger();
 	} else {
-		ztest_benchmark_end();
+		BENCH_SPAN_END();
 		done = true;
 	}
 }
@@ -352,7 +511,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, throughput_round_trip, NUM_ITERATIONS, through
 	while (!done) {
 	}
 
-
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_THROUGHPUT */
 
@@ -381,9 +540,11 @@ ZTEST_BENCHMARK_MANUAL(interrupt, dynamic_connect, NUM_ITERATIONS, dynamic_setup
 	bench_load_churn();
 	bench_load_pollute();
 
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 	(void)irq_connect_dynamic(line, CONFIG_INT_BENCH_IRQ_PRIO, bench_trigger_isr, NULL, 0);
-	ztest_benchmark_end();
+	BENCH_SPAN_END();
+
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_DYNAMIC */
 
@@ -426,9 +587,9 @@ static void mask_timer_handler(struct k_timer *timer)
 	ARG_UNUSED(timer);
 
 	if (mask_seq == 0U) {
-		ztest_benchmark_start();
+		BENCH_SPAN_START();
 	} else if (mask_seq == 1U) {
-		ztest_benchmark_end();
+		BENCH_SPAN_END();
 	}
 
 	mask_seq++;
@@ -493,6 +654,8 @@ ZTEST_BENCHMARK_MANUAL(interrupt, periodic_isr_interval, NUM_ITERATIONS, mask_se
 			irq_unlock(key);
 		}
 	}
+
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_MASKING */
 
@@ -530,7 +693,7 @@ static void alt_entry_measure(const char *name)
 	bench_load_churn();
 	bench_load_pollute();
 
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 	bench_trigger_alt();
 
 	if (!alt_wait()) {
@@ -549,6 +712,8 @@ static void alt_entry_measure(const char *name)
 ZTEST_BENCHMARK_MANUAL(interrupt, entry_direct_isr, NUM_ITERATIONS, NULL, NULL)
 {
 	alt_entry_measure("entry_direct_isr");
+
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_DIRECT */
 
@@ -571,6 +736,8 @@ ZTEST_BENCHMARK_MANUAL(interrupt, entry_direct_isr, NUM_ITERATIONS, NULL, NULL)
 ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_trigger_to_isr, NUM_ITERATIONS, NULL, NULL)
 {
 	alt_entry_measure("zli_entry_trigger_to_isr");
+
+	bench_trace();
 }
 
 ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, NULL)
@@ -584,7 +751,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, 
 
 	key = irq_lock();
 
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 	bench_trigger_alt();
 
 	served = alt_wait();
@@ -595,6 +762,8 @@ ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, 
 		printk("zli_entry_while_locked: not served while locked, skipping\n");
 		return;
 	}
+
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_ZLI */
 
@@ -611,7 +780,7 @@ static void e2e_waiter_entry(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p3);
 
 	k_sem_take(&wake_sem, K_FOREVER);
-	ztest_benchmark_end();
+	BENCH_SPAN_END();
 	k_sem_give(&sync_sem);
 }
 
@@ -646,10 +815,12 @@ ZTEST_BENCHMARK_MANUAL(interrupt, irq_to_thread, NUM_ITERATIONS, e2e_setup, e2e_
 	bench_load_churn();
 	bench_load_pollute();
 
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 	bench_trigger();
 
 	k_sem_take(&sync_sem, K_FOREVER);
+
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_END_TO_END */
 
@@ -670,7 +841,7 @@ static void nested_low_handler(void)
 {
 	alt_fired = false;
 
-	ztest_benchmark_start();
+	BENCH_SPAN_START();
 	bench_trigger_alt();
 
 	nested_preempted = alt_wait();
@@ -712,5 +883,6 @@ ZTEST_BENCHMARK_MANUAL(interrupt, nested_preempt, NUM_ITERATIONS, nested_setup,
 		return;
 	}
 
+	bench_trace();
 }
 #endif /* CONFIG_INT_BENCH_SCENARIO_NESTED */

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -20,6 +20,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/timing/timing.h>
 
+#include "load.h"
 #include "trigger.h"
 
 #define NUM_ITERATIONS CONFIG_INT_BENCH_NUM_ITERATIONS
@@ -38,9 +39,17 @@ static void suite_setup(void)
 #endif
 
 	(void)bench_trigger_init();
+
+	printk("Background load: %s\n", bench_load_description());
+	bench_load_start();
 }
 
-ZTEST_BENCHMARK_SUITE(interrupt, suite_setup, NULL);
+static void suite_teardown(void)
+{
+	bench_load_stop();
+}
+
+ZTEST_BENCHMARK_SUITE(interrupt, suite_setup, suite_teardown);
 
 #if defined(CONFIG_INT_BENCH_SCENARIO_ENTRY) || defined(CONFIG_INT_BENCH_SCENARIO_EXIT) || \
 	defined(CONFIG_INT_BENCH_SCENARIO_LOCKED)
@@ -76,6 +85,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, entry_trigger_to_isr, NUM_ITERATIONS, entry_se
 		       entry_teardown)
 {
 	fired = false;
+	bench_load_pollute();
 
 	ztest_benchmark_start();
 	bench_trigger();
@@ -112,6 +122,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, exit_resume_interrupted, NUM_ITERATIONS, exit_
 		       exit_teardown)
 {
 	fired = false;
+	bench_load_pollute();
 
 	bench_trigger();
 
@@ -170,6 +181,8 @@ static void resched_teardown(void)
 ZTEST_BENCHMARK_MANUAL(interrupt, exit_reschedule, NUM_ITERATIONS, resched_setup,
 		       resched_teardown)
 {
+	bench_load_pollute();
+
 	bench_trigger();
 	k_sem_take(&sync_sem, K_FOREVER);
 
@@ -205,6 +218,14 @@ ZTEST_BENCHMARK_MANUAL(interrupt, locked_unlock_to_isr, NUM_ITERATIONS, locked_s
 
 	bench_trigger();
 	k_busy_wait(CONFIG_INT_BENCH_LOCK_HOLD_US);
+
+	/*
+	 * Pollute from inside the critical section, so that the
+	 * interrupt is unmasked with the caches in the state a critical
+	 * section doing real work would leave them in. This lengthens
+	 * the hold time beyond the configured value.
+	 */
+	bench_load_pollute();
 
 	ztest_benchmark_start();
 	irq_unlock(key);
@@ -258,6 +279,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, throughput_round_trip, NUM_ITERATIONS, through
 {
 	isr_count = 0U;
 	done = false;
+	bench_load_pollute();
 
 	bench_trigger();
 
@@ -289,6 +311,8 @@ ZTEST_BENCHMARK_MANUAL(interrupt, dynamic_connect, NUM_ITERATIONS, dynamic_setup
 		       dynamic_teardown)
 {
 	unsigned int line = bench_trigger_irq_line();
+
+	bench_load_pollute();
 
 	ztest_benchmark_start();
 	(void)irq_connect_dynamic(line, CONFIG_INT_BENCH_IRQ_PRIO, bench_trigger_isr, NULL, 0);

--- a/tests/benchmarks/interrupt_latency/src/load.c
+++ b/tests/benchmarks/interrupt_latency/src/load.c
@@ -44,9 +44,13 @@ static K_SEM_DEFINE(kernel_load_sem, 0, 1);
 #endif
 
 #ifdef CONFIG_INT_BENCH_LOAD_TIMER
+static volatile uint32_t load_timer_runs;
+
 static void load_timer_handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
+
+	load_timer_runs++;
 
 	/*
 	 * Runs in the system clock ISR. Kept short on purpose: the
@@ -190,6 +194,15 @@ void bench_load_pollute(void)
 	for (size_t i = 0U; i < WORKING_SET_SIZE; i += WORKING_SET_STRIDE) {
 		working_set[i]++;
 	}
+#endif
+}
+
+uint32_t bench_load_timer_runs(void)
+{
+#ifdef CONFIG_INT_BENCH_LOAD_TIMER
+	return load_timer_runs;
+#else
+	return 0;
 #endif
 }
 

--- a/tests/benchmarks/interrupt_latency/src/load.c
+++ b/tests/benchmarks/interrupt_latency/src/load.c
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Background system load sources, see load.h.
+ *
+ * Which source perturbs which measurement depends on the context the
+ * load runs in:
+ *
+ * - The cache load runs in the benchmark thread itself, between
+ *   samples, and affects every scenario on every platform.
+ * - The timer load runs in the system clock ISR, so it competes with
+ *   the benchmark interrupt for the interrupt controller and for
+ *   interrupt-disabled windows in the kernel. It affects every
+ *   platform.
+ * - The thread load runs in threads of lower priority than the
+ *   benchmark. On SMP those threads execute on the other CPUs and
+ *   contend for the memory system throughout. On a uniprocessor they
+ *   only run while the benchmark blocks, which happens in the
+ *   rescheduling scenario, so their effect there is limited.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+#include "load.h"
+
+#ifdef CONFIG_INT_BENCH_LOAD_CACHE
+#define WORKING_SET_SIZE (CONFIG_INT_BENCH_LOAD_CACHE_KB * 1024)
+
+/*
+ * Stride of one cache line on the widest line size in common use, so
+ * that every line of the working set is touched exactly once.
+ */
+#define WORKING_SET_STRIDE 64
+
+static volatile uint8_t working_set[WORKING_SET_SIZE];
+#endif /* CONFIG_INT_BENCH_LOAD_CACHE */
+
+#ifdef CONFIG_INT_BENCH_LOAD_TIMER
+static void load_timer_handler(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+
+	/*
+	 * Runs in the system clock ISR. Kept short on purpose: the
+	 * point is to compete for interrupt service, not to monopolise
+	 * the CPU.
+	 */
+}
+
+static K_TIMER_DEFINE(load_timer, load_timer_handler, NULL);
+#endif /* CONFIG_INT_BENCH_LOAD_TIMER */
+
+#ifdef CONFIG_INT_BENCH_LOAD_THREADS
+#define LOAD_STACK_SIZE  (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define LOAD_BUFFER_SIZE 256
+
+static K_THREAD_STACK_ARRAY_DEFINE(load_stacks, CONFIG_INT_BENCH_LOAD_NUM_THREADS,
+				   LOAD_STACK_SIZE);
+static struct k_thread load_threads[CONFIG_INT_BENCH_LOAD_NUM_THREADS];
+static volatile uint32_t load_buffers[CONFIG_INT_BENCH_LOAD_NUM_THREADS][LOAD_BUFFER_SIZE];
+static volatile bool load_running;
+
+static void load_thread_entry(void *p1, void *p2, void *p3)
+{
+	volatile uint32_t *buffer = p1;
+	uint32_t value = 0U;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (load_running) {
+		for (uint32_t i = 0U; i < LOAD_BUFFER_SIZE; i++) {
+			buffer[i] += value;
+			value = buffer[i];
+		}
+
+		k_yield();
+	}
+}
+#endif /* CONFIG_INT_BENCH_LOAD_THREADS */
+
+void bench_load_start(void)
+{
+#ifdef CONFIG_INT_BENCH_LOAD_TIMER
+	k_timer_start(&load_timer, K_USEC(CONFIG_INT_BENCH_LOAD_TIMER_PERIOD_US),
+		      K_USEC(CONFIG_INT_BENCH_LOAD_TIMER_PERIOD_US));
+#endif
+
+#ifdef CONFIG_INT_BENCH_LOAD_THREADS
+	int priority = k_thread_priority_get(k_current_get());
+
+	load_running = true;
+
+	for (uint32_t i = 0U; i < CONFIG_INT_BENCH_LOAD_NUM_THREADS; i++) {
+		k_thread_create(&load_threads[i], load_stacks[i], LOAD_STACK_SIZE,
+				load_thread_entry, (void *)load_buffers[i], NULL, NULL,
+				priority + 1, 0, K_NO_WAIT);
+	}
+#endif
+}
+
+void bench_load_stop(void)
+{
+#ifdef CONFIG_INT_BENCH_LOAD_TIMER
+	k_timer_stop(&load_timer);
+#endif
+
+#ifdef CONFIG_INT_BENCH_LOAD_THREADS
+	load_running = false;
+
+	for (uint32_t i = 0U; i < CONFIG_INT_BENCH_LOAD_NUM_THREADS; i++) {
+		(void)k_thread_join(&load_threads[i], K_FOREVER);
+	}
+#endif
+}
+
+void bench_load_pollute(void)
+{
+#ifdef CONFIG_INT_BENCH_LOAD_CACHE
+	for (size_t i = 0U; i < WORKING_SET_SIZE; i += WORKING_SET_STRIDE) {
+		working_set[i]++;
+	}
+#endif
+}
+
+const char *bench_load_description(void)
+{
+	return ""
+#ifdef CONFIG_INT_BENCH_LOAD_CACHE
+		"cache "
+#endif
+#ifdef CONFIG_INT_BENCH_LOAD_TIMER
+		"timer "
+#endif
+#ifdef CONFIG_INT_BENCH_LOAD_THREADS
+		"threads "
+#endif
+		;
+}

--- a/tests/benchmarks/interrupt_latency/src/load.c
+++ b/tests/benchmarks/interrupt_latency/src/load.c
@@ -39,6 +39,10 @@
 static volatile uint8_t working_set[WORKING_SET_SIZE];
 #endif /* CONFIG_INT_BENCH_LOAD_CACHE */
 
+#ifdef CONFIG_INT_BENCH_LOAD_KERNEL
+static K_SEM_DEFINE(kernel_load_sem, 0, 1);
+#endif
+
 #ifdef CONFIG_INT_BENCH_LOAD_TIMER
 static void load_timer_handler(struct k_timer *timer)
 {
@@ -49,10 +53,49 @@ static void load_timer_handler(struct k_timer *timer)
 	 * point is to compete for interrupt service, not to monopolise
 	 * the CPU.
 	 */
+#ifdef CONFIG_INT_BENCH_LOAD_KERNEL
+	/*
+	 * Kernel calls that take a spinlock, so that the benchmark
+	 * interrupt competes with the windows the kernel masks
+	 * interrupts for rather than with an empty handler.
+	 */
+	k_sem_give(&kernel_load_sem);
+	(void)k_sem_take(&kernel_load_sem, K_NO_WAIT);
+	(void)k_uptime_get();
+#endif
 }
 
 static K_TIMER_DEFINE(load_timer, load_timer_handler, NULL);
 #endif /* CONFIG_INT_BENCH_LOAD_TIMER */
+
+#ifdef CONFIG_INT_BENCH_LOAD_SCHED
+#define CHURN_STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+static K_SEM_DEFINE(churn_sem, 0, 1);
+static K_SEM_DEFINE(churn_done_sem, 0, 1);
+static K_THREAD_STACK_DEFINE(churn_stack, CHURN_STACK_SIZE);
+static struct k_thread churn_thread;
+static volatile bool churn_running;
+
+/*
+ * Runs at a higher priority than the benchmark, so waking it forces a
+ * context switch away and back. It only ever runs between samples,
+ * because that is the only point at which the benchmark gives it the
+ * semaphore; a thread that could preempt a measurement in progress
+ * would add its scheduling delay to the result.
+ */
+static void churn_thread_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (churn_running) {
+		k_sem_take(&churn_sem, K_FOREVER);
+		k_sem_give(&churn_done_sem);
+	}
+}
+#endif /* CONFIG_INT_BENCH_LOAD_SCHED */
 
 #ifdef CONFIG_INT_BENCH_LOAD_THREADS
 #define LOAD_STACK_SIZE  (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
@@ -83,8 +126,24 @@ static void load_thread_entry(void *p1, void *p2, void *p3)
 }
 #endif /* CONFIG_INT_BENCH_LOAD_THREADS */
 
+void bench_load_churn(void)
+{
+#ifdef CONFIG_INT_BENCH_LOAD_SCHED
+	k_sem_give(&churn_sem);
+	(void)k_sem_take(&churn_done_sem, K_FOREVER);
+#endif
+}
+
 void bench_load_start(void)
 {
+#ifdef CONFIG_INT_BENCH_LOAD_SCHED
+	int churn_priority = k_thread_priority_get(k_current_get()) - 1;
+
+	churn_running = true;
+	k_thread_create(&churn_thread, churn_stack, CHURN_STACK_SIZE, churn_thread_entry,
+			NULL, NULL, NULL, churn_priority, 0, K_NO_WAIT);
+#endif
+
 #ifdef CONFIG_INT_BENCH_LOAD_TIMER
 	k_timer_start(&load_timer, K_USEC(CONFIG_INT_BENCH_LOAD_TIMER_PERIOD_US),
 		      K_USEC(CONFIG_INT_BENCH_LOAD_TIMER_PERIOD_US));
@@ -105,6 +164,13 @@ void bench_load_start(void)
 
 void bench_load_stop(void)
 {
+#ifdef CONFIG_INT_BENCH_LOAD_SCHED
+	churn_running = false;
+	k_sem_give(&churn_sem);
+	(void)k_sem_take(&churn_done_sem, K_FOREVER);
+	(void)k_thread_join(&churn_thread, K_FOREVER);
+#endif
+
 #ifdef CONFIG_INT_BENCH_LOAD_TIMER
 	k_timer_stop(&load_timer);
 #endif
@@ -135,6 +201,12 @@ const char *bench_load_description(void)
 #endif
 #ifdef CONFIG_INT_BENCH_LOAD_TIMER
 		"timer "
+#endif
+#ifdef CONFIG_INT_BENCH_LOAD_KERNEL
+		"kernel "
+#endif
+#ifdef CONFIG_INT_BENCH_LOAD_SCHED
+		"sched "
 #endif
 #ifdef CONFIG_INT_BENCH_LOAD_THREADS
 		"threads "

--- a/tests/benchmarks/interrupt_latency/src/load.h
+++ b/tests/benchmarks/interrupt_latency/src/load.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTS_BENCHMARKS_INTERRUPT_LATENCY_SRC_LOAD_H_
+#define ZEPHYR_TESTS_BENCHMARKS_INTERRUPT_LATENCY_SRC_LOAD_H_
+
+#include <zephyr/kernel.h>
+
+/*
+ * Background system load.
+ *
+ * Interrupt latency measured on an otherwise idle system is a best
+ * case: caches are warm with the benchmark's own working set, no other
+ * interrupt is in service and no other code competes for the memory
+ * system. These helpers put the system under load so that the reported
+ * maximum and standard deviation describe something closer to what an
+ * application will see.
+ */
+
+#ifdef CONFIG_INT_BENCH_LOAD
+
+/* Start the background load sources. Called once before benchmarking. */
+void bench_load_start(void);
+
+/* Stop the background load sources. */
+void bench_load_stop(void);
+
+/*
+ * Evict the caches and TLBs by walking a working set larger than the
+ * benchmark's own. Called between samples, outside the measured span,
+ * so that each measured interrupt is served with cold caches.
+ */
+void bench_load_pollute(void);
+
+/* Describe the enabled load sources, for the benchmark banner. */
+const char *bench_load_description(void);
+
+#else
+
+static inline void bench_load_start(void)
+{
+}
+
+static inline void bench_load_stop(void)
+{
+}
+
+static inline void bench_load_pollute(void)
+{
+}
+
+static inline const char *bench_load_description(void)
+{
+	return "idle";
+}
+
+#endif /* CONFIG_INT_BENCH_LOAD */
+
+#endif /* ZEPHYR_TESTS_BENCHMARKS_INTERRUPT_LATENCY_SRC_LOAD_H_ */

--- a/tests/benchmarks/interrupt_latency/src/load.h
+++ b/tests/benchmarks/interrupt_latency/src/load.h
@@ -34,6 +34,14 @@ void bench_load_stop(void);
  */
 void bench_load_pollute(void);
 
+/*
+ * Exercise the kernel and the scheduler between samples, outside the
+ * measured span. Separate from bench_load_pollute() because that one
+ * is also called from inside a critical section, where making kernel
+ * calls would not be valid.
+ */
+void bench_load_churn(void);
+
 /* Describe the enabled load sources, for the benchmark banner. */
 const char *bench_load_description(void);
 
@@ -48,6 +56,10 @@ static inline void bench_load_stop(void)
 }
 
 static inline void bench_load_pollute(void)
+{
+}
+
+static inline void bench_load_churn(void)
 {
 }
 

--- a/tests/benchmarks/interrupt_latency/src/load.h
+++ b/tests/benchmarks/interrupt_latency/src/load.h
@@ -42,6 +42,12 @@ void bench_load_pollute(void);
  */
 void bench_load_churn(void);
 
+/*
+ * Number of times the load timer handler has run, for attributing
+ * outlying samples to it. Zero when there is no timer load.
+ */
+uint32_t bench_load_timer_runs(void);
+
 /* Describe the enabled load sources, for the benchmark banner. */
 const char *bench_load_description(void);
 
@@ -61,6 +67,11 @@ static inline void bench_load_pollute(void)
 
 static inline void bench_load_churn(void)
 {
+}
+
+static inline uint32_t bench_load_timer_runs(void)
+{
+	return 0;
 }
 
 static inline const char *bench_load_description(void)

--- a/tests/benchmarks/interrupt_latency/src/trigger.h
+++ b/tests/benchmarks/interrupt_latency/src/trigger.h
@@ -29,6 +29,42 @@ void bench_trigger_isr(const void *arg);
 
 #ifdef CONFIG_INT_BENCH_TRIGGER_SW_IRQ
 unsigned int bench_trigger_irq_line(void);
+
+/*
+ * Second benchmark IRQ line.
+ *
+ * Scenarios that compare two ways of connecting an interrupt need a
+ * line of their own, because the connection method is fixed at build
+ * time. The line number has to be visible here rather than staying
+ * private to the backend, since IRQ_DIRECT_CONNECT() is expanded where
+ * the handler is defined.
+ *
+ * RISC-V is absent on purpose: without a CLIC the machine software
+ * interrupt is the only interrupt a hart can raise on itself, and the
+ * first line already uses it.
+ */
+#if CONFIG_INT_BENCH_IRQ_LINE_ALT >= 0
+#define BENCH_IRQ_LINE_ALT CONFIG_INT_BENCH_IRQ_LINE_ALT
+#define BENCH_HAS_ALT_LINE 1
+#elif defined(CONFIG_GIC)
+/* SGI 0-2 are Zephyr's SMP IPIs and 8-15 may be Secure only */
+#define BENCH_IRQ_LINE_ALT 7
+#define BENCH_HAS_ALT_LINE 1
+#elif defined(CONFIG_BOARD_QEMU_CORTEX_M3)
+#define BENCH_IRQ_LINE_ALT 41
+#define BENCH_HAS_ALT_LINE 1
+#elif defined(CONFIG_X86)
+#define BENCH_IRQ_LINE_ALT 28
+#define BENCH_HAS_ALT_LINE 1
+#elif defined(CONFIG_CPU_CORTEX_M) || defined(CONFIG_ARC)
+#define BENCH_IRQ_LINE_ALT (CONFIG_NUM_IRQS - 2)
+#define BENCH_HAS_ALT_LINE 1
 #endif
+
+#ifdef BENCH_HAS_ALT_LINE
+/* Raise the interrupt on the second line */
+void bench_trigger_alt(void);
+#endif
+#endif /* CONFIG_INT_BENCH_TRIGGER_SW_IRQ */
 
 #endif /* ZEPHYR_TESTS_BENCHMARKS_INTERRUPT_LATENCY_SRC_TRIGGER_H_ */

--- a/tests/benchmarks/interrupt_latency/src/trigger.h
+++ b/tests/benchmarks/interrupt_latency/src/trigger.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTS_BENCHMARKS_INTERRUPT_LATENCY_SRC_TRIGGER_H_
+#define ZEPHYR_TESTS_BENCHMARKS_INTERRUPT_LATENCY_SRC_TRIGGER_H_
+
+#include <zephyr/kernel.h>
+
+/*
+ * Trigger backend abstraction.
+ *
+ * A backend provides a way to run a benchmark-controlled handler in
+ * interrupt context. The sw-irq backend raises a real asynchronous
+ * interrupt through the platform interrupt controller; the offload
+ * backend falls back to the synchronous irq_offload() trap. Scenarios
+ * install their measurement handler with bench_trigger_set_handler()
+ * and fire it with bench_trigger().
+ */
+typedef void (*bench_trigger_handler_t)(void);
+
+int bench_trigger_init(void);
+void bench_trigger_set_handler(bench_trigger_handler_t handler);
+void bench_trigger(void);
+
+/* ISR wrapper installed on the benchmark IRQ line */
+void bench_trigger_isr(const void *arg);
+
+#ifdef CONFIG_INT_BENCH_TRIGGER_SW_IRQ
+unsigned int bench_trigger_irq_line(void);
+#endif
+
+#endif /* ZEPHYR_TESTS_BENCHMARKS_INTERRUPT_LATENCY_SRC_TRIGGER_H_ */

--- a/tests/benchmarks/interrupt_latency/src/trigger.h
+++ b/tests/benchmarks/interrupt_latency/src/trigger.h
@@ -18,6 +18,17 @@
  * install their measurement handler with bench_trigger_set_handler()
  * and fire it with bench_trigger().
  */
+/*
+ * Placement of the benchmark's interrupt handlers. With
+ * CONFIG_INT_BENCH_ISR_IN_RAM they are relocated out of flash, so that
+ * two runs can be compared to see what fetching them costs.
+ */
+#ifdef CONFIG_INT_BENCH_ISR_IN_RAM
+#define BENCH_ISR_FUNC __ramfunc
+#else
+#define BENCH_ISR_FUNC
+#endif
+
 typedef void (*bench_trigger_handler_t)(void);
 
 int bench_trigger_init(void);
@@ -25,7 +36,7 @@ void bench_trigger_set_handler(bench_trigger_handler_t handler);
 void bench_trigger(void);
 
 /* ISR wrapper installed on the benchmark IRQ line */
-void bench_trigger_isr(const void *arg);
+BENCH_ISR_FUNC void bench_trigger_isr(const void *arg);
 
 #ifdef CONFIG_INT_BENCH_TRIGGER_SW_IRQ
 unsigned int bench_trigger_irq_line(void);

--- a/tests/benchmarks/interrupt_latency/src/trigger_offload.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_offload.c
@@ -17,7 +17,7 @@
 
 static bench_trigger_handler_t trigger_handler;
 
-void bench_trigger_isr(const void *arg)
+BENCH_ISR_FUNC void bench_trigger_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 

--- a/tests/benchmarks/interrupt_latency/src/trigger_offload.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_offload.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Fallback trigger backend based on irq_offload(). Portable to every
+ * architecture, but the handler runs from a synchronous software trap
+ * rather than an asynchronous interrupt: only the interrupt exit paths
+ * are meaningfully measured with this backend.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq_offload.h>
+
+#include "trigger.h"
+
+static bench_trigger_handler_t trigger_handler;
+
+void bench_trigger_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	if (trigger_handler != NULL) {
+		trigger_handler();
+	}
+}
+
+void bench_trigger_set_handler(bench_trigger_handler_t handler)
+{
+	trigger_handler = handler;
+}
+
+int bench_trigger_init(void)
+{
+	return 0;
+}
+
+void bench_trigger(void)
+{
+	irq_offload(bench_trigger_isr, NULL);
+}

--- a/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Trigger backend raising a real asynchronous interrupt through the
+ * platform interrupt controller. The per-architecture trigger methods
+ * are adapted from subsys/testsuite/include/zephyr/interrupt_util.h,
+ * which is the mechanism proven by tests/arch/common/interrupt.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+
+#include "trigger.h"
+
+/*
+ * Benchmark IRQ line selection. CONFIG_INT_BENCH_IRQ_LINE overrides;
+ * otherwise pick a platform-appropriate default.
+ */
+#if CONFIG_INT_BENCH_IRQ_LINE >= 0
+#define BENCH_IRQ_LINE CONFIG_INT_BENCH_IRQ_LINE
+#elif defined(CONFIG_GIC)
+/*
+ * Use an SGI (software generated interrupt) line. SGI 0-2 are used by
+ * Zephyr for SMP IPIs and SGI 8-15 may be inaccessible from the
+ * Non-Secure state, so use SGI 6.
+ */
+#define BENCH_IRQ_LINE 6
+#elif defined(CONFIG_BOARD_QEMU_CORTEX_M3)
+/*
+ * QEMU's NVIC model for this board does not implement all
+ * CONFIG_NUM_IRQS lines; line 42 is implemented and unused (same line
+ * used by tests/arch/common/interrupt).
+ */
+#define BENCH_IRQ_LINE 42
+#else
+#define BENCH_IRQ_LINE (CONFIG_NUM_IRQS - 1)
+#endif
+
+static bench_trigger_handler_t trigger_handler;
+
+void bench_trigger_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	if (trigger_handler != NULL) {
+		trigger_handler();
+	}
+}
+
+void bench_trigger_set_handler(bench_trigger_handler_t handler)
+{
+	trigger_handler = handler;
+}
+
+unsigned int bench_trigger_irq_line(void)
+{
+	return BENCH_IRQ_LINE;
+}
+
+#if defined(CONFIG_CPU_CORTEX_M)
+#include <cmsis_core.h>
+
+void bench_trigger(void)
+{
+#if defined(CONFIG_SOC_TI_LM3S6965_QEMU) || defined(CONFIG_CPU_CORTEX_M0) ||                       \
+	defined(CONFIG_CPU_CORTEX_M0PLUS) || defined(CONFIG_CPU_CORTEX_M1) ||                      \
+	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	/* QEMU does not simulate the STIR register: this is a workaround */
+	NVIC_SetPendingIRQ(BENCH_IRQ_LINE);
+#else
+	NVIC->STIR = BENCH_IRQ_LINE;
+#endif
+}
+
+#elif defined(CONFIG_GIC)
+#include <zephyr/drivers/interrupt_controller/gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+void bench_trigger(void)
+{
+#if CONFIG_GIC_VER <= 2
+	sys_write32(GICD_SGIR_TGTFILT_REQONLY | GICD_SGIR_SGIINTID(BENCH_IRQ_LINE), GICD_SGIR);
+#else
+	uint64_t mpidr = GET_MPIDR();
+	uint8_t aff0 = MPIDR_AFFLVL(mpidr, 0);
+
+	gic_raise_sgi(BENCH_IRQ_LINE, mpidr, BIT(aff0));
+#endif
+}
+
+#elif defined(CONFIG_ARC)
+
+void bench_trigger(void)
+{
+	z_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_HINT, BENCH_IRQ_LINE);
+}
+
+#else
+#error "No software interrupt trigger available for this architecture"
+#endif
+
+int bench_trigger_init(void)
+{
+	IRQ_CONNECT(BENCH_IRQ_LINE, CONFIG_INT_BENCH_IRQ_PRIO, bench_trigger_isr, NULL, 0);
+	irq_enable(BENCH_IRQ_LINE);
+
+	return 0;
+}

--- a/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
@@ -62,7 +62,7 @@ static inline void bench_trigger_ack(void);
 
 static bench_trigger_handler_t trigger_handler;
 
-void bench_trigger_isr(const void *arg)
+BENCH_ISR_FUNC void bench_trigger_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 

--- a/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
@@ -35,6 +35,13 @@
  * used by tests/arch/common/interrupt).
  */
 #define BENCH_IRQ_LINE 42
+#elif defined(CONFIG_X86)
+/*
+ * x86 has no CONFIG_NUM_IRQS; IRQ lines are mapped to IDT vectors at
+ * build time. Use the same line as tests/arch/common/interrupt, which
+ * is known not to collide with the platform's own IRQ assignments.
+ */
+#define BENCH_IRQ_LINE 27
 #else
 #define BENCH_IRQ_LINE (CONFIG_NUM_IRQS - 1)
 #endif
@@ -98,6 +105,43 @@ void bench_trigger(void)
 	z_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_HINT, BENCH_IRQ_LINE);
 }
 
+#elif defined(CONFIG_X86)
+#ifdef CONFIG_X2APIC
+#include <zephyr/drivers/interrupt_controller/loapic.h>
+#define VECTOR_MASK 0xFFU
+#else
+#include <zephyr/arch/arch_interface.h>
+/*
+ * LOAPIC ICR value for a self directed IPI: fixed delivery mode,
+ * physical destination mode, level assert, edge triggered, no
+ * destination shorthand.
+ */
+#define LOAPIC_ICR_IPI_TEST 0x00004000U
+#endif
+
+/*
+ * The interrupt is emulated by sending an IPI from the local APIC to
+ * the core itself. Note that unlike trigger_irq() in
+ * <zephyr/interrupt_util.h>, no delay loop is added after the write:
+ * the delay would be counted as interrupt entry latency. Callers spin
+ * on a flag set by the ISR instead.
+ */
+static uint8_t bench_vector;
+
+void bench_trigger(void)
+{
+#ifdef CONFIG_X2APIC
+	x86_write_x2apic(LOAPIC_SELF_IPI, bench_vector & VECTOR_MASK);
+#else
+#ifdef CONFIG_SMP
+	int cpu_id = arch_curr_cpu()->id;
+#else
+	int cpu_id = 0;
+#endif
+	z_loapic_ipi(cpu_id, LOAPIC_ICR_IPI_TEST, bench_vector);
+#endif /* CONFIG_X2APIC */
+}
+
 #else
 #error "No software interrupt trigger available for this architecture"
 #endif
@@ -105,6 +149,16 @@ void bench_trigger(void)
 int bench_trigger_init(void)
 {
 	IRQ_CONNECT(BENCH_IRQ_LINE, CONFIG_INT_BENCH_IRQ_PRIO, bench_trigger_isr, NULL, 0);
+
+#ifdef CONFIG_X86
+	/*
+	 * The local APIC is addressed by IDT vector rather than by IRQ
+	 * line. Resolve the vector assigned to the benchmark line once,
+	 * so that triggering costs no more than the APIC write itself.
+	 */
+	bench_vector = (uint8_t)Z_IRQ_TO_INTERRUPT_VECTOR(BENCH_IRQ_LINE);
+#endif
+
 	irq_enable(BENCH_IRQ_LINE);
 
 	return 0;

--- a/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
@@ -98,6 +98,19 @@ void bench_trigger(void)
 #endif
 }
 
+#ifdef BENCH_HAS_ALT_LINE
+void bench_trigger_alt(void)
+{
+#if defined(CONFIG_SOC_TI_LM3S6965_QEMU) || defined(CONFIG_CPU_CORTEX_M0) ||                       \
+	defined(CONFIG_CPU_CORTEX_M0PLUS) || defined(CONFIG_CPU_CORTEX_M1) ||                      \
+	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	NVIC_SetPendingIRQ(BENCH_IRQ_LINE_ALT);
+#else
+	NVIC->STIR = BENCH_IRQ_LINE_ALT;
+#endif
+}
+#endif
+
 #elif defined(CONFIG_GIC)
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
@@ -114,12 +127,33 @@ void bench_trigger(void)
 #endif
 }
 
+#ifdef BENCH_HAS_ALT_LINE
+void bench_trigger_alt(void)
+{
+#if CONFIG_GIC_VER <= 2
+	sys_write32(GICD_SGIR_TGTFILT_REQONLY | GICD_SGIR_SGIINTID(BENCH_IRQ_LINE_ALT), GICD_SGIR);
+#else
+	uint64_t mpidr = GET_MPIDR();
+	uint8_t aff0 = MPIDR_AFFLVL(mpidr, 0);
+
+	gic_raise_sgi(BENCH_IRQ_LINE_ALT, mpidr, BIT(aff0));
+#endif
+}
+#endif
+
 #elif defined(CONFIG_ARC)
 
 void bench_trigger(void)
 {
 	z_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_HINT, BENCH_IRQ_LINE);
 }
+
+#ifdef BENCH_HAS_ALT_LINE
+void bench_trigger_alt(void)
+{
+	z_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_HINT, BENCH_IRQ_LINE_ALT);
+}
+#endif
 
 #elif defined(CONFIG_X86)
 #ifdef CONFIG_X2APIC
@@ -143,20 +177,35 @@ void bench_trigger(void)
  * on a flag set by the ISR instead.
  */
 static uint8_t bench_vector;
+#ifdef BENCH_HAS_ALT_LINE
+static uint8_t bench_vector_alt;
+#endif
 
-void bench_trigger(void)
+static inline void bench_send_self_ipi(uint8_t vector)
 {
 #ifdef CONFIG_X2APIC
-	x86_write_x2apic(LOAPIC_SELF_IPI, bench_vector & VECTOR_MASK);
+	x86_write_x2apic(LOAPIC_SELF_IPI, vector & VECTOR_MASK);
 #else
 #ifdef CONFIG_SMP
 	int cpu_id = arch_curr_cpu()->id;
 #else
 	int cpu_id = 0;
 #endif
-	z_loapic_ipi(cpu_id, LOAPIC_ICR_IPI_TEST, bench_vector);
+	z_loapic_ipi(cpu_id, LOAPIC_ICR_IPI_TEST, vector);
 #endif /* CONFIG_X2APIC */
 }
+
+void bench_trigger(void)
+{
+	bench_send_self_ipi(bench_vector);
+}
+
+#ifdef BENCH_HAS_ALT_LINE
+void bench_trigger_alt(void)
+{
+	bench_send_self_ipi(bench_vector_alt);
+}
+#endif
 
 #elif defined(CONFIG_RISCV)
 #if defined(CONFIG_CLIC) || defined(CONFIG_NRFX_CLIC)
@@ -227,6 +276,9 @@ int bench_trigger_init(void)
 	 * so that triggering costs no more than the APIC write itself.
 	 */
 	bench_vector = (uint8_t)Z_IRQ_TO_INTERRUPT_VECTOR(BENCH_IRQ_LINE);
+#ifdef BENCH_HAS_ALT_LINE
+	bench_vector_alt = (uint8_t)Z_IRQ_TO_INTERRUPT_VECTOR(BENCH_IRQ_LINE_ALT);
+#endif
 #endif
 
 	irq_enable(BENCH_IRQ_LINE);

--- a/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
@@ -42,15 +42,31 @@
  * is known not to collide with the platform's own IRQ assignments.
  */
 #define BENCH_IRQ_LINE 27
+#elif defined(CONFIG_RISCV) && !defined(CONFIG_CLIC) && !defined(CONFIG_NRFX_CLIC)
+/*
+ * Without a CLIC, the only interrupt a RISC-V hart can raise on itself
+ * is the machine software interrupt, asserted through the CLINT.
+ */
+#define BENCH_IRQ_LINE RISCV_IRQ_MSOFT
 #else
 #define BENCH_IRQ_LINE (CONFIG_NUM_IRQS - 1)
 #endif
+
+/*
+ * Deassert a level triggered benchmark interrupt. Called at the very
+ * start of the ISR, before the measurement handler, so that the
+ * throughput scenario can reassert the interrupt from within its own
+ * handler.
+ */
+static inline void bench_trigger_ack(void);
 
 static bench_trigger_handler_t trigger_handler;
 
 void bench_trigger_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
+
+	bench_trigger_ack();
 
 	if (trigger_handler != NULL) {
 		trigger_handler();
@@ -142,8 +158,62 @@ void bench_trigger(void)
 #endif /* CONFIG_X2APIC */
 }
 
+#elif defined(CONFIG_RISCV)
+#if defined(CONFIG_CLIC) || defined(CONFIG_NRFX_CLIC)
+void riscv_clic_irq_set_pending(uint32_t irq);
+
+void bench_trigger(void)
+{
+	riscv_clic_irq_set_pending(BENCH_IRQ_LINE);
+}
+
+#else
+#include <zephyr/arch/riscv/csr.h>
+
+/*
+ * Without a CLIC, a hart cannot make one of its own external
+ * interrupts pending: PLIC pending bits are driven by the interrupt
+ * gateways, and the machine software, timer and external pending bits
+ * of the mip CSR are read only. The machine software interrupt is
+ * therefore asserted the same way the SMP IPI code does it, by writing
+ * this hart's MSIP register in the CLINT.
+ *
+ * MSIP is level triggered, so the ISR has to deassert it; see
+ * bench_trigger_ack() below.
+ *
+ * Both the CLINT and mhartid are machine mode only, which is why
+ * CONFIG_INT_BENCH_TRIGGER_SW_IRQ excludes CONFIG_RISCV_S_MODE.
+ */
+#define CLINT_NODE DT_NODELABEL(clint)
+#if !DT_NODE_EXISTS(CLINT_NODE)
+#error "No CLIC and no 'clint' devicetree node: cannot trigger an interrupt"
+#endif
+
+#define MSIP_BASE       DT_REG_ADDR_RAW(CLINT_NODE)
+#define MSIP(hartid)    ((volatile uint32_t *)MSIP_BASE)[hartid]
+
+#define BENCH_TRIGGER_LEVEL_ACK 1
+
+void bench_trigger(void)
+{
+	MSIP(csr_read(mhartid)) = 1U;
+}
+
+static inline void bench_trigger_ack(void)
+{
+	MSIP(csr_read(mhartid)) = 0U;
+}
+#endif /* CONFIG_CLIC || CONFIG_NRFX_CLIC */
+
 #else
 #error "No software interrupt trigger available for this architecture"
+#endif
+
+#ifndef BENCH_TRIGGER_LEVEL_ACK
+static inline void bench_trigger_ack(void)
+{
+	/* Edge triggered: nothing to deassert */
+}
 #endif
 
 int bench_trigger_init(void)

--- a/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
@@ -42,6 +42,12 @@
  * is known not to collide with the platform's own IRQ assignments.
  */
 #define BENCH_IRQ_LINE 27
+#elif defined(CONFIG_INTC_ESP32)
+/*
+ * Reported for the banner only. The interrupt matrix assigns the CPU
+ * interrupt when the source is allocated, so there is no line to pick.
+ */
+#define BENCH_IRQ_LINE 0
 #elif defined(CONFIG_RISCV) && !defined(CONFIG_CLIC) && !defined(CONFIG_NRFX_CLIC)
 /*
  * Without a CLIC, the only interrupt a RISC-V hart can raise on itself
@@ -207,6 +213,74 @@ void bench_trigger_alt(void)
 }
 #endif
 
+#elif defined(CONFIG_INTC_ESP32)
+/*
+ * Espressif SoCs route every interrupt through an interrupt matrix
+ * rather than exposing lines the CPU can pend directly, so neither the
+ * RISC-V nor the Xtensa mechanism below applies. What they do have is a
+ * set of peripheral sources whose only job is to be raised by software,
+ * intended for cross-core signalling: writing the register asserts a
+ * real interrupt that arrives through the matrix like any other.
+ *
+ * Sources 0 and 1 are the ones ESP-IDF and Zephyr's own SMP code use,
+ * so take source 2.
+ *
+ * The register lives in a different peripheral depending on the part,
+ * and the interrupt is level triggered, so the ISR has to clear it.
+ */
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <soc/soc.h>
+#include <soc/interrupts.h>
+
+/* The registers moved peripheral, and name, more than once */
+#if defined(CONFIG_SOC_SERIES_ESP32C6) || defined(CONFIG_SOC_SERIES_ESP32H2) ||                    \
+	defined(CONFIG_SOC_SERIES_ESP32C5)
+#include <soc/intpri_reg.h>
+#define BENCH_FROM_CPU_REG INTPRI_CPU_INTR_FROM_CPU_2_REG
+#define BENCH_FROM_CPU_BIT INTPRI_CPU_INTR_FROM_CPU_2
+#elif defined(CONFIG_SOC_SERIES_ESP32)
+#include <soc/dport_reg.h>
+#define BENCH_FROM_CPU_REG DPORT_CPU_INTR_FROM_CPU_2_REG
+#define BENCH_FROM_CPU_BIT DPORT_CPU_INTR_FROM_CPU_2
+#elif defined(CONFIG_SOC_SERIES_ESP32S2)
+/* The register moved to the system peripheral but kept the old prefix */
+#include <soc/system_reg.h>
+#define BENCH_FROM_CPU_REG DPORT_CPU_INTR_FROM_CPU_2_REG
+#define BENCH_FROM_CPU_BIT DPORT_CPU_INTR_FROM_CPU_2
+#else
+#include <soc/system_reg.h>
+#define BENCH_FROM_CPU_REG SYSTEM_CPU_INTR_FROM_CPU_2_REG
+#define BENCH_FROM_CPU_BIT SYSTEM_CPU_INTR_FROM_CPU_2
+#endif
+
+#define BENCH_TRIGGER_LEVEL_ACK 1
+#define BENCH_TRIGGER_OWN_CONNECT 1
+
+void bench_trigger(void)
+{
+	WRITE_PERI_REG(BENCH_FROM_CPU_REG, BENCH_FROM_CPU_BIT);
+}
+
+static inline void bench_trigger_ack(void)
+{
+	WRITE_PERI_REG(BENCH_FROM_CPU_REG, 0);
+}
+
+/* The allocator hands the ISR a non-const argument */
+static void bench_trigger_esp_isr(void *arg)
+{
+	bench_trigger_isr(arg);
+}
+
+/*
+ * The matrix allocates a CPU interrupt for the source, so the line is
+ * not known until then and IRQ_CONNECT() cannot be used.
+ */
+static int bench_trigger_connect(void)
+{
+	return esp_intr_alloc(ETS_FROM_CPU_INTR2_SOURCE, 0, bench_trigger_esp_isr, NULL, NULL);
+}
+
 #elif defined(CONFIG_RISCV)
 #if defined(CONFIG_CLIC) || defined(CONFIG_NRFX_CLIC)
 void riscv_clic_irq_set_pending(uint32_t irq);
@@ -267,6 +341,9 @@ static inline void bench_trigger_ack(void)
 
 int bench_trigger_init(void)
 {
+#ifdef BENCH_TRIGGER_OWN_CONNECT
+	return bench_trigger_connect();
+#else
 	IRQ_CONNECT(BENCH_IRQ_LINE, CONFIG_INT_BENCH_IRQ_PRIO, bench_trigger_isr, NULL, 0);
 
 #ifdef CONFIG_X86
@@ -284,4 +361,5 @@ int bench_trigger_init(void)
 	irq_enable(BENCH_IRQ_LINE);
 
 	return 0;
+#endif /* BENCH_TRIGGER_OWN_CONNECT */
 }

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -15,6 +15,8 @@ tests:
     platform_exclude:
       - qemu_cortex_m0
       - m2gl025_miv
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
     harness: console
     integration_platforms:
       - qemu_cortex_m3
@@ -38,7 +40,41 @@ tests:
       - qemu_riscv32
     extra_configs:
       - CONFIG_DYNAMIC_INTERRUPTS=y
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
     harness: console
+    harness_config:
+      type: one_line
+      record:
+        regex:
+          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
+
+  # Re-run the scenarios under background system load. The interesting
+  # numbers here are the maximum and the standard deviation, not the mean.
+  benchmark.kernel.interrupt.latency.load:
+    platform_exclude:
+      - qemu_cortex_m0
+      - m2gl025_miv
+      # The critical section scenario busy waits with interrupts
+      # locked while the load timer keeps expiring. Under ARC emulation
+      # that combination costs orders of magnitude more wall clock than
+      # the nominal hold time: clocked at 10MHz, none of the models get
+      # through that one scenario in half an hour.
+      - qemu_arc/qemu_arc_em
+      - qemu_arc/qemu_arc_hs
+      - qemu_arc/qemu_arc_hs/xip
+      - qemu_arc/qemu_arc_hs5x
+      - qemu_arc/qemu_arc_hs6x
+    extra_args:
+      - EXTRA_CONF_FILE="prj.load.conf"
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    timeout: 600
+    harness: console
+    integration_platforms:
+      - qemu_cortex_a53
+      - qemu_x86
     harness_config:
       type: one_line
       record:

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -57,20 +57,22 @@ tests:
       - qemu_cortex_m0
       - m2gl025_miv
       # The critical section scenario busy waits with interrupts
-      # locked while the load timer keeps expiring. Under ARC emulation
-      # that combination costs orders of magnitude more wall clock than
-      # the nominal hold time: clocked at 10MHz, none of the models get
-      # through that one scenario in half an hour.
+      # locked while the load timer keeps expiring. Under emulation
+      # that combination costs orders of magnitude more wall clock
+      # than the nominal hold time, making the run impractically long:
+      # the ARC models, clocked at 10MHz, do not get through that one
+      # scenario in half an hour.
       - qemu_arc/qemu_arc_em
       - qemu_arc/qemu_arc_hs
       - qemu_arc/qemu_arc_hs/xip
       - qemu_arc/qemu_arc_hs5x
       - qemu_arc/qemu_arc_hs6x
+      - qemu_cortex_m3
     extra_args:
       - EXTRA_CONF_FILE="prj.load.conf"
     extra_configs:
       - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
-    timeout: 600
+    timeout: 120
     harness: console
     integration_platforms:
       - qemu_cortex_a53

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -15,8 +15,6 @@ tests:
     platform_exclude:
       - qemu_cortex_m0
       - m2gl025_miv
-    extra_configs:
-      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
     harness: console
     integration_platforms:
       - qemu_cortex_m3
@@ -119,6 +117,28 @@ tests:
     harness: console
     integration_platforms:
       - qemu_cortex_m3
+    harness_config:
+      type: one_line
+      record:
+        regex:
+          - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
+
+  # The nested scenario needs the second line at a higher priority than
+  # the first, so it cannot share a build with the direct ISR
+  # comparison, which needs the two at equal priority.
+  benchmark.kernel.interrupt.latency.nested:
+    filter: CONFIG_CPU_CORTEX_M or CONFIG_ARC or CONFIG_GIC
+    extra_args:
+      - EXTRA_CONF_FILE="prj.nested.conf"
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    timeout: 120
+    harness: console
+    integration_platforms:
+      - qemu_cortex_m3
+      - qemu_cortex_a53
     harness_config:
       type: one_line
       record:

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -105,3 +105,24 @@ tests:
           - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
+
+  # Same scenarios with the benchmark's interrupt handlers relocated to
+  # RAM. Compare against the base run to see what fetching them from
+  # flash costs; only meaningful on hardware with flash wait states.
+  benchmark.kernel.interrupt.latency.ramfunc:
+    filter: CONFIG_ARCH_HAS_RAMFUNC_SUPPORT and CONFIG_XIP
+    extra_args:
+      - EXTRA_CONF_FILE="prj.ramfunc.conf"
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    timeout: 120
+    harness: console
+    integration_platforms:
+      - qemu_cortex_m3
+    harness_config:
+      type: one_line
+      record:
+        regex:
+          - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -20,6 +20,7 @@ tests:
       - qemu_cortex_m3
       - qemu_cortex_a53
       - qemu_x86
+      - qemu_riscv32
     harness_config:
       type: one_line
       record:
@@ -34,6 +35,7 @@ tests:
     platform_allow:
       - qemu_cortex_m3
       - qemu_cortex_a53
+      - qemu_riscv32
     extra_configs:
       - CONFIG_DYNAMIC_INTERRUPTS=y
     harness: console

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -1,0 +1,46 @@
+common:
+  tags:
+    - kernel
+    - benchmark
+    - interrupt
+  # The framework's timed control benchmark spins until a deadline
+  # expires, and on a simulated target time does not advance while the
+  # CPU is busy, so it never returns. tests/benchmarks/memory_allocators
+  # excludes posix for the same reason.
+  arch_exclude:
+    - posix
+tests:
+  benchmark.kernel.interrupt.latency:
+    # FIXME: no DWT on qemu_cortex_m0, no timing support on m2gl025_miv
+    platform_exclude:
+      - qemu_cortex_m0
+      - m2gl025_miv
+    harness: console
+    integration_platforms:
+      - qemu_cortex_m3
+      - qemu_cortex_a53
+      - qemu_x86
+    harness_config:
+      type: one_line
+      record:
+        regex:
+          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
+
+  # Additionally measure the dynamic interrupt connect cost on
+  # platforms supporting runtime ISR installation.
+  benchmark.kernel.interrupt.latency.dynamic:
+    platform_allow:
+      - qemu_cortex_m3
+      - qemu_cortex_a53
+    extra_configs:
+      - CONFIG_DYNAMIC_INTERRUPTS=y
+    harness: console
+    harness_config:
+      type: one_line
+      record:
+        regex:
+          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -27,7 +27,7 @@ tests:
       type: one_line
       record:
         regex:
-          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+          - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -46,7 +46,7 @@ tests:
       type: one_line
       record:
         regex:
-          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+          - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -81,7 +81,7 @@ tests:
       type: one_line
       record:
         regex:
-          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+          - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -102,6 +102,6 @@ tests:
       type: one_line
       record:
         regex:
-          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+          - "^P,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<min>[^,]+),(?P<p50>[^,]+),(?P<p90>[^,]+),(?P<p99>[^,]+),(?P<p999>[^,]+),(?P<p9999>[^,]+),(?P<max>[^,]+)$"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"

--- a/tests/benchmarks/interrupt_latency/tests.yaml
+++ b/tests/benchmarks/interrupt_latency/tests.yaml
@@ -84,3 +84,24 @@ tests:
           - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
+
+  # Zero-latency interrupts are Cortex-M only, and claim the same IRQ
+  # line as the direct ISR scenario, so they need a build of their own.
+  benchmark.kernel.interrupt.latency.zli:
+    arch_allow: arm
+    filter: CONFIG_CPU_CORTEX_M_HAS_BASEPRI
+    extra_args:
+      - EXTRA_CONF_FILE="prj.zli.conf"
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    timeout: 120
+    harness: console
+    integration_platforms:
+      - qemu_cortex_m3
+    harness_config:
+      type: one_line
+      record:
+        regex:
+          - "^M,(?P<suite>[^,]+),(?P<metric>[^,]+),(?P<samples>[^,]+),(?P<total_cycles>[^,]+),(?P<mean>[^,]+),(?P<stddev>[^,]+),(?P<std_error>[^,]+),(?P<min>[^,]+),(?P<min_sample>[^,]+),(?P<max>[^,]+),(?P<max_sample>[^,]+)$"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"

--- a/tests/ztest/benchmark_manual/CMakeLists.txt
+++ b/tests/ztest/benchmark_manual/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(benchmark_manual)
+
+target_sources(app PRIVATE
+  src/main.c
+)

--- a/tests/ztest/benchmark_manual/prj.conf
+++ b/tests/ztest/benchmark_manual/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_BENCHMARK=y
+CONFIG_IRQ_OFFLOAD=y
+CONFIG_MAIN_STACK_SIZE=2048

--- a/tests/ztest/benchmark_manual/src/main.c
+++ b/tests/ztest/benchmark_manual/src/main.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Validation for ZTEST_BENCHMARK_MANUAL(): one benchmark measuring a
+ * span of a known duration (k_busy_wait) that is only part of the body,
+ * and one measuring a span that starts in a different execution context
+ * (an ISR entered via irq_offload marks it) and ends in the thread,
+ * which framework-timed benchmarks cannot express.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/irq_offload.h>
+
+#define NUM_SAMPLES  100
+#define BUSY_WAIT_US 100
+
+ZTEST_BENCHMARK_SUITE(benchmark_manual, NULL, NULL);
+
+ZTEST_BENCHMARK_MANUAL(benchmark_manual, busy_wait_span, NUM_SAMPLES, NULL, NULL)
+{
+	/* Excluded from the measurement, to show that the brackets pick
+	 * out part of the body rather than all of it.
+	 */
+	k_busy_wait(BUSY_WAIT_US);
+
+	ztest_benchmark_start();
+	k_busy_wait(BUSY_WAIT_US);
+	ztest_benchmark_end();
+}
+
+static void offload_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	/* Marking the span from interrupt context is the point here. */
+	ztest_benchmark_start();
+}
+
+ZTEST_BENCHMARK_MANUAL(benchmark_manual, isr_exit_span, NUM_SAMPLES, NULL, NULL)
+{
+	irq_offload(offload_isr, NULL);
+
+	ztest_benchmark_end();
+}

--- a/tests/ztest/benchmark_manual/tests.yaml
+++ b/tests/ztest/benchmark_manual/tests.yaml
@@ -1,0 +1,20 @@
+common:
+  tags:
+    - test_framework
+    - benchmark
+  # The framework's timed control benchmark spins until a deadline
+  # expires, and on a simulated target time does not advance while the
+  # CPU is busy, so it never returns. tests/benchmarks/memory_allocators
+  # excludes posix for the same reason.
+  arch_exclude:
+    - posix
+tests:
+  testing.ztest.benchmark_manual:
+    integration_platforms:
+      - qemu_x86
+      - qemu_cortex_a53
+  testing.ztest.benchmark_manual.csv:
+    extra_configs:
+      - CONFIG_ZTEST_BENCHMARK_OUTPUT_CSV=y
+    integration_platforms:
+      - qemu_x86


### PR DESCRIPTION
This benchmark measures the individual components of interrupt handling in
Zephyr, with the goal of characterizing a platform for interrupt-heavy
applications. Where possible it uses a *real asynchronous interrupt* raised
through the platform interrupt controller, rather than the synchronous
``irq_offload()`` trap used by the ``latency_measure`` benchmark, so that the
hardware interrupt entry path is part of what is measured.

The benchmarks are built on the `ztest benchmarking framework` as manually sampled benchmarks
(``ZTEST_BENCHMARK_MANUAL``), because every measured span has at least one
endpoint captured in a different execution context (inside the ISR, or in a
woken thread) which framework-timed benchmarks cannot express.
