### PR TITLE
device: Add DEVICE_DT_INST_GET_COMMA macro

### DIFF
--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -20,9 +20,8 @@
 LOG_MODULE_REGISTER(gpio_npcx, CONFIG_GPIO_LOG_LEVEL);
 
 /* GPIO module instances */
-#define NPCX_GPIO_DEV(inst) DEVICE_DT_INST_GET(inst),
 static const struct device *const gpio_devs[] = {
-	DT_INST_FOREACH_STATUS_OKAY(NPCX_GPIO_DEV)
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
 };
 
 /* Driver config */

--- a/drivers/gpio/gpio_si32.c
+++ b/drivers/gpio/gpio_si32.c
@@ -195,8 +195,9 @@ static int gpio_si32_init(const struct device *dev)
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_DEVICE_INIT)
 
-#define GPIO_DEVICE_LIST_ENTRY(inst) DEVICE_DT_GET(DT_DRV_INST(inst)),
-static const struct device *gpio_devices[] = {DT_INST_FOREACH_STATUS_OKAY(GPIO_DEVICE_LIST_ENTRY)};
+static const struct device *gpio_devices[] = {
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
+};
 
 /* The hardware only supports level interrupts, so we have to emulate edge
  * interrupts in this handler.

--- a/drivers/i2c/i2c_ene_kb106x.c
+++ b/drivers/i2c/i2c_ene_kb106x.c
@@ -334,11 +334,10 @@ static DEVICE_API(i2c, i2c_kb106x_api) = {
 #endif
 };
 
-#define KB106X_FSMBM_DEV(inst) DEVICE_DT_INST_GET(inst),
 static void i2c_kb106x_isr_wrap(const void *unused)
 {
 	static const struct device *const fsmbm_devices[] = {
-		DT_INST_FOREACH_STATUS_OKAY(KB106X_FSMBM_DEV)};
+		DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)};
 	ARG_UNUSED(unused);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fsmbm_devices); i++) {

--- a/drivers/i2c/i2c_ene_kb1200.c
+++ b/drivers/i2c/i2c_ene_kb1200.c
@@ -334,8 +334,9 @@ static DEVICE_API(i2c, i2c_kb1200_api) = {
 #endif
 };
 
-#define KB1200_FSMBM_DEV(inst) DEVICE_DT_INST_GET(inst),
-static const struct device *const fsmbm_devices[] = {DT_INST_FOREACH_STATUS_OKAY(KB1200_FSMBM_DEV)};
+static const struct device *const fsmbm_devices[] = {
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
+};
 static void i2c_kb1200_isr_wrap(void)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(fsmbm_devices); i++) {

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -61,10 +61,8 @@
 LOG_MODULE_REGISTER(intc_miwu, LOG_LEVEL_ERR);
 
 /* MIWU module instances */
