### PR TITLE
scripts: build: fix uf2conv.py's drive lookup, block fill and messages

### DIFF
--- a/scripts/build/uf2conv.py
+++ b/scripts/build/uf2conv.py
@@ -51,14 +51,14 @@ def convert_from_uf2(buf):
         block = buf[ptr : ptr + 512]
         hd = struct.unpack(b"<IIIIIIII", block[0:32])
         if hd[0] != UF2_MAGIC_START0 or hd[1] != UF2_MAGIC_START1:
-            print("Skipping block at " + ptr + "; bad magic")
+            print(f"Skipping block at {ptr}; bad magic")
             continue
         if hd[2] & 1:
             # NO-flash flag set; skip block
             continue
         datalen = hd[4]
         if datalen > 476:
-            raise AssertionError("Invalid UF2 data size at " + ptr)
+            raise AssertionError(f"Invalid UF2 data size at {ptr}")
         newaddr = hd[3]
         if (hd[2] & 0x2000) and (currfamilyid is None):
             currfamilyid = hd[7]
@@ -69,11 +69,11 @@ def convert_from_uf2(buf):
                 appstartaddr = newaddr
         padding = newaddr - curraddr
         if padding < 0:
-            raise AssertionError("Block out of order at " + ptr)
+            raise AssertionError(f"Block out of order at {ptr}")
         if padding > 10 * 1024 * 1024:
-            raise AssertionError("More than 10M of padding needed at " + ptr)
+            raise AssertionError(f"More than 10M of padding needed at {ptr}")
         if padding % 4 != 0:
-            raise AssertionError("Non-word padding size at " + ptr)
+            raise AssertionError(f"Non-word padding size at {ptr}")
         while padding > 0:
             padding -= 4
             outp.append(b"\x00\x00\x00\x00")

--- a/scripts/build/uf2conv.py
+++ b/scripts/build/uf2conv.py
@@ -251,7 +251,7 @@ def get_drives():
         for rootpath in searchpaths:
             if os.path.isdir(rootpath):
                 for d in os.listdir(rootpath):
-                    if os.path.isdir(rootpath):
+                    if os.path.isdir(os.path.join(rootpath, d)):
                         drives.append(os.path.join(rootpath, d))
 
     def has_info(d):

--- a/scripts/build/uf2conv.py
+++ b/scripts/build/uf2conv.py
@@ -229,22 +229,18 @@ def to_str(b):
 def get_drives():
     drives = []
     if sys.platform == "win32":
+        # Removable (DriveType 2) FAT volumes, which is what a UF2
+        # bootloader presents. wmic used to answer this, but it was removed
+        # in Windows 11 24H2, so ask PowerShell for the same two properties.
         r = subprocess.check_output(
             [
-                "wmic",
-                "PATH",
-                "Win32_LogicalDisk",
-                "get",
-                "DeviceID,",
-                "VolumeName,",
-                "FileSystem,",
-                "DriveType",
+                "powershell",
+                "-Command",
+                '(Get-WmiObject Win32_LogicalDisk'
+                ' -Filter "DriveType=2 AND FileSystem=\'FAT\'").DeviceID',
             ]
         )
-        for line in to_str(r).split('\n'):
-            words = re.split(r'\s+', line)
-            if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
-                drives.append(words[0])
+        drives = [line.strip() for line in to_str(r).splitlines() if line.strip()]
     else:
         searchpaths = ["/media"]
         if sys.platform == "darwin":

--- a/scripts/build/uf2conv.py
+++ b/scripts/build/uf2conv.py
@@ -155,9 +155,11 @@ def convert_to_uf2(file_content):
 
 
 class Block:
-    def __init__(self, addr):
+    def __init__(self, addr, default_data=0xFF):
         self.addr = addr
-        self.bytes = bytearray(256)
+        # 0xFF is what erased flash reads as on most MCUs, so a byte the
+        # hex file does not mention is left as the device would have it.
+        self.bytes = bytearray([default_data] * 256)
 
     def encode(self, blockno, numblocks):
         global familyid

