### PR TITLE
posix: convert absolute timeouts directly to kernel ticks

### DIFF
--- a/subsys/portability/posix/options/cond.c
+++ b/subsys/portability/posix/options/cond.c
@@ -105,7 +105,7 @@ static int cond_wait(pthread_cond_t *cond, pthread_mutex_t *mu, const struct tim
 	}
 
 	if (abstime != NULL) {
-		timeout = K_MSEC(timespec_to_timeoutms(cv->attr.clock, abstime));
+		timeout = timespec_abs_to_timeout(cv->attr.clock, abstime);
 	}
 
 	LOG_DBG("Waiting on cond %p with timeout %" PRIx64, cv, (int64_t)timeout.ticks);

--- a/subsys/portability/posix/options/mqueue.c
+++ b/subsys/portability/posix/options/mqueue.c
@@ -277,7 +277,7 @@ int mq_timedsend(mqd_t mqdes, const char *msg_ptr, size_t msg_len,
 	}
 
 	return send_message(mqd, msg_ptr, msg_len,
-			    K_MSEC(timespec_to_timeoutms(CLOCK_REALTIME, abstime)));
+			    timespec_abs_to_timeout(CLOCK_REALTIME, abstime));
 }
 
 /**
@@ -313,7 +313,7 @@ int mq_timedreceive(mqd_t mqdes, char *msg_ptr, size_t msg_len,
 	}
 
 	return receive_message(mqd, msg_ptr, msg_len,
-			       K_MSEC(timespec_to_timeoutms(CLOCK_REALTIME, abstime)));
+			       timespec_abs_to_timeout(CLOCK_REALTIME, abstime));
 }
 
 /**

--- a/subsys/portability/posix/options/mutex.c
+++ b/subsys/portability/posix/options/mutex.c
@@ -219,7 +219,7 @@ int pthread_mutex_timedlock(pthread_mutex_t *m,
 		return EINVAL;
 	}
 
-	return acquire_mutex(m, K_MSEC(timespec_to_timeoutms(CLOCK_REALTIME, abstime)));
+	return acquire_mutex(m, timespec_abs_to_timeout(CLOCK_REALTIME, abstime));
 }
 
 /**

--- a/subsys/portability/posix/options/posix_clock.h
+++ b/subsys/portability/posix/options/posix_clock.h
@@ -59,6 +59,12 @@ static inline bool tp_diff_in_range_ns(const struct timespec *a, const struct ti
 
 uint32_t timespec_to_timeoutms(int clock_id, const struct timespec *abstime);
 
+/* Convert an absolute timespec on clock_id to a relative kernel timeout in
+ * ticks, rounding up, so that a wait armed with the result cannot expire
+ * before abstime.  abstime must be valid (caller-checked per POSIX).
+ */
+k_timeout_t timespec_abs_to_timeout(int clock_id, const struct timespec *abstime);
+
 /** INTERNAL_HIDDEN @endcond */
 
 #ifdef __cplusplus

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -1142,7 +1142,7 @@ int pthread_timedjoin_np(pthread_t pthread, void **status, const struct timespec
 	}
 
 	return pthread_timedjoin_internal(pthread, status,
-					  K_MSEC(timespec_to_timeoutms(CLOCK_REALTIME, abstime)));
+					  timespec_abs_to_timeout(CLOCK_REALTIME, abstime));
 }
 
 /**

--- a/subsys/portability/posix/options/semaphore.c
+++ b/subsys/portability/posix/options/semaphore.c
@@ -167,7 +167,7 @@ int sem_timedwait(sem_t *semaphore, struct timespec *abstime)
 		return -1;
 	}
 
-	if (k_sem_take(semaphore, K_MSEC(timespec_to_timeoutms(CLOCK_REALTIME, abstime)))) {
+	if (k_sem_take(semaphore, timespec_abs_to_timeout(CLOCK_REALTIME, abstime))) {
 		errno = ETIMEDOUT;
 		return -1;
 	}

--- a/subsys/portability/posix/options/timespec_to_timeout.c
+++ b/subsys/portability/posix/options/timespec_to_timeout.c
@@ -10,8 +10,10 @@
 #include <stdint.h>
 #include <time.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/minmax.h>
+#include <zephyr/sys/timeutil.h>
 #include <zephyr/sys/util.h>
 
 uint32_t timespec_to_timeoutms(int clock_id, const struct timespec *abstime)
@@ -23,4 +25,25 @@ uint32_t timespec_to_timeoutms(int clock_id, const struct timespec *abstime)
 	}
 
 	return clamp(tp_diff(abstime, &curtime) / NSEC_PER_MSEC, 0, UINT32_MAX);
+}
+
+k_timeout_t timespec_abs_to_timeout(int clock_id, const struct timespec *abstime)
+{
+	struct timespec delta = *abstime;
+	struct timespec curtime;
+
+	if (sys_clock_gettime(sys_clock_from_clockid(clock_id), &curtime) < 0) {
+		return K_NO_WAIT;
+	}
+
+	if (!timespec_sub(&delta, &curtime)) {
+		/* unreachable for valid clock values; saturate */
+		return (k_timeout_t){.ticks = K_TICK_MAX};
+	}
+
+	/* Negative deltas (abstime in the past) become K_NO_WAIT; positive
+	 * deltas are rounded up to the next tick boundary so the wait can
+	 * never end before abstime.
+	 */
+	return timespec_to_timeout(&delta, NULL);
 }

