### PR TITLE
drivers: sdhc: Fix bouffalolab include path

### DIFF
--- a/drivers/sdhc/sdhc_bflb.c
+++ b/drivers/sdhc/sdhc_bflb.c
@@ -17,7 +17,7 @@
 
 #include <bflb_soc.h>
 #include <glb_reg.h>
-#include <sdh_reg.h>
+#include <bouffalolab/common/sdh_reg.h>
 
 #if defined(CONFIG_SOC_SERIES_BL61X)
 #include <zephyr/dt-bindings/clock/bflb_bl61x_clock.h>


### PR DESCRIPTION
The include path for the sdhc driver is wrong, fix it.

hotfixes https://github.com/zephyrproject-rtos/zephyr/actions/runs/32928662916/job/98057075226?pr=114752