### PR TITLE
usb: device_next: place per-class constant data in ROM

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1566,6 +1566,10 @@ USB
   and should be removed from DTS files; the underlying driver will compute the correct value
   automatically if the property doesn't exist (and honor it otherwise). (:github:`117882`)
 
+* The ``get_desc`` callback in :c:struct:`usbd_class_api` now returns ``const void *`` instead of
+  ``void *``, so that a class can keep its array of descriptor pointers in ROM. Out-of-tree
+  classes must update the return type of their handler. (:github:`118251`)
+
 Video
 =====
 

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -799,8 +799,8 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
  *  @param _reqs Variable number of vendor requests
  */
 #define USBD_VENDOR_REQ(_reqs...) \
-	VENDOR_REQ_DEFINE(((uint8_t []) { _reqs }), \
-			  sizeof((uint8_t []) { _reqs }))
+	VENDOR_REQ_DEFINE(((const uint8_t []) { _reqs }), \
+			  sizeof((const uint8_t []) { _reqs }))
 
 
 /**

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -386,8 +386,8 @@ struct usbd_class_api {
 	void (*shutdown)(struct usbd_class_data *const c_data);
 
 	/** Get function descriptor based on speed parameter */
-	void *(*get_desc)(struct usbd_class_data *const c_data,
-			  const enum usbd_speed speed);
+	const void *(*get_desc)(struct usbd_class_data *const c_data,
+				const enum usbd_speed speed);
 };
 
 /**

--- a/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.c
+++ b/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.c
@@ -362,7 +362,8 @@ static const struct usb_desc_header *bridge_desc_list[] = {
 	(struct usb_desc_header *)&bridge_desc.nil_desc,
 };
 
-static void *bridge_get_desc(struct usbd_class_data *const c_data, const enum usbd_speed speed)
+static const void *bridge_get_desc(struct usbd_class_data *const c_data,
+				   const enum usbd_speed speed)
 {
 	/* Without endpoints the same descriptors are used at any speed */
 	return bridge_desc_list;

--- a/samples/subsys/usb/webusb/src/sfunc.c
+++ b/samples/subsys/usb/webusb/src/sfunc.c
@@ -100,8 +100,8 @@ static int sfunc_request_handler(struct usbd_class_data *c_data,
 	return 0;
 }
 
