### PR TITLE
kernel: timeout: add Pugh skip list timeout backend

### DIFF
--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -201,7 +201,7 @@ The default, :kconfig:option:`CONFIG_TIMEOUT_BACKEND_DLIST`, stores
 events in a doubly linked list sorted by expiry, each holding a delta
 count in ticks from its predecessor.  Insertion is O(N) in the number of
 pending timeouts: inexpensive for the handful a typical system has
-pending, but it scales poorly when many are outstanding.  The three
+pending, but it scales poorly when many are outstanding.  The four
 alternative backends, all currently experimental, trade extra memory or
 behaviour for faster insertion at scale:
 
@@ -227,6 +227,13 @@ behaviour for faster insertion at scale:
   sorted overflow list beyond it.  It also requires 64-bit ticks, but
   unlike the wheel it preserves same-tick firing order and adds no
   idle-wakeup cost.
+
+* :kconfig:option:`CONFIG_TIMEOUT_BACKEND_SKIPLIST` is a Pugh skip list
+  keyed on absolute expiry.  Expected insertion and removal are O(log N)
+  with no capacity limit, and same-tick firing order is FIFO.  It
+  requires 64-bit ticks.  Each event stores
+  :kconfig:option:`CONFIG_TIMEOUT_SKIPLIST_MAX_LEVEL` forward pointers,
+  so per-event RAM is higher than the delta list or min-heap.
 
 The non-default backends target systems that hold many concurrent
 timeouts, especially ones clustered in the near future.  For most

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -314,12 +314,21 @@ struct _timeout {
 	 */
 	int64_t abs_ticks;
 	struct min_heap_handle heap_handle;
+#elif defined(CONFIG_TIMEOUT_BACKEND_SKIPLIST)
+	/*
+	 * Skip-list backend: absolute expiry tick plus a geometric-height
+	 * tower of forward pointers. height == 0 means the timeout is not
+	 * queued (idle, popped for announcing, or aborted).
+	 */
+	int64_t abs_ticks;
+	uint8_t height;
+	struct _timeout *forward[CONFIG_TIMEOUT_SKIPLIST_MAX_LEVEL];
 #else
 	/*
-	 * Delta-list and timer-wheel backends: a list node plus dticks (a
-	 * delta to the predecessor for the delta list; an encoded slot
-	 * position for the wheel). The wheel adds a flags field recording
-	 * which wheel tier the timeout currently occupies.
+	 * Delta-list, bucket, and timer-wheel backends: a list node plus
+	 * dticks (a delta to the predecessor for the delta list; an encoded
+	 * slot position for the wheel or bucket). The wheel adds a flags
+	 * field recording which wheel tier the timeout currently occupies.
 	 */
 	sys_dnode_t node;
 #if defined(CONFIG_TIMEOUT_BACKEND_WHEEL)

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -819,6 +819,22 @@ config TIMEOUT_BACKEND_BUCKET
 	  is on demand against the actual next event, so it imposes no
 	  tickless-idle floor. Requires 64-bit timeouts.
 
+config TIMEOUT_BACKEND_SKIPLIST
+	bool "Skip list [EXPERIMENTAL]"
+	depends on TIMEOUT_64BIT
+	select EXPERIMENTAL
+	help
+	  A Pugh skip list keyed on absolute expiry tick. Expected insertion
+	  and arbitrary removal are O(log n), the earliest timeout is O(1),
+	  and there is no capacity limit. Same-tick firing order is FIFO.
+	  Each pending timeout carries CONFIG_TIMEOUT_SKIPLIST_MAX_LEVEL
+	  forward pointers, sized for the worst case although the expected
+	  height is 2. At the default 8 levels struct _timeout is 88 bytes
+	  on a 64-bit target, against 32 for the delta list and 24 for the
+	  min-heap, and every k_thread, k_timer and delayable work item
+	  pays it. Requires 64-bit timeouts. Consider this when many
+	  timeouts are pending and a bounded heap is undesirable.
+
 endchoice # TIMEOUT_BACKEND
 
 config TIMEOUT_BUCKET_LISTS
@@ -833,6 +849,19 @@ config TIMEOUT_BUCKET_LISTS
 	  the O(1) window at the cost of more static RAM (one list head each).
 	  Below 8 the plain delta-list backend is likely the better choice. The
 	  occupancy bitmap is a uint32_t for up to 32 buckets, a uint64_t beyond.
+
+config TIMEOUT_SKIPLIST_MAX_LEVEL
+	int "Maximum skip-list height"
+	depends on TIMEOUT_BACKEND_SKIPLIST
+	default 8
+	range 4 16
+	help
+	  Maximum number of forward-pointer levels in each timeout node.
+	  Height is drawn from a geometric(1/2) distribution, so expected
+	  search cost is O(log n) as long as this is at least log2 of the
+	  peak number of pending timeouts. Each extra level adds one pointer
+	  to every struct _timeout (k_timer, k_thread, delayable work, ...).
+	  8 levels cover a few hundred concurrent timeouts comfortably.
 
 config TIMEOUT_HEAP_MAX_ENTRIES
 	int "Maximum simultaneous pending timeouts in the heap"

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -59,6 +59,25 @@ static inline bool z_is_inactive_timeout(const struct _timeout *to)
 	return !sys_dnode_is_linked(&to->node);
 }
 
