### PR TITLE
infineon: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/counter/counter_infineon.c
+++ b/drivers/counter/counter_infineon.c
@@ -11,6 +11,7 @@
 
 #define DT_DRV_COMPAT infineon_counter
 
+#include <zephyr/irq.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <cyhal_timer.h>
@@ -457,7 +458,7 @@ static uint32_t ifx_cat1_counter_get_pending_int(const struct device *dev)
 
 	const struct ifx_cat1_counter_config *const config = dev->config;
 
-	return NVIC_GetPendingIRQ(config->irqn);
+	return k_irq_is_pending(config->irqn);
 }
 
 static uint32_t ifx_cat1_counter_get_guard_period(const struct device *dev, uint32_t flags)

--- a/drivers/counter/counter_infineon_tcpwm.c
+++ b/drivers/counter/counter_infineon_tcpwm.c
@@ -122,7 +122,7 @@ static void counter_isr_handler(const struct device *dev)
 
 	pending_int = Cy_TCPWM_GetInterruptStatusMasked(config->reg_base, config->index);
 	Cy_TCPWM_ClearInterrupt(config->reg_base, config->index, pending_int);
-	NVIC_ClearPendingIRQ(config->irq_num);
+	k_irq_clear_pending(config->irq_num);
 
 	/* Alarm compare/capture interrupt */
 	if ((data->alarm_cfg.callback != NULL) &&
@@ -475,7 +475,7 @@ static uint32_t ifx_tcpwm_counter_get_pending_int(const struct device *dev)
 #if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
 	return (pending & CY_TCPWM_INT_ON_CC) ? COUNTER_IRQ_CAPTURE_COMPARE : 0U;
 #else
-	return NVIC_GetPendingIRQ(config->irq_num);
+	return k_irq_is_pending(config->irq_num);
 #endif
 }
 

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -477,7 +477,7 @@ void ifx_cat1_uart_enable_event(const struct device *dev, uint32_t event, bool e
 	irq_disable(config->irq_num);
 
 #if !defined(CONFIG_INFINEON_INTC_SYSINTC)
-	NVIC_ClearPendingIRQ(config->irq_num);
+	k_irq_clear_pending(config->irq_num);
 #endif /* CONFIG_INFINEON_INTC_SYSINTC */
 
 	if (event & CY_SCB_UART_TRANSMIT_EMTPY) {

--- a/soc/infineon/cat1c/xmc7200/soc_m7.c
+++ b/soc/infineon/cat1c/xmc7200/soc_m7.c
@@ -9,6 +9,7 @@
  * @brief Infineon XMC7200 SOC.
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/cache.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
@@ -55,7 +56,7 @@ __attribute__((section(".itcm"))) void sys_int_handler(uint32_t intrNum)
 		(entry->isr)(entry->arg);
 	}
 #endif
-	NVIC_ClearPendingIRQ((IRQn_Type)intrNum);
+	k_irq_clear_pending(intrNum);
 }
 
 void system_irq_init(void)

--- a/soc/infineon/psoc4/psoc4100tp/power.c
+++ b/soc/infineon/psoc4/psoc4100tp/power.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/pm/pm.h>
@@ -129,7 +130,7 @@ void z_sys_clock_lpm_enter(uint64_t max_lpm_time_us)
 	 * does not need Cy_WDT_Enable() to start.
 	 */
 
-	NVIC_ClearPendingIRQ(WDT_IRQ_NUM);
+	k_irq_clear_pending(WDT_IRQ_NUM);
 	irq_enable(WDT_IRQ_NUM);
 }
 
@@ -151,7 +152,7 @@ static bool wdt_lpm_continue(void)
 	}
 
 	Cy_WDT_ClearInterrupt();
-	NVIC_ClearPendingIRQ(WDT_IRQ_NUM);
+	k_irq_clear_pending(WDT_IRQ_NUM);
 	wdt_lpm_arm_window(now_value, wdt_target_cycles - wdt_elapsed_cycles);
 
 	return true;
@@ -168,7 +169,7 @@ uint64_t z_sys_clock_lpm_exit(void)
 	Cy_WDT_ClearInterrupt();
 
 	irq_disable(WDT_IRQ_NUM);
-	NVIC_ClearPendingIRQ(WDT_IRQ_NUM);
+	k_irq_clear_pending(WDT_IRQ_NUM);
 
 	total_cycles = wdt_elapsed_cycles + ((end_count - wdt_start_count) & UINT16_MAX);
 


### PR DESCRIPTION
- **drivers: counter: infineon: use portable IRQ pending API**
- **drivers: serial: infineon_pdl: use portable IRQ pending API**
- **soc: infineon: use portable IRQ pending API**
