### PR TITLE
Display: enable rendering into display driver-owned framebuffers

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -403,6 +403,15 @@ Digital Microphone
 Display
 =======
 
+* :c:func:`display_get_framebuffer` now takes a framebuffer index and a place to report the size
+  of the buffer, so a driver owning several can hand out each of them. Callers of the old form pass
+  ``0`` for the index and ``NULL`` for the size to keep the previous behaviour. Drivers gain both
+  parameters, return ``NULL`` for any index they do not own, and set the size whenever they return
+  a buffer. A driver that hands its framebuffers out also selects
+  :kconfig:option:`CONFIG_DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS` and reports how many it owns through
+  :c:member:`display_capabilities.framebuffer_count`, so a caller can depend on the support at
+  build time instead of discovering it at run time.
+
 * The Kconfig options ``CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_*`` for SDL display pixel-format
   selection have been removed in favour of setting the pixel-format property directly in devicetree
   on the SDL pseudo-device node using the PANEL_PIXEL_FORMAT_* macros from

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -464,6 +464,13 @@ New APIs and options
   * :c:macro:`DT_IRQN_BY_NAME`
   * :c:macro:`DT_INST_IRQN_BY_NAME`
 
+* Display
+
+  * :c:member:`display_capabilities.framebuffer_count`, so a caller can tell
+    how many framebuffers a driver hands out, and
+    :kconfig:option:`CONFIG_DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS`, which a
+    driver selects to say it hands them out at all.
+
 * Haptics
 
   * :c:enumerator:`haptics_monitor`

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -16,6 +16,12 @@ config DISPLAY_INIT_PRIORITY
 	help
 	  Display devices initialization priority.
 
+config DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS
+	bool
+	help
+	  Selected by display drivers that hand out the framebuffers they own,
+	  so a caller can render into one while the driver presents another.
+
 config DISPLAY_COLOR_PALETTE
 	bool "Support for color palette"
 	help

--- a/drivers/display/Kconfig.charlieplex_led_matrix
+++ b/drivers/display/Kconfig.charlieplex_led_matrix
@@ -7,6 +7,7 @@ config DISPLAY_CHARLIEPLEX_LED_MATRIX
 	depends on DT_HAS_CHARLIEPLEX_LED_MATRIX_ENABLED
 	select GPIO
 	select COUNTER
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS
 	help
 	  Enable the display driver for a monochrome/grayscale LED matrix driven
 	  by charlieplexed GPIOs. N GPIO lines drive up to N*(N-1) LEDs; each

--- a/drivers/display/Kconfig.esp32_dsi
+++ b/drivers/display/Kconfig.esp32_dsi
@@ -9,6 +9,7 @@ menuconfig DISPLAY_ESP32_DSI
 	select ESP_SPIRAM
 	select SHARED_MULTI_HEAP
 	select MIPI_DSI
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS
 	help
 	  Enable driver for the ESP32 MIPI DSI display controller, which
 	  streams the framebuffer to a video mode panel. The framebuffers are

--- a/drivers/display/Kconfig.hub12
+++ b/drivers/display/Kconfig.hub12
@@ -7,5 +7,6 @@ config HUB12
 	depends on DT_HAS_ZEPHYR_HUB12_ENABLED
 	select SPI
 	select GPIO
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS
 	help
 	  HUB12 LED panel controller for 32x16 monochrome displays

--- a/drivers/display/Kconfig.mcux_dcnano_lcdif
+++ b/drivers/display/Kconfig.mcux_dcnano_lcdif
@@ -6,6 +6,7 @@ menuconfig DISPLAY_MCUX_DCNANO_LCDIF
 	bool "MCUX DCNano LCDIF driver"
 	default y
 	depends on DT_HAS_NXP_DCNANO_LCDIF_ENABLED
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS if MCUX_DCNANO_LCDIF_FB_NUM > 0
 	help
 	  Enable support for mcux DCNano LCDIF driver.
 

--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -8,6 +8,7 @@ menuconfig DISPLAY_MCUX_ELCDIF
 	default y
 	depends on DT_HAS_NXP_IMX_ELCDIF_ENABLED
 	select PINCTRL
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS if MCUX_ELCDIF_FB_NUM > 0
 	help
 	  Enable support for mcux eLCDIF driver.
 

--- a/drivers/display/Kconfig.mcux_lcdifv3
+++ b/drivers/display/Kconfig.mcux_lcdifv3
@@ -7,6 +7,7 @@ menuconfig DISPLAY_MCUX_LCDIFV3
 	default y
 	depends on DT_HAS_NXP_IMX_LCDIFV3_ENABLED
 	depends on CLOCK_CONTROL
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS if MCUX_LCDIFV3_FB_NUM > 0
 	help
 	  Enable support for mcux LCDIFV3 driver.
 

