### PR TITLE
boards: weact: blackpill_f411ce: add STM32CubeProgrammer support

### DIFF
--- a/boards/weact/blackpill_f411ce/board.cmake
+++ b/boards/weact/blackpill_f411ce/board.cmake
@@ -2,8 +2,10 @@
 
 board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32F411CE" "--speed=4000")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)


### PR DESCRIPTION
## Summary

Add STM32CubeProgrammer as an SWD flashing option for the
WeAct Black Pill F411CE board.

This allows the board to be flashed with an ST-Link using:

`west flash --runner stm32cubeprogrammer`

## Testing

Tested on a WeAct Black Pill STM32F411CE with an ST-Link.

Verified:
- `samples/basic/blinky`
- repeated flashing
- flashing after a power cycle
- local Zephyr compliance checks