### PR TITLE
stm32: drivers: hwinfo : add STM32WL33 UID handling

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -25,10 +25,11 @@
 #define STM32_UID_WORD_2 HAL_GetUIDw0()
 /* zephyr-keep-sorted-stop */
 
-#elif defined(CONFIG_SOC_SERIES_STM32WB0X)
+#elif defined(CONFIG_SOC_SERIES_STM32WB0X) || \
+	defined(CONFIG_SOC_SERIES_STM32WL3X)
 
 /*
- * The STM32WB0 series doesn't have the 96-bit UID.
+ * The STM32WB0 and STM32WL33 series don't have the 96-bit UID.
  * The LL_GetUID_WordN() API exists but returns the
  * value of UID64 instead, so there is no "Word2".
  */


### PR DESCRIPTION

This PR addresses a build issue encountered in the following test and samples: `tests/lib/fdtable` and `samples/subsys/portability/posix/*`, on the `nucleo_wl33cc1/stm32wl33xx` platform.

To reproduce :

`west build -p -b nucleo_wl33cc1/stm32wl33xx tests/lib/fdtable -T libraries.fdtable`


```
zephyrproject/zephyr/drivers/hwinfo/hwinfo_stm32.c:45:26: error: implicit declaration of function 'LL_GetUID_Word2'; did you mean 'LL_GetUID_Word1'? [-Wimplicit-function-declaration]
   45 | #define STM32_UID_WORD_0 LL_GetUID_Word2()
      |                          ^~~~~~~~~~~~~~~

```