### PR TITLE
west: bindesc: pad a gap between UF2 blocks with bytes, not ints

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -586,6 +586,7 @@ Binary Descriptors:
     - include/zephyr/bindesc.h
     - samples/subsys/bindesc/
     - scripts/west_commands/bindesc.py
+    - scripts/west_commands/tests/test_bindesc.py
     - tests/subsys/bindesc/
   labels:
     - "area: Binary Descriptors"

--- a/scripts/west_commands/bindesc.py
+++ b/scripts/west_commands/bindesc.py
@@ -47,7 +47,9 @@ def convert_from_uf2(cmd, buf):
             cmd.die(f'Non-word padding size at {ptr}')
         while padding > 0:
             padding -= 4
-            outp += b'\x00\x00\x00\x00'
+            # outp holds bytes objects for the b''.join() below; += would
+            # extend it with the ints that iterating one yields instead.
+            outp.append(b'\x00\x00\x00\x00')
         outp.append(block[32 : 32 + datalen])
         curraddr = newaddr + datalen
     return b''.join(outp)

--- a/scripts/west_commands/tests/test_bindesc.py
+++ b/scripts/west_commands/tests/test_bindesc.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+'''Tests for reading a UF2 image in the bindesc command.'''
+
+import struct
+from unittest import mock
+
+import pytest
+
+from bindesc import convert_from_uf2
+
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+
+NO_FLASH_FLAG = 0x1
+BASE = 0x1000
+
+
+class Died(Exception):
+    '''Stands in for what WestCommand.die() does: stop.'''
+
+
+@pytest.fixture
+def cmd():
+    command = mock.Mock()
+    command.die = mock.Mock(side_effect=Died)
+    return command
+
+
+def block(
+    addr,
+    payload,
+    blockno=0,
+    numblocks=1,
+    flags=0,
+    datalen=None,
+    magic0=UF2_MAGIC_START0,
+    magic1=UF2_MAGIC_START1,
+):
+    '''One 512-byte UF2 block.'''
+    head = struct.pack(
+        b'<IIIIIIII',
+        magic0,
+        magic1,
+        flags,
+        addr,
+        len(payload) if datalen is None else datalen,
+        blockno,
+        numblocks,
+        0,
+    )
+    return head + payload + b'\x00' * (476 - len(payload)) + struct.pack(b'<I', UF2_MAGIC_END)
+
+
+def test_contiguous_blocks_are_concatenated(cmd):
+    buf = block(BASE, b'A' * 16, 0, 2) + block(BASE + 16, b'B' * 16, 1, 2)
+
+    assert convert_from_uf2(cmd, buf) == b'A' * 16 + b'B' * 16
+
+
+def test_a_gap_between_blocks_is_padded_with_zeros(cmd):
+    '''An image with a hole in it is the normal case, not an odd one.'''
+    buf = block(BASE, b'A' * 16, 0, 2) + block(BASE + 16 + 16, b'B' * 16, 1, 2)
+
+    assert convert_from_uf2(cmd, buf) == b'A' * 16 + b'\x00' * 16 + b'B' * 16
+
+
+@pytest.mark.parametrize('which', ['magic0', 'magic1'])
+def test_a_block_with_the_wrong_magic_is_skipped(cmd, which):
+    '''Both magic numbers have to be checked, not just the first.'''
+    bad = {which: 0xDEADBEEF}
+    buf = block(BASE, b'A' * 16, 0, 2, **bad) + block(BASE, b'B' * 16, 1, 2)
+
+    assert convert_from_uf2(cmd, buf) == b'B' * 16
+    cmd.inf.assert_called_once()
+
+
+def test_a_block_marked_not_for_flash_is_skipped(cmd):
+    buf = block(BASE, b'A' * 16, 0, 2, flags=NO_FLASH_FLAG) + block(BASE, b'B' * 16, 1, 2)
+
+    assert convert_from_uf2(cmd, buf) == b'B' * 16
+
+
+def test_trailing_bytes_that_are_not_a_whole_block_are_ignored(cmd):
+    buf = block(BASE, b'A' * 16) + b'\x00' * 100
+
+    assert convert_from_uf2(cmd, buf) == b'A' * 16
+    # Ignored, not read and rejected: a short tail is not a block with bad magic.
+    cmd.inf.assert_not_called()
+
+
+def test_a_payload_larger_than_the_block_is_refused(cmd):
+    buf = block(BASE, b'A' * 16, datalen=477)
+
+    with pytest.raises(Died):
+        convert_from_uf2(cmd, buf)
+    assert 'Invalid UF2 data size' in cmd.die.call_args[0][0]
+
+
+@pytest.mark.parametrize('size', [256, 476], ids=['what uf2conv writes', 'the largest legal'])
+def test_a_block_that_is_full_is_read(cmd, size):
+    '''The other side of the size check, which every real image is on.
+
+    scripts/build/uf2conv.py writes 256 bytes of payload per block, and 476
+    is as much as one holds. Only refusing 477 and up would leave the check
+    free to move anywhere below it.
+    '''
+    assert convert_from_uf2(cmd, block(BASE, b'A' * size)) == b'A' * size
+    cmd.die.assert_not_called()
+
+
+@pytest.mark.parametrize('back', [64, 1], ids=['well before', 'one byte'])
+def test_blocks_that_go_backwards_are_refused(cmd, back):
+    '''Any step backwards is out of order, including one that is not a word.'''
+    buf = block(BASE + 64, b'A' * 16, 0, 2) + block(BASE + 64 + 16 - back, b'B' * 16, 1, 2)
+
+    with pytest.raises(Died):
+        convert_from_uf2(cmd, buf)
+    assert 'out of order' in cmd.die.call_args[0][0]
+
+
+def test_a_gap_of_more_than_ten_megabytes_is_refused(cmd):
+    buf = block(BASE, b'A' * 16, 0, 2) + block(BASE + 16 + 11 * 1024 * 1024, b'B' * 16, 1, 2)
+
+    with pytest.raises(Died):
+        convert_from_uf2(cmd, buf)
+    assert 'More than 10M of padding' in cmd.die.call_args[0][0]
+
+
+def test_a_gap_that_is_not_a_whole_number_of_words_is_refused(cmd):
+    buf = block(BASE, b'A' * 16, 0, 2) + block(BASE + 16 + 2, b'B' * 16, 1, 2)
+
+    with pytest.raises(Died):
+        convert_from_uf2(cmd, buf)
+    assert 'Non-word padding' in cmd.die.call_args[0][0]


