### PR TITLE
soc: nxp: rw: guard RTC wakeup count calls

### DIFF
--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -297,6 +297,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 					k_spinlock_key_t key = sys_clock_lock();
 
 					sys_clock_set_timeout(0, true);
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby))
 					/* Subtract exit-latency from the programmed
 					 * RTC wakeup to account for PM3 re-entry
 					 * recovery overhead.
@@ -308,6 +309,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 					if (wake > latency_ticks) {
 						RTC_SetWakeupCount(RTC, wake - latency_ticks);
 					}
+#endif
 					sys_clock_unlock(key);
 				}
 				/* GDET got enabled when exiting PM3, disable it


### PR DESCRIPTION
RTC_GetWakeupCount() and RTC_SetWakeupCount() are declared in fsl_rtc.h, which power.c only includes when the standby DT node is enabled. The calls in the PM_STATE_STANDBY case were not guarded by the same condition, so any build without the standby node compiled them with no declaration in scope, producing "implicit declaration of function" errors.

Wrap the wakeup-count adjustment in the same standby guard used for the fsl_rtc.h include and the RTC_ClearStatusFlags() call, so the RTC symbols are only referenced when the header is present. This fixes the build for frdm_rw612 and rd_rw612_bga targets that do not enable the standby node.

Fixes: #117797