### PR TITLE
modules: hal_silabs: Compile PHY configs for all supported protocols

### DIFF
--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -128,8 +128,18 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
         endif()
       endif()
       set(PHY_DIR ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_built_in_phys/efr32xg${SILABS_DEVICE_FAMILY_NUMBER})
-      zephyr_library_sources_ifdef(CONFIG_BT_SILABS_EFR32 ${PHY_DIR}/sl_rail_ble_config${phy_suffix}.c)
-      zephyr_library_sources_ifdef(CONFIG_IEEE802154_SILABS_EFR32 ${PHY_DIR}/sl_rail_ieee802154_config${phy_suffix}.c)
+
+      # sl_rail_util_built_in_phys.c provides strong definitions of the PHY pointers for
+      # every protocol the device supports, overriding the weak fallbacks in the RAIL
+      # library. Core RAIL objects reference those pointers regardless of which protocol
+      # is enabled, so the configuration of every supported protocol must be compiled,
+      # including protocols Zephyr has no support for. Unused configurations are
+      # discarded by the linker.
+      foreach(phy ble ieee802154 zwave sidewalk rfsense_ook)
+        if(EXISTS ${PHY_DIR}/sl_rail_${phy}_config${phy_suffix}.c)
+          zephyr_library_sources(${PHY_DIR}/sl_rail_${phy}_config${phy_suffix}.c)
+        endif()
+      endforeach()
     endif()
 
     # PA curve for the modules comes from their config archive - omit the compilation of the SoC curves on modules


### PR DESCRIPTION
sl_rail_util_built_in_phys.c provides strong definitions of the RAIL_*_Phy* pointers for every protocol the device supports, overriding the weak fallback definitions in the RAIL library. Core RAIL objects reference these pointers regardless of which protocol is enabled, e.g. rail_rf_hal.o references RAIL_BLE_Phy1MbpsViterbi and rail_zwave_rf_hal.o references RAIL_ZWAVE_Phy9p6kbpsConcurrent, both of which are pulled in via rail_singleprotocol.o.

Only compiling the Bluetooth and IEEE 802.15.4 PHY configurations therefore breaks the link on devices supporting other protocols, such as Z-Wave on EFR32xG23 and EFR32xG28:

  undefined reference to `zwave_9p6kb_conc_channelConfig'

Compile the PHY configuration of every protocol supported by the device instead. Unused configurations are discarded by the linker, so this has no impact on the resulting image.