+#elif defined(CONFIG_TIMEOUT_BACKEND_SKIPLIST)
+
+static inline void z_init_timeout(struct _timeout *to)
+{
+	uint8_t i;
+
+	to->height = 0;
+	to->abs_ticks = 0;
+
+	for (i = 0; i < CONFIG_TIMEOUT_SKIPLIST_MAX_LEVEL; i++) {
+		to->forward[i] = NULL;
+	}
+}
+
+static inline bool z_is_inactive_timeout(const struct _timeout *to)
+{
+	return to->height == 0;
+}
+
 #else /* CONFIG_TIMEOUT_BACKEND_DLIST or _BUCKET */
 
 static inline void z_init_timeout(struct _timeout *to)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -111,6 +111,8 @@ static uint32_t elapsed(void)
 #include "timeout_wheel.h"
 #elif defined(CONFIG_TIMEOUT_BACKEND_BUCKET)
 #include "timeout_bucket.h"
+#elif defined(CONFIG_TIMEOUT_BACKEND_SKIPLIST)
+#include "timeout_skiplist.h"
 #else /* CONFIG_TIMEOUT_BACKEND_DLIST */
 #include "timeout_list.h"
 #endif

--- a/kernel/timeout_skiplist.h
+++ b/kernel/timeout_skiplist.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 Dhruv Menon <dhruvmenon1104@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_TIMEOUT_SKIPLIST_H_
+#define ZEPHYR_KERNEL_TIMEOUT_SKIPLIST_H_
+
+/**
+ * @file
+ * @brief Skip-list timeout backend (implementation).
+ *
+ * Pending timeouts are kept in a Pugh skip list keyed on absolute expiry
+ * tick (struct _timeout's abs_ticks). Expected insertion and arbitrary
+ * removal are O(log n); the earliest timeout is always the level-0 successor
+ * of the sentinel. A timeout that is not queued has height == 0.
+ *
+ * Same-tick firing order is FIFO: a new node is inserted after every node
+ * that already has the same abs_ticks.
+ *
+ * Node height is drawn from a geometric(1/2) distribution using a private
+ * xorshift32, so the announce/add/abort paths never call the entropy driver.
+ * There is no capacity limit (unlike the min-heap backend).
+ */
+
+#define SKIPLIST_LEVELS CONFIG_TIMEOUT_SKIPLIST_MAX_LEVEL
+
+/* Sentinel: never expires, participates in every level, never fired. */
+static struct _timeout sl_head = {
+	.height = SKIPLIST_LEVELS,
+	.forward = { NULL },
+};
+
+/* Highest height of any currently queued node; 0 when the list is empty. */
+static uint8_t sl_top;
+
+/*
+ * Scratch predecessor vector shared by insert and remove. Both run with
+ * timeout_lock held and neither keeps it across an unlock, so one array is
+ * enough. Any future caller must hold that lock too.
+ */
+static struct _timeout *sl_update[SKIPLIST_LEVELS];
+
+/* Marsaglia xorshift32 state; period 2^32-1, must stay non-zero. */
+static uint32_t sl_rng = 2463534242U;
+
+static uint8_t skiplist_random_height(void)
+{
+	uint32_t r = sl_rng;
+
+	r ^= r << 13;
+	r ^= r >> 17;
+	r ^= r << 5;
+	sl_rng = r;
+
+	/* p = 1/2: height is 1 + the run of low 1-bits, capped at SKIPLIST_LEVELS. */
+	return 1 + MIN(u32_count_trailing_zeros(~r), SKIPLIST_LEVELS - 1);
+}
+
+static inline struct _timeout *skiplist_first(void)
+{
+	return sl_head.forward[0];
+}
+
+static void skiplist_drop_top(void)
+{
+	while (sl_top > 0 && sl_head.forward[sl_top - 1] == NULL) {
+		sl_top--;
+	}
+}
+
+static void skiplist_update_init(struct _timeout **update)
+{
+	uint8_t i;
+
+	for (i = 0; i < SKIPLIST_LEVELS; i++) {
+		update[i] = &sl_head;
+	}
+}
+
+/* Splice @to out at every level it occupies. */
+static void skiplist_unlink(struct _timeout *to, struct _timeout **update)
+{
+	uint8_t i;
+	uint8_t height = to->height;
+
+	for (i = 0; i < height; i++) {
+		__ASSERT_NO_MSG(update[i]->forward[i] == to);
+		update[i]->forward[i] = to->forward[i];
+	}
+
+	to->height = 0;
+	skiplist_drop_top();
+}
+
+/* Equal keys are skipped so a later insert lands after them (same-tick FIFO). */
+static void skiplist_predecessors_after(int64_t abs_ticks, struct _timeout **update)
+{
+	struct _timeout *x = &sl_head;
+	int i;
+
+	for (i = (int)sl_top - 1; i >= 0; i--) {
+		while (x->forward[i] != NULL && x->forward[i]->abs_ticks <= abs_ticks) {
+			x = x->forward[i];
+		}
+		update[i] = x;
+	}
+}
+
+/* Walk equal-key nodes so identity, not just expiry, selects the splice points. */
+static void skiplist_predecessors_of(struct _timeout *to, struct _timeout **update)
+{
+	struct _timeout *x = &sl_head;
+	int i;
+
+	for (i = (int)sl_top - 1; i >= 0; i--) {
+		while (x->forward[i] != NULL && x->forward[i]->abs_ticks < to->abs_ticks) {
+			x = x->forward[i];
+		}
+		update[i] = x;
+	}
+
+	for (i = 0; i < to->height; i++) {
+		while (update[i]->forward[i] != NULL &&
+		       update[i]->forward[i] != to &&
+		       update[i]->forward[i]->abs_ticks == to->abs_ticks) {
+			update[i] = update[i]->forward[i];
+		}
+	}
+}
+
+static inline bool z_timeout_q_insert(struct _timeout *to, k_ticks_t dticks)
+{
+	uint8_t i;
+	uint8_t height;
+
+	to->abs_ticks = (int64_t)curr_tick + dticks;
+	height = skiplist_random_height();
+	to->height = height;
+
+	skiplist_update_init(sl_update);
+	skiplist_predecessors_after(to->abs_ticks, sl_update);
+
+	if (height > sl_top) {
+		sl_top = height;
+	}
+
+	for (i = 0; i < height; i++) {
+		to->forward[i] = sl_update[i]->forward[i];
+		sl_update[i]->forward[i] = to;
+	}
+
+	return skiplist_first() == to;
+}
+
+static inline bool z_timeout_q_remove(struct _timeout *to)
+{
+	bool was_first = (skiplist_first() == to);
+
+	__ASSERT_NO_MSG(to->height > 0);
+
+	skiplist_update_init(sl_update);
+	skiplist_predecessors_of(to, sl_update);
+
+	skiplist_unlink(to, sl_update);
+
+	return was_first;
+}
+
+static inline k_ticks_t z_timeout_q_remainder(const struct _timeout *to)
+{
+	return (k_ticks_t)(to->abs_ticks - (int64_t)curr_tick);
+}
+
+static inline k_ticks_t z_timeout_q_next_expiry(void)
+{
+	struct _timeout *t = skiplist_first();
+	int64_t gap;
+
+	if (t == NULL) {
+		return K_TICKS_FOREVER;
+	}
+
+	gap = t->abs_ticks - (int64_t)curr_tick;
+	return (gap < 0) ? 0 : (k_ticks_t)gap;
+}
+
+static inline int32_t z_timeout_q_next_gap(void)
+{
+	struct _timeout *t = skiplist_first();
+	int64_t gap;
+
+	if (t == NULL) {
+		return INT32_MAX;
+	}
+
+	/* Overdue must be 0: announce casts dt to uint32_t. */
+	gap = t->abs_ticks - (int64_t)curr_tick;
+	if (gap <= 0) {
+		return 0;
+	}
+
+	return (int32_t)MIN(gap, (int64_t)INT32_MAX);
+}
+
+static inline void z_timeout_q_advance(int32_t dt)
+{
+	ARG_UNUSED(dt);
+}
+
+/* Earliest node, so it is the head's successor at every level it occupies. */
+static inline struct _timeout *z_timeout_q_pop_due(void)
+{
+	struct _timeout *t = skiplist_first();
+	uint8_t i;
+
+	if ((t == NULL) || (t->abs_ticks > (int64_t)curr_tick)) {
+		return NULL;
+	}
+
+	for (i = 0; i < t->height; i++) {
+		__ASSERT_NO_MSG(sl_head.forward[i] == t);
+		sl_head.forward[i] = t->forward[i];
+	}
+
+	t->height = 0;
+	skiplist_drop_top();
+
+	return t;
+}
+
+#endif /* ZEPHYR_KERNEL_TIMEOUT_SKIPLIST_H_ */

