### PR TITLE
manifest: loramac-node: pull in manifest update adding security metadata

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -319,7 +319,7 @@ manifest:
       revision: a8ddc544043e72807cf7db532478e1dda734ae7c
       path: modules/lib/lora-basics-modem
     - name: loramac-node
-      revision: fb00b383072518c918e2258b0916c996f2d4eebe
+      revision: 874544f2a8a0212a0cc12e5eea51a024fd3d93d1
       path: modules/lib/loramac-node
     - name: lvgl
       revision: d1fe35d350a1503db2ec7fd4dfff8e0cc26eea7e


### PR DESCRIPTION
Pulls in a manifest update adding security metadata to the loramac-node west module, so it participates in [vulnerability monitoring](https://docs.zephyrproject.org/latest/develop/modules.html#vulnerability-monitoring).

Module PR: zephyrproject-rtos/loramac-node#18

CPE picked:

```
cpe:2.3:a:semtech:loramac-node:4.7.0:*:*:*:*:*:*:*
```
