### PR TITLE
Add the Kmu push area to dts for nrf54L and nrf71 devices

### DIFF
--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.dts
@@ -16,7 +16,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp.dts
@@ -16,7 +16,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/holyiot/holyiot_25008/holyiot_25008_nrf54l15_cpuapp.dts
+++ b/boards/holyiot/holyiot_25008/holyiot_25008_nrf54l15_cpuapp.dts
@@ -21,7 +21,7 @@
 		zephyr,flash-controller = &rram_controller;
 		zephyr,flash = &cpuapp_rram;
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 		zephyr,ieee802154 = &ieee802154;
 	};
 };

--- a/boards/kaga-fei/ec4l15ba1/ec4l15ba1_nrf54l15_cpuapp.dts
+++ b/boards/kaga-fei/ec4l15ba1/ec4l15ba1_nrf54l15_cpuapp.dts
@@ -16,7 +16,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuapp.dts
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuapp.dts
@@ -17,7 +17,7 @@
 
 	chosen {
 		zephyr,flash = &cpuapp_rram;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 		zephyr,code-partition = &slot0_partition;
 	};
 };

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.dts
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20b_cpuapp.dts
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20b_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuapp.dts
+++ b/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf7120dk/nrf7120dk_nrf7120e_cpuapp.dts
+++ b/boards/nordic/nrf7120dk/nrf7120dk_nrf7120e_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp.dts
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuapp.dts
+++ b/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuapp.dts
+++ b/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuapp.dts
@@ -16,7 +16,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/raytac/an54lv_db_15/raytac_an54lv_db_15_nrf54l15_cpuapp.dts
+++ b/boards/raytac/an54lv_db_15/raytac_an54lv_db_15_nrf54l15_cpuapp.dts
@@ -16,7 +16,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
@@ -43,7 +43,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 		zephyr,flash = &cpuapp_rram;
 		zephyr,flash-controller = &rram_controller;
 		zephyr,console = &uart20;

--- a/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuapp.dts
+++ b/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuapp.dts
@@ -15,6 +15,6 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };

--- a/boards/u-blox/ubx_evknorab2/ubx_evknorab2_nrf54l05_cpuapp.dts
+++ b/boards/u-blox/ubx_evknorab2/ubx_evknorab2_nrf54l05_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/u-blox/ubx_evknorab2/ubx_evknorab2_nrf54l10_cpuapp.dts
+++ b/boards/u-blox/ubx_evknorab2/ubx_evknorab2_nrf54l10_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/u-blox/ubx_evknorab2/ubx_evknorab2_nrf54l15_cpuapp.dts
+++ b/boards/u-blox/ubx_evknorab2/ubx_evknorab2_nrf54l15_cpuapp.dts
@@ -15,7 +15,7 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 };
 

--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.dts
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.dts
@@ -23,7 +23,7 @@
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,boot-mode = &boot_mode0;
 		zephyr,code-partition = &slot0_partition;
-		zephyr,sram = &cpuapp_sram;
+		zephyr,sram = &cpuapp_sram_app;
 	};
 
 	aliases {

--- a/dts/vendor/nordic/nrf54l05.dtsi
+++ b/dts/vendor/nordic/nrf54l05.dtsi
@@ -9,6 +9,13 @@
 &cpuapp_sram {
 	reg = <0x20000000 DT_SIZE_K(96)>;
 	ranges = <0x0 0x20000000 DT_SIZE_K(96)>;
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+	cpuapp_sram_app: sram@60 {
+		compatible = "mmio-sram";
+		reg = <0x60 (DT_SIZE_K(96) - 0x60)>;
+	};
+#endif
 };
 
 &cpuapp_rram {

--- a/dts/vendor/nordic/nrf54l10.dtsi
+++ b/dts/vendor/nordic/nrf54l10.dtsi
@@ -9,6 +9,13 @@
 &cpuapp_sram {
 	reg = <0x20000000 DT_SIZE_K(192)>;
 	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+	cpuapp_sram_app: sram@60 {
+		compatible = "mmio-sram";
+		reg = <0x60 (DT_SIZE_K(192) - 0x60)>;
+	};
+#endif
 };
 
 &cpuapp_rram {

--- a/dts/vendor/nordic/nrf54l15.dtsi
+++ b/dts/vendor/nordic/nrf54l15.dtsi
@@ -9,6 +9,13 @@
 &cpuapp_sram {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+	cpuapp_sram_app: sram@60 {
+		compatible = "mmio-sram";
+		reg = <0x60 (DT_SIZE_K(256) - 0x60)>;
+	};
+#endif
 };
 
 &cpuapp_rram {

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -810,3 +810,25 @@
 		};
 	};
 };
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		/*
+		 * The KMU pushes keys to a fixed address at the start of SRAM,
+		 * so this area is not available to the application. When
+		 * building with TF-M the area is part of the SRAM partition
+		 * owned by the secure image instead.
+		 */
+		kmu_push_area: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 0x60>;
+			zephyr,memory-region = "KMU_PUSH";
+		};
+	};
+};
+#endif

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -125,6 +125,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x20000000 DT_SIZE_K(511)>;
+
+			cpuapp_sram_app: sram@60 {
+				compatible = "mmio-sram";
+				reg = <0x60 (DT_SIZE_K(511) - 0x60)>;
+			};
 		};
 #endif
 
