### PR TITLE
samples: subsys:  profiling: perf: fix issues on STM32 platforms 

### DIFF
--- a/samples/subsys/profiling/perf/pytest/test_perf.py
+++ b/samples/subsys/profiling/perf/pytest/test_perf.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def test_shell_perf(dut: DeviceAdapter, shell: Shell):
 
-    shell.base_timeout=10
+    shell.base_timeout=20
 
     logger.info('send "perf record 200 99" command')
     lines = shell.exec_command('perf record 200 99')

--- a/samples/subsys/profiling/perf/tests.yaml
+++ b/samples/subsys/profiling/perf/tests.yaml
@@ -8,7 +8,7 @@ tests:
       - perf
       - profiling
     extra_configs:
-      - CONFIG_PROFILING_PERF_BUFFER_SIZE=128
+      - CONFIG_PROFILING_PERF_BUFFER_SIZE=256
     filter: CONFIG_PROFILING_PERF_HAS_BACKEND
     integration_platforms:
       - qemu_cortex_m3


### PR DESCRIPTION

This PR fixes issues encountered on severals STM32 platforms after this [commit](https://github.com/zephyrproject-rtos/zephyr/commit/0a9a02be87b294b4c49a17bb713ed6cd075585fb)


The test can fail on hardware in two ways:

- **the perf buffer can overflow while recording samples**

```
INFO: send "perf record 200 99" command 
DEBUG: #: [1;32muart:~$ [mperf record 200 99 
DEBUG: #: Number of CPUs: 1 
DEBUG: #: Enabled perf 
DEBUG: #: [1;32muart:~$ [m 
DEBUG: #: [1;32muart:~$ [m[8D[JTimer fires: 16 
DEBUG: #: [1;32muart:~$ [m[8D[J 
DEBUG: #: [1;32muart:~$ [m[8D[JCPU 0: Attempts=16, Samples=15 
DEBUG: #: [1;32muart:~$ [m[8D[J====================== 
DEBUG: #: [1;32muart:~$ [m[8D[J[1;31mPerf buf overflow! 
=== Return code: -15 
```

- **the shell helper timeout can expire while waiting for the prompt after printing the perf buffer**

```
DEBUG: #: 0000000008004ebd 
ERROR: Did not find line "uart:\~\$\ " within 10 seconds 
FAILED 
```

Non-exhaustive list of STM32 platforms concerned :

b_u585i_iot02a/stm32u585xx , disco_l475_iot1/stm32l475xx , nucleo_c071rb/stm32c071xx , nucleo_c5a3zg/stm32c5a3xx
 , nucleo_f091rc/stm32f091xc, nucleo_f103rb/stm32f103xb , nucleo_f207zg/stm32f207xx , nucleo_f429zi/stm32f429xx , nucleo_f746zg/stm32f746xx , nucleo_g071rb/stm32g071xx , nucleo_g474re/stm32g474xx , nucleo_h753zi/stm32h753xx
 , nucleo_l073rz/stm32l073xx , nucleo_l152re/stm32l152xe, nucleo_u385rg_q@D/stm32u385xx , nucleo_wb09ke/stm32wb09, nucleo_wb55rg/stm32wb55xx , nucleo_wba55cg/stm32wba55xx , nucleo_wl55jc/stm32wl55xx , stm32f3_disco@B/stm32f303xc , stm32h573i_dk/stm32h573xx , stm32l562e_dk/stm32l562xx , stm32n6570_dk/stm32n657xx/sb , stm32u083c_dk/stm32u083xx