### PR TITLE
tests: lib: mpsc_pbuf: use empty initializer for local spinlock

### DIFF
--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -1433,7 +1433,7 @@ ZTEST(log_buffer, test_alloc_in_spinlock)
 {
 	struct mpsc_pbuf_buffer buffer;
 	struct test_data_var *packet;
-	struct k_spinlock l = {0};
+	struct k_spinlock l = {};
 
 	init(&buffer, 32, false);
 


### PR DESCRIPTION
struct k_spinlock has no members when neither CONFIG_SMP nor
CONFIG_SPIN_VALIDATE is enabled, so `= {0}` is an excess element
initializer and fails the build with -Werror:

  main.c:1436:32: warning: excess elements in struct initializer
   1436 |         struct k_spinlock l = {0};

Use `= {}` which is valid for both empty and populated structs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
