### PR TITLE
Imx9 A-core supports pwm

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
+++ b/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
@@ -225,6 +225,14 @@
 			drive-strength = "x5";
 		};
 	};
+
+	pwm6_default: pwm6_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io08_tpm_ch_tpm6_ch0>;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+		};
+	};
 };
 
 &eth2_default_group1 {

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
@@ -215,3 +215,9 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&pwm6 {
+	pinctrl-0 = <&pwm6_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
@@ -20,6 +20,7 @@ supported:
   - net
   - netif:eth
   - ptp_clock
+  - pwm
   - spi
   - uart
   - watchdog

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
@@ -136,3 +136,9 @@
 	phys = <&can_phy2>;
 	status = "okay";
 };
+
+&pwm2 {
+	pinctrl-0 = <&tpm2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
@@ -19,6 +19,7 @@ supported:
   - net
   - netif:eth
   - ptp_clock
+  - pwm
   - uart
   - watchdog
 testing:

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -611,6 +611,18 @@
 		status = "disabled";
 	};
 
+	pwm6: pwm@42510000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x42510000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 89 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&scmi_clk IMX943_CLK_TPM6>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
 	flexcan1: can@443a0000 {
 		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -593,6 +593,66 @@
 		status = "disabled";
 	};
 
+	pwm2: pwm@44320000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x44320000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&scmi_clk IMX95_CLK_TPM2>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm3: pwm@424e0000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x424e0000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&scmi_clk IMX95_CLK_BUSWAKEUP>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm4: pwm@424f0000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x424f0000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 74 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&scmi_clk IMX95_CLK_TPM4>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm5: pwm@42500000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x42500000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 75 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&scmi_clk IMX95_CLK_TPM5>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm6: pwm@42510000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x42510000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 76 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&scmi_clk IMX95_CLK_TPM6>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
 	gpio1: gpio@47400000 {
 		compatible = "nxp,imx-rgpio";
 		reg = <0x47400000 DT_SIZE_K(64)>;

--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -59,6 +59,8 @@ In these other cases, however, manual wiring is necessary:
      - connect GPIO2 to an LED
    * - :zephyr:board:`esp32c3_devkitm`
      - connect GPIO2 to an LED
+   * - :zephyr:board:`imx943_evk`
+     - connect PWM6 (J47-6) to an LED
 
 Building and Running
 ********************

--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -61,6 +61,8 @@ In these other cases, however, manual wiring is necessary:
      - connect GPIO2 to an LED
    * - :zephyr:board:`imx943_evk`
      - connect PWM6 (J47-6) to an LED
+   * - :zephyr:board:`imx95_evk`
+     - connect PWM2 (R881) to an LED
 
 Building and Running
 ********************

--- a/samples/basic/blinky_pwm/boards/imx943_evk_mimx94398_a55.overlay
+++ b/samples/basic/blinky_pwm/boards/imx943_evk_mimx94398_a55.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* Connect PWM6 (J47-6) to an LED */
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm6 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};

--- a/samples/basic/blinky_pwm/boards/imx95_evk_mimx9596_a55.overlay
+++ b/samples/basic/blinky_pwm/boards/imx95_evk_mimx9596_a55.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* Connect PWM2 (R881) to an LED */
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm2 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};


### PR DESCRIPTION
Add PWM support on i.MX95 and i.MX943 Cortex-A platform.
The PWM function has been verified on boards.