### PR TITLE
cmake: emu: qemu: let boards place the virtio-blk device

### DIFF
--- a/boards/qemu/cortex_a53/board.cmake
+++ b/boards/qemu/cortex_a53/board.cmake
@@ -26,23 +26,15 @@ if(CONFIG_INPUT_VIRTIO)
   endif()
 endif()
 
-if(CONFIG_DISK_DRIVER_VIRTIO_BLK)
-  # The matching "-drive ...,id=vblk" is added by
-  # cmake/emu/qemu/virtio_blk.cmake; attach it here so the MMIO virtio-blk
-  # device is backed by the disk image.
-  set(virtio_blk_mmio_dev "virtio-blk-device,drive=vblk,bus=virtio-mmio-bus.4")
-  set(blk_size ${CONFIG_QEMU_VIRTIO_BLK_LOGICAL_BLOCK_SIZE})
-  # QEMU requires physical_block_size >= logical_block_size.
-  set(virtio_blk_mmio_dev
-    "${virtio_blk_mmio_dev},logical_block_size=${blk_size},physical_block_size=${blk_size}")
-  set(QEMU_VIRTIO_BLK_FLAGS -device ${virtio_blk_mmio_dev})
-endif()
+# MMIO transport the block device is attached to, matching the virtio_mmio node
+# it hangs off in the board devicetree. The device itself is added by
+# cmake/emu/qemu/virtio_blk.cmake.
+set(QEMU_VIRTIO_BLK_TRANSPORT bus=virtio-mmio-bus.4)
 
 set(QEMU_BOARD_FLAGS
   -cpu ${QEMU_CPU_TYPE}
   ${QEMU_VIRTIO_ENTROPY_FLAGS}
   ${QEMU_VIRTIO_INPUT_FLAGS}
-  ${QEMU_VIRTIO_BLK_FLAGS}
   -machine ${QEMU_MACH}
   )
 

--- a/cmake/emu/qemu/virtio_blk.cmake
+++ b/cmake/emu/qemu/virtio_blk.cmake
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Emulated virtio-blk disk, backed by a raw disk image created at build time.
+#
+# Boards say where the device goes by setting QEMU_VIRTIO_BLK_TRANSPORT to the
+# device property picking their transport, "bus=virtio-mmio-bus.4" or
+# "addr=06.0" for example, matching the devicetree.
 
 if(CONFIG_DISK_DRIVER_VIRTIO_BLK)
   if(qemu_alternate_path)
@@ -23,13 +27,21 @@ if(CONFIG_DISK_DRIVER_VIRTIO_BLK)
   )
 
   if(CONFIG_VIRTIO_PCI)
-    set(virtio_blk_pci_dev "virtio-blk-pci,drive=vblk")
-    set(blk_size ${CONFIG_QEMU_VIRTIO_BLK_LOGICAL_BLOCK_SIZE})
-    # QEMU requires physical_block_size >= logical_block_size.
-    set(virtio_blk_pci_dev
-      "${virtio_blk_pci_dev},logical_block_size=${blk_size},physical_block_size=${blk_size}")
-    qemu_append_extra_flags(-device ${virtio_blk_pci_dev})
+    set(virtio_blk_dev "virtio-blk-pci,drive=vblk")
+  else()
+    set(virtio_blk_dev "virtio-blk-device,drive=vblk")
   endif()
+
+  if(QEMU_VIRTIO_BLK_TRANSPORT)
+    string(APPEND virtio_blk_dev ",${QEMU_VIRTIO_BLK_TRANSPORT}")
+  endif()
+
+  # QEMU requires physical_block_size >= logical_block_size.
+  set(blk_size ${CONFIG_QEMU_VIRTIO_BLK_LOGICAL_BLOCK_SIZE})
+  string(APPEND virtio_blk_dev
+    ",logical_block_size=${blk_size},physical_block_size=${blk_size}")
+
+  qemu_append_extra_flags(-device ${virtio_blk_dev})
 
   add_custom_target(qemu_virtio_blk_disk
     COMMAND


### PR DESCRIPTION
The MMIO virtio-blk device was assembled by hand in `qemu_cortex_a53`'s `board.cmake`. Build it in the emulator fragment instead, for MMIO as well as PCI, and let a board point it at its transport with `QEMU_VIRTIO_BLK_TRANSPORT`.

No functional change. The QEMU command line for `tests/subsys/fs/fat_fs_api` with `FILE_SUFFIX=virtio_blk` on `qemu_cortex_a53` is byte-identical before and after.
