### PR TITLE
modules: hostap: Add WIFI_NM_WPA_SUPPLICANT_PRINT_PMK debug option

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -765,3 +765,9 @@ if(CONFIG_SAE_PWE_EARLY_EXIT)
   "this is not secure and is a workaround for low resource systems, "
   "please use it carefully and do not use it production.")
 endif()
+
+if(CONFIG_WIFI_NM_WPA_SUPPLICANT_PRINT_PMK)
+  message(WARNING "CONFIG_WIFI_NM_WPA_SUPPLICANT_PRINT_PMK is enabled, "
+  "the PMK will be printed in cleartext on every successful Wi-Fi handshake, "
+  "this is a security risk and must not be enabled in production builds.")
+endif()

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -125,6 +125,19 @@ config WIFI_NM_WPA_SUPPLICANT_DEBUG_SHOW_KEYS
 	  development or debugging. Key material should never be logged in production
 	  systems as it can compromise network security.
 
+config WIFI_NM_WPA_SUPPLICANT_PRINT_PMK
+	bool "Print PMK once per successful handshake"
+	select EXPERIMENTAL
+	help
+	  Prints the PMK (as a hex string) once per completed 4-way handshake,
+	  independent of WIFI_NM_WPA_SUPPLICANT_DEBUG_LEVEL and
+	  WIFI_NM_WPA_SUPPLICANT_DEBUG_SHOW_KEYS. Intended for capturing the PMK
+	  needed to decrypt an over-the-air Wi-Fi capture, without the log
+	  volume that comes with enabling full supplicant debug output.
+
+	  WARNING: This is a security risk and should only be enabled during
+	  development or debugging.
+
 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_DBG
 # hostap debug is very verbose and despite large log buffer sizes
 # log messages can be lost. So, we set the log mode to immediate

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -42,6 +42,19 @@ static K_THREAD_STACK_DEFINE(iface_wq_stack, CONFIG_WIFI_NM_WPA_SUPPLICANT_WQ_ST
 #include "eloop.h"
 #include "wpa_supplicant/config.h"
 #include "wpa_supplicant_i.h"
+
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_PRINT_PMK
+/* struct wpa_sm is private to rsn_supp, pulled in only for this debug-only
+ * print. wpa_i.h is not self-contained - it needs struct wpa_sm_ctx,
+ * struct wpa_sm_mlo and enum wpa_rsn_override (all in wpa.h), matching the
+ * exact preamble wpa.c itself uses right before including wpa_i.h.
+ */
+#include "rsn_supp/wpa.h"
+#include "preauth.h"
+#include "pmksa_cache.h"
+#include "rsn_supp/wpa_i.h"
+#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_PRINT_PMK */
+
 #include "fst/fst.h"
 #include "wpa_cli_zephyr.h"
 #include "ctrl_iface_zephyr.h"
@@ -238,6 +251,15 @@ static void zephyr_wpa_supplicant_msg(void *ctx, const char *txt, size_t len)
 
 	/* Only interested in CTRL-EVENTs */
 	if (strncmp(txt, "CTRL-EVENT", 10) == 0) {
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_PRINT_PMK
+		if (strncmp(txt, "CTRL-EVENT-CONNECTED", 20) == 0 && wpa_s->wpa) {
+			char pmk_hex[2 * PMK_LEN_MAX + 1];
+
+			wpa_snprintf_hex(pmk_hex, sizeof(pmk_hex),
+					 wpa_s->wpa->pmk, wpa_s->wpa->pmk_len);
+			wpa_printf(MSG_ERROR, "WPA: PMK = %s", pmk_hex);
+		}
+#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_PRINT_PMK */
 		if (strncmp(txt, "CTRL-EVENT-SIGNAL-CHANGE", 24) == 0) {
 			supplicant_send_wifi_mgmt_event(wpa_s->ifname,
 						NET_EVENT_WIFI_CMD_SIGNAL_CHANGE,

--- a/tests/net/wifi/configs/tests.yaml
+++ b/tests/net/wifi/configs/tests.yaml
@@ -85,3 +85,6 @@ tests:
   wifi.build.nan:
     extra_configs:
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN=y
+  net.wifi.build.print_pmk:
+    extra_configs:
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_PRINT_PMK=y


### PR DESCRIPTION
Getting the PMK out of the supplicant for offline decryption currently requires WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_DBG plus DEBUG_SHOW_KEYS, which floods the console with full debug output and may affect application execution.

Add a dedicated Kconfig, decoupled from the supplicant debug level, that gates a single PMK print per successful handshake. Also add a CMake configure-time warning so it can't be left enabled unnoticed.