### PR TITLE
usb: host: uhc: track IN transfer progress

### DIFF
--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -93,6 +93,7 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
+				    const size_t rec_len,
 				    void *const cb,
 				    void *const cb_priv)
 {
@@ -147,6 +148,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	xfer->udev = udev;
 	xfer->cb = cb;
 	xfer->priv = cb_priv;
+	xfer->expected_data_len = rec_len;
 
 xfer_alloc_error:
 	api->unlock(dev);
@@ -169,7 +171,7 @@ struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
 		return NULL;
 	}
 
-	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv);
+	xfer = uhc_xfer_alloc(dev, ep, udev, size, cb, cb_priv);
 	if (xfer == NULL) {
 		net_buf_unref(buf);
 		return NULL;

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -143,6 +143,10 @@ struct uhc_transfer {
 	 * This flag is optional and is mainly used for testing.
 	 */
 	unsigned int no_status : 1;
+	/** Expected length of the data that wil be recived (device to host xfers only) */
+	size_t expected_data_len;
+	/** Length of the data that was already received (device to host xfers only) */
+	size_t recived_data_len;
 	/** Pointer to USB device */
 	struct usb_device *udev;
 	/** Pointer to transfer completion callback (opaque for the UHC) */
@@ -417,6 +421,8 @@ static inline int uhc_bus_resume(const struct device *dev)
  * @param[in] dev     Pointer to device struct of the driver instance
  * @param[in] ep      Endpoint address
  * @param[in] udev    Pointer to USB device
+ * @param[in] rec_len Desired length of the response from the device in bytes.
+ *                    Set to 0 if receiving one packet or if sending data.
  * @param[in] cb      Transfer completion callback
  * @param[in] cb_priv Completion callback callback private data
  *
@@ -425,6 +431,7 @@ static inline int uhc_bus_resume(const struct device *dev)
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
+				    const size_t rec_len,
 				    void *const cb,
 				    void *const cb_priv);
 

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -1516,11 +1516,13 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 	const struct usb_ep_descriptor *const stream_ep = stream_info->ep;
 	struct net_buf *buf;
 	struct uhc_transfer *xfer;
+	size_t rec_len =
+		USB_EP_DIR_IS_IN(stream_ep->bEndpointAddress) ? stream_info->ep_mps_mult : 0;
 	int ret;
 
 	LOG_DBG("Initiating transfer: ep=0x%02x, vbuf=%p", stream_ep->bEndpointAddress, vbuf);
 
-	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress,
+	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress, rec_len,
 			       stream_iso_req_cb, host_data);
 	if (xfer == NULL) {
 		LOG_ERR("Failed to allocate transfer");

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -66,7 +66,7 @@ int usbh_req_setup(struct usb_device *const udev,
 	uint8_t ep = usb_reqtype_is_to_device(&req) ? 0x00 : 0x80;
 	int ret;
 
-	xfer = usbh_xfer_alloc(udev, ep, ch9_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, wLength, ch9_req_cb, NULL);
 	if (!xfer) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -57,12 +57,13 @@ void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev);
 /* Wrappers around to avoid glue UHC calls. */
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,
+						   const size_t rec_len,
 						   usbh_udev_cb_t cb,
 						   void *const cb_priv)
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv);
+	return uhc_xfer_alloc(ctx->dev, ep, udev, rec_len, cb, cb_priv);
 }
 
 static inline int usbh_xfer_buf_add(const struct usb_device *udev,

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -235,6 +235,7 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	uint8_t addr;
 	uint8_t ep;
 	size_t len;
+	size_t rec_len;
 	int ret;
 
 	uhs_ctx = get_uhs_ctx_or_error(sh);
@@ -251,8 +252,9 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 
 	ep = strtol(argv[2], NULL, 16);
 	len = MIN(sizeof(vreq_test_buf), strtol(argv[3], NULL, 10));
+	rec_len = USB_EP_DIR_IS_IN(ep) ? len : 0;
 
-	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, rec_len, bulk_req_cb, NULL);
 	if (!xfer) {
 		shell_error(sh, "host: Failed to allocate transfer");
 		return -ENOMEM;

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -216,6 +216,7 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	struct usb_device *const udev = dev_ctx->udev;
 	uint32_t retry = USBIP_SUBMIT_REQ_RETRY_COUNT;
 	struct uhc_transfer *xfer;
+	size_t rec_len = USB_EP_DIR_IS_IN(ep) && buf != NULL ? cmd->submit.length : 0;
 	int ret;
 
 	/*
@@ -225,7 +226,7 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	 * be reworked to take a timeout argument.
 	 */
 	do {
-		xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd);
+		xfer = usbh_xfer_alloc(udev, ep, rec_len, usbip_req_cb, cmd_nd);
 		if (xfer == NULL) {
 			k_msleep(1);
 		}


### PR DESCRIPTION
An IN transfer completes when the expected amount of data is received, a short packet is received, or a zero-length packet is received.

Short and zero-length packets can be detected from their payload size. A full-size packet, however, does not indicate whether another transaction is needed. In particular, when the requested length equals the endpoint's maximum packet size, the host must know the expected length to recognize that the transfer is complete.

Add expected and received byte counts to UHC transfers and extend the allocation API to provide the requested receive length. Update existing call sites to use the new API.

Note: this is part of the effort extracted https://github.com/zephyrproject-rtos/zephyr/pull/110420.