### PR TITLE
net: ptp: report a transmitter change to the port state machine

### DIFF
--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -66,6 +66,11 @@ struct ptp_clock {
 	sys_slist_t		    ports_list;
 	struct zsock_pollfd	    pollfd[1 + 2 * CONFIG_PTP_NUM_PORTS];
 	struct k_work timeout_work;
+	struct {
+		struct ptp_port_id sender;
+		ptp_clk_id grandmaster;
+		bool valid;
+	} selected_tt;
 	bool			    pollfd_valid;
 	bool			    state_decision_event;
 	uint8_t			    time_src;
@@ -128,6 +133,20 @@ static ptp_timeinterval clock_ns_to_timeinterval(int64_t val)
 	}
 
 	return (uint64_t)val << 16;
+}
+
+static bool clock_selected_tt_matches(const struct ptp_foreign_tt_clock *best)
+{
+	return ptp_clk.selected_tt.valid &&
+	       ptp_port_id_eq(&ptp_clk.selected_tt.sender, &best->dataset.sender) &&
+	       ptp_clock_id_eq(&ptp_clk.selected_tt.grandmaster, &best->dataset.clk_id);
+}
+
+static void clock_selected_tt_update(const struct ptp_foreign_tt_clock *best)
+{
+	ptp_clk.selected_tt.sender = best->dataset.sender;
+	ptp_clk.selected_tt.grandmaster = best->dataset.clk_id;
+	ptp_clk.selected_tt.valid = true;
 }
 
 static int clock_forward_msg(struct ptp_port *ingress,
@@ -326,6 +345,7 @@ const struct ptp_clock *ptp_clock_init(void)
 		LOG_ERR("Couldn't get PTP HW Clock for the interface.");
 		return NULL;
 	}
+	ptp_clk.selected_tt.valid = false;
 
 	ret = zvfs_eventfd(0, ZVFS_EFD_NONBLOCK);
 	if (ret < 0) {
@@ -360,9 +380,17 @@ void ptp_clock_handle_state_decision_evt(void)
 {
 	struct ptp_foreign_tt_clock *best = NULL, *foreign;
 	struct ptp_port *port;
-	bool tt_changed = false;
+	bool receiver_selected = false;
+	bool tt_changed;
 
 	if (!ptp_clk.state_decision_event) {
+		return;
+	}
+
+	if (sys_slist_is_empty(&ptp_clk.ports_list)) {
+		ptp_clk.best = NULL;
+		ptp_clk.selected_tt.valid = false;
+		ptp_clk.state_decision_event = false;
 		return;
 	}
 
@@ -377,6 +405,8 @@ void ptp_clock_handle_state_decision_evt(void)
 	}
 
 	ptp_clk.best = best;
+	tt_changed = best != NULL && ptp_clk.selected_tt.valid &&
+		     !clock_selected_tt_matches(best);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&ptp_clk.ports_list, port, node) {
 		enum ptp_port_state state;
@@ -396,6 +426,7 @@ void ptp_clock_handle_state_decision_evt(void)
 			event = PTP_EVT_RS_TIME_TRANSMITTER;
 			break;
 		case PTP_PS_TIME_RECEIVER:
+			receiver_selected = true;
 			clock_update_time_receiver();
 			event = PTP_EVT_RS_TIME_RECEIVER;
 			break;
@@ -407,7 +438,11 @@ void ptp_clock_handle_state_decision_evt(void)
 			break;
 		}
 
-		ptp_port_event_handle(port, event, tt_changed);
+		ptp_port_event_handle(port, event, tt_changed && state == PTP_PS_TIME_RECEIVER);
+	}
+
+	if (receiver_selected) {
+		clock_selected_tt_update(best);
 	}
 
 	ptp_clk.state_decision_event = false;

--- a/tests/net/ptp/clock_decision/src/main.c
+++ b/tests/net/ptp/clock_decision/src/main.c
@@ -239,14 +239,21 @@ static void map_port(struct ptp_port *port, enum ptp_port_state decision,
 	ctx->last_tt_diff = false;
 }
 
-static void assert_single_event(struct ptp_port *port, enum ptp_port_event expected_event)
+static void assert_single_event_with_tt_diff(struct ptp_port *port,
+					     enum ptp_port_event expected_event,
+					     bool expected_tt_diff)
 {
 	struct port_stub_ctx *ctx = ctx_for_port(port, false);
 
 	zassert_not_null(ctx, "missing context for asserted port");
 	zassert_equal(ctx->event_calls, 1, "unexpected event count");
 	zassert_equal(ctx->last_event, expected_event, "unexpected event value");
-	zassert_false(ctx->last_tt_diff, "tt_diff should remain false");
+	zassert_equal(ctx->last_tt_diff, expected_tt_diff, "unexpected tt_diff value");
+}
+
+static void assert_single_event(struct ptp_port *port, enum ptp_port_event expected_event)
+{
+	assert_single_event_with_tt_diff(port, expected_event, false);
 }
 
 static void reset_clock_decision_state(void)
@@ -478,6 +485,122 @@ ZTEST(ptp_clock_decision, test_time_receiver_update_path)
 		      "UTC offset mismatch");
 	zassert_equal(tpds->flags, msg.header.flags[1], "time_prop flags mismatch");
 	assert_single_event(&port, PTP_EVT_RS_TIME_RECEIVER);
