### PR TITLE
doc: boards: index every compatible on a node in the board catalog

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -309,7 +309,10 @@ def get_catalog(
                             locations.add("soc")
 
                     existing_feature = features.get(binding_type, {}).get(node.matching_compat)
-                    target_compatibles.add(node.matching_compat)
+                    for compat in node.compats:
+                        if compat.startswith("zephyr,") and board.name != "native_sim":
+                            continue
+                        target_compatibles.add(compat)
 
                     node_info = {
                         "filename": str(filename),


### PR DESCRIPTION
`gen_boards_catalog.py` keys each board's compatible set off
`node.matching_compat`, the single compatible edtlib bound the node to. A node
whose `compatible` property lists several strings - an Ethernet MAC naming both
its vendor wrapper and `snps,dwmac`, say - therefore contributes only the one
that won the match, and the documentation's board finder cannot find the board
by any of the others.

This builds the set from every string in `node.compats`, keeping the existing
`zephyr,` filter and applying it per string.

Measured on nucleo_h563zi against a real `edt.pickle`: the indexed set grows
from 67 compatibles to 79, and `snps,dwmac` goes from absent to present.

Fixes #117218
