### PR TITLE
tests bsim BT ll multiple_id & throughput

### DIFF
--- a/tests/bsim/bluetooth/ll/multiple_id/prj.conf
+++ b/tests/bsim/bluetooth/ll/multiple_id/prj.conf
@@ -77,3 +77,8 @@ CONFIG_BT_SMP_ALLOW_UNAUTH_OVERWRITE=y
 # the logs.
 CONFIG_BOOT_BANNER=n
 CONFIG_PRINTK=n
+
+# Enable optimizations, this test is very long, enabling optimizations will speed it up
+# considerably. If somebody wants to debug an issue locally, and this optimization level challenges
+# it, they can always set NO_OPTIMIZATIONS
+CONFIG_DEBUG_OPTIMIZATIONS=y

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
@@ -18,6 +18,6 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_multiple_id_prj_conf -RealEncry
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -rs=7
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=2410e6 $@ -argschannel -at=40
+  -D=2 -sim_length=2410e6 -nodump $@ -argschannel -at=40
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="${BOARD_TS}_multiple"
 verbosity_level=2
-EXECUTE_TIMEOUT=1600
+EXECUTE_TIMEOUT=3600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
@@ -27,6 +27,6 @@ done
 let device_count=$central_count+1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=$device_count -sim_length=1800e6 $@ -argschannel -at=40
+  -D=$device_count -sim_length=1800e6 -nodump $@ -argschannel -at=40
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="${BOARD_TS}_central_single_peripheral_multilink"
 verbosity_level=2
-EXECUTE_TIMEOUT=1600
+EXECUTE_TIMEOUT=3600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="${BOARD_TS}_central_multiple_peripheral_single"
 verbosity_level=2
-EXECUTE_TIMEOUT=1600
+EXECUTE_TIMEOUT=3600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
@@ -27,6 +27,6 @@ done
 let device_count=$peripheral_count+1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=$device_count -sim_length=1800e6 $@ -argschannel -at=40
+  -D=$device_count -sim_length=1800e6 -nodump $@ -argschannel -at=40
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/throughput/prj.conf
+++ b/tests/bsim/bluetooth/ll/throughput/prj.conf
@@ -50,3 +50,8 @@ CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 CONFIG_BT_CTLR_PHY_CODED=y
 
 CONFIG_LOG=y
+
+# Enable optimizations, this test is very long, enabling optimizations will speed it up
+# considerably. If somebody wants to debug an issue locally, and this optimization level challenges
+# it, they can always set NO_OPTIMIZATIONS
+CONFIG_DEBUG_OPTIMIZATIONS=y

--- a/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write_no_phy_update.sh
+++ b/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write_no_phy_update.sh
@@ -19,6 +19,6 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_throughput_prj_conf_overlay-no_
   -testid=peripheral
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=1500e6 $@ -argschannel -at=40
+  -D=2 -sim_length=1500e6 -nodump $@ -argschannel -at=40
 
 wait_for_background_jobs


### PR DESCRIPTION
3 related changes:

1. Do not dump to disk the radio activity traces, nobody looks at them in CI for these tests, and for this very long tests, that is ~2GiB of data. This speeds up the test.

2. Enable debug optimizations, these test are very long, enabling optimizations will speed them up considerably.
If somebody wants to debug an issue locally, DEBUG_OPTIMIZATIONS should not be a problem.

3. In some CI runners these tests take longer than expected, and they are killed while they are executing. Let's increase their timeout to avoid them getting killed (and failing) midway.

Due to 1. & 2. I see an speed up of around 10% in my own machine. In machines which may be more I/O limited this may significantly more.

----

For comparison [this PR run ](https://productionresultssa8.blob.core.windows.net/actions-results/6f1ebb54-a272-4fdc-b578-86def3fafe12/workflow-job-run-a6a355e8-b8e0-5ade-93af-af4e188b918c/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-08-31T11%3A35%3A16Z&sig=eVZ%2F9YhiDPJdhi9aVP5ECaGDGkzeB%2FJqpUbLMIe7oGQ%3D&ske=2026-08-31T12%3A44%3A48Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-08-31T08%3A44%3A48Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-08-31T11%3A25%3A11Z&sv=2025-11-05)vs one of the [last which run in CI](https://productionresultssa14.blob.core.windows.net/actions-results/45708c8b-d852-4d2c-a010-f8657dc48174/workflow-job-run-177673c8-5faa-5d5c-a76d-667b71883118/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-08-31T11%3A32%3A01Z&sig=LWHq8txBR1ws0J9dmXzV8VUUiukqd2jNTTMGBI%2FSyV0%3D&ske=2026-08-31T12%3A43%3A45Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-08-31T08%3A43%3A45Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-08-31T11%3A21%3A56Z&sv=2025-11-05):

* nrf52_bsim/native         tests.bsim.bluetooth.ll.throughput_no_phy_update: 106.308s vs 134.620s
* nrf52_bsim/native         tests.bsim.bluetooth.ll.multiple_id         174.678s vs 192.002s
(For other boards the gain is comparable)
