### PR TITLE
net: arp: Update a known cache entry from any accepted ARP message

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -522,23 +522,32 @@ int net_arp_prepare(struct net_pkt *pkt,
 	return NET_ARP_COMPLETE;
 }
 
-static void arp_gratuitous(struct net_if *iface,
-			   struct net_in_addr *src,
-			   struct net_eth_addr *hwaddr)
+/* RFC 826 tells to update the hardware address of an already known sender
+ * whenever we accept an ARP message from it, no matter what the operation
+ * code of that message is. Only an existing entry is refreshed here, a new
+ * one is never created.
+ */
+static bool arp_entry_update(struct net_if *iface,
+			     struct net_in_addr *src,
+			     struct net_eth_addr *hwaddr)
 {
 	sys_snode_t *prev = NULL;
 	struct arp_entry *entry;
 
 	entry = arp_entry_find(&arp_table, iface, src, &prev);
-	if (entry) {
-		NET_DBG("Gratuitous ARP hwaddr %s -> %s",
-			net_sprint_ll_addr((const uint8_t *)&entry->eth,
-					   sizeof(struct net_eth_addr)),
-			net_sprint_ll_addr((const uint8_t *)hwaddr,
-					   sizeof(struct net_eth_addr)));
-
-		memcpy(&entry->eth, hwaddr, sizeof(struct net_eth_addr));
+	if (entry == NULL) {
+		return false;
 	}
+
+	NET_DBG("Update ARP hwaddr %s -> %s",
+		net_sprint_ll_addr((const uint8_t *)&entry->eth,
+				   sizeof(struct net_eth_addr)),
+		net_sprint_ll_addr((const uint8_t *)hwaddr,
+				   sizeof(struct net_eth_addr)));
+
+	memcpy(&entry->eth, hwaddr, sizeof(struct net_eth_addr));
+
+	return true;
 }
 
 #if defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION)
@@ -700,35 +709,24 @@ void net_arp_update(struct net_if *iface,
 
 	entry = arp_entry_get_pending(iface, src);
 	if (!entry) {
-		if (IS_ENABLED(CONFIG_NET_ARP_GRATUITOUS) && gratuitous) {
-			arp_gratuitous(iface, src, hwaddr);
-		}
-
-		if (force) {
-			sys_snode_t *prev = NULL;
+		if (!arp_entry_update(iface, src, hwaddr) && force) {
+			/* Add new entry as it was not found and force
+			 * was set.
+			 */
 			struct arp_entry *arp_ent;
 
-			arp_ent = arp_entry_find(&arp_table, iface, src, &prev);
-			if (arp_ent) {
-				memcpy(&arp_ent->eth, hwaddr,
-				       sizeof(struct net_eth_addr));
-			} else {
-				/* Add new entry as it was not found and force
-				 * was set.
-				 */
-				arp_ent = arp_entry_get_free();
-				if (!arp_ent) {
-					/* Then let's take one from table? */
-					arp_ent = arp_entry_get_last_from_table();
-				}
+			arp_ent = arp_entry_get_free();
+			if (arp_ent == NULL) {
+				/* Then let's take one from table? */
+				arp_ent = arp_entry_get_last_from_table();
+			}
 
-				if (arp_ent) {
-					arp_ent->req_start = k_uptime_get_32();
-					arp_ent->iface = iface;
-					net_ipaddr_copy(&arp_ent->ip, src);
-					memcpy(&arp_ent->eth, hwaddr, sizeof(arp_ent->eth));
-					sys_slist_prepend(&arp_table, &arp_ent->node);
-				}
+			if (arp_ent != NULL) {
+				arp_ent->req_start = k_uptime_get_32();
+				arp_ent->iface = iface;
+				net_ipaddr_copy(&arp_ent->ip, src);
+				memcpy(&arp_ent->eth, hwaddr, sizeof(arp_ent->eth));
+				sys_slist_prepend(&arp_table, &arp_ent->node);
 			}
 		}
 

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -696,7 +696,6 @@ static void arp_gratuitous_work_handler(struct k_work *work)
 void net_arp_update(struct net_if *iface,
 		    struct net_in_addr *src,
 		    struct net_eth_addr *hwaddr,
-		    bool gratuitous,
 		    bool force)
 {
 	struct arp_entry *entry;
@@ -880,8 +879,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 				net_ipv4_addr_copy_raw(src_ipaddr.s4_addr,
 						       arp_hdr->src_ipaddr);
 				net_arp_update(net_pkt_iface(pkt), &src_ipaddr,
-					       &arp_hdr->src_hwaddr,
-					       true, false);
+					       &arp_hdr->src_hwaddr, false);
 				break;
 			}
 		}
@@ -923,8 +921,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 			net_ipv4_addr_copy_raw(src_ipaddr.s4_addr,
 					       arp_hdr->src_ipaddr);
 			net_arp_update(net_pkt_iface(pkt), &src_ipaddr,
-				       &arp_hdr->src_hwaddr,
-				       false, true);
+				       &arp_hdr->src_hwaddr, true);
 
 			dst_hw_addr = &arp_hdr->src_hwaddr;
 		} else {
@@ -950,8 +947,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 			net_ipv4_addr_copy_raw(src_ipaddr.s4_addr,
 					       arp_hdr->src_ipaddr);
 			net_arp_update(net_pkt_iface(pkt), &src_ipaddr,
-				       &arp_hdr->src_hwaddr,
-				       false, false);
+				       &arp_hdr->src_hwaddr, false);
 		}
 
 		break;

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -90,8 +90,7 @@ int net_arp_foreach(net_arp_cb_t cb, void *user_data);
 void net_arp_clear_cache(struct net_if *iface);
 void net_arp_init(void);
 void net_arp_update(struct net_if *iface, struct net_in_addr *src,
-		    struct net_eth_addr *hwaddr, bool gratuitous,
-		    bool force);
+		    struct net_eth_addr *hwaddr, bool force);
 
 
 #else /* CONFIG_NET_ARP */

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -677,7 +677,7 @@ static int dhcpv4_send(struct dhcpv4_server_ctx *ctx, enum net_dhcpv4_msg_type t
 		struct net_eth_addr hwaddr;
 
 		memcpy(&hwaddr, msg->chaddr, sizeof(hwaddr));
-		net_arp_update(ctx->iface, yiaddr, &hwaddr, false, true);
+		net_arp_update(ctx->iface, yiaddr, &hwaddr, true);
 		dst_addr.sin_addr = *yiaddr;
 	} else {
 		NET_ERR("Unspecified destination address.");

--- a/subsys/net/lib/shell/arp.c
+++ b/subsys/net/lib/shell/arp.c
@@ -136,7 +136,7 @@ static int cmd_net_arp_add(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	net_arp_update(iface, &ip, &eth, false, true);
+	net_arp_update(iface, &ip, &eth, true);
 	PR("Added static ARP entry %s -> %s on interface %d\n", net_sprint_ipv4_addr(&ip),
 	   net_sprint_ll_addr(eth.addr, sizeof(eth.addr)), net_if_get_by_iface(iface));
 	return 0;

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -783,4 +783,134 @@ ZTEST(arp_fn_tests, test_bcast_hwaddr_unicast_ipaddr)
 			unicast_ipaddr, true);
 }
 
