### PR TITLE
drivers: i2s: clear mem_slab when unconfiguring from user mode

### DIFF
--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -24,9 +24,13 @@ static inline int z_vrfy_i2s_configure(const struct device *dev,
 				sizeof(struct i2s_config)));
 
 	/* When frame_clk_freq is 0, the stream is being disabled/unconfigured
-	 * and other config fields are not used, so skip validation.
+	 * and other config fields are not used, so skip validation. Clear the
+	 * memory slab so that an unvalidated pointer is never handed to a
+	 * driver that does not special-case this.
 	 */
 	if (config.frame_clk_freq == 0U) {
+		config.mem_slab = NULL;
+		config.block_size = 0;
 		goto do_configure;
 	}
 


### PR DESCRIPTION
Harden syscall verifiers for i2s.

- `i2s_configure`: the `frame_clk_freq == 0` path skipped the `K_SYSCALL_OBJ()` check on `cfg->mem_slab`. Clear `mem_slab` and `block_size` in the copied-in config there, so the documented unconfigure call still works for a thread that owns no memory slab.

Fixes: #119089