### PR TITLE
realtek-bee: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/counter/counter_bee_rtc.c
+++ b/drivers/counter/counter_bee_rtc.c
@@ -319,11 +319,11 @@ static DEVICE_API(counter, counter_bee_rtc_driver_api) = {
 	RTC_IRQ_CONFIG_FUNC(index);                                                                \
 	static void set_irq_pending_##index(void)                                                  \
 	{                                                                                          \
-		(NVIC_SetPendingIRQ(DT_INST_IRQN(index)));                                         \
+		(k_irq_set_pending(DT_INST_IRQN(index)));                                         \
 	}                                                                                          \
 	static uint32_t get_irq_pending_##index(void)                                              \
 	{                                                                                          \
-		return NVIC_GetPendingIRQ(DT_INST_IRQN(index));                                    \
+		return k_irq_is_pending(DT_INST_IRQN(index));                                    \
 	}
 
 #define BEE_RTC_INIT(index)                                                                        \

--- a/drivers/counter/counter_bee_timer.c
+++ b/drivers/counter/counter_bee_timer.c
@@ -346,7 +346,7 @@ static DEVICE_API(counter, counter_bee_timer_driver_api) = {
 	TIMER_IRQ_HANDLER(index);                                                                  \
 	static uint32_t get_irq_pending_##index(void)                                              \
 	{                                                                                          \
-		return NVIC_GetPendingIRQ(DT_IRQN(PARENT_NODE(index)));                            \
+		return k_irq_is_pending(DT_IRQN(PARENT_NODE(index)));                            \
 	}
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)

--- a/drivers/watchdog/wdt_bee_core.c
+++ b/drivers/watchdog/wdt_bee_core.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT realtek_bee_core_wdt
 
+#include <zephyr/irq.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/clock.h>
@@ -180,7 +181,7 @@ static int core_wdt_bee_init(const struct device *dev)
 	nvic_init_struct.NVIC_IRQChannelPriority = 0;
 	NVIC_Init(&nvic_init_struct);
 #else
-	NVIC_ClearPendingIRQ(config->irq_num);
+	k_irq_clear_pending(config->irq_num);
 	config->cfg_func();
 #endif
 

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/reboot.h>
@@ -60,11 +61,11 @@ static void rtl8752h_isr_register(void)
 		uint32_t expected_zephyr_isr = FlashVectorTable_INT[irq];
 
 		if (current_isr != expected_zephyr_isr) {
-			if (NVIC_GetEnableIRQ(irq) == 1) {
-				NVIC_DisableIRQ(irq);
+			if (irq_is_enabled(irq) != 0) {
+				irq_disable(irq);
 				z_isr_install(irq, (void *)current_isr, NULL);
 				RamVectorTableUpdate(irq + 16, (IRQ_Fun)_isr_wrapper);
-				NVIC_EnableIRQ(irq);
+				irq_enable(irq);
 			} else {
 				z_isr_install(irq, (void *)current_isr, NULL);
 				RamVectorTableUpdate(irq + 16, (IRQ_Fun)_isr_wrapper);

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/common/init.h>
 #include <zephyr/sys/reboot.h>
@@ -116,11 +117,11 @@ static void rtl87x2g_isr_register(void)
 		uint32_t expected_zephyr_isr = FlashVectorTable_INT[irq];
 
 		if (current_isr != expected_zephyr_isr) {
-			if (NVIC_GetEnableIRQ(irq) == 1) {
-				NVIC_DisableIRQ(irq);
+			if (irq_is_enabled(irq) != 0) {
+				irq_disable(irq);
 				z_isr_install(irq, (void *)current_isr, NULL);
 				RamVectorTableUpdate(irq + 16, (IRQ_Fun)_isr_wrapper);
-				NVIC_EnableIRQ(irq);
+				irq_enable(irq);
 			} else {
 				z_isr_install(irq, (void *)current_isr, NULL);
 				RamVectorTableUpdate(irq + 16, (IRQ_Fun)_isr_wrapper);


### PR DESCRIPTION
- **drivers: counter: bee: use portable IRQ pending API**
- **drivers: watchdog: bee: use portable IRQ pending API**
- **soc: realtek: bee: use portable IRQ pending API**
