### PR TITLE
net: gptp: add static timeReceiver mode for Announce-less bridges

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1444,6 +1444,12 @@ New Drivers
 
 * Networking
 
+  * gPTP
+
+    * :kconfig:option:`CONFIG_NET_GPTP_STATIC_TIME_RECEIVER` operates the node as a
+      statically configured time receiver, so it can synchronize through IEEE 802.1AS
+      automotive profile bridges that transmit no Announce messages.
+
   * :dtcompatible:`st,stm32wba-radio` (:github:`110546`)
 
 * :abbr:`OPAMP (Operational Amplifier)`

--- a/doc/services/connectivity/networking/api/gptp.rst
+++ b/doc/services/connectivity/networking/api/gptp.rst
@@ -27,6 +27,10 @@ interfaces (also defined as "ports" in the standard) and thus act as
 a 802.1AS bridge. However, this mode of operation has not been validated on
 the Zephyr OS.
 
+The stack can also operate as a statically configured time receiver on
+networks that follow the IEEE 802.1AS automotive profile, where no Announce
+messages are exchanged. See `Static timeReceiver operation`_ below.
+
 Supported hardware
 ******************
 
@@ -50,6 +54,29 @@ Enabling the stack
 The following configuration option must me enabled in :file:`prj.conf` file.
 
 - :kconfig:option:`CONFIG_NET_GPTP`
