### PR TITLE
devicetree: add uint64 CPU frequency properties and structural CPU enumeration

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -1,3 +1,5 @@
+.. Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+
 .. _dt-bindings-file-syntax:
 
 Devicetree bindings syntax
@@ -232,7 +234,7 @@ Property entries in ``properties:`` are written in this syntax:
 
    <property name>:
      required: <true | false>
-     type: <string | int | boolean | array | uint8-array | string-array |
+     type: <string | int | uint64 | boolean | array | uint8-array | string-array |
             phandle | phandles | phandle-array | path | compound>
      deprecated: <true | false>
      default: <default>
@@ -242,7 +244,7 @@ Property entries in ``properties:`` are written in this syntax:
        - <item2>
        ...
        - <itemN>
-     const: <string | int | array | uint8-array | string-array>
+     const: <string | int | uint64 | array | uint8-array | string-array>
      min: <int>
      max: <int>
      min-len: <int>
@@ -354,6 +356,15 @@ about the ``phandle*`` type properties.
    * - ``int``
      - exactly one 32-bit value (cell)
      - ``current-speed = <115200>;``
+
+   * - ``uint64``
+     - a 32-bit or 64-bit unsigned integer; multiple properties in the
+       Devicetree Specification have this shape. Encoded as 1 cell (32-bit)
+       or 2 cells (64-bit, high word first).
+       For example, ``<0xABCD1234>`` represents the value ``0xABCD1234``
+       (3,134,984,756 decimal), while ``<0x00000001 0x00000000>`` represents
+       ``0x100000000`` (4,294,967,296 decimal).
+     - ``clock-frequency = <100000000>;`` or ``clock-frequency = <1 0>;``
 
    * - ``boolean``
      - flags that don't take a value when true, and are absent if false

--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -417,6 +417,18 @@ other-macro =/ %s"DT_N_INST_" dt-name %s"_NUM_OKAY"
 ; DT_FOREACH_STATUS_OKAY_NODE respectively.
 other-macro =/ %s"DT_FOREACH_HELPER"
 other-macro =/ %s"DT_FOREACH_OKAY_HELPER"
+; These are used internally by the DT_FOREACH_CPU* macros, which iterate
+; over CPU nodes.
+other-macro =/ %s"DT_FOREACH_CPU_HELPER"
+other-macro =/ %s"DT_FOREACH_CPU_SEP_HELPER"
+other-macro =/ %s"DT_FOREACH_CPU_VARGS_HELPER"
+other-macro =/ %s"DT_FOREACH_CPU_SEP_VARGS_HELPER"
+other-macro =/ %s"DT_FOREACH_CPU_OKAY_HELPER"
+other-macro =/ %s"DT_FOREACH_CPU_OKAY_SEP_HELPER"
+other-macro =/ %s"DT_FOREACH_CPU_OKAY_VARGS_HELPER"
+other-macro =/ %s"DT_FOREACH_CPU_OKAY_SEP_VARGS_HELPER"
+; Total number of CPU nodes.
+other-macro =/ %s"DT_CPU_NUM"
 ; These are used internally by DT_FOREACH_STATUS_OKAY,
 ; which iterates over each enabled node of a compatible.
 other-macro =/ %s"DT_FOREACH_OKAY_" dt-name

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -8,11 +8,10 @@ include: base.yaml
 properties:
   device_type:
     type: string
-    default: "cpu"
+    const: "cpu"
     description: |
       Standard device_type identifying this node as a cpu. Required to maintain compatibility
-      with the IEEE 1275 standard as well as for DT_FOREACH_CPU family of devicetree macros to
-      identify cpu nodes within the "/cpus" parent node
+      with the IEEE 1275 standard.
   zephyr,deferred-start:
     type: boolean
     description: |

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -22,8 +22,10 @@ properties:
       application code brings it up at run time with k_smp_cpu_start() (or
       k_smp_cpu_resume()). The flag has no effect on the boot CPU.
   clock-frequency:
-    type: int
-    description: Clock frequency in Hz
+    type: uint64
+    description: Clock frequency in Hz. May be a single 32-bit cell or a
+      64-bit value encoded as two 32-bit cells (high word first), per the
+      Devicetree Specification.
   cpu-power-states:
     type: phandles
     description: List of power management states supported by this cpu
@@ -49,3 +51,10 @@ properties:
   cpu-release-addr:
     type: array
     description: Address of the release mailbox used by the spin-table enable-method.
+
+  timebase-frequency:
+    type: uint64
+    description: |
+      Frequency at which the timebase and decrementer registers are updated
+      (in Hertz). May be a single 32-bit cell or a 64-bit value encoded as
+      two 32-bit cells (high word first), per the Devicetree Specification.

--- a/dts/bindings/cpu/openhwgroup,cva6.yaml
+++ b/dts/bindings/cpu/openhwgroup,cva6.yaml
@@ -10,5 +10,4 @@ include: riscv-common.yaml
 properties:
   timebase-frequency:
     required: true
-    type: int
     description: Clock speed at which the core-local machine timer operates.

--- a/dts/bindings/test/vnd,uint64-holder.yaml
+++ b/dts/bindings/test/vnd,uint64-holder.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test uint64 property type
+
+compatible: "vnd,uint64-holder"
+
+include: [base.yaml]
+
+properties:
+  val-32:
+    type: uint64
+    description: 1-cell (32-bit) uint64 value
+
+  val-64:
+    type: uint64
+    description: 2-cell (64-bit) uint64 value
+
+  val-with-default:
+    type: uint64
+    default: 42
+    description: uint64 with a default; omitted from DTS to exercise the default path
+
+  val-with-or:
+    type: uint64
+    description: uint64 with no default; omitted from DTS to exercise DT_PROP_OR fallback

