### PR TITLE
drivers: clock_control: bflb: make flash clock update safer

### DIFF
--- a/drivers/clock_control/clock_control_bl60x.c
+++ b/drivers/clock_control/clock_control_bl60x.c
@@ -620,7 +620,9 @@ static __bflb_critfunc void clock_control_bl60x_init_root_as_crystal(const struc
 	sys_write32(clock_control_bl60x_get_clk(dev), CORECLOCKREGISTER);
 }
 
-static __ramfunc void clock_control_bl60x_update_flash_clk(const struct device *dev)
+static __ramfunc void clock_control_bl60x_update_flash_clk(const struct device *dev,
+							   const enum bl60x_clkid source,
+							   bool final)
 {
 	struct clock_control_bl60x_data *data = dev->data;
 	volatile uint32_t tmp;
@@ -634,11 +636,11 @@ static __ramfunc void clock_control_bl60x_update_flash_clk(const struct device *
 	tmp = *(volatile uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET);
 	tmp &= GLB_SF_CLK_SEL_UMSK;
 	tmp &= GLB_SF_CLK_SEL2_UMSK;
-	if (data->flashclk.source == bl60x_clkid_clk_pll) {
+	if (source == bl60x_clkid_clk_pll) {
 		clk = clock_control_bl60x_get_clk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 0U << GLB_SF_CLK_SEL2_POS;
-	} else if (data->flashclk.source == bl60x_clkid_clk_crystal) {
+	} else if (source == bl60x_clkid_clk_crystal) {
 		clk = clock_control_bl60x_get_xclk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 1U << GLB_SF_CLK_SEL2_POS;
@@ -651,12 +653,12 @@ static __ramfunc void clock_control_bl60x_update_flash_clk(const struct device *
 	/* If flash controller will manage flash, set to standard speed
 	 * and let it set the divider.
 	 */
-#if defined(CONFIG_SOC_FLASH_BFLB)
-	clk = DIV_ROUND_CLOSEST(clk, BL60X_TARGET_BASIC_CLOCK);
-	tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
-#else
-	tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
-#endif
+	if (IS_ENABLED(CONFIG_SOC_FLASH_BFLB) || !final) {
+		clk = DIV_ROUND_CLOSEST(clk, BL60X_TARGET_BASIC_CLOCK);
+		tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
+	} else {
+		tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
+	}
 
 	*(volatile uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
 
@@ -770,6 +772,8 @@ static __bflb_critfunc int clock_control_bl60x_update_clocks(const struct device
 	clock_control_bl60x_set_root_clock_dividers(0, 0);
 	sys_write32(BFLB_RC32M_FREQUENCY, CORECLOCKREGISTER);
 
+	clock_control_bl60x_update_flash_clk(dev, bl60x_clkid_clk_rc32m, false);
+
 	clock_control_bl60x_set_PKA_clock(0);
 	clock_control_bl60x_cache_2T(false);
 
@@ -807,6 +811,8 @@ static __bflb_critfunc int clock_control_bl60x_update_clocks(const struct device
 	} else {
 		/* Root clock already setup as RC32M */
 	}
+
+	clock_control_bl60x_update_flash_clk(dev, data->flashclk.source, true);
 
 	ret = clock_control_bl60x_clock_trim_32M();
 	if (ret < 0) {
@@ -1048,8 +1054,6 @@ static int clock_control_bl60x_init(const struct device *dev)
 	clock_control_bl60x_peripheral_clock_init();
 
 	clock_bflb_settle();
-
-	clock_control_bl60x_update_flash_clk(dev);
 
 	irq_unlock(key);
 

--- a/drivers/clock_control/clock_control_bl616cl.c
+++ b/drivers/clock_control/clock_control_bl616cl.c
@@ -797,7 +797,9 @@ static __bflb_critfunc void clock_control_bl616cl_init_root_as_crystal(const str
 	clock_bflb_set_root_clock(BFLB_MAIN_CLOCK_XTAL);
 }
 
-static __ramfunc void clock_control_bl616cl_update_flash_clk(const struct device *dev)
+static __ramfunc void clock_control_bl616cl_update_flash_clk(const struct device *dev,
+							     const enum bl616cl_clkid source,
+							     bool final)
 {
 	struct clock_control_bl616cl_data *data = dev->data;
 	volatile uint32_t tmp;
@@ -811,11 +813,11 @@ static __ramfunc void clock_control_bl616cl_update_flash_clk(const struct device
 	tmp = *(volatile uint32_t *)(GLB_BASE + GLB_SF_CFG0_OFFSET);
 	tmp &= GLB_SF_CLK_SEL_UMSK;
 	tmp &= GLB_SF_CLK_SEL2_UMSK;
-	if (data->flashclk.source == bl616cl_clkid_clk_pll) {
+	if (source == bl616cl_clkid_clk_pll) {
 		clk = clock_control_bl616cl_get_hclk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 0U << GLB_SF_CLK_SEL2_POS;
-	} else if (data->flashclk.source == bl616cl_clkid_clk_crystal) {
+	} else if (source == bl616cl_clkid_clk_crystal) {
 		clk = clock_control_bl616cl_get_xclk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 1U << GLB_SF_CLK_SEL2_POS;
@@ -828,12 +830,12 @@ static __ramfunc void clock_control_bl616cl_update_flash_clk(const struct device
 	/* If flash controller will manage flash, set to standard speed
 	 * and let it set the divider.
 	 */
-#if defined(CONFIG_SOC_FLASH_BFLB)
-	clk = DIV_ROUND_CLOSEST(clk, BL616CL_TARGET_BASIC_CLOCK);
-	tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
-#else
-	tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
-#endif
+	if (IS_ENABLED(CONFIG_SOC_FLASH_BFLB) || !final) {
+		clk = DIV_ROUND_CLOSEST(clk, BL616CL_TARGET_BASIC_CLOCK);
+		tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
+	} else {
+		tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
+	}
 
 	*(volatile uint32_t *)(GLB_BASE + GLB_SF_CFG0_OFFSET) = tmp;
 
@@ -1002,7 +1004,7 @@ static __bflb_critfunc int clock_control_bl616cl_update_clocks(const struct devi
 
 	clock_control_bl616cl_set_crystal_type(6U);
 
-	clock_control_bl616cl_update_flash_clk(dev);
+	clock_control_bl616cl_update_flash_clk(dev, bl616cl_clkid_clk_rc32m, false);
 
 	ret = clock_control_bl616cl_update_f32k(dev);
 	if (ret < 0) {
@@ -1073,6 +1075,8 @@ static __bflb_critfunc int clock_control_bl616cl_update_clocks(const struct devi
 	} else {
 		/* Root clock already setup as RC32M */
 	}
+
+	clock_control_bl616cl_update_flash_clk(dev, data->flashclk.source, true);
 
 	ret = clock_control_bl616cl_clock_trim_32M();
 	if (ret < 0) {

--- a/drivers/clock_control/clock_control_bl61x.c
+++ b/drivers/clock_control/clock_control_bl61x.c
@@ -1187,7 +1187,9 @@ static __bflb_critfunc void clock_control_bl61x_init_root_as_crystal(const struc
 	clock_bflb_set_root_clock(BFLB_MAIN_CLOCK_XTAL);
 }
 
-static __ramfunc void clock_control_bl61x_update_flash_clk(const struct device *dev)
+static __ramfunc void clock_control_bl61x_update_flash_clk(const struct device *dev,
+							   const enum bl61x_clkid source,
+							   bool final)
 {
 	struct clock_control_bl61x_data *data = dev->data;
 	volatile uint32_t tmp;
@@ -1201,11 +1203,11 @@ static __ramfunc void clock_control_bl61x_update_flash_clk(const struct device *
 	tmp = *(volatile uint32_t *)(GLB_BASE + GLB_SF_CFG0_OFFSET);
 	tmp &= GLB_SF_CLK_SEL_UMSK;
 	tmp &= GLB_SF_CLK_SEL2_UMSK;
-	if (data->flashclk.source == bl61x_clkid_clk_wifipll) {
+	if (source == bl61x_clkid_clk_wifipll) {
 		clk = clock_control_bl61x_get_hclk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 0U << GLB_SF_CLK_SEL2_POS;
-	} else if (data->flashclk.source == bl61x_clkid_clk_crystal) {
+	} else if (source == bl61x_clkid_clk_crystal) {
 		clk = clock_control_bl61x_get_xclk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 1U << GLB_SF_CLK_SEL2_POS;
@@ -1218,12 +1220,12 @@ static __ramfunc void clock_control_bl61x_update_flash_clk(const struct device *
 	/* If flash controller will manage flash, set to standard speed
 	 * and let it set the divider.
 	 */
-#if defined(CONFIG_SOC_FLASH_BFLB)
-	clk = DIV_ROUND_CLOSEST(clk, BL61X_TARGET_BASIC_CLOCK);
-	tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
-#else
-	tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
-#endif
+	if (IS_ENABLED(CONFIG_SOC_FLASH_BFLB) || !final) {
+		clk = DIV_ROUND_CLOSEST(clk, BL61X_TARGET_BASIC_CLOCK);
+		tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
+	} else {
+		tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
+	}
 
 	*(volatile uint32_t *)(GLB_BASE + GLB_SF_CFG0_OFFSET) = tmp;
 
@@ -1348,6 +1350,8 @@ static __bflb_critfunc int clock_control_bl61x_update_clocks(const struct device
 		return -EIO;
 	}
 
+	clock_control_bl61x_update_flash_clk(dev, bl61x_clkid_clk_rc32m, false);
+
 	ret = clock_control_bl61x_update_f32k(dev);
 	if (ret < 0) {
 		return ret;
@@ -1408,6 +1412,8 @@ static __bflb_critfunc int clock_control_bl61x_update_clocks(const struct device
 	} else {
 		/* Root clock already setup as RC32M */
 	}
+
+	clock_control_bl61x_update_flash_clk(dev, data->flashclk.source, true);
 
 	ret = clock_control_bl61x_clock_trim_32M();
 	if (ret < 0) {
@@ -1750,8 +1756,6 @@ static int clock_control_bl61x_init(const struct device *dev)
 	clock_control_bl61x_peripheral_clock_init();
 
 	clock_bflb_settle();
-
-	clock_control_bl61x_update_flash_clk(dev);
 
 	irq_unlock(key);
 

--- a/drivers/clock_control/clock_control_bl70x_l.c
+++ b/drivers/clock_control/clock_control_bl70x_l.c
@@ -576,7 +576,9 @@ static __bflb_critfunc void clock_control_bl70x_l_init_root_as_crystal(const str
 	sys_write32(clock_control_bl70x_l_get_clk(dev), CORECLOCKREGISTER);
 }
 
-static __ramfunc void clock_control_bl70x_l_update_flash_clk(const struct device *dev)
+static __ramfunc void clock_control_bl70x_l_update_flash_clk(const struct device *dev,
+							     const enum bl70x_l_clkid source,
+							     bool final)
 {
 	struct clock_control_bl70x_l_data *data = dev->data;
 	volatile uint32_t tmp;
@@ -592,7 +594,7 @@ static __ramfunc void clock_control_bl70x_l_update_flash_clk(const struct device
 #if !defined(CONFIG_SOC_SERIES_BL70XL)
 	tmp &= GLB_SF_CLK_SEL2_UMSK;
 #endif
-	if (data->flashclk.source == bl70x_l_clkid_clk_dll) {
+	if (source == bl70x_l_clkid_clk_dll) {
 		clk = clock_control_bl70x_l_get_clk(dev);
 #if defined(CONFIG_SOC_SERIES_BL70XL)
 		tmp |= 1U << GLB_SF_CLK_SEL_POS;
@@ -600,7 +602,7 @@ static __ramfunc void clock_control_bl70x_l_update_flash_clk(const struct device
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 0U << GLB_SF_CLK_SEL2_POS;
 #endif
-	} else if (data->flashclk.source == bl70x_l_clkid_clk_crystal) {
+	} else if (source == bl70x_l_clkid_clk_crystal) {
 		clk = clock_control_bl70x_l_get_xclk(dev);
 #if defined(CONFIG_SOC_SERIES_BL70XL)
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
@@ -617,12 +619,12 @@ static __ramfunc void clock_control_bl70x_l_update_flash_clk(const struct device
 	/* If flash controller will manage flash, set to standard speed
 	 * and let it set the divider.
 	 */
-#if defined(CONFIG_SOC_FLASH_BFLB)
-	clk = DIV_ROUND_CLOSEST(clk, BL70X_L_TARGET_BASIC_CLOCK);
-	tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
-#else
-	tmp |= ((uint32_t)(data->flashclk.divider - 1U)) << GLB_SF_CLK_DIV_POS;
-#endif
+	if (IS_ENABLED(CONFIG_SOC_FLASH_BFLB) || !final) {
+		clk = DIV_ROUND_CLOSEST(clk, BL70X_L_TARGET_BASIC_CLOCK);
+		tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
+	} else {
+		tmp |= ((uint32_t)(data->flashclk.divider - 1U)) << GLB_SF_CLK_DIV_POS;
+	}
 
 	*(volatile uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
 
@@ -740,6 +742,8 @@ static __bflb_critfunc int clock_control_bl70x_l_update_clocks(const struct devi
 	clock_control_bl70x_l_set_root_clock_dividers(0, 0);
 	sys_write32(BFLB_RC32M_FREQUENCY, CORECLOCKREGISTER);
 
+	clock_control_bl70x_l_update_flash_clk(dev, bl70x_l_clkid_clk_rc32m, false);
+
 	clock_control_bl70x_l_cache_2T(false);
 
 	ret = clock_control_bl70x_l_update_f32k(dev);
@@ -777,6 +781,8 @@ static __bflb_critfunc int clock_control_bl70x_l_update_clocks(const struct devi
 	} else {
 		/* Root clock already setup as RC32M */
 	}
+
+	clock_control_bl70x_l_update_flash_clk(dev, data->flashclk.source, true);
 
 	ret = clock_control_bl70x_l_clock_trim_32M();
 	if (ret < 0) {
@@ -1021,8 +1027,6 @@ static int clock_control_bl70x_l_init(const struct device *dev)
 	clock_control_bl70x_l_peripheral_clock_init();
 
 	clock_bflb_settle();
-
-	clock_control_bl70x_l_update_flash_clk(dev);
 
 	irq_unlock(key);
 

--- a/drivers/clock_control/clock_control_bl808.c
+++ b/drivers/clock_control/clock_control_bl808.c
@@ -1576,7 +1576,9 @@ static int clock_control_bl808_update_f32k(const struct device *dev)
 	return 0;
 }
 
-static __ramfunc void clock_control_bl808_update_flash_clk(const struct device *dev)
+static __ramfunc void clock_control_bl808_update_flash_clk(const struct device *dev,
+							   const enum bl808_clkid source,
+							   bool final)
 {
 	struct clock_control_bl808_data *data = dev->data;
 	volatile uint32_t tmp;
@@ -1590,11 +1592,11 @@ static __ramfunc void clock_control_bl808_update_flash_clk(const struct device *
 	tmp = *(volatile uint32_t *)(GLB_BASE + GLB_SF_CFG0_OFFSET);
 	tmp &= GLB_SF_CLK_SEL_UMSK;
 	tmp &= GLB_SF_CLK_SEL2_UMSK;
-	if (data->flashclk.source == bl808_clkid_clk_wifipll) {
+	if (source == bl808_clkid_clk_wifipll) {
 		clk = clock_control_bl808_get_hclk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 0U << GLB_SF_CLK_SEL2_POS;
-	} else if (data->flashclk.source == bl808_clkid_clk_crystal) {
+	} else if (source == bl808_clkid_clk_crystal) {
 		clk = clock_control_bl808_get_xclk(dev);
 		tmp |= 0U << GLB_SF_CLK_SEL_POS;
 		tmp |= 1U << GLB_SF_CLK_SEL2_POS;
@@ -1607,12 +1609,12 @@ static __ramfunc void clock_control_bl808_update_flash_clk(const struct device *
 	/* If flash controller will manage flash, set to standard speed
 	 * and let it set the divider.
 	 */
-#if defined(CONFIG_SOC_FLASH_BFLB)
-	clk = DIV_ROUND_CLOSEST(clk, BL808_TARGET_BASIC_CLOCK);
-	tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
-#else
-	tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
-#endif
+	if (IS_ENABLED(CONFIG_SOC_FLASH_BFLB) || !final) {
+		clk = DIV_ROUND_CLOSEST(clk, BL808_TARGET_BASIC_CLOCK);
+		tmp |= clamp(clk - 1, 0x0, 0x7) << GLB_SF_CLK_DIV_POS;
+	} else {
+		tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
+	}
 
 	*(volatile uint32_t *)(GLB_BASE + GLB_SF_CFG0_OFFSET) = tmp;
 
@@ -1690,7 +1692,7 @@ static __bflb_critfunc int clock_control_bl808_update_clocks(const struct device
 	clock_control_bl808_set_emi_clk(0, 1);
 	clock_control_bl808_set_mm_clks(bl808_clkid_clk_rc32m, 1, bl808_clkid_clk_rc32m, 1, 1);
 
-	clock_control_bl808_update_flash_clk(dev);
+	clock_control_bl808_update_flash_clk(dev, bl808_clkid_clk_rc32m, false);
 
 	ret = clock_control_bl808_update_f32k(dev);
 	if (ret < 0) {
@@ -1780,6 +1782,8 @@ static __bflb_critfunc int clock_control_bl808_update_clocks(const struct device
 	} else {
 		/* Root clock already set to RC32M */
 	}
+
+	clock_control_bl808_update_flash_clk(dev, data->flashclk.source, false);
 
 	ret = clock_control_bl808_clock_trim_32M();
 	if (ret < 0) {


### PR DESCRIPTION
Apply a safer method of handling flash clock update for all SoCs

Not super thoroughly tested, but built various samples with a few clock settings and with FLASH driver on/off on some on:
- wb2
- tg01-m
- m61
- bl704l dvk
- m64p
- m1s dock