### PR TITLE
scripts: footprint: Make compare_footprint use twister

### DIFF
--- a/scripts/footprint/compare_footprint
+++ b/scripts/footprint/compare_footprint
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
-
+#
 # SPDX-License-Identifier: Apache-2.0
+
 """
 This script help you to compare footprint results with previous commits in git.
 If you don't have a git repository, it will compare your current tree
 against the last release results.
-To run it you need to set up the same environment as twister.
-The scripts take 2 optional args COMMIT and BASE_COMMIT, which tell the scripts
-which commit to use as current commit and as base for comparing, respectively.
-The script can take any SHA commit recognized for git.
+It leverages twister to output size reports and then compares the results.
 
 COMMIT is the commit to compare against BASE_COMMIT.
  Default
@@ -16,16 +14,17 @@ COMMIT is the commit to compare against BASE_COMMIT.
  HEAD in any other case.
 BASE_COMMIT is the commit used as base to compare results.
  Default:
-  twister_last_release.csv if we don't have git tree.
   HEAD is we have changes in the working tree.
   HEAD~1 if we don't have changes and we have default COMMIT.
   COMMIT~1 if we have a valid COMMIT.
 
+To compare only specific tests, use -F to supply a testplan for twister.
+You can generate testplans using twister's --save-tests option.
 """
 
 import argparse
 import os
-import csv
+import json
 import subprocess
 import logging
 import tempfile
@@ -37,7 +36,6 @@ if "ZEPHYR_BASE" not in os.environ:
 
 logger = None
 GIT_ENABLED = False
-RELEASE_DATA = 'twister_last_release.csv'
 
 def is_git_enabled():
     global GIT_ENABLED
@@ -74,11 +72,28 @@ def parse_args():
                 allow_abbrev=False)
     parser.add_argument('-b', '--base-commit', default=None,
                         help="Commit ID to use as base for footprint "
-                                    "compare. Default is parent current commit."
-                                    " or twister_last_release.csv if we don't have git.")
+                                    "compare. Default is parent current commit.")
     parser.add_argument('-c', '--commit', default=None,
                         help="Commit ID to use compare footprint against base. "
                                     "Default is HEAD or working tree.")
+    parser.add_argument("-F", "--load-tests", default=None,
+                        help="Path to a twister testplan. "
+                                    "When provided, only builds tests defined in the plan.")
+    parser.add_argument('-o', '--output-dir', default=None,
+                        help="Directory to place twister build output for each commit. "
+                                    "Results are stored in <output_dir>/<SHA_BASE> and "
+                                    "<output_dir>/<SHA_COMMIT>. If not provided, output goes "
+                                    "under a 'zephyr-footprint-compare' directory in the "
+                                    "system temporary directory (e.g. /tmp).")
+    parser.add_argument('--keep-artifacts', action='store_true',
+                        help="Preserve twister's per-test build trees (object files, "
+                                    "assembly, ELF, maps, etc.) under "
+                                    "<results_dir>/<SHA>/twister-out, where <results_dir> is "
+                                    "either --output-dir or a 'zephyr-footprint-compare' "
+                                    "directory in the system temporary directory. Without "
+                                    "this flag, the build tree is left in twister's default "
+                                    "location and, for non-HEAD commits, is discarded with "
+                                    "the temporary git worktree.")
     return parser.parse_args()
 
 def get_git_commit(commit):
@@ -89,43 +104,43 @@ def get_git_commit(commit):
         commit_id = proc.stdout.read().decode("utf-8").strip()
     return commit_id
 
-def sanity_results_filename(commit=None, cwd=os.environ.get('ZEPHYR_BASE')):
+def sanity_results_filename(commit=None, cwd=os.environ.get('ZEPHYR_BASE'),
+                            output_base=None):
     if not commit:
-        file_name = "tmp.csv"
+        dir_name = "tmp"
     else:
-        if commit == RELEASE_DATA:
-            file_name = RELEASE_DATA
-        else:
-            file_name = "%s.csv" % commit
+        dir_name = commit
 
