### PR TITLE
userspace: correct K_SYSCALL_*() check macro documentation

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -472,6 +472,22 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
 #define K_SYSCALL_MEMORY_WRITE(ptr, size) \
 	K_SYSCALL_MEMORY(ptr, size, 1)
 
+/**
+ * @brief Validate user thread has read and/or write permission for sized array
+ *
+ * Used when the memory region is expressed in terms of number of elements and
+ * each element size, handles any overflow issues with computing the total
+ * array bounds. Otherwise see K_SYSCALL_MEMORY().
+ *
+ * @param ptr Memory area to examine
+ * @param nmemb Number of elements in the array
+ * @param size Size of each array element
+ * @param write If the thread should be able to write to this memory, not just
+ *		read it
+ * @return false on success, true on failure
+ * @note This is an internal API. Do not use unless you are extending
+ *       functionality in the Zephyr tree.
+ */
 #define K_SYSCALL_MEMORY_ARRAY(ptr, nmemb, size, write) \
 	({ \
 		size_t product; \

--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -504,7 +504,7 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  *
  * Used when the memory region is expressed in terms of number of elements and
  * each element size, handles any overflow issues with computing the total
- * array bounds. Otherwise see _SYSCALL_MEMORY_READ.
+ * array bounds. Otherwise see K_SYSCALL_MEMORY_READ().
  *
  * @param ptr Memory area to examine
  * @param nmemb Number of elements in the array
@@ -521,7 +521,7 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  *
  * Used when the memory region is expressed in terms of number of elements and
  * each element size, handles any overflow issues with computing the total
- * array bounds. Otherwise see _SYSCALL_MEMORY_WRITE.
+ * array bounds. Otherwise see K_SYSCALL_MEMORY_WRITE().
  *
  * @param ptr Memory area to examine
  * @param nmemb Number of elements in the array
@@ -627,9 +627,9 @@ static inline int k_object_validation_check(struct k_object *ko,
 	K_SYSCALL_IS_OBJ(ptr, type, _OBJ_INIT_TRUE)
 
 /**
- * @brief Runtime check kernel object pointer for non-init functions
+ * @brief Runtime check kernel object pointer for init functions
  *
- * See description of _SYSCALL_IS_OBJ. No initialization checks are done.
+ * See description of K_SYSCALL_IS_OBJ(). No initialization checks are done.
  * Intended for init functions where objects may be re-initialized at will.
  *
  * @param ptr Untrusted kernel object pointer
@@ -643,9 +643,9 @@ static inline int k_object_validation_check(struct k_object *ko,
 	K_SYSCALL_IS_OBJ(ptr, type, _OBJ_INIT_ANY)
 
 /**
- * @brief Runtime check kernel object pointer for non-init functions
+ * @brief Runtime check kernel object pointer for one-shot init functions
  *
- * See description of _SYSCALL_IS_OBJ. The check fails if the object is
+ * See description of K_SYSCALL_IS_OBJ(). The check fails if the object is
  * initialized. Intended for init functions where objects, once initialized,
  * can only be re-used when their initialization state expires due to some
  * other mechanism.

--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -342,7 +342,8 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  * This macro can be used to induce a kernel oops which will kill the
  * calling thread.
  *
- * @param expr Expression to be evaluated
+ * @param expr Expression to be evaluated. The oops is induced when it
+ *             evaluates to true.
  *
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
@@ -358,14 +359,13 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  * @brief Runtime expression check for system call arguments
  *
  * Used in handler functions to perform various runtime checks on arguments,
- * and generate a kernel oops if anything is not expected, printing a custom
- * message.
+ * printing a custom message if anything is not expected. Wrap in K_OOPS() to
+ * turn a failed check into a kernel oops.
  *
- * @param expr Boolean expression to verify, a false result will trigger an
- *             oops
+ * @param expr Boolean expression to verify, a false result is a failed check
  * @param fmt Printf-style format string (followed by appropriate variadic
  *            arguments) to print on verification failure
- * @return False on success, True on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -383,12 +383,11 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
 /**
  * @brief Runtime expression check for system call arguments
  *
- * Used in handler functions to perform various runtime checks on arguments,
- * and generate a kernel oops if anything is not expected.
+ * Used in handler functions to perform various runtime checks on arguments.
  *
- * @param expr Boolean expression to verify, a false result will trigger an
- *             oops. A stringified version of this expression will be printed.
- * @return 0 on success, nonzero on failure
+ * @param expr Boolean expression to verify, a false result is a failed check.
+ *             A stringified version of this expression will be printed.
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -415,16 +414,16 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  *        a memory area
  *
  * Checks that the particular memory area is readable and/or writeable by the
- * currently running thread if the CPU was in user mode, and generates a kernel
- * oops if it wasn't. Prevents userspace from getting the kernel to read and/or
- * modify memory the thread does not have access to, or passing in garbage
- * pointers that would crash/pagefault the kernel if dereferenced.
+ * currently running thread if the CPU was in user mode. Prevents userspace
+ * from getting the kernel to read and/or modify memory the thread does not
+ * have access to, or passing in garbage pointers that would crash/pagefault
+ * the kernel if dereferenced.
  *
  * @param ptr Memory area to examine
  * @param size Size of the memory area
  * @param write If the thread should be able to write to this memory, not just
  *		read it
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -441,14 +440,13 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  * @brief Runtime check that a user thread has read permission to a memory area
  *
  * Checks that the particular memory area is readable by the currently running
- * thread if the CPU was in user mode, and generates a kernel oops if it
- * wasn't. Prevents userspace from getting the kernel to read memory the thread
- * does not have access to, or passing in garbage pointers that would
- * crash/pagefault the kernel if dereferenced.
+ * thread if the CPU was in user mode. Prevents userspace from getting the
+ * kernel to read memory the thread does not have access to, or passing in
+ * garbage pointers that would crash/pagefault the kernel if dereferenced.
  *
  * @param ptr Memory area to examine
  * @param size Size of the memory area
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -459,14 +457,14 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  * @brief Runtime check that a user thread has write permission to a memory area
  *
  * Checks that the particular memory area is readable and writable by the
- * currently running thread if the CPU was in user mode, and generates a kernel
- * oops if it wasn't. Prevents userspace from getting the kernel to read or
- * modify memory the thread does not have access to, or passing in garbage
- * pointers that would crash/pagefault the kernel if dereferenced.
+ * currently running thread if the CPU was in user mode. Prevents userspace
+ * from getting the kernel to read or modify memory the thread does not have
+ * access to, or passing in garbage pointers that would crash/pagefault the
+ * kernel if dereferenced.
  *
  * @param ptr Memory area to examine
  * @param size Size of the memory area
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  *
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
@@ -495,7 +493,7 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  * @param ptr Memory area to examine
  * @param nmemb Number of elements in the array
  * @param size Size of each array element
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -512,7 +510,7 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  * @param ptr Memory area to examine
  * @param nmemb Number of elements in the array
  * @param size Size of each array element
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -554,7 +552,7 @@ static inline int k_object_validation_check(struct k_object *ko,
  * @param api_name Name of the driver API struct (e.g. gpio_driver_api)
  * @param op Driver operation (e.g. manage_callback)
  *
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  *
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
@@ -585,7 +583,7 @@ static inline int k_object_validation_check(struct k_object *ko,
  * @param _device Untrusted device pointer
  * @param _dtype Expected kernel object type for the provided device pointer
  * @param _api Expected driver API structure memory address
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -600,13 +598,12 @@ static inline int k_object_validation_check(struct k_object *ko,
 /**
  * @brief Runtime check kernel object pointer for non-init functions
  *
- * Calls k_object_validate and triggers a kernel oops if the check fails.
- * For use in system call handlers which are not init functions; a fatal
- * error will occur if the object is not initialized.
+ * Calls k_object_validate(). For use in system call handlers which are not
+ * init functions; the check fails if the object is not initialized.
  *
  * @param ptr Untrusted kernel object pointer
  * @param type Expected kernel object type
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -621,7 +618,7 @@ static inline int k_object_validation_check(struct k_object *ko,
  *
  * @param ptr Untrusted kernel object pointer
  * @param type Expected kernel object type
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */
@@ -632,14 +629,14 @@ static inline int k_object_validation_check(struct k_object *ko,
 /**
  * @brief Runtime check kernel object pointer for non-init functions
  *
- * See description of _SYSCALL_IS_OBJ. Triggers a fatal error if the object is
+ * See description of _SYSCALL_IS_OBJ. The check fails if the object is
  * initialized. Intended for init functions where objects, once initialized,
  * can only be re-used when their initialization state expires due to some
  * other mechanism.
  *
  * @param ptr Untrusted kernel object pointer
  * @param type Expected kernel object type
- * @return 0 on success, nonzero on failure
+ * @return false on success, true on failure
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
  */


### PR DESCRIPTION
This tries to fix a lot of confusing/inconsistent docs & terminology across the `K_SYSCALL_` macros.

The `K_SYSCALL_*()` check macros never oops. They log the failure and return a `bool` that is **true on failure**; only `K_OOPS()` oopses. The doc blocks said otherwise, and documented the polarity three different ways.

#117927 fixes a verifier that has had every buffer check inverted for exactly this reason.

- Drop the "generates a kernel oops" / "triggers a fatal error" claims; point at `K_OOPS()` instead, and state on `K_OOPS()` itself that it fires when its expression is true.
- Normalize every `@return` in the family to "false on success, true on failure".
- Document `K_SYSCALL_MEMORY_ARRAY()`, which had no doc block.
- Refresh stale `_SYSCALL_*` references, and fix the copy-pasted "for non-init functions" briefs on the `K_SYSCALL_OBJ_INIT()` variants.
