### PR TITLE
drivers: timer: nrf_rtc_timer: fix RTC init issue

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -747,7 +747,16 @@ static int sys_clock_driver_init(void)
 		    rtc_nrf_isr, 0, 0);
 	irq_enable(RTC_IRQn);
 
+	/* We need a delay of 46 usec between the CLEAR/START event, otherwise
+	 * we may seen a non-zero value for RTC, which will grip the whole
+	 * "tick counting machinery".
+	 * This can happen when the RTC was used by a bootloader before
+	 * Zephyr starts.
+	 *
+	 * See: NRF52840 RTC spec, section "TASK and EVENT jitter/delay"
+	 */
 	nrfy_rtc_task_trigger(RTC, NRF_RTC_TASK_CLEAR);
+	k_busy_wait(46);
 	nrfy_rtc_task_trigger(RTC, NRF_RTC_TASK_START);
 
 	int_mask = BIT_MASK(CHAN_COUNT);


### PR DESCRIPTION
The driver initialization routine has been changed to use the generic `timer_core_init`. As per nRF52840 RTC specification / section section TASK and EVENT jitter/delay, a delay of 46usec should be observed after a TASK CLEAR event before the counter is reset to 0.

Failing to do so will cause a spurious RTC wrap under certain conditions, such as on the Arduino Nano 33. The timer core logic will incorrectly assume that the RTC has wrapped, setting the main thread's initial timeslice far in the future. As a result, k_msleep() blocks for a very, very long time.

This bug was present before the driver rework, but changes to the driver initialization code likely exposed it.

Fixes: #117522
Fixes: #116583