### PR TITLE
STM32 Timers: Add Qdec support for all series

### DIFF
--- a/drivers/sensor/st/qdec_stm32/qdec_stm32.c
+++ b/drivers/sensor/st/qdec_stm32/qdec_stm32.c
@@ -126,11 +126,16 @@ static int qdec_stm32_initialize(const struct device *dev)
 	}
 
 	/* Ensure that the counter will always count up to a multiple of counts_per_revolution */
+#ifdef IS_TIM_32B_COUNTER_INSTANCE
 	if (IS_TIM_32B_COUNTER_INSTANCE(dev_cfg->timer_inst)) {
 		max_counter_value = UINT32_MAX - (UINT32_MAX % dev_cfg->counts_per_revolution) - 1;
 	} else {
+#endif /* IS_TIM_32B_COUNTER_INSTANCE */
 		max_counter_value = UINT16_MAX - (UINT16_MAX % dev_cfg->counts_per_revolution) - 1;
+#ifdef IS_TIM_32B_COUNTER_INSTANCE
 	}
+#endif /* IS_TIM_32B_COUNTER_INSTANCE */
+
 	LL_TIM_SetAutoReload(dev_cfg->timer_inst, max_counter_value);
 
 	LL_TIM_SetPrescaler(dev_cfg->timer_inst, dev_cfg->prescaler);

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -65,10 +65,11 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/reset/stm32c0_reset.h>
-#include <zephyr/dt-bindings/power/stm32_pwr.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -378,6 +379,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -399,6 +406,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/c0/stm32c051.dtsi
+++ b/dts/arm/st/c0/stm32c051.dtsi
@@ -32,6 +32,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		i2c2: i2c@40005800 {

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -632,12 +632,6 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
 		};
 
 		timers7: timers@40001400 {
@@ -653,12 +647,6 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
-			};
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
 			};
 		};
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -7,14 +7,15 @@
  */
 
 #include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32f0_clock.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
