### PR TITLE
drivers: wifi: siwx91x: fix sign of reported RSSI

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -33,7 +33,10 @@ static void siwx91x_report_scan_res(struct siwx91x_dev *sidev, sl_wifi_scan_resu
 	};
 	struct wifi_scan_result tmp = {
 		.channel = result->scan_info[item].rf_channel,
-		.rssi = result->scan_info[item].rssi_val,
+		/* WiSeConnect reports rssi_val as an unsigned magnitude, while
+		 * struct wifi_scan_result expects signed dBm.
+		 */
+		.rssi = -result->scan_info[item].rssi_val,
 		.ssid_length = strlen(result->scan_info[item].ssid),
 		.mac_length = sizeof(result->scan_info[item].bssid),
 		.security = WIFI_SECURITY_TYPE_UNKNOWN,


### PR DESCRIPTION
Every AP in a scan is reported with a positive RSSI on the SiWx917.

WiSeConnect gives `rssi_val` as an unsigned magnitude:

```c
uint8_t rssi_val;      ///< RSSI value of the AP
```

while `struct wifi_scan_result.rssi` is `int8_t` in dBm. `siwx91x_report_scan_res()` assigns one to the other directly, so an AP at -76 dBm is reported as +76. Anything that sorts or thresholds by signal strength gets the ordering inverted, and the sign is already gone by the time a consumer sees it, so this cannot be worked around above the driver.

The fix negates on assignment.

## How I tested it

Hardware: Silicon Labs SiWx917-DK2605A (Zephyr board `siwx917_dk2605a`, SoC SiWG917M111MGTBA), running a Zephyr application that calls `net_mgmt(NET_REQUEST_WIFI_SCAN, ...)` and prints each result.

- Before: every AP in range reported a positive value, e.g. `+76`.
- After: the same APs report negative dBm matching a phone's scan at the same spot within a couple of dBm.
- Walking the board away from a known AP moves the value in the correct direction, which it did not do before (the magnitude moved, the sign never did).

Not tested on the NCP or RCP variants of this part, though `siwx91x_wifi_scan.c` is shared and the assignment is the same on all of them.

## AI assistance

Written with Claude Code. I ran the hardware scans and confirmed the readings against an independent device myself.
