### PR TITLE
smartbond: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/adc/adc_smartbond_gpadc.c
+++ b/drivers/adc/adc_smartbond_gpadc.c
@@ -381,8 +381,8 @@ static int adc_smartbond_init(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    adc_smartbond_isr, DEVICE_DT_INST_GET(0), 0);
 
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
-	NVIC_EnableIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
+	irq_enable(DT_INST_IRQN(0));
 
 	adc_context_unlock_unconditionally(&data->ctx);
 

--- a/drivers/adc/adc_smartbond_sdadc.c
+++ b/drivers/adc/adc_smartbond_sdadc.c
@@ -385,8 +385,8 @@ static int sdadc_smartbond_init(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    sdadc_smartbond_isr, DEVICE_DT_INST_GET(0), 0);
 
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
-	NVIC_EnableIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
+	irq_enable(DT_INST_IRQN(0));
 
 	adc_context_unlock_unconditionally(&data->ctx);
 

--- a/drivers/bluetooth/hci/hci_da1469x.c
+++ b/drivers/bluetooth/hci/hci_da1469x.c
@@ -194,7 +194,7 @@ static void rx_isr_start(void)
 {
 	if (rx.deferred) {
 		rx.deferred = false;
-		NVIC_SetPendingIRQ(CMAC2SYS_IRQn);
+		k_irq_set_pending(CMAC2SYS_IRQn);
 	}
 
 	irq_enable(CMAC2SYS_IRQn);

--- a/drivers/counter/counter_smartbond_timer.c
+++ b/drivers/counter/counter_smartbond_timer.c
@@ -269,7 +269,7 @@ static int counter_smartbond_set_alarm(const struct device *dev, uint8_t chan,
 		 * for absolute depending on the flag.
 		 */
 		if (irq_on_late) {
-			NVIC_SetPendingIRQ(config->irqn);
+			k_irq_set_pending(config->irqn);
 		} else {
 			data->callback = NULL;
 		}
@@ -280,7 +280,7 @@ static int counter_smartbond_set_alarm(const struct device *dev, uint8_t chan,
 			 * should be triggered. No need to enable interrupt
 			 * on TIMER just make sure interrupt is pending.
 			 */
-			NVIC_SetPendingIRQ(config->irqn);
+			k_irq_set_pending(config->irqn);
 		} else {
 			timer->TIMER2_CTRL_REG |= TIMER2_TIMER2_CTRL_REG_TIM_IRQ_EN_Msk;
 		}
@@ -322,7 +322,7 @@ static uint32_t counter_smartbond_get_pending_int(const struct device *dev)
 	/* There is no register to check TIMER peripheral to check for interrupt
 	 * pending, check directly in NVIC.
 	 */
-	return NVIC_GetPendingIRQ(config->irqn);
+	return k_irq_is_pending(config->irqn);
 }
 
 static int counter_smartbond_init_timer(const struct device *dev)

--- a/drivers/entropy/entropy_smartbond.c
+++ b/drivers/entropy/entropy_smartbond.c
@@ -94,7 +94,7 @@ static void trng_enable(bool enable)
 	} else {
 		CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_TRNG_CLK_ENABLE_Msk;
 		TRNG->TRNG_CTRL_REG = 0;
-		NVIC_ClearPendingIRQ(IRQN);
+		k_irq_clear_pending(IRQN);
 
 		entropy_smartbond_pm_policy_state_lock_put();
 	}
@@ -323,7 +323,7 @@ static int entropy_smartbond_get_entropy_isr(const struct device *dev, uint8_t *
 		 * to 1 (the bit is set when NVIC pending IRQ status is
 		 * changed from 0 to 1)
 		 */
-		NVIC_ClearPendingIRQ(IRQN);
+		k_irq_clear_pending(IRQN);
 
 		do {
 			uint8_t bytes[4];
@@ -345,7 +345,7 @@ static int entropy_smartbond_get_entropy_isr(const struct device *dev, uint8_t *
 				__WFE();
 			}
 
-			NVIC_ClearPendingIRQ(IRQN);
+			k_irq_clear_pending(IRQN);
 			if (random_word_get(bytes) != 0) {
 				continue;
 			}

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -10,7 +10,6 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
-#include <cmsis_core.h>
 #include <zephyr/irq.h>
 #include <da1469x_pdc.h>
 
@@ -103,7 +102,7 @@ static void schedule_next_interrupt(uint32_t ticks)
 	 * not but time expired anyway so make sure that interrupt is pending.
 	 */
 	if ((int32_t)(target_val - timer_val_32_noupdate() - 1) < 0) {
-		NVIC_SetPendingIRQ(TIMER2_IRQn);
+		k_irq_set_pending(TIMER2_IRQn);
 	}
 }
 

--- a/drivers/usb/device/usb_dc_smartbond.c
+++ b/drivers/usb/device/usb_dc_smartbond.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <zephyr/irq.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/usb/usb_dc.h>
 #include <zephyr/init.h>
@@ -1152,7 +1153,7 @@ static int usb_init(void)
 
 	IRQ_CONNECT(VBUS_IRQ, VBUS_IRQ_PRI, usb_dc_smartbond_vbus_isr, 0, 0);
 	CRG_TOP->VBUS_IRQ_CLEAR_REG = 1;
-	NVIC_ClearPendingIRQ(VBUS_IRQ);
+	k_irq_clear_pending(VBUS_IRQ);
 	/* Both connect and disconnect needs to be handled */
 	CRG_TOP->VBUS_IRQ_MASK_REG = CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_FALL_Msk |
 				     CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_RISE_Msk;

--- a/drivers/usb/udc/udc_smartbond.c
+++ b/drivers/usb/udc/udc_smartbond.c
@@ -15,6 +15,7 @@
 #include <DA1469xAB.h>
 #include <da1469x_config.h>
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/usb/udc.h>
@@ -1613,7 +1614,7 @@ static int udc_smartbond_init(const struct device *dev)
 	/* Both connect and disconnect needs to be handled */
 	CRG_TOP->VBUS_IRQ_MASK_REG = CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_FALL_Msk |
 				     CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_RISE_Msk;
-	NVIC_SetPendingIRQ(config->vbus_irq);
+	k_irq_set_pending(config->vbus_irq);
 	irq_enable(config->vbus_irq);
 
 	return 0;


### PR DESCRIPTION
- **drivers: adc: smartbond: use portable IRQ pending API**
- **drivers: entropy: smartbond: use portable IRQ pending API**
- **drivers: counter: smartbond: use portable IRQ pending API**
- **drivers: timer: smartbond: use portable IRQ pending API**
- **drivers: usb: smartbond: use portable IRQ pending API**
- **drivers: bluetooth: hci_da1469x: use portable IRQ pending API**
