### PR TITLE
soc: esp32: pm: Fix/improve sleep path timing

### DIFF
--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -47,7 +47,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <1000>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -48,7 +48,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <1000>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
@@ -51,7 +51,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <2500>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -50,7 +50,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <2500>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/riscv/espressif/esp32c61/esp32c61_common.dtsi
+++ b/dts/riscv/espressif/esp32c61/esp32c61_common.dtsi
@@ -48,7 +48,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <2500>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
@@ -48,7 +48,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <1000>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
+++ b/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
@@ -62,7 +62,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <1000>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -51,7 +51,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <1000>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -47,7 +47,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <1000>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -55,7 +55,7 @@
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
 				min-residency-us = <1000>;
-				exit-latency-us = <50>;
+				exit-latency-us = <0>;
 			};
 
 			deep_sleep: deep_sleep {

--- a/soc/espressif/common/Kconfig.pm
+++ b/soc/espressif/common/Kconfig.pm
@@ -79,6 +79,38 @@ config ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU
 config SOC_ESP32_PM_SLP_DEFAULT_PARAMS_OPT
 	bool
 
+config SOC_ESP32_PM_WAKEUP_MARGIN_US
+	int "Light sleep RTC wake pad (us)"
+	range 0 2000
+	default 1000 if SOC_SERIES_ESP32C5 && \
+			ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP && ESP32_PM_SLP_IRAM_OPT
+	default 2000 if SOC_SERIES_ESP32C5 && ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP
+	default 0 if ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP
+	default 300
+	help
+	  Extra time subtracted when programming the RTC wake timer for light
+	  sleep, in addition to the measured time since idle entry.
+	  HAL's sleep code has an estimation to compensate for exit latency depending
+	  on the hardware resources enabled. However, this compensation does not cover
+	  all code involved in the sleep path. If no extra margin is added, we
+	  fail to meet the kernel's wake deadline in some configurations.
+
+	  Zephyr's exit-latency-us (DTS setting) can't be used for this compensation,
+	  as the wakeup signal comes from an LP timer, not from the system timer
+	  Zephyr schedules on. This means that we need to recalculate the wake
+	  deadline and add an extra margin.
+
+	  Defaults to 0 when peripheral power down is enabled (except on
+	  ESP32-C5): the HAL already overestimates that wake path, so an
+	  extra pad would only waste sleep.
+
+	  ESP32-C5 needs a much larger lead when the CPU powers down: its cache
+	  tags live in the CPU power domain, so every wake starts with a cold
+	  cache and refills from flash, which dominates the resume path.
+	  Disabling CPU power down removes the extra latency, and the IRAM
+	  optimization shortens it by keeping the early wake path independent
+	  of the flash cache.
+
 config ESP32_TIMER_IN_IRAM
 	bool
 
@@ -95,6 +127,7 @@ config ESP32_SLEEP_POWER_DOWN_FLASH
 	bool "Power down flash supply in light sleep (VDDSDIO path)"
 	depends on SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	depends on SOC_ESP32_FLASH_SUPPORTED
+	depends on !SOC_ESP32_PM_FLASH_KEEP_POWER_IN_LSLP
 	depends on !ESP_SPIRAM
 	select ESP32_PM_SLP_IRAM_OPT
 	help

--- a/soc/espressif/common/power.c
+++ b/soc/espressif/common/power.c
@@ -45,12 +45,18 @@ extern esp_err_t sleep_clock_icg_startup_init(void);
 LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 #define MIN_RESIDENCY_SLEEP_US DT_PROP(DT_NODELABEL(light_sleep), min_residency_us)
-#define WAKEUP_MARGIN_US       200
+
+#if defined(CONFIG_ESP32_PM_SLP_IRAM_OPT)
+#define ESP32_PM_SLEEP_FN_ATTR IRAM_ATTR
+#else
+#define ESP32_PM_SLEEP_FN_ATTR
+#endif
 
 static const struct device *const rtc_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(rtc_timer));
 
 static bool sleep_enabled;
 static uint64_t sleep_time_us;
