### PR TITLE
drivers: intc: irqmp: namespace the driver API

### DIFF
--- a/arch/sparc/core/irq_manage.c
+++ b/arch/sparc/core/irq_manage.c
@@ -33,7 +33,7 @@ void z_sparc_enter_irq(uint32_t irl)
 
 #ifdef CONFIG_IRQ_OFFLOAD
 	if (irl != 141U) {
-		irl = z_sparc_int_get_source(irl);
+		irl = intc_irqmp_get_source(irl);
 		ite = &_sw_isr_table[irl];
 		ite->isr(ite->arg);
 	} else {
@@ -41,7 +41,7 @@ void z_sparc_enter_irq(uint32_t irl)
 	}
 #else
 	/* Get the actual interrupt source from the interrupt controller */
-	irl = z_sparc_int_get_source(irl);
+	irl = intc_irqmp_get_source(irl);
 	ite = &_sw_isr_table[irl];
 	ite->isr(ite->arg);
 #endif

--- a/arch/sparc/core/irq_manage.c
+++ b/arch/sparc/core/irq_manage.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/interrupt_controller/intc_irqmp.h>
 #include <kernel_internal.h>
 #include <kswap.h>
 #include <zephyr/logging/log.h>
@@ -50,3 +51,27 @@ void z_sparc_enter_irq(uint32_t irl)
 	z_check_stack_sentinel();
 #endif
 }
+
+#ifdef CONFIG_LEON_IRQMP
+/*
+ * The SPARC port assumes an IRQMP-style interrupt controller: the trap
+ * path above already queries it for the interrupt source. Map the
+ * architecture interrupt control functions to the IRQMP driver here so
+ * every SoC using it gets them; an SoC with a different controller
+ * provides its own implementation instead.
+ */
+void arch_irq_enable(unsigned int irq)
+{
+	intc_irqmp_irq_enable(irq);
+}
+
+void arch_irq_disable(unsigned int irq)
+{
+	intc_irqmp_irq_disable(irq);
+}
+
+int arch_irq_is_enabled(unsigned int irq)
+{
+	return intc_irqmp_irq_is_enabled(irq);
+}
+#endif /* CONFIG_LEON_IRQMP */

--- a/drivers/interrupt_controller/intc_irqmp.c
+++ b/drivers/interrupt_controller/intc_irqmp.c
@@ -17,6 +17,7 @@
 #define DT_DRV_COMPAT gaisler_irqmp
 
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/interrupt_controller/intc_irqmp.h>
 #include <zephyr/device.h>
 
 /*
@@ -58,7 +59,7 @@ static int get_irqmp_eirq(void)
 	return DT_INST_PROP(0, eirq);
 }
 
-void arch_irq_enable(unsigned int source)
+void intc_irqmp_irq_enable(unsigned int source)
 {
 	volatile struct irqmp_regs *regs = get_irqmp_regs();
 	volatile uint32_t *pimask = &regs->pimask[0];
@@ -70,7 +71,7 @@ void arch_irq_enable(unsigned int source)
 	arch_irq_unlock(key);
 }
 
-void arch_irq_disable(unsigned int source)
+void intc_irqmp_irq_disable(unsigned int source)
 {
 	volatile struct irqmp_regs *regs = get_irqmp_regs();
 	volatile uint32_t *pimask = &regs->pimask[0];
@@ -82,7 +83,7 @@ void arch_irq_disable(unsigned int source)
 	arch_irq_unlock(key);
 }
 
-int arch_irq_is_enabled(unsigned int source)
+int intc_irqmp_irq_is_enabled(unsigned int source)
 {
 	volatile struct irqmp_regs *regs = get_irqmp_regs();
 	volatile uint32_t *pimask = &regs->pimask[0];

--- a/drivers/interrupt_controller/intc_irqmp.c
+++ b/drivers/interrupt_controller/intc_irqmp.c
@@ -91,7 +91,7 @@ int intc_irqmp_irq_is_enabled(unsigned int source)
 	return !!(*pimask & (1U << source));
 }
 
-int z_sparc_int_get_source(int irl)
+int intc_irqmp_get_source(int irl)
 {
 	volatile struct irqmp_regs *regs = get_irqmp_regs();
 	const int eirq = get_irqmp_eirq();

--- a/include/zephyr/arch/sparc/arch.h
+++ b/include/zephyr/arch/sparc/arch.h
@@ -53,7 +53,6 @@ extern "C" {
  * (1..15) to logical interrupt source number. For example by probing the
  * interrupt controller.
  */
-int z_sparc_int_get_source(int irl);
 void z_irq_spurious(const void *unused);
 
 

--- a/include/zephyr/drivers/interrupt_controller/intc_irqmp.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_irqmp.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief GRLIB IRQMP interrupt controller driver API
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_INTC_IRQMP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_INTC_IRQMP_H_
+
+/**
+ * @brief Enable an interrupt source
+ *
+ * @param source Interrupt source number
+ */
+void intc_irqmp_irq_enable(unsigned int source);
+
+/**
+ * @brief Disable an interrupt source
+ *
+ * @param source Interrupt source number
+ */
+void intc_irqmp_irq_disable(unsigned int source);
+
+/**
+ * @brief Get the enable state of an interrupt source
+ *
+ * @param source Interrupt source number
+ *
+ * @return 1 if the interrupt source is enabled, 0 otherwise
+ */
+int intc_irqmp_irq_is_enabled(unsigned int source);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_INTC_IRQMP_H_ */

--- a/include/zephyr/drivers/interrupt_controller/intc_irqmp.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_irqmp.h
@@ -34,4 +34,16 @@ void intc_irqmp_irq_disable(unsigned int source);
  */
 int intc_irqmp_irq_is_enabled(unsigned int source);
 
+/**
+ * @brief Get the interrupt source behind a processor interrupt request
+ *
+ * Acknowledges interrupt request level @a irl and returns the actual
+ * interrupt source, taking IRQMP extended interrupts into account.
+ *
+ * @param irl Processor interrupt request level
+ *
+ * @return Interrupt source number
+ */
+int intc_irqmp_get_source(int irl);
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_INTC_IRQMP_H_ */


### PR DESCRIPTION
The IRQMP driver defines arch_irq_enable(), arch_irq_disable() and
arch_irq_is_enabled() directly. Interrupt controller drivers should
only expose their own namespaced API; providing the architecture
interrupt control functions is platform glue and does not belong in
a driver.

Rename the functions to intc_irqmp_irq_* and declare them in a
driver header. The arch_irq_* mapping goes into the SPARC arch
layer, not the SoCs: the port is already coupled to an IRQMP-style
controller -- the interrupt trap path queries it for the interrupt
source -- and every SPARC SoC uses it, so mapping it once in
arch/sparc/core/irq_manage.c under CONFIG_LEON_IRQMP serves all of
them. An SoC with a different controller can leave the option
disabled and provide its own implementation.
