### PR TITLE
boards: stm32mp2: fix west attach to the Cortex-M33 debug target

### DIFF
--- a/boards/common/openocd-stm32.board.cmake
+++ b/boards/common/openocd-stm32.board.cmake
@@ -19,4 +19,20 @@ elseif(CONFIG_SOC_SERIES_STM32F2X OR
   board_runner_args(openocd "--cmd-erase=stm32f2x mass_erase 0")
 endif()
 
+# Extra OpenOCD scripts search path for STM32MP boards.
+#
+# This is useful when using a custom OpenOCD build that has not been
+# installed system-wide (e.g. built in-place from a git checkout): in that
+# case OpenOCD's compiled-in default scripts path does not exist, and its
+# own tcl/ scripts directory (containing board/st/... and target/st/...)
+# must be added to the search path explicitly, in addition to pointing
+# -DOPENOCD at the built binary.
+set(STM32MP_OPENOCD_SCRIPTS "" CACHE PATH
+  "Extra OpenOCD scripts search path, e.g. the tcl/ directory of a \
+non-installed OpenOCD build")
+
+if(STM32MP_OPENOCD_SCRIPTS)
+  set(OPENOCD_DEFAULT_PATH ${STM32MP_OPENOCD_SCRIPTS})
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/st/stm32mp215f_dk/board.cmake
+++ b/boards/st/stm32mp215f_dk/board.cmake
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+
 if(CONFIG_BOARD_STM32MP215F_DK_STM32MP215FXX_M33)
   board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32mp215f_dk_m33.cfg")
-  board_runner_args(openocd "--gdb-init=target extended-remote :3334")
+  board_runner_args(openocd "--gdb-client-port=3334")
 endif()
-
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/st/stm32mp215f_dk/doc/index.rst
+++ b/boards/st/stm32mp215f_dk/doc/index.rst
@@ -255,8 +255,38 @@ remoteproc framework. (more information about the procedure can be found in the
 
 Debugging
 =========
-Applications can be debugged using OpenOCD and GDB. The OpenOCD files can be
-found at `device-stm-openocd`_.
+Applications can be debugged using OpenOCD and GDB, using the
+community/mainline `OpenOCD project`_ (tested at commit ``fc566d7``).
+STM32MP21x support is provided there as ``tcl/target/st/stm32mp21x.cfg``;
+since upstream does not ship a ready-made ``board/stm32mp21x_dk.cfg`` for
+this SoC, this board provides its own
+``support/openocd_stm32mp215f_dk_m33.cfg`` file.
+
+The OpenOCD version bundled with the Zephyr SDK is typically too old for
+this board file (missing board/target scripts, or an incompatible
+``interface/stlink.cfg``), so build the community/mainline OpenOCD from
+source instead:
+
+.. code-block:: console
+
+  $ git clone https://github.com/openocd-org/openocd
+  $ cd openocd
+  $ ./bootstrap with-submodules
+  $ ./configure --enable-internal-jimtcl --enable-stlink
+  $ make
+
+``--enable-internal-jimtcl`` is required unless jimtcl is already
+installed system-wide. Building the ST-Link driver also requires the
+libusb-1.0 development headers (e.g. ``libusb-1.0-0-dev`` on
+Debian/Ubuntu).
+
+Then point west at both the built binary and its scripts directory:
+
+.. code-block:: console
+
+  $ west build -- -DOPENOCD=/path/to/openocd/src/openocd \
+      -DSTM32MP_OPENOCD_SCRIPTS=/path/to/openocd/tcl
+
 The firmware must first be started by the Cortex®-A35. The debugger can
 then be attached to the running Zephyr firmware using OpenOCD.
 
@@ -266,6 +296,7 @@ then be attached to the running Zephyr firmware using OpenOCD.
    :zephyr-app: samples/basic/blinky
    :board: stm32mp215f_dk/stm32mp215fxx/m33
    :goals: build
+   :gen-args: -DOPENOCD=/path/to/openocd/src/openocd -DSTM32MP_OPENOCD_SCRIPTS=/path/to/openocd/tcl
 
 - Copy the firmware to the board, load it and start it with remoteproc
   (`STM32MP215F boot Cortex-M33 firmware`_). The orange LED should be blinking.
@@ -273,7 +304,13 @@ then be attached to the running Zephyr firmware using OpenOCD.
 
 .. code-block:: console
 
-   $ west attach
+  $ west attach
+
+The Cortex®-A35 and Cortex®-M33 cores are two separate debug views (Access
+Ports) behind the same physical debug/SWD port. The board file keeps both
+enabled and pins their GDB ports so ``west attach`` reliably reaches the
+Cortex®-M33 (port 3334) while the Cortex®-A35 stays reachable on port 3333,
+e.g. with ``gdb-multiarch -ex "target extended-remote :3333"``.
 
 References
 ==========
@@ -295,5 +332,5 @@ References
 .. _STM32MPU Wiki:
   https://wiki.st.com/stm32mpu/wiki/Main_Page
 
-.. _device-stm-openocd:
-  https://github.com/STMicroelectronics/device-stm-openocd/tree/main
+.. _OpenOCD project:
+  https://github.com/openocd-org/openocd

--- a/boards/st/stm32mp215f_dk/support/openocd_stm32mp215f_dk_m33.cfg
+++ b/boards/st/stm32mp215f_dk/support/openocd_stm32mp215f_dk_m33.cfg
@@ -1,8 +1,51 @@
-# Only enable the Cortex-M33 debugger
-set EN_CA35 	0
-set EN_CM33   	1
+# Copyright (C) 2026 STMicroelectronics
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Board file for the STM32MP215F-DK Cortex-M33 core, for use with the
+# community/mainline OpenOCD project (https://github.com/openocd-org/openocd).
+#
+# Upstream OpenOCD does not ship a board/stm32mp21x_dk.cfg, only the
+# target/st/stm32mp21x.cfg chip file, so the ST-Link setup usually found in
+# a board file is inlined here.
+#
+# Cortex-A35 and Cortex-M33 are two independent debug views (Access Ports)
+# behind the same physical debug port: both are kept enabled/examined below,
+# so the Cortex-A35 stays reachable even though this file's default target
+# is the Cortex-M33.
+#
+# GDB ports are pinned explicitly so this file behaves the same regardless
+# of the exact Access Port creation order used upstream:
+#   - Cortex-A35 : 3333 (OpenOCD's default base gdb port)
+#   - Cortex-M33 : 3334 (matches the --gdb-client-port used in board.cmake)
 
-source [find board/stm32mp21x_dk.cfg]
+# Script for stm32mp21x DISCO board with external ST-Link adapter
 
-# Set active target to Cortex-M33
-targets stm32mp21x.m33
+source [find interface/stlink-dap.cfg]
+
+transport select dapdirect_swd
+
+
+# Keep both cores enabled: the Cortex-A35 debug view must stay available.
+set EN_CA35 1
+set EN_CM33 1
+
+source [find target/st/stm32mp21x.cfg]
+
+# ap0/ap1/axi/ap3 are internal helper Access Ports (AXI/APB plumbing, used
+# to unlock DBGMCU) and are not meant to be debugged directly with GDB:
+# disable their GDB servers so Cortex-A35 and Cortex-M33 land on
+# deterministic ports.
+foreach _ap {ap0 ap1 axi ap3} {
+  $_CHIPNAME.$_ap configure -gdb-port disabled
+}
+
+$_CHIPNAME.a35 configure -gdb-port 3333
+$_CHIPNAME.m33 configure -gdb-port 3334
+
+# `west attach`/`west debug` operate on the Cortex-M33 by default. The
+# Cortex-A35 stays reachable on port 3333, e.g.:
+#   gdb-multiarch -ex "target extended-remote :3333"
+targets $_CHIPNAME.m33
+
+reset_config srst_only

--- a/boards/st/stm32mp257f_dk/board.cmake
+++ b/boards/st/stm32mp257f_dk/board.cmake
@@ -1,10 +1,10 @@
 # Copyright (C) 2025 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+
 if(CONFIG_BOARD_STM32MP257F_DK_STM32MP257FXX_M33)
   board_runner_args(
     openocd "--config=${BOARD_DIR}/support/openocd_stm32mp257f_dk_m33.cfg")
-  board_runner_args(openocd "--gdb-init=target extended-remote :3334")
+  board_runner_args(openocd "--gdb-client-port=3334")
 endif()
-
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/st/stm32mp257f_dk/doc/index.rst
+++ b/boards/st/stm32mp257f_dk/doc/index.rst
@@ -168,8 +168,37 @@ remoteproc framework. (more information about the procedure can be found in the
 
 Debugging
 =========
-Applications can be debugged using OpenOCD and GDB. The OpenOCD files can be
-found at `device-stm-openocd`_.
+Applications can be debugged using OpenOCD and GDB, using the
+community/mainline `OpenOCD project`_ (tested at commit ``fc566d7``), which
+ships a ready-made ``board/st/stm32mp257f-dk.cfg``. This board provides its
+own ``support/openocd_stm32mp257f_dk_m33.cfg`` file on top of it to keep
+both Cortex®-A35 and Cortex®-M33 enabled with deterministic GDB ports.
+
+The OpenOCD version bundled with the Zephyr SDK is typically too old for
+this board file (missing board/target scripts, or an incompatible
+``interface/stlink.cfg``), so build the community/mainline OpenOCD from
+source instead:
+
+.. code-block:: console
+
+  $ git clone https://github.com/openocd-org/openocd
+  $ cd openocd
+  $ ./bootstrap with-submodules
+  $ ./configure --enable-internal-jimtcl --enable-stlink
+  $ make
+
+``--enable-internal-jimtcl`` is required unless jimtcl is already
+installed system-wide. Building the ST-Link driver also requires the
+libusb-1.0 development headers (e.g. ``libusb-1.0-0-dev`` on
+Debian/Ubuntu).
+
+Then point west at both the built binary and its scripts directory:
+
+.. code-block:: console
+
+  $ west build -- -DOPENOCD=/path/to/openocd/src/openocd \
+      -DSTM32MP_OPENOCD_SCRIPTS=/path/to/openocd/tcl
+
 The firmware must first be started by the Cortex®-A35. The debugger can
 then be attached to the running Zephyr firmware using OpenOCD.
 
@@ -179,6 +208,7 @@ then be attached to the running Zephyr firmware using OpenOCD.
    :zephyr-app: samples/basic/blinky
    :board: stm32mp257f_dk/stm32mp257fxx/m33
    :goals: build
+   :gen-args: -DOPENOCD=/path/to/openocd/src/openocd -DSTM32MP_OPENOCD_SCRIPTS=/path/to/openocd/tcl
 
 - Copy the firmware to the board, load it and start it with remoteproc
   (`STM32MP257F boot Cortex-M33 firmware`_). The orange LED should be blinking.
@@ -186,7 +216,13 @@ then be attached to the running Zephyr firmware using OpenOCD.
 
 .. code-block:: console
 
-   $ west attach
+  $ west attach
+
+The Cortex®-A35 (SMP pair) and Cortex®-M33 cores are independent debug views
+(Access Ports) behind the same physical debug/SWD port. The board file keeps
+both enabled and pins their GDB ports so ``west attach`` reliably reaches the
+Cortex®-M33 (port 3334) while the Cortex®-A35 stays reachable on port 3333,
+e.g. with ``gdb-multiarch -ex "target extended-remote :3333"``.
 
 References
 ==========
@@ -220,5 +256,5 @@ References
 .. _STM32MPU Wiki:
   https://wiki.st.com/stm32mpu/wiki/Main_Page
 
-.. _device-stm-openocd:
-  https://github.com/STMicroelectronics/device-stm-openocd/tree/main
+.. _OpenOCD project:
+  https://github.com/openocd-org/openocd

--- a/boards/st/stm32mp257f_dk/support/openocd_stm32mp257f_dk_m33.cfg
+++ b/boards/st/stm32mp257f_dk/support/openocd_stm32mp257f_dk_m33.cfg
@@ -1,10 +1,43 @@
-# Only enable the Cortex-M33 debugger
-set EN_CA35_0 	0
-set EN_CA35_1 	0
-set EN_CM33   	1
-set EN_CM0P 	0
+# Copyright (C) 2026 STMicroelectronics
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Board file for the STM32MP257F-DK Cortex-M33 core, for use with the
+# community/mainline OpenOCD project (https://github.com/openocd-org/openocd),
+# which ships a ready-made board/st/stm32mp257f-dk.cfg.
+#
+# Cortex-A35 (dual-core, SMP) and Cortex-M33 are independent debug views
+# (Access Ports) behind the same physical debug port: both are kept
+# enabled/examined below, so the Cortex-A35 stays reachable even though
+# this file's default target is the Cortex-M33.
+#
+# GDB ports are pinned explicitly so this file behaves the same regardless
+# of the exact Access Port creation order used upstream:
+#   - Cortex-A35 (a35_0/a35_1, SMP) : 3333 (OpenOCD's default base gdb port)
+#   - Cortex-M33                    : 3334 (matches --gdb-client-port in board.cmake)
 
-source [find board/stm32mp25x_dk.cfg]
+# Keep both cores enabled: the Cortex-A35 debug view must stay available.
+set EN_CA35_0 1
+set EN_CA35_1 1
+set EN_CM33   1
+set EN_CM0P   0
 
-# Set active target to Cortex-M33
-targets stm32mp25x.m33
+source [find board/st/stm32mp257f-dk.cfg]
+
+# ap0/axi/ap2/ap8 are internal helper Access Ports (AXI/APB plumbing, used
+# to unlock DBGMCU) and are not meant to be debugged directly with GDB:
+# disable their GDB servers so Cortex-A35 and Cortex-M33 land on
+# deterministic ports.
+foreach _ap {ap0 axi ap2 ap8} {
+  $_CHIPNAME.$_ap configure -gdb-port disabled
+}
+
+$_CHIPNAME.a35_0 configure -gdb-port 3333
+$_CHIPNAME.a35_1 configure -gdb-port disabled
+$_CHIPNAME.m33 configure -gdb-port 3334
+$_CHIPNAME.m0p configure -gdb-port disabled
+
+# `west attach`/`west debug` operate on the Cortex-M33 by default. The
+# Cortex-A35 SMP pair stays reachable on port 3333, e.g.:
+#   gdb-multiarch -ex "target extended-remote :3333"
+targets $_CHIPNAME.m33

--- a/boards/st/stm32mp257f_ev1/board.cmake
+++ b/boards/st/stm32mp257f_ev1/board.cmake
@@ -1,9 +1,9 @@
 # Copyright (C) 2025 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+
 if(CONFIG_BOARD_STM32MP257F_EV1_STM32MP257FXX_M33)
   board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32mp257f_ev1_m33.cfg")
-  board_runner_args(openocd "--gdb-init=target extended-remote :3334")
+  board_runner_args(openocd "--gdb-client-port=3334")
 endif()
-
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/st/stm32mp257f_ev1/doc/index.rst
+++ b/boards/st/stm32mp257f_ev1/doc/index.rst
@@ -194,8 +194,38 @@ remoteproc framework. (more information about the procedure can be found in the
 
 Debugging
 =========
-Applications can be debugged using OpenOCD and GDB. The OpenOCD files can be
-found at `device-stm-openocd`_.
+Applications can be debugged using OpenOCD and GDB, using the
+community/mainline `OpenOCD project`_ (tested at commit ``fc566d7``), which
+ships a ready-made ``board/st/stm32mp257f-dk.cfg`` (shared with the DK
+board, same SoC). This board provides its own
+``support/openocd_stm32mp257f_ev1_m33.cfg`` file on top of it to keep both
+Cortex®-A35 and Cortex®-M33 enabled with deterministic GDB ports.
+
+The OpenOCD version bundled with the Zephyr SDK is typically too old for
+this board file (missing board/target scripts, or an incompatible
+``interface/stlink.cfg``), so build the community/mainline OpenOCD from
+source instead:
+
+.. code-block:: console
+
+  $ git clone https://github.com/openocd-org/openocd
+  $ cd openocd
+  $ ./bootstrap with-submodules
+  $ ./configure --enable-internal-jimtcl --enable-stlink
+  $ make
+
+``--enable-internal-jimtcl`` is required unless jimtcl is already
+installed system-wide. Building the ST-Link driver also requires the
+libusb-1.0 development headers (e.g. ``libusb-1.0-0-dev`` on
+Debian/Ubuntu).
+
+Then point west at both the built binary and its scripts directory:
+
+.. code-block:: console
+
+  $ west build -- -DOPENOCD=/path/to/openocd/src/openocd \
+      -DSTM32MP_OPENOCD_SCRIPTS=/path/to/openocd/tcl
+
 The firmware must first be started by the Cortex®-A35. The debugger can
 then be attached to the running Zephyr firmware using OpenOCD.
 
@@ -205,6 +235,7 @@ then be attached to the running Zephyr firmware using OpenOCD.
    :zephyr-app: samples/basic/blinky
    :board: stm32mp257f_ev1/stm32mp257fxx/m33
    :goals: build
+   :gen-args: -DOPENOCD=/path/to/openocd/src/openocd -DSTM32MP_OPENOCD_SCRIPTS=/path/to/openocd/tcl
 
 - Copy the firmware to the board, load it and start it with remoteproc
   (`STM32MP257F boot Cortex-M33 firmware`_). The orange LED should be blinking.
@@ -212,7 +243,13 @@ then be attached to the running Zephyr firmware using OpenOCD.
 
 .. code-block:: console
 
-   $ west attach
+  $ west attach
+
+The Cortex®-A35 (SMP pair) and Cortex®-M33 cores are independent debug views
+(Access Ports) behind the same physical debug/SWD port. The board file keeps
+both enabled and pins their GDB ports so ``west attach`` reliably reaches the
+Cortex®-M33 (port 3334) while the Cortex®-A35 stays reachable on port 3333,
+e.g. with ``gdb-multiarch -ex "target extended-remote :3333"``.
 
 References
 ==========
@@ -246,5 +283,5 @@ References
 .. _STM32MPU Wiki:
   https://wiki.st.com/stm32mpu/wiki/Main_Page
 
-.. _device-stm-openocd:
-  https://github.com/STMicroelectronics/device-stm-openocd/tree/main
+.. _OpenOCD project:
+  https://github.com/openocd-org/openocd

--- a/boards/st/stm32mp257f_ev1/support/openocd_stm32mp257f_ev1_m33.cfg
+++ b/boards/st/stm32mp257f_ev1/support/openocd_stm32mp257f_ev1_m33.cfg
@@ -1,10 +1,44 @@
-# Only enable the Cortex-M33 debugger
-set EN_CA35_0 	0
-set EN_CA35_1 	0
-set EN_CM33   	1
-set EN_CM0P 	0
+# Copyright (C) 2026 STMicroelectronics
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
-source [find board/stm32mp25x_dk.cfg]
+# Board file for the STM32MP257F-EV1 Cortex-M33 core, for use with the
+# community/mainline OpenOCD project (https://github.com/openocd-org/openocd).
+# The STM32MP257Fxx SoC is shared with the DK board, so this reuses
+# upstream's board/st/stm32mp257f-dk.cfg (same target script/AP layout).
+#
+# Cortex-A35 (dual-core, SMP) and Cortex-M33 are independent debug views
+# (Access Ports) behind the same physical debug port: both are kept
+# enabled/examined below, so the Cortex-A35 stays reachable even though
+# this file's default target is the Cortex-M33.
+#
+# GDB ports are pinned explicitly so this file behaves the same regardless
+# of the exact Access Port creation order used upstream:
+#   - Cortex-A35 (a35_0/a35_1, SMP) : 3333 (OpenOCD's default base gdb port)
+#   - Cortex-M33                    : 3334 (matches --gdb-client-port in board.cmake)
 
-# Set active target to Cortex-M33
-targets stm32mp25x.m33
+# Keep both cores enabled: the Cortex-A35 debug view must stay available.
+set EN_CA35_0 1
+set EN_CA35_1 1
+set EN_CM33   1
+set EN_CM0P   0
+
+source [find board/st/stm32mp257f-dk.cfg]
+
+# ap0/axi/ap2/ap8 are internal helper Access Ports (AXI/APB plumbing, used
+# to unlock DBGMCU) and are not meant to be debugged directly with GDB:
+# disable their GDB servers so Cortex-A35 and Cortex-M33 land on
+# deterministic ports.
+foreach _ap {ap0 axi ap2 ap8} {
+  $_CHIPNAME.$_ap configure -gdb-port disabled
+}
+
+$_CHIPNAME.a35_0 configure -gdb-port 3333
+$_CHIPNAME.a35_1 configure -gdb-port disabled
+$_CHIPNAME.m33 configure -gdb-port 3334
+$_CHIPNAME.m0p configure -gdb-port disabled
+
+# `west attach`/`west debug` operate on the Cortex-M33 by default. The
+# Cortex-A35 SMP pair stays reachable on port 3333, e.g.:
+#   gdb-multiarch -ex "target extended-remote :3333"
+targets $_CHIPNAME.m33


### PR DESCRIPTION
STM32MP25 OpenOCD exposes independent debug views (Access Ports) for the Cortex-A35 and Cortex-M33 behind the same physical debug port. The legacy board files sourced ST's out-of-tree device-stm-openocd board scripts (board/stm32mp25x_dk.cfg, board/stm32mp21x_dk.cfg), which are not shipped by the community/mainline OpenOCD project, and left GDB port assignment implicit, so west attach would connect to the wrong target or time out depending on Access Port creation order.

Rework the per-board OpenOCD support files to build on top of mainline OpenOCD's own STM32MP25/21 target scripts (board/st/stm32mp257f-dk.cfg, target/st/stm32mp21x.cfg), keep both the Cortex-A35 and Cortex-M33 debug views enabled, and explicitly pin their GDB ports:
  - Cortex-A35 (SMP pair where applicable): 3333 (OpenOCD's default base gdb port)
  - Cortex-M33: 3334

Update board.cmake for the three affected boards to match with --gdb-client-port=3334, replacing the previous --gdb-init override which could point GDB at the wrong port once OpenOCD's own base gdb port was touched.

Add a shared boards/common/openocd-stm32mp.board.cmake helper providing STM32MP_OPENOCD_SCRIPTS, an optional CMake cache variable used to extend OpenOCD's scripts search path. This is needed alongside -DOPENOCD when using a custom OpenOCD build, since the OpenOCD version bundled with the Zephyr SDK predates the mainline board/target scripts these boards rely on, and is missing TCL commands the newer scripts require.

Update the board documentation with a concrete recipe for building community/mainline OpenOCD from source (bootstrap with-submodules, --enable-internal-jimtcl, --enable-stlink, and the libusb-1.0 development headers needed for the ST-Link driver), and how to point west at both the built binary and its scripts directory with -DOPENOCD and -DSTM32MP_OPENOCD_SCRIPTS. Drop the now unnecessary references to device-stm-openocd.

Tested on stm32mp257f_dk/stm32mp257fxx/m33 and stm32mp215f_dk/stm32mp215fxx/m33 with samples/basic/blinky and a real ST-Link V3 probe: building community/mainline OpenOCD at commit fc566d7 with the documented recipe and pointing west at it, west attach reliably attaches GDB to the Cortex-M33 on port 3334, while the Cortex-A35 SMP pair stays reachable on port 3333.

Note: stm32mp215f_dk/stm32mp215fxx/m33 has external STLINK probe and requires specific config that is not upstreamed (so added into Zephyr config).