### PR TITLE
soc: nxp: imx93: add USB and USB PHY clock support

### DIFF
--- a/soc/nxp/imx/imx9/imx93/common_clock_set.c
+++ b/soc/nxp/imx/imx9/imx93/common_clock_set.c
@@ -56,6 +56,20 @@ uint32_t common_clock_set_freq(uint32_t clock_name, uint32_t rate)
 		CLOCK_SetRootClockMux(kCLOCK_Root_CamPix,
 				      kCLOCK_MEDIALDB_ClockRoot_MuxVideoPll1Out);
 		break;
+	case IMX_CCM_USB_CLK:
+		/* 400MHz SysPll1Pfd1Div2 source, /3 -> 133.33MHz (closest match to 134MHz) */
+		clk_root = kCLOCK_Root_Hsio;
+		clk_gate = kCLOCK_Usb_Controller;
+		CLOCK_SetRootClockMux(kCLOCK_Root_Hsio,
+				      kCLOCK_HSIO_ClockRoot_MuxSysPll1Pfd1Div2);
+		break;
+	case IMX_CCM_USB_PHY_CLK:
+		/* 400MHz SysPll1Pfd1Div2 source, /8 -> exactly 50MHz, no dedicated LPCG gate */
+		clk_root = kCLOCK_Root_UsbPhyBurunin;
+		clk_gate = kCLOCK_IpInvalid;
+		CLOCK_SetRootClockMux(kCLOCK_Root_UsbPhyBurunin,
+				      kCLOCK_USBPHYBURUNIN_ClockRoot_MuxSysPll1Pfd1Div2);
+		break;
 	default:
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
common_clock_set_freq() was missing cases for IMX_CCM_USB_CLK and IMX_CCM_USB_PHY_CLK, so mcux_ccm_set_subsys_rate() returned -ENOTSUP whenever a UDC NXP EHCI driver instance requested these clocks during udc_mcux_driver_preinit(). This left the USB device controller uninitialized with no error surfaced to the application, only visible as a silent "not ready" failure.

Add the two missing cases:

- IMX_CCM_USB_CLK: routed from the Hsio root, sourced from the 400 MHz SysPll1Pfd1Div2 and divided by 3 for ~133.33 MHz, the closest achievable match to the requested 134 MHz.
- IMX_CCM_USB_PHY_CLK: routed from the UsbPhyBurunin root, same 400 MHz source divided by 8 for an exact 50 MHz. This root has no dedicated LPCG gate.

Tested by building and flashing samples/subsys/usb/cdc_acm to a
nitrogen93_smarc/mimx9352/a55 board with the smarc_car_brd shield
(nxp,ehci UDC driver). Before this change, boot failed with -ENOTSUP
from udc_mcux_driver_preinit(); after this change, the device boots
correctly and USB device support/CDC-ACM enumerates as expected.

Assisted-by: GitHub Copilot:claude-sonnet-5