### PR TITLE
drivers: spi: esp32: fix quad line mode truncated to 16-bit

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -730,7 +730,7 @@ static int spi_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static inline uint8_t spi_esp32_get_line_mode(uint16_t operation)
+static inline uint8_t spi_esp32_get_line_mode(spi_operation_t operation)
 {
 	if (IS_ENABLED(CONFIG_SPI_EXTENDED_MODES)) {
 		switch (operation & SPI_LINES_MASK) {


### PR DESCRIPTION
drivers: spi: esp32: fix quad line mode truncated to 16-bit

## Summary

`spi_esp32_get_line_mode()` in `drivers/spi/spi_esp32_spim.c` declares its
`operation` parameter as `uint16_t`, but the line-mode bits
`SPI_LINES_DUAL/QUAD/OCTAL` live at bit 16 and above of `spi_operation_t`,
which is `uint32_t` when `CONFIG_SPI_EXTENDED_MODES` is enabled.

Passing the full operation into the `uint16_t` parameter truncates those
bits, so `operation & SPI_LINES_MASK` is always 0 and the function always
returns single-line mode. Any request for dual, quad, or octal lines is
silently downgraded to single-line, driving only the D0 data line.

Widen the parameter to `uint32_t` so the line-mode bits survive.

## Verification

- `check_compliance.py`: 34/34 checks pass (Gitlint, Checkpatch, ClangFormat, DCO, LicenseAndCopyright, Kconfig, ...).
- `west twister -T tests/drivers/spi/spi_loopback` builds clean on `esp32s3_devkitc/esp32s3/procpu`.
- Hardware: verified on an ESP32-S3-Touch-AMOLED-1.8 QSPI panel, where quad transfers only produced correct colors with this fix.
