### PR TITLE
boards: shields: nxp_arduino_aw510_wifi_bt update BT control gpio

### DIFF
--- a/boards/shields/nxp_arduino_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/nxp_arduino_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -22,7 +22,7 @@
 		m2_bt_module: m2_bt_module {
 			compatible = "nxp,bt-hci-uart";
 			sdio-reset-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
-			w-disable-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+			w-disable-gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };


### PR DESCRIPTION
### Motivation

- The Azurwave M2 module's W-DISABLE line is physically connected to `GPIO1[21]` on the FRDM-MCXN947 board.
- With this GPIO mapped, the BT controller no longer requires an explicit hard reset at startup. The existing FW loader code handles the full reset sequence via W-DISABLE toggling

### Testing

- Verified BT initialization on `frdm_mcxn947/mcxn947/cpu0` with `nxp_arduino_aw510_wifi_bt` shield.
- BT controller powers up and firmware loads successfully without requiring a hard reset.
- Tested peripheral_hr sample which worked good with no external reset

### Notes

- This change only affects `frdm_mcxn947` with the Azurwave M2 module variant.
