### PR TITLE
drivers: comparator: document the fake comparator driver

### DIFF
--- a/doc/hardware/peripherals/comparator.rst
+++ b/doc/hardware/peripherals/comparator.rst
@@ -68,3 +68,5 @@ API Reference
 *************
 
 .. doxygengroup:: comparator_interface
+
+.. doxygengroup:: comparator_fake

--- a/include/zephyr/drivers/comparator/fake_comp.h
+++ b/include/zephyr/drivers/comparator/fake_comp.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Fake comparator driver API functions.
+ * @ingroup comparator_fake
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_COMPARATOR_FAKE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_COMPARATOR_FAKE_H_
 
@@ -14,24 +20,53 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Fake comparator driver
+ * @defgroup comparator_fake Fake comparator
+ * @ingroup io_emulators
+ * @ingroup comparator_interface
+ *
+ * @driver_fake{comparator_interface,CONFIG_COMPARATOR_FAKE_COMP,zephyr\,fake-comp}
+ *
+ * @code{.c}
+ * const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(fake_comp));
+ *
+ * comp_fake_comp_get_output_fake.return_val = 1;
+ *
+ * zassert_equal(1, comparator_get_output(dev));
+ * zassert_equal(1, comp_fake_comp_get_output_fake.call_count);
+ * zassert_equal(dev, comp_fake_comp_get_output_fake.arg0_val);
+ * @endcode
+ *
+ * @{
+ */
+
+/** @fake_of{comparator_driver_api::get_output} */
 DECLARE_FAKE_VALUE_FUNC(int,
 			comp_fake_comp_get_output,
 			const struct device *);
 
+/** @fake_of{comparator_driver_api::set_trigger} */
 DECLARE_FAKE_VALUE_FUNC(int,
 			comp_fake_comp_set_trigger,
 			const struct device *,
 			enum comparator_trigger);
 
+/** @fake_of{comparator_driver_api::set_trigger_callback} */
 DECLARE_FAKE_VALUE_FUNC(int,
 			comp_fake_comp_set_trigger_callback,
 			const struct device *,
 			comparator_callback_t,
 			void *);
 
+/** @fake_of{comparator_driver_api::trigger_is_pending} */
 DECLARE_FAKE_VALUE_FUNC(int,
 			comp_fake_comp_trigger_is_pending,
 			const struct device *);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Documents the fake comparator driver as a Doxygen group, with each fake documented as the API function it stands in for.

The first two commits come from #117979 and will be dropped from this PR once that merges.

https://builds.zephyrproject.io/zephyr/pr/117915/docs/doxygen/html/group__comparator__fake.html