### PR TITLE
drivers: counter: max32: use portable IRQ pending API

### DIFF
--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -192,7 +192,7 @@ static int set_cc(const struct device *dev, uint8_t id, uint32_t val, uint32_t f
 		 * for absolute depending on the flag.
 		 */
 		if (irq_on_late) {
-			NVIC_SetPendingIRQ(MXC_TMR_GET_IRQ(MXC_TMR_GET_IDX(regs)));
+			k_irq_set_pending(MXC_TMR_GET_IRQ(MXC_TMR_GET_IDX(regs)));
 		} else {
 			config->ch_data[id].callback = NULL;
 		}

--- a/drivers/counter/counter_max32_wut.c
+++ b/drivers/counter/counter_max32_wut.c
@@ -164,7 +164,7 @@ static int counter_max32_wut_set_alarm(const struct device *dev, uint8_t chan,
 
 	irq_on_late = alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE;
 	if (irq_on_late || !absolute) {
-		NVIC_SetPendingIRQ(cfg->irq_number);
+		k_irq_set_pending(cfg->irq_number);
 	} else {
 		data->alarm.callback = NULL;
 		data->alarm.user_data = NULL;


### PR DESCRIPTION
Replace direct NVIC pending-state calls with k_irq_set_pending()/
k_irq_is_pending()/k_irq_clear_pending(), dropping the dependency on
cmsis_core.h where nothing else needed it.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
