### PR TITLE
driver/wifi/esp_mesh: Converted to runtime config

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -477,24 +477,32 @@ menuconfig WIFI_ESP32_MESH
 if WIFI_ESP32_MESH
 
 config WIFI_ESP32_MESH_MAX_LAYER
-	int "Maximum mesh layer (tree depth)"
+	int "Maximum mesh layer (tree depth) buffer ceiling"
 	default 25
 	range 1 25
 	help
-	  Maximum number of layers (tree depth) the mesh may grow to. The root
-	  is layer 1, its direct children layer 2, and so on. Nodes that would
-	  attach deeper than this limit are refused, bounding the tree height.
-	  The routing table on the root is sized for the whole sub-network, so
-	  the maximum node count is roughly MAX_LAYER * MAX_CONNECTIONS + 1.
+	  Compile-time ceiling on the mesh tree depth (layers): it sizes the
+	  routing-table buffers at build time and bounds the num_layers field
+	  esp_wifi_mesh_set_config() accepts, which is the value actually
+	  applied at runtime (esp_wifi_mesh_start() defaults num_layers to this
+	  ceiling if the config is never set). The root is layer 1, its direct
+	  children layer 2, and so on; nodes that would attach deeper than the
+	  runtime num_layers are refused. The routing table on the root is sized
+	  for the whole sub-network, so the maximum node count is roughly
+	  MAX_LAYER * MAX_CONNECTIONS + 1.
 
 config WIFI_ESP32_MESH_MAX_CONNECTIONS
-	int "Maximum direct child connections per node"
+	int "Maximum direct child connections per node buffer ceiling"
 	default 6
 	range 1 10
 	help
-	  Maximum number of direct child nodes a single node accepts on its
-	  softAP interface. This is a per-node fan-out limit, not a whole-network
-	  limit: nodes beyond this count attach one layer deeper instead, so the
+	  Compile-time ceiling on the per-node child fan-out: it sizes the
+	  routing-table buffers at build time and bounds the
+	  max_connections field esp_wifi_mesh_set_config() accepts, which
+	  is the value actually applied at runtime (esp_wifi_mesh_start()
+	  defaults max_connections to this ceiling if the config is never
+	  set). This is a per-node fan-out limit, not a whole-network limit:
+	  nodes beyond this count attach one layer deeper instead, so the
 	  network still grows by extending the tree. A larger value makes a
 	  flatter tree (more RAM per node for the extra links); a smaller value
 	  makes a deeper tree. Each direct link consumes Wi-Fi RX/TX buffers from
@@ -520,49 +528,6 @@ config WIFI_ESP32_MESH_START_TIMEOUT
 	  MESH_EVENT_STARTED before it proceeds to re-deliver the initial
 	  station-start event. The wait ends as soon as the event arrives; this
 	  is only the upper bound before it gives up and continues anyway.
-
-config WIFI_ESP32_MESH_CHANNEL
-	int "Mesh channel (0 = auto, 1-13 = fixed)"
-	default 0
-	range 0 13
-	help
-	  Channel the mesh network operates on. 0 lets the mesh select the
-	  channel by scanning, which is required when the router channel is
-	  unknown. A fixed value 1-13 pins the channel; all nodes must then
-	  use the same one.
-
-config WIFI_ESP32_MESH_ROUTER_SSID
-	string "Router SSID"
-	default "myssid"
-	help
-	  SSID of the router the root node connects to for external network
-	  access. The mesh stack requires a router SSID to be set, so this
-	  carries a placeholder rather than an empty default. Set it to the
-	  router in use: a node left on the placeholder finds no such network
-	  and keeps searching for a parent.
-
-config WIFI_ESP32_MESH_ROUTER_PSK
-	string "Router password"
-	default "mypassword"
-	help
-	  Password of the router the root node connects to. Leave empty for an
-	  open router.
-
-config WIFI_ESP32_MESH_AP_PSK
-	string "Mesh softAP password"
-	default "meshpassword"
-	help
-	  Password protecting the inter-node mesh softAP links. Must be at
-	  least 8 characters and identical on every node.
-
-config WIFI_ESP32_MESH_ID
-	string "Mesh network ID (6 bytes, colon-separated hex)"
-	default "12:34:56:78:9a:bc"
-	help
-	  Unique 6-byte identifier of this mesh network, written as six
-	  colon-separated hex octets. Nodes only join a mesh that advertises
-	  the same ID, so every node in one network must use the same value and
-	  different networks sharing a channel must use different IDs.
 
 config WIFI_ESP32_MESH_ASSOC_EXPIRE
 	int "Idle child association expiry (seconds)"

