### PR TITLE
cmake: sca: set compiler and linker launchers as normal variables

### DIFF
--- a/cmake/sca/coverity/sca.cmake
+++ b/cmake/sca/coverity/sca.cmake
@@ -17,5 +17,5 @@ file(MAKE_DIRECTORY ${output_dir})
 set(output_arg --dir=${output_dir})
 
 
-set(CMAKE_C_COMPILER_LAUNCHER ${COVERITY_BUILD} ${output_arg} CACHE INTERNAL "")
-set(CMAKE_CXX_COMPILER_LAUNCHER ${COVERITY_BUILD} ${output_arg} CACHE INTERNAL "")
+set(CMAKE_C_COMPILER_LAUNCHER ${COVERITY_BUILD} ${output_arg})
+set(CMAKE_CXX_COMPILER_LAUNCHER ${COVERITY_BUILD} ${output_arg})

--- a/cmake/sca/cpptest/sca.cmake
+++ b/cmake/sca/cpptest/sca.cmake
@@ -11,5 +11,5 @@ file(MAKE_DIRECTORY ${output_dir})
 set(output_file ${output_dir}/cpptestscan.bdf)
 set(output_arg --cpptestscanOutputFile=${output_file})
 
-set(CMAKE_C_COMPILER_LAUNCHER ${CPPTESTSCAN} ${output_arg} CACHE INTERNAL "")
-set(CMAKE_CXX_COMPILER_LAUNCHER ${CPPTESTSCAN} ${output_arg} CACHE INTERNAL "")
+set(CMAKE_C_COMPILER_LAUNCHER ${CPPTESTSCAN} ${output_arg})
+set(CMAKE_CXX_COMPILER_LAUNCHER ${CPPTESTSCAN} ${output_arg})

--- a/cmake/sca/dtdoctor/sca.cmake
+++ b/cmake/sca/dtdoctor/sca.cmake
@@ -26,10 +26,12 @@ set(dtdoctor_wrapper_cmd
   --
 )
 
-set(CMAKE_C_COMPILER_LAUNCHER   ${dtdoctor_wrapper_cmd})
-set(CMAKE_CXX_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd})
-set(CMAKE_ASM_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd})
+# The wrapper runs the command it is given unmodified, so it can be chained with
+# an already configured launcher such as ccache instead of replacing it.
+set(CMAKE_C_COMPILER_LAUNCHER   ${dtdoctor_wrapper_cmd} ${CMAKE_C_COMPILER_LAUNCHER})
+set(CMAKE_CXX_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd} ${CMAKE_CXX_COMPILER_LAUNCHER})
+set(CMAKE_ASM_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd} ${CMAKE_ASM_COMPILER_LAUNCHER})
 
-set(CMAKE_C_LINKER_LAUNCHER   ${dtdoctor_wrapper_cmd})
-set(CMAKE_CXX_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd})
-set(CMAKE_ASM_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd})
+set(CMAKE_C_LINKER_LAUNCHER   ${dtdoctor_wrapper_cmd} ${CMAKE_C_LINKER_LAUNCHER})
+set(CMAKE_CXX_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd} ${CMAKE_CXX_LINKER_LAUNCHER})
+set(CMAKE_ASM_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd} ${CMAKE_ASM_LINKER_LAUNCHER})

--- a/cmake/sca/dtdoctor/sca.cmake
+++ b/cmake/sca/dtdoctor/sca.cmake
@@ -26,10 +26,10 @@ set(dtdoctor_wrapper_cmd
   --
 )
 
-set(CMAKE_C_COMPILER_LAUNCHER   ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
-set(CMAKE_CXX_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
-set(CMAKE_ASM_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
+set(CMAKE_C_COMPILER_LAUNCHER   ${dtdoctor_wrapper_cmd})
+set(CMAKE_CXX_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd})
+set(CMAKE_ASM_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd})
 
-set(CMAKE_C_LINKER_LAUNCHER   ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
-set(CMAKE_CXX_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
-set(CMAKE_ASM_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
+set(CMAKE_C_LINKER_LAUNCHER   ${dtdoctor_wrapper_cmd})
+set(CMAKE_CXX_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd})
+set(CMAKE_ASM_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd})

--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -169,7 +169,7 @@ list(JOIN ECLAIR_ENV_ADDITIONAL_OPTIONS "\n                        " ECLAIR_ENV_
 configure_file(${CMAKE_CURRENT_LIST_DIR}/eclair.template ${ECLAIR_OUTPUT_DIR}/eclair.cmake @ONLY)
 
 set(launch_environment ${CMAKE_COMMAND} -P ${ECLAIR_OUTPUT_DIR}/eclair.cmake --)
-set(CMAKE_C_COMPILER_LAUNCHER ${launch_environment} CACHE INTERNAL "")
+set(CMAKE_C_COMPILER_LAUNCHER ${launch_environment})
 
 list(APPEND ECLAIR_PROJECT_ARGS
                         +project

--- a/cmake/sca/iar_c_stat/sca.cmake
+++ b/cmake/sca/iar_c_stat/sca.cmake
@@ -67,5 +67,5 @@ if(CSTAT_CLEANUP)
 endif()
 
 # Enable IAR C-STAT Static Analysis (requires CMake v4.1+)
-set(CMAKE_C_ICSTAT ${IAR_CSTAT};${output_arg} CACHE INTERNAL "")
-set(CMAKE_CXX_ICSTAT ${IAR_CSTAT};${output_arg} CACHE INTERNAL "")
+set(CMAKE_C_ICSTAT ${IAR_CSTAT};${output_arg})
+set(CMAKE_CXX_ICSTAT ${IAR_CSTAT};${output_arg})

--- a/cmake/sca/iwyu/sca.cmake
+++ b/cmake/sca/iwyu/sca.cmake
@@ -23,5 +23,5 @@ endif()
 # Enable include-what-you-use using the native CMake support. CMake invokes the
 # tool alongside the compiler for every translation unit and prints the
 # suggested include changes to stderr during the build.
-set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${iwyu_command} CACHE INTERNAL "")
-set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${iwyu_command} CACHE INTERNAL "")
+set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${iwyu_command})
+set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${iwyu_command})