-    return os.path.join(cwd,'scripts', 'sanity_chk', file_name)
+    if output_base:
+        return os.path.join(output_base, dir_name)
 
-def git_reset(commit, cwd=os.environ.get('ZEPHYR_BASE')):
-    proc = subprocess.Popen('git diff --quiet', stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT, cwd=cwd, shell=True)
-    if proc.wait() != 0:
-        raise Exception("Cannot continue, you have unstaged changes in your working tree")
-
-    proc = subprocess.Popen('git reset %s --hard' % commit,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT,
-                            cwd=cwd, shell=True)
-    if proc.wait() == 0:
-        return True
-    else:
-        logger.error(proc.stdout.read())
-    return False
+    return os.path.join(tempfile.gettempdir(), 'zephyr-footprint-compare',
+                        dir_name)
 
 def run_sanity_footprint(commit=None, cwd=os.environ.get('ZEPHYR_BASE'),
-                         output_file=None):
-    if not output_file:
-        output_file = sanity_results_filename(commit)
-    cmd = '/bin/bash -c "source ./zephyr-env.sh && twister'
-    cmd += ' +scripts/sanity_chk/sanity_compare.args -o %s"' % output_file
+                         output_dir=None, testplan_file=None, output_base=None,
+                         keep_artifacts=False):
+    if not output_dir:
+        output_dir = sanity_results_filename(commit, output_base=output_base)
+
+    # -o / --report-dir is where twister writes its JSON/XML reports.
+    # -O / --outdir is where twister writes per-test build trees (the
+    # 'twister-out' directory). When --keep-artifacts is set we redirect
+    # the build tree under the results dir so all evidence for a given
+    # commit lives together in <results_dir>/<SHA>/{reports, twister-out/}.
+    cmd = 'west twister -b --enable-size-report -o %s' % output_dir
+    if keep_artifacts:
+        build_outdir = os.path.join(output_dir, 'twister-out')
+        cmd += ' -O %s' % build_outdir
+    if testplan_file:
+        cmd += ' --load-tests %s' % testplan_file
     logger.debug('Sanity (%s)   %s' %(commit, cmd))
 
+    new_env = os.environ.copy()
+    new_env["ZEPHYR_BASE"] = cwd
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            cwd=cwd, shell=True)
+                            cwd=cwd, shell=True, env=new_env)
+
     output,_ = proc.communicate()
     if proc.wait() == 0:
         logger.debug(output)
