### PR TITLE
soc: arm: fvp_aem: Kconfig: fix SoC options

### DIFF
--- a/soc/arm/fvp_aem/Kconfig
+++ b/soc/arm/fvp_aem/Kconfig
@@ -1,27 +1,18 @@
 # Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config SOC_SERIES_FVP_AEM
-	bool
-	help
-	  Enable support for Arm FVP AEM (Architectural Envelope Model) Series
-
 config SOC_V8A
-	bool
 	select ARM64
 	select CPU_CORTEX_A53
 
 config SOC_V9A
-	bool
 	select ARM64
 	select CPU_CORTEX_A510
 
 config SOC_A320
-	bool
 	select ARM64
 	select CPU_CORTEX_A320
 
 config SOC_V8A_AARCH32
-	bool
 	select ARM
 	select CPU_CORTEX_A32

--- a/soc/arm/fvp_aem/Kconfig.soc
+++ b/soc/arm/fvp_aem/Kconfig.soc
@@ -3,6 +3,8 @@
 
 config SOC_SERIES_FVP_AEM
 	bool
+	help
+	  Enable support for Arm FVP AEM (Architectural Envelope Model) Series
 
 config SOC_V8A
 	bool


### PR DESCRIPTION
SoC options shall not be redefined in `Kconfig` file per https://docs.zephyrproject.org/latest/hardware/porting/soc_porting.html#write-kconfig-files