### PR TITLE
scripts: twister: pack subsets by test suite instead of slicing

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -10,6 +10,7 @@ import copy
 import glob
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -18,7 +19,6 @@ import sys
 import time
 from argparse import Namespace
 from collections import OrderedDict
-from itertools import islice
 from pathlib import Path
 
 from twisterlib import ZEPHYR_BASE
@@ -46,6 +46,11 @@ from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite, scan_testsuite_path
 
 logger = logging.getLogger('twister')
+
+# Largest share of one subset a single test suite may occupy before it is cut
+# up between subsets. Keeping suites whole matters more than perfect balance,
+# but a suite bigger than this would leave its subset unable to catch up.
+SUBSET_UNIT_DIVISOR = 4
 
 # Directory holding twister's YAML schemas.
 TWISTER_SCHEMA_DIR = os.path.join(ZEPHYR_BASE, "scripts", "schemas", "twister")
@@ -358,22 +363,28 @@ class TestPlan:
         # This fixes an issue where some sets would get majority of skips and
         # basically run nothing beside filtering.
         to_run = {k : v for k,v in self.instances.items() if v.status == TwisterStatus.NONE}
-        total = len(to_run)
-        per_set = int(total / sets)
-        num_extra_sets = total - (per_set * sets)
 
-        # Try and be more fair for rounding error with integer division
-        # so the last subset doesn't get overloaded, we add 1 extra to
-        # subsets 1..num_extra_sets.
-        if subset <= num_extra_sets:
-            start = (subset - 1) * (per_set + 1)
-            end = start + per_set + 1
-        else:
-            base = num_extra_sets * (per_set + 1)
-            start = ((subset - num_extra_sets - 1) * per_set) + base
-            end = start + per_set
+        # Keep a test suite's instances together so that a suite failing on many
+        # platforms fails one subset rather than most of them. Suites too large
+        # to fit are cut up, otherwise one of them outweighs a whole subset.
+        limit = max(1, math.ceil(len(to_run) / (sets * SUBSET_UNIT_DIVISOR)))
+        by_suite = OrderedDict()
+        for name, instance in to_run.items():
+            by_suite.setdefault(instance.testsuite.name, []).append((name, instance))
+        units = []
+        for group in by_suite.values():
+            units += [group[i:i + limit] for i in range(0, len(group), limit)]
 
