### PR TITLE
drivers: counter: mchp_g1: use portable IRQ pending API

### DIFF
--- a/drivers/counter/counter_mchp_rtc_g1.c
+++ b/drivers/counter/counter_mchp_rtc_g1.c
@@ -819,7 +819,7 @@ static int32_t counter_mchp_set_alarm(const struct device *const dev, const uint
 				data->channel_data[chan_id].compare_value = ticks;
 
 				/* Enable interrupt and trigger immediately */
-				NVIC_SetPendingIRQ(cfg->irq_line);
+				k_irq_set_pending(cfg->irq_line);
 			} else {
 				data->channel_data[chan_id].callback = NULL;
 				data->channel_data[chan_id].user_data = NULL;
@@ -1018,7 +1018,7 @@ static void counter_mchp_alarm_irq_handler(const struct device *const dev)
 	struct counter_mchp_dev_data *const data = dev->data;
 	const struct counter_mchp_dev_config *const cfg = dev->config;
 
-	NVIC_ClearPendingIRQ(cfg->irq_line);
+	k_irq_clear_pending(cfg->irq_line);
 	pending_irq_status = rtc_counter_get_pending_irqs(cfg->regs, cfg->max_bit_width);
 
 	/* Check for immediate interrupt trigger */
@@ -1064,7 +1064,7 @@ static void counter_mchp_top_irq_handler(const struct device *const dev)
 	const struct counter_mchp_dev_config *const cfg = dev->config;
 	uint32_t pending_irq_status = rtc_counter_get_pending_irqs(cfg->regs, cfg->max_bit_width);
 
-	NVIC_ClearPendingIRQ(cfg->irq_line);
+	k_irq_clear_pending(cfg->irq_line);
 	if (false != rtc_counter_top_irq_status(pending_irq_status, cfg->max_bit_width)) {
 		rtc_counter_top_irq_clear(cfg->regs, cfg->max_bit_width);
 

--- a/drivers/counter/counter_mchp_tc_g1.c
+++ b/drivers/counter/counter_mchp_tc_g1.c
@@ -1150,7 +1150,7 @@ static int32_t counter_mchp_set_alarm(const struct device *const dev, const uint
 				data->late_alarm_flag = true;
 				data->late_alarm_channel = chan_id;
 				data->channel_data[chan_id].compare_value = ticks;
-				NVIC_SetPendingIRQ(cfg->irq_line);
+				k_irq_set_pending(cfg->irq_line);
 			} else {
 				data->channel_data[chan_id].callback = NULL;
 				data->channel_data[chan_id].user_data = NULL;
@@ -1336,7 +1336,7 @@ static void counter_mchp_alarm_irq_handler(const struct device *const dev)
 	const struct counter_mchp_dev_config *const cfg = dev->config;
 	uint32_t pending_irq_status = 0u;
 
-	NVIC_ClearPendingIRQ(cfg->irq_line);
+	k_irq_clear_pending(cfg->irq_line);
 	pending_irq_status = tc_counter_get_pending_irqs(cfg->regs, cfg->max_bit_width);
 
 	/* Check for immediate interrupt trigger */
@@ -1382,7 +1382,7 @@ static void counter_mchp_top_irq_handler(const struct device *const dev)
 	const struct counter_mchp_dev_config *const cfg = dev->config;
 	uint32_t pending_irq_status = 0u;
 
-	NVIC_ClearPendingIRQ(cfg->irq_line);
+	k_irq_clear_pending(cfg->irq_line);
 	pending_irq_status = tc_counter_get_pending_irqs(cfg->regs, cfg->max_bit_width);
 
 	if (0 != tc_counter_top_irq_status(pending_irq_status, cfg->max_bit_width)) {

--- a/drivers/counter/counter_mchp_tcc_g1.c
+++ b/drivers/counter/counter_mchp_tcc_g1.c
@@ -411,9 +411,9 @@ static int32_t counter_mchp_set_alarm(const struct device *const dev, const uint
 
 				/* Enable interrupt and trigger immediately */
 #if defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
-				NVIC_SetPendingIRQ(cfg->irq_line);
+				k_irq_set_pending(cfg->irq_line);
 #else
-				NVIC_SetPendingIRQ(cfg->channel_irq_map->comp_irq_line[chan_id]);
+				k_irq_set_pending(cfg->channel_irq_map->comp_irq_line[chan_id]);
 #endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 			} else {
 				data->channel_data[chan_id].callback = NULL;
@@ -459,9 +459,9 @@ static int32_t counter_mchp_cancel_alarm(const struct device *const dev, uint8_t
 
 /* Clear NVIC Flag to avoid retrigger */
 #if defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH)
-	NVIC_ClearPendingIRQ(cfg->irq_line);
+	k_irq_clear_pending(cfg->irq_line);
 #else
-	NVIC_ClearPendingIRQ(cfg->channel_irq_map->comp_irq_line[chan_id]);
+	k_irq_clear_pending(cfg->channel_irq_map->comp_irq_line[chan_id]);
 #endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 
 	return 0;
@@ -683,7 +683,7 @@ static inline void counter_mchp_irq_0_handle(const struct device *const dev)
 	struct counter_mchp_dev_data *const data = dev->data;
 	const struct counter_mchp_dev_config *const cfg = dev->config;
 
-	NVIC_ClearPendingIRQ(cfg->channel_irq_map->ovf_irq_line);
+	k_irq_clear_pending(cfg->channel_irq_map->ovf_irq_line);
 	tcc_counter_top_irq_clear(cfg->regs);
 
 	if (data->top_cb != NULL) {


### PR DESCRIPTION
Replace direct NVIC_SetPendingIRQ()/NVIC_ClearPendingIRQ() calls with
k_irq_set_pending()/k_irq_clear_pending(), dropping the dependency on
cmsis_core.h where nothing else needed it. These platforms are
plain-NVIC Cortex-M, so the pending-state capabilities are always
available where this code builds.

