### PR TITLE
drivers: mipi_dbi: fix cs_is_gpio index mismatch

### DIFF
--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -49,6 +49,18 @@ extern "C" {
 	GPIO_DT_SPEC_GET_BY_IDX_OR(MIPI_DBI_DT_SPI_DEV(node_id),	\
 		cs_gpios, DT_REG_ADDR_RAW(node_id), {})
 
+/*
+ * Does the MIPI DBI device's underlying SPI controller have a chip
+ * select GPIO at this device's own index? This mirrors
+ * DT_SPI_DEV_HAS_CS_GPIOS(), but goes through the MIPI DBI phandle
+ * indirection (MIPI_DBI_DT_SPI_DEV) instead of DT_BUS(), since a MIPI
+ * DBI device's bus node is the MIPI DBI wrapper, not the SPI
+ * controller itself.
+ */
+#define MIPI_DBI_SPI_HAS_CS_GPIOS(node_id)				\
+	DT_PROP_HAS_IDX(MIPI_DBI_DT_SPI_DEV(node_id), cs_gpios,	\
+		DT_REG_ADDR_RAW(node_id))
+
 #define MIPI_DBI_SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)		\
 	.gpio = MIPI_DBI_SPI_CS_GPIOS_DT_SPEC_GET(node_id),		\
 	.delay = delay_,
@@ -75,10 +87,10 @@ extern "C" {
 			COND_CODE_1(DT_PROP(node_id, mipi_hold_cs), SPI_HOLD_ON_CS, (0)),	\
 		.slave = DT_REG_ADDR(node_id),				\
 		.cs = {									\
-			COND_CODE_1(DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),	\
+			COND_CODE_1(MIPI_DBI_SPI_HAS_CS_GPIOS(node_id),		\
 			(MIPI_DBI_SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)),		\
 			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))				\
-			.cs_is_gpio = DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),\
+			.cs_is_gpio = MIPI_DBI_SPI_HAS_CS_GPIOS(node_id),		\
 		},									\
 	}
 

--- a/tests/drivers/build_all/display/src/main.c
+++ b/tests/drivers/build_all/display/src/main.c
@@ -4,6 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/mipi_dbi.h>
+
+/*
+ * test_mipi_dbi_hx8353e_pwm (app.overlay) sits at reg = 0x27 on test_spi,
+ * whose cs-gpios property only has 10 entries (index 0-9). Regression
+ * check for MIPI_DBI_SPI_HAS_CS_GPIOS(): it must answer per this
+ * device's own index, not just whether test_spi has a cs-gpios property
+ * at all, since that property existing says nothing about whether index
+ * 0x27 is actually one of its 10 entries.
+ */
+BUILD_ASSERT(MIPI_DBI_SPI_HAS_CS_GPIOS(DT_NODELABEL(test_mipi_dbi_hx8353e_pwm)) == 0,
+	     "index 0x27 is out of range for a 10-entry cs-gpios property");
+
 int main(void)
 {
 	return 0;


### PR DESCRIPTION
## Summary

`MIPI_DBI_SPI_CONFIG_DT()` decides whether a display's chip select is a GPIO using `DT_SPI_HAS_CS_GPIOS()`, which only checks whether the SPI controller has a `cs-gpios` property at all. The GPIO spec next to it, `MIPI_DBI_SPI_CS_GPIOS_DT_SPEC_GET()`, reads a specific entry from that property, indexed by the display's own `reg` address. If a display's index falls past the end of the controller's `cs-gpios` list, the two disagree: `cs_is_gpio` ends up `true` while the GPIO spec is empty.

This already happens in-tree: `tests/drivers/build_all/display/app.overlay`'s `test_spi` node has a 10 entry `cs-gpios` property, and `test_mipi_dbi_hx8353e_pwm` sits at `reg = 0x27` (39), well past the end of it.

## Fix

Added `MIPI_DBI_SPI_HAS_CS_GPIOS()`, which checks the property at the device's own index instead of just checking the controller for the property's existence, mirroring `DT_SPI_DEV_HAS_CS_GPIOS()` but routed through MIPI DBI's own phandle indirection since a MIPI DBI device's `DT_BUS()` is the MIPI DBI wrapper node, not the SPI controller. Used it in both places `MIPI_DBI_SPI_CONFIG_DT()` was using the old check.

Added a `BUILD_ASSERT` to the existing build_all display test against the same out-of-range fixture as a regression guard.

Fixes #115251

## Test plan

- Verified the bug is real by compiling `BUILD_ASSERT`s against the unfixed header showing the property-existence check and the per-index check disagree on the same in-tree fixture
- Applied the fix and confirmed the corrected macro now agrees with the per-index check
- Ran `scripts/checkpatch.pl` against both changed files: 0 errors, 0 warnings
- Built the display driver library and app for `native_sim`: compiles cleanly

Assisted-by: Claude:claude-sonnet-5