### PR TITLE
net: sockets: skip recv callback re-registration on every send

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -663,9 +663,11 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	end = sys_timepoint_calc(timeout);
 
 	/* Register the callback before sending in order to receive the response
-	 * from the peer.
+	 * from the peer. Once registered, a context with a connection handler
+	 * needs no update.
 	 */
-	if (!sock_is_eof(ctx)) {
+	if (!sock_is_eof(ctx) &&
+	    (ctx->recv_cb != zsock_received_cb || ctx->conn_handler == NULL)) {
 		status = net_context_recv(ctx, zsock_received_cb,
 					  K_NO_WAIT, ctx->user_data);
 		if (status < 0) {


### PR DESCRIPTION
`zsock_sendto_ctx()` re-registered `zsock_received_cb` via `net_context_recv()` before every single send — a context mutex pair, a `bind_default()` re-run and two sockaddr copies into the connection table, all a no-op after the first registration. Skip it when the callback is registered and a connection handler exists; bind/connect/accept re-register themselves, and offloaded contexts (no conn_handler) keep the per-send behaviour.

Instruction counts (callgrind, native_sim/native/64 on x86-64, UDP loopback 32-byte datagrams): `zsock_sendto_ctx()` 9955 → 9523 (-4.3%), one mutex pair and one conn-table update less per send.

## `1c71f3f4179` vs `upstream/main` (qemu_x86)

| Metric | Reference (Mbps) | Candidate (Mbps) | Change | Status |
|:--|--:|--:|--:|:--|
| `udp4_mbps` | 14.316 | 14.357 | +0.29% | PASS |
| `udp4_frag_mbps` | 21.729 | 22.080 | +1.62% | PASS |
| `tcp4_mbps` | 7.068 | 7.101 | +0.47% | PASS |
| `tcp4_nodelay_mbps` | 7.032 | 7.062 | +0.43% | PASS |
| `udp6_mbps` | 14.171 | 14.667 | +3.50% | PASS |
| `udp6_frag_mbps` | 21.532 | 21.932 | +1.86% | PASS |
| `tcp6_mbps` | 7.126 | 7.156 | +0.42% | PASS |
| `tcp6_nodelay_mbps` | 7.134 | 7.163 | +0.41% | PASS |

