### PR TITLE
samples: zbus: proxy_agent_ipc: Fix shared memory regions on nRF54L15 DK

### DIFF
--- a/samples/subsys/zbus/proxy_agent_ipc/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/zbus/proxy_agent_ipc/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -14,12 +14,12 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sram_rx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
+			sram_rx: memory@20017c00 {
+				reg = <0x20017c00 0x8000>;
 			};
 
-			sram_tx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
+			sram_tx: memory@2001fc00 {
+				reg = <0x2001fc00 0x8000>;
 			};
 		};
 	};

--- a/samples/subsys/zbus/proxy_agent_ipc/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/subsys/zbus/proxy_agent_ipc/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -14,12 +14,12 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sram_tx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
+			sram_tx: memory@20017c00 {
+				reg = <0x20017c00 0x8000>;
 			};
 
-			sram_rx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
+			sram_rx: memory@2001fc00 {
+				reg = <0x2001fc00 0x8000>;
 			};
 		};
 	};


### PR DESCRIPTION
Since the RAM region assigned to the FLPR core on nRF54L15 was moved 1 kB down (see commit 630cd71bc606710a0cd369963032b4041ccee399), also the shared memory regions for that SoC in this sample need to be moved accordingly, otherwise the FLPR RAM might get overwritten with some random data.