### PR TITLE
ci: bsim: trigger on all nrfx driver changes

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -23,11 +23,10 @@ on:
       - "modules/openthread/**"
       - "subsys/net/l2/openthread/**"
       - "include/zephyr/net/openthread.h"
+      - "drivers/**nrfx**"
       - "drivers/ieee802154/**"
       - "include/zephyr/net/ieee802154*"
-      - "drivers/serial/*nrfx*"
       - "tests/drivers/uart/**"
-      - "drivers/gpio/*nrfx*"
       - '!**.rst'
 
 permissions:
@@ -106,6 +105,8 @@ jobs:
             scripts/native_simulator/
             tests/bsim/*
             boards/nordic/nrf5*/*dt*
+            drivers/**/*nrfx*
+            drivers/**/*nrfx*/**
             dts/*/nordic/
             modules/mbedtls/**
             modules/hal_nordic/**


### PR DESCRIPTION
    Instead of specifying one by one which drivers should trigger this
    workflow, let's just trigger on any called *nrfx*.
    That will trigger a little bit too much, but avoids missing on some, as we
    were just doing with the rtc one, which caused a CI break to sneak into
    main.
    
    Note that the github workflow `on: ... paths` matches any set of characters
    (including possible subdirectories with `**`).
    So there "drivers/**nrfx**" matches also "drivers/<anything>/**nrfx**  or 
    "drivers/<anything>/**nrfx**/<whatever>.
    
    While the tj-actions/changed-files `files:` behaves differently only matching
    any number of characters without "/" in that case. But if it is provided as
    "/**/" it matches any number of subdirectories... 
    So to be able to cover both files and files in directories with nrfx in the path we need both lines.
    
Bsim CI will fail until this hotfix is in:
* https://github.com/zephyrproject-rtos/zephyr/pull/118189