### PR TITLE
boards: qemu: x86: disable qemu_x86_64_kvm in twister

### DIFF
--- a/boards/qemu/x86/qemu_x86_64_kvm.yaml
+++ b/boards/qemu/x86/qemu_x86_64_kvm.yaml
@@ -14,3 +14,7 @@ testing:
     - benchmark
     - kernel
 vendor: qemu
+
+# Running this board needs /dev/kvm and a QEMU able to emulate CET, which no
+# CI runner nor any Zephyr SDK release provides yet.
+twister: false


### PR DESCRIPTION
`qemu_x86_64_kvm/atom:sample.kernel.synchronization` fails on main with `unexpected eof` — QEMU dies before printing anything.

The board needs `/dev/kvm` and a QEMU able to emulate CET (Linux ≥ 6.18, QEMU ≥ 11.0 per c0a8c419b); CI has neither. `testing: default: false` does not keep twister away, since `build_on_all` tests are built and run on every platform regardless.

`twister: false` takes the platform out of twister entirely — it is never assigned a test, whatever the test asks for. Nothing in the tree selects the board by name, so nothing else changes. Drop the flag once a QEMU that can run it is generally available.