### PR TITLE
tests: benchmarks: thread_metric: ensure asserts are disabled

### DIFF
--- a/tests/benchmarks/thread_metric/prj.conf
+++ b/tests/benchmarks/thread_metric/prj.conf
@@ -1,5 +1,8 @@
 # Default base configuration file
 
+# The interrupt scenarios select TEST, which in turn enables asserts by default
+CONFIG_ASSERT=n
+
 # Use a tickless kernel to minimize the number of timer interrupts
 CONFIG_TICKLESS_KERNEL=y
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=100


### PR DESCRIPTION
The `interrupt` and `interrupt_preemption` scenarios `select TEST` to get `irq_offload()`. `config ASSERT` is `default y if TEST`, and `SPIN_VALIDATE` lives inside the `if ASSERT` block with `default y if !FLASH || FLASH_SIZE > 32`. Those two scenarios therefore measure an assert-instrumented kernel with spinlock validation on every context switch, while the other six scenarios measure a clean one.

The cost is large and could be misleading if one runs the tests "out-of-the-box" without lookoing further. On `qemu_x86` (icount, so these are exact):

| `interrupt` | v4.4 | main |
|---|---:|---:|
| as shipped today | 3,084,853 | 2,742,082 |
| `CONFIG_ASSERT=n` | 5,069,194 | 5,069,193 |
| under-reported by | 39% | 46% |

`interrupt_preemption` behaves the same way, and `qemu_cortex_m3` is worse still (spinlock validation costs ~62% there).

This also manufactures a phantom regression: as shipped, `interrupt` looks 11% slower on main than on v4.4 (19% on Cortex-M3), entirely because d844a4a861c made the validation more expensive. With asserts off the two branches land one count apart out of five million.
