### PR TITLE
drivers: ethernet: nxp_enet_qos: reclaim TX resources on link drop

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/Kconfig
+++ b/drivers/ethernet/eth_nxp_enet_qos/Kconfig
@@ -63,4 +63,14 @@ config ETH_NXP_ENET_QOS_RX_THREAD_PRIORITY
 	help
 	  Cooperative priority of the ENET QOS RX thread
 
+config ETH_NXP_ENET_QOS_TX_TIMEOUT_MS
+	int "Transmit completion timeout in milliseconds"
+	default 100
+	range 10 10000
+	help
+	  Time to wait for the transmit DMA to write back the descriptors of
+	  a frame handed to it. A frame still outstanding after this time is
+	  abandoned: the transmit path is reset and the packet is returned to
+	  its pool.
+
 endif # ETH_NXP_ENET_QOS

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
@@ -389,6 +389,12 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 					(desc->write.control3 >> 28) & 0x0f);
 				/* Error statistics for this packet already updated earlier */
 				LOG_DBG("dropping frame from errored packet");
+				/* The writeback clobbered RDES0, which is the buffer
+				 * address in read format, so restore it before handing
+				 * the descriptor back to the DMA.
+				 */
+				desc->read.buf1_addr =
+					(uint32_t)data->rx.reserved_bufs[desc_idx]->data;
 				desc->read.control = rx_desc_refresh_flags;
 				goto next;
 			}
@@ -399,6 +405,8 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			if (!pkt) {
 				LOG_WRN("Could not alloc new RX pkt");
 				/* error: no new buffer, reuse previous immediately */
+				desc->read.buf1_addr =
+					(uint32_t)data->rx.reserved_bufs[desc_idx]->data;
 				desc->read.control = rx_desc_refresh_flags;
 				eth_stats_update_errors_rx(data->iface);
 				goto next;
@@ -422,6 +430,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 				pkt_len, processed_len);
 			net_pkt_unref(pkt);
 			pkt = NULL;
+			desc->read.buf1_addr = (uint32_t)data->rx.reserved_bufs[desc_idx]->data;
 			desc->read.control = rx_desc_refresh_flags;
 			eth_stats_update_errors_rx(data->iface);
 			goto next;
@@ -442,6 +451,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			LOG_WRN("No new RX buf available");
 			net_pkt_unref(pkt);
 			pkt = NULL;
