### PR TITLE
tests/bsim: Remove with tests.bsim prefix from identifiers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -645,8 +645,8 @@ Bluetooth Audio:
     - "area: Bluetooth"
   tests:
     - bluetooth.audio
+    - bluetooth.audio_samples
     - sample.bluetooth.audio
-    - tests.bsim.bluetooth.audio
 
 Bluetooth Classic:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -884,7 +884,7 @@ Bluetooth Qualification:
   tests:
     - bluetooth
     - bluetooth.general
-    - bluetooth.tester_bsim
+    - bluetooth.tester
 
 Board/SoC configuration:
   status: maintained

--- a/tests/bsim/bluetooth/audio/tests.yaml
+++ b/tests/bsim/bluetooth/audio/tests.yaml
@@ -16,7 +16,7 @@ tests:
   # chunks so they are at least parallelized at that level.
   # See #116077
 
-  tests.bsim.bluetooth.audio:
+  bluetooth.audio.bsim:
     extra_args:
       - EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
       - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE=""
@@ -27,20 +27,20 @@ tests:
       tests_scripts:
         - test_scripts/[!_]*.sh
 
-  tests.bsim.bluetooth.audio.audio_config.cap:
+  bluetooth.audio.bsim.audio_config.cap:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - test_scripts/audio_config_tests/cap*
     required_applications:
-      - application: tests.bsim.bluetooth.audio
+      - application: bluetooth.audio.bsim
 
-  tests.bsim.bluetooth.audio.audio_config.gmap:
+  bluetooth.audio.bsim.audio_config.gmap:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - test_scripts/audio_config_tests/gmap*
     required_applications:
-      - application: tests.bsim.bluetooth.audio
+      - application: bluetooth.audio.bsim

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  tests.bsim.bluetooth.audio_samples.bap_broadcast_sink:
+  bluetooth.audio_samples.bsim.bap_broadcast_sink:
     timeout: 600
     tags:
       - bluetooth

--- a/tests/bsim/bluetooth/audio_samples/bap_unicast_client/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/bap_unicast_client/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  tests.bsim.bluetooth.audio_samples.bap_unicast_client:
+  bluetooth.audio_samples.bsim.bap_unicast_client:
     tags:
       - bluetooth
     depends_on: bsim

--- a/tests/bsim/bluetooth/audio_samples/cap/acceptor/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/cap/acceptor/tests.yaml
@@ -16,13 +16,13 @@ common:
     # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
 
 tests:
-  tests.bsim.bluetooth.audio_samples.cap.acceptor.broadcast:
+  bluetooth.audio_samples.bsim.cap.acceptor.broadcast:
     extra_configs:
       - CONFIG_SAMPLE_UNICAST=n
       - CONFIG_SAMPLE_SCAN_SELF=y
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_acceptor_broadcast_prj_conf
 
-  tests.bsim.bluetooth.audio_samples.cap.acceptor.unicast:
+  bluetooth.audio_samples.bsim.cap.acceptor.unicast:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_acceptor_unicast_prj_conf

--- a/tests/bsim/bluetooth/audio_samples/cap/initiator/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/cap/initiator/tests.yaml
@@ -16,12 +16,12 @@ common:
     # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
 
 tests:
-  tests.bsim.bluetooth.audio_samples.cap.initiator.broadcast:
+  bluetooth.audio_samples.bsim.cap.initiator.broadcast:
     extra_configs:
       - CONFIG_SAMPLE_UNICAST=n
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_initiator_broadcast_prj_conf
 
-  tests.bsim.bluetooth.audio_samples.cap.initiator.unicast:
+  bluetooth.audio_samples.bsim.cap.initiator.unicast:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_initiator_unicast_prj_conf

--- a/tests/bsim/bluetooth/audio_samples/cap/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/cap/tests.yaml
@@ -10,24 +10,24 @@ common:
   build: false
 
 tests:
-  tests.bsim.bluetooth.audio_samples.cap.broadcast:
+  bluetooth.audio_samples.bsim.cap.broadcast:
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/cap_broadcast.sh
     required_applications:
