### PR TITLE
drivers: pwm: mcux_ctimer: realign counter on period shrink

### DIFF
--- a/drivers/pwm/pwm_mcux_ctimer.c
+++ b/drivers/pwm/pwm_mcux_ctimer.c
@@ -179,6 +179,7 @@ static int mcux_ctimer_pwm_set_cycles(const struct device *dev, uint32_t pulse_c
 	const struct pwm_mcux_ctimer_config *config = dev->config;
 	struct pwm_mcux_ctimer_data *data = dev->data;
 	uint32_t period_channel = data->current_period_channel;
+	bool period_changed;
 	int ret = 0;
 	status_t status;
 
@@ -205,6 +206,8 @@ static int mcux_ctimer_pwm_set_cycles(const struct device *dev, uint32_t pulse_c
 		LOG_ERR("could not select valid period channel. ret=%d", ret);
 		return ret;
 	}
+
+	period_changed = data->channel_states[period_channel].cycles != period_cycles;
 
 	/*
 	 * CTIMER PWM-mode output: after each TC reset the pin starts LOW; it
@@ -237,6 +240,20 @@ static int mcux_ctimer_pwm_set_cycles(const struct device *dev, uint32_t pulse_c
 		LOG_ERR("failed setup pwm period. status=%d", status);
 		return -EIO;
 	}
+
+	/*
+	 * CTIMER_SetupPwmPeriod() only rewrites the match registers, it does not
+	 * touch TC. Shortening the period while the timer runs can therefore leave
+	 * TC above the new MR[period_channel] value, so the reset-on-match never
+	 * fires again until TC wraps around 32 bits and the output freezes for up
+	 * to 2^32 timer cycles. Realign TC with the new period whenever the period
+	 * value actually changes. Duty-cycle-only updates keep the counter running
+	 * so they introduce no phase discontinuity.
+	 */
+	if (period_changed) {
+		CTIMER_Reset(config->base);
+	}
+
 	mcux_ctimer_pwm_update_state(data, pulse_channel, pulse_cycles, period_channel,
 				     period_cycles);
 

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_mcxa156.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_mcxa156.overlay
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+&pinctrl {
+	pinmux_ctimer1_pwm_out: pinmux_ctimer1_pwm_out {
+		group0 {
+			pinmux = <CT1_MAT0_P2_4>;
+			slew-rate = "fast";
+			drive-strength = "low";
+		};
+	};
+
+	pinmux_ctimer2_pwm_cap: pinmux_ctimer2_pwm_cap {
+		group0 {
+			pinmux = <CT_INP15_P2_5>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
+};
+
+/* To test this sample, connect P2_4(J2-11) ---> P2_5(J2-13) */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&ctimer1 0 0 PWM_POLARITY_NORMAL>, /* OUT: CT1_MAT0 P2_4 (Arduino A3) */
+		       <&ctimer2 0 0 PWM_POLARITY_NORMAL>; /* IN : CT_INP15 P2_5 (Arduino A1) */
+	};
+};
+
+&ctimer1 {
+	status = "okay";
+	compatible = "nxp,ctimer-pwm";
+	prescaler = <95>;
+	#pwm-cells = <3>;
+	pinctrl-0 = <&pinmux_ctimer1_pwm_out>;
+	pinctrl-names = "default";
+};
+
+&ctimer2 {
+	status = "okay";
+	compatible = "nxp,ctimer-pwm";
+	prescaler = <95>;
+	#pwm-cells = <3>;
+	/*
+	 * Route CT_INP15 (P2_5) to CTIMER2 CAPTSEL[0] via INPUTMUX0.
+	 * Cells: <&inputmux0 index connection> where connection is
+	 * kINPUTMUX_CtimerInp15ToTimer2Captsel = 16U | (TIMER2CAPTSEL0 << 20)
+	 * = 0x06000010.
+	 */
+	mux-states = <&inputmux0 0 0x06000010>;
+	pinctrl-0 = <&pinmux_ctimer2_pwm_cap>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -158,6 +158,54 @@ ZTEST_USER(pwm_loopback, test_pulse_and_period_capture)
 		     PWM_CAPTURE_TYPE_BOTH | PWM_POLARITY_NORMAL);
 }
 
+ZTEST_USER(pwm_loopback, test_period_shrink_while_running)
+{
+	struct test_pwm in;
+	struct test_pwm out;
+	uint32_t long_period = CONFIG_TEST_PWM_PERIOD_USEC;
+	/* Floor of 2 keeps short_period / 2 (the pulse width below) from rounding to 0. */
+	uint32_t short_period = MAX(long_period / 10, 2);
+	uint64_t period_capture = 0;
+	uint64_t pulse_capture = 0;
+	int err;
+
+	get_test_pwms(&out, &in);
+
+	TC_PRINT("Testing period shrink %u -> %u usec while running\n", long_period, short_period);
+
+	err = pwm_set(out.dev, out.pwm, PWM_USEC(long_period), PWM_USEC(long_period / 2),
+		      out.flags);
+	zassert_equal(err, 0, "failed to set long pwm period (err %d)", err);
+
+	/*
+	 * Let the counter advance well past the shorter period's match value
+	 * before shrinking the period. A driver that reprograms the period
+	 * without realigning its counter leaves the counter above the new match
+	 * value, so the match never fires again and the output stops.
+	 */
+	k_sleep(K_USEC(long_period * 3 / 4));
+
+	err = pwm_set(out.dev, out.pwm, PWM_USEC(short_period), PWM_USEC(short_period / 2),
+		      out.flags);
+	zassert_equal(err, 0, "failed to shrink pwm period (err %d)", err);
+
+	/* Allow drivers that only apply a new period at the next period boundary to catch up. */
+	k_sleep(K_USEC(long_period));
+
+	err = pwm_capture_usec(in.dev, in.pwm, in.flags | PWM_CAPTURE_TYPE_PERIOD, &period_capture,
+			       &pulse_capture, K_USEC(short_period * 10));
+	pwm_disable_capture(in.dev, in.pwm);
+
+	if (err == -ENOTSUP) {
+		TC_PRINT("period capture not supported\n");
+		ztest_test_skip();
+	}
+
+	zassert_equal(err, 0, "no pwm output after shrinking the period (err %d)", err);
+	zassert_within(period_capture, short_period, MAX(short_period / 100, 1),
+		       "period capture off by more than 1%%");
+}
+
 ZTEST_USER(pwm_loopback, test_capture_timeout)
 {
 	struct test_pwm in;


### PR DESCRIPTION
CTIMER_SetupPwmPeriod() only rewrites the match registers; it does
not touch TC. Shrinking the period while the timer is running can
leave TC above the new MR[period_channel] value, so the reset-on-
match condition never fires again until TC wraps around 32 bits,
freezing the output for up to 2^32 timer cycles.

Reset the counter whenever the period value actually changes.
Duty-cycle-only updates keep the counter running, so they introduce
no phase discontinuity.