### PR TITLE
Add support of STM32MP13 U(S)ARTs

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_mp13.c
+++ b/drivers/clock_control/clock_stm32_ll_mp13.c
@@ -133,6 +133,14 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 		case LL_APB1_GRP1_PERIPH_UART4:
 			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_UART4_CLKSOURCE);
 			break;
+		case LL_APB1_GRP1_PERIPH_USART3:
+		case LL_APB1_GRP1_PERIPH_UART5:
+			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_USART35_CLKSOURCE);
+			break;
+		case LL_APB1_GRP1_PERIPH_UART7:
+		case LL_APB1_GRP1_PERIPH_UART8:
+			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_UART78_CLKSOURCE);
+			break;
 		case LL_APB1_GRP1_PERIPH_I2C1:
 		case LL_APB1_GRP1_PERIPH_I2C2:
 			*rate = LL_RCC_GetI2CClockFreq(LL_RCC_I2C12_CLKSOURCE);
@@ -152,12 +160,21 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 		case LL_APB2_GRP1_PERIPH_SPI1:
 			*rate = LL_RCC_GetSPIClockFreq(LL_RCC_SPI1_CLKSOURCE);
 			break;
+		case LL_APB2_GRP1_PERIPH_USART6:
+			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_USART6_CLKSOURCE);
+			break;
 		default:
 			return -ENOTSUP;
 		}
 		break;
 	case STM32_CLOCK_BUS_APB6:
 		switch (pclken->enr) {
+		case LL_APB6_GRP1_PERIPH_USART1:
+			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_USART1_CLKSOURCE);
+			break;
+		case LL_APB6_GRP1_PERIPH_USART2:
+			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_USART2_CLKSOURCE);
+			break;
 		case LL_APB6_GRP1_PERIPH_I2C3:
 			*rate = LL_RCC_GetI2CClockFreq(LL_RCC_I2C3_CLKSOURCE);
 			break;

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/clock/stm32mp13_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/reset/stm32mp13_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
@@ -61,12 +62,75 @@
 			reg = <0x2ffe0000 DT_SIZE_K(128)>;
 		};
 
+		usart1: serial@4c000000 {
+			compatible = "st,stm32-uart";
+			reg = <0x4c000000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 0)>;
+			resets = <&rctl STM32_RESET(APB6, 0)>;
+			interrupts = <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		usart2: serial@4c001000 {
+			compatible = "st,stm32-uart";
+			reg = <0x4c001000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 1)>;
+			resets = <&rctl STM32_RESET(APB6, 1)>;
+			interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		usart3: serial@4000f000 {
+			compatible = "st,stm32-uart";
+			reg = <0x4000f000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
+			resets = <&rctl STM32_RESET(APB1, 15)>;
+			interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
 		uart4: serial@40010000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40010000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 16)>;
 			resets = <&rctl STM32_RESET(APB1, 16)>;
 			interrupts = <GIC_SPI 53 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		uart5: serial@40011000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40011000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
+			interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		usart6: serial@44003000 {
+			compatible = "st,stm32-uart";
+			reg = <0x44003000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
+			interrupts = <GIC_SPI 72 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		uart7: serial@40018000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40018000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
+			interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		uart8: serial@40019000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40019000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
+			interrupts = <GIC_SPI 84 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Today, only UART4 was upstreamed in Zephyr project for console usage.
This PR brings other U(S)ART instances into STM32MP13 SoC DT, and the necessary support in the clock driver.
USART1 (present by default on GPIO connector of STM32MP135F-DK) has been tested in loopback mode using tests present in Zephyr project. 