### PR TITLE
net: lib: coap: RFC compliance fixes for the client and message layer

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -528,6 +528,8 @@ New APIs and options
 
 * Network
 
+  * Add :c:func:`coap_age_is_newer` to compare CoAP Observe option values for
+    freshness (RFC 7641, section 3.4).
   * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.
   * Add :c:func:`net_dhcpv4_set_reboot_hint` to seed the DHCPv4 client with a
     previously leased address for INIT-REBOOT.

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -1049,6 +1049,21 @@ size_t coap_next_block(const struct coap_packet *cpkt,
 		       struct coap_block_context *ctx);
 
 /**
+ * @brief Compare Observe option values for freshness.
+ *
+ * Uses the serial number arithmetic of @rfc{7641,section-3.4}, without the
+ * 128-second timestamp clause, to decide whether the notification carrying
+ * Observe option value @p v2 was sent more recently than the one carrying
+ * @p v1.
+ *
+ * @param v1 Observe option value of the freshest notification so far
+ * @param v2 Observe option value of the received notification
+ *
+ * @return true if @p v2 is newer than @p v1
+ */
+bool coap_age_is_newer(int v1, int v2);
+
+/**
  * @brief Indicates that the remote device referenced by @a addr, with
  * @a request, wants to observe a resource.
  *

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -195,6 +195,10 @@ struct coap_client_internal_request {
 
 	/* For GETs with observe option set */
 	bool is_observe;
+	/* Observe option value of the freshest accepted notification, < 0 if none */
+	int last_observe_seq;
+	/* Uptime at which the freshest notification was accepted */
+	int64_t last_observe_at;
 	int last_response_id;
 #if defined(CONFIG_COAP_CLIENT_MULTICAST)
 	bool is_mcast;

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1478,6 +1478,13 @@ static int update_descriptive_block(struct coap_block_context *ctx,
 		return 0;
 	}
 
+	/* RFC 7959, section 2.2: SZX value 7 is reserved outside reliable
+	 * transports and leads to a 4.00 Bad Request response.
+	 */
+	if (block >= 0 && GET_BLOCK_SIZE(block) == COAP_BLOCK_BERT) {
+		return -EINVAL;
+	}
+
 	if (size && ctx->total_size && ctx->total_size != size) {
 		return -EINVAL;
 	}
@@ -1512,6 +1519,13 @@ static int update_control_block1(struct coap_block_context *ctx,
 		return -EINVAL;
 	}
 
