### PR TITLE
bluetooth: mesh: fix beacon cache flush for all IVU dividers

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -989,10 +989,13 @@ void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 
 static void ivu_refresh(struct k_work *work)
 {
+	uint8_t prev_duration;
+
 	if (!bt_mesh_is_provisioned()) {
 		return;
 	}
 
+	prev_duration = bt_mesh.ivu_duration;
 	bt_mesh.ivu_duration = MIN(UINT8_MAX,
 	       bt_mesh.ivu_duration + BT_MESH_IVU_HOURS);
 
@@ -1012,8 +1015,10 @@ static void ivu_refresh(struct k_work *work)
 	/* Because the beacon may be cached, iv update or iv recovery
 	 * cannot be performed after 96 hours or 192 hours.
 	 * So we need clear beacon cache.
+	 * BT_MESH_IVU_HOURS need not divide the limit, so test for crossing it.
 	 */
-	if (!(bt_mesh.ivu_duration % BT_MESH_IVU_MIN_HOURS)) {
+	if (prev_duration / BT_MESH_IVU_MIN_HOURS !=
+	    bt_mesh.ivu_duration / BT_MESH_IVU_MIN_HOURS) {
 		bt_mesh_subnet_foreach(bt_mesh_beacon_cache_clear);
 	}
 


### PR DESCRIPTION
BT_MESH_IVU_HOURS is BT_MESH_IVU_MIN_HOURS divided by CONFIG_BT_MESH_IVU_DIVIDER with integer truncation, so the step by which bt_mesh.ivu_duration grows need not divide 96. For dividers 5, 7, 9, 10, 13, 17, 18 and 19 the step is 19, 13, 10, 9, 7, 5, 5 and 5, and the duration steps over the 96 hour boundary without landing on it. The old exact-multiple test then never flushed the beacon cache, so a beacon refused because of the limit stayed cached, every identical retransmission was dropped as a duplicate, and the node never ran IV Update or IV Index Recovery once the limit expired.