### PR TITLE
net: ipv6: Drop the neighbour entry when a tentative address is removed

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -6080,14 +6080,22 @@ static void remove_ipv6_ifaddr(struct net_if *iface,
 #if defined(CONFIG_NET_IPV6_DAD)
 	if (!net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
 		k_mutex_lock(&lock, K_FOREVER);
-		if (sys_slist_find_and_remove(&active_dad_timers,
-					      &ifaddr->dad_node)) {
-			/* Address with active DAD timer would still have
-			 * stale entry in the neighbor cache.
-			 */
+		(void)sys_slist_find_and_remove(&active_dad_timers,
+						&ifaddr->dad_node);
+		k_mutex_unlock(&lock);
+
+		/* An address that has not been checked yet still has the
+		 * entry for itself that the solicitation left in the
+		 * neighbour cache. Being on the timer list is not what says
+		 * so: dad_timeout() takes the entry off that list before it
+		 * works on it and does so with the lock released, so an
+		 * address removed just then is on no list at all. Ask the
+		 * address state instead, which is tentative until the check
+		 * is done.
+		 */
+		if (ifaddr->addr_state == NET_ADDR_TENTATIVE) {
 			net_ipv6_nbr_rm(iface, &ifaddr->address.in6_addr);
 		}
-		k_mutex_unlock(&lock);
 	}
 #endif
 


### PR DESCRIPTION
An address being checked for duplicates has an entry for itself in the neighbour cache, left there by the solicitation, and removing the address has to take that entry with it. The removal decides whether there is one to take by looking for the address on the DAD timer list, which is not what says so: dad_timeout() takes the entry off that list before it works on it, and works on it with the lock released, so an address removed just then is on no list at all and keeps its entry.

Nothing is seen to leak today only because the timeout goes on to drop the entry itself, as the last thing it does for that address. That holds just as long as it keeps working on a slot that is no longer in use, and it reads the address out of the slot to do it, so once the slot has been taken by another address the entry that gets dropped is the new address's and the old one stays for good, an incomplete entry being one that nothing evicts.

Ask the address state instead. An address stays tentative until the check finishes, so a removal that finds it tentative is one that has an entry to reclaim, whichever list the address is on at the time. Drop the entry outside the timer lock as well, the way the timeout does, rather than taking the neighbour lock underneath it.

Assisted-by: Claude:claude-opus-5