### PR TITLE
rtio: harden syscall verifiers

### DIFF
--- a/subsys/rtio/rtio_syscalls.c
+++ b/subsys/rtio/rtio_syscalls.c
@@ -88,23 +88,27 @@ static inline int z_vrfy_rtio_sqe_cancel(struct rtio_sqe *sqe)
 	 * K_SYSCALL_MEMORY_READ check is wrong here. A malicious user could
 	 * still pass an arbitrary pointer, which the impl's CONTAINER_OF would
 	 * turn into an arbitrary kernel write of RTIO_SQE_CANCELED. Bound the
-	 * handle against the actual SQE pools before forwarding.
+	 * handle against the actual SQE pools, and require permission on the
+	 * RTIO context owning the matching pool.
 	 */
-	bool valid = false;
+	struct rtio *owner = NULL;
 	uintptr_t addr = (uintptr_t)CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
 
-	STRUCT_SECTION_FOREACH(rtio_sqe_pool, p) {
+	STRUCT_SECTION_FOREACH(rtio, ctx) {
+		const struct rtio_sqe_pool *p = ctx->sqe_pool;
 		uintptr_t base = (uintptr_t)p->pool;
 		uintptr_t end = base + (uintptr_t)p->pool_size * sizeof(struct rtio_iodev_sqe);
 
 		if (addr >= base && addr < end &&
 		    (addr - base) % sizeof(struct rtio_iodev_sqe) == 0) {
-			valid = true;
+			owner = ctx;
 			break;
 		}
 	}
 
-	K_OOPS(K_SYSCALL_VERIFY_MSG(valid, "invalid sqe handle"));
+	K_OOPS(K_SYSCALL_VERIFY_MSG(owner != NULL, "invalid sqe handle"));
+	K_OOPS(K_SYSCALL_OBJ(owner, K_OBJ_RTIO));
+
 	return z_impl_rtio_sqe_cancel(sqe);
 }
 #include <zephyr/syscalls/rtio_sqe_cancel_mrsh.c>

--- a/subsys/rtio/rtio_syscalls.c
+++ b/subsys/rtio/rtio_syscalls.c
@@ -31,11 +31,11 @@ static inline bool rtio_vrfy_sqe(struct rtio_sqe *sqe)
 	case RTIO_OP_NOP:
 		break;
 	case RTIO_OP_TX:
-		valid_sqe &= K_SYSCALL_MEMORY(sqe->tx.buf, sqe->tx.buf_len, false);
+		valid_sqe &= !K_SYSCALL_MEMORY(sqe->tx.buf, sqe->tx.buf_len, false);
 		break;
 	case RTIO_OP_RX:
 		if ((sqe->flags & RTIO_SQE_MEMPOOL_BUFFER) == 0) {
-			valid_sqe &= K_SYSCALL_MEMORY(sqe->rx.buf, sqe->rx.buf_len, true);
+			valid_sqe &= !K_SYSCALL_MEMORY(sqe->rx.buf, sqe->rx.buf_len, true);
 		}
 		break;
 	case RTIO_OP_TINY_TX:
@@ -49,8 +49,8 @@ static inline bool rtio_vrfy_sqe(struct rtio_sqe *sqe)
 		break;
 #endif
 	case RTIO_OP_TXRX:
-		valid_sqe &= K_SYSCALL_MEMORY(sqe->txrx.tx_buf, sqe->txrx.buf_len, true);
-		valid_sqe &= K_SYSCALL_MEMORY(sqe->txrx.rx_buf, sqe->txrx.buf_len, true);
+		valid_sqe &= !K_SYSCALL_MEMORY(sqe->txrx.tx_buf, sqe->txrx.buf_len, false);
+		valid_sqe &= !K_SYSCALL_MEMORY(sqe->txrx.rx_buf, sqe->txrx.buf_len, true);
 		break;
 	default:
 		/* RTIO OP must be known and allowable from user mode


### PR DESCRIPTION
**`rtio_vrfy_sqe()` — inverted buffer validation.** `K_SYSCALL_MEMORY()` returns `true` on *failure*, so accumulating it into `valid_sqe` with `&=` and no negation inverted every check: accessible user buffers were rejected, inaccessible ones accepted. Broken since e3d877f8117d (2022), unnoticed because the userspace tests only exercise the mempool RX path, which skips the check. Also drops the write requirement on the TXRX transmit buffer, a `const` source that SPI, I2C and I3C already validate read-only.

**`z_vrfy_rtio_sqe_cancel()` — missing ownership check.** The handle was bounded against the SQE pools, but nothing tied the matching pool back to a context the caller has permission on, so a user thread could cancel submissions queued on another context. Iterating the `rtio` section instead makes the owner available for a `K_SYSCALL_OBJ()` check; every pool has exactly one context, so the accepted address range is unchanged.

The doc blocks that make this polarity so easy to get wrong are fixed separately in #118008.

`rtio_sqe_signal` has no verifier and is left as is... one should probably be added?

Fixes: #119039