### PR TITLE
boards: lilygo: t_deck: fix out-of-range SD card chip-select GPIO

### DIFF
--- a/boards/lilygo/t_deck/t_deck_procpu.dts
+++ b/boards/lilygo/t_deck/t_deck_procpu.dts
@@ -200,7 +200,7 @@
 	pinctrl-names = "default";
 	clock-frequency = <DT_FREQ_M(40)>;
 	cs-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>, <&gpio0 9 GPIO_ACTIVE_LOW>,
-		   <&gpio0 39 GPIO_ACTIVE_LOW>;
+		   <&gpio1 7 GPIO_ACTIVE_LOW>;
 
 	lora: lora@1 {
 		compatible = "semtech,sx1262";


### PR DESCRIPTION
## Description

`spi2`'s `cs-gpios` list in the T-Deck devicetree gives the SD card's chip
select as `<&gpio0 39>`. On the ESP32-S3 `gpio0` has `ngpios = <32>` (pins
0..31) and `gpio1` covers 32..53, so GPIO39 is `gpio1` pin 7.

The consequence reaches well past the SD card. A pin index is a bit position
in a 32-bit `gpio_port_pins_t`, so `gpio_pin_configure()` range checks it
against `GPIO_MAX_PINS_PER_PORT` and returns `-EINVAL` for anything from 32
up. That check is unconditional — distinct from the `__ASSERT` on the
controller's `port_pin_mask` just above it, which compiles out without
`CONFIG_ASSERT`. The error propagates out of `spi_context_cs_configure_all()`
and fails `spi_esp32_init()`, which takes the entire bus with it.

On a stock `samples/subsys/display/lvgl` build, `device list` reports:

```
- spi@60024000  (DISABLED)
- mipi_dbi      (DISABLED)
- st7789v@0     (DISABLED)
- trackball     (READY)
- touchscreen@5d (READY)
```

so the board boots and the input devices come up, but the display never
lights — which is what sent me looking.

With the chip select expressed against the correct controller, the same
command on the same build reports:

```
- spi@60024000  (READY)
  requires: gpio@60004800     <- gpio1, i.e. the fix taking effect
  requires: gpio@60004000
- mipi_dbi      (READY)
- st7789v@0     (READY)
```

and the panel works.

The pin itself does not change. `gpio_esp32_config()` computes
`io_pin = pin + ((gpio_port == 1 && pin < 32) ? 32 : 0)`, so `<&gpio0 39>`
and `<&gpio1 7>` both resolve to physical GPIO39. This only spells the
intended pin in a form the generic GPIO API accepts.

## Testing

Hardware: LilyGO T-Deck, ESP32-S3 rev v0.2, 8 MB PSRAM, flashed over the
built-in USB-Serial/JTAG.

- `samples/subsys/display/lvgl` on `t_deck/esp32s3/procpu` — before the
  change the panel stays dark and the three devices above are `DISABLED`;
  after it, the demo renders and the trackball's centre press registers.
- An out-of-tree BLE application on the same board target, driving the
  ST7789V through the display API, plus the GT911 and the trackball. All
  report `READY` and the panel renders correctly.
- `samples/hello_world` builds for both `t_deck/esp32s3/procpu` and
  `t_deck@plus/esp32s3/procpu`.
- `scripts/checkpatch.pl` — clean.

One caveat, stated plainly: I have not exercised the SD card with a card
inserted. This verifies that GPIO39 is now expressed in a form the GPIO API
accepts and that the bus and the other devices on it initialise — not that
the SD slot enumerates. Happy to test that if it would help; I just did not
want to imply coverage I do not have.

## Notes

Introduced in 2bd92ce5141 ("boards: lilygo: add initial suport for LilyGo
T-Deck and T-Deck Plus"). cc @kartben
