### PR TITLE
usb: device_next: dfu: Fix download when using fwupd

### DIFF
--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -535,11 +535,20 @@ static struct net_buf *handle_get_status(struct usbd_class_data *const c_data,
 	/*
 	 * Add GET_STATUS response consisting of
 	 * bStatus, bwPollTimeout, bStatus, iString (no strings defined)
+	 *
+	 * The bState is the state that the device enters immediately after this
+	 * response instead the one it is leaving, per DFU 1.1 Table 6-2.
+	 *
+	 * The distinction here is what tells to the host wait: an image backend
+	 * that reply a waiting condition due to a slow operation from its next_cb
+	 * puts the device into DFU_DNBUSY. Without this signaling the host
+	 * interpret as DFU_DNLOAD_SYNC instead send the next block straight
+	 * into a device that is still busy without perform a poll.
 	 */
 	net_buf_add_u8(buf, data->status);
 	net_buf_add_le16(buf, CONFIG_USBD_DFU_POLLTIMEOUT);
 	net_buf_add_u8(buf, 0);
-	net_buf_add_u8(buf, data->state);
+	net_buf_add_u8(buf, data->next);
 	net_buf_add_u8(buf, 0);
 
 	return buf;

--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -813,10 +813,12 @@ static int dfu_mode_init(struct usbd_class_data *const c_data)
 			data->image = image;
 		}
 
-		if (usbd_add_descriptor(uds_ctx, image->sd_nd)) {
-			LOG_ERR("Failed to add string descriptor");
-		} else {
-			image->if_desc->iInterface = usbd_str_desc_get_idx(image->sd_nd);
+		if (image->if_desc->iInterface == 0) {
+			if (usbd_add_descriptor(uds_ctx, image->sd_nd)) {
+				LOG_ERR("Failed to add string descriptor");
+			} else {
+				image->if_desc->iInterface = usbd_str_desc_get_idx(image->sd_nd);
+			}
 		}
 	}
 


### PR DESCRIPTION
The [fwupd](https://fwupd.org) is a well-know tool in Linux. This address 3 issues found when downloading multiple images on a device with TF-M.

With this fix both dfu and fwupd can work in harmony including tf-m images almost out-of-box.

Validated with STM32U5A5 and TF-M with v4.4.1

CC: @erwango, @etienne-lms