### PR TITLE
nuvoton-npcx: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -124,7 +124,7 @@ static int peci_npcx_enable(const struct device *dev)
 
 	reg->PECI_CTL_STS = BIT(NPCX_PECI_CTL_STS_DONE) | BIT(NPCX_PECI_CTL_STS_CRC_ERR) |
 			    BIT(NPCX_PECI_CTL_STS_ABRT_ERR);
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 	irq_enable(DT_INST_IRQN(0));
 
 	k_sem_give(&data->lock);

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -6,6 +6,7 @@
 
 #include "ec_host_cmd_backend_shi.h"
 
+#include <zephyr/irq.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>
@@ -851,7 +852,7 @@ static int shi_npcx_enable(const struct device *dev)
 		return ret;
 	}
 
-	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+	k_irq_clear_pending(DT_INST_IRQN(0));
 	/*
 	 * Clear the pending bit because switching the pinmux (pinctrl) might cause a faking WUI
 	 * pending bit set.


### PR DESCRIPTION
- **drivers: peci: npcx: use portable IRQ pending API**
- **mgmt: ec_host_cmd: shi_npcx: use portable IRQ pending API**
