### PR TITLE
tests: drivers: uart: async_api: increase read abort baudrate

### DIFF
--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -686,7 +686,7 @@ ZTEST_USER(uart_async_read_abort, test_read_abort)
 	 * RX interrupt load and delay TX completion handling on some platforms.
 	 */
 	if (!IS_ENABLED(CONFIG_UART_WIDE_DATA)) {
-		cfg.baudrate = MIN(cfg.baudrate, 9600);
+		cfg.baudrate = MIN(cfg.baudrate, 19200);
 	}
 	zassert_ok(uart_configure(uart_dev, &cfg));
 


### PR DESCRIPTION
Fast nRF UARTE instances cannot accurately generate the 9600 baud.
On nRF54x devices (fast UARTE clocked by HFCLK) the baudrate 9600
results in 9460 thus a 95 byte transfer takes ~2ms longer than
calculated from the requested baudrate.

Use 19200 baud instead. It halves the nominal transfer time and thus
the absolute error, while it is still slow enough to abort the transfer
before it is finished.