### PR TITLE
drivers: watchdog: wdt_ti_rti: fix build with interrupts on Cortex-M

### DIFF
--- a/drivers/watchdog/wdt_ti_rti.c
+++ b/drivers/watchdog/wdt_ti_rti.c
@@ -228,7 +228,9 @@ static DEVICE_API(wdt, wdt_ti_rti_api) = {
 	{                                                                                          \
 		IF_ENABLED(DT_INST_IRQ_HAS_IDX(i, 0), (						   \
 			IRQ_CONNECT(DT_INST_IRQN(i), DT_INST_IRQ(i, priority), wdt_ti_rti_isr,     \
-				DEVICE_DT_INST_GET(i), DT_INST_IRQ(i, flags));                     \
+				DEVICE_DT_INST_GET(i),                                             \
+				COND_CODE_1(DT_INST_IRQ_HAS_CELL(i, flags),                        \
+					(DT_INST_IRQ(i, flags)), (0)));                            \
 			irq_enable(DT_INST_IRQN(i));                                               \
 		));										   \
 	};                                                                                         \


### PR DESCRIPTION
`IRQ_CONNECT()` in `WDT_TI_RTI_INIT()` is passed `DT_INST_IRQ(i, flags)`, which requires the interrupt controller binding to define a `flags` cell. `arm,v7m-nvic.yaml` defines only `irq` and `priority`, so adding an `interrupts` property to a `ti,j7-rti-wdt` node on a Cortex-M target fails to build:

```
include/zephyr/toolchain/gcc.h:87:51: error: expression in static assertion is not an integer
  ... in expansion of macro 'IRQ_CONNECT'
  drivers/watchdog/wdt_ti_rti.c:230
```

`interrupts` is what sets `nmi_supported`, so the NMI reaction of the windowed watchdog cannot be selected on those targets. On AM62x that reaction is the one wired to the ESM, and the reset reaction available in its place does not produce a reset — see #118097.

Uses the flags cell where the controller defines one and passes 0 otherwise, following `gpio_dw.c`, `i2c_dw.c` and others.

No in-tree `ti,j7-rti-wdt` node declares `interrupts`, and where a flags cell exists the macro expands to the previous expression, so no existing configuration changes.

Verified by building `am62x_m4_bl350/am6254/m4` with `interrupts = <19 4>` on `mcu_rti0`, which fails on `main` and succeeds here.

Fixes #118097
