### PR TITLE
scripts: gen_kobject_list: handle DWARF v4 type units

### DIFF
--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -1128,7 +1128,11 @@ def main():
         max_threads = syms["CONFIG_MAX_THREAD_BYTES"] * 8
         objs = find_kobjects(elf, syms)
         if not objs:
-            sys.stderr.write(f"WARNING: zero kobject found in {args.kernel}\n")
+            sys.exit(
+                f"zero kobjects found in {args.kernel}, "
+                "but a CONFIG_USERSPACE build always has some; "
+                "the DWARF scan likely failed to see the kernel object types"
+            )
 
         if thread_counter > max_threads:
             err = f"Too many thread objects ({thread_counter})\n"

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -52,6 +52,7 @@ This script can generate five different output files:
 """
 
 import argparse
+import itertools
 import json
 import math
 import os
@@ -59,12 +60,13 @@ import struct
 import sys
 
 import elftools
+from elftools.dwarf.typeunit import TypeUnit
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 from packaging import version
 
-if version.parse(elftools.__version__) < version.parse('0.24'):
-    sys.exit("pyelftools is out of date, need version 0.24 or later")
+if version.parse(elftools.__version__) < version.parse('0.32'):
+    sys.exit("pyelftools is out of date, need version 0.32 or later")
 
 from collections import OrderedDict
 
@@ -408,13 +410,35 @@ def die_get_name(die):
     return die.attributes["DW_AT_name"].value.decode("utf-8")
 
 
+def die_key(die):
+    if isinstance(die.cu, TypeUnit):
+        return -die.offset - 1
+    return die.offset
+
+
+def die_resolve_ref(die, attribute):
+    try:
+        return die.get_DIE_from_attribute(attribute)
+    except KeyError:
+        return None
+
+
 def die_get_type_offset(die):
     if 'DW_AT_type' not in die.attributes:
         die = die_get_spec(die)
         if not die:
             return None
 
-    return die.attributes["DW_AT_type"].value + die.cu.cu_offset
+    type_die = die_resolve_ref(die, "DW_AT_type")
+    if type_die is None:
+        return None
+
+    if "DW_AT_signature" in type_die.attributes:
+        definition = die_resolve_ref(type_die, "DW_AT_signature")
+        if definition is not None:
+            type_die = definition
+
+    return die_key(type_die)
 
 
 def die_get_byte_size(die):
@@ -426,7 +450,7 @@ def die_get_byte_size(die):
 
 def analyze_die_struct(die):
     name = die_get_name(die) or "<anon>"
-    offset = die.offset
+    offset = die_key(die)
     size = die_get_byte_size(die)
 
     # Incomplete type
@@ -464,7 +488,7 @@ def analyze_die_const(die):
     if not type_offset:
         return
 
-    type_env[die.offset] = ConstType(type_offset)
+    type_env[die_key(die)] = ConstType(type_offset)
 
 
 def _is_constant_form(form):
@@ -512,9 +536,9 @@ def analyze_die_array(die):
             mt = type_env[type_offset]
             if mt.has_kobject() and isinstance(mt, KobjectType) and mt.name == STACK_TYPE:
                 elements.append(1)
-                type_env[die.offset] = ArrayType(die.offset, elements, type_offset)
+                type_env[die_key(die)] = ArrayType(die_key(die), elements, type_offset)
     else:
-        type_env[die.offset] = ArrayType(die.offset, elements, type_offset)
+        type_env[die_key(die)] = ArrayType(die_key(die), elements, type_offset)
 
 
 def analyze_typedef(die):
@@ -523,7 +547,7 @@ def analyze_typedef(die):
     if type_offset not in type_env:
         return
 
-    type_env[die.offset] = type_env[type_offset]
+    type_env[die_key(die)] = type_env[type_offset]
 
 
 def decode_uleb128(data, idx):
@@ -592,8 +616,8 @@ def find_kobjects(elf, syms):
     variables = []
 
     # Step 1: collect all type information.
-    for CU in di.iter_CUs():
-        for die in CU.iter_DIEs():
+    for unit in itertools.chain(di.iter_CUs(), di.iter_TUs()):
+        for die in unit.iter_DIEs():
             # Unions are disregarded, kernel objects should never be union
             # members since the memory is not dedicated to that object and
             # could be something else

--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -17,7 +17,7 @@ mypy
 natsort
 ply>=3.10
 psutil>=5.6.6
-pyelftools>=0.29
+pyelftools>=0.32
 pygithub>=2.7.0
 pykwalify
 pylint>=3

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -4,7 +4,7 @@
 # part of the recommended workflow
 
 # used by various build scripts
-pyelftools>=0.29
+pyelftools>=0.32
 
 # used by dts generation to parse binding YAMLs, also used by
 # twister to parse YAMLs, by west, zephyr_module,...


### PR DESCRIPTION
`gen_kobject_list.py` walks only DWARF compile units (`di.iter_CUs()`). A
`CONFIG_USERSPACE` build compiled with `-fdebug-types-section` therefore sees
no kernel object types at all: GCC moves their full definitions into type units
in `.debug_types` and leaves skeleton declarations behind in `.debug_info`. The
scan builds an empty type environment, finds zero kernel objects, and the build
dies later inside gperf with an error that names nothing about the cause.

The first commit also walks `DWARFInfo.iter_TUs()` and follows the
`DW_AT_signature` a skeleton declaration carries to its real definition when
resolving a `DW_AT_type` reference. `iter_TUs()` needs pyelftools 0.32, so the
floor in `scripts/requirements-base.txt` moves from 0.29 to 0.32.

The second commit is separable: it turns the existing zero-kobjects warning
into a hard error at the point where the cause is still known, instead of
letting an empty gperf table fail obscurely downstream.

Fixes #114043
