### PR TITLE
close - error pr

### DIFF
--- a/drivers/disk/nvme/Kconfig
+++ b/drivers/disk/nvme/Kconfig
@@ -52,7 +52,7 @@ config NVME_REQUEST_TIMEOUT
 	range 5 120
 	default 5
 	help
-	  This sets the waiting time for a request to succeed.
+	  This sets the waiting time for a request to succeed, in seconds.
 	  Do not touch this unless you know what you are doing.
 
 config NVME_PRP_PAGE_SIZE

--- a/drivers/disk/nvme/nvme_cmd.c
+++ b/drivers/disk/nvme/nvme_cmd.c
@@ -266,27 +266,32 @@ struct nvme_request *nvme_cmd_request_alloc(void)
 
 static void nvme_cmd_register_request(struct nvme_request *request)
 {
+	const uint32_t timeout_ms =
+		CONFIG_NVME_REQUEST_TIMEOUT * MSEC_PER_SEC;
+
 	sys_dlist_append(&pending_request, &request->node);
 
 	request->req_start = k_uptime_get_32();
 
 	if (!k_work_delayable_remaining_get(&request_timer)) {
-		k_work_reschedule(&request_timer,
-				  K_SECONDS(CONFIG_NVME_REQUEST_TIMEOUT));
+		k_work_reschedule(&request_timer, K_MSEC(timeout_ms));
 	}
 }
 
 static void request_timeout(struct k_work *work)
 {
+	const uint32_t timeout_ms =
+		CONFIG_NVME_REQUEST_TIMEOUT * MSEC_PER_SEC;
 	uint32_t current = k_uptime_get_32();
 	struct nvme_request *request, *next;
+	int32_t remain = 0;
 
 	ARG_UNUSED(work);
 
 	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&pending_request,
 					  request, next, node) {
-		if ((int32_t)(request->req_start +
-			      CONFIG_NVME_REQUEST_TIMEOUT - current) > 0) {
+		remain = (int32_t)(request->req_start + timeout_ms - current);
+		if (remain > 0) {
 			break;
 		}
 
@@ -306,11 +311,8 @@ static void request_timeout(struct k_work *work)
 		nvme_cmd_request_free(request);
 	}
 
-	if (request) {
-		k_work_reschedule(&request_timer,
-				  K_SECONDS(request->req_start +
-					    CONFIG_NVME_REQUEST_TIMEOUT -
-					    current));
+	if (request && remain > 0) {
+		k_work_reschedule(&request_timer, K_MSEC(remain));
 	}
 }
 


### PR DESCRIPTION
## Problem

CONFIG_NVME_REQUEST_TIMEOUT is documented and ranged in seconds, but the
request timeout path compared k_uptime_get_32 values in milliseconds
without converting. Default 5 therefore expired after about 5 ms instead
of 5 seconds.

## Fix

Convert the Kconfig value with MSEC_PER_SEC before scheduling and expiry
checks, and reschedule with K_MSEC using the remaining time. Clarify the
Kconfig help text that the unit is seconds.

The FreeBSD NVMe host driver this path follows converts a seconds timeout
with SBT_1S before comparing against the request start time. Apply the
same seconds-to-milliseconds conversion here.

## Testing

Static review of drivers/disk/nvme/nvme_cmd.c timeout path against
CONFIG_NVME_REQUEST_TIMEOUT Kconfig help and range. No hardware run in
this submission.

Made with [Cursor](https://cursor.com)