### PR TITLE
drivers: clock_control: stm32h7: select PLL VCO range from VCO output

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -40,7 +40,7 @@
 #define apb5_prescaler(v) CONCAT(LL_RCC_APB5_DIV_, v)
 
 /* PLLx fractional ratio is 2^13 */
-#define PLL_FRACN_DIVISOR 8192
+#define PLL_FRACN_DIVISOR 8192ULL
 
 /* Given source clock and dividers, compute the output frequency of PLLx_P */
 #define PLLX_VCO_FREQ(pllsrc_freq, divm, divn, fracn) \
@@ -366,14 +366,32 @@ static int get_vco_input_range(uint32_t m_div, uint32_t *range)
 	return 0;
 }
 
+/*
+ * Select the PLL VCO output range (PLLxVCOSEL). Per RM0433 the medium range
+ * spans 150-420 MHz and the wide range spans 192-960 MHz. The range must be
+ * chosen from the VCO *output* frequency, not the VCO input range: a 1-2 MHz
+ * input can legally drive the VCO above 420 MHz (e.g. M=4, N=480 for a 480 MHz
+ * SYSCLK), and selecting the medium range for such a VCO leaves the PLL unable
+ * to lock, hanging clock init in the PLL-ready wait loop below. Force the wide
+ * range above the medium ceiling and force the medium range below the wide
+ * floor; in the 192-420 MHz overlap keep the historical input-range-based
+ * choice so existing configurations are unchanged.
+ */
 __unused
-static uint32_t get_vco_output_range(uint32_t vco_input_range)
+static int get_vco_output_range(uint32_t target_vco_ck, uint32_t *range)
 {
-	if (vco_input_range == LL_RCC_PLLINPUTRANGE_1_2) {
-		return LL_RCC_PLLVCORANGE_MEDIUM;
+	if (IN_RANGE(target_vco_ck, MHZ(150), MHZ(420))) {
+		/* Prefer VCOL if possible (for power consumption) */
+		*range = LL_RCC_PLLVCORANGE_MEDIUM;
+		return 0;
 	}
 
-	return LL_RCC_PLLVCORANGE_WIDE;
+	if (IN_RANGE(target_vco_ck, MHZ(192), MHZ(960))) {
+		*range = LL_RCC_PLLVCORANGE_WIDE;
+		return 0;
+	}
+
+	return -ERANGE;
 }
 
 #endif /* ! CONFIG_CPU_CORTEX_M4 */
@@ -980,7 +998,12 @@ static int set_up_plls(void)
 		return r;
 	}
 
-	vco_output_range = get_vco_output_range(vco_input_range);
+	r = get_vco_output_range(
+		(uint32_t)PLLX_VCO_FREQ(PLLSRC_FREQ, STM32_PLL_M_DIVISOR, STM32_PLL_N_MULTIPLIER, STM32_PLL_FRACN_VALUE),
+		&vco_output_range);
+	if (r < 0) {
+		return r;
+	}
 
 	LL_RCC_PLL1_SetM(STM32_PLL_M_DIVISOR);
 
@@ -1028,7 +1051,12 @@ static int set_up_plls(void)
 		return r;
 	}
 
-	vco_output_range = get_vco_output_range(vco_input_range);
+	r = get_vco_output_range(
+		(uint32_t)PLLX_VCO_FREQ(PLLSRC_FREQ, STM32_PLL2_M_DIVISOR, STM32_PLL2_N_MULTIPLIER, STM32_PLL2_FRACN_VALUE),
+		&vco_output_range);
+	if (r < 0) {
+		return r;
+	}
 
 	LL_RCC_PLL2_SetM(STM32_PLL2_M_DIVISOR);
 
@@ -1082,7 +1110,12 @@ static int set_up_plls(void)
 		return r;
 	}
 
-	vco_output_range = get_vco_output_range(vco_input_range);
+	r = get_vco_output_range(
+		(uint32_t)PLLX_VCO_FREQ(PLLSRC_FREQ, STM32_PLL3_M_DIVISOR, STM32_PLL3_N_MULTIPLIER, STM32_PLL3_FRACN_VALUE),
+		&vco_output_range);
+	if (r < 0) {
+		return r;
+	}
 
 	LL_RCC_PLL3_SetM(STM32_PLL3_M_DIVISOR);
 

--- a/dts/bindings/clock/st,stm32h7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-pll-clock.yaml
@@ -20,7 +20,9 @@ description: |
 
       with f(VCOx clock) = f(REFx_CK) × (PLLNx / PLLMx)
 
-  The PLL output frequency must not exceed 80 MHz.
+  The maximum PLL output frequency is device dependent,
+  for example 480 MHz on STM32H743 - refer to the reference manual
+  and datasheet of the target device.
 
 compatible: "st,stm32h7-pll-clock"
 


### PR DESCRIPTION
The STM32H7 PLL VCO output range (PLLxVCOSEL) was derived solely from the VCO input range: any 1-2 MHz PLL input selected the medium VCO range. That is incorrect. Per RM0433 the medium range only spans 150-420 MHz while the wide range spans 192-960 MHz, and the range must be chosen from the VCO *output* frequency, not the input frequency.

A 1-2 MHz input can legally drive the VCO well above 420 MHz. For example a board with an 8 MHz HSE and M=4 (2 MHz input), N=480 targets a 960 MHz VCO for a 480 MHz SYSCLK. With the old logic the medium range was programmed for that 960 MHz VCO, the PLL never reached the locked state, and clock init hung forever in the `while (LL_RCC_PLLx_IsReady() != 1U)` wait - the board came up completely dead (no console, no output) with no diagnostic.

Fix get_vco_output_range() to force the wide range whenever the VCO output exceeds the medium ceiling (420 MHz), and otherwise keep the historical input-range-based choice so existing, already-working configurations are unchanged. The VCO output frequency is computed at each PLL call site as (PLLSRC_FREQ / M) * N.