### PR TITLE
drivers: pwm: mcux_sctimer: fix 0% duty glitch and capture interrupt storm

### DIFF
--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 NXP
+ * Copyright (c) 2021, 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -147,6 +147,34 @@ static int mcux_sctimer_new_channel(const struct device *dev,
 	return 0;
 }
 
+/* Hold a channel's output at its inactive level. */
+static void mcux_sctimer_pwm_force_inactive(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+	SCT_Type *base = config->base;
+	bool was_running = (base->CTRL & SCT_CTRL_HALT_L_MASK) == 0U;
+
+	/* SCT OUTPUT is only writable while the counter is halted*/
+	if (was_running) {
+		SCTIMER_StopTimer(base, kSCTIMER_Counter_U);
+	}
+
+	base->OUT[channel].SET = 0U;
+	base->OUT[channel].CLR = 0U;
+
+	/* Set the output to inactive State */
+	if (data->channel[channel].level == kSCTIMER_HighTrue) {
+		base->OUTPUT &= ~(1UL << channel);
+	} else {
+		base->OUTPUT |= (1UL << channel);
+	}
+
+	if (was_running) {
+		SCTIMER_StartTimer(base, kSCTIMER_Counter_U);
+	}
+}
+
 static void mcux_sctimer_pwm_update_polarity(const struct device *dev, uint32_t channel)
 {
 	const struct pwm_mcux_sctimer_config *config = dev->config;
@@ -213,25 +241,6 @@ static int mcux_sctimer_pwm_set_cycles(const struct device *dev,
 	}
 
 	duty_cycle = 100 * pulse_cycles / period_cycles;
-
-	if (duty_cycle == 0 && data->configured_chan == 1) {
-		/* Only one channel is active. We can turn off the SCTimer
-		 * global counter.
-		 */
-		SCT_Type *base = config->base;
-
-		/* Stop timer so we can set output directly */
-		SCTIMER_StopTimer(base, kSCTIMER_Counter_U);
-
-		/* Set the output to inactive State */
-		if (data->channel[channel].level == kSCTIMER_HighTrue) {
-			base->OUTPUT &= ~(1UL << channel);
-		} else {
-			base->OUTPUT |= (1UL << channel);
-		}
-
-		return 0;
-	}
 
 	/* SCTimer has some unique restrictions when operation as a PWM output.
 	 * The peripheral is based around a single counter, with a block of
@@ -301,6 +310,11 @@ static int mcux_sctimer_pwm_set_cycles(const struct device *dev,
 		/* Only duty cycle needs to be updated */
 		SCTIMER_UpdatePwmDutycycle(config->base, channel, duty_cycle,
 					   data->event_number[channel]);
+	}
+
+	if (duty_cycle == 0) {
+		/* Must work on the first call for a channel and while others run */
+		mcux_sctimer_pwm_force_inactive(dev, channel);
 	}
 
 	return 0;

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -93,6 +93,8 @@ struct pwm_mcux_sctimer_data {
 	uint32_t configured_chan;
 #ifdef CONFIG_PWM_CAPTURE
 	uint32_t match_event;
+	/* Channels with a measurement in flight, see mcux_sctimer_update_overflow_irq() */
+	uint32_t overflow_irq_mask;
 	struct pwm_mcux_sctimer_capture_data capture_data[CAPTURE_CHANNEL_COUNT];
 #endif /* CONFIG_PWM_CAPTURE */
 	bool pwm_channel_active;
@@ -479,6 +481,33 @@ static int mcux_sctimer_configure_capture(const struct device *dev,
 	return 0;
 }
 
+/* Arm the counter overflow interrupt only while a measurement is in flight.
+ *
+ * calc_ticks() uses the wrap count as a difference between the two edges, so wraps
+ * before the first edge cancel out. They are not free: match_event is the PWM period
+ * event and nothing disables it until a capture completes, so waiting for an edge that
+ * never arrives turns a short PWM period into an interrupt storm. The event is shared
+ * by all capture channels, hence the bitmask.
+ */
+static void mcux_sctimer_update_overflow_irq(const struct device *dev, uint32_t channel,
+					     bool needed)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+
+	if (needed) {
+		data->overflow_irq_mask |= (1UL << channel);
+	} else {
+		data->overflow_irq_mask &= ~(1UL << channel);
+	}
+
+	if (data->overflow_irq_mask != 0U) {
+		SCTIMER_EnableInterrupts(config->base, (1 << data->match_event));
+	} else {
+		SCTIMER_DisableInterrupts(config->base, (1 << data->match_event));
+	}
+}
+
 static int mcux_sctimer_enable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct pwm_mcux_sctimer_config *config = dev->config;