--- a/drivers/display/Kconfig.nrf_led_matrix
+++ b/drivers/display/Kconfig.nrf_led_matrix
@@ -7,6 +7,7 @@ config DISPLAY_NRF_LED_MATRIX
 	depends on DT_HAS_NORDIC_NRF_LED_MATRIX_ENABLED
 	select NRFX_GPIOTE
 	select NRFX_GPPI
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS
 	help
 	  Enable driver for a LED matrix with rows and columns driven by
 	  GPIOs. The driver allows setting one of 256 levels of brightness

--- a/drivers/display/Kconfig.renesas_lcdc
+++ b/drivers/display/Kconfig.renesas_lcdc
@@ -9,6 +9,7 @@ config DISPLAY_RENESAS_LCDC
 	select DMA
 	select PINCTRL
 	default y
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS
 	help
 	  Enable Smartbond display controller.
 

--- a/drivers/display/Kconfig.renesas_ra
+++ b/drivers/display/Kconfig.renesas_ra
@@ -8,6 +8,7 @@ config RENESAS_RA_GLCDC
 	default y
 	depends on DT_HAS_RENESAS_RA_GLCDC_ENABLED
 	select USE_RA_FSP_DISPLAY
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS if RENESAS_RA_GLCDC_FB_NUM > 0
 	help
 	  Enable Renesas display controller.
 

--- a/drivers/display/Kconfig.socionext_dpu
+++ b/drivers/display/Kconfig.socionext_dpu
@@ -5,6 +5,7 @@ menuconfig DISPLAY_SOCIONEXT_DPU
 	bool "Socionext DPU driver"
 	default y
 	depends on DT_HAS_SOCIONEXT_DPU_ENABLED
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS if DPU_FB_NUM > 0
 	help
 	  Enable support for dpu driver.
 

--- a/drivers/display/Kconfig.stm32_ltdc
+++ b/drivers/display/Kconfig.stm32_ltdc
@@ -13,6 +13,7 @@ menuconfig STM32_LTDC
 	select RESET
 	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_LTDC),disp-on-gpios) || \
 		$(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_LTDC),bl-ctrl-gpios)
+	select DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS if STM32_LTDC_FB_NUM > 0
 	help
 	  Enable driver for STM32 LCT-TFT display controller periheral.
 

--- a/drivers/display/display_charlieplex_led_matrix.c
+++ b/drivers/display/display_charlieplex_led_matrix.c
@@ -217,9 +217,18 @@ static int cplx_write(const struct device *dev, uint16_t x, uint16_t y,
 	return 0;
 }
 
-static void *cplx_get_framebuffer(const struct device *dev)
+static void *cplx_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
+	const struct cplx_config *cfg = dev->config;
 	struct cplx_data *data = dev->data;
+
+	if (index != 0U) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = cfg->num_pixels;
+	}
 
 	/* Exposes the per-pixel brightness buffer (1 byte/pixel, 0..max). */
 	return data->framebuf;
@@ -253,6 +262,7 @@ static void cplx_get_capabilities(const struct device *dev, struct display_capab
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO01;
 	caps->current_pixel_format = PIXEL_FORMAT_MONO01;
 	caps->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	caps->framebuffer_count = 1;
 }
 
 static int cplx_set_pixel_format(const struct device *dev, enum display_pixel_format format)

--- a/drivers/display/display_esp32_dsi.c
+++ b/drivers/display/display_esp32_dsi.c
@@ -709,22 +709,16 @@ static int display_esp32_dsi_blanking_off(const struct device *dev)
 	return display_blanking_off(config->panel);
 }
 
