### PR TITLE
boards: alif: ensemble_e1c_dk/balletto_b1_dk: Add support for GPIO controllers and on-board LED/button

### DIFF
--- a/boards/alif/balletto_b1_dk/balletto_b1_dk-pinctrl.dtsi
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk-pinctrl.dtsi
@@ -34,4 +34,26 @@
 			drive-strength = <12>;
 		};
 	};
+
+	pinctrl_gpio4: pinctrl_gpio4 {
+		group0 {
+			/* Multicolor LED0: blue on P4_3, green on P4_5, red on P4_7 */
+			pinmux = <PIN_P4_3__GPIO>,
+				 <PIN_P4_5__GPIO>,
+				 <PIN_P4_7__GPIO>;
+		};
+	};
+
+	pinctrl_gpio5: pinctrl_gpio5 {
+		group0 {
+			/* Navigation joystick JOY_SW1 to JOY_SW5 on SW3 */
+			pinmux = <PIN_P5_0__GPIO>,
+				 <PIN_P5_4__GPIO>,
+				 <PIN_P5_5__GPIO>,
+				 <PIN_P5_6__GPIO>,
+				 <PIN_P5_7__GPIO>;
+			input-enable;
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
@@ -6,6 +6,8 @@
 /dts-v1/;
 
 #include <alif/balletto/ab1c1f4m51820ph0.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "balletto_b1_dk-pinctrl.dtsi"
 
 / {
@@ -17,11 +19,89 @@
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
+
+	aliases {
+		led0 = &led_red;
+		led1 = &led_blue;
+		led2 = &led_green;
+		sw0 = &joy_center;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_red: led_0 {
+			gpios = <&gpio4 7 GPIO_ACTIVE_HIGH>;
+			label = "LED0_R";
+		};
+
+		led_blue: led_1 {
+			gpios = <&gpio4 3 GPIO_ACTIVE_HIGH>;
+			label = "LED0_B";
+		};
+
+		led_green: led_2 {
+			gpios = <&gpio4 5 GPIO_ACTIVE_HIGH>;
+			label = "LED0_G";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		/*
+		 * The DesignWare GPIO driver does not implement both
+		 * edge triggering, which the interrupt driven mode of
+		 * the GPIO keys driver needs.
+		 */
+		polling-mode;
+
+		joy_down: joy_down {
+			gpios = <&gpio5 0 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW1";
+			zephyr,code = <INPUT_KEY_DOWN>;
+		};
+
+		joy_left: joy_left {
+			gpios = <&gpio5 4 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW2";
+			zephyr,code = <INPUT_KEY_LEFT>;
+		};
+
+		joy_right: joy_right {
+			gpios = <&gpio5 5 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW3";
+			zephyr,code = <INPUT_KEY_RIGHT>;
+		};
+
+		joy_up: joy_up {
+			gpios = <&gpio5 6 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW4";
+			zephyr,code = <INPUT_KEY_UP>;
+		};
+
+		joy_center: joy_center {
+			gpios = <&gpio5 7 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW5";
+			zephyr,code = <INPUT_KEY_ENTER>;
+		};
+	};
 };
 
 &uart2 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-names = "default";
+};
+
+&gpio4 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_gpio4>;
+	pinctrl-names = "default";
+};
+
+&gpio5 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_gpio5>;
 	pinctrl-names = "default";
 };
 

--- a/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.yaml
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.yaml
@@ -9,4 +9,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk-pinctrl.dtsi
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk-pinctrl.dtsi
@@ -34,4 +34,26 @@
 			drive-strength = <12>;
 		};
 	};
