### PR TITLE
drivers: wifi: esp32: keep slp iram opt off in no-blobs builds

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -326,7 +326,9 @@ config ESP32_WIFI_SLP_IRAM_OPT
 	bool "Wi-Fi SLP IRAM speed optimization"
 	select SOC_ESP32_PM_SLP_DEFAULT_PARAMS_OPT if PM && TICKLESS_KERNEL
 	select ESP32_PM_SLP_IRAM_OPT if PM && TICKLESS_KERNEL
-	default y if SOC_ESP32_WIFI_HE_SUPPORT
+	# Keep disabled in no-blobs builds: without CONFIG_PM this path
+	# links a modem sleep function that only the blobs provide.
+	default y if SOC_ESP32_WIFI_HE_SUPPORT && !BUILD_ONLY_NO_BLOBS
 	help
 	  Select this option to place called Wi-Fi library TBTT process and receive
 	  beacon functions in IRAM. Some functions can be put in IRAM either by


### PR DESCRIPTION
Without CONFIG_PM the Wi-Fi SLP IRAM optimization path calls esp_wifi_internal_update_modem_sleep_default_params(), which is only provided by the Wi-Fi blobs. Builds on Wi-Fi 6 SoCs with CONFIG_BUILD_ONLY_NO_BLOBS=y fail to link, so keep the option default off there until a stub is available.

Fixes build errors:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/32902885013/job/97980864420