@@ -135,42 +150,80 @@ def run_sanity_footprint(commit=None, cwd=os.environ.get('ZEPHYR_BASE'),
     logger.error(output)
     raise Exception("Couldn't build footprint apps in commit %s" % commit)
 
-def run_footprint_build(commit=None):
+def run_footprint_build(commit=None, testplan_file=None, output_base=None,
+                        keep_artifacts=False):
     logging.debug("footprint build for %s" % commit)
     if not commit:
-        run_sanity_footprint()
-    else:
-        cmd = "git clone --no-hardlinks %s" % os.environ.get('ZEPHYR_BASE')
-        tmp_location = os.path.join(tempfile.gettempdir(),
-                                os.path.basename(os.environ.get('ZEPHYR_BASE')))
-        if os.path.exists(tmp_location):
-            shutil.rmtree(tmp_location)
-        logging.debug("cloning into %s" % tmp_location)
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT,
-                                cwd=tempfile.gettempdir(), shell=True)
-        if proc.wait() == 0:
-            if git_reset(commit, tmp_location):
-                run_sanity_footprint(commit, tmp_location)
-        else:
-            logger.error(proc.stdout.read())
-        shutil.rmtree(tmp_location, ignore_errors=True)
+        run_sanity_footprint(testplan_file=testplan_file, output_base=output_base,
+                             keep_artifacts=keep_artifacts)
+        return True
+
+    # Use `git worktree` instead of a full clone:
+    # We place the worktree as a sibling of $ZEPHYR_BASE so it stays inside
+    # the same west workspace.
+    zephyr_base = os.environ.get('ZEPHYR_BASE')
+    worktree_path = os.path.join(os.path.dirname(zephyr_base),
+                                 'zephyr-footprint-%s' % commit)
+
+    # Drop any previous worktree, but don't touch normal directories
+    if os.path.exists(worktree_path):
+        subprocess.run(['git', 'worktree', 'remove', '--force', worktree_path],
+                       cwd=zephyr_base,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       check=False)
+        # `git worktree remove` may refuse (e.g. worktree unknown to git)
+        raise Exception("Couldn't remove a worktree unknown to git: %s" % worktree_path)
+
+    logging.debug("creating worktree at %s" % worktree_path)
+    proc = subprocess.Popen(
+        ['git', 'worktree', 'add', '--detach', worktree_path, commit],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        cwd=zephyr_base)
+    output, _ = proc.communicate()
+    if proc.wait() != 0:
+        logger.error(output)
+        raise Exception("Couldn't create worktree for commit %s" % commit)
+
+    try:
+        run_sanity_footprint(commit, worktree_path,
+                             testplan_file=testplan_file,
+                             output_base=output_base,
+                             keep_artifacts=keep_artifacts)
+    finally:
+        subprocess.run(['git', 'worktree', 'remove', '--force', worktree_path],
+                       cwd=zephyr_base,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       check=False)
+        shutil.rmtree(worktree_path, ignore_errors=True)
     return True
 
-def read_sanity_report(filename):
+def read_sanity_report(directory):
+    """Read test results from twister.json in the output directory."""
+    twister_json = os.path.join(directory, 'twister.json')
     data = []
-    with open(filename) as fp:
-        tmp = csv.DictReader(fp)
-        for row in tmp:
-            data.append(row)
+    with open(twister_json) as fp:
+        report = json.load(fp)
+        for ts in report.get('testsuites', []):
+            # Only include testsuites that have footprint data
+            if ts.get('used_ram') is not None or ts.get('used_rom') is not None:
+                data.append({
+                    'test': ts['name'],
+                    'platform': ts['platform'],
+                    'used_ram': str(ts.get('used_ram', '')),
+                    'used_rom': str(ts.get('used_rom', '')),
+                })
     return data
 
-def get_footprint_results(commit=None):
-    sanity_file = sanity_results_filename(commit)
-    if (not os.path.exists(sanity_file) or not commit) and commit != RELEASE_DATA:
-        run_footprint_build(commit)
+def get_footprint_results(commit=None, testplan_file=None, output_base=None,
+                          keep_artifacts=False):
+    sanity_dir = sanity_results_filename(commit, output_base=output_base)
+    twister_json = os.path.join(sanity_dir, 'twister.json')
+    if not os.path.exists(twister_json) or not commit:
+        run_footprint_build(commit, testplan_file=testplan_file,
+                            output_base=output_base,
+                            keep_artifacts=keep_artifacts)
 
