### PR TITLE
ci: workflows: set git http version to HTTP/1.1

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -76,6 +76,7 @@ jobs:
           rm -fr ".git/rebase-apply"
           git rebase origin/${BASE_REF}
           git log  --pretty=oneline | head -n 10
+          git config --global http.version HTTP/1.1
           west init -l . || true
           west config manifest.group-filter -- +ci
           west config --global update.narrow true
@@ -142,6 +143,7 @@ jobs:
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
           git -c advice.detachedHead=false checkout ${BSIM_VERSION}
+          git config --global http.version HTTP/1.1
           west update
           make everything -s -j 8
 

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -63,6 +63,7 @@ jobs:
           rm -fr ".git/rebase-apply"
           git rebase origin/${BASE_REF}
           git log  --pretty=oneline | head -n 10
+          git config --global http.version HTTP/1.1
           west init -l . || true
           west config --global update.narrow true
           west config manifest.group-filter -- +ci,+optional
@@ -95,6 +96,7 @@ jobs:
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
+          git config --global http.version HTTP/1.1
           git -c advice.detachedHead=false checkout ${BSIM_VERSION}
           west update
           make everything -s -j 8

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -67,6 +67,7 @@ jobs:
 
       - name: west setup
         run: |
+          git config --global http.version HTTP/1.1
           west init -l . || true
           west update 1> west.update.log || west update 1> west.update-2.log
 
@@ -92,6 +93,7 @@ jobs:
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
           git -c advice.detachedHead=false checkout ${BSIM_VERSION}
+          git config --global http.version HTTP/1.1
           west update
           make everything -s -j 8
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -55,6 +55,7 @@ jobs:
         # debug
         git log  --pretty=oneline | head -n 10
         west init -l . || true
+        git config --global http.version HTTP/1.1
         west config manifest.group-filter -- +ci,-optional
         west update -o=--depth=1 -n 2>&1 1> west.update.log || west update -o=--depth=1 -n 2>&1 1> west.update2.log
 

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -78,6 +78,7 @@ jobs:
           rm -fr ".git/rebase-apply"
           git rebase origin/${BASE_REF}
           git log  --pretty=oneline | head -n 10
+          git config --global http.version HTTP/1.1
           west init -l . || true
           west config manifest.group-filter -- +ci,+optional
           west config --global update.narrow true
@@ -188,6 +189,7 @@ jobs:
             git log  --pretty=oneline | head -n 10
           fi
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          git config --global http.version HTTP/1.1
 
           west init -l . || true
           west config manifest.group-filter -- +ci,+optional
@@ -219,6 +221,7 @@ jobs:
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
+          git config --global http.version HTTP/1.1
           git -c advice.detachedHead=false checkout ${BSIM_VERSION}
           west update
           make everything -s -j 8


### PR DESCRIPTION
Workaround GH git servers changing behavior causing issues with
HTTP/2-based git clone. Forcing HTTP/1.1 as suggested in a community
thread seems to fix the issue for now.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
