### PR TITLE
drivers: flash: flash_renesas_ra_ospi_b: reset the configured chip-select

### DIFF
--- a/drivers/flash/flash_renesas_ra_ospi_b.c
+++ b/drivers/flash/flash_renesas_ra_ospi_b.c
@@ -171,10 +171,22 @@ static int flash_renesas_ra_ospi_b_spi_mode_init(ospi_b_instance_ctrl_t *p_ctrl,
 		return -EIO;
 	}
 
-	/* Reset flash device by driving OM_RESET pin */
-	R_XSPI0->LIOCTL_b.RSTCS0 = 0;
-	k_sleep(K_USEC(500));
-	R_XSPI0->LIOCTL_b.RSTCS0 = 1;
+	/* Reset flash device by driving the OM_RESET pin of the *configured*
+	 * chip-select. The attached device may be on CS0 or CS1
+	 * (p_ctrl->channel, as used just above for LIOCFGCS). Unconditionally
+	 * driving RSTCS0 never resets a device wired to CS1 (e.g. the S28HL512T
+	 * on the EK-RA8D1, reg = <0x90000000 ...>), so it can be left in a
+	 * non-1S protocol mode across a warm reboot.
+	 */
+	if (p_ctrl->channel == OSPI_B_DEVICE_NUMBER_1) {
+		R_XSPI0->LIOCTL_b.RSTCS1 = 0;
+		k_sleep(K_USEC(500));
+		R_XSPI0->LIOCTL_b.RSTCS1 = 1;
+	} else {
+		R_XSPI0->LIOCTL_b.RSTCS0 = 0;
+		k_sleep(K_USEC(500));
+		R_XSPI0->LIOCTL_b.RSTCS0 = 1;
+	}
 	k_sleep(K_NSEC(50));
 
 	/* Transfer write enable command */


### PR DESCRIPTION
### Summary

`flash_renesas_ra_ospi_b_spi_mode_init()` resets the attached flash by driving the OM_RESET line for **chip-select 0 only**, but the driver configures the device on **chip-select 1** (`.channel = OSPI_B_DEVICE_NUMBER_1`). `RSTCS1` is never written anywhere in the driver.

```c
/* Reset flash device by driving OM_RESET pin */
R_XSPI0->LIOCTL_b.RSTCS0 = 0;
k_sleep(K_USEC(500));
R_XSPI0->LIOCTL_b.RSTCS0 = 1;
```

`RSTCS0` / `RSTCS1` are independent bits in `XSPI0.LIOCTL`. On a board whose OSPI-B flash is on CS1 (e.g. `ek_ra8d1`, whose `s28hl512t` node is at `reg = <0x90000000 ...>`, and whose `ospi0_default` pinctrl group2 is commented `/* cs1 rst ecsint1 */`), this "reset flash device" step is a no-op, so the device can be left in a non-1S protocol mode across a warm reboot.

The same function two lines earlier already indexes the CS correctly (`R_XSPI0->LIOCFGCS_b[p_ctrl->channel].DDRSMPEX`). This change makes the reset select `RSTCS0`/`RSTCS1` from `p_ctrl->channel` to match.

### Testing / honesty

Found by code inspection during `ek_ra8d1` bring-up. **Not functionally verified** — the OSPI NOR on the board sample in hand is non-responsive (returns `0xFF` to every command, before and after the reset, warm boot and after a full power cycle; the flash chip is electrically silent — an unrelated hardware/population issue on that unit), so this reset change produces no observable difference there.

Submitting because the code defect is unambiguous and CS1 is a supported configuration used by an in-tree board. Builds clean for `ek_ra8d1` on `66e5135ffc3`.

### Minor, related

Every failure path inside `spi_mode_init()` is `LOG_DBG`, so at the default log level a failure surfaces only as `Init SPI mode failed` with no indication of which step failed — happy to send a separate patch promoting those if useful.
