### PR TITLE
drivers: wifi: esp_hosted: Set the WiFi mode at init and fix TLV parsing.

### DIFF
--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -651,6 +651,16 @@ static int esp_hosted_dev_init(const struct device *dev)
 	LOG_INF("firmware version: v%u.%u.%u.%u.%u", fw->major1, fw->major2, fw->minor,
 		fw->rev_patch1, fw->rev_patch2);
 
+	/*
+	 * Both firmwares boot in WIFI_MODE_NULL, leaving the mode to the host.
+	 * APSTA enables both interfaces, which the MAC reads below need.
+	 */
+	ctrl_msg = (CtrlMsg)CtrlMsg_init_zero;
+	ctrl_msg.req_set_wifi_mode.mode = Ctrl_WifiMode_APSTA;
+	if (esp_hosted_ctrl(dev, CtrlMsgId_Req_SetWifiMode, &ctrl_msg, ESP_HOSTED_SYNC_TIMEOUT)) {
+		LOG_WRN("failed to set wifi mode");
+	}
+
 	/* Set MAC addresses. */
 	for (size_t i = 0; i < 2; i++) {
 		ctrl_msg.req_get_mac_address.mode = i + 1;

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -200,12 +200,27 @@ static void esp_hosted_event_task(const struct device *dev, void *p2, void *p3)
 		}
 		case ESP_HOSTED_PRIV_IF: {
 			esp_hosted_event_t *ev = (esp_hosted_event_t *)frame->payload;
+			uint8_t vals[ESP_PRIV_TAG_MAX] = {0};
 
-			if (frame->priv_pkt_type == ESP_PACKET_TYPE_EVENT &&
-			    ev->event_type == ESP_PRIV_EVENT_INIT && ev->event_len > 8) {
-				LOG_INF("chip id %d spi_mhz %d caps 0x%x", ev->event_data[2],
-					ev->event_data[5], ev->event_data[8]);
+			if (frame->priv_pkt_type != ESP_PACKET_TYPE_EVENT ||
+			    ev->event_type != ESP_PRIV_EVENT_INIT ||
+			    frame->len < sizeof(*ev) + ev->event_len) {
+				continue;
 			}
+
+			/* A list of {tag, length, value} triplets. Which tags are
+			 * present varies between firmware versions.
+			 */
+			for (size_t i = 0; i + 3 <= ev->event_len; i += 2 + ev->event_data[i + 1]) {
+				uint8_t tag = ev->event_data[i];
+
+				if (tag < ARRAY_SIZE(vals) && ev->event_data[i + 1] == 1) {
+					vals[tag] = ev->event_data[i + 2];
+				}
+			}
+
+			LOG_INF("chip id %d spi_mhz %d caps 0x%x", vals[ESP_PRIV_FIRMWARE_CHIP_ID],
+				vals[ESP_PRIV_SPI_CLK_MHZ], vals[ESP_PRIV_CAPABILITY]);
 			continue;
 		}
 		case ESP_HOSTED_SERIAL_IF: /* Requires further processing */

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.h
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.h
@@ -61,6 +61,18 @@ typedef enum {
 	ESP_PRIV_EVENT_INIT,
 } esp_hosted_priv_event_t;
 
+/* Tags of the TLVs carried by ESP_PRIV_EVENT_INIT. Which ones the slave emits,
+ * and in what order, depends on the firmware version and the transport.
+ */
+typedef enum {
+	ESP_PRIV_CAPABILITY = 0x00,
+	ESP_PRIV_SPI_CLK_MHZ = 0x01,
+	ESP_PRIV_FIRMWARE_CHIP_ID = 0x02,
+	ESP_PRIV_TEST_RAW_TP = 0x03,
+	ESP_PRIV_FW_DATA = 0x04,
+	ESP_PRIV_TAG_MAX,
+} esp_hosted_priv_tag_t;
+
 /* TLV payload. */
 typedef struct __packed {
 	uint8_t ep_type;


### PR DESCRIPTION
Two minor fixes:

1. Set the WiFi mode at init. Depending on the version, the firmware boots in either WIFI_MODE_NULL or WIFI_MODE_STA, so the host should select one.

2. Fix the init event TLV parsing. Which TLVs the firmware sends varies by version, so the hard-coded indices read the wrong values on the latest firmware.