### PR TITLE
net: websocket: fix RFC 6455 GUID

### DIFF
--- a/subsys/net/lib/http/http_server_ws.c
+++ b/subsys/net/lib/http/http_server_ws.c
@@ -28,7 +28,7 @@ LOG_MODULE_DECLARE(net_http_server, CONFIG_NET_HTTP_SERVER_LOG_LEVEL);
 #endif
 
 /* From RFC 6455 chapter 4.2.2 */
-#define WS_MAGIC "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+#define WS_MAGIC "258EAFA5-E914-47DA-95CA-5AB0DC85B11F"
 
 /* Handle upgrade from HTTP/1.1 to Websocket, see RFC 6455
  */

--- a/subsys/net/lib/websocket/websocket_internal.h
+++ b/subsys/net/lib/websocket/websocket_internal.h
@@ -22,7 +22,7 @@
 #define MAX_HEADER_LEN 14
 
 /* From RFC 6455 chapter 4.2.2 */
-#define WS_MAGIC "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+#define WS_MAGIC "258EAFA5-E914-47DA-95CA-5AB0DC85B11F"
 
 /**
  * Websocket parser states


### PR DESCRIPTION
Correct the WebSocket GUID used to calculate the expected Sec-WebSocket-Accept value, per RFC 6455 §4.2.2.

The current GUID is 258EAFA5-E914-47DA-95CA-C5AB0DC85B11, while RFC 6455 specifies 258EAFA5-E914-47DA-95CA-5AB0DC85B11F. This causes the WebSocket client to calculate an incorrect expected Sec-WebSocket-Accept value and reject handshake responses from standards-compliant servers.

The issue surfaced while connecting the Zephyr WebSocket client to an external WebSocket server and was resolved by correcting the GUID.