### PR TITLE
Infineon HPPASS pm-action

### DIFF
--- a/drivers/adc/adc_infineon_hppass_sar.c
+++ b/drivers/adc/adc_infineon_hppass_sar.c
@@ -26,6 +26,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/sys_io.h>
@@ -215,6 +216,12 @@ struct ifx_hppass_sar_adc_data {
 	uint32_t enabled_channels;
 	uint16_t *buffer;
 	uint16_t *repeat_buffer;
+#ifdef CONFIG_PM_S2RAM
+	/* Shadow of SAR SAMP_GAIN; SAR_Init() does not restore it, replayed on
+	 * S2RAM warm boot (regular DeepSleep retains it).
+	 */
+	uint32_t samp_gain;
+#endif
 };
 
 /*
@@ -678,9 +685,50 @@ static int ifx_hppass_sar_adc_channel_setup(const struct device *dev,
 	samp_gain |= (sampler_gain << gain_shift);
 	sys_write32(samp_gain, ctrl_base + IFX_HPPASS_SAR_SAMP_GAIN);
 
+#ifdef CONFIG_PM_S2RAM
+	data->samp_gain = samp_gain;
+#endif
+
 	data->enabled_channels |= BIT(channel_cfg->channel_id);
 
 	adc_context_release(&data->ctx, 0);
+
+	return 0;
+}
+
+/**
+ * @brief (Re)program the SAR core registers
+ *
+ * Loads SFLASH calibration/config and, in async mode, arms the Group 0 result
+ * interrupt and connects its ISR.  Shared by init and the S2RAM warm-boot path.
+ */
+static int ifx_hppass_sar_adc_hw_reinit(const struct device *dev)
+{
+	const struct ifx_hppass_sar_adc_config *cfg = dev->config;
+	cy_stc_hppass_sar_t sar_cfg;
+
+	ifx_init_pdl_struct(&sar_cfg, cfg);
+
+	/*
+	 * Cy_HPPASS_SAR_Init() loads SFLASH calibration and fills the
+	 * calOffsetMirror[] table that cross-talk compensation reads, so it must stay.
+	 */
+	if (Cy_HPPASS_SAR_Init(&sar_cfg) != CY_RSLT_SUCCESS) {
+		LOG_ERR("Failed to initialize HPPASS SAR ADC");
+		return -EIO;
+	}
+
+#if defined(CONFIG_ADC_ASYNC)
+	/*
+	 * Group 0 result interrupt drives async completions: arm the peripheral
+	 * mask and (re)connect/enable the NVIC line.  irq_func() is idempotent,
+	 * so this is safe on both cold init and S2RAM warm boot (where the NVIC
+	 * enable is otherwise lost).
+	 */
+	sys_write32(IFX_HPPASS_SAR_INTR_RESULT_GROUP_0,
+		    cfg->ctrl_base + IFX_HPPASS_SAR_RESULT_INTR_MASK);
+	cfg->irq_func();
+#endif /* CONFIG_ADC_ASYNC */
 
 	return 0;
 }