@@ -972,3 +977,25 @@
 		};
 	};
 };
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		/*
+		 * The KMU pushes keys to a fixed address at the start of SRAM,
+		 * so this area is not available to the application. When
+		 * building with TF-M the area is part of the SRAM partition
+		 * owned by the secure image instead.
+		 */
+		kmu_push_area: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 0x60>;
+			zephyr,memory-region = "KMU_PUSH";
+		};
+	};
+};
+#endif

--- a/dts/vendor/nordic/nrf7120_7120e_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_7120e_enga.dtsi
@@ -96,6 +96,20 @@
 			ranges = <0x0 0x200fe000 0x1000>;
 		};
 
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+		/*
+		 * The KMU pushes keys to a fixed address at the start of SRAM,
+		 * so this area is not available to the application. When
+		 * building with TF-M the area is part of the SRAM partition
+		 * owned by the secure image instead.
+		 */
+		kmu_push_area: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 0x60>;
+			zephyr,memory-region = "KMU_PUSH";
+		};
+#endif
+
 		nrf_kmu_cracen_exchange_area: memory@200ff000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -197,6 +211,13 @@
 					#size-cells = <1>;
 					ranges = <0x0 0xe0000 (DT_SIZE_K(120) - 0x20)>;
 				};
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+				cpuapp_sram_app: memory@60 {
+					compatible = "mmio-sram";
+					reg = <0x60 (DT_SIZE_K(1016) - 0x20 - 0x60)>;
+				};
+#endif
 			};
 
 			vtf_region_default: memory@fdfe0 {

--- a/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -16,10 +16,9 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
 	 * 96 - 4 = 92KB = 0x17000
 	 */
-	reg = <0x20000000 0x17000>;
-	ranges = <0x0 0x20000000 0x17000>;
+	reg = <0x60 (0x17000 - 0x60)>;
 };

--- a/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -16,10 +16,9 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
 	 * 192 - 4 = 188KB = 0x2f000
 	 */
-	reg = <0x20000000 0x2f000>;
-	ranges = <0x0 0x20000000 0x2f000>;
+	reg = <0x60 (0x2f000 - 0x60)>;
 };

--- a/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -16,8 +16,7 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region */
-	reg = <0x20000000 DT_SIZE_K(184)>;
-	ranges = <0x0 0x20000000 0x2e000>;
+	reg = <0x60 (DT_SIZE_K(184) - 0x60)>;
 };

--- a/samples/boards/nordic/system_off/boards/nrf54lm20dk_nrf54lm20_a_b_cpuapp.dtsi
+++ b/samples/boards/nordic/system_off/boards/nrf54lm20dk_nrf54lm20_a_b_cpuapp.dtsi
@@ -16,10 +16,9 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
 	 * 511 - 4 = 507KB = 0x7ec00
 	 */
-	reg = <0x20000000 DT_SIZE_K(507)>;
-	ranges = <0x0 0x20000000 0x7ec00>;
+	reg = <0x60 (DT_SIZE_K(507) - 0x60)>;
 };

--- a/samples/boards/nordic/system_off/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/boards/nordic/system_off/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -22,8 +22,7 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region */
-	reg = <0x20000000 DT_SIZE_K(184)>;
-	ranges = <0x0 0x20000000 0x2e000>;
+	reg = <0x60 (DT_SIZE_K(184) - 0x60)>;
 };

--- a/samples/subsys/shell/shell_module/boards/nrf54l15dk_nrf54l15_cpuapp_remote_shell.overlay
+++ b/samples/subsys/shell/shell_module/boards/nrf54l15dk_nrf54l15_cpuapp_remote_shell.overlay
@@ -51,9 +51,8 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(157)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(157)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(157) - 0x60)>;
 };
 
 &rram_controller {

--- a/snippets/nordic/nordic-flpr-xip/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr-xip/soc/nrf54l15_cpuapp.overlay
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(188)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(188)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(188) - 0x60)>;
 };
 
 &cpuapp_rram {

--- a/snippets/nordic/nordic-flpr/soc/nrf54l05_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l05_cpuapp.overlay
@@ -20,9 +20,8 @@
 	status = "reserved";
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(63)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(63)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(63) - 0x60)>;
 };
 
 &cpuapp_rram {

--- a/snippets/nordic/nordic-flpr/soc/nrf54l10_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l10_cpuapp.overlay
@@ -20,9 +20,8 @@
 	status = "reserved";
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(127)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(127)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(127) - 0x60)>;
 };
 
 &cpuapp_rram {

--- a/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
@@ -20,9 +20,8 @@
 	status = "reserved";
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(159)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(159)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(159) - 0x60)>;
 };
 
 &cpuapp_rram {

--- a/snippets/nordic/nordic-flpr/soc/nrf54lm20a_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54lm20a_cpuapp.overlay
@@ -16,9 +16,8 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(415)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(415)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(415) - 0x60)>;
 };
 
 &cpuapp_rram {

--- a/snippets/nordic/nordic-flpr/soc/nrf54lm20b_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54lm20b_cpuapp.overlay
@@ -16,9 +16,8 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(415)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(415)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(415) - 0x60)>;
 };
 
 &cpuapp_rram {

--- a/tests/boards/nrf/gppi/sysbuild/vpr_launcher/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/boards/nrf/gppi/sysbuild/vpr_launcher/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -42,9 +42,8 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(157)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(157)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(157) - 0x60)>;
 };
 
 &cpuapp_vevif_rx {

--- a/tests/drivers/retained_mem/api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/retained_mem/api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -22,7 +22,6 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(184)>;
-	ranges = <0x0 0x20000000 0x2e000>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(184) - 0x60)>;
 };

