### PR TITLE
boards: infineon: kit_pse84_*: enable required TF-M crypto modules

### DIFF
--- a/boards/infineon/kit_pse84_ai/tfm_extra_crypto_config.h
+++ b/boards/infineon/kit_pse84_ai/tfm_extra_crypto_config.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TFM_EXTRA_CRYPTO_CONFIG_H
+#define ZEPHYR_TFM_EXTRA_CRYPTO_CONFIG_H
+
+/*
+ * profile_medium disables these by default; Zephyr's Bluetooth host requires
+ * both for RPA generation (AES-ECB, via the cipher module) and SMP pairing
+ * (AES-CMAC). Undef first since profile_medium.h already defines the former.
+ */
+#undef CRYPTO_CIPHER_MODULE_ENABLED
+#define CRYPTO_CIPHER_MODULE_ENABLED 1
+
+#undef PSA_WANT_ALG_CMAC
+#define PSA_WANT_ALG_CMAC 1
+
+#endif /* ZEPHYR_TFM_EXTRA_CRYPTO_CONFIG_H */

--- a/boards/infineon/kit_pse84_eval/tfm_extra_crypto_config.h
+++ b/boards/infineon/kit_pse84_eval/tfm_extra_crypto_config.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TFM_EXTRA_CRYPTO_CONFIG_H
+#define ZEPHYR_TFM_EXTRA_CRYPTO_CONFIG_H
+
+/*
+ * profile_medium disables these by default; Zephyr's Bluetooth host requires
+ * both for RPA generation (AES-ECB, via the cipher module) and SMP pairing
+ * (AES-CMAC). Undef first since profile_medium.h already defines the former.
+ */
+#undef CRYPTO_CIPHER_MODULE_ENABLED
+#define CRYPTO_CIPHER_MODULE_ENABLED 1
+
+#undef PSA_WANT_ALG_CMAC
+#define PSA_WANT_ALG_CMAC 1
+
+#endif /* ZEPHYR_TFM_EXTRA_CRYPTO_CONFIG_H */

--- a/soc/infineon/edge/pse84/CMakeLists.txt
+++ b/soc/infineon/edge/pse84/CMakeLists.txt
@@ -37,6 +37,13 @@ if(CONFIG_BUILD_WITH_TFM)
     message(FATAL_ERROR "No supported board selected.")
   endif()
 
+  # Let a board supply crypto algorithms/modules its chosen TFM_PROFILE omits,
+  # without patching the vendored TF-M platform tree.
+  if(EXISTS ${BOARD_DIR}/tfm_extra_crypto_config.h)
+    set_property(TARGET zephyr_property_target APPEND PROPERTY TFM_CMAKE_OPTIONS
+      -DTFM_TF_PSA_CRYPTO_PLATFORM_EXTRA_CONFIG_PATH=${BOARD_DIR}/tfm_extra_crypto_config.h)
+  endif()
+
 endif()
 
 if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)


### PR DESCRIPTION
The Bluetooth host requires the Cipher module (AES-ECB) for Resolvable Private Address (RPA) generation, and AES-CMAC for Security Manager (SMP) pairing (LESC).

Since TF-M's profile_medium disables these by default, and Zephyr's TF-M CMake integration cannot pass arbitrary PSA algorithm overrides down into the tf-psa-crypto build, this commit intercepts the TF-M build by setting TFM_TF_PSA_CRYPTO_PLATFORM_EXTRA_CONFIG_PATH to a board-specific header that force-enables the necessary modules.

This allows BLE samples like peripheral to pair securely without requiring out-of-tree modifications to the vendored trusted-firmware-m repository.