### PR TITLE
Maintainers: BT Audio & tester tests lists corrections

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -645,8 +645,8 @@ Bluetooth Audio:
     - "area: Bluetooth"
   tests:
     - bluetooth.audio
+    - bluetooth.audio_samples
     - sample.bluetooth.audio
-    - tests.bsim.bluetooth.audio
 
 Bluetooth Classic:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -884,7 +884,7 @@ Bluetooth Qualification:
   tests:
     - bluetooth
     - bluetooth.general
-    - bluetooth.tester_bsim
+    - bluetooth.tester
 
 Board/SoC configuration:
   status: maintained


### PR DESCRIPTION
Follow up on:
* #117992

and replacement of
* https://github.com/zephyrproject-rtos/zephyr/pull/118001

-------


    MAINTAINERS: BT qualification: Correct test name
    
    There is no tests with identifiers starting w bluetooth.tester_bsim,
    but after 117992 there is a bluetooth.tester.
    Let's correct it.
    
    MAINTAINERS: BT audio: Correct tests list
    
    There is no tests with the tests.bsim.bluetooth.audio identifier prefix
    anymore after 117992.
    But there is with bluetooth.audio_samples.

----------------

Merged w https://github.com/zephyrproject-rtos/zephyr/pull/117992