### PR TITLE
drivers: clock_control: max32: Centralize 32 kHz clock configuration

### DIFF
--- a/boards/adi/max32650evkit/max32650evkit.dts
+++ b/boards/adi/max32650evkit/max32650evkit.dts
@@ -81,6 +81,10 @@
 	status = "okay";
 };
 
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/adi/max32650fthr/max32650fthr.dts
+++ b/boards/adi/max32650fthr/max32650fthr.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -70,6 +70,10 @@
 };
 
 &clk_ipo {
+	status = "okay";
+};
+
+&clk_ertco {
 	status = "okay";
 };
 

--- a/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
@@ -102,13 +102,8 @@
 	};
 };
 
-&wut0 {
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
-};
-
 &wut1 {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 	wakeup-source;
 
 	counter_wut1: counter {

--- a/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,8 +56,17 @@
 	status = "okay";
 };
 
+&clk_inro {
+	status = "okay";
+};
+
 &clk_ipo {
 	status = "okay";
+};
+
+&clk_32k {
+	status = "okay";
+	clocks = <&clk_inro>;
 };
 
 &gpio0 {
@@ -76,7 +85,6 @@
 
 &rtc_counter {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 };
 
 &i3c0 {

--- a/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
@@ -102,13 +102,8 @@
 	};
 };
 
-&wut0 {
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
-};
-
 &wut1 {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 	wakeup-source;
 
 	counter_wut1: counter {

--- a/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,8 +56,17 @@
 	status = "okay";
 };
 
+&clk_inro {
+	status = "okay";
+};
+
 &clk_ipo {
 	status = "okay";
+};
+
+&clk_32k {
+	status = "okay";
+	clocks = <&clk_inro>;
 };
 
 &gpio0 {
@@ -76,7 +85,6 @@
 
 &rtc_counter {
 	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
 };
 
 &i3c0 {

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
@@ -46,6 +46,10 @@
 	status = "okay";
 };
 
+&clk_ertco {
+	status = "okay";
+};
+
 &spibb0 {
 	status = "okay";
 };

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
@@ -105,6 +105,10 @@
 	status = "okay";
 };
 
+&clk_ertco {
+	status = "okay";
+};
+
 &dma0 {
 	status = "okay";
 };

--- a/boards/adi/max32690evkit/max32690evkit.dtsi
+++ b/boards/adi/max32690evkit/max32690evkit.dtsi
@@ -60,6 +60,10 @@
 	status = "okay";
 };
 
+&clk_ertco {
+	status = "okay";
+};
+
 &trng {
 	status = "okay";
 };

--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4.dts
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4.dts
@@ -99,6 +99,10 @@
 	status = "okay";
 };
 
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/adi/max78000evkit/max78000evkit_max78000_m4.dts
+++ b/boards/adi/max78000evkit/max78000evkit_max78000_m4.dts
@@ -87,6 +87,10 @@
 	status = "okay";
 };
 
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/adi/max78000fthr/max78000fthr_max78000_m4.dts
+++ b/boards/adi/max78000fthr/max78000fthr_max78000_m4.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -83,6 +83,10 @@ m4_serial: &cmsis_serial {};
 };
 
 &clk_ibro {
+	status = "okay";
+};
+
+&clk_ertco {
 	status = "okay";
 };
 

--- a/boards/adi/max78002evkit/max78002evkit.dtsi
+++ b/boards/adi/max78002evkit/max78002evkit.dtsi
@@ -92,6 +92,10 @@
 	status = "okay";
 };
 