### PR DESCRIPTION
## What

`bindesc.convert_from_uf2()` collects the image into a list and joins it at the end. Where two blocks are not adjacent it fills the gap like this:

```python
    outp = []
    ...
        while padding > 0:
            padding -= 4
            outp += b'\x00\x00\x00\x00'
        outp.append(block[32 : 32 + datalen])
    return b''.join(outp)
```

`outp` is a list, so `+=` extends it with what iterating a bytes object yields — four **ints**. `b''.join()` cannot take those:

```
TypeError: sequence item 1: expected a bytes-like object, int found
```

So reading any UF2 whose blocks have a gap between them fails. A gap is the normal shape of an image with more than one region in it.

`scripts/build/uf2conv.py`, which the function says it is based on, appends there instead:

```python
        while padding > 0:
            padding -= 4
            outp.append(b"\x00\x00\x00\x00")
```

Two blocks, 16 bytes of payload each, the second starting 16 bytes after the first ends:

| | `bindesc.convert_from_uf2` | `uf2conv.convert_from_uf2` |
|---|---|---|
| adjacent blocks | 32 bytes, correct | 32 bytes, correct |
| 16-byte gap | **TypeError** | 48 bytes, zero-padded |

With this change the two produce the same bytes for the same input.

## Commits

1. **tests: west: cover reading a UF2 image in bindesc** — `bindesc.py` had no tests. Ten over `convert_from_uf2`: concatenating adjacent blocks, skipping a block whose magic is wrong (either of the two) or that is marked not-for-flash, ignoring a tail too short to be a block, and each of the four inputs it refuses. Green on unmodified `bindesc.py`.

2. **west: bindesc: pad a gap between UF2 blocks with bytes, not ints** — the one-word change, and the eleventh test.

## Verification

| | result |
|---|---|
| `scripts/west_commands` tests, Windows | **921 passed / 2 skipped** (`main`: 908 / 2) |
| same, Linux | **923 passed** (`main`: 910) |
| first commit alone (bisect), Windows | 920 passed / 2 skipped |
| `ruff check`, `ruff format --diff`, `pylint --rcfile=scripts/ci/pylintrc` | clean |
| `mypy --package=runners` | clean, 55 source files |
| `check_compliance.py -m Ruff -m Gitlint -m Nits -m GitDiffCheck -m TextEncoding` | passes (`ruff==0.14.2`) |

Red, with the change reverted and the tests kept: one test fails, and it is the one the change is about —

```
E   TypeError: sequence item 1: expected a bytes-like object, int found
scripts/west_commands/bindesc.py:53: TypeError
1 failed, 8 passed
```

The tests were mutation-tested against `convert_from_uf2`: twelve slips applied one at a time — the `+=` put back, the padding written once instead of per word, either magic number no longer checked, the not-for-flash flag moved, the data-size bound off by one, backwards blocks allowed, the alignment check halved, the padding ceiling lifted, the payload slice run to the end of the block, the address not advanced by the payload, and a partial trailing block counted. All twelve are caught.

Three more were surviving: the `datalen > 476` bound could be tightened to `>= 476`, `> 400` or even `> 16` with the suite still green, because no test fed a payload larger than 16 bytes. `scripts/build/uf2conv.py` writes 256 bytes of payload per block, so `> 16` would refuse every image Zephyr produces. A test now reads a full block at both 256 and 476, and all three are caught.

Three of them were not, at first: the second magic number was never corrupted by a test, a one-byte step backwards was not tried, and nothing asserted that a short tail is *ignored* rather than read and rejected. Those three tests are there because of it.

The Linux run here is under WSL, where `tests/test_bossac.py` fails all 14 of its tests — `bossac.py` detects WSL and refuses to run. Unrelated to this change and the same before and after.

