### PR TITLE
samples: net: ptp: filter boards via new ptp_clock supported feature

### DIFF
--- a/boards/antmicro/stm32h7_hdmi_board/stm32h7_hdmi_board_stm32h747xx_m7.yaml
+++ b/boards/antmicro/stm32h7_hdmi_board/stm32h7_hdmi_board_stm32h747xx_m7.yaml
@@ -19,6 +19,7 @@ supported:
   - memc
   - netif:eth
   - nvs
+  - ptp_clock
   - qspi
   - spi
   - uart

--- a/boards/antmicro/stm32h7_renode_reference_board/stm32h7_renode_reference_board.yaml
+++ b/boards/antmicro/stm32h7_renode_reference_board/stm32h7_renode_reference_board.yaml
@@ -22,6 +22,7 @@ supported:
   - led
   - netif:eth
   - nvs
+  - ptp_clock
   - pwm
   - rtc
   - uart

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.yaml
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.yaml
@@ -10,6 +10,7 @@ flash: 768
 supported:
   - gpio
   - netif:eth
+  - ptp_clock
   - qspi
 testing:
   ignore_tags:

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_1_0_0.yaml
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_1_0_0.yaml
@@ -11,6 +11,7 @@ supported:
   - gpio
   - netif:eth
   - i2c
+  - ptp_clock
   - spi
   - qspi
   - memc

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_4_10_0.yaml
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_4_10_0.yaml
@@ -11,6 +11,7 @@ supported:
   - gpio
   - netif:eth
   - i2c
+  - ptp_clock
   - spi
   - qspi
   - memc

--- a/boards/armfly/stm32h743xih6/armfly_stm32h743xih6.yaml
+++ b/boards/armfly/stm32h743xih6/armfly_stm32h743xih6.yaml
@@ -11,6 +11,7 @@ toolchain:
 ram: 512
 flash: 2048
 supported:
+  - ptp_clock
   - uart
   - gpio
   - input

--- a/boards/atmel/sam/sam4e_xpro/sam4e_xpro.yaml
+++ b/boards/atmel/sam/sam4e_xpro/sam4e_xpro.yaml
@@ -14,6 +14,7 @@ supported:
   - hwinfo
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - sdhc
   - spi

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.yaml
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - hwinfo
   - i2s
+  - ptp_clock
   - pwm
   - netif:eth
   - sdhc

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21b.yaml
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21b.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - hwinfo
   - i2s
+  - ptp_clock
   - pwm
   - netif:eth
   - sdhc

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21.yaml
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21.yaml
@@ -19,6 +19,7 @@ supported:
   - hwinfo
   - gpio
   - i2s
+  - ptp_clock
   - pwm
   - netif:eth
   - rtc

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21b.yaml
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21b.yaml
@@ -19,6 +19,7 @@ supported:
   - hwinfo
   - gpio
   - i2s
+  - ptp_clock
   - pwm
   - netif:eth
   - rtc

--- a/boards/atmel/sam0/same54_xpro/same54_xpro.yaml
+++ b/boards/atmel/sam0/same54_xpro/same54_xpro.yaml
@@ -18,6 +18,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - rtc
   - spi

--- a/boards/emtrion/emsbc_neon_cm7/emsbc_neon_cm7.yaml
+++ b/boards/emtrion/emsbc_neon_cm7/emsbc_neon_cm7.yaml
@@ -15,6 +15,7 @@ ram: 384
 flash: 2048
 supported:
   - i2c
+  - ptp_clock
   - spi
   - gpio
   - netif:eth

--- a/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
+++ b/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
@@ -16,6 +16,7 @@ supported:
   - hwinfo
   - netif:eth
   - netif:wifi
+  - ptp_clock
   - sdhc
   - spi
   - uart

--- a/boards/espressif/esp32p4x_function_ev_board/esp32p4x_function_ev_board_hpcore.yaml
+++ b/boards/espressif/esp32p4x_function_ev_board/esp32p4x_function_ev_board_hpcore.yaml
@@ -14,6 +14,7 @@ supported:
   - i2s
   - netif:eth
   - netif:wifi
+  - ptp_clock
   - pulse_io
   - sdhc
   - spi

