### PR TITLE
soc: nxp: lpc54xxx: fix the LPC546xx SRAM description and enablement

### DIFF
--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
@@ -73,7 +73,7 @@
 
 /*
  * Default for this board is to use the full 160 KB of contiguous main SRAM
- * (SRAM0-2) as a single region; an application can provide its own devicetree
+ * (SRAM0-3) as a single region; an application can provide its own devicetree
  * to allocate the SRAM banks differently.
  */
 &sram0 {

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -122,6 +122,14 @@ Kernel
 Boards
 ******
 
+* On NXP LPC54xxx, ``CONFIG_LPC54XXX_SRAM2_CLOCK`` has been replaced by
+  ``CONFIG_SOC_SERIES_LPC54XXX_SRAM_CLOCKS``. The old name fitted while the
+  LPC54114 was the only SoC in the series, where CMSIS ``SystemInit()`` enables
+  just SRAM2. On the LPC546xx it enables SRAM2 and SRAM3, so the option now
+  covers more than the one bank it was named after. Both default to ``y``. A
+  configuration that assigned the old symbol has to be updated, and fails to
+  build until it is.
+
 * On RP2040 and RP2350, the ``vreg`` node (:dtcompatible:`raspberrypi,core-supply-regulator`) is
   now ``disabled`` by default instead of ``okay``. Out-of-tree boards that need this regulator
   must set ``status = "okay"`` on the ``&vreg`` node.

--- a/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
@@ -50,9 +50,10 @@
 		};
 
 		/*
-		 * LPC546xx main SRAM is three contiguous banks at 0x20000000:
-		 * SRAM0 (64K) + SRAM1 (64K) + SRAM2 (32K) = 160K. Each bank is a
-		 * separate node; sram0 covers the SRAM0 bank only. A board that
+		 * LPC546xx main SRAM is four contiguous banks at 0x20000000:
+		 * SRAM0 (64K) + SRAM1 (32K) + SRAM2 (32K) + SRAM3 (32K) = 160K,
+		 * each on its own AHB matrix port (UM10912 table 4). Each bank is
+		 * a separate node; sram0 covers the SRAM0 bank only. A board that
 		 * wants the full contiguous 160K overrides sram0's reg (see
 		 * lpcxpresso54628). SRAMX is a separate 32K code RAM bank at
 		 * 0x04000000.
@@ -64,14 +65,20 @@
 
 		sram1: memory@20010000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x20010000 DT_SIZE_K(64)>;
+			reg = <0x20010000 DT_SIZE_K(32)>;
 			zephyr,memory-region = "SRAM1";
 		};
 
-		sram2: memory@20020000 {
+		sram2: memory@20018000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20018000 DT_SIZE_K(32)>;
+			zephyr,memory-region = "SRAM2";
+		};
+
+		sram3: memory@20020000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20020000 DT_SIZE_K(32)>;
-			zephyr,memory-region = "SRAM2";
+			zephyr,memory-region = "SRAM3";
 		};
 
 		sramx: memory@4000000 {

--- a/soc/nxp/lpc/lpc54xxx/CMakeLists.txt
+++ b/soc/nxp/lpc/lpc54xxx/CMakeLists.txt
@@ -26,9 +26,9 @@ if(DEFINED CONFIG_LPC54XXX_USB_RAM)
   zephyr_compile_definitions_ifdef(CONFIG_UHC_DRIVER USB_STACK_USE_DEDICATED_RAM=1)
 endif()
 
-# CMSIS SystemInit allows us to skip enabling clock to SRAM2 bank via
-# this compiler definition
-if(NOT DEFINED CONFIG_LPC54XXX_SRAM2_CLOCK)
+# CMSIS SystemInit allows us to skip enabling the clock to the RAM banks that
+# are disabled out of reset, via this compiler definition
+if(NOT DEFINED CONFIG_SOC_SERIES_LPC54XXX_SRAM_CLOCKS)
 zephyr_compile_definitions(DONT_ENABLE_DISABLED_RAMBANKS=1)
 endif()
 

--- a/soc/nxp/lpc/lpc54xxx/Kconfig
+++ b/soc/nxp/lpc/lpc54xxx/Kconfig
@@ -62,13 +62,13 @@ config BUILD_OUTPUT_INFO_HEADER
 	default y
 	depends on SECOND_CORE_MCUX && SOC_LPC54114_M0
 
-config LPC54XXX_SRAM2_CLOCK
-	bool "Clock LPC54XXX SRAM2"
+config SOC_SERIES_LPC54XXX_SRAM_CLOCKS
+	bool "Clock LPC54XXX SRAM banks"
 	default y
 	help
-	  SRAM2 ram bank is disabled out of reset. By default, CMSIS SystemInit
-	  will enable the clock to this RAM bank. Disable this Kconfig to leave
-	  this ram bank untouched out of reset.
+	  SRAM banks are disabled out of reset. By default, CMSIS SystemInit
+	  will enable the clock to these RAM banks. Disable this Kconfig to
+	  leave these ram banks untouched out of reset.
 
 config LPC54XXX_USB_RAM
 	bool

--- a/soc/nxp/lpc/lpc54xxx/soc.c
+++ b/soc/nxp/lpc/lpc54xxx/soc.c
@@ -253,10 +253,45 @@ SYS_INIT(nxp_lpc54xxx_init, PRE_KERNEL_1, 0);
  * assembly. Cores without that routine (the LPC54114 M0 and the LPC54628)
  * install a reset hook here to call it instead.
  */
