### PR TITLE
boards: remove redundant LV_COLOR_DEPTH_16 defaults

### DIFF
--- a/boards/adafruit/feather_esp32s2/Kconfig.defconfig
+++ b/boards/adafruit/feather_esp32s2/Kconfig.defconfig
@@ -7,10 +7,6 @@ if DISPLAY
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 config LV_COLOR_16_SWAP
 	default y
 

--- a/boards/adafruit/feather_esp32s3_tft/Kconfig.defconfig
+++ b/boards/adafruit/feather_esp32s3_tft/Kconfig.defconfig
@@ -10,10 +10,6 @@ config BOARD_ADAFRUIT_FEATHER_ESP32S3_TFT
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 config LV_COLOR_16_SWAP
 	default y
 

--- a/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.defconfig
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.defconfig
@@ -11,10 +11,6 @@ config BOARD_ADAFRUIT_FEATHER_ESP32S3_TFT_REVERSE
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 config LV_COLOR_16_SWAP
 	default y
 

--- a/boards/adi/max32662evkit/Kconfig.defconfig
+++ b/boards/adi/max32662evkit/Kconfig.defconfig
@@ -12,10 +12,6 @@ config MIPI_DBI_SPI_3WIRE
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16  # 16 bit per pixel
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/adi/max32672evkit/Kconfig.defconfig
+++ b/boards/adi/max32672evkit/Kconfig.defconfig
@@ -12,10 +12,6 @@ config MIPI_DBI_SPI_3WIRE
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16  # 16 bit per pixel
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/adi/max32680evkit/Kconfig.defconfig
+++ b/boards/adi/max32680evkit/Kconfig.defconfig
@@ -12,10 +12,6 @@ config MIPI_DBI_SPI_3WIRE
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16  # 16 bit per pixel
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/adi/max32690evkit/Kconfig.defconfig
+++ b/boards/adi/max32690evkit/Kconfig.defconfig
@@ -12,10 +12,6 @@ config MIPI_DBI_SPI_3WIRE
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16  # 16 bit per pixel
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/alientek/dnesp32s3b/Kconfig.defconfig
+++ b/boards/alientek/dnesp32s3b/Kconfig.defconfig
@@ -11,10 +11,6 @@ config REGULATOR
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 config LV_COLOR_16_SWAP
 	default y
 

--- a/boards/ezurio/bl5340_dvk/Kconfig.defconfig
+++ b/boards/ezurio/bl5340_dvk/Kconfig.defconfig
@@ -57,10 +57,6 @@ if LVGL
 config LV_Z_VDB_SIZE
 	default 64
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/lilygo/t_deck/Kconfig.defconfig
+++ b/boards/lilygo/t_deck/Kconfig.defconfig
@@ -3,14 +3,6 @@
 
 if BOARD_T_DECK_ESP32S3_PROCPU
 
-if LVGL
-
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
-endif # LVGL
-
 if FUEL_GAUGE && BOARD_REVISION = "plus"
 
 # Composite fuel gauge gets battery voltage from ADC-based voltage-divider sensor

--- a/boards/m5stack/m5stack_cores3/Kconfig.defconfig
+++ b/boards/m5stack/m5stack_cores3/Kconfig.defconfig
@@ -10,10 +10,6 @@ config INPUT
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 config LV_COLOR_16_SWAP
 	default y
 

--- a/boards/shields/arduino_giga_display_shield/Kconfig.defconfig
+++ b/boards/shields/arduino_giga_display_shield/Kconfig.defconfig
@@ -14,11 +14,6 @@ config LV_DPI_DEF
 config LV_Z_FLUSH_THREAD
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-
-endchoice
-
 endif # LVGL
 
 endif # SHIELD_ARDUINO_GIGA_DISPLAY_SHIELD

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
@@ -10,10 +10,6 @@ if LVGL
 config LV_Z_VDB_SIZE
 	default 64
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
@@ -13,10 +13,6 @@ config LV_Z_VDB_SIZE
 config LV_Z_BITS_PER_PIXEL
 	default 24
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 config INPUT
 	default y
 

--- a/boards/shields/g1120b0mipi/Kconfig.defconfig
+++ b/boards/shields/g1120b0mipi/Kconfig.defconfig
@@ -19,10 +19,6 @@ config LV_DPI_DEF
 config LV_Z_FLUSH_THREAD
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 endif # LVGL
 
 endif # SHIELD_G1120B0MIPI

--- a/boards/shields/lcd_par_s035/Kconfig.defconfig
+++ b/boards/shields/lcd_par_s035/Kconfig.defconfig
@@ -8,10 +8,6 @@ if LVGL
 config LV_Z_DOUBLE_VDB
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 # VDB size is 10% of the full screen size
 config LV_Z_VDB_SIZE
 	default 10

