### PR TITLE
drivers: sensor: rm3100: fix I2C addressing and streaming SQE handling

### DIFF
--- a/drivers/sensor/pni/rm3100/rm3100.c
+++ b/drivers/sensor/pni/rm3100/rm3100.c
@@ -227,7 +227,7 @@ static int rm3100_init(const struct device *dev)
 
 #define RM3100_DEFINE(inst)									   \
 												   \
-	RTIO_DEFINE(rm3100_rtio_ctx_##inst, 8, 8);						   \
+	RTIO_DEFINE(rm3100_rtio_ctx_##inst, 16, 16);						   \
 	COND_CODE_1(DT_INST_ON_BUS(inst, i2c),							   \
 		    (I2C_DT_IODEV_DEFINE(rm3100_bus_##inst, DT_DRV_INST(inst))),		   \
 		    ());									   \

--- a/drivers/sensor/pni/rm3100/rm3100.c
+++ b/drivers/sensor/pni/rm3100/rm3100.c
@@ -90,7 +90,11 @@ static void rm3100_submit_one_shot(const struct device *dev, struct rtio_iodev_s
 		return;
 	}
 
-	uint8_t val = RM3100_REG_MX | REG_READ_BIT;
+	uint8_t val = RM3100_REG_MX;
+
+	if (rtio_is_spi(data->rtio.type)) {
+		val |= REG_READ_BIT;
+	}
 
 	rtio_sqe_prep_tiny_write(write_sqe,
 				 data->rtio.iodev,

--- a/drivers/sensor/pni/rm3100/rm3100_bus.h
+++ b/drivers/sensor/pni/rm3100/rm3100_bus.h
@@ -31,7 +31,13 @@ static inline int rm3100_bus_read(const struct device *dev,
 		return -ENOMEM;
 	}
 
-	reg = reg | REG_READ_BIT;
+	/* The read-address flag is an SPI-only convention. Set it only on
+	 * SPI transfers. On I2C the register address must be sent raw, or
+	 * reads hit a nonexistent register and return zeros.
+	 */
+	if (rtio_is_spi(data->rtio.type)) {
+		reg = reg | REG_READ_BIT;
+	}
 
 	rtio_sqe_prep_write(write_sqe, iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
 	write_sqe->flags |= RTIO_SQE_TRANSACTION;

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -17,6 +17,15 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(RM3100_STREAM, CONFIG_SENSOR_LOG_LEVEL);
 
+/** A streaming read-config describes triggers, not channels: struct sensor_read_config
+ * keeps "channels" and "triggers" in the same union and "count" is the trigger count.
+ * A data-ready event always carries all three axes, so the encoded channel mask is
+ * fixed here instead of being derived from the read-config.
+ */
+static const struct sensor_chan_spec rm3100_stream_chan_spec[] = {
+	{ SENSOR_CHAN_MAGN_XYZ, 0 },
+};
+
 static void rm3100_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe, int err,
 				   void *arg)
 {
@@ -69,9 +78,6 @@ static void rm3100_stream_get_data(const struct device *dev)
 	}
 
 	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
-	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
-	const struct sensor_chan_spec *const channels = cfg->channels;
-	const size_t num_channels = cfg->count;
 	uint8_t *buf;
 	uint32_t buf_len;
 	uint32_t min_buf_len = sizeof(struct rm3100_encoded_data);
@@ -88,7 +94,8 @@ static void rm3100_stream_get_data(const struct device *dev)
 
 	edata = (struct rm3100_encoded_data *)buf;
 
-	err = rm3100_encode(dev, channels, num_channels, buf);
+	err = rm3100_encode(dev, rm3100_stream_chan_spec,
+			    ARRAY_SIZE(rm3100_stream_chan_spec), buf);
 	if (err != 0) {
 		LOG_ERR("Failed to encode sensor data");
 		rtio_iodev_sqe_err(iodev_sqe, err);

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -102,20 +102,27 @@ static void rm3100_stream_get_data(const struct device *dev)
 		return;
 	}
 
-	struct rtio_sqe *status_wr_sqe = rtio_sqe_acquire(data->rtio.ctx);
-	struct rtio_sqe *status_rd_sqe = rtio_sqe_acquire(data->rtio.ctx);
-	struct rtio_sqe *write_sqe = rtio_sqe_acquire(data->rtio.ctx);
-	struct rtio_sqe *read_sqe = rtio_sqe_acquire(data->rtio.ctx);
-	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	/*
+	 * Acquire the chain's five SQEs atomically: the bus RTIO context is
+	 * shared across reads, so a per-SQE acquire that falls back to
+	 * rtio_sqe_drop_all could free an SQE still in flight from another
+	 * chain.
+	 */
+	struct rtio_sqe *sqes[5];
 
-	if (!write_sqe || !read_sqe || !complete_sqe) {
+	if (rtio_sqe_acquire_array(data->rtio.ctx, ARRAY_SIZE(sqes), sqes) != 0) {
 		LOG_ERR("Failed to acquire RTIO SQEs");
-		rtio_sqe_drop_all(data->rtio.ctx);
 
 		data->stream.iodev_sqe = NULL;
 		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
 		return;
 	}
+
+	struct rtio_sqe *status_wr_sqe = sqes[0];
+	struct rtio_sqe *status_rd_sqe = sqes[1];
+	struct rtio_sqe *write_sqe = sqes[2];
+	struct rtio_sqe *read_sqe = sqes[3];
+	struct rtio_sqe *complete_sqe = sqes[4];
 
 	uint8_t val;
 

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -112,7 +112,10 @@ static void rm3100_stream_get_data(const struct device *dev)
 
 	uint8_t val;
 
-	val = RM3100_REG_STATUS | REG_READ_BIT;
+	val = RM3100_REG_STATUS;
+	if (rtio_is_spi(data->rtio.type)) {
+		val |= REG_READ_BIT;
+	}
 
 	rtio_sqe_prep_tiny_write(status_wr_sqe,
 				 data->rtio.iodev,
@@ -134,7 +137,10 @@ static void rm3100_stream_get_data(const struct device *dev)
 	}
 	status_rd_sqe->flags |= RTIO_SQE_CHAINED;
 
-	val = RM3100_REG_MX | REG_READ_BIT;
+	val = RM3100_REG_MX;
+	if (rtio_is_spi(data->rtio.type)) {
+		val |= REG_READ_BIT;
+	}
 
 	rtio_sqe_prep_tiny_write(write_sqe,
 				 data->rtio.iodev,


### PR DESCRIPTION
Three fixes to the RM3100 driver:

- Only set the SPI read bit on SPI transfers. On I2C the read bit addressed a nonexistent register, so every bus read of a real register returned zero and measurements were unusable on I2C deployments.

- Encode a fixed channel spec when streaming. In a streaming read configuration the channels and triggers share a union, so reading cfg->channels reinterprets trigger data. The device produces one magnetic field sample type, so the streaming path now encodes the fixed magnetometer channel spec directly.

- Acquire the bus SQEs for the streaming read chain as a single array. The bus RTIO context is shared across reads, and the previous per-SQE acquire fell back to a drop-all on shortage, which could free an SQE still in flight from another chain and corrupt the pool. Acquiring the chain atomically rolls back only its own SQEs on shortage.

The one-shot read path still acquires its SQEs individually. That path cannot corrupt another chain the same way, and unifying it is left as a follow-up.

Validated on NXP MCXN947 hardware with the magnetometer streaming over I2C.