### PR TITLE
nordic: use portable IRQ pending API in drivers/socs

### DIFF
--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -90,7 +90,7 @@ static void prevent_false_prev_evt(void)
 	/* Clear interrupt that may have fired as we were setting the
 	 * comparator.
 	 */
-	NVIC_ClearPendingIRQ(TIMER0_IRQn);
+	k_irq_clear_pending(TIMER0_IRQn);
 }
 
 /* If settings is next tick from now, function attempts to set next tick. If
@@ -207,7 +207,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * QEMU.
 	 */
 	event_clear();
-	NVIC_ClearPendingIRQ(TIMER0_IRQn);
+	k_irq_clear_pending(TIMER0_IRQn);
 
 	uint32_t now = counter();
 
@@ -255,7 +255,7 @@ static int sys_clock_driver_init(void)
 	}
 
 	event_clear();
-	NVIC_ClearPendingIRQ(TIMER0_IRQn);
+	k_irq_clear_pending(TIMER0_IRQn);
 	int_enable();
 
 	return 0;

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -280,7 +280,7 @@ static int entropy_nrf5_get_entropy_isr(const struct device *dev,
 		 * to 1 (the bit is set when NVIC pending IRQ status is
 		 * changed from 0 to 1)
 		 */
-		NVIC_ClearPendingIRQ(IRQN);
+		k_irq_clear_pending(IRQN);
 
 		do {
 			int byte;
@@ -291,7 +291,7 @@ static int entropy_nrf5_get_entropy_isr(const struct device *dev,
 			}
 
 			byte = random_byte_get();
-			NVIC_ClearPendingIRQ(IRQN);
+			k_irq_clear_pending(IRQN);
 
 			if (byte < 0) {
 				continue;

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -846,7 +846,7 @@ static void uart_nrfx_irq_tx_enable(const struct device *dev)
 		/* Due to HW limitation first TXDRDY interrupt shall be
 		 * triggered by the software.
 		 */
-		NVIC_SetPendingIRQ(IRQN);
+		k_irq_set_pending(IRQN);
 	}
 	irq_unlock(key);
 }

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -187,7 +187,7 @@ static void compare_int_unlock(int32_t chan, bool key)
 		atomic_or(&int_mask, BIT(chan));
 		nrfy_rtc_int_enable(RTC, NRF_RTC_CHANNEL_INT_MASK(chan));
 		if (atomic_get(&force_isr_mask) & BIT(chan)) {
-			NVIC_SetPendingIRQ(RTC_IRQn);
+			k_irq_set_pending(RTC_IRQn);
 		}
 	}
 }
@@ -723,7 +723,7 @@ void sys_clock_disable(void)
 	nrf_rtc_task_trigger(RTC, NRF_RTC_TASK_STOP);
 	irq_disable(RTC_IRQn);
 	int_event_disable_rtc();
-	NVIC_ClearPendingIRQ(RTC_IRQn);
+	k_irq_clear_pending(RTC_IRQn);
 }
 
 static int sys_clock_driver_init(void)
@@ -741,7 +741,7 @@ static int sys_clock_driver_init(void)
 	nrfy_rtc_int_enable(RTC, NRF_RTC_INT_OVERFLOW_MASK);
 #endif
 
-	NVIC_ClearPendingIRQ(RTC_IRQn);
+	k_irq_clear_pending(RTC_IRQn);
 
 	IRQ_CONNECT(RTC_IRQn, DT_IRQ(DT_NODELABEL(RTC_LABEL), priority),
 		    rtc_nrf_isr, 0, 0);

--- a/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.c
+++ b/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.c
@@ -13,6 +13,7 @@
 #include "nrf_usbd_common.h"
 #include "nrf_usbd_common_errata.h"
 #include <string.h>
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
@@ -589,7 +590,7 @@ static void usbd_ep_abort_all(void)
  */
 static inline void usbd_int_rise(void)
 {
-	NVIC_SetPendingIRQ(USBD_IRQn);
+	k_irq_set_pending(USBD_IRQn);
 }
 
 /**
@@ -1261,7 +1262,7 @@ static void nrf_usbd_common_stop(void)
 	__ASSERT_NO_MSG(m_drv_state == NRFX_DRV_STATE_POWERED_ON);
 
 	/* Clear interrupt */
