### PR TITLE
usb: device_next: fix class init/shutdown called multiple times

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -334,8 +334,18 @@ struct usbd_cctx_vendor_req {
 	uint8_t len;
 };
 
-/** USB Class instance registered flag */
+/*
+ * Class instance lifecycle state bits. The registered bit is stored per
+ * speed in each `struct usbd_class_node`, while the initialized bit is
+ * stored once per class instance in `struct usbd_class_data`, which may
+ * be shared by the FS and HS nodes.
+ */
+
+/** Flag set in a per-speed class node once its class is registered */
 #define USBD_CCTX_REGISTERED		0
+
+/** Flag set in a class data once its class instance has been initialized */
+#define USBD_CCTX_INITIALIZED		1
 
 struct usbd_class_data;
 
@@ -404,6 +414,8 @@ struct usbd_class_data {
 	const struct usbd_cctx_vendor_req *v_reqs;
 	/** Pointer to private data */
 	void *priv;
+	/** Bitmap of the class instance lifecycle state */
+	atomic_t state;
 };
 
 /**

--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -265,6 +265,37 @@ static int usbd_class_remove(struct usbd_context *const uds_ctx,
 	return 0;
 }
 
+/*
+ * Check whether the given class data is still referenced by any registered
+ * class node. The same c_data can be shared by the FS and HS nodes, so
+ * shutdown and uds_ctx cleanup must only happen once the last registered
+ * reference is removed.
+ */
+static bool usbd_class_data_registered(struct usbd_class_data *const c_data)
+{
+	/* TODO: The use of atomic here does not make this code thread safe.
+	 * The atomic should be changed to something else.
+	 */
+	if (USBD_SUPPORTS_HIGH_SPEED) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs,
+						 usbd_class_node, i) {
+			if ((i->c_data == c_data) &&
+			    atomic_test_bit(&i->state, USBD_CCTX_REGISTERED)) {
+				return true;
+			}
+		}
+	}
+
+	STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_fs, usbd_class_node, i) {
+		if ((i->c_data == c_data) &&
+		    atomic_test_bit(&i->state, USBD_CCTX_REGISTERED)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 int usbd_class_remove_all(struct usbd_context *const uds_ctx,
 			  const enum usbd_speed speed,
 			  const uint8_t cfg)
@@ -281,8 +312,20 @@ int usbd_class_remove_all(struct usbd_context *const uds_ctx,
 	while ((node = sys_slist_get(&cfg_nd->class_list))) {
 		c_nd = CONTAINER_OF(node, struct usbd_class_node, node);
 		atomic_clear_bit(&c_nd->state, USBD_CCTX_REGISTERED);
-		usbd_class_shutdown(c_nd->c_data);
-		c_nd->c_data->uds_ctx = NULL;
+
+		/*
+		 * The same c_data may be shared by the FS and HS nodes. Only
+		 * shut it down and clear its context when the last registered
+		 * reference is gone, otherwise shutdown would be called more
+		 * than once.
+		 */
+		if (!usbd_class_data_registered(c_nd->c_data)) {
+			usbd_class_shutdown(c_nd->c_data);
+			atomic_clear_bit(&c_nd->c_data->state,
+					 USBD_CCTX_INITIALIZED);
+			c_nd->c_data->uds_ctx = NULL;
+		}
+
 		LOG_DBG("Remove class node %p from configuration %u", c_nd, cfg);
 	}
 
@@ -404,7 +447,6 @@ int usbd_unregister_class(struct usbd_context *const uds_ctx,
 {
 	struct usbd_class_node *c_nd;
 	struct usbd_class_data *c_data;
-	bool can_release_data = true;
 	int ret;
 
 	c_nd = usbd_class_node_get(name, speed);
@@ -428,35 +470,19 @@ int usbd_unregister_class(struct usbd_context *const uds_ctx,
 		goto unregister_class_error;
 	}
 
-	/* TODO: The use of atomic here does not make this code thread safe.
-	 * The atomic should be changed to something else.
-	 */
-	if (USBD_SUPPORTS_HIGH_SPEED && speed == USBD_SPEED_HS) {
-		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs,
-						 usbd_class_node, i) {
-			if ((i->c_data == c_nd->c_data) &&
-			    atomic_test_bit(&i->state, USBD_CCTX_REGISTERED)) {
-				can_release_data = false;
-				break;
-			}
-		}
-	} else {
-		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_fs,
-						 usbd_class_node, i) {
-			if ((i->c_data == c_nd->c_data) &&
-			    atomic_test_bit(&i->state, USBD_CCTX_REGISTERED)) {
-				can_release_data = false;
-				break;
-			}
-		}
-	}
-
 	ret = usbd_class_remove(uds_ctx, c_nd, speed, cfg);
 	if (ret == 0) {
 		atomic_clear_bit(&c_nd->state, USBD_CCTX_REGISTERED);
-		usbd_class_shutdown(c_nd->c_data);
 
-		if (can_release_data) {
+		/*
+		 * The same c_data may be shared by the FS and HS nodes. Only
+		 * shut it down and release its context when no other registered
+		 * node references it, otherwise shutdown would be called more
+		 * than once.
+		 */
+		if (!usbd_class_data_registered(c_data)) {
+			usbd_class_shutdown(c_data);
+			atomic_clear_bit(&c_data->state, USBD_CCTX_INITIALIZED);
 			c_data->uds_ctx = NULL;
 		}
 	}

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -290,12 +290,20 @@ static int usbd_pre_init(void)
 	k_thread_name_set(&usbd_thread_data, "usbd");
 
 	LOG_DBG("Available USB class iterators:");
+	/*
+	 * Reset the lifecycle state of both the per-speed node (registered
+	 * flag) and the shared class data (initialized flag). The class data
+	 * state is sticky once set, so clearing it here guarantees a clean
+	 * slate even if the instance was not shut down before.
+	 */
 	STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_fs, usbd_class_node, c_nd) {
 		atomic_set(&c_nd->state, 0);
+		atomic_set(&c_nd->c_data->state, 0);
 		LOG_DBG("\t%p->%p, name %s", c_nd, c_nd->c_data, c_nd->c_data->name);
 	}
 	STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs, usbd_class_node, c_nd) {
 		atomic_set(&c_nd->state, 0);
+		atomic_set(&c_nd->c_data->state, 0);
 		LOG_DBG("\t%p->%p, name %s", c_nd, c_nd->c_data, c_nd->c_data->name);
 	}
 

--- a/subsys/usb/device_next/usbd_init.c
+++ b/subsys/usb/device_next/usbd_init.c
@@ -222,10 +222,22 @@ static int init_configuration(struct usbd_context *const uds_ctx,
 			return ret;
 		}
 
-		ret = usbd_class_init(c_nd->c_data);
-		if (ret != 0) {
-			LOG_ERR("Failed to initialize class instance");
-			return ret;
+		/*
+		 * The same c_data may be shared by the FS and HS nodes, so its
+		 * init callback is guarded by a flag owned by the class data
+		 * itself: it must run once per class instance even though the
+		 * endpoint and interface assignment is done per node.
+		 */
+		if (!atomic_test_and_set_bit(&c_nd->c_data->state,
+					     USBD_CCTX_INITIALIZED)) {
+			ret = usbd_class_init(c_nd->c_data);
+			if (ret != 0) {
+				/* Roll back so that a later retry can init it */
+				atomic_clear_bit(&c_nd->c_data->state,
+						 USBD_CCTX_INITIALIZED);
+				LOG_ERR("Failed to initialize class instance");
+				return ret;
+			}
 		}
 
 		LOG_DBG("Init class node %p, descriptor length %zu",


### PR DESCRIPTION
### Summary

`USBD_DEFINE_CLASS` creates a single `usbd_class_data` that is shared by the Full-Speed and High-Speed class nodes, but the `.init` and `.shutdown` callbacks were invoked once per node. A class registered at both speeds therefore had both callbacks called twice, which leaks or overwrites the resources of the first `.init` call and releases them twice on `.shutdown`. `usbd_unregister_class()` also never released `uds_ctx` because its reference scan ran before the node was removed.

### Fix

Initialization is now tracked with a `USBD_CCTX_INITIALIZED` flag stored in `usbd_class_data` and set with `atomic_test_and_set_bit()` in `init_configuration()`, so `.init` runs exactly once per class instance regardless of which speed node is handled first and is rolled back when it fails. `usbd_class_remove_all()` and `usbd_unregister_class()` clear the node registered flag first and then check `usbd_class_data_registered()`; the instance is shut down, the flag is cleared and `uds_ctx` is dropped only when the last registered node is removed, which also fixes the `uds_ctx` leak in `usbd_unregister_class()`. `usbd_pre_init()` resets the state of both the per-speed nodes and the shared class data at startup.