### PR TITLE
drivers: adc: esp32: fix adc1 channel setup on the esp32

### DIFF
--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -14,6 +14,7 @@
 #include "adc_esp32.h"
 
 #include <zephyr/drivers/gpio.h>
+#include <esp_gpio_port.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_esp32, CONFIG_ADC_LOG_LEVEL);
@@ -343,6 +344,15 @@ static int adc_esp32_channel_setup(const struct device *dev, const struct adc_ch
 		.pin = io_num,
 	};
 
+	if (esp_gpio_pad_port(io_num) != 0) {
+		if (conf->gpio_port1 == NULL) {
+			LOG_ERR("No GPIO port for io (%d)", io_num);
+			return -ENOTSUP;
+		}
+		gpio.port = conf->gpio_port1;
+		gpio.pin = esp_gpio_pad_pin(io_num);
+	}
+
 	err = gpio_pin_configure_dt(&gpio, GPIO_DISCONNECTED);
 
 	if (err) {
@@ -371,8 +381,9 @@ static int adc_esp32_init(const struct device *dev)
 	esp_clk_tree_src_get_freq_hz(ADC_DIGI_CLK_SRC_DEFAULT,
 				     ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &clock_src_hz);
 
-	if (!device_is_ready(conf->gpio_port)) {
-		LOG_ERR("gpio0 port not ready");
+	if (!device_is_ready(conf->gpio_port) ||
+	    (conf->gpio_port1 != NULL && !device_is_ready(conf->gpio_port1))) {
+		LOG_ERR("GPIO port not ready");
 		return -ENODEV;
 	}
 
@@ -441,6 +452,7 @@ static DEVICE_API(adc, api_esp32_driver_api) = {
 		.unit = DT_PROP(DT_DRV_INST(inst), unit) - 1,                                      \
 		.channel_count = DT_PROP(DT_DRV_INST(inst), channel_count),                        \
 		.gpio_port = DEVICE_DT_GET(DT_NODELABEL(gpio0)),                                   \
+		.gpio_port1 = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpio1)),                          \
 		ADC_ESP32_CONF_INIT(inst)};                                                        \
                                                                                                    \
 	static struct adc_esp32_data adc_esp32_data_##inst = {                                     \

