### PR TITLE
scripts: twister: leave ccache alone for coverage builds

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1156,7 +1156,15 @@ class TwisterEnv:
         builds, and is limited to files generated into the build directory, as
         Zephyr refers to the rest by absolute path. Settings already in the
         environment win.
+
+        Coverage builds are left alone: ccache hashes the working directory
+        whenever it generates a .gcno file, so there is nothing to reuse, while
+        rewriting the paths would leave gcov unable to find the generated
+        headers.
         """
+        if self.options.enable_coverage:
+            return
+
         os.environ.setdefault("CCACHE_BASEDIR", self.outdir)
         if not {"CCACHE_HASHDIR", "CCACHE_NOHASHDIR"} & os.environ.keys():
             os.environ["CCACHE_NOHASHDIR"] = "true"

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -308,6 +308,38 @@ def test_twisterenv_init(options, expected_env):
     assert twister_env.outdir == expected_env.outdir
 
 
+# enable_coverage, environment beforehand, expected ccache environment afterwards
+TESTDATA_CCACHE = [
+    (False, {}, {'CCACHE_BASEDIR': 'foo', 'CCACHE_NOHASHDIR': 'true'}),
+    (False, {'CCACHE_BASEDIR': 'bar'}, {'CCACHE_BASEDIR': 'bar', 'CCACHE_NOHASHDIR': 'true'}),
+    (False, {'CCACHE_HASHDIR': 'true'}, {'CCACHE_BASEDIR': 'foo', 'CCACHE_HASHDIR': 'true'}),
+    (True, {}, {}),
+]
+
+
+@pytest.mark.parametrize(
+    'enable_coverage, preset_env, expected_env',
+    TESTDATA_CCACHE,
+    ids=[
+        'reuse objects',
+        'base directory already set',
+        'hash directory already set',
+        'coverage keeps the build directory paths'
+    ]
+)
+def test_twisterenv_setup_ccache(enable_coverage, preset_env, expected_env):
+    env = mock.Mock(
+        options=mock.Mock(enable_coverage=enable_coverage),
+        outdir='foo',
+    )
+
+    with mock.patch.dict(os.environ, preset_env, clear=True):
+        twisterlib.environment.TwisterEnv._setup_ccache(env)
+        ccache_env = {k: v for k, v in os.environ.items() if k.startswith('CCACHE_')}
+
+    assert ccache_env == expected_env
+
+
 def test_twisterenv_discover():
     options = mock.Mock(
         ninja=True


### PR DESCRIPTION
Fixes #117813

`west twister --coverage` has been failing with `ERROR - GCOVR failed with 64` since d33000ddf43a76a0d66dbc4226cfc6b131784486, which sets `CCACHE_BASEDIR`/`CCACHE_NOHASHDIR` so ccache can reuse objects between the per-test build directories.

### What breaks

`CCACHE_BASEDIR` rewrites absolute paths below the output directory into relative ones in the command line ccache *actually executes*, not just in the hash:

```
Executing /usr/bin/gcc -g --coverage -Igen -c /…/src/main.c -o main.o
```

So `-I<build>/zephyr/include/generated` is compiled as `-Izephyr/include/generated`, and the generated headers end up recorded in the `.gcno` relative to the build directory. gcovr resolves them from neither the object directory nor the source root:

```
Cannot open source file zephyr/include/generated/zephyr/syscalls/gpio.h
GCOVR could not infer a working directory that resolved it.
```

Zephyr's own sources are unaffected — they are absolute and outside `base_dir`, so ccache leaves them alone. Only files generated into the build directory are rewritten.

### Why skipping coverage builds costs nothing

**The optimization never applied to coverage runs in the first place**.

For coverage builds ccache adds two per-build-directory entries to the common hash: the absolute object file path and the absolute `.gcda` destination that GCC bakes into the object:

```
cCaChE.Absolute object file path.<…>/out/b1/main.o
cCaChE.gcda.<…>/out/b1/main.gcda
```

Neither is present for a non-coverage build. 

### Testing

New unit test covers the four cases of `TwisterEnv._setup_ccache()`: the variables it sets for a normal run, the two settings it leaves alone when they are already in the environment, and the coverage build it now skips. It patches `os.environ` for the duration so it neither depends on nor leaks ccache settings.

