### PR TITLE
samples: basic: custom_dts_binding: Add native_sim support

### DIFF
--- a/samples/basic/custom_dts_binding/README.rst
+++ b/samples/basic/custom_dts_binding/README.rst
@@ -42,6 +42,9 @@ Afterwards, the sample can be built and executed for the ``<board>`` as follows:
 
 For demonstration purposes, some boards use the GPIO pin of the built-in LED.
 
+On :zephyr:board:`native_sim`, the pin is provided by the emulated GPIO
+controller, so the sample can be run without any hardware.
+
 Sample output
 =============
 

--- a/samples/basic/custom_dts_binding/boards/native_sim.overlay
+++ b/samples/basic/custom_dts_binding/boards/native_sim.overlay
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	load_switch: load_switch {
+		compatible = "power-switch";
+		gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/samples/basic/custom_dts_binding/boards/native_sim_native_64.overlay
+++ b/samples/basic/custom_dts_binding/boards/native_sim_native_64.overlay
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"

--- a/samples/basic/custom_dts_binding/tests.yaml
+++ b/samples/basic/custom_dts_binding/tests.yaml
@@ -5,9 +5,12 @@ tests:
     tags:
       - gpio
       - devicetree
-    platform_allow: nucleo_l073rz
-    integration_platforms:
+    platform_allow:
       - nucleo_l073rz
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
     depends_on: gpio
     harness: console
     harness_config:


### PR DESCRIPTION
The sample only needs a single GPIO pin, but was restricted to the
nucleo_l073rz board and therefore never executed in CI. Add overlays
mapping the load_switch node to native_sim's emulated GPIO controller
(the 64-bit variant needs its own overlay file including the base one,
as the plain board-name fallback does not cover board variants) and
make native_sim the integration platform so the existing console
harness is exercised on every PR.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