+
+Static timeReceiver operation
+*****************************
+
+Networks built after the IEEE 802.1AS automotive profile (AVnu "Automotive
+Ethernet AVB Functional and Interoperability Specification") use static port
+roles instead of the Best Master Clock Algorithm. A bridge on such a network
+transmits Sync and Follow_Up messages but no Announce messages, and is not
+required to answer Pdelay requests on its timeTransmitter ports. The default
+stack cannot synchronize to such a bridge: without a received Announce a port
+never reaches the time receiver ("slave") role.
+
+Enabling :kconfig:option:`CONFIG_NET_GPTP_STATIC_TIME_RECEIVER` configures the
+node as a statically configured time receiver: BMCA and all Announce handling
+are bypassed, every port is pinned to the time receiver role, asCapable is forced so
+synchronization does not depend on the Pdelay measurement, and the local clock
+is disciplined from the received Sync and Follow_Up messages alone. The node
+never becomes grandmaster and never transmits Sync or Announce messages, even
+if :kconfig:option:`CONFIG_NET_GPTP_GM_CAPABLE` is set. This mirrors the
+linuxptp ptp4l automotive time receiver configuration (BMCA "noop", clientOnly,
+inhibit_announce, asCapable "true", ignore_source_id). The standards analog of
+disabling the BMCA this way is the external port configuration of IEEE
+802.1AS-2020 (clause 10.3.14, derived from IEEE 1588-2019 clause 17.6.2).
 
 Application interfaces
 **********************

--- a/samples/net/ethernet/gptp/README.rst
+++ b/samples/net/ethernet/gptp/README.rst
@@ -195,3 +195,23 @@ When the Zephyr image is built, you can start it like this:
 .. code-block:: console
 
     build/zephyr/zephyr.exe -attach_uart
+
+Static timeReceiver Setup
+=========================
+
+On networks built after the IEEE 802.1AS automotive profile the bridge sends
+Sync and Follow_Up but no Announce messages, so the default stack never
+selects a time receiver port. Build the sample with the
+:zephyr_file:`samples/net/ethernet/gptp/overlay-static-time-receiver.conf`
+overlay to pin the port to the time-receiver role instead:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/ethernet/gptp
+   :board: <board to use>
+   :conf: "prj.conf overlay-static-time-receiver.conf"
+   :goals: build
+   :compact:
+
+This can be tested against linuxptp by running ptp4l as a grandmaster that
+sends no Announce messages, for example with a configuration based on the
+``automotive-master.cfg`` file shipped with linuxptp.

--- a/samples/net/ethernet/gptp/overlay-static-time-receiver.conf
+++ b/samples/net/ethernet/gptp/overlay-static-time-receiver.conf
@@ -1,0 +1,6 @@
+# Operate as a statically configured time receiver: BMCA and Announce
+# handling are bypassed, the port role is pinned to time receiver and the
+# clock follows the received Sync/Follow_Up stream. Use this on networks
+# built after the IEEE 802.1AS automotive profile, whose bridges send no
+# Announce messages.
+CONFIG_NET_GPTP_STATIC_TIME_RECEIVER=y

--- a/samples/net/ethernet/gptp/tests.yaml
+++ b/samples/net/ethernet/gptp/tests.yaml
@@ -27,3 +27,17 @@ tests:
     extra_args:
       - EXTRA_CONF_FILE=overlay-multiport.conf
       - EXTRA_DTC_OVERLAY_FILE=overlay-multiport.overlay
+  sample.net.gptp.static_time_receiver:
+    extra_args: EXTRA_CONF_FILE="overlay-static-time-receiver.conf"
+    platform_allow:
+      - frdm_k64f
+      - sam_e70_xplained/same70q21
+      - native_sim
+      - native_sim/native/64
+      - nucleo_f767zi
+      - nucleo_h743zi
+      - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m7
+    depends_on: eth
+    integration_platforms:
+      - frdm_k64f

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -33,6 +33,29 @@ config NET_GPTP_PROBE_CLOCK_SOURCE_ON_DEMAND
 	  updated on each tick.
 	  See IEEE 802.1AS-2011, chapter 9.2 for more details.
 
+config NET_GPTP_STATIC_TIME_RECEIVER
+	bool "Static timeReceiver operation"
+	help
+	  Operate every gPTP port as a statically configured time
+	  receiver, as used by the IEEE 802.1AS automotive profile (AVnu
+	  Automotive Ethernet AVB Functional and Interoperability
+	  Specification). Automotive profile bridges use static port
+	  roles: they transmit Sync and Follow_Up but no Announce
+	  messages, so the BMCA can never select a port role. With this
+	  option the BMCA and all Announce handling are bypassed, the
+	  port role is pinned to the time receiver ("slave") state, asCapable is forced true so that
+	  synchronization does not depend on the neighbor Pdelay
+	  measurement (the bridge is not required to answer Pdelay
+	  requests), and the local clock is disciplined from the received
+	  Sync and Follow_Up messages alone. This matches the linuxptp
+	  ptp4l automotive time receiver configuration (BMCA "noop", clientOnly,
+	  inhibit_announce, asCapable "true", ignore_source_id). The
+	  device never becomes grandmaster and never transmits Sync or
+	  Announce messages, even if NET_GPTP_GM_CAPABLE is set.
+	  The standards analog of disabling the BMCA this way is the
+	  external port configuration of IEEE 802.1AS-2020, chapter
+	  10.3.14, derived from IEEE 1588-2019, chapter 17.6.2.
+
 config NET_GPTP_CLOCK_ACCURACY
 	hex "gPTP Clock Accuracy"
 	range 0 0xff

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -931,6 +931,21 @@ void gptp_md_state_machines(int port)
 {
 	gptp_md_pdelay_req_state_machine(port);
 	gptp_md_pdelay_resp_state_machine(port);
+
+#if defined(CONFIG_NET_GPTP_STATIC_TIME_RECEIVER)
+	/* A static time receiver takes part in synchronization regardless
+	 * of the Pdelay measurement outcome, the upstream bridge is not
+	 * required to answer Pdelay requests. Pin asCapable right after
+	 * the Pdelay state machines, which are its only writers, so the
+	 * Sync receive path never sees it deasserted and never resets.
+	 * Pinning pttPortEnabled is defensive as nothing clears it today,
+	 * but a future portEnabled or link state implementation must not
+	 * silently take down a statically configured time receiver.
+	 */
+	GPTP_PORT_DS(port)->ptt_port_enabled = true;
+	GPTP_PORT_DS(port)->as_capable = true;
+#endif
+
 	gptp_md_sync_receive_state_machine(port);
 	gptp_md_sync_send_state_machine(port);
 }

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -764,8 +764,14 @@ static void gptp_update_local_port_clock(void)
 
 	port_ds = GPTP_PORT_DS(port);
 
-	/* Check if the last neighbor rate ratio can still be used */
-	if (!port_ds->neighbor_rate_ratio_valid) {
+	/* Check if the last neighbor rate ratio can still be used. A static
+	 * time receiver cannot require it: the upstream bridge may never
+	 * answer Pdelay requests, in which case the ratio keeps its initial
+	 * value of 1.0 and the clock is disciplined on every Sync and
+	 * Follow_Up pair instead of once per Pdelay measurement.
+	 */
+	if (!IS_ENABLED(CONFIG_NET_GPTP_STATIC_TIME_RECEIVER) &&
+	    !port_ds->neighbor_rate_ratio_valid) {
 		return;
 	}
 
@@ -916,7 +922,8 @@ static void gptp_mi_clk_master_sync_offset_state_machine(void)
 	}
 }
 
-#if defined(CONFIG_NET_GPTP_GM_CAPABLE)
+#if defined(CONFIG_NET_GPTP_GM_CAPABLE) && \
+	!defined(CONFIG_NET_GPTP_STATIC_TIME_RECEIVER)
 static inline void gptp_mi_setup_sync_send_time(void)
 {
 	struct gptp_clk_master_sync_snd_state *state;
@@ -1910,9 +1917,42 @@ static void gptp_set_selected_tree(void)
 	GPTP_GLOBAL_DS()->selected_array = ~0;
 }
 
