### PR TITLE
kernel: events: honor reset for zero wait masks

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2859,6 +2859,9 @@ __syscall uint32_t k_event_clear(struct k_event *event, uint32_t events);
  * @param timeout Waiting period for the desired set of events or one of the
  *                special values K_NO_WAIT and K_FOREVER.
  *
+ * @note If @p events is zero, this function returns 0 immediately. If @p reset is true,
+ *       the events currently tracked by the event object are reset before returning.
+ *
  * @retval non-zero set of matching events upon success
  * @retval 0 if matching events were not received within the specified time
  */
@@ -2886,6 +2889,9 @@ __syscall uint32_t k_event_wait(struct k_event *event, uint32_t events,
  * @param timeout Waiting period for the desired set of events or one of the
  *                special values K_NO_WAIT and K_FOREVER.
  *
+ * @note If @p events is zero, this function returns 0 immediately. If @p reset is true,
+ *       the events currently tracked by the event object are reset before returning.
+ *
  * @retval non-zero set of matching events upon success
  * @retval 0 if matching events were not received within the specified time
  */
@@ -2908,6 +2914,9 @@ __syscall uint32_t k_event_wait_all(struct k_event *event, uint32_t events,
  * @param timeout Waiting period for the desired set of events or one of the
  *                special values K_NO_WAIT and K_FOREVER.
  *
+ * @note If @p events is zero, this function returns 0 immediately. If @p reset is true,
+ *       the events currently tracked by the event object are reset before returning.
+ *
  * @retval non-zero set of matching events upon success
  * @retval 0 if no matching event was received within the specified time
  */
@@ -2929,6 +2938,9 @@ __syscall uint32_t k_event_wait_safe(struct k_event *event, uint32_t events,
  *              before waiting. If false, do not clear the events.
  * @param timeout Waiting period for the desired set of events or one of the
  *                special values K_NO_WAIT and K_FOREVER.
+ *
+ * @note If @p events is zero, this function returns 0 immediately. If @p reset is true,
+ *       the events currently tracked by the event object are reset before returning.
  *
  * @retval non-zero set of matching events upon success
  * @retval 0 if all matching events were not received within the specified time

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -283,8 +283,6 @@ static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 				      unsigned int options, k_timeout_t timeout)
 {
 	uint32_t  rv = 0;
-	unsigned int  wait_condition;
-	struct k_thread  *thread;
 
 	__ASSERT(((arch_is_in_isr() == false) ||
 		  K_TIMEOUT_EQ(timeout, K_NO_WAIT)), "");
@@ -292,19 +290,25 @@ static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_event, wait, event, events,
 					options, timeout);
 
-	if (events == 0) {
+	if ((events == 0U) && !(options & K_EVENT_OPTION_RESET)) {
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_event, wait, event, events, 0);
 		return 0;
 	}
-
-	wait_condition = options & K_EVENT_WAIT_MASK;
-	thread = k_sched_current_thread_query();
 
 	k_spinlock_key_t  key = k_spin_lock(&event->lock);
 
 	if (options & K_EVENT_OPTION_RESET) {
 		event->events = 0;
 	}
+
+	if (events == 0) {
+		k_spin_unlock(&event->lock, key);
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_event, wait, event, events, 0);
+		return 0;
+	}
+
+	unsigned int wait_condition = options & K_EVENT_WAIT_MASK;
+	struct k_thread *thread = k_sched_current_thread_query();
 
 	/* Test if the wait conditions have already been met. */
 	rv = are_wait_conditions_met(events, event->events, wait_condition);

--- a/tests/kernel/events/event_api/src/main.c
+++ b/tests/kernel/events/event_api/src/main.c
@@ -694,6 +694,47 @@ ZTEST(events_api, test_event_reset_on_wait)
 }
 
 /**
+ * @brief Verify that reset clears events with a zero wait mask
+ *
+ * @details
+ * Verify that all four event wait APIs return immediately with a zero wait
+ * mask. When reset is true, events already tracked by the event object must
+ * be cleared without reading the event object's internal fields.
+ *
+ * @see k_event_wait(), k_event_wait_all(), k_event_wait_safe(),
+ *      k_event_wait_all_safe(), k_event_test()
+ */
+ZTEST(events_api, test_event_zero_mask_reset)
+{
+	uint32_t events;
+
+	k_event_set(&test_event, BIT(0));
+
+	events = k_event_wait(&test_event, 0, false, K_NO_WAIT);
+	zassert_equal(events, 0);
+	zassert_equal(k_event_test(&test_event, ~0U), BIT(0));
+
+	events = k_event_wait(&test_event, 0, true, K_NO_WAIT);
+	zassert_equal(events, 0);
+	zassert_equal(k_event_test(&test_event, ~0U), 0);
+
+	k_event_set(&test_event, BIT(0));
+	events = k_event_wait_all(&test_event, 0, true, K_NO_WAIT);
+	zassert_equal(events, 0);
+	zassert_equal(k_event_test(&test_event, ~0U), 0);
+
+	k_event_set(&test_event, BIT(0));
+	events = k_event_wait_safe(&test_event, 0, true, K_NO_WAIT);
+	zassert_equal(events, 0);
+	zassert_equal(k_event_test(&test_event, ~0U), 0);
+
+	k_event_set(&test_event, BIT(0));
+	events = k_event_wait_all_safe(&test_event, 0, true, K_NO_WAIT);
+	zassert_equal(events, 0);
+	zassert_equal(k_event_test(&test_event, ~0U), 0);
+}
+
+/**
  * @brief Verify a single event delivery wakes all matching waiters.
  *
  * @details


### PR DESCRIPTION
k_event_wait_internal() returned before acquiring the event lock when the requested event mask was zero. As a result, reset=true did not clear previously posted events.

Apply reset under the event lock before handling the zero-mask fast path. Add a regression test that verifies stale event bits are cleared.

The regression test fails on the parent revision and passes with this fix.

Test: native_sim/native/64
- events_api: 12 passed