### PR TITLE
drivers: virtio: fix MMIO status endianness

### DIFF
--- a/drivers/virtio/virtio_mmio.c
+++ b/drivers/virtio/virtio_mmio.c
@@ -154,7 +154,7 @@ static bool virtio_mmio_read_status_bit(const struct device *dev, int bit)
 
 static void virtio_mmio_write_status_bit(const struct device *dev, int bit)
 {
-	const uint32_t mask = sys_cpu_to_le32(BIT(bit));
+	const uint32_t mask = BIT(bit);
 	const uint32_t val = virtio_mmio_read32(dev, VIRTIO_MMIO_STATUS);
 
 	virtio_mmio_write32(dev, VIRTIO_MMIO_STATUS, val | mask);

--- a/tests/drivers/virtio/mmio_status_endianness/CMakeLists.txt
+++ b/tests/drivers/virtio/mmio_status_endianness/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(virtio_mmio_status_endianness)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/virtio/mmio_status_endianness/app.overlay
+++ b/tests/drivers/virtio/mmio_status_endianness/app.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&{/soc} {
+	virtio_mmio_test: virtio-mmio@7fff0000 {
+		compatible = "virtio,mmio";
+		reg = <0x7fff0000 0x200>;
+		interrupts = <5>;
+		zephyr,deferred-init;
+		status = "okay";
+	};
+};

--- a/tests/drivers/virtio/mmio_status_endianness/prj.conf
+++ b/tests/drivers/virtio/mmio_status_endianness/prj.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_MMIO=y

--- a/tests/drivers/virtio/mmio_status_endianness/src/main.c
+++ b/tests/drivers/virtio/mmio_status_endianness/src/main.c
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/virtio.h>
+#include <zephyr/drivers/virtio/virtio_config.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/ztest.h>
+
+#define TEST_NODE DT_NODELABEL(virtio_mmio_test)
+#define TEST_REG(offset) ((mem_addr_t)(DT_REG_ADDR(TEST_NODE) + (offset)))
+
+#define TEST_VIRTIO_MAGIC     0x74726976U
+#define TEST_VIRTIO_VERSION   2U
+#define TEST_VIRTIO_DEVICE_ID 1U
+
+static void test_reg_write(uint32_t offset, uint32_t value)
+{
+	sys_write32(sys_cpu_to_le32(value), TEST_REG(offset));
+}
+
+static uint32_t test_reg_read(uint32_t offset)
+{
+	return sys_le32_to_cpu(sys_read32(TEST_REG(offset)));
+}
+
+static void before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	test_reg_write(VIRTIO_MMIO_MAGIC_VALUE, TEST_VIRTIO_MAGIC);
+	test_reg_write(VIRTIO_MMIO_VERSION, TEST_VIRTIO_VERSION);
+	test_reg_write(VIRTIO_MMIO_DEVICE_ID, TEST_VIRTIO_DEVICE_ID);
+	test_reg_write(VIRTIO_MMIO_VENDOR_ID, 0U);
+	test_reg_write(VIRTIO_MMIO_STATUS, 0U);
+}
+
+ZTEST(virtio_mmio_status_endianness, test_status_round_trip_through_transport_api)
+{
+	const struct device *dev = DEVICE_DT_GET(TEST_NODE);
+	uint32_t expected_status;
+	int ret;
+
+	zassert_false(device_is_ready(dev), "deferred VirtIO MMIO device unexpectedly ready");
+
+	ret = device_init(dev);
+	zassert_ok(ret, "fake VirtIO MMIO transport failed to initialize");
+	zassert_true(device_is_ready(dev), "fake VirtIO MMIO transport did not become ready");
+
+	expected_status = BIT(DEVICE_STATUS_ACKNOWLEDGE) | BIT(DEVICE_STATUS_DRIVER);
+	zassert_equal(test_reg_read(VIRTIO_MMIO_STATUS), expected_status,
+		      "initial MMIO status bits were not written in little-endian order");
+
+	zassert_ok(virtio_commit_feature_bits(dev),
+		   "FEATURES_OK status bit did not round-trip through the MMIO transport");
+	expected_status |= BIT(DEVICE_STATUS_FEATURES_OK);
+	zassert_equal(test_reg_read(VIRTIO_MMIO_STATUS), expected_status,
+		      "FEATURES_OK status bit was not preserved in little-endian order");
+
+	virtio_finalize_init(dev);
+	expected_status |= BIT(DEVICE_STATUS_DRIVER_OK);
+	zassert_equal(test_reg_read(VIRTIO_MMIO_STATUS), expected_status,
+		      "DRIVER_OK status bit was not preserved in little-endian order");
+}
+
+ZTEST_SUITE(virtio_mmio_status_endianness, NULL, NULL, before, NULL, NULL);

--- a/tests/drivers/virtio/mmio_status_endianness/tests.yaml
+++ b/tests/drivers/virtio/mmio_status_endianness/tests.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.virtio.mmio_status_endianness:
+    platform_allow:
+      - qemu_leon3
+    tags:
+      - drivers
+      - virtio


### PR DESCRIPTION
## Summary

The VirtIO MMIO register helpers already convert 32-bit values between little-endian and CPU byte order. Preconverting the status mask therefore applies a second conversion on big-endian targets and can write the wrong status bit.

Build the status mask in CPU byte order and let the MMIO helper perform the transport conversion.

## Tests

Adds a `qemu_leon3` regression that checks the exact status value written through the real helper path.

- equivalent pre-rebase patch validation: PASS
- current rebased head: `git diff --check` PASS
- current rebased head: `checkpatch.pl --strict` 0 errors, 0 warnings

Validation run: https://github.com/alesanGreat/zephyr/actions/runs/32538220068

## Contribution metadata

AI assistance is disclosed in the commit with `Assisted-by: ChatGPT:GPT-5.6 Sol`. The commit carries the human DCO `Signed-off-by` certification.