### PR TITLE
kernel: fix thread syscall verifier checks

### DIFF
--- a/kernel/dynamic_disabled.c
+++ b/kernel/dynamic_disabled.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/thread_stack.h>
+#include <zephyr/internal/syscall_handler.h>
 
 k_thread_stack_t *z_impl_k_thread_stack_alloc(size_t size, int flags)
 {
@@ -17,9 +18,27 @@ k_thread_stack_t *z_impl_k_thread_stack_alloc(size_t size, int flags)
 	return NULL;
 }
 
+#ifdef CONFIG_USERSPACE
+static inline k_thread_stack_t *z_vrfy_k_thread_stack_alloc(size_t size, int flags)
+{
+	/* No check needed: neither argument is dereferenced, allocation always fails. */
+	return z_impl_k_thread_stack_alloc(size, flags);
+}
+#include <zephyr/syscalls/k_thread_stack_alloc_mrsh.c>
+#endif /* CONFIG_USERSPACE */
+
 int z_impl_k_thread_stack_free(k_thread_stack_t *stack)
 {
 	ARG_UNUSED(stack);
 
 	return -ENOSYS;
 }
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_k_thread_stack_free(k_thread_stack_t *stack)
+{
+	/* No check needed: stack is not dereferenced, -ENOSYS is always returned. */
+	return z_impl_k_thread_stack_free(stack);
+}
+#include <zephyr/syscalls/k_thread_stack_free_mrsh.c>
+#endif /* CONFIG_USERSPACE */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1304,10 +1304,7 @@ int z_vrfy_k_thread_stack_space_get(const struct k_thread *thread,
 	size_t unused;
 	int ret;
 
-	ret = K_SYSCALL_OBJ(thread, K_OBJ_THREAD);
-	CHECKIF(ret != 0) {
-		return ret;
-	}
+	K_OOPS(K_SYSCALL_OBJ(thread, K_OBJ_THREAD));
 
 	ret = z_impl_k_thread_stack_space_get(thread, &unused);
 	CHECKIF(ret != 0) {


### PR DESCRIPTION
Harden syscall verifiers for kernel threads.

- `k_thread_stack_space_get`: consume the object check with `K_OOPS()` rather than `CHECKIF()`, which compiles out under some configurations.
- `k_thread_stack_alloc` / `k_thread_stack_free`: add the verifiers and marshaller includes missing from the `CONFIG_DYNAMIC_THREAD=n` build, where neither syscall was dispatched.