### PR TITLE
[Backport v3.7-branch] Bluetooth: HCI: psoc6_bless: Make the TX packet info a local variable

### DIFF
--- a/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
@@ -47,7 +47,6 @@ static K_SEM_DEFINE(psoc6_bless_rx_sem, 0, 1);
 static K_SEM_DEFINE(psoc6_bless_operation_sem, 1, 1);
 static K_KERNEL_STACK_DEFINE(psoc6_bless_rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 static struct k_thread psoc6_bless_rx_thread_data;
-static cy_stc_ble_hci_tx_packet_info_t hci_tx_pkt;
 
 extern void Cy_BLE_EnableLowPowerMode(void);
 
@@ -162,11 +161,10 @@ static int psoc6_bless_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int psoc6_bless_send(const struct device *dev, struct net_buf *buf)
 {
+	cy_stc_ble_hci_tx_packet_info_t hci_tx_pkt = {0};
 	cy_en_ble_api_result_t result;
 
 	ARG_UNUSED(dev);
-
-	memset(&hci_tx_pkt, 0, sizeof(cy_stc_ble_hci_tx_packet_info_t));
 
 	hci_tx_pkt.dataLength = buf->len;
 	hci_tx_pkt.data = buf->data;


### PR DESCRIPTION
Backport of the fix from #116647 to `v3.7-branch`.

Fixes: #117347