### PR TITLE
debug: do not make spin validation part of assert

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -204,11 +204,22 @@ config ASSERT_LEVEL
 	  Level 1: on + warning in every file that includes __assert.h
 	  Level 2: on + no warning
 
+config ASSERT_CUSTOM_HEADER
+	bool "Include Custom Assert Header [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  When enabled, a custom application provided header, named
+	  "zephyr_custom_assert.h", is included at the end of __assert.h. This enables
+	  extension of the assert APIs at the macro level. Please use cautiously!
+	  The internal assert API may change in future releases.
+
+
+endif # ASSERT
+
 config SPIN_VALIDATE
 	bool "Spinlock validation"
 	depends on MULTITHREADING
 	depends on MP_MAX_NUM_CPUS <= 4 || (64BIT && MP_MAX_NUM_CPUS <= 8)
-	default y if !FLASH || FLASH_SIZE > 32
 	help
 	  There's a spinlock validation framework available when asserts are
 	  enabled. It adds a relatively hefty overhead (about 3k or so) to
@@ -223,18 +234,6 @@ config SPIN_LOCK_TIME_LIMIT
 	  Assert at the time of unlocking the number of system clock cycles
 	  the lock has been held is less than the configured value. Requires
 	  the timer driver sys_clock_get_cycles_32() be lock free.
-
-config ASSERT_CUSTOM_HEADER
-	bool "Include Custom Assert Header [EXPERIMENTAL]"
-	select EXPERIMENTAL
-	help
-	  When enabled, a custom application provided header, named
-	  "zephyr_custom_assert.h", is included at the end of __assert.h. This enables
-	  extension of the assert APIs at the macro level. Please use cautiously!
-	  The internal assert API may change in future releases.
-
-
-endif # ASSERT
 
 config FORCE_NO_ASSERT
 	bool "Force-disable no assertions"

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -1433,7 +1433,7 @@ ZTEST(log_buffer, test_alloc_in_spinlock)
 {
 	struct mpsc_pbuf_buffer buffer;
 	struct test_data_var *packet;
-	struct k_spinlock l = {0};
+	struct k_spinlock l = {};
 
 	init(&buffer, 32, false);
 

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -1110,7 +1110,11 @@ ZTEST(log_buffer, test_sema_lock)
 	struct test_msg_hnd  test_hnd = {};
 	struct test_msg_data  test_data;
 	struct test_msg_data  *item = NULL;
-	struct mpsc_pbuf_buffer_config  cfg;
+	struct mpsc_pbuf_buffer_config  cfg = {
+		.buf = buf32_1,
+		.size = ARRAY_SIZE(buf32_1),
+		.get_wlen = test_mpsc_get_used_len,
+	};
 	uint32_t loop = 0;
 	size_t wlen = 0;
 	bool fist_wait = true;
@@ -1118,10 +1122,6 @@ ZTEST(log_buffer, test_sema_lock)
 	if (CONFIG_SYS_CLOCK_TICKS_PER_SEC < 10000) {
 		ztest_test_skip();
 	}
-
-	cfg.buf = buf32_1;
-	cfg.size = ARRAY_SIZE(buf32_1);
-	cfg.get_wlen = test_mpsc_get_used_len;
 
 	mpsc_pbuf_init(&test_hnd.mpsc_buffer, &cfg);
 	test_hnd.product_max_cnt = 2;


### PR DESCRIPTION
Nothing in asserts infra is related to spin validation, spin validation
should not be automatically enable when someone wants to enable assert
and suffer the cost in flash and performance.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
