### PR TITLE
usb: device_next: elide High-Speed support in Full-Speed-only builds

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1330,6 +1330,10 @@ USB
   their API struct definitions and switch their API instances to ``DEVICE_API(uhc, ...)``.
   (:github:`108414`)
 
+* The ``hs_configs`` and ``hs_desc`` members of :c:struct:`usbd_context` are only present
+  when the USB device stack is built with High-Speed support. Out-of-tree code accessing
+  them directly must guard the access with ``USBD_SUPPORTS_HIGH_SPEED``. (:github:`118258`)
+
 Video
 =====
 

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -310,16 +310,20 @@ struct usbd_context {
 	sys_dlist_t descriptors;
 	/** slist to manage Full-Speed device configurations */
 	sys_slist_t fs_configs;
+#if USBD_SUPPORTS_HIGH_SPEED
 	/** slist to manage High-Speed device configurations */
 	sys_slist_t hs_configs;
+#endif
 	/** dlist to manage vendor requests with recipient device */
 	sys_dlist_t vreqs;
 	/** Status of the USB device support */
 	struct usbd_status status;
 	/** Pointer to Full-Speed device descriptor */
 	void *fs_desc;
+#if USBD_SUPPORTS_HIGH_SPEED
 	/** Pointer to High-Speed device descriptor */
 	void *hs_desc;
+#endif
 	/** Pre-allocated buffer for control transfer SETUP stage */
 	struct net_buf *setup_buf;
 };

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -52,7 +52,8 @@ static int post_status_stage(struct usbd_context *const uds_ctx)
 		}
 	}
 
