### PR TITLE
doc: cmake-ref: add sysbuild to the CMake reference

### DIFF
--- a/doc/build/cmake-ref/index.rst
+++ b/doc/build/cmake-ref/index.rst
@@ -27,6 +27,7 @@ Sysbuild Modules
    :glob:
 
    module/sysbuild_extensions
+   module/native_simulator_sb_extensions
 
 Utility & Tooling Modules
 -------------------------

--- a/doc/build/cmake-ref/index.rst
+++ b/doc/build/cmake-ref/index.rst
@@ -19,6 +19,15 @@ Core Build System & Hardware Modules
    module/extensions
    module/kconfig
 
+Sysbuild Modules
+----------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   module/sysbuild_extensions
+
 Utility & Tooling Modules
 -------------------------
 

--- a/doc/build/cmake-ref/index.rst
+++ b/doc/build/cmake-ref/index.rst
@@ -27,6 +27,8 @@ Sysbuild Modules
    :glob:
 
    module/sysbuild_extensions
+   module/sysbuild_kconfig
+   module/sysbuild_root
    module/native_simulator_sb_extensions
 
 Utility & Tooling Modules

--- a/doc/build/cmake-ref/module/native_simulator_sb_extensions.rst
+++ b/doc/build/cmake-ref/module/native_simulator_sb_extensions.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /share/sysbuild/cmake/modules/native_simulator_sb_extensions.cmake

--- a/doc/build/cmake-ref/module/sysbuild_extensions.rst
+++ b/doc/build/cmake-ref/module/sysbuild_extensions.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /share/sysbuild/cmake/modules/sysbuild_extensions.cmake

--- a/doc/build/cmake-ref/module/sysbuild_kconfig.rst
+++ b/doc/build/cmake-ref/module/sysbuild_kconfig.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /share/sysbuild/cmake/modules/sysbuild_kconfig.cmake

--- a/doc/build/cmake-ref/module/sysbuild_root.rst
+++ b/doc/build/cmake-ref/module/sysbuild_root.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /share/sysbuild/cmake/modules/sysbuild_root.cmake

--- a/doc/build/cmake-ref/variable/APP_DIR.rst
+++ b/doc/build/cmake-ref/variable/APP_DIR.rst
@@ -1,0 +1,9 @@
+APP_DIR
+#######
+
+Source directory of the main application in a sysbuild build.
+
+Set from the ``-DAPP_DIR=<path>`` build option or the matching environment variable. Sysbuild
+resolves the sysbuild configuration files and root lists relative to this directory.
+
+See :ref:`sysbuild`.

--- a/doc/build/cmake-ref/variable/DEFAULT_IMAGE.rst
+++ b/doc/build/cmake-ref/variable/DEFAULT_IMAGE.rst
@@ -1,0 +1,10 @@
+DEFAULT_IMAGE
+#############
+
+Name of the main application image in a sysbuild build.
+
+This is the image added with ``APP_TYPE MAIN``, and the one reported as the default domain in
+:file:`domains.yaml`. Use it from a :file:`sysbuild.cmake` file to refer to the main image without
+hardcoding its name.
+
+See :cmake:command:`ExternalZephyrProject_Add`.

--- a/doc/build/cmake-ref/variable/MODULE_EXT_ROOT.rst
+++ b/doc/build/cmake-ref/variable/MODULE_EXT_ROOT.rst
@@ -1,0 +1,7 @@
+MODULE_EXT_ROOT
+###############
+
+List of directories containing module external roots, which hold the CMake and Kconfig glue
+code for Zephyr modules that do not carry it themselves.
+
+See :cmake:module:`sysbuild_root` for how sysbuild resolves this variable for image builds.

--- a/doc/build/cmake-ref/variable/SB_APPLICATION_CONFIG_DIR.rst
+++ b/doc/build/cmake-ref/variable/SB_APPLICATION_CONFIG_DIR.rst
@@ -1,0 +1,9 @@
+SB_APPLICATION_CONFIG_DIR
+#########################
+
+Directory searched for sysbuild's own configuration files.
+
+When set, it takes precedence over :cmake:variable:`APPLICATION_CONFIG_DIR` for locating
+:cmake:variable:`SB_CONF_FILE`.
+
+See :cmake:module:`sysbuild_kconfig`.

--- a/doc/build/cmake-ref/variable/SB_CONF_FILE.rst
+++ b/doc/build/cmake-ref/variable/SB_CONF_FILE.rst
@@ -1,0 +1,12 @@
+SB_CONF_FILE
+############
+
+Sysbuild Kconfig configuration file, or list of files.
+
+Defaults to :file:`sysbuild.conf` in :cmake:variable:`APPLICATION_CONFIG_DIR`, if that file
+exists. Sysbuild is an opt-in feature, so the file is optional.
+
+Settings in these files override the defaults of sysbuild's own Kconfig tree. Paths are resolved
+relative to :cmake:variable:`APP_DIR`.
+
+See :cmake:module:`sysbuild_kconfig`.

--- a/doc/build/cmake-ref/variable/SB_EXTRA_CONF_FILE.rst
+++ b/doc/build/cmake-ref/variable/SB_EXTRA_CONF_FILE.rst
@@ -1,0 +1,8 @@
+SB_EXTRA_CONF_FILE
+##################
+
+Additional sysbuild Kconfig fragment files, applied on top of :cmake:variable:`SB_CONF_FILE`.
+
+Paths are resolved relative to :cmake:variable:`APP_DIR`.
+
+See :cmake:module:`sysbuild_kconfig`.

