### PR TITLE
dts: edtlib: let a node carry dma-ranges without declaring it

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1164,6 +1164,10 @@ class Node:
       A list of Range objects extracted from the node's ranges property.
       The list is empty if the node does not have a range property.
 
+    dma_ranges:
+      A list of Range objects extracted from the node's dma-ranges property.
+      The list is empty if the node does not have a dma-ranges property.
+
     regs:
       A list of Register objects for the node's registers
 
@@ -2025,7 +2029,11 @@ class Node:
 
     def _check_undeclared_props(self) -> None:
         # Checks that all properties are declared in the binding
-        wl = {"compatible", "status", "ranges", "phandle",
+        # "dma-ranges" sits next to "ranges": the devicetree specification
+        # defines the two the same way (2.3.8 and 2.3.9) and edtlib parses
+        # them with the same code, so a node may carry either without its
+        # binding declaring it.
+        wl = {"compatible", "status", "ranges", "dma-ranges", "phandle",
               "interrupt-parent", "interrupts-extended", "device_type"}
 
         for prop_name in self._node.props:
@@ -3918,11 +3926,18 @@ def _check_dt(dt: DT) -> None:
                      ", ".join(ok_status) +
                      " (see the devicetree specification)")
 
-        ranges_prop = node.props.get("ranges")
-        if ranges_prop and ranges_prop.type not in (Type.EMPTY, Type.NUMS):
-            _err(f"expected 'ranges = <...>;' in {node.path} in "
-                 f"{node.dt.filename}, not '{ranges_prop}' "
-                  "(see the devicetree specification)")
+        # Both names, for the same reason the two tables above list both:
+        # the specification defines them the same way, so a value that is
+        # not a cell array is as wrong for one as for the other. Without
+        # this, a malformed dma-ranges reaches _init_dma_ranges and is
+        # sliced into Range objects holding whatever the bytes happened to
+        # be, while the identical ranges is rejected here.
+        for prop_name in ("ranges", "dma-ranges"):
+            range_prop = node.props.get(prop_name)
+            if range_prop and range_prop.type not in (Type.EMPTY, Type.NUMS):
+                _err(f"expected '{prop_name} = <...>;' in {node.path} in "
+                     f"{node.dt.filename}, not '{range_prop}' "
+                      "(see the devicetree specification)")
 
 
 def _err(msg) -> NoReturn:
@@ -4007,6 +4022,7 @@ _DEFAULT_PROP_TYPES: dict[str, str] = {
     "compatible": "string-array",
     "status": "string",
     "ranges": "compound",  # NUMS or EMPTY
+    "dma-ranges": "compound",  # NUMS or EMPTY
     "reg": "array",
     "reg-names": "string-array",
     "label": "string",

--- a/scripts/dts/python-devicetree/tests/test-bindings/spec-props.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/spec-props.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: |
+  Declares a property of its own and says nothing about ranges, so a node
+  using it goes through _check_undeclared_props: every property it carries
+  has to be either declared here or on the list of properties the devicetree
+  specification defines.
+
+compatible: "spec-props"
+
+properties:
+  a-prop:
+    type: int

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -294,6 +294,151 @@
 	};
 
 	//
