### PR TITLE
samples: drivers: display: tests.yaml: clean up test conf

### DIFF
--- a/samples/drivers/display/tests.yaml
+++ b/samples/drivers/display/tests.yaml
@@ -2,7 +2,10 @@ sample:
   description: Sample application for displays
   name: display_sample
 common:
-  tags: display
+  tags:
+    - display
+  extra_configs:
+    - CONFIG_TEST=y
 tests:
   sample.display.sdl:
     build_only: true
@@ -14,105 +17,81 @@ tests:
     extra_args: DTC_OVERLAY_FILE="dummy_dc.overlay"
     extra_configs:
       - CONFIG_SDL_DISPLAY=n
-      - CONFIG_TEST=y
     harness: console
     harness_config:
-      fixture: fixture_display
-      type: one_line
-      regex:
-        - "Display sample for (.*)"
-  sample.display.g1120b0mipi:
-    platform_allow:
-      - mimxrt595_evk/mimxrt595s/cm33
-      - mimxrt700_evk/mimxrt798s/cm33_cpu0
-    harness: console
-    extra_args: SHIELD=g1120b0mipi
-    extra_configs:
-      - CONFIG_PM=y
-      - CONFIG_PM_DEVICE=y
-      - CONFIG_IDLE_STACK_SIZE=400
-      - CONFIG_TEST=y
-    harness_config:
-      fixture: fixture_display_g1120b0mipi
       type: multi_line
       regex:
         - "sample: Display sample for (.*)"
         - "Display starts"
         - "Display sample test mode done (.*)"
   sample.display.builtin:
-    # This test case is intended to insure that this sample builds & runs
+    # This test scenario ensures that the sample builds & runs
     # correctly for all boards that have a supported built-in display.
     filter: dt_chosen_enabled("zephyr,display")
+    depends_on:
+      - display
     harness: console
     harness_config:
-      fixture: fixture_display
-  sample.display.st_b_lcd40_dsi1_mb1166_a09:
-    filter: dt_compat_enabled("frida,nt35510")
-    platform_allow: stm32h747i_disco/stm32h747xx/m7
-    extra_args: SHIELD=st_b_lcd40_dsi1_mb1166_a09
-    tags:
-      - shield
-    harness: console
-    harness_config:
-      fixture: fixture_display
-  sample.display.rk043fn02h_ct:
-    platform_allow:
-      - mimxrt1064_evk
-      - mimxrt1060_evk@A/mimxrt1062/qspi
-      - mimxrt1060_evk@B/mimxrt1062/qspi
-      - mimxrt1060_evk@C/mimxrt1062/qspi
-      - mimxrt1050_evk/mimxrt1052/hyperflash
-      - mimxrt1040_evk
-    integration_platforms:
-      - mimxrt1040_evk
-    harness: console
-    extra_args: SHIELD=rk043fn02h_ct
-    harness_config:
-      fixture: fixture_display
-      type: one_line
+      type: multi_line
       regex:
-        - "Display sample for (.*)"
+        - "sample: Display sample for (.*)"
+        - "Display starts"
+        - "Display sample test mode done (.*)"
   sample.display.shield:
-    # This test case is intended to verify support for shields on boards
+    # This test scenario builds the sample for shields with boards
     # known to support them. It is not intended to cover all combinations
-    # of boards and shields, but rather serve as a method to test each
-    # display shield within Zephyr
+    # of boards and shields.
     filter: dt_chosen_enabled("zephyr,display")
     harness: console
     harness_config:
       fixture: fixture_display
-      type: one_line
+      type: multi_line
       regex:
-        - "Display sample for (.*)"
+        - "sample: Display sample for (.*)"
+        - "Display starts"
+        - "Display sample test mode done (.*)"
+    platform_allow:
+      - lpcxpresso55s69/lpc55s69/cpu0
+      - nrf52840dk/nrf52840
+      - frdm_k64f/mk64f12
+      - mimxrt685_evk/mimxrt685s/cm33
+      - nucleo_l433rc_p/stm32l433xx
+      - nrf52dk/nrf52832
+      - mimxrt1010_evk/mimxrt1011
+      - frdm_k22f/mk22f51212
+      - nrf52833dk/nrf52833
+      - mimxrt1170_evk/mimxrt1176/cm7
+      - mimxrt700_evk/mimxrt798s/cm33_cpu0
+      - da1469x_dk_pro/da14699
+      - stm32h747i_disco/stm32h747xx/m7
+      - mimxrt1064_evk/mimxrt1064
+      - frdm_rw612/rw612
+      - ek_ra8d1
+      - nucleo_g071rb/stm32g071xx
+      - m5stack_atoms3/esp32s3/procpu
+      - mimxrt595_evk/mimxrt595s/cm33
     extra_args:
       - platform:lpcxpresso55s69/lpc55s69/cpu0:SHIELD=adafruit_2_8_tft_touch_v2
       - platform:nrf52840dk/nrf52840:SHIELD=ssd1306_128x32
       - platform:frdm_k64f/mk64f12:SHIELD=ssd1306_128x64
