### PR TITLE
drivers: counter: remove redundant STM32 RTC default

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -16,7 +16,6 @@ if COUNTER_RTC_STM32
 
 config COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS
 	bool "Save rtc time value between resets"
-	default n
 	help
 	  Keep the counter value after each reset.
 


### PR DESCRIPTION
Remove the redundant `default n` from
`COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS`.

Boolean Kconfig symbols default to `n` when no explicit default is
specified, so this does not change behavior.

Addresses part of #94780.

Testing:
- `KconfigBasic` compliance check passes.