### PR TITLE
manifest: hal_microchip: pull-in REUSE metadata update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 550371954d33f7f5f17b3eb2f7ecc46ca3fa1b62
+      revision: accb0baa4090a6faf514800fef5f3c5fbe86577c
       path: modules/hal/microchip
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: accb0baa4090a6faf514800fef5f3c5fbe86577c
+      revision: pull/80/head
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Pull in zephyrproject-rtos/hal_microchip#80 to get latest changes adding machine-readable licensing information for the binary blobs so that they can appear in SBOMs when said blobs are linked into the firmware