### PR TITLE
Bluetooth: Audio: Fix bad checks for bt_audio_codec_cfg_get_frame_dur

### DIFF
--- a/samples/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -276,10 +276,10 @@ static void init_lc3_thread(void *arg1, void *arg2, void *arg3)
 	}
 
 	ret = bt_audio_codec_cfg_get_frame_dur(codec_cfg);
-	if (ret > 0) {
+	if (ret >= 0) {
 		frame_duration_us = bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret);
 	} else {
-		printk("Error: Frame duration not set, cannot start codec.");
+		printk("Error: Frame duration not set, cannot start codec: %d", ret);
 		return;
 	}
 

--- a/samples/bluetooth/audio/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/audio/bap_unicast_server/src/main.c
@@ -144,7 +144,7 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		}
 
 		ret = bt_audio_codec_cfg_get_frame_dur(codec_cfg);
-		if (ret > 0) {
+		if (ret >= 0) {
 			printk("  Frame Duration: %d us\n",
 			       bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}
@@ -304,10 +304,10 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 		}
 
 		ret = bt_audio_codec_cfg_get_frame_dur(stream->codec_cfg);
-		if (ret > 0) {
+		if (ret >= 0) {
 			frame_duration_us = bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret);
 		} else {
-			printk("Error: Frame duration not set, cannot start codec.");
+			printk("Error: Frame duration not set, cannot start codec: %d", ret);
 			*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_CONF_INVALID,
 					       BT_BAP_ASCS_REASON_CODEC_DATA);
 			return ret;

--- a/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_unicast.c
+++ b/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_unicast.c
@@ -78,7 +78,7 @@ static void log_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		}
 
 		ret = bt_audio_codec_cfg_get_frame_dur(codec_cfg);
-		if (ret > 0) {
+		if (ret >= 0) {
 			LOG_INF("\tFrame Duration: %d us",
 				bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}

--- a/samples/bluetooth/audio/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/audio/hap_ha/src/bap_unicast_sr.c
@@ -110,7 +110,7 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		}
 
 		ret = bt_audio_codec_cfg_get_frame_dur(codec_cfg);
-		if (ret > 0) {
+		if (ret >= 0) {
 			printk("  Frame Duration: %d us\n",
 			       bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}

--- a/samples/bluetooth/audio/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/audio/tmap_peripheral/src/bap_unicast_sr.c
@@ -96,7 +96,7 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		}
 
 		ret = bt_audio_codec_cfg_get_frame_dur(codec_cfg);
-		if (ret > 0) {
+		if (ret >= 0) {
 			printk("  Frame Duration: %d us\n",
 			       bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -93,7 +93,7 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		}
 
 		ret = bt_audio_codec_cfg_get_frame_dur(codec_cfg);
-		if (ret > 0) {
+		if (ret >= 0) {
 			LOG_DBG("  Frame Duration: %d us",
 				bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}


### PR DESCRIPTION
Several checks did not account for bt_audio_codec_cfg_get_frame_dur returning 0 being valid.
    