@@ -692,7 +740,7 @@ static int ifx_hppass_sar_adc_init(const struct device *dev)
 {
 	const struct ifx_hppass_sar_adc_config *cfg = dev->config;
 	struct ifx_hppass_sar_adc_data *data = dev->data;
-	cy_stc_hppass_sar_t sar_cfg;
+	int ret;
 
 	data->dev = dev;
 
@@ -708,31 +756,83 @@ static int ifx_hppass_sar_adc_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ifx_init_pdl_struct(&sar_cfg, cfg);
-
-	/*
-	 * Cy_HPPASS_SAR_Init() copies SFLASH calibration into
-	 * SAR_CALOFFST[0..3]/CALGAINC/CALGAINF and populates the PDL
-	 * calOffsetMirror[] table.  The cross-talk compensation in
-	 * ifx_hppass_sar_configure_group() reads that table via
-	 * Cy_HPPASS_SAR_CrossTalkAdjust(), so this call must stay.
-	 */
-	if (Cy_HPPASS_SAR_Init(&sar_cfg) != CY_RSLT_SUCCESS) {
-		LOG_ERR("Failed to initialize HPPASS SAR ADC");
-		return -EIO;
+	ret = ifx_hppass_sar_adc_hw_reinit(dev);
+	if (ret != 0) {
+		return ret;
 	}
-
-#if defined(CONFIG_ADC_ASYNC)
-	/* Group 0 result interrupt drives async completions. */
-	sys_write32(IFX_HPPASS_SAR_INTR_RESULT_GROUP_0,
-		    cfg->ctrl_base + IFX_HPPASS_SAR_RESULT_INTR_MASK);
-	cfg->irq_func();
-#endif /* CONFIG_ADC_ASYNC */
 
 	adc_context_unlock_unconditionally(&data->ctx);
 
 	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+#if defined(CONFIG_PM_S2RAM)
+/*
+ * Replay per-channel state (RESULT_MASK, CHAN_CFG, SAMP_GAIN) that
+ * channel_setup() programmed; SAR_Init() does not restore it and the app does
+ * not re-run channel_setup() after wake.  No-op at cold init.  Only needed
+ * after S2RAM power loss; regular DeepSleep retains this state.
+ */
+static void ifx_hppass_sar_adc_replay_channels(const struct device *dev)
+{
+	const struct ifx_hppass_sar_adc_config *cfg = dev->config;
+	struct ifx_hppass_sar_adc_data *data = dev->data;
+	mem_addr_t ctrl_base = cfg->ctrl_base;
+	uint32_t enabled = data->enabled_channels;
+
+	if (enabled == 0U) {
+		return;
+	}
+
+	for (uint32_t ch = 0U; ch < HPPASS_SAR_ADC_MAX_CHANNELS; ch++) {
+		if ((enabled & BIT(ch)) != 0U) {
+			/* channel_setup() always programs the zero default. */
+			sys_write32(0U, ctrl_base + IFX_HPPASS_SAR_CHAN_CFG(ch));
+		}
+	}
+
+	sys_write32(sys_read32(ctrl_base + IFX_HPPASS_SAR_RESULT_MASK) | enabled,
+		    ctrl_base + IFX_HPPASS_SAR_RESULT_MASK);
+	sys_write32(data->samp_gain, ctrl_base + IFX_HPPASS_SAR_SAMP_GAIN);
+}
+#endif /* CONFIG_PM_S2RAM */
+
+/*
+ * DeepSleep retains the SAR config and the MFD parent restores the calibration,
+ * so this child only refuses to suspend mid-conversion.  A full power loss
+ * (S2RAM) reloads the SAR core and replays per-channel state.
+ */
+static int ifx_hppass_sar_adc_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Refuse while a conversion is in flight. */
+		if (Cy_HPPASS_SAR_IsBusy()) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Config retained; the MFD parent restored the SAR calibration. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON: {
+		int ret = ifx_hppass_sar_adc_hw_reinit(dev);
+
+		if (ret != 0) {
+			return ret;
+		}
+		ifx_hppass_sar_adc_replay_channels(dev);
+		break;
+	}
+#endif
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 #ifdef CONFIG_ADC_ASYNC
 #define ADC_IFX_HPPASS_SAR_DRIVER_API(n)                                                           \
@@ -828,7 +928,9 @@ static int ifx_hppass_sar_adc_init(const struct device *dev)
 		ADC_CONTEXT_INIT_LOCK(ifx_hppass_sar_adc_data_##n, ctx),                           \
 		ADC_CONTEXT_INIT_SYNC(ifx_hppass_sar_adc_data_##n, ctx),                           \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, &ifx_hppass_sar_adc_init, NULL, &ifx_hppass_sar_adc_data_##n,     \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_hppass_sar_adc_pm_action);                                 \
+	DEVICE_DT_INST_DEFINE(n, &ifx_hppass_sar_adc_init, PM_DEVICE_DT_INST_GET(n),               \
+			      &ifx_hppass_sar_adc_data_##n,                                        \
 			      &ifx_hppass_sar_adc_config_##n, POST_KERNEL,                         \
 			      CONFIG_ADC_INFINEON_HPPASS_SAR_INIT_PRIORITY,                        \
 			      &adc_ifx_hppass_sar_driver_api_##n);                                 \

--- a/drivers/comparator/comparator_infineon_hppass_csg.c
+++ b/drivers/comparator/comparator_infineon_hppass_csg.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
- * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG.
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,6 +35,7 @@
 #include <zephyr/drivers/comparator.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
@@ -275,6 +276,37 @@ static int ifx_csg_comp_init(const struct device *dev)
 	return 0;
 } /* ifx_csg_comp_init() */
 
+#ifdef CONFIG_PM_DEVICE
+/*
+ * Regular DeepSleep retains CMP_CFG and the CMP_INTR_MASK, so resume is a
+ * no-op.  Only a genuine power loss (S2RAM warm boot) clears them; the TURN_ON
+ * path reprograms the base CMP_CFG (mirroring init), leaving the slice
+ * disarmed.  The app re-arms its trigger via comparator_set_trigger() after
+ * resume, matching how the CSG DAC restores its DT default and leaves the
+ * runtime value to the app.  The callback binding is retained software state.
+ */
+static int ifx_csg_comp_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON: {
+		const struct ifx_csg_comp_config *cfg = dev->config;
+
+		sys_write32(cfg->cmp_cfg, cfg->slice_base + IFX_HPPASS_CSG_SLICE_CMP_CFG);
+		break;
+	}
+#endif
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+} /* ifx_csg_comp_pm_action() */
+#endif /* CONFIG_PM_DEVICE */
+
 /*
  * Compose CMP_CFG for one comparator child.  edge_mode is left at 0 and
  * filled in at runtime by comparator_set_trigger().
@@ -304,7 +336,8 @@ static int ifx_csg_comp_init(const struct device *dev)
 		.slice      = IFX_CSG_COMP_SLICE_OF(n),                                   \
 		.cmp_cfg    = IFX_CSG_COMP_CFG_INIT(DT_DRV_INST(n)),                      \
 	};                                                                                \
-	DEVICE_DT_INST_DEFINE(n, ifx_csg_comp_init, NULL,                                 \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_csg_comp_pm_action);                              \
+	DEVICE_DT_INST_DEFINE(n, ifx_csg_comp_init, PM_DEVICE_DT_INST_GET(n),             \
 			      &ifx_csg_comp_data_##n, &ifx_csg_comp_config_##n,           \
 			      POST_KERNEL,                                                \
 			      CONFIG_COMPARATOR_INFINEON_HPPASS_CSG_INIT_PRIORITY,        \

--- a/drivers/dac/dac_infineon_hppass_csg.c
+++ b/drivers/dac/dac_infineon_hppass_csg.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,10 +27,12 @@
 #include <zephyr/drivers/dac.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
 #include <infineon_kconfig.h>
+#include <infineon_hppass_csg.h>
 #include <cy_device.h>
 
 #include "mfd_infineon_hppass_regs.h"
@@ -138,6 +140,30 @@ static int ifx_csg_dac_init(const struct device *dev)
 	return 0;
 } /* ifx_csg_dac_init() */
 
+#ifdef CONFIG_PM_DEVICE
+/*
+ * Regular DeepSleep retains the slice DAC_CFG and output value, so resume is a
+ * no-op.  Only a genuine power loss (S2RAM warm boot) clears them; the TURN_ON
+ * path reprograms them.  channel_setup_done is retained software state.
+ */
+static int ifx_csg_dac_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		return ifx_csg_dac_init(dev);
+#endif
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+} /* ifx_csg_dac_pm_action() */
+#endif /* CONFIG_PM_DEVICE */
+
 /* Compose DAC_CFG for one DAC child.  All advanced-mode fields stay zero. */
 #define IFX_CSG_DAC_CFG_INIT(node_id)                                                    \
 	FIELD_PREP(IFX_CSG_DAC_CFG_DEGLITCH, DT_PROP(node_id, deglitch))
@@ -157,7 +183,8 @@ static int ifx_csg_dac_init(const struct device *dev)
 	{                                                                                \
 		return ifx_csg_dac_init(dev);                                            \
 	}                                                                                \
-	DEVICE_DT_INST_DEFINE(n, ifx_csg_dac_init_##n, NULL,                             \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_csg_dac_pm_action);                              \
+	DEVICE_DT_INST_DEFINE(n, ifx_csg_dac_init_##n, PM_DEVICE_DT_INST_GET(n),         \
 			      &ifx_csg_dac_data_##n, &ifx_csg_dac_config_##n,            \
 			      POST_KERNEL,                                               \
 			      CONFIG_DAC_INFINEON_HPPASS_CSG_INIT_PRIORITY,              \

--- a/drivers/mfd/mfd_infineon_hppass.c
+++ b/drivers/mfd/mfd_infineon_hppass.c
@@ -30,6 +30,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
@@ -46,6 +47,17 @@ LOG_MODULE_REGISTER(mfd_infineon_hppass, CONFIG_MFD_LOG_LEVEL);
 struct ifx_hppass_mfd_data {
 	sys_slist_t callbacks;
 	struct k_mutex start_lock;
+#ifdef CONFIG_PM_DEVICE
+	/* BLOCK_STATUS.READY latched at SUSPEND; RESUME only re-powers if set. */
+	bool ac_was_ready;
+	/* Volatile SAR calibration, saved/restored around DeepSleep. */
+	struct {
+		uint32_t caloffst[IFX_HPPASS_SAR_CAL_OFFST_SIZE];
+		uint32_t callin[IFX_HPPASS_SAR_CAL_LIN_TABLE_SIZE];
+		uint32_t calgainc;
+		uint32_t calgainf;
+	} sar_cal;
+#endif
 };
 
 /*
@@ -732,6 +744,105 @@ static int ifx_hppass_mfd_init(const struct device *dev)
 	return 0;
 } /* ifx_hppass_mfd_init() */
 
+#ifdef CONFIG_PM_DEVICE
+/* Save the volatile SAR calibration before DeepSleep resets it. */
+static void ifx_hppass_sar_cal_save(const struct device *dev)
+{
+	const struct ifx_hppass_mfd_config *config = dev->config;
+	struct ifx_hppass_mfd_data *data = dev->data;
+
+	for (uint8_t n = 0U; n < IFX_HPPASS_SAR_CAL_OFFST_SIZE; n++) {
+		data->sar_cal.caloffst[n] =
+			sys_read32(config->base + IFX_HPPASS_SARADC_CALOFFST(n));
+	}
+	for (uint8_t n = 0U; n < IFX_HPPASS_SAR_CAL_LIN_TABLE_SIZE; n++) {
+		data->sar_cal.callin[n] =
+			sys_read32(config->base + IFX_HPPASS_SARADC_CALLIN(n));
+	}
+	data->sar_cal.calgainc = sys_read32(config->base + IFX_HPPASS_SARADC_CALGAINC);
+	data->sar_cal.calgainf = sys_read32(config->base + IFX_HPPASS_SARADC_CALGAINF);
+} /* ifx_hppass_sar_cal_save() */
+
+/* Restore the SAR calibration after DeepSleep; the rest is retained. */
+static void ifx_hppass_sar_cal_restore(const struct device *dev)
+{
+	const struct ifx_hppass_mfd_config *config = dev->config;
+	struct ifx_hppass_mfd_data *data = dev->data;
+
+	for (uint8_t n = 0U; n < IFX_HPPASS_SAR_CAL_OFFST_SIZE; n++) {
+		sys_write32(data->sar_cal.caloffst[n],
+			    config->base + IFX_HPPASS_SARADC_CALOFFST(n));
+	}
+	for (uint8_t n = 0U; n < IFX_HPPASS_SAR_CAL_LIN_TABLE_SIZE; n++) {
+		sys_write32(data->sar_cal.callin[n],
+			    config->base + IFX_HPPASS_SARADC_CALLIN(n));
+	}
+	sys_write32(data->sar_cal.calgainc, config->base + IFX_HPPASS_SARADC_CALGAINC);
+	sys_write32(data->sar_cal.calgainf, config->base + IFX_HPPASS_SARADC_CALGAINF);
+} /* ifx_hppass_sar_cal_restore() */
+
+/*
+ * DeepSleep retains the HPPASS config (STT, startup, triggers) but drops the
+ * block out of BLOCK_READY and resets the volatile SAR calibration.  RESUME
+ * reloads the calibration and re-runs the AC startup.
+ */
+static int ifx_hppass_mfd_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_hppass_mfd_data *data = dev->data;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Refuse while the AC is executing. */
+		if (ifx_hppass_ac_is_running(dev)) {
+			return -EBUSY;
+		}
+		/* Witness block state for RESUME; save calibration only if up. */
+		data->ac_was_ready = ifx_hppass_ac_is_block_ready(dev);
+		if (data->ac_was_ready) {
+			ifx_hppass_sar_cal_save(dev);
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME: {
+		int ret;
+
+		/* Leave the block down if it was down before suspend. */
+		if (!data->ac_was_ready) {
+			break;
+		}
+
+		/*
+		 * Reload calibration (writable while ENABLED, which is retained),
+		 * then re-kick the AC to re-power SAR + CSG.
+		 */
+		ifx_hppass_sar_cal_restore(dev);
+		ret = ifx_hppass_ac_start(dev, 0, 0);
+		if (ret != 0 && ret != -EALREADY) {
+			return ret;
+		}
+		break;
+	}
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON: {
+		const struct ifx_hppass_mfd_config *config = dev->config;
+		int ret;
+
+		/* Cold resume from S2RAM: full rebuild and re-wire the IRQ. */
+		ret = ifx_hppass_init_hw(dev);
+		if (ret != 0) {
+			return ret;
+		}
+		config->irq_config_func(dev);
+		break;
+	}
+#endif
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+} /* ifx_hppass_mfd_pm_action() */
+#endif /* CONFIG_PM_DEVICE */
+
 /*
  * Per-instance STT is basic or advanced, selected by whether ac-states is
  * present in DT.  Basic mode generates a 2-state STT: WAIT_FOR BLOCK_READY
@@ -1043,7 +1154,9 @@ static int ifx_hppass_mfd_init(const struct device *dev)
                                                                                                \
 	static struct ifx_hppass_mfd_data ifx_hppass_mfd_data_##n;                             \
                                                                                                \
-	DEVICE_DT_INST_DEFINE(n, &ifx_hppass_mfd_init, NULL,                                   \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_hppass_mfd_pm_action);                                 \
+                                                                                               \
+	DEVICE_DT_INST_DEFINE(n, &ifx_hppass_mfd_init, PM_DEVICE_DT_INST_GET(n),               \
 			      &ifx_hppass_mfd_data_##n,                                        \
 			      &ifx_hppass_mfd_config_##n, POST_KERNEL,                         \
 			      CONFIG_MFD_INFINEON_HPPASS_INIT_PRIORITY, NULL);                 \

--- a/drivers/mfd/mfd_infineon_hppass_csg.c
+++ b/drivers/mfd/mfd_infineon_hppass_csg.c
@@ -39,10 +39,12 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
 #include <infineon_kconfig.h>
+#include <infineon_hppass.h>
 #include <infineon_hppass_csg.h>
 #include <cy_device.h>
 #include <cy_sysclk.h>
@@ -290,6 +292,30 @@ static int ifx_hppass_csg_init(const struct device *dev)
 	return 0;
 } /* ifx_hppass_csg_init() */
 
+#ifdef CONFIG_PM_DEVICE
+/*
+ * Regular DeepSleep retains the CSG block configuration; only a genuine power
+ * loss (S2RAM warm boot) clears it, so the block is rebuilt from the TURN_ON
+ * path alone.
+ */
+static int ifx_hppass_csg_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		return ifx_hppass_csg_init(dev);
+#endif
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+} /* ifx_hppass_csg_pm_action() */
+#endif /* CONFIG_PM_DEVICE */
+
 #define IFX_CSG_INIT(n)                                                                            \
 	BUILD_ASSERT(DT_INST_PROP_OR(n, infineon_dac_observe_blank_cycles, 0) <=                   \
 			(HPPASS_CSG_VDAC_OUT_BLANK_BLANK_CNT_Msk >>                                \
@@ -318,7 +344,10 @@ static int ifx_hppass_csg_init(const struct device *dev)
 		return ifx_hppass_csg_init(dev);                                                   \
 	}                                                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, ifx_hppass_csg_init_##n, NULL, &ifx_csg_data_##n,                 \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_hppass_csg_pm_action);                                     \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, ifx_hppass_csg_init_##n, PM_DEVICE_DT_INST_GET(n),                \
+			      &ifx_csg_data_##n,                                                   \
 			      &ifx_csg_config_##n, POST_KERNEL,                                    \
 			      CONFIG_MFD_INFINEON_HPPASS_CSG_INIT_PRIORITY, NULL);
 

--- a/drivers/mfd/mfd_infineon_hppass_regs.h
+++ b/drivers/mfd/mfd_infineon_hppass_regs.h
@@ -60,7 +60,10 @@ extern "C" {
  */
 
 /* SARADC calibration. */
+#define IFX_HPPASS_SARADC_CALOFFST(n)      (0x00070010U + (n) * 4U)
 #define IFX_HPPASS_SARADC_CALLIN(n)        (0x00070020U + (n) * 4U)
+#define IFX_HPPASS_SARADC_CALGAINC         0x00070060U
+#define IFX_HPPASS_SARADC_CALGAINF         0x00070064U
 
 /* ACTRLR (Autonomous Controller). */
 #define IFX_HPPASS_AC_CTRL                 0x000D0000U
@@ -151,6 +154,15 @@ extern "C" {
  * mirrored from SFLASH @c SAR_CAL_LIN_TABLE[].
  */
 #define IFX_HPPASS_SAR_CAL_LIN_TABLE_SIZE 16
+
+/**
+ * @brief Number of SAR offset calibration table entries.
+ *
+ * Fixed by silicon: 4 @c SARADC.CALOFFST[n] words.  These, together with
+ * @c CALGAINC / @c CALGAINF, are volatile: the block must be enabled to
+ * access them and they reset when it is disabled.
+ */
+#define IFX_HPPASS_SAR_CAL_OFFST_SIZE 4
 
 /**
  * @brief Mask of all sources reported by @c HPPASS_INTR (Regs TRM 20.1.96).


### PR DESCRIPTION
- Added pm_action for HPPASS device suspend/resume paths.
- HPPASS MFD
- HPPASS CSG MFD
- HPPASS ADC
- HPPASS CSG comparator
- HPPASS DAC

Refer to https://github.com/zephyrproject-rtos/zephyr/pull/114225 for the general pm_action solution.