### PR TITLE
drivers: gpio: silabs: avoid switching DT_DRV_COMPAT in port init

### DIFF
--- a/drivers/gpio/gpio_silabs.c
+++ b/drivers/gpio/gpio_silabs.c
@@ -19,9 +19,8 @@
 LOG_MODULE_REGISTER(gpio_silabs, CONFIG_GPIO_LOG_LEVEL);
 
 #define SILABS_GPIO_PORT_ADDR_SPACE_SIZE sizeof(GPIO_PORT_TypeDef)
-#define GET_SILABS_GPIO_INDEX(inst)                                                                \
-	(DT_INST_REG_ADDR(inst) - DT_REG_ADDR(DT_NODELABEL(gpioa))) /                              \
-		SILABS_GPIO_PORT_ADDR_SPACE_SIZE
+#define GET_SILABS_GPIO_INDEX(node_id)                                                             \
+	(DT_REG_ADDR(node_id) - DT_REG_ADDR(DT_NODELABEL(gpioa))) / SILABS_GPIO_PORT_ADDR_SPACE_SIZE
 
 #define NUMBER_OF_PORTS      (SIZEOF_FIELD(GPIO_TypeDef, P) / SIZEOF_FIELD(GPIO_TypeDef, P[0]))
 #define NUM_IRQ_LINES        16
@@ -494,22 +493,18 @@ static int gpio_silabs_common_init(const struct device *dev)
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_CONTROLLER_INIT)
 
-#undef DT_DRV_COMPAT
-#define DT_DRV_COMPAT silabs_gpio_port
-
 #define GPIO_PORT_INIT(n)                                                                          \
 	static const struct gpio_silabs_port_config gpio_silabs_port_config_##n = {                \
-		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(n),                                      \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_NODE(n),                                      \
 		.gpio_index = GET_SILABS_GPIO_INDEX(n),                                            \
-		.common_dev = DEVICE_DT_GET(DT_INST_PARENT(n)),                                    \
-		.em4wu_pin_count = DT_INST_PROP_LEN_OR(n, silabs_wakeup_ints, 0),                  \
-		.em4wu_pins = COND_CODE_1(DT_INST_HAS_PROP(n, silabs_wakeup_ints),                 \
-			({DT_INST_FOREACH_PROP_ELEM(n, silabs_wakeup_ints, EM4_WAKEUP_PIN)}),      \
-			({})),                                                                     \
+		.common_dev = DEVICE_DT_GET(DT_PARENT(n)),                                         \
+		.em4wu_pin_count = DT_PROP_LEN_OR(n, silabs_wakeup_ints, 0),                       \
+		.em4wu_pins = COND_CODE_1(DT_HAS_PROP(n, silabs_wakeup_ints),                      \
+			({DT_FOREACH_PROP_ELEM(n, silabs_wakeup_ints, EM4_WAKEUP_PIN)}), ({})),    \
 	};                                                                                         \
 	static struct gpio_silabs_port_data gpio_silabs_port_data_##n;                             \
-	DEVICE_DT_INST_DEFINE(n, gpio_silabs_port_init, NULL, &gpio_silabs_port_data_##n,          \
-			      &gpio_silabs_port_config_##n, PRE_KERNEL_1,                          \
-			      CONFIG_GPIO_INIT_PRIORITY, &gpio_driver_api);
+	DEVICE_DT_DEFINE(n, gpio_silabs_port_init, NULL, &gpio_silabs_port_data_##n,               \
+			 &gpio_silabs_port_config_##n, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,    \
+			 &gpio_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(GPIO_PORT_INIT)
+DT_FOREACH_STATUS_OKAY(silabs_gpio_port, GPIO_PORT_INIT)

--- a/drivers/gpio/gpio_silabs_siwx91x.c
+++ b/drivers/gpio/gpio_silabs_siwx91x.c
@@ -497,28 +497,25 @@ static DEVICE_API(gpio, gpio_siwx91x_common_api) = {};
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_CONTROLLER_INIT)
 
-#undef DT_DRV_COMPAT
-#define DT_DRV_COMPAT silabs_siwx91x_gpio_port
-
 #define GPIO_PORT_INIT(n)                                                                          \
 	struct gpio_siwx91x_pin_config_info                                                        \
