### PR TITLE
dtdoctor: fix broken diagnosis paths and add test coverage

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1276,6 +1276,21 @@ DSP subsystem:
   tests:
     - zdsp
 
+DT Doctor:
+  status: maintained
+  maintainers:
+    - kartben
+  files:
+    - cmake/sca/dtdoctor/
+    - doc/develop/sca/dtdoctor.rst
+    - scripts/dts/dtdoctor_analyzer.py
+    - scripts/dts/dtdoctor_sca_wrapper.py
+    - tests/misc/dtdoctor/
+  labels:
+    - "area: Devicetree"
+  tests:
+    - sca.dtdoctor
+
 Debug:
   status: maintained
   maintainers:

--- a/scripts/ci/undef_kconfig_allowlist.txt
+++ b/scripts/ci/undef_kconfig_allowlist.txt
@@ -68,6 +68,11 @@ CPU_V7  # U-Boot boards/luckfox/pico_ultra
 CRC  # Used in TI CC13x2 / CC26x2 SDK comment
 DEEP_SLEEP  # #defined by RV32M1 in ext/
 DESCRIPTION
+DTD_PLATFORM_IMPLY  # DT Doctor test fixture symbol
+DTD_PLATFORM_SELECT  # DT Doctor test fixture symbol
+DTD_SERIAL  # DT Doctor test fixture symbol
+DTD_SPECIAL_CORE  # DT Doctor test fixture symbol
+DTD_UART  # DT Doctor test fixture symbol
 DT_HAS_  # example from doc/build/dts/dt-vs-kconfig.rst
 EFI_LOADER  # U-Boot boards/luckfox/pico_ultra
 ERR

--- a/scripts/dts/dtdoctor_analyzer.py
+++ b/scripts/dts/dtdoctor_analyzer.py
@@ -55,9 +55,11 @@ def load_edt(path: str) -> edtlib.EDT:
         return pickle.load(f)
 
 
-def setup_kconfig() -> kconfiglib.Kconfig:
-    kconf = kconfiglib.Kconfig(os.path.join(os.environ.get("ZEPHYR_BASE"), "Kconfig"), warn=False)
-    return kconf
+def setup_kconfig() -> kconfiglib.Kconfig | None:
+    zephyr_base = os.environ.get("ZEPHYR_BASE")
+    if not zephyr_base:
+        return None
+    return kconfiglib.Kconfig(os.path.join(zephyr_base, "Kconfig"), warn=False)
 
 
 def format_node(node: edtlib.Node) -> str:
@@ -70,7 +72,15 @@ def find_kconfig_deps(kconf: kconfiglib.Kconfig, dt_has_symbol: str) -> set[str]
     """
     prefix = os.environ.get("CONFIG_", "CONFIG_")
     target = f"{prefix}{dt_has_symbol}"
+    # Word-boundary match so e.g. DT_HAS_FOO_ENABLED doesn't match DT_HAS_FOO_ENABLED_EXT
+    target_re = re.compile(rf"(?<!\w){re.escape(target)}(?!\w)")
     deps = set()
+
+    def expr_to_str(expr):
+        return kconfiglib.expr_str(
+            expr,
+            lambda sc: f"{prefix}{sc.name}" if hasattr(sc, 'name') and sc.name else str(sc),
+        )
 
     def collect_syms(expr):
         # Recursively collect all symbol names in the expression tree except the target
@@ -81,24 +91,19 @@ def find_kconfig_deps(kconf: kconfiglib.Kconfig, dt_has_symbol: str) -> set[str]
             if sym_name != target:
                 deps.add(sym_name)
 
-    for sym in getattr(kconf, "unique_defined_syms", []):
+    for sym in kconf.unique_defined_syms:
         for node in sym.nodes:
             # Check dependencies
-            if node.dep is None:
-                continue
-            dep_str = kconfiglib.expr_str(
-                node.dep,
-                lambda sc: f"{prefix}{sc.name}" if hasattr(sc, 'name') and sc.name else str(sc),
-            )
-            if target in dep_str:
+            if node.dep is not None and target_re.search(expr_to_str(node.dep)):
                 collect_syms(node.dep)
 
-            # Check selects/implies
+            # A symbol whose select/imply is conditioned on the DT_HAS symbol is itself
+            # an option worth enabling
             for attr in ["orig_selects", "orig_implies"]:
-                for value, _ in getattr(node, attr, []) or []:
-                    value_str = kconfiglib.expr_str(value, str)
-                    if target in value_str:
-                        collect_syms(value)
+                for _, cond in getattr(node, attr, []) or []:
+                    if cond is not None and target_re.search(expr_to_str(cond)):
+                        deps.add(f"{prefix}{sym.name}")
+                        collect_syms(cond)
 
     return deps
 
@@ -111,8 +116,12 @@ def handle_enabled_node(node: edtlib.Node) -> list[str]:
     lines = [f"'{format_node(node)}' is enabled but no driver appears to be available for it.\n"]
 
     compats = list(getattr(node, "compats", []))
-    if compats:
-        kconf = setup_kconfig()
+    kconf = setup_kconfig() if compats else None
+    if not compats:
+        lines.append("Could not determine compatible; check driver Kconfig manually.")
+    elif not kconf:
+        lines.append("ZEPHYR_BASE is not set; check driver Kconfig manually.")
+    else:
         deps = set()
         for compat in compats:
             dt_has = f"DT_HAS_{edtlib.str_as_token(compat.upper())}_ENABLED"
@@ -121,8 +130,6 @@ def handle_enabled_node(node: edtlib.Node) -> list[str]:
         if deps:
             lines.append("Try enabling these Kconfig options:\n")
             lines.extend(f" - {dep}=y" for dep in sorted(deps))
-    else:
-        lines.append("Could not determine compatible; check driver Kconfig manually.")
 
     return lines
 
@@ -142,12 +149,8 @@ def handle_disabled_node(node: edtlib.Node) -> list[str]:
         lines.extend(f" - {u.path}" for u in users)
 
     # Show chosen/alias references
-    chosen_refs = [
-        name
-        for name, n in (getattr(edt, "chosen_nodes", {}) or getattr(edt, "chosen", {})).items()
-        if n is node
-    ]
-    alias_refs = [name for name, n in getattr(edt, "aliases", {}).items() if n is node]
+    chosen_refs = [name for name, n in edt.chosen_nodes.items() if n is node]
+    alias_refs = node.aliases
 
     if chosen_refs or alias_refs:
         lines.append("")

--- a/scripts/dts/dtdoctor_sca_wrapper.py
+++ b/scripts/dts/dtdoctor_sca_wrapper.py
@@ -5,7 +5,7 @@
 
 """
 Compiler launcher wrapper that captures what appears to be Devicetree-related build errors, and
