### PR TITLE
dts: riscv: esp32p4: add missing lp core isa extensions

### DIFF
--- a/dts/riscv/espressif/esp32p4/esp32p4_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32p4/esp32p4_lpcore.dtsi
@@ -21,7 +21,7 @@
 			device_type = "cpu";
 			compatible = "espressif,riscv", "riscv";
 			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "c", "zicsr";
+			riscv,isa-extensions = "i", "m", "a", "c", "zicsr", "zifencei";
 			reg = <0>;
 			clock-source = <ESP32_RTC_FAST_CLK_SRC_XTAL>;
 			clock-frequency = <DT_FREQ_M(40)>;


### PR DESCRIPTION
The lp core is an rv32imac processor with the zicsr and zifencei extensions, but the devicetree only declared i, m, c and zicsr. Add the missing a and zifencei extensions so the lp core image builds with native atomic instructions and fence.i support.
