### PR TITLE
boards: nxp: microchip: invert `ETH_DRIVER` and `NET_L2_ETHERNET`

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/Kconfig.defconfig
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/Kconfig.defconfig
@@ -6,7 +6,7 @@ if BOARD_PIC32CX_SG41_CULT
 config EEPROM
 	default y if NVMEM
 
-configdefault NET_L2_ETHERNET
+configdefault ETH_DRIVER
 	default y
 
 endif # BOARD_PIC32CX_SG41_CULT

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/Kconfig.defconfig
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/Kconfig.defconfig
@@ -6,7 +6,7 @@ if BOARD_PIC32CX_SG61_CULT
 config EEPROM
 	default y if NVMEM
 
-configdefault NET_L2_ETHERNET
+configdefault ETH_DRIVER
 	default y
 
 endif # BOARD_PIC32CX_SG61_CULT

--- a/boards/nxp/frdm_mcxe31b/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxe31b/Kconfig.defconfig
@@ -3,7 +3,7 @@
 
 if BOARD_FRDM_MCXE31B
 
-configdefault NET_L2_ETHERNET
+configdefault ETH_DRIVER
 	default y
 
 endif # BOARD_FRDM_MCXE31B


### PR DESCRIPTION
this was missed in
https://github.com/zephyrproject-rtos/zephyr/pull/117121

@JordanYates