### PR TITLE
boards: nrfbsim & native_sim: Support both irq_pending and _get_active APIs

### DIFF
--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/arch/posix/posix_soc_if.h>
 #include "board_irq.h"
+#include <zephyr/irq.h>
 
 #ifdef CONFIG_IRQ_OFFLOAD
 #include <zephyr/irq_offload.h>
@@ -35,6 +36,36 @@ int arch_irq_is_enabled(unsigned int irq)
 {
 	return posix_irq_is_enabled(irq);
 }
+
+#ifdef CONFIG_ARCH_HAS_IRQ_PENDING_OPS
+void arch_irq_set_pending(unsigned int irq)
+{
+	posix_sw_set_pending_IRQ(irq);
+}
+
+void arch_irq_clear_pending(unsigned int irq)
+{
+	posix_sw_clear_pending_IRQ(irq);
+}
+
+bool arch_irq_is_pending(unsigned int irq)
+{
+	return posix_irq_is_pending(irq);
+}
+#endif /* CONFIG_ARCH_HAS_IRQ_PENDING_OPS */
+
+#ifdef CONFIG_ARCH_HAS_IRQ_GET_ACTIVE
+unsigned int arch_irq_get_active(void)
+{
+	int current = posix_get_current_irq();
+
+	if (current == -1) {
+		return K_IRQ_ACTIVE_NONE;
+	} else {
+		return current;
+	}
+}
+#endif
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
 /**

--- a/boards/native/native_sim/Kconfig
+++ b/boards/native/native_sim/Kconfig
@@ -8,6 +8,8 @@ config BOARD_NATIVE_SIM
 	select NATIVE_LIBRARY
 	select NATIVE_SIM_TIMER
 	select 64BIT if BOARD_NATIVE_SIM_NATIVE_64
+	select ARCH_HAS_IRQ_PENDING_OPS
+	select ARCH_HAS_IRQ_GET_ACTIVE
 	help
 	  Native simulator (Single Core)
 	  Will produce a console Linux process which can be executed natively.

--- a/boards/native/native_sim/irq_handler.c
+++ b/boards/native/native_sim/irq_handler.c
@@ -213,6 +213,11 @@ int posix_irq_is_enabled(unsigned int irq)
 	return hw_irq_ctrl_is_irq_enabled(irq);
 }
 
+int posix_irq_is_pending(unsigned int irq)
+{
+	return hw_irq_ctrl_is_irq_pending(irq);
+}
+
 int posix_get_current_irq(void)
 {
 	return currently_running_irq;

--- a/boards/native/nrf_bsim/Kconfig
+++ b/boards/native/nrf_bsim/Kconfig
@@ -77,6 +77,8 @@ config SOC_SERIES_BSIM_NRFXX
 	select HAS_NRFX
 	select HAS_NORDIC_DRIVERS
 	select PINCTRL_DYNAMIC if PINCTRL
+	select ARCH_HAS_IRQ_PENDING_OPS
+	select ARCH_HAS_IRQ_GET_ACTIVE
 	help
 	  Any NRF simulated SOC with BabbleSim, based on the POSIX arch
 

--- a/boards/native/nrf_bsim/irq_handler.c
+++ b/boards/native/nrf_bsim/irq_handler.c
@@ -236,6 +236,14 @@ int posix_irq_is_enabled(unsigned int irq)
 	return hw_irq_ctrl_is_irq_enabled(CONFIG_NATIVE_SIMULATOR_MCU_N, irq);
 }
 
+/**
+ * Report whether an irq is pending (not necessarily active)
+ */
+int posix_irq_is_pending(unsigned int irq)
+{
+	return hw_irq_ctrl_is_irq_pending(CONFIG_NATIVE_SIMULATOR_MCU_N, irq);
+}
+
 int posix_get_current_irq(void)
 {
 	return currently_running_irq;

--- a/include/zephyr/arch/posix/posix_soc_if.h
+++ b/include/zephyr/arch/posix/posix_soc_if.h
@@ -27,6 +27,7 @@ void posix_atomic_halt_cpu(unsigned int imask);
 void posix_irq_enable(unsigned int irq);
 void posix_irq_disable(unsigned int irq);
 int  posix_irq_is_enabled(unsigned int irq);
+int  posix_irq_is_pending(unsigned int irq);
 unsigned int posix_irq_lock(void);
 void posix_irq_unlock(unsigned int key);
 void posix_irq_full_unlock(void);

--- a/scripts/native_simulator/native/src/include/irq_ctrl.h
+++ b/scripts/native_simulator/native/src/include/irq_ctrl.h
@@ -31,6 +31,7 @@ uint32_t hw_irq_ctrl_change_lock(uint32_t new_lock);
 uint64_t hw_irq_ctrl_get_irq_status(void);
 void hw_irq_ctrl_disable_irq(unsigned int irq);
 int hw_irq_ctrl_is_irq_enabled(unsigned int irq);
+int hw_irq_ctrl_is_irq_pending(unsigned int irq);
 void hw_irq_ctrl_clear_irq(unsigned int irq);
 void hw_irq_ctrl_enable_irq(unsigned int irq);
 void hw_irq_ctrl_set_irq(unsigned int irq);

--- a/scripts/native_simulator/native/src/include/nsi_timer_model.h
+++ b/scripts/native_simulator/native/src/include/nsi_timer_model.h
@@ -21,8 +21,10 @@ void hwtimer_set_rt_ratio(double ratio);
 void hwtimer_adjust_rt_ratio(double ratio_correction);
 
 void hwtimer_wake_in_time(uint64_t time);
-void hwtimer_set_silent_ticks(int64_t sys_ticks);
+
 void hwtimer_enable(uint64_t period);
+void hwtimer_set_tick_one_shot(uint64_t deadline);
+void hwtimer_set_silent_ticks(int64_t sys_ticks);
 int64_t hwtimer_get_pending_silent_ticks(void);
 
 void hwtimer_reset_rtc(void);

--- a/scripts/native_simulator/native/src/irq_ctrl.c
+++ b/scripts/native_simulator/native/src/irq_ctrl.c
@@ -157,6 +157,11 @@ int hw_irq_ctrl_is_irq_enabled(unsigned int irq)
 	return (irq_mask & ((uint64_t)1 << irq))?1:0;
 }
 
