### PR TITLE
drivers: counter: nxp: arm the wakeup route from the wake-source flag only

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -29,14 +29,6 @@
 			      DT_CHOSEN(zephyr_system_timer))),		\
 		(0))
 
-/* True for the instance chosen as the system-timer low-power companion. */
-#if DT_HAS_CHOSEN(zephyr_system_timer_companion)
-#define COUNTER_MCUX_LPTMR_IS_COMPANION(n)				\
-	DT_SAME_NODE(DT_DRV_INST(n), DT_CHOSEN(zephyr_system_timer_companion))
-#else
-#define COUNTER_MCUX_LPTMR_IS_COMPANION(n) 0
-#endif /* DT_HAS_CHOSEN(zephyr_system_timer_companion) */
-
 #define COUNTER_MCUX_LPTMR_COUNT_USABLE(n) + (!COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n))
 
 #define COUNTER_MCUX_LPTMR_DEVICE_COUNT \
@@ -57,7 +49,6 @@ struct mcux_lptmr_config {
 	unsigned int irqn;
 	void (*irq_config_func)(const struct device *dev);
 	struct wuc_dt_spec wuc;
-	bool is_companion;
 	bool wakeup_source;
 };
 
@@ -187,12 +178,8 @@ static int mcux_lptmr_set_alarm(const struct device *dev, uint8_t chan_id,
 		return ret;
 	}
 
-	/*
-	 * Arm the wakeup controller so the alarm can wake the SoC: for the
-	 * system-timer companion, or when enabled as a wakeup source at run time.
-	 */
-	if (mcux_lptmr_is_wakeup_source(dev) &&
-	    (config->is_companion || pm_device_wakeup_is_enabled(dev))) {
+	/* Arm the wakeup controller so the alarm can wake the SoC. */
+	if (mcux_lptmr_is_wakeup_source(dev) && pm_device_wakeup_is_enabled(dev)) {
 		int err = wuc_enable_wakeup_source_dt(&config->wuc);
 
 		if (err != 0) {
@@ -626,7 +613,6 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		.irq_config_func = mcux_lptmr_irq_config_##n,			\
 		.wuc = COND_CODE_1(CONFIG_WUC,					\
 			(WUC_DT_SPEC_GET_OR(DT_DRV_INST(n), {0})), ({0})),	\
-		.is_companion = COUNTER_MCUX_LPTMR_IS_COMPANION(n),		\
 		.wakeup_source = DT_INST_PROP_OR(n, wakeup_source, 0),		\
 	};									\
 										\

--- a/drivers/counter/counter_nxp_irtc.c
+++ b/drivers/counter/counter_nxp_irtc.c
@@ -20,20 +20,11 @@ LOG_MODULE_REGISTER(nxp_irtc_counter, CONFIG_COUNTER_LOG_LEVEL);
 #define NXP_IRTC_OSC_FREQ 32768U
 #define NXP_IRTC_OSC_DIV  32U
 
-/* True for the instance chosen as the system-timer low-power companion. */
-#if DT_HAS_CHOSEN(zephyr_system_timer_companion)
-#define NXP_IRTC_IS_COMPANION(n)						\
-	DT_SAME_NODE(DT_DRV_INST(n), DT_CHOSEN(zephyr_system_timer_companion))
-#else
-#define NXP_IRTC_IS_COMPANION(n) 0
-#endif
-
 struct nxp_irtc_counter_config {
 	struct counter_config_info info;
 	RTC_Type *base;
 	void (*irq_config_func)(const struct device *dev);
 	struct wuc_dt_spec wuc;
-	bool is_companion;
 	bool wakeup_source;
 	/* Enable the OSC_DIV_ENA /32 prescaler (1024 Hz vs raw 32768 Hz). */
 	bool osc_div;
@@ -66,18 +57,12 @@ static inline bool nxp_irtc_is_wakeup_source(const struct device *dev)
 }
 
 /*
- * Arm the wakeup controller so the alarm can wake the SoC: for the system-timer
- * companion (which arms via the tickless idle path with no run-time enable), or
- * when enabled as a wakeup source at run time (pm_device_wakeup_enable()).
+ * Arm the wakeup controller so the alarm can wake the SoC when the counter
+ * is enabled as a wakeup source at run time (pm_device_wakeup_enable()).
  */
 static inline bool nxp_irtc_wake_via_wuc(const struct device *dev)
 {
-	const struct counter_config_info *info = dev->config;
-	const struct nxp_irtc_counter_config *config =
-		CONTAINER_OF(info, struct nxp_irtc_counter_config, info);
-
-	return nxp_irtc_is_wakeup_source(dev) &&
-	       (config->is_companion || pm_device_wakeup_is_enabled(dev));
+	return nxp_irtc_is_wakeup_source(dev) && pm_device_wakeup_is_enabled(dev);
 }
 
 /*
@@ -408,7 +393,6 @@ static DEVICE_API(counter, nxp_irtc_counter_driver_api) = {
 		.base = (RTC_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),                                \
 		.irq_config_func = nxp_irtc_counter_irq_config_##n,                                \
 		NXP_IRTC_COUNTER_WUC_INIT(n)                                                       \
-		.is_companion = NXP_IRTC_IS_COMPANION(n),                                          \
 		.wakeup_source = DT_INST_PROP_OR(n, wakeup_source, 0),                             \
 		.osc_div = DT_INST_PROP(n, osc_div),                                               \
 		.info =                                                                            \


### PR DESCRIPTION
Both drivers arm their WUU route when the instance is the chosen system-timer companion,
OR'd ahead of `pm_device_wakeup_is_enabled()`. That makes
`/chosen/zephyr,system-timer-companion` an implicit wake-enable the application cannot
decline, and its documented contract is only "keep time while the primary system timer is
inactive in low-power states".

@mathieuchopstm raised this on #116335 and opened #117274, which makes the generic hook
enable the counter as a wake source itself. That leaves the flag as the single control
point, so the special case in these two drivers can go.

The `is_companion` config member, the `*_IS_COMPANION()` macros and the disjunct all drop
out, leaving `pm_device_wakeup_is_enabled()` as the only gate.

Depends on #117274. Without it the companion counter is no longer armed at all, so this
should not land first.

### Testing

`tests/drivers/counter/counter_basic_api` builds clean on `frdm_mcxa153` and `frdm_mcxa577`
(LPTMR) and `mimxrt700_evk/mimxrt798s/cm33_cpu0` (IRTC).

Relates to #116335