+	// 'dma-ranges'
+	//
+	dma-ranges-zero-cells {
+		#address-cells = <0>;
+
+		node {
+			#address-cells = <0>;
+			#size-cells = <0>;
+
+			dma-ranges;
+		};
+	};
+
+	dma-ranges-zero-parent-cells {
+		#address-cells = <0>;
+
+		node {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			dma-ranges = <0xa>,
+				     <0x1a>,
+				     <0x2a>;
+		};
+	};
+
+	dma-ranges-one-address-cells {
+		#address-cells = <0>;
+
+		node {
+			reg = <1>;
+			#address-cells = <1>;
+
+			dma-ranges = <0xa 0xb>,
+				     <0x1a 0x1b>,
+				     <0x2a 0x2b>;
+		};
+	};
+
+	dma-ranges-one-address-two-size-cells {
+		#address-cells = <0>;
+
+		node {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <2>;
+
+			dma-ranges = <0xa 0xb 0xc>,
+				     <0x1a 0x1b 0x1c>,
+				     <0x2a 0x2b 0x2c>;
+		};
+	};
+
+	dma-ranges-two-address-cells {
+		#address-cells = <1>;
+
+		node@1 {
+			reg = <1 2>;
+
+			dma-ranges = <0xa 0xb 0xc 0xd>,
+				     <0x1a 0x1b 0x1c 0x1d>,
+				     <0x2a 0x2b 0x2c 0x2d>;
+		};
+	};
+
+	dma-ranges-two-address-two-size-cells {
+		#address-cells = <1>;
+
+		node@1 {
+			reg = <1 2>;
+			#size-cells = <2>;
+
+			dma-ranges = <0xa 0xb 0xc 0xd 0xe>,
+				     <0x1a 0x1b 0x1c 0x1d 0x1e>,
+				     <0x2a 0x2b 0x2c 0x2d 0x1d>;
+		};
+	};
+
+	dma-ranges-three-address-cells {
+		node@1 {
+			reg = <0 1 2>;
+			#address-cells = <3>;
+
+			dma-ranges = <0xa 0xb 0xc 0xd 0xe 0xf>,
+				     <0x1a 0x1b 0x1c 0x1d 0x1e 0x1f>,
+				     <0x2a 0x2b 0x2c 0x2d 0x2e 0x2f>;
+		};
+	};
+
+	dma-ranges-three-address-two-size-cells {
+		node@1 {
+			reg = <0 1 2>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+
+			dma-ranges = <0xa 0xb 0xc 0xd 0xe 0xf 0x10>,
+				     <0x1a 0x1b 0x1c 0x1d 0x1e 0x1f 0x110>,
+				     <0x2a 0x2b 0x2c 0x2d 0x2e 0x2f 0x210>;
+		};
+	};
+
+	dma-ranges-zero-child-address-cells {
+		#address-cells = <1>;
+
+		node {
+			#address-cells = <0>;
+			#size-cells = <1>;
+
+			dma-ranges = <0xa 0xb>,
+				     <0x1a 0x1b>,
+				     <0x2a 0x2b>;
+		};
+	};
+
+	//
+	// 'ranges' and 'dma-ranges' without the binding declaring them
+	//
+
+	spec-defined-range-props {
+		#address-cells = <1>;
+
+		node {
+			compatible = "spec-props";
+			a-prop = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			ranges = <0x0 0x10000000 0x1000>;
+			dma-ranges = <0x0 0x20000000 0x2000>;
+		};
+	};
+
+	spec-defined-range-props-no-binding {
+		#address-cells = <1>;
+
+		node {
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			ranges = <0x0 0x30000000 0x3000>;
+			dma-ranges = <0x0 0x40000000 0x4000>;
+		};
+	};
+
+	//
 	// 'reg'
 	//
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -297,6 +297,144 @@ def test_ranges():
         edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x2a0000002b0000002c, parent_bus_cells=0x2, parent_bus_addr=0x2d0000002e, length_cells=0x2, length=0x2f00000210)
     ]
 
