### PR TITLE
drivers: timer: lpm_hooks_counter: enable counter as wake-up source

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1307,6 +1307,16 @@ Timer
   :c:func:`sys_clock_elapsed` and :c:func:`sys_clock_cycle_get_32` /
   :c:func:`sys_clock_cycle_get_64` (:github:`115844`).
 
+* When :kconfig:option:`SYSTEM_TIMER_LPM_COMPANION_COUNTER` is enabled, the Low-Power
+  Companion counter, selected by the :ref:`generic chosen <devicetree-zephyr-chosen-nodes>`
+  ``zephyr,system-timer-companion``, is checked at build time and must be usable as
+  wake-up source. If not already present, the ``wakeup-source`` property should be
+  added to such nodes to indicate they can be used as wake-up source. (:github:`117274`)
+
+  .. note::
+
+    This behavior was already expected in previous Zephyr releases but never asserted.
+
 USB
 ===
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -615,6 +615,10 @@ New APIs and options
 
   * :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)
 
+* Timer
+
+  * :c:func:`z_sys_clock_lpm_enter`
+
 * USB Type-C
 
   * :kconfig:option:`CONFIG_USBC_LOG_PD_MSG_NAMES`

--- a/drivers/timer/CMakeLists.txt
+++ b/drivers/timer/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 zephyr_library()
 zephyr_library_sources(sys_clock_init.c)
+zephyr_library_sources_ifndef(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE sys_lpm_hooks_stubs.c)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/counter)
 # zephyr-keep-sorted-start

--- a/drivers/timer/Kconfig.system_timer_lpm
+++ b/drivers/timer/Kconfig.system_timer_lpm
@@ -10,15 +10,22 @@ config SYSTEM_TIMER_HAS_LPM_COMPANION_SUPPORT
 	  This option should be selected by system timer drivers that support
 	  delegating low-power timekeeping to a companion timer.
 
+# The SYSTEM_TIMER_LPM_COMPANION choice and SYSTEM_TIMER_LPM_COMPANION_NONE option
+# have no dependency on purpose: this allows using the option as an always-available
+# indicator of whether or not companions are enabled, regardless of whether they are
+# supported (irrelevant to consumers).
+#
 # If all dependencies are enabled, and either the preferred
 # /chosen/zephyr,system-timer-companion property or the deprecated
 # /chosen/zephyr,cortex-m-idle-timer property is enabled, default
 # to using the Counter API-based LPM timer. Otherwise, the first
-# choice (SYSTEM_TIMER_LPM_COMPANION_NONE) will be selected automatically,
-# and no LPM companion timer will be enabled.
+# choice will be selected automatically and no LPM companion timer
+# will be enabled (CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE=y).
+#
+# The choice is promptless if LPM companions are not supported: in this situation,
+# only the NONE option can be selected - no "choice" can really be made.
 choice SYSTEM_TIMER_LPM_COMPANION
-	prompt "System timer low-power companion"
-	depends on SYSTEM_TIMER_HAS_LPM_COMPANION_SUPPORT
+	prompt "System timer low-power companion" if SYSTEM_TIMER_HAS_LPM_COMPANION_SUPPORT
 	# Preserve legacy SysTick Kconfig selections during the deprecation period.
 	# These defaults are scheduled to be removed in Zephyr 4.6.0.
 	default SYSTEM_TIMER_LPM_COMPANION_COUNTER if CORTEX_M_SYSTICK_LPM_TIMER_COUNTER
@@ -49,7 +56,7 @@ config SYSTEM_TIMER_LPM_COMPANION_NONE
 	  timer cannot keep time when this option is selected; otherwise, system
 	  behavior becomes unpredictable.
 
-if TICKLESS_KERNEL && PM
+if SYSTEM_TIMER_HAS_LPM_COMPANION_SUPPORT && TICKLESS_KERNEL && PM
 
 config SYSTEM_TIMER_LPM_COMPANION_COUNTER
 	bool "Counter API timer"
