### PR TITLE
ci: Report networking throughput changes on pull requests

### DIFF
--- a/.github/workflows/net-perf-comment.yml
+++ b/.github/workflows/net-perf-comment.yml
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Posts the report produced by the "Networking throughput" workflow as a comment
+# on the pull request, so the numbers are visible where they are reviewed rather
+# than only in the Actions log.
+#
+# It has to be a separate workflow. The measurement runs from a pull_request
+# event, whose token is read-only for forks and so cannot comment. This one runs
+# on workflow_run, which is privileged, and therefore treats everything the
+# measurement produced as untrusted: it reads a report and a pull request number
+# out of the artifacts, and never checks out or executes pull request code.
+#
+# Note that workflow_run only fires for workflow files that are on the default
+# branch, so this cannot demonstrate itself on the pull request that adds it. It
+# starts commenting once merged.
+
+name: Networking Throughput Comment
+
+on:
+  workflow_run:
+    workflows: ["Networking throughput"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    name: "Comment on the pull request"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.repository == 'zephyrproject-rtos/zephyr'
+
+    steps:
+      - name: Download artifacts
+        id: download-artifacts
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: net-perf.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          if_no_artifact_found: ignore
+
+      - name: Post or update the report
+        if: steps.download-artifacts.outputs.found_artifact == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs");
+            const head_sha = context.payload.workflow_run.head_sha;
+            const MARKER = "<!-- net-perf-report -->";
+
+            function skip(reason) {
+              core.warning(`Throughput report not posted: ${reason}`);
+            }
+
+            let report;
+            try {
+              report = fs.readFileSync("./net-perf/net-perf.md", "utf8");
+            } catch {
+              skip("the run produced no report.");
+              return;
+            }
+
+            let pr_num;
+            try {
+              pr_num = Number(fs.readFileSync("./pr_num/pr_num", "utf8").trim());
+            } catch {
+              skip("the run recorded no pull request number.");
+              return;
+            }
+            if (!Number.isSafeInteger(pr_num) || pr_num <= 0) {
+              skip("the artifact carries a malformed pull request number.");
+              return;
+            }
+
+            // The artifacts come from a workflow that ran untrusted code, so
+            // make sure the pull request number really belongs to the commit
+            // that was measured. A mismatch means either a stale run - the
+            // branch moved on while it was measuring, and a newer run is on its
+            // way - or a spoofed number.
+            let pr;
+            try {
+              pr = (await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr_num,
+              })).data;
+            } catch (err) {
+              skip(`PR #${pr_num} could not be retrieved (status ${err.status}).`);
+              return;
+            }
+
+            if (pr.head.sha !== head_sha) {
+              skip(`throughput was measured on ${head_sha}, but PR #${pr_num} ` +
+                   `is now at ${pr.head.sha}.`);
+              return;
+            }
+
+            const run_url = context.payload.workflow_run.html_url;
+            const body = `${MARKER}\n${report}\n` +
+                         `[Full output, logs and plots](${run_url})\n`;
+
+            // One comment per pull request, rewritten in place, so a branch
+            // pushed ten times does not leave ten tables behind.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_num,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_num,
+                body,
+              });
+            }

--- a/.github/workflows/net-perf.yml
+++ b/.github/workflows/net-perf.yml
@@ -168,6 +168,25 @@ jobs:
               --exit-zero
           cat net-perf.md >> "${GITHUB_STEP_SUMMARY}"
 
+      # The companion workflow that comments on the pull request runs in a
+      # privileged context and cannot trust anything this job produces, so the
+      # pull request number travels as its own artifact and is checked against
+      # the measured commit there. Same shape as doc-build.yml.
+      - name: Record the pull request number
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr_num
+
+      - name: Upload the pull request number
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr_num
+          path: pr_num
+          if-no-files-found: ignore
+
       - name: Upload throughput data
         if: ${{ !cancelled() }}
         continue-on-error: true

