### PR TITLE
manifest: psa-arch-test: fix builds for frdmmcxn947

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -373,7 +373,7 @@ manifest:
       path: modules/lib/picolibc
       revision: 01254932e8e81085817ed61fd858648584ffe37c
     - name: psa-arch-tests
-      revision: 588572c0ebd835c7e0929eaf3007d4fbadb47b5b
+      revision: 3ce2420dd321c86928b40d33a8f799f5138469d3
       path: modules/tee/tf-m/psa-arch-tests
       groups:
         - testing


### PR DESCRIPTION
psa-arch-test builds fixed for frdmmcxn947.
Continuing from previously stale/closed pr: https://github.com/zephyrproject-rtos/zephyr/pull/112036