### PR TITLE
scripts: ci: consider previous devicetree compatibles

### DIFF
--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -1933,16 +1933,21 @@ class DtsBindingStrategy(DriverCompatStrategy):
 
     Resolution chain
     ----------------
-    1. For each changed ``.yaml`` file under ``dts/bindings/``, read the
-       top-level ``compatible:`` field.  Bindings without a ``compatible:``
-       field (base / include fragments) are skipped.
+    1. For each changed ``.yaml`` file under ``dts/bindings/``, collect the
+       top-level ``compatible:`` field from the current file and, when a git
+       commit range is available, from the base revision. This preserves the
+       previous compatible when a binding is deleted or its compatible string
+       is changed. Bindings without a ``compatible:`` field (base / include
+       fragments) are skipped.
 
-    2. Feed the compat string to ``_find_test_dirs_for_compat()`` to collect
-       ``-T`` test-root calls.
+    2. Feed each collected compat string to ``_find_test_dirs_for_compat()``
+       to collect ``-T`` test-root calls. Identical compatible strings from
+       the current and base revisions are deduplicated.
 
     3. If a *maintainers_file* is configured, additionally call
-       ``_find_boards_for_compat()`` and emit a board-targeted area-pattern
-       call (same as the board-targeted path in :class:`DriverCompatStrategy`).
+       ``_find_boards_for_compat()`` for each compat string and emit a
+       board-targeted area-pattern call (same as the board-targeted path in
+       :class:`DriverCompatStrategy`).
 
     This strategy is **additive** (``consumes = False``) so that
     :class:`MaintainerAreaStrategy` still runs as a backstop for binding
@@ -1950,6 +1955,22 @@ class DtsBindingStrategy(DriverCompatStrategy):
     """
 
     # Inherit consumes = False from SelectionStrategy (DCS sets it False too)
+
+    def __init__(
+        self,
+        zephyr_base,
+        platform_filter=None,
+        maintainers_file=None,
+        repo=None,
+        commits=None,
+    ):
+        super().__init__(
+            zephyr_base=zephyr_base,
+            platform_filter=platform_filter,
+            maintainers_file=maintainers_file,
+        )
+        self._repo = repo
+        self._commits = commits
 
     @property
     def name(self):
@@ -1964,16 +1985,33 @@ class DtsBindingStrategy(DriverCompatStrategy):
 
         # Map compat_str → set of binding file paths
         compat_to_files: dict = {}
+
         for f in binding_files:
-            compat_str = self._read_binding_compat(self._zephyr_base / f)
-            if compat_str is None:
-                log.debug("[%s] '%s' has no top-level compatible - skipping.", self.name, f)
+            compats = {
+                compat
+                for compat in (
+                    self._read_binding_compat(self._zephyr_base / f),
+                    self._read_old_binding_compat(f),
+                )
+                if compat is not None
+            }
+
+            if not compats:
+                log.debug(
+                    "[%s] '%s' has no top-level compatible in either revision - skipping.",
+                    self.name,
+                    f,
+                )
                 continue
-            vendor = compat_str.split(",")[0]
-            if vendor in self._MOCK_VENDORS:
-                log.debug("[%s] Skipping mock compat '%s'.", self.name, compat_str)
-                continue
-            compat_to_files.setdefault(compat_str, set()).add(f)
+
+            for compat_str in sorted(compats):
+                vendor = compat_str.split(",")[0]
+
+                if vendor in self._MOCK_VENDORS:
+                    log.debug("[%s] Skipping mock compat '%s'.", self.name, compat_str)
+                    continue
+
+                compat_to_files.setdefault(compat_str, set()).add(f)
 
         if not compat_to_files:
             return [], set()
@@ -2044,6 +2082,26 @@ class DtsBindingStrategy(DriverCompatStrategy):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _read_old_binding_compat(self, rel_path):
+        """Return a binding's compatible value from the base revision."""
+        if self._repo is None or not self._commits:
+            return None
+
+        base_commit = self._commits.split("..")[0]
+
+        try:
+            content = self._repo.git.show(f"{base_commit}:{rel_path}")
+            data = yaml.safe_load(content)
+
+            if isinstance(data, dict):
+                compat = data.get("compatible")
+                if isinstance(compat, str) and compat:
+                    return compat
+        except Exception:  # noqa: BLE001
+            pass
+
+        return None
 
     @staticmethod
     def _read_binding_compat(abs_path):
