### PR TITLE
dts: amd: fix IPI mailbox register sizes for Versal2 and VersalNet

### DIFF
--- a/dts/vendor/amd/versal2.dtsi
+++ b/dts/vendor/amd/versal2.dtsi
@@ -33,7 +33,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 57 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb330000 0x20>, <0xeb3f0400 0x1000>;
+			reg = <0xeb330000 0x10000>, <0xeb3f0400 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <2>;
 			#address-cells = <1>;
@@ -44,7 +44,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 58 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb340000 0x20>, <0xeb3f0600 0x1000>;
+			reg = <0xeb340000 0x10000>, <0xeb3f0600 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <3>;
 			#address-cells = <1>;
@@ -55,7 +55,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb350000 0x20>, <0xeb3f0800 0x1000>;
+			reg = <0xeb350000 0x10000>, <0xeb3f0800 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <4>;
 			#address-cells = <1>;
@@ -66,7 +66,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb360000 0x20>, <0xeb3f0a00 0x1000>;
+			reg = <0xeb360000 0x10000>, <0xeb3f0a00 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <5>;
 			#address-cells = <1>;
@@ -77,7 +77,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb370000 0x20>, <0xeb3f0c00 0x1000>;
+			reg = <0xeb370000 0x10000>, <0xeb3f0c00 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <6>;
 			#address-cells = <1>;
@@ -88,7 +88,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb380000 0x20>, <0xeb3f0e00 0x1000>;
+			reg = <0xeb380000 0x10000>, <0xeb3f0e00 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <7>;
 			#address-cells = <1>;
@@ -99,7 +99,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 63 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3a0000 0x20>;
+			reg = <0xeb3a0000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <9>;
 			#address-cells = <1>;
@@ -110,7 +110,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 64 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b0000 0x20>;
+			reg = <0xeb3b0000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <10>;
 			#address-cells = <1>;
@@ -121,7 +121,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b1000 0x20>;
+			reg = <0xeb3b1000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <11>;
 			#address-cells = <1>;
@@ -132,7 +132,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 66 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b2000 0x20>;
+			reg = <0xeb3b2000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <12>;
 			#address-cells = <1>;
@@ -143,7 +143,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b3000 0x20>;
+			reg = <0xeb3b3000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <13>;
 			#address-cells = <1>;
@@ -154,7 +154,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 68 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b4000 0x20>;
+			reg = <0xeb3b4000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <14>;
 			#address-cells = <1>;
@@ -165,7 +165,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 69 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b5000 0x20>;
+			reg = <0xeb3b5000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <15>;
 			#address-cells = <1>;
@@ -176,7 +176,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb310000 0x20>, <0xeb3f0000 0x1000>;
+			reg = <0xeb310000 0x10000>, <0xeb3f0000 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <0>;
 			#address-cells = <1>;
@@ -187,7 +187,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb320000 0x20>, <0xeb3f0200 0x1000>;
+			reg = <0xeb320000 0x10000>, <0xeb3f0200 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <1>;
 			#address-cells = <1>;
@@ -198,7 +198,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb390000 0x20>;
+			reg = <0xeb390000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <8>;
 			#address-cells = <1>;

--- a/dts/vendor/amd/versalnet.dtsi
+++ b/dts/vendor/amd/versalnet.dtsi
@@ -58,7 +58,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 57 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb330000 0x20>, <0xeb3f0400 0x1000>;
+			reg = <0xeb330000 0x10000>, <0xeb3f0400 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <2>;
 			#address-cells = <1>;
@@ -69,7 +69,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 58 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb340000 0x20>, <0xeb3f0600 0x1000>;
+			reg = <0xeb340000 0x10000>, <0xeb3f0600 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <3>;
 			#address-cells = <1>;
@@ -80,7 +80,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb350000 0x20>, <0xeb3f0800 0x1000>;
+			reg = <0xeb350000 0x10000>, <0xeb3f0800 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <4>;
 			#address-cells = <1>;
@@ -91,7 +91,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb360000 0x20>, <0xeb3f0a00 0x1000>;
+			reg = <0xeb360000 0x10000>, <0xeb3f0a00 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <5>;
 			#address-cells = <1>;
@@ -102,7 +102,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb370000 0x20>, <0xeb3f0c00 0x1000>;
+			reg = <0xeb370000 0x10000>, <0xeb3f0c00 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <6>;
 			#address-cells = <1>;
@@ -113,7 +113,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb380000 0x20>, <0xeb3f0e00 0x1000>;
+			reg = <0xeb380000 0x10000>, <0xeb3f0e00 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <7>;
 			#address-cells = <1>;
@@ -124,7 +124,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 63 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3a0000 0x20>;
+			reg = <0xeb3a0000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <9>;
 			#address-cells = <1>;
@@ -135,7 +135,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 64 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b0000 0x20>;
+			reg = <0xeb3b0000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <10>;
 			#address-cells = <1>;
@@ -146,7 +146,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b1000 0x20>;
+			reg = <0xeb3b1000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <11>;
 			#address-cells = <1>;
