### PR TITLE
boards: nucode: add NU54V DK board support

### DIFF
--- a/boards/nucode/nucode_nu54/Kconfig.defconfig
+++ b/boards/nucode/nucode_nu54/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# NUCODE NU54V DK board configuration
+
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NUCODE_NU54
+
+config HW_STACK_PROTECTION
+	default ARCH_HAS_STACK_PROTECTION
+
+endif # BOARD_NUCODE_NU54

--- a/boards/nucode/nucode_nu54/Kconfig.nucode_nu54
+++ b/boards/nucode/nucode_nu54/Kconfig.nucode_nu54
@@ -1,0 +1,8 @@
+# NUCODE NU54V DK board configuration
+
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NUCODE_NU54
+	select SOC_NRF54L15_CPUAPP if BOARD_NUCODE_NU54_NRF54L15_CPUAPP

--- a/boards/nucode/nucode_nu54/board.cmake
+++ b/boards/nucode/nucode_nu54/board.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_NRF54L15_CPUAPP)
+  # Never let pyOCD recover a protected target by erasing it implicitly.
+  board_runner_args(pyocd "--target=nrf54l" "--tool-opt=-O=auto_unlock=false")
+  board_runner_args(jlink "--device=nRF54L15_M33" "--speed=4000")
+
+  # The onboard DAPLink probe is the default runner.
+  include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()

--- a/boards/nucode/nucode_nu54/board.yml
+++ b/boards/nucode/nucode_nu54/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: nucode_nu54
+  full_name: NUCODE NU54V DK
+  vendor: nucode
+  socs:
+  - name: nrf54l15