-	NVIC_ClearPendingIRQ(USBD_IRQn);
+	k_irq_clear_pending(USBD_IRQn);
 
 	if (irq_is_enabled(USBD_IRQn)) {
 		/* Abort transfers */

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <soc.h>
 
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/usb/udc.h>
 #include <zephyr/drivers/clock_control.h>
@@ -391,7 +392,7 @@ static void usbd_ep_abort_all(void)
 /* Rise USBD interrupt to trigger interrupt handler */
 static inline void usbd_int_rise(void)
 {
-	NVIC_SetPendingIRQ(USBD_IRQn);
+	k_irq_set_pending(USBD_IRQn);
 }
 
 static void ev_usbreset_handler(void)
@@ -951,7 +952,7 @@ static void nrf_usbd_legacy_start(bool enable_sof)
 static void nrf_usbd_common_stop(void)
 {
 	/* Clear interrupt */
-	NVIC_ClearPendingIRQ(USBD_IRQn);
+	k_irq_clear_pending(USBD_IRQn);
 
 	if (irq_is_enabled(USBD_IRQn)) {
 		/* Abort transfers */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <zephyr/irq.h>
 #include <zephyr/sys/byteorder.h>
 
 #include <hal/nrf_ecb.h>
@@ -191,7 +192,7 @@ void ecb_encrypt_nonblocking(struct ecb *e)
 				    | ECB_INTENSET_ENDECB_Msk);
 
 	/* enable interrupt */
-	NVIC_ClearPendingIRQ(ECB_IRQn);
+	k_irq_clear_pending(ECB_IRQn);
 	irq_enable(ECB_IRQn);
 
 	/* start the encryption h/w */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/sys/byteorder.h>
@@ -1196,7 +1197,7 @@ uint32_t radio_tmr_isr_set(uint32_t start_us, radio_isr_cb_t cb, void *param)
 
 	nrf_timer_int_enable(EVENT_TIMER, TIMER_INTENSET_COMPARE2_Msk);
 
-	NVIC_ClearPendingIRQ(TIMER0_IRQn);
+	k_irq_clear_pending(TIMER0_IRQn);
 
 	irq_enable(TIMER0_IRQn);
 
@@ -2530,7 +2531,7 @@ uint32_t radio_ccm_is_done(void)
 		cpu_sleep();
 	}
 	nrf_ccm_int_disable(NRF_CCM, CCM_INTENCLR_ENDCRYPT_Msk);
-	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_CCM));
+	k_irq_clear_pending(nrfx_get_irq_number(NRF_CCM));
 
 	return (NRF_CCM->EVENTS_ERROR == 0);
 }
@@ -2742,7 +2743,7 @@ uint32_t radio_ar_has_match(void)
 
 	nrf_aar_int_disable(NRF_AAR, AAR_INTENCLR_END_Msk);
 
-	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_AAR));
+	k_irq_clear_pending(nrfx_get_irq_number(NRF_AAR));
 
 	if (NRF_AAR->EVENTS_RESOLVED && !NRF_AAR->EVENTS_NOTRESOLVED) {
 		return 1U;
@@ -2782,7 +2783,7 @@ uint8_t radio_ar_resolve(const uint8_t *addr)
 	nrf_aar_event_clear(NRF_AAR, NRF_AAR_EVENT_RESOLVED);
 	nrf_aar_event_clear(NRF_AAR, NRF_AAR_EVENT_NOTRESOLVED);
 
-	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_AAR));
+	k_irq_clear_pending(nrfx_get_irq_number(NRF_AAR));
 
 	nrf_aar_int_enable(NRF_AAR, AAR_INTENSET_END_Msk);
 
@@ -2792,7 +2793,7 @@ uint8_t radio_ar_resolve(const uint8_t *addr)
 
 	nrf_aar_int_disable(NRF_AAR, AAR_INTENCLR_END_Msk);
 
-	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_AAR));
+	k_irq_clear_pending(nrfx_get_irq_number(NRF_AAR));
 
 	retval = (NRF_AAR->EVENTS_RESOLVED && !NRF_AAR->EVENTS_NOTRESOLVED) ?
 		 1U : 0U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
@@ -63,6 +63,8 @@
 
 #endif
 
+#include <zephyr/irq.h>
+
 static inline void hal_swi_init(void)
 {
 	/* No platform-specific initialization required. */
@@ -70,15 +72,15 @@ static inline void hal_swi_init(void)
 
 static inline void hal_swi_lll_pend(void)
 {
-	NVIC_SetPendingIRQ(HAL_SWI_RADIO_IRQ);
+	k_irq_set_pending(HAL_SWI_RADIO_IRQ);
 }
 
 static inline void hal_swi_worker_pend(void)
 {
-	NVIC_SetPendingIRQ(HAL_SWI_WORKER_IRQ);
+	k_irq_set_pending(HAL_SWI_WORKER_IRQ);
 }
 
 static inline void hal_swi_job_pend(void)
 {
-	NVIC_SetPendingIRQ(HAL_SWI_JOB_IRQ);
+	k_irq_set_pending(HAL_SWI_JOB_IRQ);
 }


### PR DESCRIPTION

- **drivers: timer: nrf_rtc: use portable IRQ pending API**
- **drivers: serial: nrfx_uart: use portable IRQ pending API**
- **drivers: usb: nrf: use portable IRQ pending API**
- **drivers: entropy: nrf5: use portable IRQ pending API**
- **Bluetooth: controller: nrf5: use portable IRQ pending API**
- **boards: qemu: cortex_m0: use portable IRQ pending API**

-----

edit by @aescolar 
Related
* #116360