### PR TITLE
soc: espressif: load all LP-SRAM data sections under MCUboot

### DIFF
--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -157,9 +157,9 @@ SECTIONS
      * 12. Flash offset (LMA) for start of RTC_DRAM region
      * 13. Size of RTC_DRAM region
      */
-    LONG(ADDR(.rtc.data))
-    LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(ADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -187,7 +187,7 @@ SECTIONS
   /* --- START OF RTC --- */
 
   /* RTC fast memory holds RTC wake stub code */
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     *(.rtc.literal .rtc.literal.*)
@@ -200,7 +200,7 @@ SECTIONS
    * It holds data marked with RTC_FAST_ATTR attribute.
    * See the file "esp_attr.h" for more information.
    */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     *(.rtc.force_fast .rtc.force_fast.*)
@@ -212,13 +212,25 @@ SECTIONS
    * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
    * See the file "esp_attr.h" for more information.
    */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     . = ALIGN(4);
+  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4);
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -241,18 +253,6 @@ SECTIONS
     . = ALIGN(4);
   } GROUP_LINK_IN(rtc_iram_seg)
 
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4);
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
-
   /* Get size of rtc slow data */
   _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
 
@@ -274,6 +274,15 @@ SECTIONS
 #else
   _rtc_reserved_length = 0;
 #endif
+
+  /* The RTC_DRAM load descriptor above spans .rtc.force_fast through .rtc.force_slow, so the
+   * bootloader can only place those sections correctly while the VMA and LMA layouts of that
+   * span agree. ALIGN_WITH_INPUT on the four loadable LP sections keeps them in step; this
+   * catches any future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.force_fast)),
+         "LP-SRAM loadable sections must be contiguous with equal VMA and LMA offsets")
 
   /* --- END OF RTC --- */
 

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -189,9 +189,9 @@ SECTIONS
      * 12. Flash offset (LMA) for start of LP_DRAM region
      * 13. Size of LP_DRAM region
      */
-    LONG(ADDR(.rtc.data))
-    LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(ADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -217,7 +217,7 @@ SECTIONS
   #include <zephyr/linker/llext-sections.ld>
 
   /* --- START OF RTC --- */
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_fast_start = ABSOLUTE(.);
@@ -232,7 +232,7 @@ SECTIONS
    * It holds data marked with RTC_FAST_ATTR attribute.
    * See the file "esp_attr.h" for more information.
    */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_force_fast_start = ABSOLUTE(.);
@@ -245,12 +245,25 @@ SECTIONS
   /* RTC data section holds data marked with
    * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
    */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     _rtc_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4);
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -273,19 +286,6 @@ SECTIONS
     . = ALIGN(4) ;
     _rtc_noinit_end = ABSOLUTE(.);
   } GROUP_LINK_IN(lp_ram_seg)
-
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4);
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   /**
    * This section holds RTC data that should have fixed addresses.
@@ -312,6 +312,15 @@ SECTIONS
 
   ASSERT((_rtc_slow_length <= LENGTH(rtc_slow_seg)), "RTC_SLOW segment data does not fit.")
   ASSERT((_rtc_fast_length <= LENGTH(rtc_data_seg)), "RTC_FAST segment data does not fit.")
+
+  /* The LP_DRAM load descriptor above spans .rtc.force_fast through .rtc.force_slow, so the
+   * bootloader can only place those sections correctly while the VMA and LMA layouts of that
+   * span agree. ALIGN_WITH_INPUT on the four loadable LP sections keeps them in step; this
+   * catches any future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.force_fast)),
+         "LP-SRAM loadable sections must be contiguous with equal VMA and LMA offsets")
 
   /* --- END OF RTC --- */
 

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -177,9 +177,9 @@ SECTIONS
      * 12. Flash offset (LMA) for start of LP_DRAM region
      * 13. Size of LP_DRAM region
      */
-    LONG(ADDR(.rtc.data))
-    LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(ADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -205,7 +205,7 @@ SECTIONS
   #include <zephyr/linker/llext-sections.ld>
 
   /* --- START OF RTC --- */
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_fast_start = ABSOLUTE(.);
@@ -220,7 +220,7 @@ SECTIONS
    * It holds data marked with RTC_FAST_ATTR attribute.
    * See the file "esp_attr.h" for more information.
    */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_force_fast_start = ABSOLUTE(.);
@@ -233,12 +233,25 @@ SECTIONS
   /* RTC data section holds data marked with
    * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
    */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     _rtc_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4);
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -261,19 +274,6 @@ SECTIONS
     . = ALIGN(4) ;
     _rtc_noinit_end = ABSOLUTE(.);
   } GROUP_LINK_IN(lp_ram_seg)
