### PR TITLE
west: build: survive a source directory on another drive

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -400,8 +400,10 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
          - ``board``: The board name
          - ``source_dir``: Path to the CMake source directory, relative to the
            current working directory. If the current working directory is
-           inside the source directory, this is an empty string. If no source
-           directory is specified, it defaults to current working directory.
+           inside the source directory, this is an empty string, as it is on
+           Windows for a source directory on another drive, which has no
+           relative path to the current one. If no source directory is
+           specified, it defaults to current working directory.
            E.g. if ``west build ../app`` is run from ``<west_topdir>/app1``,
            ``source_dir`` resolves to ``../app`` (which is the relative path
            to the current working dir).

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -143,7 +143,12 @@ def _resolve_build_dir(fmt, guess, cwd, **kwargs):
     source_dir = kwargs.get('source_dir')
     if source_dir:
         if escapes_directory(cwd, source_dir):
-            kwargs['source_dir'] = os.path.relpath(source_dir, cwd)
+            try:
+                kwargs['source_dir'] = os.path.relpath(source_dir, cwd)
+            except ValueError:
+                # Two paths with no common root have no relative path between
+                # them at all: on Windows, ones on different drives.
+                kwargs['source_dir'] = ''
         else:
             # no meaningful relative path possible
             kwargs['source_dir'] = ''