@@ -3801,6 +3859,8 @@ def build_strategies(
             zephyr_base=base,
             platform_filter=platform_filter,
             maintainers_file=maintainers_file,
+            repo=repo,
+            commits=commits,
         ),
         # 9. Kconfig / config-fragment changes: tests that enable the symbols.
         KconfigImpactStrategy(

--- a/scripts/tests/ci/test_test_plan_v2.py
+++ b/scripts/tests/ci/test_test_plan_v2.py
@@ -389,6 +389,129 @@ class TestMaintainerAreaStrategy:
 
 
 # ---------------------------------------------------------------------------
+# DtsBindingStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestDtsBindingStrategy:
+    """Unit tests for DtsBindingStrategy."""
+
+    def test_deleted_binding_uses_old_compatible(self, tmp_path):
+        binding = "dts/bindings/test/vendor,old.yaml"
+
+        # Simulate the deleted binding as it existed in the base revision.
+        repo = mock.MagicMock()
+        repo.git.show.return_value = textwrap.dedent(
+            """
+            description: Old device
+            compatible: "vendor,old"
+            """
+        )
+
+        strategy = tp.DtsBindingStrategy(
+            zephyr_base=str(tmp_path),
+            repo=repo,
+            commits="base..HEAD",
+        )
+
+        test_dir = tmp_path / "tests" / "drivers" / "old_device"
+        strategy._find_test_dirs_for_compat = mock.Mock(return_value={test_dir})
+
+        calls, handled = strategy.analyze([binding])
+
+        repo.git.show.assert_called_once_with(f"base:{binding}")
+
+        strategy._find_test_dirs_for_compat.assert_called_once_with("vendor,old")
+
+        assert len(calls) == 1
+        assert calls[0].testsuite_roots == ["tests/drivers/old_device"]
+        assert handled == {binding}
+
+    def test_changed_binding_uses_old_and_new_compatibles(self, tmp_path):
+        binding = "dts/bindings/test/vendor,device.yaml"
+
+        # Current revision has the new compatible.
+        binding_path = tmp_path / binding
+        binding_path.parent.mkdir(parents=True)
+        binding_path.write_text(
+            textwrap.dedent(
+                """
+                description: Device
+                compatible: "vendor,new"
+                """
+            )
+        )
+
+        # Base revision had the old compatible.
+        repo = mock.MagicMock()
+        repo.git.show.return_value = textwrap.dedent(
+            """
+            description: Device
+            compatible: "vendor,old"
+            """
+        )
+
+        strategy = tp.DtsBindingStrategy(
+            zephyr_base=str(tmp_path),
+            repo=repo,
+            commits="base..HEAD",
+        )
+
+        old_test_dir = tmp_path / "tests" / "drivers" / "old_device"
+        new_test_dir = tmp_path / "tests" / "drivers" / "new_device"
+
+        def find_test_dirs(compat):
+            if compat == "vendor,old":
+                return {old_test_dir}
+            if compat == "vendor,new":
+                return {new_test_dir}
+            return set()
+
+        strategy._find_test_dirs_for_compat = mock.Mock(side_effect=find_test_dirs)
+
+        calls, handled = strategy.analyze([binding])
+
+        repo.git.show.assert_called_once_with(f"base:{binding}")
+
+        assert {call.testsuite_roots[0] for call in calls} == {
+            "tests/drivers/old_device",
+            "tests/drivers/new_device",
+        }
+
+        assert handled == {binding}
+
+    def test_current_binding_works_without_commit_range(self, tmp_path):
+        binding = "dts/bindings/test/vendor,device.yaml"
+
+        binding_path = tmp_path / binding
+        binding_path.parent.mkdir(parents=True)
+        binding_path.write_text(
+            textwrap.dedent(
+                """
+                description: Device
+                compatible: "vendor,current"
+                """
+            )
+        )
+
+        strategy = tp.DtsBindingStrategy(
+            zephyr_base=str(tmp_path),
+        )
+
+        test_dir = tmp_path / "tests" / "drivers" / "current_device"
+
+        strategy._find_test_dirs_for_compat = mock.Mock(return_value={test_dir})
+
+        calls, handled = strategy.analyze([binding])
+
+        strategy._find_test_dirs_for_compat.assert_called_once_with("vendor,current")
+
+        assert len(calls) == 1
+        assert calls[0].testsuite_roots == ["tests/drivers/current_device"]
+        assert handled == {binding}
+
+
+# ---------------------------------------------------------------------------
 # BoilerplateFilter
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`DtsBindingStrategy` reads a binding's compatible only from the current working tree. 
When a binding is deleted or its compatible is renamed, the previous compatible can no longer
be recovered from the working tree, so dependencies using that value may not be considered
by this strategy.

This updates `DtsBindingStrategy` to also read the binding from the base revision when a commit
range is available. Compatibles from both the base and current revisions are analyzed, with 
unchanged values deduplicated.

This improves compatible-based impact analysis for two cases:
- deleted bindings, where the compatible is no longer available in the working tree
- changed compatible values, where dependencies using either the old or new value may be relevant

Tests were added for deleted bindings, changed compatibles, and operation without a commit range.

Tested with:
- python -m pytest scripts/tests/ci/test_test_plan_v2.py -v

Result:
- 96 passed