### PR TITLE
shell: kernel_service: add kernel thread top shell command

### DIFF
--- a/samples/subsys/shell/thread_top/CMakeLists.txt
+++ b/samples/subsys/shell/thread_top/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Nerijus Bendžiūnas
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(thread_top)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/shell/thread_top/README.rst
+++ b/samples/subsys/shell/thread_top/README.rst
@@ -1,0 +1,64 @@
+.. zephyr:code-sample:: shell-thread-top
+   :name: kernel thread top shell
+   :relevant-api: shell_api thread_apis
+
+   Watch synthetic CPU load threads with the ``kernel thread top`` command.
+
+Overview
+********
+
+This sample starts three named load threads with known CPU consumption so
+that the ``kernel thread top`` shell command has something interesting to
+show:
+
+* ``load_50_percent`` (priority 10) burns 50% of the CPU in 100 ms periods.
+* ``load_25_percent`` (priority 11) burns 25% of the CPU in 100 ms periods.
+* ``load_remainder`` (lowest application priority) never sleeps and soaks
+  up whatever CPU is left, driving the idle percentage close to zero.
+
+The duty-cycle threads measure their busy window with their own runtime
+statistics rather than wall-clock time, so the displayed percentages match
+the thread names even while higher priority threads preempt them.
+
+The shell thread priority is raised above the load threads so the shell
+stays responsive while ``load_remainder`` spins.
+
+Building and Running
+********************
+
+Build for a QEMU target and run:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/shell/thread_top
+   :host-os: unix
+   :board: qemu_cortex_m3
+   :goals: run
+   :compact:
+
+Then start the live view in the shell (refresh interval in seconds is
+optional, default 3):
+
+.. code-block:: console
+
+   uart:~$ kernel thread top -d 1
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   top - uptime 4.110 s, refresh 2 s, press 'q' to quit
+   Threads: 6 total, CPU: 100.0% busy, 0.0% idle
+
+    %CPU  PRIO  STATE       STACK%  NAME
+    46.3    10  queued         23%  load_50_percent
+    30.7    14  queued          9%  load_remainder
+    22.4    11  sleeping       23%  load_25_percent
+     0.4    -1  queued         59%  sysworkq
+     0.0     5  pending        32%  shell_uart
+     0.0    15                 18%  idle
+
+The duty-cycle percentages read slightly below their nominal values because
+shell rendering time slightly stretches each 100 ms load period.
+
+Press :kbd:`q` to quit back to the shell prompt.

--- a/samples/subsys/shell/thread_top/prj.conf
+++ b/samples/subsys/shell/thread_top/prj.conf
@@ -1,0 +1,22 @@
+CONFIG_PRINTK=y
+CONFIG_SHELL=y
+CONFIG_KERNEL_SHELL=y
+CONFIG_THREAD_MONITOR=y
+CONFIG_THREAD_NAME=y
+CONFIG_INIT_STACKS=y
+CONFIG_THREAD_STACK_INFO=y
+
+# Keep THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS disabled: the stats then
+# use the system clock cycle counter, which also works on QEMU targets
+# where the DWT cycle counter is not emulated.
+CONFIG_THREAD_RUNTIME_STATS=y
+
+# Keep the shell responsive above the always-spinning load thread.
+CONFIG_SHELL_THREAD_PRIORITY_OVERRIDE=y
+CONFIG_SHELL_THREAD_PRIORITY=5
+
+# Round-robin threads that share the lowest application priority (e.g. the
+# logging thread) so the greedy load thread cannot starve them.
+CONFIG_TIMESLICING=y
+CONFIG_TIMESLICE_SIZE=10
+CONFIG_TIMESLICE_PRIORITY=0

