### PR TITLE
drivers: can: add support for adding multiple state change callbacks

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -507,6 +507,14 @@ Controller Area Network (CAN)
 * The deprecated ``bus-speed`` and ``bus-speed-data`` CAN controller devicetree properties have
   been removed. Use ``bitrate`` and ``bitrate-data`` instead.
 
+* The CAN controllers driver ops no longer contain a ``can_set_state_change_callback_t`` function
+  pointer as adding/removing callbacks is now handled via the generic
+  :c:func:`can_add_state_change_callback`, and :c:func:`can_remove_state_change_callback` API
+  functions. Out-of-tree drivers can either remove the driver op completely or replace it with
+  ``can_state_change_callbacks_enabled_t`` as needed. Drivers must now use
+  :c:func:`can_fire_state_change_callbacks` for firing CAN controller state change callbacks
+  (:github:`117889`).
+
 Counter
 =======
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -324,6 +324,13 @@ Deprecated APIs and options
     located in the ``drivers/clock_control/Kconfig.nrf`` and  ``modules/hal_nordic/nrfx/Kconfig``
     files.
 
+* Controller Area Network (CAN)
+
+  * :c:func:`can_set_state_change_callback` is deprecated in favor of
+    :c:func:`can_init_state_change_callback`, :c:func:`can_add_state_change_callback`, and
+    :c:func:`can_remove_state_change_callback`. The new API functions allow adding more than one CAN
+    controller state change callback (:github:`117889`).
+
 * CPU Load
 
   * :kconfig:option:`CONFIG_CPU_LOAD_METRIC` and :c:func:`cpu_load_metric_get` are deprecated. The

--- a/drivers/can/can_bflb_bl61x.c
+++ b/drivers/can/can_bflb_bl61x.c
@@ -146,7 +146,6 @@ static DEVICE_API(can, can_bflb_driver_api) = {
 	.add_rx_filter = can_sja1000_add_rx_filter,
 	.remove_rx_filter = can_sja1000_remove_rx_filter,
 	.get_state = can_sja1000_get_state,
-	.set_state_change_callback = can_sja1000_set_state_change_callback,
 	.get_core_clock = can_bflb_get_core_clock,
 	.get_max_filters = can_sja1000_get_max_filters,
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Vestas Wind Systems A/S
  * Copyright (c) 2019 Alexander Wachter
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -121,6 +122,125 @@ int z_impl_can_add_rx_filter_msgq(const struct device *dev, struct k_msgq *msgq,
 {
 
 	return DEVICE_API_GET(can, dev)->add_rx_filter(dev, can_msgq_put, msgq, filter);
+}
+
+/* This is used for emulating the deprecated can_set_state_change_callback() API */
+static void can_state_change_callback_legacy_handler(const struct device *dev,
+						     struct can_state_change_callback *callback,
+						     enum can_state state,
+						     struct can_bus_err_cnt err_cnt)
+{
+	struct can_driver_data *common = (struct can_driver_data *)dev->data;
+	can_state_change_callback_t cb;
+	void *user_data;
+	int key = irq_lock();
+
+	cb = common->legacy_state_change_cb_handler;
+	user_data = common->legacy_state_change_cb_user_data;
+
+	irq_unlock(key);
+
+	if (cb != NULL) {
+		cb(dev, state, err_cnt, user_data);
+	}
+}
+
+/* This is the deprecated can_set_state_change_callback() API */
+void can_set_state_change_callback(const struct device *dev, can_state_change_callback_t callback,
+				   void *user_data)
+{
+	struct can_driver_data *common = (struct can_driver_data *)dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&common->state_change_callback_lock);
+
+	common->legacy_state_change_cb_handler = callback;
+	common->legacy_state_change_cb_user_data = user_data;
+
+	can_init_state_change_callback(&common->legacy_state_change_cb,
+				       can_state_change_callback_legacy_handler);
+
+	k_spin_unlock(&common->state_change_callback_lock, key);
+
+	if (callback != NULL) {
+		(void)can_add_state_change_callback(dev, &common->legacy_state_change_cb);
+	} else {
+		(void)can_remove_state_change_callback(dev, &common->legacy_state_change_cb);
+	}
+}
+
+int can_add_state_change_callback(const struct device *dev,
+				  struct can_state_change_callback *callback)
+{
+	struct can_driver_data *common = (struct can_driver_data *)dev->data;
+	const struct can_driver_api *api = DEVICE_API_GET(can, dev);
+	k_spinlock_key_t key;
+	int err = 0;
+
+	__ASSERT_NO_MSG(callback != NULL);
+	__ASSERT_NO_MSG(callback->handler != NULL);
+
+	key = k_spin_lock(&common->state_change_callback_lock);
+
+	if (api->state_change_callbacks_enabled != NULL) {
+		if (sys_slist_is_empty(&common->state_change_callbacks)) {
+			err = api->state_change_callbacks_enabled(dev, true);
+		}
+	}
+
+	(void)sys_slist_find_and_remove(&common->state_change_callbacks, &callback->node);
+	sys_slist_append(&common->state_change_callbacks, &callback->node);
+
+	k_spin_unlock(&common->state_change_callback_lock, key);
+
+	return err;
+}
+
+int can_remove_state_change_callback(const struct device *dev,
+				     struct can_state_change_callback *callback)
+{
+	struct can_driver_data *common = (struct can_driver_data *)dev->data;
+	const struct can_driver_api *api = DEVICE_API_GET(can, dev);
+	k_spinlock_key_t key;
+	int err = 0;
+
+	__ASSERT_NO_MSG(callback != NULL);
+
+	key = k_spin_lock(&common->state_change_callback_lock);
+
+	if (!sys_slist_find_and_remove(&common->state_change_callbacks, &callback->node)) {
+		err = -EINVAL;
+		goto unlock;
+	}
+
+	if (api->state_change_callbacks_enabled != NULL) {
+		if (sys_slist_is_empty(&common->state_change_callbacks)) {
+			err = api->state_change_callbacks_enabled(dev, false);
+		}
+	}
+
+unlock:
+	k_spin_unlock(&common->state_change_callback_lock, key);
+
+	return err;
+}
+
+void can_fire_state_change_callbacks(const struct device *dev, enum can_state state,
+				     struct can_bus_err_cnt err_cnt)
+{
+	struct can_driver_data *common = (struct can_driver_data *)dev->data;
+	struct can_state_change_callback *cb;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&common->state_change_callback_lock);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&common->state_change_callbacks, cb, node) {
+		__ASSERT_NO_MSG(cb->handler != NULL);
+
+		cb->handler(dev, cb, state, err_cnt);
+	}
+
+	k_spin_unlock(&common->state_change_callback_lock, key);
 }
 
 /**

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -230,7 +230,6 @@ DEVICE_API(can, can_esp32_twai_driver_api) = {
 	.add_rx_filter = can_sja1000_add_rx_filter,
 	.remove_rx_filter = can_sja1000_remove_rx_filter,
 	.get_state = can_sja1000_get_state,
-	.set_state_change_callback = can_sja1000_set_state_change_callback,
 	.get_core_clock = can_esp32_twai_get_core_clock,
 	.get_max_filters = can_sja1000_get_max_filters,
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE

--- a/drivers/can/can_esp32_twaifd.c
+++ b/drivers/can/can_esp32_twaifd.c
@@ -361,25 +361,6 @@ static int can_esp32_twaifd_recover(const struct device *dev, k_timeout_t timeou
 }
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 
-/*
- * The state-change callback is dispatched directly from ISR context, so it
- * must not call blocking Zephyr APIs. This matches the Zephyr CAN API
- * contract for the TX and RX callbacks, which are also invoked from the ISR.
- */
-static void can_esp32_twaifd_set_state_change_callback(const struct device *dev,
-						       can_state_change_callback_t cb,
-						       void *user_data)
-{
-	struct can_esp32_twaifd_data *data = dev->data;
-	unsigned int key;
-
-	/* Pair update atomic vs the ISR reading both fields. */
-	key = irq_lock();
-	data->common.state_change_cb = cb;
-	data->common.state_change_cb_user_data = user_data;
-	irq_unlock(key);
-}
-
 static int can_esp32_twaifd_send(const struct device *dev, const struct can_frame *frame,
 				 k_timeout_t timeout, can_tx_callback_t callback, void *user_data)
 {
@@ -629,8 +610,6 @@ static void IRAM_ATTR can_esp32_twaifd_handle_tx(const struct device *dev)
 static void IRAM_ATTR can_esp32_twaifd_update_state(const struct device *dev, uint32_t events)
 {
 	struct can_esp32_twaifd_data *data = dev->data;
-	can_state_change_callback_t cb;
-	void *user_data;
 	enum can_state new_state = data->state;
 	struct can_bus_err_cnt err_cnt;
 
@@ -675,16 +654,10 @@ static void IRAM_ATTR can_esp32_twaifd_update_state(const struct device *dev, ui
 		}
 	}
 
-	cb = data->common.state_change_cb;
-	user_data = data->common.state_change_cb_user_data;
-	if (cb == NULL) {
-		return;
-	}
-
 	err_cnt.tx_err_cnt = twai_hal_get_tec(&data->hal);
 	err_cnt.rx_err_cnt = twai_hal_get_rec(&data->hal);
 
-	cb(dev, new_state, err_cnt, user_data);
+	can_fire_state_change_callbacks(dev, new_state, err_cnt);
 }
 
 static void IRAM_ATTR can_esp32_twaifd_isr(void *arg)
