### PR TITLE
drivers: timer: nrf_rtc_timer: Only wait for the RTC clear when needed

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -747,16 +747,20 @@ static int sys_clock_driver_init(void)
 		    rtc_nrf_isr, 0, 0);
 	irq_enable(RTC_IRQn);
 
-	/* We need a delay of 46 usec between the CLEAR/START event, otherwise
-	 * we may seen a non-zero value for RTC, which will grip the whole
-	 * "tick counting machinery".
-	 * This can happen when the RTC was used by a bootloader before
-	 * Zephyr starts.
-	 *
-	 * See: NRF52840 RTC spec, section "TASK and EVENT jitter/delay"
+	/* The CLEAR task takes up to 46 us to take effect (nRF52840 Product
+	 * Specification, RTC "TASK and EVENT jitter/delay"). If a bootloader
+	 * left the RTC running and START follows before then, the counter
+	 * still holds its old value when timer_core_init() reads it, which
+	 * gets treated as a wrap and pushes the first timeout far into the
+	 * future. Only clear and wait when the counter holds such a value:
+	 * on a cold boot, and on the simulated targets where tasks take
+	 * effect immediately, it reads zero and the wait would only shift
+	 * the tick phase.
 	 */
-	nrfy_rtc_task_trigger(RTC, NRF_RTC_TASK_CLEAR);
-	k_busy_wait(46);
+	if (nrfy_rtc_counter_get(RTC) != 0) {
+		nrfy_rtc_task_trigger(RTC, NRF_RTC_TASK_CLEAR);
+		k_busy_wait(46);
+	}
 	nrfy_rtc_task_trigger(RTC, NRF_RTC_TASK_START);
 
 	int_mask = BIT_MASK(CHAN_COUNT);


### PR DESCRIPTION
#117896 (98500853d9ef) added an unconditional 46 µs busy wait between the RTC CLEAR and START tasks so that a counter value left behind by a bootloader is gone before `timer_core_init()` reads it. On a cold boot the counter is already zero, and on the simulated nRF targets tasks take effect immediately, so there the wait only starts the system clock 46 µs later. That shifts the kernel tick phase relative to the radio timeline, and on `nrf52_bsim` it made `tests.bsim.bluetooth.mesh.bridge` (`brg_net_key_refresh.sh`) fail with the seed CI uses — every PR's bsim-test run has failed on that scenario since the merge (e.g. https://github.com/zephyrproject-rtos/zephyr/actions/runs/33720043137/job/100537133398). Bisected locally to that commit; its parent passes.

This reads the counter before CLEAR and only waits when it is non-zero, which is the case the wait exists for. Verified on an nRF52 DK with a `PRE_KERNEL_1` hook that starts LFCLK and RTC1 and lets the counter run before the driver initializes: the driver sees the old value before and right after CLEAR (the register keeps returning it for up to 46 µs), zero after the wait, and `k_msleep()`/uptime behave as on a cold boot. With the change the bsim scenario passes again with the default seed and with `-rs=1..4`.

The mesh scenario is timing sensitive on its own — it also fails for `-rs=8` on the commit before #117896 — which is reported separately in #118188.
