### PR TITLE
boards: infineon: kit_pse84_eval: add multi-image DFU overlays

### DIFF
--- a/boards/infineon/kit_pse84_ai/Kconfig.defconfig
+++ b/boards/infineon/kit_pse84_ai/Kconfig.defconfig
@@ -45,3 +45,15 @@ endif # BOARD_KIT_PSE84_AI_PSE846GPS2DBZC4A_M55
 
 config FLASH_FILL_BUFFER_SIZE
 	default 16 if FLASH
+
+# The extended boot of PSE84 validates a 0x400-byte MCUBoot-format header
+# at the start of the first image. ROM_START_OFFSET reserves space in the
+# ELF for imgtool to write the header into during signing. TF-M also reserves
+# the space at the beginning of the NSPE.
+#
+# In the sysbuild flow the CM33 image carries the ext-boot header and
+# enables the CM55, so the CM55 image itself is not signed and needs no
+# reserved header space.
+config ROM_START_OFFSET
+	default 0x0 if BOARD_KIT_PSE84_AI_PSE846GPS2DBZC4A_M55
+	default 0x400

--- a/boards/infineon/kit_pse84_ai/board.cmake
+++ b/boards/infineon/kit_pse84_ai/board.cmake
@@ -30,12 +30,3 @@ board_runner_args(probe-rs "--chip=PSE846GPS4DBZC4A")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
-
-if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
-  set_property(TARGET runners_yaml_props_target
-    PROPERTY hex_file ${KERNEL_NAME}.signed.hex)
-endif()
-
-if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_NONSECURE)
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-endif()

--- a/boards/infineon/kit_pse84_ai/doc/index.rst
+++ b/boards/infineon/kit_pse84_ai/doc/index.rst
@@ -343,7 +343,7 @@ cryptographic signature verification is performed against a provisioned key.
 
 The MCUboot image format is produced automatically by the
 :file:`soc/infineon/edge/pse84/pse84_metadata.cmake` helper
-``pse84_add_metadata_secure_hex()``, which invokes ``imgtool sign`` with the header address,
+``pse84_add_extboot_metadata()``, which invokes ``imgtool sign`` with the header address,
 header size and slot size derived from the devicetree memory map. By default this helper does not
 pass a signing key, which is sufficient for a non-provisioned device.
 
@@ -359,15 +359,15 @@ Follow sections **2.2.1**, **2.2.2** and **2.2.3** of the
 #. Program the desired security counter / anti-rollback value.
 
 After the device has been reprovisioned, the
-``pse84_add_metadata_secure_hex()`` function in
+``pse84_add_extboot_metadata()`` function in
 :file:`soc/infineon/edge/pse84/pse84_metadata.cmake` must be updated so that ``imgtool sign``
 also receives the signing key and a security counter. The relevant additions are:
 
 .. code-block:: none
 
    ${PYTHON_EXECUTABLE} ${IMGTOOL} sign --version "0.0.0+0"
-     --header-size ${header_size} --erased-val 0xff --pad-header
-     --slot-size ${slot_size} --hex-addr ${header_addr}
+     --header-size ${header_size} --erased-val 0xff
+     --slot-size ${slot_size} --hex-addr ${hex_addr}
      --key <oem-private-key-file>
      --security-counter <value>
      ${INPUT_FILE} ${OUTPUT_FILE}

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
@@ -111,10 +111,10 @@
 					reg = <0 DT_SIZE_M(1)>;
 				};
 
-				m33_xip: m33_xip@340400 {
+				m33_xip: m33_xip@340000 {
 					compatible = "zephyr,mapped-partition";
 					label = "m33-xip";
-					reg = <0x340400 DT_SIZE_M(2)>;
+					reg = <0x340000 DT_SIZE_M(2)>;
 				};
 			};
 		};
@@ -140,16 +140,10 @@
 				#size-cells = <1>;
 				ranges;
 
-				m33s_header: m33s_header@100000 {
-					compatible = "zephyr,mapped-partition";
-					label = "m33s-header";
-					reg = <0x100000 0x400>;
-				};
-
-				m33s_xip: m33s_xip@100400 {
+				m33s_xip: m33s_xip@100000 {
 					compatible = "zephyr,mapped-partition";
 					label = "m33s-xip";
-					reg = <0x100400 0x1ffc00>;
+					reg = <0x100000 0x200000>;
 				};
 			};
 		};

--- a/boards/infineon/kit_pse84_eval/Kconfig.defconfig
+++ b/boards/infineon/kit_pse84_eval/Kconfig.defconfig
@@ -45,3 +45,16 @@ endif
 
 config FLASH_FILL_BUFFER_SIZE
 	default 16 if FLASH
+
+# The extended boot of PSE84 validates a 0x400-byte MCUBoot-format header
+# at the start of the first image. ROM_START_OFFSET reserves space in the
+# ELF for imgtool to write the header into during signing. TF-M also reserves
+# the space at the beginning of the NSPE.
+#
+# Every image reserves this space except the CM55 application when it is not
+# built as an MCUBoot slot (not chain-loaded by MCUBoot). In the sysbuild flow
+# the CM33 image carries the ext-boot header and enables the CM55, so the CM55
+# image itself is not signed and needs no reserved header space.
+config ROM_START_OFFSET
+	default 0x0 if BOARD_KIT_PSE84_EVAL_PSE846GPS2DBZC4A_M55 && !BOOTLOADER_MCUBOOT
+	default 0x400

--- a/boards/infineon/kit_pse84_eval/board.cmake
+++ b/boards/infineon/kit_pse84_eval/board.cmake
@@ -30,12 +30,3 @@ board_runner_args(probe-rs "--chip=PSE846GPS4DBZC4A")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
-
-if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
-  set_property(TARGET runners_yaml_props_target
-    PROPERTY hex_file ${KERNEL_NAME}.signed.hex)
-endif()
-
-if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_NONSECURE)
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
-endif()

--- a/boards/infineon/kit_pse84_eval/doc/index.rst
+++ b/boards/infineon/kit_pse84_eval/doc/index.rst
@@ -205,10 +205,17 @@ Programming and Debugging
 *************************
 
 .. NOTE::
+   The ``SW6`` (``BOOT SW``) DIP switch controls the boot mode:
 
-   ``BOOT SW`` on the board **MUST** be set to ``ON`` for any sample
-   applications to work. On some boards this switch may be under the
-   attached LCD screen.
+   - **ON** (default): Extended boot initializes the external QSPI flash and
+     jumps directly to the XIP code partition. Use this position for
+     **non-MCUBoot** application development.
+   - **OFF**: Extended boot jumps to the MCUBoot bootloader in RRAM
+     (``0x22011000``), which then initializes the external flash and validates
+     the application image before jumping to it. Use this position when
+     **MCUBoot is enabled**.
+
+   On some boards this switch may be under the attached LCD screen.
 
 .. zephyr:board-supported-runners::
 
@@ -375,6 +382,327 @@ Where ``<oem-private-key-file>`` is the path to the OEM private key file (e.g. a
 file) matching the public key provisioned into the device, and ``<value>`` is the security
 counter assigned during provisioning. Without these additional parameters, images built for a
 provisioned device will be rejected by the ROM extended boot.
