### PR TITLE
nxp: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -300,7 +300,7 @@ static int mcux_qtmr_set_alarm(const struct device *dev, uint8_t chan_id,
 			 * forcing the interrupt.
 			 */
 			atomic_set(&data->irq_pending, 1);
-			NVIC_SetPendingIRQ(config->irqn);
+			k_irq_set_pending(config->irqn);
 		} else {
 			QTMR_DisableInterrupts(config->base, config->channel,
 					       kQTMR_Compare1InterruptEnable);

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -144,7 +144,7 @@ static void mcux_qtmr_isr(const struct device *timers[])
 			uint32_t channel_status = QTMR_GetStatus(config->base, ch);
 			bool sw_pending = (atomic_clear(&data->irq_pending) != 0);
 
-			/* A late alarm forced through NVIC_SetPendingIRQ has no
+			/* A late alarm forced through k_irq_set_pending() has no
 			 * hardware compare flag set. Synthesize the compare event
 			 * so the handler runs the alarm callback immediately.
 			 */

--- a/drivers/counter/counter_mcux_rtc_jdp.c
+++ b/drivers/counter/counter_mcux_rtc_jdp.c
@@ -143,7 +143,7 @@ static inline void mcux_rtc_jdp_alarm_sw_pend(struct mcux_rtc_jdp_data *data,
 {
 	data->sw_pending_mask |= BIT(chan_id);
 	irq_enable(config->irqn);
-	NVIC_SetPendingIRQ(config->irqn);
+	k_irq_set_pending(config->irqn);
 }
 
 static inline int mcux_rtc_jdp_alarm_handle_late_or_drop(struct mcux_rtc_jdp_data *data,

--- a/drivers/counter/counter_mcux_sysctr.c
+++ b/drivers/counter/counter_mcux_sysctr.c
@@ -299,7 +299,7 @@ static int mcux_sysctr_set_alarm(const struct device *dev, uint8_t chan_id,
 		 */
 		if (irq_on_late) {
 			atomic_or(&data->irq_pending, BIT(chan_id));
-			NVIC_SetPendingIRQ(config->irqn);
+			k_irq_set_pending(config->irqn);
 		} else {
 			data->channels[chan_id].callback = NULL;
 		}
@@ -396,7 +396,7 @@ static int mcux_sysctr_set_alarm_64(const struct device *dev, uint8_t chan_id,
 
 		if (irq_on_late) {
 			atomic_or(&data->irq_pending, BIT(chan_id));
-			NVIC_SetPendingIRQ(config->irqn);
+			k_irq_set_pending(config->irqn);
 		} else {
 			data->channels[chan_id].callback_64 = NULL;
 		}

--- a/drivers/counter/counter_mcux_wake_timer.c
+++ b/drivers/counter/counter_mcux_wake_timer.c
@@ -10,9 +10,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
-#if defined(CONFIG_GIC)
-#include <zephyr/drivers/interrupt_controller/gic.h>
-#endif /* CONFIG_GIC */
 #include <zephyr/spinlock.h>
 #include <fsl_waketimer.h>
 
@@ -68,33 +65,6 @@ struct mcux_wake_timer_data {
 #endif
 };
 
-static ALWAYS_INLINE void irq_set_pending(unsigned int irq)
-{
-#if defined(CONFIG_GIC)
-	arm_gic_irq_set_pending(irq);
-#else
-	NVIC_SetPendingIRQ(irq);
-#endif /* CONFIG_GIC */
-}
-
-static ALWAYS_INLINE bool irq_is_pending(unsigned int irq)
-{
-#if defined(CONFIG_GIC)
-	return arm_gic_irq_is_pending(irq);
-#else
-	return NVIC_GetPendingIRQ((IRQn_Type)irq) != 0U;
-#endif /* CONFIG_GIC */
-}
-
-static ALWAYS_INLINE void irq_clear_pending(unsigned int irq)
-{
-#if defined(CONFIG_GIC)
-	arm_gic_irq_clear_pending(irq);
-#else
-	NVIC_ClearPendingIRQ((IRQn_Type)irq);
-#endif /* CONFIG_GIC */
-}
-
 /* Load a non-zero count and launch the countdown. The counter must be halted
  * (it always is after init, a stop, or a previous time-out) before a write.
  */
@@ -126,7 +96,7 @@ static uint32_t mcux_wake_timer_get_pending_int(const struct device *dev)
 	 * hardware time-out.
 	 */
 	if (((config->base->WAKE_TIMER_CTRL & WAKETIMER_WAKE_TIMER_CTRL_INTR_EN_MASK) != 0U) &&
-	    irq_is_pending(config->irqn)) {
+	    k_irq_is_pending(config->irqn)) {
 		return 1U;
 	}
 
@@ -154,7 +124,7 @@ static int mcux_wake_timer_start(const struct device *dev)
 	 */
 	WAKETIMER_DisableInterrupts(config->base, kWAKETIMER_WakeInterruptEnable);
 	WAKETIMER_HaltTimer(config->base);
-	irq_clear_pending(config->irqn);
+	k_irq_clear_pending(config->irqn);
 
 	data->alarm_callback = NULL;
 	data->alarm_user_data = NULL;
@@ -176,7 +146,7 @@ static int mcux_wake_timer_stop(const struct device *dev)
 
 	WAKETIMER_DisableInterrupts(config->base, kWAKETIMER_WakeInterruptEnable);
 	WAKETIMER_HaltTimer(config->base);
-	irq_clear_pending(config->irqn);
+	k_irq_clear_pending(config->irqn);
 
 	data->alarm_callback = NULL;
 	data->alarm_user_data = NULL;
@@ -233,12 +203,12 @@ static int mcux_wake_timer_set_alarm(const struct device *dev, uint8_t chan_id,
 	 */
 	WAKETIMER_HaltTimer(config->base);
 	WAKETIMER_ClearStatusFlags(config->base, kWAKETIMER_WakeFlag);
-	irq_clear_pending(config->irqn);
+	k_irq_clear_pending(config->irqn);
 	WAKETIMER_EnableInterrupts(config->base, kWAKETIMER_WakeInterruptEnable);
 
 	if (sw_pending) {
 		/* Trigger the callback immediately through the interrupt path. */
-		irq_set_pending(config->irqn);
+		k_irq_set_pending(config->irqn);
 	} else {
 		mcux_wake_timer_load(config->base, ticks);
 	}
@@ -271,7 +241,7 @@ static int mcux_wake_timer_cancel_alarm(const struct device *dev, uint8_t chan_i
 	WAKETIMER_DisableInterrupts(config->base, kWAKETIMER_WakeInterruptEnable);
 	WAKETIMER_HaltTimer(config->base);
 	WAKETIMER_ClearStatusFlags(config->base, kWAKETIMER_WakeFlag);
-	irq_clear_pending(config->irqn);
+	k_irq_clear_pending(config->irqn);
 
 	data->alarm_callback = NULL;
 	data->alarm_user_data = NULL;
@@ -336,7 +306,7 @@ static int mcux_wake_timer_stop(const struct device *dev)
 
 	WAKETIMER_DisableInterrupts(config->base, kWAKETIMER_WakeInterruptEnable);
 	WAKETIMER_HaltTimer(config->base);
-	irq_clear_pending(config->irqn);
+	k_irq_clear_pending(config->irqn);
 
 	k_spin_unlock(&data->lock, key);
 

--- a/drivers/counter/counter_nxp_s32_sys_timer.c
+++ b/drivers/counter/counter_nxp_s32_sys_timer.c
@@ -9,9 +9,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
-#if defined(CONFIG_GIC)
-#include <zephyr/drivers/interrupt_controller/gic.h>
-#endif /* CONFIG_GIC */
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 
@@ -70,15 +67,6 @@ struct nxp_s32_sys_timer_config {
 	bool freeze;
 	unsigned int irqn;
 };
-
-static ALWAYS_INLINE void irq_set_pending(unsigned int irq)
-{
-#if defined(CONFIG_GIC)
-	arm_gic_irq_set_pending(irq);
-#else
-	NVIC_SetPendingIRQ(irq);
-#endif /* CONFIG_GIC */
-}
 
 static uint32_t ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
 {
@@ -164,7 +152,7 @@ static int stm_set_alarm(const struct device *dev, uint8_t channel, uint32_t tic
 		 */
 		if (irq_on_late) {
 			atomic_or(&data->irq_pending, BIT(channel));
-			irq_set_pending(config->irqn);
+			k_irq_set_pending(config->irqn);
 		} else {
 			ch_data->callback = NULL;
 		}

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -1061,7 +1061,7 @@ static int kw41z_init(const struct device *dev)
 	ZLL->PHY_CTRL &= ~ZLL_PHY_CTRL_TRCV_MSK_MASK;
 
 	/* Configure Radio IRQ */
-	NVIC_ClearPendingIRQ(Radio_1_IRQn);
+	k_irq_clear_pending(Radio_1_IRQn);
 	IRQ_CONNECT(Radio_1_IRQn, RADIO_0_IRQ_PRIO, kw41z_isr, 0, 0);
 
 	return 0;

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -5,7 +5,6 @@
  */
 #define DT_DRV_COMPAT nxp_lpc11u6x_uart
 
-#include <cmsis_core.h>
 
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
@@ -232,7 +231,7 @@ static void lpc11u6x_uart0_irq_tx_enable(const struct device *dev)
 	/* Due to hardware limitations, first TX interrupt is not triggered when
 	 * enabling it in the IER register. We have to trigger it.
 	 */
-	NVIC_SetPendingIRQ(DT_INST_IRQN(0));
+	k_irq_set_pending(DT_INST_IRQN(0));
 }
 
 static void lpc11u6x_uart0_irq_tx_disable(const struct device *dev)

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -330,7 +330,7 @@ static DEVICE_API(wdt, mcux_wwdt_api) = {
 		/* Defensive: clear any peripheral status and NVIC pending */                      \
 		WWDT_ClearStatusFlags((WWDT_Type *)DT_INST_REG_ADDR(id),                           \
 			      WWDT_GetStatusFlags((WWDT_Type *)DT_INST_REG_ADDR(id)));             \
-		NVIC_ClearPendingIRQ(DT_INST_IRQN(id));                                            \
+		k_irq_clear_pending(DT_INST_IRQN(id));                                            \
 		irq_enable(DT_INST_IRQN(id));                                                      \
 	}
 

--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -11,6 +11,7 @@
  * hardware for the nxp_lpc55s69 platform.
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
@@ -319,8 +320,8 @@ __weak void clock_init(void)
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(usbhfs), nxp_uhc_ohci, okay)
 	/* set BOD VBAT level to 1.65V */
 	POWER_SetBodVbatLevel(kPOWER_BodVbatLevel1650mv, kPOWER_BodHystLevel50mv, false);
-	NVIC_ClearPendingIRQ(USB0_IRQn);
-	NVIC_ClearPendingIRQ(USB0_NEEDCLK_IRQn);
+	k_irq_clear_pending(USB0_IRQn);
+	k_irq_clear_pending(USB0_NEEDCLK_IRQn);
 	/*< Turn on USB Phy */
 #if defined(CONFIG_SOC_LPC55S36)
 	POWER_DisablePD(kPDRUNCFG_PD_USBFSPHY);

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
 #include <fsl_clock.h>
@@ -54,7 +55,7 @@ static void pin0_isr(const struct device *dev)
 	uint8_t level = ~(DT_ENUM_IDX(DT_NODELABEL(pin0), wakeup_level)) & 0x1;
 
 	POWER_ConfigWakeupPin(kPOWER_WakeupPin0, level);
-	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin0)));
+	k_irq_clear_pending(DT_IRQN(DT_NODELABEL(pin0)));
 	DisableIRQ(DT_IRQN(DT_NODELABEL(pin0)));
 	POWER_DisableWakeup(DT_IRQN(DT_NODELABEL(pin0)));
 }
@@ -66,7 +67,7 @@ static void pin1_isr(const struct device *dev)
 	uint8_t level = ~(DT_ENUM_IDX(DT_NODELABEL(pin1), wakeup_level)) & 0x1;
 
 	POWER_ConfigWakeupPin(kPOWER_WakeupPin1, level);
-	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin1)));
+	k_irq_clear_pending(DT_IRQN(DT_NODELABEL(pin1)));
 	DisableIRQ(DT_IRQN(DT_NODELABEL(pin1)));
 	POWER_DisableWakeup(DT_IRQN(DT_NODELABEL(pin1)));
 }
