### PR TITLE
boards: realtek: rtl87x2g: set flash controller

### DIFF
--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_common.dtsi
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_common.dtsi
@@ -10,6 +10,7 @@
 	chosen {
 		zephyr,sram = &tcm0;
 		zephyr,flash = &flash;
+		zephyr,flash-controller = &fmc;
 		zephyr,code-partition = &app_partition;
 		zephyr,itcm = &tcm1;
 		zephyr,console = &uart2;


### PR DESCRIPTION
Set the FMC node as the chosen Zephyr flash controller for the RTL87x2G
Model A evaluation board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)