### PR TITLE
Bluetooth: HCI: fix net_buf double-free in bt_hci_recv_err

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -495,6 +495,11 @@ static void process_rx(uint8_t packetType, uint8_t *data, uint16_t len)
 
 K_MSGQ_DEFINE_STATIC_TYPE(rx_msgq, struct hci_data, CONFIG_HCI_NXP_RX_MSG_QUEUE_SIZE);
 
+/* Semaphore used by bt_nxp_rx_drain() to wait until bt_rx_thread has
+ * acknowledged the drain sentinel.
+ */
+static K_SEM_DEFINE(rx_drain_sem, 0, 1);
+
 static void bt_rx_thread(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
@@ -508,6 +513,15 @@ static void bt_rx_thread(void *p1, void *p2, void *p3)
 			LOG_ERR("Failed to get RX data from message queue");
 			continue;
 		}
+		/* A sentinel frame (data == NULL) is posted by bt_nxp_rx_drain()
+		 * to mark the boundary between pre-close and post-open frames.
+		 * Acknowledge it and skip process_rx() so that close() knows all
+		 * earlier frames have been fully processed.
+		 */
+		if (hci_rx_frame.data == NULL) {
+			k_sem_give(&rx_drain_sem);
+			continue;
+		}
 		process_rx(hci_rx_frame.packetType, hci_rx_frame.data, hci_rx_frame.len);
 		k_free(hci_rx_frame.data);
 	}
@@ -515,6 +529,34 @@ static void bt_rx_thread(void *p1, void *p2, void *p3)
 
 K_THREAD_DEFINE(nxp_hci_rx_thread, CONFIG_BT_DRV_RX_STACK_SIZE, bt_rx_thread, NULL, NULL, NULL,
 		K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, 0);
+
+/* Drain all frames that bt_rx_thread may be holding or that are buffered
+ * in rx_msgq, then wait until the thread acknowledges the drain barrier.
+ *
+ * When bt_rx_thread is blocked in k_msgq_get(K_FOREVER), k_msgq_put()
+ * copies the frame directly into the thread's stack buffer without
+ * incrementing msgq->used_msgs (kernel/msg_q.c).  A K_NO_WAIT drain
+ * loop therefore misses any frame the thread already holds.  To close
+ * this gap: drain the queue buffer first, then post a sentinel frame
+ * (data == NULL) with K_FOREVER.  Because the queue is FIFO, when
+ * bt_rx_thread dequeues the sentinel it has already processed every
+ * frame that arrived before close.  Waiting on rx_drain_sem guarantees
+ * that no pre-close packet can escape into the next session.
+ */
+static void bt_nxp_rx_drain(void)
+{
+	struct hci_data hci_rx_frame;
+	struct hci_data sentinel = {0}; /* data == NULL marks the drain barrier */
+
+	/* Free any frames sitting in the queue buffer. */
+	while (k_msgq_get(&rx_msgq, &hci_rx_frame, K_NO_WAIT) == 0) {
+		k_free(hci_rx_frame.data);
+	}
+
+	/* Post the sentinel and wait for bt_rx_thread to acknowledge it. */
+	(void)k_msgq_put(&rx_msgq, &sentinel, K_FOREVER);
+	k_sem_take(&rx_drain_sem, K_FOREVER);
+}
 
 static void hci_rx_cb(uint8_t packetType, uint8_t *data, uint16_t len)
 {
@@ -783,6 +825,17 @@ int bt_nxp_setup(const struct device *dev, const struct bt_hci_setup_params *par
 
 static int bt_nxp_close(const struct device *dev)
 {
+	int err;
+
+	err = PLATFORM_SetHciRxCallback(NULL);
+	if (err != 0) {
+		return err;
+	}
+
+#if defined(CONFIG_HCI_NXP_RX_THREAD)
+	bt_nxp_rx_drain();
+#endif /* CONFIG_HCI_NXP_RX_THREAD */
+
 	return 0;
 }
 

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -221,7 +221,6 @@ static inline int bt_hci_recv_err(const struct device *dev, struct net_buf *buf)
 	struct bt_hci_driver_data *data = dev->data;
 
 	if (data->recv == NULL) {
-		net_buf_unref(buf);
 		return -ENOTCONN;
 	}
 


### PR DESCRIPTION
bt_hci_recv_err() called net_buf_unref(buf) and returned -ENOTCONN when data->recv was NULL (i.e. after bt_hci_close() cleared the recv callback). Any caller that checks the return value and unrefs on error would then free the buffer a second time.

This is a regression introduced by commit 91f9bf6 (Bluetooth: Remove error return from bt_hci_recv()), which turned bt_hci_recv() into a wrapper that always unrefs on non-zero return from bt_hci_recv_err(). The controller's cmd_handle(), acl_handle() and iso_handle() already unref on non-zero return from bt_recv_prio()/bt_recv() so they had the
same double-free on -ENOTCONN.

Fix the double-free by removing the net_buf_unref() call from the data->recv == NULL path. The function already signals the error to its caller via the -ENOTCONN return value, and the API contract states that on error the caller still owns the reference.

The prio_recv_thread() call sites in hci_driver.c are not affected: bt_hci_open() sets data->recv before the threads start and hci_driver_close() aborts them before bt_hci_close() clears it, so data->recv == NULL is unreachable there.

bt_nxp_close() was a no-op, violating the bt_hci_close() contract that requires the transport to be fully closed before the function returns. After bt_hci_close() cleared data->recv, the NXP HAL could still fire the RX callback, and on a quick reopen stale packets could be delivered into the new session.

Deregister the HCI RX callback via PLATFORM_SetHciRxCallback(NULL) and propagate any error so bt_hci_close() only clears data->recv after the transport is confirmed closed. With CONFIG_HCI_NXP_RX_THREAD, a plain K_NO_WAIT drain loop is not sufficient: when bt_rx_thread is blocked in k_msgq_get(K_FOREVER), k_msgq_put() hands the frame directly into the thread's stack buffer without touching msgq->used_msgs, so the drain misses any frame the thread already holds. Add bt_nxp_rx_drain(): flush buffered frames, post a sentinel (data == NULL) with K_FOREVER, and wait on rx_drain_sem until bt_rx_thread acknowledges it. Because the queue is FIFO, the acknowledgement guarantees every pre-close frame has
been processed before close returns.