--- a/samples/subsys/shell/thread_top/src/main.c
+++ b/samples/subsys/shell/thread_top/src/main.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Nerijus Bendžiūnas
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+#define LOAD_THREAD_STACK_SIZE 1024
+#define LOAD_PERIOD_MS         100
+
+/*
+ * Spin until this thread has consumed the given number of milliseconds of
+ * CPU time, measured with its own runtime stats rather than wall-clock
+ * time. A wall-clock busy-wait would under-deliver whenever a higher
+ * priority load thread preempts this one, and the displayed percentages
+ * would no longer match the thread names.
+ */
+static void burn_cpu_ms(uint32_t budget_ms)
+{
+	k_thread_runtime_stats_t start_stats;
+	k_thread_runtime_stats_t now_stats;
+	uint64_t budget_cycles;
+
+	/*
+	 * Thread stats count the same cycle source as sys_clock_hw_cycles
+	 * because this sample keeps THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
+	 * disabled.
+	 */
+	budget_cycles = ((uint64_t)sys_clock_hw_cycles_per_sec() * budget_ms) / MSEC_PER_SEC;
+
+	k_thread_runtime_stats_get(k_current_get(), &start_stats);
+	do {
+		k_busy_wait(500);
+		k_thread_runtime_stats_get(k_current_get(), &now_stats);
+	} while ((now_stats.execution_cycles - start_stats.execution_cycles) < budget_cycles);
+}
+
+static void duty_cycle_thread(void *percent_ptr, void *unused1, void *unused2)
+{
+	uint32_t busy_percent = POINTER_TO_UINT(percent_ptr);
+	uint32_t budget_ms = (LOAD_PERIOD_MS * busy_percent) / 100U;
+
+	ARG_UNUSED(unused1);
+	ARG_UNUSED(unused2);
+
+	while (true) {
+		int64_t period_start = k_uptime_get();
+		int64_t elapsed;
+
+		burn_cpu_ms(budget_ms);
+
+		elapsed = k_uptime_get() - period_start;
+		if (elapsed < LOAD_PERIOD_MS) {
+			k_msleep(LOAD_PERIOD_MS - elapsed);
+		}
+	}
+}
+
+static void greedy_thread(void *unused1, void *unused2, void *unused3)
+{
+	ARG_UNUSED(unused1);
+	ARG_UNUSED(unused2);
+	ARG_UNUSED(unused3);
+
+	/* Never sleeps: soaks up whatever CPU the other threads leave over. */
+	while (true) {
+		k_busy_wait(1000);
+	}
+}
+
+K_THREAD_DEFINE(load_50_percent, LOAD_THREAD_STACK_SIZE, duty_cycle_thread, UINT_TO_POINTER(50),
+		NULL, NULL, 10, 0, 0);
+K_THREAD_DEFINE(load_25_percent, LOAD_THREAD_STACK_SIZE, duty_cycle_thread, UINT_TO_POINTER(25),
+		NULL, NULL, 11, 0, 0);
+K_THREAD_DEFINE(load_remainder, LOAD_THREAD_STACK_SIZE, greedy_thread, NULL, NULL, NULL,
+		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
+
+int main(void)
+{
+	printk("Synthetic load threads running:\n");
+	printk("  load_50_percent (prio 10) burns 50%% CPU\n");
+	printk("  load_25_percent (prio 11) burns 25%% CPU\n");
+	printk("  load_remainder  (prio %d) spins for the rest\n",
+	       K_LOWEST_APPLICATION_THREAD_PRIO);
+	printk("Watch them with: kernel thread top\n");
+
+	return 0;
+}

--- a/samples/subsys/shell/thread_top/tests.yaml
+++ b/samples/subsys/shell/thread_top/tests.yaml
@@ -1,0 +1,14 @@
+sample:
+  name: thread_top
+  description: Demonstrate the 'kernel thread top' shell command with
+    synthetic CPU load threads
+common:
+  harness: keyboard
+  tags:
+    - shell
+tests:
+  sample.shell.thread_top:
+    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
+    integration_platforms:
+      - qemu_cortex_m3
+      - nucleo_l432kc

--- a/subsys/shell/modules/kernel_service/thread/CMakeLists.txt
+++ b/subsys/shell/modules/kernel_service/thread/CMakeLists.txt
@@ -22,3 +22,5 @@ zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_SUSPEND suspend.c)
 zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_RESUME resume.c)
 
 zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_KILL kill.c)
