### PR TITLE
doc: theme: rework heading, definition list and signature styling

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1139,9 +1139,11 @@ endfunction()
    This function sets the runner for the board unconditionally.
    It's meant to be used from application's :file:`CMakeLists.txt` files.
 
-   NOTE: Usually :cmake:command:`board_set_xxx_ifnset()` is best in :file:`board.cmake` files.
-         This lets the user set the runner at cmake time, or in their own application's
-         :file:`CMakeLists.txt`.
+   .. note::
+
+      Usually :cmake:command:`board_set_xxx_ifnset()` is best in
+      :file:`board.cmake` files. This lets the user set the runner at cmake
+      time, or in their own application's :file:`CMakeLists.txt`.
 
    Example usage:
 

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -737,12 +737,47 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
     background: var(--highlight-background-color) !important;
 }
 
-/* RTD hard-codes `color: #000` on .sig-name/.descname at (0,8,x), invisible on
-   a dark signature fill. */
+/* Only CMake signatures go through Pygments and land in a .highlight wrapper;
+   other domains emit the same token classes without it, so they came out
+   monochrome. The same variables keep one palette across both. */
+
 .rst-content dt.sig .sig-name,
 .rst-content dt.sig .descname {
-    color: inherit !important;
+    color: var(--highlight-function-color) !important;
     font-weight: 700;
+}
+
+.rst-content dt.sig .sig-prename,
+.rst-content dt.sig .descclassname {
+    color: var(--footer-color) !important;
+    font-weight: 400;
+}
+
+.rst-content dt.sig .property,
+.rst-content dt.sig .k {
+    color: var(--highlight-keyword-color);
+}
+
+/* Body colour on purpose: --highlight-type2-color is a near neighbour of
+   --highlight-type-color, so colouring this muddies the annotation. */
+.rst-content dt.sig .sig-param > .n:first-child {
+    color: var(--highlight-default-color);
+}
+
+.rst-content dt.sig .sig-param .n,
+.rst-content dt.sig .sig-return-typehint,
+.rst-content dt.sig .sig-return-typehint .n {
+    color: var(--highlight-type-color);
+}
+
+.rst-content dt.sig .default_value,
+.rst-content dt.sig .m {
+    color: var(--highlight-number-color);
+}
+
+.rst-content dt.sig .o,
+.rst-content dt.sig .sig-return-icon {
+    color: var(--highlight-operator-color);
 }
 
 /* Buttons */

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -149,7 +149,6 @@ hr,
     border-color: var(--hr-color);
 }
 
-
 footer,
 #search-results .context {
     color: var(--footer-color);
@@ -508,7 +507,6 @@ kbd, .kbd,
   color: var(--link-color);
 }
 
-
 /* heading tweaks to make document hierarchy easier to grasp */
 
 .rst-content section > h1 {
@@ -531,45 +529,60 @@ kbd, .kbd,
     opacity:50%;
 }
 
-.rst-content section > h2,
-.rst-content section > h3,
-.rst-content section > h4,
-.rst-content section > h5 {
-    font-weight: 500;
-    padding-inline-start: 8px;
-    margin-inline-start: 0px;
-    border-inline-start: 8px solid;
-    padding-top: 0.2em;
-    padding-bottom: 0.2em;
-}
-
 .rst-content section > h2 {
-    border-color: var(--admonition-note-title-background-color);
+    font-size: 1.625rem;
+    font-weight: 600;
+    line-height: 1.2;
+    margin: 3.5rem 0 1rem;
+    padding-inline-start: 12px;
+    border-inline-start: 3px solid var(--heading-accent-color);
 }
 
 .rst-content section > h3 {
-    border-color: var(--admonition-note-background-color);
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.3;
+    margin: 2.5rem 0 0.75rem;
+    padding-inline-start: 12px;
+    border-inline-start: 3px solid var(--heading-rule-color);
 }
 
 .rst-content section > h4 {
-    border-color: transparent;
-    font-weight: 400;
+    font-size: 1.0625rem;
+    font-weight: 600;
+    margin: 1.875rem 0 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+}
+
+.rst-content section > h4::before {
+    content: '';
+    flex: none;
+    width: 14px;
+    height: 2px;
+    background: var(--footer-color);
 }
 
 .rst-content section > h5 {
-    border-color: transparent;
-    font-weight: 100;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--body-color);
+    margin: 2rem 0 0.5rem;
+}
+
+/* Consecutive leaf sections are a list of entries — separate them. */
+.rst-content section:has(> h5) + section:has(> h5) > h5 {
+    border-top: 1px solid var(--hr-color);
+    padding-top: 1.75rem;
+    margin-top: 1.75rem;
 }
 
 /* Section titles that are code identifiers would otherwise render as a small inline-code chip, both
    in the body and the sidebar. Let the code inherit the surrounding size, weight and color so the
-   heading hierarchy and nav entries stay legible. */
-.rst-content section > h1 code,
-.rst-content section > h2 code,
-.rst-content section > h3 code,
-.rst-content section > h4 code,
-.rst-content section > h5 code,
-.rst-content section > h6 code,
+   heading hierarchy and nav entries stay legible.
+   The code.literal qualifier is what makes `color` stick. */
+.rst-content section > :is(h1, h2, h3, h4, h5, h6) code.literal,
 .wy-menu-vertical a code.literal {
     font-size: inherit;
     font-weight: inherit;
@@ -577,6 +590,13 @@ kbd, .kbd,
     border: 0;
     padding: 0;
     color: inherit;
+}
+
+/* An h5 that is nothing but an identifier is named like one, in the same colour
+   a signature would give it. */
+.rst-content section > h5 > code.literal {
+    color: var(--highlight-function-color);
+    font-weight: 700;
 }
 
 /* Definition lists */

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -661,16 +661,88 @@ html.writer-html5 .rst-content dl.field-list > dt,
     padding: 0;
 }
 
