### PR TITLE
posix: pthread_once: skip the global lock once initialized

### DIFF
--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -1006,6 +1006,14 @@ int pthread_once(pthread_once_t *once, void (*init_func)(void))
 		return EINVAL;
 	}
 
+	/* Nothing to do once the flag is set: it is never cleared, and since it is
+	 * set before init_func() is called, taking the lock would not make this
+	 * caller wait for initialization to finish anyway.
+	 */
+	if (_once->flag) {
+		return 0;
+	}
+
 	SYS_SEM_LOCK(&pthread_pool_lock) {
 		if (!_once->flag) {
 			run_init_func = true;


### PR DESCRIPTION
`pthread_once()` took the global pthread pool lock on every call forever, even long after initialization completed. Return immediately once the init flag is observed set; the flag never goes back to false, and the locked path already allowed returning while `init_func()` was still running (it is set before the call), so no synchronization is lost.

Instruction counts (callgrind, native_sim/native/64 on x86-64): hot `pthread_once()` 244 → 21 (-91%), and it no longer serializes against unrelated pthread operations.

Validated with the threads_base suite on qemu_x86_64 (108/108 cases).