### PR TITLE
drivers: rtc: mspm0_rtc: Add RTC Update, Caliberation, interval interrupt and prescaler interrupt features

### DIFF
--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
@@ -15,4 +15,5 @@ supported:
   - dac
   - spi
   - vref
+  - rtc
 vendor: ti

--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
@@ -15,4 +15,5 @@ supported:
   - dac
   - spi
   - vref
+  - rtc
 vendor: ti

--- a/boards/ti/lp_mspm33c321a/lp_mspm33c321a.yaml
+++ b/boards/ti/lp_mspm33c321a/lp_mspm33c321a.yaml
@@ -6,4 +6,6 @@ toolchain:
   - zephyr
 ram: 256
 flash: 1024
+supported:
+  - rtc
 vendor: ti

--- a/drivers/rtc/Kconfig.ti_mspm0
+++ b/drivers/rtc/Kconfig.ti_mspm0
@@ -14,3 +14,9 @@ config RTC_TI_MSPM0_INTERVAL_TIMER
 	help
 	  Enable configurable interval timer (RTCTEV). Generates interrupts
 	  once per minute, hour, at midnight, or at noon.
+
+config RTC_TI_MSPM0_PS_TIMER
+	bool "MSPM0 RTC prescaler timer"
+	depends on RTC_TI_MSPM0
+	help
+	  Enable RT0PS and RT1PS prescaler timer periodic interrupts.

--- a/drivers/rtc/Kconfig.ti_mspm0
+++ b/drivers/rtc/Kconfig.ti_mspm0
@@ -7,3 +7,10 @@ config RTC_TI_MSPM0
 	depends on DT_HAS_TI_MSPM0_RTC_ENABLED
 	help
 	  Texas Instruments Real-Time Clock (RTC) driver used on MSPM0 SoC series.