+static uint64_t lpm_entry_counter;
 static uint64_t gpio_sleep_hold;
 #if defined(SOC_RTC_SLOW_MEM_SUPPORTED) || defined(SOC_RTC_FAST_MEM_SUPPORTED)
 static RTC_DATA_ATTR uint64_t gpio_was_held;
@@ -64,7 +70,18 @@ static gpio_hal_context_t gpio_hal = {.dev = GPIO_HAL_GET_HW(GPIO_PORT_0)};
 static uint32_t intenable;
 #endif
 
-static bool rtc_wakeup_enable(enum pm_state state, bool enable)
+static inline uint64_t lpm_counter_ticks_per_us(void)
+{
+#if defined(SOC_SYSTIMER_SUPPORTED)
+	return systimer_us_to_ticks(1);
+#elif defined(CONFIG_SOC_SERIES_ESP32)
+	return LACT_TICKS_PER_US;
+#else
+	return 1;
+#endif
+}
+
+static bool ESP32_PM_SLEEP_FN_ATTR rtc_wakeup_enable(enum pm_state state, bool enable)
 {
 	bool wakeup_allowed;
 	bool result = false;
@@ -96,17 +113,22 @@ static bool rtc_wakeup_enable(enum pm_state state, bool enable)
 	}
 
 	if (enable) {
-		/* Here we subtract a time margin from the sleep period to wake up before the
-		 * systimer/ccount scheduler event. Since the RTC timer is used as a wakeup
-		 * source instead of the systimer, the compensation must be applied based on
-		 * the programmed wakeup time in order to resume execution just in time to
-		 * execute the scheduler event. Because of this, we keep 'exit-latency-us' to
-		 * a minimum in the device tree, and apply the actual compensation here. Also,
-		 * HAL already compensates exit latency according to config/dynamic parameters,
-		 * so we'll leave HAL to manage it.
+		/* The RTC timer, not the systimer/ccount, is the wakeup source, so we must
+		 * resume before the scheduler deadline captured at low-power-idle entry. The
+		 * lead time has two parts: the software latency from that entry until here,
+		 * measured from the counter snapshot taken in the LPM entry hook (the HAL
+		 * cannot see it), plus CONFIG_SOC_ESP32_PM_WAKEUP_MARGIN_US as a residual pad
+		 * for the remaining, unmeasured tail up to the HAL's internal sleep-start (GPIO
+		 * prepare and the sleep prologue). Feature-dependent hardware wake latency
+		 * (peripheral, flash and CPU power down) is compensated by HAL.
 		 */
-		if (sleep_time_us >= (MIN_RESIDENCY_SLEEP_US + WAKEUP_MARGIN_US)) {
-			esp_sleep_enable_timer_wakeup(sleep_time_us - WAKEUP_MARGIN_US);
+		uint64_t now = esp_timer_impl_get_counter_reg();
+		uint64_t elapsed_us = (now - lpm_entry_counter) / lpm_counter_ticks_per_us();
+		uint64_t lead_us = elapsed_us + CONFIG_SOC_ESP32_PM_WAKEUP_MARGIN_US;
+
+		if ((sleep_time_us > lead_us) &&
+		    ((sleep_time_us - lead_us) >= MIN_RESIDENCY_SLEEP_US)) {
+			esp_sleep_enable_timer_wakeup(sleep_time_us - lead_us);
 			result = true;
 		}
 	} else {
@@ -163,7 +185,7 @@ void esp32_sleep_gpio_prepare(void)
 	}
 }
 
-void esp32_sleep_gpio_restore(void)
+void ESP32_PM_SLEEP_FN_ATTR esp32_sleep_gpio_restore(void)
 {
 	for (int gpio = 0; gpio < SOC_GPIO_PIN_COUNT; gpio++) {
 
@@ -210,7 +232,11 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 		if (sleep_enabled) {
 			esp32_sleep_gpio_prepare();
-			esp_light_sleep_start();
+			esp_err_t ret = esp_light_sleep_start();
+
+			if (ret != ESP_OK) {
+				LOG_DBG("Light sleep rejected by HAL (0x%x)", ret);
+			}
 		}
 		break;
 
@@ -231,7 +257,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	}
 }
 