--- a/boards/nucode/nucode_nu54/doc/index.rst
+++ b/boards/nucode/nucode_nu54/doc/index.rst
@@ -1,0 +1,168 @@
+.. zephyr:board:: nucode_nu54
+
+Overview
+********
+
+The NUCODE NU54V DK is a development board for the NU54V module, which is
+based on the Nordic Semiconductor nRF54L15. The module provides 1.5 MB of
+RRAM, 256 KB of RAM, and a 2.4 GHz radio supporting Bluetooth Low Energy and
+IEEE 802.15.4. The board includes four user LEDs, four push buttons, a Qwiic
+connector, a Cortex 10-pin debug connector, and an onboard DAPLink CMSIS-DAP
+debug probe.
+
+This board definition targets the NU54V DK with the nRF54L15. The NU54 module
+family also contains nRF54L05 and nRF54L10 variants, which are not covered by
+this board definition.
+
+The pin assignments are based on the `NUCODE NU54 DK board files`_,
+`NUCODE NU54 DK pinout`_, and the current `NUCODE NU54 DK schematic`_.
+See the `NUCODE NU54 software page`_ and `NUCODE NU54V DK product page`_ for
+more information.
+
+Hardware
+********
+
+- Nordic Semiconductor nRF54L15 Arm Cortex-M33 application processor
+- 1.5 MB RRAM and 256 KB RAM
+- 2.4 GHz multiprotocol radio
+- Four user LEDs and four user push buttons
+- Qwiic I2C connector
+- Onboard DAPLink CMSIS-DAP probe with two CDC ACM UART interfaces
+- Cortex 10-pin SWD connector for an external probe
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Connections and IOs
+===================
+
+LEDs
+----
+
+* LED0 = P2.09 (active high)
+* LED1 = P1.10 (active high)
+* LED2 = P2.07 (active high)
+* LED3 = P1.14 (active high)
+
+Push Buttons
+------------
+
+* ``button0``/``sw0`` = board signal SW1 = component SW2 = P1.13
+  (active low, pull-up)
+* ``button1``/``sw1`` = board signal SW2 = component SW3 = P1.09
+  (active low, pull-up)
+* ``button2``/``sw2`` = board signal SW3 = component SW4 = P1.08
+  (active low, pull-up)
+* ``button3``/``sw3`` = board signal SW4 = component SW5 = P0.04
+  (active low, pull-up)
+
+Component SW1 is the two-pole ``DISABLE_SWD``/``DISABLE_UART`` switch, not a
+user push button. The ``sw0`` through ``sw3`` names above are Zephyr aliases.
+
+UART Console
+------------
+
+The board schematic routes the primary onboard debugger UART path to UART20.
+The default console speed is 115200 baud. RTS and CTS are routed to the debug
+interface, but hardware flow control is not enabled by default.
+
+* TX = P1.04
+* RX = P1.05
+* RTS = P1.06
+* CTS = P1.07
+
+UART30 is available to the CPUAPP as a disabled optional configuration on
+P0.00 through P0.03.
+
+Both UART paths pass through the onboard debug interface. Probe firmware may
+expose them as two CDC ACM interfaces named ``UART0`` and ``UART1``. If there
+is no console output, verify that the ``DISABLE_UART`` half of SW1 allows the
+UART level shifters to drive the target. UART20 also depends on SB9 through
+SB12; UART30 depends on SB5 through SB8. The switch direction, solder-bridge
+population, and onboard probe firmware must be checked against the actual
+board revision. A CDC ACM interface appearing on the host does not by itself
+confirm that the probe firmware is forwarding the corresponding target UART.
+
+Qwiic I2C
+---------
+
+The Qwiic connector uses I2C22.
+
+* SCL = P1.03
+* SDA = P1.02
+
+Pin Sharing
+-----------
+
+P1.02 and P1.03 are shared with NFC, so NFCT is disabled by default. P1.10 is
+shared by ``led1`` and ``pwm-led0``. P2.07 can be connected to SWO through
+SB13. P1.08 and P0.04 are connected to buttons which short the pins to ground
+when pressed. Do not route GRTC clock outputs to these pins unless the physical
+button paths have been isolated.
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+The onboard probe enumerates as a DAPLink CMSIS-DAP device. Build
+and flash a sample with pyOCD as follows. The board's USB-C connection powers
+the board and carries CMSIS-DAP, mass-storage, and CDC ACM interfaces; a second
+USB-UART cable is not required by the board design.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucode_nu54/nrf54l15/cpuapp
+   :goals: build flash
+
+The board does not have a pyOCD board-ID entry, so the board runner explicitly
+selects the built-in ``nrf54l`` target. It also disables pyOCD's automatic
+unlock operation so that connecting to a protected target fails instead of
+implicitly mass-erasing it. An external J-Link can also be used through the
+Cortex 10-pin connector by selecting the J-Link runner.
+
+On Linux, pyOCD needs permission to access the onboard probe's composite USB
+device. If the probe is listed only when running pyOCD as root, install the
+following udev rule as ``root``:
+
+.. code-block:: console
+
+   # echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE="0666"' > /etc/udev/rules.d/50-nucode-nu54-cmsis-dap.rules
+
+Reload the rules, and then unplug and reconnect the board:
+
+.. code-block:: console
+
+   $ sudo udevadm control --reload-rules
+
+The supported board target is ``nucode_nu54/nrf54l15/cpuapp``. When using an
+external probe, isolate the onboard SWD interface before driving the same
+signals.
+
+Hardware Configuration Notes
+****************************
+
+The internal HFXO and LFXO load-capacitance values and the DCDC mode follow
+NUCODE's current board files. The board's oscillator path depends on its BOM
+and the SB18 through SB21 population. If an external LFXO is populated, update
+the devicetree configuration as described in the
+`NUCODE NU54 DK hardware notes`_. Verify these settings when supporting a board
+revision with a different BOM or solder-bridge population.
+
+References
+**********
+
+.. target-notes::
+
+.. _NUCODE NU54 software page: https://nuworks.io/wiki/software/NU54
+.. _NUCODE NU54 DK board files: https://github.com/Nucode01/NU54DK_Zephyr_DTS
+.. _NUCODE NU54 DK pinout:
+   https://github.com/Nucode01/NU54DK_Zephyr_DTS/blob/main/00_Docs/03_PINOUT.md
+.. _NUCODE NU54 DK hardware notes:
+   https://github.com/Nucode01/NU54DK_Zephyr_DTS/blob/main/00_Docs/04_HARDWARE_NOTES.md
+.. _NUCODE NU54 DK schematic:
+   https://github.com/Nucode01/NU54DK_Zephyr_DTS/blob/main/NU54-DK%20Schematic.pdf
+.. _NUCODE NU54V DK product page:
+   https://nucode.store/product/nu-54v-dk-nucode-nrf54l15-ble-60-mcu-kcfcccemic/36/

