### PR TITLE
boards: antmicro: Fix int active level in hdmi board

### DIFF
--- a/boards/antmicro/stm32h7_hdmi_board/stm32h7_hdmi_board_stm32h747xx_m7.dts
+++ b/boards/antmicro/stm32h7_hdmi_board/stm32h7_hdmi_board_stm32h747xx_m7.dts
@@ -211,7 +211,7 @@ pmod_uart: &usart2 {
 	usba_p1: zephyr_uhc0: max3421e@0 {
 		compatible = "maxim,max3421e-spi";
 		reg = <0>;
-		int-gpios = <&gpioe 3 GPIO_ACTIVE_HIGH>;
+		int-gpios = <&gpioe 3 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpioc 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		spi-max-frequency = <26000000>;
 	};
@@ -229,7 +229,7 @@ pmod_spi: &spi5 {
 	usba_p2: zephyr_uhc1: max3421e@0 {
 		compatible = "maxim,max3421e-spi";
 		reg = <0>;
-		int-gpios = <&gpioj 9 GPIO_ACTIVE_HIGH>;
+		int-gpios = <&gpioj 9 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpioj 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		spi-max-frequency = <26000000>;
 	};


### PR DESCRIPTION
Change interrupt GPIO active level from high to low in both Max3421e nodes.

Max3421e driver works only with active low interrupt pin.
This commit makes the DTS compatible with the current Max3421e driver.