@@ -73,7 +80,8 @@ config SYSTEM_TIMER_LPM_COMPANION_HOOKS
 	  Refer to `include/zephyr/drivers/timer/system_timer_lpm.h` for more
 	  details.
 
-endif # TICKLESS_KERNEL && PM
+endif # SYSTEM_TIMER_HAS_LPM_COMPANION_SUPPORT && TICKLESS_KERNEL && PM
+
 endchoice # SYSTEM_TIMER_LPM_COMPANION
 
 config SYSTEM_TIMER_RESET_BY_LPM

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -474,6 +474,10 @@ static int sys_clock_driver_init(void)
 	}
 #endif
 
+#ifndef CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE
+	z_sys_clock_lpm_init();
+#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
+
 #if (DT_INST_PROP(0, wakeup_source))
 	NXP_ENABLE_WAKEUP_SIGNAL(DT_INST_IRQN(0));
 #endif

--- a/drivers/timer/sys_lpm_hooks_counter.c
+++ b/drivers/timer/sys_lpm_hooks_counter.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/timer/system_timer_lpm.h>
+#include <zephyr/pm/device.h>
 
 #if defined(CONFIG_CORTEX_M_SYSTICK) && !DT_HAS_CHOSEN(zephyr_system_timer_companion)
 /*
@@ -22,6 +23,11 @@
 #else /* CONFIG_CORTEX_M_SYSTICK && !DT_HAS_CHOSEN(zephyr_system_timer_companion) */
 #define COMPANION_COUNTER_NODE DT_CHOSEN(zephyr_system_timer_companion)
 #endif /* CONFIG_CORTEX_M_SYSTICK && !DT_HAS_CHOSEN(zephyr_system_timer_companion) */
+
+BUILD_ASSERT(DT_PROP(COMPANION_COUNTER_NODE, wakeup_source),
+	"The Low-Power Companion counter (chosen `zephyr,system-timer-companion` at path: "
+	DT_NODE_PATH(COMPANION_COUNTER_NODE) ") must be marked as wake-up capable! "
+	"(hint: add the `wakeup-source` property to the node)");
 
 static const struct device *lpm_counter = DEVICE_DT_GET(COMPANION_COUNTER_NODE);
 
@@ -37,6 +43,24 @@ static uint32_t counter_scheduled_lpm_ticks;
 /* Channel ID of the alarm that should wake up the system */
 #define LPM_ALARM_CHANNEL_ID 0U
 
+void z_sys_clock_lpm_init(void)
+{
+	__ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE) || pm_device_wakeup_is_capable(lpm_counter),
+		"Low-Power Companion counter not marked as wakeup-source!");
+
+	/*
+	 * Enable low-power companion counter as wake-up source.
+	 *
+	 * This cannot be done from z_sys_clock_lpm_enter() because this runs
+	 * after all devices have been suspended, which is what enabling the
+	 * counter as wake-up source is supposed to prevent.
+	 *
+	 * NOTE: it is assumed that no other code will change this configuration.
+	 * Doing so is an application error and will result in undefined behavior.
+	 */
+	pm_device_wakeup_enable(lpm_counter, true);
+}
+
 /* Stub to satisfy the Counter API (`callback` cannot be NULL) */
 static void stub_alarm_callback(const struct device *dev, uint8_t chan_id,
 				      uint32_t ticks, void *user_data)
