### PR TITLE
Allow multiple API configurations in the STM32 UART driver

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1465,7 +1465,9 @@ static void uart_stm32_isr(const struct device *dev)
 
 #ifdef CONFIG_UART_ASYNC_API
 		/* Prevent SoC from entering STOP mode until RX goes IDLE */
-		uart_stm32_rx_wakeup_lock_get(dev);
+		if (data->user_cb == NULL) {
+			uart_stm32_rx_wakeup_lock_get(dev);
+		}
 #endif
 
 #ifdef USART_ISR_REACK

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1551,15 +1551,19 @@ static int uart_stm32_async_callback_set(const struct device *dev,
 {
 	struct uart_stm32_data *data = dev->data;
 
-	data->async_cb = callback;
-	data->async_user_data = user_data;
-
+	if (data->dma_rx.dma_dev && data->dma_tx.dma_dev) { // Maybe we should use OR logic (more flexible)
+		data->async_cb = callback;
+		data->async_user_data = user_data;
+		
 #if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
-	data->user_cb = NULL;
-	data->user_data = NULL;
+		data->user_cb = NULL;
+		data->user_data = NULL;
 #endif
 
-	return 0;
+		return 0;
+	} else {
+		return -ENOSYS;
+	}
 }
 
 static inline void uart_stm32_dma_tx_enable(const struct device *dev)


### PR DESCRIPTION
Fixes #106927

- Support using multiple UART APIs simultaneously across different UART peripherals.
- Avoid acquiring the wakeup lock when the asynchronous API is enabled and the interrupt API is used on other UARTs.