### PR TITLE
net: shell: fix -Wuninitialized-const-pointer warnings

### DIFF
--- a/subsys/net/lib/shell/route.c
+++ b/subsys/net/lib/shell/route.c
@@ -355,7 +355,7 @@ static int cmd_net_route_add(const struct shell *sh, size_t argc, char *argv[])
 	struct net_if *iface = NULL;
 	int idx;
 	struct net_route_entry *route;
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = { 0 };
 	const char *str;
 	uint8_t mask_len;
 
@@ -590,7 +590,7 @@ static int cmd_net_route_del(const struct shell *sh, size_t argc, char *argv[])
 	struct net_if *iface = NULL;
 	int idx;
 	struct net_route_entry *route = NULL;
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = { 0 };
 	const char *str;
 	uint8_t mask_len;
 

--- a/subsys/net/lib/shell/tcp.c
+++ b/subsys/net/lib/shell/tcp.c
@@ -102,8 +102,8 @@ static void tcp_connect(const struct shell *sh, char *host, uint16_t port,
 			struct net_context **ctx)
 {
 	struct net_if *iface = net_if_get_default();
-	struct net_sockaddr_storage myaddr;
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage myaddr = { 0 };
+	struct net_sockaddr_storage addr = { 0 };
 	struct net_sockaddr *my_sa = net_sad(&myaddr);
 	struct net_sockaddr *sa = net_sad(&addr);
 	struct net_nbr *nbr;


### PR DESCRIPTION
Fix `-Wuninitialized-const-pointer` warnings in shell route and tcp commands, that are generated, if a unitialized variable of type struct net_sockaddr_storage is passed to net_sad() function.

```
/home/user/west_workspace/zephyr/subsys/net/lib/shell/route.c:379:65: warning: variable 'addr' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
  379 |         str = net_ipaddr_parse_mask(argv[2], strlen(argv[2]), net_sad(&addr), &mask_len);
      |                                                                        ^~~~
/home/user/west_workspace/zephyr/subsys/net/lib/shell/route.c:613:65: warning: variable 'addr' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
  613 |         str = net_ipaddr_parse_mask(argv[2], strlen(argv[2]), net_sad(&addr), &mask_len);
      |                                                                        ^~~~
/home/user/west_workspace/zephyr/subsys/net/lib/shell/tcp.c:107:40: warning: variable 'myaddr' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
  107 |         struct net_sockaddr *my_sa = net_sad(&myaddr);
      |                                               ^~~~~~
/home/user/west_workspace/zephyr/subsys/net/lib/shell/tcp.c:108:37: warning: variable 'addr' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
  108 |         struct net_sockaddr *sa = net_sad(&addr);
      |
```

Reported by Clang 22