+			desc->read.buf1_addr = (uint32_t)data->rx.reserved_bufs[desc_idx]->data;
 			desc->read.control = rx_desc_refresh_flags;
 			eth_stats_update_errors_rx(data->iface);
 			goto next;

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
@@ -36,6 +36,8 @@ BUILD_ASSERT((ENET_QOS_RX_BUFFER_SIZE * NUM_RX_BUFDESC) >= ENET_QOS_MAX_FRAME_LE
 static const uint32_t rx_desc_refresh_flags =
 	OWN_FLAG | RX_INTERRUPT_ON_COMPLETE_FLAG | BUF1_ADDR_VALID_FLAG;
 
+#define ENET_QOS_TX_FLUSH_TIMEOUT_US 1000U
+
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
 #define RX_TIMESTAMP_CONTEXT_RETRIES        10U
 #define RX_TIMESTAMP_CONTEXT_RETRY_DELAY_US 1U
@@ -84,57 +86,171 @@ static int rx_queue_init(void)
 
 SYS_INIT(rx_queue_init, POST_KERNEL, 0);
 
+static inline void enet_qos_tx_desc_init(enet_qos_t *base, struct nxp_enet_qos_tx_data *tx);
+
+/*
+ * Takes the packet the transmit DMA was given, if it is still ours to
+ * return, and empties the slot in the same step. Completion and abandonment
+ * race against each other, so exactly one of them may release the packet.
+ */
+static struct net_pkt *enet_qos_tx_claim(struct nxp_enet_qos_tx_data *tx)
+{
+	unsigned int key = irq_lock();
+	struct net_pkt *pkt = tx->pkt;
+
+	tx->pkt = NULL;
+	irq_unlock(key);
+
+	return pkt;
+}
+
+/* Returns a claimed packet, its fragments and the transmit slot. */
+static void enet_qos_tx_release(const struct device *dev, struct net_pkt *pkt)
+{
+	struct nxp_enet_qos_mac_data *data = dev->data;
+	struct net_buf *fragment = pkt->frags;
+
+	(void)k_work_cancel_delayable(&data->tx.watchdog);
+
+	while (fragment != NULL) {
+		/* Read the link before dropping the reference: the buffer
+		 * may be freed the moment the last holder lets go of it.
+		 */
+		struct net_buf *next = fragment->frags;
+
+		net_pkt_frag_unref(fragment);
+		fragment = next;
+	}
+
+	net_pkt_unref(pkt);
+
+	k_sem_give(&data->tx.tx_sem);
+}
+
+/*
+ * Abandons a transmission the DMA is not going to finish. The descriptors
+ * are taken back, the transmit queue is flushed and the ring is left in the
+ * state a fresh send expects, so that the interface transmits again once the
+ * link returns.
+ */
+static void enet_qos_tx_abort(const struct device *dev)
+{
+	const struct nxp_enet_qos_mac_config *config = dev->config;
+	struct nxp_enet_qos_mac_data *data = dev->data;
+	enet_qos_t *base = config->module.base;
+	struct net_pkt *pkt = enet_qos_tx_claim(&data->tx);
+	uint32_t flush_wait_us = 0;
+
+	if (pkt == NULL) {
+		return;
+	}
+
+	LOG_WRN("%s abandoning transmission of packet %p", dev->name, pkt);
+	eth_stats_update_errors_tx(data->iface);
+
+	/* Claiming the packet serializes teardown, the losing caller returns
+	 * on the NULL check above and a new send cannot start before the
+	 * release below returns the slot, so the register read-modify-writes
+	 * here have no concurrent writer.
+	 */
+	base->DMA_CH[0].DMA_CHX_TX_CTRL &= ~ENET_QOS_REG_PREP(DMA_CH_DMA_CHX_TX_CTRL, ST, 0b1);
+
+	base->MTL_QUEUE[0].MTL_TXQX_OP_MODE |=
+		ENET_QOS_REG_PREP(MTL_QUEUE_MTL_TXQX_OP_MODE, FTQ, 0b1);
+	/* Hardware clears FTQ when the flush completes. Bound the wait so a
+	 * wedged queue cannot spin the CPU forever.
+	 */
+	while (ENET_QOS_REG_GET(MTL_QUEUE_MTL_TXQX_OP_MODE, FTQ,
+				base->MTL_QUEUE[0].MTL_TXQX_OP_MODE)) {
+		if (flush_wait_us++ >= ENET_QOS_TX_FLUSH_TIMEOUT_US) {
+			LOG_ERR("%s transmit queue flush did not complete", dev->name);
+			break;
+		}
+		k_busy_wait(1U);
+	}
+
+	enet_qos_tx_desc_init(base, &data->tx);
+
+	base->DMA_CH[0].DMA_CHX_TX_CTRL |= ENET_QOS_REG_PREP(DMA_CH_DMA_CHX_TX_CTRL, ST, 0b1);
+
+	enet_qos_tx_release(dev, pkt);
+}
+
+static void eth_nxp_enet_qos_tx_watchdog(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct nxp_enet_qos_tx_data *tx_data =
+		CONTAINER_OF(dwork, struct nxp_enet_qos_tx_data, watchdog);
+	struct nxp_enet_qos_mac_data *data =
+		CONTAINER_OF(tx_data, struct nxp_enet_qos_mac_data, tx);
+
+	enet_qos_tx_abort(net_if_get_device(data->iface));
+}
+
 static void eth_nxp_enet_qos_phy_cb(const struct device *phy,
 		struct phy_link_state *state, void *eth_dev)
 {
 	const struct device *dev = eth_dev;
+	const struct nxp_enet_qos_mac_config *config = dev->config;
 	struct nxp_enet_qos_mac_data *data = dev->data;
+	enet_qos_t *base = config->module.base;
+	uint32_t mac_configuration;
 
 	if (!data->iface) {
 		return;
 	}
 
-	net_eth_carrier_set(data->iface, state->is_up);
+	if (!state->is_up) {
+		net_eth_carrier_set(data->iface, false);
 
-	/* handle link speed and duplex in MAC configuration register */
-	if (state->is_up) {
-		const struct nxp_enet_qos_mac_config *config = dev->config;
-		enet_qos_t *base = config->module.base;
+		/* A frame handed to the transmit DMA when the link drops is
+		 * never written back, so the completion interrupt that
+		 * returns the packet and the transmit slot never arrives.
+		 * Reclaim both here.
+		 */
+		enet_qos_tx_abort(dev);
+		return;
+	}
 
-		uint32_t mac_cfg = base->MAC_CONFIGURATION;
+	/* Speed and duplex live in the MAC configuration register, which may
+	 * only be written with the transmitter and receiver disabled. Program
+	 * them before the carrier is announced, so that the write cannot land
+	 * on a frame the stack has already handed to the DMA.
+	 */
+	mac_configuration =
+		base->MAC_CONFIGURATION & ~(ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1) |
+					    ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1));
+	base->MAC_CONFIGURATION = mac_configuration;
 
-		if (PHY_LINK_IS_SPEED_10M(state->speed)) {
-			LOG_DBG("Link Speed reduced to 10MBit");
-			mac_cfg &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
-		} else {
-			LOG_DBG("Link Speed 100MBit or higher");
-			mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
-		}
+	if (PHY_LINK_IS_SPEED_10M(state->speed)) {
+		LOG_DBG("Link Speed reduced to 10MBit");
+		mac_configuration &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
+	} else {
+		LOG_DBG("Link Speed 100MBit or higher");
+		mac_configuration |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
+	}
 
-		/* Duplex configuration */
-		if (PHY_LINK_IS_FULL_DUPLEX(state->speed)) {
-			LOG_DBG("Link Full Duplex");
-			mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
-		} else {
-			LOG_DBG("Link Half Duplex");
-			mac_cfg &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
-		}
+	if (PHY_LINK_IS_FULL_DUPLEX(state->speed)) {
+		LOG_DBG("Link Full Duplex");
+		mac_configuration |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
+	} else {
+		LOG_DBG("Link Half Duplex");
+		mac_configuration &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
+	}
 
 #if defined(CONFIG_NET_CHECKSUM_OFFLOAD)
-		/* IPC enables the receive checksum offload engine, which
-		 * verifies the IPv4 header and the TCP, UDP and ICMP payload
-		 * checksums of incoming frames over both IPv4 and IPv6.
-		 */
-		mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, IPC, 0b1);
+	/* IPC enables the receive checksum offload engine, which
+	 * verifies the IPv4 header and the TCP, UDP and ICMP payload
+	 * checksums of incoming frames over both IPv4 and IPv6.
+	 */
+	mac_configuration |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, IPC, 0b1);
 #endif
 
