### PR TITLE
dts: arm: elan: enable PL022 SPI2 on EM32F967

### DIFF
--- a/boards/elan/32f967_dv/32f967_dv.dts
+++ b/boards/elan/32f967_dv/32f967_dv.dts
@@ -41,7 +41,7 @@
 };
 
 &spi2 {
-	status = "disabled";
+	status = "okay";
 	pinctrl-0 = <&spi2_sck_pb5 &spi2_miso_pb6 &spi2_mosi_pb7>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiob 4 GPIO_ACTIVE_LOW>;

--- a/dts/arm/elan/em32fxxx.dtsi
+++ b/dts/arm/elan/em32fxxx.dtsi
@@ -106,11 +106,11 @@
 		};
 
 		spi2: spi@40013000 {
-			compatible = "elan,elandev-spi2";
+			compatible = "arm,pl022";
 			reg = <0x40013000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			interrupts = <25 0>;
+			interrupts = <15 0>;
 			clocks = <&clk_apb EM32_GATE_PCLKG_SSP2>;
 			status = "disabled";
 		};

--- a/tests/drivers/spi/spi_loopback/boards/32f967_dv.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/32f967_dv.overlay
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2026 ELAN Microelectronics Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect PB7 (MOSI) to PB6 (MISO) for external loopback. */
+&spi2 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};


### PR DESCRIPTION
## Summary

- Describe the EM32F967 SSP2 controller with the upstream `arm,pl022`
  compatible.
- Correct the SSP2 NVIC interrupt mapping from IRQ 25 to IRQ 15.
- Enable SPI2 on the 32f967_dv board.
- Add a native `spi_loopback` board overlay for 32f967_dv.

The EM32F967 interrupt map identifies ARM_SSP as NVIC IRQ 15.

## Testing

Connected PB7 (MOSI) to PB6 (MISO) for external loopback and ran:

```
west build -b 32f967_dv -p always tests/drivers/spi/spi_loopback
```

### Results:
- spi_extra_api_features: 2 passed
- spi_loopback: 22 passed, 6 expected skips

The expected skips are the PL022 driver's unsupported non-8-bit word
sizes and the optional deinit GPIO test.

The optional `CONFIG_SPI_PL022_INTERRUPT` mode remains disabled;
validation covers the driver's default polling mode.