### PR TITLE
drivers: uaol: fix data loss for 44.1 kHz capture

### DIFF
--- a/drivers/dai/intel/uaol/uaol.c
+++ b/drivers/dai/intel/uaol/uaol.c
@@ -20,9 +20,6 @@
 
 LOG_MODULE_REGISTER(dai_uaol_intel_adsp);
 
-#define UAOL_USB_EP_DIRECTION_OUT		0
-#define UAOL_USB_EP_DIRECTION_IN		1
-
 /* maximum payload size of PCM stream when split_ep is on */
 #define UAOL_MPS_SPLIT_EP			188
 
@@ -52,6 +49,21 @@ static const struct device *uaol_get_hw_device(uint32_t index)
 	}
 
 	return uaol_devs[index];
+}
+
+static void dai_uaol_set_ep_info(struct dai_intel_uaol_data *dp,
+				 const struct ipc4_uaol_usb_ep_info *ep_info)
+{
+	/* HW pcms_ctl.part.mps is 11 bits. */
+	uint32_t packet_size = ep_info->usb_mps & 0x7FF;
+
+	dp->hw_cfg.direction = ep_info->direction;
+
+	if (ep_info->direction == UAOL_DIR_PLAYBACK && ep_info->split_ep) {
+		dp->hw_cfg.sio_credit_size = MIN(packet_size, UAOL_MPS_SPLIT_EP);
+	} else {
+		dp->hw_cfg.sio_credit_size = packet_size;
+	}
 }
 
 static int dai_uaol_process_aux_config_data(struct dai_intel_uaol_data *dp,
@@ -128,11 +140,7 @@ static int dai_uaol_process_aux_config_data(struct dai_intel_uaol_data *dp,
 			0;
 	}
 	if (ep_info) {
-		if (ep_info->direction == UAOL_USB_EP_DIRECTION_OUT && ep_info->split_ep) {
-			dp->hw_cfg.sio_credit_size = MIN(ep_info->usb_mps, UAOL_MPS_SPLIT_EP);
-		} else {
-			dp->hw_cfg.sio_credit_size = ep_info->usb_mps;
-		}
+		dai_uaol_set_ep_info(dp, ep_info);
 	}
 	if (art_divider) {
 		dp->hw_cfg.art_divider_m = art_divider->multiplier;
@@ -223,12 +231,7 @@ static int dai_uaol_process_dma_control_data(struct dai_intel_uaol_data *dp,
 				return -EINVAL;
 			}
 			ep_info = (struct ipc4_uaol_usb_ep_info *)tlv->value;
-			if (ep_info->direction == UAOL_USB_EP_DIRECTION_OUT && ep_info->split_ep) {
-				dp->hw_cfg.sio_credit_size =
-					MIN(ep_info->usb_mps, UAOL_MPS_SPLIT_EP);
-			} else {
-				dp->hw_cfg.sio_credit_size = ep_info->usb_mps;
-			}
+			dai_uaol_set_ep_info(dp, ep_info);
 			break;
 		default:
 			break;

--- a/drivers/uaol/uaol_intel_adsp.c
+++ b/drivers/uaol/uaol_intel_adsp.c
@@ -378,7 +378,8 @@ static uint8_t uaol_intel_adsp_encode_service_interval(uint32_t service_interval
 static void uaol_intel_adsp_program_format(const struct device *dev, int stream,
 					   uint32_t sample_rate, uint32_t channels,
 					   uint32_t sample_bits, uint32_t sio_credit_size,
-					   uint32_t service_interval_usec)
+					   uint32_t service_interval_usec,
+					   enum uaol_direction direction)
 {
 	struct uaol_intel_adsp_data *dp = dev->data;
 	union UAOLxPCMSyCTL pcms_ctl;
@@ -389,6 +390,20 @@ static void uaol_intel_adsp_program_format(const struct device *dev, int stream,
 	sample_size = sample_bits / 8;
 	sample_block_size = sample_size * channels;
 	payload_size = sample_block_size * ((sample_rate * service_interval_usec) / USEC_PER_SEC);
+
+	if (direction == UAOL_DIR_CAPTURE) {
+		/* Capture streams should ignore the format and capture all available bytes.
+		 * However, sio_credit_size describes only one packet, while a high-speed
+		 * endpoint may provide up to three packets per service interval. The driver
+		 * currently provides the maximum size of a single packet, not the maximum
+		 * payload size. Therefore, infer the maximum payload size by rounding the
+		 * format-derived payload size up to a whole number of packets.
+		 *
+		 * This prevents data loss at sample rates such as 44.1 kHz, where the payload
+		 * size varies between service intervals.
+		 */
+		payload_size = DIV_ROUND_UP(payload_size, sio_credit_size) * sio_credit_size;
+	}
 
 	pcms_ctl.full = sys_read64(UAOLxPCMSyCTL_ADDR(dp, stream));
 	pcms_ctl.part.si = uaol_intel_adsp_encode_service_interval(service_interval_usec);
@@ -683,7 +698,7 @@ static int uaol_intel_adsp_config(const struct device *dev, int stream, struct u
 
 	uaol_intel_adsp_program_format(dev, stream, cfg->sample_rate, cfg->channels,
 				       cfg->sample_bits, cfg->sio_credit_size,
-				       cfg->service_interval);
+				       cfg->service_interval, cfg->direction);
 
 	uaol_intel_adsp_program_rate_adjustment(dev, stream, cfg->sample_rate,
 						cfg->service_interval);

--- a/include/zephyr/drivers/uaol.h
+++ b/include/zephyr/drivers/uaol.h
@@ -24,6 +24,12 @@ struct uaol_capabilities {
 	uint32_t max_rx_fifo_size;       /**< Max RX FIFO size */
 };
 
+/** @brief UAOL stream/endpoint direction. */
+enum uaol_direction {
+	UAOL_DIR_PLAYBACK = 0, /**< Host-to-device USB endpoint */
+	UAOL_DIR_CAPTURE  = 1, /**< Device-to-host USB endpoint */
+};
+
 /** @brief UAOL stream configuration data. */
 struct uaol_config {
 	uint8_t xhci_bus;                /**< xHCI controller bus */
@@ -38,6 +44,7 @@ struct uaol_config {
 	uint32_t sio_credit_size;        /**< SIO credit packet size in bytes */
 	uint16_t fifo_start_offset;      /**< UAOL FIFO start address offset */
 	uint16_t channel_map;            /**< HDA link stream and channels mapping for UAOL FIFO */
+	enum uaol_direction direction;   /**< USB stream/endpoint direction */
 };
 
 /** @brief UAOL stream endpoint table entry. */


### PR DESCRIPTION
UAOL capture should ignore the audio format and capture all available bytes.

This prevents data loss when the payload size varies between service intervals, as it does for 44.1 kHz audio.