### PR TITLE
Bluetooth: host: Document the callback execution-context contract

### DIFF
--- a/doc/services/connectivity/bluetooth/bluetooth-le-host.rst
+++ b/doc/services/connectivity/bluetooth/bluetooth-le-host.rst
@@ -99,6 +99,48 @@ Connections
 Connection handling and the related APIs can be found in the
 :ref:`Connection Management <bluetooth_connection_mgmt>` section.
 
+.. _bluetooth_callback_contexts:
+
+Callback execution contexts
+===========================
+
+The Host delivers events to the application through registered callbacks, for
+example those in :c:struct:`bt_conn_cb`, :c:struct:`bt_le_scan_cb` or
+:c:struct:`bt_l2cap_chan_ops`. Unless documented otherwise, these callbacks
+are invoked from a thread context, never from an ISR. Most run in a context
+internal to the stack, but some are today invoked synchronously from within
+the API call that triggers them, and so run in the calling thread: for
+example :c:func:`bt_unpair` invokes ``bond_deleted``, and
+:c:func:`bt_gatt_unsubscribe` can invoke ``notify`` with ``NULL`` data,
+before returning. Neither behavior is part of the API: a callback delivered
+synchronously today may be deferred to a stack-internal context in a future
+release, or vice versa, and the specific thread has changed between releases
+before and may change again. Applications should rely only on the guarantees
+above, not on being called from, or before the return of, anything in
+particular.
+
+When a callback runs in a context internal to the stack, that context is
+shared with the stack's own processing: time spent in the callback delays
+other Bluetooth activity, and blocking carries an additional risk, since a
+wait that only Bluetooth processing itself can satisfy becomes a deadlock,
+because that processing cannot proceed until the callback returns. The
+classic example is allocating a buffer with ``K_FOREVER`` from a pool that is
+replenished by the same context that runs the callback. As applications
+cannot rely on which context a given callback uses, the practices below apply
+to every callback.
+
+Calling Bluetooth APIs from callbacks is common and supported, even though
+most of them may block; the blocking risk is then managed rather than
+avoided:
+
+* Keep callbacks short, and defer work that is long-running or blocks
+  indefinitely to an application-owned thread or work queue.
+* Prefer allocations with ``K_NO_WAIT`` or a bounded timeout over
+  ``K_FOREVER``, and handle the failure.
+* Size buffer pools (for example :kconfig:option:`CONFIG_BT_L2CAP_TX_BUF_COUNT`
+  or :kconfig:option:`CONFIG_BT_ATT_TX_COUNT`) so that allocations made from
+  callbacks do not have to wait.
+
 Security
 ========
 

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -212,6 +212,14 @@ struct bt_le_per_adv_response_info {
  * @note Must point to valid memory during the lifetime of the advertising set.
  *
  * @note Used in @ref bt_le_ext_adv_create.
+ *
+ * @note The callbacks are invoked from a thread context, never from an
+ *       ISR. Whether a callback is invoked from a context internal to
+ *       the stack or synchronously from within the API call that
+ *       triggers it, and from which context, is not part of the API and
+ *       may change between releases. See
+ *       @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *       for the hazards of blocking in a callback and their mitigations.
  */
 struct bt_le_ext_adv_cb {
 	/**
@@ -326,7 +334,9 @@ typedef void (*bt_ready_cb_t)(int err);
  * earlier.
  *
  * @param cb Callback to notify completion or NULL to perform the
- * enabling synchronously. The callback is called from the system workqueue.
+ * enabling synchronously. The callback is called from a thread context
+ * internal to the stack, never from an ISR; see
+ * @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
@@ -1836,6 +1846,14 @@ struct bt_le_per_adv_sync_state_info {
  * advertising.
  *
  * @note Used in @ref bt_le_per_adv_sync_cb_register function.
+ *
+ * @note The callbacks are invoked from a thread context, never from an
+ *       ISR. Whether a callback is invoked from a context internal to
+ *       the stack or synchronously from within the API call that
+ *       triggers it, and from which context, is not part of the API and
+ *       may change between releases. See
+ *       @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *       for the hazards of blocking in a callback and their mitigations.
  */
 
 struct bt_le_per_adv_sync_cb {
@@ -2486,7 +2504,16 @@ struct bt_le_scan_recv_info {
 	uint8_t secondary_phy;
 };
 
-/** Listener context for (LE) scanning. */
+/** Listener context for (LE) scanning.
+ *
+ * @note The callbacks are invoked from a thread context, never from an
+ *       ISR. Whether a callback is invoked from a context internal to
+ *       the stack or synchronously from within the API call that
+ *       triggers it, and from which context, is not part of the API and
+ *       may change between releases. See
+ *       @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *       for the hazards of blocking in a callback and their mitigations.
+ */
 struct bt_le_scan_cb {
 
 	/**

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2217,6 +2217,14 @@ struct bt_conn_br_cb {
  *  tracking the connection state. If a callback is not of interest for
  *  an instance, it may be set to NULL and will as a consequence not be
  *  used for that instance.
+ *
+ *  @note The callbacks are invoked from a thread context, never from an
+ *        ISR. Whether a callback is invoked from a context internal to
+ *        the stack or synchronously from within the API call that
+ *        triggers it, and from which context, is not part of the API and
+ *        may change between releases. See
+ *        @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *        for the hazards of blocking in a callback and their mitigations.
  */
 struct bt_conn_cb {
 	/** @brief A new connection has been established.
@@ -2912,7 +2920,16 @@ struct bt_conn_pairing_feat {
  */
 #define BT_PASSKEY_RAND 0xffffffff
 
-/** Authenticated pairing callback structure */
+/** Authenticated pairing callback structure
+ *
+ *  @note The callbacks are invoked from a thread context, never from an
+ *        ISR. Whether a callback is invoked from a context internal to
+ *        the stack or synchronously from within the API call that
+ *        triggers it, and from which context, is not part of the API and
+ *        may change between releases. See
+ *        @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *        for the hazards of blocking in a callback and their mitigations.
+ */
 struct bt_conn_auth_cb {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT) || defined(__DOXYGEN__)
 	/** @brief Query to proceed incoming pairing or not.
@@ -3137,7 +3154,16 @@ struct bt_conn_auth_cb {
 #endif /* CONFIG_BT_APP_PASSKEY */
 };
 
-/** Authenticated pairing information callback structure */
+/** Authenticated pairing information callback structure
+ *
+ *  @note The callbacks are invoked from a thread context, never from an
+ *        ISR. Whether a callback is invoked from a context internal to
+ *        the stack or synchronously from within the API call that
+ *        triggers it, and from which context, is not part of the API and
+ *        may change between releases. See
+ *        @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *        for the hazards of blocking in a callback and their mitigations.
+ */
 struct bt_conn_auth_info_cb {
 	/** @brief notify that pairing procedure was complete.
 	 *

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -169,6 +169,11 @@ struct bt_gatt_attr;
  *  @note The GATT server propagates the return value from this
  *  method back to the remote client.
  *
+ *  @note When the stack invokes this method to serve a remote
+ *  operation it does so from a thread context chosen by the
+ *  stack, never from an ISR, and the implementation should not
+ *  block.
+ *
  *  @param conn   The connection that is requesting to read.
  *                NULL if local.
  *  @param attr   The attribute that's being read
@@ -211,6 +216,11 @@ typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
  *
  *  @note The GATT server propagates the return value from this
  *  method back to the remote client.
+ *
+ *  @note When the stack invokes this method to serve a remote
+ *  operation it does so from a thread context chosen by the
+ *  stack, never from an ISR, and the implementation should not
+ *  block.
  *
  *  @param conn   The connection that is requesting to write
  *  @param attr   The attribute that's being written
@@ -1430,7 +1440,8 @@ struct bt_gatt_notify_params {
  *  With the addition that after sending the notification the
  *  callback function will be called.
  *
- *  The callback is run from System Workqueue context.
+ *  The callback runs in a thread context, never in an ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
  *  When called from the System Workqueue context this API will not wait for
  *  resources for the callback but instead return an error.
  *
@@ -1725,7 +1736,8 @@ uint16_t bt_gatt_get_uatt_mtu(struct bt_conn *conn);
  *
  *  Used with @ref bt_gatt_exchange_mtu function to initiate an MTU exchange. The
  *  response is handled in the callback @p func, which is called upon
- *  completion from the Bluetooth RX thread.
+ *  completion in a thread context, never in an ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
  *
  *  @p params must remain valid until the callback executes.
  */
@@ -1742,9 +1754,10 @@ struct bt_gatt_exchange_params {
  *
  *  As the response comes in callback @p params->func, for example
  *  @ref bt_gatt_get_mtu can be invoked in the mtu_exchange-callback to read
- *  out the new negotiated ATT connection MTU. The callback is run from the
- *  context of the Bluetooth RX thread and @p params must remain
- *  valid until start of callback.
+ *  out the new negotiated ATT connection MTU. The callback runs in a thread
+ *  context, never in an ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
+ *  @p params must remain valid until start of callback.
  *
  *  @param conn Connection object.
  *  @param params Exchange MTU parameters.
@@ -1920,8 +1933,10 @@ struct bt_gatt_discover_params {
  *  For each attribute found the callback is called which can then decide
  *  whether to continue discovering or stop.
  *
- *  The Response comes in callback @p params->func. The callback is run from
- *  the BT RX thread. @p params must remain valid until start of callback where
+ *  The Response comes in callback @p params->func. The callback runs in
+ *  a thread context, never in an ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
+ *  @p params must remain valid until start of callback where
  *  iter `attr` is `NULL` or callback will return `BT_GATT_ITER_STOP`.
  *
  *  @param conn Connection object.
@@ -2054,8 +2069,9 @@ struct bt_gatt_read_params {
  *  Note that the effect of returning @ref BT_GATT_ITER_CONTINUE from the
  *  callback varies depending on the type of read operation.
  *
- *  The Response comes in callback @p params->func. The callback is run from
- *  the context of the Bluetooth RX thread.
+ *  The Response comes in callback @p params->func. The callback runs in
+ *  a thread context, never in an ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
  *  @p params must remain valid until start of callback.
  *  If the received data length is invalid, the callback @p params->func will
  *  called with the error @ref BT_ATT_ERR_INVALID_PDU.
@@ -2105,8 +2121,9 @@ struct bt_gatt_write_params {
 
 /** @brief Write Attribute Value by handle
  *
- *  The Response comes in callback @p params->func. The callback is run from
- *  the context of the Bluetooth RX thread.
+ *  The Response comes in callback @p params->func. The callback runs in
+ *  a thread context, never in an ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
  *  @p params must remain valid until start of callback.
  *
  *  @param conn Connection object.
@@ -2128,7 +2145,8 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *  With the addition that after sending the write the callback function will be
  *  called.
  *
- *  The callback is run from System Workqueue context.
+ *  The callback runs in a thread context, never in an ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
  *  When called from the System Workqueue context this API will not wait for
  *  resources for the callback but instead return an error.
  *
@@ -2312,10 +2330,10 @@ struct bt_gatt_subscribe_params {
  *  this callback. Notification callback with NULL data will not be called if
  *  subscription was removed by this method.
  *
- *  The Response comes in callback @p params->subscribe. The callback is run from
- *  the context of the Bluetooth RX thread.
- *  The Notification callback @p params->notify is also called from the BT RX
- *  thread.
+ *  The Response comes in callback @p params->subscribe, and notifications in
+ *  @p params->notify. Both callbacks run in a thread context, never in an
+ *  ISR; see
+ *  @rstref{Callback execution contexts <bluetooth_callback_contexts>}.
  *
  *  @note Notifications are asynchronous therefore the @p params must remain
  *        valid while subscribed and cannot be reused for additional subscriptions
@@ -2366,8 +2384,9 @@ int bt_gatt_resubscribe(uint8_t id, const bt_addr_le_t *peer,
  *  will be called if subscription was removed by this call, until then the
  *  parameters cannot be reused.
  *
- *  The Response comes in callback @p params->func. The callback is run from
- *  the BT RX thread.
+ *  The Response comes in callback @p params->notify with NULL data,
+ *  either from within this function or from a thread context chosen by
+ *  the stack.
  *
  *  @param conn Connection object.
  *  @param params Subscribe parameters. The parameters shall be a @ref bt_gatt_subscribe_params from

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -689,7 +689,17 @@ struct bt_iso_biginfo {
 	bool  encryption;
 };
 
-/** @brief ISO Channel operations structure. */
+/**
+ * @brief ISO Channel operations structure.
+ *
+ * @note The callbacks are invoked from a thread context, never from an
+ *       ISR. Whether a callback is invoked from a context internal to
+ *       the stack or synchronously from within the API call that
+ *       triggers it, and from which context, is not part of the API and
+ *       may change between releases. See
+ *       @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *       for the hazards of blocking in a callback and their mitigations.
+ */
 struct bt_iso_chan_ops {
 	/**
 	 * @brief Channel connected callback

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -613,6 +613,14 @@ struct bt_l2cap_br_chan {
 /** @brief L2CAP Channel operations structure.
  *
  * The object has to stay valid and constant for the lifetime of the channel.
+ *
+ * @note The callbacks are invoked from a thread context, never from an
+ *       ISR. Whether a callback is invoked from a context internal to
+ *       the stack or synchronously from within the API call that
+ *       triggers it, and from which context, is not part of the API and
+ *       may change between releases. See
+ *       @rstref{Callback execution contexts <bluetooth_callback_contexts>}
+ *       for the hazards of blocking in a callback and their mitigations.
  */
 struct bt_l2cap_chan_ops {
 	/** @brief Channel connected callback


### PR DESCRIPTION
State the execution-context contract on the application-facing callback structures (bt_conn_cb, bt_conn_auth_cb, bt_conn_auth_info_cb, bt_l2cap_chan_ops, bt_iso_chan_ops, bt_le_scan_cb, bt_le_ext_adv_cb, bt_le_per_adv_sync_cb), on the GATT attribute read/write methods and on the GATT client operation callbacks: the callbacks run in a thread context chosen by the stack, never an ISR, and should not block.

The struct notes reference a new "Callback execution contexts" section in the LE Host documentation, which explains the hazards of blocking in a callback, the buffer-allocation deadlock in particular, and the established mitigations: keeping callbacks short, bounded allocations, and sizing buffer pools so that allocations do not have to wait. Blocking is deliberately discouraged rather than forbidden, since most Bluetooth APIs today may block and calling them from callbacks is common, managed practice.

Where the documentation named an exact thread, replace it with the same contract. The named threads are already inaccurate after the host work was consolidated onto the Bluetooth workqueue, and naming them makes any future change of the dispatch context an API break, while nothing an application may rely on is lost: the guarantee that matters is thread context (not ISR), and the behavior that matters is not to block.