### PR TITLE
drivers/i2c: ite: Add error callback support in I2C target mode

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1177,18 +1177,26 @@ static void target_i2c_isr_pio(const struct device *dev, uint8_t interrupt_statu
 IT8XXX2_I2C_CODE_IN_RAM
 static void target_i2c_isr(const struct device *dev)
 {
+	struct i2c_enhance_data *data = dev->data;
 	const struct i2c_enhance_config *config = dev->config;
 	uint8_t *base = config->base;
 	uint8_t target_status = IT8XXX2_I2C_STR(base);
 
 	/* Any error */
 	if (target_status & E_TARGET_ANY_ERROR) {
+		const struct i2c_target_callbacks *target_cb = data->target_cfg->callbacks;
+
 		/* Hardware reset */
 		IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 		/* NACK */
 		IT8XXX2_I2C_CTR(base) &= ~IT8XXX2_I2C_ACK;
 		IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_ACK;
 
+		if (target_cb->error) {
+			target_cb->error(data->target_cfg, (target_status & E_TARGET_TMOE)
+								   ? I2C_ERROR_TIMEOUT
+								   : I2C_ERROR_ARBITRATION);
+		}
 		return;
 	}
 

--- a/drivers/i2c/i2c_ite_it51xxx.c
+++ b/drivers/i2c/i2c_ite_it51xxx.c
@@ -497,6 +497,11 @@ static void target_i2c_isr_fifo(const struct device *dev)
 	/* bit0-4 : FIFO byte count */
 	count = fifo_status & GENMASK(4, 0);
 
+	/* Which target address to match. */
+	target_idx = (target_status & SMB_MSLA2) ? SMB_SADR2 : SMB_SADR;
+	target_cfg = data->target_cfg[target_idx];
+	target_cb = target_cfg->callbacks;
+
 	/* Timeout status occurs */
 	if (target_status & SMB_STS) {
 		LOG_ERR("I2CS ch%d timeout occurs", config->port);
@@ -504,13 +509,12 @@ static void target_i2c_isr_fifo(const struct device *dev)
 		data->w_index = 0;
 		data->r_index = 0;
 		target_i2c_reset_fifo(dev);
+
+		if (target_cb->error) {
+			target_cb->error(target_cfg, I2C_ERROR_TIMEOUT);
+		}
 		goto done;
 	}
-
-	/* Which target address to match. */
-	target_idx = (target_status & SMB_MSLA2) ? SMB_SADR2 : SMB_SADR;
-	target_cfg = data->target_cfg[target_idx];
-	target_cb = target_cfg->callbacks;
 
 	/* Target data status, the register is waiting for read or write. */
 	if (target_status & SMB_SDS) {
@@ -589,18 +593,21 @@ static void target_i2c_isr_pio(const struct device *dev)
 	/* Write to clear a target status */
 	clear_target_status(dev, target_status);
 
+	/* Which target address to match. */
+	target_idx = (target_status & SMB_MSLA2) ? SMB_SADR2 : SMB_SADR;
+	target_cfg = data->target_cfg[target_idx];
+	target_cb = target_cfg->callbacks;
+
 	/* Any error */
 	if (target_status & SMB_STS) {
 		data->w_index = 0;
 		data->r_index = 0;
 
+		if (target_cb->error) {
+			target_cb->error(target_cfg, I2C_ERROR_TIMEOUT);
+		}
 		return;
 	}
-
-	/* Which target address to match. */
-	target_idx = (target_status & SMB_MSLA2) ? SMB_SADR2 : SMB_SADR;
-	target_cfg = data->target_cfg[target_idx];
-	target_cb = target_cfg->callbacks;
 
 	/* Stop condition, indicate stop condition detected. */
 	if (target_status & SMB_SPDS) {


### PR DESCRIPTION
Implement the target error callback in the driver to support the new common I2C target API error callback.

Report timeout(it8xxx2 and it51xxx) and arbitration(it8xxx2) errors through the target error callback based on the target status.