### PR TITLE
drivers: timer: nrf_grtc: re-base tick after SYSCOUNTER loads

### DIFF
--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -606,6 +606,30 @@ static int grtc_post_init(void)
 				   : CLOCK_CONTROL_NRF_LF_START_STABLE);
 
 	z_nrf_clock_control_lf_on(mode);
+
+#if NRF_GRTC_HAS_SYSCOUNTER_LOADED
+	/* On SoCs where the SYSCOUNTER is only clocked once the LF clock is
+	 * running, the tick base captured at init is latched from a counter
+	 * that has not loaded yet (the read path only retries on BUSY, not on
+	 * LOADED). Wait for the counter to load and re-base it before the
+	 * kernel schedules on it. NO_WAIT must not block on the LF clock.
+	 */
+	if (mode != CLOCK_CONTROL_NRF_LF_START_NOWAIT) {
+		while (!(NRF_GRTC->GRTC_SYSCOUNTER.SYSCOUNTERH &
+			 GRTC_SYSCOUNTER_SYSCOUNTERH_LOADED_Msk)) {
+		}
+
+		unsigned int key = irq_lock();
+
+		last_count = (counter() / CYC_PER_TICK) * CYC_PER_TICK;
+		grtc_start_value = last_count;
+		expired_cc = UINT64_MAX;
+		if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+			system_timeout_set_relative(CYC_PER_TICK);
+		}
+		irq_unlock(key);
+	}
+#endif /* NRF_GRTC_HAS_SYSCOUNTER_LOADED */
 #endif
 
 #if defined(CONFIG_NRF_GRTC_ALWAYS_ON)


### PR DESCRIPTION
## Summary

On SoCs where the GRTC SYSCOUNTER is only clocked once the LF clock is
running, the kernel tick never advances after boot.

`sys_clock_driver_init()` captures the tick base at `EARLY` init, but the
LF clock is only turned on later in `grtc_post_init()` (`PRE_KERNEL_2`).
On these SoCs the base is therefore latched from a counter that has not
loaded yet. The nrfx read path only retries on `BUSY`, not on `LOADED`,
so `counter()` returns a bogus value. Every absolute compare programmed
from that base is unreachable, the `COMPARE` interrupt never fires, and
the tick stalls.

## Fix

After the LF clock is started in `grtc_post_init()`, wait for the
SYSCOUNTER `LOADED` indication and re-base the tick counter.

- Gated on the hardware feature `NRF_GRTC_HAS_SYSCOUNTER_LOADED`, not a
  specific SoC. Where the counter is already loaded the wait returns
  immediately and the re-base is a no-op, so existing platforms are
  unaffected.
- Placed inside the existing LF-on block, so it does not apply to parts
  (nRF54H/nRF92) where another core owns the SYSCOUNTER.
- Skipped under `CONFIG_SYSTEM_CLOCK_NO_WAIT`, which by contract must not
  block on the LF clock.

## Test plan

- [ ] Boot on an affected SoC (nRF71): confirm the kernel tick advances
      and `k_uptime_get()` progresses (previously stalled).
- [ ] Regression on nRF54L15 / nRF54LM20: boot and basic timer/kernel
      sanity, tickless and non-tickless.
- [ ] Regression on an nRF5340 GRTC-less/other GRTC target: no behavior
      change.
- [ ] `twister` timer testsuites on the above where available.

Made with [Cursor](https://cursor.com)