### PR TITLE
drivers: fix esp32p4 mipi-dsi display on v1.3 silicon

### DIFF
--- a/drivers/display/display_esp32_dsi.c
+++ b/drivers/display/display_esp32_dsi.c
@@ -25,6 +25,8 @@
 
 LOG_MODULE_REGISTER(display_esp32_dsi, CONFIG_DISPLAY_LOG_LEVEL);
 
+#define DISPLAY_ESP32_DSI_GDMA_CLK_TIMEOUT_US 1000
+
 struct display_esp32_dsi_config {
 	const struct device *panel;
 	uint8_t dma_channel;
@@ -245,6 +247,11 @@ static int display_esp32_dsi_dma_setup(const struct device *dev)
 	uint8_t ch = data->dma_channel;
 
 	dw_gdma_ll_enable_bus_clock(0, true);
+	if (!WAIT_FOR(dw_gdma_ll_is_bus_clock_enabled(0), DISPLAY_ESP32_DSI_GDMA_CLK_TIMEOUT_US,
+		      k_busy_wait(1))) {
+		LOG_ERR("GDMA bus clock did not come up");
+		return -ETIMEDOUT;
+	}
 	dw_gdma_ll_reset(dma);
 
 	dw_gdma_ll_enable_controller(dma, true);

--- a/drivers/mipi_dsi/dsi_esp32.c
+++ b/drivers/mipi_dsi/dsi_esp32.c
@@ -26,7 +26,13 @@ LOG_MODULE_REGISTER(dsi_esp32, CONFIG_MIPI_DSI_LOG_LEVEL);
 
 #define MIPI_DSI_DEFAULT_TIMEOUT_CLK_FREQ_MHZ 10
 #define MIPI_DSI_DEFAULT_ESCAPE_CLK_FREQ_MHZ  18
+#if defined(CONFIG_SOC_ESP32P4_REV_MIN_FULL) && CONFIG_SOC_ESP32P4_REV_MIN_FULL < 300
+#define MIPI_DSI_PHY_PLLREF_CLK_SRC           MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT_LEGACY
+#define MIPI_DSI_PHY_PLL_REF_CLK_FREQ_HZ      20000000
+#else
+#define MIPI_DSI_PHY_PLLREF_CLK_SRC           MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT
 #define MIPI_DSI_PHY_PLL_REF_CLK_FREQ_HZ      40000000
+#endif
 
 /* The PHY PLL only has settings for this range, and a rate outside it is
  * programmed with the wrong one rather than being rejected.
@@ -310,7 +316,7 @@ static int mipi_dsi_esp32_init(const struct device *dev)
 	mipi_dsi_ll_set_phy_config_clock_source(0, MIPI_DSI_PHY_CFG_CLK_SRC_DEFAULT);
 	mipi_dsi_ll_enable_phy_config_clock(0, true);
 
-	mipi_dsi_ll_set_phy_pllref_clock_source(0, MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT);
+	mipi_dsi_ll_set_phy_pllref_clock_source(0, MIPI_DSI_PHY_PLLREF_CLK_SRC);
 	mipi_dsi_ll_set_phy_pll_ref_clock_div(0, 1);
 	mipi_dsi_ll_enable_phy_pllref_clock(0, true);
 


### PR DESCRIPTION
Two fixes for the recently merged esp32p4 mipi-dsi display support, both hitting v1.3 silicon only. The dsi driver always selected the XTAL d-phy pll reference, which only exists on v3.0 and newer parts; on v1.3 the hal clock source switch falls through to abort() and the board panics before printing anything, which affects esp32p4_function_ev_board out of the box. The driver now picks the legacy PLL_F20M source and its 20 MHz rate when the minimum supported revision is below v3.0. The display driver also issued the gdma controller reset right after enabling its bus clock, and the reset can fault if it lands before the clock enable takes effect, so it now polls the clock readback before resetting.

Authored-by @beriberikix 