### PR TITLE
samples: llext: edk: Fix toolchain lookup

### DIFF
--- a/samples/subsys/llext/edk/ext1/toolchain.cmake
+++ b/samples/subsys/llext/edk/ext1/toolchain.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(CMAKE_C_COMPILER   arm-zephyr-eabi-gcc)
-set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi)
+set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi)

--- a/samples/subsys/llext/edk/ext2/toolchain.cmake
+++ b/samples/subsys/llext/edk/ext2/toolchain.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(CMAKE_C_COMPILER   arm-zephyr-eabi-gcc)
-set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi)
+set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi)

--- a/samples/subsys/llext/edk/ext3/toolchain.cmake
+++ b/samples/subsys/llext/edk/ext3/toolchain.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(CMAKE_C_COMPILER   arm-zephyr-eabi-gcc)
-set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi)
+set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi)

--- a/samples/subsys/llext/edk/k-ext1/toolchain.cmake
+++ b/samples/subsys/llext/edk/k-ext1/toolchain.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(CMAKE_C_COMPILER   arm-zephyr-eabi-gcc)
-set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi)
+set(CMAKE_FIND_ROOT_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi)


### PR DESCRIPTION
Zephyr SDK moved the GNU toolchains into a gnu/ subdirectory, so CMAKE_FIND_ROOT_PATH pointed at a path that no longer exists and the EDK extension builds fail.