--- a/drivers/adc/adc_esp32.h
+++ b/drivers/adc/adc_esp32.h
@@ -21,6 +21,7 @@ struct adc_esp32_conf {
 	adc_unit_t unit;
 	uint8_t channel_count;
 	const struct device *gpio_port;
+	const struct device *gpio_port1;
 #if defined(CONFIG_ADC_ESP32_DMA) && SOC_GDMA_SUPPORTED
 	const struct device *dma_dev;
 	uint8_t dma_channel;

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -24,6 +24,7 @@
 #include <soc.h>
 #include <errno.h>
 #include <power.h>
+#include <esp_gpio_port.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/espressif-esp32-gpio.h>
@@ -103,7 +104,7 @@ static inline bool gpio_pin_is_output_capable(uint32_t pin)
 static int IRAM_ATTR gpio_esp32_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_esp32_config *const cfg = dev->config;
-	uint32_t io_pin = (uint32_t)pin + ((cfg->gpio_port == 1 && pin < 32) ? 32 : 0);
+	uint32_t io_pin = esp_gpio_port_pad(cfg->gpio_port, pin);
 	uint32_t key;
 	bool gpio_pull;
 	bool rtcio_pull;
@@ -457,7 +458,7 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port, gpio_pi
 					      enum gpio_int_mode mode, enum gpio_int_trig trig)
 {
 	const struct gpio_esp32_config *const cfg = port->config;
-	uint32_t io_pin = (uint32_t)pin + ((cfg->gpio_port == 1 && pin < 32) ? 32 : 0);
+	uint32_t io_pin = esp_gpio_port_pad(cfg->gpio_port, pin);
 
 	/* Wakeup is configured in gpio_esp32_config(); strip the bit so
 	 * convert_int_type() only sees edge/level trigger bits.

--- a/drivers/pinctrl/pinctrl_esp32.c
+++ b/drivers/pinctrl/pinctrl_esp32.c
@@ -10,6 +10,7 @@
 #include <soc/gpio_sig_map.h>
 
 #include <power.h>
+#include <esp_gpio_port.h>
 #include <soc.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -78,26 +79,25 @@ static inline bool esp32_pin_is_output_capable(uint32_t pin)
 static int esp32_pin_apply_config(uint32_t pin, uint32_t flags)
 {
 	gpio_dev_t *const gpio_base = (gpio_dev_t *)DT_REG_ADDR(DT_NODELABEL(gpio0));
-	uint32_t io_pin = (uint32_t) pin + ((ESP32_PORT_IDX(pin) == 1 && pin < 32) ? 32 : 0);
 	int ret = 0;
 
-	if (!esp32_pin_is_valid(io_pin)) {
+	if (!esp32_pin_is_valid(pin)) {
 		return -EINVAL;
 	}
 
 #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
-	if (rtc_gpio_is_valid_gpio(io_pin)) {
-		rtcio_hal_function_select(rtc_io_num_map[io_pin], RTCIO_LL_FUNC_DIGITAL);
+	if (rtc_gpio_is_valid_gpio(pin)) {
+		rtcio_hal_function_select(rtc_io_num_map[pin], RTCIO_LL_FUNC_DIGITAL);
 	}
 #endif
 
-	if (io_pin >= GPIO_NUM_MAX) {
+	if (pin >= GPIO_NUM_MAX) {
 		ret = -EINVAL;
 		goto end;
 	}
 
 	/* Set pin function as GPIO */
-	gpio_ll_func_sel(&GPIO, io_pin, PIN_FUNC_GPIO);
+	gpio_ll_func_sel(&GPIO, pin, PIN_FUNC_GPIO);
 
 	/*
 	 * Since we always configure the pin in DIGITAL mode (RTCIO_LL_FUNC_DIGITAL),
@@ -105,11 +105,11 @@ static int esp32_pin_apply_config(uint32_t pin, uint32_t flags)
 	 * The RTC IO pull resistors only work when the pin is in RTC mode.
 	 */
 	if (flags & ESP32_PULL_UP_FLAG) {
-		gpio_ll_pulldown_dis(&GPIO, io_pin);
-		gpio_ll_pullup_en(&GPIO, io_pin);
+		gpio_ll_pulldown_dis(&GPIO, pin);
+		gpio_ll_pullup_en(&GPIO, pin);
 	} else if (flags & ESP32_PULL_DOWN_FLAG) {
-		gpio_ll_pullup_dis(&GPIO, io_pin);
-		gpio_ll_pulldown_en(&GPIO, io_pin);
+		gpio_ll_pullup_dis(&GPIO, pin);
+		gpio_ll_pulldown_en(&GPIO, pin);
 	}
 
 	if (flags & ESP32_DIR_OUT_FLAG) {
@@ -119,31 +119,31 @@ static int esp32_pin_apply_config(uint32_t pin, uint32_t flags)
 		}
 
 		if (flags & ESP32_OPEN_DRAIN_FLAG) {
-			gpio_ll_od_enable(gpio_base, io_pin);
+			gpio_ll_od_enable(gpio_base, pin);
 		} else {
-			gpio_ll_od_disable(gpio_base, io_pin);
+			gpio_ll_od_disable(gpio_base, pin);
 		}
 
 		/* Set output pin initial value */
 		if (flags & ESP32_PIN_OUT_HIGH_FLAG) {
-			gpio_ll_set_level(gpio_base, io_pin, 1);
+			gpio_ll_set_level(gpio_base, pin, 1);
 		} else if (flags & ESP32_PIN_OUT_LOW_FLAG) {
-			gpio_ll_set_level(gpio_base, io_pin, 0);
+			gpio_ll_set_level(gpio_base, pin, 0);
 		}
 
-		gpio_ll_output_enable(&GPIO, io_pin);
-		esp_rom_gpio_matrix_out(io_pin, SIG_GPIO_OUT_IDX, false, false);
+		gpio_ll_output_enable(&GPIO, pin);
+		esp_rom_gpio_matrix_out(pin, SIG_GPIO_OUT_IDX, false, false);
 	} else {
 		if (!(flags & ESP32_PIN_OUT_EN_FLAG)) {
-			gpio_ll_output_disable(&GPIO, io_pin);
+			gpio_ll_output_disable(&GPIO, pin);
 		}
 	}
 
 	if (flags & ESP32_DIR_INP_FLAG) {
-		gpio_ll_input_enable(&GPIO, io_pin);
+		gpio_ll_input_enable(&GPIO, pin);
 	} else {
 		if (!(flags & ESP32_PIN_IN_EN_FLAG)) {
-			gpio_ll_input_disable(&GPIO, io_pin);
+			gpio_ll_input_disable(&GPIO, pin);
 		}
 	}
 
