### PR TITLE
soc: nordic: nrf71: fix WICR wear-avoidance skip

### DIFF
--- a/soc/nordic/nrf71/soc.h
+++ b/soc/nordic/nrf71/soc.h
@@ -18,7 +18,7 @@
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_pwr_antswc)
 
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || !defined(__ZEPHYR__)
 #define PWR_ANTSWC_REG (0x5010F780UL)
 #else
 #define PWR_ANTSWC_REG (0x4010F780UL)

--- a/soc/nordic/nrf71/wicr_setup.c
+++ b/soc/nordic/nrf71/wicr_setup.c
@@ -42,8 +42,18 @@ static const struct wicr_word wicr_words[] = {
 
 int wicr_setup(void)
 {
-	bool write_enabled = false;
 	int err = 0;
+
+	while (!nrfx_mramc_ready_check()) {
+		/* Wait until MRAMC is ready for the next operation. */
+	}
+
+	/* The page permissions gate reads as well as writes, so the page has to
+	 * be unlocked before the comparison below is meaningful. Reading it
+	 * while locked yields 0xFFFFFFFF for every word, so no word ever
+	 * matches and the whole block is rewritten on every boot.
+	 */
+	nrfx_mramc_confignvr_perm_set(true, MRAM_CONFIGNVR_WICR_PAGE);
 
 	for (size_t i = 0; i < ARRAY_SIZE(wicr_words); i++) {
 		volatile uint32_t *reg = (uint32_t *)(WICR_BASE + wicr_words[i].offset);
@@ -53,12 +63,11 @@ int wicr_setup(void)
 			continue;
 		}
 
-		if (!write_enabled) {
-			nrfx_mramc_confignvr_perm_set(true, MRAM_CONFIGNVR_WICR_PAGE);
-			write_enabled = true;
-		}
-
 		*reg = wicr_words[i].value;
+
+		while (!nrfx_mramc_ready_check()) {
+			/* Let the write commit before reading it back. */
+		}
 
 		if (*reg != wicr_words[i].value) {
 			err = -EIO;
@@ -66,9 +75,11 @@ int wicr_setup(void)
 		}
 	}
 
-	if (write_enabled) {
-		nrfx_mramc_confignvr_perm_set(false, MRAM_CONFIGNVR_WICR_PAGE);
+	while (!nrfx_mramc_ready_check()) {
+		/* Do not lock the page with a write still in flight. */
 	}
+
+	nrfx_mramc_confignvr_perm_set(false, MRAM_CONFIGNVR_WICR_PAGE);
 
 	return err;
 }


### PR DESCRIPTION
One fix and two cleanups in the nRF7120/nRF7120e WICR programming path.

### WICR wear-avoidance skip never triggered

`wicr_setup()` compares each WICR word against its intended value and
skips the write when they match, to limit MRAM wear. The comparison was
done before the CONFIGNVR page was unlocked, but the page permissions
gate reads as well as writes: every read returned `0xFFFFFFFF`, no word
ever matched, and all ten words were rewritten to MRAM on every boot --
the opposite of the comment's intent. Unlock before the comparison, and
wait for MRAMC ready before the read-back and before locking again.

### Cleanups

- `soc.h` selected the antenna switch control register address using
  `__NRF_TFM__`, while `soc.c` had already moved to
  `NRF_APPLICATION`/`__ZEPHYR__`. Use `!defined(__ZEPHYR__)`; the
  selection is unchanged in all three build configurations.
- The comment above the ROM patch address override attributed the
  addresses to an out-of-tree patch; they come from the build system
  via the patch manifest as a compile definition.

### Testing

nRF7120 **FPGA**, `cpuapp`, with and without a Wi-Fi ROM patch build. No
silicon available yet. After the fix, the WICR words are left untouched
on boots after the first, instead of being rewritten every boot.
