### PR TITLE
drivers: i3c: dw: flow control for command and response queues

### DIFF
--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -65,6 +65,8 @@ LOG_MODULE_REGISTER(i3c_dw, CONFIG_I3C_DW_LOG_LEVEL);
 	((role) == HW_CAP_DEVICE_ROLE_SEC_MASTER || (role) == HW_CAP_DEVICE_ROLE_SLAVE)
 
 #define COMMAND_QUEUE_PORT         0xc
+/* A controller command takes two queue locations: cmd_hi then cmd_lo */
+#define COMMAND_QUEUE_DWORDS_PER_CMD 2
 #define COMMAND_PORT_TOC           BIT(30)
 #define COMMAND_PORT_READ_TRANSFER BIT(28)
 #define COMMAND_PORT_SDAP          BIT(27)
@@ -128,6 +130,10 @@ LOG_MODULE_REGISTER(i3c_dw, CONFIG_I3C_DW_LOG_LEVEL);
 #define QUEUE_THLD_CTRL_IBI_STS_MASK  GENMASK(31, 24)
 #define QUEUE_THLD_CTRL_RESP_BUF_MASK GENMASK(15, 8)
 #define QUEUE_THLD_CTRL_RESP_BUF(x)   (((x) - 1) << 8)
+
+#define QUEUE_THLD_CTRL_CMD_EMPTY_BUF_MASK GENMASK(7, 0)
+/* Empty locations required before CMD_QUEUE_READY is raised */
+#define QUEUE_THLD_CTRL_CMD_EMPTY_BUF(x)   ((x) & GENMASK(7, 0))
 
 #define QUEUE_THLD_CTRL_IBI_DATA_MASK    GENMASK(23, 16)
 #define QUEUE_THLD_CTRL_IBI_DATA(x)      (((x) << 16) & QUEUE_THLD_CTRL_IBI_DATA_MASK)
@@ -375,6 +381,16 @@ LOG_MODULE_REGISTER(i3c_dw, CONFIG_I3C_DW_LOG_LEVEL);
 #define DW_I3C_MAX_DEVS         32
 #define DW_I3C_MAX_CMD_BUF_SIZE 16
 
