### PR TITLE
Bluetooth: Host: Monitor: fix timestamps of early boot log messages

### DIFF
--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <time.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/buf.h>
@@ -24,11 +25,11 @@
 #include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log_msg.h>
 #include <zephyr/logging/log_output.h>
-#include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk-hooks.h>
 #include <zephyr/sys/libc-hooks.h>
 #include <zephyr/drivers/uart.h>
@@ -315,26 +316,45 @@ static void restore_drops(const struct bt_monitor_hdr *hdr)
 	}
 }
 
-static log_timestamp_t monitor_ts_get(void)
+/* Convert microseconds to the monitor timestamp resolution */
+static uint64_t monitor_ts_from_us(uint64_t us)
 {
-	uint64_t cycle;
-
-	if (IS_ENABLED(CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER)) {
-		cycle = k_cycle_get_64();
-	} else {
-		cycle = k_cycle_get_32();
-	}
-
-	/* Convert to 1/10th of a millisecond via microseconds, rather than
-	 * dividing by hw_cycles / MONITOR_TS_FREQ: the latter truncates badly
-	 * for cycle rates that are not a multiple of MONITOR_TS_FREQ (e.g.
-	 * 32768 Hz yields a divisor of 3 instead of 3.2768, making the
-	 * timestamps run 9.2% fast).
-	 */
-	return (log_timestamp_t)(k_cyc_to_us_floor64(cycle) / (USEC_PER_MSEC / 10U));
+	return us / (USEC_PER_SEC / MONITOR_TS_FREQ);
 }
 
