### PR TITLE
drivers: mux: Fix bugs in mux driver

### DIFF
--- a/drivers/mux/mux_handlers.c
+++ b/drivers/mux/mux_handlers.c
@@ -105,6 +105,7 @@ static inline int z_vrfy_mux_control_disconnect(const struct device *dev,
 	struct mux_control k_ctrl;
 	uint32_t k_cells[CONFIG_MUX_MAX_CELLS];
 
+	K_OOPS(K_SYSCALL_DRIVER_MUX_CONTROL(dev, disconnect));
 	K_OOPS(mux_control_copy_from_user(&k_ctrl, k_cells, control));
 
 	return z_impl_mux_control_disconnect(dev, &k_ctrl);


### PR DESCRIPTION
Fix bugs form @hakehuang 's comment in #112088
1. Fix missing syscall check in disconnect
~~2. Avoid k_msleep() in adgm3121 POST_KERNEL init~~
