### PR TITLE
drivers: otp: stm32: add otp driver for stm32mp13 series

### DIFF
--- a/boards/st/stm32mp135f_dk/Kconfig.defconfig
+++ b/boards/st/stm32mp135f_dk/Kconfig.defconfig
@@ -15,6 +15,10 @@ endif # GPIO_MCP230XX
 configdefault ETH_DRIVER
 	default y
 
+# The MAC addresses are read from the OTP fuses through NVMEM
+configdefault OTP
+	default y if ETH_DRIVER && NVMEM
+
 configdefault NET_IF_MAX_IPV4_COUNT
 	default 2
 

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -323,6 +323,8 @@ csi_interface: &dcmipp {
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy0>;
 	memory-regions = <&eth_ram>;
+	nvmem-cells = <&ethernet_mac1_address>;
+	nvmem-cell-names = "mac-address";
 
 	status = "okay";
 };
@@ -357,6 +359,8 @@ csi_interface: &dcmipp {
 	phy-handle = <&eth_phy1>;
 	memory-regions = <&eth_ram>;
 	st,ext-phyclk;
+	nvmem-cells = <&ethernet_mac2_address>;
+	nvmem-cell-names = "mac-address";
 
 	status = "okay";
 };

--- a/drivers/clock_control/clock_stm32_ll_mp13.c
+++ b/drivers/clock_control/clock_stm32_ll_mp13.c
@@ -167,6 +167,19 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 			return -ENOTSUP;
 		}
 		break;
+	case STM32_CLOCK_BUS_APB5:
+		switch (pclken->enr) {
+		case LL_APB5_GRP1_PERIPH_BSEC: {
+			LL_RCC_ClocksTypeDef rcc_clocks;
+
+			LL_RCC_GetSystemClocksFreq(&rcc_clocks);
+			*rate = rcc_clocks.PCLK5_Frequency;
+			break;
+		}
+		default:
+			return -ENOTSUP;
+		}
+		break;
 	case STM32_CLOCK_BUS_APB6:
 		switch (pclken->enr) {
 		case LL_APB6_GRP1_PERIPH_USART1:

--- a/drivers/otp/otp_bsec_stm32.c
+++ b/drivers/otp/otp_bsec_stm32.c
@@ -18,11 +18,13 @@ LOG_MODULE_REGISTER(otp_bsec_stm32, CONFIG_OTP_LOG_LEVEL);
 
 #define BSEC_WORD_SIZE	4
 
+/* Start fuse index of the upper fuse region, which requires a particular SoC state to be read */
+#define BSEC_UPPER_FUSE_LIMIT DT_INST_PROP(0, st_upper_fuse_limit)
+
 static K_MUTEX_DEFINE(lock);
 
 struct bsec_stm32_config {
 	BSEC_TypeDef *base;
-	unsigned int upper_fuse_limit;
 };
 
 static inline void otp_bsec_stm32_lock(void)
@@ -112,9 +114,8 @@ static HAL_StatusTypeDef hal_bsec_otp_program(BSEC_HandleTypeDef *handle, uint32
 }
 #endif /* CONFIG_OTP_PROGRAM */
 
-static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle,
-					   const struct bsec_stm32_config *config __unused,
-					   off_t offset, unsigned int nb_fuse)
+static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle, off_t offset,
+					   unsigned int nb_fuse)
 {
 	uint32_t fuse_idx = offset / BSEC_WORD_SIZE;
 	BSEC_ChipSecurityTypeDef bsec_state;
@@ -164,8 +165,7 @@ static HAL_StatusTypeDef hal_bsec_otp_program(BSEC_HandleTypeDef *handle, uint32
 }
 #endif /* CONFIG_OTP_PROGRAM */
 
-static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle,
-					   const struct bsec_stm32_config *config, off_t offset,
+static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle, off_t offset,
 					   unsigned int nb_fuse)
 {
 	uint32_t fuse_idx = offset / BSEC_WORD_SIZE;
@@ -182,7 +182,7 @@ static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle,
 	}
 
 	/* Upper fuses are only accessible when the BSEC is in closed locked state */
