### PR TITLE
drivers: i2c: remove deprecated I2C_ALLOW_NO_STOP_TRANSACTIONS

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -578,6 +578,12 @@ I2C
   timeout is now using the generic ``zephyr,transfer-timeout-ms`` property
   instead of ``transfer-timeout-ms``, default to 500ms.
 
+* ``CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS``, deprecated since Zephyr 4.0, has been removed.
+  :c:func:`i2c_transfer` and :c:func:`i2c_transfer_cb` now always enforce a STOP condition on
+  the last message of a transfer. Splitting a logical transaction across several
+  :c:func:`i2c_transfer` calls to keep the bus claimed is no longer possible; issue the whole
+  transaction, using ``I2C_MSG_RESTART`` where needed, in a single call instead.
+
 I2S
 ===
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -130,6 +130,10 @@ Removed APIs and options
     * ``CONFIG_COUNTER_MAXIM_DS3231``
     * ``prescaler`` property of :dtcompatible:`nxp,lptmr`
 
+* I2C
+
+    * ``CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS``
+
 * LLEXT
 
     * ``llext_get_fn_table``, replaced by ``llext_get_fn_table_entry``

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -82,20 +82,6 @@ config I2C_CALLBACK
 	help
 	  API and implementations of i2c_transfer_cb.
 
-config I2C_ALLOW_NO_STOP_TRANSACTIONS
-	bool "Allows I2C transfers with no STOP on the last transaction [DEPRECATED]"
-	depends on !I2C_NRFX_TWI
-	depends on !I2C_NRFX_TWIM
-	depends on !I2C_STM32
-	depends on !I2C_GD32
-	depends on !I2C_ESP32
-	depends on (!I2C_DW || I2C_RTS5912)
-	select DEPRECATED
-	help
-	  Allow I2C transactions with no STOP on the last message. This is
-	  unsupported and can leave the bus in an unexpected state. The option
-	  will be removed in Zephyr 4.1.
-
 config I2C_BUS_RECOVERY
 	bool "Allows I2C bus recovery support"
 

--- a/drivers/i2c/Kconfig.rts5912
+++ b/drivers/i2c/Kconfig.rts5912
@@ -5,7 +5,6 @@ menuconfig I2C_RTS5912
 	bool "Realtek RTS5912 I2C support"
 	default y
 	depends on DT_HAS_REALTEK_RTS5912_I2C_ENABLED
-	select I2C_ALLOW_NO_STOP_TRANSACTIONS
 	select I2C_DW_EXTENDED_SUPPORT
 	select I2C_DW_PM_POLICY_STATE_LOCK
 	help

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -102,12 +102,6 @@ static int i2c_check_bus(const struct device *dev)
 	int ret = 0;
 	struct i2c_dw_dev_config *const dw = dev->data;
 
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	if (!dw->need_setup) {
-		return 0;
-	}
-#endif
-
 	if (dw->check_bus_cb) {
 		/* callback customize check function */
 		ret = dw->check_bus_cb(dw->check_bus_dev);
@@ -192,9 +186,6 @@ static int i2c_dw_error_chk(const struct device *dev)
 		LOG_ERR("SCL Stuck Low on %s", dev->name);
 	}
 	if (dw->state & I2C_DW_ERR_MASK) {
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-		dw->need_setup = true;
-#endif
 		LOG_ERR_RATELIMIT("IO Fail on %s", dev->name);
 		return -EIO;
 	}
@@ -568,9 +559,6 @@ static void i2c_dw_isr(const struct device *port)
 			dw->state = I2C_DW_CMD_ERROR;
 			i2c_dw_error_chk(port);
 			value = read_clr_tx_abrt(reg_base);
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-			dw->need_setup = true;
-#endif
 			goto done;
 		}
 
@@ -608,9 +596,6 @@ static void i2c_dw_isr(const struct device *port)
 		/* STOP detected: finish processing this message */
 		if (intr_stat.bits.stop_det) {
 			value = read_clr_stop_det(reg_base);
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-			dw->need_setup = true;
-#endif
 			goto done;
 		}
 
@@ -683,16 +668,6 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	union ic_con_register ic_con;
 	union ic_tar_register ic_tar;
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
-
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	if (!dw->need_setup) {
-		/* If slave address changed setup is still needed */
-		ic_tar.raw = read_tar(reg_base);
-		if (ic_tar.bits.ic_tar == slave_address) {
-			return 0;
-		}
-	}
-#endif
 
 	ic_con.raw = 0U;
 
@@ -813,9 +788,6 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	}
 	write_tar(ic_tar.raw, reg_base);
 
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	dw->need_setup = false;
-#endif
 	return 0;
 }
 
@@ -824,14 +796,6 @@ bool i2c_dw_is_busy(const struct device *dev)
 	struct i2c_dw_dev_config *const dw = dev->data;
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
 
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	/* The application explicitly started a transaction without
-	 * a STOP.  Allow the application to continue sending transactions.
-	 */
-	if (!dw->need_setup) {
-		return false;
-	}
-#endif
 	if (test_bit_status_activity(reg_base) || (dw->state & I2C_DW_BUSY)) {
 		return true;
 	}
@@ -1021,12 +985,6 @@ error:
 	k_sem_give(&dw->bus_sem);
 
 	pm_device_runtime_put(dev);
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	if (ret != 0) {
-		/* Failed/aborted transaction is no longer active, require setup */
-		dw->need_setup = true;
-	}
-#endif
 
 	return ret;
 }
@@ -1330,9 +1288,6 @@ static int i2c_dw_init_config(const struct device *dev)
 	}
 
 	dw->state = I2C_DW_STATE_READY;
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	dw->need_setup = true;
-#endif
 #ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
 	write_sdatimeout(sda_timeout, reg_base);
 	write_scltimeout(scl_timeout, reg_base);

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -216,9 +216,6 @@ struct i2c_dw_dev_config {
 	struct device *recover_bus_dev;
 	i2c_api_check_bus_t check_bus_cb;
 	const struct device *check_bus_dev;
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	bool need_setup;
-#endif
 	uint32_t i2c_stat_not_ready;
 	uint32_t not_ready_cnt;
 };

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -1013,9 +1013,7 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
 		return 0;
 	}
 
-	if (!IS_ENABLED(CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS)) {
-		msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
-	}
+	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
 
 	int res =  DEVICE_API_GET(i2c, dev)->transfer(dev, msgs, num_msgs, addr);
 
@@ -1070,9 +1068,7 @@ static inline int i2c_transfer_cb(const struct device *dev,
 		return 0;
 	}
 
-	if (!IS_ENABLED(CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS)) {
-		msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
-	}
+	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
 
 	return api->transfer_cb(dev, msgs, num_msgs, addr, cb, userdata);
 }


### PR DESCRIPTION
Removes `CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS`. It was deprecated in Zephyr 4.0 and its help text already scheduled it for removal in 4.1.

`i2c_transfer()` / `i2c_transfer_cb()` now always force a STOP condition on the last message, and the DesignWare driver loses the `need_setup` state machine that allowed an application to keep the bus claimed across `i2c_transfer()` calls. The RTS5912 driver used to `select` the option, so cross-call bus holding stops working on that platform too; complete transactions issued in a single call (using `I2C_MSG_RESTART` between messages) are unaffected.
