### PR TITLE
kernel: sem: do not wake pollers on reset

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -78,6 +78,11 @@ Kernel
 * ``_k_neg_eagain`` has been renamed to ``_errno_neg_egain`` as ``errno`` has been migrated out of
   kernel into ``lib/libc/common``.
 
+* :c:func:`k_sem_reset` no longer wakes poll waiters waiting on the semaphore. Poll waiters
+  remain pending until the semaphore becomes available or the poll operation times out.
+  Applications that rely on reset to wake poll waiters must use an explicit synchronization
+  mechanism instead.
+
 * The ``CONFIG_SMP_BOOT_DELAY`` Kconfig option has been removed. Deferring the start of secondary
   CPUs to run time is now expressed per CPU in the devicetree: add the ``zephyr,deferred-start``
   flag to the corresponding ``cpu`` node under ``/cpus`` (typically in a board overlay) and start

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3857,6 +3857,9 @@ __syscall void k_sem_give(struct k_sem *sem);
  * Any outstanding semaphore takes will be aborted
  * with -EAGAIN.
  *
+ * @note A reset does not wake semaphore poll waiters. They remain pending until the semaphore
+ *       becomes available or the poll operation times out.
+ *
  * @param sem Address of the semaphore.
  */
 __syscall void k_sem_reset(struct k_sem *sem);

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -194,8 +194,6 @@ void z_impl_k_sem_reset(struct k_sem *sem)
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_sem, reset, sem);
 
-	resched = sem_handle_poll_events(sem) || resched;
-
 	if (resched) {
 		z_reschedule(lock, key);
 	} else {

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -819,6 +819,191 @@ ZTEST(poll_api, test_poll_multi)
 	k_thread_abort(tid2);
 }
 
