### PR TITLE
net: tcp: fix typo in test callback registration

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -5030,9 +5030,9 @@ void net_tcp_init(void)
 	int rto;
 #if defined(CONFIG_NET_TEST_PROTOCOL)
 	/* Register inputs for TTCN-3 based TCP sanity check */
-	test_cb_register(NET_AF_INET,  NET_NET_SOCK_STREAM, NET_IPPROTO_TCP,
+	test_cb_register(NET_AF_INET,  NET_SOCK_STREAM, NET_IPPROTO_TCP,
 			 4242, 4242, tcp_input);
-	test_cb_register(NET_AF_INET6, NET_NET_SOCK_STREAM, NET_IPPROTO_TCP,
+	test_cb_register(NET_AF_INET6, NET_SOCK_STREAM, NET_IPPROTO_TCP,
 			 4242, 4242, tcp_input);
 	test_cb_register(NET_AF_INET,  NET_SOCK_DGRAM, NET_IPPROTO_UDP,
 			 4242, 4242, tp_input);


### PR DESCRIPTION
Use the correct `NET_SOCK_STREAM` constant when registering TCP test callbacks for TTCN-3 based TCP sanity checks.