### PR TITLE
scripts: ci: check_compliance: Allow extending the CMake style allow-list

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -510,10 +510,11 @@ class StyleCheckMixin:
                     changed.update((hunk.target_start, hunk.target_start + 1))
         return changed
 
-    def _check_files(self, tool, file_filter):
+    def _check_files(self, tool, file_filter, extra_args=()):
         # Run 'tool' on each added/modified file matching 'file_filter' and
         # report issues on changed lines only. 'tool' is a Path; file_filter is a
-        # predicate on the file path string.
+        # predicate on the file path string; 'extra_args' are passed to the tool
+        # before the file argument.
         for file in get_files(filter="d"):
             if not file_filter(file):
                 continue
@@ -523,7 +524,7 @@ class StyleCheckMixin:
                 continue
 
             result = subprocess.run(
-                [sys.executable, str(tool), file],
+                [sys.executable, str(tool), *extra_args, file],
                 cwd=GIT_TOP,
                 capture_output=True,
                 text=True,
@@ -2096,6 +2097,10 @@ class CMakeStyle(StyleCheckMixin, ComplianceTest):
     Checks the CMake style of added/modified files against the Zephyr CMake style
     guidelines, using scripts/cmake/cmake_style.py. Only issues on lines touched
     by the change are reported, so pre-existing style is not flagged.
+
+    Downstream projects can extend the mixed-case command allow-list by pointing
+    the CMAKE_STYLE_MIXED_CASE_FILE environment variable at an extra allow-list
+    file (same format as scripts/cmake/cmake_style_mixed_case.txt).
     """
 
     name = "CMakeStyle"
@@ -2110,9 +2115,16 @@ class CMakeStyle(StyleCheckMixin, ComplianceTest):
                 "'pip install tree-sitter tree-sitter-cmake'"
             )
 
+        # Load extensions to the mixed-case command allow-list
+        extra_args = []
+        if path := os.environ.get("CMAKE_STYLE_MIXED_CASE_FILE", None):
+            logging.info(f"Loading extra mixed-case commands from {path}")
+            extra_args += ["--mixed-case-file", path]
+
         self._check_files(
             ZEPHYR_BASE / "scripts" / "cmake" / "cmake_style.py",
             lambda file: file.endswith(".cmake") or Path(file).name == "CMakeLists.txt",
+            extra_args=extra_args,
         )
 
 

--- a/scripts/cmake/cmake_style.py
+++ b/scripts/cmake/cmake_style.py
@@ -10,7 +10,11 @@ Checks a subset of the "CMake Style Guidelines" documented in
 doc/contribute/style/cmake.rst:
 
   1. Indentation: use 2 spaces per block level, never tabs.
-  2. Commands: always use lowercase command names.
+  2. Commands: always use lowercase command names. Commands whose canonical
+     names are mixed-case by convention (CMake module commands and their
+     Zephyr/sysbuild extensions) are listed in cmake_style_mixed_case.txt next
+     to this script; for those the canonical spelling is the only accepted
+     form. Downstream projects append their own names with --mixed-case-file.
   3. No space between a command and its opening parenthesis ('if(' not 'if (').
   4. Cache/option variables (option(...) and set(... CACHE ...)) use UPPERCASE names.
   5. Boolean values are not quoted, in the positions where a boolean is expected:
@@ -41,6 +45,7 @@ Requires: pip install tree-sitter tree-sitter-cmake
 """
 
 import argparse
+import re
 import sys
 import traceback
 from dataclasses import dataclass
@@ -54,34 +59,12 @@ INDENT = 2
 # CMake boolean constants that should not be quoted (rule 5).
 CMAKE_BOOLEANS = {"ON", "OFF", "TRUE", "FALSE"}
 
-# Commands that are an exception to the lowercase rule (rule 2): CMake module
-# commands, and Zephyr/sysbuild commands that extend a mixed-case command, use a
-# mixed-case 'Module_Action' convention. For these the canonical mixed-case
-# spelling is the only accepted form, so both an all-lowercase and any other
-# casing are flagged and corrected to the literal below. Built-in CMake commands
-# are not listed here, so an uppercase 'FILE(' or 'SET(' is still caught by the
-# lowercase rule.
-MIXED_CASE_COMMANDS = {
-    # ExternalProject module (https://cmake.org/cmake/help/latest/module/ExternalProject.html).
-    "ExternalProject_Add",
-    "ExternalProject_Add_Step",
-    "ExternalProject_Add_StepTargets",
-    "ExternalProject_Add_StepDependencies",
-    "ExternalProject_Get_Property",
-    # FetchContent module (https://cmake.org/cmake/help/latest/module/FetchContent.html).
-    "FetchContent_Declare",
-    "FetchContent_MakeAvailable",
-    "FetchContent_Populate",
-    "FetchContent_GetProperties",
-    "FetchContent_SetPopulated",
-    # Zephyr sysbuild extensions, modeled after ExternalProject_Add.
-    "ExternalZephyrProject_Add",
-    "ExternalZephyrVariantProject_Add",
-    "ExternalZephyrProject_Cmake",
-}
+# Default allow-list of mixed-case commands (rule 2), shipped next to this
+# script. Extra files given with --mixed-case-file append to it.
+DEFAULT_MIXED_CASE_FILE = Path(__file__).parent / "cmake_style_mixed_case.txt"
 
-# Lookup from the lowercased command name to its canonical mixed-case spelling.
-_MIXED_CASE_BY_LOWER = {name.lower(): name for name in MIXED_CASE_COMMANDS}
+# CMake command names: an identifier, as matched by CMake's own grammar.
+_COMMAND_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 EXIT_OK = 0
 EXIT_ISSUES = 1
@@ -98,6 +81,39 @@ class Issue:
     col: int  # 1-based
     rule: str
     message: str
+
+
+def load_mixed_case(paths: list[Path]) -> dict[str, str]:
+    """
+    Load the mixed-case command allow-list files at 'paths', returning a lookup
+    from the lowercased command name to its canonical mixed-case spelling.
+
+    Each file holds one canonical name per line; blank lines and '#' comments
+    (whole-line or trailing) are ignored. Later files append to earlier ones.
+    Raises ValueError for an entry that is not a valid command name, is
+    all-lowercase (which would allow-list nothing), or spells a name already
+    loaded with a different case; raises OSError for an unreadable file.
+    """
+    mixed_case: dict[str, str] = {}
+    for path in paths:
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            name = line.split("#", 1)[0].strip()
+            if not name:
+                continue
+            if not _COMMAND_NAME_RE.fullmatch(name):
+                raise ValueError(f"{path}:{lineno}: '{name}' is not a valid command name")
+            if name == name.lower():
+                raise ValueError(
+                    f"{path}:{lineno}: '{name}' is all-lowercase; only mixed-case "
+                    "command names belong in the allow-list"
+                )
+            canonical = mixed_case.setdefault(name.lower(), name)
+            if canonical != name:
+                raise ValueError(
+                    f"{path}:{lineno}: '{name}' conflicts with the earlier "
+                    f"canonical spelling '{canonical}'"
+                )
+    return mixed_case
 
 
 def _text(node: Node) -> str:
@@ -117,7 +133,9 @@ def _tab_indent_issues(lines: list[str]) -> list[Issue]:
     return issues
 
 
-def _check_command(node: Node, depth: int, lines: list[str], issues: list[Issue]) -> None:
+def _check_command(
+    node: Node, depth: int, lines: list[str], mixed_case: dict[str, str], issues: list[Issue]
+) -> None:
     name_node = node.named_children[0] if node.named_children else None
     if name_node is None:
         return
@@ -125,10 +143,10 @@ def _check_command(node: Node, depth: int, lines: list[str], issues: list[Issue]
     name_line = name_node.start_point.row + 1
     name_col = name_node.start_point.column
 
-    # Rule 2: lowercase command, except module/sysbuild commands whose canonical
+    # Rule 2: lowercase command, except allow-listed commands whose canonical
     # names are mixed-case by convention. For those the canonical spelling is the
     # only accepted form; everything else must be lowercase.
-    canonical = _MIXED_CASE_BY_LOWER.get(name.lower())
+    canonical = mixed_case.get(name.lower())
     if canonical is not None:
         if name != canonical:
             issues.append(Issue(name_line, name_col + 1, "command-case", f"use '{canonical}'"))
@@ -247,14 +265,14 @@ def _check_quoted_bool(node: Node, command: str, issues: list[Issue]) -> None:
             )
 
 
-def _tree_issues(root: Node, lines: list[str]) -> list[Issue]:
+def _tree_issues(root: Node, lines: list[str], mixed_case: dict[str, str]) -> list[Issue]:
     """Rules 1 (depth), 2, 3, 4 and 5, derived from the tree-sitter-cmake tree."""
     issues: list[Issue] = []
 
     def walk(node: Node, depth: int) -> None:
         node_type = node.type
         if node_type.endswith("_command"):
-            _check_command(node, depth, lines, issues)
+            _check_command(node, depth, lines, mixed_case, issues)
         child_depth = depth + 1 if node_type == "body" else depth
         for child in node.children:
             walk(child, child_depth)
@@ -263,8 +281,12 @@ def _tree_issues(root: Node, lines: list[str]) -> list[Issue]:
     return issues
 
 
-def check_text(text: str) -> list[Issue]:
-    """Return the list of style issues for the given CMake file contents."""
+def check_text(text: str, mixed_case: dict[str, str]) -> list[Issue]:
+    """
+    Return the list of style issues for the given CMake file contents.
+    'mixed_case' maps lowercased command names to their canonical mixed-case
+    spelling (see load_mixed_case()).
+    """
     lines = text.split("\n")
     if lines and lines[-1] == "":
         lines = lines[:-1]
@@ -273,14 +295,14 @@ def check_text(text: str) -> list[Issue]:
     # token columns).
     lines = [line[:-1] if line.endswith("\r") else line for line in lines]
     root = _PARSER.parse(text.encode("utf-8")).root_node
-    issues = _tab_indent_issues(lines) + _tree_issues(root, lines)
+    issues = _tab_indent_issues(lines) + _tree_issues(root, lines, mixed_case)
     issues.sort(key=lambda issue: (issue.line, issue.col))
     return issues
 
 
-def check_file(path: Path) -> list[Issue]:
+def check_file(path: Path, mixed_case: dict[str, str]) -> list[Issue]:
     """Return the list of style issues for a single file."""
-    return check_text(path.read_text(encoding="utf-8"))
+    return check_text(path.read_text(encoding="utf-8"), mixed_case)
 
 
 def _is_cmake_file(name: str) -> bool:
@@ -316,17 +338,33 @@ def parse_args() -> argparse.Namespace:
         help="CMake files to check. Directories are searched recursively for "
         "CMakeLists.txt and *.cmake files.",
     )