-
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4);
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   /**
    * This section holds RTC data that should have fixed addresses.
@@ -300,6 +300,15 @@ SECTIONS
 
   ASSERT((_rtc_slow_length <= LENGTH(rtc_slow_seg)), "RTC_SLOW segment data does not fit.")
   ASSERT((_rtc_fast_length <= LENGTH(rtc_data_seg)), "RTC_FAST segment data does not fit.")
+
+  /* The LP_DRAM load descriptor above spans .rtc.force_fast through .rtc.force_slow, so the
+   * bootloader can only place those sections correctly while the VMA and LMA layouts of that
+   * span agree. ALIGN_WITH_INPUT on the four loadable LP sections keeps them in step; this
+   * catches any future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.force_fast)),
+         "LP-SRAM loadable sections must be contiguous with equal VMA and LMA offsets")
 
   /* --- END OF RTC --- */
 

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -156,9 +156,9 @@ SECTIONS
      * 12. Flash offset (LMA) for start of LP_DRAM region
      * 13. Size of LP_DRAM region
      */
-    LONG(ADDR(.rtc.data))
-    LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(ADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -184,7 +184,7 @@ SECTIONS
   #include <zephyr/linker/llext-sections.ld>
 
   /* --- START OF RTC --- */
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_fast_start = ABSOLUTE(.);
@@ -199,7 +199,7 @@ SECTIONS
    * It holds data marked with RTC_FAST_ATTR attribute.
    * See the file "esp_attr.h" for more information.
    */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_force_fast_start = ABSOLUTE(.);
@@ -212,12 +212,25 @@ SECTIONS
   /* RTC data section holds data marked with
    * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
    */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     _rtc_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4);
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -240,19 +253,6 @@ SECTIONS
     . = ALIGN(4) ;
     _rtc_noinit_end = ABSOLUTE(.);
   } GROUP_LINK_IN(lp_ram_seg)
-
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4);
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   /**
    * This section holds RTC data that should have fixed addresses.
@@ -279,6 +279,15 @@ SECTIONS
 
   ASSERT((_rtc_slow_length <= LENGTH(rtc_slow_seg)), "RTC_SLOW segment data does not fit.")
   ASSERT((_rtc_fast_length <= LENGTH(rtc_data_seg)), "RTC_FAST segment data does not fit.")
+
+  /* The LP_DRAM load descriptor above spans .rtc.force_fast through .rtc.force_slow, so the
+   * bootloader can only place those sections correctly while the VMA and LMA layouts of that
+   * span agree. ALIGN_WITH_INPUT on the four loadable LP sections keeps them in step; this
+   * catches any future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.force_fast)),
+         "LP-SRAM loadable sections must be contiguous with equal VMA and LMA offsets")
 
   /* --- END OF RTC --- */
 

--- a/soc/espressif/esp32p4/default.ld
+++ b/soc/espressif/esp32p4/default.ld
@@ -203,9 +203,9 @@ SECTIONS
      * 12. Flash offset (LMA) for start of LP_DRAM region
      * 13. Size of LP_DRAM region
      */
-    LONG(ADDR(.rtc.data))
-    LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(ADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_fast))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -231,7 +231,7 @@ SECTIONS
   #include <zephyr/linker/llext-sections.ld>
 
   /* --- START OF RTC --- */
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_fast_start = ABSOLUTE(.);
@@ -246,7 +246,7 @@ SECTIONS
    * It holds data marked with RTC_FAST_ATTR attribute.
    * See the file "esp_attr.h" for more information.
    */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_force_fast_start = ABSOLUTE(.);
@@ -259,12 +259,25 @@ SECTIONS
   /* RTC data section holds data marked with
    * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
    */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     _rtc_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4);
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -287,19 +300,6 @@ SECTIONS
     . = ALIGN(4) ;
     _rtc_noinit_end = ABSOLUTE(.);
   } GROUP_LINK_IN(lp_ram_seg)
-
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4);
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(lp_ram_seg, ROMABLE_REGION)
 
   /**
    * This section holds RTC data that should have fixed addresses.
@@ -326,6 +326,15 @@ SECTIONS
 
   ASSERT((_rtc_slow_length <= LENGTH(rtc_slow_seg)), "RTC_SLOW segment data does not fit.")
   ASSERT((_rtc_fast_length <= LENGTH(rtc_data_seg)), "RTC_FAST segment data does not fit.")
+
+  /* The LP_DRAM load descriptor above spans .rtc.force_fast through .rtc.force_slow, so the
+   * bootloader can only place those sections correctly while the VMA and LMA layouts of that
+   * span agree. ALIGN_WITH_INPUT on the four loadable LP sections keeps them in step; this
+   * catches any future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.force_fast)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.force_fast)),
+         "LP-SRAM loadable sections must be contiguous with equal VMA and LMA offsets")
 
   /* --- END OF RTC --- */
 


### PR DESCRIPTION
Fixes #118246

### Bug Introduction

An ESP32-C6 application chainloaded by MCUboot draws 7x more deep-sleep current than the same application booted directly. 
This fix is for SoCs whose LP sections all live in one memory region — **esp32c3, esp32c5, esp32c6, esp32h2, esp32p4**.
A reproducer is available here: https://github.com/mdrinnan/zephyr-esp32-lp-sram-repro

