### PR TITLE
audio: fix wolfson vendor prefix to wlf

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_cm.dtsi
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_cm.dtsi
@@ -106,7 +106,7 @@
 			#size-cells = <0>;
 
 			audio_codec: wm8962@1a {
-				compatible = "wolfson,wm8962";
+				compatible = "wlf,wm8962";
 				reg = <0x1a>;
 				clock-source = "MCLK";
 				clocks = <&scmi_clk IMX943_CLK_SAI1>;

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -170,7 +170,7 @@
 	};
 
 	audio_codec: wm8962@1a {
-		compatible = "wolfson,wm8962";
+		compatible = "wlf,wm8962";
 		reg = <0x1a>;
 		clock-source = "MCLK";
 		clocks = <&scmi_clk IMX95_CLK_SAI3>;

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -175,7 +175,7 @@ arduino_i2c: &flexcomm4 {
 	};
 
 	audio_codec: wm8904@1a {
-		compatible = "wolfson,wm8904";
+		compatible = "wlf,wm8904";
 		reg = <0x1a>;
 
 		clock-source = "MCLK";

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -38,7 +38,7 @@
 	#size-cells = <0>;
 
 	audio_codec: wm8962@1a {
-		compatible = "wolfson,wm8962";
+		compatible = "wlf,wm8962";
 		reg = <0x1a>;
 		clocks = <&ccm IMX_CCM_SAI1_CLK 0x7c 18>;
 		clock-names = "mclk";

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -152,7 +152,7 @@ nxp_parallel_i2c: &lpi2c1 {};
 	};
 
 	audio_codec: wm8960@1a {
-		compatible = "wolfson,wm8960";
+		compatible = "wlf,wm8960";
 		reg = <0x1a>;
 		clocks = <&ccm IMX_CCM_SAI1_CLK 0x2004 4>;
 		clock-names = "mclk";

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -89,7 +89,7 @@
 	/delete-node/ fxos8700@1f;
 
 	audio_codec: wm8962@1a {
-		compatible = "wolfson,wm8962";
+		compatible = "wlf,wm8962";
 		reg = <0x1a>;
 		clock-source = "MCLK";
 		clocks = <&ccm IMX_CCM_SAI1_CLK 0x2004 4>;

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -6,7 +6,7 @@
 
 nxp_mipi_i2c: &lpi2c5 {
 	audio_codec: wm8960@1a {
-		compatible = "wolfson,wm8960";
+		compatible = "wlf,wm8960";
 		reg = <0x1a>;
 		clocks = <&ccm IMX_CCM_SAI1_CLK 0x2004 4>;
 		clock-names = "mclk";

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -129,7 +129,7 @@ m2_hci_uart: &lpuart2 {
 	#size-cells = <0>;
 
 	audio_codec: wm8962@1a {
-		compatible = "wolfson,wm8962";
+		compatible = "wlf,wm8962";
 		reg = <0x1a>;
 		clock-source = "MCLK";
 		clocks = <&ccm IMX_CCM_SAI1_CLK 0x2004 4>;

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
@@ -342,7 +342,7 @@ p3t1755dp_ard_i2c_interface: &lpi2c2 {};
 	#size-cells = <0>;
 
 	audio_codec: wm8962@1a {
-		compatible = "wolfson,wm8962";
+		compatible = "wlf,wm8962";
 		reg = <0x1a>;
 		clock-source = "MCLK";
 		clocks = <&ccm IMX_CCM_SAI1_CLK 0x2004 4>;

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -522,7 +522,7 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 
 	audio_codec: wm8904@1a0000000000000000 {
-		compatible = "wolfson,wm8904";
+		compatible = "wlf,wm8904";
 		reg = <0x1a 0 0>;
 		clock-source = "MCLK";
 

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -437,7 +437,7 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 
 	audio_codec: wm8904@1a0000000000000000 {
-		compatible = "wolfson,wm8904";
+		compatible = "wlf,wm8904";
 		reg = <0x1a 0 0>;
 
 		clock-source = "MCLK";

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.dts
@@ -108,7 +108,7 @@ i2s1: &flexcomm3 {
 	pinctrl-names = "default";
 
 	audio_codec: wm8904@1a0000000000000000 {
-		compatible = "wolfson,wm8904";
+		compatible = "wlf,wm8904";
 		reg = <0x1a 0 0>;
 		clock-source = "MCLK";
 

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -295,7 +295,7 @@
 	#size-cells = <0>;
 
 	audio_codec: wm8962@1a {
-		compatible = "wolfson,wm8962";
+		compatible = "wlf,wm8962";
 		reg = <0x1a>;
 		clock-source = "MCLK";
 		clocks = <&clkctl0 MCUX_SAI0_CLK>;

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.dts
@@ -54,7 +54,7 @@
 	#size-cells = <0>;
 
 	audio_codec: wm8962@1a {
-		compatible = "wolfson,wm8962";
+		compatible = "wlf,wm8962";
 		reg = <0x1a>;
 		clock-source = "MCLK";
 		clocks = <&clkctl0 MCUX_SAI0_CLK>;

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -116,7 +116,7 @@ arduino_i2c: &flexcomm2 {
 	pinctrl-names = "default";
 
 	audio_codec: wm8904@1a {
-		compatible = "wolfson,wm8904";
+		compatible = "wlf,wm8904";
 		reg = <0x1a>;
 
 		clock-source = "MCLK";

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -300,6 +300,11 @@ Audio Codec
   in-tree drivers have been updated. Application code using the ``audio_codec_...`` APIs is not
   impacted.
 
+* The compatible strings for the WM8904, WM8960, and WM8962 audio codec bindings have been
+  changed from ``wolfson,wm8904``, ``wolfson,wm8960``, ``wolfson,wm8962`` to
+  :dtcompatible:`wlf,wm8904`, :dtcompatible:`wlf,wm8960`, :dtcompatible:`wlf,wm8962`, since
+  ``wlf`` is the correct prefix for Wolfson Microelectronics parts.
+
 Clock Control
 =============
 

--- a/drivers/audio/Kconfig.wm8904
+++ b/drivers/audio/Kconfig.wm8904
@@ -5,6 +5,6 @@ config AUDIO_CODEC_WM8904
 	bool "Wolfson WM8904 codec support"
 	default y
 	select I2C
-	depends on DT_HAS_WOLFSON_WM8904_ENABLED
+	depends on DT_HAS_WLF_WM8904_ENABLED
 	help
 	  Enable support for the Wolfson WM8904 codec

--- a/drivers/audio/Kconfig.wm8960
+++ b/drivers/audio/Kconfig.wm8960
@@ -5,6 +5,6 @@ config AUDIO_CODEC_WM8960
 	bool "Wolfson WM8960 Audio Codec"
 	default y
 	select I2C
-	depends on DT_HAS_WOLFSON_WM8960_ENABLED
+	depends on DT_HAS_WLF_WM8960_ENABLED
 	help
 	  Enable Wolfson WM8960 audio codec driver.

--- a/drivers/audio/Kconfig.wm8962
+++ b/drivers/audio/Kconfig.wm8962
@@ -5,6 +5,6 @@ config AUDIO_CODEC_WM8962
 	bool "Wolfson WM8962 codec support"
 	default y
 	select I2C
-	depends on DT_HAS_WOLFSON_WM8962_ENABLED
+	depends on DT_HAS_WLF_WM8962_ENABLED
 	help
 	  Enable support for the Wolfson WM8962 codec

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -12,11 +12,11 @@
 #include <zephyr/devicetree/clocks.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(wolfson_wm8904, CONFIG_AUDIO_CODEC_LOG_LEVEL);
+LOG_MODULE_REGISTER(wlf_wm8904, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
 #include "wm8904.h"
 
-#define DT_DRV_COMPAT wolfson_wm8904
+#define DT_DRV_COMPAT wlf_wm8904
 
 struct wm8904_driver_config {
 	struct i2c_dt_spec i2c;

--- a/drivers/audio/wm8960.c
+++ b/drivers/audio/wm8960.c
@@ -14,9 +14,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
-LOG_MODULE_REGISTER(wolfson_wm8960, CONFIG_AUDIO_CODEC_LOG_LEVEL);
+LOG_MODULE_REGISTER(wlf_wm8960, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
-#define DT_DRV_COMPAT wolfson_wm8960
+#define DT_DRV_COMPAT wlf_wm8960
 
 /* WM8960 Register Addresses */
 #define WM8960_LINVOL   0x00

--- a/drivers/audio/wm8962.c
+++ b/drivers/audio/wm8962.c
@@ -13,11 +13,11 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(wolfson_wm8962, CONFIG_AUDIO_CODEC_LOG_LEVEL);
+LOG_MODULE_REGISTER(wlf_wm8962, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
 #include "wm8962.h"
 
-#define DT_DRV_COMPAT wolfson_wm8962
+#define DT_DRV_COMPAT wlf_wm8962
 
 struct wm8962_driver_config {
 	struct i2c_dt_spec i2c;

--- a/dts/bindings/audio/wlf,wm8904.yaml
+++ b/dts/bindings/audio/wlf,wm8904.yaml
@@ -5,7 +5,7 @@ description: WM8904 audio codec
 
 include: [i2c-device.yaml]
 
-compatible: "wolfson,wm8904"
+compatible: "wlf,wm8904"
 
 properties:
   reg:

--- a/dts/bindings/audio/wlf,wm8960.yaml
+++ b/dts/bindings/audio/wlf,wm8960.yaml
@@ -5,7 +5,7 @@ description: Wolfson Microelectronics WM8960 Audio CODEC
 
 include: i2c-device.yaml
 
-compatible: "wolfson,wm8960"
+compatible: "wlf,wm8960"
 
 properties:
   reg:

--- a/dts/bindings/audio/wlf,wm8962.yaml
+++ b/dts/bindings/audio/wlf,wm8962.yaml
@@ -5,7 +5,7 @@ description: WM8962 audio codec
 
 include: [i2c-device.yaml]
 
-compatible: "wolfson,wm8962"
+compatible: "wlf,wm8962"
 
 properties:
   reg:

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -813,11 +813,10 @@ winstar	Winstar Display Corp.
 wits	Shenzhen Merrii Technology Co., Ltd. (WITS)
 witte	Witte Technology
 wiznet	WIZnet Co., Ltd.
-wlf	Wolfson Microelectronics
+wlf	Cirrus Logic, Inc. (formerly Wolfson Microelectronics plc)
 wm	Wondermedia Technologies, Inc.
 wnc	Wistron NeWeb Corporation
 wobo	Wobo
-wolfson	Cirrus Logic, Inc. (formerly Wolfson Microelectronics plc)
 worldsemi	Worldsemi Co., Limited
 wurth	Wurth Elektronik
 x-powers	X-Powers

--- a/samples/drivers/i2s/echo/Kconfig
+++ b/samples/drivers/i2s/echo/Kconfig
@@ -6,7 +6,7 @@
 source "Kconfig.zephyr"
 
 config I2C
-	default $(dt_compat_on_bus,$(DT_COMPAT_WOLFSON_WM8731),i2c) \
+	default $(dt_compat_on_bus,$(DT_COMPAT_WLF_WM8731),i2c) \
 		|| $(dt_compat_on_bus,$(DT_COMPAT_ADI_MAX9867),i2c)
 
 config SAMPLE_FREQ

--- a/samples/drivers/i2s/echo/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/i2s/echo/boards/nrf52840dk_nrf52840.overlay
@@ -37,7 +37,7 @@
 	pinctrl-names = "default", "sleep";
 
 	wm8731: wm8731@1a {
-		compatible = "wolfson,wm8731";
+		compatible = "wlf,wm8731";
 		reg = <0x1a>;
 	};
 };

--- a/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -38,7 +38,7 @@
 	pinctrl-names = "default", "sleep";
 
 	wm8731: wm8731@1a {
-		compatible = "wolfson,wm8731";
+		compatible = "wlf,wm8731";
 		reg = <0x1a>;
 	};
 };

--- a/samples/drivers/i2s/echo/dts/bindings/wlf,wm8731.yaml
+++ b/samples/drivers/i2s/echo/dts/bindings/wlf,wm8731.yaml
@@ -7,6 +7,6 @@
 
 description: WM8731 Audio CODEC
 
-compatible: "wolfson,wm8731"
+compatible: "wlf,wm8731"
 
 include: i2c-device.yaml

--- a/tests/drivers/audio/wm8960/boards/native_sim.overlay
+++ b/tests/drivers/audio/wm8960/boards/native_sim.overlay
@@ -25,7 +25,7 @@
 	#size-cells = <0>;
 
 	wm8960: wm8960@1a {
-		compatible = "wolfson,wm8960";
+		compatible = "wlf,wm8960";
 		reg = <0x1a>;
 		clocks = <&dummy_clock>;
 		status = "okay";

--- a/tests/drivers/audio/wm8960/src/wm8960_emul.c
+++ b/tests/drivers/audio/wm8960/src/wm8960_emul.c
@@ -14,9 +14,9 @@
 
 #include "wm8960_emul.h"
 
-LOG_MODULE_REGISTER(wolfson_wm8960_emul, CONFIG_WM8960_EMUL_LOG_LEVEL);
+LOG_MODULE_REGISTER(wlf_wm8960_emul, CONFIG_WM8960_EMUL_LOG_LEVEL);
 
-#define DT_DRV_COMPAT wolfson_wm8960
+#define DT_DRV_COMPAT wlf_wm8960
 
 /* WM8960 Register definitions */
 #define WM8960_REG_LEFT_INPUT_VOLUME    0x00


### PR DESCRIPTION
These changes fix the vendor prefix from "wolfson" to "wlf" as per dts/bindings/vendor-prefixes.txt