--- a/drivers/wifi/esp32/src/esp_wifi_mesh.c
+++ b/drivers/wifi/esp32/src/esp_wifi_mesh.c
@@ -35,11 +35,6 @@
 
 LOG_MODULE_REGISTER(esp_wifi_mesh, CONFIG_WIFI_LOG_LEVEL);
 
-/* The mesh softAP uses WPA2-PSK, which requires an 8..63 character password. */
-BUILD_ASSERT(sizeof(CONFIG_WIFI_ESP32_MESH_AP_PSK) - 1 >= 8 &&
-		     sizeof(CONFIG_WIFI_ESP32_MESH_AP_PSK) - 1 <= 63,
-	     "CONFIG_WIFI_ESP32_MESH_AP_PSK must be 8 to 63 characters");
-
 /*
  * When the mesh stack is active it drives the station and softAP directly.
  * Its softAP start/stop and association events would otherwise take the
@@ -186,43 +181,103 @@ void esp_wifi_mesh_dispatch_event(esp_event_base_t event_base, int32_t event_id,
 }
 
 /*
- * Parse the 6-byte mesh id from its "xx:xx:xx:xx:xx:xx" Kconfig string into
- * out. On a malformed value fall back to a fixed default so the mesh still
- * comes up rather than joining an unintended network.
+ * Effective mesh configuration esp_wifi_mesh_start() reads from. Seeded with
+ * what used to be the Kconfig defaults, so a caller that never calls
+ * esp_wifi_mesh_set_config() gets identical behavior to before. Set only
+ * before esp_wifi_mesh_start() runs; mesh has no runtime reconfiguration.
  */
