### PR TITLE
twister: reports: don't look past the start of the build log

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -545,12 +545,18 @@ class JsonReport:
             if "undefined reference" in line:
                 return line[line.index('undefined reference') :].strip()
             elif "error: ld returned" in line:
+                # What decides the reason is the line before this one, so
+                # when this is the first line there is nothing to decide
+                # it. lines[i - 1] at i == 0 is the last line of the log,
+                # which is a different file: reports.py appends the
+                # handler's stderr to the build log before parsing.
+                previous = lines[i - 1] if i else ""
                 if last_warning:
                     return last_warning
-                elif "overflowed by" in lines[i - 1]:
+                elif "overflowed by" in previous:
                     return "ld.bfd: region overflowed"
-                elif "ld.bfd: warning: " in lines[i - 1]:
-                    return "ld.bfd:" + lines[i - 1].split("ld.bfd:", 1)[-1]
+                elif "ld.bfd: warning: " in previous:
+                    return "ld.bfd:" + previous.split("ld.bfd:", 1)[-1]
                 return line
             elif "error: " in line:
                 return line[line.index('error: ') :].strip()

--- a/scripts/tests/twister/test_reports.py
+++ b/scripts/tests/twister/test_reports.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for reports.py
+"""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from twisterlib.reports import JsonReport, ReportingJSONEncoder, ReportStatus
+
+
+def test_report_status_is_its_value():
+    """ReportStatus goes into XML attributes, so str() has to be the value."""
+    assert str(ReportStatus.ERROR) == 'error'
+    assert str(ReportStatus.FAIL) == 'failure'
+    assert str(ReportStatus.SKIP) == 'skipped'
+    # It is a str subclass, so it also compares equal to the bare string.
+    assert ReportStatus.FAIL == 'failure'
+
+
+def test_reporting_json_encoder_writes_paths_as_strings():
+    encoded = json.dumps({'outdir': Path('a') / 'b'}, cls=ReportingJSONEncoder)
+    assert json.loads(encoded) == {'outdir': str(Path('a') / 'b')}
+
+
+def test_reporting_json_encoder_still_refuses_what_json_refuses():
+    with pytest.raises(TypeError):
+        json.dumps({'x': object()}, cls=ReportingJSONEncoder)
+
+
+def test_process_log_returns_empty_for_a_missing_file(tmp_path):
+    assert JsonReport.process_log(tmp_path / 'nothing-here.log') == ''
+
+
+def test_process_log_drops_unprintable_bytes(tmp_path):
+    """Terminal escapes and NULs go, printable characters stay.
+
+    Decoding happens first and is strict UTF-8, so what this pins is the
+    filtering of bytes that decode, not tolerance of bytes that do not.
+    """
+    log = tmp_path / 'build.log'
+    log.write_bytes(b'before\x1b[31mafter\x00end\n')
+
+    assert JsonReport.process_log(log) == 'before[31mafterend\n'
+
+
+TESTDATA_CMAKE_FAILURE = [
+    (
+        ['warning: the FOO symbol is deprecated', 'error: Aborting due to Kconfig warnings'],
+        'warning: the FOO symbol is deprecated',
+    ),
+    (
+        ['warning: undefined symbol: FOO', 'error: Aborting due to Kconfig warnings'],
+        'undefined symbol: FOO',
+    ),
+    (
+        ['error: Aborting due to Kconfig warnings'],
+        'no warning found',
+    ),
+    (
+        ['main.c:1:10: fatal error: nope.h: No such file or directory'],
+        'fatal error: nope.h: No such file or directory',
+    ),
+    (
+        ['devicetree error: /soc/uart@0: bad node'],
+        'devicetree error',
+    ),
+    (
+        ['CMake Error at cmake/modules/x.cmake:1 (message):', '', '  the reason'],
+        'CMake Error at cmake/modules/x.cmake:1 (message):   the reason',
+    ),
+    (
+        ['CMake Error at cmake/modules/x.cmake:1 (message):'],
+        'CMake Error at cmake/modules/x.cmake:1 (message):',
+    ),
+    (
+        ['[1/2] Building C object main.c.obj', '[2/2] Linking C executable zephyr.elf'],
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    'lines, expected',
+    TESTDATA_CMAKE_FAILURE,
+    ids=[
+        'warning kept',
+        'undefined symbol',
+        'no warning',
+        'fatal error',
+        'devicetree',
+        'cmake error with detail',
+        'cmake error alone',
+        'nothing to report',
+    ],
+)
+def test_parse_cmake_build_failure(lines, expected):
+    assert JsonReport._parse_cmake_build_failure('\n'.join(lines)) == expected
+
+
+LD_RETURNED = '/usr/bin/ld.bfd: error: ld returned 1 exit status'
+OVERFLOWED = "ld.bfd: region `FLASH' overflowed by 4096 bytes"
+LD_WARNING = '/usr/bin/ld.bfd: warning: something to say'
+
+TESTDATA_BUILD_FAILURE = [
+    (
+        ["main.c:(.text+0x0): undefined reference to `missing_symbol'", LD_RETURNED],
+        "undefined reference to `missing_symbol'",
+    ),
+    (
+        [OVERFLOWED, LD_RETURNED],
+        'ld.bfd: region overflowed',
+    ),
+    (
+        [LD_WARNING, LD_RETURNED],
+        'ld.bfd: warning: something to say',
+    ),
+    (
+        ["main.c: in function `main':", LD_RETURNED],
+        "in function `main':",
+    ),
+    # Both could decide it: last_warning is checked first, so the function
+    # name wins over the region the line before the linker error names.
+    (
+        ["main.c: in function `main':", OVERFLOWED, LD_RETURNED],
+        "in function `main':",
+    ),
+    (
+        ['main.c:1:1: error: nope is not a thing'],
+        'error: nope is not a thing',
+    ),
+    (
+        [LD_RETURNED],
+        LD_RETURNED,
+    ),
+    (
+        ['[1/2] Building C object main.c.obj'],
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    'lines, expected',
+    TESTDATA_BUILD_FAILURE,
+    ids=[
+        'undefined reference',
+        'overflow before',
+        'ld warning before',
+        'in function before',
+        'in function beats overflow',
+        'plain error',
+        'linker error alone',
+        'nothing to report',
+    ],
+)
+def test_parse_build_failure(lines, expected):
+    assert JsonReport._parse_build_failure('\n'.join(lines)) == expected
+
+
+TESTDATA_DETAILED_REASON = [
+    (
+        'CMake build failure',
+        ['main.c:1:10: fatal error: nope.h: No such file or directory'],
+        'CMake build failure - fatal error: nope.h: No such file or directory',
+    ),
+    (
+        'Build failure',
+        ['main.c:1:1: error: nope is not a thing'],
+        'Build failure - error: nope is not a thing',
+    ),
+    # A reason the parsers say nothing about comes back untouched.
+    ('CMake build failure', ['[1/2] Building C object main.c.obj'], 'CMake build failure'),
+    ('Build failure', ['[1/2] Building C object main.c.obj'], 'Build failure'),
+    ('Timeout', ['main.c:1:1: error: nope is not a thing'], 'Timeout'),
+]
+
+
+@pytest.mark.parametrize(
+    'reason, lines, expected',
+    TESTDATA_DETAILED_REASON,
+    ids=[
+        'cmake detailed',
+        'build detailed',
+        'cmake plain',
+        'build plain',
+        'other reason untouched',
+    ],
+)
+def test_get_detailed_reason(reason, lines, expected):
+    report = JsonReport(mock.Mock(), {})
+    assert report.get_detailed_reason(reason, '\n'.join(lines)) == expected

--- a/scripts/tests/twister/test_reports.py
+++ b/scripts/tests/twister/test_reports.py
@@ -133,6 +133,19 @@ TESTDATA_BUILD_FAILURE = [
         ['main.c:1:1: error: nope is not a thing'],
         'error: nope is not a thing',
     ),
+    # The line before the linker error is what decides the reason, so when the
+    # linker error is the first line there is no line to decide it -- including
+    # when the log ends with text that would have decided it. reports.py
+    # appends the handler's stderr to the build log before parsing, so the last
+    # line can come from a different file entirely.
+    (
+        [LD_RETURNED, 'ninja: build stopped.', OVERFLOWED],
+        LD_RETURNED,
+    ),
+    (
+        [LD_RETURNED, 'ninja: build stopped.', LD_WARNING],
+        LD_RETURNED,
+    ),
     (
         [LD_RETURNED],
         LD_RETURNED,
@@ -154,6 +167,8 @@ TESTDATA_BUILD_FAILURE = [
         'in function before',
         'in function beats overflow',
         'plain error',
+        'linker error first, overflow last',
+        'linker error first, warning last',
         'linker error alone',
         'nothing to report',
     ],


### PR DESCRIPTION
## What

`reports.py` had no test file. It is 528 statements — the JSON and XUnit writers, and the parsers that turn a build log into the short reason twister puts in its reports — and the twister suite covered 10% of it, all of that incidental to other tests. It is also the module every CI consumer reads twister's output through.

Writing the first tests for it turned up one thing that is wrong.

## The bug

`_parse_build_failure` decides why a link failed from the line **before** the one carrying `error: ld returned`:

```python
    elif "error: ld returned" in line:
        if last_warning:
            return last_warning
        elif "overflowed by" in lines[i - 1]:
            return "ld.bfd: region overflowed"
        elif "ld.bfd: warning: " in lines[i - 1]:
            return "ld.bfd:" + lines[i - 1].split("ld.bfd:", 1)[-1]
        return line
```

At `i == 0` that is `lines[-1]` — the **last** line of the log. And that line need not come from the same file: `JsonReport.create()` appends the handler's stderr to the build log before parsing it.

So the same failure gets reported two ways, depending only on whether anything was printed before the linker error:

| log | reason reported |
|---|---|
| `[ld error, "ninja: build stopped.", "…overflowed by 4096 bytes"]` | `ld.bfd: region overflowed` |
| `["[1/2] Building …", ld error, "ninja: build stopped.", "…overflowed by 4096 bytes"]` | `/usr/bin/ld.bfd: error: ld returned 1 exit status` |

Nothing precedes the first line, so the answer is the line itself — which is already what the function returns when the previous line says nothing in particular.

## Commits

1. **tests: twister: add tests for reports.py** — `ReportStatus`, the JSON encoder, `process_log`, `get_detailed_reason`, and both build-failure parsers against the shapes of log they are written for. Green on unmodified `reports.py`. Coverage of the module goes from 10% to 21%.

2. **twister: reports: don't look past the start of the build log** — the one-line guard, and the two cases that need it.

## Verification

| | result |
|---|---|
| `scripts/tests/twister`, Linux | **900 passed / 0 failed** (`main`: 872 / 0) |
| same, Windows | 56 failed / **813** passed / 30 skipped (`main`: 56 / 785 / 30) |
| first commit alone (bisect), Windows | 56 failed / 811 passed / 30 skipped |
| `ruff check`, `ruff format --diff`, `pylint --rcfile=scripts/ci/pylintrc` | clean |
| first commit alone (bisect), Windows | 56 / 810 / 30 |
| `check_compliance.py -m Ruff -m Gitlint -m Nits -m GitDiffCheck -m TextEncoding` | passes (`ruff==0.14.2`) |

The 56 failures are the pre-existing path-separator ones on Windows, unchanged and identical in set; `twister_tests.yml` runs on `ubuntu-24.04` only.

Red, with the second commit's change reverted and its tests kept:

```
E   AssertionError: assert 'ld.bfd: region overflowed' == '/usr/bin/ld.…1 exit status'
E   AssertionError: assert 'ld.bfd: warn…ething to say' == '/usr/bin/ld.…1 exit status'
2 failed, 25 passed
```

Exactly the two cases the change is about; the other 25 pass either way, which is why they are a separate commit.

The first commit was mutation-tested against `reports.py`: seventeen plausible slips applied one at a time — the negative index put back, the same lookup pointed forwards, wrong needles, the overflow and warning branches pointed at each other's text, `last_warning` starting truthy, each of the three `.index()` slices dropped, `fatal error` and `devicetree error` losing their precedence, the no-warning sentinel changed, `CMake Error` no longer joining its next line, the two reasons swapped in `get_detailed_reason`, the reason prefix dropped, the printable filter inverted, and `process_log` no longer tolerating a missing file. All seventeen are caught by `test_reports.py` alone.

One case was added after that: `last_warning` is checked before the line above the linker error, so when both could decide the reason the function name wins. Swapping those two branches used to leave the suite green; it now fails.

`scripts/ci/twister_report_analyzer.py` reads `lines[i - 1]` the same way, parsing the same linker output for the CI job summary. It is a separate tool with no tests of its own, in a directory this change does not otherwise touch, so it is left for a change of its own.

