### PR TITLE
drivers: FTM Shell and Wifi Mgmt Support

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -782,6 +782,65 @@ enum wifi_config_param {
 /** Helper function to get user-friendly status name for the status code. */
 const char *wifi_conn_status_txt(enum wifi_conn_status status);
 
+/**
+ * Measurement mode. The underlying protocol is internal; callers pick a mode.
+ * See IEEE Std 802.11-2024, 11.21.6 (Fine timing measurement procedure) and the
+ * 802.11az ranging procedures folded into the same clause.
+ */
+enum wifi_ranging_mode {
+	/**
+	 * Let the stack pick the best mode the peer and local device both
+	 * support (see section 3.10). The default; a caller that does not track
+	 * peer capability leaves the mode here.
+	 */
+	WIFI_RANGING_MODE_AUTO = 0,
+	/** Legacy Fine Timing Measurement (formerly 802.11mc). */
+	WIFI_RANGING_MODE_11MC,
+	/** 802.11az non-trigger-based (NTB) ranging. */
+	WIFI_RANGING_MODE_11AZ_NTB,
+	/** 802.11az trigger-based (TB) ranging. */
+	WIFI_RANGING_MODE_11AZ_TB,
+};
+
+/**
+ * PHY format for the measurement frames - the "format" half of the FTM
+ * Parameters "Format And Bandwidth" field (IEEE Std 802.11-2024, 9.4.2.168).
+ * The driver combines it with wifi_ranging_tuning.bandwidth to build the on-air
+ * encoding, so callers select format and width independently.
+ */
+enum wifi_ranging_preamble {
+	/** Non-HT (legacy 802.11a/g). */
+	WIFI_RANGING_PREAMBLE_LEGACY = 0,
+	/** HT (802.11n). */
+	WIFI_RANGING_PREAMBLE_HT,
+	/** VHT (802.11ac). */
+	WIFI_RANGING_PREAMBLE_VHT,
+	/** HE (802.11ax). */
+	WIFI_RANGING_PREAMBLE_HE,
+};
+
+/** Outcome of a per-peer measurement. */
+enum wifi_ranging_status {
+	WIFI_RANGING_STATUS_SUCCESS = 0,
+	WIFI_RANGING_STATUS_REQ_FAILED,
+	WIFI_RANGING_STATUS_NO_RESPONSE,
+	WIFI_RANGING_STATUS_PEER_BUSY,
+	WIFI_RANGING_STATUS_TIMEOUT,
+	WIFI_RANGING_STATUS_NOT_CAPABLE,
+};
+
+/** Validity flags for the optional fields of struct wifi_ranging_result. */
+enum wifi_ranging_result_valid {
+	WIFI_RANGING_VALID_RSSI		= BIT(0),
+	WIFI_RANGING_VALID_RTT		= BIT(1),
+	WIFI_RANGING_VALID_RTT_VAR	= BIT(2),
+	WIFI_RANGING_VALID_RTT_SPREAD	= BIT(3),
+	WIFI_RANGING_VALID_DISTANCE	= BIT(4),
+	WIFI_RANGING_VALID_DIST_VAR	= BIT(5),
+	WIFI_RANGING_VALID_DIST_SPREAD	= BIT(6),
+	WIFI_RANGING_VALID_RSSI_SPREAD	= BIT(7),
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -150,6 +150,22 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_BGSCAN,
 	/** Wi-Fi Direct (P2P) operations*/
 	NET_REQUEST_WIFI_CMD_P2P_OPER,
+#ifdef CONFIG_WIFI_MGMT_RANGING
+	/** Start a ranging (distance) session against one or more peers. */
+	NET_REQUEST_WIFI_CMD_RANGING_START,
+	/** Cancel an ongoing ranging session. */
+	NET_REQUEST_WIFI_CMD_RANGING_CANCEL,
+	/** Enable or disable the local ranging responder role. */
+	NET_REQUEST_WIFI_CMD_RANGING_RESPONDER,
+	/** Read local ranging and location capabilities (synchronous get). */
+	NET_REQUEST_WIFI_CMD_RANGING_CAPS,
+	/** Read a peer's advertised ranging capability (synchronous get). */
+	NET_REQUEST_WIFI_CMD_RANGING_PEER_CAPS,
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+	/** Get or set this device's advertised location (LCI + civic). */
+	NET_REQUEST_WIFI_CMD_LOCATION_SELF,
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
 	/** @cond INTERNAL_HIDDEN */
 	NET_REQUEST_WIFI_CMD_MAX
 	/** @endcond */
@@ -372,6 +388,50 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_BGSCAN);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_P2P_OPER);
 
