### PR TITLE
debug: coredump: fix flash header ID validation logic

### DIFF
--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -262,7 +262,7 @@ static int process_stored_dump(data_read_cb_t cb, void *cb_arg)
 	}
 
 	/* Verify header signature */
-	if ((hdr.id[0] != 'C') && (hdr.id[1] != 'D')) {
+	if ((hdr.id[0] != 'C') || (hdr.id[1] != 'D')) {
 		ret = 0;
 		goto out;
 	}
@@ -320,7 +320,7 @@ static int get_stored_dump(off_t off, uint8_t *dst, size_t len)
 	}
 
 	/* Verify header signature */
-	if ((hdr.id[0] != 'C') && (hdr.id[1] != 'D')) {
+	if ((hdr.id[0] != 'C') || (hdr.id[1] != 'D')) {
 		ret = 0;
 		goto out;
 	}


### PR DESCRIPTION
Header signature checks used &&, so a dump was rejected only when both ID bytes were wrong. Partial matches such as "C\0" or "\0D" were treated as valid and could make verify/find/print succeed on garbage data.

Require both 'C' and 'D' in process_stored_dump() and get_stored_dump().