### PR TITLE
Use new I3C_MSG_NOACK_EXPECTED on MCTP I3C polling mode

### DIFF
--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -468,19 +468,22 @@ static inline int npcx_i3c_request_auto_ibi(struct i3c_reg *inst)
 /*
  * brief:  Controller emit start and send address
  *
- * param[in] inst     Pointer to I3C register.
- * param[in] addr     Dynamic address for xfer or 0x7E for CCC command.
- * param[in] op_type  Request type.
- * param[in] is_read  Read(true) or write(false) operation.
- * param[in] read_sz  Read size in bytes.
- *                    If op_tye is HDR-DDR, the read_sz must be the number of words.
+ * param[in] inst            Pointer to I3C register.
+ * param[in] addr            Dynamic address for xfer or 0x7E for CCC command.
+ * param[in] op_type         Request type.
+ * param[in] is_read         Read(true) or write(false) operation.
+ * param[in] read_sz         Read size in bytes.
+ *                           If op_tye is HDR-DDR, the read_sz must be the number of words.
+ * param[in] noack_expected  True if a NACK from the target is expected for this
+ *                           transfer, false otherwise.
  *
  * return  0, success
+ *         -ENODATA  If noack_expected is true and the target NACKs the address.
  *         else, error
  */
 static int npcx_i3c_request_emit_start(struct i3c_reg *inst, uint8_t addr,
 				       enum npcx_i3c_mctrl_type op_type, bool is_read,
-				       size_t read_sz)
+				       size_t read_sz, bool noack_expected)
 {
 	uint32_t mctrl = 0;
 	int ret;
@@ -513,6 +516,11 @@ static int npcx_i3c_request_emit_start(struct i3c_reg *inst, uint8_t addr,
 
 	/* Check NACK after MCTRLDONE is get */
 	if (IS_BIT_SET(inst->MERRWARN, NPCX_I3C_MERRWARN_NACK)) {
+		if (noack_expected) {
+			LOG_DBG("Address nacked (expected)");
+			return -ENODATA;
+		}
+
 		LOG_DBG("Address nacked");
 		return -ENODEV;
 	}
@@ -1041,14 +1049,18 @@ out_xfer_rd_fifo_dma:
  * param[in] buf         Buffer for data to be sent or received.
  * param[in] buf_sz      Buffer size in bytes.
  * param[in] is_read     True if this is a read transaction, false if write.
- * param[in] emit_start  True if START is needed before read/write.
- * param[in] emit_stop   True if STOP is needed after read/write.
+ * param[in] emit_start      True if START is needed before read/write.
+ * param[in] emit_stop       True if STOP is needed after read/write.
+ * param[in] noack_expected  True if a NACK from the target is expected for
+ *                           this transfer, false otherwise.
  *
  * return  Number of bytes read/written, or negative if error.
+ *         -ENODATA  If noack_expected is true and the target NACKs the transfer.
  */
 static int npcx_i3c_do_one_xfer_dma(const struct device *dev, uint8_t addr,
 				    enum npcx_i3c_mctrl_type op_type, uint8_t *buf, size_t buf_sz,
-				    bool is_read, bool emit_start, bool emit_stop, uint8_t hdr_cmd)
+				    bool is_read, bool emit_start, bool emit_stop, uint8_t hdr_cmd,
+				    bool noack_expected)
 {
 	const struct npcx_i3c_config *config = dev->config;
 	struct i3c_reg *inst = config->base;
@@ -1086,9 +1098,12 @@ static int npcx_i3c_do_one_xfer_dma(const struct device *dev, uint8_t addr,
 			inst->MWDATAB = hdr_cmd;
 		}
 
-		ret = npcx_i3c_request_emit_start(inst, addr, op_type, is_read, rd_len);
+		ret = npcx_i3c_request_emit_start(inst, addr, op_type, is_read, rd_len,
+						  noack_expected);
 		if (ret != 0) {
-			LOG_ERR("%s: emit start fail", __func__);
+			if (ret != -ENODATA) {
+				LOG_ERR("%s: emit start fail", __func__);
+			}
 			goto out_do_one_xfer_dma;
 		}
 	}
@@ -1136,15 +1151,19 @@ out_do_one_xfer_dma:
  * param[in] buf         Buffer for data to be sent or received.
  * param[in] buf_sz      Buffer size in bytes.
  * param[in] is_read     True if this is a read transaction, false if write.
- * param[in] emit_start  True if START is needed before read/write.
- * param[in] emit_stop   True if STOP is needed after read/write.
- * param[in] no_ending   True if not to signal end of write message.
+ * param[in] emit_start      True if START is needed before read/write.
+ * param[in] emit_stop       True if STOP is needed after read/write.
+ * param[in] no_ending       True if not to signal end of write message.
+ * param[in] noack_expected  True if a NACK from the target is expected for
+ *                           this transfer, false otherwise.
  *
  * return  Number of bytes read/written, or negative if error.
+ *         -ENODATA  If noack_expected is true and the target NACKs the transfer.
  */
 static int npcx_i3c_do_one_xfer(struct i3c_reg *inst, uint8_t addr,
 				enum npcx_i3c_mctrl_type op_type, uint8_t *buf, size_t buf_sz,
-				bool is_read, bool emit_start, bool emit_stop, bool no_ending)
+				bool is_read, bool emit_start, bool emit_stop, bool no_ending,
+				bool noack_expected)
 {
 	int ret = 0;
 
@@ -1153,9 +1172,12 @@ static int npcx_i3c_do_one_xfer(struct i3c_reg *inst, uint8_t addr,
 
 	/* Emit START if needed */
 	if (emit_start) {
-		ret = npcx_i3c_request_emit_start(inst, addr, op_type, is_read, buf_sz);
+		ret = npcx_i3c_request_emit_start(inst, addr, op_type, is_read, buf_sz,
+						  noack_expected);
 		if (ret != 0) {
-			LOG_ERR("%s: emit start fail", __func__);
+			if (ret != -ENODATA) {
+				LOG_ERR("%s: emit start fail", __func__);
+			}
 			goto out_do_one_xfer;
 		}
 	}
@@ -1275,6 +1297,8 @@ static int npcx_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 #ifdef CONFIG_I3C_NPCX_DMA
 		bool emit_start =
 			(i == 0) || ((msgs[i].flags & I3C_MSG_RESTART) == I3C_MSG_RESTART);
+		bool noack_expected =
+			(msgs[i].flags & I3C_MSG_NOACK_EXPECTED) == I3C_MSG_NOACK_EXPECTED;
 #endif
 
 		bool emit_stop = (msgs[i].flags & I3C_MSG_STOP) == I3C_MSG_STOP;
@@ -1327,7 +1351,7 @@ static int npcx_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 			if (!(msgs[i].flags & I3C_MSG_NBCH) && send_broadcast) {
 				ret = npcx_i3c_request_emit_start(inst, I3C_BROADCAST_ADDR,
 								  NPCX_I3C_MCTRL_TYPE_I3C, false,
-								  0);
+								  0, false);
 				if (ret < 0) {
 					LOG_ERR("%s: emit start of broadcast addr failed, error "
 						"(%d)",
@@ -1362,11 +1386,14 @@ static int npcx_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 		/* Do transfer with target device */
 		xfered_len = npcx_i3c_do_one_xfer_dma(dev, target->dynamic_addr, op_type,
 						      msgs[i].buf, msgs[i].len, is_read, emit_start,
-						      emit_stop, msgs[i].hdr_cmd_code);
+						      emit_stop, msgs[i].hdr_cmd_code,
+						      noack_expected);
 #endif
 
 		if (xfered_len < 0) {
-			LOG_ERR("%s: do xfer fail", __func__);
+			if (xfered_len != -ENODATA) {
+				LOG_ERR("%s: do xfer fail", __func__);
+			}
 			ret = xfered_len; /* Set error code to ret */
 			break;
 		}
@@ -1625,7 +1652,7 @@ static int npcx_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 
 	/* Write emit START and broadcast address (0x7E) */
 	ret = npcx_i3c_request_emit_start(inst, I3C_BROADCAST_ADDR, NPCX_I3C_MCTRL_TYPE_I3C, false,
-					  0);
+					  0, false);
 	if (ret < 0) {
 		LOG_ERR("CCC[0x%02x] %s START error (%d)", payload->ccc.id,
 			i3c_ccc_is_payload_broadcast(payload) ? "broadcast" : "direct", ret);
@@ -1688,7 +1715,7 @@ static int npcx_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 
 			xfered_len = npcx_i3c_do_one_xfer(
 				inst, tgt_payload->addr, NPCX_I3C_MCTRL_TYPE_I3C, tgt_payload->data,
-				tgt_payload->data_len, is_read, true, false, false);
+				tgt_payload->data_len, is_read, true, false, false, false);
 			if (xfered_len < 0) {
 				ret = xfered_len;
 				LOG_ERR("CCC[0x%02x] target payload error (%d)", payload->ccc.id,

--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -615,6 +615,9 @@ static inline int npcx_i3c_xfer_stop(struct i3c_reg *inst)
 	LOG_DBG("Current working state=%d", state);
 
 	switch (state) {
+	case MSTATUS_STATE_IDLE:
+		ret = 0;
+		break;
 	case MSTATUS_STATE_NORMACT: /* SDR */
 		ret = npcx_i3c_request_emit_stop(inst);
 		break;

--- a/subsys/pmci/mctp/mctp_i3c_controller.c
+++ b/subsys/pmci/mctp/mctp_i3c_controller.c
@@ -39,11 +39,15 @@ static inline void mctp_i3c_recv_msg(struct mctp_binding_i3c_controller *binding
 		.flags = I3C_MSG_READ | I3C_MSG_STOP,
 	};
 
+#ifdef CONFIG_MCTP_I3C_CONTROLLER_POLLING_MODE
+	msg.flags |= I3C_MSG_NOACK_EXPECTED;
+#endif /* CONFIG_MCTP_I3C_CONTROLLER_POLLING_MODE */
+
 	rc = i3c_transfer(dev, &msg, 1);
 	if (rc != 0) {
-#ifdef CONFIG_MCTP_I3C_CONTROLLER_IBI_MODE
-		LOG_ERR("Error requesting read from endpoint %d: %d", endpoint_idx, rc);
-#endif /*CONFIG_MCTP_I3C_CONTROLLER_IBI_MODE*/
+		if (rc != -ENODATA) {
+			LOG_ERR("Error requesting read from endpoint %d: %d", endpoint_idx, rc);
+		}
 		return;
 	}
 


### PR DESCRIPTION
Since #117367 it is now possible to ask the I3C controller driver to ignore expected NACKs that will happen when MCTP over I3C polling mode is used.

This patch was tested on a NPCX4 - so the npcx driver was also updated to handle the new flag.

While at it, another spurious warning message was silenced.