### PR TITLE
Bluetooth: Host: Validate ACL reassembly buffer

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -433,6 +433,13 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf,
 			return;
 		}
 
+		if (!net_buf_is_valid(conn->rx)) {
+			LOG_ERR("Corrupted L2CAP reassembly buffer");
+			bt_conn_reset_rx_state(conn);
+			net_buf_unref(buf);
+			return;
+		}
+
 		if (buf->len > net_buf_tailroom(conn->rx)) {
 			LOG_ERR("Not enough buffer space for L2CAP data");
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -742,6 +742,13 @@ static void hci_acl(struct net_buf *buf)
 		return;
 	}
 
+	if (!net_buf_is_valid(buf)) {
+		LOG_ERR("ACL data does not fit its buffer (len %u size %u)", buf->len,
+			buf->size);
+		net_buf_unref(buf);
+		return;
+	}
+
 	conn = bt_conn_lookup_handle(acl(buf)->handle, BT_CONN_TYPE_ALL);
 	if (!conn) {
 		LOG_ERR("Unable to find conn for handle %u", acl(buf)->handle);


### PR DESCRIPTION
Validate conn->rx with net_buf_is_valid() before relying on its tailroom. Once that check passes, headroom + len is known to be within the buffer size and the subtraction cannot underflow.