-    return read_sanity_report(sanity_file)
+    return read_sanity_report(sanity_dir)
 
 def tree_changes():
     proc = subprocess.Popen('git diff --quiet', stdout=subprocess.PIPE,
@@ -194,21 +247,17 @@ def get_default_base_commit(current_commit):
     else:
         return get_git_commit('%s~1'%current_commit)
 
-def build_history(b_commit=None, c_commit=None):
-    if not GIT_ENABLED:
-        logger.info('Working on current tree, not git enabled.')
-        current_commit = None
-        base_commit = RELEASE_DATA
+def build_history(b_commit=None, c_commit=None, plan=None, output_base=None,
+                  keep_artifacts=False):
+    if not c_commit:
+        current_commit = get_default_current_commit()
     else:
-        if not c_commit:
-            current_commit = get_default_current_commit()
-        else:
-            current_commit = get_git_commit(c_commit)
+        current_commit = get_git_commit(c_commit)
 
-        if not b_commit:
-            base_commit = get_default_base_commit(current_commit)
-        else:
-            base_commit = get_git_commit(b_commit)
+    if not b_commit:
+        base_commit = get_default_base_commit(current_commit)
+    else:
+        base_commit = get_git_commit(b_commit)
 
     if not base_commit:
         logger.error("Cannot resolve base commit")
@@ -218,14 +267,33 @@ def build_history(b_commit=None, c_commit=None):
     logger.info("Current: %s" % (current_commit if current_commit else
                     'working space'))
 
-    current_results = get_footprint_results(current_commit)
-    base_results = get_footprint_results(base_commit)
+    if plan:
+        # If we don't provide an absolute path,
+        # twister will look for the testplan relative
+        # to ZEPHYR_BASE. Not what we want.
+        plan = os.path.abspath(plan)
+        logger.info("Using testplan: %s" % plan)
+
+    if output_base:
+        output_base = os.path.abspath(output_base)
+        os.makedirs(output_base, exist_ok=True)
+        logger.info("Output dir: %s" % output_base)
+
+    if keep_artifacts:
+        logger.info("Keeping per-test build artifacts under <results_dir>/<SHA>/twister-out")
+
+    current_results = get_footprint_results(current_commit, testplan_file=plan,
+                                            output_base=output_base,
+                                            keep_artifacts=keep_artifacts)
+    base_results = get_footprint_results(base_commit, testplan_file=plan,
+                                         output_base=output_base,
+                                         keep_artifacts=keep_artifacts)
     deltas = compare_results(base_results, current_results)
     print_deltas(deltas)
 
 def compare_results(base_results, current_results):
-    interesting_metrics = [("ram_size", int),
-                           ("rom_size", int)]
+    interesting_metrics = [("used_ram", int),
+                           ("used_rom", int)]
     results = {}
     metrics = {}
 
@@ -256,11 +324,10 @@ def compare_results(base_results, current_results):
                 if test_data[metric] == "":
                     continue
                 delta = test_data[metric] - golden_metric[metric]
-                if delta == 0:
-                    continue
                 tmp[metric] = {
                     'delta': delta,
                     'current': test_data[metric],
+                    'percentage': (float(delta) / float(test_data[metric] - delta))
                 }
 
             if tmp:
@@ -272,25 +339,45 @@ def compare_results(base_results, current_results):
     return results
 
 def print_deltas(deltas):
-    error_count = 0
     for test in sorted(deltas):
-        print("\n{:<25}".format(test))
+        changed = {}
         for platform, data in deltas[test].items():
+            metrics = {m: v for m, v in data.items() if v['delta'] != 0}
+            if metrics:
+                changed[platform] = metrics
+
+        if not changed:
+            continue
+
+        print("\n{:<25}".format(test))
+        for platform, data in changed.items():
             print(" {:<25}".format(platform))
             for metric, value in data.items():
-                percentage = (float(value['delta']) / float(value['current'] -
-                                                            value['delta']))
                 print("  {} ({:+.2%}) {:+6}   current size {:>7} bytes".format(
-                        "RAM" if metric == "ram_size" else "ROM", percentage,
-                        value['delta'], value['current']))
-                error_count = error_count + 1
-    if error_count == 0:
-        print("There are no changes in RAM neither in ROM of footprint apps.")
-    return error_count
+                        "RAM" if metric == "used_ram" else "ROM",
+                        value['percentage'], value['delta'], value['current']))
+    rom_percentages = [t['used_rom']['percentage'] for v in deltas.values() for t in v.values()
+                       if t.get('used_rom') is not None]
+    rom_deltas = [t['used_rom']['delta'] for v in deltas.values() for t in v.values() if
+                  t.get('used_rom') is not None]
+    ram_percentages = [t['used_ram']['percentage'] for v in deltas.values() for t in v.values()
+                       if t.get('used_ram') is not None]
+    ram_deltas = [t['used_ram']['delta'] for v in deltas.values() for t in v.values()
+                  if t.get('used_ram') is not None]
+    if len(rom_percentages) > 0 or len(ram_percentages) > 0:
+        print("\nSummary of footprint changes:")
+    if len(rom_percentages) > 0:
+        print("\tROM: [{:+.2%}, {:+.2%}] [{:+6}, {:+6}] bytes".format(
+            min(rom_percentages), max(rom_percentages), min(rom_deltas), max(rom_deltas)))
+    if len(ram_percentages) > 0:
+        print("\tRAM: [{:+.2%}, {:+.2%}] [{:+6}, {:+6}] bytes".format(
+            min(ram_percentages), max(ram_percentages), min(ram_deltas), max(ram_deltas)))
 
 def main():
     args = parse_args()
