### PR TITLE
scripts: zspdx: don't rename SPDX 2.x packages after their CPE product

### DIFF
--- a/scripts/pylib/zspdx/serializers/spdx2/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx2/serializer.py
@@ -247,11 +247,10 @@ DocumentNamespace: {namespace}
         return spdx_id
 
     def _resolve_cpe_metadata(self, component):
-        """Derive (name, supplier, version), filling gaps from a CPE 2.3 reference.
+        """Derive (supplier, version), filling gaps from a CPE 2.3 reference.
 
-        Returns local copies so component.name is left untouched (it drives ID lookup).
+        Returns local copies so the component is left untouched.
         """
-        package_name = component.name
         supplier = component.supplier
         package_version = component.version
         for ref in component.external_references:
@@ -261,9 +260,8 @@ DocumentNamespace: {namespace}
             metadata = ref.locator.split(':', 6)
             if len(metadata) > 5:
                 supplier = supplier or metadata[3]
-                package_name = metadata[4]
                 package_version = package_version or metadata[5]
-        return package_name, supplier, package_version
+        return supplier, package_version
 
     def _write_files_analyzed(self, f, component):
         """Write the FilesAnalyzed section and verification code for a component."""
@@ -284,7 +282,8 @@ DocumentNamespace: {namespace}
     def _write_package(self, f, component, doc: SBOMDocument):
         """Write a single package."""
         spdx_id = self._resolve_package_id(component)
-        package_name, supplier, package_version = self._resolve_cpe_metadata(component)
+        supplier, package_version = self._resolve_cpe_metadata(component)
+        package_name = component.name
         normalized_name = normalize_spdx_name(package_name)
 
         f.write(f"""##### Package: {normalized_name}


### PR DESCRIPTION
When a component carries a CPE, the SPDX 2.x serializer took the package name from the CPE product field. A module declaring `cpe:2.3:a:arm:mbed_tls:3.5.2:*:*:*:*:*:*:*` in its `zephyr/module.yml` was therefore written out as:

```
PackageName: mbed_tls
SPDXID: SPDXRef-mbedtls-deps
```

with every relationship in the document still referring to `mbedtls-deps`. The SPDX 3.0 serializer never did this, so the same build described its packages under different names depending on the requested specification version.

Keep the component name — it is what identifies the package across both formats and what relationships point at — and let the CPE fill in only the supplier and version when those are not otherwise known.