### PR TITLE
boards: alif: ensemble_e8_dk: enable GPIO, LED and button

### DIFF
--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
@@ -130,4 +130,41 @@
 			drive-strength = <12>;
 		};
 	};
+
+	pinctrl_gpio6: pinctrl_gpio6 {
+		group0 {
+			/* Multicolor LED1: red on P6_2, green on P6_4, blue on P6_6 */
+			pinmux = <PIN_P6_2__GPIO>,
+				 <PIN_P6_4__GPIO>,
+				 <PIN_P6_6__GPIO>;
+		};
+	};
+
+	pinctrl_gpio7: pinctrl_gpio7 {
+		group0 {
+			/* Multicolor LED0: green on P7_4 */
+			pinmux = <PIN_P7_4__GPIO>;
+		};
+	};
+
+	pinctrl_gpio12: pinctrl_gpio12 {
+		group0 {
+			/* Multicolor LED0: blue on P12_0, red on P12_3 */
+			pinmux = <PIN_P12_0__GPIO>,
+				 <PIN_P12_3__GPIO>;
+		};
+	};
+
+	pinctrl_lpgpio: pinctrl_lpgpio {
+		group0 {
+			/* Navigation joystick JOY_SW1 to JOY_SW5 on SW2 */
+			pinmux = <PIN_P15_0__LPGPIO>,
+				 <PIN_P15_1__LPGPIO>,
+				 <PIN_P15_2__LPGPIO>,
+				 <PIN_P15_3__LPGPIO>,
+				 <PIN_P15_4__LPGPIO>;
+			input-enable;
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.yaml
@@ -9,4 +9,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.yaml
@@ -9,4 +9,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.yaml
@@ -9,4 +9,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.yaml
@@ -9,4 +9,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.yaml
@@ -9,4 +9,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.yaml
@@ -10,4 +10,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.yaml
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.yaml
@@ -10,4 +10,5 @@ vendor: alif
 toolchain:
   - zephyr
 supported:
+  - gpio
   - i2c

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_common.dtsi
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_common.dtsi
@@ -9,6 +9,119 @@
  * node referenced below comes from one of those.
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	aliases {
+		led0 = &led0_red;
+		led1 = &led0_blue;
+		led2 = &led0_green;
+		led3 = &led1_red;
+		led4 = &led1_blue;
+		led5 = &led1_green;
+		sw0 = &joy_center;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0_red: led_0 {
+			gpios = <&gpio12 3 GPIO_ACTIVE_HIGH>;
+			label = "LED0_R";
+		};
+
+		led0_blue: led_1 {
+			gpios = <&gpio12 0 GPIO_ACTIVE_HIGH>;
+			label = "LED0_B";
+		};
+
+		led0_green: led_2 {
+			gpios = <&gpio7 4 GPIO_ACTIVE_HIGH>;
+			label = "LED0_G";
+		};
+
+		led1_red: led_3 {
+			gpios = <&gpio6 2 GPIO_ACTIVE_HIGH>;
+			label = "LED1_R";
+		};
+
+		led1_blue: led_4 {
+			gpios = <&gpio6 6 GPIO_ACTIVE_HIGH>;
+			label = "LED1_B";
+		};
+
+		led1_green: led_5 {
+			gpios = <&gpio6 4 GPIO_ACTIVE_HIGH>;
+			label = "LED1_G";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		/*
+		 * The DesignWare GPIO driver does not implement both
+		 * edge triggering, which the interrupt driven mode of
+		 * the GPIO keys driver needs.
+		 */
+		polling-mode;
+
+		joy_left: joy_left {
+			gpios = <&lpgpio 0 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW1";
+			zephyr,code = <INPUT_KEY_LEFT>;
+		};
+
+		joy_up: joy_up {
+			gpios = <&lpgpio 1 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW2";
+			zephyr,code = <INPUT_KEY_UP>;
+		};
+
+		joy_down: joy_down {
+			gpios = <&lpgpio 2 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW3";
+			zephyr,code = <INPUT_KEY_DOWN>;
+		};
+
+		joy_right: joy_right {
+			gpios = <&lpgpio 3 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW4";
+			zephyr,code = <INPUT_KEY_RIGHT>;
+		};
+
+		joy_center: joy_center {
+			gpios = <&lpgpio 4 GPIO_ACTIVE_LOW>;
+			label = "JOY_SW5";
+			zephyr,code = <INPUT_KEY_ENTER>;
+		};
+	};
+};
+
+&gpio6 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_gpio6>;
+	pinctrl-names = "default";
+};
+
+&gpio7 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_gpio7>;
+	pinctrl-names = "default";
+};
+
+&gpio12 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_gpio12>;
+	pinctrl-names = "default";
+};
+
+&lpgpio {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_lpgpio>;
+	pinctrl-names = "default";
+};
+
 &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_i2c0>;


### PR DESCRIPTION
## Summary

Enables the two multicolor LEDs and the 5-position navigation joystick on the Alif Ensemble E8 DevKit.

Follow-on to https://github.com/zephyrproject-rtos/zephyr/pull/117338 (Ensemble GPIO controllers and E8 AppKit LED/button) and to https://github.com/zephyrproject-rtos/zephyr/pull/117753 (Ensemble E1C / Balletto B1 DevKit GPIO/LED/Button), both already merged. The Ensemble GPIO controller nodes landed in the former, so nothing new is needed at the SoC level here. Board enablement only, no devicetree or driver changes outside `boards/alif/ensemble_e8_dk/`.

Unlike the AppKit and the E1C/B1 DevKits, which carry a single multicolor LED, the E8 DevKit has two, so all six LED channels are wired up and exposed as  `led0` through `led5`.

## Contents

One commit:

  1. `boards: alif: ensemble_e8_dk: enable GPIO, LED and button` - the six LED channels on GPIO6, GPIO7 and GPIO12, and all five joystick switches on LPGPIO. The seven board targets differ only in the SoC they are built for, the cluster they run on and the console they use, so the on-board peripherals are described once in `ensemble_e8_dk_common.dtsi` (added earlier for the mikroBUS I2C connector, and already included by every target) rather than seven times.
 
## Testing

On an Ensemble E8 DevKit, the following samples were run on all three  `ae822fa0e5597ls0` board targets (`rtss_he`, `rtss_hp`, `apss`):

- `samples/basic/blinky` - works on each target, with `led0` (LED0 red) as the default and the remaining five channels (LED0 green/blue, LED1 red/green/blue) exercised via overlays.
- `samples/basic/button` - all five joystick positions report the key codes matching the physical orientation of the switch on the board, on press and release.    
  
 ## Known limitations

- The joystick keys are polled (using the standard `polling-mode` property of the `gpio-keys` driver), not interrupt driven. The DesignWare GPIO driver does not implement both-edge triggering, which the interrupt driven mode of the `gpio-keys` driver requires.

