### PR TITLE
lib: os: cbprintf: don't rely on char-signedness

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1352,7 +1352,8 @@ static int outs(cbprintf_cb __out,
 	cbprintf_cb out = __out;
 
 	while ((sp < ep) || ((ep == NULL) && *sp)) {
-		int rc = out((int)*sp, ctx);
+		unsigned char uc = *sp;
+		int rc = out((int)uc, ctx);
 		++sp;
 
 		if (rc < 0) {
@@ -1381,7 +1382,8 @@ int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fp,
  * NB: c is evaluated exactly once: side-effects are OK
  */
 #define OUTC(c) do { \
-	int rc = (*out)((int)(c), ctx); \
+	unsigned char uc = (c); \
+	int rc = (*out)((int)uc, ctx); \
 	\
 	if (rc < 0) { \
 		return rc; \


### PR DESCRIPTION
Zephyr coding guideline rule 1: "Any implementation-defined behaviour on which the output of the program depends shall be documented and understood."

calling `cbprintf(out, "%s", "<UTF-8 string>")` invokes implementation-defined behaviour (casting a non-ASCII char to an int).

avoid implementation-defined behaviour by casting to `unsigned char` first.