-static void *display_esp32_dsi_get_framebuffer(const struct device *dev)
+static void *display_esp32_dsi_get_framebuffer(const struct device *dev, uint32_t index,
+					       size_t *size)
 {
 	struct display_esp32_dsi_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
-	void *fb = data->started ? data->fb[data->draw_fb] : NULL;
+	void *fb = (data->started && index < data->fb_count) ? data->fb[index] : NULL;
 
-	k_spin_unlock(&data->lock, key);
-
-	return fb;
-}
-
-void *display_esp32_dsi_get_framebuffer_by_index(const struct device *dev, uint32_t index)
-{
-	struct display_esp32_dsi_data *data = dev->data;
-	k_spinlock_key_t key = k_spin_lock(&data->lock);
-	void *fb = (index < data->fb_count) ? data->fb[index] : NULL;
+	if (fb != NULL && size != NULL) {
+		*size = data->fb_size;
+	}
 
 	k_spin_unlock(&data->lock, key);
 
@@ -735,6 +729,7 @@ static void display_esp32_dsi_get_capabilities(const struct device *dev,
 					       struct display_capabilities *capabilities)
 {
 	const struct display_esp32_dsi_config *config = dev->config;
+	struct display_esp32_dsi_data *data = dev->data;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->width;
@@ -742,6 +737,7 @@ static void display_esp32_dsi_get_capabilities(const struct device *dev,
 	capabilities->supported_pixel_formats = config->pixel_format;
 	capabilities->current_pixel_format = config->pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = data->fb_count;
 }
 
 static int display_esp32_dsi_set_pixel_format(const struct device *dev,

--- a/drivers/display/display_esp32_dsi.h
+++ b/drivers/display/display_esp32_dsi.h
@@ -44,20 +44,6 @@ int display_esp32_dsi_start(const struct device *dev, uint32_t bits_per_pixel);
  */
 int display_esp32_dsi_stop(const struct device *dev);
 
-/**
- * @brief Address a fixed framebuffer by index.
- *
- * Unlike display_get_framebuffer(), which follows the buffer being drawn
- * into, this addresses one specific buffer. A renderer that draws one frame
- * while another is on screen needs the pair to stay put.
- *
- * @param dev DSI scanout controller device.
- * @param index Framebuffer index.
- *
- * @retval Pointer to the framebuffer, or NULL if the index is out of range.
- */
-void *display_esp32_dsi_get_framebuffer_by_index(const struct device *dev, uint32_t index);
-
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/display/display_hub12.c
+++ b/drivers/display/display_hub12.c
@@ -214,9 +214,18 @@ static int hub12_read(const struct device *dev, const uint16_t x, const uint16_t
 	return -ENOTSUP;
 }
 
-static void *hub12_get_framebuffer(const struct device *dev)
+static void *hub12_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
+	const struct hub12_config *config = dev->config;
 	struct hub12_data *data = dev->data;
+
+	if (index != 0U) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = config->width * config->height / HUB12_PIXELS_PER_BYTE;
+	}
 
 	return data->framebuffer;
 }
@@ -263,6 +272,7 @@ static void hub12_get_capabilities(const struct device *dev, struct display_capa
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO01;
 	caps->current_pixel_format = PIXEL_FORMAT_MONO01;
 	caps->screen_info = SCREEN_INFO_MONO_MSB_FIRST;
+	caps->framebuffer_count = 1;
 }
 
 static int hub12_set_pixel_format(const struct device *dev, const enum display_pixel_format pf)

--- a/drivers/display/display_lt7680.c
+++ b/drivers/display/display_lt7680.c
@@ -641,8 +641,12 @@ static int lt7680_read(const struct device *dev, const uint16_t x, const uint16_
 	return 0;
 }
 
-static void *lt7680_get_framebuffer(const struct device *dev)
+static void *lt7680_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(index);
+	ARG_UNUSED(size);
+
 	return NULL;
 }
 

--- a/drivers/display/display_mcux_dcnano_lcdif.c
+++ b/drivers/display/display_mcux_dcnano_lcdif.c
@@ -154,6 +154,7 @@ static void mcux_dcnano_lcdif_get_capabilities(const struct device *dev,
 	capabilities->supported_pixel_formats = (PIXEL_FORMAT_RGB_565 | PIXEL_FORMAT_ARGB_8888);
 #endif
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = CONFIG_MCUX_DCNANO_LCDIF_FB_NUM;
 
 	switch (data->fb_config.format) {
 	case kLCDIF_PixelFormatRGB565:
@@ -203,11 +204,20 @@ static void mcux_dcnano_lcdif_get_capabilities(const struct device *dev,
 	}
 }
 
-static void *mcux_dcnano_lcdif_get_framebuffer(const struct device *dev)
+static void *mcux_dcnano_lcdif_get_framebuffer(const struct device *dev, uint32_t index,
+					       size_t *size)
 {
 	struct mcux_dcnano_lcdif_data *data = dev->data;
 
-	return (void *)data->active_fb;
+	if (index >= CONFIG_MCUX_DCNANO_LCDIF_FB_NUM) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = data->fb_bytes;
+	}
+
+	return data->fb[index];
 }
 
 static int mcux_dcnano_lcdif_display_blanking_off(const struct device *dev)

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -247,15 +247,19 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x, const u
 	return ret;
 }
 
-static void *mcux_elcdif_get_framebuffer(const struct device *dev)
+static void *mcux_elcdif_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
 	const struct mcux_elcdif_data *dev_data = dev->data;
 
