### PR TITLE
tests: fix tag values that twister cannot match

### DIFF
--- a/samples/boards/espressif/espnow/tests.yaml
+++ b/samples/boards/espressif/espnow/tests.yaml
@@ -9,4 +9,7 @@ tests:
     platform_allow:
       - esp32s3_devkitc/esp32s3/procpu
       - esp32c6_devkitc/esp32c6/hpcore
-    tags: esp32 espnow wifi
+    tags:
+      - esp32
+      - espnow
+      - wifi

--- a/samples/drivers/misc/tmc6460/tests.yaml
+++ b/samples/drivers/misc/tmc6460/tests.yaml
@@ -16,7 +16,9 @@ tests:
       - nucleo_f413zh
     filter: dt_compat_enabled("adi,tmc6460")
   sample.drivers.misc.tmc6460.uart:
-    tags: misc uart
+    tags:
+      - misc
+      - uart
     depends_on:
       - gpio
     platform_allow:

--- a/samples/drivers/stepper/generic/tests.yaml
+++ b/samples/drivers/stepper/generic/tests.yaml
@@ -5,7 +5,9 @@ tests:
     harness: stepper
     tags: stepper
     platform_allow: nucleo_g071rb
-    depends_on: gpio input
+    depends_on:
+      - gpio
+      - input
   sample.drivers.stepper.generic.h_bridge_4_click:
     build_only: true
     tags:

--- a/samples/drivers/stepper/tmcm3216/tests.yaml
+++ b/samples/drivers/stepper/tmcm3216/tests.yaml
@@ -5,4 +5,6 @@ tests:
     harness: stepper
     tags: stepper
     platform_allow: nucleo_u575zi_q
-    depends_on: serial gpio
+    depends_on:
+      - serial
+      - gpio

--- a/samples/sensor/max32664c/tests.yaml
+++ b/samples/sensor/max32664c/tests.yaml
@@ -9,7 +9,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - sensors
-      - heart rate
+      - heart_rate
     filter: dt_compat_enabled("maxim,max32664c")
     depends_on:
       - i2c

--- a/samples/subsys/debug/coredump_udp_demos/demo_shell/tests.yaml
+++ b/samples/subsys/debug/coredump_udp_demos/demo_shell/tests.yaml
@@ -5,6 +5,8 @@ tests:
   sample.debug.coredump_udp_demo_shell:
     build_only: true
     platform_allow: versalnet_apu
-    tags: debug coredump
+    tags:
+      - debug
+      - coredump
     extra_configs:
       - CONFIG_NET_NAMESPACE_COMPAT_MODE=n

--- a/samples/subsys/usb/cdc_acm_bridge/tests.yaml
+++ b/samples/subsys/usb/cdc_acm_bridge/tests.yaml
@@ -4,7 +4,9 @@ tests:
   sample.usb.cdc-acm-bridge.arduino_serial:
     tags: usb
     build_only: true
-    depends_on: usbd arduino_serial
+    depends_on:
+      - usbd
+      - arduino_serial
   sample.usb.cdc-acm-bridge.two_devices:
     tags: usb
     build_only: true

--- a/samples/subsys/usb_c/drp/tests.yaml
+++ b/samples/subsys/usb_c/drp/tests.yaml
@@ -3,7 +3,9 @@ sample:
 tests:
   sample.usbc.drp:
     depends_on: tcpc
-    tags: usbc drp
+    tags:
+      - usbc
+      - drp
     platform_allow: stm32g081b_eval
     harness: console
     harness_config:

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -94,6 +94,38 @@ class TwisterConfigParser:
         "sysbuild": {"type": "bool", "default": False}
     }
 
