### PR TITLE
tests: modbus: add raw ADU test scenario for native_sim

### DIFF
--- a/tests/subsys/modbus/src/main.c
+++ b/tests/subsys/modbus/src/main.c
@@ -6,6 +6,7 @@
 
 #include "test_modbus.h"
 
+#if defined(CONFIG_MODBUS_SERIAL)
 ZTEST(modbus, test_setup_low_none)
 {
 	test_server_setup_low_none();
@@ -57,6 +58,7 @@ ZTEST(modbus, test_setup_ascii)
 	test_client_disable();
 	test_server_disable();
 }
+#endif /* CONFIG_MODBUS_SERIAL */
 
 ZTEST(modbus, test_setup_raw)
 {

--- a/tests/subsys/modbus/tests.yaml
+++ b/tests/subsys/modbus/tests.yaml
@@ -15,3 +15,10 @@ tests:
     filter: CONFIG_UART_CONSOLE and CONFIG_UART_INTERRUPT_DRIVEN
     integration_platforms:
       - frdm_k64f
+  modbus.raw:
+    tags: modbus
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
The Modbus test suite can so far only run on hardware with a UART loopback fixture (frdm_k64f), so it is not exercised in CI.

Add a `modbus.raw` scenario that runs the client/server test over raw ADU on native_sim, which does not require a serial line. Guard the serial line dependent tests with `CONFIG_MODBUS_SERIAL` so they are only registered when Modbus serial line support is available.

Tested:
- `modbus.raw` passes on native_sim/native/64 (twister, real client/server raw ADU transaction executed)
- `modbus.rtu` / `modbus.rtu.build_only` still build cleanly for frdm_k64f (CONFIG_MODBUS_SERIAL=y path unchanged)