### PR TITLE
drivers: i3c: i3c_mcux: let the bus settle after pinctrl in init

### DIFF
--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -1982,6 +1982,19 @@ static int mcux_i3c_init(const struct device *dev)
 		goto err_out;
 	}
 
+	/*
+	 * On parts that gate the I3C bus pull-ups behind a dedicated pin
+	 * (e.g. NXP MCX N's I3Cn_PUR), the SDA/SCL lines have only just
+	 * been released by the pinctrl state above and need time to rise
+	 * to a valid high through those pull-ups. Touching the controller
+	 * (I3C_MasterInit(), mcux_i3c_recover_bus() or the first broadcast
+	 * CCC in i3c_bus_init()) while the lines are still low latches the
+	 * controller into a non-IDLE state that the K_FOREVER wait in the
+	 * transfer path never recovers from, so POST_KERNEL device init
+	 * hangs before the console is up. Let the bus settle first.
+	 */
+	k_busy_wait(1000);
+
 	k_mutex_init(&data->lock);
 	k_condvar_init(&data->condvar);
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);


### PR DESCRIPTION
### Summary

On NXP MCX N parts (e.g. MCXN947) the I3C bus pull-ups are gated behind a dedicated pin (`I3Cn_PUR`). In `mcux_i3c_init()`, immediately after `pinctrl_apply_state()` releases the SDA/SCL lines, they are still low and take on the order of hundreds of microseconds to rise to a valid high through those pull-ups.

If `I3C_MasterInit()`, the "just in case" `mcux_i3c_recover_bus()`, or the first broadcast CCC in `i3c_bus_init()` runs while the lines are still low, the controller latches into a non-IDLE state that the `K_FOREVER` wait in the transfer path (`mcux_i3c_wait_idle()`) never gets out of. The `POST_KERNEL` device init then blocks forever and the board never reaches the console.

### Reproduction

`mcx_n9xx_evk/mcxn947/cpu0` with `CONFIG_I3C=y` (`i3c1` is `status = "okay"` in the in-tree board DT, no child devices) hangs before `main()` — no boot banner. Single-stepping `mcux_i3c_init()` in a debugger (which inserts delays between operations) lets it initialise cleanly, with `i3c info` reporting the controller ready. This matched a fixed ~1 ms delay after pinctrl.

There is currently no CI/twister coverage of the mcux I3C driver on a real MCX N board (`tests/drivers/build_all/i3c` only allows `qemu_cortex_m3`), so this path was previously unexercised.

### Change

A `k_busy_wait(1000)` right after `pinctrl_apply_state()` in `mcux_i3c_init()`, so the bus is up before the controller is first touched.

### Notes / open to feedback

- The 1 ms value is conservative and empirical. Happy to make it a devicetree property (e.g. a `bus-settle-us` on the controller node) if maintainers prefer that over an unconditional fixed wait, or to gate it on the presence of a PUR pin in pinctrl.
- Verified on hardware (MCX-N9XX-EVK, MCXN947): with this change `CONFIG_I3C=y` boots to the console and `i3c info i3c@22000` reports the controller ready (no devices, as nothing is wired to that bus on the EVK).