### PR TITLE
scripts: zephyr_module: describe VEX statements in module.yml

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -609,6 +609,69 @@ A real life example for Mbed TLS module could look like this:
    PURL field must follow the PURL specification provided by `Github
    <https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst>`_.
 
+.. _modules-vulnerability-assessments:
+
+Vulnerability assessments (VEX)
+===============================
+
+An external reference makes a module's vulnerabilities *discoverable*, but a scanner matching a
+CPE reports every CVE ever recorded against that project, including ones already fixed at the
+module's current revision and ones that never applied to the way the module uses the code. The
+``vulnerability-assessments`` field lets a module answer those findings once, in the module
+itself, instead of leaving every downstream user to redo the analysis.
+
+Each entry is a `VEX`_ (Vulnerability Exploitability eXchange) statement about one vulnerability:
+
+.. code-block:: yaml
+
+   security:
+     external-references:
+       - cpe:2.3:a:vendor:product:1.2.3:*:*:*:*:*:*:*
+     vulnerability-assessments:
+       - vulnerability: CVE-2024-12345
+         status: fixed
+         status-notes: Backported upstream commit abc1234.
+         references:
+           - https://github.com/vendor/product/security/advisories/GHSA-xxxx-yyyy-zzzz
+       - vulnerability: CVE-2024-54321
+         status: not_affected
+         justification: vulnerable_code_not_in_execute_path
+         impact-statement: >
+           The affected parser is only reachable from the server role, which this
+           module never enables.
+
+``vulnerability`` and ``status`` are required. ``status`` is one of:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Status
+     - Meaning
+   * - ``not_affected``
+     - The vulnerability does not apply to this module as it ships.
+   * - ``affected``
+     - The module is affected and users should act.
+   * - ``fixed``
+     - This revision of the module contains the fix.
+   * - ``under_investigation``
+     - Impact is not known yet.
+
+The remaining fields depend on the status, and are rejected when they do not match it:
+
+- ``justification`` and ``impact-statement`` explain a ``not_affected`` claim. At least one of
+  the two is required, since a bare "not affected" is not actionable. ``justification`` is the
+  machine-readable reason, one of ``component_not_present``, ``vulnerable_code_not_present``,
+  ``vulnerable_code_not_in_execute_path``,
+  ``vulnerable_code_cannot_be_controlled_by_adversary`` or
+  ``inline_mitigations_already_exist``. ``impact-statement`` is the prose explanation.
+- ``action-statement`` says what a user should do about an ``affected`` vulnerability, and is
+  required for that status.
+- ``status-notes`` records how the status was reached, for any status.
+- ``references`` lists URLs backing the assessment, such as advisories or fixing commits.
+
+.. _VEX: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex_508c.pdf
+
 
 Build system integration
 ========================

--- a/scripts/schemas/module-schema.yaml
+++ b/scripts/schemas/module-schema.yaml
@@ -114,6 +114,76 @@ properties:
         type: array
         items:
           type: string
+      vulnerability-assessments:
+        type: array
+        items:
+          type: object
+          properties:
+            # The vulnerability being assessed, such as a CVE or GHSA ID.
+            vulnerability:
+              type: string
+            # Whether the vulnerability applies to this module as it ships.
+            status:
+              type: string
+              enum: ['not_affected', 'affected', 'fixed', 'under_investigation']
+            # Machine-readable reason a 'not_affected' claim holds, from the VEX
+            # vocabulary shared with OpenVEX and CSAF.
+            justification:
+              type: string
+              enum: ['component_not_present', 'vulnerable_code_not_present',
+                     'vulnerable_code_not_in_execute_path',
+                     'vulnerable_code_cannot_be_controlled_by_adversary',
+                     'inline_mitigations_already_exist']
+            # Prose explanation of why the vulnerability has no impact here.
+            impact-statement:
+              type: string
+            # What a user should do about an 'affected' vulnerability.
+            action-statement:
+              type: string
+            # How the status was reached; meaningful for any status.
+            status-notes:
+              type: string
+            # URLs backing the assessment, such as advisories or fixing commits.
+            references:
+              type: array
+              items:
+                type: string
+          required:
+            - vulnerability
+            - status
+          # VEX gives each statement below exactly one status it may appear
+          # with, which the two blocks that follow encode:
+          #   not_affected         needs a justification or an impact-statement
+          #   affected             needs an action-statement
+          #   fixed                takes none of the three
+          #   under_investigation  takes none of the three
+          # Keep every 'else' in step with its 'then': a statement no branch
+          # forbids is silently accepted for every other status.
+          allOf:
+            - if:
+                properties:
+                  status:
+                    const: not_affected
+                required: [status]
+              then:
+                anyOf:
+                  - required: [justification]
+                  - required: [impact-statement]
+              else:
+                not:
+                  anyOf:
+                    - required: [justification]
+                    - required: [impact-statement]
+            - if:
+                properties:
+                  status:
+                    const: affected
+                required: [status]
+              then:
+                required: [action-statement]
+              else:
+                not:
+                  required: [action-statement]
   package-managers:
     type: object
     properties:


### PR DESCRIPTION
A CPE makes a module's vulnerabilities discoverable, but a scanner matching one will report every CVE ever filed against that project, including ones already fixed in the revision Zephyr pins, or that may not apply in the context of the Zephyr "flavour" of the module.

Add a `vulnerability-assessments` list to the `module.yml` `security` section so a module can answer those findings once, using the [VEX](https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex_508c.pdf) vocabulary (status, justification, impact/action statements) rather than leaving every downstream user to redo the analysis.

```yaml
security:
  external-references:
    - cpe:2.3:a:vendor:product:1.2.3:*:*:*:*:*:*:*
  vulnerability-assessments:
    - vulnerability: CVE-2024-12345
      status: fixed
      status-notes: Backported upstream commit abc1234.
    - vulnerability: CVE-2024-54321
      status: not_affected
      justification: vulnerable_code_not_in_execute_path
      impact-statement: >
        The affected parser is only reachable from the server role, which this
        module never enables.
```

`status` and `justification` use the OpenVEX/CSAF spellings, so a statement copies verbatim out of a CSAF document and can map 1:1 onto the SPDX 3 vocabulary (which a follow-up PR will add support for in `zspdx`)