-void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+void ESP32_PM_SLEEP_FN_ATTR pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(substate_id);
 
@@ -274,11 +300,16 @@ uint64_t esp32_lptim_hook_on_lpm_entry(uint64_t max_lpm_time_us)
 #endif
 {
 	/* Since LPM state is not yet confirmed, we only program
-	 * wakeup at pm_state_set() event.
+	 * wakeup at pm_state_set() event. Snapshot the counter here too, so the
+	 * software latency until the wakeup is programmed can be measured and
+	 * discounted from the sleep period.
 	 */
-	sleep_time_us = max_lpm_time_us;
+	uint64_t counter = esp_timer_impl_get_counter_reg();
 
-	return esp_timer_impl_get_counter_reg();
+	sleep_time_us = max_lpm_time_us;
+	lpm_entry_counter = counter;
+
+	return counter;
 }
 
 #if defined(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)

--- a/soc/espressif/common/power.c
+++ b/soc/espressif/common/power.c
@@ -70,14 +70,14 @@ static gpio_hal_context_t gpio_hal = {.dev = GPIO_HAL_GET_HW(GPIO_PORT_0)};
 static uint32_t intenable;
 #endif
 
-static inline uint64_t lpm_counter_ticks_per_us(void)
+static inline uint64_t lpm_counter_ticks_per_sec(void)
 {
 #if defined(SOC_SYSTIMER_SUPPORTED)
-	return systimer_us_to_ticks(1);
+	return systimer_us_to_ticks(1000000ULL);
 #elif defined(CONFIG_SOC_SERIES_ESP32)
-	return LACT_TICKS_PER_US;
+	return LACT_TICKS_PER_US * 1000000ULL;
 #else
-	return 1;
+	return 1000000ULL;
 #endif
 }
 
@@ -123,7 +123,8 @@ static bool ESP32_PM_SLEEP_FN_ATTR rtc_wakeup_enable(enum pm_state state, bool e
 		 * (peripheral, flash and CPU power down) is compensated by HAL.
 		 */
 		uint64_t now = esp_timer_impl_get_counter_reg();
-		uint64_t elapsed_us = (now - lpm_entry_counter) / lpm_counter_ticks_per_us();
+		uint64_t elapsed_us =
+			((now - lpm_entry_counter) * 1000000ULL) / lpm_counter_ticks_per_sec();
 		uint64_t lead_us = elapsed_us + CONFIG_SOC_ESP32_PM_WAKEUP_MARGIN_US;
 
 		if ((sleep_time_us > lead_us) &&
@@ -329,11 +330,7 @@ uint64_t z_xtensa_lptim_hook_get_freq(void)
 uint64_t esp32_lptim_hook_get_freq(void)
 #endif
 {
-#if defined(SOC_SYSTIMER_SUPPORTED)
-	return systimer_us_to_ticks(1) * 1000000ULL;
-#elif defined(CONFIG_SOC_SERIES_ESP32)
-	return LACT_TICKS_PER_US * 1000000ULL;
-#endif
+	return lpm_counter_ticks_per_sec();
 }
 
 /* Sleep retention initialization */

--- a/soc/espressif/esp32c5/Kconfig.caps
+++ b/soc/espressif/esp32c5/Kconfig.caps
@@ -37,6 +37,10 @@ config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 
+config SOC_ESP32_PM_FLASH_KEEP_POWER_IN_LSLP
+	bool
+	default y
+
 config SOC_ESP32_ETM_SUPPORTED
 	bool
 	default y


### PR DESCRIPTION
Rework the sleep path timing calculation to improve precision by calculating sleep time and wake-up margins with the right time references. Include SoC-specific PM code under the existing option CONFIG_ESP32_PM_SLP_IRAM_OPT, to properly optimize the sleep path code.

Fix systimer frequency get, to avoid value truncation that could affect some SoCs.