### PR TITLE
boards: ti: lp_mspm0l2228: fix pinctrl pad names to point updated HAL_ti

### DIFF
--- a/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
+++ b/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
@@ -93,7 +93,7 @@
 
 &spi0 {
 	status = "okay";
-	pinctrl-0 = <&spi0_sclk_pb03 &spi0_pico_pb02 &spi0_poci_pa07>;
+	pinctrl-0 = <&spi0_sclk_pb3 &spi0_pico_pb2 &spi0_poci_pa7>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
 	#address-cells = <1>;
@@ -103,7 +103,7 @@
 
 &spi1 {
 	status = "okay";
-	pinctrl-0 = <&spi1_sclk_pa17 &spi1_pico_pb08 &spi1_poci_pb07>;
+	pinctrl-0 = <&spi1_sclk_pa17 &spi1_pico_pb8 &spi1_poci_pb7>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiob 6 GPIO_ACTIVE_LOW>;
 	#address-cells = <1>;

--- a/west.yml
+++ b/west.yml
@@ -274,7 +274,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 2e6514333cdb59e44a7635fb5852035c325f4c11
+      revision: 53c80140dd69905cc5e034f637eff9c66b2f9654
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
`lp_mspm0l2228.dts` referenced SPI pinctrl nodes with zero-padded single-digit pad suffixes (`pb03`, `pb02`, `pa07`, `pb08`, `pb07`). These matched a bug in `mspm0l222x-pinctrl.dtsi` (hal_ti) where all single-digit pads were incorrectly zero-padded.

hal_ti PR https://github.com/zephyrproject-rtos/hal_ti/pull/96  fixes the naming convention in the DTSI. 
This PR updates the board to match and bumps the manifest.