### PR TITLE
pm: device_runtime: Always run pm_device_runtime_put_async for ISR_SAFE

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -480,7 +480,6 @@ int pm_device_runtime_put(const struct device *dev)
 
 int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay)
 {
-#ifdef CONFIG_PM_DEVICE_RUNTIME_ASYNC
 	int ret;
 
 	if (dev->pm_base == NULL) {
@@ -496,15 +495,16 @@ int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay)
 
 		k_spin_unlock(&pm_sync->lock, k);
 	} else {
+#ifdef CONFIG_PM_DEVICE_RUNTIME_ASYNC
 		ret = runtime_suspend(dev, true, delay);
+#else
+		LOG_WRN("Function not available");
+		return -ENOSYS;
+#endif /* CONFIG_PM_DEVICE_RUNTIME_ASYNC */
 	}
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_put_async, dev, delay, ret);
 
 	return ret;
-#else
-	LOG_WRN("Function not available");
-	return -ENOSYS;
-#endif /* CONFIG_PM_DEVICE_RUNTIME_ASYNC */
 }
 
 __boot_func

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -254,11 +254,7 @@ ZTEST(device_runtime_api, test_unsupported)
 	zassert_equal(pm_device_runtime_disable(dev), -ENOTSUP, "");
 	zassert_equal(pm_device_runtime_get(dev), 0, "");
 	zassert_equal(pm_device_runtime_put(dev), 0, "");
-#ifdef CONFIG_PM_DEVICE_RUNTIME_ASYNC
 	zassert_equal(pm_device_runtime_put_async(dev, K_NO_WAIT), 0, "");
-#else
-	zassert_equal(pm_device_runtime_put_async(dev, K_NO_WAIT), -ENOSYS, "");
-#endif
 }
 
 int dev_pm_control(const struct device *dev, enum pm_device_action action)


### PR DESCRIPTION
When CONFIG_PM_DEVICE_RUNTIME_ASYNC=n, allow to call pm_device_runtime_put_async is device is ISR_SAFE. In that case asynchronous call is done synchronously anyway.

It allows to disable CONFIG_PM_DEVICE_RUNTIME_ASYNC and safe space for applications where all devices are ISR_SAFE but driver uses pm_device_runtime_put_async because in some configurations devices are not ISR SAFE.