@@ -170,14 +171,14 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin0))
 	POWER_ConfigWakeupPin(kPOWER_WakeupPin0, DT_ENUM_IDX(DT_NODELABEL(pin0), wakeup_level));
 	POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(pin0)));
-	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin0)));
+	k_irq_clear_pending(DT_IRQN(DT_NODELABEL(pin0)));
 	EnableIRQ(DT_IRQN(DT_NODELABEL(pin0)));
 	POWER_EnableWakeup(DT_IRQN(DT_NODELABEL(pin0)));
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin1))
 	POWER_ConfigWakeupPin(kPOWER_WakeupPin1, DT_ENUM_IDX(DT_NODELABEL(pin1), wakeup_level));
 	POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(pin1)));
-	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin1)));
+	k_irq_clear_pending(DT_IRQN(DT_NODELABEL(pin1)));
 	EnableIRQ(DT_IRQN(DT_NODELABEL(pin1)));
 	POWER_EnableWakeup(DT_IRQN(DT_NODELABEL(pin1)));
 #endif
@@ -234,7 +235,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby))
 				RTC_ClearStatusFlags(RTC, kRTC_WakeupFlag);
 #endif
-				NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(rtc)));
+				k_irq_clear_pending(DT_IRQN(DT_NODELABEL(rtc)));
 				sys_clock_idle_exit();
 				{
 					k_spinlock_key_t key = sys_clock_lock();


### PR DESCRIPTION
- **drivers: counter: mcux_qtmr: use portable IRQ pending API**
- **drivers: counter: mcux_sysctr: use portable IRQ pending API**
- **drivers: counter: mcux_rtc_jdp: use portable IRQ pending API**
- **drivers: counter: mcux_wake_timer: use portable IRQ pending API**
- **drivers: counter: nxp_s32_sys_timer: use portable IRQ pending API**
- **drivers: ieee802154: kw41z: use portable IRQ pending API**
- **drivers: watchdog: mcux_wwdt: use portable IRQ pending API**
- **soc: nxp: rw: use portable IRQ pending API**
- **soc: nxp: lpc55xxx: use portable IRQ pending API**
- **drivers: serial: lpc11u6x: use portable IRQ pending API**
- **drivers: counter: mcux_qtmr: update comment for portable IRQ API**
