### PR TITLE
samples: pmci: mctp: Unconditionaly enable USB device

### DIFF
--- a/samples/subsys/pmci/mctp/usb_endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/usb_endpoint/src/main.c
@@ -47,12 +47,10 @@ static int enable_usb_device_next(void)
 		return -ENODEV;
 	}
 
-	if (!usbd_can_detect_vbus(mctp_poc_usbd)) {
-		err = usbd_enable(mctp_poc_usbd);
-		if (err) {
-			LOG_ERR("Failed to enable device support");
-			return err;
-		}
+	err = usbd_enable(mctp_poc_usbd);
+	if (err) {
+		LOG_ERR("Failed to enable device support");
+		return err;
 	}
 
 	LOG_INF("USB device support enabled");


### PR DESCRIPTION
The MCTP USB endpoint sample stopped enumerating in FRDM-MCXN947 after VBUS detection support was enabled for NXP USB device controllers (commit 74bdd07f2c8a). While usbd_can_detect_vbus() now returns true for this board, but the sample never called usbd_enable(), since it always waited for a VBUS attach event that was expected to enable the device.

Use the simple fix of always enabling the device - this restores previous behaviour.

Fixes #117657

Assisted-by: Claude:claude-sonnet-5