### PR TITLE
lib: utils: bitarray: test bits without taking the spinlock

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1761,10 +1761,18 @@ Libraries / Subsystems
     a dedicated pool on every channel (channels fall back to the shared pool until
     :c:func:`zbus_chan_set_msg_sub_pool` is called)
 
+* Utilities
+
+  * :c:func:`sys_bitarray_test_bit` no longer takes the bitarray spinlock and is
+    now inlined.  The lock could not make a single-bit test any less stale, so
+    the semantics are unchanged for every use that was already well defined;
+    callers needing an atomic test-and-update must use
+    :c:func:`sys_bitarray_test_and_set_bit` or
+    :c:func:`sys_bitarray_test_and_clear_bit`.
+
 * __assert
 
    * ``__ASSERT_ON`` define has been removed.
-
 
 Devicetree
 **********

--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <stdint.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 
 /**
@@ -46,6 +47,8 @@ struct sys_bitarray {
 	/* Spinlock guarding access to this bit array */
 	struct k_spinlock lock;
 };
+/* Number of bits represented by one bundle */
+#define Z_BITARRAY_BUNDLE_BITNESS(ba) (sizeof((ba)->bundles[0]) * 8)
 /** @endcond */
 
 /** Bitarray structure */
@@ -114,6 +117,11 @@ int sys_bitarray_clear_bit(sys_bitarray_t *bitarray, size_t bit);
 /**
  * Test whether a bit is set or not
  *
+ * The bit is read with a single unsynchronized word access, so the value is
+ * only a snapshot of the moment the function returns.  Callers needing the
+ * test and a subsequent update to be atomic must use
+ * sys_bitarray_test_and_set_bit() or sys_bitarray_test_and_clear_bit().
+ *
  * @param[in]  bitarray Bitarray struct
  * @param[in]  bit      The bit to be tested
  * @param[out] val      The value of the bit (0 or 1)
@@ -122,7 +130,28 @@ int sys_bitarray_clear_bit(sys_bitarray_t *bitarray, size_t bit);
  * @retval -EINVAL Invalid argument (e.g. bit to test exceeds
  *                 the number of bits in bit array, etc.)
  */
-int sys_bitarray_test_bit(sys_bitarray_t *bitarray, size_t bit, int *val);
+static inline int sys_bitarray_test_bit(sys_bitarray_t *bitarray, size_t bit, int *val)
+{
+	size_t idx, off;
+
+	__ASSERT_NO_MSG(bitarray != NULL);
+	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
+	CHECKIF(val == NULL) {
+		return -EINVAL;
+	}
+
+	if (bit >= bitarray->num_bits) {
+		return -EINVAL;
+	}
+
+	idx = bit / Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+	off = bit % Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+
+	*val = (bitarray->bundles[idx] & BIT(off)) != 0 ? 1 : 0;
+
+	return 0;
+}
 
 /**
  * Test the bit and set it

--- a/lib/utils/bitarray.c
+++ b/lib/utils/bitarray.c
@@ -12,9 +12,6 @@
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/sys_io.h>
 
-/* Number of bits represented by one bundle */
-#define bundle_bitness(ba)	(sizeof((ba)->bundles[0]) * 8)
-
 struct bundle_data {
 	 /* Start and end index of bundles */
 	size_t sidx, eidx;
@@ -30,11 +27,11 @@ static void setup_bundle_data(sys_bitarray_t *bitarray,
 			      struct bundle_data *bd,
 			      size_t offset, size_t num_bits)
 {
-	bd->sidx = offset / bundle_bitness(bitarray);
-	bd->soff = offset % bundle_bitness(bitarray);
+	bd->sidx = offset / Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+	bd->soff = offset % Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 
-	bd->eidx = (offset + num_bits - 1) / bundle_bitness(bitarray);
-	bd->eoff = (offset + num_bits - 1) % bundle_bitness(bitarray);
+	bd->eidx = (offset + num_bits - 1) / Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+	bd->eoff = (offset + num_bits - 1) % Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 
 	bd->smask = ~(BIT(bd->soff) - 1);
 	bd->emask = (BIT(bd->eoff) - 1) | BIT(bd->eoff);
@@ -151,7 +148,7 @@ mismatch:
 
 		mismatch_bit_off = find_lsb_set(mismatch_bundle) - 1;
 		mismatch_bit_off += mismatch_bundle_idx *
-				    bundle_bitness(bitarray);
+				    Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 		*mismatch = (uint32_t)mismatch_bit_off;
 	}
 	return false;
@@ -333,8 +330,8 @@ int sys_bitarray_set_bit(sys_bitarray_t *bitarray, size_t bit)
 		goto out;
 	}
 
-	idx = bit / bundle_bitness(bitarray);
-	off = bit % bundle_bitness(bitarray);
+	idx = bit / Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+	off = bit % Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 
 	bitarray->bundles[idx] |= BIT(off);
 
@@ -361,47 +358,10 @@ int sys_bitarray_clear_bit(sys_bitarray_t *bitarray, size_t bit)
 		goto out;
 	}
 
-	idx = bit / bundle_bitness(bitarray);
-	off = bit % bundle_bitness(bitarray);
+	idx = bit / Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+	off = bit % Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 
 	bitarray->bundles[idx] &= ~BIT(off);
