### PR TITLE
mgmt: hawkbit: Added TFM_BL2 to hawkbit dependencies Kconfig

### DIFF
--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -12,7 +12,7 @@ menuconfig HAWKBIT
 	depends on NETWORKING
 	depends on HTTP_CLIENT
 	depends on JSON_LIBRARY
-	depends on BOOTLOADER_MCUBOOT
+	depends on BOOTLOADER_MCUBOOT || TFM_BL2
 	depends on SMF
 	depends on SMF_ANCESTOR_SUPPORT
 	depends on !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP


### PR DESCRIPTION
If building with TF-M and BL2, BOOTLOADER_MCUBOOT is `n`. But, TF-M's BL2 is just a wrapper around mcuboot.
Hawkbit should be allowed if BOOTLOADER_MCUBOOT or TFM_BL2 are `y`.