### PR TITLE
net: socket: service: register individual sockets to user_data

### DIFF
--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -162,10 +162,25 @@ struct net_socket_service_desc {
  *
  * @retval 0 No error
  * @retval -ENOENT Service is not found.
- * @retval -EINVAL Invalid parameter.
+ * @retval -EIO Service thread not running.
+ * @retval -ENOMEM Out of memory.
  */
 __syscall int net_socket_service_register(const struct net_socket_service_desc *service,
 					  struct zsock_pollfd *fds, int len, void *user_data);
+
+/**
+ * @brief Deregister individual pollable socket.
+ *
+ * @param service Pointer to a service description.
+ * @param fd Socket to be deregister.
+ *
+ * @retval 0 No error
+ * @retval -ENOENT Service is not found.
+ * @retval -EIO Service thread not running.
+ * @retval -ENOMEM Out of memory.
+ */
+__syscall int net_socket_service_deregister(const struct net_socket_service_desc *service,
+					    int fd);
 
 /**
  * @brief Unregister pollable sockets.
@@ -174,7 +189,7 @@ __syscall int net_socket_service_register(const struct net_socket_service_desc *
  *
  * @retval 0 No error
  * @retval -ENOENT Service is not found.
- * @retval -EINVAL Invalid parameter.
+ * @retval -EIO Service thread not running.
  */
 static inline int net_socket_service_unregister(const struct net_socket_service_desc *service)
 {

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -61,6 +61,50 @@ static void register_svc_close_events(const struct net_socket_service_desc *svc)
 	}
 }
 
+int z_impl_net_socket_service_deregister(const struct net_socket_service_desc *svc,
+				         int fd)
+{
+	int i, ret = -ENOENT;
+
+	k_mutex_lock(&lock, K_FOREVER);
+
+	if (thread_status == SOCKET_SERVICE_THREAD_UNINITIALIZED) {
+		(void)k_condvar_wait(&wait_start, &lock, K_FOREVER);
+	} else if (thread_status != SOCKET_SERVICE_THREAD_RUNNING) {
+		NET_ERR("Socket service thread not running, service %p register fails.", svc);
+		ret = -EIO;
+		goto out;
+	}
+
+	if (STRUCT_SECTION_START(net_socket_service_desc) > svc ||
+		STRUCT_SECTION_END(net_socket_service_desc) <= svc) {
+		goto out;
+	}
+
+	for (i = 0; i < svc->pev_len; i++) {
+		if (i == svc->pev_len) {
+			NET_DBG("No file descriptor found in the socket service");
+			ret = -ENOMEM;
+			goto out;
+		}
+
+		if (svc->pev[i].event.fd == fd) {
+			svc->pev[i].event = (struct zsock_pollfd) {.fd = -1, .events = 0};
+			svc->pev[i].user_data = NULL;
+			break;
+		}
+	}
+
+	/* Tell the thread to re-read the variables */
+	zvfs_eventfd_write(ctx.events[0].fd, 1);
+	ret = 0;
+
+out:
+	k_mutex_unlock(&lock);
+
+	return ret;
+}
+
 int z_impl_net_socket_service_register(const struct net_socket_service_desc *svc,
 				       struct zsock_pollfd *fds, int len,
 				       void *user_data)
@@ -97,9 +141,27 @@ int z_impl_net_socket_service_register(const struct net_socket_service_desc *svc
 			goto out;
 		}
 
-		for (i = 0; i < len; i++) {
-			svc->pev[i].event = fds[i];
-			svc->pev[i].user_data = user_data;
+		/* Register only one fds in the first empty slot */
+		/* This allows individual fds to be registered, each with its own user_data */
+		if (len == 1) {
+			for (i = 0; i <= svc->pev_len; i++) {
+				if (i == svc->pev_len) {
+					NET_DBG("Service is full with file descriptors");
+					ret = -ENOMEM;
+					goto out;
+				}
+
+				if (svc->pev[i].event.fd == -1) {
+					svc->pev[i].event = *fds;
+					svc->pev[i].user_data = user_data;
+					break;
+				}
+			}
+		} else {
+			for (i = 0; i < len; i++) {
+				svc->pev[i].event = fds[i];
+				svc->pev[i].user_data = user_data;
+			}
 		}
 	}
 


### PR DESCRIPTION
In the socket service, individual sockets could not carry their own context, preventing socket-specific information from being passed to callbacks. This change allows per-socket user_data association in `net_socket_service_register()`.

By setting the `len` argument to 1 when calling `net_socket_service_register()`, it is now possible to register individual sockets with their own context in the first free slot. 
This is not expected to cause backward-compatibility issues, but in case of possible backward-compatibilty we could create a new function `net_socket_service_register_single()` (open for suggestions)

This change also adds support for deregistering individual sockets by file descriptor via net_socket_service_deregister().

Fixes: (https://github.com/zephyrproject-rtos/zephyr/issues/114405)