### PR TITLE
[Backport v4.4-branch] kernel: Fix a race in the kernel's use of z_waitq_head()

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -133,6 +133,7 @@ void k_heap_free_sched_locked(struct k_heap *heap, void *mem);
 void k_free_sched_locked(void *ptr);
 int z_msgq_cleanup_sched_locked(struct k_msgq *msgq);
 int z_stack_cleanup_sched_locked(struct k_stack *stack);
+int z_timer_cleanup_sched_locked(struct k_timer *timer);
 
 #ifdef CONFIG_USERSPACE
 bool z_stack_is_user_capable(k_thread_stack_t *stack);

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 
 #include <zephyr/kernel_structs.h>
+#include <kspinlock.h>
 #include <kernel_internal.h>
 #include <timeout_q.h>
 #include <kthread.h>
@@ -38,17 +39,9 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 #define Z_ASSERT_VALID_PRIO(prio, entry_point) __ASSERT((prio) == -1, "")
 #endif /* CONFIG_MULTITHREADING */
 
-#if (CONFIG_MP_MAX_NUM_CPUS == 1)
-#define LOCK_SCHED_SPINLOCK
-#else
-#define LOCK_SCHED_SPINLOCK   K_SPINLOCK(&_sched_spinlock)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-extern struct k_spinlock _sched_spinlock;
 
 extern struct k_thread _thread_dummy;
 

--- a/kernel/include/kspinlock.h
+++ b/kernel/include/kspinlock.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_
+#define ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_
+
+#include <zephyr/spinlock.h>
+#include <stdbool.h>
+
+extern struct k_spinlock _sched_spinlock;
+
+/**
+ * The intent of LOCK_SCHED_SPINLOCK is to lock the scheduler's spinlock for
+ * the scope that follows (e.g. LOCK_SCHED_SPINLOCK { ... }). However, on
+ * single core systems, the scheduler's spinlock is not needed when the locked
+ * region would otherwise be encapsulated by another spinlock (as that spinlock
+ * would degenerate into an IRQ lock). For that degenerate case, this macro
+ * will expand to nothing.
+ */
+#if (CONFIG_MP_MAX_NUM_CPUS == 1)
+#define LOCK_SCHED_SPINLOCK
+#else
+#define LOCK_SCHED_SPINLOCK   K_SPINLOCK(&_sched_spinlock)
+#endif
+
+#endif /* ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_ */

--- a/kernel/include/wait_q.h
+++ b/kernel/include/wait_q.h
@@ -14,6 +14,7 @@
 #include <zephyr/sys/rb.h>
 #include <timeout_q.h>
 #include <priority_q.h>
+#include <kspinlock.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +47,7 @@ static inline void z_waitq_init(_wait_q_t *w)
 	};
 }
 
-static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+static inline struct k_thread *z_waitq_head_locked(_wait_q_t *w)
 {
 	return (struct k_thread *)rb_get_min(&w->waitq.tree);
 }
@@ -89,12 +90,33 @@ static inline void z_waitq_init(_wait_q_t *w)
 	sys_dlist_init(&w->waitq);
 }
 
-static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+static inline struct k_thread *z_waitq_head_locked(_wait_q_t *w)
 {
 	return (struct k_thread *)sys_dlist_peek_head(&w->waitq);
 }
 
 #endif /* !CONFIG_WAITQ_SCALABLE */
+
+static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+{
+	struct k_thread *thread = NULL;
+
+	/*
+	 * On a single core system, all callers of this function are already
+	 * protected by a spinlock held by the caller. On those systems there
+	 * is no need to lock the scheduler's spinlock. However, on SMP systems
+	 * the caller controlled spinlock is insufficient as the thread timeout
+	 * handler may be running on another CPU. Use LOCK_SCHED_SPINLOCK
+	 * to protect the scope as necessary.
+	 */
+
+	LOCK_SCHED_SPINLOCK {
+		thread = z_waitq_head_locked(w);
+	}
+
+	return thread;
+}
+
 
 #ifdef __cplusplus
 }

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -107,14 +107,19 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 #include <zephyr/syscalls/k_msgq_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static int msgq_cleanup(struct k_msgq *msgq, void **mem)
+static int msgq_cleanup(struct k_msgq *msgq, void **mem, __maybe_unused bool locked)
 {
 	int ret = 0;
 
 	*mem = NULL;
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, cleanup, msgq);
 
-	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
+	CHECKIF(locked && (z_waitq_head_locked(&msgq->wait_q) != NULL)) {
+		ret = -EBUSY;
+		goto exit;
+	}
+
+	CHECKIF(!locked && (z_waitq_head(&msgq->wait_q) != NULL)) {
 		ret = -EBUSY;
 		goto exit;
 	}
