### PR TITLE
infineon: Peri Block Driver

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -309,6 +309,15 @@ Clock Control
   RT11xx overlays should be updated using the mapping
   ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
 
+* The Infineon peripheral clock driver now binds to the new :dtcompatible:`infineon,peri` container
+  node instead of to each individual :dtcompatible:`infineon,peri-div` node. A single device is
+  created per peripheral clock instance and it programs all of its enabled divider children. The
+  :dtcompatible:`infineon,peri-div` binding itself is unchanged, so ``clocks = <&peri_clk_div0>``
+  references in board devicetree files keep working. Out-of-tree SoC devicetree files must add
+  ``compatible = "infineon,peri";`` to the parent node that holds the divider nodes. A build
+  assertion fires if an enabled :dtcompatible:`infineon,peri-div` node is not a child of an
+  :dtcompatible:`infineon,peri` node, since such a divider would never be programmed.
+
 Comparator
 ==========
 

--- a/drivers/audio/dmic_infineon.c
+++ b/drivers/audio/dmic_infineon.c
@@ -644,14 +644,7 @@ static DEVICE_API(dmic, dmic_ops) = {
 	.read = ifx_dmic_read,
 };
 
-#define DMIC_PERI_CLOCK_INFO(n)                                                                    \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	},
+#define DMIC_PERI_CLOCK_INFO(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n),
 
 #define DMIC_DMA_CHANNEL_INIT(index)                                                               \
 	.dev_dma = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(index, rx)),                            \

--- a/drivers/can/can_infineon.c
+++ b/drivers/can/can_infineon.c
@@ -197,24 +197,7 @@ static const struct can_mcan_ops can_infineon_ops = {
 	.clear_mram = can_infineon_clear_mram,
 };
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define CAN_PERI_CLOCK_INIT(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	},
-#else
-#define CAN_PERI_CLOCK_INIT(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	},
-#endif
+#define CAN_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n),
 
 #define CAN_INFINEON_MCAN_INIT(n)                                                                  \
 	CAN_MCAN_DT_INST_BUILD_ASSERT_MRAM_CFG(n);                                                 \

--- a/drivers/clock_control/Kconfig.infineon
+++ b/drivers/clock_control/Kconfig.infineon
@@ -30,7 +30,7 @@ config CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK
 config CLOCK_CONTROL_IFX_PERI_CLOCK
 	bool "Infineon peri div clock driver"
 	default y
-	depends on DT_HAS_INFINEON_PERI_DIV_ENABLED
+	depends on DT_HAS_INFINEON_PERI_ENABLED
 	help
 	  This option enables the Peripheral clock driver for Infineon CAT1 family.
 

--- a/drivers/clock_control/clock_control_infineon_peri_clock.c
+++ b/drivers/clock_control/clock_control_infineon_peri_clock.c
@@ -9,10 +9,12 @@
  * @brief Peripheral Clock control driver for Infineon CAT1 MCU family.
  */
 
-#define DT_DRV_COMPAT infineon_peri_div
+#define DT_DRV_COMPAT infineon_peri
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
 #include <stdlib.h>
 
 #include <infineon_kconfig.h>
@@ -21,11 +23,20 @@
 #include <cy_sysclk.h>
 #include <cy_systick.h>
 
