### PR TITLE
i3c: support expected NACK from target device on data xfer

### DIFF
--- a/drivers/i3c/i3c_rtio.c
+++ b/drivers/i3c/i3c_rtio.c
@@ -48,6 +48,8 @@ struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, const s
 			((msgs[i].flags & I3C_MSG_RESTART) ? RTIO_IODEV_I3C_RESTART : 0) |
 			((msgs[i].flags & I3C_MSG_HDR) ? RTIO_IODEV_I3C_HDR : 0) |
 			((msgs[i].flags & I3C_MSG_NBCH) ? RTIO_IODEV_I3C_NBCH : 0) |
+			((msgs[i].flags & I3C_MSG_NOACK_EXPECTED) ?
+				RTIO_IODEV_I3C_NOACK_EXPECTED : 0) |
 			RTIO_IODEV_I3C_HDR_MODE_SET(msgs[i].hdr_mode) |
 			RTIO_IODEV_I3C_HDR_CMD_CODE_SET(msgs[i].hdr_cmd_code);
 	}

--- a/drivers/i3c/i3c_rtio_default.c
+++ b/drivers/i3c/i3c_rtio_default.c
@@ -24,6 +24,8 @@ static inline void i3c_msg_from_rx(const struct rtio_iodev_sqe *iodev_sqe, struc
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_RESTART) ? I3C_MSG_RESTART : 0) |
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_HDR) ? I3C_MSG_HDR : 0) |
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_NBCH) ? I3C_MSG_NBCH : 0) |
+		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_NOACK_EXPECTED) ?
+			I3C_MSG_NOACK_EXPECTED : 0) |
 		I3C_MSG_READ;
 }
 
@@ -38,6 +40,8 @@ static inline void i3c_msg_from_tx(const struct rtio_iodev_sqe *iodev_sqe, struc
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_RESTART) ? I3C_MSG_RESTART : 0) |
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_HDR) ? I3C_MSG_HDR : 0) |
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_NBCH) ? I3C_MSG_NBCH : 0) |
+		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_NOACK_EXPECTED) ?
+			I3C_MSG_NOACK_EXPECTED : 0) |
 		I3C_MSG_WRITE;
 }
 
@@ -52,6 +56,8 @@ static inline void i3c_msg_from_tiny_tx(const struct rtio_iodev_sqe *iodev_sqe, 
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_RESTART) ? I3C_MSG_RESTART : 0) |
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_HDR) ? I3C_MSG_HDR : 0) |
 		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_NBCH) ? I3C_MSG_NBCH : 0) |
+		((iodev_sqe->sqe.iodev_flags & RTIO_IODEV_I3C_NOACK_EXPECTED) ?
+			I3C_MSG_NOACK_EXPECTED : 0) |
 		I3C_MSG_WRITE;
 }
 

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -347,6 +347,9 @@ enum i3c_data_rate {
 /** Skip I3C broadcast header. Private Transfers only. */
 #define I3C_MSG_NBCH			BIT(4)
 
+/** NACK is expected from target */
+#define I3C_MSG_NOACK_EXPECTED		BIT(5)
+
 /** I3C HDR Mode 0 */
 #define I3C_MSG_HDR_MODE0		BIT(0)
 
@@ -2011,6 +2014,8 @@ static inline int z_impl_i3c_do_ccc_cb(const struct device *dev,
  * @retval 0 on success.
  * @retval -EBUSY Bus is busy.
  * @retval -EIO General input / output error.
+ * @retval -ENODATA If message has flag I3C_MSG_NOACK_EXPECTED set and
+ *		    the target NACK the transfer.
  */
 __syscall int i3c_transfer(struct i3c_device_desc *target,
 			   struct i3c_msg *msgs, uint8_t num_msgs);

--- a/include/zephyr/rtio/sqe.h
+++ b/include/zephyr/rtio/sqe.h
@@ -236,6 +236,11 @@ extern "C" {
 #define RTIO_IODEV_I3C_NBCH BIT(4)
 
 /**
+ * @brief Equivalent to the I3C_MSG_NOACK_EXPECTED
+ */
+#define RTIO_IODEV_I3C_NOACK_EXPECTED BIT(5)
+
+/**
  * @brief I3C HDR Mode Mask
  */
 #define RTIO_IODEV_I3C_HDR_MODE_MASK GENMASK(15, 8)


### PR DESCRIPTION
There are some situations where a NACK is expected from the target after sending the address. One example would be MCTP, where the target would NACK if there is no data to return during polling. This use case is not entirely conforming to traditional I2C/I3C transfer mechanism where a NACK after the address byte means there is no target with this address or the target is not responding to the transfer request. In order to support MCTP, we will need to handle this type of transfer gracefully, by adding a new transfer message flag to indicate this type of transfer. A new return value is also being introduced to i3c_transfer() to signal the expected NACK is received. Since most of the wire interactions are handled by the hardware, each individual driver will need to purposely handle this use case. For now, this commit only introduces the building block needed for the drivers to implement the bits to support this use case.

Relates to #114312