### PR TITLE
drivers: adc: esp32: fix oneshot read hang with wi-fi power save

### DIFF
--- a/drivers/adc/Kconfig.esp32
+++ b/drivers/adc/Kconfig.esp32
@@ -17,4 +17,15 @@ config ADC_ESP32_DMA
 	help
 	  Enable the ADC DMA mode
 
+config ADC_ESP32_CONVERSION_TIMEOUT_US
+	int "Oneshot conversion completion timeout in microseconds"
+	default 2000
+	range 100 1000000
+	help
+	  Maximum time to wait for a oneshot conversion to complete
+	  before adc_read returns -ETIMEDOUT. A conversion cannot
+	  complete while a shared analog block is temporarily powered
+	  down, for example during a Wi-Fi modem sleep window; callers
+	  are expected to retry such reads.
+
 endif

--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -9,6 +9,7 @@
 #include <esp_clk_tree.h>
 #include <esp_private/sar_periph_ctrl.h>
 #include <esp_private/adc_share_hw_ctrl.h>
+#include <esp_private/regi2c_ctrl.h>
 
 #include "adc_esp32.h"
 
@@ -150,6 +151,7 @@ static int adc_esp32_read(const struct device *dev, const struct adc_sequence *s
 	}
 #else
 	uint32_t acq_raw;
+	bool valid;
 
 	if (seq->channels > BIT(channel_id)) {
 		LOG_ERR("Multi-channel readings not supported");
@@ -167,6 +169,7 @@ static int adc_esp32_read(const struct device *dev, const struct adc_sequence *s
 	}
 
 	adc_lock_acquire(data->hal.unit);
+	ANALOG_CLOCK_ENABLE();
 
 	adc_oneshot_hal_setup(&data->hal, channel_id);
 
@@ -174,9 +177,14 @@ static int adc_esp32_read(const struct device *dev, const struct adc_sequence *s
 	adc_set_hw_calibration_code(data->hal.unit, data->attenuation[channel_id]);
 #endif /* SOC_ADC_CALIBRATION_V1_SUPPORTED */
 
-	adc_oneshot_hal_convert(&data->hal, &acq_raw);
+	valid = adc_oneshot_hal_convert(&data->hal, &acq_raw);
 
+	ANALOG_CLOCK_DISABLE();
 	adc_lock_release(data->hal.unit);
+
+	if (!valid) {
+		return -ETIMEDOUT;
+	}
 
 	if (data->cal_handle[channel_id]) {
 		if (data->meas_ref_internal > 0) {
@@ -380,6 +388,7 @@ static int adc_esp32_init(const struct device *dev)
 		.work_mode = ADC_HAL_SINGLE_READ_MODE,
 		.clk_src = ADC_DIGI_CLK_SRC_DEFAULT,
 		.clk_src_freq_hz = clock_src_hz,
+		.conv_timeout_us = CONFIG_ADC_ESP32_CONVERSION_TIMEOUT_US,
 	};
 
 	adc_oneshot_hal_init(&data->hal, &config);

--- a/drivers/adc/adc_esp32_dma.c
+++ b/drivers/adc/adc_esp32_dma.c
@@ -11,6 +11,7 @@
 #include <esp_private/periph_ctrl.h>
 #include <esp_private/sar_periph_ctrl.h>
 #include <esp_private/adc_share_hw_ctrl.h>
+#include <esp_private/regi2c_ctrl.h>
 
 #include "adc_esp32.h"
 
@@ -220,6 +221,8 @@ static int adc_esp32_digi_start(const struct device *dev,
 	struct adc_esp32_data *data = dev->data;
 	__maybe_unused int err = 0;
 
+	ANALOG_CLOCK_ENABLE();
+
 	sar_periph_ctrl_adc_reset();
 	sar_periph_ctrl_adc_continuous_power_acquire();
 	adc_lock_acquire(conf->unit);
@@ -287,6 +290,7 @@ static int adc_esp32_digi_start(const struct device *dev,
 	if (err) {
 		adc_lock_release(conf->unit);
 		sar_periph_ctrl_adc_continuous_power_release();
+		ANALOG_CLOCK_DISABLE();
 		return err;
 	}
 #endif /* CONFIG_SOC_SERIES_ESP32 */
@@ -325,6 +329,8 @@ static void adc_esp32_digi_stop(const struct device *dev)
 	adc_hal_digi_deinit();
 	adc_lock_release(conf->unit);
 	sar_periph_ctrl_adc_continuous_power_release();
+
+	ANALOG_CLOCK_DISABLE();
 }
 
 static void adc_esp32_fill_seq_buffer(const void *seq_buffer, const void *dma_buffer,


### PR DESCRIPTION
When Wi-Fi power saving is enabled, adc_read() can hang forever because the ADC shares an analog clock with the Wi-Fi modem and the hal waits for the conversion result in a loop with no timeout. While the modem sleeps the conversion can never finish.

The driver now holds the analog clock while reading and the hal wait is bounded, so instead of hanging the read returns ETIMEDOUT and the application can simply retry. The timeout is configurable through ADC_ESP32_CONVERSION_TIMEOUT_US.

Fixes #117247
