### PR TITLE
drivers: eth: xmc4xxx: Fix port_ctrl usage

### DIFF
--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -1035,7 +1035,7 @@ static int eth_xmc4xxx_init(const struct device *dev)
 		return ret;
 	}
 
-	XMC_ETH_MAC_SetPortControl(NULL, *dev_cfg->port_ctrl);
+	XMC_ETH_MAC_SetPortControl(NULL, dev_cfg->port_ctrl);
 	XMC_ETH_MAC_Enable(NULL);
 
 	ret = eth_xmc4xxx_reset(dev);


### PR DESCRIPTION
XMC_ETH_MAC_SetPortControl was being called with a dereference to
port_ctrl. This is already a value and does not need to be dereferenced.
The compiler fails to build. Removing the dereference and passing by
value fixes the issue.

Fixes a build issue shown in the weekly CI runs and introduced in #114899

Signed-off-by: Tom Burdick <thomas.burdick@infineon.com>
