### PR TITLE
fs: add fs_normalize_path to resolve . and .. textually

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -660,6 +660,39 @@ int fs_stat(const char *path, struct fs_dirent *entry);
 int fs_statvfs(const char *path, struct fs_statvfs *stat);
 
 /**
+ * @brief Normalize a path
+ *
+ * Produces the normalized form of @p path: repeated and trailing path
+ * separators are collapsed, and "." and ".." components are resolved
+ * textually. The mount table is not consulted, so @p path need not name a
+ * mounted file system, and Zephyr does not support symbolic links, so no
+ * link resolution is performed.
+ *
+ * A ".." is resolved against the preceding component, and one that would
+ * climb above the leading "/" resolves to "/", as it does on a POSIX
+ * system. A caller that has to keep a path inside a particular subtree
+ * checks the normalized result against it.
+ *
+ * @p path and @p buf may be the same buffer, to normalize a path in place.
+ * When they are different buffers, they must not overlap.
+ *
+ * On error the contents of @p buf are unspecified. That matters for the
+ * in-place case: a rejected path leaves the caller's own buffer modified.
+ *
+ * @param path Absolute path to normalize
+ * @param buf Buffer to receive the normalized, null-terminated path
+ * @param len Size of @p buf, in bytes
+ *
+ * @retval 0 on success;
+ * @retval -EINVAL when @p path is not an absolute path, or when @p buf is
+ *	   NULL or @p len is zero;
+ * @retval -ENAMETOOLONG when @p buf is too small to hold the normalized
+ *	   path, or any prefix of it produced before a ".." was resolved;
+ * @retval <0 another negative errno code on error.
+ */
+int fs_normalize_path(const char *path, char *buf, size_t len);
+
+/**
  * @brief Create fresh file system
  *
  * @param fs_type Type of file system to create.

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -692,6 +692,70 @@ int fs_statvfs(const char *abs_path, struct fs_statvfs *stat)
 	return rc;
 }
 
+int fs_normalize_path(const char *path, char *buf, size_t len)
+{
+	size_t dst_len = 0;
+	size_t src = 0;
+
+	if ((path == NULL) || (path[0] != '/') || (buf == NULL) || (len == 0)) {
+		LOG_ERR("invalid path or output buffer!!");
+		return -EINVAL;
+	}
+
+	while (path[src] != '\0') {
+		size_t seg_start;
+		size_t seg_len;
+		size_t i;
+
+		/* Skipping sequence of /, like /// */
+		if (path[src] == '/') {
+			++src;
+			continue;
+		}
+
+		seg_start = src;
+		while ((path[src] != '\0') && (path[src] != '/')) {
+			src++;
+		}
+		seg_len = src - seg_start;
+
+		if ((seg_len == 1) && (path[seg_start] == '.')) {
+			continue;
+		}
+
+		if ((seg_len == 2) && (path[seg_start] == '.') && (path[seg_start + 1] == '.')) {
+			while ((dst_len > 0) && (buf[dst_len - 1] != '/')) {
+				dst_len--;
+			}
+			if (dst_len > 0) {
+				dst_len--;
+			}
+			continue;
+		}
+
+		if ((dst_len + 1 + seg_len + 1) > len) {
+			return -ENAMETOOLONG;
+		}
+
+		buf[dst_len] = '/';
+		for (i = 0; i < seg_len; i++) {
+			buf[dst_len + 1 + i] = path[seg_start + i];
+		}
+		dst_len += 1 + seg_len;
+	}
+
+	if (dst_len == 0) {
+		if (len < 2) {
+			return -ENAMETOOLONG;
+		}
+		buf[dst_len] = '/';
+		dst_len++;
+	}
+	buf[dst_len] = '\0';
+
+	return 0;
+}
+
 #if defined(CONFIG_FILE_SYSTEM_GC)
 
 int fs_gc(struct fs_mount_t *mp)