@@ -157,7 +157,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 66 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b2000 0x20>;
+			reg = <0xeb3b2000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <12>;
 			#address-cells = <1>;
@@ -168,7 +168,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b3000 0x20>;
+			reg = <0xeb3b3000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <13>;
 			#address-cells = <1>;
@@ -179,7 +179,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 68 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b4000 0x20>;
+			reg = <0xeb3b4000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <14>;
 			#address-cells = <1>;
@@ -190,7 +190,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 69 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb3b5000 0x20>;
+			reg = <0xeb3b5000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <15>;
 			#address-cells = <1>;
@@ -201,7 +201,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb310000 0x20>, <0xeb3f0000 0x1000>;
+			reg = <0xeb310000 0x10000>, <0xeb3f0000 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <0>;
 			#address-cells = <1>;
@@ -212,7 +212,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb320000 0x20>, <0xeb3f0200 0x1000>;
+			reg = <0xeb320000 0x10000>, <0xeb3f0200 0x200>;
 			reg-names = "ctrl", "msg";
 			xlnx,ipi-id = <1>;
 			#address-cells = <1>;
@@ -223,7 +223,7 @@
 			compatible = "xlnx,mbox-versal-ipi-mailbox";
 			status = "disabled";
 			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			reg = <0xeb390000 0x20>;
+			reg = <0xeb390000 0x1000>;
 			reg-names = "ctrl";
 			xlnx,ipi-id = <8>;
 			#address-cells = <1>;

--- a/samples/drivers/mbox/boards/versal2_rpu.overlay
+++ b/samples/drivers/mbox/boards/versal2_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb340000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb340000 0x20>, <0xeb3f0600 0x1000>;
+		reg = <0xeb340000 0x10000>, <0xeb3f0600 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <3>;
 		#mbox-cells = <1>;

--- a/samples/drivers/mbox/boards/versalnet_rpu.overlay
+++ b/samples/drivers/mbox/boards/versalnet_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb380000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb380000 0x20>, <0xeb3f0e00 0x1000>;
+		reg = <0xeb380000 0x10000>, <0xeb3f0e00 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <7>;
 		#mbox-cells = <1>;

--- a/samples/drivers/mbox/remote/boards/versal2_rpu.overlay
+++ b/samples/drivers/mbox/remote/boards/versal2_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb340000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb340000 0x20>, <0xeb3f0600 0x1000>;
+		reg = <0xeb340000 0x10000>, <0xeb3f0600 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <3>;
 		#mbox-cells = <1>;

--- a/samples/drivers/mbox/remote/boards/versalnet_rpu.overlay
+++ b/samples/drivers/mbox/remote/boards/versalnet_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb380000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb380000 0x20>, <0xeb3f0e00 0x1000>;
+		reg = <0xeb380000 0x10000>, <0xeb3f0e00 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <7>;
 		#mbox-cells = <1>;

--- a/samples/drivers/mbox_data/boards/versal2_rpu.overlay
+++ b/samples/drivers/mbox_data/boards/versal2_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb340000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb340000 0x20>, <0xeb3f0600 0x1000>;
+		reg = <0xeb340000 0x10000>, <0xeb3f0600 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <3>;
 		#mbox-cells = <1>;

--- a/samples/drivers/mbox_data/boards/versalnet_rpu.overlay
+++ b/samples/drivers/mbox_data/boards/versalnet_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb380000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb380000 0x20>, <0xeb3f0e00 0x1000>;
+		reg = <0xeb380000 0x10000>, <0xeb3f0e00 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <7>;
 		#mbox-cells = <1>;

--- a/samples/drivers/mbox_data/remote/boards/versal2_rpu.overlay
+++ b/samples/drivers/mbox_data/remote/boards/versal2_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb340000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb340000 0x20>, <0xeb3f0600 0x1000>;
+		reg = <0xeb340000 0x10000>, <0xeb3f0600 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <3>;
 		#mbox-cells = <1>;

--- a/samples/drivers/mbox_data/remote/boards/versalnet_rpu.overlay
+++ b/samples/drivers/mbox_data/remote/boards/versalnet_rpu.overlay
@@ -10,7 +10,7 @@
 	rpu0_rpu0_mailbox: mailbox@eb380000 {
 		compatible = "xlnx,mbox-versal-ipi-dest-mailbox";
 		status = "okay";
-		reg = <0xeb380000 0x20>, <0xeb3f0e00 0x1000>;
+		reg = <0xeb380000 0x10000>, <0xeb3f0e00 0x200>;
 		reg-names = "ctrl", "msg";
 		xlnx,ipi-id = <7>;
 		#mbox-cells = <1>;


### PR DESCRIPTION
The IPI mailbox register region sizes in the Versal2 and VersalNet
devicetree files do not match the hardware specification.

For buffered channels, update the control region size from 0x20 to
0x10000 and the message buffer size from 0x1000 to 0x200. For
bufferless channels, update the control region size from 0x20 to
0x1000.

Update the base SoC devicetree files and the corresponding mailbox
sample overlays to keep the definitions consistent.