### PR TITLE
doc: polling: small fixes

### DIFF
--- a/doc/kernel/services/polling.rst
+++ b/doc/kernel/services/polling.rst
@@ -72,7 +72,7 @@ Using k_poll()
 
 The main API is :c:func:`k_poll`, which operates on an array of poll events
 of type :c:struct:`k_poll_event`. Each entry in the array represents one
-event a call to :c:func:`k_poll` will wait for its condition to be
+event with a condition, which a call to :c:func:`k_poll` will wait for to be
 fulfilled.
 
 Poll events can be initialized using either the runtime initializers

--- a/doc/kernel/services/polling.rst
+++ b/doc/kernel/services/polling.rst
@@ -38,13 +38,13 @@ Each event must specify which **type** of condition must be satisfied so that
 its state is changed to signal the requested condition has been met.
 
 Each event must specify what **kernel object** it wants the condition to be
-satisfied.
+satisfied for.
 
 Each event must specify which **mode** of operation is used when the condition
 is satisfied.
 
 Each event can optionally specify a **tag** to group multiple events together,
-to the user's discretion.
+at the user's discretion.
 
 Apart from the kernel objects, there is also a **poll signal** pseudo-object
 type that be directly signaled.


### PR DESCRIPTION
* doc: polling: improve sentence clarity

  The structure of this sentence was a little convoluted, I think this one
  makes it clearer how events and conditions are related and what a call
  to `k_poll` waits for.

* doc: polling: cleanup grammar

  These are some grammar cleanups I made while reading the documentation.

preview:
https://builds.zephyrproject.io/zephyr/pr/117736/docs/kernel/services/polling.html