--- a/tests/subsys/fs/fs_api/src/test_fs_normalize_path.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_normalize_path.c
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "test_fs.h"
+#include <string.h>
+
+struct normalize_case {
+	const char *path;
+	const char *expected;
+};
+
+typedef const char *invalid_path_t;
+
+ZTEST_DEFINE_PARAM_VALUES(invalid_paths, invalid_path_t,
+			  NULL,
+			  "",
+			  "relative/path",
+			  "NAND:/foo");
+
+ZTEST_DEFINE_PARAM_VALUES(normalize_cases, struct normalize_case,
+			  {"/NAND:", "/NAND:"},
+			  {"/NAND:/", "/NAND:"},
+			  {"/NAND://foo///bar/", "/NAND:/foo/bar"},
+			  {"/NAND:/./foo/./.", "/NAND:/foo"},
+			  {"/NAND:/some/path/../here/and/.././my.txt", "/NAND:/some/here/my.txt"},
+			  {"/NAND:/..", "/"},
+			  {"/NAND:/foo/../..", "/"},
+			  {"/..", "/"},
+			  {"/", "/"},
+			  {"/NAND:/sub/../x", "/NAND:/x"});
+
+ZTEST_P(fs_api_normalize_path, test_normalize_path_invalid)
+{
+	const char *path = ZTEST_GET_PARAM(invalid_path_t);
+	char buf[32];
+	int ret;
+
+	ret = fs_normalize_path(path, buf, sizeof(buf));
+	zassert_equal(ret, -EINVAL, "\"%s\" should be rejected (%d)", path, ret);
+}
+
+ZTEST_P(fs_api_normalize_path, test_normalize_path)
+{
+	const struct normalize_case *tc = ZTEST_GET_PARAM_PTR(struct normalize_case);
+	char buf[64];
+	int ret;
+
+	ret = fs_normalize_path(tc->path, buf, sizeof(buf));
+	zassert_equal(ret, 0, "\"%s\" should normalize (%d)", tc->path, ret);
+	zassert_str_equal(buf, tc->expected, "\"%s\" became \"%s\"", tc->path, buf);
+}
+
+ZTEST(fs_api_normalize_path, test_normalize_path_invalid_buffer)
+{
+	char buf[32];
+	int ret;
+
+	ret = fs_normalize_path("/NAND:/foo", NULL, sizeof(buf));
+	zassert_equal(ret, -EINVAL, "NULL output buffer should be rejected (%d)", ret);
+
+	ret = fs_normalize_path("/NAND:/foo", buf, 0);
+	zassert_equal(ret, -EINVAL, "zero-length output buffer should be rejected (%d)", ret);
+}
+
+ZTEST(fs_api_normalize_path, test_normalize_path_buffer_too_small)
+{
+	char buf[16];
+	int ret;
+
+	ret = fs_normalize_path("/NAND:/foo", buf, strlen("/NAND:/foo"));
+	zassert_equal(ret, -ENAMETOOLONG, "undersized buffer should be rejected (%d)", ret);
+
+	ret = fs_normalize_path("/NAND:/foo", buf, strlen("/NAND:/foo") + 1);
+	zassert_equal(ret, 0, "exactly-sized buffer should succeed (%d)", ret);
+	zassert_str_equal(buf, "/NAND:/foo", "unexpected result");
+
+	ret = fs_normalize_path("/NAND:/..", buf, 1);
+	zassert_equal(ret, -ENAMETOOLONG, "no room for \"/\" should be rejected (%d)", ret);
+
+	/* The check is per segment, so a prefix a later ".." pops is charged for */
+	ret = fs_normalize_path("/a/..", buf, sizeof("/"));
+	zassert_equal(ret, -ENAMETOOLONG, "a prefix that does not fit should be rejected (%d)",
+		      ret);
+}
+
+ZTEST(fs_api_normalize_path, test_normalize_path_in_place)
+{
+	char buf[64];
+	int ret;
+
+	strcpy(buf, "/NAND:/some/path/../here/and/.././my.txt");
+
+	ret = fs_normalize_path(buf, buf, sizeof(buf));
+
+	zassert_equal(ret, 0, "unexpected error (%d)", ret);
+	zassert_str_equal(buf, "/NAND:/some/here/my.txt", "unexpected result");
+}
+
+ZTEST_SUITE(fs_api_normalize_path, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST_INSTANTIATE_TEST_SUITE_P(all, fs_api_normalize_path, test_normalize_path_invalid,
+			       invalid_paths);
+ZTEST_INSTANTIATE_TEST_SUITE_P(all, fs_api_normalize_path, test_normalize_path,
+			       normalize_cases);


### PR DESCRIPTION
The file system subsystem has no way to turn a path containing `.` and `..`
into its normalized form, so every caller that needs one - a shell `cd`, or
code assembling a path from user input - writes its own. Requested by a
maintainer in #115895, with #81888 as an earlier, related report.

This adds `fs_normalize_path(path, buf, len)`. It resolves `.` and `..`
textually, collapses repeated and trailing separators, and writes the result
into `buf`. `path` and `buf` may be the same buffer. There is no symbolic link
resolution, since Zephyr has no symbolic links.

The mount table is not consulted, after review: `fs_mount()` permits nested
mount points and `fs_get_mnt_point()` takes the longest prefix, so anchoring
`..` at the mount point made the result depend on what happened to be mounted.
A `..` above the leading `/` clamps to `/`, and `-ENOENT` is gone with the
lookup.

Two parametrized tests in `tests/subsys/fs/fs_api` cover fourteen inputs,
beside in-place normalization and the buffer bounds.

Fixes #115895
