### PR TITLE
usb: place class data of the remaining device_next users in ROM

### DIFF
--- a/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.c
+++ b/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.c
@@ -357,7 +357,7 @@ static struct i2c_tiny_usb_desc bridge_desc = {
 };
 /* clang-format on */
 
-static const struct usb_desc_header *bridge_desc_list[] = {
+static const struct usb_desc_header *const bridge_desc_list[] = {
 	(struct usb_desc_header *)&bridge_desc.if0,
 	(struct usb_desc_header *)&bridge_desc.nil_desc,
 };
@@ -376,7 +376,7 @@ static int bridge_init(struct usbd_class_data *const c_data)
 	return 0;
 }
 
-static struct usbd_class_api bridge_api = {
+static const struct usbd_class_api bridge_api = {
 	.control_to_dev = class_control_to_dev,
 	.control_to_host = class_control_to_host,
 	.get_desc = bridge_get_desc,

--- a/samples/subsys/usb/webusb/src/sfunc.c
+++ b/samples/subsys/usb/webusb/src/sfunc.c
@@ -34,8 +34,8 @@ struct sfunc_desc {
 
 struct sfunc_data {
 	struct sfunc_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 	atomic_t state;
 };
 
@@ -175,7 +175,7 @@ static int sfunc_init(struct usbd_class_data *c_data)
 	return 0;
 }
 
-struct usbd_class_api sfunc_api = {
+static const struct usbd_class_api sfunc_api = {
 	.request = sfunc_request_handler,
 	.get_desc = sfunc_get_desc,
 	.enable = sfunc_enable,
@@ -245,14 +245,14 @@ static struct sfunc_desc sfunc_desc_##n = {					\
 	},									\
 };										\
 										\
-const static struct usb_desc_header *sfunc_fs_desc_##n[] = {			\
+const static struct usb_desc_header *const sfunc_fs_desc_##n[] = {		\
 	(struct usb_desc_header *) &sfunc_desc_##n.if0,				\
 	(struct usb_desc_header *) &sfunc_desc_##n.if0_in_ep,			\
 	(struct usb_desc_header *) &sfunc_desc_##n.if0_out_ep,			\
 	(struct usb_desc_header *) &sfunc_desc_##n.nil_desc,			\
 };										\
 										\
-const static struct usb_desc_header *sfunc_hs_desc_##n[] = {			\
+const static struct usb_desc_header *const sfunc_hs_desc_##n[] = {		\
 	(struct usb_desc_header *) &sfunc_desc_##n.if0,				\
 	(struct usb_desc_header *) &sfunc_desc_##n.if0_hs_in_ep,		\
 	(struct usb_desc_header *) &sfunc_desc_##n.if0_hs_out_ep,		\

--- a/subsys/dap/dap_backend_usb.c
+++ b/subsys/dap/dap_backend_usb.c
@@ -38,8 +38,8 @@ struct dap_func_desc {
 
 struct dap_func_data {
 	struct dap_func_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 	struct usbd_desc_node *const iface_str_desc_nd;
 	atomic_t state;
 	struct dap_link_context *dap_link_ctx;
@@ -210,7 +210,7 @@ static int dap_func_init(struct usbd_class_data *c_data)
 	return 0;
 }
 
-struct usbd_class_api dap_func_api = {
+static const struct usbd_class_api dap_func_api = {
 	.request = dap_func_request_handler,
 	.get_desc = dap_func_get_desc,
 	.enable = dap_func_enable,
@@ -280,14 +280,14 @@ static struct dap_func_desc dap_func_desc_##n = {				\
 	},									\
 };										\
 										\
-const static struct usb_desc_header *dap_func_fs_desc_##n[] = {			\
+const static struct usb_desc_header *const dap_func_fs_desc_##n[] = {		\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0,			\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_out_ep,		\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_in_ep,		\
 	(struct usb_desc_header *) &dap_func_desc_##n.nil_desc,			\
 };										\
 										\
-const static struct usb_desc_header *dap_func_hs_desc_##n[] = {			\
+const static struct usb_desc_header *const dap_func_hs_desc_##n[] = {		\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0,			\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_hs_out_ep,		\
 	(struct usb_desc_header *) &dap_func_desc_##n.if0_hs_in_ep,		\

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
@@ -104,7 +104,7 @@ struct ec_host_cmd_desc {
 struct ec_host_cmd_usb_ctx {
 	struct usbd_class_data *c_data;
 	struct ec_host_cmd_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
+	const struct usb_desc_header *const *const fs_desc;
 	struct ec_host_cmd_rx_ctx *rx_ctx;
 	struct ec_host_cmd_tx_buf *tx_buf;
 	uint8_t *bulk_out_buf;
@@ -474,7 +474,7 @@ static void ec_host_cmd_reset(struct k_work *work)
 	ec_host_cmd_enable(ctx->c_data);
 }
 
-__maybe_unused static struct usbd_class_api ec_host_cmd_api = {
+__maybe_unused static const struct usbd_class_api ec_host_cmd_api = {
 	.request = ec_host_cmd_request,
 	.suspended = ec_host_cmd_suspended,
 	.resumed = ec_host_cmd_resumed,
@@ -617,7 +617,7 @@ static struct ec_host_cmd_desc ec_host_cmd_desc = {
 		},
 };
 
-static const struct usb_desc_header *ec_host_cmd_fs_desc[] = {
+static const struct usb_desc_header *const ec_host_cmd_fs_desc[] = {
 	(struct usb_desc_header *)&ec_host_cmd_desc.if0,
 	(struct usb_desc_header *)&ec_host_cmd_desc.out_ep,
 	(struct usb_desc_header *)&ec_host_cmd_desc.in_bulk_ep,

--- a/subsys/pmci/mctp/mctp_usb.c
+++ b/subsys/pmci/mctp/mctp_usb.c
@@ -44,8 +44,8 @@ struct mctp_usb_class_desc {
 struct mctp_usb_class_ctx {
 	struct usbd_class_data *class_data;
 	struct mctp_usb_class_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 	struct mctp_usb_class_inst *inst;
 	uint8_t inst_idx;
 	struct k_fifo rx_fifo;
@@ -536,7 +536,7 @@ static int mctp_usb_class_init(struct usbd_class_data *const c_data)
 	return 0;
 }
 
-struct usbd_class_api mctp_usb_class_api = {
+static const struct usbd_class_api mctp_usb_class_api = {
 	.request = mctp_usb_class_request,
 	.enable = mctp_usb_class_enable,
 	.disable = mctp_usb_class_disable,
@@ -594,14 +594,14 @@ struct usbd_class_api mctp_usb_class_api = {
 			.bDescriptorType = 0						\
 		}									\
 	};										\
-	const static struct usb_desc_header *mctp_usb_class_fs_desc_##n[] = {		\
+	const static struct usb_desc_header *const mctp_usb_class_fs_desc_##n[] = {	\
 		(struct usb_desc_header *)&mctp_usb_class_desc_##n.if0,			\
 		(struct usb_desc_header *)&mctp_usb_class_desc_##n.if0_fs_in_ep,	\
 		(struct usb_desc_header *)&mctp_usb_class_desc_##n.if0_fs_out_ep,	\
 		(struct usb_desc_header *)&mctp_usb_class_desc_##n.nil_desc		\
 	};										\
 											\
-	const static struct usb_desc_header *mctp_usb_class_hs_desc_##n[] = {		\
+	const static struct usb_desc_header *const mctp_usb_class_hs_desc_##n[] = {	\
 		(struct usb_desc_header *)&mctp_usb_class_desc_##n.if0,			\
 		(struct usb_desc_header *)&mctp_usb_class_desc_##n.if0_hs_in_ep,	\
 		(struct usb_desc_header *)&mctp_usb_class_desc_##n.if0_hs_out_ep,	\

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -33,8 +33,8 @@ struct tracing_func_desc {
 
 struct tracing_func_data {
 	struct tracing_func_desc *const desc;
-	const struct usb_desc_header **const fs_desc;
-	const struct usb_desc_header **const hs_desc;
+	const struct usb_desc_header *const *const fs_desc;
+	const struct usb_desc_header *const *const hs_desc;
 	struct k_sem sync_sem;
 	atomic_t state;
 };
@@ -158,7 +158,7 @@ static int tracing_func_init(struct usbd_class_data *c_data)
 	return 0;
 }
 
-struct usbd_class_api tracing_func_api = {
+static const struct usbd_class_api tracing_func_api = {
 	.request = tracing_func_request_handler,
 	.get_desc = tracing_func_get_desc,
 	.enable = tracing_func_enable,
@@ -218,14 +218,14 @@ static struct tracing_func_desc func_desc = {
 	},
 };
 
-const static struct usb_desc_header *tracing_func_fs_desc[] = {
+const static struct usb_desc_header *const tracing_func_fs_desc[] = {
 	(struct usb_desc_header *) &func_desc.if0,
 	(struct usb_desc_header *) &func_desc.if0_in_ep,
 	(struct usb_desc_header *) &func_desc.if0_out_ep,
 	NULL,
 };
 
-const static __maybe_unused struct usb_desc_header *tracing_func_hs_desc[] = {
+const static __maybe_unused struct usb_desc_header *const tracing_func_hs_desc[] = {
 	(struct usb_desc_header *) &func_desc.if0,
 	(struct usb_desc_header *) &func_desc.if0_hs_in_ep,
 	(struct usb_desc_header *) &func_desc.if0_hs_out_ep,


### PR DESCRIPTION
Follow-up to #118251, which fixes the same const placement in `subsys/usb/device_next/class/`. Here it is applied to the USB functions living elsewhere in the tree: the class API vtable and the arrays of descriptor pointers were missing a `const` and so sat in `.data`. 

`.data` on `nrf52840dk/nrf52840`, before → after (lower is better):

| sample | before | after | delta |
| --- | ---: | ---: | ---: |
| samples/subsys/dap | 1172 | 1088 | −84 |
| samples/subsys/usb/webusb | 1044 | 960 | −84 |
| samples/subsys/pmci/mctp/usb_endpoint | 1442 | 1358 | −84 |
| samples/subsys/tracing/basic | 752 | 684 | −68 |
| samples/subsys/usb/i2c_tiny_usb | 1222 | 1162 | −60 |

`ec_host_cmd_api` is made const too, but no sample or test builds that backend so it is not in the table. 

~~Stacks on top of #118251 (that's the first 2 commits)~~