+#if defined(CONFIG_SOC_LPC54628) && defined(CONFIG_SOC_SERIES_LPC54XXX_SRAM_CLOCKS)
+
+/*
+ * SRAM2 and SRAM3 are not clocked out of reset; SystemInit() turns them on.
+ * A board that describes the banks as one region - lpcxpresso54628 gives sram0
+ * all 160K of SRAM0..SRAM3 - lets the linker place z_main_stack past the 96K
+ * that SRAM0 and SRAM1 hold, so the boot stack can land in memory that is not
+ * clocked yet. SystemInit() cannot fix that from there: its own prologue
+ * pushes to that stack before it reaches the write.
+ *
+ * Ungate the banks first, then tail-call SystemInit, so neither step touches
+ * the stack. A naked function is needed because a prologue would otherwise run
+ * before the store. The MCUXpresso SDK does the same in the first instructions
+ * of its reset handler, which Zephyr does not use. A build that turns the banks
+ * off through SOC_SERIES_LPC54XXX_SRAM_CLOCKS keeps the plain call, and has to
+ * keep its stack out of them.
+ */
+__attribute__((naked)) void soc_reset_hook(void)
+{
+	__asm__ volatile("ldr r0, =%[set]\n"
+			 "movs r1, %[banks]\n"
+			 "str r1, [r0]\n"
+			 "b %[init]\n"
+			 :
+			 : [set] "i"(&SYSCON->AHBCLKCTRLSET[0]),
+			   [banks] "i"(SYSCON_AHBCLKCTRL_SRAM1_MASK |
+				       SYSCON_AHBCLKCTRL_SRAM2_MASK |
+				       SYSCON_AHBCLKCTRL_SRAM3_MASK),
+			   [init] "i"(SystemInit));
+}
+
+#else
+
 void soc_reset_hook(void)
 {
 	SystemInit();
 }
+
+#endif /* CONFIG_SOC_LPC54628 && CONFIG_SOC_SERIES_LPC54XXX_SRAM_CLOCKS */
 
 #endif /* CONFIG_SOC_RESET_HOOK */
 


### PR DESCRIPTION
Fixes #117464 - boards: nxp: lpcxpresso54628: applications using more than
96K of RAM do not boot

On the LPCXpresso54628, an application that needs more RAM than the always-on
SRAM banks hold does not boot: no console output at all, not even the boot
banner. Fixing that turned up two neighbouring problems, so the three are here
together.

## The bank layout

UM10912 table 4 gives the main SRAM as four contiguous banks, each on its own
AHB matrix port:

| Bank  | Size | Address      |
|-------|------|--------------|
| SRAM0 | 64K  | `0x20000000` |
| SRAM1 | 32K  | `0x20010000` |
| SRAM2 | 32K  | `0x20018000` |
| SRAM3 | 32K  | `0x20020000` |