--- a/boards/heimann/htpa_eval/htpa_eval_same70q20b.yaml
+++ b/boards/heimann/htpa_eval/htpa_eval_same70q20b.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - hwinfo
   - i2s
+  - ptp_clock
   - pwm
   - netif:eth
   - sdhc

--- a/boards/heimann/htpa_eval/htpa_eval_same70q21.yaml
+++ b/boards/heimann/htpa_eval/htpa_eval_same70q21.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - hwinfo
   - i2s
+  - ptp_clock
   - pwm
   - netif:eth
   - sdhc

--- a/boards/heimann/htpa_eval/htpa_eval_same70q21b.yaml
+++ b/boards/heimann/htpa_eval/htpa_eval_same70q21b.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - hwinfo
   - i2s
+  - ptp_clock
   - pwm
   - netif:eth
   - sdhc

--- a/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.yaml
+++ b/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.yaml
@@ -9,6 +9,7 @@ supported:
   - adc
   - dma
   - gpio
+  - ptp_clock
   - spi
   - uart
   - watchdog

--- a/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.yaml
+++ b/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.yaml
@@ -10,6 +10,7 @@ supported:
   - dma
   - gpio
   - i2c
+  - ptp_clock
   - spi
   - uart
   - arduino_spi

--- a/boards/native/native_sim/native_sim.yaml
+++ b/boards/native/native_sim/native_sim.yaml
@@ -18,6 +18,7 @@ supported:
   - eeprom
   - netif:eth
   - mspi
+  - ptp_clock
   - usb_device
   - adc
   - i2c

--- a/boards/native/native_sim/native_sim_native_64.yaml
+++ b/boards/native/native_sim/native_sim_native_64.yaml
@@ -16,6 +16,7 @@ supported:
   - dma
   - eeprom
   - netif:eth
+  - ptp_clock
   - usb_device
   - adc
   - gpio

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 8192
 flash: 16384
 supported:
+  - ptp_clock
   - spi
   - adc
   - dma

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7_extmem.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7_extmem.yaml
@@ -14,6 +14,7 @@ flash: 16384
 supported:
   - gpio
   - hwinfo
+  - ptp_clock
   - uart
   - netif:eth
 vendor: nxp

--- a/boards/nxp/frdm_k64f/frdm_k64f.yaml
+++ b/boards/nxp/frdm_k64f/frdm_k64f.yaml
@@ -22,6 +22,7 @@ supported:
   - i2c
   - netif:eth
   - nvs
+  - ptp_clock
   - pwm
   - spi
   - usb_device

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -14,6 +14,7 @@ supported:
   - arduino_gpio
   - can
   - gpio
+  - ptp_clock
   - rtc
   - dma
   - watchdog

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -30,6 +30,7 @@ supported:
   - i3c
   - netif:eth
   - nvs
+  - ptp_clock
   - pwm
   - regulator
   - rtc

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
@@ -18,6 +18,7 @@ supported:
   - gpio
   - i2c
   - net
+  - netif:eth
   - spi
   - uart
   - watchdog

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
@@ -19,6 +19,7 @@ supported:
   - i2c
   - net
   - netif:eth
+  - ptp_clock
   - spi
   - uart
   - watchdog

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55_smp.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55_smp.yaml
@@ -17,6 +17,7 @@ supported:
   - gpio
   - net
   - netif:eth
+  - ptp_clock
   - spi
   - uart
 testing:

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55_smp.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55_smp.yaml
@@ -16,6 +16,7 @@ supported:
   - counter
   - gpio
   - net
+  - netif:eth
   - spi
   - uart
 testing:

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - net
   - netif:eth
+  - ptp_clock
   - uart
   - watchdog
 testing:

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
@@ -17,6 +17,7 @@ supported:
   - counter
   - i2c
   - net
+  - netif:eth
   - uart
   - watchdog
 testing:

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -21,6 +21,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - spi
   - uart

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
@@ -14,5 +14,6 @@ toolchain:
   - gnuarmemb
 supported:
   - netif:eth
+  - ptp_clock
   - uart
 vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
@@ -13,5 +13,6 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - netif:eth
   - uart
 vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_flash.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_flash.yaml