+def test_dma_ranges():
+    '''Tests for the dma-ranges property'''
+    # The fixtures mirror the 'ranges' ones cell for cell, and the devicetree
+    # specification gives the two properties the same layout, so the expected
+    # values here are the ones test_ranges above asserts for its counterparts.
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    assert edt.get_node("/dma-ranges-zero-cells/node").dma_ranges == []
+
+    # A child #address-cells of 0 with a non-empty property: the rows still
+    # parse, because the parent and the size cells make entry_cells non-zero,
+    # and the child address comes back as None. 'ranges' has no fixture for
+    # this shape either.
+    node = edt.get_node("/dma-ranges-zero-child-address-cells/node")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x0, child_bus_addr=None, parent_bus_cells=0x1, parent_bus_addr=0xa, length_cells=0x1, length=0xb),
+        edtlib.Range(node=node, child_bus_cells=0x0, child_bus_addr=None, parent_bus_cells=0x1, parent_bus_addr=0x1a, length_cells=0x1, length=0x1b),
+        edtlib.Range(node=node, child_bus_cells=0x0, child_bus_addr=None, parent_bus_cells=0x1, parent_bus_addr=0x2a, length_cells=0x1, length=0x2b)
+    ]
+
+    node = edt.get_node("/dma-ranges-zero-parent-cells/node")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0xa, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x0, length=None),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x1a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x0, length=None),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x2a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x0, length=None)
+    ]
+
+    node = edt.get_node("/dma-ranges-one-address-cells/node")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0xa, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x1, length=0xb),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x1a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x1, length=0x1b),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x2a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x1, length=0x2b)
+    ]
+
+    node = edt.get_node("/dma-ranges-one-address-two-size-cells/node")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0xa, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x2, length=0xb0000000c),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x1a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x2, length=0x1b0000001c),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x2a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x2, length=0x2b0000002c)
+    ]
+
+    node = edt.get_node("/dma-ranges-two-address-cells/node@1")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0xa0000000b, parent_bus_cells=0x1, parent_bus_addr=0xc, length_cells=0x1, length=0xd),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x1a0000001b, parent_bus_cells=0x1, parent_bus_addr=0x1c, length_cells=0x1, length=0x1d),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x2a0000002b, parent_bus_cells=0x1, parent_bus_addr=0x2c, length_cells=0x1, length=0x2d)
+    ]
+
+    node = edt.get_node("/dma-ranges-two-address-two-size-cells/node@1")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0xa0000000b, parent_bus_cells=0x1, parent_bus_addr=0xc, length_cells=0x2, length=0xd0000000e),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x1a0000001b, parent_bus_cells=0x1, parent_bus_addr=0x1c, length_cells=0x2, length=0x1d0000001e),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x2a0000002b, parent_bus_cells=0x1, parent_bus_addr=0x2c, length_cells=0x2, length=0x2d0000001d)
+    ]
+
+    node = edt.get_node("/dma-ranges-three-address-cells/node@1")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0xa0000000b0000000c, parent_bus_cells=0x2, parent_bus_addr=0xd0000000e, length_cells=0x1, length=0xf),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x1a0000001b0000001c, parent_bus_cells=0x2, parent_bus_addr=0x1d0000001e, length_cells=0x1, length=0x1f),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x2a0000002b0000002c, parent_bus_cells=0x2, parent_bus_addr=0x2d0000002e, length_cells=0x1, length=0x2f)
+    ]
+
+    node = edt.get_node("/dma-ranges-three-address-two-size-cells/node@1")
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0xa0000000b0000000c, parent_bus_cells=0x2, parent_bus_addr=0xd0000000e, length_cells=0x2, length=0xf00000010),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x1a0000001b0000001c, parent_bus_cells=0x2, parent_bus_addr=0x1d0000001e, length_cells=0x2, length=0x1f00000110),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x2a0000002b0000002c, parent_bus_cells=0x2, parent_bus_addr=0x2d0000002e, length_cells=0x2, length=0x2f00000210)
+    ]
+
+def test_spec_defined_range_props():
+    '''ranges and dma-ranges need no declaration in the binding'''
+    # The devicetree specification defines both (2.3.8 and 2.3.9), so a node
+    # may carry either without its binding saying anything about them. There
+    # are two paths through _init_props and both have to agree:
+    #
+    #   a binding that declares properties -> _check_undeclared_props
+    #   no binding at all                  -> the assumed types
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    # spec-props.yaml declares a-prop and nothing else. Reaching this line at
+    # all is half the assertion: an undeclared property is an error, not a
+    # warning, so a regression here fails the whole load.
+    node = edt.get_node("/spec-defined-range-props/node")
+    assert str(node.binding_path).endswith("spec-props.yaml")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x0, parent_bus_cells=0x1, parent_bus_addr=0x10000000, length_cells=0x1, length=0x1000)
+    ]
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x0, parent_bus_cells=0x1, parent_bus_addr=0x20000000, length_cells=0x1, length=0x2000)
+    ]
+
+    # No compatible, so no binding: the assumed types decide instead, and both
+    # properties have to reach node.props -- that is what DT_NODE_HAS_PROP()
+    # is generated from.
+    node = edt.get_node("/spec-defined-range-props-no-binding/node")
+    assert node.binding_path is None
+    assert "ranges" in node.props
+    assert "dma-ranges" in node.props
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x0, parent_bus_cells=0x1, parent_bus_addr=0x30000000, length_cells=0x1, length=0x3000)
+    ]
+    assert node.dma_ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x0, parent_bus_cells=0x1, parent_bus_addr=0x40000000, length_cells=0x1, length=0x4000)
+    ]
+
+def test_range_prop_type_errs(tmp_path):
+    '''ranges and dma-ranges both have to be cell arrays'''
+    # A value that is not a cell array is as wrong for one as for the other.
+    # Left unchecked it is not rejected but sliced: the string below is
+    # twelve bytes, which is exactly one row of the three cells this node
+    # asks for, so it would come back as a Range holding its ASCII bytes.
+
+    dts_file = tmp_path / "error.dts"
+
+    dts = """
+/dts-v1/;
+
+/ {
+\t#address-cells = <1>;
+\t#size-cells = <1>;
+
+\tnode {
+\t\t#address-cells = <1>;
+\t\t#size-cells = <1>;
+\t\tPROP = "abcdefghijk";
+\t};
+};
+"""
+
+    for prop_name in ("ranges", "dma-ranges"):
+        verify_error(dts.replace("PROP", prop_name),
+                     dts_file,
+                     f"expected '{prop_name} = <...>;' in /node in {dts_file}, "
+                     f"not '{prop_name} = \"abcdefghijk\";' "
+                     "(see the devicetree specification)")
+
 def test_reg():
     '''Tests for the regs property'''
     with from_here():


