### PR TITLE
Bluetooth: Host: Introduce a host lock and replace the scheduler-lock sections

### DIFF
--- a/samples/bluetooth/observer/overlay_bbc_microbit-bt_ll_sw_split.conf
+++ b/samples/bluetooth/observer/overlay_bbc_microbit-bt_ll_sw_split.conf
@@ -1,8 +1,9 @@
 # Adjust Stack Sizes for reduce RAM usage
 CONFIG_MAIN_STACK_SIZE=1024
 CONFIG_IDLE_STACK_SIZE=128
-# Extended scanning exercises deep controller ISR paths.
-CONFIG_ISR_STACK_SIZE=1024
+# Extended scanning exercises deep controller ISR paths. 960 bytes keeps
+# margin for them while making room for the host lock state in RAM.
+CONFIG_ISR_STACK_SIZE=960
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=448
 
 CONFIG_BT_RX_STACK_SIZE=892

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -632,8 +632,11 @@ static int bt_att_chan_req_send(struct bt_att_chan *chan, struct bt_att_req *req
 	buf = net_buf_take(&req->buf);
 
 	/* This lock makes sure the value of `bt_att_mtu(chan)` does not
-	 * change.
+	 * change; the scheduler lock keeps the RX-path request handling,
+	 * which does not take the host lock, from preempting a preemptible
+	 * caller.
 	 */
+	bt_dev_lock();
 	k_sched_lock();
 	err = bt_att_chan_send(chan, buf);
 	if (err) {
@@ -644,6 +647,7 @@ static int bt_att_chan_req_send(struct bt_att_chan *chan, struct bt_att_req *req
 		bt_gatt_req_set_mtu(req, bt_att_mtu(chan));
 	}
 	k_sched_unlock();
+	bt_dev_unlock();
 
 	return err;
 }
@@ -4072,11 +4076,18 @@ int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req)
 	__ASSERT_NO_MSG(conn);
 	__ASSERT_NO_MSG(req);
 
+	/* att_handle_rsp() processes the request queue on the RX workqueue
+	 * without the host lock, relying on cooperative scheduling: hold the
+	 * scheduler lock as well so that it cannot preempt a preemptible
+	 * caller mid-update.
+	 */
+	bt_dev_lock();
 	k_sched_lock();
 
 	att = att_get(conn);
 	if (!att) {
 		k_sched_unlock();
+		bt_dev_unlock();
 		return -ENOTCONN;
 	}
 
@@ -4084,6 +4095,7 @@ int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req)
 	att_req_send_process(att);
 
 	k_sched_unlock();
