### PR TITLE
boards: stm32wba65i-dk1: remove unused bluetooth and ieee802154 nodes

### DIFF
--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1-common.dtsi
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1-common.dtsi
@@ -179,19 +179,6 @@
 	status = "okay";
 };
 
-&bt_hci_wba {
-	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-};
-
-&ieee802154 {
-	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
-	interrupts = <66 0>, <61 14>;
-	interrupt-names = "radio", "radio-sw-low";
-	status = "okay";
-};
-
 &aes {
 	status = "okay";
 };


### PR DESCRIPTION
Remove the bluetooth node and the ieee802154 node because they have been moved in a radio binding in the
SHA-1: f707a0dd0d07ac6de580bf4881064c0a1a33c187 commit.

FYI: @asm5878 , @etienne-lms , @erwango 