### PR TITLE
twister: coverage: ignore gcov and child errors in lcov v2

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -275,6 +275,8 @@ class Lcov(CoverageTool):
                 "--ignore-errors", "unused,unused",
                 "--ignore-errors", "empty,empty",
                 "--ignore-errors", "mismatch,mismatch",
+                "--ignore-errors", "gcov,gcov",
+                "--ignore-errors", "child,child",
             ]
 
         cmd_str = " ".join(cmd)


### PR DESCRIPTION
When using LCOV v2 with --coverage, geninfo can encounter empty or invalid .gcda files (such as 0-byte nsi_tasks.gcda generated under the native simulator). In LCOV v2, gcov errors and parallel child worker failures are treated as fatal unless explicitly ignored.

Add "gcov,gcov" and "child,child" to the --ignore-errors list in twister's Lcov tool when LCOV v2 is detected so that coverage capture does not fail on non-fatal gcov and child errors.

Assisted-by: Antigravity:gemini-1.5-pro