@@ -159,11 +159,11 @@ static int esp32_pin_configure(const uint32_t pin_mux, const uint32_t pin_cfg)
 	uint32_t sig_out = ESP32_PIN_SIGO(pin_mux);
 	uint32_t flags = 0;
 
-	if (ESP32_PORT_IDX(pin_num) >= esp32_gpio_ports_cnt) {
+	if (esp_gpio_pad_port(pin_num) >= esp32_gpio_ports_cnt) {
 		return -EINVAL;
 	}
 
-	port_addr = esp32_gpio_ports_addrs[ESP32_PORT_IDX(pin_num)];
+	port_addr = esp32_gpio_ports_addrs[esp_gpio_pad_port(pin_num)];
 
 	if (port_addr == ESP32_INVALID_PORT_ADDR) {
 		return -EINVAL;
@@ -229,11 +229,11 @@ static int esp32_pin_configure(const uint32_t pin_mux, const uint32_t pin_cfg)
 	if (flags & ESP32_PIN_OUT_HIGH_FLAG) {
 		gpio_dev_t *const gpio_dev = (gpio_dev_t *)DT_REG_ADDR(DT_NODELABEL(gpio0));
 
-		if (pin_num < 32) {
+		if (esp_gpio_pad_port(pin_num) == 0) {
 			gpio_dev->out_w1ts = BIT(pin_num);
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio1))
 		} else {
-			gpio_dev->out1_w1ts.val = BIT(pin_num - 32);
+			gpio_dev->out1_w1ts.val = BIT(esp_gpio_pad_pin(pin_num));
 #endif
 		}
 	}
@@ -241,11 +241,11 @@ static int esp32_pin_configure(const uint32_t pin_mux, const uint32_t pin_cfg)
 	if (flags & ESP32_PIN_OUT_LOW_FLAG) {
 		gpio_dev_t *const gpio_dev = (gpio_dev_t *)DT_REG_ADDR(DT_NODELABEL(gpio0));
 
-		if (pin_num < 32) {
+		if (esp_gpio_pad_port(pin_num) == 0) {
 			gpio_dev->out_w1tc = BIT(pin_num);
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio1))
 		} else {
-			gpio_dev->out1_w1tc.val = BIT(pin_num - 32);
+			gpio_dev->out1_w1tc.val = BIT(esp_gpio_pad_pin(pin_num));
 #endif
 		}
 	}

--- a/include/zephyr/drivers/pinctrl/pinctrl_esp32_common.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_esp32_common.h
@@ -9,9 +9,6 @@
 
 /** @cond INTERNAL_HIDDEN */
 
-/** @brief Get GPIO port index from pin number */
-#define ESP32_PORT_IDX(_pin) (((_pin) < 32) ? 0 : 1)
-
 /** @brief Extract pin number from pinmux value */
 #define ESP32_PIN_NUM(_mux) (((_mux) >> ESP32_PIN_NUM_SHIFT) & ESP32_PIN_NUM_MASK)
 

