### PR TITLE
drivers: bflb: Fix bl616cl deinit

### DIFF
--- a/drivers/i2c/i2c_bflb.c
+++ b/drivers/i2c/i2c_bflb.c
@@ -758,7 +758,8 @@ static int i2c_bflb_deinit(const struct device *dev)
 	sys_write32(tmp, config->base + I2C_INT_STS_OFFSET);
 
 	/* disable clocks */
-#if defined(CONFIG_SOC_SERIES_BL61X) || defined(CONFIG_SOC_SERIES_BL808)
+#if defined(CONFIG_SOC_SERIES_BL61X) || defined(CONFIG_SOC_SERIES_BL808) \
+	|| defined(CONFIG_SOC_SERIES_BL616CL)
 	tmp = sys_read32(GLB_BASE + GLB_I2C_CFG0_OFFSET);
 	tmp &= GLB_I2C_CLK_EN_UMSK;
 	sys_write32(tmp, GLB_BASE + GLB_I2C_CFG0_OFFSET);

--- a/drivers/spi/spi_bflb.c
+++ b/drivers/spi/spi_bflb.c
@@ -383,7 +383,7 @@ static int spi_bflb_configure(const struct device *dev, const struct spi_config 
 	tmp |= SPI_CR_SPI_M_CONT_EN;
 	/* disable ignore RX */
 	tmp &= ~SPI_CR_SPI_RXD_IGNR_EN;
-#if defined(CONFIG_SOC_SERIES_BL61X)
+#if defined(CONFIG_SOC_SERIES_BL61X) || defined(CONFIG_SOC_SERIES_BL616CL)
 	tmp &= ~SPI_CR_SPI_S_3PIN_MODE;
 #endif
 
@@ -632,9 +632,17 @@ static int spi_bflb_deinit(const struct device *dev)
 	sys_write32(tmp, cfg->base + SPI_INT_STS_OFFSET);
 
 	/* disable clocks */
-#if defined(CONFIG_SOC_SERIES_BL61X)
+#if defined(CONFIG_SOC_SERIES_BL61X) || defined(CONFIG_SOC_SERIES_BL616CL)
 	tmp = sys_read32(GLB_BASE + GLB_SPI_CFG0_OFFSET);
+#if defined(CONFIG_SOC_SERIES_BL616CL)
+	if (cfg->base == SPI1_BASE) {
+		tmp &= ~GLB_SPI1_CLK_EN_MSK;
+	} else {
+		tmp &= ~GLB_SPI_CLK_EN_MSK;
+	}
+#else
 	tmp &= ~GLB_SPI_CLK_EN_MSK;
+#endif
 	sys_write32(tmp, GLB_BASE + GLB_SPI_CFG0_OFFSET);
 #else
 	tmp = sys_read32(GLB_BASE + GLB_CLK_CFG3_OFFSET);


### PR DESCRIPTION
The deinit toggles were missing when adding the SoC