### PR TITLE
native_simulator: Get latest from upstream & update timer tick driver

### DIFF
--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -17,23 +17,29 @@
 #include "nsi_timer_model.h"
 #include "soc.h"
 
-static uint64_t tick_period; /* System tick period in microseconds */
-/* Time (microseconds since boot) of the last timer tick interrupt */
-static uint64_t last_tick_time;
-
 /**
- * Return the current HW cycle counter
- * (number of microseconds since boot in 32bits)
+ * Return the current HW cycle counter. This corresponds to the number of
+ * microseconds since boot, in 64 bits.
  */
-uint32_t sys_clock_cycle_get_32(void)
+static uint64_t timer_driver_cycle_get(void)
 {
 	return nsi_hws_get_time();
 }
 
-uint64_t sys_clock_cycle_get_64(void)
+/* The model fires at once for a deadline already passed, hence ORDERED. */
+static void timer_driver_set_compare(uint64_t cycles)
 {
-	return nsi_hws_get_time();
+	hwtimer_set_tick_one_shot(cycles);
 }
+
+/*
+ * Knobs for system_timer_generic.h
+ */
+#define TIMER_CORE_BACKEND_COMPARE_ORDERED
+#define TIMER_CORE_COUNTER_WIDTH 64
+#define TIMER_CORE_ALARM_MAX_CYCLES NSI_NEVER
+
+#include "system_timer_generic.h"
 
 /**
  * Interrupt handler for the timer interrupt
@@ -43,11 +49,7 @@ static void np_timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	uint64_t now = nsi_hws_get_time();
-	int32_t elapsed_ticks = (now - last_tick_time)/tick_period;
-
-	last_tick_time += elapsed_ticks*tick_period;
-	sys_clock_announce(elapsed_ticks);
+	timer_core_announce();
 }
 
 /**
@@ -59,44 +61,6 @@ void np_timer_isr_test_hook(const void *arg)
 }
 
 /**
- * @brief Set system clock timeout
- *
- * Informs the system clock driver that the next needed call to
- * sys_clock_announce() will not be until the specified number of ticks
- * from the current time have elapsed.
- *
- * See system_timer.h for more information
- *
- * @param ticks Timeout in tick units
- * @param idle Hint to the driver that the system is about to enter
- *        the idle state immediately after setting the timeout
- */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
-{
-	ARG_UNUSED(idle);
-
-#if defined(CONFIG_TICKLESS_KERNEL)
-	uint64_t silent_ticks;
-
-	silent_ticks = (ticks > 0) ? ticks - 1 : 0;
-	hwtimer_set_silent_ticks(silent_ticks);
-#endif
-}
-
-/**
- * @brief Ticks elapsed since last sys_clock_announce() call
- *
- * Queries the clock driver for the current time elapsed since the
- * last call to sys_clock_announce() was made.  The kernel will call
- * this with appropriate locking, the driver needs only provide an
- * instantaneous answer.
- */
-uint32_t sys_clock_elapsed(void)
-{
-	return (nsi_hws_get_time() - last_tick_time)/tick_period;
-}
-
-/**
  * @brief Stop announcing sys ticks into the kernel
  *
  * Disable the system ticks generation
@@ -104,24 +68,20 @@ uint32_t sys_clock_elapsed(void)
 void sys_clock_disable(void)
 {
 	irq_disable(TIMER_TICK_IRQ);
-	hwtimer_set_silent_ticks(INT64_MAX);
+	hwtimer_set_tick_one_shot(NSI_NEVER);
 }
 
 /**
  * @brief Initialize system timer driver
  *
- * Enable the hw timer, setting its tick period, and setup its interrupt
+ * Enable the hw timer, and setup its interrupt
  */
 static int sys_clock_driver_init(void)
 {
-
-	tick_period = 1000000UL / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-	last_tick_time = nsi_hws_get_time();
-	hwtimer_enable(tick_period);
-
 	IRQ_CONNECT(TIMER_TICK_IRQ, 1, np_timer_isr, 0, 0);
 	irq_enable(TIMER_TICK_IRQ);
+
+	timer_core_init();
 
 	return 0;
 }

