### PR TITLE
tests: ram_context_for_isr: exclude imx952_evk m7/ddr variant

### DIFF
--- a/tests/application_development/ram_context_for_isr/tests.yaml
+++ b/tests/application_development/ram_context_for_isr/tests.yaml
@@ -17,6 +17,7 @@ tests:
       - imx95_evk/mimx9596/m7/flash
       - imx95_evk_15x15/mimx9596/m7
       - imx952_evk/mimx9529/m7
+      - imx952_evk/mimx9529/m7/ddr
       - imx943_evk/mimx94398/m33
       - imx943_evk/mimx94398/m33/ddr
       - frdm_mcxc444/mcxc444


### PR DESCRIPTION
The imx952_evk/mimx9529/m7/ddr board variant fails to build this test in gen_isr_tables.py with:

  error: multiple registrations at table_index 233 for irq 233

The base imx952_evk/mimx9529/m7 platform was already excluded, but the /ddr variant was not, so it was still being built and hit the duplicate IRQ registration failure.
Exclude the /ddr variant as well, consistent with how the imx95_evk board excludes its /ddr and /flash variants.