### PR TITLE
drivers: counter: correct Kconfig guards on 64-bit verifiers

### DIFF
--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -47,14 +47,12 @@ static inline uint32_t z_vrfy_counter_get_frequency(const struct device *dev)
 }
 #include <zephyr/syscalls/counter_get_frequency_mrsh.c>
 
-#ifdef CONFIG_COUNTER_64BITS_FREQ
 static inline uint64_t z_vrfy_counter_get_frequency_64(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
 	return z_impl_counter_get_frequency_64((const struct device *)dev);
 }
 #include <zephyr/syscalls/counter_get_frequency_64_mrsh.c>
-#endif /* CONFIG_COUNTER_64BITS_FREQ */
 
 static inline uint32_t z_vrfy_counter_us_to_ticks(const struct device *dev, uint64_t us)
 {
@@ -70,7 +68,6 @@ static inline uint64_t z_vrfy_counter_ticks_to_us(const struct device *dev, uint
 }
 #include <zephyr/syscalls/counter_ticks_to_us_mrsh.c>
 
-#ifdef CONFIG_COUNTER_64BITS_TICKS
 static inline uint64_t z_vrfy_counter_us_to_ticks_64(const struct device *dev, uint64_t us)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
@@ -112,7 +109,6 @@ static inline uint64_t z_vrfy_counter_ticks_to_ns_64(const struct device *dev, u
 	return z_impl_counter_ticks_to_ns_64((const struct device *)dev, (uint64_t)ticks);
 }
 #include <zephyr/syscalls/counter_ticks_to_ns_64_mrsh.c>
-#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 static inline int z_vrfy_counter_get_value(const struct device *dev, uint32_t *ticks)
 {
@@ -129,10 +125,9 @@ static inline int z_vrfy_counter_set_value(const struct device *dev, uint32_t ti
 }
 #include <zephyr/syscalls/counter_set_value_mrsh.c>
 
-#ifdef CONFIG_COUNTER_64BITS_TICKS
 static inline int z_vrfy_counter_get_value_64(const struct device *dev, uint64_t *ticks)
 {
-	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_value_64));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(ticks, sizeof(*ticks)));
 	return z_impl_counter_get_value_64(dev, ticks);
 }
@@ -140,11 +135,10 @@ static inline int z_vrfy_counter_get_value_64(const struct device *dev, uint64_t
 
 static inline int z_vrfy_counter_set_value_64(const struct device *dev, uint64_t ticks)
 {
-	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_value_64));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
 	return z_impl_counter_set_value_64(dev, ticks);
 }
 #include <zephyr/syscalls/counter_set_value_64_mrsh.c>
-#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev, uint8_t chan_id,
 						   const struct counter_alarm_cfg *alarm_cfg)
@@ -188,7 +182,6 @@ static inline uint32_t z_vrfy_counter_get_top_value(const struct device *dev)
 }
 #include <zephyr/syscalls/counter_get_top_value_mrsh.c>
 
-#ifdef CONFIG_COUNTER_64BITS_TICKS
 static inline uint64_t z_vrfy_counter_get_max_top_value_64(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
@@ -201,7 +194,11 @@ static inline int z_vrfy_counter_set_top_value_64(const struct device *dev,
 {
 	struct counter_top_cfg_64 cfg_copy;
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_top_value_64));
+#else
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+#endif
 	K_OOPS(k_usermode_from_copy(&cfg_copy, cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
@@ -215,7 +212,11 @@ static inline int z_vrfy_counter_set_channel_alarm_64(const struct device *dev, 
 {
 	struct counter_alarm_cfg_64 cfg_copy;
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_alarm_64));
+#else
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+#endif
 	K_OOPS(k_usermode_from_copy(&cfg_copy, alarm_cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
@@ -226,11 +227,14 @@ static inline int z_vrfy_counter_set_channel_alarm_64(const struct device *dev, 
 
 static inline uint64_t z_vrfy_counter_get_top_value_64(const struct device *dev)
 {
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_top_value_64));
+#else
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+#endif
 	return z_impl_counter_get_top_value_64((const struct device *)dev);
 }
 #include <zephyr/syscalls/counter_get_top_value_64_mrsh.c>
-#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 static inline uint32_t z_vrfy_counter_get_max_top_value(const struct device *dev)
 {
@@ -262,7 +266,6 @@ static inline int z_vrfy_counter_set_guard_period(const struct device *dev, uint
 }
 #include <zephyr/syscalls/counter_set_guard_period_mrsh.c>
 
-#ifdef CONFIG_COUNTER_64BITS_TICKS
 static inline uint64_t z_vrfy_counter_get_guard_period_64(const struct device *dev, uint32_t flags)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
@@ -277,7 +280,6 @@ static inline int z_vrfy_counter_set_guard_period_64(const struct device *dev, u
 	return z_impl_counter_set_guard_period_64(dev, ticks, flags);
 }
 #include <zephyr/syscalls/counter_set_guard_period_64_mrsh.c>
-#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 #ifdef CONFIG_COUNTER_CAPTURE
 static inline int z_vrfy_counter_enable_capture(const struct device *dev,


### PR DESCRIPTION
Correct the Kconfig guards on the counter syscall verifiers.

- Drop the `CONFIG_COUNTER_64BITS_TICKS` / `CONFIG_COUNTER_64BITS_FREQ` guards from the verifiers. The corresponding implementations are unconditional, so those syscalls were not dispatched.
- Keep the driver-op checks behind those options, since the `_64` members of `struct counter_driver_api` are conditional, and use the plain object check otherwise.