### PR TITLE
drivers: espi: xec: fix inverted boot load done acknowledge condition

### DIFF
--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -632,7 +632,10 @@ static void send_slave_bootdone(const struct device *dev)
 	uint8_t boot_done = false;
 
 	ret = espi_xec_receive_vwire(dev, ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE, &boot_done);
-	if ((ret == 0) && (boot_done == true)) {
+	/* Send boot load status + done only if the host has not already seen
+	 * them set.
+	 */
+	if ((ret == 0) && (boot_done == false)) {
 		/* SLAVE_BOOT_DONE & SLAVE_LOAD_STS have to be sent together */
 		espi_xec_send_vwire(dev, ESPI_VWIRE_SIGNAL_TARGET_BOOT_STS, 1);
 		espi_xec_send_vwire(dev, ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE, 1);


### PR DESCRIPTION
This change is fixing issue where send_slave_bootdone() only sent the SLAVE_BOOT_LOAD_STATUS and SLAVE_BOOT_LOAD_DONE virtual wires when BOOT_LOAD_DONE was already asserted (boot_done == true). On targets that boot from the master attached flash (MAF) the boot ROM asserts these wires, so this re-affirmation happened to work. On targets that boot from their own flash (non-MAF) the boot ROM never sets them, so boot_done reads 0 and the driver sent nothing. The eSPI host then never receives the boot load done handshake, holds the platform in S5, and SLP_S5# is never de-asserted, so the system fails to power on.

Send the status and done wires when they have not yet been asserted (boot_done == false). This keeps MAF boot working (no resend needed) while fixing non-MAF boot.