### PR TITLE
fb: cfb: protect public API

### DIFF
--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -260,8 +260,10 @@ int cfb_framebuffer_init(const struct device *dev);
  * @brief Deinitialize Character Framebuffer.
  *
  * @param dev Pointer to device structure for driver instance
+ *
+ * @return 0 on success, negative value otherwise
  */
-void cfb_framebuffer_deinit(const struct device *dev);
+int cfb_framebuffer_deinit(const struct device *dev);
 
 #ifdef __cplusplus
 }

--- a/samples/subsys/display/cfb_shell/tests.yaml
+++ b/samples/subsys/display/cfb_shell/tests.yaml
@@ -11,3 +11,14 @@ tests:
     tags: shield
   sample.display.cfb_shell.ssd16xx:
     platform_allow: reel_board
+    harness: shell
+    harness_config:
+      shell_commands:
+        - command: "cfb get_param all"
+          expected: ".*Failed to get parameter height: -19.*"
+        - command: "cfb init"
+          expected: ".*Framebuffer initialized: ssd16xxfb@0.*"
+        - command: "cfb init"
+          expected: ".*Framebuffer initialization failed: -120.*"
+        - command: "cfb get_param all"
+          expected: ".*param: cols=250.*"

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <errno.h>
 #include <string.h>
 #include <zephyr/display/cfb.h>
 #include <zephyr/sys/byteorder.h>
