### PR TITLE
net: ethernet: provide ptp clock verifier when PTP_CLOCK=n

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1284,14 +1284,6 @@ const struct device *z_impl_net_eth_get_ptp_clock_by_index(int index)
 
 	return net_eth_get_ptp_clock(iface);
 }
-
-#ifdef CONFIG_USERSPACE
-static inline const struct device *z_vrfy_net_eth_get_ptp_clock_by_index(int index)
-{
-	return z_impl_net_eth_get_ptp_clock_by_index(index);
-}
-#include <zephyr/syscalls/net_eth_get_ptp_clock_by_index_mrsh.c>
-#endif /* CONFIG_USERSPACE */
 #else /* CONFIG_PTP_CLOCK */
 const struct device *z_impl_net_eth_get_ptp_clock_by_index(int index)
 {
@@ -1300,6 +1292,14 @@ const struct device *z_impl_net_eth_get_ptp_clock_by_index(int index)
 	return NULL;
 }
 #endif /* CONFIG_PTP_CLOCK */
+
+#ifdef CONFIG_USERSPACE
+static inline const struct device *z_vrfy_net_eth_get_ptp_clock_by_index(int index)
+{
+	return z_impl_net_eth_get_ptp_clock_by_index(index);
+}
+#include <zephyr/syscalls/net_eth_get_ptp_clock_by_index_mrsh.c>
+#endif /* CONFIG_USERSPACE */
 
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 int net_eth_promisc_mode(struct net_if *iface, bool enable)


### PR DESCRIPTION
`net_eth_get_ptp_clock_by_index`: the `CONFIG_USERSPACE` verifier block sat inside the `CONFIG_PTP_CLOCK=y` arm, while the syscall is declared unconditionally and has an implementation in both arms. With `PTP_CLOCK=n` it was therefore not dispatched. Move the block below the conditional so one verifier covers both arms — a pure relocation, no line inside it changes.