### PR TITLE
net: dhcpv4: Refuse a request from another subnet once

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -1309,6 +1309,7 @@ static void dhcpv4_handle_request(struct dhcpv4_server_ctx *ctx,
 		if (!net_if_ipv4_addr_mask_cmp(ctx->iface, &requested_ip)) {
 			/* Wrong subnet. */
 			dhcpv4_send_nak(ctx, msg, &client_id);
+			return;
 		}
 
 		if (address_validator_callback != NULL) {
@@ -1366,6 +1367,7 @@ static void dhcpv4_handle_request(struct dhcpv4_server_ctx *ctx,
 	if (!net_if_ipv4_addr_mask_cmp(ctx->iface, &ciaddr)) {
 		/* Wrong subnet. */
 		dhcpv4_send_nak(ctx, msg, &client_id);
+		return;
 	}
 
 	for (int i = 0; i < ARRAY_SIZE(ctx->addr_pool); i++) {


### PR DESCRIPTION
A client that has moved network asks to keep an address the server cannot give it. RFC 2131 4.3.2 has the server answer that with a DHCPNAK, and the server does, but it then carries on through the rest of the handler and sends a second one: the client that is not recognised gets the refusal it is already being sent.

One message in, two out. A client that reads the second refusal as the answer to whatever it asked next is then a message behind for the rest of the exchange.

Return after the refusal, in the init-reboot path where the address asked for is out of the subnet, and in the renewing path where the address the client says it holds is. Only the first is reachable today, because an out of subnet address in the renewing path matches no slot in the pool and the handler falls out of its own accord; the two are the same omission and are worth closing together.

Assisted-by: Claude:claude-opus-5