@@ -737,6 +710,7 @@ static int can_esp32_twaifd_init(const struct device *dev)
 	struct can_timing timing_data = {0};
 #endif
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->lock);
 
 	if (!device_is_ready(cfg->clock_dev)) {
@@ -845,7 +819,6 @@ static DEVICE_API(can, can_esp32_twaifd_api) = {
 	.add_rx_filter = can_esp32_twaifd_add_rx_filter,
 	.remove_rx_filter = can_esp32_twaifd_remove_rx_filter,
 	.get_state = can_esp32_twaifd_get_state,
-	.set_state_change_callback = can_esp32_twaifd_set_state_change_callback,
 	.get_core_clock = can_esp32_twaifd_get_core_clock,
 	.get_max_filters = can_esp32_twaifd_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -50,8 +50,7 @@ DEFINE_FAKE_VALUE_FUNC(int, fake_can_recover, const struct device *, k_timeout_t
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_get_state, const struct device *, enum can_state *,
 		       struct can_bus_err_cnt *);
 
-DEFINE_FAKE_VOID_FUNC(fake_can_set_state_change_callback, const struct device *,
-		      can_state_change_callback_t, void *);
+DEFINE_FAKE_VALUE_FUNC(int, fake_can_state_change_callbacks_enabled, const struct device *, bool);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_get_max_filters, const struct device *, bool);
 
@@ -110,7 +109,7 @@ static void fake_can_reset_rule_before(const struct ztest_unit_test *test, void 
 	RESET_FAKE(fake_can_remove_rx_filter);
 	RESET_FAKE(fake_can_get_state);
 	RESET_FAKE(fake_can_recover);
-	RESET_FAKE(fake_can_set_state_change_callback);
+	RESET_FAKE(fake_can_state_change_callbacks_enabled);
 	RESET_FAKE(fake_can_get_max_filters);
 	RESET_FAKE(fake_can_get_core_clock);
 
@@ -125,6 +124,10 @@ ZTEST_RULE(fake_can_reset_rule, fake_can_reset_rule_before, NULL);
 
 static int fake_can_init(const struct device *dev)
 {
+	struct fake_can_data *data = dev->data;
+
+	sys_slist_init(&data->common.state_change_callbacks);
+
 	/* Install default delegates */
 	fake_can_get_capabilities_fake.custom_fake = fake_can_get_capabilities_delegate;
 	fake_can_get_state_fake.custom_fake = fake_can_get_state_delegate;
@@ -146,7 +149,7 @@ static DEVICE_API(can, fake_can_driver_api) = {
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 	.recover = fake_can_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
-	.set_state_change_callback = fake_can_set_state_change_callback,
+	.state_change_callbacks_enabled = fake_can_state_change_callbacks_enabled,
 	.get_core_clock = fake_can_get_core_clock,
 	.get_max_filters = fake_can_get_max_filters,
 	/* Recommended configuration ranges from CiA 601-2 */

--- a/drivers/can/can_infineon.c
+++ b/drivers/can/can_infineon.c
@@ -179,7 +179,6 @@ static DEVICE_API(can, can_infineon_driver_api) = {
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE*/
 	.get_core_clock = can_infineon_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -140,7 +140,6 @@ DEVICE_API(can, can_kvaser_pci_driver_api) = {
 	.add_rx_filter = can_sja1000_add_rx_filter,
 	.remove_rx_filter = can_sja1000_remove_rx_filter,
 	.get_state = can_sja1000_get_state,
-	.set_state_change_callback = can_sja1000_set_state_change_callback,
 	.get_core_clock = can_kvaser_pci_get_core_clock,
 	.get_max_filters = can_sja1000_get_max_filters,
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -339,15 +339,6 @@ static int can_loopback_get_state(const struct device *dev, enum can_state *stat
 	return 0;
 }
 
-static void can_loopback_set_state_change_callback(const struct device *dev,
-						   can_state_change_callback_t cb,
-						   void *user_data)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cb);
-	ARG_UNUSED(user_data);
-}
-
 static int can_loopback_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	ARG_UNUSED(dev);
@@ -375,7 +366,6 @@ static DEVICE_API(can, can_loopback_driver_api) = {
 	.add_rx_filter = can_loopback_add_rx_filter,
 	.remove_rx_filter = can_loopback_remove_rx_filter,
 	.get_state = can_loopback_get_state,
-	.set_state_change_callback = can_loopback_set_state_change_callback,
 	.get_core_clock = can_loopback_get_core_clock,
 	.get_max_filters = can_loopback_get_max_filters,
 	/* Recommended configuration ranges from CiA 601-2 */
@@ -418,6 +408,7 @@ static int can_loopback_init(const struct device *dev)
 	struct can_loopback_data *data = dev->data;
 	k_tid_t tx_tid;
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->mtx);
 
 	for (int i = 0; i < CONFIG_CAN_LOOPBACK_MAX_FILTERS; i++) {

--- a/drivers/can/can_max32.c
+++ b/drivers/can/can_max32.c
@@ -413,19 +413,12 @@ static void can_max32_remove_rx_filter(const struct device *dev, int filter_idx)
 
 static void can_max32_state_change_handler(const struct device *dev, enum can_state old_state)
 {
-	struct max32_can_data *dev_data = dev->data;
 	struct can_bus_err_cnt err_cnt;
 	enum can_state new_state;
-	can_state_change_callback_t state_change_cb;
-
-	state_change_cb = dev_data->common.state_change_cb;
 
 	can_get_state(dev, &new_state, &err_cnt);
 	if (old_state != new_state) {
-		if (state_change_cb) {
-			state_change_cb(dev, new_state, err_cnt,
-					dev_data->common.state_change_cb_user_data);
-		}
+		can_fire_state_change_callbacks(dev, new_state, err_cnt);
 	}
 }
 
@@ -446,20 +439,6 @@ static int can_max32_get_state(const struct device *dev, enum can_state *state,
 	}
 
 	return 0;
-}
-
-static void can_max32_set_state_change_callback(const struct device *dev,
-						can_state_change_callback_t cb, void *user_data)
-{
-	struct max32_can_data *dev_data = dev->data;
-	unsigned int key;
-
-	key = irq_lock();
-
-	dev_data->common.state_change_cb = cb;
-	dev_data->common.state_change_cb_user_data = user_data;
-
-	irq_unlock(key);
 }
 
 static int can_max32_get_max_filters(const struct device *dev, bool ide)
@@ -609,6 +588,7 @@ static int can_max32_init(const struct device *dev)
 	struct can_timing timing = {0};
 	int ret = 0;
 
+	sys_slist_init(&dev_data->common.state_change_callbacks);
 	k_mutex_init(&dev_data->inst_mutex);
 	k_sem_init(&dev_data->tx_sem, 1, 1);
 
@@ -697,7 +677,6 @@ static DEVICE_API(can, can_max32_api) = {
 	.recover = can_max32_recover,
 #endif
 	.get_state = can_max32_get_state,
-	.set_state_change_callback = can_max32_set_state_change_callback,
 	.get_core_clock = can_max32_get_core_clock,
 	.get_max_filters = can_max32_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -475,8 +475,6 @@ static void can_mcan_state_change_handler(const struct device *dev)
 {
 	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	const can_state_change_callback_t state_cb = data->common.state_change_cb;
-	void *state_cb_data = data->common.state_change_cb_user_data;
 	const struct can_mcan_callbacks *cbs = config->callbacks;
 	can_tx_callback_t tx_cb;
 	struct can_bus_err_cnt err_cnt;
@@ -489,9 +487,7 @@ static void can_mcan_state_change_handler(const struct device *dev)
 		return;
 	}
 
-	if (state_cb != NULL) {
-		state_cb(dev, state, err_cnt, state_cb_data);
-	}
+	can_fire_state_change_callbacks(dev, state, err_cnt);
 
 	if (state == CAN_STATE_BUS_OFF) {
 		/* Request all TX buffers to be cancelled */
@@ -1257,15 +1253,6 @@ void can_mcan_remove_rx_filter(const struct device *dev, int filter_id)
 	}
 
 	k_mutex_unlock(&data->lock);
-}
-
-void can_mcan_set_state_change_callback(const struct device *dev,
-					can_state_change_callback_t callback, void *user_data)
-{
-	struct can_mcan_data *data = dev->data;
-
-	data->common.state_change_cb = callback;
-	data->common.state_change_cb_user_data = user_data;
 }
 
 /* helper function allowing mcan drivers without access to private mcan

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -1374,6 +1374,8 @@ struct can_mcan_config {
  */
 #define CAN_MCAN_DATA_DEFINE(_name, _custom)                                                       \
 	static struct can_mcan_data _name = {                                                      \
+		.common.state_change_callbacks =                                                   \
+			SYS_SLIST_STATIC_INIT(_name.common.state_change_callbacks),                \
 		.lock = Z_MUTEX_INITIALIZER(_name.lock),                                           \
 		.tx_mtx = Z_MUTEX_INITIALIZER(_name.tx_mtx),                                       \
 		.custom = _custom,                                                                 \
@@ -1727,12 +1729,5 @@ void can_mcan_remove_rx_filter(const struct device *dev, int filter_id);
  */
 int can_mcan_get_state(const struct device *dev, enum can_state *state,
 		       struct can_bus_err_cnt *err_cnt);
-
-/**
- * @brief Bosch M_CAN driver callback API upon setting a state change callback
- * See @a can_set_state_change_callback() for argument description
- */
-void can_mcan_set_state_change_callback(const struct device *dev,
-					can_state_change_callback_t callback, void *user_data);
 
 #endif /* ZEPHYR_DRIVERS_CAN_CAN_MCAN_H_ */

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -658,15 +658,6 @@ static void mcp2515_remove_rx_filter(const struct device *dev, int filter_id)
 	k_mutex_unlock(&dev_data->mutex);
 }
 
-static void mcp2515_set_state_change_callback(const struct device *dev,
-					      can_state_change_callback_t cb, void *user_data)
-{
-	struct mcp2515_data *dev_data = dev->data;
-
-	dev_data->common.state_change_cb = cb;
-	dev_data->common.state_change_cb_user_data = user_data;
-}
-
 static void mcp2515_rx_filter(const struct device *dev, struct can_frame *frame)
 {
 	struct mcp2515_data *dev_data = dev->data;
@@ -777,21 +768,19 @@ static int mcp2515_get_state(const struct device *dev, enum can_state *state,
 static void mcp2515_handle_errors(const struct device *dev)
 {
 	struct mcp2515_data *dev_data = dev->data;
-	can_state_change_callback_t state_change_cb = dev_data->common.state_change_cb;
-	void *state_change_cb_data = dev_data->common.state_change_cb_user_data;
 	enum can_state state;
 	struct can_bus_err_cnt err_cnt;
 	int err;
 
-	err = mcp2515_get_state(dev, &state, state_change_cb ? &err_cnt : NULL);
+	err = mcp2515_get_state(dev, &state, &err_cnt);
 	if (err != 0) {
 		LOG_ERR("Failed to get CAN controller state [%d]", err);
 		return;
 	}
 
-	if (state_change_cb && dev_data->old_state != state) {
+	if (dev_data->old_state != state) {
 		dev_data->old_state = state;
-		state_change_cb(dev, state, err_cnt, state_change_cb_data);
+		can_fire_state_change_callbacks(dev, state, err_cnt);
 	}
 }
 
@@ -898,7 +887,6 @@ static DEVICE_API(can, can_api_funcs) = {
 	.add_rx_filter = mcp2515_add_rx_filter,
 	.remove_rx_filter = mcp2515_remove_rx_filter,
 	.get_state = mcp2515_get_state,
-	.set_state_change_callback = mcp2515_set_state_change_callback,
 	.get_core_clock = mcp2515_get_core_clock,
 	.get_max_filters = mcp2515_get_max_filters,
 	.timing_min = {
@@ -925,6 +913,7 @@ static int mcp2515_init(const struct device *dev)
 	k_tid_t tid;
 	int ret;
 
+	sys_slist_init(&dev_data->common.state_change_callbacks);
 	k_sem_init(&dev_data->int_sem, 0, 1);
 	k_mutex_init(&dev_data->mutex);
 	k_sem_init(&dev_data->tx_sem, MCP2515_TX_CNT, MCP2515_TX_CNT);

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -659,15 +659,6 @@ done:
 	k_mutex_unlock(&dev_data->mutex);
 }
 
-static void mcp251xfd_set_state_change_callback(const struct device *dev,
-						can_state_change_callback_t cb, void *user_data)
-{
-	struct mcp251xfd_data *dev_data = dev->data;
-
-	dev_data->common.state_change_cb = cb;
-	dev_data->common.state_change_cb_user_data = user_data;
-}
-
 static int mcp251xfd_get_state(const struct device *dev, enum can_state *state,
 			       struct can_bus_err_cnt *err_cnt)
 {
@@ -905,10 +896,7 @@ static int mcp251xfd_handle_cerrif(const struct device *dev)
 		mcp251xfd_reset_tx_fifos(dev, -ENETDOWN);
 	}
 
-	if (dev_data->common.state_change_cb) {
-		dev_data->common.state_change_cb(dev, new_state, err_cnt,
-						 dev_data->common.state_change_cb_user_data);
-	}
+	can_fire_state_change_callbacks(dev, new_state, err_cnt);
 
 done:
 	k_mutex_unlock(&dev_data->mutex);
@@ -1540,6 +1528,7 @@ static int mcp251xfd_init(const struct device *dev)
 		}
 	}
 
+	sys_slist_init(&dev_data->common.state_change_callbacks);
 	k_sem_init(&dev_data->int_sem, 0, 1);
 	k_sem_init(&dev_data->tx_sem, MCP251XFD_TX_QUEUE_ITEMS, MCP251XFD_TX_QUEUE_ITEMS);
 
@@ -1720,7 +1709,6 @@ static DEVICE_API(can, mcp251xfd_api_funcs) = {
 	.add_rx_filter = mcp251xfd_add_rx_filter,
 	.remove_rx_filter = mcp251xfd_remove_rx_filter,
 	.get_state = mcp251xfd_get_state,
-	.set_state_change_callback = mcp251xfd_set_state_change_callback,
 	.get_core_clock = mcp251xfd_get_core_clock,
 	.get_max_filters = mcp251xfd_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -856,16 +856,6 @@ unlock:
 	return alloc;
 }
 
-static void mcux_flexcan_set_state_change_callback(const struct device *dev,
-						   can_state_change_callback_t callback,
-						   void *user_data)
-{
-	struct mcux_flexcan_data *data = dev->data;
-
-	data->common.state_change_cb = callback;
-	data->common.state_change_cb_user_data = user_data;
-}
-
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 static int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 {
@@ -947,8 +937,6 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	CAN_Type *base = get_base(dev);
-	const can_state_change_callback_t cb = data->common.state_change_cb;
-	void *cb_data = data->common.state_change_cb_user_data;
 	can_tx_callback_t function;
 	void *arg;
 	int alloc;
@@ -982,10 +970,7 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 	(void)mcux_flexcan_get_state(dev, &state, &err_cnt);
 	if (data->state != state) {
 		data->state = state;
-
-		if (cb != NULL) {
-			cb(dev, state, err_cnt, cb_data);
-		}
+		can_fire_state_change_callbacks(dev, state, err_cnt);
 	}
 
 	if (state == CAN_STATE_BUS_OFF) {
@@ -1196,6 +1181,7 @@ static int mcux_flexcan_init(const struct device *dev)
 	LOG_DBG("Message Buffers: %d, RX MB: %d, TX MB: %d",
 		 config->number_of_mb, config->rx_mb, config->tx_mb);
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->rx_mutex);
 	k_mutex_init(&data->tx_mutex);
 	k_sem_init(&data->tx_allocs_sem, config->tx_mb, config->tx_mb);
@@ -1327,7 +1313,6 @@ static DEVICE_API(can, mcux_flexcan_driver_api) __maybe_unused = {
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 	.recover = mcux_flexcan_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
-	.set_state_change_callback = mcux_flexcan_set_state_change_callback,
 	.get_core_clock = mcux_flexcan_get_core_clock,
 	.get_max_filters = mcux_flexcan_get_max_filters,
 	/*
@@ -1370,7 +1355,6 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 	.recover = mcux_flexcan_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
-	.set_state_change_callback = mcux_flexcan_set_state_change_callback,
 	.get_core_clock = mcux_flexcan_get_core_clock,
 	.get_max_filters = mcux_flexcan_get_max_filters,
 	/*

--- a/drivers/can/can_mspm0_canfd.c
+++ b/drivers/can/can_mspm0_canfd.c
@@ -243,7 +243,6 @@ static DEVICE_API(can, can_mspm0_canfd_driver_api) = {
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_core_clock = can_mspm0_canfd_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -376,15 +376,6 @@ static int can_native_linux_get_state(const struct device *dev, enum can_state *
 	return 0;
 }
 
-static void can_native_linux_set_state_change_callback(const struct device *dev,
-						       can_state_change_callback_t cb,
-						       void *user_data)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cb);
-	ARG_UNUSED(user_data);
-}
-
 static int can_native_linux_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	ARG_UNUSED(dev);
@@ -412,7 +403,6 @@ static DEVICE_API(can, can_native_linux_driver_api) = {
 	.add_rx_filter = can_native_linux_add_rx_filter,
 	.remove_rx_filter = can_native_linux_remove_rx_filter,
 	.get_state = can_native_linux_get_state,
-	.set_state_change_callback = can_native_linux_set_state_change_callback,
 	.get_core_clock = can_native_linux_get_core_clock,
 	.get_max_filters = can_native_linux_get_max_filters,
 	/* Recommended configuration ranges from CiA 601-2 */
@@ -456,6 +446,7 @@ static int can_native_linux_init(const struct device *dev)
 	struct can_native_linux_data *data = dev->data;
 	const char *if_name;
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->filter_mutex);
 	k_sem_init(&data->tx_idle, 1, 1);
 

--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -74,7 +74,6 @@ static DEVICE_API(can, can_nrf_api) = {
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_core_clock = can_nrf_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -150,7 +150,6 @@ static DEVICE_API(can, can_numaker_driver_api) = {
 	.recover = can_mcan_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_state = can_mcan_get_state,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.get_core_clock = can_numaker_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,

--- a/drivers/can/can_nxp_lpc_mcan.c
+++ b/drivers/can/can_nxp_lpc_mcan.c
@@ -178,7 +178,6 @@ static DEVICE_API(can, nxp_lpc_mcan_driver_api) = {
 	.recover = can_mcan_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_state = can_mcan_get_state,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.get_core_clock = nxp_lpc_mcan_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
 	/*

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -430,16 +430,6 @@ static int can_nxp_s32_get_state(const struct device *dev, enum can_state *state
 	return 0;
 }
 
-static void can_nxp_s32_set_state_change_callback(const struct device *dev,
-							can_state_change_callback_t callback,
-							void *user_data)
-{
-	struct can_nxp_s32_data *data = dev->data;
-
-	data->common.state_change_cb = callback;
-	data->common.state_change_cb_user_data = user_data;
-}
-
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 static int can_nxp_s32_recover(const struct device *dev, k_timeout_t timeout)
 {
@@ -839,7 +829,6 @@ static void can_nxp_s32_err_callback(const struct device *dev,
 	struct can_nxp_s32_data *data = dev->data;
 	enum can_state state;
 	struct can_bus_err_cnt err_cnt;
-	void *cb_data = data->common.state_change_cb_user_data;
 	can_tx_callback_t function;
 	int alloc;
 	void *arg;
@@ -892,9 +881,7 @@ static void can_nxp_s32_err_callback(const struct device *dev,
 	can_nxp_s32_get_state(dev, &state, &err_cnt);
 	if (data->state != state) {
 		data->state = state;
-		if (data->common.state_change_cb) {
-			data->common.state_change_cb(dev, state, err_cnt, cb_data);
-		}
+		can_fire_state_change_callbacks(dev, state, err_cnt);
 	}
 
 	if (state == CAN_STATE_BUS_OFF) {
@@ -1137,6 +1124,7 @@ static int can_nxp_s32_init(const struct device *dev)
 		return err;
 	}
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->rx_mutex);
 	k_mutex_init(&data->tx_mutex);
 	k_sem_init(&data->tx_allocs_sem, CONFIG_CAN_NXP_S32_MAX_TX, CONFIG_CAN_NXP_S32_MAX_TX);
@@ -1273,7 +1261,6 @@ static DEVICE_API(can, can_nxp_s32_driver_api) = {
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 	.recover = can_nxp_s32_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
-	.set_state_change_callback = can_nxp_s32_set_state_change_callback,
 	.get_core_clock = can_nxp_s32_get_core_clock,
 	.get_max_filters = can_nxp_s32_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -235,8 +235,6 @@ static void can_rcar_state_change(const struct device *dev, uint32_t newstate)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
-	const can_state_change_callback_t cb = data->common.state_change_cb;
-	void *state_change_cb_data = data->common.state_change_cb_user_data;
 	struct can_bus_err_cnt err_cnt;
 
 	if (data->state == newstate) {
@@ -247,11 +245,9 @@ static void can_rcar_state_change(const struct device *dev, uint32_t newstate)
 
 	data->state = newstate;
 
-	if (cb == NULL) {
-		return;
-	}
 	can_rcar_get_error_count(config, &err_cnt);
-	cb(dev, newstate, err_cnt, state_change_cb_data);
+
+	can_fire_state_change_callbacks(dev, newstate, err_cnt);
 }
 
 static void can_rcar_error(const struct device *dev)
@@ -790,16 +786,6 @@ unlock:
 	return ret;
 }
 
-static void can_rcar_set_state_change_callback(const struct device *dev,
-					       can_state_change_callback_t cb,
-					       void *user_data)
-{
-	struct can_rcar_data *data = dev->data;
-
-	data->common.state_change_cb = cb;
-	data->common.state_change_cb_user_data = user_data;
-}
-
 static int can_rcar_get_state(const struct device *dev, enum can_state *state,
 			      struct can_bus_err_cnt *err_cnt)
 {
@@ -1010,6 +996,7 @@ static int can_rcar_init(const struct device *dev)
 	int ret;
 	uint16_t ctlr;
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->inst_mutex);
 	k_mutex_init(&data->rx_mutex);
 	k_sem_init(&data->tx_sem, RCAR_CAN_FIFO_DEPTH, RCAR_CAN_FIFO_DEPTH);
@@ -1020,8 +1007,6 @@ static int can_rcar_init(const struct device *dev)
 
 	memset(data->rx_callback, 0, sizeof(data->rx_callback));
 	data->state = CAN_STATE_ERROR_ACTIVE;
-	data->common.state_change_cb = NULL;
-	data->common.state_change_cb_user_data = NULL;
 
 	if (config->common.phy != NULL && !device_is_ready(config->common.phy)) {
 		LOG_ERR_DEVICE_NOT_READY(config->common.phy);
@@ -1158,7 +1143,6 @@ static DEVICE_API(can, can_rcar_driver_api) = {
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 	.recover = can_rcar_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
-	.set_state_change_callback = can_rcar_set_state_change_callback,
 	.get_core_clock = can_rcar_get_core_clock,
 	.get_max_filters = can_rcar_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_rcar_rscanfd.c
+++ b/drivers/can/can_rcar_rscanfd.c
@@ -657,7 +657,6 @@ static void can_rcar_rscanfd_get_error_count(const struct device *dev,
 static void can_rcar_rscanfd_state_change(const struct device *dev, uint32_t new_state)
 {
 	struct can_rcar_rscanfd_data *data = dev->data;
-	const can_state_change_callback_t callback = data->common.state_change_cb;
 	struct can_bus_err_cnt err_cnt;
 
 	if (data->state == new_state) {
@@ -668,10 +667,8 @@ static void can_rcar_rscanfd_state_change(const struct device *dev, uint32_t new
 
 	data->state = new_state;
 
-	if (callback != NULL) {
-		can_rcar_rscanfd_get_error_count(dev, &err_cnt);
-		callback(dev, new_state, err_cnt, data->common.state_change_cb_user_data);
-	}
+	can_rcar_rscanfd_get_error_count(dev, &err_cnt);
+	can_fire_state_change_callbacks(dev, new_state, err_cnt);
 }
 
 static int can_rcar_rscanfd_get_capabilities(const struct device *dev, can_mode_t *cap)
@@ -1211,20 +1208,6 @@ static int can_rcar_rscanfd_get_state(const struct device *dev, enum can_state *
 	return 0;
 }
 
-static void can_rcar_rscanfd_set_state_change_callback(const struct device *dev,
-						       can_state_change_callback_t callback,
-						       void *user_data)
-{
-	struct can_rcar_rscanfd_data *data = dev->data;
-
-	k_mutex_lock(&data->inst_mutex, K_FOREVER);
-
-	data->common.state_change_cb = callback;
-	data->common.state_change_cb_user_data = user_data;
-
-	k_mutex_unlock(&data->inst_mutex);
-}
-
 static int can_rcar_rscanfd_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	const struct can_rcar_rscanfd_config *config = dev->config;
@@ -1622,6 +1605,7 @@ static int can_rcar_rscanfd_init(const struct device *dev)
 	can_rcar_rscanfd_configure_timing_data(dev, &timing);
 #endif
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->inst_mutex);
 	k_sem_init(&data->tx_sem, CAN_RCAR_RSCANFD_TX_QUEUE_BUFFERS_COUNT,
 		CAN_RCAR_RSCANFD_TX_QUEUE_BUFFERS_COUNT);
@@ -1689,7 +1673,6 @@ static DEVICE_API(can, can_rcar_rscanfd_driver_api) = {
 	.recover = can_rcar_rscanfd_recover,
 #endif
 	.get_state = can_rcar_rscanfd_get_state,
-	.set_state_change_callback = can_rcar_rscanfd_set_state_change_callback,
 	.get_core_clock = can_rcar_rscanfd_get_core_clock,
 	.get_max_filters = can_rcar_rscanfd_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_realtek_bee.c
+++ b/drivers/can/can_realtek_bee.c
@@ -176,8 +176,6 @@ static void can_bee_update_state(const struct device *dev)
 	struct can_bee_data *data = dev->data;
 	struct can_bus_err_cnt err_cnt;
 	enum can_state state;
-	can_state_change_callback_t cb;
-	void *user_data;
 
 	can_bee_get_state(dev, &state, &err_cnt);
 
@@ -187,12 +185,7 @@ static void can_bee_update_state(const struct device *dev)
 
 	data->state = state;
 
-	cb = data->common.state_change_cb;
-	user_data = data->common.state_change_cb_user_data;
-
-	if (cb != NULL) {
-		cb(dev, state, err_cnt, user_data);
-	}
+	can_fire_state_change_callbacks(dev, state, err_cnt);
 }
 
 static int can_bee_start(const struct device *dev)
@@ -629,17 +622,6 @@ unlock:
 	k_mutex_unlock(&data->inst_mutex);
 }
 
-static void can_bee_set_state_change_callback(const struct device *dev,
-					      can_state_change_callback_t cb, void *user_data)
-{
-	struct can_bee_data *data = dev->data;
-	unsigned int key = irq_lock();
-
-	data->common.state_change_cb = cb;
-	data->common.state_change_cb_user_data = user_data;
-	irq_unlock(key);
-}
-
 static int can_bee_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	ARG_UNUSED(dev);
@@ -804,6 +786,7 @@ static int can_bee_init(const struct device *dev)
 	CAN_InitTypeDef *init_struct = &data->init_struct;
 	int ret;
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->inst_mutex);
 	k_sem_init(&data->tx_int_sem, CONFIG_CAN_REALTEK_BEE_TX_MSG_BUF_NUM,
 		   CONFIG_CAN_REALTEK_BEE_TX_MSG_BUF_NUM);
@@ -871,7 +854,6 @@ static DEVICE_API(can, can_bee_driver_api) = {
 	.add_rx_filter = can_bee_add_rx_filter,
 	.remove_rx_filter = can_bee_remove_rx_filter,
 	.get_state = can_bee_get_state,
-	.set_state_change_callback = can_bee_set_state_change_callback,
 	.get_core_clock = can_bee_get_core_clock,
 	.get_max_filters = can_bee_get_max_filters,
 	/* clang-format off */

--- a/drivers/can/can_renesas_ra.c
+++ b/drivers/can/can_renesas_ra.c
@@ -404,7 +404,7 @@ static inline void can_renesas_ra_call_state_change_cb(const struct device *dev,
 		.tx_err_cnt = can_info.error_count_transmit,
 	};
 
-	data->common.state_change_cb(dev, state, err_cnt, data->common.state_change_cb_user_data);
+	can_fire_state_change_callbacks(dev, state, err_cnt);
 }
 
 static int can_renesas_ra_get_capabilities(const struct device *dev, can_mode_t *cap)
@@ -744,9 +744,7 @@ static int can_renesas_ra_get_state(const struct device *dev, enum can_state *st
 	return 0;
 }
 
-static void can_renesas_ra_set_state_change_callback(const struct device *dev,
-						     can_state_change_callback_t callback,
-						     void *user_data)
+static int can_renesas_ra_state_change_callbacks_enabled(const struct device *dev, bool enabled)
 {
 	struct can_renesas_ra_data *data = dev->data;
 	canfd_instance_ctrl_t *p_ctrl = data->fsp_can.p_ctrl;
@@ -754,7 +752,7 @@ static void can_renesas_ra_set_state_change_callback(const struct device *dev,
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 
-	if (callback != NULL) {
+	if (enabled) {
 		/* Enable state change interrupt */
 		p_ctrl->p_reg->CFDC->CTR |= (uint32_t)CANFD_CFG_ERR_IRQ;
 	} else {
@@ -767,12 +765,11 @@ static void can_renesas_ra_set_state_change_callback(const struct device *dev,
 			  BIT(R_CANFD_CFDC_ERFL_EPF_Pos) | BIT(R_CANFD_CFDC_ERFL_BEF_Pos));
 	}
 
-	data->common.state_change_cb = callback;
-	data->common.state_change_cb_user_data = user_data;
-
 	k_mutex_unlock(&data->inst_mutex);
 
 	irq_unlock(key);
+
+	return 0;
 }
 
 static int can_renesas_ra_get_core_clock(const struct device *dev, uint32_t *rate)
@@ -963,6 +960,7 @@ static int can_renesas_ra_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->inst_mutex);
 	k_sem_init(&data->tx_sem, 1, 1);
 	data->common.started = false;
@@ -1027,7 +1025,7 @@ static DEVICE_API(can, can_renesas_ra_driver_api) = {
 	.recover = can_renesas_ra_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_state = can_renesas_ra_get_state,
-	.set_state_change_callback = can_renesas_ra_set_state_change_callback,
+	.state_change_callbacks_enabled = can_renesas_ra_state_change_callbacks_enabled,
 	.get_core_clock = can_renesas_ra_get_core_clock,
 	.get_max_filters = can_renesas_ra_get_max_filters,
 	.timing_min = CAN_RENESAS_RA_TIMING_MIN,

--- a/drivers/can/can_renesas_rz_canfd.c
+++ b/drivers/can/can_renesas_rz_canfd.c
@@ -365,7 +365,7 @@ static inline void can_renesas_rz_call_state_change_cb(const struct device *dev,
 		.tx_err_cnt = can_info.error_count_transmit,
 	};
 
-	data->common.state_change_cb(dev, state, err_cnt, data->common.state_change_cb_user_data);
+	can_fire_state_change_callbacks(dev, state, err_cnt);
 }
 
 static int can_renesas_rz_get_capabilities(const struct device *dev, can_mode_t *cap)
@@ -686,9 +686,7 @@ static int can_renesas_rz_get_state(const struct device *dev, enum can_state *st
 	return 0;
 }
 
-static void can_renesas_rz_set_state_change_callback(const struct device *dev,
-						     can_state_change_callback_t callback,
-						     void *user_data)
+static int can_renesas_rz_state_change_callbacks_enabled(const struct device *dev, bool enabled)
 {
 	struct can_renesas_rz_data *data = dev->data;
 	canfd_instance_ctrl_t *p_ctrl = data->fsp_ctrl;
@@ -696,7 +694,7 @@ static void can_renesas_rz_set_state_change_callback(const struct device *dev,
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 
-	if (callback != NULL) {
+	if (enabled) {
 		/* Enable state change interrupt */
 		p_ctrl->p_reg->CFDC->CTR |= (uint32_t)CANFD_CFG_ERR_IRQ;
 	} else {
@@ -709,12 +707,11 @@ static void can_renesas_rz_set_state_change_callback(const struct device *dev,
 			  BIT(R_CANFD_CFDC_ERFL_EPF_Pos) | BIT(R_CANFD_CFDC_ERFL_BEF_Pos));
 	}
 
-	data->common.state_change_cb = callback;
-	data->common.state_change_cb_user_data = user_data;
-
 	k_mutex_unlock(&data->inst_mutex);
 
 	irq_unlock(key);
+
+	return 0;
 }
 
 static int can_renesas_rz_get_core_clock(const struct device *dev, uint32_t *rate)
@@ -845,6 +842,7 @@ static int can_renesas_rz_init(const struct device *dev)
 	canfd_extended_cfg_t *p_extend = (canfd_extended_cfg_t *)data->fsp_cfg->p_extend;
 	int ret = 0;
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->inst_mutex);
 	k_sem_init(&data->tx_sem, 1, 1);
 	data->common.started = false;
@@ -899,7 +897,7 @@ static DEVICE_API(can, can_renesas_rz_driver_api) = {
 	.recover = can_renesas_rz_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_state = can_renesas_rz_get_state,
-	.set_state_change_callback = can_renesas_rz_set_state_change_callback,
+	.state_change_callbacks_enabled = can_renesas_rz_state_change_callbacks_enabled,
 	.get_core_clock = can_renesas_rz_get_core_clock,
 	.get_max_filters = can_renesas_rz_get_max_filters,
 	.timing_min = CAN_RENESAS_RZ_TIMING_MIN,

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -173,7 +173,6 @@ static DEVICE_API(can, can_sam_driver_api) = {
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_core_clock = can_sam_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.set_state_change_callback =  can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -180,7 +180,6 @@ static DEVICE_API(can, can_sam0_driver_api) = {
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_core_clock = can_sam0_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.set_state_change_callback =  can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -538,15 +538,6 @@ int can_sja1000_get_state(const struct device *dev, enum can_state *state,
 	return 0;
 }
 
-void can_sja1000_set_state_change_callback(const struct device *dev,
-					   can_state_change_callback_t callback, void *user_data)
-{
-	struct can_sja1000_data *data = dev->data;
-
-	data->common.state_change_cb = callback;
-	data->common.state_change_cb_user_data = user_data;
-}
-
 int can_sja1000_get_max_filters(const struct device *dev, bool ide)
 {
 	ARG_UNUSED(dev);
@@ -693,8 +684,6 @@ static void can_sja1000_handle_error_passive_irq(const struct device *dev)
 void can_sja1000_isr(const struct device *dev)
 {
 	struct can_sja1000_data *data = dev->data;
-	const can_state_change_callback_t cb = data->common.state_change_cb;
-	void *cb_data = data->common.state_change_cb_user_data;
 	enum can_state prev_state = data->state;
 	struct can_bus_err_cnt err_cnt;
 	uint8_t ir;
@@ -727,10 +716,11 @@ void can_sja1000_isr(const struct device *dev)
 		can_sja1000_handle_error_passive_irq(dev);
 	}
 
-	if (prev_state != data->state && cb != NULL) {
+	if (prev_state != data->state) {
 		err_cnt.rx_err_cnt = can_sja1000_read_reg(dev, CAN_SJA1000_RXERR);
 		err_cnt.tx_err_cnt = can_sja1000_read_reg(dev, CAN_SJA1000_TXERR);
-		cb(dev, data->state, err_cnt, cb_data);
+
+		can_fire_state_change_callbacks(dev, data->state, err_cnt);
 	}
 }
 
@@ -751,6 +741,7 @@ int can_sja1000_init(const struct device *dev)
 		}
 	}
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&data->mod_lock);
 	k_sem_init(&data->tx_idle, 1, 1);
 

--- a/drivers/can/can_sja1000.h
+++ b/drivers/can/can_sja1000.h
@@ -250,13 +250,6 @@ int can_sja1000_get_state(const struct device *dev, enum can_state *state,
 			  struct can_bus_err_cnt *err_cnt);
 
 /**
- * @brief SJA1000 callback API upon setting a state change callback
- * See @a can_set_state_change_callback() for argument description
- */
-void can_sja1000_set_state_change_callback(const struct device *dev,
-					   can_state_change_callback_t callback, void *user_data);
-
-/**
  * @brief SJA1000 callback API upon getting the maximum number of concurrent CAN RX filters
  * See @a can_get_max_filters() for argument description
  */

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -189,8 +189,6 @@ static inline void can_stm32_bus_state_change_isr(const struct device *dev)
 	struct can_stm32_data *data = dev->data;
 	struct can_bus_err_cnt err_cnt;
 	enum can_state state;
-	const can_state_change_callback_t cb = data->common.state_change_cb;
-	void *state_change_cb_data = data->common.state_change_cb_user_data;
 
 #ifdef CONFIG_CAN_STATS
 	const struct can_stm32_config *cfg = dev->config;
@@ -228,9 +226,7 @@ static inline void can_stm32_bus_state_change_isr(const struct device *dev)
 	if (state != data->state) {
 		data->state = state;
 
-		if (cb != NULL) {
-			cb(dev, state, err_cnt, state_change_cb_data);
-		}
+		can_fire_state_change_callbacks(dev, state, err_cnt);
 	}
 }
 
@@ -601,6 +597,7 @@ static int can_stm32_init(const struct device *dev)
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int ret;
 
+	sys_slist_init(&data->common.state_change_callbacks);
 	k_mutex_init(&filter_mutex);
 	k_mutex_init(&data->inst_mutex);
 	k_sem_init(&data->tx_int_sem, 0, 1);
@@ -691,22 +688,18 @@ static int can_stm32_init(const struct device *dev)
 	return 0;
 }
 
-static void can_stm32_set_state_change_callback(const struct device *dev,
-						can_state_change_callback_t cb,
-						void *user_data)
+static int can_stm32_state_change_callbacks_enabled(const struct device *dev, bool enabled)
 {
-	struct can_stm32_data *data = dev->data;
 	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
 
-	data->common.state_change_cb = cb;
-	data->common.state_change_cb_user_data = user_data;
-
-	if (cb == NULL) {
-		can->IER &= ~(CAN_IER_BOFIE | CAN_IER_EPVIE | CAN_IER_EWGIE);
-	} else {
+	if (enabled) {
 		can->IER |= CAN_IER_BOFIE | CAN_IER_EPVIE | CAN_IER_EWGIE;
+	} else {
+		can->IER &= ~(CAN_IER_BOFIE | CAN_IER_EPVIE | CAN_IER_EWGIE);
 	}
+
+	return 0;
 }
 
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
@@ -1086,7 +1079,7 @@ static DEVICE_API(can, can_api_funcs) = {
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 	.recover = can_stm32_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
-	.set_state_change_callback = can_stm32_set_state_change_callback,
+	.state_change_callbacks_enabled = can_stm32_state_change_callbacks_enabled,
 	.get_core_clock = can_stm32_get_core_clock,
 	.get_max_filters = can_stm32_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -558,7 +558,6 @@ static DEVICE_API(can, can_stm32fd_driver_api) = {
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_core_clock = can_stm32fd_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -214,7 +214,6 @@ static DEVICE_API(can, can_stm32h7_driver_api) = {
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE*/
 	.get_core_clock = can_stm32h7_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	/* Timing limits are per the STM32H7 Reference Manual (RM0433 Rev 7),
 	 * section 56.5.7, FDCAN nominal bit timing and prescaler register
 	 * (FDCAN_NBTP).

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -850,7 +850,6 @@ static DEVICE_API(can, tcan4x5x_driver_api) = {
 	.recover = can_mcan_recover,
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 	.get_state = can_mcan_get_state,
-	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.get_core_clock = tcan4x5x_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,

--- a/drivers/can/can_xmc4xxx.c
+++ b/drivers/can/can_xmc4xxx.c
@@ -434,19 +434,6 @@ static void can_xmc4xxx_remove_rx_filter(const struct device *dev, int filter_id
 	k_mutex_unlock(&dev_data->mutex);
 }
 
-static void can_xmc4xxx_set_state_change_callback(const struct device *dev,
-						  can_state_change_callback_t cb, void *user_data)
-{
-	struct can_xmc4xxx_data *dev_data = dev->data;
-	unsigned int key;
-
-	key = irq_lock();
-	/* critical section so that state_change_cb and state_change_cb_data are consistent */
-	dev_data->common.state_change_cb = cb;
-	dev_data->common.state_change_cb_user_data = user_data;
-	irq_unlock(key);
-}
-
 static void can_xmc4xxx_get_state_from_status(const struct device *dev, enum can_state *state,
 					      struct can_bus_err_cnt *err_cnt, uint32_t *status)
 {
@@ -665,11 +652,7 @@ static void can_xmc4xxx_state_change_handler(const struct device *dev, uint32_t 
 
 	can_xmc4xxx_get_state_from_status(dev, &new_state, &err_cnt, &status);
 	if (dev_data->state != new_state) {
-		if (dev_data->common.state_change_cb) {
-			dev_data->common.state_change_cb(
-				dev, new_state, err_cnt,
-				dev_data->common.state_change_cb_user_data);
-		}
+		can_fire_state_change_callbacks(dev, new_state, err_cnt);
 
 		if (dev_data->state != CAN_STATE_STOPPED && new_state == CAN_STATE_BUS_OFF) {
 			/* re-enable the node after auto bus-off recovery completes */
@@ -791,6 +774,7 @@ static int can_xmc4xxx_init(const struct device *dev)
 	CAN_MO_TypeDef *mo;
 	uint8_t mo_index = 0;
 
+	sys_slist_init(&dev_data->common.state_change_callbacks);
 	k_sem_init(&dev_data->tx_sem, CONFIG_CAN_XMC4XXX_MAX_TX_QUEUE,
 		   CONFIG_CAN_XMC4XXX_MAX_TX_QUEUE);
 	k_mutex_init(&dev_data->mutex);
@@ -892,7 +876,6 @@ static DEVICE_API(can, can_xmc4xxx_api_funcs) = {
 	.add_rx_filter = can_xmc4xxx_add_rx_filter,
 	.remove_rx_filter = can_xmc4xxx_remove_rx_filter,
 	.get_state = can_xmc4xxx_get_state,
-	.set_state_change_callback = can_xmc4xxx_set_state_change_callback,
 	.get_core_clock = can_xmc4xxx_get_core_clock,
 	.get_max_filters = can_xmc4xxx_get_max_filters,
 	.timing_min = {

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1599,12 +1599,15 @@ static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeo
  * Only one callback can be registered per controller. Calling this function
  * again overrides any previously registered callback.
  *
+ * @deprecated Use can_add_state_change_callback() and can_remove_state_change_callback() instead.
+ *
  * @param dev       Pointer to the device structure for the driver instance.
  * @param callback  Callback function.
  * @param user_data User data to pass to callback function.
  */
-void can_set_state_change_callback(const struct device *dev, can_state_change_callback_t callback,
-				   void *user_data);
+__deprecated void can_set_state_change_callback(const struct device *dev,
+						can_state_change_callback_t callback,
+						void *user_data);
 
 /**
  * @brief Initialize a CAN controller state change callback structure

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Vestas Wind Systems A/S
+ * Copyright (c) 2021-2026 Vestas Wind Systems A/S
  * Copyright (c) 2018 Karsten Koenig
  * Copyright (c) 2018 Alexander Wachter
  *
@@ -37,7 +37,7 @@ extern "C" {
  * @brief Interfaces for CAN controllers
  * @ingroup can_interface
  * @since 1.12
- * @version 1.1.0
+ * @version 1.2.0
  *
  * @{
  */
@@ -311,6 +311,41 @@ typedef void (*can_state_change_callback_t)(const struct device *dev,
 					    struct can_bus_err_cnt err_cnt,
 					    void *user_data);
 
+struct can_state_change_callback;
+
+/**
+ * @brief Defines the state change callback handler function signature
+ *
+ * @param dev      Pointer to the device structure for the driver instance.
+ * @param callback Pointer to the callback structure.
+ * @param state    State of the CAN controller.
+ * @param err_cnt  CAN controller error counter values.
+ */
+typedef void (*can_state_change_callback_handler_t)(const struct device *dev,
+						    struct can_state_change_callback *callback,
+						    enum can_state state,
+						    struct can_bus_err_cnt err_cnt);
+/**
+ * @brief CAN state change callback.
+ *
+ * This struct is used to register a CAN state callback. As many callbacks as needed can be added as
+ * long as each of them are unique pointers of struct can_state_callback.
+ *
+ * @note This structure should not be allocated on a stack.
+ *
+ * This type is opaque. Member data should not be accessed directly by the application.
+ *
+ * @see can_init_state_change_callback()
+ * @see can_add_state_change_callback()
+ * @see can_remove_state_change_callback()
+ */
+struct can_state_change_callback {
+	/** Single-linked list node */
+	sys_snode_t node;
+	/** Callback function */
+	can_state_change_callback_handler_t handler;
+};
+
 /**
  * @def_driverbackendgroup{CAN Controller,can_controller}
  * @{
@@ -400,10 +435,16 @@ struct can_driver_data {
 	can_mode_t mode;
 	/** True if the CAN controller is started, false otherwise. */
 	bool started;
-	/** State change callback function pointer or NULL. */
-	can_state_change_callback_t state_change_cb;
-	/** State change callback user data pointer or NULL. */
-	void *state_change_cb_user_data;
+	/** Legacy state change callback. */
+	struct can_state_change_callback legacy_state_change_cb;
+	/** Legacy state change callback function pointer or NULL. */
+	can_state_change_callback_t legacy_state_change_cb_handler;
+	/** Legacy state change callback user data pointer or NULL. */
+	void *legacy_state_change_cb_user_data;
+	/** Lock for changing the list of state change callbacks. */
+	struct k_spinlock state_change_callback_lock;
+	/** List of state change callbacks. */
+	sys_slist_t state_change_callbacks;
 };
 
 /**
@@ -485,14 +526,6 @@ typedef int (*can_get_state_t)(const struct device *dev, enum can_state *state,
 			       struct can_bus_err_cnt *err_cnt);
 
 /**
- * @brief Callback API upon setting a state change callback
- * See @a can_set_state_change_callback() for argument description
- */
-typedef void(*can_set_state_change_callback_t)(const struct device *dev,
-					       can_state_change_callback_t callback,
-					       void *user_data);
-
-/**
  * @brief Callback API upon getting the CAN core clock rate
  * See @a can_get_core_clock() for argument description
  */
@@ -503,6 +536,29 @@ typedef int (*can_get_core_clock_t)(const struct device *dev, uint32_t *rate);
  * See @a can_get_max_filters() for argument description
  */
 typedef int (*can_get_max_filters_t)(const struct device *dev, bool ide);
+
+/**
+ * @brief Optional callback API for notification on when state change callbacks are enabled.
+ *
+ * CAN controller drivers can e.g. use this optional callback for enabling/disabling IRQs used for
+ * reporting state changes.
+ *
+ * @param dev     Pointer to the device structure for the driver instance.
+ * @param enabled true if state change callbacks are enabled, false otherwise.
+ * @retval 0 on success.
+ * @retval -EIO General input/output error.
+ */
+typedef int (*can_state_change_callbacks_enabled_t)(const struct device *dev, bool enabled);
+
+/**
+ * @brief Fire registered CAN state change handler callbacks.
+ *
+ * @param dev     Pointer to the device structure for the driver instance.
+ * @param state   State of the CAN controller.
+ * @param err_cnt CAN controller error counter values.
+ */
+void can_fire_state_change_callbacks(const struct device *dev, enum can_state state,
+				     struct can_bus_err_cnt err_cnt);
 
 /**
  * @driver_ops{CAN Controller}
@@ -552,9 +608,9 @@ __subsystem struct can_driver_api {
 	 */
 	can_get_state_t get_state;
 	/**
-	 * @driver_ops_mandatory @copybrief can_set_state_change_callback
+	 * @driver_ops_optional @copybrief can_state_change_callbacks_enabled_t
 	 */
-	can_set_state_change_callback_t set_state_change_callback;
+	can_state_change_callbacks_enabled_t state_change_callbacks_enabled;
 	/**
 	 * @driver_ops_mandatory @copybrief can_get_core_clock
 	 */
@@ -1547,12 +1603,49 @@ static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeo
  * @param callback  Callback function.
  * @param user_data User data to pass to callback function.
  */
-static inline void can_set_state_change_callback(const struct device *dev,
-						 can_state_change_callback_t callback,
-						 void *user_data)
+void can_set_state_change_callback(const struct device *dev, can_state_change_callback_t callback,
+				   void *user_data);
+
+/**
+ * @brief Initialize a CAN controller state change callback structure
+ *
+ * @param callback Pointer to the callback structure.
+ * @param handler  Callback handler function.
+ */
+static inline void can_init_state_change_callback(struct can_state_change_callback *callback,
+						  can_state_change_callback_handler_t handler)
 {
-	DEVICE_API_GET(can, dev)->set_state_change_callback(dev, callback, user_data);
+	__ASSERT_NO_MSG(callback != NULL);
+	__ASSERT_NO_MSG(handler != NULL);
+
+	callback->handler = handler;
 }
+
+/**
+ * @brief Add a callback for CAN controller state change events
+ *
+ * Add a callback for CAN controller state change events. The callback
+ * function will be called in interrupt context.
+ *
+ * @param dev      Pointer to the device structure for the driver instance.
+ * @param callback Pointer to the callback structure.
+ * @retval 0 on success, negative errno value on failure.
+ */
+int can_add_state_change_callback(const struct device *dev,
+				  struct can_state_change_callback *callback);
+
+/**
+ * @brief Remove a callback for CAN controller state change events
+ *
+ * Remove a callback for CAN controller state change events.
+ *
+ * @param dev      Pointer to the device structure for the driver instance.
+ * @param callback Pointer to the callback structure.
+ * @retval 0 on success, negative errno value on failure.
+ * @retval -EINVAL Callback not found.
+ */
+int can_remove_state_change_callback(const struct device *dev,
+				     struct can_state_change_callback *callback);
 
 /** @} */
 

--- a/include/zephyr/drivers/can/can_fake.h
+++ b/include/zephyr/drivers/can/can_fake.h
@@ -73,9 +73,8 @@ DECLARE_FAKE_VALUE_FUNC(int, fake_can_recover, const struct device *, k_timeout_
 DECLARE_FAKE_VALUE_FUNC(int, fake_can_get_state, const struct device *, enum can_state *,
 			struct can_bus_err_cnt *);
 
-/** @fake_of{can_driver_api::set_state_change_callback} */
-DECLARE_FAKE_VOID_FUNC(fake_can_set_state_change_callback, const struct device *,
-		       can_state_change_callback_t, void *);
+/** @fake_of{can_driver_api::state_change_callbacks_enabled} */
+DECLARE_FAKE_VALUE_FUNC(int, fake_can_state_change_callbacks_enabled, const struct device *, bool);
 
 /** @fake_of{can_driver_api::get_max_filters} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_can_get_max_filters, const struct device *, bool);

--- a/samples/drivers/can/counter/src/main.c
+++ b/samples/drivers/can/counter/src/main.c
@@ -23,6 +23,11 @@
 #define RESET_LED 0
 #define SLEEP_TIME K_MSEC(250)
 
+struct state_change_context {
+	struct can_state_change_callback callback;
+	struct k_work work;
+};
+
 K_THREAD_STACK_DEFINE(rx_thread_stack, RX_THREAD_STACK_SIZE);
 K_THREAD_STACK_DEFINE(poll_state_stack, STATE_POLL_THREAD_STACK_SIZE);
 
@@ -32,7 +37,7 @@ struct gpio_dt_spec led = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led0), gpios, {0});
 struct k_thread rx_thread_data;
 struct k_thread poll_state_thread_data;
 struct k_work_poll change_led_work;
-struct k_work state_change_work;
+struct state_change_context state_change_ctx;
 enum can_state current_state;
 struct can_bus_err_cnt current_err_cnt;
 
@@ -175,16 +180,19 @@ void state_change_work_handler(struct k_work *work)
 		current_err_cnt.rx_err_cnt, current_err_cnt.tx_err_cnt);
 }
 
-void state_change_callback(const struct device *dev, enum can_state state,
-			   struct can_bus_err_cnt err_cnt, void *user_data)
+static void state_change_callback_handler(const struct device *dev,
+					  struct can_state_change_callback *callback,
+					  enum can_state state,
+					  struct can_bus_err_cnt err_cnt)
 {
-	struct k_work *work = (struct k_work *)user_data;
+	struct state_change_context *ctx =
+		CONTAINER_OF(callback, struct state_change_context, callback);
 
 	ARG_UNUSED(dev);
 
 	current_state = state;
 	current_err_cnt = err_cnt;
-	k_work_submit(work);
+	k_work_submit(&ctx->work);
 }
 
 int main(void)
@@ -241,7 +249,8 @@ int main(void)
 		}
 	}
 
-	k_work_init(&state_change_work, state_change_work_handler);
+	can_init_state_change_callback(&state_change_ctx.callback, state_change_callback_handler);
+	k_work_init(&state_change_ctx.work, state_change_work_handler);
 	k_work_poll_init(&change_led_work, change_led_work_handler);
 
 	ret = can_add_rx_filter_msgq(can_dev, &change_led_msgq, &change_led_filter);
@@ -277,7 +286,11 @@ int main(void)
 		printf("ERROR spawning poll_state_thread\n");
 	}
 
-	can_set_state_change_callback(can_dev, state_change_callback, &state_change_work);
+	ret = can_add_state_change_callback(can_dev, &state_change_ctx.callback);
+	if (ret != 0) {
+		printf("Failed to add state change callback: %d", ret);
+		return 0;
+	}
 
 	printf("Finished init.\n");
 

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -409,25 +409,31 @@ ZTEST_USER(can_classic, test_classic_get_capabilities)
 }
 
 /**
- * @brief CAN state change callback.
+ * @brief CAN state change callback handler.
  */
-static void state_change_callback(const struct device *dev, enum can_state state,
-				  struct can_bus_err_cnt err_cnt, void *user_data)
+static void state_change_callback_handler(const struct device *dev,
+					  struct can_state_change_callback *callback,
+					  enum can_state state, struct can_bus_err_cnt err_cnt)
 {
 	ARG_UNUSED(dev);
+	ARG_UNUSED(callback);
 	ARG_UNUSED(state);
 	ARG_UNUSED(err_cnt);
-	ARG_UNUSED(user_data);
+
 }
 
+static struct can_state_change_callback state_change_callback;
+
 /**
- * @brief Test setting the CAN state change callback.
+ * @brief Test adding/removing a CAN state change callback.
  */
-ZTEST(can_classic, test_set_state_change_callback)
+ZTEST(can_classic, test_add_remove_state_change_callback)
 {
+	can_init_state_change_callback(&state_change_callback, state_change_callback_handler);
+
 	/* It is not possible to provoke a change of state, but test the API call */
-	can_set_state_change_callback(can_dev, state_change_callback, NULL);
-	can_set_state_change_callback(can_dev, NULL, NULL);
+	zassert_ok(can_add_state_change_callback(can_dev, &state_change_callback));
+	zassert_ok(can_remove_state_change_callback(can_dev, &state_change_callback));
 }
 
 /**


### PR DESCRIPTION
Add support for adding multiple CAN controller state change callbacks to a single CAN controller driver instance.
    
The new state change callbacks must be initialized by the caller via `can_init_state_change_callback()` and added/removed via new API functions `can_add_state_change_callback()` and `can_remove_state_change_callback()`.
    
Adapt the existing API `can_set_state_change_callback()` API function to be a wrapper for the new API functions and deprecate it.
    
Replace the mandatory `can_set_state_change_callback_t()` driver ops with an optional `can_state_change_callbacks_enabled_t()` driver ops, allowing CAN controller drivers to e.g. enable/disable state change IRQs based on whether any state change callbacks are added.

These changes amount to a few words more RAM usage and approximately 220 bytes increase in flash footprint for in-tree samples using the feature. However, for real-world applications we typically have to create a proxy for delivering state changes to various parts of the application (e.g. application itself, protocol stack, LED indicators, ...). Not having to do this reduces the flash footprint for the application/protocol stack.

This will aid in implementing https://github.com/zephyrproject-rtos/zephyr/issues/104350 as it simplifies the drivers tasks when it comes to notifying on state changes.