### PR TITLE
kernel: timeout: fix wheel hang with distant timeouts on nRF

### DIFF
--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -586,9 +586,13 @@ static int sys_clock_driver_init(void)
 				       sys_clock_timeout_handler, NULL);
 
 	int_mask = NRFX_GRTC_CONFIG_ALLOWED_CC_CHANNELS_MASK;
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		system_timeout_set_relative(CYC_PER_TICK);
-	}
+	/*
+	 * Always arm a first compare. Tickless used to skip this and wait for
+	 * sys_clock_set_timeout(), but the kernel only calls that when insert
+	 * reports a new soon-list head. An empty soon side never does, so
+	 * announce never started (SysTick enables TICKINT at init instead).
+	 */
+	system_timeout_set_relative(CYC_PER_TICK);
 
 	return 0;
 }


### PR DESCRIPTION
This is with reference to issue #117990.

`kernel.timer.timeout_pending.wheel` hangs on nRF54 (nrf54h20, nrf54l15, nrf54lm20) 

Tickless GRTC skipped the first compare and waited for sys_clock_set_timeout(). The kernel only calls that when insert reports a new soon-list head. Wheel timeouts past the later window never do, so announce never starts and k_sleep latches.

The !TICKLESS guard was the old split, a tickful driver must fire from boot because set_timeout is a no-op, while tickless assumed the kernel would program the first real deadline. That first call never comes if soon stays empty, so drop the guard and always arm one tick at init, matching SysTick and timer_core_init(). The ISR still only re-arms itself when TICKLESS=n.

verified on nRF54L15 DK
