### PR TITLE
boards: Add sysbuild domain export to Renode Robot test construction

### DIFF
--- a/boards/common/renode_robot.board.cmake
+++ b/boards/common/renode_robot.board.cmake
@@ -14,4 +14,9 @@ board_runner_args(renode-robot "--renode-robot-arg=--variable=UART:${RENODE_UART
 board_runner_args(renode-robot "--renode-robot-arg=--variable=KEYWORDS:${ZEPHYR_BASE}/tests/robot/common.robot")
 board_runner_args(renode-robot "--renode-robot-arg=--variable=RESULTS_DIR:${APPLICATION_BINARY_DIR}")
 
+if(SYSBUILD)
+  get_filename_component(SYSBUILD_ROOT_DIR "${CMAKE_BINARY_DIR}" DIRECTORY)
+  board_runner_args(renode-robot "--renode-robot-arg=--variable=SYSBUILD_DIR:${SYSBUILD_ROOT_DIR}")
+endif()
+
 board_finalize_runner_args(renode-robot)


### PR DESCRIPTION
Adds sysbuild domain information to the runtime arguments of `renode-robot` in board test CMake