### PR TITLE
scripts: ci: check_compliance: run checks in parallel by default

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -90,7 +90,7 @@ jobs:
         # Increase rename limit to allow for large PRs
         git config diff.renameLimit 10000
         excludes="-e KconfigBasic -e SysbuildKconfigBasic -e ClangFormat"
-        ./scripts/ci/check_compliance.py --annotate $excludes --parallel -c origin/${BASE_REF}..
+        ./scripts/ci/check_compliance.py --annotate $excludes -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -659,14 +659,13 @@ before opening a new Pull Request:
 
    ./scripts/ci/check_compliance.py -c <commit range>
 
-The checks run sequentially by default. Pass ``--parallel`` (or ``-p N`` to
-limit the number of worker processes to ``N``) to run them in parallel, which
-can significantly reduce the total runtime, especially for the Kconfig-based
-checks.
+The checks run in parallel, using one worker process per CPU. Pass ``-p N`` to
+limit the number of worker processes to ``N``, or ``-p 1`` to run the checks
+sequentially.
 
 .. code-block:: bash
 
-   ./scripts/ci/check_compliance.py --parallel -c <commit range>
+   ./scripts/ci/check_compliance.py -p 1 -c <commit range>
 
 .. note::
    On Windows if the .pl extension has not yet been associated with an

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -3055,6 +3055,8 @@ def _run_tests_parallel(testcases, jobs, loglevel):
     # 'jobs' is 0). Returns the same tuples as _run_tests_sequential().
     jobs = jobs or os.cpu_count() or 1
     jobs = min(jobs, len(testcases)) or 1
+    if jobs == 1:
+        return _run_tests_sequential(testcases)
 
     # Start the slowest checks first so that they are not left running alone at
     # the end. The Kconfig-based checks each parse a full Kconfig tree.
@@ -3176,16 +3178,16 @@ def parse_args(argv):
         nargs='?',
         type=int,
         const=0,
-        default=None,
+        default=0,
         metavar='N',
         help='''Run the checks in parallel, using N worker processes (one per
-                CPU if N is 0 or omitted). The default is to run the checks
-                sequentially.''',
+                CPU if N is 0 or omitted, which is the default). Pass 1 to run
+                the checks sequentially.''',
     )
 
     args = parser.parse_args(argv)
 
-    if args.parallel is not None and args.parallel < 0:
+    if args.parallel < 0:
         parser.error("argument -p/--parallel: N must be >= 0")
 
     return args
@@ -3249,10 +3251,10 @@ def _main(args):
 
         testcases.append(testcase)
 
-    if args.parallel is not None:
-        results = _run_tests_parallel(testcases, args.parallel, args.loglevel)
-    else:
+    if args.parallel == 1:
         results = _run_tests_sequential(testcases)
+    else:
+        results = _run_tests_parallel(testcases, args.parallel, args.loglevel)
 
     for testcase, case, fmtd_failures in results:
         # Annotate if required


### PR DESCRIPTION
Run the compliance checks in parallel by default, one worker per CPU. Pass `-p 1` to get the old sequential behavior.