### PR TITLE
drivers: i2s: stm32_sai: invalidate D-cache on RX DMA completion

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -150,6 +150,8 @@ void HAL_SAI_RxCpltCallback(SAI_HandleTypeDef *hsai)
 		}
 	}
 
+	sys_cache_data_invd_range(stream->mem_block, stream->mem_block_len);
+
 	struct queue_item item = {.buffer = stream->mem_block, .size = stream->mem_block_len};
 
 	ret = k_msgq_put(&stream->queue, &item, K_NO_WAIT);


### PR DESCRIPTION
This change invalidates the cached copy of a buffer address from a previous capture in the RX path.