### PR TITLE
net: dns: fix multi-interface dispatcher pairing on UDP/5353

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -28,6 +28,16 @@ config MDNS_RESOLVER
 	  When the mDNS responder is not enabled, the resolver joins the mDNS
 	  multicast groups itself.
 
+config MDNS_RESOLVER_AUTO_ADD_UNSCOPED
+	bool "Auto-add unscoped mDNS server to the default resolver"
+	depends on MDNS_RESOLVER
+	default y
+	help
+	  When dns_resolve_init_default() runs (auto-init or a manual call),
+	  append unscoped mDNS servers to the default resolver server list.
+	  Disable on multi-interface systems that configure mDNS per
+	  interface to avoid UDP/5353 bind collisions.
+
 config LLMNR_RESOLVER
 	bool "LLMNR support [DEPRECATED]"
 	select DEPRECATED

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -47,6 +47,27 @@ static uint16_t dns_dispatcher_addr_port(const struct net_sockaddr_storage *addr
 	return 0;
 }
 
+/* Can resolver and responder share the same UDP port (e.g. mDNS 5353)?
+ *
+ * Pairing lets the second registration reuse the first socket. Refuse it
+ * only when both sides are scoped to different interfaces: each side is
+ * then bound to its own link and pairing them would mix wrong-interface
+ * answers.
+ *
+ * When one side is unscoped (ifindex 0) it must keep pairing even on a
+ * multi-interface host. Refusing is not a benign "stay independent"
+ * outcome: the refused side falls through to bind the shared port, which
+ * fails against the already-bound peer (these sockets do not use
+ * SO_REUSEPORT), and an unpaired responder socket drops any response it
+ * receives. The unscoped side pairing with an arbitrary interface's peer
+ * is a known limitation, but it keeps registration working.
+ */
+static bool dns_dispatcher_can_pair(const struct dns_socket_dispatcher *a,
+				    const struct dns_socket_dispatcher *b)
+{
+	return a->ifindex == 0 || b->ifindex == 0 || a->ifindex == b->ifindex;
+}
+
 static int dns_dispatch(struct dns_socket_dispatcher *dispatcher,
 			int sock, struct net_sockaddr *addr, size_t addrlen,
 			struct net_buf *dns_data, size_t buf_len)
@@ -271,7 +292,11 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 		 */
 		if (found == NULL && ctx->type != entry->type &&
 		    ctx->local_addr_storage.ss_family == entry->local_addr_storage.ss_family) {
-			if (ports_match) {
+			/* Resolver/responder socket sharing (e.g. mDNS UDP/5353):
+			 * same port is not enough on multi-homed hosts — pair
+			 * only when both sides listen on the same link.
+			 */
+			if (ports_match && dns_dispatcher_can_pair(ctx, entry)) {
 				found = entry;
 				continue;
 			}

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -3212,7 +3212,8 @@ int dns_resolve_init_default(struct dns_resolve_context *ctx)
 		break;
 	}
 
-#if defined(CONFIG_MDNS_RESOLVER) && (MDNS_SERVER_COUNT > 0)
+#if defined(CONFIG_MDNS_RESOLVER) && (MDNS_SERVER_COUNT > 0) && \
+	defined(CONFIG_MDNS_RESOLVER_AUTO_ADD_UNSCOPED)
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4)
 	dns_servers[DNS_SERVER_COUNT + 1] = MDNS_IPV6_ADDR;
 	dns_servers[DNS_SERVER_COUNT] = MDNS_IPV4_ADDR;
@@ -3224,7 +3225,7 @@ int dns_resolve_init_default(struct dns_resolve_context *ctx)
 	dns_servers[DNS_SERVER_COUNT] = MDNS_IPV4_ADDR;
 #endif
 #endif /* CONFIG_NET_IPV6 && CONFIG_NET_IPV4 */
-#endif /* MDNS_RESOLVER && MDNS_SERVER_COUNT > 0 */
+#endif /* MDNS_RESOLVER && MDNS_SERVER_COUNT > 0 && MDNS_RESOLVER_AUTO_ADD_UNSCOPED */
 
 #if defined(CONFIG_LLMNR_RESOLVER) && (LLMNR_SERVER_COUNT > 0)
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4)

