### PR TITLE
drivers: infineon: tcpwm: move PDL wrapper macros out of the public include tree

### DIFF
--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -4,6 +4,8 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/counter.h)
 
 zephyr_library()
 
+zephyr_library_include_directories_ifdef(CONFIG_COUNTER_INFINEON_TCPWM ${ZEPHYR_BASE}/drivers/pwm)
+
 zephyr_library_sources_ifdef(CONFIG_COUNTER_SHELL counter_timer_shell.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE counter_handlers.c)
 

--- a/drivers/counter/counter_infineon_tcpwm.c
+++ b/drivers/counter/counter_infineon_tcpwm.c
@@ -13,7 +13,6 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/pm/device.h>
 #include <infineon_kconfig.h>
-#include <zephyr/drivers/timer/ifx_tcpwm.h>
 #include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/irq.h>
@@ -23,6 +22,8 @@
 LOG_MODULE_REGISTER(ifx_tcpwm_counter, CONFIG_COUNTER_LOG_LEVEL);
 
 #include <cy_sysclk.h>
+
+#include "pwm_infineon_tcpwm_priv.h"
 #include <cy_tcpwm_counter.h>
 
 struct ifx_tcpwm_counter_config {

--- a/drivers/pwm/pwm_infineon_tcpwm.c
+++ b/drivers/pwm/pwm_infineon_tcpwm.c
@@ -16,13 +16,14 @@
 #include <zephyr/pm/device.h>
 
 #include <infineon_kconfig.h>
-#include <zephyr/drivers/timer/ifx_tcpwm.h>
 #include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 
 #include <cy_tcpwm_pwm.h>
 #include <cy_gpio.h>
 #include <cy_sysclk.h>
+
+#include "pwm_infineon_tcpwm_priv.h"
 
 #include <zephyr/logging/log.h>
 

--- a/drivers/pwm/pwm_infineon_tcpwm_priv.h
+++ b/drivers/pwm/pwm_infineon_tcpwm_priv.h
@@ -13,8 +13,8 @@
  * is always 0.
  */
 
-#if !defined(ZEPHYR_INCLUDE_DRIVERS_TIMER_IFX_TCPWM_TIMER_H)
-#define ZEPHYR_INCLUDE_DRIVERS_TIMER_IFX_TCPWM_TIMER_H
+#if !defined(ZEPHYR_DRIVERS_PWM_PWM_INFINEON_TCPWM_PRIV_H_)
+#define ZEPHYR_DRIVERS_PWM_PWM_INFINEON_TCPWM_PRIV_H_
 
 #include <stdint.h>
 #include "cy_tcpwm.h"
@@ -158,4 +158,4 @@
 	cy_en_tcpwm_status_t Cy_TCPWM_PWM_Configure_Dithering((TCPWM_Type *)ADDRESS, 0, MODE,      \
 							      PERIOD, DUTY, LIMITER)
 /** @endcond */
-#endif /* ZEPHYR_INCLUDE_DRIVERS_TIMER_IFX_TCPWM_TIMER_H */
+#endif /* ZEPHYR_DRIVERS_PWM_PWM_INFINEON_TCPWM_PRIV_H_ */


### PR DESCRIPTION
The Infineon TCPWM macro wrappers in ifx_tcpwm.h were only used by the PWM and counter TCPWM drivers, so move them into drivers/pwm/ as a shared private header.