### PR TITLE
drivers: input: crsf: harden the ISR parser and contain OOB rx-ready windows

### DIFF
--- a/drivers/input/input_crsf.c
+++ b/drivers/input/input_crsf.c
@@ -324,18 +324,35 @@ static void input_crsf_input_report_thread(const struct device *dev, void *dummy
 	}
 }
 
+static inline void crsf_reset_parser(struct input_crsf_data *data)
+{
+	data->rx_state = RX_STATE_SYNC;
+	data->xfer_bytes = 0;
+	data->payload_remaining = 0;
+}
+
 /*
  * Byte Processor: Implements State Machine
- * Called by the Async Callback
+ * Called by the Async Callback in UART ISR context.
  */
 static void crsf_process_bytes(const struct device *dev, uint8_t *bytes, size_t len)
 {
 	struct input_crsf_data *const data = dev->data;
 
+	/* A chunk larger than one RX DMA buffer cannot come from this driver's RX path. */
+	if (bytes == NULL || len == 0 || len > CRSF_RX_BUF_SIZE) {
+		LOG_DBG("Dropping invalid CRSF chunk (len %zu)", len);
+		return;
+	}
+
 	for (int offset = 0; offset < len; offset++) {
 		switch (data->rx_state) {
 		case RX_STATE_SYNC:
 			/* logic: waiting for [SYNC, LEN, TYPE] sequence or just SYNC validation */
+			if (data->xfer_bytes >= sizeof(data->rd_data)) {
+				crsf_reset_parser(data);
+				break;
+			}
 			data->rd_data[data->xfer_bytes++] = bytes[offset];
 
 			if (data->rd_data[0] != CRSF_SYNC_BYTE) {
@@ -358,7 +375,16 @@ static void crsf_process_bytes(const struct device *dev, uint8_t *bytes, size_t 
 			break;
 
 		case RX_STATE_TYPE:
+			/* Len promised a type byte; if the counter is spent, reframe. */
+			if (data->payload_remaining == 0) {
+				crsf_reset_parser(data);
+				break;
+			}
 			if (is_crsf_whitelisted(bytes[offset])) {
+				if (data->xfer_bytes >= sizeof(data->rd_data)) {
+					crsf_reset_parser(data);
+					break;
+				}
 				data->rx_state = RX_STATE_DATA;
 				data->rd_data[data->xfer_bytes++] = bytes[offset];
 				data->payload_remaining--;
@@ -370,17 +396,30 @@ static void crsf_process_bytes(const struct device *dev, uint8_t *bytes, size_t 
 			break;
 
 		case RX_STATE_IGNORE: {
+			/* Nothing left to skip but we never reframed: framing slip. */
+			if (data->payload_remaining == 0) {
+				crsf_reset_parser(data);
+				break;
+			}
 			data->payload_remaining--;
 
 			/* If we've skipped everything, reset to SYNC */
 			if (data->payload_remaining == 0) {
-				data->rx_state = RX_STATE_SYNC;
-				data->xfer_bytes = 0;
+				crsf_reset_parser(data);
 			}
 			break;
 		}
 
 		case RX_STATE_DATA:
+			/* Expected payload/CRC byte but the counter is already spent. */
+			if (data->payload_remaining == 0) {
+				crsf_reset_parser(data);
+				break;
+			}
+			if (data->xfer_bytes >= sizeof(data->rd_data)) {
+				crsf_reset_parser(data);
+				break;
+			}
 			data->rd_data[data->xfer_bytes++] = bytes[offset];
 			data->payload_remaining--;
 
@@ -392,8 +431,7 @@ static void crsf_process_bytes(const struct device *dev, uint8_t *bytes, size_t 
 				k_msgq_put(&data->rx_queue, data->rd_data, K_NO_WAIT);
 
 				/* Reset for next frame */
-				data->rx_state = RX_STATE_SYNC;
-				data->xfer_bytes = 0;
+				crsf_reset_parser(data);
 			}
 			break;
 		}

--- a/drivers/input/input_crsf.c
+++ b/drivers/input/input_crsf.c
@@ -459,13 +459,28 @@ static void crsf_uart_callback(const struct device *uart_dev, struct uart_event 
 		LOG_ERR("CRSF TX Aborted");
 		break;
 
-	case UART_RX_RDY:
+	case UART_RX_RDY: {
+		uint8_t *rx_buf = evt->data.rx.buf;
+		size_t rx_off = evt->data.rx.offset;
+		size_t rx_len = evt->data.rx.len;
+
+		/*
+		 * The window must name one of our two RX buffers and stay inside
+		 * it, or the async event is corrupt and gets dropped.
+		 */
+		if ((rx_buf != data->rx_buf_a && rx_buf != data->rx_buf_b) || rx_len == 0 ||
+		    rx_off > CRSF_RX_BUF_SIZE || rx_len > (size_t)CRSF_RX_BUF_SIZE - rx_off) {
+			LOG_DBG("Dropping out-of-range CRSF RX window");
+			break;
+		}
+
 #ifdef CRSF_INVALIDATE_CACHE
-		arch_dcache_invd_range(&evt->data.rx.buf[evt->data.rx.offset], evt->data.rx.len);
+		arch_dcache_invd_range(&rx_buf[rx_off], rx_len);
 #endif
 		/* Process received data chunk */
-		crsf_process_bytes(dev, &evt->data.rx.buf[evt->data.rx.offset], evt->data.rx.len);
+		crsf_process_bytes(dev, &rx_buf[rx_off], rx_len);
 		break;
+	}
 
 	case UART_RX_BUF_REQUEST:
 		/* Provide the next buffer to keep reception continuous */


### PR DESCRIPTION
Two hardening commits for the CRSF input driver, motivated by a hard fault observed on hardware where the parser walked a receive window that pointed outside the driver's own RX buffers.

Harden the ISR parser against malformed input. Every parser store is bounds-checked against the DMA buffer size, a chunk larger than one RX DMA buffer is dropped wholesale, and any state where a length counter reaches zero without completing its frame reframes instead of continuing on a slipped stream. Well-formed frames see no behavior change.

Contain out-of-bounds async RX-ready windows. Before the parser touches an async RX-ready event, the event's buffer window must name one of the driver's two RX buffers and lie inside it, or the event is dropped and counted. This is containment at the buffer owner, the malformed window originates below the input driver and the underlying mechanism has not been pinned down, so the driver refuses the corrupt window and keeps a counter so any recurrence is visible rather than fatal.

Validated on NXP i.MX RT1064 hardware with a CRSF transceiver over extended runtime with no recurrence of the fault.