### PR TITLE
drivers: counter: xlnx_ttc: use portable IRQ pending API

### DIFF
--- a/drivers/counter/counter_xlnx_ttc.c
+++ b/drivers/counter/counter_xlnx_ttc.c
@@ -6,9 +6,9 @@
 
 #define DT_DRV_COMPAT xlnx_ttc_counter
 
+#include <zephyr/irq.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
-#include <zephyr/drivers/interrupt_controller/gic.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
@@ -256,7 +256,7 @@ static void ttc_set_alarm_pending(const struct device *dev, uint8_t chan_id)
 	struct ttc_data *data = dev->data;
 
 	atomic_or(&data->late_alarm_pending, BIT(chan_id));
-	arm_gic_irq_set_pending(config->irq_num);
+	k_irq_set_pending(config->irq_num);
 }
 
 /* ==================== COUNTER API IMPLEMENTATION ==================== */


### PR DESCRIPTION
Replace direct NVIC pending-state calls with k_irq_set_pending()/
k_irq_is_pending()/k_irq_clear_pending(), dropping the dependency on
cmsis_core.h where nothing else needed it.

This driver called arm_gic_irq_set_pending() directly; the portable
API removes the GIC-specific dependency.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