+#ifdef CONFIG_WIFI_MGMT_RANGING
+#ifdef CONFIG_WIFI_MGMT_RANGING_INITIATOR
+/** Start a ranging session */
+#define NET_REQUEST_WIFI_RANGING_START					\
+	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_RANGING_START)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_START);
+
+/** Cancel a ranging session */
+#define NET_REQUEST_WIFI_RANGING_CANCEL					\
+	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_RANGING_CANCEL)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_CANCEL);
+#endif /* CONFIG_WIFI_MGMT_RANGING_INITIATOR */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING_RESPONDER
+/** Configure the local ranging responder role */
+#define NET_REQUEST_WIFI_RANGING_RESPONDER				\
+	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_RANGING_RESPONDER)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_RESPONDER);
+#endif /* CONFIG_WIFI_MGMT_RANGING_RESPONDER */
+
+/** Read local ranging and location capabilities */
+#define NET_REQUEST_WIFI_RANGING_CAPS					\
+	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_RANGING_CAPS)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_CAPS);
+
+/** Read a peer's advertised ranging capability */
+#define NET_REQUEST_WIFI_RANGING_PEER_CAPS				\
+	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_RANGING_PEER_CAPS)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_PEER_CAPS);
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+/** Get or set the location this device advertises */
+#define NET_REQUEST_WIFI_LOCATION_SELF					\
+	(NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_LOCATION_SELF)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_LOCATION_SELF);
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
+
 /** @cond INTERNAL_HIDDEN */
 
 enum {
@@ -398,6 +458,9 @@ enum {
 	NET_EVENT_WIFI_CMD_NAN_PUBLISH_TERMINATED_VAL,
 	NET_EVENT_WIFI_CMD_NAN_SUBSCRIBE_TERMINATED_VAL,
 	NET_EVENT_WIFI_CMD_NAN_RECEIVE_VAL,
+	NET_EVENT_WIFI_CMD_RANGING_RESULT_VAL,
+	NET_EVENT_WIFI_CMD_RANGING_DONE_VAL,
+	NET_EVENT_WIFI_CMD_LOCATION_RESULT_VAL,
 
 	NET_EVENT_WIFI_CMD_MAX,
 };
@@ -458,6 +521,16 @@ enum net_event_wifi_cmd {
 	NET_MGMT_CMD(NET_EVENT_WIFI_CMD_NAN_SUBSCRIBE_TERMINATED),
 	/** Supplicant specific event */
 	NET_MGMT_CMD(NET_EVENT_WIFI_CMD_NAN_RECEIVE),
+#endif
+#ifdef CONFIG_WIFI_MGMT_RANGING
+	/** Ranging result event */
+	NET_MGMT_CMD(NET_EVENT_WIFI_CMD_RANGING_RESULT),
+	/** Ranging result completion event */
+	NET_MGMT_CMD(NET_EVENT_WIFI_CMD_RANGING_DONE),
+#endif
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+	/** Location command result */
+	NET_MGMT_CMD(NET_EVENT_WIFI_CMD_LOCATION_RESULT),
 #endif
 };
 
@@ -524,6 +597,22 @@ enum net_event_wifi_cmd {
 /** Event emitted for P2P device found event */
 #define NET_EVENT_WIFI_P2P_DEVICE_FOUND				\
 	(NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_P2P_DEVICE_FOUND)
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+/** Event emitted for a per-peer Wi-Fi ranging result */
+#define NET_EVENT_WIFI_RANGING_RESULT					\
+	(NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_RANGING_RESULT)
+
+/** Event emitted when a Wi-Fi ranging session closes */
+#define NET_EVENT_WIFI_RANGING_DONE					\
+	(NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_RANGING_DONE)
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+/** Event emitted with a peer's decoded coordinates */
+#define NET_EVENT_WIFI_LOCATION_RESULT					\
+	(NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_LOCATION_RESULT)
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P
 /** Maximum length for P2P device name */
@@ -1337,6 +1426,13 @@ union wifi_mgmt_events {
 	struct wifi_nan_terminated_event nan_subscribe_terminated;
 	struct wifi_nan_receive_event nan_receive;
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN */
+#ifdef CONFIG_WIFI_MGMT_RANGING
+	struct wifi_ranging_result ranging_result;
+	struct wifi_ranging_done ranging_done;
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+	struct wifi_location location_result;
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
 };
 
 /** @endcond */
@@ -1948,7 +2044,256 @@ enum wifi_ext_capab {
 	WIFI_EXT_CAPAB_TIM_BROADCAST = 18,
 	/** BSS transition management support */
 	WIFI_EXT_CAPAB_BSS_TRANSITION = 19,
+	/** Fine Timing Measurement responder role */
+	WIFI_EXT_CAPAB_FTM_RESPONDER = 70,
+	/** Fine Timing Measurement initiator role */
+	WIFI_EXT_CAPAB_FTM_INITIATOR = 71,
 };
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+/**
+ * Optional per-peer measurement tuning. All zero means "let the driver choose".
+ * Applications that just want a distance can ignore this whole struct. Fields map
+ * to the Fine Timing Measurement Parameters element, IEEE Std 802.11-2024, 9.4.2.168,
+ * unless noted.
+ */
+struct wifi_ranging_tuning {
+	/**
+	 * Channel width in MHz (20/40/80/160); 0 = driver default. The "bandwidth"
+	 * half of the FTM Parameters "Format And Bandwidth" field; preamble is the
+	 * "format" half. The driver joins the two into the on-air encoding.
+	 */
+	uint16_t bandwidth;
+	/** PHY format (Non-HT/HT/VHT/HE); see enum wifi_ranging_preamble.
+	 *  LEGACY (0) = driver default.
+	 */
+	enum wifi_ranging_preamble preamble;
+	/** Bursts as a power of two (Number of Bursts Exponent); 0 = no preference. */
+	uint8_t bursts_exp;
+	/** Successful measurements per burst (FTMs Per Burst); 0 = no preference. */
+	uint8_t ftms_per_burst;
+	/** Burst duration (Burst Duration field, Table 9-257); 0 = no preference. */
+	uint8_t burst_duration;
+	/** Inter-burst period in units of 100 ms (Burst Period); 0 = no preference. */
+	uint8_t burst_period;
+	/** Request as-soon-as-possible scheduling (ASAP subfield). */
+	bool asap;
+	/**
+	 * Non-ASAP scheduling only: requested delay before the first burst, in TUs.
+	 * Meaningful when asap is false; the responder may revise it during
+	 * negotiation. 0 (or asap set) means start as soon as the responder
+	 * schedules it. See IEEE Std 802.11-2024, 11.21.6.
+	 */
+	uint16_t start_delay;
+	/*
+	 * 802.11az-only tuning. Ignored for WIFI_RANGING_MODE_11MC and by drivers
+	 * without 11az support. Present now so enabling 11az needs no API change
+	 * (section 3.9). See IEEE Std 802.11-2024, 11.21.6 and the Ranging
+	 * Parameters element.
+	 */
+	/** HE-LTF repetitions; 0 = driver default. */
+	uint8_t ltf_reps;
+	/** Use protected (secure HE-LTF) ranging (PASN, IEEE Std 802.11-2024, 12.13). */
+	bool secure_ltf;
+	/** Min time between measurements, TUs; 0 = driver default. */
+	uint16_t min_time_between_meas;
+	/** Max time between measurements, TUs; 0 = driver default. */
+	uint16_t max_time_between_meas;
+};
+
+
+/** Per-peer ranging request. */
+struct wifi_ranging_peer {
+	/** Peer (responder) MAC address. */
+	uint8_t mac[WIFI_MAC_ADDR_LEN];
+	/** Operating band, see enum wifi_frequency_bands. */
+	enum wifi_frequency_bands band;
+	/** Primary channel number. */
+	uint16_t channel;
+	/** Also fetch the peer's LCI/civic location (raises LOCATION_RESULT). */
+	bool request_location;
+	/** Optional measurement tuning; leave zeroed for driver defaults. */
+	struct wifi_ranging_tuning tuning;
+};
+
+/** Ranging session request. */
+struct wifi_ranging_params {
+	/** Caller-chosen session id, echoed on every event and used for cancel. */
+	uint32_t session_id;
+	/** Measurement mode; WIFI_RANGING_MODE_AUTO (0) lets the stack pick based
+	 *  on peer capability (section 3.10).
+	 */
+	enum wifi_ranging_mode mode;
+	/** Number of valid entries in peers[]. */
+	uint8_t num_peers;
+	/** Per-peer requests. */
+	struct wifi_ranging_peer peers[CONFIG_WIFI_MGMT_RANGING_MAX_PEERS];
+	/** Overall session timeout in milliseconds; 0 means driver default. */
+	uint32_t timeout_ms;
+};
+
+/** Per-peer ranging result (distance domain). */
+struct wifi_ranging_result {
+	/** Session id this result belongs to. */
+	uint32_t session_id;
+	/** Peer MAC address. */
+	uint8_t mac[WIFI_MAC_ADDR_LEN];
+	/** Per-peer outcome. */
+	enum wifi_ranging_status status;
+	/** Mode used for this measurement. */
+	enum wifi_ranging_mode mode;
+	/** OR of enum wifi_ranging_result_valid, marks which fields below are set. */
+	uint32_t valid_fields;
+	/** Average round-trip time in picoseconds. */
+	int64_t rtt_ps;
+	/** RTT variance. */
+	int64_t rtt_variance;
+	/** RTT spread (max - min). */
+	int64_t rtt_spread;
+	/** Average distance in millimetres. */
+	int32_t distance_mm;
+	/** Distance variance. */
+	int32_t distance_variance;
+	/** Distance spread (max - min). */
+	int32_t distance_spread;
+	/** Average RSSI in dBm. */
+	int8_t rssi;
+	/** RSSI spread. */
+	int8_t rssi_spread;
+	/** Bursts actually exchanged, as a power of two. */
+	uint8_t num_bursts_exp;
+	/** Measurements per burst actually used. */
+	uint8_t ftms_per_burst;
+};
+
+/** Payload of NET_EVENT_WIFI_RANGING_DONE; closes a session. */
+struct wifi_ranging_done {
+	/** Session id that just finished. */
+	uint32_t session_id;
+	/** Overall session status: 0 on success, negative errno otherwise. */
+	int status;
+	/** Number of per-peer results delivered for this session. */
+	uint8_t num_results;
+};
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+#ifdef CONFIG_WIFI_MGMT_LOCATION_LCI
+/**
+ * Geospatial location from an LCI report. Carried in the Measurement Report
+ * element (IEEE Std 802.11-2024, 9.4.2.20); coordinate encoding per RFC 6225.
+ */
+struct wifi_location_lci {
+	/** Latitude, fixed-point 2's complement, 25 fractional bits (degrees). */
+	int64_t latitude;
+	/** Longitude, same encoding as latitude. */
+	int64_t longitude;
+	/** Altitude, fixed-point per altitude_type. */
+	int32_t altitude;
+	/** Altitude type: 1 = metres, 2 = floors. */
+	uint8_t altitude_type;
+	/** Latitude uncertainty exponent. */
+	uint8_t lat_uncertainty;
+	/** Longitude uncertainty exponent. */
+	uint8_t long_uncertainty;
+	/** Altitude uncertainty exponent. */
+	uint8_t alt_uncertainty;
+};
+#endif /* CONFIG_WIFI_MGMT_LOCATION_LCI */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION_CIVIC
+/**
+ * Civic address from a Location Civic report. Carried in the Measurement Report
+ * element (IEEE Std 802.11-2024, 9.4.2.20); address format per RFC 4776.
+ */
+struct wifi_location_civic {
+	/** ISO 3166 country code, e.g. "NO". */
+	uint8_t country[2];
+	/** Raw civic address TLVs as received. */
+	uint8_t addr[CONFIG_WIFI_MGMT_LOCATION_CIVIC_MAX_LEN];
+	/** Length of addr in bytes. */
+	uint8_t addr_len;
+};
+#endif /* CONFIG_WIFI_MGMT_LOCATION_CIVIC */
+
+/** Decoded coordinates for one peer (or for self on a GET). */
+struct wifi_location {
+	/** Peer MAC the coordinates belong to. */
+	uint8_t mac[WIFI_MAC_ADDR_LEN];
+#ifdef CONFIG_WIFI_MGMT_LOCATION_LCI
+	/** true if lci is populated. */
+	bool has_lci;
+	/** Geospatial location. */
+	struct wifi_location_lci lci;
+#endif /* CONFIG_WIFI_MGMT_LOCATION_LCI */
+#ifdef CONFIG_WIFI_MGMT_LOCATION_CIVIC
+	/** true if civic is populated. */
+	bool has_civic;
+	/** Civic address. */
+	struct wifi_location_civic civic;
+#endif /* CONFIG_WIFI_MGMT_LOCATION_CIVIC */
+};
+
+/** Get or set the location this device advertises as a responder. */
+struct wifi_location_self_params {
+	/** WIFI_MGMT_GET or WIFI_MGMT_SET. */
+	enum wifi_mgmt_op oper;
+	/** Coordinates to advertise (SET) or read back (GET). */
+	struct wifi_location location;
+};
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+/** Local ranging responder configuration. */
+struct wifi_ranging_responder_params {
+	/** WIFI_MGMT_GET or WIFI_MGMT_SET. */
+	enum wifi_mgmt_op oper;
+	/** Enable or disable responding to ranging requests. */
+	bool enable;
+	/** Channel to respond on; only used for SET. */
+	struct wifi_channel_info chan;
+};
+/** Local device ranging and location capabilities. */
+struct wifi_ranging_caps {
+	/** Can initiate ranging. */
+	bool initiator;
+	/** Can act as a ranging responder. */
+	bool responder;
+	/** Supports 802.11az NGP modes. */
+	bool ngp;
+	/** Supports protected (secure LTF) ranging. */
+	bool secure_ltf;
+	/** Can report or consume LCI. */
+	bool lci;
+	/** Can report or consume civic location. */
+	bool civic;
+	/** Can range while not associated to any AP (section 3.11). */
+	bool unassociated;
+	/** Can range a peer off the current operating channel while associated. */
+	bool off_channel;
+	/** Maximum peers per session. */
+	uint8_t max_peers;
+};
+/**
+ * Peer (responder) ranging capability, learned from the peer's advertised
+ * information (see section 3.10). What a peer supports bounds what an initiator
+ * can ask for: you cannot run 802.11az against an 11mc-only responder.
+ */
+struct wifi_ranging_peer_caps {
+	/** Peer this describes. */
+	uint8_t mac[WIFI_MAC_ADDR_LEN];
+	/** Peer advertises the FTM responder role. */
+	bool ftm_responder;
+	/** Peer supports 802.11az ranging. */
+	bool ngp;
+	/** Peer supports protected (secure LTF) ranging. */
+	bool secure_ltf;
+	/** Peer can return LCI. */
+	bool lci;
+	/** Peer can return civic location. */
+	bool civic;
+};
+#endif /* CONFIG_WIFI_MGMT_RANGING */
 
 #include <zephyr/net/net_if.h>
 
@@ -1971,6 +2316,20 @@ typedef void (*scan_result_cb_t)(struct net_if *iface, int status,
 typedef void (*raw_scan_result_cb_t)(struct net_if *iface, int status,
 				     struct wifi_raw_scan_result *entry);
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+/**
+ * @brief Ranging result callback.
+ *
+ * @param iface      Network interface.
+ * @param session_id Session the result/done belongs to (echoes ranging_start).
+ * @param status     0 while results stream, negative errno on failure.
+ * @param result     One peer's result, or NULL to mark the end of the session.
+ */
+typedef void (*wifi_ranging_result_cb_t)(struct net_if *iface, uint32_t session_id,
+					 int status,
+					 struct wifi_ranging_result *result);
+#endif /* CONFIG_WIFI_MGMT_RANGING */
 
 /** Wi-Fi management API */
 struct wifi_mgmt_ops {
@@ -2417,6 +2776,41 @@ struct wifi_mgmt_ops {
 	 * Return 0 to let the caller use the default.
 	 */
 	 uint32_t (*get_iface_caps)(const struct device *dev, struct net_if *iface);
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+	/** Start a ranging session; results stream through cb. */
+	int (*ranging_start)(const struct device *dev,
+			     struct net_if *iface,
+			     struct wifi_ranging_params *params,
+			     wifi_ranging_result_cb_t cb);
+	/** Cancel a ranging session and free its resources; session_id == 0 means
+	 *  the sole active session (single-session drivers). Returns -ENOTSUP if the
+	 *  backend cannot abort in flight.
+	 */
+	int (*ranging_cancel)(const struct device *dev,
+			      struct net_if *iface,
+			      uint32_t session_id);
+	/** Configure the local responder role. */
+	int (*ranging_responder)(const struct device *dev,
+				 struct net_if *iface,
+				 struct wifi_ranging_responder_params *params);
+	/** Read local ranging/location capabilities. */
+	int (*ranging_get_caps)(const struct device *dev,
+				struct net_if *iface,
+				struct wifi_ranging_caps *caps);
+	/** Read a peer's advertised ranging capability. The caller sets caps->mac
+	 *  to the peer of interest; the backend answers from cached scan info.
+	 */
+	int (*ranging_get_peer_caps)(const struct device *dev,
+				     struct net_if *iface,
+				     struct wifi_ranging_peer_caps *caps);
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+	/** Get or set this device's advertised location. */
+	int (*location_self)(const struct device *dev,
+			     struct net_if *iface,
+			     struct wifi_location_self_params *params);
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
 };
 
 /** Wi-Fi management offload API */
@@ -2558,6 +2952,43 @@ void wifi_mgmt_raise_ap_sta_disconnected_event(struct net_if *iface,
 void wifi_mgmt_raise_p2p_device_found_event(struct net_if *iface,
 		struct wifi_p2p_device_info *peer_info);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+/**
+ * @brief Raise a ranging session completion event
+ *
+ * @param iface Network interface
+ * @param done Session outcome
+ */
+void wifi_mgmt_raise_ranging_done_event(struct net_if *iface,
+					struct wifi_ranging_done *done);
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+/**
+ * @brief Decode a received Measurement Report element
+ *
+ * Handles LCI (measurement type 8) and Location Civic (type 11) reports.
+ *
+ * @param report Measurement Report element body
+ * @param report_len Length of @p report in bytes
+ * @param out Decoded coordinates, populated on success
+ *
+ * @return 0 if ok, < 0 if error
+ */
+int wifi_location_parse_measurement_report(const uint8_t *report, size_t report_len,
+					   struct wifi_location *out);
+
+/**
+ * @brief Raise a location result event
+ *
+ * @param iface Network interface
+ * @param location Decoded coordinates
+ */
+void wifi_mgmt_raise_location_result_event(struct net_if *iface,
+					   struct wifi_location *location);
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
+
 
 /**
  * @}

--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -190,3 +190,79 @@ config WIFI_MGMT_BSS_MAX_IDLE_TIME
 	  equal to true, then the non-S1G AP may choose the non-AP STA’s
 	  preferred maximum idle period. The non-S1G AP indicates its chosen
 	  value to the non-S1G STA in the (Re)Association Response frame.
+
+config WIFI_MGMT_LOCATION
+	bool "Wi-Fi location services (FTM/802.11az based)"
+	help
+	  Public API for Wi-Fi positioning: ranging (distance) and location
+	  (LCI/civic coordinates).
+
+if WIFI_MGMT_LOCATION
+
+config WIFI_MGMT_RANGING
+	bool "Ranging (distance measurement)"
+	default y
+	help
+	  Distance measurement to peers using FTM. This is the optional ranging
+	  subset of the location feature.
+
+config WIFI_MGMT_RANGING_INITIATOR
+	bool "Ranging initiator role"
+	depends on WIFI_MGMT_RANGING
+	default y
+	help
+	  Enable the requests that start and cancel a ranging session. Disable
+	  this on a device that only answers ranging requests from its peers.
+
+config WIFI_MGMT_RANGING_RESPONDER
+	bool "Ranging responder role"
+	depends on WIFI_MGMT_RANGING
+	help
+	  Enable the request that turns the local FTM responder role on and off,
+	  allowing peers to measure their distance to this device.
+
+config WIFI_MGMT_RANGING_MAX_PEERS
+	int "Maximum peers per ranging session"
+	depends on WIFI_MGMT_RANGING
+	default 4
+	range 1 8
+	help
+	  Sizes the per-session peer array. The usable maximum is driver
+	  dependent; nRF71 firmware honours up to 4 peers. Set this to match the
+	  driver in use.
+
+config WIFI_MGMT_RANGING_11AZ
+	bool "802.11az ranging (NTB/TB)"
+	depends on WIFI_MGMT_RANGING
+	help
+	  Reserve the 802.11az modes in the public API. Support is driver
+	  dependent; on nRF71 it is not yet functional (802.11mc only) and
+	  selecting an 11az mode returns -ENOTSUP until firmware support lands.
+
+config WIFI_MGMT_LOCATION_LCI
+	bool "Geospatial location (LCI, RFC 6225)"
+	default y
+	help
+	  Decode and report geospatial coordinates from an LCI report, carried
+	  in the Measurement Report element as measurement type 8. Adds the
+	  latitude, longitude and altitude fields to struct wifi_location.
+
+config WIFI_MGMT_LOCATION_CIVIC
+	bool "Civic location (RFC 4776)"
+	help
+	  Decode and report a civic address (country code plus the raw civic
+	  address TLVs) from a Location Civic report, carried in the Measurement
+	  Report element as measurement type 11. Adds a
+	  WIFI_MGMT_LOCATION_CIVIC_MAX_LEN sized buffer to struct wifi_location.
+
+config WIFI_MGMT_LOCATION_CIVIC_MAX_LEN
+	int "Maximum civic report length in bytes"
+	depends on WIFI_MGMT_LOCATION_CIVIC
+	default 100
+	range 1 255
+	help
+	  Sizes the raw civic address TLV buffer in struct wifi_location_civic.
+	  A report longer than this is truncated. Capped at 255 because the
+	  accompanying addr_len field is a single octet.
+
+endif # WIFI_MGMT_LOCATION

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -1952,3 +1952,221 @@ static int connect_stored_command(uint64_t mgmt_request, struct net_if *iface, v
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT_STORED, connect_stored_command);
 
 #endif /* CONFIG_WIFI_CREDENTIALS_CONNECT_STORED */
+
+#if defined(CONFIG_WIFI_MGMT_RANGING) || defined(CONFIG_WIFI_MGMT_LOCATION)
+/*
+ * Ranging and location have no supplicant path: measurement results arrive from
+ * the firmware straight to the driver, and the decode is standards-defined work
+ * done here. So resolve the driver's ops directly instead of get_wifi_api(),
+ * which returns the network manager's table and would shadow them.
+ */
+static const struct wifi_mgmt_ops *const get_wifi_driver_api(struct net_if *iface)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api;
+
+	if (dev == NULL || !net_if_is_wifi(iface)) {
+		return NULL;
+	}
+
+	off_api = (struct net_wifi_mgmt_offload *)dev->api;
+
+	return off_api ? off_api->wifi_mgmt_api : NULL;
+}
+#endif /* CONFIG_WIFI_MGMT_RANGING || CONFIG_WIFI_MGMT_LOCATION */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+void wifi_mgmt_raise_ranging_done_event(struct net_if *iface,
+					struct wifi_ranging_done *done)
+{
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_RANGING_DONE, iface,
+					done, sizeof(*done));
+}
+
+#ifdef CONFIG_WIFI_MGMT_RANGING_INITIATOR
+static void ranging_result_cb(struct net_if *iface, uint32_t session_id, int status,
+			      struct wifi_ranging_result *result)
+{
+	if (result == NULL) {
+		struct wifi_ranging_done done = {
+			.session_id = session_id,
+			.status = status,
+		};
+
+		wifi_mgmt_raise_ranging_done_event(iface, &done);
+		return;
+	}
+
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_RANGING_RESULT, iface,
+					result, sizeof(*result));
+}
+
+static int wifi_ranging_start(uint64_t mgmt_request, struct net_if *iface,
+			      void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct wifi_ranging_params *params = data;
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_driver_api(iface);
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ranging_start == NULL) {
+		return -ENOTSUP;
+	}
+
+	/*
+	 * Admin-up is enough; ranging does not require an association. The
+	 * driver decides whether an unassociated or off-channel request is
+	 * supported and rejects with -ENOTSUP if not.
+	 */
+	if (!net_if_is_admin_up(iface)) {
+		return -ENETDOWN;
+	}
+
+	if (params == NULL || len != sizeof(*params) ||
+	    params->num_peers == 0 ||
+	    params->num_peers > CONFIG_WIFI_MGMT_RANGING_MAX_PEERS) {
+		return -EINVAL;
+	}
+
+	if (params->mode > WIFI_RANGING_MODE_11AZ_TB) {
+		return -EINVAL;
+	}
+
+	if (!IS_ENABLED(CONFIG_WIFI_MGMT_RANGING_11AZ) &&
+	    (params->mode == WIFI_RANGING_MODE_11AZ_NTB ||
+	     params->mode == WIFI_RANGING_MODE_11AZ_TB)) {
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->ranging_start(dev, iface, params, ranging_result_cb);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_START, wifi_ranging_start);
+
+static int wifi_ranging_cancel(uint64_t mgmt_request, struct net_if *iface,
+			       void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	uint32_t *session_id = data;
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_driver_api(iface);
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ranging_cancel == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (!net_if_is_admin_up(iface)) {
+		return -ENETDOWN;
+	}
+
+	if (session_id == NULL || len != sizeof(*session_id)) {
+		return -EINVAL;
+	}
+
+	return wifi_mgmt_api->ranging_cancel(dev, iface, *session_id);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_CANCEL, wifi_ranging_cancel);
+#endif /* CONFIG_WIFI_MGMT_RANGING_INITIATOR */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING_RESPONDER
+static int wifi_ranging_responder(uint64_t mgmt_request, struct net_if *iface,
+				  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct wifi_ranging_responder_params *params = data;
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_driver_api(iface);
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ranging_responder == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (!net_if_is_admin_up(iface)) {
+		return -ENETDOWN;
+	}
+
+	if (params == NULL || len != sizeof(*params)) {
+		return -EINVAL;
+	}
+
+	if (params->oper != WIFI_MGMT_GET && params->oper != WIFI_MGMT_SET) {
+		return -EINVAL;
+	}
+
+	return wifi_mgmt_api->ranging_responder(dev, iface, params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_RESPONDER, wifi_ranging_responder);
+#endif /* CONFIG_WIFI_MGMT_RANGING_RESPONDER */
+
+static int wifi_ranging_caps(uint64_t mgmt_request, struct net_if *iface,
+			     void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct wifi_ranging_caps *caps = data;
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_driver_api(iface);
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ranging_get_caps == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (caps == NULL || len != sizeof(*caps)) {
+		return -EINVAL;
+	}
+
+	return wifi_mgmt_api->ranging_get_caps(dev, iface, caps);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_CAPS, wifi_ranging_caps);
+
+static int wifi_ranging_peer_caps(uint64_t mgmt_request, struct net_if *iface,
+				  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct wifi_ranging_peer_caps *caps = data;
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_driver_api(iface);
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ranging_get_peer_caps == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (caps == NULL || len != sizeof(*caps)) {
+		return -EINVAL;
+	}
+
+	return wifi_mgmt_api->ranging_get_peer_caps(dev, iface, caps);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RANGING_PEER_CAPS, wifi_ranging_peer_caps);
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+void wifi_mgmt_raise_location_result_event(struct net_if *iface,
+					   struct wifi_location *location)
+{
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_LOCATION_RESULT, iface,
+					location, sizeof(*location));
+}
+
+static int wifi_location_self(uint64_t mgmt_request, struct net_if *iface,
+			      void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct wifi_location_self_params *params = data;
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_driver_api(iface);
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->location_self == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (params == NULL || len != sizeof(*params)) {
+		return -EINVAL;
+	}
+
+	if (params->oper != WIFI_MGMT_GET && params->oper != WIFI_MGMT_SET) {
+		return -EINVAL;
+	}
+
+	return wifi_mgmt_api->location_self(dev, iface, params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_LOCATION_SELF, wifi_location_self);
+#endif /* CONFIG_WIFI_MGMT_LOCATION */

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -78,6 +78,16 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 				NET_EVENT_WIFI_RAW_SCAN_RESULT)
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY */
 
+#ifdef CONFIG_WIFI_MGMT_RANGING
+#define WIFI_SHELL_RANGING_EVENTS (                 \
+				NET_EVENT_WIFI_RANGING_RESULT     |\
+				NET_EVENT_WIFI_RANGING_DONE)
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+#define WIFI_SHELL_LOCATION_EVENTS (NET_EVENT_WIFI_LOCATION_RESULT)
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
+
 #define MAX_BANDS_STR_LEN 64
 
 static struct {
@@ -834,6 +844,157 @@ static void handle_wifi_nan_receive(struct net_mgmt_event_callback *cb)
 }
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN */
 
