### PR TITLE
drivers: i2s: i2s_mcux_sai: avoid looping forever during tx stream disable after underrun

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -169,9 +169,11 @@ static void i2s_tx_stream_disable(const struct device *dev, bool drop)
 
 	dma_stop(dev_dma, strm->dma_channel);
 
-	/* wait for TX FIFO to drain before disabling */
-	while ((base->TCSR & I2S_TCSR_FWF_MASK) == 0) {
-		;
+	/* wait for TX FIFO to drain before disabling, if not disabled already */
+	if ((base->TCSR & I2S_TCSR_TE_MASK) != 0UL) {
+		while ((base->TCSR & I2S_TCSR_FWF_MASK) == 0) {
+			;
+		}
 	}
 
 	/* Disable the channel FIFO */


### PR DESCRIPTION
When a data underrun occured for the I2S transmitter, the tx stream gets disabled. If the application then also disables the tx stream (e.g., I2S_TRIGGER_DROP), the driver would hang forever in the while loop waiting for the TX FIFO to drain on an already disabled peripheral.

Found using AI tooling (assisted by Claude Sonnet)