### PR TITLE
soc: nxp: mcxn: move second core release to soc_late_init_hook

### DIFF
--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -77,6 +77,7 @@ if SOC_MCXN947 || SOC_MCXN547
 config SECOND_CORE_MCUX
 	bool "MCXNX4X's second core"
 	depends on HAS_MCUX
+	select SOC_LATE_INIT_HOOK if SOC_MCXN947_CPU0 || SOC_MCXN547_CPU0
 	help
 	  Indicates the second core will be enabled, and the part will run
 	  in dual core mode.

--- a/soc/nxp/mcx/mcxn/cpu_freq_scale.c
+++ b/soc/nxp/mcx/mcxn/cpu_freq_scale.c
@@ -28,9 +28,9 @@ static ALWAYS_INLINE void mcxn_update_system_timer_hz(uint32_t new_hz)
 #if defined(CONFIG_CORTEX_M_SYSTICK)
 #if !defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
 #error "MCXN CPU_FREQ with SysTick requires CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE"
-#endif
+#endif /* ! CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE */
 	z_sys_clock_hw_cycles_per_sec_update((uint32_t)SystemCoreClock);
-#endif
+#endif /* CONFIG_CORTEX_M_SYSTICK */
 }
 
 /* MCXN frequency levels. */

--- a/soc/nxp/mcx/mcxn/flash_clock_setup.c
+++ b/soc/nxp/mcx/mcxn/flash_clock_setup.c
@@ -33,5 +33,4 @@ void flexspi_clock_safe_config(void)
 	/* Switch FLEXSPI to FRO_HF */
 	SYSCON->FLEXSPICLKSEL = 3;
 #endif /* ! CONFIG_TRUSTED_EXECUTION_NONSECURE */
-
 }

--- a/soc/nxp/mcx/mcxn/power.c
+++ b/soc/nxp/mcx/mcxn/power.c
@@ -70,7 +70,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 	case PM_STATE_SUSPEND_TO_RAM:
 		mcxn_pm_suspend_to_ram();
 		break;
-#endif
+#endif /* CONFIG_PM_S2RAM */
 
 	default:
 		break;
@@ -82,7 +82,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(substate_id);
 #if !defined(CONFIG_PM_S2RAM)
 	ARG_UNUSED(state);
