### PR TITLE
boards: adi: Set JLink reset-type for MAX78000Evkit board

### DIFF
--- a/boards/adi/max78000evkit/board.cmake
+++ b/boards/adi/max78000evkit/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=MAX78000" "--reset-after-load")
+board_runner_args(jlink "--device=MAX78000" "--reset-after-load" "--reset-type=12")
 
 include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
Avoid resets not immediately halting MAX78000Evkit cores by setting a reset type of 12 for the JLink runner.

Similar to the https://github.com/zephyrproject-rtos/zephyr/pull/110974, this PR adds reset type support for the MAX78000Evkit board and aligns its behavior with the other supported boards.