### PR TITLE
net: sntp: reject a precision exponent that would shift past the type

### DIFF
--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -132,13 +132,18 @@ static int32_t parse_response(uint8_t *data, uint16_t len, struct sntp_time *exp
 	int64_t root_delay_us = q16_16_s_to_ll_us(net_ntohl(pkt->root_delay));
 	uint32_t precision_us;
 
-	if (pkt->precision <= 0) {
-		precision_us = (uint32_t)(USEC_PER_SEC + USEC_PER_SEC / 2) >> -pkt->precision;
-	} else if (pkt->precision <= 10) {
-		precision_us = (uint32_t)(USEC_PER_SEC + USEC_PER_SEC / 2) << pkt->precision;
-	} else {
+	/* precision is a shift count on a 32-bit value; below -31 the
+	 * shift is undefined, and the expression already saturates to 0 us.
+	 */
+	if (pkt->precision < -31 || pkt->precision > 10) {
 		NET_DBG("SNTP packet precision out of range: %d", pkt->precision);
 		return -EINVAL;
+	}
+
+	if (pkt->precision <= 0) {
+		precision_us = (uint32_t)(USEC_PER_SEC + USEC_PER_SEC / 2) >> -pkt->precision;
+	} else {
+		precision_us = (uint32_t)(USEC_PER_SEC + USEC_PER_SEC / 2) << pkt->precision;
 	}
 
 	res->uptime_us = client_rx_us;

--- a/tests/net/lib/sntp/CMakeLists.txt
+++ b/tests/net/lib/sntp/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sntp)
+
+# For the on-the-wire layout the tests build their responses from.
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/lib/sntp)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/net/lib/sntp/prj.conf
+++ b/tests/net/lib/sntp/prj.conf
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+
+CONFIG_NETWORKING=y
+CONFIG_NET_IPV4=y
+CONFIG_NET_IPV6=n
+CONFIG_NET_UDP=y
+CONFIG_NET_SOCKETS=y
+
+# Needed for setup()'s SO_RCVTIMEO on the server socket; otherwise a no-op.
+CONFIG_NET_CONTEXT_RCVTIMEO=y
+
+# sntp_send_async() is the only exported way to reach sntp_query_send().
+CONFIG_NET_SOCKETS_SERVICE=y
+
+# Keeps QEMU boards on loopback instead of the SLIP driver, which needs
+# a host socket no test runner provides.
+CONFIG_NET_TEST=y
+CONFIG_NET_DRIVERS=y
+CONFIG_NET_LOOPBACK=y
+CONFIG_NET_L2_ETHERNET=n
+
+CONFIG_SNTP=y
+
+# The arithmetic under test is compiled only under this option.
+CONFIG_SNTP_UNCERTAINTY=y
+
+# Deliver the response in the sending context, so the parse has already
+# happened by the time a test asserts on it.
+CONFIG_NET_TC_RX_COUNT=0
+
+# Checksum is computed by the test's own sending socket, not the peer
+# whose fields are under test.
+CONFIG_NET_UDP_CHECKSUM=n
+
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+CONFIG_MAIN_STACK_SIZE=3072
+CONFIG_ZTEST_STACK_SIZE=3072