-      - application: tests.bsim.bluetooth.audio_samples.cap.initiator.broadcast
+      - application: bluetooth.audio_samples.bsim.cap.initiator.broadcast
         path: initiator
-      - application: tests.bsim.bluetooth.audio_samples.cap.acceptor.broadcast
+      - application: bluetooth.audio_samples.bsim.cap.acceptor.broadcast
         path: acceptor
 
-  tests.bsim.bluetooth.audio_samples.cap.unicast:
+  bluetooth.audio_samples.bsim.cap.unicast:
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/cap_unicast.sh
     required_applications:
-      - application: tests.bsim.bluetooth.audio_samples.cap.initiator.unicast
+      - application: bluetooth.audio_samples.bsim.cap.initiator.unicast
         path: initiator
-      - application: tests.bsim.bluetooth.audio_samples.cap.acceptor.unicast
+      - application: bluetooth.audio_samples.bsim.cap.acceptor.unicast
         path: acceptor

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  tests.bsim.bluetooth.audio_samples.ccp.client:
+  bluetooth.audio_samples.bsim.ccp.client:
     tags:
       - bluetooth
     depends_on: bsim

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  tests.bsim.bluetooth.audio_samples.ccp.server:
+  bluetooth.audio_samples.bsim.ccp.server:
     tags:
       - bluetooth
     depends_on: bsim

--- a/tests/bsim/bluetooth/audio_samples/ccp/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/ccp/tests.yaml
@@ -10,11 +10,11 @@ common:
   build: false
 
 tests:
-  tests.bsim.bluetooth.audio_samples.ccp:
+  bluetooth.audio_samples.bsim.ccp:
     harness_config:
       fixture: bsim_multi_test
     required_applications:
-      - application: tests.bsim.bluetooth.audio_samples.ccp.client
+      - application: bluetooth.audio_samples.bsim.ccp.client
         path: call_control_client
-      - application: tests.bsim.bluetooth.audio_samples.ccp.server
+      - application: bluetooth.audio_samples.bsim.ccp.server
         path: call_control_server

--- a/tests/bsim/bluetooth/hci_uart/tests.yaml
+++ b/tests/bsim/bluetooth/hci_uart/tests.yaml
@@ -5,7 +5,7 @@ common:
   harness: bsim
 
 tests:
-  tests.bsim.bluetooth.hci_uart:
+  bluetooth.hci_uart:
     platform_allow:
       - nrf52_bsim
     build: false
@@ -16,7 +16,7 @@ tests:
         path: $ZEPHYR_BASE/samples/bluetooth/hci_uart
       - application: sample.bluetooth.hci_uart_async.bsim
         path: $ZEPHYR_BASE/samples/bluetooth/hci_uart_async
-      - application: tests.bsim.bluetooth.ll.conn.split_hci_uart
+      - application: bluetooth.controller.conn.split_hci_uart
         path: $ZEPHYR_BASE/tests/bsim/bluetooth/ll/conn/
-      - application: tests.bsim.bluetooth.ll.conn.split_hci_uart.psa
+      - application: bluetooth.controller.conn.split_hci_uart.psa
         path: $ZEPHYR_BASE/tests/bsim/bluetooth/ll/conn/

--- a/tests/bsim/bluetooth/ll/advx/tests.yaml
+++ b/tests/bsim/bluetooth/ll/advx/tests.yaml
@@ -8,14 +8,14 @@ common:
     - nrf54l15bsim/nrf54l15/cpuapp
   harness: bsim
 tests:
-  bluetooth.ll.advx:
+  bluetooth.controller.advx:
     harness_config:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_advx_prj_conf
       tests_scripts:
         - tests_scripts/basic_advx.sh
 
-  bluetooth.ll.advx.ticker_expire_info:
+  bluetooth.controller.advx.ticker_expire_info:
     extra_overlay_confs:
       - overlay-ticker_expire_info.conf
     harness_config:
@@ -24,7 +24,7 @@ tests:
       tests_scripts:
         - tests_scripts/basic_advx_ticker_expire_info.sh
 
