### PR TITLE
tests: bit_rev: limit filter to select arm/riscv platforms

### DIFF
--- a/tests/lib/bit_rev/tests.yaml
+++ b/tests/lib/bit_rev/tests.yaml
@@ -15,6 +15,7 @@ tests:
   libraries.bit_rev.llvm:
     integration_toolchains:
       - zephyr/llvm
-    arch_allow:
-      - arm
-      - arm64
+    platform_allow:
+      - mps2/an385
+      - qemu_cortex_a9
+      - qemu_riscv32e


### PR DESCRIPTION
Building with llvm is not yet fully supported on all platforms, limit
this test to qemu platforms we know to work with llvm.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
