### PR TITLE
net: ppp_l2: add proto_type to incoming packets

### DIFF
--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -107,6 +107,10 @@ static enum net_verdict process_ppp_msg(struct net_if *iface,
 
 	if ((IS_ENABLED(CONFIG_NET_IPV4) && protocol == PPP_IP) ||
 	    (IS_ENABLED(CONFIG_NET_IPV6) && protocol == PPP_IPV6)) {
+
+		net_pkt_set_ll_proto_type(pkt, protocol == PPP_IP ? NET_ETH_PTYPE_IP :
+								    NET_ETH_PTYPE_IPV6);
+
 		/* Remove the protocol field so that IP packet processing
 		 * continues properly in net_core.c:process_data()
 		 */


### PR DESCRIPTION
This adds the relevent ETH_TYPE flag to incoming ppp packets. Fixes #116350