### PR TITLE
STM32: add mco support for STM32F0 & STM32L0

### DIFF
--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -2,6 +2,7 @@
  * Copyright (c) 2017 RnDity Sp. z o.o.
  * Copyright (c) 2019 Centaur Analytics, Inc
  * Copyright (c) 2024 STMicroelectronics
+ * Copyright (c) 2026 Witekio
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -78,6 +79,14 @@
 		pll: pll {
 			#clock-cells = <0>;
 			compatible = "st,stm32f0-pll-clock";
+			status = "disabled";
+		};
+	};
+
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Endre Karlson <endre.karlson@gmail.com>
  * Copyright (c) 2019 Centaur Analytics, Inc
+ * Copyright (c) 2026 Witekio
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -90,6 +91,14 @@
 		pll: pll {
 			#clock-cells = <0>;
 			compatible = "st,stm32l0-pll-clock";
+			status = "disabled";
+		};
+	};
+
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Linaro Limited
+ * Copyright (c) 2026 Witekio
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -52,8 +53,43 @@
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
 /** CFGR1 devices */
-#define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
-#define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
+#define MCO1_SEL(val)       STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
+#define MCO1_PRE(val)       STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
+#define MCO1_PLL_DIV(val)   STM32_DT_CLOCK_SELECT((val), 31, 31, CFGR1_REG)
+
+/* MCO source clock selector */
+#define MCO_SEL_HSI14    (1)
+#define MCO_SEL_LSI      (2)
+#define MCO_SEL_LSE      (3)
+#define MCO_SEL_SYSCLK   (4)
+#define MCO_SEL_HSI      (5)
+#define MCO_SEL_HSE      (6)
+#define MCO_SEL_PLL      (7)    /* PLL/2 or PLL, see below */
+#define MCO_SEL_HSI48    (8)
+
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_1   (0)
+#define MCO_PRE_DIV_2   (1)
+#define MCO_PRE_DIV_4   (2)
+#define MCO_PRE_DIV_8   (3)
+#define MCO_PRE_DIV_16  (4)
+#define MCO_PRE_DIV_32  (5)
+#define MCO_PRE_DIV_64  (6)
+#define MCO_PRE_DIV_128 (7)
+
+/*
+ * MCO PLL source divider
+ *
+ * By default, the MCO_SEL_PLL source goes through a divide-by-2
+ * prescaler and outputs "PLL / 2". It is possible to output the
+ * undivided PLL clock by disabling the prescaler on some SoCs
+ * by using MCO_PLL_DIV_1.
+ *
+ * Refer to RM00091 Rev 10 §6.2.12 (or RM0360 Rev 5 §7.2.11) to
+ * determine if disabling the prescaler is possible on your SoC.
+ */
+#define MCO_PLL_DIV_2   (0)     /* default value */
+#define MCO_PLL_DIV_1   (1)
 
 /** @endcond */
 

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Linaro Limited
+ * Copyright (c) 2026 Witekio
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,6 +36,9 @@
 #define STM32_SRC_TIMPCLK1	(STM32_SRC_PCLK + 1)
 #define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
 
+/** @brief RCC_CFGR register offset */
+#define CFGR_REG               0x0C
+
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x4C
 
@@ -52,6 +56,27 @@
 #define HSI48_SEL(val)		STM32_DT_CLOCK_SELECT((val), 26, 26, CCIPR_REG)
 /** CSR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CSR_REG)
+
+/** CFGR1 devices */
+#define MCO1_SEL(val)       STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR_REG)
+#define MCO1_PRE(val)       STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR_REG)
+
+/* MCO source clock selector */
+#define MCO_SEL_SYSCLK   (1)
+#define MCO_SEL_HSI16    (2)
+#define MCO_SEL_MSI      (3)
+#define MCO_SEL_HSE      (4)
+#define MCO_SEL_PLL      (5)
+#define MCO_SEL_LSI      (6)
+#define MCO_SEL_LSE      (7)
+#define MCO_SEL_HSI48    (8)
+
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_1  (0)
+#define MCO_PRE_DIV_2  (1)
+#define MCO_PRE_DIV_4  (2)
+#define MCO_PRE_DIV_8  (3)
+#define MCO_PRE_DIV_16 (4)
 
 /** @endcond */
 

--- a/samples/boards/st/mco/boards/nucleo_f072rb.overlay
+++ b/samples/boards/st/mco/boards/nucleo_f072rb.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Witekio
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The clock that is output must be enabled. */
+&clk_lse {
+	status = "okay";
+};
+
+&mco1 {
+	clocks = <&rcc STM32_SRC_LSE MCO1_SEL(MCO_SEL_LSE)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_1)>;
+	pinctrl-0 = <&rcc_mco_pa8>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/boards/st/mco/boards/nucleo_l053r8.overlay
+++ b/samples/boards/st/mco/boards/nucleo_l053r8.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Witekio
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The clock that is output must be enabled. */
+&clk_lse {
+	status = "okay";
+};
+
+&mco1 {
+	clocks = <&rcc STM32_SRC_LSE MCO1_SEL(MCO_SEL_LSE)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_1)>;
+	pinctrl-0 = <&rcc_mco_pa8>;
+	pinctrl-names = "default";
+	status = "okay";
+};


### PR DESCRIPTION
Add mco support for STM32F0 & STM32L0 tested on nucleo_l053r8 & nucleo_f072rb