### PR TITLE
soc: st: stm32mp1: model STM32MP15 with silicon SoC and CPU cluster

### DIFF
--- a/boards/96boards/avenger96/Kconfig.96b_avenger96
+++ b/boards/96boards/avenger96/Kconfig.96b_avenger96
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_96B_AVENGER96
-	select SOC_STM32MP15_M4
+	select SOC_STM32MP157CXX_M4

--- a/boards/st/stm32mp157c_dk2/Kconfig.stm32mp157c_dk2
+++ b/boards/st/stm32mp157c_dk2/Kconfig.stm32mp157c_dk2
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_STM32MP157C_DK2
-	select SOC_STM32MP15_M4
+	select SOC_STM32MP157CXX_M4

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -266,6 +266,11 @@ Boards
   them have to reference the SoC nodes (``&spi2``, ``&i2c0``, ``&gpio0``,
   ``&gpio1``) directly. (:github:`116956`)
 
+* The STM32MP15 Cortex-M4 SoC Kconfig symbol ``SOC_STM32MP15_M4`` has been renamed to
+  :kconfig:option:`CONFIG_SOC_STM32MP157CXX_M4`. Out-of-tree STM32MP15 boards that selected
+  ``SOC_STM32MP15_M4`` must select :kconfig:option:`CONFIG_SOC_STM32MP157CXX_M4` instead.
+  (:github:`118151`)
+
 Device Drivers and Devicetree
 *****************************
 

--- a/soc/oct/osd32mp15x/Kconfig
+++ b/soc/oct/osd32mp15x/Kconfig
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_OSD32MP15X
-	select SOC_STM32MP15_M4
+	select SOC_STM32MP157CXX_M4

--- a/soc/oct/osd32mp15x/Kconfig.soc
+++ b/soc/oct/osd32mp15x/Kconfig.soc
@@ -3,12 +3,12 @@
 
 # The OSD32MP15X is technically a SiP (System-in-Package) that consists of
 # the STM32MP15 MCU and additional components like EEPROM. So for
-# OSD32MP1-BRK platform the STM32MP15_M4 SoC is to be indicated as
+# OSD32MP1-BRK platform the STM32MP157CXX_M4 SoC is to be indicated as
 # the build target, but since the OSD32MP15x SiP is what a user can actually
-# see on a board, using only STM32MP15_M4 in the Zephyr build
+# see on a board, using only STM32MP157CXX_M4 in the Zephyr build
 # infrastructure might be confusing. That's why in the top level of SoC
 # definitions (for user-configurable options in Kconfig, for example)
-# the OSD32MP15X term is used and STM32MP15_M4 underneath.
+# the OSD32MP15X term is used and STM32MP157CXX_M4 underneath.
 
 config SOC_OSD32MP15X
 	bool

--- a/soc/st/stm32/stm32mp1x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32mp1x/Kconfig.defconfig
@@ -5,6 +5,6 @@
 
 if SOC_SERIES_STM32MP1X
 
-rsource "Kconfig.defconfig.stm32mp15_m4"
+rsource "Kconfig.defconfig.stm32mp157cxx_m4"
 
 endif # SOC_SERIES_STM32MP1X

--- a/soc/st/stm32/stm32mp1x/Kconfig.defconfig.stm32mp157cxx_m4
+++ b/soc/st/stm32/stm32mp1x/Kconfig.defconfig.stm32mp157cxx_m4
@@ -3,9 +3,9 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_STM32MP15_M4
+if SOC_STM32MP157CXX_M4
 
 config NUM_IRQS
 	default 150
 
-endif # SOC_STM32MP15_M4
+endif # SOC_STM32MP157CXX_M4

--- a/soc/st/stm32/stm32mp1x/Kconfig.soc
+++ b/soc/st/stm32/stm32mp1x/Kconfig.soc
@@ -10,9 +10,9 @@ config SOC_SERIES_STM32MP1X
 config SOC_SERIES
 	default "stm32mp1x" if SOC_SERIES_STM32MP1X
 
-config SOC_STM32MP15_M4
+config SOC_STM32MP157CXX_M4
 	bool
 	select SOC_SERIES_STM32MP1X
 
 config SOC
-	default "stm32mp157cxx" if SOC_STM32MP15_M4
+	default "stm32mp157cxx" if SOC_STM32MP157CXX_M4


### PR DESCRIPTION
Following the discussion in #117118, this reworks the STM32MP15 SoC description so it no longer conflates the silicon with its Cortex-M4 core.

`SOC_STM32MP15_M4` conflated silicon and core, which left no room to describe the Cortex-A7 and did not follow the silicon + CPU cluster model already used by STM32MP2 and the dual-core STM32H7 parts. This PR:

- adds a shared `SOC_STM32MP1X_M4` Cortex-M4 core layer and a silicon `SOC_STM32MP157CXX_M4` symbol, moving the Cortex-M4 selects onto the core layer so the series no longer hardwires the core (leaving room for a future Cortex-A7 port);
- adds an `m4` CPU cluster and moves the Cortex-M4 SoC code into an `m4/` subdirectory, mirroring `soc/st/stm32/stm32mp2x/m33`;
- removes `SOC_STM32MP15_M4` and migrates the three in-tree consumers (`96b_avenger96`, `stm32mp157c_dk2`, `osd32mp1_brk`), renaming their board-specific overlays/fragments and updating twister platform entries for the new `m4` qualifier.

The rework is runtime-neutral: `hello_world` for the three boards builds byte-identical loadable images versus the current tree (the only object-level delta is the board-target identifier string that now carries `/m4`).

This is the preceding SoC change that #117118 (common `stm32mp157_dk2` board) will rebase on.

The OSD32MP15x SiP touches @fkokosinski / @tgorochowik's board; cc @arnopo @erwango.

_This change was prepared with AI assistance (see the `Assisted-by:` trailers on the commits)._
