### PR TITLE
net: ipv4: Lower reassembly slot exhaustion log to debug

### DIFF
--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -359,7 +359,7 @@ enum net_verdict net_ipv4_handle_fragment_hdr(struct net_pkt *pkt, struct net_ip
 
 	reass = reassembly_get(id, hdr->src, hdr->dst, hdr->proto);
 	if (!reass) {
-		LOG_ERR("Cannot get reassembly slot, dropping pkt %p", pkt);
+		LOG_DBG("Cannot get reassembly slot, dropping pkt %p", pkt);
 		goto drop;
 	}
 


### PR DESCRIPTION
When all IPv4 reassembly slots are in use, net_ipv4_handle_fragment_hdr() drops the incoming fragments and logged this as an error. Running out of reassembly slots under fragment-heavy load is expected behaviour, not a fault (the sender retransmits, communication is not lost). So under heavy load, this logging produced a flood of error messages for a recoverable condition.

Lower the message from LOG_ERR to LOG_DBG to match the equivalent IPv6 path in ipv6_fragment.c, which already logs the same "Cannot get reassembly slot" situation at debug level.