### PR TITLE
doc: interrupts: various improvements

### DIFF
--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -6,7 +6,7 @@ Interrupts
 An :dfn:`interrupt service routine` (ISR) is a function that executes
 asynchronously in response to a hardware or software interrupt.
 An ISR normally preempts the execution of the current thread,
-allowing the response to occur with very low overhead.
+allowing the response to occur with very low latency.
 Thread execution resumes only once all ISR work has been completed.
 
 .. contents::

--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -504,7 +504,7 @@ Any relocation on this stage may lead to the situation where the entry in the in
 is no longer pointing to the function that was expected.
 It means that this parser, being more compatible is limiting us from using Link Time Optimization.
 
-The local isr declaration parser uses different approach to construct
+The local ISR declaration parser uses different approach to construct
 the same arrays at binary level.
 All the entries to the arrays are declared and defined locally,
 directly in the file where :c:macro:`IRQ_CONNECT` is used.
@@ -623,7 +623,7 @@ Implementation using linker script
 ----------------------------------
 
 This way of prepare and parse .isrList section to implement interrupt vectors arrays
-is called local isr declaration.
+is called local ISR declaration.
 The name comes from the fact that all the entries to the arrays that would create
 interrupt vectors are created locally in place of invocation of :c:macro:`IRQ_CONNECT` macro.
 Then automatically generated linker scripts are used to place it in the right place in the memory.

--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -504,15 +504,16 @@ Any relocation on this stage may lead to the situation where the entry in the in
 is no longer pointing to the function that was expected.
 It means that this parser, being more compatible, is limiting us from using Link Time Optimization.
 
-The local ISR declaration parser uses different approach to construct
-the same arrays at binary level.
+The local ISR declaration parser uses a different approach to construct
+the same arrays at the binary level.
 All the entries to the arrays are declared and defined locally,
 directly in the file where :c:macro:`IRQ_CONNECT` is used.
-They are placed in a section with the unique, synthesized name.
-The name of the section is then placed in .intList section and it is used to create linker script
-to properly place the created entry in the right place in the memory.
-This parser is now limited to the supported architectures and toolchains but in reward it keeps
-the information about object relations for linker thus allowing the Link Time Optimization.
+They are placed in a section with a unique, synthesized name.
+The name of that section is then placed in the .intList section, which is used to
+generate a linker script fragment placing the entry at the right address.
+This parser is currently limited to the supported architectures and toolchains,
+but in return, it preserves the information about object relations for the linker,
+thus enabling Link Time Optimization.
 
 Implementation using C arrays
 -----------------------------

--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -80,17 +80,24 @@ illustrated and explained below:
 
 .. code-block:: none
 
-                 9             2   0
-           _ _ _ _ _ _ _ _ _ _ _ _ _         (LEVEL 1)
-         5       |         A   |
-       _ _ _ _ _ _ _         _ _ _ _ _ _ _   (LEVEL 2)
-         |   C                       B
-       _ _ _ _ _ _ _                         (LEVEL 3)
-               D
+              9                           2       0
+    ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+    │   │   │ ╷ │   │   │   │   │ A │   │ ╷ │   │   │               (LEVEL 1)
+    └───┴───┴─│─┴───┴───┴───┴───┴───┴───┴─│─┴───┴───┘
+              └─────────────────┐         └─────────────────────┐
+          5                     v                               v
+    ┌───┬───┬───┬───┬───┬───┬───┐   ┌───┬───┬───┬───┬───┬───┬───┐
+    │   │ ╷ │   │ C │   │   │   │   │   │   │   │   │ B │   │   │   (LEVEL 2)
+    └───┴─│─┴───┴───┴───┴───┴───┘   └───┴───┴───┴───┴───┴───┴───┘
+          └─────────────────────┐
+                                v
+    ┌───┬───┬───┬───┬───┬───┬───┐
+    │   │   │   │   │ D │   │   │                                   (LEVEL 3)
+    └───┴───┴───┴───┴───┴───┴───┘
 
 There are three interrupt levels shown here.
 
-* '-' means interrupt line and is numbered from 0 (right most).
+* A cell represents an interrupt line and is numbered from 0 (right most).
 * LEVEL 1 has 12 interrupt lines, with two lines (2 and 9) connected
   to nested controllers and one device 'A' on line 4.
 * One of the LEVEL 2 controllers has interrupt line 5 connected to

--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -502,7 +502,7 @@ The limitation of this parser is the fact that after the arrays are generated
 it is expected for the code not to relocate.
 Any relocation on this stage may lead to the situation where the entry in the interrupt array
 is no longer pointing to the function that was expected.
-It means that this parser, being more compatible is limiting us from using Link Time Optimization.
+It means that this parser, being more compatible, is limiting us from using Link Time Optimization.
 
 The local ISR declaration parser uses different approach to construct
 the same arrays at binary level.


### PR DESCRIPTION
* doc: interrupts: describe ISRs as low-latency

  The fact that ISRs preempt most normal threads (preemptible and
  cooperative) doesn't necessarily mean an ISR has a low overhead.

  It is more accurate to describe ISRs as having low latency in this
  context. The fact that they preempt most threads means there is
  usually a very short amount of time between an IRQ being raised
  and its associated ISR being executed. This stands in contrast with
  normal threads, which, after becoming ready, often have to wait for
  higher-priority threads to finish their work or for cooperative threads
  to yield.

* doc: interrupts: improve nested interrupt ascii art

  I found the previous ascii art a little hard to parse.

  The pointers to the next level are now directed at the beginning of
  a controller. Previously, I was wondering if the higher level somehow
  pointed at a specific line in the lower level.

  Unfortunately, the monospace font used in the rendered HTML
  documentation doesn't perfectly connect the box drawing characters.

  It should also be noted that this version is quite a bit wider than
  the previous one. For the standard text width of the rendered HTML
  documentation, it fits nicely. But, on small screens, the diagram will
  overflow the screen width more quickly.

* doc: interrupts: uppercase ISR in prose

  I noticed this inconsistency and searched the documented for all uses of
  lowercase "isr" in prose, replacing them with "ISR".

* doc: interrupts: add missing comma

  The single comma split the sentence in a way that doesn't make sense.

* doc: interrupts: reword explanation of local ISR declaration parser

  I found this paragraph hard to understand grammatically.

preview:
https://builds.zephyrproject.io/zephyr/pr/117625/docs/kernel/services/interrupts.html