### PR TITLE
bluetooth: MPL: notify track postion when stop playback

### DIFF
--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -2014,7 +2014,7 @@ static void set_track_position(int32_t position)
 		 * not be notified when the Media State is set to “Playing” and playback happens
 		 * at a constant speed.
 		 */
-		if (media_player.state != MEDIA_PROXY_STATE_PLAYING) {
+		if (media_player.state != MEDIA_PROXY_STATE_PLAYING || new_pos == 0) {
 			media_proxy_pl_track_position_cb(new_pos);
 		}
 	}


### PR DESCRIPTION
Notify Track Position when resetting it to zero while
playback is active. Stop resets the position before
changing the Media State to Paused, which previously
suppressed the Track Position notification.

The following conformance tests now pass:
GMCS/SR/MCP/BV-09-C

Testing
nRF5340 Audio DK
nRF54L15 DK