### PR TITLE
drivers: uaol: Support dynamic service interval from host IPC

### DIFF
--- a/drivers/dai/intel/uaol/uaol-params-intel-ipc4.h
+++ b/drivers/dai/intel/uaol/uaol-params-intel-ipc4.h
@@ -16,6 +16,7 @@ enum ipc4_uaol_aux_config_tlv_type {
 	IPC4_UAOL_AUX_CONFIG_TLV_USB_EP_INFO            = 3,
 	IPC4_UAOL_AUX_CONFIG_TLV_USB_EP_FEEDBACK_INFO   = 4,
 	IPC4_UAOL_AUX_CONFIG_TLV_USB_ART_DIVIDER        = 5,
+	IPC4_UAOL_AUX_CONFIG_TLV_SERVICE_INTERVAL       = 6,
 };
 
 enum ipc4_uaol_dma_control_tlv_type {

--- a/drivers/dai/intel/uaol/uaol.c
+++ b/drivers/dai/intel/uaol/uaol.c
@@ -64,6 +64,7 @@ static int dai_uaol_process_aux_config_data(struct dai_intel_uaol_data *dp,
 	struct ipc4_uaol_fifo_sao *fifo_sao = NULL;
 	struct ipc4_uaol_usb_ep_info *ep_info = NULL;
 	struct ipc4_uaol_usb_art_divider *art_divider = NULL;
+	uint32_t *service_interval = NULL;
 
 	for (i = 0; i <= size; i += hop) {
 		if (size - i < sizeof(struct ipc4_uaol_tlv)) {
@@ -93,6 +94,10 @@ static int dai_uaol_process_aux_config_data(struct dai_intel_uaol_data *dp,
 		case IPC4_UAOL_AUX_CONFIG_TLV_USB_ART_DIVIDER:
 			art_divider = (struct ipc4_uaol_usb_art_divider *)&tlv->value;
 			length = sizeof(struct ipc4_uaol_usb_art_divider);
+			break;
+		case IPC4_UAOL_AUX_CONFIG_TLV_SERVICE_INTERVAL:
+			service_interval = (uint32_t *)&tlv->value;
+			length = sizeof(uint32_t);
 			break;
 		default:
 			length = tlv->length;
@@ -139,7 +144,16 @@ static int dai_uaol_process_aux_config_data(struct dai_intel_uaol_data *dp,
 		dp->hw_cfg.art_divider_n = art_divider->divider;
 	}
 
-	dp->hw_cfg.service_interval = UAOL_SERVICE_INTERVAL_DEFAULT;
+	/*
+	 * Service interval from host IPC. Defaults to 1000 us  (standard isochronous) if not set
+	 * or 0. High-Speed devices can use micro frames, which can be 125/250/500 or 1000 us to
+	 * allow higher bandwidth.
+	 */
+	if (service_interval && *service_interval != 0) {
+		dp->hw_cfg.service_interval = *service_interval;
+	} else {
+		dp->hw_cfg.service_interval = UAOL_SERVICE_INTERVAL_DEFAULT;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Accept service_interval from the UAOL stream configuration (passed by host from TLV type 6 in the gateway config blob) and use it for budget calculations instead of the hardcoded 1000 µs assumption.

This enables automatic scaling for high-bandwidth USB devices:
- Standard isochronous (1000 µs): normal budget
- High-bandwidth isochronous (125/250/500 µs): 8/4/2× budget improvement

The payload size (aps) calculation automatically scales:
  aps = (sample_rate * service_interval_us * frame_size) / 1_000_000

Falls back to 1000 µs if service_interval is 0 for backward compatibility.