-	/* Double cast to get around the const qualifier
-	 * In the case that active_fb has been assigned from the app's buffer
-	 * in mcux_elcdif_write, the pointer already belongs to the app.
-	 */
-	return ((void *)((uint32_t)dev_data->active_fb));
+	if (index >= CONFIG_MCUX_ELCDIF_FB_NUM) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = dev_data->fb_bytes;
+	}
+
+	return dev_data->fb[index];
 }
 
 static int mcux_elcdif_display_blanking_off(const struct device *dev)
@@ -344,6 +348,7 @@ static void mcux_elcdif_get_capabilities(const struct device *dev,
 	capabilities->supported_pixel_formats = supported_fmts;
 	capabilities->current_pixel_format = ((struct mcux_elcdif_data *)dev->data)->pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = CONFIG_MCUX_ELCDIF_FB_NUM;
 	capabilities->supported_events =
 		DISPLAY_EVENT_FRAME_DONE | DISPLAY_EVENT_VSYNC | DISPLAY_EVENT_FIFO_UNDERFLOW;
 }

--- a/drivers/display/display_mcux_lcdifv3.c
+++ b/drivers/display/display_mcux_lcdifv3.c
@@ -153,11 +153,19 @@ static int mcux_lcdifv3_write(const struct device *dev, const uint16_t x, const 
 	return 0;
 }
 
-static void *mcux_lcdifv3_get_framebuffer(const struct device *dev)
+static void *mcux_lcdifv3_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
 	struct mcux_lcdifv3_data *dev_data = dev->data;
 
-	return (void *)dev_data->active_fb;
+	if (index >= CONFIG_MCUX_LCDIFV3_FB_NUM) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = dev_data->fb_bytes;
+	}
+
+	return dev_data->fb[index];
 }
 
 static void mcux_lcdifv3_get_capabilities(const struct device *dev,
@@ -172,6 +180,7 @@ static void mcux_lcdifv3_get_capabilities(const struct device *dev,
 	capabilities->supported_pixel_formats = mcux_lcdifv3_supported_fmts;
 	capabilities->current_pixel_format = dev_data->pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = CONFIG_MCUX_LCDIFV3_FB_NUM;
 }
 
 static int mcux_lcdifv3_set_pixel_format(const struct device *dev,

--- a/drivers/display/display_nrf_led_matrix.c
+++ b/drivers/display/display_nrf_led_matrix.c
@@ -159,9 +159,17 @@ static int api_blanking_off(const struct device *dev)
 	return 0;
 }
 
-static void *api_get_framebuffer(const struct device *dev)
+static void *api_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
 	struct display_drv_data *dev_data = dev->data;
+
+	if (index != 0U) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = sizeof(dev_data->framebuf);
+	}
 
 	return dev_data->framebuf;
 }
@@ -220,6 +228,7 @@ static void api_get_capabilities(const struct device *dev,
 	caps->screen_info = 0;
 	caps->current_pixel_format = PIXEL_FORMAT_MONO01;
 	caps->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	caps->framebuffer_count = 1;
 }
 
 static inline void move_to_next_pixel(uint8_t *mask, uint8_t *data,

--- a/drivers/display/display_renesas_lcdc.c
+++ b/drivers/display/display_renesas_lcdc.c
@@ -430,9 +430,19 @@ static int display_smartbond_blanking_off(const struct device *dev)
 	return ret;
 }
 
-static void *display_smartbond_get_framebuffer(const struct device *dev)
+static void *display_smartbond_get_framebuffer(const struct device *dev, uint32_t index,
+					       size_t *size)
 {
+	const struct display_smartbond_config *config = dev->config;
 	struct display_smartbond_data *data = dev->data;
+
+	if (index != 0U) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = ROUND_UP(config->x_res * config->pixel_size, 4) * config->y_res;
+	}
 
 	return ((void *)data->buffer);
 }
