### PR TITLE
drivers: i3c: snapshot target descriptor in transfer handler

### DIFF
--- a/drivers/i3c/i3c_handlers.c
+++ b/drivers/i3c/i3c_handlers.c
@@ -117,8 +117,13 @@ static uint32_t copy_i3c_msgs_and_transfer(struct i3c_device_desc *target,
 static inline int z_vrfy_i3c_transfer(struct i3c_device_desc *target,
 				      struct i3c_msg *msgs, uint8_t num_msgs)
 {
-	K_OOPS(K_SYSCALL_MEMORY_READ(target, sizeof(*target)));
-	K_OOPS(K_SYSCALL_OBJ(target->bus, K_OBJ_DRIVER_I3C));
+	struct i3c_device_desc target_copy;
+
+	/* Work from a local copy so that the bus which gets validated is
+	 * also the one the transfer is dispatched on.
+	 */
+	K_OOPS(k_usermode_from_copy(&target_copy, target, sizeof(target_copy)));
+	K_OOPS(K_SYSCALL_OBJ(target_copy.bus, K_OBJ_DRIVER_I3C));
 
 	/* copy_msgs_and_transfer() will allocate a copy on the stack using
 	 * VLA, so ensure this won't blow the stack.  Most functions defined
@@ -131,6 +136,6 @@ static inline int z_vrfy_i3c_transfer(struct i3c_device_desc *target,
 	K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(msgs, num_msgs,
 					   sizeof(struct i3c_msg)));
 
-	return copy_i3c_msgs_and_transfer(target, msgs, num_msgs);
+	return copy_i3c_msgs_and_transfer(&target_copy, msgs, num_msgs);
 }
 #include <zephyr/syscalls/i3c_transfer_mrsh.c>


### PR DESCRIPTION
Harden syscall verifiers for i3c.

- `i3c_transfer`: copy the caller's `struct i3c_device_desc` into a local, check `target_copy.bus`, and dispatch on the copy, so the bus that is checked is the one the transfer uses.

Fixes: #119046