### PR TITLE
ci: workflows: set git http version to HTTP/1.1

### DIFF
--- a/.github/actions/zephyr-ci-env/action.yml
+++ b/.github/actions/zephyr-ci-env/action.yml
@@ -34,6 +34,7 @@ runs:
         BASE_REF: ${{ inputs.base-ref }}
         GROUP_FILTER: ${{ inputs.group-filter }}
       run: |
+        git config --global http.version HTTP/1.1
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           git config --global user.email "bot@zephyrproject.org"
           git config --global user.name "Zephyr Builder"

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -161,6 +161,7 @@ jobs:
           export BSIM_VERSION=$( west list bsim -f {revision} )
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
+          git config --global http.version HTTP/1.1
           git fetch -n origin ${BSIM_VERSION}
           git -c advice.detachedHead=false checkout ${BSIM_VERSION}
           west update

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -86,6 +86,7 @@ jobs:
 
       - name: west setup
         run: |
+          git config --global http.version HTTP/1.1
           west init -l . || true
           west update 1> west.update.log || west update 1> west.update-2.log
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -62,6 +62,7 @@ jobs:
 
     - name: west setup
       run: |
+        git config --global http.version HTTP/1.1
         west init -l . || true
         west config manifest.group-filter -- +ci,-optional
         west update -o=--depth=1 -n 2>&1 1> west.update.log || west update -o=--depth=1 -n 2>&1 1> west.update2.log

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -230,6 +230,7 @@ jobs:
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
           git -c advice.detachedHead=false checkout ${BSIM_VERSION}
+          git config --global http.version HTTP/1.1
           west update
           make everything -s -j 8
 


### PR DESCRIPTION
Workaround to fix issue with unauthenticated clone of a public repo.
Seems like a GH issue, we are still investigating.

see https://github.com/orgs/community/discussions/206581
