### PR TITLE
lib/cpp: minimal: add the C++17 aligned operator delete overloads

### DIFF
--- a/lib/cpp/minimal/cpp_new.cpp
+++ b/lib/cpp/minimal/cpp_new.cpp
@@ -84,3 +84,35 @@ void operator delete[](void* ptr, size_t) NOEXCEPT
 	free(ptr);
 }
 #endif // __cplusplus > 201103L
+
+#if __cplusplus >= 201703L
+void operator delete(void* ptr, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete(void* ptr, size_t, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete[](void* ptr, size_t, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete(void* ptr, std::align_val_t, const std::nothrow_t&) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t, const std::nothrow_t&) NOEXCEPT
+{
+	free(ptr);
+}
+#endif /* __cplusplus >= 201703L */

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -136,6 +136,21 @@ ZTEST(cxx_tests, test_new_delete)
 	zassert_equal(test_foo->get_foo(), 10);
 	delete test_foo;
 }
+
+#if __cplusplus >= 201703L
+struct alignas(64) over_aligned_foo {
+	int v;
+};
+
+ZTEST(cxx_tests, test_new_delete_aligned)
+{
+	over_aligned_foo *test_foo = new over_aligned_foo;
+
+	zassert_equal(reinterpret_cast<uintptr_t>(test_foo) % alignof(over_aligned_foo), 0);
+	delete test_foo;
+}
+#endif /* __cplusplus >= 201703L */
+
 ZTEST_SUITE(cxx_tests, NULL, NULL, NULL, NULL, NULL);
 
 /*


### PR DESCRIPTION
The minimal C++ library defines the four C++17 aligned `operator new` overloads
but none of the matching aligned `operator delete` overloads, and its `<new>`
declares neither. The standard requires the aligned deallocation functions
wherever the aligned allocation ones are provided, so code built with
`CONFIG_MINIMAL_LIBCPP=y` that deletes an over-aligned object fails to link.

This adds the six aligned `operator delete` overloads, guarded by the same
`__cplusplus >= 201703L` check the aligned `operator new` overloads already
use, each freeing through `free()` so allocation and deallocation stay paired.

The regression test is in `tests/lib/cpp/cxx`. It bites at link time: with
`lib/cpp/minimal/cpp_new.cpp` reverted, `cpp.main.cpp17` on mps2/an385 fails
with `undefined reference to operator delete(void*, unsigned int,
std::align_val_t)`.

Fixes #113678