+    # Keys whose list/set members each name a single identifier: a tag, a
+    # platform, a board feature, a toolchain. Whitespace inside one of these is
+    # always a mistake. Either it is the space-separated list syntax dropped in
+    # commit 714e1933401, which is no longer split and so collapses into one
+    # unusable value, or it is a multi-word value that can never be matched.
+    #
+    # extra_args and extra_configs are deliberately absent: they carry Kconfig
+    # and CMake values that legitimately contain spaces. The conf file and
+    # overlay keys are absent because a path may contain a space.
+    keys_without_whitespace: set[str] = {
+        "arch_allow",
+        "arch_exclude",
+        "depends_on",
+        "extra_sections",
+        "integration_platforms",
+        "integration_toolchains",
+        "levels",
+        "modules",
+        "platform_allow",
+        "platform_exclude",
+        "platform_key",
+        "platform_type",
+        "required_snippets",
+        "simulation_exclude",
+        "tags",
+        "testcases",
+        "toolchain_allow",
+        "toolchain_exclude",
+        "vendor_allow",
+        "vendor_exclude",
+    }
+
     def __init__(self, filename: str, schema: dict[str, Any]) -> None:
         """Instantiate a new TwisterConfigParser object
 
@@ -114,6 +146,28 @@ class TwisterConfigParser:
         if 'common' in self.data:
             self.common = self.data['common']
         return data
+
+    def _check_no_whitespace(self, key: str, value: Any, name: str) -> None:
+        """Reject whitespace inside a value that has to name a single item.
+
+        Twister no longer splits space-separated lists, so "a b" is taken
+        verbatim and silently matches nothing. Fail loudly instead.
+        """
+        if key not in self.keys_without_whitespace:
+            return
+
+        items = [value] if isinstance(value, str) else value
+        if not isinstance(items, list):
+            return
+
+        for item in items:
+            if isinstance(item, str) and len(item.split()) > 1:
+                raise ConfigurationError(
+                    self.filename,
+                    f"whitespace in '{key}' value '{item}' in test '{name}'. "
+                    "Space-separated lists are not supported, write the value "
+                    "as a YAML list instead"
+                )
 
     def _cast_value(self, value: Any, typestr: str) -> Any:
         if typestr == "str":
@@ -263,6 +317,7 @@ class TwisterConfigParser:
                         default = self._cast_value("", kinfo["type"])
                     d[k] = default
             else:
+                self._check_no_whitespace(k, d[k], name)
                 try:
                     d[k] = self._cast_value(d[k], kinfo["type"])
                 except ValueError:

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -204,3 +204,76 @@ def test_load_yaml_with_no_scenario_data(zephyr_base):
     with pytest.raises(KeyError):
         scenario_data = parser.get_scenario('scenario1')
         assert scenario_data is None
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("tags", "'kernel userspace'"),
+        ("tags", "['kernel', 'memory slabs']"),
+        ("depends_on", "'gpio input'"),
+        ("platform_allow", "'board_a board_b'"),
+        ("integration_platforms", "['native_sim qemu_x86']"),
+    ],
+    ids=[
+        "tags-space-separated-string",
+        "tags-list-item-with-space",
+        "depends_on-space-separated-string",
+        "platform_allow-space-separated-string",
+        "integration_platforms-list-item-with-space",
+    ],
+)
+def test_whitespace_in_identifier_key_is_rejected(zephyr_base, key, value):
+    """Space-separated lists are no longer split, so they must not be accepted."""
+    filename = "test_data.yaml"
+    yaml_data = f"""
+    tests:
+      scenario1:
+        {key}: {value}
+    """
+
+    loaded_schema = scl.yaml_load(
+        os.path.join(zephyr_base, 'scripts', 'schemas', 'twister', 'testsuite-schema.yaml')
+    )
+
+    with mock.patch('builtins.open', mock.mock_open(read_data=yaml_data)):
+        parser = TwisterConfigParser(filename, loaded_schema)
+        parser.load()
+
+    with pytest.raises(ConfigurationError, match="Space-separated lists are not supported"):
+        parser.get_scenario('scenario1')
+
+
+@pytest.mark.parametrize(
+    "key, value, expected",
+    [
+        ("tags", "['kernel', 'userspace']", {'kernel', 'userspace'}),
+        ("tags", "'kernel'", {'kernel'}),
+        ("extra_configs", "['CONFIG_BOOT_BANNER_STRING=\"a b\"']", ['CONFIG_BOOT_BANNER_STRING="a b"']),
+        ("extra_conf_files", "['my dir/a.conf']", ['my dir/a.conf']),
+    ],
+    ids=[
+        "tags-proper-list",
+        "tags-single-value",
+        "extra_configs-keeps-spaces",
+        "extra_conf_files-keeps-spaces",
+    ],
+)
+def test_legitimate_whitespace_is_preserved(zephyr_base, key, value, expected):
+    """Kconfig values and file paths may contain spaces and must be left alone."""
+    filename = "test_data.yaml"
+    yaml_data = f"""
+    tests:
+      scenario1:
+        {key}: {value}
+    """
+
+    loaded_schema = scl.yaml_load(
+        os.path.join(zephyr_base, 'scripts', 'schemas', 'twister', 'testsuite-schema.yaml')
+    )
+
+    with mock.patch('builtins.open', mock.mock_open(read_data=yaml_data)):
+        parser = TwisterConfigParser(filename, loaded_schema)
+        parser.load()
+
+    assert parser.get_scenario('scenario1')[key] == expected

--- a/tests/arch/arm64/svc_el0_gate/tests.yaml
+++ b/tests/arch/arm64/svc_el0_gate/tests.yaml
@@ -5,7 +5,10 @@ common:
   ignore_faults: true
 tests:
   arch.arm64.svc_el0_gate:
-    tags: kernel userspace arm64
+    tags:
+      - kernel
+      - userspace
+      - arm64
     platform_allow:
       - qemu_cortex_a53
       - qemu_cortex_a53/qemu_cortex_a53/smp

--- a/tests/cmake/sysbuild_snippets/tests.yaml
+++ b/tests/cmake/sysbuild_snippets/tests.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: sysbuild_snippets sysbuild
+  tags:
+  - sysbuild_snippets
+  - sysbuild
   platform_allow:
   - native_sim
   integration_platforms:

--- a/tests/drivers/build_all/i3c/tests.yaml
+++ b/tests/drivers/build_all/i3c/tests.yaml
@@ -9,49 +9,63 @@ tests:
     platform_allow:
       - qemu_cortex_m3
       - nucleo_u385rg_q
-    tags: i3c_cdns i3c_dw
+    tags:
+      - i3c_cdns
+      - i3c_dw
     extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y"
   drivers.i3c.build.controller_role_only:
     # will cover drivers without in-tree boards
     platform_allow:
       - qemu_cortex_m3
       - nucleo_u385rg_q
-    tags: i3c_cdns i3c_dw
+    tags:
+      - i3c_cdns
+      - i3c_dw
     extra_args: "CONFIG_I3C_CONTROLLER_ROLE_ONLY=y CONFIG_I3C_RTIO=y"
   drivers.i3c.build.target_role_only:
     # will cover drivers without in-tree boards
     platform_allow:
       - qemu_cortex_m3
       - nucleo_u385rg_q
-    tags: i3c_cdns i3c_dw
+    tags:
+      - i3c_cdns
+      - i3c_dw
     extra_args: "CONFIG_I3C_TARGET_ROLE_ONLY=y"
   drivers.i3c.build.dual_role_nibi:
     # will cover drivers without in-tree boards
     platform_allow:
       - qemu_cortex_m3
       - nucleo_u385rg_q
-    tags: i3c_cdns i3c_dw
+    tags:
+      - i3c_cdns
+      - i3c_dw
     extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y CONFIG_I3C_USE_IBI=n"
   drivers.i3c.build.controller_role_only_nibi:
     # will cover drivers without in-tree boards
     platform_allow:
       - qemu_cortex_m3
       - nucleo_u385rg_q
-    tags: i3c_cdns i3c_dw
+    tags:
+      - i3c_cdns
+      - i3c_dw
     extra_args: "CONFIG_I3C_CONTROLLER_ROLE_ONLY=y CONFIG_I3C_RTIO=y CONFIG_I3C_USE_IBI=n"
   drivers.i3c.build.target_role_only_nibi:
     # will cover drivers without in-tree boards
     platform_allow:
       - qemu_cortex_m3
       - nucleo_u385rg_q
-    tags: i3c_cdns i3c_dw
+    tags:
+      - i3c_cdns
+      - i3c_dw
     extra_args: "CONFIG_I3C_TARGET_ROLE_ONLY=y CONFIG_I3C_USE_IBI=n"
   drivers.i3c.build.dual_role_pm:
     # will cover drivers without in-tree boards
     platform_allow:
       - qemu_cortex_m3
       - nucleo_u385rg_q
-    tags: i3c_cdns i3c_dw
+    tags:
+      - i3c_cdns
+      - i3c_dw
     extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y CONFIG_PM_DEVICE=y"
   drivers.i3c.build.stm32:
     platform_allow:

--- a/tests/drivers/input/tsc_keys/tests.yaml
+++ b/tests/drivers/input/tsc_keys/tests.yaml
@@ -1,6 +1,10 @@
 tests:
   drivers.input.stm32_tsc:
-    tags: drivers input stm32 tsc
+    tags:
+      - drivers
+      - input
+      - stm32
+      - tsc
     filter: dt_compat_enabled("st,stm32-tsc")
     depends_on: tsc
     integration_platforms: [stm32u083c_dk]

--- a/tests/drivers/pulse_io/api/tests.yaml
+++ b/tests/drivers/pulse_io/api/tests.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: drivers pulse_io
+  tags:
+    - drivers
+    - pulse_io
   filter: dt_nodelabel_enabled("pulse_io0")
   integration_platforms:
     - native_sim

--- a/tests/drivers/pulse_io/rtio/tests.yaml
+++ b/tests/drivers/pulse_io/rtio/tests.yaml
@@ -1,5 +1,8 @@
 common:
-  tags: drivers pulse_io rtio
+  tags:
+    - drivers
+    - pulse_io
+    - rtio
   filter: dt_nodelabel_enabled("pulse_io0")
   integration_platforms:
     - native_sim

--- a/tests/kernel/mem_slab/mslab_stats/tests.yaml
+++ b/tests/kernel/mem_slab/mslab_stats/tests.yaml
@@ -2,4 +2,4 @@ tests:
   kernel.memory_slabs.stats:
     tags:
       - kernel
-      - memory slabs
+      - memory_slabs

--- a/tests/kernel/msgq/msgq_usage/tests.yaml
+++ b/tests/kernel/msgq/msgq_usage/tests.yaml
@@ -3,4 +3,4 @@ tests:
     min_ram: 24
     tags:
       - kernel
-      - message queue
+      - message_queue

--- a/tests/lib/cpp/atomics_c/tests.yaml
+++ b/tests/lib/cpp/atomics_c/tests.yaml
@@ -3,7 +3,9 @@
 
 tests:
   cpp.atomics_c:
-    tags: cpp kernel
+    tags:
+      - cpp
+      - kernel
     arch_exclude: posix
     build_only: true
     filter: CONFIG_ATOMIC_OPERATIONS_C

--- a/tests/lib/heap_kasan/tests.yaml
+++ b/tests/lib/heap_kasan/tests.yaml
@@ -1,6 +1,8 @@
 tests:
   libraries.heap_kasan:
-    tags: heap asan
+    tags:
+      - heap
+      - asan
     # RX does not support -fsanitize=kernel-address.
     filter: not CONFIG_RX
     integration_platforms:

--- a/tests/lib/zvfs_eventfd/tests.yaml
+++ b/tests/lib/zvfs_eventfd/tests.yaml
@@ -1,10 +1,14 @@
 tests:
   libraries.zvfs_eventfd.add_size:
-    tags: zvfs eventfd
+    tags:
+      - zvfs
+      - eventfd
     integration_platforms:
       - qemu_x86
   libraries.zvfs_eventfd.ignore_min:
-    tags: zvfs eventfd
+    tags:
+      - zvfs
+      - eventfd
     extra_configs:
       - CONFIG_ZVFS_EVENTFD_IGNORE_MIN=y
       - CONFIG_ZVFS_EVENTFD_MAX=2

--- a/tests/net/lib/mcp/tests.yaml
+++ b/tests/net/lib/mcp/tests.yaml
@@ -1,6 +1,8 @@
 tests:
   net.mcp.server:
-    tags: mcp net
+    tags:
+      - mcp
+      - net
     min_ram: 320
     min_flash: 180
     timeout: 120


### PR DESCRIPTION
Twister stopped splitting space-separated lists a long time ago.
Fix testing still doing it.

V2:

- Fixes for `depends_on` field
- Use `Claude Opus 5 (1M context)` to check for empty spaces in list fields to avoid this problem in future.