+
+	pinctrl_gpio4: pinctrl_gpio4 {
+		group0 {
+			/* Multicolor LED0: blue on P4_3, green on P4_5, red on P4_7 */
+			pinmux = <PIN_P4_3__GPIO>,
+				 <PIN_P4_5__GPIO>,
+				 <PIN_P4_7__GPIO>;
+		};
+	};
+
+	pinctrl_gpio5: pinctrl_gpio5 {
+		group0 {
+			/* Navigation joystick JOY_SW1 to JOY_SW5 on SW3 */
+			pinmux = <PIN_P5_0__GPIO>,
+				 <PIN_P5_4__GPIO>,
+				 <PIN_P5_5__GPIO>,
+				 <PIN_P5_6__GPIO>,
+				 <PIN_P5_7__GPIO>;
+			input-enable;
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
@@ -7,6 +7,8 @@
 
 #include <alif/ensemble/ae1c1f4051920ph0.dtsi>
 #include <alif/ensemble/ae1c1f4051920ph0_nvic_irq.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "ensemble_e1c_dk-pinctrl.dtsi"
 
 / {
@@ -18,11 +20,89 @@
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
+
+	aliases {
+		led0 = &led_red;
+		led1 = &led_blue;
+		led2 = &led_green;
+		sw0 = &joy_center;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_red: led_0 {
+			gpios = <&gpio4 7 GPIO_ACTIVE_HIGH>;
+			label = "LED0_R";
+		};
+
+		led_blue: led_1 {
+			gpios = <&gpio4 3 GPIO_ACTIVE_HIGH>;
+			label = "LED0_B";
+		};
+
+		led_green: led_2 {
+			gpios = <&gpio4 5 GPIO_ACTIVE_HIGH>;
+			label = "LED0_G";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		/*
+		 * The DesignWare GPIO driver does not implement both
+		 * edge triggering, which the interrupt driven mode of
+		 * the GPIO keys driver needs.
+		 */
+		polling-mode;
+
+		joy_down: joy_down {
+			gpios = <&gpio5 0 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW1";
+			zephyr,code = <INPUT_KEY_DOWN>;
+		};
+
+		joy_left: joy_left {
+			gpios = <&gpio5 4 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW2";
+			zephyr,code = <INPUT_KEY_LEFT>;
+		};
+
+		joy_right: joy_right {
+			gpios = <&gpio5 5 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW3";
+			zephyr,code = <INPUT_KEY_RIGHT>;
+		};
+
+		joy_up: joy_up {
+			gpios = <&gpio5 6 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW4";
+			zephyr,code = <INPUT_KEY_UP>;
+		};
+
+		joy_center: joy_center {
+			gpios = <&gpio5 7 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW5";
+			zephyr,code = <INPUT_KEY_ENTER>;
+		};
+	};
 };
 
 &uart2 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-names = "default";
+};
+
+&gpio4 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_gpio4>;
+	pinctrl-names = "default";
+};
+
+&gpio5 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_gpio5>;
 	pinctrl-names = "default";
 };
 

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.yaml
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.yaml
@@ -9,4 +9,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/dts/arm/alif/balletto/common/balletto_common.dtsi
+++ b/dts/arm/alif/balletto/common/balletto_common.dtsi
@@ -188,6 +188,173 @@
 			reg = <0x49011000 0x1000>;
 			status = "disabled";
 		};
