### PR TITLE
usb: device_next: bound the CDC NCM/ECM TX completion wait

### DIFF
--- a/subsys/usb/device_next/class/Kconfig.cdc_ecm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_ecm
@@ -12,6 +12,19 @@ config USBD_CDC_ECM_CLASS
 
 if USBD_CDC_ECM_CLASS
 
+config USBD_CDC_ECM_TX_TIMEOUT
+	int "TX transfer timeout (milliseconds)"
+	default 100
+	help
+	  Maximum time cdc_ecm_send() waits for the previous IN transfer to
+	  complete before it drops the packet. A transfer completes only when
+	  the host issues an IN token, which it does not while the host side
+	  of the interface is down, even though the device is enumerated.
+	  Unbounded, the send blocks forever and holds up every other flow
+	  queued on the same network TX thread. Raising CONFIG_NET_TC_TX_COUNT
+	  does not necessarily separate them, since the default priority
+	  mapping places several priorities on one traffic class.
+
 module = USBD_CDC_ECM
 module-str = usbd cdc_ecm
 default-count = 1

--- a/subsys/usb/device_next/class/Kconfig.cdc_ncm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_ncm
@@ -25,6 +25,19 @@ config USBD_CDC_NCM_SUPPORT_NTB32
 	  Enable support for NTB32 format which allows larger
 	  packet sizes.
 
+config USBD_CDC_NCM_TX_TIMEOUT
+	int "TX transfer timeout (milliseconds)"
+	default 100
+	help
+	  Maximum time cdc_ncm_send() waits for the previous IN transfer to
+	  complete before it drops the packet. A transfer completes only when
+	  the host issues an IN token, which it does not while the host side
+	  of the interface is down, even though the device is enumerated.
+	  Unbounded, the send blocks forever and holds up every other flow
+	  queued on the same network TX thread. Raising CONFIG_NET_TC_TX_COUNT
+	  does not necessarily separate them, since the default priority
+	  mapping places several priorities on one traffic class.
+
 module = USBD_CDC_NCM
 module-str = usbd cdc_ncm
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -301,6 +301,7 @@ static int usbd_cdc_ecm_request(struct usbd_class_data *const c_data,
 	}
 
 	if (bi->ep == cdc_ecm_get_bulk_in(c_data)) {
+		net_buf_unref(buf);
 		k_sem_give(&data->sync_sem);
 
 		return 0;
@@ -513,16 +514,23 @@ static int cdc_ecm_send(const struct device *dev, struct net_pkt *const pkt)
 		return -EACCES;
 	}
 
+	if (k_sem_take(&data->sync_sem, K_MSEC(CONFIG_USBD_CDC_ECM_TX_TIMEOUT)) != 0) {
+		LOG_DBG("Previous transfer still pending, drop");
+		return -ETIMEDOUT;
+	}
+
 	ep = cdc_ecm_get_bulk_in(c_data);
 	buf = cdc_ecm_buf_alloc(ep);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
+		k_sem_give(&data->sync_sem);
 		return -ENOMEM;
 	}
 
 	if (net_pkt_read(pkt, buf->data, len)) {
 		LOG_ERR("Failed copy net_pkt");
 		net_buf_unref(buf);
+		k_sem_give(&data->sync_sem);
 
 		return -ENOBUFS;
 	}
@@ -537,11 +545,9 @@ static int cdc_ecm_send(const struct device *dev, struct net_pkt *const pkt)
 	if (ret) {
 		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
+		k_sem_give(&data->sync_sem);
 		return ret;
 	}
-
-	k_sem_take(&data->sync_sem, K_FOREVER);
-	net_buf_unref(buf);
 
 	return 0;
 }
@@ -834,7 +840,7 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 	static struct cdc_ecm_eth_data eth_data_##n = {				\
 		.c_data = &cdc_ecm_##n,						\
 		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),		\
-		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 0, 1),	\
+		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 1, 1),	\
 		.mac_desc_data = &mac_desc_data_##n,				\
 		.desc = &cdc_ecm_desc_##n,					\
 		.fs_desc = cdc_ecm_fs_desc_##n,					\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -654,6 +654,7 @@ static int usbd_cdc_ncm_request(struct usbd_class_data *const c_data,
 	}
 
 	if (bi->ep == cdc_ncm_get_bulk_in(c_data)) {
+		net_buf_unref(buf);
 		k_sem_give(&data->sync_sem);
 		return 0;
 	}
@@ -1065,9 +1066,15 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 		return -EACCES;
 	}
 
+	if (k_sem_take(&data->sync_sem, K_MSEC(CONFIG_USBD_CDC_NCM_TX_TIMEOUT)) != 0) {
+		LOG_DBG("Previous transfer still pending, drop");
+		return -ETIMEDOUT;
+	}
+
 	buf = cdc_ncm_buf_alloc(cdc_ncm_get_bulk_in(c_data));
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
+		k_sem_give(&data->sync_sem);
 		return -ENOMEM;
 	}
 
@@ -1096,6 +1103,7 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 	if (net_pkt_read(pkt, buf->data + buf->len, len)) {
 		LOG_ERR("Failed copy net_pkt");
 		net_buf_unref(buf);
+		k_sem_give(&data->sync_sem);
 
 		return -ENOBUFS;
 	}
@@ -1111,12 +1119,9 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 		LOG_ERR("Failed to enqueue net_buf for 0x%02x",
 			cdc_ncm_get_bulk_in(c_data));
 		net_buf_unref(buf);
+		k_sem_give(&data->sync_sem);
 		return ret;
 	}
-
-	k_sem_take(&data->sync_sem, K_FOREVER);
-
-	net_buf_unref(buf);
 
 	return 0;
 }
@@ -1420,7 +1425,7 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 	static struct cdc_ncm_eth_data eth_data_##n = {				\
 		.c_data = &cdc_ncm_##n,						\
 		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),		\
-		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 0, 1),	\
+		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 1, 1),	\
 		.mac_desc_data = &mac_desc_data_##n,				\
 		.desc = &cdc_ncm_desc_##n,					\
 		.fs_desc = cdc_ncm_fs_desc_##n,					\


### PR DESCRIPTION
`cdc_ncm_send()` and `cdc_ecm_send()` waited on `sync_sem` with `K_FOREVER` for the bulk IN transfer to complete. That completes only when the host issues an IN token, and the guards before the wait are device-side only, so a host with the interface up but not polling blocks the caller forever. `ethernet_api::send` runs on a TX traffic class thread shared by every interface, so it takes unrelated interfaces down with it.

`sync_sem` becomes a TX slot token. It starts at 1, `send()` claims it with a bounded timeout before allocating and drops the packet if the previous transfer still holds it, and the bulk IN completion handler unrefs the buffer and gives the token back. Nothing is cancelled, so an armed transfer still completes and releases the slot when the host resumes polling. The token also goes back on the alloc and `net_pkt_read` failure paths, not just enqueue, so every path that claims the slot either hands it to the handler or returns it.

Assisted-by: Claude:claude-opus-4.8