### PR TITLE
drivers: serial: esp32: source ESP32-C6 UART clock from XTAL

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -420,8 +420,21 @@ static int uart_esp32_configure(const struct device *dev, const struct uart_conf
 	 * breaks the reg_update sync mechanism, causing uart_ll_update()
 	 * to spin forever. Keep the ROM-configured clock source (XTAL).
 	 * IDF also does not change UART clock source during driver init.
+	 *
+	 * On C6, UART_SCLK_DEFAULT is PLL_F80M while the reset default
+	 * and ROM selection are XTAL, so this switch moves a live port
+	 * onto the PLL right after cold-boot PLL bring-up, which
+	 * intermittently latches a wrong effective clock: the port then
+	 * corrupts essentially every frame for the whole session. Warm
+	 * resets never reproduce it (PLL already settled), and re-running
+	 * this configure with identical values once the clock tree is
+	 * stable heals the port instantly - the fault is the latch, not
+	 * the values. Keep the UART on the always-stable XTAL instead;
+	 * the fractional divider keeps standard rates within ~0.1%.
 	 */
-#if !defined(CONFIG_SOC_SERIES_ESP32P4) && !defined(CONFIG_SOC_SERIES_ESP32C61)
+#if defined(CONFIG_SOC_SERIES_ESP32C6)
+	uart_hal_set_sclk(&data->hal, UART_SCLK_XTAL);
+#elif !defined(CONFIG_SOC_SERIES_ESP32P4) && !defined(CONFIG_SOC_SERIES_ESP32C61)
 	uart_hal_set_sclk(&data->hal, UART_SCLK_DEFAULT);
 #endif
 	uart_hal_set_rxfifo_full_thr(&data->hal, UART_RX_FIFO_THRESH);


### PR DESCRIPTION
On the ESP32-C6, `UART_SCLK_DEFAULT` resolves to PLL_F80M, and programming the UART clock mux/divider while the PLL is still settling after a cold boot can latch a wrong effective clock. When it happens, the port corrupts essentially every frame for the entire session: CRC failures at the frame rate with recognizable-but-wrong bytes, occasional merged frames when a delimiter byte is among the corrupted ones.

Evidence gathered on custom C6 hardware (uart1 @ 115200, framed inter-MCU link with CRC16, counters on every CRC failure):

- Cold-path resets only (power-on / flash reset): ~50% of cold boots storm under affected conditions; warm `sys_reboot` never does (8/8 across storm conditions) — the same code path runs both ways, only the PLL's physical starting state differs.
- A storm session runs corrupt for its whole life (observed 5+ min at ~8 fails/s) and heals **instantly** when `uart_configure()` is re-run with *identical* values once the clock tree is stable (measured: first valid frame 130 ms after the re-configure). The fault is the latch, not the computed values.
- Note `uart_esp32_config_get()` cannot be used to read-modify-write out of this state: it computes the baud back through the broken divider, the 0.1% standard-baud snap fails, and re-configuring would faithfully re-program the wrong rate.

Fix: source the C6 UART from the always-stable XTAL, which exists as `UART_SCLK_XTAL` on this SoC. This follows the same reasoning as the existing P4 handling directly above (keep a settle-independent clock source; IDF likewise does not switch the UART clock source during driver init, and uses XTAL sourcing under DFS). The fractional divider keeps standard rates within ~0.02% of nominal from the 40 MHz XTAL.

Scope note: kept deliberately C6-only, matching the P4 precedent. XTAL sourcing lowers the achievable maximum baud versus PLL_F80M; if maintainers prefer, this could instead be exposed as a `clock-source` devicetree property (as `spi_esp32` gained in #113713) with XTAL as the C6 default — happy to rework in that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Te9GLmNNXbmSKRvMENv98X