+MCUBoot Bootloader Support
+**************************
+
+The ``kit_pse84_eval`` board supports `MCUBoot`_ for bootloader and
+over-the-air (OTA) firmware updates. The PSOC™ Edge E84 extended-boot ROM
+validates an MCUBoot-compatible image header at the MCUBoot bootloader location
+in RRAM before handing off to MCUBoot, which then validates and starts the
+application(s).
+
+.. IMPORTANT::
+   When using MCUBoot, the ``SW6`` (``BOOT SW``) DIP switch **MUST** be set to
+   the **OFF** position. This causes the extended boot to jump to the MCUBoot
+   bootloader in RRAM at ``0x22011000``. If the switch is left ON, the extended
+   boot will attempt to jump directly to the external flash XIP address,
+   bypassing MCUBoot entirely.
+
+The base memory map (``kit_pse84_eval_memory_map.dtsi``) defines every flash
+region under a role label describing what it *is* (for example ``m33s_xip``,
+``m33_xip``, ``m55_xip``). The MCUBoot image-numbering labels
+(``slotN_partition``) are layered on top of those role labels. The absolute,
+shared slots ``slot2_partition`` .. ``slot5_partition`` are consumed only by
+the MCUBoot bootloader, so they are attached to those role nodes in the
+bootloader overlay (``kit_pse84_eval_mcuboot_bl.overlay``), which also selects
+``boot_partition`` and RRAM as the bootloader flash device. The
+``slot0_partition`` / ``slot1_partition`` labels are relative to the image
+being built and are bound by the per-core board files
+(``kit_pse84_eval_m33.dts`` / ``kit_pse84_eval_m33_ns.dts``). This means no
+extra DTS overlay is needed for application images.
+
+Flash Layout with MCUBoot
+=========================
+
+When MCUBoot is enabled, the flash is partitioned as follows:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Partition
+     - Location
+     - Offset
+     - Size
+     - Description
+   * - ``boot_partition``
+     - RRAM
+     - ``0x11000``
+     - 256 KB
+     - MCUBoot bootloader (address ``0x22011000``)
+   * - ``slot0_partition``
+     - flash0_s
+     - ``0x100000``
+     - 2.25 MB
+     - CM33S primary application (active)
+   * - ``slot1_partition``
+     - flash0_s
+     - ``0x700000``
+     - 2.25 MB
+     - CM33S secondary / update slot
+   * - ``slot2_partition``
+     - flash0
+     - ``0x340000``
+     - 1.75 MB
+     - CM33NS primary application (active)
+   * - ``slot3_partition``
+     - flash0
+     - ``0x940000``
+     - 1.75 MB
+     - CM33NS secondary / update slot
+   * - ``slot4_partition``
+     - flash0_sahb
+     - ``0x580000``
+     - 2 MB
+     - CM55 primary application (active)
+   * - ``slot5_partition``
+     - flash0_sahb
+     - ``0xB00000``
+     - 2 MB
+     - CM55 secondary / update slot
+
+The primary slot partitions share the same DTS node as the XIP code partitions
+(``m33s_xip`` / ``m33_xip`` / ``m55_xip``), so the same ``zephyr,code-partition``
+setting works for both MCUBoot and non-MCUBoot builds. The 0x400-byte image
+header is accounted for by ``CONFIG_ROM_START_OFFSET``.
+
+Building Images Independently (Standalone)
+==========================================
+
+Each image can be built and flashed individually. Application images bind
+``slot0_partition`` through their per-core board devicetree, so no extra DTS
+overlays are needed for application images.
+
+The board directory overlays referenced below are located in
+``boards/infineon/kit_pse84_eval/`` relative to ``$ZEPHYR_BASE``.
+
+Step 1 — MCUBoot bootloader
+----------------------------
+
+The bootloader must be linked at ``boot_partition`` in RRAM. Pass the
+bootloader-specific overlay and the MCUBoot configuration file.
+
+The board-level ``kit_pse84_eval_mcuboot.conf`` defaults to
+``CONFIG_UPDATEABLE_IMAGE_NUMBER=2`` so that MCUBoot validates two
+independent images out of the box (slot0/slot1 for image 0 and
+slot2/slot3 for image 1). This matches the TF-M flow (signed SPE
+at slot0 + signed NSPE at slot2).
+
+For a **two-image** build (TF-M SPE + NSPE):
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m33 \
+       ./../bootloader/mcuboot/boot/zephyr -d build_mcuboot \
+       -- -DEXTRA_DTC_OVERLAY_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot_bl.overlay" \
+          -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot.conf"
+
+For a **single-image** setup (CM33S only), override the image count to 1:
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m33 \
+       bootloader/mcuboot/boot/zephyr -d build_mcuboot \
+       -- -DEXTRA_DTC_OVERLAY_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot_bl.overlay" \
+          -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot.conf" \
+          -DCONFIG_UPDATEABLE_IMAGE_NUMBER=1
+
+Step 2 — CM33S application (slot0)
+-----------------------------------
+
+No extra DTS overlay is needed. The conf file sets
+``CONFIG_BOOTLOADER_MCUBOOT=y``, the matching MCUBoot mode, and unsigned
+image generation:
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m33 \
+       <path/to/cm33s/app> -d build_cm33s \
+       -- -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf"
+
+Step 3 — Flashing
+-----------------
+
+Each image is flashed independently from its build directory.
+``west flash`` automatically selects the correct hex file.
+
+Flash MCUBoot first (required once; re-flash only when updating the
+bootloader):
+
+.. code-block:: shell
+
+   west flash -d build_mcuboot
+
+Flash the CM33S application:
+
+.. code-block:: shell
+
+   west flash -d build_cm33s
+
+Upgrade Mode: Swap-Using-Move
+=============================
+
+The board configuration files use MCUBoot **swap-using-move** as the default
+upgrade mode:
+
+- ``kit_pse84_eval_mcuboot.conf`` sets ``CONFIG_BOOT_SWAP_USING_MOVE=y`` and
+  ``CONFIG_MCUBOOT_BOOT_MAX_ALIGN=16`` on the bootloader.
+- ``kit_pse84_eval_slot.conf`` sets
+  ``CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE=y`` on the application.
+
+Both files must agree on the mode: the application compiles in its own trailer
+geometry (``BOOT_MAX_ALIGN``) and imgtool alignment, and these have to match the
+bootloader or the image-confirm offsets will not line up.
+
+Swap is possible on this board because the external QSPI flash
+(``s25fs128s``) has a **16-byte** ``write-block-size`` — the size of the
+device's Automatic-ECC block — which is within MCUBoot's ``BOOT_MAX_ALIGN``
+limit. Every trailer field and swap-status entry is written once per 16-byte
+ECC block, so ECC is preserved. ``swap-using-move`` needs no scratch partition
+and requires the primary and secondary slots to be equal-sized with uniform
+sectors.
+
+In swap mode imgtool signs each image with ``--align 16`` and writes a trailer,
+as described below.
+
+Signing and staging a secondary (upgrade) image
+-----------------------------------------------
+
+The application build places its signed image (``zephyr.signed.hex``) at the
+**primary** slot (for example ``slot0`` / ``m33s_xip``).
+To exercise an upgrade you must stage a second image in the **secondary** slot
+(continuing the example this would be ``slot1`` / ``m33s_upgrade``)
+with a valid trailer so MCUBoot detects the pending update. ``west flash`` on
+the same build would only re-program the primary slot, so the secondary image
+has to be re-signed with a trailer and relocated to the secondary address.
+
+Relevant addresses (secure SAHB programming view for cm33s, base ``0x70000000``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+
+   * - Slot
+     - Partition
+     - Program address
+     - Purpose
+   * - ``slot0``
+     - ``m33s_xip``
+     - ``0x70100000``
+     - Primary (active) image
+   * - ``slot1``
+     - ``m33s_upgrade``
+     - ``0x70700000``
+     - Secondary (upgrade) image
+
+Sign the upgrade application's raw binary with imgtool, adding a padded trailer
+and placing it at the secondary slot's program address. The ``--slot-size``
+(``0x240000``) and ``--align 16`` values match the slot geometry and
+``write-block-size``; ``--header-size`` matches ``CONFIG_ROM_START_OFFSET``:
+
+.. code-block:: shell
+
+   python bootloader/mcuboot/scripts/imgtool.py sign \
+       --version 0.0.0+0 --header-size 0x400 --slot-size 0x240000 --align 16 \
+       --pad --hex-addr 0x70700000 \
+       build_cm33s_upgrade/zephyr/zephyr.bin \
+       build_cm33s_upgrade/zephyr/upgrade_slot1.hex
+
+Then flash the relocated hex into the secondary slot without rebuilding, so the
+primary slot is left untouched:
+
+.. code-block:: shell
+
+   west flash -d build_cm33s_upgrade --no-rebuild \
+       --hex-file build_cm33s_upgrade/zephyr/upgrade_slot1.hex
+
+On the next reset MCUBoot swaps the secondary image into the primary slot and
+boots it.
+
+.. NOTE::
+   ``--pad`` alone requests a **test** swap: the upgrade runs once, and unless
+   the application confirms it (by calling ``boot_write_img_confirmed()`` or
+   flashing an image signed with ``--pad --confirm``), MCUBoot **reverts** to
+   the previous image on the following reset. Use ``--pad --confirm`` to make
+   the upgrade permanent immediately.
+
+TF-M with MCUBoot (Multi-Image)
+================================
+
+When TF-M is used together with MCUBoot, the TF-M Secure Processing
+Environment (SPE) is placed in ``slot0_partition`` (image 0) and the
+Non-Secure application (NSPE) in ``slot2_partition`` (image 1). MCUBoot
+runs in multi-image mode (``CONFIG_UPDATEABLE_IMAGE_NUMBER=2``, the
+board default) and validates the SPE and NSPE independently. TF-M itself
+still handles the run-time transition from secure to non-secure state.
+
+Signing is done by the helper in
+:file:`soc/infineon/edge/pse84/pse84_tfm_signing.cmake`, a thin wrapper around
+the default ``cmake/mcuboot.cmake`` flow. It:
+
+- Includes the stock ``cmake/mcuboot.cmake`` to sign the NSPE. Because the
+  Non-Secure board devicetree binds ``slot0_partition`` to the NS slot, the
+  stock flow already sizes the image against the correct slot (the NS view of
+  slot2) with ``imgtool sign --overwrite-only --align 1``.
+- Merges the signed SPE (produced by TF-M's own build) with the freshly
+  signed NSPE into ``tfm_merged.hex`` and points ``west flash`` at it.
+
+Boot flow::
+
+    Extended Boot (ROM) → MCUBoot (RRAM, 0x22011000)
+        → validates image 0 (TF-M SPE  @ slot0 / 0x18100000)
+        → validates image 1 (NSPE     @ slot2 / 0x08340000)
+        → jumps to TF-M SPE
+            → TF-M configures TrustZone / MPC / SAU
+            → TF-M launches NSPE (@ 0x08340000)
+
+Step 1 — MCUBoot bootloader
+---------------------------
+
+Same as the standalone two-image case above — the board default already
+validates slot0 and slot2:
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m33 \
+       bootloader/mcuboot/boot/zephyr -d build_mcuboot \
+       -- -DEXTRA_DTC_OVERLAY_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot_bl.overlay" \
+          -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot.conf"
+
+Step 2 — TF-M NS application (SPE + NSPE)
+-----------------------------------------
+
+Building the ``m33/ns`` target with ``CONFIG_BUILD_WITH_TFM=y`` (enabled by
+default for the ``/ns`` variant) automatically builds TF-M as the SPE,
+signs it and the NSPE independently, and produces ``tfm_merged.hex``
+containing both signed images ready to be validated by MCUBoot:
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m33/ns \
+       <path/to/ns/app> -d build_tfm_ns \
+       -- -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf"
+
+Step 3 — Flashing
+------------------
+
+Flash MCUBoot (once):
+
+.. code-block:: shell
+
+   west flash -d build_mcuboot
+
+Flash the TF-M + NS application. ``west flash`` automatically uses
+``tfm_merged.hex`` which contains the signed SPE (slot0) and signed NSPE
+(slot2):
+
+.. code-block:: shell
+
+   west flash -d build_tfm_ns
+
+.. NOTE::
+   Because SPE and NSPE are signed and validated as two independent
+   MCUBoot images, OTA updates can target either one without re-signing
+   the other: a new SPE is staged in slot1 and a new NSPE in slot3.
 
 TF-M Multicore Support
 **********************
@@ -446,6 +774,77 @@ if it cannot find a valid image to jump to.
    west flash -d build_multicore_55
    west flash -d build_multicore_33
 
+Multicore with MCUBoot (Three Images)
+=====================================
+
+The TF-M multicore setup can also run behind MCUBoot. In this configuration
+MCUBoot validates three independent images before hand-off:
+
+- image 0 — TF-M SPE at ``slot0_partition`` (``0x100000``)
+- image 1 — CM33 Non-Secure at ``slot2_partition`` (``0x340000``)
+- image 2 — CM55 application at ``slot4_partition`` (``0x580000``)
+
+Compared to the standalone multicore build above, the only additions are:
+build MCUBoot with ``CONFIG_UPDATEABLE_IMAGE_NUMBER=3`` and pass the
+``kit_pse84_eval_slot.conf`` (which enables ``CONFIG_BOOTLOADER_MCUBOOT``)
+to both application builds. ``CONFIG_PSOC_EDGE_M55_SRF_SUPPORT=y`` still
+enables the CM55 core and must be set on both images.
+
+.. note::
+
+   ``SW6`` (``BOOT SW``) must be in the **OFF** position so the extended
+   boot jumps to MCUBoot in RRAM.
+
+Step 1 — MCUBoot bootloader (three images)
+------------------------------------------
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m33 \
+       bootloader/mcuboot/boot/zephyr -d build_mcuboot3 \
+       -- -DEXTRA_DTC_OVERLAY_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot_bl.overlay" \
+          -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot.conf" \
+          -DCONFIG_UPDATEABLE_IMAGE_NUMBER=3
+
+Step 2 — CM33-NS image (SPE + NSPE)
+-----------------------------------
+
+Build the CM33-NS image first; the CM55 build consumes its generated PSA
+manifest headers.
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m33/ns \
+       -d build_multicore_33 samples/hello_world \
+       -- -DCONFIG_PSOC_EDGE_M55_SRF_SUPPORT=y \
+          -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf"
+
+Step 3 — CM55 image
+-------------------
+
+Point the CM55 build at the CM33-NS build directory via
+``PSE84_CM33_BUILD_DIR``.
+
+.. code-block:: shell
+
+   west build -b kit_pse84_eval/pse846gps2dbzc4a/m55 \
+       -d build_multicore_55 samples/basic/blinky \
+       -- -DCONFIG_PSOC_EDGE_M55_SRF_SUPPORT=y \
+          -DPSE84_CM33_BUILD_DIR=build_multicore_33 \
+          -DEXTRA_CONF_FILE="$ZEPHYR_BASE/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf"
+
+Step 4 — Flashing
+-----------------
+
+Flash MCUBoot once, then the CM55 image before the CM33-NS image (the
+CM33-NS image boots the CM55 on reset):
+
+.. code-block:: shell
+
+   west flash -d build_mcuboot3
+   west flash -d build_multicore_55
+   west flash -d build_multicore_33
+
 References
 **********
 
@@ -469,3 +868,6 @@ References
 
 .. _KitProg3:
     https://github.com/Infineon/KitProg3
+
+.. _MCUBoot:
+    https://docs.mcuboot.com/

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_console_scb1.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_console_scb1.dtsi
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Route console/log to SCB1 (MiniProg4 VCOM, P9.2 TX / P9.3 RX).
+ *
+ * Included only by the DFU overlays that need SCB2 (KitProg3 VCOM) free for
+ * the mcumgr transport / serial recovery. Normal builds keep console on the
+ * board-default SCB2, leaving SCB1 available for other uses (e.g. I2C tests).
+ *
+ * Include-guarded so it stays safe even if two overlays that both pull it in
+ * are combined in a single build (belt-and-suspenders; the current DFU
+ * overlays each include it at most once per build).
+ */
+#ifndef KIT_PSE84_EVAL_CONSOLE_SCB1_DTSI
+#define KIT_PSE84_EVAL_CONSOLE_SCB1_DTSI
+
+uart1: &scb1 {
+	compatible = "infineon,uart";
+	status = "okay";
+	current-speed = <115200>;
+
+	clocks = <&peri0_group8_16bit_0>;
+
+	pinctrl-0 = <&p9_2_scb1_uart_tx &p9_3_scb1_uart_rx>;
+	pinctrl-names = "default";
+};
+
+&peri0_group8_16bit_0 {
+	status = "okay";
+	clock-div = <1>;
+};
+
+&p9_2_scb1_uart_tx {
+	drive-push-pull;
+};
+
+&p9_3_scb1_uart_rx {
+	input-enable;
+};
+
+/ {
+	chosen {
+		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
+	};
+};
+
+#endif /* KIT_PSE84_EVAL_CONSOLE_SCB1_DTSI */

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_dfu_multi.conf
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_dfu_multi.conf
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Multi-image in-app DFU Kconfig companion to kit_pse84_eval_dfu_multi.overlay.
+# Pairs with kit_pse84_eval_smp_app.conf (mcumgr transport buffers) and
+# kit_pse84_eval_slot.conf (MCUboot chain-load). Use together, e.g.:
+#   -DEXTRA_CONF_FILE="...slot.conf;...smp_app.conf;...dfu_multi.conf"
+#   -DEXTRA_DTC_OVERLAY_FILE="...smp_app.overlay;...dfu_multi.overlay"
+
+# Two updateable images: image 0 = CM33-NS (flash0), image 1 = CM55
+# (flash0_sahb). Either core running smp_svr can update either image.
+CONFIG_UPDATEABLE_IMAGE_NUMBER=2
+
+# img_mgmt must advertise/accept both images over SMP.
+CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER=2
+
+# Trim the img_mgmt state list so large multi-image responses fit the buffers.
+CONFIG_MCUMGR_GRP_IMG_FRUGAL_LIST=y

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_dfu_multi.overlay
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_dfu_multi.overlay
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Unified 2-image in-app DFU slot layout, shared by the CM33-NS and CM55
+ * smp_svr builds. Fixed image identity: image 0 (-n 0) = CM33-NS, image 1
+ * (-n 1) = CM55, so either core can update either image.
+ *
+ * Each image lives on its owner core's flash view (flash0 for CM33-NS,
+ * flash0_sahb for CM55) so that core still XIP-runs its own image; these are
+ * views of the same QSPI device and the driver programs by raw offset, so a
+ * core writes the other image through the shared controller.
+ *
+ * Rebinds slot0/1 -> flash0 and slot2/3 -> flash0_sahb, dropping the canonical
+ * labels from flash0_s to avoid duplicates. Build with
+ * UPDATEABLE_IMAGE_NUMBER=2 (+ MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER=2,
+ * MCUMGR_GRP_IMG_FRUGAL_LIST=y).
+ */
+
+&flash0_s {
+	partitions {
+		/delete-node/ partition@100000;
+		/delete-node/ partition@700000;
+		/delete-node/ partition@340000;
+		/delete-node/ partition@940000;
+
+		/* Secure slots without the canonical slot0/1 labels (rebound
+		 * below); keep m33s_xip for TF-M/SoC signing.
+		 */
+		slot0_s_partition: m33s_xip: partition@100000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x100000 0x240000>;
+		};
+
+		slot1_s_partition: partition@700000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x700000 0x240000>;
+		};
+	};
+};
+
+&flash0 {
+	partitions {
+		/delete-node/ partition@340000;
+		/delete-node/ partition@940000;
+
+		/* image 0 primary: CM33-NS (slot0, NS code XIP). */
+		slot0_partition: slot0_ns_partition: m33_xip: partition@340000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-2";
+			reg = <0x340000 0x1c0000>;
+		};
+
+		/* image 0 secondary: CM33-NS (slot1). */
+		slot1_partition: slot1_ns_partition: partition@940000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-3";
+			reg = <0x940000 0x1c0000>;
+		};
+	};
+};
+
+&flash0_sahb {
+	partitions {
+		/delete-node/ partition@580000;
+		/delete-node/ partition@b00000;
+
+		/* image 1 primary: CM55 (slot2, CM55 code XIP). */
+		slot2_partition: m55_xip: slot4_partition: partition@580000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-4";
+			reg = <0x580000 0x180000>;
+		};
+
+		/* image 1 secondary: CM55 (slot3). */
+		slot3_partition: slot5_partition: partition@b00000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-5";
+			reg = <0xb00000 0x180000>;
+		};
+	};
+};

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
@@ -28,9 +28,28 @@
 		zephyr,sram = &m33s_data;
 		zephyr,code-partition = &m33s_xip;
 		zephyr,console = &uart2;
