### PR TITLE
tests: drivers: uart: async_dual: Reduce stack size

### DIFF
--- a/tests/drivers/uart/uart_async_dual/src/main.c
+++ b/tests/drivers/uart/uart_async_dual/src/main.c
@@ -915,7 +915,7 @@ static void hci_like_rx(void)
 	TC_PRINT("\n");
 }
 
-#define HCI_LIKE_TX_STACK_SIZE 2048
+#define HCI_LIKE_TX_STACK_SIZE 512
 static K_THREAD_STACK_DEFINE(hci_like_tx_thread_stack, HCI_LIKE_TX_STACK_SIZE);
 static struct k_thread hci_like_tx_thread;
 


### PR DESCRIPTION
Reduce stack size used for receiving data in HCI like transfers. 2048 bytes were used but thread stats shown that up to 248 bytes are used. Reducing to 512 bytes, leaving some room for growth.

Test runs on targets with low memory footprint so any memory waste need to be avoided.