### PR TITLE
boards: qemu: x86: Ignore 'synchronization' tag on twister

### DIFF
--- a/boards/qemu/x86/qemu_x86_64_kvm.yaml
+++ b/boards/qemu/x86/qemu_x86_64_kvm.yaml
@@ -13,4 +13,5 @@ testing:
   ignore_tags:
     - benchmark
     - kernel
+    - synchronization
 vendor: qemu


### PR DESCRIPTION
This platform shouldn't run on twister by default - it depends on KVM being available. It seems only "ignore tags" is respected, so ignore one more tag to avoid CI failures.