### PR TITLE
modules: hal_nxp: keep the i.MX952 device drivers on the include path

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake
@@ -87,6 +87,17 @@ if(CONFIG_SOC_MIMX94398)
   set(CONFIG_MCUX_COMPONENT_driver.elec_spec ON)
 endif()
 
+# Same story on i.MX952: fsl_common_arm.h unconditionally includes
+# "fsl_clock.h" from the device drivers/ folder, and on the Cortex-A55 the
+# clocks are driven over SCMI so driver.clock is not selected above. Enable the
+# header-only memory component, which is what puts that folder on the include
+# path, for the whole device. driver.clock itself cannot be used here: its
+# fsl_clock.c talks to the system manager directly and is not built for SCMI
+# configurations.
+if(CONFIG_SOC_MIMX9529)
+  set(CONFIG_MCUX_COMPONENT_driver.memory ON)
+endif()
+
 # load device variables
 include(${mcux_device_folder}/variable.cmake)
 


### PR DESCRIPTION
## Problem

Both i.MX952 A55 targets fail to build on main:

```
error: fsl_clock.h: No such file or directory
```

- `imx952_evk/mimx9529/a55:sample.kernel.synchronization`
- `imx952_evk/mimx9529/a55/smp:sample.kernel.synchronization`

## Cause

`fsl_common_arm.h` includes `"fsl_clock.h"` unconditionally, and on i.MX952 that header lives in the device `drivers/` folder. The SDK-NG only adds that folder to the include path when one of its components is selected.

Until the SDK 26.09.00 sync (747b57c53) `MIMX9529/drivers/CMakeLists.txt` did `mcux_add_include(INCLUDES .)` unconditionally; it now does it per component (with a `driver.common` fallback that Zephyr never sets, since Zephyr adds the common driver sources itself). On the A55 the clocks are managed over SCMI, so `driver.clock` is skipped and nothing else pulls the folder in.

## Fix

Enable the header-only `driver.memory` component for the device, which is what puts that folder on the include path — the same workaround already used a few lines above for the i.MX943 `fsl_elec_spec.h` header. `driver.clock` cannot be used instead: its `fsl_clock.c` drives the system manager directly and is not meant for SCMI configurations.

The SCMI includes inside `fsl_clock.h` are guarded by `#ifndef CONFIG_ARM_SCMI`, so the header itself is fine to pull in here.