### PR TITLE
drivers: wifi: nxp: fix RX buffer length accounting across fragments

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_net.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_net.c
@@ -1662,7 +1662,7 @@ void *net_stack_buffer_alloc_rx(int offset, int len)
 
 		net_buf_add(p, p->size);
 		net_buf_pull(p, offset);
-		alloc_len -= p->len;
+		alloc_len -= p->size;
 		offset = 0;
 		p = p->frags;
 	}


### PR DESCRIPTION
In net_stack_buffer_alloc_rx(), the first fragment reserves headroom with net_buf_pull(offset), but alloc_len is decremented by p->len only, omitting the pulled offset. alloc_len stays larger than the space left, so a multi-fragment packet gets over-filled and its buffer ends up longer than requested, corrupting the SDIO scatter-gather RX path.

Decrement alloc_len by p->size, the full space this fragment consumes, so the accounting stays correct regardless of the reserved headroom.