### PR TITLE
tests: sbom: derive the expected Zephyr purl from the checkout

### DIFF
--- a/tests/application_development/software_bill_of_materials/conftest.py
+++ b/tests/application_development/software_bill_of_materials/conftest.py
@@ -4,11 +4,22 @@
 """Pytest configuration for SPDX content validation tests."""
 
 import os
+import re
 
 import pytest
 import yaml
 from packaging import version
 from spdx_tools.spdx.parser.parse_anything import parse_file
+
+# Matches the git URLs that 'west spdx' turns into package URLs:
+#   https://(<user>(:<password>)?@)?<host>/<namespace>/<package>(.git)?
+#   git@<host>:<namespace>/<package>(.git)?
+# Any credentials belong to the checkout, not to the package, so they are not
+# part of the expected purl.
+GIT_URL_REGEX = (
+    r"(?:git@|https?://(?:[^@/]+@)?)(?P<host>[\w.]+)\.\w+[/:]"
+    r"(?P<namespace>[\w\-_/]+)/(?P<package>[\w\-_]+)(?:\.git)?/?"
+)
 
 
 def pytest_addoption(parser):
@@ -128,14 +139,52 @@ def zephyr_version():
 
 
 @pytest.fixture(scope="session")
-def zephyr_meta_remote(build_dir):
-    """Fixture providing the zephyr SCM URL from zephyr.meta, if any."""
+def zephyr_meta(build_dir):
+    """Fixture providing the zephyr entry of zephyr.meta, or an empty dict."""
     meta_path = os.path.join(build_dir, "zephyr", "zephyr.meta")
     try:
         with open(meta_path) as f:
             content = yaml.safe_load(f)
     except OSError:
+        return {}
+
+    return content.get("zephyr", {}) if content else {}
+
+
+@pytest.fixture(scope="session")
+def zephyr_purl_prefix(zephyr_meta):
+    """Fixture providing the purl prefix expected for the checked-out Zephyr repository.
+
+    Derived from the SCM URL recorded in zephyr.meta so that the tests hold in
+    forks and downstream mirrors, not just in zephyrproject-rtos/zephyr.
+
+    Returns None when no purl can be derived, which is the common case in a
+    development workspace: zephyr.meta only records a remote for a checkout that
+    has exactly one, so anything with an extra fork or upstream remote lands here
+    (and gets its revision flagged '-off'). 'west spdx' emits no package URL at
+    all in that case, which the tests assert instead.
+    """
+    url = zephyr_meta.get("remote") or zephyr_meta.get("url")
+    if not url:
         return None
 
-    zephyr = content.get("zephyr", {}) if content else {}
-    return zephyr.get("remote") or zephyr.get("url")
+    match = re.fullmatch(GIT_URL_REGEX, url)
+    if not match:
+        return None
+
+    return f"pkg:{match.group('host')}/{match.group('namespace')}/{match.group('package')}@"
+
+
+@pytest.fixture(scope="session")
+def zephyr_purl_versions(zephyr_meta):
+    """Fixture providing the revisions a Zephyr purl may be pinned to.
+
+    'west spdx' pins to the release tags pointing at the checked-out commit when
+    there are any, and to the commit itself otherwise.
+    """
+    tags = zephyr_meta.get("tags")
+    if tags:
+        return set(tags)
+
+    revision = zephyr_meta.get("revision")
+    return {revision} if revision else set()

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -24,7 +24,6 @@ from spdx_tools.spdx.model.relationship import RelationshipType
 
 ZEPHYR_ORGANIZATION = "The Zephyr Project"
 SPDX_TOOL_PREFIX = "Zephyr SPDX builder"
-PURL_ZEPHYR_PREFIX = "pkg:github/zephyrproject-rtos/zephyr@"
 UTILITY_TARGETS = {
     "run",
     "flash",
@@ -113,6 +112,29 @@ def get_purl_refs(package):
         if ref.category == ExternalPackageRefCategory.PACKAGE_MANAGER
         and ref.reference_type == "purl"
     ]
