### PR TITLE
boards: nxp: switch mcxe and Kinetis kv/ke/K boards to mapped partitions

### DIFF
--- a/boards/mikroe/hexiwear/hexiwear_mk64f12.dts
+++ b/boards/mikroe/hexiwear/hexiwear_mk64f12.dts
@@ -194,7 +194,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -203,22 +203,26 @@
 		 * to the flash memory sector size of 4KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(420)>;
 		};
 
 		slot1_partition: partition@79000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00079000 DT_SIZE_K(420)>;
 		};
 
 		storage_partition: partition@e2000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000e2000 DT_SIZE_K(120)>;
 		};

--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -213,7 +213,7 @@ zephyr_uhc0: &usbh {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -222,22 +222,26 @@ zephyr_uhc0: &usbh {
 		 * to the flash memory sector size of 2KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(182)>;
 		};
 
 		slot1_partition: partition@3d800 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x0003d800 DT_SIZE_K(182)>;
 		};
 
 		storage_partition: partition@6b000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0006b000 DT_SIZE_K(84)>;
 		};

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -240,7 +240,7 @@ zephyr_udc0: &usbotg {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -249,22 +249,26 @@ zephyr_udc0: &usbotg {
 		 * to the flash memory sector size of 4KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(420)>;
 		};
 
 		slot1_partition: partition@79000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00079000 DT_SIZE_K(420)>;
 		};
 
 		storage_partition: partition@e2000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000e2000 DT_SIZE_K(120)>;
 		};

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -161,7 +161,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -170,21 +170,25 @@
 		 * to the flash memory sector size of 4KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(44)>;
 		};
 
 		slot0_partition: partition@b000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xb000 DT_SIZE_K(100)>;
 		};
 
 		slot1_partition: partition@24000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x24000 DT_SIZE_K(100)>;
 		};
 
 		storage_partition: partition@3d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3d000 DT_SIZE_K(12)>;
 		};

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -187,7 +187,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -196,21 +196,25 @@
 		 * to the flash memory sector size of 2KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(44)>;
 		};
 
 		slot0_partition: partition@b000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xb000 DT_SIZE_K(100)>;
 		};
 
 		slot1_partition: partition@24000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x24000 DT_SIZE_K(100)>;
 		};
 
 		storage_partition: partition@3d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3d000 DT_SIZE_K(12)>;
 		};

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -208,7 +208,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -217,22 +217,26 @@
 		 * to the flash memory sector size of 2KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(204)>;
 		};
 
 		slot1_partition: partition@43000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00043000 DT_SIZE_K(204)>;
 		};
 
 		storage_partition: partition@76000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00076000 DT_SIZE_K(40)>;
 		};

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -110,16 +110,18 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		ivt_header: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "ivt-header";
 			reg = <0x00000000 0x100>;
 		};
 
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x00000100 (DT_SIZE_K(3920) - 0x100)>;
 		};

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -349,7 +349,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -358,22 +358,26 @@
 		 * to the flash memory sector size of 4KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(204)>;
 		};
 
 		slot1_partition: partition@43000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00043000 DT_SIZE_K(204)>;
 		};
 
 		storage_partition: partition@76000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00076000 DT_SIZE_K(40)>;
 		};

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
@@ -118,7 +118,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -127,22 +127,26 @@
 		 * to the flash memory sector size of 8KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(424)>;
 		};
 
 		slot1_partition: partition@7a000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x0007a000 DT_SIZE_K(424)>;
 		};
 
 		storage_partition: partition@e4000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000e4000 DT_SIZE_K(112)>;
 		};

--- a/boards/segger/ip_k66f/ip_k66f.dts
+++ b/boards/segger/ip_k66f/ip_k66f.dts
@@ -68,11 +68,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;
 			read-only;
@@ -84,21 +85,25 @@
 		 * by the application.
 		 */
 		storage_partition: partition@1e000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0001e000 0x00002000>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x00060000>;
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00080000 0x00060000>;
 		};
 
 		scratch_partition: partition@e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x000e0000 0x00020000>;
 		};

--- a/dts/arm/nxp/kinetis/k2x/nxp_k2x.dtsi
+++ b/dts/arm/nxp/kinetis/k2x/nxp_k2x.dtsi
@@ -127,6 +127,7 @@
 			interrupt-names = "command-complete", "read-collision";
 			status = "okay";
 
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -135,6 +136,9 @@
 				reg = <0 DT_SIZE_M(1)>;
 				erase-block-size = <DT_SIZE_K(2)>;
 				write-block-size = <8>;
+				ranges;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/arm/nxp/kinetis/k6x/nxp_k6x.dtsi
+++ b/dts/arm/nxp/kinetis/k6x/nxp_k6x.dtsi
@@ -158,6 +158,7 @@
 			interrupt-names = "command-complete", "read-collision";
 			status = "okay";
 
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -166,6 +167,9 @@
 				reg = <0 DT_SIZE_M(1)>;
 				erase-block-size = <DT_SIZE_K(4)>;
 				write-block-size = <8>;
