### PR TITLE
ztest: print RunID at the start of each test, also in sysbuild

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -325,6 +325,7 @@ function(ExternalZephyrProject_Add)
     CMAKE_VERBOSE_MAKEFILE
     WEST_PYTHON        # Temporary export. Waiting for #87083 and extensions.cmake to be cleaned up.
     Python3_EXECUTABLE # Temporary export. Waiting for #87083 and extensions.cmake to be cleaned up.
+    TC_RUNID           # Test run id, consumed at configure time by subsys/testsuite/ztest.
     ZEPHYR_BASE
   )
 

--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -44,12 +44,27 @@
  *
  * TC_RUNID is any string, that will be converted to a string literal.
  */
+/**
+ * @def TC_PRINT_RUNID_START
+ * @brief Report a Run ID when a test image starts executing
+ *
+ * Counterpart of TC_PRINT_RUNID emitted at the beginning of a run, so
+ * that one run's output is bracketed by two Run ID markers. A start
+ * marker observed while output of an earlier run is still pending
+ * tells a log parser that the device restarted and that the pending
+ * output is stale, without depending on the optional boot banner.
+ *
+ * Prints ``RunID started: <TC_RUNID>`` when \c TC_RUNID is defined,
+ * nothing otherwise.
+ */
 #define TC_STR_HELPER(x) #x
 #define TC_STR(x) TC_STR_HELPER(x)
 #ifdef TC_RUNID
 #define TC_PRINT_RUNID PRINT_DATA("RunID: " TC_STR(TC_RUNID) "\n")
+#define TC_PRINT_RUNID_START PRINT_DATA("RunID started: " TC_STR(TC_RUNID) "\n")
 #else
 #define TC_PRINT_RUNID do {} while (false)
+#define TC_PRINT_RUNID_START do {} while (false)
 #endif
 
 #ifndef PRINT_LINE

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -1347,6 +1347,7 @@ void __weak test_main(void)
 #ifdef ZTEST_UNITTEST
 int main(void)
 {
+	TC_PRINT_RUNID_START;
 	z_init_mock();
 	test_main();
 	end_report();
@@ -1600,6 +1601,7 @@ int main(void)
 #endif
 #endif /* CONFIG_USERSPACE */
 
+	TC_PRINT_RUNID_START;
 	z_init_mock();
 #ifndef CONFIG_ZTEST_SHELL
 	test_main();


### PR DESCRIPTION
The RunID that twister injects into a test image is only printed from
TC_END_REPORT, so nothing in the console output identifies which image
produced it until a run completes. Output captured from a previously
programmed image -- the serial port is opened before flashing by
default -- or from a run cut short by a restart is indistinguishable
from the current run, which twister's Ztest harness can only guess at
from duplicate markers or the optional boot banner.

Also print the RunID when the image starts executing, using the
distinct "RunID started:" prefix, so a run's output is bracketed by
two markers and the existing end-of-run id verification keeps its
meaning. Nothing is printed when TC_RUNID is not defined, as before.
