### PR TITLE
boards: nxp: lpcxpresso54628: enable the on-board digital microphone

### DIFF
--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628-pinctrl.dtsi
@@ -79,4 +79,13 @@
 			slew-rate = "standard";
 		};
 	};
+
+	/* On-board digital microphone: DMIC channel 1 clock/data (P1_2/P1_3). */
+	pinmux_dmic: pinmux_dmic {
+		group0 {
+			pinmux = <DMIC0_CLK1_PIO1_2>,
+				 <DMIC0_DATA1_PIO1_3>;
+			slew-rate = "standard";
+		};
+	};
 };

--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
@@ -29,6 +29,7 @@
 		usart-0 = &flexcomm0;
 		sw0 = &user_button;
 		accel0 = &mma8652fc;
+		dmic0 = &dmic0;
 	};
 
 	/*
@@ -130,4 +131,24 @@ zephyr_udc0: &usbhs {
 		reg = <0x1d>;
 		int1-gpios = <&gpio3 4 GPIO_ACTIVE_LOW>;
 	};
+};
+
+&dma0 {
+	status = "okay";
+};
+
+/*
+ * On-board Knowles SPH0641LM4H MEMS microphone on DMIC hardware channel 1,
+ * which the DMIC API addresses as the right channel of controller 0. Channel 0
+ * reaches the expansion connectors only through solder jumpers JS33 and JS36,
+ * which take the pins away from LCD data lines 14 and 15, so it stays disabled.
+ */
+&dmic0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_dmic>;
+	pinctrl-names = "default";
+};
+
+&pdmc1 {
+	status = "okay";
 };

--- a/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
@@ -207,6 +207,37 @@
 			num-inputs = <64>;
 		};
 
+		dma0: dma-controller@40082000 {
+			compatible = "nxp,lpc-dma";
+			reg = <0x40082000 0x1000>;
+			interrupts = <1 0>;
+			dma-channels = <30>;
+			#dma-cells = <1>;
+			status = "disabled";
+		};
+
+		dmic0: dmic@40090000 {
+			compatible = "nxp,dmic";
+			reg = <0x40090000 0x1000>;
+			interrupts = <25 0>;
+			clocks = <&syscon MCUX_DMIC_CLK>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			pdmc0: dmic-channel@0 {
+				reg = <0>;
+				dmas = <&dma0 16>;
+				status = "disabled";
+			};
+
+			pdmc1: dmic-channel@1 {
+				reg = <1>;
+				dmas = <&dma0 17>;
+				status = "disabled";
+			};
+		};
+
 		flexcomm0: flexcomm@40086000 {
 			compatible = "nxp,lpc-flexcomm";
 			reg = <0x40086000 0x1000>;

--- a/samples/drivers/audio/dmic/boards/lpcxpresso54628.overlay
+++ b/samples/drivers/audio/dmic/boards/lpcxpresso54628.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The on-board microphone is on DMIC hardware channel 1, which this sample
+ * reaches through its two-channel transfer. Channel 0 is not connected on this
+ * board but has to be enabled for that transfer to be accepted.
+ */
+dmic_dev: &dmic0 {
+	status = "okay";
+};
+
+&pdmc0 {
+	status = "okay";
+};

--- a/soc/nxp/lpc/lpc54xxx/soc.c
+++ b/soc/nxp/lpc/lpc54xxx/soc.c
@@ -202,6 +202,15 @@ __weak void clock_init(void)
 			(CPU_FREQ / FSL_FEATURE_SDIF_MAX_SOURCE_CLOCK) + 1U, true);
 #endif
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dmic0), nxp_dmic, okay)
+	/*
+	 * The DMIC functional clock is the PDM bit clock: 12 MHz FRO divided by
+	 * 6 gives 2 MHz, within the range the on-board microphone supports.
+	 */
+	CLOCK_AttachClk(kFRO12M_to_DMIC);
+	CLOCK_SetClkDiv(kCLOCK_DivDmicClk, 6, false);
+#endif
+
 	/*
 	 * The M_CAN functional clock is the core clock divided by CANnCLKDIV,
 	 * which is halted out of reset. Divide by 11 -> 20 MHz at a 220 MHz


### PR DESCRIPTION
## Summary

Enables the Knowles SPH0641LM4H MEMS microphone of the LPCXpresso54628, using
the existing in-tree `nxp,dmic` driver. No new driver or binding is added.

1. **dts: arm: nxp** — the DMIC node with its two channels, and the DMA
   controller the channels take their data over.
2. **soc: nxp: lpc54xxx** — the DMIC functional clock.
3. **boards: nxp: lpcxpresso54628** — the pin routing, the `dmic0` alias and
   the channel the microphone sits on.

## Channels

The microphone is on DMIC hardware channel 1, which the DMIC API addresses as
the right channel of controller 0. Channel 0 reaches the expansion connectors
only through solder jumpers JS33 and JS36, which take the pins away from LCD
data lines 14 and 15, so it is left disabled in the board devicetree.

`samples/drivers/audio/dmic` asks for channel 0 first and only then for both
channels, so a board overlay enables channel 0 for the sample. Its two-channel
transfer is the one that reads the microphone.

## Testing

Verified on an LPCXpresso54628 with `samples/drivers/audio/dmic`: both the
one-channel and the two-channel transfer complete and the sample runs to
"Exiting".

Audio was checked separately by capturing the microphone channel directly
(`dmic_build_channel_map(0, 0, PDM_CHAN_RIGHT)`) and printing the peak sample
per block: the level sits around 100 in a quiet room and reaches full scale
when a sound is made next to the board.