@@ -509,11 +538,12 @@ static int mcux_sctimer_enable_capture(const struct device *dev, uint32_t channe
 	status_flags = SCTIMER_GetStatusFlags(config->base);
 	SCTIMER_ClearStatusFlags(config->base, status_flags);
 
-	/* Enable interrupts for capture events and limit */
+	/* Enable interrupts for the capture edges only, the overflow interrupt is armed
+	 * once a first edge has been captured.
+	 */
 	SCTIMER_EnableInterrupts(config->base,
 		(1 << data->capture_data[channel].first_capture_event) |
-		(1 << data->capture_data[channel].second_capture_event) |
-		(1 << data->match_event));
+		(1 << data->capture_data[channel].second_capture_event));
 
 	return 0;
 }
@@ -533,8 +563,9 @@ static int mcux_sctimer_disable_capture(const struct device *dev, uint32_t chann
 		data->capture_data[channel].channel_used = false;
 		SCTIMER_DisableInterrupts(config->base,
 			(1 << data->capture_data[channel].first_capture_event) |
-			(1 << data->capture_data[channel].second_capture_event) |
-			(1 << data->match_event));
+			(1 << data->capture_data[channel].second_capture_event));
+		/* Drop this channel's claim on the shared overflow interrupt */
+		mcux_sctimer_update_overflow_irq(dev, channel, false);
 	}
 
 	/* Stop timer */
@@ -584,6 +615,9 @@ static void mcux_sctimer_capture_first_edge(const struct device *dev, uint32_t c
 	data->capture_data[channel].first_limit_count =
 		data->capture_data[channel].overflow_count;
 	data->capture_data[channel].first_edge_captured = true;
+
+	/* A measurement is now in flight: start counting counter wraps */
+	mcux_sctimer_update_overflow_irq(dev, channel, true);
 }
 
 static void mcux_sctimer_capture_second_edge(const struct device *dev, uint32_t channel)
@@ -598,6 +632,9 @@ static void mcux_sctimer_capture_second_edge(const struct device *dev, uint32_t 
 		data->capture_data[channel].overflow_count;
 	data->capture_data[channel].capture_ready = true;
 	data->capture_data[channel].first_edge_captured = false;
+
+	/* Measurement window closed */
+	mcux_sctimer_update_overflow_irq(dev, channel, false);
 }
 
 static void prepare_next_capture(const struct device *dev, uint32_t channel)
@@ -625,16 +662,21 @@ static void prepare_next_capture(const struct device *dev, uint32_t channel)
 			/* No actions required. */
 		}
 	} else {
-		/* Single capture mode: Disable interrupts */
+		/* Single capture mode: Disable interrupts, overflow handled below */
 		SCTIMER_DisableInterrupts(config->base,
 			(1 << data->capture_data[channel].first_capture_event) |
-			(1 << data->capture_data[channel].second_capture_event) |
-			(1 << data->match_event));
+			(1 << data->capture_data[channel].second_capture_event));
 	}
 
 	/* Clear second capture setting */
 	data->capture_data[channel].second_limit_count = 0;
 	data->capture_data[channel].second_capture_value = 0;
+
+	/* Continuous period capture keeps a measurement in flight by carrying the second
+	 * edge over as the next first edge.
+	 */
+	mcux_sctimer_update_overflow_irq(dev, channel,
+					 data->capture_data[channel].first_edge_captured);
 }
 
 static void mcux_sctimer_process_channel_events(const struct device *dev, uint32_t channel,
@@ -782,6 +824,7 @@ static int mcux_sctimer_pwm_init_common(const struct device *dev)
 	}
 	/* Initialize capture data */
 	data->match_event = EVENT_NOT_SET;
+	data->overflow_irq_mask = 0;
 	for (i = 0; i < CAPTURE_CHANNEL_COUNT; i++) {
 		/* Reset capture state */
 		memset(&data->capture_data[i], 0, sizeof(struct pwm_mcux_sctimer_capture_data));


### PR DESCRIPTION
This PR fix #117696 .

1. A 0% duty cycle emits a glitch instead of a constant level
A 0% duty cycle leaves the pulse match at 0 while the period match still sets the output. As that match is also the counter limit it fires every period, producing a one tick pulse instead of the constant inactive level the PWM API requires of a zero length pulse. Force output to inactive when duty cycle is 0 to fix this issue.

2. The capture overflow interrupt is armed with no exit condition
The counter overflow interrupt fires at whatever period the application picked. It was armed from enable_capture() onwards, and the only place that disables it is reached after a capture completes. With no signal on the capture input the capture never completes, so a short PWM period becomes an unbounded interrupt storm that starves the CPU. Fix this issue by arming the
interrupt when a first edge is captured and release it once the measurement is done.