### PR TITLE
usb_c: policy engine: Always notify on datarole change

### DIFF
--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -208,6 +208,8 @@ void pe_set_data_role(const struct device *dev, enum tc_data_role dr)
 
 	/* Notify TCPC of role update */
 	tcpc_set_roles(data->tcpc, pe->power_role, pe->data_role);
+	/* Inform Device Policy Manager of Data Role Change */
+	policy_notify(dev, (dr == TC_ROLE_UFP) ? DATA_ROLE_IS_UFP : DATA_ROLE_IS_DFP);
 }
 
 /**
@@ -795,9 +797,6 @@ static enum smf_state_result pe_drs_evaluate_swap_run(void *obj)
 			/* Update Data Role */
 			pe_set_data_role(dev, (pe->data_role == TC_ROLE_UFP) ? TC_ROLE_DFP
 									     : TC_ROLE_UFP);
-			/* Inform Device Policy Manager of Data Role Change */
-			policy_notify(dev, (pe->data_role == TC_ROLE_UFP) ? DATA_ROLE_IS_UFP
-									  : DATA_ROLE_IS_DFP);
 		}
 		pe_set_ready_state(dev);
 	} else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_MSG_DISCARDED)) {
@@ -856,12 +855,8 @@ static enum smf_state_result pe_drs_send_swap_run(void *obj)
 			}
 		} else if (received_control_message(dev, header, PD_CTRL_ACCEPT)) {
 			/* Update Data Role */
-			pe->data_role = (pe->data_role == TC_ROLE_UFP) ? TC_ROLE_DFP : TC_ROLE_UFP;
-			/* Notify TCPC of role update */
-			tcpc_set_roles(data->tcpc, pe->power_role, pe->data_role);
-			/* Inform Device Policy Manager of Data Role Change */
-			policy_notify(dev, (pe->data_role == TC_ROLE_UFP) ? DATA_ROLE_IS_UFP
-									  : DATA_ROLE_IS_DFP);
+			pe_set_data_role(dev, (pe->data_role == TC_ROLE_UFP) ? TC_ROLE_DFP
+									     : TC_ROLE_UFP);
 		} else {
 			/*
 			 * A Protocol Error during a Data Role Swap when the

--- a/subsys/usb/usb_c/usbc_pe_snk_states.c
+++ b/subsys/usb/usb_c/usbc_pe_snk_states.c
@@ -608,18 +608,14 @@ void pe_snk_transition_to_default_entry(void *obj)
 
 	/* Reset flags */
 	atomic_clear(pe->flags);
-	pe->data_role = TC_ROLE_UFP;
 
 	/*
 	 * Indicate to the Device Policy Manager that the Sink Shall
 	 * transition to default
 	 */
 	policy_notify(dev, SNK_TRANSITION_TO_DEFAULT);
-	/*
-	 * Request the Device Policy Manager that the Port Data Role is
-	 * set to UFP
-	 */
-	policy_notify(dev, DATA_ROLE_IS_UFP);
+	/* Reset the data role of the policy engine to UFP */
+	pe_set_data_role(dev, TC_ROLE_UFP);
 }
 
 /**

--- a/subsys/usb/usb_c/usbc_pe_src_states.c
+++ b/subsys/usb/usb_c/usbc_pe_src_states.c
@@ -541,8 +541,7 @@ void pe_src_transition_to_default_entry(void *obj)
 	 *	 it receives the HARD_RESET_RECEIVED notification.
 	 */
 	policy_notify(dev, HARD_RESET_RECEIVED);
-	pe->data_role = TC_ROLE_DFP;
-	policy_notify(dev, DATA_ROLE_IS_DFP);
+	pe_set_data_role(dev, TC_ROLE_DFP);
 }
 
 enum smf_state_result pe_src_transition_to_default_run(void *obj)


### PR DESCRIPTION
Always use the pe_set_data_role function to switch the datarole. Move the notify call to this function, so that there is always a notification when the data-role is set.

This is especially important if you have a dual role port and need to notify a host to change the data-role