### PR TITLE
drivers: usb: dwc2: nrf: Set PHY.CONFIG value

### DIFF
--- a/drivers/usb/common/nordic/nrf_usbhs_phy_config.h
+++ b/drivers/usb/common/nordic/nrf_usbhs_phy_config.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+#ifndef NRF_USBHS_PHY_CONFIG_H__
+#define NRF_USBHS_PHY_CONFIG_H__
+
+/* This macro works for both types, because differences between Type1 and Type2
+ * are covered by devicetree bindings having different enum values and defaults.
+ */
+#define PHY_CONFIG_VALUE(node)                                                                     \
+	(0 << USBHS_PHY_CONFIG_PLLITUNE_Pos)                                                      |\
+	(0xC << USBHS_PHY_CONFIG_PLLPTUNE_Pos)                                                    |\
+	(DT_ENUM_IDX(node, compdistune) << USBHS_PHY_CONFIG_COMPDISTUNE0_Pos)                     |\
+	(DT_ENUM_IDX(node, sqrxtune) << USBHS_PHY_CONFIG_SQRXTUNE0_Pos)                           |\
+	(DT_ENUM_IDX(node, vdatreftune) << USBHS_PHY_CONFIG_VDATREFTUNE0_Pos)                     |\
+	((1 + DT_ENUM_IDX(node, txhsxvtune)) << USBHS_PHY_CONFIG_TXHSXVTUNE0_Pos)                 |\
+	(BIT_MASK(DT_ENUM_IDX(node, txfslstune)) << USBHS_PHY_CONFIG_TXFSLSTUNE0_Pos)             |\
+	(DT_ENUM_IDX(node, txvreftune) << USBHS_PHY_CONFIG_TXVREFTUNE0_Pos)                       |\
+	(DT_ENUM_IDX(node, txrisetune) << USBHS_PHY_CONFIG_TXRISETUNE0_Pos)                       |\
+	(DT_ENUM_IDX(node, txrestune) << USBHS_PHY_CONFIG_TXRESTUNE0_Pos)                         |\
+	(DT_ENUM_IDX(node, txpreempamptune) << USBHS_PHY_CONFIG_TXPREEMPAMPTUNE0_Pos)             |\
+	(DT_ENUM_IDX(node, txpreemppulsetune) << USBHS_PHY_CONFIG_TXPREEMPPULSETUNE0_Pos)
+
+#define PHY_CONFIG(node)                                                                           \
+	COND_CASE_1(DT_NODE_HAS_COMPAT(node, nordic_nrf_usbhs_phy_type1), (PHY_CONFIG_VALUE(node)),\
+		    DT_NODE_HAS_COMPAT(node, nordic_nrf_usbhs_phy_type2), (PHY_CONFIG_VALUE(node)),\
+		    (ZERO_OR_COMPILE_ERROR(0)))
+
+#endif /* NRF_USBHS_PHY_CONFIG_H__ */
+
+/** @endcond */

--- a/drivers/usb/common/nordic/nrf_usbhs_wrapper.c
+++ b/drivers/usb/common/nordic/nrf_usbhs_wrapper.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/regulator.h>
+#include <nrf_usbhs_phy_config.h>
 #include <nrf_usbhs_wrapper.h>
 
 #include <zephyr/logging/log.h>
@@ -42,6 +43,7 @@ static const char *const bc12_state_str[] = {
 struct usbhs_wrapper_config {
 	NRF_USBHS_Type *base;
 	const struct device *vregusb_dev;
+	uint32_t phy_config;
 };
 
 struct nrf_usbhs_wrapper_data {
@@ -133,6 +135,9 @@ static void wrapper_enable_core_internal(const struct device *dev)
 
 	/* Power up peripheral */
 	wrapper->ENABLE = USBHS_ENABLE_CORE_Msk;
+
+	/* Set PHY strapping options */
+	wrapper->PHY.CONFIG = config->phy_config;
 
 	/* Set role to Device, force D+ pull-up off by overriding VBUS valid signal */
 	wrapper->PHY.OVERRIDEVALUES = USBHS_PHY_OVERRIDEVALUES_ID_Msk;
@@ -483,6 +488,7 @@ static int usbhs_wrapper_init(const struct device *dev)
 	static const struct usbhs_wrapper_config usbhs_wrapper_config_##n = {	\
 		.base = (void *)(DT_INST_REG_ADDR(n)),				\
 		.vregusb_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, regulator)),	\