+				ranges;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/arm/nxp/kinetis/k8x/nxp_k8x.dtsi
+++ b/dts/arm/nxp/kinetis/k8x/nxp_k8x.dtsi
@@ -103,6 +103,7 @@
 			interrupt-names = "command-complete", "read-collision";
 			status = "okay";
 
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/dts/arm/nxp/kinetis/k8x/nxp_k8xfn256vxx15.dtsi
+++ b/dts/arm/nxp/kinetis/k8x/nxp_k8xfn256vxx15.dtsi
@@ -36,5 +36,8 @@
 		reg = <0x0 DT_SIZE_K(256)>;
 		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <4>;
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 };

--- a/dts/arm/nxp/kinetis/ke1xf/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/kinetis/ke1xf/nxp_ke1xf.dtsi
@@ -327,6 +327,7 @@
 			interrupts = <18 0>, <19 0>;
 			interrupt-names = "command-complete", "read-collision";
 
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/dts/arm/nxp/kinetis/ke1xf/nxp_ke1xf512vlx16.dtsi
+++ b/dts/arm/nxp/kinetis/ke1xf/nxp_ke1xf512vlx16.dtsi
@@ -36,5 +36,8 @@
 		reg = <0 DT_SIZE_K(512)>;
 		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <8>;
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 };

--- a/dts/arm/nxp/kinetis/ke1xz/nxp_ke17z.dtsi
+++ b/dts/arm/nxp/kinetis/ke1xz/nxp_ke17z.dtsi
@@ -36,6 +36,7 @@
 			reg = <0x40020000 0x1000>;
 			interrupts = <5 0>;
 
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -44,6 +45,9 @@
 				reg = <0 DT_SIZE_K(256)>;
 				erase-block-size = <DT_SIZE_K(2)>;
 				write-block-size = <8>;
+				ranges;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/arm/nxp/kinetis/ke1xz/nxp_ke17z512.dtsi
+++ b/dts/arm/nxp/kinetis/ke1xz/nxp_ke17z512.dtsi
@@ -45,6 +45,7 @@
 			interrupts = <5 0>;
 			interrupt-names = "command-complete";
 
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -53,6 +54,9 @@
 				reg = <0 DT_SIZE_K(512)>;
 				erase-block-size = <DT_SIZE_K(2)>;
 				write-block-size = <8>;
+				ranges;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/arm/nxp/kinetis/kv5x/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/kinetis/kv5x/nxp_kv5x.dtsi
@@ -97,6 +97,7 @@
 			interrupts = <18 0>, <19 0>;
 			interrupt-names = "command-complete", "read-collision";
 
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/dts/arm/nxp/kinetis/kv5x/nxp_kv5xf1m0vlx24.dtsi
+++ b/dts/arm/nxp/kinetis/kv5x/nxp_kv5xf1m0vlx24.dtsi
@@ -23,5 +23,8 @@
 		reg = <0x10000000 DT_SIZE_K(1024)>;
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <8>;
+		ranges = <0x0 0x10000000 DT_SIZE_K(1024)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 };

--- a/dts/arm/nxp/kinetis/kv5x/nxp_kv5xf512vlx24.dtsi
+++ b/dts/arm/nxp/kinetis/kv5x/nxp_kv5xf512vlx24.dtsi
@@ -23,5 +23,8 @@
 		reg = <0x10000000 DT_SIZE_K(512)>;
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <8>;
+		ranges = <0x0 0x10000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 };

--- a/dts/arm/nxp/mcx/mcxe/nxp_mcxe31b.dtsi
+++ b/dts/arm/nxp/mcx/mcxe/nxp_mcxe31b.dtsi
@@ -101,9 +101,12 @@
 	ranges = <0x0 0x00400000 DT_SIZE_K(3920)>;
 
 	flash0: flash@0 {
-		compatible = "nxp,c40-flash";
+		compatible = "nxp,c40-flash", "soc-nv-flash";
 		reg = <0x0 DT_SIZE_K(3920)>;
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <8>;
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 };


### PR DESCRIPTION
Switch 10 NXP boards from `fixed-partitions` to `zephyr,mapped-partition`
per the 4.4 migration guide; all were still listed in #107737.

* mcxe: `frdm_mcxe31b`
* kv5x: `twr_kv58f220m`
* ke: `frdm_ke17z`, `frdm_ke17z512`, `twr_ke18f`
* Kinetis K: `frdm_k22f`, `frdm_k64f`, `frdm_k82f`, `ip_k66f`,
  `hexiwear_mk64f12`

The SoC dtsi commits add the `ranges` needed for partition address
translation. Two special cases: the mcxe flash node also needs a
`soc-nv-flash` fallback compatible, because `gen_defines.py` checks
`compatible` literally rather than following binding includes; and the
ke1xz variants `/delete-node/` the shared flash controller, so their
`ranges` has to go into each redefinition.

`rddrone_fmuk66` (shares `nxp_k6x.dtsi`) and `frdm_ke15z` (sets no
`zephyr,code-partition`) intentionally stay on `fixed-partitions`, which
the added `ranges` does not affect.

Offsets and sizes are unchanged: `hello_world` with
`CONFIG_USE_DT_CODE_PARTITION=y` produces a byte-identical `zephyr.bin` on
all 10 boards, with `CONFIG_FLASH_LOAD_OFFSET`/`_SIZE` giving way to
`CONFIG_FLASH_USES_MAPPED_PARTITION=y`. Each commit builds standalone.