--- a/tests/kernel/timeout/tests.yaml
+++ b/tests/kernel/timeout/tests.yaml
@@ -21,3 +21,9 @@ tests:
     tags:
       - kernel
       - timer
+  kernel.timer.timeout.skiplist:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_SKIPLIST=y
+    tags:
+      - kernel
+      - timer

--- a/tests/kernel/timeout_pending/CMakeLists.txt
+++ b/tests/kernel/timeout_pending/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(timeout_pending)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/timeout_pending/prj.conf
+++ b/tests/kernel/timeout_pending/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/timeout_pending/src/main.c
+++ b/tests/kernel/timeout_pending/src/main.c
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 Dhruv Menon <dhruvmenon1104@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/ztest.h>
+
+/*
+ * Many-pending coverage for any timeout-queue backend. tests/kernel/timeout
+ * only exercises K_TIMEOUT_SUM, so a backend can pass that suite without
+ * ever linking more than a handful of nodes.
+ *
+ * Insert order is a coprime stride over the id space, so expiry order is
+ * scrambled. Ids are grouped into same-tick clusters. After the earliest
+ * cluster has fired, a scattered subset of still-pending timers is aborted.
+ *
+ * Backends that guarantee same-tick FIFO (delta list, bucket, skip list)
+ * must fire remaining timers in (deadline, insert-seq) order. Min-heap and
+ * wheel do not promise that, so those variants only check expiry order.
+ */
+#define NUM_TIMEOUTS 256
+#define CLUSTER 8
+#define FIRST_DELAY_MIN_TICKS 32
+#define FIRST_DELAY_MS 50
+#define NUM_CLUSTERS (NUM_TIMEOUTS / CLUSTER)
+/* had to keep it as a coprime with NUM_TIMEOUTS so start order is a permutation of ids. */
+#define SCRAMBLE_STRIDE 7
+
+BUILD_ASSERT((NUM_TIMEOUTS % CLUSTER) == 0, "N must be a multiple of CLUSTER");
+BUILD_ASSERT((NUM_TIMEOUTS % SCRAMBLE_STRIDE) != 0,
+	     "SCRAMBLE_STRIDE must be coprime with NUM_TIMEOUTS");
+#ifdef CONFIG_TIMEOUT_BACKEND_MINHEAP
+BUILD_ASSERT(NUM_TIMEOUTS <= CONFIG_TIMEOUT_HEAP_MAX_ENTRIES,
+	     "raise CONFIG_TIMEOUT_HEAP_MAX_ENTRIES for this many pending timeouts");
+#endif
+
+static struct k_timer timers[NUM_TIMEOUTS];
+static int delay_ticks[NUM_TIMEOUTS];
+static int insert_seq[NUM_TIMEOUTS];
+static uint8_t saw_fire[NUM_TIMEOUTS];
+static bool aborted[NUM_TIMEOUTS];
+static int fire_order[NUM_TIMEOUTS];
+static int expected[NUM_TIMEOUTS];
+static atomic_t fire_count;
+
+static int first_delay_ticks(void)
+{
+	int t = (int)k_ms_to_ticks_ceil32(FIRST_DELAY_MS);
+
+	/* Keep a tick floor so a slow clock still outlasts the start loop. */
+	return (t > FIRST_DELAY_MIN_TICKS) ? t : FIRST_DELAY_MIN_TICKS;
+}
+
+static int scrambled_id(int seq)
+{
+	return (int)(((unsigned int)seq * SCRAMBLE_STRIDE) % NUM_TIMEOUTS);
+}
+
+static int cluster_of(int id)
+{
+	return id / CLUSTER;
+}
+
+static bool same_tick_fifo(void)
+{
+	return !IS_ENABLED(CONFIG_TIMEOUT_BACKEND_MINHEAP) &&
+	       !IS_ENABLED(CONFIG_TIMEOUT_BACKEND_WHEEL);
+}
+
+static k_timeout_t cluster_timeout(int64_t abs_base, int cluster)
+{
+#ifdef CONFIG_TIMEOUT_64BIT
+	return K_TIMEOUT_ABS_TICKS(abs_base + cluster);
+#else
+	ARG_UNUSED(abs_base);
+	return K_TICKS(first_delay_ticks() + cluster);
+#endif
+}
+
+static void expiry_fn(struct k_timer *timer)
+{
+	int id = POINTER_TO_INT(k_timer_user_data_get(timer));
+	int idx = (int)atomic_inc(&fire_count);
+
+	saw_fire[id] = 1U;
+	if (idx < NUM_TIMEOUTS) {
+		fire_order[idx] = id;
+	}
+}
+
+static void sync_tick(void)
+{
+	uint32_t uptime = k_uptime_get_32();
+
+	while (uptime == k_uptime_get_32()) {
+		Z_SPIN_DELAY(50);
+	}
+}
+
+static void wait_fired_at_least(int expected)
+{
+	int64_t extra_ms = k_ticks_to_ms_ceil64(first_delay_ticks() + NUM_CLUSTERS + 20);
+	int64_t deadline = k_uptime_get() + extra_ms + 5000;
+
+	while (atomic_get(&fire_count) < expected && k_uptime_get() < deadline) {
+		k_sleep(K_TICKS(1));
+	}
+
+	zassert_true(atomic_get(&fire_count) >= expected,
+		     "only %ld of %d timeouts fired",
+		     (long)atomic_get(&fire_count), expected);
+}
+
+static void sort_by_expiry_then_insert(int *ids, int n)
+{
+	int i;
+
+	for (i = 1; i < n; i++) {
+		int key = ids[i];
+		int j = i - 1;
+
+		while (j >= 0) {
+			int a = ids[j];
+			bool after = (delay_ticks[a] < delay_ticks[key]) ||
+				     (delay_ticks[a] == delay_ticks[key] &&
+				      insert_seq[a] <= insert_seq[key]);
+
+			if (after) {
+				break;
+			}
+			ids[j + 1] = a;
+			j--;
+		}
+		ids[j + 1] = key;
+	}
+}
+
+/**
+ * @brief Many pending timeouts: scrambled keys, same-tick clusters, mid-flight abort.
+ *
+ * @ingroup kernel_timeout_tests
+ *
+ * @details
+ * Starts NUM_TIMEOUTS one-shots in scrambled order, grouped into same-tick
+ * clusters. After the earliest cluster fires, aborts a scattered subset of
+ * still-pending timers so removal is not only at the head. Remaining timers
+ * must expire in deadline order; backends that keep same-tick FIFO must also
+ * preserve insertion order inside a cluster.
+ *
+ * @see k_timer_start()
+ * @see k_timer_stop()
+ */
+ZTEST(timeout_pending, test_many_pending_scrambled)
+{
+	int i;
+	int nexp = 0;
+	int64_t abs_base = 0;
+	int first_delay;
+
+	if (!IS_ENABLED(CONFIG_TIMEOUT_64BIT)) {
+		/*
+		 * Relative starts re-anchor per call, so the loop cannot land a
+		 * cluster on one tick and delay_ticks[] stops modelling the real
+		 * deadlines. Neither assertion below is checkable.
+		 */
+		ztest_test_skip();
+	}
+
+	first_delay = first_delay_ticks();
+
+	for (i = 0; i < NUM_TIMEOUTS; i++) {
+		int id = scrambled_id(i);
+
+		delay_ticks[id] = first_delay + cluster_of(id);
+		insert_seq[id] = i;
+		saw_fire[id] = 0U;
+		aborted[id] = false;
+		fire_order[i] = -1;
+		k_timer_init(&timers[id], expiry_fn, NULL);
+		k_timer_user_data_set(&timers[id], INT_TO_POINTER(id));
+	}
+	atomic_set(&fire_count, 0);
+
+	sync_tick();
+	abs_base = k_uptime_ticks() + first_delay;
+	k_sched_lock();
+	for (i = 0; i < NUM_TIMEOUTS; i++) {
+		int id = scrambled_id(i);
+
+		k_timer_start(&timers[id],
+			      cluster_timeout(abs_base, cluster_of(id)),
+			      K_NO_WAIT);
+	}
+	k_sched_unlock();
+	zassert_equal(atomic_get(&fire_count), 0,
+		      "first cluster fired during start loop; raise FIRST_DELAY_MS");
+
+	/* First cluster must fire before aborts so remaining unlinks are interior. */
+	wait_fired_at_least(CLUSTER);
+
+	for (i = 0; i < NUM_TIMEOUTS; i++) {
+		int id = scrambled_id(i);
+
+		if ((insert_seq[id] % 5) != 1) {
+			continue;
+		}
+		if (cluster_of(id) < 3) {
+			continue;
+		}
+		if (saw_fire[id] != 0U) {
+			continue;
+		}
+		if (k_timer_remaining_ticks(&timers[id]) == 0) {
+			continue;
+		}
+		k_timer_stop(&timers[id]);
+		if (saw_fire[id] == 0U) {
+			aborted[id] = true;
+		}
+	}
+
+	for (i = 0; i < NUM_TIMEOUTS; i++) {
+		if (!aborted[i]) {
+			expected[nexp++] = i;
+		}
+	}
+
+	wait_fired_at_least(nexp);
+	zassert_equal(atomic_get(&fire_count), nexp,
+		      "fire count %ld != expected %d",
+		      (long)atomic_get(&fire_count), nexp);
+
+	for (i = 0; i < NUM_TIMEOUTS; i++) {
+		if (aborted[i]) {
+			zassert_equal(saw_fire[i], 0U, "aborted timer %d still fired", i);
+		} else {
+			zassert_equal(saw_fire[i], 1U, "timer %d neither aborted nor fired", i);
+		}
+	}
+
+	if (same_tick_fifo()) {
+		sort_by_expiry_then_insert(expected, nexp);
+		for (i = 0; i < nexp; i++) {
+			zassert_equal(fire_order[i], expected[i],
+				      "expiry[%d] was timer %d, expected %d (delay %d seq %d)",
+				      i, fire_order[i], expected[i],
+				      delay_ticks[expected[i]], insert_seq[expected[i]]);
+		}
+	} else {
+		for (i = 1; i < nexp; i++) {
+			zassert_true(delay_ticks[fire_order[i]] >= delay_ticks[fire_order[i - 1]],
+				     "expiry order broken at %d: delay %d then %d",
+				     i, delay_ticks[fire_order[i - 1]],
+				     delay_ticks[fire_order[i]]);
+		}
+	}
+
+	for (i = 0; i < NUM_TIMEOUTS; i++) {
+		k_timer_stop(&timers[i]);
+	}
+}
+
+ZTEST_SUITE(timeout_pending, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/timeout_pending/tests.yaml
+++ b/tests/kernel/timeout_pending/tests.yaml
@@ -1,0 +1,28 @@
+common:
+  tags:
+    - kernel
+    - timer
+  min_ram: 128
+  timeout: 60
+  integration_platforms:
+    - qemu_x86
+    - qemu_x86_64
+
+tests:
+  kernel.timer.timeout_pending:
+    tags:
+      - kernel
+      - timer
+  kernel.timer.timeout_pending.min_heap:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_MINHEAP=y
+      - CONFIG_TIMEOUT_HEAP_MAX_ENTRIES=512
+  kernel.timer.timeout_pending.wheel:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_WHEEL=y
+  kernel.timer.timeout_pending.bucket:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_BUCKET=y
+  kernel.timer.timeout_pending.skiplist:
+    extra_configs:
+      - CONFIG_TIMEOUT_BACKEND_SKIPLIST=y


### PR DESCRIPTION
This commit introduces a new timeout backend using a Pugh skip list, which allows for O(log N) insertion and removal of timeouts. The skip list maintains a same-tick firing order and has no capacity limit, making it suitable for systems with many concurrent timeouts. The implementation includes necessary Kconfig options and updates to the timeout management code to support this new backend.
Enable with `CONFIG_TIMEOUT_BACKEND_SKIPLIST=y` (requires `CONFIG_TIMEOUT_64BIT`). Height is `CONFIG_TIMEOUT_SKIPLIST_MAX_LEVEL` (default 8).
### Why a fifth backend
Four backends are already in tree. This is the only one that is simultaneously:
- O(log n) at any horizon
- unbounded (the min-heap's fixed capacity overflows fatally)
- same-tick FIFO (the min-heap and wheel are not; the bucket is, but degrades to O(N) past its window)
dlist is FIFO and unbounded, but insertion is O(N) when the new wait is later than everything already queued. Wheel is O(1) only inside ~1024 ticks. Bucket is O(1) only inside `CONFIG_TIMEOUT_BUCKET_LISTS` ticks (default 32).
The cost is RAM: at 8 levels, `struct _timeout` is 88 bytes on a 64-bit target, against 32 for the delta list and 24 for the min-heap. On `qemu_x86_64`, `struct k_thread` goes 880 → 928. Every `k_timer` and delayable work item pays the same per-node increase. Expected node height is 2; the extra pointers are worst-case.

### Benchmark using `timeout_mgmt`

`qemu_x86_64/atom`, SMP=2, TSC, no icount. Cycles are QEMU TCG, not silicon. N=100 is 1000 iterations; N≥250 is 200.
Add with increasing waits (dlist’s worst case; avg / max):

| Backend  | N=100      | N=250      | N=500       | N=1000      |
|----------|------------|------------|-------------|-------------|
| dlist    | 667 / 3374 | 926 / 4355 | 1435 / 3810 | 2601 / 4810 |
| bucket   | 578 / 2797 | 724 / 3435 | 1124 / 3790 | 2021 / 4990 |
| skiplist | 546 / 3141 | 467 / 3735 | 453 / 3455  | 481 / 4465  |
| min-heap | 474 / 2746 | 401 / 3275 | 380 / 3315  | 397 / 4625  |
| wheel    | 487 / 2576 | 435 / 2865 | 421 / 3080  | 442 / 3000  |

Dlist grew ~4× as N went 10×. Skiplist stayed ~480–550 (about 5.4x cheaper than dlist at N=1000), still unbounded and FIFO. Wheel and min-heap stay flat on this pattern; bucket already goes linear once waits miss the 32-tick window.
All six cases at N=1000 (average cycles):

| Backend  | Add inc | Abort exp | Add dec | Abort rev | Add mid | Abort div |
|----------|---------|-----------|---------|-----------|---------|-----------|
| dlist    | 2601    | 2461      | 2408    | 133       | 1503    | 133       |
| min-heap | 397     | 3549      | 2566    | 191       | 420     | 173       |
| wheel    | 442     | 206       | 505     | 132       | 449     | 132       |
| bucket   | 2021    | 2167      | 2227    | 131       | 1180    | 130       |
| skiplist | 481     | 2339      | 2392    | 330       | 482     | 307       |

Note: "Abort exp" and "Add dec" include sys_clock_set_timeout() calls that occur 
when the earliest deadline changes. This clock-write overhead dominates these patterns 
for all backends. Excluding it: skip list "Abort exp" is 714 cycles (vs 2339) and 
"Add dec" is 1469 cycles (vs 2392) at N=500.

### Testing
- `kernel.timer.timeout.skiplist`
- `timer_api` (206/206) and `kernel.common` (80/80) on `qemu_x86` / `qemu_x86_64`
- SMP `qemu_x86_64` timeout + `timer_api` + sleep: 123/123 with asserts on and off
- `timeout_order` (same-tick FIFO; that test skips only min-heap and wheel)
