### PR TITLE
lorawan: add a LoRa Basics Modem backend

### DIFF
--- a/modules/lora-basics-modem/CMakeLists.txt
+++ b/modules/lora-basics-modem/CMakeLists.txt
@@ -28,6 +28,10 @@ if(CONFIG_USE_LORA_BASICS_MODEM_DRIVERS)
     zephyr_library_sources(${LBM_SMTC_MODEM_HAL_DIR}/smtc_modem_hal.c)
   endif()
 
+  if(CONFIG_LORA_BASICS_MODEM_CORE)
+    include(modem_core.cmake)
+  endif()
+
   if(CONFIG_LORA_SX126X)
     include(sx126x.cmake)
   elseif(CONFIG_LORA_SX127X)

--- a/modules/lora-basics-modem/Kconfig
+++ b/modules/lora-basics-modem/Kconfig
@@ -17,3 +17,15 @@ config LORA_BASICS_MODEM_HAL
 	  Compile the smtc_modem_hal implementation for LoRa Basics Modem.
 	  This is required for porting tests and full modem functionality.
 	  Currently only supported with SX126x radios.
+
+config LORA_BASICS_MODEM_NVM
+	bool "Keep the modem context in non-volatile storage"
+	depends on LORA_BASICS_MODEM_HAL
+	depends on SETTINGS
+	default y
+	help
+	  Store the modem context, which holds the join nonce among other
+	  things, so that it survives a reboot. A network rejects a join
+	  request whose nonce does not increase, so a device that forgets the
+	  context can only join once. This needs a settings backend, which the
+	  application chooses.

--- a/modules/lora-basics-modem/Kconfig
+++ b/modules/lora-basics-modem/Kconfig
@@ -13,6 +13,7 @@ config USE_LORA_BASICS_MODEM_DRIVERS
 config LORA_BASICS_MODEM_HAL
 	bool "LoRa Basics Modem HAL implementation"
 	depends on USE_LORA_BASICS_MODEM_DRIVERS && LORA_SX126X
+	default y if LORAWAN
 	help
 	  Compile the smtc_modem_hal implementation for LoRa Basics Modem.
 	  This is required for porting tests and full modem functionality.
@@ -29,3 +30,14 @@ config LORA_BASICS_MODEM_NVM
 	  request whose nonce does not increase, so a device that forgets the
 	  context can only join once. This needs a settings backend, which the
 	  application chooses.
+
+config LORA_BASICS_MODEM_CORE
+	bool "LoRa Basics Modem LoRaWAN stack"
+	depends on LORA_BASICS_MODEM_HAL
+	depends on LORAWAN
+	default y
+	select ENTROPY_GENERATOR
+	help
+	  Compile the modem core, which provides the LoRaWAN stack on top of
+	  the radio drivers. The LoRaWAN subsystem needs it to reach the
+	  modem, so it comes on by default once both sides are present.

--- a/modules/lora-basics-modem/modem_core.cmake
+++ b/modules/lora-basics-modem/modem_core.cmake
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sources and defines of the LoRa Basics Modem core.
+
+set(LBM_CORE ${LBM_LIB_SMTC_MODEM_CORE_DIR})
+
+zephyr_include_directories(
+  ${LBM_LIB_DIR}
+  ${LBM_CORE}
+  ${LBM_CORE}/logging
+  ${LBM_CORE}/lorawan_api
+  ${LBM_CORE}/lorawan_manager
+  ${LBM_CORE}/lorawan_packages/lorawan_certification
+  ${LBM_CORE}/lr1mac
+  ${LBM_CORE}/lr1mac/src
+  ${LBM_CORE}/lr1mac/src/services
+  ${LBM_CORE}/lr1mac/src/smtc_real/src
+  ${LBM_CORE}/modem_supervisor
+  ${LBM_CORE}/modem_utilities
+  ${LBM_CORE}/radio_planner/src
+  ${LBM_CORE}/smtc_modem_crypto
+  ${LBM_CORE}/smtc_modem_crypto/smtc_secure_element
+  ${LBM_LIB_DIR}/smtc_modem_api
+)
+
+zephyr_library_sources(
+  ${LBM_CORE}/lorawan_api/lorawan_api.c
+  ${LBM_CORE}/lorawan_manager/lorawan_cid_request_management.c
+  ${LBM_CORE}/lorawan_manager/lorawan_dwn_ack_management.c
+  ${LBM_CORE}/lorawan_manager/lorawan_join_management.c
+  ${LBM_CORE}/lorawan_manager/lorawan_send_management.c
+  ${LBM_CORE}/lorawan_packages/lorawan_certification/lorawan_certification.c
+  ${LBM_CORE}/lr1mac/src/lr1_stack_mac_layer.c
+  ${LBM_CORE}/lr1mac/src/lr1mac_core.c
+  ${LBM_CORE}/lr1mac/src/lr1mac_utilities.c
+  ${LBM_CORE}/lr1mac/src/services/smtc_duty_cycle.c
+  ${LBM_CORE}/lr1mac/src/services/smtc_lbt.c
+  ${LBM_CORE}/lr1mac/src/smtc_real/src/smtc_real.c
+  ${LBM_CORE}/modem_supervisor/modem_supervisor_light.c
+  ${LBM_CORE}/modem_supervisor/modem_tx_protocol_manager.c
+  ${LBM_CORE}/modem_utilities/fifo_ctrl.c
+  ${LBM_CORE}/modem_utilities/modem_core.c
+  ${LBM_CORE}/modem_utilities/modem_event_utilities.c
+  ${LBM_CORE}/radio_planner/src/radio_planner.c
+  ${LBM_CORE}/smtc_modem.c
+  ${LBM_CORE}/smtc_modem_test.c
+  ${LBM_CORE}/smtc_modem_crypto/smtc_modem_crypto.c
+  ${LBM_CORE}/smtc_modem_crypto/soft_secure_element/aes.c
+  ${LBM_CORE}/smtc_modem_crypto/soft_secure_element/cmac.c
+  ${LBM_CORE}/smtc_modem_crypto/soft_secure_element/soft_se.c
+)
+
+zephyr_library_compile_definitions(
+  RP2_103
+  NUMBER_OF_STACKS=1
+  ADD_SMTC_PATCH_FILE
+)
+
+# One region source and one define per region the application selected.
+function(lbm_region kconfig macro file)
+  if(${kconfig})
+    zephyr_library_compile_definitions(${macro})
+    zephyr_library_sources(${LBM_CORE}/lr1mac/src/smtc_real/src/${file})
+    set(lbm_region_selected TRUE PARENT_SCOPE)
+  endif()
+endfunction()
+
+lbm_region(CONFIG_LORAWAN_REGION_AS923 REGION_AS_923 region_as_923.c)
+lbm_region(CONFIG_LORAWAN_REGION_AU915 REGION_AU_915 region_au_915.c)
+lbm_region(CONFIG_LORAWAN_REGION_CN470 REGION_CN_470 region_cn_470.c)
+lbm_region(CONFIG_LORAWAN_REGION_EU868 REGION_EU_868 region_eu_868.c)
+lbm_region(CONFIG_LORAWAN_REGION_IN865 REGION_IN_865 region_in_865.c)
+lbm_region(CONFIG_LORAWAN_REGION_KR920 REGION_KR_920 region_kr_920.c)
+lbm_region(CONFIG_LORAWAN_REGION_RU864 REGION_RU_864 region_ru_864.c)
+lbm_region(CONFIG_LORAWAN_REGION_US915 REGION_US_915 region_us_915.c)
+
+if(NOT lbm_region_selected)
+  message(FATAL_ERROR "The modem core needs a region. Select one of the "
+                      "LORAWAN_REGION_* options the modem supports.")
+endif()