--- a/scripts/build/uf2conv_test.py
+++ b/scripts/build/uf2conv_test.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for uf2conv
+"""
+
+import contextlib
+import io
+import os
+import struct
+import sys
+import unittest
+from unittest import mock
+
+import uf2conv
+
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+BASE = 0x1000
+
+
+def block(
+    addr,
+    payload,
+    blockno=0,
+    numblocks=1,
+    flags=0,
+    datalen=None,
+    magic0=UF2_MAGIC_START0,
+    magic1=UF2_MAGIC_START1,
+):
+    """One 512-byte UF2 block."""
+    head = struct.pack(
+        b"<IIIIIIII",
+        magic0,
+        magic1,
+        flags,
+        addr,
+        len(payload) if datalen is None else datalen,
+        blockno,
+        numblocks,
+        0,
+    )
+    return head + payload + b"\x00" * (476 - len(payload)) + struct.pack(b"<I", UF2_MAGIC_END)
+
+
+class TestReadingAUf2Image(unittest.TestCase):
+    """convert_from_uf2() walks the blocks and joins what they carry.
+
+    scripts/west_commands/bindesc.py carries a copy of this function; the
+    cases here are the ones both of them answer the same way.
+    """
+
+    def convert(self, buf):
+        # It reports on the last block and leaves appstartaddr behind, so
+        # neither the output of the run nor the next one is affected.
+        with (
+            mock.patch.object(uf2conv, "appstartaddr", 0x2000),
+            mock.patch.object(uf2conv, "familyid", 0x0),
+            contextlib.redirect_stdout(io.StringIO()) as out,
+        ):
+            return uf2conv.convert_from_uf2(buf), out.getvalue()
+
+    def refuse(self, buf):
+        with self.assertRaises(AssertionError) as caught:
+            self.convert(buf)
+        return str(caught.exception)
+
+    def test_contiguous_blocks_are_concatenated(self):
+        buf = block(BASE, b"A" * 16, 0, 2) + block(BASE + 16, b"B" * 16, 1, 2)
+
+        self.assertEqual(self.convert(buf)[0], b"A" * 16 + b"B" * 16)
+
+    def test_a_gap_between_blocks_is_padded_with_zeros(self):
+        """An image with a hole in it is the normal case, not an odd one."""
+        buf = block(BASE, b"A" * 16, 0, 2) + block(BASE + 32, b"B" * 16, 1, 2)
+
+        self.assertEqual(self.convert(buf)[0], b"A" * 16 + b"\x00" * 16 + b"B" * 16)
+
+    def test_a_block_with_the_wrong_magic_is_skipped_and_reported(self):
+        """Reported and skipped: the rest of the image still comes back."""
+        buf = block(BASE, b"A" * 16, 0, 2, magic0=0xDEADBEEF) + block(BASE, b"B" * 16, 1, 2)
+
+        payload, said = self.convert(buf)
+
+        self.assertEqual(payload, b"B" * 16)
+        self.assertIn("Skipping block at 0", said)
+
+    def test_a_block_that_is_not_for_flash_is_skipped(self):
+        buf = block(BASE, b"A" * 16, 0, 2, flags=0x1) + block(BASE, b"B" * 16, 1, 2)
+
+        self.assertEqual(self.convert(buf)[0], b"B" * 16)
+
+    def test_a_tail_too_short_to_be_a_block_is_ignored(self):
+        buf = block(BASE, b"A" * 16) + b"\x00" * 100
+
+        self.assertEqual(self.convert(buf)[0], b"A" * 16)
+
+    def test_a_payload_larger_than_the_block_is_refused(self):
+        self.assertEqual(
+            self.refuse(block(BASE, b"A" * 16, datalen=477)),
+            "Invalid UF2 data size at 0",
+        )
+
+    def test_a_block_before_the_one_ahead_of_it_is_refused(self):
+        buf = block(BASE, b"A" * 16, 0, 2) + block(BASE - 256, b"B" * 16, 1, 2)
+
+        self.assertEqual(self.refuse(buf), "Block out of order at 512")
+
+    def test_a_gap_that_is_not_a_whole_number_of_words_is_refused(self):
+        buf = block(BASE, b"A" * 16, 0, 2) + block(BASE + 19, b"B" * 16, 1, 2)
+
+        self.assertEqual(self.refuse(buf), "Non-word padding size at 512")
+
+    def test_a_gap_of_more_than_ten_megabytes_is_refused(self):
+        buf = block(BASE, b"A" * 16, 0, 2) + block(BASE + 16 + 11 * 1024 * 1024, b"B" * 16, 1, 2)
+
+        self.assertEqual(
+            self.refuse(buf),
+            "More than 10M of padding needed at 512",
+        )
+
+
+class TestGetDrivesOnWindows(unittest.TestCase):
+    """get_drives() asks PowerShell which volumes to offer."""
+
+    def get_drives(self, output):
+        # has_info() decides what survives; every candidate carries the
+        # marker file here, so what is under test is the listing itself.
+        with (
+            mock.patch.object(sys, "platform", "win32"),
+            mock.patch.object(uf2conv.subprocess, "check_output", return_value=output) as run,
+            mock.patch.object(uf2conv.os.path, "isfile", return_value=True),
+        ):
+            return uf2conv.get_drives(), run.call_args[0][0]
+
+    def test_one_device_id_per_line(self):
+        drives, _ = self.get_drives(b"D:\r\nE:\r\n")
+
+        self.assertEqual(drives, ["D:", "E:"])
+
+    def test_blank_lines_are_not_drives(self):
+        # Nothing attached is an empty answer, not an empty drive letter.
+        drives, _ = self.get_drives(b"\r\n")
+
+        self.assertEqual(drives, [])
+
+    def test_the_query_asks_for_a_removable_fat_volume(self):
+        """Both halves of what the wmic table used to be read for."""
+        _, cmd = self.get_drives(b"")
+        query = " ".join(cmd)
+
+        self.assertEqual(cmd[0], "powershell")
+        self.assertIn("DriveType=2", query)
+        self.assertIn("FileSystem='FAT'", query)
+
+    def test_wmic_is_not_asked(self):
+        # It was removed in Windows 11 24H2, so calling it raises before it
+        # can answer anything.
+        _, cmd = self.get_drives(b"")
+
+        self.assertNotIn("wmic", cmd)
+
+
+class TestGetDrivesElsewhere(unittest.TestCase):
+    """Off Windows the drives are directories under a few search paths."""
+
+    def get_drives(self, platform, dirs, entries, with_marker=()):
+        # Paths are joined the way the module joins them, so the assertions
+        # below read the same on a POSIX host and on Windows.
+        def isdir(path):
+            return path in dirs
+
+        def listdir(path):
+            return entries.get(path, [])
+
+        def isfile(path):
+            return path in with_marker
+
+        with (
+            mock.patch.object(sys, "platform", platform),
+            mock.patch.dict(uf2conv.os.environ, {"USER": "someone"}, clear=False),
+            mock.patch.object(uf2conv.os.path, "isdir", isdir),
+            mock.patch.object(uf2conv.os, "listdir", listdir),
+            mock.patch.object(uf2conv.os.path, "isfile", isfile),
+        ):
+            return uf2conv.get_drives()
+
+    def test_a_directory_holding_the_marker_file_is_a_drive(self):
+        board = os.path.join("/media", "BOARD")
+
+        drives = self.get_drives(
+            "linux",
+            dirs={"/media", board},
+            entries={"/media": ["BOARD"]},
+            with_marker=(board + uf2conv.INFO_FILE,),
+        )
+
+        self.assertEqual(drives, [board])
+
+    def test_a_file_beside_it_is_not(self):
+        """The entry is what has to be a directory, not the path it is under."""
+        board = os.path.join("/media", "BOARD")
+        notes = os.path.join("/media", "notes.txt")
+
+        drives = self.get_drives(
+            "linux",
+            dirs={"/media", board},  # notes.txt is not a directory
+            entries={"/media": ["BOARD", "notes.txt"]},
+            with_marker=(board + uf2conv.INFO_FILE, notes + uf2conv.INFO_FILE),
+        )
+
+        self.assertEqual(drives, [board])
+
+    def test_a_directory_without_the_marker_file_is_not(self):
+        board = os.path.join("/media", "BOARD")
+        stick = os.path.join("/media", "usb-stick")
+
+        drives = self.get_drives(
+            "linux",
+            dirs={"/media", board, stick},
+            entries={"/media": ["BOARD", "usb-stick"]},
+            with_marker=(board + uf2conv.INFO_FILE,),
+        )
+
+        self.assertEqual(drives, [board])
+
+    def test_macos_looks_under_volumes(self):
+        board = os.path.join("/Volumes", "BOARD")
+
+        drives = self.get_drives(
+            "darwin",
+            dirs={"/Volumes", board},
+            entries={"/Volumes": ["BOARD"]},
+            with_marker=(board + uf2conv.INFO_FILE,),
+        )
+
+        self.assertEqual(drives, [board])
+
+    def test_nothing_mounted(self):
+        self.assertEqual(self.get_drives("linux", dirs=set(), entries={}), [])
+
+
+class TestConvertingAHexFile(unittest.TestCase):
+    """A hex file need not mention every byte of a block."""
+
+    # Four bytes at 0x1000, then end-of-file. Nothing says what the rest of
+    # that block holds.
+    HEX = ":04100000DEADBEEF59\n:00000001FF\n"
+
+    def convert(self):
+        with (
+            mock.patch.object(uf2conv, "appstartaddr", None),
+            mock.patch.object(uf2conv, "familyid", 0x0),
+        ):
+            return uf2conv.convert_from_hex_to_uf2(self.HEX)
+
+    def payload(self):
+        # One 512-byte block: 32 bytes of header, then the data.
+        return self.convert()[32:288]
+
+    def test_the_bytes_the_file_names_are_kept(self):
+        self.assertEqual(self.payload()[:4], bytes.fromhex("deadbeef"))
+
+    def test_the_rest_of_the_block_reads_as_erased_flash(self):
+        """0xFF, which is what the device would have there anyway."""
+        self.assertEqual(set(self.payload()[4:]), {0xFF})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`scripts/build/uf2conv.py` is a vendored copy of `utils/uf2conv.py` from [microsoft/uf2](https://github.com/microsoft/uf2). Three fixes upstream has are missing here, and the first one means the file does not work at all on a current Windows. A fourth bug is in both copies.

They are independent commits and can be taken or dropped one at a time.

### 1. `wmic` is gone from Windows

`get_drives()` shells out to `wmic` to find the removable FAT volume a UF2 bootloader presents. Microsoft removed `wmic` from Windows 11 24H2, so the call raises before it can look at anything:

```
>>> import uf2conv; uf2conv.get_drives()
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

Measured on Windows 11 Pro build 26200, where `where wmic` finds nothing. That is every caller: `uf2conv.py --list`, and the deploy path that picks a drive when none was given.

PowerShell is there instead and answers the same question:

```
(Get-WmiObject Win32_LogicalDisk -Filter "DriveType=2 AND FileSystem='FAT'").DeviceID
```

Both halves of that filter are what this function already applied by hand to `wmic`'s table — `DriveType` 2 is removable, and the UF2 volume is FAT — so the set of drives offered does not change. Verified on the same machine: the fixed function returns `[]` in 0.6 s with nothing attached, where before it raised.

Upstream made the same move in [`a52b72353`](https://github.com/microsoft/uf2/commit/a52b72353) and then had to correct it in [`f3f9f1ea0`](https://github.com/microsoft/uf2/commit/f3f9f1ea0): the first version filtered on `VolumeName='RPI-RP2'`, which finds one board and no others, and the version after it filters on `FileSystem` alone, which would offer a fixed FAT partition as somewhere to flash. This keeps `DriveType` as well, so it stays with what Zephyr does today.

### 2. The path check tests the wrong path

```python
for rootpath in searchpaths:
    if os.path.isdir(rootpath):
        for d in os.listdir(rootpath):
            if os.path.isdir(rootpath):        # rootpath again
                drives.append(os.path.join(rootpath, d))
```

The inner test asks about `rootpath`, which the outer one has just established, so it is true for every entry the listing returns. What it means to ask is whether the entry itself is a directory.

Nothing has gone wrong because of it: `has_info()` filters the list afterwards on `d + "/INFO_UF2.TXT"` being a file, which a plain file under `/media` can never satisfy. The check is still not doing what it reads as doing.

Fixed upstream in [`8a37b1c8d`](https://github.com/microsoft/uf2/commit/8a37b1c8d). That commit's other half adds search paths (`/mnt`, `SUDO_USER`), which is a change of behaviour rather than a fix, so it is left out.

### 3. An unwritten byte should read as erased flash

`convert_from_hex_to_uf2()` lays the records of a hex file into 256-byte blocks, and a hex file need not mention every byte of one. `Block` started each of them as `bytearray(256)`, so a byte no record covers was written to the device as `0x00`.

Erased flash reads back as `0xFF` on most MCUs, so zero is a value the device would not otherwise have there — the conversion wrote over bytes the hex file deliberately left alone. With four bytes at `0x1000` and nothing else, the rest of that block came back as `0x00` and now comes back as `0xFF`; the bytes the file does name are unchanged either way.

Ported from [`154992f86`](https://github.com/microsoft/uf2/commit/154992f86), which gives the same reason.

### 4. Every message about a bad block raises `TypeError`

`convert_from_uf2()` puts each of its five messages together the same way:

```python
print("Skipping block at " + ptr + "; bad magic")
raise AssertionError("Invalid UF2 data size at " + ptr)
```

`ptr` is `blockno * 512`, an int, so none of them reaches the reader:

```
TypeError: can only concatenate str (not "int") to str
```

For the four that raise, one exception replaces another and the message naming the block is lost. The first is worse: a block with the wrong magic is meant to be reported and skipped, so a UF2 carrying one block from somewhere else stopped the whole conversion instead of losing that block. Measured on an image whose first block has bad magic and whose second is fine — before, `TypeError`; after, `Skipping block at 0; bad magic` and the second block's 16 bytes returned.

Upstream has the same five, written the same way. The hand-written copy in `scripts/west_commands/bindesc.py` does not — it uses f-strings, which is what these become.

## Tests

`uf2conv.py` had no tests. The last commit adds twenty, following the `<module>_test.py` convention the rest of `scripts/build` uses.

`get_drives()` answers differently on each platform, so neither branch is exercised by running the suite on one host. The tests stand in for what the platform provides — the PowerShell call on Windows, the directory listing elsewhere — and cover what the function makes of it. Nothing runs PowerShell or looks at a real mount point.

`convert_from_uf2()` is the part `scripts/west_commands/bindesc.py` carries a copy of. The cases here are the ones both of them answer the same way, so the duplication does not have to reach the test code twice — this is what @marc-hb asked for on #118057, and reading the function is what turned up the `TypeError` messages above.

## Verification

| | result |
|---|---|
| `pytest scripts/build scripts/cmake scripts/kconfig` | **92 passed** (`main`: 72) |
| each commit alone (bisect) | 72, 72, 72, 72, 92 — all green |
| `ruff check`, `ruff format --diff`, `pylint --rcfile=scripts/ci/pylintrc` | clean on every commit |
| `check_compliance.py` (Gitlint, Pylint, PythonCompat, Ruff, Nits, Identity, TextEncoding, GitDiffCheck) | no findings |

Each question the changed code turns on was mutated one at a time, with the rest of the file untouched:

| mutation | result |
|---|---|
| ask `wmic` again | 2 failed |
| drop `DriveType=2` from the filter | 1 failed |
| drop `FileSystem='FAT'` from the filter | 1 failed |
| keep the blank lines in the output | 1 failed |
| test the search path instead of the entry under it | 1 failed |
| `default_data=0x00` | 1 failed |
| `bytearray(256)` again | 1 failed |
| any of the block messages back the way it was | 1 failed each (×3) |
| read the wrong flag bit for not-for-flash | 1 failed |
| pad by half a word | 1 failed |

All twelve are caught.

## Notes

Found while answering a review question on #118057, which fixes the same padding bug in `bindesc.py`'s hand-written copy of `convert_from_uf2`. That one is the only place the padding fix was missing — `scripts/build/uf2conv.py` already carries it. `convert_from_uf2` here otherwise agrees with upstream; the differences are style (`assert False` → `raise AssertionError`, `== None` → `is None`, f-strings).

