### PR TITLE
logging: fs backend: match mounts on a path boundary

### DIFF
--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -33,6 +33,17 @@ static int del_oldest_log(void);
 static int get_log_file_id(struct fs_dirent *ent);
 static uint32_t log_format_current = CONFIG_LOG_BACKEND_FS_OUTPUT_DEFAULT;
 
+static bool log_fs_dir_on_mount(const char *mnt_point)
+{
+	const size_t len = strlen(mnt_point);
+
+	/* Path prefix, not character prefix: same rule as fs_get_mnt_point(). */
+	return (strncmp(CONFIG_LOG_BACKEND_FS_DIR, mnt_point, len) == 0) &&
+	       ((len <= 1) ||
+		(CONFIG_LOG_BACKEND_FS_DIR[len] == '/') ||
+		(CONFIG_LOG_BACKEND_FS_DIR[len] == '\0'));
+}
+
 static int check_log_volume_available(void)
 {
 	int index = 0;
@@ -42,10 +53,7 @@ static int check_log_volume_available(void)
 	while (rc == 0) {
 		rc = fs_readmount(&index, &name);
 		if (rc == 0) {
-			if (strncmp(CONFIG_LOG_BACKEND_FS_DIR,
-				    name,
-				    strlen(name))
-			    == 0) {
+			if (log_fs_dir_on_mount(name)) {
 				return 0;
 			}
 		}


### PR DESCRIPTION
check_log_volume_available() compared CONFIG_LOG_BACKEND_FS_DIR to each mount with strncmp(..., strlen(mnt)), so a mount that was only a character prefix of the log dir counted as a hit. 

With a volume at /lf and CONFIG_LOG_BACKEND_FS_DIR="/lfs/log", the backend treated the log volume as present, failed to open the real path, and marked itself CORRUPTED, so later writes were dropped even after the correct volume was mounted.

Require the next character of the log dir to be '/' or NUL after the mount name, the same rule fs_get_mnt_point() already uses, with the same exception for the root mount "/".
