### PR TITLE
scripts: kconfig: strip whitespace in shields_list_contains

### DIFF
--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -132,6 +132,10 @@ name is specified.
 
    $(shields_list_contains,<shield name>)
 
+Shield names cannot contain whitespace. A space after the comma, as in
+``$(shields_list_contains, foo)``, is stripped and a warning is printed
+so the lookup still matches ``foo``.
+
 
 Example Usage
 =============

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -1211,7 +1211,24 @@ def shields_list_contains(kconf, _, shield):
     Return "n" if cmake environment variable 'SHIELD_AS_LIST' doesn't exist.
     Return "y" if 'shield' is present list obtained after 'SHIELD_AS_LIST'
     has been split using ";" as a separator and "n" otherwise.
+
+    Shield names cannot contain whitespace. A leading or trailing space
+    (from ``$(shields_list_contains, foo)``) is stripped so the lookup
+    uses the intended name, and a warning is printed.
     """
+    stripped = shield.strip()
+    if stripped != shield:
+        _warn(kconf,
+              'searching for shield "{}", did you mean "{}" '
+              '(without a space)'.format(shield, stripped))
+        shield = stripped
+
+    if any(c.isspace() for c in shield):
+        _warn(kconf,
+              'shield name "{}" contains whitespace; shield names '
+              'cannot contain spaces'.format(shield))
+        return "n"
+
     try:
         list = os.environ['SHIELD_AS_LIST']
     except KeyError:

--- a/scripts/kconfig/kconfigfunctions_test.py
+++ b/scripts/kconfig/kconfigfunctions_test.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for shields_list_contains() whitespace handling."""
+
+from types import SimpleNamespace
+
+import kconfigfunctions
+
+
+class _Kconf(SimpleNamespace):
+    filename = "Kconfig.shield"
+    linenr = 5
+
+
+def test_shields_list_contains_exact_match(monkeypatch):
+    monkeypatch.setenv("SHIELD_AS_LIST", "myshield;other")
+    assert kconfigfunctions.shields_list_contains(_Kconf(), None, "myshield") == "y"
+    assert kconfigfunctions.shields_list_contains(_Kconf(), None, "missing") == "n"
+
+
+def test_shields_list_contains_missing_env(monkeypatch):
+    monkeypatch.delenv("SHIELD_AS_LIST", raising=False)
+    assert kconfigfunctions.shields_list_contains(_Kconf(), None, "myshield") == "n"
+
+
+def test_shields_list_contains_strips_leading_space(monkeypatch, capsys):
+    monkeypatch.setenv("SHIELD_AS_LIST", "myshield")
+    assert kconfigfunctions.shields_list_contains(_Kconf(), None, " myshield") == "y"
+    err = capsys.readouterr().out
+    assert 'searching for shield " myshield", did you mean "myshield" (without a space)' in err
+
+
+def test_shields_list_contains_strips_trailing_space(monkeypatch, capsys):
+    monkeypatch.setenv("SHIELD_AS_LIST", "myshield")
+    assert kconfigfunctions.shields_list_contains(_Kconf(), None, "myshield ") == "y"
+    err = capsys.readouterr().out
+    assert 'did you mean "myshield"' in err
+
+
+def test_shields_list_contains_internal_whitespace(monkeypatch, capsys):
+    monkeypatch.setenv("SHIELD_AS_LIST", "my shield")
+    assert kconfigfunctions.shields_list_contains(_Kconf(), None, "my shield") == "n"
+    err = capsys.readouterr().out
+    assert 'contains whitespace' in err


### PR DESCRIPTION
## Summary

`$(shields_list_contains, foo)` (space after the comma) looks up `" foo"`
and silently returns `n` even when `foo` is in `SHIELD_AS_LIST`. Shield
names cannot contain whitespace, so a leading/trailing space is stripped,
a warning is printed, and the trimmed name is used.

Internal whitespace in the name is still rejected.

Fixes #99457

## Testing

- `pytest scripts/kconfig/kconfigfunctions_test.py` (5 passed)
- `pytest scripts/kconfig` (30 passed)
- `ruff check` on the touched Python files
