### PR TITLE
drivers: flash: nrf_rram: allow throttling with radio-sync

### DIFF
--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -82,6 +82,28 @@ int nrf_flash_sync_init(void);
 void nrf_flash_sync_set_context(uint32_t duration);
 
 /**
+ * Request a minimum spacing between consecutive execution windows.
+ *
+ * Used to spread the flash controller write current over time (throttling)
+ * while radio synchronization is active: the flash driver emits one write
+ * block per execution window and asks the backend to delay the next window by
+ * at least @p delay_us microseconds after the previous one has ended. This is
+ * how the throttling delay is realized on backends whose execution windows run
+ * in interrupt context, where sleeping in the flash operation itself is
+ * illegal.
+ *
+ * The setting applies to the next @ref nrf_flash_sync_exe() continuation and
+ * may be updated between execution windows. A backend that cannot control the
+ * inter-window spacing is free to treat this as a no-op (a @c __weak default
+ * that does exactly that is provided by the flash driver).
+ *
+ * @param delay_us Minimum delay between the end of one execution window and the
+ *                 start of the next [us]. Zero requests the next window as
+ *                 early as possible.
+ */
+void nrf_flash_sync_set_delay(uint32_t delay_us);
+
+/**
  * Check if the operation need to be run synchronous with radio.
  *
  * @retval True if operation need to be run synchronously, otherwise False

--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -152,46 +152,23 @@ static void commit_changes(off_t addr, size_t len)
 }
 #endif
 
+/*
+ * Write a single block of @p len bytes at @p addr.
+ * This primitive never sleeps, so it is safe to call from the
+ * radio-sync timeslot (interrupt) context via write_op().
+ */
 static void rram_write(off_t addr, const void *data, uint8_t fill_val, size_t len)
 {
-	size_t chunk_len = len;
-#if WRITE_BUFFER_ENABLE
-	/* Preserve the original write start address and length for commit_changes(). */
-	const off_t commit_addr = addr;
-	const size_t commit_len = len;
-#endif
-
-#ifdef CONFIG_SOC_FLASH_NRF_THROTTLING
-	while (len > 0) {
-		chunk_len = MIN(len, CONFIG_NRF_RRAM_THROTTLING_DATA_BLOCK * WRITE_LINE_SIZE);
-#endif /* CONFIG_SOC_FLASH_NRF_THROTTLING */
-		if (data) {
-			memcpy((void *)addr, data, chunk_len);
-		} else {
-			memset((void *)addr, fill_val, chunk_len);
-		}
-#ifdef CONFIG_SOC_FLASH_NRF_THROTTLING
-		addr += chunk_len;
-		/* Only advance the source pointer when we are actually
-		 * copying user data. The erase emulation path enters this
-		 * loop with data == NULL and relies on the if (data) test
-		 * above to keep dispatching to memset() for every chunk.
-		 * Unconditionally adding chunk_len would turn data into a
-		 * non-NULL bogus pointer for the next iteration and cause
-		 * memcpy() to read random bytes from low memory into RRAM.
-		 */
-		if (data != NULL) {
-			data = (const uint8_t *)data + chunk_len;
-		}
-		len -= chunk_len;
-		k_usleep(CONFIG_NRF_RRAM_THROTTLING_DELAY);
+	if (data) {
+		memcpy((void *)addr, data, len);
+	} else {
+		memset((void *)addr, fill_val, len);
 	}
-#endif /* CONFIG_SOC_FLASH_NRF_THROTTLING */
 
 	barrier_dmem_fence_full(); /* Barrier following our last write. */
 
 #if WRITE_BUFFER_ENABLE
-	commit_changes(commit_addr, commit_len);
+	commit_changes(addr, len);
 #endif
 }
 
@@ -213,7 +190,9 @@ static int write_op(void *context)
 	struct flash_context *w_ctx = context;
 	size_t len;
 
+#ifndef CONFIG_SOC_FLASH_NRF_THROTTLING
 	uint32_t i = 0U;
+#endif
 
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	/* Defensive re-program of RRAMC write mode at the start of every radio time slot.
@@ -236,15 +215,26 @@ static int write_op(void *context)
 
 		shift_write_context(len, w_ctx);
 
-		if (w_ctx->len > 0) {
-			i++;
+		if (w_ctx->len == 0) {
+			break;
+		}
 
-			if (w_ctx->enable_time_limit) {
-				if (nrf_flash_sync_check_time_limit(i)) {
-					return FLASH_OP_ONGOING;
-				}
+#ifdef CONFIG_SOC_FLASH_NRF_THROTTLING
+		/* Throttling: emit exactly one write block per timeslot and let
+		 * the sync backend space the next timeslot by the throttling
+		 * delay.
+		 */
+		nrf_flash_sync_set_delay(CONFIG_NRF_RRAM_THROTTLING_DELAY);
+		return FLASH_OP_ONGOING;
+#else
+		i++;
+
+		if (w_ctx->enable_time_limit) {
+			if (nrf_flash_sync_check_time_limit(i)) {
+				return FLASH_OP_ONGOING;
 			}
 		}
+#endif /* CONFIG_SOC_FLASH_NRF_THROTTLING */
 	}
 
 	return FLASH_OP_DONE;