--- a/include/zephyr/devicetree/cpu.h
+++ b/include/zephyr/devicetree/cpu.h
@@ -24,12 +24,13 @@ extern "C" {
  */
 
 /**
- * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
- *        device_type is "cpu"
+ * @brief Invokes @p fn for each CPU node in the devicetree's "/cpus" node
  *
  * The macro @p fn must take one parameter, which will be the node
- * identifier of a "/cpus" child node with device_type = "cpu". Children of
- * "/cpus" that do not have device_type = "cpu" are skipped.
+ * identifier of a "/cpus/cpu@N" node. The list is determined at build time
+ * by the Python devicetree tooling (edt.cpus) using a structural check:
+ * direct children of "/cpus" whose name prefix is "cpu". Children of
+ * "/cpus" that do not match (e.g. "power-states") are excluded.
  *
  * Example devicetree fragment:
  *
@@ -67,19 +68,15 @@ extern "C" {
  *     };
  * @endcode
  *
- * Notice that "power-states" is skipped, since its device_type is not "cpu".
+ * Notice that "power-states" is excluded.
  *
  * @param fn macro to invoke
  */
-#define DT_FOREACH_CPU(fn) DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_INTERNAL, fn)
+#define DT_FOREACH_CPU(fn) DT_FOREACH_CPU_HELPER(fn)
 
 /**
- * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
- *        device_type is "cpu", with a separator
- *
- * The macro @p fn must take one parameter, which will be the node
- * identifier of a "/cpus" child node with device_type = "cpu". Children of
- * "/cpus" that do not have device_type = "cpu" are skipped.
+ * @brief Invokes @p fn for each CPU node in the devicetree's "/cpus" node,
+ *        with a separator
  *
  * @p sep is placed after each invocation of @p fn, not between invocations.
  * This means the expansion has a trailing @p sep, which is convenient for
@@ -100,12 +97,11 @@ extern "C" {
  *
  * @see DT_FOREACH_CPU
  */
-#define DT_FOREACH_CPU_SEP(fn, sep)                                                                \
-	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_SEP_INTERNAL, fn, sep)
+#define DT_FOREACH_CPU_SEP(fn, sep) DT_FOREACH_CPU_SEP_HELPER(fn, sep)
 
 /**
- * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
- *        device_type is "cpu", with multiple arguments
+ * @brief Invokes @p fn for each CPU node in the devicetree's "/cpus" node,
+ *        with multiple arguments
  *
  * The macro @p fn takes multiple arguments. The first should be the node
  * identifier for the "/cpus" child node. The remaining are passed-in by the
@@ -116,14 +112,11 @@ extern "C" {
  *
  * @see DT_FOREACH_CPU
  */
-#define DT_FOREACH_CPU_VARGS(fn, ...)                                                              \
-	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_VARGS_INTERNAL, fn, __VA_ARGS__)
+#define DT_FOREACH_CPU_VARGS(fn, ...) DT_FOREACH_CPU_VARGS_HELPER(fn, __VA_ARGS__)
 
 /**
- * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
- *        device_type is "cpu", with a separator and multiple arguments
- *
- * The macro @p fn takes multiple arguments. The remaining are passed-in by the caller.
+ * @brief Invokes @p fn for each CPU node in the devicetree's "/cpus" node,
+ *        with a separator and multiple arguments
  *
  * @param fn macro to invoke
  * @param sep Separator (e.g. comma or semicolon) placed after each
@@ -133,32 +126,21 @@ extern "C" {
  *
  * @see DT_FOREACH_CPU_SEP
  */
-#define DT_FOREACH_CPU_SEP_VARGS(fn, sep, ...)                                                     \
-	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_SEP_VARGS_INTERNAL, fn, sep,          \
-			       __VA_ARGS__)
+#define DT_FOREACH_CPU_SEP_VARGS(fn, sep, ...) DT_FOREACH_CPU_SEP_VARGS_HELPER(fn, sep, __VA_ARGS__)
 
 /**
- * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
- *        device_type is "cpu" and status is "okay"
- *
- * This macro iterates through children of the "/cpus" node in the same order
- * as they appear in the final devicetree, but children whose status is not `okay`
- * are also skipped.
+ * @brief Invokes @p fn for each CPU node in the devicetree's "/cpus" node
+ *        whose status is "okay"
  *
  * @param fn macro to invoke
  *
  * @see DT_FOREACH_CPU
  */
-#define DT_FOREACH_CPU_STATUS_OKAY(fn)                                                             \
-	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_STATUS_OKAY_INTERNAL, fn)
+#define DT_FOREACH_CPU_STATUS_OKAY(fn) DT_FOREACH_CPU_OKAY_HELPER(fn)
 
 /**
- * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
- *        device_type is "cpu" and status is "okay", with a separator
- *
- * This macro iterates through children of the "/cpus" node in the same order
- * as they appear in the final devicetree, but children whose status is not `okay`
- * are also skipped.
+ * @brief Invokes @p fn for each CPU node in the devicetree's "/cpus" node
+ *        whose status is "okay", with a separator
  *
  * @param fn macro to invoke
  * @param sep Separator (e.g. comma or semicolon) placed after each
@@ -167,17 +149,11 @@ extern "C" {
  *
  * @see DT_FOREACH_CPU_SEP
  */
