### PR TITLE
dts: arm: realtek: bee: correct CAN base address on rtl87x2g

### DIFF
--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -592,9 +592,9 @@
 			#size-cells = <0>;
 		};
 
-		can: can@40038000 {
+		can: can@40028000 {
 			compatible = "realtek,bee-can";
-			reg = <0x40038000 0x34c>;
+			reg = <0x40028000 0x34c>;
 			interrupts = <72 1>;
 			clocks = <&cctl APB_CLK(A2C)>;
 			status = "disabled";


### PR DESCRIPTION
The CAN node unit-address and reg base were 0x40038000; correct them to 0x40028000 to match the SoC memory map.

The Bee CAN driver does not use this reg base to reach the HAL API, so the change has no functional impact on CAN usage.