### PR TITLE
Backport 117787 to v4.4 branch

### DIFF
--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -44,6 +44,7 @@ struct ptp_clock {
 	struct ptp_foreign_tt_clock *best;
 	sys_slist_t		    ports_list;
 	struct zsock_pollfd	    pollfd[1 + 2 * CONFIG_PTP_NUM_PORTS];
+	struct k_work timeout_work;
 	bool			    pollfd_valid;
 	bool			    state_decision_event;
 	uint8_t			    time_src;
@@ -243,6 +244,22 @@ static void clock_check_pollfd(void)
 	ptp_clk.pollfd_valid = true;
 }
 
+static void clock_notify_worker(void)
+{
+	if (ptp_clk.pollfd[0].events != ZSOCK_POLLIN) {
+		return;
+	}
+
+	zvfs_eventfd_write(ptp_clk.pollfd[0].fd, 1);
+}
+
+static void clock_timeout_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	clock_notify_worker();
+}
+
 const struct ptp_clock *ptp_clock_init(void)
 {
 	struct ptp_default_ds *dds = &ptp_clk.default_ds;
@@ -288,6 +305,7 @@ const struct ptp_clock *ptp_clock_init(void)
 
 	ptp_clk.pollfd[0].fd = zvfs_eventfd(0, ZVFS_EFD_NONBLOCK);
 	ptp_clk.pollfd[0].events = ZSOCK_POLLIN;
+	k_work_init(&ptp_clk.timeout_work, clock_timeout_work_handler);
 
 	sys_slist_init(&ptp_clk.ports_list);
 	LOG_DBG("PTP Clock %s initialized", clock_id_str(&dds->clk_id));
@@ -658,7 +676,7 @@ void ptp_clock_pollfd_invalidate(void)
 
 void ptp_clock_signal_timeout(void)
 {
-	zvfs_eventfd_write(ptp_clk.pollfd[0].fd, 1);
+	k_work_submit(&ptp_clk.timeout_work);
 }
 
 void ptp_clock_state_decision_req(void)


### PR DESCRIPTION
Backport of #117787 to `v4.4-branch`.

The newer clock wakeup unit-test suite is not present in v4.4, so only the production fix was backported.

Fixes #118640

Manual backport for #118063.