### PR TITLE
drivers: usb_c: vbus: select GPIO when GPIO props are used

### DIFF
--- a/drivers/usb_c/vbus/Kconfig.usbc_vbus_adc
+++ b/drivers/usb_c/vbus/Kconfig.usbc_vbus_adc
@@ -7,5 +7,7 @@ config USBC_VBUS_ADC
 	bool "USB-C VBUS ADC"
 	default y
 	depends on DT_HAS_ZEPHYR_USB_C_VBUS_ADC_ENABLED
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_USB_C_VBUS_ADC),discharge-gpios) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_USB_C_VBUS_ADC),power-gpios)
 	help
 	  Measure VBUS with an ADC through a voltage divider


### PR DESCRIPTION
## Description

The `samples/subsys/usb_c/sink` sample does not link for `stm32g081b_eval` on current `main`:

```
libdrivers__usb_c__vbus.a(usbc_vbus_adc.c.obj):(.rodata.drv_config_0+0x20):
undefined reference to `__device_dts_ord_53'
```

`__device_dts_ord_53` is `gpiob`. The board's overlay declares a VBUS discharge pin with `discharge-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>`, and the `zephyr,usb-c-vbus-adc` driver bakes that reference into its device config unconditionally via `GPIO_DT_SPEC_INST_GET_OR()`. `CONFIG_GPIO` is no longer enabled by the board's defconfig since 90b9c954f00d ("boards: st: \*: don't enable CONFIG_GPIO by default"), so the GPIO driver is not built, `gpiob` never gets a device definition, and the link fails.

Select `CONFIG_GPIO` from the driver when either GPIO property is used, so every board and application using this driver is covered:

```kconfig
	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_USB_C_VBUS_ADC),discharge-gpios) || \
		$(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_USB_C_VBUS_ADC),power-gpios)
```

`power-gpios` is included because it has the same failure mode: it comes in through the `voltage-divider.yaml` include and the driver expands it with `GPIO_DT_SPEC_INST_GET_OR()` just like `discharge-gpios`.

## Verification

Built for `stm32g081b_eval` at `ceb28342bef` with Zephyr SDK 1.0.1:

| state | result |
| ----- | ------ |
| before this change | link fails, `undefined reference to __device_dts_ord_53` |
| with this change   | links, FLASH 48728 B (37.18%), RAM 12456 B (33.79%) |

`scripts/ci/check_compliance.py` passes on the commit.

Fixes #117678