### PR TITLE
drivers: charger: harden syscall verifiers

### DIFF
--- a/drivers/charger/charger_handlers.c
+++ b/drivers/charger/charger_handlers.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <string.h>
+
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/drivers/charger.h>
 
@@ -20,6 +22,9 @@ static inline int z_vrfy_charger_get_prop(const struct device *dev, const charge
 	K_OOPS(K_SYSCALL_VERIFY_MSG(prop != CHARGER_PROP_STATUS_NOTIFICATION &&
 				    prop != CHARGER_PROP_ONLINE_NOTIFICATION,
 				    "callbacks may not be read from user mode"));
+
+	/* The whole union is copied out, not just the member the driver writes. */
+	memset(&k_val, 0, sizeof(k_val));
 
 	int ret = z_impl_charger_get_prop(dev, prop, &k_val);
 

--- a/drivers/charger/charger_handlers.c
+++ b/drivers/charger/charger_handlers.c
@@ -7,12 +7,19 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/drivers/charger.h>
 
+BUILD_ASSERT(CHARGER_PROP_COMMON_COUNT == 16,
+	     "charger property added; re-check user mode safety of the propval union");
+
 static inline int z_vrfy_charger_get_prop(const struct device *dev, const charger_prop_t prop,
 					  union charger_propval *val)
 {
 	union charger_propval k_val;
 
 	K_OOPS(K_SYSCALL_DRIVER_CHARGER(dev, get_property));
+
+	K_OOPS(K_SYSCALL_VERIFY_MSG(prop != CHARGER_PROP_STATUS_NOTIFICATION &&
+				    prop != CHARGER_PROP_ONLINE_NOTIFICATION,
+				    "callbacks may not be read from user mode"));
 
 	int ret = z_impl_charger_get_prop(dev, prop, &k_val);
 
@@ -31,6 +38,13 @@ static inline int z_vrfy_charger_set_prop(const struct device *dev, const charge
 	union charger_propval k_val;
 
 	K_OOPS(K_SYSCALL_DRIVER_CHARGER(dev, set_property));
+
+	/* Rejected even when NULL: the notifiers are device state, so a clear would
+	 * let user mode disable a notifier a supervisor thread installed.
+	 */
+	K_OOPS(K_SYSCALL_VERIFY_MSG(prop != CHARGER_PROP_STATUS_NOTIFICATION &&
+				    prop != CHARGER_PROP_ONLINE_NOTIFICATION,
+				    "callbacks may not be set from user mode"));
 
 	K_OOPS(k_usermode_from_copy(&k_val, val, sizeof(union charger_propval)));
 


### PR DESCRIPTION
Neither propval verifier inspected `prop`, and `charger_get_prop` copied out a union it never initialized.

- **Reject notifier properties.** `CHARGER_PROP_STATUS_NOTIFICATION` and `CHARGER_PROP_ONLINE_NOTIFICATION` select function-pointer union members. Both verifiers now reject them in either direction, including when the callback is `NULL` — the notifiers are device state, so allowing a clear would let user mode disable one a supervisor thread installed. A `BUILD_ASSERT` on `CHARGER_PROP_COMMON_COUNT` forces the list to be revisited when a property is added.
- **Zero the propval before copy-out.** `k_val` was uninitialized and the whole union went to user mode on success, while a driver writes only the member the property selects — up to 15 bytes of kernel stack per successful read.

Supervisor mode is unaffected.
