### PR TITLE
drivers: mfd: max2221x: Fix register definitions

### DIFF
--- a/drivers/misc/max2221x/max2221x.c
+++ b/drivers/misc/max2221x/max2221x.c
@@ -196,7 +196,7 @@ int max2221x_read_status(const struct device *dev, uint16_t *status)
 	int ret;
 	const struct misc_max2221x_config *config = dev->config;
 
-	ret = max2221x_reg_read(config->parent, MAX2221X_REG_GLOBAL_CFG, status);
+	ret = max2221x_reg_read(config->parent, MAX2221X_REG_STATUS, status);
 	if (ret) {
 		return ret;
 	}

--- a/include/zephyr/drivers/mfd/max2221x.h
+++ b/include/zephyr/drivers/mfd/max2221x.h
@@ -46,8 +46,10 @@ extern "C" {
 #define MAX2221X_REG_GLOBAL_CFG      0x01
 /** Status register address. */
 #define MAX2221X_REG_STATUS          0x02
+/** Satus configuration register address. */
+#define MAX2221X_REG_STATUS_CFG      0x03
 /** Demagnetization duty cycle high-to-low register address. */
-#define MAX2221X_REG_DC_H2L          0x03
+#define MAX2221X_REG_DC_H2L          0x04
 /** Voltage monitor register address. */
 #define MAX2221X_REG_VM_MONITOR      0x05
 /** Voltage monitor threshold register address. */
@@ -86,7 +88,7 @@ extern "C" {
  * @brief Channel PWM duty cycle register address
  * @param x Channel number
  */
-#define MAX2221X_REG_PWM_DUTY(x)     (0x49 + ((x) * 0xE))
+#define MAX2221X_REG_PWM_DUTY(x)     (0x49 + ((x) * 0x09))
 /** Fault 0 register address. */
 #define MAX2221X_REG_FAULT0          0x65
 /** Fault 1 register address. */


### PR DESCRIPTION
The max2221x mfd driver uses the wrong register for checking device status, and the wrong stride for accessing the PWM duty register of each channel. Fix it by updating register map.