### PR TITLE
Bluetooth: Classic: HID: fix GET_REPORT size flag bit position

### DIFF
--- a/subsys/bluetooth/host/classic/hid_internal.h
+++ b/subsys/bluetooth/host/classic/hid_internal.h
@@ -52,8 +52,12 @@
 
 /** @brief Report type field mask (lower two bits of parameter). */
 #define BT_HID_PARAM_REPORT_TYPE_MASK GENMASK(1, 0)
-/** @brief Report size present flag in parameter field. */
-#define BT_HID_PARAM_REPORT_SIZE_MASK BIT(2)
+/** @brief Report size present flag in parameter field.
+ *
+ *  HID spec v1.1.2 Table 3.4: within the GET_REPORT header octet bit 3 is the
+ *  Size flag and bit 2 is reserved, so the flag is bit 3 of the parameter.
+ */
+#define BT_HID_PARAM_REPORT_SIZE_MASK BIT(3)
 
 /** @brief Report type values used in GET/SET/DATA messages. */
 #define BT_HID_PAR_REP_TYPE_OTHER   0x00


### PR DESCRIPTION
HID spec v1.1.2 Table 3.4 places the Size flag of the GET_REPORT header
octet at bit 3 and marks bit 2 as reserved, but the parameter mask used
bit 2. A host would therefore set the reserved bit instead of the Size
flag, leaving the device to parse the trailing BufferSize field as report
data. HID11.TS HID11/HOS/HCT/BV-01-C additionally requires all reserved
fields of the Get_Report command to be zero.

This is a standalone fix split out of the HID Host profile PR #109289, as
it addresses an existing spec-compliance bug in the shared HID parameter
mask and is independent of the HID Host feature.