+		zephyr,flash-controller = &flash_controller;
 		zephyr,shell-uart = &uart2;
 		zephyr,bt-hci = &bt_hci_uart;
 		zephyr,entropy = &mxcrypto_trng;
+	};
+};
+
+/*
+ * Attach the relative MCUboot slot0_partition/slot1_partition labels
+ * (image 0 primary/secondary) to the Secure image slots. These are kept
+ * out of kit_pse84_eval_memory_map.dtsi so the Non-Secure build
+ * (kit_pse84_eval_m33_ns.dts) can bind them to the Non-Secure slots
+ * instead - see "Partition label schemes" in the memory map. The MCUboot
+ * bootloader image, which also builds from this file, inherits the
+ * Secure slot0/slot1 (image 0) plus the absolute slot2..slot5 from the
+ * mcuboot_bl overlay file.
+ */
+&flash0_s {
+	partitions {
+		slot0_partition: partition@100000 {};
+
+		slot1_partition: partition@700000 {};
 	};
 };
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.dts
@@ -35,6 +35,26 @@
 	};
 };
 
+/*
+ * Bind the relative MCUboot slot0_partition/slot1_partition labels to
+ * the Non-Secure image slots so the stock cmake/mcuboot.cmake signing
+ * script sizes the Non-Secure image against its own slot (0x1c0000)
+ * rather than the Secure slot.
+ *
+ * The slot0_ns_partition/slot1_ns_partition labels are attached here too
+ * (rather than in the shared memory map) because only the Non-Secure
+ * build consumes them: Zephyr's TF-M integration looks them up by name
+ * (dt_nodelabel ... REQUIRED) to size the Non-Secure image, and the DFU /
+ * mcumgr image-management subsystems reference them at run time.
+ */
+&flash0 {
+	partitions {
+		slot0_ns_partition: slot0_partition: partition@340000 {};
+
+		slot1_ns_partition: slot1_partition: partition@940000 {};
+	};
+};
+
 &clk_iho {
 	status = "disabled";
 };

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
@@ -24,9 +24,10 @@
 	};
 
 	chosen {
-		/* m55_xip + flash0_sahb is used in the pse84_boot.c file for m55 core startup
+		/* m55_xip + flash0_sahb is used by cm33 or cm33/ns for m55 core startup
 		 * If a different region is assigned here, it also needs to be updated at:
-		 * soc/infineon/edge/pse84/security_config/pse84_boot.c
+		 * soc/infineon/edge/pse84/security_config/pse84_boot.c or
+		 * soc/infineon/edge/pse84/soc_pse84_m33_ns.c
 		 */
 		zephyr,flash = &flash0_sahb;
 		zephyr,code-partition = &m55_xip;
@@ -164,4 +165,17 @@ uart4: &scb4 {
 
 &mxcrypto_crypto {
 	status = "okay";
+};
+
+/*
+ * Bind the relative MCUboot slot0_partition/slot1_partition labels to
+ * the CM55 image slots (image 2) so the stock cmake/mcuboot.cmake signing
+ * script sizes the CM55 image against its own slot.
+ */
+&flash0_sahb {
+	partitions {
+		slot0_partition: partition@580000 {};
+
+		slot1_partition: partition@b00000 {};
+	};
 };

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
@@ -160,11 +160,11 @@ uart4: &scb4 {
 };
 
 &mxcrypto_trng {
-	status = "okay";
+	status = "disabled";
 };
 
 &mxcrypto_crypto {
-	status = "okay";
+	status = "disabled";
 };
 
 /*

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot.conf
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot.conf
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Set VTOR to app vector table before jumping (required for chain-load)
+CONFIG_BOOT_INTR_VEC_RELOC=y
+
+# SWAP upgrade mode.
+CONFIG_BOOT_SWAP_USING_MOVE=y
+
+# BOOT_MAX_ALIGN must match the slot write-block-size (16). It otherwise
+# defaults from the chosen zephyr,flash node (RRAM, also 16), but pin it
+# explicitly so the trailer geometry stays consistent with the slots.
+CONFIG_MCUBOOT_BOOT_MAX_ALIGN=16
+
+# No image signature verification by default.
+CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
+
+# Must be large enough to cover the slot size divided by the flash
+# erase-block size. 256 covers the default slots with 64 KB erase blocks.
+CONFIG_BOOT_MAX_IMG_SECTORS_AUTO=n
+CONFIG_BOOT_MAX_IMG_SECTORS=256
+
+# MCUBoot must configure and initialize SMIF HW for subsequent slots
+# in external flash to operate correctly.
+CONFIG_FLASH_INFINEON_SMIF_HW_INIT=y
+
+# Multi-image: validate SPE (image 0, slot0/slot1) and NSPE
+# (image 1, slot2/slot3) independently. Allows OTA of either
+# half without re-signing the other.
+CONFIG_UPDATEABLE_IMAGE_NUMBER=2

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot_bl.overlay
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot_bl.overlay
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * DTS overlay applied to the MCUBoot bootloader image only.
+ *
+ * Overrides the chosen code-partition to boot_partition so that MCUBoot is
+ * linked at the RRAM address where the extended boot expects it
+ * (0x22011000).
+ *
+ * The absolute, shared MCUboot image-numbering slotN labels are attached
+ * here (rather than in kit_pse84_eval_memory_map.dtsi) because only the
+ * bootloader consumes them. They are layered onto the role-labelled flash
+ * regions from the memory map:
+ *   image 0 (CM33 Secure)     : slot0/slot1 (from kit_pse84_eval_m33.dts)
+ *   image 1 (CM33 Non-Secure) : slot2/slot3 (m33_xip/m33_upgrade)
+ *   image 2 (CM55)            : slot4/slot5 (m55_xip/m55_upgrade)
+ */
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+		zephyr,flash = &rram0;
+	};
+};
+
+slot2_partition: &m33_xip {};
+
+slot3_partition: &m33_upgrade {};
+
+slot4_partition: &m55_xip {};
+
+slot5_partition: &m55_upgrade {};

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
@@ -5,16 +5,72 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/*
+ * kit_pse84_eval memory map.
+ *
+ * =========================================================================
+ * SRAM (1 MB)
+ *   0x34000000  ext-boot reserved            4 kB
+ *   0x34001000  CM33-S <-> secure enclave    4 kB
+ *   0x34002000  CM33-S code                212 kB   M33SCODE
+ *   0x34037000  CM33-S data                132 kB
+ *   0x24058000  CM33-NS code               404 kB   M33CODE
+ *   0x240bd000  CM33-NS data               256 kB
+ *   0x340fd000  CM33-S alloc shared          4 kB   SHARED_MEMORY_SEC
+ *   0x240fe000  CM33-NS alloc shared         4 kB   SHARED_MEMORY_M33
+ *   0x240ff000  CM55 alloc shared            4 kB   SHARED_MEMORY_M55
+ *
+ * SoCMEM (5 MB)
+ *   0x26100000  CM55 data                  256 kB
+ *
+ * RRAM (512 kB)
+ *   0x220000000  ext-boot reserved   68 kB
+ *   0x220011000  MCUboot bootloader 256 kB  boot_partition
+ *   0x220051000  storage             72 kB
+ *   0x220063000  security reserved  116 kB
+ *
+ * External QSPI flash (16 MB) - ONE physical device, four bus windows onto
+ * the SAME bytes at the SAME offsets. Only the window base differs, so the
+ * same partition offset appears once per view it is exposed in:
+ *
+ *   CBUS-NS  0x08000000  flash0        NSPE run-time  (zephyr,flash for NS)
+ *   CBUS-S   0x18000000  flash0_s      SPE + MCUboot  (zephyr,flash for S)
+ *   SAHB-NS  0x60000000  flash0_sahb   CM55 run-time  (zephyr,flash for M55)
+ *   SAHB-S   0x70000000  (not in DTS)  secure programming alias
+ *
+ *   offset    size     CBUS-NS(flash0)   CBUS-S(flash0_s)   SAHB(flash0_sahb)
+ *   0x000000  1.00 MB  storage_partition -                  -
+ *   0x100000  2.25 MB  -                 m33s_xip           -
+ *   0x340000  1.75 MB  m33_xip           -                  -
+ *   0x580000  1.50 MB  -                 -                  m55_xip
+ *   0x700000  2.25 MB  -                 m33s_upgrade       -
+ *   0x940000  1.75 MB  m33_upgrade       -                  -
+ *   0xb00000  1.50 MB  -                 -                  m55_upgrade
+ *
+ * CM33 images link for CBUS and are programmed at SAHB; the constant
+ * 0x58000000 CBUS -> SAHB delta is applied at flash time by
+ * CONFIG_BUILD_OUTPUT_ADJUST_LMA. CONFIG_ROM_START_OFFSET reserves the
+ * 0x400 image header (extended-boot or MCUboot) in every case.
+ *
+ * MCUboot image-numbering labels. MCUboot maps image 0 -> slot0/slot1,
+ * image 1 -> slot2/slot3, image 2 -> slot4/slot5:
+ *   - slot0/slot1 are relative (the image being signed now), so they are
+ *     bound per-build in kit_pse84_eval_m33.dts (Secure) /
+ *     kit_pse84_eval_m33_ns.dts (NS) / kit_pse84_eval_m55.dts.
+ *   - slot2..slot5 are absolute and shared and only the MCUboot bootloader
+ *     consumes them, so they are attached to the role-labelled nodes
+ *     (m33_xip/upgrade, m55_xip/upgrade) in the bootloader overlay
+ *     kit_pse84_eval_mcuboot_bl.overlay rather than here.
+ *   - slot0_ns_partition / slot1_ns_partition are consumed only by the
+ *     Non-Secure build (Zephyr's TF-M integration looks them up by name,
+ *     dt_nodelabel ... REQUIRED, to size the Non-Secure image), so they are
+ *     attached to the m33_xip/m33_upgrade nodes in kit_pse84_eval_m33_ns.dts
+ *     rather than here. Their Secure counterpart slot0_partition is likewise
+ *     supplied per-build by the board files.
+ * =========================================================================
+ */
+
 / {
-	/* Default SRAM(1MB) assignment
-	 * - Lowest 4kb reserved for the Extended boot
-	 * - 4kb shared between CM33 secure project and secure enclave
-	 * - 212 kB allocated to CM33 Secure code
-	 * - 132 kB allocated to CM33 Secure data
-	 * - 404 kB allocated to CM33 Non-Secure code
-	 * - 256 kB allocated to the CM33 Non-Secure data
-	 * - 4 kB allocated to shared memory for each core (cm33_s, cm33 and cm55)
-	 */
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -71,16 +127,6 @@
 		};
 	};
 
