### PR TITLE
posix: rwlock: do not read the clock for untimed write lock paths

### DIFF
--- a/subsys/portability/posix/options/rwlock.c
+++ b/subsys/portability/posix/options/rwlock.c
@@ -351,15 +351,19 @@ static uint32_t read_lock_acquire(struct posix_rwlock *rwl, uint32_t timeout)
 static uint32_t write_lock_acquire(struct posix_rwlock *rwl, uint32_t timeout)
 {
 	uint32_t ret = 0U;
-	int64_t elapsed_time, st_time = k_uptime_get();
+	int64_t elapsed_time, st_time = 0;
 	k_timeout_t k_timeout;
 
 	k_timeout = SYS_TIMEOUT_MS(timeout);
 
+	if ((timeout != SYS_FOREVER_MS) && (timeout != 0U)) {
+		st_time = k_uptime_get();
+	}
+
 	/* waiting for release of write lock */
 	if (sys_sem_take(&rwl->wr_sem, k_timeout) == 0) {
 		/* update remaining timeout time for 2nd sem */
-		if (timeout != SYS_FOREVER_MS) {
+		if ((timeout != SYS_FOREVER_MS) && (timeout != 0U)) {
 			elapsed_time = k_uptime_get() - st_time;
 			timeout = timeout <= elapsed_time ? 0 :
 				  timeout - elapsed_time;


### PR DESCRIPTION
`write_lock_acquire()` read `k_uptime_get()` unconditionally to prorate a timeout that untimed `pthread_rwlock_wrlock()` and `trywrlock()` never use, and trylock paid a second read to compute an always-zero remainder. Read the clock only for finite non-zero timeouts (a spinlocked 64-bit tick read plus conversion, and a syscall in userspace builds, per call on the untimed paths).

Timed behaviour is unchanged.

Validated with the rwlocks suite on qemu_x86_64.