-static void *sfunc_get_desc(struct usbd_class_data *const c_data,
-			     const enum usbd_speed speed)
+static const void *sfunc_get_desc(struct usbd_class_data *const c_data,
+				  const enum usbd_speed speed)
 {
 	struct sfunc_data *data = usbd_class_get_private(c_data);
 

--- a/subsys/dap/dap_backend_usb.c
+++ b/subsys/dap/dap_backend_usb.c
@@ -113,8 +113,8 @@ static int dap_func_request_handler(struct usbd_class_data *c_data,
 	return 0;
 }
 
-static void *dap_func_get_desc(struct usbd_class_data *const c_data,
-			     const enum usbd_speed speed)
+static const void *dap_func_get_desc(struct usbd_class_data *const c_data,
+				     const enum usbd_speed speed)
 {
 	struct dap_func_data *data = usbd_class_get_private(c_data);
 

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
@@ -349,7 +349,8 @@ static int ec_host_cmd_request(struct usbd_class_data *const c_data, struct net_
 	return 0;
 }
 
-static void *ec_host_cmd_get_desc(struct usbd_class_data *const c_data, const enum usbd_speed speed)
+static const void *ec_host_cmd_get_desc(struct usbd_class_data *const c_data,
+					const enum usbd_speed speed)
 {
 	const struct ec_host_cmd_usb_ctx *ctx = usbd_class_get_private(c_data);
 

--- a/subsys/pmci/mctp/mctp_usb.c
+++ b/subsys/pmci/mctp/mctp_usb.c
@@ -411,8 +411,8 @@ static int mctp_usb_class_request(struct usbd_class_data *const c_data,
 	return 0;
 }
 
-static void *mctp_usb_class_get_desc(struct usbd_class_data *const c_data,
-				     const enum usbd_speed speed)
+static const void *mctp_usb_class_get_desc(struct usbd_class_data *const c_data,
+					   const enum usbd_speed speed)
 {
 	struct mctp_usb_class_ctx *ctx = usbd_class_get_private(c_data);
 

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -123,8 +123,8 @@ static int tracing_func_request_handler(struct usbd_class_data *const c_data,
 	return 0;
 }
 
-static void *tracing_func_get_desc(struct usbd_class_data *const c_data,
-				   const enum usbd_speed speed)
+static const void *tracing_func_get_desc(struct usbd_class_data *const c_data,
+					 const enum usbd_speed speed)
 {
 	struct tracing_func_data *data = usbd_class_get_private(c_data);
 

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -119,8 +119,8 @@ struct usbd_bt_hci_desc {
 struct bt_hci_data {
 	struct net_buf *acl_buf;
 	struct usbd_bt_hci_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 	uint16_t acl_len;
 	struct k_sem sync_sem;
 	atomic_t state;
@@ -470,8 +470,8 @@ static int bt_hci_ctd(struct usbd_class_data *const c_data,
 	return 0;
 }
 
-static void *bt_hci_get_desc(struct usbd_class_data *const c_data,
-			     const enum usbd_speed speed)
+static const void *bt_hci_get_desc(struct usbd_class_data *const c_data,
+				   const enum usbd_speed speed)
 {
 	struct bt_hci_data *data = usbd_class_get_private(c_data);
 
@@ -489,7 +489,7 @@ static int bt_hci_init(struct usbd_class_data *const c_data)
 	return 0;
 }
 
-static struct usbd_class_api bt_hci_api = {
+static const struct usbd_class_api bt_hci_api = {
 	.request = bt_hci_request,
 	.update = bt_hci_update,
 	.enable = bt_hci_enable,
@@ -634,7 +634,7 @@ static struct usbd_bt_hci_desc bt_hci_desc_##n = {				\
 	},									\
 };										\
 										\
-const static struct usb_desc_header *bt_hci_fs_desc_##n[] = {			\
+const static struct usb_desc_header *const bt_hci_fs_desc_##n[] = {		\
 	(struct usb_desc_header *) &bt_hci_desc_##n.iad,			\
 	(struct usb_desc_header *) &bt_hci_desc_##n.if0,			\
 	(struct usb_desc_header *) &bt_hci_desc_##n.if0_int_ep,			\
@@ -649,7 +649,7 @@ const static struct usb_desc_header *bt_hci_fs_desc_##n[] = {			\
 	(struct usb_desc_header *) &bt_hci_desc_##n.nil_desc,			\
 };										\
 										\
-const static __maybe_unused struct usb_desc_header *bt_hci_hs_desc_##n[] = {	\
+const static __maybe_unused struct usb_desc_header *const bt_hci_hs_desc_##n[] = {	\
 	(struct usb_desc_header *) &bt_hci_desc_##n.iad,			\
 	(struct usb_desc_header *) &bt_hci_desc_##n.if0,			\
 	(struct usb_desc_header *) &bt_hci_desc_##n.if0_int_ep,			\

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -62,8 +62,8 @@ struct loopback_desc {
 
 struct lb_data {
 	struct loopback_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 	atomic_t state;
 };
 
@@ -254,8 +254,8 @@ static int lb_control_to_dev(struct usbd_class_data *c_data,
 	return -ENOTSUP;
 }
 
-static void *lb_get_desc(struct usbd_class_data *const c_data,
-			 const enum usbd_speed speed)
+static const void *lb_get_desc(struct usbd_class_data *const c_data,
+			       const enum usbd_speed speed)
 {
 	struct lb_data *data = usbd_class_get_private(c_data);
 
@@ -293,7 +293,7 @@ static int lb_init(struct usbd_class_data *c_data)
 	return 0;
 }
 
-struct usbd_class_api lb_api = {
+static const struct usbd_class_api lb_api = {
 	.update = lb_update,
 	.control_to_host = lb_control_to_host,
 	.control_to_dev = lb_control_to_dev,
@@ -470,7 +470,7 @@ static struct loopback_desc lb_desc_##x = {					\
 	},									\
 };										\
 										\
-const static struct usb_desc_header *lb_fs_desc_##x[] = {			\
+const static struct usb_desc_header *const lb_fs_desc_##x[] = {			\
 	(struct usb_desc_header *) &lb_desc_##x.iad,				\
 	(struct usb_desc_header *) &lb_desc_##x.if0,				\
 	(struct usb_desc_header *) &lb_desc_##x.if0_in_ep,			\
@@ -487,7 +487,7 @@ const static struct usb_desc_header *lb_fs_desc_##x[] = {			\
 	(struct usb_desc_header *) &lb_desc_##x.nil_desc,			\
 };										\
 										\
-const static struct usb_desc_header *lb_hs_desc_##x[] = {			\
+const static struct usb_desc_header *const lb_hs_desc_##x[] = {			\
 	(struct usb_desc_header *) &lb_desc_##x.iad,				\
 	(struct usb_desc_header *) &lb_desc_##x.if0,				\
 	(struct usb_desc_header *) &lb_desc_##x.if0_hs_in_ep,			\

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -89,8 +89,8 @@ struct cdc_acm_uart_config {
 	struct usbd_desc_node *const if_desc_data;
 	/* Pointer to the class interface descriptors */
 	struct usbd_cdc_acm_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 };
 
 struct cdc_acm_uart_data {
@@ -423,8 +423,8 @@ static void usbd_cdc_acm_resumed(struct usbd_class_data *const c_data)
 	atomic_clear_bit(&data->state, CDC_ACM_CLASS_SUSPENDED);
 }
 
-static void *usbd_cdc_acm_get_desc(struct usbd_class_data *const c_data,
-				   const enum usbd_speed speed)
+static const void *usbd_cdc_acm_get_desc(struct usbd_class_data *const c_data,
+					 const enum usbd_speed speed)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct cdc_acm_uart_config *cfg = dev->config;
@@ -1199,7 +1199,7 @@ static DEVICE_API(uart, cdc_acm_uart_api) = {
 #endif
 };
 
-struct usbd_class_api usbd_cdc_acm_api = {
+static const struct usbd_class_api usbd_cdc_acm_api = {
 	.request = usbd_cdc_acm_request,
 	.update = usbd_cdc_acm_update,
 	.enable = usbd_cdc_acm_enable,
@@ -1345,7 +1345,7 @@ static struct usbd_cdc_acm_desc cdc_acm_desc_##n = {				\
 	},									\
 };										\
 										\
-const static struct usb_desc_header *cdc_acm_fs_desc_##n[] = {			\
+const static struct usb_desc_header *const cdc_acm_fs_desc_##n[] = {		\
 	(struct usb_desc_header *) &cdc_acm_desc_##n.iad,			\
 	(struct usb_desc_header *) &cdc_acm_desc_##n.if0,			\
 	(struct usb_desc_header *) &cdc_acm_desc_##n.if0_header,		\
@@ -1360,7 +1360,7 @@ const static struct usb_desc_header *cdc_acm_fs_desc_##n[] = {			\
 }
 
 #define CDC_ACM_DEFINE_HS_DESC_HEADER(n)					\
-const static struct usb_desc_header *cdc_acm_hs_desc_##n[] = {			\
+const static struct usb_desc_header *const cdc_acm_hs_desc_##n[] = {		\
 	(struct usb_desc_header *) &cdc_acm_desc_##n.iad,			\
 	(struct usb_desc_header *) &cdc_acm_desc_##n.if0,			\
 	(struct usb_desc_header *) &cdc_acm_desc_##n.if0_header,		\

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -82,8 +82,8 @@ struct cdc_ecm_eth_data {
 	struct usbd_class_data *c_data;
 	struct usbd_desc_node *const mac_desc_data;
 	struct usbd_cdc_ecm_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 
 	struct net_if *iface;
 	uint8_t mac_addr[6];
@@ -480,8 +480,8 @@ static void usbd_cdc_ecm_shutdown(struct usbd_class_data *const c_data)
 	sys_dlist_remove(&data->mac_desc_data->node);
 }
 
-static void *usbd_cdc_ecm_get_desc(struct usbd_class_data *const c_data,
-				   const enum usbd_speed speed)
+static const void *usbd_cdc_ecm_get_desc(struct usbd_class_data *const c_data,
+					 const enum usbd_speed speed)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct cdc_ecm_eth_data *const data = dev->data;
@@ -636,7 +636,7 @@ static int usbd_cdc_ecm_preinit(const struct device *dev)
 	return 0;
 }
 
-static struct usbd_class_api usbd_cdc_ecm_api = {
+static const struct usbd_class_api usbd_cdc_ecm_api = {
 	.request = usbd_cdc_ecm_request,
 	.update = usbd_cdc_ecm_update,
 	.enable = usbd_cdc_ecm_enable,
@@ -793,7 +793,7 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 	},									\
 };										\
 										\
-	const static struct usb_desc_header *cdc_ecm_fs_desc_##n[] = {		\
+	const static struct usb_desc_header *const cdc_ecm_fs_desc_##n[] = {	\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.iad,		\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.if0,		\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.if0_header,	\
@@ -807,7 +807,7 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.nil_desc,		\
 	};									\
 										\
-	const static struct usb_desc_header *cdc_ecm_hs_desc_##n[] = {		\
+	const static struct usb_desc_header *const cdc_ecm_hs_desc_##n[] = {	\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.iad,		\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.if0,		\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.if0_header,	\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -219,8 +219,8 @@ struct cdc_ncm_eth_data {
 	struct usbd_class_data *c_data;
 	struct usbd_desc_node *const mac_desc_data;
 	struct usbd_cdc_ncm_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 
 	struct net_if *iface;
 	uint8_t mac_addr[6];
@@ -1030,8 +1030,8 @@ static void usbd_cdc_ncm_shutdown(struct usbd_class_data *const c_data)
 	sys_dlist_remove(&data->mac_desc_data->node);
 }
 
-static void *usbd_cdc_ncm_get_desc(struct usbd_class_data *const c_data,
-				   const enum usbd_speed speed)
+static const void *usbd_cdc_ncm_get_desc(struct usbd_class_data *const c_data,
+					 const enum usbd_speed speed)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct cdc_ncm_eth_data *const data = dev->data;
@@ -1211,7 +1211,7 @@ static int usbd_cdc_ncm_preinit(const struct device *dev)
 	return 0;
 }
 
-static struct usbd_class_api usbd_cdc_ncm_api = {
+static const struct usbd_class_api usbd_cdc_ncm_api = {
 	.request = usbd_cdc_ncm_request,
 	.update = usbd_cdc_ncm_update,
 	.enable = usbd_cdc_ncm_enable,
@@ -1377,7 +1377,7 @@ static struct usbd_cdc_ncm_desc cdc_ncm_desc_##n = {				\
 	},									\
 };										\
 										\
-const static struct usb_desc_header *cdc_ncm_fs_desc_##n[] = {			\
+const static struct usb_desc_header *const cdc_ncm_fs_desc_##n[] = {		\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.iad,			\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.if0,			\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.if0_header,		\
@@ -1392,7 +1392,7 @@ const static struct usb_desc_header *cdc_ncm_fs_desc_##n[] = {			\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.nil_desc,			\
 };										\
 										\
