### PR TITLE
dts: riscv: microchip: fix GPIO build warning

### DIFF
--- a/dts/riscv/microchip/mpfs.dtsi
+++ b/dts/riscv/microchip/mpfs.dtsi
@@ -266,8 +266,6 @@
 			reg = <0x20120000 0x1000>;
 			interrupt-parent = <&plic>;
 			interrupts = <51 1>;
-			interrupt-controller;
-			#interrupt-cells = <1>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <32>;
@@ -279,8 +277,6 @@
 			reg = <0x20121000 0x1000>;
 			interrupt-parent = <&plic>;
 			interrupts = <52 1>;
-			interrupt-controller;
-			#interrupt-cells = <1>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <32>;
@@ -292,8 +288,6 @@
 			reg = <0x20122000 0x1000>;
 			interrupt-parent = <&plic>;
 			interrupts = <53 1>;
-			interrupt-controller;
-			#interrupt-cells = <1>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <32>;


### PR DESCRIPTION
During build, we are presented with a warning from the devicetree compiler <Warning (interrupt_provider): /soc/gpio@20120000: Missing #address-cells in interrupt provider>. This patch strips the interrupt-controller
property from GPIO banks.
