### PR TITLE
boards: renesas: rx: Migrate RX boards to use zephyr,mapped-partition

### DIFF
--- a/boards/renesas/ek_rx261/ek_rx261.dts
+++ b/boards/renesas/ek_rx261/ek_rx261.dts
@@ -125,13 +125,14 @@
 	status = "okay";
 };
 
-&data_flash {
+&data_flash_mem {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_K(8)>;
 		};

--- a/boards/renesas/fpb_rx140/fpb_rx140.dts
+++ b/boards/renesas/fpb_rx140/fpb_rx140.dts
@@ -115,13 +115,14 @@
 	status = "okay";
 };
 
-&data_flash {
+&data_flash_mem {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_K(8)>;
 		};

--- a/boards/renesas/fpb_rx14t/fpb_rx14t.dts
+++ b/boards/renesas/fpb_rx14t/fpb_rx14t.dts
@@ -100,13 +100,14 @@
 	};
 };
 
-&data_flash {
+&data_flash_mem {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_K(4)>;
 		};

--- a/boards/renesas/fpb_rx261/fpb_rx261.dts
+++ b/boards/renesas/fpb_rx261/fpb_rx261.dts
@@ -107,13 +107,14 @@
 	status = "okay";
 };
 
-&data_flash {
+&data_flash_mem {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_K(8)>;
 		};

--- a/boards/renesas/mcb_rx14t/mcb_rx14t.dts
+++ b/boards/renesas/mcb_rx14t/mcb_rx14t.dts
@@ -84,13 +84,14 @@
 	};
 };
 
-&data_flash {
+&data_flash_mem {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_K(4)>;
 		};

--- a/boards/renesas/rsk_rx130/rsk_rx130.dts
+++ b/boards/renesas/rsk_rx130/rsk_rx130.dts
@@ -189,13 +189,14 @@
 	};
 };
 
-&data_flash {
+&data_flash_mem {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_K(8)>;
 		};

--- a/boards/renesas/rsk_rx140/rsk_rx140.dts
+++ b/boards/renesas/rsk_rx140/rsk_rx140.dts
@@ -122,13 +122,14 @@
 	status = "okay";
 };
 
-&data_flash {
+&data_flash_mem {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_K(8)>;
 		};

--- a/dts/rx/renesas/r5f51308axfp.dtsi
+++ b/dts/rx/renesas/r5f51308axfp.dtsi
@@ -171,6 +171,13 @@
 				ranges = <0x0 0xfff80000 DT_SIZE_K(512)>;
 				write-block-size = <4>;
 				erase-block-size = <1024>;
+
+				code_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(512)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 
 			data_flash: flash@100000 {
@@ -182,6 +189,13 @@
 				ranges = <0x0 0x100000 DT_SIZE_K(8)>;
 				write-block-size = <1>;
 				erase-block-size = <1024>;
+
+				data_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(8)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 		};
 	};

--- a/dts/rx/renesas/r5f51406.dtsi
+++ b/dts/rx/renesas/r5f51406.dtsi
@@ -175,6 +175,13 @@
 				write-block-size = <8>;
 				erase-block-size = <2048>;
 				programming-enable;
+
+				code_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(256)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 
 			data_flash: flash@100000 {
@@ -186,6 +193,13 @@
 				ranges = <0x0 0x00100000 DT_SIZE_K(8)>;
 				write-block-size = <1>;
 				erase-block-size = <256>;
+
+				data_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(8)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 		};
 	};

--- a/dts/rx/renesas/r5f514t5amfm.dtsi
+++ b/dts/rx/renesas/r5f514t5amfm.dtsi
@@ -156,6 +156,13 @@
 				ranges = <0x0 0xfffe0000 DT_SIZE_K(128)>;
 				write-block-size = <8>;
 				erase-block-size = <2048>;
+
+				code_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(128)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 
 			data_flash: flash@100000 {
@@ -167,6 +174,13 @@
 				ranges = <0x0 0x00100000 DT_SIZE_K(4)>;
 				write-block-size = <1>;
 				erase-block-size = <256>;
+
+				data_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(4)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 		};
 	};

--- a/dts/rx/renesas/r5f52618bgfp.dtsi
+++ b/dts/rx/renesas/r5f52618bgfp.dtsi
@@ -227,6 +227,13 @@
 				ranges = <0x0 0xfff80000 DT_SIZE_K(512)>;
 				write-block-size = <4>;
 				erase-block-size = <2048>;
+
+				code_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(512)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 
 			data_flash: flash@100000 {
@@ -238,6 +245,13 @@
 				ranges = <0x0 0x100000 DT_SIZE_K(8)>;
 				write-block-size = <1>;
 				erase-block-size = <256>;
+
+				data_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(8)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 		};
 	};

--- a/dts/rx/renesas/r5f526tfddfp.dtsi
+++ b/dts/rx/renesas/r5f526tfddfp.dtsi
@@ -174,6 +174,13 @@
 				ranges = <0x0 0xfff80000 DT_SIZE_K(512)>;
 				write-block-size = <128>;
 				erase-block-size = <DT_SIZE_K(16)>;
+
+				code_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(512)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 
 			data_flash: flash@100000 {
@@ -184,6 +191,13 @@
 				ranges = <0x0 0x100000 DT_SIZE_K(16)>;
 				write-block-size = <1>;
 				erase-block-size = <64>;
+
+				data_flash_mem: flash@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_K(16)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+				};
 			};
 		};
 	};


### PR DESCRIPTION
Migrate RX flash DTS to support `zephyr,mapped-partition`

RX includes Code Flash and Data Flash regions, which use the same controller but have different flash geometries and flash parameters. To preserve the existing flash device model, a dedicated `soc-nv-flash` node is added under each `renesas,rx-nv-flash` device, allowing partitions to be defined using `zephyr,mapped-partition`