+		.phy_config = PHY_CONFIG(DT_INST_PHANDLE(n, phy)),		\
 	};									\
 										\
 	static struct nrf_usbhs_wrapper_data usbhs_wrapper_data_##n;		\

--- a/drivers/usb/udc/udc_dwc2_nrf_usbhs.h
+++ b/drivers/usb/udc/udc_dwc2_nrf_usbhs.h
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 #include <nrfs_backend_ipc_service.h>
 #include <nrfs_usb.h>
+#include "../common/nordic/nrf_usbhs_phy_config.h"
 
 #define USBHS_DT_WRAPPER_REG_ADDR(n) UINT_TO_POINTER(DT_INST_REG_ADDR_BY_NAME(n, wrapper))
 
@@ -21,6 +22,8 @@
  */
 static K_EVENT_DEFINE(usbhs_events);
 #define USBHS_VBUS_READY	BIT(0)
+
+const static uint32_t phy_config = PHY_CONFIG(DT_INST_PROP(0, phy));
 
 static void usbhs_vbus_handler(nrfs_usb_evt_t const *p_evt, void *const context)
 {
@@ -96,6 +99,13 @@ static inline int usbhs_enable_core(const struct device *dev)
 		}
 	}
 
+	/* Power up peripheral */
+	wrapper->ENABLE = USBHS_ENABLE_CORE_Msk;
+
+	/* Set PHY strapping options */
+	wrapper->PHY.CONFIG = phy_config;
+
+	/* Release PHY power-on reset */
 	wrapper->ENABLE = USBHS_ENABLE_PHY_Msk | USBHS_ENABLE_CORE_Msk;
 
 	/* Wait for PHY clock to start */

--- a/dts/bindings/usb/nordic,nrf-usbhs-phy-type1.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbhs-phy-type1.yaml
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic USBHS Type 1 PHY configuration
+
+compatible: "nordic,nrf-usbhs-phy-type1"
+
+include: base.yaml
+
+properties:
+  compdistune:
+    type: string
+    default: "0"
+    enum:
+      - "-7.86%"
+      - "-5.33%"
+      - "-2.86%"
+      - "0"
+      - "+2.67%"
+      - "+6.25%"
+      - "+9.78%"
+      - "+13.93%"
+    description: |
+      Disconnect Threshold Adjustment.
+      Adjusts the voltage level for the threshold used to detect a disconnect
+      event at the host.
+
+  sqrxtune:
+    type: string
+    default: "0"
+    enum:
+      - "+17.09%"
+      - "+11.15%"
+      - "+5.84%"
+      - "0"
+      - "-5.25%"
+      - "-11.01%"
+      - "-16.49%"
+      - "-22.24%"
+    description: |
+      Squelch Threshold Adjustment.
+      Adjusts the voltage level for the threshold used to detect valid
+      high-speed data.
+
+  vdatreftune:
+    type: string
+    default: "0"
+    enum:
+      - "+10.26%"
+      - "0"
+      - "-10.38%"
+      - "-20.65%"
+    description: |
+      Data Detect Voltage Adjustment.
+      Adjusts the threshold voltage level used to detect data during Battery
+      Charging 1.2 port detection.
+
+  txhsxvtune:
+    type: string
+    default: "0"
+    enum:
+      - "-8.96 mV"
+      - "+9.21 mV"
+      - "0"
+    description: |
+      Transmitter High-Speed Crossover Adjustment.
+      Adjusts the voltage at which the DP0 and DM0 signals cross while
+      transmitting in HS mode.
+
+  txfslstune:
+    type: string
+    default: "0"
+    enum:
+      - "+6.41%"
+      - "+3.09%"
+      - "0"
+      - "-5.64%"
+      - "-10.65%"
+    description: |
+      FS/LS Source Impedance Adjustment.
+      Adjusts the low- and full-speed single-ended source impedance while
+      driving high.
+
+  txvreftune:
+    type: string
+    default: "0"
+    enum:
+      - "-6.07%"
+      - "-4.02%"
+      - "-2.04%"
+      - "0"
+      - "+1.79%"
+      - "+3.83%"
+      - "+5.80%"
+      - "+7.85%"
+      - "+9.59%"
+      - "+11.63%"
+      - "+13.60%"
+      - "+15.64%"
+      - "+17.41%"
+      - "+19.45%"
+      - "+21.42%"
+      - "+23.46%"
+    description: |
+      HS DC Voltage Level Adjustment.
+      Adjusts the high-speed DC level voltage.
+
+  txrisetune:
+    type: string
+    default: "0"
+    enum:
+      - "+2.56%"
+      - "0"
+      - "-2.81%"
+      - "-3.85%"
+    description: |
+      HS Transmitter Rise/Fall Time Adjustment.
+      Adjusts the rise/fall times of the high-speed waveform.
+
+  txrestune:
+    type: string
+    default: "0"
+    enum:
+      - "+2.93 ohm"
+      - "0"
+      - "-2.55 ohm"
+      - "-4.82 ohm"
+    description: |
+      USB Source Impedance Adjustment.
+      Adjusts the driver source impedance to compensate for added series
+      resistance on the USB.
+
+  txpreempamptune:
+    type: string
+    default: "1x"
+    enum:
+      - "disabled"
+      - "1x"
+      - "2x"
+      - "3x"
+    description: |
+      HS Transmitter Pre-Emphasis Current Control.
+      Controls the amount of current sourced to DP0 and DM0 after a J-to-K or
+      K-to-J transition. The HS Transmitter pre-emphasis current is defined in
+      terms of unit amounts. One unit amount is approximately 600 uA and is
+      defined as 1x pre-emphasis current.
+
+  txpreemppulsetune:
+    type: string
+    default: "1x"
+    enum:
+      - "2x"
+      - "1x"
+    description: |
+      HS Transmitter Pre-Emphasis Duration Control.
+      Controls the duration for which the HS pre-emphasis current is sourced
+      onto DP0 or DM0. The HS Transmitter pre-emphasis duration is defined in
+      terms of unit amounts. One unit of pre-emphasis duration is approximately
+      580 ps and is defined as 1x pre-emphasis duration.

