### PR TITLE
fs: ext2: release temporary blocks on metadata write failure

### DIFF
--- a/subsys/fs/ext2/ext2_diskops.c
+++ b/subsys/fs/ext2/ext2_diskops.c
@@ -799,6 +799,7 @@ int ext2_commit_superblock(struct ext2_data *fs)
 
 	ret = ext2_write_block(fs, b);
 	if (ret < 0) {
+		ext2_drop_block(b);
 		return ret;
 	}
 	ext2_drop_block(b);
@@ -827,6 +828,7 @@ int ext2_commit_bg(struct ext2_data *fs)
 
 	ret = ext2_write_block(fs, b);
 	if (ret < 0) {
+		ext2_drop_block(b);
 		return ret;
 	}
 	ext2_drop_block(b);


### PR DESCRIPTION
The metadata commit helpers return before releasing the temporary block when ext2_write_block() fails. This leaks slab allocations on each failed metadata write.

Drop the block before returning the write error.

Fixes #118137