### PR TITLE
manifest: declare NVD CPEs for fatfs, loramac-node and trusted-firmware-a

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: f4ead3bf4a6dab3a07d7b5f5315795c073db568d
+      revision: pull/24/head
       path: modules/fs/fatfs
       groups:
         - fs
@@ -319,7 +319,7 @@ manifest:
       revision: a8ddc544043e72807cf7db532478e1dda734ae7c
       path: modules/lib/lora-basics-modem
     - name: loramac-node
-      revision: fb00b383072518c918e2258b0916c996f2d4eebe
+      revision: pull/18/head
       path: modules/lib/loramac-node
     - name: lvgl
       revision: d1fe35d350a1503db2ec7fd4dfff8e0cc26eea7e
@@ -398,7 +398,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-a
-      revision: 4d431cbbb451d13359534c63bf67e2d315ca37de
+      revision: pull/14/head
       path: modules/tee/tf-a/trusted-firmware-a
       groups:
         - tee


### PR DESCRIPTION
Three more modules gain a `security: external-references:` block declaring the NVD CPE for the upstream release they vendor, so they show up in [vulnerability monitoring](https://docs.zephyrproject.org/latest/develop/modules.html#vulnerability-monitoring) instead of being silently unmonitored. Only 5 of 68 modules declare one today (mbedtls, mbedtls-3.6, tf-psa-crypto, trusted-firmware-m, hostap, nanopb).

**Draft, and must stay draft while it is here**: the revisions below are `pull/N/head` refs so CI builds against the module PRs. Each entry gets replaced with the merged commit hash as its module PR lands; this comes out of draft only once all three are real hashes.

| Module | Module PR | CPE added | NVD dictionary | CVEs matched today |
| --- | --- | --- | --- | --- |
| fatfs | zephyrproject-rtos/fatfs#24 | `cpe:2.3:a:elm-chan:fatfs:r0.16` | exact entry exists | 5 |
| loramac-node | zephyrproject-rtos/loramac-node#18 | `cpe:2.3:a:semtech:loramac-node:4.7.0` | exact entry exists | 0 |
| trusted-firmware-a | zephyrproject-rtos/trusted-firmware-a#14 | `cpe:2.3:a:arm:trusted_firmware-a:2.14.1` | product exists, versions enumerated only to 2.8 | 0 |

Each module PR carries the evidence for its version (in-tree version header, Makefile, or changelog) and the NVD queries confirming the CPE resolves. Summary:

- **fatfs** — `ff.h` banner and `FF_DEFINED 80386` say R0.16, as does the README. Matches CVE-2026-6682, -6683, -6686, -6687, -6688 — the runZero set the fatfs README already triages. It will keep matching the ones already fixed there, since upstream ships those as patches against R0.16 and `r0.16` is the only version NVD enumerates. Matching too much beats matching nothing.
- **loramac-node** — `GITHUB_VERSION 0x04070000` and the Zephyr commits sitting directly on upstream's "v4.7.0 release" commit. No advisory against 4.7.0 today; declaring it is what makes a future one visible.
- **trusted-firmware-a** — `Makefile` `VERSION 2.14.1` and the `lts-2.14.1` changelog entry. Worth flagging: NVD's dictionary for this product stops at 2.8, far behind what we vendor, so this matches nothing right now. It is still correct to declare — NVD matches a CPE against each CVE's version *ranges*, not against dictionary membership, so an advisory with an open-ended or forward-extending range will hit. It is insurance, not current coverage.

Two modules were investigated and deliberately left undeclared:

- **openthread** — a CPE exists but it is `cpe:2.3:o:google:openthread` (part `o`, not `a`), and every dictionary entry is a date-stamped snapshot ending at `2019-12-13`. We pin a March 2026 commit, and the fork carries no tags at all — OpenThread derives its version from `git describe` at build time. There is no honest version to write, and `-` would assert "version not applicable" for a library that very much has versions. Left alone.
- **littlefs** — no NVD CPE exists under any spelling (`littlefs`, `little fs`, `arm mbed littlefs` all return zero dictionary entries). Nothing to declare.
