### PR TITLE
Build System: adding support for calling git_describe on files

### DIFF
--- a/cmake/gen_version_h.cmake
+++ b/cmake/gen_version_h.cmake
@@ -14,8 +14,7 @@ else()
 endif()
 
 if(NOT DEFINED ${BUILD_VERSION_NAME})
-  cmake_path(GET VERSION_FILE PARENT_PATH work_dir)
-  git_describe(${work_dir} ${BUILD_VERSION_NAME})
+  git_describe(${VERSION_FILE} ${BUILD_VERSION_NAME})
 endif()
 
 include(${ZEPHYR_BASE}/cmake/modules/version.cmake)

--- a/cmake/modules/git.cmake
+++ b/cmake/modules/git.cmake
@@ -14,21 +14,23 @@ Commands
 
 .. cmake:command:: git_describe
 
-   Get a short Git description associated with a directory.
+   Get a short Git description associated with a directory or file.
 
    .. code-block:: cmake
 
-     git_describe(DIR OUTPUT)
+     git_describe(<file|dir> OUTPUT)
 
-   This function runs ``git describe --abbrev=12 --always`` in the specified
-   directory and stores the result in the provided output variable.
+   This function runs ``git describe --abbrev=12 --always`` on the provided
+   directory, or if provided a file, the directory containing that file.
+   In both cases, the result is stored in the provided output variable.
 
-   ``DIR``
-     The directory to run the git command in.
+   ``file|dir``
+     The directory or file to run the git command for.
 
    ``OUTPUT``
      The variable name where the git description will be stored.
-     If the git command fails, this variable will not be set.
+     If the git command fails or Git is not found, this variable
+     will not be set.
 
    The function will output status messages if:
 
@@ -54,17 +56,23 @@ include_guard(GLOBAL)
 find_package(Git QUIET)
 
 # Usage:
-#   git_describe(<dir> <output>)
+#   git_describe(<file|dir> <output>)
 #
-# Helper function to get a short GIT description associated with a directory.
-# OUTPUT is set to the output of `git describe --abbrev=12 --always` as run
-# from DIR.
+# Helper function to get a short GIT description associated with a directory
+# or file. OUTPUT is set to the output of `git describe --abbrev=12 --always`
+# as run from the provided file or directory.
 #
-function(git_describe DIR OUTPUT)
+function(git_describe ARG OUTPUT)
+  if(IS_DIRECTORY "${ARG}")
+    set(dir "${ARG}")
+  else()
+    cmake_path(GET ARG PARENT_PATH dir)
+  endif()
+
   if(GIT_FOUND)
     execute_process(
       COMMAND ${GIT_EXECUTABLE} describe --abbrev=12 --always
-      WORKING_DIRECTORY                ${DIR}
+      WORKING_DIRECTORY                ${dir}
       OUTPUT_VARIABLE                  DESCRIPTION
       OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_STRIP_TRAILING_WHITESPACE
@@ -72,7 +80,7 @@ function(git_describe DIR OUTPUT)
       RESULT_VARIABLE                  return_code
     )
     if(return_code)
-      message(STATUS "git describe failed: ${stderr}")
+      message(STATUS "git describe failed in ${dir}: ${stderr}")
     elseif(NOT "${stderr}" STREQUAL "")
       message(STATUS "git describe warned: ${stderr}")
     else()


### PR DESCRIPTION
This changes the git_describe CMake function to accept files, not just directories. When given a file, git_describe finds the directory containing that file and runs git describe there.

For example, suppose a file "foo" lives inside a cloned git repository, and you want to know which version of that repository your foo is from. You can now call git_describe directly on foo, and it will locate the containing directory and run git describe there, no need to determine the directory yourself.

For additional context, and a scenario where this might be helpful, this was created while working on this PR: #110386