### PR TITLE
west: blobs: implement mirroring for "blobs"

### DIFF
--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -297,6 +297,10 @@ under their original filename or with a SHA-256 suffix (``<filename>.<sha>``).
 If found, the blob is copied from the cache to the blob path; otherwise
 it is downloaded from its URL(s) to the blob path.
 
+If the ``blobs.url-mirror`` configuration option is set to a ``;``-separated
+list of ``<src-url>=<mirror-url>`` mappings, ``west blobs fetch`` tries each
+matching mirror URL before falling back to the blob's original URL.
+
 .. _west-twister:
 
 Twister wrapper: ``west twister``

--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -204,6 +204,21 @@ class Blobs(WestCommand):
         if not isinstance(urls, list):
             urls = (urls,)
 
+        url_mirror_config = self.config.get('blobs.url-mirror')
+        if url_mirror_config:
+            mirror_urls = []
+            for url in urls:
+                for url_mirror in url_mirror_config.split(';'):
+                    _src, _dst = url_mirror.split('=')
+                    _src = _src.rstrip('/') + '/'
+                    _dst = _dst.rstrip('/') + '/'
+                    if url.startswith(_src):
+                        mirror_url = f"{_dst}" + url.removeprefix(_src)
+                        self.dbg(f'    [debug] mirror was specified: {mirror_url}')
+                        mirror_urls.append(mirror_url)
+                mirror_urls.append(url)
+            urls = mirror_urls
+
         downloaded = False
         for i, url in enumerate(urls):
             scheme = blob.get('fetcher') or urlparse(url).scheme


### PR DESCRIPTION
The concept is to emulate a smart "git insteadof" feature
for blobs in order to reduce the rate-limit and networking
issues when accessing upstream repositories.

If the upstream repo has been mirrored to the URL
defined by the "west config blobs.url-mirror" configuration,
then fetch the blob content from the mirror repo "instead of"
from the upstream repository.