### PR TITLE
kernel: queue: fix unique append for allocated nodes

### DIFF
--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -385,6 +385,7 @@ bool k_queue_remove(struct k_queue *queue, void *data)
 	return ret;
 }
 
+/* Compare queue items by payload, including allocated wrapper nodes. */
 bool k_queue_unique_append(struct k_queue *queue, void *data)
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_queue, unique_append, queue);
@@ -393,7 +394,7 @@ bool k_queue_unique_append(struct k_queue *queue, void *data)
 	sys_sfnode_t *test;
 
 	SYS_SFLIST_FOR_EACH_NODE(&queue->data_q, test) {
-		if (test == (sys_sfnode_t *) data) {
+		if (z_queue_node_peek(test, false) == data) {
 			k_spin_unlock(&queue->lock, key);
 			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_queue, unique_append, queue, false);
 

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -984,3 +984,40 @@ ZTEST(queue_api, test_queue_unique_append)
 	ret = k_queue_unique_append(&queue, (void *)&data[1]);
 	zassert_true(ret, "queue unique append failed");
 }
+
+/**
+ * @brief Verify k_queue_unique_append() detects allocated duplicate entries.
+ *
+ * @details
+ * k_queue_alloc_append() and k_queue_alloc_prepend() store the payload in an
+ * internal wrapper node. k_queue_unique_append() must compare against the
+ * payload pointer rather than the wrapper node address.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_alloc_append()
+ * @see k_queue_alloc_prepend()
+ * @see k_queue_unique_append()
+ */
+ZTEST(queue_api, test_queue_unique_append_alloc)
+{
+	static qdata_t append_data = { .data = 0x42, .allocated = false };
+	static qdata_t prepend_data = { .data = 0x43, .allocated = false };
+
+	k_queue_init(&queue);
+	k_thread_heap_assign(k_current_get(), &mem_pool_pass);
+
+	zassert_ok(k_queue_alloc_append(&queue, &append_data),
+		   "alloc_append failed");
+	zassert_false(k_queue_unique_append(&queue, &append_data),
+		      "duplicate alloc_append entry was accepted");
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), &append_data,
+		      "unexpected alloc_append payload");
+
+	zassert_ok(k_queue_alloc_prepend(&queue, &prepend_data),
+		   "alloc_prepend failed");
+	zassert_false(k_queue_unique_append(&queue, &prepend_data),
+		      "duplicate alloc_prepend entry was accepted");
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), &prepend_data,
+		      "unexpected alloc_prepend payload");
+}


### PR DESCRIPTION
k_queue_alloc_append() and k_queue_alloc_prepend() wrap the caller's payload in an internal alloc_node before inserting it into the queue. k_queue_unique_append() compared the raw node address with the caller's payload pointer, so it accepted duplicate payloads when an allocated queue item was already present.

Compare the unwrapped payload returned by z_queue_node_peek() instead. Add regression coverage for duplicate entries inserted through both allocation APIs.

Tested on qemu_cortex_m3:
- queue_api: 16 tests passed, 0 failed
- queue_api_1cpu: 7 tests passed, 0 failed
- PROJECT EXECUTION SUCCESSFUL

Fixes: 2b9b4b2cf71e ("k_queue: allow user mode access via allocators")