### PR TITLE
drivers: udc_kinetis: replace slabs/fifo based events with k_events 

### DIFF
--- a/drivers/usb/udc/Kconfig.kinetis
+++ b/drivers/usb/udc/Kconfig.kinetis
@@ -6,17 +6,11 @@ config UDC_KINETIS
 	default y
 	depends on DT_HAS_NXP_KINETIS_USBD_ENABLED
 	select DYNAMIC_INTERRUPTS if UHC_NXP_KHCI
+	select EVENTS
 	help
 	  Kinetis USB device controller criver.
 
 if UDC_KINETIS
-
-config UDC_KINETIS_EVENT_COUNT
-	int "Number or blocks in event slab"
-	range 4 16
-	default 4
-	help
-	  Number of blocks in slab for internal endpoint events.
 
 config UDC_KINETIS_STACK_SIZE
 	int "UDC controller driver internal thread stack size"

--- a/drivers/usb/udc/Kconfig.kinetis
+++ b/drivers/usb/udc/Kconfig.kinetis
@@ -3,17 +3,31 @@
 
 config UDC_KINETIS
 	bool "Kinetis USB device controller driver"
-	imply UDC_WORKQUEUE
 	default y
 	depends on DT_HAS_NXP_KINETIS_USBD_ENABLED
 	select DYNAMIC_INTERRUPTS if UHC_NXP_KHCI
 	help
 	  Kinetis USB device controller criver.
 
+if UDC_KINETIS
+
 config UDC_KINETIS_EVENT_COUNT
 	int "Number or blocks in event slab"
-	depends on UDC_KINETIS
 	range 4 16
 	default 4
 	help
 	  Number of blocks in slab for internal endpoint events.
