### PR TITLE
drivers: sensor: paa3905: fix LED persistence, log level and SPI configuration

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1046,6 +1046,11 @@ SD Host Controller
 Sensor
 ======
 
+* The :dtcompatible:`pixart,paa3905` driver now enforces the sensor's
+  datasheet SPI contract: mode 3 is set by the driver and a devicetree
+  ``spi-max-frequency`` above 2 MHz fails the build. Out-of-tree boards
+  that overclocked the bus must lower the property to 2000000 or less.
+
 * The ``girqs`` and ``pcrs`` properties (array type) of :dtcompatible:`microchip,xec-tach` have been
   replaced by ``pcr-scr`` (int type) to use encoded PCR register index and bit position macros.
   GIRQ configuration is now handled via the ``microchip,dmec-ecia-girq`` binding include

--- a/drivers/sensor/pixart/paa3905/paa3905.c
+++ b/drivers/sensor/pixart/paa3905/paa3905.c
@@ -177,18 +177,40 @@ static int detection_mode_standard(const struct device *dev)
 	return 0;
 }
 
+int paa3905_apply_led_config(const struct device *dev)
+{
+	const struct paa3905_config *cfg = dev->config;
+	int err;
+
+	/* The chip rewrites the LED control register on its own when its
+	 * automatic mode switching runs, so the configured state has to be
+	 * re-applied while the device operates, not just at init.
+	 */
+	struct reg_val_pair led_control_regs[] = {
+		{.reg = 0x7F, .val = 0x14},
+		{.reg = 0x6F, .val = cfg->led_control ? 0x0C : 0x2C},
+		{.reg = 0x7F, .val = 0x00},
+	};
+
+	for (size_t i = 0 ; i < ARRAY_SIZE(led_control_regs) ; i++) {
+		err = paa3905_bus_write(dev,
+					led_control_regs[i].reg,
+					&led_control_regs[i].val,
+					1);
+		if (err) {
+			LOG_ERR("Failed to write LED control reg");
+			return err;
+		}
+	}
+
+	return 0;
+}
+
 static int paa3905_configure(const struct device *dev)
 {
 	const struct paa3905_config *cfg = dev->config;
 	uint8_t val;
 	int err;
-
-	/* Start with disabled sequence, and override it if need be. */
-	struct reg_val_pair led_control_regs[] = {
-		{.reg = 0x7F, .val = 0x14},
-		{.reg = 0x6F, .val = 0x2C},
-		{.reg = 0x7F, .val = 0x00},
-	};
 
 	/* Configure registers for Standard detection mode */
 	err = detection_mode_standard(dev);
@@ -204,23 +226,7 @@ static int paa3905_configure(const struct device *dev)
 		return err;
 	}
 
-	if (cfg->led_control) {
-		/* Enable sequence command */
-		led_control_regs[1].val = 0x0C;
-	}
-
-	for (size_t i = 0 ; i < ARRAY_SIZE(led_control_regs) ; i++) {
-		err = paa3905_bus_write(dev,
-					led_control_regs[i].reg,
-					&led_control_regs[i].val,
-					1);
-		if (err) {
-			LOG_ERR("Failed to write LED control reg");
-			return err;
-		}
-	}
-
-	return 0;
+	return paa3905_apply_led_config(dev);
 }
 
 int paa3905_recover(const struct device *dev)

--- a/drivers/sensor/pixart/paa3905/paa3905.c
+++ b/drivers/sensor/pixart/paa3905/paa3905.c
@@ -308,6 +308,9 @@ static int paa3905_init(const struct device *dev)
 }
 
 #define PAA3905_INIT(inst)									   \
