### PR TITLE
drivers: serial: stm32: don't release the PM lock twice on TC

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1430,7 +1430,7 @@ static void uart_stm32_isr(const struct device *dev)
 	 * the whole ISR sees the same status regardless of
 	 * any hardware event that may happen.
 	 */
-	const bool tx_complete = LL_USART_IsEnabledIT_TC(usart) && LL_USART_IsActiveFlag_TC(usart);
+	bool tx_complete = LL_USART_IsEnabledIT_TC(usart) && LL_USART_IsActiveFlag_TC(usart);
 #endif
 
 #ifdef CONFIG_PM
@@ -1442,6 +1442,12 @@ static void uart_stm32_isr(const struct device *dev)
 			LL_USART_DisableIT_TC(usart);
 			data->tx_poll_stream_on = false;
 			uart_stm32_pm_policy_state_lock_put(dev);
+			/* This TC belonged to the poll stream and is now handled.
+			 * Clear it so the async branch below does not treat it as
+			 * an async TX completion and release the PM constraint a
+			 * second time, which underflows the policy lock count.
+			 */
+			tx_complete = false;
 		}
 		/* Stream transmission was either async or IRQ based,
 		 * constraint will be released at the same time TC IT


### PR DESCRIPTION
turns out that commit a93e31f28064 ("drivers: uart: stm32: don't read TC interrupt flag multiple times") introduced a regression when both `PM` and `UART_ASYNC_API` are enabled.

using `uart_poll_out` `get`s the pm state lock, which then gets `put` in the ISR. However, now that the value is only checked once, the ASYNC_API/PM case `put`s the lock another time later in the handler.

fix this by clearing the `tx_complete` flag when the lock is `put` in the `tx_poll_stream_on` case.

----

to reproduce, just build the `hello_world` sample, with this config:

```
CONFIG_PM=y
CONFIG_UART_ASYNC_API=y
CONFIG_ASSERT=y
```

```
*** Booting Zephyr OS build v4.4.0-13485-g133c2eb7d3cb ***
Hello World! nucleo_u5a5zj_q/stm32u5a5xx
ASSERTION FAIL [z_spin_lock_valid(l)] @ WEST_TOPDIR/zephyr/include/zephyr/spinlock.h:143
   Invalid spinlock 0x2000075c
r0/a1:  0x00000004  r1/a2:  0x0000008f  r2/a3:  0x00000001
r3/a4:  0x00000004 r12/ip:  0x00010001 r14/lr:  0x08000f15
 xpsr:  0x2100004d
Faulting instruction address (r15/pc): 0x08006eb6
>>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
Fault during interrupt handling
Current thread: 0x20000498 (unknown)
Halting system
```

ai usage disclosure: issue found by agent while troubleshooting a different issue, code also written by agent (claude opus 5).

commit message and PR written, and code reviewed and tested on a physical board, by me.