### PR TITLE
fs: ext2: validate on-disk metadata before directory and block access

### DIFF
--- a/subsys/fs/ext2/ext2_disk_access.c
+++ b/subsys/fs/ext2/ext2_disk_access.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/device.h>
 #include <zephyr/storage/disk_access.h>
@@ -61,14 +62,27 @@ static int disk_write(const char *disk, const uint8_t *buf, uint32_t start, uint
 	return rc;
 }
 
-static int disk_prepare_range(struct disk_data *disk, uint32_t addr, uint32_t size,
+static int disk_prepare_range(struct disk_data *disk, uint64_t addr, uint32_t size,
 		uint32_t *s_start, uint32_t *s_count)
 {
-	*s_start = CONFIG_EXT2_DISK_STARTING_SECTOR + addr / disk->sector_size;
+	uint64_t start64;
+
+	if (disk->sector_size == 0) {
+		return -EINVAL;
+	}
+
+	start64 = (uint64_t)CONFIG_EXT2_DISK_STARTING_SECTOR + addr / disk->sector_size;
 	*s_count = size / disk->sector_size;
 
-	LOG_DBG("addr:0x%x size:0x%x -> sector_start:%d sector_count:%d",
-			addr, size, *s_start, *s_count);
+	LOG_DBG("addr:0x%llx size:0x%x -> sector_start:%llu sector_count:%d",
+			(unsigned long long)addr, size, (unsigned long long)start64, *s_count);
+
+	if (start64 > UINT32_MAX) {
+		LOG_ERR("Requested range can't be accessed due to overflow.");
+		return -ENOSPC;
+	}
+
+	*s_start = (uint32_t)start64;
 
 	/* Check for overflow. */
 	if (*s_count > UINT32_MAX - *s_start) {
@@ -92,7 +106,7 @@ static int disk_access_read_block(struct ext2_data *fs, void *buf, uint32_t bloc
 	struct disk_data *disk = fs->backend;
 	uint32_t sector_start, sector_count;
 
-	rc = disk_prepare_range(disk, block * fs->block_size, fs->block_size,
+	rc = disk_prepare_range(disk, (uint64_t)block * fs->block_size, fs->block_size,
 			&sector_start, &sector_count);
 	if (rc < 0) {
 		return rc;
@@ -106,7 +120,7 @@ static int disk_access_write_block(struct ext2_data *fs, const void *buf, uint32
 	struct disk_data *disk = fs->backend;
 	uint32_t sector_start, sector_count;
 
-	rc = disk_prepare_range(disk, block * fs->block_size, fs->block_size,
+	rc = disk_prepare_range(disk, (uint64_t)block * fs->block_size, fs->block_size,
 			&sector_start, &sector_count);
 	if (rc < 0) {
 		return rc;

--- a/subsys/fs/ext2/ext2_diskops.c
+++ b/subsys/fs/ext2/ext2_diskops.c
@@ -264,7 +264,7 @@ int ext2_fetch_block_group(struct ext2_data *fs, uint32_t group)
 	LOG_DBG("ngroups:%d", ngroups);
 	LOG_DBG("cur_group:%d fetch_group:%d", bg->num, group);
 
-	if (group > ngroups) {
+	if (group >= ngroups) {
 		return -ERANGE;
 	}
 
@@ -364,8 +364,16 @@ int ext2_fetch_bg_bbitmap(struct ext2_bgroup *bg)
 static int32_t get_itable_entry(struct ext2_data *fs, uint32_t ino)
 {
 	int rc;
-	uint32_t ino_group = (ino - 1) / fs->sblock.s_inodes_per_group;
-	uint32_t ino_index = (ino - 1) % fs->sblock.s_inodes_per_group;
+	uint32_t ino_group;
+	uint32_t ino_index;
+
+	if (ino < 1 || ino > fs->sblock.s_inodes_count ||
+	    fs->sblock.s_inodes_per_group == 0 || fs->sblock.s_inode_size == 0) {
+		return -EINVAL;
+	}
+
+	ino_group = (ino - 1) / fs->sblock.s_inodes_per_group;
+	ino_index = (ino - 1) % fs->sblock.s_inodes_per_group;
 
 	LOG_DBG("ino_group:%d ino_index:%d", ino_group, ino_index);
 
@@ -1010,6 +1018,10 @@ int32_t ext2_alloc_inode(struct ext2_data *fs)
 		return r;
 	}
 
+	if ((uint32_t)r >= fs->sblock.s_inodes_count) {
+		return -ENOSPC;
+	}
+
 	/* Add 1 because inodes are counted from 1 not 0. */
 	global_idx = group * fs->sblock.s_inodes_per_group + r + 1;
 
@@ -1118,9 +1130,17 @@ int ext2_free_inode(struct ext2_data *fs, uint32_t ino, bool directory)
 	LOG_DBG("Free inode %d", ino);
 
 	int rc;
-	uint32_t group = (ino - 1) / fs->sblock.s_inodes_per_group;
-	uint32_t bitmap_off = (ino - 1) % fs->sblock.s_inodes_per_group;
+	uint32_t group;
+	uint32_t bitmap_off;
 	uint32_t set;
+
+	if (ino < 1 || ino > fs->sblock.s_inodes_count ||
+	    fs->sblock.s_inodes_per_group == 0) {
+		return -EINVAL;
+	}
+
+	group = (ino - 1) / fs->sblock.s_inodes_per_group;
+	bitmap_off = (ino - 1) % fs->sblock.s_inodes_per_group;
 
 	rc = ext2_fetch_block_group(fs, group);
 	if (rc < 0) {

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -374,6 +374,12 @@ int ext2_init_fs(struct ext2_data *fs)
 		return -EINVAL;
 	}
 
+	if (sb->s_inodes_count == 0 ||
+	    sb->s_inodes_count > (uint32_t)(fs->block_size * 8U)) {
+		error_behavior(fs, "s_inodes_count exceeds single-group bitmap capacity");
+		return -EINVAL;
+	}
+
 	set = ext2_bitmap_count_set(BGROUP_INODE_BITMAP(&fs->bgroup), sb->s_inodes_count);
 
 	if (set != sb->s_inodes_count - sb->s_free_inodes_count) {
@@ -1231,6 +1237,122 @@ out:
 	return ret;
 }
 
+/* After ext2_fetch_inode_block(), write @disk_block into the slot that
+ * currently addresses the fetched data block. Direct slots live in i_block[];
+ * indirect slots live in the parent list block (little-endian on disk).
+ */
+static int inode_write_fetched_block_slot(struct ext2_inode *inode, uint32_t disk_block)
+{
+	uint32_t *list;
+
+	if (!(inode->flags & INODE_FETCHED_BLOCK) || inode_current_block(inode) == NULL) {
+		return -EINVAL;
+	}
+
+	if (inode->block_lvl == 0) {
+		inode->i_block[inode->offsets[0]] = disk_block;
+		return 0;
+	}
+
+	list = (uint32_t *)inode->blocks[inode->block_lvl - 1]->data;
+	list[inode->offsets[inode->block_lvl]] = sys_cpu_to_le32(disk_block);
+	return ext2_write_block(inode->i_fs, inode->blocks[inode->block_lvl - 1]);
+}
+
+static int ext2_remove_dir_block(struct ext2_inode *parent, uint32_t blk)
+{
+	int rc;
+	uint32_t block_size = parent->i_fs->block_size;
+	uint32_t last_blk;
+	uint32_t old_disk;
+	uint32_t last_disk = 0;
+
+	if (parent->i_size <= block_size || (parent->i_size % block_size) != 0) {
+		return -EINVAL;
+	}
+
+	last_blk = parent->i_size / block_size - 1;
+	if (blk > last_blk) {
+		return -EINVAL;
+	}
+
+	rc = ext2_fetch_inode_block(parent, blk);
+	if (rc < 0) {
+		return rc;
+	}
+
+	old_disk = inode_current_block(parent)->num;
+	if (old_disk == 0) {
+		return -EINVAL;
+	}
+
+	if (blk != last_blk) {
+		rc = ext2_fetch_inode_block(parent, last_blk);
+		if (rc < 0) {
+			return rc;
+		}
+
+		last_disk = inode_current_block(parent)->num;
+		if (last_disk == 0) {
+			return -EINVAL;
+		}
+
+		rc = ext2_fetch_inode_block(parent, blk);
+		if (rc < 0) {
+			return rc;
+		}
+
+		rc = inode_write_fetched_block_slot(parent, last_disk);
+		if (rc < 0) {
+			return rc;
+		}
+
+		ext2_inode_drop_blocks(parent);
+
+		rc = ext2_fetch_inode_block(parent, last_blk);
+		if (rc < 0) {
+			return rc;
+		}
+
+		rc = inode_write_fetched_block_slot(parent, 0);
+		if (rc < 0) {
+			return rc;
+		}
+	} else {
+		rc = inode_write_fetched_block_slot(parent, 0);
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
+	ext2_inode_drop_blocks(parent);
+
+	rc = ext2_free_block(parent->i_fs, old_disk);
+	if (rc < 0) {
+		return rc;
+	}
+
+	parent->i_size -= block_size;
+	if (parent->i_blocks >= block_size / 512) {
+		parent->i_blocks -= block_size / 512;
+	}
+
+	/* Directory no longer spans the single-indirect range: drop the empty list. */
+	if (parent->i_size <= EXT2_INODE_BLOCK_DIRECT * block_size &&
+	    parent->i_block[EXT2_INODE_BLOCK_1LVL] != 0) {
+		rc = ext2_free_block(parent->i_fs, parent->i_block[EXT2_INODE_BLOCK_1LVL]);
+		if (rc < 0) {
+			return rc;
+		}
+		parent->i_block[EXT2_INODE_BLOCK_1LVL] = 0;
+		if (parent->i_blocks >= block_size / 512) {
+			parent->i_blocks -= block_size / 512;
+		}
+	}
+
+	return ext2_commit_inode(parent);
+}
+
 static int ext2_del_direntry(struct ext2_inode *parent, uint32_t offset)
 {
 	int rc = 0;
@@ -1256,27 +1378,10 @@ static int ext2_del_direntry(struct ext2_inode *parent, uint32_t offset)
 		uint16_t reclen = ext2_get_disk_direntry_reclen(de);
 
 		if (reclen == block_size) {
-			/* Remove whole block */
-
-			uint32_t last_blk = parent->i_size / block_size - 1;
-			uint32_t old_blk = parent->i_block[blk];
-
-			/* move last block in place of removed one. Entries start only at beginning
-			 * of the block, hence we don't have to care to move any entry.
+			/* Remove whole block. Entries start only at the beginning of a
+			 * block, so the last directory block can be moved into this hole.
 			 */
-			parent->i_block[blk] = parent->i_block[last_blk];
-			parent->i_block[last_blk] = 0;
-
-			/* Free removed block */
-			rc = ext2_free_block(parent->i_fs, old_blk);
-			if (rc < 0) {
-				return rc;
-			}
-
-			rc = ext2_commit_inode(parent);
-			if (rc < 0) {
-				return rc;
-			}
+			return ext2_remove_dir_block(parent, blk);
 		} else {
 			/* Move next entry to beginning of block */
 			struct ext2_disk_direntry *next =
@@ -1411,6 +1516,10 @@ int ext2_inode_unlink(struct ext2_inode *parent, struct ext2_inode *inode, uint3
 {
 	int rc;
 
+	if (parent == NULL || inode == NULL) {
+		return -EINVAL;
+	}
+
 	rc = can_unlink(inode);
 	if (rc < 0) {
 		return rc;
@@ -1442,6 +1551,11 @@ int ext2_replace_file(struct ext2_lookup_args *args_from, struct ext2_lookup_arg
 {
 	LOG_DBG("Replace existing directory entry in rename");
 	LOG_DBG("Inode: %d Inode to replace: %d", args_from->inode->i_id, args_to->inode->i_id);
+
+	if (args_from->parent == NULL || args_to->parent == NULL ||
+	    args_from->inode == NULL || args_to->inode == NULL) {
+		return -EINVAL;
+	}
 
 	int rc = 0;
 	struct ext2_disk_direntry *de;
@@ -1499,7 +1613,13 @@ int ext2_replace_file(struct ext2_lookup_args *args_from, struct ext2_lookup_arg
 int ext2_move_file(struct ext2_lookup_args *args_from, struct ext2_lookup_args *args_to)
 {
 	int rc = 0;
-	uint32_t block_size = args_from->parent->i_fs->block_size;
+	uint32_t block_size;
+
+	if (args_from->parent == NULL || args_to->parent == NULL) {
+		return -EINVAL;
+	}
+
+	block_size = args_from->parent->i_fs->block_size;
 
 	struct ext2_inode *fparent = args_from->parent;
 	struct ext2_inode *tparent = args_to->parent;

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -20,6 +20,48 @@ LOG_MODULE_DECLARE(ext2);
 
 K_MEM_SLAB_DEFINE_TYPE(file_struct_slab, struct ext2_file, CONFIG_EXT2_MAX_FILES);
 
+/* Root, "." and ".." are not valid unlink/rename targets. A root lookup
+ * also leaves parent NULL, which the backend must not dereference.
+ */
+static bool ext2_forbidden_path(const char *path)
+{
+	const char *name;
+
+	if (path == NULL) {
+		return true;
+	}
+
+	while (*path == '/') {
+		path++;
+	}
+
+	if (*path == '\0') {
+		return true;
+	}
+
+	name = path;
+	while (*path != '\0') {
+		if (*path == '/') {
+			name = path + 1;
+		}
+		path++;
+	}
+
+	if (name[0] == '\0') {
+		return true;
+	}
+
+	if (name[0] == '.' && name[1] == '\0') {
+		return true;
+	}
+
+	if (name[0] == '.' && name[1] == '.' && name[2] == '\0') {
+		return true;
+	}
+
+	return false;
+}
+
 /* File operations */
 
 static int ext2_open(struct fs_file_t *filp, const char *fs_path, fs_mode_t flags)
@@ -509,6 +551,10 @@ static int ext2_unlink(struct fs_mount_t *mountp, const char *name)
 		.parent = NULL,
 	};
 
+	if (ext2_forbidden_path(path)) {
+		return -EINVAL;
+	}
+
 	args.flags = LOOKUP_ARG_UNLINK;
 
 	rc = ext2_lookup_inode(fs, &args);
@@ -538,6 +584,10 @@ static int ext2_rename(struct fs_mount_t *mountp, const char *from, const char *
 
 	const char *path_from = fs_impl_strip_prefix(from, mountp);
 	const char *path_to = fs_impl_strip_prefix(to, mountp);
+
+	if (ext2_forbidden_path(path_from) || ext2_forbidden_path(path_to)) {
+		return -EINVAL;
+	}
 
 	struct ext2_lookup_args args_from = {
 		.path = path_from,

--- a/tests/subsys/fs/ext2/src/test_metadata.c
+++ b/tests/subsys/fs/ext2/src/test_metadata.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Dhruv Menon <dhruvmenon1104@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/ztest.h>
+#include <zephyr/fs/fs.h>
+#include <zephyr/fs/ext2.h>
+
+#include "utils.h"
+
+/* 1024-byte blocks, 200-byte names -> 208-byte dirents, 4 entries per block.
+ * Block 0 also holds "." and "..", so it still fits 4 files.
+ * Direct blocks cover files 0..47; the first indirect block starts at 48.
+ */
+#define DIR_NAME_LEN    200
+#define NFILES          56
+#define INDIRECT_FIRST  48
+#define INDIRECT_LAST   51
+#define SURVIVOR        52
+
+static int create_file(const char *path)
+{
+	struct fs_file_t file;
+	int rc;
+
+	fs_file_t_init(&file);
+	rc = fs_open(&file, path, FS_O_CREATE);
+	if (rc < 0) {
+		return rc;
+	}
+	return fs_close(&file);
+}
+
+static void make_dir_path(char *buf, size_t buflen, unsigned int n)
+{
+	char name[DIR_NAME_LEN + 1];
+	int len;
+
+	len = snprintk(name, sizeof(name), "f%03u", n);
+	memset(name + len, 'x', DIR_NAME_LEN - len);
+	name[DIR_NAME_LEN] = '\0';
+	snprintk(buf, buflen, "/sml/d/%s", name);
+}
+
+ZTEST(ext2tests, test_root_dot_unlink_rename)
+{
+	struct fs_mount_t *mp = &testfs_mnt;
+	struct fs_dirent stat;
+
+	zassert_equal(fs_mount(mp), 0, "Mount failed");
+
+	zassert_equal(fs_rename("/sml", "/sml/moved"), -EINVAL,
+			"renaming the filesystem root must fail");
+	zassert_equal(fs_unlink("/sml"), -EINVAL, "unlinking the filesystem root must fail");
+	zassert_equal(fs_unlink("/sml/."), -EINVAL, "unlink \".\" must fail");
+	zassert_equal(fs_unlink("/sml/.."), -EINVAL, "unlink \"..\" must fail");
+
+	zassert_equal(fs_mkdir("/sml/dir"), 0, "mkdir failed");
+	zassert_equal(fs_unlink("/sml/dir/."), -EINVAL, "unlink dir/\".\" must fail");
+	zassert_equal(fs_unlink("/sml/dir/.."), -EINVAL, "unlink dir/\"..\" must fail");
+	zassert_equal(fs_rename("/sml/dir", "/sml/."), -EINVAL,
+			"rename onto \".\" must fail");
+	zassert_equal(fs_rename("/sml/dir/.", "/sml/x"), -EINVAL,
+			"rename of \".\" must fail");
+
+	zassert_equal(fs_stat("/sml/dir", &stat), 0, "directory should still exist");
+	zassert_equal(fs_unmount(mp), 0, "Unmount failed");
+}
+
+ZTEST(ext2tests, test_indirect_dir_unlink)
+{
+	struct fs_mount_t *mp = &testfs_mnt;
+	/* 128 KiB stays in one block group on the 128 MiB flash and 9 MiB
+	 * ramdisk variants. fs_size=0 uses the whole device and mkfs then
+	 * returns -ENOTSUP. Dense inodes also need a small volume so
+	 * s_inodes_count fits in one bitmap block.
+	 */
+	struct ext2_cfg cfg = {
+		.block_size = 1024,
+		.fs_size = 0x20000,
+		.bytes_per_inode = 128,
+		.volume_name = {'e', 'x', 't', '2', '\0'},
+		.set_uuid = false,
+	};
+	char path[256];
+	struct fs_dirent stat;
+	int rc;
+
+	zassert_equal(fs_mkfs(FS_EXT2, (uintptr_t)mp->storage_dev, &cfg, 0), 0,
+			"mkfs failed");
+
+	mp->flags = FS_MOUNT_FLAG_NO_FORMAT;
+	zassert_equal(fs_mount(mp), 0, "Mount failed");
+	zassert_equal(fs_mkdir("/sml/d"), 0, "mkdir /sml/d failed");
+
+	for (unsigned int i = 0; i < NFILES; i++) {
+		make_dir_path(path, sizeof(path), i);
+		rc = create_file(path);
+		zassert_equal(rc, 0, "create %u failed: %d", i, rc);
+	}
+
+	make_dir_path(path, sizeof(path), SURVIVOR);
+	zassert_equal(fs_stat(path, &stat), 0, "survivor must exist before unlink");
+
+	for (unsigned int i = INDIRECT_FIRST + 1; i <= INDIRECT_LAST; i++) {
+		make_dir_path(path, sizeof(path), i);
+		rc = fs_unlink(path);
+		zassert_equal(rc, 0, "unlink %u failed: %d", i, rc);
+	}
+
+	make_dir_path(path, sizeof(path), INDIRECT_FIRST);
+	rc = fs_unlink(path);
+	zassert_equal(rc, 0, "unlink of first indirect entry failed: %d", rc);
+
+	zassert_equal(fs_unmount(mp), 0, "unmount failed");
+	mp->flags = FS_MOUNT_FLAG_NO_FORMAT;
+	zassert_equal(fs_mount(mp), 0, "remount failed");
+
+	make_dir_path(path, sizeof(path), SURVIVOR);
+	rc = fs_stat(path, &stat);
+	zassert_equal(rc, 0, "survivor stat failed after unlink: %d", rc);
+
+	zassert_equal(fs_unmount(mp), 0, "final unmount failed");
+}


### PR DESCRIPTION
This is with reference to issue #117779 

The ext2 backend previously trusted several on-disk values without validating them against the in-memory inode layout or disk geometry. This PR introduces strict bounds checking and fixes structural bugs related to directory unlinking and root renaming.

1. Directory unlink corruption

Problem: ext2_del_direntry() incorrectly used a logical directory block number to directly index the i_block[] array. While this happened to work for the first 12 direct slots, it critically failed for directories utilizing a single-indirect block. In those cases, the unlink path would overwrite the indirect pointer, free the wrong block, fail to shrink i_size or i_blocks, and ultimately cause later directory entries to disappear after a remount.

Fix: Corrected the block indexing logic in the unlink path so that it safely resolves and handles indirect blocks without corrupting the inode's pointers or leaking metadata.

2. Root rename NULL dereference

Problem: Looking up the filesystem root leaves the parent pointer as NULL. Attempting to rename the root directory (e.g., executing fs_rename("/sml", "/sml/moved")) resulted in a system crash due to a NULL pointer dereference inside ext2_move_file().

Fix: Added explicit safeguards to reject the root directory, ., and .. as valid targets for unlink or rename operations. The backend now also actively checks for and guards against NULL parent pointers.

3. Metadata out-of-bounds vulnerabilities

Problem: Insufficient bounds checking on metadata allowed invalid inode numbers, invalid block groups, and integer overflows in block addresses to bypass validation.

Fix: Introduced rigorous bounds validation across the backend:
- Inode numbers are now strictly checked against s_inodes_count.
- Block group lookups now reject out-of-bounds groups (e.g., group == ngroups).
- The mount process now explicitly rejects an s_inodes_count that is larger than what a single inode-bitmap block can hold.
- Disk block addresses are now calculated using 64-bit arithmetic to prevent overflow before the range check occurs.