### PR TITLE
Bluetooth: Audio: Fix CI issues related to CCP and CSIP

### DIFF
--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -243,7 +243,7 @@ static int cmd_csip_set_member_set_size_and_rank(const struct shell *sh, size_t 
 		return -ENOEXEC;
 	}
 
-	if (info.lockable && !IN_RANGE(rank, 1, rank)) {
+	if (info.lockable && !IN_RANGE(rank, 1, UINT8_MAX)) {
 		shell_error(sh, "Invalid rank: %lu", rank);
 
 		return -ENOEXEC;

--- a/tests/bluetooth/audio/ccp_call_control_client/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/main.c
@@ -216,6 +216,8 @@ static ZTEST_F(ccp_call_control_client_test_suite, test_ccp_call_control_client_
 
 #if defined(CONFIG_BT_TBS_CLIENT_TBS)
 	zassert_equal(CONFIG_BT_TBS_CLIENT_MAX_TBS_INSTANCES, bearers.tbs_count);
-	zassert_not_null(bearers.tbs_bearers);
+	for (size_t i = 0U; i < bearers.tbs_count; i++) {
+		zassert_not_null(bearers.tbs_bearers[i]);
+	}
 #endif /* CONFIG_BT_TBS_CLIENT_TBS */
 }

--- a/tests/bluetooth/audio/ccp_call_control_client/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/main.c
@@ -51,7 +51,6 @@ static void discover_cb(struct bt_ccp_call_control_client *client, int err,
 
 #if defined(CONFIG_BT_TBS_CLIENT_TBS)
 	zassert_equal(CONFIG_BT_TBS_CLIENT_MAX_TBS_INSTANCES, bearers->tbs_count);
-	zassert_not_null(bearers->tbs_bearers);
 	for (size_t i = 0U; i < bearers->tbs_count; i++) {
 		zassert_not_null(bearers->tbs_bearers[i]);
 		fixture->bearers[i + IS_ENABLED(CONFIG_BT_TBS_CLIENT_GTBS)] =

--- a/tests/bluetooth/audio/ccp_call_control_client/src/test_procedures.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/test_procedures.c
@@ -56,7 +56,6 @@ static void discover_cb(struct bt_ccp_call_control_client *client, int err,
 
 #if defined(CONFIG_BT_TBS_CLIENT_TBS)
 	zassert_equal(CONFIG_BT_TBS_CLIENT_MAX_TBS_INSTANCES, bearers->tbs_count);
-	zassert_not_null(bearers->tbs_bearers);
 	for (size_t i = 0U; i < bearers->tbs_count; i++) {
 		zassert_not_null(bearers->tbs_bearers[i]);
 		fixture->bearers[i + IS_ENABLED(CONFIG_BT_TBS_CLIENT_GTBS)] =


### PR DESCRIPTION
Fixes two issues that is blocking CI due to being invalid checks. 

```
/__w/zephyr/zephyr/tests/bluetooth/audio/ccp_call_control_client/src/main.c: In function ‘discover_cb’:
/__w/zephyr/zephyr/tests/bluetooth/audio/ccp_call_control_client/src/main.c:54:9: error: the comparison will always evaluate as ‘true’ for the address of ‘tbs_bearers’ will never be NULL [-Werror=address]
   54 |         zassert_not_null(bearers->tbs_bearers);
      |         ^~~~~~~~~~~~~~~~
In file included from /__w/zephyr/zephyr/tests/bluetooth/audio/ccp_call_control_client/src/main.c:14:
/__w/zephyr/zephyr/include/zephyr/bluetooth/audio/ccp.h:205:18: note: ‘tbs_bearers’ declared here
  205 |                 *tbs_bearers[CONFIG_BT_CCP_CALL_CONTROL_CLIENT_BEARER_COUNT];
      |                  ^~~~~~~~~~~
/__w/zephyr/zephyr/tests/bluetooth/audio/ccp_call_control_client/src/main.c: In function ‘ccp_call_control_client_test_suite_test_ccp_call_control_client_get_bearers’:
```

```
/__w/zephyr/zephyr/subsys/bluetooth/audio/shell/csip_set_member.c: In function ‘cmd_csip_set_member_set_size_and_rank’:
/__w/zephyr/zephyr/subsys/bluetooth/audio/shell/csip_set_member.c:246:31: error: self-comparison always evaluates to true [-Werror=tautological-compare]
  246 |         if (info.lockable && !IN_RANGE(rank, 1, rank)) {
      |                               ^~~~~~~~
cc1: all warnings being treated as errors

```

```
/__w/zephyr/zephyr/tests/bluetooth/audio/ccp_call_control_client/src/main.c:220:9: error: the comparison will always evaluate as ‘true’ for the address of ‘tbs_bearers’ will never be NULL [-Werror=address]
  220 |         zassert_not_null(bearers.tbs_bearers);
      |         ^~~~~~~~~~~~~~~~
/__w/zephyr/zephyr/include/zephyr/bluetooth/audio/ccp.h:205:18: note: ‘tbs_bearers’ declared here
  205 |                 *tbs_bearers[CONFIG_BT_CCP_CALL_CONTROL_CLIENT_BEARER_COUNT];
      |                  ^~~~~~~~~~~

```