### PR TITLE
arch: riscv: pmp: preserve lock bit on start address for TOR

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -326,7 +326,7 @@ static bool set_pmp_entry(unsigned int *index_p, uint8_t perm,
 		ok = false;
 	} else if (PMP_TOR_SUPPORTED) {
 		pmp_addr[index] = PMP_ADDR(start);
-		pmp_n_cfg[index] = 0;
+		pmp_n_cfg[index] = perm & PMP_L;
 		index += 1;
 		pmp_addr[index] = PMP_ADDR(start + size);
 		pmp_n_cfg[index] = perm | PMP_TOR;


### PR DESCRIPTION
When Top-Of-Range (TOR) mode is used with two PMP entries, the first entry defines the lower bound address and the second entry defines the upper bound address with the desired permissions.

If the region being configured has the lock bit (PMP_L) set, the upper bound entry correctly receives perm | PMP_TOR, which includes PMP_L. However, the lower bound entry previously had its configuration set to 0. As a result, the lower bound address entry was not locked, leaving it writable. This could allow M-mode software or subsequent updates to alter the start address of what was intended to be an immutable, locked TOR region.

Set the lower bound entry configuration to perm & PMP_L so that the lock bit is preserved whenever the region is locked, while keeping address matching disabled (A=OFF) and permissions cleared (R=W=X=0) for the lower bound slot.