-	/* Default Flash memory(16MB) assignment
-	 * - 1 MB  reserved for Storage
-	 * - 1 KB  header for CM33 Secure
-	 * - 2304 KB allocated to CM33 Secure XIP
-	 * - 1791 KB allocated to CM33 Non-Secure XIP
-	 * - 2 MB  allocated to CM55 XIP
-	 *
-	 * Each code-partition uses zephyr,mapped-partition under the flash
-	 * alias whose base address matches the executing core's view.
-	 */
 	flash_controller: flash_controller@44460000 {
 		compatible = "infineon,qspi-flash";
 		reg = <0x44460000 0x20000>;
@@ -115,13 +161,19 @@
 				storage_partition: storage@0 {
 					compatible = "zephyr,mapped-partition";
 					label = "storage";
-					reg = <0 DT_SIZE_M(1)>;
+					reg = <0x0 DT_SIZE_M(1)>;
 				};
 
-				m33_xip: m33_xip@340400 {
+				m33_xip: partition@340000 {
 					compatible = "zephyr,mapped-partition";
-					label = "m33-xip";
-					reg = <0x340400 0x1bfc00>;
+					label = "image-2";
+					reg = <0x340000 0x1c0000>;
+				};
+
+				m33_upgrade: partition@940000 {
+					compatible = "zephyr,mapped-partition";
+					label = "image-3";
+					reg = <0x940000 0x1c0000>;
 				};
 			};
 		};
