### PR TITLE
net: context: drop O(N) context scan from the per-packet RX path

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1270,19 +1270,19 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 
 static inline struct net_context *find_context(void *conn_handler)
 {
-	int i;
+	struct net_conn *conn = conn_handler;
+	struct net_context *context = conn->context;
 
-	for (i = 0; i < NET_MAX_CONTEXT; i++) {
-		if (!net_context_is_used(&contexts[i])) {
-			continue;
-		}
-
-		if (contexts[i].conn_handler == conn_handler) {
-			return &contexts[i];
-		}
+	/* The connection already points back at its owning context; just
+	 * apply the same validity checks the previous linear scan of
+	 * contexts[] performed.
+	 */
+	if (context == NULL || !net_context_is_used(context) ||
+	    context->conn_handler != conn_handler) {
+		return NULL;
 	}
 
-	return NULL;
+	return context;
 }
 
 int net_context_listen(struct net_context *context, int backlog)


### PR DESCRIPTION
`net_context_packet_received()` resolved the owning context of a connection by linearly scanning `contexts[]` for every delivered UDP/RAW datagram, although `conn->context` has stored the answer since registration. Use it directly, keeping the exact validity checks the scan performed.

Instruction counts (callgrind, native_sim/native/64 on x86-64): 864 → 854 per delivered datagram at the default `CONFIG_NET_MAX_CONTEXTS=6` — small there by construction, but the RX fast path no longer scales with the context table size.

## `973f706` vs `upstream/main` (qemu_x86)

| Metric | Reference (Mbps) | Candidate (Mbps) | Change | Status |
|:--|--:|--:|--:|:--|
| `udp4_mbps` | 14.316 | 14.320 | +0.03% | PASS |
| `udp4_frag_mbps` | 21.729 | 21.738 | +0.04% | PASS |
| `tcp4_mbps` | 7.068 | 7.071 | +0.04% | PASS |
| `tcp4_nodelay_mbps` | 7.032 | 7.038 | +0.09% | PASS |
| `udp6_mbps` | 14.171 | 14.589 | +2.95% | PASS |
| `udp6_frag_mbps` | 21.532 | 21.536 | +0.02% | PASS |
| `tcp6_mbps` | 7.126 | 7.130 | +0.06% | PASS |
| `tcp6_nodelay_mbps` | 7.134 | 7.139 | +0.07% | PASS |