### PR TITLE
logging: add missing verifier for log_frontend_filter_set

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -524,6 +524,16 @@ uint32_t z_vrfy_log_filter_set(struct log_backend const *const backend,
 	return z_impl_log_filter_set(NULL, domain_id, src_id, level);
 }
 #include <zephyr/syscalls/log_filter_set_mrsh.c>
+
+uint32_t z_vrfy_log_frontend_filter_set(int16_t source_id, uint32_t level)
+{
+	K_OOPS(K_SYSCALL_VERIFY_MSG((uint32_t)source_id < log_src_cnt_get(Z_LOG_LOCAL_DOMAIN_ID),
+		"Invalid log source id"));
+	K_OOPS(K_SYSCALL_VERIFY_MSG((level <= LOG_LEVEL_DBG), "Invalid log level"));
+
+	return z_impl_log_frontend_filter_set(source_id, level);
+}
+#include <zephyr/syscalls/log_frontend_filter_set_mrsh.c>
 #endif
 
 static void link_filter_set(const struct log_link *link,


### PR DESCRIPTION
Harden syscall verifiers for logging.

- `log_frontend_filter_set`: add the verifier and marshaller include; the syscall was not dispatched. Bounds `source_id` against the local domain's source count and caps `level` at `LOG_LEVEL_DBG`.

`z_log_msg_simple_create_0/1/2` also lack verifiers; left as is, since exposing them needs a decision on the packaged-argument format first.