### PR TITLE
drivers: spi: nxp_lpspi: avoid TCR readback during RTIO transfers

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_rtio.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_rtio.c
@@ -68,6 +68,7 @@ struct lpspi_driver_data {
 		size_t words_clocked;
 	} rx_curr;
 	uint32_t word_size_bytes;
+	uint32_t tcr_cmd;
 #ifdef CONFIG_SPI_NXP_LPSPI_RTIO_DMA
 	struct spi_dma_stream dma_rx;
 	struct spi_dma_stream dma_tx;
@@ -283,7 +284,12 @@ static inline bool lpspi_rtio_next_tx_fill(const struct device *dev)
 	}
 
 	if (lpspi_data->total.words_clocked_tx >= lpspi_data->total.words_to_clock) {
-		base->TCR &= ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
+		/* End the continuous transfer with a command composed from the
+		 * cached start command. A read-modify-write here can sample TCR
+		 * while it is being loaded from the FIFO and queue a corrupted
+		 * command word (see LPSPI_GetTcr() and ERR050606).
+		 */
+		base->TCR = lpspi_data->tcr_cmd & ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
 	}
 
 	return true;
@@ -490,7 +496,7 @@ static void lpspi_dma_callback(const struct device *dev, void *arg, uint32_t cha
 	 * (chip select) line to be deasserted once the transfer fully completes.
 	 */
 	if (channel == lpspi_data->dma_tx.channel) {
-		base->TCR &= ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
+		base->TCR = lpspi_data->tcr_cmd & ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
 	}
 
 	/* RX DMA completion marks the end of the full SPI transfer;
@@ -516,7 +522,14 @@ static void lpspi_isr(const struct device *dev)
 	irq_enable &= ~(LPSPI_IER_RDIE_MASK | LPSPI_IER_TDIE_MASK);
 
 	if (lpspi_data->total.words_to_clock_rx > 0) {
-		if (lpspi_rtio_next_rx_fetch(dev)) {
+		if (!(status_flags & LPSPI_SR_RDF_MASK)) {
+			/* Words are still due but the RX watermark has not been
+			 * crossed, this interrupt is for TX or completion only.
+			 * Skip the drain pass but keep the RX interrupt armed
+			 * so completion still waits on the outstanding words.
+			 */
+			irq_enable |= LPSPI_IER_RDIE_MASK;
+		} else if (lpspi_rtio_next_rx_fetch(dev)) {
 			irq_enable |= LPSPI_IER_RDIE_MASK;
 			if (lpspi_data->total.words_to_clock_rx < config->rx_fifo_size) {
 				base->FCR =
@@ -545,11 +558,12 @@ static void lpspi_isr(const struct device *dev)
 		if (irq_enable == 0) {
 			/** Due to stalling behavior on older LPSPI, if we know we already wrote
 			 * all the words into the fifo, then we need to end xfer manually by
-			 * writing TCR in order to get last bit clocked out on bus. So all we need
-			 * to do is touch the TCR by writing to fifo through TCR register and wait
-			 * for final RX interrupt.
+			 * writing TCR in order to get last bit clocked out on bus. Write the
+			 * cached end command instead of reading TCR back, the readback is
+			 * not reliable while the FIFO holds entries.
 			 */
-			base->TCR = base->TCR;
+			base->TCR =
+				lpspi_data->tcr_cmd & ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
 
 			/** We're done both TX and RX as they each clear their Interrupt
 			 * enable bit once fully received. The transfer has completed.
@@ -611,8 +625,13 @@ static void lpspi_rtio_iodev_start(const struct device *dev)
 	lpspi_data->rx_curr.sqe = sqe;
 	lpspi_data->rx_curr.words_clocked = 0;
 
-	base->TCR = (base->TCR & ~(LPSPI_TCR_PCS_MASK | LPSPI_TCR_RXMSK_MASK)) |
-		    LPSPI_TCR_PCS(spi_cfg->slave) | LPSPI_TCR_CONT_MASK;
+	/* Compose the transfer command once, while the transmit FIFO is empty
+	 * and the TCR read is defined, and cache it. Every later command write
+	 * reuses the cached value so no TCR readback happens mid-transfer.
+	 */
+	lpspi_data->tcr_cmd = (base->TCR & ~(LPSPI_TCR_PCS_MASK | LPSPI_TCR_RXMSK_MASK)) |
+			      LPSPI_TCR_PCS(spi_cfg->slave) | LPSPI_TCR_CONT_MASK;
+	base->TCR = lpspi_data->tcr_cmd;
 	spi_context_cs_control(&data->ctx, true);
 
 	/* tcr is written to tx fifo */
@@ -649,6 +668,18 @@ static void lpspi_rtio_iodev_start(const struct device *dev)
 
 	base->CR = LPSPI_CR_MEN_MASK;
 
+	if (lpspi_data->total.words_to_clock_rx == 0) {
+		/* Mask RX before the first data word is queued so no unread
+		 * words collect in the RX FIFO behind the fill. The command
+		 * is queued ahead of the data and the cached copy keeps the
+		 * mask for the end-of-transfer command writes. The DMA path
+		 * is not masked, it drains every received word and completes
+		 * on the RX channel.
+		 */
+		lpspi_data->tcr_cmd |= LPSPI_TCR_RXMSK_MASK;
+		base->TCR = lpspi_data->tcr_cmd;
+	}
+
 	/* start the transfer sequence which are handled by irqs */
 	if (lpspi_rtio_next_tx_fill(dev) == false) {
 		ret = -EINVAL;
@@ -659,7 +690,6 @@ static void lpspi_rtio_iodev_start(const struct device *dev)
 	if (lpspi_data->total.words_to_clock_rx > 0) {
 		base->IER = LPSPI_IER_RDIE_MASK | LPSPI_IER_TCIE_MASK;
 	} else {
-		base->TCR |= LPSPI_TCR_RXMSK_MASK;
 		base->IER = LPSPI_IER_TDIE_MASK | LPSPI_IER_TCIE_MASK;
 	}
 	return;

--- a/modules/hal_afbr/platform_malloc.c
+++ b/modules/hal_afbr/platform_malloc.c
@@ -14,16 +14,25 @@
 
 BUILD_ASSERT(NUM_AFBR_INST > 0, "Invalid number of AFBR-S50 instances");
 
-/** Defined separate memslab to isolate library from the other components.
- * Through debugging, the library requests an initial allocation of ~4-KiB,
- * which is why the total pool is sized to 8-KiB per instance.
+/** Defined separate memslab to isolate the library from the other
+ * components. The library's device handle is a single allocation of
+ * ~4.1-KiB per instance, so the blocks have to be large enough to satisfy
+ * it; a request larger than a block fails honestly instead of handing
+ * back undersized memory.
  */
-K_MEM_SLAB_DEFINE(argus_memslab, 64, 128 * NUM_AFBR_INST, sizeof(void *));
+#define ARGUS_ALLOC_BLOCK_SIZE	4352
+
+K_MEM_SLAB_DEFINE(argus_memslab, ARGUS_ALLOC_BLOCK_SIZE, 2 * NUM_AFBR_INST,
+		  sizeof(void *));
 
 void *Argus_Malloc(size_t size)
 {
 	void *ptr = NULL;
 	int err;
+
+	CHECKIF(size > ARGUS_ALLOC_BLOCK_SIZE) {
+		return NULL;
+	}
 
 	err = k_mem_slab_alloc(&argus_memslab, &ptr, K_NO_WAIT);
 


### PR DESCRIPTION
Fixes half duplex reads larger than the RX FIFO on the RTIO CPU path, the transfer completes reporting success while the payload arrives displaced. On an AFBR-S50 probe on MCXN947 LPSPI (8 word RX FIFO), the device's 17 byte test ramp 0x00..0x10 returns ten 0x00 bytes with the values 0x01..0x07 landing at offsets 10..16, no error flag raised, which fails device probing.

The driver updated the transfer command with read-modify-writes of TCR from the ISR while the transmit FIFO held queued entries. TCR reads are unreliable in that state per the reference manual TCR access notes and ERR050606, and a stale or torn readback written back is queued as a command word that silently alters the frame for the remaining words.

The fix composes the transfer command once at start of transfer while the transmit FIFO is empty, caches it per instance, and writes the cached value with CONT and CONTC cleared at every later command write. Transmit only transfers on the interrupt path mask RX before the first fill so unread words no longer collect behind the queued data. The RX drain pass is skipped when the receive data flag is clear with the receive interrupt kept armed. The watermark scheme, FIFO tuning, naming, and DMA support are unchanged. The second commit sizes the hal_afbr allocator blocks for the library's requests, unchanged from the previous revision.

Validated on NXP MCXN947 (LPSPI FlexCOMM, 8 word FIFO, CPU interrupt path) with the AFBR-S50 probe and ranging plus PAA3905 and ICM42688/ICM45686 reads, and on i.MX RT1064 (16 word FIFO) with ICM45686 and BMI08x reads on both the DMA path and the CPU path. The failing 17 byte probe read now returns the exact ramp and ranging is millimeter repeatable. No board or fleet specific configuration is required to reproduce.