### PR TITLE
soc: espressif: fix kconfig capability symbol prefix

### DIFF
--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -30,7 +30,7 @@ extern char *ble_controller_get_compile_version(void);
 #define esp32_get_controller_version() ble_controller_get_compile_version()
 #endif
 
-#if defined(CONFIG_ESP32_BT_LE_SLEEP_ENABLE) && defined(CONFIG_ESP32_SOC_PAU_SUPPORTED)
+#if defined(CONFIG_ESP32_BT_LE_SLEEP_ENABLE) && defined(CONFIG_SOC_ESP32_PAU_SUPPORTED)
 extern bool r_ble_lll_sleep_should_skip_light_sleep_check(void);
 #endif
 
@@ -855,7 +855,7 @@ static int bt_esp32_pm_action(const struct device *dev, enum pm_device_action ac
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-#if defined(CONFIG_ESP32_BT_LE_SLEEP_ENABLE) && defined(CONFIG_ESP32_SOC_PAU_SUPPORTED)
+#if defined(CONFIG_ESP32_BT_LE_SLEEP_ENABLE) && defined(CONFIG_SOC_ESP32_PAU_SUPPORTED)
 		if (r_ble_lll_sleep_should_skip_light_sleep_check()) {
 			return -EBUSY;
 		}

--- a/drivers/counter/Kconfig.esp32_tmr
+++ b/drivers/counter/Kconfig.esp32_tmr
@@ -8,7 +8,7 @@ config COUNTER_TMR_ESP32
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_COUNTER_ENABLED
 	select COUNTER_SUPPORTS_64BITS_TICKS
-	select COUNTER_SUPPORTS_CAPTURE if ESP32_SOC_ETM_SUPPORTED
+	select COUNTER_SUPPORTS_CAPTURE if SOC_ESP32_ETM_SUPPORTED
 	help
 	  Enables the Counter driver API based on Espressif's General
 	  Purpose Timers for ESP32 series devices.
@@ -17,7 +17,7 @@ config COUNTER_TMR_ESP32_CAPTURE
 	bool "ESP32 GP-Timer counter capture via ETM"
 	default y
 	depends on COUNTER_TMR_ESP32 && COUNTER_CAPTURE
-	depends on ESP32_SOC_ETM_SUPPORTED
+	depends on SOC_ESP32_ETM_SUPPORTED
 	select ESP32_ETM
 	help
 	  Enables GPIO edge triggered counter capture for the ESP32

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -606,7 +606,7 @@ static int counter_esp32_capture_setup(const struct device *dev)
 		return ret;
 	}
 
-	/* The capture task always exists on SoCs gated by ESP32_SOC_ETM_SUPPORTED. */
+	/* The capture task always exists on SoCs gated by SOC_ESP32_ETM_SUPPORTED. */
 	task_id = TIMER_LL_ETM_TASK_TABLE(cfg->group, data->hal_ctx.timer_id,
 					  GPTIMER_ETM_TASK_CAPTURE);
 

--- a/soc/espressif/common/Kconfig
+++ b/soc/espressif/common/Kconfig
@@ -3,7 +3,7 @@
 
 config ESP32_ETM
 	bool
-	depends on ESP32_SOC_ETM_SUPPORTED
+	depends on SOC_ESP32_ETM_SUPPORTED
 	help
 	  Espressif Event Task Matrix (ETM) channel allocator. The ETM
 	  routes a peripheral event to a peripheral task in hardware. This

--- a/soc/espressif/common/Kconfig.pm
+++ b/soc/espressif/common/Kconfig.pm
@@ -7,7 +7,7 @@ menu "Espressif PM Config"
 
 config ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP
 	bool "Power down CPU in light sleep"
-	depends on ESP32_SOC_PM_SUPPORT_CPU_PD
+	depends on SOC_ESP32_PM_SUPPORT_CPU_PD
 	select ESP32_PM_RESTORE_CACHE_TAGMEM_AFTER_LIGHT_SLEEP if ESP32S3_DATA_CACHE_16KB
 	default y
 	help
@@ -20,7 +20,7 @@ config ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP
 
 choice ESP32_PM_CPU_RETENTION_STRATEGY
 	prompt "Retentive memory allocation strategy for light sleep"
-	depends on ESP32_SOC_PM_CPU_RETENTION_BY_SW
+	depends on SOC_ESP32_PM_CPU_RETENTION_BY_SW
 	depends on ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP
 	default ESP32_PM_CPU_RETENTION_DYNAMIC
 