-#define DT_FOREACH_CPU_STATUS_OKAY_SEP(fn, sep)                                                    \
-	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_STATUS_OKAY_SEP_INTERNAL, fn, sep)
+#define DT_FOREACH_CPU_STATUS_OKAY_SEP(fn, sep) DT_FOREACH_CPU_OKAY_SEP_HELPER(fn, sep)
 
 /**
- * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
- *        device_type is "cpu" and status is "okay", with a separator and
- *        multiple arguments
- *
- * This macro iterates through children of the "/cpus" node in the same order
- * as they appear in the final devicetree, but children whose status is not `okay`
- * are also skipped.
+ * @brief Invokes @p fn for each CPU node in the devicetree's "/cpus" node
+ *        whose status is "okay", with a separator and multiple arguments
  *
  * @param fn macro to invoke
  * @param sep Separator (e.g. comma or semicolon) placed after each
@@ -187,42 +163,8 @@ extern "C" {
  *
  * @see DT_FOREACH_CPU_STATUS_OKAY_SEP
  */
-#define DT_FOREACH_CPU_STATUS_OKAY_SEP_VARGS(fn, sep, ...)                                         \
-	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_STATUS_OKAY_SEP_VARGS_INTERNAL, fn,   \
-			       sep, __VA_ARGS__)
-
-/** @cond INTERNAL_HIDDEN */
-#define DT_FOREACH_CPU_INTERNAL(node_id, fn)                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), (fn(node_id)), ())
-
-#define DT_FOREACH_CPU_VARGS_INTERNAL(node_id, fn, ...)                                            \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
-		    (fn(node_id, __VA_ARGS__)), ())
-
-#define DT_FOREACH_CPU_SEP_INTERNAL(node_id, fn, sep)                                              \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
-		    (fn(node_id) DT_DEBRACKET_INTERNAL sep), ())
-
-#define DT_FOREACH_CPU_SEP_VARGS_INTERNAL(node_id, fn, sep, ...)                                   \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
-		    (fn(node_id, __VA_ARGS__) DT_DEBRACKET_INTERNAL sep), ())
-
-#define DT_FOREACH_CPU_STATUS_OKAY_INTERNAL(node_id, fn)                                           \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
-		    (COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(node_id), (fn(node_id)), ())), ())
-
-#define DT_FOREACH_CPU_STATUS_OKAY_SEP_INTERNAL(node_id, fn, sep)                                  \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
-		    (COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(node_id), \
-				  (fn(node_id) DT_DEBRACKET_INTERNAL sep), ())), \
-		    ())
-
-#define DT_FOREACH_CPU_STATUS_OKAY_SEP_VARGS_INTERNAL(node_id, fn, sep, ...)                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
-		    (COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(node_id), \
-				  (fn(node_id, __VA_ARGS__) DT_DEBRACKET_INTERNAL sep), ())), \
-		    ())
-/** @endcond */
+#define DT_FOREACH_CPU_STATUS_OKAY_SEP_VARGS(fn, sep, ...) \
+	DT_FOREACH_CPU_OKAY_SEP_VARGS_HELPER(fn, sep, __VA_ARGS__)
 
 /**
  * @}

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -120,6 +120,7 @@ def main():
 
         write_chosen(edt)
         write_global_macros(edt)
+        write_cpu_macros(edt)
 
     # Output text file with all binding files, if argument is provided
     if args.deps_out is not None:
@@ -1301,6 +1302,53 @@ def write_global_macros(edt: edtlib.EDT):
             out_comment("Includes descendants on this bus, excludes devices behind child buses")
             out_dt_define(f"{bus_id}_DESCENDANT_NUM_ON_BUS_{bus_ident}", count)
             out_dt_define(f"{bus_id}_DESCENDANT_NUM_ON_BUS_{bus_ident}_STATUS_OKAY", count_ok)
+
+
+def write_cpu_macros(edt: edtlib.EDT):
+    # Emits helpers for iterating over CPU nodes (edt.cpus) and a count.
+    # cpu.h's public DT_FOREACH_CPU* macros delegate directly to these
+    # helpers, replacing the old C-preprocessor device_type filter.
+
+    okay_cpus = [n for n in edt.cpus if n.status == "okay"]
+
+    out_comment("Macros for iterating over CPU nodes and querying CPU count")
+    out_dt_define(
+        "FOREACH_CPU_HELPER(fn)",
+        " ".join(f"fn(DT_{node.z_path_id})" for node in edt.cpus),
+    )
+    out_dt_define(
+        "FOREACH_CPU_SEP_HELPER(fn, sep)",
+        " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{node.z_path_id})" for node in edt.cpus),
+    )
+    out_dt_define(
+        "FOREACH_CPU_VARGS_HELPER(fn, ...)",
+        " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in edt.cpus),
+    )
+    out_dt_define(
+        "FOREACH_CPU_SEP_VARGS_HELPER(fn, sep, ...)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in edt.cpus
+        ),
+    )
+    out_dt_define(
+        "FOREACH_CPU_OKAY_HELPER(fn)",
+        " ".join(f"fn(DT_{node.z_path_id})" for node in okay_cpus),
+    )
+    out_dt_define(
+        "FOREACH_CPU_OKAY_SEP_HELPER(fn, sep)",
+        " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{node.z_path_id})" for node in okay_cpus),
+    )
+    out_dt_define(
+        "FOREACH_CPU_OKAY_VARGS_HELPER(fn, ...)",
+        " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in okay_cpus),
+    )
+    out_dt_define(
+        "FOREACH_CPU_OKAY_SEP_VARGS_HELPER(fn, sep, ...)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in okay_cpus
+        ),
+    )
+    out_dt_define("CPU_NUM", len(edt.cpus))
 
 
 def str2ident(s: str) -> str:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -986,6 +986,9 @@ def prop2value(prop: edtlib.Property) -> edtlib.PropertyValType:
     if prop.type == "int":
         return prop.val
 
+    if prop.type == "uint64":
+        return prop.val
+
     if prop.type == "boolean":
         return 1 if prop.val else 0
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1711,8 +1711,15 @@ class Node:
                 self._binding = binding_from_parent
                 return
 
-        # No binding found
-        self._binding = None
+        # No binding found. For /cpus/cpu@N nodes without a compatible,
+        # fall back to the binding loaded from cpu.yaml (if available).
+        # This gives binding-less CPU nodes typed properties and a
+        # device_type default without requiring a compatible string.
+        # Nodes with a YAML binding return early above and never reach here.
+        if _is_cpu_node(self):
+            self._binding = self.edt._cpu_fallback_binding()
+        else:
+            self._binding = None
 
     def _binding_from_properties(self) -> None:
         # Sets up a Binding object synthesized from the properties in the node.
@@ -2379,6 +2386,13 @@ class EDT:
     nodes:
       A list of Node objects for the nodes that appear in the devicetree
 
+    cpus:
+      A list of Node objects for the /cpus/cpu@N nodes, in DTS source order
+      (depth-first pre-order, matching logical CPU numbering). Children of
+      /cpus whose name-without-unit-address is not "cpu" (e.g. "power-states")
+      are excluded. Nodes appear regardless of whether they have a compatible
+      property.
+
     compat2nodes:
       A collections.defaultdict that maps each 'compatible' string that appears
       on some Node to a list of Nodes with that compatible.
@@ -2503,6 +2517,7 @@ class EDT:
 
         # Public attributes (the rest are properties)
         self.nodes: list[Node] = []
+        self.cpus: list[Node] = []
         self.compat2nodes: dict[str, list[Node]] = defaultdict(list)
         self.compat2okay: dict[str, list[Node]] = defaultdict(list)
         self.compat2notokay: dict[str, list[Node]] = defaultdict(list)
@@ -2531,6 +2546,10 @@ class EDT:
             for path in self._binding_paths
         }
         self._node2enode: dict[dtlib_Node, Node] = {}
+        # Lazily populated by _cpu_fallback_binding(). None until the first
+        # binding-less /cpus/cpu@N node is initialized, or None for the
+        # lifetime of this EDT if cpu.yaml is not in bindings_dirs.
+        self._cpu_binding: Optional[Binding] = None
 
         if dts is not None:
             try:
@@ -2538,6 +2557,39 @@ class EDT:
             except DTError as e:
                 raise EDTError(e) from e
             self._finish_init()
+
+    def _cpu_fallback_binding(self) -> Optional["Binding"]:
+        # Returns the Binding loaded from cpu.yaml, for use as a fallback on
+        # /cpus/cpu@N nodes that have no 'compatible' property.
+        #
+        # The result is cached in self._cpu_binding so cpu.yaml is parsed at
+        # most once per EDT instance, regardless of how many binding-less CPU
+        # nodes exist. Each EDT instance has its own cache, so two EDT objects
+        # with different bindings_dirs are fully independent.
+        #
+        # Returns None if cpu.yaml is not present in bindings_dirs (e.g. a
+        # minimal test-bindings directory), in which case binding-less CPU
+        # nodes receive no fallback binding.
+        if self._cpu_binding is not None:
+            return self._cpu_binding
+
+        cpu_yaml_path = self._binding_fname2path.get("cpu.yaml")
+        if cpu_yaml_path is None:
+            return None
+
+        self._cpu_binding = Binding(
+            cpu_yaml_path,
+            self._binding_fname2path,
+            require_compatible=False,
+            require_description=False,
+        )
+        return self._cpu_binding
+
+    def _werror_msg(self, msg: str) -> None:
+        if self._werror:
+            _err(msg)
+        else:
+            _LOG.warning(msg)
 
     def _finish_init(self) -> None:
         # This helper exists to make the __deepcopy__() implementation
@@ -2835,6 +2887,9 @@ class EDT:
             self.nodes.append(node)
             self._node2enode[dt_node] = node
 
+            if _is_cpu_node(node):
+                self.cpus.append(node)
+
         for node in self.nodes:
             # Initialize properties that may depend on other Node objects having
             # been created, because they (either always or sometimes) reference
@@ -2887,11 +2942,7 @@ class EDT:
                     # As an exception, the root node can have whatever
                     # compatibles it wants. Other nodes get checked.
                     elif node.path != '/':
-                        if self._werror:
-                            handler_fn: Any = _err
-                        else:
-                            handler_fn = _LOG.warning
-                        handler_fn(
+                        self._werror_msg(
                             f"node '{node.path}' compatible '{compat}' "
                             f"has unknown vendor prefix '{vendor}'")
 
@@ -2943,6 +2994,46 @@ class EDT:
             for compat in compatibles:
                 # This is also just for future-proofing.
                 assert isinstance(compat, str)
+
+        # CPU binding type-consistency check.
+        # Warn (or error with werror=True) when a vendor binding declares a
+        # cpu.yaml property with an incompatible type.  Nodes without a
+        # compatible used the cpu.yaml fallback directly; there is no vendor
+        # binding to blame, so they are skipped.
+        #
+        # Call _cpu_fallback_binding() explicitly here: if every CPU node has
+        # a compatible, the lazy accessor was never triggered during node init,
+        # so self._cpu_binding would still be None without this call.
+        cpu_binding = self._cpu_fallback_binding()
+        if cpu_binding is None:
+            return
+
+        for node in self.cpus:
+            if not node.compats:
+                # No compatible: node used the fallback binding. Nothing to
+                # compare against cpu.yaml.
+                continue
+
+            node_binding = node.binding
+            if node_binding is None:
+                continue
+
+            for prop_name, cpu_spec in cpu_binding.prop2specs.items():
+                if prop_name not in node_binding.prop2specs:
+                    continue
+
+                node_type = node_binding.prop2specs[prop_name].type
+                cpu_type = cpu_spec.type
+
+                if node_type == cpu_type:
+                    continue
+
+                msg = (
+                    f"CPU binding '{node_binding.path}' declares property "
+                    f"'{prop_name}' with type '{node_type}', but "
+                    f"cpu.yaml expects type '{cpu_type}'"
+                )
+                self._werror_msg(msg)
 
 
 def bindings_from_paths(yaml_paths: list[str],
@@ -4011,8 +4102,7 @@ _BindingLoader.add_constructor("!include", _binding_include)
 # "Default" binding for properties which are defined by the spec.
 #
 # Zephyr: do not change the _DEFAULT_PROP_TYPES keys without
-# updating the documentation for the DT_PROP() macro in
-# include/devicetree.h.
+# updating the documentation for the DT_PROP() macro.
 #
 
 _DEFAULT_PROP_TYPES: dict[str, str] = {
@@ -4057,3 +4147,14 @@ _DEFAULT_PROP_SPECS: dict[str, PropertySpec] = {
     name: PropertySpec(name, _DEFAULT_PROP_BINDING)
     for name in _DEFAULT_PROP_TYPES
 }
+
+def _is_cpu_node(node: "Node") -> bool:
+    # Returns True if 'node' is a /cpus/cpu@N node per DT spec SS3.8:
+    # a direct child of /cpus whose name-without-unit-address is "cpu".
+    # This structural check is used both to populate edt.cpus and to
+    # decide whether to apply the cpu.yaml fallback in _init_binding().
+    return bool(
+        node.parent
+        and node.parent.path == "/cpus"
+        and node.name.split("@", 1)[0] == "cpu"
+    )

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # Copyright (c) 2019 Linaro Limited
 # Copyright 2025 NXP
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Tip: You can view just the documentation with 'pydoc3 devicetree.edtlib'
@@ -1982,6 +1983,16 @@ class Node:
         if prop_type == "int":
             return prop.to_num(signed_aware=True)
 
+        if prop_type == "uint64":
+            nums = prop.to_nums()
+            if len(nums) == 1:
+                return nums[0]
+            elif len(nums) == 2:
+                return (nums[0] << 32) | nums[1]
+            else:
+                _err(f"'{name}' in {node.path} has type 'uint64' but "
+                     f"{len(nums)} cells; expected 1 or 2")
+
         if prop_type == "array":
             return prop.to_nums(signed_aware=True)
 
@@ -3240,7 +3251,7 @@ def _check_prop_by_type(prop_name: str,
         _err(f"missing 'type:' for '{prop_name}' in 'properties' in "
              f"'{binding_path}'")
 
-    ok_types = {"boolean", "int", "array", "uint8-array", "string",
+    ok_types = {"boolean", "int", "uint64", "array", "uint8-array", "string",
                 "string-array", "phandle", "phandles", "phandle-array",
                 "path", "compound"}
 
@@ -3262,23 +3273,23 @@ def _check_prop_by_type(prop_name: str,
 
     # If you change const_types, be sure to update the type annotation
     # for PropertySpec.const.
-    const_types = {"int", "array", "uint8-array", "string", "string-array"}
+    const_types = {"int", "uint64", "array", "uint8-array", "string", "string-array"}
     if const is not None:
         if prop_type not in const_types:
             _err(f"const in '{binding_path}' for property '{prop_name}' "
                  f"has type '{prop_type}', expected one of " +
                  ", ".join(const_types))
 
-        if prop_type in {"int", "array"}:
+        if prop_type in {"int", "uint64", "array"}:
             for subval in const if isinstance(const, list) else [const]:
                 if not _is_plain_int(subval):
                     _err(f"'const: {const}' for '{prop_name}' in "
                          f"'{binding_path}' is not an integer/array")
 
     if min_val is not None or max_val is not None:
-        if prop_type not in {"int", "array"}:
+        if prop_type not in {"int", "uint64", "array"}:
             _err(f"'min:'/'max:' in '{binding_path}' for '{prop_name}' "
-                 "requires 'type: int' or 'type: array', "
+                 "requires 'type: int', 'type: uint64', or 'type: array', "
                  f"but has type '{prop_type}'")
 
         if "enum" in options:
@@ -3360,6 +3371,7 @@ def _check_prop_by_type(prop_name: str,
         # PropertySpec.default.
 
         if (prop_type == "int" and _is_plain_int(default)
+            or prop_type == "uint64" and _is_plain_int(default)
             or prop_type == "string" and isinstance(default, str)):
             return True
 

--- a/scripts/dts/python-devicetree/tests/test-bindings/test-cpu-conflict.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/test-cpu-conflict.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Test CPU binding with a type conflict on clock-frequency
+compatible: "test,cpu-conflict"
+
+# Intentionally declares clock-frequency as type: string to conflict with
+# cpu.yaml which declares it as type: uint64.  Used by test_cpu_binding_type_conflict
+# and test_cpu_binding_type_mismatch_warning.
+properties:
+  reg:
+    type: array
+
+  clock-frequency:
+    type: string

--- a/scripts/dts/python-devicetree/tests/test-bindings/test-cpu-fallback.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/test-cpu-fallback.yaml
@@ -6,5 +6,5 @@ properties:
     type: array
 
   clock-frequency:
-    type: int
+    type: uint64
     required: true

--- a/scripts/dts/python-devicetree/tests/test-bindings/uint64.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/uint64.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Property uint64 type test
+
+compatible: "vnd,uint64-test"
+
+properties:
+  val-32:
+    type: uint64
+    description: 1-cell (32-bit) uint64 value
+
+  val-64:
+    type: uint64
+    description: 2-cell (64-bit) uint64 value
+
+  val-with-min:
+    type: uint64
+    min: 100
+
+  val-with-max:
+    type: uint64
+    max: 0xFFFFFFFF
+
+  val-with-default:
+    type: uint64
+    default: 42
+
+  val-const:
+    type: uint64
+    const: 999

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -719,5 +719,25 @@
 			reg = <1>;
 			clock-frequency = <2000>;
 		};
+
+		cpu@2 {
+			/* No compatible: exercises the _CPU_BINDING fallback. */
+			device_type = "cpu";
+			reg = <2>;
+			clock-frequency = <3000>;
+			enable-method = "spin-table";
+			status = "disabled";
+		};
+
+		power-states {
+			/* Child of /cpus that is NOT a cpu node: must not appear
+			 * in edt.cpus.
+			 */
+			state0: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				min-residency-us = <500>;
+			};
+		};
 	};
 };

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Nordic Semiconductor
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -492,6 +493,20 @@
 		compatible = "defaults";
 		// Should override the 'default:' in the binding
 		default-not-used = <234>;
