### PR TITLE
net: ethernet: handle forwarded packets without headroom

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -867,10 +867,16 @@ static struct net_buf *ethernet_fill_header(struct ethernet_context *ctx,
 		net_pkt_vlan_tag(pkt) != NET_VLAN_TAG_UNSPEC;
 
 	reserve_ll_header = get_reserve_ll_header_size(is_vlan);
-	if (reserve_ll_header > 0) {
+	if ((reserve_ll_header > 0) && (reserve_ll_header <= net_buf_headroom(pkt->buffer))) {
 		hdr_len = reserve_ll_header;
 		hdr_frag = pkt->buffer;
 	} else {
+		/*
+		 * Packets can be allocated by a different L2 and forwarded to
+		 * Ethernet. Such packets do not have the Ethernet header space
+		 * reserved by ethernet_l2_alloc(), so use a separate fragment.
+		 */
+		reserve_ll_header = 0U;
 		hdr_len = IS_ENABLED(CONFIG_NET_VLAN) ?
 			sizeof(struct net_eth_vlan_hdr) :
 			sizeof(struct net_eth_hdr);

--- a/tests/net/route/ipv6/tests.yaml
+++ b/tests/net/route/ipv6/tests.yaml
@@ -15,3 +15,10 @@ tests:
       - CONFIG_ETH_DRIVER=n
       - CONFIG_ASSERT=y
       - CONFIG_NET_IF_MAX_IPV6_COUNT=3
+  net.route.ipv6.reserve_header:
+    extra_configs:
+      - CONFIG_NET_L2_ETHERNET=y
+      - CONFIG_NET_L2_ETHERNET_RESERVE_HEADER=y
+      - CONFIG_ETH_DRIVER=n
+      - CONFIG_ASSERT=y
+      - CONFIG_NET_IF_MAX_IPV6_COUNT=3


### PR DESCRIPTION
Packets allocated by another L2 do not have the Ethernet header
headroom reserved by ethernet_l2_alloc().
Use a separate header fragment when a forwarded packet cannot
accommodate the reserved Ethernet header in its first fragment.

Fixes: #117863