### PR TITLE
drivers: ethernet: dwc_mac: nxp: fix IRQ comment placement and Kconfig help text

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -54,8 +54,8 @@ config ETH_NXP_DWC_ETHER_QOS
 	select CRC
 	default y
 	help
-	  This enables the Synopsys DesignWare MAC driver on NXP MCXE series
-	  SoCs, where the IP is named EMAC.
+	  This enables the Synopsys DesignWare MAC driver on NXP MCX N/MCX A/MCX E31
+	  series SoCs, where the IP is named EMAC.
 
 config ETH_STM32_DWC_ETHER_QOS
 	bool "Driver for DWC Ethernet QoS-based STM32"

--- a/drivers/ethernet/dwc_mac/eth_nxp_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_nxp_dwc_ether_qos.c
@@ -199,12 +199,13 @@ int dwmac_platform_init(const struct device *dev)
 			DMA_SYSBUS_MODE_AAL |
 			DMA_SYSBUS_MODE_FB);
 
-	/*
-	 * Set up IRQs (still masked for now). The MAC raises DMA transfer
-	 * completion on the dedicated tx/rx lines and everything else on the
-	 * common line, so all three share the same handler.
-	 */
+	/* Set up IRQs (still masked for now) */
 #if defined(CONFIG_SOC_SERIES_MCXE31X)
+	/*
+	 * The MAC raises DMA transfer completion on the dedicated tx/rx
+	 * lines and everything else on the common line, so all three share
+	 * the same handler.
+	 */
 	NXP_ETH_IRQ_CONNECT(common);
 	NXP_ETH_IRQ_CONNECT(tx);
 	NXP_ETH_IRQ_CONNECT(rx);


### PR DESCRIPTION
The explanation about the MAC raising DMA transfer completion on the dedicated tx/rx lines and everything else on the common line only applies to the MCX E31 series. Move that part into the corresponding #if block and keep the generic note outside of it, so the comment matches the code it documents.

The driver meanwhile supports the MCX N and MCX A series as well, but the help text still mentioned the MCX E series only. List all currently supported families instead.

No functional change.