@@ -147,16 +199,16 @@
 				#size-cells = <1>;
 				ranges;
 
-				m33s_header: m33s_header@100000 {
+				m33s_xip: partition@100000 {
 					compatible = "zephyr,mapped-partition";
-					label = "m33s-header";
-					reg = <0x100000 0x400>;
+					label = "image-0";
+					reg = <0x100000 0x240000>;
 				};
 
-				m33s_xip: m33s_xip@100400 {
+				m33s_upgrade: partition@700000 {
 					compatible = "zephyr,mapped-partition";
-					label = "m33s-xip";
-					reg = <0x100400 DT_SIZE_K(2304)>;
+					label = "image-1";
+					reg = <0x700000 0x240000>;
 				};
 			};
 		};
@@ -182,21 +234,21 @@
 				#size-cells = <1>;
 				ranges;
 
-				m55_xip: m55_xip@580000 {
+				m55_xip: partition@580000 {
 					compatible = "zephyr,mapped-partition";
-					label = "m55-xip";
-					reg = <0x580000 DT_SIZE_M(2)>;
+					label = "image-4";
+					reg = <0x580000 0x180000>;
+				};
+
+				m55_upgrade: partition@b00000 {
+					compatible = "zephyr,mapped-partition";
+					label = "image-5";
+					reg = <0xb00000 0x180000>;
 				};
 			};
 		};
 	};
 
-	/* RRAM memory (512 KB) assignment
-	 *   0x00000 - 0x10FFF : reserved-extended-boot (68 KB)
-	 *   0x11000 - 0x50FFF : boot_partition (256 KB) - MCUBoot bootloader
-	 *   0x51000 - 0x62FFF : storage_rram (72 KB)
-	 *   0x63000 - 0x7FFFF : reserved-security (116 KB)
-	 */
 	rram_controller: rram_controller@42200000 {
 		compatible = "infineon,rram-controller";
 		reg = <0x42200000 0x10000>;

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_scb2_disable.overlay
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_scb2_disable.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Disable SCB2 (KitProg3 VCOM) on the peer core. This prevents the peer
+ * from resetting the UART hardware and breaking the console output of the
+ * host core, since the board default console is SCB2. Console/log for this
+ * peer core is moved to SCB1 (MiniProg4 VCOM) via the shared console overlay.
+ */
+#include "kit_pse84_eval_console_scb1.dtsi"
+
+&scb2 {
+	status = "disabled";
+};

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_scb4_disable.overlay
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_scb4_disable.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Disable SCB4 (Bluetooth HCI UART).
+ * Include this overlay when a non-Bluetooth core (e.g. CM55 running Blinky)
+ * is built in a dual-core setup. This prevents the core from resetting the
+ * UART hardware and breaking the Bluetooth connection on the host core.
+ */
+&scb4 {
+	status = "disabled";
+};

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable MCUBoot chain-loading; reserves the 0x400-byte image header
+# (ROM_START_OFFSET) and triggers imgtool to produce zephyr.signed.hex.
+CONFIG_BOOTLOADER_MCUBOOT=y
+
+# Must match the MCUBoot bootloader mode (kit_pse84_eval_mcuboot.conf
+# sets BOOT_SWAP_USING_MOVE). This drives imgtool to write a trailer with
+# --align 16 (the slot write-block-size) instead of --overwrite-only, and
+# fixes the application's compiled-in trailer geometry (BOOT_MAX_ALIGN) to
+# match the bootloader so image-confirm offsets agree.
+CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE=y
+
+# Board default is BOOT_SIGNATURE_TYPE_NONE — generate an unsigned image
+# (header only, no cryptographic signature). Override in prj.conf to match
+# if you enable signature verification in MCUBoot.
+CONFIG_MCUBOOT_GENERATE_UNSIGNED_IMAGE=y

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -616,22 +616,23 @@ if(CONFIG_BUILD_WITH_TFM)
     # Default: use unsigned TF-M secure image for merging
     set(TFM_S_MERGE_HEX_FILE $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>)
 
-    if(CONFIG_SOC_SERIES_PSE84)
-      pse84_add_metadata_secure_hex(${TFM_S_HEX_FILE} ${S_SIGNED_HEX_FILE})
-      set(TFM_S_MERGE_HEX_FILE ${S_SIGNED_HEX_FILE})
+    # A platform (SoC/board) may need to post-process the secure and
+    # non-secure images (for example, extra signing) and produce the
+    # merged image itself. When it opts in by selecting the Kconfig option
+    # CONFIG_TFM_PLATFORM_HANDLES_MERGE, skip the default merge below.
+    if(NOT CONFIG_TFM_PLATFORM_HANDLES_MERGE)
+      # Merge tfm_s and zephyr (NS) image to a single binary.
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
+          -o ${MERGED_HEX_FILE}
+          ${TFM_S_MERGE_HEX_FILE}
+          ${NS_HEX_APP_FILE}
+      )
+
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+        ${MERGED_HEX_FILE}
+      )
     endif()
