### PR TITLE
wifi_mgmt: Add S1G bands and bandwidths

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -293,6 +293,9 @@ enum wifi_frequency_bands {
 	/** 6 GHz band (Wi-Fi 6E, also extends to 7GHz). */
 	WIFI_FREQ_BAND_6_GHZ,
 
+	/** Sub-1GHz band (Wi-Fi HaLow, 802.11ah)*/
+	WIFI_FREQ_BAND_SUB_1_GHZ,
+
 	/** Number of frequency bands available. */
 	__WIFI_FREQ_BAND_AFTER_LAST,
 	/** Highest frequency band available. */
@@ -314,6 +317,15 @@ enum wifi_frequency_bandwidths {
 	WIFI_FREQ_BANDWIDTH_40MHZ,
 	/** 80 MHz. */
 	WIFI_FREQ_BANDWIDTH_80MHZ,
+
+	/** 1 MHz. (Sub-1GHz channels only) */
+	WIFI_FREQ_BANDWIDTH_1MHZ,
+	/** 2 MHz. (Sub-1GHz channels only) */
+	WIFI_FREQ_BANDWIDTH_2MHZ,
+	/** 4 MHz. (Sub-1GHz channels only) */
+	WIFI_FREQ_BANDWIDTH_4MHZ,
+	/** 8 MHz. (Sub-1GHz channels only) */
+	WIFI_FREQ_BANDWIDTH_8MHZ,
 
 	/** Number of frequency bandwidths available. */
 	__WIFI_FREQ_BANDWIDTH_AFTER_LAST,

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -158,6 +158,8 @@ const char *wifi_band_txt(enum wifi_frequency_bands band)
 		return "5GHz";
 	case WIFI_FREQ_BAND_6_GHZ:
 		return "6GHz";
+	case WIFI_FREQ_BAND_SUB_1_GHZ:
+		return "Sub-1GHz";
 	case WIFI_FREQ_BAND_UNKNOWN:
 	default:
 		return "UNKNOWN";
@@ -173,6 +175,14 @@ const char *wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth)
 		return "40 MHz";
 	case WIFI_FREQ_BANDWIDTH_80MHZ:
 		return "80 MHz";
+	case WIFI_FREQ_BANDWIDTH_1MHZ:
+		return "1 MHz";
+	case WIFI_FREQ_BANDWIDTH_2MHZ:
+		return "2 MHz";
+	case WIFI_FREQ_BANDWIDTH_4MHZ:
+		return "4 MHz";
+	case WIFI_FREQ_BANDWIDTH_8MHZ:
+		return "8 MHz";
 	case WIFI_FREQ_BANDWIDTH_UNKNOWN:
 	default:
 		return "UNKNOWN";


### PR DESCRIPTION
Add support for Wi-Fi HaLow (802.11ah) frequency band Sub 1GHz and related bandwidths (1/2/4/8MHz).
As per the 802.11ah specification, opt for S1G as the spectrum ends at 999MHz

--- 

This has been tested on a Zephyr external module adding support for Morse Micro's Wi-Fi HaLow chips. Unfortunately this cannot be upstreamed due to licensing reasons. We intend to upstream a driver in the future. 