+
+config RTC_TI_MSPM0_INTERVAL_TIMER
+	bool "MSPM0 RTC interval timer"
+	depends on RTC_TI_MSPM0
+	help
+	  Enable configurable interval timer (RTCTEV). Generates interrupts
+	  once per minute, hour, at midnight, or at noon.

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -264,11 +264,20 @@ static int rtc_ti_mspm0_alarm_set_time(const struct device *dev, uint16_t id,
 	struct rtc_ti_mspm0_data *data = dev->data;
 	uint32_t imask_bit;
 
-	if (timeptr == NULL) {
+	if (id != RTC_TI_ALARM_1 && id != RTC_TI_ALARM_2) {
 		return -EINVAL;
 	}
 
-	if (id != RTC_TI_ALARM_1 && id != RTC_TI_ALARM_2) {
+	if (mask == 0) {
+		K_SPINLOCK(&data->lock) {
+			rtc_ti_mspm0_clear_alarm(dev, id);
+			data->rtc_alarm[id].mask = 0;
+			data->rtc_alarm[id].is_pending = false;
+		}
+		return 0;
+	}
+
+	if (timeptr == NULL) {
 		return -EINVAL;
 	}
 
@@ -365,10 +374,6 @@ static int rtc_ti_mspm0_alarm_set_callback(const struct device *dev, uint16_t id
 					   void *user_data)
 {
 	struct rtc_ti_mspm0_data *data = dev->data;
-
-	if (callback == NULL) {
-		return -EINVAL;
-	}
 
 	if (id != RTC_TI_ALARM_1 && id != RTC_TI_ALARM_2) {
 		return -EINVAL;

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Linumiz GmbH
+ * Copyright (c) 2026 Texas Instruments Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -16,7 +17,6 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/__assert.h>
 #include "rtc_utils.h"
-#include <ti/driverlib/dl_rtc_common.h>
 
 #if defined(CONFIG_RTC_ALARM)
 #define RTC_TI_ALARM_1		0
@@ -27,8 +27,111 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 	     "CONFIG_RTC_ALARM is enabled, without setting alarms-count property");
 #endif
 
+#define RTC_MSPM0_PWREN_MASK			BIT(0)
+#define RTC_MSPM0_PWREN_KEY_MASK		GENMASK(31, 24)
+#define RTC_MSPM0_PWREN_KEY			0x26
+
+#define RTC_MSPM0_CLKCTL_ENABLE			BIT(31)
+
+#define RTC_MSPM0_CTL_BIN			0x0
+
+#define RTC_MSPM0_SEC_BIN_MASK			BIT_MASK(6)
+#define RTC_MSPM0_MIN_BIN_MASK			BIT_MASK(6)
+#define RTC_MSPM0_HOUR_BIN_MASK			BIT_MASK(5)
+#define RTC_MSPM0_MDAY_BIN_MASK			GENMASK(12, 8)
+#define RTC_MSPM0_WDAY_BIN_MASK			BIT_MASK(3)
+#define RTC_MSPM0_MON_BIN_MASK			BIT_MASK(4)
+#define RTC_MSPM0_YEARLOW_BIN_MASK		BIT_MASK(8)
+#define RTC_MSPM0_YEARHIGH_BIN_MASK		GENMASK(11, 8)
+
+#define RTC_MSPM0_IMASK_ALARM1			BIT(2)
+#define RTC_MSPM0_IMASK_ALARM2			BIT(3)
+#define RTC_MSPM0_AMIN_BIN_MASK			BIT_MASK(6)
+#define RTC_MSPM0_AMIN_BIN_ENABLE		BIT(7)
+#define RTC_MSPM0_AHOUR_BIN_MASK		BIT_MASK(5)
+#define RTC_MSPM0_AHOUR_BIN_ENABLE		BIT(7)
+#define RTC_MSPM0_ADAY_MON_BIN_MASK		GENMASK(12, 8)
+#define RTC_MSPM0_ADAY_MON_BIN_ENABLE		BIT(15)
+#define RTC_MSPM0_ADAY_WEEK_BIN_MASK		BIT_MASK(3)
+#define RTC_MSPM0_ADAY_WEEK_BIN_ENABLE		BIT(7)
+
+#define RTC_MSPM0_IIDX_ALARM1			0x3
+#define RTC_MSPM0_IIDX_ALARM2			0x4
+
+typedef struct {
+	uint32_t reserved0[0x111];
+	volatile uint32_t fpub_0;	/* Publisher Port 0			@0x444h */
+	uint32_t reserved1[0xEE];
+	volatile uint32_t pwren;	/* Power Enable				@0x800h */
+	volatile uint32_t rstctl;	/* Reset Control			@0x804h */
+	volatile uint32_t clkcfg;	/* Peripheral Clock Configuration	@0x808h */
+	uint32_t reserved2[2];
+	volatile uint32_t stat;		/* Status Register			@0x814h */
+	uint32_t reserved3[0x1FB];
+	volatile uint32_t clksel;	/* Clock Select				@0x1004h */
+	uint32_t reserved4[6];
+	volatile uint32_t iidx;		/* Interrupt Index Register		@0x1020h */
+	uint32_t reserved5[1];
+	volatile uint32_t imask;	/* Interrupt Mask			@0x1028h */
+	uint32_t reserved6[1];
+	volatile uint32_t ris;		/* Raw Interrupt Status			@0x1030h */
+	uint32_t reserved7[1];
+	volatile uint32_t mis;		/* Masked Interrupt Status		@0x1038h */
+	uint32_t reserved8[1];
+	volatile uint32_t iset;		/* Interrupt Set			@0x1040h */
+	uint32_t reserved9[1];
+	volatile uint32_t iclr;		/* Interrupt Clear			@0x1048h */
+	uint32_t reserved10[1];
+	volatile uint32_t iidx1;	/* Interrupt Index Register 1		@0x1050h */
+	uint32_t reserved11[1];
+	volatile uint32_t imask1;	/* Interrupt Mask 1			@0x1058h */
+	uint32_t reserved12[1];
+	volatile uint32_t ris1;		/* Raw Interrupt Status 1		@0x1060h */
+	uint32_t reserved13[1];
+	volatile uint32_t mis1;		/* Masked Interrupt Status 1		@0x1068h */
+	uint32_t reserved14[1];
+	volatile uint32_t iset1;	/* Interrupt Set 1			@0x1070h */
+	uint32_t reserved15[1];
+	volatile uint32_t iclr1;	/* Interrupt Clear 1			@0x1078h */
+	uint32_t reserved16[0x19];
+	volatile uint32_t evt_mode;	/* Event Mode				0x10E0h */
+	uint32_t reserved17[6];
+	volatile uint32_t desc;		/* RTC Descriptor Register		@0x10FCh */
+	volatile uint32_t clkctl;	/* RTC Clock Control			@0x1100h */
+	volatile uint32_t dbgctl;	/* RTC Debug Control			@0x1104h */
+	volatile uint32_t ctl;		/* RTC Control				@0x1108h */
+	volatile uint32_t sta;		/* RTC Status				@0x110Ch */
+	volatile uint32_t cal;		/* RTC Clock Offset Calibration		@0x1110h */
+	volatile uint32_t tcmp;		/* RTC Temperature Compensation		@0x1114h */
+	volatile uint32_t sec;		/* RTC Seconds				@0x1118h */
+	volatile uint32_t min;		/* RTC Minutes				@0x111Ch */
+	volatile uint32_t hour;		/* RTC Hours				@0x1120h */
+	volatile uint32_t day;		/* RTC Day of Week/Month		@0x1124h */
+	volatile uint32_t mon;		/* RTC Month				@0x1128h */
+	volatile uint32_t year;		/* RTC Year				@0x112Ch */
+	volatile uint32_t a1min;	/* RTC Alarm 1 Minutes			@0x1130h */
+	volatile uint32_t a1hour;	/* RTC Alarm 1 Hours			@0x1134h */
+	volatile uint32_t a1day;	/* RTC Alarm 1 Day			@0x1138h */
+	volatile uint32_t a2min;	/* RTC Alarm 2 Minutes			@0x113Ch */
+	volatile uint32_t a2hour;	/* RTC Alarm 2 Hours			@0x1140h */
+	volatile uint32_t a2day;	/* RTC Alarm 2 Day			@0x1144h */
+	volatile uint32_t psctl;	/* RTC Prescale Timer 0/1 Control	@0x1148h */
+	volatile uint32_t extpsctl;     /* RTC Prescale Timer 2 Control		@0x114Ch */
+	volatile uint32_t tssec;	/* Time Stamp Seconds			@0x1150h */
+	volatile uint32_t tsmin;	/* Time Stamp Minutes			@0x1154h */
+	volatile uint32_t tshour;	/* Time Stamp Hours			@0x1158h */
+	volatile uint32_t tsday;	/* Time Stamp Day Of Week/Month		@0x115Ch */
+	volatile uint32_t tsmon;	/* Time Stamp Month			@0x1160h */
+	volatile uint32_t tsyear;	/* Time Stamp Years			@0x1164h */
+	volatile uint32_t tsstat;	/* Time Stamp Status			@0x1168h */
+	volatile uint32_t tsctl;	/* Time Stamp Control			@0x116Ch */
+	volatile uint32_t tsclr;	/* Time Stamp Clear			@0x1170h */
+	volatile uint32_t lfssrst;	/* Low Frequency Subsystem Reset	@0x1174h */
+	volatile uint32_t rtclock;	/* Real Time Clock Lock			@0x1178h */
+} rtc_ti_mspm0_reg_t;
+
 struct rtc_ti_mspm0_config {
-	RTC_Regs *regs;
+	rtc_ti_mspm0_reg_t *regs;
 #if defined(CONFIG_RTC_ALARM)
 	void (*irq_config_func)(void);
 #endif
@@ -66,20 +169,28 @@ static int rtc_ti_mspm0_set_time(const struct device *dev,
 	year = timeptr->tm_year + 1900;
 
 	K_SPINLOCK(&data->lock) {
-		DL_RTC_Common_setCalendarSecondsBinary(cfg->regs, timeptr->tm_sec);
-		DL_RTC_Common_setCalendarMinutesBinary(cfg->regs, timeptr->tm_min);
-		DL_RTC_Common_setCalendarHoursBinary(cfg->regs, timeptr->tm_hour);
 		/*
 		 * Back to back writes to counter/calendar registers such as
 		 * SEC, MIN, HOUR, DAY, MON, YEAR need to be avoided since writes
 		 * to calendar registers take 2 to 3 RTCCLK cycles to take effect.
 		 */
-		DL_Common_updateReg(&cfg->regs->DAY,
-				    (uint32_t)timeptr->tm_wday |
-					    ((uint32_t)timeptr->tm_mday << RTC_DAY_DOMBIN_OFS),
-				    RTC_DAY_DOW_MASK | RTC_DAY_DOMBIN_MASK);
-		DL_RTC_Common_setCalendarMonthBinary(cfg->regs, mon);
-		DL_RTC_Common_setCalendarYearBinary(cfg->regs, year);
+
+		/* Set calendar seconds in binary */
+		cfg->regs->sec = timeptr->tm_sec & RTC_MSPM0_SEC_BIN_MASK;
+		/* Set calendar minutes in binary */
+		cfg->regs->min = timeptr->tm_min & RTC_MSPM0_MIN_BIN_MASK;
+		/* Set calendar hours in binary */
+		cfg->regs->hour = timeptr->tm_hour & RTC_MSPM0_HOUR_BIN_MASK;
+		/* Set calendar day in binary */
+		/* Month of the day: bits 12-8
+		 * Month of the week: bits 2-0
+		 */
+		cfg->regs->day = FIELD_PREP(RTC_MSPM0_MDAY_BIN_MASK, timeptr->tm_mday) |
+				      FIELD_PREP(RTC_MSPM0_WDAY_BIN_MASK, timeptr->tm_wday);
+		/* Set calendar month in binary */
+		cfg->regs->mon = mon & RTC_MSPM0_MON_BIN_MASK;
+		cfg->regs->year =
+			year & (RTC_MSPM0_YEARLOW_BIN_MASK | RTC_MSPM0_YEARHIGH_BIN_MASK);
 	}
 
 	return 0;
@@ -96,13 +207,15 @@ static int rtc_ti_mspm0_get_time(const struct device *dev,
 	}
 
 	K_SPINLOCK(&data->lock) {
-		timeptr->tm_sec  = DL_RTC_Common_getCalendarSecondsBinary(cfg->regs);
-		timeptr->tm_min  = DL_RTC_Common_getCalendarMinutesBinary(cfg->regs);
-		timeptr->tm_hour = DL_RTC_Common_getCalendarHoursBinary(cfg->regs);
-		timeptr->tm_mday = DL_RTC_Common_getCalendarDayOfMonthBinary(cfg->regs);
-		timeptr->tm_mon = DL_RTC_Common_getCalendarMonthBinary(cfg->regs) - 1;
-		timeptr->tm_year = DL_RTC_Common_getCalendarYearBinary(cfg->regs) - 1900;
-		timeptr->tm_wday = DL_RTC_Common_getCalendarDayOfWeekBinary(cfg->regs);
+		timeptr->tm_sec = cfg->regs->sec & RTC_MSPM0_SEC_BIN_MASK;
+		timeptr->tm_min = cfg->regs->min & RTC_MSPM0_MIN_BIN_MASK;
+		timeptr->tm_hour = cfg->regs->hour & RTC_MSPM0_HOUR_BIN_MASK;
+		timeptr->tm_mday = FIELD_GET(RTC_MSPM0_MDAY_BIN_MASK, cfg->regs->day);
+		timeptr->tm_mon = (cfg->regs->mon & RTC_MSPM0_MON_BIN_MASK) - 1;
+		timeptr->tm_year = (cfg->regs->year &
+				    (RTC_MSPM0_YEARLOW_BIN_MASK | RTC_MSPM0_YEARHIGH_BIN_MASK)) -
+				   1900;
+		timeptr->tm_wday = FIELD_GET(RTC_MSPM0_WDAY_BIN_MASK, cfg->regs->day);
 	}
 
 	timeptr->tm_yday = -1;
@@ -135,30 +248,37 @@ static inline void rtc_ti_mspm0_set_alarm1(const struct device *dev,
 {
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
 
-	DL_RTC_Common_disableInterrupt(cfg->regs, DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM1);
+	/* Disable Alarm 1 interrupt */
+	cfg->regs->imask &= ~(RTC_MSPM0_IMASK_ALARM1);
 
 	if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		cfg->regs->A1MIN = 0;
-		DL_RTC_Common_setAlarm1MinutesBinary(cfg->regs, timeptr->tm_min);
-		DL_RTC_Common_enableAlarm1MinutesBinary(cfg->regs);
+		cfg->regs->a1min = 0;
+		/* Set alarm minutes and enable */
+		cfg->regs->a1min =
+			RTC_MSPM0_AMIN_BIN_ENABLE | (timeptr->tm_min & RTC_MSPM0_AMIN_BIN_MASK);
 	}
 
 	if (mask & RTC_ALARM_TIME_MASK_HOUR) {
-		DL_RTC_Common_setAlarm1HoursBinary(cfg->regs, timeptr->tm_hour);
-		DL_RTC_Common_enableAlarm1HoursBinary(cfg->regs);
+		cfg->regs->a1hour = RTC_MSPM0_AHOUR_BIN_ENABLE |
+				    (timeptr->tm_hour & RTC_MSPM0_AHOUR_BIN_MASK);
 	}
 
-	if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-		DL_RTC_Common_setAlarm1DayOfWeekBinary(cfg->regs, timeptr->tm_wday);
-		DL_RTC_Common_enableAlarm1DayOfWeekBinary(cfg->regs);
+	if (mask & (RTC_ALARM_TIME_MASK_WEEKDAY | RTC_ALARM_TIME_MASK_MONTHDAY)) {
+		uint32_t day = 0;
+
+		if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
+			day |= RTC_MSPM0_ADAY_WEEK_BIN_ENABLE |
+			       (timeptr->tm_wday & RTC_MSPM0_ADAY_WEEK_BIN_MASK);
+		}
+		if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
+			day |= RTC_MSPM0_ADAY_MON_BIN_ENABLE |
+			       FIELD_PREP(RTC_MSPM0_ADAY_MON_BIN_MASK, timeptr->tm_mday);
+		}
+		cfg->regs->a1day = day;
 	}
 
-	if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-		DL_RTC_Common_setAlarm1DayOfMonthBinary(cfg->regs, timeptr->tm_mday);
-		DL_RTC_Common_enableAlarm1DayOfMonthBinary(cfg->regs);
-	}
-
-	DL_RTC_Common_enableInterrupt(cfg->regs, DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM1);
+	/* Enable Alarm 1 interrupt */
+	cfg->regs->imask |= RTC_MSPM0_IMASK_ALARM1;
 }
 
 static inline void rtc_ti_mspm0_set_alarm2(const struct device *dev,
@@ -167,30 +287,37 @@ static inline void rtc_ti_mspm0_set_alarm2(const struct device *dev,
 {
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
 
-	DL_RTC_Common_disableInterrupt(cfg->regs, DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM2);
+	/* Disable Alarm 2 interrupt */
+	cfg->regs->imask &= ~(RTC_MSPM0_IMASK_ALARM2);
 
 	if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		cfg->regs->A2MIN = 0;
-		DL_RTC_Common_setAlarm2MinutesBinary(cfg->regs, timeptr->tm_min);
-		DL_RTC_Common_enableAlarm2MinutesBinary(cfg->regs);
+		cfg->regs->a2min = 0;
+		/* Set alarm minutes and enable */
+		cfg->regs->a2min =
+			RTC_MSPM0_AMIN_BIN_ENABLE | (timeptr->tm_min & RTC_MSPM0_AMIN_BIN_MASK);
 	}
 
 	if (mask & RTC_ALARM_TIME_MASK_HOUR) {
-		DL_RTC_Common_setAlarm2HoursBinary(cfg->regs, timeptr->tm_hour);
-		DL_RTC_Common_enableAlarm2HoursBinary(cfg->regs);
+		cfg->regs->a2hour = RTC_MSPM0_AHOUR_BIN_ENABLE |
+				    (timeptr->tm_hour & RTC_MSPM0_AHOUR_BIN_MASK);
 	}
 
-	if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-		DL_RTC_Common_setAlarm2DayOfWeekBinary(cfg->regs, timeptr->tm_wday);
-		DL_RTC_Common_enableAlarm2DayOfWeekBinary(cfg->regs);
+	if (mask & (RTC_ALARM_TIME_MASK_WEEKDAY | RTC_ALARM_TIME_MASK_MONTHDAY)) {
+		uint32_t day = 0;
+
+		if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
+			day |= RTC_MSPM0_ADAY_WEEK_BIN_ENABLE |
+			       (timeptr->tm_wday & RTC_MSPM0_ADAY_WEEK_BIN_MASK);
+		}
+		if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
+			day |= RTC_MSPM0_ADAY_MON_BIN_ENABLE |
+			       FIELD_PREP(RTC_MSPM0_ADAY_MON_BIN_MASK, timeptr->tm_mday);
+		}
+		cfg->regs->a2day = day;
 	}
 
-	if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-		DL_RTC_Common_setAlarm2DayOfMonthBinary(cfg->regs, timeptr->tm_mday);
-		DL_RTC_Common_enableAlarm2DayOfMonthBinary(cfg->regs);
-	}
-
-	DL_RTC_Common_enableInterrupt(cfg->regs, DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM2);
+	/* Enable Alarm 2 interrupt */
+	cfg->regs->imask |= RTC_MSPM0_IMASK_ALARM2;
 }
 
 static inline void rtc_ti_mspm0_clear_alarm(const struct device *dev, uint16_t id)
@@ -198,13 +325,13 @@ static inline void rtc_ti_mspm0_clear_alarm(const struct device *dev, uint16_t i
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
 
 	if (id == RTC_TI_ALARM_1) {
-		cfg->regs->A1MIN = 0x00;
-		cfg->regs->A1HOUR = 0x00;
-		cfg->regs->A1DAY = 0x00;
+		cfg->regs->a1min = 0x00;
+		cfg->regs->a1hour = 0x00;
+		cfg->regs->a1day = 0x00;
 	} else {
-		cfg->regs->A2MIN = 0x00;
-		cfg->regs->A2HOUR = 0x00;
-		cfg->regs->A2DAY = 0x00;
+		cfg->regs->a2min = 0x00;
+		cfg->regs->a2hour = 0x00;
+		cfg->regs->a2day = 0x00;
 	}
 }
 
@@ -252,22 +379,22 @@ static int rtc_ti_mspm0_get_alarm1(const struct device *dev,
 
 	alarm_mask = data->rtc_alarm[RTC_TI_ALARM_1].mask;
 	if (alarm_mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		timeptr->tm_min = DL_RTC_Common_getAlarm1MinutesBinary(cfg->regs);
+		timeptr->tm_min = cfg->regs->a1min & RTC_MSPM0_AMIN_BIN_MASK;
 		return_mask |= RTC_ALARM_TIME_MASK_MINUTE;
 	}
 
 	if (alarm_mask & RTC_ALARM_TIME_MASK_HOUR) {
-		timeptr->tm_hour = DL_RTC_Common_getAlarm1HoursBinary(cfg->regs);
+		timeptr->tm_hour = cfg->regs->a1hour & RTC_MSPM0_AHOUR_BIN_MASK;
 		return_mask |= RTC_ALARM_TIME_MASK_HOUR;
 	}
 
 	if (alarm_mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-		timeptr->tm_wday = DL_RTC_Common_getAlarm1DayOfWeekBinary(cfg->regs);
+		timeptr->tm_wday = FIELD_GET(RTC_MSPM0_ADAY_WEEK_BIN_MASK, cfg->regs->a1day);
 		return_mask |= RTC_ALARM_TIME_MASK_WEEKDAY;
 	}
 
 	if (alarm_mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-		timeptr->tm_mday =  DL_RTC_Common_getAlarm1DayOfMonthBinary(cfg->regs);
+		timeptr->tm_mday = FIELD_GET(RTC_MSPM0_ADAY_MON_BIN_MASK, cfg->regs->a1day);
 		return_mask |= RTC_ALARM_TIME_MASK_MONTHDAY;
 	}
 
@@ -283,22 +410,22 @@ static int rtc_ti_mspm0_get_alarm2(const struct device *dev, struct rtc_time *ti
 
 	alarm_mask = data->rtc_alarm[RTC_TI_ALARM_2].mask;
 	if (alarm_mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		timeptr->tm_min = DL_RTC_Common_getAlarm2MinutesBinary(cfg->regs);
+		timeptr->tm_min = cfg->regs->a2min & RTC_MSPM0_AMIN_BIN_MASK;
 		return_mask |= RTC_ALARM_TIME_MASK_MINUTE;
 	}
 
 	if (alarm_mask & RTC_ALARM_TIME_MASK_HOUR) {
-		timeptr->tm_hour = DL_RTC_Common_getAlarm2HoursBinary(cfg->regs);
+		timeptr->tm_hour = cfg->regs->a2hour & RTC_MSPM0_AHOUR_BIN_MASK;
 		return_mask |= RTC_ALARM_TIME_MASK_HOUR;
 	}
 
 	if (alarm_mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-		timeptr->tm_wday = DL_RTC_Common_getAlarm2DayOfWeekBinary(cfg->regs);
+		timeptr->tm_wday = FIELD_GET(RTC_MSPM0_ADAY_WEEK_BIN_MASK, cfg->regs->a2day);
 		return_mask |= RTC_ALARM_TIME_MASK_WEEKDAY;
 	}
 
 	if (alarm_mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-		timeptr->tm_mday =  DL_RTC_Common_getAlarm2DayOfMonthBinary(cfg->regs);
+		timeptr->tm_mday = FIELD_GET(RTC_MSPM0_ADAY_MON_BIN_MASK, cfg->regs->a2day);
 		return_mask |= RTC_ALARM_TIME_MASK_MONTHDAY;
 	}
 
@@ -379,12 +506,12 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 	struct rtc_ti_mspm0_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	switch (DL_RTC_Common_getPendingInterrupt(cfg->regs)) {
-	case DL_RTC_COMMON_IIDX_ALARM1:
+	switch (cfg->regs->iidx) {
+	case RTC_MSPM0_IIDX_ALARM1:
 		id = RTC_TI_ALARM_1;
 		alarm = &data->rtc_alarm[RTC_TI_ALARM_1];
 		break;
-	case DL_RTC_COMMON_IIDX_ALARM2:
+	case RTC_MSPM0_IIDX_ALARM2:
 		id = RTC_TI_ALARM_2;
 		alarm = &data->rtc_alarm[RTC_TI_ALARM_2];
 		break;
@@ -409,14 +536,17 @@ static int rtc_ti_mspm0_init(const struct device *dev)
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
 
 	if (!cfg->rtc_x) {
-		/* Enable power to RTC module */
-		if (!DL_RTC_Common_isPowerEnabled(cfg->regs)) {
-			DL_RTC_Common_enablePower(cfg->regs);
+		if (!(cfg->regs->pwren & RTC_MSPM0_PWREN_MASK)) {
+			/* Write Power enable key and set Power enable bit simultaneously */
+			cfg->regs->pwren =
+				FIELD_PREP(RTC_MSPM0_PWREN_KEY_MASK, RTC_MSPM0_PWREN_KEY) |
+				RTC_MSPM0_PWREN_MASK;
 		}
 	}
-
-	DL_RTC_Common_enableClockControl(cfg->regs);
-	DL_RTC_Common_setClockFormat(cfg->regs, DL_RTC_COMMON_FORMAT_BINARY);
+	/* Enable 32k clock supply */
+	cfg->regs->clkctl = RTC_MSPM0_CLKCTL_ENABLE;
+	/* Set clock format to binary */
+	cfg->regs->ctl = RTC_MSPM0_CTL_BIN;
 
 #if defined(CONFIG_RTC_ALARM)
 	cfg->irq_config_func();
@@ -449,7 +579,7 @@ static DEVICE_API(rtc, rtc_ti_mspm0_driver_api) = {
 	static struct rtc_ti_mspm0_data rtc_data_##n;				\
 										\
 	static struct rtc_ti_mspm0_config rtc_config_##n = {			\
-		.regs		 = (RTC_Regs *)DT_INST_REG_ADDR(n),		\
+		.regs = (rtc_ti_mspm0_reg_t *)DT_INST_REG_ADDR(n),		\
 		.rtc_x		 = DT_INST_PROP(n, ti_rtc_x),			\
 		IF_ENABLED(CONFIG_RTC_ALARM,					\
 		(.irq_config_func = ti_mspm0_config_irq_##n,))			\

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -397,46 +397,46 @@ static int rtc_ti_mspm0_alarm_is_pending(const struct device *dev, uint16_t id)
 		return -EINVAL;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&data->lock);
+	K_SPINLOCK(&data->lock) {
+		alarm = &data->rtc_alarm[id];
+		ret = alarm->is_pending ? 1 : 0;
+		alarm->is_pending = false;
+	}
 
-	alarm = &data->rtc_alarm[id];
-	ret = alarm->is_pending ? 1 : 0;
-	alarm->is_pending = false;
-
-	k_spin_unlock(&data->lock, key);
 	return ret;
 }
 
 static void rtc_ti_mspm0_isr(const struct device *dev)
 {
-	uint8_t id;
-	struct rtc_ti_mspm0_alarm *alarm = NULL;
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
 	struct rtc_ti_mspm0_data *data = dev->data;
-	k_spinlock_key_t key = k_spin_lock(&data->lock);
+	struct rtc_ti_mspm0_alarm alarm = {0};
+	uint8_t alarm_id = 0;
+	bool has_cb = false;
 
-	switch (cfg->regs->iidx) {
-	case RTC_MSPM0_IIDX_ALARM1:
-		id = RTC_TI_ALARM_1;
-		alarm = &data->rtc_alarm[RTC_TI_ALARM_1];
-		break;
-	case RTC_MSPM0_IIDX_ALARM2:
-		id = RTC_TI_ALARM_2;
-		alarm = &data->rtc_alarm[RTC_TI_ALARM_2];
-		break;
-	default:
-		goto out;
-	}
+	K_SPINLOCK(&data->lock) {
+		switch (cfg->regs->iidx) {
+		case RTC_MSPM0_IIDX_ALARM1:
+			alarm_id = RTC_TI_ALARM_1;
+			break;
+		case RTC_MSPM0_IIDX_ALARM2:
+			alarm_id = RTC_TI_ALARM_2;
+			break;
+		default:
+			K_SPINLOCK_BREAK;
+		}
 
-	if (alarm != NULL) {
-		alarm->is_pending = true;
-		if (alarm->callback) {
-			alarm->callback(dev, id, alarm->user_data);
+		alarm = data->rtc_alarm[alarm_id];
+		if (!alarm.callback) {
+			data->rtc_alarm[alarm_id].is_pending = true;
+		} else {
+			has_cb = true;
 		}
 	}
 
-out:
-	k_spin_unlock(&data->lock, key);
+	if (has_cb) {
+		alarm.callback(dev, alarm_id, alarm.user_data);
+	}
 }
 #endif
 

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -61,6 +61,11 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 #define RTC_MSPM0_IMASK_RTCRDY			BIT(0)
 #define RTC_MSPM0_STA_RTCTCRDY_MASK		BIT(1)
 
+#define RTC_MSPM0_CAL_MAX_VALUE			240
+#define RTC_MSPM0_CAL_PPB_PER_PPM		1000
+#define RTC_MSPM0_CAL_UP_ENABLE			BIT(15)
+#define RTC_MSPM0_CAL_MASK			BIT_MASK(8)
+
 typedef struct {
 	volatile uint32_t a_min;	/* RTC Alarm Minutes	*/
 	volatile uint32_t a_hour;	/* RTC Alarm Hours	*/
@@ -498,6 +503,49 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 }
 #endif
 
+#if defined(CONFIG_RTC_CALIBRATION)
+static int rtc_ti_mspm0_set_calibration(const struct device *dev, int32_t calibration)
+{
+	const struct rtc_ti_mspm0_config *cfg = dev->config;
+	struct rtc_ti_mspm0_data *data = dev->data;
+	int32_t cal_ppm = calibration / RTC_MSPM0_CAL_PPB_PER_PPM;
+
+	if (cal_ppm > RTC_MSPM0_CAL_MAX_VALUE || cal_ppm < -RTC_MSPM0_CAL_MAX_VALUE) {
+		return -EINVAL;
+	}
+
+	K_SPINLOCK(&data->lock) {
+		if (cal_ppm > 0) {
+			cfg->regs->cal = RTC_MSPM0_CAL_UP_ENABLE | (cal_ppm & RTC_MSPM0_CAL_MASK);
+		} else {
+			cfg->regs->cal = ((-cal_ppm) & RTC_MSPM0_CAL_MASK);
+		}
+	}
+	return 0;
+}
+
+static int rtc_ti_mspm0_get_calibration(const struct device *dev, int32_t *calibration)
+{
+	const struct rtc_ti_mspm0_config *cfg = dev->config;
+	struct rtc_ti_mspm0_data *data = dev->data;
+	uint32_t cal_reg;
+	int32_t cal_ppm;
+
+	K_SPINLOCK(&data->lock) {
+		cal_reg = cfg->regs->cal;
+	}
+
+	cal_ppm = cal_reg & RTC_MSPM0_CAL_MASK;
+	if (!(cal_reg & RTC_MSPM0_CAL_UP_ENABLE)) {
+		cal_ppm = -cal_ppm;
+	}
+
+	*calibration = cal_ppm * RTC_MSPM0_CAL_PPB_PER_PPM;
+
+	return 0;
+}
+#endif
+
 static int rtc_ti_mspm0_init(const struct device *dev)
 {
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
@@ -534,6 +582,10 @@ static DEVICE_API(rtc, rtc_ti_mspm0_driver_api) = {
 #endif /* CONFIG_RTC_ALARM */
 #if defined(CONFIG_RTC_UPDATE)
 	.update_set_callback = rtc_ti_mspm0_update_set_callback,
+#endif
+#if defined(CONFIG_RTC_CALIBRATION)
+	.set_calibration = rtc_ti_mspm0_set_calibration,
+	.get_calibration = rtc_ti_mspm0_get_calibration,
 #endif
 };
 

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -18,6 +18,8 @@
 #include <zephyr/sys/__assert.h>
 #include "rtc_utils.h"
 
+#include <zephyr/drivers/rtc/rtc_ti_mspm0.h>
+
 #if defined(CONFIG_RTC_ALARM)
 #define RTC_TI_ALARM_1		0
 #define RTC_TI_ALARM_2		1
@@ -34,6 +36,7 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 #define RTC_MSPM0_CLKCTL_ENABLE			BIT(31)
 
 #define RTC_MSPM0_CTL_BIN			0x0
+#define RTC_MSPM0_CTL_RTCTEVTX_MASK		GENMASK(1, 0)
 
 #define RTC_MSPM0_SEC_BIN_MASK			BIT_MASK(6)
 #define RTC_MSPM0_MIN_BIN_MASK			BIT_MASK(6)
@@ -56,9 +59,12 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 #define RTC_MSPM0_ADAY_WEEK_BIN_ENABLE		BIT(7)
 
 #define RTC_MSPM0_IIDX_RTCRDY			0x1
+#define RTC_MSPM0_IIDX_RTCTEV			0x2
 #define RTC_MSPM0_IIDX_ALARM1			0x3
 #define RTC_MSPM0_IIDX_ALARM2			0x4
 #define RTC_MSPM0_IMASK_RTCRDY			BIT(0)
+#define RTC_MSPM0_IMASK_RTCTEV			BIT(1)
+
 #define RTC_MSPM0_STA_RTCTCRDY_MASK		BIT(1)
 
 #define RTC_MSPM0_CAL_MAX_VALUE			240
@@ -145,7 +151,8 @@ typedef struct {
 
 struct rtc_ti_mspm0_config {
 	rtc_ti_mspm0_reg_t *regs;
-#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) || \
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
 	void (*irq_config_func)(void);
 #endif
 	bool rtc_x;
@@ -168,6 +175,10 @@ struct rtc_ti_mspm0_data {
 #endif
 #if defined(CONFIG_RTC_ALARM)
 	struct rtc_ti_mspm0_alarm rtc_alarm[RTC_TI_MAX_ALARM];
+#endif
+#if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+	rtc_mspm0_interval_callback interval_cb;
+	void *interval_cb_user_data;
 #endif
 };
 
@@ -442,7 +453,34 @@ static int rtc_ti_mspm0_update_set_callback(const struct device *dev,
 }
 #endif
 
-#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
+#if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+int rtc_mspm0_set_interval_callback(const struct device *dev,
+				    enum rtc_mspm0_interval interval,
+				    rtc_mspm0_interval_callback callback,
+				    void *user_data)
+{
+	const struct rtc_ti_mspm0_config *cfg = dev->config;
+	struct rtc_ti_mspm0_data *data = dev->data;
+
+	K_SPINLOCK(&data->lock) {
+		data->interval_cb = callback;
+		data->interval_cb_user_data = user_data;
+
+		if (callback) {
+			cfg->regs->ctl = (cfg->regs->ctl & ~RTC_MSPM0_CTL_RTCTEVTX_MASK) |
+					FIELD_PREP(RTC_MSPM0_CTL_RTCTEVTX_MASK, interval);
+			cfg->regs->imask |= RTC_MSPM0_IMASK_RTCTEV;
+		} else {
+			cfg->regs->imask &= ~RTC_MSPM0_IMASK_RTCTEV;
+		}
+	}
+
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) || \
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
 static void rtc_ti_mspm0_isr(const struct device *dev)
 {
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
@@ -455,6 +493,10 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 #if defined(CONFIG_RTC_UPDATE)
 	rtc_update_callback update_cb = NULL;
 	void *update_cb_data = NULL;
+#endif
+#if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+	rtc_mspm0_interval_callback interval_cb = NULL;
+	void *interval_cb_data = NULL;
 #endif
 
 	K_SPINLOCK(&data->lock) {
@@ -485,6 +527,12 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 			}
 			break;
 #endif
+#if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+		case RTC_MSPM0_IIDX_RTCTEV:
+			interval_cb = data->interval_cb;
+			interval_cb_data = data->interval_cb_user_data;
+			break;
+#endif
 		default:
 			K_SPINLOCK_BREAK;
 		}
@@ -498,6 +546,11 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 #if defined(CONFIG_RTC_ALARM)
 	if (has_cb) {
 		alarm.callback(dev, alarm_id, alarm.user_data);
+	}
+#endif
+#if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+	if (interval_cb != NULL) {
+		interval_cb(dev, interval_cb_data);
 	}
 #endif
 }
@@ -563,7 +616,8 @@ static int rtc_ti_mspm0_init(const struct device *dev)
 	/* Set clock format to binary */
 	cfg->regs->ctl = RTC_MSPM0_CTL_BIN;
 
-#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) || \
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
 	cfg->irq_config_func();
 #endif
 
@@ -589,7 +643,8 @@ static DEVICE_API(rtc, rtc_ti_mspm0_driver_api) = {
 #endif
 };
 
-#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) ||					\
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
 #define RTC_TI_MSP_IRQ_FUNC(n)									\
 	static void ti_mspm0_config_irq_##n(void)						\
 	{											\

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -37,6 +37,8 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 
 #define RTC_MSPM0_CTL_BIN			0x0
 #define RTC_MSPM0_CTL_RTCTEVTX_MASK		GENMASK(1, 0)
+#define RTC_MSPM0_PSCTL_RT0IP_MASK		GENMASK(4, 2)
+#define RTC_MSPM0_PSCTL_RT1IP_MASK		GENMASK(20, 18)
 
 #define RTC_MSPM0_SEC_BIN_MASK			BIT_MASK(6)
 #define RTC_MSPM0_MIN_BIN_MASK			BIT_MASK(6)
@@ -62,8 +64,12 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 #define RTC_MSPM0_IIDX_RTCTEV			0x2
 #define RTC_MSPM0_IIDX_ALARM1			0x3
 #define RTC_MSPM0_IIDX_ALARM2			0x4
+#define RTC_MSPM0_IIDX_RT0PS			0x5
+#define RTC_MSPM0_IIDX_RT1PS			0x6
 #define RTC_MSPM0_IMASK_RTCRDY			BIT(0)
 #define RTC_MSPM0_IMASK_RTCTEV			BIT(1)
+#define RTC_MSPM0_IMASK_RT0PS			BIT(4)
+#define RTC_MSPM0_IMASK_RT1PS			BIT(5)
 
 #define RTC_MSPM0_STA_RTCTCRDY_MASK		BIT(1)
 
@@ -152,7 +158,7 @@ typedef struct {
 struct rtc_ti_mspm0_config {
 	rtc_ti_mspm0_reg_t *regs;
 #if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) || \
-    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER) || defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
 	void (*irq_config_func)(void);
 #endif
 	bool rtc_x;
@@ -179,6 +185,10 @@ struct rtc_ti_mspm0_data {
 #if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
 	rtc_mspm0_interval_callback interval_cb;
 	void *interval_cb_user_data;
+#endif
+#if defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
+	rtc_mspm0_ps_callback ps_cb[2];
+	void *ps_cb_user_data[2];
 #endif
 };
 
@@ -479,8 +489,39 @@ int rtc_mspm0_set_interval_callback(const struct device *dev,
 }
 #endif
 
+#if defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
+int rtc_mspm0_set_ps_callback(const struct device *dev,
+			      enum rtc_mspm0_ps_timer timer,
+			      uint8_t interval,
+			      rtc_mspm0_ps_callback callback,
+			      void *user_data)
+{
+	const struct rtc_ti_mspm0_config *cfg = dev->config;
+	struct rtc_ti_mspm0_data *data = dev->data;
+	uint32_t mask = (timer == RTC_MSPM0_PS_TIMER_0) ?
+			RTC_MSPM0_PSCTL_RT0IP_MASK : RTC_MSPM0_PSCTL_RT1IP_MASK;
+	uint32_t imask_bit = (timer == RTC_MSPM0_PS_TIMER_0) ?
+				RTC_MSPM0_IMASK_RT0PS : RTC_MSPM0_IMASK_RT1PS;
+
+	K_SPINLOCK(&data->lock) {
+		data->ps_cb[timer] = callback;
+		data->ps_cb_user_data[timer] = user_data;
+
+		if (callback) {
+			cfg->regs->psctl = (cfg->regs->psctl & ~mask) |
+						FIELD_PREP(mask, interval);
+			cfg->regs->imask |= imask_bit;
+		} else {
+			cfg->regs->imask &= ~imask_bit;
+		}
+	}
+
+	return 0;
+}
+#endif
+
 #if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) || \
-    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER) || defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
 static void rtc_ti_mspm0_isr(const struct device *dev)
 {
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
@@ -497,6 +538,11 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 #if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
 	rtc_mspm0_interval_callback interval_cb = NULL;
 	void *interval_cb_data = NULL;
+#endif
+#if defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
+	rtc_mspm0_ps_callback ps_cb = NULL;
+	void *ps_cb_data = NULL;
+	uint8_t ps_id = 0;
 #endif
 
 	K_SPINLOCK(&data->lock) {
@@ -533,6 +579,18 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 			interval_cb_data = data->interval_cb_user_data;
 			break;
 #endif
+#if defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
+		case RTC_MSPM0_IIDX_RT0PS:
+			ps_id = RTC_MSPM0_PS_TIMER_0;
+			ps_cb = data->ps_cb[ps_id];
+			ps_cb_data = data->ps_cb_user_data[ps_id];
+			break;
+		case RTC_MSPM0_IIDX_RT1PS:
+			ps_id = RTC_MSPM0_PS_TIMER_1;
+			ps_cb = data->ps_cb[ps_id];
+			ps_cb_data = data->ps_cb_user_data[ps_id];
+			break;
+#endif
 		default:
 			K_SPINLOCK_BREAK;
 		}
@@ -551,6 +609,11 @@ static void rtc_ti_mspm0_isr(const struct device *dev)
 #if defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
 	if (interval_cb != NULL) {
 		interval_cb(dev, interval_cb_data);
+	}
+#endif
+#if defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
+	if (ps_cb != NULL) {
+		ps_cb(dev, ps_cb_data);
 	}
 #endif
 }
@@ -617,7 +680,7 @@ static int rtc_ti_mspm0_init(const struct device *dev)
 	cfg->regs->ctl = RTC_MSPM0_CTL_BIN;
 
 #if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) || \
-    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER) || defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
 	cfg->irq_config_func();
 #endif
 
@@ -644,7 +707,7 @@ static DEVICE_API(rtc, rtc_ti_mspm0_driver_api) = {
 };
 
 #if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE) ||					\
-    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER)
+    defined(CONFIG_RTC_TI_MSPM0_INTERVAL_TIMER) || defined(CONFIG_RTC_TI_MSPM0_PS_TIMER)
 #define RTC_TI_MSP_IRQ_FUNC(n)									\
 	static void ti_mspm0_config_irq_##n(void)						\
 	{											\

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -59,6 +59,12 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 #define RTC_MSPM0_IIDX_ALARM2			0x4
 
 typedef struct {
+	volatile uint32_t a_min;	/* RTC Alarm Minutes	*/
+	volatile uint32_t a_hour;	/* RTC Alarm Hours	*/
+	volatile uint32_t a_day;	/* RTC Alarm Day	*/
+} rtc_ti_mspm0_alarm_reg_t;
+
+typedef struct {
 	uint32_t reserved0[0x111];
 	volatile uint32_t fpub_0;	/* Publisher Port 0			@0x444h */
 	uint32_t reserved1[0xEE];
@@ -109,12 +115,11 @@ typedef struct {
 	volatile uint32_t day;		/* RTC Day of Week/Month		@0x1124h */
 	volatile uint32_t mon;		/* RTC Month				@0x1128h */
 	volatile uint32_t year;		/* RTC Year				@0x112Ch */
-	volatile uint32_t a1min;	/* RTC Alarm 1 Minutes			@0x1130h */
-	volatile uint32_t a1hour;	/* RTC Alarm 1 Hours			@0x1134h */
-	volatile uint32_t a1day;	/* RTC Alarm 1 Day			@0x1138h */
-	volatile uint32_t a2min;	/* RTC Alarm 2 Minutes			@0x113Ch */
-	volatile uint32_t a2hour;	/* RTC Alarm 2 Hours			@0x1140h */
-	volatile uint32_t a2day;	/* RTC Alarm 2 Day			@0x1144h */
+	/*
+	 * Alarm 1 @0x1130h
+	 * Alarm 2 @0x113Ch
+	 */
+	rtc_ti_mspm0_alarm_reg_t alarm[2];
 	volatile uint32_t psctl;	/* RTC Prescale Timer 0/1 Control	@0x1148h */
 	volatile uint32_t extpsctl;     /* RTC Prescale Timer 2 Control		@0x114Ch */
 	volatile uint32_t tssec;	/* Time Stamp Seconds			@0x1150h */
@@ -242,104 +247,22 @@ static int rtc_ti_mspm0_alarm_get_supported_fields(const struct device *dev,
 	return 0;
 }
 
-static inline void rtc_ti_mspm0_set_alarm1(const struct device *dev,
-					   uint16_t mask,
-					   const struct rtc_time *timeptr)
-{
-	const struct rtc_ti_mspm0_config *cfg = dev->config;
-
-	/* Disable Alarm 1 interrupt */
-	cfg->regs->imask &= ~(RTC_MSPM0_IMASK_ALARM1);
-
-	if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		cfg->regs->a1min = 0;
-		/* Set alarm minutes and enable */
-		cfg->regs->a1min =
-			RTC_MSPM0_AMIN_BIN_ENABLE | (timeptr->tm_min & RTC_MSPM0_AMIN_BIN_MASK);
-	}
-
-	if (mask & RTC_ALARM_TIME_MASK_HOUR) {
-		cfg->regs->a1hour = RTC_MSPM0_AHOUR_BIN_ENABLE |
-				    (timeptr->tm_hour & RTC_MSPM0_AHOUR_BIN_MASK);
-	}
-
-	if (mask & (RTC_ALARM_TIME_MASK_WEEKDAY | RTC_ALARM_TIME_MASK_MONTHDAY)) {
-		uint32_t day = 0;
-
-		if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-			day |= RTC_MSPM0_ADAY_WEEK_BIN_ENABLE |
-			       (timeptr->tm_wday & RTC_MSPM0_ADAY_WEEK_BIN_MASK);
-		}
-		if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-			day |= RTC_MSPM0_ADAY_MON_BIN_ENABLE |
-			       FIELD_PREP(RTC_MSPM0_ADAY_MON_BIN_MASK, timeptr->tm_mday);
-		}
-		cfg->regs->a1day = day;
-	}
-
-	/* Enable Alarm 1 interrupt */
-	cfg->regs->imask |= RTC_MSPM0_IMASK_ALARM1;
-}
-
-static inline void rtc_ti_mspm0_set_alarm2(const struct device *dev,
-					   uint16_t mask,
-					   const struct rtc_time *timeptr)
-{
-	const struct rtc_ti_mspm0_config *cfg = dev->config;
-
-	/* Disable Alarm 2 interrupt */
-	cfg->regs->imask &= ~(RTC_MSPM0_IMASK_ALARM2);
-
-	if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		cfg->regs->a2min = 0;
-		/* Set alarm minutes and enable */
-		cfg->regs->a2min =
-			RTC_MSPM0_AMIN_BIN_ENABLE | (timeptr->tm_min & RTC_MSPM0_AMIN_BIN_MASK);
-	}
-
-	if (mask & RTC_ALARM_TIME_MASK_HOUR) {
-		cfg->regs->a2hour = RTC_MSPM0_AHOUR_BIN_ENABLE |
-				    (timeptr->tm_hour & RTC_MSPM0_AHOUR_BIN_MASK);
-	}
-
-	if (mask & (RTC_ALARM_TIME_MASK_WEEKDAY | RTC_ALARM_TIME_MASK_MONTHDAY)) {
-		uint32_t day = 0;
-
-		if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-			day |= RTC_MSPM0_ADAY_WEEK_BIN_ENABLE |
-			       (timeptr->tm_wday & RTC_MSPM0_ADAY_WEEK_BIN_MASK);
-		}
-		if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-			day |= RTC_MSPM0_ADAY_MON_BIN_ENABLE |
-			       FIELD_PREP(RTC_MSPM0_ADAY_MON_BIN_MASK, timeptr->tm_mday);
-		}
-		cfg->regs->a2day = day;
-	}
-
-	/* Enable Alarm 2 interrupt */
-	cfg->regs->imask |= RTC_MSPM0_IMASK_ALARM2;
-}
-
 static inline void rtc_ti_mspm0_clear_alarm(const struct device *dev, uint16_t id)
 {
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
 
-	if (id == RTC_TI_ALARM_1) {
-		cfg->regs->a1min = 0x00;
-		cfg->regs->a1hour = 0x00;
-		cfg->regs->a1day = 0x00;
-	} else {
-		cfg->regs->a2min = 0x00;
-		cfg->regs->a2hour = 0x00;
-		cfg->regs->a2day = 0x00;
-	}
+	cfg->regs->alarm[id].a_min = 0x00;
+	cfg->regs->alarm[id].a_hour = 0x00;
+	cfg->regs->alarm[id].a_day = 0x00;
 }
 
 static int rtc_ti_mspm0_alarm_set_time(const struct device *dev, uint16_t id,
 				       uint16_t mask,
 				       const struct rtc_time *timeptr)
 {
+	const struct rtc_ti_mspm0_config *cfg = dev->config;
 	struct rtc_ti_mspm0_data *data = dev->data;
+	uint32_t imask_bit;
 
 	if (timeptr == NULL) {
 		return -EINVAL;
@@ -353,15 +276,38 @@ static int rtc_ti_mspm0_alarm_set_time(const struct device *dev, uint16_t id,
 		return -EINVAL;
 	}
 
+	imask_bit = (id == RTC_TI_ALARM_1) ? RTC_MSPM0_IMASK_ALARM1 : RTC_MSPM0_IMASK_ALARM2;
+
 	K_SPINLOCK(&data->lock) {
 		rtc_ti_mspm0_clear_alarm(dev, id);
+		cfg->regs->imask &= ~imask_bit;
 
-		if (id == RTC_TI_ALARM_1) {
-			rtc_ti_mspm0_set_alarm1(dev, mask, timeptr);
-		} else {
-			rtc_ti_mspm0_set_alarm2(dev, mask, timeptr);
+		if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
+			cfg->regs->alarm[id].a_min = RTC_MSPM0_AMIN_BIN_ENABLE |
+						     (timeptr->tm_min & RTC_MSPM0_AMIN_BIN_MASK);
 		}
 
+		if (mask & RTC_ALARM_TIME_MASK_HOUR) {
+			cfg->regs->alarm[id].a_hour =
+				RTC_MSPM0_AHOUR_BIN_ENABLE |
+				(timeptr->tm_hour & RTC_MSPM0_AHOUR_BIN_MASK);
+		}
+
+		if (mask & (RTC_ALARM_TIME_MASK_WEEKDAY | RTC_ALARM_TIME_MASK_MONTHDAY)) {
+			uint32_t day = 0;
+
+			if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
+				day |= RTC_MSPM0_ADAY_WEEK_BIN_ENABLE |
+				       (timeptr->tm_wday & RTC_MSPM0_ADAY_WEEK_BIN_MASK);
+			}
+			if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
+				day |= RTC_MSPM0_ADAY_MON_BIN_ENABLE |
+				       FIELD_PREP(RTC_MSPM0_ADAY_MON_BIN_MASK, timeptr->tm_mday);
+			}
+			cfg->regs->alarm[id].a_day = day;
+		}
+
+		cfg->regs->imask |= imask_bit;
 		data->rtc_alarm[id].mask = mask;
 		data->rtc_alarm[id].is_pending = false;
 	}
@@ -369,72 +315,12 @@ static int rtc_ti_mspm0_alarm_set_time(const struct device *dev, uint16_t id,
 	return 0;
 }
 
-static int rtc_ti_mspm0_get_alarm1(const struct device *dev,
-				   struct rtc_time *timeptr)
-{
-	uint16_t return_mask = 0;
-	uint16_t alarm_mask = 0;
-	const struct rtc_ti_mspm0_config *cfg = dev->config;
-	struct rtc_ti_mspm0_data *data = dev->data;
-
-	alarm_mask = data->rtc_alarm[RTC_TI_ALARM_1].mask;
-	if (alarm_mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		timeptr->tm_min = cfg->regs->a1min & RTC_MSPM0_AMIN_BIN_MASK;
-		return_mask |= RTC_ALARM_TIME_MASK_MINUTE;
-	}
-
-	if (alarm_mask & RTC_ALARM_TIME_MASK_HOUR) {
-		timeptr->tm_hour = cfg->regs->a1hour & RTC_MSPM0_AHOUR_BIN_MASK;
-		return_mask |= RTC_ALARM_TIME_MASK_HOUR;
-	}
-
-	if (alarm_mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-		timeptr->tm_wday = FIELD_GET(RTC_MSPM0_ADAY_WEEK_BIN_MASK, cfg->regs->a1day);
-		return_mask |= RTC_ALARM_TIME_MASK_WEEKDAY;
-	}
-
-	if (alarm_mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-		timeptr->tm_mday = FIELD_GET(RTC_MSPM0_ADAY_MON_BIN_MASK, cfg->regs->a1day);
-		return_mask |= RTC_ALARM_TIME_MASK_MONTHDAY;
-	}
-
-	return return_mask;
-}
-
-static int rtc_ti_mspm0_get_alarm2(const struct device *dev, struct rtc_time *timeptr)
-{
-	uint16_t return_mask = 0;
-	uint16_t alarm_mask = 0;
-	const struct rtc_ti_mspm0_config *cfg = dev->config;
-	struct rtc_ti_mspm0_data *data = dev->data;
-
-	alarm_mask = data->rtc_alarm[RTC_TI_ALARM_2].mask;
-	if (alarm_mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		timeptr->tm_min = cfg->regs->a2min & RTC_MSPM0_AMIN_BIN_MASK;
-		return_mask |= RTC_ALARM_TIME_MASK_MINUTE;
-	}
-
-	if (alarm_mask & RTC_ALARM_TIME_MASK_HOUR) {
-		timeptr->tm_hour = cfg->regs->a2hour & RTC_MSPM0_AHOUR_BIN_MASK;
-		return_mask |= RTC_ALARM_TIME_MASK_HOUR;
-	}
-
-	if (alarm_mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-		timeptr->tm_wday = FIELD_GET(RTC_MSPM0_ADAY_WEEK_BIN_MASK, cfg->regs->a2day);
-		return_mask |= RTC_ALARM_TIME_MASK_WEEKDAY;
-	}
-
-	if (alarm_mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-		timeptr->tm_mday = FIELD_GET(RTC_MSPM0_ADAY_MON_BIN_MASK, cfg->regs->a2day);
-		return_mask |= RTC_ALARM_TIME_MASK_MONTHDAY;
-	}
-
-	return return_mask;
-}
-
 static int rtc_ti_mspm0_alarm_get_time(const struct device *dev, uint16_t id,
 				       uint16_t *mask, struct rtc_time *timeptr)
 {
+	uint16_t return_mask = 0;
+	uint16_t alarm_mask = 0;
+	const struct rtc_ti_mspm0_config *cfg = dev->config;
 	struct rtc_ti_mspm0_data *data = dev->data;
 
 	if (timeptr == NULL) {
@@ -446,11 +332,29 @@ static int rtc_ti_mspm0_alarm_get_time(const struct device *dev, uint16_t id,
 	}
 
 	K_SPINLOCK(&data->lock) {
-		if (id == RTC_TI_ALARM_1) {
-			*mask = rtc_ti_mspm0_get_alarm1(dev, timeptr);
-		} else {
-			*mask = rtc_ti_mspm0_get_alarm2(dev, timeptr);
+		alarm_mask = data->rtc_alarm[id].mask;
+
+		if (alarm_mask & RTC_ALARM_TIME_MASK_MINUTE) {
+			timeptr->tm_min = cfg->regs->alarm[id].a_min & RTC_MSPM0_AMIN_BIN_MASK;
+			return_mask |= RTC_ALARM_TIME_MASK_MINUTE;
 		}
+		if (alarm_mask & RTC_ALARM_TIME_MASK_HOUR) {
+			timeptr->tm_hour =
+				cfg->regs->alarm[id].a_hour & RTC_MSPM0_AHOUR_BIN_MASK;
+			return_mask |= RTC_ALARM_TIME_MASK_HOUR;
+		}
+		if (alarm_mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
+			timeptr->tm_wday = FIELD_GET(RTC_MSPM0_ADAY_WEEK_BIN_MASK,
+						     cfg->regs->alarm[id].a_day);
+			return_mask |= RTC_ALARM_TIME_MASK_WEEKDAY;
+		}
+		if (alarm_mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
+			timeptr->tm_mday = FIELD_GET(RTC_MSPM0_ADAY_MON_BIN_MASK,
+						     cfg->regs->alarm[id].a_day);
+			return_mask |= RTC_ALARM_TIME_MASK_MONTHDAY;
+		}
+
+		*mask = return_mask;
 	}
 
 	return 0;

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -55,8 +55,11 @@ BUILD_ASSERT((RTC_TI_MAX_ALARM != 0),
 #define RTC_MSPM0_ADAY_WEEK_BIN_MASK		BIT_MASK(3)
 #define RTC_MSPM0_ADAY_WEEK_BIN_ENABLE		BIT(7)
 
+#define RTC_MSPM0_IIDX_RTCRDY			0x1
 #define RTC_MSPM0_IIDX_ALARM1			0x3
 #define RTC_MSPM0_IIDX_ALARM2			0x4
+#define RTC_MSPM0_IMASK_RTCRDY			BIT(0)
+#define RTC_MSPM0_STA_RTCTCRDY_MASK		BIT(1)
 
 typedef struct {
 	volatile uint32_t a_min;	/* RTC Alarm Minutes	*/
@@ -137,7 +140,7 @@ typedef struct {
 
 struct rtc_ti_mspm0_config {
 	rtc_ti_mspm0_reg_t *regs;
-#if defined(CONFIG_RTC_ALARM)
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
 	void (*irq_config_func)(void);
 #endif
 	bool rtc_x;
@@ -154,6 +157,10 @@ struct rtc_ti_mspm0_alarm {
 
 struct rtc_ti_mspm0_data {
 	struct k_spinlock lock;
+#if defined(CONFIG_RTC_UPDATE)
+	rtc_update_callback update_cb;
+	void *update_cb_user_data;
+#endif
 #if defined(CONFIG_RTC_ALARM)
 	struct rtc_ti_mspm0_alarm rtc_alarm[RTC_TI_MAX_ALARM];
 #endif
@@ -405,38 +412,89 @@ static int rtc_ti_mspm0_alarm_is_pending(const struct device *dev, uint16_t id)
 
 	return ret;
 }
+#endif
 
+#if defined(CONFIG_RTC_UPDATE)
+static int rtc_ti_mspm0_update_set_callback(const struct device *dev,
+			rtc_update_callback callback,
+			void *user_data)
+{
+	const struct rtc_ti_mspm0_config *cfg = dev->config;
+	struct rtc_ti_mspm0_data *data = dev->data;
+
+	K_SPINLOCK(&data->lock) {
+		data->update_cb = callback;
+		data->update_cb_user_data = user_data;
+
+		if (callback) {
+			cfg->regs->imask |= RTC_MSPM0_IMASK_RTCRDY;
+		} else {
+			cfg->regs->imask &= ~RTC_MSPM0_IMASK_RTCRDY;
+		}
+	}
+
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
 static void rtc_ti_mspm0_isr(const struct device *dev)
 {
 	const struct rtc_ti_mspm0_config *cfg = dev->config;
 	struct rtc_ti_mspm0_data *data = dev->data;
+#if defined(CONFIG_RTC_ALARM)
 	struct rtc_ti_mspm0_alarm alarm = {0};
 	uint8_t alarm_id = 0;
 	bool has_cb = false;
+#endif
+#if defined(CONFIG_RTC_UPDATE)
+	rtc_update_callback update_cb = NULL;
+	void *update_cb_data = NULL;
+#endif
 
 	K_SPINLOCK(&data->lock) {
 		switch (cfg->regs->iidx) {
+#if defined(CONFIG_RTC_UPDATE)
+		case RTC_MSPM0_IIDX_RTCRDY:
+			update_cb = data->update_cb;
+			update_cb_data = data->update_cb_user_data;
+			break;
+#endif
+#if defined(CONFIG_RTC_ALARM)
 		case RTC_MSPM0_IIDX_ALARM1:
 			alarm_id = RTC_TI_ALARM_1;
+			alarm = data->rtc_alarm[alarm_id];
+			if (!alarm.callback) {
+				data->rtc_alarm[alarm_id].is_pending = true;
+			} else {
+				has_cb = true;
+			}
 			break;
 		case RTC_MSPM0_IIDX_ALARM2:
 			alarm_id = RTC_TI_ALARM_2;
+			alarm = data->rtc_alarm[alarm_id];
+			if (!alarm.callback) {
+				data->rtc_alarm[alarm_id].is_pending = true;
+			} else {
+				has_cb = true;
+			}
 			break;
+#endif
 		default:
 			K_SPINLOCK_BREAK;
 		}
-
-		alarm = data->rtc_alarm[alarm_id];
-		if (!alarm.callback) {
-			data->rtc_alarm[alarm_id].is_pending = true;
-		} else {
-			has_cb = true;
-		}
 	}
 
+#if defined(CONFIG_RTC_UPDATE)
+	if (update_cb != NULL) {
+		update_cb(dev, update_cb_data);
+	}
+#endif
+#if defined(CONFIG_RTC_ALARM)
 	if (has_cb) {
 		alarm.callback(dev, alarm_id, alarm.user_data);
 	}
+#endif
 }
 #endif
 
@@ -457,7 +515,7 @@ static int rtc_ti_mspm0_init(const struct device *dev)
 	/* Set clock format to binary */
 	cfg->regs->ctl = RTC_MSPM0_CTL_BIN;
 
-#if defined(CONFIG_RTC_ALARM)
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
 	cfg->irq_config_func();
 #endif
 
@@ -474,28 +532,33 @@ static DEVICE_API(rtc, rtc_ti_mspm0_driver_api) = {
 	.alarm_set_callback	= rtc_ti_mspm0_alarm_set_callback,
 	.alarm_get_supported_fields = rtc_ti_mspm0_alarm_get_supported_fields,
 #endif /* CONFIG_RTC_ALARM */
+#if defined(CONFIG_RTC_UPDATE)
+	.update_set_callback = rtc_ti_mspm0_update_set_callback,
+#endif
 };
 
-#define RTC_TI_MSPM0_DEVICE_INIT(n)						\
-	IF_ENABLED(CONFIG_RTC_ALARM,						\
-	(static void ti_mspm0_config_irq_##n(void)				\
-	{									\
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),		\
-			    rtc_ti_mspm0_isr, DEVICE_DT_INST_GET(n), 0);	\
-		irq_enable(DT_INST_IRQN(n));					\
-	}))									\
-										\
-	static struct rtc_ti_mspm0_data rtc_data_##n;				\
-										\
-	static struct rtc_ti_mspm0_config rtc_config_##n = {			\
-		.regs = (rtc_ti_mspm0_reg_t *)DT_INST_REG_ADDR(n),		\
-		.rtc_x		 = DT_INST_PROP(n, ti_rtc_x),			\
-		IF_ENABLED(CONFIG_RTC_ALARM,					\
-		(.irq_config_func = ti_mspm0_config_irq_##n,))			\
-	};									\
-										\
-DEVICE_DT_INST_DEFINE(n, &rtc_ti_mspm0_init, NULL, &rtc_data_##n,		\
-		      &rtc_config_##n, PRE_KERNEL_1,				\
-		      CONFIG_RTC_INIT_PRIORITY, &rtc_ti_mspm0_driver_api);
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
+#define RTC_TI_MSP_IRQ_FUNC(n)									\
+	static void ti_mspm0_config_irq_##n(void)						\
+	{											\
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), rtc_ti_mspm0_isr,	\
+			    DEVICE_DT_INST_GET(n), 0);						\
+		irq_enable(DT_INST_IRQN(n));							\
+	}
+#define RTC_TI_MSP_IRQ_CFG(n) .irq_config_func = ti_mspm0_config_irq_##n,
+#else
+#define RTC_TI_MSP_IRQ_FUNC(n)
+#define RTC_TI_MSP_IRQ_CFG(n)
+#endif
+
+#define RTC_TI_MSPM0_DEVICE_INIT(n)								\
+	RTC_TI_MSP_IRQ_FUNC(n)									\
+	static struct rtc_ti_mspm0_data rtc_data_##n;						\
+	static const struct rtc_ti_mspm0_config rtc_config_##n = {				\
+		.regs = (rtc_ti_mspm0_reg_t *)DT_INST_REG_ADDR(n),				\
+		.rtc_x = DT_INST_PROP(n, ti_rtc_x),						\
+		RTC_TI_MSP_IRQ_CFG(n)};								\
+	DEVICE_DT_INST_DEFINE(n, &rtc_ti_mspm0_init, NULL, &rtc_data_##n, &rtc_config_##n,	\
+			      PRE_KERNEL_1, CONFIG_RTC_INIT_PRIORITY, &rtc_ti_mspm0_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RTC_TI_MSPM0_DEVICE_INIT);

--- a/dts/arm/ti/mspm33c/mspm33c.dtsi
+++ b/dts/arm/ti/mspm33c/mspm33c.dtsi
@@ -73,6 +73,15 @@
 				#gpio-cells = <2>;
 			};
 		};
+
+		rtc: rtc@400d8000 {
+			compatible = "ti,mspm0-rtc";
+			reg = <0x400d8000 0x2000>;
+			interrupts = <42 0>;
+			alarms-count = <2>;
+			ti,rtc-x;
+			status = "disabled";
+		};
 	};
 };
 

--- a/include/zephyr/drivers/rtc/rtc_ti_mspm0.h
+++ b/include/zephyr/drivers/rtc/rtc_ti_mspm0.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Texas Instruments
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup ti_mspm0_rtc_interface
+ * @brief Public API for TI MSPM0 RTC driver extensions
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_RTC_TI_MSPM0_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RTC_RTC_TI_MSPM0_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief TI MSPM0 RTC device-specific API extension
+ * @defgroup ti_mspm0_rtc_interface TI MSPM0 RTC
+ * @since 4.5.0
+ * @version 0.1.0
+ * @ingroup rtc_interface
+ * @{
+ */
+
+/**
+ * @brief RTC interval timer event selection
+ *
+ * Selects the interval at which the RTCTEV interrupt is generated.
+ */
+enum rtc_mspm0_interval {
+	/** Interrupt fires when the minute changes */
+	RTC_MSPM0_INTERVAL_MINUTE   = 0,
+	/** Interrupt fires when the hour changes */
+	RTC_MSPM0_INTERVAL_HOUR     = 1,
+	/** Interrupt fires every day at midnight (00:00) */
+	RTC_MSPM0_INTERVAL_MIDNIGHT = 2,
+	/** Interrupt fires every day at noon (12:00) */
+	RTC_MSPM0_INTERVAL_NOON     = 3,
+};
+
+/**
+ * @brief Callback type for RTC interval timer events
+ *
+ * @param dev      RTC device instance
+ * @param user_data User-supplied context pointer
+ */
+typedef void (*rtc_mspm0_interval_callback)(const struct device *dev, void *user_data);
+
+/**
+ * @brief Register a callback for the RTC interval timer (RTCTEV)
+ *
+ * Configures the interval at which the RTCTEV interrupt fires and registers
+ * a callback to be invoked on each event. Pass @p callback as NULL to
+ * disable the interval timer.
+ *
+ * @param dev       RTC device instance
+ * @param interval  Interval selection (@ref rtc_mspm0_interval)
+ * @param callback  Function to call on each interval event, or NULL to disable
+ * @param user_data User context pointer passed to the callback
+ *
+ * @retval 0 on success
+ */
+int rtc_mspm0_set_interval_callback(const struct device *dev,
+				    enum rtc_mspm0_interval interval,
+				    rtc_mspm0_interval_callback callback,
+				    void *user_data);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RTC_RTC_TI_MSPM0_H_ */

--- a/include/zephyr/drivers/rtc/rtc_ti_mspm0.h
+++ b/include/zephyr/drivers/rtc/rtc_ti_mspm0.h
@@ -42,12 +42,62 @@ enum rtc_mspm0_interval {
 };
 
 /**
+ * @brief Prescaler timer selection
+ */
+enum rtc_mspm0_ps_timer {
+	/** Prescaler timer 0 (RT0PS) */
+	RTC_MSPM0_PS_TIMER_0 = 0,
+	/** Prescaler timer 1 (RT1PS) */
+	RTC_MSPM0_PS_TIMER_1 = 1,
+};
+
+/**
+ * @brief RT0PS interrupt interval selection
+ *
+ * Valid values for the @p interval parameter of @ref rtc_mspm0_set_ps_callback
+ * when @p timer is @ref RTC_MSPM0_PS_TIMER_0.
+ */
+enum rtc_mspm0_rt0ps_interval {
+	RTC_MSPM0_RT0PS_DIV8   = 2,	/**< 244 microsecond interval  */
+	RTC_MSPM0_RT0PS_DIV16  = 3,	/**< 488 microsecond interval  */
+	RTC_MSPM0_RT0PS_DIV32  = 4,	/**< 976 microsecond interval  */
+	RTC_MSPM0_RT0PS_DIV64  = 5,	/**< 1.95 millisecond interval */
+	RTC_MSPM0_RT0PS_DIV128 = 6,	/**< 3.90 millisecond interval */
+	RTC_MSPM0_RT0PS_DIV256 = 7,	/**< 7.81 millisecond interval */
+};
+
+/**
+ * @brief RT1PS interrupt interval selection
+ *
+ * Valid values for the @p interval parameter of @ref rtc_mspm0_set_ps_callback
+ * when @p timer is @ref RTC_MSPM0_PS_TIMER_1.
+ */
+enum rtc_mspm0_rt1ps_interval {
+	RTC_MSPM0_RT1PS_DIV2   = 0,	/**< 15.6 millisecond interval */
+	RTC_MSPM0_RT1PS_DIV4   = 1,	/**< 31.2 millisecond interval */
+	RTC_MSPM0_RT1PS_DIV8   = 2,	/**< 62.5 millisecond interval */
+	RTC_MSPM0_RT1PS_DIV16  = 3,	/**< 125 millisecond interval  */
+	RTC_MSPM0_RT1PS_DIV32  = 4,	/**< 250 millisecond interval  */
+	RTC_MSPM0_RT1PS_DIV64  = 5,	/**< 500 millisecond interval  */
+	RTC_MSPM0_RT1PS_DIV128 = 6,	/**< 1 second interval         */
+	RTC_MSPM0_RT1PS_DIV256 = 7,	/**< 2 second interval         */
+};
+
+/**
  * @brief Callback type for RTC interval timer events
  *
- * @param dev      RTC device instance
+ * @param dev       RTC device instance
  * @param user_data User-supplied context pointer
  */
 typedef void (*rtc_mspm0_interval_callback)(const struct device *dev, void *user_data);
+
+/**
+ * @brief Callback type for RTC prescaler timer events
+ *
+ * @param dev       RTC device instance
+ * @param user_data User-supplied context pointer
+ */
+typedef void (*rtc_mspm0_ps_callback)(const struct device *dev, void *user_data);
 
 /**
  * @brief Register a callback for the RTC interval timer (RTCTEV)
@@ -67,6 +117,31 @@ int rtc_mspm0_set_interval_callback(const struct device *dev,
 				    enum rtc_mspm0_interval interval,
 				    rtc_mspm0_interval_callback callback,
 				    void *user_data);
+
+/**
+ * @brief Register a callback for a prescaler timer (RT0PS or RT1PS)
+ *
+ * Configures the periodic interrupt interval for the selected prescaler timer
+ * and registers a callback to be invoked on each event. Pass @p callback as
+ * NULL to disable the prescaler timer interrupt.
+ *
+ * Use values from @ref rtc_mspm0_rt0ps_interval when @p timer is
+ * @ref RTC_MSPM0_PS_TIMER_0, and values from @ref rtc_mspm0_rt1ps_interval
+ * when @p timer is @ref RTC_MSPM0_PS_TIMER_1.
+ *
+ * @param dev       RTC device instance
+ * @param timer     Prescaler timer selection (@ref rtc_mspm0_ps_timer)
+ * @param interval  Interval value for the selected timer
+ * @param callback  Function to call on each timer event, or NULL to disable
+ * @param user_data User context pointer passed to the callback
+ *
+ * @retval 0 on success
+ */
+int rtc_mspm0_set_ps_callback(const struct device *dev,
+			      enum rtc_mspm0_ps_timer timer,
+			      uint8_t interval,
+			      rtc_mspm0_ps_callback callback,
+			      void *user_data);
 
 /**
  * @}

--- a/samples/drivers/rtc/boards/lp_mspm33c321a.overlay
+++ b/samples/drivers/rtc/boards/lp_mspm33c321a.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};
+
+&rtc {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/lp_mspm0g3519.conf
+++ b/tests/drivers/rtc/rtc_api/boards/lp_mspm0g3519.conf
@@ -1,0 +1,1 @@
+CONFIG_RTC_ALARM=y

--- a/tests/drivers/rtc/rtc_api/boards/lp_mspm0g3519.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/lp_mspm0g3519.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};
+
+&rtc {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/lp_mspm0l2228.conf
+++ b/tests/drivers/rtc/rtc_api/boards/lp_mspm0l2228.conf
@@ -1,0 +1,1 @@
+CONFIG_RTC_ALARM=y

--- a/tests/drivers/rtc/rtc_api/boards/lp_mspm0l2228.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};
+
+&rtc {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/lp_mspm33c321a.conf
+++ b/tests/drivers/rtc/rtc_api/boards/lp_mspm33c321a.conf
@@ -1,0 +1,1 @@
+CONFIG_RTC_ALARM=y

--- a/tests/drivers/rtc/rtc_api/boards/lp_mspm33c321a.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/lp_mspm33c321a.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};
+
+&rtc {
+	status = "okay";
+};


### PR DESCRIPTION
- Once RTCRDY bit in STA register is set, an interrupt is sent so that RTC time reghisters can be read clearly for 1 second. This can be used for RTC update feature to call an update callback when interrupt is fired.
- RTC can be caliberated using CAL register. The value has to be converted to ppm since zephyr uses ppb for proper usage.
- Introduce a vendor specific feature to set interval interrupts to trigger every minute, hour, midnight or noon using RTCTEVTX in CTL register. Also, added a header file to make the API Public.
- The RTC module has 2 prescaler interrupt alarms which can be configured via PSCTL register. RT0PS and RT1PS prescaler timers generate periodic interrupts at configurable intervals. RT0PS supports intervals from 244us to 7.81ms, and RT1PS supports intervals from 15.6ms to 2s.

Tested on:
- lp_mspm0g3507
- lp_mspm0g3519
- lp_mspm0l2228

This PR depends on:
- #115394 