### PR TITLE
tracing: ctf: add cpu_id and prio to thread switch events

### DIFF
--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -35,11 +35,18 @@ void sys_trace_k_thread_switched_out(void)
 {
 	ctf_bounded_string_t name = {"unknown"};
 	struct k_thread *thread;
+	uint8_t cpu_id = 0U;
+	int8_t prio;
 
 	thread = k_sched_current_thread_query();
 	_get_thread_name(thread, &name);
 
-	ctf_top_thread_switched_out((uint32_t)(uintptr_t)thread, name);
+#ifdef CONFIG_SMP
+	cpu_id = (uint8_t)thread->base.cpu;
+#endif
+	prio = (int8_t)thread->base.prio;
+
+	ctf_top_thread_switched_out((uint32_t)(uintptr_t)thread, name, cpu_id, prio);
 }
 
 void sys_trace_k_thread_user_mode_enter(void)
@@ -64,11 +71,19 @@ void sys_trace_k_thread_switched_in(void)
 {
 	struct k_thread *thread;
 	ctf_bounded_string_t name = {"unknown"};
+	uint8_t cpu_id = 0U;
+	int8_t prio;
 
 	thread = k_sched_current_thread_query();
 	_get_thread_name(thread, &name);
 
-	ctf_top_thread_switched_in((uint32_t)(uintptr_t)thread, name);
+#ifdef CONFIG_SMP
+	cpu_id = (uint8_t)thread->base.cpu;
+#endif
+	prio = (int8_t)thread->base.prio;
+
+	ctf_top_thread_switched_in((uint32_t)(uintptr_t)thread, name, cpu_id, prio);
+
 }
 
 void sys_trace_k_thread_priority_set(struct k_thread *thread)

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -503,14 +503,20 @@ typedef struct {
 	char buf[CTF_MAX_STRING_LEN];
 } ctf_bounded_string_t;
 
-static inline void ctf_top_thread_switched_out(uint32_t thread_id, ctf_bounded_string_t name)
+static inline void ctf_top_thread_switched_out(uint32_t thread_id,
+						ctf_bounded_string_t name,
+						uint8_t cpu_id, int8_t prio)
 {
-	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_THREAD_SWITCHED_OUT), thread_id, name);
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_THREAD_SWITCHED_OUT),
+		  thread_id, name, cpu_id, prio);
 }
 
-static inline void ctf_top_thread_switched_in(uint32_t thread_id, ctf_bounded_string_t name)
+static inline void ctf_top_thread_switched_in(uint32_t thread_id,
+					       ctf_bounded_string_t name,
+					       uint8_t cpu_id, int8_t prio)
 {
-	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_THREAD_SWITCHED_IN), thread_id, name);
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_THREAD_SWITCHED_IN),
+		  thread_id, name, cpu_id, prio);
 }
 
 static inline void ctf_top_thread_priority_set(uint32_t thread_id, int8_t prio,

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /* CTF 1.8 */
 typealias integer { size = 8; align = 8; signed = true; } := int8_t;
 typealias integer { size = 8; align = 8; signed = false; } := uint8_t;
@@ -28,6 +29,8 @@ event {
 	fields := struct {
 		uint32_t thread_id;
 		ctf_bounded_string_t name[20];
+		uint8_t cpu_id;
+		int8_t prio;
 	};
 };
 
@@ -37,6 +40,8 @@ event {
 	fields := struct {
 		uint32_t thread_id;
 		ctf_bounded_string_t name[20];
+		uint8_t cpu_id;
+		int8_t prio;
 	};
 };
 


### PR DESCRIPTION
## What
Add `cpu_id` and `prio` to the `thread_switched_in`/`thread_switched_out` CTF tracing events.

## Why
Without `cpu_id`, there is no way to determine which CPU a context switch occurred on in SMP systems, making it impossible to correlate thread activity to a specific processor or reconstruct per-core execution timelines from the CTF stream alone.

Without `prio`, the scheduling priority of a thread at the time it was switched in or out is lost, preventing post-hoc analysis of scheduling behavior such as detecting priority inversions or understanding how priority influenced scheduling decisions.

Recording both fields directly in the context-switch events eliminates the need for separate probe events that would otherwise be required to recover this information, reducing tracing overhead and complexity.

## Notes
- `cpu_id` is extracted under `CONFIG_SMP`; emits `0U` on uniprocessor builds. The field is always present to maintain a single, consistent metadata schema across SMP and non-SMP configurations.
- CTF metadata has been updated to reflect the new binary layout.

## Testing
Built on `qemu_cortex_a53/smp` (SMP) and `qemu_x86` (non-SMP). 
Twister `tests/subsys/tracing/` passes on both targets.

Field order in both events (matches metadata):
  thread_id (uint32_t), name (char[20]), cpu_id (uint8_t), prio (int8_t)