-  bluetooth.ll.advx.scan_aux_use_chains:
+  bluetooth.controller.advx.scan_aux_use_chains:
     extra_overlay_confs:
       - overlay-scan_aux_use_chains.conf
     harness_config:

--- a/tests/bsim/bluetooth/ll/bis/tests.yaml
+++ b/tests/bsim/bluetooth/ll/bis/tests.yaml
@@ -6,7 +6,7 @@ common:
   harness: bsim
 
 tests:
-  bluetooth.ll.bis.sequential:
+  bluetooth.controller.bis.sequential:
     sysbuild: true
     platform_allow:
       - nrf52_bsim/native
@@ -21,7 +21,7 @@ tests:
       tests_scripts:
         - tests_scripts/broadcast_iso_sequential.sh
 
-  bluetooth.ll.bis.interleaved:
+  bluetooth.controller.bis.interleaved:
     sysbuild: true
     platform_allow:
       - nrf52_bsim/native
@@ -36,7 +36,7 @@ tests:
       tests_scripts:
         - tests_scripts/broadcast_iso_interleaved.sh
 
-  bluetooth.ll.bis.ll_interface:
+  bluetooth.controller.bis.ll_interface:
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
@@ -48,7 +48,7 @@ tests:
       tests_scripts:
         - tests_scripts/broadcast_iso_ll_interface.sh
 
-  bluetooth.ll.bis.ticker_expire_info:
+  bluetooth.controller.bis.ticker_expire_info:
     sysbuild: true
     platform_allow:
       - nrf52_bsim/native
@@ -63,7 +63,7 @@ tests:
       tests_scripts:
         - tests_scripts/broadcast_iso_ticker_expire_info.sh
 
-  bluetooth.ll.bis.scan_aux_use_chains:
+  bluetooth.controller.bis.scan_aux_use_chains:
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
@@ -75,7 +75,7 @@ tests:
       tests_scripts:
         - tests_scripts/broadcast_iso_scan_aux_use_chains.sh
 
-  bluetooth.ll.bis.vs_dp:
+  bluetooth.controller.bis.vs_dp:
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
@@ -87,9 +87,9 @@ tests:
       tests_scripts:
         - tests_scripts/broadcast_iso_vs_dp.sh
     required_applications:
-      - application: bluetooth.ll.bis.sequential
+      - application: bluetooth.controller.bis.sequential
 
-  bluetooth.ll.bis.past:
+  bluetooth.controller.bis.past:
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet

--- a/tests/bsim/bluetooth/ll/cis/tests.yaml
+++ b/tests/bsim/bluetooth/ll/cis/tests.yaml
@@ -9,7 +9,7 @@ common:
     - nrf5340bsim/nrf5340/cpunet
 
 tests:
-  bluetooth.ll.cis:
+  bluetooth.controller.cis:
     extra_overlay_confs:
       - overlay.conf
     harness_config:
@@ -18,7 +18,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso.sh
 
-  bluetooth.ll.cis.acl_first:
+  bluetooth.controller.cis.acl_first:
     extra_overlay_confs:
       - overlay-acl_first.conf
     harness_config:
@@ -27,7 +27,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_acl_first.sh
 
-  bluetooth.ll.cis.legacy_adv:
+  bluetooth.controller.cis.legacy_adv:
     extra_overlay_confs:
       - overlay-legacy_adv.conf
     harness_config:
@@ -36,7 +36,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_legacy_adv.sh
 
-  bluetooth.ll.cis.legacy_adv_acl_first:
+  bluetooth.controller.cis.legacy_adv_acl_first:
     extra_overlay_confs:
       - overlay-legacy_adv_acl_first.conf
     harness_config:
@@ -45,7 +45,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_legacy_adv_acl_first.sh
 
-  bluetooth.ll.cis.acl_group:
+  bluetooth.controller.cis.acl_group:
     sysbuild: true
     platform_allow:
       - nrf52_bsim/native
@@ -59,7 +59,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_acl_group.sh
 
-  bluetooth.ll.cis.acl_group_acl_first:
+  bluetooth.controller.cis.acl_group_acl_first:
     extra_overlay_confs:
       - overlay-acl_group_acl_first.conf
     harness_config:
@@ -68,7 +68,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_acl_group_acl_first.sh
 
-  bluetooth.ll.cis.peripheral_cis:
+  bluetooth.controller.cis.peripheral_cis:
     extra_overlay_confs:
       - overlay-peripheral_cis.conf
     harness_config:
@@ -77,7 +77,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_peripheral_cis.sh
 
-  bluetooth.ll.cis.acl_first_ft_per_skip_2_se:
+  bluetooth.controller.cis.acl_first_ft_per_skip_2_se:
     extra_overlay_confs:
       - overlay-acl_first_ft_per_skip_2_se.conf
     harness_config:
@@ -86,7 +86,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_acl_first_ft_per_skip_2_se.sh
 
-  bluetooth.ll.cis.acl_first_ft_per_skip_4_se:
+  bluetooth.controller.cis.acl_first_ft_per_skip_4_se:
     extra_overlay_confs:
       - overlay-acl_first_ft_per_skip_4_se.conf
     harness_config:
@@ -95,7 +95,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_acl_first_ft_per_skip_4_se.sh
 
-  bluetooth.ll.cis.acl_first_ft_cen_skip_2_se:
+  bluetooth.controller.cis.acl_first_ft_cen_skip_2_se:
     extra_overlay_confs:
       - overlay-acl_first_ft_cen_skip_2_se.conf
     harness_config:
@@ -104,7 +104,7 @@ tests:
       tests_scripts:
         - tests_scripts/connected_iso_acl_first_ft_cen_skip_2_se.sh
 
-  bluetooth.ll.cis.acl_first_ft_cen_skip_4_se:
+  bluetooth.controller.cis.acl_first_ft_cen_skip_4_se:
     extra_overlay_confs:
       - overlay-acl_first_ft_cen_skip_4_se.conf
     harness_config:

--- a/tests/bsim/bluetooth/ll/conn/tests.yaml
+++ b/tests/bsim/bluetooth/ll/conn/tests.yaml
@@ -5,7 +5,7 @@ common:
   harness: bsim
 
 tests:
-  tests.bsim.bluetooth.ll.conn.split:
+  bluetooth.controller.conn.split:
     platform_allow:
       - nrf52_bsim
       - nrf54l15bsim/nrf54l15/cpuapp
@@ -18,7 +18,7 @@ tests:
         - tests_scripts/basic_conn20_split.sh
         - tests_scripts/basic_conn_encrypted_split.sh
 
-  tests.bsim.bluetooth.ll.conn.split_1ms:
+  bluetooth.controller.conn.split_1ms:
     platform_allow:
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpunet
@@ -29,7 +29,7 @@ tests:
       tests_scripts:
         - tests_scripts/basic_conn_split_1ms.sh
 
-  tests.bsim.bluetooth.ll.conn.split_tx_defer:
+  bluetooth.controller.conn.split_tx_defer:
     platform_allow:
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpunet
@@ -40,7 +40,7 @@ tests:
       tests_scripts:
         - tests_scripts/basic_conn_split_tx_defer.sh
 
-  tests.bsim.bluetooth.ll.conn.split_privacy:
+  bluetooth.controller.conn.split_privacy:
     sysbuild: true
     platform_allow:
       - nrf52_bsim
@@ -53,7 +53,7 @@ tests:
       tests_scripts:
         - tests_scripts/basic_conn_encrypted_split_privacy.sh
 
-  tests.bsim.bluetooth.ll.conn.split_low_lat:
+  bluetooth.controller.conn.split_low_lat:
     platform_allow:
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpunet
@@ -64,7 +64,7 @@ tests:
       tests_scripts:
         - tests_scripts/basic_conn_split_low_lat.sh
 
-  tests.bsim.bluetooth.ll.conn.split_single_timer:
+  bluetooth.controller.conn.split_single_timer:
     platform_allow:
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpunet
@@ -75,7 +75,7 @@ tests:
       tests_scripts:
         - tests_scripts/basic_conn_encrypted_split_single_timer.sh
 
-  tests.bsim.bluetooth.ll.conn.split_hci_uart:
+  bluetooth.controller.conn.split_hci_uart:
     platform_allow:
       - nrf52_bsim
     build_only: true
