### PR TITLE
drivers: serial: ns16550: prevent DW8250 TX FIFO overflow in fifo_fill

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -1106,6 +1106,15 @@ static int uart_ns16550_fifo_fill(const struct device *dev,
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	for (i = 0; (i < size) && (i < data->fifo_size); i++) {
+		/* uart_ns16550_irq_tx_ready() reports the DW8250 ready as soon
+		 * as its TX FIFO has room, not only when it is empty, so the
+		 * FIFO may already hold data here. Bytes written to a full
+		 * FIFO are lost: stop as soon as it fills up.
+		 */
+		if (IS_ENABLED(CONFIG_UART_NS16550_DW8250_DW_APB) &&
+		    (ns16550_inbyte(dev_cfg, USR(dev)) & USR_TFNF) == 0) {
+			break;
+		}
 		ns16550_outbyte(dev_cfg, THR(dev), tx_data[i]);
 	}
 


### PR DESCRIPTION
With CONFIG_UART_NS16550_DW8250_DW_APB, uart_ns16550_irq_tx_ready() reports the transmitter ready whenever USR.TFNF is set, i.e. as soon as the TX FIFO has room, while uart_ns16550_fifo_fill() writes up to fifo_size bytes without checking how much room there actually is. When the ISR runs with data left in the FIFO, the excess bytes are written to a full FIFO and lost.

On the Silicon Labs SiWx917 (ulpuart, ns16550 with the DW8250 option) this happens right after boot and about once per thousand fills under load: the UART ISR is entered with no interrupt pending (IIR reads 0xC1) while the FIFO still holds 15 of the 16 bytes of the previous fill, so the fill loses up to 15 bytes. With the Bluetooth monitor in interrupt-driven mode on that UART the stream had a truncated New Index frame after every boot and lost 15-byte chunks every 1-2 seconds, while the polled mode was unaffected.

Stop the DW8250 fill loop as soon as USR.TFNF clears, so that the driver never writes more than the FIFO can take and returns the number of bytes it actually accepted.

Fixes #117777