--- a/.github/workflows/net-perf.yml
+++ b/.github/workflows/net-perf.yml
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Informational networking throughput comparison.
+#
+# Runs the deterministic zperf loopback selftest (see
+# samples/net/zperf/README-loopback-icount.rst) twice on the same runner: once
+# on the pull request and once on the branch it targets. Under QEMU icount the
+# reported Mbps is a function of executed instructions per payload byte, not of
+# host speed, so the difference between the two runs is attributable to the
+# change itself.
+#
+# The result is written to the job summary. This check is advisory: it never
+# fails, and must not be added to the required checks.
+
+name: Networking throughput
+
+on:
+  pull_request:
+    paths:
+      - 'subsys/net/**'
+      - 'include/zephyr/net/**'
+      - 'lib/net_buf/**'
+      - 'include/zephyr/net_buf.h'
+      - 'drivers/net/loopback.c'
+      - 'samples/net/zperf/**'
+      - '.github/workflows/net-perf.yml'
+    branches:
+      - main
+      - v*-branch
+      - collab-*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  net-perf:
+    name: "Networking throughput"
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      options: '--entrypoint /bin/bash'
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      SUITE: sample.net.zperf.loopback_icount
+      ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+
+    steps:
+      - name: Apply container owner mismatch workaround
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone --shared /repo-cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      # Same manifest group filter as the twister workflow. The workspace
+      # cannot be trimmed by group to save time here: nrf_hw_models is
+      # ungrouped, so it is always cloned, and its module.yml declares a
+      # dependency on hal_nordic, which is in the hal group. Dropping that
+      # group leaves the dependency unmet and zephyr_module.py exits before
+      # twister does any work.
+      - name: Environment Setup
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          base-ref: ${{ github.base_ref }}
+          group-filter: '+ci,'
+          run-checks: 'true'
+
+      - name: Install Python packages
+        run: |
+          pip install -r scripts/requirements-actions.txt --require-hashes
+
+      # The setup step above rebases the pull request onto the target branch, so
+      # this has to run after it: HEAD is the rebased series, not the pull
+      # request head, and origin/${BASE_REF} is exactly what the series adds to.
+      - name: Record the revisions to compare
+        run: |
+          echo "PR_SHA=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
+          echo "BASE_SHA=$(git rev-parse origin/${BASE_REF})" >> ${GITHUB_ENV}
+
+      - name: Measure the pull request
+        continue-on-error: true
+        run: |
+          # The step shell already sets pipefail, but the "|| echo" below
+          # depends on it, so do not leave that to the runner default.
+          set -o pipefail
+          export ZEPHYR_BASE=${PWD}
+          ./scripts/twister -T samples/net/zperf -s "${SUITE}" \
+              -p qemu_x86 -p qemu_x86_64 --outdir pr-run 2>&1 | tee pr-run.log \
+              || echo "twister exited with status ${PIPESTATUS[0]}" | tee -a pr-run.log
+
+      # Measure the target branch with the pull request's copy of the sample, so
+      # the measuring instrument - runner, overlay, payload sizes - is identical
+      # on both sides and only the code under test differs.
+      - name: Measure the target branch
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          export ZEPHYR_BASE=${PWD}
+          git checkout -f "${BASE_SHA}"
+          git checkout "${PR_SHA}" -- samples/net/zperf
+          ./scripts/twister -T samples/net/zperf -s "${SUITE}" \
+              -p qemu_x86 -p qemu_x86_64 --outdir base-run 2>&1 | tee base-run.log \
+              || echo "twister exited with status ${PIPESTATUS[0]}" | tee -a base-run.log
+
+      - name: Restore the pull request tree
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          git checkout -f "${PR_SHA}"
+
+      # --exit-zero keeps this advisory even if a metric collapsed. A run that
+      # produced no report at all is a different matter: report what twister
+      # said, rather than leaving a bare "cannot read twister.json" behind.
+      - name: Compare and report
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          if [ ! -s pr-run/twister.json ] || [ ! -s base-run/twister.json ]; then
+              {
+                  echo "### Networking throughput"
+                  echo
+                  echo "No comparison available: a measurement produced no twister"
+                  echo "report. The tail of each run follows."
+                  echo
+                  for log in pr-run.log base-run.log; do
+                      [ -f "${log}" ] || continue
+                      echo "<details><summary>${log}</summary>"
+                      echo
+                      echo '```'
+                      tail -n 40 "${log}"
+                      echo '```'
+                      echo
+                      echo "</details>"
+                      echo
+                  done
+                  echo "This check is informational and never fails a pull request."
+              } >> "${GITHUB_STEP_SUMMARY}"
+              exit 0
+          fi
+
+          samples/net/zperf/scripts/zperf_regression.py \
+              --twister-json pr-run/twister.json \
+              --baseline-twister-json base-run/twister.json \
+              --suite "${SUITE}" \
+              --markdown net-perf.md \
+              --plot net-perf.svg \
+              --annotate \
+              --exit-zero
+          cat net-perf.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload throughput data
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: net-perf
+          path: |
+            net-perf.md
+            net-perf*.svg
+            pr-run/twister.json
+            base-run/twister.json
+            pr-run.log
+            base-run.log
+          if-no-files-found: ignore

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4594,7 +4594,7 @@ Networking:
   collaborators:
     - pdgendt
   files:
-    - .github/workflows/net-perf.yml
+    - .github/workflows/net-perf*
     - scripts/net/
     - drivers/net/
     - include/zephyr/net/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4594,6 +4594,7 @@ Networking:
   collaborators:
     - pdgendt
   files:
+    - .github/workflows/net-perf.yml
     - scripts/net/
     - drivers/net/
     - include/zephyr/net/

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -306,6 +306,37 @@ The remaining options shape the report rather than the measurement:
    report from the sibling ``../build`` tree while writing outputs into the
    repository.
 
+Continuous integration
+======================
+
+:file:`.github/workflows/net-perf.yml` runs this scenario on every pull request
+that touches ``subsys/net/``, ``include/zephyr/net/``, ``lib/net_buf/``, the
+loopback driver or this sample. It measures the pull request and the branch it
+targets on the same runner, on both platforms, and writes the comparison to the
+job summary.
+
+Two details make the comparison mean what it should:
+
+- The workflow runs after the pull request has been rebased onto its target
+  branch, so the difference is what the series itself does and cannot pick up
+  unrelated movement on the target branch.
+- The target branch is measured with the pull request's copy of
+  :file:`samples/net/zperf/`, so the runner, the overlay and the payload sizes
+  are identical on both sides and only the code under test differs. A pull
+  request that changes the sample therefore does not move the number by changing
+  what is being measured.
+
+The check is **advisory**. It runs with ``--exit-zero``, every measuring step is
+``continue-on-error``, and it is not one of the required checks: a red or
+surprising number is information for the reviewer, never a merge blocker. A
+result that cannot be produced - because the target branch did not build, for
+instance - is reported as a comparison that was not available, and the job still
+passes.
+
+Only the loopback path is measured, so a flat report is not a claim that a
+change has no performance effect; driver, L2 and offload work will not show up
+here at all.
+
 Visualize the results
 =====================
 

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -216,13 +216,22 @@ report:
        --outdir ../build/zperf_run
 
 The scenario is allowed on both ``qemu_x86`` (32-bit) and ``qemu_x86_64``