--- a/dts/bindings/usb/nordic,nrf-usbhs-phy-type2.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbhs-phy-type2.yaml
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic USBHS Type 2 PHY configuration
+
+compatible: "nordic,nrf-usbhs-phy-type2"
+
+include: base.yaml
+
+properties:
+  compdistune:
+    type: string
+    default: "0"
+    enum:
+      - "-4.65%"
+      - "-3.29%"
+      - "-1.44%"
+      - "0"
+      - "+1.85%"
+      - "+3.40%"
+      - "+5.48%"
+      - "+7.15%"
+    description: |
+      Disconnect Threshold Adjustment.
+      Adjusts the voltage level for the threshold used to detect a disconnect
+      event at the host.
+
+  sqrxtune:
+    type: string
+    default: "0"
+    enum:
+      - "+16.75%"
+      - "+11.06%"
+      - "+5.66%"
+      - "0"
+      - "-5.42%"
+      - "-11.03%"
+      - "-16.35%"
+      - "-21.90%"
+    description: |
+      Squelch Threshold Adjustment.
+      Adjusts the voltage level for the threshold used to detect valid
+      high-speed data.
+
+  vdatreftune:
+    type: string
+    default: "0"
+    enum:
+      - "+11.36%"
+      - "0"
+      - "-11.33%"
+      - "-22.74%"
+    description: |
+      Data Detect Voltage Adjustment.
+      Adjusts the threshold voltage level (Vdat_ref) used to detect data during
+      Battery Charging 1.2 port detection.
+
+  txhsxvtune:
+    type: string
+    default: "0"
+    enum:
+      - "-13 mV"
+      - "+13 mV"
+      - "0"
+    description: |
+      Transmitter High-Speed Crossover Adjustment.
+      Adjusts the voltage at which the DP0 and DM0 signals cross while
+      transmitting in HS mode.
+
+  txfslstune:
+    type: string
+    default: "0"
+    enum:
+      - "+15%"
+      - "+7%"
+      - "0"
+      - "-6%"
+      - "-12%"
+    description: |
+      FS/LS Source Impedance Adjustment.
+      Adjusts the low- and full-speed single-ended source impedance while
+      driving high.
+
+  txvreftune:
+    type: string
+    default: "0"
+    enum:
+      - "-9%"
+      - "-6%"
+      - "-3%"
+      - "0"
+      - "+3%"
+      - "+6%"
+      - "+9%"
+      - "+12%"
+      - "+15%"
+      - "+18%"
+      - "+22%"
+      - "+25%"
+      - "+28%"
+      - "+31%"
+      - "+34%"
+      - "+37%"
+    description: |
+      HS DC Voltage Level Adjustment.
+      Adjusts the high-speed DC level voltage.
+
+  txrisetune:
+    type: string
+    default: "0"
+    enum:
+      - "+10%"
+      - "0"
+      - "-12%"
+      - "-25%"
+    description: |
+      HS Transmitter Rise/Fall Time Adjustment.
+      Adjusts the rise/fall times of the high-speed waveform.
+
+  txrestune:
+    type: string
+    default: "0"
+    enum:
+      - "+6.5 ohm"
+      - "+3 ohm"
+      - "0"
+      - "-2 ohm"
+    description: |
+      USB Source Impedance Adjustment.
+      Adjusts the driver source impedance to compensate for added series
+      resistance on the USB.
+
+  txpreempamptune:
+    type: string
+    default: "disabled"
+    enum:
+      - "disabled"
+      - "2x"
+      - "1x"
+      - "3x"
+    description: |
+      HS Transmitter Pre-Emphasis Current Control.
+      Controls the amount of current sourced to DP0 and DM0 after a J-to-K or
+      K-to-J transition. The HS Transmitter pre-emphasis current is defined in
+      terms of unit amounts. One unit amount is approximately 4 mA and is
+      defined as 1x pre-emphasis current.
+
+  txpreemppulsetune:
+    type: string
+    default: "2x"
+    enum:
+      - "2x"
+      - "1x"
+    description: |
+      HS Transmitter Pre-Emphasis Duration Control.
+      Controls the duration for which the HS pre-emphasis current is sourced
+      onto DP0 or DM0. The HS Transmitter pre-emphasis duration is defined in
+      terms of unit amounts. One unit of pre-emphasis duration is approximately
+      580 ps and is defined as 1x pre-emphasis duration.

