### PR TITLE
manifest: hal_espressif: pull-in REUSE metadata update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: eb6c0806b2a766291d96634c98146884cfb101d4
+      revision: pull/643/head
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 5e3b702250c3e05de5a4cb3a53f74fc3cd8094cf
+      revision: eb6c0806b2a766291d96634c98146884cfb101d4
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Pull in zephyrproject-rtos/hal_espressif#643 to get latest changes adding machine-readable licensing information for the binary blobs so that they can appear in SBOMs when said blobs are linked into the firmware