-(64-bit); run the latter for a 64-bit data point (for example to exercise the
-64-bit checksum fast path):
+(64-bit); the latter gives a 64-bit data point (for example the 64-bit checksum
+fast path). Both can be measured in one run:
 
 .. code-block:: console
 
-   ./scripts/twister -p qemu_x86_64 -s sample.net.zperf.loopback_icount \
-       --outdir ../build/zperf_run64
+   ./scripts/twister -T samples/net/zperf -s sample.net.zperf.loopback_icount \
+       -p qemu_x86 -p qemu_x86_64 --outdir ../build/zperf_run
+
+Restricting the scan with ``-T samples/net/zperf`` avoids walking the whole
+tree for a single scenario.
+
+The two platforms report different absolute numbers and are never comparable
+with each other, so :file:`scripts/zperf_regression.py` keys every metric by
+the twister platform name (``qemu_x86/atom``, ``qemu_x86_64/atom``) and reports
+each one separately. Use ``--platform`` to restrict the report to one of them,
+given either as the full ``board/soc`` name or as just the board.
 
 Baseline and regression gate
 ============================
@@ -251,6 +260,43 @@ On a later commit, re-run and gate on a maximum allowed drop (in percent):
 The script exits non-zero if any recorded metric dropped by more than the
 tolerance, which makes it suitable as a CI regression check.
 
+Two runs can also be compared directly, without the intermediate baseline file:
+
+.. code-block:: console
+
+   samples/net/zperf/scripts/zperf_regression.py --base-dir .. \
+       --twister-json ../build/zperf_cur/twister.json \
+       --baseline-twister-json ../build/zperf_base/twister.json
+
+The remaining options shape the report rather than the measurement:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Meaning
+   * - ``--threshold PCT``
+     - Reporting noise floor, 1% by default. A metric that moved by less than
+       this is described as unchanged rather than as an improvement or a
+       regression. icount repeats exactly for a given binary, but two trees
+       build two different binaries, and code layout alone can move the number
+       without any change in the work performed. In practice that drift is
+       small: comparing two trees 157 commits apart, across a change that only
+       touched TCP, every UDP metric came back bit-identical on ``qemu_x86``
+       and within 0.02% on ``qemu_x86_64``.
+   * - ``--markdown PATH``
+     - Write the comparison as a markdown table, one section per platform, for a
+       GitHub Actions job summary or a pull request comment. A platform whose
+       metrics all held still is folded into a collapsed ``<details>`` block
+       whose summary line says so; one where something moved is left open.
+   * - ``--annotate``
+     - Emit one ``::notice::`` workflow command per platform, summarising the
+       metrics that moved.
+   * - ``--exit-zero``
+     - Always exit successfully. Use when the comparison is advisory and must
+       not fail a build. A missing or unbuildable baseline is reported the same
+       way, as a comparison that could not be made.
+
 .. note::
 
    For safety when the script is driven by automation, every file it reads or
@@ -272,3 +318,7 @@ combined with ``--baseline`` it draws grouped baseline-vs-current bars:
    samples/net/zperf/scripts/zperf_regression.py --base-dir .. \
        --twister-json ../build/zperf_cur/twister.json \
        --baseline baseline.json --plot throughput.svg
+
+With more than one platform in the report the platform name is appended to each
+file name, so the example above writes :file:`throughput-qemu_x86_atom.svg` and
+:file:`throughput-qemu_x86_64_atom.svg`.

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -326,6 +326,16 @@ Two details make the comparison mean what it should:
   request that changes the sample therefore does not move the number by changing
   what is being measured.
 
+A companion workflow, :file:`.github/workflows/net-perf-comment.yml`, posts the
+same report as a comment on the pull request, so the numbers are visible where
+the change is reviewed. It is a separate workflow because the measurement runs
+from a ``pull_request`` event, whose token is read-only for forks and cannot
+comment; the companion runs on ``workflow_run``, reads the report and the pull
+request number out of the artifacts, and never checks out pull request code.
+There is one comment per pull request, rewritten in place on every push, and a
+platform whose metrics all held still is collapsed so an unchanged result stays
+a single line.
+
 The check is **advisory**. It runs with ``--exit-zero``, every measuring step is
 ``continue-on-error``, and it is not one of the required checks: a red or
 surprising number is information for the reviewer, never a merge blocker. A

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -162,6 +162,14 @@ A few non-obvious points are baked into :file:`overlay-loopback-icount.conf`:
   so any realistic packet size (up to ~500 kB) is supported.
 - **No SLIP/TAP.** The QEMU SLIP host networking backend is disabled; the run
   needs no host-side ``slip.sock``.
+- **Log buffer size.** The result lines are printed with ``printk()``, which the
+  log subsystem forwards through its deferred backend. At the default 1024 byte
+  buffer the ``qemu_x86_64`` run overflows it during the first IPv4 transfers,
+  and :kconfig:option:`CONFIG_LOG_MODE_OVERFLOW` then drops the three oldest
+  messages - which silently swallows the ``udp4_frag`` result line, so that
+  metric never reaches the report at all. The overlay raises
+  :kconfig:option:`CONFIG_LOG_BUFFER_SIZE` to 4096. The measurement itself is
+  unaffected; the 32-bit numbers are bit-identical with the larger buffer.
 
 Usage
 *****

--- a/samples/net/zperf/overlay-loopback-icount.conf
+++ b/samples/net/zperf/overlay-loopback-icount.conf
@@ -35,6 +35,15 @@ CONFIG_NET_SLIP_TAP=n
 # which can stall under icount waiting on real-time stdin.
 CONFIG_ZPERF_LOOPBACK_SELFTEST=y
 
