### PR TITLE
scripts: ci: hwmv2: kconfig: Add missing Kconfigs

### DIFF
--- a/scripts/ci/Kconfig.board.v2
+++ b/scripts/ci/Kconfig.board.v2
@@ -9,5 +9,11 @@ mainmenu "Zephyr board / SoC v2 Configuration"
 config BOARD_REVISION
 	def_string "$(BOARD_REVISION)"
 
+config EXPERIMENTAL
+	bool
+
+config DEPRECATED
+	bool
+
 source "boards/Kconfig.v2"
 source "soc/Kconfig.v2"


### PR DESCRIPTION
Adds missing Kconfigs for deprecated and experimental