### PR TITLE
dts: arm64: rockchip: add RK3588 GMAC and MDIO nodes

### DIFF
--- a/dts/arm64/rockchip/rk3588.dtsi
+++ b/dts/arm64/rockchip/rk3588.dtsi
@@ -118,4 +118,40 @@
 		reg-shift = <2>;
 		status = "disabled";
 	};
+
+	gmac0: ethernet@fe1b0000 {
+		compatible = "snps,designware-ethernet";
+		reg = <0xfe1b0000 0x10000>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 227 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		phy-connection-type = "rgmii";
+		status = "disabled";
+	};
+
+	gmac1: ethernet@fe1c0000 {
+		compatible = "snps,designware-ethernet";
+		reg = <0xfe1c0000 0x10000>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 234 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		phy-connection-type = "rgmii";
+		status = "disabled";
+	};
+
+	mdio0: mdio@fe1b0000 {
+		compatible = "snps,designware-mdio";
+		reg = <0xfe1b0000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clock-frequency = <125000000>;
+		status = "disabled";
+	};
+
+	mdio1: mdio@fe1c0000 {
+		compatible = "snps,designware-mdio";
+		reg = <0xfe1c0000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clock-frequency = <125000000>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
Describe `gmac0`/`gmac1` and standalone `mdio0`/`mdio1` nodes in `rk3588.dtsi`. Nodes default to `status = "disabled"`; boards enable the instance they use.

Depends-on: zephyrproject-rtos/zephyr#117976
Depends-on: zephyrproject-rtos/zephyr#117977

## Testing
- Devicetree builds with bindings and CRU IDs from dependent PRs