-		pin_config_info_##n[__builtin_popcount(GPIO_PORT_PIN_MASK_FROM_DT_INST(n))];       \
+		pin_config_info_##n[__builtin_popcount(GPIO_PORT_PIN_MASK_FROM_DT_NODE(n))];       \
 	static const struct gpio_siwx91x_port_config gpio_siwx91x_port_config##n = {               \
-		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(n),                                      \
-		.parent = DEVICE_DT_GET(DT_INST_PARENT(n)),                                        \
-		.pads = DT_INST_PROP(n, silabs_pads),                                              \
-		.port = DT_INST_REG_ADDR(n),                                                       \
-		.hal_port = (DT_PROP(DT_INST_PARENT(n), silabs_ulp) ? SL_GPIO_ULP_PORT : 0) +      \
-			    DT_INST_REG_ADDR(n),                                                   \
-		.ulp = DT_PROP(DT_INST_PARENT(n), silabs_ulp),                                     \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_NODE(n),                                      \
+		.parent = DEVICE_DT_GET(DT_PARENT(n)),                                             \
+		.pads = DT_PROP(n, silabs_pads),                                                   \
+		.port = DT_REG_ADDR(n),                                                            \
+		.hal_port = (DT_PROP(DT_PARENT(n), silabs_ulp) ? SL_GPIO_ULP_PORT : 0) +           \
+			    DT_REG_ADDR(n),                                                        \
+		.ulp = DT_PROP(DT_PARENT(n), silabs_ulp),                                          \
 	};                                                                                         \
 	static struct gpio_siwx91x_port_data gpio_siwx91x_port_data##n = {                         \
 		.pin_config_info = pin_config_info_##n,                                            \
-		.total_pin_cnt = __builtin_popcount(GPIO_PORT_PIN_MASK_FROM_DT_INST(n)),           \
+		.total_pin_cnt = __builtin_popcount(GPIO_PORT_PIN_MASK_FROM_DT_NODE(n)),           \
 	};                                                                                         \
-	PM_DEVICE_DT_INST_DEFINE(n, gpio_siwx91x_port_pm_action);                                  \
-	DEVICE_DT_INST_DEFINE(n, gpio_siwx91x_init_port, PM_DEVICE_DT_INST_GET(n),                 \
-			      &gpio_siwx91x_port_data##n, &gpio_siwx91x_port_config##n,            \
-			      PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY, &gpio_siwx91x_api);
+	PM_DEVICE_DT_DEFINE(n, gpio_siwx91x_port_pm_action);                                       \
+	DEVICE_DT_DEFINE(n, gpio_siwx91x_init_port, PM_DEVICE_DT_GET(n),                           \
+			 &gpio_siwx91x_port_data##n, &gpio_siwx91x_port_config##n, PRE_KERNEL_1,   \
+			 CONFIG_GPIO_INIT_PRIORITY, &gpio_siwx91x_api);
 
-DT_INST_FOREACH_STATUS_OKAY(GPIO_PORT_INIT)
+DT_FOREACH_STATUS_OKAY(silabs_siwx91x_gpio_port, GPIO_PORT_INIT)


### PR DESCRIPTION
`GPIO_PORT_INIT()` temporarily redefined `DT_DRV_COMPAT` to the port compatible so it could be invoked with `DT_INST_FOREACH_STATUS_OKAY()`. This is unnecessary: `DT_FOREACH_STATUS_OKAY(compat, fn)` already iterates status-okay nodes of a given compatible directly by node identifier, without requiring it to be the `DT_DRV_COMPAT` of the file.

Drop the `#undef/#define DT_DRV_COMPAT` dance and revert `GPIO_PORT_INIT()` to use node-id-based devicetree macros, invoking it with `DT_FOREACH_STATUS_OKAY(silabs_gpio_port, GPIO_PORT_INIT)` and `DT_FOREACH_STATUS_OKAY(silabs_siwx91x_gpio_port, GPIO_PORT_INIT)` respectively. This addresses a review comment left on PR #110971 after it was merged.

Verified by building `samples/basic/blinky` for `xg24_dk2601b` (exercises `gpio_silabs.c`) and `siwx917_dk2605a` (exercises `gpio_silabs_siwx91x.c`).
