### PR TITLE
drivers: pwm: mcux_pwt: discard first incomplete capture

### DIFF
--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Vestas Wind Systems A/S
- * Copyright 2024 NXP
+ * Copyright 2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,6 +44,7 @@ struct mcux_pwt_data {
 	bool continuous : 1;
 	bool inverted : 1;
 	bool overflowed : 1;
+	bool skip_first: 1;
 };
 
 static inline bool mcux_pwt_is_active(const struct device *dev)
@@ -86,19 +87,6 @@ static int mcux_pwt_configure_capture(const struct device *dev,
 		return -EBUSY;
 	}
 
-#if defined(CONFIG_SOC_SERIES_KE1XZ)
-	if ((flags & PWM_CAPTURE_TYPE_MASK) == PWM_CAPTURE_TYPE_BOTH) {
-		LOG_ERR("Cannot capture both period and pulse width");
-		return -ENOTSUP;
-	}
-
-	if (((flags & PWM_CAPTURE_TYPE_MASK) == PWM_CAPTURE_TYPE_PERIOD) &&
-		((flags & PWM_POLARITY_MASK) == PWM_POLARITY_NORMAL)) {
-		LOG_ERR("Cannot capture period in normal polarity (active-high pulse)");
-		return -ENOTSUP;
-	}
-#endif
-
 	data->callback = cb;
 	data->user_data = user_data;
 
@@ -140,6 +128,7 @@ static int mcux_pwt_enable_capture(const struct device *dev, uint32_t channel)
 	data->overflowed = false;
 	data->high_overflows = 0;
 	data->low_overflows = 0;
+	data->skip_first = true;
 	PWT_StartTimer(config->base);
 
 	return 0;
@@ -239,6 +228,25 @@ static void mcux_pwt_isr(const struct device *dev)
 	if (flags & kPWT_PulseWidthValidFlag) {
 		ppw = PWT_ReadPositivePulseWidth(config->base);
 		npw = PWT_ReadNegativePulseWidth(config->base);
+
+		if (data->skip_first) {
+			/*
+			 * The first pulse width valid event after enabling
+			 * the capture reports a partial measurement: the PWT
+			 * starts counting when it is enabled, which is in the
+			 * middle of an input pulse, and the pulse width
+			 * register holding the level present at that time is
+			 * loaded with that truncated value (or is still zero).
+			 * Discard it and report the next event, for which both
+			 * pulse width registers hold complete, adjacent pulses.
+			 */
+			data->skip_first = false;
+			data->overflowed = false;
+			data->high_overflows = 0;
+			data->low_overflows = 0;
+			PWT_ClearStatusFlags(config->base, kPWT_PulseWidthValidFlag);
+			return;
+		}
 
 		if (!data->continuous) {
 			PWT_StopTimer(config->base);


### PR DESCRIPTION
This patch fix test error:
Command:

```west build -b frdm_ke17z .\tests\drivers\pwm\pwm_loopback\ -p```

Error log
```
START - test_period_capture_inverted
Testing PWM capture @ 15000000/100000000 nsec

    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c:101: test_capture: (period_capture not within period +/- period / 100)
period capture off by more than 1%
 FAIL - test_period_capture_inverted in 0.123 seconds

START - test_pulse_capture_inverted
Testing PWM capture @ 15000000/100000000 nsec

    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c:106: test_capture: (pulse_capture not within pulse +/- pulse / 100)
pulse capture off by more than 1%
 FAIL - test_pulse_capture_inverted in 0.123 seconds
===================================================================
TESTSUITE pwm_loopback failed. 
```

PWT_StartTimer() enables the counter in the middle of an input pulse, so on the first pulse width valid (PWTRDY) event after enabling a capture, one of the two pulse width registers holds a truncated pulse - or has never been loaded at all. The driver reported that first event as a valid measurement: with normal polarity that gives a wrong period (ppw=8479 complete, npw=236 fragment), with inverted polarity both a wrong pulse and a wrong period (ppw=213 fragment, npw=0).

Discard that first event and report from the second one on, where both registers hold complete, adjacent pulses. This also removes the need for the KE1XZ specific -ENOTSUP for PWM_CAPTURE_TYPE_PERIOD with normal polarity and for PWM_CAPTURE_TYPE_BOTH, which only hid the same defect.

tests/drivers/pwm/pwm_loopback on frdm_ke17z now passes 8 of 8 with no skipped cases (was 4 passed, 2 failed, 2 skipped), over three flash and run cycles on hardware.