-const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
+const static struct usb_desc_header *const cdc_ncm_hs_desc_##n[] = {		\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.iad,			\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.if0,			\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.if0_header,		\

--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -55,7 +55,7 @@ static const struct usb_dfu_descriptor dfu_desc = {
 
 /* Common class data for both run-time and DFU instances. */
 struct usbd_dfu_data {
-	struct usb_desc_header **const runtime_mode_descs;
+	struct usb_desc_header *const *const runtime_mode_descs;
 	struct usb_desc_header **const dfu_mode_descs;
 	enum usb_dfu_state state;
 	enum usb_dfu_state next;
@@ -71,7 +71,7 @@ struct usbd_dfu_data {
 static __noinit struct usb_if_descriptor runtime_if0_desc;
 
 /* Run-Time mode descriptors. No endpoints, identical for high and full speed. */
-static struct usb_desc_header *runtime_mode_descs[] = {
+static struct usb_desc_header *const runtime_mode_descs[] = {
 	(struct usb_desc_header *) &runtime_if0_desc,
 	(struct usb_desc_header *) &dfu_desc,
 	NULL,
@@ -627,8 +627,8 @@ static int runtime_mode_control_to_dev(struct usbd_class_data *const c_data,
 	return ret;
 }
 
-static void *runtime_mode_get_desc(struct usbd_class_data *const c_data,
-				   const enum usbd_speed speed)
+static const void *runtime_mode_get_desc(struct usbd_class_data *const c_data,
+					 const enum usbd_speed speed)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 
@@ -650,7 +650,7 @@ static int runtime_mode_init(struct usbd_class_data *const c_data)
 	return 0;
 }
 
-struct usbd_class_api runtime_mode_api = {
+static const struct usbd_class_api runtime_mode_api = {
 	.control_to_host = runtime_mode_control_to_host,
 	.control_to_dev = runtime_mode_control_to_dev,
 	.get_desc = runtime_mode_get_desc,
@@ -796,8 +796,8 @@ static void dfu_mode_update(struct usbd_class_data *const c_data,
 	}
 }
 
-static void *dfu_mode_get_desc(struct usbd_class_data *const c_data,
-			       const enum usbd_speed speed)
+static const void *dfu_mode_get_desc(struct usbd_class_data *const c_data,
+				     const enum usbd_speed speed)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 
@@ -834,7 +834,7 @@ static int dfu_mode_init(struct usbd_class_data *const c_data)
 	return data->image == NULL ? -EINVAL : 0;
 }
 
-struct usbd_class_api dfu_api = {
+static const struct usbd_class_api dfu_api = {
 	.control_to_host = dfu_mode_control_to_host,
 	.control_to_dev = dfu_mode_control_to_dev,
 	.update = dfu_mode_update,

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -67,8 +67,8 @@ struct hid_device_config {
 	struct net_buf_pool *pool_out;
 	struct net_buf_pool *pool_in;
 	struct usbd_desc_node *const if_desc_data;
-	const struct usb_desc_header **fs_desc;
-	const struct usb_desc_header **hs_desc;
+	const struct usb_desc_header *const *fs_desc;
+	const struct usb_desc_header *const *hs_desc;
 };
 
 struct hid_device_data {
@@ -530,8 +530,8 @@ static void usbd_hid_resumed(struct usbd_class_data *const c_data)
 	LOG_DBG("Configuration resumed, device %s", dev->name);
 }
 
-static void *usbd_hid_get_desc(struct usbd_class_data *const c_data,
-			       const enum usbd_speed speed)
+static const void *usbd_hid_get_desc(struct usbd_class_data *const c_data,
+				     const enum usbd_speed speed)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct hid_device_config *dcfg = dev->config;
@@ -783,7 +783,7 @@ static int hid_device_init(const struct device *dev)
 	return 0;
 }
 
-struct usbd_class_api usbd_hid_api = {
+static const struct usbd_class_api usbd_hid_api = {
 	.request = usbd_hid_request,
 	.update = NULL,
 	.sof = usbd_hid_sof,
@@ -819,7 +819,7 @@ static const struct hid_device_driver_api hid_device_api = {
 		.hs_out_ep = HID_OUT_EP_DEFINE_OR_ZERO(n, 1, 1),		\
 	};									\
 										\
-	const static struct usb_desc_header *hid_fs_desc_##n[] = {		\
+	const static struct usb_desc_header *const hid_fs_desc_##n[] = {	\
 		(struct usb_desc_header *) &hid_desc_##n.if0,			\
 		(struct usb_desc_header *) &hid_desc_##n.hid,			\
 		(struct usb_desc_header *) &hid_desc_##n.in_ep,			\
@@ -827,7 +827,7 @@ static const struct hid_device_driver_api hid_device_api = {
 		NULL,								\
 	};									\
 										\
-	const static struct usb_desc_header *hid_hs_desc_##n[] = {		\
+	const static struct usb_desc_header *const hid_hs_desc_##n[] = {	\
 		(struct usb_desc_header *) &hid_desc_##n.if0,			\
 		(struct usb_desc_header *) &hid_desc_##n.hid,			\
 		(struct usb_desc_header *) &hid_desc_##n.hs_in_ep,		\
@@ -848,7 +848,7 @@ static const struct hid_device_driver_api hid_device_api = {
 		.alt_hs_out_ep = HID_OUT_EP_DEFINE_OR_ZERO(n, 1, 1),		\
 	};									\
 										\
-	const static struct usb_desc_header *hid_fs_desc_##n[] = {		\
+	const static struct usb_desc_header *const hid_fs_desc_##n[] = {	\
 		(struct usb_desc_header *) &hid_desc_##n.if0,			\
 		(struct usb_desc_header *) &hid_desc_##n.hid,			\
 		(struct usb_desc_header *) &hid_desc_##n.in_ep,			\
@@ -856,7 +856,7 @@ static const struct hid_device_driver_api hid_device_api = {
 		NULL,								\
 	};									\
 										\
-	const static struct usb_desc_header *hid_hs_desc_##n[] = {		\
+	const static struct usb_desc_header *const hid_hs_desc_##n[] = {	\
 		(struct usb_desc_header *) &hid_desc_##n.if0,			\
 		(struct usb_desc_header *) &hid_desc_##n.hid,			\
 		(struct usb_desc_header *) &hid_desc_##n.hs_in_ep,		\

--- a/subsys/usb/device_next/class/usbd_hid_api.c
+++ b/subsys/usb/device_next/class/usbd_hid_api.c
@@ -61,10 +61,10 @@ int hid_device_set_out_polling(const struct device *dev, const unsigned int peri
 struct legacy_wrapper {
 	const struct device *dev;
 	const struct hid_ops *legacy_ops;
-	struct hid_device_ops *ops;
+	const struct hid_device_ops *ops;
 };
 
-static struct hid_device_ops wrapper_ops;
+static const struct hid_device_ops wrapper_ops;
 
 #define DT_DRV_COMPAT zephyr_hid_device
 
@@ -173,7 +173,7 @@ void wrapper_output_report(const struct device *dev,
 	__ASSERT(false, "Output report callback is not supported");
 }
 
-static struct hid_device_ops wrapper_ops = {
+static const struct hid_device_ops wrapper_ops = {
 	.get_report = wrapper_get_report,
 	.set_report = wrapper_set_report,
 	.set_idle = wrapper_set_idle,

--- a/subsys/usb/device_next/class/usbd_midi2.c
+++ b/subsys/usb/device_next/class/usbd_midi2.c
@@ -141,8 +141,8 @@ struct usbd_midi_descriptors {
 /* Device driver configuration */
 struct usbd_midi_config {
 	struct usbd_midi_descriptors *desc;
-	struct usb_desc_header const **fs_descs;
-	struct usb_desc_header const **hs_descs;
+	struct usb_desc_header const *const *fs_descs;
+	struct usb_desc_header const *const *hs_descs;
 };
 
 /* Device driver data */
@@ -341,8 +341,8 @@ static int usbd_midi_class_init(struct usbd_class_data *const class_data)
 	return 0;
 }
 
-static void *usbd_midi_class_get_desc(struct usbd_class_data *const class_data,
-				      const enum usbd_speed speed)
+static const void *usbd_midi_class_get_desc(struct usbd_class_data *const class_data,
+					    const enum usbd_speed speed)
 {
 	const struct device *dev = usbd_class_get_private(class_data);
 	const struct usbd_midi_config *config = dev->config;
@@ -357,7 +357,7 @@ static void *usbd_midi_class_get_desc(struct usbd_class_data *const class_data,
 }
 
 
-static struct usbd_class_api usbd_midi_class_api = {
+static const struct usbd_class_api usbd_midi_class_api = {
 	.request = usbd_midi_class_request,
 	.update = usbd_midi_class_update,
 	.enable = usbd_midi_class_enable,
@@ -740,7 +740,7 @@ void usbd_midi_set_ops(const struct device *dev, const struct usbd_midi_ops *ops
 			)                                                                \
 		},                                                                       \
 	};                                                                               \
-	static const struct usb_desc_header *usbd_midi_desc_array_fs_##n[] = {           \
+	static const struct usb_desc_header *const usbd_midi_desc_array_fs_##n[] = {     \
 		(struct usb_desc_header *)&usbd_midi_desc_##n.iad,                       \
 		(struct usb_desc_header *)&usbd_midi_desc_##n.if0_std,                   \
 		(struct usb_desc_header *)&usbd_midi_desc_##n.if0_cs,                    \
@@ -758,7 +758,7 @@ void usbd_midi_set_ops(const struct device *dev, const struct usbd_midi_ops *ops
 		(struct usb_desc_header *)&usbd_midi_desc_##n.if1_1_cs_in_ep,            \
 		NULL,                                                                    \
 	};                                                                               \
-	static const struct usb_desc_header *usbd_midi_desc_array_hs_##n[] = {           \
+	static const struct usb_desc_header *const usbd_midi_desc_array_hs_##n[] = {     \
 		(struct usb_desc_header *)&usbd_midi_desc_##n.iad,                       \
 		(struct usb_desc_header *)&usbd_midi_desc_##n.if0_std,                   \
 		(struct usb_desc_header *)&usbd_midi_desc_##n.if0_cs,                    \

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -113,8 +113,8 @@ enum msc_bot_state {
 struct msc_bot_ctx {
 	struct usbd_class_data *class_node;
 	struct msc_bot_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 	uint8_t *scsi_bufs[MSC_NUM_BUFFERS];
 	atomic_t bits;
 	enum msc_bot_state state;
@@ -877,8 +877,8 @@ static void msc_bot_disable(struct usbd_class_data *const c_data)
 	atomic_clear_bit(&ctx->bits, MSC_CLASS_ENABLED);
 }
 
-static void *msc_bot_get_desc(struct usbd_class_data *const c_data,
-			      const enum usbd_speed speed)
+static const void *msc_bot_get_desc(struct usbd_class_data *const c_data,
+				    const enum usbd_speed speed)
 {
 	struct msc_bot_ctx *ctx = usbd_class_get_private(c_data);
 
@@ -963,14 +963,14 @@ static struct msc_bot_desc msc_bot_desc_##n = {					\
 	},									\
 };										\
 										\
-const static struct usb_desc_header *msc_bot_fs_desc_##n[] = {			\
+const static struct usb_desc_header *const msc_bot_fs_desc_##n[] = {		\
 	(struct usb_desc_header *) &msc_bot_desc_##n.if0,			\
 	(struct usb_desc_header *) &msc_bot_desc_##n.if0_in_ep,			\
 	(struct usb_desc_header *) &msc_bot_desc_##n.if0_out_ep,		\
 	(struct usb_desc_header *) &msc_bot_desc_##n.nil_desc,			\
 };										\
 										\
-const static struct usb_desc_header *msc_bot_hs_desc_##n[] = {			\
+const static struct usb_desc_header *const msc_bot_hs_desc_##n[] = {		\
 	(struct usb_desc_header *) &msc_bot_desc_##n.if0,			\
 	(struct usb_desc_header *) &msc_bot_desc_##n.if0_hs_in_ep,		\
 	(struct usb_desc_header *) &msc_bot_desc_##n.if0_hs_out_ep,		\
@@ -978,7 +978,7 @@ const static struct usb_desc_header *msc_bot_hs_desc_##n[] = {			\
 };
 
 
-struct usbd_class_api msc_bot_api = {
+static const struct usbd_class_api msc_bot_api = {
 	.feature_halt = msc_bot_feature_halt,
 	.control_to_dev = msc_bot_control_to_dev,
 	.control_to_host = msc_bot_control_to_host,

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -94,8 +94,8 @@ struct uac2_ctx {
 /* UAC2 device constant data */
 struct uac2_cfg {
 	struct usbd_class_data *const c_data;
-	const struct usb_desc_header **fs_descriptors;
-	const struct usb_desc_header **hs_descriptors;
+	const struct usb_desc_header *const *fs_descriptors;
+	const struct usb_desc_header *const *hs_descriptors;
 	/* Entity 1 type is at entity_types[0] */
 	const entity_type_t *entity_types;
 	/* Array of indexes to data endpoint descriptor in descriptors set.
@@ -131,7 +131,7 @@ get_as_data_ep(struct usbd_class_data *const c_data, int as_idx)
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uac2_cfg *cfg = dev->config;
 	const struct usb_desc_header *desc = NULL;
-	const struct usb_desc_header **descriptors;
+	const struct usb_desc_header *const *descriptors;
 
 	if (usbd_bus_speed(c_data->uds_ctx) == USBD_SPEED_FS) {
 		descriptors = cfg->fs_descriptors;
@@ -153,7 +153,7 @@ get_as_feedback_ep(struct usbd_class_data *const c_data, int as_idx)
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uac2_cfg *cfg = dev->config;
 	const struct usb_desc_header *desc = NULL;
-	const struct usb_desc_header **descriptors;
+	const struct usb_desc_header *const *descriptors;
 
 	if (usbd_bus_speed(c_data->uds_ctx) == USBD_SPEED_FS) {
 		descriptors = cfg->fs_descriptors;
@@ -462,7 +462,7 @@ void uac2_update(struct usbd_class_data *const c_data,
 	struct usbd_context *uds_ctx = usbd_class_get_ctx(c_data);
 	const struct uac2_cfg *cfg = dev->config;
 	struct uac2_ctx *ctx = dev->data;
-	const struct usb_desc_header **descriptors;
+	const struct usb_desc_header *const *descriptors;
 	const struct usb_association_descriptor *iad;
 	const struct usb_ep_descriptor *data_ep, *fb_ep;
 	uint8_t as_idx;
@@ -920,8 +920,8 @@ static void uac2_sof(struct usbd_class_data *const c_data)
 	}
 }
 
-static void *uac2_get_desc(struct usbd_class_data *const c_data,
-			   const enum usbd_speed speed)
+static const void *uac2_get_desc(struct usbd_class_data *const c_data,
+				 const enum usbd_speed speed)
 {
 	struct device *dev = usbd_class_get_private(c_data);
 	const struct uac2_cfg *cfg = dev->config;
@@ -966,7 +966,7 @@ static int uac2_init(struct usbd_class_data *const c_data)
 	return 0;
 }
 
-struct usbd_class_api uac2_api = {
+static const struct usbd_class_api uac2_api = {
 	.update = uac2_update,
 	.control_to_dev = uac2_control_to_dev,
 	.control_to_host = uac2_control_to_host,
@@ -1034,11 +1034,11 @@ struct usbd_class_api uac2_api = {
 	static struct uac2_ctx uac2_ctx_##inst;					\
 	UAC2_DESCRIPTOR_ARRAYS(DT_DRV_INST(inst))				\
 	IF_ENABLED(UAC2_ALLOWED_AT_FULL_SPEED(DT_DRV_INST(inst)), (		\
-		static const struct usb_desc_header *uac2_fs_desc_##inst[] =	\
+		static const struct usb_desc_header *const uac2_fs_desc_##inst[] =	\
 			UAC2_FS_DESCRIPTOR_PTRS_ARRAY(DT_DRV_INST(inst));	\
 	))									\
 	IF_ENABLED(UAC2_ALLOWED_AT_HIGH_SPEED(DT_DRV_INST(inst)), (		\
-		static const struct usb_desc_header *uac2_hs_desc_##inst[] =	\
+		static const struct usb_desc_header *const uac2_hs_desc_##inst[] =	\
 			UAC2_HS_DESCRIPTOR_PTRS_ARRAY(DT_DRV_INST(inst));	\
 	))									\
 	USBD_DEFINE_CLASS(uac2_##inst, &uac2_api,				\

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1119,7 +1119,8 @@ end:
 
 /* UVC descriptor handling */
 
-static void *uvc_get_desc(struct usbd_class_data *const c_data, const enum usbd_speed speed)
+static const void *uvc_get_desc(struct usbd_class_data *const c_data,
+				const enum usbd_speed speed)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uvc_config *const cfg = dev->config;

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -470,7 +470,7 @@ static struct net_buf *sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	net_buf_add_mem(buf, cfg_desc, MIN(net_buf_tailroom(buf), cfg_desc->bLength));
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&cfg_nd->class_list, c_nd, node) {
-		struct usb_desc_header **dhp;
+		struct usb_desc_header *const *dhp;
 
 		dhp = usbd_class_get_desc(c_nd->c_data, get_desc_speed);
 		if (dhp == NULL) {

--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(usbd_class, CONFIG_USBD_LOG_LEVEL);
 size_t usbd_class_desc_len(struct usbd_class_data *const c_data,
 			   const enum usbd_speed speed)
 {
-	struct usb_desc_header **dhp;
+	struct usb_desc_header *const *dhp;
 	size_t len = 0;
 
 	dhp = usbd_class_get_desc(c_data, speed);

--- a/subsys/usb/device_next/usbd_class_api.h
+++ b/subsys/usb/device_next/usbd_class_api.h
@@ -297,8 +297,8 @@ static inline void usbd_class_shutdown(struct usbd_class_data *const c_data)
  * @return Array of struct usb_desc_header pointers with a last element
  *         pointing to a nil descriptor on success, NULL if not available.
  */
-static inline void *usbd_class_get_desc(struct usbd_class_data *const c_data,
-					const enum usbd_speed speed)
+static inline const void *usbd_class_get_desc(struct usbd_class_data *const c_data,
+					      const enum usbd_speed speed)
 {
 	const struct usbd_class_api *api = c_data->api;
 

--- a/subsys/usb/device_next/usbd_init.c
+++ b/subsys/usb/device_next/usbd_init.c
@@ -114,7 +114,7 @@ static int init_configuration_inst(struct usbd_context *const uds_ctx,
 				   uint32_t *const config_ep_bm,
 				   uint8_t *const nif)
 {
-	struct usb_desc_header **dhp;
+	struct usb_desc_header *const *dhp;
 	struct usb_association_descriptor *iad = NULL;
 	struct usb_if_descriptor *ifd = NULL;
 	struct usb_ep_descriptor *ed;

--- a/subsys/usb/device_next/usbd_interface.c
+++ b/subsys/usb/device_next/usbd_interface.c
@@ -56,7 +56,7 @@ static int usbd_interface_modify(struct usbd_context *const uds_ctx,
 				 const uint8_t iface,
 				 const uint8_t alt)
 {
-	struct usb_desc_header **dhp;
+	struct usb_desc_header *const *dhp;
 	bool found_iface = false;
 	int ret;
 


### PR DESCRIPTION
Class API vtables and the per-instance descriptor pointer arrays were missing a `const`, so they sat in `.data` although nothing writes them after init. Adding the const (and `static` where the symbol is file-local) moves them to ROM; `USBD_VENDOR_REQ()` now builds a const compound literal as well.

The descriptors themselves stay in RAM, only the arrays of pointers to them become constant.

`.data` on `nrf52840dk/nrf52840`, before → after (lower is better):

| sample | before | after | delta |
| --- | ---: | ---: | ---: |
| cdc_acm | 1031 | 935 | −96 |
| hid-keyboard | 828 | 736 | −92 |
| mass | 1092 | 1006 | −86 |
| dfu | 1063 | 947 | −116 |
| midi | 1330 | 1150 | −180 |