+#if defined(CONFIG_NET_GPTP_STATIC_TIME_RECEIVER)
+static void gptp_mi_port_role_static_time_receiver(void)
+{
+	int port;
+
+	/* Static port roles, no BMCA: every port is a time receiver. The
+	 * grandmaster is whichever time-aware system originates the Sync
+	 * stream received on the port, even though it never sends an
+	 * Announce.
+	 */
+	for (port = GPTP_PORT_START; port <= GPTP_PORT_END; port++) {
+		gptp_change_port_state(port, GPTP_PORT_SLAVE);
+	}
+
+	/* Port 0 carries the role of the time-aware system itself, which
+	 * is passive on a system that is synchronized through one of its
+	 * ports.
+	 */
+	gptp_change_port_state(0, GPTP_PORT_PASSIVE);
+
+	/* SiteSyncSync forwards a received PortSyncSync to ClockSlaveSync
+	 * only while a grandmaster is present. The grandmaster is static
+	 * here, it just never announces itself.
+	 */
+	GPTP_GLOBAL_DS()->gm_present = true;
+}
+#endif
+
 static void gptp_mi_port_role_selection_state_machine(void)
 {
 	struct gptp_port_role_selection_state *state;
+
+#if defined(CONFIG_NET_GPTP_STATIC_TIME_RECEIVER)
+	gptp_mi_port_role_static_time_receiver();
+	return;
+#endif
 
 	state = &GPTP_STATE()->pr_sel;
 
@@ -2020,6 +2060,27 @@ void gptp_mi_port_sync_state_machines(int port)
 
 void gptp_mi_port_bmca_state_machines(int port)
 {
+#if defined(CONFIG_NET_GPTP_STATIC_TIME_RECEIVER)
+	struct gptp_port_announce_receive_state *pa_rcv;
+	struct gptp_port_bmca_data *bmca_data;
+
+	pa_rcv = &GPTP_PORT_STATE(port)->pa_rcv;
+	bmca_data = GPTP_PORT_BMCA_DATA(port);
+
+	/* Static port roles, no BMCA: a received Announce is dropped
+	 * without qualification and no Announce is ever transmitted.
+	 */
+	pa_rcv->rcvd_announce = false;
+	bmca_data->rcvd_msg = false;
+
+	if (bmca_data->rcvd_announce_ptr != NULL) {
+		net_pkt_unref(bmca_data->rcvd_announce_ptr);
+		bmca_data->rcvd_announce_ptr = NULL;
+	}
+
+	return;
+#endif
+
 	gptp_mi_port_announce_receive_state_machine(port);
 	gptp_mi_port_announce_information_state_machine(port);
 	gptp_mi_port_announce_transmit_state_machine(port);
@@ -2031,7 +2092,8 @@ void gptp_mi_state_machines(void)
 	gptp_mi_clk_slave_sync_state_machine();
 	gptp_mi_port_role_selection_state_machine();
 	gptp_mi_clk_master_sync_offset_state_machine();
-#if defined(CONFIG_NET_GPTP_GM_CAPABLE)
+#if defined(CONFIG_NET_GPTP_GM_CAPABLE) && \
+	!defined(CONFIG_NET_GPTP_STATIC_TIME_RECEIVER)
 	/*
 	 * Only call ClockMasterSyncSend state machine in case a Grand Master clock
 	 * is present and is this time aware system.


### PR DESCRIPTION
Networks built after the IEEE 802.1AS automotive profile use static port roles instead of the Best Master Clock Algorithm. A bridge on such a network relays Sync and Follow_Up but transmits no Announce messages and is not required to answer Pdelay requests on its timeTransmitter ports. The stock state machine can never synchronize behind one of these bridges because without a qualified Announce a port never reaches the time receiver ("slave") role, so the node sits with a healthy Sync stream arriving and an undisciplined clock. The same static-role time distribution is increasingly common in robotics sensor networks, where fixed-function nodes on 100BASE-T1 and 10BASE-T1S links follow a single time source through an automotive-profile switch.

CONFIG_NET_GPTP_STATIC_TIME_RECEIVER operates the node as a timeReceiver by configuration. Every port is pinned to the time receiver role with port 0 passive and gm_present asserted, BMCA and all Announce handling are bypassed, and asCapable is held so synchronization runs from the received Sync and Follow_Up messages alone even when the bridge never answers Pdelay. The grandmaster path is fully compiled out in this mode and nothing changes when the option is off. This mirrors the timeReceiver-only provisioning of IEEE 802.1AS-2020 clause 10.3.14 (external port configuration, from IEEE 1588-2019 clause 17.6.2) and the linuxptp automotive time receiver configuration (BMCA noop, clientOnly, inhibit_announce, asCapable true).

This was validated and tested on a 100BASE-T1 automotive network with a GNSS-disciplined MCXN947 grandmaster (PPS servo locked within tens of nanoseconds of the receiver time pulse), an SJA1110 automotive-profile transparent clock bridge that forwards no Announce, and an MCXN947 node running this option as the time receiver. The receiver locks from cold boot in under ten seconds and holds a sync offset of 0 ns mean, 87 ns standard deviation, 209 ns worst case at a 16 Hz two-step Sync rate. Under a simultaneous saturating UDP upload from the same node the offset holds at 158 ns standard deviation with a 491 ns worst case and zero datagram loss. Without this option the same node never leaves the unsynchronized state. Also build tested with the new sample overlay for the platforms listed in the sample manifest.