### PR TITLE
drivers: ethernet: dwc_mac: imply NVMEM when a MAC address cell is used

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -14,6 +14,7 @@ config ETH_DWC_ETHER_QOS_CORE
 	# The DMA descriptor rings are not cache maintained, so they need an
 	# uncached region, which on ARM can only be carved out by the MPU.
 	select ARM_MPU if CPU_HAS_ARM_MPU && DCACHE
+	imply NVMEM if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DWMAC),nvmem-cells)
 	help
 	  This is a driver for the Synopsys DesignWare Ethernet MAC 10/100/1G Quality-of-Service,
 	  also referred to as "dwc_ether_qos".
@@ -26,6 +27,7 @@ config ETH_DWC_ETHER_1000_CORE
 	# The DMA descriptor rings are not cache maintained, so they need an
 	# uncached region, which on ARM can only be carved out by the MPU.
 	select ARM_MPU if CPU_HAS_ARM_MPU && DCACHE
+	imply NVMEM if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DWMAC),nvmem-cells)
 	help
 	  This is a driver for the Synopsys DesignWare Ethernet MAC 10/100/1G Universal,
 	  also referred to as "dwc_ether_mac10_100_1000_universal".


### PR DESCRIPTION
Like the other ethernet drivers, enable NVMEM by default when a MAC node reads its address from an NVMEM cell, so the board only has to enable the provider of the cell.