### PR TITLE
drivers: mipi_dsi: stm32: align generic write with the API

### DIFF
--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -402,20 +402,25 @@ static ssize_t mipi_dsi_stm32_transfer(const struct device *dev, uint8_t channel
 	case MIPI_DSI_GENERIC_SHORT_WRITE_0_PARAM:
 	case MIPI_DSI_GENERIC_SHORT_WRITE_1_PARAM:
 	case MIPI_DSI_GENERIC_SHORT_WRITE_2_PARAM:
-		param1 = ((uint8_t *)msg->tx_buf)[0];
-		if (msg->tx_len == 1U) {
-			param2 = ((uint8_t *)msg->tx_buf)[1];
+		if (msg->tx_len >= 1U) {
+			param1 = ((uint8_t *)msg->tx_buf)[0];
 		}
 
 		if (msg->tx_len >= 2U) {
-			param2 = *(uint16_t *)&((uint8_t *)msg->tx_buf)[1];
+			param2 = ((uint8_t *)msg->tx_buf)[1];
 		}
 
 		ret = HAL_DSI_ShortWrite(&data->hdsi, channel, msg->type, param1, param2);
 		len = msg->tx_len;
 		break;
 	case MIPI_DSI_GENERIC_LONG_WRITE:
-		ret = HAL_DSI_LongWrite(&data->hdsi, channel, msg->type, msg->tx_len,
+		if (msg->tx_len == 0U) {
+			LOG_ERR("Generic long write with an empty buffer");
+			return -EINVAL;
+		}
+
+		/* The first payload byte is passed separately from the remaining ones. */
+		ret = HAL_DSI_LongWrite(&data->hdsi, channel, msg->type, msg->tx_len - 1U,
 					((uint8_t *)msg->tx_buf)[0], &((uint8_t *)msg->tx_buf)[1]);
 		len = msg->tx_len;
 		break;


### PR DESCRIPTION
`mipi_dsi_generic_write()` documents `len` as "@param len Length of the transmission buffer", and `mipi_dsi.c` derives the packet type from it. The NXP and Renesas hosts conform to this and send exactly `len` bytes, but the ST host reads `len + 1`: 

- short writes read `tx_buf[1]` when `len` is 1, and a 16-bit word at `tx_buf[1]` when `len` is 2
- long writes pass `len` as `NbParams` while also passing `tx_buf[0]` separately as `Param1`. `HAL_DSI_LongWrite()` transmits `Param1` followed by `NbParams` bytes, so the packet carries one extra stray byte.

Every in-tree generic caller passes the full buffer length, and the driver reads one byte past the caller's buffer:

- `tests/drivers/mipi_dsi/api/src/main.c:34` writes a register and its value from `uint8_t param[2]` with `len` 2, so the API test itself reads `param[2]`
- `display_rm67199.c` does the same from `uint8_t buf[2]` (lines 372, 381, 389, 408)
- `display_hx8394.c` passes 2 byte const arrays such as `hx8394_cmd3[]`, and its longer `*_config[]` tables go through the long write path
- `display_st7701.c` runs on an ST host today (Arduino GIGA Display Shield). Its 6 byte bank select `ff 77 01 00 00 10` at line 176 goes out as a 7 byte payload whose last byte is read from past the array.

~I've added a migration note because an out-of-tree driver might have compensated by passing `len` one byte short of its buffer will now send a truncated packet (st7701 was written this way).~