### PR TITLE
include: dt-bindings: add RK3588 CRU clock and reset IDs for GMAC

### DIFF
--- a/include/zephyr/dt-bindings/clock/rk3588-cru.h
+++ b/include/zephyr/dt-bindings/clock/rk3588-cru.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 KylinSoft
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Subset of Linux include/dt-bindings/clock/rk3588-cru.h for GMAC.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RK3588_CRU_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RK3588_CRU_H_
+
+#define MCLK_GMAC0_OUT     248
+#define CLK_GMAC0_PTP_REF  308
+#define CLK_GMAC1_PTP_REF  309
+#define CLK_GMAC_125M      310
+#define CLK_GMAC_50M       311
+#define PCLK_GMAC0         344
+#define PCLK_GMAC1         345
+#define ACLK_GMAC0         349
+#define ACLK_GMAC1         350
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RK3588_CRU_H_ */

--- a/include/zephyr/dt-bindings/reset/rk3588-cru-reset.h
+++ b/include/zephyr/dt-bindings/reset/rk3588-cru-reset.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 KylinSoft
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Subset of Linux include/dt-bindings/reset/rk3588-cru.h.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RK3588_CRU_RESET_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RK3588_CRU_RESET_H_
+
+#define SRST_A_GMAC0 291
+#define SRST_A_GMAC1 292
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_RK3588_CRU_RESET_H_ */


### PR DESCRIPTION
Add clock and reset identifiers for RK3588 GMAC blocks. Values are a subset of the Linux RK3588 CRU headers and are used by platform glue and devicetree nodes.
## Testing
- Build-only; consumed by follow-up Rockchip GMAC DTS and platform driver PRs