-		/* Transmit and receive enable */
-		mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1);
-		mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1);
+	base->MAC_CONFIGURATION = mac_configuration |
+				  ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1) |
+				  ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1);
 
-		/* Single write back */
-		base->MAC_CONFIGURATION = mac_cfg;
-	}
+	net_eth_carrier_set(data->iface, true);
 }
 
 static void eth_nxp_enet_qos_iface_init(struct net_if *iface)
@@ -171,6 +287,7 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 
 	struct net_buf *fragment = pkt->frags;
 	int frags_count = 0, total_bytes = 0, frags_idx = 0;
+	unsigned int key;
 	int ret;
 
 	/* Only allow send of the maximum normal packet size */
@@ -198,7 +315,6 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 						      k_thread_name_get(k_current_get()));
 
 	net_pkt_ref(pkt);
-	data->tx.pkt = pkt;
 
 	LOG_DBG("Setting up TX descriptors for packet %p", pkt);
 
@@ -243,20 +359,31 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	LOG_DBG("Starting TX DMA on packet %p", pkt);
 	data->tx.num_descs = (frags_count + 1) / 2;
 
-	/* Set the DMA ownership of all the used descriptors */
+	/*
+	 * Publish the packet, arm the watchdog and start the DMA as a single
+	 * step under irq_lock, together with the descriptor ownership and the
+	 * tail pointer. An abort from a carrier-loss callback then observes
+	 * either no outstanding packet or a fully built submission, never a
+	 * half-built one, so it cannot free a packet this path is still
+	 * reading or reinitialize the ring while it is being filled.
+	 */
+	key = irq_lock();
+
 	__DMB();
 	for (int i = 0; i < data->tx.num_descs; i++) {
 		data->tx.descriptors[i].read.control2 |= OWN_FLAG;
 	}
 	__DSB();
 
