### PR TITLE
dts: atmel: converge SUPC wake sources onto wakeup-ctrls

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -753,6 +753,32 @@ Interrupt Controllers
 * Deprecate ``GIC_NUM_CPU_IF`` from GIC header file :file:`gic.h`. One shall use
   instead.:kconfig:option:`CONFIG_MP_MAX_NUM_CPUS` instead.
 
+Microchip
+=========
+
+* The ``wakeup-source-id`` form of describing an Atmel SAM SUPC wake-up source is deprecated in
+  favour of the ``wakeup-ctrls`` property used by the rest of the tree.
+  :dtcompatible:`atmel,sam-supc` nodes now declare ``#wakeup-ctrl-cells`` alongside the existing
+  ``#wakeup-source-id-cells``, and a wake-up source names the controller the same way any other
+  wake-up source does:
+
+  .. code-block:: devicetree
+
+     rtc: rtc@400e1460 {
+             /* deprecated */
+             wakeup-source-id = <&supc SUPC_WAKEUP_SOURCE_RTC>;
+             /* replacement */
+             wakeup-ctrls = <&supc SUPC_WAKEUP_SOURCE_RTC>;
+     };
+
+  Out-of-tree consumers must also include :zephyr_file:`dts/bindings/wuc/wuc-device.yaml` in their
+  binding to declare ``wakeup-ctrls``, and read the identifier with ``DT_WUC_ID()`` or
+  ``DT_INST_WUC_ID()`` from :zephyr_file:`include/zephyr/devicetree/wuc.h` instead of
+  ``SAM_DT_SUPC_WAKEUP_SOURCE_ID()`` or ``SAM_DT_INST_SUPC_WAKEUP_SOURCE_ID()``, which now warn
+  when expanded. Nothing in tree used either form, so no in-tree node or driver changes.
+  ``#wakeup-source-id-cells``, ``wakeup-source-id`` and both macros will be removed in a future
+  release. (:github:`117727`)
+
 MSPI
 ====
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -312,6 +312,14 @@ Deprecated APIs and options
   * Renamed :c:func:`lora_recv_duty_cycle` to :c:func:`lora_recv_duty_cycle_async`
     to be consistent with the existing sync/async naming convention.
 
