### PR TITLE
drivers: wifi: siwx91x: relocate APIs from siwx91x_on_join()

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -524,6 +524,7 @@ static void siwx91x_iface_init(struct net_if *iface)
 
 	sidev->state = WIFI_STATE_INTERFACE_DISABLED;
 	sidev->iface = iface;
+	k_work_init(&sidev->on_join_work, siwx91x_on_join_work);
 
 	sl_wifi_set_callback_v2(SL_WIFI_SCAN_RESULT_EVENTS, siwx91x_on_scan, sidev);
 	sl_wifi_set_callback_v2(SL_WIFI_JOIN_EVENTS, siwx91x_on_join, sidev);

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -26,6 +26,8 @@ struct siwx91x_dev {
 	uint8_t max_num_sta;
 	bool reboot_needed;
 	bool hidden_ssid;
+	/* Runs net_if_dormant_off / IP / PS off the WiseConnect event engine */
+	struct k_work on_join_work;
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_OFFLOAD
 	struct k_event fds_recv_event;

--- a/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
 
 #include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
@@ -125,6 +126,24 @@ unsigned int siwx91x_on_join(sl_wifi_event_t event, unsigned int status,
 
 	wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_SUCCESS);
 	sidev->state = WIFI_STATE_COMPLETED;
+	k_work_submit(&sidev->on_join_work);
+
+	return 0;
+}
+
+/*
+ * siwx91x_on_join runs on the WiseConnect event-engine thread. Sync NWP
+ * commands from that context (multicast filter via net_if_dormant_off,
+ * DHCP, power-save) block the engine so BLE RX buffers cannot be freed and
+ * the shared pool exhausts. Defer that work to the system workqueue.
+ */
+void siwx91x_on_join_work(struct k_work *work)
+{
+	struct siwx91x_dev *sidev = CONTAINER_OF(work, struct siwx91x_dev, on_join_work);
+
+	if (sidev->state != WIFI_STATE_COMPLETED) {
+		return;
+	}
 
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
 		net_if_dormant_off(sidev->iface);
@@ -134,8 +153,6 @@ unsigned int siwx91x_on_join(sl_wifi_event_t event, unsigned int status,
 	siwx91x_on_join_ipv6(sidev);
 
 	siwx91x_apply_power_save(sidev);
-
-	return 0;
 }
 
 int siwx91x_disconnect(const struct device *dev, struct net_if *iface)

--- a/drivers/wifi/siwx91x/siwx91x_wifi_sta.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_sta.h
@@ -9,6 +9,7 @@
 
 struct device;
 struct wifi_connect_req_params;
+struct k_work;
 
 int siwx91x_connect(const struct device *dev, struct net_if *iface,
 		    struct wifi_connect_req_params *params);
@@ -18,5 +19,6 @@ unsigned int siwx91x_wifi_module_stats_event_handler(sl_wifi_event_t event, unsi
 						    void *data, uint32_t data_length, void *arg);
 unsigned int siwx91x_on_join(sl_wifi_event_t event, unsigned int status,
 			     void *data, uint32_t data_length, void *arg);
+void siwx91x_on_join_work(struct k_work *work);
 
 #endif


### PR DESCRIPTION
When running the sequence Wi-Fi Connection → DHCP → Wi-Fi Disconnection in a loop while BLE advertising and scanning are active, heap exhaustion occurs after several iterations, causing RX buffer allocation failures. 
However, the issue here is that, buffers are not released immediately after heap exhaustion. 
In my observation, it can take 30 seconds to 1 minute before the buffers are freed and RX allocation starts succeeding again. 
Based on the analysis, this delay appears to be caused by blocking APIs being invoked inside the join callback.  Since the heap is exhausted, the corresponding responses cannot be processed, resulting in the commands eventually timing out. Buffers are released only after these timeouts occur.​‌
