### PR TITLE
arch: common: copy TCM sections regardless of CONFIG_XIP

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_subdirectory_ifdef(CONFIG_ACPI acpi)
 zephyr_library_sources(init.c)
 zephyr_library_sources_ifdef(CONFIG_PM pm.c)
-zephyr_library_sources_ifdef(CONFIG_XIP xip.c)
+zephyr_library_sources(xip.c)
 
 zephyr_library_sources_ifdef(
   CONFIG_ISR_TABLE_SHELL

--- a/arch/common/xip.c
+++ b/arch/common/xip.c
@@ -20,12 +20,16 @@ extern volatile uintptr_t __stack_chk_guard;
 #endif /* CONFIG_REQUIRES_STACK_CANARIES */
 
 /**
- * @brief Copy the data section from ROM to RAM
+ * @brief Copy sections whose load address differs from their virtual address
  *
- * This routine copies the data section from ROM to RAM.
+ * With CONFIG_XIP this copies the data section and the other regions residing
+ * in ROM. TCM regions are copied unconditionally, as they are separate
+ * memories whose load address differs from their virtual address regardless
+ * of CONFIG_XIP.
  */
 void arch_data_copy(void)
 {
+#ifdef CONFIG_XIP
 	arch_early_memcpy(&__data_region_start, &__data_region_load_start,
 		       __data_region_end - __data_region_start);
 #ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
@@ -38,14 +42,6 @@ void arch_data_copy(void)
 		       (uintptr_t) &_nocache_load_ram_size);
 #endif /* CONFIG_NOCACHE_MEMORY */
 #endif /* CONFIG_ARCH_HAS_NOCACHE_MEMORY_SUPPORT */
-#if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_itcm))
-	arch_early_memcpy(&__itcm_start, &__itcm_load_start,
-		       (uintptr_t) &__itcm_size);
-#endif
-#if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
-	arch_early_memcpy(&__dtcm_data_start, &__dtcm_data_load_start,
-		       __dtcm_data_end - __dtcm_data_start);
-#endif
 #ifdef CONFIG_CODE_DATA_RELOCATION
 	extern void data_copy_xip_relocation(void);
 
@@ -75,4 +71,17 @@ void arch_data_copy(void)
 		       _app_smem_end - _app_smem_start);
 #endif /* CONFIG_REQUIRES_STACK_CANARIES */
 #endif /* CONFIG_USERSPACE */
+#endif /* CONFIG_XIP */
+
+	/* TCM regions are separate memories: their load address always differs
+	 * from their virtual address, independently of CONFIG_XIP.
+	 */
+#if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_itcm))
+	arch_early_memcpy(&__itcm_start, &__itcm_load_start,
+		       (uintptr_t) &__itcm_size);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
+	arch_early_memcpy(&__dtcm_data_start, &__dtcm_data_load_start,
+		       __dtcm_data_end - __dtcm_data_start);
+#endif
 }

--- a/include/zephyr/arch/common/xip.h
+++ b/include/zephyr/arch/common/xip.h
@@ -11,14 +11,15 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_XIP
+/**
+ * @brief Copy sections whose load address differs from their virtual address
+ *
+ * With CONFIG_XIP this copies the data section and the other regions residing
+ * in ROM. TCM regions are copied unconditionally, as they are separate
+ * memories whose load address differs from their virtual address regardless
+ * of CONFIG_XIP.
+ */
 void arch_data_copy(void);
-#else
-static inline void arch_data_copy(void)
-{
-	/* Do nothing */
-}
-#endif /* CONFIG_XIP */
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Problem

`arch_data_copy()` copies the ITCM and DTCM load regions, but it lives in
`arch/common/xip.c`, which `arch/common/CMakeLists.txt` only compiles when
`CONFIG_XIP` is set. `include/zephyr/arch/common/xip.h` substitutes an empty
inline for `arch_data_copy()` otherwise. An image built with `CONFIG_XIP=n`
that has a chosen `zephyr,itcm` or `zephyr,dtcm` therefore never initializes
those memories, and nothing is reported at build or link time.

The TCM copy is not XIP-dependent. In
`include/zephyr/arch/arm/cortex_m/scripts/linker.ld` the sections are linked as

