### PR TITLE
drivers: wifi: fix unused function warning in esp-hosted-mcu

### DIFF
--- a/drivers/wifi/esp_hosted_mcu/esp_hosted_mcu.c
+++ b/drivers/wifi/esp_hosted_mcu/esp_hosted_mcu.c
@@ -251,28 +251,6 @@ static enum wifi_security_type esp_hosted_mcu_map_security(int authmode)
 	}
 }
 
-/* Map a Zephyr security type to the esp_wifi wifi_auth_mode_t the soft-AP expects. */
-static int esp_hosted_mcu_ap_authmode(enum wifi_security_type security)
-{
-	switch (security) {
-	case WIFI_SECURITY_TYPE_NONE:
-		return 0; /* OPEN */
-	case WIFI_SECURITY_TYPE_WPA_PSK:
-		return 2; /* WPA_PSK */
-	case WIFI_SECURITY_TYPE_PSK:
-	case WIFI_SECURITY_TYPE_PSK_SHA256:
-		return 3; /* WPA2_PSK */
-	case WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL:
-		return 4; /* WPA_WPA2_PSK */
-	case WIFI_SECURITY_TYPE_SAE:
-	case WIFI_SECURITY_TYPE_SAE_H2E:
-	case WIFI_SECURITY_TYPE_SAE_AUTO:
-		return 6; /* WPA3_PSK */
-	default:
-		return -ENOTSUP;
-	}
-}
-
 static int esp_hosted_mcu_scan(const struct device *dev, struct net_if *iface,
 			       struct wifi_scan_params *params, scan_result_cb_t cb)
 {
@@ -448,6 +426,28 @@ static int esp_hosted_mcu_disconnect(const struct device *dev, struct net_if *if
 }
 
 #if defined(CONFIG_WIFI_ESP_HOSTED_MCU_AP_STA_MODE)
+/* Map a Zephyr security type to the esp_wifi wifi_auth_mode_t the soft-AP expects. */
+static int esp_hosted_mcu_ap_authmode(enum wifi_security_type security)
+{
+	switch (security) {
+	case WIFI_SECURITY_TYPE_NONE:
+		return 0; /* OPEN */
+	case WIFI_SECURITY_TYPE_WPA_PSK:
+		return 2; /* WPA_PSK */
+	case WIFI_SECURITY_TYPE_PSK:
+	case WIFI_SECURITY_TYPE_PSK_SHA256:
+		return 3; /* WPA2_PSK */
+	case WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL:
+		return 4; /* WPA_WPA2_PSK */
+	case WIFI_SECURITY_TYPE_SAE:
+	case WIFI_SECURITY_TYPE_SAE_H2E:
+	case WIFI_SECURITY_TYPE_SAE_AUTO:
+		return 6; /* WPA3_PSK */
+	default:
+		return -ENOTSUP;
+	}
+}
+
 static int esp_hosted_mcu_ap_enable(const struct device *dev, struct net_if *iface,
 				    struct wifi_connect_req_params *params)
 {


### PR DESCRIPTION
Move esp_hosted_mcu_ap_authmode() into the soft-AP Kconfig guard next to its only caller. Station-only builds compile out the AP management code and emitted an unused-function warning.