### PR TITLE
scripts: zspdx: attach a proper purl and CPE to the Zephyr sources

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -390,6 +390,11 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
      - String. If present, the value will be split according to shell rules and
        passed to CMake whenever a new build system is generated. See
        :ref:`west-building-cmake-config`.
+   * - ``build.cmake-file-api``
+     - Boolean, default ``true``. If ``true``, ``west build`` enables CMake's
+       `file-based API`_ before configuring, so the build's object model is
+       available to tooling such as :ref:`west spdx <west-spdx>`. Set to
+       ``false`` to skip it.
    * - ``build.dir-fmt``
      - String, default ``build``. The build folder format string, used by
        west whenever it needs to create or locate a build folder. The currently
@@ -882,5 +887,8 @@ commands do it).
 
 .. _CMake Generator:
    https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html
+
+.. _file-based API:
+   https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html
 
 .. _MCUboot: https://mcuboot.com/

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -162,6 +162,9 @@ For SPDX 3.0, every document declares conformance to the Core, Software and Simp
 profiles, and :file:`build.jsonld` additionally declares the :ref:`Build profile
 <west-spdx-build-profile>` that captures how the artifacts were produced.
 
+With ``--analyze-elf=snippets``, an additional ``snippets`` document records the source line-ranges
+that ended up in the final image. See :ref:`west-spdx-analyze-elf`.
+
 Each file in the bill-of-materials is scanned, so that its hashes (SHA256, SHA1, and MD5)
 can be recorded, along with any detected licenses if an
 ``SPDX-License-Identifier`` comment appears in the file.
@@ -208,6 +211,35 @@ used.
 Each intermediate target, such as a static library, also gets its own sub-build capturing the exact
 sources, tools and compile flags that produced its artifact, so any output can be traced back to how
 it was built.
+
+.. _west-spdx-analyze-elf:
+
+Image analysis (``--analyze-elf``)
+----------------------------------
+
+By default the bill-of-materials lists every source file that took part in the build. Not all of
+that code reaches the firmware: the linker garbage-collects unused sections, and whole files can end
+up contributing nothing. ``--analyze-elf`` reads the DWARF debug information of the final image to
+narrow the documents down to what actually shipped. It may be given more than once to combine
+analyses.
+
+``--analyze-elf=prune-sources`` drops the translation units (``.c``, ``.S``, ...) whose code is
+absent from the image, so the BOM lists the sources the firmware is actually built from rather than
+everything that was compiled. Headers, generated data and build artifacts are left untouched.
+
+``--analyze-elf=snippets`` records the opposite view: the source line-ranges that *did* contribute
+code, as SPDX Snippets in an additional :file:`snippets.spdx` (or :file:`snippets.jsonld`) document.
+Each snippet carries the line and byte range within its source file, inherits that file's license
+and copyright, and is tied back to the image it was found in. This narrows license and provenance
+questions from "which files were compiled" down to "which lines shipped".
+
+The image analyzed defaults to :file:`BUILD_DIR/zephyr/zephyr.elf`; point ``--elf-file`` at another
+one to analyze it instead.
+
+.. note::
+   Both analyses need an image built with debug symbols, which is the default for most Zephyr
+   configurations. If the image carries no DWARF information, ``west spdx`` reports it and leaves
+   the bill-of-materials untouched rather than silently emitting an empty result.
 
 Command-line options
 --------------------

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -231,15 +231,19 @@ Command-line options
   document, :file:`sdk.spdx` (or :file:`sdk.jsonld`), which lists header files
   included from the SDK.
 
-- ``--analyze-elf {snippets}``: inspect the final image's DWARF debug
-  information to refine the bill-of-materials down to what actually ended up in
-  the firmware. Requires a build with debug symbols (the default for most
-  Zephyr configurations).
+- ``--analyze-elf {snippets,prune-sources}``: inspect the final image's DWARF
+  debug information to refine the bill-of-materials down to what actually ended
+  up in the firmware. Requires a build with debug symbols (the default for most
+  Zephyr configurations). May be given more than once to combine analyses:
 
   - ``snippets``: record the specific source line-ranges that contributed code
     to the image as an additional :file:`snippets.spdx` (or
     :file:`snippets.jsonld`) document, using SPDX Snippets. Each snippet points
     back at its source file and carries that file's license and copyright.
+
+  - ``prune-sources``: drop source files (``.c``, ``.S``, ...) that contributed
+    no code to the image, for example because the linker garbage-collected
+    them. Header files, generated data and build artifacts are left untouched.
 
 - ``--elf-file ELF``: the image analyzed by ``--analyze-elf``. Defaults to
   :file:`BUILD_DIR/zephyr/zephyr.elf`.

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -231,6 +231,19 @@ Command-line options
   document, :file:`sdk.spdx` (or :file:`sdk.jsonld`), which lists header files
   included from the SDK.
 
+- ``--analyze-elf {snippets}``: inspect the final image's DWARF debug
+  information to refine the bill-of-materials down to what actually ended up in
+  the firmware. Requires a build with debug symbols (the default for most
+  Zephyr configurations).
+
+  - ``snippets``: record the specific source line-ranges that contributed code
+    to the image as an additional :file:`snippets.spdx` (or
+    :file:`snippets.jsonld`) document, using SPDX Snippets. Each snippet points
+    back at its source file and carries that file's license and copyright.
+
+- ``--elf-file ELF``: the image analyzed by ``--analyze-elf``. Defaults to
+  :file:`BUILD_DIR/zephyr/zephyr.elf`.
+
 .. warning::
 
    The generation of SBOM documents for the ``native_sim`` platform is currently not supported.

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -109,6 +109,17 @@ Generating SPDX documents
 
       west build -d BUILD_DIR [...]
 
+   ``west build`` enables the CMake file-based API (the build "object model" that ``west spdx``
+   relies on) automatically, so no separate initialization step is required.
+
+   If you configure CMake without ``west build`` -- or you disabled the file-based API with
+   ``west config build.cmake-file-api false`` -- create the query manually *before* configuring
+   the build:
+
+   .. code-block:: bash
+
+      west spdx --init -d BUILD_DIR
+
 #. Generate SPDX documents using this build directory:
 
    .. code-block:: bash

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1874,6 +1874,25 @@ Other notable changes
     :zephyr:board:`Arm Musca-S1 <v2m_musca_s1>` (``v2m_musca_s1``) has been deprecated.
     This is to avoid a confusing state of partial support.
 
+* SBOM (``west spdx``)
+
+  * ``west spdx`` can now emit **SPDX 3.0** documents (JSON-LD) alongside the
+    SPDX 2.2/2.3 tag-value formats; pick the version with ``--spdx-version``.
+    See :ref:`west-spdx`.
+
+  * SPDX 3.0 output includes a :ref:`Build profile <west-spdx-build-profile>`
+    that records build provenance: the toolchain (compilers, assembler, linker
+    and archiver, with versions), the CMake generator and build type, selected
+    environment variables such as ``BOARD`` and ``ARCH``, and
+    ``hasInput``/``hasOutput``/``usesTool`` relationships tracing each artifact
+    back to how it was built.
+
+  * The new ``--analyze-elf`` option inspects the final image's DWARF debug
+    information to refine the bill-of-materials to what actually shipped:
+    ``snippets`` records the source line-ranges that contributed code as SPDX
+    Snippets, and ``prune-sources`` drops source files the linker left out.
+    Use ``--elf-file`` to analyze a non-default image.
+
 ..
   Any more descriptive subsystem or driver changes. Do you really want to write
   a paragraph or is it enough to link to the api/driver/Kconfig/board page above?

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1880,6 +1880,12 @@ Other notable changes
     SPDX 2.2/2.3 tag-value formats; pick the version with ``--spdx-version``.
     See :ref:`west-spdx`.
 