-	if (((fuse_idx + nb_fuse) > config->upper_fuse_limit) &&
+	if (((fuse_idx + nb_fuse) > BSEC_UPPER_FUSE_LIMIT) &&
 	    (bsec_state != HAL_BSEC_CLOSED_STATE)) {
 		return -EACCES;
 	}
@@ -218,7 +218,7 @@ static int otp_bsec_stm32_program(const struct device *dev, off_t offset, const 
 
 	nb_fuse = len / BSEC_WORD_SIZE;
 
-	ret = otp_bsec_stm32_check_accessible(&handle, config, offset, nb_fuse);
+	ret = otp_bsec_stm32_check_accessible(&handle, offset, nb_fuse);
 	if (ret != 0) {
 		return ret;
 	}
@@ -266,7 +266,7 @@ static int otp_bsec_stm32_read(const struct device *dev, off_t offset, void *buf
 	/* Allow intra-word and spanned reads but not 0-sized reads */
 	nb_fuse = len != 0 ? DIV_ROUND_UP(offset % BSEC_WORD_SIZE + len, BSEC_WORD_SIZE) : 0;
 
-	ret = otp_bsec_stm32_check_accessible(&handle, config, offset, nb_fuse);
+	ret = otp_bsec_stm32_check_accessible(&handle, offset, nb_fuse);
 	if (ret != 0) {
 		return ret;
 	}
@@ -308,7 +308,6 @@ static int otp_bsec_stm32_read(const struct device *dev, off_t offset, void *buf
 
 static const struct bsec_stm32_config bsec_config = {
 	.base = (void *)DT_INST_REG_ADDR(0),
-	.upper_fuse_limit = DT_INST_PROP(0, st_upper_fuse_limit),
 };
 
 static DEVICE_API(otp, otp_bsec_stm32_api) = {

--- a/drivers/otp/otp_bsec_stm32.c
+++ b/drivers/otp/otp_bsec_stm32.c
@@ -5,6 +5,8 @@
 
 #include <soc.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/otp.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -37,6 +39,131 @@ static inline void otp_bsec_stm32_unlock(void)
 	}
 }
 
+#if defined(CONFIG_SOC_SERIES_STM32MP13X)
+/*
+ * The STM32MP13 HAL exposes a different BSEC API than the other series: the
+ * SAFMEM fuse array has to be powered up before fuses can be read from it or
+ * programmed, and reading a fuse loads it into its shadow register on the way.
+ * The upper fuses can be accessed from the secure world only, which is where
+ * Zephyr runs as the first stage boot loader, whatever the life cycle state,
+ * so the upper fuse limit is not checked here. HAL_BSEC_GetSecurityStatus()
+ * could not report a closed state anyway: it masks the BSEC_OTP_STATUS bits
+ * down to SECURE/FULLDBG/INVALID before testing the CLOSED bit.
+ */
+#define BSEC_HANDLE_INIT(cfg)                                                                      \
+	{                                                                                          \
+		.Instance = (cfg)->base, .State = BSEC_STATE_READY                                 \
+	}
+
+static const struct device *const bsec_clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+static const struct stm32_pclken bsec_pclken = STM32_DT_INST_CLOCK_INFO(0);
+
+static int otp_bsec_stm32_safmem_on(BSEC_HandleTypeDef *handle)
+{
+	BSEC_SafMemClkRangeTypeDef clk_range;
+	uint32_t rate;
+	int ret;
+
+	/* SAFMEM is clocked by the BSEC bus clock, whose range has to be told to the fuse array */
+	ret = clock_control_get_rate(bsec_clock, (clock_control_subsys_t)&bsec_pclken, &rate);
+	if (ret != 0) {
+		LOG_ERR("Could not get the BSEC clock rate: %d", ret);
+		return ret;
+	}
+
+	if (!IN_RANGE(rate, MHZ(10), MHZ(67))) {
+		LOG_ERR("BSEC clock rate %u Hz outside of the SAFMEM range", rate);
+		return -ENOTSUP;
+	}
+
+	if (rate <= MHZ(20)) {
+		clk_range = BSEC_SAFMEM_CLK_RANGE_10MHZ_20MHZ;
+	} else if (rate <= MHZ(30)) {
+		clk_range = BSEC_SAFMEM_CLK_RANGE_20MHZ_30MHZ;
+	} else if (rate <= MHZ(45)) {
+		clk_range = BSEC_SAFMEM_CLK_RANGE_30MHZ_45MHZ;
+	} else {
+		clk_range = BSEC_SAFMEM_CLK_RANGE_45MHZ_67MHZ;
+	}
+
+	if (HAL_BSEC_SafMemPwrUp(handle, clk_range) != HAL_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static void otp_bsec_stm32_safmem_off(BSEC_HandleTypeDef *handle)
+{
+	HAL_BSEC_SafMemPwrDown(handle);
+}
+
+static HAL_StatusTypeDef hal_bsec_otp_read(BSEC_HandleTypeDef *handle, uint32_t fuse_idx,
+					   uint32_t *fuse_data)
+{
+	return HAL_BSEC_OtpRead(handle, fuse_idx, fuse_data);
+}
+
+#if defined(CONFIG_OTP_PROGRAM)
+static HAL_StatusTypeDef hal_bsec_otp_program(BSEC_HandleTypeDef *handle, uint32_t fuse_idx,
+					      uint32_t fuse_data)
+{
+	return HAL_BSEC_OtpProgram(handle, fuse_idx, fuse_data);
+}
+#endif /* CONFIG_OTP_PROGRAM */
+
+static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle,
+					   const struct bsec_stm32_config *config __unused,
+					   off_t offset, unsigned int nb_fuse)
+{
+	uint32_t fuse_idx = offset / BSEC_WORD_SIZE;
+	BSEC_ChipSecurityTypeDef bsec_state;
+
+	if ((nb_fuse == 0) || ((fuse_idx + nb_fuse) > HAL_BSEC_OTP_NB_WORDS)) {
+		return -EINVAL;
+	}
+
+	if ((HAL_BSEC_GetSecurityStatus(handle, &bsec_state) != HAL_OK) ||
+	    (bsec_state == BSEC_INVALID_STATE)) {
+		return -EACCES;
+	}
+
+	return 0;
+}
+
+static int otp_bsec_stm32_init(const struct device *dev __unused)
+{
+	return clock_control_on(bsec_clock, (clock_control_subsys_t)&bsec_pclken);
+}
+#else /* CONFIG_SOC_SERIES_STM32MP13X */
+#define BSEC_HANDLE_INIT(cfg)                                                                      \
+	{                                                                                          \
+		.Instance = (cfg)->base                                                            \
+	}
+
+static int otp_bsec_stm32_safmem_on(BSEC_HandleTypeDef *handle __unused)
+{
+	return 0;
+}
+
+static void otp_bsec_stm32_safmem_off(BSEC_HandleTypeDef *handle __unused)
+{
+}
+
+static HAL_StatusTypeDef hal_bsec_otp_read(BSEC_HandleTypeDef *handle, uint32_t fuse_idx,
+					   uint32_t *fuse_data)
+{
+	return HAL_BSEC_OTP_Read(handle, fuse_idx, fuse_data);
+}
+
+#if defined(CONFIG_OTP_PROGRAM)
+static HAL_StatusTypeDef hal_bsec_otp_program(BSEC_HandleTypeDef *handle, uint32_t fuse_idx,
+					      uint32_t fuse_data)
+{
+	return HAL_BSEC_OTP_Program(handle, fuse_idx, fuse_data, 0);
+}
+#endif /* CONFIG_OTP_PROGRAM */
+
 static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle,
 					   const struct bsec_stm32_config *config, off_t offset,
 					   unsigned int nb_fuse)
@@ -63,12 +190,15 @@ static int otp_bsec_stm32_check_accessible(BSEC_HandleTypeDef *handle,
 	return 0;
 }
 
+#define otp_bsec_stm32_init NULL
+#endif /* CONFIG_SOC_SERIES_STM32MP13X */
+
 #if defined(CONFIG_OTP_PROGRAM)
 static int otp_bsec_stm32_program(const struct device *dev, off_t offset, const void *buf,
 				  size_t len)
 {
 	const struct bsec_stm32_config *config = dev->config;
-	BSEC_HandleTypeDef handle = { .Instance = config->base };
+	BSEC_HandleTypeDef handle = BSEC_HANDLE_INIT(config);
 	HAL_StatusTypeDef hal_ret;
 	unsigned int nb_fuse;
 	unsigned int i;
@@ -95,6 +225,12 @@ static int otp_bsec_stm32_program(const struct device *dev, off_t offset, const 
 
 	otp_bsec_stm32_lock();
 
+	ret = otp_bsec_stm32_safmem_on(&handle);
+	if (ret != 0) {
+		otp_bsec_stm32_unlock();
+		return ret;
+	}
+
 	for (i = 0; i < nb_fuse; i++) {
 		uint32_t prog_data = 0;
 
@@ -102,24 +238,24 @@ static int otp_bsec_stm32_program(const struct device *dev, off_t offset, const 
 
 		prog_data = UNALIGNED_GET((uint32_t *)((uint8_t *)buf + i * BSEC_WORD_SIZE));
 
-		hal_ret = HAL_BSEC_OTP_Program(&handle, (offset / BSEC_WORD_SIZE) + i, prog_data,
-					       0);
+		hal_ret = hal_bsec_otp_program(&handle, (offset / BSEC_WORD_SIZE) + i, prog_data);
 		if (hal_ret != HAL_OK) {
-			otp_bsec_stm32_unlock();
-			return -EACCES;
+			ret = -EACCES;
+			break;
 		}
 	}
 
+	otp_bsec_stm32_safmem_off(&handle);
 	otp_bsec_stm32_unlock();
 
-	return 0;
+	return ret;
 }
 #endif /* CONFIG_OTP_PROGRAM */
 
 static int otp_bsec_stm32_read(const struct device *dev, off_t offset, void *buf, size_t len)
 {
 	const struct bsec_stm32_config *config = dev->config;
-	BSEC_HandleTypeDef handle = { .Instance = config->base };
+	BSEC_HandleTypeDef handle = BSEC_HANDLE_INIT(config);
 	uint8_t *dest = (uint8_t *)buf;
 	HAL_StatusTypeDef hal_ret;
 	size_t bytes_left = len;
@@ -137,6 +273,12 @@ static int otp_bsec_stm32_read(const struct device *dev, off_t offset, void *buf
 
 	otp_bsec_stm32_lock();
 
+	ret = otp_bsec_stm32_safmem_on(&handle);
+	if (ret != 0) {
+		otp_bsec_stm32_unlock();
+		return ret;
+	}
+
 	for (i = 0; i < nb_fuse; i++) {
 		size_t first_offset  = (i == 0) ? offset % BSEC_WORD_SIZE : 0;
 		size_t read_sz = MIN(BSEC_WORD_SIZE - first_offset, bytes_left);
@@ -144,10 +286,10 @@ static int otp_bsec_stm32_read(const struct device *dev, off_t offset, void *buf
 
 		LOG_DBG("Reading Fuse %lu", (offset / BSEC_WORD_SIZE) + i);
 
-		hal_ret = HAL_BSEC_OTP_Read(&handle, (offset / BSEC_WORD_SIZE) + i, &fuse_data);
+		hal_ret = hal_bsec_otp_read(&handle, (offset / BSEC_WORD_SIZE) + i, &fuse_data);
 		if (hal_ret != HAL_OK) {
-			otp_bsec_stm32_unlock();
-			return -EACCES;
+			ret = -EACCES;
+			break;
 		}
 
 		memcpy(dest, ((uint8_t *)&fuse_data) + first_offset, read_sz);
@@ -158,9 +300,10 @@ static int otp_bsec_stm32_read(const struct device *dev, off_t offset, void *buf
 		}
 	}
 
+	otp_bsec_stm32_safmem_off(&handle);
 	otp_bsec_stm32_unlock();
 
-	return 0;
+	return ret;
 }
 
 static const struct bsec_stm32_config bsec_config = {
@@ -175,5 +318,5 @@ static DEVICE_API(otp, otp_bsec_stm32_api) = {
 	.read = otp_bsec_stm32_read,
 };
 
-DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &bsec_config, PRE_KERNEL_1,
+DEVICE_DT_INST_DEFINE(0, otp_bsec_stm32_init, NULL, NULL, &bsec_config, PRE_KERNEL_1,
 		      CONFIG_OTP_INIT_PRIORITY, &otp_bsec_stm32_api);

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -827,6 +827,30 @@
 			status = "disabled";
 		};
 
+		bsec: efuse@5c005000 {
+			compatible = "st,stm32-bsec";
+			reg = <0x5c005000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB5, 16)>;
+			st,upper-fuse-limit = <32>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				/* MAC addresses programmed into OTP words 57 to 59 by ST */
+				ethernet_mac1_address: mac-address@e4 {
+					reg = <0xe4 0x6>;
+					#nvmem-cell-cells = <0>;
+				};
+
+				ethernet_mac2_address: mac-address@ea {
+					reg = <0xea 0x6>;
+					#nvmem-cell-cells = <0>;
+				};
+			};
+		};
+
 		rtc: rtc@5c004000 {
 			compatible = "st,stm32-rtc";
 			reg = <0x5c004000 0x400>;


### PR DESCRIPTION
- add otp driver for stm32mp13 series
- use the ethernet mac addresses in the otp as the default mac addresses on the stm32mp135f-dk (they match the sticker on the ethernet port) This also makes the addresses of the two ifaces different, as the otherwise default via hwinfo will make both iface have the same mac address.