--- a/tests/net/lib/dns_dispatcher/prj_multi_iface.conf
+++ b/tests/net/lib/dns_dispatcher/prj_multi_iface.conf
@@ -1,0 +1,10 @@
+# Overlay for net.dns.dispatch.multi_iface (merged with prj.conf)
+# Multi-interface DNS socket dispatcher pairing test (no mDNS).
+
+CONFIG_NET_IF_MAX_IPV4_COUNT=2
+CONFIG_NET_IF_MAX_IPV6_COUNT=2
+CONFIG_NET_INTERFACE_NAME=y
+CONFIG_DNS_RESOLVER_AUTO_INIT=n
+CONFIG_NET_DRIVERS=y
+CONFIG_NET_UDP=y
+CONFIG_NET_L2_ETHERNET=n

--- a/tests/net/lib/dns_dispatcher/src/dispatcher_multi_iface.c
+++ b/tests/net/lib/dns_dispatcher/src/dispatcher_multi_iface.c
@@ -1,0 +1,313 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* DNS socket dispatcher pairing on a multi-interface host (no mDNS):
+ * resolver and responder share UDP/5353 per interface. Cross-interface
+ * registration must not pair (eth-sink class bug without can_pair()).
+ */
+
+#include "dns_dispatcher_test.h"
+
+#if DNS_DISPATCHER_MULTI_IFACE_TEST
+
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/dummy.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/socket_service.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/ztest.h>
+
+#define TEST_DNS_PORT 5353
+
+extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
+
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(test_dns_svc, dns_dispatcher_svc_handler, 4);
+
+static struct net_if *iface1;
+static struct net_if *iface2;
+
+/* Mock dispatcher registrations (resolver/responder on UDP/5353).
+ * resp* are scoped to iface1/iface2; resv2 is a scoped resolver reused
+ * across same- and cross-iface cases; resv_any is an unscoped resolver
+ * (ifindex 0) for test_dispatcher_unscoped_pairs_multi_iface().
+ */
+static struct dns_socket_dispatcher resp1;
+static struct dns_socket_dispatcher resp2;
+static struct dns_socket_dispatcher resv2;
+static struct dns_socket_dispatcher resv_any;
+static struct zsock_pollfd resp1_fd;
+static struct zsock_pollfd resp2_fd;
+static struct zsock_pollfd resv2_fd;
+static struct zsock_pollfd resv_any_fd;
+
+struct multi_if_test {
+	uint8_t idx;
+	uint8_t mac_addr[sizeof(struct net_eth_addr)];
+};
+
+static struct multi_if_test if1_data;
+static struct multi_if_test if2_data;
+
+static int multi_if_dummy_send(const struct device *dev, struct net_pkt *pkt)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pkt);
+
+	return 0;
+}
+
+static uint8_t *multi_if_mac(struct multi_if_test *data, uint8_t idx)
+{
+	if (data->mac_addr[2] == 0x00) {
+		data->mac_addr[0] = 0x00;
+		data->mac_addr[1] = 0x00;
+		data->mac_addr[2] = 0x5E;
+		data->mac_addr[3] = 0x00;
+		data->mac_addr[4] = 0x53;
+		data->mac_addr[5] = idx;
+	}
+
+	data->idx = idx;
+
+	return data->mac_addr;
+}
+
+static void if1_init(struct net_if *iface)
+{
+	net_if_set_link_addr(iface, multi_if_mac(&if1_data, 1),
+			     sizeof(struct net_eth_addr), NET_LINK_ETHERNET);
+}
+
+static void if2_init(struct net_if *iface)
+{
+	net_if_set_link_addr(iface, multi_if_mac(&if2_data, 2),
+			     sizeof(struct net_eth_addr), NET_LINK_ETHERNET);
+}
+
+#define _MULTI_L2 DUMMY_L2
+#define _MULTI_L2_CTX NET_L2_GET_CTX_TYPE(DUMMY_L2)
+
+static struct dummy_api if1_api = {
+	.iface_api.init = if1_init,
+	.send = multi_if_dummy_send,
+};
+
+static struct dummy_api if2_api = {
+	.iface_api.init = if2_init,
+	.send = multi_if_dummy_send,
+};
+
+NET_DEVICE_INIT_INSTANCE(disp_if1_test, "iface1", iface1, NULL, NULL,
+			 &if1_data, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+			 &if1_api, _MULTI_L2, _MULTI_L2_CTX, 127);
+
+NET_DEVICE_INIT_INSTANCE(disp_if2_test, "iface2", iface2, NULL, NULL,
+			 &if2_data, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+			 &if2_api, _MULTI_L2, _MULTI_L2_CTX, 127);
+
+static int mock_dispatcher_cb(struct dns_socket_dispatcher *ctx, int sock,
+			      struct net_sockaddr *addr, size_t addrlen,
+			      struct net_buf *buf, size_t len)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(sock);
+	ARG_UNUSED(addr);
+	ARG_UNUSED(addrlen);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+
+	return 0;
+}
+
+static int create_socket(struct net_if *iface)
+{
+	struct net_ifreq ifreq = { 0 };
+	const struct device *dev = net_if_get_device(iface);
+	int reuse = 1;
+	int sock;
+
+	sock = zsock_socket(NET_AF_INET6, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_not_null(dev, "iface device");
+	zassert_true(sock >= 0, "socket failed");
+
+	if (IS_ENABLED(CONFIG_NET_CONTEXT_REUSEPORT)) {
+		(void)zsock_setsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_REUSEPORT,
+				       &reuse, sizeof(reuse));
+	}
+
+	strncpy(ifreq.ifr_name, dev->name, sizeof(ifreq.ifr_name) - 1);
+	(void)zsock_setsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_BINDTODEVICE,
+			       &ifreq, sizeof(ifreq));
+
+	return sock;
+}
+
+static void setup_dispatcher(struct dns_socket_dispatcher *disp,
+			     enum dns_socket_type type, struct net_if *iface,
+			     int sock, struct zsock_pollfd *pfd)
+{
+	struct net_sockaddr_in6 *local = net_sin6(&disp->local_addr);
+
+	memset(disp, 0, sizeof(*disp));
+	disp->type = type;
+	disp->ifindex = net_if_get_by_iface(iface);
+	disp->sock = sock;
+	disp->cb = mock_dispatcher_cb;
+	disp->fds = pfd;
+	disp->fds_len = 1;
+	disp->svc = &test_dns_svc;
+	pfd->fd = sock;
+	pfd->events = ZSOCK_POLLIN;
+
+	local->sin6_family = NET_AF_INET6;
+	local->sin6_port = net_htons(TEST_DNS_PORT);
+}
+
+static void close_paired(struct dns_socket_dispatcher *primary,
+			 struct dns_socket_dispatcher *paired)
+{
+	if (paired->sock >= 0) {
+		(void)zsock_close(paired->sock);
+	}
+
+	paired->sock = -1;
+	paired->pair = NULL;
+	if (paired->fds != NULL && paired->fds_len > 0) {
+		paired->fds[0].fd = -1;
+	}
+
+	if (primary->pair == paired) {
+		primary->pair = NULL;
+	}
+}
+
+static void teardown_primary(struct dns_socket_dispatcher *primary,
+			     struct zsock_pollfd *pfd)
+{
+	int fd;
+
+	if (primary->pair != NULL) {
+		close_paired(primary, primary->pair);
+	}
+
+	fd = primary->sock;
+
+	if (fd >= 0) {
+		(void)dns_dispatcher_unregister(primary);
+		(void)zsock_close(fd);
+	}
+
+	memset(primary, 0, sizeof(*primary));
+	primary->sock = -1;
+	pfd->fd = -1;
+}
+
+static void *multi_iface_setup(void)
+{
+	iface1 = net_if_get_by_index(1);
+	iface2 = net_if_get_by_index(2);
+
+	zassert_not_null(iface1, "iface1 missing");
+	zassert_not_null(iface2, "iface2 missing");
+
+	net_if_up(iface1);
+	net_if_up(iface2);
+
+	resp1.sock = -1;
+	resp2.sock = -1;
+	resv2.sock = -1;
+	resv_any.sock = -1;
+	resp1_fd.fd = -1;
+	resp2_fd.fd = -1;
+	resv2_fd.fd = -1;
+	resv_any_fd.fd = -1;
+
+	return NULL;
+}
+
+ZTEST(dns_dispatch_pair, test_dispatcher_iface_pairing)
+{
+	int ret;
+
+	/* Same interface: resolver pairs with responder. */
+	setup_dispatcher(&resp1, DNS_SOCKET_RESPONDER, iface1,
+			 create_socket(iface1), &resp1_fd);
+	ret = dns_dispatcher_register(&resp1);
+	zassert_ok(ret, "iface1 responder register failed (%d)", ret);
+	zassert_is_null(resp1.pair, "responder not paired yet");
+
+	setup_dispatcher(&resv2, DNS_SOCKET_RESOLVER, iface1,
+			 create_socket(iface1), &resv2_fd);
+	ret = dns_dispatcher_register(&resv2);
+	zassert_ok(ret, "iface1 resolver register failed (%d)", ret);
+	zassert_equal(resp1.pair, &resv2, "same-iface resolver must pair");
+
+	teardown_primary(&resp1, &resp1_fd);
+	memset(&resv2, 0, sizeof(resv2));
+	resv2.sock = -1;
+	resv2_fd.fd = -1;
+
+	/* Cross interface: must not pair (needs dns_dispatcher_can_pair()). */
+	setup_dispatcher(&resp1, DNS_SOCKET_RESPONDER, iface1,
+			 create_socket(iface1), &resp1_fd);
+	ret = dns_dispatcher_register(&resp1);
+	zassert_ok(ret, "iface1 responder re-register failed (%d)", ret);
+
+	setup_dispatcher(&resv2, DNS_SOCKET_RESOLVER, iface2,
+			 create_socket(iface2), &resv2_fd);
+	ret = dns_dispatcher_register(&resv2);
+	zassert_ok(ret, "iface2 resolver register failed (%d)", ret);
+	zassert_is_null(resp1.pair, "cross-iface must not pair with iface1 responder");
+	zassert_is_null(resv2.pair, "cross-iface resolver must stay unpaired");
+
+	setup_dispatcher(&resp2, DNS_SOCKET_RESPONDER, iface2,
+			 create_socket(iface2), &resp2_fd);
+	ret = dns_dispatcher_register(&resp2);
+	zassert_ok(ret, "iface2 responder register failed (%d)", ret);
+	zassert_equal(resv2.pair, &resp2, "iface2 responder pairs locally");
+
+	teardown_primary(&resp2, &resp2_fd);
+	teardown_primary(&resv2, &resv2_fd);
+	teardown_primary(&resp1, &resp1_fd);
+}
+
+/* Multi-interface host: an unscoped (ifindex 0) resolver still pairs with a
+ * scoped responder. Which interface's responder it gets is a known
+ * limitation, but refusing would leave the resolver unable to bind the
+ * shared port (no SO_REUSEPORT on the real sockets) and an unpaired
+ * responder drops responses, so registration must keep working.
+ */
+ZTEST(dns_dispatch_pair, test_dispatcher_unscoped_pairs_multi_iface)
+{
+	int ret;
+
+	setup_dispatcher(&resp1, DNS_SOCKET_RESPONDER, iface1,
+			 create_socket(iface1), &resp1_fd);
+	ret = dns_dispatcher_register(&resp1);
+	zassert_ok(ret, "iface1 responder register failed (%d)", ret);
+
+	setup_dispatcher(&resv_any, DNS_SOCKET_RESOLVER, iface1,
+			 create_socket(iface1), &resv_any_fd);
+	resv_any.ifindex = 0;
+	ret = dns_dispatcher_register(&resv_any);
+	zassert_ok(ret, "unscoped resolver register failed (%d)", ret);
+	zassert_equal(resp1.pair, &resv_any,
+		      "unscoped resolver must pair on multi-iface too");
+	zassert_is_null(resv_any.pair, "later registrant's pair stays unset");
+
+	teardown_primary(&resp1, &resp1_fd);
+	memset(&resv_any, 0, sizeof(resv_any));
+	resv_any.sock = -1;
+	resv_any_fd.fd = -1;
+}
+
+ZTEST_SUITE(dns_dispatch_pair, NULL, multi_iface_setup, NULL, NULL, NULL);
+
+#endif /* DNS_DISPATCHER_MULTI_IFACE_TEST */

