### PR TITLE
[Backport v3.7-branch] net: dhcpv4: Use one transaction identifier per transaction

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -455,6 +455,19 @@ static uint32_t dhcpv4_lease_timeleft(struct net_if *iface, int64_t now)
 				   now);
 }
 
+/* RFC 2131 4.1 asks a client to use one transaction identifier for every
+ * message of a transaction, and to choose it so that two clients are unlikely
+ * to pick the same one. So it is drawn afresh whenever a transaction begins,
+ * and left alone for as long as that transaction lasts, retransmissions
+ * included.
+ *
+ * Must be invoked with lock held.
+ */
+static void dhcpv4_generate_xid(struct net_if *iface)
+{
+	iface->config.dhcpv4.xid = sys_rand32_get();
+}
+
 /* Must be invoked with lock held */
 static uint32_t dhcpv4_update_message_timeout(struct net_if_dhcpv4 *dhcpv4)
 {
@@ -624,8 +637,6 @@ static uint32_t dhcpv4_send_discover(struct net_if *iface)
 	struct net_pkt *pkt;
 	uint32_t timeout;
 
-	iface->config.dhcpv4.xid++;
-
 	pkt = dhcpv4_create_message(iface, NET_DHCPV4_MSG_TYPE_DISCOVER,
 				    NULL, NULL, net_ipv4_broadcast_address(),
 				    false, false);
@@ -651,7 +662,8 @@ fail:
 		net_pkt_unref(pkt);
 	}
 
-	return iface->config.dhcpv4.xid %
+	/* Nothing was sent, so try again after a short random delay. */
+	return sys_rand32_get() %
 			(CONFIG_NET_DHCPV4_INITIAL_DELAY_MAX -
 			 DHCPV4_INITIAL_DELAY_MIN) +
 			DHCPV4_INITIAL_DELAY_MIN;
