### PR TITLE
MAINTAINERS: add ncadieux as USB-C collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6495,6 +6495,8 @@ USB-C:
   maintainers:
     - sambhurst
     - keith-zephyr
+  collaborators:
+    - ncadieux
   files:
     - drivers/usb_c/
     - dts/bindings/usb-c/


### PR DESCRIPTION
Add ncadieux as a collaborator for the `USB-C` area based on ongoing active contributions to this area and to assist with PR review and issues.

Per the collaborator process in `doc/project/project_roles.rst`, notifying the USB-C maintainers: @sambhurst @keith-zephyr