--- a/tests/subsys/portability/posix/semaphores/src/main.c
+++ b/tests/subsys/portability/posix/semaphores/src/main.c
@@ -361,4 +361,42 @@ ZTEST(posix_semaphores, test_named_semaphore)
 	zassert_equal(nsem_get_list_len(), 0);
 }
 
+/* POSIX: sem_timedwait() "shall not return an error of [ETIMEDOUT] before
+ * the absolute time specified by abstime has passed".  Offsets with
+ * sub-millisecond / sub-tick components must be rounded up, never down.
+ */
+ZTEST(posix_semaphores, test_sem_timedwait_not_early)
+{
+	sem_t sem;
+	struct timespec abstime;
+	struct timespec now;
+	/* deliberately not multiples of a millisecond or a tick */
+	const int64_t offsets_ns[] = {
+		1,
+		500000,                      /* 0.5 ms */
+		NSEC_PER_MSEC + 1,
+		10 * NSEC_PER_MSEC + 500000, /* 10.5 ms */
+		33333333,                    /* ~33.3 ms */
+	};
+
+	zassert_equal(sem_init(&sem, 0, 0), 0, "sem_init failed");
+
+	ARRAY_FOR_EACH(offsets_ns, i) {
+		zassert_equal(clock_gettime(CLOCK_REALTIME, &abstime), 0);
+		timespec_add(&abstime,
+			     &(struct timespec){.tv_sec = offsets_ns[i] / NSEC_PER_SEC,
+						.tv_nsec = offsets_ns[i] % NSEC_PER_SEC});
+
+		zassert_equal(sem_timedwait(&sem, &abstime), -1);
+		zassert_equal(errno, ETIMEDOUT);
+
+		zassert_equal(clock_gettime(CLOCK_REALTIME, &now), 0);
+		zassert_true(timespec_compare(&now, &abstime) >= 0,
+			     "sem_timedwait returned before abstime (offset %lld ns)",
+			     (long long)offsets_ns[i]);
+	}
+
+	zassert_equal(sem_destroy(&sem), 0, "semaphore is not destroyed");
+}
+
 ZTEST_SUITE(posix_semaphores, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/portability/posix/semaphores/tests.yaml
+++ b/tests/subsys/portability/posix/semaphores/tests.yaml
@@ -13,6 +13,9 @@ common:
   min_ram: 32
 tests:
   portability.posix.semaphores: {}
+  portability.posix.semaphores.tickrate_10k:
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
   portability.posix.semaphores.minimal:
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Timed waits (`pthread_mutex_timedlock`, `pthread_cond_timedwait`, `sem_timedwait`, `mq_timedsend`/`receive`, `pthread_timedjoin_np`) converted their absolute timespec through a truncating milliseconds step, so a wait could return `ETIMEDOUT` up to 1 ms *before* abstime, a **POSIX conformance defect** (also: timeouts beyond ~49.7 days were silently clamped).
New `timespec_abs_to_timeout()` converts once, directly to ticks with ceiling rounding, saturating.

A new conformance ztest (plus a 10 kHz tick suite variant that makes sub-millisecond truncation observable) fails on the previous code and passes with this change.

Validated with the semaphores (incl. new test), threads_base and mqueue-relevant suites on qemu_x86_64 — 7/7 configs, 120/120 cases.

`timespec_to_timeoutms()` survives for two callers that each need their own conversion, and should be deleted once both are done:

- `pthread_rwlock_timedrdlock`/`timedwrlock` — same defect, but `write_lock_acquire()` recomputes a remaining timeout in milliseconds across two sequential semaphore takes, and that ms-based signature is shared with the four non-timed rwlock entry points.
- `timer_settime()` — a different defect: the timer object is millisecond-based throughout (`reload`, the relative `it_value` branch, and `timer_gettime()` reading back `k_timer_remaining_get()`), so converting only the `TIMER_ABSTIME` branch would leave it half-tick and half-ms.