-	if (setup->bRequest == USB_SREQ_SET_FEATURE &&
+	if (USBD_SUPPORTS_HIGH_SPEED &&
+	    setup->bRequest == USB_SREQ_SET_FEATURE &&
 	    setup->wValue == USB_SFS_TEST_MODE) {
 		uint8_t mode = SF_TEST_MODE_SELECTOR(setup->wIndex);
 
@@ -279,6 +280,11 @@ static int sreq_set_feature(struct usbd_context *const uds_ctx)
 	}
 
 	if (unlikely(setup->wValue == USB_SFS_TEST_MODE)) {
+		if (!USBD_SUPPORTS_HIGH_SPEED) {
+			/* Test Mode is only required for High-Speed devices */
+			return -ENOTSUP;
+		}
+
 		return set_feature_test_mode(uds_ctx);
 	}
 

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -589,7 +589,7 @@ static struct net_buf *sreq_get_desc_dev(struct usbd_context *const uds_ctx)
 		head = uds_ctx->fs_desc;
 		break;
 	case USBD_SPEED_HS:
-		head = uds_ctx->hs_desc;
+		head = usbd_get_hs_desc(uds_ctx);
 		break;
 	default:
 		return NULL;
@@ -653,7 +653,7 @@ static struct net_buf *sreq_get_dev_qualifier(struct usbd_context *const uds_ctx
 	/* At Full-Speed we want High-Speed descriptor and vice versa */
 	struct usb_device_descriptor *d_desc =
 		usbd_bus_speed(uds_ctx) == USBD_SPEED_FS ?
-		uds_ctx->hs_desc : uds_ctx->fs_desc;
+		usbd_get_hs_desc(uds_ctx) : uds_ctx->fs_desc;
 	struct usb_device_qualifier_descriptor q_desc = {
 		.bLength = sizeof(struct usb_device_qualifier_descriptor),
 		.bDescriptorType = USB_DESC_DEVICE_QUALIFIER,
@@ -731,7 +731,7 @@ static struct net_buf *sreq_get_desc_bos(struct usbd_context *const uds_ctx)
 		dev_dsc = uds_ctx->fs_desc;
 		break;
 	case USBD_SPEED_HS:
-		dev_dsc = uds_ctx->hs_desc;
+		dev_dsc = usbd_get_hs_desc(uds_ctx);
 		break;
 	default:
 		return NULL;

--- a/subsys/usb/device_next/usbd_config.c
+++ b/subsys/usb/device_next/usbd_config.c
@@ -23,7 +23,7 @@ static sys_slist_t *usbd_configs(struct usbd_context *uds_ctx,
 	case USBD_SPEED_FS:
 		return &uds_ctx->fs_configs;
 	case USBD_SPEED_HS:
-		return &uds_ctx->hs_configs;
+		return usbd_get_hs_configs(uds_ctx);
 	default:
 		return NULL;
 	}
@@ -33,9 +33,14 @@ struct usbd_config_node *usbd_config_get(struct usbd_context *const uds_ctx,
 					 const enum usbd_speed speed,
 					 const uint8_t cfg)
 {
+	sys_slist_t *configs = usbd_configs(uds_ctx, speed);
 	struct usbd_config_node *cfg_nd;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(usbd_configs(uds_ctx, speed), cfg_nd, node) {
+	if (configs == NULL) {
+		return NULL;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER(configs, cfg_nd, node) {
 		if (usbd_config_get_value(cfg_nd) == cfg) {
 			return cfg_nd;
 		}
@@ -290,29 +295,29 @@ int usbd_add_configuration(struct usbd_context *const uds_ctx,
 	}
 
 	configs = usbd_configs(uds_ctx, speed);
-	switch (speed) {
-	case USBD_SPEED_HS:
-		SYS_SLIST_FOR_EACH_NODE(&uds_ctx->fs_configs, node) {
-			if (node == &cfg_nd->node) {
-				LOG_ERR("HS config already on FS list");
-				ret = -EINVAL;
-				goto add_configuration_exit;
-			}
-		}
-		break;
-	case USBD_SPEED_FS:
-		SYS_SLIST_FOR_EACH_NODE(&uds_ctx->hs_configs, node) {
-			if (node == &cfg_nd->node) {
-				LOG_ERR("FS config already on HS list");
-				ret = -EINVAL;
-				goto add_configuration_exit;
-			}
-		}
-		break;
-	default:
+	if (configs == NULL) {
 		LOG_ERR("Unsupported configuration speed");
 		ret = -ENOTSUP;
 		goto add_configuration_exit;
+	}
+
+	if (USBD_SUPPORTS_HIGH_SPEED) {
+		const bool hs = (speed == USBD_SPEED_HS);
+		sys_slist_t *other_configs = hs ? &uds_ctx->fs_configs :
+						  usbd_get_hs_configs(uds_ctx);
+
+		SYS_SLIST_FOR_EACH_NODE(other_configs, node) {
+			if (node == &cfg_nd->node) {
+				if (hs) {
+					LOG_ERR("HS config already on FS list");
+				} else {
+					LOG_ERR("FS config already on HS list");
+				}
+
+				ret = -EINVAL;
+				goto add_configuration_exit;
+			}
+		}
 	}
 
 	if (sys_slist_find_and_remove(configs, &cfg_nd->node)) {

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -250,7 +250,7 @@ int usbd_device_shutdown_core(struct usbd_context *const uds_ctx)
 	int ret;
 
 	if (USBD_SUPPORTS_HIGH_SPEED) {
-		SYS_SLIST_FOR_EACH_CONTAINER(&uds_ctx->hs_configs, cfg_nd, node) {
+		SYS_SLIST_FOR_EACH_CONTAINER(usbd_get_hs_configs(uds_ctx), cfg_nd, node) {
 			uint8_t cfg_value = usbd_config_get_value(cfg_nd);
 
 			ret = usbd_class_remove_all(uds_ctx, USBD_SPEED_HS, cfg_value);
@@ -294,9 +294,11 @@ static int usbd_pre_init(void)
 		atomic_set(&c_nd->state, 0);
 		LOG_DBG("\t%p->%p, name %s", c_nd, c_nd->c_data, c_nd->c_data->name);
 	}
-	STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs, usbd_class_node, c_nd) {
-		atomic_set(&c_nd->state, 0);
-		LOG_DBG("\t%p->%p, name %s", c_nd, c_nd->c_data, c_nd->c_data->name);
+	if (USBD_SUPPORTS_HIGH_SPEED) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs, usbd_class_node, c_nd) {
+			atomic_set(&c_nd->state, 0);
+			LOG_DBG("\t%p->%p, name %s", c_nd, c_nd->c_data, c_nd->c_data->name);
+		}
 	}
 
 	return 0;

--- a/subsys/usb/device_next/usbd_desc.c
+++ b/subsys/usb/device_next/usbd_desc.c
@@ -125,7 +125,7 @@ int usbd_add_descriptor(struct usbd_context *const uds_ctx,
 
 	usbd_device_lock(uds_ctx);
 
-	hs_desc = uds_ctx->hs_desc;
+	hs_desc = usbd_get_hs_desc(uds_ctx);
 	if (USBD_SUPPORTS_HIGH_SPEED && hs_desc == NULL) {
 		ret = -EPERM;
 		goto add_descriptor_error;

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -45,7 +45,7 @@ get_device_descriptor(struct usbd_context *const uds_ctx,
 	case USBD_SPEED_FS:
 		return uds_ctx->fs_desc;
 	case USBD_SPEED_HS:
-		return uds_ctx->hs_desc;
+		return usbd_get_hs_desc(uds_ctx);
 	default:
 		__ASSERT(false, "Not supported speed");
 		return NULL;

--- a/subsys/usb/device_next/usbd_device.h
+++ b/subsys/usb/device_next/usbd_device.h
@@ -31,6 +31,42 @@ struct usbd_vreq_node *usbd_device_get_vreq(struct usbd_context *const uds_ctx,
 void usbd_device_unregister_all_vreq(struct usbd_context *const uds_ctx);
 
 /**
+ * @brief Get the High-Speed device descriptor
+ *
+ * @param[in] uds_ctx Pointer to a device context
+ *
+ * @return pointer to the High-Speed device descriptor, or NULL if the stack
+ *         is built without High-Speed support.
+ */
+static inline void *usbd_get_hs_desc(const struct usbd_context *const uds_ctx)
+{
+#if USBD_SUPPORTS_HIGH_SPEED
+	return uds_ctx->hs_desc;
+#else
+	ARG_UNUSED(uds_ctx);
+	return NULL;
+#endif
+}
+
+/**
+ * @brief Get the list of High-Speed device configurations
+ *
+ * @param[in] uds_ctx Pointer to a device context
+ *
+ * @return pointer to the High-Speed configuration list, or NULL if the stack
+ *         is built without High-Speed support.
+ */
+static inline sys_slist_t *usbd_get_hs_configs(struct usbd_context *const uds_ctx)
+{
+#if USBD_SUPPORTS_HIGH_SPEED
+	return &uds_ctx->hs_configs;
+#else
+	ARG_UNUSED(uds_ctx);
+	return NULL;
+#endif
+}
+
+/**
  * @brief Get device descriptor bNumConfigurations value
  *
  * @param[in] uds_ctx Pointer to a device context
@@ -46,7 +82,7 @@ static inline uint8_t usbd_get_num_configs(const struct usbd_context *const uds_
 	if (speed == USBD_SPEED_FS) {
 		desc = uds_ctx->fs_desc;
 	} else if (USBD_SUPPORTS_HIGH_SPEED && speed == USBD_SPEED_HS) {
-		desc = uds_ctx->hs_desc;
+		desc = usbd_get_hs_desc(uds_ctx);
 	} else {
 		return 0;
 	}
@@ -71,7 +107,7 @@ static inline void usbd_set_num_configs(struct usbd_context *const uds_ctx,
 	if (speed == USBD_SPEED_FS) {
 		desc = uds_ctx->fs_desc;
 	} else if (USBD_SUPPORTS_HIGH_SPEED && speed == USBD_SPEED_HS) {
-		desc = uds_ctx->hs_desc;
+		desc = usbd_get_hs_desc(uds_ctx);
 	} else {
 		return;
 	}

--- a/subsys/usb/device_next/usbd_init.c
+++ b/subsys/usb/device_next/usbd_init.c
@@ -282,7 +282,7 @@ int usbd_init_configurations(struct usbd_context *const uds_ctx)
 	usbd_init_update_fs_mps0(uds_ctx);
 
 	if (USBD_SUPPORTS_HIGH_SPEED) {
-		SYS_SLIST_FOR_EACH_CONTAINER(&uds_ctx->hs_configs, cfg_nd, node) {
+		SYS_SLIST_FOR_EACH_CONTAINER(usbd_get_hs_configs(uds_ctx), cfg_nd, node) {
 			int ret;
 
 			ret = init_configuration(uds_ctx, USBD_SPEED_HS, cfg_nd);

--- a/subsys/usb/device_next/usbd_shell.c
+++ b/subsys/usb/device_next/usbd_shell.c
@@ -196,7 +196,8 @@ static int cmd_usbd_default_config(const struct shell *sh,
 		return err;
 	}
 
-	if (usbd_caps_speed(my_uds_ctx) == USBD_SPEED_HS) {
+	if (USBD_SUPPORTS_HIGH_SPEED &&
+	    usbd_caps_speed(my_uds_ctx) == USBD_SPEED_HS) {
 		err = usbd_add_configuration(my_uds_ctx, USBD_SPEED_HS, &config_1_hs);
 		if (err) {
 			shell_error(sh, "dev: Failed to add HS configuration");


### PR DESCRIPTION
Most Zephyr USB devices are Full-Speed only, but a `CONFIG_USBD_MAX_SPEED_FULL` build still carries High-Speed state and code the compiler cannot remove. Follow-up to #90791, which guarded the `hs_desc` initializer in `USBD_DEVICE_DEFINE()` but left the members in `struct usbd_context`.

Three independent commits:

1. **shell** — `usbd_caps_speed()` can report High-Speed on a Full-Speed-only build because udc_virtual derives `caps.hs` from devicetree alone, so `usbd defaults` failed. Making udc_virtual honour `CONFIG_UDC_DRIVER_HIGH_SPEED_SUPPORT_ENABLED` instead would work too — happy to move the fix there.
2. **context** — `hs_configs` / `hs_desc` are compiled only with High-Speed support and reached through `usbd_get_hs_desc()` / `usbd_get_hs_configs()`, which fold to NULL otherwise. That is the value the members already had, so no error path changes. Migration note included.
3. **Test Mode** — only required of High-Speed capable devices. This is the only behaviour change in the series, and it is last so it can be dropped on its own.

nrf52840dk/nrf52840, Full-Speed only, flash in bytes (lower is better):

| sample | before | after | delta |
| --- | --- | --- | --- |
| cdc_acm | 62064 | 61708 | −356 |
| hid-keyboard | 62960 | 62604 | −356 |
| console | 47832 | 47580 | −252 |
| dfu | 62816 | 62464 | −352 |
| mass | 71080 | 70720 | −360 |

`sizeof(struct usbd_context)`: 124 → 112 bytes.

High-Speed is not regressed: the all-classes native_sim build with a High-Speed virtual controller loses 47 bytes of text with identical data and bss, and the device_next tests pass there and on a Full-Speed-only rebuild.
