### PR TITLE
drivers: i2c: dw: fix remaining MMIO address truncation

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1381,7 +1381,7 @@ static int i2c_dw_probe_hw(const struct device *dev)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 	union ic_con_register ic_con;
-	uint32_t reg_base = DEVICE_MMIO_GET(dev);
+	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
 
 	if (read_comp_type(reg_base) != I2C_DW_MAGIC_KEY) {
 		LOG_DBG("I2C: DesignWare magic key not found, check base "


### PR DESCRIPTION
## Description

Follow up on #116179.

`i2c_dw_probe_hw()` still stores the result of `DEVICE_MMIO_GET()` in a
`uint32_t`, causing the MMIO base address to be truncated on 64-bit systems
when the controller is mapped above 4 GiB.

Use `mm_reg_t` for the remaining MMIO base address.

## Testing

Tested on a 64-bit RISC-V platform with the DesignWare I2C controller mapped
above 4 GiB.

This fixes an omission from #116179.