@@ -453,6 +463,7 @@ static void display_smartbond_get_capabilities(const struct device *dev,
 	 */
 	capabilities->supported_pixel_formats = DT_INST_PROP(0, pixel_format);
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = 1;
 	capabilities->current_pixel_format = DT_INST_PROP(0, pixel_format);
 	capabilities->x_resolution = DT_INST_PROP(0, width);
 	capabilities->y_resolution = DT_INST_PROP(0, height);

--- a/drivers/display/display_renesas_ra.c
+++ b/drivers/display/display_renesas_ra.c
@@ -206,6 +206,7 @@ static void ra_display_get_capabilities(const struct device *dev,
 	capabilities->x_resolution = config->width;
 	capabilities->y_resolution = config->height;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = CONFIG_RENESAS_RA_GLCDC_FB_NUM;
 	capabilities->supported_pixel_formats =
 		PIXEL_FORMAT_RGB_888 | PIXEL_FORMAT_ARGB_8888 | PIXEL_FORMAT_RGB_565;
 	capabilities->current_pixel_format = data->current_pixel_format;
@@ -340,11 +341,19 @@ static int ra_display_set_contrast(const struct device *dev, const uint8_t contr
 	return ra_display_color_config(dev, &display_color_cfg);
 }
 
-static void *ra_display_get_framebuffer(const struct device *dev)
+static void *ra_display_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
 	struct display_ra_data *data = dev->data;
 
-	return (void *)data->front_buf;
+	if (index >= CONFIG_RENESAS_RA_GLCDC_FB_NUM) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = data->frame_buffer_len;
+	}
+
+	return data->frame_buffer + (index * data->frame_buffer_len);
 }
 
 static DEVICE_API(display, display_api) = {

--- a/drivers/display/display_socionext_dpu.c
+++ b/drivers/display/display_socionext_dpu.c
@@ -148,13 +148,22 @@ static void dpu_get_capabilities(const struct device *dev,
 	capabilities->supported_pixel_formats = dpu_supported_fmts;
 	capabilities->current_pixel_format = data->pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = CONFIG_DPU_FB_NUM;
 }
 
-static void *dpu_get_framebuffer(const struct device *dev)
+static void *dpu_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
 	struct dpu_data *data = dev->data;
 
-	return (void *)(uintptr_t)data->active_fb;
+	if (index >= CONFIG_DPU_FB_NUM) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = data->fb_bytes;
+	}
+
+	return data->fb[index];
 }
 
 static int dpu_set_pixel_format(const struct device *dev,

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -238,6 +238,7 @@ static void stm32_ltdc_get_capabilities(const struct device *dev,
 
 	capabilities->current_pixel_format = data->current_pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->framebuffer_count = CONFIG_STM32_LTDC_FB_NUM;
 	capabilities->supported_events = DISPLAY_EVENT_VSYNC | DISPLAY_EVENT_LINE_INT;
 }
 
@@ -383,11 +384,19 @@ static int stm32_ltdc_read(const struct device *dev, const uint16_t x,
 	return 0;
 }
 
-static void *stm32_ltdc_get_framebuffer(const struct device *dev)
+static void *stm32_ltdc_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
 	struct display_stm32_ltdc_data *data = dev->data;
 
-	return ((void *)data->front_buf);
+	if (index >= CONFIG_STM32_LTDC_FB_NUM) {
+		return NULL;
+	}
+
+	if (size != NULL) {
+		*size = data->frame_buffer_len;
+	}
+
+	return data->frame_buffer + (index * data->frame_buffer_len);
 }
 
 static int stm32_ltdc_display_blanking_off(const struct device *dev)

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -342,6 +342,8 @@ struct display_capabilities {
 	enum display_orientation current_orientation;
 	/** Supported callback events mask, 0 when event callback unsupported */
 	uint32_t supported_events;
+	/** Number of framebuffers the driver hands out, zero if it does not */
+	uint8_t framebuffer_count;
 #if defined(CONFIG_DISPLAY_COLOR_PALETTE) || defined(__DOXYGEN__)
 	/** Color palette supported by the display, indexed by pixel value */
 	struct display_palette_color color_palette[CONFIG_DISPLAY_COLOR_PALETTE_MAX_SIZE];
@@ -466,7 +468,8 @@ typedef int (*display_clear_api)(const struct device *dev);
  * @brief Callback API to get framebuffer pointer.
  * See display_get_framebuffer() for argument description
  */
-typedef void *(*display_get_framebuffer_api)(const struct device *dev);
+typedef void *(*display_get_framebuffer_api)(const struct device *dev, uint32_t index,
+					     size_t *size);
 
 /**
  * @brief Callback API to set display brightness.
@@ -647,15 +650,25 @@ static inline int display_clear(const struct device *dev)
 }
 
 /**
- * @brief Get pointer to framebuffer for direct access
+ * @brief Get a framebuffer for direct access
+ *
+ * A driver that owns several framebuffers exposes each of them here, so a
+ * caller can render into one while the driver presents another. The index
+ * identifies a fixed buffer: it stays the same across page flips.
+ *
+ * This call has no side effects: it neither changes which buffer the driver
+ * renders into nor which one it presents.
  *
  * @param dev Pointer to device structure
+ * @param index Framebuffer index, zero for the first
+ * @param size Size of the framebuffer in bytes, so a caller can tell how
+ * much it may write. May be NULL when the caller does not need it. A driver
+ * that returns a buffer must set it to the buffer's size.
  *
- * @return Pointer to frame buffer or NULL if direct framebuffer access
- * is not supported
- *
+ * @return Pointer to the framebuffer, or NULL if direct framebuffer access
+ * is not supported or the index does not exist.
  */
-static inline void *display_get_framebuffer(const struct device *dev)
+static inline void *display_get_framebuffer(const struct device *dev, uint32_t index, size_t *size)
 {
 	const struct display_driver_api *api = DEVICE_API_GET(display, dev);
 
@@ -663,7 +676,7 @@ static inline void *display_get_framebuffer(const struct device *dev)
 		return NULL;
 	}
 
-	return api->get_framebuffer(dev);
+	return api->get_framebuffer(dev, index, size);
 }
 
 /**

--- a/modules/lvgl/Kconfig.memory
+++ b/modules/lvgl/Kconfig.memory
@@ -68,7 +68,7 @@ config LV_Z_MEMORY_POOL_ZEPHYR_REGION_NAME
 	  Name of the Zephyr memory-region where LVGL memory pool is placed.
 
 config LV_Z_VDB_SIZE
-	int "Rendering buffer size"
+	int "Rendering buffer size" if !LV_Z_BUFFER_ALLOC_DISPLAY
 	default 100 if LV_Z_FULL_REFRESH
 	default 100 if LV_Z_DIRECT_RENDERING
 	range 100 100 if LV_Z_FULL_REFRESH || LV_Z_DIRECT_RENDERING
@@ -76,21 +76,27 @@ config LV_Z_VDB_SIZE
 	range 1 100
 	help
 	  Size of the buffer used for rendering screen content as a percentage
-	  of total display size.
+	  of total display size. It does not apply when the driver supplies
+	  the buffers, which are always full display.
 
 config LV_Z_DOUBLE_VDB
 	bool "Use two rendering buffers"
+	default y if LV_Z_BUFFER_ALLOC_DISPLAY
 	help
-	  Use two buffers to render and flush data in parallel
+	  Use two buffers to render and flush data in parallel, so LVGL draws
+	  the next frame while the current one is on screen. When the driver
+	  supplies the buffers, it has to own two of them.
 
 choice LV_Z_RENDERING_MODE
 	prompt "Rendering Mode"
+	default LV_Z_FULL_REFRESH if LV_Z_BUFFER_ALLOC_DISPLAY
 	default LV_Z_PARTIAL_REFRESH
 	help
 	  Select the rendering mode for LVGL.
 
 config LV_Z_PARTIAL_REFRESH
 	bool "Partial Refresh Mode"
+	depends on !LV_Z_BUFFER_ALLOC_DISPLAY
 	help
 	  Use the buffer(s) to render to the display using buffers smaller
 	  than the size of the display. Use of buffers at least 1/10 display
@@ -118,6 +124,10 @@ config LV_Z_FULL_REFRESH
 	  performance for display controllers that require a framebuffer
 	  to be present in system memory, since the controller can render
 	  the LVGL framebuffer directly.
+
+	  Always selected with LV_Z_BUFFER_ALLOC_DISPLAY, where the driver
+	  presents a whole buffer: a partial render would leave the regions
+	  it did not draw showing an older frame.
 
 endchoice
 
@@ -183,6 +193,14 @@ config LV_Z_BUFFER_ALLOC_DYNAMIC
 	help
 	  Rendering buffers are dynamically allocated based on the actual
 	  display parameters
+
+config LV_Z_BUFFER_ALLOC_DISPLAY
+	bool "Supplied by the display driver"
+	depends on DISPLAY_SUPPORTS_FRAMEBUFFER_ACCESS
+	help
+	  Render straight into the framebuffers the display driver owns, so
+	  flushing a frame swaps a buffer instead of copying one. The buffers
+	  are whole frames, so the screen is rendered whole.
 
 endchoice
 

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -146,6 +146,102 @@ static void lvgl_log(lv_log_level_t level, const char *buf)
 }
 #endif
 
+#ifdef CONFIG_LV_Z_BUFFER_ALLOC_DISPLAY
+
+static int lvgl_display_px_bytes(enum display_pixel_format format, uint32_t *px_bytes)
+{
+	switch (format) {
+	case PIXEL_FORMAT_ARGB_8888:
+	case PIXEL_FORMAT_XRGB_8888:
+		*px_bytes = 4;
+		break;
+	case PIXEL_FORMAT_RGB_888:
+	case PIXEL_FORMAT_BGR_888:
+		*px_bytes = 3;
+		break;
+	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_RGB_565X:
+		*px_bytes = 2;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int lvgl_use_display_buffers(lv_display_t *display)
+{
+	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
+	uint32_t disp_px_bytes;
+	uint32_t buf_size;
+	size_t buf0_size = 0;
+	size_t buf1_size = 0;
+	void *buf0;
+	void *buf1 = NULL;
+
+	if (lvgl_display_px_bytes(data->cap.current_pixel_format, &disp_px_bytes) < 0) {
+		LOG_ERR("Display pixel format %u cannot back a render buffer",
+			data->cap.current_pixel_format);
+		return -ENOTSUP;
+	}
+
+	/* A wider colour depth would render past the end of the buffer. */
+	if (disp_px_bytes != DIV_ROUND_UP(CONFIG_LV_Z_BITS_PER_PIXEL, 8)) {
+		LOG_ERR("LVGL colour depth %u does not match the display's %u bytes per pixel",
+			CONFIG_LV_Z_BITS_PER_PIXEL, disp_px_bytes);
+		return -EINVAL;
+	}
+
+	/* LVGL rounds every row up to its stride alignment, so a frame is
+	 * wider in memory than the visible pixels alone.
+	 */
+	buf_size = ROUND_UP(data->cap.x_resolution * disp_px_bytes, LV_DRAW_BUF_STRIDE_ALIGN) *
+		   data->cap.y_resolution;
+
+	/* By index, so the pair is fixed rather than following whichever
+	 * buffer the driver is currently drawing into.
+	 */
+	buf0 = display_get_framebuffer(data->display_dev, 0, &buf0_size);
+	if (buf0 == NULL) {
+		LOG_ERR("Display driver does not expose a framebuffer");
+		return -ENOTSUP;
+	}
+
+#ifdef CONFIG_LV_Z_DOUBLE_VDB
+	if (data->cap.framebuffer_count < 2U) {
+		LOG_ERR("Two rendering buffers were asked for, but the driver owns %u",
+			data->cap.framebuffer_count);
+		return -ENOTSUP;
+	}
+
+	buf1 = display_get_framebuffer(data->display_dev, 1, &buf1_size);
+	if (buf1 == NULL) {
+		LOG_ERR("Display driver does not expose a second framebuffer");
+		return -ENOTSUP;
+	}
+#endif
+
+	/* A frame is written whole, so a buffer shorter than one is fatal. */
+	if (buf0_size < buf_size || (buf1 != NULL && buf1_size < buf_size)) {
+		LOG_ERR("Display framebuffers are smaller than a %u byte frame", buf_size);
+		return -EINVAL;
+	}
+
+	/* LVGL only enforces its alignment on buffers it allocates itself. */
+	if (!IS_ALIGNED(buf0, LV_DRAW_BUF_ALIGN) ||
+	    (buf1 != NULL && !IS_ALIGNED(buf1, LV_DRAW_BUF_ALIGN))) {
+		LOG_ERR("Display framebuffers are not aligned to %u bytes", LV_DRAW_BUF_ALIGN);
+		return -EINVAL;
+	}
+
+	lv_display_set_buffers(display, buf0, buf1, buf_size, RENDER_MODE);
+
+	return 0;
+}
+
+#endif /* CONFIG_LV_Z_BUFFER_ALLOC_DISPLAY */
+
 #ifdef CONFIG_LV_Z_BUFFER_ALLOC_STATIC
 
 static void lvgl_allocate_rendering_buffers_static(lv_display_t *display, int disp_idx)