+	};
+
+	//
+	// For testing 'type: uint64'
+	//
+
+	uint64-node {
+		compatible = "vnd,uint64-test";
+		val-32 = <100000000>;		/* 0x5F5E100 - 1-cell value */
+		val-64 = <1 0>;			/* 4294967296 = 0x100000000 - 2-cell value */
+		val-with-min = <200>;		/* above min: 100 */
+		val-with-max = <0xabcdef01>;	/* below max: 0xFFFFFFFF */
+		val-const = <999>;		/* matches const: 999 */
+		/* val-with-default intentionally omitted to exercise default: 42 */
 	};
 
 	//

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import contextlib
@@ -823,6 +824,102 @@ def test_prop_defaults():
     assert not isinstance(node.props["int"].spec.default, edtlib.HexInt)
     assert not any(isinstance(v, edtlib.HexInt) for v in node.props["array"].spec.default)
 
+def test_uint64_type():
+    '''type: uint64 assembles 1-cell and 2-cell DTS values into a scalar int'''
+
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    node = edt.get_node("/uint64-node")
+
+    # 1-cell value: plain 32-bit integer returned as scalar
+    assert node.props["val-32"].val == 100000000
+    assert node.props["val-32"].spec.type == "uint64"
+
+    # 2-cell value: assembled 64-bit integer (1 << 32) | 0 = 4294967296
+    assert node.props["val-64"].val == 4294967296
+
+    # min/max constraints work on the assembled value
+    assert node.props["val-with-min"].val == 200
+    assert node.props["val-with-max"].val == 0xABCDEF01
+
+    # const works
+    assert node.props["val-const"].val == 999
+
+    # default is used when property is absent from DTS
+    assert node.props["val-with-default"].val == 42
+
+
+def test_uint64_three_cell_error(tmp_path):
+    '''type: uint64 rejects a 3-cell DTS value with a clear error'''
+
+    dts = tmp_path / "bad.dts"
+    dts.write_text("""\
+/dts-v1/;
+/ {
+    #address-cells = <1>;
+    #size-cells = <1>;
+    n {
+        compatible = "vnd,uint64-test";
+        val-32 = <1 2 3>;
+    };
+};
+""")
+    with from_here():
+        with pytest.raises(edtlib.EDTError) as exc_info:
+            edtlib.EDT(str(dts), ["test-bindings"])
+    msg = str(exc_info.value)
+    assert "uint64" in msg
+    assert "3" in msg
+
+
+def test_uint64_min_max(tmp_path):
+    '''type: uint64 min: constraint is enforced on the assembled value'''
+
+    dts = tmp_path / "bad.dts"
+    dts.write_text("""\
+/dts-v1/;
+/ {
+    #address-cells = <1>;
+    #size-cells = <1>;
+    n {
+        compatible = "vnd,uint64-test";
+        val-with-min = <50>;
+    };
+};
+""")
+    with from_here():
+        with pytest.raises(edtlib.EDTError) as exc_info:
+            edtlib.EDT(str(dts), ["test-bindings"])
+    assert "min" in str(exc_info.value).lower()
+
+
+def test_uint64_binding_errs(tmp_path):
+    '''Binding validator: min:/max: accepted on uint64; min-len: rejected'''
+
+    def check_binding_err(yaml_content, expected_err):
+        binding_file = tmp_path / "bad-uint64.yaml"
+        binding_file.write_text(yaml_content)
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding(str(binding_file), {})
+        assert str(e.value) == expected_err
+
+    path = str(tmp_path / "bad-uint64.yaml")
+
+    # min-len: on uint64 must be rejected
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: uint64
+    min-len: 1
+""",
+        f"'min-len:'/'max-len:' in '{path}' for 'foo' "
+        f"requires an array type, but has type 'uint64'")
+
+
 def test_prop_enums():
     '''test properties with enum: in the binding'''
 
@@ -1107,7 +1204,7 @@ properties:
     min: 0
 """,
         f"'min:'/'max:' in '{path}' for 'foo' requires "
