### PR TITLE
instrumentation: Add option to dump events when buffer fills up

### DIFF
--- a/scripts/instrumentation/zaru.py
+++ b/scripts/instrumentation/zaru.py
@@ -417,64 +417,75 @@ def get_stream(port):
 # Generator for getting an event with symbols resolved.
 # The event returned is a dict().
 def get_trace_event_generator(msg_it, symbols):
-    for msg in msg_it:
-        if isinstance(msg, bt2._EventMessageConst):
-            event = msg.event
+    while True:
+        try:
+            msg = next(msg_it, None)
+        except bt2._Error as er:
+            print("Cannot get next CTF event")
+            print(er)
+            break
 
-            # Entry / exit events (w/ or wo/ context) are converted to
-            # 'entry' and 'exit' types just to simplify the matching
-            # code using them -- match against a shorter string.  It can
-            # be enhanced if necessary. Currently just handle entry /
-            # exit with context and sched switch in/out events.
-            if "entry" in event.name:
-                event_type = "entry"
-            elif "exit" in event.name:
-                event_type = "exit"
-            elif "switched_in" in event.name:
-                event_type = "switched_in"
-            elif "switched_out" in event.name:
-                event_type = "switched_out"
-            else:
-                continue
+        if msg is None:
+            break
+        if not isinstance(msg, bt2._EventMessageConst):
+            continue
 
-            # Resolve callee symbol.
-            callee = event.payload_field.get("callee").real
-            callee_symbol = symbols.get(callee)
+        event = msg.event
 
-            if callee_symbol is None:
-                print(
-                    Fore.RED + f"Symbol address {callee} could not be resolved! "
-                    "Are you sure FW flashed matches provided zephyr.elf in build dir?\n"
-                    "Tracing will be aborted because it's unreliable when symbols can't be "
-                    "properly resolved."
-                )
+        # Entry / exit events (w/ or wo/ context) are converted to
+        # 'entry' and 'exit' types just to simplify the matching
+        # code using them -- match against a shorter string.  It can
+        # be enhanced if necessary. Currently just handle entry /
+        # exit with context and sched switch in/out events.
+        if "entry" in event.name:
+            event_type = "entry"
+        elif "exit" in event.name:
+            event_type = "exit"
+        elif "switched_in" in event.name:
+            event_type = "switched_in"
+        elif "switched_out" in event.name:
+            event_type = "switched_out"
+        else:
+            continue
 
-                sys.exit(1)
+        # Resolve callee symbol.
+        callee = event.payload_field.get("callee").real
+        callee_symbol = symbols.get(callee)
 
-            thread_id = event.payload_field.get("thread_id")
-            # When tracing non-application code usually there isn't
-            # a thread ID associated to the context, so in this case
-            # change thread ID to "none-thread".
-            if thread_id == 0:
-                thread_id = "none-thread"
-            else:
-                thread_id = hex(thread_id)
+        if callee_symbol is None:
+            print(
+                Fore.RED + f"Symbol address {callee} could not be resolved! "
+                "Are you sure FW flashed matches provided zephyr.elf in build dir?\n"
+                "Tracing will be aborted because it's unreliable when symbols can't be "
+                "properly resolved."
+            )
 
-            cpu = event.payload_field.get("cpu")
-            mode = event.payload_field.get("mode")
-            timestamp = event.payload_field.get("timestamp").real
-            thread_name = event.payload_field.get("thread_name")
+            sys.exit(1)
 
-            e = dict()
-            e["type"] = str(event_type)
-            e["func"] = str(callee_symbol)
-            e["thread_id"] = str(thread_id)
-            e["cpu"] = str(cpu)
-            e["mode"] = str(mode)
-            e["timestamp"] = str(timestamp)
-            e["thread_name"] = str(thread_name)
+        thread_id = event.payload_field.get("thread_id")
+        # When tracing non-application code usually there isn't
+        # a thread ID associated to the context, so in this case
+        # change thread ID to "none-thread".
+        if thread_id == 0:
+            thread_id = "none-thread"
+        else:
+            thread_id = hex(thread_id)
 
