### PR TITLE
cmake: clang: use the target ISA for compiler capability probes

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -98,6 +98,25 @@ if(NOT "${ARCH}" STREQUAL "posix")
     endif()
   endif()
 
+  # Compiler capability probes run through try_compile(), which only sees
+  # CMAKE_REQUIRED_FLAGS. The target flags gathered in TOOLCHAIN_C_FLAGS are
+  # applied as target properties and never reach it. CMake does propagate
+  # '--target=<triple>', but the triples used by the LLVM toolchain only pin the
+  # architecture profile, so the CPU, FPU and ABI have to be passed explicitly
+  # for probe results to describe the target actually being built.
+  if("${ARCH}" STREQUAL "arm")
+    list(APPEND CMAKE_REQUIRED_FLAGS ${ARM_C_FLAGS})
+  elseif("${ARCH}" STREQUAL "arm64")
+    if(DEFINED GCC_M_CPU)
+      list(APPEND CMAKE_REQUIRED_FLAGS -mcpu=${GCC_M_CPU})
+    endif()
+    if(DEFINED GCC_M_ARCH)
+      list(APPEND CMAKE_REQUIRED_FLAGS -march=${GCC_M_ARCH})
+    endif()
+  elseif("${ARCH}" STREQUAL "riscv")
+    list(APPEND CMAKE_REQUIRED_FLAGS ${RISCV_C_FLAGS})
+  endif()
+
   list(APPEND CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 


### PR DESCRIPTION
Compiler capability probes go through `try_compile()`, which only sees `CMAKE_REQUIRED_FLAGS`. The target flags collected in `TOOLCHAIN_C_FLAGS` are applied as target properties and never reach it.

CMake does propagate `CMAKE_<LANG>_COMPILER_TARGET` on its own, so `--target=<triple>` is on the probe command line, but the triples set in `cmake/toolchain/host/llvm/target.cmake` only pin the *architecture* profile. Everything below that (`-mcpu`, `-mfpu`, `-mfloat-abi`, `-mthumb`, `-mabi`, and on RISC-V the whole `-march`/`-mabi`) is missing, so probes run against clang's default for the triple:

| triple | `-target-cpu` | float ABI | ISA |
| --- | --- | --- | --- |
| `armv7m-none-eabi` | `cortex-m3` | soft | no FPU |
| `armv8m.main-none-eabi` | `generic` | soft | no FPU/DSP/MVE |
| `aarch64-none-elf` | `generic` | aapcs | base armv8-a |
| `riscv32-unknown-elf` | `generic-rv32` | `ilp32` | `+m +a +c` |

A Cortex-M55 board therefore probes as a soft-float Cortex-M3, and every RISC-V board probes as `rv32imac`/`ilp32` no matter what its Kconfig selects.

Passing the architecture flags that the triple does not carry makes flag support be decided for the ISA actually being built. It also fixes the toolchain capability cache key: that key is derived from `TOOLCHAIN_SIGNATURE` (MD5 of the compiler binary plus its path/id/version) and `CMAKE_REQUIRED_FLAGS`, neither of which currently says anything about the target. With GCC this is masked because each architecture has its own binary, but a single clang serves all of them, so an Arm build and a RISC-V build hash to the same key and share results out of `ToolchainCapabilityDatabase`.

### Notes for reviewers

- Follow-up to #117290, which addresses the same class of problem for armclang.