-/* Give CMake signatures and their nested parameter terms the code background, so the syntax
-   highlighting stays legible and the terms aren't left with the theme's too-bright default. */
-.rst-content dl.cmake > dt,
-.rst-content dl.cmake dd dl:not(.field-list) > dt {
-    background: var(--highlight-background-color) !important;
+/* Entry: dt.sig is Sphinx's marker on every object description, so this covers
+   py, cmake, kconfig, c and cpp without a selector per domain. */
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt.sig {
+    /* Not flex: the py domain emits many sibling spans per signature. */
+    display: block;
+    font-size: 1rem;
+    /* RTD bolds the whole dt; the name should carry the weight, not the
+       parameters. */
+    font-weight: 400;
+    line-height: 1.6;
+    border-radius: 5px;
+    padding: 9px 12px;
+    position: static;
+    /* RTD hard-codes #f0f0f0/#555 for nested object descriptions at (0,14,3);
+       repeating that chain would be unreadable, hence !important. */
     color: var(--highlight-default-color) !important;
+    background: var(--sig-background-color) !important;
+    border: 1px solid var(--sig-border-color) !important;
+    margin: 0 0 13px !important;
 }
 
-.rst-content dl.cmake > dt .sig-name {
+.rst-content dt.sig + dd {
+    margin-left: 1.5rem;
+    padding-left: 1.25rem;
+    border-left: 1px solid var(--hr-color);
+    padding-bottom: 20px;
+    margin-bottom: 24px;
+    border-bottom: 1px solid var(--hr-color);
+}
+
+html.writer-html5 .rst-content dd dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt.sig {
+    background: none !important;
+    border: 0 !important;
+    border-bottom: 1px solid var(--sig-border-color) !important;
+    border-radius: 0;
+    padding: 0 0 5px;
+    margin: 0 0 10px;
+}
+
+.rst-content dd dt.sig + dd {
+    border-bottom: 0;
+    padding-bottom: 0;
+    margin-bottom: 20px;
+}
+
+.rst-content dl > dt.sig:last-of-type + dd:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+    margin-bottom: 0;
+}
+
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt.sig .headerlink {
+    float: right;
+    margin-left: 12px;
+    color: var(--link-color);
+    opacity: 0.45;
+    visibility: visible;
+}
+
+.rst-content dt.sig:hover .headerlink,
+.rst-content dt.sig .headerlink:focus {
+    opacity: 1;
+}
+
+.rst-content dt.sig + dd dl:not(.field-list) > dt:not(.sig) {
+    justify-self: start;
+    font-family: var(--monospace-font-family);
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid var(--code-border-color) !important;
+    border-radius: 3px;
+    padding: 2px 8px;
+    color: var(--highlight-default-color) !important;
+    background: var(--highlight-background-color) !important;
+}
+
+/* RTD hard-codes `color: #000` on .sig-name/.descname at (0,8,x), invisible on
+   a dark signature fill. */
+.rst-content dt.sig .sig-name,
+.rst-content dt.sig .descname {
     color: inherit !important;
+    font-weight: 700;
 }
 
 /* Buttons */
@@ -976,7 +1048,6 @@ html.writer-html5 .rst-content dl.field-list > dt,
 .wy-alert.wy-alert-danger {
     background-color: var(--admonition-danger-background-color);
 }
-
 
 dark-mode-toggle::part(fieldset) {
   padding-inline: 0.75rem;

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -599,31 +599,66 @@ kbd, .kbd,
     font-weight: 700;
 }
 
-/* Definition lists */
-.rst-content dl {
-    /* Neutral gray, distinct from the accent color the headings use for their left border, so a
-       definition list is not mistaken for content nested under the preceding heading. */
-    border-left: 4px solid var(--code-border-color);
+/* Definition lists: three layouts (stacked, fields, entry) and two term
+   flavours (word, code). Stock RTD styles every classed dl as an API
+   signature at (0,8,2), which is why the entry rules below repeat its
+   :not() chain — that chain is an inert filter on the selectors we use. */
+
+/* Exclusions go in :where() so they cost no specificity; otherwise this base
+   rule outranks the component rules below it. */
+
+.rst-content dl:where(:not(.option-list, .footnote, .citation)) {
+    border-left: 0;
 }
 
-.rst-content dl:not(.field-list) > dt {
-    position: relative;
-    padding-left: 1rem;
-    line-height: 1.8rem;
-    background: var(--highlight-background-color);
-    border-radius: 0 16px 16px 0;
+.rst-content dl:where(:not(.option-list, .footnote, .citation)) > dt {
+    font-size: 1.0625rem;
+    font-weight: 700;
+    line-height: 1.4;
+    color: var(--term-color);
+    background: none;
+    border-radius: 0;
+    padding: 0;
+    margin: 1.875rem 0 0.1875rem;
 }
 
-.rst-content dl:not(.field-list) > dt::before {
-    content: '';
-    position: absolute;
-    left: -10px;
-    top: 6px;
-    width: 16px;
-    height: 16px;
-    background: var(--admonition-note-title-background-color);
-    border-radius: 50%;
-    border: 4px solid var(--content-background-color);
+.rst-content dl > dt:first-child {
+    margin-top: 0;
+}
+
+.rst-content dl:where(:not(.option-list, .footnote, .citation)) > dt::before {
+    content: none;
+}
+
+.rst-content dl:where(:not(.option-list, .footnote, .citation)) > dd {
+    margin: 0;
+}
+
+.rst-content dl:where(:not(.option-list, .footnote, .citation)) > dd > :last-child {
+    margin-bottom: 0;
+}
+
+/* Fields: a field list and a colon-terminated definition list say the same
+   thing, so they render alike. fit-content() stops a long label eating the row. */
+html.writer-html5 .rst-content dl.field-list,
+.rst-content dl.simple:not(.glossary) {
+    display: grid;
+    grid-template-columns: fit-content(11rem) minmax(0, 1fr);
+    gap: 6px 20px;
+    align-items: baseline;
+}
+
+html.writer-html5 .rst-content dl.field-list > dt,
+.rst-content dl.simple:not(.glossary) > dt {
+    display: block;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    line-height: 1.5;
+    color: var(--footer-color);
+    /* RTD indents a field-list term by 1em, which misaligns it against its
+       own value. */
+    margin: 0;
+    padding: 0;
 }
 
 /* Give CMake signatures and their nested parameter terms the code background, so the syntax
@@ -1000,25 +1035,37 @@ div.graphviz > object {
     margin-bottom: 0px;
 }
 
-.rst-content .sidebar dl.field-list {
-    align-items: center;
-    margin-top: 12px !important;
-    margin-bottom: 12px !important;
-    grid-template-columns: auto 1fr !important;
-    padding-right: 1em;
+/* A sidebar card is narrow, so its labels shrink rather than its values: at the
+   body label size, "Architecture:" alone takes half the card. */
+html.writer-html5 .rst-content .sidebar dl.field-list {
+    grid-template-columns: fit-content(5.5rem) minmax(0, 1fr);
+    gap: 9px 12px;
+    align-items: baseline;
+    margin: 12px 0;
+    /* The card has no padding of its own: each child insets itself, and the
+       figure caption above sets the convention at 16px. */
+    padding: 0 16px;
 }
 
-.rst-content .sidebar dl.field-list>dt {
-    background: transparent !important;
+html.writer-html5 .rst-content .sidebar dl.field-list > dt {
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 500;
+    margin: 0;
+    padding: 0;
 }
 
-.rst-content .sidebar dl.field-list>dd {
-    margin-left: 1em;
-    text-overflow: ellipsis;
-    overflow: hidden;
+.rst-content .sidebar dl.field-list > dt .colon {
+    display: none;
 }
 
-.rst-content .sidebar dl.field-list>dd code {
+html.writer-html5 .rst-content .sidebar dl.field-list > dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.rst-content .sidebar dl.field-list > dd code {
     font-size: 0.9em;
 }
 

--- a/doc/_static/css/dark.css
+++ b/doc/_static/css/dark.css
@@ -34,6 +34,10 @@
     --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNmFkIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4=");
     --classref-badge-text-color: hsl(0, 0%, 70%);
 
+    /* Heading rails */
+    --heading-accent-color: #6ab0de;
+    --heading-rule-color: #727d90;
+
     --hr-color: #555;
     --table-row-odd-background-color: #3b3e41;
     --code-background-color: #434649;

--- a/doc/_static/css/dark.css
+++ b/doc/_static/css/dark.css
@@ -37,6 +37,10 @@
     /* Definition terms */
     --term-color: #ffffff;
 
+    /* Signature blocks */
+    --sig-background-color: #1c2029;
+    --sig-border-color: #727d90;
+
     /* Heading rails */
     --heading-accent-color: #6ab0de;
     --heading-rule-color: #727d90;

--- a/doc/_static/css/dark.css
+++ b/doc/_static/css/dark.css
@@ -34,6 +34,9 @@
     --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNmFkIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4=");
     --classref-badge-text-color: hsl(0, 0%, 70%);
 
+    /* Definition terms */
+    --term-color: #ffffff;
+
     /* Heading rails */
     --heading-accent-color: #6ab0de;
     --heading-rule-color: #727d90;

--- a/doc/_static/css/light.css
+++ b/doc/_static/css/light.css
@@ -33,6 +33,10 @@
     --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMWE1YThhIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4=");
     --classref-badge-text-color: hsl(0, 0%, 45%);
 
+    /* Heading rails */
+    --heading-accent-color: #1a5c8a;
+    --heading-rule-color: #8996a8;
+
     --hr-color: #e1e4e5;
     --table-row-odd-background-color: #f3f6f6;
     --code-background-color: #fff;

--- a/doc/_static/css/light.css
+++ b/doc/_static/css/light.css
@@ -36,6 +36,10 @@
     /* Definition terms */
     --term-color: #1a1a1a;
 
+    /* Signature blocks */
+    --sig-background-color: #e8edf4;
+    --sig-border-color: #8996a8;
+
     /* Heading rails */
     --heading-accent-color: #1a5c8a;
     --heading-rule-color: #8996a8;

--- a/doc/_static/css/light.css
+++ b/doc/_static/css/light.css
@@ -33,6 +33,9 @@
     --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMWE1YThhIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4=");
     --classref-badge-text-color: hsl(0, 0%, 45%);
 
+    /* Definition terms */
+    --term-color: #1a1a1a;
+
     /* Heading rails */
     --heading-accent-color: #1a5c8a;
     --heading-rule-color: #8996a8;


### PR DESCRIPTION
Headings and definition lists are hard to tell apart. This makes them legible again.

* **Headings** — each level gets its own spacing, and the levels stay distinguishable in dark mode.
* **Definition lists** — every term in the docs currently looks like an API signature. Simplified, so a glossary reads like a glossary, field labels line up in two columns, and pages get a good deal shorter.
* **Signatures** — drawn the same way whether they come from CMake, Python or Kconfig, and the Python ones are syntax colored now instead of all one color.
* A `NOTE:` in `board_set_runner()` that was rendering as a definition list is now a note admonition.

Also fixes a few spots where stock RTD hard-codes light-theme colors that break in dark mode.

CSS only, except the last commit.

Preview (`?mode=light` / `?mode=dark` forces the theme):

* [west APIs](https://builds.zephyrproject.io/zephyr/pr/117578/docs/develop/west/west-apis.html?mode=dark) — exercises the whole series
* [CMake extensions](https://builds.zephyrproject.io/zephyr/pr/117578/docs/build/cmake-ref/module/extensions.html?mode=dark)
* [Twister → Expressions](https://builds.zephyrproject.io/zephyr/pr/117578/docs/develop/twister/index.html?mode=dark#expressions)
* [Bluetooth Mesh Shell → Testing](https://builds.zephyrproject.io/zephyr/pr/117578/docs/services/connectivity/bluetooth/api/mesh/shell.html?mode=dark#testing)
* [Boards (side-bar)](https://builds.zephyrproject.io/zephyr/pr/117578/docs/boards/adafruit/feather_esp32s3_tft_reverse/doc/index.html)
* [Glossary](https://builds.zephyrproject.io/zephyr/pr/117578/docs/glossary.html?mode=light) (light theme)