-#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
-#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -285,6 +286,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -306,6 +313,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/f0/stm32f031.dtsi
+++ b/dts/arm/st/f0/stm32f031.dtsi
@@ -31,6 +31,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -8,7 +8,6 @@
  */
 
 #include <st/f1/stm32f103Xb.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	sram0: memory@20000000 {

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/dt-bindings/clock/stm32f10x_clock.h>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <st/f1/stm32f1.dtsi>
 
 / {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -651,6 +651,11 @@
 				#pwm-cells = <3>;
 			};
 
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
 			qdec {
 				compatible = "st,stm32-qdec";
 				st,input-filter-level = <NO_FILTER>;

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/f3/stm32f3.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/f3/stm32f3.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -6,7 +6,6 @@
 
 #include <st/f3/stm32f3.dtsi>
 #include <zephyr/dt-bindings/clock/stm32f37x_clock.h>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -6,7 +6,6 @@
  */
 
 #include <st/f4/stm32f401.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	chosen {

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/f4/stm32f410.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 /delete-node/ &dac1;
 /delete-node/ &rng;

--- a/dts/arm/st/g0/stm32g031.dtsi
+++ b/dts/arm/st/g0/stm32g031.dtsi
@@ -6,7 +6,6 @@
  */
 
 #include <st/g0/stm32g030.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/g0/stm32g070.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -7,7 +7,6 @@
 
 #include <st/g0/stm32g071.dtsi>
 #include <zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	clocks {

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/g4/stm32g491.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/g4/stm32g4.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -7,13 +7,14 @@
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32h5_clock.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/reset/stm32h5_reset.h>
-#include <zephyr/dt-bindings/dma/stm32_dma.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/power/stm32h5_iocell.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/reset/stm32h5_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -407,6 +408,12 @@
 				status = "disabled";
 				#counter-capture-cells = <2>;
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers2: timers@40000000 {
@@ -430,6 +437,12 @@
 				status = "disabled";
 				#counter-capture-cells = <2>;
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -452,6 +465,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 				#counter-capture-cells = <2>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -484,12 +484,6 @@
 			interrupt-names = "global";
 			status = "disabled";
 
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
-
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
@@ -506,12 +500,6 @@
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			status = "disabled";
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
 
 			counter {
 				compatible = "st,stm32-counter";

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -376,6 +376,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -398,6 +404,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers8: timers@40013400 {
@@ -418,6 +430,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -8,7 +8,6 @@
 #include <st/h7/stm32h7.dtsi>
 #include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	soc {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -6,19 +6,20 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32h7rs_clock.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/dt-bindings/power/stm32h7rs_iocell.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/reset/stm32h7rs_reset.h>
-#include <zephyr/dt-bindings/adc/adc.h>
-#include <zephyr/dt-bindings/memory-attr/memory-attr.h>
-#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-#include <zephyr/dt-bindings/flash_controller/xspi.h>
-#include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <zephyr/dt-bindings/video/video-interfaces.h>
-#include <zephyr/dt-bindings/power/stm32h7rs_iocell.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -677,6 +678,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers2: timers@40000000 {
@@ -698,6 +705,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};
@@ -723,6 +736,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers4: timers@40000800 {
@@ -746,6 +765,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -767,6 +792,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -847,6 +847,12 @@
 			st,prescaler = <0>;
 			status = "disabled";
 
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
@@ -863,6 +869,12 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 
 			counter {
 				compatible = "st,stm32-counter";
@@ -881,6 +893,12 @@
 			st,prescaler = <0>;
 			status = "disabled";
 
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
@@ -897,6 +915,12 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 
 			counter {
 				compatible = "st,stm32-counter";

--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/l1/stm32l151.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	sram0: memory@20000000 {

--- a/dts/arm/st/l1/stm32l151Xe.dtsi
+++ b/dts/arm/st/l1/stm32l151Xe.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/l1/stm32l151.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	sram0: memory@20000000 {

--- a/dts/arm/st/l1/stm32l152Xc.dtsi
+++ b/dts/arm/st/l1/stm32l152Xc.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/l1/stm32l152.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	sram0: memory@20000000 {

--- a/dts/arm/st/l1/stm32l152Xe.dtsi
+++ b/dts/arm/st/l1/stm32l152Xe.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/l1/stm32l152.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	sram0: memory@20000000 {

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/l4/stm32l4.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	clocks {

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <st/l4/stm32l4.dtsi>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	sram1: memory@10000000 {

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -277,12 +277,6 @@
 			st,prescaler = <0>;
 			status = "disabled";
 
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
-
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -7,7 +7,6 @@
 #include <st/l4/stm32l4.dtsi>
 #include <zephyr/dt-bindings/clock/stm32l4plus_clock.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
-#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 /delete-node/ &quadspi;
 

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -9,14 +9,15 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32n6_clock.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/reset/stm32n6_reset.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-#include <zephyr/dt-bindings/video/video-interfaces.h>
 #include <zephyr/dt-bindings/power/stm32n6_iocell.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
+#include <zephyr/dt-bindings/video/video-interfaces.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -1030,6 +1031,12 @@
 					compatible = "st,stm32-counter";
 					status = "disabled";
 				};
+
+				qdec {
+					compatible = "st,stm32-qdec";
+					st,input-filter-level = <NO_FILTER>;
+					status = "disabled";
+				};
 			};
 
 			timers2: timers@50000000 {
@@ -1050,6 +1057,12 @@
 
 				counter {
 					compatible = "st,stm32-counter";
+					status = "disabled";
+				};
+
+				qdec {
+					compatible = "st,stm32-qdec";
+					st,input-filter-level = <NO_FILTER>;
 					status = "disabled";
 				};
 			};
@@ -1074,6 +1087,12 @@
 					compatible = "st,stm32-counter";
 					status = "disabled";
 				};
+
+				qdec {
+					compatible = "st,stm32-qdec";
+					st,input-filter-level = <NO_FILTER>;
+					status = "disabled";
+				};
 			};
 
 			timers4: timers@50000800 {
@@ -1096,6 +1115,12 @@
 					compatible = "st,stm32-counter";
 					status = "disabled";
 				};
+
+				qdec {
+					compatible = "st,stm32-qdec";
+					st,input-filter-level = <NO_FILTER>;
+					status = "disabled";
+				};
 			};
 
 			timers5: timers@50000c00 {
@@ -1116,6 +1141,12 @@
 
 				counter {
 					compatible = "st,stm32-counter";
+					status = "disabled";
+				};
+
+				qdec {
+					compatible = "st,stm32-qdec";
+					st,input-filter-level = <NO_FILTER>;
 					status = "disabled";
 				};
 			};
@@ -1170,6 +1201,12 @@
 
 				counter {
 					compatible = "st,stm32-counter";
+					status = "disabled";
+				};
+
+				qdec {
+					compatible = "st,stm32-qdec";
+					st,input-filter-level = <NO_FILTER>;
 					status = "disabled";
 				};
 			};

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -7,12 +7,13 @@
 
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/clock/stm32u3_clock.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/reset/stm32u3_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -568,6 +569,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers2: timers@40000000 {
@@ -588,6 +595,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};
@@ -612,6 +625,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers4: timers@40000800 {
@@ -632,6 +651,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -671,12 +671,6 @@
 			interrupt-names = "global";
 			status = "disabled";
 
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
-
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
@@ -692,12 +686,6 @@
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			status = "disabled";
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
 
 			counter {
 				compatible = "st,stm32-counter";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -717,12 +717,6 @@
 			interrupt-names = "global";
 			status = "disabled";
 
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
-
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
@@ -738,12 +732,6 @@
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			status = "disabled";
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
 
 			counter {
 				compatible = "st,stm32-counter";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -7,15 +7,16 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32wb_clock.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
-#include <zephyr/dt-bindings/adc/adc.h>
-#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
-#include <zephyr/dt-bindings/dma/stm32_dma.h>
-#include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -408,6 +409,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers2: timers@40000000 {
@@ -429,6 +436,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -5,13 +5,14 @@
  */
 
 #include <arm/armv6-m.dtsi>
-#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/adc/adc.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
-#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/stm32wb0_clock.h>
-#include <zephyr/dt-bindings/reset/stm32wb0_reset.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/reset/stm32wb0_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 

--- a/dts/arm/st/wb0/stm32wb05.dtsi
+++ b/dts/arm/st/wb0/stm32wb05.dtsi
@@ -43,6 +43,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers16: timers@40005000 {

--- a/dts/arm/st/wb0/stm32wb07.dtsi
+++ b/dts/arm/st/wb0/stm32wb07.dtsi
@@ -81,6 +81,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -5,15 +5,16 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32wba_clock.h>
-#include <zephyr/dt-bindings/reset/stm32wba_reset.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
-#include <zephyr/dt-bindings/adc/adc.h>
-#include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/reset/stm32wba_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -457,6 +458,12 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -52,6 +52,12 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -74,6 +80,12 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -117,6 +117,12 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		usbotg_hs: usb@42040000 {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -5,16 +5,17 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32wl_clock.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/lora/sx126x.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
-#include <zephyr/dt-bindings/adc/adc.h>
-#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
-#include <zephyr/dt-bindings/dma/stm32_dma.h>
-#include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -441,6 +442,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 
 		timers2: timers@40000000 {
@@ -462,6 +469,12 @@
 
 			counter {
 				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
 				status = "disabled";
 			};
 		};

--- a/samples/sensor/qdec/boards/b_u585i_iot02a.overlay
+++ b/samples/sensor/qdec/boards/b_u585i_iot02a.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/disco_l475_iot1.overlay
+++ b/samples/sensor/qdec/boards/disco_l475_iot1.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_c071rb.overlay
+++ b/samples/sensor/qdec/boards/nucleo_c071rb.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,12 +12,12 @@
 	};
 };
 
-&timers3 {
+&timers2 {
 	st,prescaler = <5000>;
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim2_ch1_pc4 &tim2_ch2_pc5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_f091rc.overlay
+++ b/samples/sensor/qdec/boards/nucleo_f091rc.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,12 +12,12 @@
 	};
 };
 
-&timers3 {
+&timers2 {
 	st,prescaler = <5000>;
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim2_ch1_pa15 &tim2_ch2_pb3>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_f103rb.overlay
+++ b/samples/sensor/qdec/boards/nucleo_f103rb.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,12 +12,12 @@
 	};
 };
 
-&timers3 {
+&timers4 {
 	st,prescaler = <5000>;
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim4_ch1_pwm_in_pb6 &tim4_ch2_pwm_in_pb7>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_f429zi.overlay
+++ b/samples/sensor/qdec/boards/nucleo_f429zi.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_f746zg.overlay
+++ b/samples/sensor/qdec/boards/nucleo_f746zg.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_g071rb.overlay
+++ b/samples/sensor/qdec/boards/nucleo_g071rb.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_g474re.overlay
+++ b/samples/sensor/qdec/boards/nucleo_g474re.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch2_pb5 &tim3_ch3_pb0>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_h753zi.overlay
+++ b/samples/sensor/qdec/boards/nucleo_h753zi.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch3_pb0>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_l073rz.overlay
+++ b/samples/sensor/qdec/boards/nucleo_l073rz.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_l152re.overlay
+++ b/samples/sensor/qdec/boards/nucleo_l152re.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_u385rg_q.overlay
+++ b/samples/sensor/qdec/boards/nucleo_u385rg_q.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pc6 &tim3_ch2_pc7>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_wb09ke.overlay
+++ b/samples/sensor/qdec/boards/nucleo_wb09ke.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,12 +12,12 @@
 	};
 };
 
-&timers3 {
+&timers2 {
 	st,prescaler = <5000>;
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim2_ch1_pb4 &tim2_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_wb55rg.overlay
+++ b/samples/sensor/qdec/boards/nucleo_wb55rg.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,12 +12,12 @@
 	};
 };
 
-&timers3 {
+&timers2 {
 	st,prescaler = <5000>;
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim2_ch3_pa2 &tim2_ch4_pa3>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_wba55cg.overlay
+++ b/samples/sensor/qdec/boards/nucleo_wba55cg.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch3_pb14 &tim3_ch4_pb9>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/nucleo_wl55jc.overlay
+++ b/samples/sensor/qdec/boards/nucleo_wl55jc.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,12 +12,12 @@
 	};
 };
 
-&timers3 {
+&timers1 {
 	st,prescaler = <5000>;
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim1_ch1_pa8 &tim1_ch2_pa9>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/stm32f3_disco.overlay
+++ b/samples/sensor/qdec/boards/stm32f3_disco.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/stm32h573i_dk.overlay
+++ b/samples/sensor/qdec/boards/stm32h573i_dk.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch3_pb0>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/stm32h7s78_dk.overlay
+++ b/samples/sensor/qdec/boards/stm32h7s78_dk.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,12 +12,12 @@
 	};
 };
 
-&timers3 {
+&timers4 {
 	st,prescaler = <5000>;
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim4_ch1_pd12 &tim4_ch2_pd13>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/stm32l562e_dk.overlay
+++ b/samples/sensor/qdec/boards/stm32l562e_dk.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pe3 &tim3_ch2_pe4>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/stm32n6570_dk_sb.overlay
+++ b/samples/sensor/qdec/boards/stm32n6570_dk_sb.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch4_pb1>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;

--- a/samples/sensor/qdec/boards/stm32u083c_dk.overlay
+++ b/samples/sensor/qdec/boards/stm32u083c_dk.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	qdec: qdec {
-		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
 		pinctrl-names = "default";
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;


### PR DESCRIPTION
Some STM32 series didn't yet support the Qdec driver.
This PR completes QDec support for STM32 by adding the `qdec` node in the corresponding `timers` node where it was missing.
Overlays are added in the Qdec sample to test every family on ST test bench.

While at it, I did a little cleanup of the timers node, removing `pwm` nodes from the basic timers (no PWM support on them), and adding `pwm` or `counter` for timers where it was missing.