### PR TITLE
boards: fix battery voltage divider adc unit on esp32-based boards

### DIFF
--- a/boards/ebyte/eora_hub_900tb/eora_hub_900tb_procpu.dts
+++ b/boards/ebyte/eora_hub_900tb/eora_hub_900tb_procpu.dts
@@ -57,7 +57,7 @@
 
 	vbatt {
 		compatible = "voltage-divider";
-		io-channels = <&adc1 0>;
+		io-channels = <&adc0 0>;
 		output-ohms = <100000>;
 		full-ohms = <(100000 + 390000)>;
 		power-domains = <&adc_ctrl>;
@@ -100,7 +100,7 @@
 	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
-&adc1 {
+&adc0 {
 	status = "okay";
 };
 

--- a/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_procpu.dts
+++ b/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_procpu.dts
@@ -60,7 +60,7 @@
 
 	vbatt {
 		compatible = "voltage-divider";
-		io-channels = <&adc1 0>;
+		io-channels = <&adc0 0>;
 		output-ohms = <100000>;
 		full-ohms = <(100000 + 390000)>;
 	};
@@ -90,7 +90,7 @@
 	};
 };
 
-&adc1 {
+&adc0 {
 	status = "okay";
 };
 

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
@@ -60,7 +60,7 @@
 
 	vbatt {
 		compatible = "voltage-divider";
-		io-channels = <&adc1 0>;
+		io-channels = <&adc0 0>;
 		output-ohms = <100000>;
 		full-ohms = <(100000 + 390000)>;
 	};
@@ -94,7 +94,7 @@
 	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
-&adc1 {
+&adc0 {
 	status = "okay";
 };
 

--- a/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker_procpu.dts
+++ b/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker_procpu.dts
@@ -46,7 +46,7 @@
 
 	vbatt {
 		compatible = "voltage-divider";
-		io-channels = <&adc1 0>;
+		io-channels = <&adc0 0>;
 		output-ohms = <100000>;
 		full-ohms = <(100000 + 390000)>;
 	};
@@ -101,7 +101,7 @@
 	};
 };
 
-&adc1 {
+&adc0 {
 	status = "okay";
 };
 

--- a/boards/solderedelectronics/inkplate_6color/inkplate_6color_procpu.dts
+++ b/boards/solderedelectronics/inkplate_6color/inkplate_6color_procpu.dts
@@ -55,7 +55,7 @@
 	vbatt: vbatt0 {
 		status = "okay";
 		compatible = "voltage-divider";
-		io-channels = <&adc1 7>;
+		io-channels = <&adc0 7>;
 		output-ohms = <100000>;
 		full-ohms = <(100000 + 100000)>;
 		power-gpios = <&pcal6416a 9 GPIO_ACTIVE_HIGH>;
@@ -63,7 +63,7 @@
 	};
 };
 
-&adc1 {
+&adc0 {
 	status = "okay";
 
 	#address-cells = <1>;


### PR DESCRIPTION
Five ESP32 based boards point their battery voltage divider at the adc1 devicetree node, which is ADC2, instead of adc0, which is ADC1. On the four ESP32-S3 LoRa boards (heltec_wireless_tracker, heltec_wifi_lora32_v3, heltec_wireless_stick_lite_v3, eora_hub_900tb) ADC2 channel 0 maps to GPIO11, the LoRa SPI MISO line, so setting up the battery channel disconnects that pad and every SPI read from the radio returns zeros. On inkplate_6color ADC2 channel 7 is GPIO27 while the battery sense is actually GPIO35 (ADC1 channel 7), and ADC2 is not usable while Wi-Fi is active anyway. The correct unit is confirmed by each board's documentation or vendor sources, and the existing divider ratios and enable GPIOs in the devicetrees already match the ADC1 wiring.

Fixes #117549