### PR TITLE
[ZEP-5863] mcxa-577 enet MII instead of RMII

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -336,8 +336,12 @@ void board_early_init_hook(void)
 	/* Connect ENET to internal TENBASET_PHY0 */
 	SYSCON->ENET_CTRL = SYSCON_ENET_CTRL_PHY_SEL(1) | SYSCON_ENET_CTRL_PHY_INTF(0);
 #else
-	/* Connect ENET to external PHY over RMII */
-	SYSCON->ENET_CTRL = SYSCON_ENET_CTRL_PHY_SEL(0) | SYSCON_ENET_CTRL_PHY_INTF(1);
+	/*
+	 * Connect ENET to external PHY over MII (Rev B pilot board).
+	 * PHY_INTF: 0 = MII, 1 = RMII. MII avoids ERR053383, under which
+	 * ENET can intermittently fail to receive in RMII mode.
+	 */
+	SYSCON->ENET_CTRL = SYSCON_ENET_CTRL_PHY_SEL(0) | SYSCON_ENET_CTRL_PHY_INTF(0);
 #endif
 #endif
 

--- a/boards/nxp/frdm_mcxa577/doc/index.rst
+++ b/boards/nxp/frdm_mcxa577/doc/index.rst
@@ -15,8 +15,10 @@ Hardware
 - 2048KB dual-bank on chip Flash
 - 640 KB RAM
 - 2x FlexCAN with FD, 1x RGB LED, 3x SW buttons
+- 10/100 Mbit Ethernet (external PHY, MII interface)
 - On-board MCU-Link debugger with CMSIS-DAP
 - Arduino Header, SmartDMA/Camera Header, mikroBUS
+
 
 For more information about the MCX-A577 SoC and FRDM-MCXA577 board, see:
 
@@ -82,6 +84,32 @@ Serial Port
 
 The FRDM-MCXA577 SoC has 6 LPUART  interfaces for serial communication.
 LPUART0 is configured as UART for the console.
+
+Ethernet
+===========
+
+The board has a 10/100 Mbit external Ethernet PHY (MII interface). MII avoids
+ERR053383, under which ENET can intermittently fail to receive in RMII mode, so
+the Rev B pilot board is reworked for MII.
+
+The ENET MAC, MDIO bus and PHY are **disabled by default** so that ordinary
+samples keep the on-board MCU-Link VCOM console on LPUART1. This is necessary
+because MII needs P1_8/P1_9 (ENET0_TXD2/TXD3, the only balls that carry those
+signals), which are the LPUART1 VCOM pins. ENET and the on-board VCOM therefore
+cannot coexist.
+
+To build a networking application, add the board's ENET overlay to the build.
+It enables the ENET MAC/MDIO/PHY, disables LPUART1 and moves the console/shell
+to LPUART2 (Arduino D0/D1 header, P2_11/P2_10):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/zperf
+   :board: frdm_mcxa577
+   :gen-args: -DEXTRA_DTC_OVERLAY_FILE=boards/nxp/frdm_mcxa577/dts/nxp,enet.overlay
+   :goals: build
+
+While ENET is enabled the on-board VCOM is not available; connect a USB-serial
+adapter to the LPUART2 pins on the Arduino D0/D1 header for the console.
 
 Programming and Debugging
 *************************

--- a/boards/nxp/frdm_mcxa577/dts/nxp,enet.overlay
+++ b/boards/nxp/frdm_mcxa577/dts/nxp,enet.overlay
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * External-PHY Ethernet (MII) opt-in overlay for frdm_mcxa577.
+ *
+ * ENET and its external PHY are disabled by default in the board dtsi so that
+ * ordinary samples keep the on-board MCU-Link VCOM console on LPUART1
+ * (P1_8/P1_9). This overlay enables the external-PHY MII ENET for networking
+ * applications. MII needs P1_8/P1_9 for ENET0_TXD2/TXD3 (the only balls that
+ * carry those signals), which are the LPUART1 VCOM pins, so enabling ENET also
+ * disables LPUART1 and moves the console/shell to LPUART2 (Arduino D0/D1
+ * header). The on-board VCOM is therefore not available while ENET is enabled.
+ */
+
+&enet {
+	status = "okay";
+};
+
+&enet_mdio {
+	status = "okay";
+
+	phy: ethernet-phy@0 {
+		status = "okay";
+	};
+};
+
+&lpuart1 {
+	status = "disabled";
+};
+
+&lpuart2 {
+	status = "okay";
+};
+
+/ {
+	chosen {
+		zephyr,console = &lpuart2;
+		zephyr,shell-uart = &lpuart2;
+	};
+};

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -103,10 +103,16 @@
 			pinmux = <ENET0_RXDV_P1_13>,
 				 <ENET0_RXD0_P1_11>,
 				 <ENET0_RXD1_P1_12>,
+				 <ENET0_RXD2_P1_16>,
+				 <ENET0_RXD3_P1_17>,
+				 <ENET0_RX_CLK_P1_14>,
+				 <ENET0_RXER_P1_15>,
 				 <ENET0_TX_CLK_P1_4>,
 				 <ENET0_TXEN_P1_5>,
 				 <ENET0_TXD0_P1_6>,
-				 <ENET0_TXD1_P1_7>;
+				 <ENET0_TXD1_P1_7>,
+				 <ENET0_TXD2_P1_8>,
+				 <ENET0_TXD3_P1_9>;
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -302,22 +302,32 @@
 	};
 };
 
+/*
+ * External-PHY Ethernet is disabled by default so that ordinary samples keep
+ * the on-board MCU-Link VCOM console on LPUART1. It is enabled for networking
+ * applications by adding boards/nxp/frdm_mcxa577/dts/nxp,enet.overlay to the
+ * build (EXTRA_DTC_OVERLAY_FILE), which also moves the console to LPUART2
+ * because MII needs the LPUART1 VCOM pins (P1_8/P1_9 = ENET0_TXD2/TXD3).
+ * See ERR053383: ENET can intermittently fail to receive in RMII mode, so the
+ * Rev B board uses MII.
+ */
+
 &enet {
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&pinmux_enet_qos>;
 	pinctrl-names = "default";
-	phy-connection-type = "rmii";
+	phy-connection-type = "mii";
 	zephyr,random-mac-address;
 	phy-handle = <&phy>;
 };
 
 &enet_mdio {
-	status = "okay";
+	status = "disabled";
 
 	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 	};
 };
 


### PR DESCRIPTION
Due to SoC bug, ENET sometimes does not receive in RMII mode.
There will be a new board revision using MII instead of RMII.
Hardware initialization will be reworked to use MII.
This does not solve the underlying SoC issue, but will make examples running.