-
-	ret = 0;
-
-out:
-	k_spin_unlock(&bitarray->lock, key);
-	return ret;
-}
-
-int sys_bitarray_test_bit(sys_bitarray_t *bitarray, size_t bit, int *val)
-{
-	k_spinlock_key_t key;
-	int ret;
-	size_t idx, off;
-
-	__ASSERT_NO_MSG(bitarray != NULL);
-	__ASSERT_NO_MSG(bitarray->num_bits > 0);
-
-	key = k_spin_lock(&bitarray->lock);
-
-	CHECKIF(val == NULL) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	if (bit >= bitarray->num_bits) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	idx = bit / bundle_bitness(bitarray);
-	off = bit % bundle_bitness(bitarray);
-
-	if ((bitarray->bundles[idx] & BIT(off)) != 0) {
-		*val = 1;
-	} else {
-		*val = 0;
-	}
 
 	ret = 0;
 
@@ -431,8 +391,8 @@ int sys_bitarray_test_and_set_bit(sys_bitarray_t *bitarray, size_t bit, int *pre
 		goto out;
 	}
 
-	idx = bit / bundle_bitness(bitarray);
-	off = bit % bundle_bitness(bitarray);
+	idx = bit / Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+	off = bit % Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 
 	if ((bitarray->bundles[idx] & BIT(off)) != 0) {
 		*prev_val = 1;
@@ -470,8 +430,8 @@ int sys_bitarray_test_and_clear_bit(sys_bitarray_t *bitarray, size_t bit, int *p
 		goto out;
 	}
 
-	idx = bit / bundle_bitness(bitarray);
-	off = bit % bundle_bitness(bitarray);
+	idx = bit / Z_BITARRAY_BUNDLE_BITNESS(bitarray);
+	off = bit % Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 
 	if ((bitarray->bundles[idx] & BIT(off)) != 0) {
 		*prev_val = 1;
@@ -538,7 +498,7 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 	for (size_t idx = 0; idx < bitarray->num_bundles; idx++) {
 		if (~bitarray->bundles[idx] == 0U) {
 			/* bundle is all 1s => all allocated, skip */
-			bit_idx += bundle_bitness(bitarray);
+			bit_idx += Z_BITARRAY_BUNDLE_BITNESS(bitarray);
 			continue;
 		}
 
@@ -634,10 +594,10 @@ found:
 	/* The bit we are looking for must be in the current bundle idx.
 	 * Find out the exact index of the bit.
 	 */
-	for (size_t j = 0; j <= bundle_bitness(bitarray) - 1; j++) {
+	for (size_t j = 0; j <= Z_BITARRAY_BUNDLE_BITNESS(bitarray) - 1; j++) {
 		if (bitarray->bundles[idx] & mask & BIT(j)) {
 			if (--n <= 0) {
-				*found_at = idx * bundle_bitness(bitarray) + j;
+				*found_at = idx * Z_BITARRAY_BUNDLE_BITNESS(bitarray) + j;
 				ret = 0;
 				break;
 			}


### PR DESCRIPTION
`sys_bitarray_test_bit()` took the bitarray spinlock around what is a single aligned word read. The lock cannot make that result any less stale — it is only a snapshot of the moment the call returns — so it bought no caller anything, while costing an IRQ-lock window on UP and an atomic RMW plus barriers on SMP. Callers needing an atomic test-and-update already have `sys_bitarray_test_and_set_bit()` / `sys_bitarray_test_and_clear_bit()`.

This drops the lock and moves the accessor into the header as a `static inline`, matching what `atomic_test_bit()` and `sys_bitfield_test_bit()` already do for the equivalent one-word test. The struct layout it touches is public in practice — `SYS_BITARRAY_DEFINE()` builds it field by field in the caller's translation unit — so inlining exposes nothing new. The bundle-width macro moves along with it, renamed `Z_BITARRAY_BUNDLE_BITNESS()` now that it lives in a public header.

The POSIX object pools test an allocation bit on every pthread mutex, condvar, rwlock, spinlock, barrier and key operation, so they see most of the benefit.

### Results

Instructions per operation on `qemu_cortex_m3` under deterministic icount (`shift=0`, so 1 instruction = 1 ns of virtual time; two independent runs were bit-identical). Lower is better.

| benchmark | before | after | |
|---|---|---|---|
| `pthread_mutex_lock`+`unlock`, uncontended | 218.8 | 172.9 | −21.0% |
| `pthread_cond_signal`, no waiter | 72.9 | 50.0 | −31.4% |
| `pthread_getspecific` | 165.6 | 142.7 | −13.8% |

Cross-checked against `objdump`: the validation path goes 41 → 16 instructions statically, and the mutex pair (which validates twice) measures 26 instructions saved per validation dynamically.

A POSIX application image on the same board shrinks by 40 bytes.

### Testing

- `tests/kernel/common` (bitarray suite) on `qemu_cortex_m3`: 77 passed, 0 failed
- `tests/subsys/portability/posix/threads_base`: 42 passed, 0 failed
- `tests/subsys/portability/posix/spinlocks`: 3 passed, 0 failed
- Also built for `qemu_cortex_m0` to cover the `CONFIG_ATOMIC_OPERATIONS_C` path

The behaviour change is documented in the release notes.

The one judgement call worth a second opinion is inlining a public-API accessor into the header; without it the win drops to about −6%, since the remaining cost is almost entirely the call itself.