### PR TITLE
net: l2: ppp: act on a received Protocol-Reject

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -699,6 +699,13 @@ static void ppp_process_msg(struct ppp_driver_context *ppp)
 }
 
 #if defined(CONFIG_NET_TEST)
+static void (*ppp_send_cb)(struct net_pkt *pkt);
+
+void ppp_driver_register_send_cb(void (*cb)(struct net_pkt *pkt))
+{
+	ppp_send_cb = cb;
+}
+
 static uint8_t *ppp_recv_cb(uint8_t *buf, size_t *off)
 {
 	struct ppp_driver_context *ppp =
@@ -822,6 +829,10 @@ static int ppp_send(const struct device *dev, struct net_pkt *pkt)
 	int i, offset;
 
 #if defined(CONFIG_NET_TEST)
+	if (ppp_send_cb != NULL) {
+		ppp_send_cb(pkt);
+	}
+
 	return 0;
 #endif
 

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -1130,14 +1130,55 @@ enum net_verdict ppp_fsm_input(struct ppp_fsm *fsm, uint16_t proto,
 	return NET_DROP;
 }
 
+static struct ppp_fsm *ppp_proto_fsm(struct ppp_context *ctx, uint16_t protocol)
+{
+	switch (protocol) {
+#if defined(CONFIG_NET_IPV4)
+	case PPP_IPCP:
+		return &ctx->ipcp.fsm;
+#endif
+#if defined(CONFIG_NET_IPV6)
+	case PPP_IPV6CP:
+		return &ctx->ipv6cp.fsm;
+#endif
+#if defined(CONFIG_NET_L2_PPP_PAP)
+	case PPP_PAP:
+		return &ctx->pap.fsm;
+#endif
+	default:
+		return NULL;
+	}
+}
+
 enum net_verdict ppp_fsm_recv_protocol_rej(struct ppp_fsm *fsm,
 					   uint8_t id,
 					   struct net_pkt *pkt)
 {
+	struct ppp_fsm *rejected_fsm;
+	uint16_t protocol;
+
 	NET_DBG("[%s/%p] Current state %s (%d)", fsm->name, fsm,
 		ppp_state_str(fsm->state), fsm->state);
 
-	return NET_DROP;
+	/* RFC 1661 chapter 5.7 - discard outside LCP Opened, don't Code-Reject */
+	if (fsm->state != PPP_OPENED) {
+		return NET_OK;
+	}
+
+	if (net_pkt_read_be16(pkt, &protocol) < 0) {
+		return NET_OK;
+	}
+
+	NET_DBG("[%s/%p] Peer rejected protocol %s (0x%04x)", fsm->name, fsm,
+		ppp_proto2str(protocol), protocol);
+
+	/* RFC 1661 chapter 4.2 - RXJ+: LCP stays up, rejected protocol must stop */
+	rejected_fsm = ppp_proto_fsm(ppp_fsm_ctx(fsm), protocol);
+	if (rejected_fsm != NULL && rejected_fsm->cb.proto_reject != NULL) {
+		rejected_fsm->cb.proto_reject(rejected_fsm);
+	}
+
+	return NET_OK;
 }
 
 enum net_verdict ppp_fsm_recv_echo_req(struct ppp_fsm *fsm,

--- a/tests/net/ppp/driver/src/main.c
+++ b/tests/net/ppp/driver/src/main.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_log.h>
 #include <zephyr/net/ppp.h>
+#include <zephyr/sys/byteorder.h>
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
@@ -41,6 +42,7 @@ typedef enum net_verdict (*ppp_l2_callback_t)(struct net_if *iface,
 					      struct net_pkt *pkt);
 void ppp_l2_register_pkt_cb(ppp_l2_callback_t cb); /* found in ppp_l2.c */
 void ppp_driver_feed_data(uint8_t *data, int data_len);
+void ppp_driver_register_send_cb(void (*cb)(struct net_pkt *pkt));
 
 static struct net_if *net_iface;
 
@@ -898,6 +900,187 @@ ZTEST(net_ppp_test_suite, test_net_ppp)
 	test_send_ppp_6();
 	test_send_ppp_7();
 	test_send_ppp_8();
+}
+
+#define TX_FRAME_COUNT 8
+#define TX_FRAME_LEN 64
+
+struct tx_frame {
+	uint16_t protocol;
+	uint8_t data[TX_FRAME_LEN];
+	size_t len;
+};
+
+static struct tx_frame tx_frames[TX_FRAME_COUNT];
+static int tx_frame_count;
+static bool tx_capture;
+
+static void ppp_tx_cb(struct net_pkt *pkt)
+{
+	uint8_t buf[sizeof(uint16_t) + TX_FRAME_LEN];
+	struct tx_frame *frame;
+	size_t len;
+
+	if (!tx_capture || tx_frame_count >= TX_FRAME_COUNT) {
+		return;
+	}
+
+	len = net_pkt_get_len(pkt);
+	if (len <= sizeof(uint16_t) || len > sizeof(buf)) {
+		return;
+	}
+
+	net_pkt_cursor_init(pkt);
+
+	if (net_pkt_read(pkt, buf, len) < 0) {
+		return;
+	}
+
+	net_pkt_cursor_init(pkt);
+
+	frame = &tx_frames[tx_frame_count++];
+	frame->protocol = sys_get_be16(buf);
+	frame->len = len - sizeof(uint16_t);
+	memcpy(frame->data, &buf[sizeof(uint16_t)], frame->len);
+}
+
+/* code 0 matches any code of the given protocol */
+static int tx_frames_count(uint16_t protocol, uint8_t code)
+{
+	int count = 0;
+
+	for (int i = 0; i < tx_frame_count; i++) {
+		if (tx_frames[i].protocol != protocol) {
+			continue;
+		}
+
+		if (code == 0U || tx_frames[i].data[0] == code) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+static struct tx_frame *tx_frames_get(uint16_t protocol, uint8_t code)
+{
+	for (int i = 0; i < tx_frame_count; i++) {
+		if (tx_frames[i].protocol == protocol &&
+		    tx_frames[i].data[0] == code) {
+			return &tx_frames[i];
+		}
+	}
+
+	return NULL;
+}
+
+static void feed_ppp_frame(const uint8_t *data, size_t len)
+{
+	uint8_t frame[TX_FRAME_LEN * 2];
+	uint8_t encoded[sizeof(frame) * 2 + 2];
+	size_t frame_len = 0;
+	size_t encoded_len = 0;
+	uint16_t fcs;
+
+	zassert_true(len + 4U <= sizeof(frame), "Frame too long");
+
+	frame[frame_len++] = 0xff;
+	frame[frame_len++] = 0x03;
+	memcpy(&frame[frame_len], data, len);
+	frame_len += len;
+
+	fcs = crc16_ccitt(0xffff, frame, frame_len) ^ 0xffff;
+	frame[frame_len++] = fcs & 0xff;
+	frame[frame_len++] = fcs >> 8;
+
+	encoded[encoded_len++] = 0x7e;
+
+	for (size_t i = 0; i < frame_len; i++) {
+		uint8_t byte = frame[i];
+
+		if (byte == 0x7e || byte == 0x7d || byte < 0x20) {
+			encoded[encoded_len++] = 0x7d;
+			encoded[encoded_len++] = byte ^ 0x20;
+		} else {
+			encoded[encoded_len++] = byte;
+		}
+	}
+
+	encoded[encoded_len++] = 0x7e;
+
+	ppp_driver_feed_data(encoded, encoded_len);
+}
+
+/* RFC 1661 chapter 5.7: Protocol-Reject must stop the protocol, not get a Code-Reject */
+ZTEST(net_ppp_test_suite, test_net_ppp_protocol_reject)
+{
+	struct tx_frame *ipv6cp_req;
+	struct ppp_context *ctx;
+	uint8_t rej[TX_FRAME_LEN];
+	size_t rej_len = 0;
+	uint16_t length;
+
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
+	zassert_not_null(net_iface, "PPP interface not found!");
+
+	ppp_l2_register_pkt_cb(NULL);
+	ppp_driver_register_send_cb(ppp_tx_cb);
+
+	ctx = net_if_l2_data(net_iface);
+
+	(void)net_if_up(net_iface);
+
+	tx_frame_count = 0;
+	tx_capture = true;
+
+	/* no peer here, so fake LCP Opened to let the NCPs start negotiating */
+	ppp_change_state(&ctx->lcp.fsm, PPP_OPENED);
+	ppp_link_established(ctx, &ctx->lcp.fsm);
+
+	k_sleep(K_MSEC(WAIT_TIME));
+
+	tx_capture = false;
+
+	ipv6cp_req = tx_frames_get(PPP_IPV6CP, PPP_CONFIGURE_REQ);
+	zassert_not_null(ipv6cp_req, "No IPV6CP Configure-Req sent");
+	zassert_true(tx_frames_count(PPP_IPCP, PPP_CONFIGURE_REQ) > 0,
+		     "No IPCP Configure-Req sent");
+
+	/* build a Protocol-Reject of IPV6CP, echoing back its Configure-Req */
+	length = 4U + sizeof(uint16_t) + ipv6cp_req->len;
+
+	sys_put_be16(PPP_LCP, &rej[rej_len]);
+	rej_len += sizeof(uint16_t);
+	rej[rej_len++] = PPP_PROTOCOL_REJ;
+	rej[rej_len++] = 0x42;
+	sys_put_be16(length, &rej[rej_len]);
+	rej_len += sizeof(uint16_t);
+	sys_put_be16(PPP_IPV6CP, &rej[rej_len]);
+	rej_len += sizeof(uint16_t);
+	memcpy(&rej[rej_len], ipv6cp_req->data, ipv6cp_req->len);
+	rej_len += ipv6cp_req->len;
+
+	tx_frame_count = 0;
+	tx_capture = true;
+
+	feed_ppp_frame(rej, rej_len);
+
+	/* longer than the FSM restart timer, so a retransmission would show up */
+	k_sleep(K_MSEC(CONFIG_NET_L2_PPP_TIMEOUT + WAIT_TIME));
+
+	tx_capture = false;
+
+	ppp_driver_register_send_cb(NULL);
+	ppp_l2_register_pkt_cb(ppp_l2_recv);
+
+	zexpect_equal(tx_frames_count(PPP_LCP, PPP_CODE_REJ), 0,
+		      "Code-Reject sent for a valid Protocol-Reject");
+	zexpect_equal(tx_frames_count(PPP_IPV6CP, 0), 0,
+		      "IPV6CP packet sent after Protocol-Reject");
+	zexpect_equal(ctx->ipv6cp.fsm.state, PPP_STARTING,
+		      "IPV6CP in state %d", ctx->ipv6cp.fsm.state);
+	zexpect_true(tx_frames_count(PPP_IPCP, PPP_CONFIGURE_REQ) > 0,
+		     "IPCP negotiation stopped after Protocol-Reject");
 }
 
 ZTEST_SUITE(net_ppp_test_suite, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
`ppp_fsm_recv_protocol_rej()` logged the LCP state and returned `NET_DROP`, so a received Protocol-Reject was ignored: the rejected protocol kept retransmitting until Max-Configure (RFC 1661 §5.7 says it MUST stop), and the fallthrough to `ppp_fsm_input()`'s default branch answered a valid Protocol-Reject with a Code-Reject.

Read the Rejected-Protocol field and dispatch to the matching FSM's `proto_reject` callback (already registered by IPCP/IPV6CP/PAP, never invoked). Per §4.2 a Protocol-Reject of a network-layer protocol is RXJ+ (LCP stays up); per §5.7 one outside LCP Opened is discarded. Matches pppd's `lcp_rprotrej()`.

Found running a Zephyr PPP client against a peer that rejects IPV6CP: link came up 30s late, and the client wrongly Code-Rejected a valid Protocol-Reject.

Note: `ppp_fsm_proto_reject()` in fsm.c is unused — that's the RXJ- (Protocol-Reject of LCP itself) case, not this one.

Verified: `west twister -p mps2/an385 -T tests/net/ppp/driver` — 4/4 pass; fails on both assertions with the fix reverted. checkpatch clean.