+  * ``west build`` now enables CMake's file-based API automatically, so
+    generating an SBOM no longer requires a separate ``west spdx --init`` step
+    before the build: build with :kconfig:option:`CONFIG_BUILD_OUTPUT_META`
+    enabled and then run ``west spdx``. Set
+    ``west config build.cmake-file-api false`` to opt out.
+
   * SPDX 3.0 output includes a :ref:`Build profile <west-spdx-build-profile>`
     that records build provenance: the toolchain (compilers, assembler, linker
     and archiver, with versions), the CMake generator and build type, selected

--- a/scripts/pylib/zspdx/dwarf.py
+++ b/scripts/pylib/zspdx/dwarf.py
@@ -66,6 +66,7 @@ def collect_used_lines(
         DWARF info or cannot be opened.
     """
     try:
+        from elftools.common.exceptions import ELFError
         from elftools.elf.elffile import ELFFile
     except ImportError:
         _logger.error(
@@ -85,6 +86,9 @@ def collect_used_lines(
             _collect_lines(elf.get_dwarf_info(), file_lines, known_paths)
     except OSError as exc:
         _logger.error("Cannot open ELF file %s: %s", elf_path, exc)
+        return {}
+    except ELFError as exc:
+        _logger.error("Not a valid ELF file %s: %s", elf_path, exc)
         return {}
 
     _logger.debug(

--- a/scripts/pylib/zspdx/dwarf.py
+++ b/scripts/pylib/zspdx/dwarf.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract used source information from an ELF file's DWARF debug info.
+
+The DWARF line programs of a linked image tell us which source lines actually
+contributed code to it.  Two views of that data are exposed:
+
+* :func:`collect_used_lines` returns the raw ``{source path: {used line}}``
+  mapping.  Its key set is the set of source files present in the final image,
+  which the ``prune-sources`` analysis uses to drop sources that contributed
+  nothing.
+* :func:`extract_source_ranges` folds those lines into contiguous
+  :class:`SourceRange` objects (with source-file byte offsets), which the
+  ``snippets`` analysis emits as SPDX Snippets.
+
+Callers may restrict results to a known set of paths via ``known_paths``.
+
+Requires ``pyelftools`` (already listed in ``requirements-base.txt``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SourceRange:
+    """A contiguous block of used source lines within a single file.
+
+    ``start_byte`` / ``end_byte`` are byte offsets *within the source file*
+    (not within the binary), as required by the SPDX Snippet model.
+    """
+
+    path: str
+    start_line: int
+    end_line: int
+    start_byte: int
+    end_byte: int
+
+
+def collect_used_lines(
+    elf_path: str,
+    known_paths: set[str] | None = None,
+) -> dict[str, set[int]]:
+    """Return the used source lines per file from an ELF's DWARF debug info.
+
+    This is the single DWARF pass shared by the ``prune-sources`` and
+    ``snippets`` analyses: the key set answers "which source files are in the
+    final image?" and the line sets answer "which lines of each?".
+
+    Args:
+        elf_path: Path to the compiled ELF file (must carry DWARF debug info).
+        known_paths: When provided, only source files whose ``os.path.realpath``
+            is in this set are included in the result.  Pass ``None`` to collect
+            all files referenced by DWARF.
+
+    Returns:
+        Dict mapping absolute (realpath) source path to the set of 1-based line
+        numbers used from that file.  Returns an empty dict when the ELF has no
+        DWARF info or cannot be opened.
+    """
+    try:
+        from elftools.elf.elffile import ELFFile
+    except ImportError:
+        _logger.error(
+            "pyelftools is required for --analyze-elf; "
+            "install it with: pip install pyelftools"
+        )
+        return {}
+
+    file_lines: dict[str, set[int]] = {}
+
+    try:
+        with open(elf_path, "rb") as f:
+            elf = ELFFile(f)
+            if not elf.has_dwarf_info():
+                _logger.warning("ELF file has no DWARF debug info: %s", elf_path)
+                return {}
+            _collect_lines(elf.get_dwarf_info(), file_lines, known_paths)
+    except OSError as exc:
+        _logger.error("Cannot open ELF file %s: %s", elf_path, exc)
+        return {}
+
+    _logger.debug(
+        "Collected used lines from %s: %d source files", elf_path, len(file_lines)
+    )
+    return file_lines
+
+
+def ranges_from_line_map(file_lines: dict[str, set[int]]) -> dict[str, list[SourceRange]]:
+    """Fold a ``{path: {used lines}}`` mapping into contiguous source ranges.
+
+    Args:
+        file_lines: Used lines per source file, as returned by
+            :func:`collect_used_lines`.
+
+    Returns:
+        Dict mapping absolute (realpath) source path to a list of
+        :class:`SourceRange` objects, sorted by ``start_line``.  Files whose
+        ranges cannot be resolved (e.g. the source is unreadable) are omitted.
+    """
+    result: dict[str, list[SourceRange]] = {}
+    for path, lines in file_lines.items():
+        ranges = _lines_to_ranges(path, sorted(lines))
+        if ranges:
+            result[path] = ranges
+    return result
+
+
+def extract_source_ranges(
+    elf_path: str,
+    known_paths: set[str] | None = None,
+) -> dict[str, list[SourceRange]]:
+    """Return contiguous used-line ranges per source file from ELF DWARF debug info.
+
+    Convenience wrapper over :func:`collect_used_lines` followed by
+    :func:`ranges_from_line_map`.
+
+    Args:
+        elf_path: Path to the compiled ELF file (must carry DWARF debug info).
+        known_paths: When provided, only source files whose ``os.path.realpath``
+            is in this set are included in the result.  Pass ``None`` to collect
+            all files referenced by DWARF.
+
+    Returns:
+        Dict mapping absolute (realpath) source path to a list of
+        :class:`SourceRange` objects, sorted by ``start_line``.  Returns an
+        empty dict when the ELF has no DWARF info or cannot be opened.
+    """
+    return ranges_from_line_map(collect_used_lines(elf_path, known_paths))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_lines(
+    dwarf,
+    file_lines: dict[str, set[int]],
+    known_paths: set[str] | None,
+) -> None:
+    """Walk every DWARF line program and accumulate used line numbers per file."""
+    for CU in dwarf.iter_CUs():
+        lp = dwarf.line_program_for_CU(CU)
+        if lp is None:
+            continue
+
+        top_die = CU.get_top_DIE()
+        comp_dir_attr = top_die.attributes.get("DW_AT_comp_dir")
+        comp_dir = (
+            comp_dir_attr.value.decode("utf-8", errors="replace") if comp_dir_attr else ""
+        )
+
+        lp_header = lp.header
+        file_entries = lp_header.file_entry
+        include_dirs = lp_header.include_directory
+
+        for entry in lp.get_entries():
+            state = entry.state
+            if state is None or state.end_sequence or state.line == 0:
+                continue
+            try:
+                path = _resolve_file(state.file, file_entries, include_dirs, comp_dir)
+            except (IndexError, AttributeError):
+                continue
+            if known_paths is not None and path not in known_paths:
+                continue
+            file_lines.setdefault(path, set()).add(state.line)
+
+
+def _resolve_file(
+    file_idx: int,
+    file_entries,
+    include_dirs,
+    comp_dir: str,
+) -> str:
+    """Resolve a 1-based DWARF file-table index to an absolute realpath."""
+    fe = file_entries[file_idx - 1]
+    name = fe.name.decode("utf-8", errors="replace")
+    dir_idx = fe.dir_index
+    if dir_idx == 0:
+        base = comp_dir
+    else:
+        raw = include_dirs[dir_idx - 1].decode("utf-8", errors="replace")
+        base = raw if os.path.isabs(raw) else os.path.join(comp_dir, raw)
+    full = name if os.path.isabs(name) else os.path.join(base, name)
+    return os.path.realpath(full)
+
+
+def _build_line_offsets(path: str) -> dict[int, tuple[int, int]]:
+    """Return ``{line_number: (start_byte, end_byte)}`` for every line in *path*.
+
+    Line numbers are 1-based.  ``end_byte`` points to the last byte of the line
+    *before* the newline.  Returns an empty dict when the file cannot be read.
+    """
+    try:
+        with open(path, "rb") as f:
+            content = f.read()
+    except OSError:
+        return {}
+
+    offsets: dict[int, tuple[int, int]] = {}
+    pos = 0
+    for lineno, chunk in enumerate(content.split(b"\n"), start=1):
+        offsets[lineno] = (pos, pos + len(chunk))
+        pos += len(chunk) + 1  # +1 for the '\n' separator
+    return offsets
+
+
+def _lines_to_ranges(path: str, sorted_lines: list[int]) -> list[SourceRange]:
+    """Convert a sorted list of used line numbers to contiguous :class:`SourceRange` objects."""
+    if not sorted_lines:
+        return []
+
+    offsets = _build_line_offsets(path)
+    if not offsets:
+        return []
+
+    max_line = max(offsets)
+    ranges: list[SourceRange] = []
+    start = sorted_lines[0]
+    prev = sorted_lines[0]
+
+    for line in sorted_lines[1:]:
+        if line > prev + 1:
+            r = _make_range(path, start, prev, offsets, max_line)
+            if r is not None:
+                ranges.append(r)
+            start = line
+        prev = line
+
+    r = _make_range(path, start, prev, offsets, max_line)
+    if r is not None:
+        ranges.append(r)
+
+    return ranges
+
+
+def _make_range(
+    path: str,
+    start_line: int,
+    end_line: int,
+    offsets: dict[int, tuple[int, int]],
+    max_line: int,
+) -> SourceRange | None:
+    end_line = min(end_line, max_line)
+    if start_line not in offsets or end_line not in offsets:
+        return None
+    return SourceRange(
+        path=path,
+        start_line=start_line,
+        end_line=end_line,
+        start_byte=offsets[start_line][0],
+        end_byte=offsets[end_line][1],
+    )

--- a/scripts/pylib/zspdx/dwarf.py
+++ b/scripts/pylib/zspdx/dwarf.py
@@ -167,7 +167,9 @@ def _collect_lines(
             if state is None or state.end_sequence or state.line == 0:
                 continue
             try:
-                path = _resolve_file(state.file, file_entries, include_dirs, comp_dir)
+                path = _resolve_file(
+                    state.file, file_entries, include_dirs, comp_dir, lp_header.version
+                )
             except (IndexError, AttributeError):
                 continue
             if known_paths is not None and path not in known_paths:
@@ -180,16 +182,31 @@ def _resolve_file(
     file_entries,
     include_dirs,
     comp_dir: str,
+    version: int,
 ) -> str:
-    """Resolve a 1-based DWARF file-table index to an absolute realpath."""
-    fe = file_entries[file_idx - 1]
+    """Resolve a DWARF file-table index to an absolute realpath.
+
+    Up to v4 the file table is 1-based and directory 0 is implicitly the
+    compilation directory; from v5 both tables are 0-based and directory 0 is
+    an explicit entry holding it.
+    """
+    if version >= 5:
+        fe = file_entries[file_idx]
+    else:
+        fe = file_entries[file_idx - 1]
+
     name = fe.name.decode("utf-8", errors="replace")
     dir_idx = fe.dir_index
-    if dir_idx == 0:
+
+    if version >= 5:
+        raw = include_dirs[dir_idx].decode("utf-8", errors="replace")
+        base = raw if os.path.isabs(raw) else os.path.join(comp_dir, raw)
+    elif dir_idx == 0:
         base = comp_dir
     else:
         raw = include_dirs[dir_idx - 1].decode("utf-8", errors="replace")
         base = raw if os.path.isabs(raw) else os.path.join(comp_dir, raw)
+
     full = name if os.path.isabs(name) else os.path.join(base, name)
     return os.path.realpath(full)
 

--- a/scripts/pylib/zspdx/model.py
+++ b/scripts/pylib/zspdx/model.py
@@ -204,7 +204,7 @@ class SBOMComponent:
         return reference
 
 
-type SBOMElement = SBOMComponent | SBOMFile
+type SBOMElement = SBOMComponent | SBOMFile | SBOMSnippet
 
 
 @dataclass
@@ -349,6 +349,33 @@ class BuildInfo(TypedDict, total=False):
 
 
 @dataclass
+class SBOMSnippet:
+    """A contiguous range of used source lines within a tracked SBOM file.
+
+    Instances are produced by the DWARF extractor and consumed by serializers to
+    emit SPDX ``Snippet`` elements (2.x tag-value) or ``software_Snippet``
+    elements (SPDX 3.0).  ``byte_range`` and ``line_range`` are offsets/line
+    numbers within the *source* file, not the binary.
+
+    Attributes:
+        spdx_file: The :class:`SBOMFile` whose source lines this snippet covers.
+        byte_range: ``(start_byte, end_byte)`` offsets within the source file.
+        line_range: ``(start_line, end_line)`` line numbers within the source
+            file, or ``None`` when line information is unavailable.
+        name: Optional human-readable label for this snippet.
+        concluded_license: Concluded license expression (defaults to parent's).
+        copyright_text: Copyright text (defaults to parent's).
+    """
+
+    spdx_file: SBOMFile
+    byte_range: tuple[int, int]
+    line_range: tuple[int, int] | None = None
+    name: str = ""
+    concluded_license: str = NOASSERTION
+    copyright_text: str = NOASSERTION
+
+
+@dataclass
 class SBOMBuild:
     """Format-agnostic identity of the build that produced the graph's artifacts."""
 
@@ -375,8 +402,19 @@ class SBOMGraph:
         files: Files in the graph, keyed by absolute path.
         relationships: Relationships in the graph.
         custom_license_ids: Custom license IDs that need to be declared by serializers.
-        build: Build that produced the graph's artifacts, or ``None`` if it carries no build.
-        metadata: Additional data not represented by the common model fields.
+        build: Build instance that produced the graph's artifacts, or ``None`` when no build
+            information was collected.
+        snippets: Source-code snippets extracted from DWARF debug info, populated by the
+            snippet extraction step when ``--analyze-elf=snippets`` is requested.  Empty when
+            not requested or when the ELF carries no DWARF info.
+        snippet_binary: The linked image (ELF) the snippets were extracted from, when it is a
+            tracked file in the graph.  Serializers use it to emit the source-to-binary
+            provenance relationship (``zephyr.elf GENERATED_FROM <snippet>`` in SPDX 2.x, the
+            Build profile's ``hasInput`` in SPDX 3.0).  ``None`` when no snippets were requested
+            or the image is not tracked as a file.
+        metadata: Additional data not represented by the common model fields. The
+            ``build_info`` key, when present, holds the detailed build configuration (compiler,
+            linker and CMake information) consumed by the SPDX 3.0 Build profile serializer.
     """
 
     namespace_prefix: str = ""
@@ -387,6 +425,8 @@ class SBOMGraph:
     relationships: list[SBOMRelationship] = field(default_factory=list)
     custom_license_ids: set[str] = field(default_factory=set)
     build: SBOMBuild | None = None
+    snippets: list[SBOMSnippet] = field(default_factory=list)
+    snippet_binary: SBOMFile | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def add_document(self, document: SBOMDocument) -> None:

--- a/scripts/pylib/zspdx/sbom.py
+++ b/scripts/pylib/zspdx/sbom.py
@@ -41,6 +41,10 @@ class SBOMConfig:
     # final image's DWARF debug info?
     generate_snippets: bool = False
 
+    # --analyze-elf=prune-sources: drop source files that contributed no code
+    # to the final image, per its DWARF debug info?
+    prune_sources: bool = False
+
     # ELF file to analyze for --analyze-elf; when empty, defaults to
     # <build_dir>/zephyr/zephyr.elf
     elf_file: str = ""
@@ -114,7 +118,7 @@ def make_spdx(cfg):
     scan_sbom_graph(scanner_cfg, sbom_graph)
 
     # optional: analyze the final image's DWARF debug info
-    if cfg.generate_snippets:
+    if cfg.generate_snippets or cfg.prune_sources:
         _analyze_elf(cfg, sbom_graph)
 
     # route to appropriate serializer based on version
@@ -135,8 +139,20 @@ def make_spdx(cfg):
         return False
 
 
+# Source file extensions treated as translation units, i.e. files that are
+# compiled and can therefore be present in (or absent from) the final image's
+# DWARF debug info. Only these are candidates for --analyze-elf=prune-sources;
+# headers, generated blobs, licenses and build artifacts are left untouched.
+_TRANSLATION_UNIT_EXTS = frozenset({".c", ".cpp", ".cxx", ".cc", ".c++", ".s", ".asm"})
+
+
 def _analyze_elf(cfg: SBOMConfig, sbom_graph) -> None:
-    """Record the final image's used source ranges as SPDX snippets."""
+    """Run the requested --analyze-elf analyses over the final image's DWARF info.
+
+    Performs a single DWARF pass and dispatches to the requested analyses:
+    ``prune-sources`` drops sources absent from the image, ``snippets`` records
+    the used source ranges as SPDX Snippets.
+    """
     from zspdx.dwarf import collect_used_lines
 
     elf_path = cfg.elf_file or os.path.join(cfg.build_dir, "zephyr", "zephyr.elf")
@@ -148,8 +164,70 @@ def _analyze_elf(cfg: SBOMConfig, sbom_graph) -> None:
         )
         return
 
+    # Single DWARF pass, shared by both analyses.
     file_lines = collect_used_lines(elf_path)
-    _extract_snippets(sbom_graph, elf_path, file_lines)
+
+    if cfg.prune_sources:
+        _prune_unused_sources(sbom_graph, set(file_lines))
+
+    if cfg.generate_snippets:
+        _extract_snippets(sbom_graph, elf_path, file_lines)
+
+
+def _prune_unused_sources(sbom_graph, used_paths: set[str]) -> None:
+    """Drop source files that contributed no code to the final image.
+
+    ``used_paths`` is the set of source-file realpaths referenced by the image's
+    DWARF debug info. Any tracked translation unit whose realpath is absent from
+    that set is removed from the graph along with its relationships.
+    """
+    # An empty set almost always means the DWARF walk failed (missing debug info
+    # or unreadable ELF); pruning against it would wrongly remove every source.
+    if not used_paths:
+        _logger.error(
+            "no sources found in the ELF's DWARF info; skipping prune-sources "
+            "to avoid removing every source file"
+        )
+        return
+
+    to_remove = [
+        spdx_file
+        for path, spdx_file in sbom_graph.files.items()
+        if os.path.splitext(path)[1].lower() in _TRANSLATION_UNIT_EXTS
+        and os.path.realpath(path) not in used_paths
+    ]
+    for spdx_file in to_remove:
+        _remove_file_from_graph(sbom_graph, spdx_file)
+
+    _logger.info(
+        "prune-sources: removed %d source file(s) absent from the final image",
+        len(to_remove),
+    )
+
+
+def _remove_file_from_graph(sbom_graph, spdx_file) -> None:
+    """Remove a file from the graph, keeping ownership and relationships consistent."""
+    # Detach from the owning component and the global file index.
+    if spdx_file.component is not None:
+        spdx_file.component.files.pop(spdx_file.path, None)
+    sbom_graph.files.pop(spdx_file.path, None)
+
+    # Rebuild the relationship list, dropping any relationship that starts at the
+    # removed file and unlinking it from any relationship that targets it.
+    surviving = []
+    for rel in sbom_graph.relationships:
+        if rel.from_element is spdx_file:
+            continue
+        if any(target is spdx_file for target in rel.to_elements):
+            rel.to_elements = [t for t in rel.to_elements if t is not spdx_file]
+            if not rel.to_elements:
+                # Relationship has no targets left; drop it and detach it from
+                # the element that owned it.
+                owner = rel.from_element
+                owner.relationships = [r for r in owner.relationships if r is not rel]
+                continue
+        surviving.append(rel)
+    sbom_graph.relationships = surviving
 
 
 def _extract_snippets(sbom_graph, elf_path: str, file_lines: dict[str, set[int]]) -> None:

--- a/scripts/pylib/zspdx/sbom.py
+++ b/scripts/pylib/zspdx/sbom.py
@@ -37,6 +37,14 @@ class SBOMConfig:
     # should also add an SPDX document for the SDK?
     include_sdk: bool = False
 
+    # --analyze-elf=snippets: generate a snippets add-on document from the
+    # final image's DWARF debug info?
+    generate_snippets: bool = False
+
+    # ELF file to analyze for --analyze-elf; when empty, defaults to
+    # <build_dir>/zephyr/zephyr.elf
+    elf_file: str = ""
+
 
 # create Cmake file-based API directories and query file
 # Arguments:
@@ -105,6 +113,10 @@ def make_spdx(cfg):
     # scan SBOM graph
     scan_sbom_graph(scanner_cfg, sbom_graph)
 
+    # optional: analyze the final image's DWARF debug info
+    if cfg.generate_snippets:
+        _analyze_elf(cfg, sbom_graph)
+
     # route to appropriate serializer based on version
     if cfg.spdx_version.major == 2:
         # Use SPDX 2.x serializer
@@ -121,3 +133,64 @@ def make_spdx(cfg):
     else:
         _logger.error("Unsupported SPDX version: %s", cfg.spdx_version)
         return False
+
+
+def _analyze_elf(cfg: SBOMConfig, sbom_graph) -> None:
+    """Record the final image's used source ranges as SPDX snippets."""
+    from zspdx.dwarf import collect_used_lines
+
+    elf_path = cfg.elf_file or os.path.join(cfg.build_dir, "zephyr", "zephyr.elf")
+    if not os.path.isfile(elf_path):
+        _logger.error(
+            "ELF file not found for --analyze-elf: %s "
+            "(build first, or pass --elf-file=<path>)",
+            elf_path,
+        )
+        return
+
+    file_lines = collect_used_lines(elf_path)
+    _extract_snippets(sbom_graph, elf_path, file_lines)
+
+
+def _extract_snippets(sbom_graph, elf_path: str, file_lines: dict[str, set[int]]) -> None:
+    """Populate ``sbom_graph.snippets`` from the collected DWARF line map."""
+    from zspdx.dwarf import ranges_from_line_map
+    from zspdx.model import SBOMSnippet
+
+    # Restrict to tracked files before folding into ranges so we only read the
+    # sources we actually emit snippets for.
+    known_paths = set(sbom_graph.files.keys())
+    ranges_by_file = ranges_from_line_map(
+        {path: lines for path, lines in file_lines.items() if path in known_paths}
+    )
+
+    # Record the image the snippets came from so serializers can emit the
+    # source-to-binary provenance relationship. The graph may key the file by a
+    # different (non-realpath) path, so fall back to a realpath comparison.
+    sbom_graph.snippet_binary = sbom_graph.get_file(elf_path)
+    if sbom_graph.snippet_binary is None:
+        real_elf = os.path.realpath(elf_path)
+        for file_path, spdx_file in sbom_graph.files.items():
+            if os.path.realpath(file_path) == real_elf:
+                sbom_graph.snippet_binary = spdx_file
+                break
+
+    for path, ranges in ranges_by_file.items():
+        spdx_file = sbom_graph.get_file(path)
+        if spdx_file is None:
+            continue
+        for r in ranges:
+            snippet = SBOMSnippet(
+                spdx_file=spdx_file,
+                byte_range=(r.start_byte, r.end_byte),
+                line_range=(r.start_line, r.end_line),
+                concluded_license=spdx_file.concluded_license,
+                copyright_text=spdx_file.copyright_text,
+            )
+            sbom_graph.snippets.append(snippet)
+
+    _logger.info(
+        "Extracted %d snippet(s) from %d source file(s)",
+        len(sbom_graph.snippets),
+        len(ranges_by_file),
+    )

--- a/scripts/pylib/zspdx/serializers/helpers.py
+++ b/scripts/pylib/zspdx/serializers/helpers.py
@@ -20,7 +20,12 @@ def generate_download_url(url: str, revision: str) -> str:
     """Generate download URL with revision if available."""
     if not revision:
         return url
-    return f'git+{url}@{revision}'
+    # Strip git-describe suffixes (-dirty, -off, …) so the ref is a valid git
+    # object name. packageVersion retains the original string for dirty tracking.
+    import re
+    clean = re.sub(r'[+\-](dirty|off).*$', '', revision).strip()
+    ref = clean if re.match(r'^[a-f0-9]{40}$', clean) else revision
+    return f'git+{url}@{ref}'
 
 
 def get_standard_licenses() -> set:

--- a/scripts/pylib/zspdx/serializers/spdx2/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx2/serializer.py
@@ -14,6 +14,7 @@ from zspdx.model import (
     SBOMDocument,
     SBOMElement,
     SBOMFile,
+    SBOMSnippet,
 )
 from zspdx.serializers.helpers import (
     generate_download_url,
@@ -67,6 +68,10 @@ class SPDX2Serializer:
             if not self._write_document_second_pass(doc, output_path):
                 _logger.error(f"Failed to rewrite document {doc.name} with external references")
                 return False
+
+        # Optional: write snippets add-on document
+        if self.sbom_graph.snippets:
+            self._write_snippets_document(output_dir)
 
         return True
 
@@ -442,3 +447,151 @@ LicenseComment: Corresponds to the license ID `{lic}` detected in an SPDX-Licens
         sha1 = hashlib.sha1(usedforsecurity=False)
         sha1.update(file_list.encode('utf-8'))
         return sha1.hexdigest()
+
+    # ---- Snippet add-on document -------------------------------------------
+
+    def _write_snippets_document(self, output_dir: str) -> None:
+        """Write a standalone ``snippets.spdx`` add-on document.
+
+        Contains one SPDX 2.x ``Snippet`` block per entry in
+        ``sbom_graph.snippets``.  Each snippet references its parent file via a
+        cross-document ``DocumentRef-<name>:SPDXRef-File-<id>`` identifier.
+        """
+        snippets = self.sbom_graph.snippets
+        if not snippets:
+            return
+
+        # Determine which source documents are actually referenced and ensure
+        # their hashes are available (they were computed in the first pass).
+        used_docs: dict[str, SBOMDocument] = {}
+        for snippet in snippets:
+            doc = self.sbom_graph.get_document_for_file(snippet.spdx_file)
+            if doc and doc.name in self.document_hashes:
+                used_docs[doc.name] = doc
+
+        # The image the snippets came from lives in its own (build) document; it
+        # must also be declared as an external reference so the provenance
+        # relationships below can point at it across documents.
+        binary_ref = self._snippet_binary_ref()
+        if binary_ref is not None:
+            binary_doc = self.sbom_graph.get_document_for_file(self.sbom_graph.snippet_binary)
+            if binary_doc and binary_doc.name in self.document_hashes:
+                used_docs[binary_doc.name] = binary_doc
+
+        output_path = os.path.join(output_dir, "snippets.spdx")
+        created = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        namespace = f"{self.sbom_graph.namespace_prefix}/snippets"
+
+        try:
+            with open(output_path, "w", encoding="utf-8") as f:
+                f.write(f"""SPDXVersion: SPDX-{self.spdx_version}
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: Zephyr-Source-Snippets
+DocumentNamespace: {namespace}
+Creator: Tool: Zephyr SPDX builder
+Created: {created}
+
+""")
+                # ExternalDocumentRef for every referenced source document
+                for doc_name, doc in sorted(used_docs.items()):
+                    doc_hash = self.document_hashes[doc_name]
+                    doc_ns = doc.namespace or (
+                        f"{self.sbom_graph.namespace_prefix}/{doc_name}"
+                    )
+                    doc_ref = self.document_refs.get(doc_name, f"DocumentRef-{doc_name}")
+                    f.write(
+                        f"ExternalDocumentRef: {doc_ref} {doc_ns} SHA1: {doc_hash}\n"
+                    )
+                if used_docs:
+                    f.write("\n")
+
+                count = 0
+                written_indices = []
+                for index, snippet in enumerate(snippets):
+                    if self._write_snippet(f, snippet, index):
+                        written_indices.append(index)
+                        count += 1
+
+                self._write_snippet_provenance(f, binary_ref, written_indices)
+
+        except OSError:
+            _logger.exception("Error: unable to write snippets document to %s", output_path)
+            return
+
+        _logger.info("Written %d snippet(s) to %s", count, output_path)
+
+    def _snippet_binary_ref(self) -> str | None:
+        """Cross-document SPDX id of the image the snippets were extracted from.
+
+        Returns ``DocumentRef-<build>:SPDXRef-File-<elf>`` (or a bare id when the
+        image lives in the current document), or ``None`` when the graph tracks no
+        such binary or it has no assigned id.
+        """
+        binary = self.sbom_graph.snippet_binary
+        if binary is None:
+            return None
+        binary_id = self.file_ids.get(binary.path)
+        if not binary_id:
+            return None
+        doc = self.sbom_graph.get_document_for_file(binary)
+        if doc and doc.name in self.document_hashes:
+            doc_ref = self.document_refs.get(doc.name, f"DocumentRef-{doc.name}")
+            return f"{doc_ref}:{binary_id}"
+        return binary_id
+
+    def _write_snippet_provenance(self, f, binary_ref: str | None, indices: list) -> None:
+        """Emit ``<image> GENERATED_FROM <snippet>`` for each written snippet.
+
+        This is the source-to-binary provenance the base SBOM lacks: the ELF is
+        otherwise only ``STATIC_LINK``-ed to archives, so the exact source ranges
+        that ended up in it are recorded here, mirroring the file-level
+        ``GENERATED_FROM`` edges the ELF already carries for directly linked
+        sources.
+        """
+        if binary_ref is None or not indices:
+            return
+        f.write("\n")
+        for index in indices:
+            f.write(f"Relationship: {binary_ref} GENERATED_FROM SPDXRef-Snippet-{index}\n")
+
+    def _write_snippet(self, f, snippet: SBOMSnippet, index: int) -> bool:
+        """Write a single SPDX 2.x Snippet block.  Returns True on success."""
+        file_obj = snippet.spdx_file
+        file_spdx_id = self.file_ids.get(file_obj.path)
+        if not file_spdx_id:
+            _logger.warning(
+                "Snippet references unresolved file %s; skipping", file_obj.path
+            )
+            return False
+
+        doc = self.sbom_graph.get_document_for_file(file_obj)
+        if doc and doc.name in self.document_hashes:
+            doc_ref = self.document_refs.get(doc.name, f"DocumentRef-{doc.name}")
+            from_file_ref = f"{doc_ref}:{file_spdx_id}"
+        else:
+            from_file_ref = file_spdx_id
+
+        snippet_id = f"SPDXRef-Snippet-{index}"
+        rel_path = file_obj.relative_path or os.path.basename(file_obj.path)
+
+        f.write(f"SnippetSPDXID: {snippet_id}\n")
+        f.write(f"SnippetFromFileSPDXID: {from_file_ref}\n")
+        f.write(
+            f"SnippetByteRange: {snippet.byte_range[0]}:{snippet.byte_range[1]}\n"
+        )
+        if snippet.line_range:
+            f.write(
+                f"SnippetLineRange: {snippet.line_range[0]}:{snippet.line_range[1]}\n"
+            )
+        f.write(f"SnippetLicenseConcluded: {snippet.concluded_license}\n")
+        f.write(f"LicenseInfoInSnippet: {snippet.concluded_license}\n")
+        f.write(f"SnippetCopyrightText: {snippet.copyright_text}\n")
+        if snippet.line_range:
+            f.write(
+                f"SnippetName: {rel_path}:{snippet.line_range[0]}-{snippet.line_range[1]}\n"
+            )
+        else:
+            f.write(f"SnippetName: {rel_path}@{snippet.byte_range[0]}\n")
+        f.write("\n")
+        return True

--- a/scripts/pylib/zspdx/serializers/spdx2/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx2/serializer.py
@@ -513,6 +513,7 @@ Created: {created}
                         written_indices.append(index)
                         count += 1
 
+                self._write_snippets_describes(f, binary_ref, written_indices)
                 self._write_snippet_provenance(f, binary_ref, written_indices)
 
         except OSError:
@@ -520,6 +521,23 @@ Created: {created}
             return
 
         _logger.info("Written %d snippet(s) to %s", count, output_path)
+
+    def _write_snippets_describes(self, f, binary_ref: str | None, indices: list) -> None:
+        """Emit the ``SPDXRef-DOCUMENT DESCRIBES ...`` relationship SPDX requires.
+
+        A document without exactly one package must state what it describes.
+        This one holds no package, so it describes the image the snippets were
+        read from, or the snippets themselves when that image is not tracked.
+        """
+        if binary_ref:
+            f.write(f"Relationship: SPDXRef-DOCUMENT DESCRIBES {binary_ref}\n")
+        else:
+            for index in indices:
+                f.write(
+                    f"Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Snippet-{index}\n"
+                )
+        if indices:
+            f.write("\n")
 
     def _snippet_binary_ref(self) -> str | None:
         """Cross-document SPDX id of the image the snippets were extracted from.

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -19,6 +19,7 @@ from zspdx.model import (
     SBOMFile,
     SBOMGraph,
     SBOMRelationship,
+    SBOMSnippet,
 )
 from zspdx.serializers.helpers import (
     CPE23TYPE_REGEX,
@@ -1117,6 +1118,9 @@ class SPDX3Serializer:
             self._create_documents()
             self._write_documents(output_dir)
 
+            if self.sbom_data.snippets:
+                self._write_snippets_document(output_dir)
+
             _logger.info(f"SPDX 3.0 documents written to {output_dir}")
             return True
 
@@ -1240,6 +1244,138 @@ class SPDX3Serializer:
         for sbom_doc in self.sbom_data.documents.values():
             if sbom_doc.components:
                 self._create_document(sbom_doc)
+
+    # ---- Snippet add-on document -------------------------------------------
+
+    def _generate_snippet_id(self, index: int) -> str:
+        """Generate URI-based ID for a snippet element."""
+        namespace = self.sbom_data.namespace_prefix.rstrip("/")
+        return self._shorten_id(f"{namespace}/snippets/{index}")
+
+    def _create_software_snippet(
+        self, snippet: SBOMSnippet, index: int
+    ) -> spdx.software_Snippet | None:
+        """Convert an :class:`SBOMSnippet` to a SPDX 3.0 ``software_Snippet`` element."""
+        parent_file = self.file_elements.get(snippet.spdx_file.path)
+        if parent_file is None:
+            _logger.warning(
+                "Snippet references unresolved file %s; skipping", snippet.spdx_file.path
+            )
+            return None
+
+        snip = spdx.software_Snippet()
+        snip._id = self._generate_snippet_id(index)
+        snip.creationInfo = self.creation_info._id
+
+        rel_path = snippet.spdx_file.relative_path or os.path.basename(snippet.spdx_file.path)
+        if snippet.line_range:
+            snip.name = (
+                f"{rel_path}:{snippet.line_range[0]}-{snippet.line_range[1]}"
+            )
+        else:
+            snip.name = f"{rel_path}@{snippet.byte_range[0]}-{snippet.byte_range[1]}"
+
+        snip.software_snippetFromFile = parent_file._id
+        snip.software_copyrightText = snippet.copyright_text or NOASSERTION
+
+        byte_range = spdx.PositiveIntegerRange()
+        byte_range.beginIntegerRange = snippet.byte_range[0]
+        byte_range.endIntegerRange = snippet.byte_range[1]
+        snip.software_byteRange = byte_range
+
+        if snippet.line_range:
+            line_range = spdx.PositiveIntegerRange()
+            line_range.beginIntegerRange = snippet.line_range[0]
+            line_range.endIntegerRange = snippet.line_range[1]
+            snip.software_lineRange = line_range
+
+        return snip
+
+    def _create_snippet_build_input(
+        self, namespace: str, snippet_elements: list
+    ) -> spdx.LifecycleScopedRelationship | None:
+        """Relate the build to the snippets it consumed as inputs.
+
+        Returns a single ``hasInput`` relationship from the overall
+        ``build_Build`` (which already ``hasOutput`` the image) to every snippet,
+        or ``None`` when no Build element was produced. The ``from`` references the
+        build element in the base build document; consumers load both documents.
+        """
+        if self.build is None or not snippet_elements:
+            return None
+
+        rel = spdx.LifecycleScopedRelationship()
+        rel._id = self._shorten_id(f"{namespace}/snippets/relationships/build-input")
+        rel.relationshipType = spdx.RelationshipType.hasInput
+        rel.from_ = self.build._id
+        rel.to = [snip._id for snip in snippet_elements]
+        rel.scope = spdx.LifecycleScopeType.build
+        rel.creationInfo = self.creation_info._id
+        return rel
+
+    def _write_snippets_document(self, output_dir: str) -> None:
+        """Write a standalone ``snippets.jsonld`` add-on document.
+
+        The document contains one ``software_Snippet`` per entry in
+        ``sbom_graph.snippets``.  Each snippet references its parent
+        ``software_File`` element (already serialized in the base documents)
+        via ``software_snippetFromFile``.
+        """
+        namespace = self.sbom_data.namespace_prefix.rstrip("/")
+
+        doc = spdx.SpdxDocument()
+        doc._id = self._shorten_id(f"{namespace}/documents/snippets")
+        for uri, prefix in self.namespace_prefixes.items():
+            ns_map = spdx.NamespaceMap()
+            ns_map.prefix = prefix
+            ns_map.namespace = uri
+            doc.namespaceMap.append(ns_map)
+        doc.name = "Zephyr Source Snippets"
+        doc.creationInfo = self.creation_info
+        data_license = self._create_license_expression("CC0-1.0")
+        if data_license:
+            doc.dataLicense = data_license._id
+
+        doc.profileConformance.append(spdx.ProfileIdentifierType.core)
+        doc.profileConformance.append(spdx.ProfileIdentifierType.software)
+        doc.profileConformance.append(spdx.ProfileIdentifierType.simpleLicensing)
+
+        snippet_elements = []
+        for index, sbom_snippet in enumerate(self.sbom_data.snippets):
+            snip = self._create_software_snippet(sbom_snippet, index)
+            if snip is not None:
+                snippet_elements.append(snip)
+                doc.element.append(snip)
+                doc.rootElement.append(snip)
+
+        if not snippet_elements:
+            _logger.warning("No valid snippets to serialize; skipping snippets.jsonld")
+            return
+
+        # Source-to-binary provenance: the extracted ranges are the exact source
+        # lines that ended up in the image the Build ``hasOutput``. Record them as
+        # a build ``hasInput``, at the same (file) granularity the Build profile
+        # already uses for compiled sources, refining it down to used line ranges.
+        build_input_rel = self._create_snippet_build_input(namespace, snippet_elements)
+
+        object_set = spdx.SHACLObjectSet()
+        object_set.add(doc)
+        if self.creation_info:
+            object_set.add(self.creation_info)
+        if self.tool:
+            object_set.add(self.tool)
+        if self.creator_agent:
+            object_set.add(self.creator_agent)
+        for snip in snippet_elements:
+            object_set.add(snip)
+        if build_input_rel is not None:
+            doc.element.append(build_input_rel)
+            object_set.add(build_input_rel)
+
+        output_path = os.path.join(output_dir, "snippets.jsonld")
+        with open(output_path, "wb") as f:
+            spdx.JSONLDSerializer().write(object_set, f, force_at_graph=True, indent=2)
+        _logger.info("Written %d snippet(s) to %s", len(snippet_elements), output_path)
 
     def _write_documents(self, output_dir: str):
         """Write each created document to its own JSON-LD file."""

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -24,7 +24,13 @@ from build_helpers import (
     is_zephyr_build,
     load_domains,
 )
-from zcmake import DEFAULT_CMAKE_GENERATOR, CMakeCache, run_build, run_cmake
+from zcmake import (
+    DEFAULT_CMAKE_GENERATOR,
+    CMakeCache,
+    run_build,
+    run_cmake,
+    setup_cmake_file_api_query,
+)
 from zephyr_ext_common import Forceable
 
 _ARG_SEPARATOR = '--'
@@ -731,6 +737,18 @@ class Build(Forceable):
             final_cmake_args.extend([f'-DWEST_PYTHON_PROPERTIES="{cmake_list}"'])
         if cmake_opts:
             final_cmake_args.extend(cmake_opts)
+
+        # Enable CMake's file-based API before invoking CMake so its object
+        # model (codemodel + toolchains reply) is emitted at generation time.
+        # Tooling such as "west spdx" consumes this, so producing it by default
+        # means no separate "west spdx --init" step is required. The query must
+        # exist before CMake runs and therefore cannot be created from within
+        # the CMake build system itself. Opt out with:
+        #     west config build.cmake-file-api false
+        if self.config.getboolean('build.cmake-file-api', default=True):
+            setup_cmake_file_api_query(self.build_dir,
+                                       dry_run=self.args.dry_run)
+
         run_cmake(final_cmake_args, dry_run=self.args.dry_run, env=cmake_env)
 
     def _run_pristine(self):

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -25,9 +25,15 @@ SPDX_DESCRIPTION = """\
 This command creates an SPDX bill of materials following the completion
 of a Zephyr build.
 
-Enable CONFIG_BUILD_OUTPUT_META in the application and build it as usual.
-The build then asks CMake for the file-based API this command reads, so the
-build directory needs no preparation."""
+The SPDX command relies on the CMake file-based API. `west build` enables it
+automatically, so in the common case no preparation is required: just build,
+then run `west spdx`.
+
+If you configure CMake without `west build` -- or you disabled the file-based
+API with `west config build.cmake-file-api false` -- either enable
+CONFIG_BUILD_OUTPUT_META in the application, which makes the build request the
+API itself, or seed the query manually before configuring the build with
+`west spdx --init -d BUILDDIR`."""
 
 
 class ZephyrSpdx(WestCommand):

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -61,6 +61,24 @@ class ZephyrSpdx(WestCommand):
         parser.add_argument(
             '--include-sdk', action="store_true", help="also generate SPDX document for SDK"
         )
+        parser.add_argument(
+            '--analyze-elf',
+            metavar='ANALYSIS',
+            action='append',
+            choices=['snippets'],
+            help=(
+                "analyze the final image's DWARF debug info (requires a build "
+                "with debug symbols). "
+                "'snippets': emit the used source line-ranges as an SPDX Snippets "
+                "add-on document."
+            ),
+        )
+        parser.add_argument(
+            '--elf-file',
+            metavar='ELF',
+            help="ELF file to analyze for --analyze-elf (default: "
+            "<build-dir>/zephyr/zephyr.elf)",
+        )
 
         return parser
 
@@ -79,6 +97,8 @@ class ZephyrSpdx(WestCommand):
         self.dbg("  --spdx-version is", args.spdx_version)
         self.dbg("  --analyze-includes is", args.analyze_includes)
         self.dbg("  --include-sdk is", args.include_sdk)
+        self.dbg("  --analyze-elf is", args.analyze_elf)
+        self.dbg("  --elf-file is", args.elf_file)
 
         if args.init:
             self.do_run_init(args)
@@ -136,6 +156,12 @@ class ZephyrSpdx(WestCommand):
             cfg.analyze_includes = True
         if args.include_sdk:
             cfg.include_sdk = True
+        analyses = set(args.analyze_elf or [])
+        cfg.generate_snippets = 'snippets' in analyses
+        if args.elf_file:
+            if not analyses:
+                self.wrn("--elf-file has no effect without --analyze-elf; ignoring")
+            cfg.elf_file = args.elf_file
 
         # make sure SPDX directory exists, or create it if it doesn't
         if os.path.exists(cfg.spdx_dir):

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -65,12 +65,14 @@ class ZephyrSpdx(WestCommand):
             '--analyze-elf',
             metavar='ANALYSIS',
             action='append',
-            choices=['snippets'],
+            choices=['snippets', 'prune-sources'],
             help=(
                 "analyze the final image's DWARF debug info (requires a build "
-                "with debug symbols). "
+                "with debug symbols). May be given more than once. "
                 "'snippets': emit the used source line-ranges as an SPDX Snippets "
-                "add-on document."
+                "add-on document. "
+                "'prune-sources': drop source files that contributed no code to "
+                "the final image."
             ),
         )
         parser.add_argument(
@@ -158,6 +160,7 @@ class ZephyrSpdx(WestCommand):
             cfg.include_sdk = True
         analyses = set(args.analyze_elf or [])
         cfg.generate_snippets = 'snippets' in analyses
+        cfg.prune_sources = 'prune-sources' in analyses
         if args.elf_file:
             if not analyses:
                 self.wrn("--elf-file has no effect without --analyze-elf; ignoring")

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -174,6 +174,7 @@ def test_cmake_args(monkeypatch, test_case):
 
     monkeypatch.setattr('build.run_cmake', run_cmake_mock)
     monkeypatch.setattr('build.west_topdir', lambda start=None, fall_back=True: '/west/topdir')
+    monkeypatch.setattr('build.setup_cmake_file_api_query', lambda *a, **kw: True)
     monkeypatch.setattr(b, '_banner', lambda _: True)
 
     # --- Trigger CMake run ---
@@ -224,6 +225,7 @@ def test_test_item_updates_source_dir(tmp_path, monkeypatch):
 
     monkeypatch.setattr('build.run_cmake', run_cmake_mock)
     monkeypatch.setattr('build.west_topdir', lambda start=None, fall_back=True: str(tmp_path))
+    monkeypatch.setattr('build.setup_cmake_file_api_query', lambda *a, **kw: True)
     monkeypatch.setattr(b, '_banner', lambda _: True)
     b.run_cmake = True
     b.build_dir = str(tmp_path / 'build')
@@ -373,3 +375,26 @@ def test_cwd_preferred_over_non_existent_dir_fmt(monkeypatch, build_instance, te
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd
+
+
+def test_cmake_file_api_query(tmp_path):
+    """Test: setup_cmake_file_api_query seeds the CMake file-based API query."""
+    from zcmake import CMAKE_FILE_API_OBJECTS, setup_cmake_file_api_query
+
+    build_dir = tmp_path / 'build'
+    query_dir = build_dir / '.cmake' / 'api' / 'v1' / 'query'
+
+    # A dry run reports success without touching the filesystem.
+    assert setup_cmake_file_api_query(str(build_dir), dry_run=True) is True
+    assert not query_dir.exists()
+
+    # A real run creates an empty query file for each requested object.
+    assert setup_cmake_file_api_query(str(build_dir)) is True
+    assert CMAKE_FILE_API_OBJECTS  # sanity: at least one object requested
+    for query_object in CMAKE_FILE_API_OBJECTS:
+        query_file = query_dir / query_object
+        assert query_file.is_file()
+        assert query_file.read_bytes() == b''
+
+    # Running it again is idempotent.
+    assert setup_cmake_file_api_query(str(build_dir)) is True

--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -28,6 +28,42 @@ DEFAULT_CACHE = 'CMakeCache.txt'
 DEFAULT_CMAKE_GENERATOR = 'Ninja'
 '''Name of the default CMake generator.'''
 
+# CMake file-based API objects requested by default. Keep this in sync with
+# zspdx.sbom.setup_cmake_query, which seeds the same query for "west spdx".
+CMAKE_FILE_API_OBJECTS = ('codemodel-v2', 'toolchains-v1')
+
+
+def setup_cmake_file_api_query(build_dir, dry_run=False):
+    '''Enable CMake's file-based API for a build directory.
+
+    Creates the query files that make CMake emit its "object model" (the
+    codemodel and toolchains reply files) at generation time. This must happen
+    before CMake is invoked, because CMake reads the query directory only at
+    start-up; a query written while CMake is configuring only takes effect on
+    the *next* run. Downstream tooling such as ``west spdx`` consumes the reply.
+
+    :param build_dir: build directory that is about to be configured
+    :param dry_run: if True, don't touch the filesystem
+
+    Returns True if the query is in place (or would be, for a dry run).'''
+    if dry_run:
+        return True
+
+    query_dir = os.path.join(build_dir, '.cmake', 'api', 'v1', 'query')
+    try:
+        os.makedirs(query_dir, exist_ok=True)
+        for query_object in CMAKE_FILE_API_OBJECTS:
+            query_file = os.path.join(query_dir, query_object)
+            if not os.path.exists(query_file):
+                # An empty file is a valid "shared, stateless" query.
+                with open(query_file, 'w'):
+                    pass
+    except OSError as e:
+        _logger.warning('could not enable CMake file-based API in %s: %s',
+                        build_dir, e)
+        return False
+    return True
+
 
 def run_cmake(args, cwd=None, capture_output=False, dry_run=False, env=None):
     '''Run cmake to (re)generate a build system, a script, etc.

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -511,18 +511,24 @@ def _create_meta_project(project_path):
 
         remote_url = None
 
-        # If more than one remote, do not return any remote
+        # Prefer 'origin' when multiple remotes exist; fall back to the sole
+        # remote when there is only one.
         if len(remotes_name) == 1:
             remote = remotes_name[0]
-            popen = subprocess.Popen(['git', 'remote', 'get-url', remote],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE,
-                                     cwd=path)
-            stdout, stderr = popen.communicate()
-            stdout = stdout.decode('utf-8')
+        elif 'origin' in remotes_name:
+            remote = 'origin'
+        else:
+            return None
 
-            if not (popen.returncode or stderr):
-                remote_url = stdout.rstrip()
+        popen = subprocess.Popen(['git', 'remote', 'get-url', remote],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 cwd=path)
+        stdout, stderr = popen.communicate()
+        stdout = stdout.decode('utf-8')
+
+        if not (popen.returncode or stderr):
+            remote_url = stdout.rstrip()
 
         return remote_url
 


### PR DESCRIPTION
`zephyr-sources` and `zephyr-deps` only got a CPE when a tag matching exactly `vX.Y.Z` pointed at the built revision, so on `main`, a release branch, a topic branch or a release candidate the SBOM said nothing about which version of Zephyr was built.

The version now falls back to the repository's own `VERSION` file, with `EXTRAVERSION` mapped onto the CPE *update* field as NVD spells pre-releases:

```
v4.4.0-rc3  ->  cpe:2.3:o:zephyrproject:zephyr:4.4.0:rc3:*:*:*:*:*:*
main        ->  cpe:2.3:o:zephyrproject:zephyr:4.4.99:-:*:*:*:*:*:*
```

The upstream purl is also emitted when the git remote cannot be determined, where both packages previously carried no package URL either.

The first commit is submitted as a separate fix in #117666