-	/* This implementation is clearly naive and basic, it just changes the
-	 * ring length for every TX send, there is room for optimization
-	 */
+	data->tx.pkt = pkt;
+	(void)k_work_reschedule(&data->tx.watchdog, K_MSEC(CONFIG_ETH_NXP_ENET_QOS_TX_TIMEOUT_MS));
+
 	base->DMA_CH[0].DMA_CHX_TXDESC_RING_LENGTH = data->tx.num_descs - 1;
 	base->DMA_CH[0].DMA_CHX_TXDESC_TAIL_PTR =
 		ENET_QOS_REG_PREP(DMA_CH_DMA_CHX_TXDESC_TAIL_PTR, TDTP,
 			ENET_QOS_ALIGN_ADDR_SHIFT((uint32_t) tx_desc_ptr));
+
+	irq_unlock(key);
 
 	return 0;
 }
@@ -265,15 +392,20 @@ static void tx_dma_done(const struct device *dev)
 {
 	struct nxp_enet_qos_mac_data *data = dev->data;
 	struct nxp_enet_qos_tx_data *tx_data = &data->tx;
-	struct net_pkt *pkt = tx_data->pkt;
-	struct net_buf *fragment = pkt->frags;
+	struct net_pkt *pkt = enet_qos_tx_claim(tx_data);
 
 	if (pkt == NULL) {
-		LOG_WRN("%s TX DMA done on nonexistent packet?", dev->name);
-		goto skip;
-	} else {
-		LOG_DBG("TX DMA completed on packet %p", pkt);
+		/* The watchdog or a carrier loss already abandoned this
+		 * transmission, or this is a repeat of an interrupt already
+		 * handled. There is nothing left to return, and returning it
+		 * a second time would underflow the reference counts of a
+		 * packet and buffers that now belong to someone else.
+		 */
+		LOG_DBG("%s TX DMA done on nonexistent packet", dev->name);
+		return;
 	}
+
+	LOG_DBG("TX DMA completed on packet %p", pkt);
 
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
 	volatile union nxp_enet_qos_tx_desc *last_desc =
@@ -291,20 +423,9 @@ static void tx_dma_done(const struct device *dev)
 	}
 #endif
 
-	/* Returning the buffers and packet to the pool */
-	while (fragment != NULL) {
-		net_pkt_frag_unref(fragment);
-		fragment = fragment->frags;
-	}
-	net_pkt_unref(pkt);
-
 	eth_stats_update_pkts_tx(data->iface);
 
-skip:
-	/* Allows another send */
-	k_sem_give(&data->tx.tx_sem);
-	LOG_DBG("Gave driver TX sem %p by thread %s", &data->tx.tx_sem,
-						      k_thread_name_get(k_current_get()));
+	enet_qos_tx_release(dev, pkt);
 }
 
 static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct device *dev __unused,
@@ -931,6 +1052,9 @@ static int eth_nxp_enet_qos_init(const struct device *dev)
 	 * until the DMA is available again. This is therefore a simple but naive implementation.
 	 */
 	k_sem_init(&data->tx.tx_sem, 1, 1);
+
+	/* Reclaims the transmit slot from a DMA that does not complete */
+	k_work_init_delayable(&data->tx.watchdog, eth_nxp_enet_qos_tx_watchdog);
 
 	/* Work upon a reception of a packet to a buffer */
 	k_work_init(&data->rx.rx_work, eth_nxp_enet_qos_rx);

--- a/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
+++ b/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
@@ -143,6 +143,7 @@ struct nxp_enet_qos_tx_data {
 	struct k_sem tx_sem;
 	struct net_pkt *pkt;
 	int num_descs;
+	struct k_work_delayable watchdog;
 	volatile union nxp_enet_qos_tx_desc descriptors[NUM_TX_BUFDESC];
 };
 


### PR DESCRIPTION
Two RX/TX reliability fixes for the enet_qos driver.

Restore the RX buffer address on every drop path. The DMA writeback clobbers RDES0, which in read format is the buffer address, so any dropped frame handed the descriptor back to the DMA with a corrupt address and permanently poisoned that ring slot.

Reclaim TX resources when the link drops. A frame handed to the transmit DMA when carrier is lost is never written back, so the completion interrupt that returns the packet and the single transmit slot never arrives, and every later send fails with -EBUSY until reset. A bounded TX watchdog abandons the transmission, the abort and completion paths are serialized under irq_lock so exactly one of them releases the packet, and speed and duplex are programmed only with the transmitter and receiver disabled before carrier is announced.

Validated on NXP MCXN947 hardware across repeated physical link flaps. RX and TX both recover on every cycle and the TX buffer pool returns to its baseline with no leaked buffers.

Fixes: #119378