### PR TITLE
net: gptp: release stranded Sync on port reset

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -533,9 +533,6 @@ void net_pkt_unref(struct net_pkt *pkt)
 	atomic_val_t ref;
 
 	if (!pkt) {
-#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-		NET_ERR("*** ERROR *** pkt %p (%s():%d)", pkt, caller, line);
-#endif
 		return;
 	}
 

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -855,6 +855,19 @@ static void gptp_md_sync_send_state_machine(int port)
 	port_ds = GPTP_PORT_DS(port);
 
 	if ((!port_ds->ptt_port_enabled) || !port_ds->as_capable) {
+		/* A Sync waiting here for a transmit timestamp will never be
+		 * given one: the port that was to produce it is down or no
+		 * longer capable. Unregister the callback before dropping
+		 * the packet reference so a late timestamp cannot match the
+		 * packet, then release it, or its reference and the stale
+		 * callback are leaked.
+		 */
+		gptp_sync_timestamp_cb_unregister(port);
+
+		net_pkt_unref(state->sync_ptr);
+		state->sync_ptr = NULL;
+
+		state->md_sync_timestamp_avail = false;
 		state->rcvd_md_sync = false;
 		state->state = GPTP_SYNC_SEND_INITIALIZING;
 

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -822,6 +822,16 @@ void gptp_send_sync(int port, struct net_pkt *pkt)
 	net_if_queue_tx(net_pkt_iface(pkt), pkt);
 }
 
+void gptp_sync_timestamp_cb_unregister(int port)
+{
+	if (!sync_cb_registered[port - 1]) {
+		return;
+	}
+
+	net_if_unregister_timestamp_cb(&sync_timestamp_cb[port - 1]);
+	sync_cb_registered[port - 1] = false;
+}
+
 void gptp_send_follow_up(int port, struct net_pkt *pkt)
 {
 	GPTP_STATS_INC(port, tx_fup_count);

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.h
@@ -451,6 +451,16 @@ void gptp_handle_signaling(int port, struct net_pkt *pkt);
 void gptp_send_sync(int port, struct net_pkt *pkt);
 
 /**
+ * @brief Unregister the Sync transmit timestamp callback.
+ *
+ * Unregisters the timestamp callback of a Sync that will not be
+ * timestamped, so that the next Sync registers one of its own.
+ *
+ * @param port gPTP port number.
+ */
+void gptp_sync_timestamp_cb_unregister(int port);
+
+/**
  * @brief Send a Follow Up message.
  *
  * @param port gPTP port number.


### PR DESCRIPTION
When the Sync send state machine resets while a Sync is waiting for its transmit timestamp, that Sync will never be given one and the port that was to produce it is down or no longer capable. The reset path left the packet reference held and the timestamp callback registered, so the packet and its buffers leaked from the pool for good and no later Sync could ever register a callback, leaving the machine unable to transmit timestamped Syncs after recovery.

Release the stranded Sync and reset the callback registration in the reset path. Independently valid for any driver whose port drops mid-Sync.

Validated on NXP MCXN947 hardware acting as a time transmitter across repeated physical link flaps. Sync transmission resumes after every flap and the TX buffer pool shows no per-flap leak.