### PR TITLE
usb: device_next: dfu: write to the image's own flash area

### DIFF
--- a/subsys/usb/device_next/class/usbd_dfu_flash.c
+++ b/subsys/usb/device_next/class/usbd_dfu_flash.c
@@ -95,7 +95,7 @@ static int dfu_flash_write(void *const priv,
 	int ret;
 
 	if (block == 0) {
-		if (flash_img_init(&data->fi_ctx)) {
+		if (flash_img_init_id(&data->fi_ctx, data->id)) {
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
`dfu_flash_write()` used `flash_img_init()`, which targets the default upload partition rather than the image's own flash area, so a download to `slot1_image` was written to `slot0`.