### PR TITLE
drivers: led: document the fake LED controller driver

### DIFF
--- a/doc/hardware/peripherals/led.rst
+++ b/doc/hardware/peripherals/led.rst
@@ -159,3 +159,8 @@ LED Strip
 =========
 
 .. doxygengroup:: led_strip_interface
+
+Fake LED controller
+===================
+
+.. doxygengroup:: led_fake

--- a/include/zephyr/drivers/led/led_fake.h
+++ b/include/zephyr/drivers/led/led_fake.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Fake LED controller driver API functions.
+ * @ingroup led_fake
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_LED_LED_FAKE_H_
@@ -20,62 +21,52 @@ extern "C" {
 #endif
 
 /**
- * @brief Fake LED controller driver API functions.
+ * @brief Fake LED controller driver
  * @defgroup led_fake Fake LED controller
  * @ingroup io_emulators
  * @ingroup led_interface
+ *
+ * @driver_fake{led_interface,CONFIG_LED_FAKE,zephyr\,fake-leds}
+ *
+ * `fake_led_get_info()` and `fake_led_set_color()` are given a default
+ * `custom_fake` resolving the LED index and colour count against the devicetree
+ * node, re-installed on every reset. Install your own `custom_fake` in the test
+ * case to change what they report.
+ *
+ * @code{.c}
+ * const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(fake_leds));
+ *
+ * fake_led_on_fake.return_val = -EIO;
+ *
+ * zassert_equal(-EIO, led_on(dev, 2));
+ * zassert_equal(1, fake_led_on_fake.call_count);
+ * zassert_equal(2, fake_led_on_fake.arg1_val);
+ * @endcode
+ *
  * @{
  */
 
-/**
- * @brief Turn a fake LED controller LED on.
- *
- * @see led_on
- */
+/** @fake_of{led_driver_api::on} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_led_on, const struct device *, uint32_t);
 
-/**
- * @brief Turn a fake LED controller LED off.
- *
- * @see led_off
- */
+/** @fake_of{led_driver_api::off} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_led_off, const struct device *, uint32_t);
 
-/**
- * @brief Set brightness of a fake LED controller LED.
- *
- * @see led_set_brightness
- */
+/** @fake_of{led_driver_api::set_brightness} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_led_set_brightness, const struct device *, uint32_t, uint8_t);
 
-/**
- * @brief Blink a fake LED controller LED.
- *
- * @see led_blink
- */
+/** @fake_of{led_driver_api::blink} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_led_blink, const struct device *, uint32_t, uint32_t, uint32_t);
 
-/**
- * @brief Get info of a fake LED controller LED.
- *
- * @see led_get_info
- */
+/** @fake_of{led_driver_api::get_info} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_led_get_info, const struct device *, uint32_t,
 			const struct led_info **);
 
-/**
- * @brief Set the color of a fake LED controller LED.
- *
- * @see led_set_color
- */
+/** @fake_of{led_driver_api::set_color} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_led_set_color, const struct device *, uint32_t, uint8_t,
 			const uint8_t *);
 
-/**
- * @brief Write/update a strip of a fake LED controller LEDs.
- *
- * @see led_write_channels
- */
+/** @fake_of{led_driver_api::write_channels} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_led_write_channels, const struct device *, uint32_t, uint32_t,
 			const uint8_t *);
 


### PR DESCRIPTION
Documents the fake LED controller driver as a Doxygen group, with each fake documented as the API function it stands in for.

The first two commits come from #117979 and will be dropped from this PR once that merges.

https://builds.zephyrproject.io/zephyr/pr/117917/docs/doxygen/html/group__led__fake.html