+/*
+ * TID is shared by the command and response descriptors. 0x0-0x7 are user-defined; the
+ * controller generates the rest itself, and only while it is acting as a target.
+ */
+#define DW_I3C_TID_USER_MAX   0x7
+#define DW_I3C_TID_MWR_STATUS 0x8 /* Master Write Data Status */
+#define DW_I3C_TID_DEFSLVS    0xf /* DEFSLVS Status */
+
+#define DW_I3C_MAX_CMDS (DW_I3C_TID_USER_MAX + 1)
+
 /* Snps I3C/I2C Device Private Data */
 struct dw_i3c_i2c_dev_data {
 	/* Device id within the retaining registers. This is set after bus initialization by the
@@ -396,6 +412,7 @@ struct dw_i3c_xfer {
 	int32_t ret;
 	uint32_t ncmds;
 	uint32_t nresp_seen;
+	uint32_t cmd_idx;
 	struct dw_i3c_cmd cmds[DW_I3C_MAX_CMD_BUF_SIZE];
 };
 
@@ -631,6 +648,57 @@ static void dw_i3c_deftgts_work_fn(struct k_work *work)
 }
 #endif /* CONFIG_I3C_CONTROLLER && CONFIG_I3C_TARGET */
 
+static void dw_i3c_intr_enable(const struct dw_i3c_config *config, uint32_t bits)
+{
+	uint32_t mask = sys_read32(config->regs + INTR_STATUS_EN) | bits;
+
+	sys_write32(mask, config->regs + INTR_STATUS_EN);
+	sys_write32(mask, config->regs + INTR_SIGNAL_EN);
+}
+
+static void dw_i3c_intr_disable(const struct dw_i3c_config *config, uint32_t bits)
+{
+	uint32_t mask = sys_read32(config->regs + INTR_STATUS_EN) & ~bits;
+
+	sys_write32(mask, config->regs + INTR_STATUS_EN);
+	sys_write32(mask, config->regs + INTR_SIGNAL_EN);
+}
+
+/**
+ * @brief Enqueue pending commands into the Command Queue as space allows.
+ *
+ * Keeping the queue fed avoids the "next command unavailable" SCL stall on
+ * repeated-start chains longer than the queue.
+ *
+ * @param dev Pointer to the I3C device structure.
+ *
+ * @retval true if every command has been enqueued.
+ * @retval false if commands remain.
+ */
+static bool dw_i3c_cmd_write_to_cmd_fifo(const struct device *dev)
+{
+	const struct dw_i3c_config *config = dev->config;
+	struct dw_i3c_data *data = dev->data;
+	struct dw_i3c_xfer *xfer = &data->xfer;
+	struct dw_i3c_cmd *cmd;
+	uint32_t nempty;
+
+	while (xfer->cmd_idx < xfer->ncmds) {
+		nempty = QUEUE_STATUS_LEVEL_CMD(sys_read32(config->regs + QUEUE_STATUS_LEVEL));
+		if (nempty < COMMAND_QUEUE_DWORDS_PER_CMD) {
+			/* Rest goes on CMD_QUEUE_READY */
+			break;
+		}
+
+		cmd = &xfer->cmds[xfer->cmd_idx];
+		sys_write32(cmd->cmd_hi, config->regs + COMMAND_QUEUE_PORT);
+		sys_write32(cmd->cmd_lo, config->regs + COMMAND_QUEUE_PORT);
+		xfer->cmd_idx++;
+	}
+
+	return xfer->cmd_idx == xfer->ncmds;
+}
+
 static void dw_i3c_reset(const struct dw_i3c_config *config, uint32_t mask)
 {
 	sys_write32(mask, config->regs + RESET_CTRL);
@@ -640,6 +708,8 @@ static void dw_i3c_reset(const struct dw_i3c_config *config, uint32_t mask)
 
 static void dw_i3c_reset_fifos_and_queues(const struct dw_i3c_config *config)
 {
+	/* A flushed queue asserts CMD_QUEUE_READY; stop the refill before it fires */
+	dw_i3c_intr_disable(config, INTR_CMD_QUEUE_READY_STAT);
 	dw_i3c_reset(config, RESET_CTRL_FIFO_QUEUE);
 	sys_write32(INTR_TRANSFER_ERR_STAT | INTR_TRANSFER_ABORT_STAT, config->regs + INTR_STATUS);
 	sys_write32(sys_read32(config->regs + DEVICE_CTRL) | DEV_CTRL_RESUME,
@@ -680,10 +750,12 @@ static void dw_i3c_process_response(const struct device *dev, uint32_t resp)
 	struct dw_i3c_cmd *cmd;
 	uint8_t tid = RESPONSE_PORT_TID(resp);
 
-	if (tid == 0xf) {
+	if (tid > DW_I3C_TID_USER_MAX) {
 #if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)
-		data->deftgts_count = RESPONSE_PORT_DATA_LEN(resp);
-		k_work_submit(&data->deftgts_work);
+		if (tid == DW_I3C_TID_DEFSLVS) {
+			data->deftgts_count = RESPONSE_PORT_DATA_LEN(resp);
+			k_work_submit(&data->deftgts_work);
+		}
 #endif
 		return;
 	}
@@ -814,6 +886,7 @@ static void start_xfer(const struct device *dev)
 
 	/* Cap at the FIFO depth; dw_i3c_end_xfer() re-arms for any remainder */
 	xfer->nresp_seen = 0;
+	xfer->cmd_idx = 0;
 	xfer->ret = 0;
 	thld_ctrl = sys_read32(config->regs + QUEUE_THLD_CTRL);
 	thld_ctrl &= ~QUEUE_THLD_CTRL_RESP_BUF_MASK;
@@ -821,13 +894,21 @@ static void start_xfer(const struct device *dev)
 	sys_write32(thld_ctrl, config->regs + QUEUE_THLD_CTRL);
 
 	/* Enqueue CMD */
-	for (i = 0; i < xfer->ncmds; i++) {
-		cmd = &xfer->cmds[i];
-		/* Only cmd_lo is used when it is a target */
-		if (dw_i3c_is_current_controller(dev)) {
-			sys_write32(cmd->cmd_hi, config->regs + COMMAND_QUEUE_PORT);
+	if (dw_i3c_is_current_controller(dev)) {
+		if (!dw_i3c_cmd_write_to_cmd_fifo(dev)) {
+			thld_ctrl = sys_read32(config->regs + QUEUE_THLD_CTRL);
+			thld_ctrl &= ~QUEUE_THLD_CTRL_CMD_EMPTY_BUF_MASK;
+			thld_ctrl |= QUEUE_THLD_CTRL_CMD_EMPTY_BUF(COMMAND_QUEUE_DWORDS_PER_CMD);
+			sys_write32(thld_ctrl, config->regs + QUEUE_THLD_CTRL);
+
+			dw_i3c_intr_enable(config, INTR_CMD_QUEUE_READY_STAT);
 		}
-		sys_write32(cmd->cmd_lo, config->regs + COMMAND_QUEUE_PORT);
+	} else {
+		/* Only cmd_lo is used when it is a target */
+		for (i = 0; i < xfer->ncmds; i++) {
+			cmd = &xfer->cmds[i];
+			sys_write32(cmd->cmd_lo, config->regs + COMMAND_QUEUE_PORT);
+		}
 	}
 }
 #ifdef CONFIG_I3C_CONTROLLER
@@ -906,7 +987,7 @@ static int dw_i3c_xfers(const struct device *dev, struct i3c_device_desc *target
 		return -EACCES;
 	}
 
-	if (num_msgs > data->cmdfifodepth) {
+	if (num_msgs > DW_I3C_MAX_CMDS) {
 		return -ENOTSUP;
 	}
 
@@ -1129,7 +1210,7 @@ static int dw_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device_d
 		return -EACCES;
 	}
 
-	if (num_msgs > data->cmdfifodepth) {
+	if (num_msgs > DW_I3C_MAX_CMDS) {
 		return -ENOTSUP;
 	}
 
@@ -1690,6 +1771,16 @@ static int i3c_dw_irq(const struct device *dev)
 
 		if (status & INTR_TRANSFER_ERR_STAT) {
 			sys_write32(INTR_TRANSFER_ERR_STAT, config->regs + INTR_STATUS);
+		}
+	}
+
+	/*
+	 * CMD_QUEUE_READY tracks queue occupancy and cannot be cleared by writing the status
+	 * bit, so mask against the enable register to tell an armed refill from an idle queue.
+	 */
+	if (status & sys_read32(config->regs + INTR_STATUS_EN) & INTR_CMD_QUEUE_READY_STAT) {
+		if (dw_i3c_cmd_write_to_cmd_fifo(dev)) {
+			dw_i3c_intr_disable(config, INTR_CMD_QUEUE_READY_STAT);
 		}
 	}
 #ifdef CONFIG_I3C_CONTROLLER

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -149,6 +149,8 @@ LOG_MODULE_REGISTER(i3c_dw, CONFIG_I3C_DW_LOG_LEVEL);
 #define RESET_CTRL_RESP_QUEUE BIT(2)
 #define RESET_CTRL_CMD_QUEUE  BIT(1)
 #define RESET_CTRL_SOFT       BIT(0)
+#define RESET_CTRL_FIFO_QUEUE                                                                      \
+	(RESET_CTRL_RX_FIFO | RESET_CTRL_TX_FIFO | RESET_CTRL_RESP_QUEUE | RESET_CTRL_CMD_QUEUE)
 #define RESET_CTRL_ALL                                                                             \
 	(RESET_CTRL_IBI_QUEUE | RESET_CTRL_RX_FIFO | RESET_CTRL_TX_FIFO | RESET_CTRL_RESP_QUEUE |  \
 	 RESET_CTRL_CMD_QUEUE | RESET_CTRL_SOFT)
@@ -628,6 +630,21 @@ static void dw_i3c_deftgts_work_fn(struct k_work *work)
 }
 #endif /* CONFIG_I3C_CONTROLLER && CONFIG_I3C_TARGET */
 
+static void dw_i3c_reset(const struct dw_i3c_config *config, uint32_t mask)
+{
+	sys_write32(mask, config->regs + RESET_CTRL);
+	while ((sys_read32(config->regs + RESET_CTRL) & mask) != 0) {
+	}
+}
+
+static void dw_i3c_reset_fifos_and_queues(const struct dw_i3c_config *config)
+{
+	dw_i3c_reset(config, RESET_CTRL_FIFO_QUEUE);
+	sys_write32(INTR_TRANSFER_ERR_STAT | INTR_TRANSFER_ABORT_STAT, config->regs + INTR_STATUS);
+	sys_write32(sys_read32(config->regs + DEVICE_CTRL) | DEV_CTRL_RESUME,
+		    config->regs + DEVICE_CTRL);
+}
+
 /**
  * @brief End the I3C transfer and process responses.
  *
@@ -721,11 +738,7 @@ static void dw_i3c_end_xfer(const struct device *dev)
 	xfer->ret = ret;
 
 	if (ret < 0) {
-		sys_write32(RESET_CTRL_RX_FIFO | RESET_CTRL_TX_FIFO | RESET_CTRL_RESP_QUEUE |
-			    RESET_CTRL_CMD_QUEUE,
-			    config->regs + RESET_CTRL);
-		sys_write32(sys_read32(config->regs + DEVICE_CTRL) | DEV_CTRL_RESUME,
-			    config->regs + DEVICE_CTRL);
+		dw_i3c_reset_fifos_and_queues(config);
 	}
 	k_sem_give(&data->sem_xfer);
 }
@@ -746,6 +759,8 @@ static void start_xfer(const struct device *dev)
 	struct dw_i3c_cmd *cmd;
 	uint32_t thld_ctrl;
 	int32_t i;
+
+	k_sem_reset(&data->sem_xfer);
 
 	/* Push data to TXFIFO */
 	for (i = 0; i < xfer->ncmds; i++) {
@@ -772,6 +787,28 @@ static void start_xfer(const struct device *dev)
 	}
 }
 #ifdef CONFIG_I3C_CONTROLLER
+/**
+ * @brief Wait for the running transfer to complete.
+ *
+ * @param dev Pointer to the I3C device structure.
+ *
+ * @retval 0 if the transfer completed.
+ * @retval -ETIMEDOUT if it did not complete in time.
+ */
+static int dw_i3c_wait_for_xfer(const struct device *dev)
+{
+	const struct dw_i3c_config *config = dev->config;
+	struct dw_i3c_data *data = dev->data;
+
+	if (k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS)) != 0) {
+		LOG_ERR("%s: Transfer timeout", dev->name);
+		dw_i3c_reset_fifos_and_queues(config);
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
 /**
  * @brief Get the position of an I3C device with the specified address.
  *
@@ -858,7 +895,6 @@ static int dw_i3c_xfers(const struct device *dev, struct i3c_device_desc *target
 	memset(xfer, 0, sizeof(struct dw_i3c_xfer));
 
 	xfer->ncmds = num_msgs;
-	xfer->ret = -1;
 
 	for (i = 0; i < num_msgs; i++) {
 		struct dw_i3c_cmd *cmd = &xfer->cmds[i];
@@ -968,9 +1004,8 @@ static int dw_i3c_xfers(const struct device *dev, struct i3c_device_desc *target
 
 	start_xfer(dev);
 
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
+	ret = dw_i3c_wait_for_xfer(dev);
 	if (ret) {
-		LOG_ERR("%s: Semaphore err (%d)", dev->name, ret);
 		goto error;
 	}
 
@@ -1088,7 +1123,6 @@ static int dw_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device_d
 	memset(xfer, 0, sizeof(struct dw_i3c_xfer));
 
 	xfer->ncmds = num_msgs;
-	xfer->ret = -1;
 
 	for (i = 0; i < num_msgs; i++) {
 		struct dw_i3c_cmd *cmd = &xfer->cmds[i];
@@ -1125,9 +1159,8 @@ static int dw_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device_d
 
 	start_xfer(dev);
 
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
+	ret = dw_i3c_wait_for_xfer(dev);
 	if (ret) {
-		LOG_ERR("%s: Semaphore err (%d)", dev->name, ret);
 		goto error;
 	}
 
@@ -1990,7 +2023,6 @@ static int dw_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *paylo
 	pm_device_busy_set(dev);
 
 	memset(xfer, 0, sizeof(struct dw_i3c_xfer));
-	xfer->ret = -1;
 
 	/* in the case of multiple targets in a CCC, each command queue must have the same CCC ID
 	 * loaded along with different dev index fields pointing to the targets
@@ -2060,9 +2092,8 @@ static int dw_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *paylo
 
 	start_xfer(dev);
 
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
+	ret = dw_i3c_wait_for_xfer(dev);
 	if (ret) {
-		LOG_ERR("%s: Semaphore err (%d)", dev->name, ret);
 		goto error;
 	}
 
@@ -2271,7 +2302,6 @@ static int dw_i3c_do_daa(const struct device *dev)
 	memset(xfer, 0, sizeof(struct dw_i3c_xfer));
 
 	xfer->ncmds = 1;
-	xfer->ret = -1;
 
 	cmd = &xfer->cmds[0];
 	cmd->cmd_hi = COMMAND_PORT_TRANSFER_ARG;
@@ -2280,13 +2310,12 @@ static int dw_i3c_do_daa(const struct device *dev)
 		      COMMAND_PORT_CMD(I3C_CCC_ENTDAA) | COMMAND_PORT_ADDR_ASSGN_CMD;
 
 	start_xfer(dev);
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
+	ret = dw_i3c_wait_for_xfer(dev);
 
 	pm_device_busy_clear(dev);
 	k_mutex_unlock(&data->mt);
 
 	if (ret) {
-		LOG_ERR("%s: Semaphore err (%d)", dev->name, ret);
 		return ret;
 	}
 
@@ -2565,10 +2594,7 @@ static int dw_i3c_recover_bus(const struct device *dev)
 	/* Flush command / response / data FIFOs and the IBI queue.
 	 * Crucially, SOFT reset is NOT asserted here — DAT/DCT survive.
 	 */
-	sys_write32(RESET_CTRL_RX_FIFO | RESET_CTRL_TX_FIFO |
-		    RESET_CTRL_RESP_QUEUE | RESET_CTRL_CMD_QUEUE |
-		    RESET_CTRL_IBI_QUEUE,
-		    config->regs + RESET_CTRL);
+	dw_i3c_reset(config, RESET_CTRL_FIFO_QUEUE | RESET_CTRL_IBI_QUEUE);
 
 	/* Resume controller from any halt state caused by a prior error. */
 	sys_write32(sys_read32(config->regs + DEVICE_CTRL) | DEV_CTRL_RESUME,

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2049,6 +2049,12 @@ static int dw_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *paylo
 			ret = -EINVAL;
 			goto error;
 		}
+		if (payload->targets.num_targets > DW_I3C_MAX_CMD_BUF_SIZE) {
+			LOG_ERR("%s: %zu CCC targets exceeds %d", dev->name,
+				payload->targets.num_targets, DW_I3C_MAX_CMD_BUF_SIZE);
+			ret = -ENOTSUP;
+			goto error;
+		}
 		xfer->ncmds = payload->targets.num_targets;
 		for (i = 0; i < payload->targets.num_targets; i++) {
 			cmd = &xfer->cmds[i];

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -395,6 +395,7 @@ struct dw_i3c_cmd {
 struct dw_i3c_xfer {
 	int32_t ret;
 	uint32_t ncmds;
+	uint32_t nresp_seen;
 	struct dw_i3c_cmd cmds[DW_I3C_MAX_CMD_BUF_SIZE];
 };
 
@@ -645,102 +646,142 @@ static void dw_i3c_reset_fifos_and_queues(const struct dw_i3c_config *config)
 		    config->regs + DEVICE_CTRL);
 }
 
+static int dw_i3c_resp_err_to_errno(uint8_t error)
+{
+	switch (error) {
+	case RESPONSE_NO_ERROR:
+		return 0;
+	case RESPONSE_ERROR_PARITY:
+	case RESPONSE_ERROR_IBA_NACK:
+	case RESPONSE_ERROR_TRANSF_ABORT:
+	case RESPONSE_ERROR_CRC:
+	case RESPONSE_ERROR_FRAME:
+		return -EIO;
+	case RESPONSE_ERROR_OVER_UNDER_FLOW:
+		return -ENOSPC;
+	case RESPONSE_ERROR_I2C_W_NACK_ERR:
+	case RESPONSE_ERROR_ADDRESS_NACK:
+		return -ENXIO;
+	default:
+		return -EINVAL;
+	}
+}
+
 /**
- * @brief End the I3C transfer and process responses.
- *
- * This function is responsible for ending the I3C transfer on the specified
- * I3C device. It processes the responses received from the I3C bus, updating the
- * status and error information in the transfer structure.
+ * @brief Consume one response word and record its result against the owning command.
  *
  * @param dev Pointer to the I3C device structure.
+ * @param resp Raw word read from RESPONSE_QUEUE_PORT.
  */
-static void dw_i3c_end_xfer(const struct device *dev)
+static void dw_i3c_process_response(const struct device *dev, uint32_t resp)
+{
+	struct dw_i3c_data *data = dev->data;
+	struct dw_i3c_xfer *xfer = &data->xfer;
+	struct dw_i3c_cmd *cmd;
+	uint8_t tid = RESPONSE_PORT_TID(resp);
+
+	if (tid == 0xf) {
+#if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)
+		data->deftgts_count = RESPONSE_PORT_DATA_LEN(resp);
+		k_work_submit(&data->deftgts_work);
+#endif
+		return;
+	}
+
+	cmd = &xfer->cmds[tid];
+	cmd->rx_len = RESPONSE_PORT_DATA_LEN(resp);
+	cmd->error = RESPONSE_PORT_ERR_STATUS(resp);
+#ifdef CONFIG_I3C_TARGET
+	/* if we are in target mode */
+	if (!dw_i3c_is_current_controller(dev)) {
+		const struct dw_i3c_config *config = dev->config;
+		const struct i3c_target_callbacks *target_cb = data->target_config->callbacks;
+		uint32_t rx_data;
+		int j, k;
+
+		for (j = 0; j < cmd->rx_len; j += 4) {
+			rx_data = sys_read32(config->regs + RX_TX_DATA_PORT);
+			if (target_cb == NULL || target_cb->write_received_cb == NULL) {
+				continue;
+			}
+			/* Call write received cb for each remaining byte */
+			for (k = 0; k < MIN(4, cmd->rx_len - j); k++) {
+				target_cb->write_received_cb(data->target_config,
+							     (rx_data >> (8 * k)) & 0xff);
+			}
+		}
+
+		if (target_cb != NULL && target_cb->stop_cb != NULL) {
+			/*
+			 * TODO: modify API to include status, such as success or aborted
+			 * transfer
+			 */
+			target_cb->stop_cb(data->target_config);
+		}
+	}
+#endif /* CONFIG_I3C_TARGET */
+
+	xfer->nresp_seen++;
+	if (cmd->error != RESPONSE_NO_ERROR && xfer->ret == 0) {
+		xfer->ret = dw_i3c_resp_err_to_errno(cmd->error);
+	}
+}
+
+/**
+ * @brief Drain the response queue and, once complete, end the I3C transfer.
+ *
+ * The response FIFO can be shallower than the command FIFO, so the responses for a long
+ * transfer arrive across several RESP_READY interrupts.
+ *
+ * @param dev Pointer to the I3C device structure.
+ * @param xfer_err True if a transfer-error interrupt triggered this.
+ */
+static void dw_i3c_end_xfer(const struct device *dev, bool xfer_err)
 {
 	const struct dw_i3c_config *config = dev->config;
 	struct dw_i3c_data *data = dev->data;
 	struct dw_i3c_xfer *xfer = &data->xfer;
-	struct dw_i3c_cmd *cmd;
-	uint32_t nresp, resp;
-	int i, ret = 0;
-#ifdef CONFIG_I3C_TARGET
-	uint32_t rx_data;
-	int j, k;
-#endif /* CONFIG_I3C_TARGET */
+	uint32_t nresp, remaining, thld_ctrl;
+	int i;
 
-	nresp = QUEUE_STATUS_LEVEL_RESP(sys_read32(config->regs + QUEUE_STATUS_LEVEL));
-	for (i = 0; i < nresp; i++) {
-		uint8_t tid;
-
-		resp = sys_read32(config->regs + RESPONSE_QUEUE_PORT);
-		tid = RESPONSE_PORT_TID(resp);
-		if (tid == 0xf) {
-#if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_TARGET)
-			data->deftgts_count = RESPONSE_PORT_DATA_LEN(resp);
-			k_work_submit(&data->deftgts_work);
-#endif
-			continue;
+	for (;;) {
+		nresp = QUEUE_STATUS_LEVEL_RESP(sys_read32(config->regs + QUEUE_STATUS_LEVEL));
+		for (i = 0; i < nresp; i++) {
+			dw_i3c_process_response(dev,
+						sys_read32(config->regs + RESPONSE_QUEUE_PORT));
 		}
 
-		cmd = &xfer->cmds[tid];
-		cmd->rx_len = RESPONSE_PORT_DATA_LEN(resp);
-		cmd->error = RESPONSE_PORT_ERR_STATUS(resp);
-#ifdef CONFIG_I3C_TARGET
-		/* if we are in target mode */
-		if (!dw_i3c_is_current_controller(dev)) {
-			const struct i3c_target_callbacks *target_cb =
-				data->target_config->callbacks;
-
-			for (j = 0; j < cmd->rx_len; j += 4) {
-				rx_data = sys_read32(config->regs + RX_TX_DATA_PORT);
-				if (target_cb != NULL && target_cb->write_received_cb != NULL) {
-					/* Call write received cb for each remaining byte  */
-					for (k = 0; k < MIN(4, cmd->rx_len - j); k++) {
-						target_cb->write_received_cb(data->target_config,
-								(rx_data >> (8 * k)) & 0xff);
-					}
-				}
-			}
-
-			if (target_cb != NULL && target_cb->stop_cb != NULL) {
-				/*
-				 * TODO: modify API to include status, such as success or aborted
-				 * transfer
-				 */
-				target_cb->stop_cb(data->target_config);
-			}
+		/* A transfer error aborts the remaining commands */
+		if (xfer_err && xfer->ret == 0) {
+			xfer->ret = -EIO;
 		}
-#endif /* CONFIG_I3C_TARGET */
-	}
 
-	for (i = 0; i < nresp; i++) {
-		switch (xfer->cmds[i].error) {
-		case RESPONSE_NO_ERROR:
-			break;
-		case RESPONSE_ERROR_PARITY:
-		case RESPONSE_ERROR_IBA_NACK:
-		case RESPONSE_ERROR_TRANSF_ABORT:
-		case RESPONSE_ERROR_CRC:
-		case RESPONSE_ERROR_FRAME:
-			ret = -EIO;
-			break;
-		case RESPONSE_ERROR_OVER_UNDER_FLOW:
-			ret = -ENOSPC;
-			break;
-		case RESPONSE_ERROR_I2C_W_NACK_ERR:
-		case RESPONSE_ERROR_ADDRESS_NACK:
-			ret = -ENXIO;
-			break;
-		default:
-			ret = -EINVAL;
-			break;
+		if (xfer->ret != 0) {
+			dw_i3c_reset_fifos_and_queues(config);
+			k_sem_give(&data->sem_xfer);
+			return;
+		}
+
+		/* Also covers the ncmds == 0 target path */
+		if (xfer->nresp_seen >= xfer->ncmds) {
+			k_sem_give(&data->sem_xfer);
+			return;
+		}
+
+		/*
+		 * Re-arm for the remainder, then re-check occupancy: a response arriving
+		 * mid-drain would not re-assert the level-sensitive interrupt.
+		 */
+		remaining = xfer->ncmds - xfer->nresp_seen;
+		thld_ctrl = sys_read32(config->regs + QUEUE_THLD_CTRL);
+		thld_ctrl &= ~QUEUE_THLD_CTRL_RESP_BUF_MASK;
+		thld_ctrl |= QUEUE_THLD_CTRL_RESP_BUF(MIN(remaining, data->respfifodepth));
+		sys_write32(thld_ctrl, config->regs + QUEUE_THLD_CTRL);
+
+		if (QUEUE_STATUS_LEVEL_RESP(sys_read32(config->regs + QUEUE_STATUS_LEVEL)) == 0) {
+			return;
 		}
 	}
-	xfer->ret = ret;
-
-	if (ret < 0) {
-		dw_i3c_reset_fifos_and_queues(config);
-	}
-	k_sem_give(&data->sem_xfer);
 }
 
 /**
@@ -771,9 +812,12 @@ static void start_xfer(const struct device *dev)
 		}
 	}
 
+	/* Cap at the FIFO depth; dw_i3c_end_xfer() re-arms for any remainder */
+	xfer->nresp_seen = 0;
+	xfer->ret = 0;
 	thld_ctrl = sys_read32(config->regs + QUEUE_THLD_CTRL);
 	thld_ctrl &= ~QUEUE_THLD_CTRL_RESP_BUF_MASK;
-	thld_ctrl |= QUEUE_THLD_CTRL_RESP_BUF(xfer->ncmds);
+	thld_ctrl |= QUEUE_THLD_CTRL_RESP_BUF(MIN(xfer->ncmds, data->respfifodepth));
 	sys_write32(thld_ctrl, config->regs + QUEUE_THLD_CTRL);
 
 	/* Enqueue CMD */
@@ -1642,7 +1686,7 @@ static int i3c_dw_irq(const struct device *dev)
 
 	status = sys_read32(config->regs + INTR_STATUS);
 	if (status & (INTR_TRANSFER_ERR_STAT | INTR_RESP_READY_STAT)) {
-		dw_i3c_end_xfer(dev);
+		dw_i3c_end_xfer(dev, (status & INTR_TRANSFER_ERR_STAT) != 0);
 
 		if (status & INTR_TRANSFER_ERR_STAT) {
 			sys_write32(INTR_TRANSFER_ERR_STAT, config->regs + INTR_STATUS);


### PR DESCRIPTION
Every command was written up front, so a transfer was capped at what the Command Queue holds. A controller command occupies two DWORDs, cmd_hi then cmd_lo, so a Command Queue of eight DWORDs only fits four messages. Write as many whole commands as currently fit and let CMD_QUEUE_READY refill the queue from the ISR as the controller drains it, which also keeps it fed past the point where the controller stalls SCL waiting for the next command. Payload is still bounded by the txfifodepth and rxfifodepth checks.

The response-ready threshold was set to the full command count, but the field is a FIFO occupancy level, so any transfer with more commands than the response FIFO holds stalled until the timeout. The command FIFO guard does not cover this, as the two depths are synthesised independently. Drain the responses across several interrupts instead, completing only once every command is accounted for.
