### PR TITLE
ambiq: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/counter/counter_ambiq_timer.c
+++ b/drivers/counter/counter_ambiq_timer.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT ambiq_counter
 
+#include <zephyr/irq.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/kernel.h>
@@ -53,7 +54,7 @@ static void counter_irq_config_func(void)
 	global_irq_init = false;
 
 	/* Shared irq config default to ctimer0. */
-	NVIC_ClearPendingIRQ(CTIMER_IRQn);
+	k_irq_clear_pending(CTIMER_IRQn);
 	IRQ_CONNECT(CTIMER_IRQn, DT_IRQ(DT_INST_PARENT(0), priority), counter_ambiq_isr,
 		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(CTIMER_IRQn);
@@ -430,7 +431,7 @@ static void counter_ambiq_isr(void *arg)
 #define AMBIQ_COUNTER_CONFIG_FUNC(idx)                                                             \
 	static void counter_irq_config_func_##idx(void)                                            \
 	{                                                                                          \
-		NVIC_ClearPendingIRQ(DT_IRQN(DT_INST_PARENT(idx)));                                \
+		k_irq_clear_pending(DT_IRQN(DT_INST_PARENT(idx)));                                \
 		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(idx)), DT_IRQ(DT_INST_PARENT(idx), priority),   \
 			    counter_ambiq_isr, DEVICE_DT_INST_GET(idx), 0);                        \
 		irq_enable(DT_IRQN(DT_INST_PARENT(idx)));                                          \

--- a/drivers/gpio/gpio_ambiq.c
+++ b/drivers/gpio/gpio_ambiq.c
@@ -546,7 +546,7 @@ static int ambiq_gpio_init(const struct device *port)
 {
 	const struct ambiq_gpio_config *const dev_cfg = port->config;
 
-	NVIC_ClearPendingIRQ(dev_cfg->irq_num);
+	k_irq_clear_pending(dev_cfg->irq_num);
 
 #if defined(CONFIG_SOC_SERIES_APOLLO3X)
 	ambiq_gpio_cfg_func();

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -224,11 +224,11 @@ static int stimer_init(void)
 	/* A Possible clock glitch could rarely cause the Stimer interrupt to be lost.
 	 * Set up a backup comparator to handle this case
 	 */
-	NVIC_ClearPendingIRQ(COMPAREA_IRQ);
+	k_irq_clear_pending(COMPAREA_IRQ);
 	IRQ_CONNECT(COMPAREA_IRQ, 0, stimer_isr, 0, 0);
 	irq_enable(COMPAREA_IRQ);
 #if !defined(CONFIG_SOC_SERIES_APOLLO5X)
-	NVIC_ClearPendingIRQ(COMPAREB_IRQ);
+	k_irq_clear_pending(COMPAREB_IRQ);
 	IRQ_CONNECT(COMPAREB_IRQ, 0, stimer_isr, 0, 0);
 	irq_enable(COMPAREB_IRQ);
 #endif

--- a/drivers/watchdog/wdt_ambiq.c
+++ b/drivers/watchdog/wdt_ambiq.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT ambiq_watchdog
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/watchdog.h>
 
@@ -178,7 +179,7 @@ static int wdt_ambiq_init(const struct device *dev)
 		}
 	}
 
-	NVIC_ClearPendingIRQ(dev_cfg->irq_num);
+	k_irq_clear_pending(dev_cfg->irq_num);
 
 	dev_cfg->cfg_func();
 


### PR DESCRIPTION
- **drivers: counter: ambiq: use portable IRQ pending API**
- **drivers: gpio: ambiq: use portable IRQ pending API**
- **drivers: timer: ambiq_stimer: use portable IRQ pending API**
- **drivers: watchdog: ambiq: use portable IRQ pending API**
