### PR TITLE
runners: jlink: Respect --reset option for attach command

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -455,6 +455,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                 client_cmd += ['-ex', 'monitor halt',
                                '-ex', 'monitor reset',
                                '-ex', 'load']
+            if command in ('debug', 'attach'):
                 if self.is_batch:
                     client_cmd += ['-ex', 'monitor go', '-ex', 'disconnect', '-ex', 'quit']
                 elif self.reset:


### PR DESCRIPTION
The --reset option was ignored for the 'attach' command. Issue a monitor reset on attach if --reset is passed to match the 'debug' command.