--- a/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
+++ b/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/random/random.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/sys/printk.h>
 
 #include <lbm_common.h>
@@ -22,6 +23,9 @@ LOG_MODULE_REGISTER(smtc_modem_hal, CONFIG_LORA_LOG_LEVEL);
 
 #define HAL_WORKQ_STACK_SIZE 1024
 #define HAL_WORKQ_PRIORITY (-1)
+
+/* "lbm/" + context type + "/" + offset + NUL */
+#define CONTEXT_KEY_LEN 24
 
 typedef void (*callback_t)(void *context);
 
@@ -93,6 +97,16 @@ void smtc_modem_hal_init(const struct device *transceiver)
 	__ASSERT(DEVICE_API_IS(lora, transceiver), "transceiver must be a LoRa device");
 
 	prv_transceiver_dev = transceiver;
+
+	if (IS_ENABLED(CONFIG_LORA_BASICS_MODEM_NVM)) {
+		int ret = settings_subsys_init();
+
+		if (ret < 0) {
+			LOG_ERR("settings init failed: %d", ret);
+		}
+	} else {
+		LOG_WRN("no context storage, the join nonce restarts on every boot");
+	}
 
 	k_work_queue_start(&hal_workq, hal_workq_stack,
 			   K_THREAD_STACK_SIZEOF(hal_workq_stack),
@@ -386,12 +400,39 @@ void smtc_modem_hal_set_offset_to_test_wrapping(const uint32_t offset_to_test_wr
 /* --- CONTEXT SAVING MANAGEMENT -------------------------------------------- */
 /* -------------------------------------------------------------------------- */
 
+struct context_read {
+	uint8_t *buffer;
+	uint32_t size;
+};
+
+static int context_read_cb(const char *key, size_t len, settings_read_cb read_cb, void *cb_arg,
+			   void *param)
+{
+	struct context_read *req = param;
+
+	if (len != req->size) {
+		LOG_WRN("stored context is %u bytes, %u wanted", (unsigned int)len,
+			(unsigned int)req->size);
+		return -EINVAL;
+	}
+
+	return read_cb(cb_arg, req->buffer, req->size);
+}
+
+/*
+ * One settings entry per context and offset. The modem reads a context back
+ * with the offset and size it wrote, and checks the content itself, so a
+ * missing entry only has to leave the buffer alone.
+ */
+static void context_key(char *key, size_t key_len, modem_context_type_t ctx_type, uint32_t offset)
+{
+	snprintk(key, key_len, "lbm/%u/%u", (unsigned int)ctx_type, (unsigned int)offset);
+}
+
 /**
  * @brief Restores the data context.
  *
  * @remark This function is used to restore Modem data from a non volatile memory.
- *
- * @remark Not implemented yet.
  *
  * @param [in]  ctx_type Type of modem context that need to be restored
  * @param [in]  offset   Memory offset after ctx_type address
@@ -401,15 +442,29 @@ void smtc_modem_hal_set_offset_to_test_wrapping(const uint32_t offset_to_test_wr
 void smtc_modem_hal_context_restore(const modem_context_type_t ctx_type, uint32_t offset,
 				    uint8_t *buffer, const uint32_t size)
 {
-	/* Not implemented yet */
+	struct context_read req = {
+		.buffer = buffer,
+		.size = size,
+	};
+	char key[CONTEXT_KEY_LEN];
+	int ret;
+
+	if (!IS_ENABLED(CONFIG_LORA_BASICS_MODEM_NVM)) {
+		return;
+	}
+
+	context_key(key, sizeof(key), ctx_type, offset);
+
+	ret = settings_load_subtree_direct(key, context_read_cb, &req);
+	if (ret < 0) {
+		LOG_WRN("restore %s failed: %d", key, ret);
+	}
 }
 
 /**
  * @brief Stores the data context.
  *
  * @remark This function is used to store Modem data in a non volatile memory.
- *
- * @remark Not implemented yet.
  *
  * @param [in] ctx_type Type of modem context that need to be saved
  * @param [in] offset   Memory offset after ctx_type address
@@ -419,7 +474,19 @@ void smtc_modem_hal_context_restore(const modem_context_type_t ctx_type, uint32_
 void smtc_modem_hal_context_store(const modem_context_type_t ctx_type, uint32_t offset,
 				  const uint8_t *buffer, const uint32_t size)
 {
-	/* Not implemented yet */
+	char key[CONTEXT_KEY_LEN];
+	int ret;
+
+	if (!IS_ENABLED(CONFIG_LORA_BASICS_MODEM_NVM)) {
+		return;
+	}
+
+	context_key(key, sizeof(key), ctx_type, offset);
+
+	ret = settings_save_one(key, buffer, size);
+	if (ret < 0) {
+		LOG_ERR("store %s failed: %d", key, ret);
+	}
 }
 
 /**

--- a/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
+++ b/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
@@ -531,6 +531,11 @@ void smtc_modem_hal_on_panic(uint8_t *func, uint32_t line, const char *fmt, ...)
 /* --- ENVIRONMENT MANAGEMENT ----------------------------------------------- */
 /* -------------------------------------------------------------------------- */
 
