### PR TITLE
tests: arch: arm: custom_interrupt: provide the IRQ pending-state hooks

### DIFF
--- a/tests/arch/arm/arm_custom_interrupt/Kconfig
+++ b/tests/arch/arm/arm_custom_interrupt/Kconfig
@@ -11,3 +11,6 @@ config ENABLE_CUSTOM_INTERRUPTS
 	bool
 	default y
 	select ARM_CUSTOM_INTERRUPT_CONTROLLER
+	# The custom controller wraps the NVIC, so it can provide the
+	# pending-state hooks the way a real SoC integration would.
+	select ARCH_HAS_IRQ_PENDING_OPS

--- a/tests/arch/arm/arm_custom_interrupt/src/arm_custom_interrupt.c
+++ b/tests/arch/arm/arm_custom_interrupt/src/arm_custom_interrupt.c
@@ -63,6 +63,21 @@ int z_soc_irq_is_enabled(unsigned int irq)
 	return NVIC->ISER[REG_FROM_IRQ(irq)] & BIT(BIT_FROM_IRQ(irq));
 }
 
+void z_soc_irq_clear_pending(unsigned int irq)
+{
+	NVIC_ClearPendingIRQ((IRQn_Type)irq);
+}
+
+void z_soc_irq_set_pending(unsigned int irq)
+{
+	NVIC_SetPendingIRQ((IRQn_Type)irq);
+}
+
+bool z_soc_irq_is_pending(unsigned int irq)
+{
+	return NVIC_GetPendingIRQ((IRQn_Type)irq) != 0U;
+}
+
 void z_soc_irq_eoi(unsigned int irq)
 {
 	if (irq == sw_irq_number) {


### PR DESCRIPTION
This test turns on ARM_CUSTOM_INTERRUPT_CONTROLLER on every Cortex-M
platform, which routes the architecture IRQ operations to z_soc_irq_*()
hooks that the test implements on top of the NVIC. It provides the
enable, disable, is_enabled, priority, EOI and get_active hooks but not
the pending-state ones, and since ARCH_HAS_IRQ_PENDING_OPS is only
selected for a plain NVIC, k_irq_*_pending() disappears in this
configuration.

Drivers that are always part of the image -- system timers and console
UARTs -- and that use k_irq_clear_pending() therefore fail to build
here, for example mchp_xec_rtos_timer.c on mec15xxevb_assy6853:

  error: implicit declaration of function 'k_irq_clear_pending'

Select ARCH_HAS_IRQ_PENDING_OPS from the test's Kconfig and add NVIC
backed z_soc_irq_clear_pending(), z_soc_irq_set_pending() and
z_soc_irq_is_pending(), the same way the test already wraps the NVIC
for the other hooks. This is exactly what an SoC with a custom
controller that can report and clear pending state is expected to do.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