+
+		gpio0: gpio@49000000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49000000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <179 0>,
+				     <180 0>,
+				     <181 0>,
+				     <182 0>,
+				     <183 0>,
+				     <184 0>,
+				     <185 0>,
+				     <186 0>;
+			status = "disabled";
+		};
+
+		gpio1: gpio@49001000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49001000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <187 0>,
+				     <188 0>,
+				     <189 0>,
+				     <190 0>,
+				     <191 0>,
+				     <192 0>,
+				     <193 0>,
+				     <194 0>;
+			status = "disabled";
+		};
+
+		gpio2: gpio@49002000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49002000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <195 0>,
+				     <196 0>,
+				     <197 0>,
+				     <198 0>,
+				     <199 0>,
+				     <200 0>,
+				     <201 0>,
+				     <202 0>;
+			status = "disabled";
+		};
+
+		gpio3: gpio@49003000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49003000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <203 0>,
+				     <204 0>,
+				     <205 0>,
+				     <206 0>,
+				     <207 0>,
+				     <208 0>,
+				     <209 0>,
+				     <210 0>;
+			status = "disabled";
+		};
+
+		gpio4: gpio@49004000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49004000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <211 0>,
+				     <212 0>,
+				     <213 0>,
+				     <214 0>,
+				     <215 0>,
+				     <216 0>,
+				     <217 0>,
+				     <218 0>;
+			status = "disabled";
+		};
+
+		gpio5: gpio@49005000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49005000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <219 0>,
+				     <220 0>,
+				     <221 0>,
+				     <222 0>,
+				     <223 0>,
+				     <224 0>,
+				     <225 0>,
+				     <226 0>;
+			status = "disabled";
+		};
+
+		gpio6: gpio@49006000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49006000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <227 0>,
+				     <228 0>,
+				     <229 0>,
+				     <230 0>,
+				     <231 0>,
+				     <232 0>,
+				     <233 0>,
+				     <234 0>;
+			status = "disabled";
+		};
+
+		gpio7: gpio@49007000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49007000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <235 0>,
+				     <236 0>,
+				     <237 0>,
+				     <238 0>,
+				     <239 0>,
+				     <240 0>,
+				     <241 0>,
+				     <242 0>;
+			status = "disabled";
+		};
+
+		gpio8: gpio@49008000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x49008000 0x1000>;
+			ngpios = <8>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <243 0>,
+				     <244 0>,
+				     <245 0>,
+				     <246 0>,
+				     <247 0>,
+				     <248 0>,
+				     <249 0>,
+				     <250 0>;
+			status = "disabled";
+		};
+
+		/*
+		 * LPGPIO sits in the Always-On domain and is reached through a
+		 * separate pin control region. It is two pins wide.
+		 */
+		lpgpio: gpio@42002000 {
+			compatible = "snps,designware-gpio";
+			reg = <0x42002000 0x1000>;
+			ngpios = <2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupts = <171 0>, <172 0>;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
## Summary
 
Adds devicetree support for the GPIO controllers on the Alif Balletto SoC family, and enables the multicolor LED and the 5-position navigation joystick on both the Ensemble E1C DevKit and the Balletto B1 DevKit.
 
Follow-on to https://github.com/zephyrproject-rtos/zephyr/pull/117338  (Ensemble GPIO controllers and E8 AppKit LED/button), already merged. The Ensemble GPIO nodes landed there; this adds the equivalent for Balletto and wires up the two DevKits. Devicetree and board enablement only, no driver changes.

## Contents
 
Three commits:

1. `dts: arm: alif: ensemble_e1c_dk: enable GPIO, LED and button` - Enable the three LED channels on GPIO4 and all five joystick switches on GPIO5.    
2. `dts: arm: alif: balletto: add GPIO controller nodes` - Add GPIO0 to GPIO8 and LPGPIO, the full set the B1 carries.     
3. `boards: alif: balletto_b1_dk: enable GPIO, LED and button` -  same wiring as the E1C DevKit.

## Testing
 
Following samples were tested on an Ensemble E1C DevKit and a Balletto B1 DevKit:
 
  - `samples/basic/blinky` - works with red as the default `led0` and green and blue exercised via overlays
  - `samples/basic/button` - all five joystick positions report the expected key codes on press and release.
  
## Known limitations
  
- GPIO interrupts are described for completeness but the hardware requires the GPIO debounce logic to be enabled for interrupt detection to work correctly, which needs the debounce clock running. That clock is off after reset. Enabling it is left to a follow-up.
- The joystick keys are polled (using the standard `polling-mode` property of the `gpio-keys` driver), not interrupt driven. The DesignWare GPIO driver does not implement both-edge triggering, which the interrupt driven mode of the gpio-keys driver requires. 



