### PR TITLE
drivers: virtio: fix used ring endianness

### DIFF
--- a/drivers/virtio/virtio_common.c
+++ b/drivers/virtio/virtio_common.c
@@ -21,12 +21,8 @@ void virtio_isr(const struct device *dev, uint8_t isr_status, uint16_t virtqueue
 
 			while (vq->last_used_idx != used_idx) {
 				uint16_t idx = vq->last_used_idx % vq->num;
-				uint16_t idx_le = sys_cpu_to_le16(idx);
-				uint16_t chain_head_le = vq->used->ring[idx_le].id;
-				uint16_t chain_head = sys_le16_to_cpu(chain_head_le);
-				uint32_t used_len = sys_le32_to_cpu(
-					vq->used->ring[idx_le].len
-				);
+				uint32_t chain_head = sys_le32_to_cpu(vq->used->ring[idx].id);
+				uint32_t used_len = sys_le32_to_cpu(vq->used->ring[idx].len);
 
 				/*
 				 * The used ring is written by the (untrusted) device.
@@ -63,10 +59,10 @@ void virtio_isr(const struct device *dev, uint8_t isr_status, uint16_t virtqueue
 				 */
 				while (!last) {
 					uint16_t curr = next;
-					uint16_t curr_le = sys_cpu_to_le16(curr);
+					uint16_t flags = sys_le16_to_cpu(vq->desc[curr].flags);
 
-					next = vq->desc[curr_le].next;
-					last = !(vq->desc[curr_le].flags & VIRTQ_DESC_F_NEXT);
+					next = sys_le16_to_cpu(vq->desc[curr].next);
+					last = !(flags & VIRTQ_DESC_F_NEXT);
 					virtq_add_free_desc(vq, curr);
 				}
 

--- a/tests/drivers/virtio/used_ring_endianness/CMakeLists.txt
+++ b/tests/drivers/virtio/used_ring_endianness/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(virtio_used_ring_endianness)
+
+target_sources(app PRIVATE src/main.c)
+
+# Use the shared transport ISR declaration; its implementation is built by Kconfig.
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/drivers/virtio)

--- a/tests/drivers/virtio/used_ring_endianness/prj.conf
+++ b/tests/drivers/virtio/used_ring_endianness/prj.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_LOG_LEVEL_OFF=y

--- a/tests/drivers/virtio/used_ring_endianness/src/main.c
+++ b/tests/drivers/virtio/used_ring_endianness/src/main.c
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/virtio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/ztest.h>
+
+#include "virtio_common.h"
+
+#define TEST_QUEUE_SIZE 4U
+#define TEST_RING_ENTRIES 257U
+
+struct test_used_ring {
+	uint16_t flags;
+	uint16_t idx;
+	struct virtq_used_elem ring[TEST_RING_ENTRIES];
+};
+
+BUILD_ASSERT(offsetof(struct test_used_ring, ring) == offsetof(struct virtq_used, ring));
+
+static struct virtq queue;
+static struct virtq_desc descriptors[TEST_RING_ENTRIES];
+static struct test_used_ring used_ring;
+static struct virtq_receive_callback_entry callbacks[TEST_QUEUE_SIZE];
+static stack_data_t free_desc_storage[TEST_QUEUE_SIZE];
+static size_t callback_count;
+static uint32_t callback_len;
+
+static void assert_next_free_desc(uint16_t expected)
+{
+	uint16_t descriptor;
+
+	zassert_ok(virtq_get_free_desc(&queue, &descriptor, K_NO_WAIT));
+	zassert_equal(descriptor, expected, "wrong descriptor returned to the real free stack");
+}
+
+static struct virtq *fake_get_virtqueue(const struct device *dev, uint16_t queue_idx)
+{
+	zassert_not_null(dev);
+	zassert_equal(queue_idx, 0U);
+	return &queue;
+}
+
+static DEVICE_API(virtio, fake_api) = {
+	.get_virtqueue = fake_get_virtqueue,
+};
+
+static struct device fake_device = {
+	.name = "virtio-used-ring-endianness",
+	.api = &fake_api,
+};
+
+static void receive_callback(void *opaque, uint32_t used_len)
+{
+	zassert_equal_ptr(opaque, &queue);
+	callback_count++;
+	callback_len = used_len;
+}
+
+static void set_used_entry(size_t slot, uint32_t id, uint32_t len)
+{
+	used_ring.ring[slot].id = sys_cpu_to_le32(id);
+	used_ring.ring[slot].len = sys_cpu_to_le32(len);
+}
+
+static void before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	memset(&queue, 0, sizeof(queue));
+	memset(descriptors, 0, sizeof(descriptors));
+	memset(&used_ring, 0, sizeof(used_ring));
+	memset(callbacks, 0, sizeof(callbacks));
+	callback_count = 0U;
+	callback_len = 0U;
+
+	queue.num = TEST_QUEUE_SIZE;
+	queue.desc = descriptors;
+	queue.used = (struct virtq_used *)&used_ring;
+	queue.recv_cbs = callbacks;
+	k_stack_init(&queue.free_desc_stack, free_desc_storage, ARRAY_SIZE(free_desc_storage));
+}
+
+ZTEST(virtio_used_ring_endianness, test_used_element_id_is_little_endian_32_bit)
+{
+	const uint32_t expected_len = 0x10203040U;
+
+	used_ring.idx = sys_cpu_to_le16(1U);
+	set_used_entry(0U, 1U, expected_len);
+	callbacks[1].cb = receive_callback;
+	callbacks[1].opaque = &queue;
+
+	virtio_isr(&fake_device, VIRTIO_QUEUE_INTERRUPT, 1U);
+
+	zassert_equal(queue.last_used_idx, 1U);
+	zassert_equal(queue.free_desc_n, 1U);
+	assert_next_free_desc(1U);
+	zassert_equal(callback_count, 1U);
+	zassert_equal(callback_len, expected_len);
+}
+
+ZTEST(virtio_used_ring_endianness, test_descriptor_chain_fields_are_little_endian)
+{
+	used_ring.idx = sys_cpu_to_le16(1U);
+	set_used_entry(0U, 0U, 0U);
+	descriptors[0].flags = sys_cpu_to_le16(VIRTQ_DESC_F_NEXT);
+	descriptors[0].next = sys_cpu_to_le16(1U);
+	callbacks[0].cb = receive_callback;
+	callbacks[0].opaque = &queue;
+
+	virtio_isr(&fake_device, VIRTIO_QUEUE_INTERRUPT, 1U);
+
+	zassert_equal(queue.free_desc_n, 2U);
+	assert_next_free_desc(1U);
+	assert_next_free_desc(0U);
+	zassert_equal(callback_count, 1U);
+}
+
+ZTEST(virtio_used_ring_endianness, test_used_ring_index_stays_cpu_endian)
+{
+	queue.last_used_idx = 1U;
+	used_ring.idx = sys_cpu_to_le16(2U);
+	set_used_entry(1U, 0U, 0U);
+	/* Old code byte-swaps slot 1 to 256 and truncates this ID back to 4. */
+	set_used_entry(256U, TEST_QUEUE_SIZE << 16, 0U);
+	callbacks[0].cb = receive_callback;
+	callbacks[0].opaque = &queue;
+
+	virtio_isr(&fake_device, VIRTIO_QUEUE_INTERRUPT, 1U);
+
+	zassert_equal(queue.last_used_idx, 2U);
+	zassert_equal(queue.free_desc_n, 1U);
+	assert_next_free_desc(0U);
+	zassert_equal(callback_count, 1U);
+}
+
+ZTEST_SUITE(virtio_used_ring_endianness, NULL, NULL, before, NULL, NULL);

--- a/tests/drivers/virtio/used_ring_endianness/tests.yaml
+++ b/tests/drivers/virtio/used_ring_endianness/tests.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.virtio.used_ring_endianness:
+    platform_allow:
+      - qemu_leon3
+      - qemu_malta
+    tags:
+      - drivers
+      - virtio


### PR DESCRIPTION
## Summary

The common VirtIO ISR byte-swapped CPU-side ring and descriptor indices before using them as array subscripts, truncated the 32-bit used element ID, and read descriptor flags and `next` without converting those shared-memory fields from little-endian.

Keep CPU-side indices in CPU byte order and convert only the fields read from the VirtIO shared-memory structures.

## Tests

Adds `qemu_leon3` regressions covering used elements, descriptor chains, 32-bit element IDs, and nonzero ring positions.

- equivalent pre-rebase patch validation: PASS
- current rebased head: `git diff --check` PASS
- current rebased head: `checkpatch.pl --strict` 0 errors, 0 warnings

Validation run: https://github.com/alesanGreat/zephyr/actions/runs/32539345267

## Contribution metadata

AI assistance is disclosed in the commit with `Assisted-by: ChatGPT:GPT-5.6 Sol`. The commit carries the human DCO `Signed-off-by` certification.