### PR TITLE
stm32: phy_u5otghs: automatic CLKSEL determination

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -86,6 +86,5 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &otghs_phy {
-	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
 	status = "okay";
 };

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri-common.dtsi
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri-common.dtsi
@@ -190,6 +190,5 @@ zephyr_udc0: &usbotg_hs {
 	/* Select 32 MHz HSE as OTG HS PHY clock source */
 	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
 		 <&rcc STM32_SRC_HSE OTGHS_SEL(0)>;
-	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_32MHz";
 	status = "okay";
 };

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -264,7 +264,6 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &otghs_phy {
-	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
 	status = "okay";
 };
 

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -273,7 +273,6 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &otghs_phy {
-	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
 	status = "okay";
 };
 

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -301,7 +301,6 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &otghs_phy {
-	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
 	status = "okay";
 };
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1229,6 +1229,10 @@ USB
   their API struct definitions and switch their API instances to ``DEVICE_API(uhc, ...)``.
   (:github:`108414`)
 
+* The ``clock-reference`` property of :dtcompatible:`st,stm32u5-otghs-phy` is now deprecated
+  and should be removed from DTS files; the underlying driver will compute the correct value
+  automatically if the property doesn't exist (and honor it otherwise). (:github:`117882`)
+
 Video
 =====
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -332,6 +332,11 @@ Deprecated APIs and options
   * New :c:func:`sys_clock_idle_enter` hook for handling of entry in low-power state,
     replacing the call to :c:func:`sys_clock_set_timeout` with ``idle=true``.
 
+* :abbr:`USB (Universal Serial Bus)`
+
+  * Deprecated property ``clock-reference`` of :dtcompatible:`st,stm32u5-otghs-phy`.
+    Do not specify the property; it is no longer required by the underlying driver.
+
 * Video
 
   * All functions in the video driver API (``<zephyr/drivers/video.h>``) have moved to the video

--- a/drivers/usb/common/stm32/phy_u5otghs.c
+++ b/drivers/usb/common/stm32/phy_u5otghs.c
@@ -30,8 +30,21 @@
 /* Even though we won't use this macro, define it for grep-ability */
 #define DT_DRV_COMPAT st_stm32u5_otghs_phy
 
+/*
+ * Detect appropriate CLKSEL value automatically based on input clock frequency.
+ * This value must differ from all SYSCFG_OTG_HS_PHY_CLK_SELECT_<n> values!
+ */
+#define CLKSEL_AUTODETECT	0u
+
+/*
+ * Does any PHY node need CLKSEL autodetection?
+ * True if any node lacks the `clock-reference` property.
+ */
+#define ANY_U5OTGHS_PHY_NEEDS_AUTODETECT \
+	!DT_ALL_COMPAT_HAS_PROP_STATUS_OKAY(DT_DRV_COMPAT, clock_reference)
+
 struct stm32_u5otghs_phy_config {
-	uint32_t reference;
+	uint32_t phycr_clksel;
 	uint32_t num_clocks;
 	struct stm32_pclken clocks[];
 };
