### PR TITLE
doc: doxygen: add @rfc alias for IETF RFC references

### DIFF
--- a/doc/contribute/style/doxygen.rst
+++ b/doc/contribute/style/doxygen.rst
@@ -355,6 +355,27 @@ or label that does not exist causes a documentation build warning.
    These commands expand to plain text when the Doxygen documentation is built standalone, i.e.
    without the rest of the documentation. See :ref:`zephyr_doc` for more details.
 
+.. _doxygen_rfc_refs:
+
+Referencing IETF RFCs
+*********************
+
+``@rfc{<number>}`` or ``@rfc{<number>,<anchor>}``
+  Reference an IETF RFC by number, optionally pointing to an anchor within it. This is the
+  Doxygen counterpart of the :rst:role:`rfc` role and renders as a hyperlink to the RFC on the
+  IETF Datatracker.
+
+  The anchor is passed through verbatim, so it can target anything the Datatracker defines for
+  that RFC, such as ``section-3.1``, ``appendix-B.1.2``, ``figure-2``, or ``table-1``. Which
+  anchors exist depends on the RFC: figures and tables are only anchored on RFCs rendered from
+  their XML source.
+
+  Do not put whitespace after the comma: Doxygen keeps it as part of the argument, where it ends
+  up inside the URL fragment. The rendered link text still looks correct, so a broken anchor is
+  only noticeable when following the link.
+
+  Example: ``@rfc{7519}``, ``@rfc{8613,section-3.1}`` or ``@rfc{8613,appendix-B.1.2}``
+
 .. _doxygen_internals:
 
 Hiding internal details

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -301,11 +301,19 @@ TAB_SIZE               = 8
 # - rstref{1}:       reference any Sphinx ':ref:' target, with optional custom
 #                    text, e.g. @rstref{coding_guidelines} or
 #                    @rstref{the coding guidelines <coding_guidelines>}
+# - rfc{1}:          reference an IETF RFC by number, e.g. @rfc{7519} (a plain
+#                    hyperlink, unlike the placeholders above)
+# - rfc{2}:          same, with an anchor, e.g. @rfc{8613,section-3.1},
+#                    @rfc{8613,appendix-B.1.2} or @rfc{9175,figure-2}
+#                    (no whitespace after the comma, as it would become part
+#                    of the anchor)
 
 ALIASES                = "kconfig{1}=\htmlonly<code class='doxyxref' data-stype='kconfig:option' data-starget='\1'>\1</code>\endhtmlonly" \
                          "kconfig_regex{1}=\htmlonly<code class='doxyxref' data-stype='kconfig:option-regex' data-starget='\1'>\1</code>\endhtmlonly" \
                          "dtcompatible{1}=\htmlonly<code class='doxyxref' data-stype='std:dtcompatible' data-starget='\1'>\1</code>\endhtmlonly" \
                          "rstref{1}=\htmlonly<span class='doxyxref' data-stype='std:ref' data-starget='\1'>\1</span>\endhtmlonly" \
