### PR TITLE
drivers: nrf_clock_calibration: remove duplicate code

### DIFF
--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -54,18 +54,12 @@ static struct onoff_manager *mgrs;
 #endif
 
 /* Temperature sensor is only needed if
- * CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP > 0, or
  * CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP > 0, since a value of 0
  * indicates performing calibration periodically regardless of temperature
  * change.
  */
-#ifdef CONFIG_CLOCK_CONTROL_NRF
 #define USE_TEMP_SENSOR							\
 	(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP > 0)
-#else
-#define USE_TEMP_SENSOR							\
-	(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP > 0)
-#endif
 
 #if USE_TEMP_SENSOR
 static const struct device *const temp_sensor =
@@ -167,29 +161,20 @@ static void start_hw_cal(void)
 {
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
 	nrfx_clock_calibration_start();
-	calib_skip_cnt = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP;
 #else
 	nrfx_clock_lfclk_calibration_start();
-	calib_skip_cnt = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP;
 #endif
+	calib_skip_cnt = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP;
 }
 
 /* Start cycle by starting backoff timer and releasing HFCLK XTAL. */
 static void start_cycle(void)
 {
 	k_timer_start(&backoff_timer,
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 		      K_MSEC(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD),
-#else
-		      K_MSEC(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD),
-#endif
 		      K_NO_WAIT);
 	hf_release();
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	if (!IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_LF_ALWAYS_ON)) {
-#else
-	if (!IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_LF_ALWAYS_ON)) {
-#endif
 		lf_release();
 	}
 
@@ -202,12 +187,7 @@ static void start_cal_process(void)
 		return;
 	}
 
-
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_LF_ALWAYS_ON)) {
-#else
-	if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_LF_ALWAYS_ON)) {
-#endif
 		hf_request();
 	} else {
 		/* LF clock is probably running but it is requested to ensure
@@ -287,11 +267,7 @@ static void measure_temperature(struct k_work *work)
 	}
 
 	if ((calib_skip_cnt == 0) ||
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 		(diff >= CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF)) {
-#else
-		(diff >= CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF)) {
-#endif
 		prev_temperature = temperature;
 		started = true;
 		start_hw_cal();
@@ -356,11 +332,7 @@ void z_nrf_clock_calibration_done_handler(void)
 
 int z_nrf_clock_calibration_count(void)
 {
-#ifdef CONFIG_CLOCK_CONTROL_NRF
 	if (!IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG)) {
-#else
-	if (!IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG)) {
-#endif
 		return -1;
 	}
 
@@ -369,11 +341,7 @@ int z_nrf_clock_calibration_count(void)
 
 int z_nrf_clock_calibration_skips_count(void)
 {
-#ifdef CONFIG_CLOCK_CONTROL_NRF
 	if (!IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG)) {
-#else
-	if (!IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG)) {
-#endif
 		return -1;
 	}
 

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -136,8 +136,7 @@ void z_nrf_clock_calibration_force_start(void);
 
 /** @brief Return number of calibrations performed.
  *
- * Valid when @kconfig{CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG} or
- * @kconfig{CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG} is set.
+ * Valid when @kconfig{CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG} is set.
  *
  * @return Number of calibrations or -1 if feature is disabled.
  */
@@ -145,8 +144,7 @@ int z_nrf_clock_calibration_count(void);
 
 /** @brief Return number of attempts when calibration was skipped.
  *
- * Valid when @kconfig{CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG} or
- * @kconfig{CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG} is set.
+ * Valid when @kconfig{CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_DEBUG} is set.
  *
  * @return Number of calibrations or -1 if feature is disabled.
  */

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
@@ -143,26 +143,16 @@ static void sync_just_after_calibration(void)
  */
 ZTEST(nrf_clock_calibration, test_basic_clock_calibration)
 {
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	int wait_ms = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD *
 		(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP + 1) +
-#else
-	int wait_ms = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD *
-		(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP + 1) +
-#endif
 		CALIBRATION_PROCESS_TIME_MS;
 	struct sensor_value value = { .val1 = 0, .val2 = 0 };
 
 	mock_temp_nrf5_value_set(&value);
 	sync_just_after_calibration();
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	TEST_CALIBRATION(1, CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP,
 			 wait_ms);
-#else
-	TEST_CALIBRATION(1, CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP,
-			 wait_ms);
-#endif
 }
 
 /* Test checks if calibration happens just after clock is enabled. */
@@ -201,11 +191,7 @@ ZTEST(nrf_clock_calibration, test_calibration_after_enabling_lfclk)
 	turn_on_clock(clk_dev);
 #endif
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	TEST_CALIBRATION(1, 0, CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD);
-#else
-	TEST_CALIBRATION(1, 0, CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD);
-#endif
 }
 
 /* Test checks if temperature change triggers calibration. */
@@ -216,7 +202,6 @@ ZTEST(nrf_clock_calibration, test_temp_change_triggers_calibration)
 	mock_temp_nrf5_value_set(&value);
 	sync_just_after_calibration();
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	/* change temperature by 0.25'C which should not trigger calibration */
 	value.val2 += ((CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF - 1) *
 			250000);
@@ -238,29 +223,6 @@ ZTEST(nrf_clock_calibration, test_temp_change_triggers_calibration)
 	/* expect calibration due to temp change. */
 	TEST_CALIBRATION(1, 0,
 			 CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD + 40);
-#else
-	/* change temperature by 0.25'C which should not trigger calibration */
-	value.val2 += ((CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF - 1) *
-			250000);
-
-	mock_temp_nrf5_value_set(&value);
-
-	/* expected one skip */
-	TEST_CALIBRATION(0, CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP,
-				CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP *
-				CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD +
-				CALIBRATION_PROCESS_TIME_MS);
-
-	TEST_CALIBRATION(1, 0,
-			 CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD + 40);
-
-	value.val2 += (CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF * 250000);
-	mock_temp_nrf5_value_set(&value);
-
-	/* expect calibration due to temp change. */
-	TEST_CALIBRATION(1, 0,
-			 CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD + 40);
-#endif
 }
 
 /* Test checks if z_nrf_clock_calibration_force_start() results in immediate
@@ -276,19 +238,11 @@ ZTEST(nrf_clock_calibration, test_force_calibration)
 	TEST_CALIBRATION(1, 0,
 		CALIBRATION_PROCESS_TIME_MS + 5);
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	/* and back to scheduled operation. */
 	TEST_CALIBRATION(1, CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP,
 		CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD *
 		(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP + 1) +
 		CALIBRATION_PROCESS_TIME_MS);
-#else
-	/* and back to scheduled operation. */
-	TEST_CALIBRATION(1, CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP,
-		CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD *
-		(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP + 1) +
-		CALIBRATION_PROCESS_TIME_MS);
-#endif
-
 }
+
 ZTEST_SUITE(nrf_clock_calibration, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Removed leftover duplicate code after Nordic clock control rework.