### PR TITLE
manifest: tf-a: pull in manifest update adding security metadata

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -398,7 +398,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-a
-      revision: 4d431cbbb451d13359534c63bf67e2d315ca37de
+      revision: pull/14/head
       path: modules/tee/tf-a/trusted-firmware-a
       groups:
         - tee


### PR DESCRIPTION
Pulls in a manifest update adding security metadata to the trusted-firmware-a west module, so it participates in [vulnerability monitoring](https://docs.zephyrproject.org/latest/develop/modules.html#vulnerability-monitoring).

Module PR: zephyrproject-rtos/trusted-firmware-a#14

CPE picked:

```
cpe:2.3:a:arm:trusted_firmware-a:2.14.1:*:*:*:*:*:*:*
```
