### PR TITLE
drivers: clock control: stm32u3 voltage scale for 48MHz clock

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u3.c
+++ b/drivers/clock_control/clock_stm32_ll_u3.c
@@ -315,7 +315,7 @@ static DEVICE_API(clock_control, stm32_clock_control_api) = {
 
 static void set_regu_voltage(uint32_t hclk_freq)
 {
-	if (hclk_freq < MHZ(48)) {
+	if (hclk_freq <= MHZ(48)) {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE2);
 	} else {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);


### PR DESCRIPTION
On the stm32U3 series, the Voltage Scale 2 (lower-range) is accessible for a system clock frequency up or equal to 48MHz. This is specified by the RefMan RM0487 and prefered to minimize the power consumption.

"_Range 2: low-power range
It provides a typical output voltage at 0.75 V. The system clock frequency can be up to 48 MHz_."


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/114175