### PR TITLE
tests: drivers: spi: spi_loopback: add device_deinit busy test and define the contract

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -939,12 +939,17 @@ __syscall int device_init(const struct device *dev);
  * Note: this will be available if CONFIG_DEVICE_DEINIT_SUPPORT is enabled.
  *
  * @warning It is the responsibility of the caller to ensure that the device is
- * ready to be de-initialized.
+ * ready to be de-initialized. As a best-effort guard on top of that contract, a
+ * driver may reject de-initialization with -EBUSY while an operation is still in
+ * flight; this is driver-defined and is not a substitute for caller-side
+ * synchronization.
  *
  * @param dev device to be de-initialized.
  *
  * @retval 0 If successful
  * @retval -EPERM If device has not been initialized.
+ * @retval -EBUSY If the device is busy and the driver rejects de-initialization
+ *         while an operation is in flight (driver-defined, best-effort).
  * @retval -ENOTSUP If device does not support de-initialization, or if the
  *         feature is not enabled (see CONFIG_DEVICE_DEINIT_SUPPORT)
  * @retval -errno For any other errors.

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
@@ -55,3 +55,10 @@ spi1: &scb10 {
 &dma0 {
 	status = "okay";
 };
+
+/ {
+	zephyr,user {
+		mosi-gpios = <&gpio_prt16 1 GPIO_ACTIVE_HIGH>;
+		miso-gpios = <&gpio_prt16 2 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -1042,6 +1042,64 @@ ZTEST(spi_loopback, test_spi_transceive_cb)
 	/* Verify loopback data */
 	spi_loopback_compare_bufs(buffer_tx, buffer_rx, BUF_SIZE, buffer_print_tx, buffer_print_rx);
 }
+
+/* Exercise device_deinit() against a transfer that is still in flight. A single
+ * large buffer is big enough that the driver runs it through the DMA channels
+ * instead of the FIFO, so on drivers that refuse a busy teardown this also
+ * exercises the DMA channel-state busy check in the deinit path. Drivers may
+ * either refuse with -EBUSY or tear the bus down; both are handled below.
+ */
+ZTEST(spi_loopback, test_spi_deinit_busy)
+{
+	struct spi_dt_spec *spec = loopback_specs[spec_idx];
+	const struct device *dev = spec->bus;
+	const struct spi_buf_set tx = spi_loopback_setup_xfer(tx_bufs_pool, 1,
+							      large_buffer_tx, BUF3_SIZE);
+	const struct spi_buf_set rx = spi_loopback_setup_xfer(rx_bufs_pool, 1,
+							      large_buffer_rx, BUF3_SIZE);
+	int ret;
+
+	memset(large_buffer_rx, 0, sizeof(large_buffer_rx));
+
+	k_sem_give(&start_async);
+
+	ret = spi_transceive_signal(spec->bus, &spec->config, &tx, &rx, &async_sig);
+	if (ret == -ENOTSUP) {
+		TC_PRINT("Skipping ASYNC deinit test\n");
+		return;
+	}
+	zassert_false(ret, "SPI transceive failed, code %d", ret);
+
+	/* Whether device_deinit() refuses to tear the bus down while a transfer
+	 * is in flight is driver-defined: this driver returns -EBUSY, while others
+	 * tear the bus down and return 0 (or a PM result). Accept the driver's
+	 * choice; only the -EBUSY path exercises the busy guard under test.
+	 */
+	ret = device_deinit(dev);
+	if (ret == -ENOTSUP) {
+		TC_PRINT("  device deinit not supported\n");
+		k_sem_take(&caller, K_FOREVER);
+		return;
+	}
+
+	/* Let the in-flight transfer unwind before touching the device again. */
+	k_sem_take(&caller, K_FOREVER);
+
+	if (ret == -EBUSY) {
+		/* Bus left intact: the transfer ran to completion, so it is idle
+		 * now and deinit must succeed and the device must re-init.
+		 */
+		zassert_false(result, "SPI async transceive failed, result %d", result);
+		zassert_ok(device_deinit(dev));
+		zassert_ok(device_init(dev));
+	} else {
+		/* Bus torn down mid-transfer: the device is already deinitialised,
+		 * so just bring it back up.
+		 */
+		zassert_ok(ret, "device_deinit returned unexpected error %d", ret);
+		zassert_ok(device_init(dev));
+	}
+}
 #endif
 
 ZTEST(spi_extra_api_features, test_spi_lock_release)


### PR DESCRIPTION
Split out of #110676 at the reviewer's request: the SPI loopback deinit
test and the `device_deinit()` contract it checks belong in their own PR
for the SPI maintainer to review, separate from the driver deinit hook.

## What this does

- **Defines the `device_deinit()` busy contract.** `device_deinit()`
  previously left it unspecified what happens if a device is de-initialized
  while an operation is still in flight. This documents that a driver may,
  as a best-effort guard on top of the caller's keep-it-idle
  responsibility, reject de-initialization with `-EBUSY`, and adds `-EBUSY`
  to the documented return values.

- **Adds a `test_spi_deinit_busy` case** to the shared `drivers.spi.spi_loopback`
  suite. It starts an async transfer and calls `device_deinit()` while it is
  in flight. The behavior is driver-defined: a driver may reject with
  `-EBUSY` (the busy guard under test) or tear the bus down and return 0;
  both paths are handled, and `-ENOTSUP` is skipped. The test is enabled on
  `kit_pse84_eval` via a board overlay.

## Notes

- The `-EBUSY` path is exercised end-to-end by the Infineon SPI driver's
  deinit hook in #110676; on drivers without a busy guard the test simply
  accepts the teardown path (or skips on `-ENOTSUP`).

Assisted-by: AI (GitHub Copilot)
