### PR TITLE
libc: picolibc: add missing verifier for zephyr_write_stdout

### DIFF
--- a/lib/libc/picolibc/stdio.c
+++ b/lib/libc/picolibc/stdio.c
@@ -27,6 +27,15 @@ int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
 	}
 	return nbytes;
 }
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_zephyr_write_stdout(const void *buf, int nbytes)
+{
+	K_OOPS(K_SYSCALL_MEMORY_READ(buf, nbytes));
+	return z_impl_zephyr_write_stdout(buf, nbytes);
+}
+#include <zephyr/syscalls/zephyr_write_stdout_mrsh.c>
+#endif
 #endif
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
Add the `zephyr_write_stdout` verifier and marshaller include, matching the newlib and arcmwdt builds. Under picolibc the syscall was not dispatched.