-struct ifx_peri_clock_data {
+LOG_MODULE_REGISTER(clock_control_ifx_peri, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
+
+/** @brief Compile time description of a single peripheral clock divider. */
+struct ifx_peri_divider {
 	struct ifx_cat1_clock clock;
 	uint16_t divider;
 	uint8_t frac_divider;
 	uint8_t div_type;
+};
+
+/** @brief All dividers belonging to one peripheral clock instance. */
+struct ifx_peri_clock_config {
+	const struct ifx_peri_divider *dividers;
+	size_t num_dividers;
 };
 
 static inline en_clk_dst_t peri_pclk_build_en_clk_dst(uint8_t output, uint8_t group,
@@ -45,9 +56,8 @@ static inline en_clk_dst_t peri_pclk_build_en_clk_dst(uint8_t output, uint8_t gr
 	return clk_dst;
 }
 
-static int ifx_cat1_peri_clock_init(const struct device *dev)
+static int ifx_peri_divider_setup(const struct ifx_peri_divider *div_cfg)
 {
-	struct ifx_peri_clock_data *const data = dev->data;
 	en_clk_dst_t clk_dst;
 
 	/* PDL calls to set the and enable peri clock divider use the en_clk_dst_t
@@ -58,7 +68,7 @@ static int ifx_cat1_peri_clock_init(const struct device *dev)
 	 * clock configuration calls.
 	 */
 #if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-	clk_dst = peri_pclk_build_en_clk_dst(0, data->clock.group, data->clock.instance);
+	clk_dst = peri_pclk_build_en_clk_dst(0, div_cfg->clock.group, div_cfg->clock.instance);
 #else
 	/* For PSOC4, clk_dst is simply 0 since we don't have instance/group fields */
 	clk_dst = 0;
@@ -68,66 +78,85 @@ static int ifx_cat1_peri_clock_init(const struct device *dev)
 	 * use the clock must connect to the clock by calling:
 	 * ifx_cat1_utils_peri_pclk_assign_divider()
 	 */
-	if ((data->div_type == CY_SYSCLK_DIV_8_BIT) || (data->div_type == CY_SYSCLK_DIV_16_BIT)) {
-		if (CY_RSLT_SUCCESS != ifx_cat1_utils_peri_pclk_set_divider(clk_dst,
-						&data->clock, data->divider - 1)) {
+	if ((div_cfg->div_type == CY_SYSCLK_DIV_8_BIT) ||
+	    (div_cfg->div_type == CY_SYSCLK_DIV_16_BIT)) {
+		if (CY_RSLT_SUCCESS != ifx_cat1_utils_peri_pclk_set_divider(
+					       clk_dst, &div_cfg->clock, div_cfg->divider - 1)) {
 			return -EIO;
 		}
 	} else {
-		if (CY_RSLT_SUCCESS != ifx_cat1_utils_peri_pclk_set_frac_divider(clk_dst,
-				&data->clock, data->divider - 1, data->frac_divider)) {
+		if (CY_RSLT_SUCCESS != ifx_cat1_utils_peri_pclk_set_frac_divider(
+					       clk_dst, &div_cfg->clock, div_cfg->divider - 1,
+					       div_cfg->frac_divider)) {
 			return -EIO;
 		}
 	}
 
-	if (CY_RSLT_SUCCESS != ifx_cat1_utils_peri_pclk_enable_divider(clk_dst, &data->clock)) {
+	if (CY_RSLT_SUCCESS != ifx_cat1_utils_peri_pclk_enable_divider(clk_dst, &div_cfg->clock)) {
 		return -EIO;
 	}
 
 	return 0;
 }
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define PERI_CLOCK_INIT(n)                                                                         \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(DT_INST_PROP_BY_IDX(n, peri_group, 0),   \
-							  DT_INST_PROP_BY_IDX(n, peri_group, 1),   \
-							  DT_INST_PROP(n, div_type)),              \
-		.channel = DT_INST_PROP(n, channel),                                               \
-		.instance = DT_INST_PROP_BY_IDX(n, peri_group, 0),                                 \
-		.group = DT_INST_PROP_BY_IDX(n, peri_group, 1),                                    \
-	},
-#elif defined(CY_IP_MXPERI) || defined(CY_IP_M0S8PERI)
-/* PSOC4 devices - struct ifx_cat1_clock only has block and channel fields */
-#define PERI_CLOCK_INIT(n)                                                                         \
-	.clock = {                                                                                 \
-		.block = DT_INST_PROP(n, div_type),                                                \
-		.channel = DT_INST_PROP(n, channel),                                               \
-	},
-#else
-#define PERI_CLOCK_INIT(n)                                                                         \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(DT_INST_PROP_BY_IDX(n, peri_group, 1),   \
-							  DT_INST_PROP(n, div_type)),              \
-		.channel = DT_INST_PROP(n, channel),                                               \
-		.instance = DT_INST_PROP_BY_IDX(n, peri_group, 0),                                 \
-		.group = DT_INST_PROP_BY_IDX(n, peri_group, 1),                                    \
-	},
-#endif
+static int ifx_peri_clock_init(const struct device *dev)
+{
+	const struct ifx_peri_clock_config *const config = dev->config;
 
-#define INFINEON_CAT1_PERI_CLOCK_INIT(n)                                                           \
-	static struct ifx_peri_clock_data ifx_cat1_peri_clock##n##_data = {                        \
-		.div_type = DT_INST_PROP(n, div_type),                                             \
-		.divider = DT_INST_PROP(n, clock_div),                                             \
-		.frac_divider = DT_INST_PROP_OR(n, div_frac_value, 0),                             \
-		PERI_CLOCK_INIT(n)};                                                               \
+	for (size_t i = 0; i < config->num_dividers; i++) {
+		int ret = ifx_peri_divider_setup(&config->dividers[i]);
+
+		if (ret != 0) {
+			LOG_ERR("%s: failed to configure divider %zu (%d)", dev->name, i, ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/* The struct ifx_cat1_clock initializer is shared with the peripheral drivers so that
+ * the divider encoding only has to be described in one place.
+ */
+#define IFX_PERI_DIV_ENTRY(node_id)                                                                \
+	IF_ENABLED(DT_NODE_HAS_COMPAT(node_id, infineon_peri_div),                                 \
+		   ({                                                                              \
+			    .clock = IFX_CAT1_PERI_CLOCK_DT_INIT(node_id),                         \
+			    .div_type = DT_PROP(node_id, div_type),                                \
+			    .divider = DT_PROP(node_id, clock_div),                                \
+			    .frac_divider = DT_PROP_OR(node_id, div_frac_value, 0),                \
+		    },))
+
+/* A peripheral clock instance with no enabled dividers is legitimate, so a terminating
+ * entry keeps the array from being empty. clock-div is always at least 1 for a real
+ * divider, which makes a zero divider usable as a sentinel.
+ */
+#define IFX_PERI_DIV_END {.divider = 0}
+
+#define IFX_PERI_CLOCK_INIT(n)                                                                     \
+	static const struct ifx_peri_divider ifx_peri_dividers_##n[] = {                           \
+		DT_INST_FOREACH_CHILD_STATUS_OKAY(n, IFX_PERI_DIV_ENTRY) IFX_PERI_DIV_END,         \
+	};                                                                                         \
                                                                                                    \
-	static int ifx_cat1_peri_clock_init_##n(const struct device *dev)                          \
-	{                                                                                          \
-		return ifx_cat1_peri_clock_init(dev);                                              \
-	}                                                                                          \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_peri_clock_init_##n, NULL,                              \
-		&ifx_cat1_peri_clock##n##_data, NULL, PRE_KERNEL_1,                                \
-		CONFIG_CLOCK_CONTROL_INIT_PRIORITY, NULL);
+	static const struct ifx_peri_clock_config ifx_peri_clock_config_##n = {                    \
+		.dividers = ifx_peri_dividers_##n,                                                 \
+		.num_dividers = ARRAY_SIZE(ifx_peri_dividers_##n) - 1,                             \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &ifx_peri_clock_init, NULL, NULL, &ifx_peri_clock_config_##n,     \
+			      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY, NULL);
 
-DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_PERI_CLOCK_INIT)
+DT_INST_FOREACH_STATUS_OKAY(IFX_PERI_CLOCK_INIT)
+
+/* Dividers are only programmed when they are a child of an infineon,peri node. Catch any
+ * out of tree devicetree that still places them elsewhere instead of silently leaving
+ * them unconfigured.
+ */
+#define IFX_PERI_COUNT_DIV(node_id) 1 +
+#define IFX_PERI_COUNT_CHILD_DIV(node_id)                                                          \
+	IF_ENABLED(DT_NODE_HAS_COMPAT(node_id, infineon_peri_div), (1 +))
+#define IFX_PERI_COUNT_INST_DIV(n) DT_INST_FOREACH_CHILD_STATUS_OKAY(n, IFX_PERI_COUNT_CHILD_DIV)
+
+BUILD_ASSERT((DT_INST_FOREACH_STATUS_OKAY(IFX_PERI_COUNT_INST_DIV) 0) ==
+		     (DT_FOREACH_STATUS_OKAY(infineon_peri_div, IFX_PERI_COUNT_DIV) 0),
+	     "Every enabled infineon,peri-div node must be a child of an infineon,peri node");

--- a/drivers/counter/counter_infineon_tcpwm.c
+++ b/drivers/counter/counter_infineon_tcpwm.c
@@ -565,24 +565,7 @@ static DEVICE_API(counter, counter_api) = {
 #define COUNTER_PERI_CLOCK_INSTANCE(n)
 #endif
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define COUNTER_PERI_CLOCK_INIT(n)                                                                 \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	}
-#else
-#define COUNTER_PERI_CLOCK_INIT(n)                                                                 \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	}
-#endif
+#define COUNTER_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n)
 
 #if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
 #define TCPWM_CNT_IDX(n) .index = DT_NODE_CHILD_IDX(DT_INST_PARENT(n))

--- a/drivers/dac/dac_infineon_autanalog_ctdac.c
+++ b/drivers/dac/dac_infineon_autanalog_ctdac.c
@@ -383,14 +383,8 @@ static DEVICE_API(dac, dac_ifx_autanalog_api) = {
 	(DT_NODE_CHILD_IDX(DT_DRV_INST(n)) - DT_NODE_CHILD_IDX(DT_NODELABEL(dac0)))
 
 /* Extract peripheral clock divider info from the DTS clocks phandle */
-#define CTDAC_PERI_CLOCK_INIT(n)                                                               \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	}
+#define CTDAC_PERI_CLOCK_INIT(n)                                                                   \
+	.clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n)
 
 /*
  * Macros to extract waveform channel child node configurations.

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -986,24 +986,7 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 #endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
 };
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define I2C_PERI_CLOCK_INIT(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	},
-#else
-#define I2C_PERI_CLOCK_INIT(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	},
-#endif
+#define I2C_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n),
 
 #ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
 #define I2C_CAT1_SCL_INIT(n) .scl = GPIO_DT_SPEC_INST_GET_OR(n, scl_gpios, {0}),

--- a/drivers/i2s/i2s_infineon.c
+++ b/drivers/i2s/i2s_infineon.c
@@ -1016,13 +1016,7 @@ static DEVICE_API(i2s, ifx_i2s_api) = {
 };
 
 #define I2S_PERI_CLOCK_INFO(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	},                                                                                         \
+	.clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n),                                              \
 	.clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
 
 #define I2S_DMA_CHANNEL_INIT(index, dir, ch_dir)                                                   \

--- a/drivers/mfd/mfd_infineon_hppass_csg.c
+++ b/drivers/mfd/mfd_infineon_hppass_csg.c
@@ -298,12 +298,7 @@ static int ifx_hppass_csg_init(const struct device *dev)
 	static const struct ifx_csg_config ifx_csg_config_##n = {                                  \
 		.base = (mem_addr_t)DT_INST_REG_ADDR(n),                                           \
 		.parent = DEVICE_DT_GET(DT_INST_PARENT(n)),                                        \
-		.clock = {                                                                         \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
-		},                                                                                 \
+		.clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n),                                      \
 		.clk_dst = (en_clk_dst_t)DT_INST_PROP(n, clk_dst),                                 \
 		.dac_observe_blank = (uint8_t)DT_INST_PROP(n, infineon_dac_observe_blank_cycles),  \
 	};                                                                                         \

--- a/drivers/pwm/pwm_infineon_m0s8tcpwm.c
+++ b/drivers/pwm/pwm_infineon_m0s8tcpwm.c
@@ -219,13 +219,7 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 	.get_cycles_per_sec = ifx_tcpwm_pwm_get_cycles_per_sec,
 };
 
-#define PWM_PERI_CLOCK_INIT(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	}
+#define PWM_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n)
 
 #define INFINEON_TCPWM_PWM_INIT(n)                                                                 \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \

--- a/drivers/pwm/pwm_infineon_tcpwm.c
+++ b/drivers/pwm/pwm_infineon_tcpwm.c
@@ -251,29 +251,8 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 
 /*
  * Initialize the peripheral clock divider from devicetree.
- *
- * PSoC Edge SoCs require an extra peri_group index argument to
- * IFX_CAT1_PERIPHERAL_GROUP_ADJUST, so the two variants are selected
- * at compile time based on CONFIG_SOC_FAMILY_INFINEON_EDGE.
  */
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define PWM_PERI_CLOCK_INIT(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	}
-#else
-#define PWM_PERI_CLOCK_INIT(n)                                                                     \
-	.clock = {                                                                                 \
-		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
-			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
-			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
-		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	}
-#endif
+#define PWM_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n)
 
 /*
  * Per-instance wrapper init for PWM event support.

--- a/drivers/sdhc/sdhc_infineon.c
+++ b/drivers/sdhc/sdhc_infineon.c
@@ -1062,15 +1062,7 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
 
 #define PERI_INFO(n) .clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
 
-#define IFX_SDHC_PERI_CLOCK_INIT(n)                                                                \
-	.clock =                                                                                   \
-		{                                                                                  \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),         \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-	},                                                                                         \
-	PERI_INFO(n)
+#define IFX_SDHC_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n), PERI_INFO(n)
 #elif defined(COMPONENT_CAT1A)
 #define IFX_SDHC_IRQ_INIT(n)                                                                       \
 	void sdhc_infineon_isr_##n(void)                                                           \

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -1495,28 +1495,7 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 #define CALL_UART_IRQ_CONFIG(n)
 #endif
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define UART_PERI_CLOCK_INIT(n)                                                                    \
-	.clock =                                                                                   \
-		{                                                                                  \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),         \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
-	},                                                                                         \
-	PERI_INFO(n)
-#else
-#define UART_PERI_CLOCK_INIT(n)                                                                    \
-	.clock =                                                                                   \
-		{                                                                                  \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
-	},                                                                                         \
-	PERI_INFO(n)
-#endif
+#define UART_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n), PERI_INFO(n)
 
 #define INFINEON_CAT1_UART_INIT(n)                                                                 \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \

--- a/drivers/spi/spi_infineon_pdl.c
+++ b/drivers/spi/spi_infineon_pdl.c
@@ -718,28 +718,7 @@ static int ifx_cat1_spi_init(const struct device *dev)
 #define EN_XFER_SEPARATION enableTransferSeperation
 #endif
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define SPI_PERI_CLOCK_INIT(n)                                                                     \
-	.clock =                                                                                   \
-		{                                                                                  \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),         \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
-	},                                                                                         \
-	PERI_INFO(n)
-#else
-#define SPI_PERI_CLOCK_INIT(n)                                                                     \
-	.clock =                                                                                   \
-		{                                                                                  \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
-	},                                                                                         \
-	PERI_INFO(n)
-#endif
+#define SPI_PERI_CLOCK_INIT(n) .clock = IFX_CAT1_PERI_CLOCK_DT_INST_INIT(n), PERI_INFO(n)
 
 #if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
 #define ADVANCED_SPI_FIELDS(n)                                                                     \

--- a/dts/arm/infineon/cat1b/cyw20829/system_clocks.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/system_clocks.dtsi
@@ -149,6 +149,8 @@
 	};
 
 	peri0: peri0 {
+		compatible = "infineon,peri";
+
 		/* Peripheral 0, Clock Group 0 */
 		/* 24.5-bit */
 		peri0_group0_24_5bit_0: peri0_group0_24_5bit_0 {

--- a/dts/arm/infineon/cat1b/psc3/system_clocks.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/system_clocks.dtsi
@@ -171,6 +171,8 @@
 	};
 
 	peri0: peri0 {
+		compatible = "infineon,peri";
+
 		/* Peripheral 0, Clock Group 0 */
 		/* 24.5-bit */
 		peri0_group0_24_5bit_0: peri0_group0_24_5bit_0 {

--- a/dts/arm/infineon/edge/pse84/system_clocks.dtsi
+++ b/dts/arm/infineon/edge/pse84/system_clocks.dtsi
@@ -251,6 +251,8 @@
 	};
 
 	peri0: peri0 {
+		compatible = "infineon,peri";
+
 		/* Peripheral 0, Clock Group 1 */
 		/* 8-bit */
 		peri0_group1_8bit_0: peri0_group1_8bit_0 {
@@ -480,6 +482,8 @@
 	};
 
 	peri1: peri1 {
+		compatible = "infineon,peri";
+
 		/* Peripheral 1, Clock Group 1 */
 		/* 16.5-bit */
 		peri1_group1_16_5bit_0: peri1_group1_16_5bit_0 {

--- a/dts/arm/infineon/psoc4/psoc4100smax/system_clocks.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100smax/system_clocks.dtsi
@@ -72,6 +72,8 @@
 	};
 
 	peri_div: peri-div {
+		compatible = "infineon,peri";
+
 		peri_clk_div0: peri-clk-div0 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";

--- a/dts/arm/infineon/psoc4/psoc4100tp/system_clocks.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100tp/system_clocks.dtsi
@@ -72,6 +72,8 @@
 	};
 
 	peri_div: peri-div {
+		compatible = "infineon,peri";
+
 		peri_clk_div0: peri-clk-div0 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";

--- a/dts/bindings/clock/infineon,peri.yaml
+++ b/dts/bindings/clock/infineon,peri.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Infineon peripheral clock (PERI) instance.
+
+  Groups the programmable peripheral clock dividers belonging to one PERI
+  instance. Divider child nodes use the "infineon,peri-div" compatible and are
+  programmed by the driver bound to this node, so every "infineon,peri-div"
+  node must be a child of an "infineon,peri" node.
+
+  Peripherals reference an individual divider, not this node, for example:
+
+      peri0: peri0 {
+              compatible = "infineon,peri";
+
+              peri0_group1_8bit_0: peri0_group1_8bit_0 {
+                      compatible = "infineon,peri-div";
+                      peri-group = [00 01];
+                      div-type = <DIV_8_BIT>;
+                      channel = <0>;
+                      clock-div = <1>;
+                      status = "okay";
+              };
+      };
+
+      &uart0 {
+              clocks = <&peri0_group1_8bit_0>;
+      };
+
+compatible: "infineon,peri"
+
+include: [base.yaml]

--- a/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
+++ b/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
@@ -11,6 +11,8 @@
  * @ingroup clock_control_ifx_cat1
  */
 
+#include <zephyr/devicetree.h>
+
 #include <cy_sysclk.h>
 #include <cy_systick.h>
 
@@ -410,6 +412,56 @@ struct ifx_cat1_clock {
 	const void *funcs;               /**< Clock-specific functions. */
 };
 
+/** @cond INTERNAL_HIDDEN */
+#define IFX_CAT1_PERI_DIV_INST(node_id)  DT_PROP_BY_IDX(node_id, peri_group, 0)
+#define IFX_CAT1_PERI_DIV_GROUP(node_id) DT_PROP_BY_IDX(node_id, peri_group, 1)
+/** @endcond */
+
+/**
+ * @brief Static initializer for a struct ifx_cat1_clock describing a
+ *        peripheral clock divider.
+ *
+ * Decodes the @c peri-group, @c div-type and @c channel properties of an
+ * @c infineon,peri-div devicetree node. The encoding of the block field
+ * differs between EDGE and the other CAT1 devices; both are handled here so
+ * that consumers do not have to repeat the conditional.
+ *
+ * On devices without peripheral clock instances and groups (PSOC4) the
+ * @c peri-group property defaults to @c [00 00], which reduces the block
+ * encoding to the divider type alone.
+ *
+ * @param node_id Devicetree node identifier for an @c infineon,peri-div node.
+ */
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#define IFX_CAT1_PERI_CLOCK_DT_INIT(node_id)                                                       \
+	{                                                                                          \
+		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(IFX_CAT1_PERI_DIV_INST(node_id),         \
+							  IFX_CAT1_PERI_DIV_GROUP(node_id),        \
+							  DT_PROP(node_id, div_type)),             \
+		.channel = DT_PROP(node_id, channel),                                              \
+		.instance = IFX_CAT1_PERI_DIV_INST(node_id),                                       \
+		.group = IFX_CAT1_PERI_DIV_GROUP(node_id),                                         \
+	}
+#else
+#define IFX_CAT1_PERI_CLOCK_DT_INIT(node_id)                                                       \
+	{                                                                                          \
+		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(IFX_CAT1_PERI_DIV_GROUP(node_id),        \
+							  DT_PROP(node_id, div_type)),             \
+		.channel = DT_PROP(node_id, channel),                                              \
+		.instance = IFX_CAT1_PERI_DIV_INST(node_id),                                       \
+		.group = IFX_CAT1_PERI_DIV_GROUP(node_id),                                         \
+	}
+#endif
+
+/**
+ * @brief Static initializer for the divider referenced by the @c clocks
+ *        property of a @c DT_DRV_COMPAT instance.
+ *
+ * @param inst Instance number of the peripheral referencing the divider.
+ */
+#define IFX_CAT1_PERI_CLOCK_DT_INST_INIT(inst)                                                     \
+	IFX_CAT1_PERI_CLOCK_DT_INIT(DT_INST_PHANDLE(inst, clocks))
+
 /** @brief CAT1 resource instance descriptor. */
 struct ifx_cat1_resource_inst {
 	uint8_t type;      /**< The resource block type. */
@@ -420,17 +472,6 @@ struct ifx_cat1_resource_inst {
 	 */
 	uint8_t channel_num;
 };
-
-/**
- * @brief Get the frequency of a clock identified by its Devicetree ordinal.
- *
- * @param dt_ord Devicetree ordinal (dependency ordinal) of the clock node.
- * @param[out] frequency Resulting clock frequency, in Hz.
- *
- * @retval 0 on success.
- * @retval -errno Negative error code on failure.
- */
-int ifx_cat1_clock_control_get_frequency(uint32_t dt_ord, uint32_t *frequency);
 
 /**
  * @brief Get the frequency of a peripheral clock divider.


### PR DESCRIPTION
> [!NOTE]
> In draft, heavily used claude to do what I wanted it, but wanted to prototype
> this out quickly to prove out it was possible. Will clean up and de-LLM, with hardware
> testing being a priority.

Rather than having a driver per peri divider as we have today for PSoC parts, have a driver per peri block (typically one or two per part) which manages all the dividers that then feed out to peripheral blocks. 

In theory this should (I will measure it) reduce the footprint usage of our parts when many dividers are being used. It's very likely more reduction can be done by encoding the peri divider into a single word rather than a structure as done today, either with bitfields or explicit masks and shifts.

Do this, without breaking changes to board device tree descriptions which may have overridden which divider and divider value are being used for particular peripherals.

In the future each peri divider could easily have an attribute allowing for dynamic divider allocation. Each peri divider could also easily have an attribute allowing a divider to phase align itself to another.

Additionally cleans up some of the macros needed to create the opaque value for clock control today.