### PR TITLE
posix: shm: release fd on shm_open error paths [117419]

### DIFF
--- a/subsys/portability/posix/options/shm.c
+++ b/subsys/portability/posix/options/shm.c
@@ -339,6 +339,7 @@ int shm_open(const char *name, int oflag, mode_t mode)
 	shm = shm_obj_find(key);
 	if ((shm != NULL) && shm->unlinked) {
 		/* we cannot open a shm object that has already been unlinked */
+		zvfs_free_fd(fd);
 		errno = EACCES;
 		return -1;
 	}
@@ -362,6 +363,7 @@ int shm_open(const char *name, int oflag, mode_t mode)
 			shm_obj_add(shm);
 		}
 	} else if (shm == NULL) {
+		zvfs_free_fd(fd);
 		errno = ENOENT;
 		return -1;
 	}


### PR DESCRIPTION
## Summary

`shm_open()` calls `zvfs_reserve_fd()` to allocate a descriptor before validating the shared memory object. Two error paths returned without releasing the descriptor, leaking it on repeated failed opens:

1. **Object already unlinked** (`EACCES` path): `fd` reserved but never freed.
2. **Object does not exist without `O_CREAT`** (`ENOENT` path): `fd` reserved but never freed.

Fixes #117419

## Changes

- Add `zvfs_free_fd(fd)` before `return -1` on the `EACCES` (unlinked object) path.
- Add `zvfs_free_fd(fd)` before `return -1` on the `ENOENT` (no `O_CREAT`, object missing) path.

These two additions mirror the existing `zvfs_free_fd(fd)` calls already present on the `O_CREAT/O_EXCL` (`EEXIST`) and allocation-failure (`ENOSPC`) paths in the same function.

## Testing

- Static inspection of all `zvfs_reserve_fd()` error returns in `shm_open()` confirms no remaining leak paths.