### PR TITLE
drivers: intc: nxp_irqsteer: namespace the driver API

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_irqsteer.c
+++ b/drivers/interrupt_controller/intc_nxp_irqsteer.c
@@ -225,6 +225,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree/interrupt_controller.h>
 #include <zephyr/irq.h>
+#include <zephyr/drivers/interrupt_controller/nxp_irqsteer.h>
 #include <zephyr/cache.h>
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/logging/log.h>
@@ -654,8 +655,8 @@ static void irqstr_release_irq_unlocked(struct irqsteer_dispatcher *disp,
 		system_irq, disp->irq_refcnt[irqsteer_master_irq_off]);
 }
 
-/* Zephyr SoC interrupt interface */
-void z_soc_irq_enable_disable(uint32_t irq, bool enable)
+/* Interrupt control API, dispatching between level 1 and IRQSTEER */
+static void nxp_irqstr_irq_enable_disable(uint32_t irq, bool enable)
 {
 	uint32_t parent_irq;
 	int i, level2_irq;
@@ -693,17 +694,17 @@ void z_soc_irq_enable_disable(uint32_t irq, bool enable)
 	}
 }
 
-void z_soc_irq_enable(uint32_t irq)
+void nxp_irqstr_irq_enable(uint32_t irq)
 {
-	z_soc_irq_enable_disable(irq, true);
+	nxp_irqstr_irq_enable_disable(irq, true);
 }
 
-void z_soc_irq_disable(uint32_t irq)
+void nxp_irqstr_irq_disable(uint32_t irq)
 {
-	z_soc_irq_enable_disable(irq, false);
+	nxp_irqstr_irq_enable_disable(irq, false);
 }
 
-int z_soc_irq_is_enabled(unsigned int irq)
+int nxp_irqstr_irq_is_enabled(unsigned int irq)
 {
 	uint32_t parent_irq;
 	int i;
@@ -734,7 +735,7 @@ int z_soc_irq_is_enabled(unsigned int irq)
 }
 
 #if defined(CONFIG_ARM)
-void z_soc_irq_priority_set(unsigned int irq, unsigned int prio, unsigned int flags)
+void nxp_irqstr_irq_priority_set(unsigned int irq, unsigned int prio, unsigned int flags)
 {
 	uint32_t level1_irq = irq;
 

--- a/include/zephyr/drivers/interrupt_controller/nxp_irqsteer.h
+++ b/include/zephyr/drivers/interrupt_controller/nxp_irqsteer.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief NXP IRQSTEER interrupt aggregator driver API
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_NXP_IRQSTEER_H_
+#define ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_NXP_IRQSTEER_H_
+
+#include <zephyr/types.h>
+
+/**
+ * @brief Enable a multi-level IRQ line
+ *
+ * @param irq Multi-level encoded IRQ number
+ */
+void nxp_irqstr_irq_enable(uint32_t irq);
+
+/**
+ * @brief Disable a multi-level IRQ line
+ *
+ * @param irq Multi-level encoded IRQ number
+ */
+void nxp_irqstr_irq_disable(uint32_t irq);
+
+/**
+ * @brief Get the enable state of a multi-level IRQ line
+ *
+ * @param irq Multi-level encoded IRQ number
+ *
+ * @return 1 if the IRQ line is enabled, 0 otherwise
+ */
+int nxp_irqstr_irq_is_enabled(unsigned int irq);
+
+/**
+ * @brief Set the priority of the parent line of a multi-level IRQ
+ *
+ * @param irq Multi-level encoded IRQ number
+ * @param prio Interrupt priority
+ * @param flags Architecture-specific IRQ configuration flags
+ */
+void nxp_irqstr_irq_priority_set(unsigned int irq, unsigned int prio, unsigned int flags);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_NXP_IRQSTEER_H_ */

--- a/soc/nxp/common/irqsteer_irq.c
+++ b/soc/nxp/common/irqsteer_irq.c
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Platform implementation of the SoC multi-level interrupt control
+ * functions for i.MX platforms where the IRQSTEER aggregator is the
+ * second-level interrupt controller. Interrupt controller drivers only
+ * expose their own namespaced API; mapping z_soc_irq_* is the
+ * platform's responsibility.
+ */
+
+#include <zephyr/irq.h>
+#include <zephyr/drivers/interrupt_controller/nxp_irqsteer.h>
+
+void z_soc_irq_enable(uint32_t irq)
+{
+	nxp_irqstr_irq_enable(irq);
+}
+
+void z_soc_irq_disable(uint32_t irq)
+{
+	nxp_irqstr_irq_disable(irq);
+}
+
+int z_soc_irq_is_enabled(unsigned int irq)
+{
+	return nxp_irqstr_irq_is_enabled(irq);
+}
+
+#if defined(CONFIG_ARM)
+void z_soc_irq_priority_set(unsigned int irq, unsigned int prio, unsigned int flags)
+{
+	nxp_irqstr_irq_priority_set(irq, prio, flags);
+}
+#endif

--- a/soc/nxp/imx/CMakeLists.txt
+++ b/soc/nxp/imx/CMakeLists.txt
@@ -13,3 +13,5 @@ zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
 if(CONFIG_CPU_CORTEX_A)
   zephyr_linker_sources_ifdef(CONFIG_OPENAMP_RSC_TABLE SECTIONS rsc_table.ld)
 endif()
+
+zephyr_sources_ifdef(CONFIG_NXP_IRQSTEER ../common/irqsteer_irq.c)


### PR DESCRIPTION
The IRQSTEER driver defines the z_soc_irq_* SoC multi-level
interrupt hooks directly, claiming the SoC's contract from a driver:
z_soc_irq_enable(), z_soc_irq_disable(), z_soc_irq_is_enabled() and
z_soc_irq_priority_set(), plus an internal helper that also sat in
the global z_soc namespace. Interrupt controller drivers should only
expose their own namespaced API; providing the SoC hooks is platform
glue and does not belong in a driver.

Rename the control functions to nxp_irqstr_irq_* following the
driver's existing internal prefix, declare them in a driver header,
make the internal enable/disable helper static, and provide the
z_soc_irq_* mapping from one shared platform file wired at the i.MX
family level, covering every SoC with an IRQSTEER devicetree node
(i.MX8/8M/8X ADSP on Xtensa, i.MX93/94/95 M cores on ARM).
