### PR TITLE
debug: gdbstub: drain checksum on oversized packet NACK

### DIFF
--- a/subsys/debug/gdbstub/gdbstub.c
+++ b/subsys/debug/gdbstub/gdbstub.c
@@ -261,6 +261,9 @@ static int gdb_get_packet(uint8_t *buf, size_t buf_len, size_t *len)
 
 	if (*len >= (buf_len - 1)) {
 		LOG_DBG("Packet too large. Got %u but only has %u", *len, (buf_len - 1));
+		/* Drain checksum to keep RX stream aligned with GDB RSP framing */
+		(void)z_gdb_getchar();
+		(void)z_gdb_getchar();
 		/* NACK packet */
 		z_gdb_putchar('-');
 		return -2;


### PR DESCRIPTION
GDB RSP packets are framed as $<payload>#<CS_hi><CS_lo>. When the payload exceeds the receive buffer, gdb_get_packet() NACKed and returned without consuming the two checksum bytes still in the RX stream. Later z_gdb_getchar() calls then read those leftover bytes instead of the expected ACK or next packet start, desynchronizing the session.

Drain and discard the checksum before sending '-' so the stream stays aligned with GDB framing.