--- a/cmake/sca/sparse/sca.cmake
+++ b/cmake/sca/sparse/sca.cmake
@@ -12,7 +12,7 @@ message(STATUS "Found SCA: sparse (${SPARSE_COMPILER})")
 configure_file(${CMAKE_CURRENT_LIST_DIR}/sparse.template ${CMAKE_BINARY_DIR}/sparse.cmake @ONLY)
 
 set(launch_environment ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/sparse.cmake --)
-set(CMAKE_C_COMPILER_LAUNCHER ${launch_environment} CACHE INTERNAL "")
+set(CMAKE_C_COMPILER_LAUNCHER ${launch_environment})
 
 list(APPEND TOOLCHAIN_C_FLAGS -D__CHECKER__)
 # Avoid compiler "attribute directive ignored" warnings

--- a/doc/develop/sca/index.rst
+++ b/doc/develop/sca/index.rst
@@ -51,6 +51,23 @@ Remember to add ``/path/to/my_tools`` to :makevar:`SCA_ROOT`.
 ``-DSCA_ROOT=<sca_root>``, or added by a Zephyr module in its :file:`module.yml`
 file, see :ref:`Zephyr Modules - Build settings <modules_build_settings>`
 
+Compiler and linker launchers
+=============================
+
+An SCA tool that needs to observe or wrap the compilation and link commands
+does so by setting the ``CMAKE_<LANG>_COMPILER_LAUNCHER`` and
+``CMAKE_<LANG>_LINKER_LAUNCHER`` variables from its :file:`sca.cmake`. They must
+be set as normal variables, not as cache entries.
+
+A launcher set this way replaces any launcher that was already configured,
+``ccache`` included. A tool that is a transparent wrapper, meaning it runs the
+command it is given unmodified, may instead keep the previous launcher by
+appending it:
+
+.. code-block:: cmake
+
+   set(CMAKE_C_COMPILER_LAUNCHER ${my_wrapper} ${CMAKE_C_COMPILER_LAUNCHER})
+
 .. _sca_native_tools:
 
 Native SCA Tool support


### PR DESCRIPTION
SCA tools install themselves as compiler and linker launchers, but since [CMP0126](https://cmake.org/cmake/help/latest/policy/CMP0126.html) a cache entry no longer removes a normal variable of the same name. The launchers were set as `CACHE INTERNAL` entries, so they ended up shadowed by the normal variables `FindTargetTools` sets for ccache, and the tool silently never ran. This started with a119dbf9572, which bumped the minimum CMake version to 3.28.0 and thereby turned the policy to NEW. Only `main` is affected, no release.

Every variant setting `CMAKE_<LANG>_{COMPILER,LINKER}_LAUNCHER` is hit (coverity, cpptest, dtdoctor, eclair and sparse), and since ccache is used automatically whenever it is found, this affects developers by default.

There is no reason for these to be cache variables: they are `INTERNAL`, and `sca.cmake` is re-included on every configure. `find_package(ScaTools)` runs in the same scope as `find_package(TargetTools)`, so setting them as normal variables makes the SCA launcher take effect again regardless of the policy — which is also what CMP0126 `OLD` used to give, so there is no change in semantics.

Whether a tool can coexist with ccache is left to the tool itself. Only dtdoctor opts in, since its wrapper runs the command it is given unmodified; sparse, ECLAIR, Coverity and C/C++test keep replacing ccache. Chaining them all would not be safe: it would break sparse, whose template skips exactly one argument after `--`, and silently disable ECLAIR, whose `eclair_env` only recognizes a compile when argv[0] matches `CC_ALIASES`.

The last two commits are cleanup: the same cache idiom in iwyu and IAR C-STAT, and the contract written down in the SCA docs so the next tool does not copy it back in.

Verified with `-DZEPHYR_SCA_VARIANT=dtdoctor` and ccache installed: the tool reports as expected and the launcher chain is `<wrapper> -- ccache <compiler>`.

Reworked after review: the first version fixed this centrally in `FindScaTools.cmake`, this one leaves it untouched and fixes the tools instead.