### PR TITLE
mgmt: hawkbit: Prevent dangling k_malloc

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -1283,6 +1283,7 @@ static void s_http_start(void *o)
 	if (!start_http_client(&s->hb_context.sock)) {
 		s->hb_context.code_status = HAWKBIT_NETWORKING_ERROR;
 		smf_set_state(SMF_CTX(s), &hawkbit_states[S_HAWKBIT_TERMINATE]);
+		return;
 	}
 
 	s->hb_context.response_data_size = RESPONSE_BUFFER_SIZE;


### PR DESCRIPTION

When there was a networking error in the s_http_start function, the hawkbit stat would change to terminate, and the s_http_end function would run, freeing any k_malloc memory. But because there was no return statement, the function would proceed to allocate memory, which would not get freed because the state was already terminate which does not have a cleanup exit function assigned.