### PR TITLE
instrumentation: Exclude irq lock/unlock and timestamp getters

### DIFF
--- a/subsys/instrumentation/Kconfig
+++ b/subsys/instrumentation/Kconfig
@@ -112,6 +112,8 @@ config INSTRUMENTATION_DYNAMIC_TRIGGER
 
 config INSTRUMENTATION_EXCLUDE_FUNCTION_LIST
 	string "Exclude function list"
+	default "arch_timing_counter_get,arch_irq_lock,arch_irq_unlock,\
+		k_cycle_get_64,sys_clock_cycle_get_64,elapsed"
 	depends on INSTRUMENTATION_MODE_CALLGRAPH || INSTRUMENTATION_MODE_STATISTICAL
 	help
 	  Set the list of function names to be excluded from instrumentation.


### PR DESCRIPTION
Having tracing and instrumentation enabled at the same time causes tracing events to have an end timestamp earlier than the instrumented methods that were sources of these events. This works around this fact by avoiding emitting unnecessary events during instrumentation of tracing event handling.