### PR TITLE
manifest: hal_renesas: pull-in REUSE metadata update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: f2eb9bc7352f4dadae08e9f5f16b05bb26779b87
+      revision: b0b3d42587142d5e88a509d3db91ca39cc43da8e
       groups:
         - hal
     - name: hal_rpi_pico

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: b0b3d42587142d5e88a509d3db91ca39cc43da8e
+      revision: pull/221/head
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Pull in zephyrproject-rtos/hal_renesas#221 to get latest changes adding machine-readable licensing information for the binary blobs so that they can appear in SBOMs when said blobs are linked into the firmware