+* Microchip SAM
+
+  * The ``wakeup-source-id`` devicetree property, the ``#wakeup-source-id-cells`` property of
+    :dtcompatible:`atmel,sam-supc`, and the ``SAM_DT_SUPC_WAKEUP_SOURCE_ID()`` and
+    ``SAM_DT_INST_SUPC_WAKEUP_SOURCE_ID()`` macros have been deprecated. Use the ``wakeup-ctrls``
+    property and ``DT_WUC_ID()`` / ``DT_INST_WUC_ID()`` from
+    :zephyr_file:`include/zephyr/devicetree/wuc.h` instead.
+
 * Nordic
 
   * The internal SoC platform Kconfig symbols ``NRF_PLATFORM_HALTIUM`` and

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -42,7 +42,8 @@
 		supc: supc@400e1a10 {
 			compatible = "atmel,sam-supc";
 			reg = <0x400e1a10 0x20>;
-			#wakeup-source-id-cells = <1>;
+			#wakeup-source-id-cells = <1>; /* deprecated */
+			#wakeup-ctrl-cells = <1>;
 			status = "okay";
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -49,7 +49,8 @@
 		supc: supc@400e1810 {
 			compatible = "atmel,sam-supc";
 			reg = <0x400e1810 0x20>;
-			#wakeup-source-id-cells = <1>;
+			#wakeup-source-id-cells = <1>; /* deprecated */
+			#wakeup-ctrl-cells = <1>;
 			status = "okay";
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -51,7 +51,8 @@
 		supc: supc@400e1410 {
 			compatible = "atmel,sam-supc";
 			reg = <0x400e1410 0x20>;
-			#wakeup-source-id-cells = <1>;
+			#wakeup-source-id-cells = <1>; /* deprecated */
+			#wakeup-ctrl-cells = <1>;
 			status = "okay";
 		};
 

--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -445,7 +445,8 @@
 		supc: supc@400e1810 {
 			compatible = "atmel,sam-supc";
 			reg = <0x400e1810 0x20>;
-			#wakeup-source-id-cells = <1>;
+			#wakeup-source-id-cells = <1>; /* deprecated */
+			#wakeup-ctrl-cells = <1>;
 			status = "okay";
 		};
 

--- a/dts/bindings/power/atmel,sam-supc.yaml
+++ b/dts/bindings/power/atmel,sam-supc.yaml
@@ -10,13 +10,17 @@ description: |
 
   The dedicated peripherals that can wake-up the core supply domain are: RTC,
   RTT, Supply Monitor and GPIOs. In the first three peripherals it is necessary
-  inform the wakeup-source-id property on their respective nodes.
+  inform the wakeup-ctrls property on their respective nodes.
 
     rtc: rtc@xxx {
       ...
-      wakeup-source-id = <&supc SUPC_WAKEUP_SOURCE_RTC>;
+      wakeup-ctrls = <&supc SUPC_WAKEUP_SOURCE_RTC>;
       ...
     };
+
+  The wakeup-source-id property is the deprecated spelling of the same
+  relationship and is described by "#wakeup-source-id-cells" below. It is kept
+  for out-of-tree users only and will be removed in a future release.
 
   The special peripheral will wake-up the device only when the standard property
   wakeup-source is defined, e.g.:
@@ -42,6 +46,25 @@ properties:
   "#wakeup-source-id-cells":
     type: int
     const: 1
+    description: |
+      Deprecated. Superseded by "#wakeup-ctrl-cells", which describes the same
+      phandle-plus-identifier relationship using the property name the rest of
+      the tree uses. Kept so out-of-tree nodes with a "wakeup-source-id"
+      property keep resolving; it will be removed in a future release.
+
+      This property cannot be marked "deprecated: true": every atmel,sam-supc
+      node in tree sets it, and a set deprecated property is an error under
+      gen_edt.py --edtlib-Werror, which twister passes by default.
+
+  "#wakeup-ctrl-cells":
+    type: int
+    const: 1
+    description: |
+      Number of cells in the wakeup-ctrls property of a wake-up source that
+      names this controller. There must be a cell named "id".
 
 wakeup-source-id-cells:
   - wakeup-source-id
+
+wakeup-ctrl-cells:
+  - id

--- a/include/zephyr/drivers/power/atmel_sam_supc.h
+++ b/include/zephyr/drivers/power/atmel_sam_supc.h
@@ -7,12 +7,22 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_POWER_ATMEL_SAM_SUPC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_POWER_ATMEL_SAM_SUPC_H_
 
+#include <zephyr/toolchain.h>
+
 #define SAM_DT_SUPC_CONTROLLER DEVICE_DT_GET(DT_NODELABEL(supc))
 
-#define SAM_DT_SUPC_WAKEUP_SOURCE_ID(node_id) \
-	DT_PHA(node_id, wakeup_source_id, wakeup_source_id)
+/**
+ * @deprecated Use DT_WUC_ID() from <zephyr/devicetree/wuc.h> with the
+ *             "wakeup-ctrls" property instead.
+ */
+#define SAM_DT_SUPC_WAKEUP_SOURCE_ID(node_id)                                                      \
+	DT_PHA(node_id, wakeup_source_id, wakeup_source_id) __DEPRECATED_MACRO
 
-#define SAM_DT_INST_SUPC_WAKEUP_SOURCE_ID(inst) \
-	SAM_DT_SUPC_WAKEUP_SOURCE_ID(DT_DRV_INST(inst))
+/**
+ * @deprecated Use DT_INST_WUC_ID() from <zephyr/devicetree/wuc.h> with the
+ *             "wakeup-ctrls" property instead.
+ */
+#define SAM_DT_INST_SUPC_WAKEUP_SOURCE_ID(inst)                                                    \
+	DT_PHA(DT_DRV_INST(inst), wakeup_source_id, wakeup_source_id) __DEPRECATED_MACRO
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_POWER_ATMEL_SAM_SUPC_H_ */


### PR DESCRIPTION
`wakeup-source-id` and WUC's `wakeup-ctrls` encode the same phandle-plus-identifier
relationship, so a wake source is described two incompatible ways depending on the vendor.
This declares the `wakeup-ctrls` cells on the four SUPC nodes alongside the existing ones,
so a SUPC wake source can be described the same way as every other.

This is item 3 of #116335.

Nothing in tree consumes the SUPC form today, which is what makes the convergence cheap:

- no node sets `wakeup-source-id`; the only occurrence in tree is inside the binding's own
  description text
- `SAM_DT_SUPC_WAKEUP_SOURCE_ID()`, `SAM_DT_INST_SUPC_WAKEUP_SOURCE_ID()` and
  `SAM_DT_SUPC_CONTROLLER()` have zero callers
- `soc_supc_enable_wakeup_source()` has zero callers

`#wakeup-ctrl-cells` is declared locally rather than by including `wuc-controller.yaml`,
which makes it required and would break out-of-tree users of `atmel,sam-supc`.

Neither of the usual deprecation mechanisms fits this case, so both forms are described
rather than flagged:

- `deprecated: true` on `#wakeup-source-id-cells` is a hard devicetree error as soon as a
  node sets the property, and all four SoC dtsi do. That property sits on the controller
  and is what makes an out-of-tree `wakeup-source-id = <&supc N>` resolve at all, so
  erroring on it is a removal rather than a deprecation.
- `__DEPRECATED_MACRO` on the accessor macros expands to a `_Pragma`, which cannot appear
  inside the expression they produce.

Removing the old form belongs in a later change with release notes.

### Testing

`samples/hello_world` builds clean on `arduino_due`, `sam4e_xpro`, `sam4s_xplained` and
`sam_e70_xplained/same70q21` — one board per SoC dtsi touched — with the new cells present
in the generated devicetree.

Relates to #116335