-#endif
+#endif /* ! CONFIG_PM_S2RAM */
 
 	if ((SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
 		SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
@@ -94,7 +94,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	if (state == PM_STATE_SUSPEND_TO_RAM) {
 		SPC_ClearPeriphIOIsolationFlag(MCXN_SPC_ADDR);
 	}
-#endif
+#endif /* CONFIG_PM_S2RAM */
 
 	SPC_ClearPowerDomainLowPowerRequestFlag(MCXN_SPC_ADDR, kSPC_PowerDomain0);
 	SPC_ClearPowerDomainLowPowerRequestFlag(MCXN_SPC_ADDR, kSPC_PowerDomain1);

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -8,8 +8,8 @@
  * @file
  * @brief System/hardware module for nxp_mcxn94x platform
  *
- * This module provides routines to initialize and support board-level
- * hardware for the nxp_mcxn94x platform.
+ * This module provides routines to initialize and support soc-level
+ * hardware for the NXP MCXNx4x platform.
  */
 
 #include <zephyr/kernel.h>
@@ -23,7 +23,6 @@
 #endif
 
 #ifdef CONFIG_SOC_EARLY_RESET_HOOK
-
 void soc_early_reset_hook(void)
 {
 	/* SystemInit() disables RAM ECC, so the retained working set in RAMA
@@ -37,11 +36,9 @@ void soc_early_reset_hook(void)
 	 */
 	SYSCON0->ECC_ENABLE_CTRL = 0U;
 }
-
 #endif /* CONFIG_SOC_EARLY_RESET_HOOK */
 
 #ifdef CONFIG_SOC_RESET_HOOK
-
 void soc_reset_hook(void)
 {
 #if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
@@ -51,17 +48,16 @@ void soc_reset_hook(void)
 		SPC_ClearPowerDomainLowPowerRequestFlag(SPC0, kSPC_PowerDomain1);
 		SPC_ClearLowPowerRequest(SPC0);
 	}
-#endif
+#endif /* CONFIG_PM || CONFIG_POWEROFF */
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	SystemInit();
 #endif /* ! CONFIG_TRUSTED_EXECUTION_NONSECURE */
 }
+#endif /* CONFIG_SOC_RESET_HOOK */
 
-#endif
-
-#define FLEXCOMM_CHECK_2(n)                                                                        \
-	BUILD_ASSERT((DT_NODE_HAS_COMPAT(n, nxp_lpuart) == 0) &&                                   \
-			     (DT_NODE_HAS_COMPAT(n, nxp_lpi2c) == 0),                              \
+#define FLEXCOMM_CHECK_2(n)							\
+	BUILD_ASSERT((DT_NODE_HAS_COMPAT(n, nxp_lpuart) == 0) &&		\
+			     (DT_NODE_HAS_COMPAT(n, nxp_lpi2c) == 0),		\
 		     "Do not enable SPI and UART/I2C on the same Flexcomm node");
 
 /* For SPI node enabled, check if UART or I2C is also enabled on the same parent Flexcomm node */
@@ -72,9 +68,8 @@ void soc_reset_hook(void)
  */
 DT_FOREACH_STATUS_OKAY(nxp_lpspi, FLEXCOMM_CHECK)
 
-#if defined(CONFIG_SECOND_CORE_MCUX) &&                                                            \
+#if defined(CONFIG_SECOND_CORE_MCUX) &&						\
 	(defined(CONFIG_SOC_MCXN947_CPU0) || defined(CONFIG_SOC_MCXN547_CPU0))
-
 void soc_late_init_hook(void)
 {
 	/* Configure CPU1 TrustZone access level before CPU1 is enabled */
@@ -95,7 +90,7 @@ void soc_late_init_hook(void)
 	SYSCON->CPUCTRL = temp | SYSCON_CPUCTRL_CPU1RSTEN_MASK | SYSCON_CPUCTRL_CPU1CLKEN_MASK;
 	SYSCON->CPUCTRL = (temp | SYSCON_CPUCTRL_CPU1CLKEN_MASK) & (~SYSCON_CPUCTRL_CPU1RSTEN_MASK);
 }
-#endif
+#endif /* CONFIG_SECOND_CORE_MCUX && (CONFIG_SOC_MCXN947_CPU0 || CONFIG_SOC_MCXN547_CPU0) */
 
 void enable_ecc(uint32_t mask)
 {

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/platform/hooks.h>
 #include <soc.h>
 #if defined(CONFIG_PM) || defined(CONFIG_POWEROFF)
 #include <fsl_spc.h>
@@ -74,8 +75,7 @@ DT_FOREACH_STATUS_OKAY(nxp_lpspi, FLEXCOMM_CHECK)
 #if defined(CONFIG_SECOND_CORE_MCUX) &&                                                            \
 	(defined(CONFIG_SOC_MCXN947_CPU0) || defined(CONFIG_SOC_MCXN547_CPU0))
 
-/* This function is also called at deep sleep resume. */
-static int second_core_boot(void)
+void soc_late_init_hook(void)
 {
 	/* Configure CPU1 TrustZone access level before CPU1 is enabled */
 	AHBSC->MASTER_SEC_LEVEL |=
@@ -94,11 +94,7 @@ static int second_core_boot(void)
 	temp |= 0xc0c40000U;
 	SYSCON->CPUCTRL = temp | SYSCON_CPUCTRL_CPU1RSTEN_MASK | SYSCON_CPUCTRL_CPU1CLKEN_MASK;
 	SYSCON->CPUCTRL = (temp | SYSCON_CPUCTRL_CPU1CLKEN_MASK) & (~SYSCON_CPUCTRL_CPU1RSTEN_MASK);
-
-	return 0;
 }
-
-SYS_INIT(second_core_boot, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif
 
 void enable_ecc(uint32_t mask)


### PR DESCRIPTION
1. compare with `SYS_INIT`, platform hook is a more recommended way, refer to:https://github.com/zephyrproject-rtos/zephyr/issues/75907

2. release second core should be executed after `board_early_init_hook()` to ensure the clock tree and VDD_CORE are configured, and also after `POST_KERNEL` to ensure the mailbox is initialized.