### PR TITLE
drivers: ethernet: dwc_mac: fix EQOS setup and designware compat

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -639,9 +639,17 @@ static void phy_link_state_changed(const struct device *phy_dev,
 		}
 
 		DWMAC_REG_WRITE(MAC_CONF, reg_val);
+		dwmac_platform_phy_link_up(dev, state);
 	}
 
 	net_eth_carrier_set(p->iface, state->is_up);
+}
+
+__weak void dwmac_platform_phy_link_up(const struct device *dev,
+				       const struct phy_link_state *state)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(state);
 }
 
 static const struct device *dwmac_get_phy(const struct device *dev, struct net_if *iface __unused)
@@ -682,6 +690,15 @@ static void dwmac_iface_init(struct net_if *iface)
 		/* multicast is perfect filtered against the MAC address entries */
 		DWMAC_REG_WRITE(MAC_PKT_FILTER, 0);
 	}
+
+	/*
+	 * After DMA soft reset the DBF bit may block broadcast frames (ARP).
+	 * Mirror Linux stmmac and always allow broadcast/multicast passthrough.
+	 */
+	reg_val = DWMAC_REG_READ(MAC_PKT_FILTER);
+	reg_val &= ~MAC_PKT_FILTER_DBF;
+	reg_val |= MAC_PKT_FILTER_PM;
+	DWMAC_REG_WRITE(MAC_PKT_FILTER, reg_val);
 
 	if (cfg->phy_dev != NULL) {
 		/* Do not start the interface until PHY link is up */
@@ -779,19 +796,42 @@ int dwmac_probe(const struct device *dev)
 	}
 
 	/* setup queues */
-	/* currently only a single queue is supported, assign full FIFO to it */
-	rx_fifo_size = BIT(7 + FIELD_GET(MAC_HW_FEATURE1_RXFIFOSIZE, p->feature1));
-	tx_fifo_size = BIT(7 + FIELD_GET(MAC_HW_FEATURE1_TXFIFOSIZE, p->feature1));
+	rx_fifo_size = 128U << FIELD_GET(MAC_HW_FEATURE1_RXFIFOSIZE, p->feature1);
+	tx_fifo_size = 128U << FIELD_GET(MAC_HW_FEATURE1_TXFIFOSIZE, p->feature1);
 	LOG_DBG("RX/TX fifo size: %u/%u bytes", rx_fifo_size, tx_fifo_size);
 
-	DWMAC_REG_WRITE(MTL_RXQn_OPERATION_MODE(0),
-			MTL_RXQn_OPERATION_MODE_RSF |
-			FIELD_PREP(MTL_RXQn_OPERATION_MODE_RQS, (rx_fifo_size/256) - 1));
-	DWMAC_REG_WRITE(MAC_RXQ_CTRL0, FIELD_PREP(MAC_RXQ_CTRL0_RXQ0EN, 2));
-	DWMAC_REG_WRITE(MTL_TXQn_OPERATION_MODE(0),
-			MTL_TXQn_OPERATION_MODE_TSF |
-			FIELD_PREP(MTL_TXQn_OPERATION_MODE_TQS, (tx_fifo_size/256) - 1) |
-			FIELD_PREP(MTL_TXQn_OPERATION_MODE_TXQEN, 1));
+	{
+		unsigned int tqs = (tx_fifo_size / 256U) - 1U;
+		unsigned int rqs = (rx_fifo_size / 256U) - 1U;
+		uint32_t mtl_tx;
+		uint32_t mtl_rx;
+		uint32_t reg;
+
+		mtl_tx = DWMAC_REG_READ(MTL_TXQn_OPERATION_MODE(0));
+		mtl_tx |= MTL_TXQn_OPERATION_MODE_TSF |
+			  FIELD_PREP(MTL_TXQn_OPERATION_MODE_TXQEN, 1);
+		mtl_tx &= ~MTL_TXQn_OPERATION_MODE_TQS;
+		mtl_tx |= FIELD_PREP(MTL_TXQn_OPERATION_MODE_TQS, tqs);
+		DWMAC_REG_WRITE(MTL_TXQn_OPERATION_MODE(0), mtl_tx);
+
+		mtl_rx = DWMAC_REG_READ(MTL_RXQn_OPERATION_MODE(0));
+		mtl_rx |= MTL_RXQn_OPERATION_MODE_RSF;
+		mtl_rx &= ~MTL_RXQn_OPERATION_MODE_RQS;
+		mtl_rx |= FIELD_PREP(MTL_RXQn_OPERATION_MODE_RQS, rqs);
+		DWMAC_REG_WRITE(MTL_RXQn_OPERATION_MODE(0), mtl_rx);
+
+		DWMAC_REG_WRITE(MTL_RXQ_DMA_MAP0, 0);
+
+		reg = DWMAC_REG_READ(MAC_RXQ_CTRL0);
+		reg &= ~GENMASK(1, 0);
+		reg |= FIELD_PREP(MAC_RXQ_CTRL0_RXQ0EN, 2);
+		DWMAC_REG_WRITE(MAC_RXQ_CTRL0, reg);
+
+		reg = DWMAC_REG_READ(MAC_RXQ_CTRL1);
+		reg &= ~GENMASK(18, 12);
+		reg |= BIT(20);
+		DWMAC_REG_WRITE(MAC_RXQ_CTRL1, reg);
+	}
 
 	/* set up DMA */
 	memset(p->tx_descs, 0, NB_TX_DESCS * sizeof(struct dwmac_dma_desc));

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -19,6 +19,8 @@
 #include <zephyr/net/ethernet.h>
 #include <zephyr/sys/device_mmio.h>
 