@@ -132,7 +137,7 @@ exit:
 int k_msgq_cleanup(struct k_msgq *msgq)
 {
 	void *mem;
-	int ret = msgq_cleanup(msgq, &mem);
+	int ret = msgq_cleanup(msgq, &mem, false);
 
 	k_free(mem);
 	return ret;
@@ -141,7 +146,7 @@ int k_msgq_cleanup(struct k_msgq *msgq)
 int z_msgq_cleanup_sched_locked(struct k_msgq *msgq)
 {
 	void *mem;
-	int ret = msgq_cleanup(msgq, &mem);
+	int ret = msgq_cleanup(msgq, &mem, true);
 
 	k_free_sched_locked(mem);
 	return ret;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1007,7 +1007,9 @@ int z_unpend_all_locked(_wait_q_t *wait_q)
 	__ASSERT(z_spin_is_locked(&_sched_spinlock), "sched lock not held");
 #endif
 
-	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
+	for (thread = z_waitq_head_locked(wait_q);
+	     thread != NULL;
+	     thread = z_waitq_head_locked(wait_q)) {
 		unpend_thread_no_timeout(thread);
 		z_abort_thread_timeout(thread);
 		ready_thread(thread);
@@ -1321,7 +1323,9 @@ static inline void unpend_all(_wait_q_t *wait_q)
 {
 	struct k_thread *thread;
 
-	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
+	for (thread = z_waitq_head_locked(wait_q);
+	     thread != NULL;
+	     thread = z_waitq_head_locked(wait_q)) {
 		unpend_thread_no_timeout(thread);
 		z_abort_thread_timeout(thread);
 		arch_thread_return_value_set(thread, 0);

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -19,6 +19,7 @@
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <kernel_internal.h>
+#include <stdbool.h>
 
 #ifdef CONFIG_OBJ_CORE_STACK
 static struct k_obj_type obj_type_stack;
@@ -77,15 +78,22 @@ static inline int32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 #include <zephyr/syscalls/k_stack_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static int stack_cleanup(struct k_stack *stack, void **mem)
+static int stack_cleanup(struct k_stack *stack, void **mem, __maybe_unused bool locked)
 {
+	int ret = 0;
+
 	*mem = NULL;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, cleanup, stack);
 
-	CHECKIF(z_waitq_head(&stack->wait_q) != NULL) {
-		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, -EAGAIN);
-		return -EAGAIN;
+	CHECKIF(locked && (z_waitq_head_locked(&stack->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto exit;
+	}
+
+	CHECKIF(!locked && (z_waitq_head(&stack->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto exit;
 	}
 
 	if ((stack->flags & K_STACK_FLAG_ALLOC) != (uint8_t)0) {
@@ -94,14 +102,15 @@ static int stack_cleanup(struct k_stack *stack, void **mem)
 		stack->flags &= ~K_STACK_FLAG_ALLOC;
 	}
 
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, 0);
-	return 0;
+exit:
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, ret);
+	return ret;
 }
 
 int k_stack_cleanup(struct k_stack *stack)
 {
 	void *mem;
-	int ret = stack_cleanup(stack, &mem);
+	int ret = stack_cleanup(stack, &mem, false);
 
 	k_free(mem);
 	return ret;
@@ -110,7 +119,7 @@ int k_stack_cleanup(struct k_stack *stack)
 int z_stack_cleanup_sched_locked(struct k_stack *stack)
 {
 	void *mem;
-	int ret = stack_cleanup(stack, &mem);
+	int ret = stack_cleanup(stack, &mem, true);
 
 	k_free_sched_locked(mem);
 	return ret;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -179,18 +179,22 @@ void k_timer_init(struct k_timer *timer,
 	z_timer_observer_on_init(timer);
 }
 
-int k_timer_cleanup(struct k_timer *timer)
+static int timer_cleanup(struct k_timer *timer, __maybe_unused bool locked)
 {
+	int ret = 0;
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, cleanup, timer);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	CHECKIF(z_waitq_head(&timer->wait_q) != NULL) {
-		k_spin_unlock(&lock, key);
+	CHECKIF(locked && (z_waitq_head_locked(&timer->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto exit;
+	}
 
-		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, -EAGAIN);
-
-		return -EAGAIN;
+	CHECKIF(!locked && (z_waitq_head(&timer->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto exit;
 	}
 
 	/* Need to abort the timer so it will not trigger anymore.
@@ -214,11 +218,22 @@ int k_timer_cleanup(struct k_timer *timer)
 		key = k_spin_lock(&lock);
 	}
 
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, 0);
+exit:
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, ret);
 
 	k_spin_unlock(&lock, key);
 
-	return 0;
+	return ret;
+}
+
+int k_timer_cleanup(struct k_timer *timer)
+{
+	return timer_cleanup(timer, false);
+}
+
+int z_timer_cleanup_sched_locked(struct k_timer *timer)
+{
+	return timer_cleanup(timer, true);
 }
 
 void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -705,7 +705,11 @@ static void unref_check(struct k_object *ko, uintptr_t index, bool sched_locked)
 			/* k_timer_cleanup() does not check if timer has been
 			 * initialized. So we need to do it here before calling.
 			 */
-			k_timer_cleanup((struct k_timer *)ko->name);
+			if (sched_locked) {
+				z_timer_cleanup_sched_locked((struct k_timer *)ko->name);
+			} else {
+				k_timer_cleanup((struct k_timer *)ko->name);
+			}
 		}
 		break;
 	default:


### PR DESCRIPTION
Backport of the fix from #116114 to `v4.4-branch`.

Fixes: #115756