### PR TITLE
kernel: pipe: refuse a length that the return value cannot express

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5922,6 +5922,7 @@ struct k_pipe {
  * @retval -EAGAIN if no data could be written before the timeout expired
  * @retval -ECANCELED if the write was interrupted by k_pipe_reset(..)
  * @retval -EPIPE if the pipe was closed
+ * @retval -EOVERFLOW if @a len is greater than INT_MAX
  */
 __syscall int k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len,
 			   k_timeout_t timeout);
@@ -5940,6 +5941,7 @@ __syscall int k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len,
  * @retval -EAGAIN if no data could be read before the timeout expired
  * @retval -ECANCELED if the read was interrupted by k_pipe_reset(..)
  * @retval -EPIPE if the pipe was closed
+ * @retval -EOVERFLOW if @a len is greater than INT_MAX
  */
 __syscall int k_pipe_read(struct k_pipe *pipe, uint8_t *data, size_t len,
 			  k_timeout_t timeout);

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -159,6 +159,11 @@ int z_impl_k_pipe_write(struct k_pipe *pipe, const uint8_t *data, size_t len, k_
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, write, pipe, data, len, timeout);
 
+	if (unlikely(len > INT_MAX)) {
+		rc = -EOVERFLOW;
+		goto out;
+	}
+
 	if (unlikely(pipe_resetting(pipe))) {
 		rc = -ECANCELED;
 		goto out;
@@ -231,6 +236,11 @@ int z_impl_k_pipe_read(struct k_pipe *pipe, uint8_t *data, size_t len, k_timeout
 	bool need_resched = false;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, read, pipe, data, len, timeout);
+
+	if (unlikely(len > INT_MAX)) {
+		rc = -EOVERFLOW;
+		goto out;
+	}
 
 	if (unlikely(pipe_resetting(pipe))) {
 		rc = -ECANCELED;

--- a/tests/kernel/pipe/pipe_api/src/basic.c
+++ b/tests/kernel/pipe/pipe_api/src/basic.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <limits.h>
 #include <stdint.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
@@ -322,6 +323,41 @@ ZTEST(k_pipe_basic, test_pipe_close)
 	zassert_true(memcmp(&input[5], res, 3) == 0, "Written and read bytes should be equal");
 	zassert_true(k_pipe_read(&pipe, res, 5, K_NO_WAIT) == -EPIPE,
 		"Closed and empty pipe should return -EPIPE");
+}
+
+/**
+ * @brief Verify a length above INT_MAX is refused with -EOVERFLOW.
+ *
+ * @details
+ * Both calls report a successful transfer as a positive int, so a request
+ * they could not report the size of is refused up front rather than
+ * truncated.
+ *
+ * Test steps:
+ * - Ask to write, then to read, INT_MAX + 1 bytes.
+ * - Verify both return -EOVERFLOW and leave the pipe untouched.
+ *
+ * Expected result:
+ * - Both calls return -EOVERFLOW and the pipe is still empty.
+ *
+ * @see k_pipe_read()
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_basic, test_pipe_len_above_int_max)
+{
+	uint8_t buffer[16];
+	uint8_t data[4];
+
+	k_pipe_init(&pipe, buffer, sizeof(buffer));
+
+	zassert_equal(k_pipe_write(&pipe, data, (size_t)INT_MAX + 1, K_NO_WAIT), -EOVERFLOW,
+		"write of more than INT_MAX bytes should return -EOVERFLOW");
+	zassert_equal(k_pipe_read(&pipe, data, (size_t)INT_MAX + 1, K_NO_WAIT), -EOVERFLOW,
+		"read of more than INT_MAX bytes should return -EOVERFLOW");
+
+	/* The rejected calls must not have consumed or produced anything. */
+	zassert_equal(k_pipe_read(&pipe, data, sizeof(data), K_NO_WAIT), -EAGAIN,
+		"pipe should still be empty");
 }
 
 /**


### PR DESCRIPTION
Don't accept sizes we can't return.

Fixes #118242
