### PR TITLE
microchip-xec: use portable IRQ pending API in drivers/socs

### DIFF
--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -6,7 +6,6 @@
 
 #define DT_DRV_COMPAT microchip_xec_kbd
 
-#include <cmsis_core.h>
 #include <errno.h>
 #include <soc.h>
 #include <zephyr/device.h>
@@ -90,7 +89,7 @@ static void xec_kbd_set_detect_mode(const struct device *dev, bool enabled)
 		sys_write32(MCHP_KSCAN_KSO_SEL_REG_MASK, base + XEC_KBD_KSI_STS_OFS);
 
 		soc_ecia_girq_status_clear(cfg->girq, cfg->girq_pos);
-		NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+		k_irq_clear_pending(DT_INST_IRQN(0));
 		irq_enable(DT_INST_IRQN(0));
 	} else {
 		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE,

--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -187,7 +187,7 @@ static int peci_xec_disable(const struct device *dev)
 
 #ifdef CONFIG_PECI_INTERRUPT_DRIVEN
 	peci_girq_status_clear(dev);
-	NVIC_ClearPendingIRQ(cfg->irq_num);
+	k_irq_clear_pending(cfg->irq_num);
 	irq_disable(cfg->irq_num);
 #endif
 	regs->CONTROL |= MCHP_PECI_CTRL_PD;

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -207,7 +207,7 @@ static int ps2_xec_inhibit_interface(const struct device *dev)
 	regs->CTRL = 0x00;
 	regs->STATUS = MCHP_PS2_STATUS_RW1C_MASK;
 	ps2_xec_girq_clr(config->girq_id, config->girq_bit);
-	NVIC_ClearPendingIRQ(config->isr_nvic);
+	k_irq_clear_pending(config->isr_nvic);
 
 	k_sem_give(&data->tx_lock);
 

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT microchip_xec_qmspi
 
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(spi_xec, CONFIG_SPI_LOG_LEVEL);
 
@@ -645,7 +646,7 @@ static int qmspi_init(const struct device *dev)
 	MCHP_GIRQ_SRC_CLR(cfg->girq, cfg->girq_pos);
 
 	MCHP_GIRQ_BLK_CLREN(cfg->girq);
-	NVIC_ClearPendingIRQ(cfg->girq_nvic_direct);
+	k_irq_clear_pending(cfg->girq_nvic_direct);
 
 	err = spi_context_cs_configure_all(&data->ctx);
 	if (err < 0) {

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -13,7 +13,6 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>
-#include <cmsis_core.h>
 #include <zephyr/irq.h>
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_SMP), "XEC RTOS timer doesn't support SMP");
@@ -293,7 +292,7 @@ static int sys_clock_driver_init(void)
 	sys_write32(0, TIMER_BASE + TIMER_CR_OFS);
 	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_ENCLR_OFS);
 	sys_write32(BIT(TIMER_GIRQ_BITPOS), TIMER_GIRQ_BASE + GIRQ_SRC_OFS);
-	NVIC_ClearPendingIRQ(TIMER_NVIC_NO);
+	k_irq_clear_pending(TIMER_NVIC_NO);
 
 	IRQ_CONNECT(TIMER_NVIC_NO, TIMER_NVIC_PRIO, xec_rtos_timer_isr, 0, 0);
 	irq_enable(TIMER_NVIC_NO);


### PR DESCRIPTION
- **drivers: spi: xec_qmspi: use portable IRQ pending API**
- **drivers: input: xec_kbd: use portable IRQ pending API**
- **drivers: peci: xec: use portable IRQ pending API**
- **drivers: ps2: xec: use portable IRQ pending API**
- **drivers: timer: mchp_xec_rtos: use portable IRQ pending API**