-
-    # Merge tfm_s and zephyr (NS) image to a single binary.
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
-        -o ${MERGED_HEX_FILE}
-        ${TFM_S_MERGE_HEX_FILE}
-        ${NS_HEX_APP_FILE}
-    )
-
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
-      ${MERGED_HEX_FILE}
-    )
 
   elseif(CONFIG_TFM_MCUBOOT_IMAGE_NUMBER STREQUAL "1")
     tfm_sign(sign_cmd_s_ns_confirm_hex SUFFIX "S_NS"

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -73,6 +73,16 @@ menuconfig BUILD_WITH_TFM
 
 if BUILD_WITH_TFM
 
+config TFM_PLATFORM_HANDLES_MERGE
+	bool
+	help
+	  Selected by a platform (SoC/board) that post-processes the TF-M
+	  secure and non-secure images itself (for example, extra signing)
+	  and produces the merged image on its own, instead of relying on the
+	  default secure/non-secure merge performed by the TF-M module. This
+	  is an internal symbol with no prompt and is not meant to be set by
+	  users.
+
 config TFM_PROFILE
 	string
 	default "profile_small" if TFM_PROFILE_TYPE_SMALL

--- a/soc/infineon/edge/pse84/CMakeLists.txt
+++ b/soc/infineon/edge/pse84/CMakeLists.txt
@@ -39,6 +39,11 @@ if(CONFIG_BUILD_WITH_TFM)
 
 endif()
 
+# All image signing and merging logic lives in one place. Keep this after
+# the TF-M cmake-args block above so the TF-M options are set before the
+# signing flow runs.
+include(${CMAKE_CURRENT_LIST_DIR}/pse84_signing.cmake)
+
 if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   zephyr_sources(soc_pse84_m33_s.c)
 
@@ -46,11 +51,6 @@ if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   zephyr_sources(security_config/pse84_s_protection.c)
   zephyr_sources(security_config/pse84_s_system.c)
   zephyr_sources(security_config/pse84_s_sau.c)
-
-  set(unsigned_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.hex)
-  set(signed_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.hex)
-
-  pse84_add_metadata_secure_hex(${unsigned_hex} ${signed_hex})
 elseif(CONFIG_CPU_CORTEX_M33)
   zephyr_sources(soc_pse84_m33_ns.c)
 elseif(CONFIG_CPU_CORTEX_M55)

--- a/soc/infineon/edge/pse84/Kconfig.defconfig
+++ b/soc/infineon/edge/pse84/Kconfig.defconfig
@@ -46,10 +46,13 @@ config SYS_CLOCK_TICKS_PER_SEC
 # For cm33 all code executes from CBUS aliases (0x08.../0x18...)
 # for performance improvements but must be flashed at SAHB
 # alias (0x60.../0x70...). Adjust LMA by +0x58000000 (constant
-# difference between 0x08 -> 0x60)
+# difference between 0x08 -> 0x60).
+# Not applied to MCUBoot itself, which runs from RRAM and needs
+# no address translation.
 config BUILD_OUTPUT_ADJUST_LMA
 	depends on XIP
 	depends on CPU_CORTEX_M33
+	depends on !MCUBOOT
 	default "0x58000000"
 
 # BL2 implementation not available yet

--- a/soc/infineon/edge/pse84/Kconfig.defconfig
+++ b/soc/infineon/edge/pse84/Kconfig.defconfig
@@ -59,4 +59,8 @@ config BUILD_OUTPUT_ADJUST_LMA
 config TFM_BL2_NOT_SUPPORTED
 	default y
 
+# PSE84 handles its own signing/merging for TF-M
+config TFM_PLATFORM_HANDLES_MERGE
+	default y
+
 endif # SOC_SERIES_PSE84

--- a/soc/infineon/edge/pse84/pse84_metadata.cmake
+++ b/soc/infineon/edge/pse84/pse84_metadata.cmake
@@ -3,42 +3,145 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Adds mcuboot metadata to the PSE84 CM33 secure image using imgtool
-# with parameters derived from the DT memory map (header address,
-# header size, and slot size). Uses default version 0.0.0+0 as imgtool
-# requires a version parameter.
-# Registers the add metadata command and output file via
-# extra_post_build properties.
+# Adds ext-boot metadata header to a PSE84 CM33 secure hex image using imgtool.
+# Derives partition addresses and sizes from the devicetree.
 #
-# Usage: pse84_add_metadata_secure_hex(<input_hex> <output_hex>)
-function(pse84_add_metadata_secure_hex INPUT_FILE OUTPUT_FILE)
-  # flash0_s and flash0_sahb are two DT views (CBUS / SAHB) of the same
-  # physical external flash. Partitions are declared under flash0_s, so
-  # dt_reg_addr returns the CBUS-translated partition address. Translate
-  # from CBUS view to SAHB view by rebasing against the two flash node
-  # base addresses.
-  dt_nodelabel(flash_sahb NODELABEL "flash0_sahb")
-  dt_nodelabel(flash_s    NODELABEL "flash0_s")
-  dt_reg_addr(flash_sahb_addr PATH ${flash_sahb})
-  dt_reg_addr(flash_s_addr    PATH ${flash_s})
+# When CONFIG_MCUBOOT is set (building MCUBoot itself), uses boot_partition
+# for address/size and ROM_START_OFFSET for header size. The header space is
+# pre-reserved in the ELF so --pad-header is not used.
+#
+# Apps chain-loaded by MCUBoot (slot0/slot2) do NOT use this function —
+# their signing is handled by cmake/mcuboot.cmake.
+#
+# Otherwise (standalone secure image or TF-M SPE), uses m33s_xip with a
+# fixed header size of 0x400. The header is separate from the code
+# partition so --pad-header is used to prepend it.
+#
+# Usage: pse84_add_extboot_metadata(<input_hex> <output_hex> [PAD_HEADER])
+#
+# PAD_HEADER — pass --pad-header to imgtool. Use this when the input image
+#   does not pre-reserve the header area with zeros (e.g. TF-M SPE binary
+#   built by TF-M's own build system). Zephyr images that use
+#   ROM_START_OFFSET already have the space reserved and do NOT need this.
+function(pse84_add_extboot_metadata INPUT_FILE OUTPUT_FILE)
+  cmake_parse_arguments(ARG "PAD_HEADER" "" "" ${ARGN})
 
-  dt_nodelabel(m33s_header_node NODELABEL "m33s_header")
-  dt_nodelabel(m33s_xip_node    NODELABEL "m33s_xip")
-  dt_reg_addr(part_addr   PATH ${m33s_header_node})
-  dt_reg_size(header_size PATH ${m33s_header_node})
-  dt_reg_size(m33s_xip_size PATH ${m33s_xip_node})
+  if(CONFIG_MCUBOOT)
+    # MCUBoot bootloader image: use boot_partition, header from ROM_START_OFFSET.
+    dt_nodelabel(part_node NODELABEL "boot_partition")
+    dt_reg_addr(part_addr PATH ${part_node})
+    dt_reg_size(slot_size PATH ${part_node})
+    set(header_size ${CONFIG_ROM_START_OFFSET})
+  else()
+    # Standalone secure image or TF-M SPE: use m33s_xip partition.
+    #
+    # The header size is fixed at 0x400.
+    # CONFIG_ROM_START_OFFSET cannot be used here because in NS-side
+    # TF-M builds this function runs from the NS application context
+    # where ROM_START_OFFSET reflects the NS image, not the SPE.
+    dt_nodelabel(part_node NODELABEL "m33s_xip")
+    dt_reg_addr(part_addr PATH ${part_node})
+    dt_reg_size(slot_size PATH ${part_node})
+    set(header_size 0x400)
+  endif()
 
-  math(EXPR slot_size "${m33s_xip_size} + ${header_size}" OUTPUT_FORMAT HEXADECIMAL)
+  if(ARG_PAD_HEADER)
+    set(pad_header_arg "--pad-header")
+  else()
+    set(pad_header_arg "")
+  endif()
 
-  # Rebase partition address from flash0_s space to flash0_sahb space.
-  math(EXPR header_sahb_addr
-       "${part_addr} - ${flash_s_addr} + ${flash_sahb_addr}"
-       OUTPUT_FORMAT HEXADECIMAL)
+  # With zephyr,mapped-partition, dt_reg_addr already returns the absolute
+  # address (translated through the parent's `ranges`), so no flash base
+  # needs to be added. Partitions in the CBUS-S address space still need
+  # BUILD_OUTPUT_ADJUST_LMA on top to rebase to the SAHB-S programming
+  # alias used by the flasher; RRAM partitions do not need this.
+  if(CONFIG_BUILD_OUTPUT_ADJUST_LMA)
+    math(EXPR hex_addr "${part_addr} + ${CONFIG_BUILD_OUTPUT_ADJUST_LMA}" OUTPUT_FORMAT HEXADECIMAL)
+  else()
+    set(hex_addr ${part_addr})
+  endif()
 
   set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${IMGTOOL} sign --version "0.0.0+0"
-      --header-size ${header_size} --erased-val 0xff --pad-header
-      --slot-size ${slot_size} --hex-addr ${header_sahb_addr}
+      --header-size ${header_size} --erased-val 0xff ${pad_header_arg}
+      --slot-size ${slot_size} --hex-addr ${hex_addr}
+      ${INPUT_FILE} ${OUTPUT_FILE}
+  )
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${OUTPUT_FILE})
+endfunction()
+
+# Signs a PSE84 TF-M SPE image (MCUboot image 0) so the MCUboot bootloader
+# validates it with the same key and parameters it uses for the chain-loaded
+# Non-Secure image.
+#
+# cmake/mcuboot.cmake only signs the Zephyr-built artifact, which in a
+# Non-Secure TF-M build is the NS app (image 1). The SPE is a TF-M-built
+# artifact that cmake/mcuboot.cmake never sees, so it must be signed here to
+# receive a valid MCUboot image-0 header. The SPE is signed against the
+# Secure slot label (SLOT_LABEL, e.g. m33s_xip) directly, because this runs
+# from the Non-Secure build context where slot0_partition is rebound to the
+# Non-Secure slots.
+#
+# Signing parameters mirror cmake/mcuboot.cmake: version, header size
+# (ROM_START_OFFSET), slot size, overwrite-only alignment and the optional
+# signature key. The TF-M SPE binary does not reserve header space, so
+# --pad-header is always passed.
+#
+# Usage: pse84_sign_tfm(<input_hex> <output_hex> <slot_nodelabel>)
+function(pse84_sign_tfm INPUT_FILE OUTPUT_FILE SLOT_LABEL)
+  dt_nodelabel(part_node NODELABEL "${SLOT_LABEL}" REQUIRED)
+  dt_reg_addr(part_addr PATH ${part_node})
+  dt_reg_size(slot_size PATH ${part_node})
+
+  # Mirror cmake/mcuboot.cmake alignment handling. PSE84 uses overwrite-only
+  # upgrades, so imgtool takes --overwrite-only --align 1.
+  if(CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY)
+    set(align_args --overwrite-only --align 1)
+  else()
+    dt_chosen(flash_node PROPERTY "zephyr,flash")
+    dt_prop(write_block_size PATH "${flash_node}" PROPERTY "write-block-size")
+    if(NOT write_block_size)
+      set(write_block_size 4)
+    endif()
+    set(align_args --align ${write_block_size})
+  endif()
+
+  # Resolve the MCUboot signature key the same way cmake/mcuboot.cmake does.
+  # An unset key or CONFIG_MCUBOOT_GENERATE_UNSIGNED_IMAGE yields a hash-only
+  # (unsigned) image, matching the Non-Secure image's signing.
+  set(key_args)
+  if(NOT CONFIG_MCUBOOT_GENERATE_UNSIGNED_IMAGE)
+    set(keyfile "${CONFIG_MCUBOOT_SIGNATURE_KEY_FILE}")
+    string(CONFIGURE "${keyfile}" keyfile)
+    if(NOT "${keyfile}" STREQUAL "")
+      if(NOT IS_ABSOLUTE "${keyfile}")
+        if(EXISTS "${APPLICATION_CONFIG_DIR}/${keyfile}")
+          set(keyfile "${APPLICATION_CONFIG_DIR}/${keyfile}")
+        elseif(WEST_TOPDIR)
+          set(keyfile "${WEST_TOPDIR}/${keyfile}")
+        endif()
+      endif()
+      set(key_args --key "${keyfile}")
+    endif()
+  endif()
+
+  # With zephyr,mapped-partition, dt_reg_addr already returns the absolute
+  # address. Partitions in the CBUS-S address space still need
+  # BUILD_OUTPUT_ADJUST_LMA on top to rebase to the SAHB-S programming alias
+  # used by the flasher (see pse84_add_extboot_metadata).
+  if(CONFIG_BUILD_OUTPUT_ADJUST_LMA)
+    math(EXPR hex_addr "${part_addr} + ${CONFIG_BUILD_OUTPUT_ADJUST_LMA}" OUTPUT_FORMAT HEXADECIMAL)
+  else()
+    set(hex_addr ${part_addr})
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND ${PYTHON_EXECUTABLE} ${IMGTOOL} sign
+      --version ${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}
+      --header-size ${CONFIG_ROM_START_OFFSET} --pad-header
+      --slot-size ${slot_size} ${align_args} ${key_args}
+      --hex-addr ${hex_addr}
       ${INPUT_FILE} ${OUTPUT_FILE}
   )
   set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${OUTPUT_FILE})

