### PR TITLE
cmake: armclang: use the target CPU for compiler capability probes

### DIFF
--- a/cmake/compiler/armclang/target.cmake
+++ b/cmake/compiler/armclang/target.cmake
@@ -59,7 +59,7 @@ foreach(isystem_include_dir ${NOSTDINC})
   list(APPEND isystem_include_flags -isystem ${isystem_include_dir})
 endforeach()
 
-set(CMAKE_REQUIRED_FLAGS ${isystem_include_flags})
+set(CMAKE_REQUIRED_FLAGS -mcpu=${GCC_M_CPU} ${isystem_include_flags})
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 if(CONFIG_ARMCLANG_STD_LIBC)


### PR DESCRIPTION
Since [CMP0123](https://cmake.org/cmake/help/latest/policy/CMP0123.html) became NEW, CMake no longer adds `-mcpu` for armclang itself, and Zephyr only passes it through `TOOLCHAIN_C_FLAGS`, which does not reach `try_compile`. Compiler capability probes are therefore evaluated against armclang's default CPU instead of the target one, so flag support is decided for the wrong ISA. This started with a119dbf9572, which bumped the minimum CMake version to 3.28.0 and turned the policy to NEW.

Adding `-mcpu` to `CMAKE_REQUIRED_FLAGS` makes probe results match the target again.

This has not been tested with a real armclang toolchain, so a review from someone who can build with it would be welcome.

Related and deliberately left alone here: armlink no longer receives `--cpu` either, which looks harmless since it derives the processor from object attributes, but it does mean the processor name is no longer validated.
