### PR TITLE
kernel: avoid unnecessary z_time_slice scheduler locking

### DIFF
--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
 #include <kspinlock.h>
 #include <kswap.h>
 #include <ksched.h>
@@ -13,7 +14,9 @@
 static int slice_ticks = DIV_ROUND_UP(CONFIG_TIMESLICE_SIZE * Z_HZ_ticks, Z_HZ_ms);
 static int slice_max_prio = CONFIG_TIMESLICE_PRIORITY;
 static struct _timeout slice_timeouts[CONFIG_MP_MAX_NUM_CPUS];
-static bool slice_expired[CONFIG_MP_MAX_NUM_CPUS];
+
+/* Timeouts can expire on another CPU, so each CPU's flag must be atomic. */
+static atomic_t slice_expired[CONFIG_MP_MAX_NUM_CPUS];
 
 #ifdef CONFIG_SWAP_NONATOMIC
 /* If z_swap() isn't atomic, then it's possible for a timer interrupt
@@ -64,7 +67,7 @@ static void slice_timeout(struct _timeout *timeout)
 {
 	int cpu = ARRAY_INDEX(slice_timeouts, timeout);
 
-	slice_expired[cpu] = true;
+	atomic_set(&slice_expired[cpu], 1);
 
 	/* We need an IPI if we just handled a timeslice expiration
 	 * for a different CPU.
@@ -89,12 +92,12 @@ static void slice_reset(int slice_size)
 		 * announce window, so subtract 1 to cancel z_add_timeout()'s
 		 * "+1" round-up and land at exactly slice_size ticks.
 		 */
-		int delay = slice_expired[cpu] ? slice_size - 1 : slice_size;
+		int delay = atomic_get(&slice_expired[cpu]) ? slice_size - 1 : slice_size;
 
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
 			      K_TICKS(delay));
 	}
-	slice_expired[cpu] = false;
+	atomic_clear(&slice_expired[cpu]);
 }
 
 void z_time_slice_reset(struct k_thread *thread)
@@ -146,6 +149,16 @@ void k_thread_time_slice_set(struct k_thread *thread, int32_t thread_slice_ticks
 /* Called out of each timer and IPI interrupt */
 void z_time_slice(void)
 {
+	/*
+	 * Atomic context switches need no scheduler work until this CPU's
+	 * time slice expires. Non-atomic context switches must still take
+	 * the scheduler lock to synchronize pending_current.
+	 */
+	if (!IS_ENABLED(CONFIG_SWAP_NONATOMIC) &&
+	    !atomic_get(&slice_expired[_current_cpu->id])) {
+		return;
+	}
+
 	k_spinlock_key_t key = z_sched_spinlock_lock();
 	struct k_thread *curr = _current;
 
@@ -160,7 +173,7 @@ void z_time_slice(void)
 
 	int slice_size = 0;
 
-	if (slice_expired[_current_cpu->id]) {
+	if (atomic_get(&slice_expired[_current_cpu->id])) {
 		slice_size = z_time_slice_size(curr);
 	}
 


### PR DESCRIPTION
On ARMv8 a53 quad core SMP application running benchmarks, we see 54% of sampled CPU cycles in spinlock related instructions. ~70% of these cycles are related to the global scheduler spinlock.

Reduce global scheduler spinlock contention by short-circuiting the global scheduler lock in the timer and IPI time-slice hook with atomic flag when context switching is atomic AND this CPU's slice has not expired. Currently, every `z_time_slice()` acquires the scheduler spinlock, and `z_time_slice()` is called every scheduler IPI and `sys_clock_announce_locked()`. In practice, the vast majority of z_time_slice calls are not time slice expiration, and `z_time_slice()` is a NOP. Use a plain atomic flag per CPU because another CPU can publish an expiration while the hook reads the flag without the scheduler lock.

What makes this safe?

1. All accesses to the per-CPU expiration flag use Zephyr atomics, making the unlocked check safe against remote-CPU updates.
2. Expiration is published before requesting an IPI, so an expiration racing with the early return still notifies the target CPU (maintains happens-after relationship).
3. When work is pending, the code acquires _sched_spinlock and rechecks the flag before modifying scheduler state. Existing callback and timeout-reset behavior is preserved.
4. CONFIG_SWAP_NONATOMIC platforms always retain the original locked path, including pending_current synchronization.


Preserve the locked path for non-atomic context switches, including pending_current synchronization. Keep expired-slice processing, per-thread callbacks, round-robin rotation and timeout reset behavior.

We observe a 2.9% to 4.7% latency improvement and up to 10.8% throughput improvement.

Assisted-by: Codex:GPT-5