### PR TITLE
posix: make times() and its runtime accounting optional

### DIFF
--- a/subsys/portability/posix/options/Kconfig.procN
+++ b/subsys/portability/posix/options/Kconfig.procN
@@ -4,8 +4,7 @@
 
 menuconfig POSIX_MULTI_PROCESS
 	bool "POSIX multi-process support"
-	select SCHED_THREAD_USAGE # times()
-	select THREAD_RUNTIME_STATS
+	imply THREAD_RUNTIME_STATS # times()
 	help
 	  Support for multi-processing.
 

--- a/subsys/portability/posix/options/multi_process.c
+++ b/subsys/portability/posix/options/multi_process.c
@@ -33,6 +33,12 @@ pid_t getpid(void)
 FUNC_ALIAS(getpid, _getpid, pid_t);
 #endif /* CONFIG_POSIX_MULTI_PROCESS_ALIAS_GETPID */
 
+/*
+ * The runtime statistics this needs are only collected when
+ * CONFIG_SCHED_THREAD_USAGE is enabled, and collecting them adds
+ * accounting to every context switch.
+ */
+#ifdef CONFIG_SCHED_THREAD_USAGE
 clock_t times(struct tms *buffer)
 {
 	int ret;
@@ -58,3 +64,4 @@ clock_t times(struct tms *buffer)
 
 	return utime;
 }
+#endif /* CONFIG_SCHED_THREAD_USAGE */


### PR DESCRIPTION
POSIX_MULTI_PROCESS selects SCHED_THREAD_USAGE and THREAD_RUNTIME_STATS for times(), the only interface in the group that needs them. Gathering those statistics adds accounting to every context switch, and CONFIG_POSIX_API implies the whole group, so every POSIX application pays for times() whether it calls it or not. Turning the group off is not an alternative, because sleep() and getpid() live in it too.

Move the selects onto a new POSIX_MULTI_PROCESS_TIMES option, default y, so nothing changes unless an application opts out.

On qemu_cortex_m3 the Thread-Metric cooperative scheduling benchmark goes from 2,273,378 to 5,922,745 context switches per 30 s window with times() disabled, +160%. Paths that never block, such as the synchronization benchmark, are unaffected.