### PR TITLE
modem: ppp: full carrier state control

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1767,7 +1767,6 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
-		net_if_carrier_off(modem_ppp_get_iface(config->ppp));
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
 		break;
 	case MODEM_CELLULAR_EVENT_RING:
@@ -1860,7 +1859,6 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
-		net_if_carrier_off(modem_ppp_get_iface(config->ppp));
 		modem_chat_release(&data->chat);
 		modem_ppp_release(config->ppp);
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
@@ -1921,7 +1919,6 @@ static int modem_cellular_on_await_ppp_dead_state_leave(struct modem_cellular_da
 {
 	const struct modem_cellular_config *config = data->dev->config;
 
-	net_if_carrier_off(modem_ppp_get_iface(config->ppp));
 	modem_chat_release(&data->chat);
 	modem_ppp_release(config->ppp);
 

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -236,7 +236,7 @@ static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 				LOG_WRN("Received 'NO CARRIER' event");
 				ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
 				atomic_set_bit(&ppp->state, MODEM_PPP_STATE_DEAD_BIT);
-				/* TODO: Notify L2 PPP that link is dead */
+				net_if_carrier_off(ppp->iface);
 			}
 			break;
 		}
@@ -622,6 +622,7 @@ int modem_ppp_attach(struct modem_ppp *ppp, struct modem_pipe *pipe)
 
 	atomic_clear(&ppp->state);
 	atomic_set_bit(&ppp->state, MODEM_PPP_STATE_ATTACHED_BIT);
+	net_if_carrier_on(ppp->iface);
 	return 0;
 }
 
@@ -639,6 +640,7 @@ void modem_ppp_release(struct modem_ppp *ppp)
 		return;
 	}
 
+	net_if_carrier_off(ppp->iface);
 	modem_pipe_release(ppp->pipe);
 	k_work_cancel_sync(&ppp->send_work, &sync);
 	k_work_cancel_sync(&ppp->process_work, &sync);

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -393,45 +393,67 @@ ZTEST(modem_ppp, test_ppp_frame_receive)
 	put_and_validate_wrapped_frame();
 }
 
-ZTEST(modem_ppp, test_ppp_no_connect_received)
+ZTEST(modem_ppp, test_carrier_follows_attach_release)
 {
-	static const char *unsolicited_no_connect = "\r\nNO CARRIER\r\n";
+	/* Attached by the test fixture */
+	zassert_true(net_if_is_carrier_ok(&test_iface), "Carrier should be on while attached");
+
+	modem_ppp_release(&ppp);
+	zassert_false(net_if_is_carrier_ok(&test_iface), "Carrier should be off after release");
+
+	zassert_ok(modem_ppp_attach(&ppp, mock_pipe), "Failed to reattach PPP");
+	zassert_true(net_if_is_carrier_ok(&test_iface), "Carrier should be on after attach");
+}
+
+ZTEST(modem_ppp, test_ppp_no_carrier_received)
+{
+	static const char *unsolicited_no_carrier = "\r\nNO CARRIER\r\n";
 
 	/* Not dead to start with */
 	zassert_false(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
+	zassert_true(net_if_is_carrier_ok(&test_iface), "Carrier should be on before NO CARRIER");
 
 	/* Partial message doesn't result in anything */
-	modem_backend_mock_put(&mock, unsolicited_no_connect, strlen(unsolicited_no_connect) - 1);
+	modem_backend_mock_put(&mock, unsolicited_no_carrier, strlen(unsolicited_no_carrier) - 1);
 
 	/* Link continues to work */
 	put_and_validate_wrapped_frame();
+	zassert_true(net_if_is_carrier_ok(&test_iface),
+		     "Partial NO CARRIER should leave carrier on");
 
-	/* Put full 'NO CONNECT' message */
-	modem_backend_mock_put(&mock, unsolicited_no_connect, strlen(unsolicited_no_connect));
+	/* Put full 'NO CARRIER' message */
+	modem_backend_mock_put(&mock, unsolicited_no_carrier, strlen(unsolicited_no_carrier));
 
 	/* Give modem ppp time to process received frame */
 	k_msleep(1000);
 
 	/* Dead after receiving the 'NO CARRIER' message */
 	zassert_true(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
+	zassert_false(net_if_is_carrier_ok(&test_iface), "NO CARRIER should turn carrier off");
+	modem_ppp_release(&ppp);
+
+	zassert_ok(modem_ppp_attach(&ppp, mock_pipe), "Failed to reattach PPP");
+	zassert_true(net_if_is_carrier_ok(&test_iface), "Carrier should be on after attach");
+	zassert_false(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT), "Attach should clear dead state");
 }
 
-
-ZTEST(modem_ppp, test_ppp_no_connect_received_first)
+ZTEST(modem_ppp, test_ppp_no_carrier_received_first)
 {
-	static const char *unsolicited_no_connect = "\r\nNO CARRIER\r\n";
+	static const char *unsolicited_no_carrier = "\r\nNO CARRIER\r\n";
 
 	/* Not dead to start with */
 	zassert_false(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
+	zassert_true(net_if_is_carrier_ok(&test_iface), "Carrier should be on before NO CARRIER");
 
-	/* Put full 'NO CONNECT' message as first message on pipe */
-	modem_backend_mock_put(&mock, unsolicited_no_connect, strlen(unsolicited_no_connect));
+	/* Put full 'NO CARRIER' message as first message on pipe */
+	modem_backend_mock_put(&mock, unsolicited_no_carrier, strlen(unsolicited_no_carrier));
 
 	/* Give modem ppp time to process received frame */
 	k_msleep(1000);
 
 	/* Dead after receiving the 'NO CARRIER' message */
 	zassert_true(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
+	zassert_false(net_if_is_carrier_ok(&test_iface), "NO CARRIER should turn carrier off");
 }
 
 ZTEST(modem_ppp, test_corrupt_start_end_ppp_frame_receive)


### PR DESCRIPTION
Move the interface carrier state out of `modem_cellular` into `modem_ppp`, as the PPP module is the true "carrier" for the PPP networking interface.

Continuation from #107639