--- a/soc/infineon/edge/pse84/pse84_signing.cmake
+++ b/soc/infineon/edge/pse84/pse84_signing.cmake
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# PSE84 image signing and merging.
+# The reusable imgtool helpers live in pse84_metadata.cmake
+# (pse84_add_extboot_metadata for the boot ROM ext-boot header,
+# pse84_sign_tfm for an MCUboot image-0 header); the MCUboot + TF-M
+# SIGNING_SCRIPT wrapper lives in pse84_tfm_signing.cmake (it must be a
+# separate file because Zephyr invokes it via the SIGNING_SCRIPT property).
+# Which of the hexes below `west flash` programs is selected at the end of
+# this file (see "Runner hex selection").
+#
+# Platform invariant
+# ------------------
+# The boot ROM's extended boot always verifies an MCUboot-format header
+# (0x400, CONFIG_ROM_START_OFFSET) on the FIRST image it runs, regardless
+# of whether a further bootloader follows. So exactly one image per boot
+# chain carries the ext-boot header:
+#   - no MCUboot in the chain -> the secure app / TF-M SPE carries it;
+#   - MCUboot present         -> the MCUboot bootloader carries it, and the
+#                                images it loads get their own MCUboot
+#                                headers instead: the NS app from
+#                                cmake/mcuboot.cmake and the TF-M SPE from
+#                                pse84_sign_tfm.
+#
+# Build scenarios and the hex that gets flashed
+# ---------------------------------------------
+#   Secure M33 app, no MCUboot      ext-boot sign vs m33s_xip   .signed.hex
+#   MCUboot bootloader (CONFIG_     ext-boot sign vs            .signed.hex
+#     MCUBOOT)                        boot_partition
+#   App chain-loaded by MCUboot     signed by mcuboot.cmake     .signed.hex
+#     (secure/NS/M55)
+#   TF-M SPE+NSPE, no MCUboot       ext-boot sign SPE, merge    tfm_merged.hex
+#                                     SPE + raw NS
+#   TF-M SPE+NSPE + MCUboot         SPE signed as MCUboot       tfm_merged.hex
+#                                     image 0; NS signed by
+#                                     mcuboot.cmake; merge in
+#                                     pse84_tfm_signing.cmake
+#
+# The NS core always pairs with a TF-M SPE built on the secure core, so a
+# Non-Secure build always flashes the merged SPE + NS image.
+
+# --------------------------------------------------------------------------
+# TF-M: sign the SPE (as an ext-boot or an MCUboot image, depending on
+# whether MCUboot is in the chain) and merge it with the NS image.
+# --------------------------------------------------------------------------
+if(CONFIG_BUILD_WITH_TFM AND NOT CONFIG_TFM_BL2)
+  # PSE84 post-processes the TF-M images itself rather than using the
+  # TF-M module's default (unsigned) secure + non-secure merge:
+  #  - The Secure image (SPE, image 0) is signed so the first stage of the
+  #    boot chain can validate it: the ext-boot header when the SPE runs
+  #    directly from the boot ROM, or an MCUboot image-0 header when MCUboot
+  #    chain-loads it.
+  #  - The image programmed to flash is the merged signed SPE plus the
+  #    Non-Secure image.
+  # Opt out of the default merge (via CONFIG_TFM_PLATFORM_HANDLES_MERGE);
+  # this platform produces the merged hex.
+
+  set(pse84_tfm_s_signed_hex ${CMAKE_BINARY_DIR}/zephyr/tfm_s_signed.hex)
+  set(pse84_tfm_merged_hex ${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex)
+
+  if(CONFIG_TFM_USE_NS_APP)
+    set(pse84_ns_hex $<TARGET_PROPERTY:tfm,TFM_NS_HEX_FILE>)
+  else()
+    set(pse84_ns_hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME})
+  endif()
+
+  if(CONFIG_BOOTLOADER_MCUBOOT)
+    # Chain-loaded by MCUboot: the boot ROM's ext-boot header belongs on the
+    # MCUboot bootloader (a separate CONFIG_MCUBOOT build), not on the SPE.
+    # Here MCUboot validates both images it loads, so the SPE (image 0) gets
+    # a proper MCUboot image-0 header signed with the same key and parameters
+    # as the Non-Secure image, which cmake/mcuboot.cmake signs.
+    pse84_sign_tfm($<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
+                            ${pse84_tfm_s_signed_hex} m33s_xip)
+
+    # The merged hex must contain the *signed* NSPE so MCUboot finds a valid
+    # header at its slot. Defer the merge to the signing script, which runs
+    # after NS signing has produced zephyr.signed.hex, and point the runner
+    # at the merged image.
+    set_target_properties(zephyr_property_target PROPERTIES
+      SIGNING_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/pse84_tfm_signing.cmake)
+    set_property(GLOBAL PROPERTY pse84_tfm_s_merge_hex_file
+                                 ${pse84_tfm_s_signed_hex})
+    set_property(GLOBAL PROPERTY pse84_merged_hex_file
+                                 ${pse84_tfm_merged_hex})
+  else()
+    # No MCUboot: the SPE is the first image the boot ROM runs, so it carries
+    # the extended-boot metadata header. The TF-M-built secure binary does
+    # not reserve header space, so pad it. Merge the signed SPE with the raw
+    # Non-Secure image.
+    pse84_add_extboot_metadata($<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
+                               ${pse84_tfm_s_signed_hex} PAD_HEADER)
+
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
+        -o ${pse84_tfm_merged_hex}
+        ${pse84_tfm_s_signed_hex}
+        ${pse84_ns_hex}
+    )
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+      ${pse84_tfm_merged_hex}
+    )
+  endif()
+endif()
+
+# --------------------------------------------------------------------------
+# Standalone secure image: prepend the ext-boot header with imgtool.
+# --------------------------------------------------------------------------
+# The PSE84 boot ROM always validates an ext-boot header on the first image
+# it runs, so every secure PSE84 image reaching here needs it. Two cases:
+#  - CONFIG_MCUBOOT: the MCUboot bootloader image itself, signed against
+#    boot_partition.
+#  - !CONFIG_BOOTLOADER_MCUBOOT: a standalone secure image (no MCUboot
+#    chain-load), signed against m33s_xip.
+# Apps chain-loaded by MCUboot are signed by cmake/mcuboot.cmake and must
+# not be double-signed here.
+if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE
+   AND (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT))
+  set(unsigned_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.hex)
+  set(signed_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.hex)
+  pse84_add_extboot_metadata(${unsigned_hex} ${signed_hex})
+endif()
+
+# --------------------------------------------------------------------------
+# Runner hex selection: tell `west flash` which of the hexes produced above
+# to program. Kept next to the flow that produces the files so the selection
+# and the production logic stay in sync.
+#   secure M33 or MCUboot-loaded image      -> <kernel>.signed.hex
+#   Non-Secure build (always TF-M SPE + NS) -> tfm_merged.hex
+# In the TF-M + MCUboot case the stock cmake/mcuboot.cmake later resets
+# hex_file to zephyr.signed.hex, so pse84_tfm_signing.cmake re-asserts the
+# merged hex after that flow runs.
+# --------------------------------------------------------------------------
+if((CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
+    OR CONFIG_BOOTLOADER_MCUBOOT)
+  set_property(TARGET runners_yaml_props_target
+    PROPERTY hex_file ${KERNEL_NAME}.signed.hex)
+endif()
+
+if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_NONSECURE)
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+endif()