```
} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)     /* line 164 */
} GROUP_LINK_IN(DTCM AT> ROMABLE_REGION)     /* line 382 */
```

ITCM and DTCM are separate memories, so the load address differs from the
virtual address whether or not `CONFIG_XIP` is set — with `CONFIG_XIP=n` the
LMA simply moves from FLASH to RAM. `include/zephyr/arch/riscv/common/linker.ld`
has the same layout and the same exposure.

## The inconsistency is visible inside DTCM itself

| section | linker | needs | handled by | `CONFIG_XIP=n` |
|---|---|---|---|---|
| `.dtcm_bss` | `(NOLOAD)`, no `AT>` | zeroing | `arch_bss_zero()` in `init.c` | works |
| `.dtcm_noinit` | `(NOLOAD)`, no `AT>` | nothing | — | works |
| `.dtcm_data` | `AT> ROMABLE_REGION` | copy | `arch_data_copy()` in `xip.c` | **broken** |

`arch_bss_zero()` gates on `DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))`
and lives in `arch/common/init.c`, which is compiled unconditionally.
`arch_data_copy()` uses the identical devicetree condition, but its file is
gated on `CONFIG_XIP`. The two are called back to back in `z_prep_c()`.

Symptoms: a function placed in `.itcm` faults on first call, and initialized
variables in `.dtcm_data` read back garbage, while uninitialized variables in
the same DTCM read correctly.

## Change

Build `xip.c` unconditionally and move the `CONFIG_XIP` guard inside
`arch_data_copy()`, so every item is gated on its own real condition. This
mirrors how `arch_bss_zero()` is already organized.

`.data`, ramfunc, nocache, code relocation and app_smem stay under
`CONFIG_XIP`: they all link with
`GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)`, and `ROMABLE_REGION` is
`#define`d to `RAM` when `CONFIG_XIP=n`, so their load address already equals
their virtual address and skipping them is correct.

There is precedent in-tree for making exactly this distinction —
`scripts/build/gen_relocate_app.py` emits

```
#ifdef CONFIG_XIP
GROUP_DATA_LINK_IN({0}, ROMABLE_REGION)
#else
GROUP_DATA_LINK_IN({0}, {0})
#endif
```

for relocated regions, i.e. it explicitly makes the LMA equal the VMA in the
non-XIP case. The TCM sections in `linker.ld` lack that distinction.

## Use case

A Cortex-M core running from RAM rather than executing in place (hence
`CONFIG_XIP=n`), with its own ITCM and DTCM.

## Testing

`samples/hello_world` built for three targets covering each affected path:

| board | `CONFIG_XIP` | TCM | result | `arch_data_copy` |
|---|---|---|---|---|
| `mimxrt1170_evk/mimxrt1176/cm7` | y | itcm + dtcm | pass | 0x64 (100 B) |
| `qemu_riscv32` | n | none | pass | 0x02 (2 B) |
| `qemu_x86` | n | none | pass | GC'd, `crt0.S` does not call it |

On the RT1170 build (`CONFIG_XIP=y`) the symbol addresses show that the load
and virtual addresses are always in different memories:

```
__itcm_load_start      = 0x300023a8   (FLASH)
__itcm_start           = 0x00000000   (ITCM)
__dtcm_data_load_start = 0x3000a9b0   (FLASH)
__dtcm_data_start      = 0x20000000   (DTCM)
```

On `qemu_riscv32` (`CONFIG_XIP=n`, no TCM) `arch_data_copy` is now a real
symbol of 2 bytes — a single `ret` — where it previously was an empty inline.
That is the entire footprint cost of dropping the header stub.

`scripts/ci/check_compliance.py -c upstream/main..HEAD` reports no failures.

## Notes

- The ClangFormat notice on `arch/common/xip.c` is pre-existing formatting
  carried over verbatim. The TCM lines are moved unchanged so the diff shows
  the logic is untouched; happy to reformat if preferred.
- `xip.c` now builds when `CONFIG_XIP=n`, so its name is no longer accurate.
  I would rather rename it in a separate follow-up PR than mix a file rename
  into this behavioral fix.
- `arch/x86/core/ia32/crt0.S` still guards its `call arch_data_copy` with
  `#ifdef CONFIG_XIP`. x86 has no TCM sections, so this is left as is.
