### PR TITLE
net: lib: coap: Fix block-wise ./well-known/core serving and add ETag

### DIFF
--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -20,12 +20,17 @@ config COAP_TEST_API_ENABLE
 
 config COAP_WELL_KNOWN_BLOCK_WISE
 	bool "CoAP ./well-known/core services block wise support"
+	imply SYS_HASH_FUNC32
 	help
 	  This option enables the block wise support of CoAP response
 	  to ./well-known/core request. Without this option all resource's
 	  information will be sent in a single IP packet (can be multiple
 	  fragments depends on MTU size). This will be useful in mesh kind
 	  of networks.
+
+	  When CONFIG_SYS_HASH_FUNC32 is enabled, the responses include an
+	  ETag option, so clients can verify that the blocks they reassemble
+	  belong to the same representation (RFC 7959, section 2.4).
 
 config COAP_WELL_KNOWN_BLOCK_WISE_SIZE
 	int "CoAP ./well-known/core services block wise support"

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -15,6 +15,7 @@ LOG_MODULE_DECLARE(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <errno.h>
 
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/hash_function.h>
 
 #include <zephyr/sys/printk.h>
 
@@ -178,6 +179,49 @@ static bool match_queries_resource(const struct coap_resource *resource,
 #if defined(CONFIG_COAP_WELL_KNOWN_BLOCK_WISE)
 
 #define MAX_BLOCK_WISE_TRANSFER_SIZE 2048
+
+static uint32_t hash_combine_str(uint32_t seed, const char *str)
+{
+	/* Boost-style hash combine, the constant is the 32-bit golden ratio */
+	return seed ^ (sys_hash32(str, strlen(str)) + 0x9e3779b9U + (seed << 6) + (seed >> 2));
+}
+
+/* The link-format document is regenerated for every block, so derive an ETag
+ * from the inputs that determine its content. It lets clients verify that the
+ * blocks they reassemble belong to the same representation
+ * (RFC 7959, section 2.4).
+ */
+static uint32_t well_known_core_etag(const struct coap_resource *resources, size_t resources_len,
+				     const struct coap_option *query, unsigned int num_queries)
+{
+	uint32_t etag = 0U;
+
+	for (size_t i = 0; i < resources_len; i++) {
+		const struct coap_core_metadata *meta = resources[i].metadata;
+
+		if (!match_queries_resource(&resources[i], query, num_queries)) {
+			continue;
+		}
+
+		for (const char * const *p = resources[i].path; p != NULL && *p != NULL; p++) {
+			etag = hash_combine_str(etag, *p);
+		}
+
+		/* Separate the path segments from the attributes, like ">" does
+		 * in the document, so that a segment moving between the two
+		 * lists, or to the next resource, changes the ETag.
+		 */
+		etag = hash_combine_str(etag, ">");
+
+		if (meta != NULL && meta->attributes != NULL) {
+			for (const char * const *attr = meta->attributes; *attr != NULL; attr++) {
+				etag = hash_combine_str(etag, *attr);
+			}
+		}
+	}
+
+	return etag;
+}
 
 enum coap_block_size default_block_size(void)
 {
@@ -496,6 +540,17 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 			     tkl, token, COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		return r;
+	}
+
+	if (IS_ENABLED(CONFIG_SYS_HASH_FUNC32)) {
+		uint32_t etag = well_known_core_etag(resources, resources_len,
+						     &query, num_queries);
+
+		r = coap_packet_append_option(response, COAP_OPTION_ETAG,
+					      (const uint8_t *)&etag, sizeof(etag));
+		if (r < 0) {
+			return r;
+		}
 	}
 
 	r = coap_append_option_int(response, COAP_OPTION_CONTENT_FORMAT,

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -22,21 +22,6 @@ LOG_MODULE_DECLARE(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <zephyr/net/coap.h>
 #include <zephyr/net/coap_link_format.h>
 
-static inline bool append_u8(struct coap_packet *cpkt, uint8_t data)
-{
-	if (!cpkt) {
-		return false;
-	}
-
-	if (cpkt->max_len - cpkt->offset < 1) {
-		return false;
-	}
-
-	cpkt->data[cpkt->offset++] = data;
-
-	return true;
-}
-
 static inline bool append(struct coap_packet *cpkt, const uint8_t *data, uint16_t len)
 {
 	if (!cpkt || !data) {
@@ -610,6 +595,21 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 }
 
 #else
+
+static inline bool append_u8(struct coap_packet *cpkt, uint8_t data)
+{
+	if (!cpkt) {
+		return false;
+	}
+
+	if (cpkt->max_len - cpkt->offset < 1) {
+		return false;
+	}
+
+	cpkt->data[cpkt->offset++] = data;
+
+	return true;
+}
 
 static int format_uri(const char * const *path, struct coap_packet *response)
 {

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -438,7 +438,7 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 				 struct coap_packet *response,
 				 uint8_t *data, uint16_t len)
 {
-	static struct coap_block_context ctx;
+	struct coap_block_context ctx;
 	struct coap_option query;
 	unsigned int num_queries;
 	size_t offset;
@@ -447,25 +447,36 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 	uint16_t id;
 	uint8_t tkl;
 	int r;
+	int block2;
 	bool more = false, first = true;
 
 	if (!resources || !request || !response || !data || !len) {
 		return -EINVAL;
 	}
 
-	if (ctx.total_size == 0) {
-		/* We have to iterate through resources and it's attributes,
-		 * total size is unknown, so initialize it to
-		 * MAX_BLOCK_WISE_TRANSFER_SIZE and update it according to
-		 * offset.
-		 */
-		coap_block_transfer_init(&ctx, default_block_size(),
-					 MAX_BLOCK_WISE_TRANSFER_SIZE);
+	/* The response is regenerated for every block and the block context is
+	 * derived from the request alone, so no state is shared between calls
+	 * and concurrent transfers from different clients stay independent.
+	 * The total size is unknown until the last block; the
+	 * MAX_BLOCK_WISE_TRANSFER_SIZE placeholder keeps the more flag set
+	 * until clear_more_flag() corrects the final block.
+	 */
+	coap_block_transfer_init(&ctx, default_block_size(),
+				 MAX_BLOCK_WISE_TRANSFER_SIZE);
+
+	/* Honor a smaller block size negotiated by the client on an earlier
+	 * block, which coap_update_from_block() would otherwise reject as a
+	 * size mismatch.
+	 */
+	block2 = coap_get_option_int(request, COAP_OPTION_BLOCK2);
+	if (block2 >= 0) {
+		ctx.block_size = MIN((enum coap_block_size)GET_BLOCK_SIZE(block2),
+				     ctx.block_size);
 	}
 
 	r = coap_update_from_block(request, &ctx);
 	if (r < 0) {
-		goto end;
+		return r;
 	}
 
 	id = coap_header_get_id(request);
@@ -476,7 +487,7 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 	 */
 	r = coap_find_options(request, COAP_OPTION_URI_QUERY, &query, 1);
 	if (r < 0) {
-		goto end;
+		return r;
 	}
 
 	num_queries = r;
@@ -484,23 +495,23 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 	r = coap_packet_init(response, data, len, COAP_VERSION_1, COAP_TYPE_ACK,
 			     tkl, token, COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
-		goto end;
+		return r;
 	}
 
 	r = coap_append_option_int(response, COAP_OPTION_CONTENT_FORMAT,
 				   COAP_CONTENT_FORMAT_APP_LINK_FORMAT);
 	if (r < 0) {
-		goto end;
+		return r;
 	}
 
 	r = coap_append_block2_option(response, &ctx);
 	if (r < 0) {
-		goto end;
+		return r;
 	}
 
 	r = coap_packet_append_payload_marker(response);
 	if (r < 0) {
-		goto end;
+		return r;
 	}
 
 	offset = 0;
@@ -522,14 +533,14 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 			r = append_to_coap_pkt(response, ",", 1, &remaining,
 					       &offset, ctx.current);
 			if (!r) {
-				goto end;
+				return r;
 			}
 		}
 
 		r = format_resource(&resources[i], response, &remaining, &offset,
 				    ctx.current, &more);
 		if (r < 0) {
-			goto end;
+			return r;
 		}
 	}
 
@@ -537,14 +548,7 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 	 * appended. So update only 'more' flag.
 	 */
 	if (!more) {
-		ctx.total_size = offset;
 		r = clear_more_flag(response);
-	}
-
-end:
-	/* So it's a last block, reset context */
-	if (!more) {
-		(void)memset(&ctx, 0, sizeof(ctx));
 	}
 
 	return r;

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -322,7 +322,8 @@ static int format_attributes(const char * const *attributes,
 	}
 
 	for (attr = attributes; *attr; attr++) {
-		int attr_len;
+		size_t attr_len;
+		size_t attr_offset;
 
 		res = append_to_coap_pkt(response, ";", 1,
 					 remaining, offset, current);
@@ -336,11 +337,22 @@ static int format_attributes(const char * const *attributes,
 		}
 
 		attr_len = strlen(*attr);
+		attr_offset = *offset;
 
 		res = append_to_coap_pkt(response, *attr, attr_len,
 					 remaining, offset, current);
 		if (!res) {
 			return -ENOMEM;
+		}
+
+		/* The offset advances by less than the attribute length only
+		 * when the attribute was cut short by the block boundary. The
+		 * remainder belongs in the next block, even when this is the
+		 * last attribute of the last resource.
+		 */
+		if (*offset - attr_offset < attr_len) {
+			*more = true;
+			return 0;
 		}
 
 		if (*(attr + 1) && !*remaining) {

--- a/tests/net/lib/coap/src/wellknown.c
+++ b/tests/net/lib/coap/src/wellknown.c
@@ -1,0 +1,232 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Basalte bv
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+
+#include <zephyr/net/coap.h>
+#include <zephyr/net/coap_link_format.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/ztest.h>
+
+#if defined(CONFIG_COAP_WELL_KNOWN_BLOCK_WISE)
+
+#define WK_BUF_SIZE 256U
+
+#define WK_DEFAULT_BLOCK_SIZE CONFIG_COAP_WELL_KNOWN_BLOCK_WISE_SIZE
+
+static const char * const path_a[] = { "large", NULL };
+static const char * const attrs_a[] = { "rt=\"observe\"", "if=\"core.s\"", NULL };
+static struct coap_core_metadata meta_a = { .attributes = attrs_a };
+
+static const char * const path_b[] = { "location", "1", NULL };
+
+static const char * const path_c[] = { "switch", NULL };
+static const char * const attrs_c[] = { "rt=\"actuator\"", NULL };
+static struct coap_core_metadata meta_c = { .attributes = attrs_c };
+
+static struct coap_resource test_resources[] = {
+	{ .path = path_a, .metadata = &meta_a },
+	{ .path = path_b },
+	{ .path = path_c, .metadata = &meta_c },
+};
+
+static const char expected_doc[] =
+	"</large>;rt=\"observe\";if=\"core.s\",</location/1>,</switch>;rt=\"actuator\"";
+
+/* The tests request blocks of up to 32 bytes and expect the document to span
+ * multiple blocks of the default size.
+ */
+BUILD_ASSERT(WK_DEFAULT_BLOCK_SIZE >= 32, "Tests request blocks of up to 32 bytes");
+BUILD_ASSERT(sizeof(expected_doc) - 1U > WK_DEFAULT_BLOCK_SIZE,
+	     "Document must span multiple blocks");
+
+struct wk_transfer {
+	uint8_t doc[WK_BUF_SIZE];
+	size_t len;
+	uint8_t etag[4];
+};
+
+/* Issue a .well-known/core GET, with a Block2 option when block_num >= 0 */
+static int well_known_req(struct coap_packet *response, uint8_t *buf, uint16_t buf_len,
+			  size_t num_resources, int block_num, enum coap_block_size size)
+{
+	struct coap_packet request;
+	uint8_t req_buf[64];
+	int r;
+
+	r = coap_packet_init(&request, req_buf, sizeof(req_buf), COAP_VERSION_1, COAP_TYPE_CON,
+			     COAP_TOKEN_MAX_LEN, coap_next_token(), COAP_METHOD_GET,
+			     coap_next_id());
+	zassert_equal(r, 0, "Failed to init request");
+
+	if (block_num >= 0) {
+		r = coap_append_option_int(&request, COAP_OPTION_BLOCK2,
+					   (block_num << 4) | size);
+		zassert_equal(r, 0, "Failed to append block2 option");
+	}
+
+	return coap_well_known_core_get_len(test_resources, num_resources, &request, response,
+					    buf, buf_len);
+}
+
+/* Fetch one block into the transfer, verify its options, return the more flag */
+static bool fetch_block(struct wk_transfer *tr, int block_num, enum coap_block_size size)
+{
+	struct coap_packet response;
+	struct coap_packet parsed;
+	struct coap_option etag_opt = { 0 };
+	uint8_t buf[WK_BUF_SIZE];
+	const uint8_t *payload;
+	uint16_t payload_len;
+	int block2;
+	int r;
+
+	r = well_known_req(&response, buf, sizeof(buf), ARRAY_SIZE(test_resources), block_num,
+			   size);
+	zassert_equal(r, 0, "Well-known request failed (%d)", r);
+
+	r = coap_packet_parse(&parsed, buf, response.offset, NULL, 0U);
+	zassert_equal(r, 0, "Failed to parse response (%d)", r);
+
+	block2 = coap_get_option_int(&parsed, COAP_OPTION_BLOCK2);
+	zassert_true(block2 >= 0, "No block2 option in response");
+	zassert_equal(GET_BLOCK_NUM(block2), block_num, "Unexpected block number");
+	zassert_equal(GET_BLOCK_SIZE(block2), size, "Unexpected block size");
+
+	if (IS_ENABLED(CONFIG_SYS_HASH_FUNC32)) {
+		r = coap_find_options(&parsed, COAP_OPTION_ETAG, &etag_opt, 1U);
+		zassert_equal(r, 1, "No ETag option in response");
+		zassert_equal(etag_opt.len, sizeof(tr->etag), "Unexpected ETag length");
+
+		if (block_num == 0) {
+			memcpy(tr->etag, etag_opt.value, sizeof(tr->etag));
+		} else {
+			zassert_mem_equal(etag_opt.value, tr->etag, sizeof(tr->etag),
+					  "ETag changed during transfer");
+		}
+	}
+
+	payload = coap_packet_get_payload(&parsed, &payload_len);
+	zassert_not_null(payload, "No payload in response");
+	zassert_true(tr->len + payload_len <= sizeof(tr->doc), "Transfer too large");
+	zassert_equal(tr->len, (size_t)block_num * coap_block_size_to_bytes(size),
+		      "Unexpected payload offset");
+
+	memcpy(&tr->doc[tr->len], payload, payload_len);
+	tr->len += payload_len;
+
+	return GET_MORE(block2);
+}
+
+ZTEST(coap_wellknown, test_blockwise_reassembly)
+{
+	struct wk_transfer tr = { 0 };
+	bool more = true;
+
+	for (int i = 0; more; i++) {
+		more = fetch_block(&tr, i, COAP_BLOCK_16);
+	}
+
+	zassert_equal(tr.len, strlen(expected_doc), "Unexpected document length");
+	zassert_mem_equal(tr.doc, expected_doc, tr.len, "Unexpected document content");
+}
+
+ZTEST(coap_wellknown, test_blockwise_interleaved)
+{
+	struct wk_transfer tr_a = { 0 };
+	struct wk_transfer tr_b = { 0 };
+	bool more_a = true;
+	bool more_b = true;
+
+	/* Two interleaved transfers with different block sizes must not
+	 * interfere with each other.
+	 */
+	for (int i = 0; more_a || more_b; i++) {
+		if (more_a) {
+			more_a = fetch_block(&tr_a, i, COAP_BLOCK_16);
+		}
+		if (more_b) {
+			more_b = fetch_block(&tr_b, i, COAP_BLOCK_32);
+		}
+	}
+
+	zassert_equal(tr_a.len, strlen(expected_doc), "Unexpected document length");
+	zassert_mem_equal(tr_a.doc, expected_doc, tr_a.len, "Unexpected document content");
+	zassert_equal(tr_b.len, strlen(expected_doc), "Unexpected document length");
+	zassert_mem_equal(tr_b.doc, expected_doc, tr_b.len, "Unexpected document content");
+}
+
+ZTEST(coap_wellknown, test_blockwise_fresh_after_abandoned)
+{
+	struct coap_packet response;
+	struct coap_packet parsed;
+	struct wk_transfer tr = { 0 };
+	uint8_t buf[WK_BUF_SIZE];
+	const uint8_t *payload;
+	uint16_t payload_len;
+	int block2;
+	int r;
+
+	/* Abandon a transfer after two blocks */
+	(void)fetch_block(&tr, 0, COAP_BLOCK_16);
+	(void)fetch_block(&tr, 1, COAP_BLOCK_16);
+
+	/* A fresh request without a block2 option starts over at block 0 */
+	r = well_known_req(&response, buf, sizeof(buf), ARRAY_SIZE(test_resources), -1,
+			   COAP_BLOCK_16);
+	zassert_equal(r, 0, "Well-known request failed (%d)", r);
+
+	r = coap_packet_parse(&parsed, buf, response.offset, NULL, 0U);
+	zassert_equal(r, 0, "Failed to parse response (%d)", r);
+
+	block2 = coap_get_option_int(&parsed, COAP_OPTION_BLOCK2);
+	zassert_true(block2 >= 0, "No block2 option in response");
+	zassert_equal(GET_BLOCK_NUM(block2), 0, "Fresh request did not start at block 0");
+	zassert_true(GET_MORE(block2), "Expected more blocks");
+
+	payload = coap_packet_get_payload(&parsed, &payload_len);
+	zassert_not_null(payload, "No payload in response");
+	zassert_equal(payload_len, WK_DEFAULT_BLOCK_SIZE, "Unexpected payload length");
+	zassert_mem_equal(payload, expected_doc, payload_len, "Unexpected document content");
+}
+
+ZTEST(coap_wellknown, test_blockwise_etag_representation)
+{
+	struct coap_packet response;
+	struct coap_packet parsed;
+	struct coap_option etag_opt = { 0 };
+	struct wk_transfer tr_a = { 0 };
+	struct wk_transfer tr_b = { 0 };
+	uint8_t buf[WK_BUF_SIZE];
+	int r;
+
+	if (!IS_ENABLED(CONFIG_SYS_HASH_FUNC32)) {
+		ztest_test_skip();
+	}
+
+	/* The same resource set produces the same ETag across transfers */
+	(void)fetch_block(&tr_a, 0, COAP_BLOCK_16);
+	(void)fetch_block(&tr_b, 0, COAP_BLOCK_16);
+	zassert_mem_equal(tr_a.etag, tr_b.etag, sizeof(tr_a.etag),
+			  "ETag differs for the same resource set");
+
+	/* A different resource set produces a different ETag */
+	r = well_known_req(&response, buf, sizeof(buf), ARRAY_SIZE(test_resources) - 1U, 0,
+			   COAP_BLOCK_16);
+	zassert_equal(r, 0, "Well-known request failed (%d)", r);
+
+	r = coap_packet_parse(&parsed, buf, response.offset, NULL, 0U);
+	zassert_equal(r, 0, "Failed to parse response (%d)", r);
+
+	r = coap_find_options(&parsed, COAP_OPTION_ETAG, &etag_opt, 1U);
+	zassert_equal(r, 1, "No ETag option in response");
+	zassert_equal(etag_opt.len, sizeof(tr_a.etag), "Unexpected ETag length");
+	zassert_true(memcmp(etag_opt.value, tr_a.etag, sizeof(tr_a.etag)) != 0,
+		     "ETag did not change with the resource set");
+}
+
+ZTEST_SUITE(coap_wellknown, NULL, NULL, NULL, NULL, NULL);
+
+#endif /* CONFIG_COAP_WELL_KNOWN_BLOCK_WISE */

--- a/tests/net/lib/coap/tests.yaml
+++ b/tests/net/lib/coap/tests.yaml
@@ -3,3 +3,9 @@ tests:
     min_ram: 16
     tags: net
     depends_on: netif
+  net.coap.wellknown_blockwise:
+    min_ram: 16
+    tags: net
+    depends_on: netif
+    extra_configs:
+      - CONFIG_COAP_WELL_KNOWN_BLOCK_WISE=y


### PR DESCRIPTION
The block-wise `./well-known/core` response had two bugs and a compliance gap:

- **Truncated documents:** when a block boundary fell inside the last attribute of a resource, `format_attributes()` reported the transfer as finished and the remaining bytes were never served.
- **Shared transfer state:** the block context was a single `static` shared across all clients and services, so concurrent block-wise discovery requests corrupted each other's position, and an abandoned transfer left stale state behind for the next request.
- **No ETag:** the link-format document is regenerated from the live resource list for every block, but carried no ETag option, so a representation change between blocks was undetectable by clients (RFC 7959, section 2.4 recommends the server includes one).

The fixes: detect attribute truncation from the document offset, derive the block context from the request alone (the stateless Block2 server model, making concurrent transfers independent), and include a 4-byte ETag hashed from the matching resources' path segments and attributes. `COAP_WELL_KNOWN_BLOCK_WISE` now implies `SYS_HASH_FUNC32`, so the ETag is included by default; disabling the hash function omits the option and saves its code size.