### PR TITLE
drivers: espi: validate the packet snapshot handed to the driver

### DIFF
--- a/drivers/espi/espi_handlers.c
+++ b/drivers/espi/espi_handlers.c
@@ -112,9 +112,9 @@ static inline int z_vrfy_espi_write_request(const struct device *dev,
 	struct  espi_request_packet req_copy;
 
 	K_OOPS(K_SYSCALL_DRIVER_ESPI(dev, write_request));
-	K_OOPS(K_SYSCALL_MEMORY_READ(req->data, req->len));
 	K_OOPS(k_usermode_from_copy(&req_copy, req,
 				sizeof(struct espi_request_packet)));
+	K_OOPS(K_SYSCALL_MEMORY_READ(req_copy.data, req_copy.len));
 
 	ret = z_impl_espi_write_request(dev, &req_copy);
 
@@ -129,9 +129,9 @@ static inline int z_vrfy_espi_send_oob(const struct device *dev,
 	struct  espi_oob_packet pckt_copy;
 
 	K_OOPS(K_SYSCALL_DRIVER_ESPI(dev, send_oob));
-	K_OOPS(K_SYSCALL_MEMORY_READ(pckt->buf, pckt->len));
 	K_OOPS(k_usermode_from_copy(&pckt_copy, pckt,
 				sizeof(struct espi_oob_packet)));
+	K_OOPS(K_SYSCALL_MEMORY_READ(pckt_copy.buf, pckt_copy.len));
 
 	ret = z_impl_espi_send_oob(dev, &pckt_copy);
 
@@ -148,7 +148,7 @@ static inline int z_vrfy_espi_receive_oob(const struct device *dev,
 	K_OOPS(K_SYSCALL_DRIVER_ESPI(dev, receive_oob));
 	K_OOPS(k_usermode_from_copy(&pckt_copy, pckt,
 				sizeof(struct espi_oob_packet)));
-	K_OOPS(K_SYSCALL_MEMORY_WRITE(pckt->buf, pckt->len));
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(pckt_copy.buf, pckt_copy.len));
 
 	ret = z_impl_espi_receive_oob(dev, &pckt_copy);
 	K_OOPS(k_usermode_to_copy(pckt, &pckt_copy,
@@ -167,9 +167,9 @@ static inline int z_vrfy_espi_read_flash(const struct device *dev,
 	K_OOPS(K_SYSCALL_DRIVER_ESPI(dev, flash_read));
 	K_OOPS(k_usermode_from_copy(&pckt_copy, pckt,
 				sizeof(struct espi_flash_packet)));
-	K_OOPS(K_SYSCALL_MEMORY_WRITE(pckt->buf, pckt->len));
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(pckt_copy.buf, pckt_copy.len));
 
-	ret = z_impl_espi_read_flash(dev, pckt);
+	ret = z_impl_espi_read_flash(dev, &pckt_copy);
 	K_OOPS(k_usermode_to_copy(pckt, &pckt_copy,
 			      sizeof(struct espi_flash_packet)));
 
@@ -186,7 +186,7 @@ static inline int z_vrfy_espi_write_flash(const struct device *dev,
 	K_OOPS(K_SYSCALL_DRIVER_ESPI(dev, flash_write));
 	K_OOPS(k_usermode_from_copy(&pckt_copy, pckt,
 				sizeof(struct espi_flash_packet)));
-	K_OOPS(K_SYSCALL_MEMORY_READ(pckt->buf, pckt->len));
+	K_OOPS(K_SYSCALL_MEMORY_READ(pckt_copy.buf, pckt_copy.len));
 
 	ret = z_impl_espi_write_flash(dev, &pckt_copy);
 
@@ -200,10 +200,10 @@ static inline int z_vrfy_espi_flash_erase(const struct device *dev,
 	int ret;
 	struct  espi_flash_packet pckt_copy;
 
-	K_OOPS(K_SYSCALL_DRIVER_ESPI(dev, flash_write));
+	K_OOPS(K_SYSCALL_DRIVER_ESPI(dev, flash_erase));
 	K_OOPS(k_usermode_from_copy(&pckt_copy, pckt,
 				sizeof(struct espi_flash_packet)));
-	K_OOPS(K_SYSCALL_MEMORY_READ(pckt->buf, pckt->len));
+	K_OOPS(K_SYSCALL_MEMORY_READ(pckt_copy.buf, pckt_copy.len));
 
 	ret = z_impl_espi_flash_erase(dev, &pckt_copy);
 


### PR DESCRIPTION
Harden syscall verifiers for espi. Six verifiers checked the `buf`/`len` fields on the caller's struct rather than on the local copy handed to the driver.

- `espi_read_flash`: pass `&pckt_copy` to the implementation and check the copy's fields.
- `espi_receive_oob`, `espi_write_flash`, `espi_flash_erase`: check `pckt_copy` instead of the caller's struct.
- `espi_send_oob`, `espi_write_request`: take the copy first, then check it.
- `espi_flash_erase`: check for the `flash_erase` op; it checked `flash_write` while the implementation calls `flash_erase`.