-diagnoses them using diagnose_build_error.py.
+diagnoses them using dtdoctor_analyzer.py.
 
 The tool is meant to be configured as a CMAKE_<LANG>_COMPILER_LAUNCHER or as a
 CMAKE_<LANG>_LINKER_LAUNCHER.
@@ -47,10 +47,11 @@ def main() -> int:
     # Extract __device_dts_ord_xxx symbols from errors and run diagnostics
     if proc.returncode != 0 and args.edt_pickle:
         patterns = [
-            r"(__device_dts_ord_\d+).*undeclared here",  # gcc
+            r"(__device_dts_ord_\d+).* undeclared",  # gcc (quote style depends on locale)
+            r"(__device_dts_ord_\d+).* was not declared",  # g++
             r"undefined reference to.*(__device_dts_ord_\d+)",  # ld
             r"use of undeclared identifier '(__device_dts_ord_\d+)'",  # LLVM/clang (ATfE)
-            r"undefined symbol: \(__device_dts_ord_(\d+)",  # LLVM/lld (ATfE)
+            r"undefined symbol: (__device_dts_ord_\d+)",  # LLVM/lld (ATfE)
         ]
         symbols = {m for p in patterns for m in re.findall(p, proc.stderr)}
 

--- a/tests/misc/dtdoctor/CMakeLists.txt
+++ b/tests/misc/dtdoctor/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(dtdoctor_test)
+target_sources(app PRIVATE src/main.c)
+
+enable_testing()
+include(CTest)
+
+# Unit tests for the dtdoctor scripts (fixture DTS and Kconfig trees)
+add_test(
+  NAME dtdoctor_unit
+  COMMAND ${PYTHON_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/unit -v
+)

--- a/tests/misc/dtdoctor/CMakeLists.txt
+++ b/tests/misc/dtdoctor/CMakeLists.txt
@@ -3,10 +3,14 @@
 
 cmake_minimum_required(VERSION 3.28.0)
 
+# The e2e suite replays the application's own compile commands through the
+# SCA wrapper, against deliberately-broken translation units
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(dtdoctor_test)
-target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE src/main.c src/main.cpp)
 
 enable_testing()
 include(CTest)
