### PR TITLE
[v4.3-branch] kernel: Backport z_waitq_head_locked() to 4.3

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -123,6 +123,15 @@ extern uint8_t *z_priv_stack_find(k_thread_stack_t *stack);
 /* Calculate stack usage. */
 int z_stack_space_get(const uint8_t *stack_start, size_t size, size_t *unused_ptr);
 
+/*
+ * Variants of k_heap_free()/k_free() for callers that already hold
+ * _sched_spinlock, avoiding recursive locking when waking heap waiters.
+ * Woken threads are readied but not rescheduled; the caller must ensure
+ * a reschedule happens after releaseing the scheduler lock.
+ */
+void k_heap_free_sched_locked(struct k_heap *heap, void *mem);
+void k_free_sched_locked(void *mem);
+
 #ifdef CONFIG_USERSPACE
 bool z_stack_is_user_capable(k_thread_stack_t *stack);
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 
 #include <zephyr/kernel_structs.h>
+#include <kspinlock.h>
 #include <kernel_internal.h>
 #include <timeout_q.h>
 #include <kthread.h>
@@ -64,6 +65,7 @@ void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
 void z_reschedule_irqlock(uint32_t key);
 void z_unpend_thread(struct k_thread *thread);
 int z_unpend_all(_wait_q_t *wait_q);
+int z_unpend_all_locked(_wait_q_t *wait_q);
 bool z_thread_prio_set(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 

--- a/kernel/include/kspinlock.h
+++ b/kernel/include/kspinlock.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_
+#define ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_
+
+#include <zephyr/spinlock.h>
+#include <stdbool.h>
+
+extern struct k_spinlock _sched_spinlock;
+
+/**
+ * The intent of LOCK_SCHED_SPINLOCK is to lock the scheduler's spinlock for
+ * the scope that follows (e.g. LOCK_SCHED_SPINLOCK { ... }). However, on
+ * single core systems, the scheduler's spinlock is not needed when the locked
+ * region would otherwise be encapsulated by another spinlock (as that spinlock
+ * would degenerate into an IRQ lock). For that degenerate case, this macro
+ * will expand to nothing.
+ */
+#if (CONFIG_MP_MAX_NUM_CPUS == 1)
+#define LOCK_SCHED_SPINLOCK
+#else
+#define LOCK_SCHED_SPINLOCK   K_SPINLOCK(&_sched_spinlock)
+#endif
+
+#endif /* ZEPHYR_KERNEL_INCLUDE_KSPINLOCK_H_ */

--- a/kernel/include/wait_q.h
+++ b/kernel/include/wait_q.h
@@ -14,6 +14,7 @@
 #include <zephyr/sys/rb.h>
 #include <timeout_q.h>
 #include <priority_q.h>
+#include <kspinlock.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,7 +34,7 @@ static inline void z_waitq_init(_wait_q_t *w)
 	};
 }
 
-static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+static inline struct k_thread *z_waitq_head_locked(_wait_q_t *w)
 {
 	return (struct k_thread *)rb_get_min(&w->waitq.tree);
 }
@@ -49,12 +50,32 @@ static inline void z_waitq_init(_wait_q_t *w)
 	sys_dlist_init(&w->waitq);
 }
 
-static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+static inline struct k_thread *z_waitq_head_locked(_wait_q_t *w)
 {
 	return (struct k_thread *)sys_dlist_peek_head(&w->waitq);
 }
 
 #endif /* !CONFIG_WAITQ_SCALABLE */
+
+static inline struct k_thread *z_waitq_head(_wait_q_t *w)
+{
+	struct k_thread *thread = NULL;
+
+	/*
+	 * On a single core system, all callers of this function are already
+	 * protected by a spinlock held by the caller. On those systems, there
+	 * is no need to lock the scheduler's spinlock. However, on SMP systems
+	 * the caller controlled spinlock is insufficient as the thread timeout
+	 * handler may be running on another CPU. Use LOCK_SCHED_SPINLOCK
+	 * to protect the scope as necessary.
+	 */
+
+	LOCK_SCHED_SPINLOCK {
+		thread = z_waitq_head_locked(w);
+	}
+
+	return thread;
+}
 
 #ifdef __cplusplus
 }

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -216,3 +216,24 @@ void k_heap_free(struct k_heap *heap, void *mem)
 		k_spin_unlock(&heap->lock, key);
 	}
 }
