### PR TITLE
drivers: serial: uart_renesas_ra_sci: always clear ERI error + IRQ

### DIFF
--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -1031,9 +1031,11 @@ static void uart_ra_sci_eri_isr(const struct device *dev)
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN)
 	struct uart_ra_sci_data *data = dev->data;
 
+	(void)uart_ra_sci_err_check(dev);
+	R_ICU->IELSR_b[data->fsp_config.eri_irq].IR = 0U;
+
 	if (data->user_cb != NULL) {
 		data->user_cb(dev, data->user_cb_data);
-		R_ICU->IELSR_b[data->fsp_config.eri_irq].IR = 0U;
 		return;
 	}
 #endif


### PR DESCRIPTION
The ERI ISR only cleared the SCI error flags and the pending IELSR.IR inside the user_cb!=NULL branch. When an RX error (overrun/framing/ parity) occurs while no interrupt callback is registered yet - e.g. the window during uart_configure()/R_SCI_UART_Open() before the Zephyr callback is set - nothing is acknowledged, so the error stays pending and the ISR re-triggers forever, starving the CPU (uart_configure hangs, USB never enumerates). Always run err_check() and clear IELSR.IR.


Assisted-by: Claude:claude-opus-4.8

Fixes: #119097