### PR TITLE
Bluetooth: GATT: Discard notifications with oversized values

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3610,6 +3610,15 @@ static void call_notify_cb_and_maybe_unsubscribe(struct bt_conn *conn, struct ga
 	struct bt_gatt_subscribe_params *params, *tmp;
 	int err;
 
+	/* Core Specification Vol 3, Part F, Section 3.2.9: the maximum length
+	 * of an attribute value is 512 octets.
+	 */
+	if (length > BT_ATT_MAX_ATTRIBUTE_LEN) {
+		LOG_WRN("Ignoring value with invalid length %u for handle 0x%04x", length,
+			handle);
+		return;
+	}
+
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&sub->list, params, tmp, node) {
 		if (handle != params->value_handle) {
 			continue;

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bsim_test_gatt_notify_oversized)
+
+add_subdirectory(${ZEPHYR_BASE}/tests/bsim/babblekit babblekit)
+target_link_libraries(app PRIVATE babblekit)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+zephyr_include_directories(
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+)

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/prj.conf
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/prj.conf
@@ -1,0 +1,20 @@
+CONFIG_BT=y
+CONFIG_BT_DEVICE_NAME="GATT tester"
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_GATT_CLIENT=y
+CONFIG_BT_GATT_AUTO_DISCOVER_CCC=y
+CONFIG_BT_SMP=y
+
+CONFIG_BT_GATT_CACHING=y
+CONFIG_BT_GATT_NOTIFY_MULTIPLE=y
+# Keep single notifications as single PDUs even after the client has
+# enabled Multiple Handle Value Notifications
+CONFIG_BT_GATT_NOTIFY_MULTIPLE_FLUSH_MS=0
+
+# ATT MTU large enough to carry values above the 512 octet attribute limit
+CONFIG_BT_L2CAP_TX_MTU=600
+CONFIG_BT_BUF_ACL_RX_SIZE=604
+
+CONFIG_ASSERT=y
+CONFIG_LOG=y

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/src/common.h
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/src/common.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTS_BSIM_BLUETOOTH_HOST_GATT_NOTIFY_OVERSIZED_SRC_COMMON_H_
+#define ZEPHYR_TESTS_BSIM_BLUETOOTH_HOST_GATT_NOTIFY_OVERSIZED_SRC_COMMON_H_
+
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/toolchain.h>
+
+#define TEST_SERVICE_UUID                                                                          \
+	BT_UUID_DECLARE_128(0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,      \
+			    0x07, 0x08, 0x09, 0x00, 0x00)
+
+#define TEST_CHRC_A_UUID                                                                           \
+	BT_UUID_DECLARE_128(0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,      \
+			    0x07, 0x08, 0x09, 0xFF, 0x00)
+
+#define TEST_CHRC_B_UUID                                                                           \
+	BT_UUID_DECLARE_128(0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,      \
+			    0x07, 0x08, 0x09, 0xFF, 0x11)
+
+/* Value lengths sent by the server */
+#define OVERSIZED_LEN (BT_ATT_MAX_ATTRIBUTE_LEN + 1)
+#define MAX_LEN       BT_ATT_MAX_ATTRIBUTE_LEN
+#define SHORT_LEN     10
+#define MARKER_LEN    1
+
+/* Multiple Handle Value Notification carrying a short and an oversized value */
+#define REQUIRED_ATT_MTU (1 + 4 + SHORT_LEN + 4 + OVERSIZED_LEN)
+
+BUILD_ASSERT(CONFIG_BT_L2CAP_TX_MTU >= REQUIRED_ATT_MTU);
+
+#endif /* ZEPHYR_TESTS_BSIM_BLUETOOTH_HOST_GATT_NOTIFY_OVERSIZED_SRC_COMMON_H_ */

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/src/gatt_client_test.c
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+
+#include "babblekit/flags.h"
+#include "babblekit/testcase.h"
+
+#include "common.h"
+
+DEFINE_FLAG_STATIC(flag_is_connected);
+DEFINE_FLAG_STATIC(flag_mtu_exchanged);
+DEFINE_FLAG_STATIC(flag_discover_complete);
+DEFINE_FLAG_STATIC(flag_write_complete);
+DEFINE_FLAG_STATIC(flag_a_subscribed);
+DEFINE_FLAG_STATIC(flag_b_subscribed);
+DEFINE_FLAG_STATIC(flag_marker_received);
+
+static struct bt_conn *g_conn;
+static uint16_t chrc_a_handle;
+static uint16_t chrc_b_handle;
+static uint16_t csf_handle;
+
+struct notification {
+	uint16_t handle;
+	uint16_t len;
+};
+
+static struct notification received[8];
+static size_t num_received;
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	if (err != 0) {
+		TEST_FAIL("Failed to connect to %s (%u)", bt_conn_dst_str(conn), err);
+		return;
+	}
+
+	printk("Connected to %s\n", bt_conn_dst_str(conn));
+
+	SET_FLAG(flag_is_connected);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	if (conn != g_conn) {
+		return;
+	}
+
+	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
+
+	bt_conn_drop(&g_conn);
+	UNSET_FLAG(flag_is_connected);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			 struct net_buf_simple *ad)
+{
+	int err;
+
+	if (g_conn != NULL) {
+		return;
+	}
+
+	if (type != BT_HCI_ADV_IND && type != BT_HCI_ADV_DIRECT_IND) {
+		return;
+	}
+
+	printk("Device found: %s (RSSI %d)\n", bt_addr_le_str(addr), rssi);
+
+	err = bt_le_scan_stop();
+	if (err != 0) {
+		TEST_FAIL("Could not stop scan (err %d)", err);
+		return;
+	}
+
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &g_conn);
+	if (err != 0) {
+		TEST_FAIL("Could not connect to peer (err %d)", err);
+	}
+}
+
+static void exchange_func(struct bt_conn *conn, uint8_t err,
+			  struct bt_gatt_exchange_params *params)
+{
+	TEST_ASSERT(err == 0, "MTU exchange failed (err %u)", err);
+
+	SET_FLAG(flag_mtu_exchanged);
+}
+
+static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+			     struct bt_gatt_discover_params *params)
+{
+	const struct bt_gatt_chrc *chrc;
+
+	if (attr == NULL) {
+		SET_FLAG(flag_discover_complete);
+		return BT_GATT_ITER_STOP;
+	}
+
+	chrc = attr->user_data;
+
+	if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_A_UUID) == 0) {
+		chrc_a_handle = chrc->value_handle;
+	} else if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_B_UUID) == 0) {
+		chrc_b_handle = chrc->value_handle;
+	} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_GATT_CLIENT_FEATURES) == 0) {
+		csf_handle = chrc->value_handle;
+	}
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void discover(void)
+{
+	static struct bt_gatt_discover_params params = {
+		.func = discover_func,
+		.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE,
+		.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
+		.type = BT_GATT_DISCOVER_CHARACTERISTIC,
+	};
+	int err;
+
+	err = bt_gatt_discover(g_conn, &params);
+	TEST_ASSERT(err == 0, "Discovery failed (err %d)", err);
+
+	WAIT_FOR_FLAG(flag_discover_complete);
+	TEST_ASSERT(chrc_a_handle != 0 && chrc_b_handle != 0 && csf_handle != 0,
+		    "Characteristics not found");
+}
+
+static void write_cb(struct bt_conn *conn, uint8_t err, struct bt_gatt_write_params *params)
+{
+	TEST_ASSERT(err == 0, "Write failed (err 0x%02x)", err);
+
+	SET_FLAG(flag_write_complete);
+}
+
+/* Enable Multiple Handle Value Notifications in Client Supported Features */
+static void write_csf(void)
+{
+	static const uint8_t csf[] = { BIT(2) };
+	static struct bt_gatt_write_params params = {
+		.func = write_cb,
+		.data = csf,
+		.length = sizeof(csf),
+	};
+	int err;
+
+	params.handle = csf_handle;
+
+	err = bt_gatt_write(g_conn, &params);
+	TEST_ASSERT(err == 0, "Failed to write CSF (err %d)", err);
+
+	WAIT_FOR_FLAG(flag_write_complete);
+}
+
+static uint8_t notify_func(struct bt_conn *conn, struct bt_gatt_subscribe_params *params,
+			   const void *data, uint16_t length)
+{
+	const uint8_t *value = data;
+
+	if (data == NULL) {
+		return BT_GATT_ITER_STOP;
+	}
+
+	printk("Received %u bytes for handle 0x%04x\n", length, params->value_handle);
+
+	TEST_ASSERT(num_received < ARRAY_SIZE(received), "Too many notifications");
+
+	for (uint16_t i = 0; i < length; i++) {
+		TEST_ASSERT(value[i] == (uint8_t)i, "Unexpected data at offset %u", i);
+	}
+
+	received[num_received].handle = params->value_handle;
+	received[num_received].len = length;
+	num_received++;
+
+	if (params->value_handle == chrc_b_handle && length == MARKER_LEN) {
+		SET_FLAG(flag_marker_received);
+	}
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void subscribed(struct bt_conn *conn, uint8_t err, struct bt_gatt_subscribe_params *params)
+{
+	TEST_ASSERT(err == 0, "Subscribe failed (err 0x%02x)", err);
+
+	if (params->value_handle == chrc_a_handle) {
+		SET_FLAG(flag_a_subscribed);
+	} else if (params->value_handle == chrc_b_handle) {
+		SET_FLAG(flag_b_subscribed);
+	}
+}
+
+static struct bt_gatt_discover_params disc_params_a;
+static struct bt_gatt_subscribe_params sub_params_a = {
+	.notify = notify_func,
+	.subscribe = subscribed,
+	.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE,
+	.disc_params = &disc_params_a,
+	.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
+	.value = BT_GATT_CCC_NOTIFY | BT_GATT_CCC_INDICATE,
+};
+
+static struct bt_gatt_discover_params disc_params_b;
+static struct bt_gatt_subscribe_params sub_params_b = {
+	.notify = notify_func,
+	.subscribe = subscribed,
+	.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE,
+	.disc_params = &disc_params_b,
+	.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
+	.value = BT_GATT_CCC_NOTIFY,
+};
+
+static void subscribe(struct bt_gatt_subscribe_params *params, uint16_t value_handle)
+{
+	int err;
+
+	params->value_handle = value_handle;
+
+	err = bt_gatt_subscribe(g_conn, params);
+	TEST_ASSERT(err == 0, "Subscribing to handle 0x%04x failed (err %d)", value_handle, err);
+}
+
+static void verify_received(void)
+{
+	const struct notification expected[] = {
+		{ chrc_a_handle, MAX_LEN },   /* notification */
+		{ chrc_a_handle, MAX_LEN },   /* indication */
+		{ chrc_b_handle, SHORT_LEN }, /* tuple after the oversized one */
+		{ chrc_b_handle, MARKER_LEN },
+	};
+
+	TEST_ASSERT(num_received == ARRAY_SIZE(expected),
+		    "Received %zu notifications, expected %zu", num_received, ARRAY_SIZE(expected));
+
+	ARRAY_FOR_EACH(expected, i) {
+		TEST_ASSERT(received[i].handle == expected[i].handle &&
+			    received[i].len == expected[i].len,
+			    "Notification %zu: handle 0x%04x len %u, expected handle 0x%04x len %u",
+			    i, received[i].handle, received[i].len, expected[i].handle,
+			    expected[i].len);
+	}
+}
+
+static void test_main(void)
+{
+	static struct bt_gatt_exchange_params exchange_params = {
+		.func = exchange_func,
+	};
+	int err;
+
+	err = bt_enable(NULL);
+	TEST_ASSERT(err == 0, "Bluetooth init failed (err %d)", err);
+
+	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);
+	TEST_ASSERT(err == 0, "Scanning failed to start (err %d)", err);
+
+	WAIT_FOR_FLAG(flag_is_connected);
+
+	err = bt_gatt_exchange_mtu(g_conn, &exchange_params);
+	TEST_ASSERT(err == 0, "MTU exchange failed (err %d)", err);
+
+	WAIT_FOR_FLAG(flag_mtu_exchanged);
+	TEST_ASSERT(bt_gatt_get_mtu(g_conn) >= REQUIRED_ATT_MTU, "ATT MTU %u too small",
+		    bt_gatt_get_mtu(g_conn));
+
+	discover();
+	write_csf();
+
+	subscribe(&sub_params_a, chrc_a_handle);
+	subscribe(&sub_params_b, chrc_b_handle);
+	WAIT_FOR_FLAG(flag_a_subscribed);
+	WAIT_FOR_FLAG(flag_b_subscribed);
+
+	WAIT_FOR_FLAG(flag_marker_received);
+
+	verify_received();
+
+	TEST_PASS_AND_EXIT("GATT client passed");
+}
+
+static const struct bst_test_instance test_gatt_client[] = {
+	{
+		.test_id = "gatt_client",
+		.test_main_f = test_main,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_gatt_client);
+}

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/src/gatt_server_test.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+
+#include "babblekit/flags.h"
+#include "babblekit/testcase.h"
+
+#include "common.h"
+
+DEFINE_FLAG_STATIC(flag_is_connected);
+DEFINE_FLAG_STATIC(flag_mtu_updated);
+DEFINE_FLAG_STATIC(flag_a_subscribed);
+DEFINE_FLAG_STATIC(flag_b_subscribed);
+DEFINE_FLAG_STATIC(flag_sent);
+DEFINE_FLAG_STATIC(flag_confirmed);
+
+static struct bt_conn *g_conn;
+static uint8_t test_data[OVERSIZED_LEN];
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	if (err != 0) {
+		TEST_FAIL("Failed to connect to %s (%u)", bt_conn_dst_str(conn), err);
+		return;
+	}
+
+	printk("Connected to %s\n", bt_conn_dst_str(conn));
+
+	g_conn = bt_conn_ref(conn);
+	SET_FLAG(flag_is_connected);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	if (conn != g_conn) {
+		return;
+	}
+
+	printk("Disconnected: %s (reason 0x%02x)\n", bt_conn_dst_str(conn), reason);
+
+	bt_conn_drop(&g_conn);
+	UNSET_FLAG(flag_is_connected);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
+{
+	printk("ATT MTU updated: tx %u rx %u\n", tx, rx);
+
+	if (tx >= REQUIRED_ATT_MTU) {
+		SET_FLAG(flag_mtu_updated);
+	}
+}
+
+static struct bt_gatt_cb gatt_callbacks = {
+	.att_mtu_updated = att_mtu_updated,
+};
+
+static void a_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
+{
+	if (value == (BT_GATT_CCC_NOTIFY | BT_GATT_CCC_INDICATE)) {
+		SET_FLAG(flag_a_subscribed);
+	}
+}
+
+static void b_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
+{
+	if (value == BT_GATT_CCC_NOTIFY) {
+		SET_FLAG(flag_b_subscribed);
+	}
+}
+
+BT_GATT_SERVICE_DEFINE(test_svc, BT_GATT_PRIMARY_SERVICE(TEST_SERVICE_UUID),
+		       BT_GATT_CHARACTERISTIC(TEST_CHRC_A_UUID,
+					      BT_GATT_CHRC_NOTIFY | BT_GATT_CHRC_INDICATE,
+					      BT_GATT_PERM_NONE, NULL, NULL, NULL),
+		       BT_GATT_CCC(a_ccc_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+		       BT_GATT_CHARACTERISTIC(TEST_CHRC_B_UUID, BT_GATT_CHRC_NOTIFY,
+					      BT_GATT_PERM_NONE, NULL, NULL, NULL),
+		       BT_GATT_CCC(b_ccc_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE));
+
+static void notify_sent(struct bt_conn *conn, void *user_data)
+{
+	SET_FLAG(flag_sent);
+}
+
+static void notify(const struct bt_gatt_attr *attr, uint16_t len)
+{
+	struct bt_gatt_notify_params params = {
+		.attr = attr,
+		.data = test_data,
+		.len = len,
+		.func = notify_sent,
+	};
+	int err;
+
+	UNSET_FLAG(flag_sent);
+
+	do {
+		err = bt_gatt_notify_cb(g_conn, &params);
+		if (err == -ENOMEM) {
+			k_sleep(K_MSEC(10));
+		}
+	} while (err == -ENOMEM);
+
+	TEST_ASSERT(err == 0, "Failed to send %u byte notification (err %d)", len, err);
+}
+
+static void indicate_cb(struct bt_conn *conn, struct bt_gatt_indicate_params *params, uint8_t err)
+{
+	TEST_ASSERT(err == 0, "%u byte indication failed (err %u)", params->len, err);
+
+	SET_FLAG(flag_confirmed);
+}
+
+static void indicate(const struct bt_gatt_attr *attr, uint16_t len)
+{
+	static struct bt_gatt_indicate_params params;
+	int err;
+
+	params.attr = attr;
+	params.func = indicate_cb;
+	params.data = test_data;
+	params.len = len;
+
+	UNSET_FLAG(flag_confirmed);
+
+	err = bt_gatt_indicate(g_conn, &params);
+	TEST_ASSERT(err == 0, "Failed to send %u byte indication (err %d)", len, err);
+
+	WAIT_FOR_FLAG(flag_confirmed);
+	printk("%u byte indication confirmed\n", len);
+}
+
+static void notify_multiple(const struct bt_gatt_attr *attr_a, const struct bt_gatt_attr *attr_b)
+{
+	struct bt_gatt_notify_params params[] = {
+		{ .attr = attr_a, .data = test_data, .len = OVERSIZED_LEN },
+		{ .attr = attr_b, .data = test_data, .len = SHORT_LEN },
+	};
+	int err;
+
+	do {
+		err = bt_gatt_notify_multiple(g_conn, ARRAY_SIZE(params), params);
+		if (err == -ENOMEM) {
+			k_sleep(K_MSEC(10));
+		}
+	} while (err == -ENOMEM);
+
+	TEST_ASSERT(err == 0, "Failed to send multiple handle value notification (err %d)", err);
+}
+
+static void test_main(void)
+{
+	const struct bt_data ad[] = {
+		BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	};
+	const struct bt_gatt_attr *attr_a;
+	const struct bt_gatt_attr *attr_b;
+	int err;
+
+	ARRAY_FOR_EACH(test_data, i) {
+		test_data[i] = (uint8_t)i;
+	}
+
+	bt_gatt_cb_register(&gatt_callbacks);
+
+	err = bt_enable(NULL);
+	TEST_ASSERT(err == 0, "Bluetooth init failed (err %d)", err);
+
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
+	TEST_ASSERT(err == 0, "Advertising failed to start (err %d)", err);
+
+	WAIT_FOR_FLAG(flag_is_connected);
+	WAIT_FOR_FLAG(flag_mtu_updated);
+	WAIT_FOR_FLAG(flag_a_subscribed);
+	WAIT_FOR_FLAG(flag_b_subscribed);
+
+	attr_a = bt_gatt_find_by_uuid(NULL, 0, TEST_CHRC_A_UUID);
+	attr_b = bt_gatt_find_by_uuid(NULL, 0, TEST_CHRC_B_UUID);
+	TEST_ASSERT(attr_a != NULL && attr_b != NULL, "Test characteristics not found");
+
+	/* The client must discard the oversized values and deliver the rest in
+	 * this order. Wait for the notifications to be sent so that the
+	 * indications do not overtake them.
+	 */
+	notify(attr_a, OVERSIZED_LEN);
+	notify(attr_a, MAX_LEN);
+	WAIT_FOR_FLAG(flag_sent);
+	indicate(attr_a, OVERSIZED_LEN);
+	indicate(attr_a, MAX_LEN);
+	notify_multiple(attr_a, attr_b);
+	notify(attr_b, MARKER_LEN);
+
+	TEST_PASS("GATT server passed");
+}
+
+static const struct bst_test_instance test_gatt_server[] = {
+	{
+		.test_id = "gatt_server",
+		.test_main_f = test_main,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_gatt_server);
+}

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/src/main.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bstests.h"
+
+extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests);
+
+bst_test_install_t test_installers[] = {
+	test_gatt_server_install,
+	test_gatt_client_install,
+	NULL
+};
+
+int main(void)
+{
+	bst_main();
+	return 0;
+}

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/tests.yaml
@@ -1,0 +1,11 @@
+tests:
+  bluetooth.host.gatt.notify_oversized:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_host_gatt_notify_oversized_prj_conf

