### PR TITLE
Bluetooth: Classic: SCO: Route requests by bound ACL server

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1498,6 +1498,11 @@ Bluetooth Classic
   to preserve previous synchronous behavior, or ``-EINPROGRESS`` to use the new
   asynchronous completion path.
 
+* ``bt_sco_server_register()`` and ``bt_sco_server_unregister()`` have been
+  replaced by ``bt_sco_server_bind()`` and ``bt_sco_server_unbind()``, which
+  bind the SCO server to an ACL connection given as an additional argument.
+  (:github:`117676`)
+
 Bluetooth HCI
 =============
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -440,6 +440,9 @@ New APIs and options
     * :c:func:`bt_rfcomm_dlc_recv_complete` to return RX credits to the peer. Applications can
       return ``-EINPROGRESS`` from the :c:member:`bt_rfcomm_dlc_ops.recv` callback to defer buffer
       release and flow-control credit refill until processing is complete.
+    * ``bt_sco_server_bind()`` and ``bt_sco_server_unbind()`` to bind a
+      SCO server to a specific BR/EDR ACL connection, replacing the global
+      ``bt_sco_server_register()``/``bt_sco_server_unregister()``.
 
   * Mesh
 

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -71,6 +71,14 @@ NET_BUF_POOL_FIXED_DEFINE(ag_pool, CONFIG_BT_HFP_AG_TX_BUF_COUNT,
 
 static struct bt_hfp_ag bt_hfp_ag_pool[CONFIG_BT_MAX_CONN];
 
+static int bt_hfp_ag_sco_accept(const struct bt_sco_accept_info *info,
+				struct bt_sco_chan **chan);
+
+static struct bt_sco_server sco_server = {
+	.sec_level = BT_SECURITY_L0,
+	.accept = bt_hfp_ag_sco_accept,
+};
+
 static struct bt_hfp_ag_cb *bt_ag;
 
 #define AG_SUPT_FEAT(ag, _feature) ((ag->ag_features & (_feature)) != 0)
@@ -3639,6 +3647,13 @@ static struct bt_hfp_ag_at_cmd_handler cmd_handlers[] = {
 static void hfp_ag_connected(struct bt_rfcomm_dlc *dlc)
 {
 	struct bt_hfp_ag *ag = CONTAINER_OF(dlc, struct bt_hfp_ag, rfcomm_dlc);
+	int err;
+
+	/* Route incoming SCO requests on this ACL to the AG server. */
+	err = bt_sco_server_bind(ag->acl_conn, &sco_server);
+	if (err != 0) {
+		LOG_WRN("Bind SCO server failed: %d", err);
+	}
 
 	bt_hfp_ag_set_state(ag, BT_HFP_CONFIG);
 
@@ -3664,6 +3679,7 @@ static void hfp_ag_disconnected(struct bt_rfcomm_dlc *dlc)
 	struct bt_hfp_ag *ag = CONTAINER_OF(dlc, struct bt_hfp_ag, rfcomm_dlc);
 	struct bt_ag_tx *tx;
 	struct bt_hfp_ag_call *call;
+	int err;
 
 	k_work_cancel_delayable(&ag->tx_work);
 	k_work_cancel_delayable(&ag->ongoing_call_work);
@@ -3703,6 +3719,12 @@ static void hfp_ag_disconnected(struct bt_rfcomm_dlc *dlc)
 	}
 
 	hfp_ag_close_sco(ag);
+
+	/* Stop routing incoming SCO requests on this ACL to the AG server. */
+	err = bt_sco_server_unbind(ag->acl_conn, &sco_server);
+	if (err != 0) {
+		LOG_WRN("Unbind SCO server failed: %d", err);
+	}
 
 	ag->acl_conn = NULL;
 
@@ -4396,13 +4418,6 @@ static void hfp_ag_init(void)
 	};
 
 	bt_rfcomm_server_register(&chan);
-
-	static struct bt_sco_server sco_server = {
-		.sec_level = BT_SECURITY_L0,
-		.accept = bt_hfp_ag_sco_accept,
-	};
-
-	bt_sco_server_register(&sco_server);
 
 	bt_sdp_register_service(&hfp_ag_rec);
 

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -44,6 +44,14 @@ NET_BUF_POOL_FIXED_DEFINE(hf_pool, CONFIG_BT_MAX_CONN + 1,
 
 static struct bt_hfp_hf bt_hfp_hf_pool[CONFIG_BT_MAX_CONN];
 
+static int bt_hfp_hf_sco_accept(const struct bt_sco_accept_info *info,
+				struct bt_sco_chan **chan);
+
+static struct bt_sco_server sco_server = {
+	.sec_level = BT_SECURITY_L0,
+	.accept = bt_hfp_hf_sco_accept,
+};
+
 #define HF_ENHANCED_CALL_STATUS_TIMEOUT 50 /* ms */
 
 struct at_callback_set {
@@ -4248,8 +4256,15 @@ int bt_hfp_hf_ready_to_accept_audio(struct bt_hfp_hf *hf)
 static void hfp_hf_connected(struct bt_rfcomm_dlc *dlc)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(dlc, struct bt_hfp_hf, rfcomm_dlc);
+	int err;
 
 	LOG_DBG("hf connected");
+
+	/* Route incoming SCO requests on this ACL to the HF server. */
+	err = bt_sco_server_bind(hf->acl, &sco_server);
+	if (err != 0) {
+		LOG_WRN("Bind SCO server failed: %d", err);
+	}
 
 	atomic_set_bit(hf->flags, BT_HFP_HF_FLAG_DLC_CONNECTED);
 	k_work_submit(&hf->slc_work);
@@ -4259,6 +4274,7 @@ static void hfp_hf_disconnected(struct bt_rfcomm_dlc *dlc)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(dlc, struct bt_hfp_hf, rfcomm_dlc);
 	struct net_buf *buf;
+	int err;
 
 	LOG_DBG("hf disconnected!");
 	if (bt_hf->disconnected) {
@@ -4286,6 +4302,12 @@ static void hfp_hf_disconnected(struct bt_rfcomm_dlc *dlc)
 	while (buf != NULL) {
 		net_buf_unref(buf);
 		buf = k_fifo_get(&hf->tx_pending, K_NO_WAIT);
+	}
+
+	/* Stop routing incoming SCO requests on this ACL to the HF server. */
+	err = bt_sco_server_unbind(hf->acl, &sco_server);
+	if (err != 0) {
+		LOG_WRN("Unbind SCO server failed: %d", err);
 	}
 
 	hf->acl = NULL;
@@ -4597,13 +4619,6 @@ static void hfp_hf_init(void)
 	};
 
 	bt_rfcomm_server_register(&chan);
-
-	static struct bt_sco_server sco_server = {
-		.sec_level = BT_SECURITY_L0,
-		.accept = bt_hfp_hf_sco_accept,
-	};
-
-	bt_sco_server_register(&sco_server);
 
 	bt_sdp_register_service(&hfp_rec);
 

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -29,22 +29,21 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_sco);
 
-struct bt_sco_server *sco_server;
-
 #define SCO_CHAN(_sco) ((_sco)->sco.chan);
 
 static sys_slist_t sco_conn_cbs = SYS_SLIST_STATIC_INIT(&sco_conn_cbs);
 static sys_slist_t sco_hci_cbs = SYS_SLIST_STATIC_INIT(&sco_hci_cbs);
 
-int bt_sco_server_register(struct bt_sco_server *server)
+int bt_sco_server_bind(struct bt_conn *acl, struct bt_sco_server *server)
 {
-	if (!server) {
-		LOG_DBG("Invalid parameter: server %p", server);
+	if (acl == NULL || server == NULL) {
+		LOG_DBG("Invalid parameter: acl %p server %p", acl, server);
 		return -EINVAL;
 	}
 
-	if (sco_server) {
-		return -EADDRINUSE;
+	if (!bt_conn_is_br(acl)) {
+		LOG_DBG("acl %p is not a BR/EDR connection", acl);
+		return -EINVAL;
 	}
 
 	if (!server->accept) {
@@ -55,25 +54,38 @@ int bt_sco_server_register(struct bt_sco_server *server)
 		return -EINVAL;
 	}
 
-	LOG_DBG("%p", server);
+	/* Only one server can be bound to an ACL at a time; fail loudly
+	 * instead of silently replacing an existing binding.
+	 */
+	if (acl->br.sco_server != NULL) {
+		LOG_WRN("acl %p already has SCO server %p bound", acl, acl->br.sco_server);
+		return -EADDRINUSE;
+	}
 
-	sco_server = server;
+	acl->br.sco_server = server;
+
+	LOG_DBG("acl %p server %p", acl, server);
 
 	return 0;
 }
 
-int bt_sco_server_unregister(struct bt_sco_server *server)
+int bt_sco_server_unbind(struct bt_conn *acl, struct bt_sco_server *server)
 {
-	if (!server) {
-		LOG_DBG("Invalid parameter: server %p", server);
+	if (acl == NULL || server == NULL || !bt_conn_is_br(acl)) {
 		return -EINVAL;
 	}
 
-	if (sco_server != server) {
+	/* Only the profile that bound the server may unbind it, so that one
+	 * profile cannot clear another profile's binding on the same ACL.
+	 */
+	if (acl->br.sco_server != server) {
+		LOG_WRN("acl %p bound to %p, not %p", acl, acl->br.sco_server, server);
 		return -EINVAL;
 	}
 
-	sco_server = NULL;
+	acl->br.sco_server = NULL;
+
+	LOG_DBG("acl %p", acl);
 
 	return 0;
 }
@@ -201,13 +213,14 @@ void bt_sco_disconnected(struct bt_conn *sco)
 	chan->sco = NULL;
 }
 
-static uint8_t sco_server_check_security(struct bt_conn *conn)
+static uint8_t sco_server_check_security(const struct bt_sco_server *server,
+					 struct bt_conn *acl)
 {
 	if (IS_ENABLED(CONFIG_BT_CONN_DISABLE_SECURITY)) {
 		return BT_HCI_ERR_SUCCESS;
 	}
 
-	if (conn->sec_level >= sco_server->sec_level) {
+	if (acl->sec_level >= server->sec_level) {
 		return BT_HCI_ERR_SUCCESS;
 	}
 
@@ -287,10 +300,11 @@ static void bt_sco_chan_add(struct bt_conn *sco, struct bt_sco_chan *chan)
 	LOG_DBG("sco %p chan %p", sco, chan);
 }
 
-static int sco_accept(struct bt_conn *acl, struct bt_conn *sco)
+static int sco_accept(struct bt_sco_server *server,
+		      const struct bt_sco_accept_info *accept_info,
+		      struct bt_conn *sco)
 {
-	struct bt_sco_accept_info accept_info;
-	struct bt_sco_chan *chan;
+	struct bt_sco_chan *chan = NULL;
 	int err;
 
 	if (!sco || sco->type != BT_CONN_TYPE_SCO) {
@@ -300,18 +314,15 @@ static int sco_accept(struct bt_conn *acl, struct bt_conn *sco)
 
 	LOG_DBG("%p", sco);
 
-	accept_info.acl = acl;
-	memcpy(accept_info.dev_class, sco->sco.dev_class, sizeof(accept_info.dev_class));
-	accept_info.link_type = sco->sco.link_type;
-
-	err = sco_server->accept(&accept_info, &chan);
+	err = server->accept(accept_info, &chan);
 	if (err < 0) {
 		LOG_ERR("Server failed to accept: %d", err);
 		return err;
 	}
 
-	if (chan->ops == NULL) {
-		LOG_ERR("invalid parameter: chan %p chan->ops %p", chan, chan->ops);
+	if (chan == NULL || chan->ops == NULL) {
+		LOG_ERR("invalid parameter: chan %p chan->ops %p", chan,
+			chan ? chan->ops : NULL);
 		return -EINVAL;
 	}
 
@@ -321,13 +332,15 @@ static int sco_accept(struct bt_conn *acl, struct bt_conn *sco)
 	return 0;
 }
 
-static int accept_sco_conn(const bt_addr_t *bdaddr, struct bt_conn *sco_conn)
+static int accept_sco_conn(struct bt_sco_server *server, const bt_addr_t *bdaddr,
+			   const struct bt_sco_accept_info *accept_info,
+			   struct bt_conn *sco_conn)
 {
 	struct bt_hci_cp_accept_sync_conn_req *cp;
 	struct net_buf *buf;
 	int err;
 
-	err = sco_accept(sco_conn->sco.acl, sco_conn);
+	err = sco_accept(server, accept_info, sco_conn);
 	if (err) {
 		return err;
 	}
@@ -358,30 +371,43 @@ static int accept_sco_conn(const bt_addr_t *bdaddr, struct bt_conn *sco_conn)
 
 uint8_t bt_esco_conn_req(struct bt_hci_evt_conn_request *evt)
 {
+	struct bt_sco_accept_info accept_info;
+	struct bt_sco_server *server;
 	struct bt_conn *sco_conn;
 	uint8_t sec_err;
-
-	if (sco_server == NULL) {
-		LOG_ERR("No SCO server registered");
-		return BT_HCI_ERR_UNSPECIFIED;
-	}
+	int err;
 
 	sco_conn = bt_conn_add_sco(&evt->bdaddr, evt->link_type);
 	if (!sco_conn) {
 		return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 	}
 
-	sec_err = sco_server_check_security(sco_conn->sco.acl);
+	memcpy(sco_conn->sco.dev_class, evt->dev_class, sizeof(sco_conn->sco.dev_class));
+	sco_conn->sco.link_type = evt->link_type;
+
+	accept_info.acl = sco_conn->sco.acl;
+	memcpy(accept_info.dev_class, sco_conn->sco.dev_class, sizeof(accept_info.dev_class));
+	accept_info.link_type = sco_conn->sco.link_type;
+
+	/* The server is bound to the ACL connection that owns the SCO link,
+	 * so the request is routed directly to it.
+	 */
+	server = sco_conn->sco.acl->br.sco_server;
+	if (server == NULL) {
+		LOG_ERR("No SCO server bound to ACL %p", sco_conn->sco.acl);
+		bt_sco_cleanup(sco_conn);
+		return BT_HCI_ERR_UNSPECIFIED;
+	}
+
+	sec_err = sco_server_check_security(server, sco_conn->sco.acl);
 	if (BT_HCI_ERR_SUCCESS != sec_err) {
 		LOG_DBG("Insufficient security %u", sec_err);
 		bt_sco_cleanup(sco_conn);
 		return sec_err;
 	}
 
-	memcpy(sco_conn->sco.dev_class, evt->dev_class, sizeof(sco_conn->sco.dev_class));
-	sco_conn->sco.link_type = evt->link_type;
-
-	if (accept_sco_conn(&evt->bdaddr, sco_conn)) {
+	err = accept_sco_conn(server, &evt->bdaddr, &accept_info, sco_conn);
+	if (err != 0) {
 		struct bt_sco_chan *chan = sco_conn->sco.chan;
 
 		LOG_ERR("Error accepting connection from %s", bt_addr_str(&evt->bdaddr));

--- a/subsys/bluetooth/host/classic/sco_internal.h
+++ b/subsys/bluetooth/host/classic/sco_internal.h
@@ -7,6 +7,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+
+#include <zephyr/sys/slist.h>
+
 /** @brief Life-span states of SCO channel. Used only by internal APIs
  *  dealing with setting channel to proper state depending on operational
  *  context.
@@ -104,27 +108,42 @@ struct bt_sco_server {
 			  struct bt_sco_chan **chan);
 };
 
-/** @brief Register SCO server.
+/** @brief Bind a SCO server to an ACL connection.
  *
- *  Register SCO server, each new connection is authorized using the accept()
- *  callback which in case of success shall allocate the channel structure
- *  to be used by the new connection.
+ *  Bind a SCO server to the given ACL connection. All incoming SCO
+ *  requests on this ACL are routed to the server's accept() callback.
+ *  Only one server can be bound to an ACL at a time.
  *
+ *  The server structure must remain valid until it is unbound with
+ *  bt_sco_server_unbind().
+ *
+ *  @param acl   ACL connection that owns the SCO link.
  *  @param server Server structure.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0           Success.
+ *  @retval -EINVAL     Invalid parameters, or the ACL is not a BR/EDR
+ *                      connection.
+ *  @retval -EADDRINUSE The ACL already has a SCO server bound.
  */
-int bt_sco_server_register(struct bt_sco_server *server);
+int bt_sco_server_bind(struct bt_conn *acl, struct bt_sco_server *server);
 
-/** @brief Unregister SCO server.
+/** @brief Unbind a SCO server from an ACL connection.
  *
- *  Unregister previously registered SCO server.
+ *  Unbind the SCO server previously bound to the ACL connection with
+ *  bt_sco_server_bind(). Incoming SCO requests on this ACL are rejected
+ *  until a server is bound again.
  *
- *  @param server Server structure.
+ *  The ACL is only unbound if @p server is the server currently bound to
+ *  it; this prevents one profile from clearing another profile's binding.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @param acl   ACL connection to unbind the server from.
+ *  @param server Server structure previously bound to the ACL.
+ *
+ *  @retval 0       Success.
+ *  @retval -EINVAL Invalid parameters, the ACL is not a BR/EDR connection,
+ *                  or @p server is not the server bound to the ACL.
  */
-int bt_sco_server_unregister(struct bt_sco_server *server);
+int bt_sco_server_unbind(struct bt_conn *acl, struct bt_sco_server *server);
 
 /** @brief sco channel connected.
  *

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -146,6 +146,8 @@ struct bt_conn_le {
 /* For now reserve space for 2 pages of LMP remote features */
 #define LMP_MAX_PAGES 2
 
+struct bt_sco_server;
+
 struct bt_conn_br {
 	bt_addr_t		dst;
 	uint8_t			remote_io_capa;
@@ -154,6 +156,11 @@ struct bt_conn_br {
 	uint8_t			pairing_method;
 	/* remote LMP features pages per 8 bytes each */
 	uint8_t			features[LMP_MAX_PAGES][8];
+
+	/* SCO server bound to this ACL. Incoming SCO requests on this ACL are
+	 * routed to this server, see bt_sco_server_bind().
+	 */
+	struct bt_sco_server	*sco_server;
 
 	struct bt_keys_link_key	*link_key;
 


### PR DESCRIPTION
The SCO host retained only one server, so the first HFP profile to register handled every incoming SCO request. This prevented HFP AG and HF from handling SCO links for different ACLs concurrently.

Bind the SCO server to the ACL connection that owns the SCO link instead of selecting one from a global registry: HFP binds its server when the RFCOMM connection is established and unbinds on disconnect, and incoming SCO requests are routed directly to the server bound to the requesting ACL. Requests without a bound server are rejected.