--- a/dts/bindings/usb/nordic,nrf-usbhs-wrapper.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbhs-wrapper.yaml
@@ -16,3 +16,9 @@ properties:
     type: phandle
     description: |
       USB PHY and controller function depends on the USB regulator VREGUSB.
+
+  phy:
+    required: true
+    type: phandle
+    description: |
+      USB PHY configuration

--- a/dts/bindings/usb/nordic,nrf-usbhs.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbhs.yaml
@@ -1,0 +1,16 @@
+description: |
+  Nordic USB High-Speed controller (DWC2 compatible) used on targets with NRFS.
+
+compatible: "nordic,nrf-usbhs"
+
+include: ["snps,dwc2.yaml"]
+
+properties:
+  reg:
+    required: true
+
+  phy:
+    required: true
+    type: phandle
+    description: |
+      USB PHY configuration

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -265,6 +265,11 @@
 		#power-domain-cells = <0>;
 	};
 
+	usbhs_phy: usbhs_phy {
+		compatible = "nordic,nrf-usbhs-phy-type1";
+		status = "reserved";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -682,6 +687,7 @@
 				ghwcfg1 = <0xaa555000>;
 				ghwcfg2 = <0x22abfc72>;
 				ghwcfg4 = <0x1e10aa60>;
+				phy = <&usbhs_phy>;
 				status = "disabled";
 			};
 

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -87,6 +87,11 @@
 		};
 	};
 
+	usbhs_phy: usbhs_phy {
+		compatible = "nordic,nrf-usbhs-phy-type2";
+		status = "reserved";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -243,6 +248,7 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 				regulator = <&vregusb>;
+				phy = <&usbhs_phy>;
 				status = "disabled";
 
 				usbhs: usbhs@20000 {

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -132,6 +132,11 @@
 		};
 	};
 
+	usbhs_phy: usbhs_phy {
+		compatible = "nordic,nrf-usbhs-phy-type1";
+		status = "reserved";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -444,6 +449,7 @@
 				ghwcfg1 = <0xaa555000>;
 				ghwcfg2 = <0x22abfc72>;
 				ghwcfg4 = <0x1e10aa60>;
+				phy = <&usbhs_phy>;
 				status = "disabled";
 			};
 


### PR DESCRIPTION
Generate PHY.CONFIG based on devicetree and assign it before PHY power-on reset is released.