### PR TITLE
drivers: flash: add M95P32 extended operations

### DIFF
--- a/boards/shields/x_nucleo_pgeez1/boards/nucleo_u575zi_q.conf
+++ b/boards/shields/x_nucleo_pgeez1/boards/nucleo_u575zi_q.conf
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable the M95P32 identification-page and page-program-with-buffer-load operations.
+CONFIG_FLASH_EX_OP_ENABLED=y
+
 # Match the STM32U575 8-KiB sectors for MCUboot swap using offset.
 CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE=8192

--- a/boards/shields/x_nucleo_pgeez1/boards/nucleo_u575zi_q.overlay
+++ b/boards/shields/x_nucleo_pgeez1/boards/nucleo_u575zi_q.overlay
@@ -19,7 +19,7 @@
 };
 
 &m95p32_x_nucleo_pgeez1 {
-	compatible = "st,nor", "jedec,nor";
+	compatible = "st,nor", "st,m95p32", "jedec,nor";
 	st,mem-type = "macronix";
 
 	partitions {

--- a/boards/shields/x_nucleo_pgeez1/x_nucleo_pgeez1.overlay
+++ b/boards/shields/x_nucleo_pgeez1/x_nucleo_pgeez1.overlay
@@ -21,7 +21,7 @@
 	status = "okay";
 
 	m95p32_x_nucleo_pgeez1: eeprom@0 {
-		compatible = "jedec,nor";
+		compatible = "st,m95p32", "jedec,nor";
 		reg = <0>;
 		size = <DT_SIZE_M(32)>; /* 32 Mbits */
 		erase-block-size = <512>;

--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -50,6 +50,7 @@ menuconfig FLASH_MSPI_NOR
 	select FLASH_HAS_EXPLICIT_ERASE
 	select FLASH_JESD216
 	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_EX_OP if DT_HAS_ST_M95P32_ENABLED
 	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_NOR),reset-gpios) || \
 			$(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_NOR),supply-gpios)
 

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -736,7 +736,31 @@ static int api_read_jedec_id(const struct device *dev, uint8_t *id)
 
 	return rc;
 }
-#endif /* CONFIG_FLASH_JESD216_API  */
+#endif /* CONFIG_FLASH_JESD216_API */
+
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+static int api_ex_op(const struct device *dev, uint16_t code,
+		     const uintptr_t in, void *out)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	int rc;
+
+	if ((dev_config->quirks == NULL) ||
+	    (dev_config->quirks->ex_op == NULL)) {
+		return -ENOTSUP;
+	}
+
+	rc = acquire(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+	rc = dev_config->quirks->ex_op(dev, code, in, out);
+	release(dev);
+
+	return rc;
+}
+#endif /* CONFIG_FLASH_EX_OP_ENABLED */
 
 #if defined(WITH_DPD)
 static int enter_dpd(const struct device *const dev)
@@ -1481,6 +1505,9 @@ static DEVICE_API(flash, drv_api) = {
 #if defined(CONFIG_FLASH_JESD216_API)
 	.sfdp_read = api_sfdp_read,
 	.read_jedec_id = api_read_jedec_id,
+#endif
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+	.ex_op = api_ex_op,
 #endif
 };
 

--- a/drivers/flash/flash_mspi_nor_quirks.h
+++ b/drivers/flash/flash_mspi_nor_quirks.h
@@ -18,6 +18,8 @@ struct flash_mspi_nor_quirks {
 	int (*pre_init)(const struct device *dev);
 	/* Called after switching to default IO mode. */
 	int (*post_switch_mode)(const struct device *dev);
+	/* Called by flash_ex_op() while the flash device is acquired. */
+	int (*ex_op)(const struct device *dev, uint16_t code, const uintptr_t in, void *out);
 };
 
 /* Extend this macro when adding new flash chip with quirks */
@@ -26,7 +28,9 @@ struct flash_mspi_nor_quirks {
 		    (&flash_quirks_mxicy_mx25r),				\
 	(COND_CODE_1(DT_NODE_HAS_COMPAT_STATUS(node, mxicy_mx25u, okay),	\
 		    (&flash_quirks_mxicy_mx25u),				\
-		    (NULL))))
+	(COND_CODE_1(DT_NODE_HAS_COMPAT_STATUS(node, st_m95p32, okay),		\
+		    (&flash_quirks_st_m95p32),					\
+		    (NULL))))))
 
 #if DT_HAS_COMPAT_STATUS_OKAY(mxicy_mx25r)
 
@@ -210,5 +214,9 @@ struct flash_mspi_nor_quirks flash_quirks_mxicy_mx25u = {
 };
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(mxicy_mx25u) */
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_m95p32)
+#include "flash_mspi_nor_quirks_m95p32.h"
+#endif
 
 #endif /*__FLASH_MSPI_NOR_QUIRKS_H__*/

