### PR TITLE
Bluetooth: Classic: AVDTP: Cancel timeout work on disconnect

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -811,8 +811,6 @@ static int avdtp_send(struct bt_avdtp *session,
 	req->tid = AVDTP_GET_TR_ID(hdr->hdr);
 	LOG_DBG("sig 0x%02X, tid 0x%02X", req->sig, req->tid);
 
-	/* Init the timer */
-	k_work_init_delayable(&session->timeout_work, avdtp_timeout);
 	/* Start timeout work */
 	k_work_reschedule(&session->timeout_work, AVDTP_TIMEOUT);
 	return result;
@@ -863,6 +861,9 @@ void bt_avdtp_l2cap_disconnected(struct bt_l2cap_chan *chan)
 	struct bt_avdtp *session = AVDTP_CHAN(chan);
 
 	LOG_DBG("chan %p session %p", chan, session);
+
+	k_work_cancel_delayable(&session->timeout_work);
+
 	session->br_chan.chan.conn = NULL;
 	session->signalling_l2cap_connected = 0;
 	/* todo: Clear the Pending req if set*/
@@ -987,6 +988,7 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 	}
 
 	session->signalling_l2cap_connected = 1;
+	k_work_init_delayable(&session->timeout_work, avdtp_timeout);
 	session->br_chan.rx.mtu	= BT_L2CAP_RX_MTU;
 	session->br_chan.chan.ops = &ops;
 	session->br_chan.required_sec_level = BT_SECURITY_L2;
@@ -1027,6 +1029,7 @@ int bt_avdtp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 			.recv = bt_avdtp_l2cap_recv,
 		};
 		session->signalling_l2cap_connected = 1;
+		k_work_init_delayable(&session->timeout_work, avdtp_timeout);
 		session->br_chan.chan.ops = &ops;
 		session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
 		*chan = &session->br_chan.chan;


### PR DESCRIPTION
Every AVDTP response handler cancels session->timeout_work before clearing the pending request, but bt_avdtp_l2cap_disconnected() only clears the request. A command that is still outstanding when the signalling channel goes down therefore leaves the AVDTP_TIMEOUT timer armed.

The stale timeout itself is harmless (session->req is NULL by the time it fires), but the session object is embedded in struct bt_a2dp, and a2dp_get_connection() wipes that struct with memset() when the connection slot is reused. Zeroing a delayable work whose timeout is still linked into the kernel timeout list corrupts the kernel's timeout bookkeeping.

Cancel the timeout work on disconnect, like the response handlers do. To make sure the work item is always initialized by the time the disconnected callback can run, move its initialization from avdtp_send_cmd() to the session establishment paths (bt_avdtp_connect() and bt_avdtp_l2cap_accept()), next to the existing session work initialization. This also stops avdtp_send_cmd() from re-initializing the work item on every command.

(cherry picked from commit a10d18c3be9d1a968574dbfbce6baee58ea398e8)

Fixes: #116687