### PR TITLE
boards: st: stm32mp135f_dk: default to 2 IP addresses

### DIFF
--- a/boards/st/stm32mp135f_dk/Kconfig.defconfig
+++ b/boards/st/stm32mp135f_dk/Kconfig.defconfig
@@ -15,4 +15,10 @@ endif # GPIO_MCP230XX
 configdefault ETH_DRIVER
 	default y
 
+configdefault NET_IF_MAX_IPV4_COUNT
+	default 2
+
+configdefault NET_IF_MAX_IPV6_COUNT
+	default 2
+
 endif # BOARD_STM32MP135F_DK


### PR DESCRIPTION
this board has 2 ethernet controllers, so be
able to use both ifaces at the same time by
default.