### PR TITLE
boards: heltec: heltec_wireless_tracker: fix SX1262 chip select

### DIFF
--- a/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker-pinctrl.dtsi
+++ b/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker-pinctrl.dtsi
@@ -47,8 +47,7 @@
 	spim2_default: spim2_default {
 		group1 {
 			pinmux = <SPIM2_MISO_GPIO11>,
-				 <SPIM2_SCLK_GPIO9>,
-				 <SPIM2_CSEL_GPIO8>;
+				 <SPIM2_SCLK_GPIO9>;
 		};
 
 		group2 {

--- a/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker_procpu.dts
+++ b/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker_procpu.dts
@@ -157,6 +157,7 @@
 	status = "okay";
 	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 
 	lora0: lora@0 {
 		compatible = "semtech,sx1262";


### PR DESCRIPTION
The in-tree heltec_wireless_tracker board's SX1262 LoRa radio cannot
work: GPIO8 is pinmuxed to the SPIM2 hardware CSEL function, but the
spi2 node has no cs-gpios, and spi_esp32_spim only operates chip
select via spi_context GPIOs. So NSS never asserts. And since the pin
is muxed away from GPIO, adding cs-gpios without removing the CSEL
entry doesn't help either.

Fix it the way the working ESP32 LoRa boards do (see ttgo_lora32): no
CSEL in the pinmux, software CS via cs-gpios.

Hardware status: the equivalent change has been running on a Heltec
Wireless Tracker in our v4.4.0-based tree as a board overlay (the
hardware is a V2, but its LoRa wiring matches the V1.1 the board files
target, checked against the schematic) — NSS asserts and SPI
transactions reach the radio. On current main, samples/drivers/lora/send
builds clean for heltec_wireless_tracker/esp32s3/procpu with this
change; I'll re-verify on hardware against main and report back on this
PR. Full LoRa TX/RX on this board also needs the MISO pad input-buffer
problem described in #117549 sorted; this PR is the board-file half.

Relates to #117549