@@ -29,7 +30,7 @@ static inline uint8_t byte_reverse(uint8_t b)
 }
 
 struct char_framebuffer {
-	/** Pointer to a buffer in RAM */
+	/** Pointer to a buffer in RAM. NULL when structure is not yet/not anymore initialized. */
 	uint8_t *buf;
 
 	/** Size of the framebuffer */
@@ -67,6 +68,15 @@ struct char_framebuffer {
 };
 
 static struct char_framebuffer char_fb;
+
+static inline bool cfb_framebuffer_init_is_done(const struct char_framebuffer *const fb)
+{
+	if (!fb->buf) {
+		return false;
+	}
+
+	return true;
+}
 
 static inline const uint8_t *get_glyph_ptr(const struct cfb_font *fptr, uint8_t c)
 {
@@ -457,7 +467,11 @@ static int draw_text(const struct device *dev, const char *const str, int16_t x,
 	const struct cfb_font *fptr;
 	size_t len;
 
-	if (!fb->fonts || !fb->buf) {
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
+	if (!fb->fonts) {
 		return -ENODEV;
 	}
 
@@ -482,6 +496,10 @@ int cfb_draw_point(const struct device *dev, const struct cfb_position *pos)
 {
 	struct char_framebuffer *fb = &char_fb;
 
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
 	draw_point(fb, pos->x, pos->y);
 
 	return 0;
@@ -492,6 +510,10 @@ int cfb_draw_line(const struct device *dev, const struct cfb_position *start,
 {
 	struct char_framebuffer *fb = &char_fb;
 
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
 	draw_line(fb, start->x, start->y, end->x, end->y);
 
 	return 0;
@@ -501,6 +523,10 @@ int cfb_draw_rect(const struct device *dev, const struct cfb_position *start,
 		  const struct cfb_position *end)
 {
 	struct char_framebuffer *fb = &char_fb;
+
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
 
 	draw_line(fb, start->x, start->y, end->x, start->y);
 	draw_line(fb, end->x, start->y, end->x, end->y);
@@ -516,6 +542,10 @@ int cfb_draw_circle(const struct device *dev, const struct cfb_position *center,
 	uint16_t x = 0;
 	int16_t y = -radius;
 	int16_t p = -radius;
+
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
 
 	/* Using the Midpoint Circle Algorithm */
 	while (x < -y) {
@@ -554,7 +584,13 @@ int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 		    uint16_t width, uint16_t height)
 {
 	const struct char_framebuffer *fb = &char_fb;
-	const bool need_reverse = ((fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0);
+	bool need_reverse;
+
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
+	need_reverse = ((fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0);
 
 	if ((x + width) < 0 || x >= fb->x_res) {
 		return 0;
@@ -669,6 +705,10 @@ int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 
 static int cfb_invert(const struct char_framebuffer *fb)
 {
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
 	for (size_t i = 0; i < fb->x_res * fb->y_res / 8U; i++) {
 		fb->buf[i] = ~fb->buf[i];
 	}
@@ -680,7 +720,7 @@ int cfb_framebuffer_clear(const struct device *dev, bool clear_display)
 {
 	const struct char_framebuffer *fb = &char_fb;
 
-	if (!fb->buf) {
+	if (!cfb_framebuffer_init_is_done(fb)) {
 		return -ENODEV;
 	}
 
@@ -697,6 +737,10 @@ int cfb_framebuffer_invert(const struct device *dev)
 {
 	struct char_framebuffer *fb = &char_fb;
 
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
 	fb->inverted = !fb->inverted;
 
 	return 0;
@@ -710,7 +754,7 @@ int cfb_framebuffer_finalize(const struct device *dev)
 
 	__ASSERT_NO_MSG(DEVICE_API_IS(display, dev));
 
-	if (!fb->buf) {
+	if (!cfb_framebuffer_init_is_done(fb)) {
 		return -ENODEV;
 	}
 
@@ -735,6 +779,10 @@ int cfb_get_display_parameter(const struct device *dev,
 			       enum cfb_display_param param)
 {
 	const struct char_framebuffer *fb = &char_fb;
+
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
 
 	switch (param) {
 	case CFB_DISPLAY_HEIGHT:
@@ -761,6 +809,10 @@ int cfb_framebuffer_set_font(const struct device *dev, uint8_t idx)
 {
 	struct char_framebuffer *fb = &char_fb;
 
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
 	if (idx >= fb->numof_fonts) {
 		return -EINVAL;
 	}
@@ -774,6 +826,10 @@ int cfb_get_font_size(const struct device *dev, uint8_t idx, uint8_t *width,
 		      uint8_t *height)
 {
 	const struct char_framebuffer *fb = &char_fb;
+
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
 
 	if (idx >= fb->numof_fonts) {
 		return -EINVAL;
@@ -792,7 +848,13 @@ int cfb_get_font_size(const struct device *dev, uint8_t idx, uint8_t *width,
 
 int cfb_set_kerning(const struct device *dev, int8_t kerning)
 {
-	char_fb.kerning = kerning;
+	struct char_framebuffer *fb = &char_fb;
+
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
+
+	fb->kerning = kerning;
 
 	return 0;
 }
@@ -800,6 +862,10 @@ int cfb_set_kerning(const struct device *dev, int8_t kerning)
 int cfb_get_numof_fonts(const struct device *dev)
 {
 	const struct char_framebuffer *fb = &char_fb;
+
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		return -ENODEV;
+	}
 
 	return fb->numof_fonts;
 }
@@ -811,6 +877,11 @@ int cfb_framebuffer_init(const struct device *dev)
 	struct display_capabilities cfg;
 
 	__ASSERT_NO_MSG(DEVICE_API_IS(display, dev));
+
+	if (cfb_framebuffer_init_is_done(fb)) {
+		LOG_ERR("Framebuffer already initialized");
+		return -EALREADY;
+	}
 
 	api->get_capabilities(dev, &cfg);
 
@@ -840,13 +911,17 @@ int cfb_framebuffer_init(const struct device *dev)
 	return 0;
 }
 
-void cfb_framebuffer_deinit(const struct device *dev)
+int cfb_framebuffer_deinit(const struct device *dev)
 {
 	struct char_framebuffer *fb = &char_fb;
 
-	if (fb->buf) {
-		k_free(fb->buf);
-		fb->buf = NULL;
+	if (!cfb_framebuffer_init_is_done(fb)) {
+		LOG_ERR("Framebuffer not initialized");
+		return -EALREADY;
 	}
 
+	k_free(fb->buf);
+	fb->buf = NULL;
+
+	return 0;
 }

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -59,6 +59,9 @@ static int cmd_cfb_print(const struct shell *sh, int col, int row, char *str)
 	uint8_t ppt;
 
 	ppt = cfb_get_display_parameter(dev, CFB_DISPLAY_PPT);
+	if (ppt < 0) {
+		shell_error(sh, "Failed to get display parameter=%d", ppt);
+	}
 
 	err = cfb_framebuffer_clear(dev, false);
 	if (err) {
@@ -370,14 +373,24 @@ static int cmd_get_fonts(const struct shell *sh, size_t argc, char *argv[])
 	int err = 0;
 	uint8_t font_height;
 	uint8_t font_width;
+	int numof_fonts;
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	numof_fonts = cfb_get_numof_fonts(dev);
+	if (numof_fonts < 0) {
+		shell_error(sh, "Failed to get fonts: %d", numof_fonts);
+		return numof_fonts;
+	}
+
 	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+		err = cfb_get_font_size(dev, idx, &font_width, &font_height);
+
+		if (err) {
 			break;
 		}
+
 		shell_print(sh, "idx=%d height=%d width=%d", idx,
 			    font_height, font_width);
 	}
@@ -397,6 +410,20 @@ static int cmd_get_device(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
+static int print_display_param(const struct shell *sh, const enum cfb_display_param param)
+{
+	const int err = cfb_get_display_parameter(dev, param);
+
+	if (err < 0) {
+		shell_error(sh, "Failed to get parameter %s: %d", param_name[param], err);
+		return err;
+	}
+
+	shell_print(sh, "param: %s=%d", param_name[param], err);
+
+	return 0;
+}
+
 static int cmd_get_param_all(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
@@ -404,9 +431,11 @@ static int cmd_get_param_all(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argv);
 
 	for (unsigned int i = 0; i <= CFB_DISPLAY_COLS; i++) {
-		shell_print(sh, "param: %s=%d", param_name[i],
-				cfb_get_display_parameter(dev, i));
+		const int err = print_display_param(sh, (enum cfb_display_param)i);
 
+		if (err < 0) {
+			return err;
+		}
 	}
 
 	return 0;
@@ -418,10 +447,7 @@ static int cmd_get_param_height(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_HEIGHT],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGHT));
-
-	return 0;
+	return print_display_param(sh, CFB_DISPLAY_HEIGHT);
 }
 
 static int cmd_get_param_width(const struct shell *sh, size_t argc,
@@ -430,10 +456,7 @@ static int cmd_get_param_width(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_WIDTH],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_WIDTH));
-
-	return 0;
+	return print_display_param(sh, CFB_DISPLAY_WIDTH);
 }
 
 static int cmd_get_param_ppt(const struct shell *sh, size_t argc,
@@ -442,10 +465,7 @@ static int cmd_get_param_ppt(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_PPT],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_PPT));
-
-	return 0;
+	return print_display_param(sh, CFB_DISPLAY_PPT);
 }
 
 static int cmd_get_param_rows(const struct shell *sh, size_t argc,
@@ -454,10 +474,7 @@ static int cmd_get_param_rows(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_ROWS],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS));
-
-	return 0;
+	return print_display_param(sh, CFB_DISPLAY_ROWS);
 }
 
 static int cmd_get_param_cols(const struct shell *sh, size_t argc,
@@ -466,10 +483,7 @@ static int cmd_get_param_cols(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_COLS],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_COLS));
-
-	return 0;
+	return print_display_param(sh, CFB_DISPLAY_COLS);
 }
 
 static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
@@ -498,7 +512,7 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 
 	err = cfb_framebuffer_init(dev);
 	if (err) {
-		shell_error(sh, "Framebuffer initialization failed!");
+		shell_error(sh, "Framebuffer initialization failed: %d", err);
 		return err;
 	}
 


### PR DESCRIPTION
Without those changes, almost all public APIs are unsafe to call before an init and likely even resulted in a crash.

Once could reproduce the error easily by running "cfb get_param all" before "cfb init" in the shell.