### PR TITLE
drivers: pwm: document the fake PWM driver

### DIFF
--- a/doc/hardware/peripherals/pwm.rst
+++ b/doc/hardware/peripherals/pwm.rst
@@ -162,3 +162,5 @@ API Reference
 *************
 
 .. doxygengroup:: pwm_interface
+
+.. doxygengroup:: pwm_fake

--- a/include/zephyr/drivers/pwm/pwm_fake.h
+++ b/include/zephyr/drivers/pwm/pwm_fake.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
-#define INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
 
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/fff.h>
@@ -21,4 +21,4 @@ DECLARE_FAKE_VALUE_FUNC(int, fake_pwm_set_cycles, const struct device *, uint32_
 }
 #endif
 
-#endif /* INCLUDE_DRIVERS_PWM_PWM_FAKE_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PWM_PWM_FAKE_H_ */

--- a/include/zephyr/drivers/pwm/pwm_fake.h
+++ b/include/zephyr/drivers/pwm/pwm_fake.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Fake PWM driver API functions.
+ * @ingroup pwm_fake
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
 
@@ -14,8 +20,34 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Fake PWM driver
+ * @defgroup pwm_fake Fake PWM
+ * @ingroup io_emulators
+ * @ingroup pwm_interface
+ *
+ * @driver_fake{pwm_interface,CONFIG_PWM_FAKE,zephyr\,fake-pwm}
+ *
+ * @code{.c}
+ * const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(fake_pwm));
+ *
+ * zassert_ok(pwm_set_cycles(dev, 0, 1000, 500, 0));
+ *
+ * zassert_equal(1, fake_pwm_set_cycles_fake.call_count);
+ * zassert_equal(1000, fake_pwm_set_cycles_fake.arg2_val);
+ * zassert_equal(500, fake_pwm_set_cycles_fake.arg3_val);
+ * @endcode
+ *
+ * @{
+ */
+
+/** @fake_of{pwm_driver_api::set_cycles} */
 DECLARE_FAKE_VALUE_FUNC(int, fake_pwm_set_cycles, const struct device *, uint32_t, uint32_t,
 			uint32_t, pwm_flags_t);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Documents the fake PWM driver as a Doxygen group, with each fake documented as the API function it stands in for, and fixes the header's include guard.

The first two commits come from #117979 and will be dropped from this PR once that merges.

https://builds.zephyrproject.io/zephyr/pr/117918/docs/doxygen/html/group__pwm__fake.html