### PR TITLE
[Backport v4.4-branch] net: dns: Use a fresh source port for each query

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -52,6 +52,25 @@ config DNS_RESOLVER_AI_MAX_ENTRIES
 	  resolution the DNS resolver can handle.
 
 
+config DNS_RESOLVER_RANDOMIZE_SOURCE_PORT
+	bool "Use a fresh source port for each query"
+	default y
+	help
+	  Ask the system for a new local port before sending a query to a
+	  server that has nothing outstanding, so that consecutive queries do
+	  not leave from the same one.
+
+	  RFC 5452 section 9.2 asks for this. An attacker who cannot see a
+	  query has to guess both the 16 bit identifier and the source port to
+	  forge an answer to it; a port that never changes is one of the two
+	  given away, and it is learned from any single query.
+
+	  This costs a socket being closed and reopened, and its dispatcher
+	  re-registered, before a query that follows an idle period. Turn it
+	  off where that matters more than the hardening does. Queries to
+	  multicast DNS and LLMNR are unaffected either way: those protocols
+	  fix the port.
+
 config DNS_RESOLVER_MAX_SERVERS
 	int "Number of DNS server addresses"
 	range 1 NET_MAX_CONTEXTS

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1552,6 +1552,149 @@ static int set_ttl_hop_limit(int sock, int level, int option, int new_limit)
 	return zsock_setsockopt(sock, level, option, &new_limit, sizeof(new_limit));
 }
 
