### PR TITLE
ec_host_cmd: spi_stm32: prevent DMA race on unexpected CS toggles

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -662,10 +662,9 @@ void gpio_cb_nss(const struct device *port, struct gpio_callback *cb, gpio_port_
 	if (gpio_pin_get(hc_spi->cs.port, hc_spi->cs.pin)) {
 		ec_host_cmd_pm_policy_state_lock_put(hc_spi);
 
-		/* CS asserted during processing a command. Prepare for receiving after
-		 * sending response.
-		 */
-		if (hc_spi->state == SPI_HOST_CMD_STATE_PROCESSING) {
+		/* If command processing or response sending is in progress, do not re-arm RX. */
+		if (hc_spi->state == SPI_HOST_CMD_STATE_PROCESSING ||
+		    hc_spi->state == SPI_HOST_CMD_STATE_SENDING) {
 			hc_spi->prepare_rx_later = 1;
 			return;
 		}
@@ -679,6 +678,13 @@ void gpio_cb_nss(const struct device *port, struct gpio_callback *cb, gpio_port_
 	}
 
 	/* CS asserted. Receive full packet and call general handler */
+	if (hc_spi->state == SPI_HOST_CMD_STATE_PROCESSING ||
+	    hc_spi->state == SPI_HOST_CMD_STATE_SENDING) {
+		/* Ignore unexpected CS assertions while busy. Do not alter state to RX_BAD. */
+		LOG_WRN("Unexpected CS assert in state %d", hc_spi->state);
+		return;
+	}
+
 	if (hc_spi->state == SPI_HOST_CMD_STATE_READY_TO_RX) {
 		/* The SPI module and DMA are already configured and ready to receive data.
 		 * Consider disabling the SPI module at the end of sending response and


### PR DESCRIPTION
Unexpected CS assertions during PROCESSING or SENDING states previously fell through to the spi_bad_rx label, clobbering the backend state to RX_BAD. A subsequent CS deassertion would then fail the state check and immediately re-arm RX DMA into the shared buffer while the handler thread was still processing the active request.

Fix this by:
- Ignoring unexpected CS assertions during PROCESSING and SENDING states with a warning log, preserving the current state and avoiding hardware TX register corruption.
- Extending the CS deassertion deferral check to cover the SENDING state in addition to PROCESSING, ensuring RX re-arming is safely postponed until the TX transfer completes.