### PR TITLE
fs: ext2: preserve partial I/O results after block errors

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -709,7 +709,7 @@ ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, si
 	}
 
 	if (rc < 0) {
-		return rc;
+		return read > 0 ? read : rc;
 	}
 	return read;
 }
@@ -748,7 +748,20 @@ ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t off
 	}
 
 	if (rc < 0) {
-		return rc;
+		if (written == 0) {
+			return rc;
+		}
+
+		/* Preserve the size of data committed before the failed block. */
+		if (offset > inode->i_size) {
+			inode->i_size = offset;
+			rc = ext2_commit_inode(inode);
+			if (rc < 0) {
+				return rc;
+			}
+		}
+
+		return written;
 	}
 
 	if (offset > inode->i_size) {


### PR DESCRIPTION
The inode read and write paths return a later block error after earlier bytes have completed. The file wrapper therefore leaves its offset despite completed write data already being persisted.

Return completed byte counts after later block errors and persist the size reached by completed writes.

Fixes #118142