### PR TITLE
soc: arm: Disable USE_SWITCH on non-secure boards

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -1,7 +1,7 @@
 # ARM Cortex-M platform configuration options
 
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
-# Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 # NOTE: We have the specific core implementations first and outside of the
@@ -228,7 +228,7 @@ config ARMV7_M_ARMV8_M_MAINLINE
 	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	select CPU_CORTEX_M_HAS_SYSTICK
-	select USE_SWITCH_SUPPORTED
+	select USE_SWITCH_SUPPORTED if !TRUSTED_EXECUTION_NONSECURE
 	select ARCH_HAS_LLEXT_VENEERS
 	select ARCH_HAS_BIT_REV
 	help

--- a/soc/arm/mps3/Kconfig
+++ b/soc/arm/mps3/Kconfig
@@ -16,7 +16,7 @@ config SOC_CORSTONE300
 	select ARMV8_1_M_MVEI
 	select ARMV8_1_M_MVEF
 	select ARMV8_1_M_PMU
-	select USE_SWITCH
+	imply USE_SWITCH
 
 config SOC_CORSTONE310
 	select CPU_CORTEX_M85

--- a/soc/arm/mps4/Kconfig
+++ b/soc/arm/mps4/Kconfig
@@ -26,7 +26,7 @@ config SOC_CORSTONE320
 	select ARMV8_1_M_MVEF
 	select ARMV8_1_M_PMU
 	select ARM_MPU_PXN if ARM_MPU
-	select USE_SWITCH
+	imply USE_SWITCH
 
 config ARMV8_1_M_PMU_EVENTCNT
 	int


### PR DESCRIPTION
USE_SWITCH currently does not work for non-secure Zephyr images.
Thus USE_SWITCH_SUPPORTED should only be selected if TRUSTED_EXECUTION_SECURE holds.

Additionally, weaken the changes in https://github.com/zephyrproject-rtos/zephyr/pull/114659 to use `imply` instead of `select` to avoid a Kconfig warning on Corstone300 and Corstone320.