### PR TITLE
drivers: ethernet: mdio: dwmac: include pinctrl.h only when used

### DIFF
--- a/drivers/ethernet/mdio/mdio_dwmac.c
+++ b/drivers/ethernet/mdio/mdio_dwmac.c
@@ -9,12 +9,15 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/mdio.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/util.h>
+
+#ifdef CONFIG_PINCTRL
+#include <zephyr/drivers/pinctrl.h>
+#endif
 
 #include "../dwc_mac/eth_dwmac_priv.h"
 


### PR DESCRIPTION
## Summary

- Gate `#include <zephyr/drivers/pinctrl.h>` behind the existing `DWMAC_MDIO_PINCTRL_ENABLED` DT check.
- Avoid requiring `pinctrl_soc.h` on SoCs that enable `snps,dwmac-mdio` without `pinctrl-0` (e.g. Rockchip RK3588).

## Test plan

- [x] Diff limited to `drivers/ethernet/mdio/mdio_dwmac.c`
- [ ] CI / existing DWMAC+pinctrl platforms still build
- [x] RK3588 without `pinctrl_soc.h`: fails before, succeeds with this guard