### PR TITLE
bluetooth: mesh: clean beacon cache for IV index test mode

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -286,6 +286,11 @@ void bt_mesh_iv_update_test(bool enable)
 	atomic_set_bit_to(bt_mesh.flags, BT_MESH_IVU_TEST, enable);
 	/* Reset the duration variable - needed for some PTS tests */
 	bt_mesh.ivu_duration = 0U;
+	/* ivu_refresh() drops the beacon cache when the 96-hour limit expires. Test mode
+	 * lifts that limit without the timer running, so drop it here too, or a beacon
+	 * cached while the limit was in force would keep being filtered as a duplicate.
+	 */
+	bt_mesh_subnet_foreach(bt_mesh_beacon_cache_clear);
 }
 
 bool bt_mesh_iv_update(void)

--- a/tests/bsim/bluetooth/mesh/src/test_beacon.c
+++ b/tests/bsim/bluetooth/mesh/src/test_beacon.c
@@ -1056,6 +1056,70 @@ static void test_tx_beacon_cache(void)
 	PASS();
 }
 
+static void snb_recv_ivu(const struct bt_mesh_snb *snb)
+{
+	ASSERT_EQUAL(snb->flags, 0x02);
+	ASSERT_EQUAL(snb->iv_idx, 1);
+	snb_cnt++;
+	k_sem_give(&beacon_sem);
+}
+
+static void test_rx_beacon_cache_ivu_test_mode(void)
+{
+	k_sem_init(&beacon_sem, 0, 1);
+	snb_cb_ptr = snb_recv_ivu;
+
+	bt_mesh_test_cfg_set(&rx_cfg, WAIT_TIME);
+	bt_mesh_test_setup();
+
+	/* Test mode is left off, so the first beacon is refused by the 96-hour limit. */
+	ASSERT_OK_MSG(k_sem_take(&beacon_sem, K_SECONDS(20)), "Didn't receive first SNB");
+	ASSERT_EQUAL(bt_mesh.iv_index, 0);
+	ASSERT_FALSE(atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS));
+
+	bt_mesh_iv_update_test(true);
+
+	/* The repeated beacon must not be filtered out as a duplicate now that the limit
+	 * no longer applies.
+	 */
+	ASSERT_OK_MSG(k_sem_take(&beacon_sem, K_SECONDS(20)), "Cached SNB was not reprocessed");
+	ASSERT_EQUAL(bt_mesh.iv_index, 1);
+	ASSERT_TRUE(atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS));
+
+	bt_mesh_iv_update_test(false);
+
+	ASSERT_OK_MSG(k_sem_take(&beacon_sem, K_SECONDS(20)), "Cached SNB was not reprocessed");
+
+	/* Duplicate filtering is unaffected by test mode, so the fourth beacon is dropped. */
+	ASSERT_TRUE(k_sem_take(&beacon_sem, K_SECONDS(20)) != 0);
+	ASSERT_EQUAL(snb_cnt, 3);
+
+	PASS();
+}
+
+static void test_tx_beacon_cache_ivu_test_mode(void)
+{
+	NET_BUF_SIMPLE_DEFINE(iv1, 22);
+
+	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
+	bt_mesh_crypto_init();
+	ASSERT_OK_MSG(bt_enable(NULL), "Bluetooth init failed");
+
+	beacon_create(&iv1, test_net_key, 0x02, 0x0001);
+
+	/* The rx device sends its own beacons on a 10 second cycle. Offset the transmissions by
+	 * half a cycle, otherwise they collide with those and the rx device never sees them.
+	 */
+	k_sleep(K_SECONDS(5));
+
+	for (size_t i = 0; i < 4; i++) {
+		send_beacon(&iv1);
+		k_sleep(K_SECONDS(10));
+	}
+
+	PASS();
+}
+
 typedef void (*priv_beacon_cb)(const struct bt_mesh_prb *prb);
 
 static priv_beacon_cb priv_beacon_cb_ptr;
