### PR TITLE
cmake: extensions: document the generate_inc_file target helpers

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1011,8 +1011,8 @@ See :zephyr_file:`tests/application_development/gen_inc_file` for an example of 
 
 #]=======================================================================]
 function(generate_inc_file
-    source_file    # The source file to be converted to hex
-    generated_file # The generated file
+    source_file
+    generated_file
     )
   add_custom_command(
     OUTPUT ${generated_file}
@@ -1027,12 +1027,36 @@ function(generate_inc_file
     )
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: generate_inc_file_for_gen_target(<target> <source_file> <generated_file> <gen_target> ...)
+
+   Generate a file that can be included into the application at build time, and
+   make a target depend on the target that generates it.
+
+   Use this when a target generating ``generated_file`` already exists. To have
+   one created, use :cmake:command:`generate_inc_file_for_target` instead.
+
+   ``target``
+     The target that depends on the generated file
+
+   ``source_file``
+     The source file to be converted to hex
+
+   ``generated_file``
+     The generated file
+
+   ``gen_target``
+     The target that generates ``generated_file``
+
+   ``...``
+     Extra arguments are passed to file2hex.py
+
+#]=======================================================================]
 function(generate_inc_file_for_gen_target
-    target          # The cmake target that depends on the generated file
-    source_file     # The source file to be converted to hex
-    generated_file  # The generated file
-    gen_target      # The generated file target we depend on
-                    # Any additional arguments are passed on to file2hex.py
+    target
+    source_file
+    generated_file
+    gen_target
     )
   generate_inc_file(${source_file} ${generated_file} ${ARGN})
 
@@ -1042,11 +1066,32 @@ function(generate_inc_file_for_gen_target
   add_dependencies(${target} ${gen_target})
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: generate_inc_file_for_target(<target> <source_file> <generated_file> ...)
+
+   Generate a file that can be included into the application at build time, and
+   make a target depend on it.
+
+   A target is created to run the conversion, and ``target`` is made to depend on
+   it, so that ``generated_file`` exists before anything in ``target`` is built.
+
+   ``target``
+     The target that depends on the generated file
+
+   ``source_file``
+     The source file to be converted to hex
+
+   ``generated_file``
+     The generated file
+
+   ``...``
+     Extra arguments are passed to file2hex.py
+
+#]=======================================================================]
 function(generate_inc_file_for_target
-    target          # The cmake target that depends on the generated file
-    source_file     # The source file to be converted to hex
-    generated_file  # The generated file
-                    # Any additional arguments are passed on to file2hex.py
+    target
+    source_file
+    generated_file
     )
   # Ensure 'generated_file' is generated before 'target' by creating a
   # 'custom_target' for it and setting up a dependency between the two


### PR DESCRIPTION
`cmake/modules/extensions.cmake` documents the `generate_inc_*` family with a single `cmake:signature` block, for `generate_inc_file()`. The two variants that take a target carry ordinary `#` comments only, so the [CMake reference](https://docs.zephyrproject.org/latest/build/cmake-ref/module/extensions.html) — which is generated by `.. cmake-module::` harvesting the `#[===[.rst:` blocks — shows neither of them.

That leaves the reference documenting the one nobody calls and omitting the one everybody does:

| Function | In-tree call sites | In the reference |
|---|---|---|
| `generate_inc_file()` | 0 | yes |
| `generate_inc_file_for_target()` | 67 | no |
| `generate_inc_file_for_gen_target()` | 0 | no |

This adds a block for each of the two, in the same style as the rest of the file: one bracket comment per function, a definition list per parameter, and a `:cmake:command:` cross-reference between the two so the "which one do I want" question is answerable from either page.

### Rendered

Built with the vendored `moderncmakedomain` extension against the real `doc/build/cmake-ref/module/extensions.rst`; all three now appear under the existing `generate_inc_*` heading, and the cross-reference resolves:

```
generate_inc_file( <source_file> <generated_file> ... )
generate_inc_file_for_gen_target( <target> <source_file> <generated_file> <gen_target> ... )
generate_inc_file_for_target( <target> <source_file> <generated_file> ... )
```

Documentation only, no behaviour change.
