### PR TITLE
boards: arduino: portenta_c33: add spi on arduino mkr connector

### DIFF
--- a/boards/arduino/portenta_c33/arduino_mkr_connector.dtsi
+++ b/boards/arduino/portenta_c33/arduino_mkr_connector.dtsi
@@ -40,7 +40,4 @@ arduino_mkr_i2c: &iic0 {};
 
 arduino_mkr_serial: &uart9 {};
 
-/*
- * TODO: enable when SCI as SPI is supported
- * arduino_mkr_spi: &sci4 {};
- */
+arduino_mkr_spi: &sci4_spi {};

--- a/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
@@ -172,6 +172,15 @@
 		};
 	};
 
+	sci4_spi_default: sci4_spi_default {
+		group1 {
+			/* MOSI(TXD4) SCK4 MISO(RXD4) */
+			psels = <RA_PSEL(RA_PSEL_SCI_4, 9, 0)>,
+				<RA_PSEL(RA_PSEL_SCI_4, 2, 4)>,
+				<RA_PSEL(RA_PSEL_SCI_4, 3, 15)>;
+		};
+	};
+
 	pwm7_default: pwm7_default {
 		group1 {
 			psels = <RA_PSEL(RA_PSEL_GPT1, 3, 3)>;

--- a/boards/arduino/portenta_c33/arduino_portenta_c33.dts
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33.dts
@@ -70,6 +70,16 @@
 	};
 };
 
+&sci4 {
+	pinctrl-0 = <&sci4_spi_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sci4_spi: spi {
+		status = "okay";
+	};
+};
+
 &sci8 {
 	pinctrl-0 = <&sci8_default>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Configure SCI4 as the SPI controller for the Arduino MKR connector.

Verified SPI communication on the Portenta C33 connector using a logic analyzer and in loopback mode.