### PR TITLE
tests: gpio: it8xxx2_v2: include arch_interface.h in cpu.h shim

### DIFF
--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/zephyr/arch/cpu.h
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/zephyr/arch/cpu.h
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_ARCH_CPU_H_
+#define ZEPHYR_INCLUDE_ARCH_CPU_H_
+
+#include <zephyr/arch/arch_interface.h>
+
 #include <chip_chipregs.h>
 #include <zephyr/arch/posix/arch.h>
 
-int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-		    void (*routine)(const void *parameter),
-		    const void *parameter, uint32_t flags);
-int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
-		       void (*routine)(const void *parameter),
-		       const void *parameter, uint32_t flags);
 typedef struct z_thread_stack_element k_thread_stack_t;
+
+#endif /* ZEPHYR_INCLUDE_ARCH_CPU_H_ */


### PR DESCRIPTION
The test replaces zephyr/arch/cpu.h with a shim that includes
posix/arch.h directly. Since irq.h gained the inline k_irq_* wrappers
that call arch_irq_lock() and friends, the shim breaks the build: the
posix arch header pulls in irq.h before it defines those functions,
and the real cpu.h only avoids this by including arch_interface.h,
which declares the arch_irq_* prototypes, ahead of the arch header.

Mirror the real cpu.h in the shim: include arch_interface.h first and
add the matching include guard, which is needed because
arch_interface.h includes cpu.h back. The hand-written dynamic
interrupt prototypes are provided by arch_interface.h, so drop them.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
