### PR TITLE
boards: arm: mps3: doc: fix mps3_an547 board target

### DIFF
--- a/boards/arm/mps3/doc/index.rst
+++ b/boards/arm/mps3/doc/index.rst
@@ -68,7 +68,7 @@ Zephyr board options
 
     .. code-block:: bash
 
-     $ west build -b mps3_an547 samples/hello_world -DEMU_PLATFORM=qemu -t run
+     $ west build -b mps3/corstone300/an547 samples/hello_world -DEMU_PLATFORM=qemu -t run
 
   .. tab:: MPS3 Corstone-300 (AN552)
 


### PR DESCRIPTION
Replace `mps3_an547` with `mps3/corstone300/an547` in QEMU build instruction.