### PR TITLE
manifest: hal_espressif: link blobs as imported targets

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 5e3b702250c3e05de5a4cb3a53f74fc3cd8094cf
+      revision: 049f33f97a80912da7136c33527c8254fab3d6c8
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Links the Espressif blobs as imported targets so the build graph depends on the archives and relinks when west blobs fetch replaces them.