### PR TITLE
Revert "kconfig: Do not track macro expansion by default"

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -565,13 +565,11 @@ config COMPILER_SAVE_TEMPS
 
 config COMPILER_TRACK_MACRO_EXPANSION
 	bool "Track macro expansion"
+	default y
 	help
 	  When enabled, locations of tokens across macro expansions will be
-	  tracked, so a diagnostic reports every step of the expansion chain
-	  that produced it. Zephyr's logging, device and devicetree macros
-	  expand through many layers, which turns a single mistake into pages
-	  of output, so this is disabled by default. Enable it when the
-	  expansion chain itself is what you need to see.
+	  tracked. Disabling this option may be useful to debug long macro
+	  expansion chains.
 
 config COMPILER_COLOR_DIAGNOSTICS
 	bool "Colored diagnostics"

--- a/doc/build/dts/troubleshooting.rst
+++ b/doc/build/dts/troubleshooting.rst
@@ -298,23 +298,23 @@ them. For example, to use ``clang-format`` to reformat the file in place:
 You can then open the file in your favorite editor to view the final C results
 after preprocessing.
 
-Track macro expansion
-*********************
+Do not track macro expansion
+****************************
 
-Devicetree macros expand through several intermediate steps, and a compiler that
-reports every one of them turns a single error into a very long message. Zephyr
-therefore leaves :kconfig:option:`CONFIG_COMPILER_TRACK_MACRO_EXPANSION` disabled,
-which typically reduces the output to one message per error.
+Compiler messages for devicetree errors can sometimes be very long. This
+typically happens when the compiler prints a message for every step of a
+complex macro expansion that has several intermediate expansion steps.
 
-Enable the option when the intermediate expansion steps are what you need to see,
-for example when you are working on the macros themselves.
+To prevent the compiler from doing this, you can disable the
+:kconfig:option:`CONFIG_COMPILER_TRACK_MACRO_EXPANSION` option. This typically
+reduces the output to one message per error.
 
-For example, to build :zephyr:code-sample:`hello_world` with west and this option enabled,
+For example, to build :zephyr:code-sample:`hello_world` with west and this option disabled,
 use:
 
 .. code-block:: sh
 
-   west build -b BOARD samples/hello_world -- -DCONFIG_COMPILER_TRACK_MACRO_EXPANSION=y
+   west build -b BOARD samples/hello_world -- -DCONFIG_COMPILER_TRACK_MACRO_EXPANSION=n
 
 Validate properties
 *******************

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -37,11 +37,6 @@ Build System
 * :kconfig:option:`CONFIG_LEGACY_GENERATED_INCLUDE_PATH` has been deprecated, and disabled by
   default, includes must now be prefixed with ``zephyr/`` for zephyr files.
 
-* :kconfig:option:`CONFIG_COMPILER_TRACK_MACRO_EXPANSION` is now disabled by default, so a
-  compiler diagnostic raised inside a macro is reported once, at the line that caused it,
-  rather than once per step of the expansion chain. Applications that relied on seeing the
-  whole chain can enable the option again.
-
 * CMake variables ``SOC_NAME``, ``SOC_SERIES``, ``SOC_FAMILY`` and ``SOC_V2_DIR`` have been
   deprecated as they duplicate variables already, the replacement variables are as follows:
   :kconfig:option:`CONFIG_SOC`, :kconfig:option:`CONFIG_SOC_SERIES`,

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1768,11 +1768,6 @@ Other notable changes
     Ubuntu 24.04 LTS package repositories. See the :ref:`migration guide <migration_4.5>` for
     options if your distribution ships an older version.
 
-  * :kconfig:option:`CONFIG_COMPILER_TRACK_MACRO_EXPANSION` is now disabled by default. A
-    diagnostic raised inside Zephyr's logging, device or devicetree macros is now reported as a
-    single message at the line that caused it, instead of one message for every step of the
-    expansion chain. Set the option to ``y`` to get the full chain back.
-
 * Kernel
 
   * :kconfig:option:`CONFIG_SCHED_CPU_MASK` no longer depends on


### PR DESCRIPTION
This reverts commit 3a18beaf9eddf27d36059ddf1e0b7dc05f5cd981.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