-            yield e  # event
+        cpu = event.payload_field.get("cpu")
+        mode = event.payload_field.get("mode")
+        timestamp = event.payload_field.get("timestamp").real
+        thread_name = event.payload_field.get("thread_name")
+
+        e = dict()
+        e["type"] = str(event_type)
+        e["func"] = str(callee_symbol)
+        e["thread_id"] = str(thread_id)
+        e["cpu"] = str(cpu)
+        e["mode"] = str(mode)
+        e["timestamp"] = timestamp
+        e["thread_name"] = str(thread_name)
+
+        yield e  # event
 
 
 def get_and_print_trace(args, tmpdir, elf, demangle, annotate_ret=False, verbose=False):
@@ -525,7 +536,7 @@ def get_and_print_trace(args, tmpdir, elf, demangle, annotate_ret=False, verbose
             + ") "
             + cur_mode.rjust(4)
             + " | "
-            + cur_ts.rjust(12)
+            + str(cur_ts).rjust(12)
             + " ns |"
         )
         line_buffer_first_half.append(line)

--- a/scripts/instrumentation/zaru.py
+++ b/scripts/instrumentation/zaru.py
@@ -459,6 +459,8 @@ def get_trace_event_generator(msg_it, symbols):
                 "Tracing will be aborted because it's unreliable when symbols can't be "
                 "properly resolved."
             )
+            thread_id = event.payload_field.get("thread_id")
+            thread_id = hex(thread_id)
 
             sys.exit(1)
 
@@ -512,6 +514,12 @@ def get_and_print_trace(args, tmpdir, elf, demangle, annotate_ret=False, verbose
         cur_type, cur_func, cur_thread_id, cur_cpu, cur_mode, cur_ts, cur_tn = (
             current_event.values()
         )
+
+        # When tracing non-application code usually there isn't
+        # a thread ID associated to the context, so in this case
+        # change thread ID to "none-thread".
+        if int(cur_thread_id, 16) == 0:
+            cur_thread_id = "none-thread"
 
         if demangle:
             cmd = CPPFILT_CMD + [cur_func]

--- a/subsys/instrumentation/Kconfig
+++ b/subsys/instrumentation/Kconfig
@@ -40,16 +40,36 @@ config INSTRUMENTATION_MODE_CALLGRAPH_TRACE_BUFFER_SIZE
 	  tracing events and has two working modes: it can be configure either
 	  as a simple buffer or as a ring buffer (overwriting mode).
 
+choice
+	prompt "Choose an action done when buffer is full"
+	default INSTRUMENTATION_MODE_CALLGRAPH_BUFFER_OVERWRITE
+	optional
+	help
+	  Choice of a policy defining how to react to a full buffer,
+	  if none is selected instrumentation will be disabled
+	  when buffer is filled.
+
 config INSTRUMENTATION_MODE_CALLGRAPH_BUFFER_OVERWRITE
 	bool "Trace buffer overwriting mode"
 	depends on INSTRUMENTATION_MODE_CALLGRAPH
-	default y
 	help
 	  If the trace buffer is set as overwriting it works as a ring buffer.
 	  In this working mode if the buffer gets full old records will be
 	  overwritten by the newer records. This mode allows recording the most
 	  recent tracing events at the expense of losing the old ones. If this
 	  mode is not selected, then once the buffer is full tracing stops.
+
+config INSTRUMENTATION_MODE_CALLGRAPH_DUMP_ON_FULL
+	bool "Dump events when buffer is full"
+	depends on INSTRUMENTATION_MODE_CALLGRAPH
+	help
+	  Instead of disabling instrumentation when a buffer is full, dump
+	  its content via UART and empty the buffer. This allows to
+	  continuously gather events without disabling instrumentation.
+	  Currently the zaru script may not work properly when events are being
+	  dumped, therefore it is suggested to use it after the application end.
+
+endchoice
 
 config INSTRUMENTATION_MODE_STATISTICAL
 	bool "Statistical mode (Profiling)"

--- a/subsys/instrumentation/common/instr_common.c
+++ b/subsys/instrumentation/common/instr_common.c
@@ -12,6 +12,7 @@
 #include <instr_buffer.h>
 #include <instr_timestamp.h>
 
+#include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
@@ -20,6 +21,12 @@
 
 #include <kernel_internal.h>
 #include <ksched.h>
+
+#ifdef CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_DUMP_ON_FULL
+#define INSTR_INIT_TAG "-*-INSTR-INIT-*-\n"
+#endif
+#define INSTR_START_TAG "-*-#"
+#define INSTR_END_TAG "-*-!\n"
 
 /*
  * Memory buffer to store instrumentation event records has the following modes:
@@ -91,6 +98,16 @@ static void *k_stopper_callee = INSTR_STOPPER_FUNCTION;
 /* Current (live) trigger and stopper addresses */
 static void *trigger_callee;
 static void *stopper_callee;
+
+#ifdef CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_DUMP_ON_FULL
+int instr_init_tag_emit(void)
+{
+	printk(INSTR_INIT_TAG);
+	return 0;
+}
+
+SYS_INIT(instr_init_tag_emit, APPLICATION, 0);
+#endif
 
 bool instr_tracing_supported(void)
 {
@@ -302,7 +319,7 @@ void instr_dump_buffer_uart(void)
 	instr_disable();
 
 	/* Initiator mark */
-	printk("-*-#");
+	printk(INSTR_START_TAG);
 
 	while (!ring_buf_is_empty(instr_buffer_get_ring_buf())) {
 		transferring_length =
@@ -316,7 +333,7 @@ void instr_dump_buffer_uart(void)
 	}
 
 	/* Terminator mark */
-	printk("-*-!\n");
+	printk(INSTR_END_TAG);
 #endif
 }
 
@@ -330,7 +347,7 @@ void instr_dump_deltas_uart(void)
 	instr_disable();
 
 	/* Initiator mark */
-	printk("-*-#");
+	printk(INSTR_START_TAG);
 
 	for (int i = 0; i < num_disco_func; i++) {
 		uart_poll_out(uart_dev, INSTR_EVENT_PROFILE);
@@ -343,7 +360,7 @@ void instr_dump_deltas_uart(void)
 	}
 
 	/* Terminator mark */
-	printk("-*-!\n");
+	printk(INSTR_END_TAG);
 #endif
 }
 
