### PR TITLE
ipc: icbmsg: define stats_name if CONFIG_STATS

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -1470,8 +1470,8 @@ const static struct ipc_service_backend backend_ops = {
 			},                                                                         \
 		.bound_packet =                                                                    \
 			BOUND_PACKET_INIT(DT_INST_PROP(i, tx_blocks), DT_INST_PROP(i, rx_blocks)), \
-		IF_ENABLED(CONFIG_STATS_NAMES,                                              \
-			   (.stats_name = STRINGIFY(ipc_icbmsg_##i),)) };         \
+		IF_ENABLED(CONFIG_STATS,                                                           \
+			   (.stats_name = STRINGIFY(ipc_icbmsg_##i),)) };                          \
 	BUILD_ASSERT(IS_ALIGNED(GET_MEM_ADDR_INST(i, tx), GET_CACHE_ALIGNMENT(i)),                 \
 		     "TX producer queue is not aligned to cache alignment");                       \
 	BUILD_ASSERT(IS_ALIGNED(GET_MEM_ADDR_INST(i, rx), GET_CACHE_ALIGNMENT(i)),                 \


### PR DESCRIPTION
The stats_name used by CONFIG_STATS must be defined if stats are registered. CONFIG_STATS_NAMES covers individual stats, not the stats group, which must have a name.

Letting stats_name be initializing to NULL, the stats module will hit a NULL dereference if either stats_group_find or stats_register is called after icbmsg has registered itself.

The issue was not found since icbmsg is the only stats module registering itself, thus stats_register() did not need to access the stats_name to validate no duplicates are registered on the next call to stats_register().

The bug was introduced as with the rework here #111878