### PR TITLE
fs: reject duplicate fs_data regardless of mount point length

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -586,6 +586,9 @@ int fs_closedir(struct fs_dir_t *zdp);
  * @retval -ENOTSUP when not supported by underlying file system driver;
  *         when @c FS_MOUNT_FLAG_USE_DISK_ACCESS is set but driver does not
  *         support it.
+ * @retval -EBUSY when @p mp is already mounted, when another file system is
+ *	   already mounted at @c mp->mnt_point, or when @c mp->fs_data is
+ *	   already in use by another mount point;
  * @retval -EROFS if system requires formatting but @c FS_MOUNT_FLAG_READ_ONLY
  *	   has been set;
  * @retval <0 another negative errno code on error.

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -745,15 +745,22 @@ int fs_mount(struct fs_mount_t *mp)
 	/* Check if mount point already exists */
 	SYS_DLIST_FOR_EACH_NODE(&fs_mnt_list, node) {
 		itr = CONTAINER_OF(node, struct fs_mount_t, node);
-		/* continue if length does not match */
-		if (len != itr->mountp_len) {
-			continue;
-		}
 
-		CHECKIF(mp->fs_data == itr->fs_data) {
+		/* A file system's private state may only be owned by a single
+		 * mount point, no matter how the mount point strings compare,
+		 * fs_data may still be NULL here for file systems that
+		 * allocate their state while mounting, such as ext2, and NULL
+		 * must not be treated as a collision.
+		 */
+		if ((mp->fs_data != NULL) && (mp->fs_data == itr->fs_data)) {
 			LOG_ERR("file system already mounted!!");
 			rc = -EBUSY;
 			goto mount_err;
+		}
+
+		/* continue if length does not match */
+		if (len != itr->mountp_len) {
+			continue;
 		}
 
 		if (strncmp(mp->mnt_point, itr->mnt_point, len) == 0) {

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -953,6 +953,19 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 	int ret = 0;
 	struct fs_littlefs *fs = mountp->fs_data;
 
+	/* littlefs requires a pre-allocated fs_littlefs; it does not
+	 * allocate one from a NULL fs_data the way ext2 does.
+	 */
+	if (fs == NULL) {
+		LOG_ERR("fs_data is required for littlefs");
+		return -EINVAL;
+	}
+
+	if (fs->backend != NULL) {
+		LOG_ERR("littlefs instance is already mounted");
+		return -EBUSY;
+	}
+
 	/* Create and take mutex. */
 	k_mutex_init(&fs->mutex);
 	fs_lock(fs);

--- a/tests/subsys/fs/fs_api/src/test_fs_mount_fs_data.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_mount_fs_data.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Dhruv Menon <dhruvmenon1104@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "test_fs.h"
+
+#define MNT_SHORT_A "/dup_a"
+#define MNT_SHORT_B "/dup_b"
+#define MNT_LONG    "/dup_longer_c"
+
+static int dup_mount(struct fs_mount_t *mountp)
+{
+	ARG_UNUSED(mountp);
+	return 0;
+}
+
+static int dup_unmount(struct fs_mount_t *mountp)
+{
+	ARG_UNUSED(mountp);
+	return 0;
+}
+
+static const struct fs_file_system_t dup_fs = {
+	.mount = dup_mount,
+	.unmount = dup_unmount,
+};
+
+static struct test_fs_data shared_data;
+static struct test_fs_data other_data;
+
+static struct fs_mount_t mnt_short_a_shared = {
+		.type = TEST_FS_1,
+		.mnt_point = MNT_SHORT_A,
+		.fs_data = &shared_data,
+};
+
+static struct fs_mount_t mnt_short_b_shared = {
+		.type = TEST_FS_1,
+		.mnt_point = MNT_SHORT_B,
+		.fs_data = &shared_data,
+};
+
+static struct fs_mount_t mnt_long_shared = {
+		.type = TEST_FS_1,
+		.mnt_point = MNT_LONG,
+		.fs_data = &shared_data,
+};
+
+static struct fs_mount_t mnt_long_other = {
+		.type = TEST_FS_1,
+		.mnt_point = MNT_LONG,
+		.fs_data = &other_data,
+};
+
+/* fs_data is intentionally left NULL on the two mount points below. */
+static struct fs_mount_t mnt_short_a_null = {
+		.type = TEST_FS_1,
+		.mnt_point = MNT_SHORT_A,
+};
+
+static struct fs_mount_t mnt_long_null = {
+		.type = TEST_FS_1,
+		.mnt_point = MNT_LONG,
+};
+
+/**
+ * @brief Sharing one fs_data between two mount points must be rejected
+ *
+ * @details
+ * Covers both mount point length relations, in both directions, because the
+ * duplicate detection must not be gated on the mount point lengths.
+ *
+ * @ingroup filesystem_api
+ */
+ZTEST(fs_api_mount_fs_data, test_duplicate_fs_data_rejected)
+{
+	int ret;
+
+	zassert_ok(fs_mount(&mnt_short_a_shared), "failed to mount %s", MNT_SHORT_A);
+
+	/* Mount point of equal length to the mounted one. */
+	ret = fs_mount(&mnt_short_b_shared);
+	zassert_equal(ret, -EBUSY,
+		      "duplicate fs_data accepted for an equal length mount point (%d)", ret);
+
+	/* Mount point longer than the mounted one. */
+	ret = fs_mount(&mnt_long_shared);
+	zassert_equal(ret, -EBUSY,
+		      "duplicate fs_data accepted for a longer mount point (%d)", ret);
+
+	zassert_ok(fs_unmount(&mnt_short_a_shared), "failed to unmount %s", MNT_SHORT_A);
+
+	/* Same collision the other way round, so that the incoming mount point
+	 * is shorter than the mounted one.
+	 */
+	zassert_ok(fs_mount(&mnt_long_shared), "failed to mount %s", MNT_LONG);
+
+	ret = fs_mount(&mnt_short_a_shared);
+	zassert_equal(ret, -EBUSY,
+		      "duplicate fs_data accepted for a shorter mount point (%d)", ret);
+
+	zassert_ok(fs_unmount(&mnt_long_shared), "failed to unmount %s", MNT_LONG);
+}
+
+/**
+ * @brief Mount points with distinct fs_data must both be accepted
+ *
+ * @ingroup filesystem_api
+ */
+ZTEST(fs_api_mount_fs_data, test_distinct_fs_data_accepted)
+{
+	zassert_ok(fs_mount(&mnt_short_a_shared), "failed to mount %s", MNT_SHORT_A);
+	zassert_ok(fs_mount(&mnt_long_other), "failed to mount %s alongside %s", MNT_LONG,
+		   MNT_SHORT_A);
+
+	zassert_ok(fs_unmount(&mnt_long_other), "failed to unmount %s", MNT_LONG);
+	zassert_ok(fs_unmount(&mnt_short_a_shared), "failed to unmount %s", MNT_SHORT_A);
+}
+
+/**
+ * @brief One fs_data may be reused once the previous mount point released it
+ *
+ * @details
+ * The duplicate detection has to reject concurrent owners only; reusing an
+ * instance after unmounting has to keep working.
+ *
+ * @ingroup filesystem_api
+ */
+ZTEST(fs_api_mount_fs_data, test_fs_data_reuse_after_unmount)
+{
+	zassert_ok(fs_mount(&mnt_short_a_shared), "failed to mount %s", MNT_SHORT_A);
+	zassert_ok(fs_unmount(&mnt_short_a_shared), "failed to unmount %s", MNT_SHORT_A);
+
+	zassert_ok(fs_mount(&mnt_long_shared), "failed to reuse fs_data for %s", MNT_LONG);
+	zassert_ok(fs_unmount(&mnt_long_shared), "failed to unmount %s", MNT_LONG);
+}
+
+/**
+ * @brief A NULL fs_data must not be treated as a duplicate
+ *
+ * @details
+ * File systems such as ext2 allocate their private state inside their own
+ * mount handler, so they reach the duplicate check with fs_data still NULL.
+ * Two such mount points share no state and must both be accepted.
+ *
+ * @ingroup filesystem_api
+ */
+ZTEST(fs_api_mount_fs_data, test_null_fs_data_accepted)
+{
+	zassert_ok(fs_mount(&mnt_short_a_null), "failed to mount %s with NULL fs_data",
+		   MNT_SHORT_A);
+	zassert_ok(fs_mount(&mnt_long_null), "NULL fs_data treated as a duplicate for %s",
+		   MNT_LONG);
+
+	zassert_ok(fs_unmount(&mnt_long_null), "failed to unmount %s", MNT_LONG);
+	zassert_ok(fs_unmount(&mnt_short_a_null), "failed to unmount %s", MNT_SHORT_A);
+}
+
+static void *mount_fs_data_setup(void)
+{
+	zassert_ok(fs_register(TEST_FS_1, &dup_fs), "failed to register test file system");
+	return NULL;
+}
+
+/* A failing assertion aborts the test in progress, so anything it had already
+ * mounted would stay on the mount list and leak into the tests that follow.
+ * Drop every mount point after each test to keep the failures isolated.
+ */
+static void mount_fs_data_after(void *fixture)
+{
+	static struct fs_mount_t *const all_mnts[] = {
+		&mnt_short_a_shared, &mnt_short_b_shared, &mnt_long_shared,
+		&mnt_long_other,     &mnt_short_a_null,   &mnt_long_null,
+	};
+
+	ARG_UNUSED(fixture);
+
+	ARRAY_FOR_EACH(all_mnts, i) {
+		(void)fs_unmount(all_mnts[i]);
+	}
+}
+
+static void mount_fs_data_teardown(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	(void)fs_unregister(TEST_FS_1, &dup_fs);
+}
+
+ZTEST_SUITE(fs_api_mount_fs_data, NULL, mount_fs_data_setup, NULL, mount_fs_data_after,
+	    mount_fs_data_teardown);

--- a/tests/subsys/fs/fs_api/src/test_multi_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_multi_fs.c
@@ -10,18 +10,19 @@
 #define TEST_FS_NAND1 "/NAND:"
 #define TEST_FS_NAND2 "/MMCBLOCK:"
 
-static struct test_fs_data test_data;
+static struct test_fs_data test_data_1;
+static struct test_fs_data test_data_2;
 
 static struct fs_mount_t test_fs_mnt_1 = {
 		.type = TEST_FS_1,
 		.mnt_point = TEST_FS_NAND1,
-		.fs_data = &test_data,
+		.fs_data = &test_data_1,
 };
 
 static struct fs_mount_t test_fs_mnt_2 = {
 		.type = TEST_FS_2,
 		.mnt_point = TEST_FS_NAND2,
-		.fs_data = &test_data,
+		.fs_data = &test_data_2,
 };
 
 static int test_fs_init(void)

--- a/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
+++ b/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
@@ -30,3 +30,20 @@ ZTEST(littlefs, test_fs_mount_flags_lfs)
 
 	test_fs_mount_flags();
 }
+
+/**
+ * @brief littlefs must reject a mount with no pre-allocated fs_data
+ */
+ZTEST(littlefs, test_fs_mount_null_fs_data)
+{
+	struct fs_mount_t mp = {
+		.type = FS_LITTLEFS,
+		.mnt_point = "/nullfs",
+		.fs_data = NULL,
+	};
+	int ret;
+
+	ret = fs_mount(&mp);
+	zassert_equal(ret, -EINVAL,
+		      "NULL fs_data must be rejected with -EINVAL, got %d", ret);
+}


### PR DESCRIPTION
This PR is with reference to issue #117723

fs_mount() mistakenly allowed multiple mount points to share the same filesystem state (fs_data) if their path strings had different lengths.
The fs_data collision check was placed after a path length short-circuit (if (len != itr->mountp_len) continue;). If the path lengths differed, the collision check was skipped entirely.

This bug allowed a single filesystem state to be driven by multiple mount entries, with varying consequences:

1. FATFS: Silently accepts the duplicate mount. Unmounting the second entry breaks the shared volume, rendering the first entry unusable.
2. littlefs: Rejects the second mount, but the failure path clears fs->backend on the live instance. This breaks the guard, allowing a subsequent mount to succeed and alias the live state.

to fix this I have:

1. Moved the fs_data pointer comparison before the path length check.
2. The check is now skipped if fs_data == NULL. This prevents false -EBUSY errors for filesystems like ext2, which allocate their state during the mount handler.
3. Replaced CHECKIF with a plain if to ensure this critical check isn't silently compiled out in size-optimized builds (CONFIG_NO_RUNTIME_CHECKS).
4. Updated the littlefs driver to cleanly reject duplicate mounts before modifying any instance state.

I have also fixed test_multi_fs.c, this test previously relied on the bug by sharing one test_data state between /NAND: and /MMCBLOCK:. It now correctly uses separate states.

Added fs_api_mount_fs_data suite: A new test suite that explicitly covers fs_data aliasing with different path lengths, NULL states, distinct states, and sequential reuse.