### PR TITLE
net: http: server: fix NULL deref on HTTP/2 CONTINUATION frames

### DIFF
--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -801,6 +801,10 @@ static int handle_http2_dynamic_resource(
 		return -ESRCH;
 	}
 
+	if (client->current_stream == NULL) {
+		return -ENOENT;
+	}
+
 	user_method = dynamic_detail->common.bitmask_of_supported_http_methods;
 
 	if (!(BIT(client->method) & user_method)) {
@@ -969,6 +973,17 @@ static int enter_http_frame_continuation_state(struct http_client_ctx *client)
 {
 	struct http2_frame *frame = &client->current_frame;
 
+	/* Current_stream is only preserved for an expected
+	 * continuation, so a NULL pointer here means the peer sent a
+	 * stray CONTINUATION frame.
+	 */
+	if (client->current_stream == NULL ||
+	    client->current_stream->stream_id != frame->stream_identifier) {
+		LOG_DBG("Unexpected CONTINUATION frame for stream ID %d",
+			frame->stream_identifier);
+		return -ENOENT;
+	}
+
 	if (!is_header_flag_set(frame->flags, HTTP2_FLAG_END_HEADERS)) {
 		client->expect_continuation = true;
 	} else {
@@ -1030,7 +1045,14 @@ int handle_http_frame_header(struct http_client_ctx *client)
 		return -EBADMSG;
 	}
 
-	client->current_stream = NULL;
+	/* The stream context is bound when the header block starts and has to
+	 * stay valid until that block is complete, i. e. across the
+	 * CONTINUATION frames that carry the rest of it. Only release it when
+	 * the previous frame actually ended a block.
+	 */
+	if (!client->expect_continuation) {
+		client->current_stream = NULL;
+	}
 
 	switch (client->current_frame.type) {
 	case HTTP2_DATA_FRAME:

--- a/tests/net/lib/http_server/core/src/main.c
+++ b/tests/net/lib/http_server/core/src/main.c
@@ -175,6 +175,19 @@ BUILD_ASSERT(sizeof(long_payload) - 1 > CONFIG_HTTP_SERVER_CLIENT_BUFFER_SIZE,
 	0x00, 0x00, 0x10, 0x09, 0x04, 0x00, 0x00, 0x00, TEST_STREAM_ID_1, \
 	0x2f, 0x2a, 0x5f, 0x87, 0x49, 0x7c, 0xa5, 0x8a, 0xe8, 0x19, 0xaa, 0x0f, \
 	0x0d, 0x02, 0x31, 0x37
+/* Same header block as above, but split exactly on a header field boundary,
+ * so that the continuation frame header is processed by the regular frame
+ * header handler instead of being consumed by the incomplete header handling.
+ */
+#define TEST_HTTP2_PARTIAL_HEADERS_POST_DYNAMIC_STREAM_1_ALIGNED \
+	0x00, 0x00, 0x22, 0x01, 0x00, 0x00, 0x00, 0x00, TEST_STREAM_ID_1, \
+	0x83, 0x86, 0x41, 0x87, 0x0b, 0xe2, 0x5c, 0x0b, 0x89, 0x70, 0xff, 0x04, \
+	0x86, 0x62, 0x4f, 0x55, 0x0e, 0x93, 0x13, 0x7a, 0x88, 0x25, 0xb6, 0x50, \
+	0xc3, 0xcb, 0xbc, 0xb8, 0x3f, 0x53, 0x03, 0x2a, 0x2f, 0x2a
+#define TEST_HTTP2_CONTINUATION_POST_DYNAMIC_STREAM_1_ALIGNED \
+	0x00, 0x00, 0x0e, 0x09, 0x04, 0x00, 0x00, 0x00, TEST_STREAM_ID_1, \
+	0x5f, 0x87, 0x49, 0x7c, 0xa5, 0x8a, 0xe8, 0x19, 0xaa, 0x0f, 0x0d, 0x02, \
+	0x31, 0x37
 #define TEST_HTTP2_DATA_POST_DYNAMIC_STREAM_1 \
 	0x00, 0x00, 0x11, 0x00, 0x01, 0x00, 0x00, 0x00, TEST_STREAM_ID_1, \
 	0x54, 0x65, 0x73, 0x74, 0x20, 0x64, 0x79, 0x6e, 0x61, 0x6d, 0x69, 0x63, \
@@ -1350,6 +1363,50 @@ ZTEST(server_function_tests, test_http2_post_missing_continuation)
 
 	/* Expect settings, but processing headers (and lack of continuation
 	 * frame) should break the stream, and trigger disconnect.
+	 */
+	expect_http2_settings_frame(&offset, false);
+	expect_http2_settings_frame(&offset, true);
+
+	ret = zsock_recv(client_fd, buf, sizeof(buf), 0);
+	zassert_equal(ret, 0, "Connection should've been closed");
+}
+
+ZTEST(server_function_tests, test_http2_post_headers_with_continuation_aligned)
+{
+	static const uint8_t request_post_dynamic[] = {
+		TEST_HTTP2_MAGIC,
+		TEST_HTTP2_SETTINGS,
+		TEST_HTTP2_SETTINGS_ACK,
+		TEST_HTTP2_PARTIAL_HEADERS_POST_DYNAMIC_STREAM_1_ALIGNED,
+		TEST_HTTP2_CONTINUATION_POST_DYNAMIC_STREAM_1_ALIGNED,
+		TEST_HTTP2_DATA_POST_DYNAMIC_STREAM_1,
+		TEST_HTTP2_GOAWAY,
+	};
+
+	common_verify_http2_dynamic_post_request(request_post_dynamic,
+						 sizeof(request_post_dynamic));
+}
+
+ZTEST(server_function_tests, test_http2_unexpected_continuation)
+{
+	static const uint8_t request_post_dynamic[] = {
+		TEST_HTTP2_MAGIC,
+		TEST_HTTP2_SETTINGS,
+		TEST_HTTP2_SETTINGS_ACK,
+		TEST_HTTP2_CONTINUATION_POST_DYNAMIC_STREAM_1,
+		TEST_HTTP2_GOAWAY,
+	};
+	size_t offset = 0;
+	int ret;
+
+	(void)memset(buf, 0, sizeof(buf));
+
+	ret = zsock_send(client_fd, request_post_dynamic,
+			 sizeof(request_post_dynamic), 0);
+	zassert_not_equal(ret, -1, "send() failed (%d)", errno);
+
+	/* A continuation frame which is not preceded by a headers frame is a
+	 * protocol error, the connection should be closed.
 	 */
 	expect_http2_settings_frame(&offset, false);
 	expect_http2_settings_frame(&offset, true);


### PR DESCRIPTION
The HTTP/2 frame header handler cleared current_stream in the middle of a header
block, so the dynamic POST/PUT/PATCH dispatch dereferenced NULL once a
CONTINUATION frame completed the block, halting the server on a single
unauthenticated request. Keep the stream bound while a continuation is expected,
reject stray or cross-stream CONTINUATION frames, and add regression tests.