### PR TITLE
renesas-ra: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/counter/counter_renesas_ra_agt.c
+++ b/drivers/counter/counter_renesas_ra_agt.c
@@ -265,7 +265,7 @@ static int renesas_ra_agt_abs_alarm_set(const struct device *dev, uint32_t val, 
 	max_val = ticks_sub(read_again + top, data->guard_period, top);
 	if (val > max_val) {
 		if (irq_on_late) {
-			NVIC_SetPendingIRQ(data->agtcmai_irq);
+			k_irq_set_pending(data->agtcmai_irq);
 		} else {
 			data->alarm_cb = NULL;
 		}
@@ -314,7 +314,7 @@ static int renesas_ra_agt_rel_alarm_set(const struct device *dev, uint32_t val, 
 
 	if (diff > max_rel_val || diff == 0) {
 		if (irq_on_late) {
-			NVIC_SetPendingIRQ(data->agtcmai_irq);
+			k_irq_set_pending(data->agtcmai_irq);
 		} else {
 			data->alarm_cb = NULL;
 		}
@@ -391,7 +391,7 @@ static int counter_renesas_ra_agt_cancel_alarm(const struct device *dev, uint8_t
 	}
 
 	irq_disable(data->agtcmai_irq);
-	NVIC_ClearPendingIRQ(data->agtcmai_irq);
+	k_irq_clear_pending(data->agtcmai_irq);
 	data->alarm_cb = NULL;
 	data->alarm_data = NULL;
 out:

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -466,14 +466,14 @@ static void uart_ra_sci_b_irq_err_enable(const struct device *dev)
 {
 	struct uart_ra_sci_b_data *data = dev->data;
 
-	NVIC_EnableIRQ(data->fsp_config.eri_irq);
+	irq_enable(data->fsp_config.eri_irq);
 }
 
 static void uart_ra_sci_b_irq_err_disable(const struct device *dev)
 {
 	struct uart_ra_sci_b_data *data = dev->data;
 
-	NVIC_DisableIRQ(data->fsp_config.eri_irq);
+	irq_disable(data->fsp_config.eri_irq);
 }
 
 static int uart_ra_sci_b_irq_is_pending(const struct device *dev)

--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -434,14 +434,14 @@ static void uart_ra_sci_irq_err_enable(const struct device *dev)
 {
 	struct uart_ra_sci_data *data = dev->data;
 
-	NVIC_EnableIRQ(data->fsp_config.eri_irq);
+	irq_enable(data->fsp_config.eri_irq);
 }
 
 static void uart_ra_sci_irq_err_disable(const struct device *dev)
 {
 	struct uart_ra_sci_data *data = dev->data;
 
-	NVIC_DisableIRQ(data->fsp_config.eri_irq);
+	irq_disable(data->fsp_config.eri_irq);
 }
 
 static int uart_ra_sci_irq_is_pending(const struct device *dev)


### PR DESCRIPTION
- **drivers: counter: renesas_ra_agt: use portable IRQ pending API**
- **drivers: serial: renesas_ra: use portable IRQ pending API**
