### PR TITLE
manifest: Update libmetal w CMAKE_SYSTEM_PROCESSOR condition change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       revision: b6be45dfc5c67c43c3a5e12589ae3845ea00ab5e
       path: modules/lib/libmctp
     - name: libmetal
-      revision: c41f476ba425663cadf7e456b6432e4b21591278
+      revision: 77237e9748212796a8f93a33689ce935fb9c81c2
       path: modules/hal/libmetal
       groups:
         - hal


### PR DESCRIPTION
Instead of looking at the current value of CMAKE_SYSTEM_PROCESSOR (which may not be set to "posix" anymore),
let's look at the architecture kconfig option, which should be stable.

Integration/test PR for:
* https://github.com/zephyrproject-rtos/libmetal/pull/33