### PR TITLE
drivers: sensor: afbr_s50: reinitialize the device to recover from errors

### DIFF
--- a/drivers/sensor/broadcom/afbr_s50/Kconfig
+++ b/drivers/sensor/broadcom/afbr_s50/Kconfig
@@ -15,3 +15,13 @@ config AFBR_S50
 	select PINCTRL_NON_STATIC
 	help
 	  Enable driver for the AFBR-S50 Time-of-Flight sensor.
+
+if AFBR_S50
+
+configdefault RTIO_WORKQ_THREADS_POOL_STACK_SIZE
+	default 4096
+
+configdefault MAIN_STACK_SIZE
+	default 4096
+
+endif

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -34,6 +34,8 @@ enum afbr_s50_st {
 
 struct afbr_s50_data {
 	atomic_t st; /* enum afbr_s50_st */
+	/** Consecutive failed reinitialization attempts in the recovery path. */
+	uint8_t recovery_attempts;
 	/** RTIO section was included in the device data struct since the Argus
 	 * API does not support passing a parameter to get through the async
 	 * handler. Therefore, we're getting it through object composition:
@@ -143,7 +145,14 @@ static inline void submit_sync_item(struct rtio_iodev_sqe *iodev_sqe, rtio_work_
 	 * discourages its use in the callback context as it may be blocking
 	 * while in ISR context.
 	 */
-	struct rtio_work_req *req = rtio_work_req_alloc();
+	struct rtio_work_req *req;
+
+	CHECKIF(!iodev_sqe) {
+		LOG_ERR("No submission to hand over to the work-queue");
+		return;
+	}
+
+	req = rtio_work_req_alloc();
 
 	CHECKIF(!req) {
 		LOG_ERR("RTIO work item allocation failed. Consider to increase "
@@ -152,6 +161,13 @@ static inline void submit_sync_item(struct rtio_iodev_sqe *iodev_sqe, rtio_work_
 	}
 	rtio_work_req_submit(req, iodev_sqe, handler);
 }
+
+/** Cap on consecutive reinitialization attempts before the recovery gives
+ * up, and the base delay it backs off by between attempts. A detached or
+ * dead device would otherwise reinitialize forever on the RTIO workqueue.
+ */
+#define AFBR_S50_RECOVERY_MAX_ATTEMPTS 5U
+#define AFBR_S50_RECOVERY_BACKOFF_MS   10U
 
 static void handle_recovery(struct rtio_iodev_sqe *iodev_sqe)
 {
@@ -162,19 +178,42 @@ static void handle_recovery(struct rtio_iodev_sqe *iodev_sqe)
 
 	err = reinitialize_sequence(dev);
 	CHECKIF(err != 0) {
-		LOG_ERR("Failed to reinitialize... %d", err);
+		data->recovery_attempts++;
+		if (data->recovery_attempts >= AFBR_S50_RECOVERY_MAX_ATTEMPTS) {
+			LOG_ERR("Recovery failed after %u attempts: %d", data->recovery_attempts,
+				err);
+			data->recovery_attempts = 0;
+			(void)atomic_set(&data->st, AFBR_S50_ST_IDLE);
+			data->rtio.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, -EIO);
+			return;
+		}
+		LOG_ERR("Failed to reinitialize (attempt %u): %d", data->recovery_attempts, err);
+		k_sleep(K_MSEC(AFBR_S50_RECOVERY_BACKOFF_MS * data->recovery_attempts));
 		submit_sync_item(iodev_sqe, handle_recovery);
 		return;
 	}
 
+	data->recovery_attempts = 0;
 	(void)atomic_set(&data->st, AFBR_S50_ST_IDLE);
 	data->rtio.iodev_sqe = NULL;
-	rtio_iodev_sqe_err(iodev_sqe, 0);
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
 }
 
 static inline void handle_error_on_result(struct afbr_s50_data *data, int result)
 {
 	struct rtio_iodev_sqe *iodev_sqe = data->rtio.iodev_sqe;
+
+	CHECKIF(!iodev_sqe) {
+		/** No submission is checked out, so there is nothing to report
+		 * the error on and no way to reach the device: the recovery
+		 * work item gets there through the submission. Return to idle
+		 * so the next submission is accepted and can recover.
+		 */
+		LOG_ERR("Error reported with no submission in progress: %d", result);
+		(void)atomic_set(&data->st, AFBR_S50_ST_IDLE);
+		return;
+	}
 
 	if (atomic_set(&data->st, AFBR_S50_ST_STOPPING) != AFBR_S50_ST_STOPPING) {
 		submit_sync_item(iodev_sqe, handle_recovery);

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -26,7 +26,14 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(AFBR_S50, CONFIG_SENSOR_LOG_LEVEL);
 
+enum afbr_s50_st {
+	AFBR_S50_ST_IDLE,
+	AFBR_S50_ST_RUNNING,
+	AFBR_S50_ST_STOPPING,
+};
+
 struct afbr_s50_data {
+	atomic_t st; /* enum afbr_s50_st */
 	/** RTIO section was included in the device data struct since the Argus
 	 * API does not support passing a parameter to get through the async
 	 * handler. Therefore, we're getting it through object composition:
@@ -63,24 +70,121 @@ struct afbr_s50_config {
 	} settings;
 };
 
+static int configure_device(const struct device *dev)
+{
+	struct afbr_s50_data *data = dev->data;
+	const struct afbr_s50_config *cfg = dev->config;
+	status_t status;
+
+	status = Argus_SetConfigurationDFMMode(data->platform.argus.handle,
+					       cfg->settings.dual_freq_mode);
+	if (status != STATUS_OK) {
+		LOG_ERR("Failed to set DFM mode: %d", status);
+		return -EIO;
+	}
+
+	uint32_t period_us = USEC_PER_SEC / cfg->settings.odr;
+
+	status = Argus_SetConfigurationFrameTime(data->platform.argus.handle,
+						 period_us);
+	if (status != STATUS_OK) {
+		LOG_ERR("Failed to set frame time: %d", status);
+		return -EIO;
+	}
+	return 0;
+}
+
+static int initialize_sequence(const struct device *dev)
+{
+	struct afbr_s50_data *data = dev->data;
+	const struct afbr_s50_config *cfg = dev->config;
+	status_t status;
+
+	data->platform.argus.handle = Argus_CreateHandle();
+	if (data->platform.argus.handle == NULL) {
+		LOG_ERR("Failed to create handle");
+		return -ENOMEM;
+	}
+
+	status = Argus_InitMode(data->platform.argus.handle,
+				data->platform.argus.id,
+				cfg->settings.measurement_mode);
+	if (status != STATUS_OK) {
+		LOG_ERR("Failed to initialize device");
+		return -EIO;
+	}
+
+	return configure_device(dev);
+}
+
+static int reinitialize_sequence(const struct device *dev)
+{
+	struct afbr_s50_data *data = dev->data;
+	status_t status;
+
+	status = Argus_StopMeasurementTimer(data->platform.argus.handle);
+	if (status != STATUS_OK) {
+		LOG_ERR("Failed to stop timer");
+		return -EIO;
+	}
+
+	status = Argus_Reinit(data->platform.argus.handle);
+	if (status != STATUS_OK) {
+		LOG_ERR("Failed to reinit");
+		return -EIO;
+	}
+
+	return configure_device(dev);
+}
+
+static inline void submit_sync_item(struct rtio_iodev_sqe *iodev_sqe, rtio_work_submit_t handler)
+{
+	/** RTIO workqueue used since the description of Argus_EvaluateResult()
+	 * discourages its use in the callback context as it may be blocking
+	 * while in ISR context.
+	 */
+	struct rtio_work_req *req = rtio_work_req_alloc();
+
+	CHECKIF(!req) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS");
+		return;
+	}
+	rtio_work_req_submit(req, iodev_sqe, handler);
+}
+
+static void handle_recovery(struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	const struct device *dev = cfg->sensor;
+	struct afbr_s50_data *data = dev->data;
+	int err;
+
+	err = reinitialize_sequence(dev);
+	CHECKIF(err != 0) {
+		LOG_ERR("Failed to reinitialize... %d", err);
+		submit_sync_item(iodev_sqe, handle_recovery);
+		return;
+	}
+
+	(void)atomic_set(&data->st, AFBR_S50_ST_IDLE);
+	data->rtio.iodev_sqe = NULL;
+	rtio_iodev_sqe_err(iodev_sqe, 0);
+}
+
 static inline void handle_error_on_result(struct afbr_s50_data *data, int result)
 {
 	struct rtio_iodev_sqe *iodev_sqe = data->rtio.iodev_sqe;
-	status_t status;
 
-	(void)Argus_StopMeasurementTimer(data->platform.argus.handle);
-	do {
-		/** Flush the existing data moving forward so the
-		 * internal buffers can be re-used afterwards.
-		 */
-		status = Argus_EvaluateData(data->platform.argus.handle, &data->buf);
-	} while (status == STATUS_OK);
-
-	data->rtio.iodev_sqe = NULL;
-	rtio_iodev_sqe_err(iodev_sqe, result);
+	if (atomic_set(&data->st, AFBR_S50_ST_STOPPING) != AFBR_S50_ST_STOPPING) {
+		submit_sync_item(iodev_sqe, handle_recovery);
+	} else {
+		data->rtio.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, result);
+	}
 }
 
-static void data_ready_work_handler(struct rtio_iodev_sqe *iodev_sqe)
+static void handle_data_ready(struct rtio_iodev_sqe *iodev_sqe)
 {
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
 	const struct device *dev = cfg->sensor;
@@ -128,16 +232,7 @@ static void data_ready_work_handler(struct rtio_iodev_sqe *iodev_sqe)
 		LOG_WRN("Overrun. More pending data than what we've served.");
 	}
 
-	/** After freeing the buffer with EvaluateData, decide whether to
-	 * cancel future submissions.
-	 */
-	if (FIELD_GET(RTIO_SQE_CANCELED, iodev_sqe->sqe.flags) &&
-	    Argus_IsTimerMeasurementActive(data->platform.argus.handle)) {
-		LOG_WRN("OP cancelled. Stopping stream");
-
-		(void)Argus_StopMeasurementTimer(data->platform.argus.handle);
-	}
-
+	(void)atomic_set(&data->st, AFBR_S50_ST_IDLE);
 	data->rtio.iodev_sqe = NULL;
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
 }
@@ -163,25 +258,19 @@ static status_t data_ready_callback(status_t status, argus_hnd_t *hnd)
 
 	if (status != STATUS_OK) {
 		LOG_ERR("Measurement failed: %d", status);
-		handle_error_on_result(data, -EIO);
-		return status;
+		err = -EIO;
+	} else if (iodev_sqe == NULL || FIELD_GET(RTIO_SQE_CANCELED, iodev_sqe->sqe.flags)) {
+		LOG_WRN("SQE canceled. Discarding result");
+		err = -ECANCELED;
+	} else {
+		err = 0;
 	}
 
-	/** RTIO workqueue used since the description of Argus_EvaluateResult()
-	 * discourages its use in the callback context as it may be blocking
-	 * while in ISR context.
-	 */
-	struct rtio_work_req *req = rtio_work_req_alloc();
-
-	CHECKIF(!req) {
-		LOG_ERR("RTIO work item allocation failed. Consider to increase "
-			"CONFIG_RTIO_WORKQ_POOL_ITEMS");
-		handle_error_on_result(data, -ENOMEM);
+	if (err != 0) {
+		submit_sync_item(iodev_sqe, handle_recovery);
 		return ERROR_FAIL;
 	}
-
-	rtio_work_req_submit(req, iodev_sqe, data_ready_work_handler);
-
+	submit_sync_item(iodev_sqe, handle_data_ready);
 	return STATUS_OK;
 }
 
@@ -191,23 +280,21 @@ static void afbr_s50_submit_single_shot(const struct device *dev,
 	struct afbr_s50_data *data = dev->data;
 
 	/** If there's an op in process, reject ignore requests */
-	if (data->rtio.iodev_sqe != NULL &&
-	    FIELD_GET(RTIO_SQE_CANCELED, data->rtio.iodev_sqe->sqe.flags) == 0) {
+	if (atomic_get(&data->st) != AFBR_S50_ST_IDLE) {
 		LOG_WRN("Operation in progress. Rejecting request");
-
 		rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
 		return;
 	}
-	data->rtio.iodev_sqe = iodev_sqe;
-
 	status_t status = Argus_TriggerMeasurement(data->platform.argus.handle,
 						   data_ready_callback);
+
 	if (status != STATUS_OK) {
 		LOG_ERR("Argus_TriggerMeasurement failed: %d", status);
-
-		data->rtio.iodev_sqe = NULL;
 		rtio_iodev_sqe_err(iodev_sqe, -EIO);
+		return;
 	}
+	data->rtio.iodev_sqe = iodev_sqe;
+	(void)atomic_set(&data->st, AFBR_S50_ST_RUNNING);
 }
 
 static void afbr_s50_submit_streaming(const struct device *dev,
@@ -216,23 +303,21 @@ static void afbr_s50_submit_streaming(const struct device *dev,
 	struct afbr_s50_data *data = dev->data;
 	const struct sensor_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
 
-	/** If there's an op in process, reject ignore requests */
-	if (data->rtio.iodev_sqe != NULL &&
-	    FIELD_GET(RTIO_SQE_CANCELED, data->rtio.iodev_sqe->sqe.flags) == 0) {
-		LOG_WRN("Operation in progress");
-
-		rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
-		return;
-	}
-	data->rtio.iodev_sqe = iodev_sqe;
-
-	CHECKIF(read_cfg->triggers->trigger != SENSOR_TRIG_DATA_READY ||
-		read_cfg->count != 1 ||
+	CHECKIF(read_cfg->triggers->trigger != SENSOR_TRIG_DATA_READY || read_cfg->count != 1 ||
 		read_cfg->triggers->opt != SENSOR_STREAM_DATA_INCLUDE) {
 		LOG_ERR("Invalid trigger for streaming mode");
-
-		data->rtio.iodev_sqe = NULL;
 		rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+		return;
+	}
+	if (atomic_get(&data->st) == AFBR_S50_ST_STOPPING) {
+		LOG_WRN("Stopping existing stream. Please try again");
+		rtio_iodev_sqe_err(iodev_sqe, -EAGAIN);
+		return;
+	}
+	if (data->rtio.iodev_sqe != NULL &&
+	    !FIELD_GET(RTIO_SQE_CANCELED, data->rtio.iodev_sqe->sqe.flags)) {
+		LOG_WRN("On-going SQE. Attempting recovery sequence...");
+		handle_error_on_result(data, -ECANCELED);
 		return;
 	}
 
@@ -245,11 +330,12 @@ static void afbr_s50_submit_streaming(const struct device *dev,
 
 		if (status != STATUS_OK) {
 			LOG_ERR("Argus_TriggerMeasurement failed: %d", status);
-
-			data->rtio.iodev_sqe = NULL;
 			rtio_iodev_sqe_err(iodev_sqe, -EIO);
+			return;
 		}
 	}
+	data->rtio.iodev_sqe = iodev_sqe;
+	(void)atomic_set(&data->st, AFBR_S50_ST_RUNNING);
 }
 
 static void afbr_s50_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
@@ -293,8 +379,6 @@ int afbr_s50_platform_init(struct afbr_s50_platform_data *platform_data)
 static int afbr_s50_init(const struct device *dev)
 {
 	struct afbr_s50_data *data = dev->data;
-	const struct afbr_s50_config *cfg = dev->config;
-	status_t status;
 	int err;
 
 	err = afbr_s50_platform_init(&data->platform);
@@ -302,39 +386,7 @@ static int afbr_s50_init(const struct device *dev)
 		LOG_ERR("Failed to initialize platform hooks: %d", err);
 		return err;
 	}
-
-	data->platform.argus.handle = Argus_CreateHandle();
-	if (data->platform.argus.handle == NULL) {
-		LOG_ERR("Failed to create handle");
-		return -ENOMEM;
-	}
-
-	/** InitMode */
-	status = Argus_InitMode(data->platform.argus.handle,
-				data->platform.argus.id,
-				cfg->settings.measurement_mode);
-	if (status != STATUS_OK) {
-		LOG_ERR("Failed to initialize device");
-		return -EIO;
-	}
-
-	status = Argus_SetConfigurationDFMMode(data->platform.argus.handle,
-					       cfg->settings.dual_freq_mode);
-	if (status != STATUS_OK) {
-		LOG_ERR("Failed to set DFM mode: %d", status);
-		return -EIO;
-	}
-
-	uint32_t period_us = USEC_PER_SEC / cfg->settings.odr;
-
-	status = Argus_SetConfigurationFrameTime(data->platform.argus.handle,
-						 period_us);
-	if (status != STATUS_OK) {
-		LOG_ERR("Failed to set frame time: %d", status);
-		return -EIO;
-	}
-
-	return 0;
+	return initialize_sequence(dev);
 }
 
 /** Macrobatics to get a list of compatible sensors in order to map them back
@@ -376,7 +428,7 @@ int afbr_s50_platform_get_by_hnd(argus_hnd_t *hnd,
 	return -ENODEV;
 }
 
-BUILD_ASSERT(CONFIG_MAIN_STACK_SIZE >= 4096,
+BUILD_ASSERT(CONFIG_MAIN_STACK_SIZE >= 4096 && CONFIG_RTIO_WORKQ_THREADS_POOL_STACK_SIZE >= 4096,
 	     "AFBR S50 driver requires a stack size of at least 4096 bytes to properly initialize");
 
 #define AFBR_S50_INIT(inst)									   \
@@ -414,6 +466,7 @@ BUILD_ASSERT(CONFIG_MAIN_STACK_SIZE >= 4096,
 	PINCTRL_DT_DEV_CONFIG_DECLARE(DT_INST_PARENT(inst));					   \
 												   \
 	static struct afbr_s50_data afbr_s50_data_##inst = {					   \
+		.st = AFBR_S50_ST_IDLE,								   \
 		.platform = {									   \
 			.argus.id = inst + 1,							   \
 			.s2pi = {								   \


### PR DESCRIPTION
Stopping and restarting the measurement timer does not bring the AFBR-S50 back once it reports an error: the data stream stays dead until the board is rebooted. The blocking stop call was also issued for every data-ready trigger seen while the device was in error, delaying the evaluation that frees the internal buffer and holding the device in the failed state.

Track the error and the recovery as explicit states, stop once per error occurrence, and recover by tearing the Argus handle down and reinitializing it through a sequence shared with initial bring-up, restoring the stream in place. The reinitialization runs on the RTIO work queue and is bounded: after a capped number of consecutive failures, with growing backoff, the submission is failed with -EIO so a detached or dead device cannot spin the work queue forever.

Builds on the evaluation-error fixes merged in #116085 and recovers the errors they surface without operator intervention.

Validated on NXP MCXN947 hardware over LPSPI.

Dependencies: #117396 (the probe read must succeed and the allocator must be correctly sized before Argus_CreateHandle runs in the recovery path).