### PR TITLE
boards: shields: arduino_giga_display_shield: fix swapped porch timings

### DIFF
--- a/boards/shields/arduino_giga_display_shield/arduino_giga_display_shield.overlay
+++ b/boards/shields/arduino_giga_display_shield/arduino_giga_display_shield.overlay
@@ -41,12 +41,12 @@
 			vsync-active = <0>;
 			de-active = <0>;
 			pixelclk-active = <0>;
-			hback-porch = <40>;
-			hsync-len = <32>;
-			hfront-porch = <8>;
-			vback-porch = <6>;
-			vsync-len = <8>;
-			vfront-porch = <9>;
+			hback-porch = <6>;
+			hsync-len = <8>;
+			hfront-porch = <1>;
+			vback-porch = <40>;
+			vsync-len = <32>;
+			vfront-porch = <8>;
 		};
 	};
 };

--- a/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
+++ b/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
@@ -38,12 +38,12 @@
 		vsync-active = <0>;
 		de-active = <0>;
 		pixelclk-active = <0>;
-		hback-porch = <40>;
-		hsync-len = <32>;
-		hfront-porch = <8>;
-		vback-porch = <6>;
-		vsync-len = <8>;
-		vfront-porch = <9>;
+		hback-porch = <6>;
+		hsync-len = <8>;
+		hfront-porch = <1>;
+		vback-porch = <40>;
+		vsync-len = <32>;
+		vfront-porch = <8>;
 	};
 };
 


### PR DESCRIPTION
The display-timings of the GIGA Display Shield swapped the horizontal and vertical porch values. The panel is a 480x800 portrait ST7701S, but the timings were the landscape 800x480.

This is visible as clipping/shifting like a missing row along one edge when drawing a single pixel border around the framebuffer.

Verified on arduino_giga_r1/stm32h747xx/m7 with the shield attached.


Before

<img width="240" height="320" alt="image" src="https://github.com/user-attachments/assets/aa70db0a-76ae-4f8d-ae9c-0d4223ed0386" />


After

<img width="240" height="320" alt="image" src="https://github.com/user-attachments/assets/601774b0-1277-4c9c-aef4-31326cbf682e" />