### PR DESCRIPTION
## What

`0791e4c24ee` added `dma-ranges` parsing to edtlib, mirroring `ranges` cell for cell — the devicetree specification defines the two the same way (§2.3.8 and §2.3.9), and its commit message says so. Two things did not follow.

**Nothing tested it.** There was no `dma-ranges` fixture and no `dma-ranges` assertion anywhere under `scripts/dts/python-devicetree/tests`, while `ranges` has eight fixtures and eleven assertions.

**A node with a binding cannot carry it.** Three places in edtlib name `ranges` and not `dma-ranges`:

| table | decides |
|---|---|
| `_check_undeclared_props` | the properties a node may carry without its binding declaring them |
| `_DEFAULT_PROP_TYPES` | the type assumed for a property when there is no binding |
| `_check_dt` | that the value has to be a cell array |

The first one is the one that bites. A node whose binding declares any property of its own, and which carries `dma-ranges`:

```
EDTError: 'dma-ranges' appears in /node@0 in ..., but is not declared in
'properties:' in .../ranger.yaml
```

That is an error, not a warning, so it fails the whole devicetree rather than the one node — reverting just that line makes 23 of the 102 tests here fail, because none of them can load `test.dts` any more.

`base.yaml` declares `dma-ranges`, which is why the one in-tree user (`tests/lib/devicetree/api/app.overlay`) does not hit it. Resolving the `include:` chains transitively, **257 of the 4218 bindings** under `dts/bindings` do not reach `base.yaml`, and an out-of-tree binding need not either. `ranges` has never needed the declaration.

