### PR TITLE
manifest: fatfs: pull in manifest update adding security metadata

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: f4ead3bf4a6dab3a07d7b5f5315795c073db568d
+      revision: 4f60a12c58c3de4246857ad87c40239ecd93349b
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
Pulls in a manifest update adding security metadata to the fatfs west module, so it participates in [vulnerability monitoring](https://docs.zephyrproject.org/latest/develop/modules.html#vulnerability-monitoring).

Module PR: zephyrproject-rtos/fatfs#24

CPE picked:

```
cpe:2.3:a:elm-chan:fatfs:r0.16:*:*:*:*:*:*:*
```