+__weak uint8_t lbm_battery_level(void)
+{
+	return 255;
+}
+
 /**
  * @brief Return the battery level.
  *
@@ -539,14 +544,11 @@ void smtc_modem_hal_on_panic(uint8_t *func, uint32_t line, const char *fmt, ...)
  *         1..254: Battery level, where 1 is the minimum and 254 is the maximum.
  *         255: The end-device was not able to measure the battery level.
  *
- * @remark Not implemented yet.
- *
  * @return Battery level for LoRaWAN stack (255 = not able to measure)
  */
 uint8_t smtc_modem_hal_get_battery_level(void)
 {
-	/* Not implemented yet */
-	return 255;
+	return lbm_battery_level();
 }
 
 /**

--- a/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
+++ b/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
@@ -799,10 +799,12 @@ uint16_t smtc_modem_hal_flash_get_page_size(void)
  *
  * @remark It could be convenient in the case of an RTOS implementation to
  *         notify the thread that manages the LBM stack.
- *
- * @remark Not implemented yet.
  */
+__weak void lbm_engine_notify(void)
+{
+}
+
 void smtc_modem_hal_user_lbm_irq(void)
 {
-	/* Not implemented yet */
+	lbm_engine_notify();
 }

--- a/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
+++ b/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/random/random.h>
+#include <zephyr/sys/printk.h>
 
 #include <lbm_common.h>
 #include <smtc_modem_hal.h>
@@ -501,14 +502,16 @@ int8_t smtc_modem_hal_get_board_delay_ms(void)
 /**
  * @brief Prints debug trace.
  *
- * @remark Not implemented yet.
- *
  * @param [in] fmt  String format
  * @param [in] ...  String arguments
  */
 void smtc_modem_hal_print_trace(const char *fmt, ...)
 {
-	/* Not implemented yet */
+	va_list args;
+
+	va_start(args, fmt);
+	vprintk(fmt, args);
+	va_end(args);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal_ext.h
+++ b/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal_ext.h
@@ -23,6 +23,16 @@ extern "C" {
  */
 void smtc_modem_hal_init(const struct device *transceiver);
 
+/**
+ * @brief Tell the stack owner that the modem engine has work to do.
+ *
+ * The HAL calls this on every modem interrupt. Code that queues a task from
+ * another thread must call it too, because the engine is otherwise asleep
+ * until the wake-up the last engine run asked for.
+ *
+ * The default implementation does nothing.
+ */
+void lbm_engine_notify(void);
 
 #ifdef __cplusplus
 }

--- a/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal_ext.h
+++ b/modules/lora-basics-modem/smtc_modem_hal/smtc_modem_hal_ext.h
@@ -34,6 +34,16 @@ void smtc_modem_hal_init(const struct device *transceiver);
  */
 void lbm_engine_notify(void);
 
+/**
+ * @brief Report the battery level the modem answers a DevStatusReq with.
+ *
+ * @return 0 on external power, 1 to 254 for a battery level, 255 when the
+ *         level is unknown.
+ *
+ * The default implementation returns 255.
+ */
+uint8_t lbm_battery_level(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/subsys/lorawan/class_a/tests.yaml
+++ b/samples/subsys/lorawan/class_a/tests.yaml
@@ -44,6 +44,12 @@ tests:
     extra_configs:
       - CONFIG_LORAWAN_REGION_EU868=y
       - CONFIG_LORAWAN_REGION_US915=y
+  sample.lorawan.class_a.lora_basics_modem:
+    modules:
+      - lora-basics-modem
+    extra_configs:
+      - CONFIG_LORA_MODULE_BACKEND_LORA_BASICS_MODEM=y
+      - CONFIG_LORAWAN_REGION_EU868=y
   sample.lorawan.class_a.native:
     extra_configs:
       - CONFIG_LORA_MODULE_BACKEND_NATIVE=y

--- a/subsys/lorawan/CMakeLists.txt
+++ b/subsys/lorawan/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_LORAWAN)
   add_subdirectory_ifdef(CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE loramac-node)
   add_subdirectory_ifdef(CONFIG_LORA_MODULE_BACKEND_NATIVE native)
+  add_subdirectory_ifdef(CONFIG_LORA_MODULE_BACKEND_LORA_BASICS_MODEM lora-basics-modem)
   add_subdirectory(emul)
   add_subdirectory(services)
   add_subdirectory(nvm)

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -34,10 +34,12 @@ config LORAWAN_REGION_CN470
 config LORAWAN_REGION_CN779
 	bool "China 779MHz Frequency band"
 	depends on !LORA_MODULE_BACKEND_NATIVE
+	depends on !LORA_MODULE_BACKEND_LORA_BASICS_MODEM
 
 config LORAWAN_REGION_EU433
 	bool "Europe 433MHz Frequency band"
 	depends on !LORA_MODULE_BACKEND_NATIVE
+	depends on !LORA_MODULE_BACKEND_LORA_BASICS_MODEM
 
 config LORAWAN_REGION_EU868
 	bool "Europe 868MHz Frequency band"
@@ -63,6 +65,8 @@ endmenu
 rsource "loramac-node/Kconfig"
 
 rsource "native/Kconfig"
+
+rsource "lora-basics-modem/Kconfig"
 
 rsource "emul/Kconfig"
 

--- a/subsys/lorawan/lora-basics-modem/CMakeLists.txt
+++ b/subsys/lorawan/lora-basics-modem/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+# Add include path for local headers (lbm_priv.h)
+zephyr_library_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+zephyr_library_sources(lbm_engine.c)
+zephyr_library_sources(lbm_priv.c)
+zephyr_library_sources(lorawan.c)

--- a/subsys/lorawan/lora-basics-modem/Kconfig
+++ b/subsys/lorawan/lora-basics-modem/Kconfig
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+
+if LORA_MODULE_BACKEND_LORA_BASICS_MODEM
+
+config LORAWAN_LBM
+	bool
+	default y
+	depends on LORA_BASICS_MODEM_CORE
+	help
+	  Hidden symbol enabling the LoRa Basics Modem LoRaWAN backend. The
+	  modem core carries the stack this backend calls into, and turns
+	  itself on alongside LoRaWAN.
+
+config LORAWAN_LBM_ENGINE_STACK_SIZE
+	int "Engine thread stack size"
+	default 4096
+
+config LORAWAN_LBM_ENGINE_PRIORITY
+	int "Engine thread priority"
+	default 5
+
+config LORAWAN_LBM_ENGINE_START_DELAY_MS
+	int "Engine thread start delay in milliseconds"
+	default 0
+	help
+	  Delay before the engine thread runs. Raise it to keep the modem off
+	  the bus until a console that only comes up after boot, such as CDC
+	  ACM, is ready to carry the log.
+
+config LORAWAN_LBM_ENGINE_MAX_SLEEP_MS
+	int "Longest the engine thread sleeps between runs"
+	default 1000
+	help
+	  Upper bound on the wait the modem engine asks for. The engine names
+	  a time and expects an interrupt to wake it sooner, so a wake-up that
+	  never arrives would otherwise park it for as long as it asked, which
+	  can be days. Running it again this often costs power but keeps a
+	  missed wake-up from stalling the stack.
+
+config LORAWAN_LBM_START_TIMEOUT_S
+	int "Seconds to wait for the modem to come up in lorawan_start()"
+	default 10
+
+config LORAWAN_LBM_JOIN_TIMEOUT_S
+	int "Seconds to wait for a join to settle"
+	default 120
+
+config LORAWAN_LBM_TX_TIMEOUT_S
+	int "Seconds to wait for an uplink to settle"
+	default 120
+
+endif # LORA_MODULE_BACKEND_LORA_BASICS_MODEM

--- a/subsys/lorawan/lora-basics-modem/lbm_engine.c
+++ b/subsys/lorawan/lora-basics-modem/lbm_engine.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include <smtc_modem_api.h>
+#include <smtc_modem_hal_ext.h>
+#include <smtc_modem_utilities.h>
+
+#include "lbm_lorawan.h"
+
+LOG_MODULE_REGISTER(lorawan_lbm, CONFIG_LORAWAN_LOG_LEVEL);
+
+#define LORA_NODE DT_ALIAS(lora0)
+
+static K_SEM_DEFINE(engine_wake, 0, 1);
+
+void lbm_engine_notify(void)
+{
+	k_sem_give(&engine_wake);
+}
+
+static void modem_event_cb(void)
+{
+	smtc_modem_event_t event;
+	uint8_t pending;
+
+	do {
+		if (smtc_modem_get_event(&event, &pending) != SMTC_MODEM_RC_OK) {
+			return;
+		}
+
+		lbm_lorawan_event(&event);
+	} while (pending > 0);
+}
+
+static void engine_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	const struct device *radio = DEVICE_DT_GET(LORA_NODE);
+
+	if (!device_is_ready(radio)) {
+		LOG_ERR("radio %s not ready", radio->name);
+		return;
+	}
+
+	smtc_modem_hal_init(radio);
+	smtc_modem_set_radio_context(radio);
+	smtc_modem_init(modem_event_cb);
+
+	for (;;) {
+		uint32_t sleep_ms = smtc_modem_run_engine();
+
+		sleep_ms = MIN(sleep_ms, CONFIG_LORAWAN_LBM_ENGINE_MAX_SLEEP_MS);
+
+		LOG_DBG("sleep %u ms", sleep_ms);
+		k_sem_take(&engine_wake, K_MSEC(sleep_ms));
+	}
+}
+
+K_THREAD_DEFINE(lbm_engine_tid, CONFIG_LORAWAN_LBM_ENGINE_STACK_SIZE, engine_thread, NULL, NULL,
+		NULL, CONFIG_LORAWAN_LBM_ENGINE_PRIORITY, 0,
+		CONFIG_LORAWAN_LBM_ENGINE_START_DELAY_MS);