-static inline void encode_hdr(struct bt_monitor_hdr *hdr, log_timestamp_t timestamp,
+/* Timestamp for HCI packets, on the same time base as the logging core's
+ * clock so that log messages (converted in monitor_log_process()) and
+ * packets can be compared: the real-time clock when the logging core uses
+ * it, otherwise the system timer that the logging core's default clock
+ * also runs off. Conversions go via microseconds rather than dividing by
+ * hw_cycles / MONITOR_TS_FREQ: the latter truncates badly for cycle rates
+ * that are not a multiple of MONITOR_TS_FREQ (e.g. 32768 Hz yields a
+ * divisor of 3 instead of 3.2768, making the timestamps run 9.2% fast).
+ */
+static uint64_t monitor_ts_get(void)
+{
+	struct timespec ts;
+	uint64_t us;
+
+	if (IS_ENABLED(CONFIG_LOG_TIMESTAMP_USE_REALTIME) &&
+	    sys_clock_gettime(SYS_CLOCK_REALTIME, &ts) == 0) {
+		us = ((uint64_t)ts.tv_sec * USEC_PER_SEC) + (ts.tv_nsec / NSEC_PER_USEC);
+	} else if (IS_ENABLED(CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER)) {
+		us = k_cyc_to_us_floor64(k_cycle_get_64());
+	} else if (sys_clock_hw_cycles_per_sec() > USEC_PER_SEC) {
+		/* A 32-bit cycle counter this fast wraps within minutes, so
+		 * use the tick counter instead, like the logging core does
+		 * (it uses uptime for cycle rates above 1 MHz).
+		 */
+		us = k_ticks_to_us_floor64(k_uptime_ticks());
+	} else {
+		us = k_cyc_to_us_floor64(k_cycle_get_32());
+	}
+
+	return monitor_ts_from_us(us);
+}
+
+static inline void encode_hdr(struct bt_monitor_hdr *hdr, uint64_t timestamp,
 			      uint16_t opcode, uint16_t len)
 {
 	struct bt_monitor_ts32 *ts;
@@ -483,6 +503,7 @@ static void monitor_log_process(const struct log_backend *const backend,
 	struct bt_monitor_user_logging user_log;
 	struct monitor_log_ctx ctx;
 	struct bt_monitor_hdr hdr;
+	uint64_t ts_us;
 	static const char id[] = "bt";
 	struct bt_monitor_data frags[] = {
 		{ &hdr, 0 },    /* Length known only after encode_hdr() */
@@ -498,13 +519,23 @@ static void monitor_log_process(const struct log_backend *const backend,
 	log_output_msg_process(&monitor_log_output, &msg->log,
 			       LOG_OUTPUT_FLAG_CRLF_NONE);
 
+	/* The message is stamped by the logging core's clock, which runs on
+	 * the same time base as monitor_ts_get() but at its own rate.
+	 * Registering monitor_ts_get() as the logging timestamp source
+	 * instead is not an option: this backend is only initialized once
+	 * the logging subsystem starts up (from the logging thread by
+	 * default), so everything logged before that (boot banner, driver and
+	 * Bluetooth initialization) would already be stamped at the original
+	 * rate, with no way to tell such messages apart.
+	 */
+	ts_us = log_output_timestamp_to_us(log_msg_get_timestamp(&msg->log));
+
 	if (atomic_test_and_set_bit(&flags, BT_LOG_BUSY)) {
 		drop_add(BT_MONITOR_USER_LOGGING);
 		return;
 	}
 
-	encode_hdr(&hdr, log_msg_get_timestamp(&msg->log),
-		   BT_MONITOR_USER_LOGGING,
+	encode_hdr(&hdr, monitor_ts_from_us(ts_us), BT_MONITOR_USER_LOGGING,
 		   sizeof(user_log) + sizeof(id) + ctx.total_len + 1);
 
 	user_log.priority = monitor_priority_get(log_msg_get_level(&msg->log));
@@ -570,15 +601,9 @@ static void monitor_log_panic(const struct log_backend *const backend)
 #endif
 }
 
-static void monitor_log_init(const struct log_backend *const backend)
-{
-	log_set_timestamp_func(monitor_ts_get, MONITOR_TS_FREQ);
-}
-
 static const struct log_backend_api monitor_log_api = {
 	.process = monitor_log_process,
 	.panic = monitor_log_panic,
-	.init = monitor_log_init,
 };
 
 LOG_BACKEND_DEFINE(bt_monitor, monitor_log_api, true);


### PR DESCRIPTION
The monitor log backend registered monitor_ts_get() as the logging core's timestamp source from its init callback and then passed message timestamps on to encode_hdr() unconverted, assuming they were already in the monitor's 1/10th millisecond unit. Backends are however only initialized once the logging subsystem starts up, which with the default CONFIG_LOG_PROCESS_THREAD means when the logging thread first gets to run. Everything logged before that point is stamped by the logging core's default clock, i.e. the raw cycle counter (or uptime in milliseconds for cycle counters above 1 MHz), and ends up in btmon in the wrong unit.

With samples/bluetooth/observer on nrf52dk/nrf52832, where the cycle counter runs at 32768 Hz, the logging thread does not run before main() has returned, so the boot banner and all of the Bluetooth initialization messages are affected and show up 3.2768 times too late: the banner, logged at 0.3233 s right before bt_enable() sent the New Index record, carried the timestamp 10595 (its cycle count) and was displayed at 1.0595 s, 0.74 s after the HCI initialization that followed it.

Fix this by leaving the logging core's clock alone and converting the message timestamp through log_output_timestamp_to_us(), which knows the rate of whatever clock the logging core is using, in monitor_log_process(). HCI packets keep being stamped by monitor_ts_get(), which by default derives from the same system timer as the logging core's clock, so log messages and packets stay on a common time base. With the fix the banner is displayed at 0.3046 s against the New Index record at 0.3047 s, and the HW Platform message falls between the Zephyr Read Version Info command complete event that produces it and the next command. Also verified on xg24_rb4186c (32768 Hz cycle counter as well) and on siwx917_rb4338a, whose 180 MHz SysTick makes the logging core default to uptime in milliseconds: on all three boards each "Device found" message is stamped within a millisecond of the advertising report it is logged for. A side effect is that enabling the monitor no longer changes the timestamp rate seen by all other log backends, nor overrides a timestamp source registered by the application.

For the packet timestamps to stay comparable with the converted message timestamps in every configuration, monitor_ts_get() now follows the logging core's choice of clock: the real-time clock with CONFIG_LOG_TIMESTAMP_USE_REALTIME, and the (64-bit) tick counter where a 32-bit cycle counter runs above 1 MHz, since such a counter wraps within minutes while the messages, stamped with uptime by the logging core, do not. Verified on siwx917_rb4338a with its 64-bit cycle counter disabled (CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER=n, the 180 MHz counter then wraps every 24 s): a 60 s capture stays monotonic and the messages stay within a millisecond of their advertising reports throughout. Also verified with CONFIG_LOG_TIMESTAMP_USE_REALTIME on nrf52dk.

monitor_ts_get() is no longer a log_timestamp_get_t, so it and encode_hdr() now use a plain uint64_t; the truncation to the 32-bit wire format stays in encode_hdr().