@@ -15,5 +15,6 @@ toolchain:
   - gnuarmemb
 supported:
   - netif:eth
+  - ptp_clock
   - uart
 vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_flash.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_flash.yaml
@@ -14,5 +14,6 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - netif:eth
   - uart
 vendor: nxp

--- a/boards/nxp/imx95_evk_15x15/imx95_evk_15x15_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk_15x15/imx95_evk_15x15_mimx9596_m7.yaml
@@ -17,6 +17,7 @@ supported:
   - dma
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - spi
   - uart

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
@@ -26,6 +26,7 @@ supported:
   - i3c
   - nvs
   - netif:eth
+  - ptp_clock
   - pwm
   - regulator
   - rtc

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -23,6 +23,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - sdhc
   - spi
   - usb_device

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -23,6 +23,7 @@ supported:
   - gpio
   - hwinfo
   - netif:eth
+  - ptp_clock
   - pwm
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
@@ -21,6 +21,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - spi
   - rtc

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -24,6 +24,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - sdhc
   - spi
   - usb_device

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -24,6 +24,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - sdhc
   - spi
   - usb_device

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -25,6 +25,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -27,6 +27,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
@@ -27,6 +27,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - sdhc
   - spi
   - usbd

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
@@ -28,6 +28,7 @@ supported:
   - i2c
   - i2s
   - netif:eth
+  - ptp_clock
   - sdhc
   - spi
   - usbd

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -26,6 +26,7 @@ supported:
   - hwinfo
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
@@ -22,6 +22,7 @@ supported:
   - hwinfo
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - spi
   - usb_device

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -26,6 +26,7 @@ supported:
   - i2c
   - mipi_dsi
   - netif:eth
+  - ptp_clock
   - pwm
   - spi
   - usb_device

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -25,6 +25,7 @@ supported:
   - i2c
   - mipi_dsi
   - netif:eth
+  - ptp_clock
   - pwm
   - spi
   - usbd

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
@@ -23,6 +23,7 @@ supported:
   - mbox
   - mecc
   - netif:eth
+  - ptp_clock
   - pwm
   - uart
   - i3c

--- a/boards/nxp/s32k148_evb/s32k148_evb.yaml
+++ b/boards/nxp/s32k148_evb/s32k148_evb.yaml
@@ -21,3 +21,4 @@ supported:
   - counter
   - adc
   - netif:eth
+  - ptp_clock

--- a/boards/nxp/s32k148_evb/s32k148_evb.yaml
+++ b/boards/nxp/s32k148_evb/s32k148_evb.yaml
@@ -20,3 +20,4 @@ supported:
   - watchdog
   - counter
   - adc
+  - netif:eth

--- a/boards/olimex/esp32p4_pc/esp32p4_pc_esp32p4_hpcore.yaml
+++ b/boards/olimex/esp32p4_pc/esp32p4_pc_esp32p4_hpcore.yaml
@@ -18,6 +18,7 @@ supported:
   - hwinfo
   - led
   - netif:eth
+  - ptp_clock
   - sdhc
   - spi
   - uart

--- a/boards/olimex/stm32_e407/olimex_stm32_e407.yaml
+++ b/boards/olimex/stm32_e407/olimex_stm32_e407.yaml
@@ -9,5 +9,6 @@ ram: 128
 flash: 1024
 supported:
   - counter
+  - netif:eth
   - usb_device
 vendor: olimex

--- a/boards/olimex/stm32_e407/olimex_stm32_e407.yaml
+++ b/boards/olimex/stm32_e407/olimex_stm32_e407.yaml
@@ -10,5 +10,6 @@ flash: 1024
 supported:
   - counter
   - netif:eth
+  - ptp_clock
   - usb_device
 vendor: olimex

--- a/boards/others/jz_f407vet6/jz_f407vet6.yaml
+++ b/boards/others/jz_f407vet6/jz_f407vet6.yaml
@@ -15,6 +15,7 @@ supported:
   - i2c
   - netif:eth
   - nvs
+  - ptp_clock
   - rtc
   - sdhc
   - spi

