### PR TITLE
soc: nxp: deduplicate the pinctrl_soc.h shims

### DIFF
--- a/soc/nxp/common/pinctrl_soc.h
+++ b/soc/nxp/common/pinctrl_soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/soc/nxp/kinetis/CMakeLists.txt
+++ b/soc/nxp/kinetis/CMakeLists.txt
@@ -4,8 +4,6 @@ zephyr_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG	flash_configuration.c)
 
 add_subdirectory(${CONFIG_SOC_SERIES})
 
-# This is for access to pinctrl macros
-zephyr_include_directories(common)
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
 
 zephyr_linker_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG

--- a/soc/nxp/kinetis/common/pinctrl_soc.h
+++ b/soc/nxp/kinetis/common/pinctrl_soc.h
@@ -1,7 +1,0 @@
-/*
- * Copyright 2024 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/drivers/pinctrl/pinctrl_nxp_port_common.h>

--- a/soc/nxp/mcx/mcxa/pinctrl_soc.h
+++ b/soc/nxp/mcx/mcxa/pinctrl_soc.h
@@ -1,7 +1,0 @@
-/*
- * Copyright 2024 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/drivers/pinctrl/pinctrl_nxp_port_common.h>

--- a/soc/nxp/mcx/mcxc/pinctrl_soc.h
+++ b/soc/nxp/mcx/mcxc/pinctrl_soc.h
@@ -1,7 +1,0 @@
-/*
- * Copyright 2024 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/drivers/pinctrl/pinctrl_nxp_port_common.h>

--- a/soc/nxp/mcx/mcxe/mcxe24x/pinctrl_soc.h
+++ b/soc/nxp/mcx/mcxe/mcxe24x/pinctrl_soc.h
@@ -1,7 +1,0 @@
-/*
- * Copyright 2025 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/drivers/pinctrl/pinctrl_nxp_port_common.h>

--- a/soc/nxp/mcx/mcxl/pinctrl_soc.h
+++ b/soc/nxp/mcx/mcxl/pinctrl_soc.h
@@ -1,7 +1,0 @@
-/*
- * Copyright 2025 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/drivers/pinctrl/pinctrl_nxp_port_common.h>

--- a/soc/nxp/mcx/mcxn/pinctrl_soc.h
+++ b/soc/nxp/mcx/mcxn/pinctrl_soc.h
@@ -1,7 +1,0 @@
-/*
- * Copyright 2024 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/drivers/pinctrl/pinctrl_nxp_port_common.h>

--- a/soc/nxp/mcx/mcxw/mcxw7xx/pinctrl_soc.h
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/pinctrl_soc.h
@@ -1,7 +1,0 @@
-/*
- * Copyright 2024 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/drivers/pinctrl/pinctrl_nxp_port_common.h>


### PR DESCRIPTION
`drivers/pinctrl.h` includes `<pinctrl_soc.h>` by name off the include path, so every SoC using pinctrl has to supply a file with that exact name. For the SoCs driven by the shared NXP PORT pinctrl code that file is a one-line shim to `pinctrl_nxp_port_common.h`, and it was copy-pasted eight times.

Keep a single copy in `soc/nxp/common/`, which is already on the include path of every NXP family via `zephyr_include_directories(../common)` and already hosts `soc_common.h` for the same reason. Drop the seven other copies, and with them the now-empty `soc/nxp/kinetis/common/` and the `kinetis include_directories()` line that only existed to reach it.

SoC-local include directories are searched before `soc/nxp/common`, so SoCs that need a different `pinctrl_soc.h` keep resolving to their own. Verified by building `samples/hello_world` on 17 boards and checking which header each one actually resolved, via the ninja dependency log:

resolves to `soc/nxp/common/`: frdm_k64f, frdm_kl25z, frdm_ke16z, frdm_mcxa156, frdm_mcxc242, frdm_mcxe247,                            frdm_mcxl255, frdm_mcxn947, frdm_mcxw71, s32k148_evb

resolves to its own: frdm_mcxe31b, frdm_mcxw23, mr_canhubk3, lpcxpresso55s69, frdm_rw612, mimxrt1064_evk, mimxrt1170_evk