+    parser.add_argument(
+        "--mixed-case-file",
+        metavar="FILE",
+        type=Path,
+        action="append",
+        default=[],
+        help="extra mixed-case command allow-list file (one canonical name per "
+        f"line, '#' comments), appended to '{DEFAULT_MIXED_CASE_FILE.name}'. "
+        "May be given multiple times.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
 
+    try:
+        mixed_case = load_mixed_case([DEFAULT_MIXED_CASE_FILE, *args.mixed_case_file])
+    except (OSError, ValueError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return EXIT_ERROR
+
     total = 0
     failed = False
     for path in expand_paths(args.paths):
         try:
-            issues = check_file(path)
+            issues = check_file(path, mixed_case)
         except Exception:
             # Never let a checker failure masquerade as "no issues" (exit 0) or
             # "issues found" (exit 1): report it and exit with EXIT_ERROR.

--- a/scripts/cmake/cmake_style_mixed_case.txt
+++ b/scripts/cmake/cmake_style_mixed_case.txt
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Commands that are an exception to cmake_style.py's lowercase rule: CMake
+# module commands, and Zephyr/sysbuild commands that extend a mixed-case
+# command, use a mixed-case 'Module_Action' convention. For these the canonical
+# mixed-case spelling below is the only accepted form, so both an all-lowercase
+# and any other casing are flagged.
+#
+# One canonical name per line. Downstream projects append their own names by
+# passing extra files like this one with --mixed-case-file.
+
+# ExternalProject module (https://cmake.org/cmake/help/latest/module/ExternalProject.html).
+ExternalProject_Add
+ExternalProject_Add_Step
+ExternalProject_Add_StepTargets
+ExternalProject_Add_StepDependencies
+ExternalProject_Get_Property
+
+# FetchContent module (https://cmake.org/cmake/help/latest/module/FetchContent.html).
+FetchContent_Declare
+FetchContent_MakeAvailable
+FetchContent_Populate
+FetchContent_GetProperties
+FetchContent_SetPopulated
+
+# Zephyr sysbuild extensions, modeled after ExternalProject_Add.
+ExternalZephyrProject_Add
+ExternalZephyrVariantProject_Add
+ExternalZephyrProject_Cmake

--- a/scripts/cmake/cmake_style_test.py
+++ b/scripts/cmake/cmake_style_test.py
@@ -10,10 +10,14 @@ import pytest
 # cmake_style needs tree-sitter; skip the whole module if it is not installed.
 cmake_style = pytest.importorskip("cmake_style")
 
+# A fixture allow-list, so the rule tests don't depend on the contents of the
+# shipped cmake_style_mixed_case.txt.
+MIXED_CASE = {"externalproject_add": "ExternalProject_Add"}
 
-def _rules(text):
+
+def _rules(text, mixed_case=MIXED_CASE):
     """The set of rule ids reported for 'text'."""
-    return {issue.rule for issue in cmake_style.check_text(text)}
+    return {issue.rule for issue in cmake_style.check_text(text, mixed_case)}
 
 
 # Rule 1: indentation (2 spaces per block level, no tabs).
@@ -67,6 +71,11 @@ def test_command_case_module_canonical_clean():
 def test_command_case_module_non_canonical_flagged():
     # A module command must use its canonical mixed case, not all-lowercase.
     assert _rules("externalproject_add(foo)\n") == {"command-case"}
+
+
+def test_command_case_unlisted_mixed_case_flagged():
+    # A mixed-case command not in the allow-list is held to the lowercase rule.
+    assert _rules("UpdateableImage_Get(foo)\n") == {"command-case"}
 
 
 # Rule 3: no space before the opening parenthesis.
@@ -139,3 +148,47 @@ if(ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
 """)
+
+
+# The mixed-case allow-list loader.
+def test_load_mixed_case_appends_across_files(tmp_path):
+    extra = tmp_path / "extra.txt"
+    extra.write_text("""\
+# downstream extension
+UpdateableImage_Get  # trailing comment
+
+""")
+    mixed_case = cmake_style.load_mixed_case([cmake_style.DEFAULT_MIXED_CASE_FILE, extra])
+    assert mixed_case["externalproject_add"] == "ExternalProject_Add"
+    assert mixed_case["updateableimage_get"] == "UpdateableImage_Get"
+
+
+def test_load_mixed_case_rejects_lowercase_entry(tmp_path):
+    f = tmp_path / "bad.txt"
+    f.write_text("all_lowercase\n")
+    with pytest.raises(ValueError, match="all-lowercase"):
+        cmake_style.load_mixed_case([f])
+
+
+def test_load_mixed_case_rejects_invalid_name(tmp_path):
+    f = tmp_path / "bad.txt"
+    f.write_text("Not a command\n")
+    with pytest.raises(ValueError, match="not a valid command name"):
+        cmake_style.load_mixed_case([f])
+
+
+def test_load_mixed_case_rejects_conflicting_case(tmp_path):
+    f = tmp_path / "bad.txt"
+    f.write_text("Foo_Bar\nFOO_Bar\n")
+    with pytest.raises(ValueError, match="conflicts"):
+        cmake_style.load_mixed_case([f])
+
+
+def test_load_mixed_case_missing_file_raises(tmp_path):
+    with pytest.raises(OSError):
+        cmake_style.load_mixed_case([tmp_path / "nonexistent.txt"])
+
+
+def test_default_mixed_case_file_loads():
+    # Guards the format of the shipped allow-list.
+    assert cmake_style.load_mixed_case([cmake_style.DEFAULT_MIXED_CASE_FILE])


### PR DESCRIPTION
Let downstream projects point the `CMAKE_STYLE_MIXED_CASE_FILE` environment variable at an extra mixed-case command allow-list file, forwarded to cmake_style.py as `--mixed-case-file`, mirroring the `UNDEF_KCONFIG_OUTSIDE_ALLOWLIST_FILE` mechanism.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/117038