+	/* RFC 7959, section 2.2: SZX value 7 is reserved outside reliable
+	 * transports and leads to a 4.00 Bad Request response.
+	 */
+	if (GET_BLOCK_SIZE(block) == COAP_BLOCK_BERT) {
+		return -EINVAL;
+	}
+
 	new_current = GET_NUM(block) << (GET_BLOCK_SIZE(block) + 4);
 	if (new_current != ctx->current) {
 		return -EINVAL;
@@ -1540,6 +1554,13 @@ static int update_control_block2(struct coap_block_context *ctx,
 	}
 
 	if (block < 0) {
+		return -EINVAL;
+	}
+
+	/* RFC 7959, section 2.2: SZX value 7 is reserved outside reliable
+	 * transports and leads to a 4.00 Bad Request response.
+	 */
+	if (GET_BLOCK_SIZE(block) == COAP_BLOCK_BERT) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1545,9 +1545,9 @@ static int update_control_block2(struct coap_block_context *ctx,
 
 	new_current = GET_NUM(block) << (GET_BLOCK_SIZE(block) + 4);
 
-	if (GET_MORE(block)) {
-		return -EINVAL;
-	}
+	/* RFC 7959, section 2.4: the M bit has no function in a Block2 request
+	 * and is ignored on reception.
+	 */
 
 	if (GET_NUM(block) > 0 && GET_BLOCK_SIZE(block) != ctx->block_size) {
 		return -EINVAL;
@@ -2560,9 +2560,9 @@ static int update_control_block2_tcp(struct coap_block_context *ctx,
 
 	new_current = GET_NUM(block) << (MIN(COAP_BLOCK_1024, GET_BLOCK_SIZE(block)) + 4);
 
-	if (GET_MORE(block)) {
-		return -EINVAL;
-	}
+	/* RFC 7959, section 2.4: the M bit has no function in a Block2 request
+	 * and is ignored on reception.
+	 */
 
 	if (GET_NUM(block) > 0 && GET_BLOCK_SIZE(block) != ctx->block_size) {
 		return -EINVAL;

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1868,7 +1868,6 @@ size_t coap_pendings_count(struct coap_pending *pendings, size_t len)
 }
 
 /* Reordering according to RFC7641 section 3.4 but without timestamp comparison */
-IF_DISABLED(CONFIG_ZTEST, (static inline))
 bool coap_age_is_newer(int v1, int v2)
 {
 	return (v1 < v2 && v2 - v1 < (1 << 23))

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -797,6 +797,13 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		return -EBADMSG;
 	}
 
+	/* RFC 7252, section 4.1: an Empty message has the token length set to
+	 * zero and no bytes after the message ID.
+	 */
+	if (data[1] == COAP_CODE_EMPTY && (tkl != 0U || len > BASIC_HEADER_SIZE)) {
+		return -EBADMSG;
+	}
+
 	cpkt->hdr_len = BASIC_HEADER_SIZE + tkl;
 	if (cpkt->hdr_len > len) {
 		return -EBADMSG;

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -873,6 +873,15 @@ static int handle_poll(void)
 				if (ret == -EAGAIN) {
 					continue;
 				}
+				if (ret == -EBADMSG || ret == -EILSEQ) {
+					/* RFC 7252, sections 4.2 and 4.3: a
+					 * malformed message is rejected by
+					 * silently ignoring it; it must not
+					 * tear down unrelated exchanges.
+					 */
+					LOG_WRN("Dropping malformed packet");
+					continue;
+				}
 				LOG_ERR("Error receiving response");
 				cancel_requests_with(client, -EIO);
 				continue;
@@ -940,7 +949,12 @@ static int recv_response(struct coap_client *client, struct net_sockaddr *addr,
 
 	ret = coap_packet_parse(response, client->recv_buf, available_len, NULL, 0);
 	if (ret < 0) {
-		LOG_ERR("Invalid data received");
+		LOG_ERR("Invalid data received (%d)", ret);
+		/* Normalize parse failures, including datagrams shorter than a
+		 * CoAP header (-EINVAL), so the caller can tell a malformed
+		 * packet from a socket error.
+		 */
+		return -EBADMSG;
 	}
 
 	return ret;

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1314,6 +1314,19 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 			goto fail;
 		}
 		coap_next_block(response, &internal_req->recv_blk_ctx);
+
+		/* RFC 7959, section 2.3: with the M bit set, the payload size
+		 * must match the block size exactly, otherwise the transfer
+		 * position desynchronizes. Truncated responses are re-requested
+		 * with a smaller block size instead.
+		 */
+		if (!last_block && !response_truncated &&
+		    payload_len !=
+			    coap_block_size_to_bytes(internal_req->recv_blk_ctx.block_size)) {
+			LOG_ERR("Payload size does not match the block size");
+			ret = -EBADMSG;
+			goto fail;
+		}
 	} else {
 		internal_req->offset = 0;
 		last_block = true;

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1158,6 +1158,15 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		return 0;
 	}
 
+	/* RFC 7252, section 5.3.2: for a piggybacked response, the message ID
+	 * of the Acknowledgment must match the request in addition to the
+	 * token. Separate CON/NON responses carry their own message ID.
+	 */
+	if (response_type == COAP_TYPE_ACK && response_id != (uint16_t)internal_req->last_id) {
+		LOG_WRN("Piggybacked response ID mismatch, dropping");
+		return 0;
+	}
+
 	/* Snapshot the slot's keep-alive flags before dropping the lock for the
 	 * callback below: a concurrent coap_client_deregister_observe() may clear
 	 * is_observe while we are in the callback, which must not retroactively

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -224,6 +224,87 @@ static enum coap_block_size coap_client_default_block_size(void)
 	return COAP_BLOCK_256;
 }
 
+static bool request_is_observe_register(const struct coap_client_request *req)
+{
+	for (int i = 0; i < req->num_options; i++) {
+		if (req->options[i].code != COAP_OPTION_OBSERVE) {
+			continue;
+		}
+		return req->options[i].len == 0U ||
+		       (req->options[i].len == 1U && req->options[i].value[0] == 0U);
+	}
+
+	return false;
+}
+
+/* Uri-Host, Uri-Port and Uri-Query options change the target resource beyond
+ * what the path spells out.
+ */
+static bool request_has_uri_options(const struct coap_client_request *req)
+{
+	for (int i = 0; i < req->num_options; i++) {
+		switch (req->options[i].code) {
+		case COAP_OPTION_URI_HOST:
+		case COAP_OPTION_URI_PORT:
+		case COAP_OPTION_URI_QUERY:
+			return true;
+		default:
+			break;
+		}
+	}
+
+	return false;
+}
+
+static const char *skip_leading_slashes(const char *path)
+{
+	while (*path == '/') {
+		path++;
+	}
+
+	return path;
+}
+
+/* RFC 7641, section 3.1: a client must not register more than once for the
+ * same target resource of the same server. Only registrations whose target
+ * is fully described by the path and the destination address are compared;
+ * a request carrying Uri-Host, Uri-Port or Uri-Query options addresses a
+ * resource this comparison cannot identify and is never treated as a
+ * duplicate.
+ */
+static bool observe_registration_exists(const struct coap_client *client,
+					const struct coap_client_request *req,
+					const struct net_sockaddr *addr)
+{
+	if (request_has_uri_options(req)) {
+		return false;
+	}
+
+	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
+		const struct coap_client_internal_request *ir = &client->requests[i];
+
+		if (!ir->request_ongoing || !ir->is_observe) {
+			continue;
+		}
+		if (request_has_uri_options(&ir->coap_request)) {
+			continue;
+		}
+		if (strcmp(skip_leading_slashes(ir->coap_request.path),
+			   skip_leading_slashes(req->path)) != 0) {
+			continue;
+		}
+		if (ir->addrlen == 0U && addr == NULL) {
+			return true;
+		}
+		if (ir->addrlen != 0U && addr != NULL &&
+		    net_sockaddr_cmp((const struct net_sockaddr *)&ir->addr, addr)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static int coap_client_init_request(struct coap_client *client, struct coap_client_request *req,
 				    struct coap_client_internal_request *internal_req)
 {
@@ -455,6 +536,12 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 	}
 
 	k_mutex_lock(&client->lock, K_FOREVER);
+
+	if (request_is_observe_register(req) && observe_registration_exists(client, req, addr)) {
+		LOG_ERR("Observe registration for the resource already ongoing");
+		ret = -EALREADY;
+		goto out;
+	}
 
 	internal_req = get_free_request(client);
 

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -59,7 +59,8 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 			   net_socklen_t addrlen, const struct coap_packet *response,
 			   bool response_truncated);
 static struct coap_client_internal_request *get_request_with_mid(struct coap_client *client,
-								 uint16_t mid);
+								 uint16_t mid,
+								 const struct net_sockaddr *from);
 
 static int send_request(int sock, const void *buf, size_t len, int flags,
 			const struct net_sockaddr *dest_addr, net_socklen_t addrlen)
@@ -989,8 +990,31 @@ static int send_rst(int sock_fd, const struct net_sockaddr *addr, net_socklen_t 
 	return 0;
 }
 
+/* RFC 7252, sections 4.4 and 5.3.2: the source endpoint of a response,
+ * Acknowledgment or Reset must match the destination endpoint of the
+ * request. The check is skipped when either address is unknown (connected
+ * sockets) and for multicast requests, whose responses arrive from the
+ * group members' unicast addresses.
+ */
+static bool source_matches_request(const struct coap_client_internal_request *internal_req,
+				   const struct net_sockaddr *from)
+{
+	if (internal_req->addrlen == 0U || from == NULL || from->sa_family == NET_AF_UNSPEC) {
+		return true;
+	}
+
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	if (internal_req->is_mcast) {
+		return true;
+	}
+#endif
+
+	return net_sockaddr_cmp((const struct net_sockaddr *)&internal_req->addr, from);
+}
+
 static struct coap_client_internal_request *get_request_with_token(
-	struct coap_client *client, const struct coap_packet *resp)
+	struct coap_client *client, const struct coap_packet *resp,
+	const struct net_sockaddr *from)
 {
 
 	uint8_t response_token[COAP_TOKEN_MAX_LEN];
@@ -1008,7 +1032,8 @@ static struct coap_client_internal_request *get_request_with_token(
 				continue;
 			}
 			if (memcmp(&client->requests[i].request_token, &response_token,
-			    response_tkl) == 0) {
+			    response_tkl) == 0 &&
+			    source_matches_request(&client->requests[i], from)) {
 				return &client->requests[i];
 			}
 		}
@@ -1018,11 +1043,13 @@ static struct coap_client_internal_request *get_request_with_token(
 }
 
 static struct coap_client_internal_request *get_request_with_mid(struct coap_client *client,
-								 uint16_t mid)
+								 uint16_t mid,
+								 const struct net_sockaddr *from)
 {
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
 		if (client->requests[i].request_ongoing) {
-			if (client->requests[i].last_id == (int)mid) {
+			if (client->requests[i].last_id == (int)mid &&
+			    source_matches_request(&client->requests[i], from)) {
 				return &client->requests[i];
 			}
 		}
@@ -1087,7 +1114,7 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	const uint8_t *payload = coap_packet_get_payload(response, &payload_len);
 
 	if (response_type == COAP_TYPE_RESET) {
-		internal_req = get_request_with_mid(client, response_id);
+		internal_req = get_request_with_mid(client, response_id, addr);
 		if (!internal_req) {
 			LOG_WRN("No matching request for RESET");
 			return 0;
@@ -1100,7 +1127,7 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	/* Separate response coming */
 	if (payload_len == 0 && response_type == COAP_TYPE_ACK &&
 	    response_code == COAP_CODE_EMPTY) {
-		internal_req = get_request_with_mid(client, response_id);
+		internal_req = get_request_with_mid(client, response_id, addr);
 		if (internal_req == NULL) {
 			LOG_WRN("No matching request for ACK");
 			return 0;
@@ -1115,7 +1142,7 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		return 1;
 	}
 
-	internal_req = get_request_with_token(client, response);
+	internal_req = get_request_with_token(client, response, addr);
 	if (!internal_req) {
 		LOG_WRN("No matching request for response");
 		if (response_type != COAP_TYPE_ACK) {

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1311,6 +1311,7 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		ret = coap_update_from_block(response, &internal_req->recv_blk_ctx);
 		if (ret < 0) {
 			LOG_ERR("Error updating block context");
+			goto fail;
 		}
 		coap_next_block(response, &internal_req->recv_blk_ctx);
 	} else {

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -99,6 +99,7 @@ static int receive(int sock, void *buf, size_t max_len, int flags,
 static void reset_internal_request(struct coap_client_internal_request *request)
 {
 	*request = (struct coap_client_internal_request){
+		.last_observe_seq = -1,
 		.last_response_id = -1,
 	};
 }
@@ -1286,6 +1287,35 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		}
 		LOG_DBG("Drop request, already handled");
 		return 0;
+	}
+
+	/* RFC 7641, section 3.4: the notification sent most recently is the
+	 * freshest, regardless of arrival order. Drop a notification whose
+	 * Observe sequence number is not newer than the last accepted one,
+	 * unless more than 128 seconds passed since that one arrived. A CON
+	 * notification was already acknowledged at the message layer. Block2
+	 * continuations of an accepted notification carry no Observe option
+	 * per RFC 7959, section 2.6; one echoed there anyway must not stall
+	 * the transfer. Checked before touching the pending state: a stale
+	 * notification matches the request token while a Block2 continuation
+	 * may be in flight, and clearing its pending entry here would disable
+	 * the continuation's retransmission and could hang the transfer.
+	 */
+	if (internal_req->is_observe) {
+		int seq = coap_get_option_int(response, COAP_OPTION_OBSERVE);
+		int block2 = coap_get_option_int(response, COAP_OPTION_BLOCK2);
+		int64_t now = k_uptime_get();
+
+		if (seq >= 0 && (block2 < 0 || GET_BLOCK_NUM(block2) == 0)) {
+			if (internal_req->last_observe_seq >= 0 &&
+			    !coap_age_is_newer(internal_req->last_observe_seq, seq) &&
+			    (now - internal_req->last_observe_at) <= 128 * MSEC_PER_SEC) {
+				LOG_DBG("Dropping reordered observe notification");
+				return 0;
+			}
+			internal_req->last_observe_seq = seq;
+			internal_req->last_observe_at = now;
+		}
 	}
 
 	if (internal_req->pending.timeout != 0) {

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -818,6 +818,43 @@ ZTEST(coap, test_block2_request_more_bit_ignored)
 	zassert_equal(ctx.current, 128, "Unexpected block position");
 }
 
+ZTEST(coap, test_block_bert_rejected_over_udp)
+{
+	struct coap_block_context ctx;
+	struct coap_packet pkt;
+	uint8_t data[128];
+	int r;
+
+	/* RFC 7959, section 2.2: SZX value 7 is reserved outside reliable
+	 * transports and leads to a 4.00 Bad Request response. A request with
+	 * a BERT block2 option is rejected by the server-side update.
+	 */
+	r = coap_packet_init(&pkt, data, sizeof(data), COAP_VERSION_1, COAP_TYPE_CON,
+			     COAP_TOKEN_MAX_LEN, coap_next_token(), COAP_METHOD_GET,
+			     coap_next_id());
+	zassert_equal(r, 0, "Failed to init request");
+
+	r = coap_append_option_int(&pkt, COAP_OPTION_BLOCK2, (1 << 4) | COAP_BLOCK_BERT);
+	zassert_equal(r, 0, "Failed to append block2 option");
+
+	coap_block_transfer_init(&ctx, COAP_BLOCK_1024, 4096);
+	zassert_equal(coap_update_from_block(&pkt, &ctx), -EINVAL,
+		      "BERT block size in a request must be rejected over UDP");
+
+	/* The same applies to the client side receiving a BERT response */
+	r = coap_packet_init(&pkt, data, sizeof(data), COAP_VERSION_1, COAP_TYPE_ACK,
+			     COAP_TOKEN_MAX_LEN, coap_next_token(),
+			     COAP_RESPONSE_CODE_CONTENT, coap_next_id());
+	zassert_equal(r, 0, "Failed to init response");
+
+	r = coap_append_option_int(&pkt, COAP_OPTION_BLOCK2, BIT(3) | COAP_BLOCK_BERT);
+	zassert_equal(r, 0, "Failed to append block2 option");
+
+	coap_block_transfer_init(&ctx, COAP_BLOCK_1024, 4096);
+	zassert_equal(coap_update_from_block(&pkt, &ctx), -EINVAL,
+		      "BERT block size in a response must be rejected over UDP");
+}
+
 ZTEST(coap, test_retransmit_second_round)
 {
 	struct coap_packet cpkt;

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -84,7 +84,6 @@ static uint8_t data_buf[2][COAP_BUF_SIZE];
 #define COAP_MAX_AGE      0xffffff
 #define COAP_FIRST_AGE    2
 
-extern bool coap_age_is_newer(int v1, int v2);
 
 ZTEST(coap, test_build_empty_pdu)
 {

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -793,6 +793,31 @@ ZTEST(coap, test_block2_size)
 	}
 }
 
+ZTEST(coap, test_block2_request_more_bit_ignored)
+{
+	struct coap_block_context ctx;
+	struct coap_packet req;
+	uint8_t data[128];
+	int r;
+
+	/* RFC 7959, section 2.4: the M bit of a Block2 option in a request
+	 * has no function and is ignored by the server.
+	 */
+	r = coap_packet_init(&req, data, sizeof(data), COAP_VERSION_1, COAP_TYPE_CON,
+			     COAP_TOKEN_MAX_LEN, coap_next_token(), COAP_METHOD_GET,
+			     coap_next_id());
+	zassert_equal(r, 0, "Failed to init request");
+
+	r = coap_append_option_int(&req, COAP_OPTION_BLOCK2, (2 << 4) | BIT(3) | COAP_BLOCK_64);
+	zassert_equal(r, 0, "Failed to append block2 option");
+
+	coap_block_transfer_init(&ctx, COAP_BLOCK_64, 256);
+
+	r = coap_update_from_block(&req, &ctx);
+	zassert_equal(r, 0, "M bit in a block2 request must be ignored (%d)", r);
+	zassert_equal(ctx.current, 128, "Unexpected block position");
+}
+
 ZTEST(coap, test_retransmit_second_round)
 {
 	struct coap_packet cpkt;

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -188,6 +188,31 @@ ZTEST(coap, test_parse_empty_pdu)
 	zassert_equal(id, 0U, "Packet id doesn't match reference");
 }
 
+ZTEST(coap, test_parse_malformed_empty_message)
+{
+	/* RFC 7252, section 4.1: an Empty message has the token length set to
+	 * zero and no bytes after the message ID.
+	 */
+	uint8_t empty_with_token[] = { 0x62, 0x00, 0x12, 0x34, 0xde, 0xad };
+	uint8_t empty_with_extra[] = { 0x60, 0x00, 0x12, 0x34, 0xff, 0x42 };
+	uint8_t empty_ok[] = { 0x60, 0x00, 0x12, 0x34 };
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+	int r;
+
+	memcpy(data, empty_with_token, sizeof(empty_with_token));
+	r = coap_packet_parse(&cpkt, data, sizeof(empty_with_token), NULL, 0);
+	zassert_equal(r, -EBADMSG, "Empty message with a token not rejected");
+
+	memcpy(data, empty_with_extra, sizeof(empty_with_extra));
+	r = coap_packet_parse(&cpkt, data, sizeof(empty_with_extra), NULL, 0);
+	zassert_equal(r, -EBADMSG, "Empty message with a payload not rejected");
+
+	memcpy(data, empty_ok, sizeof(empty_ok));
+	r = coap_packet_parse(&cpkt, data, sizeof(empty_ok), NULL, 0);
+	zassert_equal(r, 0, "Well-formed Empty message rejected");
+}
+
 /* 1 option, No payload (No payload marker) */
 ZTEST(coap, test_parse_empty_pdu_1)
 {

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -190,6 +190,40 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_wrong_source(int sock, void *bu
 	return ret;
 }
 
+/* A datagram shorter than a CoAP header, then a valid response */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_runt(int sock, void *buf, size_t max_len,
+						      int flags,
+						      struct net_sockaddr *src_addr,
+						      net_socklen_t *addrlen)
+{
+	((uint8_t *)buf)[0] = 0x60;
+	((uint8_t *)buf)[1] = 0x45;
+
+	fill_recv_src_addr(src_addr, addrlen);
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake;
+
+	return 2;
+}
+
+/* A malformed packet (reserved token length 15), then a runt datagram */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_malformed(int sock, void *buf, size_t max_len,
+							   int flags,
+							   struct net_sockaddr *src_addr,
+							   net_socklen_t *addrlen)
+{
+	((uint8_t *)buf)[0] = 0x6F;
+	((uint8_t *)buf)[1] = 0x45;
+	((uint8_t *)buf)[2] = 0x00;
+	((uint8_t *)buf)[3] = 0x00;
+
+	fill_recv_src_addr(src_addr, addrlen);
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_runt;
+
+	return 4;
+}
+
 /* Piggybacked response with the right token but a corrupted message ID */
 static ssize_t z_impl_zsock_recvfrom_custom_fake_wrong_mid(int sock, void *buf, size_t max_len,
 							   int flags,
@@ -912,6 +946,20 @@ ZTEST(coap_client, test_blockwise_short_block_fails)
 	 */
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_equal(last_response_code, -EBADMSG, "Unexpected response");
+}
+
+ZTEST(coap_client, test_malformed_packet_ignored)
+{
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_malformed;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
+
+	/* The malformed packet and the runt datagram are dropped without
+	 * cancelling the exchange, and the valid response that follows
+	 * completes it.
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_separate_response)

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -1431,6 +1431,49 @@ ZTEST(coap_client, test_observe_reordered_notification_dropped)
 		      "Reordered notification must be dropped");
 }
 
+ZTEST(coap_client, test_observe_duplicate_registration_rejected)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.cb = coap_callback,
+		.options = { {
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		} },
+		.num_options = 1,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_observe;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* RFC 7641, section 3.1: a second registration for the same resource
+	 * of the same server is rejected, also when the path spells the same
+	 * URI with a leading slash.
+	 */
+	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL),
+		      -EALREADY, "Duplicate observe registration not rejected");
+
+	strcpy(req.path, "/" TEST_PATH);
+	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL),
+		      -EALREADY, "Duplicate registration with a leading slash not rejected");
+
+	/* A Uri-Query option addresses a different resource; the registration
+	 * is not a duplicate.
+	 */
+	strcpy(req.path, TEST_PATH);
+	req.options[1].code = COAP_OPTION_URI_QUERY;
+	req.options[1].len = 3U;
+	memcpy(req.options[1].value, "x=1", 3);
+	req.num_options = 2;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+}
+
 ZTEST(coap_client, test_observe_deregister_con)
 {
 	struct coap_client_request req = {

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -67,10 +67,11 @@ static struct coap_client_request long_request = {
 	.user_data = &sem2,
 };
 
-/* Dummy destination addresses */
-static struct net_sockaddr_storage dst_address = {
-	.ss_family = NET_AF_INET,
-};
+/* Destination of the requests; the response fakes fill the same address as
+ * the response source (see recv_src_address), matching the RFC 7252,
+ * section 5.3.2, source endpoint check.
+ */
+static struct net_sockaddr_storage dst_address;
 static struct net_sockaddr_in mcast_address = {
 	.sin_family = NET_AF_INET,
 	.sin_addr = {{{224, 0, 1, 187}}},
@@ -80,6 +81,13 @@ static const struct net_sockaddr_in recv_src_address = {
 	.sin_family = NET_AF_INET,
 	.sin_port = 0x1600,
 	.sin_addr = {{{192, 0, 2, 1}}},
+};
+
+/* A source address the requests were never sent to */
+static const struct net_sockaddr_in recv_wrong_src_address = {
+	.sin_family = NET_AF_INET,
+	.sin_port = 0x1600,
+	.sin_addr = {{{192, 0, 2, 99}}},
 };
 
 static void fill_recv_src_addr(struct net_sockaddr *src_addr, net_socklen_t *addrlen)
@@ -163,6 +171,23 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake(int sock, void *buf, size_t max
 	clear_socket_events(sock, ZSOCK_POLLIN);
 
 	return sizeof(ack_data);
+}
+
+/* Valid piggybacked response, but reported from an address the request was
+ * not sent to.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_wrong_source(int sock, void *buf, size_t max_len,
+							      int flags,
+							      struct net_sockaddr *src_addr,
+							      net_socklen_t *addrlen)
+{
+	ssize_t ret = z_impl_zsock_recvfrom_custom_fake(sock, buf, max_len, flags, src_addr,
+							addrlen);
+
+	memcpy(src_addr, &recv_wrong_src_address, sizeof(recv_wrong_src_address));
+	*addrlen = sizeof(recv_wrong_src_address);
+
+	return ret;
 }
 
 static ssize_t z_impl_zsock_sendto_custom_fake(int sock, void *buf, size_t len, int flags,
@@ -594,6 +619,11 @@ static void *suite_setup(void)
 	hwtimer_set_rt_ratio(100.0);
 	k_sleep(K_MSEC(1));
 #endif
+	/* Requests go to the same address the response fakes report as the
+	 * response source, so the source endpoint check matches.
+	 */
+	memcpy(&dst_address, &recv_src_address, sizeof(recv_src_address));
+
 	net_coap_init();
 	zassert_ok(coap_client_init(&client, NULL));
 	zassert_ok(coap_client_init(&client2, NULL));
@@ -737,6 +767,25 @@ ZTEST(coap_client, test_no_response)
 
 	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, &params));
 
+	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
+	zassert_equal(last_response_code, -ETIMEDOUT, "Unexpected response");
+}
+
+ZTEST(coap_client, test_response_from_wrong_source_ignored)
+{
+	struct coap_transmission_parameters params = {
+		.ack_timeout = LONG_ACK_TIMEOUT_MS,
+		.coap_backoff_percent = 200,
+		.max_retransmission = 0
+	};
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_wrong_source;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, &params));
+
+	/* The response comes from an address the request was not sent to and
+	 * must not be matched to it; the request times out instead.
+	 */
 	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, -ETIMEDOUT, "Unexpected response");
 }

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -475,8 +475,8 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_empty_ack(int sock, void *buf, 
 {
 	uint16_t last_message_id = 0;
 
-	static uint8_t ack_data[] = {0x60, 0x00, 0x00, 0x00, 0x00, 0x00,
-				     0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	/* RFC 7252, section 4.1: an Empty message is exactly four bytes */
+	static uint8_t ack_data[] = {0x60, 0x00, 0x00, 0x00};
 
 	last_message_id = get_next_pending_message_id();
 
@@ -528,8 +528,8 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_rst(int sock, void *buf, size_t
 {
 	uint16_t last_message_id = 0;
 
-	static uint8_t rst_data[] = {0x70, 0x00, 0x00, 0x00, 0x00, 0x00,
-				     0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	/* RFC 7252, section 4.1: an Empty message is exactly four bytes */
+	static uint8_t rst_data[] = {0x70, 0x00, 0x00, 0x00};
 
 	last_message_id = get_next_pending_message_id();
 

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -458,6 +458,36 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_empty_ack(int sock, void *buf, 
 	return sizeof(ack_data);
 }
 
+/* Piggybacked block2 response with the more bit set but a payload shorter
+ * than the block size.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_block2_short(int sock, void *buf, size_t max_len,
+							      int flags,
+							      struct net_sockaddr *src_addr,
+							      net_socklen_t *addrlen)
+{
+	struct coap_packet response;
+	uint8_t token[COAP_TOKEN_MAX_LEN] = {0};
+	uint8_t payload[10];
+	uint16_t message_id = get_next_pending_message_id();
+
+	memset(payload, 'A', sizeof(payload));
+
+	zassert_ok(coap_packet_init(&response, buf, max_len, COAP_VERSION_1, COAP_TYPE_ACK,
+				    COAP_TOKEN_MAX_LEN, token, COAP_RESPONSE_CODE_CONTENT,
+				    message_id));
+	zassert_ok(coap_append_option_int(&response, COAP_OPTION_BLOCK2,
+					  BIT(3) | COAP_BLOCK_256));
+	zassert_ok(coap_packet_append_payload_marker(&response));
+	zassert_ok(coap_packet_append_payload(&response, payload, sizeof(payload)));
+
+	restore_token(buf);
+	fill_recv_src_addr(src_addr, addrlen);
+	clear_socket_events(sock, ZSOCK_POLLIN);
+
+	return response.offset;
+}
+
 static ssize_t z_impl_zsock_recvfrom_custom_fake_rst(int sock, void *buf, size_t max_len, int flags,
 						     struct net_sockaddr *src_addr,
 						     net_socklen_t *addrlen)
@@ -869,6 +899,19 @@ ZTEST(coap_client, test_piggybacked_response_wrong_mid_ignored)
 	 */
 	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, -ETIMEDOUT, "Unexpected response");
+}
+
+ZTEST(coap_client, test_blockwise_short_block_fails)
+{
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_block2_short;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
+
+	/* RFC 7959, section 2.3: a block with the more bit set whose payload
+	 * does not match the block size fails the transfer.
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, -EBADMSG, "Unexpected response");
 }
 
 ZTEST(coap_client, test_separate_response)

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -190,6 +190,20 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_wrong_source(int sock, void *bu
 	return ret;
 }
 
+/* Piggybacked response with the right token but a corrupted message ID */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_wrong_mid(int sock, void *buf, size_t max_len,
+							   int flags,
+							   struct net_sockaddr *src_addr,
+							   net_socklen_t *addrlen)
+{
+	ssize_t ret = z_impl_zsock_recvfrom_custom_fake(sock, buf, max_len, flags, src_addr,
+							addrlen);
+
+	((uint8_t *)buf)[3] ^= 0xFF;
+
+	return ret;
+}
+
 static ssize_t z_impl_zsock_sendto_custom_fake(int sock, void *buf, size_t len, int flags,
 					       const struct net_sockaddr *dest_addr,
 					       net_socklen_t addrlen)
@@ -594,6 +608,13 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_observe(int sock, void *buf, si
 	int ret = z_impl_zsock_recvfrom_custom_fake_duplicate_response(sock, buf, max_len, flags,
 								       src_addr, addrlen);
 
+	/* Notifications are Non-confirmable messages with a fresh message ID;
+	 * an Acknowledgment type would have to echo a request's message ID
+	 * (RFC 7252, section 4.4).
+	 */
+	((uint8_t *)buf)[0] = (COAP_VERSION_1 << 6) | (COAP_TYPE_NON_CON << 4) |
+			      COAP_TOKEN_MAX_LEN;
+
 	set_next_pending_message_id(get_next_pending_message_id() + 1);
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_observe;
 	return ret;
@@ -785,6 +806,25 @@ ZTEST(coap_client, test_response_from_wrong_source_ignored)
 
 	/* The response comes from an address the request was not sent to and
 	 * must not be matched to it; the request times out instead.
+	 */
+	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
+	zassert_equal(last_response_code, -ETIMEDOUT, "Unexpected response");
+}
+
+ZTEST(coap_client, test_piggybacked_response_wrong_mid_ignored)
+{
+	struct coap_transmission_parameters params = {
+		.ack_timeout = LONG_ACK_TIMEOUT_MS,
+		.coap_backoff_percent = 200,
+		.max_retransmission = 0
+	};
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_wrong_mid;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, &params));
+
+	/* An Acknowledgment whose message ID does not match the request must
+	 * not be accepted on the token alone; the request times out instead.
 	 */
 	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, -ETIMEDOUT, "Unexpected response");

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -620,6 +620,34 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_observe(int sock, void *buf, si
 	return ret;
 }
 
+/* Piggybacked block2 response with the reserved SZX value 7 (BERT) */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_block2_bert(int sock, void *buf, size_t max_len,
+							     int flags,
+							     struct net_sockaddr *src_addr,
+							     net_socklen_t *addrlen)
+{
+	struct coap_packet response;
+	uint8_t token[COAP_TOKEN_MAX_LEN] = {0};
+	uint8_t payload[16];
+	uint16_t message_id = get_next_pending_message_id();
+
+	memset(payload, 'B', sizeof(payload));
+
+	zassert_ok(coap_packet_init(&response, buf, max_len, COAP_VERSION_1, COAP_TYPE_ACK,
+				    COAP_TOKEN_MAX_LEN, token, COAP_RESPONSE_CODE_CONTENT,
+				    message_id));
+	zassert_ok(coap_append_option_int(&response, COAP_OPTION_BLOCK2,
+					  BIT(3) | COAP_BLOCK_BERT));
+	zassert_ok(coap_packet_append_payload_marker(&response));
+	zassert_ok(coap_packet_append_payload(&response, payload, sizeof(payload)));
+
+	restore_token(buf);
+	fill_recv_src_addr(src_addr, addrlen);
+	clear_socket_events(sock, ZSOCK_POLLIN);
+
+	return response.offset;
+}
+
 void coap_callback(const struct coap_client_response_data *data, void *user_data)
 {
 	LOG_INF("CoAP response callback, %d", data->result_code);
@@ -703,6 +731,19 @@ ZTEST(coap_client, test_request_block)
 
 	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL),
 		      -EAGAIN, "");
+}
+
+ZTEST(coap_client, test_blockwise_bert_response_fails)
+{
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_block2_bert;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
+
+	/* RFC 7959, section 2.2: SZX value 7 is reserved over UDP; the
+	 * exchange fails instead of the payload reaching the application.
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, -EINVAL, "Unexpected response");
 }
 
 ZTEST(coap_client, test_resend_request)

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -1271,6 +1271,166 @@ static ssize_t z_impl_zsock_sendto_custom_fake_deregister_non(int sock, void *bu
 	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
 }
 
+static int observe_seq_idx;
+static const int observe_seq_values[] = {2, 5, 3, 6};
+static int observe_notifications_delivered;
+
+/* Serve one notification per receive, with Observe option values taken from
+ * observe_seq_values: an initial piggybacked response followed by
+ * Non-confirmable notifications with fresh message IDs.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_observe_reorder(int sock, void *buf,
+								 size_t max_len, int flags,
+								 struct net_sockaddr *src_addr,
+								 net_socklen_t *addrlen)
+{
+	struct coap_packet response;
+	static uint16_t message_id;
+	bool first = observe_seq_idx == 0;
+	bool last = observe_seq_idx == (ARRAY_SIZE(observe_seq_values) - 1);
+
+	zassert_true(observe_seq_idx < ARRAY_SIZE(observe_seq_values), "Too many receives");
+
+	if (first) {
+		message_id = get_next_pending_message_id();
+	} else {
+		message_id++;
+	}
+
+	zassert_ok(coap_packet_init(&response, buf, max_len, COAP_VERSION_1,
+				    first ? COAP_TYPE_ACK : COAP_TYPE_NON_CON,
+				    COAP_TOKEN_MAX_LEN, saved_observe_token,
+				    COAP_RESPONSE_CODE_CONTENT, message_id));
+	zassert_ok(coap_append_option_int(&response, COAP_OPTION_OBSERVE,
+					  observe_seq_values[observe_seq_idx]));
+	zassert_ok(coap_packet_append_payload_marker(&response));
+	zassert_ok(coap_packet_append_payload(&response, (const uint8_t *)"n", 1));
+
+	fill_recv_src_addr(src_addr, addrlen);
+
+	observe_seq_idx++;
+	if (last) {
+		clear_socket_events(sock, ZSOCK_POLLIN);
+	} else {
+		set_socket_events(sock, ZSOCK_POLLIN);
+	}
+
+	return response.offset;
+}
+
+static void observe_count_cb(const struct coap_client_response_data *data, void *user_data)
+{
+	if (data->result_code >= 0) {
+		observe_notifications_delivered++;
+	}
+	last_response_code = data->result_code;
+}
+
+static int observe_oneshot_seq;
+
+/* Serve a single notification with the Observe value from observe_oneshot_seq;
+ * the test re-arms POLLIN for each further notification.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_observe_oneshot(int sock, void *buf,
+								 size_t max_len, int flags,
+								 struct net_sockaddr *src_addr,
+								 net_socklen_t *addrlen)
+{
+	struct coap_packet response;
+	static uint16_t message_id;
+	uint16_t pending = get_next_pending_message_id();
+	bool first = pending != UINT16_MAX;
+
+	message_id = first ? pending : (uint16_t)(message_id + 1U);
+
+	zassert_ok(coap_packet_init(&response, buf, max_len, COAP_VERSION_1,
+				    first ? COAP_TYPE_ACK : COAP_TYPE_NON_CON,
+				    COAP_TOKEN_MAX_LEN, saved_observe_token,
+				    COAP_RESPONSE_CODE_CONTENT, message_id));
+	zassert_ok(coap_append_option_int(&response, COAP_OPTION_OBSERVE, observe_oneshot_seq));
+	zassert_ok(coap_packet_append_payload_marker(&response));
+	zassert_ok(coap_packet_append_payload(&response, (const uint8_t *)"n", 1));
+
+	fill_recv_src_addr(src_addr, addrlen);
+	clear_socket_events(sock, ZSOCK_POLLIN);
+
+	return response.offset;
+}
+
+ZTEST(coap_client, test_observe_freshness_timeout)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.cb = observe_count_cb,
+		.options = { {
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		} },
+		.num_options = 1,
+	};
+
+	observe_notifications_delivered = 0;
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_observe_subscribe;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_observe_oneshot;
+
+	observe_oneshot_seq = 5;
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+	k_sleep(K_MSEC(1000));
+	zassert_equal(observe_notifications_delivered, 1, "Initial notification not delivered");
+
+	/* A stale value within 128 seconds is dropped */
+	observe_oneshot_seq = 3;
+	set_socket_events(client.fd, ZSOCK_POLLIN);
+	k_sleep(K_MSEC(1000));
+	zassert_equal(observe_notifications_delivered, 1, "Stale notification not dropped");
+
+	/* RFC 7641, section 3.4: after 128 seconds any value is fresh again */
+	k_sleep(K_SECONDS(129));
+	observe_oneshot_seq = 2;
+	set_socket_events(client.fd, ZSOCK_POLLIN);
+	k_sleep(K_MSEC(1000));
+	zassert_equal(observe_notifications_delivered, 2,
+		      "Notification after the freshness timeout dropped");
+}
+
+ZTEST(coap_client, test_observe_reordered_notification_dropped)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.cb = observe_count_cb,
+		.options = { {
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		} },
+		.num_options = 1,
+	};
+
+	observe_seq_idx = 0;
+	observe_notifications_delivered = 0;
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_observe_subscribe;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_observe_reorder;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* The notifications carry Observe values 2, 5, 3 and 6; the one with
+	 * value 3 arrives after 5 and is stale (RFC 7641, section 3.4), so
+	 * only three notifications reach the application.
+	 */
+	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
+	zassert_equal(observe_seq_idx, ARRAY_SIZE(observe_seq_values),
+		      "All notifications must be served");
+	zassert_equal(observe_notifications_delivered, 3,
+		      "Reordered notification must be dropped");
+}
+
 ZTEST(coap_client, test_observe_deregister_con)
 {
 	struct coap_client_request req = {


### PR DESCRIPTION
**Response matching and robustness (RFC 7252):**
- Match responses, ACKs and Resets against the request's destination endpoint (§4.4, §5.3.2). Previously any address was accepted on an unconnected socket, so spoofing a response only required the 8-byte token.
- Require the message ID of a piggybacked response to match the request in addition to the token (§5.3.2).
- Validate Empty messages: code 0.00 with a token, options or payload is a message format error (§4.1).
- Drop malformed packets instead of cancelling every ongoing request with `-EIO`; rejecting a message means ignoring it (§4.2, §4.3).

**Block-wise transfers (RFC 7959):**
- Ignore the `M` bit of `Block2` options in requests instead of rejecting them with `-EINVAL` (§2.4).
- Reject the reserved `SZX` value 7 over UDP instead of computing a 2048-byte block size from it (§2.2); `BERT` over reliable transports is unaffected.
- Fail a transfer when a non-final block's payload does not match the block size, instead of silently desynchronizing the transfer position (§2.3).

**Observe (RFC 7641):**
- Drop reordered notifications whose `Observe` value is not newer than the last accepted one (§3.4).
- Reject a duplicate observe registration for the same resource and server with `-EALREADY` (§3.1).