### PR TITLE
fs: ext2: roll back inode allocation when creation fails

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -971,7 +971,8 @@ static int ext2_create_inode(struct ext2_data *fs, struct ext2_inode *parent,
 
 	/* fill inode with correct data */
 	inode->i_fs = fs;
-	inode->flags = 0;
+	/* Keep the allocation rollback pending until creation is complete. */
+	inode->flags = INODE_REMOVE;
 	inode->i_id = ino;
 	inode->i_size = 0;
 	inode->i_mode = type == FS_DIR_ENTRY_FILE ? EXT2_DEF_FILE_MODE : EXT2_DEF_DIR_MODE;
@@ -990,7 +991,12 @@ static int ext2_create_inode(struct ext2_data *fs, struct ext2_inode *parent,
 	}
 
 	rc = ext2_commit_inode(inode);
-	return rc;
+	if (rc < 0) {
+		return rc;
+	}
+
+	inode->flags &= ~INODE_REMOVE;
+	return 0;
 }
 
 struct ext2_direntry *ext2_create_direntry(const char *name, uint8_t namelen, uint32_t ino,
@@ -1141,6 +1147,9 @@ int ext2_create_file(struct ext2_inode *parent, struct ext2_inode *new_inode,
 		ret = rc;
 	}
 out:
+	if (ret < 0) {
+		new_inode->flags |= INODE_REMOVE;
+	}
 	k_heap_free(&direntry_heap, entry);
 	return ret;
 }
@@ -1227,6 +1236,9 @@ int ext2_create_dir(struct ext2_inode *parent, struct ext2_inode *new_inode,
 		ret = rc;
 	}
 out:
+	if (ret < 0) {
+		new_inode->flags |= INODE_REMOVE;
+	}
 	k_heap_free(&direntry_heap, entry);
 	return ret;
 }


### PR DESCRIPTION
New inode allocation remains committed when file or directory creation fails after allocation. The caller only drops the in-memory reference; the inode remains allocated on disk.

Keep removal pending until initial creation succeeds. Mark later creation failures for cleanup through the existing inode-drop path.

Fixes #118139