### PR TITLE
drivers: counter: gd32: use portable IRQ pending API

### DIFF
--- a/drivers/counter/counter_gd32_timer.c
+++ b/drivers/counter/counter_gd32_timer.c
@@ -472,11 +472,11 @@ static DEVICE_API(counter, counter_api) = {
 	}                                                                      \
 	static void set_irq_pending_##n(void)                                  \
 	{                                                                      \
-		(NVIC_SetPendingIRQ(DT_INST_IRQ_BY_NAME(n, global, irq)));     \
+		(k_irq_set_pending(DT_INST_IRQ_BY_NAME(n, global, irq)));     \
 	}                                                                      \
 	static uint32_t get_irq_pending_##n(void)                              \
 	{                                                                      \
-		return NVIC_GetPendingIRQ(                                     \
+		return k_irq_is_pending(\
 			DT_INST_IRQ_BY_NAME(n, global, irq));                  \
 	}
 
@@ -494,11 +494,11 @@ static DEVICE_API(counter, counter_api) = {
 	}                                                                      \
 	static void set_irq_pending_##n(void)                                  \
 	{                                                                      \
-		(NVIC_SetPendingIRQ(DT_INST_IRQ_BY_NAME(n, cc, irq)));         \
+		(k_irq_set_pending(DT_INST_IRQ_BY_NAME(n, cc, irq)));         \
 	}                                                                      \
 	static uint32_t get_irq_pending_##n(void)                              \
 	{                                                                      \
-		return NVIC_GetPendingIRQ(DT_INST_IRQ_BY_NAME(n, cc, irq));    \
+		return k_irq_is_pending(DT_INST_IRQ_BY_NAME(n, cc, irq));    \
 	}
 
 #define GD32_TIMER_INIT(n)                                                     \


### PR DESCRIPTION
Replace direct NVIC pending-state calls with k_irq_set_pending()/
k_irq_is_pending()/k_irq_clear_pending(), dropping the dependency on
cmsis_core.h where nothing else needed it.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
