### PR TITLE
net: coap_client: Deregister observe with the original request method

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1574,8 +1574,8 @@ int coap_client_deregister_observe(struct coap_client *client, struct coap_clien
 		err = coap_packet_init(
 			&pkt, internal_req->send_buf, sizeof(internal_req->send_buf), COAP_VERSION,
 			internal_req->coap_request.confirmable ? COAP_TYPE_CON : COAP_TYPE_NON_CON,
-			internal_req->observe_tkl, internal_req->observe_token, COAP_METHOD_GET,
-			mid);
+			internal_req->observe_tkl, internal_req->observe_token,
+			internal_req->coap_request.method, mid);
 
 		if (err == 0) {
 			err = coap_packet_set_path(&pkt, internal_req->coap_request.path);


### PR DESCRIPTION
coap_client_deregister_observe() hardcoded GET for the deregistration. That is conformant for observations registered with GET (RFC 7641 is written entirely in terms of GET) cancellation included, because GET was the only observable method when it was written. But this client also allows registering an observation with FETCH, which RFC 8132 permits ("The Observe option can be used with a FETCH request as it can be used with a GET request"), and there the literal-GET reading breaks RFC 7641 section 3.6's own rules: the deregister request's options MUST be identical to the registration's (a GET can never match a FETCH registration), and the server is to "process the GET request as usual"; impossible on a resource that only serves FETCH. Such servers correctly answer 4.05 Method Not Allowed before ever looking at the Observe option, and the observation lives on until it times out.

Reuse the stored request's method instead, which degenerates to GET for GET-registered observations and mirrors the registration for everything else.