### PR TITLE
Bluetooth: host: Fix net_buf double free on bt_disable during init

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -337,6 +337,10 @@ int bt_enable(bt_ready_cb_t cb);
  *
  * Disable Bluetooth. Can't be called before bt_enable has completed.
  *
+ * When bt_enable() was called with a ready callback the initialization runs
+ * asynchronously. If bt_disable() is called before the ready callback fires,
+ * it returns -EAGAIN. The caller should retry after the ready callback.
+ *
  * This API will clear all configured identity addresses and keys that are not persistently
  * stored with @kconfig{CONFIG_BT_SETTINGS}. These can be restored
  * with @ref settings_load before reenabling the stack.
@@ -349,7 +353,10 @@ int bt_enable(bt_ready_cb_t cb);
  *
  * Close and release HCI resources. Result is architecture dependent.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 Success.
+ * @retval -EAGAIN bt_enable() with a ready callback has not completed yet;
+ *                 retry after the ready callback fires.
+ * @retval -EALREADY bt_disable() has already been called.
  */
 int bt_disable(void);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4813,6 +4813,16 @@ int bt_disable(void)
 	struct net_buf *buf;
 	int err;
 
+	/* When bt_enable() was called with a ready callback, bt_init() runs
+	 * asynchronously in the init_work item. If bt_disable() is called
+	 * before init has finished, reject it so that bt_init() can complete
+	 * without racing against HCI_Reset. The caller should retry once
+	 * bt_enable() has signalled its ready callback.
+	 */
+	if (k_work_busy_get(&bt_dev.init) != 0) {
+		return -EAGAIN;
+	}
+
 	if (atomic_test_and_set_bit(bt_dev.flags, BT_DEV_DISABLE)) {
 		return -EALREADY;
 	}

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1335,7 +1335,15 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_disable(const struct shell *sh, size_t argc, char *argv[])
 {
-	return bt_disable();
+	int err;
+
+	err = bt_disable();
+	if (err != 0) {
+		shell_error(sh, "Bluetooth disable failed (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
 }
 
 #ifdef CONFIG_SETTINGS

--- a/tests/bsim/bluetooth/host/misc/disable/src/main_disable.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/main_disable.c
@@ -90,6 +90,56 @@ static void test_disable_set_default_id(void)
 	TEST_PASS("Disable set default ID test passed");
 }
 
+K_SEM_DEFINE(ready_sem, 0, 1);
+
+static void ready_cb(int err)
+{
+	if (err != 0) {
+		TEST_FAIL("bt_enable ready callback error %d", err);
+	} else {
+		k_sem_give(&ready_sem);
+	}
+}
+
+static void test_disable_async_init(void)
+{
+	/* Call bt_enable() with a ready callback so bt_init() runs
+	 * asynchronously on the system workqueue. Immediately call
+	 * bt_disable(); it must return -EAGAIN because init is still
+	 * in progress.
+	 *
+	 * k_sched_lock() prevents the workqueue from running until
+	 * k_sched_unlock() is called, so bt_disable() is guaranteed to
+	 * observe the init work item as queued regardless of
+	 * controller behavior.
+	 */
+	int err;
+
+	k_sched_lock();
+
+	err = bt_enable(ready_cb);
+	if (err != 0) {
+		k_sched_unlock();
+		TEST_FAIL("bt_enable failed (err %d)", err);
+	}
+
+	err = bt_disable();
+	k_sched_unlock();
+	if (err != -EAGAIN) {
+		TEST_FAIL("Expected -EAGAIN from bt_disable before init complete, got %d", err);
+	}
+
+	/* Wait for init to finish, then disable properly. */
+	k_sem_take(&ready_sem, K_FOREVER);
+
+	err = bt_disable();
+	if (err != 0) {
+		TEST_FAIL("bt_disable after init failed (err %d)", err);
+	}
+
+	TEST_PASS("disable async init test passed");
+}
+
 static const struct bst_test_instance test_def[] = {
 	{
 		.test_id = "disable",
@@ -100,6 +150,11 @@ static const struct bst_test_instance test_def[] = {
 		.test_id = "disable_set_default_id",
 		.test_descr = "disable_test where each iteration sets the default ID",
 		.test_main_f = test_disable_set_default_id
+	},
+	{
+		.test_id = "disable_async_init",
+		.test_descr = "bt_disable during async bt_init returns -EAGAIN",
+		.test_main_f = test_disable_async_init
 	},
 	BSTEST_END_MARKER
 };

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_async_init.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_async_init.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+# Disable test: bt_disable() called immediately after bt_enable(cb) must
+# return -EAGAIN while async init is still in progress.
+simulation_id="${BOARD_TS}_disable_async_init"
+verbosity_level=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_misc_disable_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=disable_async_init
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=1 -sim_length=10e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
When bt_enable() is called with a ready callback, bt_init() runs asynchronously in the init_work item and issues several HCI commands via bt_hci_cmd_send_sync(). If bt_disable() runs in another thread (for example the shell thread) and sends HCI_Reset while init is still in flight, the shared bt_dev.sent_cmd net_buf can be unref'd twice, triggering a net_buf double free assert.

bt_hci_cmd_send_sync() only serializes commands issued from the same thread, so it does not protect against this cross-thread race. Reject the bt_disable() call with -EAGAIN while init is still pending (queued or running). The caller should retry after bt_enable() has signalled its ready callback. 

Print the error code to the shell so the user knows to retry the disable command.