### PR TITLE
drivers: ethernet: dwc_mac: fix -Werror=unused-value

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define RX_FRAG_SIZE  CONFIG_NET_BUF_DATA_SIZE
 #define TX_AVAIL_WAIT K_MSEC(1)
 
-#define INC_WRAP(idx, size) ({ (idx) = ((idx) + 1) % (size); })
+#define INC_WRAP(idx, size) ((idx) = ((idx) + 1) % (size))
 #define DEC_WRAP(idx, size) ({ (idx) = ((idx) + (size) - 1) % (size); })
 
 #define TDES0_OWN BIT(31)
@@ -370,7 +370,8 @@ static void dwmac_rx_refill_desc(const struct device *dev, struct net_buf *frag)
 
 	d->des0 = RDES0_OWN;
 
-	p->rx_desc_head = INC_WRAP(d_idx, NB_RX_DESCS);
+	INC_WRAP(d_idx, NB_RX_DESCS);
+	p->rx_desc_head = d_idx;
 	DWMAC_REG_WRITE(DWMAC_DMARPDR, 0);
 
 	LOG_DBG("desc sem/head/tail=%d/%d/%d %s", k_sem_count_get(&p->free_rx_descs),

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -26,7 +26,6 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define TX_AVAIL_WAIT K_MSEC(1)
 
 #define INC_WRAP(idx, size) ((idx) = ((idx) + 1) % (size))
-#define DEC_WRAP(idx, size) ({ (idx) = ((idx) + (size) - 1) % (size); })
 
 #define TDES0_OWN BIT(31)
 #define TDES0_IC  BIT(30)

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -48,8 +48,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define TX_AVAIL_WAIT K_MSEC(1)
 
 /* descriptor index iterators */
-#define INC_WRAP(idx, size) ({ idx = (idx + 1) % size; })
-#define DEC_WRAP(idx, size) ({ idx = (idx + size - 1) % size; })
+#define INC_WRAP(idx, size) ((idx) = ((idx) + 1) % (size))
+#define DEC_WRAP(idx, size) ({ (idx) = ((idx) + (size) - 1) % (size); })
 
 /*
  * Descriptor physical location .
@@ -437,7 +437,8 @@ static void dwmac_rx_refill_desc(const struct device *dev, struct net_buf *frag)
 	barrier_dmem_fence_full();
 
 	/* advance to the next descriptor */
-	p->rx_desc_head = INC_WRAP(d_idx, NB_RX_DESCS);
+	INC_WRAP(d_idx, NB_RX_DESCS);
+	p->rx_desc_head = d_idx;
 
 	/* lastly notify the hardware */
 	DWMAC_REG_WRITE(DMA_CHn_RXDESC_TAIL_PTR(0), RXDESC_PHYS_L(d_idx));

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -49,7 +49,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 /* descriptor index iterators */
 #define INC_WRAP(idx, size) ((idx) = ((idx) + 1) % (size))
-#define DEC_WRAP(idx, size) ({ (idx) = ((idx) + (size) - 1) % (size); })
 
 /*
  * Descriptor physical location .


### PR DESCRIPTION
fix -Werror=unused-value in the dwc_mac ethernet drivers.

CI error in https://github.com/zephyrproject-rtos/zephyr/actions/runs/33086398117/job/98567919118