### PR TITLE
modules: hal_infineon: Include correct flash driver for CAT1C

### DIFF
--- a/modules/hal_infineon/mtb-pdl-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-pdl-cat1/CMakeLists.txt
@@ -48,6 +48,8 @@ zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SPI      ${pdl_drv_dir}/source/
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_TIMER    ${pdl_drv_dir}/source/cy_tcpwm_counter.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_UART     ${pdl_drv_dir}/source/cy_scb_uart.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_FLASH    ${pdl_drv_dir}/source/cy_flash.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_FLASH    ${pdl_drv_dir}/source/cy_flash_v2.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_FLASH    ${pdl_drv_dir}/source/cy_flash_srom.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_WDT      ${pdl_drv_dir}/source/cy_wdt.c)
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_LPCOMP   ${pdl_drv_dir}/source/cy_lpcomp.c)
 


### PR DESCRIPTION
Fixes the undefined reference to `Cy_Flash_IsOperationComplete  build failures which were identified in https://github.com/zephyrproject-rtos/zephyr/actions/runs/33287335774 