-      - platform:mimxrt685_evk/mimxrt685/cm33:SHIELD=waveshare_epaper_gdeh0213b1
+      - platform:mimxrt685_evk/mimxrt685s/cm33:SHIELD=waveshare_epaper_gdeh0213b1
       - platform:nucleo_l433rc_p/stm32l433xx:SHIELD=waveshare_epaper_gdew042t2
       - platform:nrf52dk/nrf52832:SHIELD=st7789v_tl019fqv01
       - platform:mimxrt1010_evk/mimxrt1011:SHIELD=st7789v_waveshare_240x240
       - platform:frdm_k22f/mk22f51212:SHIELD=ls013b7dh03
       - platform:nrf52833dk/nrf52833:SHIELD=st7735r_ada_160x128
       - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
-      - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=rk055hdmipi4ma0
       - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=zc143ac72mipi
       - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=lcd_par_s035_8080
       - platform:da1469x_dk_pro/da14699:DTC_OVERLAY_FILE=da1469x_dk_pro_mipi_dbi.overlay
       - platform:nrf52840dk/nrf52840:SHIELD=max7219_8x8
       - platform:stm32h747i_disco/stm32h747xx/m7:SHIELD=st_b_lcd40_dsi1_mb1166
       - platform:mimxrt1064_evk/mimxrt1064:SHIELD=rk043fn66hs_ctg
-      - platform:mimxrt1060_evk/mimxrt1062:SHIELD=rk043fn66hs_ctg
-      - platform:mimxrt1050_evk/mimxrt1052:SHIELD=rk043fn66hs_ctg
-      - platform:mimxrt1040_evk/mimxrt1042:SHIELD=rk043fn66hs_ctg
-      - platform:frdm_mcxn947/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
-      - platform:mcx_n9xx_evk/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
-      - platform:mcx_n5xx_evk/mcxn547/cpu0:SHIELD=lcd_par_s035_8080
-      - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
-      - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
-      - platform:frdm_mcxa577:SHIELD=lcd_par_s035_8080
       - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
-      - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu
+      - platform:ek_ra8d1:SHIELD="rtk7eka6m3b00001bu;ek_ra8d1_rtk7eka6m3b00001bu"
       - platform:nucleo_g071rb/stm32g071xx:SHIELD=x_nucleo_gfx01m2
       - platform:m5stack_atoms3/esp32s3/procpu:SHIELD=m5stack_unit_minioled
+      - platform:mimxrt595_evk/mimxrt595s/cm33:SHIELD=g1120b0mipi
+      - platform:stm32h747i_disco/stm32h747xx/m7:SHIELD=st_b_lcd40_dsi1_mb1166_a09
+      - platform:mimxrt1040_evk/mimxrt1064:SHIELD=rk043fn02h_ct

--- a/tests/drivers/display/display_check/tests.yaml
+++ b/tests/drivers/display/display_check/tests.yaml
@@ -78,7 +78,7 @@ tests:
       - platform:lpcxpresso55s69/lpc55s69/cpu0:SHIELD=adafruit_2_8_tft_touch_v2
       - platform:nrf52840dk/nrf52840:SHIELD=ssd1306_128x32
       - platform:frdm_k64f/mk64f12:SHIELD=ssd1306_128x64
-      - platform:mimxrt685_evk/mimxrt685/cm33:SHIELD=waveshare_epaper_gdeh0213b1
+      - platform:mimxrt685_evk/mimxrt685s/cm33:SHIELD=waveshare_epaper_gdeh0213b1
       - platform:nucleo_l433rc_p/stm32l433xx:SHIELD=waveshare_epaper_gdew042t2
       - platform:nrf52dk/nrf52832:SHIELD=st7789v_tl019fqv01
       - platform:mimxrt1010_evk/mimxrt1011:SHIELD=st7789v_waveshare_240x240


### PR DESCRIPTION
`sample.display.shield` test scenario is not intended to cover all combinations of boards and shields. Building for each shield is the goal. So remove duplicated shield confs.
Add platform_allow list to prevent the test scenario from building boards with built-in displays.

Remove shield-specific test scenarios.

Run all test scenarios with `CONFIG_TEST=y` so that the rendering loop is stopped after some interations and the test doesn't timeout in CI.

Remove `fixture: fixture_display` from `sample.display.builtin` test scenario, which kept it from being built in CI for boards with a built-in display i.e. no fixture is needed.