### PR TITLE
Bluetooth: Classic: AVDTP: return NULL from avdtp_get_sep for unknown SEID

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -718,15 +718,14 @@ static void avdtp_discover_rsp(struct bt_avdtp *session, struct net_buf *buf, ui
 
 static struct bt_avdtp_sep *avdtp_get_sep(uint8_t stream_endpoint_id)
 {
-	struct bt_avdtp_sep *sep = NULL;
+	struct bt_avdtp_sep *sep;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&seps, sep, _node) {
 		if (sep->sep_info.id == stream_endpoint_id) {
-			break;
+			return sep;
 		}
 	}
-
-	return sep;
+	return NULL;
 }
 
 static struct bt_avdtp_sep *avdtp_get_cmd_sep(struct net_buf *buf, uint8_t *error_code,


### PR DESCRIPTION
SYS_SLIST_FOR_EACH_CONTAINER leaves the loop variable pointing at the last node when the scan comes up empty, so avdtp_get_sep() returned that node for a SEID the endpoint never registered. Every command handler (get caps, set config, open, start, suspend, abort, close, ...) branches on sep == NULL to answer Reject, so an unknown SEID was instead treated as targeting the wrong SEP: a Close carrying SEID 62 was answered against the only registered SEP (id 8, streaming) instead of being rejected with BAD_ACP_SEID.

This was found while running PTS AVDTP/SNK/ACP/SIG/SMG/BI-23-C (reject an invalid CLOSE command) against a BR/EDR classic AVDTP implementation: the tester timed out waiting for the Reject.

Track the match explicitly and return NULL when none is found.