-static void mesh_id_parse(uint8_t out[6])
+static struct esp_wifi_mesh_config runtime_cfg = {
+	.ssid = "myssid",
+	.password = "mypassword",
+	.mesh_password = "meshpassword",
+	.channel = 0,
+	.mesh_id = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
+	.authmode = WIFI_SECURITY_TYPE_PSK,
+	.num_layers = CONFIG_WIFI_ESP32_MESH_MAX_LAYER,
+	.max_connections = CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS,
+};
+
+/* Translate the Zephyr-native security type to the vendor mesh softAP auth
+ * mode. The mesh softAP only ever needs to be open or PSK/SAE-secured, so
+ * this covers that practical subset rather than every wifi_security_type.
+ */
+static int mesh_authmode_from_security(enum wifi_security_type security,
+					wifi_auth_mode_t *authmode)
 {
-	static const uint8_t fallback[6] = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc};
-	const char *p = CONFIG_WIFI_ESP32_MESH_ID;
-	uint8_t id[6];
+	switch (security) {
+	case WIFI_SECURITY_TYPE_NONE:
+		*authmode = WIFI_AUTH_OPEN;
+		return 0;
+	case WIFI_SECURITY_TYPE_PSK:
+		*authmode = WIFI_AUTH_WPA2_PSK;
+		return 0;
+	case WIFI_SECURITY_TYPE_SAE:
+		*authmode = WIFI_AUTH_WPA3_PSK;
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
 
-	for (int i = 0; i < 6; i++) {
-		uint8_t hi, lo;
+int esp_wifi_mesh_set_config(const struct esp_wifi_mesh_config *config)
+{
+	wifi_auth_mode_t authmode;
+	size_t mesh_password_len;
 
-		if (char2hex(p[0], &hi) != 0 || char2hex(p[1], &lo) != 0) {
-			goto invalid;
-		}
-		id[i] = (hi << 4) | lo;
-		p += 2;
-
-		if (i < 5) {
-			if (*p != ':') {
-				goto invalid;
-			}
-			p++;
-		}
+	if (config == NULL) {
+		return -EINVAL;
 	}
 
-	if (*p != '\0') {
-		goto invalid;
+	if (esp_wifi_mesh_is_active()) {
+		return -EBUSY;
 	}
 
-	memcpy(out, id, sizeof(id));
-	return;
+	if (strnlen(config->ssid, sizeof(config->ssid)) >= sizeof(config->ssid)) {
+		return -EINVAL;
+	}
 
-invalid:
-	LOG_WRN("invalid mesh id '%s', using default", CONFIG_WIFI_ESP32_MESH_ID);
-	memcpy(out, fallback, sizeof(fallback));
+	if (strnlen(config->password, sizeof(config->password)) >= sizeof(config->password)) {
+		return -EINVAL;
+	}
+
+	mesh_password_len = strnlen(config->mesh_password, sizeof(config->mesh_password));
+	if (mesh_password_len >= sizeof(config->mesh_password) ||
+	    (mesh_password_len != 0 && (mesh_password_len < 8 || mesh_password_len > 63))) {
+		return -EINVAL;
+	}
+
+	if (config->channel > 13) {
+		return -EINVAL;
+	}
+
+	if (mesh_authmode_from_security(config->authmode, &authmode) != 0) {
+		return -EINVAL;
+	}
+
+	if ((config->authmode == WIFI_SECURITY_TYPE_NONE) != (mesh_password_len == 0)) {
+		return -EINVAL;
+	}
+
+	if (config->num_layers < 1 || config->num_layers > CONFIG_WIFI_ESP32_MESH_MAX_LAYER) {
+		return -EINVAL;
+	}
+
+	if (config->max_connections < 1 ||
+	    config->max_connections > CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS) {
+		return -EINVAL;
+	}
+
+	runtime_cfg = *config;
+	return 0;
+}
+
+void esp_wifi_mesh_get_config(struct esp_wifi_mesh_config *config)
+{
+	if (config == NULL) {
+		return;
+	}
+
+	*config = runtime_cfg;
 }
 
 static esp_wifi_mesh_event_cb_t app_event_cb;
@@ -359,9 +414,8 @@ int esp_wifi_mesh_start(void)
 	 * role needs a router. A fixed root or fixed child does not run an
 	 * election and can form a router-less mesh, so the router is optional.
 	 */
-	if (IS_ENABLED(CONFIG_WIFI_ESP32_MESH_ROLE_AUTO) &&
-	    strlen(CONFIG_WIFI_ESP32_MESH_ROUTER_SSID) == 0) {
-		LOG_ERR("router SSID must be set (CONFIG_WIFI_ESP32_MESH_ROUTER_SSID)");
+	if (IS_ENABLED(CONFIG_WIFI_ESP32_MESH_ROLE_AUTO) && strlen(runtime_cfg.ssid) == 0) {
+		LOG_ERR("router SSID must be set (see esp_wifi_mesh_set_config())");
 		return -EINVAL;
 	}
 
@@ -380,7 +434,7 @@ int esp_wifi_mesh_start(void)
 	}
 
 	esp_mesh_set_topology(MESH_TOPO_TREE);
-	esp_mesh_set_max_layer(CONFIG_WIFI_ESP32_MESH_MAX_LAYER);
+	esp_mesh_set_max_layer(runtime_cfg.num_layers);
 	esp_mesh_set_vote_percentage((float)CONFIG_WIFI_ESP32_MESH_VOTE_PERCENTAGE / 100.0f);
 	esp_mesh_set_xon_qsize(CONFIG_WIFI_ESP32_MESH_XON_QSIZE);
 
@@ -389,15 +443,12 @@ int esp_wifi_mesh_start(void)
 
 	esp_mesh_set_ap_assoc_expire(CONFIG_WIFI_ESP32_MESH_ASSOC_EXPIRE);
 
-	cfg.channel = CONFIG_WIFI_ESP32_MESH_CHANNEL;
+	cfg.channel = runtime_cfg.channel;
 	if (cfg.channel == 0) {
 		/* Scan all channels to locate the router. */
 		cfg.allow_channel_switch = true;
 	}
-	uint8_t mesh_id[6];
-
-	mesh_id_parse(mesh_id);
-	memcpy((uint8_t *)&cfg.mesh_id, mesh_id, sizeof(mesh_id));
+	memcpy((uint8_t *)&cfg.mesh_id, runtime_cfg.mesh_id, sizeof(runtime_cfg.mesh_id));
 
 	/*
 	 * Router credentials: only the elected or fixed root associates to the
@@ -406,8 +457,8 @@ int esp_wifi_mesh_start(void)
 	 * SSID the fixed root never actually associates to; its children attach
 	 * to the root's softAP and the mesh forms with no router involved.
 	 */
-	const char *router_ssid = CONFIG_WIFI_ESP32_MESH_ROUTER_SSID;
-	const char *router_psk = CONFIG_WIFI_ESP32_MESH_ROUTER_PSK;
+	const char *router_ssid = runtime_cfg.ssid;
+	const char *router_psk = runtime_cfg.password;
 
 	if (strlen(router_ssid) == 0) {
 		router_ssid = "esp-mesh-no-router";
@@ -419,10 +470,19 @@ int esp_wifi_mesh_start(void)
 	memcpy(cfg.router.password, router_psk,
 	       MIN(strlen(router_psk), sizeof(cfg.router.password) - 1));
 
-	esp_mesh_set_ap_authmode(WIFI_AUTH_WPA2_PSK);
-	cfg.mesh_ap.max_connection = CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS;
-	memcpy(cfg.mesh_ap.password, CONFIG_WIFI_ESP32_MESH_AP_PSK,
-	       MIN(strlen(CONFIG_WIFI_ESP32_MESH_AP_PSK), sizeof(cfg.mesh_ap.password) - 1));
+	wifi_auth_mode_t mesh_authmode = WIFI_AUTH_WPA_PSK;
+
+	/* Validated in esp_wifi_mesh_set_config(); the seeded default is also valid. */
+	(void)mesh_authmode_from_security(runtime_cfg.authmode, &mesh_authmode);
+
+	if (esp_mesh_set_ap_authmode(mesh_authmode) != ESP_OK) {
+		LOG_ERR("failed to set authmode for AP");
+		return -EIO;
+	}
+
+	cfg.mesh_ap.max_connection = runtime_cfg.max_connections;
+	memcpy(cfg.mesh_ap.password, runtime_cfg.mesh_password,
+	       MIN(strlen(runtime_cfg.mesh_password), sizeof(cfg.mesh_ap.password) - 1));
 
 	esp_err_t cfg_ret = esp_mesh_set_config(&cfg);
 
@@ -467,7 +527,7 @@ int esp_wifi_mesh_start(void)
 	 * stay enabled: self-organized networking also drives the association to
 	 * the router and the reconnection that maintains the root uplink.
 	 */
-	if (strlen(CONFIG_WIFI_ESP32_MESH_ROUTER_SSID) == 0) {
+	if (strlen(runtime_cfg.ssid) == 0) {
 		esp_mesh_set_self_organized(false, false);
 	}
 #endif

--- a/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
+++ b/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/wifi.h>
 
 /**
  * @brief ESP32 Wi-Fi Mesh API.
@@ -101,12 +102,87 @@ typedef void (*esp_wifi_mesh_event_cb_t)(enum esp_wifi_mesh_event event,
 void esp_wifi_mesh_event_cb_register(esp_wifi_mesh_event_cb_t cb);
 
 /**
+ * @brief Runtime-configurable mesh credentials and tree limits.
+ *
+ * Read by esp_wifi_mesh_start() in place of the driver's Kconfig defaults.
+ * Set this before calling esp_wifi_mesh_start(); the mesh stack has no
+ * runtime reconfiguration or teardown, so changes after start have no effect.
+ */
+struct esp_wifi_mesh_config {
+	/** Router SSID: the upstream Wi-Fi network the root associates to for
+	 *  external network access. Empty forms a router-less fixed-root mesh
+	 *  (see esp_wifi_mesh_start()). NUL-terminated, up to 32 characters.
+	 */
+	char ssid[33];
+	/** Router password. NUL-terminated, up to 63 characters; empty for an
+	 *  open router.
+	 */
+	char password[64];
+	/** Mesh softAP password securing the inter-node mesh links. Must be
+	 *  empty (for WIFI_SECURITY_TYPE_NONE) or 8..63 characters, and
+	 *  identical on every node in the mesh.
+	 */
+	char mesh_password[64];
+	/** Mesh channel: 0 lets the mesh select it by scanning (required when
+	 *  the router channel is unknown); 1-13 pins a fixed channel, which
+	 *  must then match on every node.
+	 */
+	uint8_t channel;
+	/** 6-byte mesh network identifier. Nodes only join a mesh advertising
+	 *  the same ID, so every node in one network must use the same value.
+	 */
+	uint8_t mesh_id[6];
+	/** Mesh softAP authentication mode. */
+	enum wifi_security_type authmode;
+	/** Tree depth (layers) to use for this mesh. Must be at least 1 and no
+	 *  greater than the compiled-in CONFIG_WIFI_ESP32_MESH_MAX_LAYER,
+	 *  which sizes the routing-table buffers at build time.
+	 */
+	uint8_t num_layers;
+	/** Per-node direct child fan-out to use for this mesh. Must be at
+	 *  least 1 and no greater than the compiled-in
+	 *  CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS, which sizes the
+	 *  routing-table buffers at build time.
+	 */
+	uint8_t max_connections;
+};
+
+/**
+ * @brief Set the mesh configuration used by the next esp_wifi_mesh_start().
+ *
+ * Validates every field and, if valid, replaces the current configuration in
+ * full (there is no partial update). On failure the previous configuration is
+ * left unchanged. Must be called before esp_wifi_mesh_start(); mesh has no
+ * runtime reconfiguration.
+ *
+ * @param config configuration to apply.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL on a NULL argument or any field outside its documented
+ *         valid range (string lengths, channel, authmode, a mismatched
+ *         authmode/mesh_password pair, or a tree limit above its
+ *         compiled-in Kconfig ceiling).
+ * @retval -EBUSY if the mesh is already active.
+ */
+int esp_wifi_mesh_set_config(const struct esp_wifi_mesh_config *config);
+
+/**
+ * @brief Get the mesh configuration esp_wifi_mesh_start() will use.
+ *
+ * Returns the last configuration passed to esp_wifi_mesh_set_config(), or the
+ * driver's built-in defaults if it was never called.
+ *
+ * @param config output filled with the current configuration.
+ */
+void esp_wifi_mesh_get_config(struct esp_wifi_mesh_config *config);
+
+/**
  * @brief Start the Wi-Fi mesh stack.
  *
  * Performs the full mesh bring-up: puts Wi-Fi in AP+STA mode, initializes and
- * configures the mesh stack from the driver Kconfig options (mesh id, channel,
- * router and softAP credentials, tree limits), disables power save, and starts
- * the mesh.
+ * configures the mesh stack from the current configuration (see
+ * esp_wifi_mesh_set_config()/esp_wifi_mesh_get_config()) plus the mesh tuning
+ * Kconfig options, disables power save, and starts the mesh.
  *
  * The node role follows the WIFI_ESP32_MESH_ROLE choice: the auto role runs
  * self-organized election (a router is required); WIFI_ESP32_MESH_FORCE_ROOT

--- a/samples/boards/espressif/wifi_mesh/README.rst
+++ b/samples/boards/espressif/wifi_mesh/README.rst
@@ -68,9 +68,9 @@ Building and Running
    :goals: build flash
    :compact:
 
-Configure the mesh channel and the router credentials through Kconfig
-(``CONFIG_WIFI_ESP32_MESH_CHANNEL``, ``CONFIG_WIFI_ESP32_MESH_ROUTER_SSID``,
-``CONFIG_WIFI_ESP32_MESH_ROUTER_PSK``). The router credentials default to the
+Configure the mesh channel and the router credentials at runtime, in
+``src/main.c``, through ``esp_wifi_mesh_set_config()`` (see
+``esp_wifi_mesh.h``). The router credentials default to the
 ``myssid``/``mypassword`` placeholders and must be set to the router in use;
 a node left on the placeholder finds no such network and keeps searching for
 a parent. Set the channel to the router's channel. Flash the same image to
@@ -116,7 +116,7 @@ Sample Output
 
 .. code-block:: console
 
-   <inf> wifi_mesh: Wi-Fi mesh starting, use the "mesh" shell commands
+   <inf> wifi_mesh: Wi-Fi mesh starting (router SSID "myssid"), use the "mesh" shell commands
    <inf> wifi_mesh: mesh started, layer -1
    <inf> wifi_mesh: parent connected, layer 1 (root)
    <inf> wifi_mesh: child connected

--- a/samples/boards/espressif/wifi_mesh/prj.conf
+++ b/samples/boards/espressif/wifi_mesh/prj.conf
@@ -6,8 +6,8 @@ CONFIG_WIFI_ESP32_MESH=y
 
 # A router is required for the mesh to elect a root: self-organized election
 # is driven by router reachability. The router credentials default to
-# placeholders and must be set to the router in use, through Kconfig
-# (CONFIG_WIFI_ESP32_MESH_ROUTER_SSID/_PSK), for example in a board overlay.
+# placeholders and must be set to the router in use, at runtime through
+# esp_wifi_mesh_set_config() in main.c, before esp_wifi_mesh_start() is called.
 
 # The mesh stack manages the Wi-Fi interface directly. The network stack is
 # only used to instantiate the Wi-Fi interface; this sample exchanges data

--- a/samples/boards/espressif/wifi_mesh/src/main.c
+++ b/samples/boards/espressif/wifi_mesh/src/main.c
@@ -138,11 +138,34 @@ int main(void)
 
 	esp_wifi_mesh_event_cb_register(mesh_event);
 
+	/*
+	 * Mesh credentials and tree limits are runtime-configurable; set them
+	 * here before esp_wifi_mesh_start() rather than through Kconfig. These
+	 * values match the driver's built-in defaults: replace them with your
+	 * router's credentials and a mesh ID unique to your network.
+	 */
+	struct esp_wifi_mesh_config mesh_cfg = {
+		.ssid = "myssid",
+		.password = "mypassword",
+		.mesh_password = "meshpassword",
+		.channel = 0,
+		.mesh_id = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
+		.authmode = WIFI_SECURITY_TYPE_PSK,
+		.num_layers = CONFIG_WIFI_ESP32_MESH_MAX_LAYER,
+		.max_connections = CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS,
+	};
+
+	if (esp_wifi_mesh_set_config(&mesh_cfg) != 0) {
+		LOG_ERR("invalid mesh configuration");
+		return -EINVAL;
+	}
+
 	if (esp_wifi_mesh_start() != 0) {
 		LOG_ERR("Wi-Fi mesh start failed");
 		return -EIO;
 	}
 
-	LOG_INF("Wi-Fi mesh starting, use the \"mesh\" shell commands");
+	LOG_INF("Wi-Fi mesh starting (router SSID \"%s\"), use the \"mesh\" shell commands",
+		mesh_cfg.ssid);
 	return 0;
 }

--- a/samples/boards/espressif/wifi_mesh_ip/README.rst
+++ b/samples/boards/espressif/wifi_mesh_ip/README.rst
@@ -85,9 +85,9 @@ Building and Running
    :goals: build flash
    :compact:
 
-Configure the mesh channel and the router credentials through Kconfig
-(``CONFIG_WIFI_ESP32_MESH_CHANNEL``, ``CONFIG_WIFI_ESP32_MESH_ROUTER_SSID``,
-``CONFIG_WIFI_ESP32_MESH_ROUTER_PSK``). The router credentials default to the
+Configure the mesh channel and the router credentials at runtime, in
+``src/main.c``, through ``esp_wifi_mesh_set_config()`` (see
+``esp_wifi_mesh.h``). The router credentials default to the
 ``myssid``/``mypassword`` placeholders and must be set to the router in use;
 a node left on the placeholder finds no such network and keeps searching for
 a parent. Set the channel to the router's
@@ -108,6 +108,7 @@ mesh:
 
 .. code-block:: console
 
+   <inf> wifi_mesh_ip: Wi-Fi mesh starting (router SSID "myssid")
    <inf> wifi_mesh_ip: parent connected, layer 1 (root)
    <inf> wifi_mesh_ip: mesh root IP: gateway 192.168.4.1, DHCP + NAT up
    <inf> wifi_mesh_ip: child connected

--- a/samples/boards/espressif/wifi_mesh_ip/prj.conf
+++ b/samples/boards/espressif/wifi_mesh_ip/prj.conf
@@ -9,8 +9,9 @@ CONFIG_WIFI_ESP32_MESH=y
 CONFIG_WIFI_ESP32_MESH_IP=y
 
 # Router the elected root associates to for external access. The credentials
-# default to placeholders and must be set to the router in use, through Kconfig
-# (CONFIG_WIFI_ESP32_MESH_ROUTER_SSID/_PSK), for example in a board overlay.
+# default to placeholders and must be set to the router in use, at runtime
+# through esp_wifi_mesh_set_config() (see esp_wifi_mesh.h), before calling
+# esp_wifi_mesh_start().
 
 CONFIG_NETWORKING=y
 CONFIG_NET_L2_ETHERNET=y

--- a/samples/boards/espressif/wifi_mesh_ip/src/main.c
+++ b/samples/boards/espressif/wifi_mesh_ip/src/main.c
@@ -84,11 +84,33 @@ int main(void)
 
 	esp_wifi_mesh_event_cb_register(mesh_event);
 
+	/*
+	 * Mesh credentials and tree limits are runtime-configurable; set them
+	 * here before esp_wifi_mesh_start() rather than through Kconfig. These
+	 * values match the driver's built-in defaults: replace them with your
+	 * router's credentials and a mesh ID unique to your network.
+	 */
+	struct esp_wifi_mesh_config mesh_cfg = {
+		.ssid = "myssid",
+		.password = "mypassword",
+		.mesh_password = "meshpassword",
+		.channel = 0,
+		.mesh_id = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
+		.authmode = WIFI_SECURITY_TYPE_PSK,
+		.num_layers = CONFIG_WIFI_ESP32_MESH_MAX_LAYER,
+		.max_connections = CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS,
+	};
+
+	if (esp_wifi_mesh_set_config(&mesh_cfg) != 0) {
+		LOG_ERR("invalid mesh configuration");
+		return -EINVAL;
+	}
+
 	if (esp_wifi_mesh_start() != 0) {
 		LOG_ERR("Wi-Fi mesh start failed");
 		return -EIO;
 	}
 
-	LOG_INF("Wi-Fi mesh starting");
+	LOG_INF("Wi-Fi mesh starting (router SSID \"%s\")", mesh_cfg.ssid);
 	return 0;
 }


### PR DESCRIPTION
# Make Wi-Fi mesh SSID/password and tree limits runtime-configurable

Improves the Wi-Fi mesh API for Espressif devices by moving mesh configuration (router SSID/password, mesh password, channel, mesh ID, auth mode, layer/connection limits) from Kconfig to a runtime call, `esp_wifi_mesh_set_config()`, invoked before `esp_wifi_mesh_start()`.

## Motivation
- **Consistency with the existing Wi-Fi stack.** Zephyr's ordinary Wi-Fi API already lets applications set SSID/credentials at runtime; the mesh API should follow the same pattern rather than forcing a rebuild for every network change.
- **Provisioning flows.** Credentials frequently need to come from a runtime source rather than being known at compile time — that's only possible if the mesh stack accepts them after boot.

## Changes
- Added `esp_wifi_mesh_set_config()` for runtime SSID/password/mesh_password/
  channel/mesh_id/authmode/layer limits.
- Updated `wifi_mesh` and `wifi_mesh_ip` samples to call it before
  `esp_wifi_mesh_start()`, using placeholder credentials (`myssid`/`mypassword`)
  documented in each sample's README.
