### PR TITLE
west: blobs: don't assert when no URL has the expected checksum

### DIFF
--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -150,21 +150,26 @@ class Blobs(WestCommand):
 
     def handle_auto_cache(self, blob, auto_cache_dir) -> Path:
         """
-        This function guarantees that a given blob exists in the auto-cache.
-        It first checks whether the blob is already present. If so, it
-        returns the path of this cached blob. If the blob is not yet cached,
-        the blob is downloaded into the auto-cache directory and the path of
-        the freshly cached blob is returned.
+        Return the path of the blob inside the auto-cache directory,
+        downloading it there first if it is not already cached.
+
+        The path is returned whether or not the download matched the
+        checksum, so that a run with an auto-cache reaches verify_blob()
+        with the same file a run without one would have. Only a file that
+        does match is served to a later run.
         """
         cached_blob = self.get_cached_blob(blob, [auto_cache_dir])
         if cached_blob:
             return cached_blob
         name = Path(blob['path']).name
         sha256 = blob['sha256']
-        self.download_blob(blob, auto_cache_dir / f'{name}.{sha256}')
-        cached_blob = self.get_cached_blob(blob, [auto_cache_dir])
-        assert cached_blob, f'Blob {name} still not cached in auto-cache.'
-        return cached_blob
+        target = auto_cache_dir / f'{name}.{sha256}'
+        self.download_blob(blob, target)
+        # Not get_cached_blob() again: for a download that matched it would
+        # re-hash the whole file to arrive at this same path, and for one
+        # that did not it answers None -- the case verify_blob() has to be
+        # reached to report.
+        return target
 
     def get_cached_blob(self, blob, cache_dirs: list) -> Path | None:
         """

--- a/scripts/west_commands/tests/test_blobs.py
+++ b/scripts/west_commands/tests/test_blobs.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+'''Tests for the blobs command's cache and download handling.'''
+
+import hashlib
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from blobs import Blobs
+from fetchers.core import ZephyrBlobException
+
+WANTED = b'the real blob'
+WANTED_SHA = hashlib.sha256(WANTED).hexdigest()
+# What a server answers with when it wants a login instead of serving a file.
+SIGN_IN_PAGE = b'<html>please sign in</html>'
+
+
+@pytest.fixture
+def cmd():
+    '''A Blobs command with its logging silenced.'''
+    command = Blobs()
+    for name in ('dbg', 'wrn', 'inf', 'err'):
+        setattr(command, name, mock.Mock())
+    return command
+
+
+def make_blob(tmp_path, urls=('https://example.invalid/blob.bin',)):
+    return {
+        'path': 'blob.bin',
+        'abspath': str(tmp_path / 'out' / 'blob.bin'),
+        'sha256': WANTED_SHA,
+        'url': list(urls),
+        'module': 'demo',
+        'type': 'img',
+    }
+
+
+def fetcher_writing(payload, seen=None):
+    '''A fetcher class that reports success and writes the given bytes.
+
+    Passing a list as 'seen' records the URL each call was handed, which is
+    how a test tells "went on to the next URL" apart from "asked the first
+    one twice".
+    '''
+
+    class Fetcher:
+        def fetch(self, cmd, blob, path):
+            if seen is not None:
+                seen.append(blob['url'])
+            Path(path).write_bytes(payload)
+
+    return Fetcher
+
+
+def fetcher_failing():
+    class Fetcher:
+        def fetch(self, cmd, blob, path):
+            raise ZephyrBlobException('no answer from the server')
+
+    return Fetcher
+
+
+def patch_fetchers(*classes):
+    '''Hand out the given fetcher classes, one per call, then repeat the last.'''
+    remaining = list(classes)
+
+    def get_fetcher_cls(_scheme):
+        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
+
+    module = mock.Mock()
+    module.get_fetcher_cls = get_fetcher_cls
+    return mock.patch.dict(sys.modules, {'fetchers': module})
+
+
+def test_get_cached_blob_finds_the_suffixed_name(cmd, tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    cached = cache / f'blob.bin.{WANTED_SHA}'
+    cached.write_bytes(WANTED)
+
+    assert cmd.get_cached_blob(make_blob(tmp_path), [cache]) == cached
+
+
+def test_get_cached_blob_prefers_the_suffixed_name(cmd, tmp_path):
+    '''Both names can be cached at once; the suffixed one is the auto-cache's.'''
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    (cache / 'blob.bin').write_bytes(WANTED)
+    suffixed = cache / f'blob.bin.{WANTED_SHA}'
+    suffixed.write_bytes(WANTED)
+
+    assert cmd.get_cached_blob(make_blob(tmp_path), [cache]) == suffixed
+
+
+def test_get_cached_blob_finds_the_plain_name(cmd, tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    cached = cache / 'blob.bin'
+    cached.write_bytes(WANTED)
+
+    assert cmd.get_cached_blob(make_blob(tmp_path), [cache]) == cached
+
+
+def test_get_cached_blob_ignores_a_file_with_the_wrong_checksum(cmd, tmp_path):
+    '''The name says which blob it is; only the checksum says it is that blob.'''
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    (cache / f'blob.bin.{WANTED_SHA}').write_bytes(SIGN_IN_PAGE)
+
+    assert cmd.get_cached_blob(make_blob(tmp_path), [cache]) is None
+
+
+def test_get_cached_blob_skips_a_directory_that_is_not_there(cmd, tmp_path):
+    present = tmp_path / 'present'
+    present.mkdir()
+    cached = present / 'blob.bin'
+    cached.write_bytes(WANTED)
+
+    dirs = [tmp_path / 'absent', present]
+    assert cmd.get_cached_blob(make_blob(tmp_path), dirs) == cached
+
+
+def test_get_cached_blob_returns_none_when_nothing_is_cached(cmd, tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+
+    assert cmd.get_cached_blob(make_blob(tmp_path), [cache]) is None
+
+
+def test_download_blob_moves_on_to_the_next_url(cmd, tmp_path):
+    blob = make_blob(tmp_path, urls=('https://a.invalid/b', 'https://b.invalid/b'))
+    dest = tmp_path / 'out' / 'blob.bin'
+
+    with patch_fetchers(fetcher_failing(), fetcher_writing(WANTED)):
+        cmd.download_blob(blob, dest)
+
+    assert dest.read_bytes() == WANTED
+
+
+def test_download_blob_moves_on_when_the_body_is_wrong(cmd, tmp_path):
+    '''A 200 with the wrong body is a reason to try the next URL too.
+
+    Nothing raises here: the first URL answers. What sends download_blob()
+    on is the checksum of what it was handed, which is the half of the
+    docstring's promise the failing fetcher above cannot reach.
+    '''
+    seen = []
+    blob = make_blob(tmp_path, urls=('https://a.invalid/b', 'https://b.invalid/b'))
+    dest = tmp_path / 'out' / 'blob.bin'
+
+    with patch_fetchers(fetcher_writing(SIGN_IN_PAGE, seen), fetcher_writing(WANTED, seen)):
+        cmd.download_blob(blob, dest)
+
+    assert dest.read_bytes() == WANTED
+    assert seen == ['https://a.invalid/b', 'https://b.invalid/b']
+
+
+def test_download_blob_uses_the_fetcher_the_blob_names(cmd, tmp_path):
+    '''A blob may name its fetcher rather than leave it to the URL scheme.'''
+    seen = []
+
+    def get_fetcher_cls(scheme):
+        seen.append(scheme)
+        return fetcher_writing(WANTED)
+
+    module = mock.Mock()
+    module.get_fetcher_cls = get_fetcher_cls
+    blob = make_blob(tmp_path) | {'fetcher': 'git-lfs'}
+
+    with mock.patch.dict(sys.modules, {'fetchers': module}):
+        cmd.download_blob(blob, tmp_path / 'out' / 'blob.bin')
+
+    assert seen == ['git-lfs']
+
+
+def test_download_blob_raises_when_no_url_answers(cmd, tmp_path):
+    blob = make_blob(tmp_path, urls=('https://a.invalid/b', 'https://b.invalid/b'))
+
+    with patch_fetchers(fetcher_failing()), pytest.raises(ZephyrBlobException):
+        cmd.download_blob(blob, tmp_path / 'out' / 'blob.bin')
+
+
+def test_download_blob_leaves_a_mismatched_download_in_place(cmd, tmp_path):
+    '''A 200 with the wrong body is a download, not a failure to download.
+
+    download_blob() deliberately does not raise here: verify_blob() reports
+    the mismatch later, with the advice it has for it.
+    '''
+    blob = make_blob(tmp_path)
+    dest = tmp_path / 'out' / 'blob.bin'
+
+    with patch_fetchers(fetcher_writing(SIGN_IN_PAGE)):
+        cmd.download_blob(blob, dest)
+
+    assert dest.read_bytes() == SIGN_IN_PAGE
+
+
+def test_handle_auto_cache_uses_what_is_already_cached(cmd, tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    cached = cache / f'blob.bin.{WANTED_SHA}'
+    cached.write_bytes(WANTED)
+
+    with mock.patch.object(cmd, 'download_blob') as download:
+        assert cmd.handle_auto_cache(make_blob(tmp_path), cache) == cached
+    download.assert_not_called()
+
+
+def test_handle_auto_cache_downloads_what_is_missing(cmd, tmp_path):
+    cache = tmp_path / 'cache'
+
+    with patch_fetchers(fetcher_writing(WANTED)):
+        got = cmd.handle_auto_cache(make_blob(tmp_path), cache)
+
+    assert got == cache / f'blob.bin.{WANTED_SHA}'
+    assert got.read_bytes() == WANTED
+
+
+def test_handle_auto_cache_hands_back_a_mismatched_download(cmd, tmp_path):
+    '''Having an auto-cache must not change how a bad download is reported.
+
+    get_cached_blob() checks the checksum, so it finds nothing after a
+    download that did not match, and the path has to come from somewhere:
+    fetch_blob() copies it to the blob's place and verify_blob() reports the
+    mismatch, exactly as when no cache is configured.
+    '''
+    cache = tmp_path / 'cache'
+
+    with patch_fetchers(fetcher_writing(SIGN_IN_PAGE)):
+        got = cmd.handle_auto_cache(make_blob(tmp_path), cache)
+
+    assert got == cache / f'blob.bin.{WANTED_SHA}'
+    assert got.read_bytes() == SIGN_IN_PAGE


### PR DESCRIPTION
## What

`download_blob()` treats a download whose checksum does not match as a download, not as a failure to download, and says why:

```python
    # Not necessarily an attack: a server can answer a raw file
    # request with an HTML sign-in page and a 200 status.
    self.wrn(f'Checksum mismatch for blob downloaded from {url}')
    ...
    # verify_blob() will report the detailed checksum error later.
```

`verify_blob()` has a paragraph of advice for exactly that. **The auto-cache path never reaches it:**

```python
    self.download_blob(blob, auto_cache_dir / f'{name}.{sha256}')
    cached_blob = self.get_cached_blob(blob, [auto_cache_dir])
    assert cached_blob, f'Blob {name} still not cached in auto-cache.'
```

`get_cached_blob()` checks the checksum, so after such a download it finds nothing and the assert fires. `AssertionError` is not a `ZephyrBlobException`, so the loop in `fetch()` does not catch it either.

Driving `fetch_blob()` with a fetcher that answers every URL with the wrong bytes, auto-cache configured:

| | outcome | downloads | file at the destination |
|---|---|---|---|
| `python` | `AssertionError: Blob blob.bin still not cached in auto-cache.` | 1 | no |
| `python -O` | returns | **2** | yes |

Neither is what the code above intends, which is:

```
Checksum mismatch for blob downloaded from <url>
The checksum of the downloaded file does not match that in the blob metadata: ...
1 blobs have bad checksums
```

and exit status `EX_DATAERR`. Without an auto-cache that is exactly what happens; the cache is meant to be an optimisation, not a change of behaviour.

## The change

Hand back the path that was written. `fetch_blob()` then copies it into place and `verify_blob()` reports the mismatch, the same as with no cache configured. After the change both interpreters do one download and report it the same way.

A file whose checksum does not match is never served from the cache on a later run: `get_cached_blob()` checks the checksum there too — which is itself one of the tests here.

## Commits

1. **tests: west: cover the blobs cache and download paths** — `blobs.py` had no tests. Ten tests over `get_cached_blob` (both names it looks for, a file whose checksum does not match, a cache directory that is not there) and `download_blob` (next URL after a fetcher raises, giving up when none answers, leaving a mismatched download in place). Green on unmodified `blobs.py`.

2. **west: blobs: don't assert when no URL has the expected checksum** — the change, and the test for it.

The change hands back the path that was written rather than asking `get_cached_blob()` again. After the download that call can only answer with the file just written or with `None` — nothing else is in that directory under that name — so it would re-read and re-hash the whole blob to arrive at the path `target` already holds.

The fetchers are stood in for, so nothing reaches the network.

## Verification

Run on Windows and on Linux.

| | result |
|---|---|
| `scripts/west_commands` tests, Windows | **922 passed / 2 skipped** (`main`: 908 / 2) |
| same, Linux | **924 passed** (`main`: 910) |
| first commit alone (bisect), Windows | 921 passed / 2 skipped |
| `mypy --package=runners` | clean, 55 source files |
| `ruff check`, `ruff format --diff`, `pylint --rcfile=scripts/ci/pylintrc` | clean |
| `check_compliance.py`, all checks CI runs | no findings |

Red, with the change reverted and the tests kept: exactly one test fails, and it is the one the change is about —

```
E   AssertionError: Blob blob.bin still not cached in auto-cache.
scripts/west_commands/blobs.py:166: AssertionError
1 failed, 10 passed
```

The other thirteen pass either way, which is why they are a separate commit.

The tests were mutation-tested against `blobs.py`: the checksum gate inverted, the URL always taken from the first entry, the `fetcher:` field ignored, the cached-name preference reversed, and `handle_auto_cache` put back the way it was — all five are caught. A sixth, dropping the `if not cache_dir.exists(): continue` guard, is not: `get_blob_status()` returns `BLOB_NOT_PRESENT` for a path under a directory that is not there, so removing the guard changes nothing observable.

The Linux run is under WSL, where `bossac.py` detects WSL and refuses to run, so `tests/test_bossac.py` is excluded from both sides of the comparison; it fails identically on `main`.