@@ -49,6 +73,10 @@ static void stub_alarm_callback(const struct device *dev, uint8_t chan_id,
 
 void z_sys_clock_lpm_enter(uint64_t max_lpm_time_us)
 {
+	/* Catch misuse of the device by external code */
+	__ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE) || pm_device_wakeup_is_enabled(lpm_counter),
+		"External code must not disable Low-Power Companion wake-up source!");
+
 	counter_scheduled_lpm_ticks = counter_us_to_ticks(lpm_counter, max_lpm_time_us);
 
 	struct counter_alarm_cfg cfg = {

--- a/drivers/timer/sys_lpm_hooks_stubs.c
+++ b/drivers/timer/sys_lpm_hooks_stubs.c
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Stub implementation of certain functions of the system timer
+ * low-power companion interface. These stubs are weak functions
+ * so they can be overridden.
+ */
+
+#include <zephyr/drivers/timer/system_timer_lpm.h>
+#include <zephyr/toolchain.h>
+
+__weak void z_sys_clock_lpm_init(void)
+{
+	/* Stub implementation: do nothing */
+}

--- a/drivers/timer/system_timer_generic.h
+++ b/drivers/timer/system_timer_generic.h
@@ -134,6 +134,7 @@
 #ifndef ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_
 #define ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_
 
+#include <zephyr/drivers/timer/system_timer_lpm.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
@@ -856,6 +857,9 @@ static inline void timer_core_smp_prime(void)
  */
 static inline void timer_core_init(void)
 {
+#ifndef CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE
+	z_sys_clock_lpm_init();
+#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 #ifdef TIMER_CORE_PRECOMPUTE_CYC_PER_TICK
 	/* Rate is known only now (the driver has brought the counter up), so
 	 * fix the cycles-per-tick the tick math will divide by.

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -323,6 +323,7 @@
 			prescaler = <32768>;
 			alarms-count = <1>;
 			alrm-exti-line = <19>;
+			wakeup-source; /* Enable use as system timer companion */
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -347,6 +347,7 @@
 			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
 			alrm-exti-line = <17>;
+			wakeup-source; /* Enable use as system timer companion */
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -598,6 +598,7 @@
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
+			wakeup-source; /* Enable use as system timer companion */
 			status = "disabled";
 
 			bbram: backup_regs {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -182,6 +182,7 @@
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
+			wakeup-source; /* Enable use as system timer companion */
 			status = "disabled";
 		};
 

--- a/include/zephyr/drivers/timer/system_timer_lpm.h
+++ b/include/zephyr/drivers/timer/system_timer_lpm.h
@@ -38,6 +38,18 @@ extern "C" {
  */
 
 /**
+ * @brief Low-power companion initialization hook
+ *
+ * System timer drivers must call this function during their initialization.
+ *
+ * @note This is an internal kernel/platform interface. Application code must
+ * not call it.
+ *
+ * @note Implementation of this function by the platform code is optional.
+ */
+void z_sys_clock_lpm_init(void);
+
+/**
  * @brief Prepare low-power companion timer before entry in low-power state
  *
  * Implementations must ensure the system wakes up no later than @p max_lpm_time_us

--- a/include/zephyr/drivers/timer/system_timer_lpm.h
+++ b/include/zephyr/drivers/timer/system_timer_lpm.h
@@ -29,6 +29,7 @@ extern "C" {
  * @kconfig_dep{CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER,CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS}
  *
  * This interface is used when a system timer low-power companion is configured.
+ * It is not available when CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE=y.
  *
  * If CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS is selected, SoC/platform-specific code
  * provides the implementation of all hooks; otherwise, the implementation is provided

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_f429zi.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_f429zi.overlay
@@ -9,3 +9,8 @@
 		zephyr,system-timer-companion = &rtc;
 	};
 };
+
+&rtc {
+	wakeup-source;
+	status = "okay";
+};

--- a/tests/subsys/pm/power_mgmt_soc/boards/nucleo_f429zi.overlay
+++ b/tests/subsys/pm/power_mgmt_soc/boards/nucleo_f429zi.overlay
@@ -9,3 +9,8 @@
 		zephyr,system-timer-companion = &rtc;
 	};
 };
+
+&rtc {
+	wakeup-source;
+	status = "okay";
+};


### PR DESCRIPTION
If the counter device is not enabled as wake-up source, it will get suspended by `pm_suspend_devices()` and may be unable to wake up the system once scheduled timeout elapses. Make sure we do enable it as wake-up source since that's what we want to use it for.