### PR TITLE
bluetooth: add Media Player Name setter support

### DIFF
--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -880,6 +880,16 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn);
 int media_proxy_ctrl_get_player_name(struct media_player *player);
 
 /**
+ * @brief Set Media Player Name
+ *
+ * @param player   Media player instance pointer
+ * @param name     The new Media Player Name
+ *
+ * @return 0 if success, errno on failure.
+ */
+int media_proxy_ctrl_set_player_name(struct media_player *player, const char *name);
+
+/**
  * @brief Read Icon Object ID
  *
  * Get an ID (48 bit) that can be used to retrieve the Icon
@@ -1279,6 +1289,13 @@ struct media_proxy_pl_calls {
 	 * @return The name of the media player
 	 */
 	const char *(*get_player_name)(void);
+
+	/**
+	 * @brief Set Media Player Name
+	 *
+	 * @param name    The new Media Player Name
+	 */
+	void (*set_player_name)(const char *name);
 
 	/**
 	 * @brief Read Icon Object ID

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -894,6 +894,29 @@ int media_proxy_ctrl_get_player_name(struct media_player *player)
 	return -EINVAL;
 }
 
+int media_proxy_ctrl_set_player_name(struct media_player *player, const char *name)
+{
+	CHECKIF(player == NULL || name == NULL) {
+		LOG_DBG("player or name is NULL");
+		return -EINVAL;
+	}
+
+#if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
+	if (mprx.local_player.registered && player == &mprx.local_player) {
+		if (mprx.local_player.calls->set_player_name != NULL) {
+			mprx.local_player.calls->set_player_name(name);
+
+			return 0;
+		}
+
+		LOG_DBG("No call");
+		return -EOPNOTSUPP;
+	}
+#endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
+
+	return -EINVAL;
+}
+
 int media_proxy_ctrl_get_icon_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -1947,6 +1947,21 @@ static const char *get_player_name(void)
 	return media_player.name;
 }
 
+static void set_player_name(const char *name)
+{
+	size_t len = strlen(name);
+
+	if (len >= sizeof(media_player.name)) {
+		LOG_DBG("Media Player Name is too long: %zu", len);
+		return;
+	}
+
+	if (strcmp(media_player.name, name) != 0) {
+		(void)memcpy(media_player.name, name, len + 1U);
+		media_proxy_pl_name_cb(media_player.name);
+	}
+}
+
 #ifdef CONFIG_BT_MPL_OBJECTS
 static uint64_t get_icon_id(void)
 {
@@ -2508,6 +2523,7 @@ int media_proxy_pl_init(void)
 
 	/* Set up the calls structure */
 	media_player.calls.get_player_name              = get_player_name;
+	media_player.calls.set_player_name              = set_player_name;
 #ifdef CONFIG_BT_MPL_OBJECTS
 	media_player.calls.get_icon_id                  = get_icon_id;
 #endif /* CONFIG_BT_MPL_OBJECTS */

--- a/tests/bluetooth/tester/overlay-le-audio.conf
+++ b/tests/bluetooth/tester/overlay-le-audio.conf
@@ -79,6 +79,9 @@ CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER=y
 # BASS notifications need higher MTU
 CONFIG_BT_L2CAP_TX_MTU=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255
+# Must be at least 23 (default ATT MTU) + 1 so the player name cannot be
+# read in a single operation with the default ATT MTU; any value > 23 works.
+CONFIG_BT_MPL_MEDIA_PLAYER_NAME_MAX=32
 
 # ASCS
 CONFIG_BT_ASCS=y

--- a/tests/bluetooth/tester/src/audio/btp/btp_mcs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_mcs.h
@@ -39,3 +39,9 @@ struct btp_mcs_state_set_rp {
 } __packed;
 
 #define BTP_MCS_PARENT_GROUP_SET		0x06U
+
+#define BTP_MCS_PLAYER_NAME_SET			0x07U
+struct btp_mcs_player_name_set_cmd {
+	uint8_t name_len;
+	char name[0];
+} __packed;

--- a/tests/bluetooth/tester/src/audio/btp_mcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_mcp.c
@@ -1659,6 +1659,32 @@ static uint8_t mcs_inactive_state_set(const void *cmd, uint16_t cmd_len, void *r
 	return BTP_STATUS_SUCCESS;
 }
 
+static uint8_t mcs_player_name_set(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
+{
+	const struct btp_mcs_player_name_set_cmd *cp = cmd;
+	char name[CONFIG_BT_MPL_MEDIA_PLAYER_NAME_MAX];
+	int err;
+
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
+	if (cmd_len < sizeof(*cp) || cmd_len != sizeof(*cp) + cp->name_len ||
+	    cp->name_len >= sizeof(name)) {
+		return BTP_STATUS_FAILED;
+	}
+
+	(void)memcpy(name, cp->name, cp->name_len);
+	name[cp->name_len] = '\0';
+
+	LOG_DBG("MCS Set Media Player Name");
+	err = media_proxy_ctrl_set_player_name(mcs_media_player, name);
+	if (err != 0) {
+		return BTP_STATUS_FAILED;
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
 static void mcs_player_instance_cb(struct media_player *plr, int err)
 {
 	ARG_UNUSED(err);
@@ -1768,6 +1794,11 @@ static const struct btp_handler mcs_handlers[] = {
 		.opcode = BTP_MCS_PARENT_GROUP_SET,
 		.expect_len = 0,
 		.func = mcs_parent_group_set,
+	},
+	{
+		.opcode = BTP_MCS_PLAYER_NAME_SET,
+		.expect_len = BTP_HANDLER_LENGTH_VARIABLE,
+		.func = mcs_player_name_set,
 	},
 };
 


### PR DESCRIPTION
Add a proper Media Proxy API for setting the local
Media Player Name and expose it through the media
player callback interface.

The following conformance tests now pass:
GMCS/SR/SPN/BV-01-C

Testing
nRF5340 Audio DK
nRF54L15 DK

Fixed https://github.com/zephyrproject-rtos/zephyr/issues/65062