### PR TITLE
drivers: intc_gicv3_its: fix ITT size for non-power-of-2 vector counts

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -567,8 +567,9 @@ static int gicv3_its_init_device_id(const struct device *dev, uint32_t device_id
 		}
 	}
 
-	/* ITT must be of power of 2 */
+	/* ITT must be power of 2 — round up to next power-of-2 */
 	nr_ites = MAX(2, nites);
+	nr_ites = 1 << fls_z(nr_ites - 1);
 	alloc_size = ROUND_UP(nr_ites * entry_size, 256);
 
 	LOG_INF("Allocating ITT for DeviceID %x and %d vectors (%ld bytes entry)",


### PR DESCRIPTION
### Problem
 
When a PCIe device requests a non-power-of-2 number of MSI-X vectors,
the ITS driver computes an ITT size that is too small. MAPTI commands
for higher event IDs are rejected by hardware, causing the ITS command
queue to time out.
 
### Root Cause
 
The MAPD size field is computed as `fls_z(nr_ites) - 2`, which only
yields the correct result when nr_ites is a power of 2.
 
### Fix
 
Round nr_ites up to the next power of 2 before computing size and
allocating ITT memory.
 
### Testing
 
Tested on FT3KM01 from phytium with YT6801 NIC (enable 4 rx and 1 tx).
Without the fix, MAPTI for eventid=4 times out. With the fix, all
vectors are mapped successfully.