### PR TITLE
samples: usb: host_uvc: add console harness for twister

### DIFF
--- a/samples/subsys/usb/host_uvc/tests.yaml
+++ b/samples/subsys/usb/host_uvc/tests.yaml
@@ -12,3 +12,12 @@ tests:
       - rd_rw612_bga/rw612
     integration_platforms:
       - rd_rw612_bga/rw612
+    timeout: 30
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Video device connected!"
+        - "Capture started"
+        - "Received \\d+ frames"


### PR DESCRIPTION
The sample did not define a harness, so twister fell back to the default ztest harness. As the sample is a plain application that only emits log messages and never prints "PROJECT EXECUTION SUCCESSFUL", every run with --device-testing waited for the full test timeout and was then reported as failed with "Unknown Error".

Add a console harness matching the sample's own log output in order, so a run only passes once the UVC device has been enumerated, streaming has started and frames are actually received.