### PR TITLE
doc: workqueue: mention cooperative system workqueue priority

### DIFF
--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -190,6 +190,13 @@ use of it.
     for example, if the new work items perform blocking operations that
     would delay other system workqueue processing to an unacceptable degree.
 
+    Also note: The system workqueue has the lowest cooperative priority by
+    default. This means that draining the system workqueue takes precedence over
+    *all preemptible threads*. Configuring the system workqueue's priority to be
+    preemptible is risky, because subsystems and drivers may implicitly rely on
+    work items being executed in a cooperative context. Therefore, a separate
+    workqueue with lower priority may be appropriate for low-priority tasks.
+
 How to Use Workqueues
 *********************
 


### PR DESCRIPTION
When reading the workqueue documentation, the priority of a workqueue seemed important to me, so I checked the default priority of the system workqueue. It being cooperative was unintuitive for me, since I thought I could use it for low-priority background tasks. I asked about this on Discord, and people generally confirmed that the system workqueue is not ideal for this use case.

Link to question on Discord:
https://discord.com/channels/720317445772017664/720317445772017667/1543206806791389214

preview:
https://builds.zephyrproject.io/zephyr/pr/118047/docs/kernel/services/threads/workqueue.html#system-workqueue