### PR TITLE
drivers: entropy: stm32: miscellaneous cleanups

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -6,30 +6,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <stddef.h>
-#include <zephyr/kernel.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/entropy.h>
-#include <zephyr/random/random.h>
-#include <zephyr/init.h>
-#include <zephyr/sys/__assert.h>
-#include <zephyr/sys/util.h>
+
 #include <errno.h>
+#include <stddef.h>
+
 #include <soc.h>
-#include <zephyr/pm/policy.h>
 #include <stm32_bitops.h>
+#include <stm32_hsem.h>
 #include <stm32_ll_bus.h>
+#include <stm32_ll_pka.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_rng.h>
-#include <stm32_ll_pka.h>
 #include <stm32_ll_system.h>
-#include <zephyr/sys/printk.h>
-#include <zephyr/pm/device.h>
+
+#include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/entropy.h>
+#include <zephyr/init.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/random/random.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/barrier.h>
-#include "stm32_hsem.h"
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
 #include "entropy_stm32.h"
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -768,9 +768,6 @@ static int entropy_stm32_rng_get_entropy(const struct device *dev,
 					 uint8_t *buf,
 					 uint16_t len)
 {
-	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_stm32_rng_data == dev->data);
-
 	while (len) {
 		uint16_t bytes;
 
@@ -799,9 +796,6 @@ static int entropy_stm32_rng_get_entropy_isr(const struct device *dev,
 					     uint32_t flags)
 {
 	uint16_t cnt = len;
-
-	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_stm32_rng_data == dev->data);
 
 	if (likely((flags & ENTROPY_BUSYWAIT) == 0U)) {
 		return rng_pool_get(
@@ -859,17 +853,9 @@ static int entropy_stm32_rng_get_entropy_isr(const struct device *dev,
 
 static int entropy_stm32_rng_init(const struct device *dev)
 {
-	struct entropy_stm32_rng_dev_data *dev_data;
-	const struct entropy_stm32_rng_dev_cfg *dev_cfg;
+	const struct entropy_stm32_rng_dev_cfg *dev_cfg = dev->config;
+	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
 	int res;
-
-	__ASSERT_NO_MSG(dev != NULL);
-
-	dev_data = dev->data;
-	dev_cfg = dev->config;
-
-	__ASSERT_NO_MSG(dev_data != NULL);
-	__ASSERT_NO_MSG(dev_cfg != NULL);
 
 	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -95,12 +95,12 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_SOC_STM32WB09XX) ||
 	"STM32WB09: TRNG requires system clock frequency >= 32MHz");
 
 struct entropy_stm32_rng_dev_cfg {
+	RNG_TypeDef *rng;
+	const struct device *clock;
 	struct stm32_pclken *pclken;
 };
 
 struct entropy_stm32_rng_dev_data {
-	RNG_TypeDef *rng;
-	const struct device *clock;
 	struct k_sem sem_lock;
 	struct k_sem sem_sync;
 	struct k_work filling_work;
@@ -117,19 +117,18 @@ struct entropy_stm32_rng_dev_data {
 static struct stm32_pclken pclken_rng[] = STM32_DT_INST_CLOCKS(0);
 
 static struct entropy_stm32_rng_dev_cfg entropy_stm32_rng_config = {
+	.rng = (RNG_TypeDef *)DT_INST_REG_ADDR(0),
+	.clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 	.pclken	= pclken_rng
 };
 
-static struct entropy_stm32_rng_dev_data entropy_stm32_rng_data = {
-	.rng = (RNG_TypeDef *)DT_INST_REG_ADDR(0),
-};
+static struct entropy_stm32_rng_dev_data entropy_stm32_rng_data;
 
 static int entropy_stm32_suspend(void)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
 	const struct entropy_stm32_rng_dev_cfg *dev_cfg = dev->config;
-	RNG_TypeDef *rng = dev_data->rng;
+	RNG_TypeDef *rng = dev_cfg->rng;
 	int res;
 
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
@@ -177,7 +176,7 @@ static int entropy_stm32_suspend(void)
 #ifdef CONFIG_SOC_SERIES_STM32WBAX
 	uint32_t wait_cycles, rng_rate;
 
-	if (clock_control_get_rate(dev_data->clock,
+	if (clock_control_get_rate(dev_cfg->clock,
 			(clock_control_subsys_t) &dev_cfg->pclken[0],
 			&rng_rate) < 0) {
 		return -EIO;
@@ -189,7 +188,7 @@ static int entropy_stm32_suspend(void)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32WBAX */
 
-	res = clock_control_off(dev_data->clock,
+	res = clock_control_off(dev_cfg->clock,
 			(clock_control_subsys_t)&dev_cfg->pclken[0]);
 
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
@@ -202,12 +201,11 @@ static int entropy_stm32_suspend(void)
 static int entropy_stm32_resume(void)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
 	const struct entropy_stm32_rng_dev_cfg *dev_cfg = dev->config;
-	RNG_TypeDef *rng = dev_data->rng;
+	RNG_TypeDef *rng = dev_cfg->rng;
 	int res;
 
-	res = clock_control_on(dev_data->clock,
+	res = clock_control_on(dev_cfg->clock,
 			(clock_control_subsys_t)&dev_cfg->pclken[0]);
 #if defined(CONFIG_SOC_STM32WB09XX)
 	/**
@@ -225,7 +223,7 @@ static int entropy_stm32_resume(void)
 
 static void configure_rng(void)
 {
-	RNG_TypeDef *rng = entropy_stm32_rng_data.rng;
+	RNG_TypeDef *rng = entropy_stm32_rng_config.rng;
 
 #ifdef STM32_CONDRST_SUPPORT
 	uint32_t desired_nist_cfg = DT_INST_PROP_OR(0, nist_config, 0U);
@@ -402,7 +400,7 @@ static int random_sample_get(rng_sample_t *rnd_sample)
 {
 	int retval = -EAGAIN;
 	unsigned int key;
-	RNG_TypeDef *rng = entropy_stm32_rng_data.rng;
+	RNG_TypeDef *rng = entropy_stm32_rng_config.rng;
 
 	key = irq_lock();
 
@@ -462,8 +460,8 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 
 	/* do not proceed if a Seed error occurred */
-	if (ll_rng_is_active_secs(entropy_stm32_rng_data.rng) ||
-		ll_rng_is_active_seis(entropy_stm32_rng_data.rng)) {
+	if (ll_rng_is_active_secs(entropy_stm32_rng_config.rng) ||
+		ll_rng_is_active_seis(entropy_stm32_rng_config.rng)) {
 
 		(void)random_sample_get(&rnd_sample); /* this will recover the error */
 
@@ -481,7 +479,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 
 	do {
 		while (ll_rng_is_active_drdy(
-				entropy_stm32_rng_data.rng) != 1) {
+				entropy_stm32_rng_config.rng) != 1) {
 
 #if !defined(CONFIG_PM_S2RAM)
 #if !IRQLESS_TRNG
@@ -725,11 +723,11 @@ static int perform_pool_refill(void)
 static void trng_poll_work_item(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	RNG_TypeDef *rng = entropy_stm32_rng_data.rng;
+	RNG_TypeDef *rng = entropy_stm32_rng_config.rng;
 
 	/* Seed error occurred: reset TRNG and try again */
-	if (ll_rng_is_active_secs(entropy_stm32_rng_data.rng) ||
-		ll_rng_is_active_seis(entropy_stm32_rng_data.rng)) {
+	if (ll_rng_is_active_secs(entropy_stm32_rng_config.rng) ||
+		ll_rng_is_active_seis(entropy_stm32_rng_config.rng)) {
 
 		rng_sample_t dummy;
 		(void)random_sample_get(&dummy); /* this will recover the error */
@@ -857,9 +855,7 @@ static int entropy_stm32_rng_init(const struct device *dev)
 	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
 	int res;
 
-	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-
-	res = clock_control_on(dev_data->clock,
+	res = clock_control_on(dev_cfg->clock,
 		(clock_control_subsys_t)&dev_cfg->pclken[0]);
 	if (res != 0) {
 		LOG_ERR("Failed to enable RNG bus clock (err %d). "
@@ -869,7 +865,7 @@ static int entropy_stm32_rng_init(const struct device *dev)
 
 	/* Configure domain clock if any */
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
-		res = clock_control_configure(dev_data->clock,
+		res = clock_control_configure(dev_cfg->clock,
 					      (clock_control_subsys_t)&dev_cfg->pclken[1],
 					      NULL);
 		if (res != 0) {
@@ -912,7 +908,7 @@ static int entropy_stm32_rng_init(const struct device *dev)
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
 		uint32_t rng_clock_rate;
 
-		if (clock_control_get_rate(dev_data->clock,
+		if (clock_control_get_rate(dev_cfg->clock,
 					   (clock_control_subsys_t)&dev_cfg->pclken[1],
 					   &rng_clock_rate) != 0) {
 			LOG_ERR("Failed to get RNG domain clock rate");
@@ -934,6 +930,7 @@ static int entropy_stm32_rng_init(const struct device *dev)
 static int entropy_stm32_rng_pm_action(const struct device *dev,
 				       enum pm_device_action action)
 {
+	const struct entropy_stm32_rng_dev_cfg *dev_cfg = dev->config;
 	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
 
 	int res = 0;
@@ -955,9 +952,9 @@ static int entropy_stm32_rng_pm_action(const struct device *dev,
 #if DT_INST_NODE_HAS_PROP(0, health_test_config)
 			entropy_stm32_resume();
 #if DT_INST_NODE_HAS_PROP(0, health_test_magic)
-			LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health_test_magic));
+			LL_RNG_SetHealthConfig(dev_cfg->rng, DT_INST_PROP(0, health_test_magic));
 #endif /* health_test_magic */
-			if (LL_RNG_GetHealthConfig(dev_data->rng) !=
+			if (LL_RNG_GetHealthConfig(dev_cfg->rng) !=
 				DT_INST_PROP_OR(0, health_test_config, 0U)) {
 				entropy_stm32_rng_init(dev);
 			} else if (!entropy_stm32_rng_data.filling_pools) {

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -114,10 +114,12 @@ struct entropy_stm32_rng_dev_data {
 	RNG_POOL_DEFINE(thr, CONFIG_ENTROPY_STM32_THR_POOL_SIZE);
 };
 
+#define TRNG_BASE ((RNG_TypeDef *)DT_INST_REG_ADDR(0))
+
 static struct stm32_pclken pclken_rng[] = STM32_DT_INST_CLOCKS(0);
 
 static struct entropy_stm32_rng_dev_cfg entropy_stm32_rng_config = {
-	.rng = (RNG_TypeDef *)DT_INST_REG_ADDR(0),
+	.rng = TRNG_BASE,
 	.clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 	.pclken	= pclken_rng
 };
@@ -247,7 +249,7 @@ static int entropy_stm32_resume(void)
 
 static void configure_rng(void)
 {
-	RNG_TypeDef *rng = entropy_stm32_rng_config.rng;
+	RNG_TypeDef *rng = TRNG_BASE;
 
 #ifdef STM32_CONDRST_SUPPORT
 	uint32_t desired_nist_cfg = DT_INST_PROP_OR(0, nist_config, 0U);
@@ -418,7 +420,7 @@ static int random_sample_get(rng_sample_t *rnd_sample)
 {
 	int retval = -EAGAIN;
 	unsigned int key;
-	RNG_TypeDef *rng = entropy_stm32_rng_config.rng;
+	RNG_TypeDef *rng = TRNG_BASE;
 
 	key = irq_lock();
 
@@ -476,8 +478,8 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 	ASSERT_RNG_HSEM_OWNED();
 
 	/* do not proceed if a Seed error occurred */
-	if (ll_rng_is_active_secs(entropy_stm32_rng_config.rng) ||
-		ll_rng_is_active_seis(entropy_stm32_rng_config.rng)) {
+	if (ll_rng_is_active_secs(TRNG_BASE) ||
+		ll_rng_is_active_seis(TRNG_BASE)) {
 
 		(void)random_sample_get(&rnd_sample); /* this will recover the error */
 
@@ -494,8 +496,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 #endif /* !IRQLESS_TRNG */
 
 	do {
-		while (ll_rng_is_active_drdy(
-				entropy_stm32_rng_config.rng) != 1) {
+		while (ll_rng_is_active_drdy(TRNG_BASE) != 1) {
 
 #if !defined(CONFIG_PM_S2RAM)
 #if !IRQLESS_TRNG
@@ -736,11 +737,11 @@ static int perform_pool_refill(void)
 static void trng_poll_work_item(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	RNG_TypeDef *rng = entropy_stm32_rng_config.rng;
+	RNG_TypeDef *rng = TRNG_BASE;
 
 	/* Seed error occurred: reset TRNG and try again */
-	if (ll_rng_is_active_secs(entropy_stm32_rng_config.rng) ||
-		ll_rng_is_active_seis(entropy_stm32_rng_config.rng)) {
+	if (ll_rng_is_active_secs(TRNG_BASE) ||
+		ll_rng_is_active_seis(TRNG_BASE)) {
 
 		rng_sample_t dummy;
 		(void)random_sample_get(&dummy); /* this will recover the error */

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -124,6 +124,36 @@ static struct entropy_stm32_rng_dev_cfg entropy_stm32_rng_config = {
 
 static struct entropy_stm32_rng_dev_data entropy_stm32_rng_data;
 
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
+#define HAS_MULTICORE_SHARED_RNG 1
+#else /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+#define HAS_MULTICORE_SHARED_RNG 0
+#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+
+static void entropy_stm32_hsem_acquire(void)
+{
+	z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
+}
+
+static int entropy_stm32_hsem_try_acquire(void)
+{
+	return z_stm32_hsem_try_lock(CFG_HW_RNG_SEMID);
+}
+
+static void entropy_stm32_hsem_release(void)
+{
+	z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
+}
+
+/* Note API quirk: on uniprocessor, this returns false! */
+static bool entropy_stm32_hsem_is_owned(void)
+{
+	return z_stm32_hsem_is_owned(CFG_HW_RNG_SEMID);
+}
+
+#define ASSERT_RNG_HSEM_OWNED() \
+	__ASSERT_NO_MSG(!HAS_MULTICORE_SHARED_RNG || entropy_stm32_hsem_is_owned())
+
 static int entropy_stm32_suspend(void)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
@@ -131,10 +161,8 @@ static int entropy_stm32_suspend(void)
 	RNG_TypeDef *rng = dev_cfg->rng;
 	int res;
 
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-	/* Prevent concurrent access with PM */
-	z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+	entropy_stm32_hsem_acquire();
+
 	LL_RNG_Disable(rng);
 #if defined(CONFIG_SOC_STM32WB09XX)
 	/* RM0505 Rev.2 §14.4:
@@ -164,9 +192,7 @@ static int entropy_stm32_suspend(void)
 #endif /* CONFIG_STM32_HAL2 */
 
 	if (pka_clock_enabled && LL_PKA_IsEnabled(PKA)) {
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-		z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+		entropy_stm32_hsem_release();
 
 		/* PKA needs RNG clock, so exit here if in use */
 		return 0;
@@ -191,9 +217,7 @@ static int entropy_stm32_suspend(void)
 	res = clock_control_off(dev_cfg->clock,
 			(clock_control_subsys_t)&dev_cfg->pclken[0]);
 
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-	z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+	entropy_stm32_hsem_release();
 
 	return res;
 }
@@ -289,25 +313,19 @@ static void configure_rng(void)
 
 static void acquire_rng(void)
 {
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-	/* Lock the RNG to prevent concurrent access */
-	z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
-
+	entropy_stm32_hsem_acquire();
 	entropy_stm32_resume();
 
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
+#if HAS_MULTICORE_SHARED_RNG
 	/* RNG configuration could have been changed by the other core */
 	configure_rng();
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+#endif /* HAS_MULTICORE_SHARED_RNG */
 }
 
 static void release_rng(void)
 {
 	entropy_stm32_suspend();
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-	z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+	entropy_stm32_hsem_release();
 }
 
 static int entropy_stm32_got_error(RNG_TypeDef *rng)
@@ -455,9 +473,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 	__ASSERT_NO_MSG(!irq_is_enabled(IRQN));
 #endif /* !IRQLESS_TRNG */
 
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-	__ASSERT_NO_MSG(z_stm32_hsem_is_owned(CFG_HW_RNG_SEMID));
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+	ASSERT_RNG_HSEM_OWNED();
 
 	/* do not proceed if a Seed error occurred */
 	if (ll_rng_is_active_secs(entropy_stm32_rng_config.rng) ||
@@ -530,15 +546,12 @@ static int start_pool_filling(bool wait)
 	bool already_filling;
 
 	key = irq_lock();
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-	/* In non-blocking mode, return immediately if the RNG is not available */
-	if (!wait && z_stm32_hsem_try_lock(CFG_HW_RNG_SEMID) != 0) {
+
+	if (!wait && entropy_stm32_hsem_try_acquire() != 0) {
+		/* In non-blocking mode, return immediately if the RNG is not available */
 		irq_unlock(key);
 		return -EAGAIN;
 	}
-#else
-	ARG_UNUSED(wait);
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 
 	already_filling = entropy_stm32_rng_data.filling_pools;
 	entropy_stm32_rng_data.filling_pools = true;
@@ -822,7 +835,7 @@ static int entropy_stm32_rng_get_entropy_isr(const struct device *dev,
 		 * when the pools are full. On TRNG without interrupt line, the
 		 * default value of false ensures TRNG is always released.
 		 */
-		if (z_stm32_hsem_is_owned(CFG_HW_RNG_SEMID)) {
+		if (entropy_stm32_hsem_is_owned()) {
 			rng_already_acquired = true;
 		}
 		if (!rng_already_acquired) {
@@ -898,12 +911,12 @@ static int entropy_stm32_rng_init(const struct device *dev)
 	IRQ_CONNECT(IRQN, IRQ_PRIO, stm32_rng_isr, &entropy_stm32_rng_data, 0);
 #endif /* !IRQLESS_TRNG */
 
-#if !defined(CONFIG_SOC_SERIES_STM32WBX) && !defined(CONFIG_STM32H7_DUAL_CORE)
+#if !HAS_MULTICORE_SHARED_RNG
 	/* For multi-core MCUs, RNG configuration is automatically performed
 	 * after acquiring the RNG in start_pool_filling()
 	 */
 	configure_rng();
-#endif /* !CONFIG_SOC_SERIES_STM32WBX && !CONFIG_STM32H7_DUAL_CORE */
+#endif /* !HAS_MULTICORE_SHARED_RNG */
 
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
 		uint32_t rng_clock_rate;
@@ -940,11 +953,9 @@ static int entropy_stm32_rng_pm_action(const struct device *dev,
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-		/* Lock to Prevent concurrent access with PM */
-		z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
-	/* Call release_rng instead of entropy_stm32_suspend to avoid double hsem_unlock */
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+		entropy_stm32_hsem_acquire();
+
+		/* Call release_rng instead of entropy_stm32_suspend to avoid double hsem_unlock */
 		release_rng();
 		break;
 	case PM_DEVICE_ACTION_RESUME:
@@ -959,14 +970,11 @@ static int entropy_stm32_rng_pm_action(const struct device *dev,
 				entropy_stm32_rng_init(dev);
 			} else if (!entropy_stm32_rng_data.filling_pools) {
 				/* Resume RNG only if it was suspended during filling pool */
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-				/* Lock to Prevent concurrent access with PM */
-				z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
+				entropy_stm32_hsem_acquire();
 				/*
 				 * Call release_rng instead of entropy_stm32_suspend
 				 * to avoid double hsem_unlock
 				 */
-#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 				release_rng();
 			}
 #endif /* health_test_config */


### PR DESCRIPTION
- drivers: entropy: stm32: reorganize includes
- drivers: entropy: stm32: remove unnecessary assertions
- drivers: entropy: stm32: move constants to instance configuration
- drivers: entropy: stm32: factor out HSEM handling
- drivers: entropy: stm32: use RNG address directly

Tested OK on `nucleo_wb07cc`, `nucleo_wb09ke` and `nucleo_h753zi` (`tests/drivers/entropy/api/`).