### PR TITLE
boards: qemu: riscv32(e): add the virtio ethernet controller

### DIFF
--- a/boards/qemu/riscv32/Kconfig.defconfig
+++ b/boards/qemu/riscv32/Kconfig.defconfig
@@ -16,4 +16,28 @@ config HAS_COVERAGE_SUPPORT
 config QEMU_ICOUNT_SHIFT
 	default 6 if QEMU_ICOUNT
 
+configdefault ETH_DRIVER
+	default y
+
+configdefault NET_QEMU_DEVICE_EXTRA_ARGS
+	default "bus=virtio-mmio-bus.0"
+
+configdefault NET_TX_STACK_SIZE
+	default 8192
+
+configdefault NET_RX_STACK_SIZE
+	default 8192
+
+configdefault NET_TCP_WORKQ_STACK_SIZE
+	default 8192
+
+configdefault NET_MGMT_EVENT_STACK_SIZE
+	default 8192
+
+configdefault NET_SOCKETS_SERVICE_STACK_SIZE
+	default 8192
+
+configdefault TEST_RANDOM_GENERATOR
+	default y if NETWORKING
+
 endif # BOARD_QEMU_RISCV32

--- a/boards/qemu/riscv32/qemu_riscv32.dts
+++ b/boards/qemu/riscv32/qemu_riscv32.dts
@@ -4,6 +4,7 @@
 
 #include <qemu/virt-riscv32.dtsi>
 #include <qemu/virt-riscv-plic.dtsi>
+#include <qemu/virt-riscv-virtio-net.dtsi>
 
 / {
 	chosen {

--- a/boards/qemu/riscv32/qemu_riscv32.yaml
+++ b/boards/qemu/riscv32/qemu_riscv32.yaml
@@ -7,11 +7,10 @@ arch: riscv
 toolchain:
   - zephyr
 supported:
-  - netif
+  - netif:eth
 ram: 262144
 flash: 32768
 testing:
   default: true
   ignore_tags:
-    - net
     - bluetooth

--- a/boards/qemu/riscv32e/Kconfig.defconfig
+++ b/boards/qemu/riscv32e/Kconfig.defconfig
@@ -13,4 +13,28 @@ config BUILD_OUTPUT_BIN
 config HAS_COVERAGE_SUPPORT
 	default y
 
+configdefault ETH_DRIVER
+	default y
+
+configdefault NET_QEMU_DEVICE_EXTRA_ARGS
+	default "bus=virtio-mmio-bus.0"
+
+configdefault NET_TX_STACK_SIZE
+	default 8192
+
+configdefault NET_RX_STACK_SIZE
+	default 8192
+
+configdefault NET_TCP_WORKQ_STACK_SIZE
+	default 8192
+
+configdefault NET_MGMT_EVENT_STACK_SIZE
+	default 8192
+
+configdefault NET_SOCKETS_SERVICE_STACK_SIZE
+	default 8192
+
+configdefault TEST_RANDOM_GENERATOR
+	default y if NETWORKING
+
 endif # BOARD_QEMU_RISCV32E

--- a/boards/qemu/riscv32e/qemu_riscv32e.dts
+++ b/boards/qemu/riscv32e/qemu_riscv32e.dts
@@ -9,6 +9,7 @@
 
 #include <qemu/virt-riscv32e.dtsi>
 #include <qemu/virt-riscv-plic.dtsi>
+#include <qemu/virt-riscv-virtio-net.dtsi>
 
 / {
 	chosen {

--- a/boards/qemu/riscv32e/qemu_riscv32e.yaml
+++ b/boards/qemu/riscv32e/qemu_riscv32e.yaml
@@ -8,11 +8,10 @@ toolchain:
   - zephyr
 preferred_toolchain: zephyr/llvm
 supported:
-  - netif
+  - netif:eth
 ram: 262144
 flash: 32768
 testing:
   default: true
   ignore_tags:
-    - net
     - bluetooth

--- a/samples/net/dhcpv4_client/tests.yaml
+++ b/samples/net/dhcpv4_client/tests.yaml
@@ -15,6 +15,8 @@ tests:
         - "Run dhcpv4 client"
         - "Address\\[[0-9]+\\]: 10\\.0\\.2\\."
     platform_allow:
+      - qemu_riscv32
+      - qemu_riscv32e
       - qemu_riscv64
     extra_configs:
       - CONFIG_NET_QEMU_USER=y


### PR DESCRIPTION
add the virtio ethernet controller to
the qemu_riscv32(e) board. Just like already done on the qemu_riscv64