+
+zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_TOP top.c)

--- a/subsys/shell/modules/kernel_service/thread/Kconfig
+++ b/subsys/shell/modules/kernel_service/thread/Kconfig
@@ -78,3 +78,24 @@ config KERNEL_THREAD_SHELL_KILL
 	select KERNEL_THREAD_SHELL
 	help
 	  Internal helper macro to compile the 'kill' subcommad
+
+config KERNEL_THREAD_SHELL_TOP
+	bool
+	default y
+	depends on THREAD_MONITOR
+	depends on THREAD_RUNTIME_STATS
+	depends on SCHED_THREAD_USAGE_ALL
+	depends on !SHELL_REMOTE_CLI
+	select KERNEL_THREAD_SHELL
+	help
+	  Internal helper macro to compile the 'top' subcommand
+
+config KERNEL_THREAD_SHELL_TOP_MAX_THREADS
+	int "Maximum number of threads shown by 'kernel thread top'"
+	default 20
+	range 1 256
+	depends on KERNEL_THREAD_SHELL_TOP
+	help
+	  Size of the static table used by the 'kernel thread top' command to
+	  track per-thread execution cycles between refreshes. Threads beyond
+	  this count are counted but not shown.

--- a/subsys/shell/modules/kernel_service/thread/top.c
+++ b/subsys/shell/modules/kernel_service/thread/top.c
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Nerijus Bendžiūnas
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kernel_shell.h"
+
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/util.h>
+
+#define TOP_DEFAULT_REFRESH_INTERVAL_SECONDS 3
+#define TOP_MIN_REFRESH_INTERVAL_SECONDS     1
+#define TOP_MAX_REFRESH_INTERVAL_SECONDS     3600
+
+#define TOP_MAX_THREADS CONFIG_KERNEL_THREAD_SHELL_TOP_MAX_THREADS
+
+#define TOP_VT100_CLEAR_SCREEN_AND_CURSOR_HOME "\x1b[2J\x1b[H"
+
+#define ASCII_END_OF_TEXT_CTRL_C 0x03
+
+#define TOP_STACK_USAGE_UNKNOWN UINT8_MAX
+
+struct top_thread_snapshot {
+	struct k_thread *thread;
+	uint64_t execution_cycles;
+};
+
+struct top_thread_row {
+	struct k_thread *thread;
+	uint64_t execution_cycles;
+	uint64_t delta_cycles;
+	int priority;
+	char state[16];
+	char name[24];
+#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
+	uint8_t stack_usage_percent;
+#endif
+};
+
+static struct top_context {
+	struct k_work_delayable work;
+	const struct shell *sh;
+	atomic_t active;
+	uint32_t interval_seconds;
+	uint64_t previous_all_cycles;
+	uint64_t previous_busy_cycles;
+	struct top_thread_snapshot snapshots[TOP_MAX_THREADS];
+	size_t snapshot_count;
+	struct top_thread_row rows[TOP_MAX_THREADS];
+	size_t row_count;
+	size_t thread_count;
+	size_t hidden_count;
+} top_context;
+
+static void top_stop(struct top_context *context)
+{
+	atomic_set(&context->active, 0);
+	k_work_cancel_delayable(&context->work);
+	shell_set_bypass(context->sh, NULL, NULL);
+}
+
+static void top_collect_cb(const struct k_thread *cthread, void *user_data)
+{
+	struct k_thread *thread = (struct k_thread *)cthread;
+	struct top_context *context = user_data;
+	k_thread_runtime_stats_t stats;
+	struct top_thread_row *row;
+	const char *name;
+
+	context->thread_count++;
+
+	if (context->row_count >= ARRAY_SIZE(context->rows)) {
+		context->hidden_count++;
+		return;
+	}
+
+	if (k_thread_runtime_stats_get(thread, &stats) != 0) {
+		context->hidden_count++;
+		return;
+	}
+
+	row = &context->rows[context->row_count++];
+	row->thread = thread;
+	row->execution_cycles = stats.execution_cycles;
+	row->priority = thread->base.prio;
+	k_thread_state_str(thread, row->state, sizeof(row->state));
+
+	name = k_thread_name_get(thread);
+	if (name != NULL && name[0] != '\0') {
+		strncpy(row->name, name, sizeof(row->name) - 1);
+		row->name[sizeof(row->name) - 1] = '\0';
+	} else {
+		snprintk(row->name, sizeof(row->name), "%p", (void *)thread);
+	}
+
+	/* First refresh has no prior snapshot, so delta is since-boot, like top's first frame. */
+	row->delta_cycles = stats.execution_cycles;
+	for (size_t i = 0; i < context->snapshot_count; i++) {
+		if (context->snapshots[i].thread != thread) {
+			continue;
+		}
+		/*
+		 * A dead thread's memory may be reused by a new thread with a
+		 * smaller cycle count; treat a backwards jump as a new thread.
+		 */
+		if (stats.execution_cycles >= context->snapshots[i].execution_cycles) {
+			row->delta_cycles =
+				stats.execution_cycles - context->snapshots[i].execution_cycles;
+		}
+		break;
+	}
+
+#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
+	size_t unused_stack;
+	size_t stack_size = thread->stack_info.size;
+
+	if ((k_thread_stack_space_get(thread, &unused_stack) == 0) && (stack_size > 0)) {
+		row->stack_usage_percent = ((stack_size - unused_stack) * 100U) / stack_size;
+	} else {
+		row->stack_usage_percent = TOP_STACK_USAGE_UNKNOWN;
+	}
+#endif /* CONFIG_INIT_STACKS && CONFIG_THREAD_STACK_INFO */
+}
+
+static void top_sort_rows(struct top_context *context)
+{
+	/* Table is small; insertion sort keeps it descending by delta cycles. */
+	for (size_t i = 1; i < context->row_count; i++) {
+		struct top_thread_row key = context->rows[i];
+		size_t j = i;
+
+		while ((j > 0) && (context->rows[j - 1].delta_cycles < key.delta_cycles)) {
+			context->rows[j] = context->rows[j - 1];
+			j--;
+		}
+		context->rows[j] = key;
+	}
+}
+
+static void top_permille_split(uint64_t part, uint64_t whole, uint32_t *integer_part,
+			       uint32_t *tenths)
+{
+	uint64_t permille = 0;
+
+	if (whole > 0) {
+		permille = MIN((part * 1000U) / whole, 1000U);
+	}
+
+	*integer_part = (uint32_t)(permille / 10U);
+	*tenths = (uint32_t)(permille % 10U);
+}
+
+static void top_screen_print(struct top_context *context, uint64_t all_delta, uint64_t busy_delta)
+{
+	const struct shell *sh = context->sh;
+	int64_t uptime_ms = k_uptime_get();
+	uint32_t busy_percent;
+	uint32_t busy_tenths;
+	uint32_t idle_percent;
+	uint32_t idle_tenths;
+
+	top_permille_split(busy_delta, all_delta, &busy_percent, &busy_tenths);
+	top_permille_split(all_delta - MIN(busy_delta, all_delta), all_delta, &idle_percent,
+			   &idle_tenths);
+
+	shell_fprintf(sh, SHELL_NORMAL, TOP_VT100_CLEAR_SCREEN_AND_CURSOR_HOME);
+	shell_print(sh, "top - uptime %lld.%03lld s, refresh %u s, press 'q' to quit",
+		    uptime_ms / MSEC_PER_SEC, uptime_ms % MSEC_PER_SEC, context->interval_seconds);
+	shell_print(sh, "Threads: %zu total, CPU: %u.%u%% busy, %u.%u%% idle",
+		    context->thread_count, busy_percent, busy_tenths, idle_percent, idle_tenths);
+	shell_print(sh, "");
+
+#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
+	shell_print(sh, " %%CPU  PRIO  STATE       STACK%%  NAME");
+#else
+	shell_print(sh, " %%CPU  PRIO  STATE       NAME");
+#endif /* CONFIG_INIT_STACKS && CONFIG_THREAD_STACK_INFO */
+
+	for (size_t i = 0; i < context->row_count; i++) {
+		struct top_thread_row *row = &context->rows[i];
+		uint32_t cpu_percent;
+		uint32_t cpu_tenths;
+
+		top_permille_split(row->delta_cycles, all_delta, &cpu_percent, &cpu_tenths);
+
+#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
+		char stack_usage[8];
+
+		if (row->stack_usage_percent == TOP_STACK_USAGE_UNKNOWN) {
+			snprintk(stack_usage, sizeof(stack_usage), "?");
+		} else {
+			snprintk(stack_usage, sizeof(stack_usage), "%u%%",
+				 row->stack_usage_percent);
+		}
+		shell_print(sh, "%3u.%u  %4d  %-10.10s  %6s  %s", cpu_percent, cpu_tenths,
+			    row->priority, row->state, stack_usage, row->name);
+#else
+		shell_print(sh, "%3u.%u  %4d  %-10.10s  %s", cpu_percent, cpu_tenths, row->priority,
+			    row->state, row->name);
+#endif /* CONFIG_INIT_STACKS && CONFIG_THREAD_STACK_INFO */
+	}
+
+	if (context->hidden_count > 0) {
+		shell_print(sh, "(%zu more threads not shown, see %s)", context->hidden_count,
+			    "CONFIG_KERNEL_THREAD_SHELL_TOP_MAX_THREADS");
+	}
+}
+
+static void top_work_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct top_context *context = CONTAINER_OF(dwork, struct top_context, work);
+	k_thread_runtime_stats_t all_stats;
+	uint64_t all_delta;
+	uint64_t busy_delta;
+
+	if (atomic_get(&context->active) == 0) {
+		return;
+	}
+
+	if (k_thread_runtime_stats_all_get(&all_stats) != 0) {
+		shell_error(context->sh, "Failed to get CPU statistics");
+		top_stop(context);
+		return;
+	}
+
+	context->row_count = 0;
+	context->thread_count = 0;
+	context->hidden_count = 0;
+	k_thread_foreach_unlocked(top_collect_cb, context);
+
+	all_delta = all_stats.execution_cycles - context->previous_all_cycles;
+	busy_delta = all_stats.total_cycles - context->previous_busy_cycles;
+
+	top_sort_rows(context);
+	top_screen_print(context, all_delta, busy_delta);
+
+	for (size_t i = 0; i < context->row_count; i++) {
+		context->snapshots[i].thread = context->rows[i].thread;
+		context->snapshots[i].execution_cycles = context->rows[i].execution_cycles;
+	}
+	context->snapshot_count = context->row_count;
+	context->previous_all_cycles = all_stats.execution_cycles;
+	context->previous_busy_cycles = all_stats.total_cycles;
+
+	if (atomic_get(&context->active) == 1) {
+		k_work_reschedule(&context->work, K_SECONDS(context->interval_seconds));
+	}
+}
+
+static void top_bypass_cb(const struct shell *sh, uint8_t *data, size_t len, void *user_data)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(user_data);
+
+	for (size_t i = 0; i < len; i++) {
+		if ((data[i] == 'q') || (data[i] == 'Q') || (data[i] == ASCII_END_OF_TEXT_CTRL_C)) {
+			top_stop(&top_context);
+			break;
+		}
+	}
+}
+
+static int cmd_kernel_thread_top(const struct shell *sh, size_t argc, char **argv)
+{
+	uint32_t interval_seconds = TOP_DEFAULT_REFRESH_INTERVAL_SECONDS;
+
+	if (argc >= 2) {
+		uint64_t value;
+		int err = 0;
+
+		if ((strcmp(argv[1], "-d") != 0) || (argc != 3)) {
+			shell_error(sh, "Usage: top [-d <seconds>]");
+			return -EINVAL;
+		}
+
+		value = shell_strtoul(argv[2], 10, &err);
+		if ((err != 0) || (value < TOP_MIN_REFRESH_INTERVAL_SECONDS) ||
+		    (value > TOP_MAX_REFRESH_INTERVAL_SECONDS)) {
+			shell_error(sh, "Invalid interval: %s (allowed: %u-%u seconds)", argv[2],
+				    TOP_MIN_REFRESH_INTERVAL_SECONDS,
+				    TOP_MAX_REFRESH_INTERVAL_SECONDS);
+			return -EINVAL;
+		}
+		interval_seconds = (uint32_t)value;
+	}
+
+	if (atomic_get(&top_context.active) == 1) {
+		shell_error(sh, "top is already running");
+		return -EBUSY;
+	}
+
+	top_context.sh = sh;
+	top_context.interval_seconds = interval_seconds;
+	top_context.previous_all_cycles = 0;
+	top_context.previous_busy_cycles = 0;
+	top_context.snapshot_count = 0;
+
+	k_work_init_delayable(&top_context.work, top_work_handler);
+	atomic_set(&top_context.active, 1);
+	shell_set_bypass(sh, top_bypass_cb, NULL);
+	k_work_reschedule(&top_context.work, K_NO_WAIT);
+
+	return 0;
+}
+
+KERNEL_THREAD_CMD_ARG_ADD(top, NULL,
+			  "Show per-thread CPU usage, refreshed periodically.\n"
+			  "Usage: top [-d <seconds>] (default 3), press 'q' to quit.",
+			  cmd_kernel_thread_top, 1, 2);