+
+config UDC_KINETIS_STACK_SIZE
+	int "UDC controller driver internal thread stack size"
+	default 512
+	help
+	  Device controller driver internal thread stack size.
+
+config UDC_KINETIS_THREAD_PRIORITY
+	int "UDC controller driver thread priority"
+	default 8
+	help
+	  Device controller driver thread priority.
+
+endif # UDC_KINETIS

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -86,6 +86,7 @@ struct usbfsotg_config {
 	struct usbfsotg_bd *bdt;
 	void (*irq_enable_func)(const struct device *dev);
 	void (*irq_disable_func)(const struct device *dev);
+	void (*make_thread)(const struct device *dev);
 	size_t num_of_eps;
 	struct udc_ep_config *ep_cfg_in;
 	struct udc_ep_config *ep_cfg_out;
@@ -105,7 +106,6 @@ enum usbfsotg_event_type {
 /* Structure for driver's endpoint events */
 struct usbfsotg_ep_event {
 	sys_snode_t node;
-	const struct device *dev;
 	enum usbfsotg_event_type event;
 	uint8_t ep;
 };
@@ -114,7 +114,7 @@ K_MEM_SLAB_DEFINE_TYPE(usbfsotg_ee_slab, struct usbfsotg_ep_event,
 		       CONFIG_UDC_KINETIS_EVENT_COUNT);
 
 struct usbfsotg_data {
-	struct k_work work;
+	struct k_thread thread_data;
 	struct k_fifo fifo;
 	struct usb_setup_packet setup;
 	uint32_t odd;
@@ -253,7 +253,7 @@ static int usbfsotg_xfer_next(const struct device *dev,
 	return usbfsotg_xfer_continue(dev, cfg, buf);
 }
 
-static inline int work_handler_setup(const struct device *dev)
+static inline int handle_evt_setup(const struct device *dev)
 {
 	struct usbfsotg_data *priv = udc_get_private(dev);
 
@@ -265,8 +265,8 @@ static inline int work_handler_setup(const struct device *dev)
 	return 0;
 }
 
-static inline int work_handler_data(const struct device *dev,
-				    struct udc_ep_config *ep_cfg)
+static inline int handle_evt_finished(const struct device *dev,
+				     struct udc_ep_config *ep_cfg)
 {
 	struct net_buf *buf;
 
@@ -293,60 +293,57 @@ static void usbfsotg_event_submit(const struct device *dev,
 		return;
 	}
 
-	ev->dev = dev;
 	ev->ep = ep;
 	ev->event = event;
 	k_fifo_put(&priv->fifo, ev);
-	k_work_submit_to_queue(udc_get_work_q(), &priv->work);
 }
 
-static void xfer_work_handler(struct k_work *item)
+static ALWAYS_INLINE void usbfsotg_thread_handler(const struct device *const dev)
 {
+	struct usbfsotg_data *priv = udc_get_private(dev);
 	struct usbfsotg_ep_event *ev;
-	struct usbfsotg_data *priv;
+	struct udc_ep_config *ep_cfg;
+	int err = 0;
 
-	priv = CONTAINER_OF(item, struct usbfsotg_data, work);
-	while ((ev = k_fifo_get(&priv->fifo, K_NO_WAIT)) != NULL) {
-		struct udc_ep_config *ep_cfg;
-		int err = 0;
+	ev = k_fifo_get(&priv->fifo, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 
-		LOG_DBG("dev %p, ep 0x%02x, event %u",
-			ev->dev, ev->ep, ev->event);
-		ep_cfg = udc_get_ep_cfg(ev->dev, ev->ep);
-		if (unlikely(ep_cfg == NULL)) {
-			udc_submit_event(ev->dev, UDC_EVT_ERROR, -ENODATA);
-			goto xfer_work_error;
-		}
-
-		switch (ev->event) {
-		case USBFSOTG_EVT_SETUP:
-			err = work_handler_setup(ev->dev);
-			break;
-		case USBFSOTG_EVT_DOUT:
-		case USBFSOTG_EVT_DIN:
-			err = work_handler_data(ev->dev, ep_cfg);
-			udc_ep_set_busy(ep_cfg, false);
-			break;
-		case USBFSOTG_EVT_XFER:
-			break;
-		default:
-			break;
-		}
-
-		if (unlikely(err)) {
-			udc_submit_event(ev->dev, UDC_EVT_ERROR, err);
-		}
-
-		/* Peek next transfer */
-		if (ev->ep != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ep_cfg)) {
-			if (usbfsotg_xfer_next(ev->dev, ep_cfg) == 0) {
-				udc_ep_set_busy(ep_cfg, true);
-			}
-		}
-
-xfer_work_error:
-		k_mem_slab_free(&usbfsotg_ee_slab, (void *)ev);
+	LOG_DBG("dev %s, ep 0x%02x, event %u", dev->name, ev->ep, ev->event);
+	ep_cfg = udc_get_ep_cfg(dev, ev->ep);
+	if (unlikely(ep_cfg == NULL)) {
+		udc_submit_event(dev, UDC_EVT_ERROR, -ENODATA);
+		goto thread_handler_exit;
 	}
+
+	switch (ev->event) {
+	case USBFSOTG_EVT_SETUP:
+		err = handle_evt_setup(dev);
+		break;
+	case USBFSOTG_EVT_DOUT:
+	case USBFSOTG_EVT_DIN:
+		err = handle_evt_finished(dev, ep_cfg);
+		udc_ep_set_busy(ep_cfg, false);
+		break;
+	case USBFSOTG_EVT_XFER:
+		break;
+	default:
+		break;
+	}
+
+	if (unlikely(err)) {
+		udc_submit_event(dev, UDC_EVT_ERROR, err);
+	}
+
+	/* Peek next transfer */
+	if (ev->ep != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ep_cfg)) {
+		if (usbfsotg_xfer_next(dev, ep_cfg) == 0) {
+			udc_ep_set_busy(ep_cfg, true);
+		}
+	}
+
+thread_handler_exit:
+	udc_unlock_internal(dev);
+	k_mem_slab_free(&usbfsotg_ee_slab, (void *)ev);
 }
 
 static ALWAYS_INLINE uint8_t stat_reg_get_ep(const uint8_t status)
@@ -862,12 +859,14 @@ static int usbfsotg_shutdown(const struct device *dev)
 
 static void usbfsotg_lock(const struct device *dev)
 {
+	k_sched_lock();
 	udc_lock_internal(dev, K_FOREVER);
 }
 
 static void usbfsotg_unlock(const struct device *dev)
 {
 	udc_unlock_internal(dev);
+	k_sched_unlock();
 }
 
 static int usbfsotg_driver_preinit(const struct device *dev)
@@ -879,7 +878,6 @@ static int usbfsotg_driver_preinit(const struct device *dev)
 
 	k_mutex_init(&data->mutex);
 	k_fifo_init(&priv->fifo);
-	k_work_init(&priv->work, xfer_work_handler);
 
 	for (int i = 0; i < config->num_of_eps; i++) {
 		config->ep_cfg_out[i].caps.out = 1;
@@ -924,6 +922,8 @@ static int usbfsotg_driver_preinit(const struct device *dev)
 	data->caps.rwup = false;
 	data->caps.mps0 = USBFSOTG_MPS0;
 
+	config->make_thread(dev);
+
 	return 0;
 }
 
@@ -955,6 +955,31 @@ static const struct udc_api usbfsotg_api = {
 		     DEVICE_DT_INST_GET(n), 0)))
 
 #define USBFSOTG_DEVICE_DEFINE(n)						\
+	K_THREAD_STACK_DEFINE(usbfsotg_stack_##n,				\
+			      CONFIG_UDC_KINETIS_STACK_SIZE);			\
+										\
+	static void usbfsotg_thread_##n(void *dev, void *arg1, void *arg2)	\
+	{									\
+		while (true) {							\
+			usbfsotg_thread_handler(dev);				\
+		}								\
+	}									\
+										\
+	static void usbfsotg_make_thread_##n(const struct device *dev)		\
+	{									\
+		struct usbfsotg_data *priv = udc_get_private(dev);		\
+										\
+		k_thread_create(&priv->thread_data,				\
+				usbfsotg_stack_##n,				\
+				K_THREAD_STACK_SIZEOF(usbfsotg_stack_##n),	\
+				usbfsotg_thread_##n,				\
+				(void *)dev, NULL, NULL,			\
+				K_PRIO_COOP(CONFIG_UDC_KINETIS_THREAD_PRIORITY),\
+				K_ESSENTIAL,					\
+				K_NO_WAIT);					\
+		k_thread_name_set(&priv->thread_data, dev->name);		\
+	}									\
+										\
 	static void udc_irq_enable_func##n(const struct device *dev)		\
 	{									\
 		USBFSOTG_IRQ_DEFINE_OR(n);					\
@@ -979,6 +1004,7 @@ static const struct udc_api usbfsotg_api = {
 		.bdt = bdt_##n,							\
 		.irq_enable_func = udc_irq_enable_func##n,			\
 		.irq_disable_func = udc_irq_disable_func##n,			\
+		.make_thread = usbfsotg_make_thread_##n,			\
 		.num_of_eps = DT_INST_PROP(n, num_bidir_endpoints),		\
 		.ep_cfg_in = ep_cfg_in,						\
 		.ep_cfg_out = ep_cfg_out,					\

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -93,36 +93,54 @@ struct usbfsotg_config {
 };
 
 enum usbfsotg_event_type {
-	/* Trigger next transfer, must not be used for control OUT */
-	USBFSOTG_EVT_XFER,
 	/* Setup packet received */
 	USBFSOTG_EVT_SETUP,
-	/* OUT transaction for specific endpoint is finished */
-	USBFSOTG_EVT_DOUT,
-	/* IN transaction for specific endpoint is finished */
-	USBFSOTG_EVT_DIN,
+	/* Trigger new transfer (except control endpoints) */
+	USBFSOTG_EVT_XFER_NEW,
+	/* Transfer for specific endpoint is finished */
+	USBFSOTG_EVT_XFER_FINISHED,
 };
-
-/* Structure for driver's endpoint events */
-struct usbfsotg_ep_event {
-	sys_snode_t node;
-	enum usbfsotg_event_type event;
-	uint8_t ep;
-};
-
-K_MEM_SLAB_DEFINE_TYPE(usbfsotg_ee_slab, struct usbfsotg_ep_event,
-		       CONFIG_UDC_KINETIS_EVENT_COUNT);
 
 struct usbfsotg_data {
 	struct k_thread thread_data;
-	struct k_fifo fifo;
+	struct k_event events;
+	/*
+	 * xfer_new and xfer_finished contain information on which endpoints
+	 * events USBFSOTG_EVT_XFER_NEW or USBFSOTG_EVT_XFER_FINISHED are
+	 * triggered. The mapping is bits 31..16 for IN endpoints and bits
+	 * 15..0 for OUT endpoints.
+	 */
+	atomic_t xfer_new;
+	atomic_t xfer_finished;
 	struct usb_setup_packet setup;
 	uint32_t odd;
 	bool setup_valid;
 };
 
-static int usbfsotg_ep_clear_halt(const struct device *dev,
-				  struct udc_ep_config *const cfg);
+static inline int udc_ep_to_bnum(const uint8_t ep)
+{
+	if (USB_EP_DIR_IS_IN(ep)) {
+		return 16UL + USB_EP_GET_IDX(ep);
+	}
+
+	return USB_EP_GET_IDX(ep);
+}
+
+static inline uint8_t udc_pull_ep_from_bmsk(uint32_t *const bitmap)
+{
+	unsigned int bit;
+
+	__ASSERT_NO_MSG(bitmap && *bitmap);
+
+	bit = find_lsb_set(*bitmap) - 1;
+	*bitmap &= ~BIT(bit);
+
+	if (bit >= 16U) {
+		return USB_EP_DIR_IN | (bit - 16U);
+	}
+
+	return USB_EP_DIR_OUT | bit;
+}
 
 static uint8_t usbfsotg_get_odd_bit(const uint8_t ep)
 {
@@ -278,72 +296,86 @@ static inline int handle_evt_finished(const struct device *dev,
 	return udc_submit_ep_event(dev, buf, 0);
 }
 
-static void usbfsotg_event_submit(const struct device *dev,
-				 const uint8_t ep,
-				 const enum usbfsotg_event_type event)
+static void usbfsotg_xfer_new_submit(const struct device *dev, const uint8_t ep)
 {
 	struct usbfsotg_data *priv = udc_get_private(dev);
-	struct usbfsotg_ep_event *ev;
-	int ret;
 
-	ret = k_mem_slab_alloc(&usbfsotg_ee_slab, (void **)&ev, K_NO_WAIT);
-	if (ret) {
-		udc_submit_event(dev, UDC_EVT_ERROR, ret);
-		LOG_ERR("Failed to allocate slab");
-		return;
-	}
+	atomic_set_bit(&priv->xfer_new, udc_ep_to_bnum(ep));
+	k_event_post(&priv->events, BIT(USBFSOTG_EVT_XFER_NEW));
+}
 
-	ev->ep = ep;
-	ev->event = event;
-	k_fifo_put(&priv->fifo, ev);
+static void usbfsotg_xfer_finished_submit(const struct device *dev, const uint8_t ep)
+{
+	struct usbfsotg_data *priv = udc_get_private(dev);
+
+	atomic_set_bit(&priv->xfer_finished, udc_ep_to_bnum(ep));
+	k_event_post(&priv->events, BIT(USBFSOTG_EVT_XFER_FINISHED));
 }
 
 static ALWAYS_INLINE void usbfsotg_thread_handler(const struct device *const dev)
 {
 	struct usbfsotg_data *priv = udc_get_private(dev);
-	struct usbfsotg_ep_event *ev;
 	struct udc_ep_config *ep_cfg;
-	int err = 0;
+	uint32_t evt;
+	uint32_t eps;
+	uint8_t ep;
+	int err;
 
-	ev = k_fifo_get(&priv->fifo, K_FOREVER);
+	evt = k_event_wait(&priv->events, UINT32_MAX, false, K_FOREVER);
 	udc_lock_internal(dev, K_FOREVER);
 
-	LOG_DBG("dev %s, ep 0x%02x, event %u", dev->name, ev->ep, ev->event);
-	ep_cfg = udc_get_ep_cfg(dev, ev->ep);
-	if (unlikely(ep_cfg == NULL)) {
-		udc_submit_event(dev, UDC_EVT_ERROR, -ENODATA);
-		goto thread_handler_exit;
-	}
+	if (evt & BIT(USBFSOTG_EVT_XFER_FINISHED)) {
+		k_event_clear(&priv->events, BIT(USBFSOTG_EVT_XFER_FINISHED));
+		eps = atomic_clear(&priv->xfer_finished);
 
-	switch (ev->event) {
-	case USBFSOTG_EVT_SETUP:
-		err = handle_evt_setup(dev);
-		break;
-	case USBFSOTG_EVT_DOUT:
-	case USBFSOTG_EVT_DIN:
-		err = handle_evt_finished(dev, ep_cfg);
-		udc_ep_set_busy(ep_cfg, false);
-		break;
-	case USBFSOTG_EVT_XFER:
-		break;
-	default:
-		break;
-	}
+		while (eps) {
+			ep = udc_pull_ep_from_bmsk(&eps);
+			ep_cfg = udc_get_ep_cfg(dev, ep);
+			LOG_DBG("Finished event ep 0x%02x", ep);
 
-	if (unlikely(err)) {
-		udc_submit_event(dev, UDC_EVT_ERROR, err);
-	}
+			err = handle_evt_finished(dev, ep_cfg);
+			if (unlikely(err)) {
+				udc_submit_event(dev, UDC_EVT_ERROR, err);
+			}
 
-	/* Peek next transfer */
-	if (ev->ep != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ep_cfg)) {
-		if (usbfsotg_xfer_next(dev, ep_cfg) == 0) {
-			udc_ep_set_busy(ep_cfg, true);
+			udc_ep_set_busy(ep_cfg, false);
+
+			/* Peek next transfer */
+			if (ep != USB_CONTROL_EP_OUT) {
+				if (usbfsotg_xfer_next(dev, ep_cfg) == 0) {
+					udc_ep_set_busy(ep_cfg, true);
+				}
+			}
 		}
 	}
 
-thread_handler_exit:
+	if (evt & BIT(USBFSOTG_EVT_XFER_NEW)) {
+		k_event_clear(&priv->events, BIT(USBFSOTG_EVT_XFER_NEW));
+		eps = atomic_clear(&priv->xfer_new);
+
+		while (eps) {
+			ep = udc_pull_ep_from_bmsk(&eps);
+			ep_cfg = udc_get_ep_cfg(dev, ep);
+			LOG_DBG("New transfer ep 0x%02x in the queue", ep);
+
+			if (!udc_ep_is_busy(ep_cfg)) {
+				if (usbfsotg_xfer_next(dev, ep_cfg) == 0) {
+					udc_ep_set_busy(ep_cfg, true);
+				}
+			}
+		}
+	}
+
+	if (evt & BIT(USBFSOTG_EVT_SETUP)) {
+		k_event_clear(&priv->events, BIT(USBFSOTG_EVT_SETUP));
+
+		err = handle_evt_setup(dev);
+		if (unlikely(err)) {
+			udc_submit_event(dev, UDC_EVT_ERROR, err);
+		}
+	}
+
 	udc_unlock_internal(dev);
-	k_mem_slab_free(&usbfsotg_ee_slab, (void *)ev);
 }
 
 static ALWAYS_INLINE uint8_t stat_reg_get_ep(const uint8_t status)
@@ -395,7 +427,7 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 			memcpy(&priv->setup, UINT_TO_POINTER(bd->buf_addr), sizeof(priv->setup));
 		}
 
-		usbfsotg_event_submit(dev, ep, USBFSOTG_EVT_SETUP);
+		k_event_post(&priv->events, BIT(USBFSOTG_EVT_SETUP));
 		break;
 	case USBFSOTG_OUT_TOKEN:
 		WRITE_BIT(priv->odd, odd_bit, !odd);
@@ -414,7 +446,7 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 		    len == udc_mps_ep_size(ep_cfg)) {
 			usbfsotg_xfer_continue(dev, ep_cfg, buf);
 		} else {
-			usbfsotg_event_submit(dev, ep, USBFSOTG_EVT_DOUT);
+			usbfsotg_xfer_finished_submit(dev, ep);
 		}
 
 		break;
@@ -439,7 +471,7 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 				break;
 			}
 
-			usbfsotg_event_submit(dev, ep, USBFSOTG_EVT_DIN);
+			usbfsotg_xfer_finished_submit(dev, ep);
 		}
 
 		break;
@@ -560,7 +592,7 @@ static int usbfsotg_ep_enqueue(const struct device *dev,
 		return 0;
 	}
 
-	usbfsotg_event_submit(dev, cfg->addr, USBFSOTG_EVT_XFER);
+	usbfsotg_xfer_new_submit(dev, cfg->addr);
 
 	return 0;
 }
@@ -622,7 +654,7 @@ static int usbfsotg_ep_clear_halt(const struct device *dev,
 
 	if (USB_EP_GET_IDX(cfg->addr) != 0) {
 		/* trigger queued transfers */
-		usbfsotg_event_submit(dev, cfg->addr, USBFSOTG_EVT_XFER);
+		usbfsotg_xfer_new_submit(dev, cfg->addr);
 	}
 
 	return 0;
@@ -877,7 +909,9 @@ static int usbfsotg_driver_preinit(const struct device *dev)
 	int err;
 
 	k_mutex_init(&data->mutex);
-	k_fifo_init(&priv->fifo);
+	k_event_init(&priv->events);
+	atomic_clear(&priv->xfer_new);
+	atomic_clear(&priv->xfer_finished);
 
 	for (int i = 0; i < config->num_of_eps; i++) {
 		config->ep_cfg_out[i].caps.out = 1;


### PR DESCRIPTION
Using k_events eliminates the drawback of the queue potentially dropping
messages and provides a reliable event notification mechanism.

With the commit https://github.com/zephyrproject-rtos/zephyr/commit/c3109b9ebe67864b751acbb625922114fa002dae
("usb: device_next: cdc_acm: rx throughput improvements"),
the CDC implementation queues as many buffers as are available.
The default UDC_KINETIS_EVENT_COUNT was set to 4, and it could already
be observed that the events are dropped. Though the number of
UDC_KINETIS_EVENT_COUNT could be increased, using k_events is the right
fix.