### PR TITLE
tests: entropy: Fix buffer pointer sign

### DIFF
--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <inttypes.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/ztest.h>
@@ -32,7 +33,7 @@ static uint8_t entropy_buffer[BUFFER_LENGTH] = {0};
 static uint8_t entropy_buffer[BUFFER_LENGTH] = {0};
 #endif
 
-static int random_entropy(const struct device *dev, char *buffer, char num)
+static int random_entropy(const struct device *dev, uint8_t *buffer, char num)
 {
 	int ret, i;
 	int count = 0;
@@ -56,7 +57,7 @@ static int random_entropy(const struct device *dev, char *buffer, char num)
 	}
 
 	for (i = 0; i < BUFFER_LENGTH - 1; i++) {
-		TC_PRINT("  0x%02x\n", buffer[i]);
+		TC_PRINT("  0x%02" PRIx8 "\n", buffer[i]);
 		if (buffer[i] == num) {
 			count++;
 		}


### PR DESCRIPTION
Fix the entropy test output that was sometimes on 1 byte, sometimes on 4 bytes.

Output of `west build -t run -b native_sim tests/drivers/entropy/api/ -T drivers.entropy` is now:
```
===================================================================
START - test_entropy_get_entropy
random device is 0x8056f14, name is rng
  0x3b
  0xdb
  0x31
  0xcc
  0xb6
  0xd5
  0x08
  0xaa
  0xd2
 PASS - test_entropy_get_entropy in 0.000 seconds
===================================================================
```

instead of:
```
===================================================================
START - test_entropy_get_entropy
random device is 0x8056b84, name is rng
  0x3b
  0xffffffdb
  0x31
  0xffffffcc
  0xffffffb6
  0xffffffd5
  0x08
  0xffffffaa
  0xffffffd2
 PASS - test_entropy_get_entropy in 0.000 seconds
===================================================================
```