+# The results are printed with printk(), which the log subsystem forwards
+# through its deferred backend. At the default 1024 byte buffer the qemu_x86_64
+# run overflows it during the first IPv4 transfers and LOG_MODE_OVERFLOW drops
+# the three oldest messages, which silently swallows the udp4_frag result line -
+# the metric simply never appears in the report. Give the buffer enough room for
+# the whole run. The measurement is unaffected: the 32 bit numbers are
+# bit-identical with the larger buffer.
+CONFIG_LOG_BUFFER_SIZE=4096
+
 # The UDP uploader needs a receive timeout to collect the server statistics.
 CONFIG_NET_CONTEXT_RCVTIMEO=y
 

--- a/samples/net/zperf/scripts/zperf_regression.py
+++ b/samples/net/zperf/scripts/zperf_regression.py
@@ -8,6 +8,11 @@ The ``sample.net.zperf.loopback_icount`` scenario runs a deterministic,
 host-speed-independent throughput test under QEMU icount mode and records the
 UDP and TCP throughput (in Mbps) into the twister JSON report.
 
+Metrics are keyed by twister platform, so a single run covering several
+platforms (for example ``-p qemu_x86 -p qemu_x86_64``) is reported per
+platform rather than merged: the 32-bit and 64-bit numbers are not comparable
+with each other.
+
 By default all files read or written must live under the current directory;
 pass --base-dir to widen that (the examples below read the twister report from
 the sibling ../build tree and write into the repo, so they use --base-dir ..).
@@ -15,21 +20,28 @@ the sibling ../build tree and write into the repo, so they use --base-dir ..).
 Typical usage::
 
     # Capture a baseline on the reference commit.
-    ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \\
+    ./scripts/twister -T samples/net/zperf -s sample.net.zperf.loopback_icount \\
         --outdir ../build/zperf_base
     samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
         --twister-json ../build/zperf_base/twister.json \\
         --save baseline.json
 
     # On a later commit, re-run and gate on a maximum allowed drop.
-    ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \\
+    ./scripts/twister -T samples/net/zperf -s sample.net.zperf.loopback_icount \\
         --outdir ../build/zperf_cur
     samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
         --twister-json ../build/zperf_cur/twister.json \\
         --baseline baseline.json --tolerance 5
 
+    # Compare two twister runs directly, and report the difference without
+    # ever failing (what continuous integration does).
+    samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
+        --twister-json ../build/zperf_cur/twister.json \\
+        --baseline-twister-json ../build/zperf_base/twister.json \\
+        --markdown report.md --annotate --exit-zero
+
     # Visualize the results as an SVG bar chart (optionally baseline vs
-    # current when --baseline is also given).
+    # current when a baseline is also given).
     samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
         --twister-json ../build/zperf_cur/twister.json \\
         --baseline baseline.json --plot throughput.svg
@@ -42,6 +54,21 @@ import os
 import sys
 
 DEFAULT_SUITE = "sample.net.zperf.loopback_icount"
+
+# Metrics that moved by less than this are reported as unchanged. The icount
+# measurement repeats exactly for a given binary, but a baseline and a modified
+# tree are two different binaries: adding or removing code shifts the layout and
+# nudges the number without changing the work actually done. See the "Noise
+# floor" discussion in README-loopback-icount.rst.
+DEFAULT_THRESHOLD_PCT = 1.0
+
+# Placeholder platform name used for baseline files written before the metrics
+# were keyed by platform.
+UNKNOWN_PLATFORM = "unknown"
+
+
+class MetricsError(Exception):
+    """No usable throughput recordings could be read."""
 
 
 def validate_path(path: str, base_dir: str, *, for_write: bool) -> str:
@@ -82,51 +109,247 @@ def validate_path(path: str, base_dir: str, *, for_write: bool) -> str:
     return target_real
 
 
-def extract_metrics(twister_json: str, suite_name: str) -> dict[str, float]:
-    """Return a {metric: value} mapping from a twister.json recording."""
-    with open(twister_json) as fp:
-        data = json.load(fp)
+def platform_matches(platform: str, wanted: str) -> bool:
+    """Match a twister platform name against a user-supplied selector.
 
-    metrics: dict[str, float] = {}
+    Twister reports a platform as ``board/soc`` (``qemu_x86/atom``), so accept
+    either the full name or just the board part.
+    """
+    return wanted in (platform, platform.split("/", 1)[0])
+
+
+def extract_metrics(
+    twister_json: str, suite_name: str, platform: str | None = None
+) -> dict[str, dict[str, float]]:
+    """Return a {platform: {metric: value}} mapping from a twister.json recording."""
+    try:
+        with open(twister_json) as fp:
+            data = json.load(fp)
+    except OSError as err:
+        raise MetricsError(f"Cannot read {twister_json}: {err}") from err
+    except json.JSONDecodeError as err:
+        raise MetricsError(f"{twister_json} is not valid JSON: {err}") from err
+
+    metrics: dict[str, dict[str, float]] = {}
     for suite in data.get("testsuites", []):
         if suite.get("name") != suite_name:
             continue
+
+        suite_platform = suite.get("platform") or UNKNOWN_PLATFORM
+        if platform is not None and not platform_matches(suite_platform, platform):
+            continue
+
         for record in suite.get("recording") or []:
             for key, value in record.items():
                 try:
-                    metrics[key] = float(value)
+                    metrics.setdefault(suite_platform, {})[key] = float(value)
                 except (TypeError, ValueError):
                     continue
 
     if not metrics:
