### PR TITLE
soc: ch32v: support linking at a non-zero offset

### DIFF
--- a/soc/wch/ch32v/qingke_v4b/vector.S
+++ b/soc/wch/ch32v/qingke_v4b/vector.S
@@ -18,15 +18,14 @@ GTEXT(__initialize)
 
 SECTION_FUNC(vectors, ivt)
 	.option norvc
-	/* Jump to 0x08000008, into the main flash zone where j __start is */
-	lui	x5, 0x8000
-	jr	0x8(x5)
-	j       __start
+	lui     a0, %hi(__start)
+	jr      %lo(__start)(a0)
 	.rept   CONFIG_VECTOR_TABLE_SIZE
 	.word	_isr_wrapper
 	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 0xf
+	la      a0, ivt
+	ori     a0, a0, 0xf
 	csrw	mtvec, a0
-	j	__initialize
+	tail	__initialize


### PR DESCRIPTION
On reset, the CH32V series starts executing from address 0x0 which is aliased to the main flash. The startup code immediately jumps into the corresponding non-aliased address at 0x08000000. This assumes that the application is linked at the start of flash.

Add support for linking at a non-zero offset. This is required for boards like the Comu that use the first 2 KiB for a bootloader.

Tested on the bluepillplus_ch32v203. If this looks good I'll roll it out for the other Qingkes.