### PR TITLE
drivers: ethernet: phy: tja1103: init work before enabling IRQ

### DIFF
--- a/drivers/ethernet/phy/phy_tja1103.c
+++ b/drivers/ethernet/phy/phy_tja1103.c
@@ -257,6 +257,13 @@ static void phy_tja1103_cfg_irq_poll(const struct device *dev)
 {
 	struct phy_tja1103_data *const data = dev->data;
 
+	/* The interrupt can fire as soon as its GPIO is enabled. Initialize the
+	 * delayable work before enabling that interrupt so the ISR can always
+	 * reschedule a work item with a valid handler.
+	 */
+	data->timeout = sys_timepoint_calc(K_MSEC(SWITCH_WAIT_RANGE(1000, 3000)));
+	k_work_init_delayable(&data->phy_work, phy_work_handler);
+
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
 	int ret;
 	const struct phy_tja1103_config *const cfg = dev->config;
@@ -298,11 +305,7 @@ static void phy_tja1103_cfg_irq_poll(const struct device *dev)
 	}
 #endif
 
-	data->timeout = sys_timepoint_calc(K_MSEC(SWITCH_WAIT_RANGE(1000, 3000)));
-
-	k_work_init_delayable(&data->phy_work, phy_work_handler);
-
-	phy_work_handler(&data->phy_work.work);
+	(void)k_work_reschedule(&data->phy_work, K_NO_WAIT);
 }
 
 static int phy_tja1103_init(const struct device *dev)


### PR DESCRIPTION
The delayable phy_work item was initialized only after the link interrupt had been enabled. On hardware that asserts the PHY interrupt GPIO immediately at configuration time, the ISR can run and reschedule phy_work before k_work_init_delayable() has executed, rescheduling a work item with no valid handler and corrupting workqueue state on early link-up.

Initialize the timeout and the delayable work at the top of phy_tja1103_cfg_irq_poll(), before the interrupt is enabled, and replace the direct phy_work_handler() call with a K_NO_WAIT reschedule so the first poll still runs from workqueue context.

Validated on 100BASE-T1 hardware using the TJA1103 with both the NXP MCXN (enet_qos) and i.MX RT (enet) MACs.
