### PR TITLE
posix: mutex: avoid k_current_get() and type lookup on uncontended lock

### DIFF
--- a/subsys/portability/posix/options/mutex.c
+++ b/subsys/portability/posix/options/mutex.c
@@ -133,12 +133,13 @@ static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
 
 	LOG_DBG("Locking mutex %p with timeout %" PRIx64, m, (int64_t)timeout.ticks);
 
-	bit = posix_mutex_to_offset(m);
-	type = posix_mutex_type[bit];
 	owner = m->owner;
 	lock_count = m->lock_count;
 
-	if (owner == k_current_get()) {
+	if (owner != NULL && owner == k_current_get()) {
+		bit = posix_mutex_to_offset(m);
+		type = posix_mutex_type[bit];
+
 		switch (type) {
 		case PTHREAD_MUTEX_NORMAL:
 			if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {


### PR DESCRIPTION
acquire_mutex() evaluated k_current_get() and loaded the mutex type on every lock operation, but both values are only needed when the calling thread already owns the mutex (relock handling).  In the common uncontended case the owner is NULL, so short-circuit on that before calling k_current_get() - which is a system call in userspace builds without thread-local current - and move the type/offset lookup into the self-owned branch.

Measured with callgrind on native_sim/native/64: uncontended pthread_mutex_lock() drops from 241 to 229 instructions (-5%); in userspace builds this additionally removes one syscall per uncontended lock.  No behaviour change: a NULL owner can never equal the calling thread.