### PR TITLE
scripts: dts: gen_defines: Avoid percent signs in identifiers

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -1295,7 +1295,7 @@ def write_global_macros(edt: edtlib.EDT):
 def str2ident(s: str) -> str:
     # Converts 's' to a form suitable for (part of) an identifier
 
-    return re.sub('[-,.@/+]', '_', s.lower())
+    return re.sub('[-,.@/+%]', '_', s.lower())
 
 
 def list2init(values: Iterable[str]) -> str:


### PR DESCRIPTION
Update regular expression in str2ident to replace percent sign (%) character when creating identifiers.