### PR TITLE
tracing: ctf: Configurable CTF timestamp function

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -144,6 +144,12 @@ config TRACING_CTF_TIMESTAMP
 	  Timestamp prefix will be added to the beginning of CTF
 	  event internally.
 
+config TRACING_CTF_CONFIGURABLE_TIMER
+	bool "CTF configurable timestamp function"
+	depends on TRACING_CTF_TIMESTAMP
+	help
+	  Enable configurable timestamp function.
+
 choice TRACING_METHOD_CHOICE
 	prompt "Tracing Method"
 	default TRACING_ASYNC

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -20,6 +20,24 @@ struct rtio_sqe;
 struct rtio_cqe;
 struct rtio_iodev_sqe;
 
+#ifdef CONFIG_TRACING_CTF_CONFIGURABLE_TIMER
+static ctf_timestamp_get_t ctf_timestamp_func = ctf_top_timestamp_get;
+
+int ctf_set_timestamp_func(ctf_timestamp_get_t timestamp_getter)
+{
+	if (timestamp_getter == NULL) {
+		return -EINVAL;
+	}
+	ctf_timestamp_func = timestamp_getter;
+	return 0;
+}
+
+uint64_t ctf_timestamp_get(void)
+{
+	return ctf_timestamp_func();
+}
+#endif /* CONFIG_TRACING_CTF_CONFIGURABLE_TIMER */
+
 static void _get_thread_name(struct k_thread *thread, ctf_bounded_string_t *name)
 {
 	const char *tname = k_thread_name_get(thread);

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -58,13 +58,24 @@ static inline uint64_t ctf_top_timestamp_get(void)
 	return timing_ns_get();
 }
 
+#ifdef CONFIG_TRACING_CTF_CONFIGURABLE_TIMER
+typedef uint64_t (*ctf_timestamp_get_t)(void);
+int ctf_set_timestamp_func(ctf_timestamp_get_t timestamp_getter);
+uint64_t ctf_timestamp_get(void);
+#else  /* CONFIG_TRACING_CTF_CONFIGURABLE_TIMER */
+static inline uint64_t ctf_timestamp_get(void)
+{
+	return ctf_top_timestamp_get();
+}
+#endif /* CONFIG_TRACING_CTF_CONFIGURABLE_TIMER */
+
 #define CTF_EVENT(...)                                                                             \
 	{                                                                                          \
 		if (!is_tracing_enabled()) {                                                       \
 			return;                                                                    \
 		}                                                                                  \
 		int key = irq_lock();                                                              \
-		const uint64_t tstamp = ctf_top_timestamp_get();                                   \
+		const uint64_t tstamp = ctf_timestamp_get();                                       \
                                                                                                    \
 		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                                             \
 		irq_unlock(key);                                                                   \

--- a/subsys/tracing/include/tracing_core.h
+++ b/subsys/tracing/include/tracing_core.h
@@ -92,6 +92,10 @@ void tracing_trigger_output(bool before_put_is_empty);
  */
 bool is_tracing_thread(void);
 
+#ifdef CONFIG_TRACING_CTF_CONFIGURABLE_TIMER
+int tracing_set_ctf_timestamp_func(uint64_t (*ctf_timestamp_func)(void));
+#endif /* CONFIG_TRACING_CTF_CONFIGURABLE_TIMER */
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -20,6 +20,9 @@
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
 #include <zephyr/timing/timing.h>
 #endif
+#ifdef CONFIG_TRACING_CTF_CONFIGURABLE_TIMER
+#include <ctf_top.h>
+#endif /* CONFIG_TRACING_CTF_CONFIGURABLE_TIMER */
 
 #define TRACING_CMD_ENABLE  "enable"
 #define TRACING_CMD_DISABLE "disable"
@@ -235,3 +238,10 @@ int tracing_backends_flush(void)
 
 	return ret;
 }
+
+#ifdef CONFIG_TRACING_CTF_CONFIGURABLE_TIMER
+int tracing_set_ctf_timestamp_func(uint64_t (*ctf_timestamp_func)(void))
+{
+	return ctf_set_timestamp_func(ctf_timestamp_func);
+}
+#endif /* CONFIG_TRACING_CTF_CONFIGURABLE_TIMER */


### PR DESCRIPTION
Enables configurability of CTF timestamp getter to allow synchronization of different SoCs using shared clock.