### PR TITLE
doc: add some missing API links

### DIFF
--- a/doc/kernel/services/synchronization/events.rst
+++ b/doc/kernel/services/synchronization/events.rst
@@ -134,7 +134,7 @@ of the events are posted in time.
     }
 
 Alternatively, the consumer thread may desire to wait for all the events
-before continuing.
+before continuing using :c:func:`k_event_wait_all`.
 
 .. code-block:: c
 

--- a/doc/kernel/services/synchronization/mutexes.rst
+++ b/doc/kernel/services/synchronization/mutexes.rst
@@ -176,9 +176,9 @@ API Reference
 Futex API Reference
 *******************
 
-k_futex is a lightweight mutual exclusion primitive designed to minimize
+:c:struct:`k_futex` is a lightweight mutual exclusion primitive designed to minimize
 kernel involvement. Uncontended operation relies only on atomic access
-to shared memory. k_futex are tracked as kernel objects and can live in
+to shared memory. :c:struct:`k_futex` are tracked as kernel objects and can live in
 user memory so that any access bypasses the kernel object permission
 management mechanism.
 
@@ -187,8 +187,8 @@ management mechanism.
 User Mode Mutex API Reference
 *****************************
 
-sys_mutex behaves almost exactly like k_mutex, with the added advantage
-that a sys_mutex instance can reside in user memory. When user mode isn't
-enabled, sys_mutex behaves like k_mutex.
+:c:struct:`sys_mutex` behaves almost exactly like :c:struct:`k_mutex`, with the added advantage
+that a :c:struct:`sys_mutex` instance can reside in user memory. When user mode isn't
+enabled, :c:struct:`sys_mutex` behaves like :c:struct:`k_mutex`.
 
 .. doxygengroup:: user_mutex_apis


### PR DESCRIPTION
* doc: mutexes: add missing API links

  I cleaned this up while reading the documentation.

* doc: events: add missing API link

  I noticed there is no direct link to the API of `k_event_wait_all` while
  reading the documentation.

previews:
https://builds.zephyrproject.io/zephyr/pr/117776/docs/kernel/services/synchronization/mutexes.html
https://builds.zephyrproject.io/zephyr/pr/117776/docs/kernel/services/synchronization/events.html