### PR TITLE
net: ptp: validate the sync interval of a Sync message

### DIFF
--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -1099,8 +1099,19 @@ static void port_sync_msg_process(struct ptp_port *port, struct ptp_msg *msg)
 		return;
 	}
 
-	if (port->port_ds.log_sync_interval != msg->header.log_msg_interval) {
-		port->port_ds.log_sync_interval = msg->header.log_msg_interval;
+	/* The interval is only specified for multicast Sync messages. For unicast
+	 * ones it is not applicable, because it is subject to unicast negotiation,
+	 * and the field carries 0x7F (IEEE 1588-2019 Table 42).
+	 */
+	if ((msg->header.flags[0] & PTP_MSG_UNICAST_FLAG) == 0 &&
+	    msg->header.log_msg_interval != DEFAULT_LOG_MSG_INTERVAL) {
+		if (IN_RANGE(msg->header.log_msg_interval,
+			     PTP_LOG_MSG_INTERVAL_MIN, PTP_LOG_MSG_INTERVAL_MAX)) {
+			port->port_ds.log_sync_interval = msg->header.log_msg_interval;
+		} else {
+			LOG_WRN("Port %d ignoring bogus Sync interval 2^%d",
+				port->port_ds.id.port_number, msg->header.log_msg_interval);
+		}
 	}
 
 	if (!port_sync_rx_timestamp_valid(port, msg)) {

--- a/tests/net/ptp/port_events/src/main.c
+++ b/tests/net/ptp/port_events/src/main.c
@@ -1088,6 +1088,52 @@ ZTEST(ptp_port_events, test_event_gen_sync_without_rx_timestamp_is_dropped)
 	stop_port_timers(&port);
 }
 
+static int8_t sync_interval_result(uint8_t flags, int8_t log_msg_interval)
+{
+	struct ptp_port port;
+
+	init_port(&port, PTP_PS_TIME_RECEIVER);
+	init_rx_msg(PTP_MSG_SYNC, 0x62);
+	scripted_rx_msg.header.sequence_id = 13;
+	scripted_rx_msg.header.flags[0] = flags;
+	scripted_rx_msg.header.log_msg_interval = log_msg_interval;
+	scripted_rx_msg.rx_timestamp_valid = false;
+	fake_parent_ds.port_id = scripted_rx_msg.header.src_port_id;
+
+	zassert_equal(ptp_port_event_gen(&port, PTP_SOCKET_EVENT), PTP_EVT_NONE,
+		      "Sync should not change port event state");
+
+	stop_port_timers(&port);
+
+	return port.port_ds.log_sync_interval;
+}
+
+ZTEST(ptp_port_events, test_event_gen_sync_updates_interval)
+{
+	zassert_equal(sync_interval_result(0, -3), -3,
+		      "interval advertised in a Sync should be adopted");
+}
+
+ZTEST(ptp_port_events, test_event_gen_sync_ignores_not_applicable_interval)
+{
+	zassert_equal(sync_interval_result(0, 0x7F), 0,
+		      "0x7F marks the interval as not applicable and must not be adopted");
+}
+
+ZTEST(ptp_port_events, test_event_gen_sync_ignores_bogus_interval)
+{
+	zassert_equal(sync_interval_result(0, 23), 0,
+		      "out of range sync interval must be ignored");
+	zassert_equal(sync_interval_result(0, -11), 0,
+		      "out of range sync interval must be ignored");
+}
+
+ZTEST(ptp_port_events, test_event_gen_sync_ignores_unicast_interval)
+{
+	zassert_equal(sync_interval_result(PTP_MSG_UNICAST_FLAG, -3), 0,
+		      "interval of a unicast Sync must be ignored");
+}
+
 ZTEST(ptp_port_events, test_event_gen_follow_up_first_bad_sync_clears_pair)
 {
 	struct ptp_port port;


### PR DESCRIPTION
The logMessageInterval of a received Sync message was adopted unchecked.
The value ends up as a shift count in port_timer_set_timeout(), so a
timeTransmitter announcing an out of range interval made the PTP Port
arm its sync receipt timer with a nonsensical timeout.
Reject values outside the range that can be represented, and treat the
value 0x7F as not applicable instead of adopting it, as required by
IEEE 1588-2019 Table 42.

Assisted-by: Claude:claude-opus-5

Fixes: #119396