### PR TITLE
boards: microchip: add SPI support for pic32cz_ca80_cult and pic32cz_ca90_cult

### DIFF
--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult-pinctrl.dtsi
@@ -20,4 +20,12 @@
 				 <PD29D_SERCOM9_PAD1>;  /* SCL */
 		};
 	};
+
+	sercom2_spi_default: sercom2_spi_default {
+		group1 {
+			pinmux = <PC8D_SERCOM2_PAD0>,   /* MOSI */
+				 <PC11D_SERCOM2_PAD3>,  /* MISO */
+				 <PC9D_SERCOM2_PAD1>;   /* SCK  */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -172,6 +172,12 @@
 			gclkperiph-src = "gclk1";
 			gclkperiph-en = <0>;
 		};
+
+		sercom2 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_SERCOM2_CORE>;
+			gclkperiph-src = "gclk0";
+			gclkperiph-en = <1>;
+		};
 	};
 
 	mclkdomain: mclkdomain {
@@ -194,6 +200,11 @@
 
 		sercom1 {
 			subsystem = <CLOCK_MCHP_MCLKPERIPH_ID_SERCOM1>;
+			mclk-en = <1>;
+		};
+
+		sercom2 {
+			subsystem = <CLOCK_MCHP_MCLKPERIPH_ID_SERCOM2>;
 			mclk-en = <1>;
 		};
 	};
@@ -245,4 +256,18 @@ i2c0: &sercom9 {
 		address-width = <8>;
 		timeout = <5>;
 	};
+};
+
+&sercom2 {
+	compatible = "microchip,sercom-g1-spi";
+	dipo = <3>;
+	dopo = <0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&sercom2_spi_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&portc 10 GPIO_ACTIVE_LOW>;
+	dmas = <&dmac 3 10>, <&dmac 4 9>;
+	dma-names = "tx", "rx";
+	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - i2c
   - pinctrl
+  - spi
   - uart
   - watchdog
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult-pinctrl.dtsi
@@ -20,4 +20,12 @@
 				 <PD29D_SERCOM9_PAD1>;  /* SCL */
 		};
 	};
+
+	sercom2_spi_default: sercom2_spi_default {
+		group1 {
+			pinmux = <PC8D_SERCOM2_PAD0>,   /* MOSI */
+				 <PC11D_SERCOM2_PAD3>,  /* MISO */
+				 <PC9D_SERCOM2_PAD1>;   /* SCK  */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
@@ -172,6 +172,12 @@
 			gclkperiph-src = "gclk1";
 			gclkperiph-en = <0>;
 		};
+
+		sercom2 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_SERCOM2_CORE>;
+			gclkperiph-src = "gclk0";
+			gclkperiph-en = <1>;
+		};
 	};
 
 	mclkdomain: mclkdomain {
@@ -194,6 +200,11 @@
 
 		sercom1 {
 			subsystem = <CLOCK_MCHP_MCLKPERIPH_ID_SERCOM1>;
+			mclk-en = <1>;
+		};
+
+		sercom2 {
+			subsystem = <CLOCK_MCHP_MCLKPERIPH_ID_SERCOM2>;
 			mclk-en = <1>;
 		};
 	};
@@ -245,4 +256,18 @@ i2c0: &sercom9 {
 		address-width = <8>;
 		timeout = <5>;
 	};
+};
+
+&sercom2 {
+	compatible = "microchip,sercom-g1-spi";
+	dipo = <3>;
+	dopo = <0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&sercom2_spi_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&portc 10 GPIO_ACTIVE_LOW>;
+	dmas = <&dmac 3 10>, <&dmac 4 9>;
+	dma-names = "tx", "rx";
+	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.yaml
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - i2c
   - pinctrl
+  - spi
   - uart
   - watchdog
 vendor: microchip

--- a/drivers/spi/Kconfig.mchp
+++ b/drivers/spi/Kconfig.mchp
@@ -42,7 +42,7 @@ config SPI_MCHP_INTER_CHARACTER_SPACE
 	default 63 if SPI_SLAVE
 	default 0
 	range 0 63
-	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X || SOC_FAMILY_MICROCHIP_PIC32CZ_CA
 	help
 	  Number of clock cycles to delay between characters on SPI bus.
 

--- a/drivers/spi/spi_mchp_sercom_g1.c
+++ b/drivers/spi/spi_mchp_sercom_g1.c
@@ -1089,29 +1089,22 @@ static DEVICE_API(spi, spi_mchp_api) = {
 	.reg_cfg.regs = (sercom_registers_t *)DT_INST_REG_ADDR(n),                                 \
 	.reg_cfg.pads = SPI_MCHP_SERCOM_PADS(n),
 
-#if DT_INST_IRQ_HAS_IDX(0, 3)
 #define SPI_MCHP_IRQ_HANDLER(n)                                                                    \
 	static void spi_mchp_irq_config_##n(const struct device *dev)                              \
 	{                                                                                          \
-		MCHP_SPI_IRQ_CONNECT(n, 0);                                                        \
-		MCHP_SPI_IRQ_CONNECT(n, 1);                                                        \
-		MCHP_SPI_IRQ_CONNECT(n, 2);                                                        \
-		MCHP_SPI_IRQ_CONNECT(n, 3);                                                        \
+		LISTIFY(                                         \
+		DT_INST_NUM_IRQS(n),                    \
+		MCHP_SPI_IRQ_CONNECT,                   \
+		(;),                                    \
+		n);                           \
 	}
-#else
-#define SPI_MCHP_IRQ_HANDLER(n)                                                                    \
-	static void spi_mchp_irq_config_##n(const struct device *dev)                              \
-	{                                                                                          \
-		MCHP_SPI_IRQ_CONNECT(n, 0);                                                        \
-	}
-#endif
 
 #define SPI_MCHP_CLOCK_DEFN(n)                                                                     \
 	.spi_clock.clock_dev = DEVICE_DT_GET(DT_NODELABEL(clock)),                                 \
 	.spi_clock.mclk_sys = (void *)(DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, subsystem)),           \
 	.spi_clock.gclk_sys = (void *)(DT_INST_CLOCKS_CELL_BY_NAME(n, gclk, subsystem))
 
-#define MCHP_SPI_IRQ_CONNECT(n, m)                                                                 \
+#define MCHP_SPI_IRQ_CONNECT(m, n)                                                                 \
 	do {                                                                                       \
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, m, irq), DT_INST_IRQ_BY_IDX(n, m, priority),     \
 			    spi_mchp_isr, DEVICE_DT_INST_GET(n), 0);                               \

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 550371954d33f7f5f17b3eb2f7ecc46ca3fa1b62
+      revision: eb7765f7399129198f669394fcf2b430e38929c9
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
This PR does the following:

- adds SPI g1 support for the Microchip PIC32CZ CA80 Curiosity Ultra and PIC32CZ CA90 Curiosity Ultra boards
- updates the driver to connect every SERCOM interrupt line the devicetree node declares via LISTIFY(DT_INST_NUM_IRQS)