### PR TITLE
NXP dts: boards: nxp: frdm_mcxe31b: update EDMA channels for LPUART_5

### DIFF
--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -170,7 +170,7 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_lpuart_5>;
 	pinctrl-names = "default";
-	dmas = <&edma 1 44>, <&edma 2 45>;
+	dmas = <&edma 20 44>, <&edma 21 45>;
 	dma-names = "tx", "rx";
 };
 


### PR DESCRIPTION
Update LPUART_5 eDMA channels, fixes #116255 

Tested with  `samples/subsys/shell/shell_module`

```
CONFIG_UART_ASYNC_API=y
CONFIG_UART_INTERRUPT_DRIVEN=y

CONFIG_SHELL_BACKEND_SERIAL=y
CONFIG_SHELL_ASYNC_API=y
CONFIG_SHELL_BACKEND_SERIAL_API_ASYNC=y
```