### PR TITLE
dts: nxp: rt7xx: fix sram_shared_code1 address and drop unused sram4

### DIFF
--- a/dts/arm/nxp/imxrt/imxrt7xx/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/imxrt7xx/nxp_rt7xx_common.dtsi
@@ -72,9 +72,9 @@
 	};
 
 	/* This partition is shared with code in RAM */
-	sram_shared_code1: memory@20058000 {
+	sram_shared_code1: memory@20580000 {
 		compatible = "mmio-sram";
-		reg = <0x20058000 DT_SIZE_K(256)>;
+		reg = <0x20580000 DT_SIZE_K(256)>;
 	};
 
 	sram0: memory@20180000 {
@@ -92,11 +92,6 @@
 		compatible = "mmio-sram";
 		/* Only use 256K, align with SDK */
 		reg = <0x205c0000 DT_SIZE_K(256)>;
-	};
-
-	sram4: memory@20600000 {
-		compatible = "mmio-sram";
-		reg = <0x20600000 DT_SIZE_K(256)>;
 	};
 };
 


### PR DESCRIPTION
sram_shared_code1 had base address 0x20058000, which overlaps sram_shared_code0 (0x018000-0x17FFFF) and does not match the documented CPU1-side shared-memory region. The correct base is 0x20580000 (offset 0x580000), the 256K shared-memory window preceding sram3 (CPU1 app area at 0x5C0000). The wrong value originated in the initial RT7xx DTS commit (83fab799e82) and was carried forward unchanged by the common-DTSI refactor.

Also remove the sram4 node at 0x20600000: it aliases the same physical SRAM as sram_code (CPU1 code region at offset 0x600000) via the system-bus window, is not referenced by any board, overlay, sample, or driver, and was not present in either per-CPU file before the refactor.