### PR TITLE
cmake: extensions: declare the file generate_inc_file converts as a source

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1055,7 +1055,7 @@ function(generate_inc_file_for_target
   # But first create a unique name for the custom target
   generate_unique_target_name_from_filename(${generated_file} generated_target_name)
 
-  add_custom_target(${generated_target_name} DEPENDS ${generated_file})
+  add_custom_target(${generated_target_name} DEPENDS ${generated_file} SOURCES ${source_file})
   generate_inc_file_for_gen_target(${target} ${source_file} ${generated_file} ${generated_target_name} ${ARGN})
 endfunction()
 


### PR DESCRIPTION
`generate_inc_file_for_target()` creates a target whose whole purpose is to bake one file into the firmware as a C array, yet the file it converts is named only in the custom command's `DEPENDS`:

```cmake
add_custom_command(OUTPUT ${generated_file} COMMAND file2hex.py --file ${source_file} ... DEPENDS ${source_file})
add_custom_target(${generated_target_name} DEPENDS ${generated_file})
```

CMake treats `DEPENDS` as private build-graph plumbing. It does not show up in IDE project files, and it is not reported by the CMake file-based API, which describes a target by its *sources*. Anything reading the project model — IDE integrations, build and dependency analysis, licence scanners — therefore sees a target that consumes nothing, and the content actually embedded in the image is only recoverable by reverse-engineering generator output.

`SOURCES` is CMake's documented way to say "this target is about these files, even though they have no build rule". Declaring the converted file there makes the relationship part of the project model. Custom target sources are never compiled, so the build itself is unaffected.

### Behaviour change worth noting

CMake now checks the file at configure time. An input that neither exists on disk nor is produced by the build is reported as

```
CMake Error at ...: Cannot find source file: ...
```

rather than failing later in the generated build system. Out-of-tree callers passing a file that appears only at build time, without CMake knowing it is generated, would now fail at configure. Such a call is already broken today (the `DEPENDS` would have no rule to satisfy it), so this turns a late, generator-specific error into an early, clear one.

### Context

This came up while improving `west spdx` support to record the binary blobs a build embeds into the image (e.g. nRF70 and RW61x Wi-Fi firmware and similar).
