### PR TITLE
Bluetooth: Controller: Fix compiler error in use of PHY flags

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -691,6 +691,7 @@ Bluetooth Controller:
     - doc/services/connectivity/bluetooth/img/ctlr*
     - doc/services/connectivity/bluetooth/api/controller.rst
     - include/zephyr/bluetooth/controller.h
+    - samples/bluetooth/hci_*/
     - subsys/bluetooth/common/
     - subsys/bluetooth/controller/
     - subsys/bluetooth/crypto/
@@ -700,9 +701,17 @@ Bluetooth Controller:
     - "area: Bluetooth Controller"
     - "area: Bluetooth"
   tests:
-    - bluetooth.controller
     - bluetooth
+    - bluetooth.controller
     - bluetooth.ll
+    - sample.bluetooth.hci_ipc
+    - sample.bluetooth.hci_pwr_ctrl
+    - sample.bluetooth.hci_spi
+    - sample.bluetooth.hci_uart
+    - sample.bluetooth.hci_uart_3wire
+    - sample.bluetooth.hci_uart_async
+    - sample.bluetooth.hci_usb
+    - sample.bluetooth.hci_vs_scan_req
 
 Bluetooth HCI:
   status: maintained

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -432,7 +432,7 @@ static void isr_tx(void *param)
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
 				 EVENT_SYNC_B2B_MAFS_US -
 				 (EVENT_CLOCK_JITTER_US << 1) + cte_len_us -
-				 radio_tx_chain_delay_get(lll->phy_s, lll->adv->phy_flags) -
+				 radio_tx_chain_delay_get(lll->phy_s, lll->phy_flags) -
 				 HAL_RADIO_GPIO_PA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_PA_PIN */
 


### PR DESCRIPTION
Fixes commit ae09922fa454 ("Bluetooth: Controller: Use PHY flags for Coded PHY").

The  MAINTAINERS change is fixing the non-working "integration_platforms" that shall cover the hotfix. This PR is not covering all the (I seem to have believed that) "integration_platforms:" that is not covered in PR CI these days.

<img width="1182" height="253" alt="image" src="https://github.com/user-attachments/assets/dd07f07c-2b85-4576-b2fd-a81dec2a93e7" />

Now covered in this PR  CI:
<img width="1009" height="796" alt="image" src="https://github.com/user-attachments/assets/044315b6-aedb-4b29-9456-790097650163" />
