### PR TITLE
manifest: Update nrf_wifi with latest rpu v1.2.14.11 bins

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -356,7 +356,7 @@ manifest:
       revision: c84230d0329a2ce5e449bbd556d6854861a6eee7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: fc0872109ec4c006d32843a202b129db33cf16b9
+      revision: pull/109/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 01032a8a7bdfdd541686f5dfa3671e602b9fcbff


### PR DESCRIPTION
1.Ping issue fix for ASUS_RT_AC66U in 11ac80.
2.Association fix for the NETGEAR_RAX120 11ax 40Mhz.