### PR TITLE
dts: bindings: input: add row-size/col-size limits to keymap

### DIFF
--- a/dts/bindings/input/input-keymap.yaml
+++ b/dts/bindings/input/input-keymap.yaml
@@ -17,12 +17,16 @@ properties:
 
   row-size:
     type: int
+    min: 1
+    max: 255
     required: true
     description: |
       The number of rows in the keymap.
 
   col-size:
     type: int
+    min: 1
+    max: 255
     required: true
     description: |
       The number of columns in the keymap.


### PR DESCRIPTION
### Problem

In input-keymap.yaml, row-size and col-size had no range constraints, so invalid values (for example 257) could still compile. Keymap row/column values are encoded in 8-bit fields, so valid range is 1..255 for size properties.

### Validation

Modify to an invalid row-size in boards/steelseries/apex_pro_mini/apex_pro_mini.dts, 
``` 
keymap {
			compatible = "input-keymap";
			row-size = <257>;
			col-size = <1>;
			keymap = <MATRIX_KEY(0, 0, INPUT_KEY_ESC)
				  ... >;
}; 
```

Modify samples/basic/blinky/prj.conf
``` CONFIG_INPUT=y ```

Build command:
``` west build -p always -b apex_pro_mini samples/basic/blinky ```

Before this change, invalid input-keymap values could still build successfully. After, out-of-range values are now rejected during devicetree validation.