--- a/doc/build/cmake-ref/variable/SB_SNIPPET.rst
+++ b/doc/build/cmake-ref/variable/SB_SNIPPET.rst
@@ -1,0 +1,8 @@
+SB_SNIPPET
+##########
+
+List of snippets to apply to the sysbuild build itself.
+
+Defaults to the value of ``SNIPPET`` when that is set and ``SB_SNIPPET`` is not.
+
+See :ref:`snippets`.

--- a/doc/build/cmake-ref/variable/SCA_ROOT.rst
+++ b/doc/build/cmake-ref/variable/SCA_ROOT.rst
@@ -1,0 +1,6 @@
+SCA_ROOT
+########
+
+List of directories containing static code analysis tool integrations.
+
+See :cmake:module:`sysbuild_root` for how sysbuild resolves this variable for image builds.

--- a/doc/build/cmake-ref/variable/SNIPPET_ROOT.rst
+++ b/doc/build/cmake-ref/variable/SNIPPET_ROOT.rst
@@ -1,0 +1,6 @@
+SNIPPET_ROOT
+############
+
+List of directories searched for snippet definitions.
+
+See :cmake:module:`sysbuild_root` for how sysbuild resolves this variable for image builds.

--- a/doc/build/cmake-ref/variable/SOC_ROOT.rst
+++ b/doc/build/cmake-ref/variable/SOC_ROOT.rst
@@ -1,0 +1,6 @@
+SOC_ROOT
+########
+
+List of directories containing SoC implementations.
+
+See :cmake:module:`sysbuild_root` for how sysbuild resolves this variable for image builds.

--- a/doc/build/sysbuild/images.rst
+++ b/doc/build/sysbuild/images.rst
@@ -334,15 +334,15 @@ Image configuration script (Zephyr-wide)
 ----------------------------------------
 
 Global Zephyr provided image configuration scripts, which allow specifying the type when using
-``ExternalZephyrProject_Add()`` require changes to sysbuild code in Zephyr. This should only be
-added to when adding a new type that any project should be able to select, generally this should
-only be needed for upstream Zephyr though forked versions of Zephyr might use this to add
-additional types without restriction.
+:cmake:command:`ExternalZephyrProject_Add` require changes to sysbuild code in Zephyr. This
+should only be added to when adding a new type that any project should be able to select,
+generally this should only be needed for upstream Zephyr though forked versions of Zephyr might
+use this to add additional types without restriction.
 
 Image configuration has an allow-list of names which must be set in the Zephyr file
 :zephyr_file:`share/sysbuild/cmake/modules/sysbuild_extensions.cmake` in the
-``ExternalZephyrProject_Add`` function. After adding a new type, it can be used when adding a
-sysbuild image, for example:
+:cmake:command:`ExternalZephyrProject_Add` function. After adding a new type, it can be used
+when adding a sysbuild image, for example:
 
 .. tabs::
 

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -145,11 +145,14 @@ As mentioned above, you can run sysbuild via ``west build`` or ``cmake``.
 
       .. tip::
 
-         The environment variables, ``CMAKE_BUILD_PARALLEL_LEVEL`` and ``VERBOSE``, can be used to
-         control the build process when using sysbuild with CMake and ninja.
+         The environment variables
+         :cmake:envvar:`CMAKE_BUILD_PARALLEL_LEVEL <envvar:CMAKE_BUILD_PARALLEL_LEVEL>` and
+         :cmake:envvar:`VERBOSE <envvar:VERBOSE>` can be used to control the build process
+         when using sysbuild with CMake and ninja.
 
-         To set number of jobs for ninja for all sysbuild images, set the CMAKE_BUILD_PARALLEL_LEVEL
-         environment variable and invoke the build with ``cmake --build``, for example:
+         To set number of jobs for ninja for all sysbuild images, set the
+         :cmake:envvar:`CMAKE_BUILD_PARALLEL_LEVEL <envvar:CMAKE_BUILD_PARALLEL_LEVEL>` environment
+         variable and invoke the build with ``cmake --build``, for example:
 
          .. code-block:: shell
 
@@ -907,8 +910,8 @@ can be added.
 Sysbuild and CMake presets
 **************************
 
-`CMake presets <https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html>`_ can be used with
-Sysbuild but not all preset macros will work as expected.
+:cmake:manual:`CMake presets <manual:cmake-presets(7)>` can be used with Sysbuild but not all
+preset macros will work as expected.
 
 .. note::
 

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -507,18 +507,18 @@ target to execute and it will run.
 Adding Zephyr applications to sysbuild
 **************************************
 
-You can use the ``ExternalZephyrProject_Add()`` function to add Zephyr
+You can use the :cmake:command:`ExternalZephyrProject_Add` function to add Zephyr
 applications as sysbuild domains. Call this CMake function from your
 application's :file:`sysbuild.cmake` file, or any other CMake file you know will
 run as part sysbuild CMake invocation.
 
