### PR TITLE
manifest: hal_realtek: pull-in REUSE metadata update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: 29d365ccfbceb9f42ce666d75463fbe2c83b8e29
+      revision: 0023f7ea1376988e48bf0eddd6d487e8110480ce
       west-commands: west/west-commands.yml
       groups:
         - hal


### PR DESCRIPTION
Pull in zephyrproject-rtos/hal_realtek#47 to get latest changes adding machine-readable licensing information for the binary blobs so that they can appear in SBOMs when said blobs are linked into the firmware