### PR TITLE
boards: renesas: Fix touch controller coordinate manipulation properties

### DIFF
--- a/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_lcdc.overlay
+++ b/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_lcdc.overlay
@@ -46,7 +46,7 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
-		swap-xy;
+		swapped-x-y;
 	};
 };
 

--- a/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_mipi_dbi.overlay
+++ b/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_mipi_dbi.overlay
@@ -28,9 +28,9 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
-		swap-xy;
-		invert-x;
-		invert-y;
+		swapped-x-y;
+		inverted-x;
+		inverted-y;
 	};
 };
 

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
@@ -46,7 +46,7 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
-		swap-xy;
+		swapped-x-y;
 	};
 };
 

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
@@ -28,9 +28,9 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
-		swap-xy;
-		invert-x;
-		invert-y;
+		swapped-x-y;
+		inverted-x;
+		inverted-y;
 	};
 };
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1739,9 +1739,9 @@ lvgl
 ====
 
 * The ``zephyr,lvgl-pointer-input`` devicetree binding marks the ``swap-xy``, ``invert-x``, and
-  ``invert-y`` properties as **deprecated**. Users should instead add these properties to the
-  underlying touch input controller device node, where they are now the canonical location for
-  such transformations.
+  ``invert-y`` properties as **deprecated**. Users should instead add the corresponding
+  touchscreen properties ``swapped-x-y``, ``inverted-x``, and ``inverted-y`` to the underlying
+  touch input controller device node, where these transformations are now defined canonically.
 
 * :kconfig:option:`CONFIG_LV_Z_FULL_REFRESH` is now part of the ``LV_Z_RENDERING_MODE`` Kconfig
   choice, alongside :kconfig:option:`CONFIG_LV_Z_PARTIAL_REFRESH` (default) and

--- a/dts/bindings/input/zephyr,lvgl-pointer-input.yaml
+++ b/dts/bindings/input/zephyr,lvgl-pointer-input.yaml
@@ -20,21 +20,21 @@ properties:
     deprecated: true
     description: |
       Swap x-y axes to align input with the display.
-      Deprecated: Use the swap-xy property of the underlying input device instead.
+      Deprecated: Use the swapped-x-y property of the underlying input device instead.
 
   invert-x:
     type: boolean
     deprecated: true
     description: |
       Invert x axes to align input with the display.
-      Deprecated: Use the invert-x property of the underlying input device instead.
+      Deprecated: Use the inverted-x property of the underlying input device instead.
 
   invert-y:
     type: boolean
     deprecated: true
     description: |
       Invert y axes to align input with the display.
-      Deprecated: Use the invert-y property of the underlying input device instead.
+      Deprecated: Use the inverted-y property of the underlying input device instead.
 
 examples:
   - |


### PR DESCRIPTION
Fixes touch controller coordinate manipulation properties according to touchscreen-common.yaml.