### PR TITLE
net: sockets: read snd/rcv timeout without taking the context mutex

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -66,6 +66,32 @@ static int fifo_wait_non_empty(struct k_fifo *fifo, k_timeout_t timeout)
 	return k_poll(events, ARRAY_SIZE(events), timeout);
 }
 
+/* Read the send/receive timeout without going through
+ * net_context_get_option(): that helper takes the context mutex for what
+ * is a single k_timeout_t load.  These are called on every blocking
+ * send/recv, where the per-socket fd mutex already serializes against
+ * setsockopt(SO_SNDTIMEO/SO_RCVTIMEO) from other threads.
+ */
+static k_timeout_t zsock_get_sndtimeo(const struct net_context *ctx)
+{
+#if defined(CONFIG_NET_CONTEXT_SNDTIMEO)
+	return ctx->options.sndtimeo;
+#else
+	ARG_UNUSED(ctx);
+	return K_FOREVER;
+#endif
+}
+
+static k_timeout_t zsock_get_rcvtimeo(const struct net_context *ctx)
+{
+#if defined(CONFIG_NET_CONTEXT_RCVTIMEO)
+	return ctx->options.rcvtimeo;
+#else
+	ARG_UNUSED(ctx);
+	return K_FOREVER;
+#endif
+}
+
 static void zsock_flush_queue(struct net_context *ctx)
 {
 	bool is_listen = net_context_get_state(ctx) == NET_CONTEXT_LISTENING;
@@ -657,7 +683,7 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 		timeout = K_NO_WAIT;
 		buf_timeout = sys_timepoint_calc(K_NO_WAIT);
 	} else {
-		net_context_get_option(ctx, NET_OPT_SNDTIMEO, &timeout, NULL);
+		timeout = zsock_get_sndtimeo(ctx);
 		buf_timeout = sys_timepoint_calc(MAX_WAIT_BUFS);
 	}
 	end = sys_timepoint_calc(timeout);
@@ -715,7 +741,7 @@ ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct net_msghdr *msg,
 		timeout = K_NO_WAIT;
 		buf_timeout = sys_timepoint_calc(K_NO_WAIT);
 	} else {
-		net_context_get_option(ctx, NET_OPT_SNDTIMEO, &timeout, NULL);
+		timeout = zsock_get_sndtimeo(ctx);
 		buf_timeout = sys_timepoint_calc(MAX_WAIT_BUFS);
 	}
 	end = sys_timepoint_calc(timeout);
@@ -1264,7 +1290,7 @@ static ssize_t zsock_recv_dgram(struct net_context *ctx,
 	} else {
 		int ret;
 
-		net_context_get_option(ctx, NET_OPT_RCVTIMEO, &timeout, NULL);
+		timeout = zsock_get_rcvtimeo(ctx);
 
 		ret = zsock_wait_data(ctx, &timeout);
 		if (ret < 0) {
@@ -1680,7 +1706,7 @@ static ssize_t zsock_recv_stream(struct net_context *ctx, struct net_msghdr *msg
 	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
 		timeout = K_NO_WAIT;
 	} else if (!sock_is_eof(ctx) && !sock_is_error(ctx)) {
-		net_context_get_option(ctx, NET_OPT_RCVTIMEO, &timeout, NULL);
+		timeout = zsock_get_rcvtimeo(ctx);
 	}
 
 	if (max_len == 0) {


### PR DESCRIPTION
Every blocking send/recv fetched SO_SNDTIMEO/SO_RCVTIMEO through `net_context_get_option()` — a context mutex pair plus a 25-case switch for a single `k_timeout_t` load. The per-socket fd mutex already serializes these paths against `setsockopt()`, so read the field directly via small static helpers; getsockopt/setsockopt and external net_context users keep the locked accessor.

Instruction counts (callgrind, native_sim/native/64 on x86-64, UDP loopback 32-byte datagrams): `zsock_sendto_ctx()` 9955 → 9559 (-4.0%); kernel mutex work per send+recv round -11.6% (two lock/unlock pairs fewer).

## `c19a6f975fc` vs `upstream/main` (qemu_x86)

| Metric | Reference (Mbps) | Candidate (Mbps) | Change | Status |
|:--|--:|--:|--:|:--|
| `udp4_mbps` | 14.316 | 14.228 | -0.61% | PASS |
| `udp4_frag_mbps` | 21.729 | 21.893 | +0.75% | PASS |
| `tcp4_mbps` | 7.068 | 7.124 | +0.79% | PASS |
| `tcp4_nodelay_mbps` | 7.032 | 7.085 | +0.75% | PASS |
| `udp6_mbps` | 14.171 | 14.494 | +2.28% | PASS |
| `udp6_frag_mbps` | 21.532 | 21.982 | +2.09% | PASS |
| `tcp6_mbps` | 7.126 | 7.226 | +1.40% | PASS |
| `tcp6_nodelay_mbps` | 7.134 | 7.234 | +1.40% | PASS |
