### PR TITLE
linker: KEEP C++ exception tables and personality routine

### DIFF
--- a/include/zephyr/arch/x86/intel64/linker.ld
+++ b/include/zephyr/arch/x86/intel64/linker.ld
@@ -93,6 +93,7 @@ SECTIONS
 	__text_region_start = .;
 	z_mapped_start = .;
 	*(.text)
+	KEEP (*(.text*personality*))
 	*(.text.*)
 
 	#include <snippets-text-sections.ld>

--- a/include/zephyr/linker/cplusplus-ram.ld
+++ b/include/zephyr/linker/cplusplus-ram.ld
@@ -7,7 +7,7 @@
 #if defined (CONFIG_CPP)
 	SECTION_DATA_PROLOGUE(.gcc_except_table,,ONLY_IF_RW)
 	{
-	*(.gcc_except_table .gcc_except_table.*)
+	KEEP (*(.gcc_except_table .gcc_except_table.*))
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #if defined (CONFIG_CPP_EXCEPTIONS)

--- a/include/zephyr/linker/cplusplus-rom.ld
+++ b/include/zephyr/linker/cplusplus-rom.ld
@@ -7,7 +7,7 @@
 #if defined (CONFIG_CPP)
 	SECTION_PROLOGUE(.gcc_except_table,,ONLY_IF_RO)
 	{
-	*(.gcc_except_table .gcc_except_table.*)
+	KEEP (*(.gcc_except_table .gcc_except_table.*))
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #if defined (CONFIG_CPP_EXCEPTIONS)


### PR DESCRIPTION
Zephyr links with `--gc-sections`, so a section survives only if something references it or the linker script explicitly keeps it. 
`.gcc_except_table` and the C++ personality routine are referenced only from `.eh_frame`, which is not a garbage collection root: every function has an FDE there, so treating it as one would keep the entire image. Neither section is `KEEP`'d in the linker script either, which leaves their retention unspecified.
When they are collected, `.eh_frame` still points at them, the link succeeds without a warning, and the failure only appears at runtime on the first throw. 
This surfaced running the test suite on `qemu_x86_64` with ELD, where `cpp.libcxx.glibcxx.picolibc` faults when it throws. 

`.eh_frame` is already `KEEP`'d in these fragments for the same reason. This extends that to the two sections it points at: 
- `cplusplus-{rom,ram}.ld`: `.gcc_except_table`
- `arch/x86/intel64/linker.ld`: the personality routine

`cpp.libcxx.glibcxx.picolibc` on `qemu_x86_64`, 5/5 test cases passing with this change under both ELD and the default Zephyr SDK GNU ld toolchain.

This explicit retention is also consistent with existing Zephyr linker scripts. Several SoC linker scripts already use `KEEP(*(.gcc_except_table .gcc_except_table.*))`, including those for AMD ACP, Intel ADSP, NXP ADSP, and Xtensa targets. 
The NXP i.MX RT7xx HiFi1 linker script similarly retains personality sections explicitly.