### PR TITLE
can: userspace: reject dynamically allocated RX message queues

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -223,7 +223,11 @@ static inline int z_vrfy_can_add_rx_filter_msgq(const struct device *dev,
 	struct can_filter filter_copy;
 
 	K_OOPS(K_SYSCALL_DRIVER_CAN(dev, add_rx_filter));
-	K_OOPS(K_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	/* The message queue pointer is retained by the CAN RX filter for as long
+	 * as the filter is installed, so it must not be an object which user
+	 * mode can free. See CAN_MSGQ_DEFINE().
+	 */
+	K_OOPS(K_SYSCALL_OBJ_STATIC(msgq, K_OBJ_MSGQ));
 	K_OOPS(k_usermode_from_copy(&filter_copy, filter, sizeof(filter_copy)));
 
 	return z_impl_can_add_rx_filter_msgq(dev, msgq, &filter_copy);

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1404,6 +1404,15 @@ int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
  * @note The message queue must be initialized before calling this function and
  * the caller must have appropriate permissions on it.
  *
+ * @warning The CAN controller driver retains the message queue pointer for as
+ * long as the filter is installed. The message queue must therefore remain
+ * valid until the filter is removed with @a can_remove_rx_filter(); received
+ * frames are otherwise written to freed memory. Use @a CAN_MSGQ_DEFINE() to
+ * statically define the message queue. Message queues obtained from
+ * @a k_object_alloc() may not be used, as they are freed once the last thread
+ * holding permission on them releases it or terminates; such message queues
+ * are rejected when this function is called from user mode.
+ *
  * @warning Message queue overruns are silently ignored and overrun frames
  * discarded. Custom error handling can be implemented by using
  * @a can_add_rx_filter() and @a k_msgq_put() directly.

--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -121,6 +121,33 @@ void k_object_dump_error(int retval, const void *obj,
  */
 struct k_object *k_object_find(const void *obj);
 
+/**
+ * Check whether a kernel object was dynamically allocated
+ *
+ * The lifetime of a dynamically allocated kernel object is driven by its
+ * permission bitmask: the object is freed as soon as
+ * the last thread holding permission on it releases that permission or
+ * terminates, and the memory may then be reused by an unrelated kernel object.
+ * A pointer held by the kernel itself is not represented in that bitmask and
+ * therefore does not keep the object alive.
+ *
+ * Any syscall which retains a pointer to a kernel object beyond the duration
+ * of the call itself must therefore reject dynamically allocated objects, as
+ * validating the object at registration time says nothing about its validity
+ * when the retained pointer is later dereferenced.
+ *
+ * @param obj Address of the kernel object
+ * @return true if the object exists and was dynamically allocated
+ * @note This is an internal API. Do not use unless you are extending
+ *       functionality in the Zephyr tree.
+ */
+static inline bool k_object_is_dynamic(const void *obj)
+{
+	struct k_object *ko = k_object_find(obj);
+
+	return (ko != NULL) && ((ko->flags & K_OBJ_FLAG_ALLOC) != 0U);
+}
+
 typedef void (*_wordlist_cb_func_t)(struct k_object *ko, void *context);
 
 /**
@@ -646,6 +673,32 @@ static inline int k_object_validation_check(struct k_object *ko,
 
 #define K_SYSCALL_OBJ_NEVER_INIT(ptr, type) \
 	K_SYSCALL_IS_OBJ(ptr, type, _OBJ_INIT_FALSE)
+
+/**
+ * @brief Runtime check kernel object pointer that the kernel will retain
+ *
+ * As K_SYSCALL_OBJ(), but additionally rejects dynamically allocated kernel
+ * objects. Use this instead of K_SYSCALL_OBJ() in system call handlers which
+ * store the object pointer somewhere the kernel dereferences after the system
+ * call has returned. A dynamically allocated object can be freed by user mode
+ * at any point after the check -- by calling k_object_release() or simply by
+ * terminating the last thread holding permission on it -- leaving the retained
+ * pointer dangling and liable to alias an unrelated object once the memory is
+ * reused.
+ *
+ * @param ptr Untrusted kernel object pointer
+ * @param type Expected kernel object type
+ * @return 0 on success, nonzero on failure
+ * @note This is an internal API. Do not use unless you are extending
+ *       functionality in the Zephyr tree.
+ */
+
+#define K_SYSCALL_OBJ_STATIC(ptr, type) \
+	(K_SYSCALL_OBJ(ptr, type) || \
+	 K_SYSCALL_VERIFY_MSG(!k_object_is_dynamic((const void *)(ptr)), \
+			      "dynamically allocated kernel object %p may not " \
+			      "be used here, it can be freed while still in use", \
+			      (const void *)(ptr)))
 
 #include <zephyr/driver-validation.h>
 

--- a/tests/drivers/can/api/prj.conf
+++ b/tests/drivers/can/api/prj.conf
@@ -7,6 +7,8 @@ CONFIG_CAN_RX_TIMESTAMP=y
 CONFIG_PM_DEVICE=y
 CONFIG_TEST_USERSPACE=y
 CONFIG_ZTEST=y
+# Needed by test_add_rx_filter_msgq_dynamic, which expects a kernel oops
+CONFIG_ZTEST_FATAL_HOOK=y
 # Global default settings assign both the ZTest thread and the system worker queue to the same
 # cooperative priority. Relying solely on the system worker queue for concurrency management can
 # lead to unwanted interference between the two threads, causing the test to report its expected

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/drivers/can.h>
 #include <zephyr/ztest.h>
+#include <zephyr/ztest_error_hook.h>
 
 #include "common.h"
 
@@ -730,6 +731,35 @@ ZTEST_USER(can_classic, test_max_ext_filters)
 {
 	add_remove_max_filters(true);
 }
+
+#if defined(CONFIG_USERSPACE) && defined(CONFIG_DYNAMIC_OBJECTS)
+/**
+ * @brief Test that a dynamically allocated message queue is rejected from user mode.
+ *
+ * The CAN RX filter retains the message queue pointer for as long as the filter is
+ * installed, but a dynamically allocated kernel object is freed as soon as the last
+ * thread holding permission on it releases it or terminates. Accepting one would
+ * leave the filter with a dangling pointer, which a later matching frame would
+ * write through - potentially into an unrelated object which has since reused the
+ * memory. The syscall must therefore refuse it.
+ */
+ZTEST_USER(can_classic, test_add_rx_filter_msgq_dynamic)
+{
+	struct k_msgq *msgq;
+	int err;
+
+	msgq = k_object_alloc(K_OBJ_MSGQ);
+	zassert_not_null(msgq, "failed to allocate message queue object");
+
+	err = k_msgq_alloc_init(msgq, sizeof(struct can_frame), 5);
+	zassert_ok(err, "failed to initialize message queue (err %d)", err);
+
+	ztest_set_fault_valid(true);
+	(void)can_add_rx_filter_msgq(can_dev, msgq, &test_std_filter_1);
+
+	zassert_unreachable("dynamically allocated message queue was accepted");
+}
+#endif /* CONFIG_USERSPACE && CONFIG_DYNAMIC_OBJECTS */
 
 /**
  * @brief Test that no message is received when nothing was sent.


### PR DESCRIPTION
`can_add_rx_filter_msgq()` stores the caller's `k_msgq` pointer in the CAN
RX filter, where the driver dereferences it on every matching frame for as
long as the filter is installed. The syscall handler validated that pointer
exactly once, at registration.

A dynamically allocated message queue is freed as soon as the last thread
holding permission on it releases that permission or terminates — either by
calling `k_object_release()`, or simply by exiting. The filter is left
holding a dangling pointer, and the next matching frame is written through
it, into whichever kernel object has since reused the memory.

Fixes: #118955