### PR TITLE
tests: lib: json: use char buffer for JSON output

### DIFF
--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -2057,7 +2057,7 @@ ZTEST(lib_json_test, test_json_encode_bounds_check)
 		JSON_OBJ_DESCR_PRIM(struct number, val, JSON_TOK_NUMBER),
 	};
 	/* Encodes to {"val":0}\0 for a total of 10 bytes */
-	uint8_t buf[10];
+	char buf[10];
 	ssize_t ret = json_obj_encode_buf(descr, ARRAY_SIZE(descr),
 					  &str, buf, 10);
 	zassert_equal(ret, 0, "Encoding failed despite large enough buffer");


### PR DESCRIPTION
## Description

Use a `char` buffer in `test_json_encode_bounds_check()` because it stores JSON text and is passed to APIs expecting `char *`. This removes the test's `-Wpointer-sign` warnings without adding casts.

Related to #8921.

## Testing

- `west build -p always -b qemu_x86 tests/lib/json -d b/json`
- `west build -p always -b qemu_x86 tests/lib/json -d b/json-pointer-sign -- -DEXTRA_CFLAGS=-Werror=pointer-sign`
- QEMU `lib_json_test`: 91/91 test cases passed
- `scripts/checkpatch.pl --no-tree -`: 0 errors, 0 warnings

Assisted-by: OpenAI Codex:GPT-5