### PR TITLE
stm: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/counter/counter_stm32_rtc.c
+++ b/drivers/counter/counter_stm32_rtc.c
@@ -525,7 +525,7 @@ static int rtc_stm32_get_value_64(const struct device *dev, uint64_t *ticks)
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
 static void rtc_stm32_set_int_pending(void)
 {
-	NVIC_SetPendingIRQ(DT_INST_IRQN(0));
+	k_irq_set_pending(DT_INST_IRQN(0));
 }
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 

--- a/drivers/counter/counter_stm32_timer.c
+++ b/drivers/counter/counter_stm32_timer.c
@@ -14,9 +14,6 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/drivers/counter/stm32.h>
 #include <zephyr/drivers/pinctrl.h>
-#if defined(CONFIG_GIC)
-#include <zephyr/drivers/interrupt_controller/gic.h>
-#endif /* CONFIG_GIC */
 #include <stm32_ll_tim.h>
 #include <stm32_ll_rcc.h>
 
@@ -223,22 +220,13 @@ static uint32_t counter_stm32_ticks_sub(uint32_t val, uint32_t old, uint32_t top
 	return (val >= old) ? (val - old) : val + top + 1U - old;
 }
 
-static void counter_stm32_set_pending(unsigned int irq)
-{
-#if defined(CONFIG_GIC)
-	arm_gic_irq_set_pending(irq);
-#else  /* NVIC */
-	NVIC_SetPendingIRQ(irq);
-#endif /* CONFIG_GIC */
-}
-
 static void counter_stm32_counter_stm32_set_cc_int_pending(const struct device *dev, uint8_t chan)
 {
 	const struct counter_stm32_config *config = dev->config;
 	struct counter_stm32_data *data = dev->data;
 
 	atomic_or(&data->cc_int_pending, BIT(chan));
-	counter_stm32_set_pending(config->irqn);
+	k_irq_set_pending(config->irqn);
 }
 
 static int counter_stm32_set_cc(const struct device *dev, uint8_t id,

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -473,7 +473,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 	 * to 1 (the bit is set when NVIC pending IRQ status is
 	 * changed from 0 to 1)
 	 */
-	NVIC_ClearPendingIRQ(IRQN);
+	k_irq_clear_pending(IRQN);
 #endif /* !IRQLESS_TRNG */
 
 	do {
@@ -503,7 +503,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 
 		ret = random_sample_get(&rnd_sample);
 #if !IRQLESS_TRNG
-		NVIC_ClearPendingIRQ(IRQN);
+		k_irq_clear_pending(IRQN);
 #endif /* !IRQLESS_TRNG */
 
 		if (ret < 0) {

--- a/drivers/lora/loramac-node/sx126x_stm32wl.c
+++ b/drivers/lora/loramac-node/sx126x_stm32wl.c
@@ -41,7 +41,7 @@ uint32_t sx126x_get_dio1_pin_state(struct sx126x_data *dev_data)
 
 void sx126x_dio1_irq_enable(struct sx126x_data *dev_data)
 {
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 	irq_enable(DT_INST_IRQN(0));
 }
 

--- a/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
@@ -85,7 +85,7 @@ int sx126x_hal_set_dio1_callback(const struct device *dev,
 	data->dio1_callback = callback;
 
 	if (callback != NULL) {
-		NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+		k_irq_clear_pending(DT_INST_IRQN(0));
 		irq_enable(DT_INST_IRQN(0));
 	} else {
 		irq_disable(DT_INST_IRQN(0));
@@ -105,7 +105,7 @@ void sx126x_hal_dio1_irq_enable(const struct device *dev)
 	 * can wake the radio from a duty-cycle sleep phase and
 	 * abort the cycle.
 	 */
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 	irq_enable(DT_INST_IRQN(0));
 }
 

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -369,7 +369,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 		LL_LPTIM_DisableIT_ARROK(LPTIM);
 		LL_LPTIM_ClearFlag_ARROK(LPTIM);
-		NVIC_ClearPendingIRQ(DT_IRQN(LPTIM_SYSTIMER_NODE));
+		k_irq_clear_pending(DT_IRQN(LPTIM_SYSTIMER_NODE));
 		/* Stop clocks for LPTIM, since RTC is used instead */
 		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 


### PR DESCRIPTION
- **drivers: entropy: stm32: use portable IRQ pending API**
- **drivers: counter: stm32_rtc: use portable IRQ pending API**
- **drivers: counter: stm32_timer: use portable IRQ pending API**
- **drivers: timer: stm32_lptim: use portable IRQ pending API**
- **drivers: lora: stm32wl: use portable IRQ pending API**
