### PR TITLE
twister: build the neutral job client off Linux

### DIFF
--- a/scripts/pylib/twister/twisterlib/jobserver.py
+++ b/scripts/pylib/twister/twisterlib/jobserver.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Module for job counters, limiting the amount of concurrent executions."""
 
-import fcntl
 import functools
 import logging
 import multiprocessing
@@ -12,6 +11,14 @@ import select
 import selectors
 import subprocess
 import sys
+
+# GNU Make's job server speaks over a POSIX pipe, so fcntl is needed only by
+# the two clients that drive it. JobHandle and JobClient use nothing from it,
+# which is what lets this module import on Windows, the one platform that
+# does not ship fcntl. Keyed on os.name, not sys.platform: macOS and the
+# BSDs are POSIX and do have it, and GNUMakeJobClient uses it there.
+if os.name == 'posix':
+    import fcntl
 
 logger = logging.getLogger('twister')
 
@@ -57,10 +64,21 @@ class JobClient:
         Returns:
             A Popen object.
         """
-        kwargs.setdefault("env", os.environ)
-        kwargs.setdefault("pass_fds", [])
-        kwargs["env"].update(self.env())
-        kwargs["pass_fds"] += self.pass_fds()
+        # Only touched when there is something to share. The base client has
+        # nothing, and off Linux it is the only one built: naming env and
+        # pass_fds anyway would hand the child os.environ instead of the
+        # inherited block, which on Windows is not the same environment --
+        # os.environ upper-cases its keys there, so ProgramFiles(x86)
+        # reaches the child as PROGRAMFILES(X86).
+        env = self.env()
+        if env:
+            kwargs.setdefault("env", os.environ)
+            kwargs["env"].update(env)
+
+        pass_fds = self.pass_fds()
+        if pass_fds:
+            kwargs.setdefault("pass_fds", [])
+            kwargs["pass_fds"] += pass_fds
 
         return subprocess.Popen(argv, **kwargs)
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -47,9 +47,13 @@ from twisterlib.statuses import TwisterStatus
 if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
-# Job server only works on Linux for now.
+# Only GNU Make's job server is Linux-only. JobClient is the neutral client --
+# unlimited jobs, plain subprocess.Popen -- and is what every other platform
+# gets, so it is imported everywhere.
+from twisterlib.jobserver import JobClient
+
 if sys.platform == 'linux':
-    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
+    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer
 
 from domains import Domains
 from twisterlib.coverage import run_coverage_instance
@@ -307,10 +311,7 @@ class CMake:
             kwargs['cwd'] = self.cwd
 
         start_time = time.time()
-        if sys.platform == 'linux':
-            p = self.jobserver.popen(cmd, **kwargs)
-        else:
-            p = subprocess.Popen(cmd, **kwargs)
+        p = self.jobserver.popen(cmd, **kwargs)
         logger.debug(f'Running {" ".join(cmd)}')
 
         out, _ = p.communicate()
@@ -491,10 +492,7 @@ class CMake:
             kwargs['cwd'] = self.cwd
 
         start_time = time.time()
-        if sys.platform == 'linux':
-            p = self.jobserver.popen(cmd, **kwargs)
-        else:
-            p = subprocess.Popen(cmd, **kwargs)
+        p = self.jobserver.popen(cmd, **kwargs)
         out, _ = p.communicate()
 
         duration = time.time() - start_time
@@ -1998,18 +1996,19 @@ class TwisterRunner:
         else:
             self.jobs = mp.cpu_count()
 
+        # sys.platform == 'linux' already implies os.name == 'posix', so the
+        # platform is the whole decision: GNU Make's job server there, the
+        # neutral client everywhere else.
         if sys.platform == "linux":
-            if os.name == 'posix':
-                self.jobserver = GNUMakeJobClient.from_environ(jobs=self.options.jobs)
-                if not self.jobserver:
-                    self.jobserver = GNUMakeJobServer(self.jobs)
-                elif self.jobserver.jobs:
-                    self.jobs = self.jobserver.jobs
-            # TODO: Implement this on windows/mac also
-            else:
-                self.jobserver = JobClient()
+            self.jobserver = GNUMakeJobClient.from_environ(jobs=self.options.jobs)
+            if not self.jobserver:
+                self.jobserver = GNUMakeJobServer(self.jobs)
+            elif self.jobserver.jobs:
+                self.jobs = self.jobserver.jobs
+        else:
+            self.jobserver = JobClient()
 
