### PR TITLE
modules: hal_bouffalolab: re-run the blob objcopy when the blob changes

### DIFF
--- a/modules/hal_bouffalolab/cmake/blob_objcopy.cmake
+++ b/modules/hal_bouffalolab/cmake/blob_objcopy.cmake
@@ -6,6 +6,7 @@ function(blob_objcopy name library)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}
     COMMAND ${CMAKE_OBJCOPY} ${ARGN} ${library} ${name}
+    DEPENDS ${library}
   )
   add_custom_target(${name}_target DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${name})
   add_dependencies(zephyr_interface ${name}_target)


### PR DESCRIPTION
`blob_objcopy()` objcopies a vendor blob out of the module's `zephyr/blobs/` directory into the build directory and links the copy, but the custom command that does the copying declares no dependency on the blob:

```cmake
add_custom_command(
  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}
  COMMAND ${CMAKE_OBJCOPY} ${ARGN} ${library} ${name}
)
```

With no `DEPENDS`, the output is produced exactly once. From then on it exists and the build system knows of no input that could make it stale, so the copy is never refreshed. Re-fetching a blob with `west blobs fetch`, or moving the module to a revision that ships different ones, silently leaves the previous copy linked into the image.

The fix is to declare the source library as a dependency of the command. It affects the 10 `blob_objcopy()` call sites across `src/bl61x` and `src/bl616cl` (phyrf, BLE controller, wl80211, macsw and the macsw config library).

Spotted while working on some improved tooling to capture blobs in `west spdx` SBOMs