--- a/boards/phytec/phyboard_atlas/phyboard_atlas_mimxrt1176_cm7.yaml
+++ b/boards/phytec/phyboard_atlas/phyboard_atlas_mimxrt1176_cm7.yaml
@@ -22,6 +22,7 @@ supported:
   - i2s
   - mipi_dsi
   - netif:eth
+  - ptp_clock
   - spi
   - uart
   - usb_device

--- a/boards/ruiside/art_pi/art_pi.yaml
+++ b/boards/ruiside/art_pi/art_pi.yaml
@@ -15,4 +15,5 @@ supported:
   - display
   - sdmmc
   - usbd
+  - netif:eth
 vendor: ruiside

--- a/boards/ruiside/art_pi/art_pi.yaml
+++ b/boards/ruiside/art_pi/art_pi.yaml
@@ -16,4 +16,5 @@ supported:
   - sdmmc
   - usbd
   - netif:eth
+  - ptp_clock
 vendor: ruiside

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
@@ -20,6 +20,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - rng
   - rtc

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.yaml
@@ -13,6 +13,7 @@ supported:
   - arduino_spi
   - netif:eth
   - i2c
+  - ptp_clock
   - spi
   - gpio
   - pwm

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.yaml
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.yaml
@@ -13,6 +13,7 @@ supported:
   - arduino_spi
   - netif:eth
   - i2c
+  - ptp_clock
   - spi
   - gpio
   - pwm

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.yaml
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.yaml
@@ -21,6 +21,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - rtc
   - spi

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_i2c
   - arduino_gpio
   - arduino_spi
+  - ptp_clock
   - uart
   - gpio
   - netif:eth

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.yaml
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_i2c
   - arduino_gpio
   - arduino_spi
+  - ptp_clock
   - uart
   - gpio
   - netif:eth

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
@@ -13,6 +13,7 @@ supported:
   - backup_sram
   - can
   - gpio
+  - ptp_clock
   - uart
   - entropy
   - adc

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
+  - ptp_clock
   - uart
   - gpio
   - counter

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.yaml
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.yaml
@@ -10,6 +10,7 @@ flash: 2048
 supported:
   - arduino_gpio
   - arduino_i2c
+  - ptp_clock
   - uart
   - gpio
   - counter

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - ptp_clock
   - uart
   - gpio
   - counter

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.yaml
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.yaml
@@ -18,6 +18,7 @@ supported:
   - gpio
   - i2c
   - netif:eth
+  - ptp_clock
   - pwm
   - rtc
   - spi

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - ptp_clock
   - uart
   - gpio
   - counter

--- a/boards/st/nucleo_h7s3l8/twister.yaml
+++ b/boards/st/nucleo_h7s3l8/twister.yaml
@@ -5,6 +5,7 @@ toolchain:
   - zephyr
 supported:
   - gpio
+  - ptp_clock
   - uart
   - watchdog
   - dma

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -14,6 +14,7 @@ supported:
   - i2c
   - gpio
   - netif:eth
+  - ptp_clock
   - rtc
   - spi
   - uart

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_i2c
   - netif:eth
   - i2c
+  - ptp_clock
   - spi
   - gpio
   - pwm

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.yaml
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.yaml
@@ -14,6 +14,7 @@ supported:
   - arduino_i2c
   - netif:eth
   - i2c
+  - ptp_clock
   - spi
   - gpio
   - pwm

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.yaml
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.yaml
@@ -10,6 +10,7 @@ flash: 2048
 supported:
   - arduino_i2c
   - i2c
+  - ptp_clock
   - spi
   - arduino_spi
   - gpio

--- a/boards/st/stm32h573i_dk/twister.yaml
+++ b/boards/st/stm32h573i_dk/twister.yaml
@@ -20,6 +20,7 @@ supported:
   - i2c
   - netif:eth
   - octospi
+  - ptp_clock
   - pwm
   - rtc
   - sdhc

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
@@ -16,5 +16,6 @@ supported:
   - can
   - crypto
   - aes
+  - ptp_clock
   - usb_device
 vendor: st

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.yaml
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.yaml
@@ -10,6 +10,7 @@ flash: 1024
 supported:
   - arduino_gpio
   - arduino_i2c
