### PR TITLE
boards: seeed: commit RRAM write buffer after image load

### DIFF
--- a/boards/seeed/xiao_nrf54l15/support/openocd.cfg
+++ b/boards/seeed/xiao_nrf54l15/support/openocd.cfg
@@ -66,6 +66,9 @@ if {![using_hla]} {
 proc nrf54l-load {file} {
 	mww 0x5004b500 0x101
 	load_image $file
+	# Commit the final partial 128-bit RRAM write line left by load_image.
+	# RRAMC.TASKS_COMMITWRITEBUF @ 0x5004b008.
+	mww 0x5004b008 1
 }
 
 # Define CTRL_AP_NUM explicitly to avoid variable errors


### PR DESCRIPTION
The XIAO nRF54L15 OpenOCD load helper enables the RRAM controller's
128-bit write buffer before loading an image. If the image ends on a partial
write line, `load_image` can return with that line still buffered, and a
following reset loses the final bytes even though OpenOCD reported success.

Trigger `RRAMC.TASKS_COMMITWRITEBUF` after `load_image` so the final partial
line is programmed. This matches the handling proposed for the sibling XIAO
nRF54LM20A board in #115162.

Validation:
- Zephyr focused compliance: 7/7 passed (`BinaryFiles`, `Checkpatch`,
  `ClangFormat`, `GitDiffCheck`, `Gitlint`, `Nits`, `TextEncoding`).
- Board/config compliance: 5/5 passed (`BoardYml`, `KconfigBasic`,
  `KconfigHWMv2`, `MaintainersFormat`, `ModulesMaintainers`).
- `west build --pristine -b xiao_nrf54l15/nrf54l15/cpuapp
  samples/hello_world` passed with Zephyr SDK 1.0.1.
- `west flash --context` selected OpenOCD and resolved
  `--cmd-load=nrf54l-load` from this board directory.
- A Tcl mock harness confirmed the sequence is RRAM configuration,
  `load_image`, then `TASKS_COMMITWRITEBUF`.
- `git diff --check origin/main..HEAD` passed.

Physical flashing was not performed because XIAO nRF54L15 hardware is not
available on this host.

Fixes #117724
