### PR TITLE
drivers: udc_stm32: recover isochronous IN on incomplete transfer

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -439,19 +439,15 @@ void HAL_PCD_ISOOUTIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
 
 void HAL_PCD_ISOINIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
 {
-	ARG_UNUSED(hpcd);
-	ARG_UNUSED(epnum);
-
-	/* Recovering isochronous IN after an incomplete transfer is a TODO. It
-	 * keeps working today because iso IN is completion-driven: every
-	 * transmitted frame yields a DataInStageCallback that arms the next queued
-	 * buffer, so a missed frame only drops that one packet. Iso OUT gets no
-	 * such completion on a miss (the core disables the endpoint and nothing
-	 * re-arms it), which is why only OUT wedges. A proper IN fix cannot re-arm
-	 * here either: udc_stm32_tx() has already advanced the pending buffer's
-	 * data/len, so it must go through the normal data-in completion path (drop
-	 * the missed frame and arm the next one).
+	/* The OTG core aborts and disables the endpoint on IISOIXFR, then calls this
+	 * instead of HAL_PCD_DataInStageCallback(). Drop the missed frame through the
+	 * normal IN completion path so that the next queued buffer gets armed.
+	 *
+	 * The ST USB IP does not report incomplete isochronous IN transfers, so this
+	 * callback is never invoked for it and HAL_PCD_DataInStageCallback() is called
+	 * as usual.
 	 */
+	HAL_PCD_DataInStageCallback(hpcd, epnum);
 }
 
 void HAL_PCDEx_SetConnectionState(stm32_pcd_handle_t *hpcd, uint8_t state)

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -407,6 +407,53 @@ void HAL_PCD_SOFCallback(stm32_pcd_handle_t *hpcd)
 	udc_submit_sof_event(priv->dev);
 }
 
+void HAL_PCD_ISOOUTIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
+{
+	struct udc_stm32_data *priv = hpcd2data(hpcd);
+	uint8_t ep = epnum | USB_EP_DIR_OUT;
+	struct udc_ep_config *ep_cfg;
+	struct net_buf *buf;
+	stm32_status_t status;
+
+	ep_cfg = udc_get_ep_cfg(priv->dev, ep);
+	if (ep_cfg == NULL) {
+		return;
+	}
+
+	buf = udc_buf_peek(ep_cfg);
+	if (buf == NULL) {
+		return;
+	}
+
+	/* When an incomplete ISO OUT transfer occurs, the endpoint is disabled.
+	 * Re-enable the endpoint to allow reception in the remaining free space
+	 * of the buffer. HAL_PCD_DataOutStageCallback() will be called as usual
+	 * when the buffer is eventually filled.
+	 */
+	status = hal_udc_set_endpoint_receive(&priv->pcd, ep, net_buf_tail(buf),
+					      net_buf_tailroom(buf));
+	if (status != HAL_OK) {
+		LOG_ERR("ISO OUT re-enable failed(0x%02x), %d", ep, (int)status);
+	}
+}
+
+void HAL_PCD_ISOINIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
+{
+	ARG_UNUSED(hpcd);
+	ARG_UNUSED(epnum);
+
+	/* Recovering isochronous IN after an incomplete transfer is a TODO. It
+	 * keeps working today because iso IN is completion-driven: every
+	 * transmitted frame yields a DataInStageCallback that arms the next queued
+	 * buffer, so a missed frame only drops that one packet. Iso OUT gets no
+	 * such completion on a miss (the core disables the endpoint and nothing
+	 * re-arms it), which is why only OUT wedges. A proper IN fix cannot re-arm
+	 * here either: udc_stm32_tx() has already advanced the pending buffer's
+	 * data/len, so it must go through the normal data-in completion path (drop
+	 * the missed frame and arm the next one).
+	 */
+}
+
 void HAL_PCDEx_SetConnectionState(stm32_pcd_handle_t *hpcd, uint8_t state)
 {
 	struct udc_stm32_data *priv = hpcd2data(hpcd);
@@ -619,53 +666,6 @@ void HAL_PCD_DataOutStageCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
 	if (err != 0) {
 		LOG_ERR("UDC Message queue overrun");
 	}
-}
-
-void HAL_PCD_ISOOUTIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
-{
-	struct udc_stm32_data *priv = hpcd2data(hpcd);
-	uint8_t ep = epnum | USB_EP_DIR_OUT;
-	struct udc_ep_config *ep_cfg;
-	struct net_buf *buf;
-	stm32_status_t status;
-
-	ep_cfg = udc_get_ep_cfg(priv->dev, ep);
-	if (ep_cfg == NULL) {
-		return;
-	}
-
-	buf = udc_buf_peek(ep_cfg);
-	if (buf == NULL) {
-		return;
-	}
-
-	/* When an incomplete ISO OUT transfer occurs, the endpoint is disabled.
-	 * Re-enable the endpoint to allow reception in the remaining free space
-	 * of the buffer. HAL_PCD_DataOutStageCallback() will be called as usual
-	 * when the buffer is eventually filled.
-	 */
-	status = hal_udc_set_endpoint_receive(&priv->pcd, ep, net_buf_tail(buf),
-					      net_buf_tailroom(buf));
-	if (status != HAL_OK) {
-		LOG_ERR("ISO OUT re-enable failed(0x%02x), %d", ep, (int)status);
-	}
-}
-
-void HAL_PCD_ISOINIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
-{
-	ARG_UNUSED(hpcd);
-	ARG_UNUSED(epnum);
-
-	/* Recovering isochronous IN after an incomplete transfer is a TODO. It
-	 * keeps working today because iso IN is completion-driven: every
-	 * transmitted frame yields a DataInStageCallback that arms the next queued
-	 * buffer, so a missed frame only drops that one packet. Iso OUT gets no
-	 * such completion on a miss (the core disables the endpoint and nothing
-	 * re-arms it), which is why only OUT wedges. A proper IN fix cannot re-arm
-	 * here either: udc_stm32_tx() has already advanced the pending buffer's
-	 * data/len, so it must go through the normal data-in completion path (drop
-	 * the missed frame and arm the next one).
-	 */
 }
 
 static void handle_msg_data_out(struct udc_stm32_data *priv, uint8_t epnum, uint16_t rx_count)


### PR DESCRIPTION
## Summary
- Recover STM32 OTG isochronous IN after an incomplete transfer by dropping the missed frame through the existing DataIn completion path and arming the next queued buffer.

The UDC driver already recovers ISO OUT from that callback; ISO IN was a TODO no-op, so the endpoint stayed busy and UAC2 capture went silent after the first missed frame.

Related to the ISO OUT re-arm in this driver and to #102720 / #118090.

## Tested on
- `nucleo_h743zi` with `samples/subsys/usb/uac2_loopback` (#118090): 1 kHz loopback peak 0.500, RMS 0.35356, 1 kHz only

## Test plan
- [x] `west build -b nucleo_h743zi samples/subsys/usb/uac2_loopback -p auto` and flash
- [x] Host sees `UAC2 loopback sample` as a 48 kHz stereo headset
- [x] Before this change, capture is silence after ISO IN wedges (`usbd_uac2_send` returns `-EAGAIN`)
- [x] After this change, play a 1 kHz sine while recording capture; recording matches the played tone