### PR TITLE
drivers: udc_rpi_pico: remove confusing error log

### DIFF
--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -447,8 +447,6 @@ static ALWAYS_INLINE void rpi_pico_thread_handler(void *const arg)
 
 			if (!udc_ep_is_busy(ep_cfg)) {
 				rpi_pico_handle_xfer_next(dev, ep_cfg);
-			} else {
-				LOG_ERR("Endpoint 0x%02x busy", ep);
 			}
 		}
 	}


### PR DESCRIPTION
With the commit c3109b9ebe67
("usb: device_next: cdc_acm: rx throughput improvements"), the CDC implementation queues as many buffers as are available. This may trigger an error log, "<err> udc_rpi_pico: Endpoint 0x01 busy". There is nothing wrong with the driver, it is just that another transfer is queued while an endpoint is busy.

Resolves: #117760