+static void arp_cb_ip_only(struct arp_entry *entry, void *user_data)
+{
+	struct net_in_addr *addr = user_data;
+
+	if (memcmp(&entry->ip, addr, sizeof(struct net_in_addr)) == 0) {
+		entry_found = true;
+	}
+}
+
+/* Craft an ARP message with the given opcode and addresses and feed it to the
+ * ARP input handler the way the Ethernet L2 would.
+ */
+static enum net_verdict recv_arp_msg(struct net_if *iface, uint16_t opcode,
+				     const struct net_in_addr *src_ip,
+				     const struct net_eth_addr *src_hwaddr,
+				     const struct net_in_addr *dst_ip,
+				     const struct net_eth_addr *dst_hwaddr,
+				     const struct net_eth_addr *eth_dst)
+{
+	struct net_arp_hdr *arp_hdr;
+	enum net_verdict verdict;
+	struct net_pkt *pkt;
+
+	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct net_eth_hdr) +
+					sizeof(struct net_arp_hdr),
+					NET_AF_UNSPEC, 0, K_SECONDS(1));
+	zassert_not_null(pkt, "out of mem");
+
+	setup_eth_header(iface, pkt, eth_dst, NET_ETH_PTYPE_ARP);
+
+	net_buf_add(pkt->buffer, sizeof(struct net_eth_hdr));
+	net_buf_pull(pkt->buffer, sizeof(struct net_eth_hdr));
+
+	arp_hdr = NET_ARP_HDR(pkt);
+
+	arp_hdr->hwtype = net_htons(NET_ARP_HTYPE_ETH);
+	arp_hdr->protocol = net_htons(NET_ETH_PTYPE_IP);
+	arp_hdr->hwlen = sizeof(struct net_eth_addr);
+	arp_hdr->protolen = sizeof(struct net_in_addr);
+	arp_hdr->opcode = net_htons(opcode);
+
+	memcpy(&arp_hdr->src_hwaddr, src_hwaddr, sizeof(struct net_eth_addr));
+	memcpy(&arp_hdr->dst_hwaddr, dst_hwaddr, sizeof(struct net_eth_addr));
+	net_ipv4_addr_copy_raw(arp_hdr->src_ipaddr, (const uint8_t *)src_ip);
+	net_ipv4_addr_copy_raw(arp_hdr->dst_ipaddr, (const uint8_t *)dst_ip);
+
+	net_buf_add(pkt->buffer, sizeof(struct net_arp_hdr));
+
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_ARP);
+
+	verdict = net_arp_input(pkt, (struct net_eth_addr *)src_hwaddr,
+				(struct net_eth_addr *)eth_dst);
+	if (verdict == NET_DROP) {
+		net_pkt_unref(pkt);
+	}
+
+	return verdict;
+}
+
+/* A peer whose link address changed can announce itself with an ARP reply we
+ * never solicited. As the peer is already in our cache, that reply must
+ * refresh it instead of being ignored, otherwise we keep sending to the old
+ * link address forever.
+ */
+ZTEST(arp_fn_tests, test_arp_msg_updates_known_entry)
+{
+	struct net_eth_addr hwaddr_old = { { 0x02, 0x00, 0x5e, 0x11, 0x22, 0x33 } };
+	struct net_eth_addr hwaddr_new = { { 0x02, 0x00, 0x5e, 0x44, 0x55, 0x66 } };
+	struct net_eth_addr zero_hwaddr = { { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } };
+	struct net_in_addr peer = { { { 192, 0, 2, 2 } } };
+	struct net_in_addr unknown = { { { 192, 0, 2, 3 } } };
+	struct net_in_addr src = { { { 192, 0, 2, 1 } } };
+	struct net_eth_addr *our_hwaddr;
+	struct net_if_addr *ifaddr;
+	enum net_verdict verdict;
+	struct net_if *iface;
+
+	iface = net_if_lookup_by_dev(DEVICE_GET(net_arp_test));
+	zassert_not_null(iface, "No ARP test interface");
+
+	ifaddr = net_if_ipv4_addr_add(iface, &src, NET_ADDR_MANUAL, 0);
+	zassert_not_null(ifaddr, "Cannot add address");
+	ifaddr->addr_state = NET_ADDR_PREFERRED;
+
+	our_hwaddr = (struct net_eth_addr *)net_if_get_link_addr(iface)->addr;
+
+	req_test = true;
+
+	net_arp_clear_cache(iface);
+
+	/* Learn the peer from an ordinary broadcast ARP request asking for our
+	 * address. This is the path that keeps the cache fresh for any peer
+	 * that sends something to us.
+	 */
+	verdict = recv_arp_msg(iface, NET_ARP_REQUEST, &peer, &hwaddr_old,
+			       &src, &zero_hwaddr, net_eth_broadcast_addr());
+	zassert_not_equal(verdict, NET_DROP, "ARP request was dropped");
+
+	/* Yielding so that network interface TX thread can proceed. */
+	k_yield();
+
+	entry_found = false;
+	expected_hwaddr = &hwaddr_old;
+	net_arp_foreach(arp_cb, &peer);
+	zassert_true(entry_found, "Peer was not added to the ARP cache");
+
+	/* The same peer now announces a new link address with an ARP reply
+	 * that we did not solicit.
+	 */
+	verdict = recv_arp_msg(iface, NET_ARP_REPLY, &peer, &hwaddr_new,
+			       &src, our_hwaddr, our_hwaddr);
+	zexpect_not_equal(verdict, NET_DROP, "ARP reply was dropped");
+
+	entry_found = false;
+	expected_hwaddr = &hwaddr_new;
+	net_arp_foreach(arp_cb, &peer);
+	zexpect_true(entry_found, "ARP reply did not update the cache entry");
+
+	/* A reply from a peer we know nothing about must not add an entry, we
+	 * only refresh what we already have.
+	 */
+	verdict = recv_arp_msg(iface, NET_ARP_REPLY, &unknown, &hwaddr_new,
+			       &src, our_hwaddr, our_hwaddr);
+	zexpect_not_equal(verdict, NET_DROP, "ARP reply was dropped");
+
+	entry_found = false;
+	net_arp_foreach(arp_cb_ip_only, &unknown);
+	zexpect_false(entry_found, "Unsolicited ARP reply created a cache entry");
+}
+
 ZTEST_SUITE(arp_fn_tests, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -500,7 +500,7 @@ static void test_local_ipv4_tx_unicast(void)
 	/* Seed the bridge ARP cache as if the peer had already been resolved
 	 * (this is what an incoming SYN/ARP from the peer would have done).
 	 */
-	net_arp_update(bridge, &peer_ip, &peer_mac, false, true);
+	net_arp_update(bridge, &peer_ip, &peer_mac, true);
 
 	send_local_ipv4(&peer_ip);
 
@@ -542,7 +542,7 @@ static void test_local_ipv4_tx_unicast_arp_miss(void)
 	/* Simulate the peer's ARP reply arriving: this resolves the entry and
 	 * flushes the queued packet back through the bridge TX path.
 	 */
-	net_arp_update(bridge, &peer_ip, &peer_mac, false, false);
+	net_arp_update(bridge, &peer_ip, &peer_mac, false);
 
 	/* give time to the processing threads to run */
 	k_sleep(K_MSEC(100));

--- a/tests/net/route/ipv4/src/main.c
+++ b/tests/net/route/ipv4/src/main.c
@@ -664,8 +664,7 @@ static void test_route_ipv4_forward_packet_between_ifaces(void)
 				   NET_ROUTE_PREFERENCE_HIGH);
 	zassert_not_null(route, "Forwarding route add failed");
 