+
+/*
+ * Variant of k_heap_free() for callers that already hold _sched_spinlock.
+ * Uses z_unpend_all_locked() to avoid recursive locking.
+ * Any woken threads are readied but not rescheduled. The caller is
+ * responsible for ensuring a reschedule happens after releasing the
+ * scheduler lock.
+ */
+void k_heap_free_sched_locked(struct k_heap *heap, void *mem)
+{
+	k_spinlock_key_t key = k_spin_lock(&heap->lock);
+
+	sys_heap_free(&heap->heap, mem);
+
+	SYS_PORT_TRACING_OBJ_FUNC(k_heap, free, heap);
+	k_spin_unlock(&heap->lock, key);
+
+	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+		z_unpend_all_locked(&heap->wait_q);
+	}
+}

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
+#include <kernel_internal.h>
 
 typedef void * (sys_heap_allocator_t)(struct sys_heap *heap, size_t align, size_t bytes);
 
@@ -69,6 +70,20 @@ void k_free(void *ptr)
 		k_heap_free(*heap_ref, ptr);
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, *heap_ref, heap_ref);
+	}
+}
+
+/* See k_heap_free_sched_locked() */
+void k_free_sched_locked(void *ptr)
+{
+	struct k_heap **heap_ref;
+
+	if (ptr != NULL) {
+		heap_ref = ptr;
+		--heap_ref;
+		ptr = heap_ref;
+
+		k_heap_free_sched_locked(*heap_ref, ptr);
 	}
 }
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -103,24 +103,38 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 #include <zephyr/syscalls/k_msgq_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-int k_msgq_cleanup(struct k_msgq *msgq)
+int z_msgq_cleanup(struct k_msgq *msgq, bool locked)
 {
 	int ret = 0;
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, cleanup, msgq);
 
-	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
+	CHECKIF(locked && (z_waitq_head_locked(&msgq->wait_q) != NULL)) {
+		ret = -EBUSY;
+		goto exit;
+	}
+
+	CHECKIF(!locked && (z_waitq_head(&msgq->wait_q) != NULL)) {
 		ret = -EBUSY;
 		goto exit;
 	}
 
 	if ((msgq->flags & K_MSGQ_FLAG_ALLOC) != 0U) {
-		k_free(msgq->buffer_start);
+		if (locked) {
+			k_free_sched_locked(msgq->buffer_start);
+		} else {
+			k_free(msgq->buffer_start);
+		}
 		msgq->flags &= ~K_MSGQ_FLAG_ALLOC;
 	}
 
 exit:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, cleanup, msgq, ret);
 	return ret;
+}
+
+int k_msgq_cleanup(struct k_msgq *msgq)
+{
+	return z_msgq_cleanup(msgq, false);
 }
 
 static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -926,17 +926,29 @@ void *z_get_next_switch_handle(void *interrupted)
 }
 #endif /* CONFIG_USE_SWITCH */
 
-int z_unpend_all(_wait_q_t *wait_q)
+int z_unpend_all_locked(_wait_q_t *wait_q)
 {
 	int need_sched = 0;
 	struct k_thread *thread;
 
-	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
-		z_unpend_thread(thread);
-		z_ready_thread(thread);
+	for (thread = z_waitq_head_locked(wait_q);
+	     thread != NULL;
+	     thread = z_waitq_head_locked(wait_q)) {
+		unpend_thread_no_timeout(thread);
+		z_abort_thread_timeout(thread);
+		ready_thread(thread);
 		need_sched = 1;
 	}
 
+	return need_sched;
+}
+
+int z_unpend_all(_wait_q_t *wait_q)
+{
+	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	int need_sched = z_unpend_all_locked(wait_q);
+
+	k_spin_unlock(&_sched_spinlock, key);
 	return need_sched;
 }
 
