### PR TITLE
drivers: mux: nxp_trgmux: support clock-gated TRGMUX on MCXE31x

### DIFF
--- a/drivers/clock_control/clock_control_nxp_mc_cgm.c
+++ b/drivers/clock_control/clock_control_nxp_mc_cgm.c
@@ -339,6 +339,11 @@ static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsy
 		CLOCK_EnableClock(kCLOCK_TempSensor);
 		return 0;
 #endif
+#if defined(CONFIG_MUX_NXP_TRGMUX)
+	case MCUX_TRGMUX_CLK:
+		CLOCK_EnableClock(kCLOCK_Trgmux);
+		return 0;
+#endif
 #if defined(MC_CGM_HAS_EMAC)
 	case MCUX_EMACRX_CLK:
 		return mc_cgm_emac_attach(&mc_cgm_emac_rx_clk);
@@ -373,6 +378,11 @@ static int mc_cgm_clock_control_off(const struct device *dev, clock_control_subs
 #if defined(CONFIG_NXP_TEMPSENSE)
 	case MCUX_TEMPSENSE_CLK:
 		CLOCK_DisableClock(kCLOCK_TempSensor);
+		return 0;
+#endif
+#if defined(CONFIG_MUX_NXP_TRGMUX)
+	case MCUX_TRGMUX_CLK:
+		CLOCK_DisableClock(kCLOCK_Trgmux);
 		return 0;
 #endif
 #if defined(MC_CGM_HAS_EMAC)

--- a/drivers/mux/mux_nxp_trgmux.c
+++ b/drivers/mux/mux_nxp_trgmux.c
@@ -22,12 +22,20 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
+#include <zephyr/drivers/clock_control.h>
+#endif
+
 #include <fsl_trgmux.h>
 
 LOG_MODULE_REGISTER(mux_nxp_trgmux, CONFIG_MUX_LOG_LEVEL);
 
 struct mux_nxp_trgmux_config {
 	TRGMUX_Type *base;
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+#endif
 };
 
 static int mux_nxp_trgmux_set(const struct device *dev,
@@ -76,12 +84,47 @@ static DEVICE_API(mux_control, mux_nxp_trgmux_driver_api) = {
 	.get_state = mux_nxp_trgmux_get_state,
 };
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
+/* Some SoCs (e.g. MCXE31x) gate the TRGMUX register interface behind a
+ * peripheral clock, and touching TRGCFG while it is gated raises a bus
+ * fault. Where TRGMUX is ungated the node carries no clocks property and
+ * clock_dev stays NULL, so this init is a no-op.
+ */
+static int mux_nxp_trgmux_init(const struct device *dev)
+{
+	const struct mux_nxp_trgmux_config *cfg = dev->config;
+
+	if (cfg->clock_dev == NULL) {
+		return 0;
+	}
+
+	if (!device_is_ready(cfg->clock_dev)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->clock_dev);
+		return -ENODEV;
+	}
+
+	return clock_control_on(cfg->clock_dev, cfg->clock_subsys);
+}
+
+#define MUX_NXP_TRGMUX_INIT_FN mux_nxp_trgmux_init
+
+#define MUX_NXP_TRGMUX_CLOCK_CFG(n)                                            \
+	.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),             \
+		(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n))), (NULL)),              \
+	.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),          \
+		((clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name)), (0)),
+#else
+#define MUX_NXP_TRGMUX_INIT_FN     NULL
+#define MUX_NXP_TRGMUX_CLOCK_CFG(n)
+#endif
+
 #define MUX_NXP_TRGMUX_INIT(n)                                       \
 	static const struct mux_nxp_trgmux_config                    \
 		mux_nxp_trgmux_cfg_##n = {                           \
 			.base = (TRGMUX_Type *)DT_INST_REG_ADDR(n),  \
+			MUX_NXP_TRGMUX_CLOCK_CFG(n)                  \
 		};                                                   \
-	DEVICE_DT_INST_DEFINE(n, NULL, NULL,                         \
+	DEVICE_DT_INST_DEFINE(n, MUX_NXP_TRGMUX_INIT_FN, NULL,       \
 			      NULL, &mux_nxp_trgmux_cfg_##n,         \
 			      POST_KERNEL, CONFIG_MUX_INIT_PRIORITY, \
 			      &mux_nxp_trgmux_driver_api);

--- a/dts/arm/nxp/mcx/mcxe/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxe/nxp_mcxe31x_common.dtsi
@@ -1250,6 +1250,9 @@
 	trgmux: trgmux@80000 {
 		compatible = "nxp,trgmux";
 		reg = <0x80000 0xbc>;
+		clocks = <&mc_cgm MCUX_TRGMUX_CLK>;
+		#mux-control-cells = <2>;
+		#mux-state-cells = <3>;
 		status = "disabled";
 	};
 

--- a/include/zephyr/dt-bindings/clock/nxp_mc_cgm.h
+++ b/include/zephyr/dt-bindings/clock/nxp_mc_cgm.h
@@ -107,6 +107,8 @@
 #define MCUX_STM0_CLK MCUX_MC_CGM_CLK_ID(0x2B, 0x00)
 #define MCUX_STM1_CLK MCUX_MC_CGM_CLK_ID(0x2B, 0x01)
 
+#define MCUX_TRGMUX_CLK MCUX_MC_CGM_CLK_ID(0x2D, 0x00)
+
 /* --------------------- Partition 2 clock --------------------- */
 #define MCUX_QSPISF_CLK MCUX_MC_CGM_CLK_ID(0x2C, 0x00)
 #define MCUX_EMACRX_CLK MCUX_MC_CGM_CLK_ID(0x2C, 0x01)

--- a/tests/drivers/mux/mux_api/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/mux/mux_api/boards/frdm_mcxe31b.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+&trgmux {
+	status = "okay";
+};
+
+/ {
+	mux_consumer: mux-consumer {
+		compatible = "vnd,mux-consumer-test";
+		/* control idx0: ExtOut0 (17), input 0 - driven at runtime and read back.
+		 * state:        ExtOut0 (17), input 0, source Pit0Ch0 (117), baked in DT.
+		 */
+		mux-controls = <&trgmux 17 0>;
+		mux-states = <&trgmux 17 0 117>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/mux/mux_api/tests.yaml
+++ b/tests/drivers/mux/mux_api/tests.yaml
@@ -17,6 +17,7 @@ tests:
     filter: dt_compat_enabled("nxp,trgmux")
     platform_allow:
       - frdm_mcxe247
+      - frdm_mcxe31b
     integration_platforms:
       - frdm_mcxe247
     extra_configs:


### PR DESCRIPTION
Enable the existing NXP TRGMUX mux driver on MCXE31x, and turn on the
`mux_api` test for `frdm_mcxe31b`.

On MCXE31B the TRGMUX register interface is gated by
`MC_ME->PRTN0_COFB1_CLKEN` bit 0. MCXE24x has no such gate. The clock enable is therefore made optional: the mux driver only calls `clock_control_on()` when the node actually provides a `clocks` phandle.