-	net_arp_update(my_iface_alt, &gateway_addr_alt, &gateway_lladdr_alt,
-		      false, true);
+	net_arp_update(my_iface_alt, &gateway_addr_alt, &gateway_lladdr_alt, true);
 
 	reset_send_state();
 	drain_wait_data();
@@ -775,8 +774,7 @@ static void test_route_ipv4_forward_onlink_packet_between_ifaces(void)
 	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV4_FORWARDING);
 
 	net_arp_clear_cache(my_iface_alt);
-	net_arp_update(my_iface_alt, &onlink_dest_addr_alt, &gateway_lladdr_alt,
-		       false, true);
+	net_arp_update(my_iface_alt, &onlink_dest_addr_alt, &gateway_lladdr_alt, true);
 
 	reset_send_state();
 	drain_wait_data();
@@ -837,8 +835,7 @@ static void test_route_ipv4_forward_onlink_ttl_expired_drops(void)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV4_FORWARDING);
 
-	net_arp_update(my_iface_alt, &onlink_dest_addr_alt, &gateway_lladdr_alt,
-		       false, true);
+	net_arp_update(my_iface_alt, &onlink_dest_addr_alt, &gateway_lladdr_alt, true);
 
 	reset_send_state();
 	drain_wait_data();
@@ -930,8 +927,7 @@ static void test_route_ipv4_input_onlink_routes_via_matching_iface(void)
 	 * honors the NULL "search all interfaces" contract.
 	 */
 	net_arp_clear_cache(my_iface_alt);
-	net_arp_update(my_iface_alt, &onlink_input_dest, &onlink_input_lladdr,
-		       false, true);
+	net_arp_update(my_iface_alt, &onlink_input_dest, &onlink_input_lladdr, true);
 
 	reset_send_state();
 	drain_wait_data();


### PR DESCRIPTION
An ARP reply that we did not solicit was silently discarded. In
net_arp_update() the pending entry lookup fails for such a reply, and
with neither the gratuitous nor the force flag set the function returned
without touching the cache. A peer whose link address changed could
therefore announce itself with an ARP reply and we would keep sending to
the address we learnt earlier.

RFC 826 asks for the opposite: whenever we accept an ARP message and the
sender protocol address is already in our translation table, the hardware
address stored in it is to be updated, regardless of the operation code
of that message. Only the gratuitous ARP request path did that so far.
