### PR TITLE
arch: arm: cortex_m: Separate saving stack pointer from coredump Kconfig

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -398,6 +398,12 @@ config CORTEX_M_DEBUG_MONITOR_HOOK
 	  Enable this option to configure debug monitor exception to low priority
 	  for debugging purposes.
 
+config CORTEX_M_DEBUG_SAVE_FAULT_SP
+	bool "Save fault stack pointer"
+	default y if DEBUG_COREDUMP
+	help
+	  Enable to save the stack pointer on a fault for debugging purposes.
+
 # enabled, which may increase ESF stacking requirements for
 # threads.
 config TEST_EXTRA_STACK_SIZE

--- a/arch/arm/core/cortex_m/coredump.c
+++ b/arch/arm/core/cortex_m/coredump.c
@@ -7,10 +7,9 @@
 #include <string.h>
 #include <zephyr/debug/coredump.h>
 #include <zephyr/kernel/thread.h>
+#include <cortex_m/exception.h>
 
 #define ARCH_HDR_VER 3
-
-uint32_t z_arm_coredump_fault_sp;
 
 struct arm_arch_block {
 	struct {

--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -22,6 +22,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/barrier.h>
 #include <cortex_m/debug.h>
+#include <cortex_m/exception.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
@@ -73,6 +74,10 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 #define SCB_CFSR_USGFAULTSR                                                                        \
 	(uint32_t)((SCB->CFSR & SCB_CFSR_USGFAULTSR_Msk) >> SCB_CFSR_USGFAULTSR_Pos)
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
+
+#ifdef CONFIG_CORTEX_M_DEBUG_SAVE_FAULT_SP
+uint32_t z_arm_coredump_fault_sp;
+#endif
 
 /**
  *

--- a/arch/arm/include/cortex_m/exception.h
+++ b/arch/arm/include/cortex_m/exception.h
@@ -232,7 +232,7 @@ static ALWAYS_INLINE void z_arm_clear_faults(void)
  */
 static ALWAYS_INLINE void z_arm_set_fault_sp(const struct arch_esf *esf, uint32_t exc_return)
 {
-#ifdef CONFIG_DEBUG_COREDUMP
+#ifdef CONFIG_CORTEX_M_DEBUG_SAVE_FAULT_SP
 	z_arm_coredump_fault_sp = POINTER_TO_UINT(esf);
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE) || defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	/* Gdb expects a stack pointer that does not include the exception stack frame in order to

--- a/tests/subsys/debug/coredump/tests.yaml
+++ b/tests/subsys/debug/coredump/tests.yaml
@@ -51,3 +51,20 @@ tests:
         - "E: #CD:4([dD])([0-9a-fA-F]+)"
         - "E: #CD:END#"
         - "k_sys_fatal_error_handler"
+  debug.coredump.cortex_m_save_fault_stack_pointer:
+    tags: coredump
+    ignore_faults: true
+    ignore_qemu_crash: true
+    filter: CONFIG_CPU_CORTEX_M
+    extra_configs:
+      - CONFIG_DEBUG_COREDUMP=n
+      - CONFIG_CORTEX_M_DEBUG_SAVE_FAULT_SP=y
+    arch_allow: arm
+    integration_platforms:
+      - mps2/an385
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Coredump: (.*)"
+        - "k_sys_fatal_error_handler"


### PR DESCRIPTION
Allow saving the stack pointer on a fatal error when DEBUG_COREDUMP is disabled. This allows projects to maintain debugging capabilities when RAM dumps are saved through different mechanisms than DEBUG_COREDUMP like retrieving through a debugger or saving RAM contents with a separate executable.