+#ifdef CONFIG_WIFI_MGMT_RANGING
+static const char *wifi_ranging_mode_txt(enum wifi_ranging_mode mode)
+{
+	switch (mode) {
+	case WIFI_RANGING_MODE_AUTO:
+		return "auto";
+	case WIFI_RANGING_MODE_11MC:
+		return "11mc";
+	case WIFI_RANGING_MODE_11AZ_NTB:
+		return "11az-ntb";
+	case WIFI_RANGING_MODE_11AZ_TB:
+		return "11az-tb";
+	default:
+		return "unknown";
+	}
+}
+
+static const char *wifi_ranging_status_txt(enum wifi_ranging_status status)
+{
+	switch (status) {
+	case WIFI_RANGING_STATUS_SUCCESS:
+		return "success";
+	case WIFI_RANGING_STATUS_REQ_FAILED:
+		return "request failed";
+	case WIFI_RANGING_STATUS_NO_RESPONSE:
+		return "no response";
+	case WIFI_RANGING_STATUS_PEER_BUSY:
+		return "peer busy";
+	case WIFI_RANGING_STATUS_TIMEOUT:
+		return "timeout";
+	case WIFI_RANGING_STATUS_NOT_CAPABLE:
+		return "not capable";
+	default:
+		return "unknown";
+	}
+}
+
+static void handle_wifi_ranging_result(struct net_mgmt_event_callback *cb)
+{
+	const struct wifi_ranging_result *res =
+		(const struct wifi_ranging_result *)cb->info;
+	const struct shell *sh = context.sh;
+	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+
+	PR("Ranging result: session %u, peer %s, mode %s, status %s\n",
+	   res->session_id,
+	   net_sprint_ll_addr_buf(res->mac, WIFI_MAC_ADDR_LEN,
+				  mac_string_buf, sizeof(mac_string_buf)),
+	   wifi_ranging_mode_txt(res->mode),
+	   wifi_ranging_status_txt(res->status));
+
+	if (res->status != WIFI_RANGING_STATUS_SUCCESS) {
+		return;
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_DISTANCE) {
+		PR("\tDistance       : %d mm\n", res->distance_mm);
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_DIST_VAR) {
+		PR("\tDistance var   : %d\n", res->distance_variance);
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_DIST_SPREAD) {
+		PR("\tDistance spread: %d mm\n", res->distance_spread);
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_RTT) {
+		PR("\tRTT            : %lld ps\n", res->rtt_ps);
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_RTT_VAR) {
+		PR("\tRTT var        : %lld\n", res->rtt_variance);
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_RTT_SPREAD) {
+		PR("\tRTT spread     : %lld ps\n", res->rtt_spread);
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_RSSI) {
+		PR("\tRSSI           : %d dBm\n", res->rssi);
+	}
+
+	if (res->valid_fields & WIFI_RANGING_VALID_RSSI_SPREAD) {
+		PR("\tRSSI spread    : %d dB\n", res->rssi_spread);
+	}
+
+	PR("\tBursts (exp)   : %u\n", res->num_bursts_exp);
+	PR("\tFTMs per burst : %u\n", res->ftms_per_burst);
+}
+
+static void handle_wifi_ranging_done(struct net_mgmt_event_callback *cb)
+{
+	const struct wifi_ranging_done *done =
+		(const struct wifi_ranging_done *)cb->info;
+	const struct shell *sh = context.sh;
+
+	if (done->status) {
+		PR_WARNING("Ranging session %u failed (%d)\n",
+			   done->session_id, done->status);
+		return;
+	}
+
+	PR("Ranging session %u done, %u result(s)\n",
+	   done->session_id, done->num_results);
+}
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+static void print_wifi_location(const struct shell *sh,
+				const struct wifi_location *loc)
+{
+	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+
+	PR("Location of %s:\n",
+	   net_sprint_ll_addr_buf(loc->mac, WIFI_MAC_ADDR_LEN,
+				  mac_string_buf, sizeof(mac_string_buf)));
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION_LCI
+	if (loc->has_lci) {
+		PR("\tLatitude    : %lld (uncertainty %u)\n",
+		   loc->lci.latitude, loc->lci.lat_uncertainty);
+		PR("\tLongitude   : %lld (uncertainty %u)\n",
+		   loc->lci.longitude, loc->lci.long_uncertainty);
+		PR("\tAltitude    : %d (type %u, uncertainty %u)\n",
+		   loc->lci.altitude, loc->lci.altitude_type,
+		   loc->lci.alt_uncertainty);
+	} else {
+		PR("\tNo LCI report\n");
+	}
+#endif /* CONFIG_WIFI_MGMT_LOCATION_LCI */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION_CIVIC
+	if (loc->has_civic) {
+		PR("\tCountry     : %c%c\n",
+		   loc->civic.country[0], loc->civic.country[1]);
+		PR("\tCivic length: %u bytes\n", loc->civic.addr_len);
+	} else {
+		PR("\tNo civic report\n");
+	}
+#endif /* CONFIG_WIFI_MGMT_LOCATION_CIVIC */
+}
+
+static void handle_wifi_location_result(struct net_mgmt_event_callback *cb)
+{
+	const struct wifi_location *loc = (const struct wifi_location *)cb->info;
+
+	print_wifi_location(context.sh, loc);
+}
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
+
 static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 				    uint64_t mgmt_event, struct net_if *iface)
 {
@@ -889,6 +1050,19 @@ static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 		handle_wifi_nan_receive(cb);
 		break;
 #endif
+#ifdef CONFIG_WIFI_MGMT_RANGING
+	case NET_EVENT_WIFI_RANGING_RESULT:
+		handle_wifi_ranging_result(cb);
+		break;
+	case NET_EVENT_WIFI_RANGING_DONE:
+		handle_wifi_ranging_done(cb);
+		break;
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+	case NET_EVENT_WIFI_LOCATION_RESULT:
+		handle_wifi_location_result(cb);
+		break;
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
 	default:
 		break;
 	}
