### PR TITLE
west.yml: update STM32 HAL to latest revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 02baa06ccea3304d1f65ec6550c68e5e300fcc58
+      revision: 9e579a021d6ed794a7c2a4777a4c5be552769035
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update the STM32 HAL repository to the latest revision, including STM32WB0 BLE integration cleanup.

Related PR: https://github.com/zephyrproject-rtos/hal_stm32/pull/402