@@ -661,8 +673,9 @@ static void dhcpv4_send_decline(struct net_if *iface)
 {
 	struct net_pkt *pkt;
 
-	iface->config.dhcpv4.xid++;
-
+	/* RFC 2131 table 5: a decline carries the identifier of the exchange
+	 * that offered the address being declined, so it is not a new one.
+	 */
 	pkt = dhcpv4_create_message(iface, NET_DHCPV4_MSG_TYPE_DECLINE,
 				    NULL, NULL, net_ipv4_broadcast_address(),
 				    false, true);
@@ -687,6 +700,11 @@ fail:
 static void dhcpv4_enter_selecting(struct net_if *iface)
 {
 	iface->config.dhcpv4.attempts = 0U;
+
+	/* A discover starts a new exchange, so it gets a new identifier.
+	 * Retransmissions of it do not: they are the same exchange.
+	 */
+	dhcpv4_generate_xid(iface);
 
 	iface->config.dhcpv4.lease_time = 0U;
 	iface->config.dhcpv4.renewal_time = 0U;
@@ -758,6 +776,9 @@ static void dhcpv4_enter_renewing(struct net_if *iface)
 {
 	iface->config.dhcpv4.state = NET_DHCPV4_RENEWING;
 	iface->config.dhcpv4.attempts = 0U;
+
+	/* Renewing is a new exchange with the server, RFC 2131 4.4.5. */
+	dhcpv4_generate_xid(iface);
 	NET_DBG("enter state=%s",
 		net_dhcpv4_state_name(iface->config.dhcpv4.state));
 }
@@ -766,6 +787,11 @@ static void dhcpv4_enter_rebinding(struct net_if *iface)
 {
 	iface->config.dhcpv4.state = NET_DHCPV4_REBINDING;
 	iface->config.dhcpv4.attempts = 0U;
+
+	/* Rebinding asks any server rather than the one that granted the
+	 * lease, which makes it a new exchange too.
+	 */
+	dhcpv4_generate_xid(iface);
 	NET_DBG("enter state=%s",
 		net_dhcpv4_state_name(iface->config.dhcpv4.state));
 }
@@ -1554,6 +1580,13 @@ static void dhcpv4_iface_event_handler(struct net_mgmt_event_callback *cb,
 		if (iface->config.dhcpv4.state == NET_DHCPV4_BOUND) {
 			iface->config.dhcpv4.attempts = 0U;
 			iface->config.dhcpv4.state = NET_DHCPV4_INIT;
+
+			/* What follows is a new exchange rather than a
+			 * continuation of the one that granted the lease
+			 * being left behind.
+			 */
+			dhcpv4_generate_xid(iface);
+
 			NET_DBG("enter state=%s", net_dhcpv4_state_name(
 					iface->config.dhcpv4.state));
 			/* Remove any bound address as interface is gone */
@@ -1679,17 +1712,17 @@ static void dhcpv4_start_internal(struct net_if *iface, bool first_start)
 		NET_DBG("iface %p state=%s", iface,
 			net_dhcpv4_state_name(iface->config.dhcpv4.state));
 
-		/* We need entropy for both an XID and a random delay
-		 * before sending the initial discover message.
+		/* Random delay before sending the initial discover message,
+		 * drawn separately from the transaction identifier so that
+		 * one cannot be guessed from the other.
 		 */
 		entropy = sys_rand32_get();
 
-		/* A DHCP client MUST choose xid's in such a way as to
-		 * minimize the change of using and xid identical to
-		 * one used by another client.  Choose a random xid st
-		 * startup and increment it on each new request.
+		/* RFC 2131 4.1: choose the identifier so that two clients are
+		 * unlikely to pick the same one. It stays put for the whole of
+		 * the exchange that follows; the next exchange draws another.
 		 */
-		iface->config.dhcpv4.xid = entropy;
+		dhcpv4_generate_xid(iface);
 
 		/* Use default */
 		if (first_start) {

--- a/tests/net/dhcpv4/client/src/main.c
+++ b/tests/net/dhcpv4/client/src/main.c
@@ -236,6 +236,12 @@ struct dhcp_msg {
 
 static uint32_t offer_xid;
 static uint32_t request_xid;
+/* How many discovers to swallow before answering, so that the client is made
+ * to retransmit, and what identifiers those retransmissions carried.
+ */
+static int discovers_to_drop;
+static int discovers_seen;
+static uint32_t discover_xids[4];
 
 static struct k_sem test_lock;
 
@@ -436,6 +442,18 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	parse_dhcp_message(pkt, &msg);
 
 	if (msg.type == DISCOVER) {
+		if (discovers_seen < ARRAY_SIZE(discover_xids)) {
+			discover_xids[discovers_seen] = msg.xid;
+		}
+		discovers_seen++;
+
+		if (discovers_to_drop > 0) {
+			/* Say nothing, so that the client retransmits. */
+			discovers_to_drop--;
+			net_pkt_unref(pkt);
+			return 0;
+		}
+
 		/* Reply with DHCPv4 offer message */
 		rpkt = prepare_dhcp_offer(net_pkt_iface(pkt), msg.xid);
 		if (!rpkt) {
@@ -707,4 +725,55 @@ ZTEST(dhcpv4_tests, test_dhcp)
 }
 
 /**test case main entry */
+/* RFC 2131 4.1: one transaction identifier for every message of a
+ * transaction. A retransmitted discover is the same transaction, so a server
+ * that has already seen the first one has to be able to recognise the second
+ * as a repeat rather than as another client asking.
+ *
+ * Every discover is dropped, so the exchange never completes and this leaves
+ * neither a lease nor a set of DNS servers behind for whatever runs next.
+ */
+ZTEST(dhcpv4_tests, test_discover_retransmission_keeps_xid)
+{
+	/* Long enough for two retransmissions: the backoff is four seconds,
+	 * then eight, plus a second of randomisation each. native_sim
+	 * fast-forwards idle time, so this costs no wall clock.
+	 */
+	const k_timeout_t settle = K_SECONDS(4 + 8 + 4);
+	struct net_if *iface;
+
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	zassert_not_null(iface, "Interface not available");
+
+	/* The suite has no per-test setup, so put the interface and the
+	 * counters back to a known state here. An earlier test leaves the
+	 * lease bound, and a bound interface ignores a start.
+	 */
+	net_dhcpv4_stop(iface);
+	discovers_seen = 0;
+	memset(discover_xids, 0, sizeof(discover_xids));
+
+	discovers_to_drop = ARRAY_SIZE(discover_xids);
+
+	net_dhcpv4_start(iface);
+	k_sleep(settle);
+	net_dhcpv4_stop(iface);
+
+	/* Nothing tears this down for whatever runs next, either. */
+	discovers_to_drop = 0;
+
+	zassert_true(discovers_seen >= 3,
+		     "Expected the client to retransmit, saw %d discover(s)",
+		     discovers_seen);
+
+	zassert_not_equal(discover_xids[0], 0U, "Transaction identifier is zero");
+
+	for (int i = 1; i < MIN(discovers_seen, ARRAY_SIZE(discover_xids)); i++) {
+		zassert_equal(discover_xids[i], discover_xids[0],
+			      "Discover %d carries xid 0x%08x, the first carried "
+			      "0x%08x; a retransmission is the same transaction",
+			      i, discover_xids[i], discover_xids[0]);
+	}
+}
+
 ZTEST_SUITE(dhcpv4_tests, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Backport of the fix from #116955 to `v3.7-branch`.

Fixes: #117500