### PR TITLE
realtek-rts5912: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/adc/adc_realtek_rts5912.c
+++ b/drivers/adc/adc_realtek_rts5912.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT realtek_rts5912_adc
 
+#include <zephyr/irq.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/clock_control_rts5912.h>
@@ -262,7 +263,7 @@ static int adc_rts5912_init(const struct device *dev)
 
 	regs->ctrl = ADC_CTRL_RST;
 
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), adc_rts5912_single_isr,
 		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));

--- a/drivers/counter/counter_realtek_rts5912.c
+++ b/drivers/counter/counter_realtek_rts5912.c
@@ -22,6 +22,7 @@
  *   when the counters reach zero.
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
@@ -349,7 +350,7 @@ static int counter_rts5912_init(const struct device *dev)
                                                                                                    \
 	static void counter_rts5912_irq_config_##inst(void)                                        \
 	{                                                                                          \
-		NVIC_ClearPendingIRQ(DT_INST_IRQN(inst));                                          \
+		k_irq_clear_pending(DT_INST_IRQN(inst));                                          \
 		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), counter_rts5912_isr,  \
 			    DEVICE_DT_INST_GET(inst), 0);                                          \
 		irq_enable(DT_INST_IRQN(inst));                                                    \

--- a/drivers/espi/espi_realtek_rts5912.c
+++ b/drivers/espi/espi_realtek_rts5912.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT realtek_rts5912_espi
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/espi.h>
 #include <zephyr/drivers/gpio.h>
@@ -184,8 +185,8 @@ static int espi_kbc_setup(const struct device *dev)
 	kbc_reg->VWCTRL1 = (0x01 << KBC_VWCTRL1_IRQNUM_Pos) | KBC_VWCTRL1_ACTEN;
 	kbc_reg->INTEN = KBC_INTEN_IBFINTEN | KBC_INTEN_OBFINTEN;
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_ibf, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_obe, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_ibf, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_obe, irq));
 
 	/* IBF */
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_ibf, irq),
@@ -381,7 +382,7 @@ static int espi_acpi_setup(const struct device *dev)
 	acpi_reg->VWCTRL1 = (0x00UL << ACPI_VWCTRL1_IRQNUM_Pos) | ACPI_VWCTRL1_ACTEN;
 	acpi_reg->INTEN = ACPI_INTEN_IBFINTEN;
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), acpi_ibf, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), acpi_ibf, irq));
 
 	/* IBF */
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), acpi_ibf, irq),
@@ -526,7 +527,7 @@ static int espi_promt0_setup(const struct device *dev)
 	promt0_reg->VWCTRL1 = ACPI_VWCTRL1_ACTEN;
 	promt0_reg->INTEN = ACPI_INTEN_IBFINTEN;
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), promt0_ibf, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), promt0_ibf, irq));
 
 	/* IBF */
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), promt0_ibf, irq),
@@ -615,18 +616,18 @@ static int lpc_request_write_custom(const struct espi_rts5912_config *const espi
 	switch (op) {
 	case ECUSTOM_HOST_SUBS_INTERRUPT_EN:
 		if (*data == 0) {
-			NVIC_DisableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), promt0_ibf, irq)));
-			NVIC_DisableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), acpi_ibf, irq)));
-			NVIC_DisableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, irq)));
-			NVIC_DisableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_ibf, irq)));
-			NVIC_DisableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_obe, irq)));
+			irq_disable((DT_IRQ_BY_NAME(DT_DRV_INST(0), promt0_ibf, irq)));
+			irq_disable((DT_IRQ_BY_NAME(DT_DRV_INST(0), acpi_ibf, irq)));
+			irq_disable((DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, irq)));
+			irq_disable((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_ibf, irq)));
+			irq_disable((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_obe, irq)));
 
 		} else {
-			NVIC_EnableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), promt0_ibf, irq)));
-			NVIC_EnableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), acpi_ibf, irq)));
-			NVIC_EnableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, irq)));
-			NVIC_EnableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_ibf, irq)));
-			NVIC_EnableIRQ((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_obe, irq)));
+			irq_enable((DT_IRQ_BY_NAME(DT_DRV_INST(0), promt0_ibf, irq)));
+			irq_enable((DT_IRQ_BY_NAME(DT_DRV_INST(0), acpi_ibf, irq)));
+			irq_enable((DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, irq)));
+			irq_enable((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_ibf, irq)));
+			irq_enable((DT_IRQ_BY_NAME(DT_DRV_INST(0), kbc_obe, irq)));
 		}
 		break;
 	case ECUSTOM_HOST_CMD_SEND_RESULT:
@@ -666,7 +667,7 @@ static void espi_periph_ch_setup(const struct device *dev)
 
 	espi_reg->EPINTEN = ESPI_EPINTEN_CFGCHGEN | ESPI_EPINTEN_MEMWREN | ESPI_EPINTEN_MEMRDEN;
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), periph_ch, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), periph_ch, irq));
 
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), periph_ch, irq),
 		    DT_IRQ_BY_NAME(DT_DRV_INST(0), periph_ch, priority), espi_periph_ch_isr,
