### PR TITLE
boards: infineon: kit_pse84_ai: add ambient-temp0 alias for SHT40

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -14,6 +14,7 @@
 		watchdog0 = &watchdog0;
 
 		/* Sensor Aliases */
+		ambient-temp0 = &sht4x;
 		pressure-sensor = &dps368;
 		accel0 = &bosch_bmi270;
 	};
@@ -104,7 +105,7 @@ i2c0: &scb0 {
 		reg = <0x77>;
 	};
 
-	sht4x@44 {
+	sht4x: sht4x@44 {
 		status = "okay";
 		compatible = "sensirion,sht4x";
 		reg = <0x44>;


### PR DESCRIPTION
The sht4x@44 node on kit_pse84_ai has an on-board SHT40 temperature/humidity sensor but lacked a node label and the standard `ambient-temp0` alias, making it inaccessible via `DEVICE_DT_GET(DT_ALIAS(ambient_temp0)) `in application code and peripheral tests.

Add the `sht4x` node label and `ambient-temp0 = &sht4x` alias in `kit_pse84_ai_common.dtsi `so the sensor is reachable through the standard Zephyr alias mechanism on both the M33 and M55 targets.