### PR TITLE
tests: net: Remove unnecessary twister timeout settings

### DIFF
--- a/tests/net/lib/dns_addremove/tests.yaml
+++ b/tests/net/lib/dns_addremove/tests.yaml
@@ -4,7 +4,7 @@ common:
     - net
   depends_on: netif
   min_ram: 16
-  timeout: 600
+  timeout: 120
 tests:
   net.dns.addremove:
     min_ram: 21

--- a/tests/net/lib/dns_dispatcher/tests.yaml
+++ b/tests/net/lib/dns_dispatcher/tests.yaml
@@ -4,7 +4,6 @@ common:
     - net
   depends_on: netif
   min_ram: 21
-  timeout: 600
 tests:
   net.dns.dispatch:
     min_ram: 21

--- a/tests/net/lib/dns_packet/tests.yaml
+++ b/tests/net/lib/dns_packet/tests.yaml
@@ -4,5 +4,4 @@ tests:
     tags:
       - dns
       - net
-    timeout: 200
     depends_on: netif

--- a/tests/net/lib/dns_resolve/tests.yaml
+++ b/tests/net/lib/dns_resolve/tests.yaml
@@ -3,7 +3,6 @@ common:
     - dns
     - net
   depends_on: netif
-  timeout: 600
   min_ram: 21
 tests:
   net.dns.resolve:

--- a/tests/net/lib/dns_sd/tests.yaml
+++ b/tests/net/lib/dns_sd/tests.yaml
@@ -6,8 +6,6 @@ common:
 tests:
   net.dns.sd:
     min_ram: 21
-    timeout: 600
   net.dns.sd.no_ipv6:
     extra_args: CONF_FILE=prj-no-ipv6.conf
     min_ram: 16
-    timeout: 600

--- a/tests/net/lib/llmnr_responder/tests.yaml
+++ b/tests/net/lib/llmnr_responder/tests.yaml
@@ -6,4 +6,3 @@ common:
 tests:
   net.llmnr:
     min_ram: 21
-    timeout: 60

--- a/tests/net/lib/mdns_responder/tests.yaml
+++ b/tests/net/lib/mdns_responder/tests.yaml
@@ -6,17 +6,14 @@ common:
 tests:
   net.mdns:
     min_ram: 21
-    timeout: 600
   net.mdns.iface_allowlist:
     min_ram: 21
-    timeout: 600
     extra_configs:
       # mDNS responder operates only on the listed interface (dummy0 == iface1).
       - CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST=y
       - CONFIG_MDNS_RESPONDER_IFACE_LIST="dummy0"
   net.mdns.iface_denylist:
     min_ram: 21
-    timeout: 600
     extra_configs:
       # mDNS responder operates on every interface except the listed one
       # (dummy1 == iface2), so iface1 stays enabled and iface2 is excluded.
@@ -24,13 +21,11 @@ tests:
       - CONFIG_MDNS_RESPONDER_IFACE_LIST="dummy1"
   net.mdns.runtime_iface:
     min_ram: 21
-    timeout: 600
     extra_configs:
       # Runtime per-interface control on top of the default (ALL) policy.
       - CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL=y
   net.mdns.runtime_iface_allowlist:
     min_ram: 21
-    timeout: 600
     extra_configs:
       # Runtime per-interface control combined with an allowlist policy, so that a
       # runtime enable can override a policy-excluded interface (dummy1 == iface2).

--- a/tests/net/lib/mdns_responder_probe/tests.yaml
+++ b/tests/net/lib/mdns_responder_probe/tests.yaml
@@ -6,4 +6,3 @@ common:
 tests:
   net.mdns.probe:
     min_ram: 21
-    timeout: 600

--- a/tests/net/lib/zperf/tests.yaml
+++ b/tests/net/lib/zperf/tests.yaml
@@ -6,6 +6,5 @@ common:
   platform_allow:
     - native_sim
     - native_sim/native/64
-  timeout: 60
 tests:
   net.zperf: {}


### PR DESCRIPTION
Twister defaults to a 60 second timeout, so a testsuite only needs to spell one out when it really runs longer than that. Most of the DNS and mDNS suites carry timeout: 600, but none of them chose that value. It was inherited: it first appears in tests/net/lib/dns_resolve/testcase.ini in 2017, next to slow = True and a qemu_x86 whitelist, and was copied from suite to suite ever since. The slow flag and the whitelist are long gone, the 600 is not.

Measured on native_sim and qemu_x86, these suites take fractions of a second to a few seconds, the slowest being net.dns.addremove at 11.2 s on qemu_x86. The second bound that matters is the all-fail case, where every internal wait expires instead of being signalled: that is about 17 s for dns_resolve, 3 s for mdns_responder and 6 s for the mDNS probe suite, while dns_sd, dns_dispatcher, llmnr_responder and dns_packet have no blocking waits at all. All of them fit inside the default with room to spare, so drop the setting.

dns_addremove keeps an explicit value, reduced to 120. It performs 23 semaphore waits of 2.4 s each, so a run where every one of them times out needs roughly 55 s, which is uncomfortably close to the default.

Left alone are tests/net/lib/lwm2m/interop, which drives an external Leshan server and is marked slow, tests/net/lib/mcp, measured at 65 s on qemu_x86 and therefore genuinely above the default, and tests/net/socket/tcp at 127 s.

Assisted-by: Claude:claude-opus-5