### PR TITLE
net: websocket: Select the SHA-1 algorithm the client uses

### DIFF
--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -9,7 +9,7 @@ config WEBSOCKET_CLIENT
 	select HTTP_CLIENT
 	select BASE64
 	select PSA_CRYPTO
-	select PSA_WANT_ALG_SHA_256
+	select PSA_WANT_ALG_SHA_1
 	select EXPERIMENTAL
 	help
 	  Enable Websocket client library.


### PR DESCRIPTION
The Websocket client computes the Sec-WebSocket-Accept hash with PSA_ALG_SHA_1, but WEBSOCKET_CLIENT asked PSA for SHA-256, which the library never uses. In a build that enables the client and nothing else, psa_hash_compute() then returns PSA_ERROR_NOT_SUPPORTED and websocket_connect() fails with -EPROTO before the handshake is sent. The websocket_client sample is affected as shipped.

The wrong algorithm came in when the client moved off the legacy Mbed TLS crypto API and "select MBEDTLS_SHA1 if MBEDTLS_BUILTIN" was replaced. HTTP_SERVER_WEBSOCKET selects SHA-1 itself, which is why builds that pair the client with the server were unaffected.

Assisted-by: Claude:claude-opus-5