### PR TITLE
net: ptp: defer timeout wakeups from ISR context

### DIFF
--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -65,6 +65,7 @@ struct ptp_clock {
 	struct ptp_foreign_tt_clock *best;
 	sys_slist_t		    ports_list;
 	struct zsock_pollfd	    pollfd[1 + 2 * CONFIG_PTP_NUM_PORTS];
+	struct k_work timeout_work;
 	bool			    pollfd_valid;
 	bool			    state_decision_event;
 	uint8_t			    time_src;
@@ -276,6 +277,13 @@ static void clock_notify_worker(void)
 	zvfs_eventfd_write(ptp_clk.pollfd[0].fd, 1);
 }
 
+static void clock_timeout_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	clock_notify_worker();
+}
+
 const struct ptp_clock *ptp_clock_init(void)
 {
 	struct ptp_default_ds *dds = &ptp_clk.default_ds;
@@ -326,6 +334,7 @@ const struct ptp_clock *ptp_clock_init(void)
 	}
 	ptp_clk.pollfd[0].fd = ret;
 	ptp_clk.pollfd[0].events = ZSOCK_POLLIN;
+	k_work_init(&ptp_clk.timeout_work, clock_timeout_work_handler);
 
 	sys_slist_init(&ptp_clk.ports_list);
 	LOG_DBG("PTP Clock %s initialized", clock_id_str(&dds->clk_id));
@@ -892,7 +901,7 @@ void ptp_clock_pollfd_invalidate(void)
 
 void ptp_clock_signal_timeout(void)
 {
-	zvfs_eventfd_write(ptp_clk.pollfd[0].fd, 1);
+	k_work_submit(&ptp_clk.timeout_work);
 }
 
 void ptp_clock_state_decision_req(void)

--- a/tests/net/ptp/clock_wakeup/src/main.c
+++ b/tests/net/ptp/clock_wakeup/src/main.c
@@ -29,6 +29,8 @@ static int fake_eventfd_create_calls;
 static int fake_eventfd_write_calls;
 static int fake_eventfd_last_fd;
 static zvfs_eventfd_t fake_eventfd_last_value;
+static int fake_work_submit_calls;
+static struct k_work *fake_work_submit_last;
 static int fake_ptp_clock_get_calls;
 static int fake_ptp_clock_set_calls;
 static int fake_ptp_clock_rate_adjust_calls;
@@ -70,6 +72,14 @@ static int fake_zvfs_eventfd_read(int fd, zvfs_eventfd_t *value)
 	}
 
 	return 0;
+}
+
+static int fake_k_work_submit(struct k_work *work)
+{
+	fake_work_submit_calls++;
+	fake_work_submit_last = work;
+
+	return 1;
 }
 
 static struct net_if *fake_net_if_get_first_by_type(const struct net_l2 *l2)
@@ -229,6 +239,7 @@ int ptp_port_management_msg_process(struct ptp_port *port, struct ptp_port *send
 #define zvfs_eventfd             fake_zvfs_eventfd
 #define zvfs_eventfd_write       fake_zvfs_eventfd_write
 #define zvfs_eventfd_read        fake_zvfs_eventfd_read
+#define k_work_submit            fake_k_work_submit
 #define net_if_get_first_by_type fake_net_if_get_first_by_type
 #define net_if_get_link_addr     fake_net_if_get_link_addr
 #define net_eth_get_ptp_clock    fake_net_eth_get_ptp_clock
@@ -242,6 +253,7 @@ int ptp_port_management_msg_process(struct ptp_port *port, struct ptp_port *send
 #undef net_eth_get_ptp_clock
 #undef net_if_get_link_addr
 #undef net_if_get_first_by_type
+#undef k_work_submit
 #undef zvfs_eventfd_read
 #undef zvfs_eventfd_write
 #undef zvfs_eventfd
@@ -257,6 +269,8 @@ static void reset_clock_state(void)
 	fake_eventfd_write_calls = 0;
 	fake_eventfd_last_fd = -1;
 	fake_eventfd_last_value = 0;
+	fake_work_submit_calls = 0;
+	fake_work_submit_last = NULL;
 	fake_ptp_clock_get_calls = 0;
 	fake_ptp_clock_set_calls = 0;
 	fake_ptp_clock_rate_adjust_calls = 0;
@@ -297,6 +311,25 @@ ZTEST(ptp_clock_wakeup, test_pollfd_invalidate_wakes_worker_after_init)
 
 	zassert_false(ptp_clk.pollfd_valid, "pollfd cache should be invalidated");
 	zassert_equal(fake_eventfd_write_calls, 1, "worker was not woken");
+	zassert_equal(fake_eventfd_last_fd, 17, "unexpected eventfd target");
+	zassert_equal(fake_eventfd_last_value, 1, "unexpected wakeup value");
+}
+
+ZTEST(ptp_clock_wakeup, test_timeout_wakeup_is_deferred)
+{
+	zassert_not_null(ptp_clock_init(), "clock init failed");
+	fake_eventfd_write_calls = 0;
+
+	ptp_clock_signal_timeout();
+
+	zassert_equal(fake_work_submit_calls, 1, "timeout work was not submitted");
+	zassert_equal(fake_work_submit_last, &ptp_clk.timeout_work, "unexpected timeout work item");
+	zassert_equal(fake_eventfd_write_calls, 0,
+		      "eventfd write ran in the timer callback context");
+
+	ptp_clk.timeout_work.handler(&ptp_clk.timeout_work);
+
+	zassert_equal(fake_eventfd_write_calls, 1, "deferred wakeup was not delivered");
 	zassert_equal(fake_eventfd_last_fd, 17, "unexpected eventfd target");
 	zassert_equal(fake_eventfd_last_value, 1, "unexpected wakeup value");
 }


### PR DESCRIPTION
PTP port timers expire in interrupt context. Their expiry handler currently calls `zvfs_eventfd_write()` through  `ptp_clock_signal_timeout()`, but eventfd writes acquire the file descriptor mutex and are therefore not safe from ISR context.

Defer timeout notifications to the system workqueue so the eventfd wakeup is performed from thread context. The xisting per-port timeout bits remain the source of pending events, allowing multiple timer expiries to safely share a queued work item without losing timeout information.

This change does not alter PTP protocol behavior.

A regression test verifies that the timeout path submits work before writing to the eventfd and that the deferred handler delivers the wakeup.
