### PR TITLE
dts: wch: add the missing reset property for the ch32v203f8u

### DIFF
--- a/dts/riscv/wch/ch32v203/ch32v203f8u.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203f8u.dtsi
@@ -12,6 +12,7 @@
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			resets = <&rctl CH32_RESET(APB1, 17)>;
 			interrupt-parent = <&pfic>;
 			interrupts = <54>;
 			status = "disabled";


### PR DESCRIPTION
A previous PR added reset support for the UART but missed the 203f8u variant. Fix.