+  - ptp_clock
   - uart
   - gpio
   - counter

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.yaml
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_gpio
   - gpio
   - arduino_spi
+  - ptp_clock
   - spi
   - netif:eth
   - qspi

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.yaml
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.yaml
@@ -10,6 +10,7 @@ ram: 512
 flash: 1024
 supported:
   - gpio
+  - ptp_clock
   - spi
   - netif:eth
   - qspi

--- a/boards/st/stm32h7s78_dk/twister.yaml
+++ b/boards/st/stm32h7s78_dk/twister.yaml
@@ -13,6 +13,7 @@ supported:
   - memc
   - netif:eth
   - octospi
+  - ptp_clock
   - rtc
   - uart
   - usbd

--- a/boards/st/stm32h7s78_dk/twister.yaml
+++ b/boards/st/stm32h7s78_dk/twister.yaml
@@ -11,6 +11,7 @@ supported:
   - entropy
   - gpio
   - memc
+  - netif:eth
   - octospi
   - rtc
   - uart

--- a/boards/st/stm32mp135f_dk/twister.yaml
+++ b/boards/st/stm32mp135f_dk/twister.yaml
@@ -9,6 +9,7 @@ supported:
   - gpio
   - uart
   - spi
+  - netif:eth
 ram: 262144
 flash: 262144
 vendor: st

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -18,6 +18,7 @@ supported:
   - gpio
   - memc
   - netif:eth
+  - ptp_clock
   - pwm
   - rtc
   - spi

--- a/boards/waveshare/esp32p4_eth/waveshare_esp32p4_eth_hpcore.yaml
+++ b/boards/waveshare/esp32p4_eth/waveshare_esp32p4_eth_hpcore.yaml
@@ -15,6 +15,7 @@ supported:
   - hwinfo
   - i2c
   - netif:eth
+  - ptp_clock
   - sdhc
   - uart
   - usb_device

--- a/boards/waveshare/esp32p4_wifi6_dev_kit/esp32p4_wifi6_dev_kit_esp32p4_hpcore.yaml
+++ b/boards/waveshare/esp32p4_wifi6_dev_kit/esp32p4_wifi6_dev_kit_esp32p4_hpcore.yaml
@@ -15,6 +15,7 @@ supported:
   - i2c
   - input
   - netif:eth
+  - ptp_clock
   - sdhc
   - uart
   - watchdog

--- a/boards/witte/linum/linum.yaml
+++ b/boards/witte/linum/linum.yaml
@@ -8,6 +8,7 @@ toolchain:
 ram: 512
 flash: 2048
 supported:
+  - ptp_clock
   - uart
   - gpio
   - counter

--- a/samples/net/ptp/tests.yaml
+++ b/samples/net/ptp/tests.yaml
@@ -8,16 +8,9 @@ sample:
   name: PTP sample app
 tests:
   sample.net.ptp:
-    platform_allow:
-      - native_sim
-      - native_sim/native/64
-      - nucleo_h563zi
-      - nucleo_h743zi
-      - nucleo_h753zi
-      - nucleo_h745zi_q/stm32h745xx/m7
-      - qemu_x86
-      - esp32p4x_function_ev_board/esp32p4/hpcore
-    depends_on: eth
+    depends_on:
+      - eth
+      - ptp_clock
     integration_platforms:
       - nucleo_h563zi
 
@@ -25,7 +18,9 @@ tests:
     extra_configs:
       - CONFIG_ETH_STM32_HAL=n
       - CONFIG_ETH_ESP32=n
-    depends_on: eth
+    depends_on:
+      - eth
+      - ptp_clock
     platform_allow:
       - stm32h735g_disco
       - nucleo_h753zi


### PR DESCRIPTION
Introduce a `ptp_clock` supported feature in the board yamls and let
`samples/net/ptp` depend on it, instead of maintaining a platform allowlist
in the sample. The tag is added to all board targets that have an enabled
ethernet controller with a driver-backed PTP clock, extending the sample's
coverage from 8 to ~80 platforms.

Some boards that enable an ethernet controller in their devicetree were also
missing `netif:eth` in their supported features; this is fixed along the way.

See the individual commit messages for details.
