### PR TITLE
arm: replace the direct NVIC_*IRQ() call with k_irq_*() calls

### DIFF
--- a/boards/digilent/arty_a7/board.c
+++ b/boards/digilent/arty_a7/board.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <cmsis_core.h>
+#include <zephyr/irq.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
@@ -57,7 +57,7 @@ bool board_daplink_is_fitted(void)
 	 * level-detect non-interrupt signal to determine if the DAPLink shield
 	 * is fitted.
 	 */
-	return !NVIC_GetPendingIRQ(DT_IRQN(DAPLINK_QSPI_MUX_NODE));
+	return !k_irq_is_pending(DT_IRQN(DAPLINK_QSPI_MUX_NODE));
 }
 
 /* The board init must take place after the GPIO driver is initialized;

--- a/drivers/counter/counter_crsas_ma2_timer.c
+++ b/drivers/counter/counter_crsas_ma2_timer.c
@@ -316,7 +316,7 @@ static int timer_crsas_ma2_set_alarm(const struct device *dev, uint8_t chan_id,
 		    (alarm_cfg->ticks == now && data->guard_period > 0)) {
 			if (alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE) {
 				/* Late, trigger interrupt */
-				NVIC_SetPendingIRQ(config->irqn);
+				k_irq_set_pending(config->irqn);
 			} else {
 				data->alarm_cb = NULL;
 			}

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -171,7 +171,7 @@ static void cmsdk_apb_timer_isr(const void *arg)
 	}
 
 	cfg->timer->intclear = TIMER_CTRL_INT_CLEAR;
-	NVIC_ClearPendingIRQ(TIMER_IRQ);
+	k_irq_clear_pending(TIMER_IRQ);
 	sys_clock_announce_locked(ticks, key);
 }
 


### PR DESCRIPTION
- **drivers: timer: cmsdk_apb: use portable IRQ pending API**
- **drivers: counter: crsas_ma2: use portable IRQ pending API**
- **boards: digilent: arty_a7: use portable IRQ pending API**