-A variant image can also added using the ``ExternalZephyrVariantProject_Add()`` function which
-will duplicate an existing image in the sysbuild project, and allows for slight differences in
-configuration. An example use case for this feature is to change the chosen flash node of an image
-but having the rest of the configuration identical to the base image. When this is used, neither
-sysbuild itself nor the image will have the extra Kconfig targets made for it such as menuconfig,
-guiconfig, hardenconfig or traceconfig, as the base image can be used for viewing/adjusting
-these instead.
+A variant image can also added using the :cmake:command:`ExternalZephyrVariantProject_Add`
+function which will duplicate an existing image in the sysbuild project, and allows for slight
+differences in configuration. An example use case for this feature is to change the chosen flash
+node of an image but having the rest of the configuration identical to the base image. When this
+is used, neither sysbuild itself nor the image will have the extra Kconfig targets made for it
+such as menuconfig, guiconfig, hardenconfig or traceconfig, as the base image can be used for
+viewing/adjusting these instead.
 
 Targeting the same board
 ========================
@@ -783,10 +783,10 @@ images used by ``west flash``; this could be used if a specific flashing order
 is required by an SoC, a _runner_, or something else.
 
 By default, sysbuild will configure and flash applications in the order that
-they are added, as ``ExternalZephyrProject_Add()`` calls are processed by CMake.
-You can use the ``sysbuild_add_dependencies()`` function to make adjustments to
+they are added, as :cmake:command:`ExternalZephyrProject_Add` calls are processed by CMake.
+You can use the :cmake:command:`sysbuild_add_dependencies` function to make adjustments to
 this order, according to your needs. Its usage is similar to the standard
-``add_dependencies()`` function in CMake.
+:cmake:command:`add_dependencies() <command:add_dependencies>` function in CMake.
 
 Here is an example of adding configuration dependencies for ``my_sample``:
 
@@ -833,16 +833,15 @@ Adding non-Zephyr applications to sysbuild
 ******************************************
 
 You can include non-Zephyr applications in a multi-image build using the
-standard CMake module `ExternalProject`_. Please refer to the CMake
-documentation for usage details.
+standard CMake module :cmake:module:`ExternalProject <module:ExternalProject>`.
+Please refer to the CMake documentation for usage details.
 
-When using ``ExternalProject``, the non-Zephyr application will be built as
-part of the sysbuild build invocation, but ``west flash`` or ``west debug``
-will not be aware of the application. Instead, you must manually flash and
-debug the application.
+When using :cmake:module:`ExternalProject <module:ExternalProject>`, the
+non-Zephyr application will be built as part of the sysbuild build invocation,
+but ``west flash`` or ``west debug`` will not be aware of the application.
+Instead, you must manually flash and debug the application.
 
 .. _MCUboot with Zephyr: https://docs.mcuboot.com/readme-zephyr