@@ -565,8 +582,13 @@ void instr_event_handler(enum instr_event_types type, void *callee, void *caller
 		if (!IS_ENABLED(CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_BUFFER_OVERWRITE) &&
 		    ring_buf_space_get(instr_buffer_get_ring_buf()) <
 			    sizeof(struct instr_record)) {
+#ifdef CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_DUMP_ON_FULL
+			instr_dump_buffer_uart();
+			instr_buffer_reset();
+#else
 			_instr_tracing_disabled = true;
 			return;
+#endif
 		}
 
 		set_up_record(&record, type, callee, caller);

--- a/subsys/instrumentation/include/instr_buffer.h
+++ b/subsys/instrumentation/include/instr_buffer.h
@@ -21,6 +21,11 @@ extern "C" {
 void instr_buffer_init(void);
 
 /**
+ * @brief Reset instrumentation buffer state.
+ */
+void instr_buffer_reset(void);
+
+/**
  * @brief Get the instrumentation ring buffer.
  *
  * @return Pointer to the instrumentation ring buffer.

--- a/subsys/instrumentation/ringbuffer/ringbuffer.c
+++ b/subsys/instrumentation/ringbuffer/ringbuffer.c
@@ -20,3 +20,8 @@ void instr_buffer_init(void)
 	ring_buf_init(&instr_ring_buf,
 		      sizeof(instr_buffer), instr_buffer);
 }
+
+void instr_buffer_reset(void)
+{
+	ring_buf_reset(&instr_ring_buf);
+}


### PR DESCRIPTION
Implements an option to dump the instrumentation buffers when filled onto a transport, instead of stopping instrumentation. The change is configurable with Kconfig options


Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/111492