--- a/subsys/lorawan/lora-basics-modem/lbm_lorawan.h
+++ b/subsys/lorawan/lora-basics-modem/lbm_lorawan.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_LORAWAN_LORA_BASICS_MODEM_LBM_LORAWAN_H_
+#define ZEPHYR_SUBSYS_LORAWAN_LORA_BASICS_MODEM_LBM_LORAWAN_H_
+
+#include <smtc_modem_api.h>
+
+#define LBM_STACK_ID 0
+
+void lbm_lorawan_event(const smtc_modem_event_t *event);
+
+#endif /* ZEPHYR_SUBSYS_LORAWAN_LORA_BASICS_MODEM_LBM_LORAWAN_H_ */

--- a/subsys/lorawan/lora-basics-modem/lbm_priv.c
+++ b/subsys/lorawan/lora-basics-modem/lbm_priv.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+
+#include <zephyr/sys/util.h>
+
+#include "lbm_priv.h"
+
+static const int rc2errno[] = {
+	[SMTC_MODEM_RC_OK] = 0,
+	[SMTC_MODEM_RC_NOT_INIT] = -EPERM,
+	[SMTC_MODEM_RC_INVALID] = -EINVAL,
+	[SMTC_MODEM_RC_BUSY] = -EBUSY,
+	[SMTC_MODEM_RC_FAIL] = -EIO,
+	[SMTC_MODEM_RC_NO_TIME] = -EAGAIN,
+	[SMTC_MODEM_RC_INVALID_STACK_ID] = -ENODEV,
+	[SMTC_MODEM_RC_NO_EVENT] = -ENOMSG,
+};
+
+static const char *const rc2str[] = {
+	[SMTC_MODEM_RC_OK] = "OK",
+	[SMTC_MODEM_RC_NOT_INIT] = "not initialised",
+	[SMTC_MODEM_RC_INVALID] = "invalid parameter",
+	[SMTC_MODEM_RC_BUSY] = "busy",
+	[SMTC_MODEM_RC_FAIL] = "failed",
+	[SMTC_MODEM_RC_NO_TIME] = "no time available",
+	[SMTC_MODEM_RC_INVALID_STACK_ID] = "invalid stack id",
+	[SMTC_MODEM_RC_NO_EVENT] = "no event",
+};
+
+static const char *const txdone2str[] = {
+	[SMTC_MODEM_EVENT_TXDONE_NOT_SENT] = "not sent",
+	[SMTC_MODEM_EVENT_TXDONE_SENT] = "sent",
+	[SMTC_MODEM_EVENT_TXDONE_CONFIRMED] = "confirmed",
+};
+
+int lbm_rc2errno(smtc_modem_return_code_t rc)
+{
+	if (rc >= ARRAY_SIZE(rc2errno)) {
+		return -EIO;
+	}
+
+	return rc2errno[rc];
+}
+
+const char *lbm_rc2str(smtc_modem_return_code_t rc)
+{
+	if (rc >= ARRAY_SIZE(rc2str)) {
+		return "unknown";
+	}
+
+	return rc2str[rc];
+}
+
+int lbm_txdone2errno(smtc_modem_event_txdone_status_t status, bool confirmed)
+{
+	if (status == SMTC_MODEM_EVENT_TXDONE_NOT_SENT) {
+		return -EIO;
+	}
+
+	/* A confirmed uplink is only done once the network has acknowledged it. */
+	if (confirmed && status != SMTC_MODEM_EVENT_TXDONE_CONFIRMED) {
+		return -EAGAIN;
+	}
+
+	return 0;
+}
+
+const char *lbm_txdone2str(smtc_modem_event_txdone_status_t status)
+{
+	if (status >= ARRAY_SIZE(txdone2str)) {
+		return "unknown";
+	}
+
+	return txdone2str[status];
+}