-    build_history(args.base_commit, args.commit)
+    output_base = os.path.abspath(args.output_dir) if args.output_dir else None
+    build_history(args.base_commit, args.commit, args.load_tests, output_base,
+                  args.keep_artifacts)
 
 if __name__ == "__main__":
     init_logs()

--- a/scripts/footprint/testplan.json
+++ b/scripts/footprint/testplan.json
@@ -1,0 +1,299 @@
+{
+  "testsuites": [
+    {
+      "name": "benchmark.kernel.footprints.default",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.userspace",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.default",
+      "platform": "disco_l475_iot1/stm32l475xx",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.userspace",
+      "platform": "disco_l475_iot1/stm32l475xx",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.default",
+      "platform": "nrf5340dk/nrf5340/cpuapp",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.default",
+      "platform": "nrf51dk/nrf51822",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.default",
+      "platform": "hifive1_revb/fe310_g002",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.default",
+      "platform": "intel_ehl_crb/elkhart_lake",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.userspace",
+      "platform": "intel_ehl_crb/elkhart_lake",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.pm",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.pm",
+      "platform": "disco_l475_iot1/stm32l475xx",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.pm",
+      "platform": "it8xxx2_evb/it81302bx",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "benchmark.kernel.footprints.pm",
+      "platform": "iotdk/arc_iot",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.net.sockets.echo_client",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.net.sockets.echo_client.802154.rf2xx.arduino",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.net.sockets.echo_client.mcr20a",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.net.sockets.echo_server",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.net.sockets.echo_server.802154.rf2xx.arduino",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.net.sockets.echo_server.mcr20a",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.net.sockets.echo_server.usbd_cdc_ncm",
+      "platform": "frdm_k64f/mk64f12",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.beacon-coex",
+      "platform": "nrf52840dk/nrf52840",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.central_hr.bt_ll_sw_split.extended",
+      "platform": "nrf52840dk/nrf52840",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.central_hr.bt_ll_sw_split.phy_coded",
+      "platform": "nrf52840dk/nrf52840",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.mesh_demo",
+      "platform": "bbc_microbit/nrf51822",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.audio.unicast_client",
+      "platform": "nrf5340dk/nrf5340/cpuapp",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.audio.unicast_server",
+      "platform": "nrf5340dk/nrf5340/cpuapp",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_broadcast.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.bis.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_central.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_peripheral.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.cis.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.df.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.df.no_phy_coded.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.mesh.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_broadcast.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.bis.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_central.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_peripheral.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.cis.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.df.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.df.no_phy_coded.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.mesh.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_broadcast.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.bis.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_central.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso_peripheral.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.cis.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.iso.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.df.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.df.no_phy_coded.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    },
+    {
+      "name": "sample.bluetooth.hci_ipc.mesh.bt_ll_sw_split",
+      "platform": "nrf5340dk/nrf5340/cpunet",
+      "toolchain": "zephyr/gnu"
+    }
+  ]
+}


### PR DESCRIPTION
In follow-up work it would be nice to have a footprint output for each PR so that he reviewers know how the changes affect the ROM and RAM size.