@@ -2213,6 +2277,7 @@ static const struct bst_test_instance test_beacon[] = {
 	TEST_CASE(tx, multiple_netkeys, "Beacon: multiple Net Keys"),
 	TEST_CASE(tx, secure_beacon_interval, "Beacon: send secure beacons"),
 	TEST_CASE(tx, beacon_cache,   "Beacon: advertise duplicate SNBs"),
+	TEST_CASE(tx, beacon_cache_ivu_test_mode, "Beacon: duplicate SNB, IVU test mode"),
 	TEST_CASE(tx, priv_on_iv_update,   "Private Beacon: send on IV update"),
 	TEST_CASE(tx, priv_on_key_refresh,   "Private Beacon: send on Key Refresh"),
 	TEST_CASE(tx, priv_adv,   "Private Beacon: advertise Private Beacons"),
@@ -2235,6 +2300,7 @@ static const struct bst_test_instance test_beacon[] = {
 	TEST_CASE(rx, multiple_netkeys, "Beacon: multiple Net Keys"),
 	TEST_CASE(rx, secure_beacon_interval, "Beacon: receive and send secure beacons"),
 	TEST_CASE(rx, beacon_cache,   "Beacon: receive duplicate SNBs"),
+	TEST_CASE(rx, beacon_cache_ivu_test_mode, "Beacon: duplicate SNB, IVU test mode"),
 	TEST_CASE(rx, priv_adv,   "Private Beacon: verify random regeneration"),
 	TEST_CASE(rx, priv_invalid,   "Private Beacon: receive invalid beacons"),
 	TEST_CASE(rx, priv_interleave,   "Private Beacon: interleaved with SNB"),

--- a/tests/bsim/bluetooth/mesh/tests_scripts/beacon/beacon_cache_ivu_test_mode.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/beacon/beacon_cache_ivu_test_mode.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test that a cached beacon is reprocessed once IV Update test mode lifts the 96-hour limit
+#
+# Test procedure:
+# 0. RX device starts monitoring all accepted SNB messages, with IV Update test mode off.
+# 1. TX device sends an SNB with the IV Update flag set. RX device authenticates and caches it,
+#    but refuses the IV Update because of the 96-hour limit.
+# 2. RX device enables IV Update test mode, which lifts that limit.
+# 3. TX device sends an identical SNB. RX device verifies that it was not filtered out as a
+#    duplicate, and that the IV Update was performed.
+# 4. RX device disables IV Update test mode.
+# 5. TX device sends the identical SNB twice more. RX device verifies that only the first of
+#    the two was processed, i.e. that duplicate filtering still works.
+RunTest mesh_beacon_cache_ivu_test_mode \
+	beacon_tx_beacon_cache_ivu_test_mode \
+	beacon_rx_beacon_cache_ivu_test_mode


### PR DESCRIPTION
## Problem

With `CONFIG_BT_MESH_IV_UPDATE_TEST=y`, a node does not perform an IV Update
after `bt_mesh_iv_update_test()` is called, even when it then receives a Secure
Network beacon that should trigger one.

A beacon received *before* test mode is enabled is authenticated and stored in
the per-subnet cache by `net_beacon_resolve()`, and only then refused by
`bt_mesh_net_iv_update()` because of the 96-hour limit. Every identical
retransmission afterwards is filtered as a duplicate and never reaches
`net_beacon_recv()`.

## Fix

`bt_mesh_iv_update_test()` now clears the beacon cache.

`ivu_refresh()` already does this in normal operation: the flush condition and
the expiry of the 96-hour limit both derive from `bt_mesh.ivu_duration`, so they
coincide at multiples of 96. Test mode lifts the limit without the timer
running, so the same invalidation is applied there.

Caching itself stays independent of test mode. Per MshPRT v1.1.1 §3.11.5.1 test
mode *"only removes the 96-hour limit; all other behavior of the device shall be
unchanged"*, and §3.10.4.2 explicitly permits caching to filter duplicates.

## Test

New bsim test `tests_scripts/beacon/beacon_cache_ivu_test_mode.sh`. The tx
device sends the same beacon four times:

| # | Test mode | Expected |
|---|-----------|----------|
| 1 | off       | cached, IV Update refused by the 96-hour limit |
| 2 | **on**    | reprocessed, IV Update performed |
| 3 | off       | reprocessed |
| 4 | off       | filtered as a duplicate |

Validated by mutation:

| Mutation | Result |
|----------|--------|
| drop the `bt_mesh_beacon_cache_clear()` call | fails on beacon 2 |
| drop `cache_add()` from `net_beacon_resolve()` | fails on beacon 4 |

Regression: `beacon_cache`, `iv_update` and `invalid` still pass.