### PR TITLE
Bluetooth: Classic: HFP AG: accept AT+CCWA regardless of 3-way negotiation

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -3336,10 +3336,6 @@ static int bt_hfp_ag_ccwa_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 	int err;
 	uint32_t value;
 
-	if (!BOTH_SUPT_FEAT(ag, BT_HFP_HF_FEATURE_3WAY_CALL, BT_HFP_AG_FEATURE_3WAY_CALL)) {
-		return -ENOEXEC;
-	}
-
 	if (!is_char(buf, '=')) {
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
AT+CCWA only toggles the call-waiting notification switch; whether the AG actually emits +CCWA is decided later where an incoming second call is delivered, guarded by the 3-way calling support and the CCWA flag.

Gating the command itself on the negotiated 3-way feature makes the AG answer +CME ERROR to an AT+CCWA enable request whenever either side did not advertise 3-way calling, which is not required by the HFP spec.

Discovered while qualifying the HFP AG role with PTS: HFP/AG/DIS/BV-01-C sends AT+CCWA=1, expects OK, but receives +CME ERROR.