### PR TITLE
manifest: hal_afbr: pull-in REUSE metadata update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_afbr
-      revision: 1abf6947457380934e27f92508ec5532ddedfc6d
+      revision: 83d0a28346f40c8675974346c83bab4cd93d49d5
       path: modules/hal/afbr
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_afbr
-      revision: 83d0a28346f40c8675974346c83bab4cd93d49d5
+      revision: pull/5/head
       path: modules/hal/afbr
       groups:
         - hal


### PR DESCRIPTION
Pull in zephyrproject-rtos/hal_afbr#5 to get latest changes adding machine-readable licensing information for the binary blobs so that they can appear in SBOMs when said blobs are linked into the firmware