--- a/drivers/flash/flash_mspi_nor_quirks_m95p32.h
+++ b/drivers/flash/flash_mspi_nor_quirks_m95p32.h
@@ -1,0 +1,357 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_FLASH_FLASH_MSPI_NOR_QUIRKS_M95P32_H_
+#define ZEPHYR_DRIVERS_FLASH_FLASH_MSPI_NOR_QUIRKS_M95P32_H_
+
+#include <zephyr/drivers/flash/m95p32_flash_api_extensions.h>
+
+#define M95P32_CMD_RDID_PAGE 0x83
+#define M95P32_CMD_WRID_PAGE 0x82
+#define M95P32_CMD_RDVR      0x85
+#define M95P32_CMD_WRVR      0x81
+#define M95P32_CMD_PGPR      0x0A
+
+#define M95P32_VOLATILE_BUFEN BIT(1)
+#define M95P32_VOLATILE_BUFLD BIT(0)
+
+#define M95P32_PAGE_SIZE 512U
+
+static void m95p32_set_up_xfer_with_addr(const struct device *dev, enum mspi_xfer_direction dir,
+					 uint32_t addr, enum mspi_xfer_mode xfer_mode)
+{
+	struct flash_mspi_nor_data *dev_data = dev->data;
+
+	set_up_xfer(dev, dir, xfer_mode);
+	dev_data->xfer.addr_length = 3;
+	dev_data->packet.address = addr;
+}
+
+static int m95p32_ex_op_read_id_page(const struct device *dev,
+				     const struct flash_m95p32_ex_op_read_id_page_in *op_in,
+				     void *out)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	uint32_t addr;
+	uint8_t *data = out;
+	size_t remaining;
+	int rc;
+
+	if (op_in == NULL) {
+		return -EINVAL;
+	}
+	if (op_in->length == 0U) {
+		return 0;
+	}
+	if (out == NULL || op_in->offset < 0 || op_in->offset >= M95P32_ID_AREA_SIZE ||
+	    op_in->length > M95P32_ID_AREA_SIZE - (size_t)op_in->offset) {
+		return -EINVAL;
+	}
+
+	addr = (uint32_t)op_in->offset;
+	remaining = op_in->length;
+
+	while (remaining > 0U) {
+		size_t to_read = remaining;
+
+		if (dev_config->packet_data_limit != 0U) {
+			to_read = MIN(to_read, dev_config->packet_data_limit);
+		}
+
+		m95p32_set_up_xfer_with_addr(dev, MSPI_RX, addr, dev_config->control_xfer_mode);
+		dev_data->packet.data_buf = data;
+		dev_data->packet.num_bytes = to_read;
+		rc = perform_xfer(dev, M95P32_CMD_RDID_PAGE);
+		if (rc < 0) {
+			return rc;
+		}
+
+		addr += to_read;
+		data += to_read;
+		remaining -= to_read;
+	}
+
+	return 0;
+}
+
+static int m95p32_ex_op_write_id_page(const struct device *dev,
+				      const struct flash_m95p32_ex_op_write_id_page_in *op_in)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	const uint8_t *data;
+	uint32_t addr;
+	size_t remaining;
+	int rc;
+
+	if (op_in == NULL) {
+		return -EINVAL;
+	}
+	if (op_in->length == 0U) {
+		return 0;
+	}
+	if (op_in->data == NULL || op_in->offset < M95P32_CUSTOMER_ID_PAGE_OFFSET ||
+	    op_in->offset >= M95P32_ID_AREA_SIZE ||
+	    op_in->length > M95P32_ID_AREA_SIZE - (size_t)op_in->offset) {
+		return -EINVAL;
+	}
+
+	addr = (uint32_t)op_in->offset;
+	data = op_in->data;
+	remaining = op_in->length;
+
+	while (remaining > 0U) {
+		size_t to_write = remaining;
+
+		if (dev_config->packet_data_limit != 0U) {
+			to_write = MIN(to_write, dev_config->packet_data_limit);
+		}
+
+		rc = cmd_wren(dev);
+		if (rc < 0) {
+			return rc;
+		}
+
+		m95p32_set_up_xfer_with_addr(dev, MSPI_TX, addr, dev_config->control_xfer_mode);
+		dev_data->packet.data_buf = (uint8_t *)data;
+		dev_data->packet.num_bytes = to_write;
+		rc = perform_xfer(dev, M95P32_CMD_WRID_PAGE);
+		if (rc < 0) {
+			return rc;
+		}
+
+		rc = wait_until_ready(dev, K_MSEC(1));
+		if (rc < 0) {
+			return rc;
+		}
+
+		addr += to_write;
+		data += to_write;
+		remaining -= to_write;
+	}
+
+	return 0;
+}
+
+static int m95p32_read_volatile_reg(const struct device *dev, uint8_t *value)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+
+	if (value == NULL) {
+		return -EINVAL;
+	}
+
+	set_up_xfer(dev, MSPI_RX, dev_config->control_xfer_mode);
+	dev_data->packet.data_buf = value;
+	dev_data->packet.num_bytes = sizeof(*value);
+
+	return perform_xfer(dev, M95P32_CMD_RDVR);
+}
+
+static int m95p32_write_volatile_reg(const struct device *dev, uint8_t value)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	int rc;
+
+	if ((value & ~M95P32_VOLATILE_BUFEN) != 0U) {
+		return -EINVAL;
+	}
+
+	rc = cmd_wren(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+	set_up_xfer(dev, MSPI_TX, dev_config->control_xfer_mode);
+	dev_data->packet.data_buf = &value;
+	dev_data->packet.num_bytes = sizeof(value);
+
+	return perform_xfer(dev, M95P32_CMD_WRVR);
+}
+
+static int m95p32_set_buffer_mode(const struct device *dev, bool enable)
+{
+	uint8_t volatile_reg;
+	int rc;
+
+	rc = m95p32_write_volatile_reg(dev, enable ? M95P32_VOLATILE_BUFEN : 0U);
+	if (rc < 0) {
+		return rc;
+	}
+
+	rc = m95p32_read_volatile_reg(dev, &volatile_reg);
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (!!(volatile_reg & M95P32_VOLATILE_BUFEN) != enable) {
+		LOG_ERR("%s: volatile register 0x%02x after setting BUFEN to %u", dev->name,
+			volatile_reg, enable);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int m95p32_wait_buffer_free(const struct device *dev)
+{
+	uint8_t volatile_reg;
+	int rc;
+
+	while (true) {
+		rc = m95p32_read_volatile_reg(dev, &volatile_reg);
+		if (rc < 0) {
+			return rc;
+		}
+		if ((volatile_reg & M95P32_VOLATILE_BUFEN) == 0U) {
+			LOG_ERR("%s: BUFEN cleared while waiting, volatile register 0x%02x",
+				dev->name, volatile_reg);
+			return -EIO;
+		}
+		if ((volatile_reg & M95P32_VOLATILE_BUFLD) == 0U) {
+			return 0;
+		}
+
+		k_sleep(K_USEC(1));
+	}
+}
+
+static int m95p32_page_program_with_buffer_load(const struct device *dev, uint32_t addr,
+						const uint8_t *data, size_t length)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+
+	m95p32_set_up_xfer_with_addr(dev, MSPI_TX, addr, dev_config->data_xfer_mode);
+	dev_data->packet.data_buf = (uint8_t *)data;
+	dev_data->packet.num_bytes = length;
+
+	return perform_xfer(dev, M95P32_CMD_PGPR);
+}
+
+static int m95p32_ex_op_page_program_with_buffer_load(
+	const struct device *dev,
+	const struct flash_m95p32_ex_op_page_program_with_buffer_load_in *op_in)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	const uint16_t page_size = dev_config->page_size;
+	const uint8_t *data;
+	uint32_t addr;
+	size_t remaining;
+	bool buffer_enabled = false;
+	int cleanup_rc;
+	int rc;
+
+	if (op_in == NULL) {
+		return -EINVAL;
+	}
+	if (op_in->length == 0U) {
+		return 0;
+	}
+	if (op_in->data == NULL) {
+		return -EINVAL;
+	}
+	if (op_in->offset < 0 || op_in->offset >= dev_config->flash_size ||
+	    op_in->length > dev_config->flash_size - (size_t)op_in->offset ||
+	    page_size != M95P32_PAGE_SIZE) {
+		return -EINVAL;
+	}
+	if (dev_data->cmd_info.pp_cmd != M95P32_CMD_PGPR) {
+		return -ENOTSUP;
+	}
+
+	addr = (uint32_t)op_in->offset;
+	data = op_in->data;
+	remaining = op_in->length;
+
+	rc = m95p32_set_buffer_mode(dev, true);
+	if (rc < 0) {
+		LOG_ERR("%s: failed to enable buffer mode: %d", dev->name, rc);
+		return rc;
+	}
+	buffer_enabled = true;
+
+	if (rc == 0) {
+		rc = cmd_wren(dev);
+		if (rc < 0) {
+			LOG_ERR("%s: WREN before page program with buffer load failed: %d",
+				dev->name, rc);
+		}
+	}
+	while (rc == 0 && remaining > 0U) {
+		size_t page_left = page_size - (addr % page_size);
+		size_t to_write = MIN(remaining, page_left);
+
+		if (dev_config->packet_data_limit != 0U) {
+			to_write = MIN(to_write, dev_config->packet_data_limit);
+		}
+
+		rc = m95p32_wait_buffer_free(dev);
+		if (rc < 0) {
+			LOG_ERR("%s: buffer was not available: %d", dev->name, rc);
+			break;
+		}
+
+		rc = m95p32_page_program_with_buffer_load(dev, addr, data, to_write);
+		if (rc < 0) {
+			LOG_ERR("%s: page program with buffer load at 0x%06x failed: %d", dev->name,
+				addr, rc);
+			break;
+		}
+
+		addr += to_write;
+		data += to_write;
+		remaining -= to_write;
+	}
+
+	cleanup_rc = wait_until_ready(dev, K_MSEC(1));
+	if (cleanup_rc < 0) {
+		LOG_ERR("%s: final WIP wait failed: %d", dev->name, cleanup_rc);
+	}
+	if (rc == 0) {
+		rc = cleanup_rc;
+	}
+
+	if (buffer_enabled && cleanup_rc == 0) {
+		cleanup_rc = m95p32_set_buffer_mode(dev, false);
+		if (cleanup_rc < 0) {
+			LOG_ERR("%s: failed to disable buffer mode: %d", dev->name, cleanup_rc);
+		}
+		if (rc == 0) {
+			rc = cleanup_rc;
+		}
+	}
+
+	return rc;
+}
+
+static int m95p32_ex_op(const struct device *dev, uint16_t code, const uintptr_t in, void *out)
+{
+	switch (code) {
+	case FLASH_M95P32_EX_OP_READ_ID_PAGE:
+		return m95p32_ex_op_read_id_page(
+			dev, (const struct flash_m95p32_ex_op_read_id_page_in *)in, out);
+	case FLASH_M95P32_EX_OP_WRITE_ID_PAGE:
+		return m95p32_ex_op_write_id_page(
+			dev, (const struct flash_m95p32_ex_op_write_id_page_in *)in);
+	case FLASH_M95P32_EX_OP_PAGE_PROGRAM_WITH_BUFFER_LOAD:
+		return m95p32_ex_op_page_program_with_buffer_load(
+			dev,
+			(const struct flash_m95p32_ex_op_page_program_with_buffer_load_in *)in);
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static struct flash_mspi_nor_quirks flash_quirks_st_m95p32 = {
+	.ex_op = m95p32_ex_op,
+};
+
+#endif /* ZEPHYR_DRIVERS_FLASH_FLASH_MSPI_NOR_QUIRKS_M95P32_H_ */

--- a/dts/bindings/mtd/st,m95p32-mspi.yaml
+++ b/dts/bindings/mtd/st,m95p32-mspi.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: ST M95P32 page EEPROM on a MSPI bus
+
+description: |
+  The M95P32 is a 32-Mbit page EEPROM with a 512-byte page size. In
+  addition to the main memory array, it provides a factory identification
+  page and a customer-programmable identification page. It also provides an
+  internal page buffer that can be loaded before programming the main memory
+  array.
+
+compatible: "st,m95p32"
+
+include: jedec,nor-mspi.yaml

--- a/include/zephyr/drivers/flash/m95p32_flash_api_extensions.h
+++ b/include/zephyr/drivers/flash/m95p32_flash_api_extensions.h
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ST M95P32 page EEPROM flash API extensions.
+ * @ingroup m95p32_flash_ex_op
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FLASH_M95P32_FLASH_API_EXTENSIONS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FLASH_M95P32_FLASH_API_EXTENSIONS_H_
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#include <zephyr/drivers/flash.h>
+
+/**
+ * @brief ST M95P32 page EEPROM extended operations.
+ * @defgroup m95p32_flash_ex_op ST M95P32
+ * @ingroup flash_ex_op
+ * @{
+ */
+
+/** Size of one M95P32 identification page. */
+#define M95P32_ID_PAGE_SIZE 512U
+
+/** Total size of the two M95P32 identification pages. */
+#define M95P32_ID_AREA_SIZE (2U * M95P32_ID_PAGE_SIZE)
+
+/** Start of the customer identification page. */
+#define M95P32_CUSTOMER_ID_PAGE_OFFSET M95P32_ID_PAGE_SIZE
+
+/** M95P32-specific flash extended operations. */
+enum flash_m95p32_ex_ops {
+	/** Read the factory and customer identification pages. */
+	FLASH_M95P32_EX_OP_READ_ID_PAGE = FLASH_EX_OP_VENDOR_BASE,
+	/** Write data to the customer identification page. */
+	FLASH_M95P32_EX_OP_WRITE_ID_PAGE,
+	/** Program main-memory pages with M95P32 buffer-load mode enabled. */
+	FLASH_M95P32_EX_OP_PAGE_PROGRAM_WITH_BUFFER_LOAD,
+};
+
+/** Input parameters for @ref FLASH_M95P32_EX_OP_READ_ID_PAGE. */
+struct flash_m95p32_ex_op_read_id_page_in {
+	/** Offset in the M95P32 identification area. */
+	off_t offset;
+	/** Number of bytes to read. */
+	size_t length;
+};
+
+/** Input parameters for @ref FLASH_M95P32_EX_OP_WRITE_ID_PAGE. */
+struct flash_m95p32_ex_op_write_id_page_in {
+	/** Offset in the customer identification page. */
+	off_t offset;
+	/** Data to write. */
+	const void *data;
+	/** Number of bytes to write. */
+	size_t length;
+};
+
+/**
+ * @brief Input parameters for @ref FLASH_M95P32_EX_OP_PAGE_PROGRAM_WITH_BUFFER_LOAD.
+ *
+ * The target array must be erased before programming. The driver splits the
+ * data at the M95P32 512-byte page boundaries and uses buffer-load mode to
+ * overlap programming one page with loading the next page.
+ */
+struct flash_m95p32_ex_op_page_program_with_buffer_load_in {
+	/** Offset in the M95P32 main memory array. */
+	off_t offset;
+	/** Data to program. */
+	const void *data;
+	/** Number of bytes to program. */
+	size_t length;
+};
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FLASH_M95P32_FLASH_API_EXTENSIONS_H_ */

--- a/samples/shields/x_nucleo_pgeez1/CMakeLists.txt
+++ b/samples/shields/x_nucleo_pgeez1/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+# This sample requires the M95P32 provided by the X-NUCLEO-PGEEZ1 shield.
+set(SHIELD x_nucleo_pgeez1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(x_nucleo_pgeez1)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/shields/x_nucleo_pgeez1/README.rst
+++ b/samples/shields/x_nucleo_pgeez1/README.rst
@@ -1,0 +1,88 @@
+X-NUCLEO-PGEEZ1 M95P32 extended operations
+############################################
+
+Overview
+********
+
+This sample demonstrates the M95P32-specific flash operations exposed through
+the Flash API ``flash_ex_op()`` extension:
+
+* Read the 1024-byte identification area with ``RDID`` (0x83).
+* Write and read back a pattern in the customer identification page with
+  ``WRID`` (0x82), and verify that a write crossing its boundary is rejected.
+* Read across the factory/customer identification-page boundary.
+* Compare standard page programming through ``flash_write()`` with ``PGPR``
+  (0x0A) page program with buffer load over two independently erased 64-KiB
+  main-array regions. The sample times only each write call, then reads back
+  both regions to verify their contents.
+
+The page-program-with-buffer-load operation enables and disables the M95P32
+buffer mode internally using its volatile register. Direct volatile-register
+access is not part of the public API.
+
+.. warning::
+
+   The sample modifies the customer identification page at offset 0x200 and
+   erases the main-array regions from 0x3e0000 to 0x3fffff. Do not run it when
+   this region contains data that must be preserved.
+
+Building and Running
+********************
+
+Build the sample for a NUCLEO-U575ZI-Q with the X-NUCLEO-PGEEZ1 shield:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/shields/x_nucleo_pgeez1
+   :board: nucleo_u575zi_q
+   :shield: x_nucleo_pgeez1
+   :goals: build flash
+   :compact:
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   [00:00:00.000,000] <inf> ospi_stm32: MSPI config result: success
+   *** Booting Zephyr OS build v4.4.0-11617-g2189ec6da640 ***
+   M95P32 extended operation test
+
+   ==================== READ: Factory identification page ====================
+   Identification page [0x000..0x00f]: 20 00 16 00 ff ff ff ff ff ff ff ff ff ff ff ff
+
+   ==================== READ: Customer identification page before clear ====================
+   Customer identification page before WRID [0x200..0x20f]: 4d 39 35 50 33 32 2d 65 78 2d 6f 70 2d 74 65 73
+
+   ==================== WRITE: Clear customer identification page ====================
+   Clearing customer identification page [0x200..0x20f]: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+
+   ==================== READ: Customer identification page after clear ====================
+   Customer identification page after clear [0x200..0x20f]: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+
+   ==================== WRITE: Customer identification page ====================
+   Writing customer identification page [0x200..0x20f]: 4d 39 35 50 33 32 2d 65 78 2d 6f 70 2d 74 65 73
+
+   ==================== READ: Customer identification page after WRID ====================
+   Customer identification page after WRID [0x200..0x20f]: 4d 39 35 50 33 32 2d 65 78 2d 6f 70 2d 74 65 73
+
+   ==================== READ: Identification page boundary ====================
+   Identification page boundary [0x1f8..0x207]: ff ff ff ff ff ff ff ff 4d 39 35 50 33 32 2d 65
+
+   ==================== WRITE: Cross-page protection ====================
+   Cross-page WRID protection passed
+
+   Identification page read/write passed
+
+   ==================== PREPARE: Erase write benchmark regions ====================
+
+   ==================== WRITE: Standard page program ====================
+   Standard page program data verification passed
+
+   ==================== WRITE: Page program with buffer load ====================
+   Page program with buffer load data verification passed
+
+   ==================== RESULT: Write performance ====================
+   Standard page program (65536 bytes): 21752449 cycles, 0.135952 s
+   Page program with buffer load (65536 bytes): 17151523 cycles, 0.107197 s
+   Page-program-with-buffer-load speedup: 1.26x (21.1% less write time)
+   M95P32 extended operation test passed

--- a/samples/shields/x_nucleo_pgeez1/prj.conf
+++ b/samples/shields/x_nucleo_pgeez1/prj.conf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_PRINTK=y
+CONFIG_FLASH=y
+
+# The sample calls the M95P32-specific flash_ex_op() extensions.
+CONFIG_FLASH_EX_OP_ENABLED=y
+CONFIG_MSPI=y

--- a/samples/shields/x_nucleo_pgeez1/src/main.c
+++ b/samples/shields/x_nucleo_pgeez1/src/main.c
@@ -1,0 +1,331 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/m95p32_flash_api_extensions.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/time_units.h>
+
+#include <errno.h>
+#include <string.h>
+
+#define M95P32_ID_READ_SIZE 16U
+#define M95P32_ID_WRITE_SIZE 16U
+#define M95P32_ID_BOUNDARY_OFFSET (M95P32_CUSTOMER_ID_PAGE_OFFSET - 8U)
+#define M95P32_ID_BOUNDARY_SIZE 16U
+#define M95P32_STANDARD_PAGE_PROGRAM_TEST_OFFSET 0x3e0000U
+#define M95P32_BUFFER_LOAD_TEST_OFFSET 0x3f0000U
+#define M95P32_WRITE_TEST_SIZE      (64U * 1024U)
+
+static uint8_t main_write_data[M95P32_WRITE_TEST_SIZE];
+static uint8_t main_read_data[M95P32_WRITE_TEST_SIZE];
+
+static void print_bytes(const char *label, const uint8_t *data, size_t length)
+{
+	printk("%s", label);
+	for (size_t i = 0; i < length; ++i) {
+		printk(" %02x", data[i]);
+	}
+	printk("\n");
+}
+
+static void print_test_section(const char *title)
+{
+	printk("\n==================== %s ====================\n", title);
+}
+
+static int read_id_page(const struct device *dev, off_t offset, void *data,
+			size_t length)
+{
+	/* Pass typed parameters to the generic Flash API extension entry point. */
+	const struct flash_m95p32_ex_op_read_id_page_in op_in = {
+		.offset = offset,
+		.length = length,
+	};
+
+	return flash_ex_op(dev, FLASH_M95P32_EX_OP_READ_ID_PAGE,
+			   (uintptr_t)&op_in, data);
+}
+
+static int write_id_page(const struct device *dev, off_t offset,
+			 const void *data, size_t length)
+{
+	const struct flash_m95p32_ex_op_write_id_page_in op_in = {
+		.offset = offset,
+		.data = data,
+		.length = length,
+	};
+
+	return flash_ex_op(dev, FLASH_M95P32_EX_OP_WRITE_ID_PAGE,
+			   (uintptr_t)&op_in, NULL);
+}
+
+static int page_program_with_buffer_load(const struct device *dev, off_t offset,
+					 const void *data, size_t length)
+{
+	const struct flash_m95p32_ex_op_page_program_with_buffer_load_in op_in = {
+		.offset = offset,
+		.data = data,
+		.length = length,
+	};
+
+	return flash_ex_op(dev, FLASH_M95P32_EX_OP_PAGE_PROGRAM_WITH_BUFFER_LOAD,
+			   (uintptr_t)&op_in, NULL);
+}
+
+/* Exercise factory/customer identification pages and reject an invalid write. */
+static int test_identification_page(const struct device *dev)
+{
+	const uint8_t expected_id[] = { 0x20, 0x00, 0x16 };
+	const uint8_t expected_customer_data[M95P32_ID_WRITE_SIZE] = {
+		'M', '9', '5', 'P', '3', '2', '-', 'e', 'x', '-', 'o', 'p',
+		'-', 't', 'e', 's',
+	};
+	uint8_t id_data[M95P32_ID_READ_SIZE];
+	uint8_t customer_data_before[M95P32_ID_WRITE_SIZE];
+	uint8_t customer_data[M95P32_ID_WRITE_SIZE];
+	uint8_t cleared_customer_data[M95P32_ID_WRITE_SIZE];
+	uint8_t boundary_data[M95P32_ID_BOUNDARY_SIZE];
+	struct flash_m95p32_ex_op_write_id_page_in boundary_write = {
+		.offset = M95P32_ID_AREA_SIZE - 8U,
+		.data = expected_customer_data,
+		.length = sizeof(expected_customer_data),
+	};
+	int rc;
+
+	print_test_section("READ: Factory identification page");
+	rc = read_id_page(dev, 0, id_data, sizeof(id_data));
+	if (rc < 0) {
+		printk("RDID failed: %d\n", rc);
+		return rc;
+	}
+
+	print_bytes("Identification page [0x000..0x00f]:", id_data,
+		    sizeof(id_data));
+	if (memcmp(id_data, expected_id, sizeof(expected_id)) != 0) {
+		printk("Unexpected identification bytes\n");
+		return -EIO;
+	}
+
+	print_test_section("READ: Customer identification page before clear");
+	rc = read_id_page(dev, M95P32_CUSTOMER_ID_PAGE_OFFSET,
+			  customer_data_before, sizeof(customer_data_before));
+	if (rc < 0) {
+		printk("Customer ID page read before WRID failed: %d\n", rc);
+		return rc;
+	}
+	print_bytes("Customer identification page before WRID [0x200..0x20f]:",
+		    customer_data_before, sizeof(customer_data_before));
+
+	print_test_section("WRITE: Clear customer identification page");
+	memset(cleared_customer_data, 0xff, sizeof(cleared_customer_data));
+	print_bytes("Clearing customer identification page [0x200..0x20f]:",
+		    cleared_customer_data, sizeof(cleared_customer_data));
+	rc = write_id_page(dev, M95P32_CUSTOMER_ID_PAGE_OFFSET,
+			   cleared_customer_data, sizeof(cleared_customer_data));
+	if (rc < 0) {
+		printk("Customer ID page clear failed: %d\n", rc);
+		return rc;
+	}
+
+	print_test_section("READ: Customer identification page after clear");
+	rc = read_id_page(dev, M95P32_CUSTOMER_ID_PAGE_OFFSET, customer_data,
+			  sizeof(customer_data));
+	if (rc < 0) {
+		printk("Customer ID page read after clear failed: %d\n", rc);
+		return rc;
+	}
+	print_bytes("Customer identification page after clear [0x200..0x20f]:",
+		    customer_data, sizeof(customer_data));
+	if (memcmp(customer_data, cleared_customer_data,
+		   sizeof(customer_data)) != 0) {
+		printk("Customer identification page clear data mismatch\n");
+		return -EIO;
+	}
+
+	print_test_section("WRITE: Customer identification page");
+	print_bytes("Writing customer identification page [0x200..0x20f]:",
+		    expected_customer_data, sizeof(expected_customer_data));
+
+	rc = write_id_page(dev, M95P32_CUSTOMER_ID_PAGE_OFFSET,
+			   expected_customer_data, sizeof(expected_customer_data));
+	if (rc < 0) {
+		printk("WRID failed: %d\n", rc);
+		return rc;
+	}
+
+	print_test_section("READ: Customer identification page after WRID");
+	rc = read_id_page(dev, M95P32_CUSTOMER_ID_PAGE_OFFSET, customer_data,
+			  sizeof(customer_data));
+	if (rc < 0) {
+		printk("Customer ID page read failed: %d\n", rc);
+		return rc;
+	}
+	if (memcmp(customer_data, expected_customer_data,
+		   sizeof(customer_data)) != 0) {
+		printk("Customer identification page data mismatch\n");
+		return -EIO;
+	}
+	print_bytes("Customer identification page after WRID [0x200..0x20f]:",
+		    customer_data, sizeof(customer_data));
+
+	print_test_section("READ: Identification page boundary");
+	rc = read_id_page(dev, M95P32_ID_BOUNDARY_OFFSET, boundary_data,
+			  sizeof(boundary_data));
+	if (rc < 0) {
+		printk("Cross-page RDID failed: %d\n", rc);
+		return rc;
+	}
+	print_bytes("Identification page boundary [0x1f8..0x207]:",
+		    boundary_data, sizeof(boundary_data));
+	if (memcmp(&boundary_data[8], expected_customer_data, 8U) != 0) {
+		printk("Cross-page identification data mismatch\n");
+		return -EIO;
+	}
+
+	/* Writes are restricted to the customer identification page. */
+	print_test_section("WRITE: Cross-page protection");
+	rc = flash_ex_op(dev, FLASH_M95P32_EX_OP_WRITE_ID_PAGE,
+			 (uintptr_t)&boundary_write, NULL);
+	if (rc != -EINVAL) {
+		printk("Cross-page WRID was not rejected: %d\n", rc);
+		return -EIO;
+	}
+	printk("Cross-page WRID protection passed\n");
+
+	printk("Identification page read/write passed\n");
+	return 0;
+}
+
+static int verify_main_array_write(const struct device *dev, off_t offset,
+				   const char *operation)
+{
+	int rc;
+
+	rc = flash_read(dev, offset, main_read_data,
+			sizeof(main_read_data));
+	if (rc < 0) {
+		printk("%s read failed: %d\n", operation, rc);
+		return rc;
+	}
+	if (memcmp(main_read_data, main_write_data, sizeof(main_read_data)) != 0) {
+		printk("%s data mismatch\n", operation);
+		return -EIO;
+	}
+
+	printk("%s data verification passed\n", operation);
+	return 0;
+}
+
+/* Compare regular programming with page program using buffer-load mode. */
+static int test_write_performance(const struct device *dev)
+{
+	uint32_t standard_start;
+	uint32_t standard_cycles;
+	uint32_t standard_us;
+	uint32_t buffer_load_start;
+	uint32_t buffer_load_cycles;
+	uint32_t buffer_load_us;
+	uint32_t speedup_x100;
+	uint32_t time_saved_x10;
+	int rc;
+
+	for (size_t i = 0; i < sizeof(main_write_data); ++i) {
+		main_write_data[i] = (uint8_t)(i ^ 0x5aU);
+	}
+
+	print_test_section("PREPARE: Erase write benchmark regions");
+	rc = flash_erase(dev, M95P32_STANDARD_PAGE_PROGRAM_TEST_OFFSET,
+			 M95P32_WRITE_TEST_SIZE);
+	if (rc < 0) {
+		printk("Standard-page-program region erase failed: %d\n", rc);
+		return rc;
+	}
+	rc = flash_erase(dev, M95P32_BUFFER_LOAD_TEST_OFFSET,
+			 M95P32_WRITE_TEST_SIZE);
+	if (rc < 0) {
+		printk("Buffer-load region erase failed: %d\n", rc);
+		return rc;
+	}
+
+	print_test_section("WRITE: Standard page program");
+	standard_start = k_cycle_get_32();
+	rc = flash_write(dev, M95P32_STANDARD_PAGE_PROGRAM_TEST_OFFSET, main_write_data,
+			 sizeof(main_write_data));
+	standard_cycles = k_cycle_get_32() - standard_start;
+	if (rc < 0) {
+		printk("Standard page program failed: %d\n", rc);
+		return rc;
+	}
+	rc = verify_main_array_write(dev, M95P32_STANDARD_PAGE_PROGRAM_TEST_OFFSET,
+				    "Standard page program");
+	if (rc < 0) {
+		return rc;
+	}
+
+	print_test_section("WRITE: Page program with buffer load");
+	buffer_load_start = k_cycle_get_32();
+	rc = page_program_with_buffer_load(dev, M95P32_BUFFER_LOAD_TEST_OFFSET,
+					   main_write_data, sizeof(main_write_data));
+	buffer_load_cycles = k_cycle_get_32() - buffer_load_start;
+	if (rc < 0) {
+		printk("Page program with buffer load failed: %d\n", rc);
+		return rc;
+	}
+	rc = verify_main_array_write(dev, M95P32_BUFFER_LOAD_TEST_OFFSET,
+				    "Page program with buffer load");
+	if (rc < 0) {
+		return rc;
+	}
+
+	/* Time only the write calls; verification reads are deliberately excluded. */
+	print_test_section("RESULT: Write performance");
+	standard_us = k_cyc_to_us_floor32(standard_cycles);
+	buffer_load_us = k_cyc_to_us_floor32(buffer_load_cycles);
+	speedup_x100 = (uint32_t)(((uint64_t)standard_us * 100U) / buffer_load_us);
+	time_saved_x10 = (uint32_t)(((uint64_t)(standard_us - buffer_load_us) * 1000U) /
+				    standard_us);
+	printk("Standard page program (%u bytes): %u cycles, %u.%06u s\n",
+		M95P32_WRITE_TEST_SIZE, standard_cycles, standard_us / USEC_PER_SEC,
+		standard_us % USEC_PER_SEC);
+	printk("Page program with buffer load (%u bytes): %u cycles, %u.%06u s\n",
+		M95P32_WRITE_TEST_SIZE, buffer_load_cycles,
+		buffer_load_us / USEC_PER_SEC, buffer_load_us % USEC_PER_SEC);
+	printk("Page-program-with-buffer-load speedup: %u.%02ux "
+		"(%u.%u%% less write time)\n", speedup_x100 / 100U,
+		speedup_x100 % 100U, time_saved_x10 / 10U, time_saved_x10 % 10U);
+
+	return 0;
+}
+
+int main(void)
+{
+	const struct device *flash_dev = DEVICE_DT_GET(DT_ALIAS(flash0));
+	int rc;
+
+	if (!device_is_ready(flash_dev)) {
+		printk("%s: device not ready\n", flash_dev->name);
+		return 1;
+	}
+
+	printk("M95P32 extended operation test\n");
+
+	rc = test_identification_page(flash_dev);
+	if (rc < 0) {
+		return 1;
+	}
+
+	rc = test_write_performance(flash_dev);
+	if (rc < 0) {
+		return 1;
+	}
+
+	printk("M95P32 extended operation test passed\n");
+	return 0;
+}

--- a/samples/shields/x_nucleo_pgeez1/tests.yaml
+++ b/samples/shields/x_nucleo_pgeez1/tests.yaml
@@ -1,0 +1,11 @@
+sample:
+  name: X-NUCLEO-PGEEZ1 M95P32 extended operations
+tests:
+  sample.shields.x_nucleo_pgeez1:
+    harness: shield
+    tags: shield
+    platform_allow:
+      - nucleo_u575zi_q
+    integration_platforms:
+      - nucleo_u575zi_q
+    extra_args: SHIELD=x_nucleo_pgeez1


### PR DESCRIPTION
## Summary

- Add the `st,m95p32` MSPI Devicetree binding.
- Add M95P32-specific Flash API extended operations:
  - Identification-page read and customer-page write.
  - Page program with buffer-load mode.
- Enable the extended operations for X-NUCLEO-PGEEZ1.
- Add an X-NUCLEO-PGEEZ1 sample that verifies the operations and benchmarks standard versus buffer-load programming.
