### PR TITLE
Bluetooth: Classic: SDP: Bound the client AttributeIDList length

### DIFF
--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -654,7 +654,13 @@ struct bt_sdp_attribute_id_range {
 
 /** @brief SDP attribute ID list for Service Attribute and Service Search Attribute transactions */
 struct bt_sdp_attribute_id_list {
-	/** Count of the SDP attribute ID range */
+	/**
+	 * Count of the SDP attribute ID range
+	 *
+	 * The encoded list has to fit in an SDP request PDU: a range is encoded in 5 bytes, a
+	 * single attribute ID (equal beginning and ending) in 3 bytes, and the list including its
+	 * 2-byte header is limited to 162 bytes. bt_sdp_discover() rejects longer lists.
+	 */
 	size_t count;
 	/** Attribute ID range array list */
 	struct bt_sdp_attribute_id_range *ranges;
@@ -717,7 +723,9 @@ struct bt_sdp_discover_params {
  * @param conn Object identifying connection to remote.
  * @param params SDP discovery parameters.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 Success.
+ * @retval -EINVAL Invalid @p params, or an attribute ID list that does not fit in a request PDU.
+ * @return Other negative error code on failure to set up the SDP channel.
  */
 
 int bt_sdp_discover(struct bt_conn *conn,

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -84,6 +84,18 @@ NET_BUF_POOL_FIXED_DEFINE(sdp_pool, CONFIG_BT_MAX_CONN, BT_L2CAP_BUF_SIZE(SDP_MT
 
 #define SDP_CLIENT_MTU 64
 
+/*
+ * Largest encoded AttributeIDList a request PDU can carry. The PDU parameters have to fit in
+ * SDP_DATA_MTU together with a ServiceSearchPattern holding a 128-bit UUID (2-byte sequence
+ * header, 1-byte UUID header, 16-byte UUID), the 2-byte MaximumAttributeByteCount and a
+ * ContinuationState of the maximum length (1-byte length, BT_SDP_MAX_PDU_CSTATE_LEN bytes of
+ * state). A ServiceAttribute request carries a 4-byte ServiceRecordHandle instead of the search
+ * pattern, so the bound holds for it as well. The resulting size is documented at
+ * bt_sdp_attribute_id_list::count.
+ */
+#define SDP_CLIENT_ATTR_ID_LIST_MAX_LEN                                                            \
+	(SDP_DATA_MTU - (2 + 1 + BT_UUID_SIZE_128) - 2 - (1 + BT_SDP_MAX_PDU_CSTATE_LEN))
+
 #define SDP_SA_MAX_ATTR_BYTE_COUNT 0xffff
 #define SDP_SA_MIN_ATTR_BYTE_COUNT 0x0007
 
@@ -2103,9 +2115,10 @@ static int sdp_client_ss_search(struct bt_sdp_client *session,
 	return bt_sdp_send(&session->chan.chan, buf, BT_SDP_SVC_SEARCH_REQ, session->tid);
 }
 
-static uint16_t sdp_client_get_attribute_id_list_len(struct bt_sdp_attribute_id_list *ids)
+/* Encoded size of the AttributeIDList elements, excluding the sequence header */
+static size_t sdp_client_get_attribute_id_list_len(const struct bt_sdp_attribute_id_list *ids)
 {
-	uint16_t len = 0;
+	size_t len = 0;
 
 	if (ids == NULL || ids->count == 0) {
 		return sizeof(uint8_t) + sizeof(uint32_t);
@@ -2122,11 +2135,23 @@ static uint16_t sdp_client_get_attribute_id_list_len(struct bt_sdp_attribute_id_
 	return len;
 }
 
-static void sdp_client_add_attribute_id(struct net_buf *buf, struct bt_sdp_attribute_id_list *ids)
+/* Size of the sequence header of an AttributeIDList with @p len bytes of elements */
+static size_t sdp_client_get_attribute_id_list_hdr_len(size_t len)
 {
-	uint16_t len;
+	if (len > UINT8_MAX) {
+		return sizeof(uint8_t) + sizeof(uint16_t);
+	}
 
-	len = sdp_client_get_attribute_id_list_len(ids);
+	return sizeof(uint8_t) + sizeof(uint8_t);
+}
+
+/*
+ * Add the AttributeIDList to the PDU. @p len is the size of its elements as returned by
+ * sdp_client_get_attribute_id_list_len(), which the caller has checked against the tailroom.
+ */
+static void sdp_client_add_attribute_id(struct net_buf *buf,
+					const struct bt_sdp_attribute_id_list *ids, size_t len)
+{
 	/*
 	 * Sequence definition where data is sequence of elements and where
 	 * additional next byte points the size of elements within
@@ -2164,20 +2189,11 @@ static void sdp_client_add_attribute_id(struct net_buf *buf, struct bt_sdp_attri
 	}
 }
 
-static uint16_t sdp_client_get_total_len(struct bt_sdp_client *session,
-					 const struct bt_sdp_discover_params *param)
+/* Size of the AttributeIDList and the ContinuationState of the next request */
+static size_t sdp_client_get_total_len(const struct bt_sdp_client *session, size_t ids_len)
 {
-	uint16_t len;
-
-	len = sdp_client_get_attribute_id_list_len(param->ids);
-	if (len > UINT8_MAX) {
-		len += sizeof(uint8_t) + sizeof(uint16_t);
-	} else {
-		len += sizeof(uint8_t) + sizeof(uint8_t);
-	}
-	len += sizeof(session->cstate.length) + session->cstate.length;
-
-	return len;
+	return sdp_client_get_attribute_id_list_hdr_len(ids_len) + ids_len +
+	       sizeof(session->cstate.length) + session->cstate.length;
 }
 
 /* ServiceAttribute PDU, ref to BT Core 5.4, Vol 3, part B, 4.6.1 */
@@ -2186,6 +2202,7 @@ static int sdp_client_sa_search(struct bt_sdp_client *session,
 {
 	struct net_buf *buf;
 	uint16_t len;
+	size_t ids_len;
 
 	/* Update context param directly. */
 	session->param = param;
@@ -2205,15 +2222,15 @@ static int sdp_client_sa_search(struct bt_sdp_client *session,
 	net_buf_add_be16(buf, len);
 
 	/* Check the tailroom of the buffer */
-	len = sdp_client_get_total_len(session, param);
-	if (len > net_buf_tailroom(buf)) {
+	ids_len = sdp_client_get_attribute_id_list_len(param->ids);
+	if (sdp_client_get_total_len(session, ids_len) > net_buf_tailroom(buf)) {
 		LOG_ERR("No space to add attribute ID");
 		net_buf_unref(buf);
 		return -ENOMEM;
 	}
 
 	/* Add attribute ID List */
-	sdp_client_add_attribute_id(buf, param->ids);
+	sdp_client_add_attribute_id(buf, param->ids, ids_len);
 
 	/*
 	 * Update and validate PDU ContinuationState. Initial SSA Request has
@@ -2240,6 +2257,7 @@ static int sdp_client_ssa_search(struct bt_sdp_client *session,
 	struct net_buf *buf;
 	uint8_t uuid128[BT_UUID_SIZE_128];
 	uint16_t len;
+	size_t ids_len;
 
 	/* Update context param directly. */
 	session->param = param;
@@ -2303,15 +2321,15 @@ static int sdp_client_ssa_search(struct bt_sdp_client *session,
 	net_buf_add_be16(buf, len);
 
 	/* Check the tailroom of the buffer */
-	len = sdp_client_get_total_len(session, param);
-	if (len > net_buf_tailroom(buf)) {
+	ids_len = sdp_client_get_attribute_id_list_len(param->ids);
+	if (sdp_client_get_total_len(session, ids_len) > net_buf_tailroom(buf)) {
 		LOG_ERR("No space to add attribute ID");
 		net_buf_unref(buf);
 		return -ENOMEM;
 	}
 
 	/* Add attribute ID List */
-	sdp_client_add_attribute_id(buf, param->ids);
+	sdp_client_add_attribute_id(buf, param->ids, ids_len);
 
 	/*
 	 * Update and validate PDU ContinuationState. Initial SSA Request has
@@ -2905,6 +2923,8 @@ static int sdp_client_discovery_start(struct bt_conn *conn,
 int bt_sdp_discover(struct bt_conn *conn,
 		    struct bt_sdp_discover_params *params)
 {
+	size_t ids_len;
+
 	if (params == NULL || params->uuid == NULL || params->func == NULL ||
 	    params->pool == NULL ||
 	    (params->ids != NULL && params->ids->count != 0 && params->ids->ranges == NULL)) {
@@ -2924,6 +2944,13 @@ int bt_sdp_discover(struct bt_conn *conn,
 			LOG_WRN("Invalid range %u > %u", range->beginning, range->ending);
 			return -EINVAL;
 		}
+	}
+
+	ids_len = sdp_client_get_attribute_id_list_len(params->ids);
+	if (sdp_client_get_attribute_id_list_hdr_len(ids_len) + ids_len >
+	    SDP_CLIENT_ATTR_ID_LIST_MAX_LEN) {
+		LOG_WRN("Attribute ID list of %zu bytes does not fit in a request PDU", ids_len);
+		return -EINVAL;
 	}
 
 	return sdp_client_discovery_start(conn, params);

--- a/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
+++ b/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
@@ -44,6 +44,10 @@ logger = logging.getLogger(__name__)
 AVDTP_PSM = 0x0019
 AVDTP_VERSION = 0x0100
 
+# Largest attribute ID list a request PDU carries: 32 ranges of 5 bytes plus the 2-byte
+# sequence header make 162 bytes.
+SDP_ATTR_ID_RANGE_MAX_COUNT = 32
+
 SDP_SERVICE_RECORDS_A2DP = {
     0x00010001: [
         ServiceAttribute(
@@ -1047,6 +1051,60 @@ async def sdp_sa_discover_multiple_records_with_range(hci_port, shell, dut, addr
             assert found is True
 
 
+async def sdp_sa_discover_max_attr_id_ranges(hci_port, shell, dut, address) -> None:
+    logger.info('<<< SDP Discovery ...')
+    async with await open_transport_or_link(hci_port) as hci_transport:
+        device = Device.with_hci(
+            'Bumble',
+            Address('F0:F1:F2:F3:F4:F5'),
+            hci_transport.source,
+            hci_transport.sink,
+        )
+        device.classic_enabled = True
+        device.le_enabled = False
+        device.sdp_service_records = SDP_SERVICE_ONE_RECORD
+        with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
+            device.host.snooper = BtSnooper(snoop_file)
+            await device_power_on(device)
+            await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
+
+            target_address = address.split(" ")[0]
+            logger.info(f'=== Connecting to {target_address}...')
+            try:
+                connection = await device.connect(target_address, transport=BT_BR_EDR_TRANSPORT)
+                logger.info(f'=== Connected to {connection.peer_address}!')
+            except Exception as e:
+                logger.error(f'Fail to connect to {target_address}!')
+                raise e
+
+            await wait_for_shell_response(dut, "Connected:")
+
+            # Discover SDP Record with the whole attribute ID space split into the largest
+            # number of ranges that fits in a request
+            shell.exec_command(
+                f"sdp_client sa_discovery_ranges 00010001 {SDP_ATTR_ID_RANGE_MAX_COUNT}"
+            )
+            found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
+            assert found is True
+
+            found = False
+            for line in lines:
+                if "PROTOCOL:" in line and "L2CAP" in line.split(':')[1]:
+                    assert int(line.split(':')[2]) == AVDTP_PSM
+                    found = True
+
+            logger.info(f'Rsp: PROTOCOL: L2CAP: {AVDTP_PSM} is found? {found}')
+            assert found is True
+
+            # One range more does not fit in a request and is rejected
+            lines = shell.exec_command(
+                f"sdp_client sa_discovery_ranges 00010001 {SDP_ATTR_ID_RANGE_MAX_COUNT + 1}"
+            )
+            logger.info(f'{lines}')
+            found = any("Fail to start SDP Discovery (err -22)" in line for line in lines)
+            assert found is True
+
+
 async def sdp_ssa_discover_fail(hci_port, shell, dut, address) -> None:
     def on_app_connection_request(self, request) -> None:
         logger.info('Force L2CAP connection failure')
@@ -1196,6 +1254,15 @@ class TestSdpServer:
         logger.info(f'test_sdp_sa_discover_multiple_records_with_range {sdp_client_dut}')
         hci, iut_address = sdp_client_dut
         asyncio.run(sdp_sa_discover_multiple_records_with_range(hci, shell, dut, iut_address))
+
+    def test_sdp_sa_discover_max_attr_id_ranges(
+        self, shell: Shell, dut: DeviceAdapter, sdp_client_dut
+    ):
+        """Test case to request SDP records with the largest attribute ID list that fits in a
+        request, and with one that does not."""
+        logger.info(f'test_sdp_sa_discover_max_attr_id_ranges {sdp_client_dut}')
+        hci, iut_address = sdp_client_dut
+        asyncio.run(sdp_sa_discover_max_attr_id_ranges(hci, shell, dut, iut_address))
 
     def test_sdp_ssa_discover_fail(self, shell: Shell, dut: DeviceAdapter, sdp_client_dut):
         """Test case to request SDP records. but the L2CAP connecting fail."""

--- a/tests/bluetooth/classic/sdp_c/src/sdp_client.c
+++ b/tests/bluetooth/classic/sdp_c/src/sdp_client.c
@@ -333,6 +333,62 @@ static int cmd_sa_discovery(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+/*
+ * Attribute ID ranges for sa_discovery_ranges. Sized for one range more than a request PDU
+ * carries: 32 ranges of 5 bytes plus the 2-byte sequence header make the 162-byte limit.
+ */
+#define ATTR_ID_RANGE_MAX_COUNT 32
+static struct bt_sdp_attribute_id_range attr_id_range_list[ATTR_ID_RANGE_MAX_COUNT + 1];
+
+static int cmd_sa_discovery_ranges(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+	size_t len;
+	uint32_t handle;
+	unsigned long count;
+	uint32_t step;
+
+	len = strlen(argv[1]);
+
+	if (len == (sizeof(handle) * 2)) {
+		hex2bin(argv[1], len, (uint8_t *)&handle, sizeof(handle));
+		sdp_discover.handle = sys_be32_to_cpu(handle);
+	} else {
+		shell_error(sh, "Invalid handle");
+		return -ENOEXEC;
+	}
+
+	count = shell_strtoul(argv[2], 0, &err);
+	if (err < 0 || count == 0 || count > ARRAY_SIZE(attr_id_range_list)) {
+		shell_error(sh, "Invalid range count");
+		return -ENOEXEC;
+	}
+
+	/* Split the attribute ID space into ascending, non-overlapping ranges */
+	step = 0x10000 / count;
+	for (size_t i = 0; i < count; i++) {
+		attr_id_range_list[i].beginning = (uint16_t)(i * step);
+		attr_id_range_list[i].ending =
+			(i == count - 1) ? 0xffff : (uint16_t)((i + 1) * step - 1);
+	}
+
+	attr_ids.count = count;
+	attr_ids.ranges = attr_id_range_list;
+
+	sdp_discover.func = sdp_discover_func;
+	sdp_discover.pool = &sdp_client_pool;
+	sdp_discover.type = BT_SDP_DISCOVER_SERVICE_ATTR;
+	sdp_discover.ids = &attr_ids;
+
+	err = bt_sdp_discover(default_conn, &sdp_discover);
+	if (err != 0) {
+		shell_error(sh, "Fail to start SDP Discovery (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
 static uint8_t sdp_discover_fail_func(struct bt_conn *conn, struct bt_sdp_client_result *result,
 				      const struct bt_sdp_discover_params *params)
 {
@@ -370,6 +426,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sdp_client_cmds,
 		      cmd_sa_discovery, 2, 2),
 	SHELL_CMD_ARG(ssa_discovery, NULL, "<Big endian UUID>" HELP_ATTR_ID_LIST,
 		      cmd_ssa_discovery, 2, 2),
+	SHELL_CMD_ARG(sa_discovery_ranges, NULL, "<Service Record Handle> <range count>",
+		      cmd_sa_discovery_ranges, 3, 0),
 	SHELL_CMD_ARG(ssa_discovery_fail, NULL, "", cmd_ssa_discovery_fail, 1, 0),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
`sdp_client_get_attribute_id_list_len()` summed the encoded size of `bt_sdp_discover_params::ids` in a `uint16_t` while iterating a `size_t` count. With enough ranges the sum wrapped, the tailroom check in the SA/SSA request builders passed on the wrapped value, and `sdp_client_add_attribute_id()` encoded the whole list past the end of the request PDU.

Accumulate in `size_t`, hand the measured length to the encoder instead of recomputing it there, and reject lists that cannot fit in a request PDU in `bt_sdp_discover()` with `-EINVAL`. The bound is derived from the request with the largest fixed-size parameters (SSA with a 128-bit UUID and a full-size continuation state), so a list accepted by `bt_sdp_discover()` fits every request of the transaction. The limit is documented on `bt_sdp_attribute_id_list::count`.

The second commit adds a `sa_discovery_ranges` shell command to `tests/bluetooth/classic/sdp_c` and a test that discovers a record with the largest list that fits (32 ranges, 162 bytes on the wire) and checks that 33 ranges are rejected. Verified against a Bumble SDP server.

Fixes #117579