-        f"'type: int' or 'type: array', but has type 'string'")
+        f"'type: int', 'type: uint64', or 'type: array', but has type 'string'")
 
     # min/max combined with enum
     check_binding_err(

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -782,6 +782,123 @@ def test_cpu_props_fallback_from_cpus_node():
     # CPU-local value takes precedence.
     assert cpu1.props["clock-frequency"].val == 2000
 
+
+def test_edt_cpus_list():
+    """edt.cpus contains exactly the /cpus/cpu@N nodes in source order.
+
+    Non-cpu children of /cpus (e.g. power-states) must not appear in the
+    list.
+    """
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    cpu_paths = [n.path for n in edt.cpus]
+    assert cpu_paths == ["/cpus/cpu@0", "/cpus/cpu@1", "/cpus/cpu@2"]
+
+
+def test_cpu_fallback_binding():
+    """A /cpus/cpu@N node with no compatible receives the cpu.yaml binding.
+
+    Verifies binding_path, property types, and property values including
+    a disabled status.
+    """
+    with from_here():
+        edt = edtlib.EDT(
+            "test.dts",
+            ["test-bindings", "../../../../dts/bindings"],
+        )
+
+    cpu2 = edt.get_node("/cpus/cpu@2")
+
+    assert cpu2.binding_path is not None
+    assert cpu2.binding_path.endswith("cpu.yaml")
+    assert cpu2.props["device_type"].val == "cpu"
+    assert cpu2.props["clock-frequency"].val == 3000
+    assert cpu2.props["enable-method"].val == "spin-table"
+    assert cpu2.props["status"].val == "disabled"
+
+
+def test_cpu_binding_type_conflict(tmp_path):
+    """A vendor CPU binding that conflicts with cpu.yaml raises EDTError (werror=True).
+
+    The error message must name the property, the declared type, and the
+    expected type from cpu.yaml.
+    """
+    dts = tmp_path / "conflict.dts"
+    dts.write_text(textwrap.dedent("""\
+        /dts-v1/;
+        / {
+            #address-cells = <1>;
+            #size-cells = <1>;
+            cpus {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                cpu@0 {
+                    compatible = "test,cpu-conflict";
+                    device_type = "cpu";
+                    reg = <0>;
+                };
+            };
+        };
+    """))
+
+    with from_here():
+        with pytest.raises(edtlib.EDTError) as exc_info:
+            edtlib.EDT(
+                str(dts),
+                ["test-bindings", "../../../../dts/bindings"],
+                werror=True,
+            )
+
+    msg = str(exc_info.value)
+    assert "clock-frequency" in msg
+    assert "string" in msg
+    assert "uint64" in msg
+
+
+def test_cpu_binding_type_mismatch_warning(caplog, tmp_path):
+    """A vendor CPU binding that conflicts with cpu.yaml emits a warning (werror=False).
+
+    No EDTError must be raised; the warning message must contain the same
+    information as the hard-error path.
+    """
+    dts = tmp_path / "conflict.dts"
+    dts.write_text(textwrap.dedent("""\
+        /dts-v1/;
+        / {
+            #address-cells = <1>;
+            #size-cells = <1>;
+            cpus {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                cpu@0 {
+                    compatible = "test,cpu-conflict";
+                    device_type = "cpu";
+                    reg = <0>;
+                };
+            };
+        };
+    """))
+
+    with caplog.at_level(WARNING):
+        with from_here():
+            # Must not raise even though there is a type conflict.
+            edtlib.EDT(
+                str(dts),
+                ["test-bindings", "../../../../dts/bindings"],
+                werror=False,
+            )
+
+    conflict_warnings = [
+        r.message for r in caplog.records
+        if "clock-frequency" in str(r.message)
+    ]
+    assert conflict_warnings, "expected a warning about clock-frequency type conflict"
+    msg = str(conflict_warnings[0])
+    assert "string" in msg
+    assert "uint64" in msg
+
+
 def test_nexus():
     '''Test <prefix>-map via gpio-map (the most common case).'''
     with from_here():

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -59,6 +59,14 @@
 			c = "bar", "baz";
 		};
 