-        sliced_instances = islice(to_run.items(), start, end)
+        # Pack the units largest first into whichever subset is lightest. Simply
+        # slicing the list would hand each subset one alphabetical slab of the
+        # tree, and slabs differ widely in build cost.
+        buckets = [[] for _ in range(sets)]
+        load = [0] * sets
+        for unit in sorted(units, key=len, reverse=True):
+            lightest = load.index(min(load))
+            buckets[lightest] += unit
+            load[lightest] += len(unit)
+        sliced_instances = buckets[subset - 1]
         skipped = {k : v for k,v in self.instances.items() if v.status == TwisterStatus.SKIP}
         errors = {k : v for k,v in self.instances.items() if v.status == TwisterStatus.ERROR}
         self.instances = OrderedDict(sliced_instances)

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1017,23 +1017,23 @@ def test_testplan_load(
 
 TESTDATA_5 = [
     (False, False, None, 1, 2,
-     ['plat1/testA', 'plat2/testA', 'plat1/testB',
+     ['plat1/testA', 'plat1/testB', 'plat1/testC',
       'plat3/testA', 'plat3/testB', 'plat3/testC']),
     (False, False, None, 1, 5,
      ['plat1/testA',
       'plat3/testA', 'plat3/testB', 'plat3/testC']),
     (False, False, None, 2, 2,
-     ['plat2/testB', 'plat1/testC']),
+     ['plat2/testA', 'plat2/testB']),
     (True, False, None, 1, 2,
-     ['plat1/testA', 'plat2/testA', 'plat1/testB',
+     ['plat1/testA', 'plat1/testB', 'plat1/testC',
       'plat3/testA', 'plat3/testB', 'plat3/testC']),
     (True, False, None, 2, 2,
-     ['plat2/testB', 'plat1/testC']),
+     ['plat2/testA', 'plat2/testB']),
     (True, True, 123, 1, 2,
      ['plat2/testA', 'plat2/testB', 'plat1/testC',
       'plat3/testB', 'plat3/testA', 'plat3/testC']),
     (True, True, 123, 2, 2,
-     ['plat1/testB', 'plat1/testA']),
+     ['plat1/testA', 'plat1/testB']),
 ]
 
 @pytest.mark.parametrize(
@@ -1078,6 +1078,86 @@ def test_testplan_generate_subset(
 
     assert [instance for instance in testplan.instances.keys()] == \
            expected_subset
+
+
+def _place(instances, sets):
+    """Run every subset over the same instances; return names seen and, per test
+    suite, the set of subsets its instances landed in."""
+    seen = []
+    placement = {}
+    for subset in range(1, sets + 1):
+        testplan = TestPlan(env=mock_twister_env())
+        testplan.options = mock.Mock(
+            device_testing=False, shuffle_tests=False, shuffle_tests_seed=None
+        )
+        testplan.instances = dict(instances)
+        testplan.generate_subset(subset, sets)
+        seen.extend(testplan.instances.keys())
+        for inst in testplan.instances.values():
+            placement.setdefault(inst.testsuite.name, set()).add(subset)
+    return seen, placement
+
+
+@pytest.mark.parametrize('sets', [2, 3, 5, 7, 30], ids=lambda s: f'{s} sets')
+def test_testplan_generate_subset_covers_every_instance_once(sets):
+    """Every runnable instance lands in exactly one subset, whatever the number
+    of sets, and pre-filtered ones are not handed out at all."""
+    instances = {}
+    for suite in range(11):
+        for plat in range(7):
+            status = TwisterStatus.FILTER if (suite + plat) % 3 == 0 else TwisterStatus.NONE
+            inst = mock.Mock(status=status)
+            inst.testsuite.name = f'test{suite}'
+            instances[f'plat{plat}/test{suite}'] = inst
+    runnable = [name for name, inst in instances.items() if inst.status == TwisterStatus.NONE]
+
+    seen, _ = _place(instances, sets)
+
+    assert sorted(seen) == sorted(runnable)
+
+
+@pytest.mark.parametrize('sets', [2, 3, 4, 8], ids=lambda s: f'{s} sets')
+def test_testplan_generate_subset_keeps_suites_whole(sets):
+    """A test suite small enough to fit stays in one subset, so a suite failing
+    on many platforms fails one subset rather than most of them."""
+    instances = {}
+    for suite in range(40):
+        for plat in range(3):
+            inst = mock.Mock(status=TwisterStatus.NONE)
+            inst.testsuite.name = f'test{suite}'
+            instances[f'plat{plat}/test{suite}'] = inst
+
+    _, placement = _place(instances, sets)
+
+    for suite, subsets in placement.items():
+        assert len(subsets) == 1, f'{suite} spread over subsets {sorted(subsets)}'
+
+
+def test_testplan_generate_subset_splits_oversized_suite():
+    """A suite too large for a subset is cut up rather than swamping one."""
+    instances = {}
+    for plat in range(100):
+        inst = mock.Mock(status=TwisterStatus.NONE)
+        inst.testsuite.name = 'huge'
+        instances[f'plat{plat}/huge'] = inst
+    for plat in range(20):
+        inst = mock.Mock(status=TwisterStatus.NONE)
+        inst.testsuite.name = f'small{plat}'
+        instances[f'plat{plat}/small{plat}'] = inst
+
+    sizes = []
+    for subset in range(1, 5):
+        testplan = TestPlan(env=mock_twister_env())
+        testplan.options = mock.Mock(
+            device_testing=False, shuffle_tests=False, shuffle_tests_seed=None
+        )
+        testplan.instances = dict(instances)
+        testplan.generate_subset(subset, 4)
+        sizes.append(len(testplan.instances))
+
+    # without splitting, one subset would hold all 100 instances of 'huge'
+    assert max(sizes) < 100
+    assert sum(sizes) == len(instances)
 
 
 TESTDATA_6 = [

--- a/scripts/tests/twister_blackbox/test_selection.py
+++ b/scripts/tests/twister_blackbox/test_selection.py
@@ -261,11 +261,33 @@ class TestSubset:
     @pytest.mark.parametrize(
         'subset, expected_names',
         [
-            ('1/2', ['dummy.device.group', 'dummy.agnostic.group1.subgroup2']),
-            ('2/2', ['dummy.agnostic.group2', 'dummy.agnostic.group1.subgroup1']),
-            ('1/3', ['dummy.device.group', 'dummy.agnostic.group1.subgroup2']),
-            ('2/3', ['dummy.agnostic.group2']),
-            ('3/3', ['dummy.agnostic.group1.subgroup1']),
+            (
+                '1/2',
+                [
+                    'dummy.agnostic.group1.subgroup2',
+                    'dummy.agnostic_cpp.group1.subgroup2',
+                    'dummy.agnostic.group2',
+                    'dummy.agnostic_cpp.group2',
+                ],
+            ),
+            (
+                '2/2',
+                [
+                    'dummy.device.group',
+                    'dummy.agnostic_cpp.group1.subgroup1',
+                    'dummy.agnostic.group1.subgroup1',
+                ],
+            ),
+            (
+                '1/3',
+                [
+                    'dummy.agnostic.group1.subgroup2',
+                    'dummy.agnostic_cpp.group1.subgroup1',
+                    'dummy.agnostic_cpp.group2',
+                ],
+            ),
+            ('2/3', ['dummy.device.group', 'dummy.agnostic.group2']),
+            ('3/3', ['dummy.agnostic_cpp.group1.subgroup2', 'dummy.agnostic.group1.subgroup1']),
         ],
         ids=['first_half', 'second_half', 'first_third', 'mid_third', 'last_third'],
     )

--- a/scripts/tests/twister_blackbox/test_shuffle.py
+++ b/scripts/tests/twister_blackbox/test_shuffle.py
@@ -85,16 +85,70 @@ class TestShuffleTests:
     @pytest.mark.parametrize(
         'seed, subset, expected_names',
         [
-            ('123', '1/2', ['dummy.agnostic.group1.subgroup2', 'dummy.device.group']),
-            ('123', '2/2', ['dummy.agnostic.group2', 'dummy.agnostic.group1.subgroup1']),
-            ('321', '1/2', ['dummy.agnostic.group1.subgroup2', 'dummy.agnostic.group1.subgroup1']),
-            ('321', '2/2', ['dummy.agnostic_cpp.group2', 'dummy.device.group']),
-            ('123', '1/3', ['dummy.agnostic.group1.subgroup2', 'dummy.device.group']),
-            ('123', '2/3', ['dummy.agnostic.group2']),
-            ('123', '3/3', ['dummy.agnostic.group1.subgroup1']),
-            ('321', '1/3', ['dummy.agnostic.group1.subgroup1', 'dummy.agnostic.group1.subgroup2']),
-            ('321', '2/3', ['dummy.device.group']),
-            ('321', '3/3', ['dummy.agnostic_cpp.group2']),
+            (
+                '123',
+                '1/2',
+                [
+                    'dummy.agnostic.group1.subgroup2',
+                    'dummy.agnostic_cpp.group1.subgroup2',
+                    'dummy.agnostic.group2',
+                    'dummy.agnostic_cpp.group2',
+                ],
+            ),
+            (
+                '123',
+                '2/2',
+                [
+                    'dummy.device.group',
+                    'dummy.agnostic_cpp.group1.subgroup1',
+                    'dummy.agnostic.group1.subgroup1',
+                ],
+            ),
+            (
+                '321',
+                '1/2',
+                [
+                    'dummy.agnostic_cpp.group1.subgroup2',
+                    'dummy.agnostic.group1.subgroup1',
+                    'dummy.device.group',
+                    'dummy.agnostic_cpp.group1.subgroup1',
+                ],
+            ),
+            (
+                '321',
+                '2/2',
+                [
+                    'dummy.agnostic.group1.subgroup2',
+                    'dummy.agnostic.group2',
+                    'dummy.agnostic_cpp.group2',
+                ],
+            ),
+            (
+                '123',
+                '1/3',
+                [
+                    'dummy.agnostic.group1.subgroup2',
+                    'dummy.agnostic_cpp.group1.subgroup1',
+                    'dummy.agnostic_cpp.group2',
+                ],
+            ),
+            ('123', '2/3', ['dummy.device.group', 'dummy.agnostic.group2']),
+            (
+                '123',
+                '3/3',
+                ['dummy.agnostic_cpp.group1.subgroup2', 'dummy.agnostic.group1.subgroup1'],
+            ),
+            (
+                '321',
+                '1/3',
+                [
+                    'dummy.agnostic_cpp.group1.subgroup2',
+                    'dummy.agnostic.group2',
+                    'dummy.agnostic_cpp.group1.subgroup1',
+                ],
+            ),
+            ('321', '2/3', ['dummy.agnostic.group1.subgroup2', 'dummy.device.group']),
+            ('321', '3/3', ['dummy.agnostic.group1.subgroup1', 'dummy.agnostic_cpp.group2']),
         ],
         ids=[
             'seed123-half1',


### PR DESCRIPTION
Twister slices the instance list into contiguous subsets. The list is sorted by test suite name, so each subset holds one alphabetical slab of the tree, and slabs differ widely in build cost. On a recent push to `main` (https://github.com/zephyrproject-rtos/zephyr/actions/runs/33334604208) the subsets ranged from 5.9 to 19.7 build hours, and the run spent 77 minutes waiting on the slowest one.

This packs whole test suites into whichever subset is lightest instead. Replaying that run through the new code takes the heaviest subset from 19.8 to 14.2 build hours, which should cut the 77 minute critical path by roughly 25%, down to 55 min or so.

Suites are packed whole to keep the spirit of 5a0990039a4 ("twister: subsets: when creating subsets, sort by tests"): a suite failing on many platforms should fail just one subset/runner.

The exception is a suite too big to fit in a subset, which still gets cut up. Only `sample.kernel.synchronization` is that big, at 1591 instances and 21 build hours, and slicing splits it today too.

Checked at 10, 30 and 200 subsets, so pull request, push and weekly runs all benefit. Numbers come from the 31 artifacts of run [33334604208](https://github.com/zephyrproject-rtos/zephyr/actions/runs/33334604208).
