### PR TITLE
stm32: samples: mspi: mspi_flash: fix build errors on stm32l562e_dk

### DIFF
--- a/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.overlay
@@ -35,7 +35,7 @@
 			status = "okay";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "mxicy,mx25u", "jedec,nor";
+				compatible = "st,nor", "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Megabits */
 				mspi-max-frequency = <DT_FREQ_M(50)>;
@@ -47,6 +47,7 @@
 				write-command = <0x12ed>; /* WRite 4Bytes */
 				rx-dummy = <20>;
 				jedec-id = [c2 85 3a];
+				st,mem-type = "macronix";
 				status = "okay";
 
 				partitions {


### PR DESCRIPTION
This PR fixes two independent build errors in the `mspi_flash` sample for STM32 boards.


-  stm32l562e_dk: static assertion failure on missing `st,nor` compatible
     
     To reproduce : 
     
     `west build -p -b stm32l562e_dk samples/drivers/mspi/mspi_flash -T sample.drivers.mspi.flash`
     
           
      
       zephyrproject/zephyr/include/zephyr/toolchain/gcc.h:87:36: error: static assertion failed: "MSPI controller 
       must have a child with compatible st,nor/st,psram-device"      
