### PR TITLE
soc: ti: k3: implement sys_arch_reboot() for AM62x Cortex-M

### DIFF
--- a/soc/ti/k3/common/cortex_m/soc.c
+++ b/soc/ti/k3/common/cortex_m/soc.c
@@ -41,3 +41,47 @@ void soc_early_init_hook(void)
 
 	k3_unlock_all_ctrl_partitions();
 }
+
+#if defined(CONFIG_SOC_SERIES_AM62X_M4)
+
+/*
+ * MCU_CTRL_MMR0 as addressed by the M4F. The first RAT region above maps system
+ * address 0x00000000 to local 0x60000000, so the addresses documented in the
+ * AM62x TRM (SPRUIV7) are reached at that offset.
+ */
+#define MCU_CTRL_MMR_BASE        0x64500000U
+#define MCU_CTRL_MMR_RST_CTRL    (MCU_CTRL_MMR_BASE + 0x18170U)
+#define MCU_CTRL_MMR_LOCK6_KICK0 (MCU_CTRL_MMR_BASE + 0x19008U)
+#define MCU_CTRL_MMR_LOCK6_KICK1 (MCU_CTRL_MMR_BASE + 0x1900CU)
+
+/*
+ * RST_CTRL field SW_MCU_WARMRST. Writing 0x6 requests the reset; the field is
+ * fault tolerant and returns to 0xF by itself.
+ */
+#define RST_CTRL_SW_MCU_WARMRST_MSK GENMASK(11, 8)
+#define RST_CTRL_SW_MCU_WARMRST_REQ 0x6U
+
+/*
+ * SYSRESETREQ, which the weak Cortex-M implementation asserts, is not routed
+ * for this core; resets are requested through MCU_CTRL_MMR0 instead. The
+ * partition holding RST_CTRL is not among those unlocked at boot, so it is
+ * kicked here.
+ *
+ * The reset covers the MAIN domain as well as the MCU domain.
+ */
+void sys_arch_reboot(int type)
+{
+	uint32_t rst_ctrl;
+
+	ARG_UNUSED(type);
+
+	sys_write32(KICK0_UNLOCK_VAL, MCU_CTRL_MMR_LOCK6_KICK0);
+	sys_write32(KICK1_UNLOCK_VAL, MCU_CTRL_MMR_LOCK6_KICK1);
+
+	rst_ctrl = sys_read32(MCU_CTRL_MMR_RST_CTRL);
+	rst_ctrl &= ~RST_CTRL_SW_MCU_WARMRST_MSK;
+	rst_ctrl |= FIELD_PREP(RST_CTRL_SW_MCU_WARMRST_MSK, RST_CTRL_SW_MCU_WARMRST_REQ);
+	sys_write32(rst_ctrl, MCU_CTRL_MMR_RST_CTRL);
+}
+
+#endif /* CONFIG_SOC_SERIES_AM62X_M4 */

--- a/soc/ti/k3/common/peripherals/ctrl_partitions.c
+++ b/soc/ti/k3/common/peripherals/ctrl_partitions.c
@@ -9,8 +9,7 @@
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/arch/common/sys_io.h>
 
-#define KICK0_UNLOCK_VAL (0x68EF3490U)
-#define KICK1_UNLOCK_VAL (0xD172BC5AU)
+#include "ctrl_partitions.h"
 
 #define K3_UNLOCK_CONTROL_MODULE_(node_id)                                                         \
 	const uint32_t conf_##node_id[] = DT_PROP(node_id, ti_unlock_offsets);                     \

--- a/soc/ti/k3/common/peripherals/ctrl_partitions.h
+++ b/soc/ti/k3/common/peripherals/ctrl_partitions.h
@@ -7,6 +7,9 @@
 #ifndef __K3_CTRL_PARTITIONS_H_
 #define __K3_CTRL_PARTITIONS_H_
 
+#define KICK0_UNLOCK_VAL (0x68EF3490U)
+#define KICK1_UNLOCK_VAL (0xD172BC5AU)
+
 void k3_unlock_all_ctrl_partitions(void);
 
 #endif /* __K3_CTRL_PARTITIONS_H */


### PR DESCRIPTION
`soc/ti/k3/` provides no `sys_arch_reboot()`, so K3 Cortex-M targets fall back to the weak Cortex-M implementation, which asserts `SYSRESETREQ`. That signal is not routed for these cores — resets on K3 are requested through the control module — so `sys_reboot()` never resets and never returns, and `CONFIG_RESET_ON_FATAL_ERROR` logs a reset it does not perform.

Requests the reset by writing the `SW_MCU_WARMRST` field of `MCU_CTRL_MMR_CFG0_RST_CTRL`, kicking the lock on that partition first since it is not among those unlocked at boot. The register is addressed through the RAT window installed by `soc_early_init_hook()`.

`SW_MAIN_POR`, the other field in that register, is not usable here: it resets the MAIN domain and leaves the Cortex-M running, so the caller survives `sys_reboot()`.

Scoped to `SOC_SERIES_AM62X_M4`. The offsets come from the AM62x TRM and are not confirmed for the other K3 SoCs with a Cortex-M cluster, so those keep the current behaviour.

The unlock keys move to `ctrl_partitions.h` so both users share one definition.

Verified on `am62x_m4_bl350/am6254/m4`: `sys_reboot(SYS_REBOOT_COLD)` reboots the board, does not return, and the Cortex-M is reset — Linux reloads the core rather than attaching to a running one, and `MCU_CTRL_MMR_CFG0_RST_SRC` reports `SW_MCU_WARMRST`.

Fixes #118046
