### PR TITLE
drivers: ethernet: nxp_enet_qos: arm RX timestamping after MAC start

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
@@ -715,6 +715,19 @@ static inline void enet_qos_start(enet_qos_t *base)
 	base->MAC_CONFIGURATION |=
 		ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1) |
 		ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1);
+
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	/*
+	 * Writing MAC_TIMESTAMP_CONTROL while the receiver is enabled arms the
+	 * RX timestamp snapshot logic. The PTP clock driver may have
+	 * programmed this register before RX was enabled, so rewrite the
+	 * existing value here to latch it. This read-back write is
+	 * intentional and not a redundant no-op.
+	 */
+	uint32_t timestamp_control = base->MAC_TIMESTAMP_CONTROL;
+
+	base->MAC_TIMESTAMP_CONTROL = timestamp_control;
+#endif
 }
 
 static inline void enet_qos_tx_desc_init(enet_qos_t *base, struct nxp_enet_qos_tx_data *tx)


### PR DESCRIPTION
The PTP clock driver programs MAC_TIMESTAMP_CONTROL at its own init time, which can run before enet_qos_start() enables the receiver. On cold boots with that ordering the RX timestamp snapshot logic never arms: and received PTP frames carry no hardware timestamps, so gPTP path delay measurement cannot complete and the port never becomes AS capable.

Read back and rewrite MAC_TIMESTAMP_CONTROL after the MAC receiver is enabled. Rewriting the existing value while RX is running is what latches the snapshot configuration, so this is deliberately not a no-op even though it writes back the same register value.

Validated on NXP MCXN947 hardware across repeated cold boots including power-on resets, path delay measurement completes and the port reports AS capable on every boot, where the broken ordering left it permanently incapable.
