### PR TITLE
net: http: Do not print a header slice as a C string

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -169,9 +169,11 @@ static void print_header_field(size_t len, const char *str)
 			len = sizeof(output) - 1;
 		}
 
-		snprintk(output, len + 1, "%s", str);
+		/* str is not NUL terminated */
+		memcpy(output, str, len);
+		output[len] = '\0';
 
-		NET_DBG("[%zd] %s", len, output);
+		NET_DBG("[%zu] %s", len, output);
 	}
 }
 


### PR DESCRIPTION
The HTTP parser hands its data callbacks a pointer and a length, and the field it points at is not NUL terminated. print_header_field() passed that pointer to a %s conversion:

	snprintk(output, len + 1, "%s", str);

The size argument bounds the destination, not how far the source is walked. Both formatter implementations measure the whole string first, cbprintf_complete.c with strlen() when no precision is given and cbprintf_nano.c with strlen() unconditionally, so the read runs past the end of the field and out of the receive buffer that holds it.

The in-tree tests/net/lib/http_client suite reproduces it on an ordinary GET, no crafted response needed, once it is built with CONFIG_ASAN=y and CONFIG_NET_HTTP_LOG_LEVEL_DBG=y:

	AddressSanitizer: global-buffer-overflow
	READ of size 48 at 0x08117480
	    #1 in z_cbvprintf_impl lib/os/cbprintf_complete.c:1627
	    #5 in print_header_field subsys/net/lib/http/http_client.c:172
	0x08117480 is located 0 bytes after global variable 'recv_buf'
	  (0x8117440) of size 64

Copy the bytes the parser actually offered and terminate them, rather than reaching for a precision. A precision only bounds the read in cbprintf_complete.c; with CONFIG_CBPRINTF_NANO=y the source is still measured in full before the precision is applied.

Assisted-by: Claude:claude-opus-5

Fixes #117807