--- a/tests/net/lib/dns_dispatcher/src/dns_dispatcher_test.h
+++ b/tests/net/lib/dns_dispatcher/src/dns_dispatcher_test.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DNS_DISPATCHER_TEST_H_
+#define DNS_DISPATCHER_TEST_H_
+
+/*
+ * Select single- vs multi-interface test sources. prj_multi_iface.conf sets
+ * both CONFIG_NET_IF_MAX_IPV4_COUNT and CONFIG_NET_IF_MAX_IPV6_COUNT to 2.
+ */
+#if (CONFIG_NET_IF_MAX_IPV6_COUNT >= 2) && (CONFIG_NET_IF_MAX_IPV4_COUNT >= 2)
+#define DNS_DISPATCHER_MULTI_IFACE_TEST 1
+#else
+#define DNS_DISPATCHER_MULTI_IFACE_TEST 0
+#endif
+
+#endif /* DNS_DISPATCHER_TEST_H_ */

--- a/tests/net/lib/dns_dispatcher/src/main.c
+++ b/tests/net/lib/dns_dispatcher/src/main.c
@@ -30,6 +30,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
+#include "dns_dispatcher_test.h"
 
 #if defined(CONFIG_DNS_RESOLVER_LOG_LEVEL_DBG)
 #define DBG(fmt, ...) printk(fmt, ##__VA_ARGS__)
