### PR TITLE
tests: display: use qualified MCXA577 platform

### DIFF
--- a/tests/drivers/display/display_check/tests.yaml
+++ b/tests/drivers/display/display_check/tests.yaml
@@ -98,7 +98,7 @@ tests:
       - platform:mcx_n5xx_evk/mcxn547/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
-      - platform:frdm_mcxa577:SHIELD=lcd_par_s035_8080
+      - platform:frdm_mcxa577/mcxa577:SHIELD=lcd_par_s035_8080
       - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
       - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu


### PR DESCRIPTION
## Summary

Use the fully qualified MCXA577 board target for the display-check
configuration with the `lcd_par_s035_8080` shield.

## Testing

- Confirmed the new platform entry is present and the old entry is absent.
- `git diff --check`
