### PR TITLE
stm32: drivers: usb_c: tcpc:  select GPIO for STM32 TCPC driver

### DIFF
--- a/drivers/usb_c/tcpc/Kconfig.tcpc_stm32
+++ b/drivers/usb_c/tcpc/Kconfig.tcpc_stm32
@@ -8,6 +8,7 @@ config USBC_TCPC_STM32
 	default y
 	depends on DT_HAS_ST_STM32_UCPD_ENABLED
 	select PINCTRL
+	select GPIO
 	help
 	  Enable USB-C TCPC support on the STM32 G0, G4, L5, and U5 family of
 	  processors.


### PR DESCRIPTION
This PR addresses a build issue encountered in the following sample: `samples/subsys/usb_c/sink`, on the `stm32g081b_eval/stm32g081xx` platform.

To reproduce :

`west build -p -b stm32g081b_eval/stm32g081xx samples/subsys/usb_c/sink -T sample.usbc.sink -- -DZEPHYR_SCA_VARIANT=dtdoctor`

```
undefined reference to `__device_dts_ord_53'
collect2: error: ld returned 1 exit status
+--------------------------------------------------------------------------------------------------------------+
| DT Doctor                                                                                                    |
+==============================================================================================================+
| 'gpiob: /soc/pin-controller@50000000/gpio@50000400' is enabled but no driver appears to be available for it. |
|                                                                                                              |
| Try enabling these Kconfig options:                                                                          |
|                                                                                                              |
|  - CONFIG_DT_HAS_ST_STM32F1_PINCTRL_ENABLED=y                                                                |
|  - CONFIG_DT_HAS_ST_STM32MP2_GPIO_ENABLED=y                                                                  |
|  - CONFIG_DT_HAS_ST_STM32_PINCTRL_ENABLED=y                                                                  |
|  - CONFIG_GPIO=y                                                                                             |
|  - CONFIG_PINCTRL=y                                                                                          |
+--------------------------------------------------------------------------------------------------------------+
```