--- a/tests/bsim/bluetooth/host/gatt/notify_oversized/tests_scripts/notify_oversized.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_oversized/tests_scripts/notify_oversized.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# A GATT server sends notifications and indications whose values exceed the
+# maximum attribute value length. The GATT client verifies that only the
+# valid ones are delivered to the application.
+
+set -eu
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="${BOARD_TS}_gatt_notify_oversized"
+verbosity_level=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_notify_oversized_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=gatt_client
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_notify_oversized_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=gatt_server
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
The maximum length of an attribute value is 512 octets (Core Specification Vol 3, Part F, Section 3.2.9), but the GATT client delivers notification and indication values of any length permitted by the ATT MTU to subscribe callbacks. Subscribers that size their buffers to the specification limit can be handed more data than they have room for.

This drops notifications, indications and multiple handle value notification tuples whose value exceeds `BT_ATT_MAX_ATTRIBUTE_LEN` before calling the subscriber. Oversized indications are still confirmed, since the confirmation only acknowledges receipt of the PDU and not confirming would leave the peer to hit the 30 s ATT transaction timeout over a malformed but otherwise harmless PDU.

The second commit adds a bsim test where the server sends 513- and 512-byte values over an ATT MTU of 600 through all three paths, and the client verifies only the valid ones arrive. The test fails without the first commit.

Fixes: #118959