+                         "rfc{1}=[RFC \1](https://datatracker.ietf.org/doc/html/rfc\1)" \
+                         "rfc{2}=[RFC \1, \2](https://datatracker.ietf.org/doc/html/rfc\1#\2)" \
                          "kconfig_dep{1}=\attention Available only when the following Kconfig option is enabled: \kconfig{\1}." \
                          "kconfig_dep{2}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}." \
                          "kconfig_dep{3}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}, \kconfig{\3}." \

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -45,37 +45,37 @@ extern "C" {
  * they know how to format them correctly. The only restriction is
  * that all options must be added to a packet in numeric order.
  *
- * Refer to RFC 7252, section 12.2 for more information.
+ * Refer to @rfc{7252,section-12.2} for more information.
  */
 enum coap_option_num {
 	COAP_OPTION_IF_MATCH = 1,        /**< If-Match */
 	COAP_OPTION_URI_HOST = 3,        /**< Uri-Host */
 	COAP_OPTION_ETAG = 4,            /**< ETag */
 	COAP_OPTION_IF_NONE_MATCH = 5,   /**< If-None-Match */
-	COAP_OPTION_OBSERVE = 6,         /**< Observe (RFC 7641) */
+	COAP_OPTION_OBSERVE = 6,         /**< Observe (@rfc{7641}) */
 	COAP_OPTION_URI_PORT = 7,        /**< Uri-Port */
 	COAP_OPTION_LOCATION_PATH = 8,   /**< Location-Path */
-	COAP_OPTION_OSCORE = 9,          /**< OSCORE (RFC 8613) */
+	COAP_OPTION_OSCORE = 9,          /**< OSCORE (@rfc{8613}) */
 	COAP_OPTION_URI_PATH = 11,       /**< Uri-Path */
 	COAP_OPTION_CONTENT_FORMAT = 12, /**< Content-Format */
 	COAP_OPTION_MAX_AGE = 14,        /**< Max-Age */
 	COAP_OPTION_URI_QUERY = 15,      /**< Uri-Query */
 	COAP_OPTION_ACCEPT = 17,         /**< Accept */
 	COAP_OPTION_LOCATION_QUERY = 20, /**< Location-Query */
-	COAP_OPTION_BLOCK2 = 23,         /**< Block2 (RFC 7959) */
-	COAP_OPTION_BLOCK1 = 27,         /**< Block1 (RFC 7959) */
-	COAP_OPTION_SIZE2 = 28,          /**< Size2 (RFC 7959) */
+	COAP_OPTION_BLOCK2 = 23,         /**< Block2 (@rfc{7959}) */
+	COAP_OPTION_BLOCK1 = 27,         /**< Block1 (@rfc{7959}) */
+	COAP_OPTION_SIZE2 = 28,          /**< Size2 (@rfc{7959}) */
 	COAP_OPTION_PROXY_URI = 35,      /**< Proxy-Uri */
 	COAP_OPTION_PROXY_SCHEME = 39,   /**< Proxy-Scheme */
 	COAP_OPTION_SIZE1 = 60,          /**< Size1 */
-	COAP_OPTION_ECHO = 252,          /**< Echo (RFC 9175) */
-	COAP_OPTION_NO_RESPONSE = 258,   /**< No-Response (RFC 7967) */
-	COAP_OPTION_REQUEST_TAG = 292,   /**< Request-Tag (RFC 9175) */
-	COAP_OPTION_SIGNAL_701_MMS = 2,  /**< Signal 7.01 Max message size (RFC 8323) */
-	COAP_OPTION_SIGNAL_701_BWT = 4,	 /**< Signal 7.01 Block-wise transfer (RFC 8323) */
-	COAP_OPTION_SIGNAL_704_ALT_ADDR = 2, /**< Signal 7.04 Alternative-Address (RFC 8323) */
-	COAP_OPTION_SIGNAL_704_HOLD_OFF = 4, /**< Signal 7.04 Hold-Off (RFC 8323) */
-	COAP_OPTION_SIGNAL_705_BAD_CSM = 2   /**< Signal 7.05 Bad-CSM-Option (RFC 8323) */
+	COAP_OPTION_ECHO = 252,          /**< Echo (@rfc{9175}) */
+	COAP_OPTION_NO_RESPONSE = 258,   /**< No-Response (@rfc{7967}) */
+	COAP_OPTION_REQUEST_TAG = 292,   /**< Request-Tag (@rfc{9175}) */
+	COAP_OPTION_SIGNAL_701_MMS = 2,  /**< Signal 7.01 Max message size (@rfc{8323}) */
+	COAP_OPTION_SIGNAL_701_BWT = 4,	 /**< Signal 7.01 Block-wise transfer (@rfc{8323}) */
+	COAP_OPTION_SIGNAL_704_ALT_ADDR = 2, /**< Signal 7.04 Alternative-Address (@rfc{8323}) */
+	COAP_OPTION_SIGNAL_704_HOLD_OFF = 4, /**< Signal 7.04 Hold-Off (@rfc{8323}) */
+	COAP_OPTION_SIGNAL_705_BAD_CSM = 2   /**< Signal 7.05 Bad-CSM-Option (@rfc{8323}) */
 };
 
 /**
@@ -149,7 +149,7 @@ enum coap_msgtype {
  *
  * To be used when creating a response.
  *
- * Refer to RFC 7252, section 12.1.2 for more information.
+ * Refer to @rfc{7252,section-12.1.2} for more information.
  */
 enum coap_response_code {
 	/** 2.01 - Created */
@@ -260,7 +260,7 @@ enum coap_content_format {
  * @brief Set of No-Response option values for CoAP.
  *
  * To be used when encoding or decoding a No-Response option defined
- * in RFC 7967.
+ * in @rfc{7967}.
  */
 enum coap_no_response {
 	COAP_NO_RESPONSE_SUPPRESS_2_XX = 0x02,
@@ -787,11 +787,9 @@ int coap_handle_request(struct coap_packet *cpkt,
 
 /**
  * Represents the size of each block that will be transferred using
- * block-wise transfers [RFC7959]:
+ * block-wise transfers (@rfc{7959}):
  *
  * Each entry maps directly to the value that is used in the wire.
- *
- * https://tools.ietf.org/html/rfc7959
  */
 enum coap_block_size {
 	COAP_BLOCK_16,   /**< 16-byte block size */
@@ -801,7 +799,7 @@ enum coap_block_size {
 	COAP_BLOCK_256,  /**< 256-byte block size */
 	COAP_BLOCK_512,  /**< 512-byte block size */
 	COAP_BLOCK_1024, /**< 1024-byte block size */
-	COAP_BLOCK_BERT, /**< BERT block size (RFC 8323) - acts like 1024 for calculations */
+	COAP_BLOCK_BERT, /**< BERT block size (@rfc{8323}) - acts like 1024 for calculations */
 };
 
 /**
@@ -1362,7 +1360,7 @@ void coap_set_transmission_parameters(const struct coap_transmission_parameters 
  * @brief Check if a CoAP packet contains unsupported critical options.
  *
  * This function checks if a parsed CoAP packet contains any critical options
- * that this build does not support. Per RFC 7252 Section 5.4.1, unrecognized
+ * that this build does not support. Per @rfc{7252,section-5.4.1}, unrecognized
  * critical options must cause the message to be rejected.
  *
  * Currently checks for:

--- a/include/zephyr/net/coap_oscore.h
+++ b/include/zephyr/net/coap_oscore.h
@@ -8,7 +8,7 @@
 /** @file
  * @brief CoAP OSCORE API
  *
- * A public API for creating OSCORE (RFC 8613) security contexts that can be
+ * A public API for creating OSCORE (@rfc{8613}) security contexts that can be
  * attached to a CoAP client or service.
  */
 
@@ -45,20 +45,20 @@ extern "C" {
  */
 struct coap_oscore_context;
 
-/** @brief AEAD algorithm used to protect OSCORE messages (RFC 8613 Section 3.1). */
+/** @brief AEAD algorithm used to protect OSCORE messages (@rfc{8613,section-3.1}). */
 enum coap_oscore_aead_alg {
 	/** AES-CCM mode 128-bit key, 64-bit tag, 13-byte nonce. */
 	COAP_OSCORE_AEAD_AES_CCM_16_64_128 = 0,
 };
 
-/** @brief HKDF algorithm used to derive OSCORE keys (RFC 8613 Section 3.1). */
+/** @brief HKDF algorithm used to derive OSCORE keys (@rfc{8613,section-3.1}). */
 enum coap_oscore_hkdf {
 	/** HKDF-SHA-256. */
 	COAP_OSCORE_HKDF_SHA_256 = 0,
 };
 
 /**
- * @brief OSCORE security context derivation parameters (RFC 8613 Section 3.2).
+ * @brief OSCORE security context derivation parameters (@rfc{8613,section-3.2}).
  *
  * @note coap_oscore_context_add() copies all referenced buffers into the
  *       context pool, so the caller may free or reuse them as soon as the call
@@ -110,7 +110,7 @@ struct coap_oscore_init_params {
  * @brief Add an OSCORE security context.
  *
  * Derives the common, sender and recipient contexts from @p params
- * (RFC 8613 Section 3.2) and adds them to the pool of contexts that can be used with
+ * (@rfc{8613,section-3.2}) and adds them to the pool of contexts that can be used with
  * the CoAP server. Contexts are allocated from a fixed pool sized by
  * @kconfig{CONFIG_COAP_OSCORE_MAX_CONTEXTS} and released with
  * coap_oscore_context_remove(). Each context corresponds to one client identity
@@ -154,7 +154,7 @@ int coap_oscore_context_remove(struct coap_oscore_context *ctx);
  * @brief OSCORE exchange entry.
  *
  * Tracks which server responses need OSCORE protection by matching the client
- * address and request token (RFC 8613 Section 8.3). A CoAP service defined with
+ * address and request token (@rfc{8613,section-8.3}). A CoAP service defined with
  * @ref COAP_SERVICE_DEFINE_OSCORE owns a statically allocated cache of these
  * entries.
  *

--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -27,7 +27,7 @@ extern "C" {
  * @ref DNS_SD_REGISTER_TCP_SERVICE or
  * @ref DNS_SD_REGISTER_UDP_SERVICE.
  *
- * @see <a href="https://tools.ietf.org/html/rfc6763">RFC 6763</a>
+ * @see @rfc{6763}
  *
  * @defgroup dns_sd DNS Service Discovery
  * @since 2.5
@@ -36,21 +36,21 @@ extern "C" {
  * @{
  */
 
-/** RFC 1034 Section 3.1 */
+/** @rfc{1034,section-3.1} */
 #define DNS_SD_INSTANCE_MIN_SIZE 1
-/** RFC 1034 Section 3.1, RFC 6763 Section 7.2 */
+/** @rfc{1034,section-3.1}, @rfc{6763,section-7.2} */
 #define DNS_SD_INSTANCE_MAX_SIZE 63
-/** RFC 6763 Section 7.2 - inclusive of underscore */
+/** @rfc{6763,section-7.2} - inclusive of underscore */
 #define DNS_SD_SERVICE_MIN_SIZE 2
-/** RFC 6763 Section 7.2 - inclusive of underscore */
+/** @rfc{6763,section-7.2} - inclusive of underscore */
 #define DNS_SD_SERVICE_MAX_SIZE 16
-/** RFC 6763 Section 4.1.2 */
+/** @rfc{6763,section-4.1.2} */
 #define DNS_SD_SERVICE_PREFIX '_'
-/** RFC 6763 Section 4.1.2 - either _tcp or _udp (case insensitive) */
+/** @rfc{6763,section-4.1.2} - either _tcp or _udp (case insensitive) */
 #define DNS_SD_PROTO_SIZE 4
 /** ICANN Rules for TLD naming */
 #define DNS_SD_DOMAIN_MIN_SIZE 2
-/** RFC 1034 Section 3.1, RFC 6763 Section 7.2 */
+/** @rfc{1034,section-3.1}, @rfc{6763,section-7.2} */
 #define DNS_SD_DOMAIN_MAX_SIZE 63
 
 /**
@@ -65,7 +65,7 @@ extern "C" {
  * ```
  * <sub>._sub.<sn>._tcp.<servicedomain>.<parentdomain>.
  * ```
- * @see <a href="https://datatracker.ietf.org/doc/html/rfc6763">RFC 6763</a>, Section 7.2.
+ * @see @rfc{6763,section-7.2}
  */
 #define DNS_SD_MIN_LABELS 3
 /**
@@ -81,7 +81,7 @@ extern "C" {
  * ```
  * <sub>._sub.<sn>._tcp.<servicedomain>.<parentdomain>.
  * ```
- * @see <a href="https://datatracker.ietf.org/doc/html/rfc6763">RFC 6763</a>, Section 7.2.
+ * @see @rfc{6763,section-7.2}
  */
 #define DNS_SD_MAX_LABELS 4
 
@@ -147,7 +147,7 @@ extern "C" {
  * must not exceed 255 bytes. Care must be taken to ensure that the
  * encoded length value is correct.
  *
- * For additional rules on TXT encoding, see RFC 6763, Section 6.
+ * For additional rules on TXT encoding, see @rfc{6763,section-6}.
 
  * @param id variable name for the DNS-SD service record
  * @param instance name of the service instance such as "My HTTP Server"
@@ -156,7 +156,7 @@ extern "C" {
  * @param text information for the DNS TXT record
  * @param port the port number that this service will use
  *
- * @see <a href="https://tools.ietf.org/html/rfc6763">RFC 6763</a>
+ * @see @rfc{6763}
  */
 #define DNS_SD_REGISTER_TCP_SERVICE(id, instance, service, domain, text, \
 				    port)				 \
@@ -185,7 +185,7 @@ extern "C" {
  * @param text information for the DNS TXT record
  * @param port the port number that this service will use
  *
- * @see <a href="https://tools.ietf.org/html/rfc6763">RFC 6763</a>
+ * @see @rfc{6763}
  */
 #define DNS_SD_REGISTER_UDP_SERVICE(id, instance, service, domain, text, \
 				    port)				 \
@@ -199,7 +199,7 @@ extern "C" {
 /**
  * @brief DNS Service Discovery record
  *
- * This structure used in the implementation of RFC 6763 and should not
+ * This structure used in the implementation of @rfc{6763} and should not
  * need to be accessed directly from application code.
  *
  * The @a port pointer must be non-NULL. When the value in @a port
@@ -210,7 +210,7 @@ extern "C" {
  * Thus, it is possible for multiple services to advertise on a
  * particular port if they hard-code the port.
  *
- * @see <a href="https://tools.ietf.org/html/rfc6763">RFC 6763</a>
+ * @see @rfc{6763}
  */
 struct dns_sd_rec {
 	/** "<Instance>" - e.g. "My HTTP Server" */
@@ -269,7 +269,7 @@ static inline size_t dns_sd_txt_size(const struct dns_sd_rec *rec)
  *
  * Currently, only the '.local' domain is supported.
  *
- * @see <a href="https://datatracker.ietf.org/doc/html/rfc6763#section-9">Service Type Enumeration, RFC 6763</a>.
+ * @see @rfc{6763,section-9}
  *
  * @param rec the record to in question
  * @return true if @a rec is a DNS-SD Service Type Enumeration

--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -79,16 +79,16 @@ BUILD_ASSERT(offsetof(struct ppp_api, iface_api) == 0);
  * for details.
  */
 enum ppp_protocol_type {
-	PPP_IP     = 0x0021, /**< RFC 1332 */
-	PPP_IPV6   = 0x0057, /**< RFC 5072 */
-	PPP_IPCP   = 0x8021, /**< RFC 1332 */
-	PPP_ECP    = 0x8053, /**< RFC 1968 */
-	PPP_IPV6CP = 0x8057, /**< RFC 5072 */
-	PPP_CCP    = 0x80FD, /**< RFC 1962 */
-	PPP_LCP    = 0xc021, /**< RFC 1661 */
-	PPP_PAP    = 0xc023, /**< RFC 1334 */
-	PPP_CHAP   = 0xc223, /**< RFC 1334 */
-	PPP_EAP    = 0xc227, /**< RFC 2284 */
+	PPP_IP     = 0x0021, /**< @rfc{1332} */
+	PPP_IPV6   = 0x0057, /**< @rfc{5072} */
+	PPP_IPCP   = 0x8021, /**< @rfc{1332} */
+	PPP_ECP    = 0x8053, /**< @rfc{1968} */
+	PPP_IPV6CP = 0x8057, /**< @rfc{5072} */
+	PPP_CCP    = 0x80FD, /**< @rfc{1962} */
+	PPP_LCP    = 0xc021, /**< @rfc{1661} */
+	PPP_PAP    = 0xc023, /**< @rfc{1334} */
+	PPP_CHAP   = 0xc223, /**< @rfc{1334} */
+	PPP_EAP    = 0xc227, /**< @rfc{2284} */
 };
 
 /**
@@ -147,7 +147,7 @@ enum ppp_packet_type {
 /** @endcond */
 
 /**
- * LCP option types from RFC 1661 ch. 6
+ * LCP option types from @rfc{1661,section-6}
  */
 enum lcp_option_type {
 	/** Reserved option value (do not use) */
@@ -176,7 +176,7 @@ enum lcp_option_type {
 } __packed;
 
 /**
- * IPCP option types from RFC 1332
+ * IPCP option types from @rfc{1332}
  */
 enum ipcp_option_type {
 	/** Reserved IPCP option value (do not use) */
@@ -207,7 +207,7 @@ enum ipcp_option_type {
 } __packed;
 
 /**
- * IPV6CP option types from RFC 5072
+ * IPV6CP option types from @rfc{5072}
  */
 enum ipv6cp_option_type {
 	/** Reserved IPV6CP option value (do not use) */


### PR DESCRIPTION
Add `@rfc{<number>}` and `@rfc{<number>,<anchor>}` Doxygen aliases that expand to a hyperlink to the RFC on the IETF Datatracker, mirroring the Sphinx `:rfc:` role used in the main documentation. Document the new command in the Doxygen style guide.

Applied for CoAP, DNS-SD and PPP.

See an example here: https://builds.zephyrproject.io/zephyr/pr/117718/docs/doxygen/html/group__coap.html#ga7b8b3041e2f4ae26e663ff7431a6e6e3