### PR TITLE
settings: return -EIO when compress close fails

### DIFF
--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -352,7 +352,10 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 		}
 		cf->cf_lines = lines + 1;
 	} else {
-		rc = -EIO;
+		if (rc2 == 0) {
+			(void)fs_unlink(tmp_file);
+		}
+		return -EIO;
 	}
 	/*
 	 * XXX at settings_file_load(), look for .cmp if actual file does not


### PR DESCRIPTION
settings_file_save_and_compress() stored -EIO on a failed fs_close() but then returned 0, so settings_save() reported success after a failed compress.