-.. _ExternalProject: https://cmake.org/cmake/help/latest/module/ExternalProject.html
 
 .. _sysbuild_var_override:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -399,6 +399,7 @@ external_content_contents = [
     (ZEPHYR_BASE / "doc", "[!_]*"),
     (ZEPHYR_BASE, "tests/**/*.pts"),
     (ZEPHYR_BASE, "cmake/modules"),
+    (ZEPHYR_BASE, "share/sysbuild/cmake/modules"),
 ]
 if not SKIP_EXTERNAL_CONTENT:
     external_content_contents += [

--- a/share/sysbuild/cmake/modules/native_simulator_sb_extensions.cmake
+++ b/share/sysbuild/cmake/modules/native_simulator_sb_extensions.cmake
@@ -2,18 +2,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Usage:
-#   native_simulator_set_final_executable(<final_image>)
-#
-# When building for a native_simulator based target (including bsim targets),
-# this function adds an extra build target which will copy the executable produced by
-# `<final_image>` to the top level, as zephyr/zephyr.exe
-#
-# This final image is expected to have been set to assemble other dependent images into
-# itself if necessary, by calling native_simulator_set_child_images()
-# This will allow other tools, like twister, or the bsim test scripts, as well as users to find
-# this final executable in the same place as for non-sysbuild builds.
-#
+#[=======================================================================[.rst:
+native_simulator_sb_extensions
+##############################
+
+Sysbuild extension commands for :zephyr:board:`native_sim` based targets.
+
+These commands are used by the :file:`sysbuild.cmake` file of a board or application that builds
+several images into a single native simulator executable. They are no-ops unless the board target
+is a native simulator or :ref:`bsim <bsim boards>` based one.
+
+#]=======================================================================]
+
+#[=======================================================================[.rst:
+.. cmake:signature:: native_simulator_set_final_executable(<final_image>)
+
+   Add a build target which copies the executable produced by ``<final_image>`` to the top level,
+   as :file:`zephyr/zephyr.exe`.
+
+   ``<final_image>`` is expected to have been set to assemble other dependent images into itself
+   if necessary, by calling :cmake:command:`native_simulator_set_child_images`.
+
+   This allows other tools, like twister or the bsim test scripts, as well as users, to find this
+   final executable in the same place as for non-sysbuild builds.
+
+#]=======================================================================]
 function(native_simulator_set_final_executable final_image)
   if(("${BOARD}" MATCHES "native") OR ("${BOARD}" MATCHES "bsim"))
     add_custom_target(final_executable
@@ -27,13 +40,13 @@ function(native_simulator_set_final_executable final_image)
   endif()
 endfunction()
 
-# Usage:
-#   native_simulator_set_child_images(<final_image> <child_image>)
-#
-# When building for a native_simulator based target (including bsim targets),
-# this function sets a `<child_image>` as dependencies of `<final_image>`
-# and configures the final image to assemble the child images into its final executable.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: native_simulator_set_child_images(<final_image> <child_image>)
+
+   Set ``<child_image>`` as a dependency of ``<final_image>``, and configure the final image to
+   assemble the child image into its final executable.
+
+#]=======================================================================]
 function(native_simulator_set_child_images final_image child_image)
   if(("${BOARD}" MATCHES "native") OR ("${BOARD}" MATCHES "bsim"))
     add_dependencies(${final_image} ${child_image})
@@ -45,12 +58,13 @@ function(native_simulator_set_child_images final_image child_image)
   endif()
 endfunction()
 
-# Usage:
-#   native_simulator_set_primary_mcu_index(<image> [<image2> ...])
-#
-# Propagate the SB_CONFIG_NATIVE_SIMULATOR_PRIMARY_MCU_INDEX setting,
-# if it is set, to each given image CONFIG_NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: native_simulator_set_primary_mcu_index(<image> [<image2> ...])
+
+   Propagate the ``SB_CONFIG_NATIVE_SIMULATOR_PRIMARY_MCU_INDEX`` setting, if it is set, to the
+   ``CONFIG_NATIVE_SIMULATOR_PRIMARY_MCU_INDEX`` of each given image.
+
+#]=======================================================================]
 function(native_simulator_set_primary_mcu_index)
   if(NOT ("${SB_CONFIG_NATIVE_SIMULATOR_PRIMARY_MCU_INDEX}" STREQUAL ""))
     foreach(arg IN LISTS ARGV)

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -2,6 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+#[=======================================================================[.rst:
+sysbuild_extensions
+###################
+
+Sysbuild's CMake extension commands.
+
+This module defines the commands used to describe a :ref:`sysbuild <sysbuild>` configuration: which
+images take part in the build, how they are configured, and in which order they are configured and
+flashed.
+
+The commands documented below are available in the :file:`sysbuild.cmake` file of any application or
+Zephyr module that participates in a sysbuild build.
+
+Commands not documented here are used by sysbuild itself and may be removed, renamed, or
+re-purposed without prior notice.
+
+.. contents::
+   :backlinks: entry
+   :local:
+
+#]=======================================================================]
+
 # Usage:
 #   load_cache(IMAGE <image> BINARY_DIR <dir>)
 #
@@ -43,36 +65,50 @@ function(load_cache)
   endforeach()
 endfunction()
 
-# Usage:
-#   sysbuild_get(<variable> IMAGE <image> [VAR <image-variable>] <KCONFIG|CACHE>)
-#
-# This function will return the variable found in the CMakeCache.txt file
-# identified by image.
-# If `VAR` is provided, the name given as parameter will be looked up, but if
-# `VAR` is not given, the `<variable>` name provided will be used both for
-# lookup and value return.
-#
-# The result will be returned in `<variable>`.
-#
-# Example use:
-#   sysbuild_get(PROJECT_NAME IMAGE my_sample CACHE)
-#     will lookup PROJECT_NAME from the CMakeCache identified by `my_sample` and
-#     and return the value in the local variable `PROJECT_NAME`.
-#
-#   sysbuild_get(my_sample_PROJECT_NAME IMAGE my_sample VAR PROJECT_NAME CACHE)
-#     will lookup PROJECT_NAME from the CMakeCache identified by `my_sample` and
-#     and return the value in the local variable `my_sample_PROJECT_NAME`.
-#
-#   sysbuild_get(my_sample_CONFIG_FOO IMAGE my_sample VAR CONFIG_FOO KCONFIG)
-#     will lookup CONFIG_FOO from the KConfig identified by `my_sample` and
-#     and return the value in the local variable `my_sample_CONFIG_FOO`.
-#
-# <variable>: variable used for returning CMake cache value. Also used as lookup
-#             variable if `VAR` is not provided.
-# IMAGE:      image name identifying the cache to use for variable lookup.
-# VAR:        name of the CMake cache variable name to lookup.
-# KCONFIG:    Flag indicating that a Kconfig setting should be fetched.
-# CACHE:      Flag indicating that a CMake cache variable should be fetched.
+#[=======================================================================[.rst:
+.. cmake:signature:: sysbuild_get(<variable> IMAGE <image> [VAR <image-variable>] <KCONFIG|CACHE>)
+
+   Read a CMake cache variable or Kconfig setting from an image.
+
+   Sysbuild can only read an image once that image has been configured, for example from the
+   post-CMake hook of a :ref:`sysbuild module <sysbuild_module_integration>`.
+
+   If ``VAR`` is provided, the name given as parameter will be looked up, but if ``VAR`` is not
+   given, the ``<variable>`` name provided will be used both for lookup and value return.
+
+   The result will be returned in ``<variable>``.
+
+   ``<variable>``
+     Variable used for returning the value. Also used as lookup variable if ``VAR`` is not
+     provided.
+
+   ``IMAGE <image>``
+     Name of the image to read the variable from.
+
+   ``VAR <image-variable>``
+     Name of the variable to look up.
+
+   ``KCONFIG``
+     Flag indicating that a Kconfig setting should be fetched.
+
+   ``CACHE``
+     Flag indicating that a CMake cache variable should be fetched.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      # Look up PROJECT_NAME from the CMake cache of `my_sample` and return it
+      # in the local variable `PROJECT_NAME`.
+      sysbuild_get(PROJECT_NAME IMAGE my_sample CACHE)
+
+      # Same lookup, but returned in `my_sample_PROJECT_NAME`.
+      sysbuild_get(my_sample_PROJECT_NAME IMAGE my_sample VAR PROJECT_NAME CACHE)
+
+      # Look up the Kconfig setting CONFIG_FOO of `my_sample`.
+      sysbuild_get(my_sample_CONFIG_FOO IMAGE my_sample VAR CONFIG_FOO KCONFIG)
+
+#]=======================================================================]
 function(sysbuild_get variable)
   cmake_parse_arguments(GET_VAR "CACHE;KCONFIG" "IMAGE;VAR" "" ${ARGN})
 
@@ -189,35 +225,49 @@ function(sysbuild_cache)
 
 endfunction()
 
-# Usage:
-#   ExternalZephyrProject_Add(APPLICATION <name>
-#                             SOURCE_DIR <dir>
-#                             [BOARD <board> [BOARD_REVISION <revision>]]
-#                             [APP_TYPE <MAIN|BOOTLOADER|FIRMWARE_LOADER>]
-#                             [BUILD_ONLY <bool>]
-#   )
-#
-# This function includes a Zephyr based build system into the multiimage
-# build system
-#
-# APPLICATION: <name>:       Name of the application, name will also be used for build
-#                            folder of the application
-# SOURCE_DIR <dir>:          Source directory of the application
-# BOARD <board>:             Use <board> for application build instead user defined BOARD.
-# BOARD_REVISION <revision>: Use <revision> of <board> for application (only valid if
-#                            <board> is also supplied).
-# APP_TYPE <MAIN|BOOTLOADER|: Application type.
-#           FIRMWARE_LOADER>  MAIN indicates this application is the main application
-#                             and where user defined settings should be passed on as-is
-#                             except for multi image build flags.
-#                             For example, -DCONF_FILES=<files> will be passed on to the
-#                             MAIN_APP unmodified.
-#                             BOOTLOADER indicates this app is a bootloader
-#                             FIRMWARE_LOADER indicates this app is a firmware loader image for MCUboot
-# BUILD_ONLY <bool>:          Mark the application as build-only. If <bool> evaluates to
-#                             true, then this application will be excluded from flashing
-#                             and debugging.
-#
+#[=======================================================================[.rst:
+.. cmake:signature::
+   ExternalZephyrProject_Add(APPLICATION <name>
+                             SOURCE_DIR <dir>
+                             [BOARD <board> [BOARD_REVISION <revision>]]
+                             [APP_TYPE <MAIN|BOOTLOADER|FIRMWARE_LOADER>]
+                             [BUILD_ONLY <bool>]
+   )
+
+   Include a Zephyr based build system into the multi-image build system.
+
+   ``APPLICATION <name>``
+     Name of the application. The name will also be used for the build folder of the application.
+
+   ``SOURCE_DIR <dir>``
+     Source directory of the application.
+
+   ``BOARD <board>``
+     Use ``<board>`` for the application build instead of the user defined
+     :cmake:variable:`BOARD`.
+
+   ``BOARD_REVISION <revision>``
+     Use ``<revision>`` of ``<board>`` for the application. Only valid if ``BOARD`` is also
+     supplied.
+
+   ``APP_TYPE <MAIN|BOOTLOADER|FIRMWARE_LOADER>``
+     Application type.
+
+     ``MAIN`` indicates this application is the main application, and where user defined settings
+     should be passed on as-is except for multi image build flags. For example,
+     ``-DCONF_FILE=<files>`` will be passed on to the main application unmodified.
+
+     ``BOOTLOADER`` indicates this application is a bootloader.
+
+     ``FIRMWARE_LOADER`` indicates this application is a firmware loader image for MCUboot.
+
+   ``BUILD_ONLY <bool>``
+     Mark the application as build-only. If ``<bool>`` evaluates to true, then this application
+     will be excluded from flashing and debugging.
+
+   See :ref:`sysbuild_zephyr_application` for a worked example.
+
+#]=======================================================================]
 function(ExternalZephyrProject_Add)
   set(app_types MAIN BOOTLOADER FIRMWARE_LOADER)
   cmake_parse_arguments(ZBUILD "" "APPLICATION;BOARD;BOARD_REVISION;SOURCE_DIR;APP_TYPE;BUILD_ONLY" "" ${ARGN})
@@ -434,32 +484,48 @@ function(ExternalZephyrProject_Add)
   endif()
 endfunction()
 
-# Usage:
-#   ExternalZephyrVariantProject_Add(APPLICATION <name>
-#                                    SOURCE_APP <name>
-#                                    [SNIPPET <snippet>]
-#                                    [EXTRA_DTC_OVERLAY_FILE <file>]
-#                                    [EXTRA_CONF_FILE <file>]
-#                                    [BUILD_ONLY <bool>]
-#   )
-#
-# This function duplicates an existing Zephyr based build system into the multi-image
-# build system with a specified modification. This will not creates the extra build targets that
-# ExternalZephyrProject_Add() adds e.g. ``<app>_menuconfig``. Note that the variant image must
-# either have a ``CONF_FILE``, ``EXTRA_CONF_FILE``, ``EXTRA_DTC_OVERLAY_FILE`` or ``SNIPPET``
-# added to it or it will be invalid and image configuration will result in a fatal error.
-#
-# APPLICATION: <name>:           Name of the application, name will also be used for build folder
-#                                of the application.
-# SOURCE_APP <name>:             Name of the existing image to use for duplication.
-# SNIPPET <snippet>:             List of default snippets to apply for variant image.
-# EXTRA_DTC_OVERLAY_FILE <file>: List of default extra DTC files to apply for variant image.
-# EXTRA_CONF_FILE <file>:        List of default extra Kconfig fragments to apply for variant
-#                                image.
-# BUILD_ONLY <bool>:             Mark the application as build-only. If <bool> evaluates to true,
-#                                then this application will be excluded from flashing and
-#                                debugging.
-#
+#[=======================================================================[.rst:
+.. cmake:signature::
+   ExternalZephyrVariantProject_Add(APPLICATION <name>
+                                    SOURCE_APP <name>
+                                    [SNIPPET <snippet>]
+                                    [EXTRA_DTC_OVERLAY_FILE <file>]
+                                    [EXTRA_CONF_FILE <file>]
+                                    [BUILD_ONLY <bool>]
+   )
+
+   Duplicate an existing Zephyr based build system into the multi-image build system with a
+   specified modification.
+
+   This will not create the extra build targets that :cmake:command:`ExternalZephyrProject_Add`
+   adds, for example ``<app>_menuconfig``.
+
+   .. note::
+
+      The variant image must have a :cmake:variable:`CONF_FILE`,
+      :cmake:variable:`EXTRA_CONF_FILE`, :cmake:variable:`EXTRA_DTC_OVERLAY_FILE` or ``SNIPPET``
+      added to it, or it will be invalid and image configuration will result in a fatal error.
+
+   ``APPLICATION <name>``
+     Name of the application. The name will also be used for the build folder of the application.
+
+   ``SOURCE_APP <name>``
+     Name of the existing image to use for duplication.
+
+   ``SNIPPET <snippet>``
+     List of default snippets to apply for the variant image.
+
+   ``EXTRA_DTC_OVERLAY_FILE <file>``
+     List of default extra devicetree overlay files to apply for the variant image.
+
+   ``EXTRA_CONF_FILE <file>``
+     List of default extra Kconfig fragments to apply for the variant image.
+
+   ``BUILD_ONLY <bool>``
+     Mark the application as build-only. If ``<bool>`` evaluates to true, then this application
+     will be excluded from flashing and debugging.
+
+#]=======================================================================]
 function(ExternalZephyrVariantProject_Add)
   cmake_parse_arguments(ZBUILD "" "SOURCE_APP;APPLICATION;SNIPPET;EXTRA_DTC_OVERLAY_FILE;EXTRA_CONF_FILE;BUILD_ONLY" "" ${ARGN})
 
@@ -822,26 +888,34 @@ function(sysbuild_module_call)
   endforeach()
 endfunction()
 
-# Usage:
-#   sysbuild_cache_set(VAR <variable> [APPEND [REMOVE_DUPLICATES]] <value>)
-#
-# This function will set the specified value of the sysbuild cache variable in
-# the CMakeCache.txt file which can then be accessed by images.
-# `VAR` specifies the variable name to set/update.
-#
-# The result will be returned in `<variable>`.
-#
-# Example use:
-#   sysbuild_cache_set(VAR ATTRIBUTES APPEND REMOVE_DUPLICATES battery)
-#     Will add the item `battery` to the `ATTRIBUTES` variable as a new element
-#     in the list in the CMakeCache and remove any duplicates from the list.
-#
-# <variable>:        Name of variable in CMake cache.
-# APPEND:            If specified then will append the supplied data to the
-#                    existing value as a list.
-# REMOVE_DUPLICATES: If specified then remove duplicate entries contained
-#                    within the list before saving to the cache.
-# <value>:           Value to set/update.
+#[=======================================================================[.rst:
+.. cmake:signature:: sysbuild_cache_set(VAR <variable> [APPEND [REMOVE_DUPLICATES]] <value>)
+
+   Set a sysbuild cache variable, which can then be accessed by images.
+
+   The result will be returned in ``<variable>``.
+
+   ``VAR <variable>``
+     Name of the variable in the CMake cache.
+
+   ``APPEND``
+     If specified, append the supplied data to the existing value as a list.
+
+   ``REMOVE_DUPLICATES``
+     If specified, remove duplicate entries contained within the list before saving to the cache.
+
+   ``<value>``
+     Value to set or update.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      # Add `battery` to the `ATTRIBUTES` list in the CMake cache, removing
+      # any duplicates from the list.
+      sysbuild_cache_set(VAR ATTRIBUTES APPEND REMOVE_DUPLICATES battery)
+
+#]=======================================================================]
 function(sysbuild_cache_set)
   cmake_parse_arguments(VARS "APPEND;REMOVE_DUPLICATES" "VAR" "" ${ARGN})
 
@@ -886,6 +960,38 @@ function(sysbuild_cache_set)
   set(${VARS_VAR} "${var_new}" CACHE "${var_type}" "${var_help}" FORCE)
 endfunction()
 
+#[=======================================================================[.rst:
+Setting Kconfig values on an image
+==================================
+
+The following commands add a Kconfig fragment line to ``<image>``. They are the supported way for
+a :file:`sysbuild.cmake` file to configure an image it has added.
+
+The collected fragment is passed to the image as a forced input configuration, so it is applied
+last and takes precedence over the image's own Kconfig fragments. See
+:ref:`sysbuild_kconfig_namespacing` for how these relate to ``SB_CONFIG_`` options.
+
+.. cmake:signature:: set_config_bool(<image> <setting> <value>)
+
+   Set a boolean Kconfig option to ``y`` if ``<value>`` evaluates to true, and to ``n`` otherwise.
+
+.. cmake:signature:: set_config_string(<image> <setting> <value>)
+
+   Set a string Kconfig option to ``<value>``.
+
+.. cmake:signature:: set_config_int(<image> <setting> <value>)
+
+   Set an int or hex Kconfig option to ``<value>``.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      set_config_bool(${DEFAULT_IMAGE} CONFIG_BOOTLOADER_MCUBOOT y)
+      set_config_string(${DEFAULT_IMAGE} CONFIG_MCUBOOT_SIGNATURE_KEY_FILE "${keyfile}")
+      set_config_int(mcuboot CONFIG_LOG_MAX_LEVEL 2)
+
+#]=======================================================================]
 function(set_config_bool image setting value)
   if(${value})
     set_property(TARGET ${image} APPEND_STRING PROPERTY CONFIG "${setting}=y\n")
@@ -946,17 +1052,20 @@ function(sysbuild_mcuboot_application_signature_key_file out_var key_files)
   set(${out_var} "${resolved}" PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   sysbuild_add_subdirectory(<source_dir> [<binary_dir>])
-#
-# This function extends the standard add_subdirectory() command with additional,
-# recursive processing of the sysbuild images added via <source_dir>.
-#
-# After exiting <source_dir>, this function will take every image added so far,
-# and include() its sysbuild.cmake file (if found). If more images get added at
-# this stage, their sysbuild.cmake files will be included as well, and so on.
-# This continues until all expected images have been added, before returning.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: sysbuild_add_subdirectory(<source_dir> [<binary_dir>])
+
+   Add a subdirectory, and recursively process the sysbuild images it adds.
+
+   This command extends :cmake:command:`add_subdirectory <command:add_subdirectory>` with
+   additional, recursive processing of the sysbuild images added via ``<source_dir>``.
+
+   After exiting ``<source_dir>``, this command will take every image added so far and
+   :cmake:command:`include() <command:include>` its :file:`sysbuild.cmake` file, if found. If more
+   images get added at this stage, their :file:`sysbuild.cmake` files will be included as well, and
+   so on. This continues until all expected images have been added, before returning.
+
+#]=======================================================================]
 function(sysbuild_add_subdirectory source_dir)
   if(ARGC GREATER 2)
     message(FATAL_ERROR
@@ -985,18 +1094,24 @@ function(sysbuild_add_subdirectory source_dir)
   endwhile()
 endfunction()
 
-# Usage:
-#   sysbuild_add_dependencies(<CONFIGURE | FLASH> <image> [<image-dependency> ...])
-#
-# This function makes an image depend on other images in the configuration or
-# flashing order. Each image named "<image-dependency>" will be ordered before
-# the image named "<image>".
-#
-# CONFIGURE: Add CMake configuration dependencies. This will determine the order
-#            in which `ExternalZephyrProject_Cmake()` will be called.
-# FLASH:     Add flashing dependencies. This will determine the order in which
-#            all images will appear in `domains.yaml`.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: sysbuild_add_dependencies(<CONFIGURE | FLASH> <image> [<image-dependency> ...])
+
+   Make an image depend on other images in the configuration or flashing order.
+
+   Each image named ``<image-dependency>`` will be ordered before the image named ``<image>``.
+
+   ``CONFIGURE``
+     Add CMake configuration dependencies. This will determine the order in which images are
+     configured.
+
+   ``FLASH``
+     Add flashing dependencies. This will determine the order in which all images will appear in
+     :file:`domains.yaml`.
+
+   See :ref:`sysbuild_zephyr_application_dependencies` for a worked example.
+
+#]=======================================================================]
 function(sysbuild_add_dependencies dependency_type image)
   set(valid_dependency_types CONFIGURE FLASH)
   if(NOT dependency_type IN_LIST valid_dependency_types)
@@ -1026,13 +1141,15 @@ function(sysbuild_add_dependencies dependency_type image)
   set_property(TARGET ${image} APPEND PROPERTY ${property_name} ${ARGN})
 endfunction()
 
-# Usage:
-#   sysbuild_images_order(<variable> <CONFIGURE | FLASH> IMAGES <images>)
-#
-# This function will sort the provided `<images>` to satisfy the dependencies
-# specified using `sysbuild_add_dependencies()`. The result will be returned in
-# `<variable>`.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: sysbuild_images_order(<variable> <CONFIGURE | FLASH> IMAGES <images>)
+
+   Sort the provided ``<images>`` to satisfy the dependencies specified using
+   :cmake:command:`sysbuild_add_dependencies`.
+
+   The result will be returned in ``<variable>``.
+
+#]=======================================================================]
 function(sysbuild_images_order variable dependency_type)
   cmake_parse_arguments(SIS "" "" "IMAGES" ${ARGN})
   zephyr_check_arguments_required_all("sysbuild_images_order" SIS IMAGES)

--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -2,6 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+#[=======================================================================[.rst:
+sysbuild_kconfig
+################
+
+Sysbuild's own Kconfig configuration.
+
+Sysbuild has a Kconfig tree of its own, rooted at the application's :file:`Kconfig.sysbuild` file
+and namespaced under ``SB_CONFIG_`` so that it cannot collide with an image's own ``CONFIG_``
+options. See :ref:`sysbuild_kconfig_namespacing`.
+
+This module locates the sysbuild configuration files and runs Kconfig over them. It also defines
+the ``sysbuild_menuconfig`` and ``sysbuild_guiconfig`` build targets, which edit sysbuild's own
+configuration rather than that of any image.
+
+Configuration input files are looked up in :cmake:variable:`SB_APPLICATION_CONFIG_DIR`, falling
+back to :cmake:variable:`APPLICATION_CONFIG_DIR`, and are controlled by:
+
+* :cmake:variable:`SB_CONF_FILE`
+* :cmake:variable:`SB_EXTRA_CONF_FILE`
+
+#]=======================================================================]
+
 set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_sysbuild_menuconfig
   ${ZEPHYR_BASE}/scripts/kconfig/menuconfig.py
 )

--- a/share/sysbuild/cmake/modules/sysbuild_root.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_root.cmake
@@ -2,24 +2,30 @@
 #
 # Copyright (c) 2024, Nordic Semiconductor ASA
 
-# Convert Zephyr roots to absolute paths to be used by sysbuild.
-#
-# This CMake module will convert all relative paths in existing ROOT lists to
-# absolute path relative from APP_DIR.
-#
-# Optional variables:
-# - ARCH_ROOT:       CMake list of arch roots containing arch implementations
-# - SOC_ROOT:        CMake list of SoC roots containing SoC implementations
-# - BOARD_ROOT:      CMake list of board roots containing board and shield implementations
-# - MODULE_EXT_ROOT: CMake list of module external roots containing module glue code
-# - SCA_ROOT:        CMake list of SCA roots containing static code analysis integration code
-#
-# If a root is defined it will check the list of paths in the root and convert
-# any relative path to absolute path and update the root list.
-# If a root is undefined it will still be undefined when this module has loaded.
-#
-# Converted paths are placed in the CMake cache so that they are propagated
-# correctly to image builds.
+#[=======================================================================[.rst:
+sysbuild_root
+#############
+
+Convert Zephyr roots to absolute paths to be used by sysbuild.
+
+This module converts all relative paths in the following root lists to absolute paths, relative
+from :cmake:variable:`APP_DIR`:
+
+* :cmake:variable:`ARCH_ROOT`
+* :cmake:variable:`BOARD_ROOT`
+* :cmake:variable:`MODULE_EXT_ROOT`
+* :cmake:variable:`SCA_ROOT`
+* :cmake:variable:`SNIPPET_ROOT`
+* :cmake:variable:`SOC_ROOT`
+
+If a root is defined, this module checks the list of paths in the root, converts any relative path
+to an absolute path, and updates the root list. If a root is undefined, it is still undefined once
+this module has loaded.
+
+Converted paths are placed in the CMake cache so that they are propagated correctly to image
+builds.
+
+#]=======================================================================]
 
 include_guard(GLOBAL)
 


### PR DESCRIPTION
Follow-up to the CMake build system reference documentation. Sysbuild is a second CMake extension surface that was entirely absent from the reference: its commands were described only in `#` comments and in prose under `doc/build/sysbuild/`.

https://builds.zephyrproject.io/zephyr/pr/117588/docs/build/cmake-ref/index.html
https://builds.zephyrproject.io/zephyr/pr/117588/docs/build/cmake-ref/module/sysbuild_extensions.html

## What this adds

`share/sysbuild/cmake/modules` is now pulled into the documentation build, and four sysbuild modules are rendered through the CMake domain:

| Module | Contents |
| --- | --- |
| `sysbuild_extensions` | The 10 commands a `sysbuild.cmake` calls |
| `sysbuild_kconfig` | Sysbuild's own Kconfig tree and its input files |
| `sysbuild_root` | Root list conversion for image builds |
| `native_simulator_sb_extensions` | The 3 `native_simulator_*` commands |

## What is deliberately not documented

Commands only invoked by sysbuild itself are left as plain comments, and the module page says so: `load_cache`, `sysbuild_cache`, `ExternalZephyrProject_Cmake`, `sysbuild_module_call` and the two `sysbuild_mcuboot_*` helpers. Each has zero callers outside `share/sysbuild/cmake/modules/`. `sysbuild_images`, `sysbuild_merged_hex` and `sysbuild_default` are internal machinery and are also left alone.

TBD: `set_config_bool()`, `set_config_string()` and `set_config_int()` had no documentation at all despite 47, 8 and 3 call sites.

## Formatting

The `.cmake` diffs look large but are comment-to-reStructuredText conversions only.

## Corrections made along the way

- `ExternalZephyrProject_Add` documented `-DCONF_FILES=<files>`; the variable is `CONF_FILE` (`CONF_FILES` exists only as a `zephyr_file()` keyword).
- The `sysbuild_root` header listed five roots but the module handles six: `SNIPPET_ROOT` was missing.