### PR TITLE
drivers: memc: siwx91x: disable the PSRAM data cache

### DIFF
--- a/drivers/memc/memc_silabs_siwx91x_qspi.c
+++ b/drivers/memc/memc_silabs_siwx91x_qspi.c
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 
+#include "rsi_d_cache.h"
 #include "rsi_qspi_proto.h"
 #include "sl_si91x_psram_handle.h"
 
@@ -26,6 +27,13 @@ static int siwx91x_memc_init(const struct device *dev)
 {
 	const struct siwx91x_memc_config *config = dev->config;
 	int ret;
+
+	/* The bootloader leaves the PSRAM data cache enabled, and nothing in a
+	 * Zephyr build maintains it: the SoC does not select CPU_HAS_DCACHE and
+	 * sys_cache_data_*() return -ENOTSUP. The network processor writes the
+	 * same memory, so leaving the cache on returns stale data.
+	 */
+	rsi_d_cache_disable();
 
 	/* Memory controller is automatically setup by the siwx91x bootloader,
 	 * so we have to uninitialize it before to change the configuration

--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -186,6 +186,7 @@ zephyr_compile_definitions_ifdef(CONFIG_MEMC_SILABS_SIWX91X_QSPI
   QSPI_ROMDRIVER_PRESENT # replace rsi_qspi.c
 )
 zephyr_library_sources_ifdef(CONFIG_MEMC_SILABS_SIWX91X_QSPI
+  ${WISECONNECT}/components/device/silabs/si91x/mcu/drivers/unified_api/src/rsi_d_cache.c
   ${WISECONNECT}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_psram.c
 )
 

--- a/west.yml
+++ b/west.yml
@@ -249,7 +249,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 28eb6670caf3486321a033c7f08687867a7ef4f4
+      revision: 1093933f15c4ad606059441a96b1433d53df1a84
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
The SiWG917 has a data cache in front of PSRAM (family reference manual rev 1.2 section 5.4.5). The bootloader leaves it enabled and nothing in a Zephyr build maintains it: the SoC does not select `CPU_HAS_DCACHE` and `sys_cache_data_*()` return `-ENOTSUP`. The network processor writes the same memory, so contents read back stale or torn under load.

Disabled at the top of `siwx91x_memc_init()` with the vendor call, before PSRAM is set up. `rsi_d_cache.c` is not in the HAL yet, so this needs zephyrproject-rtos/hal_silabs#190 and a manifest bump before CI can build it.

## How I tested it

Two SiWx917-DK2605A boards (SiWG917M111MGTBA), one macOS host and one Ubuntu 24.04 host, each with its own J-Link, running CircuitPython with PSRAM as the heap arena. Both boot, `DCACHE->CTRL` reads 0x2 with the enable bit clear, and 4 MB of PSRAM written and read back while pinging over Wi-Fi shows no mismatches. It costs 32 bytes of flash.

Not tested on the NCP or RCP variants, which do not expose PSRAM this way.

## Also carried downstream

Adafruit's Zephyr fork is what the CircuitPython zephyr-cp port pins, so this is carried there as adafruit/zephyr#3, which I will update to this form. It drops out when that fork next rebases onto an upstream carrying this.

## AI assistance

Written with Claude Code. The register probing and the hardware runs are mine.
