### PR TITLE
net: sockets: packet: correct dependency for NET_NATIVE

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -40,9 +40,9 @@ config NET_NATIVE
 	bool "Native network stack support"
 	default y
 	help
-	  Enables Zephyr native IP stack. If you disable this, then
+	  Enables Zephyr native networking stack. If you disable this, then
 	  you need to enable the offloading support if you want to
-	  have IP connectivity.
+	  have connectivity.
 
 # Hidden options for enabling native IPv6/IPv4. Using these options
 # avoids having "defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_NATIVE)"

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -364,6 +364,7 @@ config NET_SOCKETS_OFFLOAD_DISPATCHER_CONTEXT_MAX
 
 config NET_SOCKETS_PACKET
 	bool "Packet socket support"
+	depends on NET_NATIVE
 	select NET_CONNECTION_SOCKETS
 	help
 	  This is an initial version of packet socket support (special type
@@ -386,7 +387,7 @@ config NET_SOCKETS_PACKET_DGRAM
 
 config NET_SOCKETS_PACKET_MCAST_MEMBERSHIP
 	bool "Packet socket multicast membership support"
-	depends on NET_SOCKETS_PACKET && NET_NATIVE && NET_L2_ETHERNET
+	depends on NET_SOCKETS_PACKET && NET_L2_ETHERNET
 	help
 	  Add support for ZSOCK_PACKET_ADD_MEMBERSHIP and ZSOCK_PACKET_DROP_MEMBERSHIP
 	  socket options for AF_PACKET sockets. The options operate at layer 2 and tell


### PR DESCRIPTION
Move dependency of NET_SOCKETS_PACKET_MCAST_MEMBERSHIP for NET_NATIVE to NET_SOCKETS_PACKET