### PR TITLE
Bluetooth: Host: Adv: Modify BT_ADV_CREATED for legacy adv

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -251,6 +251,9 @@ void bt_le_ext_adv_foreach(void (*func)(struct bt_le_ext_adv *adv, void *data),
 		}
 	}
 #else
+	/* When CONFIG_BT_EXT_ADV=n there is only a single legacy advertising set,
+	 * which is always considered created, so we do not need to check for BT_ADV_CREATED here
+	 */
 	func(&bt_dev.adv, data);
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4671,6 +4671,10 @@ void bt_finalize_init(void)
 		bt_scan_reset();
 	}
 
+#if !defined(CONFIG_BT_EXT_ADV)
+	atomic_set_bit(bt_dev.adv.flags, BT_ADV_CREATED);
+#endif /* !CONFIG_BT_EXT_ADV */
+
 	bt_dev_show_info();
 }
 


### PR DESCRIPTION
When CONFIG_BT_EXT_ADV=n then there is semantically always a created legacy advertising set.
This commit does 2 things:
1) BT_ADV_CREATED is explicitly set for the advertising set.
   This does not have any functional changes, but is just a
   minor semantic thing.
2) The lack of the check for BT_ADV_CREATED in
   bt_le_ext_adv_foreach has been commented. We could now
   actually check for BT_ADV_CREATED, but that would just
   be wasted cycles, given that it is always set.