### PR TITLE
modbus: implement locking callbacks in server

### DIFF
--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -389,6 +389,12 @@ struct modbus_user_callbacks {
 
 	/** Floating Point Holding Register write callback */
 	int (*holding_reg_wr_fp)(uint16_t addr, float reg);
+
+	/** Lock registers callback */
+	void (*lock_reg)();
+
+	/** Unlock registers callback */
+	void (*unlock_reg)();
 };
 
 /**

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -989,6 +989,10 @@ bool modbus_server_handler(struct modbus_context *ctx)
 
 	update_server_msg_ctr(ctx);
 
+	if (ctx->mbs_user_cb->lock_reg != NULL) {
+		ctx->mbs_user_cb->lock_reg();
+	}
+
 	switch (fc) {
 	case MODBUS_FC01_COIL_RD:
 		send_reply = mbs_fc01_coil_read(ctx);
@@ -1028,6 +1032,10 @@ bool modbus_server_handler(struct modbus_context *ctx)
 
 	default:
 		send_reply = mbs_try_user_fc(ctx, fc);
+	}
+
+	if (ctx->mbs_user_cb->unlock_reg != NULL) {
+		ctx->mbs_user_cb->unlock_reg();
 	}
 
 	if (addr == 0) {


### PR DESCRIPTION
Modbus server callbacks operate at the register level and provide no information about which registers will be accessed in a complete call.

If the application updates registers during a Modbus read operation, the returned results may inconsistently reflect both the state before and after the update.

To prevent this, two callbacks are introduced to allow resource locking during multi-register access:
- lock_reg
- unlock_reg