### PR TITLE
logging: respect the compile-time level in the rate-limited macros

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -154,23 +154,25 @@ extern "C" {
  */
 #define _LOG_RATELIMIT_CORE(_level, _rate_ms, ...)                                                 \
 	do {                                                                                       \
-		static atomic_t __last_log_time;                                                   \
-		static atomic_t __skipped_count;                                                   \
-		uint32_t __now = k_uptime_get_32();                                                \
-		uint32_t __last = atomic_get(&__last_log_time);                                    \
-		uint32_t __diff = __now - __last;                                                  \
-		if (unlikely(__diff >= (_rate_ms))) {                                              \
-			if (atomic_cas(&__last_log_time, __last, __now)) {                         \
-				uint32_t __skipped = atomic_clear(&__skipped_count);               \
-				if (__skipped > 0) {                                               \
-					Z_LOG(_level, "Skipped %d messages", __skipped);           \
+		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {                                             \
+			static atomic_t __last_log_time;                                           \
+			static atomic_t __skipped_count;                                           \
+			uint32_t __now = k_uptime_get_32();                                        \
+			uint32_t __last = atomic_get(&__last_log_time);                            \
+			uint32_t __diff = __now - __last;                                          \
+			if (unlikely(__diff >= (_rate_ms))) {                                      \
+				if (atomic_cas(&__last_log_time, __last, __now)) {                 \
+					uint32_t __skipped = atomic_clear(&__skipped_count);       \
+					if (__skipped > 0) {                                       \
+						Z_LOG(_level, "Skipped %d messages", __skipped);   \
+					}                                                          \
+					Z_LOG(_level, __VA_ARGS__);                                \
+				} else {                                                           \
+					atomic_inc(&__skipped_count);                              \
 				}                                                                  \
-				Z_LOG(_level, __VA_ARGS__);                                        \
 			} else {                                                                   \
 				atomic_inc(&__skipped_count);                                      \
 			}                                                                          \
-		} else {                                                                           \
-			atomic_inc(&__skipped_count);                                              \
 		}                                                                                  \
 	} while (0)
 
@@ -265,23 +267,26 @@ extern "C" {
  */
 #define _LOG_HEXDUMP_RATELIMIT_CORE(_level, _rate_ms, _data, _length, _str)                        \
 	do {                                                                                       \
-		static atomic_t __last_log_time;                                                   \
-		static atomic_t __skipped_count;                                                   \
-		uint32_t __now = k_uptime_get_32();                                                \
-		uint32_t __last = atomic_get(&__last_log_time);                                    \
-		uint32_t __diff = __now - __last;                                                  \
-		if (unlikely(__diff >= (_rate_ms))) {                                              \
-			if (atomic_cas(&__last_log_time, __last, __now)) {                         \
-				uint32_t __skipped = atomic_clear(&__skipped_count);               \
-				if (__skipped > 0) {                                               \
-					Z_LOG(_level, "Skipped %d hexdump messages", __skipped);   \
+		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {                                             \
+			static atomic_t __last_log_time;                                           \
+			static atomic_t __skipped_count;                                           \
+			uint32_t __now = k_uptime_get_32();                                        \
+			uint32_t __last = atomic_get(&__last_log_time);                            \
+			uint32_t __diff = __now - __last;                                          \
+			if (unlikely(__diff >= (_rate_ms))) {                                      \
+				if (atomic_cas(&__last_log_time, __last, __now)) {                 \
+					uint32_t __skipped = atomic_clear(&__skipped_count);       \
+					if (__skipped > 0) {                                       \
+						Z_LOG(_level, "Skipped %d hexdump messages",       \
+						      __skipped);                                  \
+					}                                                          \
+					Z_LOG_HEXDUMP(_level, _data, _length, _str);               \
+				} else {                                                           \
+					atomic_inc(&__skipped_count);                              \
 				}                                                                  \
-				Z_LOG_HEXDUMP(_level, _data, _length, _str);                       \
 			} else {                                                                   \
 				atomic_inc(&__skipped_count);                                      \
 			}                                                                          \
-		} else {                                                                           \
-			atomic_inc(&__skipped_count);                                              \
 		}                                                                                  \
 	} while (0)
 

--- a/tests/subsys/logging/log_ratelimited/tests.yaml
+++ b/tests/subsys/logging/log_ratelimited/tests.yaml
@@ -21,3 +21,11 @@ tests:
     extra_configs:
       - CONFIG_LOG_RATELIMIT=n
       - CONFIG_LOG_RATELIMIT_FALLBACK_LOG=y
+  # Build with the module level below most of the call sites, so that the
+  # rate limiting bookkeeping has to compile out rather than just the
+  # message it guards.
+  logging.log_ratelimited.filtered:
+    build_only: true
+    extra_configs:
+      - CONFIG_LOG_RATELIMIT_INTERVAL_MS=1000
+      - CONFIG_LOG_DEFAULT_LEVEL=1


### PR DESCRIPTION
The rate-limited logging macros do all their bookkeeping (two `static atomic_t` counters, `k_uptime_get_32()`, the `atomic_get`/`atomic_cas`/`atomic_clear`/`atomic_inc` sequence) *before* reaching `Z_LOG()`, which is where compile-time level filtering happens, so a call site below its module's log level keeps that machinery even though the message itself is compiled out.

Wrapping both cores in `Z_LOG_CONST_LEVEL_CHECK()` lets such a site collapse to nothing: **<ins>132 bytes of text and 8 bytes of bss saved per filtered-out call site</ins>**.