### PR TITLE
soc: nxp: mcxl: add ADVC driver support for MCXL255

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -435,5 +435,25 @@ if((DEFINED CONFIG_FLASH_MCUX_XSPI_XIP) AND (DEFINED CONFIG_FLASH))
     LOCATION ${CONFIG_FLASH_MCUX_XSPI_XIP_MEM}_RODATA)
 endif()
 
+if(CONFIG_ADVC_DRIVER_USED)
+  # Pull in fsl_advc.c/.h directly instead of turning on the whole
+  # driver.advc component: that component's device CMakeLists.txt
+  # (devices/MCX/MCXL/MCXL255/drivers/CMakeLists.txt) also links
+  # libadvc_cm33.a/libadvc_cm0p.a straight from the device tree, which
+  # doesn't exist for Zephyr (those binaries are fetched via `west blobs`
+  # into zephyr/blobs/mcxl255 instead). Linking the correct blob path below
+  # avoids ever adding the wrong one, so no fixup.cmake cleanup is needed.
+  set(advc_drivers_dir ${SdkRootDirPath}/devices/MCX/MCXL/MCXL255/drivers)
+  zephyr_library_sources(${advc_drivers_dir}/fsl_advc.c)
+  zephyr_include_directories(${advc_drivers_dir})
+
+  set(advc_blobs_dir ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/mcxl255)
+  if(CONFIG_SOC_MCXL255_CPU0)
+    target_link_libraries(${MCUX_SDK_PROJECT_NAME} PRIVATE ${advc_blobs_dir}/libadvc_cm33.a)
+  elseif(CONFIG_SOC_MCXL255_CPU1)
+    target_link_libraries(${MCUX_SDK_PROJECT_NAME} PRIVATE ${advc_blobs_dir}/libadvc_cm0p.a)
+  endif()
+endif()
+
 # Load all drivers
 mcux_load_all_cmakelists_in_directory(${SdkRootDirPath}/drivers)

--- a/soc/nxp/mcx/mcxl/Kconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig
@@ -23,6 +23,15 @@ config SOC_MCXL255_CPU0
 config SOC_MCXL255_CPU1
 	select CPU_CORTEX_M0PLUS
 
+config ADVC_DRIVER_USED
+	bool "NXP ADVC (Adaptive Voltage Control) driver support"
+	depends on SOC_MCXL255_CPU0 || SOC_MCXL255_CPU1
+	help
+	  Link the precompiled NXP ADVC library (fetched via west blobs)
+	  and enable the ADVC-aware code paths in the NXP power/clock
+	  drivers. When disabled, those drivers fall back to fixed
+	  voltage selection based on target frequency.
+
 config SOC_MCXL254_CPU0
 	select CPU_CORTEX_M33
 	select CPU_HAS_ARM_SAU


### PR DESCRIPTION
Blocked by:
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/117430

Add CONFIG_ADVC_DRIVER_USED to opt into the NXP ADVC (Adaptive Voltage Control) driver on MCXL255. Defaults to off, no behavior change for existing builds.

Wire it into the mcux-sdk-ng build: enable driver.advc and link libadvc_cm33.a / libadvc_cm0p.a from their west-blobs location (zephyr/blobs/mcxl255/) instead of the nonexistent device-tree path the auto-synced CMakeLists.txt points at.