+	BUILD_ASSERT(DT_INST_PROP(inst, spi_max_frequency) <= MHZ(2),		   \
+		     "PAA3905 supports a maximum SPI clock of 2 MHz");		   \
+										   \
 												   \
 	BUILD_ASSERT(DT_PROP(DT_DRV_INST(inst), resolution) > 0 &&				   \
 		     DT_PROP(DT_DRV_INST(inst), resolution) <= 0xFF,				   \
@@ -316,7 +319,8 @@ static int paa3905_init(const struct device *dev)
 	RTIO_DEFINE(paa3905_rtio_ctx_##inst, 8, 8);						   \
 	SPI_DT_IODEV_DEFINE(paa3905_bus_##inst,							   \
 			    DT_DRV_INST(inst),							   \
-			    SPI_OP_MODE_CONTROLLER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB);	   \
+			    SPI_OP_MODE_CONTROLLER | SPI_MODE_CPOL | SPI_MODE_CPHA |		   \
+			    SPI_WORD_SET(8) | SPI_TRANSFER_MSB);				   \
 												   \
 	static const struct paa3905_config paa3905_cfg_##inst = {				   \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),			   \

--- a/drivers/sensor/pixart/paa3905/paa3905.h
+++ b/drivers/sensor/pixart/paa3905/paa3905.h
@@ -46,6 +46,8 @@ struct paa3905_stream {
 	const struct device *dev;
 	struct rtio_iodev_sqe *iodev_sqe;
 	struct k_timer timer;
+	struct k_work led_work;
+	uint16_t led_reassert_ctr;
 	struct {
 		struct {
 			bool drdy : 1;
@@ -79,5 +81,7 @@ struct paa3905_config {
  * is detected.
  */
 int paa3905_recover(const struct device *dev);
+
+int paa3905_apply_led_config(const struct device *dev);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_PAA3905_H_ */

--- a/drivers/sensor/pixart/paa3905/paa3905_decoder.c
+++ b/drivers/sensor/pixart/paa3905/paa3905_decoder.c
@@ -38,7 +38,7 @@ static bool is_data_valid(const struct paa3905_encoded_data *edata)
 	uint32_t shutter;
 
 	if (!REG_MOTION_DETECTED(edata->motion)) {
-		LOG_WRN("Invalid data - No motion detected");
+		LOG_DBG("Invalid data - No motion detected");
 		return false;
 	}
 

--- a/drivers/sensor/pixart/paa3905/paa3905_stream.c
+++ b/drivers/sensor/pixart/paa3905/paa3905_stream.c
@@ -57,6 +57,15 @@ static void start_drdy_backup_timer(const struct device *dev)
 		      K_NO_WAIT);
 }
 
+static void paa3905_led_work_handler(struct k_work *work)
+{
+	struct paa3905_stream *stream = CONTAINER_OF(work,
+						     struct paa3905_stream,
+						     led_work);
+
+	(void)paa3905_apply_led_config(stream->dev);
+}
+
 static void paa3905_complete_result(struct rtio *ctx,
 				    const struct rtio_sqe *sqe,
 				    int err,
@@ -83,6 +92,11 @@ static void paa3905_complete_result(struct rtio *ctx,
 
 	if (data->stream.settings.enabled.drdy) {
 		start_drdy_backup_timer(dev);
+	}
+
+	if (++data->stream.led_reassert_ctr >= 128) {
+		data->stream.led_reassert_ctr = 0;
+		k_work_submit(&data->stream.led_work);
 	}
 
 	/* Flush RTIO bus CQEs */
@@ -363,6 +377,7 @@ int paa3905_stream_init(const struct device *dev)
 	}
 
 	k_timer_init(&data->stream.timer, paa3905_stream_drdy_timeout, NULL);
+	k_work_init(&data->stream.led_work, paa3905_led_work_handler);
 
 	return err;
 }


### PR DESCRIPTION
Three fixes for the PAA3905 optical flow sensor driver, all found running the sensor on hardware.

1. The chip rewrites its LED control register on its own when automatic mode switching runs, so the state written once during configuration does not persist and a device configured with the LED disabled strobes again shortly after init. The LED control sequence moves into paa3905_apply_led_config() and is re-applied from the stream path roughly once a second, making the devicetree configured state remain across mode switches.

2. A stationary sensor reports no motion for every sample, which flooded the console with warnings at the streaming rate for a condition that is expected rather than exceptional. The report drops to debug level.

3. The chip communicates in SPI mode 3 with a maximum clock of 2 MHz (PAA3905E1-Q datasheet, section 6.0), but the bus configuration left clock polarity and phase at mode 0. In mode 0 every register read returns the value shifted right by one bit, so the product ID 0xA2 reads back as 0x51 and probing fails unless the board devicetree happens to set spi-cpol and spi-cpha. The driver now sets both mode bits itself.

Verified on an MCXN947 board with the sensor on LPSPI. Before the mode fix the product ID read 0x51 on a node without spi-cpol/spi-cpha and probing failed, afterwards it reads 0xA2 with no devicetree flags. With led-control unset the illumination LED now stays off across mode switches instead of re-arming, confirmed over multi-hour runs. Builds clean in tests/drivers/build_all/sensor.