### PR TITLE
net: use the @rfc doxygen alias

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -165,7 +165,7 @@ struct coap_client_request {
 	 * request that accepts multiple responses within the timeout period. After the
 	 * timeout, a final callback with source=NULL signals completion, after which
 	 * no further callbacks will be issued. Multicast requests are always
-	 * non-confirmable (RFC 7252).
+	 * non-confirmable (@rfc{7252}).
 	 *
 	 * @kconfig_dep{CONFIG_COAP_CLIENT_MULTICAST}
 	 */
@@ -283,7 +283,7 @@ void coap_client_cancel_request(struct coap_client *client, struct coap_client_r
  * @brief Deregister matching CoAP observe subscriptions.
  *
  * Sends a GET with Observe option set to 1 (deregister) using the same token as the original
- * observe request, per RFC 7641 Section 3.6. The CON/NON type mirrors the original request.
+ * observe request, per @rfc{7641,section-3.6}. The CON/NON type mirrors the original request.
  *
  * For Confirmable requests the operation is asynchronous: retransmissions are handled by the
  * library and the response callback is invoked with the server's final response once the
@@ -305,7 +305,7 @@ int coap_client_deregister_observe(struct coap_client *client, struct coap_clien
  * @brief Initialise a Block2 option to be added to a request
  *
  * If the application expects a request to require a blockwise transfer, it may preemptively
- * suggest a maximum block size to the server - see RFC7959 Figure 3: Block-Wise GET with Early
+ * suggest a maximum block size to the server - see @rfc{7959} Figure 3: Block-Wise GET with Early
  * Negotiation.
  *
  * This helper function returns a Block2 option to send with the initial request.

--- a/include/zephyr/net/coap_client_tcp.h
+++ b/include/zephyr/net/coap_client_tcp.h
@@ -12,7 +12,7 @@
  * @brief CoAP TCP client API
  *
  * An API for applications to send CoAP requests over reliable transports
- * (TCP/TLS) as specified in RFC 8323.
+ * (TCP/TLS) as specified in @rfc{8323}.
  */
 
 /**
@@ -85,9 +85,9 @@ enum coap_client_tcp_event {
 	COAP_CLIENT_TCP_EVENT_CSM_UPDATED,
 	/** Pong received in response to Ping */
 	COAP_CLIENT_TCP_EVENT_PONG_RECEIVED,
-	/** Server initiated connection release (RFC 8323) */
+	/** Server initiated connection release (@rfc{8323}) */
 	COAP_CLIENT_TCP_EVENT_RELEASE,
-	/** Server aborted connection (RFC 8323) */
+	/** Server aborted connection (@rfc{8323}) */
 	COAP_CLIENT_TCP_EVENT_ABORT,
 };
 
@@ -234,7 +234,7 @@ int coap_client_tcp_init(struct coap_client_tcp *client, const char *info);
  * Unlike the UDP client, the TCP client manages the socket internally.
  * This function creates a TCP socket, connects to the server, and
  * automatically sends a CSM (Capabilities and Settings Message) to
- * negotiate capabilities per RFC 8323.
+ * negotiate capabilities per @rfc{8323}.
  *
  * @param client Client instance.
  * @param addr Destination address of the server.
@@ -273,7 +273,7 @@ int coap_client_tcp_req(struct coap_client_tcp *client,
 /**
  * @brief Send CSM (Capabilities and Settings Message) over TCP
  *
- * Per RFC 8323, CSM should be exchanged when a CoAP-over-TCP connection is
+ * Per @rfc{8323}, CSM should be exchanged when a CoAP-over-TCP connection is
  * established. This negotiates capabilities like max message size and BERT.
  *
  * @param client Client instance (must be connected via coap_client_tcp_connect).
@@ -320,7 +320,7 @@ struct coap_client_tcp_option coap_client_tcp_option_initial_block2(struct coap_
 bool coap_client_tcp_has_ongoing_exchange(struct coap_client_tcp *client);
 
 /**
- * @brief Send a Ping signal to the server (RFC 8323)
+ * @brief Send a Ping signal to the server (@rfc{8323})
  *
  * This sends a Ping signal and waits for Pong response. Can be used
  * for connection keep-alive or RTT measurement.
@@ -331,7 +331,7 @@ bool coap_client_tcp_has_ongoing_exchange(struct coap_client_tcp *client);
 int coap_client_tcp_ping(struct coap_client_tcp *client);
 
 /**
- * @brief Send a Release signal to the server (RFC 8323)
+ * @brief Send a Release signal to the server (@rfc{8323})
  *
  * This signals graceful connection termination. The server should
  * complete pending requests before closing.

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -230,7 +230,7 @@ struct coap_service {
  * @brief Define an OSCORE-enabled CoAP service with static resources.
  *
  * Behaves like @ref COAP_SERVICE_DEFINE but additionally wires OSCORE support
- * (RFC 8613) into the service. A per-service OSCORE exchange cache is allocated
+ * (@rfc{8613}) into the service. A per-service OSCORE exchange cache is allocated
  * statically.
  *
  * @note Requires @kconfig{CONFIG_COAP_OSCORE}. When that option is disabled the

--- a/include/zephyr/net/dhcpv4.h
+++ b/include/zephyr/net/dhcpv4.h
@@ -51,10 +51,10 @@ enum net_dhcpv4_state {
 /**
  * @brief DHCPv4 message types
  *
- * These enumerations represent RFC2131 defined msy type codes, hence
- * they should not be renumbered.
+ * These enumerations represent the message type codes defined in
+ * @rfc{2132,section-9.6}, hence they should not be renumbered.
  *
- * Additions, removald and reorders in this definition must be reflected
+ * Additions, removals and reorders in this definition must be reflected
  * within corresponding changes to net_dhcpv4_msg_type_name.
  */
 enum net_dhcpv4_msg_type {

--- a/include/zephyr/net/dhcpv4_server.h
+++ b/include/zephyr/net/dhcpv4_server.h
@@ -34,8 +34,7 @@ struct net_if;
 #define DHCPV4_CLIENT_ID_MAX_SIZE 20
 
 /**
- * Max DHCP hardware address size is defined in RFC2131
- * https://www.rfc-editor.org/rfc/rfc2131
+ * Max DHCP hardware address size is defined in @rfc{2131}
  */
 #define DHCPV4_HARDWARE_ADDRESS_MAX_SIZE 16
 

--- a/include/zephyr/net/dhcpv6.h
+++ b/include/zephyr/net/dhcpv6.h
@@ -75,7 +75,7 @@ struct net_dhcpv6_params {
 	uint8_t downstream_count;
 	/** Optional downstream interface indices. When a prefix is delegated
 	 *  (request_prefix), each listed interface is turned into a downstream
-	 *  link of a requesting router (RFC 8415): it is assigned a distinct
+	 *  link of a requesting router (@rfc{8415}): it is assigned a distinct
 	 *  /64 carved from the delegated prefix (the Nth entry gets the Nth
 	 *  /64), which is then advertised via Router Advertisements. Requires
 	 *  @kconfig{CONFIG_NET_IPV6_ND_RA_TX}. A @ref downstream_count of 0 means the

--- a/include/zephyr/net/dhcpv6_server.h
+++ b/include/zephyr/net/dhcpv6_server.h
@@ -5,7 +5,7 @@
  */
 
 /** @file
- *  @brief DHCPv6 server (prefix delegation), RFC 8415
+ *  @brief DHCPv6 server (prefix delegation), @rfc{8415}
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_DHCPV6_SERVER_H_

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -57,13 +57,13 @@ enum dns_query_type {
 };
 
 
-/** Private RR type range start (RFC 6895) */
+/** Private RR type range start (@rfc{6895}) */
 #define DNS_RR_TYPE_PRIVATE_START_VALUE 65280
-/** Private RR type range end (RFC 6895) */
+/** Private RR type range end (@rfc{6895}) */
 #define DNS_RR_TYPE_PRIVATE_END_VALUE 65534
 
 /**
- * @brief Check if query type is a private RR (RFC 6895: 65280-65534)
+ * @brief Check if query type is a private RR (@rfc{6895}: 65280-65534)
  *
  * @param type Query type to check
  * @return true if type is in private RR range, false otherwise

--- a/include/zephyr/net/dplpmtud.h
+++ b/include/zephyr/net/dplpmtud.h
@@ -44,7 +44,7 @@
 extern "C" {
 #endif
 
-/** Default base PLPMTU from RFC 8899/RFC 9000 for UDP-based transports. */
+/** Default base PLPMTU from @rfc{8899}/@rfc{9000} for UDP-based transports. */
 #define NET_DPLPMTUD_BASE_PLPMTU 1200U
 
 /** DPLPMTUD search state. */

--- a/include/zephyr/net/ftp_client.h
+++ b/include/zephyr/net/ftp_client.h
@@ -39,7 +39,7 @@ extern "C" {
 
 /**
  * @brief List of FTP server reply codes
- * Reference RFC959 FTP Transfer Protocol
+ * Reference @rfc{959} File Transfer Protocol
  */
 enum ftp_reply_code {
 	/* 100 Series	The requested action is being initiated, expect another

--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -181,7 +181,7 @@ struct http_response {
 	 */
 	size_t processed;
 
-	/** See https://tools.ietf.org/html/rfc7230#section-3.1.2 for more information.
+	/** See @rfc{7230,section-3.1.2} for more information.
 	 * The status-code element is a 3-digit integer code
 	 *
 	 * The reason-phrase element exists for the sole

--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -531,7 +531,7 @@ struct http_client_ctx {
 	/** Websocket subprotocol selected from the client's
 	 *  Sec-WebSocket-Protocol request header. NUL-terminated; empty
 	 *  if the client did not list any subprotocol. Echoed back in
-	 *  the 101 Switching Protocols response per RFC 6455.
+	 *  the 101 Switching Protocols response per @rfc{6455}.
 	 */
 	IF_ENABLED(CONFIG_WEBSOCKET,
 		   (char ws_sec_protocol[HTTP_SERVER_WS_MAX_SEC_PROTOCOL_LEN]));

--- a/include/zephyr/net/http/status.h
+++ b/include/zephyr/net/http/status.h
@@ -30,7 +30,7 @@ extern "C" {
  * @note HTTP response status codes are subject to IANA approval.
  *
  * @see <a href="https://www.iana.org/assignments/http-status-codes">Hypertext Transfer Protocol (HTTP) Status Code Registry</a>
- * @see <a href="https://www.ietf.org/rfc/rfc9110.txt">RFC9110</a>
+ * @see @rfc{9110}
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status">HTTP response status codes</a>
  */
 enum http_status {

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -1477,7 +1477,7 @@ static inline int ieee802154_attr_get_channel_page_and_range(
  * The following rules apply:
  * * An interface is considered "UP" when it is able to transmit and receive
  *   packets, "DOWN" otherwise (see precise definitions of the corresponding
- *   ifOperStatus values in RFC 2863, section 3.1.14, @ref net_if_oper_state and
+ *   ifOperStatus values in @rfc{2863,section-3.1.14}, @ref net_if_oper_state and
  *   the `continuous_carrier()` exception below). A device that has its receiver
  *   temporarily disabled during "UP" state due to an active receive window
  *   configuration is still considered "UP".
@@ -1505,14 +1505,14 @@ static inline int ieee802154_attr_get_channel_page_and_range(
  * * The driver SHALL NOT change the interface's "UP"/"DOWN" state on its own.
  *   Initially, the interface SHALL be in the "DOWN" state.
  * * Drivers that implement the optional `continuous_carrier()` operation will
- *   be considered to be in the RFC 2863 "testing" ifOperStatus state if that
+ *   be considered to be in the @rfc{2863} "testing" ifOperStatus state if that
  *   operation returns zero. This state is active until either `start()` or
  *   `stop()` is called. If `continuous_carrier()` returns a non-zero value then
  *   the previous state is assumed by upper layers.
  * * If calls to `start()`/`stop()` return any other value than zero or
  *   `-EALREADY`, upper layers will consider the interface to be in a
- *   "lowerLayerDown" state as defined in RFC 2863.
- * * The RFC 2863 "dormant", "unknown" and "notPresent" ifOperStatus states are
+ *   "lowerLayerDown" state as defined in @rfc{2863}.
+ * * The @rfc{2863} "dormant", "unknown" and "notPresent" ifOperStatus states are
  *   currently not supported. The "lowerLevelUp" state.
  * * The `ed_scan()`, `cca()` and `tx()` operations SHALL only be supported in
  *   the "UP" state and return `-ENETDOWN` in any other state. See the

--- a/include/zephyr/net/ipv4_autoconf.h
+++ b/include/zephyr/net/ipv4_autoconf.h
@@ -21,7 +21,7 @@ enum net_ipv4_autoconf_state {
 struct net_if;
 
 /**
- * @brief Start IPv4 autoconfiguration RFC 3927: IPv4 Link Local
+ * @brief Start IPv4 autoconfiguration @rfc{3927}: IPv4 Link Local
  *
  * @details Start IPv4 IP autoconfiguration
  *

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -400,7 +400,7 @@ __net_socket struct net_context {
 #if defined(CONFIG_NET_IPV6)
 		/**
 		 * Source address selection preferences. Currently used only for IPv6,
-		 * see RFC 5014 for details.
+		 * see @rfc{5014} for details.
 		 */
 		uint16_t addr_preferences;
 #endif
@@ -454,7 +454,7 @@ __net_socket struct net_context {
 			/** MRDS (Maximum Reassembled Datagram Size), 0 = not set */
 			struct net_udp_opt_mrds mrds;
 #if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
-			/** DPLPMTUD (RFC 9869) per-socket state. */
+			/** DPLPMTUD (@rfc{9869}) per-socket state. */
 			struct {
 				/** Generic engine path handle (per destination). */
 				struct net_dplpmtud_path path;
@@ -1460,7 +1460,7 @@ enum net_context_option {
 	NET_OPT_RECV_HOPLIMIT     = 24, /**< Receive hop limit information */
 	NET_OPT_DONT_FRAGMENT     = 25, /**< Disable local IP fragmentation */
 	NET_OPT_LINGER            = 26, /**< Socket linger (SO_LINGER) */
-	NET_OPT_UDP_OPT           = 27, /**< UDP options master enable (RFC 9868) */
+	NET_OPT_UDP_OPT           = 27, /**< UDP options master enable (@rfc{9868}) */
 	NET_OPT_UDP_OPT_OCS       = 28, /**< UDP options: Option Checksum */
 	NET_OPT_UDP_OPT_APC       = 29, /**< UDP options: Additional Payload Checksum */
 	NET_OPT_UDP_OPT_FRAG      = 30, /**< UDP options: Fragmentation */
@@ -1474,7 +1474,7 @@ enum net_context_option {
 	NET_OPT_UDP_OPT_UCMP      = 38, /**< UDP options: UNSAFE Compression */
 	NET_OPT_UDP_OPT_UENC      = 39, /**< UDP options: UNSAFE Encryption */
 	NET_OPT_UDP_OPT_UEXP      = 40, /**< UDP options: UNSAFE Experimental */
-	NET_OPT_UDP_OPT_DPLPMTUD  = 41, /**< UDP options: DPLPMTUD enable (RFC 9869) */
+	NET_OPT_UDP_OPT_DPLPMTUD  = 41, /**< UDP options: DPLPMTUD enable (@rfc{9869}) */
 	NET_OPT_UDP_OPT_DPLPMTUD_APP_RESPOND = 42, /**< UDP options: app echoes RES itself */
 };
 
@@ -1507,7 +1507,7 @@ int net_context_get_option(struct net_context *context,
 			   void *value, uint32_t *len);
 
 /**
- * @brief Enable or disable DPLPMTUD (RFC 9869) on a UDP context.
+ * @brief Enable or disable DPLPMTUD (@rfc{9869}) on a UDP context.
  *
  * When enabled, the stack probes the path MTU using UDP options and answers
  * incoming probes. Must be a UDP context.

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -143,7 +143,7 @@ struct net_if_addr {
 	uint8_t is_mesh_local : 1;
 
 	/** Is this IP address temporary and generated for example by
-	 * IPv6 privacy extension (RFC 8981)
+	 * IPv6 privacy extension (@rfc{8981})
 	 */
 	uint8_t is_temporary : 1;
 
@@ -309,7 +309,7 @@ enum net_if_flag {
 /** @endcond */
 };
 
-/** @brief Network interface operational status (RFC 2863). */
+/** @brief Network interface operational status (@rfc{2863}). */
 enum net_if_oper_state {
 	NET_IF_OPER_UNKNOWN,        /**< Initial (unknown) value */
 	NET_IF_OPER_NOTPRESENT,     /**< Hardware missing */
@@ -347,13 +347,13 @@ struct net_if_ipv6 {
 	/** Prefixes */
 	struct net_if_ipv6_prefix prefix[NET_IF_MAX_IPV6_PREFIX];
 
-	/** Default reachable time (RFC 4861, page 52) */
+	/** Default reachable time (@rfc{4861,page-52}) */
 	uint32_t base_reachable_time;
 
-	/** Reachable time (RFC 4861, page 20) */
+	/** Reachable time (@rfc{4861,page-20}) */
 	uint32_t reachable_time;
 
-	/** Retransmit timer (RFC 4861, page 52) */
+	/** Retransmit timer (@rfc{4861,page-52}) */
 	uint32_t retrans_timer;
 
 #if defined(CONFIG_NET_IPV6_IID_STABLE)
@@ -367,7 +367,7 @@ struct net_if_ipv6 {
 #endif /* CONFIG_NET_IPV6_IID_STABLE */
 
 #if defined(CONFIG_NET_IPV6_PE)
-	/** Privacy extension DESYNC_FACTOR value from RFC 8981 ch 3.4.
+	/** Privacy extension DESYNC_FACTOR value from @rfc{8981,section-3.4}.
 	 * "DESYNC_FACTOR is a random value within the range 0 - MAX_DESYNC_FACTOR.
 	 * It is computed every time a temporary address is created.
 	 */
@@ -440,7 +440,7 @@ struct net_if_dhcpv6 {
 	uint64_t t2;
 
 	/** The time when the last lease expires (terminates rebinding,
-	 *  DHCPv6 RFC8415, ch. 18.2.5). Absolute time, milliseconds.
+	 *  DHCPv6 @rfc{8415,section-18.2.5}). Absolute time, milliseconds.
 	 */
 	uint64_t expire;
 
@@ -735,7 +735,7 @@ struct net_if_dev {
 	net_socket_create_t socket_offload;
 #endif /* CONFIG_NET_SOCKETS_OFFLOAD */
 
-	/** RFC 2863 operational status */
+	/** @rfc{2863} operational status */
 	enum net_if_oper_state oper_state;
 
 	/** Last time the operational state was changed.
@@ -795,7 +795,7 @@ struct net_if {
 	struct k_mutex tx_lock;
 
 	/** Network interface specific flags */
-	/** Enable IPv6 privacy extension (RFC 8981), this is enabled
+	/** Enable IPv6 privacy extension (@rfc{8981}), this is enabled
 	 * by default if PE support is enabled in configuration.
 	 */
 	uint8_t pe_enabled : 1;
@@ -1367,7 +1367,7 @@ static inline void net_if_stop_rs(struct net_if *iface)
  * Neighbor Discovery process about an active link to a specific neighbor.
  * By signaling a recent "forward progress" event, such as the reception of
  * an ACK, this function can help reduce unnecessary ND traffic as per the
- * guidelines in RFC 4861 (section 7.3).
+ * guidelines in @rfc{4861,section-7.3}.
  *
  * @param iface A pointer to the network interface.
  * @param ipv6_addr Pointer to the IPv6 address of the neighbor node.
@@ -2190,10 +2190,10 @@ static inline void net_if_ipv6_set_mcast_hop_limit(struct net_if *iface,
  * @brief Maximum IPv6 base reachable time in milliseconds.
  *
  * Upper bound for the base reachable time, matching the AdvReachableTime limit
- * from RFC 4861 section 6.2.1. Values passed to
+ * from @rfc{4861,section-6.2.1}. Values passed to
  * @ref net_if_ipv6_set_base_reachable_time above this are clamped. This also
  * keeps @ref net_if_ipv6_calc_reachable_time from overflowing when it scales
- * the value by the RFC 4861 random factor.
+ * the value by the @rfc{4861} random factor.
  */
 #define NET_IPV6_MAX_REACHABLE_TIME 3600000U
 
@@ -2389,7 +2389,7 @@ static inline const struct net_in6_addr *net_if_ipv6_select_src_addr(
  * @param iface Interface that was used when packet was received.
  * If the interface is not known, then NULL can be given.
  * @param dst IPv6 destination address
- * @param flags Hint from the related socket. See RFC 5014 for value details.
+ * @param flags Hint from the related socket. See @rfc{5014} for value details.
  *
  * @return Pointer to IPv6 address to use, NULL if no IPv6 address
  * could be found.

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -647,7 +647,7 @@ struct net_udp_hdr {
 	uint16_t chksum;
 } __packed;
 
-/** @brief UDP Options Maximum Reassembled Datagram Size (MRDS), RFC 9868.
+/** @brief UDP Options Maximum Reassembled Datagram Size (MRDS), @rfc{9868}.
  *
  * Value type for the @c ZSOCK_UDP_OPT_MRDS socket option and the
  * @c ZSOCK_UDP_OPT_CMSG_MRDS ancillary control message.
@@ -659,7 +659,7 @@ struct net_udp_opt_mrds {
 	uint8_t segs;
 };
 
-/** @brief UDP Options Timestamp (TIME), RFC 9868.
+/** @brief UDP Options Timestamp (TIME), @rfc{9868}.
  *
  * Value type for the @c ZSOCK_UDP_OPT_CMSG_TIME ancillary control message.
  */
@@ -1448,7 +1448,7 @@ static inline bool net_ipv6_is_addr_solicited_node_raw(const uint8_t *addr)
 
 /**
  *  @brief Check if the IPv6 address is solicited node multicast address
- *  FF02:0:0:0:0:1:FFXX:XXXX defined in RFC 3513
+ *  FF02:0:0:0:0:1:FFXX:XXXX defined in @rfc{3513}
  *
  *  @param addr IPv6 address.
  *
@@ -1726,7 +1726,7 @@ net_ipv6_is_addr_mcast_link_all_nodes(const struct net_in6_addr *addr)
 
 /**
  *  @brief Create solicited node IPv6 multicast address
- *  FF02:0:0:0:0:1:FFXX:XXXX defined in RFC 3513
+ *  FF02:0:0:0:0:1:FFXX:XXXX defined in @rfc{3513}
  *
  *  @param src IPv6 address.
  *  @param dst IPv6 address.
@@ -1846,7 +1846,7 @@ static inline void net_ipv6_addr_get_v4_mapped(const struct net_in6_addr *addr6,
 /**
  *  @brief Generate IPv6 address using a prefix and interface identifier.
  *         Interface identifier is either generated from EUI-64 (MAC) defined
- *         in RFC 4291 or from randomized value defined in RFC 7217.
+ *         in @rfc{4291} or from randomized value defined in @rfc{7217}.
  *
  *  @param iface Network interface
  *  @param prefix IPv6 prefix, can be left out in which case fe80::/64 is used

--- a/include/zephyr/net/quic.h
+++ b/include/zephyr/net/quic.h
@@ -21,7 +21,7 @@
  * @ingroup networking
  *
  * @note Server mode sends Version Negotiation for unsupported versions and can
- * enforce the RFC 9000 anti-amplification limit before peer address
+ * enforce the @rfc{9000} anti-amplification limit before peer address
  * validation, including Retry and NEW_TOKEN-based address-validation tokens.
  * @{
  */
@@ -164,7 +164,7 @@ enum {
 	 * The option value is a pointer to a uint32_t. Set it on a listening or
 	 * server-side connection socket before the handshake. A value of 0 keeps
 	 * 0-RTT disabled for newly issued tickets; any non-zero value enables it.
-	 * Per RFC 9001 4.6.1 the ticket always advertises the fixed 0xffffffff
+	 * Per @rfc{9001,section-4.6.1} the ticket always advertises the fixed 0xffffffff
 	 * sentinel and the amount of early data a resuming client may send is
 	 * bounded by the connection's flow-control (transport-parameter) limits,
 	 * not by this value; the option is therefore only an enable switch, not a
@@ -238,7 +238,7 @@ struct quic_session_state {
 	uint32_t ticket_age_add;
 	/**
 	 * Early-data allowance from NewSessionTicket: 0 when 0-RTT is not
-	 * permitted, otherwise the RFC 9001 4.6.1 sentinel 0xffffffff (in QUIC
+	 * permitted, otherwise the @rfc{9001,section-4.6.1} sentinel 0xffffffff (in QUIC
 	 * the actual early-data limit is governed by transport parameters).
 	 */
 	uint32_t max_early_data_size;

--- a/include/zephyr/net/rtp.h
+++ b/include/zephyr/net/rtp.h
@@ -35,7 +35,7 @@ extern "C" {
  * @{
  */
 
-/** RTP protocol version 2 as defined in RFC 3550. */
+/** RTP protocol version 2 as defined in @rfc{3550}. */
 #define RTP_VERSION 2
 
 /** Minimum RTP header length in bytes, excluding any CSRC list or extension. */
@@ -69,7 +69,7 @@ extern "C" {
 #define RTP_MAX_CSRC_COUNT 0
 #endif
 
-/** RTP header extension as defined in RFC 3550 section 5.3.1. */
+/** RTP header extension as defined in @rfc{3550,section-5.3.1}. */
 struct rtp_header_extension {
 	/** Profile-defined extension header identifier. */
 	uint16_t definition;
@@ -79,7 +79,7 @@ struct rtp_header_extension {
 	uint8_t *data;
 };
 
-/** RTP fixed header as defined in RFC 3550 section 5.1. */
+/** RTP fixed header as defined in @rfc{3550,section-5.1}. */
 struct rtp_header {
 	/** Raw encoding of the version, padding, extension, and CC fields. */
 	uint8_t vpxcc;

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -791,7 +791,7 @@ __syscall int z_zsock_getaddrinfo_internal(const char *host,
 #define ZSOCK_AI_ADDRCONFIG 0x20
 /** Assume service (port) is numeric */
 #define ZSOCK_AI_NUMERICSERV 0x400
-/** Extra flags present (see RFC 5014) */
+/** Extra flags present (see @rfc{5014}) */
 #define ZSOCK_AI_EXTFLAGS 0x800
 /** @} */
 
@@ -1033,7 +1033,7 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
  */
 /* Socket options for NET_IPPROTO_UDP level */
 
-/** Enable/disable all UDP options (int boolean), these are from RFC 9868 */
+/** Enable/disable all UDP options (int boolean), these are from @rfc{9868} */
 #define ZSOCK_UDP_OPT      1
 /** Enable/disable UDP OCS (int boolean) */
 #define ZSOCK_UDP_OPT_OCS  2
@@ -1061,7 +1061,7 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 #define ZSOCK_UDP_OPT_UENC 13
 /** Enable/disable UDP UEXP option (int boolean) */
 #define ZSOCK_UDP_OPT_UEXP 14
-/** Enable/disable DPLPMTUD over UDP options, RFC 9869 (int boolean) */
+/** Enable/disable DPLPMTUD over UDP options, @rfc{9869} (int boolean) */
 #define ZSOCK_UDP_OPT_DPLPMTUD 15
 /** Let the application echo REQ->RES itself instead of the stack (int boolean) */
 #define ZSOCK_UDP_OPT_DPLPMTUD_APP_RESPOND 16
@@ -1203,7 +1203,7 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 
 /** Pass an IPV6_RECVPKTINFO ancillary message that contains a
  *  in6_pktinfo structure that supplies some information about the
- *  incoming packet. See RFC 3542.
+ *  incoming packet. See @rfc{3542}.
  */
 #define ZSOCK_IPV6_RECVPKTINFO 49
 
@@ -1211,14 +1211,14 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 #define ZSOCK_IPV6_PKTINFO 50
 
 /** Pass an IPV6_RECVHOPLIMIT ancillary message that contains information
- *  about the hop limit of the incoming packet. See RFC 3542.
+ *  about the hop limit of the incoming packet. See @rfc{3542}.
  */
 #define ZSOCK_IPV6_RECVHOPLIMIT 51
 
 /** Set or receive the hoplimit value for an outgoing packet. */
 #define ZSOCK_IPV6_HOPLIMIT 52
 
-/** RFC5014: Source address selection. */
+/** @rfc{5014}: Source address selection. */
 #define ZSOCK_IPV6_ADDR_PREFERENCES   72
 
 /** Prefer temporary address as source. */

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * RFC1350: the file is sent in fixed length blocks of 512 bytes.
+ * @rfc{1350}: the file is sent in fixed length blocks of 512 bytes.
  * Each data packet contains one block of data, and must be acknowledged
  * by an acknowledgment packet before the next packet can be sent.
  * A data packet of less than 512 bytes signals termination of a transfer.
@@ -34,7 +34,7 @@ extern "C" {
 #define TFTP_BLOCK_SIZE          512
 
 /**
- * RFC1350: For non-request TFTP message, the header contains 2-byte operation
+ * @rfc{1350}: For non-request TFTP message, the header contains 2-byte operation
  * code plus 2-byte block number or error code.
  */
 #define TFTP_HEADER_SIZE         4

--- a/include/zephyr/net/trickle.h
+++ b/include/zephyr/net/trickle.h
@@ -1,7 +1,7 @@
 /** @file
  * @brief Trickle timer library
  *
- * This implements Trickle timer as specified in RFC 6206
+ * This implements Trickle timer as specified in @rfc{6206}
  */
 
 /*
@@ -48,7 +48,7 @@ typedef void (*net_trickle_cb_t)(struct net_trickle *trickle,
 				 bool do_suppress, void *user_data);
 
 /**
- * The variable names are taken directly from RFC 6206 when applicable.
+ * The variable names are taken directly from @rfc{6206} when applicable.
  * Note that the struct members should not be accessed directly but
  * only via the Trickle API.
  */
@@ -79,7 +79,7 @@ struct net_trickle {
  * @param trickle Pointer to Trickle struct.
  * @param Imin Imin configuration parameter in ms.
  * @param Imax Max number of doublings.
- * @param k Redundancy constant parameter. See RFC 6206 for details.
+ * @param k Redundancy constant parameter. See @rfc{6206} for details.
  *
  * @return Return 0 if ok and <0 if error.
  */

--- a/include/zephyr/net/websocket.h
+++ b/include/zephyr/net/websocket.h
@@ -139,7 +139,7 @@ int websocket_connect(int http_sock, struct websocket_request *req,
  * @param payload Websocket data to send.
  * @param payload_len Length of the data to be sent.
  * @param opcode Operation code (text, binary, ping, pong, close)
- * @param mask Mask the data, see RFC 6455 for details
+ * @param mask Mask the data, see @rfc{6455} for details
  * @param final Is this final message for this message send. If final == false,
  *        then the first message must have valid opcode and subsequent messages
  *        must have opcode WEBSOCKET_OPCODE_CONTINUE. If final == true and this

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -146,11 +146,11 @@ enum wifi_wep_key_type {
 enum wifi_eap_type {
 	/** No EPA  security. */
 	WIFI_EAP_TYPE_NONE = 0,
-	/** EPA GTC security, refer to rfc3748 chapter 5. */
+	/** EPA GTC security, refer to @rfc{3748,section-5}. */
 	WIFI_EAP_TYPE_GTC = 6,
-	/** EPA TLS security, refer to rfc5216. */
+	/** EPA TLS security, refer to @rfc{5216}. */
 	WIFI_EAP_TYPE_TLS = 13,
-	/** EPA TTLS security, refer to rfc5281. */
+	/** EPA TTLS security, refer to @rfc{5281}. */
 	WIFI_EAP_TYPE_TTLS = 21,
 	/** EPA PEAP security, refer to draft-josefsson-pppext-eap-tls-eap-06.txt. */
 	WIFI_EAP_TYPE_PEAP = 25,


### PR DESCRIPTION
Convert plain-text RFC mentions in the networking API documentation to the `@rfc` alias so they render as hyperlinks to the IETF Datatracker.

Follow-up of https://github.com/zephyrproject-rtos/zephyr/pull/117718