### PR TITLE
soc: rpi_pico: fix binary info header placed before vector table

### DIFF
--- a/soc/raspberrypi/rpi_pico/common/CMakeLists.txt
+++ b/soc/raspberrypi/rpi_pico/common/CMakeLists.txt
@@ -15,7 +15,7 @@ zephyr_library_sources_ifdef(CONFIG_RPI_PICO_BINARY_INFO
 )
 
 zephyr_linker_sources_ifdef(CONFIG_RPI_PICO_BINARY_INFO
-  ROM_START SORT_KEY 0x0binary_info_header binary_info_header.ld
+  ROM_START SORT_KEY 0x2binary_info_header binary_info_header.ld
 )
 
 zephyr_linker_sources_ifdef(CONFIG_RPI_PICO_BINARY_INFO


### PR DESCRIPTION
The binary info header is injected into rom_start with sort key '0x0binary_info_header', which sorts before '0x0vectors' (the ARM vector table). This places the header at XIP_BASE + 0x100, right where the RP2040 boot2 stage hardcodes VTOR. The vector table, pushed to 0x10000200 by ALIGN(0x100) after the header's 24 bytes, is never reached — the core loads the header marker as its stack pointer and faults immediately.

Fix by using sort key '0x2binary_info_header' so the header emits after the vector table snippets ('0x0vectors' / '0x1vectors'). The vector table sits at 0x10000100 as boot2 expects, and the header ends at ~offset 0xbc — within the 256-byte limit picotool scans.

Only affects RP2040 builds with CONFIG_RPI_PICO_BINARY_INFO=y.