+	bt_dev_unlock();
 
 	return 0;
 }

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -420,6 +420,13 @@ static bool chan_has_data(struct bt_l2cap_br_chan *br_chan)
 
 static void raise_data_ready(struct bt_l2cap_br_chan *br_chan)
 {
+	/* The l2cap_data_ready list is only ever modified under the host
+	 * lock: here (append, any thread context), in cancel_data_ready()
+	 * (remove, any thread context) and in lower_data_ready() (remove,
+	 * TX processor context, which holds the lock across the whole pass).
+	 */
+	bt_dev_lock();
+
 	if (!atomic_set(&br_chan->_pdu_ready_lock, 1)) {
 		sys_slist_append(&br_chan->chan.conn->l2cap_data_ready,
 				 &br_chan->_pdu_ready);
@@ -428,13 +435,22 @@ static void raise_data_ready(struct bt_l2cap_br_chan *br_chan)
 		LOG_DBG("data ready already");
 	}
 
+	bt_dev_unlock();
+
 	bt_conn_data_ready(br_chan->chan.conn);
 }
 
 static void lower_data_ready(struct bt_l2cap_br_chan *br_chan)
 {
 	struct bt_conn *conn = br_chan->chan.conn;
-	__maybe_unused sys_snode_t *s = sys_slist_get(&conn->l2cap_data_ready);
+	__maybe_unused sys_snode_t *s;
+
+	/* Only called from the TX processor, which holds the host lock
+	 * across the whole processing pass.
+	 */
+	BT_DEV_LOCK_ASSERT();
+
+	s = sys_slist_get(&conn->l2cap_data_ready);
 
 	__ASSERT_NO_MSG(s == &br_chan->_pdu_ready);
 
@@ -447,10 +463,18 @@ static void cancel_data_ready(struct bt_l2cap_br_chan *br_chan)
 {
 	struct bt_conn *conn = br_chan->chan.conn;
 
+	/* Take the host lock as this function can be called from any
+	 * thread context and the data ready list must not be modified
+	 * while we are removing the channel from it (see raise_data_ready()).
+	 */
+	bt_dev_lock();
+
 	sys_slist_find_and_remove(&conn->l2cap_data_ready,
 				  &br_chan->_pdu_ready);
 
 	atomic_set(&br_chan->_pdu_ready_lock, 0);
+
+	bt_dev_unlock();
 }
 
 #if defined(CONFIG_BT_L2CAP_RET_FC)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -675,9 +675,11 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 	/* Acquire the right to send 1 packet to the controller */
 	if (k_sem_take(bt_conn_get_pkts(conn), K_NO_WAIT)) {
 		/* This shouldn't happen now that we acquire the resources
-		 * before calling `send_buf` (in `get_conn_ready`). We say
-		 * "acquire" as `tx_processor()` is not re-entrant and the
-		 * thread is non-preemptible. So the sem value shouldn't change.
+		 * before calling `send_buf` (in `get_conn_ready`). All
+		 * consumers of this semaphore run under the host lock
+		 * (held across the whole TX processing pass), and givers
+		 * only ever increase the count. So the sem value cannot
+		 * have decreased since the get_conn_ready() check.
 		 */
 		__ASSERT(0, "No controller bufs");
 
@@ -865,11 +867,11 @@ void bt_conn_data_ready(struct bt_conn *conn)
 
 	bt_conn_ref(conn);
 
-	/* This function is the only function which accesses conn_ready list  that can be called
-	 * from a preemptive thread context, therefore requires a critical section to ensure that
-	 * the conn_ready list is not modified while we are checking and appending to it.
+	/* The conn_ready list is only ever modified under the host lock:
+	 * here (append, any thread context) and in get_conn_ready() (remove,
+	 * TX processor context, which holds the lock across the whole pass).
 	 */
-	k_sched_lock();
+	bt_dev_lock();
 
 	if (!sys_slist_find(&bt_dev.le.conn_ready, &conn->_conn_ready, NULL)) {
 		sys_slist_append(&bt_dev.le.conn_ready, &conn->_conn_ready);
@@ -879,7 +881,7 @@ void bt_conn_data_ready(struct bt_conn *conn)
 		added = false;
 	}
 
-	k_sched_unlock();
+	bt_dev_unlock();
 
 	if (!added) {
 		bt_conn_unref(conn);
@@ -926,6 +928,11 @@ static struct bt_conn *get_conn_ready(void)
 {
 	struct bt_conn *conn, *tmp;
 	sys_snode_t *prev = NULL;
+
+	/* Called from the TX processor with the host lock held; the lock
+	 * serializes conn_ready list access against bt_conn_data_ready().
+	 */
+	BT_DEV_LOCK_ASSERT();
 
 	if (dont_have_viewbufs()) {
 		/* We will get scheduled again when the (view) buffers are freed. If you

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -36,6 +36,13 @@ static uint8_t pub_key[BT_PUB_KEY_LEN];
 static sys_slist_t pub_key_cb_slist;
 static bt_dh_key_cb_t dh_key_cb;
 
+/* Incremented by bt_pub_key_hci_disrupted() under the host lock. A public
+ * key generation that was in flight at that point publishes nothing when it
+ * completes: the disruption completed the callbacks registered with it, and
+ * any request made since has re-queued the work item.
+ */
+static uint32_t pub_key_disruptions;
+
 static void generate_pub_key(struct k_work *work);
 static void generate_dh_key(struct k_work *work);
 K_WORK_DEFINE(pub_key_work, generate_pub_key);
@@ -127,12 +134,18 @@ static void set_key_attributes(psa_key_attributes_t *attr)
 static void generate_pub_key(struct k_work *work)
 {
 	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
-	struct bt_pub_key_cb *cb;
+	struct bt_pub_key_cb *cb, *next;
+	sys_slist_t cbs;
 	psa_key_id_t key_id;
 	uint8_t tmp_pub_key_buf[BT_PUB_KEY_LEN + 1];
 	size_t tmp_len;
+	uint32_t disruptions;
 	int err;
 	psa_status_t ret;
+
+	bt_dev_lock();
+	disruptions = pub_key_disruptions;
+	bt_dev_unlock();
 
 	set_key_attributes(&attr);
 
@@ -169,32 +182,49 @@ static void generate_pub_key(struct k_work *work)
 		goto done;
 	}
 
-	sys_memcpy_swap(pub_key, ecc.public_key_be, BT_PUB_KEY_COORD_LEN);
-	sys_memcpy_swap(&pub_key[BT_PUB_KEY_COORD_LEN],
-			&ecc.public_key_be[BT_PUB_KEY_COORD_LEN], BT_PUB_KEY_COORD_LEN);
-
-	atomic_set_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
 	err = 0;
 
 done:
+	/* Publish the key, detach the registered callbacks and clear the
+	 * pending state under the host lock, then invoke the callbacks
+	 * without it, so that the lock is never held across application
+	 * callbacks.
+	 */
+	bt_dev_lock();
+
+	if (disruptions != pub_key_disruptions) {
+		/* Disrupted while in flight: the disruption completed the
+		 * registered callbacks, and any request made since has
+		 * re-queued this work item, so leave the list and the
+		 * pending state to that run.
+		 */
+		bt_dev_unlock();
+		return;
+	}
+
+	if (err == 0) {
+		sys_memcpy_swap(pub_key, ecc.public_key_be, BT_PUB_KEY_COORD_LEN);
+		sys_memcpy_swap(&pub_key[BT_PUB_KEY_COORD_LEN],
+				&ecc.public_key_be[BT_PUB_KEY_COORD_LEN], BT_PUB_KEY_COORD_LEN);
+		atomic_set_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
+	}
+
+	cbs = pub_key_cb_slist;
+	sys_slist_init(&pub_key_cb_slist);
 	atomic_clear_bit(flags, PENDING_PUB_KEY);
+	bt_dev_unlock();
 
-	/* Change to cooperative priority while we do the callbacks */
-	k_sched_lock();
-
-	SYS_SLIST_FOR_EACH_CONTAINER(&pub_key_cb_slist, cb, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&cbs, cb, next, node) {
 		if (cb->func) {
 			cb->func(err ? NULL : pub_key);
 		}
 	}
-
-	sys_slist_init(&pub_key_cb_slist);
-
-	k_sched_unlock();
 }
 
 static void generate_dh_key(struct k_work *work)
 {
+	uint8_t dhkey[BT_DH_KEY_LEN];
+	bt_dh_key_cb_t cb;
 	int err;
 
 	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
@@ -237,26 +267,21 @@ static void generate_dh_key(struct k_work *work)
 	err = 0;
 
 exit:
-	/* Change to cooperative priority while we do the callback */
-	k_sched_lock();
-
-	if (dh_key_cb) {
-		bt_dh_key_cb_t cb = dh_key_cb;
-
-		dh_key_cb = NULL;
-		atomic_clear_bit(flags, PENDING_DHKEY);
-
-		if (err) {
-			cb(NULL);
-		} else {
-			uint8_t dhkey[BT_DH_KEY_LEN];
-
-			sys_memcpy_swap(dhkey, ecc.dhkey_be, sizeof(ecc.dhkey_be));
-			cb(dhkey);
-		}
+	/* Take the callback and the result and clear the pending state under
+	 * the host lock, then invoke the callback without it.
+	 */
+	bt_dev_lock();
+	cb = dh_key_cb;
+	dh_key_cb = NULL;
+	if (err == 0) {
+		sys_memcpy_swap(dhkey, ecc.dhkey_be, sizeof(ecc.dhkey_be));
 	}
+	atomic_clear_bit(flags, PENDING_DHKEY);
+	bt_dev_unlock();
 
-	k_sched_unlock();
+	if (cb != NULL) {
+		cb(err ? NULL : dhkey);
+	}
 }
 
 int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
@@ -274,14 +299,21 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 		return -EINVAL;
 	}
 
+	/* The callback list and the pending state are only accessed under
+	 * the host lock (see generate_pub_key()).
+	 */
+	bt_dev_lock();
+
 	SYS_SLIST_FOR_EACH_CONTAINER(&pub_key_cb_slist, cb, node) {
 		if (cb == new_cb) {
+			bt_dev_unlock();
 			LOG_DBG("Callback already registered");
 			return -EALREADY;
 		}
 	}
 
 	if (atomic_test_bit(flags, PENDING_DHKEY)) {
+		bt_dev_unlock();
 		LOG_WRN("Busy performing another ECDH operation");
 		return -EBUSY;
 	}
@@ -289,10 +321,13 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 	sys_slist_prepend(&pub_key_cb_slist, &new_cb->node);
 
 	if (atomic_test_and_set_bit(flags, PENDING_PUB_KEY)) {
+		bt_dev_unlock();
 		return 0;
 	}
 
 	atomic_clear_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
+
+	bt_dev_unlock();
 
 	if (IS_ENABLED(CONFIG_BT_LONG_WQ)) {
 		bt_long_wq_submit(&pub_key_work);
@@ -305,17 +340,21 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 
 void bt_pub_key_hci_disrupted(void)
 {
-	struct bt_pub_key_cb *cb;
+	struct bt_pub_key_cb *cb, *next;
+	sys_slist_t cbs;
 
+	bt_dev_lock();
+	pub_key_disruptions++;
+	cbs = pub_key_cb_slist;
+	sys_slist_init(&pub_key_cb_slist);
 	atomic_clear_bit(flags, PENDING_PUB_KEY);
+	bt_dev_unlock();
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pub_key_cb_slist, cb, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&cbs, cb, next, node) {
 		if (cb->func) {
 			cb->func(NULL);
 		}
 	}
-
-	sys_slist_init(&pub_key_cb_slist);
 }
 
 const uint8_t *bt_pub_key_get(void)
@@ -333,17 +372,27 @@ const uint8_t *bt_pub_key_get(void)
 
 int bt_dh_key_gen(const uint8_t remote_pk[BT_PUB_KEY_LEN], bt_dh_key_cb_t cb)
 {
+	/* The pending state and the callback are only accessed under the
+	 * host lock; the shared key storage is written under it here and
+	 * then owned by the worker until it clears the pending state (see
+	 * generate_dh_key()).
+	 */
+	bt_dev_lock();
+
 	if (dh_key_cb == cb) {
+		bt_dev_unlock();
 		return -EALREADY;
 	}
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY)) {
+		bt_dev_unlock();
 		return -EADDRNOTAVAIL;
 	}
 
 	if (dh_key_cb ||
 	    atomic_test_bit(flags, PENDING_PUB_KEY) ||
 	    atomic_test_and_set_bit(flags, PENDING_DHKEY)) {
+		bt_dev_unlock();
 		return -EBUSY;
 	}
 
@@ -355,6 +404,8 @@ int bt_dh_key_gen(const uint8_t remote_pk[BT_PUB_KEY_LEN], bt_dh_key_cb_t cb)
 	sys_memcpy_swap(ecc.public_key_be, remote_pk, BT_PUB_KEY_COORD_LEN);
 	sys_memcpy_swap(&ecc.public_key_be[BT_PUB_KEY_COORD_LEN],
 			&remote_pk[BT_PUB_KEY_COORD_LEN], BT_PUB_KEY_COORD_LEN);
+
+	bt_dev_unlock();
 
 	if (IS_ENABLED(CONFIG_BT_LONG_WQ)) {
 		bt_long_wq_submit(&dh_key_work);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1177,6 +1177,8 @@ static int gatt_register(struct bt_gatt_service *svc)
 	struct bt_gatt_attr *attrs = svc->attrs;
 	uint16_t count = svc->attr_count;
 
+	BT_DEV_LOCK_ASSERT();
+
 	if (sys_slist_is_empty(&db)) {
 		handle = last_static_handle;
 		last_handle = 0;
@@ -1660,17 +1662,26 @@ int bt_gatt_service_register(struct bt_gatt_service *svc)
 		return -EALREADY;
 	}
 
+	bt_dev_lock();
+
+	/* The RX-path readers of the database (the ATT request handlers
+	 * iterating the attributes) do not take the host lock and rely on
+	 * cooperative scheduling: hold the scheduler lock as well so that
+	 * they cannot preempt a preemptible caller mid-update.
+	 */
 	k_sched_lock();
 
 	err = gatt_register(svc);
 	if (err < 0) {
 		k_sched_unlock();
+		bt_dev_unlock();
 		return err;
 	}
 
 	/* Don't submit any work until the stack is initialized */
 	if (!atomic_test_bit(gatt_flags, GATT_INITIALIZED)) {
 		k_sched_unlock();
+		bt_dev_unlock();
 		return 0;
 	}
 
@@ -1680,6 +1691,7 @@ int bt_gatt_service_register(struct bt_gatt_service *svc)
 	db_changed();
 
 	k_sched_unlock();
+	bt_dev_unlock();
 
 	return 0;
 }
@@ -1698,17 +1710,24 @@ int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 	sc_start_handle = svc->attrs[0].handle;
 	sc_end_handle = svc->attrs[svc->attr_count - 1].handle;
 
+	bt_dev_lock();
+
+	/* See bt_gatt_service_register() for why the scheduler lock is
+	 * held as well.
+	 */
 	k_sched_lock();
 
 	err = gatt_unregister(svc);
 	if (err) {
 		k_sched_unlock();
+		bt_dev_unlock();
 		return err;
 	}
 
 	/* Don't submit any work until the stack is initialized */
 	if (!atomic_test_bit(gatt_flags, GATT_INITIALIZED)) {
 		k_sched_unlock();
+		bt_dev_unlock();
 		return 0;
 	}
 
@@ -1717,6 +1736,7 @@ int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 	db_changed();
 
 	k_sched_unlock();
+	bt_dev_unlock();
 
 	return 0;
 }
@@ -1726,7 +1746,7 @@ bool bt_gatt_service_is_registered(const struct bt_gatt_service *svc)
 	bool registered = false;
 	sys_snode_t *node;
 
-	k_sched_lock();
+	bt_dev_lock();
 	SYS_SLIST_FOR_EACH_NODE(&db, node) {
 		if (&svc->node == node) {
 			registered = true;
@@ -1734,7 +1754,7 @@ bool bt_gatt_service_is_registered(const struct bt_gatt_service *svc)
 		}
 	}
 
-	k_sched_unlock();
+	bt_dev_unlock();
 
 	return registered;
 }
@@ -5630,6 +5650,13 @@ void bt_gatt_cancel(struct bt_conn *conn, void *params)
 	struct bt_att_req *req;
 	bt_att_func_t func = NULL;
 
+	bt_dev_lock();
+
+	/* att_handle_rsp() processes the request state on the RX workqueue
+	 * without the host lock, relying on cooperative scheduling: hold the
+	 * scheduler lock as well so that it cannot preempt a preemptible
+	 * caller mid-cancel.
+	 */
 	k_sched_lock();
 
 	req = bt_att_find_req_by_user_data(conn, params);
@@ -5639,6 +5666,7 @@ void bt_gatt_cancel(struct bt_conn *conn, void *params)
 	}
 
 	k_sched_unlock();
