### PR TITLE
soc: adi: max32: Fix MPU partitioning

### DIFF
--- a/soc/adi/max32/mpu_regions.c
+++ b/soc/adi/max32/mpu_regions.c
@@ -26,22 +26,27 @@
 	}
 
 #define MAX32_MPU_REGION(name, base, attr, size) MPU_REGION_ENTRY(name, (base), attr((base), size))
+#if DT_HAS_CHOSEN(zephyr_settings_partition)
+#define STORAGE_PARTITION DT_CHOSEN(zephyr_settings_partition)
+#else
+#define STORAGE_PARTITION DT_NODELABEL(storage_partition)
+#endif /* DT_HAS_CHOSEN(zephyr_settings_partition) */
 
 /*
  * The MPU regions are defined in the following way:
  * - Cacheable flash region
- * - Non-cacheable flash region, i.e., storage area at the end of the flash
+ * - Non-cacheable flash region, i.e., storage area in flash
  * - SRAM region
  * If the storage partition is not defined, the flash region spans the whole
  * flash.
  */
 static const struct arm_mpu_region mpu_regions[] = {
-#if PARTITION_EXISTS(storage_partition)
-#define STORAGE_ADDR (CONFIG_FLASH_BASE_ADDRESS + PARTITION_OFFSET(storage_partition))
-#define STORAGE_SIZE (PARTITION_SIZE(storage_partition) >> 10)
-	MAX32_MPU_REGION("FLASH", CONFIG_FLASH_BASE_ADDRESS, REGION_FLASH_ATTR,
-			 KB(CONFIG_FLASH_SIZE - STORAGE_SIZE)),
-	MAX32_MPU_REGION("STORAGE", STORAGE_ADDR, MAX32_FLASH_NON_CACHEABLE, KB(STORAGE_SIZE)),
+#if DT_NODE_EXISTS(STORAGE_PARTITION)
+#define STORAGE_ADDR DT_PARTITION_ADDR(STORAGE_PARTITION)
+#define STORAGE_SIZE DT_REG_SIZE(STORAGE_PARTITION)
+	MAX32_MPU_REGION("FLASH", DT_PARTITION_ADDR(DT_CHOSEN(zephyr_code_partition)),
+			 REGION_FLASH_ATTR, DT_REG_SIZE(DT_CHOSEN(zephyr_code_partition))),
+	MAX32_MPU_REGION("STORAGE", STORAGE_ADDR, MAX32_FLASH_NON_CACHEABLE, STORAGE_SIZE),
 #else
 	MAX32_MPU_REGION("FLASH", CONFIG_FLASH_BASE_ADDRESS, REGION_FLASH_ATTR,
 			 KB(CONFIG_FLASH_SIZE)),

--- a/soc/adi/max32/mpu_regions.c
+++ b/soc/adi/max32/mpu_regions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,9 +12,15 @@
  * Define noncacheable flash region attributes using noncacheable SRAM memory
  * attribute index.
  */
+#if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
+#define MAX32_RBAR_RW_MASK P_RW_U_RO_Msk
+#else
+#define MAX32_RBAR_RW_MASK RO_Msk
+#endif /* CONFIG_MPU_ALLOW_FLASH_WRITE */
+
 #define MAX32_FLASH_NON_CACHEABLE(base, size)                                                      \
 	{                                                                                          \
-		.rbar = RO_Msk | NON_SHAREABLE_Msk,                                                \
+		.rbar = NOT_EXEC | MAX32_RBAR_RW_MASK | NON_SHAREABLE_Msk,                         \
 		.mair_idx = MPU_MAIR_INDEX_SRAM_NOCACHE,                                           \
 		.r_limit = REGION_LIMIT_ADDR(base, size),                                          \
 	}


### PR DESCRIPTION
Use `DT_PARTITION_ADDR()` to obtain partition addresses rather than assuming a fixed layout where the storage partition follows the code partition.

Give write access to non-cacheable storage partition if `CONFIG_MPU_ALLOW_FLASH_WRITE` is enabled.