+struct sem_reset_poll_waiter {
+	struct k_poll_event event;
+	struct k_sem done;
+	k_timeout_t timeout;
+	int rc;
+};
+
+static struct k_sem sem_reset_poll;
+static struct k_sem sem_reset_poll_done;
+static struct k_sem sem_reset_poll_allow_give;
+static struct k_thread sem_reset_poll_thread;
+static K_THREAD_STACK_DEFINE(sem_reset_poll_stack, STACK_SIZE);
+static struct sem_reset_poll_waiter sem_reset_poll_waiters[2];
+static struct k_thread sem_reset_poll_threads[2];
+static K_THREAD_STACK_ARRAY_DEFINE(sem_reset_poll_stacks, 2, STACK_SIZE);
+
+/* Wait for the semaphore poll event and record the result. */
+static void sem_reset_poll_waiter_thread(void *p1, void *p2, void *p3)
+{
+	struct sem_reset_poll_waiter *waiter = p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_poll_event_init(&waiter->event, K_POLL_TYPE_SEM_AVAILABLE, K_POLL_MODE_NOTIFY_ONLY,
+			  &sem_reset_poll);
+	waiter->rc = k_poll(&waiter->event, 1, waiter->timeout);
+	k_sem_give(&waiter->done);
+}
+
+/* Delay reset long enough for the test thread to register its poll waiter. */
+static void sem_reset_poll_reset_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_sleep(K_MSEC(20));
+	k_sem_reset(&sem_reset_poll);
+	k_sem_give(&sem_reset_poll_done);
+}
+
+/* Reset the semaphore, then wait for permission to wake the poller with give. */
+static void sem_reset_poll_reset_then_give_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_sleep(K_MSEC(20));
+	k_sem_reset(&sem_reset_poll);
+	k_sem_give(&sem_reset_poll_done);
+	k_sem_take(&sem_reset_poll_allow_give, K_FOREVER);
+	k_sem_give(&sem_reset_poll);
+}
+
+/**
+ * @brief Verify that reset does not wake a single semaphore poll waiter
+ *
+ * @details Resetting an unavailable semaphore must not report the semaphore
+ * as available to a thread waiting in k_poll().
+ *
+ * @ingroup kernel_poll_tests
+ */
+ZTEST(poll_api, test_poll_sem_reset_single_waiter)
+{
+	/* Verify that the poll waiter remains pending until its timeout. */
+	int rc;
+	k_tid_t tid;
+	struct k_poll_event event;
+
+	k_sem_init(&sem_reset_poll, 0, 1);
+	k_sem_init(&sem_reset_poll_done, 0, 1);
+	k_poll_event_init(&event, K_POLL_TYPE_SEM_AVAILABLE, K_POLL_MODE_NOTIFY_ONLY,
+			  &sem_reset_poll);
+
+	tid = k_thread_create(&sem_reset_poll_thread, sem_reset_poll_stack,
+			      K_THREAD_STACK_SIZEOF(sem_reset_poll_stack),
+			      sem_reset_poll_reset_thread, NULL, NULL, NULL, K_PRIO_PREEMPT(1), 0,
+			      K_NO_WAIT);
+
+	rc = k_poll(&event, 1, K_MSEC(100));
+
+	zassert_equal(k_sem_take(&sem_reset_poll_done, K_SECONDS(1)), 0);
+	zassert_equal(rc, -EAGAIN);
+	zassert_equal(event.state, K_POLL_STATE_NOT_READY);
+	zassert_equal(k_sem_count_get(&sem_reset_poll), 0);
+
+	k_thread_abort(tid);
+}
+
+/**
+ * @brief Verify that reset does not wake multiple semaphore poll waiters
+ *
+ * @details
+ * Resetting an unavailable semaphore must leave all poll waiters pending until
+ * their poll timeouts expire.
+ *
+ * @ingroup kernel_poll_tests
+ */
+ZTEST(poll_api, test_poll_sem_reset_multiple_waiters)
+{
+	/* Verify that all poll waiters remain pending until their timeouts. */
+	int rc;
+
+	k_sem_init(&sem_reset_poll, 0, 1);
+
+	for (size_t i = 0; i < ARRAY_SIZE(sem_reset_poll_waiters); i++) {
+		struct sem_reset_poll_waiter *waiter = &sem_reset_poll_waiters[i];
+
+		k_sem_init(&waiter->done, 0, 1);
+		waiter->timeout = K_MSEC(100);
+		waiter->rc = -EINVAL;
+		k_thread_create(&sem_reset_poll_threads[i], sem_reset_poll_stacks[i],
+				K_THREAD_STACK_SIZEOF(sem_reset_poll_stacks[i]),
+				sem_reset_poll_waiter_thread, waiter, NULL, NULL, K_PRIO_PREEMPT(1),
+				0, K_NO_WAIT);
+	}
+
+	k_sleep(K_MSEC(20));
+	k_sem_reset(&sem_reset_poll);
+
+	for (size_t i = 0; i < ARRAY_SIZE(sem_reset_poll_waiters); i++) {
+		struct sem_reset_poll_waiter *waiter = &sem_reset_poll_waiters[i];
+
+		rc = k_sem_take(&waiter->done, K_SECONDS(1));
+		zassert_equal(rc, 0);
+		zassert_equal(waiter->rc, -EAGAIN);
+		zassert_equal(waiter->event.state, K_POLL_STATE_NOT_READY);
+		k_thread_abort(&sem_reset_poll_threads[i]);
+	}
+
+	zassert_equal(k_sem_count_get(&sem_reset_poll), 0);
+}
+
+/**
+ * @brief Verify that a semaphore poller wakes after reset and a subsequent give
+ *
+ * @details
+ * Reset must not wake a pending poller, but a subsequent give that makes the
+ * semaphore available must wake it normally.
+ *
+ * @ingroup kernel_poll_tests
+ *
+ * @see k_sem_reset(), k_sem_give(), k_poll()
+ */
+ZTEST(poll_api, test_poll_sem_reset_then_give)
+{
+	/* Verify that reset does not end the poll before the subsequent give. */
+	struct sem_reset_poll_waiter *waiter = &sem_reset_poll_waiters[0];
+	k_tid_t waiter_tid;
+	k_tid_t reset_tid;
+
+	k_sem_init(&sem_reset_poll, 0, 1);
+	k_sem_init(&sem_reset_poll_done, 0, 1);
+	k_sem_init(&sem_reset_poll_allow_give, 0, 1);
+	k_sem_init(&waiter->done, 0, 1);
+	waiter->timeout = K_FOREVER;
+	waiter->rc = -EINVAL;
+
+	waiter_tid = k_thread_create(&sem_reset_poll_threads[0], sem_reset_poll_stacks[0],
+				     K_THREAD_STACK_SIZEOF(sem_reset_poll_stacks[0]),
+				     sem_reset_poll_waiter_thread, waiter, NULL, NULL,
+				     K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
+
+	k_sleep(K_MSEC(20));
+	reset_tid = k_thread_create(&sem_reset_poll_thread, sem_reset_poll_stack,
+				    K_THREAD_STACK_SIZEOF(sem_reset_poll_stack),
+				    sem_reset_poll_reset_then_give_thread, NULL, NULL, NULL,
+				    K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
+
+	zassert_equal(k_sem_take(&sem_reset_poll_done, K_SECONDS(1)), 0);
+	zassert_equal(k_sem_take(&waiter->done, K_NO_WAIT), -EBUSY);
+
+	k_sem_give(&sem_reset_poll_allow_give);
+
+	zassert_equal(k_sem_take(&waiter->done, K_SECONDS(1)), 0);
+	zassert_equal(waiter->rc, 0);
+	zassert_equal(waiter->event.state, K_POLL_STATE_SEM_AVAILABLE);
+	zassert_equal(k_sem_count_get(&sem_reset_poll), 1);
+
+	k_thread_abort(reset_tid);
+	k_thread_abort(waiter_tid);
+}
+
 static struct k_poll_signal signal;
 
 static void threadstate(void *p1, void *p2, void *p3)


### PR DESCRIPTION
k_sem_reset() clears the semaphore count to zero. It must not report K_POLL_STATE_SEM_AVAILABLE to poll waiters.

The previous implementation removed and woke a poll event even though no token was available. Stop notifying semaphore poll events from k_sem_reset(). Regular semaphore waiters still wake with -EAGAIN.

Add regression tests for single and multiple poll waiters, and verify that a subsequent k_sem_give() still wakes a waiter after reset.

Test:
- Baseline 4564d775ab0: both new tests failed.
- Fixed qemu_cortex_m3: poll_api 6/6 and poll_api_1cpu 7/7.
- git diff --check