@@ -265,6 +255,14 @@ static int write_synchronously(off_t addr, const void *data, uint8_t fill_val, s
 	nrf_flash_sync_set_context(FLASH_SLOT_WRITE);
 	return nrf_flash_sync_exe(&flash_op_desc);
 }
+
+#ifdef CONFIG_SOC_FLASH_NRF_THROTTLING
+/* Weak fallback for sync backends that cannot control inter-timeslot spacing */
+__weak void nrf_flash_sync_set_delay(uint32_t delay_us)
+{
+	ARG_UNUSED(delay_us);
+}
+#endif /* CONFIG_SOC_FLASH_NRF_THROTTLING */
 
 #endif /* !CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE */
 
@@ -304,7 +302,35 @@ static int nrf_write(off_t addr, const void *data, uint8_t fill_val, size_t len)
 	} else
 #endif /* !CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE */
 	{
+#ifdef CONFIG_SOC_FLASH_NRF_THROTTLING
+		/* Thread-context throttling: write one block at a time and
+		 * sleep in between to spread the RRAM write current over time.
+		 */
+		while (len > 0) {
+			size_t chunk_len =
+				MIN(len, CONFIG_NRF_RRAM_THROTTLING_DATA_BLOCK * WRITE_LINE_SIZE);
+
+			rram_write(addr, data, fill_val, chunk_len);
+
+			addr += chunk_len;
+			/* Only advance the source pointer for real data. The
+			 * erase-emulation path passes data == NULL and relies on
+			 * rram_write() dispatching to memset() for every chunk;
+			 * advancing NULL would fabricate a bogus pointer and turn
+			 * later chunks into memcpy() from low memory.
+			 */
+			if (data != NULL) {
+				data = (const uint8_t *)data + chunk_len;
+			}
+			len -= chunk_len;
+
+			if (len > 0 && !k_is_in_isr()) {
+				k_usleep(CONFIG_NRF_RRAM_THROTTLING_DELAY);
+			}
+		}
+#else
 		rram_write(addr, data, fill_val, len);
+#endif /* CONFIG_SOC_FLASH_NRF_THROTTLING */
 	}
 
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)


### PR DESCRIPTION
Make rram_write() a non-sleeping single-block primitive so it is safe to call from interrupt context.
The throttling delay is now realized by the callers: k_usleep() between blocks on the thread path.
Add as well a new nrf_flash_sync_set_delay() function that spaces timeslots on the radio-sync path.
This allows SOC_FLASH_NRF_THROTTLING and SOC_FLASH_NRF_RADIO_SYNC_MPSL to be enabled at the same time.