--- a/scripts/west_commands/tests/test_build_helpers.py
+++ b/scripts/west_commands/tests/test_build_helpers.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+'''Tests for picking a build directory.'''
+
+import os
+
+import pytest
+
+from build_helpers import _resolve_build_dir, find_build_dir, is_zephyr_build
+
+FMT = 'build/{source_dir}'
+
+
+@pytest.fixture
+def tree(tmp_path):
+    '''work/app, work/app/build and other/app, all real directories.'''
+    (tmp_path / 'work' / 'app' / 'build').mkdir(parents=True)
+    (tmp_path / 'other' / 'app').mkdir(parents=True)
+    return tmp_path
+
+
+def resolve(cwd, source_dir, fmt=FMT, guess=False):
+    return _resolve_build_dir(fmt, guess, str(cwd), source_dir=str(source_dir), board='qemu_x86')
+
+
+def test_a_source_below_the_cwd_is_named_relative_to_it(tree):
+    got = resolve(tree / 'work', tree / 'work' / 'app')
+
+    assert got == 'build/app'
+
+
+def test_a_cwd_below_the_source_leaves_the_source_out(tree):
+    """There is no useful way to name a directory above the current one."""
+    got = resolve(tree / 'work' / 'app' / 'build', tree / 'work' / 'app')
+
+    assert got == 'build/'
+
+
+def test_a_source_beside_the_cwd_is_still_named_relative_to_it(tree):
+    """Going up and across is a relative path like any other."""
+    got = resolve(tree / 'work', tree / 'other' / 'app')
+
+    assert got == 'build/' + os.path.join('..', 'other', 'app')
+
+
+@pytest.mark.skipif(os.name != 'nt', reason='drive letters are a Windows thing')
+def test_a_source_on_another_drive_leaves_the_source_out(tree):
+    """os.path.relpath refuses two paths on different drives.
+
+    The source directory is made relative before the format string is even
+    looked at, so a format that does not mention it is affected too.
+    """
+    other_drive = 'D:' if str(tree)[0].upper() != 'D' else 'E:'
+
+    assert resolve(tree / 'work', other_drive + os.sep + 'app') == 'build/'
+    assert (
+        _resolve_build_dir(
+            'build',
+            False,
+            str(tree / 'work'),
+            source_dir=other_drive + os.sep + 'app',
+            board='qemu_x86',
+        )
+        == 'build'
+    )
+
+
+def test_a_source_that_is_not_named_at_all(tree):
+    got = _resolve_build_dir('build', False, str(tree), board='qemu_x86')
+
+    assert got == 'build'
+
+
+def test_a_format_naming_something_that_was_not_given(tree):
+    """Without --guess there is nothing to fall back on."""
+    got = _resolve_build_dir('build/{shield}', False, str(tree), board='qemu_x86')
+
+    assert got is None
+
+
+def test_is_zephyr_build_of_a_directory_that_is_not_one(tree):
+    assert is_zephyr_build(str(tree / 'work')) is False
+
+
+def test_is_zephyr_build_of_nothing(tree):
+    assert is_zephyr_build('') is False
+    assert is_zephyr_build(None) is False
+
+
+@pytest.mark.parametrize('variable', ['ZEPHYR_BASE', 'ZEPHYR_TOOLCHAIN_VARIANT'])
+def test_is_zephyr_build_of_a_build_directory(tree, variable):
+    """Either variable in the cache is enough, for old build directories."""
+    build = tree / 'work' / 'app' / 'build'
+    (build / 'CMakeCache.txt').write_text(f'{variable}:PATH=/somewhere\n', encoding='utf-8')
+
+    assert is_zephyr_build(str(build)) is True
+
+
+class FakeConfig:
+    '''Just enough of west.configuration.Configuration to answer a lookup.'''
+
+    def __init__(self, **values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+def test_find_build_dir_prefers_what_it_is_given(tree):
+    '''A directory named outright wins over build.dir-fmt.
+
+    The format below points at a real build directory, so it is what would
+    be returned if the named one did not come first. The config is handed
+    in rather than left as None: None sends find_build_dir looking for a
+    west workspace, and it would find whichever one the tests are run in.
+    '''
+    build = tree / 'work' / 'app' / 'build'
+    (build / 'CMakeCache.txt').write_text('ZEPHYR_BASE:PATH=/somewhere\n', encoding='utf-8')
+    config = FakeConfig(**{'build.dir-fmt': str(build)})
+
+    assert find_build_dir(str(tree / 'work'), config=config) == str(tree / 'work')
+    assert is_zephyr_build(str(build)) is True


### PR DESCRIPTION
## What

`_resolve_build_dir()` names the source directory relative to the current one before it looks at the format string at all:

```python
    source_dir = kwargs.get('source_dir')
    if source_dir:
        if escapes_directory(cwd, source_dir):
            kwargs['source_dir'] = os.path.relpath(source_dir, cwd)
        else:
            # no meaningful relative path possible
            kwargs['source_dir'] = ''
```

Two paths on different Windows drives have no relative path between them, and `os.path.relpath` says so:

```
ValueError: path is on mount 'D:', start on mount 'C:'
```

So `west build` with `build.dir-fmt` set and a source directory on another drive ends in a traceback — and does so whatever the format string is, since this runs before it is used:

```
>>> _resolve_build_dir('build', False, r'C:\work', source_dir=r'D:\app', board='qemu_x86')
ValueError: path is on mount 'D:', start on mount 'C:'
>>> _resolve_build_dir('build/{board}', False, r'C:\work', source_dir=r'D:\app', board='qemu_x86')
ValueError: path is on mount 'D:', start on mount 'C:'
```

The change falls back to naming nothing, which is what the branch below already does when there is no useful relative path to give.

**Going up and across is untouched.** `tests/west_build/test_resolve_build_dir.py` asks for `'../subdir'` when the source is outside the current directory, and still gets it — that is a relative path, just not a downward one. Only the case where no relative path exists at all is new.

## Commits

1. **tests: west: cover is_zephyr_build and the build dir it is given** — `tests/west_build` covers `_resolve_build_dir`'s format handling; the rest of `build_helpers` had no tests. `is_zephyr_build` (both cache variables, and the empty cases) and `find_build_dir` returning what it is handed, plus the three arrangements the source and current directories can be in, against real directories. Green on unmodified `build_helpers.py`.

2. **west: build: survive a source directory on another drive** — the fallback, and a test for it.

## Verification

| | result |
|---|---|
| `scripts/west_commands` tests, Windows | **919 passed / 2 skipped** (`main`: 908 / 2) |
| first commit alone (bisect), Windows | 918 passed / 2 skipped |
| same, Linux | **920 passed / 1 skipped** (`main`: 910) |
| `ruff check`, `ruff format --diff`, `pylint --rcfile=scripts/ci/pylintrc` | clean |
| `mypy --package=runners` | clean, 55 source files |
| `check_compliance.py -m Ruff -m Gitlint -m Nits -m GitDiffCheck -m TextEncoding` | passes (`ruff==0.14.2`) |

Red, with the change reverted and the tests kept: one test fails, and it is the one the change is about.

The drive test is skipped where there are no drive letters, so it runs on the `windows-2025` leg of `west_cmds.yml` and nowhere else. The rest run everywhere.

The Linux run here is under WSL, where `tests/test_bossac.py` fails all 14 of its tests — `bossac.py` detects WSL and refuses to run. Unrelated to this change and the same before and after.