+
+
+def assert_zephyr_purl(doc_name, package, purl_prefix, purl_versions):
+    """Assert a package's purl identifies the Zephyr checkout the SBOM was built from.
+
+    With no purl prefix, zephyr.meta records no usable remote for zephyr, so the
+    package is expected to carry no purl at all.
+    """
+    purls = get_purl_refs(package)
+    if purl_prefix is None:
+        assert not purls, (
+            f"{doc_name}: {package.name} should carry no purl when zephyr.meta records "
+            f"no remote for zephyr, got {purls}"
+        )
+        return
+
+    matching = [p for p in purls if p.startswith(purl_prefix)]
+    assert matching, f"{doc_name}: {package.name} missing purl prefix '{purl_prefix}', got {purls}"
+    pinned = {p.removeprefix(purl_prefix) for p in matching}
+    assert pinned <= purl_versions, (
+        f"{doc_name}: {package.name} purls {sorted(pinned - purl_versions)} are not pinned to "
+        f"a revision recorded in zephyr.meta ({sorted(purl_versions)})"
+    )
 
 
 def get_supplier_name(package):
@@ -488,21 +510,20 @@ class TestModulesDocument:
 class TestPackageProvenance:
     """Tests for package supplier and purl metadata."""
 
-    def test_zephyr_sources_supplier_and_purl(self, zephyr_doc, zephyr_meta_remote):
+    def test_zephyr_sources_supplier_and_purl(
+        self, zephyr_doc, zephyr_purl_prefix, zephyr_purl_versions
+    ):
         """Test zephyr-sources supplier and purl reference."""
         pkg = find_package_by_name(zephyr_doc, "zephyr-sources")
         assert pkg is not None, "zephyr.spdx: zephyr-sources package not found"
         assert get_supplier_name(pkg) == f"Organization: {ZEPHYR_ORGANIZATION}", (
             f"zephyr.spdx: zephyr-sources supplier is '{get_supplier_name(pkg)}'"
         )
-        if not zephyr_meta_remote:
-            pytest.skip("zephyr.meta has no remote URL for zephyr")
-        purls = get_purl_refs(pkg)
-        assert any(p.startswith(PURL_ZEPHYR_PREFIX) for p in purls), (
-            f"zephyr.spdx: zephyr-sources missing purl prefix '{PURL_ZEPHYR_PREFIX}', got {purls}"
-        )
+        assert_zephyr_purl("zephyr.spdx", pkg, zephyr_purl_prefix, zephyr_purl_versions)
 
-    def test_zephyr_deps_supplier_and_purl(self, modules_doc, zephyr_meta_remote):
+    def test_zephyr_deps_supplier_and_purl(
+        self, modules_doc, zephyr_purl_prefix, zephyr_purl_versions
+    ):
         """Test zephyr-deps supplier and purl reference."""
         if len(modules_doc.packages) == 0:
             pytest.skip("No packages in modules-deps.spdx")
@@ -511,13 +532,7 @@ class TestPackageProvenance:
         assert get_supplier_name(pkg) == f"Organization: {ZEPHYR_ORGANIZATION}", (
             f"modules-deps.spdx: zephyr-deps supplier is '{get_supplier_name(pkg)}'"
         )
-        if not zephyr_meta_remote:
-            pytest.skip("zephyr.meta has no remote URL for zephyr")
-        purls = get_purl_refs(pkg)
-        assert any(p.startswith(PURL_ZEPHYR_PREFIX) for p in purls), (
-            f"modules-deps.spdx: zephyr-deps missing purl prefix '{PURL_ZEPHYR_PREFIX}', "
-            f"got {purls}"
-        )
+        assert_zephyr_purl("modules-deps.spdx", pkg, zephyr_purl_prefix, zephyr_purl_versions)
 
     def test_module_deps_supplier_and_purl(self, modules_doc):
         """Test first module-deps supplier and purl reference."""


### PR DESCRIPTION
The zephyr-sources and zephyr-deps provenance tests asserted a hardcoded 'pkg:github/zephyrproject-rtos/zephyr@' purl prefix, but 'west spdx' builds the purl from the remote URL recorded in zephyr.meta. Any fork or downstream mirror therefore failed the test: in zephyr-testing CI the purl is pkg:github/zephyrproject-rtos/zephyr-testing@<sha>.

Derive the expected prefix from that same remote URL instead, and check that the purl is pinned to a revision the build actually recorded (a tag pointing at HEAD, or the commit itself) rather than only checking the prefix.

zephyr.meta only records a remote for a checkout that has exactly one, so a development workspace with a fork remote gets no purl at all. Assert that absence rather than skipping, so the tests cover both cases.