+#if defined(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT)
+/* True when no query is still waiting for an answer, so a socket can be
+ * replaced without losing an answer that is on its way. A pending query does
+ * not record which server it was sent to, so any one of them holds every
+ * socket.
+ */
+static bool dns_resolver_is_idle(struct dns_resolve_context *ctx,
+				 int except_query_idx)
+{
+	for (int i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
+		/* The query about to be sent already holds its slot by the
+		 * time it gets here, so it does not count.
+		 */
+		if (i == except_query_idx) {
+			continue;
+		}
+
+		if (ctx->queries[i].cb != NULL && ctx->queries[i].query != NULL) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/* Give the server's socket a new local port.
+ *
+ * RFC 5452 9.2: an attacker who cannot see a query has to guess the identifier
+ * and the source port together to forge an answer to it. The identifier is
+ * already drawn afresh for every query; the port was chosen once, when the
+ * socket was opened, and then reused for the life of the resolver, so a single
+ * observed query gave it away for good.
+ *
+ * The socket is closed and opened again rather than rebound, because a bound
+ * UDP socket cannot be rebound. The port itself is left to the system: binding
+ * to zero is what the resolver already does at startup, and the dispatcher
+ * that shares the port keeps working the same way.
+ *
+ * A server whose socket cannot be replaced is left without one, which the
+ * resolver already treats as unavailable: the query goes to the next server
+ * instead. Getting here means the system is out of sockets, in which case the
+ * old one could not have been kept either.
+ */
+static void dns_randomize_source_port(struct dns_resolve_context *ctx,
+				      int server_idx, int query_idx)
+{
+	struct dns_server *server = &ctx->servers[server_idx];
+	struct net_sockaddr local;
+	int old_sock = server->sock;
+	int sock;
+	int ret;
+
+	/* Multicast DNS and LLMNR are spoken on a fixed port, and the
+	 * dispatcher pairs a resolver with a responder by that port.
+	 */
+	if (server->is_mdns || server->is_llmnr) {
+		return;
+	}
+
+	if (old_sock < 0 || !dns_resolver_is_idle(ctx, query_idx)) {
+		return;
+	}
+
+	/* Keep the address the dispatcher was bound to, drop the port. */
+	memcpy(&local, &server->dispatcher.local_addr, sizeof(local));
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) && local.sa_family == NET_AF_INET6) {
+		net_sin6(&local)->sin6_port = 0;
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && local.sa_family == NET_AF_INET) {
+		net_sin(&local)->sin_port = 0;
+	} else {
+		return;
+	}
+
+	/* Give the old socket up first. Its descriptor is then free for the
+	 * replacement, which matters where the descriptor budget is sized for
+	 * exactly the sockets the resolver holds.
+	 */
+	(void)dns_dispatcher_unregister(&server->dispatcher);
+
+	ARRAY_FOR_EACH(ctx->fds, j) {
+		if (ctx->fds[j].fd == old_sock) {
+			ctx->fds[j].fd = -1;
+			break;
+		}
+	}
+
+	zsock_close(old_sock);
+	server->sock = -1;
+
+	sock = zsock_socket(server->dns_server.sa_family, NET_SOCK_DGRAM,
+			    NET_IPPROTO_UDP);
+	if (sock < 0) {
+		NET_ERR("Cannot get a socket to renew the source port (%d)", -errno);
+		return;
+	}
+
+	if (server->if_index > 0) {
+		ret = bind_to_iface(sock, &server->dns_server, server->if_index);
+		if (ret < 0) {
+			zsock_close(sock);
+			return;
+		}
+	}
+
+	ARRAY_FOR_EACH(ctx->fds, j) {
+		if (ctx->fds[j].fd < 0) {
+			ctx->fds[j].fd = sock;
+			ctx->fds[j].events = ZSOCK_POLLIN;
+			break;
+		}
+	}
+
+	server->sock = sock;
+
+	/* -EALREADY means another server already dispatches this family and
+	 * port, which is how the resolver registers its later servers at
+	 * startup too, so the socket is in hand either way.
+	 */
+	ret = register_dispatcher(ctx, server->dispatcher.svc, server, &local,
+				  NULL, NULL);
+	if (ret < 0 && ret != -EALREADY) {
+		/* The old socket is gone and the new one is not dispatched, so
+		 * an answer arriving on it would not be seen. Give the socket
+		 * up: the resolver treats a server without one as unavailable
+		 * and moves on to the next.
+		 */
+		NET_ERR("Cannot dispatch the renewed socket for server %d (%d)",
+			server_idx, ret);
+
+		ARRAY_FOR_EACH(ctx->fds, j) {
+			if (ctx->fds[j].fd == sock) {
+				ctx->fds[j].fd = -1;
+				break;
+			}
+		}
+
+		zsock_close(sock);
+		server->sock = -1;
+	}
+}
+#endif /* CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT */
+
 /* Must be invoked with context lock held */
 static int dns_write(struct dns_resolve_context *ctx,
 		     int server_idx,
@@ -1567,7 +1710,15 @@ static int dns_write(struct dns_resolve_context *ctx,
 	int ret, sock, family;
 	char *query_name;
 
+	if (IS_ENABLED(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT)) {
+		dns_randomize_source_port(ctx, server_idx, query_idx);
+	}
+
 	sock = ctx->servers[server_idx].sock;
+	if (sock < 0) {
+		return -ENOTCONN;
+	}
+
 	family = ctx->servers[server_idx].dns_server.sa_family;
 	server = &ctx->servers[server_idx].dns_server;
 	dns_id = ctx->queries[query_idx].id;

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/hostname.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/net/udp.h>
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
@@ -131,11 +132,29 @@ static inline int get_slot_by_id(struct dns_resolve_context *ctx,
 	return -1;
 }
 
+/* The source port the last two queries left from, so that a test can see
+ * whether it moves. RFC 5452 9.2 asks that it does.
+ */
+static uint16_t query_src_port;
+static uint16_t last_query_src_port;
+
 static int sender_iface(const struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		DBG("No data to send!\n");
 		return -ENODATA;
+	}
+
+	if (IS_ENABLED(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT)) {
+		struct net_udp_hdr *udp = net_udp_get_hdr(pkt, NULL);
+
+		/* Only ordinary queries. Multicast DNS and LLMNR are spoken
+		 * from a fixed port on purpose, so theirs does not move.
+		 */
+		if (udp != NULL && net_ntohs(udp->dst_port) == 53U) {
+			last_query_src_port = query_src_port;
+			query_src_port = net_ntohs(udp->src_port);
+		}
 	}
 
 	if (!timeout_query) {
@@ -636,6 +655,57 @@ ZTEST(dns_resolve, test_dns_query_ipv4)
 	if (k_sem_take(&wait_data2, WAIT_TIME)) {
 		zassert_true(false, "Timeout while waiting data");
 	}
+}
+
+/* RFC 5452 9.2: an off path attacker forging an answer has to guess the
+ * identifier and the source port together. A port that never moves is learned
+ * from any single query, leaving only the identifier to guess.
+ */
+ZTEST(dns_resolve, test_dns_query_source_port_varies)
+{
+	struct expected_status status = {
+		.status1 = DNS_EAI_INPROGRESS,
+		.status2 = DNS_EAI_ALLDONE,
+		.caller = __func__,
+	};
+	int ret;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_DNS_RESOLVER_RANDOMIZE_SOURCE_PORT);
+
+	timeout_query = false;
+	query_src_port = 0U;
+	last_query_src_port = 0U;
+
+	/* The port is only renewed for a server with nothing outstanding, so
+	 * each lookup has to be seen through to the end before the next.
+	 */
+	for (int i = 0; i < 2; i++) {
+		k_sem_reset(&wait_data2);
+
+		ret = dns_get_addr_info(NAME4,
+					DNS_QUERY_TYPE_A,
+					&current_dns_id,
+					dns_result_cb,
+					&status,
+					DNS_TIMEOUT);
+		zassert_equal(ret, 0, "Cannot create IPv4 query");
+
+		/* Let the network stack to proceed */
+		k_msleep(THREAD_SLEEP);
+
+		if (k_sem_take(&wait_data2, WAIT_TIME)) {
+			zassert_true(false, "Timeout while waiting data");
+		}
+
+		if (i == 0) {
+			zassert_not_equal(query_src_port, 0U, "No query was seen");
+		}
+	}
+
+	zassert_not_equal(query_src_port, last_query_src_port,
+			  "Both queries left from port %u; an observer learns it "
+			  "from the first and need only guess the identifier",
+			  query_src_port);
 }
 
 ZTEST(dns_resolve, test_dns_query_ipv6)


### PR DESCRIPTION
Backport of the fix from #116963 to `v4.4-branch`.

Fixes: #117501