### PR TITLE
net: lib: coap: client: Verify ETag consistency in block-wise transfers

### DIFF
--- a/doc/services/connectivity/networking/api/coap_client.rst
+++ b/doc/services/connectivity/networking/api/coap_client.rst
@@ -72,6 +72,14 @@ application through the response callback registered in the request structure.
 As the response can be a blockwise transfer and the client calls the callback once per each
 block, the application should be to process all of the blocks to be able to process the response.
 
+During a blockwise transfer the client compares the ETag option of the received blocks, as
+required by :rfc:`7959`. When the resource representation changes in the middle of the transfer,
+the transfer is aborted and the callback is invoked with ``result_code`` set to ``-EBADMSG``.
+Stricter than the RFC minimum, which only mandates comparing ETags the server provides, the
+transfer is also aborted when the ETag option appears or disappears between blocks, as such a
+mix of tagged and untagged blocks cannot be verified. The application should discard the partial
+data it received and may retry the request.
+
 The following is an example of a very simple response handling function:
 
 .. code-block:: c

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -225,6 +225,9 @@ enum coap_response_code {
 #define COAP_TOKEN_MAX_LEN 8UL
 #define COAP_FIXED_HEADER_SIZE 4UL
 
+/** Maximum length of the ETag option value (@rfc{7252,section-5.10.6}) */
+#define COAP_ETAG_MAX_LEN 8UL
+
 /* CoAP TCP header constants (RFC 8323) */
 /* Len/TKL + Code */
 #define COAP_TCP_BASIC_HEADER_SIZE        (2)

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -186,6 +186,8 @@ struct coap_client_internal_request {
 	atomic_t in_callback;
 	int unreported_error;
 	struct coap_block_context recv_blk_ctx;
+	uint8_t recv_etag[COAP_ETAG_MAX_LEN];
+	uint8_t recv_etag_len;
 	struct coap_block_context send_blk_ctx;
 	struct coap_pending pending;
 	struct coap_client_request coap_request;

--- a/include/zephyr/net/coap_client_tcp.h
+++ b/include/zephyr/net/coap_client_tcp.h
@@ -173,6 +173,8 @@ struct coap_client_tcp_internal_request {
 	bool request_ongoing;
 	atomic_t in_callback;
 	struct coap_block_context recv_blk_ctx;
+	uint8_t recv_etag[COAP_ETAG_MAX_LEN];
+	uint8_t recv_etag_len;
 	struct coap_block_context send_blk_ctx;
 	struct coap_client_tcp_request coap_request;
 	struct coap_packet request;

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -17,6 +17,8 @@ LOG_MODULE_DECLARE(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <zephyr/net/coap.h>
 #include <zephyr/net/coap_client.h>
 
+#include "coap_client_internal.h"
+
 #define COAP_VERSION 1
 #define COAP_SEPARATE_TIMEOUT 6000
 #define COAP_PERIODIC_TIMEOUT 500
@@ -1296,6 +1298,16 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 						 coap_client_default_block_size(),
 						 0);
 			internal_req->offset = 0;
+		}
+
+		/* RFC 7959, section 2.4: blocks reassembled into one representation
+		 * must all carry the same ETag.
+		 */
+		ret = coap_client_check_etag(response, block_num == 0, internal_req->recv_etag,
+					     &internal_req->recv_etag_len);
+		if (ret < 0) {
+			LOG_ERR("ETag changed during block-wise transfer");
+			goto fail;
 		}
 
 		ret = coap_update_from_block(response, &internal_req->recv_blk_ctx);

--- a/subsys/net/lib/coap/coap_client_internal.h
+++ b/subsys/net/lib/coap/coap_client_internal.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_NET_LIB_COAP_CLIENT_INTERNAL_H_
+#define ZEPHYR_SUBSYS_NET_LIB_COAP_CLIENT_INTERNAL_H_
+
+#include <errno.h>
+#include <string.h>
+
+#include <zephyr/net/coap.h>
+
+/**
+ * @brief Verify ETag consistency across the blocks of a block-wise response
+ *
+ * @rfc{7959,section-2.4} and @rfc{7959,section-2.6} require a client
+ * reassembling a representation from a Block2 transfer to compare the ETag
+ * option of each block when the server provides one. A change indicates the
+ * blocks belong to different representations and reassembly must not
+ * continue.
+ *
+ * On the first block the ETag (or its absence) is recorded. On subsequent
+ * blocks it is compared against the recorded value; a change in value or
+ * presence is a mismatch. Failing on a presence change is stricter than the
+ * RFC's minimum, which only mandates comparing ETags the server provides: a
+ * transfer mixing tagged and untagged blocks cannot be verified.
+ *
+ * @param response Response packet of the current block.
+ * @param first_block True when this is the first block of a transfer.
+ * @param etag Buffer of COAP_ETAG_MAX_LEN bytes holding the transfer's ETag.
+ * @param etag_len Length of the stored ETag, 0 when the first block had none.
+ *
+ * @retval 0 ETag options are consistent so far.
+ * @retval -EBADMSG ETag changed during the transfer.
+ * @retval -EINVAL Response options could not be parsed.
+ */
+static inline int coap_client_check_etag(const struct coap_packet *response, bool first_block,
+					 uint8_t *etag, uint8_t *etag_len)
+{
+	struct coap_option option = {0};
+	int count;
+
+	count = coap_find_options(response, COAP_OPTION_ETAG, &option, 1);
+	if (count < 0) {
+		return count;
+	}
+
+	/* RFC 7252: an option length outside the defined range is treated like
+	 * an unrecognized option (section 5.4.3, stated for requests, applied
+	 * to responses alike), and unrecognized elective options are silently
+	 * ignored upon reception (section 5.4.1, not scoped to a direction).
+	 */
+	if (count > 0 && (option.len == 0U || option.len > COAP_ETAG_MAX_LEN)) {
+		count = 0;
+	}
+
+	if (first_block) {
+		*etag_len = (count > 0) ? option.len : 0U;
+		memcpy(etag, option.value, *etag_len);
+		return 0;
+	}
+
+	if (count == 0) {
+		return (*etag_len == 0U) ? 0 : -EBADMSG;
+	}
+
+	if (option.len != *etag_len || memcmp(option.value, etag, option.len) != 0) {
+		return -EBADMSG;
+	}
+
+	return 0;
+}
+
+#endif /* ZEPHYR_SUBSYS_NET_LIB_COAP_CLIENT_INTERNAL_H_ */

--- a/subsys/net/lib/coap/coap_client_tcp.c
+++ b/subsys/net/lib/coap/coap_client_tcp.c
@@ -26,6 +26,8 @@ LOG_MODULE_DECLARE(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <zephyr/net/coap.h>
 #include <zephyr/net/coap_client_tcp.h>
 
+#include "coap_client_internal.h"
+
 #define COAP_PERIODIC_TIMEOUT 500
 
 /* RFC 8323 Section 5.3.1: Base value for Max-Message-Size */
@@ -1008,6 +1010,16 @@ static int handle_response_tcp(struct coap_client_tcp *client, const struct coap
 						 coap_bytes_to_block_size(client->max_block_size),
 						 0);
 			internal_req->offset = 0;
+		}
+
+		/* RFC 7959, section 2.4: blocks reassembled into one representation
+		 * must all carry the same ETag.
+		 */
+		ret = coap_client_check_etag(response, block_num == 0, internal_req->recv_etag,
+					     &internal_req->recv_etag_len);
+		if (ret < 0) {
+			LOG_ERR("ETag changed during block-wise transfer");
+			goto fail;
 		}
 
 		ret = coap_tcp_update_from_block(response, &internal_req->recv_blk_ctx);

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -419,6 +419,59 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_empty_ack(int sock, void *buf, 
 	return sizeof(ack_data);
 }
 
+#define BLOCK2_NUM_BLOCKS     3
+#define BLOCK2_BLOCK_SIZE     64
+#define BLOCK2_LAST_BLOCK_LEN 10
+
+static int block2_serve_cnt;
+static const uint8_t *block2_etags[BLOCK2_NUM_BLOCKS];
+static uint8_t block2_etag_lens[BLOCK2_NUM_BLOCKS];
+static bool block2_got_last_block;
+static size_t block2_bytes_received;
+
+/* Serve a block-wise GET response, one 64-byte block per call, with a
+ * test-controlled ETag option per block (NULL/0 omits the option).
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_block2(int sock, void *buf, size_t max_len,
+							int flags, struct net_sockaddr *src_addr,
+							net_socklen_t *addrlen)
+{
+	struct coap_packet response;
+	uint8_t token[COAP_TOKEN_MAX_LEN] = {0};
+	uint8_t payload[BLOCK2_BLOCK_SIZE];
+	bool more = block2_serve_cnt < (BLOCK2_NUM_BLOCKS - 1);
+	uint16_t payload_len = more ? BLOCK2_BLOCK_SIZE : BLOCK2_LAST_BLOCK_LEN;
+	uint16_t message_id = get_next_pending_message_id();
+
+	zassert_true(block2_serve_cnt < BLOCK2_NUM_BLOCKS, "Too many block requests");
+
+	memset(payload, 'A' + block2_serve_cnt, sizeof(payload));
+
+	zassert_ok(coap_packet_init(&response, buf, max_len, COAP_VERSION_1, COAP_TYPE_ACK,
+				    COAP_TOKEN_MAX_LEN, token, COAP_RESPONSE_CODE_CONTENT,
+				    message_id));
+
+	if (block2_etag_lens[block2_serve_cnt] > 0) {
+		zassert_ok(coap_packet_append_option(&response, COAP_OPTION_ETAG,
+						     block2_etags[block2_serve_cnt],
+						     block2_etag_lens[block2_serve_cnt]));
+	}
+
+	zassert_ok(coap_append_option_int(&response, COAP_OPTION_BLOCK2,
+					  (block2_serve_cnt << 4) | (more ? BIT(3) : 0) |
+						  COAP_BLOCK_64));
+	zassert_ok(coap_packet_append_payload_marker(&response));
+	zassert_ok(coap_packet_append_payload(&response, payload, payload_len));
+
+	restore_token(buf);
+	fill_recv_src_addr(src_addr, addrlen);
+	clear_socket_events(sock, ZSOCK_POLLIN);
+
+	block2_serve_cnt++;
+
+	return response.offset;
+}
+
 static ssize_t z_impl_zsock_recvfrom_custom_fake_rst(int sock, void *buf, size_t max_len, int flags,
 						     struct net_sockaddr *src_addr,
 						     net_socklen_t *addrlen)
@@ -930,6 +983,47 @@ static void coap_callback_deregister_on_last_block(const struct coap_client_resp
 	}
 }
 
+static void coap_block2_callback(const struct coap_client_response_data *data, void *user_data)
+{
+	LOG_INF("CoAP block2 response callback, %d", data->result_code);
+	last_response_code = data->result_code;
+
+	if (data->result_code >= 0) {
+		block2_bytes_received += data->payload_len;
+	}
+	if (data->last_block) {
+		block2_got_last_block = (data->result_code >= 0);
+		k_sem_give((struct k_sem *)user_data);
+	}
+}
+
+static struct coap_client_request block2_request = {
+	.method = COAP_METHOD_GET,
+	.confirmable = true,
+	.path = TEST_PATH,
+	.cb = coap_block2_callback,
+	.user_data = &sem1,
+};
+
+static void block2_test_start(const uint8_t *const etags[BLOCK2_NUM_BLOCKS],
+			      const uint8_t etag_lens[BLOCK2_NUM_BLOCKS])
+{
+	block2_serve_cnt = 0;
+	block2_bytes_received = 0;
+	block2_got_last_block = false;
+
+	for (int i = 0; i < BLOCK2_NUM_BLOCKS; i++) {
+		block2_etags[i] = etags[i];
+		block2_etag_lens[i] = etag_lens[i];
+	}
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_block2;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &block2_request, NULL));
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)),
+		   "No final block2 callback");
+}
+
 extern void net_coap_init(void);
 
 static void *suite_setup(void)
@@ -1010,6 +1104,83 @@ ZTEST(coap_client, test_request_block)
 
 	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL),
 		      -EAGAIN, "");
+}
+
+ZTEST(coap_client, test_blockwise_recv_etag_consistent)
+{
+	static const uint8_t etag[] = {0xde, 0xad, 0xbe, 0xef};
+	const uint8_t *const etags[BLOCK2_NUM_BLOCKS] = {etag, etag, etag};
+	const uint8_t etag_lens[BLOCK2_NUM_BLOCKS] = {sizeof(etag), sizeof(etag), sizeof(etag)};
+
+	block2_test_start(etags, etag_lens);
+
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
+	zassert_true(block2_got_last_block, "Transfer did not complete");
+	zassert_equal(block2_serve_cnt, BLOCK2_NUM_BLOCKS, "Unexpected number of blocks");
+	zassert_equal(block2_bytes_received,
+		      (BLOCK2_NUM_BLOCKS - 1) * BLOCK2_BLOCK_SIZE + BLOCK2_LAST_BLOCK_LEN,
+		      "Unexpected payload length");
+}
+
+ZTEST(coap_client, test_blockwise_recv_no_etag)
+{
+	const uint8_t *const etags[BLOCK2_NUM_BLOCKS] = {NULL, NULL, NULL};
+	const uint8_t etag_lens[BLOCK2_NUM_BLOCKS] = {0, 0, 0};
+
+	block2_test_start(etags, etag_lens);
+
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
+	zassert_true(block2_got_last_block, "Transfer did not complete");
+	zassert_equal(block2_serve_cnt, BLOCK2_NUM_BLOCKS, "Unexpected number of blocks");
+}
+
+ZTEST(coap_client, test_blockwise_recv_etag_changed)
+{
+	static const uint8_t etag_old[] = {0x01, 0x02};
+	static const uint8_t etag_new[] = {0x03, 0x04};
+	const uint8_t *const etags[BLOCK2_NUM_BLOCKS] = {etag_old, etag_new, etag_new};
+	const uint8_t etag_lens[BLOCK2_NUM_BLOCKS] = {sizeof(etag_old), sizeof(etag_new),
+						      sizeof(etag_new)};
+
+	block2_test_start(etags, etag_lens);
+
+	zassert_equal(last_response_code, -EBADMSG, "Transfer should fail on ETag change");
+	zassert_false(block2_got_last_block, "Transfer should not complete");
+	zassert_equal(block2_serve_cnt, 2, "No further blocks should be requested");
+}
+
+ZTEST(coap_client, test_blockwise_recv_etag_malformed_ignored)
+{
+	/* RFC 7252, sections 5.4.1 and 5.4.3: an ETag exceeding 8 bytes is
+	 * treated like an unrecognized elective option and silently ignored,
+	 * so the transfer completes as if no ETag was sent. This path only
+	 * runs for ETags that fit the coap_option value buffer (12 bytes
+	 * here, CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE with extended options
+	 * enabled): parse_option() rejects longer values, making the block2
+	 * lookup fail first, and such a response is treated as non-block-wise.
+	 */
+	static const uint8_t etag[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+	const uint8_t *const etags[BLOCK2_NUM_BLOCKS] = {etag, etag, etag};
+	const uint8_t etag_lens[BLOCK2_NUM_BLOCKS] = {sizeof(etag), sizeof(etag), sizeof(etag)};
+
+	block2_test_start(etags, etag_lens);
+
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
+	zassert_true(block2_got_last_block, "Transfer did not complete");
+	zassert_equal(block2_serve_cnt, BLOCK2_NUM_BLOCKS, "Unexpected number of blocks");
+}
+
+ZTEST(coap_client, test_blockwise_recv_etag_lost)
+{
+	static const uint8_t etag[] = {0x01, 0x02};
+	const uint8_t *const etags[BLOCK2_NUM_BLOCKS] = {etag, NULL, NULL};
+	const uint8_t etag_lens[BLOCK2_NUM_BLOCKS] = {sizeof(etag), 0, 0};
+
+	block2_test_start(etags, etag_lens);
+
+	zassert_equal(last_response_code, -EBADMSG, "Transfer should fail on ETag change");
+	zassert_false(block2_got_last_block, "Transfer should not complete");
+	zassert_equal(block2_serve_cnt, 2, "No further blocks should be requested");
 }
 
 ZTEST(coap_client, test_resend_request)


### PR DESCRIPTION
RFC 7959, sections 2.4 and 2.6, require a client reassembling a
representation from a Block2 transfer to compare the ETag option of
each block when the server provides one. Neither the UDP nor the TCP
CoAP client did so, silently stitching together blocks of different
representations when the resource changed mid-transfer.

Record the ETag option (or its absence) on the first block of a
transfer and compare it on every subsequent block. On a change in
value or presence, abort the transfer and report -EBADMSG through the
response callback. An ETag with a length outside the valid 1 to 8
byte range is treated like an unrecognized elective option and ignored
(RFC 7252, sections 5.4.1 and 5.4.3). The check lives in a new
internal header shared by both clients.