### PR TITLE
drivers: eth: sy1xx: handle RX metadata stripping

### DIFF
--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -45,9 +45,12 @@ LOG_MODULE_REGISTER(sy1xx_mac, CONFIG_ETHERNET_LOG_LEVEL);
 /* Clock divider mask */
 #define SY1XX_MAC_CTRL_CLK_DIV_MASK (0x3)
 
-#define MAX_MAC_PACKET_LEN      1600
-#define MAX_TX_RETRIES          5
-#define RECEIVE_GRACE_TIME_MSEC 1
+#define MAX_MAC_PACKET_LEN         1600
+#define SY1XX_MAC_RX_TIMESTAMP_SIZE 8
+#define SY1XX_MAC_RX_STATUS_SIZE    1
+#define SY1XX_MAC_RX_METADATA_SIZE  (SY1XX_MAC_RX_TIMESTAMP_SIZE + SY1XX_MAC_RX_STATUS_SIZE)
+#define MAX_TX_RETRIES             5
+#define RECEIVE_GRACE_TIME_MSEC    1
 
 #define SY1XX_ETH_STACK_SIZE      4096
 #define SY1XX_ETH_THREAD_PRIORITY K_PRIO_PREEMPT(0)
@@ -411,15 +414,23 @@ static int sy1xx_mac_low_level_receive(const struct device *dev, uint8_t *rx, ui
 
 	/* rx udma is ready */
 	bytes_transferred = SY1XX_UDMA_READ_REG(cfg->base_addr, SY1XX_UDMA_CFG_REG) & 0x0000ffff;
-	if (bytes_transferred) {
-		/* message received, copy data */
-		memcpy(rx, data->dma_buffers->rx, bytes_transferred);
-		*len = bytes_transferred;
-		ret = 0;
-	} else {
+	if (bytes_transferred == 0) {
 		/* no data, should never happen */
 		SY1XX_UDMA_CANCEL_RX(cfg->base_addr);
 		ret = -EINVAL;
+	} else if (bytes_transferred < SY1XX_MAC_RX_METADATA_SIZE +
+		   NET_ETH_MINIMAL_FRAME_SIZE) {
+		LOG_ERR("rx frame too short (%u bytes)", bytes_transferred);
+		ret = -EINVAL;
+	} else {
+		/*
+		 * The MAC appends its internal RTC timestamp and RX status to every
+		 * received frame. Do not pass this MAC-specific metadata to the
+		 * Ethernet stack.
+		 */
+		*len = bytes_transferred - SY1XX_MAC_RX_METADATA_SIZE;
+		memcpy(rx, data->dma_buffers->rx, *len);
+		ret = 0;
 	}
 
 	/* start new reception */


### PR DESCRIPTION
Add error handling for RX frames shorter than metadata size and strip MAC-specific metadata (timestamp and status) from RX frames before passing them to the
Ethernet stack.