### PR TITLE
Fix infineon tfm rtc

### DIFF
--- a/drivers/rtc/Kconfig.infineon
+++ b/drivers/rtc/Kconfig.infineon
@@ -1,7 +1,7 @@
 # Infineon CAT1 RTC configuration options
 
-# Copyright (c) 2024 Cypress Semiconductor Corporation (an Infineon company) or
-# an affiliate of Cypress Semiconductor Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,3 +12,11 @@ config RTC_INFINEON_CAT1
 	select USE_INFINEON_RTC
 	help
 	  This option enables the RTC driver for Infineon CAT1 family.
+
+config RTC_INFINEON_SKIP_SECURE_ACCESS
+	bool "Infineon RTC init skip"
+	default y if BUILD_WITH_TFM || PSOC_EDGE_M55_SRF_SUPPORT
+	depends on RTC_INFINEON_CAT1
+	help
+	  This option limits the scope of the init, if a board's core
+	  is running in a nonsecure TF-M state.

--- a/drivers/rtc/rtc_infineon.c
+++ b/drivers/rtc/rtc_infineon.c
@@ -173,6 +173,12 @@ void _ifx_cat1_rtc_century_interrupt(void)
 	_ifx_cat1_rtc_set_century(_ifx_cat1_rtc_get_century() + 100);
 }
 
+/* Cy_RTC_CenturyInterrupt is a definition for a WEAK function from the hal_infineon module */
+void Cy_RTC_CenturyInterrupt(void)
+{
+	_ifx_cat1_rtc_century_interrupt();
+}
+
 static int ifx_cat1_rtc_init(const struct device *dev)
 {
 	cy_rslt_t rslt = CY_RSLT_SUCCESS;

--- a/drivers/rtc/rtc_infineon.c
+++ b/drivers/rtc/rtc_infineon.c
@@ -183,7 +183,9 @@ static int ifx_cat1_rtc_init(const struct device *dev)
 {
 	cy_rslt_t rslt = CY_RSLT_SUCCESS;
 
+#ifndef CONFIG_RTC_INFINEON_SKIP_SECURE_ACCESS
 	Cy_SysClk_ClkBakSetSource(CY_SYSCLK_BAK_IN_CLKLF);
+#endif
 
 	if (_ifx_cat1_rtc_get_state() == _IFX_CAT1_RTC_STATE_UNINITIALIZED) {
 		if (Cy_RTC_IsExternalResetOccurred()) {

--- a/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
@@ -239,6 +239,10 @@
 	interrupts = <34 4>;
 };
 
+&rtc0 {
+	interrupts = <35 4>;
+};
+
 &can0 {
 	interrupts = <84 4>, <85 4>;
 };

--- a/modules/hal_infineon/mtb-hal-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-hal-cat1/CMakeLists.txt
@@ -92,7 +92,6 @@ zephyr_library_sources_ifdef(CONFIG_SOC_DIE_PSOC6_04
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_FLASH   ${hal_dir}/source/cyhal_nvm.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_I2C     ${hal_dir}/source/cyhal_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_LPTIMER ${hal_dir}/source/cyhal_lptimer.c)
-zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_RTC     ${hal_dir}/source/cyhal_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SDIO    ${hal_dir}/source/cyhal_sdhc.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SPI     ${hal_dir}/source/cyhal_spi.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_TIMER   ${hal_dir}/source/cyhal_timer.c)

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.conf
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};


### PR DESCRIPTION
Fix a bug for the century rollover interrupt on infineon boards.
For the pse84 boards specifically, define irq number for the m55
core. Additionally define a config that skips part of the init,
when running in a tfm boot flow. Without the #ifndef section, the
nonsecure run will stop the board from functioning further.
