### PR TITLE
Bluetooth: Host: Make bt_le_ext_adv_get_index take const adv

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1498,7 +1498,7 @@ int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv);
  * @return Index of the advertising set object.
  * The range of the returned value is 0..@kconfig{CONFIG_BT_EXT_ADV_MAX_ADV_SET}-1
  */
-uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv);
+uint8_t bt_le_ext_adv_get_index(const struct bt_le_ext_adv *adv);
 
 /** Advertising states. */
 enum bt_le_ext_adv_state {

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -185,7 +185,7 @@ static struct bt_le_ext_adv adv_pool[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
 
 
 #if defined(CONFIG_BT_EXT_ADV)
-uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv)
+uint8_t bt_le_ext_adv_get_index(const struct bt_le_ext_adv *adv)
 {
 	__ASSERT(IS_ARRAY_ELEMENT(adv_pool, adv), "Invalid bt_adv pointer");
 

--- a/tests/bluetooth/host/id/mocks/adv.c
+++ b/tests/bluetooth/host/id/mocks/adv.c
@@ -10,7 +10,7 @@
 
 DEFINE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable, struct bt_le_ext_adv *, bool);
 DEFINE_FAKE_VALUE_FUNC(struct bt_le_ext_adv *, bt_le_adv_lookup_legacy);
-DEFINE_FAKE_VALUE_FUNC(uint8_t, bt_le_ext_adv_get_index, struct bt_le_ext_adv *);
+DEFINE_FAKE_VALUE_FUNC(uint8_t, bt_le_ext_adv_get_index, const struct bt_le_ext_adv *);
 DEFINE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_legacy, struct bt_le_ext_adv *, bool);
 DEFINE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_ext, struct bt_le_ext_adv *, bool,
 		       const struct bt_le_ext_adv_start_param *);

--- a/tests/bluetooth/host/id/mocks/adv.h
+++ b/tests/bluetooth/host/id/mocks/adv.h
@@ -22,7 +22,7 @@ typedef void (*bt_le_ext_adv_foreach_cb)(struct bt_le_ext_adv *adv, void *data);
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable, struct bt_le_ext_adv *, bool);
 DECLARE_FAKE_VALUE_FUNC(struct bt_le_ext_adv *, bt_le_adv_lookup_legacy);
-DECLARE_FAKE_VALUE_FUNC(uint8_t, bt_le_ext_adv_get_index, struct bt_le_ext_adv *);
+DECLARE_FAKE_VALUE_FUNC(uint8_t, bt_le_ext_adv_get_index, const struct bt_le_ext_adv *);
 DECLARE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_legacy, struct bt_le_ext_adv *, bool);
 DECLARE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_ext, struct bt_le_ext_adv *, bool,
 			const struct bt_le_ext_adv_start_param *);


### PR DESCRIPTION
Since this a "get" function that does not, and never should, modify the provided advertising set pointer, modify it to be const.