+	bt_dev_unlock();
 
 	if (func) {
 		func(conn, BT_ATT_ERR_UNLIKELY, NULL, 0, params);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -166,6 +166,7 @@ struct bt_dev bt_dev = {
 	.appearance = CONFIG_BT_DEVICE_APPEARANCE,
 #endif
 	.hci = BT_HCI_DEV,
+	.lock = Z_MUTEX_INITIALIZER(bt_dev.lock),
 };
 
 static bt_ready_cb_t ready_cb;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5275,13 +5275,21 @@ static void tx_processor(struct k_work *item)
 {
 	LOG_DBG("TX process start");
 
-	/* Historically, the code in process_pending_cmd() and
-	 * bt_conn_tx_processor() has been invoked only from
-	 * cooperative threads. For now, we assume their
-	 * implementations rely on this and ensure the current
-	 * thread is cooperative.
+	/* The whole TX processing pass (command and data processors) runs
+	 * under the host lock, which replaces the historical reliance on
+	 * cooperative scheduling (k_sched_lock). This serializes it against
+	 * bt_conn_data_ready()/l2cap raise/cancel_data_ready() and the other
+	 * host-lock sections.
+	 *
+	 * Ordering rule: no code may wait, while holding the host lock,
+	 * on anything produced by the HCI prio path (ncmd_sem, command
+	 * completion). All resource acquisitions on this path are K_NO_WAIT.
+	 * Note that the HCI driver's send() is called with the lock held;
+	 * drivers that deliver events synchronously from send() (e.g. the
+	 * native controller) re-enter bt_recv() on this thread, which is
+	 * fine since the lock is recursive.
 	 */
-	k_sched_lock();
+	bt_dev_lock();
 
 	if (process_pending_cmd(K_NO_WAIT)) {
 		/* If we processed a command, let the scheduler run before
@@ -5297,7 +5305,7 @@ static void tx_processor(struct k_work *item)
 	}
 
 exit:
-	k_sched_unlock();
+	bt_dev_unlock();
 }
 
 /**

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -472,9 +472,41 @@ struct bt_dev {
 	/* Appearance Value */
 	uint16_t		appearance;
 #endif
+
+	/* The host lock: serializes access to the per-controller host state
+	 * between the contexts that mutate it. Statically initialized
+	 * (Z_MUTEX_INITIALIZER) so that it is usable before bt_enable(), e.g.
+	 * from bt_gatt_service_register().
+	 */
+	struct k_mutex		lock;
 };
 
 extern struct bt_dev bt_dev;
+
+/* Lock/unlock the host lock. k_mutex is recursive, so nested lock/unlock
+ * pairs on the same thread are legal (needed e.g. for the
+ * bt_att_req_send() -> bt_att_chan_req_send() nesting).
+ */
+static inline void bt_dev_lock(void)
+{
+	__maybe_unused int err = k_mutex_lock(&bt_dev.lock, K_FOREVER);
+
+	__ASSERT(err == 0, "failed to lock the host lock (err %d)", err);
+}
+
+static inline void bt_dev_unlock(void)
+{
+	__maybe_unused int err = k_mutex_unlock(&bt_dev.lock);
+
+	__ASSERT(err == 0, "failed to unlock the host lock (err %d)", err);
+}
+
+/* Assert that the current thread holds the host lock. k_mutex resets the
+ * owner on the final unlock, so the owner check alone is exact.
+ */
+#define BT_DEV_LOCK_ASSERT()						\
+	__ASSERT(bt_dev.lock.owner == k_current_get(),			\
+		 "host lock not held by %p", k_current_get())
 extern const struct bt_conn_auth_cb *bt_auth;
 extern sys_slist_t bt_auth_info_cbs;
 enum bt_security_err bt_security_err_get(uint8_t hci_err);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -720,11 +720,12 @@ static void raise_data_ready(struct bt_l2cap_le_chan *le_chan)
 {
 	__maybe_unused bool added;
 
-	/* This function is the only function which accesses l2cap_data_ready list that can be
-	 * called from a preemptive thread context, therefore requires a critical section to ensure
-	 * that the data ready list is not modified while we are checking and appending to it.
+	/* The l2cap_data_ready list is only ever modified under the host
+	 * lock: here (append, any thread context), in cancel_data_ready()
+	 * (remove, any thread context) and in lower_data_ready() (remove,
+	 * TX processor context, which holds the lock across the whole pass).
 	 */
-	k_sched_lock();
+	bt_dev_lock();
 
 	if (!sys_slist_find(&le_chan->chan.conn->l2cap_data_ready,
 				 &le_chan->_pdu_ready, NULL)) {
@@ -736,7 +737,7 @@ static void raise_data_ready(struct bt_l2cap_le_chan *le_chan)
 		added = false;
 	}
 
-	k_sched_unlock();
+	bt_dev_unlock();
 
 	LOG_DBG("L2CAP channel %p data ready %s", le_chan, added ? "added" : "already added");
 
@@ -746,7 +747,14 @@ static void raise_data_ready(struct bt_l2cap_le_chan *le_chan)
 static void lower_data_ready(struct bt_l2cap_le_chan *le_chan)
 {
 	struct bt_conn *conn = le_chan->chan.conn;
-	__maybe_unused sys_snode_t *s = sys_slist_get(&conn->l2cap_data_ready);
+	__maybe_unused sys_snode_t *s;
+
+	/* Only called from the TX processor, which holds the host lock
+	 * across the whole processing pass.
+	 */
+	BT_DEV_LOCK_ASSERT();
+
+	s = sys_slist_get(&conn->l2cap_data_ready);
 
 	LOG_DBG("%p", le_chan);
 
@@ -759,16 +767,16 @@ static void cancel_data_ready(struct bt_l2cap_le_chan *le_chan)
 
 	LOG_DBG("%p", le_chan);
 
-	/* Use critical section here as this function can be called from
-	 * a preemptive thread context and we need to ensure that the data ready list is not
-	 * modified while we are removing the channel from it.
+	/* Take the host lock as this function can be called from any
+	 * thread context and the data ready list must not be modified
+	 * while we are removing the channel from it (see raise_data_ready()).
 	 */
-	k_sched_lock();
+	bt_dev_lock();
 
 	sys_slist_find_and_remove(&conn->l2cap_data_ready,
 				  &le_chan->_pdu_ready);
 
-	k_sched_unlock();
+	bt_dev_unlock();
 }
 
 int bt_l2cap_send_pdu(struct bt_l2cap_le_chan *le_chan, struct net_buf *pdu,

--- a/tests/bluetooth/host/conn/mocks/kernel.c
+++ b/tests/bluetooth/host/conn/mocks/kernel.c
@@ -32,6 +32,8 @@ DEFINE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout_
 DEFINE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
 DEFINE_FAKE_VOID_FUNC(k_sched_lock);
 DEFINE_FAKE_VOID_FUNC(k_sched_unlock);
+DEFINE_FAKE_VALUE_FUNC(int, k_mutex_lock, struct k_mutex *, k_timeout_t);
+DEFINE_FAKE_VALUE_FUNC(int, k_mutex_unlock, struct k_mutex *);
 DEFINE_FAKE_VALUE_FUNC(void *, k_heap_aligned_alloc, struct k_heap *,
 			size_t, size_t, k_timeout_t);
 

--- a/tests/bluetooth/host/conn/mocks/kernel.h
+++ b/tests/bluetooth/host/conn/mocks/kernel.h
@@ -31,6 +31,8 @@
 	FAKE(k_heap_free)                                                                          \
 	FAKE(k_sched_lock)                                                                         \
 	FAKE(k_sched_unlock)                                                                       \
+	FAKE(k_mutex_lock)                                                                         \
+	FAKE(k_mutex_unlock)                                                                       \
 
 DECLARE_FAKE_VALUE_FUNC(bool, k_is_in_isr);
 DECLARE_FAKE_VALUE_FUNC(int, k_sem_take, struct k_sem *, k_timeout_t);
@@ -53,5 +55,7 @@ DECLARE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout
 DECLARE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
 DECLARE_FAKE_VOID_FUNC(k_sched_lock);
 DECLARE_FAKE_VOID_FUNC(k_sched_unlock);
+DECLARE_FAKE_VALUE_FUNC(int, k_mutex_lock, struct k_mutex *, k_timeout_t);
+DECLARE_FAKE_VALUE_FUNC(int, k_mutex_unlock, struct k_mutex *);
 DECLARE_FAKE_VALUE_FUNC(void *, k_heap_aligned_alloc, struct k_heap *,
 			size_t, size_t, k_timeout_t);


### PR DESCRIPTION
The Bluetooth host has relied on cooperative scheduling for mutual exclusion, with k_sched_lock() marking the sections that need it. That holds only on UP with every host context cooperative: a scheduler lock gives no exclusion on SMP, cannot be held across anything that blocks, has no priority inheritance and is invisible to deadlock analysis. This PR replaces those sections with an explicit lock. All of them live in the common host core shared by LE and BR/EDR (there are no scheduler-lock sections under host/classic/), so the change covers both transports.

The first commit adds a recursive k_mutex to struct bt_dev (the host lock) with bt_dev_lock()/bt_dev_unlock() helpers and a BT_DEV_LOCK_ASSERT() ownership check, and converts the sections that are independent of the TX path: GATT database/service registration, ATT request sending and ECC result delivery. The ECC request, completion and disruption paths, which had no serialization at all, use the same protocol, with a disruption counter so that a key generation in flight at bt_disable() (the long workqueue is preemptible) cannot complete a request made after it. The second commit converts the TX-path sections (tx_processor(), the connection data-ready list and the L2CAP data-ready helpers) in one step, since they guard the same lists from different threads and converting one side alone would turn the implicit exclusion into an actual race.

**Rules of the lock**: the host never blocks under it (the TX processor only performs K_NO_WAIT acquisitions), and it is never held across application callbacks, with two exceptions inherited from the TX processor pass, which ran under the scheduler lock the same way: the L2CAP `status()` notification on credit exhaustion (`chan_take_credit()`), whose fate — a hard non-blocking contract or a move out of the TX processor — is decided with the callback contracts in #116316, and the fatal-error recovery paths (a failed `send_buf()` invoking the completion callback with an error and disconnecting synchronously), which are reworked with the asynchronous HCI command API; the synchronous disconnect already cannot complete from the TX processor thread. An HCI driver's `send()` may block while the lock is held, as it could under the scheduler lock, which bounds the hold time by the driver's transmit time. The lock is statically initialized because `bt_gatt_service_register()` is legal before `bt_enable()`. The mutex being recursive is load-bearing: the ATT send path nests the sections up to four deep, and the native controller and the `status()` callback re-enter the host from under it. The GATT registration/cancel and ATT request-send sections keep the scheduler lock nested inside the host lock, because their RX-path readers (the ATT request handlers that iterate the database) do not take the host lock yet and rely on cooperative scheduling; the nesting preserves that exclusion for preemptible callers until those readers are converted in #116316. Since every host context is still cooperative today the lock is uncontended, so this is behavior-preserving; it becomes real exclusion on SMP and for preemptible callers, and CONFIG_MUTEX_DEADLOCK_DETECT now covers these sections for free.

**Not converted**: the priority receive path in bt_recv(), which is meant to become lock-free rather than take the host lock, and buf_rx_freed_notify() in buf.c, which has an ISR path a mutex cannot serve. The two irq_lock() sections guarding conn->tx_complete are also left as they are: their producer is the priority receive path, which stays outside the host lock, and the section is a short ISR-safe list handoff for which a spinlock is the right primitive.

**Footprint**: +28 B RAM (the mutex in bt_dev and the ECC disruption counter) and +216 B flash on nrf52840dk peripheral_hr. The extra RAM no longer fits the extended observer build for bbc_microbit, so its ISR stack is reduced from 1024 to 960 B in the sample's board overlay (thread-analyzer high-water leaves margin).

Tested with the bsim suites for disconnect, disable, att/sequential, att/timeout, l2cap/stress, the SMP security suites and gatt/sc_indicate, all with the ownership assertions enabled, plus the conn and id host unit tests.

Part of #116316 (preemptibility workstream).


