### PR TITLE
Fix clock references in samd5xe5x_j.dtsi

### DIFF
--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi
@@ -12,7 +12,7 @@
 			compatible = "microchip,tcc-g1";
 			reg = <0x42001000 0x2000>;
 			interrupts = <101 0>, <102 0>, <103 0>;
-			clocks = <&mclkperiphperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TCC3>,
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TCC3>,
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC3>;
 			clock-names = "mclk", "gclk";
 			max-bit-width = <16>;
@@ -23,7 +23,7 @@
 			compatible = "microchip,tc-g1";
 			reg = <0x42001400 0x400>;
 			interrupts = <111 0>;
-			clocks = <&mclkperiphperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC4>,
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC4>,
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC4>;
 			clock-names = "mclk", "gclk";
 			max-bit-width = <16>;
@@ -35,7 +35,7 @@
 			compatible = "microchip,tc-g1";
 			reg = <0x42001800 0x400>;
 			interrupts = <112 0>;
-			clocks = <&mclkperiphperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC5>,
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC5>,
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC5>;
 			clock-names = "mclk", "gclk";
 			max-bit-width = <16>;
@@ -47,7 +47,7 @@
 			compatible = "microchip,tcc-g1";
 			reg = <0x43001000 0x2000>;
 			interrupts = <104 0>, <105 0>, <106 0>;
-			clocks = <&mclkperiphperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TCC4>,
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TCC4>,
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC4>;
 			clock-names = "mclk", "gclk";
 			max-bit-width = <16>;


### PR DESCRIPTION
socs: the samd5xe5x_j.dtsi contained typo which was preventing compilation

Signed-off-by: Arsham Atonyan <arshamatonyan@gmail.com>