### PR TITLE
twister: skip token-pasted ZTEST names in the static scan

### DIFF
--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -244,9 +244,14 @@ def _find_new_ztest_testcases(search_area):
     Find regular ztest testcases like "ZTEST", "ZTEST_F" etc. Return
     testcases' names and eventually found warnings.
     """
+    # The negative lookahead rejects names built with the ## token-paste
+    # operator (e.g. ZTEST(suite, test_dma##idx##_m2m_loop)); those cannot be
+    # resolved statically, so registering the truncated name would create a
+    # phantom testcase that never runs. Such cases are still discovered at
+    # runtime from the harness output.
     testcase_regex = re.compile(
         br"^\s*(?:ZTEST|ZTEST_F|ZTEST_USER|ZTEST_USER_F)\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,"
-        br"\s*(?P<testcase_name>[a-zA-Z0-9_]+)\s*",
+        br"\s*(?P<testcase_name>[a-zA-Z0-9_]+)(?![a-zA-Z0-9_#])\s*",
         re.MULTILINE)
 
     return _find_ztest_testcases(search_area, testcase_regex)

--- a/scripts/tests/twister/test_data/testsuites/tests/test_e/test_ztest_token_paste.c
+++ b/scripts/tests/twister/test_data/testsuites/tests/test_e/test_ztest_token_paste.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ZTEST_SUITE(feature6, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST(feature6, test_normal_case);
+
+/*
+ * Cases generated with the ## token-paste operator (as in
+ * tests/drivers/dma/loop_transfer) cannot be resolved statically and must not
+ * be registered as testcases; otherwise a phantom "feature6.dma" case is
+ * created that never runs.
+ */
+#define DEFINE_LOOP_TESTS(idx, _)                                                                  \
+	ZTEST(feature6, test_dma##idx##_m2m_loop);
+
+LISTIFY(2, DEFINE_LOOP_TESTS, ())
+
+ztest_run_registered_test_suites(feature6);

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -98,6 +98,7 @@ def test_get_all_testsuites_short(class_testplan, all_testsuites_dict):
                       'test_d.check_1.unit_1b',
                       'test_e.check_1.feature5.1a',
                       'test_e.check_1.feature5.1b',
+                      'test_e.check_1.feature6.normal_case',
                       'test_config.main']
 
     assert sorted(plan.get_all_tests()) == sorted(expected_tests)

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -169,6 +169,25 @@ TESTDATA_2 = [
             ztest_suite_names = ['feature5']
         )
     ),
+    (
+        os.path.join(
+            'testsuites',
+            'tests',
+            'test_e',
+            'test_ztest_token_paste.c'
+        ),
+        ScanPathResult(
+            warnings=None,
+            # The ## token-pasted ZTEST cases must be skipped so no phantom
+            # 'feature6.dma' testcase is registered; only the literal case
+            # is picked up statically.
+            matches=['feature6.normal_case'],
+            has_registered_test_suites=False,
+            has_run_registered_test_suites=True,
+            has_test_main=False,
+            ztest_suite_names = ['feature6']
+        )
+    ),
 #    (
 #        os.path.join(
 #            'testsuites',
@@ -197,6 +216,7 @@ TESTDATA_2 = [
         'invalid ifdef with test_main',
         'registered testsuite',
         'new testsuite with registered run',
+        'new testsuite with token-pasted testcase names',
 #        'empty testsuite'
     ]
 )


### PR DESCRIPTION
## Problem

Twister's static ztest source scanner extracts `ZTEST()` testcase names
with the regex `[a-zA-Z0-9_]+`. When a case name is built with the `##`
token-paste operator — as in `tests/drivers/dma/loop_transfer`:

```c
#define DEFINE_DMA_M2M_LOOP_TESTS(idx, _) \
    ZTEST(dma_m2m_loop, test_dma##idx##_m2m_loop) ...
LISTIFY(DMA_TEST_DEV_COUNT, DEFINE_DMA_M2M_LOOP_TESTS, ())
```

the regex stops at the first `#` and captures `test_dma`. After the
`test_` prefix is stripped, twister registers a phantom subcase
`dma_m2m_loop.dma` that never runs — the real, fully expanded cases
(`test_dma0_m2m_loop`, ...) only exist after preprocessing. On hardware
runs this surfaces as a spurious warning even though the suite passes:

```
WARNING - A None status detected in instance .../drivers.dma.loop_transfer,
          test case drivers.dma.loop_transfer.dma_m2m_loop.dma
```

The same happens for `tests/drivers/dma/chan_blen_transfer`, which uses
the identical macro-generation pattern.

## Fix

Add a negative lookahead `(?![a-zA-Z0-9_#])` so a testcase name
immediately followed by a word character or `#` is not matched.
Token-pasted names are skipped by the static scan and no longer create
phantom subcases; the real cases continue to be discovered from the
harness output at runtime.

## Tests

Added a `scan_file` unit test with a suite that mixes a literal `ZTEST`
case and token-pasted, macro-generated cases; only the literal case is
returned. All existing `test_scan_file` cases still pass.