@@ -1227,7 +1239,9 @@ static inline void unpend_all(_wait_q_t *wait_q)
 {
 	struct k_thread *thread;
 
-	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
+	for (thread = z_waitq_head_locked(wait_q);
+	     thread != NULL;
+	     thread = z_waitq_head_locked(wait_q)) {
 		unpend_thread_no_timeout(thread);
 		z_abort_thread_timeout(thread);
 		arch_thread_return_value_set(thread, 0);

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -77,26 +77,42 @@ static inline int32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 #include <zephyr/syscalls/k_stack_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-int k_stack_cleanup(struct k_stack *stack)
+int z_stack_cleanup(struct k_stack *stack, bool locked)
 {
+	int ret = 0;
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, cleanup, stack);
 
-	CHECKIF(z_waitq_head(&stack->wait_q) != NULL) {
-		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, -EAGAIN);
+	CHECKIF(locked && (z_waitq_head_locked(&stack->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto out;
+	}
 
-		return -EAGAIN;
+	CHECKIF(!locked && (z_waitq_head(&stack->wait_q) != NULL)) {
+		ret = -EAGAIN;
+		goto out;
 	}
 
 	if ((stack->flags & K_STACK_FLAG_ALLOC) != (uint8_t)0) {
-		k_free(stack->base);
+		if (locked) {
+			k_free_sched_locked(stack->base);
+		} else {
+			k_free(stack->base);
+		}
 		stack->base = NULL;
 		stack->flags &= ~K_STACK_FLAG_ALLOC;
 	}
 
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, 0);
-
-	return 0;
+out:
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, ret);
+	return ret;
 }
+
+int k_stack_cleanup(struct k_stack *stack)
+{
+	return z_stack_cleanup(stack, false);
+}
+
 
 int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
 {

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -75,9 +75,12 @@ static struct k_spinlock obj_lock;         /* kobj struct data */
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 extern uint8_t _thread_idx_map[CONFIG_MAX_THREAD_BYTES];
+
+extern int z_msgq_cleanup(struct k_msgq *q, bool locked);
+extern int z_stack_cleanup(struct k_stack *stack, bool locked);
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 
-static void clear_perms_cb(struct k_object *ko, void *ctx_ptr);
+static void unref_check(struct k_object *ko, uintptr_t index, bool locked);
 
 const char *otype_to_str(enum k_objects otype)
 {
@@ -252,6 +255,13 @@ static struct dyn_obj *dyn_object_find(const void *obj)
 	k_spin_unlock(&lists_lock, key);
 
 	return node;
+}
+
+static void clear_perms_cb(struct k_object *ko, void *ctx_ptr)
+{
+	uintptr_t id = (uintptr_t)ctx_ptr;
+
+	unref_check(ko, id, false);
 }
 
 /**
@@ -624,7 +634,7 @@ static unsigned int thread_index_get(struct k_thread *thread)
  * sys_dlist_remove() below is mutually exclusive with concurrent
  * obj_list traversal in k_object_wordlist_foreach() on another CPU.
  */
-static void unref_check(struct k_object *ko, uintptr_t index)
+static void unref_check(struct k_object *ko, uintptr_t index, bool locked)
 {
 	k_spinlock_key_t key = k_spin_lock(&obj_lock);
 
@@ -655,10 +665,10 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	 */
 	switch (ko->type) {
 	case K_OBJ_MSGQ:
-		k_msgq_cleanup((struct k_msgq *)ko->name);
+		z_msgq_cleanup((struct k_msgq *)ko->name, locked);
 		break;
 	case K_OBJ_STACK:
-		k_stack_cleanup((struct k_stack *)ko->name);
+		z_stack_cleanup((struct k_stack *)ko->name, locked);
 		break;
 	default:
 		/* Nothing to do */
@@ -666,8 +676,13 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	}
 
 	sys_dlist_remove(&dyn->dobj_list);
-	k_free(dyn->data);
-	k_free(dyn);
+	if (locked) {
+		k_free_sched_locked(dyn->data);
+		k_free_sched_locked(dyn);
+	} else {
+		k_free(dyn->data);
+		k_free(dyn);
+	}
 out:
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 	k_spin_unlock(&obj_lock, key);
@@ -717,19 +732,19 @@ void k_thread_perms_clear(struct k_object *ko, struct k_thread *thread)
 #ifdef CONFIG_DYNAMIC_OBJECTS
 		k_spinlock_key_t key = k_spin_lock(&lists_lock);
 
-		unref_check(ko, index);
+		unref_check(ko, index, false);
 		k_spin_unlock(&lists_lock, key);
 #else
-		unref_check(ko, index);
+		unref_check(ko, index, false);
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 	}
 }
 
-static void clear_perms_cb(struct k_object *ko, void *ctx_ptr)
+static void clear_perms_cb_locked(struct k_object *ko, void *ctx_ptr)
 {
 	uintptr_t id = (uintptr_t)ctx_ptr;
 
-	unref_check(ko, id);
+	unref_check(ko, id, true);
 }
 
 void k_thread_perms_all_clear(struct k_thread *thread)
@@ -737,7 +752,7 @@ void k_thread_perms_all_clear(struct k_thread *thread)
 	uintptr_t index = thread_index_get(thread);
 
 	if ((int)index != -1) {
-		k_object_wordlist_foreach(clear_perms_cb, (void *)index);
+		k_object_wordlist_foreach(clear_perms_cb_locked, (void *)index);
 	}
 }
 


### PR DESCRIPTION
Backports a fix that splits z_waitq_head() into versions:
    z_waitq_head_locked() and z_waitq_head()
When the scheduler's spinlock is known to be already held, z_waitq_head_locked() should be used--otherwise, z_waitq_head() is to be used. This helps prevent corruption.

However, this approach uncovered paths in k_thread_perms_all_clear() where the scheduler spinlock could be recusrively taken when a thread is aborted. To work around the recursion, knowledge of the scheduler's spinlock state must be passed to the lower layers for use in the cleanup routines for message queues and stacks.

Fixes #117334