### PR TITLE
soc: intel_adsp: coredump: fix debug window slot corruption with dynamic slot manager

### DIFF
--- a/subsys/debug/coredump/coredump_backend_intel_adsp_mem_window.c
+++ b/subsys/debug/coredump/coredump_backend_intel_adsp_mem_window.c
@@ -32,8 +32,14 @@ static void coredump_mem_window_backend_start(void)
 #ifdef CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER
 	struct adsp_dw_desc slot_desc = { .type = ADSP_DW_SLOT_TELEMETRY, };
 
-	/* Forcibly take debug slot 1 */
-	coredump_slot_addr = adsp_dw_seize_slot(1, &slot_desc, NULL);
+	/* Reuse the telemetry slot if one is already assigned, avoiding a second,
+	 * duplicate ADSP_DW_SLOT_TELEMETRY descriptor pointing elsewhere.
+	 */
+	coredump_slot_addr = adsp_dw_request_slot(&slot_desc, NULL);
+	if (!coredump_slot_addr) {
+		/* No telemetry slot exists yet, forcibly take debug slot 1 */
+		coredump_slot_addr = adsp_dw_seize_slot(1, &slot_desc, NULL);
+	}
 	if (!coredump_slot_addr) {
 		/* Try to get the first slot if slot 1 is not available as fallback */
 		coredump_slot_addr = adsp_dw_seize_slot(0, &slot_desc, NULL);

--- a/subsys/debug/coredump/coredump_backend_intel_adsp_mem_window.c
+++ b/subsys/debug/coredump/coredump_backend_intel_adsp_mem_window.c
@@ -87,6 +87,11 @@ static void coredump_mem_window_backend_buffer_output(uint8_t *buf, size_t bufle
 		return;
 	}
 
+	/* Clamp to the remaining space: writing past the slot boundary would
+	 * spill into whatever debug window slot physically follows this one.
+	 */
+	buflen = MIN(buflen, ADSP_DW_SLOT_SIZE - 4 - mem_wptr);
+
 	if (buf) {
 		for (data_left = buflen; data_left > 0; data_left--) {
 			*mem_window_sink = *coredump_data;


### PR DESCRIPTION
With CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER=y, the coredump memory-window backend could corrupt other debug window slots (e.g. the mtrace log ring buffer) or fail to preserve the actual exception dump. Two related fixes:
- clamp the write to make sure that writes are not spilling over to the next slot
- If a telemetry slot has been already allocated, reuse it before trying to force take a slot.

