### PR TITLE
drivers: sensor: shell: fix decimal parsing of attribute values

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -322,21 +322,38 @@ static int parse_sensor_value(const char *val_str, struct sensor_value *out)
 		return 0;
 	}
 
-	/* Parse the decimal portion */
-	value = strtoul(decimal_pos + 1, &endptr, 0);
-	if (*endptr != '\0') {
+	/* Parse the decimal portion into micro-units. The digits are accumulated one at a
+	 * time so that the leading zeros are kept: '.000001' is 1 micro-unit, not 1e5.
+	 */
+	const char *decimal_str = decimal_pos + 1;
+	int32_t micro = 0;
+	int digits = 0;
+
+	if (*decimal_str == '\0') {
 		return -EINVAL;
 	}
-	while (value < 100000) {
-		value *= 10;
+
+	for (; *decimal_str != '\0'; decimal_str++) {
+		if (!isdigit((unsigned char)*decimal_str)) {
+			return -EINVAL;
+		}
+		if (digits < 6) {
+			micro = (micro * 10) + (*decimal_str - '0');
+			digits++;
+		} else if (*decimal_str != '0') {
+			/* Finer than the micro-unit resolution of struct sensor_value */
+			return -EINVAL;
+		}
 	}
-	if (value > INT32_C(999999)) {
-		return -EINVAL;
+
+	/* Left align the digits that were given, so '.5' becomes 500000 */
+	while (digits < 6) {
+		micro *= 10;
+		digits++;
 	}
-	out->val2 = (int32_t)value;
-	if (is_negative) {
-		out->val2 *= -1;
-	}
+
+	out->val2 = is_negative ? -micro : micro;
+
 	return 0;
 }
 


### PR DESCRIPTION
parse_sensor_value() read the fractional part of a value with a single strtoul() and then multiplied it by 10 until it reached 100000. That discards the leading zeros, so '50.000001' and '50.1' both produced a val2 of 100000, and '50.005' produced 500000 instead of 5000.

That loop also never terminates when the fraction is all zeros, since multiplying 0 by 10 never reaches 100000, so 'attr_set <dev> <chan> sampling_frequency 50.0' hung the shell thread.

Parsing the fraction with base 0 was wrong as well: '50.08' was rejected as an invalid octal literal, '50.0x10' was silently accepted as hex, and strtoul() accepts a sign, so '50.-5' wrapped around to a large unsigned value.

Accumulate the fraction one digit at a time and scale it to micro-units based on the number of digits that were actually given, and reject anything that is not a decimal digit. Trailing zeros beyond six digits are accepted, while a fraction that genuinely needs finer than micro-unit resolution is still rejected.

Fixes: #116846