### PR TITLE
boards: st: nucleo_h563zi: simplify mapped-partition declaration

### DIFF
--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -219,30 +219,27 @@
 
 &flash0 {
 	partitions {
+		compatible = "zephyr,mapped-partition";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
 
 		boot_partition: partition@0 {
-			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
-			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(960)>;
 		};
 
 		slot1_partition: partition@100000 {
-			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00100000 DT_SIZE_K(960)>;
 		};
 
 		storage_partition: partition@1f0000 {
-			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x001f0000 DT_SIZE_K(64)>;
 		};


### PR DESCRIPTION
By declaring this compatibility string once on the partitions node instead of for each partition node individually, duplications can be reduced and overlays do not have to declare the compatibility of partitions they add anymore.

Additionally, this aligns with the example given in the Zephyr documentation.