+&clk_ertco {
+	status = "okay";
+};
+
 &uart0 {
 	pinctrl-0 = <&uart0a_tx_p0_1 &uart0a_rx_p0_0>;
 	clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -344,6 +344,11 @@ Counter
   ``prescale-glitch-filter`` and ``prescale-glitch-filter-bypass`` instead. The new property is
   an exponent, not a divisor: the prescaler divides by ``2^(prescale-glitch-filter + 1)``.
 
+* :dtcompatible:`adi,max32-rtc-counter` and :dtcompatible:`adi,max32-wut` now use the shared
+  ``clk_32k`` node for 32 kHz clock source selection. The clock source is now configured through the
+  ``clocks`` property of the ``clk_32k`` node, instead of ``clock-source`` property in each
+  peripheral node (:github:`117709`).
+
 Devicetree
 ==========
 

--- a/drivers/clock_control/clock_control_max32.c
+++ b/drivers/clock_control/clock_control_max32.c
@@ -6,10 +6,17 @@
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/adi_max32_clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #include <wrap_max32_sys.h>
 
 #define DT_DRV_COMPAT adi_max32_gcr
+
+#define MAX32_32K_CLK_CTLR DT_CLOCKS_CTLR_BY_IDX(DT_NODELABEL(clk_32k), 0)
+
+struct max32_clock_config {
+	const struct pinctrl_dev_config *pctrl_rtc_in;
+};
 
 static inline int api_on(const struct device *dev, clock_control_subsys_t clkcfg)
 {
@@ -141,14 +148,30 @@ static void setup_fixed_clocks(void)
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_extclk), fixed_clock, okay)
 	MXC_SYS_ClockSourceEnable(ADI_MAX32_CLK_EXTCLK);
 #endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(clk_32k))
+#if DT_SAME_NODE(MAX32_32K_CLK_CTLR, DT_NODELABEL(clk_ertco))
+	Wrap_MXC_SYS_Select32KClockSource(ADI_MAX32_PRPH_CLK_SRC_ERTCO);
+#elif DT_SAME_NODE(MAX32_32K_CLK_CTLR, DT_NODELABEL(clk_inro))
+	Wrap_MXC_SYS_Select32KClockSource(ADI_MAX32_PRPH_CLK_SRC_INRO);
+#elif DT_SAME_NODE(MAX32_32K_CLK_CTLR, DT_NODELABEL(clk_rtc_in))
+	Wrap_MXC_SYS_Select32KClockSource(ADI_MAX32_PRPH_CLK_SRC_EXTCLK);
+#else
+#error "32K clock source is not supported by this SoC"
+#endif
+#endif
 }
 
 static int max32_clkctrl_init(const struct device *dev)
 {
-	ARG_UNUSED(dev);
+	const struct max32_clock_config *cfg = dev->config;
 
 	/* Setup fixed clocks if enabled */
 	setup_fixed_clocks();
+
+	if (cfg->pctrl_rtc_in) {
+		pinctrl_apply_state(cfg->pctrl_rtc_in, PINCTRL_STATE_DEFAULT);
+	}
 
 	/* Setup device clock source */
 	MXC_SYS_Clock_Select(ADI_MAX32_SYSCLK_SRC);
@@ -168,5 +191,16 @@ static int max32_clkctrl_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, max32_clkctrl_init, NULL, NULL, NULL, PRE_KERNEL_1,
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(clk_rtc_in))
+PINCTRL_DT_DEFINE(DT_NODELABEL(clk_rtc_in));
+#define PINCTRL_RTC_IN PINCTRL_DT_DEV_CONFIG_GET(DT_NODELABEL(clk_rtc_in))
+#else
+#define PINCTRL_RTC_IN NULL
+#endif
+
+static const struct max32_clock_config max32_clkctrl_config = {
+	.pctrl_rtc_in = PINCTRL_RTC_IN,
+};
+
+DEVICE_DT_INST_DEFINE(0, max32_clkctrl_init, NULL, NULL, &max32_clkctrl_config, PRE_KERNEL_1,
 		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &max32_clkctrl_api);

--- a/drivers/counter/counter_max32_rtc.c
+++ b/drivers/counter/counter_max32_rtc.c
@@ -14,7 +14,6 @@
 
 #include <rtc.h>
 #include <wrap_max32_lp.h>
-#include <wrap_max32_rtc.h>
 
 LOG_MODULE_REGISTER(max32_counter_rtc, CONFIG_COUNTER_LOG_LEVEL);
 
@@ -252,10 +251,10 @@ static int rtc_max32_init(const struct device *dev)
 	int ret;
 	const struct max32_rtc_config *cfg = dev->config;
 
