### PR TITLE
dts: arm: microchip: mec5: Enable watchdog

### DIFF
--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -17,6 +17,10 @@
 #include "mec5/mec5-vw-routing.dtsi"
 
 / {
+	aliases {
+		watchdog0 = &watchdog0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -263,11 +267,11 @@
 		};
 
 		watchdog0: watchdog@40000400 {
+			compatible = "microchip,xec-watchdog";
 			reg = <0x40000400 0x400>;
 			interrupts = <171 0>;
 			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 2)>;
 			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 9)>;
-			status = "disabled";
 		};
 
 		rtimer: timer@40007400 {


### PR DESCRIPTION
Set the watchdog0 node compatible to microchip,xec-watchdog and enable it at the MEC5 SoC level, matching the MEC172x SoC definition. Also add the watchdog0 alias so generic applications such as the watchdog sample can find the device without a board overlay.