@@ -85,7 +85,7 @@ tests:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_hci_uart_conf
 
-  tests.bsim.bluetooth.ll.conn.split_hci_uart.psa:
+  bluetooth.controller.conn.split_hci_uart.psa:
     platform_allow:
       - nrf52_bsim
     build_only: true

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/tests.yaml
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/tests.yaml
@@ -9,7 +9,7 @@ common:
     - nrf54l15bsim/nrf54l15/cpuapp
   harness: bsim
 tests:
-  bluetooth.ll.edtt.gatt_test_app:
+  bluetooth.controller.edtt.gatt_test_app:
     harness_config:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_edtt_gatt_test_app_prj_llcp_conf
@@ -18,5 +18,5 @@ tests:
     extra_args:
       CONF_FILE=prj_llcp.conf
     required_applications:
-      - application: bluetooth.ll.edtt.hci_test_app.dut
+      - application: bluetooth.controller.edtt.hci_test_app.dut
         path: ../hci_test_app

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/tests.yaml
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/tests.yaml
@@ -9,14 +9,14 @@ common:
     - nrf54l15bsim/nrf54l15/cpuapp
   harness: bsim
 tests:
-  bluetooth.ll.edtt.hci_test_app.dut:
+  bluetooth.controller.edtt.hci_test_app.dut:
     build_only: true
     harness_config:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_edtt_hci_test_app_prj_dut_llcp_conf
     extra_args:
       CONF_FILE=prj_dut_llcp.conf
-  bluetooth.ll.edtt.hci_test_app.tst:
+  bluetooth.controller.edtt.hci_test_app.tst:
     harness_config:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_edtt_hci_test_app_prj_tst_llcp_conf
@@ -28,4 +28,4 @@ tests:
     extra_args:
       CONF_FILE=prj_tst_llcp.conf
     required_applications:
-      - application: bluetooth.ll.edtt.hci_test_app.dut
+      - application: bluetooth.controller.edtt.hci_test_app.dut

--- a/tests/bsim/bluetooth/ll/multiple_id/tests.yaml
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests.yaml
@@ -6,7 +6,7 @@ common:
   harness: bsim
 
 tests:
-  tests.bsim.bluetooth.ll.multiple_id:
+  bluetooth.controller.multiple_id:
     sysbuild: true
     platform_allow:
       - nrf52_bsim

--- a/tests/bsim/bluetooth/ll/throughput/tests.yaml
+++ b/tests/bsim/bluetooth/ll/throughput/tests.yaml
@@ -12,14 +12,14 @@ common:
     - nrf54l15bsim/nrf54l15/cpuapp
 
 tests:
-  tests.bsim.bluetooth.ll.throughput:
+  bluetooth.controller.throughput:
     harness_config:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_throughput_prj_conf
       tests_scripts:
         - tests_scripts/gatt_write.sh
 
-  tests.bsim.bluetooth.ll.throughput_no_phy_update:
+  bluetooth.controller.throughput_no_phy_update:
     extra_overlay_confs:
       - overlay-no_phy_update.conf
     harness_config:

--- a/tests/bsim/bluetooth/mesh/tests.yaml
+++ b/tests/bsim/bluetooth/mesh/tests.yaml
@@ -11,13 +11,13 @@ tests:
   ###########################
   # Images reused by tests: #
   ###########################
-  tests.bsim.bluetooth.mesh.image:
+  bluetooth.mesh.bsim.image:
     build_only: true
     harness_config:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf
 
-  tests.bsim.bluetooth.mesh.image.pst:
+  bluetooth.mesh.bsim.image.pst:
     build_only: true
     extra_overlay_confs:
       - overlay_pst.conf
@@ -25,7 +25,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_pst_conf
 
-  tests.bsim.bluetooth.mesh.image.gatt:
+  bluetooth.mesh.bsim.image.gatt:
     build_only: true
     extra_overlay_confs:
       - overlay_gatt.conf
@@ -33,7 +33,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf
 