@@ -6047,6 +6221,474 @@ SHELL_SUBCMD_ADD((wifi), wps_pin, NULL,
 
 SHELL_SUBCMD_SET_CREATE(wifi_commands, (wifi));
 
+#ifdef CONFIG_WIFI_MGMT_RANGING
+static int cmd_wifi_ranging_caps(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	struct wifi_ranging_caps caps = { 0 };
+	int ret;
+
+	if (iface == NULL) {
+		return -ENOEXEC;
+	}
+
+	ret = net_mgmt(NET_REQUEST_WIFI_RANGING_CAPS, iface, &caps, sizeof(caps));
+	if (ret) {
+		PR_WARNING("Cannot get ranging capabilities: %d\n", ret);
+		return -ENOEXEC;
+	}
+
+	PR("Ranging capabilities:\n");
+	PR("\tInitiator      : %s\n", caps.initiator ? "yes" : "no");
+	PR("\tResponder      : %s\n", caps.responder ? "yes" : "no");
+	PR("\t802.11az (NGP) : %s\n", caps.ngp ? "yes" : "no");
+	PR("\tSecure LTF     : %s\n", caps.secure_ltf ? "yes" : "no");
+	PR("\tLCI            : %s\n", caps.lci ? "yes" : "no");
+	PR("\tCivic          : %s\n", caps.civic ? "yes" : "no");
+	PR("\tUnassociated   : %s\n", caps.unassociated ? "yes" : "no");
+	PR("\tOff-channel    : %s\n", caps.off_channel ? "yes" : "no");
+	PR("\tMax peers      : %u\n", caps.max_peers);
+
+	return 0;
+}
+
+static int cmd_wifi_ranging_peer_caps(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	struct wifi_ranging_peer_caps caps = { 0 };
+	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+	int ret;
+
+	if (iface == NULL) {
+		return -ENOEXEC;
+	}
+
+	/* An omitted MAC leaves caps.mac zeroed, which asks about the
+	 * associated AP. Skip a leading option so "-i <idx>" alone still works.
+	 */
+	if (argc > 1 && argv[1][0] != '-') {
+		if (net_bytes_from_str(caps.mac, WIFI_MAC_ADDR_LEN, argv[1]) < 0) {
+			PR_WARNING("Invalid peer MAC \"%s\"\n", argv[1]);
+			return -ENOEXEC;
+		}
+	}
+
+	ret = net_mgmt(NET_REQUEST_WIFI_RANGING_PEER_CAPS, iface, &caps, sizeof(caps));
+	if (ret) {
+		PR_WARNING("Cannot get peer ranging capabilities: %d\n", ret);
+		return -ENOEXEC;
+	}
+
+	PR("Ranging capabilities of %s:\n",
+	   net_sprint_ll_addr_buf(caps.mac, WIFI_MAC_ADDR_LEN,
+				  mac_string_buf, sizeof(mac_string_buf)));
+	PR("\tFTM responder  : %s\n", caps.ftm_responder ? "yes" : "no");
+	PR("\t802.11az (NGP) : %s\n", caps.ngp ? "yes" : "no");
+	PR("\tSecure LTF     : %s\n", caps.secure_ltf ? "yes" : "no");
+	PR("\tLCI            : %s\n", caps.lci ? "yes" : "no");
+	PR("\tCivic          : %s\n", caps.civic ? "yes" : "no");
+
+	return 0;
+}
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING_RESPONDER
+static int cmd_wifi_ranging_responder(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	struct wifi_ranging_responder_params params = { 0 };
+	int ret;
+
+	if (iface == NULL) {
+		return -ENOEXEC;
+	}
+
+	if (!strcasecmp(argv[1], "enable")) {
+		params.enable = true;
+	} else if (!strcasecmp(argv[1], "disable")) {
+		params.enable = false;
+	} else {
+		PR_WARNING("Invalid argument \"%s\", expected enable or disable\n", argv[1]);
+		return -ENOEXEC;
+	}
+
+	params.oper = WIFI_MGMT_SET;
+
+	ret = net_mgmt(NET_REQUEST_WIFI_RANGING_RESPONDER, iface, &params, sizeof(params));
+	if (ret) {
+		PR_WARNING("Cannot %s ranging responder: %d\n",
+			   params.enable ? "enable" : "disable", ret);
+		return -ENOEXEC;
+	}
+
+	PR("Ranging responder %s\n", params.enable ? "enabled" : "disabled");
+
+	return 0;
+}
+#endif /* CONFIG_WIFI_MGMT_RANGING_RESPONDER */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING_INITIATOR
+/* Long-only options for "wifi ranging start"; values above the ASCII range so
+ * they cannot collide with the short options.
+ */
+enum wifi_ranging_start_opt {
+	RANGING_START_OPT_FORMAT = 0x100,
+	RANGING_START_OPT_ASAP,
+	RANGING_START_OPT_START_DELAY,
+	RANGING_START_OPT_LOCATION,
+};
+
+static int wifi_ranging_parse_band(const char *arg, enum wifi_frequency_bands *band)
+{
+	if (!strcmp(arg, "2")) {
+		*band = WIFI_FREQ_BAND_2_4_GHZ;
+	} else if (!strcmp(arg, "5")) {
+		*band = WIFI_FREQ_BAND_5_GHZ;
+	} else if (!strcmp(arg, "6")) {
+		*band = WIFI_FREQ_BAND_6_GHZ;
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int wifi_ranging_parse_mode(const char *arg, enum wifi_ranging_mode *mode)
+{
+	if (!strcasecmp(arg, "auto")) {
+		*mode = WIFI_RANGING_MODE_AUTO;
+	} else if (!strcasecmp(arg, "11mc")) {
+		*mode = WIFI_RANGING_MODE_11MC;
+	} else if (!strcasecmp(arg, "11az-ntb")) {
+		*mode = WIFI_RANGING_MODE_11AZ_NTB;
+	} else if (!strcasecmp(arg, "11az-tb")) {
+		*mode = WIFI_RANGING_MODE_11AZ_TB;
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int wifi_ranging_parse_preamble(const char *arg, enum wifi_ranging_preamble *preamble)
+{
+	if (!strcasecmp(arg, "non-ht")) {
+		*preamble = WIFI_RANGING_PREAMBLE_LEGACY;
+	} else if (!strcasecmp(arg, "ht")) {
+		*preamble = WIFI_RANGING_PREAMBLE_HT;
+	} else if (!strcasecmp(arg, "vht")) {
+		*preamble = WIFI_RANGING_PREAMBLE_VHT;
+	} else if (!strcasecmp(arg, "he")) {
+		*preamble = WIFI_RANGING_PREAMBLE_HE;
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int cmd_wifi_ranging_start(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	struct wifi_ranging_params params = { 0 };
+	struct wifi_ranging_peer *peer = NULL;
+	struct sys_getopt_state *state;
+	int opt, opt_index = 0, ret;
+	static const struct sys_getopt_option long_options[] = {
+		{"peer", sys_getopt_required_argument, 0, 'p'},
+		{"band", sys_getopt_required_argument, 0, 'b'},
+		{"channel", sys_getopt_required_argument, 0, 'c'},
+		{"bandwidth", sys_getopt_required_argument, 0, 'w'},
+		{"bursts", sys_getopt_required_argument, 0, 'n'},
+		{"ftms-per-burst", sys_getopt_required_argument, 0, 'f'},
+		{"burst-duration", sys_getopt_required_argument, 0, 'd'},
+		{"burst-period", sys_getopt_required_argument, 0, 'r'},
+		{"mode", sys_getopt_required_argument, 0, 'm'},
+		{"timeout", sys_getopt_required_argument, 0, 't'},
+		{"session", sys_getopt_required_argument, 0, 's'},
+		{"iface", sys_getopt_required_argument, 0, 'i'},
+		{"format", sys_getopt_required_argument, 0, RANGING_START_OPT_FORMAT},
+		{"start-delay", sys_getopt_required_argument, 0, RANGING_START_OPT_START_DELAY},
+		{"asap", sys_getopt_no_argument, 0, RANGING_START_OPT_ASAP},
+		{"location", sys_getopt_no_argument, 0, RANGING_START_OPT_LOCATION},
+		{"help", sys_getopt_no_argument, 0, 'h'},
+		{NULL, 0, NULL, 0}
+	};
+
+	if (iface == NULL) {
+		return -ENOEXEC;
+	}
+
+	while ((opt = sys_getopt_long(argc, argv, "p:b:c:w:n:f:d:r:m:t:s:i:h",
+				      long_options, &opt_index)) != -1) {
+		state = sys_getopt_state_get();
+
+		/* Every option below 'p' aside applies to the peer named by the
+		 * most recent --peer, so ordering is "--peer X --band 5 ...".
+		 */
+		if (opt != 'p' && opt != 'm' && opt != 't' && opt != 's' &&
+		    opt != 'i' && opt != 'h' && opt != '?' && peer == NULL) {
+			PR_WARNING("Option must follow a --peer\n");
+			return -ENOEXEC;
+		}
+
+		switch (opt) {
+		case 'p':
+			if (params.num_peers >= CONFIG_WIFI_MGMT_RANGING_MAX_PEERS) {
+				PR_WARNING("Too many peers, maximum is %d\n",
+					   CONFIG_WIFI_MGMT_RANGING_MAX_PEERS);
+				return -ENOEXEC;
+			}
+
+			peer = &params.peers[params.num_peers];
+
+			if (net_bytes_from_str(peer->mac, WIFI_MAC_ADDR_LEN,
+					       state->optarg) < 0) {
+				PR_WARNING("Invalid peer MAC \"%s\"\n", state->optarg);
+				return -ENOEXEC;
+			}
+
+			params.num_peers++;
+			break;
+		case 'b':
+			if (wifi_ranging_parse_band(state->optarg, &peer->band)) {
+				PR_WARNING("Invalid band \"%s\", expected 2, 5 or 6\n",
+					   state->optarg);
+				return -ENOEXEC;
+			}
+			break;
+		case 'c':
+			peer->channel = (uint16_t)strtoul(state->optarg, NULL, 10);
+			break;
+		case 'w':
+			peer->tuning.bandwidth = (uint16_t)strtoul(state->optarg, NULL, 10);
+			if (peer->tuning.bandwidth != 20 && peer->tuning.bandwidth != 40 &&
+			    peer->tuning.bandwidth != 80 && peer->tuning.bandwidth != 160) {
+				PR_WARNING("Invalid bandwidth \"%s\", expected 20, 40, 80 or 160\n",
+					   state->optarg);
+				return -ENOEXEC;
+			}
+			break;
+		case 'n':
+			peer->tuning.bursts_exp = (uint8_t)strtoul(state->optarg, NULL, 10);
+			break;
+		case 'f':
+			peer->tuning.ftms_per_burst = (uint8_t)strtoul(state->optarg, NULL, 10);
+			break;
+		case 'd':
+			peer->tuning.burst_duration = (uint8_t)strtoul(state->optarg, NULL, 10);
+			break;
+		case 'r':
+			peer->tuning.burst_period = (uint8_t)strtoul(state->optarg, NULL, 10);
+			break;
+		case RANGING_START_OPT_FORMAT:
+			if (wifi_ranging_parse_preamble(state->optarg, &peer->tuning.preamble)) {
+				PR_WARNING("Invalid format \"%s\", expected non-ht, ht, vht or he\n",
+					   state->optarg);
+				return -ENOEXEC;
+			}
+			break;
+		case RANGING_START_OPT_ASAP:
+			peer->tuning.asap = true;
+			break;
+		case RANGING_START_OPT_START_DELAY:
+			peer->tuning.start_delay = (uint16_t)strtoul(state->optarg, NULL, 10);
+			break;
+		case RANGING_START_OPT_LOCATION:
+			peer->request_location = true;
+			break;
+		case 'm':
+			if (wifi_ranging_parse_mode(state->optarg, &params.mode)) {
+				PR_WARNING("Invalid mode \"%s\"\n", state->optarg);
+				return -ENOEXEC;
+			}
+			break;
+		case 't':
+			params.timeout_ms = (uint32_t)strtoul(state->optarg, NULL, 10);
+			break;
+		case 's':
+			params.session_id = (uint32_t)strtoul(state->optarg, NULL, 0);
+			break;
+		case 'i':
+			/* Parsed by get_iface() above. */
+			break;
+		case 'h':
+			shell_help(sh);
+			return SHELL_CMD_HELP_PRINTED;
+		default:
+			return -ENOEXEC;
+		}
+	}
+
+	if (params.num_peers == 0) {
+		PR_WARNING("At least one --peer is required\n");
+		return -ENOEXEC;
+	}
+
+	ret = net_mgmt(NET_REQUEST_WIFI_RANGING_START, iface, &params, sizeof(params));
+	if (ret) {
+		PR_WARNING("Ranging start failed: %d\n", ret);
+		return -ENOEXEC;
+	}
+
+	PR("Ranging session %u started for %u peer(s)\n",
+	   params.session_id, params.num_peers);
+
+	return 0;
+}
+
+static int cmd_wifi_ranging_cancel(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	uint32_t session_id = 0;
+	int ret;
+
+	if (iface == NULL) {
+		return -ENOEXEC;
+	}
+
+	if (argc > 1) {
+		session_id = (uint32_t)strtoul(argv[1], NULL, 0);
+	}
+
+	ret = net_mgmt(NET_REQUEST_WIFI_RANGING_CANCEL, iface,
+		       &session_id, sizeof(session_id));
+	if (ret) {
+		PR_WARNING("Ranging cancel failed: %d\n", ret);
+		return -ENOEXEC;
+	}
+
+	PR("Ranging session %u cancelled\n", session_id);
+
+	return 0;
+}
+#endif /* CONFIG_WIFI_MGMT_RANGING_INITIATOR */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+static int cmd_wifi_location_self(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	struct wifi_location_self_params params = { 0 };
+	int ret;
+
+	if (iface == NULL) {
+		return -ENOEXEC;
+	}
+
+	if (!strcasecmp(argv[1], "get")) {
+		params.oper = WIFI_MGMT_GET;
+	} else if (!strcasecmp(argv[1], "set")) {
+		params.oper = WIFI_MGMT_SET;
+	} else {
+		PR_WARNING("Invalid argument \"%s\", expected get or set\n", argv[1]);
+		return -ENOEXEC;
+	}
+
+	if (params.oper == WIFI_MGMT_SET) {
+#ifdef CONFIG_WIFI_MGMT_LOCATION_LCI
+		if (argc < 5) {
+			PR_WARNING("Usage: wifi location self set <lat> <long> <alt> "
+				   "[alt_type]\n");
+			return -ENOEXEC;
+		}
+
+		params.location.has_lci = true;
+		params.location.lci.latitude = strtoll(argv[2], NULL, 10);
+		params.location.lci.longitude = strtoll(argv[3], NULL, 10);
+		params.location.lci.altitude = (int32_t)strtol(argv[4], NULL, 10);
+		params.location.lci.altitude_type =
+			(argc > 5) ? (uint8_t)strtoul(argv[5], NULL, 10) : 1;
+#else
+		PR_WARNING("Setting a location requires CONFIG_WIFI_MGMT_LOCATION_LCI\n");
+		return -ENOEXEC;
+#endif /* CONFIG_WIFI_MGMT_LOCATION_LCI */
+	}
+
+	ret = net_mgmt(NET_REQUEST_WIFI_LOCATION_SELF, iface, &params, sizeof(params));
+	if (ret) {
+		PR_WARNING("Cannot %s own location: %d\n",
+			   params.oper == WIFI_MGMT_GET ? "get" : "set", ret);
+		return -ENOEXEC;
+	}
+
+	if (params.oper == WIFI_MGMT_GET) {
+		print_wifi_location(sh, &params.location);
+	} else {
+		PR("Own location updated\n");
+	}
+
+	return 0;
+}
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
+
+#ifdef CONFIG_WIFI_MGMT_RANGING
+SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ranging,
+	SHELL_CMD_ARG(caps, NULL,
+		      SHELL_HELP("Show ranging/location capabilities",
+				 "[-i, --iface <idx>]"),
+		      cmd_wifi_ranging_caps, 1, 2),
+	SHELL_CMD_ARG(peer_caps, NULL,
+		      SHELL_HELP("Show a peer's advertised ranging capability",
+				 "[<peer mac>, default = the associated AP]\n"
+				 "[-i, --iface <idx>]"),
+		      cmd_wifi_ranging_peer_caps, 1, 3),
+#ifdef CONFIG_WIFI_MGMT_RANGING_RESPONDER
+	SHELL_CMD_ARG(responder, NULL,
+		      SHELL_HELP("Enable/disable responder",
+				 "<enable|disable>\n"
+				 "[-i, --iface <idx>]"),
+		      cmd_wifi_ranging_responder, 2, 2),
+#endif /* CONFIG_WIFI_MGMT_RANGING_RESPONDER */
+#ifdef CONFIG_WIFI_MGMT_RANGING_INITIATOR
+	SHELL_CMD_ARG(start, NULL,
+		      SHELL_HELP("Start a ranging session",
+				 "Per-peer options must follow their --peer.\n"
+				 "[-p, --peer <mac> peer MAC, repeatable up to\n"
+				 "    CONFIG_WIFI_MGMT_RANGING_MAX_PEERS]\n"
+				 "[-b, --band <2|5|6>]\n"
+				 "[-c, --channel <n>]\n"
+				 "[-w, --bandwidth <20|40|80|160>]\n"
+				 "[--format <non-ht|ht|vht|he> PHY format; with\n"
+				 "    --bandwidth this is the spec's Format And Bandwidth]\n"
+				 "[-n, --bursts <exp> bursts as a power of two]\n"
+				 "[-f, --ftms-per-burst <n>]\n"
+				 "[-d, --burst-duration <n>]\n"
+				 "[-r, --burst-period <n> units of 100ms]\n"
+				 "[--asap]\n"
+				 "[--start-delay <tu> non-ASAP only: requested delay\n"
+				 "    before the first burst (default 0)]\n"
+				 "[--location fetch each peer's lci/civic]\n"
+				 "[-m, --mode <auto|11mc|11az-ntb|11az-tb>]\n"
+				 "[-t, --timeout <ms>]\n"
+				 "[-s, --session <id> optional session id, used by\n"
+				 "    wifi ranging cancel]\n"
+				 "[-i, --iface <idx>]\n"
+				 "[-h, --help]"),
+		      cmd_wifi_ranging_start, 2, 20),
+	SHELL_CMD_ARG(cancel, NULL,
+		      SHELL_HELP("Cancel a ranging session",
+				 "[<session id>, default 0 = the only active session]\n"
+				 "[-i, --iface <idx>]"),
+		      cmd_wifi_ranging_cancel, 1, 3),
+#endif /* CONFIG_WIFI_MGMT_RANGING_INITIATOR */
+	SHELL_SUBCMD_SET_END);
+SHELL_SUBCMD_ADD((wifi), ranging, &wifi_cmd_ranging, "Ranging (distance) commands.",
+		 NULL, 0, 0);
+#endif /* CONFIG_WIFI_MGMT_RANGING */
+
+#ifdef CONFIG_WIFI_MGMT_LOCATION
+SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_location,
+	SHELL_CMD_ARG(self, NULL,
+		      SHELL_HELP("Get/set own location",
+				 "get\n"
+				 "set <lat> <long> <alt> [alt_type]\n"
+				 "[-i, --iface <idx>]"),
+		      cmd_wifi_location_self, 2, 8),
+	SHELL_SUBCMD_SET_END);
+SHELL_SUBCMD_ADD((wifi), location, &wifi_cmd_location, "Location (coordinate) commands.",
+		 NULL, 0, 0);
+#endif /* CONFIG_WIFI_MGMT_LOCATION */
+
 SHELL_CMD_REGISTER(wifi, &wifi_commands, "Wi-Fi commands", NULL);
 
 static int wifi_shell_init(void)
@@ -6060,7 +6702,11 @@ static int wifi_shell_init(void)
 				     wifi_mgmt_event_handler,
 				     WIFI_SHELL_MGMT_EVENTS
 				     IF_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN,
-						(|WIFI_SHELL_NAN_EVENTS)));
+						(|WIFI_SHELL_NAN_EVENTS))
+				     IF_ENABLED(CONFIG_WIFI_MGMT_RANGING,
+						(|WIFI_SHELL_RANGING_EVENTS))
+				     IF_ENABLED(CONFIG_WIFI_MGMT_LOCATION,
+						(|WIFI_SHELL_LOCATION_EVENTS)));
 
 	net_mgmt_add_event_callback(&wifi_shell_mgmt_cb);
 


### PR DESCRIPTION
1. Addition Wifi Ranging Enums such as Ranging Mode, preamble ,status.
2. Addition of Net mgmt Request commands such as Ranging Start, Ranging Cancel, Responder,Ranging Caps, Ranging Peer Caps, Self Location and Ranging events.
3. Addition of Wifi Ranging and Location structs.
4. Addition of Ranging callbacks and Ranging APIs for Event Handler.
5. Addition of Shell Command Supports for FTM/Ranging Support.