@@ -166,7 +262,7 @@ static void lvgl_allocate_rendering_buffers_static(lv_display_t *display, int di
 #endif
 }
 
-#else
+#elif !defined(CONFIG_LV_Z_BUFFER_ALLOC_DISPLAY)
 
 static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 {
@@ -399,7 +495,12 @@ int lvgl_init(void)
 			return -ENOTSUP;
 		}
 
-#ifdef CONFIG_LV_Z_BUFFER_ALLOC_STATIC
+#if defined(CONFIG_LV_Z_BUFFER_ALLOC_DISPLAY)
+		err = lvgl_use_display_buffers(lv_displays[i]);
+		if (err < 0) {
+			return err;
+		}
+#elif defined(CONFIG_LV_Z_BUFFER_ALLOC_STATIC)
 		lvgl_allocate_rendering_buffers_static(lv_displays[i], i);
 #else
 		err = lvgl_allocate_rendering_buffers(lv_displays[i]);

--- a/samples/boards/nordic/nrf_led_matrix/src/main.c
+++ b/samples/boards/nordic/nrf_led_matrix/src/main.c
@@ -110,7 +110,7 @@ static void show_all_brightness_levels(const struct device *dev)
 
 static void update_through_framebuffer(const struct device *dev)
 {
-	uint8_t *framebuf = display_get_framebuffer(dev);
+	uint8_t *framebuf = display_get_framebuffer(dev, 0, NULL);
 	uint8_t dimmed = 0;
 	bool inc = false;
 	enum {

--- a/tests/drivers/display/charlieplex_led_matrix/src/main.c
+++ b/tests/drivers/display/charlieplex_led_matrix/src/main.c
@@ -39,7 +39,7 @@ ZTEST(charlieplex, test_capabilities)
  */
 ZTEST(charlieplex, test_write_all_on_off)
 {
-	uint8_t *fb = display_get_framebuffer(disp);
+	uint8_t *fb = display_get_framebuffer(disp, 0, NULL);
 	struct display_buffer_descriptor desc = {
 		.buf_size = sizeof(uint8_t) * ((MATRIX_W + 7) / 8) * MATRIX_H,
 		.width = MATRIX_W,
@@ -71,7 +71,7 @@ ZTEST(charlieplex, test_write_all_on_off)
  */
 ZTEST(charlieplex, test_write_single_pixel)
 {
-	uint8_t *fb = display_get_framebuffer(disp);
+	uint8_t *fb = display_get_framebuffer(disp, 0, NULL);
 	struct display_buffer_descriptor desc = {
 		.buf_size = ((MATRIX_W + 7) / 8) * MATRIX_H,
 		.width = MATRIX_W,
@@ -128,6 +128,38 @@ ZTEST(charlieplex, test_pixel_format)
 		   "MONO01 should be accepted");
 	zassert_not_ok(display_set_pixel_format(disp, PIXEL_FORMAT_RGB_888),
 		       "RGB_888 should be rejected");
+}
+
+/* The framebuffer accessor takes an index and reports the buffer size. This
+ * driver owns a single buffer, so index 0 resolves and anything above it does
+ * not, and the size it reports has to cover the whole framebuffer.
+ */
+ZTEST(charlieplex, test_get_framebuffer_index_and_size)
+{
+	struct display_capabilities caps;
+	size_t size = 0;
+	void *fb0;
+
+	display_get_capabilities(disp, &caps);
+	zassert_equal(caps.framebuffer_count, 1, "driver should hand out one framebuffer");
+
+	fb0 = display_get_framebuffer(disp, 0, &size);
+	zassert_not_null(fb0, "index 0 should resolve");
+	zassert_equal(size, NUM_PIXELS, "reported size should cover the framebuffer");
+
+	/* The index names a fixed buffer, so asking again gives the same one. */
+	zassert_equal_ptr(display_get_framebuffer(disp, 0, NULL), fb0,
+			  "index 0 should stay put across calls");
+
+	/* Every index the driver does not own is refused, and the size it was
+	 * given is left alone.
+	 */
+	size = 0xdeadbeef;
+	zassert_is_null(display_get_framebuffer(disp, caps.framebuffer_count, &size),
+			"index past the last buffer should be refused");
+	zassert_equal(size, 0xdeadbeef, "size should be untouched when no buffer is returned");
+	zassert_is_null(display_get_framebuffer(disp, UINT32_MAX, NULL),
+			"a wild index should be refused");
 }
 
 ZTEST_SUITE(charlieplex, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Some display drivers own the framebuffers they scan out, but LVGL cannot reach them, so it allocates its own and copies every finished frame into the driver's buffer. On a 1024x600 RGB888 panel in external RAM that is 1.8 MB of copying per frame, plus two full-screen buffers duplicating the driver's own.

This adds display_get_framebuffer_by_index(), so a driver owning more than one framebuffer can hand them out, along with a count and size in the display capabilities. display_get_framebuffer() cannot serve here: it follows whichever buffer is currently drawn into, so the pointer moves as buffers flip and the others stay unreachable. LV_Z_BUFFER_ALLOC_DISPLAY then makes LVGL render straight into them, so presenting a frame swaps a buffer instead of copying one. Nothing changes for existing drivers: the mode is only offered where a driver advertises support.

Measured on an ESP32-P4 with a 1024x600 RGB888 panel, LVGL benchmark demo: 15 -> 35 FPS average and 98% -> 64% CPU against the same build using a small partial-refresh buffer. Giving LVGL two full-screen buffers of its own does not fit in that board's 8 MB of PSRAM. See https://github.com/zephyrproject-rtos/zephyr/pull/117658