-            logger.info(f"JOBS: {self.jobs}")
+        logger.info(f"JOBS: {self.jobs}")
 
         self.update_counting_before_pipeline()
 
@@ -2192,10 +2191,7 @@ class TwisterRunner:
     def pipeline_mgr(self, processing_queue: deque, processing_ready: dict[str, TestInstance],
                      lock, results: ExecutionCounter):
         try:
-            if sys.platform == 'linux':
-                with self.jobserver.get_job():
-                    return self.process_tasks(processing_queue, processing_ready, lock, results)
-            else:
+            with self.jobserver.get_job():
                 return self.process_tasks(processing_queue, processing_ready, lock, results)
         except Exception as e:
             logger.error(f"General exception: {e}\n{traceback.format_exc()}")

--- a/scripts/tests/twister/test_jobserver.py
+++ b/scripts/tests/twister/test_jobserver.py
@@ -7,6 +7,7 @@ Tests for jobserver.py classes' methods
 """
 
 import functools
+import importlib.util
 import os
 import sys
 from contextlib import nullcontext
@@ -15,13 +16,20 @@ from selectors import EVENT_READ
 from unittest import mock
 
 import pytest
+from twisterlib import jobserver
+from twisterlib.jobserver import JobClient, JobHandle
 
-# Job server only works on Linux for now.
-pytestmark = pytest.mark.skipif(sys.platform != 'linux', reason='JobServer only works on Linux.')
+# Only GNU Make's job server is Linux-only. JobHandle and JobClient are not,
+# and runner.py hands JobClient to every other platform, so the tests for
+# those two need to run there as well.
+linux_only = pytest.mark.skipif(
+    sys.platform != 'linux', reason='GNU Make job server only works on Linux.'
+)
+
 if sys.platform == 'linux':
     from fcntl import F_GETFL
 
-    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient, JobHandle
+    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer
 
 
 def test_jobhandle(capfd):
@@ -63,7 +71,7 @@ def test_jobclient_pass_fds():
 
 
 TESTDATA_1 = [
-    ({}, {'env': {'k': 'v'}, 'pass_fds': []}),
+    ({}, {}),
     ({'env': {}, 'pass_fds': ['fd']}, {'env': {}, 'pass_fds': ['fd']}),
 ]
 
@@ -88,6 +96,73 @@ def test_jobclient_popen(kwargs, expected_kwargs):
     assert proc == proc_mock
 
 
+def _reimport_jobserver():
+    # A fresh module object built from the same source, so the import-time
+    # guard runs again under whatever the caller is patching. Reloading the
+    # installed module would hand back the one this file already imported.
+    spec = importlib.util.spec_from_file_location(
+        'jobserver_reimport', jobserver.__file__
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def test_jobserver_module_imports_where_fcntl_does_not_exist():
+    # Windows is the one platform without fcntl, and this module has to
+    # import there. Blocking the name in sys.modules is what makes
+    # `import fcntl` raise on a host that has it, so what is under test is
+    # the guard and not the platform the suite happens to run on.
+    with mock.patch.object(os, 'name', 'nt'), \
+         mock.patch.dict(sys.modules, {'fcntl': None}):
+        module = _reimport_jobserver()
+
+    assert not hasattr(module, 'fcntl')
+    assert module.JobClient().get_job() is not None
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec('fcntl') is None,
+    reason='the host has no fcntl for the guard to keep'
+)
+def test_jobserver_module_keeps_fcntl_on_posix():
+    # macOS and the BSDs are POSIX and do ship fcntl, and
+    # GNUMakeJobClient.from_environ() calls fcntl.fcntl(), so a guard keyed
+    # on Linux alone leaves it raising NameError on those hosts.
+    with mock.patch.object(os, 'name', 'posix'), \
+         mock.patch.object(sys, 'platform', 'darwin'):
+        module = _reimport_jobserver()
+
+    assert hasattr(module, 'fcntl')
+
+
+def test_jobclient_popen_shares_what_it_has():
+    # The base client has nothing to share, but a client that does still has
+    # to name env and pass_fds -- that is the half GNUMakeJobClient relies
+    # on, and it is the same code path.
+    class SharingJobClient(JobClient):
+        @staticmethod
+        def env():
+            return {'MAKEFLAGS': '-j2'}
+
+        @staticmethod
+        def pass_fds():
+            return [7]
+
+    argv = ['cmd']
+    popen_mock = mock.Mock()
+    env_mock = {'k': 'v'}
+
+    with mock.patch('subprocess.Popen', popen_mock), \
+         mock.patch('os.environ', env_mock):
+        SharingJobClient().popen(argv)
+
+    popen_mock.assert_called_once_with(
+        argv, env={'k': 'v', 'MAKEFLAGS': '-j2'}, pass_fds=[7]
+    )
+
+
 TESTDATA_2 = [
     (False, 0),
     (True, 0),
@@ -101,6 +176,7 @@ TESTDATA_2 = [
     ids=['no inheritable, no internal', 'inheritable, no internal',
          'no inheritable, internal', 'inheritable, internal']
 )
+@linux_only
 def test_gnumakejobclient_dunders(inheritable, internal_jobs):
     inherit_read_fd = mock.Mock()
     inherit_write_fd = mock.Mock()
@@ -227,6 +303,7 @@ TESTDATA_3 = [
          'env, no jobs, oserror', 'env, no jobs, wrong read pipe',
          'env, no jobs, wrong write pipe', 'environ, no makeflags']
 )
+@linux_only
 def test_gnumakejobclient_from_environ(
     caplog,
     env,
@@ -282,6 +359,7 @@ def test_gnumakejobclient_from_environ(
 
 
 
+@linux_only
 def test_gnumakejobclient_get_job():
     inherit_read_fd = mock.Mock()
     inherit_write_fd = mock.Mock()
@@ -353,6 +431,7 @@ TESTDATA_4 = [
     ids=['preexisting makeflags', 'no jobs, no pipe', 'one job',
          ' multiple jobs', 'no jobs']
 )
+@linux_only
 def test_gnumakejobclient_env(
     makeflags,
     jobs,
@@ -393,6 +472,7 @@ TESTDATA_5 = [
     TESTDATA_5,
     ids=['no pipe', 'one job', ' multiple jobs', 'no jobs']
 )
+@linux_only
 def test_gnumakejobclient_pass_fds(jobs, use_inheritable_pipe, expected_fds):
     inheritable_pipe = (0, 1) if use_inheritable_pipe else None
 
@@ -427,6 +507,7 @@ TESTDATA_6 = [
     TESTDATA_6,
     ids=['no jobs', 'too many jobs', 'valid jobs']
 )
+@linux_only
 def test_gnumakejobserver(jobs, expected_jobs):
     def mock_init(self, p, j):
         self._inheritable_pipe = p

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -22,6 +22,7 @@ import yaml
 from elftools.elf.sections import SymbolTableSection
 from twisterlib.error import BuildError
 from twisterlib.harness import Pytest
+from twisterlib.jobserver import JobClient
 from twisterlib.runner import CMake, ExecutionCounter, FilterBuilder, ProjectBuilder, TwisterRunner
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuitedata import HarnessConfig
@@ -253,7 +254,7 @@ def test_cmake_parse_generated(mocked_jobserver):
 
 TESTDATA_1_1 = [
     ('linux'),
-    ('nt')
+    ('win32')
 ]
 TESTDATA_1_2 = [
     (0, False, 'dummy out',
@@ -341,14 +342,15 @@ def test_cmake_run_build(
 
     assert expected_results == result
 
-    popen_caller = cmake.jobserver.popen if sys_platform == 'linux' else \
-                   popen_mock
-    popen_caller.assert_called_once_with(
+    # The job server is set on every platform, so run_build goes through it
+    # rather than choosing by platform, and both rows make the same call.
+    cmake.jobserver.popen.assert_called_once_with(
         [os.path.join('dummy', 'cmake'), 'arg1', 'arg2'],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         cwd=os.path.join('dummy', 'working', 'dir')
     )
+    popen_mock.assert_not_called()
 
     assert cmake.instance.status == expected_status
     assert cmake.instance.reason == expected_reason
@@ -364,7 +366,7 @@ def test_cmake_run_build(
 
 TESTDATA_2_1 = [
     ('linux'),
-    ('nt')
+    ('win32')
 ]
 TESTDATA_2_2 = [
     (True, ['dummy_stage_1', 'ds2'],
@@ -492,14 +494,15 @@ def test_cmake_run_cmake(
 
     assert expected_results == result
 
-    popen_caller = cmake.jobserver.popen if sys_platform == 'linux' else \
-                   popen_mock
-    popen_caller.assert_called_once_with(
+    # The job server is set on every platform, so run_cmake goes through it
+    # rather than choosing by platform, and both rows make the same call.
+    cmake.jobserver.popen.assert_called_once_with(
         expected_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         cwd=os.path.join('dummy', 'working', 'dir')
     )
+    popen_mock.assert_not_called()
 
     assert cmake.instance.status == expected_status
     assert cmake.instance.reason == expected_reason
@@ -2903,15 +2906,18 @@ def test_projectbuilder_calc_size(
         assert instance_mock.metrics == {}
 
 
+# The rows vary sys.platform alone: it is the whole decision, since
+# sys.platform == 'linux' implies os.name == 'posix'. So the two rows that
+# reach the neutral client name the platforms it is chosen for.
 TESTDATA_17 = [
-    ('linux', 'posix', {'jobs': 4}, True, 32, 'GNUMakeJobClient'),
-    ('linux', 'posix', {'build_only': True}, False, 16, 'GNUMakeJobServer'),
-    ('linux', '???', {}, False, 8, 'JobClient'),
-    ('linux', '???', {'jobs': 4}, False, 4, 'JobClient'),
+    ('linux', {'jobs': 4}, True, 32, 'GNUMakeJobClient'),
+    ('linux', {'build_only': True}, False, 16, 'GNUMakeJobServer'),
+    ('win32', {}, False, 8, 'JobClient'),
+    ('darwin', {'jobs': 4}, False, 4, 'JobClient'),
 ]
 
 @pytest.mark.parametrize(
-    'platform, os_name, options, jobclient_from_environ, expected_jobs,' \
+    'platform, options, jobclient_from_environ, expected_jobs,' \
     ' expected_jobserver',
     TESTDATA_17,
     ids=['GNUMakeJobClient', 'GNUMakeJobServer',
@@ -2920,7 +2926,6 @@ TESTDATA_17 = [
 def test_twisterrunner_run(
     caplog,
     platform,
-    os_name,
     options,
     jobclient_from_environ,
     expected_jobs,
@@ -2987,8 +2992,7 @@ def test_twisterrunner_run(
          mock.patch('twisterlib.runner.JobClient', jobclient_mock), \
          mock.patch('multiprocessing.cpu_count', return_value=8), \
          mock.patch('sys.platform', platform), \
-         mock.patch('time.sleep', mock.Mock()), \
-         mock.patch('os.name', os_name):
+         mock.patch('time.sleep', mock.Mock()):
         tr.run()
 
     assert f'JOBS: {expected_jobs}' in caplog.text
@@ -3001,6 +3005,61 @@ def test_twisterrunner_run(
     }
 
     assert results_mock().error == 0
+
+
+@pytest.mark.parametrize('platform', ['win32', 'darwin'], ids=['windows', 'macos'])
+def test_twisterrunner_run_builds_a_real_jobserver_off_linux(platform):
+    """Off Linux, run() has to leave a job server the pipeline can use.
+
+    The two JobClient rows of TESTDATA_17 put a mock in its place, so they
+    cannot say whether the real one answers what pipeline_mgr and the build
+    steps ask of it. This builds the real one -- and patches none of the
+    GNUMake* names, which exist only on Linux, so it runs on every host.
+    """
+    tr = TwisterRunner({'dummy instance': mock.Mock(metrics={'k': 'v'})},
+                       [mock.Mock()], env=mock.Mock())
+    tr.options.retry_failed = 0
+    tr.options.retry_interval = 0
+    tr.options.retry_build_errors = False
+    tr.options.jobs = None
+    tr.options.build_only = None
+    tr.update_counting_before_pipeline = mock.Mock()
+    tr.execute = mock.Mock()
+    tr.show_brief = mock.Mock()
+
+    manager_mock = mock.Mock()
+    manager_mock().deque = mock.Mock(return_value=deque())
+    manager_mock().get_dict = mock.Mock(return_value={})
+
+    results_mock = mock.Mock()
+    results_mock().iteration = 0
+    results_mock().failed = 0
+    results_mock().error = 0
+    results_mock().total = 1
+    results_mock().filtered_static = 0
+    results_mock().skipped = 0
+
+    def iteration_increment(value=1, decrement=False):
+        results_mock().iteration += value * (-1 if decrement else 1)
+    results_mock().iteration_increment = iteration_increment
+
+    with mock.patch('twisterlib.runner.ExecutionCounter', results_mock), \
+         mock.patch('twisterlib.runner.BaseManager', manager_mock), \
+         mock.patch('multiprocessing.cpu_count', return_value=8), \
+         mock.patch('sys.platform', platform), \
+         mock.patch('time.sleep', mock.Mock()):
+        tr.run()
+
+    # The exact class, not isinstance: GNUMakeJobClient and
+    # GNUMakeJobServer both inherit from JobClient, so isinstance would
+    # accept the two this row is meant to rule out.
+    assert tr.jobserver.__class__ is JobClient
+
+    # What pipeline_mgr wraps every task in: a claim with nothing to release.
+    with tr.jobserver.get_job():
+        pass
+    assert tr.jobserver.env() == {}
+    assert tr.jobserver.pass_fds() == []
 
 
 def test_twisterrunner_update_counting_before_pipeline():
@@ -3205,7 +3264,7 @@ def test_twisterrunner_add_tasks_to_queue(
 
 TESTDATA_19 = [
     ('linux'),
-    ('nt')
+    ('win32')
 ]
 
 @pytest.mark.parametrize(
@@ -3245,8 +3304,9 @@ def test_twisterrunner_pipeline_mgr(mocked_jobserver, platform):
 
     assert len(pb().process.call_args_list) == 5
 
-    if platform == 'linux':
-        tr.jobserver.get_job.assert_called_once()
+    # The job server is set on every platform, so pipeline_mgr always claims
+    # a job: there is no bare-call path for it to take instead.
+    tr.jobserver.get_job.assert_called_once()
 
 
 def test_twisterrunner_execute(caplog):


### PR DESCRIPTION
## What

`TwisterRunner.run()` picks a job server in a block whose fallback cannot be reached:

```python
if sys.platform == "linux":
    if os.name == 'posix':
        self.jobserver = GNUMakeJobClient.from_environ(...)
        ...
    # TODO: Implement this on windows/mac also
    else:
        self.jobserver = JobClient()
```

In CPython `sys.platform == 'linux'` implies `os.name == 'posix'`, so that `else` cannot run on any platform, and `self.jobserver` stays `None` everywhere but Linux.

**Nothing is broken today.** Each of the three places that would use it tests the platform itself and falls back to `subprocess.Popen`:

| `runner.py` | when linux | else |
|---|---|---|
| 310 | `p = self.jobserver.popen(cmd, **kwargs)` | `p = subprocess.Popen(cmd, **kwargs)` |
| 494 | `p = self.jobserver.popen(cmd, **kwargs)` | `p = subprocess.Popen(cmd, **kwargs)` |
| 2195 | `with self.jobserver.get_job(): return self.process_tasks(...)` | `return self.process_tasks(...)` |

So this is not a bug report. It is three copies of one decision, kept alive by a fallback that is never built.

`JobClient` is nearly that fallback already: `get_job()` returns a `JobHandle(None)` whose `__enter__`/`__exit__` do nothing.

`popen()` was not neutral, though. It named `env` and `pass_fds` unconditionally, so routing the non-Linux calls through it would have handed the child `os.environ` in place of the block it inherits. Those are not the same environment on Windows, where `os.environ` upper-cases its keys — measured on a Windows host, twelve names change:

```
inherited       ProgramFiles(x86)  ProgramData  PSModulePath   ...
env=os.environ  PROGRAMFILES(X86)  PROGRAMDATA  PSMODULEPATH   ...
```

`popen()` now adds each only when the client has something to share. That leaves `GNUMakeJobClient` exactly as it was — its `env()` and `pass_fds()` are non-empty — and makes the base client the plain `subprocess.Popen` its docstring describes. With that, assigning `JobClient` in the `else` lets all three sites drop their platform test.

`jobserver.py` had to make `fcntl` conditional as well. Only `GNUMakeJobClient` uses it (lines 150, 158), and importing it at module scope is what kept the module — and with it `JobClient` — unimportable on Windows. The guard reads `os.name` rather than `sys.platform`, because **Windows is the only platform without `fcntl`**: macOS and the BSDs are POSIX and do ship it, and `GNUMakeJobClient.from_environ()` calls `fcntl.fcntl()`, so a guard naming Linux alone would leave it raising `NameError` there.

`JOBS: n` was logged inside the platform branch, so only Linux reported it. It now sits with the rest of the job counting.

## Tests

- `TESTDATA_17`'s two `JobClient` rows passed `os_name='???'`, a value `os.name` cannot hold. They had to, to reach the fallback — the suite was documenting the unreachability. They now name `win32` and `darwin`, and the `os_name` parameter goes with the branch that read it.
- `test_cmake_run_build` / `test_cmake_run_cmake` chose between `cmake.jobserver.popen` and `subprocess.Popen` by platform. Both rows now assert the same job server call **and** that `subprocess.Popen` is not called at all.
- `test_jobserver.py` skipped its whole file off Linux, including the five tests for `JobHandle` and `JobClient`, which need nothing from GNU Make. The skip now covers only the `GNUMake*` tests. CI runs this suite on ubuntu alone, so what that buys is a developer running it on their own macOS or Windows machine — the three tests below are what cover the off-Linux paths on every host.
- `test_twisterrunner_pipeline_mgr` asserted the job had been claimed only when `platform == 'linux'`. That assertion is unconditional now, and covers the third site.
- One new test drives `run()` to the fallback and checks the real client answers what `pipeline_mgr` asks of it. It patches no `GNUMake*` name, so it runs on every host, and it pins the exact class — `GNUMakeJobClient` and `GNUMakeJobServer` both inherit from `JobClient`, so `isinstance` would accept the two the row is meant to rule out.
- Three more cover what the module does at import: one re-imports it with `os.name` as `'nt'` and `fcntl` blocked in `sys.modules`, one re-imports it as POSIX and asserts `fcntl` is still bound, and one hands a client something to share and asserts `popen()` still names `env` and `pass_fds`. Patching `sys.platform` cannot reach any of that, because the import has already happened by then.

## Verification

Run on Linux (Ubuntu, the platform `twister_tests.yml` uses) and on Windows.

| | before | after |
|---|---|---|
| Linux, `scripts/tests/twister/` | 872 passed, 0 failed | **877 passed, 0 failed** |
| Windows, `scripts/tests/twister/` | 56 failed / 785 passed / 30 skipped | 56 failed / **795** passed / **25** skipped |

The Windows failures are the pre-existing path-separator ones, unchanged and identical in set; `twister_tests.yml` runs on `ubuntu-24.04` only.

Each of the three changed lines was mutated back and the suite re-run:

| mutation | result |
|---|---|
| guard `os.name == 'posix'` → `sys.platform == 'linux'` | 2 failed |
| guard removed, `import fcntl` unconditional | module unimportable, collection error |
| `popen()` names `env`/`pass_fds` unconditionally again | 1 failed |

`ruff check`, `ruff format --diff` and `pylint --rcfile=scripts/ci/pylintrc` are clean on every changed file.

## Notes

Behaviour on Linux is unchanged: the `sys.platform == 'linux'` path is byte-for-byte the same work, and `GNUMakeJobClient` still shares what it shared.

`JobClient` is stateless, so it pickles into the worker processes on spawn platforms exactly as the previous `None` did.