--- a/soc/infineon/edge/pse84/pse84_tfm_signing.cmake
+++ b/soc/infineon/edge/pse84/pse84_tfm_signing.cmake
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# PSE84 TF-M + MCUboot signing script.
+#
+# On PSE84 the Non-Secure image lives in a slot whose size differs from
+# the Secure slot. The board devicetree already rebinds slot0_partition /
+# slot1_partition to the Non-Secure slots for the Non-Secure build (see
+# kit_pse84_eval_m33_ns.dts), so the stock cmake/mcuboot.cmake flow signs
+# the NSPE against the correct slot size on its own. This wrapper only
+# adds the PSE84-specific post-signing steps on top of that flow:
+#
+#   1. Run the stock MCUboot signing (produces zephyr.signed.hex/.bin and
+#      points the runner at zephyr.signed.hex).
+#   2. Merge the signed SPE image with the freshly signed NSPE image into
+#      tfm_merged.hex. The SPE hex and the merged-output path are handed
+#      over from the SoC CMakeLists via global properties.
+#   3. Override the runner hex_file to tfm_merged.hex so `west flash`
+#      programs the combined signed SPE + signed NSPE image.
+
+# Step 1: stock MCUboot signing (slot geometry comes from slot0/slot1
+# partitions, which the Non-Secure devicetree points at the NS slots).
+include(${ZEPHYR_BASE}/cmake/mcuboot.cmake)
+
+# Step 2: merge the signed SPE with the signed NSPE. The SoC CMakeLists
+# deferred this merge to here so that zephyr.signed.hex (produced above)
+# is used instead of the raw NS image. The SPE was already signed as
+# MCUboot image 0 by pse84_sign_tfm; this lets MCUboot validate
+# image 1 (NSPE) at slot2 in addition to image 0 (SPE) at slot0.
+get_property(pse84_tfm_s_merge_hex_file GLOBAL
+             PROPERTY pse84_tfm_s_merge_hex_file)
+get_property(pse84_merged_hex_file GLOBAL
+             PROPERTY pse84_merged_hex_file)
+
+if(pse84_merged_hex_file)
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
+      -o ${pse84_merged_hex_file}
+      ${pse84_tfm_s_merge_hex_file}
+      ${CMAKE_BINARY_DIR}/zephyr/zephyr.signed.hex
+  )
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+    ${pse84_merged_hex_file}
+  )
+
+  # Step 3: flash the merged image instead of the bare signed NSPE.
+  set_target_properties(runners_yaml_props_target PROPERTIES
+    hex_file ${pse84_merged_hex_file})
+endif()

--- a/soc/infineon/edge/pse84/soc_pse84_m33_s.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_s.c
@@ -92,8 +92,15 @@ void soc_early_init_hook(void)
 
 void soc_late_init_hook(void)
 {
+/* Skip the SAU init when running the MCUBoot as it
+ * would interfere with the RRAM configuration.
+ * This has no effect on the standalone secure image
+ * because it will handle the SAU initialization itself.
+ */
+#if !defined(CONFIG_MCUBOOT)
 	/* SAU Init */
 	cy_sau_init();
+#endif
 
 #if defined(CONFIG_SOC_PSE84_M55_ENABLE)
 	ifx_pse84_cm55_startup();


### PR DESCRIPTION
This PR adds the configuration needed to support **Multi-Image DFU over BLE using SMP/mcumgr** on the `kit_pse84_eval` board.

* **CM55 boot fix:** Prevents CM55 from accessing crypto hardware owned by TF-M, avoiding HardFault bootloops.
* **Multi-image DFU:** Configures separate firmware slots for **CM33-NS and CM55**, allowing both images to be updated over BLE.
* **UART isolation:** Prevents CM55 from interfering with the Bluetooth HCI UART or the other core’s console.
* **Reusable overlays:** Provides flexible console and UART configurations for different hardware setups.

depends on https://github.com/zephyrproject-rtos/zephyr/pull/108938
