### PR TITLE
soc: tiva_c: cmake: change SOC_SERIES variable

### DIFF
--- a/soc/ti/tiva_c/CMakeLists.txt
+++ b/soc/ti/tiva_c/CMakeLists.txt
@@ -4,6 +4,6 @@
 # Author: Sri Surya <srisurya@linumiz.com>
 
 
-add_subdirectory(${SOC_SERIES})
+add_subdirectory(${CONFIG_SOC_SERIES})
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")


### PR DESCRIPTION
Changed the SOC_SERIES cmake varible to use
CONFIG_SOC_SERIES as SOC_* variables will be
deprecated.

Signed-off-by: Thamaraimanalan M <thamaraimanalan@linumiz.com>