### PR TITLE
drivers: wifi: nxp: remove unused debug Kconfig options

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1301,6 +1301,12 @@ config NXP_WIFI_NET_DEBUG
 	help
 	  If you enable this the network driver abstraction APIs debugs will be enabled.
 
+config NXP_WIFI_SUPP_DEBUG
+	bool "Supplicant interface debug"
+	default y if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_DBG
+	help
+	  If you enable this the supplicant interface debugs will be enabled.
+
 config NXP_WIFI_WLCMGR_DEBUG
 	bool "Wireless Connection Manager"
 	help

--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1296,28 +1296,13 @@ config NXP_WIFI_ENABLE_WARNING_LOGS
 	  recommended to keep it enabled during development, to quickly
 	  localize problems.
 
-config NXP_WIFI_DEBUG_BUILD
-	bool "Debug build"
-	depends on WIFI_LOG_LEVEL_DBG
-	help
-	  If you enable this the debug options will be
-	  enabled. Asserts will be also be enabled.
-
-config NXP_WIFI_OS_DEBUG
-	bool "OS debug"
-	depends on NXP_WIFI_DEBUG_BUILD
-	help
-	  If you enable this the OS abstraction APIs debugs will be enabled.
-
 config NXP_WIFI_NET_DEBUG
 	bool "NET debug"
-	depends on NXP_WIFI_DEBUG_BUILD
 	help
 	  If you enable this the network driver abstraction APIs debugs will be enabled.
 
 config NXP_WIFI_WLCMGR_DEBUG
 	bool "Wireless Connection Manager"
-	depends on NXP_WIFI_DEBUG_BUILD
 	help
 	  If you enable this the WLAN Connection Manager APIs debugs will be enabled.
 


### PR DESCRIPTION
Remove NXP_WIFI_DEBUG_BUILD, NXP_WIFI_OS_DEBUG
Kconfig options that are not referenced
anywhere in the source code. Also remove the depends on
NXP_WIFI_DEBUG_BUILD from NXP_WIFI_WLCMGR_DEBUG so that
individual debug options can be enabled independently
without the unnecessary intermediate toggle.