Broken, and out-of-date, script brought back alive to be used for comparing the footprint of 2 different commits using a twister test plan. The size reports output by twister are used to compare if the footprint has changed.

Use git worktree to keep a lighter copy of the git revisions being compared.

`scripts/footprint/plan.txt` is converted to a testplan.json so that the same suite of tests can be ran using twister.

When --output-dir is not provided, place twister results under a 'zephyr-footprint-compare' subdirectory of the system temporary directory (e.g. /tmp) instead of scripts/sanity_chk/ in the tree.

--keep-artifacts can be passed to inspect the build output when investigating any changes between 2 builds.
"Artifacts" is the twister output stored in
<output_dir>/<SHA>/twister-out.

Add a short summary of the biggest RAM and ROM changes (min-max range).

Here is output from a previous change (#114392) with varying effects,
```
benchmark.kernel.footprints.default
 frdm_k64f/mk64f12
  ROM (-0.05%)    -12   current size   24160 bytes
 disco_l475_iot1/stm32l475xx
  ROM (-0.05%)    -12   current size   24632 bytes
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.04%)    -12   current size   28436 bytes
 nrf51dk/nrf51822
  ROM (-0.07%)    -16   current size   22932 bytes
 hifive1_revb/fe310_g002
  ROM (-0.08%)    -18   current size   21270 bytes

benchmark.kernel.footprints.pm
 frdm_k64f/mk64f12
  ROM (-0.04%)    -12   current size   27040 bytes
 disco_l475_iot1/stm32l475xx
  ROM (-0.04%)    -12   current size   31505 bytes
 iotdk/arc_iot
  RAM (-0.02%)     -8   current size   34273 bytes
  ROM (-0.03%)     -8   current size   24139 bytes

benchmark.kernel.footprints.userspace
 frdm_k64f/mk64f12
  ROM (-0.02%)    -12   current size   63404 bytes
 disco_l475_iot1/stm32l475xx
  ROM (-0.02%)    -12   current size   63780 bytes

sample.bluetooth.audio.unicast_client
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.00%)    -12   current size  256037 bytes

sample.bluetooth.audio.unicast_server
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.00%)    -12   current size  262714 bytes

sample.bluetooth.beacon-coex
 nrf52840dk/nrf52840
  ROM (-0.02%)    -12   current size   64890 bytes

sample.bluetooth.central_hr.bt_ll_sw_split.extended
 nrf52840dk/nrf52840
  ROM (-0.01%)    -12   current size  183457 bytes

sample.bluetooth.central_hr.bt_ll_sw_split.phy_coded
 nrf52840dk/nrf52840
  ROM (-0.01%)    -12   current size  186877 bytes

sample.bluetooth.hci_ipc
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  112764 bytes

sample.bluetooth.hci_ipc.bis.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  225204 bytes

sample.bluetooth.hci_ipc.cis.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  198964 bytes

sample.bluetooth.hci_ipc.df.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  185136 bytes

sample.bluetooth.hci_ipc.df.no_phy_coded.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  180976 bytes

sample.bluetooth.hci_ipc.iso.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  211064 bytes

sample.bluetooth.hci_ipc.iso_broadcast.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  115848 bytes

sample.bluetooth.hci_ipc.iso_central.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  152116 bytes

sample.bluetooth.hci_ipc.iso_peripheral.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  147628 bytes

sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  118000 bytes

sample.bluetooth.hci_ipc.mesh.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.01%)    -12   current size  123764 bytes

sample.bluetooth.mesh_demo
 bbc_microbit/nrf51822
  ROM (-0.01%)    -16   current size  154316 bytes

sample.net.sockets.echo_client
 frdm_k64f/mk64f12
  ROM (-0.01%)    -12   current size  230448 bytes

sample.net.sockets.echo_client.802154.rf2xx.arduino
 frdm_k64f/mk64f12
  ROM (-0.01%)    -12   current size  224296 bytes

sample.net.sockets.echo_client.mcr20a
 frdm_k64f/mk64f12
  ROM (-0.01%)    -12   current size  210724 bytes

sample.net.sockets.echo_server
 frdm_k64f/mk64f12
  ROM (-0.01%)    -12   current size  234836 bytes

sample.net.sockets.echo_server.802154.rf2xx.arduino
 frdm_k64f/mk64f12
  ROM (-0.01%)    -12   current size  227232 bytes

sample.net.sockets.echo_server.mcr20a
 frdm_k64f/mk64f12
  ROM (-0.01%)    -12   current size  212280 bytes

sample.net.sockets.echo_server.usbd_cdc_ncm
 frdm_k64f/mk64f12
  ROM (-0.00%)    -12   current size  257404 bytes

Summary of footprint changes:
        ROM: [-0.08%, +0.00%] [   -18,     +0] bytes
        RAM: [-0.02%, +0.00%] [    -8,     +0] bytes
````

Here is the output of a comparison of ZASSERT between `ASSERT_MODULE_DEFAULT_LEVEL_TERSE` and `ASSERT_MODULE_DEFAULT_LEVEL_VERBOSE` (#112756) when asserts are enabled for the Bluetooth mesh_demo in the testplan.

```
sample.bluetooth.mesh_demo
 bbc_microbit/nrf51822
  ROM (-14.45%) -27448   current size  162468 bytes

Summary of footprint changes:
        ROM: [-14.45%, +0.00%] [-27448,     +0] bytes
        RAM: [+0.00%, +0.00%] [    +0,     +0] bytes
```

ZASSERT with `CONFIG_ASSERT=n` also result in some interesting size reductions,
```
Detta ar footprint testsuiten med CONFIG_ASSERT=n,


sample.bluetooth.audio.unicast_client
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.20%)   -524   current size  257021 bytes

