### PR TITLE
doc: workqueue: small fixes

### DIFF
--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -434,7 +434,7 @@ protected by such a lock to prevent further resubmission, it's safe to do the
 resubmit as long as you're sure that eventually the item will take its lock
 and check that state to determine whether it should do anything.  Where a
 delayable work item is being rescheduled in its handler due to inability to
-take the lock some other self-locking state, such as an atomic flag set by the
+take the lock, some other self-locking state, such as an atomic flag set by the
 application/driver when the cancel is initiated, would be required to detect
 the cancellation and avoid the cancelled work item being submitted again after
 the deadline.

--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -306,7 +306,7 @@ work item:
 * :c:func:`k_work_cancel_sync()` may be invoked from threads to block until
   the work completes; it will return immediately if the cancellation was
   successful or not necessary (the work wasn't submitted or running).  This
-  can be used after :c:func:`k_work_cancel()` is invoked (from an ISR)` to
+  can be used after :c:func:`k_work_cancel()` is invoked (from an ISR) to
   confirm completion of an ISR-initiated cancellation.
 
 Scheduling a Delayable Work Item

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5218,14 +5218,14 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
  *
  * Submitting a previously submitted triggered work item that is still
  * waiting for the event cancels the existing submission and reschedules it
- * the using the new event list. Note that this behavior is inherently subject
+ * using the new event list. Note that this behavior is inherently subject
  * to race conditions with the pre-existing triggered work item and work queue,
  * so care must be taken to synchronize such resubmissions externally.
  *
  * @isr_ok
  *
  * @warning
- * Provided array of events as well as a triggered work item must not be
+ * The provided array of events as well as a triggered work item must not be
  * modified until the item has been processed by the workqueue.
  *
  * @param work Address of delayed work item.


### PR DESCRIPTION
* doc: workqueue: fix grammar in API comment

  I cleaned this up while reading through the workqueue documentation.

* doc: workqueue: remove misplaced backtick

  I cleaned this up while reading the documentation.

* doc: workqueue: add missing comma

  I struggled to understand the structure of this sentence without the
  comma.