+int hw_irq_ctrl_is_irq_pending(unsigned int irq)
+{
+	return (irq_premask & ((uint64_t)1 << irq))?1:0;
+}
+
 /**
  * Get the current interrupt enable mask
  */

--- a/scripts/native_simulator/native/src/timer_model.c
+++ b/scripts/native_simulator/native/src/timer_model.c
@@ -189,11 +189,44 @@ static void hwtimer_init(void)
 NSI_TASK(hwtimer_init, HW_INIT, 10);
 
 /**
- * Enable the HW timer tick interrupts with a period <period> in microseconds
+ * Enable the HW ticker timer in one shot mode, so it triggers once at <deadline>
+ * where <deadline> is the number of microseconds since boot.
+ *
+ * If deadline is in the past, at less than UINT64_MAX/2 it will trigger immediately.
+ * If it is further than that, an overflow will be assumed, and it will not trigger ever.
+ *
+ * You can call it with deadline = NSI_NEVER to effectively disable the tick timer interrupt
+ *
+ * Note a possible periodic tick, and silent_ticks, configuration will be cleared.
+ */
+void hwtimer_set_tick_one_shot(uint64_t deadline)
+{
+	uint64_t now = nsi_hws_get_time();
+
+	if (deadline < now) {
+		if ((now - deadline) > UINT64_MAX/2) {
+			nsi_print_warning("%s: deadline seems to have overflowed. "
+					  "It will never trigger.\n", __func__);
+			deadline = NSI_NEVER;
+		} else {
+			deadline = now;
+		}
+	}
+	hw_timer_tick_timer = deadline;
+	tick_p = NSI_NEVER;
+	silent_ticks = 0;
+	hwtimer_update_timer();
+	nsi_hws_find_next_event();
+}
+
+/**
+ * Enable the HW timer periodic tick interrupts with a period <period> in microseconds.
  *
  * The next interrupt will be <period> microseconds from now.
  *
  * If silent_ticks had been enabled, it will be cleared.
+ * If a one shot deadline had been configured it will also be cleared.
+ *
  * If period would overflow the timer, the deadline will be set at the end of time (NSI_NEVER)
  */
 void hwtimer_enable(uint64_t period)
@@ -290,7 +323,8 @@ NSI_HW_EVENT(hw_timer_timer, hwtimer_timer_reached, 0);
 
 /**
  * The timer HW will awake the CPU (without an interrupt) at least when <time>
- * comes (it may awake it earlier)
+ * comes (it may awake it earlier).
+ * This is unrelated to the timer tick functionality and its one shot mode
  *
  * If there was a previous request for an earlier time, the old one will prevail
  *


### PR DESCRIPTION
    boards: nrfbsim & native_sim: Support both irq_pending and _get_active APIs
    
    Provide a hook for posix_irq_is_pending() and, as we already
    supported all other APIs from these sets, claim support for
    ARCH_HAS_IRQ_PENDING_OPS and ARCH_HAS_IRQ_GET_ACTIVE
 
------

    arch: posix: Provide hooks for new irq pending and irq get active API
    
    Provide a standard API towards boards, and hooks at the arch level
    so boards can provide the ARCH_HAS_IRQ_PENDING_OPS and
    ARCH_HAS_IRQ_GET_ACTIVE kernel APIs.
    
    Note: Boards do not necessarily need to implement this, so this does
    not break out of tree boards forcing anybody to immediately provide
    those. But it is recommended for all POSIX arch boards to provide them.
    
-----

    native_simulator: Get latest from upstream
    * 38c1844 native irq_ctrl: Add is_pending AP

Note the PR includes an extra commit updating the native simulator to avoid needing to rebase this or another PR wjhich in flight depending on merge order. Just ignore this first commit.

Relates to
* #117388
* https://github.com/zephyrproject-rtos/zephyr/pull/116360