### PR TITLE
mgmt: ec_host_cmd: enforce RX buffer capacity check in verify_rx

### DIFF
--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -227,6 +227,11 @@ static enum ec_host_cmd_status verify_rx(struct ec_host_cmd_rx_ctx *rx)
 		return EC_HOST_CMD_INVALID_HEADER;
 	}
 
+	/* Prevent header claim from exceeding max buffer capacity */
+	if (rx_header->data_len > (rx->len_max - RX_HEADER_SIZE)) {
+		return EC_HOST_CMD_REQUEST_TRUNCATED;
+	}
+
 	const uint16_t rx_valid_data_size = rx_header->data_len + RX_HEADER_SIZE;
 	/*
 	 * Ensure we received at least as much data as is expected.


### PR DESCRIPTION
Add a check in `verify_rx()` to ensure the incoming packet's declared `data_len` does not exceed the maximum payload capacity of the `RX buffer (rx->len_max - RX_HEADER_SIZE)`. Return `EC_HOST_CMD_REQUEST_TRUNCATED` if the requested size exceeds available buffer capacity, rejecting oversized frames before handler validation.