### PR TITLE
arch: riscv: irq: Add missing header

### DIFF
--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -18,6 +18,7 @@
 extern "C" {
 #endif
 
+#include <zephyr/arch/riscv/arch_inlines.h>
 #include <zephyr/sys/util_macro.h>
 
 #ifndef _ASMLANGUAGE


### PR DESCRIPTION
Adds missing header that is required for ISR tracing.