### PR TITLE
MAINTAINERS: enable meta for bsim

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -7778,6 +7778,7 @@ hawkBit:
 
 nRF BSIM:
   status: maintained
+  meta: true
   maintainers:
     - aescolar
   files:


### PR DESCRIPTION
Quite often bluetooth changes go together with new bsim tests or updates of existing ones.
Such PRs should not be assigned on BabbleSim test
environment maintainer. They should be assigned on subsystem maintainer those changes belong.