### PR TITLE
boards: qemu: x86: fix BOARD_QEMU_X86 leaking to the other x86 boards

### DIFF
--- a/boards/qemu/x86/Kconfig
+++ b/boards/qemu/x86/Kconfig
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-config BOARD_QEMU_X86
+# The 32-bit and the 64-bit boards share the Atom SoC, so unlike the other x86
+# SoCs, soc/intel/atom cannot select the sub-architecture itself.
+config QEMU_X86_64BIT
 	bool
-	default y
-	select CPU_HAS_FPU if BOARD_QEMU_X86 || BOARD_QEMU_X86_LAKEMONT || BOARD_QEMU_X86_TINY
-	select X86_64 if BOARD_QEMU_X86_64 || BOARD_QEMU_X86_64_KVM
+	default y if BOARD_QEMU_X86_64 || BOARD_QEMU_X86_64_KVM
+	select X86_64
 	select X86_CPU_HAS_CET if BOARD_QEMU_X86_64_KVM


### PR DESCRIPTION
2b0b93231 ("boards: qemu: Update x86 Kconfig to be more HWMv2-y") gave `BOARD_QEMU_X86` a `default y`, but `boards/qemu/x86/Kconfig` is the *directory*-level Kconfig, sourced for every board in `board.yml` — so the symbol is also y for `qemu_x86_64`, `qemu_x86_lakemont`, `qemu_x86_tiny` and `qemu_x86_64_kvm`.

That pulls in the `if BOARD_QEMU_X86` block of `Kconfig.defconfig`, which enables `MULTIBOOT`, so `arch/x86/core/bootargs.c` takes the multiboot branch instead of the EFI one and `qemu_x86_64/atom:sample.kernel.bootargs.efi` fails to build with `error: 'zefi_bootargs' undeclared`. Every other user of the symbol means the `qemu_x86` board specifically (`arch/common/acpi/acpi.c` and `arch/x86/core/fatal.c` test it *next to* `BOARD_QEMU_X86_64`), so the uart_pipe 802.15.4 dependency, the Bluetooth monitor default and a couple of test Kconfigs are mis-applied the same way.

The intent of 2b0b93231 is right — board symbols are created by the build system and shouldn't be redeclared by hand — so `BOARD_QEMU_X86` is left untouched and the selects move onto a board-agnostic helper symbol, the pattern `boards/acrn/acrn/Kconfig` already uses for its three boards.

`CPU_HAS_FPU` drops out entirely: `CPU_ATOM` and `CPU_LAKEMONT_PERF` already select it, and `SOC_ATOM` / `SOC_LAKEMONT` select those. `X86_64` is the only one that has to stay at board level, because `atom` is shared by the 32- and 64-bit boards — every other x86 SoC (`soc/intel/*_lake/Kconfig`) selects it itself.

cc @edersondisouza
