### PR TITLE
drivers: dma: fix kconfig leak in dma drivers

### DIFF
--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -41,12 +41,12 @@ config DMA_MCUX_EDMA_DMAMUX
 	help
 	  Automatically enabled when EDMA device tree node has has-dmamux property.
 
+if DMA_MCUX_EDMA || DMA_MCUX_EDMA_V3 || DMA_MCUX_EDMA_V4
+
 config DMA_MCUX_MAX_DATA_SIZE
 	int
 	default 64 if DMA_MCUX_EDMA_V4 || DMA_MCUX_EDMA_V3
 	default 32
-
-if DMA_MCUX_EDMA || DMA_MCUX_EDMA_V3 || DMA_MCUX_EDMA_V4
 
 config DMA_TCD_QUEUE_SIZE
 	int "number of TCD in a queue for SG mode"

--- a/drivers/dma/Kconfig.xilinx_adma
+++ b/drivers/dma/Kconfig.xilinx_adma
@@ -13,6 +13,8 @@ config DMA_XILINX_ADMA
 	help
 	  DMA driver for Xilinx ADMA.
 
+if DMA_XILINX_ADMA
+
 config DMA_XILINX_ADMA_SG_BUFFER_COUNT
 	int "Maximum number of scatter-gather descriptors per channel"
 	default 32
@@ -27,3 +29,5 @@ config DMA_XILINX_ADMA_DESC_POOL_ALIGNMENT
 	default 64
 	help
 	  Memory alignment requirement for DMA descriptor pool allocation.
+
+endif


### PR DESCRIPTION
- **driver: dma : xilinx: fix kconfig leakage**
- **driver: dma : mcux_edma: fix kconfig leakage**