@@ -15,4 +19,20 @@ include(CTest)
 add_test(
   NAME dtdoctor_unit
   COMMAND ${PYTHON_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/unit -v
+)
+
+add_test(
+  NAME dtdoctor_e2e
+  COMMAND ${PYTHON_EXECUTABLE} -m pytest
+    ${CMAKE_CURRENT_SOURCE_DIR}/e2e
+    --build-dir ${CMAKE_BINARY_DIR}
+    --cc ${CMAKE_C_COMPILER}
+    -v
+)
+
+# Reproduce the Kconfig environment the dtdoctor SCA launcher runs with, so the
+# analyzer can parse the full Zephyr Kconfig tree for the enabled-node diagnosis
+set_tests_properties(
+  dtdoctor_e2e
+  PROPERTIES ENVIRONMENT "${COMMON_KCONFIG_ENV_SETTINGS}"
 )

--- a/tests/misc/dtdoctor/README.rst
+++ b/tests/misc/dtdoctor/README.rst
@@ -1,0 +1,36 @@
+DT Doctor tests
+###############
+
+Test suite for the DT Doctor static analysis tool
+(``scripts/dts/dtdoctor_sca_wrapper.py`` and ``scripts/dts/dtdoctor_analyzer.py``,
+documented in ``doc/develop/sca/dtdoctor.rst``).
+
+Twister builds this application like any other, with
+``ZEPHYR_SCA_VARIANT=dtdoctor``, and then runs two ctest entries on the host
+(``harness: ctest``) — the firmware itself never executes:
+
+* ``unit/`` is a unit-test pytest suite for the scripts. EDTs are built from
+  inline DTS snippets against the fixture bindings and Kconfig trees under
+  ``unit/fixture/``, so it needs no toolchain and no application build.
+
+* ``e2e/`` is an integration pytest suite run against this application's build
+  directory. It compiles deliberately-broken sources that use the real
+  devicetree macros on the fixture nodes from ``app.overlay``, replaying the
+  application's own compile commands (from ``compile_commands.json``) through
+  the real SCA wrapper, and checks the resulting diagnoses. This exercises the
+  whole chain — generated macros, ``<devicetree.h>`` expansion, the
+  toolchain's actual error messages, wrapper, analyzer — with the same C and
+  C++ compilers the application was built with.
+
+The application is only a build vehicle: ``app.overlay`` declares fake
+``vnd,dtdoctor-*`` devices that deliberately have no driver, and a C++ source
+file is included so a real C++ compile command is exported for the e2e suite.
+
+To run everything locally::
+
+   west twister -T tests/misc/dtdoctor
+
+or, against an existing build::
+
+   west build -b qemu_cortex_m3 tests/misc/dtdoctor -- -DZEPHYR_SCA_VARIANT=dtdoctor
+   ctest --test-dir build --output-on-failure

--- a/tests/misc/dtdoctor/app.overlay
+++ b/tests/misc/dtdoctor/app.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * dtdoctor_disabled is the target of the deliberately-failing builds in
+ * e2e/test_dtdoctor.py; the chosen entry and alias below must show up in its
+ * diagnosis. dtdoctor_enabled exercises the "enabled but no driver" path
+ * (vnd,dtdoctor-device deliberately has no driver).
+ */
+/ {
+	chosen {
+		dtdoctor,dev = &dtdoctor_disabled;
+	};
+
+	aliases {
+		dtdoctor-dev = &dtdoctor_disabled;
+	};
+
+	dtdoctor_disabled: dtdoctor-disabled-device {
+		compatible = "vnd,dtdoctor-device";
+		status = "disabled";
+	};
+
+	dtdoctor_enabled: dtdoctor-enabled-device {
+		compatible = "vnd,dtdoctor-device";
+		status = "okay";
+	};
+};

--- a/tests/misc/dtdoctor/dts/bindings/vnd,dtdoctor-device.yaml
+++ b/tests/misc/dtdoctor/dts/bindings/vnd,dtdoctor-device.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: Fake device without a driver, used by the DT Doctor integration test
+
+compatible: "vnd,dtdoctor-device"

--- a/tests/misc/dtdoctor/e2e/conftest.py
+++ b/tests/misc/dtdoctor/e2e/conftest.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pytest configuration for the DT Doctor integration test."""
+
+import json
+import pickle
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+ZEPHYR_BASE = Path(__file__).parents[4]
+sys.path.insert(0, str(ZEPHYR_BASE / "scripts" / "dts" / "python-devicetree" / "src"))
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--build-dir",
+        action="store",
+        required=True,
+        help="Path to the build directory of the test application",
+    )
+    parser.addoption(
+        "--cc",
+        action="store",
+        required=True,
+        help="Path to the C compiler the application was built with",
+    )
+
+
+@pytest.fixture(scope="session")
+def build_dir(request):
+    return Path(request.config.getoption("--build-dir"))
+
+
+@pytest.fixture(scope="session")
+def cc(request):
+    return request.config.getoption("--cc")
+
+
+@pytest.fixture(scope="session")
+def edt_pickle(build_dir):
+    return build_dir / "zephyr" / "edt.pickle"
+
+
+@pytest.fixture(scope="session")
+def edt(edt_pickle):
+    from devicetree import edtlib  # noqa: F401 (needed to unpickle the EDT)
+
+    with open(edt_pickle, "rb") as f:
+        return pickle.load(f)
+
+
+@pytest.fixture(scope="session")
+def compile_cmd(build_dir):
+    """The application's real compile command for the source file with the given suffix.
+
+    Returns (argv, cwd, source_path), straight from the build's compile_commands.json.
+    """
+    with open(build_dir / "compile_commands.json", encoding="utf-8") as f:
+        entries = json.load(f)
+
+    def _get(suffix: str):
+        entry = next(e for e in entries if e["file"].endswith(suffix))
+        return shlex.split(entry["command"]), Path(entry["directory"]), entry["file"]
+
+    return _get
+
+
+def retarget(argv, source_file, new_source, new_obj):
+    """Point a compile command at another source file and output object.
+
+    Dependency-generation flags are dropped so the replay cannot touch the
+    application build's own .obj/.d files.
+    """
+    result = []
+    skip_next = False
+    for tok in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in ("-MD", "-MMD"):
+            continue
+        if tok in ("-MT", "-MF", "-MQ"):
+            skip_next = True
+            continue
+        result.append(tok)
+
+    for i, tok in enumerate(result):
+        if tok == source_file:
+            result[i] = str(new_source)
+        elif tok == "-o":
+            result[i + 1] = str(new_obj)
+    return result

--- a/tests/misc/dtdoctor/e2e/test_dtdoctor.py
+++ b/tests/misc/dtdoctor/e2e/test_dtdoctor.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end DT Doctor checks, run by ctest against a real application build.
+
+The analyzer and the SCA wrapper are exercised as real subprocesses against the
+build's edt.pickle. The deliberately-failing translation units use the real
+devicetree macros and are compiled with the application's own compile commands
+(replayed from compile_commands.json), so the whole chain is real:
+gen_defines.py output, <devicetree.h> expansion, toolchain message, wrapper,
+analyzer.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from conftest import retarget
+
+ZEPHYR_BASE = Path(__file__).parents[4]
+ANALYZER = ZEPHYR_BASE / "scripts" / "dts" / "dtdoctor_analyzer.py"
+WRAPPER = ZEPHYR_BASE / "scripts" / "dts" / "dtdoctor_sca_wrapper.py"
+
+HEADER = "#include <zephyr/device.h>\n#include <zephyr/devicetree.h>\n\n"
+
+# DEVICE_DT_GET() on the disabled node fails at compile time: <zephyr/device.h>
+# only declares device symbols for status "okay" nodes
+BAD_COMPILE_SNIPPETS = [
+    "const struct device *bad = DEVICE_DT_GET(DT_NODELABEL(dtdoctor_disabled));\n",
+    "const struct device *get_bad(void)\n"
+    "{\n"
+    "\treturn DEVICE_DT_GET(DT_NODELABEL(dtdoctor_disabled));\n"
+    "}\n",
+]
+
+# DEVICE_DT_GET() on the enabled, driver-less node compiles (the symbol is
+# declared) and fails at link time instead
+BAD_LINK_SNIPPET = (
+    "const struct device *okdev = DEVICE_DT_GET(DT_NODELABEL(dtdoctor_enabled));\n"
+    "int main(void)\n"
+    "{\n"
+    "\treturn okdev != (const struct device *)0;\n"
+    "}\n"
+)
+
+
+def ord_symbol(edt, label):
+    return f"__device_dts_ord_{edt.label2node[label].dep_ordinal}"
+
+
+def run_analyzer(edt_pickle, symbol):
+    return subprocess.run(
+        [sys.executable, str(ANALYZER), "--edt-pickle", str(edt_pickle), "--symbol", symbol],
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_wrapper_around(cmd, edt_pickle, cwd=None):
+    return subprocess.run(
+        [sys.executable, str(WRAPPER), "--edt-pickle", str(edt_pickle), "--", *cmd],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+def test_analyzer_reports_disabled_node(edt, edt_pickle):
+    proc = run_analyzer(edt_pickle, ord_symbol(edt, "dtdoctor_disabled"))
+    assert proc.returncode == 0
+    assert "DT Doctor" in proc.stdout
+    assert "is disabled in" in proc.stdout
+    assert "dtdoctor-disabled-device" in proc.stdout
+    assert "'dtdoctor,dev'" in proc.stdout
+    assert "'dtdoctor-dev'" in proc.stdout
+    assert "'status' property to 'okay'" in proc.stdout
+
+
+def test_analyzer_reports_enabled_node_without_driver(edt, edt_pickle):
+    proc = run_analyzer(edt_pickle, ord_symbol(edt, "dtdoctor_enabled"))
+    assert proc.returncode == 0
+    assert "is enabled but no driver" in proc.stdout
+
+
+@pytest.mark.parametrize('suffix', ['src/main.c', 'src/main.cpp'], ids=['c', 'cpp'])
+@pytest.mark.parametrize('snippet', BAD_COMPILE_SNIPPETS, ids=['file-scope', 'function-scope'])
+def test_wrapper_diagnoses_compile_error(compile_cmd, edt_pickle, tmp_path, suffix, snippet):
+    argv, cwd, source = compile_cmd(suffix)
+    bad_src = tmp_path / f"bad{Path(suffix).suffix}"
+    bad_src.write_text(HEADER + snippet, encoding="utf-8")
+
+    cmd = retarget(argv, source, bad_src, tmp_path / "bad.obj")
+    proc = run_wrapper_around(cmd, edt_pickle, cwd=cwd)
+    assert proc.returncode != 0
+
+    # Pin the real toolchain spelling the wrapper regexes exist for: g++ has a
+    # C++-only one, while clang++ shares the C message
+    if suffix.endswith(".cpp") and "g++" in Path(argv[0]).name:
+        assert "was not declared" in proc.stderr
+    else:
+        assert "undeclared" in proc.stderr
+
+    assert "DT Doctor" in proc.stdout
+    assert "is disabled in" in proc.stdout
+
+
+def test_wrapper_diagnoses_link_error(compile_cmd, edt_pickle, cc, tmp_path):
+    argv, cwd, source = compile_cmd('src/main.c')
+    bad_src = tmp_path / "bad.c"
+    bad_src.write_text(HEADER + BAD_LINK_SNIPPET, encoding="utf-8")
+
+    obj = tmp_path / "bad.obj"
+    subprocess.run(retarget(argv, source, bad_src, obj), cwd=cwd, check=True)
+
+    link_cmd = [cc, str(obj), "-nostdlib", "-o", str(tmp_path / "bad.elf")]
+    proc = run_wrapper_around(link_cmd, edt_pickle)
+    assert proc.returncode != 0
+    if "undefined reference" not in proc.stderr and "undefined symbol" not in proc.stderr:
+        pytest.skip(f"unsupported linker error format: {proc.stderr[:200]}")
+    assert "DT Doctor" in proc.stdout
+    assert "is enabled but no driver" in proc.stdout

--- a/tests/misc/dtdoctor/prj.conf
+++ b/tests/misc/dtdoctor/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/tests/misc/dtdoctor/prj.conf
+++ b/tests/misc/dtdoctor/prj.conf
@@ -1,1 +1,1 @@
-# nothing here
+CONFIG_CPP=y

--- a/tests/misc/dtdoctor/src/main.c
+++ b/tests/misc/dtdoctor/src/main.c
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int main(void)
+{
+	return 0;
+}

--- a/tests/misc/dtdoctor/src/main.cpp
+++ b/tests/misc/dtdoctor/src/main.cpp
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Compiled as C++ so the build exports a real C++ compile command for the
+ * e2e suite to replay against deliberately-broken C++ sources.
+ */
+int dtdoctor_cpp(void)
+{
+	return 0;
+}

--- a/tests/misc/dtdoctor/tests.yaml
+++ b/tests/misc/dtdoctor/tests.yaml
@@ -1,0 +1,9 @@
+common:
+  harness: ctest
+  timeout: 120
+tests:
+  sca.dtdoctor:
+    integration_platforms:
+      - qemu_cortex_m3
+    platform_allow:
+      - qemu_cortex_m3

--- a/tests/misc/dtdoctor/unit/conftest.py
+++ b/tests/misc/dtdoctor/unit/conftest.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common fixtures and helpers for the DT Doctor test suite."""
+
+import os
+import pickle
+import sys
+from pathlib import Path
+
+import pytest
+
+ZEPHYR_BASE = Path(os.environ.get("ZEPHYR_BASE", Path(__file__).parents[4]))
+sys.path.insert(0, str(ZEPHYR_BASE / "scripts" / "dts"))
+
+# Importing the analyzer first also puts python-devicetree/src on sys.path, so the
+# edtlib imported below is the same module the analyzer unpickles with.
+import dtdoctor_analyzer  # noqa: E402
+from devicetree import edtlib  # noqa: E402
+
+FIXTURE_DIR = Path(__file__).parent / "fixture"
+BINDINGS_DIR = FIXTURE_DIR / "bindings"
+
+# Disabled node with every kind of reference the disabled-node diagnosis can report:
+# a dependent node ('friend' is a phandle-typed property in the vnd,consumer binding,
+# which is what creates the edt dependency edge), a /chosen entry (which must use the
+# bare &label path form, not <&label>, to show up in edt.chosen_nodes), and an alias.
+DTS_DISABLED_FULL = """
+/dts-v1/;
+
+/ {
+	chosen {
+		zephyr,console = &foo_dev;
+	};
+
+	aliases {
+		my-foo = &foo_dev;
+	};
+
+	foo_dev: foo-device {
+		compatible = "vnd,foo-device";
+		status = "disabled";
+	};
+
+	consumer_a: consumer-a {
+		compatible = "vnd,consumer";
+		friend = <&foo_dev>;
+	};
+};
+"""
+
+# Disabled node nothing refers to: the diagnosis must not claim dependents or references
+DTS_DISABLED_UNREFERENCED = """
+/dts-v1/;
+
+/ {
+	foo_dev: foo-device {
+		compatible = "vnd,foo-device";
+		status = "disabled";
+	};
+};
+"""
+
+# Enabled node whose compatible is gated by fixture/kconfig_basic (DTD_UART
+# depends on DTD_SERIAL && DT_HAS_VND_FOO_DEVICE_ENABLED), for the "enabled but no
+# driver" diagnosis and its Kconfig suggestions
+DTS_ENABLED = """
+/dts-v1/;
+
+/ {
+	foo_dev: foo-device {
+		compatible = "vnd,foo-device";
+		status = "okay";
+	};
+};
+"""
+
+# Two compatibles: suggestions must be the union over both DT_HAS_* symbols
+DTS_ENABLED_MULTI = """
+/dts-v1/;
+
+/ {
+	foo_dev: foo-device {
+		compatible = "vnd,foo-special", "vnd,foo-device";
+		status = "okay";
+	};
+};
+"""
+
+# Enabled node without a compatible: triggers the "could not determine compatible"
+# fallback, no Kconfig analysis
+DTS_ENABLED_NO_COMPAT = """
+/dts-v1/;
+
+/ {
+	bare_dev: bare-device {
+		status = "okay";
+	};
+};
+"""
+
+
+def ord_symbol(edt: edtlib.EDT, label: str) -> str:
+    """Return the __device_dts_ord_N symbol for the node with the given label."""
+    return f"__device_dts_ord_{edt.label2node[label].dep_ordinal}"
+
+
+def dts_line_of(dts_path: Path, needle: str) -> int:
+    """Return the 1-based line number of the first line containing 'needle'."""
+    for lineno, line in enumerate(dts_path.read_text(encoding="utf-8").splitlines(), start=1):
+        if needle in line:
+            return lineno
+    raise ValueError(f"'{needle}' not found in {dts_path}")
+
+
+@pytest.fixture
+def make_edt(tmp_path):
+    """Build an EDT (and its .dts file) from an inline DTS string."""
+
+    def _make(dts_text: str) -> tuple[edtlib.EDT, Path]:
+        dts_path = tmp_path / "test.dts"
+        dts_path.write_text(dts_text, encoding="utf-8")
+        return edtlib.EDT(str(dts_path), [str(BINDINGS_DIR)]), dts_path
+
+    return _make
+
+
+@pytest.fixture
+def make_pickle(tmp_path):
+    """Pickle an EDT the same way gen_edt.py does."""
+
+    def _make(edt: edtlib.EDT) -> Path:
+        pickle_path = tmp_path / "edt.pickle"
+        with open(pickle_path, "wb") as f:
+            pickle.dump(edt, f, protocol=4)
+        return pickle_path
+
+    return _make
+
+
+@pytest.fixture
+def run_analyzer(monkeypatch, capsys):
+    """Run dtdoctor_analyzer.main() in-process and capture its output."""
+
+    def _run(edt_pickle, symbol: str) -> tuple[int, str, str]:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["dtdoctor_analyzer.py", "--edt-pickle", str(edt_pickle), "--symbol", symbol],
+        )
+        rc = dtdoctor_analyzer.main()
+        out, err = capsys.readouterr()
+        return rc, out, err
+
+    return _run
+
+
+@pytest.fixture
+def kconfig_env(monkeypatch):
+    """Point setup_kconfig() at a fixture Kconfig tree, scrubbing kconfiglib env vars."""
+
+    def _use(scenario: str) -> None:
+        for var in list(os.environ):
+            if var.startswith("KCONFIG_"):
+                monkeypatch.delenv(var)
+        for var in ("srctree", "CONFIG_", "EDT_PICKLE"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("ZEPHYR_BASE", str(FIXTURE_DIR / scenario))
+
+    return _use

--- a/tests/misc/dtdoctor/unit/fixture/bindings/vnd,consumer.yaml
+++ b/tests/misc/dtdoctor/unit/fixture/bindings/vnd,consumer.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test node depending on another device through a phandle
+
+compatible: "vnd,consumer"
+
+properties:
+  friend:
+    type: phandle
+    description: phandle to the device this node depends on

--- a/tests/misc/dtdoctor/unit/fixture/bindings/vnd,foo-device.yaml
+++ b/tests/misc/dtdoctor/unit/fixture/bindings/vnd,foo-device.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test device used by the DT Doctor test suite
+
+compatible: "vnd,foo-device"

--- a/tests/misc/dtdoctor/unit/fixture/kconfig_basic/Kconfig
+++ b/tests/misc/dtdoctor/unit/fixture/kconfig_basic/Kconfig
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Standalone Kconfig tree parsed through dtdoctor_analyzer.setup_kconfig() with
+# ZEPHYR_BASE pointing at this directory. DT_HAS_* symbols are generated Kconfig
+# in real builds; they are declared manually here.
+
+config DTD_SERIAL
+	bool "Serial driver support"
+
+config DTD_UART
+	bool "Vendor foo UART driver"
+	default y
+	depends on DTD_SERIAL && DT_HAS_VND_FOO_DEVICE_ENABLED
+
+config DTD_SPECIAL_CORE
+	bool "Special core support"
+
+config DTD_SPECIAL_DRIVER
+	bool "Vendor foo special driver"
+	default y
+	depends on DTD_SPECIAL_CORE && DT_HAS_VND_FOO_SPECIAL_ENABLED
+
+config DTD_BARE_DRIVER
+	bool "Driver whose only dependency is the DT_HAS symbol"
+	default y
+	depends on DT_HAS_VND_BARE_DEVICE_ENABLED
+
+config DT_HAS_VND_FOO_DEVICE_ENABLED
+	def_bool y
+
+config DT_HAS_VND_FOO_SPECIAL_ENABLED
+	def_bool y
+
+config DT_HAS_VND_BARE_DEVICE_ENABLED
+	def_bool y

--- a/tests/misc/dtdoctor/unit/fixture/kconfig_select/Kconfig
+++ b/tests/misc/dtdoctor/unit/fixture/kconfig_select/Kconfig
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Symbols related to the DT_HAS symbol only through select/imply conditions.
+
+config DTD_SELECT_HELPER
+	bool "Helper selected when the foo device is present"
+
+config DTD_PLATFORM_SELECT
+	bool "Platform selecting the helper for the foo device"
+	select DTD_SELECT_HELPER if DT_HAS_VND_FOO_DEVICE_ENABLED
+
+config DTD_IMPLY_HELPER
+	bool "Helper implied when the foo device is present"
+
+config DTD_PLATFORM_IMPLY
+	bool "Platform implying the helper for the foo device"
+	imply DTD_IMPLY_HELPER if DT_HAS_VND_FOO_DEVICE_ENABLED
+
+config DT_HAS_VND_FOO_DEVICE_ENABLED
+	def_bool y

--- a/tests/misc/dtdoctor/unit/fixture/kconfig_substring/Kconfig
+++ b/tests/misc/dtdoctor/unit/fixture/kconfig_substring/Kconfig
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Only a longer-named DT_HAS symbol is defined here; querying the shorter
+# DT_HAS_VND_FOO_DEVICE_ENABLED name must not substring-match it.
+
+config DTD_LONGER_GATE
+	bool "Gate for the longer-named driver"
+
+config DTD_LONGER_DRIVER
+	bool "Driver depending on a longer-named DT_HAS symbol"
+	default y
+	depends on DTD_LONGER_GATE && DT_HAS_VND_FOO_DEVICE_ENABLED_EXT
+
+config DT_HAS_VND_FOO_DEVICE_ENABLED_EXT
+	def_bool y

--- a/tests/misc/dtdoctor/unit/test_dtdoctor_cli.py
+++ b/tests/misc/dtdoctor/unit/test_dtdoctor_cli.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the analyzer CLI symbol/ordinal resolution and exit codes."""
+
+from conftest import DTS_DISABLED_FULL, ord_symbol
+
+
+def test_non_device_symbol_silent_rc1(run_analyzer):
+    # The wrapper only ever passes __device_dts_ord_* symbols; anything else is
+    # rejected silently, before the pickle is even opened
+    rc, out, err = run_analyzer("does-not-matter.pickle", "some_other_symbol")
+    assert rc == 1
+    assert out == ""
+    assert err == ""
+
+
+def test_symbol_embedded_in_text_accepted(make_edt, make_pickle, run_analyzer):
+    edt, _ = make_edt(DTS_DISABLED_FULL)
+    symbol = ord_symbol(edt, "foo_dev")
+    rc, out, _ = run_analyzer(make_pickle(edt), f"`{symbol}' referenced in section .text")
+    assert rc == 0
+    assert "DT Doctor" in out
+
+
+def test_unknown_ordinal_reports_error(make_edt, make_pickle, run_analyzer):
+    edt, _ = make_edt(DTS_DISABLED_FULL)
+    missing = max(n.dep_ordinal for n in edt.nodes) + 1000
+    rc, out, err = run_analyzer(make_pickle(edt), f"__device_dts_ord_{missing}")
+    assert rc == 1
+    assert out == ""
+    assert f"Ordinal {missing} not found" in err

--- a/tests/misc/dtdoctor/unit/test_dtdoctor_disabled.py
+++ b/tests/misc/dtdoctor/unit/test_dtdoctor_disabled.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the disabled-node diagnosis."""
+
+import dtdoctor_analyzer
+from conftest import DTS_DISABLED_FULL, DTS_DISABLED_UNREFERENCED, dts_line_of, ord_symbol
+
+
+def diagnose(edt):
+    return dtdoctor_analyzer.handle_disabled_node(edt.label2node["foo_dev"])
+
+
+def test_headline_reports_file_and_line(make_edt):
+    edt, dts_path = make_edt(DTS_DISABLED_FULL)
+    lineno = dts_line_of(dts_path, 'status = "disabled"')
+    assert diagnose(edt)[0] == f"'foo_dev: /foo-device' is disabled in {dts_path}:{lineno}"
+
+
+def test_lists_dependent_nodes(make_edt):
+    edt, _ = make_edt(DTS_DISABLED_FULL)
+    lines = diagnose(edt)
+    assert "The following nodes depend on it:" in lines
+    assert " - /consumer-a" in lines
+
+
+def test_no_dependents_when_unreferenced(make_edt):
+    edt, _ = make_edt(DTS_DISABLED_UNREFERENCED)
+    assert not any("depend on it" in line for line in diagnose(edt))
+
+
+def test_chosen_reference_reported(make_edt):
+    edt, _ = make_edt(DTS_DISABLED_FULL)
+    assert any("chosen" in line and "'zephyr,console'" in line for line in diagnose(edt))
+
+
+def test_alias_reference_reported(make_edt):
+    edt, _ = make_edt(DTS_DISABLED_FULL)
+    assert any("aliases" in line and "'my-foo'" in line for line in diagnose(edt))
+
+
+def test_remediation_hint(make_edt):
+    edt, _ = make_edt(DTS_DISABLED_FULL)
+    assert any("setting its 'status' property to 'okay'" in line for line in diagnose(edt))
+
+
+def test_main_end_to_end_disabled(make_edt, make_pickle, run_analyzer):
+    edt, dts_path = make_edt(DTS_DISABLED_FULL)
+    rc, out, _ = run_analyzer(make_pickle(edt), ord_symbol(edt, "foo_dev"))
+    assert rc == 0
+    assert "DT Doctor" in out
+    assert "is disabled in" in out
+    assert str(dts_path) in out

--- a/tests/misc/dtdoctor/unit/test_dtdoctor_enabled.py
+++ b/tests/misc/dtdoctor/unit/test_dtdoctor_enabled.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the enabled-node (no driver available) diagnosis."""
+
+import dtdoctor_analyzer
+from conftest import DTS_ENABLED, DTS_ENABLED_MULTI, DTS_ENABLED_NO_COMPAT, ord_symbol
+
+
+def diagnose(edt, label="foo_dev"):
+    return dtdoctor_analyzer.handle_enabled_node(edt.label2node[label])
+
+
+def test_headline_names_node(make_edt, kconfig_env):
+    kconfig_env("kconfig_basic")
+    edt, _ = make_edt(DTS_ENABLED)
+    assert diagnose(edt)[0] == (
+        "'foo_dev: /foo-device' is enabled but no driver appears to be available for it.\n"
+    )
+
+
+def test_suggests_gating_kconfig_options(make_edt, kconfig_env):
+    kconfig_env("kconfig_basic")
+    edt, _ = make_edt(DTS_ENABLED)
+    lines = diagnose(edt)
+    assert "Try enabling these Kconfig options:\n" in lines
+    assert " - CONFIG_DTD_SERIAL=y" in lines
+    # The depending driver symbol itself is not suggested, only its gating options
+    assert not any("CONFIG_DTD_UART" in line for line in lines)
+
+
+def test_multi_compat_union(make_edt, kconfig_env):
+    kconfig_env("kconfig_basic")
+    edt, _ = make_edt(DTS_ENABLED_MULTI)
+    lines = diagnose(edt)
+    assert " - CONFIG_DTD_SERIAL=y" in lines
+    assert " - CONFIG_DTD_SPECIAL_CORE=y" in lines
+
+
+def test_no_compat_fallback(make_edt):
+    edt, _ = make_edt(DTS_ENABLED_NO_COMPAT)
+    lines = diagnose(edt, label="bare_dev")
+    assert "Could not determine compatible; check driver Kconfig manually." in lines
+
+
+def test_missing_zephyr_base_handled(make_edt, monkeypatch):
+    monkeypatch.delenv("ZEPHYR_BASE", raising=False)
+    edt, _ = make_edt(DTS_ENABLED)
+    lines = diagnose(edt)
+    assert any("check driver Kconfig manually" in line for line in lines)
+
+
+def test_main_end_to_end_enabled(make_edt, make_pickle, run_analyzer, kconfig_env):
+    kconfig_env("kconfig_basic")
+    edt, _ = make_edt(DTS_ENABLED)
+    rc, out, _ = run_analyzer(make_pickle(edt), ord_symbol(edt, "foo_dev"))
+    assert rc == 0
+    assert "DT Doctor" in out
+    assert "is enabled but no driver" in out
+    assert " - CONFIG_DTD_SERIAL=y" in out

--- a/tests/misc/dtdoctor/unit/test_dtdoctor_kconfig.py
+++ b/tests/misc/dtdoctor/unit/test_dtdoctor_kconfig.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for find_kconfig_deps() against the fixture Kconfig trees."""
+
+import dtdoctor_analyzer
+import pytest
+
+DT_HAS_FOO = "DT_HAS_VND_FOO_DEVICE_ENABLED"
+
+
+@pytest.fixture
+def load_kconf(kconfig_env):
+    def _load(scenario):
+        kconfig_env(scenario)
+        kconf = dtdoctor_analyzer.setup_kconfig()
+        assert kconf is not None
+        return kconf
+
+    return _load
+
+
+def test_depends_on_suggests_gating_symbols(load_kconf):
+    deps = dtdoctor_analyzer.find_kconfig_deps(load_kconf("kconfig_basic"), DT_HAS_FOO)
+    assert deps == {"CONFIG_DTD_SERIAL"}
+
+
+def test_only_dt_dep_yields_no_suggestions(load_kconf):
+    # A driver whose only dependency is the DT_HAS symbol yields nothing: the
+    # depending symbol itself is never suggested, only its gating options
+    deps = dtdoctor_analyzer.find_kconfig_deps(
+        load_kconf("kconfig_basic"), "DT_HAS_VND_BARE_DEVICE_ENABLED"
+    )
+    assert deps == set()
+
+
+def test_select_condition_detected(load_kconf):
+    deps = dtdoctor_analyzer.find_kconfig_deps(load_kconf("kconfig_select"), DT_HAS_FOO)
+    assert "CONFIG_DTD_PLATFORM_SELECT" in deps
+
+
+def test_imply_condition_detected(load_kconf):
+    deps = dtdoctor_analyzer.find_kconfig_deps(load_kconf("kconfig_select"), DT_HAS_FOO)
+    assert "CONFIG_DTD_PLATFORM_IMPLY" in deps
+
+
+def test_no_substring_false_positive(load_kconf):
+    # DT_HAS_VND_FOO_DEVICE_ENABLED must not match DT_HAS_VND_FOO_DEVICE_ENABLED_EXT
+    deps = dtdoctor_analyzer.find_kconfig_deps(load_kconf("kconfig_substring"), DT_HAS_FOO)
+    assert deps == set()

--- a/tests/misc/dtdoctor/unit/test_dtdoctor_wrapper.py
+++ b/tests/misc/dtdoctor/unit/test_dtdoctor_wrapper.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dtdoctor_sca_wrapper.py error detection and analyzer dispatch."""
+
+import subprocess
+import sys
+
+import dtdoctor_sca_wrapper
+import pytest
+from conftest import DTS_DISABLED_FULL, ZEPHYR_BASE, ord_symbol
+
+WRAPPER = ZEPHYR_BASE / "scripts" / "dts" / "dtdoctor_sca_wrapper.py"
+
+
+def make_fake_run(rc, stdout="", stderr=""):
+    """Fake subprocess.run: the compiler call uses capture_output, analyzer calls don't."""
+    calls = {"compiler": None, "analyzer": []}
+
+    def fake_run(cmd, **kwargs):
+        if kwargs.get("capture_output"):
+            calls["compiler"] = cmd
+            return subprocess.CompletedProcess(cmd, rc, stdout, stderr)
+        calls["analyzer"].append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    return fake_run, calls
+
+
+def run_wrapper(monkeypatch, argv, fake_run):
+    monkeypatch.setattr(sys, "argv", ["dtdoctor_sca_wrapper.py", *argv])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return dtdoctor_sca_wrapper.main()
+
+
+TESTDATA_TOOLCHAIN_ERRORS = [
+    (
+        "main.c:10:23: error: '__device_dts_ord_7' undeclared here (not in a function); "
+        "did you mean 'device_get_binding'?",
+        "__device_dts_ord_7",
+    ),
+    (
+        "main.c:12:9: error: '__device_dts_ord_7' undeclared (first use in this function)",
+        "__device_dts_ord_7",
+    ),
+    (
+        # gcc built with NLS uses Unicode quotes in UTF-8 locales
+        "main.c:10:23: error: ‘__device_dts_ord_7’ undeclared here (not in a function)",
+        "__device_dts_ord_7",
+    ),
+    (
+        "main.cpp:10:11: error: '__device_dts_ord_7' was not declared in this scope",
+        "__device_dts_ord_7",
+    ),
+    (
+        "main.c:(.text+0x12): undefined reference to `__device_dts_ord_7'",
+        "__device_dts_ord_7",
+    ),
+    (
+        "main.c:10:23: error: use of undeclared identifier '__device_dts_ord_7'",
+        "__device_dts_ord_7",
+    ),
+    (
+        "ld.lld: error: undefined symbol: __device_dts_ord_7",
+        "__device_dts_ord_7",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    'stderr_line, expected_symbol',
+    TESTDATA_TOOLCHAIN_ERRORS,
+    ids=[
+        'gcc-file-scope',
+        'gcc-function-scope',
+        'gcc-utf8-quotes',
+        'g++',
+        'gnu-ld',
+        'clang',
+        'lld',
+    ],
+)
+def test_toolchain_regex_detection(monkeypatch, stderr_line, expected_symbol):
+    fake_run, calls = make_fake_run(rc=1, stderr=stderr_line + "\n")
+    rc = run_wrapper(
+        monkeypatch, ["--edt-pickle", "edt.pickle", "--", "cc", "-c", "main.c"], fake_run
+    )
+    assert rc == 1
+    assert calls["compiler"] == ["cc", "-c", "main.c"]
+    assert len(calls["analyzer"]) == 1
+    cmd = calls["analyzer"][0]
+    assert cmd[0] == sys.executable
+    assert cmd[1].endswith("dtdoctor_analyzer.py")
+    assert cmd[2:] == ["--edt-pickle", "edt.pickle", "--symbol", expected_symbol]
+
+
+def test_deduplication(monkeypatch):
+    stderr = "\n".join(
+        [
+            "main.c:10:23: error: '__device_dts_ord_7' undeclared here (not in a function)",
+            "main.c:(.text+0x12): undefined reference to `__device_dts_ord_7'",
+            "main.c:11:5: error: use of undeclared identifier '__device_dts_ord_9'",
+        ]
+    )
+    fake_run, calls = make_fake_run(rc=1, stderr=stderr)
+    run_wrapper(monkeypatch, ["--edt-pickle", "edt.pickle", "--", "cc"], fake_run)
+    symbols = [cmd[-1] for cmd in calls["analyzer"]]
+    assert symbols == ["__device_dts_ord_7", "__device_dts_ord_9"]
+
+
+def test_success_runs_no_analysis(monkeypatch):
+    stderr = "main.c:10:23: error: '__device_dts_ord_7' undeclared here (not in a function)"
+    fake_run, calls = make_fake_run(rc=0, stderr=stderr)
+    rc = run_wrapper(monkeypatch, ["--edt-pickle", "edt.pickle", "--", "cc"], fake_run)
+    assert rc == 0
+    assert calls["analyzer"] == []
+
+
+def test_no_edt_pickle_no_analysis(monkeypatch):
+    stderr = "main.c:10:23: error: '__device_dts_ord_7' undeclared here (not in a function)"
+    fake_run, calls = make_fake_run(rc=1, stderr=stderr)
+    rc = run_wrapper(monkeypatch, ["--", "cc"], fake_run)
+    assert rc == 1
+    assert calls["analyzer"] == []
+
+
+def test_compiler_output_replayed(monkeypatch, capsys):
+    fake_run, _ = make_fake_run(rc=1, stdout="compiler stdout\n", stderr="compiler stderr\n")
+    rc = run_wrapper(monkeypatch, ["--", "cc"], fake_run)
+    out, err = capsys.readouterr()
+    assert rc == 1
+    assert out == "compiler stdout\n"
+    assert err == "compiler stderr\n"
+
+
+def test_rc_passthrough(monkeypatch):
+    fake_run, _ = make_fake_run(rc=3)
+    assert run_wrapper(monkeypatch, ["--edt-pickle", "edt.pickle", "--", "cc"], fake_run) == 3
+
+
+def test_rc_passthrough_with_analysis(monkeypatch):
+    stderr = "main.c:(.text+0x12): undefined reference to `__device_dts_ord_7'"
+    fake_run, calls = make_fake_run(rc=1, stderr=stderr)
+    rc = run_wrapper(monkeypatch, ["--edt-pickle", "edt.pickle", "--", "cc"], fake_run)
+    assert rc == 1
+    assert len(calls["analyzer"]) == 1
+
+
+def test_no_double_dash_fallback(monkeypatch):
+    fake_run, calls = make_fake_run(rc=0)
+    run_wrapper(monkeypatch, ["cc", "-c", "main.c"], fake_run)
+    assert calls["compiler"] == ["cc", "-c", "main.c"]
+
+
+def test_no_double_dash_keeps_flag_in_cmd(monkeypatch):
+    # Without a '--' separator the whole argv is used as the command, --edt-pickle included
+    fake_run, calls = make_fake_run(rc=0)
+    run_wrapper(monkeypatch, ["--edt-pickle", "edt.pickle", "cc"], fake_run)
+    assert calls["compiler"] == ["--edt-pickle", "edt.pickle", "cc"]
+
+
+def test_end_to_end_real_processes(make_edt, make_pickle, tmp_path):
+    edt, _ = make_edt(DTS_DISABLED_FULL)
+    symbol = ord_symbol(edt, "foo_dev")
+    fake_cc = tmp_path / "fake_cc.py"
+    fake_cc.write_text(
+        "import sys\n"
+        f"sys.stderr.write(\"main.c: undefined reference to `{symbol}'\\n\")\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            "--edt-pickle",
+            str(make_pickle(edt)),
+            "--",
+            sys.executable,
+            str(fake_cc),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1
+    assert "undefined reference" in proc.stderr
+    assert "DT Doctor" in proc.stdout
+    assert "is disabled in" in proc.stdout


### PR DESCRIPTION
- Fix several issues in the DT Doctor SCA scripts that prevented diagnoses from being emitted (toolchain error regexes, alias reporting, select/imply matching, crash when `ZEPHYR_BASE` is unset)
- Add a test suite under `tests/misc/dtdoctor/`: unit tests covering error detection and both diagnosis paths, plus an integration test (`harness: ctest`) that builds the documented way, with `-DZEPHYR_SCA_VARIANT=dtdoctor`, and exercises the tool end to end with real failing compile and link commands
