### PR TITLE
drivers: eth: sy1xx: fix promiscuous mode bit handling

### DIFF
--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -144,11 +144,7 @@ static int sy1xx_mac_set_promiscuous_mode(const struct device *dev, bool promisc
 
 	/* set promiscuous mode */
 	prom = sys_read32(cfg->ctrl_addr + SY1XX_MAC_ADDRESS_HIGH_REG);
-	if (promiscuous_mode) {
-		prom &= ~BIT(16);
-	} else {
-		prom |= BIT(16);
-	}
+	WRITE_BIT(prom, 16, promiscuous_mode);
 	sys_write32(prom, cfg->ctrl_addr + SY1XX_MAC_ADDRESS_HIGH_REG);
 
 	return 0;


### PR DESCRIPTION
With this commit, we fix the unintentionally
inverted promiscuous mode flag.