### PR TITLE
[Backport v3.7-branch] west.yml: Update libmetal and open-amp CMake minimum version to 3.16

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -263,7 +263,7 @@ manifest:
       path: modules/lib/hostap
       revision: a90df86d7c596a5367ff70c2b50c7f599e6636f3
     - name: libmetal
-      revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
+      revision: 14f519529a1e4a46aaea6826f5a41d99a3347276
       path: modules/hal/libmetal
       groups:
         - hal
@@ -303,7 +303,7 @@ manifest:
       revision: 6c389b9b5fa0a079cd4502e69d375da4c0c289b7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
-      revision: 76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a
+      revision: f7f4d083c7909a39d86e217376c69b416ec4faf3
       path: modules/lib/open-amp
     - name: openthread
       revision: 3873c6fcd5a8a9dd01b71e8efe32ef5dc7923bb1


### PR DESCRIPTION
Backport of #87973 to `v3.7-branch`. Cherry-picked with `-x`; both
`west.yml` hunks required revision-only conflict resolution because this branch
still pins the v2024.05 OpenAMP/libmetal releases, while the original change
was based on v2024.10.

CMake 4 removed compatibility with CMake versions older than 3.5, but both
modules pinned by this branch declare `cmake_minimum_required(VERSION 3.0.2)`.
Update the paired module revisions to versions declaring CMake 3.16. Updating
only libmetal would expose the same configuration failure in OpenAMP.

Relative to the current 3.7 pins, these revisions also include the intervening
v2024.10 imports: three libmetal commits and five OpenAMP commits.

Validated on Ubuntu 26.04 with CMake 4.2.3:

- `west manifest --validate`
- Full `peripheral_hr` sysbuilds for `nrf5340dk/nrf5340/cpuapp` and
  `nrf5340bsim/nrf5340/cpuapp`
- All five configurations selected by the OpenAMP-tagged IPC sample test
  matrix: `openamp_rsc_table` on `stm32mp157c_dk2`, and the `openamp` and
  `rpmsg_service` samples on `mps2/an521/cpu0` and
  `v2m_musca_b1/musca_b1`

Fixes #118223