### PR TITLE
maintainers: Add tests.bsim.bluetooth* to BT areas

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -868,6 +868,7 @@ Bluetooth Mesh:
     - "area: Bluetooth"
   tests:
     - bluetooth.mesh
+    - tests.bsim.bluetooth.mesh
 
 Bluetooth Qualification:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -890,6 +890,7 @@ Bluetooth Qualification:
     - bluetooth
     - bluetooth.general
     - bluetooth.tester_bsim
+    - bluetooth.tests.bsim.tester
 
 Board/SoC configuration:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -818,6 +818,7 @@ Bluetooth Host:
   tests:
     - bluetooth
     - sample.bluetooth
+    - tests.bsim.bluetooth
 
 Bluetooth ISO:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -741,6 +741,7 @@ Bluetooth HCI:
   tests:
     - bluetooth
     - sample.bluetooth
+    - tests.bsim.bluetooth
 
 Bluetooth Host:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -647,6 +647,7 @@ Bluetooth Audio:
     - bluetooth.audio
     - sample.bluetooth.audio
     - tests.bsim.bluetooth.audio
+    - tests.bsim.bluetooth.audio_samples
 
 Bluetooth Classic:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -713,6 +713,7 @@ Bluetooth Controller:
     - sample.bluetooth.hci_uart_async
     - sample.bluetooth.hci_usb
     - sample.bluetooth.hci_vs_scan_req
+    - tests.bsim.bluetooth
 
 Bluetooth HCI:
   status: maintained


### PR DESCRIPTION
Add more tests identifiers groups to these BT areas.

(Note that by now, the bsim tests are built and run in a separate workflow which does not care about the MAINTAINERS file content, but instead triggers based on the file name regex'es defined in the workflow. So all these were already covered by that workflow.

Nonetheless,) this will ensure these tests are built in the normal twister workflow. And eventually when that twister workflow can, also run there.

See the respective commit msgs for the justification for each change. Maintainers of the respective areas are more than welcome to change these lists as they consider beneficial.