--- a/tests/drivers/retained_mem/api/socs/nrf54l05_cpuapp.overlay
+++ b/tests/drivers/retained_mem/api/socs/nrf54l05_cpuapp.overlay
@@ -22,10 +22,9 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
 	 * 96 - 4 = 92KB = 0x17000
 	 */
-	reg = <0x20000000 0x17000>;
-	ranges = <0x0 0x20000000 0x17000>;
+	reg = <0x60 (0x17000 - 0x60)>;
 };

--- a/tests/drivers/retained_mem/api/socs/nrf54l10_cpuapp.overlay
+++ b/tests/drivers/retained_mem/api/socs/nrf54l10_cpuapp.overlay
@@ -22,10 +22,9 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
 	 * 192 - 4 = 188KB = 0x2f000
 	 */
-	reg = <0x20000000 0x2f000>;
-	ranges = <0x0 0x20000000 0x2f000>;
+	reg = <0x60 (0x2f000 - 0x60)>;
 };

--- a/tests/drivers/retained_mem/api/socs/nrf54l15_cpuapp.overlay
+++ b/tests/drivers/retained_mem/api/socs/nrf54l15_cpuapp.overlay
@@ -22,7 +22,6 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(184)>;
-	ranges = <0x0 0x20000000 0x2e000>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(184) - 0x60)>;
 };

--- a/tests/drivers/retained_mem/api/socs/nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/retained_mem/api/socs/nrf54lm20a_cpuapp.overlay
@@ -22,10 +22,9 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
 	 * 511 - 4 = 507KB = 0x7ec00
 	 */
-	reg = <0x20000000 DT_SIZE_K(507)>;
-	ranges = <0x0 0x20000000 0x7ec00>;
+	reg = <0x60 (DT_SIZE_K(507) - 0x60)>;
 };

--- a/tests/drivers/retained_mem/api/socs/nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/retained_mem/api/socs/nrf54lm20b_cpuapp.overlay
@@ -22,10 +22,9 @@
 	};
 };
 
-&cpuapp_sram {
+&cpuapp_sram_app {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
 	 * 511 - 4 = 507KB = 0x7ec00
 	 */
-	reg = <0x20000000 DT_SIZE_K(507)>;
-	ranges = <0x0 0x20000000 0x7ec00>;
+	reg = <0x60 (DT_SIZE_K(507) - 0x60)>;
 };

--- a/tests/subsys/ipc/ipc_service_api/boards/nrf54l15dk_nrf54l15_cpuapp_common.dtsi
+++ b/tests/subsys/ipc/ipc_service_api/boards/nrf54l15dk_nrf54l15_cpuapp_common.dtsi
@@ -24,9 +24,8 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(151)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(151)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(151) - 0x60)>;
 };
 
 &rram_controller {

--- a/tests/subsys/ipc/ipc_service_benchmark/boards/nrf54l15dk_nrf54l15_cpuapp_common.dtsi
+++ b/tests/subsys/ipc/ipc_service_benchmark/boards/nrf54l15dk_nrf54l15_cpuapp_common.dtsi
@@ -24,9 +24,8 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(151)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(151)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(151) - 0x60)>;
 };
 
 &rram_controller {

--- a/tests/subsys/shell/shell_remote/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/shell/shell_remote/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -51,9 +51,8 @@
 	};
 };
 
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(157)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(157)>;
+&cpuapp_sram_app {
+	reg = <0x60 (DT_SIZE_K(157) - 0x60)>;
 };
 
 &rram_controller {


### PR DESCRIPTION
The KMU requires a 96-Byte push area in RAM.
This was previously handled in a linker script, but as a
hardware requirement this should be represented in dts.
Add a reserved-memory node kmu_push_area at 0x20000000 (96 bytes)
to all 54L devices with KMU support. Shift cpuapp_sram to
start at 0x20000060 in non-secure builds so the Zephyr RAM region
is disjoint from the KMU push area, preventing overlap.
The reserved-memory node is guarded by #ifndef USE_NON_SECURE_ADDRESS_MAP
since TF-M/NS builds manage the KMU push area through their own
partition layout starting at 0x2000000. As we now