### PR TITLE
net: route: Clear lladdr_dst when forwarding via an on-link route

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -624,5 +624,12 @@ int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
 		net_pkt_lladdr_src(pkt)->len = lladdr_if->len;
 	}
 
+	/* The RX path left the router's own MAC in lladdr_dst, and L2 takes a
+	 * non-empty lladdr_dst as "already resolved". Clear it so the
+	 * destination gets resolved on the outgoing interface, the same way
+	 * net_route_ipv4_packet() does on the route table path.
+	 */
+	(void)net_linkaddr_clear(net_pkt_lladdr_dst(pkt));
+
 	return net_send_data(pkt);
 }


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#118103 

net_route_packet_if() is the path IPv4 forwarding takes when the destination is directly connected and no route table entry matches, that is the ipv4_route_packet() -> net_if_ipv4_addr_onlink() fallback. It rewrites the source link address but leaves net_pkt_lladdr_dst() holding the value ethernet_recv() stored on RX, which for a routed packet is the router's own MAC, since the sender addressed the frame to its gateway.

ethernet_ll_prepare_on_ipv4() treats a non-empty lladdr_dst as already resolved and returns NET_ARP_COMPLETE without doing ARP, so ethernet_fill_header() copies the router's own MAC into the outgoing frame as the destination. On a router on a stick the switch then sees a frame whose destination MAC it learned on the ingress port and drops it, so the packet is transmitted but never reaches the next hop.

Clear lladdr_dst so L2 resolves the destination on the outgoing interface, matching what net_route_ipv4_packet() already does on the route table path.