sample.bluetooth.audio.unicast_server
 nrf5340dk/nrf5340/cpuapp
  ROM (-0.21%)   -568   current size  263930 bytes

sample.bluetooth.beacon-coex
 nrf52840dk/nrf52840
  ROM (-1.43%)   -936   current size   64450 bytes

sample.bluetooth.central_hr.bt_ll_sw_split.extended
 nrf52840dk/nrf52840
  ROM (-0.95%)  -1752   current size  182421 bytes

sample.bluetooth.central_hr.bt_ll_sw_split.phy_coded
 nrf52840dk/nrf52840
  ROM (-0.93%)  -1752   current size  185909 bytes

sample.bluetooth.hci_ipc
 nrf5340dk/nrf5340/cpunet
  ROM (-1.32%)  -1504   current size  112384 bytes

sample.bluetooth.hci_ipc.bis.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.76%)  -1716   current size  224568 bytes

sample.bluetooth.hci_ipc.cis.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.69%)  -1388   current size  198676 bytes

sample.bluetooth.hci_ipc.df.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.78%)  -1444   current size  184760 bytes

sample.bluetooth.hci_ipc.df.no_phy_coded.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.79%)  -1432   current size  180608 bytes

sample.bluetooth.hci_ipc.iso.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.93%)  -1968   current size  210028 bytes

sample.bluetooth.hci_ipc.iso_broadcast.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.79%)   -924   current size  115932 bytes

sample.bluetooth.hci_ipc.iso_central.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.54%)   -824   current size  152348 bytes

sample.bluetooth.hci_ipc.iso_peripheral.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.65%)   -960   current size  147724 bytes

sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.73%)   -872   current size  118148 bytes

sample.bluetooth.hci_ipc.mesh.bt_ll_sw_split
 nrf5340dk/nrf5340/cpunet
  ROM (-0.93%)  -1164   current size  123648 bytes

sample.bluetooth.mesh_demo
 bbc_microbit/nrf51822
  ROM (-0.95%)  -1480   current size  154000 bytes

Summary of footprint changes:
        ROM: [-1.43%, +0.00%] [ -1968,     +0] bytes
        RAM: [+0.00%, +0.00%] [    +0,     +0] bytes
```