### PR TITLE
lib: cbprintf: nano: fix out-of-bounds %s read with precision

### DIFF
--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* for strnlen() */
+
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
@@ -296,9 +299,15 @@ start:
 			SKIP_TAG_IF_NEEDED(ap, tagged_ap);
 
 			data = va_arg(ap, char *);
-			data_len = strlen(data);
-			if (precision >= 0 && data_len > precision) {
-				data_len = precision;
+			/*
+			 * Use strnlen() when a precision is given so the scan
+			 * for the NUL terminator stops at the precision and
+			 * does not read past a buffer that lacks a terminator.
+			 */
+			if (precision >= 0) {
+				data_len = strnlen(data, precision);
+			} else {
+				data_len = strlen(data);
 			}
 			precision = 0;
 			break;


### PR DESCRIPTION
## Description

Formatting a string with `%s` and a precision (e.g. `%.*s` or `%.5s`) in the space-optimized cbprintf implementation (`CONFIG_CBPRINTF_NANO`) calls `strlen()` on the argument before applying the precision. A precision is precisely what lets callers pass a buffer that is not NUL-terminated, so `strlen()` reads past the end of such a buffer even though the precision correctly clamps the emitted output.

The complete implementation already bounds the scan with `strnlen()`. Do the same in the nano implementation: when a precision is present use `strnlen(data, precision)`, otherwise keep `strlen()`. Also define `_POSIX_C_SOURCE` at the top of the file so the libc headers declare `strnlen()`, matching `cbprintf_complete.c`.

Fixes zephyrproject-rtos/zephyr#117791

## Testing

The out-of-bounds read was reproduced by compiling `lib/os/cbprintf_nano.c` into a host harness under AddressSanitizer: formatting a non-NUL-terminated buffer with `%.*s` reported a heap-buffer-overflow read in
`z_cbvprintf_impl()`; with the fix the report is gone and the formatted output is unchanged.

On-target verification used QEMU (`native_sim` cannot run on this macOS host):
- `west twister -p qemu_cortex_m3 -T tests/lib/sprintf`: pass
- `west twister -p qemu_cortex_m3 -T tests/lib/cbprintf_package`: pass,
  including the `CONFIG_CBPRINTF_NANO` variants
- a `CONFIG_MINIMAL_LIBC` + `CONFIG_CBPRINTF_NANO` build of the
  cbprintf_package test run on `qemu_cortex_m3`: pass

`scripts/checkpatch.pl` on the commit reports no errors or warnings.

## Checklist
- [x] DCO Signed-off-by: Rithwik Reddy Eedula <rithwikreddy.eedula@sjsu.edu>
- [ ] Added relevant documentation / Kconfig / Devicetree updates (if applicable)
- [x] Verified with `sanitycheck` or relevant local tests