@@ -727,7 +728,7 @@ static int espi_peri_ch_port80_setup(const struct device *dev)
 	port80_reg->CFG = PORT80_CFG_CLRFLG | PORT80_CFG_THREEN;
 	port80_reg->INTEN = PORT80_INTEN_THREINTEN;
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, irq));
 
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, irq),
 		    DT_IRQ_BY_NAME(DT_DRV_INST(0), port80, priority), espi_port80_isr,
@@ -1598,18 +1599,18 @@ static void espi_vw_ch_setup(const struct device *dev, bool first_init)
 
 	espi_reg->EVRXINTEN = (ESPI_EVRXINTEN_CFGCHGEN | ESPI_EVRXINTEN_RXCHGEN);
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_ch, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx2, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx3, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx7, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx41, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx42, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx43, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx44, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx47, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx4a, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx51, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx61, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_ch, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx2, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx3, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx7, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx41, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx42, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx43, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx44, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx47, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx4a, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx51, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_idx61, irq));
 
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_ch, irq),
 		    DT_IRQ_BY_NAME(DT_DRV_INST(0), vw_ch, priority), espi_vw_ch_isr,
@@ -1958,9 +1959,9 @@ static int espi_oob_ch_setup(const struct device *dev)
 	k_sem_init(&espi_data->oob_rx_lock, 0, 1);
 #endif
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), oob_tx, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), oob_rx, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), oob_chg, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), oob_tx, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), oob_rx, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), oob_chg, irq));
 
 	/* Tx */
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), oob_tx, irq),
@@ -2175,8 +2176,8 @@ static int espi_flash_ch_setup(const struct device *dev)
 
 	k_sem_init(&espi_data->flash_lock, 0, 1);
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), maf_tr, irq));
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), flash_chg, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), maf_tr, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), flash_chg, irq));
 
 	/* MAF Tr */
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), maf_tr, irq),
@@ -2442,7 +2443,7 @@ static void espi_bus_reset_setup(const struct device *dev)
 	 */
 	espi_reg->ERSTCFG |= ESPI_ERSTCFG_RSTSTS;
 
-	NVIC_ClearPendingIRQ(DT_IRQ_BY_NAME(DT_DRV_INST(0), bus_rst, irq));
+	k_irq_clear_pending(DT_IRQ_BY_NAME(DT_DRV_INST(0), bus_rst, irq));
 
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), bus_rst, irq),
 		    DT_IRQ_BY_NAME(DT_DRV_INST(0), bus_rst, priority), espi_rst_isr,
@@ -2564,7 +2565,7 @@ static int espi_rts5912_init(const struct device *dev)
 	static struct gpio_callback cb;
 	uint32_t cs_irq_nun = gpio_rts5912_get_pin_num(&espi_config->cs_pin);
 
-	NVIC_ClearPendingIRQ(cs_irq_nun);
+	k_irq_clear_pending(cs_irq_nun);
 	gpio_init_callback(&cb, espi_cs_low_isr, BIT(espi_config->cs_pin.pin));
 	gpio_add_callback(espi_config->cs_pin.port, &cb);
 	irq_enable(cs_irq_nun);

--- a/drivers/input/input_realtek_rts5912_kbd.c
+++ b/drivers/input/input_realtek_rts5912_kbd.c
@@ -148,7 +148,7 @@ static int rts5912_kbd_init(const struct device *dev)
 
 	rts5912_intc_isr_clear(dev);
 
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), rts5912_kbd_isr,
 		    DEVICE_DT_INST_GET(0), 0);

--- a/drivers/serial/uart_realtek_rts5912.c
+++ b/drivers/serial/uart_realtek_rts5912.c
@@ -7,6 +7,7 @@
 
 #define DT_DRV_COMPAT realtek_rts5912_uart
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
@@ -93,7 +94,7 @@ static void uart_rts5912_pm_state_exit(const struct device *dev, enum pm_state s
 			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 			k_work_reschedule(&rx_refresh_timeout_work, delay);
 		}
-		NVIC_ClearPendingIRQ(dev_data->rx_wakeup_pin_num);
+		k_irq_clear_pending(dev_data->rx_wakeup_pin_num);
 		irq_disable(dev_data->rx_wakeup_pin_num);
 		break;
 	default:

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -204,7 +204,7 @@ static int sys_clock_driver_init(void)
 {
 	/* Enable RTMR clock power */
 	RTMR_REG->INTSTS = RTOSTMR_INTSTS_STS_Msk;
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 
 	SYSTEM_Type *sys_reg = RTS5912_SCCON_REG_BASE;
 

--- a/drivers/watchdog/wdt_rts5912.c
+++ b/drivers/watchdog/wdt_rts5912.c
@@ -225,7 +225,7 @@ static int wdt_rts5912_init(const struct device *dev)
 	wdt_reg->DIV = cfg->div;
 
 	wdt_reg->CTRL |= WDT_CTRL_CLRRSTFLAG;
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 
 	IRQ_CONNECT(DT_INST_IRQN(0), 0, wdt_rts5912_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));


### PR DESCRIPTION
- **drivers: adc: rts5912: use portable IRQ pending API**
- **drivers: counter: rts5912: use portable IRQ pending API**
- **drivers: espi: rts5912: use portable IRQ pending API**
- **drivers: input: rts5912: use portable IRQ pending API**
- **drivers: serial: rts5912: use portable IRQ pending API**
- **drivers: timer: rts5912: use portable IRQ pending API**
- **drivers: watchdog: rts5912: use portable IRQ pending API**
