### PR TITLE
boards: st: nucleo_wba65ri: Restore RNG in default variant

### DIFF
--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -29,6 +29,10 @@
 	};
 };
 
+&rng {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;


### PR DESCRIPTION
Restore enabling of the rng node in nucleo_wba65ri default variant that was mistakenly removed by commit a1cb51d8c3cb ("boards: st: nucleo_wba65ri: Define a common DTSI file for variants").