### PR TITLE
drivers: eeprom: document the fake EEPROM driver

### DIFF
--- a/doc/hardware/peripherals/eeprom/api.rst
+++ b/doc/hardware/peripherals/eeprom/api.rst
@@ -20,3 +20,5 @@ API Reference
 *************
 
 .. doxygengroup:: eeprom_interface
+
+.. doxygengroup:: eeprom_fake

--- a/include/zephyr/drivers/eeprom/eeprom_fake.h
+++ b/include/zephyr/drivers/eeprom/eeprom_fake.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_EEPROM_FAKE_EEPROM_H_
-#define ZEPHYR_INCLUDE_DRIVERS_EEPROM_FAKE_EEPROM_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_EEPROM_EEPROM_FAKE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_EEPROM_EEPROM_FAKE_H_
 
 #include <zephyr/drivers/eeprom.h>
 #include <zephyr/fff.h>
@@ -24,4 +24,4 @@ DECLARE_FAKE_VALUE_FUNC(size_t, fake_eeprom_size, const struct device *);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_EEPROM_FAKE_EEPROM_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_EEPROM_EEPROM_FAKE_H_ */

--- a/include/zephyr/drivers/eeprom/eeprom_fake.h
+++ b/include/zephyr/drivers/eeprom/eeprom_fake.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Fake EEPROM driver API functions.
+ * @ingroup eeprom_fake
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_EEPROM_EEPROM_FAKE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_EEPROM_EEPROM_FAKE_H_
 
@@ -14,11 +20,46 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Fake EEPROM driver
+ * @defgroup eeprom_fake Fake EEPROM
+ * @ingroup io_emulators
+ * @ingroup eeprom_interface
+ *
+ * @driver_fake{eeprom_interface,CONFIG_EEPROM_FAKE,zephyr\,fake-eeprom}
+ *
+ * `fake_eeprom_read()` and `fake_eeprom_size()` are given a default
+ * `custom_fake` honouring the size from devicetree and zero-filling reads,
+ * re-installed on every reset. Install your own `custom_fake` in the test case
+ * to change what they report.
+ *
+ * @code{.c}
+ * const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(fake_eeprom));
+ * const uint8_t data[] = {0x01, 0x02};
+ *
+ * zassert_ok(eeprom_write(dev, 8, data, sizeof(data)));
+ *
+ * zassert_equal(1, fake_eeprom_write_fake.call_count);
+ * zassert_equal(dev, fake_eeprom_write_fake.arg0_val);
+ * zassert_equal(8, fake_eeprom_write_fake.arg1_val);
+ * zassert_equal(sizeof(data), fake_eeprom_write_fake.arg3_val);
+ * @endcode
+ *
+ * @{
+ */
+
+/** @fake_of{eeprom_driver_api::read} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_eeprom_read, const struct device *, off_t, void *, size_t);
 
+/** @fake_of{eeprom_driver_api::write} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_eeprom_write, const struct device *, off_t, const void *, size_t);
 
+/** @fake_of{eeprom_driver_api::size} */
 DECLARE_FAKE_VALUE_FUNC(size_t, fake_eeprom_size, const struct device *);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Documents the fake EEPROM driver as a Doxygen group, with each fake documented as the API function it stands in for, and fixes the header's include guard.

The first two commits come from #117979 and will be dropped from this PR once that merges.

https://builds.zephyrproject.io/zephyr/pr/117916/docs/doxygen/html/group__eeprom__fake.html