+struct phy_link_state;
+
 /*
  * Common checks
  */
@@ -80,10 +82,16 @@
  * are assumed to be the same for all instances.
  */
 
-BUILD_ASSERT(DT_HAS_COMPAT_STATUS_OKAY(snps_dwmac),
-	     "No device tree node with compatible \"snps,dwmac\" found");
+BUILD_ASSERT(DT_HAS_COMPAT_STATUS_OKAY(snps_dwmac) ||
+	     DT_HAS_COMPAT_STATUS_OKAY(snps_designware_ethernet),
+	     "No device tree node with compatible \"snps,dwmac\" or "
+	     "\"snps,designware-ethernet\" found");
 
+#if DT_HAS_COMPAT_STATUS_OKAY(snps_designware_ethernet)
+#define DWMAC_DT_NODE DT_INST(0, snps_designware_ethernet)
+#else
 #define DWMAC_DT_NODE DT_INST(0, snps_dwmac)
+#endif
 
 /* multicast filter capabilities of the hardware */
 #define DWMAC_MULTICAST_FILTER_BINS	DT_PROP_OR(DWMAC_DT_NODE, snps_multicast_filter_bins, 0)
@@ -228,6 +236,8 @@ struct dwmac_priv {
 int dwmac_probe(const struct device *dev);
 int dwmac_bus_init(const struct device *dev);
 int dwmac_platform_init(const struct device *dev);
+void dwmac_platform_phy_link_up(const struct device *dev,
+				const struct phy_link_state *state);
 void dwmac_setup_multicast_filter(const struct device *dev, const struct ethernet_filter *filter);
 void dwmac_isr(const struct device *ddev);
 #if defined(CONFIG_PTP_CLOCK_DWC_MAC)
@@ -1387,19 +1397,19 @@ extern const struct ethernet_api dwmac_api;
  * The following offsets are used to adjust the register addresses accordingly. We assume here that
  * the order is the same for all instances of the DWMAC driver, so we only check the first instance.
  */
-#if DT_REG_HAS_NAME(DT_INST(0, snps_dwmac), base)
-#if DT_REG_HAS_NAME(DT_INST(0, snps_dwmac), mac)
+#if DT_REG_HAS_NAME(DWMAC_DT_NODE, base)
+#if DT_REG_HAS_NAME(DWMAC_DT_NODE, mac)
 #define DWMAC_MAC_OFFSET                                                                           \
-	(DT_REG_ADDR_BY_NAME(DT_INST(0, snps_dwmac), mac) -                                        \
-	 DT_REG_ADDR_BY_NAME(DT_INST(0, snps_dwmac), base))
+	(DT_REG_ADDR_BY_NAME(DWMAC_DT_NODE, mac) -                                                \
+	 DT_REG_ADDR_BY_NAME(DWMAC_DT_NODE, base))
 #endif
 
-#if DT_REG_HAS_NAME(DT_INST(0, snps_dwmac), dma)
+#if DT_REG_HAS_NAME(DWMAC_DT_NODE, dma)
 #define DWMAC_DMA_OFFSET                                                                           \
-	(DT_REG_ADDR_BY_NAME(DT_INST(0, snps_dwmac), dma) -                                        \
-	 DT_REG_ADDR_BY_NAME(DT_INST(0, snps_dwmac), base))
+	(DT_REG_ADDR_BY_NAME(DWMAC_DT_NODE, dma) -                                                \
+	 DT_REG_ADDR_BY_NAME(DWMAC_DT_NODE, base))
 #endif
-#endif /* DT_REG_HAS_NAME(DT_INST(0, snps_dwmac), base) */
+#endif /* DT_REG_HAS_NAME(DWMAC_DT_NODE, base) */
 
 #ifndef DWMAC_MAC_OFFSET
 #define DWMAC_MAC_OFFSET		0x0000


### PR DESCRIPTION
Fix several EQOS core issues affecting platforms using the shared DWMAC driver:
- Program MTL and MAC RX queue routing after DMA soft reset
- Clear MAC_PKT_FILTER DBF so broadcast frames (e.g. ARP) are not blocked after reset
- Add `dwmac_platform_phy_link_up()` weak hook for platform-specific PHY/link handling
- Accept `snps,designware-ethernet` in `priv.h` alongside `snps,dwmac`
## Testing
- Verified as part of Rockchip RK3588 GMAC bring-up (see platform driver PR)