### PR TITLE
drivers: usb: build and wire up the bc12 syscall handlers

### DIFF
--- a/drivers/usb/bc12/CMakeLists.txt
+++ b/drivers/usb/bc12/CMakeLists.txt
@@ -4,6 +4,8 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/usb/usb_bc12.h)
 
 zephyr_library()
 
+zephyr_library_sources_ifdef(CONFIG_USERSPACE bc12_handlers.c)
+
 zephyr_library_sources_ifdef(CONFIG_USB_BC12_PI3USB9201	bc12_pi3usb9201.c)
 zephyr_library_sources_ifdef(CONFIG_EMUL_BC12_PI3USB9201 emul_bc12_pi3usb9201.c)
 zephyr_include_directories_ifdef(CONFIG_EMUL_BC12_PI3USB9201 .)

--- a/drivers/usb/bc12/bc12_handlers.c
+++ b/drivers/usb/bc12/bc12_handlers.c
@@ -13,6 +13,7 @@ static inline int z_vrfy_bc12_set_role(const struct device *dev, enum bc12_role 
 
 	return z_impl_bc12_set_role(dev, role);
 }
+#include <zephyr/syscalls/bc12_set_role_mrsh.c>
 
 static inline int z_vrfy_bc12_set_result_cb(const struct device *dev, bc12_callback_t cb,
 					    void *user_data)
@@ -22,3 +23,4 @@ static inline int z_vrfy_bc12_set_result_cb(const struct device *dev, bc12_callb
 
 	return z_impl_bc12_set_result_cb(dev, cb, user_data);
 }
+#include <zephyr/syscalls/bc12_set_result_cb_mrsh.c>


### PR DESCRIPTION
`bc12_handlers.c` was not listed in `drivers/usb/bc12/CMakeLists.txt` and included no marshallers, so neither BC12 syscall was dispatched. Build the file under `CONFIG_USERSPACE` and include both marshallers.