--- a/subsys/lorawan/lora-basics-modem/lbm_priv.h
+++ b/subsys/lorawan/lora-basics-modem/lbm_priv.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_LORAWAN_LORA_BASICS_MODEM_LBM_PRIV_H_
+#define ZEPHYR_SUBSYS_LORAWAN_LORA_BASICS_MODEM_LBM_PRIV_H_
+
+#include <smtc_modem_api.h>
+
+int lbm_rc2errno(smtc_modem_return_code_t rc);
+const char *lbm_rc2str(smtc_modem_return_code_t rc);
+
+int lbm_txdone2errno(smtc_modem_event_txdone_status_t status, bool confirmed);
+const char *lbm_txdone2str(smtc_modem_event_txdone_status_t status);
+
+#endif /* ZEPHYR_SUBSYS_LORAWAN_LORA_BASICS_MODEM_LBM_PRIV_H_ */

--- a/subsys/lorawan/lora-basics-modem/lorawan.c
+++ b/subsys/lorawan/lora-basics-modem/lorawan.c
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/lorawan/lorawan.h>
+#include <zephyr/sys/atomic.h>
+
+#include <smtc_modem_api.h>
+#include <smtc_modem_hal_ext.h>
+
+#include "lbm_lorawan.h"
+#include "lbm_priv.h"
+
+LOG_MODULE_DECLARE(lorawan_lbm, CONFIG_LORAWAN_LOG_LEVEL);
+
+#define JOIN_TIMEOUT K_SECONDS(CONFIG_LORAWAN_LBM_JOIN_TIMEOUT_S)
+#define TX_TIMEOUT   K_SECONDS(CONFIG_LORAWAN_LBM_TX_TIMEOUT_S)
+
+enum {
+	FLAG_STARTED,
+	FLAG_JOINED,
+};
+
+static struct {
+	struct k_mutex api_lock;
+	struct k_sem reset_evt;
+	struct k_sem join_evt;
+	struct k_sem tx_evt;
+	atomic_t flags;
+	smtc_modem_event_txdone_status_t tx_status;
+	enum lorawan_region region;
+	bool region_set;
+	struct lorawan_downlink_cb *dl_cb;
+	lorawan_dr_changed_cb_t dr_cb;
+	lorawan_link_check_ans_cb_t link_check_cb;
+	lorawan_battery_level_cb_t battery_cb;
+} lbm = {
+	.api_lock = Z_MUTEX_INITIALIZER(lbm.api_lock),
+	.reset_evt = Z_SEM_INITIALIZER(lbm.reset_evt, 0, 1),
+	.join_evt = Z_SEM_INITIALIZER(lbm.join_evt, 0, 1),
+	.tx_evt = Z_SEM_INITIALIZER(lbm.tx_evt, 0, 1),
+};
+
+static const struct {
+	bool enabled;
+	enum lorawan_region id;
+} region_table[] = {
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_AS923), LORAWAN_REGION_AS923},
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_AU915), LORAWAN_REGION_AU915},
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_CN470), LORAWAN_REGION_CN470},
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_EU868), LORAWAN_REGION_EU868},
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_IN865), LORAWAN_REGION_IN865},
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_KR920), LORAWAN_REGION_KR920},
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_US915), LORAWAN_REGION_US915},
+	{IS_ENABLED(CONFIG_LORAWAN_REGION_RU864), LORAWAN_REGION_RU864},
+};
+
+static int region_to_lbm(enum lorawan_region region, smtc_modem_region_t *out)
+{
+	switch (region) {
+	case LORAWAN_REGION_AS923:
+		*out = SMTC_MODEM_REGION_AS_923_GRP1;
+		break;
+	case LORAWAN_REGION_AU915:
+		*out = SMTC_MODEM_REGION_AU_915;
+		break;
+	case LORAWAN_REGION_CN470:
+		*out = SMTC_MODEM_REGION_CN_470;
+		break;
+	case LORAWAN_REGION_EU868:
+		*out = SMTC_MODEM_REGION_EU_868;
+		break;
+	case LORAWAN_REGION_KR920:
+		*out = SMTC_MODEM_REGION_KR_920;
+		break;
+	case LORAWAN_REGION_IN865:
+		*out = SMTC_MODEM_REGION_IN_865;
+		break;
+	case LORAWAN_REGION_US915:
+		*out = SMTC_MODEM_REGION_US_915;
+		break;
+	case LORAWAN_REGION_RU864:
+		*out = SMTC_MODEM_REGION_RU_864;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static void handle_downlink(void)
+{
+	uint8_t payload[SMTC_MODEM_MAX_LORAWAN_PAYLOAD_LENGTH];
+	smtc_modem_dl_metadata_t meta;
+	uint8_t len;
+	uint8_t remaining;
+
+	if (smtc_modem_get_downlink_data(payload, &len, &meta, &remaining) != SMTC_MODEM_RC_OK) {
+		return;
+	}
+
+	if (lbm.dl_cb == NULL) {
+		return;
+	}
+
+	if (lbm.dl_cb->port != LW_RECV_PORT_ANY && lbm.dl_cb->port != meta.fport) {
+		return;
+	}
+
+	lbm.dl_cb->cb(meta.fport, meta.fpending_bit ? LORAWAN_DATA_PENDING : 0, meta.rssi - 64,
+		      meta.snr / 4, len, payload);
+}
+
+static void handle_link_check(const smtc_modem_event_t *event)
+{
+	uint8_t margin;
+	uint8_t gw_cnt;
+
+	if (event->event_data.link_check.status == SMTC_MODEM_EVENT_MAC_REQUEST_NOT_ANSWERED) {
+		LOG_DBG("link check not answered");
+		return;
+	}
+
+	if (lbm.link_check_cb == NULL) {
+		return;
+	}
+
+	if (smtc_modem_get_lorawan_link_check_data(LBM_STACK_ID, &margin, &gw_cnt) !=
+	    SMTC_MODEM_RC_OK) {
+		return;
+	}
+
+	lbm.link_check_cb(margin, gw_cnt);
+}
+
+void lbm_lorawan_event(const smtc_modem_event_t *event)
+{
+	LOG_DBG("event %u", event->event_type);
+
+	switch (event->event_type) {
+	case SMTC_MODEM_EVENT_RESET:
+		k_sem_give(&lbm.reset_evt);
+		break;
+	case SMTC_MODEM_EVENT_JOINED:
+		atomic_set_bit(&lbm.flags, FLAG_JOINED);
+		k_sem_give(&lbm.join_evt);
+		break;
+	case SMTC_MODEM_EVENT_JOINFAIL:
+		/* The modem keeps retrying, so let the caller keep waiting. */
+		LOG_DBG("join attempt failed");
+		break;
+	case SMTC_MODEM_EVENT_TXDONE:
+		lbm.tx_status = event->event_data.txdone.status;
+		k_sem_give(&lbm.tx_evt);
+		break;
+	case SMTC_MODEM_EVENT_DOWNDATA:
+		handle_downlink();
+		break;
+	case SMTC_MODEM_EVENT_LINK_CHECK:
+		handle_link_check(event);
+		break;
+	default:
+		LOG_DBG("unhandled event %u", event->event_type);
+		break;
+	}
+}
+
+static int lbm_lorawan_init(void)
+{
+	size_t count = 0;
+	enum lorawan_region single = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(region_table); i++) {
+		if (region_table[i].enabled) {
+			single = region_table[i].id;
+			count++;
+		}
+	}
+
+	if (count == 1) {
+		lbm.region = single;
+		lbm.region_set = true;
+	}
+
+	return 0;
+}
+SYS_INIT(lbm_lorawan_init, POST_KERNEL, 0);
+
+int lorawan_start(void)
+{
+	smtc_modem_region_t lbm_region;
+	smtc_modem_return_code_t rc;
+	int ret;
+
+	if (atomic_test_and_set_bit(&lbm.flags, FLAG_STARTED)) {
+		return -EALREADY;
+	}
+
+	if (!lbm.region_set) {
+		ret = -EINVAL;
+		LOG_ERR("no region set, call lorawan_set_region() first");
+		goto fail;
+	}
+
+	ret = region_to_lbm(lbm.region, &lbm_region);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	/* The engine thread reports RESET once the modem core is up. */
+	if (k_sem_take(&lbm.reset_evt, K_SECONDS(CONFIG_LORAWAN_LBM_START_TIMEOUT_S)) < 0) {
+		ret = -ETIMEDOUT;
+		LOG_ERR("modem did not come up");
+		goto fail;
+	}
+
+	rc = smtc_modem_set_region(LBM_STACK_ID, lbm_region);
+	if (rc != SMTC_MODEM_RC_OK) {
+		ret = lbm_rc2errno(rc);
+		LOG_ERR("set_region failed: %d", rc);
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	atomic_clear_bit(&lbm.flags, FLAG_STARTED);
+	return ret;
+}
+
+int lorawan_set_region(enum lorawan_region region)
+{
+	smtc_modem_region_t unused;
+	int ret;
+
+	if (atomic_test_bit(&lbm.flags, FLAG_STARTED)) {
+		return -EPERM;
+	}
+
+	ret = region_to_lbm(region, &unused);
+	if (ret < 0) {
+		return ret;
+	}
+
+	lbm.region = region;
+	lbm.region_set = true;
+
+	return 0;
+}
+
+int lorawan_join(const struct lorawan_join_config *config)
+{
+	smtc_modem_return_code_t rc;
+	int ret;
+
+	if (config == NULL) {
+		return -EINVAL;
+	}
+
+	if (!atomic_test_bit(&lbm.flags, FLAG_STARTED)) {
+		return -EPERM;
+	}
+
+	if (config->mode != LORAWAN_ACT_OTAA) {
+		LOG_ERR("only OTAA is supported");
+		return -ENOTSUP;
+	}
+
+	if (config->dev_eui == NULL || config->otaa.join_eui == NULL ||
+	    config->otaa.nwk_key == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&lbm.api_lock, K_FOREVER);
+
+	rc = smtc_modem_set_deveui(LBM_STACK_ID, config->dev_eui);
+	if (rc == SMTC_MODEM_RC_OK) {
+		rc = smtc_modem_set_joineui(LBM_STACK_ID, config->otaa.join_eui);
+	}
+	if (rc == SMTC_MODEM_RC_OK) {
+		rc = smtc_modem_set_nwkkey(LBM_STACK_ID, config->otaa.nwk_key);
+	}
+	if (rc != SMTC_MODEM_RC_OK) {
+		ret = lbm_rc2errno(rc);
+		LOG_ERR("credentials rejected: %s", lbm_rc2str(rc));
+		goto out;
+	}
+
+	atomic_clear_bit(&lbm.flags, FLAG_JOINED);
+	k_sem_reset(&lbm.join_evt);
+
+	rc = smtc_modem_join_network(LBM_STACK_ID);
+	if (rc != SMTC_MODEM_RC_OK) {
+		ret = lbm_rc2errno(rc);
+		LOG_ERR("join_network failed: %s", lbm_rc2str(rc));
+		goto out;
+	}
+
+	lbm_engine_notify();
+
+	if (k_sem_take(&lbm.join_evt, JOIN_TIMEOUT) < 0) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
+
+out:
+	k_mutex_unlock(&lbm.api_lock);
+	return ret;
+}
+
+int lorawan_send(uint8_t port, uint8_t *data, uint8_t len, enum lorawan_message_type type)
+{
+	smtc_modem_return_code_t rc;
+	int ret;
+
+	if (data == NULL && len > 0) {
+		return -EINVAL;
+	}
+
+	if (!atomic_test_bit(&lbm.flags, FLAG_JOINED)) {
+		return -EPERM;
+	}
+
+	k_mutex_lock(&lbm.api_lock, K_FOREVER);
+
+	k_sem_reset(&lbm.tx_evt);
+
+	rc = smtc_modem_request_uplink(LBM_STACK_ID, port, type == LORAWAN_MSG_CONFIRMED, data,
+				       len);
+	if (rc != SMTC_MODEM_RC_OK) {
+		ret = lbm_rc2errno(rc);
+		goto out;
+	}
+
+	lbm_engine_notify();
+
+	if (k_sem_take(&lbm.tx_evt, TX_TIMEOUT) < 0) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
+
+	ret = lbm_txdone2errno(lbm.tx_status, type == LORAWAN_MSG_CONFIRMED);
+	if (ret < 0) {
+		LOG_WRN("uplink %s", lbm_txdone2str(lbm.tx_status));
+	}
+
+out:
+	k_mutex_unlock(&lbm.api_lock);
+	return ret;
+}
+
+int lorawan_set_class(enum lorawan_class dev_class)
+{
+	if (dev_class != LORAWAN_CLASS_A) {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+void lorawan_enable_adr(bool enable)
+{
+	ARG_UNUSED(enable);
+}
+
+int lorawan_set_datarate(enum lorawan_datarate dr)
+{
+	ARG_UNUSED(dr);
+
+	return -ENOSYS;
+}
+
+enum lorawan_datarate lorawan_get_min_datarate(void)
+{
+	uint16_t datarates = 0;
+
+	if (smtc_modem_get_enabled_datarates(LBM_STACK_ID, &datarates) != SMTC_MODEM_RC_OK ||
+	    datarates == 0) {
+		return LORAWAN_DR_0;
+	}
+
+	/* The mask carries one bit per datarate, so the lowest one set is the slowest. */
+	return (enum lorawan_datarate)(find_lsb_set(datarates) - 1);
+}
+
+void lorawan_get_payload_sizes(uint8_t *max_next_payload_size, uint8_t *max_payload_size)
+{
+	uint8_t tx_max_payload = 0;
+
+	(void)smtc_modem_get_next_tx_max_payload(LBM_STACK_ID, &tx_max_payload);
+
+	*max_next_payload_size = tx_max_payload;
+	*max_payload_size = tx_max_payload;
+}
+
+int lorawan_set_conf_msg_tries(uint8_t tries)
+{
+	ARG_UNUSED(tries);
+
+	return -ENOSYS;
+}
+
+int lorawan_set_channels_mask(uint16_t *channels_mask, size_t channels_mask_size)
+{
+	ARG_UNUSED(channels_mask);
+	ARG_UNUSED(channels_mask_size);
+
+	return -ENOSYS;
+}
+
+uint8_t lbm_battery_level(void)
+{
+	if (lbm.battery_cb == NULL) {
+		return 255;
+	}
+
+	return lbm.battery_cb();
+}
+
+void lorawan_register_battery_level_callback(lorawan_battery_level_cb_t cb)
+{
+	lbm.battery_cb = cb;
+}
+
+void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb)
+{
+	lbm.dl_cb = cb;
+}
+
+void lorawan_register_dr_changed_callback(lorawan_dr_changed_cb_t cb)
+{
+	lbm.dr_cb = cb;
+}
+
+void lorawan_register_link_check_ans_callback(lorawan_link_check_ans_cb_t cb)
+{
+	lbm.link_check_cb = cb;
+}
+
+int lorawan_request_device_time(bool force_request)
+{
+	ARG_UNUSED(force_request);
+
+	return -ENOSYS;
+}
+
+int lorawan_device_time_get(uint32_t *gps_time)
+{
+	ARG_UNUSED(gps_time);
+
+	return -ENOSYS;
+}
+
+int lorawan_request_link_check(bool force_request)
+{
+	smtc_modem_return_code_t rc;
+	int ret = 0;
+
+	if (!atomic_test_bit(&lbm.flags, FLAG_JOINED)) {
+		return -EPERM;
+	}
+
+	k_mutex_lock(&lbm.api_lock, K_FOREVER);
+
+	rc = smtc_modem_trig_lorawan_mac_request(LBM_STACK_ID,
+						 SMTC_MODEM_LORAWAN_MAC_REQ_LINK_CHECK);
+	if (rc != SMTC_MODEM_RC_OK) {
+		ret = lbm_rc2errno(rc);
+		goto out;
+	}
+
+	/* Without an uplink to carry it the request waits for the next one. */
+	if (force_request) {
+		rc = smtc_modem_request_empty_uplink(LBM_STACK_ID, false, 0, false);
+		if (rc != SMTC_MODEM_RC_OK) {
+			ret = lbm_rc2errno(rc);
+			goto out;
+		}
+	}
+
+	lbm_engine_notify();
+
+out:
+	k_mutex_unlock(&lbm.api_lock);
+	return ret;
+}


### PR DESCRIPTION
A LoRaWAN backend on top of the LoRa Basics Modem (LBM), alongside loramac-node and the native stack.

Continues #102817, which @carlocaione opened and the stale bot closed. The module, the HAL, the SX126x driver and the porting tests it built on are already upstream; the LoRaWAN backend was the missing piece. This is an independent implementation, not a rebase of that branch. @carlocaione, if you would rather continue your own branch, say so and I will close this.

loramac-node is the long-standing one, the native stack covers EU868 with the other regions gated off in Kconfig, and LBM is Semtech's own, carrying the eight regions listed below. This is meant as an option for the regions the native stack has not reached yet, not as a replacement for it.

An engine thread owns the stack. It runs `smtc_modem_run_engine()`, waits for as long as the engine asks but no longer than `CONFIG_LORAWAN_LBM_ENGINE_MAX_SLEEP_MS`, and wakes early on a modem interrupt or when an API call queues work. The bound is needed because the engine can name a wait of days and rely on an interrupt to cut it short. The wake is a semaphore, so an interrupt arriving before the thread sleeps is not lost.

Modem return codes and transmit outcomes become errno values in `lbm_priv.c`, kept apart so an application can replace the file, as loramac-node allows with `lw_priv.c`.

No driver option is selected from the subsystem. `LORA_BASICS_MODEM_HAL` and `LORA_BASICS_MODEM_CORE` turn themselves on from their own dependencies; `LORAWAN_LBM` depends on the core.

## API

| API | Notes |
| --- | --- |
| `lorawan_start()` | |
| `lorawan_join()` | OTAA only, ABP is `-ENOTSUP` |
| `lorawan_send()` | confirmed and unconfirmed |
| `lorawan_set_class()` | Class A, anything else is `-ENOTSUP` |
| `lorawan_set_region()` | |
| `lorawan_get_min_datarate()` | lowest bit of the modem's enabled datarate mask |
| `lorawan_get_payload_sizes()` | |
| `lorawan_request_link_check()` | `force_request` sends an empty uplink to carry it |
| `lorawan_register_downlink_callback()` | |
| `lorawan_register_dr_changed_callback()` | |
| `lorawan_register_link_check_ans_callback()` | not called when the request goes unanswered |
| `lorawan_register_battery_level_callback()` | reaches DevStatusAns through a weak hook in the HAL |
| `lorawan_enable_adr()` | accepted and ignored, the modem runs ADR itself |
| `lorawan_set_datarate()` | `-ENOSYS`, the modem owns it |
| `lorawan_set_conf_msg_tries()` | `-ENOSYS`, the modem owns it |
| `lorawan_set_channels_mask()` | `-ENOSYS`, the modem owns it |
| `lorawan_request_device_time()` | `-ENOSYS`, needs DeviceTimeReq handling |
| `lorawan_device_time_get()` | `-ENOSYS`, needs DeviceTimeReq handling |

## Features

| Feature | State |
| --- | --- |
| Class A | verified |
| Class B, Class C | not supported |
| OTAA | verified |
| Confirmed uplink | verified, `-EAGAIN` when unacknowledged |
| Unconfirmed uplink | verified |
| Downlink with payload | verified |
| ADR | verified |
| Link check | verified |
| Modem context in NVS | verified across a reboot |
| Minimum datarate | verified against a region with an uplink dwell time |
| Regions | AS923, AU915, CN470, EU868, IN865, KR920, US915, RU864 |
| CN779, EU433 | the modem has no such region |

## Notes

`lorawan_join()` returns `-ETIMEDOUT` and nothing else. `SMTC_MODEM_EVENT_JOINFAIL` is per attempt and the modem keeps retrying with no terminal event, so the backend waits for `SMTC_MODEM_EVENT_JOINED` or for `CONFIG_LORAWAN_LBM_JOIN_TIMEOUT_S`. Mapping one failed attempt to an error would end the join while the modem is still working on it.

`CONFIG_LORA_BASICS_MODEM_NVM` is not `CONFIG_LORAWAN_NVM`. The latter is a loramac-node choice and resolves to `LORAWAN_NVM_NONE` here. The modem asks its HAL for byte-range store and restore of four contexts, one of which is the secure element, so the existing three-function interface does not fit. Unifying them means reshaping `lorawan_nvm.h` for both stacks, which belongs in its own series.

## Hardware test

RAK4631 with a RAK WisGate Edge Lite 2 running its builtin LNS, KR920.

```
west build -b rak4631/nrf52840 samples/subsys/lorawan/class_a -- \
  -DCONFIG_LORAWAN_REGION_KR920=y \
  -DCONFIG_LORA_MODULE_BACKEND_LORA_BASICS_MODEM=y \
  -DCONFIG_FLASH=y -DCONFIG_FLASH_MAP=y -DCONFIG_NVS=y \
  -DCONFIG_SETTINGS=y -DCONFIG_SETTINGS_NVS=y \
  -DCONFIG_MPU_ALLOW_FLASH_WRITE=y
```

<details>
<summary>Join, uplink, downlink and link check, one boot</summary>

One run over RTT, as captured, with the terminal control characters removed.

```
*** Booting Zephyr OS build v4.4.0-13616-g5b195174b008 ***
[00:00:00.255,493] <inf> fs_nvs: 8 Sectors of 4096 bytes
[00:00:00.255,493] <inf> fs_nvs: alloc wra: 0, f20
[00:00:00.255,523] <inf> fs_nvs: data wra: 0, 294
INFO: Modem Initialization
INFO: Use soft secure element for cryptographic functionalities
stack_id 0
 DevNonce = 5
 JoinNonce = 0xad 73 9b, NetID = 0x01 00 00
 Region = KR_920
LoRaWAN Certification is disabled on stack 0
[00:00:00.301,971] <inf> lorawan_class_a: Joining network over OTAA
INFO: smtc_modem_join_network
 Start a new join sequence now on stack 0
DevEUI - (8 bytes):
 DD EE AA DD BB EE EE FF
JoinEUI - (8 bytes):
 00 00 00 00 00 00 00 00
DevNonce 0x6, stack_id 0

  *************************************
  * Send Payload  for stack_id = 0
  *************************************
  Tx  LoRa at 2827 ms: freq:922500000, SF9, BW125, len 23 bytes 12 dBm, fcnt_up 0, toa = 206

  *************************************
  *  TX DONE
  *************************************

  Open Rx1 for Hook Id = 1  RX1 LoRa at 8054 ms: freq:922500000, SF9, BW125, sync word = 0x34
  Timer will expire in 5001 ms

  *************************************
  * Receive a Valid downlink Rx1 for stack_id = 0, rssi: -35 dBm, snr: 10 dB
  *************************************
 update join procedure
MacTxFrequency [0] = 922700000 
MacDataRateChannel [0] =  1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0
MacChannelIndexEnabled [0] = 1 
MacTxFrequency [1] = 922900000 
MacDataRateChannel [1] =  1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0
MacChannelIndexEnabled [1] = 1 
MacTxFrequency [2] = 923100000 
MacDataRateChannel [2] =  1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0
MacChannelIndexEnabled [2] = 1 
MacTxFrequency [3] = 923300000 
MacDataRateChannel [3] =  1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0
MacChannelIndexEnabled [3] = 1 
WARN: INVALID TX FREQUENCY IN CFLIST OR CFLIST EMPTY 
 DevAddr= 225e3fb
 MacRx1DataRateOffset= 0
 MacRx2DataRate= 0
 MacRx1Delay= 1
[00:00:08.306,304] <inf> lorawan_class_a: Sending data...
cid_request_mask:0x1
INFO: add send task
TPM Launch TX_PROTOCOL_TRANSMIT_CID current_tpm_data_len = 1 data = 2 , 0 

  *************************************
  * Send Payload  for stack_id = 0
  *************************************
  Tx  LoRa at 13305 ms: freq:922100000, SF9, BW125, len 14 bytes 12 dBm, fcnt_up 1, toa = 165

  *************************************
  *  TX DONE
  *************************************

  Open Rx1 for Hook Id = 1  RX1 LoRa at 14491 ms: freq:922100000, SF9, BW125, sync word = 0x34
  Timer will expire in 1002 ms

  *************************************
  * Receive a Valid downlink Rx1 for stack_id = 0, rssi: -33 dBm, snr: 10 dB
  *************************************
 Margin = 25, GwCnt = 1
[00:00:14.658,203] <inf> lorawan_class_a: Link check: margin 25 dB, 1 gateway(s)
 User LoRaWAN tx on FPort 2 

  *************************************
  * Send Payload  for stack_id = 0
  *************************************
  Tx  LoRa at 15715 ms: freq:923100000, SF9, BW125, len 23 bytes 12 dBm, fcnt_up 2, toa = 206
```

</details>

<details>
<summary>The same uplink at the gateway</summary>

```json
{
  "type": "Uplink",
  "payload": {
    "devEUI": "ddeeaaddbbeeeeff",
    "fCnt": 2,
    "fPort": 2,
    "data": "aGVsbG93b3JsZA==",
    "data_encode": "base64",
    "adr": true,
    "rxInfo": [ { "gatewayID": "ac1f09fffe09195d", "loRaSNR": 10.2, "rssi": -39 } ]
  }
}
```

</details>

<details>
<summary>Modem context across a reboot</summary>

Two boots. Before the first join:

```
 DevNonce = 0
 JoinNonce = 0xff ff ff, NetID = 0xff ff ff
```

After a join and a reboot:

```
 DevNonce = 2
 JoinNonce = 0x83 0e 97, NetID = 0x01 00 00
```

</details>

<details>
<summary>Minimum datarate, KR920 against AS923</summary>

`lorawan_get_min_datarate()` has no caller in tree, so the sample was given a temporary line printing it after `lorawan_start()`. AS923 carries an uplink dwell time, KR920 does not. Two builds:

```
 Region = KR_920
[00:00:00.476,593] <inf> lorawan_class_a: DBG min datarate = DR_0
```

```
 Region = AS923_GRP1
[00:00:00.457,611] <inf> lorawan_class_a: DBG min datarate = DR_2
```

</details>

Currently the SX126x family only. `LORA_BASICS_MODEM_HAL` has no SX127x support and the module carries no LR11xx driver.
