### PR TITLE
MAINTAINERS: add Aman Lachhiramka as hal_ti collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -7215,6 +7215,8 @@ West:
     - vaishnavachath
     - ssekar15
     - d-philpot
+  collaborators:
+    - Aman-Lachhiramka-ti
   files: []
   labels:
     - "platform: TI"


### PR DESCRIPTION
Add myself as collaborator for the hal_ti west module.

I have been actively contributing to the TI MSPM0 HAL (pinctrl DTSI files, driverlib updates) and am actively working on upstream Zephyr drivers for the MSPM0 platform.