### PR TITLE
sys: util: wrap WAIT_FOR() delay statement in a statement expression

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -1106,7 +1106,7 @@ static ALWAYS_INLINE uint64_t sys_lcm_s(int32_t a, int32_t b)
 		bool _wf_ret;                                                                      \
 		while (!(_wf_ret = (expr)) &&                                                      \
 		       (_wf_cycle_count > (k_cycle_get_32() - _wf_start))) {                       \
-			delay_stmt;                                                                \
+			({ delay_stmt; });                                                         \
 			Z_SPIN_DELAY(10);                                                          \
 		}                                                                                  \
 		(_wf_ret);                                                                         \


### PR DESCRIPTION
With macro expansion tracking disabled (-ftrack-macro-expansion=0) GCC no
longer suppresses -Wunused-value inside macro expansions, so every
WAIT_FOR(..., NULL) caller fails with "statement with no effect".

Wrap delay_stmt in a statement expression, which accepts NULL, a call
or an empty argument without warning.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
