### PR TITLE
samples: boards: nxp: tflm_neutron: update filter condition

### DIFF
--- a/samples/boards/nxp/tflm_neutron/tests.yaml
+++ b/samples/boards/nxp/tflm_neutron/tests.yaml
@@ -10,7 +10,9 @@ tests:
     build_only: true
     # The Neutron NPU driver and firmware are binary blobs, which CI does
     # not fetch. Skip the sample rather than fail the build without them.
-    filter: CONFIG_ZEPHYR_HAL_NXP_MODULE_BLOBS
+    filter: CONFIG_TAINT_BLOBS
+    vendor_allow:
+      - nxp
     platform_allow:
       - mimxrt700_evk/mimxrt798s/cm33_cpu0
       - mcx_n9xx_evk/mcxn947/cpu0


### PR DESCRIPTION
`CONFIG_TAINT_BLOBS` is set only when blobs are present, it is defined in the static Kconfig tree, whereas the module-generated `ZEPHYR_HAL_NXP_MODULE_BLOBS` symbol is undefined when hal_nxp is absent and made check_compliance fail.

fix https://github.com/zephyrproject-rtos/zephyr/issues/117243