### PR TITLE
net: if: fix lock inversion in address lifetime timeout

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1966,11 +1966,6 @@ static void address_expired(struct net_if_addr *ifaddr)
 	NET_DBG("IPv6 address %s is expired",
 		net_sprint_ipv6_addr(&ifaddr->address.in6_addr));
 
-	sys_slist_find_and_remove(&active_address_lifetime_timers,
-				  &ifaddr->lifetime.node);
-
-	net_timeout_set(&ifaddr->lifetime, 0, 0);
-
 	STRUCT_SECTION_FOREACH(net_if, iface) {
 		ARRAY_FOR_EACH(iface->config.ip.ipv6->unicast, i) {
 			if (&iface->config.ip.ipv6->unicast[i] == ifaddr) {
@@ -1987,8 +1982,11 @@ static void address_lifetime_timeout(struct k_work *work)
 	uint32_t next_update = UINT32_MAX;
 	uint32_t current_time = k_uptime_get_32();
 	struct net_if_addr *current, *next;
+	sys_slist_t expired_list;
 
 	ARG_UNUSED(work);
+
+	sys_slist_init(&expired_list);
 
 	k_mutex_lock(&lock, K_FOREVER);
 
@@ -1999,7 +1997,12 @@ static void address_lifetime_timeout(struct k_work *work)
 							     current_time);
 
 		if (this_update == 0U) {
-			address_expired(current);
+			sys_slist_find_and_remove(
+				&active_address_lifetime_timers,
+				&current->lifetime.node);
+			net_timeout_set(&current->lifetime, 0, 0);
+			sys_slist_append(&expired_list,
+					 &current->lifetime.node);
 			continue;
 		}
 
@@ -2019,6 +2022,15 @@ static void address_lifetime_timeout(struct k_work *work)
 	}
 
 	k_mutex_unlock(&lock);
+
+	/* address_expired() calls net_if_ipv6_addr_rm(), which takes the
+	 * interface lock. That lock is acquired before this one elsewhere, so
+	 * the removals must happen with this lock released.
+	 */
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&expired_list, current, next,
+					  lifetime.node) {
+		address_expired(current);
+	}
 }
 
 #if defined(CONFIG_NET_TEST)

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -56,6 +56,10 @@ static struct net_in6_addr ll_addr = { { { 0xfe, 0x80, 0x43, 0xb8, 0, 0, 0, 0,
 				       0, 0, 0, 0xf2, 0xaa, 0x29, 0x02,
 				       0x04 } } };
 
+/* Short lived address used by the lifetime timeout lock ordering test */
+static struct net_in6_addr lifetime_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 4, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0, 0x1 } } };
+
 static struct net_in_addr inaddr_mcast = { { { 224, 0, 0, 1 } } };
 static struct net_in6_addr in6addr_mcast;
 
@@ -1004,6 +1008,77 @@ ZTEST(net_iface, test_v6_addr_add_rm)
 	v6_addr_add_mcast_twice();
 	v6_addr_lookup();
 	v6_addr_rm();
+}
+
+static K_SEM_DEFINE(global_lock_taken, 0, 1);
+static K_THREAD_STACK_DEFINE(global_lock_stack, 1024);
+static struct k_thread global_lock_thread;
+static struct net_if_link_cb lifetime_link_cb;
+
+static void lifetime_link_cb_fn(struct net_if *iface,
+				struct net_linkaddr *lladdr, int status)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(lladdr);
+	ARG_UNUSED(status);
+}
+
+static void take_global_lock(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	/* Any user of the global net_if lock will do. */
+	net_if_register_link_cb(&lifetime_link_cb, lifetime_link_cb_fn);
+	net_if_unregister_link_cb(&lifetime_link_cb);
+
+	k_sem_give(&global_lock_taken);
+}
+
+/* The address lifetime timeout must not remove an expired address while it
+ * holds the global net_if lock, because removing it takes the interface lock,
+ * and the interface lock is taken before the global one elsewhere.
+ */
+ZTEST(net_iface, test_v6_addr_lifetime_lock_order)
+{
+	struct net_if_addr *ifaddr;
+	int ret;
+
+	ifaddr = net_if_ipv6_addr_add(iface2, &lifetime_addr,
+				      NET_ADDR_MANUAL, 1);
+	zassert_not_null(ifaddr, "Cannot add IPv6 address");
+
+	/* Take the interface lock just before the address lifetime expires. */
+	k_sleep(K_MSEC(900));
+	net_if_lock(iface2);
+
+	/* Let the work queue run the lifetime timeout. It now waits for the
+	 * interface lock held here.
+	 */
+	k_sleep(K_MSEC(400));
+
+	/* The helper thread needs only the global lock. If the work queue is
+	 * waiting for our interface lock while holding the global one, the
+	 * helper never gets to run to completion.
+	 */
+	k_thread_create(&global_lock_thread, global_lock_stack,
+			K_THREAD_STACK_SIZEOF(global_lock_stack),
+			take_global_lock, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(8), 0, K_NO_WAIT);
+
+	ret = k_sem_take(&global_lock_taken, K_MSEC(500));
+
+	net_if_unlock(iface2);
+
+	k_thread_join(&global_lock_thread, K_FOREVER);
+
+	zassert_equal(ret, 0, "Global lock held while waiting for the "
+		      "interface lock");
+
+	zassert_is_null(net_if_ipv6_addr_lookup_by_iface(iface2,
+							 &lifetime_addr),
+			"Expired IPv6 address was not removed");
 }
 
 ZTEST(net_iface, test_v6_addr_add_rm_solicited)


### PR DESCRIPTION
address_lifetime_timeout() called address_expired() while holding the global lock. address_expired() calls net_if_ipv6_addr_rm(), which takes the interface lock, giving order global -> iface. Other paths, such as net_if_up() via init_igmp(), take the two in the opposite order, so they can deadlock.

Collect the expired addresses into a local list and remove them after the global lock is released, matching what dad_timeout(), rs_timeout() and prefix_lifetime_timeout() already do.

Fixes [117596](https://github.com/zephyrproject-rtos/zephyr/issues/117596)