### PR TITLE
requirements: install reuse with the custom_properties API

### DIFF
--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -12,7 +12,9 @@ pylint>=3
 python-dotenv>=1.2.2
 python-magic-bin; sys_platform == "win32"
 python-magic; sys_platform != "win32"
-reuse
+reuse @ https://codeberg.org/fsfe/reuse-tool/archive/f94ae0b1bb1d4d2ea91f49df88f3184c5d781a1d.tar.gz
+    # Provisional version directly from the reuse git tree
+    # See https://github.com/zephyrproject-rtos/zephyr/pull/113130
 ruff==0.14.2
 sphinx-lint
 tabulate


### PR DESCRIPTION
Since 7235648f399f9c0d2b8ca30f4aabeb27a6fc0c29 check_compliance LicenseAndCopyrightCheck needs reuse's custom_properties API, which is not yet in a released package. Install it from the reuse-tool repo as a temporary measure until a new release makes it to PyPi.

Without this users who follow our getting started guide, or in general install from this requirement file or with
`west packages pip --install`
won't be able to run this check locally, as
scripts/ci/check_compliance.py -m LicenseAndCopyrightCheck would fail with a
  `AttributeError: 'AnnotationsItem' object has no attribute 'custom_properties'`
error.

Users who already had installed reuse, will need to remove it first with `pip uninstall -y reuse`
as both the previous official version and this new version report the same version (6.2.0).

For more info see
* https://github.com/zephyrproject-rtos/zephyr/pull/113130

Note this change is just pointing this requirements file to the same version which other requirement files modified in #113130 already point to.

As a bonus people searching in GitHub will see this PR description and now what to do.