-	while ((ret = Wrap_MXC_RTC_Init(0, 0, cfg->perclk.clk_src)) != E_SUCCESS) {
+	while ((ret = MXC_RTC_Init(0, 0)) != E_SUCCESS) {
 		if (ret < 0) {
-			LOG_ERR("RTC does not support this clock source.");
-			return -ENOTSUP;
+			LOG_ERR("RTC initialization failed.");
+			return -EIO;
 		}
 	}
 
@@ -315,8 +314,6 @@ static DEVICE_API(counter, counter_rtc_max32_driver_api) = {
 		.pctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(_num),                                     \
 		.sqw_freq = DT_INST_PROP(_num, sqw_frequency),                               \
 		.irq_func = max32_rtc_irq_init_##_num,                                             \
-		.perclk.clk_src =                                                                  \
-			DT_INST_PROP_OR(_num, clock_source, ADI_MAX32_PRPH_CLK_SRC_ERTCO),         \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(_num, &rtc_max32_init, NULL, &rtc_max32_data_##_num,                 \

--- a/drivers/counter/counter_max32_wut.c
+++ b/drivers/counter/counter_max32_wut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,7 +33,6 @@ struct max32_wut_data {
 struct max32_wut_config {
 	struct counter_config_info info;
 	mxc_wut_regs_t *regs;
-	int clock_source;
 	int prescaler;
 	void (*irq_config)(const struct device *dev);
 	uint32_t irq_number;
@@ -234,8 +233,6 @@ static int counter_max32_wut_init(const struct device *dev)
 	mxc_wut_pres_t pres;
 	mxc_wut_cfg_t wut_cfg;
 
-	Wrap_MXC_SYS_Select32KClockSource(cfg->clock_source);
-
 	counter_max32_wut_hw_init(dev);
 
 	prescaler_lo = FIELD_GET(GENMASK(2, 0), LOG2(cfg->prescaler));
@@ -288,8 +285,6 @@ static DEVICE_API(counter, counter_max32_wut_driver_api) = {
 				.channels = 1,                                                     \
 			},                                                                         \
 		.regs = (mxc_wut_regs_t *)DT_REG_ADDR(TIMER(_num)),                                \
-		.clock_source =                                                                    \
-			DT_PROP_OR(TIMER(_num), clock_source, ADI_MAX32_PRPH_CLK_SRC_ERTCO),       \
 		.prescaler = DT_PROP(TIMER(_num), prescaler),                                      \
 		.irq_config = max32_wut_irq_init_##_num,                                           \
 		.irq_number = DT_IRQN(TIMER(_num)),                                                \

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Intel Corporation
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,12 +15,10 @@
 
 #include <wut.h>
 #include <wrap_max32_lp.h>
-#include <wrap_max32_sys.h>
 
 #define WUT_NODE       DT_INST_PARENT(0)
 #define WUT_REGS       ((mxc_wut_regs_t *)DT_REG_ADDR(WUT_NODE))
 #define WUT_PRESCALER  DT_PROP(WUT_NODE, prescaler)
-#define WUT_CLK_SRC    DT_PROP_OR(WUT_NODE, clock_source, ADI_MAX32_PRPH_CLK_SRC_ERTCO)
 
 #define WUT_CLOCK_FREQ (32768 / WUT_PRESCALER)
 #define CYC_PER_TICK   (WUT_CLOCK_FREQ / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
@@ -159,9 +157,6 @@ static int sys_clock_driver_init(void)
 	uint8_t prescaler_lo, prescaler_hi;
 	mxc_wut_pres_t pres;
 	mxc_wut_cfg_t wut_cfg;
-
-	/* Select 32kHz clock source */
-	Wrap_MXC_SYS_Select32KClockSource(WUT_CLK_SRC);
 
 	/* Calculate prescaler register values */
 	prescaler_lo = FIELD_GET(GENMASK(2, 0), LOG2(WUT_PRESCALER));

--- a/dts/arm/adi/max32/max32657-pinctrl.dtsi
+++ b/dts/arm/adi/max32/max32657-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,6 +45,11 @@
 
 	/omit-if-no-ref/ uart0_tx_p0_9: uart0_tx_p0_9 {
 		pinmux = <MAX32_PINMUX(0, 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ rtc_clk_in_p0_12: rtc_clk_in_p0_12 {
+		pinmux = <MAX32_PINMUX(0, 12, GPIO)>;
+		input-enable;
 	};
 
 	/omit-if-no-ref/ sqwout_p0_13: sqwout_p0_13 {
@@ -153,6 +158,12 @@
 
 	/omit-if-no-ref/ uart0_tx_p0_9_sleep: uart0_tx_p0_9_sleep {
 		pinmux = <MAX32_PINMUX(0, 9, AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ rtc_clk_in_p0_12_sleep: rtc_clk_in_p0_12_sleep {
+		pinmux = <MAX32_PINMUX(0, 12, GPIO)>;
+		input-enable;
 		low-power-enable;
 	};
 

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -80,7 +80,7 @@
 		clk_inro: clk_inro {
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(8)>;
+			clock-frequency = <DT_FREQ_K(131)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -105,6 +105,21 @@
 			capacitance-erfoctrl = <0>;
 			status = "disabled";
 		};
+
+		clk_rtc_in: clk_rtc_in {
+			compatible = "adi,max32-extclk";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_K(32768)>;
+			status = "disabled";
+		};
+
+		clk_32k: clk_32k {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <32768>;
+			clocks = <&clk_ertco>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/clock/adi,max32-extclk.yaml
+++ b/dts/bindings/clock/adi,max32-extclk.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Analog Device MAX32 External Clock
+
+compatible: "adi,max32-extclk"
+
+include: [fixed-clock.yaml, pinctrl-device.yaml]

--- a/dts/bindings/counter/adi,max32-rtc-counter.yaml
+++ b/dts/bindings/counter/adi,max32-rtc-counter.yaml
@@ -12,17 +12,6 @@ properties:
   reg:
     required: true
 
-  clock-source:
-    type: int
-    enum: [4, 5]
-    description: |
-      Clock source to be used by the RTC peripheral. The following options
-      are available:
-      - 4: "ADI_MAX32_PRPH_CLK_SRC_ERTCO" External Real-Time Clock Oscillator
-      - 5: "ADI_MAX32_PRPH_CLK_SRC_INRO" Internal Ring Oscillator
-      The target device might not support all option please take a look on
-      target device user guide
-
   sqw-frequency:
     type: int
     description: |
@@ -39,13 +28,6 @@ properties:
 examples:
   - |
     /*
-     * Enable RTC counter.
-     */
-    &rtc_counter {
-        status = "okay";
-    };
-  - |
-    /*
      * Enable 32kHz square wave output on P3.1.
      */
     &rtc_counter {
@@ -53,4 +35,28 @@ examples:
         pinctrl-0 = <&sqwout_p3_1>;
         pinctrl-names = "default";
         sqw-frequency = <32768>;
+    };
+
+  - |
+    /* Use INRO as clock source */
+    &clk_32k {
+            status = "okay";
+            clocks = <&clk_inro>;
+    };
+
+  - |
+    /* Use RTC_CLK_IN as clock source */
+    &clk_rtc_in {
+      status = "okay";
+      pinctrl-0 = <&rtc_clk_in_p0_12>;
+      pinctrl-names = "default";
+    };
+
+    &clk_32k {
+      status = "okay";
+      clocks = <&clk_rtc_in>;
+    };
+
+    &rtc_counter {
+      status = "okay";
     };

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 1a5d9748b680adf0669739f37d05cb985f39b7b8
+      revision: 7b845b62c15a2ec75e67f4eb95f23790aa607c61
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Move 32 kHz clock source selection into the clock control driver to centralize 32 kHz clock configuration for peripherals such as the RTC and WUT. Previously, peripherals such as the RTC and WUT configured the 32 kHz clock source independently, which could result in conflicting configurations when they are both enabled.