-        sys.exit(
-            f"No throughput recordings for suite '{suite_name}' in "
+        selected = f" on platform '{platform}'" if platform else ""
+        raise MetricsError(
+            f"No throughput recordings for suite '{suite_name}'{selected} in "
             f"{twister_json}. Did the run pass?"
         )
 
     return metrics
 
 
-def compare(baseline: dict[str, float], current: dict[str, float], tolerance_pct: float) -> bool:
-    """Print a comparison table and return True if no metric regressed."""
-    ok = True
-    print(f"{'metric':<20}{'baseline':>12}{'current':>12}{'change':>10}  status")
+def load_baseline(path: str) -> dict[str, dict[str, float]]:
+    """Read a saved baseline file, accepting the flat pre-platform format too."""
+    with open(path) as fp:
+        raw = json.load(fp)
+
+    if not isinstance(raw, dict):
+        raise MetricsError(f"{path} does not contain a baseline object.")
+
+    # A baseline saved before the metrics were keyed by platform is a flat
+    # {metric: value} mapping. Treat the whole file as one unnamed platform so
+    # existing baseline files keep working.
+    if raw and all(not isinstance(value, dict) for value in raw.values()):
+        return {UNKNOWN_PLATFORM: {k: float(v) for k, v in raw.items()}}
+
+    return {
+        platform: {k: float(v) for k, v in values.items()}
+        for platform, values in raw.items()
+        if isinstance(values, dict)
+    }
+
+
+def pair_platforms(
+    baseline: dict[str, dict[str, float]], current: dict[str, dict[str, float]]
+) -> list[tuple[str, dict[str, float], dict[str, float]]]:
+    """Line the two runs' platforms up for comparison.
+
+    A baseline in the old flat format carries no platform name, so pair it with
+    the current run's single platform when there is exactly one.
+    """
+    if list(baseline) == [UNKNOWN_PLATFORM] and len(current) == 1:
+        platform, values = next(iter(current.items()))
+        return [(platform, baseline[UNKNOWN_PLATFORM], values)]
+
+    return [
+        (platform, baseline.get(platform, {}), current.get(platform, {}))
+        for platform in sorted(set(baseline) | set(current))
+    ]
+
+
+def compare_platform(
+    baseline: dict[str, float],
+    current: dict[str, float],
+    tolerance_pct: float,
+    threshold_pct: float,
+) -> list[dict]:
+    """Return one row per metric describing how it moved."""
+    rows = []
     for metric in sorted(set(baseline) | set(current)):
         base = baseline.get(metric)
         cur = current.get(metric)
+
         if base is None or cur is None:
-            print(f"{metric:<20}{str(base):>12}{str(cur):>12}{'':>10}  MISSING")
-            ok = False
+            rows.append({"metric": metric, "base": base, "current": cur, "status": "MISSING"})
             continue
 
         change_pct = ((cur - base) / base * 100.0) if base else 0.0
         min_allowed = base * (1.0 - tolerance_pct / 100.0)
-        status = "OK" if cur >= min_allowed else "REGRESSION"
-        if status != "OK":
-            ok = False
-        print(f"{metric:<20}{base:>12.3f}{cur:>12.3f}{change_pct:>+9.1f}%  {status}")
 
-    return ok
+        if abs(change_pct) < threshold_pct:
+            verdict = "unchanged"
+        elif change_pct > 0:
+            verdict = "improved"
+        else:
+            verdict = "slower"
+
+        rows.append(
+            {
+                "metric": metric,
+                "base": base,
+                "current": cur,
+                "change": change_pct,
+                "verdict": verdict,
+                "status": "OK" if cur >= min_allowed else "REGRESSION",
+            }
+        )
+
+    return rows
+
+
+def rows_ok(rows: list[dict]) -> bool:
+    """True when no metric is missing and none dropped past the tolerance."""
+    return all(row["status"] == "OK" for row in rows)
+
+
+def print_comparison(results: list[tuple[str, list[dict]]]) -> None:
+    """Print a comparison table per platform."""
+    for platform, rows in results:
+        print(f"\nPlatform: {platform}")
+        print(f"{'metric':<20}{'baseline':>12}{'current':>12}{'change':>10}  status")
+        for row in rows:
+            if row["status"] == "MISSING":
+                base = "-" if row["base"] is None else f"{row['base']:.3f}"
+                cur = "-" if row["current"] is None else f"{row['current']:.3f}"
+                print(f"{row['metric']:<20}{base:>12}{cur:>12}{'':>10}  MISSING")
+                continue
+            print(
+                f"{row['metric']:<20}{row['base']:>12.3f}{row['current']:>12.3f}"
+                f"{row['change']:>+9.1f}%  {row['status']}"
+            )
+
+
+def _verdict_icon(verdict: str) -> str:
+    return {"improved": "🟢", "slower": "🔴", "unchanged": "▫️"}.get(verdict, "❔")
+
+
+def _platform_headline(rows: list[dict], threshold_pct: float) -> str:
+    """One line saying what moved on a platform, or that nothing did."""
+    moved = [r for r in rows if r["status"] != "MISSING" and r["verdict"] != "unchanged"]
+    missing = [r for r in rows if r["status"] == "MISSING"]
+
+    if moved:
+        headline = ", ".join(f"{r['metric']} {r['change']:+.1f}%" for r in moved)
+    else:
+        headline = f"no metric moved by more than {threshold_pct:g}%"
+
+    if missing:
+        headline += f" ({len(missing)} not measured)"
+
+    return headline
+
+
+def write_markdown(
+    path: str,
+    results: list[tuple[str, list[dict]]],
+    threshold_pct: float,
+    baseline_label: str,
+    current_label: str,
+) -> None:
+    """Write the comparison as markdown, for a GitHub Actions job summary."""
+    out: list[str] = ["### Networking throughput", ""]
+
+    for platform, rows in results:
+        # Collapse a platform whose metrics all held still. The report is also
+        # posted as a pull request comment, where sixteen unchanged rows on
+        # every networking pull request would be noise; the headline says what
+        # happened and the table is one click away.
+        headline = _platform_headline(rows, threshold_pct)
+        moved = any(r["status"] != "MISSING" and r["verdict"] != "unchanged" for r in rows)
+        out.append(
+            f"<details{' open' if moved else ''}><summary><b>{platform}</b> — {headline}</summary>"
+        )
+        out.append("")
+        out.append(f"| metric | {baseline_label} | {current_label} | change | |")
+        out.append("| --- | ---: | ---: | ---: | :-: |")
+        for row in rows:
+            if row["status"] == "MISSING":
+                base = "-" if row["base"] is None else f"{row['base']:.3f}"
+                cur = "-" if row["current"] is None else f"{row['current']:.3f}"
+                out.append(f"| `{row['metric']}` | {base} | {cur} | not measured | ❔ |")
+                continue
+            out.append(
+                f"| `{row['metric']}` | {row['base']:.3f} | {row['current']:.3f} "
+                f"| {row['change']:+.1f}% | {_verdict_icon(row['verdict'])} |"
+            )
+        out.append("")
+        out.append("</details>")
+        out.append("")
+
+    out.append(
+        f"Throughput is measured in Mbps of virtual time under QEMU icount, which makes "
+        f"it a stand-in for instructions per payload byte rather than a line rate. "
+        f"Changes below {threshold_pct:g}% are reported as unchanged: the two trees are "
+        f"different binaries, so code layout alone moves the number a little."
+    )
+    out.append("")
+    out.append("This check is informational and never fails a pull request.")
+    out.append("")
+
+    with open(path, "w") as fp:
+        fp.write("\n".join(out))
+    print(f"Wrote markdown report to {path}")
+
+
+def write_unavailable_markdown(path: str, reason: str) -> None:
+    """Write a markdown note explaining why no comparison could be made."""
+    with open(path, "w") as fp:
+        fp.write(
+            "### Networking throughput\n\n"
+            f"No comparison available: {reason}\n\n"
+            "This check is informational and never fails a pull request.\n"
+        )
+    print(f"Wrote markdown report to {path}")
+
+
+def emit_annotations(results: list[tuple[str, list[dict]]], threshold_pct: float) -> None:
+    """Emit one ``::notice::`` workflow command per platform for the Actions log.
+
+    The platform is named in the message as well as in the title, because the
+    Actions log renders only the message: without it, two platforms that both
+    came back unchanged produce two identical lines.
+    """
+    for platform, rows in results:
+        detail = _platform_headline(rows, threshold_pct)
+        print(f"::notice title=Networking throughput ({platform})::{platform}: {detail}")
 
 
 def _nice_ceil(value: float) -> float:
@@ -142,7 +365,10 @@ def _nice_ceil(value: float) -> float:
 
 
 def write_plot(
-    path: str, current: dict[str, float], baseline: dict[str, float] | None = None
+    path: str,
+    current: dict[str, float],
+    baseline: dict[str, float] | None = None,
+    title: str = "zperf loopback throughput (Mbps)",
 ) -> None:
     """Render a bar chart of the metrics as a self-contained SVG file.
 
@@ -177,8 +403,7 @@ def write_plot(
     svg.append(f'<rect width="{width}" height="{height}" fill="white"/>')
     svg.append(
         f'<text x="{width / 2:.1f}" y="24" text-anchor="middle" '
-        f'font-size="16" font-weight="bold">'
-        f'zperf loopback throughput (Mbps)</text>'
+        f'font-size="16" font-weight="bold">{title}</text>'
     )
 
     ticks = 5
@@ -247,7 +472,17 @@ def write_plot(
     print(f"Wrote plot to {path}")
 
 
-def main() -> int:
+def plot_path_for(path: str, platform: str, single: bool) -> str:
+    """Derive a per-platform plot file name when more than one platform ran."""
+    if single:
+        return path
+
+    stem, ext = os.path.splitext(path)
+    suffix = platform.replace("/", "_")
+    return f"{stem}-{suffix}{ext or '.svg'}"
+
+
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -260,23 +495,65 @@ def main() -> int:
         "--suite", default=DEFAULT_SUITE, help="Test suite name to read recordings from"
     )
     parser.add_argument(
+        "--platform",
+        metavar="NAME",
+        help="Only consider this twister platform, given either as the full "
+        "'board/soc' name or as just the board (default: all platforms in "
+        "the report, reported separately)",
+    )
+    parser.add_argument(
         "--save", metavar="PATH", help="Write the extracted metrics as a baseline file"
     )
     parser.add_argument(
         "--baseline", metavar="PATH", help="Compare against a previously saved baseline file"
     )
     parser.add_argument(
+        "--baseline-twister-json",
+        metavar="PATH",
+        help="Compare against the twister.json of another run, without going "
+        "through a saved baseline file",
+    )
+    parser.add_argument(
         "--tolerance",
         type=float,
         default=5.0,
-        help="Allowed throughput drop in percent (default: 5.0)",
+        help="Allowed throughput drop in percent before the exit status "
+        "reports a regression (default: 5.0)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD_PCT,
+        help="Reporting noise floor in percent: a metric that moved by less "
+        f"than this is described as unchanged (default: {DEFAULT_THRESHOLD_PCT}). "
+        "The baseline and the current tree are different binaries, so code "
+        "layout alone moves the number slightly without any change in the "
+        "work performed",
+    )
+    parser.add_argument(
+        "--markdown",
+        metavar="PATH",
+        help="Write the comparison as a markdown report, for example to append "
+        "to a GitHub Actions job summary",
+    )
+    parser.add_argument(
+        "--annotate",
+        action="store_true",
+        help="Emit ::notice:: workflow command annotations summarising each platform",
+    )
+    parser.add_argument(
+        "--exit-zero",
+        action="store_true",
+        help="Always exit successfully, even when a metric regressed. Use when "
+        "the comparison is informational and must not fail a build",
     )
     parser.add_argument(
         "--plot",
         metavar="PATH",
         help="Write an SVG bar chart of the metrics to PATH "
-        "(grouped baseline vs current when --baseline is "
-        "given)",
+        "(grouped baseline vs current when a baseline is "
+        "given). With several platforms the platform name is "
+        "appended to each file name",
     )
     parser.add_argument(
         "--base-dir",
@@ -286,13 +563,37 @@ def main() -> int:
         "directory tree (default: current directory). "
         "Paths resolving outside it are rejected.",
     )
+
     args = parser.parse_args()
 
-    twister_json = validate_path(args.twister_json, args.base_dir, for_write=False)
-    current = extract_metrics(twister_json, args.suite)
+    if args.baseline and args.baseline_twister_json:
+        parser.error("--baseline and --baseline-twister-json are mutually exclusive")
 
-    for metric, value in sorted(current.items()):
-        print(f"{metric} = {value:.3f} Mbps")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+
+    markdown_path = None
+    if args.markdown:
+        markdown_path = validate_path(args.markdown, args.base_dir, for_write=True)
+
+    twister_json = validate_path(args.twister_json, args.base_dir, for_write=False)
+    try:
+        current = extract_metrics(twister_json, args.suite, args.platform)
+    except MetricsError as err:
+        # Without the current run there is nothing to report at all. Still
+        # leave a readable note behind when a report was asked for.
+        if markdown_path:
+            write_unavailable_markdown(markdown_path, str(err))
+        print(err, file=sys.stderr)
+        return 0 if args.exit_zero else 1
+
+    for platform, values in sorted(current.items()):
+        print(f"Platform: {platform}")
+        for metric, value in sorted(values.items()):
+            print(f"  {metric} = {value:.3f} Mbps")
 
     if args.save:
         save_path = validate_path(args.save, args.base_dir, for_write=True)
@@ -302,22 +603,68 @@ def main() -> int:
         print(f"Saved baseline to {save_path}")
 
     baseline = None
-    if args.baseline:
-        baseline_path = validate_path(args.baseline, args.base_dir, for_write=False)
-        with open(baseline_path) as fp:
-            baseline = {k: float(v) for k, v in json.load(fp).items()}
+    baseline_error = None
+    if args.baseline or args.baseline_twister_json:
+        try:
+            if args.baseline:
+                path = validate_path(args.baseline, args.base_dir, for_write=False)
+                baseline = load_baseline(path)
+            else:
+                path = validate_path(args.baseline_twister_json, args.base_dir, for_write=False)
+                baseline = extract_metrics(path, args.suite, args.platform)
+        except (MetricsError, OSError, json.JSONDecodeError) as err:
+            baseline_error = str(err)
+
+    if baseline_error is not None:
+        # A missing or unusable baseline is expected in continuous integration
+        # when the reference tree failed to build. Say so and carry on.
+        print(f"No baseline to compare against: {baseline_error}", file=sys.stderr)
+        if markdown_path:
+            write_unavailable_markdown(markdown_path, baseline_error)
+        if args.annotate:
+            print(f"::notice title=Networking throughput::{baseline_error}")
+        return 0 if args.exit_zero else 1
+
+    if baseline is None:
+        pairs = [(platform, {}, values) for platform, values in sorted(current.items())]
+    else:
+        pairs = pair_platforms(baseline, current)
 
     if args.plot:
-        plot_path = validate_path(args.plot, args.base_dir, for_write=True)
-        write_plot(plot_path, current, baseline)
+        single = len(pairs) == 1
+        for platform, base_values, values in pairs:
+            plot_path = validate_path(
+                plot_path_for(args.plot, platform, single), args.base_dir, for_write=True
+            )
+            write_plot(
+                plot_path,
+                values,
+                base_values or None,
+                title=f"zperf loopback throughput, {platform} (Mbps)",
+            )
 
-    if baseline is not None:
-        print()
-        if not compare(baseline, current, args.tolerance):
-            print("\nThroughput regression detected.", file=sys.stderr)
-            return 1
-        print("\nNo throughput regression.")
+    if baseline is None:
+        return 0
 
+    results = [
+        (platform, compare_platform(base, cur, args.tolerance, args.threshold))
+        for platform, base, cur in pairs
+    ]
+
+    print_comparison(results)
+
+    if markdown_path:
+        write_markdown(markdown_path, results, args.threshold, "baseline", "current")
+
+    if args.annotate:
+        emit_annotations(results, args.threshold)
+
+    ok = all(rows_ok(rows) for _, rows in results)
+    if not ok:
+        print("\nThroughput regression detected.", file=sys.stderr)
+        return 0 if args.exit_zero else 1
+
+    print("\nNo throughput regression.")
     return 0
 
 


### PR DESCRIPTION
Zephyr has had a deterministic way to measure networking throughput since the
zperf loopback icount selftest landed in PR #114388, but nothing runs it. Somebody who makes
the stack measurably slower finds out whenever a maintainer next profiles the
code, which can be releases later. This wires the existing measurement into CI
as an advisory report on the pull requests that could move it.

### What it does

A new workflow, `.github/workflows/net-perf.yml`, triggers on pull requests
touching `subsys/net/`, `include/zephyr/net/`, `lib/net_buf/`, the loopback
driver or the zperf sample. It measures the pull request and the branch it
targets on the same runner, on `qemu_x86` and `qemu_x86_64`, and writes a
per-metric comparison to the job summary with one `::notice::` annotation per
platform:

| metric | baseline | current | change | |
| --- | ---: | ---: | ---: | :-: |
| `tcp4_mbps` | 6.357 | 6.687 | +5.2% | 🟢 |
| `udp4_mbps` | 13.353 | 13.353 | +0.0% | ▫️ |

The measurement itself is unchanged and already documented in
`samples/net/zperf/README-loopback-icount.rst`: eight loopback transfers per
platform inside a QEMU guest under icount, where virtual time advances with
executed instructions, so the reported Mbps is a function of instructions per
payload byte rather than of how fast the runner happens to be.

### It never fails a pull request

This is a reviewer's aid, not a gate, and it is deliberately built so that it
cannot become one by accident:

- the comparison runs with `--exit-zero`,
- every measuring step is `continue-on-error`,
- a result that cannot be produced - the target branch does not build, say -
  is reported as an unavailable comparison, and the job still passes.

It should not be added to the required checks.

### Why the number is attributable to the change

Two details, both of which matter more than they look:

- The job runs after the shared `zephyr-ci-env` setup has rebased the series
  onto its target branch, so `origin/$BASE_REF` is exactly what the series adds
  to. Unrelated movement on the target branch cannot leak into the difference.
- The target branch is measured with the pull request's copy of
  `samples/net/zperf/`, so the runner, the overlay and the payload sizes - the
  measuring instrument - are identical on both sides and only the code under
  test differs. This mirrors what the Doxygen coverage check already does when
  it builds the base tree with the pull request's doc build system.

### Does it actually work

Rehearsed end to end by running the workflow's exact sequence on an existing
TCP series (eight commits reusing the parsed TCP header) against its merge base:

| | qemu_x86 | qemu_x86_64 |
|---|---|---|
| all four TCP metrics | +5.2 … +6.4% | +5.2 … +6.5% |
| all four UDP metrics | **±0.0%**, bit-identical | −0.02% |

A TCP-only change lights up every TCP metric on both platforms, while the UDP
numbers do not move a single digit across trees 157 commits apart. That is also
the answer to the obvious objection - that two trees are two different binaries
and code layout alone will move the number. Measured drift is around 0.02%, so
the 1% reporting threshold below which a metric is called unchanged sits about
fifty times above it.

### The commits

**`samples: net: zperf: Keep the log buffer from dropping a result line`**

A bug fix that has to come first, because without it the report is wrong.
`udp4_frag_mbps` has never been recorded on `qemu_x86_64`. The selftest prints
its results with `printk()`, which the log subsystem forwards through its
deferred backend, and the default 1 KB buffer overflows during the first IPv4
transfers; `CONFIG_LOG_MODE_OVERFLOW` then drops the three oldest messages,
which happen to be the two zperf bind/listen lines and that result. Nothing
reports it: the transfer runs, the console harness matches the remaining
markers, and the scenario passes with the metric simply absent. It reproduces
on every `qemu_x86_64` run and never on `qemu_x86`, which is why the scenario
looked healthy when it was added.

`CONFIG_LOG_BUFFER_SIZE=4096` in the overlay fixes it. The buffer is not in the
measured path: with it, all eight markers print on both platforms, no message
is dropped, and the `qemu_x86` numbers are bit-identical to what they were.

**`samples: net: zperf: Report loopback throughput per platform`**

`extract_metrics()` merged the recordings of every suite whose name matched into
one flat dictionary, so a single twister run covering both platforms silently
kept whichever came last, and comparing such a report against a baseline
compared 32-bit against 64-bit values. Metrics are now keyed by twister platform
and reported separately. Baseline files written before this carry no platform
name; they are still read and paired with a single-platform run, so the
documented capture-and-gate flow keeps working.

On top of that, what a CI job needs: `--baseline-twister-json` to compare two
runs directly, `--markdown` and `--annotate` for the report, `--threshold` for
the noise floor, `--exit-zero` to stay advisory, and `--platform` to narrow a
report to one platform.

**`ci: Add an informational networking throughput check`**

The workflow, plus `.github/workflows/net-perf.yml` in the Networking
maintainers' file list, as the nRF BSIM area already does for its own workflow.

### Cost

Four builds and four QEMU runs. Locally, both platforms build and execute in one
twister invocation in about 47 seconds, so the measurement adds roughly a minute
and a half on top of the usual container and west setup.

### Deliberately not in this PR

- **No pull request comments.** The report goes to the job summary and to
  `::notice::` annotations, which needs no extra token permissions and works
  for fork pull requests. A sticky comment would be more visible and could be
  added later, at the cost of a companion `workflow_run` workflow with
  `pull-requests: write`.
- **No history.** Nothing is stored, so a regression that lands anyway is not
  detected afterwards. Uploading the metrics to ElasticSearch on pushes to
  `main`, the way footprint tracking does, would give trend graphs, but it
  depends on project secrets and is better proposed separately.
- **Networking paths only.** The metric is genuinely sensitive to scheduler and
  timer changes, but triggering on `kernel/` would put a networking job on a
  large share of all pull requests.

### Known limits, stated up front

- The Mbps figure is a virtual-time stand-in for instructions per payload byte,
  not a line rate. It is only comparable against itself, at the same icount
  shift, packet size and tick rate.
- Only the loopback path is measured, so a flat report is not a claim that a
  change has no performance effect. Driver, L2 and offload work will not appear
  here at all.
