### PR TITLE
dts: Move to mapped partition binding

### DIFF
--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
@@ -45,24 +45,27 @@
 		/* Embedded flash */
 		compatible = "soc-nv-flash";
 		reg = <0x0a000000 DT_SIZE_M(2)>;
+		ranges = <0x0 0x0a000000 DT_SIZE_M(2)>;
 		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <4>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		partitions {
-			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			/* Please see the memory layout in:
 			 * https://git.trustedfirmware.org/plugins/gitiles/TF-M/trusted-firmware-m.git/+/refs/heads/main/platform/ext/target/arm/musca_b1/partition/flash_layout.h
 			 */
 			slot0_partition: partition@20000 {
+				compatible = "zephyr,mapped-partition";
 				reg = <0x20000 DT_SIZE_K(384)>;
 			};
 
 			slot0_ns_partition: partition@80000 {
+				compatible = "zephyr,mapped-partition";
 				reg = <0x80000 DT_SIZE_K(512)>;
 			};
 		};

--- a/boards/telink/tlsr9518adk80d/tlsr9518adk80d.dts
+++ b/boards/telink/tlsr9518adk80d/tlsr9518adk80d.dts
@@ -93,34 +93,42 @@
 };
 
 &flash {
+	#address-cells = <1>;
+	#size-cells = <1>;
 	reg = <0x20000000 0x100000>;
+	ranges = <0x0 0x20000000 0x100000>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x10000>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 0x70000>;
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x80000 0x70000>;
 		};
 
 		scratch_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0xf0000 0x4000>;
 		};
 
 		storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf4000 0x0000b000>;
 			/* region <0xff000 0x1000> is reserved for Telink B91 SDK's data */

--- a/samples/subsys/fs/fs_sample/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -15,19 +15,22 @@
 
 &cpuapp_rram {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00010000 DT_SIZE_K(300)>;
 		};
 
 		slot1_partition: partition@5b000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0005b000 DT_SIZE_K(300)>;
 		};
 
 		storage_partition: partition@a6000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000a6000 DT_SIZE_K(128)>;
 		};

--- a/samples/subsys/fs/fs_sample/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -15,19 +15,22 @@
 
 &cpuapp_rram {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00010000 DT_SIZE_K(300)>;
 		};
 
 		slot1_partition: partition@5b000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0005b000 DT_SIZE_K(300)>;
 		};
 
 		storage_partition: partition@a6000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000a6000 DT_SIZE_K(128)>;
 		};

--- a/samples/subsys/shell/shell_module/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/subsys/shell/shell_module/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -50,12 +50,12 @@
 	ranges = <0x0 0x15d000 DT_SIZE_K(96)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(96)>;
 		};

--- a/tests/cmake/hwm/board_extend/oot_root/boards/native/native_sim_extend/native_sim_native_one.dts
+++ b/tests/cmake/hwm/board_extend/oot_root/boards/native/native_sim_extend/native_sim_native_one.dts
@@ -57,6 +57,7 @@
 	flashcontroller0: flash-controller@0 {
 		compatible = "zephyr,sim-flash";
 		reg = <0x00000000 DT_SIZE_K(2048)>;
+		ranges;
 
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -67,34 +68,42 @@
 			compatible = "soc-nv-flash";
 			erase-block-size = <4096>;
 			write-block-size = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			reg = <0x00000000 DT_SIZE_K(2048)>;
+			ranges = <0x0 0x00000000 DT_SIZE_K(2048)>;
 
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 0x0000c000>;
 				};
 
 				slot0_partition: partition@c000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x0000c000 0x00069000>;
 				};
 
 				slot1_partition: partition@75000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00075000 0x00069000>;
 				};
 
 				scratch_partition: partition@de000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-scratch";
 					reg = <0x000de000 0x0001e000>;
 				};
 
 				storage_partition: partition@fc000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x000fc000 0x00004000>;
 				};

--- a/tests/subsys/dfu/mcuboot_multi/native_sim.overlay
+++ b/tests/subsys/dfu/mcuboot_multi/native_sim.overlay
@@ -9,31 +9,36 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x0000c000>;
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000c000 0x00069000>;
 		};
 
 		slot1_partition: partition@75000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00075000 0x00069000>;
 		};
 
 		slot2_partition: partition@de000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-2";
 			reg = <0x000de000 0x00069000>;
 		};
 
 		slot3_partition: partition@146000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-3";
 			reg = <0x00146000 0x00069000>;
 		};

--- a/tests/subsys/ipc/ipc_service_api/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_common.dtsi
+++ b/tests/subsys/ipc/ipc_service_api/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_common.dtsi
@@ -14,12 +14,12 @@
 	ranges = <0x0 0x15d000 DT_SIZE_K(96)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(96)>;
 		};

--- a/tests/subsys/ipc/ipc_service_benchmark/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_common.dtsi
+++ b/tests/subsys/ipc/ipc_service_benchmark/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_common.dtsi
@@ -14,12 +14,12 @@
 	ranges = <0x0 0x15d000 DT_SIZE_K(96)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(96)>;
 		};

--- a/tests/subsys/kvss/nvs/boards/native_sim_64kb_erase_block.overlay
+++ b/tests/subsys/kvss/nvs/boards/native_sim_64kb_erase_block.overlay
@@ -14,31 +14,36 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 0x00070000>;
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00080000 0x00070000>;
 		};
 
 		scratch_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x000f0000 0x00020000>;
 		};
 
 		storage_partition: partition@110000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00110000 0x00050000>;
 		};

--- a/tests/subsys/shell/shell_remote/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/subsys/shell/shell_remote/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -45,12 +45,12 @@
 	ranges = <0x0 0x15d000 DT_SIZE_K(96)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(96)>;
 		};


### PR DESCRIPTION
    Moves to the mapped partition binding as fixed partitions for
    bootable slots is being deprecated
