### PR TITLE
drivers: dap: fix sw_get_pins() for CLK and RESET

### DIFF
--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -573,14 +573,27 @@ static int sw_port_on(const struct device *dev)
 		}
 	}
 
-	ret = gpio_pin_configure_dt(&config->clk, GPIO_OUTPUT_ACTIVE);
+	ret = gpio_pin_configure_dt(&config->clk, GPIO_INPUT | GPIO_OUTPUT_ACTIVE);
+	if (ret == -ENOTSUP) {
+		LOG_DBG("Fall back to CLK output only");
+		ret = gpio_pin_configure_dt(&config->clk, GPIO_OUTPUT_ACTIVE);
+	}
+
 	if (ret) {
+		LOG_ERR("Failed to configure CLK GPIO");
 		return ret;
 	}
 
 	if (config->reset.port) {
-		ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE);
+		ret = gpio_pin_configure_dt(&config->reset,
+					    GPIO_INPUT | GPIO_OUTPUT_INACTIVE);
+		if (ret == -ENOTSUP) {
+			LOG_DBG("Fall back to RESET output only");
+			ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE);
+		}
+
 		if (ret) {
+			LOG_ERR("Failed to configure RESET GPIO");
 			return ret;
 		}
 	}


### PR DESCRIPTION
The values of the pins configured as GPIO_OUTPUT_* and GPIO_ACTIVE_LOW would be always read as 1. And read back as 0 when configured as GPIO_OUTPUT_* and GPIO_ACTIVE_HIGH. Means there is mismatch between the actual state of the pins and value read back.

Example from an adapter where RESET is configured as ACTIVE_LOW:

pyocd> set pins 0x11
Pins mask = 0x10
SWCLK/TCK = 0 (mask 0x1)
SWDIO/TMS = 0 (mask 0x2)
TDI =       0 (mask 0x4)
TDO =       0 (mask 0x8)
nRESET =    1 (mask 0x10)
nTRST =     0 (mask 0x20)
pyocd> set pins 0x00
Pins mask = 0x10
SWCLK/TCK = 0 (mask 0x1)
SWDIO/TMS = 0 (mask 0x2)
TDI =       0 (mask 0x4)
TDO =       0 (mask 0x8)
nRESET =    1 (mask 0x10)
nTRST =     0 (mask 0x20)

Fix it by also configuring output pins as inputs. This commit only fixes the CLK and RESET pins.

Now, sw_get_pins() returns correct values for CLK and RESET

pyocd> set pins 0x11
Pins mask = 0x11
SWCLK/TCK = 1 (mask 0x1)
SWDIO/TMS = 0 (mask 0x2)
TDI =       0 (mask 0x4)
TDO =       0 (mask 0x8)
nRESET =    1 (mask 0x10)
nTRST =     0 (mask 0x20)
pyocd> set pins 0x00
Pins mask = 0x0
SWCLK/TCK = 0 (mask 0x1)
SWDIO/TMS = 0 (mask 0x2)
TDI =       0 (mask 0x4)
TDO =       0 (mask 0x8)
nRESET =    0 (mask 0x10)
nTRST =     0 (mask 0x20)