--- a/boards/nucode/nucode_nu54/nucode_nu54-pinctrl.dtsi
+++ b/boards/nucode/nucode_nu54/nucode_nu54-pinctrl.dtsi
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	/omit-if-no-ref/ uart20_default: uart20_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 5)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ uart20_sleep: uart20_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 1, 5)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
+			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ uart30_default: uart30_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 0)>,
+				<NRF_PSEL(UART_RTS, 0, 2)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 1)>,
+				<NRF_PSEL(UART_CTS, 0, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ uart30_sleep: uart30_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 0)>,
+				<NRF_PSEL(UART_RX, 0, 1)>,
+				<NRF_PSEL(UART_RTS, 0, 2)>,
+				<NRF_PSEL(UART_CTS, 0, 3)>;
+			low-power-enable;
+		};
+	};
+
+	/omit-if-no-ref/ i2c22_default: i2c22_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+		};
+	};
+
+	/omit-if-no-ref/ i2c22_sleep: i2c22_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/nucode/nucode_nu54/nucode_nu54_common.dtsi
+++ b/boards/nucode/nucode_nu54/nucode_nu54_common.dtsi
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nucode_nu54-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+
+		led1: led_1 {
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 1";
+		};
+
+		led2: led_2 {
+			gpios = <&gpio2 7 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 2";
+		};
+
+		led3: led_3 {
+			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 3";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio1 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		button1: button_1 {
+			gpios = <&gpio1 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+
+		button2: button_2 {
+			gpios = <&gpio1 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+
+		button3: button_3 {
+			gpios = <&gpio0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 3";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+	};
+
+	qwiic_connector: qwiic-connector {
+		compatible = "stemma-qt-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 3 0>,
+			   <1 0 &gpio1 2 0>;
+	};
+};
+
+&uart20 {
+	current-speed = <115200>;
+	pinctrl-0 = <&uart20_default>;
+	pinctrl-1 = <&uart20_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&uart30 {
+	current-speed = <115200>;
+	pinctrl-0 = <&uart30_default>;
+	pinctrl-1 = <&uart30_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/boards/nucode/nucode_nu54/nucode_nu54_cpuapp_common.dtsi
+++ b/boards/nucode/nucode_nu54/nucode_nu54_cpuapp_common.dtsi
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nucode_nu54_common.dtsi"
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	chosen {
+		zephyr,console = &uart20;
+		zephyr,shell-uart = &uart20;
+		zephyr,uart-mcumgr = &uart20;
+		zephyr,bt-mon-uart = &uart20;
+		zephyr,bt-c2h-uart = &uart20;
+		zephyr,flash-controller = &rram_controller;
+		zephyr,flash = &cpuapp_rram;
+		zephyr,ieee802154 = &ieee802154;
+		zephyr,boot-mode = &boot_mode0;
+	};
+
+	aliases {
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+		pwm-led0 = &pwm_led1;
+		watchdog0 = &wdt31;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led1: pwm_led_1 {
+			pwms = <&pwm20 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+&cpuapp_sram {
+	status = "okay";
+};
+
+/* These oscillator settings follow NUCODE's current board files. */
+&lfxo {
+	load-capacitors = "internal";
+	load-capacitance-femtofarad = <17000>;
+};
+
+&hfxo {
+	load-capacitors = "internal";
+	load-capacitance-femtofarad = <15000>;
+};
+
+&regulators {
+	status = "okay";
+};
+
+&vregmain {
+	status = "okay";
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
+&grtc {
+	owned-channels = <0 1 2 3 4 5 6 7 8 9 10 11>;
+	/* Channels 7-11 are reserved for zero-latency IRQs, 3-4 for FLPR. */
+	child-owned-channels = <3 4 7 8 9 10 11>;
+	status = "okay";
+};
+
+&uart20 {
+	status = "okay";
+};
+
+&i2c22 {
+	status = "okay";
+	clock-frequency = <100000>;
+	pinctrl-0 = <&i2c22_default>;
+	pinctrl-1 = <&i2c22_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm20 {
+	status = "okay";
+	pinctrl-0 = <&pwm20_default>;
+	pinctrl-1 = <&pwm20_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&wdt31 {
+	status = "okay";
+};
+
+&adc {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpiote30 {
+	status = "okay";
+};
+
+&radio {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+&temp {
+	status = "okay";
+};
+
+&clock {
+	status = "okay";
+};
+
+&xo {
+	status = "okay";
+};
+
+&lfclk {
+	status = "okay";
+};
+
+&nfct {
+	status = "disabled";
+};
+
+&gpregret1 {
+	status = "okay";
+
+	boot_mode0: boot_mode@0 {
+		compatible = "zephyr,retention";
+		status = "okay";
+		reg = <0x0 0x1>;
+	};
+};

--- a/boards/nucode/nucode_nu54/nucode_nu54_nrf54l15_cpuapp.dts
+++ b/boards/nucode/nucode_nu54/nucode_nu54_nrf54l15_cpuapp.dts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <nordic/nrf54l15_cpuapp.dtsi>
+#include "nucode_nu54_cpuapp_common.dtsi"
+
+/ {
+	model = "NUCODE NU54V DK nRF54L15 Application MCU";
+	compatible = "nucode,nucode-nu54-nrf54l15-cpuapp";
+
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+		zephyr,sram = &cpuapp_sram;
+	};
+};
+
+#include <vendor/nordic/nrf54l15_cpuapp_partition.dtsi>

--- a/boards/nucode/nucode_nu54/nucode_nu54_nrf54l15_cpuapp.yaml
+++ b/boards/nucode/nucode_nu54/nucode_nu54_nrf54l15_cpuapp.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: nucode_nu54/nrf54l15/cpuapp
+name: NUCODE-NU54V-DK-nRF54L15-Application
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - zephyr
+sysbuild: true
+ram: 188
+flash: 1428
+supported:
+  - adc
+  - counter
+  - gpio
+  - i2c
+  - pwm
+  - retained_mem
+  - watchdog
+vendor: nucode

--- a/boards/nucode/nucode_nu54/nucode_nu54_nrf54l15_cpuapp_defconfig
+++ b/boards/nucode/nucode_nu54/nucode_nu54_nrf54l15_cpuapp_defconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable UART driver and console
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y

--- a/boards/nucode/nucode_nu54/pre_dt_board.cmake
+++ b/boards/nucode/nucode_nu54/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# The nRF54L15 power, clock, XO, and LFCLK nodes intentionally overlap.
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
## Summary

Adds initial Zephyr board support for the **NUCODE NU54V DK**, carrying a
NU54V module based on the Nordic **nRF54L15** SoC.

Board target: `nucode_nu54/nrf54l15/cpuapp`

## Hardware

- Arm Cortex-M33 application core, 1.5 MB RRAM, and 256 KB RAM
- Bluetooth Low Energy and IEEE 802.15.4 radio support
- Four user LEDs and four user push buttons
- Qwiic I2C connector
- Onboard DAPLink CMSIS-DAP probe with mass storage and two CDC ACM interfaces
- Cortex 10-pin SWD connector for an external probe

## Supported features

- GPIO LEDs and buttons
- UART console
- I2C, PWM, ADC, counter, retained memory, and watchdog
- Bluetooth LE and IEEE 802.15.4
- Flashing and debugging with the onboard probe through pyOCD
- External J-Link flashing and debugging

## Local validation

The following builds passed against current `upstream/main`:

```
west build -p always -b nucode_nu54/nrf54l15/cpuapp samples/hello_world
west build -p always -b nucode_nu54/nrf54l15/cpuapp samples/basic/blinky
west build -p always -b nucode_nu54/nrf54l15/cpuapp samples/sysbuild/with_mcuboot
```

A build-only Twister run covered `samples/philosophers` and all
`tests/kernel` scenarios for the board. Of 221 selected configurations, 84
were filtered and all 137 remaining configurations built with no failures,
errors, or warnings.

`checkpatch`, `git diff --check`, `sphinx-lint`, `yamllint`, Gitlint, and DCO
checks pass locally.

## Hardware validation

Validated on a physical NU54V DK using its onboard DAPLink probe:

- pyOCD sector flashing with automatic unlock disabled
- GPIO LED blinking and PWM fading
- Bluetooth LE advertising, with 37 matching packets received by an external
  scanner in eight seconds
- Counter alarms
- Watchdog reset
- ADC reads
- User button input

The target UART driver and TX path were also verified: UART20 completed DMA
transfers and P1.04 toggled. The pre-release onboard DAPLink firmware on the
tested board did not forward console data through its CDC interfaces. The
board documentation records the relevant switch and solder-bridge paths so
this probe-side limitation can be diagnosed without changing the Zephyr UART
configuration.

## References

- NUCODE NU54 software and board files: https://nuworks.io/wiki/software/NU54
- NUCODE NU54 DK devicetree sources: https://github.com/Nucode01/NU54DK_Zephyr_DTS
