### PR TITLE
drivers: i2c: mchp: sercom g1: Add I2C support for PIC32CM SG/GC family

### DIFF
--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro-pinctrl.dtsi
@@ -13,4 +13,11 @@
 				 <PD19D_SERCOM4_PAD0>;
 		};
 	};
+
+	sercom1_i2c_default: sercom1_i2c_default {
+		group1 {
+			pinmux = <PD1D_SERCOM1_PAD0>,  /* SDA */
+				 <PD0D_SERCOM1_PAD1>;  /* SCL */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <microchip/pic32c/pic32cm_sg_gc/pic32cm_gc00/pic32cm5112gc00100.dtsi>
 #include "pic32cm_gc00_cpro-pinctrl.dtsi"
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -206,5 +207,17 @@
 };
 
 &dmac {
+	status = "okay";
+};
+
+i2c0: &sercom1 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom1_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 2 6>, <&dmac 3 7>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/pic32cm_gc00_cpro.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - dma
   - gpio
+  - i2c
   - pinctrl
   - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro-pinctrl.dtsi
@@ -13,4 +13,11 @@
 				 <PD19D_SERCOM4_PAD0>;
 		};
 	};
+
+	sercom1_i2c_default: sercom1_i2c_default {
+		group1 {
+			pinmux = <PD1D_SERCOM1_PAD0>,  /* SDA */
+				 <PD0D_SERCOM1_PAD1>;  /* SCL */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <microchip/pic32c/pic32cm_sg_gc/pic32cm_sg00/pic32cm5112sg00100.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "pic32cm_sg00_cpro-pinctrl.dtsi"
 
 / {
@@ -206,5 +207,17 @@
 };
 
 &dmac {
+	status = "okay";
+};
+
+i2c0: &sercom1 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom1_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 2 6>, <&dmac 3 7>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/pic32cm_sg00_cpro.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - dma
   - gpio
+  - i2c
   - pinctrl
   - uart
 vendor: microchip

--- a/dts/bindings/i2c/microchip,sercom-g1-i2c.yaml
+++ b/dts/bindings/i2c/microchip,sercom-g1-i2c.yaml
@@ -9,7 +9,7 @@ description: |
   Group g1 SERCOM I2C driver supports following hardware peripherals:
     - module name="SERCOM"
           id="U2201" version="3.1.1","5.0.0"
-          id="03715" name2="com_sercom_u2201_v6" version="6b0"
+          id="03715" name2="com_sercom_u2201_v6" version="6b0","6c0"
 
 compatible: "microchip,sercom-g1-i2c"
 

--- a/tests/drivers/i2c/i2c_target_api/boards/pic32cm_gc00_cpro.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/pic32cm_gc00_cpro.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect EXT1 (J400): Pin 11 (PD1) to Pin 5 (PC0) SDA, Pin 12 (PD0) to Pin 6 (PC1) SCL */
+
+&pinctrl {
+	sercom0_i2c_default: sercom0_i2c_default {
+		group1 {
+			pinmux = <PC0D_SERCOM0_PAD0>,  /* SDA */
+				 <PC1D_SERCOM0_PAD1>;  /* SCL */
+		};
+	};
+};
+
+&sercom0 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom0_i2c_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+/* sercom1 already defined in board DTS as i2c0 */
+&i2c0 {
+	eeprom1: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/pic32cm_sg00_cpro.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/pic32cm_sg00_cpro.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect EXT1 (J400): Pin 11 (PD1) to Pin 5 (PC0) SDA, Pin 12 (PD0) to Pin 6 (PC1) SCL */
+
+&pinctrl {
+	sercom0_i2c_default: sercom0_i2c_default {
+		group1 {
+			pinmux = <PC0D_SERCOM0_PAD0>,  /* SDA */
+				 <PC1D_SERCOM0_PAD1>;  /* SCL */
+		};
+	};
+};
+
+&sercom0 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom0_i2c_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+/* sercom1 already defined in board DTS as i2c0 */
+&i2c0 {
+	eeprom1: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -87,6 +87,7 @@ tests:
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
       - pic32cm_jh01_cpro
+      - pic32cm_sg00_cpro
       - pic32cx_sg41_cult
       - pic32cz_ca80_cult
       - sam_e54_xpro


### PR DESCRIPTION
This PR includes:

- Add I2C driver support for PIC32CM SG00 and GC00 Curiosity Pro boards.
- Add pic32cm_sg_gc version to sercom-g1-i2c binding yaml
- Add board overlays for i2c_target_api test