--- a/soc/espressif/common/include/esp_gpio_port.h
+++ b/soc/espressif/common/include/esp_gpio_port.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_ESPRESSIF_COMMON_ESP_GPIO_PORT_H_
+#define ZEPHYR_SOC_ESPRESSIF_COMMON_ESP_GPIO_PORT_H_
+
+#include <stdint.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/toolchain.h>
+
+/* A Zephyr GPIO port is as wide as gpio_port_pins_t, so the pads above
+ * GPIO_MAX_PINS_PER_PORT are exposed through the gpio1 device. The
+ * helpers are always inlined because the gpio driver calls them from
+ * code that must stay in IRAM.
+ */
+
+/**
+ * @brief Get the GPIO port index owning a pad.
+ *
+ * @param pad Absolute pad number
+ * @return Port index, 0 for gpio0 and 1 for gpio1
+ */
+static ALWAYS_INLINE uint32_t esp_gpio_pad_port(uint32_t pad)
+{
+	return pad / GPIO_MAX_PINS_PER_PORT;
+}
+
+/**
+ * @brief Get the pin index of a pad within its GPIO port.
+ *
+ * @param pad Absolute pad number
+ * @return Pin index inside the owning port
+ */
+static ALWAYS_INLINE gpio_pin_t esp_gpio_pad_pin(uint32_t pad)
+{
+	return (gpio_pin_t)(pad % GPIO_MAX_PINS_PER_PORT);
+}
+
+/**
+ * @brief Get the absolute pad number from a port and pin index.
+ *
+ * @param port Port index, 0 for gpio0 and 1 for gpio1
+ * @param pin  Pin index inside the port
+ * @return Absolute pad number
+ */
+static ALWAYS_INLINE uint32_t esp_gpio_port_pad(uint32_t port, gpio_pin_t pin)
+{
+	return (port * GPIO_MAX_PINS_PER_PORT) + pin;
+}
+
+#endif /* ZEPHYR_SOC_ESPRESSIF_COMMON_ESP_GPIO_PORT_H_ */

--- a/tests/drivers/adc/adc_api/boards/esp32_devkitc_procpu.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32_devkitc_procpu.overlay
@@ -8,7 +8,7 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc0 0>, <&adc0 1>;
+		io-channels = <&adc0 0>, <&adc0 3>;
 	};
 };
 
@@ -25,8 +25,8 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@1 {
-		reg = <1>;
+	channel@3 {
+		reg = <3>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;

--- a/tests/drivers/adc/adc_api/boards/yd_esp32_procpu.overlay
+++ b/tests/drivers/adc/adc_api/boards/yd_esp32_procpu.overlay
@@ -8,7 +8,7 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc0 0>, <&adc0 1>;
+		io-channels = <&adc0 0>, <&adc0 3>;
 	};
 };
 
@@ -25,8 +25,8 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@1 {
-		reg = <1>;
+	channel@3 {
+		reg = <3>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;


### PR DESCRIPTION
On the esp32, the ADC1 pads are GPIO32 to GPIO39, which Zephyr exposes through the gpio1 port, but the ADC driver disconnected every pad through gpio0 with the raw pad number. Since the GPIO API started rejecting pins above 31, setting up any ADC1 channel on the esp32 failed with -EINVAL, or tripped the pin mask assertion with asserts on. The driver now picks the port from the pad number and returns -ENOTSUP for a pad the SoC has no port for, which also covers the ADC2 pads above 31 on the esp32p4.

The pad to port split was open coded in the gpio and pinctrl drivers as well, so it moves into one small header in the common soc folder and the three drivers share it. The pinctrl copy was a no-op and is dropped, and the adc_api test overlays for esp32_devkitc and yd_esp32 switch their second channel from GPIO37, which those modules do not bond out, to GPIO39. The adc_api suite passes on esp32, esp32s2 is build only, and it also passes on esp32s3, c3, c6, c61, h2 and p4 hardware.
