### PR TITLE
modules: hal_realtek: update to pick up Ameba toolchain enforcement

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: 29d365ccfbceb9f42ce666d75463fbe2c83b8e29
+      revision: 5fa3e29115ea5dbe05da2de27288e8aa015af123
       west-commands: west/west-commands.yml
       groups:
         - hal


### PR DESCRIPTION
Update hal_realtek to pick up commit 5fa3e29 ("hal: ameba: enforce the
Ameba toolchain and drop the zephyr variant"), which enforces the
required Ameba toolchain (gnuarmemb) at CMake configure time and removes
support for an unsupported toolchain variant in merge_bin.py.