### PR TITLE
drivers: timer: sam0_rtc: use portable IRQ pending API

### DIFF
--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -322,7 +322,7 @@ static int sys_clock_driver_init(void)
 #endif
 
 	/* Enable RTC interrupt. */
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority), rtc_isr, 0, 0);
 	irq_enable(DT_INST_IRQN(0));


### PR DESCRIPTION
Replace direct NVIC pending-state calls with k_irq_set_pending()/
k_irq_is_pending()/k_irq_clear_pending(), dropping the dependency on
cmsis_core.h where nothing else needed it.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