@@ -41,13 +54,54 @@ static const struct device *rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 static int stm32_u5otghs_phy_enable(const struct stm32_usb_phy *phy)
 {
 	const struct stm32_u5otghs_phy_config *cfg = phy->pcfg;
+	uint32_t clksel;
 	int res;
 
 	/* Enable SYSCFG where PHY configuration registers reside */
 	__HAL_RCC_SYSCFG_CLK_ENABLE();
 
 	/* Configure PHY input frequency selection  */
-	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(cfg->reference);
+	if (ANY_U5OTGHS_PHY_NEEDS_AUTODETECT && cfg->phycr_clksel == CLKSEL_AUTODETECT) {
+		clock_control_subsys_t ck_src;
+		uint32_t phy_ck_freq;
+
+		if (cfg->num_clocks > 1) {
+			ck_src = (clock_control_subsys_t)&cfg->clocks[1];
+		} else {
+			ck_src = (clock_control_subsys_t)&cfg->clocks[0];
+		}
+
+		res = clock_control_get_rate(rcc, ck_src, &phy_ck_freq);
+		if (res != 0) {
+			return res;
+		}
+
+		switch (phy_ck_freq) {
+		case MHZ(16):
+			clksel = SYSCFG_OTG_HS_PHY_CLK_SELECT_1;
+			break;
+		case KHZ(19200):
+			clksel = SYSCFG_OTG_HS_PHY_CLK_SELECT_2;
+			break;
+		case MHZ(20):
+			clksel = SYSCFG_OTG_HS_PHY_CLK_SELECT_3;
+			break;
+		case MHZ(24):
+			clksel = SYSCFG_OTG_HS_PHY_CLK_SELECT_4;
+			break;
+		case MHZ(26):
+			clksel = SYSCFG_OTG_HS_PHY_CLK_SELECT_5;
+			break;
+		case MHZ(32):
+			clksel = SYSCFG_OTG_HS_PHY_CLK_SELECT_6;
+			break;
+		default:
+			return -EINVAL;
+		}
+	} else {
+		clksel = cfg->phycr_clksel;
+	}
+	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(clksel);
 
 	/* Deassert PHY reset */
 	HAL_SYSCFG_EnableOTGPHY(SYSCFG_OTG_HS_PHY_ENABLE);
@@ -76,11 +130,13 @@ static int stm32_u5otghs_phy_disable(const struct stm32_usb_phy *phy)
  * but DT_ENUM_IDX() is zero-based, hence the UTIL_INC().
  */
 #define PHY_CLK_REF(n)	\
-	CONCAT(SYSCFG_OTG_HS_PHY_CLK_SELECT_, UTIL_INC(DT_ENUM_IDX(n, clock_reference)))
+	COND_CODE_0(DT_NODE_HAS_PROP(n, clock_reference),					\
+		(CLKSEL_AUTODETECT),								\
+		(CONCAT(SYSCFG_OTG_HS_PHY_CLK_SELECT_, UTIL_INC(DT_ENUM_IDX(n, clock_reference)))))
 
 #define DEFINE_U5OTGHS_PHY(usb_node, phy_node)							\
 	static const struct stm32_u5otghs_phy_config CONCAT(phy, DT_DEP_ORD(phy_node), _cfg) = {\
-		.reference = PHY_CLK_REF(phy_node),						\
+		.phycr_clksel = PHY_CLK_REF(phy_node),						\
 		.num_clocks = DT_NUM_CLOCKS(phy_node),						\
 		.clocks = STM32_DT_CLOCKS(phy_node)						\
 	};											\

--- a/drivers/usb/common/stm32/phy_u5otghs.c
+++ b/drivers/usb/common/stm32/phy_u5otghs.c
@@ -78,10 +78,6 @@ static int stm32_u5otghs_phy_disable(const struct stm32_usb_phy *phy)
 #define PHY_CLK_REF(n)	\
 	CONCAT(SYSCFG_OTG_HS_PHY_CLK_SELECT_, UTIL_INC(DT_ENUM_IDX(n, clock_reference)))
 
-/*
- * Note that SYSCFG_OTG_HS_PHY_CLK_SELECT goes from 1 to N whereas
- * DT_ENUM_IDX() goes from 0 to (N-1), hence the UTIL_INC()
- */
 #define DEFINE_U5OTGHS_PHY(usb_node, phy_node)							\
 	static const struct stm32_u5otghs_phy_config CONCAT(phy, DT_DEP_ORD(phy_node), _cfg) = {\
 		.reference = PHY_CLK_REF(phy_node),						\

--- a/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
+++ b/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
@@ -39,7 +39,7 @@ properties:
 
   clock-reference:
     type: string
-    required: true
+    deprecated: true
     enum:
       - "SYSCFG_OTG_HS_PHY_CLK_16MHz"
       - "SYSCFG_OTG_HS_PHY_CLK_19.2MHz"
@@ -49,6 +49,10 @@ properties:
       - "SYSCFG_OTG_HS_PHY_CLK_32MHz"
     description: |
       OTG_HS PHY reference clock frequency selection.
+
+      This property is deprecated; it remains only for backwards compatibility and will
+      be removed in a future release. When this property is not present, the correct
+      value is computed automatically at runtime.
 
       This value selects the reference clock frequency to be used in the OTG_HS PHY PLL
       in the SYSCFG OTG_HS PHY register (SYSCFG_OTGHSPHYCR). The selection of this value


### PR DESCRIPTION
Since we can obtain the input frequency of the OTG_HS PHY from clock cells, use them to compute the corresponding CLKSEL value automatically. Includes preliminary and optional cleanup commit (no functional change) + binding update.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/95646

Tested using `samples/subsys/usb/cdc_acm/` on `stm32u5g9j_dk1` with the following DTS modifications (6 distinct configurations, all tested OK):

<details><summary>Details</summary>
<p>

```
/* Configurations 1/2/3: OTG_HS PHY @ 32 MHz / 20 MHz / 16 MHz */
&pll1 {
	/*
	 * VCO = 16 * 20 = 320 MHz
	 * Option A: pll1_p = 320 / 10 = 32 MHz
	 *              ==> can also be used to test 16 MHz via div2
	 * Option B: pll1_p = 320 / 16 = 20 MHz
	 *
	 * pll1_q = pll1_r = 320 / 2 = 160 MHz
	 */
	clocks = <&clk_hse>;
	div-m = <1>;
	mul-n = <20>;
//	div-p = <10>;  // <-- for 32 MHz / 16 MHz
//	div-p = <16>;  // <-- for 20 MHz
	div-q = <2>;
	div-r = <2>;
};

&otghs_phy {
	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
		 <&rcc STM32_SRC_PLL1_P OTGHS_SEL(1)>;
/* For 16 MHz, use instead:
	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
		 <&rcc (STM32_SRC_PLL1_P | STM32_CLOCK_DIV(2)) OTGHS_SEL(3)>;
*/
};
```

```dts
/* Configuration 4: OTG_HS PHY @ 26 MHz */
&pll1 {
	/*
	 * VCO = 16 * 26 = 416 MHz
	 * pll1_p = 416 / 16 = 26 MHz
	 *
	 * pll1_q = pll1_r = 416 / 3 = 138 MHz
	 *   ==> must set RCC clock-frequency = <DT_FREQ_M(138)>
	 */
	clocks = <&clk_hse>;
	div-m = <1>;
	mul-n = <26>;
	div-p = <16>;
	div-q = <3>;
	div-r = <3>;
};

&rcc {
	clock-frequency = <DT_FREQ_M(138)>;
};

&otghs_phy {
	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
		 <&rcc STM32_SRC_PLL1_P OTGHS_SEL(1)>;
};
```

```dts
/* Configuration 5: OTG_HS PHY @ 24 MHz */
&pll1 {
	/*
	 * VCO = 16 * 30 = 480 MHz
	 * pll1_p = 480 / 20 = 24 MHz
	 *
	 * pll1_q = pll1_r = 480 / 3 = 160 MHz
	 */
	clocks = <&clk_hse>;
	div-m = <1>;
	mul-n = <30>;
	div-p = <20>;
	div-q = <3>;
	div-r = <3>;
};

&otghs_phy {
	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
		 <&rcc STM32_SRC_PLL1_P OTGHS_SEL(1)>;
};
```

```dts
/* Configuration 6: OTG_HS PHY @ 19.2 MHz
&pll1 {
	/*
	 * VCO = 16 * 24 = 384 MHz
	 * pll1_p = 384 / 20 = 19.2 MHz
	 *
	 * pll1_q = pll1_r = 384 / 3 = 128 MHz
	 *   ==> must set RCC clock-frequency = <DT_FREQ_M(128)>
	 */
	clocks = <&clk_hse>;
	div-m = <1>;
	mul-n = <24>;
	div-p = <20>;
	div-q = <3>;
	div-r = <3>;

	status = "okay";
};

&rcc {
	clock-frequency = <DT_FREQ_M(128)>;
};

&otghs_phy {
	clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
		 <&rcc STM32_SRC_PLL1_P OTGHS_SEL(1)>;
};
```

</p>
</details> 