### PR TITLE
manifest: hal_nxp: update revision for FW blob update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: c2d68e4b9526aa03174d1da9464dd8e8b87e0a3e
+      revision: 8723557b8d1b1629941cd2697a59d71bee0538b8
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp firmware blobs to nxp-v4.4.2:
- RW612: FW version 8.p133
- IW610: FW version 8.p133
- IW612 (NW61x): FW version 18.99.8.p133
- IW416: FW version 16.92.21.p164

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/802