### PR TITLE
device: Add DEVICE_DT_GET_COMMA macro

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -442,8 +442,6 @@ int intel_adsp_hda_dma_get_attribute(const struct device *dev, uint32_t type, ui
 	return 0;
 }
 
-#define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
-
 void intel_adsp_hda_dma_isr(void)
 {
 #if CONFIG_DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT
@@ -455,10 +453,10 @@ void intel_adsp_hda_dma_isr(void)
 	atomic_val_t enabled_chs;
 	const struct device *host_dev[] = {
 #if CONFIG_DMA_INTEL_ADSP_HDA_HOST_OUT
-		DT_FOREACH_STATUS_OKAY(intel_adsp_hda_host_out, DEVICE_DT_GET_AND_COMMA)
+		DT_FOREACH_STATUS_OKAY(intel_adsp_hda_host_out, DEVICE_DT_GET_COMMA)
 #endif
 #if CONFIG_DMA_INTEL_ADSP_HDA_HOST_IN
-		DT_FOREACH_STATUS_OKAY(intel_adsp_hda_host_in, DEVICE_DT_GET_AND_COMMA)
+		DT_FOREACH_STATUS_OKAY(intel_adsp_hda_host_in, DEVICE_DT_GET_COMMA)
 #endif
 	};
 

--- a/drivers/led/linux_leds.c
+++ b/drivers/led/linux_leds.c
@@ -100,8 +100,6 @@ cleanup:
 	return ret;
 }
 
-#define DEVICE_DT_GET_COMMA(node_id) DEVICE_DT_GET(node_id),
-
 static void linux_leds_cleanup(void)
 {
 	const struct device *devs[] = {

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -317,6 +317,18 @@ typedef int16_t device_handle_t;
 #define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
 
 /**
+ * @brief Like @ref DEVICE_DT_GET, with a trailing comma.
+ *
+ * This is convenient for use with devicetree iteration macros like
+ * @ref DT_FOREACH_STATUS_OKAY.
+ *
+ * @param node_id A devicetree node identifier
+ *
+ * @return A pointer to the device object created for that node, followed by a comma
+ */
+#define DEVICE_DT_GET_COMMA(node_id) DEVICE_DT_GET(node_id),
+
+/**
  * @brief Get a @ref device reference for an instance of a `DT_DRV_COMPAT`
  * compatible.
  *

--- a/samples/subsys/usb/cdc_acm_bridge/src/main.c
+++ b/samples/subsys/usb/cdc_acm_bridge/src/main.c
@@ -21,8 +21,6 @@ const struct device *const uart_dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
 
 static struct usbd_context *sample_usbd;
 
-#define DEVICE_DT_GET_COMMA(node_id) DEVICE_DT_GET(node_id),
-
 const struct device *uart_bridges[] = {
 	DT_FOREACH_STATUS_OKAY(zephyr_uart_bridge, DEVICE_DT_GET_COMMA)
 };

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -28,7 +28,6 @@ struct counter_alarm_cfg cntr_alarm_cfg2;
 
 /* clang-format off */
 
-#define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
 #define DEVICE_DT_GET_AND_COMMA_IF_NOT_SYSTEM_TIMER(node_id) \
 	COND_CODE_1(DT_HAS_CHOSEN(zephyr_system_timer), \
 		(COND_CODE_1(DT_SAME_NODE(node_id, DT_CHOSEN(zephyr_system_timer)), \
@@ -36,7 +35,7 @@ struct counter_alarm_cfg cntr_alarm_cfg2;
 		(DEVICE_DT_GET(node_id),))
 /* Generate a list of devices for all instances of the "compat" */
 #define DEVS_FOR_DT_COMPAT(compat) \
-	DT_FOREACH_STATUS_OKAY(compat, DEVICE_DT_GET_AND_COMMA)
+	DT_FOREACH_STATUS_OKAY(compat, DEVICE_DT_GET_COMMA)
 
 static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_NRF_TIMER

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
@@ -13,10 +13,9 @@ LOG_MODULE_REGISTER(test);
 
 static volatile uint32_t top_cnt;
 
-#define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
 /* Generate a list of devices for all instances of the "compat" */
 #define DEVS_FOR_DT_COMPAT(compat) \
-	DT_FOREACH_STATUS_OKAY(compat, DEVICE_DT_GET_AND_COMMA)
+	DT_FOREACH_STATUS_OKAY(compat, DEVICE_DT_GET_COMMA)
 
 #define DEVICE_DT_GET_REG_AND_COMMA(node_id) (NRF_RTC_Type *)DT_REG_ADDR(node_id),
 /* Generate a list of devices for all instances of the "compat" */

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -64,6 +64,11 @@ DEVICE_DEFINE(manual_dev, "Manual Device", dev_init, NULL,
 DEVICE_DT_DEFINE(TEST_NOLABEL, dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 90, NULL);
 
+static const struct device *const comma_devs[] = {
+	DEVICE_DT_GET_COMMA(TEST_GPIO)
+	DEVICE_DT_GET_COMMA(TEST_I2C)
+};
+
 #define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
 #define DEV_HDL_NAME(name) device_handle_get(DEVICE_GET(name))
 
@@ -94,6 +99,10 @@ ZTEST(devicetree_devices, test_init_get)
 		      DEVICE_GET(manual_dev));
 	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev,
 		      DEVICE_DT_GET(TEST_NOLABEL));
+
+	/* Check DEVICE_DT_GET_COMMA */
+	zassert_equal(comma_devs[0], DEVICE_DT_GET(TEST_GPIO));
+	zassert_equal(comma_devs[1], DEVICE_DT_GET(TEST_I2C));
 
 	/* Check init functions */
 	zassert_equal(DEVICE_DT_GET(TEST_GPIO)->ops.init, dev_init);


### PR DESCRIPTION
Add DEVICE_DT_GET_COMMA helper macro to include/zephyr/device.h to easily get a device pointer followed by a comma when expanding devicetree foreach iterators like DT_FOREACH_STATUS_OKAY.

Update samples, drivers, and tests to use the common definition.
