### PR TITLE
drivers: memc: stm32: enable FMC peripheral globally in initialization

### DIFF
--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -69,6 +69,12 @@ static int memc_stm32_init(const struct device *dev)
 		}
 	}
 
+#if defined(FMC_BCR1_FMCEN)
+	stm32_reg_modify_bits(&FMC_Bank1_R->BTCR[0], FMC_BCR1_FMCEN, FMC_BCR1_FMCEN);
+#elif defined(FMC_CFGR_FMCEN)
+	stm32_reg_modify_bits(&FMC_COMMON_DEVICE->CFGR, FMC_CFGR_FMCEN, FMC_CFGR_FMCEN);
+#endif
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_fmc)
 #if (DT_ENUM_IDX(DT_DRV_INST(0), st_mem_swap) == 1)
 	/* sdram-sram */


### PR DESCRIPTION
drivers: memc: stm32: enable FMC peripheral globally in init
On several STM32 families (STM32H7, STM32U5, STM32H5, STM32H7RS,
STM32N6, STM32MP1, STM32MP2), the Flexible Memory Controller (FMC)
features a master controller enable bit (FMC_BCR1_FMCEN or
FMC_CFGR_FMCEN) in the hardware registers.

Currently, memc_stm32_init() enables the peripheral clock and
configures pinmux, but omits asserting the master controller enable
bit. When accessing memory banks (e.g., via MIPI-DBI host controller
on Bank 4 or standalone devices), this triggers a Cortex-M BusFault.

Enable the FMC controller globally during memc_stm32_init() using
CMSIS register bit definitions (FMC_BCR1_FMCEN / FMC_CFGR_FMCEN) via
stm32_reg_modify_bits().

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/118006

Signed-off-by: Priyanshu Singh <singhpriyanshu9838@gmail.com>