### PR TITLE
drivers: xen: add grant table query size helper

### DIFF
--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -411,16 +411,16 @@ const char *gnttabop_error(int16_t status)
 static unsigned long gnttab_get_max_frames(void)
 {
 	int ret;
-	struct gnttab_query_size q = {
-		.dom = DOMID_SELF,
-	};
+	uint32_t nr_frames;
+	uint32_t max_nr_frames;
+	int16_t status;
 
-	ret = HYPERVISOR_grant_table_op(GNTTABOP_query_size, &q, 1);
-	if ((ret < 0) || (q.status != GNTST_okay)) {
+	ret = gnttab_query_size(DOMID_SELF, &nr_frames, &max_nr_frames, &status);
+	if ((ret < 0) || (status != GNTST_okay)) {
 		return LEGACY_MAX_GNT_FRAMES_SUPPORTED;
 	}
 
-	return q.max_nr_frames;
+	return max_nr_frames;
 }
 
 static int gnttab_init(void)

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -374,6 +374,25 @@ int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int cou
 	return HYPERVISOR_grant_table_op(GNTTABOP_unmap_grant_ref, unmap_ops, count);
 }
 
+int gnttab_query_size(domid_t dom, uint32_t *nr_frames, uint32_t *max_nr_frames,
+		      int16_t *status)
+{
+	struct gnttab_query_size query = {
+		.dom = dom,
+	};
+	int ret;
+
+	if (!nr_frames || !max_nr_frames || !status) {
+		return -EINVAL;
+	}
+
+	ret = HYPERVISOR_grant_table_op(GNTTABOP_query_size, &query, 1);
+	*nr_frames = query.nr_frames;
+	*max_nr_frames = query.max_nr_frames;
+	*status = query.status;
+
+	return ret;
+}
 
 static const char * const gnttab_error_msgs[] = GNTTABOP_error_msgs;
 

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -136,6 +136,22 @@ int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count);
 int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count);
 
 /**
+ * @brief Query current and maximum grant table size for a domain.
+ *
+ * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}
+ *
+ * @param dom Domain whose grant table size should be queried. Use
+ *        ``DOMID_SELF`` for the calling domain.
+ * @param nr_frames Storage where Xen writes the current frame count.
+ * @param max_nr_frames Storage where Xen writes the maximum frame count.
+ * @param status Storage where Xen writes the ``GNTST_*`` operation status.
+ *
+ * @return Zero on hypercall success, negative errno value on failure.
+ */
+int gnttab_query_size(domid_t dom, uint32_t *nr_frames, uint32_t *max_nr_frames,
+		      int16_t *status);
+
+/**
  * @brief Convert a Xen grant-table status into readable text.
  *
  * @kconfig_dep{CONFIG_XEN_GRANT_TABLE}


### PR DESCRIPTION
drivers: xen: add grant table query size helper
Add gnttab_query_size() to expose GNTTABOP_query_size through the
public Xen grant table helper API.

The helper accepts operation arguments directly, builds the Xen ABI
request internally, and returns the per-operation GNTST_* status through
an output parameter.

----

drivers: xen: use grant table query size helper
Use gnttab_query_size() in the grant table initialization path instead
of calling the low-level grant table hypercall entry point directly.

This keeps the existing max-frame fallback behavior while making the
driver use the public grant table helper API for the operation it
performs during initialization.