### PR TITLE
drivers: modem: sim7080: handle F_GETFL/F_SETFL in offload_ioctl

### DIFF
--- a/drivers/modem/vendor_standalone/simcom/sim7080/sim7080_sock.c
+++ b/drivers/modem/vendor_standalone/simcom/sim7080/sim7080_sock.c
@@ -532,7 +532,8 @@ static int offload_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 }
 
 /*
- * Offloads ioctl. Only supported ioctl is poll_offload.
+ * Offloads ioctl. Supports the poll offload requests and the
+ * F_GETFL/F_SETFL fcntl requests.
  */
 static int offload_ioctl(void *obj, unsigned int request, va_list args)
 {
@@ -554,6 +555,16 @@ static int offload_ioctl(void *obj, unsigned int request, va_list args)
 
 		return offload_poll(fds, nfds, timeout);
 	}
+
+	case ZVFS_F_GETFL:
+		/* The socket is always blocking, no flags are set. */
+		return 0;
+
+	case ZVFS_F_SETFL:
+		/* Accept and ignore: the socket stays blocking, non-blocking
+		 * reads are requested per call via MSG_DONTWAIT.
+		 */
+		return 0;
 
 	default:
 		errno = EINVAL;


### PR DESCRIPTION
## Problem

With `CONFIG_NET_SOCKETS_SOCKOPT_TLS=y` (native TLS over the offloaded socket, e.g. `CONFIG_MQTT_LIB_TLS=y`), every connection attempt over the SIM7080 driver fails before `AT+CAOPEN` is ever sent. The only visible symptom is a confusing cleanup-path error:

```
<err> modem_simcom_sim7080_sock: AT+CACLOSE=0 ret: -5
<err> net_mqtt: mqtt_connect: -22
```

## Root cause

`ztls_connect_ctx()` (`subsys/net/lib/sockets/sockets_tls.c`) calls `zsock_fcntl(F_GETFL)` on the underlying offloaded socket to clear/restore `O_NONBLOCK` around the TLS handshake, before issuing the underlying `connect()`. The driver's `offload_ioctl()` only handles the three poll ioctls, so `F_GETFL` hits the `default:` branch (`errno = EINVAL, return -1`). The TLS layer then aborts the connect, the socket is closed (producing the `AT+CACLOSE=0` on a socket that was never opened), and `mqtt_connect()` surfaces `-EINVAL`.

## Fix

Handle `ZVFS_F_GETFL` and `ZVFS_F_SETFL` by returning 0: the offloaded socket is always blocking, and non-blocking reads are requested per call via `MSG_DONTWAIT`. This is the same approach used by the `ublox-sara-r4` and `hl78xx` drivers.

## Testing

Tested on SIM7080G (Cat-M1, Telcel MX) hardware on `esp32_devkitc/esp32/procpu`, connecting to an EMQX broker on port 8883 with `CONFIG_NET_SOCKETS_SOCKOPT_TLS=y` + `CONFIG_MQTT_LIB_TLS=y` (mbedTLS in software over the plain-TCP offload): without this change `mqtt_connect()` always fails with `-EINVAL`; with it the TLS handshake completes and the MQTT session (CONNACK, QoS1 subscribe/publish) runs normally.

## Disclosure

This issue was diagnosed and the fix developed with the assistance of an AI tool (Claude Code); the change was reviewed and verified on real hardware by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1pQeLhNjvsTrXARmZ3LwK