### PR TITLE
drivers: mfd: infineon_mxcrypto: fix build without a child driver

### DIFF
--- a/drivers/mfd/Kconfig.infineon_mxcrypto
+++ b/drivers/mfd/Kconfig.infineon_mxcrypto
@@ -5,14 +5,18 @@
 
 config MFD_INFINEON_MXCRYPTO
 	bool "Infineon MXCRYPTO multi-function device driver"
-	default y
+	default y if ENTROPY_INFINEON_MXCRYPTO_TRNG || CRYPTO_INFINEON_MXCRYPTO
 	depends on DT_HAS_INFINEON_MXCRYPTO_ENABLED
+	select USE_INFINEON_MXCRYPTO_CORE
 	help
 	  Enable the Infineon MXCRYPTO MFD driver.  The MXCRYPTO block is a
 	  single hardware crypto engine shared by a True Random Number Generator
 	  (TRNG) and AES / SHA acceleration.  This driver owns the shared
 	  register base address and the mutex that serialises access between the
-	  TRNG and crypto child function drivers.
+	  TRNG and crypto child function drivers, and enables the block through
+	  the MXCRYPTO PDL.
+
+	  Enabled by default when a child function driver is enabled.
 
 config MFD_INFINEON_MXCRYPTO_INIT_PRIORITY
 	int "Infineon MXCRYPTO MFD init priority"

--- a/modules/hal_infineon/Kconfig
+++ b/modules/hal_infineon/Kconfig
@@ -104,18 +104,27 @@ config USE_INFINEON_TRNG
 	help
 	  Enable True Random Number Generator (TRNG) HAL module driver for Infineon devices
 
+config USE_INFINEON_MXCRYPTO_CORE
+	bool
+	help
+	  Enable Infineon MXCRYPTO PDL core sources, shared by the TRNG, AES
+	  and SHA accelerators and by the MFD driver that enables the block
+
 config USE_INFINEON_MXCRYPTO_TRNG
 	bool
+	select USE_INFINEON_MXCRYPTO_CORE
 	help
 	  Enable Infineon MXCRYPTO PDL TRNG hardware accelerator sources
 
 config USE_INFINEON_MXCRYPTO_AES
 	bool
+	select USE_INFINEON_MXCRYPTO_CORE
 	help
 	  Enable Infineon MXCRYPTO PDL AES (ECB/CBC/CTR/CCM/GCM) hardware accelerator sources
 
 config USE_INFINEON_MXCRYPTO_SHA
 	bool
+	select USE_INFINEON_MXCRYPTO_CORE
 	help
 	  Enable Infineon MXCRYPTO PDL SHA (SHA-224/256/384/512) hardware accelerator sources
 

--- a/modules/hal_infineon/mtb-dsl-pse8xxgp/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-dsl-pse8xxgp/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_LPCOMP ${pdl_drv_dir}/source/cy_lpcomp.c)
 
-if(CONFIG_USE_INFINEON_MXCRYPTO_AES OR CONFIG_USE_INFINEON_MXCRYPTO_SHA OR CONFIG_USE_INFINEON_MXCRYPTO_TRNG)
+if(CONFIG_USE_INFINEON_MXCRYPTO_CORE)
   zephyr_library_sources(${pdl_drv_dir}/source/cy_crypto.c)
   zephyr_library_sources(${pdl_drv_dir}/source/cy_crypto_core_hw.c)
   zephyr_library_sources(${pdl_drv_dir}/source/cy_crypto_core_hw_v1.c)


### PR DESCRIPTION
Lining this up as a an alternative to reverting #117103 as proposed in #117440. Will live it at the discretion of fellow release engineers which hotfix is preferred.

Also would appreciate @lauracarlesso @teburd @mcatee-infineon input here.

## Problem

Five `kit_pse84_eval` tests fail to link on main:

```
undefined reference to `Cy_Crypto_Core_Enable'
```

- `kit_pse84_eval/pse846gps2dbzc4a/m55:sample.boards.infineon.autanalog_fir_fifo`
- `kit_pse84_eval/pse846gps2dbzc4a/m55:sample.driver.adc_stream.pse84`
- `kit_pse84_eval/pse846gps2dbzc4a/m33:drivers.comparator.build.build`
- `kit_pse84_eval/pse846gps2dbzc4a/m55:drivers.comparator.build.build`
- `kit_pse84_eval/pse846gps2dbzc4a/m55:drivers.comparator.gpio_loopback.infineon_ptcomp`

## Cause

The MXCRYPTO MFD init hook calls `Cy_Crypto_Core_Enable()`, but the driver never selected the PDL sources that provide it — `cy_crypto_core_hw.c` and friends are only built when a child function driver selects one of the `USE_INFINEON_MXCRYPTO_*` symbols. On top of that, `MFD_INFINEON_MXCRYPTO` is `default y` whenever `DT_HAS_INFINEON_MXCRYPTO_ENABLED`, which on PSE84 is always (the `crypto0` node has no `status` property).

So any build that pulls in MFD for another Infineon function driver (autanalog, HPPASS, PTCOMP) while leaving crypto and entropy off gets the MFD with no PDL behind it. That has been true since the driver landed in #108439; it only became visible when #117103 dropped crypto and entropy from the board defconfigs.

## Fix

Add a hidden `USE_INFINEON_MXCRYPTO_CORE` symbol for the PDL sources shared by the TRNG, AES and SHA accelerators, selected by all three and by the MFD driver itself, so the MFD builds on its own — a driver should select the HAL sources it calls.

Then default the MFD to `y` only when a child function driver is enabled, so it is no longer instantiated (and the crypto block no longer powered up at `PRE_KERNEL_1`) in builds that have no use for it. Unlike `depends on`, this keeps `CONFIG_MFD_INFINEON_MXCRYPTO=y` working if someone enables it explicitly.

No change for configurations that already use the TRNG or the crypto driver: they select `USE_INFINEON_MXCRYPTO_CORE` through the same PDL symbols as before, and still get the MFD by default.

> [!NOTE]
> **Alternative:** #117440 reverts #117103 instead. Turns main back to green but re-hides the driver bug rather than fixing it: the MFD has been unbuildable without crypto or entropy since #108439.