-#define NPCX_MIWU_DEV(inst) DEVICE_DT_INST_GET(inst),
-
 static const struct device *const miwu_devs[] = {
-	DT_INST_FOREACH_STATUS_OKAY(NPCX_MIWU_DEV)
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
 };
 
 BUILD_ASSERT(ARRAY_SIZE(miwu_devs) == NPCX_MIWU_TABLE_COUNT,

--- a/drivers/misc/devmux/devmux.c
+++ b/drivers/misc/devmux/devmux.c
@@ -199,5 +199,6 @@ static DEVICE_API(devmux, devmux_api) = {
 
 DT_INST_FOREACH_STATUS_OKAY(DEVMUX_DEFINE)
 
-#define DEVMUX_DEVICE_GET(_n) DEVICE_DT_INST_GET(_n),
-static const struct device *devmux_devices[] = {DT_INST_FOREACH_STATUS_OKAY(DEVMUX_DEVICE_GET)};
+static const struct device *devmux_devices[] = {
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
+};

--- a/drivers/power_domain/power_domain_gpio_monitor.c
+++ b/drivers/power_domain/power_domain_gpio_monitor.c
@@ -26,9 +26,8 @@ struct pd_gpio_monitor_data {
 };
 
 #ifdef CONFIG_POWER_DOMAIN_GPIO_MONITOR_INITIAL_READ
-#define DOMAIN_DEV(inst) DEVICE_DT_INST_GET(inst),
 static const struct device *const domain_devs[] = {
-	DT_INST_FOREACH_STATUS_OKAY(DOMAIN_DEV)
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
 };
 #endif
 

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -431,10 +431,8 @@ static int afbr_s50_init(const struct device *dev)
 /** Macrobatics to get a list of compatible sensors in order to map them back
  * and forth at run-time.
  */
-#define AFBR_S50_LIST(inst) DEVICE_DT_GET(DT_DRV_INST(inst)),
-
 const static struct device *afbr_s50_list[] = {
-	DT_INST_FOREACH_STATUS_OKAY(AFBR_S50_LIST)
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
 };
 
 int afbr_s50_platform_get_by_id(s2pi_slave_t peripheral,

--- a/drivers/serial/uart_ene_kb106x.c
+++ b/drivers/serial/uart_ene_kb106x.c
@@ -315,8 +315,9 @@ static DEVICE_API(uart, kb106x_uart_api) = {
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 /* UART module instances */
-#define KB106X_UART_DEV(inst) DEVICE_DT_INST_GET(inst),
-static const struct device *const uart_devices[] = {DT_INST_FOREACH_STATUS_OKAY(KB106X_UART_DEV)};
+static const struct device *const uart_devices[] = {
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
+};
 static void kb106x_uart_isr_wrap(const struct device *dev)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(uart_devices); i++) {

--- a/drivers/serial/uart_ene_kb1200.c
+++ b/drivers/serial/uart_ene_kb1200.c
@@ -308,9 +308,10 @@ static DEVICE_API(uart, kb1200_uart_api) = {
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 
-/* GPIO module instances */
-#define KB1200_UART_DEV(inst) DEVICE_DT_INST_GET(inst),
-static const struct device *const uart_devices[] = {DT_INST_FOREACH_STATUS_OKAY(KB1200_UART_DEV)};
+/* UART module instances */
+static const struct device *const uart_devices[] = {
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
+};
 static void kb1200_uart_isr_wrap(const struct device *dev)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(uart_devices); i++) {

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -340,6 +340,18 @@ typedef int16_t device_handle_t;
 #define DEVICE_DT_INST_GET(inst) DEVICE_DT_GET(DT_DRV_INST(inst))
 
 /**
+ * @brief Like @ref DEVICE_DT_INST_GET, with a trailing comma.
+ *
+ * This is convenient for use with devicetree iteration macros like
+ * @ref DT_INST_FOREACH_STATUS_OKAY.
+ *
+ * @param inst `DT_DRV_COMPAT` instance number
+ *
+ * @return A pointer to the device object created for that instance, followed by a comma
+ */
+#define DEVICE_DT_INST_GET_COMMA(inst) DEVICE_DT_INST_GET(inst),
+
+/**
  * @brief Get a @ref device reference from a devicetree compatible.
  *
  * If an enabled devicetree node has the given compatible and a device

--- a/soc/mediatek/mt8xxx/ipi.c
+++ b/soc/mediatek/mt8xxx/ipi.c
@@ -48,9 +48,8 @@ void mtk_adsp_ipi_signal(const struct device *ipi, uint32_t op)
 	cfg->ipi->int2cirq |= DSP2CPU_IRQ;
 }
 
-#define DEF_DEVPTR(N) DEVICE_DT_INST_GET(N),
 const struct device * const ipi_dev = {
-	DEF_DEVPTR(0)
+	DEVICE_DT_INST_GET_COMMA(0)
 };
 
 static void ipi_handle(const void *arg)

--- a/soc/mediatek/mt8xxx/mbox.c
+++ b/soc/mediatek/mt8xxx/mbox.c
@@ -84,9 +84,8 @@ void mtk_adsp_mbox_signal(const struct device *mbox, uint32_t chan)
 	}
 }
 
-#define DEF_DEVPTR(N) DEVICE_DT_INST_GET(N),
 const struct device * const mbox_devs[] = {
-	DT_INST_FOREACH_STATUS_OKAY(DEF_DEVPTR)
+	DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)
 };
 
 static void mbox_handle(const void *arg)

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -1559,14 +1559,12 @@ static void icbmsg_print_instance_stats(const struct shell *sh, const struct dev
 		    data->stats.rx_data_count);
 }
 
-#define ICBMSG_DEVICE(i) DEVICE_DT_INST_GET(i),
-
 static int cmd_icbmsg_stats(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 	static const struct device *const icbmsg_devices[] = {
-		DT_INST_FOREACH_STATUS_OKAY(ICBMSG_DEVICE)};
+		DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET_COMMA)};
 
 	for (size_t i = 0; i < ARRAY_SIZE(icbmsg_devices); i++) {
 		if (!device_is_ready(icbmsg_devices[i])) {

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -69,6 +69,14 @@ static const struct device *const comma_devs[] = {
 	DEVICE_DT_GET_COMMA(TEST_I2C)
 };
 
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_gpio_device
+
+static const struct device *const comma_inst_devs[] = {
+	DEVICE_DT_INST_GET_COMMA(0)
+	DEVICE_DT_INST_GET_COMMA(1)
+};
+
 #define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
 #define DEV_HDL_NAME(name) device_handle_get(DEVICE_GET(name))
 
@@ -103,6 +111,10 @@ ZTEST(devicetree_devices, test_init_get)
 	/* Check DEVICE_DT_GET_COMMA */
 	zassert_equal(comma_devs[0], DEVICE_DT_GET(TEST_GPIO));
 	zassert_equal(comma_devs[1], DEVICE_DT_GET(TEST_I2C));
+
+	/* Check DEVICE_DT_INST_GET_COMMA */
+	zassert_equal(comma_inst_devs[0], DEVICE_DT_INST_GET(0));
+	zassert_equal(comma_inst_devs[1], DEVICE_DT_INST_GET(1));
 
 	/* Check init functions */
 	zassert_equal(DEVICE_DT_GET(TEST_GPIO)->ops.init, dev_init);


### PR DESCRIPTION
Add DEVICE_DT_INST_GET_COMMA helper macro to include/zephyr/device.h to easily get a device pointer followed by a comma when expanding devicetree foreach iterators like DT_INST_FOREACH_STATUS_OKAY.

Update drivers, soc, subsys, and tests to use the common definition.