The second table decides `node.props` for a node with **no binding at all** — the bus and container nodes that carry these properties in the first place — and `node.props` is where `DT_NODE_HAS_PROP()` comes from. `ranges` reached it; `dma-ranges` did not.

The third is why this cannot stop at the first two. Once `dma-ranges` is allowed through undeclared, that error is no longer there to reject a *malformed* one either, and nothing else was: `_init_dma_ranges` slices whatever bytes it is given. Measured, `dma-ranges = "abcdefghijk";` on a node asking for three cells came back as a `Range` holding `0x61626364`, `0x65666768` and `0x696a6b00` — the ASCII of the string — while the byte-identical `ranges` was rejected with `expected 'ranges = <...>;'`. Neither name had a test for that error before; both have one now.

## Commits

1. **tests: dts: cover the dma-ranges property** — nine fixtures mirroring the `ranges` ones cell for cell, so the two can be compared assertion for assertion, plus the expected values `test_ranges` already states for its counterparts. Green on unmodified edtlib.

2. **dts: edtlib: let a node carry dma-ranges without declaring it** — the two table entries, the `_check_dt` guard, and tests covering both paths through `_init_props` as well as the type error.

One fixture has no counterpart above it: a child `#address-cells` of 0 with a non-empty property. `entry_cells` is still non-zero there, because the parent and the size cells contribute, so the rows parse and the child address comes back as `None`. `ranges` has no fixture for that shape either.

## On the DT_PROP() documentation

The comment above `_DEFAULT_PROP_TYPES` asks for `include/zephyr/devicetree.h` to be updated alongside its keys. That documentation lists the properties whose *value* `DT_PROP()` can expand — `compatible`, `status` and `interrupt-controller`. `ranges` is in the table and not in that list, being `compound`; `dma-ranges` is the same, so the documentation is unchanged here.

## Verification

Run on Windows and on Linux.

| | result |
|---|---|
| `scripts/dts/python-devicetree/tests`, Linux | **103 passed** (`main`: 100) |
| same, Windows | **103 passed** (`main`: 100) |
| first commit alone (bisect) | **101 passed** |
| `scripts/tests/twister`, Windows | 56 failed / 785 passed / 30 skipped — unchanged from `main` |
| `DevicetreeLinting` on the changed `.dts` | passes |
| `scripts/build`, `scripts/cmake`, `scripts/kconfig` | 43 passed / 1 skipped |
| `check_compliance.py -m Ruff -m Gitlint -m Nits -m GitDiffCheck -m TextEncoding` | passes (`ruff==0.14.2`) |

Red, one half of the fix reverted at a time:

| reverted | whole suite | the new test |
|---|---|---|
| `_check_undeclared_props` entry | 23 failed / 79 passed | fails |
| `_DEFAULT_PROP_TYPES` entry | 1 failed / 101 passed | fails |
| `_check_dt` guard | 1 failed / 102 passed | fails (`DID NOT RAISE EDTError`) |
| none | 103 passed | passes |

The second one is surgical: exactly one test fails, and it is the new one.

The coverage commit was mutation-tested against `_init_dma_ranges` — twelve plausible slips, each applied on its own with the rest of the file untouched: wrong property name, swapped cell counts, either default carried over wrong, the empty-property guard dropped, each of the three slice boundaries moved, `length_cells`/`parent_bus_cells` reported from the wrong count, and a zero-cell address reported as `0` rather than `None`. All twelve are caught by `test_dma_ranges` alone. The first eleven were caught straight away; the twelfth needed the zero-child-address-cells fixture, which is why it is there.

The three cases that reach `_init_props` differently were checked against a binding that declares `dma-ranges` (what `base.yaml` does), one that declares something else, and one that declares nothing: all three load, and `dma-ranges` now behaves exactly as `ranges` does in each.

