### PR TITLE
debug: coredump: adjust logging backend behavior during panic

### DIFF
--- a/subsys/debug/coredump/coredump_backend_logging.c
+++ b/subsys/debug/coredump/coredump_backend_logging.c
@@ -31,10 +31,6 @@ static void coredump_logging_backend_start(void)
 	/* Reset error */
 	error = 0;
 
-	while (LOG_PROCESS()) {
-		;
-	}
-
 	LOG_PANIC();
 	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_BEGIN_STR);
 }


### PR DESCRIPTION
Updated the coredump logging backend to ensure that LOG_PROCESS() is not called before LOG_PANIC(). This change prevents buffered messages from being delivered while backends are still in normal mode, aligning the logging behavior with the intended panic notification flow.