### PR TITLE
drivers: i2c: target: add auto-register support to regset library

### DIFF
--- a/drivers/i2c/target/regset_target_lib.c
+++ b/drivers/i2c/target/regset_target_lib.c
@@ -261,5 +261,9 @@ int regset_target_lib_init(const struct device *dev)
 	data->config.address = cfg->bus.addr;
 	data->config.callbacks = &regset_target_lib_callbacks;
 
+	if (cfg->auto_register) {
+		return regset_target_lib_register(dev);
+	}
+
 	return 0;
 }

--- a/dts/bindings/i2c/regset-target-base.yaml
+++ b/dts/bindings/i2c/regset-target-base.yaml
@@ -14,3 +14,7 @@ properties:
     description: |
       Number of address bits used to address the EEPROM. If not specified
       the EEPROM is assumed to have a 8-bit address.
+
+  auto-register:
+    type: boolean
+    description: Automatically register target device on the I2C bus at init time.

--- a/include/zephyr/drivers/i2c/target/regset_target_lib.h
+++ b/include/zephyr/drivers/i2c/target/regset_target_lib.h
@@ -51,6 +51,7 @@ struct regset_target_lib_config {
 	uint32_t buffer_size;
 	uint8_t *buffer;
 	uint8_t address_width;
+	bool auto_register;
 	/** @endcond */
 };
 
@@ -161,6 +162,7 @@ int regset_target_lib_init(const struct device *dev);
 	.buffer_size = DT_PROP(node_id, size),			\
 	.buffer = (uint8_t[DT_PROP(node_id, size)]) {},		\
 	.address_width = DT_PROP_OR(node_id, address_width, 8),	\
+	.auto_register = DT_PROP(node_id, auto_register),	\
 }
 
 /**


### PR DESCRIPTION
Add an auto-register boolean devicetree property to the regset target library binding and call regset_target_lib_register() during regset_target_lib_init() when enabled. This allows I2C target devices to be automatically registered on the bus at init time without requiring manual registration.