--- a/tests/net/lib/sntp/src/main.c
+++ b/tests/net/lib/sntp/src/main.c
@@ -1,0 +1,249 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Tests for what the SNTP client accepts and rejects in a server's response.
+ *
+ * parse_response() is static with no test-only export, so it is reached
+ * the way a client reaches it: bind to the SNTP port on loopback, let
+ * the client run a real sntp_init()/sntp_send_async(), read its request
+ * to learn the ephemeral port, and answer with a built response.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/sntp.h>
+#include <zephyr/ztest.h>
+
+#include "sntp_pkt.h"
+
+#define SNTP_PORT 123
+
+#define MODE_CLIENT 3
+#define MODE_SERVER 4
+#define VERSION     4
+
+/* Seconds between the NTP epoch and 1 Jan 1970, which parse_response()
+ * subtracts when the transmit timestamp's top bit is set.
+ */
+#define OFFSET_1970_JAN_1 2208988800U
+
+/* The loopback datagram is delivered inside zsock_sendto(), so it is
+ * already waiting by the time the client polls for it.
+ */
+#define RECV_TIMEOUT_MS 100
+
+static int server_fd = -1;
+
+/* A well-formed response; a test overrides only the field it exercises.
+ * The originate timestamp is left zero, filled in by exchange().
+ */
+static struct sntp_pkt response_template(void)
+{
+	struct sntp_pkt pkt = {0};
+
+	pkt.li = 0;
+	pkt.vn = VERSION;
+	pkt.mode = MODE_SERVER;
+	pkt.stratum = 2;
+	pkt.poll = 4;
+	pkt.precision = -6;
+	pkt.rx_tm_s = net_htonl(OFFSET_1970_JAN_1);
+	pkt.tx_tm_s = net_htonl(OFFSET_1970_JAN_1 + 1);
+
+	return pkt;
+}
+
+/* Run one query/response exchange. echo_originate false leaves the
+ * originate timestamp as the caller set it, to test the replay check.
+ */
+static int exchange(struct sntp_pkt *response, bool echo_originate, struct sntp_time *ts)
+{
+	struct net_sockaddr_in server = {
+		.sin_family = NET_AF_INET,
+		.sin_port = net_htons(SNTP_PORT),
+		.sin_addr = {{{127, 0, 0, 1}}},
+	};
+	struct net_sockaddr_in client;
+	net_socklen_t client_len = sizeof(client);
+	struct sntp_pkt request;
+	struct sntp_ctx ctx;
+	int ret;
+
+	ret = sntp_init(&ctx, (struct net_sockaddr *)&server, sizeof(server));
+	zassert_ok(ret, "sntp_init failed: %d", ret);
+
+	ret = sntp_send_async(&ctx);
+	zassert_ok(ret, "sntp_send_async failed: %d", ret);
+
+	ret = zsock_recvfrom(server_fd, &request, sizeof(request), 0,
+			     (struct net_sockaddr *)&client, &client_len);
+	zassert_equal(ret, (int)sizeof(request), "no request from the client: %d", ret);
+
+	if (echo_originate) {
+		response->orig_tm_s = net_htonl((uint32_t)ctx.expected_orig_ts.seconds);
+		response->orig_tm_f = net_htonl(ctx.expected_orig_ts.fraction);
+	}
+
+	ret = zsock_sendto(server_fd, response, sizeof(*response), 0,
+			   (struct net_sockaddr *)&client, client_len);
+	zassert_equal(ret, (int)sizeof(*response), "could not send the response: %d", ret);
+
+	ret = sntp_recv_response(&ctx, RECV_TIMEOUT_MS, ts);
+
+	sntp_close(&ctx);
+
+	return ret;
+}
+
+static int query_with_precision(int8_t precision)
+{
+	struct sntp_pkt response = response_template();
+	struct sntp_time ts;
+
+	response.precision = precision;
+
+	return exchange(&response, true, &ts);
+}
+
+/* precision is a shift count on a 32-bit value; checks both range
+ * boundaries, one step to either side.
+ */
+ZTEST(sntp_response, test_precision_range)
+{
+	zassert_ok(query_with_precision(0), "precision 0 should be accepted");
+	zassert_ok(query_with_precision(-6), "precision -6 should be accepted");
+	zassert_ok(query_with_precision(-31), "precision -31 should be accepted");
+	zassert_ok(query_with_precision(10), "precision 10 should be accepted");
+
+	zassert_equal(query_with_precision(-32), -EINVAL,
+		      "precision -32 shifts by the width of the type");
+	zassert_equal(query_with_precision(INT8_MIN), -EINVAL,
+		      "precision -128 shifts past the width of the type");
+	zassert_equal(query_with_precision(11), -EINVAL,
+		      "precision 11 is above the range the client accepts");
+	zassert_equal(query_with_precision(INT8_MAX), -EINVAL,
+		      "precision 127 is above the range the client accepts");
+}
+
+ZTEST(sntp_response, test_well_formed_response_is_accepted)
+{
+	struct sntp_pkt response = response_template();
+	/* A sentinel rather than a zero-initializer: uptime 0 is a valid
+	 * reading, so only "the field changed" proves it was populated.
+	 */
+	struct sntp_time ts = {.uptime_us = UINT64_MAX};
+
+	zassert_ok(exchange(&response, true, &ts), "a valid response was rejected");
+	zassert_not_equal(ts.uptime_us, UINT64_MAX, "the uptime timestamp was not filled in");
+}
+
+/* A stratum of zero is a kiss-o'-death packet: the server is telling
+ * the client to stop asking, not reporting a time.
+ */
+ZTEST(sntp_response, test_kiss_o_death_is_rejected)
+{
+	struct sntp_pkt response = response_template();
+	struct sntp_time ts;
+
+	response.stratum = 0;
+
+	zassert_equal(exchange(&response, true, &ts), -EBUSY, "kiss-o'-death was not reported");
+}
+
+ZTEST(sntp_response, test_non_server_mode_is_rejected)
+{
+	struct sntp_pkt response = response_template();
+	struct sntp_time ts;
+
+	response.mode = MODE_CLIENT;
+
+	zassert_equal(exchange(&response, true, &ts), -EINVAL,
+		      "a response in client mode was accepted");
+}
+
+ZTEST(sntp_response, test_zero_transmit_timestamp_is_rejected)
+{
+	struct sntp_pkt response = response_template();
+	struct sntp_time ts;
+
+	response.tx_tm_s = 0;
+	response.tx_tm_f = 0;
+
+	zassert_equal(exchange(&response, true, &ts), -EINVAL,
+		      "a response with no transmit timestamp was accepted");
+}
+
+/* The originate timestamp is the client's own transmit timestamp echoed
+ * back, and a response that does not carry it belongs to some other
+ * exchange.
+ */
+ZTEST(sntp_response, test_originate_timestamp_must_match)
+{
+	struct sntp_pkt response = response_template();
+	struct sntp_time ts;
+
+	response.orig_tm_s = net_htonl(1);
+	response.orig_tm_f = net_htonl(1);
+
+	zassert_equal(exchange(&response, false, &ts), -ERANGE,
+		      "a response for another exchange was accepted");
+}
+
+/* The server claims to have sent its answer before the request reached
+ * it, which makes the round-trip computation meaningless.
+ */
+ZTEST(sntp_response, test_reversed_server_timestamps_are_rejected)
+{
+	struct sntp_pkt response = response_template();
+	struct sntp_time ts;
+
+	response.rx_tm_s = net_htonl(OFFSET_1970_JAN_1 + 100);
+	response.tx_tm_s = net_htonl(OFFSET_1970_JAN_1 + 1);
+
+	zassert_equal(exchange(&response, true, &ts), -EINVAL,
+		      "reversed server timestamps were accepted");
+}
+
+static void *setup(void)
+{
+	struct net_sockaddr_in addr = {
+		.sin_family = NET_AF_INET,
+		.sin_port = net_htons(SNTP_PORT),
+		.sin_addr = {{{127, 0, 0, 1}}},
+	};
+	/* Bounds the server's wait for the client's request, so a client
+	 * that fails to send fails the test instead of hanging the run.
+	 */
+	struct timeval timeout = {.tv_sec = 1, .tv_usec = 0};
+
+	server_fd = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(server_fd >= 0, "could not open the server socket");
+
+	zassert_ok(zsock_bind(server_fd, (struct net_sockaddr *)&addr, sizeof(addr)),
+		   "could not bind the server socket");
+
+	zassert_ok(zsock_setsockopt(server_fd, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVTIMEO, &timeout,
+				     sizeof(timeout)),
+		   "could not set the server socket's receive timeout");
+
+	return NULL;
+}
+
+static void teardown(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	(void)zsock_close(server_fd);
+	server_fd = -1;
+}
+
+ZTEST_SUITE(sntp_response, NULL, setup, NULL, NULL, teardown);

--- a/tests/net/lib/sntp/tests.yaml
+++ b/tests/net/lib/sntp/tests.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Dev It Wise
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  depends_on: netif
+  tags:
+    - net
+    - sntp
+tests:
+  net.sntp:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - qemu_x86
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
The `precision` field of an SNTP response is a signed exponent taken straight off the wire and used as a shift count on a 32-bit value. The upper end of that expression is range-checked; the lower end is not, so an exponent of -32 or below shifts by at least the width of the type, which is undefined behavior. Any time server the device talks to can send one.

The first commit bounds the lower end at the largest exponent that still shifts inside the type. Nothing is lost by rejecting the rest: 1.5 s shifted right by 31 is already 0 us.

The second commit adds a test suite, since nothing under `tests/` currently exercises SNTP beyond a sample that needs a real time server. `parse_response()` is static, so the tests reach it as a client would: over a loopback socket, answering the client's own request. Seven cases cover the precision range around both boundaries, the kiss-o'-death stratum, client-mode response, a zero transmit timestamp, reversed server timestamps, and an originate timestamp from another exchange.

Reverting the first commit turns exactly one of the seven cases red.