@@ -50,7 +50,7 @@ config ESP32_PM_RESTORE_CACHE_TAGMEM_AFTER_LIGHT_SLEEP
 
 config ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP
 	bool "Power down digital peripherals in light sleep (EXPERIMENTAL)"
-	depends on ESP32_SOC_PM_SUPPORT_TOP_PD && ESP32_SOC_PAU_SUPPORTED
+	depends on SOC_ESP32_PM_SUPPORT_TOP_PD && SOC_ESP32_PAU_SUPPORTED
 	select ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP
 	help
 	  Allow the main digital (TOP) peripheral power domain to switch off
@@ -93,8 +93,8 @@ config ESP32_PM_SLP_IRAM_OPT
 
 config ESP32_SLEEP_POWER_DOWN_FLASH
 	bool "Power down flash supply in light sleep (VDDSDIO path)"
-	depends on ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
-	depends on ESP32_SOC_FLASH_SUPPORTED
+	depends on SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
+	depends on SOC_ESP32_FLASH_SUPPORTED
 	depends on !ESP_SPIRAM
 	select ESP32_PM_SLP_IRAM_OPT
 	help
@@ -107,7 +107,7 @@ config ESP32_SLEEP_POWER_DOWN_FLASH
 
 config ESP32_SLEEP_SET_FLASH_DPD
 	bool "SPI flash deep power-down mode in light sleep"
-	depends on ESP32_SOC_FLASH_SUPPORTED
+	depends on SOC_ESP32_FLASH_SUPPORTED
 	depends on !ESP32_SLEEP_POWER_DOWN_FLASH
 	select ESP32_PM_SLP_IRAM_OPT
 	help

--- a/soc/espressif/common/esp_psram.c
+++ b/soc/espressif/common/esp_psram.c
@@ -10,7 +10,7 @@
 #include <esp_private/esp_psram_extram.h>
 #include <hal/cache_hal.h>
 #include <zephyr/multi_heap/shared_multi_heap.h>
-#if defined(CONFIG_ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING)
+#if defined(CONFIG_SOC_ESP32_SPI_MEM_SUPPORT_TIMING_TUNING)
 #include <esp_flash.h>
 #include <esp_private/spi_flash_os.h>
 #include <hal/spi_flash_hal.h>
@@ -36,7 +36,7 @@ int esp_psram_smh_init(void)
 	return shared_multi_heap_add(&smh_psram, NULL);
 }
 
