### PR TITLE
[Backport v3.7-branch] usb: device_next: bt_hci: size buffers for complete HCI packets

### DIFF
--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -76,6 +76,15 @@ static K_FIFO_DEFINE(bt_hci_tx_queue);
 NET_BUF_POOL_FIXED_DEFINE(bt_hci_ep_pool,
 			  3, 512,
 			  sizeof(struct udc_buf_info), NULL);
+
+/*
+ * The TX queue carries Controller-to-Host ACL data and events. Size the
+ * pool for the largest complete HCI packet.
+ */
+NET_BUF_POOL_FIXED_DEFINE(bt_hci_tx_pool,
+			  2, MAX(BT_BUF_ACL_RX_SIZE, BT_BUF_EVT_RX_SIZE),
+			  sizeof(struct udc_buf_info), NULL);
+
 /* HCI RX/TX threads */
 static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 static struct k_thread rx_thread_data;
@@ -179,13 +188,18 @@ static void bt_hci_tx_sync_in(struct usbd_class_data *const c_data,
 			      struct net_buf *const bt_buf, const uint8_t ep)
 {
 	struct bt_hci_data *hci_data = usbd_class_get_private(c_data);
+	struct udc_buf_info *bi;
 	struct net_buf *buf;
 
-	buf = bt_hci_buf_alloc(ep);
+	buf = net_buf_alloc(&bt_hci_tx_pool, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		return;
 	}
+
+	bi = udc_get_buf_info(buf);
+	memset(bi, 0, sizeof(struct udc_buf_info));
+	bi->ep = ep;
 
 	net_buf_add_mem(buf, bt_buf->data, bt_buf->len);
 	usbd_ep_enqueue(c_data, buf);


### PR DESCRIPTION
Backport of the fix from #116173 to `v3.7-branch`.

Fixes: #117499