### PR TITLE
Revert "modules: hal_realtek: update to pick up Ameba toolchain enforcement"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: 5fa3e29115ea5dbe05da2de27288e8aa015af123
+      revision: 29d365ccfbceb9f42ce666d75463fbe2c83b8e29
       west-commands: west/west-commands.yml
       groups:
         - hal


### PR DESCRIPTION
This reverts commit 0a8297648704471442482abc0bb64852be9594f4.

Failure in CI related to toolchain setup and ZEPHYR_TOOLCHAIN_VARIANT.


see https://github.com/zephyrproject-rtos/zephyr/pull/117285#issuecomment-5478130893