-#if defined(CONFIG_ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING)
+#if defined(CONFIG_SOC_ESP32_SPI_MEM_SUPPORT_TIMING_TUNING)
 /*
  * PSRAM timing tuning reprograms the MSPI core clock, which is shared
  * between flash and PSRAM. The esp_flash driver latched the flash
@@ -83,7 +83,7 @@ void esp_init_psram(void)
 		return;
 	}
 
-#if defined(CONFIG_ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING)
+#if defined(CONFIG_SOC_ESP32_SPI_MEM_SUPPORT_TIMING_TUNING)
 	esp_psram_refresh_flash_timing();
 #endif
 

--- a/soc/espressif/esp32/Kconfig.caps
+++ b/soc/espressif/esp32/Kconfig.caps
@@ -1,11 +1,11 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 

--- a/soc/espressif/esp32c2/Kconfig.caps
+++ b/soc/espressif/esp32c2/Kconfig.caps
@@ -1,11 +1,11 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 

--- a/soc/espressif/esp32c3/Kconfig.caps
+++ b/soc/espressif/esp32c3/Kconfig.caps
@@ -1,15 +1,15 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_PM_SUPPORT_CPU_PD
+config SOC_ESP32_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 

--- a/soc/espressif/esp32c5/Kconfig.caps
+++ b/soc/espressif/esp32c5/Kconfig.caps
@@ -1,11 +1,11 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_PM_SUPPORT_CPU_PD
+config SOC_ESP32_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
-config ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING
+config SOC_ESP32_SPI_MEM_SUPPORT_TIMING_TUNING
 	bool
 	default y
 
@@ -17,26 +17,26 @@ config SOC_ESP32_WIFI_HE_SUPPORT
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_TOP_PD
+config SOC_ESP32_PM_SUPPORT_TOP_PD
 	bool
 	default y
 
-config ESP32_SOC_PAU_SUPPORTED
+config SOC_ESP32_PAU_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_CPU_RETENTION_BY_SW
+config SOC_ESP32_PM_CPU_RETENTION_BY_SW
 	bool
 	default y
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 
-config ESP32_SOC_ETM_SUPPORTED
+config SOC_ESP32_ETM_SUPPORTED
 	bool
 	default y

--- a/soc/espressif/esp32c6/Kconfig.caps
+++ b/soc/espressif/esp32c6/Kconfig.caps
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_PM_SUPPORT_CPU_PD
+config SOC_ESP32_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
@@ -13,26 +13,26 @@ config SOC_ESP32_WIFI_HE_SUPPORT
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_TOP_PD
+config SOC_ESP32_PM_SUPPORT_TOP_PD
 	bool
 	default y
 
-config ESP32_SOC_PAU_SUPPORTED
+config SOC_ESP32_PAU_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_CPU_RETENTION_BY_SW
+config SOC_ESP32_PM_CPU_RETENTION_BY_SW
 	bool
 	default y
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 
-config ESP32_SOC_ETM_SUPPORTED
+config SOC_ESP32_ETM_SUPPORTED
 	bool
 	default y

--- a/soc/espressif/esp32c61/Kconfig.caps
+++ b/soc/espressif/esp32c61/Kconfig.caps
@@ -1,34 +1,34 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_PM_SUPPORT_CPU_PD
+config SOC_ESP32_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
-config ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING
+config SOC_ESP32_SPI_MEM_SUPPORT_TIMING_TUNING
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_TOP_PD
+config SOC_ESP32_PM_SUPPORT_TOP_PD
 	bool
 	default y
 
-config ESP32_SOC_PAU_SUPPORTED
+config SOC_ESP32_PAU_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_CPU_RETENTION_BY_SW
+config SOC_ESP32_PM_CPU_RETENTION_BY_SW
 	bool
 	default y
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 
-config ESP32_SOC_ETM_SUPPORTED
+config SOC_ESP32_ETM_SUPPORTED
 	bool
 	default y

--- a/soc/espressif/esp32h2/Kconfig.caps
+++ b/soc/espressif/esp32h2/Kconfig.caps
@@ -1,30 +1,30 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_PM_SUPPORT_CPU_PD
+config SOC_ESP32_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_TOP_PD
+config SOC_ESP32_PM_SUPPORT_TOP_PD
 	bool
 	default y
 
-config ESP32_SOC_PAU_SUPPORTED
+config SOC_ESP32_PAU_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_CPU_RETENTION_BY_SW
+config SOC_ESP32_PM_CPU_RETENTION_BY_SW
 	bool
 	default y
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 
-config ESP32_SOC_ETM_SUPPORTED
+config SOC_ESP32_ETM_SUPPORTED
 	bool
 	default y

--- a/soc/espressif/esp32p4/Kconfig.caps
+++ b/soc/espressif/esp32p4/Kconfig.caps
@@ -1,26 +1,26 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_PM_SUPPORT_CPU_PD
+config SOC_ESP32_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_TOP_PD
+config SOC_ESP32_PM_SUPPORT_TOP_PD
 	bool
 	default y
 
-config ESP32_SOC_PAU_SUPPORTED
+config SOC_ESP32_PAU_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_CPU_RETENTION_BY_SW
+config SOC_ESP32_PM_CPU_RETENTION_BY_SW
 	bool
 	default y
 
-config ESP32_SOC_ETM_SUPPORTED
+config SOC_ESP32_ETM_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING
+config SOC_ESP32_SPI_MEM_SUPPORT_TIMING_TUNING
 	bool
 	default y

--- a/soc/espressif/esp32s2/Kconfig.caps
+++ b/soc/espressif/esp32s2/Kconfig.caps
@@ -1,11 +1,11 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 

--- a/soc/espressif/esp32s3/Kconfig.caps
+++ b/soc/espressif/esp32s3/Kconfig.caps
@@ -1,19 +1,19 @@
 # Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config ESP32_SOC_PM_SUPPORT_CPU_PD
+config SOC_ESP32_PM_SUPPORT_CPU_PD
 	bool
 	default y
 
-config ESP32_SOC_FLASH_SUPPORTED
+config SOC_ESP32_FLASH_SUPPORTED
 	bool
 	default y
 
-config ESP32_SOC_PM_SUPPORT_VDDSDIO_PD
+config SOC_ESP32_PM_SUPPORT_VDDSDIO_PD
 	bool
 	default y
 
-config ESP32_SOC_SPI_MEM_SUPPORT_TIMING_TUNING
+config SOC_ESP32_SPI_MEM_SUPPORT_TIMING_TUNING
 	bool
 	default y
 


### PR DESCRIPTION
Rename the ESP32_SOC_* capability symbols to SOC_ESP32_* so that symbols defined under the soc folder follow the Zephyr Kconfig naming policy. Update all references in the common soc code and in the counter and bluetooth drivers.

Symbols here were created in current `main` branch, so no migration/release notes needed.