--- a/scripts/native_simulator/native/src/include/nsi_timer_model.h
+++ b/scripts/native_simulator/native/src/include/nsi_timer_model.h
@@ -21,8 +21,10 @@ void hwtimer_set_rt_ratio(double ratio);
 void hwtimer_adjust_rt_ratio(double ratio_correction);
 
 void hwtimer_wake_in_time(uint64_t time);
-void hwtimer_set_silent_ticks(int64_t sys_ticks);
+
 void hwtimer_enable(uint64_t period);
+void hwtimer_set_tick_one_shot(uint64_t deadline);
+void hwtimer_set_silent_ticks(int64_t sys_ticks);
 int64_t hwtimer_get_pending_silent_ticks(void);
 
 void hwtimer_reset_rtc(void);

--- a/scripts/native_simulator/native/src/timer_model.c
+++ b/scripts/native_simulator/native/src/timer_model.c
@@ -189,11 +189,44 @@ static void hwtimer_init(void)
 NSI_TASK(hwtimer_init, HW_INIT, 10);
 
 /**
- * Enable the HW timer tick interrupts with a period <period> in microseconds
+ * Enable the HW ticker timer in one shot mode, so it triggers once at <deadline>
+ * where <deadline> is the number of microseconds since boot.
+ *
+ * If deadline is in the past, at less than UINT64_MAX/2 it will trigger immediately.
+ * If it is further than that, an overflow will be assumed, and it will not trigger ever.
+ *
+ * You can call it with deadline = NSI_NEVER to effectively disable the tick timer interrupt
+ *
+ * Note a possible periodic tick, and silent_ticks, configuration will be cleared.
+ */
+void hwtimer_set_tick_one_shot(uint64_t deadline)
+{
+	uint64_t now = nsi_hws_get_time();
+
+	if (deadline < now) {
+		if ((now - deadline) > UINT64_MAX/2) {
+			nsi_print_warning("%s: deadline seems to have overflowed. "
+					  "It will never trigger.\n", __func__);
+			deadline = NSI_NEVER;
+		} else {
+			deadline = now;
+		}
+	}
+	hw_timer_tick_timer = deadline;
+	tick_p = NSI_NEVER;
+	silent_ticks = 0;
+	hwtimer_update_timer();
+	nsi_hws_find_next_event();
+}
+
+/**
+ * Enable the HW timer periodic tick interrupts with a period <period> in microseconds.
  *
  * The next interrupt will be <period> microseconds from now.
  *
  * If silent_ticks had been enabled, it will be cleared.
+ * If a one shot deadline had been configured it will also be cleared.
+ *
  * If period would overflow the timer, the deadline will be set at the end of time (NSI_NEVER)
  */
 void hwtimer_enable(uint64_t period)
@@ -290,7 +323,8 @@ NSI_HW_EVENT(hw_timer_timer, hwtimer_timer_reached, 0);
 
 /**
  * The timer HW will awake the CPU (without an interrupt) at least when <time>
- * comes (it may awake it earlier)
+ * comes (it may awake it earlier).
+ * This is unrelated to the timer tick functionality and its one shot mode
  *
  * If there was a previous request for an earlier time, the old one will prevail
  *


### PR DESCRIPTION
    native_simulator: Get latest from upstream
    
    Align with native_simulator's upstream main
    eff1949a87a312928903b533e367bf7b62d382ec
    
    Which includes:
    eff1949 native: hw_timer: Add one shot API for the ticker

----
    drivers: timer: native_sim_timer: use the generic timer core
    
    Convert the native_sim_timer system-timer driver to the generic tickless
    timer core. The core takes over the tick accounting, and what is left here
    is the cycle-domain primitives for this hardware, for a COMPARE_ORDERED
    backend.
    
    Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
