### PR TITLE
drivers: bbram: register the syscall header

### DIFF
--- a/drivers/bbram/CMakeLists.txt
+++ b/drivers/bbram/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 Google Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/bbram.h)
+
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_BBRAM_SHELL bbram_shell.c)


### PR DESCRIPTION
`drivers/bbram/CMakeLists.txt` never called `zephyr_syscall_header()` for `bbram.h`, so the marshallers that `bbram_handlers.c` includes were not generated. Register the header.