### PR TITLE
net: lib: coap: client: Recover from truncated responses block-wise

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -193,6 +193,11 @@ struct coap_client_internal_request {
 	uint8_t request_tag[COAP_TOKEN_MAX_LEN];
 	uint8_t send_buf[MAX_COAP_MSG_LEN];
 
+	/* A block-wise receive is in progress, so recv_blk_ctx is valid and
+	 * further requests of this exchange are continuation retrievals.
+	 */
+	bool recv_blockwise;
+
 	/* For GETs with observe option set */
 	bool is_observe;
 	int last_response_id;

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -227,7 +227,7 @@ static int coap_client_init_request(struct coap_client *client, struct coap_clie
 {
 	int ret = 0;
 	int i;
-	bool block2 = false;
+	bool block2 = internal_req->recv_blockwise;
 
 	memset(internal_req->send_buf, 0, sizeof(internal_req->send_buf));
 
@@ -265,9 +265,13 @@ static int coap_client_init_request(struct coap_client *client, struct coap_clie
 		}
 	}
 
-	/* Blockwise receive ongoing, request next block. */
-	if (internal_req->recv_blk_ctx.current > 0) {
-		block2 = true;
+	/* Blockwise receive ongoing, request the current block. The context
+	 * position does not tell: it is zero both before any transfer and
+	 * after a truncated response, where the retry must carry a block2
+	 * option so the server switches to a block-wise response instead of
+	 * repeating the truncated one.
+	 */
+	if (block2) {
 		ret = coap_append_block2_option(&internal_req->request,
 						&internal_req->recv_blk_ctx);
 
@@ -1288,6 +1292,7 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	block_option = coap_get_option_int(response, COAP_OPTION_BLOCK2);
 	if (block_option > 0 || response_truncated) {
 		blockwise_transfer = true;
+		internal_req->recv_blockwise = true;
 		last_block = response_truncated ? false : !GET_MORE(block_option);
 		block_num = (block_option > 0) ? GET_BLOCK_NUM(block_option) : 0;
 
@@ -1304,6 +1309,7 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		}
 		coap_next_block(response, &internal_req->recv_blk_ctx);
 	} else {
+		internal_req->recv_blockwise = false;
 		internal_req->offset = 0;
 		last_block = true;
 	}

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -879,6 +879,124 @@ static ssize_t z_impl_zsock_sendto_custom_fake_observe_dereg(
 	return 1;
 }
 
+static int sent_block2_opts[4];
+static int sent_block2_cnt;
+
+static int sent_block1_opts[8];
+static int sent_upload_block2_opts[8];
+static int sent_upload_cnt;
+
+/* Record the block1 and block2 options of every sent request */
+static ssize_t z_impl_zsock_sendto_custom_fake_record_blocks(int sock, void *buf, size_t len,
+							     int flags,
+							     const struct net_sockaddr *dest_addr,
+							     net_socklen_t addrlen)
+{
+	struct coap_packet req = {0};
+
+	zassert_ok(coap_packet_parse(&req, buf, len, NULL, 0));
+	if (sent_upload_cnt < (int)ARRAY_SIZE(sent_block1_opts)) {
+		sent_block1_opts[sent_upload_cnt] = coap_get_option_int(&req, COAP_OPTION_BLOCK1);
+		sent_upload_block2_opts[sent_upload_cnt] =
+			coap_get_option_int(&req, COAP_OPTION_BLOCK2);
+		sent_upload_cnt++;
+	}
+
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+/* Record the block2 option of every sent request */
+static ssize_t z_impl_zsock_sendto_custom_fake_record_block2(int sock, void *buf, size_t len,
+							     int flags,
+							     const struct net_sockaddr *dest_addr,
+							     net_socklen_t addrlen)
+{
+	struct coap_packet req = {0};
+
+	zassert_ok(coap_packet_parse(&req, buf, len, NULL, 0));
+	if (sent_block2_cnt < (int)ARRAY_SIZE(sent_block2_opts)) {
+		sent_block2_opts[sent_block2_cnt++] =
+			coap_get_option_int(&req, COAP_OPTION_BLOCK2);
+	}
+
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+static ssize_t serve_block2(int sock, void *buf, size_t max_len, struct net_sockaddr *src_addr,
+			    net_socklen_t *addrlen, int block_num, bool more)
+{
+	struct coap_packet response;
+	uint8_t token[COAP_TOKEN_MAX_LEN] = {0};
+	uint8_t payload[CONFIG_COAP_CLIENT_BLOCK_SIZE];
+	uint16_t payload_len = more ? sizeof(payload) : 10U;
+	uint16_t message_id = get_next_pending_message_id();
+
+	memset(payload, 'A' + block_num, sizeof(payload));
+
+	zassert_ok(coap_packet_init(&response, buf, max_len, COAP_VERSION_1, COAP_TYPE_ACK,
+				    COAP_TOKEN_MAX_LEN, token, COAP_RESPONSE_CODE_CONTENT,
+				    message_id));
+	zassert_ok(coap_append_option_int(&response, COAP_OPTION_BLOCK2,
+					  (block_num << 4) | (more ? BIT(3) : 0) |
+						  COAP_BLOCK_256));
+	zassert_ok(coap_packet_append_payload_marker(&response));
+	zassert_ok(coap_packet_append_payload(&response, payload, payload_len));
+
+	restore_token(buf);
+	fill_recv_src_addr(src_addr, addrlen);
+	clear_socket_events(sock, ZSOCK_POLLIN);
+
+	return response.offset;
+}
+
+static ssize_t z_impl_zsock_recvfrom_custom_fake_block2_last(int sock, void *buf, size_t max_len,
+							     int flags,
+							     struct net_sockaddr *src_addr,
+							     net_socklen_t *addrlen)
+{
+	return serve_block2(sock, buf, max_len, src_addr, addrlen, 1, false);
+}
+
+static ssize_t z_impl_zsock_recvfrom_custom_fake_block2_first(int sock, void *buf, size_t max_len,
+							      int flags,
+							      struct net_sockaddr *src_addr,
+							      net_socklen_t *addrlen)
+{
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_block2_last;
+
+	return serve_block2(sock, buf, max_len, src_addr, addrlen, 0, true);
+}
+
+/* A valid plain response whose reported length exceeds the buffer: the
+ * datagram was truncated. Follow up with a block-wise transfer.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_truncated(int sock, void *buf, size_t max_len,
+							   int flags,
+							   struct net_sockaddr *src_addr,
+							   net_socklen_t *addrlen)
+{
+	struct coap_packet response;
+	uint8_t token[COAP_TOKEN_MAX_LEN] = {0};
+	uint8_t payload[64];
+	uint16_t message_id = get_next_pending_message_id();
+
+	memset(payload, 'T', sizeof(payload));
+
+	zassert_ok(coap_packet_init(&response, buf, max_len, COAP_VERSION_1, COAP_TYPE_ACK,
+				    COAP_TOKEN_MAX_LEN, token, COAP_RESPONSE_CODE_CONTENT,
+				    message_id));
+	zassert_ok(coap_packet_append_payload_marker(&response));
+	zassert_ok(coap_packet_append_payload(&response, payload, sizeof(payload)));
+
+	restore_token(buf);
+	fill_recv_src_addr(src_addr, addrlen);
+	clear_socket_events(sock, ZSOCK_POLLIN);
+
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_block2_first;
+
+	return max_len + 1;
+}
+
 void coap_callback(const struct coap_client_response_data *data, void *user_data)
 {
 	LOG_INF("CoAP response callback, %d", data->result_code);
@@ -1011,6 +1129,30 @@ ZTEST(coap_client, test_request_block)
 	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL),
 		      -EAGAIN, "");
 }
+ZTEST(coap_client, test_truncated_response_retries_blockwise)
+{
+	sent_block2_cnt = 0;
+	memset(sent_block2_opts, 0, sizeof(sent_block2_opts));
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_record_block2;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_truncated;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
+
+	/* The retry after the truncated response must carry a block2 option
+	 * requesting block 0, so the server switches to a block-wise response
+	 * instead of repeating the truncated one, and the transfer completes.
+	 */
+	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Transfer did not complete");
+	zassert_equal(sent_block2_cnt, 3, "Unexpected number of requests");
+	zassert_equal(sent_block2_opts[0], -ENOENT, "Initial request must not carry block2");
+	zassert_equal(sent_block2_opts[1], COAP_BLOCK_256,
+		      "Retry after truncation must request block 0");
+	zassert_equal(sent_block2_opts[2], (1 << 4) | COAP_BLOCK_256,
+		      "Transfer must continue with block 1");
+}
+
 
 ZTEST(coap_client, test_resend_request)
 {
@@ -1080,6 +1222,28 @@ ZTEST(coap_client, test_send_large_data)
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
+}
+
+ZTEST(coap_client, test_blockwise_upload_no_stray_block2)
+{
+	sent_upload_cnt = 0;
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_record_blocks;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &long_request, NULL));
+
+	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
+	zassert_true(sent_upload_cnt > 1, "Payload must span several block1 requests");
+
+	/* The client did not ask for a block-wise response, so no request of a
+	 * block-wise upload carries a block2 option.
+	 */
+	for (int i = 0; i < sent_upload_cnt; i++) {
+		zassert_true(sent_block1_opts[i] >= 0, "Request %d must carry block1", i);
+		zassert_equal(sent_upload_block2_opts[i], -ENOENT,
+			      "Request %d must not carry block2", i);
+	}
 }
 
 ZTEST(coap_client, test_no_response)


### PR DESCRIPTION
A response too large for the receive buffer initializes the block-wise
receive context so the request is retried with a smaller block size.
The retry only carried a `block2` option while the context position was
beyond zero, but after a truncated plain response `coap_next_block()`
cannot advance the position, as the response holds no `block2` option.
The client therefore re-sent the identical request, received the same
truncated response and looped until the exchange lifetime expired.

The position does not identify an ongoing block-wise receive, so let
the callers of `coap_client_init_request()` state whether the request
carries the `block2` option: the block continuation path knows it does,
the initial request does not, and the echo resend reads it from the
stored previous request it rebuilds. The retry after a truncated
response then requests block 0 with the configured block size and the
server switches to a block-wise response.