### PR TITLE
boards: arduino: mapped-partition fixes

### DIFF
--- a/boards/arduino/portenta_c33/arduino_portenta_c33.dts
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33.dts
@@ -283,17 +283,19 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		code_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 (DT_SIZE_M(2) - DT_SIZE_K(64))>;
 		};

--- a/boards/arduino/uno_r4/arduino_uno_r4.dts
+++ b/boards/arduino/uno_r4/arduino_uno_r4.dts
@@ -91,17 +91,19 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "bootloader";
 			reg = <0x00000000 0x4000>;
 			read-only;
 		};
 
 		code_partition: partition@4000 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x4000 0x3c000>;
 			read-only;

--- a/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfm.dtsi
@@ -16,15 +16,19 @@
 	soc {
 		flash-controller@407e0000 {
 			flash-hardware-version = <3>;
+			ranges;
 			#erase-block-cells = <2>;
 
 			flash0: flash@0 {
-				compatible = "renesas,ra-nv-code-flash";
+				compatible = "renesas,ra-nv-code-flash", "soc-nv-flash";
 				reg = <0x0 DT_SIZE_K(256)>;
+				ranges = <0x0 0x0 DT_SIZE_K(256)>;
 				write-block-size = <8>;
 				erase-block-size = <2048>;
 				erase-blocks = <&flash 128 2048>;
 				programming-enable;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 
 			flash1: flash@40100000 {

--- a/dts/arm/renesas/ra/ra6/r7fa6m5bh3cfc.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5bh3cfc.dtsi
@@ -9,16 +9,20 @@
 / {
 	soc {
 		flash-controller@407e0000 {
+			ranges;
 			flash-hardware-version = <40>;
 			#erase-block-cells = <2>;
 
 			flash0: flash@0 {
-				compatible = "renesas,ra-nv-code-flash";
+				compatible = "renesas,ra-nv-code-flash", "soc-nv-flash";
 				reg = <0x0 DT_SIZE_M(2)>;
+				ranges = <0x0 0x0 DT_SIZE_M(2)>;
 				write-block-size = <128>;
 				erase-block-size = <32768>;
 				erase-blocks = <&flash 8 8192>, <&flash 62 32768>;
 				programming-enable;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 
 			flash1: flash@8000000 {


### PR DESCRIPTION
Fix Portenta C33 and UNO R4 (Renesas SoCs) to use the `zephyr,mapped-partition` specifiers for code partitions. 