### PR TITLE
usb: device_next: cdc_acm: limit RX transfers to one

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -45,7 +45,8 @@ LOG_MODULE_REGISTER(usbd_cdc_acm, CONFIG_USBD_CDC_ACM_LOG_LEVEL);
 #define CDC_ACM_CLASS_SUSPENDED		1
 #define CDC_ACM_IRQ_RX_ENABLED		2
 #define CDC_ACM_IRQ_TX_ENABLED		3
-#define CDC_ACM_TX_FIFO_BUSY		4
+#define CDC_ACM_RX_FIFO_BUSY		4
+#define CDC_ACM_TX_FIFO_BUSY		5
 
 struct cdc_acm_rx_uart_fifo {
 	struct k_fifo *bufs;
@@ -301,6 +302,10 @@ static int usbd_cdc_acm_request(struct usbd_class_data *const c_data,
 				bi->ep, buf->len);
 		}
 
+		if (bi->ep == cdc_acm_get_bulk_out(c_data)) {
+			atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
+		}
+
 		if (bi->ep == cdc_acm_get_bulk_in(c_data)) {
 			atomic_clear_bit(&data->state, CDC_ACM_TX_FIFO_BUSY);
 		}
@@ -319,6 +324,7 @@ static int usbd_cdc_acm_request(struct usbd_class_data *const c_data,
 		if (buf->len == 0) {
 			/* Drop transfer with zero length */
 			net_buf_unref(buf);
+			atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
 			cdc_acm_work_submit(&data->rx_fifo_work);
 			goto ep_buf_already_handled;
 		}
@@ -328,6 +334,8 @@ static int usbd_cdc_acm_request(struct usbd_class_data *const c_data,
 			cdc_acm_work_submit(&data->irq_cb_work);
 		}
 
+		atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
+		cdc_acm_work_submit(&data->rx_fifo_work);
 		goto ep_buf_already_handled;
 	}
 
@@ -723,6 +731,8 @@ static void cdc_acm_rx_fifo_handler(struct k_work *work)
 	struct cdc_acm_uart_data *data;
 	const struct cdc_acm_uart_config *cfg;
 	struct usbd_class_data *c_data;
+	struct udc_buf_info *bi;
+	struct net_buf *buf;
 
 	data = CONTAINER_OF(work, struct cdc_acm_uart_data, rx_fifo_work);
 	cfg = data->dev->config;
@@ -734,25 +744,25 @@ static void cdc_acm_rx_fifo_handler(struct k_work *work)
 		return;
 	}
 
-	while (true) {
-		struct udc_buf_info *bi;
-		struct net_buf *buf;
+	if (atomic_test_and_set_bit(&data->state, CDC_ACM_RX_FIFO_BUSY)) {
+		return;
+	}
 
-		buf = net_buf_alloc(data->rx_fifo.pool, K_NO_WAIT);
-		if (buf == NULL) {
-			break;
-		}
+	buf = net_buf_alloc(data->rx_fifo.pool, K_NO_WAIT);
+	if (buf == NULL) {
+		atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
+		return;
+	}
 
-		/* Shrink the buffer size if operating on a full speed bus */
-		buf->size = MIN(cdc_acm_get_bulk_mps(c_data), buf->size);
+	/* Shrink the buffer size if operating on a full speed bus */
+	buf->size = MIN(cdc_acm_get_bulk_mps(c_data), buf->size);
 
-		bi = udc_get_buf_info(buf);
-		bi->ep = cdc_acm_get_bulk_out(c_data);
-		if (usbd_ep_enqueue(c_data, buf) != 0) {
-			LOG_ERR("Failed to enqueue net_buf for 0x%02x", bi->ep);
-			net_buf_unref(buf);
-			break;
-		}
+	bi = udc_get_buf_info(buf);
+	bi->ep = cdc_acm_get_bulk_out(c_data);
+	if (usbd_ep_enqueue(c_data, buf) != 0) {
+		LOG_ERR("Failed to enqueue net_buf for 0x%02x", bi->ep);
+		net_buf_unref(buf);
+		atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
 	}
 }
 


### PR DESCRIPTION
## Description

With c3109b9 The CDC ACM RX FIFO handler can queue multiple RX transfers for the same endpoint. This causes `-EBUSY` / `Endpoint busy` errors on USB device controllers that only support a single active transfer per endpoint, such as the Raspberry Pi Pico RP2040/RP2350 UDC.

This patch  limits the CDC ACM RX path to one active transfer at a time. The RX FIFO handler uses an atomic busy flag to prevent submitting another transfer while one is already in progress. Once the transfer completes, the busy flag is cleared and the RX work is resubmitted to keep the RX pipeline running.

This preserves the net_buf and k_fifo zero-copy throughput optimizations, but prevents it from overrunning USB device controllers that only support a single active transfer at a time.

Fixes: #117760 

## Testing
The patch was tested on `rp2350`

```minimum
uart:~$ <tab>
  bypass              clear               date
  demo                device              devmem
  dynamic             help                history
  kernel              log                 log_test
  rem                 resize              retval
  section_cmd         shell               shell_uart_release
  stats               version
uart:~$ date get
1970-01-01 00:00:51 UTC
uart:~$ 
```
No `udc_rpi_pico: Endpoint 0x01 busy` errors observed.