### PR TITLE
drivers: i2c: ite: Add support for disabling hardware timers

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -83,6 +83,7 @@ struct i2c_enhance_config {
 	uint8_t data_hold_time;
 	uint32_t clock_gate_offset;
 	int transfer_timeout_ms;
+	uint32_t scl_sda_low_timeout_ms;
 	bool target_enable;
 	bool target_pio_mode;
 	bool push_pull_recovery;
@@ -439,6 +440,27 @@ static int enhanced_i2c_error(const struct device *dev)
 }
 
 IT8XXX2_I2C_CODE_IN_RAM
+static void i2c_enhance_set_low_timeout(const struct device *dev)
+{
+	const struct i2c_enhance_config *config = dev->config;
+	uint8_t *base = config->base;
+
+	if (config->scl_sda_low_timeout_ms == 0) {
+		/* Disable the timeout setting when clock/data are in a low state */
+		IT8XXX2_I2C_TO_ARB_ST(base) &=
+			~(IT8XXX2_I2C_SCL_TIMEOUT_EN | IT8XXX2_I2C_SDA_TIMEOUT_EN);
+		/* The IT8XXX2_I2C_TOR register must have a non-zero value
+		 * even if the hardware timeout is disabled.
+		 */
+		IT8XXX2_I2C_TOR(base) = I2C_CLK_LOW_TIMEOUT;
+	} else {
+		IT8XXX2_I2C_TOR(base) = config->scl_sda_low_timeout_ms;
+		IT8XXX2_I2C_TO_ARB_ST(base) |=
+			(IT8XXX2_I2C_SCL_TIMEOUT_EN | IT8XXX2_I2C_SDA_TIMEOUT_EN);
+	}
+}
+
+IT8XXX2_I2C_CODE_IN_RAM
 static void enhanced_i2c_start(const struct device *dev)
 {
 	const struct i2c_enhance_config *config = dev->config;
@@ -448,11 +470,8 @@ static void enhanced_i2c_start(const struct device *dev)
 	i2c_reset(dev);
 	/* Set i2c frequency */
 	i2c_enhanced_port_set_frequency(dev, config->bitrate);
-	/*
-	 * Set time out register.
-	 * I2C D/E/F clock/data low timeout.
-	 */
-	IT8XXX2_I2C_TOR(base) = I2C_CLK_LOW_TIMEOUT;
+	/* Set SCL/SDA low timeout */
+	i2c_enhance_set_low_timeout(dev);
 	/* bit1: Enable enhanced i2c module */
 	IT8XXX2_I2C_CTR1(base) = IT8XXX2_I2C_MDL_EN;
 }
@@ -844,8 +863,8 @@ static int enhanced_i2c_cmd_queue_trans(const struct device *dev)
 	IT8XXX2_I2C_CTR(base) = E_STS_AND_HW_RST;
 	/* Set "PSR" registers to decide the i2c speed. */
 	i2c_enhanced_port_set_frequency(dev, config->bitrate);
-	/* Set time out register. port D, E, or F clock/data low timeout. */
-	IT8XXX2_I2C_TOR(base) = I2C_CLK_LOW_TIMEOUT;
+	/* Set SCL/SDA low timeout */
+	i2c_enhance_set_low_timeout(dev);
 
 	if (data->num_msgs == 2) {
 		/* I2C write to read of command queue mode. */
@@ -1284,6 +1303,8 @@ static int i2c_enhance_init(const struct device *dev)
 		IT8XXX2_I2C_DHTR(base) &= ~IT8XXX2_I2C_SOFT_RST;
 		/* reset i2c port */
 		i2c_reset(dev);
+		/* Set SCL/SDA low timeout */
+		i2c_enhance_set_low_timeout(dev);
 		/* bit1, Module enable */
 		IT8XXX2_I2C_CTR1(base) = 0;
 
@@ -1661,6 +1682,10 @@ static DEVICE_API(i2c, i2c_enhance_driver_api) = {
 		.data_hold_time = DT_INST_PROP_OR(inst, data_hold_time, 0),     \
 		.clock_gate_offset = DT_INST_PROP(inst, clock_gate_offset),     \
 		.transfer_timeout_ms = I2C_DT_INST_TRANSFER_TIMEOUT_MS(inst),   \
+		.scl_sda_low_timeout_ms =                                       \
+			DT_INST_PROP_OR(inst,                                   \
+					scl_sda_low_timeout_ms,                 \
+					I2C_CLK_LOW_TIMEOUT),                   \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                   \
 		.target_enable = DT_INST_PROP(inst, target_enable),             \
 		.target_pio_mode = DT_INST_PROP(inst, target_pio_mode),         \

--- a/dts/bindings/i2c/ite,enhance-i2c.yaml
+++ b/dts/bindings/i2c/ite,enhance-i2c.yaml
@@ -47,3 +47,25 @@ properties:
     description: |
       This option is used when the I2C target is enabled and it can
       support PIO mode for I2C target transfer.
+
+  scl-sda-low-timeout:
+    type: int
+    min: 0
+    max: 255
+    description: |
+      This option is used to configure the SCL/SDA low hardware timeout.
+      The timeout value specifies the number of 1024 kHz clock periods
+      to wait, which roughly translates to milliseconds of delay.
+      If this property is not specified, the driver defaults to the longest
+      possible SCL/SDA low timeout of 255 (which is 249 ms).
+
+      The ITE enhance driver also supports a software timeout using the
+      zephyr,transfer-timeout-ms property (or CONFIG_I2C_TRANSFER_TIMEOUT_MS).
+
+      The shorter timeout value (hardware or software) configures the maximum
+      clock stretch time supported on this I2C bus.
+
+      To support I2C targets that clock stretch longer than 249ms, set
+      scl-sda-low-timeout-ms to 0 to disable the hardware timer. The maximum
+      clock stretch time is then configured using the software timeout property
+      zephyr,transfer-timeout-ms.


### PR DESCRIPTION
The SCL/SDA stuck low hardware timer is limited to about 255ms. Add a new devicetree property scl-sda-low-timeout-ms that allows designs to either modify the SCL/SDA stuck low timer or to disable the timer completely.


Assisted-by: Antigravity:gemini-1.5-pro