### PR TITLE
Revert "dts: intel_adsp: align boards to new CPU deferral config"

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -26,7 +26,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -34,7 +33,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d3>;
-			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -26,7 +26,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -34,7 +33,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu3: cpu@3 {
@@ -42,7 +40,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu4: cpu@4 {
@@ -50,7 +47,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <4>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -26,7 +26,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -34,7 +33,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -13,7 +13,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu4: cpu@4 {
@@ -21,7 +20,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <4>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 	};
 

--- a/dts/xtensa/intel/intel_adsp_ace40.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace40.dtsi
@@ -26,7 +26,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace40_nvl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace40_nvl.dtsi
@@ -13,7 +13,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu3: cpu@3 {
@@ -21,7 +20,6 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
 			cpu-power-states = <&d0i3 &d3>;
-			zephyr,deferred-start;
 		};
 	};
 

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -26,7 +26,6 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 			cpu-power-states = <&d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu2: cpu@2 {
@@ -34,7 +33,6 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <2>;
 			cpu-power-states = <&d3>;
-			zephyr,deferred-start;
 		};
 
 		cpu3: cpu@3 {
@@ -42,7 +40,6 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <3>;
 			cpu-power-states = <&d3>;
-			zephyr,deferred-start;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -26,7 +26,6 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 			cpu-power-states = <&d3>;
-			zephyr,deferred-start;
 		};
 
 		power-states {


### PR DESCRIPTION
This reverts commit c0926335d490f171bbd8bc08af9eaddd01e23468.

When the CPUs are marked as deferred start, they are not being started at boot and must rely on the app to start them manually. However, for tests, we expect all the CPUs to be up and running. Since some tests require those CPUs to be off at boot so SMP startup can be tested, we cannot start those CPUs in the SoC code for testing either. All these deferred tags will need to be defined in SOF as overlay to keep the tests running.

Fixes #117639