### PR DESCRIPTION
Add a `kernel thread top` shell command: a live, Linux `top`-style view of per-thread CPU usage, sorted by CPU% and refreshed periodically. Unlike `kernel thread list` (cumulative since-boot cycles only), it samples runtime stats each refresh and shows the per-interval delta, so a currently busy thread stands out.

Supersedes #114254, which was auto-closed by the stale bot and cannot be reopened after the rebase force-push. Same two commits, rebased on current `main`; all CI checks were green on the previous PR. No review feedback was received there before it went stale, so I am happy to adjust naming, Kconfig placement, or the sample if maintainers prefer a different shape.

## Sample output

From `samples/subsys/shell/thread_top` on `qemu_cortex_m3`, with three synthetic load threads (50%, 25%, and a lowest-priority spinner soaking the rest):

```
top - uptime 4.110 s, refresh 2 s, press 'q' to quit
Threads: 6 total, CPU: 100.0% busy, 0.0% idle

 %CPU  PRIO  STATE       STACK%  NAME
 46.3    10  queued         23%  load_50_percent
 30.7    14  queued          9%  load_remainder
 22.4    11  sleeping       23%  load_25_percent
  0.4    -1  queued         59%  sysworkq
  0.0     5  pending        32%  shell_uart
  0.0    15                 18%  idle
```

## Design notes

- The handler must not block the shell thread, so it follows the net-shell `ping` pattern: `k_work_delayable` drives the refreshes and `shell_set_bypass` catches `q` / Ctrl+C.
- The sample keeps runtime stats on the system clock cycle counter because QEMU does not emulate the Cortex-M3 DWT counter, and raises the shell thread priority so the UI stays responsive under full load.

## Testing

```
west build -p -b qemu_cortex_m3 samples/subsys/shell/thread_top
west build -t run
uart:~$ kernel thread top
```

Rebuilt and booted on `qemu_cortex_m3` against current `main` (no warnings).