### Root cause

LP-SRAM sections are not all loaded. The Espressif SoC linker scripts emit an `esp_image_load_header_t` (`.metadata`) that the MCUboot Espressif port uses to copy the application into RAM. Its two LP descriptors cover only two of the **four** loadable LP-SRAM sections:

| section | collects | described by |
|---|---|---|
| `.rtc.text` | wake-stub code | LP_IRAM |
| `.rtc.force_fast` | `RTC_FAST_ATTR` | **nothing** |
| `.rtc.data` | `RTC_DATA_ATTR`, `RTC_RODATA_ATTR` | LP_DATA |
| `.rtc.force_slow` | `RTC_SLOW_ATTR` | **nothing** |

`.rtc.data` is empty in any application not using those attributes, so LP_DATA is typically a zero-length descriptor while the sections that do need loading are described by nothing. The bytes are in the flashed image, they are simply never copied. Direct boot is unaffected — the ROM loader uses the esptool segment list — which is why this presents as "MCUboot costs current".

On ESP32-C6 the uninitialised statics include `s_sleep_sub_mode_ref_cnt[]` from `esp_hw_support/sleep_modes.c`. Garbage counts make `get_sleep_flags()` report the ADC/TSEN monitor, ultra-low and RTC-fast-uses-XTAL sub-modes active, so `esp_deep_sleep_start()` keeps the LP peripheral domain powered and skips `sar_periph_ctrl_power_disable()`. This is the ESP32-C6 instance of [discussion #106900](https://github.com/zephyrproject-rtos/zephyr/discussions/106900), which reports the same MCUboot-dependent regression on ESP32-S3.

### Fix

Two changes per linker script, both required:

1. **LP_DATA descriptor** spans `.rtc.force_fast` through `.rtc.force_slow` instead of the usually-empty `.rtc.data`.
2. **`.rtc.force_slow` moves ahead of the NOLOAD `.rtc.bss` / `.rtc_noinit` sections**, so the four loadable LP sections are adjacent in both VMA and LMA.

Change 2 is not cosmetic. With only change 1, a non-empty `.rtc_noinit` or `.rtc.bss` pushes `.rtc.force_slow` past the descriptor's VMA span while the LMAs stay contiguous, so the loader writes `.rtc.force_slow` to the wrong address and **overwrites `.rtc.bss` / `.rtc_noinit`**.

Putting the retained data in **LP_DATA** rather than LP_IRAM is deliberate: the MCUboot port loads LP_DATA only when `reset_reason != RESET_REASON_CORE_DEEP_SLEEP` and loads LP_IRAM unconditionally, so retained sections must keep the conditional path.

### Scope

Fixed: the SoCs whose LP sections all live in one memory region — **esp32c3, esp32c5, esp32c6, esp32h2, esp32p4**.

Deliberately not fixed:

| SoC | reason |
|---|---|
| `esp32s3` | LP sections split across `rtc_iram_seg` / `rtc_slow_seg`. Both descriptors fit, but `.rtc.force_fast` would land in the unconditionally-loaded LP_IRAM descriptor and lose deep-sleep retention. Needs a decision on intended behaviour. |
| `esp32`, `esp32s2` | Three distinct regions against two descriptors. Needs a third descriptor — it fits in `_reserved[4]`, but requires a coordinated MCUboot change. |

`esp32c2` and the `default_appcpu.ld` variants emit no LP descriptors and are unaffected.

### Testing

**Build (hardware-free, all five targets).** A test application populates every LP section using only section attributes, and a script reads the built ELF's `.metadata` and asserts that each loadable LP section is covered by exactly one descriptor **with VMA offset equal to LMA offset** — that second assertion is what catches the interleaved-NOLOAD case; a coverage-only check passes the incomplete fix. Built `--sysbuild` with `SB_CONFIG_BOOTLOADER_MCUBOOT=y` on `esp32c3_devkitm`, `esp32c5_devkitc`, `esp32c6_devkitc`, `esp32h2_devkitm`, `esp32p4_function_ev_board` against `main` at `b6a5e6e8aa9`: **before 5/5 fail** (`.rtc.force_fast` and `.rtc.force_slow` covered by 0 descriptors on every target), **after 5/5 pass**.

**Hardware (ESP32-C6).** Seeed XIAO ESP32-C6, PPK2 into the BAT pad at 3700 mV, time-averaged over deep-sleep gaps. Absolutes are board-specific; the relative change is the point. No application-side mitigation compiled in, so the delta is attributable to the linker fix alone.

| build | deep-sleep floor |
|---|---|
| release + MCUboot | 92.94 µA |
| release + MCUboot, sub-mode counts re-zeroed from the application | 17.15 µA |
| release, no MCUboot | 12.56 µA |
| **release + MCUboot + this patch** | **11.84 µA** |

A reproducer is available here: https://github.com/mdrinnan/zephyr-esp32-lp-sram-repro