The nodes described three, with `sram1` covering 64K, so the node named `sram2`
was really SRAM3 and the bank at `0x20018000` had none. The address range as a
whole was right, so nothing was ever misplaced, but a board could not target a
single bank.

## The boot failure

SRAM2 and SRAM3 are not clocked out of reset and `SystemInit()` turns them on,
so only the 96K in SRAM0 and SRAM1 is usable before that. The LPC54628 reaches
`SystemInit()` from `soc_reset_hook()`, and the first write to the stack on
that path happens before the ungate:

    soc_reset_hook:              SystemInit:
        b.w  SystemInit              push {r3, lr}      <- dies here

At `-Os` the hook is a tail call and the fatal push is `SystemInit`'s own
prologue; at `-Og` and `-O0` the hook pushes as well. The write lands in memory
that is not clocked, the return address comes back as garbage, and the core
branches into the boot ROM, which takes over FlexComm0 and leaves the console
silent.

The boot stack is the top of `z_main_stack`, which the linker places at the end
of used RAM, so it rises with the size of the image. `lpcxpresso54628.dts`
gives `sram0` all 160K, so an image needing more than 96K puts the stack in a
gated bank. Smaller images are unaffected, which is why this was missed when
the board was added.

The fix ungates the banks first and tail-calls `SystemInit()`, so neither step
touches the stack:

    soc_reset_hook:
        ldr   r0, [pc, #8]      ; &SYSCON->AHBCLKCTRLSET[0]
        movs  r1, #56           ; SRAM1 | SRAM2 | SRAM3
        str   r1, [r0, #0]
        b.w   SystemInit

This is what the MCUXpresso SDK does in the first three instructions of its
reset handler, with the comment "Enable SRAM clock used by Stack". Zephyr does
not use those startup files, and nothing else performs the step.

`naked` is required. Written in plain C the same code is only correct when GCC
picks a sibling call, which it does at `-Os` and `-O2` but not at `-Og` or
`-O0`, so it would boot in release builds and fail in debug ones.

Moving the stack instead is not an option: one larger than 96K cannot end
below `0x20018000` wherever it is placed, and the SDK deliberately puts it at
the top of RAM as well. Driving the ungate from devicetree does not
work either, because the board gives `sram0` all 160K and the stack follows
`zephyr,sram`, not the individual bank nodes.

### Why only the LPC54628

The LPC54114 shares this directory and has the same ordering in
`gcc/startup_LPC54114_cm4.S`, but cannot reach the failure: the M4 caps
`sram0` at 128K, exactly the always-on banks, and the M0, whose stack is in the
gated bank, is released by the M4 after it has already run `SystemInit()`.

## The Kconfig option

`LPC54XXX_SRAM2_CLOCK` names one bank, but gates the SDK's
`DONT_ENABLE_DISABLED_RAMBANKS`, which covers every bank that is off out of
reset: SRAM2 on the LPC54114, SRAM2 and SRAM3 on the LPC546xx. It is replaced
by `SOC_SERIES_LPC54XXX_SRAM_CLOCKS`, which says what it does and also defaults
to `y`. The option lives in `/soc` and applies to the whole series, so the
Kconfig style guide asks for the `SOC_SERIES_` base.

This is a breaking change and is noted in the migration guide. It is not a
silent one: assigning a symbol that no longer exists aborts the build, so a
configuration using the old name is told to update rather than quietly getting
the other behaviour. `select DEPRECATED` was not usable here, because the
symbol defaults to `y` and every LPC54xxx build would then warn about something
nobody set.

## Testing

The 96K boundary was measured on the board with unpatched images whose stack
was placed in each bank in turn: SRAM1 (`0x20010398`) boots, SRAM2
(`0x20018480`) and SRAM3 (`0x20020374`) are silent.

On an LPCXpresso54628, `samples/hello_world` built with
`CONFIG_MAIN_STACK_SIZE=140000` puts the boot stack at `0x20023060`, inside
SRAM3. The two images differ only by this series: without it the board prints
nothing at all, with it it boots and prints
`Hello World! lpcxpresso54628/lpc54628`.

Builds clean on `lpcxpresso54628` and on both `lpcxpresso54114` cores, which
share this hook and keep the plain call. Each commit builds on its own and
checkpatch is clean.