@@ -66,18 +67,22 @@ static int test_dispatch_cb(struct dns_socket_dispatcher *ctx, int sock,
 
 #define DNS_TIMEOUT 500 /* ms */
 
-#if defined(CONFIG_NET_IPV6)
+#if defined(CONFIG_NET_IPV6) && !DNS_DISPATCHER_MULTI_IFACE_TEST
 /* Interface 1 addresses */
 static struct net_in6_addr my_addr1 = { { { 0x20, 0x01, 0x0d, 0xb8, 1, 0, 0, 0,
 					    0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 #endif
 
-#if defined(CONFIG_NET_IPV4)
+#if defined(CONFIG_NET_IPV4) && !DNS_DISPATCHER_MULTI_IFACE_TEST
 /* Interface 1 addresses */
 static struct net_in_addr my_addr2 = { { { 192, 0, 2, 1 } } };
 #endif
 
+#if !DNS_DISPATCHER_MULTI_IFACE_TEST
+
 static struct net_if *iface1;
+
+#endif
 
 /* this must be higher that the DNS_TIMEOUT */
 #define WAIT_TIME K_MSEC((DNS_TIMEOUT + 300) * 3)
@@ -86,6 +91,8 @@ struct net_if_test {
 	uint8_t idx;
 	uint8_t mac_addr[sizeof(struct net_eth_addr)];
 };
+
+#if !DNS_DISPATCHER_MULTI_IFACE_TEST
 
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
@@ -145,8 +152,13 @@ NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 _ETH_L2_CTX_TYPE,
 			 127);
 
+#endif /* !DNS_DISPATCHER_MULTI_IFACE_TEST */
+
 static void *test_init(void)
 {
+#if DNS_DISPATCHER_MULTI_IFACE_TEST
+	return NULL;
+#else
 	struct net_if_addr *ifaddr;
 
 	iface1 = net_if_get_by_index(0);
@@ -189,12 +201,21 @@ static void *test_init(void)
 	net_if_up(iface1);
 
 	return NULL;
+#endif
 }
 
 ZTEST(dns_dispatcher, test_dns_dispatcher)
 {
 	struct dns_resolve_context *ctx;
 	int ret, sock1, sock2 = -1;
+
+#if DNS_DISPATCHER_MULTI_IFACE_TEST
+	ztest_test_skip();
+#endif
+
+#if IS_ENABLED(CONFIG_MDNS_RESOLVER)
+	ztest_test_skip();
+#endif
 
 	ctx = dns_resolve_get_default();
 
@@ -345,4 +366,120 @@ ZTEST(dns_dispatcher, test_dns_dispatcher_ephemeral_ports)
 	dns_resolve_close(ctx);
 }
 
+#if !DNS_DISPATCHER_MULTI_IFACE_TEST
+
+/* Single-interface host: an unscoped (ifindex 0) resolver must pair with a
+ * scoped responder on that interface.
+ */
+
+#define TEST_DNS_PAIR_PORT 5353
+
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(pair_svc, dns_dispatcher_svc_handler, 2);
+
+static struct dns_socket_dispatcher pair_resp;
+static struct dns_socket_dispatcher pair_resv;
+static struct zsock_pollfd pair_resp_fd;
+static struct zsock_pollfd pair_resv_fd;
+
+static int pair_mock_cb(struct dns_socket_dispatcher *ctx, int sock,
+			struct net_sockaddr *addr, size_t addrlen,
+			struct net_buf *buf, size_t len)
+{
+	ARG_UNUSED(ctx); ARG_UNUSED(sock); ARG_UNUSED(addr);
+	ARG_UNUSED(addrlen); ARG_UNUSED(buf); ARG_UNUSED(len);
+	return 0;
+}
+
+static int pair_create_socket(void)
+{
+	struct net_ifreq ifreq = { 0 };
+	const struct device *dev = net_if_get_device(iface1);
+	int reuse = 1;
+	int sock;
+
+	sock = zsock_socket(NET_AF_INET6, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(sock >= 0, "socket failed");
+
+	if (IS_ENABLED(CONFIG_NET_CONTEXT_REUSEPORT)) {
+		(void)zsock_setsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_REUSEPORT,
+				       &reuse, sizeof(reuse));
+	}
+
+	strncpy(ifreq.ifr_name, dev->name, sizeof(ifreq.ifr_name) - 1);
+	(void)zsock_setsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_BINDTODEVICE,
+			       &ifreq, sizeof(ifreq));
+	return sock;
+}
+
+static void pair_setup(struct dns_socket_dispatcher *disp, enum dns_socket_type type,
+		       int ifindex, int sock, struct zsock_pollfd *pfd)
+{
+	struct net_sockaddr_in6 *local = net_sin6(&disp->local_addr);
+
+	memset(disp, 0, sizeof(*disp));
+	disp->type = type;
+	disp->ifindex = ifindex;
+	disp->sock = sock;
+	disp->cb = pair_mock_cb;
+	disp->fds = pfd;
+	disp->fds_len = 1;
+	disp->svc = &pair_svc;
+	pfd->fd = sock;
+	pfd->events = ZSOCK_POLLIN;
+
+	local->sin6_family = NET_AF_INET6;
+	local->sin6_port = net_htons(TEST_DNS_PAIR_PORT);
+}
+
+static void pair_teardown(struct dns_socket_dispatcher *disp, struct zsock_pollfd *pfd)
+{
+	int fd = disp->sock;
+
+	if (disp->pair != NULL) {
+		struct dns_socket_dispatcher *p = disp->pair;
+
+		if (p->sock >= 0) {
+			(void)zsock_close(p->sock);
+		}
+		p->sock = -1;
+		p->pair = NULL;
+		if (p->fds != NULL && p->fds_len > 0) {
+			p->fds[0].fd = -1;
+		}
+		disp->pair = NULL;
+	}
+
+	if (fd >= 0) {
+		(void)dns_dispatcher_unregister(disp);
+		(void)zsock_close(fd);
+	}
+	memset(disp, 0, sizeof(*disp));
+	disp->sock = -1;
+	pfd->fd = -1;
+}
+
+ZTEST(dns_dispatcher, test_dispatcher_unscoped_pairs_single_iface)
+{
+	int iface_idx = net_if_get_by_iface(iface1);
+	int ret;
+
+	pair_setup(&pair_resp, DNS_SOCKET_RESPONDER, iface_idx,
+		   pair_create_socket(), &pair_resp_fd);
+	ret = dns_dispatcher_register(&pair_resp);
+	zassert_ok(ret, "scoped responder register failed (%d)", ret);
+
+	pair_setup(&pair_resv, DNS_SOCKET_RESOLVER, 0,
+		   pair_create_socket(), &pair_resv_fd);
+	ret = dns_dispatcher_register(&pair_resv);
+	zassert_ok(ret, "unscoped resolver register failed (%d)", ret);
+	zassert_equal(pair_resp.pair, &pair_resv,
+		      "unscoped resolver must pair with scoped responder on single-iface host");
+
+	pair_teardown(&pair_resp, &pair_resp_fd);
+	pair_resv_fd.fd = -1;
+	memset(&pair_resv, 0, sizeof(pair_resv));
+	pair_resv.sock = -1;
+}
+
+#endif /* !DNS_DISPATCHER_MULTI_IFACE_TEST */
 ZTEST_SUITE(dns_dispatcher, NULL, test_init, NULL, NULL, NULL);

--- a/tests/net/lib/dns_dispatcher/tests.yaml
+++ b/tests/net/lib/dns_dispatcher/tests.yaml
@@ -14,3 +14,7 @@ tests:
   net.dns.dispatch.ctx_no_cleanup:
     extra_configs:
       - CONFIG_DNS_RECONFIGURE_CLEANUP=n
+  net.dns.dispatch.multi_iface:
+    min_ram: 30
+    extra_conf_files:
+      - prj_multi_iface.conf


### PR DESCRIPTION
The DNS socket dispatcher paired resolver/responder sockets on UDP/5353 by
port only. On multi-interface hosts this caused two related problems:

**A. Wrong cross-interface pairing (resolver ↔ responder)**  
A scoped mDNS resolver (e.g. `[ff02::fb]:5353%dect0`) could pair with a
responder on another interface. Observed on a DECT NR+ sink with `eth0` +
`dect0`: dect0 queries got wrong-interface answers (e.g. AAAA from eth0) and
the dect0 responder could be blocked.

**B. Unscoped mDNS auto-add collision (resolver ↔ resolver)**  
`dns_resolve_init_default()` always appends unscoped mDNS servers. Together
with per-interface scoped `[ff02::fb]:5353%<iface>` entries this causes
EADDRINUSE on UDP/5353 and fails resolver init. This cannot be fixed via
dispatcher pairing (pairing is resolver↔responder only).

## Changes

**Commit 1 — dispatcher pairing**  
Add `dns_dispatcher_can_pair()`: refuse pairing only when both sides are
scoped to different interfaces. Same ifindex still pairs; if either side is
unscoped (`ifindex 0`), pairing is kept (required to avoid bind failures when
no `SO_REUSEPORT`).

**Commit 2 — tests**  
`net.dns.dispatch.multi_iface`: same-iface pairing, cross-iface refusal,
unscoped resolver pairing on multi-iface. Single-interface unscoped-must-pair
case in `main.c`.

**Commit 3 — Kconfig**  
Add `CONFIG_MDNS_RESOLVER_AUTO_ADD_UNSCOPED` (default y). Gate applies
whenever `dns_resolve_init_default()` runs (auto-init or manual call).
Disable when configuring mDNS per interface.

## Test plan

- [x] `west twister -T tests/net/lib/dns_dispatcher -p native_sim`
- [x] `west twister -p native_sim --tag dns -T tests/net/lib`
- [x] `tests/net/lib/mdns_responder` with scoped servers +
      `CONFIG_MDNS_RESOLVER_AUTO_ADD_UNSCOPED=n`
- [x] Original product issue: DECT NR+ sink (`eth0` + `dect0`, mDNS resolver
      + responder)