### PR TITLE
boards: antmicro: Add potentiometer in reference platform repl

### DIFF
--- a/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
+++ b/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
@@ -68,6 +68,10 @@ phy: Network.EthernetPhysicalLayer @ ethernet 0
     AutoNegotiationExpansion: 0x0064
     AutoNegotiationNextPageTransmit: 0x2001
 
+potentiometer: Analog.Potentiometer @ adcM1S2 2
+    minVolt: 0
+    maxVolt: 3.3
+
 sysbus:
     init:
         Tag <0x58024800 4> "PWR_CR1_DBP_SET" 0x100


### PR DESCRIPTION
Add missing potentiometer entry to Antmicro's STM32H7 Renode Reference Platform REPL file.