### PR TITLE
Restrict QMSPI access when TAF is enabled

### DIFF
--- a/drivers/mspi/mspi_mchp_xec_qmspi.c
+++ b/drivers/mspi/mspi_mchp_xec_qmspi.c
@@ -335,6 +335,10 @@ static int api_mspi_mchp_xec_qmspi_cfg(const struct mspi_dt_spec *spec)
 	const struct mspi_cfg *cfg = &spec->config;
 	int rc = 0;
 
+	if (soc_taf_enabled() != 0) {
+		return -EPERM;
+	}
+
 	rc = mspi_xec_validate_config(cfg);
 	if (rc != 0) {
 		xdat->ctrl_cfg_ok = false;
@@ -694,6 +698,10 @@ static int api_mspi_mchp_xec_qmspi_dev_cfg(const struct device *ctrl,
 	int rc = 0;
 	bool locked = false;
 
+	if (soc_taf_enabled() != 0) {
+		return -EPERM;
+	}
+
 	if (xdat->dev_id != dev_id) {
 #ifdef CONFIG_MULTITHREADING
 		rc = k_mutex_lock(&xdat->lock, K_FOREVER);
@@ -780,6 +788,10 @@ static int api_mspi_mchp_xec_qmspi_get_chs(const struct device *ctrl, uint8_t ch
 {
 	struct mspi_xec_xdat *const xdat = ctrl->data;
 
+	if (soc_taf_enabled() != 0) {
+		return -EPERM;
+	}
+
 	if (ch != 0) {
 		return -EINVAL;
 	}
@@ -823,6 +835,10 @@ static int api_mspi_mchp_xec_qmspi_rcb(const struct device *ctrl, const struct m
 				       struct mspi_callback_context *ctx)
 {
 	struct mspi_xec_xdat *const xdat = ctrl->data;
+
+	if (soc_taf_enabled() != 0) {
+		return -EPERM;
+	}
 
 	if (dev_id == NULL) {
 		return -EINVAL;
@@ -1506,6 +1522,10 @@ static int api_mspi_mchp_xec_qmspi_tc(const struct device *ctrl, const struct ms
 	struct mspi_xec_context *ctx = &xdat->ctx;
 	int rc = 0;
 
+	if (soc_taf_enabled() != 0) {
+		return -EPERM;
+	}
+
 	if ((dev_id == NULL) || (req == NULL)) {
 		return -EINVAL;
 	}
@@ -1899,6 +1919,10 @@ static int mspi_mchp_xec_pm_suspend(const struct device *ctrl)
 static int mspi_mchp_xec_pm_action_cb(const struct device *ctrl, enum pm_device_action action)
 {
 	int rc = 0;
+
+	if (soc_taf_enabled() != 0) {
+		return 0;
+	}
 
 	if (action == PM_DEVICE_ACTION_SUSPEND) {
 		rc = mspi_mchp_xec_pm_suspend(ctrl);

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -819,6 +819,10 @@ static int mec5_qspi_pm_action(const struct device *dev, enum pm_device_action a
 	mm_reg_t qb = devcfg->regbase;
 	int ret = 0;
 
+	if (soc_taf_enabled() != 0) {
+		return 0;
+	}
+
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
 		sys_clear_bit(qb + XEC_QSPI_MODE_OFS, XEC_QSPI_MODE_ACTV_POS);


### PR DESCRIPTION
eSPI TAF (Target Attached Flash) takes exclusive ownership of the QMSPI
controller when enabled. Application-level SPI/MSPI access must be
blocked in that case to avoid conflicting with TAF's use of the shared
hardware block.

- `drivers/spi/spi_xec_qmspi_ldma.c`: the transceive and release paths
   already rejected requests when TAF is enabled; this extends the same
   check to the PM action callback (suspend/resume/turn on/off).
- `drivers/mspi/mspi_mchp_xec_qmspi.c`: adds the same restriction across
   all driver API entry points — `config`, `dev_config`,
   `get_channel_status`, `register_callback`, `transceive` — and the PM
   action callback.
