### PR TITLE
silabs: Replace the direct NVIC_ClearPendingIRQ() call with k_irq_clear_pending()

### DIFF
--- a/drivers/gpio/gpio_si32.c
+++ b/drivers/gpio/gpio_si32.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT silabs_si32_gpio
 
+#include <zephyr/irq.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
@@ -205,7 +206,7 @@ static void gpio_si32_irq_handler(const struct device *arg)
 	ARG_UNUSED(arg);
 
 	irq_disable(PMATCH_IRQn);
-	NVIC_ClearPendingIRQ(PMATCH_IRQn);
+	k_irq_clear_pending(PMATCH_IRQn);
 
 	for (size_t i = 0; i < ARRAY_SIZE(gpio_devices); i++) {
 		const struct device *dev = gpio_devices[i];

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -212,7 +212,7 @@ static int burtc_init(void)
 	/* Enable compare match interrupt */
 	BURTC_IntClear(BURTC_IF_COMP);
 	BURTC_IntEnable(BURTC_IF_COMP);
-	NVIC_ClearPendingIRQ(TIMER_IRQ);
+	k_irq_clear_pending(TIMER_IRQ);
 	IRQ_CONNECT(TIMER_IRQ, DT_INST_IRQ(0, priority), burtc_isr, 0, 0);
 	irq_enable(TIMER_IRQ);
 

--- a/soc/silabs/silabs_s2/soc.c
+++ b/soc/silabs/silabs_s2/soc.c
@@ -9,6 +9,7 @@
  * @brief SoC initialization for Silicon Labs Series 2 products
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
@@ -115,7 +116,7 @@ void soc_prep_hook(void)
 	__DSB();
 	__ISB();
 
-	NVIC_ClearPendingIRQ(SMU_SECURE_IRQn);
+	k_irq_clear_pending(SMU_SECURE_IRQn);
 	SMU->IF_CLR = SMU_IF_PPUSEC | SMU_IF_BMPUSEC;
 	SMU->IEN = SMU_IEN_PPUSEC | SMU_IEN_BMPUSEC;
 #endif

--- a/soc/silabs/silabs_sim3/sim3u/soc.c
+++ b/soc/silabs/silabs_sim3/sim3u/soc.c
@@ -91,7 +91,7 @@ static void vmon_init(void)
 {
 	/* VMON must be enabled for flash write/erase support */
 
-	NVIC_ClearPendingIRQ(VDDLOW_IRQn);
+	k_irq_clear_pending(VDDLOW_IRQn);
 
 	IRQ_CONNECT(VDDLOW_IRQn, 0, vddlow_irq_handler, NULL, 0);
 	irq_enable(VDDLOW_IRQn);


### PR DESCRIPTION
- **soc: silabs: use portable IRQ pending API**
- **drivers: timer: gecko_burtc: use portable IRQ pending API**
- **drivers: gpio: si32: use portable IRQ pending API**
