### PR TITLE
boards: nxp: lpcxpresso54628: enable the on-board accelerometer

### DIFF
--- a/boards/nxp/lpcxpresso54628/Kconfig.defconfig
+++ b/boards/nxp/lpcxpresso54628/Kconfig.defconfig
@@ -1,0 +1,15 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_LPCXPRESSO54628
+
+if FXOS8700
+
+# The on-board MMA8652FC has no magnetometer.
+choice FXOS8700_MODE
+	default FXOS8700_MODE_ACCEL
+endchoice
+
+endif # FXOS8700
+
+endif # BOARD_LPCXPRESSO54628

--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
@@ -70,4 +70,13 @@
 			bias-pull-up;
 		};
 	};
+
+	/* FlexComm2 I2C: the on-board accelerometer (external pull-ups). */
+	pinmux_flexcomm2_i2c: pinmux_flexcomm2_i2c {
+		group0 {
+			pinmux = <FC2_CTS_SDA_SSEL0_PIO3_23>,
+				 <FC2_RTS_SCL_SSEL1_PIO3_24>;
+			slew-rate = "standard";
+		};
+	};
 };

--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <nxp/lpc/nxp_lpc546xx.dtsi>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "lpcxpresso54628-pinctrl.dtsi"
 
@@ -27,6 +28,7 @@
 		led2 = &led3;
 		usart-0 = &flexcomm0;
 		sw0 = &user_button;
+		accel0 = &mma8652fc;
 	};
 
 	/*
@@ -105,5 +107,27 @@ zephyr_udc0: &usbhs {
 		compatible = "zephyr,sdmmc-disk";
 		disk-name = "SD";
 		status = "okay";
+	};
+};
+
+&flexcomm2 {
+	compatible = "nxp,lpc-i2c";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&pinmux_flexcomm2_i2c>;
+	pinctrl-names = "default";
+
+	/*
+	 * NXP MMA8652FC 3-axis accelerometer. INT1 is wired to P3_4 and INT2 is
+	 * unconnected. The pin interrupt engine can only select pins on ports 0
+	 * and 1, so INT1 cannot raise a GPIO interrupt and the driver's trigger
+	 * support is unavailable on this board.
+	 */
+	mma8652fc: mma8652fc@1d {
+		compatible = "nxp,fxos8700", "nxp,mma8652fc";
+		reg = <0x1d>;
+		int1-gpios = <&gpio3 4 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/soc/nxp/lpc/lpc54xxx/soc.c
+++ b/soc/nxp/lpc/lpc54xxx/soc.c
@@ -187,6 +187,11 @@ __weak void clock_init(void)
 #endif
 #endif
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm2), nxp_lpc_i2c, okay)
+	/* Attach 12 MHz clock to FLEXCOMM2 */
+	CLOCK_AttachClk(kFRO12M_to_FLEXCOMM2);
+#endif
+
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(sdif), nxp_lpc_sdif, okay)
 	/*
 	 * SD/MMC host source clock: the main clock, divided to stay within the


### PR DESCRIPTION
## Summary

Enables the NXP MMA8652FC 3-axis accelerometer of the LPCXpresso54628, using
the existing in-tree `fxos8700` driver. No new driver or binding is added.

* FlexComm2 is enabled as I2C (P3_23 SDA, P3_24 SCL) with its clock and pinctrl.
* The accelerometer is added at address 0x1d, with INT1 on P3_4 and an `accel0`
  alias.
* The board defaults the driver to accelerometer-only mode, as the MMA8652FC
  has no magnetometer.

This is the same setup the LPCXpresso55S69 uses for the same part.

## No trigger support

INT1 is wired to P3_4. The pin interrupt engine of this SoC can only select
pins on ports 0 and 1 (UM10912 section 11.6.2), and so can the GPIO group
interrupts, so P3_4 cannot raise a GPIO interrupt and the driver's trigger
support is unavailable on this board. The pin is still described in the
devicetree, and a note in the board file records why it cannot be used.

## Testing

Verified on an LPCXpresso54628 with `samples/sensor/accel_polling`: the device
is detected (WHOAMI 0x4A) and reads about 1 g on Z with the board flat.