-  tests.bsim.bluetooth.mesh.image.gatt_separate:
+  bluetooth.mesh.bsim.image.gatt_separate:
     build_only: true
     extra_overlay_confs:
       - overlay_gatt_separate.conf
@@ -41,7 +41,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_separate_conf
 
-  tests.bsim.bluetooth.mesh.image.low_lat:
+  bluetooth.mesh.bsim.image.low_lat:
     build_only: true
     extra_overlay_confs:
       - overlay_low_lat.conf
@@ -49,7 +49,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_low_lat_conf
 
-  tests.bsim.bluetooth.mesh.image.workq_sys:
+  bluetooth.mesh.bsim.image.workq_sys:
     build_only: true
     extra_overlay_confs:
       - overlay_workq_sys.conf
@@ -57,7 +57,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_workq_sys_conf
 
-  tests.bsim.bluetooth.mesh.image.multi_adv_sets:
+  bluetooth.mesh.bsim.image.multi_adv_sets:
     build_only: true
     extra_overlay_confs:
       - overlay_multi_adv_sets.conf
@@ -65,7 +65,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_multi_adv_sets_conf
 
-  tests.bsim.bluetooth.mesh.image.lpn_scan_on:
+  bluetooth.mesh.bsim.image.lpn_scan_on:
     build_only: true
     extra_overlay_confs:
       - overlay_lpn_scan_on.conf
@@ -73,7 +73,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_lpn_scan_on_conf
 
-  tests.bsim.bluetooth.mesh.image.gatt_workq_sys:
+  bluetooth.mesh.bsim.image.gatt_workq_sys:
     build_only: true
     extra_overlay_confs:
       - overlay_gatt.conf
@@ -82,7 +82,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf_overlay_workq_sys_conf
 
-  tests.bsim.bluetooth.mesh.image.gatt_low_lat:
+  bluetooth.mesh.bsim.image.gatt_low_lat:
     build_only: true
     extra_overlay_confs:
       - overlay_gatt.conf
@@ -91,7 +91,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf_overlay_low_lat_conf
 
-  tests.bsim.bluetooth.mesh.image.pst_gatt:
+  bluetooth.mesh.bsim.image.pst_gatt:
     build_only: true
     extra_overlay_confs:
       - overlay_pst.conf
@@ -100,7 +100,7 @@ tests:
       fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_pst_conf_overlay_gatt_conf
 
-  tests.bsim.bluetooth.mesh.image.gatt_multi_adv_sets:
+  bluetooth.mesh.bsim.image.gatt_multi_adv_sets:
     build_only: true
     extra_overlay_confs:
       - overlay_gatt.conf
@@ -110,7 +110,7 @@ tests:
       bsim_exe_name: >-
         tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf_overlay_multi_adv_sets_conf
 
-  tests.bsim.bluetooth.mesh.image.pst_gatt_workq_sys:
+  bluetooth.mesh.bsim.image.pst_gatt_workq_sys:
     build_only: true
     extra_overlay_confs:
       - overlay_pst.conf
@@ -125,221 +125,221 @@ tests:
   # Actual tests: #
   #################
 
-  tests.bsim.bluetooth.mesh.access:
+  bluetooth.mesh.bsim.access:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/access
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.advertiser:
+  bluetooth.mesh.bsim.advertiser:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/advertiser
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.gatt
-      - application: tests.bsim.bluetooth.mesh.image.gatt_multi_adv_sets
-      - application: tests.bsim.bluetooth.mesh.image.gatt_separate
-      - application: tests.bsim.bluetooth.mesh.image.gatt_workq_sys
-      - application: tests.bsim.bluetooth.mesh.image.low_lat
-      - application: tests.bsim.bluetooth.mesh.image.multi_adv_sets
-      - application: tests.bsim.bluetooth.mesh.image.workq_sys
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.gatt
+      - application: bluetooth.mesh.bsim.image.gatt_multi_adv_sets
+      - application: bluetooth.mesh.bsim.image.gatt_separate
+      - application: bluetooth.mesh.bsim.image.gatt_workq_sys
+      - application: bluetooth.mesh.bsim.image.low_lat
+      - application: bluetooth.mesh.bsim.image.multi_adv_sets
+      - application: bluetooth.mesh.bsim.image.workq_sys
 
