### PR TITLE
drivers: wifi: esp_hosted: add firmware get_version support

### DIFF
--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(esp_hosted, CONFIG_WIFI_LOG_LEVEL);
 #include <esp_hosted_wifi.h>
 #include <esp_hosted_hal.h>
 #include <esp_hosted_util.h>
+#include <zephyr/version.h>
 
 static struct k_thread esp_hosted_event_thread;
 K_THREAD_STACK_DEFINE(esp_hosted_event_stack, CONFIG_WIFI_ESP_HOSTED_EVENT_TASK_STACK_SIZE);
@@ -648,8 +649,10 @@ static int esp_hosted_dev_init(const struct device *dev)
 		data->fw_version.rev_patch2 = fw->rev_patch2;
 	}
 
-	LOG_INF("firmware version: v%u.%u.%u.%u.%u", fw->major1, fw->major2, fw->minor,
-		fw->rev_patch1, fw->rev_patch2);
+	snprintk(data->fw_version.str, sizeof(data->fw_version.str), "%u.%u.%u.%u.%u",
+		 data->fw_version.major1, data->fw_version.major2, data->fw_version.minor,
+		 data->fw_version.rev_patch1, data->fw_version.rev_patch2);
+	LOG_INF("firmware version: v%s", data->fw_version.str);
 
 	/* Set MAC addresses. */
 	for (size_t i = 0; i < 2; i++) {
@@ -663,6 +666,21 @@ static int esp_hosted_dev_init(const struct device *dev)
 	return 0;
 }
 
+static int esp_hosted_get_version(const struct device *dev, struct net_if *iface __unused,
+				  struct wifi_version *params)
+{
+	esp_hosted_data_t *data = dev->data;
+
+	if (params == NULL) {
+		return -EINVAL;
+	}
+
+	params->drv_version = KERNEL_VERSION_STRING;
+	params->fw_version = data->fw_version.str[0] != '\0' ? data->fw_version.str : "unknown";
+
+	return 0;
+}
+
 static const struct wifi_mgmt_ops esp_hosted_mgmt = {
 	.scan = esp_hosted_scan,
 	.connect = esp_hosted_connect,
@@ -673,6 +691,7 @@ static const struct wifi_mgmt_ops esp_hosted_mgmt = {
 	.get_stats = esp_hosted_stats,
 #endif
 	.iface_status = esp_hosted_status,
+	.get_version = esp_hosted_get_version,
 };
 
 static const struct net_wifi_mgmt_offload esp_hosted_api = {

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.h
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.h
@@ -119,6 +119,7 @@ typedef struct {
 		uint32_t minor;
 		uint32_t rev_patch1;
 		uint32_t rev_patch2;
+		char str[32];
 	} fw_version;
 
 	/* RX reassembly accumulator. */


### PR DESCRIPTION
Add `get_version` support to the ESP-Hosted Wi-Fi management API. 

The ESP-Hosted driver already requests and stores its firmware version during
initialization. Cache the formatted version string in the per-device driver state so version
queries through `NET_REQUEST_WIFI_VERSION` can return the same string.


