### PR TITLE
drivers: i2c: dw: scope the NVIC pending-clear to RTS5912 and use k_irq_clear_pending()

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -7,10 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifdef CONFIG_I2C_RTS5912
-#include <cmsis_core.h>
-#endif
-
 #include <stddef.h>
 #include <zephyr/types.h>
 #include <stdlib.h>
@@ -512,7 +508,7 @@ static inline void i2c_dw_transfer_complete(const struct device *dev)
 	 * source has been cleared, so the pending bit has to be dropped by hand.
 	 * This is a quirk of that SoC, not of the DesignWare IP.
 	 */
-	NVIC_ClearPendingIRQ(rom->irqnumber);
+	k_irq_clear_pending(rom->irqnumber);
 #endif
 	k_sem_give(&dw->device_sync_sem);
 }

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -7,8 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/cpu.h>
-#ifdef CONFIG_CPU_CORTEX_M
+#ifdef CONFIG_I2C_RTS5912
 #include <cmsis_core.h>
 #endif
 
@@ -506,9 +505,13 @@ static inline void i2c_dw_transfer_complete(const struct device *dev)
 
 	write_intr_mask(DW_DISABLE_ALL_I2C_INT, reg_base);
 	value = read_clr_intr(reg_base);
-#ifdef CONFIG_CPU_CORTEX_M
+#ifdef CONFIG_I2C_RTS5912
 	const struct i2c_dw_rom_config *const rom = dev->config;
-	/* clear pending interrupt */
+	/*
+	 * The RTS5912 keeps the NVIC line asserted after the IP-level interrupt
+	 * source has been cleared, so the pending bit has to be dropped by hand.
+	 * This is a quirk of that SoC, not of the DesignWare IP.
+	 */
 	NVIC_ClearPendingIRQ(rom->irqnumber);
 #endif
 	k_sem_give(&dw->device_sync_sem);
@@ -1617,6 +1620,12 @@ static int i2c_dw_initialize(const struct device *dev)
 #define TIMEOUT_DW_CONFIG(n)
 #endif
 
+#ifdef CONFIG_I2C_RTS5912
+#define IRQN_DW_CONFIG(n) .irqnumber = DT_INST_IRQN(n),
+#else
+#define IRQN_DW_CONFIG(n)
+#endif
+
 /* clang-format off */
 #define I2C_DEVICE_INIT_DW(n)                                                                      \
 	PINCTRL_DW_DEFINE(n);                                                                      \
@@ -1629,7 +1638,7 @@ static int i2c_dw_initialize(const struct device *dev)
 				 (HOLD_TIME_TO_TICKS(DT_INST_PROP(n, i2c_sda_hold_time_ns))),      \
 				 (DT_INST_PROP_OR(n, sda_hold_tx, SDA_HOLD_INVALID))),             \
 		.sda_hold_rx = DT_INST_PROP_OR(n, sda_hold_rx, SDA_HOLD_INVALID),                  \
-		.irqnumber = DT_INST_IRQN(n),                                                      \
+		IRQN_DW_CONFIG(n)                                                                  \
 		.lcnt_offset = (int16_t)DT_INST_PROP_OR(n, lcnt_offset, 0),                        \
 		.hcnt_offset = (int16_t)DT_INST_PROP_OR(n, hcnt_offset, 0),                        \
 		.fs_spk_len = MAX((uint8_t)DT_INST_PROP_OR(n, fs_spike_len, 0), DW_IC_SPKLEN_MIN), \

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -153,7 +153,9 @@ struct i2c_dw_rom_config {
 	uint32_t bitrate;
 	uint32_t sda_hold_tx;
 	uint32_t sda_hold_rx;
+#ifdef CONFIG_I2C_RTS5912
 	uint32_t irqnumber;
+#endif
 	int16_t lcnt_offset;
 	int16_t hcnt_offset;
 	uint8_t fs_spk_len;


### PR DESCRIPTION
i2c_dw_transfer_complete() clears the NVIC pending bit for its own IRQ
line after clearing the IP-level interrupt source. This was added along
with the RTS5912 support in commit 748789eadf710 ("drivers: i2c: rts5912
i2c dirver") but gated on CONFIG_CPU_CORTEX_M, so every Cortex-M user of
the DesignWare IP -- RP2040/RP2350, SiWG917, Synaptics SR100 -- silently
inherited a Realtek-specific workaround, and the shared IP driver grew a
dependency on cmsis_core.h.

Clearing the NVIC pending bit after the source has already been cleared
also discards any interrupt that latched in between, so it is not a
harmless no-op on parts that do not need it.

Gate the call, the cmsis_core.h include and the irqnumber config member
on CONFIG_I2C_RTS5912 instead, matching the other RTS5912 carve-outs
already present in Kconfig.dw. Behaviour on RTS5912 is unchanged; other
Cortex-M platforms return to the pre-748789eadf710 behaviour. Dropping
irqnumber for everyone else also removes a DT_INST_IRQN() on PCIe
instances, which have no devicetree interrupt of their own.

Also drop the unused zephyr/arch/cpu.h include added by the same commit;
it is a pure dispatch header and kernel.h and irq.h already provide
everything the driver uses.