--- a/boards/shields/m5stack_cardputer/Kconfig.defconfig
+++ b/boards/shields/m5stack_cardputer/Kconfig.defconfig
@@ -6,16 +6,4 @@ if SHIELD_M5STACK_CARDPUTER
 config INPUT
 	default y
 
-if DISPLAY
-
-if LVGL
-
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
-endif # LVGL
-
-endif # DISPLAY
-
 endif # SHIELD_M5STACK_CARDPUTER

--- a/boards/shields/rk043fn02h_ct/Kconfig.defconfig
+++ b/boards/shields/rk043fn02h_ct/Kconfig.defconfig
@@ -25,10 +25,6 @@ config LV_DPI_DEF
 config LV_Z_FLUSH_THREAD
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 # Force display buffers to be aligned to cache line size (32 bytes)
 config LV_Z_VDB_ALIGN
 	default 32

--- a/boards/shields/rk043fn66hs_ctg/Kconfig.defconfig
+++ b/boards/shields/rk043fn66hs_ctg/Kconfig.defconfig
@@ -28,10 +28,6 @@ config LV_DPI_DEF
 config LV_Z_FLUSH_THREAD
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 # Force display buffers to be aligned to cache line size (32 bytes)
 config LV_Z_VDB_ALIGN
 	default 32

--- a/boards/shields/rk055hdmipi4m/Kconfig.defconfig
+++ b/boards/shields/rk055hdmipi4m/Kconfig.defconfig
@@ -37,10 +37,6 @@ config LV_DPI_DEF
 config LV_Z_FLUSH_THREAD
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 endif # LVGL
 
 endif # SHIELD_RK055HDMIPI4M

--- a/boards/shields/rk055hdmipi4ma0/Kconfig.defconfig
+++ b/boards/shields/rk055hdmipi4ma0/Kconfig.defconfig
@@ -41,10 +41,6 @@ config LV_DPI_DEF
 config LV_Z_FLUSH_THREAD
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 endif # LVGL
 
 endif # SHIELD_RK055HDMIPI4MA0

--- a/boards/shields/rtklcdpar1s00001be/Kconfig.defconfig
+++ b/boards/shields/rtklcdpar1s00001be/Kconfig.defconfig
@@ -22,10 +22,6 @@ choice LV_Z_RENDERING_MODE
 	default LV_Z_FULL_REFRESH
 endchoice
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 endif # LVGL
 
 orsource "boards/*.defconfig"

--- a/boards/shields/rtkmipilcdb00000be/Kconfig.defconfig
+++ b/boards/shields/rtkmipilcdb00000be/Kconfig.defconfig
@@ -29,11 +29,6 @@ choice LV_Z_RENDERING_MODE
 	default LV_Z_FULL_REFRESH
 endchoice
 
-# Use offloaded render thread
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 endif # LVGL
 
 endif # DISPLAY

--- a/boards/shields/seeed_xiao_round_display/Kconfig.defconfig
+++ b/boards/shields/seeed_xiao_round_display/Kconfig.defconfig
@@ -10,10 +10,6 @@ if LVGL
 config INPUT
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/shields/waveshare_pico_lcd_1_14/Kconfig.defconfig
+++ b/boards/shields/waveshare_pico_lcd_1_14/Kconfig.defconfig
@@ -10,10 +10,6 @@ if LVGL
 config LV_DPI_DEF
 	default 242
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 configdefault LV_COLOR_16_SWAP
 	default y
 

--- a/boards/shields/zc143ac72mipi/Kconfig.defconfig
+++ b/boards/shields/zc143ac72mipi/Kconfig.defconfig
@@ -19,10 +19,6 @@ config LV_DPI_DEF
 config LV_Z_FLUSH_THREAD
 	default y
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 endif # LVGL
 
 endif # SHIELD_ZC143AC72MIPI

--- a/boards/waveshare/esp32s3_geek/Kconfig.defconfig
+++ b/boards/waveshare/esp32s3_geek/Kconfig.defconfig
@@ -7,10 +7,6 @@ if DISPLAY
 
 if LVGL
 
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
 config LV_COLOR_16_SWAP
 	default y
 


### PR DESCRIPTION
Remove board-specific `LV_COLOR_DEPTH_16` defaults since 16-bit RGB565 is already the default selection for `LV_COLOR_DEPTH`.

https://github.com/zephyrproject-rtos/zephyr/blob/4c6971ba90a3231092758d876d03f8d73b41554e/modules/lvgl/Kconfig#L87-L101