+}
+
+ZTEST(ptp_clock_decision, test_same_transmitter_reappearing_does_not_report_tt_diff)
+{
+	struct ptp_port port;
+	struct ptp_foreign_tt_clock foreign_initial;
+	struct ptp_foreign_tt_clock foreign_reappeared;
+	struct ptp_msg msg_initial;
+	struct ptp_msg msg_reappeared;
+
+	init_announce_msg(&msg_initial, 0x81, 111, 112, 6, 44, 0x5A);
+	init_announce_msg(&msg_reappeared, 0x81, 111, 112, 6, 44, 0x5A);
+	init_port(&port, 0x43, 1);
+	init_foreign(&foreign_initial, &port, make_foreign_desc(0x57, 8, 120, 100, 6),
+		     &msg_initial);
+	map_port(&port, PTP_PS_TIME_RECEIVER, &foreign_initial);
+
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	assert_single_event(&port, PTP_EVT_RS_TIME_RECEIVER);
+
+	map_port(&port, PTP_PS_LISTENING, NULL);
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	zassert_is_null(ptp_clock_best_time_transmitter(),
+			"best transmitter should disappear during source loss");
+	assert_single_event(&port, PTP_EVT_NONE);
+
+	init_foreign(&foreign_reappeared, &port, make_foreign_desc(0x57, 8, 120, 100, 6),
+		     &msg_reappeared);
+	map_port(&port, PTP_PS_TIME_RECEIVER, &foreign_reappeared);
+
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	zassert_equal(ptp_clock_best_time_transmitter(), &foreign_reappeared,
+		      "reappeared transmitter should be selected");
+	assert_single_event(&port, PTP_EVT_RS_TIME_RECEIVER);
+}
+
+ZTEST(ptp_clock_decision, test_local_grandmaster_does_not_replace_selected_transmitter)
+{
+	struct ptp_port port;
+	struct ptp_foreign_tt_clock foreign_initial;
+	struct ptp_foreign_tt_clock foreign_holdover;
+	struct ptp_foreign_tt_clock foreign_reappeared;
+	struct ptp_msg msg_initial;
+	struct ptp_msg msg_reappeared;
+
+	init_announce_msg(&msg_initial, 0x84, 111, 112, 6, 44, 0x5A);
+	init_announce_msg(&msg_reappeared, 0x84, 111, 112, 6, 44, 0x5A);
+	init_port(&port, 0x45, 1);
+	init_foreign(&foreign_initial, &port, make_foreign_desc(0x5A, 8, 120, 100, 6),
+		     &msg_initial);
+	map_port(&port, PTP_PS_TIME_RECEIVER, &foreign_initial);
+
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	assert_single_event(&port, PTP_EVT_RS_TIME_RECEIVER);
+
+	init_foreign(&foreign_holdover, &port, make_foreign_desc(0x5B, 9, 130, 110, 7), NULL);
+	map_port(&port, PTP_PS_GRAND_MASTER, &foreign_holdover);
+
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	assert_single_event(&port, PTP_EVT_RS_GRAND_MASTER);
+
+	init_foreign(&foreign_reappeared, &port, make_foreign_desc(0x5A, 8, 120, 100, 6),
+		     &msg_reappeared);
+	map_port(&port, PTP_PS_TIME_RECEIVER, &foreign_reappeared);
+
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	zassert_equal(ptp_clock_best_time_transmitter(), &foreign_reappeared,
+		      "reappeared transmitter should be selected");
+	assert_single_event(&port, PTP_EVT_RS_TIME_RECEIVER);
+}
+
+ZTEST(ptp_clock_decision, test_different_transmitter_reports_tt_diff)
+{
+	struct ptp_port port;
+	struct ptp_port passive_port;
+	struct ptp_foreign_tt_clock foreign_initial;
+	struct ptp_foreign_tt_clock foreign_new;
+	struct ptp_msg msg_initial;
+	struct ptp_msg msg_new;
+
+	init_announce_msg(&msg_initial, 0x82, 111, 112, 6, 44, 0x5A);
+	init_announce_msg(&msg_new, 0x83, 111, 112, 6, 44, 0x5A);
+	init_port(&port, 0x44, 1);
+	init_foreign(&foreign_initial, &port, make_foreign_desc(0x58, 8, 120, 100, 6),
+		     &msg_initial);
+	map_port(&port, PTP_PS_TIME_RECEIVER, &foreign_initial);
+
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	assert_single_event(&port, PTP_EVT_RS_TIME_RECEIVER);
+
+	init_port(&passive_port, 0x46, 2);
+	map_port(&passive_port, PTP_PS_PASSIVE, NULL);
+	init_foreign(&foreign_new, &port, make_foreign_desc(0x59, 9, 120, 100, 6), &msg_new);
+	map_port(&port, PTP_PS_TIME_RECEIVER, &foreign_new);
+
+	ptp_clock_state_decision_req();
+	ptp_clock_handle_state_decision_evt();
+
+	zassert_equal(ptp_clock_best_time_transmitter(), &foreign_new,
+		      "new transmitter should be selected");
+	assert_single_event_with_tt_diff(&port, PTP_EVT_RS_TIME_RECEIVER, true);
+	assert_single_event(&passive_port, PTP_EVT_RS_PASSIVE);
 }
 
 ZTEST(ptp_clock_decision, test_getters_reflect_selected_best)


### PR DESCRIPTION
`ptp_clock_handle_state_decision_evt()` declared a `tt_changed` flag but never assigned it, so `ptp_port_event_handle()` always received `false`.

IEEE 1588-2019 section 9.2.6.11 requires a `TIME_RECEIVER` port to re-enter `UNCALIBRATED` when the selected Time Transmitter changes. Because the change flag was never set, that existing state-machine transition was unreachable.

Remember the selected transmitter's sender and grandmaster identities and report a change only to the selected `TIME_RECEIVER` port. Preserve the identity across temporary source loss and local grandmaster operation so that the same returning transmitter does not cause a spurious `UNCALIBRATED` transition.

Other ports continue to receive `tt_changed = false`.