### PR TITLE
drivers: ethernet: nxp_enet, nxp_enet_qos: optional pass-all multicast

### DIFF
--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -74,4 +74,15 @@ config ETH_NXP_ENET_RMII_EXT_CLK
 	  Setting this option will configure ENET clock block to feed RMII
 	  reference clock from external source (ENET_1588_CLKIN)
 
+config ETH_NXP_ENET_MULTICAST_FILTER
+	bool "Multicast destination address filtering"
+	default y
+	help
+	  Enable support for multicast destination address filtering in the
+	  MAC. The MAC performs imperfect filtering using a group-address hash
+	  table (GAUR/GALR). Only multicast whose computed hash bit is set in
+	  the table is received and all other multicast is dropped by the MAC.
+	  If disabled, the hash table is opened to every multicast address so
+	  that reception does not depend on per-group hash installation.
+
 endif # ETH_NXP_ENET

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -226,7 +226,9 @@ static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *
 	enum ethernet_hw_caps caps;
 
 	caps = ETHERNET_LINK_10BASE |
+#if defined(CONFIG_ETH_NXP_ENET_MULTICAST_FILTER)
 		ETHERNET_HW_FILTERING |
+#endif
 #if defined(CONFIG_NET_VLAN)
 		ETHERNET_HW_VLAN |
 #endif
@@ -265,6 +267,7 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 			data->mac_addr[2], data->mac_addr[3],
 			data->mac_addr[4], data->mac_addr[5]);
 		return 0;
+#if defined(CONFIG_ETH_NXP_ENET_MULTICAST_FILTER)
 	case ETHERNET_CONFIG_TYPE_FILTER:
 		/* The ENET driver does not modify the address buffer but the API is not const */
 		if (cfg->filter.set) {
@@ -275,6 +278,7 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 						 (uint8_t *)cfg->filter.mac_address.addr);
 		}
 		return 0;
+#endif
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		/* Promiscuous mode is enabled at eth_nxp_enet_init and
 		 * cannot be disabled at runtime
@@ -723,6 +727,16 @@ static int eth_nxp_enet_init(const struct device *dev)
 	nxp_enet_driver_cb(config->ptp_clock, NXP_ENET_PTP_CLOCK,
 				NXP_ENET_MODULE_RESET, &data->ptp);
 	ENET_SetTxReclaim(&data->enet_handle, true, 0);
+#endif
+
+#if !defined(CONFIG_ETH_NXP_ENET_MULTICAST_FILTER)
+	/*
+	 * With hash filtering disabled, open the group-address hash (GAUR/GALR)
+	 * to every multicast address so reception does not depend on per-group
+	 * hash installation. Software filtering still applies in the stack.
+	 */
+	data->base->GAUR = 0xFFFFFFFFU;
+	data->base->GALR = 0xFFFFFFFFU;
 #endif
 
 	ENET_ActiveRead(data->base);

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
@@ -649,10 +649,12 @@ static inline void enet_qos_mac_config_init(enet_qos_t *base, struct nxp_enet_qo
 					data->mac_addr.addr[1] << 8  |
 					data->mac_addr.addr[0]);
 
-	/* permit multicast packets if there is no space in hash table for mac addresses */
-	if ((base->MAC_HW_FEAT[1] & ENET_MAC_HW_FEAT_HASHTBLSZ_MASK) == 0) {
-		base->MAC_PACKET_FILTER |= ENET_MAC_PACKET_FILTER_PM_MASK;
-	}
+	/* This driver never populates the multicast hash table nor advertises
+	 * ETHERNET_HW_FILTERING, so perfect multicast filtering is unavailable
+	 * regardless of HASHTBLSZ. Pass all multicast unconditionally. The stack
+	 * still filters in software.
+	 */
+	base->MAC_PACKET_FILTER |= ENET_MAC_PACKET_FILTER_PM_MASK;
 
 #ifdef ENET_MAC_ONEUS_TIC_COUNTER_TIC_1US_CNTR
 	/* Set the reference for 1 microsecond of ENET QOS CSR clock cycles */


### PR DESCRIPTION
Two related multicast RX changes for the NXP Ethernet drivers.

nxp_enet_qos: pass all multicast frames. The driver never populates the multicast hash table and does not advertise hardware filtering, but on MACs with a hash table it left perfect filtering active, so every multicast frame was dropped. That includes the IPv6 neighbor discovery and MLD groups the stack joins, which breaks IPv6 on those parts entirely. Pass multicast unconditionally and let the stack filter in software, matching the driver's advertised capabilities.

nxp_enet: add a Kconfig option to disable the multicast hash filter. This driver does advertise hardware filtering and delivers stack-joined groups correctly. What cannot be received is multicast the stack never joins, which protocols that observe foreign group traffic need. ETH_NXP_ENET_MULTICAST_FILTER defaults to y, keeping today's behavior, and disabling it opens the group-address hash to accept all multicast, following the precedent of the equivalent s32 and stm32 options.

Validated on NXP MCXN947 (enet_qos) and i.MX RT1064 (enet) hardware with IPv6 traffic.