+		test_uint64: uint64-holder {
+			compatible = "vnd,uint64-holder";
+			val-32 = <100000000>;	/* 0x5F5E100 - 1-cell value */
+			val-64 = <1 0>;		/* 4294967296 = 0x100000000 - 2-cell value */
+			/* val-with-default intentionally omitted to exercise default: 42 */
+			/* val-with-or intentionally omitted to exercise DT_PROP_OR fallback */
+		};
+
 		test_phandles: phandle-holder-0 {
 			/*
 			 * There should only be one vnd,phandle-holder in the entire DTS.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -21,6 +21,7 @@
 #define TEST_NODELABEL	DT_NODELABEL(test_nodelabel)
 #define TEST_INST	DT_INST(0, vnd_gpio_device)
 #define TEST_ARRAYS	DT_NODELABEL(test_arrays)
+#define TEST_UINT64	DT_NODELABEL(test_uint64)
 #define TEST_PH		DT_NODELABEL(test_phandles)
 #define TEST_INTC	DT_NODELABEL(test_intc)
 #define TEST_INTC2	DT_NODELABEL(test_intc2)
@@ -2172,6 +2173,52 @@ ZTEST(devicetree_api, test_arrays)
 	zassert_true(!strcmp(DT_PROP_BY_IDX(TEST_ARRAYS, c, 1), c[1]), "");
 
 	zassert_equal(DT_PROP_LEN(TEST_ARRAYS, c), 2, "");
+}
+
+/*
+ * Compile-time check: uint64 is a scalar type so gen_defines.py must NOT
+ * emit a _LEN macro for it. If it did, the DT_PROP_LEN_OR expansion below
+ * would reference an undefined identifier and this file would fail to compile.
+ * The fact that this translation unit compiles is the proof.
+ *
+ * We use the absent property (val_with_or has no _EXISTS) so DT_PROP_LEN_OR
+ * safely returns the fallback without touching _LEN.
+ */
+BUILD_ASSERT(DT_PROP_LEN_OR(TEST_UINT64, val_with_or, 0) == 0,
+	     "absent uint64 property must have no _LEN macro");
+
+ZTEST(devicetree_api, test_uint64_prop)
+{
+	/*
+	 * 1-cell value: DT_PROP must return a plain scalar integer,
+	 * not a brace-initializer list.
+	 */
+	zassert_equal(DT_PROP(TEST_UINT64, val_32), 100000000, "");
+
+	/*
+	 * 2-cell value <1 0>: assembled as (1 << 32) | 0 = 4294967296.
+	 * Cast to uint64_t to avoid truncation on 32-bit hosts.
+	 */
+	zassert_equal((uint64_t)DT_PROP(TEST_UINT64, val_64),
+		      (uint64_t)UINT64_C(4294967296), "");
+
+	/* DT_PROP_OR: property present - must return the property value */
+	zassert_equal(DT_PROP_OR(TEST_UINT64, val_32, 0), 100000000, "");
+
+	/* DT_PROP_OR: property absent - must return the fallback */
+	zassert_equal(DT_PROP_OR(TEST_UINT64, val_with_or, 999), 999, "");
+
+	/* DT_NODE_HAS_PROP: present property must return 1 */
+	zassert_equal(DT_NODE_HAS_PROP(TEST_UINT64, val_32), 1, "");
+
+	/* DT_NODE_HAS_PROP: absent property must return 0 */
+	zassert_equal(DT_NODE_HAS_PROP(TEST_UINT64, val_with_or), 0, "");
+
+	/*
+	 * default: in binding is used when property is absent from DTS.
+	 * val-with-default has default: 42 and is not set in the overlay.
+	 */
+	zassert_equal(DT_PROP(TEST_UINT64, val_with_default), 42, "");
 }
 
 ZTEST(devicetree_api, test_foreach)


### PR DESCRIPTION
## Summary

This PR adds a `uint64` binding property type and updates CPU devicetree
support to use it.

The Devicetree specification permits the standard CPU `clock-frequency` and
`timebase-frequency` properties to be encoded as either one 32-bit cell or
two 32-bit cells representing a 64-bit value. Zephyr currently models these
properties as `int`, which accepts only the former. Modeling them as `array`
would accept both encodings, but would change `DT_PROP()` from a scalar
integer to a brace initializer and break existing C users.

The new `uint64` type accepts one or two cells, converts them to one integer
in edtlib, and emits a scalar integer literal for `DT_PROP()`. This correctly
models the specification while preserving the existing scalar C API. The type
is general-purpose and can be used by other spec-level bindings with the same
encoding. The PR includes edtlib unit tests and an end-to-end Ztest covering
the generated C macros.

## CPU Support

This PR updates `cpu.yaml` to use `uint64` for `clock-frequency` and
`timebase-frequency`, so CPU bindings can accept both valid encodings without
breaking existing DTS files or C call sites.

It also makes CPU enumeration structural. Per the Devicetree specification,
CPU nodes are direct `/cpus` children named `cpu@N`; they do not require a
`compatible` property or an explicit `device_type` property. The previous
`DT_FOREACH_CPU*` implementation filtered `/cpus` children in the C
preprocessor based on `device_type`, which can omit otherwise valid CPU
nodes. `edt.cpus` provides the canonical source-ordered list of structural CPU
nodes, and `gen_defines.py` emits the helper macros consumed by the existing
`DT_FOREACH_CPU*` interfaces.

Using the same structural definition also allows edtlib to apply `cpu.yaml` as
a fallback binding to CPU nodes without a `compatible`. Such nodes previously
had no binding, leaving standard CPU properties untyped and `cpu.yaml`
defaults unavailable.

Finally, the PR checks vendor CPU bindings against `cpu.yaml` and warns, or
fails with `werror=True`, when they redeclare a standard CPU property with a
different type. This keeps vendor bindings consistent with the specification
defined CPU property types, including the new `uint64` frequency properties.

The CPU macro implementation builds on the approach in
zephyrproject-rtos/zephyr#114235.