### PR TITLE
dfu: img_util: flash_img: Allow non-secure slot upload

### DIFF
--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -29,8 +29,10 @@ LOG_MODULE_REGISTER(flash_img, CONFIG_IMG_MANAGER_LOG_LEVEL);
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && (CONFIG_TFM_MCUBOOT_IMAGE_NUMBER == 2)
 #define UPLOAD_FLASH_AREA_LABEL slot1_ns_partition
 #else
-#if PARTITION_EXISTS(slot1_partition) && \
-	PARTITION_IS_RUNNING_APP_PARTITION(slot0_partition)
+#if (PARTITION_EXISTS(slot1_partition) && \
+	(PARTITION_IS_RUNNING_APP_PARTITION(slot0_partition) || \
+	(PARTITION_EXISTS(slot0_ns_partition) && \
+	PARTITION_IS_RUNNING_APP_PARTITION(slot0_ns_partition))))
 #define UPLOAD_FLASH_AREA_LABEL slot1_partition
 #else
 #define UPLOAD_FLASH_AREA_LABEL slot0_partition


### PR DESCRIPTION
Allows uploading to slot1_partition when there is a non-secure image running that is not built to support split updated

Fixes #117802