### PR TITLE
usb: usbd_dfu: add missing toolchain.h and fix initializer order

### DIFF
--- a/include/zephyr/usb/class/usbd_dfu.h
+++ b/include/zephyr/usb/class/usbd_dfu.h
@@ -15,6 +15,7 @@
 #define ZEPHYR_INCLUDE_USB_CLASS_USBD_DFU_H
 
 #include <stdint.h>
+#include <zephyr/toolchain.h>
 
 /* DFU Class Subclass */
 #define USB_DFU_SUBCLASS		0x01
@@ -162,9 +163,9 @@ struct usbd_dfu_image {
 		.if_desc = &usbd_dfu_iface_##id,					\
 		.priv = ipriv,								\
 		.sd_nd = &usbd_dfu_str_##id,						\
+		.next_cb = inext,							\
 		.read_cb = iread,							\
 		.write_cb = iwrite,							\
-		.next_cb = inext,							\
 	}
 
 /**


### PR DESCRIPTION
usb: class: usbd_dfu: Fix C++20 compatibility issues in usbd_dfu.h

This commit addresses two of the three C++20 compatibility issues reported in #117319.

1. Add missing #include <zephyr/toolchain.h>

struct usb_dfu_descriptor is declared with __packed, which is defined in <zephyr/toolchain.h>. This header was not included in usbd_dfu.h, meaning compilation could silently rely on __packed being pulled in transitively by another include. When that indirect include is absent — for example in a minimal C++20 translation unit — the build fails because __packed is undefined. Adding the explicit include makes the header self-contained and robust against include-order changes.

2. Reorder designated initializers in USBD_DFU_DEFINE_IMG to match declaration order

The USBD_DFU_DEFINE_IMG macro previously initialized .read_cb and .write_cb before .next_cb. However, struct usbd_dfu_image declares next_cb before read_cb and write_cb. C++20 requires designated initializers to appear in the same order as the struct member declarations (gaps are permitted, but reordering is not — see [P0329](https://wg21.link/p0329)). The previous order compiled silently under C but caused a hard build error under g++ -std=c++20.

Zephyr's own documentation recommends that designated initializers in public headers follow C++20 declaration order to maximize toolchain and standard compatibility.
[C++ Designated Initializers](https://docs.zephyrproject.org/latest/develop/languages/cpp/index.html#designated-initializers)

The corrected initializer order is:
static const STRUCT_SECTION_ITERABLE(usbd_dfu_image, usbd_dfu_image_##id) = { \
    .name    = iname,                  \
    .if_desc = &usbd_dfu_iface_##id,   \
    .priv    = ipriv,                  \
    .sd_nd   = &usbd_dfu_str_##id,     \
    .next_cb = inext,                  \
    .read_cb = iread,                  \
    .write_cb = iwrite,                \
}

This matches the member declaration order in struct usbd_dfu_image.
[usbd_dfu.h source](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/usb/class/usbd_dfu.h#L1-L108)

Out of scope: buf[static CONFIG_USBD_DFU_TRANSFER_SIZE] in callback signatures

The use of static-sized array notation in the read_cb and write_cb function pointer signatures is a C99/C11 feature not supported in C++. This is the third incompatibility identified in #117319 and is intentionally not addressed here. The static qualifier provides useful semantic information and a solution that preserves this benefit while remaining valid C++ has not yet been identified. 

[GitHub Issue #117319](https://github.com/zephyrproject-rtos/zephyr/issues/117319)