-  tests.bsim.bluetooth.mesh.beacon:
+  bluetooth.mesh.bsim.beacon:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/beacon
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.blob_mdls:
+  bluetooth.mesh.bsim.blob_mdls:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/blob_mdls
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.bridge:
+  bluetooth.mesh.bsim.bridge:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/bridge
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.cdb:
+  bluetooth.mesh.bsim.cdb:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/cdb
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.comp_data:
+  bluetooth.mesh.bsim.comp_data:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/comp_data
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.dfu:
+  bluetooth.mesh.bsim.dfu:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/dfu
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.friendship:
+  bluetooth.mesh.bsim.friendship:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/friendship
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.low_lat
-      - application: tests.bsim.bluetooth.mesh.image.lpn_scan_on
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.low_lat
+      - application: bluetooth.mesh.bsim.image.lpn_scan_on
 
-  tests.bsim.bluetooth.mesh.heartbeat:
+  bluetooth.mesh.bsim.heartbeat:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/heartbeat
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.iv_index:
+  bluetooth.mesh.bsim.iv_index:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/iv_index
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.large_comp_data:
+  bluetooth.mesh.bsim.large_comp_data:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/large_comp_data
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.op_agg:
+  bluetooth.mesh.bsim.op_agg:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/op_agg
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.persistence:
+  bluetooth.mesh.bsim.persistence:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/persistence
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.priv_beacon:
+  bluetooth.mesh.bsim.priv_beacon:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/priv_beacon
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.gatt
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.gatt
 
-  tests.bsim.bluetooth.mesh.provision:
+  bluetooth.mesh.bsim.provision:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/provision
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.gatt
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.gatt
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.proxy_sol:
+  bluetooth.mesh.bsim.proxy_sol:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/proxy_sol
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image.pst_gatt
-      - application: tests.bsim.bluetooth.mesh.image.pst_gatt_workq_sys
+      - application: bluetooth.mesh.bsim.image.pst_gatt
+      - application: bluetooth.mesh.bsim.image.pst_gatt_workq_sys
 
-  tests.bsim.bluetooth.mesh.replay_cache:
+  bluetooth.mesh.bsim.replay_cache:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/replay_cache
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.sar:
+  bluetooth.mesh.bsim.sar:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/sar
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.pst
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.pst
 
-  tests.bsim.bluetooth.mesh.scanner:
+  bluetooth.mesh.bsim.scanner:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/scanner
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
+      - application: bluetooth.mesh.bsim.image
 
-  tests.bsim.bluetooth.mesh.suspend:
+  bluetooth.mesh.bsim.suspend:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/suspend
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.gatt
-      - application: tests.bsim.bluetooth.mesh.image.gatt_low_lat
-      - application: tests.bsim.bluetooth.mesh.image.low_lat
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.gatt
+      - application: bluetooth.mesh.bsim.image.gatt_low_lat
+      - application: bluetooth.mesh.bsim.image.low_lat
 
-  tests.bsim.bluetooth.mesh.transport:
+  bluetooth.mesh.bsim.transport:
     build: false
     harness_config:
       fixture: bsim_multi_test
       tests_scripts:
         - tests_scripts/transport
     required_applications:
-      - application: tests.bsim.bluetooth.mesh.image
-      - application: tests.bsim.bluetooth.mesh.image.low_lat
+      - application: bluetooth.mesh.bsim.image
+      - application: bluetooth.mesh.bsim.image.low_lat

--- a/tests/bsim/bluetooth/samples/battery_service/tests.yaml
+++ b/tests/bsim/bluetooth/samples/battery_service/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  tests.bsim.bluetooth.samples.battery_service:
+  bluetooth.samples.battery_service:
     tags:
       - bluetooth
     depends_on: bsim

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests.yaml
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests.yaml
@@ -10,7 +10,7 @@ common:
     - nrf54l15bsim/nrf54l15/cpuapp
 
 tests:
-  tests.bsim.bluetooth.samples.central_hr_peripheral_hr:
+  bluetooth.samples.central_hr_peripheral_hr:
     extra_conf_files:
       - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
     harness_config:
@@ -22,7 +22,7 @@ tests:
       - application: sample.bluetooth.peripheral_hr.bsim
         path: $ZEPHYR_BASE/samples/bluetooth/peripheral_hr
 
-  tests.bsim.bluetooth.samples.central_hr_peripheral_hr.extended:
+  bluetooth.samples.central_hr_peripheral_hr.extended:
     extra_conf_files:
       - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
     extra_overlay_confs:
@@ -37,7 +37,7 @@ tests:
       - application: sample.bluetooth.peripheral_hr.extended.bsim
         path: $ZEPHYR_BASE/samples/bluetooth/peripheral_hr
 
-  tests.bsim.bluetooth.samples.central_hr_peripheral_hr.phy_coded:
+  bluetooth.samples.central_hr_peripheral_hr.phy_coded:
     extra_conf_files:
       - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
     extra_overlay_confs:
@@ -52,7 +52,7 @@ tests:
       - application: sample.bluetooth.peripheral_hr.phy_coded.bsim
         path: $ZEPHYR_BASE/samples/bluetooth/peripheral_hr
 
-  tests.bsim.bluetooth.samples.central_hr_peripheral_hr.static_callbacks:
+  bluetooth.samples.central_hr_peripheral_hr.static_callbacks:
     extra_conf_files:
       - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
     extra_overlay_confs:

--- a/tests/bsim/bluetooth/samples/peripheral_gap_svc/tests.yaml
+++ b/tests/bsim/bluetooth/samples/peripheral_gap_svc/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  tests.bsim.bluetooth.samples.peripheral_gap_svc:
+  bluetooth.samples.peripheral_gap_svc:
     tags:
       - bluetooth
     depends_on: bsim

--- a/tests/bsim/bluetooth/tester/tests.yaml
+++ b/tests/bsim/bluetooth/tester/tests.yaml
@@ -5,14 +5,14 @@ common:
   depends_on: bsim
 
 tests:
-  bluetooth.tests.bsim.tester.image:
+  bluetooth.tester.image:
     build_only: true
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_tester_prj_conf
     platform_allow:
       - nrf52_bsim/native
 
-  bluetooth.tests.bsim.tester:
+  bluetooth.tester:
     timeout: 1200
     build: false
     platform_allow:
@@ -25,7 +25,7 @@ tests:
         path: ${ZEPHYR_BASE}/tests/bluetooth/tester/
       - application: bluetooth.audio.tester_bsim
         path: ${ZEPHYR_BASE}/tests/bluetooth/tester/
-      - application: bluetooth.tests.bsim.tester.image
+      - application: bluetooth.tester.image
         platform: nrf52_bsim/native
         # We only want to build the tests/bsim/bluetooth/tester/ application for the
         # nrf52_bsim/native board as we do not gain anything from running this application for the

--- a/tests/bsim/drivers/gpio/file_backend/tests.yaml
+++ b/tests/bsim/drivers/gpio/file_backend/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  bsim.drivers.gpio.file_backend:
+  drivers.gpio.file_backend:
     tags:
       - drivers
       - gpio


### PR DESCRIPTION
Until now, some of these tests were prefixed with tests.bsim and some were not.
Let's be consistent and remove the tests.bsim. prefix from all as agree both in here and in [discord](https://discord.com/channels/720317445772017664/1072528982278414448/1545018052305887273)

    * Rename all `bluetooth.ll. to `bluetooth.controller.` (maintainer's wish)
    * All tests identifiers starting with tests.bsim. got that prefix removed
      (if they would collide with something else twister will warn us right
      away)

This is just a "trivial" change only affecting the twister test identifiers. These twister tests definitions were added a couple of weeks ago.

Note that I ended up not adding a .bsim suffix to avoid name conflicts wholesale, as twister would anyhow error out if there is such an identifier conflict.

This is just a plain search and replace, with no magic. You don't need to cross check each line. If twister does not error out due to duplicates we are fine.

You can get all identifiers by running `twister -T tests/bsim/bluetooh/ll --list-tests`